### PR TITLE
DAOS-6494 mgmt: Print param value in hex

### DIFF
--- a/src/mgmt/cli_debug.c
+++ b/src/mgmt/cli_debug.c
@@ -90,8 +90,8 @@ dc_debug_set_params(tse_task_t *task)
 	if (rc != 0)
 		D_GOTO(err_rpc, rc);
 
-	D_DEBUG(DB_MGMT, "set parameter %d/%u/"DF_U64"\n", args->rank,
-		args->key_id, args->value);
+	D_DEBUG(DB_MGMT, "set parameter %u/%u/"DF_X64"/"DF_U64"\n", args->rank,
+		args->key_id, args->value, args->value_extra);
 
 	/** send the request */
 	return daos_rpc_send(rpc, task);


### PR DESCRIPTION
Since most parameter values are defined in hex, like

  #define DAOS_DTX_FAIL_IO (DAOS_FAIL_UNIT_TEST_GROUP_LOC | 0x3a)

this patch changes dc_debug_set_params to print values in hex. Also,
ranks should be printed with "%u" instead of "%d". And, extra values
should be printed as well.

Signed-off-by: Li Wei <wei.g.li@intel.com>