### PR TITLE
DAOS-6507 test: Increase timeout for checksum tests

### DIFF
--- a/src/tests/ftest/daos_test/daos_core_test.yaml
+++ b/src/tests/ftest/daos_test/daos_core_test.yaml
@@ -136,7 +136,7 @@ daos_tests:
     test_z:
       daos_test: z
       test_name: Checksum tests
-      test_timeout: 220
+      test_timeout: 240
     test_S:
       daos_test: S
       test_name: DAOS rebuild ec tests


### PR DESCRIPTION
The daos_test -z suite has started intermittently failing due
to timeout in cleanup because the test run does not leave
enough time. Increasing the overall test timeout by 20s to
240s should alleviate this problem.