### PR TITLE
DAOS-4881 sched: Remove redundant ABT pools

### DIFF
--- a/src/container/container_iv.c
+++ b/src/container/container_iv.c
@@ -921,8 +921,8 @@ cont_iv_hdl_fetch(uuid_t cont_hdl_uuid, uuid_t pool_uuid,
 	uuid_copy(arg.cont_hdl_uuid, cont_hdl_uuid);
 	arg.eventual = eventual;
 	arg.invalidate_current = invalidate_current;
-	rc = dss_ult_create(cont_iv_capa_refresh_ult, &arg,
-			    DSS_ULT_POOL_SRV, 0, 0, NULL);
+	rc = dss_ult_create(cont_iv_capa_refresh_ult, &arg, DSS_XS_SYS,
+			    0, 0, NULL);
 	if (rc)
 		D_GOTO(out_eventual, rc);
 
@@ -1240,8 +1240,8 @@ cont_iv_prop_fetch(struct ds_iv_ns *ns, uuid_t cont_uuid,
 	uuid_copy(arg.cont_uuid, cont_uuid);
 	arg.prop = cont_prop;
 	arg.eventual = eventual;
-	rc = dss_ult_create(cont_iv_prop_fetch_ult, &arg,
-			    DSS_ULT_POOL_SRV, 0, DSS_DEEP_STACK_SZ, NULL);
+	rc = dss_ult_create(cont_iv_prop_fetch_ult, &arg, DSS_XS_SYS,
+			    0, DSS_DEEP_STACK_SZ, NULL);
 	if (rc)
 		D_GOTO(out, rc);
 

--- a/src/container/srv_container.c
+++ b/src/container/srv_container.c
@@ -1093,8 +1093,7 @@ ds_cont_tgt_refresh_agg_eph(uuid_t pool_uuid, uuid_t cont_uuid,
 	uuid_copy(arg.cont_uuid, cont_uuid);
 	arg.min_eph = eph;
 
-	rc = dss_task_collective(cont_refresh_vos_agg_eph_one, &arg, 0,
-				 DSS_ULT_IO);
+	rc = dss_task_collective(cont_refresh_vos_agg_eph_one, &arg, 0);
 	return rc;
 }
 
@@ -1183,7 +1182,7 @@ cont_svc_ec_agg_leader_start(struct cont_svc *svc)
 
 	D_INIT_LIST_HEAD(&svc->cs_ec_agg_list);
 
-	rc = dss_ult_create(cont_agg_eph_leader_ult, svc, DSS_ULT_POOL_SRV,
+	rc = dss_ult_create(cont_agg_eph_leader_ult, svc, DSS_XS_SYS,
 			    0, 0, &ec_eph_leader_ult);
 	if (rc) {
 		D_ERROR(DF_UUID" Failed to create aggregation ULT. %d\n",

--- a/src/container/srv_csum_recalc.c
+++ b/src/container/srv_csum_recalc.c
@@ -295,19 +295,19 @@ void
 ds_csum_recalc(void *args)
 {
 	struct csum_recalc_args	*cs_args = (struct csum_recalc_args *) args;
-	struct dss_module_info  *info;
+	struct dss_module_info *info;
 
 	C_TRACE("Checksum Aggregation\n");
+
+	info = dss_get_module_info();
+	D_ASSERT(info != NULL);
+	cs_args->cra_bio_ctxt = info->dmi_nvme_ctxt;
+	cs_args->cra_tgt_id = info->dmi_tgt_id;
+
 	ABT_eventual_create(0, &cs_args->csum_eventual);
 	dss_ult_create(ds_csum_agg_recalc, args,
-		       DSS_ULT_CHECKSUM, DSS_TGT_SELF, 0, NULL);
+		       DSS_XS_OFFLOAD, cs_args->cra_tgt_id, 0, NULL);
 	ABT_eventual_wait(cs_args->csum_eventual, NULL);
-	if (cs_args->cra_rc == -DER_CSUM) {
-		info = dss_get_module_info();
-
-		cs_args->cra_bio_ctxt = info->dmi_nvme_ctxt;
-		cs_args->cra_tgt_id = info->dmi_tgt_id;
-	}
 	ABT_eventual_free(&cs_args->csum_eventual);
 }
 #endif

--- a/src/container/srv_target.c
+++ b/src/container/srv_target.c
@@ -423,8 +423,8 @@ cont_start_agg_ult(struct ds_cont_child *cont)
 	if (cont->sc_agg_req != NULL)
 		return 0;
 
-	rc = dss_ult_create(cont_aggregate_ult, cont, DSS_ULT_GC,
-			    DSS_TGT_SELF, 0, &agg_ult);
+	rc = dss_ult_create(cont_aggregate_ult, cont, DSS_XS_SELF,
+			    0, 0, &agg_ult);
 	if (rc) {
 		D_ERROR(DF_CONT"[%d]: Failed to create aggregation ULT. %d\n",
 			DP_CONT(cont->sc_pool->spc_uuid, cont->sc_uuid),
@@ -512,8 +512,8 @@ cont_start_dtx_reindex_ult(struct ds_cont_child *cont)
 
 	ds_cont_child_get(cont);
 	cont->sc_dtx_reindex = 1;
-	rc = dss_ult_create(ds_cont_dtx_reindex_ult, cont,
-			    DSS_ULT_DTX_RESYNC, DSS_TGT_SELF, 0, NULL);
+	rc = dss_ult_create(ds_cont_dtx_reindex_ult, cont, DSS_XS_SELF,
+			    0, 0, NULL);
 	if (rc != 0) {
 		D_ERROR(DF_UUID": Failed to create DTX reindex ULT: rc %d\n",
 			DP_UUID(cont->sc_uuid), rc);
@@ -1107,7 +1107,7 @@ ds_cont_tgt_destroy(uuid_t pool_uuid, uuid_t cont_uuid)
 	uuid_copy(in.tdi_uuid, cont_uuid);
 
 	cont_delete_ec_agg(pool_uuid, cont_uuid);
-	rc = dss_thread_collective(cont_child_destroy_one, &in, 0, DSS_ULT_IO);
+	rc = dss_thread_collective(cont_child_destroy_one, &in, 0);
 	return rc;
 }
 
@@ -1382,8 +1382,8 @@ ds_cont_local_open(uuid_t pool_uuid, uuid_t cont_hdl_uuid, uuid_t cont_uuid,
 
 		ddra->pool = ds_pool_child_get(hdl->sch_cont->sc_pool);
 		uuid_copy(ddra->co_uuid, cont_uuid);
-		rc = dss_ult_create(ds_dtx_resync, ddra, DSS_ULT_DTX_RESYNC,
-				    DSS_TGT_SELF, 0, NULL);
+		rc = dss_ult_create(ds_dtx_resync, ddra, DSS_XS_SELF,
+				    0, 0, NULL);
 		if (rc != 0) {
 			ds_pool_child_put(hdl->sch_cont->sc_pool);
 			D_FREE(ddra);
@@ -1482,8 +1482,7 @@ ds_cont_tgt_open(uuid_t pool_uuid, uuid_t cont_hdl_uuid,
 		return rc;
 	}
 
-	rc = dss_thread_collective_reduce(&coll_ops, &coll_args, 0,
-					  DSS_ULT_IO);
+	rc = dss_thread_collective_reduce(&coll_ops, &coll_args, 0);
 	if (coll_args.ca_exclude_tgts)
 		D_FREE(coll_args.ca_exclude_tgts);
 
@@ -1586,7 +1585,7 @@ ds_cont_tgt_force_close(uuid_t cont_uuid)
 	D_DEBUG(DF_DSMS, "Force closing all handles for container "
 		DF_UUID"\n", DP_UUID(cont_uuid));
 
-	rc = dss_thread_collective(cont_close_all, &cont_uuid, 0, DSS_ULT_IO);
+	rc = dss_thread_collective(cont_close_all, &cont_uuid, 0);
 	if (rc != 0)
 		D_ERROR("dss_thread_collective failed: rc="DF_RC, DP_RC(rc));
 	return rc;
@@ -1611,7 +1610,7 @@ ds_cont_tgt_close(uuid_t hdl_uuid)
 	struct coll_close_arg arg;
 
 	uuid_copy(arg.uuid, hdl_uuid);
-	return dss_thread_collective(cont_close_one_hdl, &arg, 0, DSS_ULT_IO);
+	return dss_thread_collective(cont_close_one_hdl, &arg, 0);
 }
 
 struct xstream_cont_query {
@@ -1733,7 +1732,7 @@ ds_cont_tgt_query_handler(crt_rpc_t *rpc)
 	coll_args.ca_func_args		= &coll_args.ca_stream_args;
 
 
-	rc = dss_task_collective_reduce(&coll_ops, &coll_args, 0, DSS_ULT_IO);
+	rc = dss_task_collective_reduce(&coll_ops, &coll_args, 0);
 
 	D_ASSERTF(rc == 0, ""DF_RC"\n", DP_RC(rc));
 	out->tqo_hae	= MIN(out->tqo_hae, pack_args.xcq_hae);
@@ -1820,8 +1819,7 @@ ds_cont_tgt_snapshots_update(uuid_t pool_uuid, uuid_t cont_uuid,
 	args.snapshots = snapshots;
 	D_DEBUG(DB_TRACE, DF_UUID": refreshing snapshots %d\n",
 		DP_UUID(cont_uuid), snap_count);
-	return dss_thread_collective(cont_snap_update_one, &args, 0,
-				     DSS_ULT_IO);
+	return dss_thread_collective(cont_snap_update_one, &args, 0);
 }
 
 void
@@ -1857,8 +1855,8 @@ ds_cont_tgt_snapshots_refresh(uuid_t pool_uuid, uuid_t cont_uuid)
 		return -DER_NOMEM;
 	uuid_copy(args->pool_uuid, pool_uuid);
 	uuid_copy(args->cont_uuid, cont_uuid);
-	rc = dss_ult_create(cont_snapshots_refresh_ult, args,
-			    DSS_ULT_POOL_SRV, 0, 0, NULL);
+	rc = dss_ult_create(cont_snapshots_refresh_ult, args, DSS_XS_SYS,
+			    0, 0, NULL);
 	if (rc != 0)
 		D_FREE(args);
 	return rc;
@@ -1903,8 +1901,7 @@ ds_cont_tgt_snapshot_notify_handler(crt_rpc_t *rpc)
 	args.snap_epoch = in->tsi_epoch;
 	args.snap_opts = in->tsi_opts;
 
-	out->tso_rc = dss_thread_collective(cont_snap_notify_one, &args, 0,
-					    DSS_ULT_IO);
+	out->tso_rc = dss_thread_collective(cont_snap_notify_one, &args, 0);
 	if (out->tso_rc != 0)
 		D_ERROR(DF_CONT": Snapshot notify failed: "DF_RC"\n",
 			DP_CONT(in->tsi_pool_uuid, in->tsi_cont_uuid),
@@ -1950,8 +1947,7 @@ ds_cont_tgt_epoch_aggregate_handler(crt_rpc_t *rpc)
 	if (out->tao_rc != 0)
 		return;
 
-	rc = dss_thread_collective(cont_epoch_aggregate_one, NULL, 0,
-				   DSS_ULT_IO);
+	rc = dss_thread_collective(cont_epoch_aggregate_one, NULL, 0);
 	if (rc != 0)
 		D_ERROR(DF_CONT": Aggregation failed: "DF_RC"\n",
 			DP_CONT(in->tai_pool_uuid, in->tai_cont_uuid),
@@ -2318,8 +2314,7 @@ ds_cont_tgt_ec_eph_query_ult(void *data)
 		coll_args.ca_aggregator = pool;
 		coll_args.ca_func_args	= &coll_args.ca_stream_args;
 
-		rc = dss_thread_collective_reduce(&coll_ops, &coll_args,
-						  0, DSS_ULT_IO);
+		rc = dss_thread_collective_reduce(&coll_ops, &coll_args, 0);
 		if (rc) {
 			D_ERROR(DF_UUID": Can not collect min epoch: %d\n",
 				DP_UUID(pool->sp_uuid), rc);

--- a/src/dtx/dtx_common.c
+++ b/src/dtx/dtx_common.c
@@ -207,8 +207,8 @@ dtx_batched_commit(void *arg)
 				DTX_AGG_THRESHOLD_AGE_UPPER))) {
 			ds_cont_child_get(cont);
 			cont->sc_dtx_aggregating = 1;
-			rc = dss_ult_create(dtx_aggregate, cont, DSS_ULT_GC,
-					    DSS_TGT_SELF, 0, NULL);
+			rc = dss_ult_create(dtx_aggregate, cont, DSS_XS_SELF,
+					    0, 0, NULL);
 			if (rc != 0) {
 				cont->sc_dtx_aggregating = 0;
 				ds_cont_child_put(cont);
@@ -1236,7 +1236,7 @@ dtx_leader_exec_ops(struct dtx_leader_handle *dlh, dtx_sub_func_t func,
 	 * targets for now.
 	 */
 	dlh->dlh_result = 0;
-	rc = dss_ult_create(dtx_leader_exec_ops_ult, ult_arg, DSS_ULT_IOFW,
+	rc = dss_ult_create(dtx_leader_exec_ops_ult, ult_arg, DSS_XS_IOFW,
 			    dss_get_module_info()->dmi_tgt_id,
 			    DSS_DEEP_STACK_SZ, NULL);
 	if (rc != 0) {

--- a/src/dtx/dtx_resync.c
+++ b/src/dtx/dtx_resync.c
@@ -609,7 +609,7 @@ dtx_resync_ult(void *data)
 		DP_UUID(arg->pool_uuid), pool->sp_dtx_resync_version,
 		arg->version);
 
-	rc = dss_thread_collective(dtx_resync_one, arg, 0, DSS_ULT_REBUILD);
+	rc = dss_thread_collective(dtx_resync_one, arg, 0);
 	if (rc) {
 		/* If dtx resync fails, then let's still update
 		 * sp_dtx_resync_version, so the rebuild can go ahead,

--- a/src/dtx/dtx_srv.c
+++ b/src/dtx/dtx_srv.c
@@ -211,7 +211,7 @@ dtx_setup(void)
 {
 	int	rc;
 
-	rc = dss_ult_create_all(dtx_batched_commit, NULL, DSS_ULT_GC, true);
+	rc = dss_ult_create_all(dtx_batched_commit, NULL, true);
 	if (rc != 0)
 		D_ERROR("Failed to create DTX batched commit ULT: "DF_RC"\n",
 			DP_RC(rc));

--- a/src/include/daos_srv/container.h
+++ b/src/include/daos_srv/container.h
@@ -238,7 +238,7 @@ struct csum_recalc_args {
 	daos_size_t		 cra_seg_size;  /* size of coalesced entry */
 	unsigned int		 cra_seg_cnt;   /* # of read segments */
 	unsigned int		 cra_buf_len;	/* length of read buffer */
-	int			 cra_tgt_id;	/* used to log error */
+	int			 cra_tgt_id;	/* VOS target ID */
 	int			 cra_rc;	/* return code */
 	ABT_eventual		 csum_eventual;
 };

--- a/src/iosrv/drpc_listener.c
+++ b/src/iosrv/drpc_listener.c
@@ -145,8 +145,8 @@ drpc_listener_start_ult(ABT_thread *thread)
 	}
 
 	/* Create a ULT to start the drpc listener */
-	rc = dss_ult_create(drpc_listener_run, (void *)ctx,
-			    DSS_ULT_DRPC_LISTENER, 0, 0, thread);
+	rc = dss_ult_create(drpc_listener_run, (void *)ctx, DSS_XS_DRPC,
+			    0, 0, thread);
 	if (rc != 0) {
 		D_ERROR("Failed to create drpc listener ULT: "DF_RC"\n",
 			DP_RC(rc));

--- a/src/iosrv/drpc_progress.c
+++ b/src/iosrv/drpc_progress.c
@@ -371,7 +371,7 @@ handle_incoming_call(struct drpc *session_ctx)
 	 * Ownership of the call context is passed on to the handler ULT.
 	 */
 	rc = dss_ult_create(drpc_handler_ult, (void *)call_ctx,
-			    DSS_ULT_DRPC_HANDLER, 0, 0, NULL);
+			    DSS_XS_SYS, 0, 0, NULL);
 	if (rc != 0) {
 		D_ERROR("Failed to create drpc handler ULT: "DF_RC"\n",
 			DP_RC(rc));

--- a/src/iosrv/sched.c
+++ b/src/iosrv/sched.c
@@ -524,23 +524,16 @@ static int
 req_kickoff_internal(struct dss_xstream *dx, struct sched_req_attr *attr,
 		     void (*func)(void *), void *arg)
 {
-	ABT_pool	abt_pool;
+	ABT_pool	abt_pool = dx->dx_pools[DSS_POOL_GENERIC];
 	int		rc;
 
 	D_ASSERT(attr && func && arg);
 	switch (attr->sra_type) {
 	case SCHED_REQ_UPDATE:
 	case SCHED_REQ_FETCH:
-		abt_pool = dx->dx_pools[DSS_POOL_IO];
-		break;
 	case SCHED_REQ_GC:
-		abt_pool = dx->dx_pools[DSS_POOL_GC];
-		break;
 	case SCHED_REQ_SCRUB:
-		abt_pool = dx->dx_pools[DSS_POOL_SCRUB];
-		break;
 	case SCHED_REQ_MIGRATE:
-		abt_pool = dx->dx_pools[DSS_POOL_REBUILD];
 		break;
 	default:
 		D_ASSERTF(0, "Invalid req type: %u\n", attr->sra_type);
@@ -1187,13 +1180,10 @@ sched_dump_data(struct sched_data *data)
 	struct sched_cycle	*cycle = &data->sd_cycle;
 
 	D_PRINT("XS(%d): comm:%d main:%d. age_net:%u, age_nvme:%u, "
-		"new_cycle:%d cycle_started:%d total_ults:%u [%u, %u, %u]\n",
+		"new_cycle:%d cycle_started:%d total_ults:%u\n",
 		dx->dx_xs_id, dx->dx_comm, dx->dx_main_xs, cycle->sc_age_net,
 		cycle->sc_age_nvme, cycle->sc_new_cycle,
-		cycle->sc_cycle_started, cycle->sc_ults_tot,
-		cycle->sc_ults_cnt[DSS_POOL_IO],
-		cycle->sc_ults_cnt[DSS_POOL_REBUILD],
-		cycle->sc_ults_cnt[DSS_POOL_GC]);
+		cycle->sc_cycle_started, cycle->sc_ults_tot);
 #endif
 }
 
@@ -1382,7 +1372,7 @@ sched_start_cycle(struct sched_data *data, ABT_pool *pools)
 	struct dss_xstream	*dx = data->sd_dx;
 	struct sched_cycle	*cycle = &data->sd_cycle;
 	size_t			 cnt;
-	int			 i, ret;
+	int			 ret;
 
 	D_ASSERT(cycle->sc_new_cycle == 1);
 	D_ASSERT(cycle->sc_cycle_started == 0);
@@ -1394,20 +1384,16 @@ sched_start_cycle(struct sched_data *data, ABT_pool *pools)
 	wakeup_all(dx);
 	process_all(dx);
 
-	/* Get number of ULTS for each ABT pool */
-	for (i = DSS_POOL_IO; i < DSS_POOL_CNT; i++) {
-		D_ASSERT(cycle->sc_ults_cnt[i] == 0);
-
-		ret = ABT_pool_get_size(pools[i], &cnt);
-		if (ret != ABT_SUCCESS) {
-			D_ERROR("XS(%d) get ABT pool(%d) size error: %d\n",
-				dx->dx_xs_id, i, ret);
-			cnt = 0;
-		}
-
-		cycle->sc_ults_cnt[i] = cnt;
-		cycle->sc_ults_tot += cycle->sc_ults_cnt[i];
+	/* Get number of ULTS in generic ABT pool */
+	D_ASSERT(cycle->sc_ults_cnt[DSS_POOL_GENERIC] == 0);
+	ret = ABT_pool_get_size(pools[DSS_POOL_GENERIC], &cnt);
+	if (ret != ABT_SUCCESS) {
+		D_ERROR("XS(%d) get ABT pool(%d) size error: %d\n",
+			dx->dx_xs_id, DSS_POOL_GENERIC, ret);
+		cnt = 0;
 	}
+	cycle->sc_ults_cnt[DSS_POOL_GENERIC] = cnt;
+	cycle->sc_ults_tot += cycle->sc_ults_cnt[DSS_POOL_GENERIC];
 }
 
 static void
@@ -1420,7 +1406,7 @@ sched_run(ABT_sched sched)
 	ABT_pool		 pool;
 	ABT_unit		 unit;
 	uint32_t		 work_count = 0;
-	int			 i, ret;
+	int			 ret;
 
 	ABT_sched_get_data(sched, (void **)&data);
 	cycle = &data->sd_cycle;
@@ -1449,13 +1435,11 @@ sched_run(ABT_sched sched)
 		if (cycle->sc_ults_tot == 0)
 			goto start_cycle;
 
-		/* Try to pick a ULT from other ABT pools */
-		for (i = DSS_POOL_IO; i < DSS_POOL_CNT; i++) {
-			pool = pools[i];
-			unit = sched_pop_one(data, pool, i);
-			if (unit != ABT_UNIT_NULL)
-				goto execute;
-		}
+		/* Try to pick a ULT from generic ABT pool */
+		pool = pools[DSS_POOL_GENERIC];
+		unit = sched_pop_one(data, pool, DSS_POOL_GENERIC);
+		if (unit != ABT_UNIT_NULL)
+			goto execute;
 
 		/*
 		 * Nothing to be executed? Could be idle helper XS or poll ULT

--- a/src/iosrv/server_iv.c
+++ b/src/iosrv/server_iv.c
@@ -506,8 +506,7 @@ ivc_pre_cb(crt_iv_namespace_t ivns, crt_iv_key_t *iv_key,
 {
 	int rc;
 
-	rc = dss_ult_create(cb_func, cb_arg, DSS_ULT_MISC, DSS_TGT_SELF,
-			    0, NULL);
+	rc = dss_ult_create(cb_func, cb_arg, DSS_XS_SELF, 0, 0, NULL);
 	if (rc)
 		D_ERROR("dss_ult_create failed, rc "DF_RC"\n", DP_RC(rc));
 }

--- a/src/iosrv/srv.c
+++ b/src/iosrv/srv.c
@@ -332,7 +332,7 @@ dss_iv_resp_hdlr(crt_context_t *ctx, void *hdlr_arg,
 	struct dss_xstream	*dx = (struct dss_xstream *)arg;
 	int			 rc;
 
-	rc = ABT_thread_create(dx->dx_pools[DSS_POOL_IO], real_rpc_hdlr,
+	rc = ABT_thread_create(dx->dx_pools[DSS_POOL_GENERIC], real_rpc_hdlr,
 			       hdlr_arg, ABT_THREAD_ATTR_NULL, NULL);
 	return dss_abterr2der(rc);
 }
@@ -361,8 +361,8 @@ dss_rpc_hdlr(crt_context_t *ctx, void *hdlr_arg,
 	if (rc == 0)
 		return sched_req_enqueue(dx, &attr, real_rpc_hdlr, rpc);
 
-	rc = ABT_thread_create(dx->dx_pools[DSS_POOL_IO], real_rpc_hdlr, rpc,
-			       ABT_THREAD_ATTR_NULL, NULL);
+	rc = ABT_thread_create(dx->dx_pools[DSS_POOL_GENERIC], real_rpc_hdlr,
+			       rpc, ABT_THREAD_ATTR_NULL, NULL);
 	return dss_abterr2der(rc);
 }
 
@@ -1115,7 +1115,7 @@ dss_acc_offload(struct dss_acc_task *at_args)
 				at_args->at_params,
 				NULL /* user-cb */,
 				NULL /* user-cb args */,
-				DSS_ULT_CHECKSUM, tid,
+				DSS_XS_OFFLOAD, tid,
 				0);
 		break;
 	case DSS_OFFLOAD_ACC:

--- a/src/iosrv/srv_cli.c
+++ b/src/iosrv/srv_cli.c
@@ -65,7 +65,7 @@ dsc_progress_start(void)
 	if (dx->dx_dsc_started)
 		return 0;
 
-	rc = ABT_thread_create(dx->dx_pools[DSS_POOL_REBUILD], dsc_progress,
+	rc = ABT_thread_create(dx->dx_pools[DSS_POOL_GENERIC], dsc_progress,
 			       dx, ABT_THREAD_ATTR_NULL, NULL);
 	if (rc != ABT_SUCCESS)
 		return dss_abterr2der(rc);

--- a/src/iosrv/srv_internal.h
+++ b/src/iosrv/srv_internal.h
@@ -31,18 +31,12 @@
  *
  * DSS_POOL_NET_POLL	Network poll ULT
  * DSS_POOL_NVME_POLL	NVMe poll ULT
- * DSS_POOL_IO		Update/Fetch/Punch, enumeration RPC handler ULTs
- * DSS_POOL_REBUILD	Rebuild/Reint scan & pull ULTs
- * DSS_POOL_GC		Space reclaiming ULTs like GC or aggregation
- * DSS_POOL_SCRUB	Scrub checksums to discover silent data corruption
+ * DSS_POOL_GENERIC	All other ULTS
  */
 enum {
 	DSS_POOL_NET_POLL	= 0,
 	DSS_POOL_NVME_POLL,
-	DSS_POOL_IO,
-	DSS_POOL_REBUILD,
-	DSS_POOL_GC,
-	DSS_POOL_SCRUB,
+	DSS_POOL_GENERIC,
 	DSS_POOL_CNT,
 };
 
@@ -140,8 +134,6 @@ struct dss_thread_local_storage *dss_tls_init(int tag);
 void ds_iv_init(void);
 void ds_iv_fini(void);
 
-/** To schedule ULT on caller's self XS */
-#define DSS_XS_SELF		(-1)
 /** Total number of XS */
 #define DSS_XS_NR_TOTAL						\
 	(dss_sys_xs_nr + dss_tgt_nr + dss_tgt_offload_xs_nr)

--- a/src/iosrv/tests/drpc_progress_tests.c
+++ b/src/iosrv/tests/drpc_progress_tests.c
@@ -481,7 +481,7 @@ test_drpc_progress_single_session_success(void **state)
 	/* ULT spawned to deal with the message */
 	assert_non_null(dss_ult_create_func);
 	assert_non_null(dss_ult_create_arg_ptr);
-	assert_int_equal(dss_ult_create_ult_type, DSS_ULT_DRPC_HANDLER);
+	assert_int_equal(dss_ult_create_ult_type, DSS_XS_SYS);
 	assert_int_equal(dss_ult_create_tgt_idx, 0);
 	assert_int_equal(dss_ult_create_stack_size, 0);
 	assert_null(dss_ult_create_ult_ptr); /* self-freeing ULT */

--- a/src/mgmt/srv_query.c
+++ b/src/mgmt/srv_query.c
@@ -89,8 +89,7 @@ int ds_mgmt_get_bs_state(uuid_t bs_uuid, int *bs_state)
 
 	/* Create a ULT on the tgt_id */
 	D_DEBUG(DB_MGMT, "Starting ULT on tgt_id:%d\n", tgt_id);
-	/* TODO Add a new DSS_ULT_BIO tag */
-	rc = dss_ult_create(bs_state_query, (void *)bs_state, DSS_ULT_GC,
+	rc = dss_ult_create(bs_state_query, (void *)bs_state, DSS_XS_VOS,
 			    tgt_id, 0, &thread);
 	if (rc != 0) {
 		D_ERROR("Unable to create a ULT on tgt_id:%d\n", tgt_id);
@@ -208,8 +207,7 @@ ds_mgmt_bio_health_query(struct mgmt_bio_health *mbh, uuid_t dev_uuid,
 
 	/* Create a ULT on the tgt_id */
 	D_DEBUG(DB_MGMT, "Starting ULT on tgt_id:%d\n", tgt_id);
-	/* TODO Add a new DSS_ULT_BIO tag */
-	rc = dss_ult_create(bio_health_query, mbh, DSS_ULT_GC, tgt_id, 0,
+	rc = dss_ult_create(bio_health_query, mbh, DSS_XS_VOS, tgt_id, 0,
 			    &thread);
 	if (rc != 0) {
 		D_ERROR("Unable to create a ULT on tgt_id:%d\n", tgt_id);
@@ -271,7 +269,7 @@ ds_mgmt_smd_list_devs(Mgmt__SmdDevResp *resp)
 	D_INIT_LIST_HEAD(&list_devs_info.dev_list);
 
 	rc = dss_ult_execute(bio_query_dev_list, &list_devs_info, NULL, NULL,
-			     DSS_ULT_GC, 0, 0);
+			     DSS_XS_VOS, 0, 0);
 	if (rc != 0) {
 		D_ERROR("Unable to create a ULT\n");
 		goto out;
@@ -655,8 +653,7 @@ ds_mgmt_dev_set_faulty(uuid_t dev_uuid, Mgmt__DevStateResp *resp)
 
 	/* Create a ULT on the tgt_id */
 	D_DEBUG(DB_MGMT, "Starting ULT on tgt_id:%d\n", tgt_id);
-	/* TODO Add a new DSS_ULT_BIO tag */
-	rc = dss_ult_create(bio_faulty_state_set, NULL, DSS_ULT_GC,
+	rc = dss_ult_create(bio_faulty_state_set, NULL, DSS_XS_VOS,
 			    tgt_id, 0, &thread);
 	if (rc != 0) {
 		D_ERROR("Unable to create a ULT on tgt_id:%d\n", tgt_id);
@@ -669,7 +666,7 @@ ds_mgmt_dev_set_faulty(uuid_t dev_uuid, Mgmt__DevStateResp *resp)
 	uuid_copy(faulty_info.devid, dev_uuid);
 	/* set the VMD LED to FAULTY state on init xstream */
 	rc = dss_ult_execute(bio_faulty_led_set, &faulty_info, NULL,
-			     NULL, DSS_ULT_GC, 0, 0);
+			     NULL, DSS_XS_VOS, 0, 0);
 	if (rc) {
 		D_ERROR("FAULT LED state not set on device:"DF_UUID"\n",
 			DP_UUID(dev_uuid));
@@ -757,7 +754,7 @@ ds_mgmt_dev_replace(uuid_t old_dev_uuid, uuid_t new_dev_uuid,
 	uuid_copy(replace_dev_info.old_dev, old_dev_uuid);
 	uuid_copy(replace_dev_info.new_dev, new_dev_uuid);
 	rc = dss_ult_execute(bio_storage_dev_replace, &replace_dev_info, NULL,
-			     NULL, DSS_ULT_GC, 0, 0);
+			     NULL, DSS_XS_VOS, 0, 0);
 	if (rc != 0) {
 		D_ERROR("Unable to create a ULT\n");
 		goto out;
@@ -840,7 +837,7 @@ ds_mgmt_dev_identify(uuid_t dev_uuid, Mgmt__DevIdentifyResp *resp)
 
 	uuid_copy(identify_info.devid, dev_uuid);
 	rc = dss_ult_execute(bio_storage_dev_identify, &identify_info, NULL,
-			     NULL, DSS_ULT_GC, 0, 0);
+			     NULL, DSS_XS_VOS, 0, 0);
 	if (rc != 0)
 		goto out;
 

--- a/src/mgmt/srv_target.c
+++ b/src/mgmt/srv_target.c
@@ -286,7 +286,7 @@ cleanup_newborn_pool(uuid_t uuid, void *arg)
 	D_DEBUG(DB_MGMT, "Clear SPDK blobs for NEWBORN pool "DF_UUID"\n",
 		DP_UUID(uuid));
 	uuid_copy(id.uuid, uuid);
-	rc = dss_thread_collective(tgt_kill_pool, &id, 0, DSS_ULT_IO);
+	rc = dss_thread_collective(tgt_kill_pool, &id, 0);
 	if (rc != 0) {
 		if (rc > 0)
 			D_ERROR("%d xstreams failed tgt_kill_pool()\n", rc);
@@ -636,8 +636,7 @@ tgt_vos_create(struct ds_pooltgts_rec *ptrec, uuid_t uuid,
 		vpa.vpa_scm_size = 0;
 		vpa.vpa_nvme_size = nvme_size;
 
-		rc = dss_thread_collective(tgt_vos_create_one, &vpa, 0,
-					   DSS_ULT_IO);
+		rc = dss_thread_collective(tgt_vos_create_one, &vpa, 0);
 	}
 
 	/** brute force cleanup to be done by the caller */
@@ -895,7 +894,7 @@ tgt_destroy(uuid_t pool_uuid, char *path)
 
 	/* destroy blobIDs first */
 	uuid_copy(id.uuid, pool_uuid);
-	rc = dss_thread_collective(tgt_kill_pool, &id, 0, DSS_ULT_IO);
+	rc = dss_thread_collective(tgt_kill_pool, &id, 0);
 	if (rc)
 		D_GOTO(out, rc);
 
@@ -1058,7 +1057,7 @@ ds_mgmt_tgt_profile_hdlr(crt_rpc_t *rpc)
 	in = crt_req_get(rpc);
 	D_ASSERT(in != NULL);
 
-	rc = dss_task_collective(tgt_profile_task, in, 0, DSS_ULT_IO);
+	rc = dss_task_collective(tgt_profile_task, in, 0);
 
 	out = crt_reply_get(rpc);
 	out->p_rc = rc;

--- a/src/object/srv_ec_aggregate.c
+++ b/src/object/srv_ec_aggregate.c
@@ -425,7 +425,7 @@ agg_encode_full_stripe(struct ec_agg_entry *entry)
 		goto out;
 	}
 	rc = dss_ult_create(agg_encode_full_stripe_ult, &stripe_ud,
-			    DSS_ULT_EC, tid, 0, NULL);
+			    DSS_XS_OFFLOAD, tid, 0, NULL);
 	if (rc)
 		goto ev_out;
 	rc = ABT_eventual_wait(stripe_ud.asu_eventual, (void **)&status);

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -4164,8 +4164,8 @@ ds_obj_cpd_handler(crt_rpc_t *rpc)
 		dcas[i].dca_future = future;
 		dcas[i].dca_idx = i;
 
-		rc = dss_ult_create(ds_obj_dtx_leader_ult, &dcas[i], DSS_ULT_IO,
-				    DSS_TGT_SELF, 0, NULL);
+		rc = dss_ult_create(ds_obj_dtx_leader_ult, &dcas[i],
+				    DSS_XS_SELF, 0, 0, NULL);
 		if (rc != 0) {
 			struct daos_cpd_sub_head	*dcsh;
 

--- a/src/object/srv_obj_migrate.c
+++ b/src/object/srv_obj_migrate.c
@@ -493,8 +493,7 @@ migrate_pool_tls_lookup_create(struct ds_pool *pool, int version,
 	arg.clear_conts = clear_conts;
 	arg.max_eph = max_eph;
 	arg.svc_list = (d_rank_list_t *)entry->dpe_val_ptr;
-	rc = dss_task_collective(migrate_pool_tls_create_one, &arg, 0,
-				 DSS_ULT_REBUILD);
+	rc = dss_task_collective(migrate_pool_tls_create_one, &arg, 0);
 	if (rc != 0) {
 		D_ERROR(DF_UUID": failed to create migrate tls: %d\n",
 			DP_UUID(pool->sp_uuid), rc);
@@ -1784,7 +1783,7 @@ migrate_start_ult(struct enum_unpack_arg *unpack_arg)
 			mrone->mo_iod_num);
 
 		d_list_del_init(&mrone->mo_list);
-		rc = dss_ult_create(migrate_one_ult, mrone, DSS_ULT_REBUILD,
+		rc = dss_ult_create(migrate_one_ult, mrone, DSS_XS_VOS,
 				    arg->tgt_idx, MIGRATE_STACK_SIZE, NULL);
 		if (rc) {
 			migrate_one_destroy(mrone);
@@ -2009,8 +2008,7 @@ ds_migrate_abort(uuid_t pool_uuid, unsigned int version)
 
 	uuid_copy(arg.pool_uuid, pool_uuid);
 	arg.version = version;
-	rc = dss_thread_collective(migrate_fini_one_ult, &arg, 0,
-				   DSS_ULT_REBUILD);
+	rc = dss_thread_collective(migrate_fini_one_ult, &arg, 0);
 	if (rc)
 		D_ERROR("migrate abort: %d\n", rc);
 
@@ -2020,8 +2018,7 @@ ds_migrate_abort(uuid_t pool_uuid, unsigned int version)
 static int
 migrate_obj_punch(struct iter_obj_arg *arg)
 {
-	return dss_task_collective(migrate_obj_punch_one, arg, 0,
-				   DSS_ULT_REBUILD);
+	return dss_task_collective(migrate_obj_punch_one, arg, 0);
 }
 
 /**
@@ -2117,7 +2114,7 @@ migrate_one_object(daos_unit_oid_t oid, daos_epoch_t eph, unsigned int shard,
 	}
 
 	/* Let's iterate the object on different xstream */
-	rc = dss_ult_create(migrate_obj_ult, obj_arg, DSS_ULT_REBUILD,
+	rc = dss_ult_create(migrate_obj_ult, obj_arg, DSS_XS_VOS,
 			    oid.id_pub.lo % dss_tgt_nr, MIGRATE_STACK_SIZE,
 			    NULL);
 	if (rc == 0) {
@@ -2603,8 +2600,8 @@ ds_obj_migrate_handler(crt_rpc_t *rpc)
 	if (!pool_tls->mpt_ult_running) {
 		pool_tls->mpt_ult_running = 1;
 		migrate_pool_tls_get(pool_tls);
-		rc = dss_ult_create(migrate_ult, pool_tls, DSS_ULT_REBUILD,
-				    DSS_TGT_SELF, 0, NULL);
+		rc = dss_ult_create(migrate_ult, pool_tls, DSS_XS_SELF,
+				    0, 0, NULL);
 		if (rc) {
 			pool_tls->mpt_ult_running = 0;
 			migrate_pool_tls_put(pool_tls);
@@ -2677,7 +2674,7 @@ ds_migrate_query_status(uuid_t pool_uuid, uint32_t ver,
 	if (rc != ABT_SUCCESS)
 		D_GOTO(out, rc);
 
-	rc = dss_thread_collective(migrate_check_one, &arg, 0, DSS_ULT_REBUILD);
+	rc = dss_thread_collective(migrate_check_one, &arg, 0);
 	if (rc)
 		D_GOTO(out, rc);
 

--- a/src/pool/srv_iv.c
+++ b/src/pool/srv_iv.c
@@ -1240,7 +1240,7 @@ ds_pool_iv_svc_fetch(struct ds_pool *pool, d_rank_list_t **svc_p)
 	} else {
 		/* create a ULT and schedule it on xstream-0 */
 		rc = dss_ult_execute(cont_pool_svc_ult, &ia, NULL, NULL,
-				     DSS_ULT_POOL_SRV, 0, 0);
+				     DSS_XS_SYS, 0, 0);
 		if (rc)
 			D_GOTO(failed, rc);
 	}

--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -917,8 +917,8 @@ pool_evict_rank(struct pool_svc *svc, d_rank_t rank)
 	pool_svc_get(svc);
 	ult_arg->svc = svc;
 	ult_arg->rank = rank;
-	rc = dss_ult_create(pool_evict_rank_ult, ult_arg, DSS_ULT_MISC,
-			    DSS_TGT_SELF, 0, NULL);
+	rc = dss_ult_create(pool_evict_rank_ult, ult_arg, DSS_XS_SELF,
+			    0, 0, NULL);
 	if (rc) {
 		pool_svc_put(svc);
 		D_FREE_PTR(ult_arg);
@@ -1394,7 +1394,7 @@ ds_pool_start_all(void)
 	int		rc;
 
 	/* Create a ULT to call ds_rsvc_start() in xstream 0. */
-	rc = dss_ult_create(pool_start_all, NULL /* arg */, DSS_ULT_POOL_SRV,
+	rc = dss_ult_create(pool_start_all, NULL /* arg */, DSS_XS_SYS,
 			    0 /* tgt_idx */, 0 /* stack_size */, &thread);
 	if (rc != 0) {
 		D_ERROR("failed to create pool start ULT: "DF_RC"\n",
@@ -5073,7 +5073,7 @@ ds_pool_child_map_refresh_sync(struct ds_pool_child *dpc)
 	uuid_copy(arg.iua_pool_uuid, dpc->spc_uuid);
 	arg.iua_eventual = eventual;
 
-	rc = dss_ult_create(ds_pool_map_refresh_ult, &arg, DSS_ULT_POOL_SRV,
+	rc = dss_ult_create(ds_pool_map_refresh_ult, &arg, DSS_XS_SYS,
 			    0, 0, NULL);
 	if (rc)
 		D_GOTO(out_eventual, rc);
@@ -5101,7 +5101,7 @@ ds_pool_child_map_refresh_async(struct ds_pool_child *dpc)
 	arg->iua_pool_version = dpc->spc_map_version;
 	uuid_copy(arg->iua_pool_uuid, dpc->spc_uuid);
 
-	rc = dss_ult_create(ds_pool_map_refresh_ult, arg, DSS_ULT_POOL_SRV,
+	rc = dss_ult_create(ds_pool_map_refresh_ult, arg, DSS_XS_SYS,
 			    0, 0, NULL);
 	return rc;
 }

--- a/src/pool/srv_pool_scrub.c
+++ b/src/pool/srv_pool_scrub.c
@@ -305,8 +305,7 @@ ds_start_scrubbing_ult(struct ds_pool_child *child)
 		"xs_id: %d, tgt_id: %d, ctx_id: %d, ",
 		dmi->dmi_xs_id, dmi->dmi_tgt_id, dmi->dmi_ctx_id);
 
-	rc = dss_ult_create(scrubbing_ult, child, DSS_ULT_IO, DSS_TGT_SELF,
-			    0, &thread);
+	rc = dss_ult_create(scrubbing_ult, child, DSS_XS_SELF, 0, 0, &thread);
 	if (rc) {
 		D_ERROR(DF_UUID"[%d]: Failed to create Scrubbing ULT. %d\n",
 			DP_UUID(child->spc_uuid), dmi->dmi_tgt_id, rc);

--- a/src/pool/srv_target.c
+++ b/src/pool/srv_target.c
@@ -148,7 +148,7 @@ start_gc_ult(struct ds_pool_child *child)
 	D_ASSERT(child != NULL);
 	D_ASSERT(child->spc_gc_req == NULL);
 
-	rc = dss_ult_create(gc_ult, child, DSS_ULT_GC, DSS_TGT_SELF, 0, &gc);
+	rc = dss_ult_create(gc_ult, child, DSS_XS_SELF, 0, 0, &gc);
 	if (rc) {
 		D_ERROR(DF_UUID"[%d]: Failed to create GC ULT. %d\n",
 			DP_UUID(child->spc_uuid), dmi->dmi_tgt_id, rc);
@@ -373,8 +373,7 @@ pool_alloc_ref(void *key, unsigned int ksize, void *varg,
 	collective_arg.pla_pool = pool;
 	collective_arg.pla_uuid = key;
 	collective_arg.pla_map_version = arg->pca_map_version;
-	rc = dss_thread_collective(pool_child_add_one, &collective_arg, 0,
-				   DSS_ULT_IO);
+	rc = dss_thread_collective(pool_child_add_one, &collective_arg, 0);
 	if (rc != 0) {
 		D_ERROR(DF_UUID": failed to add ES pool caches: "DF_RC"\n",
 			DP_UUID(key), DP_RC(rc));
@@ -420,8 +419,7 @@ pool_free_ref(struct daos_llink *llink)
 		D_ERROR(DF_UUID": failed to destroy pool group: %d\n",
 			DP_UUID(pool->sp_uuid), rc);
 
-	rc = dss_thread_collective(pool_child_delete_one, pool->sp_uuid, 0,
-				   DSS_ULT_IO);
+	rc = dss_thread_collective(pool_child_delete_one, pool->sp_uuid, 0);
 	if (rc == -DER_CANCELED)
 		D_DEBUG(DB_MD, DF_UUID": no ESs\n", DP_UUID(pool->sp_uuid));
 	else if (rc != 0)
@@ -592,7 +590,7 @@ ds_pool_start_ec_eph_query_ult(struct ds_pool *pool)
 	ABT_thread		ec_eph_query_ult = ABT_THREAD_NULL;
 	int			rc;
 
-	rc = dss_ult_create(tgt_ec_eph_query_ult, pool, DSS_ULT_POOL_SRV, 0,
+	rc = dss_ult_create(tgt_ec_eph_query_ult, pool, DSS_XS_SYS, 0,
 			    131072, &ec_eph_query_ult);
 	if (rc != 0) {
 		D_ERROR(DF_UUID": failed create ec eph equery ult: %d\n",
@@ -672,7 +670,7 @@ ds_pool_start(uuid_t uuid)
 	}
 
 	pool = pool_obj(llink);
-	rc = dss_ult_create(pool_fetch_hdls_ult, pool, DSS_ULT_POOL_SRV,
+	rc = dss_ult_create(pool_fetch_hdls_ult, pool, DSS_XS_SYS,
 			    0, 0, NULL);
 	if (rc != 0) {
 		D_ERROR(DF_UUID": failed to create fetch ult: %d\n",
@@ -1005,8 +1003,7 @@ pool_tgt_query(struct ds_pool *pool, struct daos_pool_space *ps)
 		return rc;
 	}
 
-	rc = dss_thread_collective_reduce(&coll_ops, &coll_args, 0,
-					  DSS_ULT_IO);
+	rc = dss_thread_collective_reduce(&coll_ops, &coll_args, 0);
 	if (coll_args.ca_exclude_tgts)
 		D_FREE(coll_args.ca_exclude_tgts);
 	if (rc) {
@@ -1257,8 +1254,7 @@ ds_pool_tgt_map_update(struct ds_pool *pool, struct pool_buf *buf,
 			map_version);
 
 		pool->sp_map_version = map_version;
-		rc = dss_task_collective(update_child_map, pool, 0,
-					 DSS_ULT_IO);
+		rc = dss_task_collective(update_child_map, pool, 0);
 		D_ASSERT(rc == 0);
 		update_map = true;
 	}
@@ -1276,7 +1272,7 @@ ds_pool_tgt_map_update(struct ds_pool *pool, struct pool_buf *buf,
 
 		uuid_copy(arg->pool_uuid, pool->sp_uuid);
 		arg->version = pool->sp_map_version;
-		ret = dss_ult_create(dtx_resync_ult, arg, DSS_ULT_POOL_SRV,
+		ret = dss_ult_create(dtx_resync_ult, arg, DSS_XS_SYS,
 				     0, 0, NULL);
 		if (ret) {
 			D_ERROR("dtx_resync_ult failure %d\n", ret);

--- a/src/pool/srv_util.c
+++ b/src/pool/srv_util.c
@@ -838,8 +838,7 @@ update_pool_targets(uuid_t pool_id, int *tgt_ids, int tgt_cnt, bool reint,
 	if (uta == NULL)
 		return -DER_NOMEM;
 
-	rc = dss_ult_create(update_targets_ult, uta, DSS_ULT_MISC,
-			    DSS_TGT_SELF, 0, NULL);
+	rc = dss_ult_create(update_targets_ult, uta, DSS_XS_SELF, 0, 0, NULL);
 	if (rc) {
 		D_ERROR(DF_UUID": Failed to start targets updating ULT. %d\n",
 			DP_UUID(pool_id), rc);

--- a/src/rdb/rdb_raft.c
+++ b/src/rdb/rdb_raft.c
@@ -2438,19 +2438,17 @@ rdb_raft_start(struct rdb *db)
 	raft_set_election_timeout(db->d_raft, election_timeout);
 	raft_set_request_timeout(db->d_raft, request_timeout);
 
-	rc = dss_ult_create(rdb_recvd, db, DSS_ULT_RDB, DSS_TGT_SELF, 0,
-			    &db->d_recvd);
+	rc = dss_ult_create(rdb_recvd, db, DSS_XS_SELF, 0, 0, &db->d_recvd);
 	if (rc != 0)
 		goto err_lc;
-	rc = dss_ult_create(rdb_timerd, db, DSS_ULT_RDB, DSS_TGT_SELF, 0,
-			    &db->d_timerd);
+	rc = dss_ult_create(rdb_timerd, db, DSS_XS_SELF, 0, 0, &db->d_timerd);
 	if (rc != 0)
 		goto err_recvd;
-	rc = dss_ult_create(rdb_callbackd, db, DSS_ULT_RDB, DSS_TGT_SELF, 0,
+	rc = dss_ult_create(rdb_callbackd, db, DSS_XS_SELF, 0, 0,
 			    &db->d_callbackd);
 	if (rc != 0)
 		goto err_timerd;
-	rc = dss_ult_create(rdb_compactd, db, DSS_ULT_RDB, DSS_TGT_SELF, 0,
+	rc = dss_ult_create(rdb_compactd, db, DSS_XS_SELF, 0, 0,
 			    &db->d_compactd);
 	if (rc != 0)
 		goto err_callbackd;

--- a/src/rebuild/scan.c
+++ b/src/rebuild/scan.c
@@ -674,8 +674,8 @@ rebuild_scanner(void *data)
 	}
 
 	rpt_get(rpt);
-	rc = dss_ult_create(rebuild_objects_send_ult, rpt, DSS_ULT_REBUILD,
-			    DSS_TGT_SELF, 0, &ult_send);
+	rc = dss_ult_create(rebuild_objects_send_ult, rpt, DSS_XS_SELF,
+			    0, 0, &ult_send);
 	if (rc != 0) {
 		rpt_put(rpt);
 		D_GOTO(out, rc);
@@ -728,7 +728,7 @@ rebuild_scan_leader(void *data)
 	while (rpt->rt_pool->sp_dtx_resync_version < rpt->rt_rebuild_ver)
 		ABT_thread_yield();
 
-	rc = dss_thread_collective(rebuild_scanner, rpt, 0, DSS_ULT_REBUILD);
+	rc = dss_thread_collective(rebuild_scanner, rpt, 0);
 	if (rc)
 		D_GOTO(out, rc);
 
@@ -736,7 +736,7 @@ rebuild_scan_leader(void *data)
 		DP_UUID(rpt->rt_pool_uuid));
 
 	ABT_mutex_lock(rpt->rt_lock);
-	rc = dss_task_collective(rebuild_scan_done, rpt, 0, DSS_ULT_REBUILD);
+	rc = dss_task_collective(rebuild_scan_done, rpt, 0);
 	ABT_mutex_unlock(rpt->rt_lock);
 	if (rc) {
 		D_ERROR(DF_UUID" send rebuild object list failed:%d\n",
@@ -833,8 +833,8 @@ rebuild_tgt_scan_handler(crt_rpc_t *rpc)
 		D_GOTO(out, rc);
 
 	rpt_get(rpt);
-	rc = dss_ult_create(rebuild_tgt_status_check_ult, rpt, DSS_ULT_REBUILD,
-			    DSS_TGT_SELF, 0, NULL);
+	rc = dss_ult_create(rebuild_tgt_status_check_ult, rpt, DSS_XS_SELF,
+			    0, 0, NULL);
 	if (rc) {
 		rpt_put(rpt);
 		D_GOTO(out, rc);
@@ -842,8 +842,7 @@ rebuild_tgt_scan_handler(crt_rpc_t *rpc)
 
 	rpt_get(rpt);
 	/* step-3: start scan leader */
-	rc = dss_ult_create(rebuild_scan_leader, rpt, DSS_ULT_REBUILD,
-			    DSS_TGT_SELF, 0, NULL);
+	rc = dss_ult_create(rebuild_scan_leader, rpt, DSS_XS_SELF, 0, 0, NULL);
 	if (rc != 0) {
 		rpt_put(rpt);
 		D_GOTO(out, rc);

--- a/src/rsvc/srv.c
+++ b/src/rsvc/srv.c
@@ -410,7 +410,7 @@ init_map_distd(struct ds_rsvc *svc)
 
 	ds_rsvc_get(svc);
 	get_leader(svc);
-	rc = dss_ult_create(map_distd, svc, DSS_ULT_MISC, DSS_TGT_SELF, 0,
+	rc = dss_ult_create(map_distd, svc, DSS_XS_SELF, 0, 0,
 			    &svc->s_map_distd);
 	if (rc != 0) {
 		D_ERROR("%s: failed to start map_distd: "DF_RC"\n", svc->s_name,
@@ -584,8 +584,7 @@ rsvc_stop_cb(struct rdb *db, int err, void *arg)
 	int		rc;
 
 	ds_rsvc_get(svc);
-	rc = dss_ult_create(rsvc_stopper, svc, DSS_ULT_MISC, DSS_TGT_SELF,
-			    0, NULL);
+	rc = dss_ult_create(rsvc_stopper, svc, DSS_XS_SELF, 0, 0, NULL);
 	if (rc != 0) {
 		D_ERROR("%s: failed to create service stopper: "DF_RC"\n",
 			svc->s_name, DP_RC(rc));
@@ -927,7 +926,7 @@ stop_all_cb(d_list_t *entry, void *varg)
 		return -DER_NOMEM;
 
 	d_hash_rec_addref(&rsvc_hash, &svc->s_entry);
-	rc = dss_ult_create(rsvc_stopper, svc, DSS_ULT_POOL_SRV, 0, 0,
+	rc = dss_ult_create(rsvc_stopper, svc, DSS_XS_SYS, 0, 0,
 			    &ult->su_thread);
 	if (rc != 0) {
 		d_hash_rec_decref(&rsvc_hash, &svc->s_entry);


### PR DESCRIPTION
We attempted to prioritize different kinds of ULTs by leveraging
multiple ABT pools in legacy scheduler, that's why the IO, REBUILD,
GC and SCRUB ABT pools were created. The new scheduler prioritizes
ULTs by sched request queues, these ABT pools are actually useless
now.

This patch removed all these ABT pools, and creates single GENERIC
ABT pool for all ULTs (excepting network and NVMe poll ULTs).

This patch also replaced ULT types with XS types to make code more
clear.

A small fix in ds_csum_recalc() to offload the csum calculation
on proper xstream.

Signed-off-by: Niu Yawei <yawei.niu@intel.com>