### PR TITLE
DAOS-6463 enhance stability of Java build in Leap 15

### DIFF
--- a/utils/docker/Dockerfile.leap.15
+++ b/utils/docker/Dockerfile.leap.15
@@ -110,20 +110,6 @@ ENV PASSWD daos
 RUN useradd -u $UID -ms /bin/bash $USER
 RUN echo "$USER:$PASSWD" | chpasswd
 
-# set maven mirror
-RUN mkdir -p /home/$USER/.m2
-
-RUN echo -e "<settings>\n\
-	<mirrors>\n\
-		<mirror>\n\
-			<id>google-maven-central</id>\n\
-			<name>GCS Maven Central mirror</name>\n\
-			<url>https://maven-central.storage-download.googleapis.com/maven2/</url>\n\
-			<mirrorOf>central</mirrorOf>\n\
-		</mirror>\n\
-	</mirrors>\n\
-</settings>" > /home/$USER/.m2/settings.xml
-
 # Create directory for DAOS backend storage
 RUN mkdir -p /opt/daos
 RUN chown -R daos.daos /opt/daos || { cat /etc/passwd; cat /etc/group; cat /etc/shadow; chown -R daos /opt/daos; chgrp -R daos /opt/daos; ls -ld /opt/daos; }
@@ -133,6 +119,18 @@ RUN mkdir /var/run/daos_server
 RUN chown daos.daos /var/run/daos_server || { cat /etc/passwd; cat /etc/group; cat /etc/shadow; chown daos /var/run/daos_server; chgrp daos /var/run/daos_server; ls -ld /var/run/daos_server; }
 RUN mkdir /var/run/daos_agent
 RUN chown daos.daos /var/run/daos_agent || { cat /etc/passwd; cat /etc/group; cat /etc/shadow; chown daos /var/run/daos_agent; chgrp daos /var/run/daos_agent; ls -ld /var/run/daos_agent; }
+
+RUN mkdir -p /root/.m2
+RUN echo -e "<settings>\n\
+        <mirrors>\n\
+                <mirror>\n\
+                        <id>google-maven-central</id>\n\
+                        <name>GCS Maven Central mirror</name>\n\
+                        <url>https://maven-central.storage-download.googleapis.com/maven2/</url>\n\
+                        <mirrorOf>central</mirrorOf>\n\
+                </mirror>\n\
+        </mirrors>\n\
+</settings>" > /root/.m2/settings.xml
 
 ARG JENKINS_URL=""
 ARG QUICKBUILD=false


### PR DESCRIPTION
Same as DAOS-6053.  which downloads dependencies from google repo instead of maven central repo for centos and ubuntu, we need to do the same switch for Leap 15 too.

Signed-off-by: jiafu zhang <jiafu.zhang@intel.com>