### PR TITLE
DAOS-6184: daos_core_base.py overrides timeout values w/o logging

### DIFF
--- a/src/tests/ftest/util/apricot/apricot/test.py
+++ b/src/tests/ftest/util/apricot/apricot/test.py
@@ -133,14 +133,17 @@ class Test(avocadoTest):
         #     test_quick: 120
         #     test_long: 1200
         self.timeouts = self.params.get(self.test_id, "/run/timeouts/*")
+        self._timeout = self.params.get("test_timeout", "/run/*", None)
 
         # If not specified, set a default timeout of 1 minute.
         # Tests that require a longer timeout should set a "timeout: <int>"
         # entry in their yaml file.  All tests should have a timeout defined.
-        if (not self.timeout) and (not self.timeouts):
+        if (not self.timeout) and (not self.timeouts) and (not self._timeout):
             self.timeout = 60
         elif self.timeouts:
             self.timeout = self.timeouts
+        elif self._timeout:
+            self.timeout = self._timeout
         self.log.info("self.timeout: %s", self.timeout)
 
         item_list = self.logdir.split('/')

--- a/src/tests/ftest/util/daos_core_base.py
+++ b/src/tests/ftest/util/daos_core_base.py
@@ -49,8 +49,7 @@ class DaosCoreBase(TestWithServers):
 
         test_timeout = self.params.get("test_timeout", self.TEST_PATH)
         if test_timeout:
-            self.log.info("Test timeout updated to {timeout}".format(
-                timeout=test_timeout))
+            self.log.info("Test timeout updated to %s", test_timeout)
             self.timeout = test_timeout
 
     def setUp(self):

--- a/src/tests/ftest/util/daos_core_base.py
+++ b/src/tests/ftest/util/daos_core_base.py
@@ -47,11 +47,6 @@ class DaosCoreBase(TestWithServers):
         super(DaosCoreBase, self).__init__(*args, **kwargs)
         self.subtest_name = None
 
-        test_timeout = self.params.get("test_timeout", self.TEST_PATH)
-        if test_timeout:
-            self.log.info("Test timeout updated to %s", test_timeout)
-            self.timeout = test_timeout
-
     def setUp(self):
         """Set up before each test."""
         self.subtest_name = self.params.get("test_name", self.TEST_PATH)

--- a/src/tests/ftest/util/daos_core_base.py
+++ b/src/tests/ftest/util/daos_core_base.py
@@ -49,6 +49,8 @@ class DaosCoreBase(TestWithServers):
 
         test_timeout = self.params.get("test_timeout", self.TEST_PATH)
         if test_timeout:
+            self.log.info("Test timeout updated to {timeout}".format(
+                timeout=test_timeout))
             self.timeout = test_timeout
 
     def setUp(self):


### PR DESCRIPTION
    Added a logging message to let tester know the timeout
    has been updated based on the test yaml test_timeout value.

Signed-off-by: Omar Ocampo <omar.ocampo.coronado@intel.com>