### PR TITLE
DAOS-6409 control: Add retry case for starting MS

### DIFF
--- a/src/control/lib/control/rpc.go
+++ b/src/control/lib/control/rpc.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2020 Intel Corporation.
+// (C) Copyright 2020-2021 Intel Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -379,6 +379,13 @@ func invokeUnaryRPC(parentCtx context.Context, log debugLogger, c UnaryInvoker, 
 				if err := req.onRetry(tryCtx, try); err != nil {
 					return ur, nil
 				}
+				break
+			}
+
+			// One special case here for system startup. If the
+			// request was sent to a MS replica but the DB wasn't
+			// started yet, it's always valid to retry.
+			if system.IsUnavailable(err) {
 				break
 			}
 

--- a/src/control/system/errors.go
+++ b/src/control/system/errors.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2020 Intel Corporation.
+// (C) Copyright 2020-2021 Intel Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -42,12 +42,18 @@ var (
 // IsUnavailable returns a boolean indicating whether or not the
 // supplied error corresponds to some unavailability state.
 func IsUnavailable(err error) bool {
+	if err == nil {
+		return false
+	}
 	return strings.Contains(errors.Cause(err).Error(), ErrRaftUnavail.Error())
 }
 
 // IsEmptyGroupMap returns a boolean indicating whether or not the
 // supplied error corresponds to an empty system group map.
 func IsEmptyGroupMap(err error) bool {
+	if err == nil {
+		return false
+	}
 	return strings.Contains(errors.Cause(err).Error(), ErrEmptyGroupMap.Error())
 }
 


### PR DESCRIPTION
Missed this case in the client rework. When sending a request
to a MS replica that is starting up, it's valid to retry after
receiving an error indicating that raft is not available (yet).
