### PR TITLE
CART-89 logs: Change log mask to be less verbose on cart tests

### DIFF
--- a/src/tests/ftest/cart/corpc/cart_corpc_five_node.yaml
+++ b/src/tests/ftest/cart/corpc/cart_corpc_five_node.yaml
@@ -4,7 +4,7 @@
 defaultENV:
   #!filter-only : /run/envs_CRT_CTX_SHARE_ADDR/no_sep
   #!filter-only : /run/tests/corpc_prefwd
-  D_LOG_MASK: "WARN,RPC=DEBUG,HG=DEBUG"
+  D_LOG_MASK: "WARN,CORPC=DEBUG"
   CRT_PHY_ADDR_STR: "ofi+sockets"
   OFI_INTERFACE: "eth0"
   test_servers_CRT_CTX_NUM: "0"

--- a/src/tests/ftest/cart/corpc/cart_corpc_five_node.yaml
+++ b/src/tests/ftest/cart/corpc/cart_corpc_five_node.yaml
@@ -4,7 +4,7 @@
 defaultENV:
   #!filter-only : /run/envs_CRT_CTX_SHARE_ADDR/no_sep
   #!filter-only : /run/tests/corpc_prefwd
-  D_LOG_MASK: "DEBUG,MEM=ERR"
+  D_LOG_MASK: "ERR,RPC=DEBUG,HG=DEBUG"
   CRT_PHY_ADDR_STR: "ofi+sockets"
   OFI_INTERFACE: "eth0"
   test_servers_CRT_CTX_NUM: "0"

--- a/src/tests/ftest/cart/corpc/cart_corpc_five_node.yaml
+++ b/src/tests/ftest/cart/corpc/cart_corpc_five_node.yaml
@@ -4,7 +4,7 @@
 defaultENV:
   #!filter-only : /run/envs_CRT_CTX_SHARE_ADDR/no_sep
   #!filter-only : /run/tests/corpc_prefwd
-  D_LOG_MASK: "ERR,RPC=DEBUG,HG=DEBUG"
+  D_LOG_MASK: "WARN,RPC=DEBUG,HG=DEBUG"
   CRT_PHY_ADDR_STR: "ofi+sockets"
   OFI_INTERFACE: "eth0"
   test_servers_CRT_CTX_NUM: "0"

--- a/src/tests/ftest/cart/corpc/cart_corpc_one_node.yaml
+++ b/src/tests/ftest/cart/corpc/cart_corpc_one_node.yaml
@@ -4,7 +4,7 @@
 defaultENV:
   #!filter-only : /run/envs_CRT_CTX_SHARE_ADDR/sep
   #!filter-only : /run/tests/corpc_prefwd
-  D_LOG_MASK: "ERR,RPC=DEBUG,HG=DEBUG"
+  D_LOG_MASK: "WARN,RPC=DEBUG,HG=DEBUG"
   CRT_PHY_ADDR_STR: "ofi+sockets"
   OFI_INTERFACE: "eth0"
   test_servers_CRT_CTX_NUM: "16"

--- a/src/tests/ftest/cart/corpc/cart_corpc_one_node.yaml
+++ b/src/tests/ftest/cart/corpc/cart_corpc_one_node.yaml
@@ -4,7 +4,7 @@
 defaultENV:
   #!filter-only : /run/envs_CRT_CTX_SHARE_ADDR/sep
   #!filter-only : /run/tests/corpc_prefwd
-  D_LOG_MASK: "ERR"
+  D_LOG_MASK: "ERR,RPC=DEBUG,HG=DEBUG"
   CRT_PHY_ADDR_STR: "ofi+sockets"
   OFI_INTERFACE: "eth0"
   test_servers_CRT_CTX_NUM: "16"

--- a/src/tests/ftest/cart/corpc/cart_corpc_one_node.yaml
+++ b/src/tests/ftest/cart/corpc/cart_corpc_one_node.yaml
@@ -4,7 +4,7 @@
 defaultENV:
   #!filter-only : /run/envs_CRT_CTX_SHARE_ADDR/sep
   #!filter-only : /run/tests/corpc_prefwd
-  D_LOG_MASK: "WARN,RPC=DEBUG,HG=DEBUG"
+  D_LOG_MASK: "WARN,CORPC=DEBUG"
   CRT_PHY_ADDR_STR: "ofi+sockets"
   OFI_INTERFACE: "eth0"
   test_servers_CRT_CTX_NUM: "16"

