### PR TITLE
DAOS-6251 gurt: fix compilation of MPICH romio plugin

### DIFF
--- a/src/gurt/fault_inject.c
+++ b/src/gurt/fault_inject.c
@@ -34,6 +34,7 @@
 #include <gurt/common.h>
 #include <gurt/hash.h>
 #include "fi.h"
+#include <yaml.h>
 
 /**
  * global switch for fault injection. zero globally turns off fault injection,

--- a/src/gurt/misc.c
+++ b/src/gurt/misc.c
@@ -29,6 +29,24 @@
 #include <stdarg.h>
 #include <gurt/common.h>
 
+void
+d_free(void *ptr)
+{
+	free(ptr);
+}
+
+void *
+d_calloc(size_t count, size_t eltsize)
+{
+	return calloc(count, eltsize);
+}
+
+void *
+d_realloc(void *ptr, size_t size)
+{
+	return realloc(ptr, size);
+}
+
 int
 d_rank_list_dup(d_rank_list_t **dst, const d_rank_list_t *src)
 {

--- a/src/include/gurt/common.h
+++ b/src/include/gurt/common.h
@@ -90,12 +90,12 @@ void *d_realloc(void *, size_t);
 			if ((count) <= 1)				\
 				D_DEBUG(DB_MEM,				\
 					"alloc(" #func ") '" name	\
-					"': %i at %p\n",		\
+					"': %i at %p.\n",		\
 					(int)(size), (ptr));		\
 			else						\
 				D_DEBUG(DB_MEM,				\
 					"alloc(" #func ") '" name	\
-					"': %i * '" cname "': %i at %p\n", \
+					"': %i * '" cname "':%i at %p.\n", \
 					(int)(size), (int)(count), (ptr)); \
 			break;						\
 		}							\
@@ -174,14 +174,14 @@ void *d_realloc(void *, size_t);
 				D_DEBUG(DB_MEM,				\
 					"realloc '" #newptr		\
 					"': %zu at %p (old '" #oldptr	\
-					"': %p).\n",			\
+					"':%p).\n",			\
 					_esz, (newptr), (oldptr));	\
 			else						\
 				D_DEBUG(DB_MEM,				\
 					"realloc '" #newptr		\
 					"': %zu * '" #cnt		\
-					"': %zu at %p (old '" #oldptr	\
-					"': %p).\n",			\
+					"':%zu at %p (old '" #oldptr	\
+					"':%p).\n",			\
 					_esz, _cnt, (newptr), (oldptr));\
 			(oldptr) = NULL;				\
 			break;						\

--- a/src/include/gurt/common.h
+++ b/src/include/gurt/common.h
@@ -58,12 +58,15 @@
 extern "C" {
 #endif
 
-#define likely(x)       __builtin_expect((x), 1)
-#define unlikely(x)     __builtin_expect((x), 0)
+#ifndef likely
+#define likely(x)	__builtin_expect((x), 1)
+#endif
+#ifndef unlikely
+#define unlikely(x)	__builtin_expect((x), 0)
+#endif
 
 /* Check if bit is set in passed val */
 #define D_BIT_IS_SET(val, bit) (((val) & bit) ? 1 : 0)
-
 
 /**
  * Get the current time using a monotonic timer
@@ -72,27 +75,32 @@ extern "C" {
 #define _gurt_gettime(ts) clock_gettime(CLOCK_MONOTONIC, ts)
 
 /* memory allocating macros */
+void  d_free(void *);
+void *d_calloc(size_t, size_t);
+void *d_realloc(void *, size_t);
 
 #define D_CHECK_ALLOC(func, cond, ptr, name, size, count, cname,	\
 			on_error)					\
 	do {								\
 		if (D_SHOULD_FAIL(d_fault_attr_mem)) {			\
-			free(ptr);					\
-			ptr = NULL;					\
+			d_free(ptr);					\
+			(ptr) = NULL;					\
 		}							\
 		if ((cond) && (ptr) != NULL) {				\
-			if (count <= 1)					\
+			if ((count) <= 1)				\
 				D_DEBUG(DB_MEM,				\
-					"alloc(" #func ") '" name "': %i at %p.\n", \
+					"alloc(" #func ") '" name	\
+					"': %i at %p\n",		\
 					(int)(size), (ptr));		\
 			else						\
 				D_DEBUG(DB_MEM,				\
-					"alloc(" #func ") '" name "': %i * '" cname "':%i at %p.\n", \
+					"alloc(" #func ") '" name	\
+					"': %i * '" cname "': %i at %p\n", \
 					(int)(size), (int)(count), (ptr)); \
 			break;						\
 		}							\
 		(void)(on_error);					\
-		if (count >= 1)						\
+		if ((count) >= 1)					\
 			D_ERROR("out of memory (tried to "		\
 				#func " '" name "': %i)\n",		\
 				(int)((size) * (count)));		\
@@ -102,10 +110,9 @@ extern "C" {
 				(int)(size));				\
 	} while (0)
 
