### PR TITLE
DAOS-6177 object: zero copy for dc_tx_convert

### DIFF
--- a/src/object/obj_tx.c
+++ b/src/object/obj_tx.c
@@ -1399,8 +1399,7 @@ dc_tx_reduce_rdgs(d_list_t *dtr_list, uint32_t *grp_cnt, uint32_t *mod_cnt)
 	size_t			 size = 0;
 
 	*grp_cnt = 0;
-	leader = d_list_entry(dtr_list->next, struct dc_tx_rdg, dtr_link);
-	d_list_del(&leader->dtr_link);
+	leader = d_list_pop_entry(dtr_list, struct dc_tx_rdg, dtr_link);
 
 	/* Filter the dtrs that are the same as @leader. */
 	d_list_for_each_entry_safe(dtr, next, dtr_list, dtr_link) {
@@ -1413,8 +1412,7 @@ dc_tx_reduce_rdgs(d_list_t *dtr_list, uint32_t *grp_cnt, uint32_t *mod_cnt)
 	if (d_list_empty(dtr_list))
 		goto out;
 
-	tmp = d_list_entry(dtr_list->next, struct dc_tx_rdg, dtr_link);
-	d_list_del(&tmp->dtr_link);
+	tmp = d_list_pop_entry(dtr_list, struct dc_tx_rdg, dtr_link);
 
 	/* XXX: Try to merge the other non-leaders if possible.
 	 *	Consider efficiency, just one cycle scan. We do
@@ -1517,11 +1515,11 @@ dc_tx_commit_prepare(struct dc_tx *tx, tse_task_t *task)
 	tgt_cnt = pool_map_target_nr(tx->tx_pool->dp_map);
 	D_ASSERT(tgt_cnt != 0);
 
-	start = dc_tx_leftmost_req(tx, false);
 	D_ALLOC_ARRAY(dtrgs, tgt_cnt);
 	if (dtrgs == NULL)
 		D_GOTO(out, rc = -DER_NOMEM);
 
+	start = dc_tx_leftmost_req(tx, false);
 	for (i = 0; i < req_cnt; i++) {
 		dcsr = &tx->tx_req_cache[i + start];
 		obj = dcsr->dcsr_obj;
@@ -2923,7 +2921,7 @@ dc_tx_convert(enum obj_rpc_opc opc, tse_task_t *task)
 		D_GOTO(out, rc = -DER_INVAL);
 	}
 
-	rc = dc_tx_alloc(coh, 0, 0, false, &tx);
+	rc = dc_tx_alloc(coh, 0, DAOS_TF_ZERO_COPY, false, &tx);
 	if (rc != 0) {
 		D_ERROR("Fail to open TX for opc %u: "DF_RC"\n",
 			opc, DP_RC(rc));


### PR DESCRIPTION
It is known that the dc_tx_convert() caller will not reuse
or release related data buffer before related DTX committed.
So it is unnecessary to copy data when convert standalong IO
to DAOS internal transaction.

Signed-off-by: Fan Yong <fan.yong@intel.com>