### PR TITLE
DAOS-6480 test: Re-enable Create Container ACL

### DIFF
--- a/src/tests/ftest/pool/multiple_creates_test.py
+++ b/src/tests/ftest/pool/multiple_creates_test.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-'''
+"""
   (C) Copyright 2018-2019 Intel Corporation.
 
   Licensed under the Apache License, Version 2.0 (the "License");
@@ -20,30 +20,19 @@
   provided in Contract No. B609815.
   Any reproduction of computer software, computer software documentation, or
   portions thereof marked with this legend must also reproduce the markings.
-'''
+"""
 from __future__ import print_function
 
 from apricot import TestWithServers
-from command_utils import CommandFailure
 
 import check_for_pool
 
+
 class MultipleCreatesTest(TestWithServers):
-    """
-    Tests DAOS pool creation, calling it repeatedly one after another
+    """Tests DAOS pool creation, calling it repeatedly one after another.
 
     :avocado: recursive
     """
-
-    def create_pool(self):
-        """Create and verify a pool."""
-        try:
-            pool = self.get_pool(connect=False)
-        except CommandFailure as error:
-            self.fail("Expecting to pass but test has failed with error '{}' \
-                .\n".format(error))
-        return pool
-
 
     def verify_pool(self, host, uuid):
         """Verify the pool.
@@ -55,40 +44,33 @@ class MultipleCreatesTest(TestWithServers):
         if check_for_pool.check_for_pool(host, uuid.lower()):
             self.fail("Pool {0} not found on host {1}.".format(uuid, host))
 
-
     def test_create_one(self):
-        """
-        Test issuing a single  pool create commands at once.
+        """Test issuing a single  pool create commands at once.
 
         :avocado: tags=all,full_regression
         :avocado: tags=small
         :avocado: tags=pool,smoke,createone
         """
-
-        self.pool = self.create_pool()
+        self.pool = self.get_pool(connect=False)
         print("uuid is {0}\n".format(self.pool.uuid))
 
         host = self.hostlist_servers[0]
         self.verify_pool(host, self.pool.uuid)
 
-
     def test_create_two(self):
-        """
-        Test issuing multiple pool create commands at once.
+        """Test issuing multiple pool create commands at once.
 
         :avocado: tags=all,full_regression
         :avocado: tags=small
         :avocado: tags=pool,smoke,createtwo
         """
-
-        self.pool = [self.create_pool() for _ in range(2)]
+        self.pool = [self.get_pool(connect=False) for _ in range(2)]
         for pool in self.pool:
             print("uuid is {0}\n".format(pool.uuid))
 
         for host in self.hostlist_servers:
             for pool in self.pool:
                 self.verify_pool(host, pool.uuid)
-
 
     def test_create_three(self):
         """
@@ -98,61 +80,10 @@ class MultipleCreatesTest(TestWithServers):
         :avocado: tags=small
         :avocado: tags=pool,createthree
         """
-
-        self.pool = [self.create_pool() for _ in range(3)]
+        self.pool = [self.get_pool(connect=False) for _ in range(3)]
         for pool in self.pool:
             print("uuid is {0}\n".format(pool.uuid))
 
         for host in self.hostlist_servers:
             for pool in self.pool:
                 self.verify_pool(host, pool.uuid)
-
-
-    # COMMENTED OUT because test environments don't always have enough
-    # memory to run this
-    #def test_create_five(self):
-    #    """
-    #    Test issuing five pool create commands at once.
-    #    """
-    #
-    # Accumulate a list of pass/fail indicators representing what is
-    # expected for each parameter then "and" them to determine the
-    # expected result of the test
-    #    expected_for_param = []
-    #
-    #    modelist = self.params.get("mode",'/run/tests/modes/*')
-    #    mode = modelist[0]
-    #    expected_for_param.append(modelist[1])
-    #
-    #    setidlist = self.params.get("setname",'/run/tests/setnames/*')
-    #    setid = setidlist[0]
-    #    expected_for_param.append(setidlist[1])
-    #
-    #    uid = os.geteuid()
-    #    gid = os.getegid()
-    #
-    #    # if any parameter results in failure then the test should FAIL
-    #    expected_result = 'PASS'
-    #    for result in expected_for_param:
-    #           if result == 'FAIL':
-    #                  expected_result = 'FAIL'
-    #                  break
-    #    try:
-    #           cmd = ('../../install/bin/orterun -np 1 '
-    #                  '--ompi-server file:{0} ./pool/wrap'
-    #                  'per/SimplePoolTests {1} {2} {3} {4} {5}'.format(
-    #                      urifile, "create", mode, uid, gid, setid))
-    #           process.system(cmd)
-    #           process.system(cmd)
-    #           process.system(cmd)
-    #           process.system(cmd)
-    #           process.system(cmd)
-    #
-    #           if expected_result == 'FAIL':
-    #                  self.fail("Expected to fail but passed.\n")
-    #
-    #    except Exception as e:
-    #           print(e)
-    #           print(traceback.format_exc())
-    #           if expected_result == 'PASS':
-    #                  self.fail("Expecting to pass but test has failed.\n")

