### PR TITLE
DAOS-6281 bio: initialize VMD subsystem

### DIFF
--- a/src/bio/SConscript
+++ b/src/bio/SConscript
@@ -24,7 +24,8 @@ def scons():
     libs += ['spdk_conf', 'spdk_blob', 'spdk_nvme', 'spdk_util']
     libs += ['spdk_json', 'spdk_jsonrpc', 'spdk_rpc', 'spdk_trace']
     libs += ['spdk_sock', 'spdk_log', 'spdk_notify', 'spdk_blob_bdev']
-    libs += ['spdk_vmd']
+    libs += ['spdk_vmd', 'spdk_event', 'spdk_event_bdev', 'spdk_event_copy']
+    libs += ['spdk_event_vmd']
 
     # Other libs
     libs += ['numa', 'dl', 'smd']

--- a/src/bio/bio_internal.h
+++ b/src/bio/bio_internal.h
@@ -329,4 +329,12 @@ int bio_bs_state_set(struct bio_blobstore *bbs, enum bio_bs_state new_state);
 /* bio_device.c */
 void bio_led_event_monitor(struct bio_xs_context *ctxt, uint64_t now);
 
+/*
+ * FIXME copied from spdk_internal/event.h, should be removed once they are
+ * exported by SPDK.
+ */
+typedef void (*spdk_subsystem_init_fn)(int rc, void *ctx);
+void spdk_subsystem_init(spdk_subsystem_init_fn cb_fn, void *cb_arg);
+void spdk_subsystem_fini(spdk_msg_fn cb_fn, void *cb_arg);
+
 #endif /* __BIO_INTERNAL_H__ */

--- a/src/bio/bio_xstream.c
+++ b/src/bio/bio_xstream.c
@@ -35,7 +35,6 @@
 #include <spdk/io_channel.h>
 #include <spdk/blob_bdev.h>
 #include <spdk/blob.h>
-#include <spdk/copy_engine.h>
 #include <spdk/conf.h>
 #include "bio_internal.h"
 #include <daos_srv/smd.h>
@@ -228,8 +227,11 @@ populate_whitelist(struct spdk_env_opts *opts)
 	 * Optionally VMD devices will be used, and will require a different
 	 * transport id to pass to whitelist for DPDK.
 	 */
-	if (spdk_conf_find_section(NULL, "Vmd") != NULL)
-		vmd_enabled = true;
+	sp = spdk_conf_find_section(NULL, "Vmd");
+	if (sp != NULL) {
+		if (spdk_conf_section_get_boolval(sp, "Enable", false))
+			vmd_enabled = true;
+	}
 
 	sp = spdk_conf_find_section(NULL, "Nvme");
 	if (sp == NULL) {
@@ -335,26 +337,6 @@ bio_spdk_env_init(void)
 		rc = -DER_INVAL; /* spdk_env_init() returns -1 */
 		D_ERROR("Failed to initialize SPDK env, "DF_RC"\n", DP_RC(rc));
 		return rc;
-	}
-
-	if (spdk_conf_find_section(NULL, "Vmd") != NULL) {
-		/**
-		 * Enumerate VMD devices and hook them into the SPDK PCI
-		 * subsystem.
-		 */
-		rc = spdk_vmd_init();
-		if (rc != 0) {
-			rc = -DER_INVAL; /* spdk_vmd_init() returns -1 */
-			D_ERROR("Failed to initialize VMD env, "DF_RC"\n",
-				DP_RC(rc));
-			return rc;
-		}
-
-		/**
-		 * TODO spdk_vmd_hotplug_monitor() will need to be called
-		 * periodically on 'init' xstream to monitor VMD hotremove/
-		 * hotplug events.
-		 */
 	}
 
 	spdk_unaffinitize_thread();
@@ -563,6 +545,12 @@ common_init_cb(void *arg, int rc)
 	D_ASSERT(cp_arg->cca_rc == 0);
 	cp_arg->cca_inflights--;
 	cp_arg->cca_rc = daos_errno2der(-rc);
+}
+
+static void
+subsys_init_cb(int rc, void *arg)
+{
+	common_init_cb(arg, rc);
 }
 
 static void
@@ -1425,11 +1413,7 @@ bio_xsctxt_free(struct bio_xs_context *ctxt)
 			fini_bio_bdevs(ctxt);
 
 			common_prep_arg(&cp_arg);
-			spdk_copy_engine_finish(common_fini_cb, &cp_arg);
-			xs_poll_completion(ctxt, &cp_arg.cca_inflights);
-
-			common_prep_arg(&cp_arg);
-			spdk_bdev_finish(common_fini_cb, &cp_arg);
+			spdk_subsystem_fini(common_fini_cb, &cp_arg);
 			xs_poll_completion(ctxt, &cp_arg.cca_inflights);
 
 			nvme_glb.bd_init_thread = NULL;
@@ -1493,7 +1477,7 @@ bio_xsctxt_alloc(struct bio_xs_context **pctxt, int tgt_id)
 	/*
 	 * Register SPDK thread beforehand, it could be used for poll device
 	 * admin commands completions and hotplugged events in following
-	 * spdk_bdev_initialize() call, it also could be used for blobstore
+	 * spdk_subsystem_init() call, it also could be used for blobstore
 	 * metadata io channel in following init_bio_bdevs() call.
 	 */
 	snprintf(th_name, sizeof(th_name), "daos_spdk_%d", tgt_id);
@@ -1515,24 +1499,14 @@ bio_xsctxt_alloc(struct bio_xs_context **pctxt, int tgt_id)
 		D_ASSERTF(nvme_glb.bd_xstream_cnt == 1, "%d",
 			  nvme_glb.bd_xstream_cnt);
 
-		/* The SPDK 'Malloc' device relies on copy engine. */
-		rc = spdk_copy_engine_initialize();
-		if (rc != 0) {
-			D_ERROR("failed to init SPDK copy engine, rc:%d\n", rc);
-			goto out;
-		}
-
-		/* Initialize all types of devices */
+		/* Initialize all registered subsystems: bdev, vmd, copy. */
 		common_prep_arg(&cp_arg);
-		spdk_bdev_initialize(common_init_cb, &cp_arg);
+		spdk_subsystem_init(subsys_init_cb, &cp_arg);
 		xs_poll_completion(ctxt, &cp_arg.cca_inflights);
 
 		if (cp_arg.cca_rc != 0) {
 			rc = cp_arg.cca_rc;
 			D_ERROR("failed to init bdevs, rc:%d\n", rc);
-			common_prep_arg(&cp_arg);
-			spdk_copy_engine_finish(common_fini_cb, &cp_arg);
-			xs_poll_completion(ctxt, &cp_arg.cca_inflights);
 			goto out;
 		}
 


### PR DESCRIPTION
Call spdk_subsystem_init() to initialize all registered subsystems
like 'bdev', 'vmd' and 'copy', that'll simplify the BIO SPDK
init/fini code, also register VMD hotplug poller properly.

Signed-off-by: Niu Yawei <yawei.niu@intel.com>