--- a/src/tests/ftest/cart/corpc/cart_corpc_two_node.yaml
+++ b/src/tests/ftest/cart/corpc/cart_corpc_two_node.yaml
@@ -4,7 +4,7 @@
 defaultENV:
   #!filter-only : /run/envs_CRT_CTX_SHARE_ADDR/sep
   #!filter-only : /run/tests/corpc_prefwd
-  D_LOG_MASK: "ERR,RPC=DEBUG,HG=DEBUG"
+  D_LOG_MASK: "WARN,RPC=DEBUG,HG=DEBUG"
   CRT_PHY_ADDR_STR: "ofi+sockets"
   OFI_INTERFACE: "eth0"
   test_servers_CRT_CTX_NUM: "16"

--- a/src/tests/ftest/cart/corpc/cart_corpc_two_node.yaml
+++ b/src/tests/ftest/cart/corpc/cart_corpc_two_node.yaml
@@ -4,7 +4,7 @@
 defaultENV:
   #!filter-only : /run/envs_CRT_CTX_SHARE_ADDR/sep
   #!filter-only : /run/tests/corpc_prefwd
-  D_LOG_MASK: "WARN,RPC=DEBUG,HG=DEBUG"
+  D_LOG_MASK: "WARN,CORPC=DEBUG"
   CRT_PHY_ADDR_STR: "ofi+sockets"
   OFI_INTERFACE: "eth0"
   test_servers_CRT_CTX_NUM: "16"

--- a/src/tests/ftest/cart/corpc/cart_corpc_two_node.yaml
+++ b/src/tests/ftest/cart/corpc/cart_corpc_two_node.yaml
@@ -4,7 +4,7 @@
 defaultENV:
   #!filter-only : /run/envs_CRT_CTX_SHARE_ADDR/sep
   #!filter-only : /run/tests/corpc_prefwd
-  D_LOG_MASK: "DEBUG,MEM=ERR"
+  D_LOG_MASK: "ERR,RPC=DEBUG,HG=DEBUG"
   CRT_PHY_ADDR_STR: "ofi+sockets"
   OFI_INTERFACE: "eth0"
   test_servers_CRT_CTX_NUM: "16"

--- a/src/tests/ftest/cart/ctl/cart_ctl_five_node.yaml
+++ b/src/tests/ftest/cart/ctl/cart_ctl_five_node.yaml
@@ -4,7 +4,7 @@
 defaultENV:
   #!filter-only : /run/env_CRT_CTX_SHARE_ADDR/sep
   #!filter-only : /run/tests/ctl
-  D_LOG_MASK: "WARN,RPC=DEBUG,HG=DEBUG"
+  D_LOG_MASK: "WARN"
   CRT_PHY_ADDR_STR: "ofi+sockets"
   OFI_INTERFACE: "eth0"
   test_servers_CRT_CTX_NUM: "0"

--- a/src/tests/ftest/cart/ctl/cart_ctl_five_node.yaml
+++ b/src/tests/ftest/cart/ctl/cart_ctl_five_node.yaml
@@ -4,7 +4,7 @@
 defaultENV:
   #!filter-only : /run/env_CRT_CTX_SHARE_ADDR/sep
   #!filter-only : /run/tests/ctl
-  D_LOG_MASK: "ERR,RPC=DEBUG,HG=DEBUG"
+  D_LOG_MASK: "WARN,RPC=DEBUG,HG=DEBUG"
   CRT_PHY_ADDR_STR: "ofi+sockets"
   OFI_INTERFACE: "eth0"
   test_servers_CRT_CTX_NUM: "0"

--- a/src/tests/ftest/cart/ctl/cart_ctl_five_node.yaml
+++ b/src/tests/ftest/cart/ctl/cart_ctl_five_node.yaml
@@ -4,7 +4,7 @@
 defaultENV:
   #!filter-only : /run/env_CRT_CTX_SHARE_ADDR/sep
   #!filter-only : /run/tests/ctl
-  D_LOG_MASK: "DEBUG,MEM=ERR"
+  D_LOG_MASK: "ERR,RPC=DEBUG,HG=DEBUG"
   CRT_PHY_ADDR_STR: "ofi+sockets"
   OFI_INTERFACE: "eth0"
   test_servers_CRT_CTX_NUM: "0"

--- a/src/tests/ftest/cart/ctl/cart_ctl_one_node.yaml
+++ b/src/tests/ftest/cart/ctl/cart_ctl_one_node.yaml
@@ -4,7 +4,7 @@
 defaultENV:
   #!filter-only : /run/env_CRT_CTX_SHARE_ADDR/sep
   #!filter-only : /run/tests/ctl
