### PR TITLE
DAOS-4093 docker: add ability to select compiler

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,12 +16,16 @@ jobs:
       fail-fast: false
       matrix:
         distro: [centos.7, leap.15, ubuntu.20.04]
-        compiler: [gcc, clang]
     steps:
-    - uses: actions/checkout@v2
+    - name: Checkout code
+      uses: actions/checkout@v2
       with:
         submodules: true
-    - name: Build Docker image
+    - name: Build ${{ matrix.distro }} Docker image with gcc
       run: docker build . -f utils/docker/Dockerfile.${{ matrix.distro }}
-                          --build-arg COMPILER=${{ matrix.compiler }}
-                          -t ${{ matrix.distro }}/daos:${{ github.sha }}
+                          --build-arg COMPILER=gcc
+                          -t ${{ matrix.distro }}/gcc/daos:${{ github.sha }}
+    - name: Build ${{ matrix.distro }} Docker image with clang
+      run: docker build . -f utils/docker/Dockerfile.${{ matrix.distro }}
+                          --build-arg COMPILER=clang
+                          -t ${{ matrix.distro }}/clang/daos:${{ github.sha }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,9 +16,12 @@ jobs:
       fail-fast: false
       matrix:
         distro: [centos.7, leap.15, ubuntu.20.04]
+        compiler: [gcc, clang]
     steps:
     - uses: actions/checkout@v2
       with:
         submodules: true
     - name: Build Docker image
-      run: docker build . -f utils/docker/Dockerfile.${{ matrix.distro }} -t ${{ matrix.distro }}/daos:${{ github.sha }}
+      run: docker build . -f utils/docker/Dockerfile.${{ matrix.distro }} \
+                          --build-arg COMPILER=${{ matrix.compiler }} \
+                          -t ${{ matrix.distro }}/daos:${{ github.sha }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,16 +16,13 @@ jobs:
       fail-fast: false
       matrix:
         distro: [centos.7, leap.15, ubuntu.20.04]
+        compiler: [gcc, clang]
     steps:
     - name: Checkout code
       uses: actions/checkout@v2
       with:
         submodules: true
-    - name: Build ${{ matrix.distro }} Docker image with gcc
+    - name: Build ${{ matrix.distro }} Docker image with ${{ matrix.compiler }}
       run: docker build . -f utils/docker/Dockerfile.${{ matrix.distro }}
-                          --build-arg COMPILER=gcc
-                          -t ${{ matrix.distro }}/gcc/daos:${{ github.sha }}
-    - name: Build ${{ matrix.distro }} Docker image with clang
-      run: docker build . -f utils/docker/Dockerfile.${{ matrix.distro }}
-                          --build-arg COMPILER=clang
-                          -t ${{ matrix.distro }}/clang/daos:${{ github.sha }}
+                          --build-arg COMPILER=${{ matrix.compiler }}
+                          -t ${{ matrix.distro }}/${{ matrix.compiler }}/daos:${{ github.sha }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,6 @@ jobs:
       with:
         submodules: true
     - name: Build Docker image
-      run: docker build . -f utils/docker/Dockerfile.${{ matrix.distro }} \
-                          --build-arg COMPILER=${{ matrix.compiler }} \
+      run: docker build . -f utils/docker/Dockerfile.${{ matrix.distro }}
+                          --build-arg COMPILER=${{ matrix.compiler }}
                           -t ${{ matrix.distro }}/daos:${{ github.sha }}

--- a/utils/docker/Dockerfile.centos.7
+++ b/utils/docker/Dockerfile.centos.7
@@ -187,13 +187,16 @@ RUN yum -y upgrade --exclude=spdk,spdk-devel,dpdk-devel,dpdk,mercury-devel,mercu
 # set NOBUILD to disable build
 ARG NOBUILD
 
+# select compiler to use
+ARG COMPILER=gcc
+
 # copy DAOS tree
 WORKDIR /home/daos
 COPY ./ .
 
 # Build DAOS & dependencies
 RUN if [ "x$NOBUILD" = "x" ] ; then \
-    scons --build-deps=yes -j 4 install PREFIX=/opt/daos; fi
+    scons --build-deps=yes -j 4 install PREFIX=/opt/daos COMPILER=$COMPILER; fi
 
 # Set environment variables
 ENV LD_LIBRARY_PATH=/opt/daos/lib:/opt/daos/lib64:$LD_LIBRARY_PATH

--- a/utils/docker/Dockerfile.leap.15
+++ b/utils/docker/Dockerfile.leap.15
@@ -169,13 +169,16 @@ RUN zypper --non-interactive update
 # set NOBUILD to disable build
 ARG NOBUILD
 
+# select compiler to use
+ARG COMPILER=gcc
+
 # copy DAOS tree
 WORKDIR /home/daos
 COPY ./ .
 
 # Build DAOS & dependencies
 RUN if [ "x$NOBUILD" = "x" ] ; then \
-    scons --build-deps=yes -j 4 install PREFIX=/opt/daos; fi
+    scons --build-deps=yes -j 4 install PREFIX=/opt/daos COMPILER=$COMPILER; fi
 
 # Set environment variables
 ENV LD_LIBRARY_PATH=/opt/daos/lib:/opt/daos/lib64:$LD_LIBRARY_PATH

--- a/utils/docker/Dockerfile.ubuntu.20.04
+++ b/utils/docker/Dockerfile.ubuntu.20.04
@@ -75,13 +75,16 @@ RUN echo -e "<settings>\n\
 # set NOBUILD to disable build
 ARG NOBUILD
 
+# select compiler to use
+ARG COMPILER=gcc
+
 # copy DAOS tree
 WORKDIR /home/daos
 COPY ./ .
 
 # Build DAOS & dependencies
 RUN if [ "x$NOBUILD" = "x" ] ; then \
-    scons --build-deps=yes -j 4 install PREFIX=/opt/daos; fi
+    scons --build-deps=yes -j 4 install PREFIX=/opt/daos COMPILER=$COMPILER; fi
 
 # Set environment variables
 ENV LD_LIBRARY_PATH=/opt/daos/lib:/opt/daos/lib64:$LD_LIBRARY_PATH


### PR DESCRIPTION
Add new COMPILER ARG to the docker files to be able to
select compiler.
Modify GH action to build with both gcc and clang.

Skip-test: true

Signed-off-by: Johann Lombardi <johann.lombardi@intel.com>