### PR TITLE
DAOS-623 build: Force recompilation of MPI when mpicc changes

### DIFF
--- a/utils/daos_build.py
+++ b/utils/daos_build.py
@@ -106,6 +106,7 @@ def _find_mpicc(env):
     if mpicc:
         env.Replace(CC="mpicc")
         env.Replace(LINK="mpicc")
+        env.AppendUnique(CPPDEFINES=["-DDAOS_MPI_PATH=\"%s\"" % mpicc])
         clear_icc_env(env)
         load_mpi_path(env)
         return True


### PR DESCRIPTION
This adds a definition on the command line that will cause scons to
recompile any code that was previously compiled with a different
mpicc so that one can change the mpi used without more drastic
clean of all daos binaries.

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>