-  D_LOG_MASK: "WARN,RPC=DEBUG,HG=DEBUG"
+  D_LOG_MASK: "WARN"
   CRT_PHY_ADDR_STR: "ofi+sockets"
   OFI_INTERFACE: "eth0"
   test_servers_CRT_CTX_NUM: "16"

--- a/src/tests/ftest/cart/ctl/cart_ctl_one_node.yaml
+++ b/src/tests/ftest/cart/ctl/cart_ctl_one_node.yaml
@@ -4,7 +4,7 @@
 defaultENV:
   #!filter-only : /run/env_CRT_CTX_SHARE_ADDR/sep
   #!filter-only : /run/tests/ctl
-  D_LOG_MASK: "ERR,RPC=DEBUG,HG=DEBUG"
+  D_LOG_MASK: "WARN,RPC=DEBUG,HG=DEBUG"
   CRT_PHY_ADDR_STR: "ofi+sockets"
   OFI_INTERFACE: "eth0"
   test_servers_CRT_CTX_NUM: "16"

--- a/src/tests/ftest/cart/ctl/cart_ctl_one_node.yaml
+++ b/src/tests/ftest/cart/ctl/cart_ctl_one_node.yaml
@@ -4,7 +4,7 @@
 defaultENV:
   #!filter-only : /run/env_CRT_CTX_SHARE_ADDR/sep
   #!filter-only : /run/tests/ctl
-  D_LOG_MASK: "DEBUG,MEM=ERR"
+  D_LOG_MASK: "ERR,RPC=DEBUG,HG=DEBUG"
   CRT_PHY_ADDR_STR: "ofi+sockets"
   OFI_INTERFACE: "eth0"
   test_servers_CRT_CTX_NUM: "16"

--- a/src/tests/ftest/cart/ghost_rank_rpc/cart_ghost_rank_prc_one_node.yaml
+++ b/src/tests/ftest/cart/ghost_rank_rpc/cart_ghost_rank_prc_one_node.yaml
@@ -4,7 +4,7 @@
 defaultENV:
   #!filter-only : /run/envs_CRT_CTX_SHARE_ADDR/sep
   #!filter-only : /run/tests/corpc_prefwd
-  D_LOG_MASK: "ERR,RPC=DEBUG,HG=DEBUG"
+  D_LOG_MASK: "WARN,RPC=DEBUG,HG=DEBUG"
   CRT_PHY_ADDR_STR: "ofi+sockets"
   OFI_INTERFACE: "eth0"
   test_servers_CRT_CTX_NUM: "16"

--- a/src/tests/ftest/cart/ghost_rank_rpc/cart_ghost_rank_prc_one_node.yaml
+++ b/src/tests/ftest/cart/ghost_rank_rpc/cart_ghost_rank_prc_one_node.yaml
@@ -4,7 +4,7 @@
 defaultENV:
   #!filter-only : /run/envs_CRT_CTX_SHARE_ADDR/sep
   #!filter-only : /run/tests/corpc_prefwd
-  D_LOG_MASK: "DEBUG,MEM=ERR"
+  D_LOG_MASK: "ERR,RPC=DEBUG,HG=DEBUG"
   CRT_PHY_ADDR_STR: "ofi+sockets"
   OFI_INTERFACE: "eth0"
   test_servers_CRT_CTX_NUM: "16"

--- a/src/tests/ftest/cart/group_test/group_test.yaml
+++ b/src/tests/ftest/cart/group_test/group_test.yaml
@@ -3,9 +3,9 @@
 
 defaultENV:
   #!filter-only : /run/tests/no_pmix_launcher
+  D_LOG_MASK: "ERR,RPC=DEBUG,HG=DEBUG"
   CRT_PHY_ADDR_STR: "ofi+sockets"
   OFI_INTERFACE: "eth0"
-  D_LOG_MASK: "ERR"
 hosts: !mux
   hosts_1:
     config: one_node

--- a/src/tests/ftest/cart/group_test/group_test.yaml
+++ b/src/tests/ftest/cart/group_test/group_test.yaml
@@ -3,7 +3,7 @@
 
 defaultENV:
   #!filter-only : /run/tests/no_pmix_launcher
-  D_LOG_MASK: "ERR,RPC=DEBUG,HG=DEBUG"
+  D_LOG_MASK: "WARN,RPC=DEBUG,HG=DEBUG"
   CRT_PHY_ADDR_STR: "ofi+sockets"
   OFI_INTERFACE: "eth0"
 hosts: !mux

