### PR TITLE
DAOS-6394 Systemd: Systemd restarts DAOS too quickly on failure

### DIFF
--- a/utils/systemd/daos_agent.service
+++ b/utils/systemd/daos_agent.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=DAOS Agent
 StartLimitIntervalSec=60
-StartLimitBurst=5 
+StartLimitBurst=5
 Wants=network-online.target
 After=network-online.target
 

--- a/utils/systemd/daos_agent.service
+++ b/utils/systemd/daos_agent.service
@@ -1,5 +1,7 @@
 [Unit]
 Description=DAOS Agent
+StartLimitIntervalSec=60
+StartLimitBurst=5 
 Wants=network-online.target
 After=network-online.target
 
@@ -12,6 +14,7 @@ ExecStart=/usr/bin/daos_agent
 StandardOutput=journal
 StandardError=journal
 Restart=always
+RestartSec=10
 LimitCORE=infinity
 
 [Install]

--- a/utils/systemd/daos_server.service
+++ b/utils/systemd/daos_server.service
@@ -1,5 +1,7 @@
 [Unit]
 Description=DAOS Server
+StartLimitIntervalSec=60
+StartLimitBurst=5 
 Wants=network-online.target
 After=network-online.target
 
@@ -13,6 +15,7 @@ ExecStart=/usr/bin/daos_server start
 StandardOutput=journal
 StandardError=journal
 Restart=on-failure
+RestartSec=10
 LimitMEMLOCK=infinity
 LimitCORE=infinity
 

--- a/utils/systemd/daos_server.service
+++ b/utils/systemd/daos_server.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=DAOS Server
 StartLimitIntervalSec=60
-StartLimitBurst=5 
+StartLimitBurst=5
 Wants=network-online.target
 After=network-online.target
 


### PR DESCRIPTION
If something prevents daos_server or daos_agent from restarting it will
immediately try to restart indefinitely causing a restart storm in the logs.

Signed-off-by: David Quigley <david.quigley@intel.com>