### PR TITLE
DAOS-6500 object: Remove superfluous code from do_obj_ioc_begin().

### DIFF
--- a/src/object/obj_rpc.c
+++ b/src/object/obj_rpc.c
@@ -1226,8 +1226,10 @@ obj_reply_map_version_set(crt_rpc_t *rpc, uint32_t map_version)
 		break;
 	case DAOS_OBJ_RPC_EC_AGGREGATE:
 		((struct obj_ec_agg_out *)reply)->ea_map_ver = map_version;
+		break;
 	case DAOS_OBJ_RPC_CPD:
 		((struct obj_cpd_out *)reply)->oco_map_version = map_version;
+		break;
 	case DAOS_OBJ_RPC_EC_REPLICATE:
 		((struct obj_ec_rep_out *)reply)->er_map_ver = map_version;
 		break;

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -1677,13 +1677,8 @@ do_obj_ioc_begin(uint32_t rpc_map_ver, uuid_t pool_uuid,
 		 struct obj_io_context *ioc)
 {
 	struct ds_pool_child *poc;
-	int		      rank, rc;
-	ABT_xstream xs;
+	int		      rc;
 
-	rc = ABT_xstream_self(&xs);
-	D_ASSERT(rc == ABT_SUCCESS);
-	rc = ABT_xstream_get_rank(xs, &rank);
-	D_ASSERT(rc == ABT_SUCCESS);
 	rc = obj_ioc_init(pool_uuid, coh_uuid, cont_uuid, opc, ioc);
 	if (rc)
 		return rc;


### PR DESCRIPTION
This code was put into srv_obj.c to debug a problem with ioc verification.  This PR removes this not needed code.

Signed-off-by: Joseph Moore <joseph.moore@intel.com>