### PR TITLE
DAOS-6499 dtx: handle resent RPC properly

### DIFF
--- a/src/vos/vos_dtx.c
+++ b/src/vos/vos_dtx.c
@@ -311,11 +311,14 @@ dtx_act_ent_update(struct btr_instance *tins, struct btr_record *rec,
 	struct vos_dtx_act_ent	*dae_old;
 
 	dae_old = umem_off2ptr(&tins->ti_umm, rec->rec_off);
-	if (DAE_EPOCH(dae_old) != DAE_EPOCH(dae_new))
-		D_ASSERTF(0, "NOT allow to update act DTX entry for "DF_DTI
+	if (DAE_EPOCH(dae_old) != DAE_EPOCH(dae_new)) {
+		D_ASSERTF(!dae_old->dae_prepared,
+			  "NOT allow to update act DTX entry for "DF_DTI
 			  " from epoch "DF_X64" to "DF_X64"\n",
 			  DP_DTI(&DAE_XID(dae_old)),
 			  DAE_EPOCH(dae_old), DAE_EPOCH(dae_new));
+		return -DER_INPROGRESS;
+	}
 
 	return 0;
 }
@@ -1700,6 +1703,8 @@ vos_dtx_prepared(struct dtx_handle *dth)
 	dbd->dbd_count++;
 	dbd->dbd_index++;
 
+	dae->dae_prepared = 1;
+
 	return 0;
 }
 
@@ -1781,7 +1786,10 @@ vos_dtx_check(daos_handle_t coh, struct dtx_id *dti, daos_epoch_t *epoch,
 				return -DER_MISMATCH;
 		}
 
-		return DTX_ST_PREPARED;
+		if (dae->dae_prepared || !for_resent)
+			return DTX_ST_PREPARED;
+
+		return -DER_NONEXIST;
 	}
 
 	if (rc == -DER_NONEXIST) {

--- a/src/vos/vos_internal.h
+++ b/src/vos/vos_internal.h
@@ -242,7 +242,8 @@ struct vos_dtx_act_ent {
 	unsigned int			 dae_committable:1,
 					 dae_committed:1,
 					 dae_aborted:1,
-					 dae_maybe_shared:1;
+					 dae_maybe_shared:1,
+					 dae_prepared:1;
 };
 
 extern struct vos_tls	*standalone_tls;


### PR DESCRIPTION
To handle the race from DTX refresh, the leader will pre-create
the DTX entry in DRAM before dispatching related modifications.
If such pre-created DTX entry was found by the resent handling
logic before leader prepared related local modifications, then
it should not be regarded as 'prepared' locally; instead, under
such case, related RPC needs to be handled as a new RPC on the
leader, and then dtx_leader_begin will find former non-prepared
DTX entry (that is in processing), then reply "-DER_INPROGRESS"
to the client.

Signed-off-by: Fan Yong <fan.yong@intel.com>