### PR TITLE
DAOS-623 ci: Find executable name without arguments

### DIFF
--- a/src/tests/ftest/launch.py
+++ b/src/tests/ftest/launch.py
@@ -1482,7 +1482,13 @@ def process_the_cores(avocado_logs_dir, test_yaml, args):
                                       "quit"])
 
             last_line = gdb_output.splitlines()[-1]
-            exe_name = last_line[7:last_line[7:].find(" ") + 7]
+            cmd = last_line[7:-1]
+            # assume there are no arguments on cmd
+            find_char = "'"
+            if cmd.find(" ") > -1:
+                # there are arguments on cmd
+                find_char = " "
+            exe_name = cmd[0:cmd.find(find_char)]
         except RuntimeError:
             exe_name = None
 


### PR DESCRIPTION
The code to use gdb to find the executable that created a core file was
always expecting the executable to have arguments and failing to find
the executable name when it didn't have any.

Skip-PR-comments: true

Signed-off-by: Brian J. Murrell <brian.murrell@intel.com>