### PR TITLE
DAOS-6485 object: Fix for object class init/fini

### DIFF
--- a/src/object/cli_mod.c
+++ b/src/object/cli_mod.c
@@ -54,24 +54,33 @@ dc_obj_init(void)
 
 	rc = obj_utils_init();
 	if (rc)
-		goto out;
+		D_GOTO(out, rc);
 
 	rc = obj_class_init();
 	if (rc)
-		goto out;
+		D_GOTO(out_utils, rc);
 
 	rc = daos_rpc_register(&obj_proto_fmt, OBJ_PROTO_CLI_COUNT,
 				NULL, DAOS_OBJ_MODULE);
-	if (rc != 0) {
+	if (rc) {
 		D_ERROR("failed to register daos obj RPCs: "DF_RC"\n",
 			DP_RC(rc));
-		D_GOTO(out, rc);
+		D_GOTO(out_class, rc);
 	}
 
 	rc = obj_ec_codec_init();
-	if (rc != 0)
+	if (rc) {
 		D_ERROR("failed to obj_ec_codec_init: "DF_RC"\n", DP_RC(rc));
+		daos_rpc_unregister(&obj_proto_fmt);
+		D_GOTO(out_class, rc);
+	}
 
+	D_GOTO(out, rc = 0);
+
+out_class:
+	obj_class_fini();
+out_utils:
+	obj_utils_fini();
 out:
 	return rc;
 }

--- a/src/object/srv_mod.c
+++ b/src/object/srv_mod.c
@@ -46,14 +46,20 @@ obj_mod_init(void)
 
 	rc = obj_class_init();
 	if (rc)
-		goto out;
+		goto out_utils;
 
 	rc = obj_ec_codec_init();
-	if (rc != 0) {
+	if (rc) {
 		D_ERROR("failed to obj_ec_codec_init\n");
-		goto out;
+		goto out_class;
 	}
+
 	return 0;
+
+out_class:
+	obj_class_fini();
+out_utils:
+	obj_utils_fini();
 out:
 	D_ERROR("Object module init error: %s\n", d_errstr(rc));
 	return rc;

--- a/src/placement/tests/pl_bench.c
+++ b/src/placement/tests/pl_bench.c
@@ -33,6 +33,9 @@
 #define USE_TIME_PROFILING
 #include "benchmark_util.h"
 
+extern int  obj_class_init(void);
+extern void obj_class_fini(void);
+
 /*
  * These are only at the top of the file for reference / easy changing
  * Do not use these anywhere except in the main function where arguments are
@@ -692,6 +695,10 @@ main(int argc, char **argv)
 	if (rc != 0)
 		return rc;
 
+	rc = obj_class_init();
+	if (rc)
+		return rc;
+
 	rc = pl_init();
 	if (rc != 0) {
 		daos_debug_fini();
@@ -700,6 +707,7 @@ main(int argc, char **argv)
 
 	operation(argc, argv, num_domains, nodes_per_domain, vos_per_target);
 
+	obj_class_fini();
 	pl_fini();
 	daos_debug_fini();
 

--- a/src/placement/tests/pl_bench.c
+++ b/src/placement/tests/pl_bench.c
@@ -589,7 +589,7 @@ main(int argc, char **argv)
 	uint32_t                 nodes_per_domain = DEFAULT_NODES_PER_DOMAIN;
 	uint32_t                 vos_per_target = DEFAULT_VOS_PER_TARGET;
 
-	int                      rc;
+	int                      rc = -1;
 	int                      i;
 
 	test_op_t operation = NULL;
@@ -661,7 +661,7 @@ main(int argc, char **argv)
 					optarg);
 				print_usage(argv[0], op_names,
 					    ARRAY_SIZE(op_names));
-				return -1;
+				goto out;
 			}
 			break;
 		case 'g':
@@ -681,7 +681,7 @@ main(int argc, char **argv)
 		case '?':
 		default:
 			print_usage(argv[0], op_names, ARRAY_SIZE(op_names));
-			return -1;
+			goto out;
 		}
 	}
 
@@ -689,27 +689,27 @@ main(int argc, char **argv)
 		D_PRINT("ERROR: operation argument is required!\n");
 
 		print_usage(argv[0], op_names, ARRAY_SIZE(op_names));
-		return -1;
+		goto out;
 	}
 	rc = daos_debug_init(DAOS_LOG_DEFAULT);
-	if (rc != 0)
-		return rc;
+	if (rc)
+		goto out;
 
 	rc = obj_class_init();
 	if (rc)
-		return rc;
+		goto out_debug;
 
 	rc = pl_init();
-	if (rc != 0) {
-		daos_debug_fini();
-		return rc;
-	}
+	if (rc)
+		goto out_class;
 
 	operation(argc, argv, num_domains, nodes_per_domain, vos_per_target);
 
-	obj_class_fini();
 	pl_fini();
+out_class:
+	obj_class_fini();
+out_debug:
 	daos_debug_fini();
-
-	return 0;
+out:
+	return rc;
 }


### PR DESCRIPTION
The commit b19a56be66ce44efba35b28e50413f21b5917cc5 introduced
the memory loss during the error path in dc_obj_init().

Also pl_bench is crashing without prpopper obj_class_init().