### PR TITLE
DAOS 5066 daos: add copy cont option to utilities

### DIFF
--- a/doc/man/man8/daos.8
+++ b/doc/man/man8/daos.8
@@ -82,6 +82,8 @@ The \fBRESOURCE\fRs, respective \fBCOMMAND\fRs and \fBOPTION\fRs supported by \f
 .I container \fR(\fIcont\fR) \fBCOMMAND\fRs:
 	  \fBcreate\fR           create a container
 .br
+	  \fBcopy\fR             copy a container
+.br
 	  \fBdestroy\fR          destroy a container
 .br
 	  \fBlist-objects\fR     list all objects in container
@@ -118,6 +120,11 @@ The \fBRESOURCE\fRs, respective \fBCOMMAND\fRs and \fBOPTION\fRs supported by \f
 	  <\fIpool\fR options>   (\fB--pool\fR, \fB--sys-name\fR, \fB--svc\fR)
 .br
 	  \fB--cont=\fRUUID      (optional) container UUID (or generated)
+.TP
+.I container \fBOPTION\fRs (copy a container):
+	  \fB--src=\fRSTR      <pool uuid>/<cont uuid> | <UNS path>
+.br
+	  \fB--dst=\fRSTR      <pool uuid>/<cont uuid> | <UNS path>
 .TP
 .I container \fBOPTION\fRs (create and link to namespace path):
 	  <\fIpool\fR/\fIcont\fR opts>   (\fB--pool\fR, \fB--sys-name\fR, \fB--svc\fR, \fB--cont\fR [optional])

--- a/src/utils/daos.c
+++ b/src/utils/daos.c
@@ -45,9 +45,10 @@
 #include <daos/rpc.h>
 #include <daos/debug.h>
 #include <daos/object.h>
-
+#include <sys/stat.h>
 #include "daos_types.h"
 #include "daos_api.h"
+#include "daos_fs.h"
 #include "daos_uns.h"
 #include "daos_fs.h"
 #include "daos_hdlr.h"
@@ -70,6 +71,8 @@ cont_op_parse(const char *str)
 		return CONT_CREATE;
 	else if (strcmp(str, "destroy") == 0)
 		return CONT_DESTROY;
+	else if (strcmp(str, "copy") == 0)
+		return CONT_COPY;
 	else if (strcmp(str, "list-objects") == 0)
 		return CONT_LIST_OBJS;
 	else if (strcmp(str, "list-obj") == 0)
@@ -644,17 +647,17 @@ common_op_parse_hdlr(int argc, char *argv[], struct cmd_args_s *ap)
 				fprintf(stderr,
 					"failed to parse pool UUID: %s\n",
 					optarg);
-				D_GOTO(out_free, rc = RC_NO_HELP);
-			}
-			break;
+			D_GOTO(out_free, rc = RC_NO_HELP);
+		}
+		break;
 		case 'c':
 			if (uuid_parse(optarg, ap->c_uuid) != 0) {
 				fprintf(stderr,
 					"failed to parse cont UUID: %s\n",
 					optarg);
-				D_GOTO(out_free, rc = RC_NO_HELP);
-			}
-			break;
+			D_GOTO(out_free, rc = RC_NO_HELP);
+		}
+		break;
 		case 'm':
 			D_STRNDUP(ap->mdsrv_str, optarg, strlen(optarg));
 			if (ap->mdsrv_str == NULL)
@@ -843,9 +846,6 @@ common_op_parse_hdlr(int argc, char *argv[], struct cmd_args_s *ap)
 		D_GOTO(out_free, rc = RC_NO_HELP);
 	}
 
-	/* Verify pool svc argument. If not provided pass NULL list to libdaos,
-	 * and client will query management service for rank list.
-	 */
 	ARGS_VERIFY_MDSRV(ap, out_free, rc = RC_PRINT_HELP);
 
 	D_FREE(cmdname);
