### PR TITLE
DAOS-6475 object: handle TX restart for query key RPC callback

### DIFF
--- a/src/object/cli_shard.c
+++ b/src/object/cli_shard.c
@@ -1844,6 +1844,7 @@ obj_shard_query_key_cb(tse_task_t *task, void *data)
 	}
 
 	okqo = crt_reply_get(cb_args->rpc);
+	rc = obj_reply_get_status(rpc);
 
 	/* See the similar dc_rw_cb. */
 	if (daos_handle_is_valid(cb_args->th)) {
@@ -1859,7 +1860,6 @@ obj_shard_query_key_cb(tse_task_t *task, void *data)
 		}
 	}
 
-	rc = obj_reply_get_status(rpc);
 	if (rc != 0) {
 		if (rc == -DER_NONEXIST)
 			D_GOTO(out, rc = 0);


### PR DESCRIPTION
For query key RPC inside distributed transaction, server may reply
-DER_TX_RESTART to require related TX to restart. Under such case,
the RPC callback on client needs to parse the returned error from
reply firstly, then call dc_tx_op_end() to handle it; otherwise,
the upper layer caller may get failure when restart the TX.

Signed-off-by: Fan Yong <fan.yong@intel.com>