### PR TITLE
DAOS-6429 test: Use CANCEL_FOR_TICKET for rebuild 0-10

### DIFF
--- a/src/tests/ftest/daos_test/daos_core_test-rebuild.yaml
+++ b/src/tests/ftest/daos_test/daos_core_test-rebuild.yaml
@@ -57,12 +57,11 @@ daos_tests:
   num_replicas:
     num_replicas: 1
   Tests: !mux
-# Skipped for DAOS-5851
-#    test_r_0-10:
-#      daos_test: r
-#      test_name: rebuild tests 0-10
-#      args: -s3 -u subtests="0-10"
-#      test_timeout: 1500
+    test_r_0-10:
+      daos_test: r
+      test_name: rebuild tests 0-10
+      args: -s3 -u subtests="0-10"
+      test_timeout: 1500
     test_r_12-15:
       daos_test: r
       test_name: rebuild tests 12-15


### PR DESCRIPTION
Use CANCEL_FOR_TICKET for rebuild 0-10
instead of comments in yaml
Py is already updated. This pr is just to remove the comments in yaml.