### PR TITLE
DAOS-6499 dtx: sync commit DTX for resent modfication

### DIFF
--- a/src/dtx/dtx_common.c
+++ b/src/dtx/dtx_common.c
@@ -692,7 +692,7 @@ dtx_leader_end(struct dtx_leader_handle *dlh, struct ds_cont_child *cont,
 	if (result < 0 || rc < 0 || dth->dth_solo)
 		D_GOTO(abort, result = result < 0 ? result : rc);
 
-	if (!dth->dth_active && !dth->dth_resent) {
+	if (!dth->dth_active || dth->dth_resent) {
 		/* We do not know whether some other participants have
 		 * some active entry for this DTX, consider distributed
 		 * transaction case, the other participants may execute

--- a/src/dtx/dtx_cos.c
+++ b/src/dtx/dtx_cos.c
@@ -470,7 +470,11 @@ out:
 		rc = dbtree_delete(cont->sc_dtx_cos_hdl, BTR_PROBE_EQ,
 				   &kiov, NULL);
 
-	D_CDEBUG(rc != 0, DLOG_ERR, DB_IO, "Remove DTX "DF_DTI" from CoS "
+	if (rc == 0 && found == 0)
+		rc = -DER_NONEXIST;
+
+	D_CDEBUG(rc != 0 && rc != -DER_NONEXIST, DLOG_ERR, DB_IO,
+		 "Remove DTX "DF_DTI" from CoS "
 		 "cache, "DF_UOID", key %lu, %s shared entry: rc = "DF_RC"\n",
 		 DP_DTI(xid), DP_UOID(*oid), (unsigned long)dkey_hash,
 		 found == 1 ? "has" : "has not", DP_RC(rc));


### PR DESCRIPTION
For resent modifcation, the DTX entry on the leader has existed,
current IO handler will not initialize dth->dth_dkey_hash under
such case, then cannot use it to add the DTX into the CoS cache.
Otherwise, such DTX entry in the CoS cannot be removed later as
to trigger assertion during dtx_flush_on_deregister().

On the other hand, sync committing DTX entry for resent IO also
avoid adding the DTX into CoS cache repeatedly.

Signed-off-by: Fan Yong <fan.yong@intel.com>