### PR TITLE
DAOS-6473 control: Forbid "/" as fault domain level name

### DIFF
--- a/src/control/system/faultdomain.go
+++ b/src/control/system/faultdomain.go
@@ -154,7 +154,7 @@ func (f *FaultDomain) MustCreateChild(childLevel string) *FaultDomain {
 func NewFaultDomain(domains ...string) (*FaultDomain, error) {
 	for i := range domains {
 		domains[i] = strings.TrimSpace(domains[i])
-		if domains[i] == "" {
+		if domains[i] == "" || strings.Contains(domains[i], FaultDomainSeparator) {
 			return nil, errors.New("invalid fault domain")
 		}
 		domains[i] = strings.ToLower(domains[i])
@@ -258,15 +258,19 @@ func (t *FaultDomainTree) nextID() uint32 {
 // fault domain tree.
 func (t *FaultDomainTree) AddDomain(domain *FaultDomain) error {
 	if t == nil {
-		return errors.New("can't add to nil FaultDomainTree")
+		return errors.New("nil FaultDomainTree")
+	}
+
+	if domain == nil {
+		return errors.New("nil domain")
 	}
 
 	if domain.Empty() {
-		return errors.New("can't add empty fault domain to tree")
+		// nothing to do
+		return nil
 	}
 
 	domainAsTree := NewFaultDomainTree(domain)
-
 	return t.Merge(domainAsTree)
 }
 

--- a/src/control/system/faultdomain_test.go
+++ b/src/control/system/faultdomain_test.go
@@ -47,8 +47,16 @@ func TestSystem_NewFaultDomain(t *testing.T) {
 			input:  []string{"ok", ""},
 			expErr: errors.New("invalid fault domain"),
 		},
+		"explicit root": {
+			input:  []string{"/"},
+			expErr: errors.New("invalid fault domain"),
+		},
 		"whitespace-only strings": {
 			input:  []string{"ok", "\t    "},
+			expErr: errors.New("invalid fault domain"),
+		},
+		"name contains separator": {
+			input:  []string{"ok", "alpha/beta"},
 			expErr: errors.New("invalid fault domain"),
 		},
 		"single-level": {
@@ -565,6 +573,13 @@ func TestSystem_FaultDomain_NewChild(t *testing.T) {
 			childLevel: "   ",
 			expErr:     errors.New("invalid fault domain"),
 		},
+		"child level is root": {
+			orig: &FaultDomain{
+				Domains: []string{"parent"},
+			},
+			childLevel: "/",
+			expErr:     errors.New("invalid fault domain"),
+		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			result, err := tc.orig.NewChild(tc.childLevel)
@@ -1001,16 +1016,15 @@ func TestSystem_FaultDomainTree_AddDomain(t *testing.T) {
 	}{
 		"nil tree": {
 			toAdd:  MustCreateFaultDomain(),
-			expErr: errors.New("can't add to nil FaultDomainTree"),
+			expErr: errors.New("nil FaultDomainTree"),
 		},
 		"nil input": {
 			tree:   NewFaultDomainTree(),
-			expErr: errors.New("can't add empty fault domain to tree"),
+			expErr: errors.New("nil domain"),
 		},
-		"empty input": {
-			tree:   NewFaultDomainTree(),
-			toAdd:  MustCreateFaultDomain(),
-			expErr: errors.New("can't add empty fault domain to tree"),
+		"root domain": {
+			tree:  NewFaultDomainTree(),
+			toAdd: MustCreateFaultDomain(),
 		},
 		"single level": {
 			tree:  NewFaultDomainTree(),


### PR DESCRIPTION
- Stop allowing the separator to be part of a fault domain level
  name. It should only be used to separate level names.
- Improve a couple error messages.
- When attempting to add a root domain to the FaultDomainTree,
  it's a no-op, not an error.

Signed-off-by: Kris Jacque <kristin.jacque@intel.com>