### PR TITLE
DAOS-6264: cart_logparse.py", line 127, in __init__: KeyError: 'DAOS[2502/2502]'

### DIFF
--- a/src/tests/ftest/cart/util/cart_logparse.py
+++ b/src/tests/ftest/cart/util/cart_logparse.py
@@ -126,7 +126,7 @@ class LogLine():
         try:
             self.level = LOG_LEVELS[fields[4]]
         except KeyError:
-            raise InvalidLogFile(fields[4])
+            print('WARNING: Ignoring malformed line in log:', fields)
 
         self.ts = fields[0]
         self._fields = fields[5:]
@@ -188,7 +188,7 @@ class LogLine():
                 return int(lineno)
             except ValueError:
                 pass
-        raise AttributeError
+        print('WARNING: Ignoring unknown attribute:', attr)
 
     def get_msg(self):
         """Return the message part of a line, stripping up to and


### PR DESCRIPTION
CaRT might print a malformed line to the log file, e.g., here CaRT process 1071
appears to exit while printing to the log file:

  ...
  12/09-01:15:24.00 wolf-106vm2 DAOS[1071/1071] server INFO src/iosrv/module.c:335 dss_module_cleanup_all() Module cont: no sm_cleanup func
  12/09-01:15:24.00 wolf-106vm2 DAOS[1071/12/09-01:15:37.72 wolf-106vm2 DAOS[2502/2502] fi   INFO src/gurt/fault_inject.c:489 d_fault_inject_init() No config file, fault injection is OFF.
  ...

See https://build.hpdd.intel.com/job/daos-stack/job/daos/job/master/3296/artifact/Functional/job-2020-12-09T01.14-ce44a76-security-cont_delete_acl/daos_logs/daos_server.wolf-106vm2.cart_logtest.log

Warn user of malformed logline, but report on the lines which are not malformed.

Skip-build-leap15-rpm: true
Skip-build-ubuntu-clang: true
Skip-build-leap15-icc: true
Skip-coverity-test: true
Skip-checkpatch: true
Quick-build: true
Test-tag: dont-run-anything
Skip-func-test-leap15: true
Skip-func-hw-test-small: true
Skip-func-hw-test-medium: true
Skip-func-hw-test-large: true

Signed-off-by: Ethan Mallove <ethanx.a.mallove@intel.com>