### PR TITLE
DAOS-3885 test: Add more dmg error messages to NLT.

### DIFF
--- a/utils/node_local_test.py
+++ b/utils/node_local_test.py
@@ -400,6 +400,9 @@ class DaosServer():
                         ready = True
                     if 'format request for already-formatted storage and reformat not specified' in line:
                         cmd = ['storage', 'format', '--reformat']
+                for line in rc.stderr.decode('utf-8').splitlines():
+                    if 'system reformat requires the following' in line:
+                        ready = True
             if ready:
                 break
             if time.time() - start > 20:
@@ -420,7 +423,7 @@ class DaosServer():
 
             if ready:
                 break
-            if time.time() - start > 20:
+            if time.time() - start > 40:
                 raise Exception("Failed to start")
         print('Server started in {:.2f} seconds'.format(time.time() - start))
 


### PR DESCRIPTION
Catch another reformat output style that we see occasionally,
in particular when restarting with an existing tmpfs, and if
the timing is correct.

Increase the timeout from 20 to 40 seconds as the startup time
has increased since last measured.

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>