### PR TITLE
DAOS-4433 mgmt: test vol-daos after mgmt API change

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # DAOS
+#
 
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](./LICENSE)
 [![Coverity Scan Build Status](https://img.shields.io/coverity/scan/3015.svg)](https://scan.coverity.com/projects/daos-stack-daos)


### PR DESCRIPTION
The daos_mgmt_svc_rip() function has been removed recently.
The hdf5-vol-daos packaging repo has not advanced the
SOURCE_COMMIT yet. This change is to test a new hdf5-vol-daos
that is brought up to date with the daos mgmt API change.

Skip-checkpatch: true
Skip-unit-tests: true
PR-repos-el7: hdf5-vol-daos@PR-7
PR-repos-leap15: hdf5-vol-daos@PR-7

Signed-off-by: Kenneth Cain <kenneth.c.cain@intel.com>