### PR TITLE
DAOS-623 ci: Use DNF on EL7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,9 @@ src/cart/src/cart/_structures_from_macros_.h
 dnt.*.memcheck
 utils/.daos_server.active.yml
 nlt-errors.json
+src/tests/ftest/sysinfo-*
+src/client/java/daos-java/target/
+src/client/java/daos-java/src/main/native/include/io_daos_DaosClient.h
+src/client/java/daos-java/src/main/native/include/io_daos_dfs_DaosFsClient.h
+src/client/java/hadoop-daos/target/
+src/client/java/daos-java/build/

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -189,10 +189,13 @@ String daos_packages_version(String distro) {
     String version = cachedCommitPragma(pragma: 'RPM-test-version')
     if (version != "") {
         String dist = ""
-        if (distro == "centos7") {
-            dist = ".el7"
-        } else if (distro == "leap15") {
-            dist = ".suse.lp152"
+        if (version.indexOf('-') > -1) {
+            // only tack on the %{dist} if the release was specified
+            if (distro == "centos7") {
+                dist = ".el7"
+            } else if (distro == "leap15") {
+                dist = ".suse.lp152"
+            }
         }
         return version + dist
     }


### PR DESCRIPTION
Our repo is considerable more complicated than a repo a customer would
install from.  So much more complicated that YUM is unable to properly
resolve dependencies among duplicated packages.

To deal with this, use DNF on EL7.  DNF is much smarter than YUM at
resolving dependencies.

Signed-off-by: Brian J. Murrell <brian.murrell@intel.com>