--- a/src/tests/ftest/cart/iv/cart_iv_one_node.yaml
+++ b/src/tests/ftest/cart/iv/cart_iv_one_node.yaml
@@ -4,7 +4,7 @@
 defaultENV:
   #!filter-only : /run/env_CRT_CTX_SHARE_ADDR/no_sep
   #!filter-only : /run/tests/iv
-  D_LOG_MASK: "DEBUG,MEM=ERR"
+  D_LOG_MASK: "ERR,RPC=DEBUG,HG=DEBUG"
   CRT_PHY_ADDR_STR: "ofi+sockets"
   OFI_INTERFACE: "eth0"
   test_servers_CRT_CTX_NUM: "2"

--- a/src/tests/ftest/cart/iv/cart_iv_one_node.yaml
+++ b/src/tests/ftest/cart/iv/cart_iv_one_node.yaml
@@ -4,7 +4,7 @@
 defaultENV:
   #!filter-only : /run/env_CRT_CTX_SHARE_ADDR/no_sep
   #!filter-only : /run/tests/iv
-  D_LOG_MASK: "ERR,RPC=DEBUG,HG=DEBUG"
+  D_LOG_MASK: "WARN,RPC=DEBUG,HG=DEBUG"
   CRT_PHY_ADDR_STR: "ofi+sockets"
   OFI_INTERFACE: "eth0"
   test_servers_CRT_CTX_NUM: "2"

--- a/src/tests/ftest/cart/iv/cart_iv_one_node.yaml
+++ b/src/tests/ftest/cart/iv/cart_iv_one_node.yaml
@@ -4,7 +4,7 @@
 defaultENV:
   #!filter-only : /run/env_CRT_CTX_SHARE_ADDR/no_sep
   #!filter-only : /run/tests/iv
-  D_LOG_MASK: "WARN,RPC=DEBUG,HG=DEBUG"
+  D_LOG_MASK: "WARN,IV=DEBUG"
   CRT_PHY_ADDR_STR: "ofi+sockets"
   OFI_INTERFACE: "eth0"
   test_servers_CRT_CTX_NUM: "2"

--- a/src/tests/ftest/cart/iv/cart_iv_two_node.yaml
+++ b/src/tests/ftest/cart/iv/cart_iv_two_node.yaml
@@ -4,7 +4,7 @@
 defaultENV:
   #!filter-only : /run/env_CRT_CTX_SHARE_ADDR/no_sep
   #!filter-only : /run/tests/iv
-  D_LOG_MASK: "DEBUG,MEM=ERR"
+  D_LOG_MASK: "ERR,RPC=DEBUG,HG=DEBUG"
   CRT_PHY_ADDR_STR: "ofi+sockets"
   OFI_INTERFACE: "eth0"
   test_servers_CRT_CTX_NUM: "2"

--- a/src/tests/ftest/cart/iv/cart_iv_two_node.yaml
+++ b/src/tests/ftest/cart/iv/cart_iv_two_node.yaml
@@ -4,7 +4,7 @@
 defaultENV:
   #!filter-only : /run/env_CRT_CTX_SHARE_ADDR/no_sep
   #!filter-only : /run/tests/iv
-  D_LOG_MASK: "ERR,RPC=DEBUG,HG=DEBUG"
+  D_LOG_MASK: "WARN,RPC=DEBUG,HG=DEBUG"
   CRT_PHY_ADDR_STR: "ofi+sockets"
   OFI_INTERFACE: "eth0"
   test_servers_CRT_CTX_NUM: "2"

--- a/src/tests/ftest/cart/iv/cart_iv_two_node.yaml
+++ b/src/tests/ftest/cart/iv/cart_iv_two_node.yaml
@@ -4,7 +4,7 @@
 defaultENV:
   #!filter-only : /run/env_CRT_CTX_SHARE_ADDR/no_sep
   #!filter-only : /run/tests/iv
-  D_LOG_MASK: "WARN,RPC=DEBUG,HG=DEBUG"
+  D_LOG_MASK: "WARN,IV=DEBUG"
   CRT_PHY_ADDR_STR: "ofi+sockets"
   OFI_INTERFACE: "eth0"
   test_servers_CRT_CTX_NUM: "2"

