### PR TITLE
DAOS-6475 dtx: distinct csummer for checksum calculations

### DIFF
--- a/src/common/checksum.c
+++ b/src/common/checksum.c
@@ -61,6 +61,8 @@ daos_csummer_init(struct daos_csummer **obj, struct hash_ft *ft,
 
 	if (rc == 0)
 		*obj = result;
+	else
+		D_FREE(result);
 
 	return rc;
 }

--- a/src/object/obj_tx.c
+++ b/src/object/obj_tx.c
@@ -1485,6 +1485,7 @@ dc_tx_commit_prepare(struct dc_tx *tx, tse_task_t *task)
 {
 	daos_unit_oid_t			 leader_oid = { 0 };
 	struct daos_csummer		*csummer;
+	struct daos_csummer		*csummer_cop = NULL;
 	struct dc_tx_req_group		*dtrgs = NULL;
 	struct daos_cpd_sub_head	*dcsh = NULL;
 	struct daos_cpd_disp_ent	*dcdes = NULL;
@@ -1511,6 +1512,12 @@ dc_tx_commit_prepare(struct dc_tx *tx, tse_task_t *task)
 
 	D_INIT_LIST_HEAD(&dtr_list);
 	csummer = dc_cont_hdl2csummer(tx->tx_coh);
+	if (daos_csummer_initialized(csummer)) {
+		csummer_cop = daos_csummer_copy(csummer);
+		if (csummer_cop == NULL)
+			return -DER_NOMEM;
+	}
+
 	req_cnt = tx->tx_read_cnt + tx->tx_write_cnt;
 	tgt_cnt = pool_map_target_nr(tx->tx_pool->dp_map);
 	D_ASSERT(tgt_cnt != 0);
@@ -1525,7 +1532,7 @@ dc_tx_commit_prepare(struct dc_tx *tx, tse_task_t *task)
 		obj = dcsr->dcsr_obj;
 
 		if (dcsr->dcsr_opc == DCSO_UPDATE) {
-			rc = dc_tx_classify_update(tx, dcsr, csummer);
+			rc = dc_tx_classify_update(tx, dcsr, csummer_cop);
 			if (rc < 0)
 				goto out;
 
@@ -1752,6 +1759,7 @@ out:
 		D_FREE(dtr);
 
 	D_FREE(dtrgs);
+	daos_csummer_destroy(&csummer_cop);
 
 	return rc < 0 ? rc : 0;
 }


### PR DESCRIPTION
There is race when multiple tasks calculate checksum. It appeares
that the tasks may stomp on each others checksum buffer, and then
send the incorrect checksum to the server. Creating a copy of the
csummer on the client for calculating checksums to the issue.

Signed-off-by: Fan Yong <fan.yong@intel.com>