-
 #define D_ALLOC_CORE(ptr, size, count)					\
 	do {								\
-		(ptr) = (__typeof__(ptr))calloc(count, (size));		\
+		(ptr) = (__typeof__(ptr))d_calloc((count), (size));	\
 		D_CHECK_ALLOC(calloc, true, ptr, #ptr, size,		\
 			      count, #count, 0);			\
 	} while (0)
@@ -159,43 +166,46 @@ extern "C" {
 		if (_sz == 0)						\
 			_sz = 1;					\
 		if (D_SHOULD_FAIL(d_fault_attr_mem))			\
-			newptr = NULL;					\
+			(newptr) = NULL;				\
 		else							\
-			(newptr) = realloc(optr, _sz);			\
+			(newptr) = d_realloc(optr, _sz);		\
 		if ((newptr) != NULL) {					\
-			if ((_cnt) <= 1)				\
+			if (_cnt <= 1)					\
 				D_DEBUG(DB_MEM,				\
-					"realloc '" #newptr "': %zu at %p (old '" #oldptr "':%p).\n", \
+					"realloc '" #newptr		\
+					"': %zu at %p (old '" #oldptr	\
+					"': %p).\n",			\
 					_esz, (newptr), (oldptr));	\
 			else						\
 				D_DEBUG(DB_MEM,				\
-					"realloc '" #newptr "': %zu * '" #cnt "':%zu at %p (old '" #oldptr "':%p).\n", \
-					_esz, (_cnt), (newptr), (oldptr));	\
+					"realloc '" #newptr		\
+					"': %zu * '" #cnt		\
+					"': %zu at %p (old '" #oldptr	\
+					"': %p).\n",			\
+					_esz, _cnt, (newptr), (oldptr));\
 			(oldptr) = NULL;				\
 			break;						\
 		}							\
-		if ((_cnt) <= 1)					\
+		if (_cnt <= 1)						\
 			D_ERROR("out of memory (tried to realloc "	\
 				"'" #newptr "': size=%zu)\n",		\
 				_esz);					\
 		else							\
 			D_ERROR("out of memory (tried to realloc "	\
 				"'" #newptr "': size=%zu count=%zu)\n",	\
-				_esz, (_cnt));				\
+				_esz, _cnt);				\
 	} while (0)
 
-
-#define D_REALLOC(newptr, oldptr, size)	\
+#define D_REALLOC(newptr, oldptr, size)					\
 	D_REALLOC_COMMON(newptr, oldptr, size, 1)
 
-#define D_REALLOC_ARRAY(newptr, oldptr, count) \
+#define D_REALLOC_ARRAY(newptr, oldptr, count)				\
 	D_REALLOC_COMMON(newptr, oldptr, sizeof(*(oldptr)), count)
-
 
 #define D_FREE(ptr)							\
 	do {								\
 		D_DEBUG(DB_MEM, "free '" #ptr "' at %p.\n", (ptr));	\
-		free(ptr);						\
+		d_free(ptr);						\
 		(ptr) = NULL;						\
 	} while (0)
 
@@ -206,7 +216,7 @@ extern "C" {
 
 #define D_GOTO(label, rc)			\
 	do {					\
-		__typeof__(rc) __rc = (rc);		\
+		__typeof__(rc) __rc = (rc);	\
 		(void)(__rc);			\
 		goto label;			\
 	} while (0)
@@ -244,7 +254,6 @@ extern "C" {
 		d_errno2der(_rc);					\
 	})
 
-
 #define D_SPIN_LOCK(x)		__D_PTHREAD(pthread_spin_lock, x)
 #define D_SPIN_UNLOCK(x)	__D_PTHREAD(pthread_spin_unlock, x)
 #define D_MUTEX_LOCK(x)		__D_PTHREAD(pthread_mutex_lock, x)
@@ -258,7 +267,6 @@ extern "C" {
 #define D_MUTEX_INIT(x, y)	__D_PTHREAD_INIT(pthread_mutex_init, x, y)
 #define D_SPIN_INIT(x, y)	__D_PTHREAD_INIT(pthread_spin_init, x, y)
 #define D_RWLOCK_INIT(x, y)	__D_PTHREAD_INIT(pthread_rwlock_init, x, y)
-
 
 #define DGOLDEN_RATIO_PRIME_64	0xcbf29ce484222325ULL
 #define DGOLDEN_RATIO_PRIME_32	0x9e370001UL
@@ -358,9 +366,8 @@ d_sgl_fini(d_sg_list_t *sgl, bool free_iovs)
 
 void d_getenv_bool(const char *env, bool *bool_val);
 void d_getenv_int(const char *env, unsigned int *int_val);
-int d_write_string_buffer(struct d_string_buffer_t *buf, const char *fmt, ...);
+int  d_write_string_buffer(struct d_string_buffer_t *buf, const char *fmt, ...);
 void d_free_string(struct d_string_buffer_t *buf);
-
 
 #if !defined(container_of)
 /* given a pointer @ptr to the field @member embedded into type (usually
@@ -500,7 +507,6 @@ d_timediff(struct timespec start, struct timespec end)
 		temp.tv_nsec = end.tv_nsec - start.tv_nsec;
 	}
 
-
 	return temp;
 }
 
@@ -602,7 +608,6 @@ is_on_stack(void *ptr)
 	return false;
 }
 
-
 static inline void
 d_iov_set_safe(d_iov_t *iov, void *buf, size_t size)
 {
@@ -611,7 +616,6 @@ d_iov_set_safe(d_iov_t *iov, void *buf, size_t size)
 	iov->iov_buf = buf;
 	iov->iov_len = iov->iov_buf_len = size;
 }
-
 
 #if defined(__cplusplus)
 }

--- a/src/include/gurt/fault_inject.h
+++ b/src/include/gurt/fault_inject.h
@@ -32,7 +32,6 @@
 #define __FAULT_INJECT__
 
 #include <stdbool.h>
-#include <yaml.h>
 #include <stdint.h>
 #include <gurt/debug.h>
 

--- a/src/include/gurt/list.h
+++ b/src/include/gurt/list.h
@@ -38,7 +38,11 @@
 /** @addtogroup GURT
  * @{
  */
+#ifdef __GNUC__
+#define prefetch(a) __builtin_prefetch((a), 0, 1)
+#else
 #define prefetch(a) ((void)a)
+#endif
 
 struct d_list_head {
 	struct d_list_head *next, *prev;


### PR DESCRIPTION
MPICH has its own memory trace capability.
So, fixed the DAOS romio plugin compilation.