--- a/src/tests/ftest/cart/no_pmix/cart_nopmix_multictx_one_node.yaml
+++ b/src/tests/ftest/cart/no_pmix/cart_nopmix_multictx_one_node.yaml
@@ -3,6 +3,7 @@
 
 defaultENV:
   #!filter-only : /run/tests/no_pmix_multi_ctx
+  D_LOG_MASK: "ERR,RPC=DEBUG,HG=DEBUG"
   CRT_PHY_ADDR_STR: "ofi+sockets"
   OFI_INTERFACE: "eth0"
   CRT_CTX_NUM: "8"

--- a/src/tests/ftest/cart/no_pmix/cart_nopmix_multictx_one_node.yaml
+++ b/src/tests/ftest/cart/no_pmix/cart_nopmix_multictx_one_node.yaml
@@ -3,7 +3,7 @@
 
 defaultENV:
   #!filter-only : /run/tests/no_pmix_multi_ctx
-  D_LOG_MASK: "WARN,RPC=DEBUG,HG=DEBUG"
+  D_LOG_MASK: "WARN"
   CRT_PHY_ADDR_STR: "ofi+sockets"
   OFI_INTERFACE: "eth0"
   CRT_CTX_NUM: "8"

--- a/src/tests/ftest/cart/no_pmix/cart_nopmix_multictx_one_node.yaml
+++ b/src/tests/ftest/cart/no_pmix/cart_nopmix_multictx_one_node.yaml
@@ -3,7 +3,7 @@
 
 defaultENV:
   #!filter-only : /run/tests/no_pmix_multi_ctx
-  D_LOG_MASK: "ERR,RPC=DEBUG,HG=DEBUG"
+  D_LOG_MASK: "WARN,RPC=DEBUG,HG=DEBUG"
   CRT_PHY_ADDR_STR: "ofi+sockets"
   OFI_INTERFACE: "eth0"
   CRT_CTX_NUM: "8"

--- a/src/tests/ftest/cart/nopmix_launcher/cart_nopmix_launcher_one_node.yaml
+++ b/src/tests/ftest/cart/nopmix_launcher/cart_nopmix_launcher_one_node.yaml
@@ -3,9 +3,9 @@
 
 defaultENV:
   #!filter-only : /run/tests/no_pmix_launcher
+  D_LOG_MASK: "ERR,RPC=DEBUG,HG=DEBUG"
   CRT_PHY_ADDR_STR: "ofi+sockets"
   OFI_INTERFACE: "eth0"
-  D_LOG_MASK: "ERR"
 hosts: !mux
   hosts_1:
     config: one_node

--- a/src/tests/ftest/cart/nopmix_launcher/cart_nopmix_launcher_one_node.yaml
+++ b/src/tests/ftest/cart/nopmix_launcher/cart_nopmix_launcher_one_node.yaml
@@ -3,7 +3,7 @@
 
 defaultENV:
   #!filter-only : /run/tests/no_pmix_launcher
-  D_LOG_MASK: "ERR,RPC=DEBUG,HG=DEBUG"
+  D_LOG_MASK: "WARN,RPC=DEBUG,HG=DEBUG"
   CRT_PHY_ADDR_STR: "ofi+sockets"
   OFI_INTERFACE: "eth0"
 hosts: !mux

--- a/src/tests/ftest/cart/nopmix_launcher/cart_nopmix_launcher_one_node.yaml
+++ b/src/tests/ftest/cart/nopmix_launcher/cart_nopmix_launcher_one_node.yaml
@@ -3,7 +3,7 @@
 
 defaultENV:
   #!filter-only : /run/tests/no_pmix_launcher
-  D_LOG_MASK: "WARN,RPC=DEBUG,HG=DEBUG"
+  D_LOG_MASK: "WARN"
   CRT_PHY_ADDR_STR: "ofi+sockets"
   OFI_INTERFACE: "eth0"
 hosts: !mux

--- a/src/tests/ftest/cart/rpc/cart_rpc_one_node.yaml
+++ b/src/tests/ftest/cart/rpc/cart_rpc_one_node.yaml
@@ -4,7 +4,7 @@
 defaultENV:
   #!filter-only : /run/env_CRT_CTX_SHARE_ADDR/sep
   #!filter-only : /run/tests/proto_np
-  D_LOG_MASK: "ERR,RPC=DEBUG,HG=DEBUG"
+  D_LOG_MASK: "WARN,RPC=DEBUG,HG=DEBUG"
   CRT_PHY_ADDR_STR: "ofi+sockets"
   OFI_INTERFACE: "eth0"
   test_servers_CRT_CTX_NUM: "16"

