### PR TITLE
CART-89 test: Fix issue with test

### DIFF
--- a/src/tests/ftest/cart/test_group_np_cli.c
+++ b/src/tests/ftest/cart/test_group_np_cli.c
@@ -81,6 +81,11 @@ test_run(void)
 			for (tag = 0; tag < test_g.t_srv_ctx_num; tag++) {
 				DBG_PRINT("Sending rpc to %d:%d\n", rank, tag);
 				check_in(grp, rank, tag);
+			}
+		}
+
+		for (i = ; i < rank_list->rl_nr; i++) {
+			for (tag = 0; tag < test_g.t_srv_ctx_num; tag++) {
 				tc_sem_timedwait(&test_g.t_token_to_proceed, 61,
 						 __LINE__);
 			}

--- a/src/tests/ftest/cart/test_group_np_cli.c
+++ b/src/tests/ftest/cart/test_group_np_cli.c
@@ -75,19 +75,15 @@ test_run(void)
 	test_g.t_fault_attr_5000 = d_fault_attr_lookup(5000);
 
 	if (!test_g.t_shut_only) {
-
 		for (i = 0; i < rank_list->rl_nr; i++) {
 			rank = rank_list->rl_ranks[i];
 
 			for (tag = 0; tag < test_g.t_srv_ctx_num; tag++) {
 				DBG_PRINT("Sending rpc to %d:%d\n", rank, tag);
 				check_in(grp, rank, tag);
+				tc_sem_timedwait(&test_g.t_token_to_proceed, 61,
+						 __LINE__);
 			}
-		}
-
-		for (i = 0; i < rank_list->rl_nr; i++) {
-			tc_sem_timedwait(&test_g.t_token_to_proceed, 61,
-					 __LINE__);
 		}
 	}
 

--- a/src/tests/ftest/cart/test_group_np_cli.c
+++ b/src/tests/ftest/cart/test_group_np_cli.c
@@ -84,7 +84,7 @@ test_run(void)
 			}
 		}
 
-		for (i = ; i < rank_list->rl_nr; i++) {
+		for (i = 0; i < rank_list->rl_nr; i++) {
 			for (tag = 0; tag < test_g.t_srv_ctx_num; tag++) {
 				tc_sem_timedwait(&test_g.t_token_to_proceed, 61,
 						 __LINE__);


### PR DESCRIPTION
- If multiple contexts are specified, test was not waiting for
individual check_in() operations to complete before starting next
one. This resulted in RPC handles being incorrectly re-used.

Signed-off-by: Alexander Oganezov <alexander.a.oganezov@intel.com>