@@ -996,88 +996,105 @@ static int
 cont_op_hdlr(struct cmd_args_s *ap)
 {
 	daos_cont_info_t	cont_info;
-	int			rc;
-	int			rc2;
+	int			rc = 0;
+	int			rc2 = 0;
 	enum cont_op		op;
 	const int		RC_PRINT_HELP = 2;
 
 	assert(ap != NULL);
 	op = ap->c_op;
 
-	/* All container operations require a pool handle, connect here.
-	 * Take specified pool UUID or look up through unified namespace.
+	/* cont_copy uses its own src and dst variables, and does
+	 * not use the regular pool and cont ones stored in the
+	 * ap struct. This is because for a copy it is necessary
+	 * to explicitly specify whether a container is a src or
+	 * dst
 	 */
-	if ((op != CONT_CREATE) && (ap->path != NULL)) {
-		struct duns_attr_t dattr = {0};
-		struct dfuse_il_reply il_reply = {0};
-
-		ARGS_VERIFY_PATH_NON_CREATE(ap, out, rc = RC_PRINT_HELP);
-
-		/* Resolve pool, container UUIDs from path if needed
-		 *
-		 * Firtly check for a unified namespace entry point, then if
-		 * that isn't detected then check for dfuse backing the
-		 * path, and print pool/container/oid for the path.
+	if (op != CONT_COPY) {
+		/* All container operations require a pool handle, connect
+		 * here. Take specified pool UUID or look up through unified
+		 * namespace.
 		 */
-		rc = duns_resolve_path(ap->path, &dattr);
-		if (rc) {
+		if ((op != CONT_CREATE) && (ap->path != NULL)) {
+			struct duns_attr_t dattr = {0};
+			struct dfuse_il_reply il_reply = {0};
 
-			rc = call_dfuse_ioctl(ap->path, &il_reply);
-			if (rc != 0) {
-				fprintf(stderr, "could not resolve pool, "
-					"container by path: %d %s %s\n",
-					rc, strerror(rc), ap->path);
+			ARGS_VERIFY_PATH_NON_CREATE(ap, out,
+						    rc = RC_PRINT_HELP);
 
-				D_GOTO(out, rc);
+			/* Resolve pool, container UUIDs from path if needed
+			 * Firtly check for a unified namespace entry point,
+			 * then if that isn't detected then check for dfuse
+			 * backing the path, and print pool/container/oid
+			 * for the path.
+			 */
+			rc = duns_resolve_path(ap->path, &dattr);
+			if (rc) {
+				rc = call_dfuse_ioctl(ap->path, &il_reply);
+				if (rc != 0) {
+					fprintf(stderr, "could not resolve "
+						"pool, container by "
+						"path: %d %s %s\n",
+						rc, strerror(rc), ap->path);
+					D_GOTO(out, rc);
+				}
+
+				ap->type = DAOS_PROP_CO_LAYOUT_POSIX;
+				uuid_copy(ap->p_uuid, il_reply.fir_pool);
+				uuid_copy(ap->c_uuid, il_reply.fir_cont);
+				ap->oid = il_reply.fir_oid;
+			} else {
+				ap->type = dattr.da_type;
+				uuid_copy(ap->p_uuid, dattr.da_puuid);
+				uuid_copy(ap->c_uuid, dattr.da_cuuid);
 			}
-
-			ap->type = DAOS_PROP_CO_LAYOUT_POSIX;
-			uuid_copy(ap->p_uuid, il_reply.fir_pool);
-			uuid_copy(ap->c_uuid, il_reply.fir_cont);
-			ap->oid = il_reply.fir_oid;
 		} else {
-			ap->type = dattr.da_type;
-			uuid_copy(ap->p_uuid, dattr.da_puuid);
-			uuid_copy(ap->c_uuid, dattr.da_cuuid);
+			ARGS_VERIFY_PUUID(ap, out, rc = RC_PRINT_HELP);
 		}
-	} else {
-		ARGS_VERIFY_PUUID(ap, out, rc = RC_PRINT_HELP);
-	}
 
-	rc = daos_pool_connect(ap->p_uuid, ap->sysname, ap->mdsrv,
-			       DAOS_PC_RW, &ap->pool,
-			       NULL /* info */, NULL /* ev */);
-	if (rc != 0) {
-		fprintf(stderr, "failed to connect to pool "DF_UUIDF
-			": %s (%d)\n", DP_UUID(ap->p_uuid), d_errdesc(rc), rc);
-		D_GOTO(out, rc);
-	}
-
-	/* container UUID: user-provided, generated here or by uns library */
-
-	/* for container lookup ops: if no path specified, require --cont */
-	if ((op != CONT_CREATE) && (ap->path == NULL))
-		ARGS_VERIFY_CUUID(ap, out, rc = RC_PRINT_HELP);
-
-	/* container create scenarios (generate UUID if necessary):
-	 * 1) both --cont, --path : uns library will use specified c_uuid.
-	 * 2) --cont only         : use specified c_uuid.
-	 * 3) --path only         : uns library will create & return c_uuid
-	 *                          (currently c_uuid null / clear).
-	 * 4) neither specified   : create a UUID in c_uuid.
-	 */
-	if ((op == CONT_CREATE) && (ap->path == NULL) &&
-	    (uuid_is_null(ap->c_uuid)))
-		uuid_generate(ap->c_uuid);
-
-	if (op != CONT_CREATE && op != CONT_DESTROY) {
-		rc = daos_cont_open(ap->pool, ap->c_uuid, DAOS_COO_RW,
-				    &ap->cont, &cont_info, NULL);
+		rc = daos_pool_connect(ap->p_uuid, ap->sysname, ap->mdsrv,
+				       DAOS_PC_RW, &ap->pool,
+				       NULL /* info */, NULL /* ev */);
 		if (rc != 0) {
-			fprintf(stderr, "failed to open container "DF_UUIDF
-				": %s (%d)\n", DP_UUID(ap->c_uuid),
-				d_errdesc(rc), rc);
-			D_GOTO(out_disconnect, rc);
+			fprintf(stderr, "failed to connect to "
+				"pool "DF_UUIDF ": %s (%d)\n",
+				DP_UUID(ap->p_uuid), d_errdesc(rc), rc);
+			D_GOTO(out, rc);
+		}
+
+		/* container UUID: user-provided, generated here or by uns
+		 * library
+		 */
+
+		/* for container lookup ops: if no path specified,
+		 * require --cont
+		 */
+		if ((op != CONT_CREATE) && (ap->path == NULL))
+			ARGS_VERIFY_CUUID(ap, out, rc = RC_PRINT_HELP);
+
+		/* container create scenarios (generate UUID if necessary):
+		 * 1) both --cont, --path : uns library will use specified
+		 *			    c_uuid.
+		 * 2) --cont only	  : use specified c_uuid.
+		 * 3) --path only	  : uns library will create & return
+		 *			    c_uuid
+		 *			    (currently c_uuid null / clear).
+		 * 4) neither specified   : create a UUID in c_uuid.
+		 */
+		if ((op == CONT_CREATE) && (ap->path == NULL) &&
+		    (uuid_is_null(ap->c_uuid)))
+			uuid_generate(ap->c_uuid);
+
+		if (op != CONT_CREATE && op != CONT_DESTROY) {
+			rc = daos_cont_open(ap->pool, ap->c_uuid, DAOS_COO_RW,
+					    &ap->cont, &cont_info, NULL);
+			if (rc != 0) {
+				fprintf(stderr, "failed to open "
+					"container "DF_UUIDF
+					": %s (%d)\n", DP_UUID(ap->c_uuid),
+					d_errdesc(rc), rc);
+				D_GOTO(out_disconnect, rc);
+			}
 		}
 	}
 
@@ -1091,6 +1108,12 @@ cont_op_hdlr(struct cmd_args_s *ap)
 	case CONT_DESTROY:
 		rc = cont_destroy_hdlr(ap);
 		break;
+	case CONT_COPY:
+		rc = cont_copy_hdlr(ap);
+		break;
+
+
+	/* TODO: implement the following ops */
 	case CONT_LIST_OBJS:
 		rc = cont_list_objs_hdlr(ap);
 		break;
@@ -1149,6 +1172,9 @@ cont_op_hdlr(struct cmd_args_s *ap)
 		break;
 	}
 
+	if (op == CONT_COPY)
+		D_GOTO(out, rc);
+
 	/* Container close in normal and error flows: preserve rc */
 	if (op != CONT_CREATE && op != CONT_DESTROY) {
 		rc2 = daos_cont_close(ap->cont, NULL);
@@ -1159,7 +1185,6 @@ cont_op_hdlr(struct cmd_args_s *ap)
 		if (rc == 0)
 			rc = rc2;
 	}
-
 out_disconnect:
 	/* Pool disconnect in normal and error flows: preserve rc */
 	rc2 = daos_pool_disconnect(ap->pool, NULL);
@@ -1316,6 +1341,7 @@ do { \
 	fprintf(stream, "\n" \
 	"container (cont) commands:\n" \
 	"	  create           create a container\n" \
+	"	  copy             copy a container\n" \
 	"	  destroy          destroy a container\n" \
 	"	  list-objects     list all objects in container\n" \
 	"	  list-obj\n" \
@@ -1393,7 +1419,6 @@ help_hdlr(int argc, char *argv[], struct cmd_args_s *ap)
 		"	--attr=NAME        pool attribute name to get, set, del\n"
 		"	--value=VALUESTR   pool attribute name to set\n",
 			default_sysname);
-
 	} else if (strcmp(argv[2], "container") == 0 ||
 		   strcmp(argv[2], "cont") == 0) {
 		if (argc == 3) {
@@ -1403,6 +1428,9 @@ help_hdlr(int argc, char *argv[], struct cmd_args_s *ap)
 			"container options (create by UUID):\n"
 			"	  <pool options>   (--pool, --sys-name, --svc)\n"
 			"	--cont=UUID        (optional) container UUID (or generated)\n"
+			"container options (copy a container):\n"
+			"	--src=STR       <pool uuid>/<cont uuid> | <UNS path>"
+			"	--dst=STR       <pool uuid>/<cont uuid> | <UNS path>"
 			"container options (create and link to namespace path):\n"
 			"	  <pool/cont opts> (--pool, --sys-name, --svc, --cont [optional])\n"
 			"	--path=PATHSTR     container namespace path\n"
@@ -1443,6 +1471,11 @@ help_hdlr(int argc, char *argv[], struct cmd_args_s *ap)
 			"container options (destroy):\n"
 			"	--force            destroy container regardless of state\n");
 			ALL_BUT_CONT_CREATE_OPTS_HELP();
+		} else if (strcmp(argv[3], "copy") == 0) {
+			fprintf(stream,
+				"	container options (copy):\n"
+			"	--src=<pool/cont | path>\n"
+			"	--=<pool/cont | path>\n");
 		} else if (strcmp(argv[3], "get-attr") == 0 ||
 			   strcmp(argv[3], "set-attr") == 0 ||
 			   strcmp(argv[3], "del-attr") == 0) {
@@ -1553,8 +1586,9 @@ main(int argc, char *argv[])
 	} else if (strcmp(argv[1], "pool") == 0) {
 		hdlr = pool_op_hdlr;
 	} else if ((strcmp(argv[1], "object") == 0) ||
-		 (strcmp(argv[1], "obj") == 0))
+		 (strcmp(argv[1], "obj") == 0)) {
 		hdlr = obj_op_hdlr;
+	}
 
 	if (hdlr == NULL) {
 		dargs.ostream = stderr;

--- a/src/utils/daos_hdlr.h
+++ b/src/utils/daos_hdlr.h
@@ -28,6 +28,7 @@ enum fs_op {
 enum cont_op {
 	CONT_CREATE,
 	CONT_DESTROY,
+	CONT_COPY,
 	CONT_LIST_OBJS,
 	CONT_QUERY,
 	CONT_STAT,
@@ -77,9 +78,15 @@ struct cmd_args_s {
 	enum fs_op		fs_op;		/* filesystem sub-command */
 	char			*sysname;	/* --sys-name or --sys */
 	uuid_t			p_uuid;		/* --pool */
+	uuid_t			src_p_uuid;	/* --src_pool */
+	uuid_t			dst_p_uuid;	/* --dst_pool */
+	uuid_t			src_c_uuid;	/* --src_cont */
+	uuid_t			dst_c_uuid;	/* --dst_cont */
 	daos_handle_t		pool;
+	daos_handle_t		dst_pool;
 	uuid_t			c_uuid;		/* --cont */
 	daos_handle_t		cont;
+	daos_handle_t		dst_cont;
 	char			*mdsrv_str;	/* --svc */
 	d_rank_list_t		*mdsrv;
 	int			force;		/* --force */
@@ -205,6 +212,7 @@ int cont_create_hdlr(struct cmd_args_s *ap);
 int cont_create_uns_hdlr(struct cmd_args_s *ap);
 int cont_query_hdlr(struct cmd_args_s *ap);
 int cont_destroy_hdlr(struct cmd_args_s *ap);
+int cont_copy_hdlr(struct cmd_args_s *ap);
 int cont_get_prop_hdlr(struct cmd_args_s *ap);
 int cont_set_prop_hdlr(struct cmd_args_s *ap);
 int cont_list_attrs_hdlr(struct cmd_args_s *ap);


### PR DESCRIPTION
Add generic container copy utility

Skip-func-test: true

DAOS copy utility that will copy all types of containers.
This utility supports passing in a pool and container as
well as using a Unified Namespace Path. Currently, the
utility assumes that the pool and container already exist
for both the source and destination.  This
utility only supports DAOS -> DAOS copies, and does
not support moving data to and from POSIX.

example: daos cont copy --src=$pool1/$p1cont1 --dst=$pool1/$p1cont2

example with UNS: daos cont copy --src=/tmp/$USER/conts/uns0
		                 --dst=/tmp/$USER/conts/uns1

Signed-off-by: Danielle Sikich <danielle.sikich@intel.com>