--- a/src/tests/ftest/cart/rpc/cart_rpc_one_node.yaml
+++ b/src/tests/ftest/cart/rpc/cart_rpc_one_node.yaml
@@ -4,7 +4,7 @@
 defaultENV:
   #!filter-only : /run/env_CRT_CTX_SHARE_ADDR/sep
   #!filter-only : /run/tests/proto_np
-  D_LOG_MASK: "DEBUG,MEM=ERR"
+  D_LOG_MASK: "ERR,RPC=DEBUG,HG=DEBUG"
   CRT_PHY_ADDR_STR: "ofi+sockets"
   OFI_INTERFACE: "eth0"
   test_servers_CRT_CTX_NUM: "16"

--- a/src/tests/ftest/cart/rpc/cart_rpc_two_node.yaml
+++ b/src/tests/ftest/cart/rpc/cart_rpc_two_node.yaml
@@ -4,7 +4,7 @@
 defaultENV:
   #!filter-only : /run/env_CRT_CTX_SHARE_ADDR/sep
   #!filter-only : /run/tests/rpc_error
-  D_LOG_MASK: "DEBUG,MEM=ERR"
+  D_LOG_MASK: "ERR,RPC=DEBUG,HG=DEBUG"
   CRT_PHY_ADDR_STR: "ofi+sockets"
   OFI_INTERFACE: "eth0"
   test_servers_CRT_CTX_NUM: "16"

--- a/src/tests/ftest/cart/rpc/cart_rpc_two_node.yaml
+++ b/src/tests/ftest/cart/rpc/cart_rpc_two_node.yaml
@@ -4,7 +4,7 @@
 defaultENV:
   #!filter-only : /run/env_CRT_CTX_SHARE_ADDR/sep
   #!filter-only : /run/tests/rpc_error
-  D_LOG_MASK: "ERR,RPC=DEBUG,HG=DEBUG"
+  D_LOG_MASK: "WARN,RPC=DEBUG,HG=DEBUG"
   CRT_PHY_ADDR_STR: "ofi+sockets"
   OFI_INTERFACE: "eth0"
   test_servers_CRT_CTX_NUM: "16"

--- a/src/tests/ftest/cart/selftest/cart_selftest_three_node.yaml
+++ b/src/tests/ftest/cart/selftest/cart_selftest_three_node.yaml
@@ -4,7 +4,7 @@
 defaultENV:
   #!filter-only : /run/env_CRT_CTX_SHARE_ADDR/no_sep
   #!filter-only : /run/tests/self_np
-  D_LOG_MASK: "ERR,RPC=DEBUG,HG=DEBUG"
+  D_LOG_MASK: "WARN,RPC=DEBUG,HG=DEBUG"
   CRT_PHY_ADDR_STR: "ofi+sockets"
   OFI_INTERFACE: "eth0"
   test_servers_CRT_CTX_NUM: "16"

--- a/src/tests/ftest/cart/selftest/cart_selftest_three_node.yaml
+++ b/src/tests/ftest/cart/selftest/cart_selftest_three_node.yaml
@@ -4,7 +4,7 @@
 defaultENV:
   #!filter-only : /run/env_CRT_CTX_SHARE_ADDR/no_sep
   #!filter-only : /run/tests/self_np
-  D_LOG_MASK: "WARN,RPC=DEBUG,HG=DEBUG"
+  D_LOG_MASK: "WARN"
   CRT_PHY_ADDR_STR: "ofi+sockets"
   OFI_INTERFACE: "eth0"
   test_servers_CRT_CTX_NUM: "16"

--- a/src/tests/ftest/cart/selftest/cart_selftest_three_node.yaml
+++ b/src/tests/ftest/cart/selftest/cart_selftest_three_node.yaml
@@ -4,7 +4,7 @@
 defaultENV:
   #!filter-only : /run/env_CRT_CTX_SHARE_ADDR/no_sep
   #!filter-only : /run/tests/self_np
-  D_LOG_MASK: "DEBUG"
+  D_LOG_MASK: "ERR,RPC=DEBUG,HG=DEBUG"
   CRT_PHY_ADDR_STR: "ofi+sockets"
   OFI_INTERFACE: "eth0"
   test_servers_CRT_CTX_NUM: "16"


### PR DESCRIPTION
- Change log masks on cart tests to be ERR,RPC=DEBUG,HG=DEBUG in
  order to reduce size of logs generated.

Signed-off-by: Alexander Oganezov <alexander.a.oganezov@intel.com>