### PR TITLE
DAOS-6474 dtx: no condition ops when commit distributed transaction

### DIFF
--- a/src/object/obj_tx.c
+++ b/src/object/obj_tx.c
@@ -2190,7 +2190,7 @@ dc_tx_add_update(struct dc_tx *tx, daos_handle_t oh, uint64_t flags,
 	dcsr->dcsr_opc = DCSO_UPDATE;
 	dcsr->dcsr_nr = nr;
 	dcsr->dcsr_dkey_hash = obj_dkey2hash(obj->cob_md.omd_id, dkey);
-	dcsr->dcsr_api_flags = flags;
+	dcsr->dcsr_api_flags = flags & ~DAOS_COND_MASK;
 
 	dcu = &dcsr->dcsr_update;
 	iod_array = &dcu->dcu_iod_array;
@@ -2284,7 +2284,7 @@ dc_tx_add_punch_obj(struct dc_tx *tx, daos_handle_t oh, uint64_t flags)
 		return -DER_NO_HDL;
 
 	dcsr->dcsr_opc = DCSO_PUNCH_OBJ;
-	dcsr->dcsr_api_flags = flags;
+	dcsr->dcsr_api_flags = flags & ~DAOS_COND_MASK;
 
 	tx->tx_write_cnt++;
 
@@ -2320,7 +2320,7 @@ dc_tx_add_punch_dkey(struct dc_tx *tx, daos_handle_t oh, uint64_t flags,
 
 	dcsr->dcsr_opc = DCSO_PUNCH_DKEY;
 	dcsr->dcsr_dkey_hash = obj_dkey2hash(obj->cob_md.omd_id, dkey);
-	dcsr->dcsr_api_flags = flags;
+	dcsr->dcsr_api_flags = flags & ~DAOS_COND_MASK;
 
 	tx->tx_write_cnt++;
 
@@ -2369,9 +2369,8 @@ dc_tx_add_punch_akeys(struct dc_tx *tx, daos_handle_t oh, uint64_t flags,
 
 	dcsr->dcsr_opc = DCSO_PUNCH_AKEY;
 	dcsr->dcsr_nr = nr;
-	dcsr->dcsr_dkey_hash = obj_dkey2hash(obj->cob_md.omd_id,
-					     dkey);
-	dcsr->dcsr_api_flags = flags;
+	dcsr->dcsr_dkey_hash = obj_dkey2hash(obj->cob_md.omd_id, dkey);
+	dcsr->dcsr_api_flags = flags & ~DAOS_COND_MASK;
 
 	tx->tx_write_cnt++;
 
@@ -2460,7 +2459,7 @@ done:
 	dcsr->dcsr_opc = DCSO_READ;
 	dcsr->dcsr_nr = nr;
 	dcsr->dcsr_dkey_hash = obj_dkey2hash(obj->cob_md.omd_id, dkey);
-	dcsr->dcsr_api_flags = flags;
+	dcsr->dcsr_api_flags = flags & ~DAOS_COND_MASK;
 
 	tx->tx_read_cnt++;
 
@@ -2620,7 +2619,8 @@ dc_tx_check_existence_task(enum obj_rpc_opc opc, daos_handle_t oh,
 		} else if (flags & (DAOS_COND_AKEY_INSERT |
 				    DAOS_COND_AKEY_UPDATE)) {
 			iods = iods_or_akeys;
-			api_flags = DAOS_COND_AKEY_FETCH;
+			api_flags = DAOS_COND_AKEY_FETCH |
+				    (flags & DAOS_COND_PER_AKEY);
 		} else {
 			/* Only check dkey existence. */
 			api_flags = DAOS_COND_DKEY_FETCH;


### PR DESCRIPTION
When do conditional modification inside some distributed transaction,
the DTX client logic will trigger a conditional fetch request firstly
before adding such conditional modification reqeust into client side
cache, then according to the conditional fetch result (exist or not)
to decide whehter cache such conditional modification request or not.
So when triggers dc_tx_commit, it has checked related conditions, it
is NOT necessary to re-check the conditions on server when commit.

Signed-off-by: Fan Yong <fan.yong@intel.com>