### PR TITLE
DAOS-5906 utils: buffer overrun of daos_perf

### DIFF
--- a/src/tests/daos_perf.c
+++ b/src/tests/daos_perf.c
@@ -219,6 +219,9 @@ stride_buf_op(int opc, char *buf, unsigned offset, int size)
 			pos = i + stride_marks[j];
 			if (pos < offset)
 				continue;
+			/* possible for the last page */
+			if (pos >= stride_buf.sb_size)
+				break;
 
 			if (pos >= offset + size) {
 				/* NB: for single value, unset marks because


### PR DESCRIPTION
If write size is not page aligned, daos_perf can overrun the
write buffer while initiazing. This patch can fix the overrun.

Signed-off-by: Liang Zhen <liang.zhen@intel.com>