### PR TITLE
DAOS-5868 rebuild: test run of destroy_rebuild.py

### DIFF
--- a/src/tests/ftest/pool/destroy_rebuild.py
+++ b/src/tests/ftest/pool/destroy_rebuild.py
@@ -34,7 +34,6 @@ class DestroyRebuild(TestWithServers):
     :avocado: recursive
     """
 
-    @skipForTicket("DAOS-2723")
     def test_destroy_while_rebuilding(self):
         """Jira ID: DAOS-xxxx.
 


### PR DESCRIPTION
Skip-checkpatch: true
Quick-build: true
Skip-unit-tests: true
Skip-coverity-test: true
Skip-func-hw-test-small: true
Skip-func-hw-test-medium: true
Skip-func-hw-test-large: true
Test-tag: pr,-hw,destroypoolrebuild

Signed-off-by: Kenneth Cain <kenneth.c.cain@intel.com>