--- a/src/tests/ftest/security/cont_create_acl.py
+++ b/src/tests/ftest/security/cont_create_acl.py
@@ -21,7 +21,6 @@
   Any reproduction of computer software, computer software documentation, or
   portions thereof marked with this legend must also reproduce the markings.
 """
-from apricot import skipForTicket
 from cont_security_test_base import ContSecurityTestBase
 from security_test_base import generate_acl_file
 
@@ -34,7 +33,6 @@ class CreateContainterACLTest(ContSecurityTestBase):
 
     :avocado: recursive
     """
-    @skipForTicket("DAOS-6479")
     def test_container_basics(self):
         """Test basic container create/destroy/open/close/query.
 

--- a/src/tests/ftest/soak/soak_utils.py
+++ b/src/tests/ftest/soak/soak_utils.py
@@ -30,7 +30,7 @@ from ior_utils import IorCommand
 from fio_utils import FioCommand
 from dfuse_utils import Dfuse
 from job_manager_utils import Srun
-from command_utils_base import BasicParameter, CommandFailure
+from command_utils_base import BasicParameter
 from general_utils import get_random_string, run_command, DaosTestError
 import slurm_utils
 from test_utils_pool import TestPool
@@ -296,7 +296,7 @@ def launch_exclude_reintegrate(self, pool, name, results, args):
         try:
             pool.exclude(rank, tgt_idx=tgt_idx)
             status = True
-        except CommandFailure as error:
+        except TestFail as error:
             self.log.error(
                 "<<<FAILED:dmg pool exclude failed", exc_info=error)
             status = False
@@ -313,7 +313,7 @@ def launch_exclude_reintegrate(self, pool, name, results, args):
             try:
                 pool.reintegrate(rank, tgt_idx)
                 status = True
-            except CommandFailure as error:
+            except TestFail as error:
                 self.log.error(
                     "<<<FAILED:dmg pool reintegrate failed", exc_info=error)
                 status = False
@@ -369,7 +369,7 @@ def launch_server_stop_start(self, pools, name, results, args):
             for pool in pools:
                 try:
                     pool.drain(rank)
-                except CommandFailure as error:
+                except TestFail as error:
                     self.log.error(
                         "<<<FAILED:dmg pool {} drain failed".format(
                             pool.uuid), exc_info=error)
@@ -386,7 +386,7 @@ def launch_server_stop_start(self, pools, name, results, args):
             # Shutdown the server
             try:
                 self.dmg_command.system_stop(ranks=rank)
-            except CommandFailure as error:
+            except TestFail as error:
                 self.log.error(
                     "<<<FAILED:dmg system stop failed", exc_info=error)
                 status = False
@@ -399,7 +399,7 @@ def launch_server_stop_start(self, pools, name, results, args):
             try:
                 self.dmg_command.system_start(ranks=rank)
                 status = True
-            except CommandFailure as error:
+            except TestFail as error:
                 self.log.error(
                     "<<<FAILED:dmg system start failed", exc_info=error)
                 status = False
@@ -409,7 +409,7 @@ def launch_server_stop_start(self, pools, name, results, args):
                 try:
                     pool.reintegrate(rank)
                     status = True
-                except CommandFailure as error:
+                except TestFail as error:
                     self.log.error(
                         "<<<FAILED:dmg pool {} reintegrate failed".format(
                             pool.uuid), exc_info=error)

--- a/src/tests/ftest/util/cont_security_test_base.py
+++ b/src/tests/ftest/util/cont_security_test_base.py
@@ -28,13 +28,13 @@ import grp
 import re
 from apricot import TestWithServers
 from avocado import fail_on
+from avocado.core.exceptions import TestFail
 from daos_utils import DaosCommand
 from command_utils import CommandFailure
 import general_utils
 from general_utils import DaosTestError
 import security_test_base as secTestBase
 from test_utils_container import TestContainer
-from avocado.core.exceptions import TestFail
 
 
 class ContSecurityTestBase(TestWithServers):
@@ -434,7 +434,7 @@ class ContSecurityTestBase(TestWithServers):
         return test_errs
 
     def acl_file_diff(self, prev_acl, flag=True):
-        """Compare current content of acl-file helper funtion.
+        """Compare current content of acl-file with helper function.
 
         If provided  prev_acl file information is different from current acl
         file information test will fail if flag=True. If flag=False, test will

--- a/src/tests/ftest/util/cont_security_test_base.py
+++ b/src/tests/ftest/util/cont_security_test_base.py
@@ -34,6 +34,8 @@ import general_utils
 from general_utils import DaosTestError
 import security_test_base as secTestBase
 from test_utils_container import TestContainer
+from avocado.core.exceptions import TestFail
+
 
 class ContSecurityTestBase(TestWithServers):
     """Container security test cases.
