### PR TITLE
DAOS-623 vos: Fix a memory leak

### DIFF
--- a/src/vos/tests/vts_aggregate.c
+++ b/src/vos/tests/vts_aggregate.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2019-2020 Intel Corporation.
+ * (C) Copyright 2019-2021 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -1729,6 +1729,9 @@ fill_cont(struct io_test_args *arg, daos_unit_oid_t oid, char *dkey,
 	daos_recx_t	 recx;
 	uint64_t	 idx_max, nr_max;
 
+	if (DAOS_ON_VALGRIND)
+		size_max = (1UL << 14);
+
 	D_ALLOC(buf_u, size_max);
 	assert_non_null(buf_u);
 
@@ -1783,7 +1786,10 @@ aggregate_14(void **state)
 	fill_size = NVME_FREE(vps) ? : SCM_FREE(vps);
 	assert_true(fill_size > 0);
 
-	if (slow_test) {
+	if (DAOS_ON_VALGRIND) {
+		fill_size = min(fill_size, 1ULL << 18);
+		repeat_cnt = 2;
+	} else if (slow_test) {
 		fill_size = min(fill_size, VPOOL_2G);
 		repeat_cnt = 5;
 	} else {

--- a/src/vos/tests/vts_gc.c
+++ b/src/vos/tests/vts_gc.c
@@ -49,14 +49,14 @@ struct gc_test_args {
 static struct gc_test_args	gc_args;
 
 static const int cont_nr	= 4;
-static const int obj_per_cont	= 64;
-static const int dkey_per_obj	= 64;
+#define OBJ_PER_CONT	64
+#define DKEY_PER_OBJ	64
 static const int akey_per_dkey	= 16;
 static const int recx_size	= 4096;
 static const int singv_size	= 16;
 
-static int rt_obj_per_cont = obj_per_cont;
-static int rt_dkey_per_obj = dkey_per_obj;
+static int obj_per_cont = OBJ_PER_CONT;
+static int dkey_per_obj = DKEY_PER_OBJ;
 
 static struct vos_gc_stat	gc_stat;
 
@@ -174,7 +174,7 @@ gc_obj_prepare(struct gc_test_args *args, daos_handle_t coh,
 	d_iov_set(&cred->tc_dkey, cred->tc_dbuf, DTS_KEY_LEN);
 	d_iov_set(&iod->iod_name, cred->tc_abuf, DTS_KEY_LEN);
 
-	for (i = 0; i < rt_obj_per_cont; i++) {
+	for (i = 0; i < obj_per_cont; i++) {
 		daos_unit_oid_t	oid;
 
 		gc_add_stat(STAT_OBJ);
@@ -182,7 +182,7 @@ gc_obj_prepare(struct gc_test_args *args, daos_handle_t coh,
 		if (oids)
 			oids[i] = oid;
 
-		for (j = 0; j < rt_dkey_per_obj; j++) {
+		for (j = 0; j < dkey_per_obj; j++) {
 			gc_add_stat(STAT_DKEY);
 			dts_key_gen(cred->tc_dbuf, DTS_KEY_LEN, NULL);
 
@@ -258,7 +258,7 @@ gc_obj_run(struct gc_test_args *args)
 	int		 i;
 	int		 rc;
 
-	D_ALLOC_ARRAY(oids, rt_obj_per_cont);
+	D_ALLOC_ARRAY(oids, obj_per_cont);
 	if (!oids) {
 		print_error("failed to allocate oids\n");
 		return -DER_NOMEM;
@@ -270,7 +270,7 @@ gc_obj_run(struct gc_test_args *args)
 
 	gc_print_stat();
 
-	for (i = 0; i < rt_obj_per_cont; i++) {
+	for (i = 0; i < obj_per_cont; i++) {
 		rc = vos_obj_delete(args->gc_ctx.tsc_coh, oids[i]);
 		if (rc) {
 			print_error("failed to delete objects: %s\n",
@@ -438,8 +438,8 @@ run_gc_tests(const char *cfg)
 	char	test_name[DTS_CFG_MAX];
 
 	if (DAOS_ON_VALGRIND) {
-		rt_obj_per_cont = 2;
-		rt_dkey_per_obj = 3;
+		obj_per_cont = 2;
+		dkey_per_obj = 3;
 	}
 
 	dts_create_config(test_name, "Garbage collector %s", cfg);

--- a/src/vos/tests/vts_io.c
+++ b/src/vos/tests/vts_io.c
@@ -911,6 +911,7 @@ io_obj_cache_test(void **state)
 	rc = vos_pool_destroy(po_name, pool_uuid);
 	assert_int_equal(rc, 0);
 	vos_obj_cache_destroy(occ);
+	free(po_name);
 }
 
 static void

--- a/src/vos/tests/vts_pm.c
+++ b/src/vos/tests/vts_pm.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2019-2020 Intel Corporation.
+ * (C) Copyright 2019-2021 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -2172,6 +2172,15 @@ many_tx(void **state)
 	int			count, i, j, k, tx_num, cur_tx, old_tx;
 	int			random = 0, op;
 	int			total = 0, success = 0, writes = 0;
+	int			nr_dkey = NR_DKEY;
+	int			nr_akey = NR_AKEY;
+	int			nr_obj = NR_OBJ;
+
+	if (DAOS_ON_VALGRIND) {
+		nr_dkey /= 5;
+		nr_akey /= 5;
+		nr_obj /= 5;
+	}
 
 	test_args_reset(arg, VPOOL_SIZE);
 	coh = arg->ctx.tc_co_hdl;
@@ -2184,14 +2193,14 @@ many_tx(void **state)
 	assert_int_equal(rc, 0);
 
 	/* Set up dkey and akey */
-	for (i = 0; i < NR_OBJ; i++)
+	for (i = 0; i < nr_obj; i++)
 		oid[i] = gen_oid(arg->ofeat);
-	for (i = 0; i < NR_DKEY; i++) {
+	for (i = 0; i < nr_dkey; i++) {
 		vts_key_gen(&dkey_buf[i][0], arg->dkey_size, true, arg);
 		set_iov(&dkey[i], &dkey_buf[i][0],
 			arg->ofeat & DAOS_OF_DKEY_UINT64);
 	}
-	for (i = 0; i < NR_AKEY; i++) {
+	for (i = 0; i < nr_akey; i++) {
 		vts_key_gen(&akey_buf[i][0], arg->akey_size, true, arg);
 		set_iov(&akey[i], &akey_buf[i][0],
 			arg->ofeat & DAOS_OF_AKEY_UINT64);
@@ -2207,9 +2216,9 @@ many_tx(void **state)
 	tx_num = 0;
 start_over:
 	srand(0);
-	for (i = 0; i < NR_OBJ; i++) {
-		for (j = 0; j < NR_DKEY; j++) {
-			for (k = 0; k < NR_AKEY; k++) {
+	for (i = 0; i < nr_obj; i++) {
+		for (j = 0; j < nr_dkey; j++) {
+			for (k = 0; k < nr_akey; k++) {
 				for (count = 0; count < 3; count++) {
 					total++;
 					switch (tx_num & 3) {
@@ -2302,7 +2311,7 @@ start_over:
 		memset(&req[old_tx], 0, sizeof(req[0]));
 	}
 
-	for (i = 0; i < NR_OBJ; i++) {
+	for (i = 0; i < nr_obj; i++) {
 		rc = vos_obj_delete(coh, oid[i]);
 		assert_int_equal(rc, 0);
 	}

--- a/utils/test_memcheck.supp
+++ b/utils/test_memcheck.supp
@@ -11,7 +11,7 @@
    obj:/usr/lib64/libcmocka.so.*
    fun:_cmocka_run_group_tests
    fun:run_ts_tests
-   fun:run_all_tests
+   ...
    fun:main
 }
 {
@@ -114,19 +114,6 @@
 {
    <insert_a_suppression_name_here>
    Memcheck:Leak
-   match-leak-kinds:definite
-   fun:malloc
-   fun:vts_alloc_gen_fname
-   fun:io_obj_cache_test
-   obj:/usr/lib64/libcmocka.so.*
-   fun:_cmocka_run_group_tests
-   fun:run_io_test
-   fun:run_all_tests
-   fun:main
-}
-{
-   <insert_a_suppression_name_here>
-   Memcheck:Leak
    match-leak-kinds:reachable
    fun:malloc
    fun:xmalloc
@@ -198,7 +185,7 @@
    obj:/usr/lib64/libcmocka.so.*
    fun:_cmocka_run_group_tests
    fun:run_ts_tests
-   fun:run_all_tests
+   ...
    fun:main
 }
 {
@@ -239,7 +226,7 @@
    obj:/usr/lib64/libcmocka.so.*
    fun:_cmocka_run_group_tests
    fun:run_gc_tests
-   fun:run_all_tests
+   ...
    fun:main
 }
 {
@@ -263,7 +250,7 @@
    fun:dts_ctx_init
    fun:gc_setup
    ...
-   fun:run_all_tests
+   ...
    ...
 }
 {
@@ -372,7 +359,7 @@
    obj:/usr/lib64/libcmocka.so.*
    fun:_cmocka_run_group_tests
    fun:run_pool_test
-   fun:run_all_tests
+   ...
    fun:main
 }
 {
@@ -386,7 +373,7 @@
    obj:/usr/lib64/libcmocka.so.*
    fun:_cmocka_run_group_tests
    fun:run_aggregate_tests
-   fun:run_all_tests
+   ...
    fun:main
 }
 {
@@ -430,7 +417,7 @@
    obj:/usr/lib64/libcmocka.so.*
    fun:_cmocka_run_group_tests
    fun:run_ts_tests
-   fun:run_all_tests
+   ...
    fun:main
 }
 {


### PR DESCRIPTION
Fixes a memory leak in vos IO test
Adds a few instances of DAOS_ON_VALGRIND to speed up valgrind runs
Fix a suppression for gc when run standalone

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>