### PR TITLE
DAOS-6425: Store UT Valgrind XMLs in current directory

### DIFF
--- a/ci/unit/test_main_node.sh
+++ b/ci/unit/test_main_node.sh
@@ -50,8 +50,4 @@ if ${NLT:-false}; then
 else
     sudo mount -t tmpfs -o size=16G tmpfs /mnt/daos
     IS_CI=true OLD_CI=false RUN_TEST_VALGRIND="$WITH_VALGRIND" utils/run_test.sh
-
-    if [ "$WITH_VALGRIND" == 'memcheck' ]; then
-	mv test_results/unit-test-*.memcheck.xml .
-    fi
 fi

--- a/ci/unit/test_main_node.sh
+++ b/ci/unit/test_main_node.sh
@@ -50,5 +50,4 @@ if ${NLT:-false}; then
 else
     sudo mount -t tmpfs -o size=16G tmpfs /mnt/daos
     IS_CI=true OLD_CI=false RUN_TEST_VALGRIND="$WITH_VALGRIND" utils/run_test.sh
-
 fi

--- a/ci/unit/test_main_node.sh
+++ b/ci/unit/test_main_node.sh
@@ -50,4 +50,5 @@ if ${NLT:-false}; then
 else
     sudo mount -t tmpfs -o size=16G tmpfs /mnt/daos
     IS_CI=true OLD_CI=false RUN_TEST_VALGRIND="$WITH_VALGRIND" utils/run_test.sh
+
 fi

--- a/src/common/tests/btree.sh
+++ b/src/common/tests/btree.sh
@@ -8,7 +8,7 @@ VCMD=()
 if [ "$USE_VALGRIND" = "memcheck" ]; then
     VCMD="valgrind --leak-check=full --show-reachable=yes --error-limit=no \
           --suppressions=${VALGRIND_SUPP} --error-exitcode=42 --xml=yes \
-          --xml-file=test_results/unit-test-btree-%p.memcheck.xml"
+          --xml-file=unit-test-btree-%p.memcheck.xml"
 elif [ "$USE_VALGRIND" = "pmemcheck" ]; then
     VCMD="valgrind --tool=pmemcheck"
 fi

--- a/src/vos/tests/evt_ctl.sh
+++ b/src/vos/tests/evt_ctl.sh
@@ -3,7 +3,7 @@
 if [ "$USE_VALGRIND" = "memcheck" ]; then
     VCMD="valgrind --leak-check=full --show-reachable=yes --error-limit=no \
           --suppressions=${VALGRIND_SUPP} --error-exitcode=42 --xml=yes \
-          --xml-file=test_results/unit-test-evt_ctl-%p.memcheck.xml"
+          --xml-file=unit-test-evt_ctl-%p.memcheck.xml"
 elif [ "$USE_VALGRIND" = "pmemcheck" ]; then
     VCMD="valgrind --tool=pmemcheck "
 fi

--- a/utils/run_test.sh
+++ b/utils/run_test.sh
@@ -85,7 +85,7 @@ if [ -d "/mnt/daos" ]; then
         if [ "$RUN_TEST_VALGRIND" = "memcheck" ]; then
             [ -z "$VALGRIND_SUPP" ] &&
                 VALGRIND_SUPP="$(pwd)/utils/test_memcheck.supp"
-            VALGRIND_XML_PATH="test_results/unit-test-%q{TNAME}.memcheck.xml"
+            VALGRIND_XML_PATH="unit-test-%q{TNAME}.memcheck.xml"
             export VALGRIND_CMD="valgrind --leak-check=full \
                                           --show-reachable=yes \
                                           --error-limit=no \


### PR DESCRIPTION
Store UT Valgrind XMLs in current directory instead of test_results

When there is a failure on the CI UT with memcheck stage, test_main_node.sh
exists because it has set -e. This prevents this script from moving the
Valgrind XMLs to current directory where pipeline-lib scripts can find them
and archive them for later debug of the memory leaks.

In practice, it is not necessary to have those Valgrind XMLs in test_results
and then move them. We can reduce this step and overcome this issue by
directly keeping those files in the current directory.

Signed-off-by: Marcela Rosales <marcela.a.rosales.jimenez@intel.com>