@@ -72,7 +74,7 @@ class ContSecurityTestBase(TestWithServers):
 
     @fail_on(CommandFailure)
     def create_pool_with_dmg(self):
-        """Create a pool with the dmg tool
+        """Create a pool with the dmg tool.
 
         Also, obtains the pool uuid and svc from the operation's
         result
@@ -80,6 +82,7 @@ class ContSecurityTestBase(TestWithServers):
         Returns:
             pool_uuid (str): Pool UUID, randomly generated.
             pool_svc (str): Pool service replica rank list
+
         """
         self.prepare_pool()
         pool_uuid = self.pool.pool.get_uuid_str()
@@ -88,7 +91,7 @@ class ContSecurityTestBase(TestWithServers):
         return pool_uuid, pool_svc
 
     def create_container_with_daos(self, pool, acl_type=None, acl_file=None):
-        """Create a container with the daos tool
+        """Create a container with the daos tool.
 
         Also, obtains the container uuid from the operation's result.
 
@@ -98,6 +101,7 @@ class ContSecurityTestBase(TestWithServers):
 
         Returns:
             container_uuid: Container UUID created.
+
         """
         file_name = None
         get_acl_file = None
@@ -121,8 +125,8 @@ class ContSecurityTestBase(TestWithServers):
             self.container.get_params(self)
             self.container.create(acl_file=file_name)
             container_uuid = self.container.uuid
-        except CommandFailure:
-            if acl_type is not "invalid":
+        except TestFail:
+            if acl_type != "invalid":
                 raise DaosTestError(
                     "Could not create a container when expecting one")
             container_uuid = None
@@ -264,7 +268,6 @@ class ContSecurityTestBase(TestWithServers):
             pool_uuid, container_uuid)
         return result
 
-
     def set_container_property(
             self, pool_uuid, container_uuid, prop, value):
         """Write/Set container property.
@@ -317,13 +320,15 @@ class ContSecurityTestBase(TestWithServers):
         return result
 
     def compare_acl_lists(self, get_acl_list, expected_list):
-        """Compares two permission lists
+        """Compare two permission lists.
+
         Args:
             get_acl_list (str list): list of permissions obtained by get-acl
             expected_list (str list): list of expected permissions
 
         Returns:
             True or False if both permission lists are identical or not
+
         """
         self.log.info("    ===> get-acl ACL:  %s", get_acl_list)
         self.log.info("    ===> Expected ACL: %s", expected_list)
@@ -339,13 +344,14 @@ class ContSecurityTestBase(TestWithServers):
         return True
 
     def get_base_acl_entries(self, test_user):
-        """Get initial or base container acl entries per container enforcement
-           order for test_user.
+        """Get container acl entries per cont enforcement order for test_user.
+
         Args:
             test_user (str): test user.
 
         Returns (list str):
             List of base container acl entries for the test_user.
+
         """
         if test_user == "OWNER":
             base_acl_entries = [
@@ -387,10 +393,11 @@ class ContSecurityTestBase(TestWithServers):
         return base_acl_entries
 
     def cleanup(self, types):
-        """Removes all temporal acl files created during the test.
+        """Remove all temporal acl files created during the test.
 
         Args:
             types (list): types of acl files [valid, invalid]
+
         """
         for typ in types:
             get_acl_file = "acl_{}.txt".format(typ)
@@ -427,7 +434,7 @@ class ContSecurityTestBase(TestWithServers):
         return test_errs
 
     def acl_file_diff(self, prev_acl, flag=True):
-        """Helper function to compare current content of acl-file.
+        """Compare current content of acl-file helper funtion.
 
         If provided  prev_acl file information is different from current acl
         file information test will fail if flag=True. If flag=False, test will
@@ -439,6 +446,7 @@ class ContSecurityTestBase(TestWithServers):
             flag (bool, optional): if True, test will fail when acl-file
                 contents are different, else test will fail when acl-file
                 contents are same. Defaults to True.
+
         """
         current_acl = self.get_container_acl_list(
             self.pool.uuid, self.container.uuid)


### PR DESCRIPTION
Test-tag: pr,-hw createone createtwo createthree cont_create_acl
Test-tag-hw-large: pr,hw,large soak_smoke

The test was failing due to the change to TestPool and TestContainer utils that added
a fail_on decorator to the method.  The was done to simplify the try/except fail code in test cases.
But it impacted tests that need to catch the exception.   The few tests that where negatively impacted have 
been updated to catch "TestFail"

Signed-off-by: Maureen Jean <maureen.jean@intel.com>