### PR TITLE
DAOS-6499 vos: save DTX modified obj in DRAM instead of PMEM

### DIFF
--- a/src/vos/vos_dtx.c
+++ b/src/vos/vos_dtx.c
@@ -48,7 +48,7 @@ enum {
 };
 
 #define DTX_UMOFF_TYPES		(DTX_UMOFF_ILOG | DTX_UMOFF_SVT | DTX_UMOFF_EVT)
-#define DTX_INDEX_INVAL		(int16_t)(-1)
+#define DTX_INDEX_INVAL		(int32_t)(-1)
 
 static inline void
 dtx_type2umoff_flag(umem_off_t *rec, uint32_t type)
@@ -215,15 +215,15 @@ dtx_act_ent_cleanup(struct vos_container *cont, struct vos_dtx_act_ent *dae,
 	if (!evict)
 		return;
 
-	if (DAE_OID_CNT(dae) == 0) {
+	if (dae->dae_oid_cnt == 0) {
 		oids = &DAE_OID(dae);
 		max = 1;
-	} else if (DAE_OID_CNT(dae) == 1) {
-		oids = &DAE_OID_INLINE(dae);
+	} else if (dae->dae_oid_cnt == 1) {
+		oids = &dae->dae_oid_inline;
 		max = 1;
 	} else {
-		oids = umem_off2ptr(vos_cont2umm(cont), DAE_OID_OFF(dae));
-		max = DAE_OID_CNT(dae);
+		oids = dae->dae_oids;
+		max = dae->dae_oid_cnt;
 	}
 
 	for (i = 0; i < max; i++)
@@ -361,6 +361,11 @@ dtx_cmt_ent_free(struct btr_instance *tins, struct btr_record *rec,
 	dce = umem_off2ptr(&tins->ti_umm, rec->rec_off);
 	D_ASSERT(dce != NULL);
 
+	if (dce->dce_oid_cnt > 1) {
+		D_FREE(dce->dce_oids);
+		dce->dce_oid_cnt = 0;
+	}
+
 	rec->rec_off = UMOFF_NULL;
 	d_list_del(&dce->dce_committed_link);
 	if (!cont->vc_reindex_cmt_dtx || dce->dce_reindex)
@@ -451,7 +456,6 @@ vos_dtx_table_destroy(struct umem_instance *umm, struct vos_cont_df *cont_df)
 {
 	struct vos_dtx_blob_df		*dbd;
 	struct vos_dtx_act_ent_df	*dae_df;
-	struct vos_dtx_cmt_ent_df	*dce_df;
 	umem_off_t			 dbd_off;
 	int				 i;
 	int				 rc;
@@ -466,16 +470,6 @@ vos_dtx_table_destroy(struct umem_instance *umm, struct vos_cont_df *cont_df)
 	while (!umoff_is_null(cont_df->cd_dtx_committed_head)) {
 		dbd_off = cont_df->cd_dtx_committed_head;
 		dbd = umem_off2ptr(umm, dbd_off);
-
-		for (i = 0; i < dbd->dbd_count; i++) {
-			dce_df = &dbd->dbd_committed_data[i];
-			if (!umoff_is_null(dce_df->dce_oid_off)) {
-				rc = umem_free(umm, dce_df->dce_oid_off);
-				if (rc != 0)
-					return rc;
-			}
-		}
-
 		cont_df->cd_dtx_committed_head = dbd->dbd_next;
 		rc = umem_free(umm, dbd_off);
 		if (rc != 0)
@@ -508,12 +502,6 @@ vos_dtx_table_destroy(struct umem_instance *umm, struct vos_cont_df *cont_df)
 				if (!umoff_is_null(dae_df->dae_mbs_off)) {
 					rc = umem_free(umm,
 						       dae_df->dae_mbs_off);
-					if (rc != 0)
-						return rc;
-				}
-				if (dae_df->dae_oid_cnt > 1) {
-					rc = umem_free(umm,
-						       dae_df->dae_oid_off);
 					if (rc != 0)
 						return rc;
 				}
@@ -657,17 +645,16 @@ dtx_rec_release(struct vos_container *cont, struct vos_dtx_act_ent *dae,
 	if (dae->dae_dbd == NULL)
 		return 0;
 
+	if (dae->dae_oid_cnt > 1) {
+		D_FREE(dae->dae_oids);
+		dae->dae_oid_cnt = 0;
+	}
+
 	dbd = dae->dae_dbd;
 	D_ASSERT(dbd->dbd_magic == DTX_ACT_BLOB_MAGIC);
 
 	dae_df = umem_off2ptr(umm, dae->dae_df_off);
 	D_ASSERT(dae_df != NULL);
-
-	if (DAE_OID_CNT(dae) > 1 && abort) {
-		rc = umem_free(umm, dae_df->dae_oid_off);
-		if (rc != 0)
-			return rc;
-	}
 
 	if (!umoff_is_null(dae_df->dae_mbs_off)) {
 		/* dae_mbs_off will be invalid via flag DTE_INVALID. */
@@ -828,10 +815,8 @@ vos_dtx_commit_one(struct vos_container *cont, struct dtx_id *dti,
 
 			rc = dbtree_delete(cont->vc_dtx_active_hdl,
 					   BTR_PROBE_BYPASS, &kiov, &dae);
-			if (rc == 0) {
-				dtx_act_ent_cleanup(cont, dae, false);
+			if (rc == 0)
 				dtx_evict_lid(cont, dae);
-			}
 
 			goto out;
 		}
@@ -844,22 +829,11 @@ vos_dtx_commit_one(struct vos_container *cont, struct dtx_id *dti,
 	if (dae != NULL) {
 		memcpy(&dce->dce_base.dce_common, &dae->dae_base.dae_common,
 		       sizeof(dce->dce_base.dce_common));
-		if (DAE_OID_CNT(dae) == 1) {
-			/* Overwrite DCE_OID if modify single object. */
-			DCE_OID(dce) = DAE_OID_INLINE(dae);
-			/* The dec_dkey_hash is the real dkey hash. */
-			DCE_DKEY_HASH(dce) = DAE_DKEY_HASH(dae);
-		} else if (DAE_OID_CNT(dae) > 1) {
-			/* Take over the OID_OFF from active entry. */
-			DCE_OID_OFF(dce) = DAE_OID_OFF(dae);
-			/* Reuse dec_dkey_hash as the OID count. */
-			DCE_OID_CNT(dce) = DAE_OID_CNT(dae);
-		} else {
-			/* Only the leader_oid is modified by the DTX.
-			 * The dec_dkey_hash is the real dkey hash.
-			 */
-			DCE_DKEY_HASH(dce) = DAE_DKEY_HASH(dae);
-		}
+		/* Take over OIDs buffer. */
+		dce->dce_oid_cnt = dae->dae_oid_cnt;
+		dce->dce_oids = dae->dae_oids;
+		dae->dae_oid_cnt = 0;
+		dae->dae_oids = NULL;
 	} else {
 		struct dtx_handle	*dth = vos_dth_get();
 
@@ -867,45 +841,34 @@ vos_dtx_commit_one(struct vos_container *cont, struct dtx_id *dti,
 
 		DCE_XID(dce) = *dti;
 		DCE_EPOCH(dce) = epoch;
-		if (dth->dth_oid_array != NULL) {
-			if (dth->dth_oid_cnt == 1) {
-				DCE_OID(dce) = dth->dth_oid_array[0];
-				/* The dec_dkey_hash is the real dkey hash. */
-				DCE_DKEY_HASH(dce) = dth->dth_dkey_hash;
-			} else {
-				struct umem_instance	*umm;
-				size_t			 size;
-				umem_off_t		 rec_off;
+		DCE_OID(dce) = dth->dth_leader_oid;
+		DCE_DKEY_HASH(dce) = dth->dth_dkey_hash;
+		dce->dce_oid_cnt = dth->dth_oid_cnt;
 
-				umm = vos_cont2umm(cont);
-				size = sizeof(daos_unit_oid_t) *
-					dth->dth_oid_cnt;
-				rec_off = umem_zalloc(umm, size);
+		if (dth->dth_oid_array == NULL)
+			goto insert;
 
-				if (umoff_is_null(rec_off)) {
-					D_ERROR("No space to store CMT DTX OID "
-						DF_DTI"\n", DP_DTI(dti));
-					*fatal = true;
-					D_GOTO(out, rc = -DER_NOSPACE);
-				}
-
-				memcpy(umem_off2ptr(umm, rec_off),
-				       dth->dth_oid_array, size);
-				DCE_OID_OFF(dce) = rec_off;
-				/* Reuse dec_dkey_hash as the OID count. */
-				DCE_OID_CNT(dce) = dth->dth_oid_cnt;
-			}
+		if (dth->dth_oid_cnt == 1) {
+			dce->dce_oid_inline = dth->dth_oid_array[0];
 		} else {
-			D_ASSERT(dth->dth_oid_cnt == 0);
+			int size = sizeof(daos_unit_oid_t) * dth->dth_oid_cnt;
 
-			DCE_OID(dce) = dth->dth_leader_oid;
-			/* The dec_dkey_hash is the real dkey hash. */
-			DCE_DKEY_HASH(dce) = dth->dth_dkey_hash;
+			D_ASSERT(dth->dth_oid_cnt > 1);
+
+			D_ALLOC(dce->dce_oids, size);
+			if (dce->dce_oids == NULL) {
+				/* Not fatal. */
+				D_WARN("No DRAM to store CMT DTX OIDs "
+				       DF_DTI"\n", DP_DTI(dti));
+				dce->dce_oid_cnt = 0;
+				goto insert;
+			}
+
+			memcpy(dce->dce_oids, dth->dth_oid_array, size);
 		}
 	}
 
-	dce->dce_reindex = 0;
-
+insert:
 	d_iov_set(&riov, dce, sizeof(*dce));
 	rc = dbtree_upsert(cont->vc_dtx_committed_hdl, BTR_PROBE_EQ,
 			   DAOS_INTENT_UPDATE, &kiov, &riov);
@@ -931,8 +894,11 @@ out:
 		 "Commit the DTX "DF_DTI": rc = "DF_RC"\n",
 		 DP_DTI(dti), DP_RC(rc));
 	if (rc != 0) {
-		if (dce != NULL)
+		if (dce != NULL) {
+			if (dce->dce_oid_cnt > 1)
+				D_FREE(dce->dce_oids);
 			D_FREE_PTR(dce);
+		}
 	} else {
 		*dce_p = dce;
 	}
@@ -964,16 +930,14 @@ vos_dtx_abort_one(struct vos_container *cont, daos_epoch_t epoch,
 		D_GOTO(out, rc = -DER_NONEXIST);
 	}
 
-	/* It has been committed before, but failed to be removed
+	/* It has been aborted before, but failed to be removed
 	 * from the active table, just remove it again.
 	 */
 	if (dae->dae_aborted) {
 		rc = dbtree_delete(cont->vc_dtx_active_hdl,
 				   BTR_PROBE_BYPASS, &kiov, &dae);
-		if (rc == 0) {
-			dtx_act_ent_cleanup(cont, dae, false);
+		if (rc == 0)
 			dtx_evict_lid(cont, dae);
-		}
 
 		goto out;
 	}
@@ -1627,25 +1591,26 @@ vos_dtx_prepared(struct dtx_handle *dth)
 	    (dth->dth_modification_cnt > 0))
 		dth->dth_sync = 1;
 
-	DAE_OID_CNT(dae) = dth->dth_oid_cnt;
+	dae->dae_oid_cnt = dth->dth_oid_cnt;
 	if (dth->dth_oid_array != NULL) {
 		D_ASSERT(dth->dth_oid_cnt != 0);
 
 		if (dth->dth_oid_cnt == 1) {
-			DAE_OID_INLINE(dae) = dth->dth_oid_array[0];
+			dae->dae_oid_inline = dth->dth_oid_array[0];
 		} else {
-			size = sizeof(daos_unit_oid_t) * dth->dth_oid_cnt;
+			int size = sizeof(daos_unit_oid_t) * dth->dth_oid_cnt;
 
-			rec_off = umem_zalloc(umm, size);
-			if (umoff_is_null(rec_off)) {
-				D_ERROR("No space to store DTX OIDs "DF_DTI"\n",
-					DP_DTI(&DAE_XID(dae)));
-				return -DER_NOSPACE;
+			D_ASSERT(dth->dth_oid_cnt > 1);
+
+			D_ALLOC_ARRAY(dae->dae_oids, size);
+			if (dae->dae_oids == NULL) {
+				/* Not fatal. */
+				D_WARN("No DRAM to store ACT DTX OIDs "
+				       DF_DTI"\n", DP_DTI(&DAE_XID(dae)));
+				dth->dth_oid_cnt = 0;
+			} else {
+				memcpy(dae->dae_oids, dth->dth_oid_array, size);
 			}
-
-			memcpy(umem_off2ptr(umm, rec_off),
-			       dth->dth_oid_array, size);
-			DAE_OID_OFF(dae) = rec_off;
 		}
 	}
 
@@ -2019,10 +1984,13 @@ vos_dtx_post_handle(struct vos_container *cont, struct vos_dtx_act_ent **daes,
 			D_WARN("Cannot remove DTX "DF_DTI" from active table: "
 			       DF_RC"\n", DP_DTI(&DAE_XID(daes[i])), DP_RC(rc));
 
-			if (abort)
+			if (abort) {
 				daes[i]->dae_aborted = 1;
-			else
+				dtx_act_ent_cleanup(cont, daes[i], true);
+			} else {
 				daes[i]->dae_committed = 1;
+				dtx_act_ent_cleanup(cont, daes[i], false);
+			}
 			DAE_FLAGS(daes[i]) &= ~DTE_CORRUPTED;
 		}
 	}
@@ -2141,21 +2109,12 @@ vos_dtx_aggregate(daos_handle_t coh)
 	     !d_list_empty(&cont->vc_dtx_committed_list); i++) {
 		struct vos_dtx_cmt_ent	*dce;
 		d_iov_t			 kiov;
-		umem_off_t		 umoff;
 
 		dce = d_list_entry(cont->vc_dtx_committed_list.next,
 				   struct vos_dtx_cmt_ent, dce_committed_link);
-		umoff = DCE_OID_OFF(dce);
 		d_iov_set(&kiov, &DCE_XID(dce), sizeof(DCE_XID(dce)));
 		dbtree_delete(cont->vc_dtx_committed_hdl, BTR_PROBE_EQ,
 			      &kiov, NULL);
-
-		if (!umoff_is_null(umoff)) {
-			rc = umem_free(umm, umoff);
-			if (rc != 0)
-				D_WARN("Failed to release OIDs array "DF_RC"\n",
-				       DP_RC(rc));
-		}
 	}
 
 	tmp = umem_off2ptr(umm, dbd->dbd_next);

--- a/src/vos/vos_layout.h
+++ b/src/vos/vos_layout.h
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2020 Intel Corporation.
+ * (C) Copyright 2016-2021 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -105,7 +105,7 @@ enum vos_gc_type {
 #define POOL_DF_MAGIC				0x5ca1ab1e
 
 #define POOL_DF_VER_1				1
-#define POOL_DF_VERSION				12
+#define POOL_DF_VERSION				13
 
 /**
  * Durable format for VOS pool
@@ -170,12 +170,6 @@ struct vos_dtx_cmt_ent_df {
 	 * objects' OIDs are stored via 'dce_oid_off'.
 	 */
 	struct vos_dtx_ent_common	dce_common;
-	/**
-	 * The offset for the objects' OID if more than one are modified.
-	 * Under such case, 'dce_common.dec_dkey_hash' is used as the count
-	 * of objects' IDs.
-	 */
-	umem_off_t			dce_oid_off;
 };
 
 #define dce_xid		dce_common.dec_xid
@@ -206,18 +200,8 @@ struct vos_dtx_act_ent_df {
 	uint32_t			dae_grp_cnt;
 	/** Size of the area for dae_mbs_off. */
 	uint32_t			dae_mbs_dsize;
-	/**
-	 * The count of objects that are modified by this DTX.
-	 *
-	 * If single object is modified and if it is the same as the
-	 * 'dae_oid', then 'dae_oid_cnt' is zero.
-	 *
-	 * If the single object is differet from 'dae_oid', then the
-	 * 'dae_oid_cnt' is 1, its OID is stored in 'dae_oid_inline'.
-	 */
-	uint16_t			dae_oid_cnt;
 	/** The index in the current vos_dtx_blob_df. */
-	int16_t				dae_index;
+	int32_t				dae_index;
 	/**
 	 * The inline DTX targets, can hold 3-way replicas for single
 	 * RDG that does not contains the original leader information.
@@ -225,12 +209,6 @@ struct vos_dtx_act_ent_df {
 	struct dtx_daos_target		dae_mbs_inline[2];
 	/** The offset for the dtx mbs if out of inline. */
 	umem_off_t			dae_mbs_off;
-	union {
-		/** Hold the object'x OID if different from dae_oid. */
-		daos_unit_oid_t		dae_oid_inline;
-		/** The offset for objects' OIDs if out of inline case. */
-		umem_off_t		dae_oid_off;
-	};
 };
 
 #define dae_xid		dae_common.dec_xid


### PR DESCRIPTION
Originally, we saved the OIDs of the objects that are modified
by the DTX in PMEM. These OIDs will speed-up EC aggregation.
But EC aggregation does not depends on that, only optimization.
So saving them in DRAM is enough. Then it can reduce the space
overhead caused by the DTX entry (both actived and committed).

On the other hand, it also avoids some potential bugs caused by
reusing some committed DTX entry fields that was for saving the
OIDs in PMEM.

Signed-off-by: Fan Yong <fan.yong@intel.com>