### PR TITLE
DAOS-6440 vos: remove invalid DTX status check

### DIFF
--- a/src/vos/vos_dtx.c
+++ b/src/vos/vos_dtx.c
@@ -652,8 +652,6 @@ dtx_rec_release(struct vos_container *cont, struct vos_dtx_act_ent *dae,
 	int				 i;
 	int				 rc = 0;
 
-	D_ASSERT(DAE_INDEX(dae) >= 0);
-
 	if (dae->dae_dbd == NULL)
 		return 0;
 


### PR DESCRIPTION
The dtx_leader_begin() may generate DTX entry in DRAM before any
real modification. The index for such DTX entry will not be set
until all related modifications are done locally. If the DTX is
aborted before that, the dtx_rec_release() that is triggered by
DTX abort logic will hit assertaion when check the index of DTX
entry, that is wrong, and should be removed.

Signed-off-by: Fan Yong <fan.yong@intel.com>