### PR TITLE
DAOS-623 ci: Deal with long tag lists

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 #!/usr/bin/groovy
-/* Copyright (C) 2019-2020 Intel Corporation
+/* Copyright (C) 2019-2021 Intel Corporation
  * All rights reserved.
  *
  * This file is part of the DAOS Project. It is subject to the license terms

--- a/ftest.sh
+++ b/ftest.sh
@@ -46,7 +46,7 @@ fi
 
 TEST_TAG_ARG="${1:-quick}"
 
-TEST_TAG_DIR="/tmp/Functional_${TEST_TAG_ARG// /_}"
+TEST_TAG_DIR="$(mktemp -du)"
 
 NFS_SERVER=${NFS_SERVER:-${HOSTNAME%%.*}}
 
@@ -91,8 +91,6 @@ cleanup() {
     done
 }
 
-pre_clean
-
 # shellcheck disable=SC1091
 if ${TEST_RPMS:-false}; then
     PREFIX=/usr
@@ -104,6 +102,8 @@ else
 fi
 
 SCRIPT_LOC="$PREFIX"/lib/daos/TESTING/ftest/scripts
+
+pre_clean
 
 if ${TEARDOWN_ONLY:-false}; then
     cleanup


### PR DESCRIPTION
Using them as a directory name could result in an ENAMETOOLONG.

Move pre_clean call so that it's path is known when it's called.

Signed-off-by: Brian J. Murrell <brian.murrell@intel.com>