### PR TITLE
DAOS-4433 test: packaging hack experiment

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # DAOS
+#
 
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](./LICENSE)
 [![Coverity Scan Build Status](https://img.shields.io/coverity/scan/3015.svg)](https://scan.coverity.com/projects/daos-stack-daos)


### PR DESCRIPTION
Test daos master currently libdaos.so.0 while specifying repos
that were built with a WIP daos branch providing libdaos.so.1 to
prove no interference to existing master from the new packages.

Skip-checkpatch: true
Skip-unit-tests: true
PR-repos-el7: mpich@PR-44 ior-hpc@PR-10 hdf5-vol-daos@PR-8 romio@PR-5 mpifileutils-pkg@PR-7
PR-repos-leap15: mpich@PR-44 ior-hpc@PR-10 hdf5-vol-daos@PR-8 romio@PR-5 mpifileutils-pkg@PR-7

Signed-off-by: Kenneth Cain <kenneth.c.cain@intel.com>