### PR TITLE
DAOS-6498 control: Fix some issues in pool create

### DIFF
--- a/src/control/cmd/dmg/pretty/pool.go
+++ b/src/control/cmd/dmg/pretty/pool.go
@@ -89,14 +89,15 @@ func PrintPoolCreateResponse(pcr *control.PoolCreateResp, out io.Writer, opts ..
 		return errors.New("create response had 0 target ranks")
 	}
 
+	numRanks := uint64(len(pcr.TgtRanks))
 	title := fmt.Sprintf("Pool created with %0.2f%%%% SCM/NVMe ratio", ratio*100)
 	_, err := fmt.Fprintln(out, txtfmt.FormatEntity(title, []txtfmt.TableRow{
 		{"UUID": pcr.UUID},
 		{"Service Ranks": FormatRanks(pcr.SvcReps)},
 		{"Storage Ranks": FormatRanks(pcr.TgtRanks)},
-		{"Total Size": humanize.Bytes(pcr.ScmBytes + pcr.NvmeBytes)},
-		{"SCM": fmt.Sprintf("%s (%s / rank)", humanize.Bytes(pcr.ScmBytes), humanize.Bytes(pcr.ScmBytes/uint64(len(pcr.TgtRanks))))},
-		{"NVMe": fmt.Sprintf("%s (%s / rank)", humanize.Bytes(pcr.NvmeBytes), humanize.Bytes(pcr.NvmeBytes/uint64(len(pcr.TgtRanks))))},
+		{"Total Size": humanize.Bytes((pcr.ScmBytes + pcr.NvmeBytes) * numRanks)},
+		{"SCM": fmt.Sprintf("%s (%s / rank)", humanize.Bytes(pcr.ScmBytes*numRanks), humanize.Bytes(pcr.ScmBytes))},
+		{"NVMe": fmt.Sprintf("%s (%s / rank)", humanize.Bytes(pcr.NvmeBytes*numRanks), humanize.Bytes(pcr.NvmeBytes))},
 	}))
 
 	return err

--- a/src/control/cmd/dmg/pretty/pool_test.go
+++ b/src/control/cmd/dmg/pretty/pool_test.go
@@ -169,9 +169,9 @@ Pool created with 6.00%%%% SCM/NVMe ratio
   UUID          : %s
   Service Ranks : [0-2]                               
   Storage Ranks : [0-3]                               
-  Total Size    : 11 GB                               
-  SCM           : 600 MB (150 MB / rank)              
-  NVMe          : 10 GB (2.5 GB / rank)               
+  Total Size    : 42 GB                               
+  SCM           : 2.4 GB (600 MB / rank)              
+  NVMe          : 40 GB (10 GB / rank)                
 
 `, common.MockUUID()),
 		},
@@ -188,8 +188,8 @@ Pool created with 100.00%%%% SCM/NVMe ratio
   UUID          : %s
   Service Ranks : [0-2]                               
   Storage Ranks : [0-3]                               
-  Total Size    : 600 MB                              
-  SCM           : 600 MB (150 MB / rank)              
+  Total Size    : 2.4 GB                              
+  SCM           : 2.4 GB (600 MB / rank)              
   NVMe          : 0 B (0 B / rank)                    
 
 `, common.MockUUID()),

--- a/src/control/server/mgmt_pool.go
+++ b/src/control/server/mgmt_pool.go
@@ -41,6 +41,9 @@ import (
 )
 
 const (
+	// DefaultPoolScmRatio defines the default SCM:NVMe ratio for
+	// requests that do not specify one.
+	DefaultPoolScmRatio = 0.06
 	// DefaultPoolServiceReps defines a default value for pool create
 	// requests that do not specify a value. If there are fewer than this
 	// number of ranks available, then the default falls back to 1.
@@ -112,16 +115,27 @@ func (svc *mgmtSvc) calculateCreateStorage(req *mgmtpb.PoolCreateReq) error {
 		return errors.New("harness has no managed instances")
 	}
 
+	if len(req.GetRanks()) == 0 {
+		return errors.New("zero ranks in calculateCreateStorage()")
+	}
+	if req.GetScmratio() == 0 {
+		req.Scmratio = DefaultPoolScmRatio
+	}
+
+	storagePerRank := func(total uint64) uint64 {
+		return total / uint64(len(req.GetRanks()))
+	}
+
 	switch {
 	case len(instances[0].bdevConfig().DeviceList) == 0:
 		svc.log.Info("config has 0 bdevs; excluding NVMe from pool create request")
 		if req.GetScmbytes() == 0 {
-			req.Scmbytes = req.GetTotalbytes()
+			req.Scmbytes = storagePerRank(req.GetTotalbytes())
 		}
 		req.Nvmebytes = 0
 	case req.GetTotalbytes() > 0:
-		req.Nvmebytes = req.GetTotalbytes()
-		req.Scmbytes = uint64(float64(req.GetTotalbytes()) * req.GetScmratio())
+		req.Nvmebytes = storagePerRank(req.GetTotalbytes())
+		req.Scmbytes = storagePerRank(uint64(float64(req.GetTotalbytes()) * req.GetScmratio()))
 	}
 
 	// zero these out as they're not needed anymore
@@ -224,6 +238,10 @@ func (svc *mgmtSvc) PoolCreate(ctx context.Context, req *mgmtpb.PoolCreateReq) (
 		sort.Slice(req.Ranks, func(i, j int) bool { return req.Ranks[i] < req.Ranks[j] })
 	}
 
+	if len(req.GetRanks()) == 0 {
+		return nil, errors.New("pool request contains zero target ranks")
+	}
+
 	// Set the number of service replicas to a reasonable default
 	// if the request didn't specify. Note that the number chosen
 	// should not be even in order to work best with the raft protocol's
@@ -304,7 +322,7 @@ func (svc *mgmtSvc) PoolCreate(ctx context.Context, req *mgmtpb.PoolCreateReq) (
 		return resp, nil
 	}
 	// let the caller know what was actually created
-	resp.TgtRanks = req.Ranks
+	resp.TgtRanks = req.GetRanks()
 	resp.ScmBytes = req.Scmbytes
 	resp.NvmeBytes = req.Nvmebytes
 


### PR DESCRIPTION
The new pool create functionality didn't handle some edge
cases, and the response formatter wasn't correctly calculating
total pool size.