### PR TITLE
DAOS-6452 test: Disable Dmg pool query basic test

### DIFF
--- a/src/tests/ftest/control/dmg_pool_query_test.py
+++ b/src/tests/ftest/control/dmg_pool_query_test.py
@@ -23,6 +23,7 @@
 """
 from __future__ import print_function
 
+from apricot import skipForTicket
 from ior_test_base import IorTestBase
 from test_utils_pool import TestPool
 from control_test_base import ControlTestBase

--- a/src/tests/ftest/control/dmg_pool_query_test.py
+++ b/src/tests/ftest/control/dmg_pool_query_test.py
@@ -58,6 +58,7 @@ class DmgPoolQueryTest(ControlTestBase, IorTestBase):
         self.log.info("==>   Running dmg pool query:")
         return self.dmg.pool_query(uuid)
 
+    @skipForTicket("DAOS-6452")
     def test_pool_query_basic(self):
         """
         JIRA ID: DAOS-2976


### PR DESCRIPTION
Disabling cmd pool query basic test for DAOS-6452