### PR TITLE
DAOS-6513 build: bump protobuf-gen-c version

### DIFF
--- a/utils/sl/components/__init__.py
+++ b/utils/sl/components/__init__.py
@@ -312,8 +312,8 @@ def define_components(reqs):
                 libs=['rte_bus_pci'], patch_rpath=['lib'])
 
     url = 'https://github.com/protobuf-c/protobuf-c/releases/download/' \
-        'v1.3.0/protobuf-c-1.3.0.tar.gz'
-    web_retriever = WebRetriever(url, "08804f8bdbb3d6d44c2ec9e71e47ef6f")
+        'v1.3.3/protobuf-c-1.3.3.tar.gz'
+    web_retriever = WebRetriever(url, "dabc05a5f11c21b96d8d6db4153f5343")
     reqs.define('protobufc',
                 retriever=web_retriever,
                 commands=['./configure --prefix=$PROTOBUFC_PREFIX '


### PR DESCRIPTION
Bump protobuf-gen-c version pulled in build from 1.3.0 to 1.3.3 to
align with what we expect developers to be using.

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>