### PR TITLE
DAOS-6257 test: Add mpifileutils-mpich-daos-0 to rpms

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -188,7 +188,8 @@ el7_component_repos = ""
 def functional_rpms  = "--exclude openmpi openmpi3 hwloc ndctl " +
                        "ior-hpc-cart-4-daos-0 mpich-autoload-cart-4-daos-0 " +
                        "romio-tests-cart-4-daos-0 hdf5-tests-cart-4-daos-0 " +
-                       "mpi4py-tests-cart-4-daos-0 testmpio-cart-4-daos-0 fio"
+                       "mpi4py-tests-cart-4-daos-0 testmpio-cart-4-daos-0 " +
+                       "fio mpifileutils-mpich-daos-0"
 
 // bail out of branch builds that are not on a whitelist
 if (!env.CHANGE_ID &&


### PR DESCRIPTION
Add mpifileutils-mpich-daos-0 to the list of functional rpms.

Signed-off-by: Dalton Bohning <daltonx.bohning@intel.com>