### PR TITLE
DAOS-6334: Add assert_rc_equal macro

### DIFF
--- a/src/include/daos/tests_lib.h
+++ b/src/include/daos/tests_lib.h
@@ -42,6 +42,12 @@
 	if (__rc != 0) \
 		fail_msg("Not successful!! Error code: " DF_RC, DP_RC(__rc)); \
 	} while (0)
+#define assert_rc_equal(rc, expected_rc) do { \
+	if((rc) == (expected_rc)) \
+		break; \
+	assert_string_equal(d_errstr(rc), d_errstr(expected_rc)); \
+	} while(0)
+
 
 /** Read a command line from stdin. */
 char *dts_readline(const char *prompt);

--- a/src/include/daos/tests_lib.h
+++ b/src/include/daos/tests_lib.h
@@ -42,11 +42,13 @@
 	if (__rc != 0) \
 		fail_msg("Not successful!! Error code: " DF_RC, DP_RC(__rc)); \
 	} while (0)
-#define assert_rc_equal(rc, expected_rc) do { \
-	if((rc) == (expected_rc)) \
-		break; \
-	assert_string_equal(d_errstr(rc), d_errstr(expected_rc)); \
-	} while(0)
+#define assert_rc_equal(rc, expected_rc) \
+	do { \
+		if ((rc) == (expected_rc)) \
+			break; \
+		print_message("assert_rc_equal: %d != %d\n", rc, expected_rc); \
+		assert_string_equal(d_errstr(rc), d_errstr(expected_rc)); \
+	} while (0)
 
 
 /** Read a command line from stdin. */

--- a/src/vos/tests/vts_dtx.c
+++ b/src/vos/tests/vts_dtx.c
@@ -216,7 +216,7 @@ vts_dtx_commit_visibility(struct io_test_args *args, bool ext, bool punch_obj)
 	vts_dtx_begin(&args->oid, args->ctx.tc_co_hdl, epoch, dkey_hash, &dth);
 
 	rc = io_test_obj_update(args, epoch, 0, &dkey, &iod, &sgl, dth, true);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 
 	xid = dth->dth_xid;
 
@@ -228,14 +228,14 @@ vts_dtx_commit_visibility(struct io_test_args *args, bool ext, bool punch_obj)
 	iod.iod_size = DAOS_REC_ANY;
 
 	rc = io_test_obj_fetch(args, epoch, 0, &dkey, &iod, &sgl, true);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 
 	/* Data record with update DTX is invisible before commit. */
 	assert_memory_not_equal(update_buf, fetch_buf, UPDATE_BUF_SIZE);
 
 	/* Commit the update DTX. */
 	rc = vos_dtx_commit(args->ctx.tc_co_hdl, &xid, 1, NULL);
-	assert_int_equal(rc, 1);
+	assert_rc_equal(rc, 1);
 
 	memset(fetch_buf, 0, UPDATE_BUF_SIZE);
 	d_iov_set(&val_iov, fetch_buf, UPDATE_BUF_SIZE);
@@ -243,7 +243,7 @@ vts_dtx_commit_visibility(struct io_test_args *args, bool ext, bool punch_obj)
 
 	/* Fetch again. */
 	rc = io_test_obj_fetch(args, epoch, 0, &dkey, &iod, &sgl, true);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 
 	/* Data record with update DTX is readable after commit. */
 	assert_memory_equal(update_buf, fetch_buf, UPDATE_BUF_SIZE);
@@ -258,7 +258,7 @@ vts_dtx_commit_visibility(struct io_test_args *args, bool ext, bool punch_obj)
 	else
 		rc = vos_obj_punch(args->ctx.tc_co_hdl, args->oid, epoch,
 				   1, 0, &dkey, 1, &akey, dth);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 
 	xid = dth->dth_xid;
 
@@ -271,13 +271,13 @@ vts_dtx_commit_visibility(struct io_test_args *args, bool ext, bool punch_obj)
 
 	rc = io_test_obj_fetch(args, ++epoch, 0, &dkey, &iod, &sgl, true);
 	/* Punch is not yet visible */
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 
 	assert_memory_equal(update_buf, fetch_buf, UPDATE_BUF_SIZE);
 
 	/* Commit the punch DTX. */
 	rc = vos_dtx_commit(args->ctx.tc_co_hdl, &xid, 1, NULL);
-	assert_int_equal(rc, 1);
+	assert_rc_equal(rc, 1);
 
 	memset(fetch_buf, 0, UPDATE_BUF_SIZE);
 	d_iov_set(&val_iov, fetch_buf, UPDATE_BUF_SIZE);
@@ -285,7 +285,7 @@ vts_dtx_commit_visibility(struct io_test_args *args, bool ext, bool punch_obj)
 
 	/* Fetch again. */
 	rc = io_test_obj_fetch(args, ++epoch, 0, &dkey, &iod, &sgl, true);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 
 	/* Data record with punch DTX is invisible after commit. */
 	assert_memory_not_equal(update_buf, fetch_buf, UPDATE_BUF_SIZE);
@@ -347,7 +347,7 @@ vts_dtx_abort_visibility(struct io_test_args *args, bool ext, bool punch_obj)
 
 	/* initial update. */
 	rc = io_test_obj_update(args, epoch, 0, &dkey, &iod, &sgl, dth, true);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 
 	dts_buf_render(update_buf2, UPDATE_BUF_SIZE);
 	d_iov_set(&val_iov, update_buf2, UPDATE_BUF_SIZE);
@@ -357,7 +357,7 @@ vts_dtx_abort_visibility(struct io_test_args *args, bool ext, bool punch_obj)
 		      &dth);
 
 	rc = io_test_obj_update(args, epoch, 0, &dkey, &iod, &sgl, dth, true);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 
 	xid = dth->dth_xid;
 
@@ -366,14 +366,14 @@ vts_dtx_abort_visibility(struct io_test_args *args, bool ext, bool punch_obj)
 
 	/* Aborted the update DTX. */
 	rc = vos_dtx_abort(args->ctx.tc_co_hdl, epoch, &xid, 1);
-	assert_int_equal(rc, 1);
+	assert_rc_equal(rc, 1);
 
 	memset(fetch_buf, 0, UPDATE_BUF_SIZE);
 	d_iov_set(&val_iov, fetch_buf, UPDATE_BUF_SIZE);
 	iod.iod_size = DAOS_REC_ANY;
 
 	rc = io_test_obj_fetch(args, epoch, 0, &dkey, &iod, &sgl, true);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 
 	assert_memory_not_equal(update_buf2, fetch_buf, UPDATE_BUF_SIZE);
 	/* The fetched result is the data written via the initial update. */
@@ -389,7 +389,7 @@ vts_dtx_abort_visibility(struct io_test_args *args, bool ext, bool punch_obj)
 	else
 		rc = vos_obj_punch(args->ctx.tc_co_hdl, args->oid, epoch,
 				   1, 0, &dkey, 1, &akey, dth);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 
 	xid = dth->dth_xid;
 
@@ -398,14 +398,14 @@ vts_dtx_abort_visibility(struct io_test_args *args, bool ext, bool punch_obj)
 
 	/* Aborted the punch DTX. */
 	rc = vos_dtx_abort(args->ctx.tc_co_hdl, epoch, &xid, 1);
-	assert_int_equal(rc, 1);
+	assert_rc_equal(rc, 1);
 
 	memset(fetch_buf, 0, UPDATE_BUF_SIZE);
 	d_iov_set(&val_iov, fetch_buf, UPDATE_BUF_SIZE);
 	iod.iod_size = DAOS_REC_ANY;
 
 	rc = io_test_obj_fetch(args, ++epoch, 0, &dkey, &iod, &sgl, true);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 
 	/* The fetched result is the data written via the initial update. */
 	assert_memory_equal(update_buf1, fetch_buf, UPDATE_BUF_SIZE);
@@ -470,7 +470,7 @@ dtx_14(void **state)
 	vts_dtx_begin(&args->oid, args->ctx.tc_co_hdl, epoch, dkey_hash, &dth);
 
 	rc = io_test_obj_update(args, epoch, 0, &dkey, &iod, &sgl, dth, true);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 
 	xid = dth->dth_xid;
 
@@ -479,7 +479,7 @@ dtx_14(void **state)
 
 	/* Commit the DTX. */
 	rc = vos_dtx_commit(args->ctx.tc_co_hdl, &xid, 1, NULL);
-	assert_int_equal(rc, 1);
+	assert_rc_equal(rc, 1);
 
 	/* Double commit the DTX is harmless. */
 	vos_dtx_commit(args->ctx.tc_co_hdl, &xid, 1, NULL);
@@ -489,7 +489,7 @@ dtx_14(void **state)
 	iod.iod_size = DAOS_REC_ANY;
 
 	rc = io_test_obj_fetch(args, epoch, 0, &dkey, &iod, &sgl, true);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 
 	/* Data record is not affected by double commit. */
 	assert_memory_equal(update_buf, fetch_buf, UPDATE_BUF_SIZE);
@@ -503,7 +503,7 @@ dtx_14(void **state)
 	iod.iod_size = DAOS_REC_ANY;
 
 	rc = io_test_obj_fetch(args, epoch, 0, &dkey, &iod, &sgl, true);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 
 	/* Data record is not affected by failed abort. */
 	assert_memory_equal(update_buf, fetch_buf, UPDATE_BUF_SIZE);
@@ -539,7 +539,7 @@ dtx_15(void **state)
 
 	/* initial update. */
 	rc = io_test_obj_update(args, epoch, 0, &dkey, &iod, &sgl, dth, true);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 
 	dts_buf_render(update_buf2, UPDATE_BUF_SIZE);
 	d_iov_set(&val_iov, update_buf2, UPDATE_BUF_SIZE);
@@ -549,7 +549,7 @@ dtx_15(void **state)
 		      &dth);
 
 	rc = io_test_obj_update(args, epoch, 0, &dkey, &iod, &sgl, dth, true);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 
 	xid = dth->dth_xid;
 
@@ -558,7 +558,7 @@ dtx_15(void **state)
 
 	/* Aborted the update DTX. */
 	rc = vos_dtx_abort(args->ctx.tc_co_hdl, epoch, &xid, 1);
-	assert_int_equal(rc, 1);
+	assert_rc_equal(rc, 1);
 
 	/* Double aborted the DTX is harmless. */
 	rc = vos_dtx_abort(args->ctx.tc_co_hdl, epoch, &xid, 1);
@@ -569,7 +569,7 @@ dtx_15(void **state)
 	iod.iod_size = DAOS_REC_ANY;
 
 	rc = io_test_obj_fetch(args, epoch, 0, &dkey, &iod, &sgl, true);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 
 	assert_memory_not_equal(update_buf2, fetch_buf, UPDATE_BUF_SIZE);
 	/* The fetched result is the data written via the initial update. */
@@ -583,7 +583,7 @@ dtx_15(void **state)
 	iod.iod_size = DAOS_REC_ANY;
 
 	rc = io_test_obj_fetch(args, epoch, 0, &dkey, &iod, &sgl, true);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 
 	assert_memory_not_equal(update_buf2, fetch_buf, UPDATE_BUF_SIZE);
 	/* The fetched result is the data written via the initial update. */
@@ -622,7 +622,7 @@ dtx_16(void **state)
 	vts_dtx_begin(&args->oid, args->ctx.tc_co_hdl, epoch, dkey_hash, &dth);
 
 	rc = io_test_obj_update(args, epoch, 0, &dkey, &iod, &sgl, dth, true);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 
 	daos_fail_loc_set(DAOS_VOS_NON_LEADER | DAOS_FAIL_ALWAYS);
 
@@ -633,12 +633,12 @@ dtx_16(void **state)
 	rc = vos_fetch_begin(args->ctx.tc_co_hdl, args->oid, epoch,
 			     &dkey_iov, 1, &iod, 0, NULL, &ioh, NULL);
 	/* The former DTX is not committed, so need to retry with leader. */
-	assert_int_equal(rc, -DER_INPROGRESS);
+	assert_rc_equal(rc, -DER_INPROGRESS);
 
 	daos_fail_loc_reset();
 
 	rc = io_test_obj_fetch(args, epoch, 0, &dkey, &iod, &sgl, true);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 
 	/* Former DTX is not committed, so nothing can be fetched. */
 	assert_memory_not_equal(update_buf, fetch_buf, UPDATE_BUF_SIZE);
@@ -648,14 +648,14 @@ dtx_16(void **state)
 
 	/* Fetch again. */
 	rc = io_test_obj_fetch(args, epoch, 0, &dkey, &iod, &sgl, true);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 
 	/* The DTX in CoS cache will make related data record as readable. */
 	assert_memory_equal(update_buf, fetch_buf, UPDATE_BUF_SIZE);
 
 	/* Commit the DTX. */
 	rc = vos_dtx_commit(args->ctx.tc_co_hdl, &dth->dth_xid, 1, NULL);
-	assert_int_equal(rc, 1);
+	assert_rc_equal(rc, 1);
 
 	vts_dtx_end(dth);
 }
@@ -737,7 +737,7 @@ dtx_17(void **state)
 
 		rc = io_test_obj_update(args, epoch[i], 0, &dkey, &iod, &sgl,
 					dth, true);
-		assert_int_equal(rc, 0);
+		assert_rc_equal(rc, 0);
 
 		xid[i] = dth->dth_xid;
 
@@ -746,7 +746,7 @@ dtx_17(void **state)
 
 	/* Commit the first 4 DTXs. */
 	rc = vos_dtx_commit(args->ctx.tc_co_hdl, xid, 4, NULL);
-	assert_int_equal(rc, 4);
+	assert_rc_equal(rc, 4);
 
 	param.ip_hdl = args->ctx.tc_co_hdl;
 	param.ip_ih = DAOS_HDL_INVAL;
@@ -764,7 +764,7 @@ dtx_17(void **state)
 
 	rc = vos_iterate(&param, VOS_ITER_DKEY, false, &anchors,
 			 vts_dtx_iter_cb, NULL, &vdid, NULL);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 
 	for (i = 0; i < 4; i++) {
 		assert_true(found[i]);
@@ -773,14 +773,14 @@ dtx_17(void **state)
 
 	/* Commit the others. */
 	rc = vos_dtx_commit(args->ctx.tc_co_hdl, &xid[4], 6, NULL);
-	assert_int_equal(rc, 6);
+	assert_rc_equal(rc, 6);
 
 	memset(&anchors, 0, sizeof(anchors));
 	vdid.count = 10;
 
 	rc = vos_iterate(&param, VOS_ITER_DKEY, false, &anchors,
 			 vts_dtx_iter_cb, NULL, &vdid, NULL);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 
 	for (i = 0; i < 10; i++) {
 		assert_true(found[i]);
@@ -824,7 +824,7 @@ dtx_18(void **state)
 
 		rc = io_test_obj_update(args, epoch, 0, &dkey, &iod, &sgl,
 					dth, true);
-		assert_int_equal(rc, 0);
+		assert_rc_equal(rc, 0);
 
 		xid[i] = dth->dth_xid;
 
@@ -833,24 +833,24 @@ dtx_18(void **state)
 
 	/* Commit all DTXs. */
 	rc = vos_dtx_commit(args->ctx.tc_co_hdl, xid, 10, NULL);
-	assert_int_equal(rc, 10);
+	assert_rc_equal(rc, 10);
 
 	for (i = 0; i < 10; i++) {
 		rc = vos_dtx_check(args->ctx.tc_co_hdl, &xid[i],
 				   NULL, NULL, NULL, false);
-		assert_int_equal(rc, DTX_ST_COMMITTED);
+		assert_rc_equal(rc, DTX_ST_COMMITTED);
 	}
 
 	sleep(3);
 
 	/* Aggregate the DTXs. */
 	rc = vos_dtx_aggregate(args->ctx.tc_co_hdl);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 
 	for (i = 0; i < 10; i++) {
 		rc = vos_dtx_check(args->ctx.tc_co_hdl, &xid[i],
 				   NULL, NULL, NULL, false);
-		assert_int_equal(rc, -DER_NONEXIST);
+		assert_rc_equal(rc, -DER_NONEXIST);
 	}
 
 	memset(fetch_buf, 0, UPDATE_BUF_SIZE);
@@ -858,7 +858,7 @@ dtx_18(void **state)
 	iod.iod_size = DAOS_REC_ANY;
 
 	rc = io_test_obj_fetch(args, epoch, 0, &dkey, &iod, &sgl, true);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 
 	/* Related data record is still readable after DTX aggregation. */
 	assert_memory_equal(update_buf, fetch_buf, UPDATE_BUF_SIZE);

--- a/src/vos/tests/vts_gc.c
+++ b/src/vos/tests/vts_gc.c
@@ -292,7 +292,7 @@ gc_obj_test(void **state)
 	int		     rc;
 
 	rc = gc_obj_run(args);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 }
 
 static void
@@ -303,7 +303,7 @@ gc_obj_bio_test(void **state)
 
 	args->gc_array = true;
 	rc = gc_obj_run(args);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 }
 
 static int
@@ -370,7 +370,7 @@ gc_cont_test(void **state)
 	int		     rc;
 
 	rc = gc_cont_run(args);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 }
 
 static int

--- a/src/vos/tests/vts_ilog.c
+++ b/src/vos/tests/vts_ilog.c
@@ -66,7 +66,7 @@ ilog_alloc_root(struct umem_instance *umm)
 
 	rc = umem_tx_end(umm, rc);
 done:
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 
 	return umem_off2ptr(umm, ilog_off);
 }
@@ -86,7 +86,7 @@ ilog_free_root(struct umem_instance *umm, struct ilog_df *ilog)
 
 	rc = umem_tx_end(umm, rc);
 done:
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 }
 
 enum {
@@ -179,7 +179,7 @@ fake_tx_log_add(struct umem_instance *umm, umem_off_t offset, uint32_t *tx_id,
 	int			 rc;
 
 	rc = lrua_allocx(array, &idx, epoch, &entry);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 	assert_non_null(entry);
 
 	entry->tx_id = idx;
@@ -534,9 +534,9 @@ ilog_test_update(void **state)
 	LOG_FAIL(rc, 0, "Failed to insert ilog entry\n");
 
 	rc = entries_set(entries, ENTRY_NEW, 1, false, ENTRIES_END);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 	rc = entries_check(umm, ilog, &ilog_callbacks, NULL, 0, entries);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 
 	/* Test upgrade to punch in root */
 	rc = ilog_update(loh, NULL, epoch, 2, true);
@@ -545,9 +545,9 @@ ilog_test_update(void **state)
 	version_cache_fetch(&version_cache, loh, true);
 
 	rc = entries_set(entries, ENTRY_REPLACE, 1, true, ENTRIES_END);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 	rc = entries_check(umm, ilog, &ilog_callbacks, NULL, 0, entries);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 
 	/** Same epoch, different transaction, same operation.  In other
 	 *  words, both the existing entry and this one are punches so
@@ -575,7 +575,7 @@ ilog_test_update(void **state)
 
 	/** no change */
 	rc = entries_check(umm, ilog, &ilog_callbacks, NULL, 0, entries);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 
 	/** New epoch, creation */
 	epoch = 2;
@@ -584,9 +584,9 @@ ilog_test_update(void **state)
 	version_cache_fetch(&version_cache, loh, true);
 
 	rc = entries_set(entries, ENTRY_APPEND, 2, false, ENTRIES_END);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 	rc = entries_check(umm, ilog, &ilog_callbacks, NULL, 0, entries);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 
 	/** New epoch, upgrade to punch */
 	rc = ilog_update(loh, NULL, epoch, 2, true);
@@ -594,9 +594,9 @@ ilog_test_update(void **state)
 	version_cache_fetch(&version_cache, loh, true);
 
 	rc = entries_set(entries, ENTRY_REPLACE, 2, true, ENTRIES_END);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 	rc = entries_check(umm, ilog, &ilog_callbacks, NULL, 0, entries);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 
 
 	epoch = 3;
@@ -623,10 +623,10 @@ ilog_test_update(void **state)
 	LOG_FAIL(rc, 0, "Failed to insert log entry\n");
 
 	rc = entries_check(umm, ilog, &ilog_callbacks, NULL, 0, entries);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 	ilog_close(loh);
 	rc = ilog_destroy(umm, &ilog_callbacks, ilog);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 
 	assert_true(d_list_empty(&fake_tx_list));
 
@@ -675,9 +675,9 @@ ilog_test_abort(void **state)
 	version_cache_fetch(&version_cache, loh, true);
 
 	rc = entries_set(entries, ENTRY_NEW, 1, false, ENTRIES_END);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 	rc = entries_check(umm, ilog, &ilog_callbacks, NULL, 0, entries);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 
 	id = current_tx_id;
 	rc = ilog_abort(loh, &id);
@@ -685,10 +685,10 @@ ilog_test_abort(void **state)
 	version_cache_fetch(&version_cache, loh, true);
 
 	rc = entries_set(entries, ENTRY_NEW, ENTRIES_END);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 	rc = entries_check(umm, ilog, &ilog_callbacks, NULL, -DER_NONEXIST,
 			   entries);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 
 	rc = ilog_update(loh, NULL, id.id_epoch, 2, false);
 	LOG_FAIL(rc, 0, "Failed to insert log entry\n");
@@ -696,10 +696,10 @@ ilog_test_abort(void **state)
 
 	for (iter = 0; iter < 5; iter++) {
 		rc = entries_set(entries, ENTRY_NEW, 1, false, ENTRIES_END);
-		assert_int_equal(rc, 0);
+		assert_rc_equal(rc, 0);
 		rc = entries_check(umm, ilog, &ilog_callbacks, NULL, 0,
 				   entries);
-		assert_int_equal(rc, 0);
+		assert_rc_equal(rc, 0);
 
 		id.id_epoch = 2 + NUM_REC * iter;
 		/* Insert a bunch then delete them */
@@ -718,7 +718,7 @@ ilog_test_abort(void **state)
 
 		rc = entries_check(umm, ilog, &ilog_callbacks, NULL, 0,
 				   entries);
-		assert_int_equal(rc, 0);
+		assert_rc_equal(rc, 0);
 
 		/* delete the same entries, leaving the one entry in the tree */
 		id.id_epoch = 2 + NUM_REC * iter;
@@ -738,13 +738,13 @@ ilog_test_abort(void **state)
 	}
 
 	rc = entries_set(entries, ENTRY_NEW, 1, false, ENTRIES_END);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 	rc = entries_check(umm, ilog, &ilog_callbacks, NULL, 0, entries);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 
 	ilog_close(loh);
 	rc = ilog_destroy(umm, &ilog_callbacks, ilog);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 
 	assert_true(d_list_empty(&fake_tx_list));
 	ilog_free_root(umm, ilog);
@@ -810,9 +810,9 @@ ilog_test_persist(void **state)
 
 	rc = entries_set(entries, ENTRY_NEW, 1, false, 2, false, 3, false,
 			 4, true, ENTRIES_END);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 	rc = entries_check(umm, ilog, &ilog_callbacks, NULL, 0, entries);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 
 	id = saved_tx_id1;
 	rc = ilog_persist(loh, &id);
@@ -821,13 +821,13 @@ ilog_test_persist(void **state)
 
 	rc = entries_set(entries, ENTRY_NEW, 1, false, 2, false, 3, false, 4,
 			 true, ENTRIES_END);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 	rc = entries_check(umm, ilog, &ilog_callbacks, NULL, 0, entries);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 
 	ilog_close(loh);
 	rc = ilog_destroy(umm, &ilog_callbacks, ilog);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 	assert_true(d_list_empty(&fake_tx_list));
 	ilog_free_root(umm, ilog);
 }
@@ -894,9 +894,9 @@ ilog_test_aggregate(void **state)
 	version_cache_fetch(&version_cache, loh, true);
 
 	rc = entries_set(entries, ENTRY_NEW, 1, false, 4, true, ENTRIES_END);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 	rc = entries_check(umm, ilog, &ilog_callbacks, NULL, 0, entries);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 
 	id.id_epoch = 5;
 	rc = ilog_update(loh, NULL, id.id_epoch, 1, true);
@@ -917,9 +917,9 @@ ilog_test_aggregate(void **state)
 	LOG_FAIL(rc, 0, "Failed to aggregate ilog\n");
 	version_cache_fetch(&version_cache, loh, true);
 	rc = entries_set(entries, ENTRY_NEW, 6, false, ENTRIES_END);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 	rc = entries_check(umm, ilog, &ilog_callbacks, NULL, 0, entries);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 
 	id.id_epoch = 7;
 	rc = ilog_update(loh, NULL, id.id_epoch, 1, true);
@@ -934,15 +934,15 @@ ilog_test_aggregate(void **state)
 	version_cache_fetch(&version_cache, loh, true);
 
 	rc = entries_set(entries, ENTRY_NEW, ENTRIES_END);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 	rc = entries_check(umm, ilog, &ilog_callbacks, NULL, -DER_NONEXIST,
 			   entries);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 	assert_true(d_list_empty(&fake_tx_list));
 
 	ilog_close(loh);
 	rc = ilog_destroy(umm, &ilog_callbacks, ilog);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 
 	ilog_free_root(umm, ilog);
 	ilog_fetch_finish(&ilents);
@@ -1009,9 +1009,9 @@ ilog_test_discard(void **state)
 	version_cache_fetch(&version_cache, loh, true);
 
 	rc = entries_set(entries, ENTRY_NEW, 1, false, ENTRIES_END);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 	rc = entries_check(umm, ilog, &ilog_callbacks, NULL, 0, entries);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 
 	id.id_epoch = 5;
 	rc = ilog_update(loh, NULL, id.id_epoch, 1, true);
@@ -1031,10 +1031,10 @@ ilog_test_discard(void **state)
 	LOG_FAIL(rc, 1, "Failed to aggregate ilog\n");
 	version_cache_fetch(&version_cache, loh, true);
 	rc = entries_set(entries, ENTRY_NEW, ENTRIES_END);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 	rc = entries_check(umm, ilog, &ilog_callbacks, NULL, -DER_NONEXIST,
 			   entries);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 
 	id.id_epoch = 7;
 	rc = ilog_update(loh, NULL, id.id_epoch, 1, false);
@@ -1049,15 +1049,15 @@ ilog_test_discard(void **state)
 	version_cache_fetch(&version_cache, loh, true);
 
 	rc = entries_set(entries, ENTRY_NEW, ENTRIES_END);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 	rc = entries_check(umm, ilog, &ilog_callbacks, NULL, -DER_NONEXIST,
 			   entries);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 	assert_true(d_list_empty(&fake_tx_list));
 
 	ilog_close(loh);
 	rc = ilog_destroy(umm, &ilog_callbacks, ilog);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 
 	ilog_free_root(umm, ilog);
 	ilog_fetch_finish(&ilents);

--- a/src/vos/tests/vts_io.c
+++ b/src/vos/tests/vts_io.c
@@ -195,7 +195,7 @@ test_args_init(struct io_test_args *args,
 	rc = vts_ctx_init(&args->ctx, pool_size);
 	if (rc != 0)
 		print_error("rc = "DF_RC"\n", DP_RC(rc));
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 	args->oid = gen_oid(init_ofeats);
 	args->ofeat = init_ofeats;
 	args->dkey = UPDATE_DKEY;
@@ -820,10 +820,10 @@ io_oi_test(void **state)
 	assert_ptr_not_equal(cont, NULL);
 
 	rc = vos_oi_find_alloc(cont, oid, 1, true, &obj[0], NULL);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 
 	rc = vos_oi_find_alloc(cont, oid, 2, true, &obj[1], NULL);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 }
 
 static void
@@ -841,23 +841,23 @@ io_obj_cache_test(void **state)
 	int			 i, rc;
 
 	rc = vos_obj_cache_create(10, &occ);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 
 	rc = vts_alloc_gen_fname(&po_name);
 	assert_int_equal(rc, 0);
 
 	uuid_generate_time_safe(pool_uuid);
 	rc = vos_pool_create(po_name, pool_uuid, VPOOL_16M, 0);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 
 	rc = vos_pool_open(po_name, pool_uuid, false /* small */, &l_poh);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 
 	rc = vos_cont_create(l_poh, ctx->tc_co_uuid);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 
 	rc = vos_cont_open(l_poh, ctx->tc_co_uuid, &l_coh);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 
 	oids[0] = gen_oid(arg->ofeat);
 	oids[1] = gen_oid(arg->ofeat);
@@ -865,13 +865,13 @@ io_obj_cache_test(void **state)
 	rc = vos_obj_hold(occ, vos_hdl2cont(ctx->tc_co_hdl), oids[0], &epr, 0,
 			  VOS_OBJ_CREATE | VOS_OBJ_VISIBLE, DAOS_INTENT_DEFAULT,
 			  &objs[0], 0);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 	vos_obj_release(occ, objs[0], false);
 
 	rc = vos_obj_hold(occ, vos_hdl2cont(l_coh), oids[1], &epr, 0,
 			  VOS_OBJ_CREATE | VOS_OBJ_VISIBLE, DAOS_INTENT_DEFAULT,
 			  &objs[0], 0);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 	vos_obj_release(occ, objs[0], false);
 
 	rc = hold_objects(objs, occ, &ctx->tc_co_hdl, &oids[0], 0, 10, true, 0);
@@ -885,7 +885,7 @@ io_obj_cache_test(void **state)
 	assert_int_equal(rc, 0);
 	rc = vos_obj_hold(occ, vos_hdl2cont(l_coh), oids[1], &epr, 0,
 			  VOS_OBJ_VISIBLE, DAOS_INTENT_DEFAULT, &objs[16], 0);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 
 	vos_obj_release(occ, objs[16], false);
 
@@ -903,13 +903,13 @@ io_obj_cache_test(void **state)
 		vos_obj_release(occ, objs[i], false);
 
 	rc = vos_cont_close(l_coh);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 	rc = vos_cont_destroy(l_poh, ctx->tc_co_uuid);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 	rc = vos_pool_close(l_poh);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 	rc = vos_pool_destroy(po_name, pool_uuid);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 	vos_obj_cache_destroy(occ);
 	free(po_name);
 }
@@ -925,7 +925,7 @@ io_multiple_dkey_test(void **state, unsigned int flags)
 	arg->ta_flags = flags;
 	for (i = 0; i < init_num_keys; i++) {
 		rc = io_update_and_fetch_dkey(arg, epoch, epoch);
-		assert_int_equal(rc, 0);
+		assert_rc_equal(rc, 0);
 	}
 }
 
@@ -950,11 +950,11 @@ io_idx_overwrite_test(void **state, unsigned int flags)
 
 	arg->ta_flags = flags;
 	rc = io_update_and_fetch_dkey(arg, epoch, epoch);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 
 	arg->ta_flags |= TF_OVERWRITE;
 	rc = io_update_and_fetch_dkey(arg, epoch, epoch);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 }
 
 static void
@@ -1128,7 +1128,7 @@ io_obj_iter_test_base(void **state, vos_it_epc_expr_t direction)
 	int			 rc;
 
 	rc = io_obj_range_iter_test(args, direction);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 }
 
 static void
@@ -1150,7 +1150,7 @@ io_obj_recx_iter_test(void **state, vos_it_epc_expr_t direction)
 	int			 rc;
 
 	rc = io_obj_recx_range_iteration(args, direction);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 }
 
 static void
@@ -1226,7 +1226,7 @@ io_update_and_fetch_incorrect_dkey(struct io_test_args *arg,
 	vts_key_gen(&dkey_buf[0], arg->dkey_size, true, arg);
 
 	rc = io_test_obj_fetch(arg, fetch_epoch, 0, &dkey, &iod, &sgl, true);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 	assert_int_equal(iod.iod_size, 0);
 exit:
 	return rc;
@@ -1275,7 +1275,7 @@ io_fetch_wo_object(void **state)
 	arg->oid = gen_oid(arg->ofeat);
 
 	rc = io_test_obj_fetch(arg, 1, 0, &dkey, &iod, &sgl, true);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 	assert_int_equal(iod.iod_size, 0);
 }
 
@@ -1388,23 +1388,23 @@ pool_cont_same_uuid(void **state)
 	uuid_copy(co_uuid, pool_uuid);
 
 	ret = vos_pool_create(arg->fname, pool_uuid, VPOOL_16M, 0);
-	assert_int_equal(ret, 0);
+	assert_rc_equal(ret, 0);
 
 	ret = vos_pool_open(arg->fname, pool_uuid, false /* small */, &poh);
-	assert_int_equal(ret, 0);
+	assert_rc_equal(ret, 0);
 
 	ret = vos_cont_create(poh, co_uuid);
-	assert_int_equal(ret, 0);
+	assert_rc_equal(ret, 0);
 
 	ret = vos_pool_close(poh);
-	assert_int_equal(ret, 0);
+	assert_rc_equal(ret, 0);
 
 	poh = DAOS_HDL_INVAL;
 	ret = vos_pool_open(arg->fname, pool_uuid, false /* small */, &poh);
-	assert_int_equal(ret, 0);
+	assert_rc_equal(ret, 0);
 
 	ret = vos_cont_open(poh, co_uuid, &coh);
-	assert_int_equal(ret, 0);
+	assert_rc_equal(ret, 0);
 
 	vts_key_gen(&dkey_buf[0], arg->dkey_size, true, arg);
 	vts_key_gen(&akey_buf[0], arg->akey_size, false, arg);
@@ -1425,19 +1425,19 @@ pool_cont_same_uuid(void **state)
 
 	oid = gen_oid(arg->ofeat);
 	ret = vos_obj_update(coh, oid, 10, 0, 0, &dkey, 1, &iod, NULL, &sgl);
-	assert_int_equal(ret, 0);
+	assert_rc_equal(ret, 0);
 
 	ret = vos_cont_close(coh);
-	assert_int_equal(ret, 0);
+	assert_rc_equal(ret, 0);
 
 	ret = vos_cont_destroy(poh, co_uuid);
-	assert_int_equal(ret, 0);
+	assert_rc_equal(ret, 0);
 
 	ret = vos_pool_close(poh);
-	assert_int_equal(ret, 0);
+	assert_rc_equal(ret, 0);
 
 	ret = vos_pool_destroy(arg->fname, pool_uuid);
-	assert_int_equal(ret, 0);
+	assert_rc_equal(ret, 0);
 }
 
 static void
@@ -1448,7 +1448,7 @@ io_fetch_no_exist_dkey_base(void **state, unsigned long flags)
 
 	arg->ta_flags = flags;
 	rc = io_update_and_fetch_incorrect_dkey(arg, 1, 1);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 }
 
 static void
@@ -1492,7 +1492,7 @@ io_simple_one_key_test(void **state, unsigned int flags)
 
 	arg->ta_flags = flags;
 	rc = io_update_and_fetch_dkey(arg, 1, 1);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 }
 
 static void
@@ -1612,10 +1612,10 @@ io_simple_one_key_cross_container(void **state)
 
 failed:
 	rc = vos_cont_close(arg->addn_co);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 
 	rc = vos_cont_destroy(arg->ctx.tc_po_hdl, arg->addn_co_uuid);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 }
 
 static void
@@ -1629,7 +1629,7 @@ io_simple_punch(void **state)
 	 * epoch
 	 */
 	rc = io_update_and_fetch_dkey(arg, 10, 10);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 }
 
 static void
@@ -1641,7 +1641,7 @@ io_simple_near_epoch_test(void **state, int flags)
 
 	arg->ta_flags = flags;
 	rc = io_update_and_fetch_dkey(arg, epoch, epoch + 1000);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 }
 
 static void
@@ -1698,7 +1698,7 @@ io_sgl_update(void **state)
 
 	/* Allocate memory for the scatter-gather list */
 	rc = d_sgl_init(&sgl, SGL_TEST_BUF_COUNT);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 
 	/* Allocate memory for the SGL_TEST_BUF_COUNT buffers */
 	for (i = 0; i < SGL_TEST_BUF_COUNT; i++) {
@@ -1728,7 +1728,7 @@ io_sgl_update(void **state)
 	/* Now fetch */
 	memset(fetch_buf, 0, SGL_TEST_BUF_COUNT * SGL_TEST_BUF_SIZE);
 	rc = d_sgl_init(&sgl, 1);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 	d_iov_set(sgl.sg_iovs, &fetch_buf[0], SGL_TEST_BUF_COUNT *
 		     SGL_TEST_BUF_SIZE);
 	rc = vos_obj_fetch(arg->ctx.tc_co_hdl, arg->oid, 1, 0, &dkey, 1, &iod,
@@ -1742,7 +1742,7 @@ io_sgl_update(void **state)
 	assert_memory_equal(ground_truth, fetch_buf, SGL_TEST_BUF_COUNT *
 			    SGL_TEST_BUF_SIZE);
 exit:
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 }
 
 static void
@@ -1825,7 +1825,7 @@ io_sgl_fetch(void **state)
 	}
 	d_sgl_fini(&sgl, true);
 exit:
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 }
 
 static void
@@ -1882,14 +1882,14 @@ io_fetch_hole(void **state)
 	/* Write/Update */
 	rc = vos_obj_update(arg->ctx.tc_co_hdl, arg->oid, 1, 0, 0, &dkey, 1,
 			    &iod, NULL, &sgl);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 	inc_cntr(arg->ta_flags);
 
 	/* Fetch */
 	d_iov_set(&val_iov, &fetch_buf[0], 3 * 1024);
 	rc = vos_obj_fetch(arg->ctx.tc_co_hdl, arg->oid, 1, 0, &dkey, 1, &iod,
 			   &sgl);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 
 	assert_memory_equal(ground_truth, fetch_buf, 3 * 1024);
 
@@ -1911,7 +1911,7 @@ io_fetch_hole(void **state)
 	/* Update using epoch 2 */
 	rc = vos_obj_update(arg->ctx.tc_co_hdl, arg->oid, 2, 0, 0, &dkey, 1,
 			    &iod, NULL, &sgl);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 
 	/* Now fetch all three and test that the "hole" is untouched */
 	rexs[0].rx_nr = 3 * 1024;
@@ -1921,7 +1921,7 @@ io_fetch_hole(void **state)
 	/* Fetch using epoch 2 */
 	rc = vos_obj_fetch(arg->ctx.tc_co_hdl, arg->oid, 2, 0, &dkey, 1, &iod,
 			   &sgl);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 
 	/* Test if ground truth matches fetch_buf */
 	assert_memory_equal(ground_truth, fetch_buf, 3 * 1024);
@@ -1941,7 +1941,7 @@ io_pool_overflow_test(void **state)
 	for (i = 0; i < init_num_keys; i++) {
 		rc = io_update_and_fetch_dkey(args, epoch, epoch);
 		if (rc) {
-			assert_int_equal(rc, -DER_NOSPACE);
+			assert_rc_equal(rc, -DER_NOSPACE);
 			break;
 		}
 	}
@@ -1971,7 +1971,7 @@ oid_iter_test_setup(void **state)
 		oids[i] = gen_oid(arg->ofeat);
 
 		rc = vos_oi_find_alloc(cont, oids[i], 1, true, &obj_df, NULL);
-		assert_int_equal(rc, 0);
+		assert_rc_equal(rc, 0);
 	}
 	return 0;
 }
@@ -2043,24 +2043,24 @@ static void gen_query_tree(struct io_test_args *arg, daos_unit_oid_t oid)
 
 			rc = vos_obj_update(arg->ctx.tc_co_hdl, oid, epoch++, 0,
 					    0, &dkey, 1, &iod, NULL, &sgl);
-			assert_int_equal(rc, 0);
+			assert_rc_equal(rc, 0);
 
 			recx.rx_idx = 1;
 			rc = vos_obj_update(arg->ctx.tc_co_hdl, oid, epoch++, 0,
 					    0, &dkey, 1, &iod, NULL, &sgl);
-			assert_int_equal(rc, 0);
+			assert_rc_equal(rc, 0);
 
 			recx.rx_idx = 2;
 			rc = vos_obj_update(arg->ctx.tc_co_hdl, oid, epoch++, 0,
 					    0, &dkey, 1, &iod, NULL, &sgl);
-			assert_int_equal(rc, 0);
+			assert_rc_equal(rc, 0);
 
 			recx.rx_idx = 1;
 			recx.rx_nr = 2;
 			iod.iod_size = 0; /* punch */
 			rc = vos_obj_update(arg->ctx.tc_co_hdl, oid, epoch++, 0,
 					    0, &dkey, 1, &iod, NULL, &sgl);
-			assert_int_equal(rc, 0);
+			assert_rc_equal(rc, 0);
 		}
 	}
 
@@ -2074,7 +2074,7 @@ static void gen_query_tree(struct io_test_args *arg, daos_unit_oid_t oid)
 	akey_value = MAX_INT_KEY;
 	rc = vos_obj_update(arg->ctx.tc_co_hdl, oid, epoch++, 0, 0, &dkey, 1,
 			    &iod, NULL, &sgl);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 
 }
 
@@ -2112,7 +2112,7 @@ io_query_key(void **state)
 					       DAOS_GET_MAX | DAOS_GET_RECX,
 					       epoch + 3, &dkey, &akey,
 					       &recx_read, NULL);
-			assert_int_equal(rc, 0);
+			assert_rc_equal(rc, 0);
 			assert_int_equal(recx_read.rx_idx, 0);
 			assert_int_equal(recx_read.rx_nr, 1);
 
@@ -2121,7 +2121,7 @@ io_query_key(void **state)
 					       DAOS_GET_MAX | DAOS_GET_RECX,
 					       epoch + 2, &dkey, &akey,
 					       &recx_read, NULL);
-			assert_int_equal(rc, 0);
+			assert_rc_equal(rc, 0);
 			assert_int_equal(recx_read.rx_idx, 2);
 			assert_int_equal(recx_read.rx_nr, 1);
 
@@ -2130,7 +2130,7 @@ io_query_key(void **state)
 					       DAOS_GET_MAX | DAOS_GET_RECX,
 					       epoch + 3, &dkey_read,
 					       &akey_read, &recx_read, NULL);
-			assert_int_equal(rc, 0);
+			assert_rc_equal(rc, 0);
 			assert_int_equal(recx_read.rx_idx, 0);
 			assert_int_equal(recx_read.rx_nr, 1);
 			assert_int_equal(*(uint64_t *)dkey_read.iov_buf,
@@ -2144,7 +2144,7 @@ io_query_key(void **state)
 					       DAOS_GET_MAX | DAOS_GET_RECX,
 					       epoch + 2, &dkey_read,
 					       &akey_read, &recx_read, NULL);
-			assert_int_equal(rc, 0);
+			assert_rc_equal(rc, 0);
 			assert_int_equal(recx_read.rx_idx, 2);
 			assert_int_equal(recx_read.rx_nr, 1);
 			assert_int_equal(*(uint64_t *)dkey_read.iov_buf,
@@ -2156,7 +2156,7 @@ io_query_key(void **state)
 					       DAOS_GET_MIN | DAOS_GET_RECX,
 					       epoch + 3, &dkey, &akey,
 					       &recx_read, NULL);
-			assert_int_equal(rc, 0);
+			assert_rc_equal(rc, 0);
 			assert_int_equal(recx_read.rx_idx, 0);
 			assert_int_equal(recx_read.rx_nr, 1);
 
@@ -2165,7 +2165,7 @@ io_query_key(void **state)
 					       DAOS_GET_MIN | DAOS_GET_RECX,
 					       epoch + 2, &dkey, &akey,
 					       &recx_read, NULL);
-			assert_int_equal(rc, 0);
+			assert_rc_equal(rc, 0);
 			assert_int_equal(recx_read.rx_idx, 0);
 			assert_int_equal(recx_read.rx_nr, 1);
 
@@ -2174,7 +2174,7 @@ io_query_key(void **state)
 					       DAOS_GET_MIN | DAOS_GET_RECX,
 					       epoch + 3, &dkey_read,
 					       &akey_read, &recx_read, NULL);
-			assert_int_equal(rc, 0);
+			assert_rc_equal(rc, 0);
 			assert_int_equal(recx_read.rx_idx, 0);
 			assert_int_equal(recx_read.rx_nr, 1);
 			assert_int_equal(*(uint64_t *)dkey_read.iov_buf,
@@ -2188,7 +2188,7 @@ io_query_key(void **state)
 					       DAOS_GET_MIN | DAOS_GET_RECX,
 					       epoch + 2, &dkey_read,
 					       &akey_read, &recx_read, NULL);
-			assert_int_equal(rc, 0);
+			assert_rc_equal(rc, 0);
 			assert_int_equal(recx_read.rx_idx, 0);
 			assert_int_equal(recx_read.rx_nr, 1);
 			assert_int_equal(*(uint64_t *)dkey_read.iov_buf,
@@ -2207,23 +2207,23 @@ io_query_key(void **state)
 	dkey_value = MAX_INT_KEY;
 	rc = vos_obj_punch(arg->ctx.tc_co_hdl, oid, epoch++, 0, 0, &dkey, 1,
 			   &akey, NULL);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 
 	akey_value = KEY_INC;
 	rc = vos_obj_punch(arg->ctx.tc_co_hdl, oid, epoch++, 0, 0, &dkey, 1,
 			   &akey, NULL);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 
 	rc = vos_obj_query_key(arg->ctx.tc_co_hdl, oid, DAOS_GET_AKEY |
 			       DAOS_GET_MIN, epoch++, &dkey, &akey_read, NULL,
 			       NULL);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 	assert_int_equal(*(uint64_t *)akey_read.iov_buf, KEY_INC * 2);
 
 	rc = vos_obj_query_key(arg->ctx.tc_co_hdl, oid, DAOS_GET_AKEY |
 			       DAOS_GET_MAX, epoch++, &dkey, &akey_read, NULL,
 			       NULL);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 	assert_int_equal(*(uint64_t *)akey_read.iov_buf, MAX_INT_KEY - KEY_INC);
 
 	/* Punch all of the akeys in last dkey */
@@ -2231,17 +2231,17 @@ io_query_key(void **state)
 		akey_value = i * KEY_INC;
 		rc = vos_obj_punch(arg->ctx.tc_co_hdl, oid, epoch++, 0, 0,
 				   &dkey, 1, &akey, NULL);
-		assert_int_equal(rc, 0);
+		assert_rc_equal(rc, 0);
 	}
 	rc = vos_obj_query_key(arg->ctx.tc_co_hdl, oid, DAOS_GET_AKEY |
 			       DAOS_GET_MAX, epoch++, &dkey, &akey_read, NULL,
 			       NULL);
-	assert_int_equal(rc, -DER_NONEXIST);
+	assert_rc_equal(rc, -DER_NONEXIST);
 
 	rc = vos_obj_query_key(arg->ctx.tc_co_hdl, oid, DAOS_GET_AKEY |
 			       DAOS_GET_DKEY | DAOS_GET_MAX, epoch++,
 			       &dkey_read, &akey_read, NULL, NULL);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 	assert_int_equal(*(uint64_t *)akey_read.iov_buf, MAX_INT_KEY);
 	assert_int_equal(*(uint64_t *)dkey_read.iov_buf, MAX_INT_KEY - KEY_INC);
 
@@ -2250,7 +2250,7 @@ io_query_key(void **state)
 			       DAOS_GET_DKEY | DAOS_GET_RECX | DAOS_GET_MAX,
 			       epoch++, &dkey_read, &akey_read,
 			       &recx_read, NULL);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 	assert_int_equal(*(uint64_t *)akey_read.iov_buf, MAX_INT_KEY - KEY_INC);
 	assert_int_equal(*(uint64_t *)dkey_read.iov_buf, MAX_INT_KEY - KEY_INC);
 	assert_int_equal(recx_read.rx_nr, 1);
@@ -2260,17 +2260,17 @@ io_query_key(void **state)
 	dkey_value = MAX_INT_KEY;
 	rc = vos_obj_punch(arg->ctx.tc_co_hdl, oid, epoch++, 0, 0, &dkey, 0,
 			   NULL, NULL);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 
 	dkey_value = KEY_INC;
 	rc = vos_obj_punch(arg->ctx.tc_co_hdl, oid, epoch++, 0, 0, &dkey, 0,
 			   NULL, NULL);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 
 	rc = vos_obj_query_key(arg->ctx.tc_co_hdl, oid, DAOS_GET_DKEY |
 			       DAOS_GET_MIN, epoch++, &dkey_read, NULL, NULL,
 			       NULL);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 	assert_int_equal(*(uint64_t *)dkey_read.iov_buf, KEY_INC * 2);
 
 	if (getenv("DAOS_IO_BYPASS"))
@@ -2283,7 +2283,7 @@ io_query_key(void **state)
 	rc = vos_obj_query_key(arg->ctx.tc_co_hdl, oid, DAOS_GET_DKEY |
 			       DAOS_GET_MAX, 0 /* Ignored epoch */, &dkey_read,
 			       NULL, NULL, dth);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 	assert_int_equal(*(uint64_t *)dkey_read.iov_buf, MAX_INT_KEY - KEY_INC);
 
 	vts_dtx_end(dth);
@@ -2292,24 +2292,24 @@ io_query_key(void **state)
 	vts_dtx_begin(&oid, arg->ctx.tc_co_hdl, epoch - 3, 0, &dth);
 	rc = vos_obj_punch(arg->ctx.tc_co_hdl, oid, 0 /* ignored epoch */, 0, 0,
 			   NULL, 0, NULL, dth);
-	assert_int_equal(rc, -DER_TX_RESTART);
+	assert_rc_equal(rc, -DER_TX_RESTART);
 	vts_dtx_end(dth);
 
 	vts_dtx_begin(&oid, arg->ctx.tc_co_hdl, epoch + 1, 0, &dth);
 	/* Now punch the object */
 	rc = vos_obj_punch(arg->ctx.tc_co_hdl, oid, epoch++, 0, 0, NULL, 0,
 			   NULL, dth);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 	xid = dth->dth_xid;
 	vts_dtx_end(dth);
 
 	rc = vos_dtx_commit(arg->ctx.tc_co_hdl, &xid, 1, NULL);
-	assert_int_equal(rc, 1);
+	assert_rc_equal(rc, 1);
 
 	rc = vos_obj_query_key(arg->ctx.tc_co_hdl, oid, DAOS_GET_DKEY |
 			       DAOS_GET_MAX, epoch++, &dkey_read, NULL, NULL,
 			       NULL);
-	assert_int_equal(rc, -DER_NONEXIST);
+	assert_rc_equal(rc, -DER_NONEXIST);
 }
 
 static void
@@ -2346,7 +2346,7 @@ update_dkey(void **state, daos_unit_oid_t oid, daos_epoch_t epoch,
 
 	rc = vos_obj_update(arg->ctx.tc_co_hdl, oid, epoch++, 0, 0, &dkey, 1,
 			    &iod, NULL, &sgl);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 }
 
 static void
@@ -2372,7 +2372,7 @@ io_query_key_punch_update(void **state)
 	rc = vos_obj_query_key(arg->ctx.tc_co_hdl, oid,
 			       DAOS_GET_MAX | DAOS_GET_DKEY | DAOS_GET_RECX,
 			       epoch++, &dkey, &akey, &recx_read, NULL);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 	assert_int_equal(recx_read.rx_idx, 0);
 	assert_int_equal(recx_read.rx_nr, sizeof("Goodbye"));
 	assert_int_equal(*(uint64_t *)dkey.iov_buf, 12);
@@ -2382,12 +2382,12 @@ io_query_key_punch_update(void **state)
 	d_iov_set(&dkey, &dkey_value, sizeof(dkey_value));
 	rc = vos_obj_punch(arg->ctx.tc_co_hdl, oid, epoch++, 0, 0, &dkey, 0,
 			   NULL, NULL);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 
 	rc = vos_obj_query_key(arg->ctx.tc_co_hdl, oid,
 			       DAOS_GET_MAX | DAOS_GET_DKEY | DAOS_GET_RECX,
 			       epoch++, &dkey, &akey, &recx_read, NULL);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 	assert_int_equal(recx_read.rx_idx, 0);
 	assert_int_equal(recx_read.rx_nr, sizeof("World"));
 	assert_int_equal(*(uint64_t *)dkey.iov_buf, 0);
@@ -2398,7 +2398,7 @@ io_query_key_punch_update(void **state)
 	rc = vos_obj_query_key(arg->ctx.tc_co_hdl, oid,
 			       DAOS_GET_MAX | DAOS_GET_DKEY | DAOS_GET_RECX,
 			       epoch++, &dkey, &akey, &recx_read, NULL);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 	assert_int_equal(recx_read.rx_nr, sizeof("Hello"));
 	assert_int_equal(recx_read.rx_idx, 0);
 	assert_int_equal(*(uint64_t *)dkey.iov_buf, 12);
@@ -2421,21 +2421,21 @@ io_query_key_negative(void **state)
 			       DAOS_GET_MAX | DAOS_GET_RECX, 4,
 			       &dkey_read, &akey_read,
 			       &recx_read, NULL);
-	assert_int_equal(rc, -DER_NONEXIST);
+	assert_rc_equal(rc, -DER_NONEXIST);
 
 	rc = vos_obj_query_key(arg->ctx.tc_co_hdl, oid,
 			       DAOS_GET_DKEY | DAOS_GET_AKEY |
 			       DAOS_GET_MIN | DAOS_GET_RECX, 4,
 			       &dkey_read, &akey_read,
 			       &recx_read, NULL);
-	assert_int_equal(rc, -DER_NONEXIST);
+	assert_rc_equal(rc, -DER_NONEXIST);
 
 	gen_query_tree(arg, oid);
 
 	rc = vos_obj_query_key(arg->ctx.tc_co_hdl, arg->oid,
 			       DAOS_GET_DKEY | DAOS_GET_MAX, 4,
 			       NULL, NULL, NULL, NULL);
-	assert_int_equal(rc, -DER_INVAL);
+	assert_rc_equal(rc, -DER_INVAL);
 }
 
 static const struct CMUnitTest io_tests[] = {

--- a/src/vos/tests/vts_pm.c
+++ b/src/vos/tests/vts_pm.c
@@ -158,7 +158,7 @@ vos_check(void **state, vos_iter_param_t *param, vos_iter_type_t type,
 
 	rc = vos_iterate(param, type, true, &anchors, count_cb, NULL, &counts,
 			 NULL);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 	assert_int_equal(expected->num_objs, counts.num_objs);
 	assert_int_equal(expected->num_dkeys, counts.num_dkeys);
 	assert_int_equal(expected->num_akeys, counts.num_akeys);
@@ -276,24 +276,24 @@ array_set_get_size(void **state)
 	int			 flags;
 
 	rc = vts_array_set_size(info->pi_aoh, 2, 1000);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 
 	rc = vts_array_get_size(info->pi_aoh, 3, &size);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 	assert_int_equal(size, 1000);
 
 	rc = vts_array_set_size(info->pi_aoh, 4, 5);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 
 	rc = vts_array_get_size(info->pi_aoh, 5, &size);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 	assert_int_equal(size, 5);
 
 	rc = vts_array_reset(&info->pi_aoh, 6, 7, 1, 0, 0);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 
 	rc = vts_array_get_size(info->pi_aoh, 8, &size);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 	assert_int_equal(size, 0);
 
 	flags = VOS_IT_EPC_RR | VOS_IT_RECX_VISIBLE;
@@ -326,12 +326,12 @@ array_size_write(void **state)
 		     start_size -= 11, punch_size += 53) {
 			rc = vts_array_write(info->pi_aoh, epoch++, 0,
 					     start_size, info->pi_update_buf);
-			assert_int_equal(rc, 0);
+			assert_rc_equal(rc, 0);
 
 			memcpy(info->pi_fetch_buf, info->pi_fill_buf, buf_size);
 			rc = vts_array_read(info->pi_aoh, epoch++, 0, buf_size,
 					    info->pi_fetch_buf);
-			assert_int_equal(rc, 0);
+			assert_rc_equal(rc, 0);
 			assert_memory_equal(info->pi_fetch_buf,
 					    info->pi_update_buf, start_size);
 			assert_memory_equal(info->pi_fetch_buf + start_size,
@@ -340,12 +340,12 @@ array_size_write(void **state)
 
 			rc = vts_array_set_size(info->pi_aoh, epoch++,
 						punch_size);
-			assert_int_equal(rc, 0);
+			assert_rc_equal(rc, 0);
 
 			memcpy(info->pi_fetch_buf, info->pi_fill_buf, buf_size);
 			rc = vts_array_read(info->pi_aoh, epoch++, 0, buf_size,
 					    info->pi_fetch_buf);
-			assert_int_equal(rc, 0);
+			assert_rc_equal(rc, 0);
 			assert_memory_equal(info->pi_fetch_buf,
 					    info->pi_update_buf, punch_size);
 			assert_memory_equal(info->pi_fetch_buf + punch_size,
@@ -382,7 +382,7 @@ array_read_write_punch_size(void **state, daos_epoch_t epc_in,
 
 	rc = vts_array_reset(&info->pi_aoh, epoch, epoch + 1, rec_size,
 			     per_key, akey_size);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 	epoch += 2;
 
 	per_key += inc;
@@ -391,26 +391,26 @@ array_read_write_punch_size(void **state, daos_epoch_t epc_in,
 	for (i = 0; i < iter; i++) {
 		rc = vts_array_write(info->pi_aoh, epoch++, 0, max_elem,
 				     info->pi_update_buf);
-		assert_int_equal(rc, 0);
+		assert_rc_equal(rc, 0);
 
 		rc = vts_array_get_size(info->pi_aoh, epoch++, &size);
-		assert_int_equal(rc, 0);
+		assert_rc_equal(rc, 0);
 		assert_int_equal(size, max_elem);
 
 		memset(info->pi_fetch_buf, 0xa, max_elem * rec_size);
 		rc = vts_array_read(info->pi_aoh, epoch++, 0, max_elem,
 				    info->pi_fetch_buf);
-		assert_int_equal(rc, 0);
+		assert_rc_equal(rc, 0);
 		assert_memory_equal(info->pi_update_buf, info->pi_fetch_buf,
 				    max_elem * rec_size);
 
 		rc = vts_array_set_size(info->pi_aoh, epoch++, new_size);
-		assert_int_equal(rc, 0);
+		assert_rc_equal(rc, 0);
 
 		memset(info->pi_fetch_buf, 0xa, max_elem * rec_size);
 		rc = vts_array_read(info->pi_aoh, epoch++, 0, max_elem,
 				    info->pi_fetch_buf);
-		assert_int_equal(rc, 0);
+		assert_rc_equal(rc, 0);
 		assert_memory_equal(info->pi_update_buf, info->pi_fetch_buf,
 				    new_size * rec_size);
 		assert_memory_equal(info->pi_fetch_buf + (rec_size * new_size),
@@ -418,7 +418,7 @@ array_read_write_punch_size(void **state, daos_epoch_t epc_in,
 				    (max_elem - new_size) * rec_size);
 
 		rc = vts_array_get_size(info->pi_aoh, epoch++, &size);
-		assert_int_equal(rc, 0);
+		assert_rc_equal(rc, 0);
 		assert_int_equal(size, new_size);
 
 		new_size++;
@@ -427,7 +427,7 @@ array_read_write_punch_size(void **state, daos_epoch_t epc_in,
 
 		rc = vts_array_reset(&info->pi_aoh, epoch, epoch + 1,
 				     rec_size, per_key, akey_size);
-		assert_int_equal(rc, 0);
+		assert_rc_equal(rc, 0);
 		epoch += 2;
 		per_key += inc;
 		akey_size += inc;
@@ -436,7 +436,7 @@ array_read_write_punch_size(void **state, daos_epoch_t epc_in,
 		div++;
 
 		rc = vts_array_get_size(info->pi_aoh, epoch++, &size);
-		assert_int_equal(rc, 0);
+		assert_rc_equal(rc, 0);
 		assert_int_equal(size, 0);
 
 	}
@@ -444,12 +444,12 @@ array_read_write_punch_size(void **state, daos_epoch_t epc_in,
 	/* Now make sure fetch buf == update buf by writing again and reading */
 	rc = vts_array_write(info->pi_aoh, epoch++, 0, max_elem,
 			     info->pi_update_buf);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 
 	memset(info->pi_fetch_buf, 0xa, max_elem * rec_size);
 	rc = vts_array_read(info->pi_aoh, epoch++, 0, max_elem,
 			    info->pi_fetch_buf);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 
 	*epc_out = epoch;
 }
@@ -628,32 +628,32 @@ punch_model_test(void **state)
 
 	/* Allocate memory for the scatter-gather list */
 	rc = d_sgl_init(&sgl, 1);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 
 	d_iov_set(&sgl.sg_iovs[0], (void *)under, strlen(under));
 
 	/* Write the original value (under) */
 	rc = vos_obj_update(arg->ctx.tc_co_hdl, oid, 1, 0,
 			    0, &dkey, 1, &iod, NULL, &sgl);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 	/* Punch the akey */
 	rc = vos_obj_punch(arg->ctx.tc_co_hdl, oid, 2, 0, 0, &dkey, 1, &akey,
 			   NULL);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 
 	/* Write the new value (expected) */
 	rex.rx_nr = strlen(expected);
 	d_iov_set(&sgl.sg_iovs[0], (void *)expected, strlen(expected));
 	rc = vos_obj_update(arg->ctx.tc_co_hdl, oid, 3, 0,
 			    0, &dkey, 1, &iod, NULL, &sgl);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 
 	/* Now read back original # of bytes */
 	rex.rx_nr = strlen(under);
 	d_iov_set(&sgl.sg_iovs[0], (void *)buf, strlen(under));
 	rc = vos_obj_fetch(arg->ctx.tc_co_hdl, oid, 4, 0, &dkey, 1,
 			   &iod, &sgl);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 
 	assert_int_equal(strncmp(buf, expected, strlen(under)), 0);
 
@@ -661,18 +661,18 @@ punch_model_test(void **state)
 	d_iov_set(&sgl.sg_iovs[0], (void *)under, strlen(under));
 	rc = vos_obj_update(arg->ctx.tc_co_hdl, oid, 5, 0,
 			    0, &dkey, 1, &iod, NULL, &sgl);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 	/* Punch the dkey */
 	rc = vos_obj_punch(arg->ctx.tc_co_hdl, oid, 6, 0, 0, &dkey, 0, NULL,
 			   NULL);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 
 	/* Write the new value (expected) at latest epoch*/
 	rex.rx_nr = strlen(expected);
 	d_iov_set(&sgl.sg_iovs[0], (void *)expected, strlen(expected));
 	rc = vos_obj_update(arg->ctx.tc_co_hdl, oid, 7, 0,
 			    0, &dkey, 1, &iod, NULL, &sgl);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 
 	memset(buf, 0, sizeof(buf));
 	/* Now read back original # of bytes */
@@ -680,7 +680,7 @@ punch_model_test(void **state)
 	d_iov_set(&sgl.sg_iovs[0], (void *)buf, strlen(under));
 	rc = vos_obj_fetch(arg->ctx.tc_co_hdl, oid, 8, 0, &dkey, 1,
 			   &iod, &sgl);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 
 	assert_int_equal(strncmp(buf, expected, strlen(under)), 0);
 
@@ -689,19 +689,19 @@ punch_model_test(void **state)
 	d_iov_set(&sgl.sg_iovs[0], (void *)expected, strlen(expected));
 	rc = vos_obj_update(arg->ctx.tc_co_hdl, oid, 9, 0,
 			    0, &dkey, 1, &iod, NULL, &sgl);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 
 	/* Punch the object at 10 */
 	rc = vos_obj_punch(arg->ctx.tc_co_hdl, oid, 10, 0, 0, NULL, 0, NULL,
 			   NULL);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 
 	/* Write one more at 11 */
 	rex.rx_nr = strlen(latest);
 	d_iov_set(&sgl.sg_iovs[0], (void *)latest, strlen(latest));
 	rc = vos_obj_update(arg->ctx.tc_co_hdl, oid, 11, 0,
 			    0, &dkey, 1, &iod, NULL, &sgl);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 
 	/** read old one for sanity */
 	memset(buf, 0, sizeof(buf));
@@ -709,7 +709,7 @@ punch_model_test(void **state)
 	d_iov_set(&sgl.sg_iovs[0], (void *)buf, strlen(under));
 	rc = vos_obj_fetch(arg->ctx.tc_co_hdl, oid, 5, 0, &dkey, 1,
 			   &iod, &sgl);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 	assert_int_equal(strncmp(buf, under, strlen(under)), 0);
 
 	/* Non recursive iteration first */
@@ -738,7 +738,7 @@ punch_model_test(void **state)
 	d_iov_set(&sgl.sg_iovs[0], (void *)buf, strlen(under));
 	rc = vos_obj_fetch(arg->ctx.tc_co_hdl, oid, 11, 0, &dkey, 1,
 			   &iod, &sgl);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 	assert_int_equal(sgl.sg_iovs[0].iov_len, strlen(latest));
 	assert_int_equal(strncmp(buf, latest, strlen(latest)), 0);
 
@@ -747,7 +747,7 @@ punch_model_test(void **state)
 	rc = vos_obj_query_key(arg->ctx.tc_co_hdl, oid,
 			       DAOS_GET_RECX | DAOS_GET_MAX,
 			       11, &dkey, &akey, &rex, NULL);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 	assert_int_equal(rex.rx_idx, 0);
 	assert_int_equal(rex.rx_nr, strlen(latest));
 }
@@ -778,7 +778,7 @@ simple_multi_update(void **state)
 
 	for (i = 0; i < 2; i++) {
 		rc = d_sgl_init(&sgl[i], 1);
-		assert_int_equal(rc, 0);
+		assert_rc_equal(rc, 0);
 		iod[i].iod_type = DAOS_IOD_SINGLE;
 		iod[i].iod_size = strlen(values[i]) + 1;
 		d_iov_set(&sgl[i].sg_iovs[0], (void *)values[i],
@@ -790,7 +790,7 @@ simple_multi_update(void **state)
 
 	rc = vos_obj_update(arg->ctx.tc_co_hdl, oid, 1, 0,
 			    0, &dkey, 2, iod, NULL, sgl);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 
 	for (i = 0; i < 2; i++) {
 		iod[i].iod_size = 0; /* size fetch */
@@ -799,7 +799,7 @@ simple_multi_update(void **state)
 
 	rc = vos_obj_fetch(arg->ctx.tc_co_hdl, oid, 1, 0, &dkey, 2,
 			   iod, sgl);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 
 	for (i = 0; i < 2; i++) {
 		assert_true(iod[i].iod_size == (strlen(values[i]) + 1));
@@ -812,11 +812,11 @@ simple_multi_update(void **state)
 
 	rc = vos_obj_punch(arg->ctx.tc_co_hdl, oid, 2, 0, 0, NULL, 0, NULL,
 			   NULL);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 
 	rc = vos_obj_update(arg->ctx.tc_co_hdl, oid, 1, 0,
 			    0, &dkey, 2, iod, NULL, sgl);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 
 	for (i = 0; i < 2; i++) {
 		iod[i].iod_size = 0; /* size fetch */
@@ -825,7 +825,7 @@ simple_multi_update(void **state)
 
 	rc = vos_obj_fetch(arg->ctx.tc_co_hdl, oid, 1, 0, &dkey, 2,
 			   iod, sgl);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 
 	for (i = 0; i < 2; i++) {
 		assert_true(iod[i].iod_size == (strlen(overwrite[i]) + 1));
@@ -859,7 +859,7 @@ object_punch_and_fetch(void **state)
 	test_args_reset(arg, VPOOL_SIZE);
 
 	rc = d_sgl_init(&sgl, 1);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 	d_iov_set(&update_keys[0], &stable_key, sizeof(stable_key));
 	d_iov_set(&update_keys[1], &key1, sizeof(key1));
 	d_iov_set(&punch_keys[0], &stable_key, sizeof(stable_key));
@@ -885,21 +885,21 @@ object_punch_and_fetch(void **state)
 		rc = vos_obj_update(arg->ctx.tc_co_hdl, oid, epoch++, 0,
 				    0, &dkey, 1, &iod, NULL,
 				    &sgl);
-		assert_int_equal(rc, 0);
+		assert_rc_equal(rc, 0);
 
 		*actual_keys[0] = punch_keys[i];
 		*actual_keys[1] = punch_keys[1 - i];
 
 		rc = vos_obj_punch(arg->ctx.tc_co_hdl, oid, epoch++, 0, 0,
 				   &dkey, 1 - i, punch_akeys[i], NULL);
-		assert_int_equal(rc, 0);
+		assert_rc_equal(rc, 0);
 
 		iod.iod_size = 0;
 		d_iov_set(&sgl.sg_iovs[0], (void *)buf, sizeof(buf));
 
 		rc = vos_obj_fetch(arg->ctx.tc_co_hdl, oid, epoch++, 0, &dkey,
 				   1, &iod, &sgl);
-		assert_int_equal(rc, 0);
+		assert_rc_equal(rc, 0);
 		assert_int_equal(iod.iod_size, 0);
 	}
 
@@ -947,7 +947,7 @@ sgl_test(void **state)
 	recx[0].rx_idx = 2;
 	rc = vos_obj_update(arg->ctx.tc_co_hdl, oid, epoch++, 0,
 			    0, &dkey, 1, &iod, NULL, &sgl);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 
 	memset(rbuf, 'a', sizeof(rbuf));
 	iod.iod_size = 0;
@@ -958,7 +958,7 @@ sgl_test(void **state)
 	/* Fetch whole buffer */
 	rc = vos_obj_fetch(arg->ctx.tc_co_hdl, oid, epoch++, 0, &dkey, 1,
 			   &iod, &sgl);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 	assert_int_equal(iod.iod_size, 1);
 	for (i = 0; i < SM_BUF_LEN; i++) {
 		if (i == 2)
@@ -978,7 +978,7 @@ sgl_test(void **state)
 	}
 	rc = vos_obj_fetch(arg->ctx.tc_co_hdl, oid, epoch++, 0, &dkey, 1,
 			   &iod, &sgl);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 	assert_int_equal(iod.iod_size, 1);
 	for (i = 0; i < SM_BUF_LEN; i++) {
 		if (i == 1)
@@ -997,7 +997,7 @@ sgl_test(void **state)
 	iod.iod_size = 0;
 	rc = vos_obj_fetch(arg->ctx.tc_co_hdl, oid, epoch++, 0, &dkey, 1,
 			   &iod, &sgl);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 	assert_int_equal(iod.iod_size, 1);
 	for (i = 0; i < SM_BUF_LEN; i++) {
 		if (i == 8)
@@ -1046,10 +1046,10 @@ obj_punch_op(void **state, daos_handle_t coh, daos_unit_oid_t oid,
 	xid = dth->dth_xid;
 	vts_dtx_end(dth);
 
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 
 	rc = vos_dtx_commit(coh, &xid, 1, NULL);
-	assert_int_equal(rc, 1);
+	assert_rc_equal(rc, 1);
 }
 
 static void
@@ -1072,11 +1072,11 @@ cond_dkey_punch_op(void **state, daos_handle_t coh, daos_unit_oid_t oid,
 	xid = dth->dth_xid;
 	vts_dtx_end(dth);
 
-	assert_int_equal(rc, expected_rc);
+	assert_rc_equal(rc, expected_rc);
 
 	if (expected_rc == 0) {
 		rc = vos_dtx_commit(coh, &xid, 1, NULL);
-		assert_int_equal(rc, 1);
+		assert_rc_equal(rc, 1);
 	}
 }
 
@@ -1105,11 +1105,11 @@ cond_akey_punch_op(void **state, daos_handle_t coh, daos_unit_oid_t oid,
 	xid = dth->dth_xid;
 	vts_dtx_end(dth);
 
-	assert_int_equal(rc, expected_rc);
+	assert_rc_equal(rc, expected_rc);
 
 	if (expected_rc == 0) {
 		rc = vos_dtx_commit(coh, &xid, 1, NULL);
-		assert_int_equal(rc, 1);
+		assert_rc_equal(rc, 1);
 	}
 }
 
@@ -1153,7 +1153,7 @@ cond_fetch_op_(void **state, daos_handle_t coh, daos_unit_oid_t oid,
 	if (use_tx)
 		vts_dtx_begin(&oid, coh, epoch, 0, &dth);
 	rc = vos_obj_fetch_ex(coh, oid, epoch, flags, &dkey, 1, &iod, sgl, dth);
-	assert_int_equal(rc, expected_rc);
+	assert_rc_equal(rc, expected_rc);
 	if (use_tx)
 		vts_dtx_end(dth);
 
@@ -1216,12 +1216,12 @@ cond_updaten_op_(void **state, daos_handle_t coh, daos_unit_oid_t oid,
 	rc = vos_obj_update_ex(coh, oid, epoch, 0, flags, &dkey, n, iod, NULL,
 			       sgl, dth);
 	xid = dth->dth_xid;
-	assert_int_equal(rc, expected_rc);
+	assert_rc_equal(rc, expected_rc);
 	vts_dtx_end(dth);
 
 	if (expected_rc == 0) {
 		rc = vos_dtx_commit(coh, &xid, 1, NULL);
-		assert_int_equal(rc, 1);
+		assert_rc_equal(rc, 1);
 	}
 
 }
@@ -1443,7 +1443,7 @@ remove_test(void **state)
 	/* Write the records */
 	rc = vos_obj_update(arg->ctx.tc_co_hdl, oid, epoch++, 0,
 			    0, &dkey, 1, &iod, NULL, &sgl);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 
 	/* Try removing partial entries */
 	recx[3].rx_idx = 1;
@@ -1452,7 +1452,7 @@ remove_test(void **state)
 	epr.epr_hi = epoch;
 	rc = vos_obj_array_remove(arg->ctx.tc_co_hdl, oid, &epr, &dkey,
 				  &iod.iod_name, &recx[3]);
-	assert_int_equal(rc, -DER_NO_PERM);
+	assert_rc_equal(rc, -DER_NO_PERM);
 
 	/* Swap 1 and 2 and write again */
 	d_iov_set(&sg_iov[1], REM_VAL1, sizeof(REM_VAL1) - 1);
@@ -1466,7 +1466,7 @@ remove_test(void **state)
 
 	rc = vos_obj_update(arg->ctx.tc_co_hdl, oid, epoch++, 0,
 			    0, &dkey, 1, &iod, NULL, &sgl);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 
 	recx[0].rx_idx = 0;
 	recx[0].rx_nr = sizeof(REM_VAL1) + sizeof(REM_VAL2) +
@@ -1475,7 +1475,7 @@ remove_test(void **state)
 	d_iov_set(&sg_iov[0], rbuf, sizeof(rbuf));
 	rc = vos_obj_fetch(arg->ctx.tc_co_hdl, oid, epoch, 0, &dkey, 1, &iod,
 			   &sgl);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 	assert_memory_equal(rbuf, REM_VAL2, sizeof(REM_VAL2) - 1);
 	assert_memory_equal(rbuf + sizeof(REM_VAL2) - 1, REM_VAL1,
 			    sizeof(REM_VAL1) - 1);
@@ -1489,12 +1489,12 @@ remove_test(void **state)
 	epr.epr_lo = epoch - 1;
 	rc = vos_obj_array_remove(arg->ctx.tc_co_hdl, oid, &epr, &dkey,
 				  &iod.iod_name, &recx[3]);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 
 	/* Now fetch again, should see old value */
 	rc = vos_obj_fetch(arg->ctx.tc_co_hdl, oid, epoch, 0, &dkey, 1, &iod,
 			   &sgl);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 	assert_memory_equal(rbuf, REM_VAL1, sizeof(REM_VAL1) - 1);
 	assert_memory_equal(rbuf + sizeof(REM_VAL1) - 1, REM_VAL2,
 			    sizeof(REM_VAL2) - 1);
@@ -1552,7 +1552,7 @@ small_sgl(void **state)
 
 	rc = vos_obj_update(arg->ctx.tc_co_hdl, oid, 1, 0, 0, &dkey, 3, iod,
 			    NULL, sgl);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 
 	/** setup for fetch */
 	d_iov_set(&sg_iov[0], buf1, 4);
@@ -1563,7 +1563,7 @@ small_sgl(void **state)
 
 	rc = vos_obj_fetch(arg->ctx.tc_co_hdl, oid, 2, 0, &dkey, 3,
 			   iod, sgl);
-	assert_int_equal(rc, -DER_REC2BIG);
+	assert_rc_equal(rc, -DER_REC2BIG);
 }
 
 static void
@@ -1609,7 +1609,7 @@ minor_epoch_punch_sv(void **state)
 
 	/* Allocate memory for the scatter-gather list */
 	rc = d_sgl_init(&sgl, 1);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 
 	d_iov_set(&sgl.sg_iovs[0], (void *)first, iod.iod_size);
 
@@ -1630,10 +1630,10 @@ minor_epoch_punch_sv(void **state)
 tx_end:
 	xid = dth->dth_xid;
 	vts_dtx_end(dth);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 
 	rc = vos_dtx_commit(arg->ctx.tc_co_hdl, &xid, 1, NULL);
-	assert_int_equal(rc, 1);
+	assert_rc_equal(rc, 1);
 
 	/* Now read back original # of bytes */
 	iod.iod_size = 0;
@@ -1641,7 +1641,7 @@ tx_end:
 	d_iov_set(&sgl.sg_iovs[0], (void *)buf, sizeof(buf));
 	rc = vos_obj_fetch(arg->ctx.tc_co_hdl, oid, epoch++, 0, &dkey, 1,
 			   &iod, &sgl);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 
 	assert_int_equal(iod.iod_size, 0);
 	assert_memory_equal(buf, expected, strlen(expected));
@@ -1694,7 +1694,7 @@ minor_epoch_punch_array(void **state)
 
 	/* Allocate memory for the scatter-gather list */
 	rc = d_sgl_init(&sgl, 1);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 
 	d_iov_set(&sgl.sg_iovs[0], (void *)first, rex.rx_nr);
 
@@ -1726,10 +1726,10 @@ minor_epoch_punch_array(void **state)
 tx_end:
 	xid = dth->dth_xid;
 	vts_dtx_end(dth);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 
 	rc = vos_dtx_commit(arg->ctx.tc_co_hdl, &xid, 1, NULL);
-	assert_int_equal(rc, 1);
+	assert_rc_equal(rc, 1);
 
 	/* Now read back original # of bytes */
 	rex.rx_idx = 0;
@@ -1738,7 +1738,7 @@ tx_end:
 	d_iov_set(&sgl.sg_iovs[0], (void *)buf, strlen(expected));
 	rc = vos_obj_fetch(arg->ctx.tc_co_hdl, oid, epoch++, 0, &dkey, 1,
 			   &iod, &sgl);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 
 	assert_memory_equal(buf, expected, strlen(expected));
 
@@ -1778,7 +1778,7 @@ minor_epoch_punch_rebuild(void **state)
 	set_iov(&akey, &akey_buf[0], arg->ofeat & DAOS_OF_AKEY_UINT64);
 
 	rc = d_sgl_init(&sgl, 1);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 
 	rex.rx_idx = 0;
 	rex.rx_nr = strlen(first);
@@ -1807,12 +1807,12 @@ minor_epoch_punch_rebuild(void **state)
 	/** First write the punched extent */
 	rc = vos_obj_update(arg->ctx.tc_co_hdl, oid, epoch, 0, 0, &dkey, 1,
 			    &iod, NULL, &sgl);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 
 	/** Now the "replay" punch */
 	rc = vos_obj_punch(arg->ctx.tc_co_hdl, oid, epoch + 1, 0,
 			   VOS_OF_REPLAY_PC, &dkey, 1, &akey, NULL);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 
 	/** Now write the update at the same major epoch that is after the
 	 *  punched extent
@@ -1822,7 +1822,7 @@ minor_epoch_punch_rebuild(void **state)
 	d_iov_set(&sgl.sg_iovs[0], (void *)second, rex.rx_nr);
 	rc = vos_obj_update(arg->ctx.tc_co_hdl, oid, epoch + 1, 0, 0, &dkey, 1,
 			    &iod, NULL, &sgl);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 
 	/** Now check the value matches the expected value */
 	memset(buf, 'x', sizeof(buf));
@@ -1831,7 +1831,7 @@ minor_epoch_punch_rebuild(void **state)
 	d_iov_set(&sgl.sg_iovs[0], (void *)buf, sizeof(buf));
 	rc = vos_obj_fetch(arg->ctx.tc_co_hdl, oid, epoch + 2, 0, &dkey, 1,
 			   &iod, &sgl);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 	assert_memory_equal(buf, expected, strlen(expected));
 	epoch += 2;
 
@@ -1873,7 +1873,7 @@ many_keys(void **state)
 	d_iov_set(&dkey, &dkey_buf[0], sizeof(DKEY_NAME) - 1);
 
 	rc = d_sgl_init(&sgl, 1);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 
 	rex.rx_idx = 0;
 	rex.rx_nr = sizeof(w) - 1;
@@ -1898,7 +1898,7 @@ many_keys(void **state)
 			rc = vos_obj_update(arg->ctx.tc_co_hdl, oid,
 					    epoch, 0, 0, &dkey, 1, &iod,
 					    NULL, &sgl);
-			assert_int_equal(rc, 0);
+			assert_rc_equal(rc, 0);
 		}
 	}
 
@@ -1950,7 +1950,7 @@ test_inprogress_parent_punch(void **state)
 	set_iov(&akey3, &akey3_buf[0], arg->ofeat & DAOS_OF_AKEY_UINT64);
 
 	rc = d_sgl_init(&sgl, 1);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 
 	rex.rx_idx = 0;
 	rex.rx_nr = strlen(first);
@@ -1977,14 +1977,14 @@ test_inprogress_parent_punch(void **state)
 	epoch++;
 	rc = vos_obj_update(arg->ctx.tc_co_hdl, oid, epoch, 0, 0, &dkey, 1,
 			    &iod, NULL, &sgl);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 
 	/** Second, committed update to a2 */
 	epoch++;
 	iod.iod_name = akey2;
 	rc = vos_obj_update(arg->ctx.tc_co_hdl, oid, epoch, 0, 0, &dkey, 1,
 			    &iod, NULL, &sgl);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 
 	/** Now prepared update to akey 3 */
 	epoch++;
@@ -1992,7 +1992,7 @@ test_inprogress_parent_punch(void **state)
 	vts_dtx_begin(&oid, arg->ctx.tc_co_hdl, epoch, 0, &dth1);
 	rc = vos_obj_update_ex(arg->ctx.tc_co_hdl, oid, epoch, 0, 0, &dkey, 1,
 			       &iod, NULL, &sgl, dth1);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 	xid1 = dth1->dth_xid;
 	vts_dtx_end(dth1);
 
@@ -2002,30 +2002,30 @@ test_inprogress_parent_punch(void **state)
 	vts_dtx_begin(&oid, arg->ctx.tc_co_hdl, epoch, 0, &dth2);
 	rc = vos_obj_punch(arg->ctx.tc_co_hdl, oid, epoch, 0, 0, &dkey, 1,
 			   &akey1, dth2);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 	xid2 = dth2->dth_xid;
 	vts_dtx_end(dth2);
 	rc = vos_dtx_commit(arg->ctx.tc_co_hdl, &xid2, 1, NULL);
-	assert_int_equal(rc, 1);
+	assert_rc_equal(rc, 1);
 
 	/** Now try to punch akey 2, should fail */
 	epoch++;
 	vts_dtx_begin(&oid, arg->ctx.tc_co_hdl, epoch, 0, &dth2);
 	rc = vos_obj_punch(arg->ctx.tc_co_hdl, oid, epoch, 0, 0, &dkey, 1,
 			   &akey2, dth2);
-	assert_int_equal(rc, -DER_INPROGRESS);
+	assert_rc_equal(rc, -DER_INPROGRESS);
 
 	/** Now commit the in progress punch and try again */
 	rc = vos_dtx_commit(arg->ctx.tc_co_hdl, &xid1, 1, NULL);
-	assert_int_equal(rc, 1);
+	assert_rc_equal(rc, 1);
 
 	rc = vos_obj_punch(arg->ctx.tc_co_hdl, oid, epoch, 0, 0, &dkey, 1,
 			   &akey2, dth2);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 	xid2 = dth2->dth_xid;
 	vts_dtx_end(dth2);
 	rc = vos_dtx_commit(arg->ctx.tc_co_hdl, &xid2, 1, NULL);
-	assert_int_equal(rc, 1);
+	assert_rc_equal(rc, 1);
 
 	memset(buf, 'x', sizeof(buf));
 	rex.rx_idx = 0;
@@ -2034,7 +2034,7 @@ test_inprogress_parent_punch(void **state)
 	d_iov_set(&sgl.sg_iovs[0], (void *)buf, sizeof(buf));
 	rc = vos_obj_fetch(arg->ctx.tc_co_hdl, oid, epoch + 2, 0, &dkey, 1,
 			   &iod, &sgl);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 	assert_memory_equal(buf, expected, strlen(expected));
 
 	d_sgl_fini(&sgl, false);
@@ -2188,9 +2188,9 @@ many_tx(void **state)
 	memset(&iod, 0, sizeof(iod));
 
 	rc = d_sgl_init(&sgl, 1);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 	rc = d_sgl_init(&fetch_sgl, 1);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 
 	/* Set up dkey and akey */
 	for (i = 0; i < nr_obj; i++)
@@ -2288,7 +2288,7 @@ start_over:
 						rc = vos_dtx_commit(coh,
 							    &req[old_tx].xid, 1,
 							    NULL);
-						assert_int_equal(rc, 1);
+						assert_rc_equal(rc, 1);
 					}
 					memset(&req[old_tx], 0, sizeof(req[0]));
 				}
@@ -2298,7 +2298,7 @@ start_over:
 			continue;
 		epr.epr_hi = epoch - 200;
 		rc = vos_aggregate(coh, &epr, NULL, NULL, NULL);
-		assert_int_equal(rc, 0);
+		assert_rc_equal(rc, 0);
 	}
 	for (i = 0; i < NR_TX - 1; i++) {
 		old_tx = (tx_num++ + 1) % NR_TX;
@@ -2307,13 +2307,13 @@ start_over:
 			continue;
 		}
 		rc = vos_dtx_commit(coh, &req[old_tx].xid, 1, NULL);
-		assert_int_equal(rc, 1);
+		assert_rc_equal(rc, 1);
 		memset(&req[old_tx], 0, sizeof(req[0]));
 	}
 
 	for (i = 0; i < nr_obj; i++) {
 		rc = vos_obj_delete(coh, oid[i]);
-		assert_int_equal(rc, 0);
+		assert_rc_equal(rc, 0);
 	}
 
 	if (!done) {
@@ -2368,9 +2368,9 @@ test_multiple_key_conditionals_common(void **state, bool with_dtx)
 	set_iov(&akey2, &akey2_buf[0], arg->ofeat & DAOS_OF_AKEY_UINT64);
 
 	rc = d_sgl_init(&sgl[0], 1);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 	rc = d_sgl_init(&sgl[1], 1);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 
 	rex[0].rx_idx = 0;
 	rex[0].rx_nr = strlen(first);
@@ -2401,7 +2401,7 @@ test_multiple_key_conditionals_common(void **state, bool with_dtx)
 	rc = vos_obj_update_ex(arg->ctx.tc_co_hdl, oid, epoch, 0,
 			       DAOS_COND_PER_AKEY, &dkey, 2, iod, NULL, sgl,
 			       dth);
-	assert_int_equal(rc, -DER_NONEXIST);
+	assert_rc_equal(rc, -DER_NONEXIST);
 	if (with_dtx)
 		vts_dtx_end(dth);
 
@@ -2413,11 +2413,11 @@ test_multiple_key_conditionals_common(void **state, bool with_dtx)
 	}
 	rc = vos_obj_update_ex(arg->ctx.tc_co_hdl, oid, epoch, 0, 0, &dkey, 1,
 			       iod, NULL, sgl, dth);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 	if (with_dtx) {
 		vts_dtx_end(dth);
 		rc = vos_dtx_commit(arg->ctx.tc_co_hdl, &xid, 1, NULL);
-		assert_int_equal(rc, 1);
+		assert_rc_equal(rc, 1);
 	}
 
 	/** Try again, condition on akey 2 should fail */
@@ -2427,7 +2427,7 @@ test_multiple_key_conditionals_common(void **state, bool with_dtx)
 	rc = vos_obj_update_ex(arg->ctx.tc_co_hdl, oid, epoch, 0,
 			       DAOS_COND_PER_AKEY, &dkey, 2, iod, NULL, sgl,
 			       dth);
-	assert_int_equal(rc, -DER_NONEXIST);
+	assert_rc_equal(rc, -DER_NONEXIST);
 	if (with_dtx)
 		vts_dtx_end(dth);
 
@@ -2441,11 +2441,11 @@ test_multiple_key_conditionals_common(void **state, bool with_dtx)
 	rc = vos_obj_update_ex(arg->ctx.tc_co_hdl, oid, epoch, 0,
 			       DAOS_COND_PER_AKEY, &dkey, 2, iod, NULL, sgl,
 			       dth);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 	if (with_dtx) {
 		vts_dtx_end(dth);
 		rc = vos_dtx_commit(arg->ctx.tc_co_hdl, &xid, 1, NULL);
-		assert_int_equal(rc, 1);
+		assert_rc_equal(rc, 1);
 	}
 
 	/** Try update, should pass this time */
@@ -2458,11 +2458,11 @@ test_multiple_key_conditionals_common(void **state, bool with_dtx)
 	rc = vos_obj_update_ex(arg->ctx.tc_co_hdl, oid, epoch, 0,
 			       DAOS_COND_PER_AKEY, &dkey, 2, iod, NULL, sgl,
 			       dth);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 	if (with_dtx) {
 		vts_dtx_end(dth);
 		rc = vos_dtx_commit(arg->ctx.tc_co_hdl, &xid, 1, NULL);
-		assert_int_equal(rc, 1);
+		assert_rc_equal(rc, 1);
 	}
 
 	/** Conditional insert should fail */
@@ -2473,7 +2473,7 @@ test_multiple_key_conditionals_common(void **state, bool with_dtx)
 	rc = vos_obj_update_ex(arg->ctx.tc_co_hdl, oid, epoch, 0,
 			       DAOS_COND_PER_AKEY, &dkey, 2, iod, NULL, sgl,
 			       dth);
-	assert_int_equal(rc, -DER_EXIST);
+	assert_rc_equal(rc, -DER_EXIST);
 	if (with_dtx)
 		vts_dtx_end(dth);
 
@@ -2487,7 +2487,7 @@ test_multiple_key_conditionals_common(void **state, bool with_dtx)
 	d_iov_set(&sgl[1].sg_iovs[0], (void *)buf2, rex[1].rx_nr);
 	rc = vos_obj_fetch_ex(arg->ctx.tc_co_hdl, oid, epoch,
 			      DAOS_COND_PER_AKEY, &dkey, 2, iod, sgl, dth);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 	assert_memory_equal(buf1, first, rex[0].rx_nr);
 	assert_memory_equal(buf2, second, rex[1].rx_nr);
 	if (with_dtx)
@@ -2501,11 +2501,11 @@ test_multiple_key_conditionals_common(void **state, bool with_dtx)
 	}
 	rc = vos_obj_punch(arg->ctx.tc_co_hdl, oid, epoch, 0, 0, &dkey,
 			   1, &akey2, dth);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 	if (with_dtx) {
 		vts_dtx_end(dth);
 		rc = vos_dtx_commit(arg->ctx.tc_co_hdl, &xid, 1, NULL);
-		assert_int_equal(rc, 1);
+		assert_rc_equal(rc, 1);
 	}
 
 	epoch++;
@@ -2518,7 +2518,7 @@ test_multiple_key_conditionals_common(void **state, bool with_dtx)
 	d_iov_set(&sgl[1].sg_iovs[0], (void *)buf2, rex[1].rx_nr);
 	rc = vos_obj_fetch_ex(arg->ctx.tc_co_hdl, oid, epoch,
 			      DAOS_COND_PER_AKEY, &dkey, 2, iod, sgl, dth);
-	assert_int_equal(rc, -DER_NONEXIST);
+	assert_rc_equal(rc, -DER_NONEXIST);
 	assert_memory_equal(buf1, expected, rex[0].rx_nr);
 	assert_memory_equal(buf2, expected, rex[1].rx_nr);
 	if (with_dtx)
@@ -2535,7 +2535,7 @@ test_multiple_key_conditionals_common(void **state, bool with_dtx)
 	rc = vos_obj_update_ex(arg->ctx.tc_co_hdl, oid, epoch, 0,
 			       DAOS_COND_DKEY_INSERT | DAOS_COND_PER_AKEY,
 			       &dkey, 2, iod, NULL, sgl, dth);
-	assert_int_equal(rc, -DER_NONEXIST);
+	assert_rc_equal(rc, -DER_NONEXIST);
 	if (with_dtx)
 		vts_dtx_end(dth);
 

--- a/src/vos/tests/vts_pool.c
+++ b/src/vos/tests/vts_pool.c
@@ -102,18 +102,18 @@ pool_ref_count_test(void **state)
 	for (i = 0; i < num; i++) {
 		ret = vos_pool_open(arg->fname[0], uuid, false /*small */,
 				    &arg->poh[i]);
-		assert_int_equal(ret, 0);
+		assert_rc_equal(ret, 0);
 	}
 	for (i = 0; i < num - 1; i++) {
 		ret = vos_pool_close(arg->poh[i]);
-		assert_int_equal(ret, 0);
+		assert_rc_equal(ret, 0);
 	}
 	ret = vos_pool_destroy(arg->fname[0], uuid);
-	assert_int_equal(ret, -DER_BUSY);
+	assert_rc_equal(ret, -DER_BUSY);
 	ret = vos_pool_close(arg->poh[num - 1]);
-	assert_int_equal(ret, 0);
+	assert_rc_equal(ret, 0);
 	ret = vos_pool_destroy(arg->fname[0], uuid);
-	assert_int_equal(ret, 0);
+	assert_rc_equal(ret, 0);
 }
 
 static void
@@ -130,13 +130,13 @@ pool_interop(void **state)
 
 	daos_fail_loc_set(FLC_POOL_DF_VER | DAOS_FAIL_ONCE);
 	ret = vos_pool_create(arg->fname[0], uuid, VPOOL_16M, 0);
-	assert_int_equal(ret, 0);
+	assert_rc_equal(ret, 0);
 
 	ret = vos_pool_open(arg->fname[0], uuid, false, &poh);
-	assert_int_equal(ret, -DER_DF_INCOMPT);
+	assert_rc_equal(ret, -DER_DF_INCOMPT);
 
 	ret = vos_pool_destroy(arg->fname[0], uuid);
-	assert_int_equal(ret, 0);
+	assert_rc_equal(ret, 0);
 }
 
 static void
@@ -183,7 +183,7 @@ pool_ops_run(void **state)
 				break;
 			case QUERY:
 				ret = vos_pool_query(arg->poh[j], &pinfo);
-				assert_int_equal(ret, 0);
+				assert_rc_equal(ret, 0);
 				assert_int_equal(pinfo.pif_cont_nr, 0);
 				assert_false(SCM_TOTAL(&pinfo.pif_space) !=
 						VPOOL_16M);
@@ -197,7 +197,7 @@ pool_ops_run(void **state)
 				break;
 			}
 			if (arg->ops_seq[j][i] != QUERY)
-				assert_int_equal(ret, 0);
+				assert_rc_equal(ret, 0);
 		}
 	}
 }

--- a/src/vos/tests/vts_ts.c
+++ b/src/vos/tests/vts_ts.c
@@ -358,7 +358,7 @@ lru_array_test(void **state)
 
 	for (i = 0; i < NUM_INDEXES; i++) {
 		rc = lrua_alloc(ts_arg->array, &ts_arg->indexes[i].idx, &entry);
-		assert_int_equal(rc, 0);
+		assert_rc_equal(rc, 0);
 		assert_non_null(entry);
 
 		entry->record = &ts_arg->indexes[i];
@@ -395,7 +395,7 @@ lru_array_test(void **state)
 				    &entry);
 		assert_false(found);
 		rc = lrua_alloc(ts_arg->array, &ts_arg->indexes[i].idx, &entry);
-		assert_int_equal(rc, 0);
+		assert_rc_equal(rc, 0);
 		assert_non_null(entry);
 
 		entry->record = &ts_arg->indexes[i];
@@ -459,7 +459,7 @@ lru_array_stress_test(void **state)
 				continue;
 			rc = lrua_alloc(ts_arg->array, &stress_entries[i].idx,
 					&entry);
-			assert_int_equal(rc, 0);
+			assert_rc_equal(rc, 0);
 			assert_non_null(entry);
 			entry->record = &ts_arg->indexes[i];
 			ts_arg->indexes[i].value = i;
@@ -498,7 +498,7 @@ lru_array_stress_test(void **state)
 		if (op < 7) {
 			rc = lrua_alloc(ts_arg->array, &stress_entries[i].idx,
 					&entry);
-			assert_int_equal(rc, 0);
+			assert_rc_equal(rc, 0);
 			assert_non_null(entry);
 
 			entry->record = &stress_entries[i];
@@ -541,7 +541,7 @@ lru_array_stress_test(void **state)
 
 	for (i = 0; i < LRU_ARRAY_SIZE; i++) {
 		rc = lrua_alloc(ts_arg->array, &stress_entries[i].idx, &entry);
-		assert_int_equal(rc, 0);
+		assert_rc_equal(rc, 0);
 		assert_non_null(entry);
 		entry->record = &stress_entries[i];
 		stress_entries[i].value = i;
@@ -552,7 +552,7 @@ lru_array_stress_test(void **state)
 	for (i = 0; i < LRU_ARRAY_SIZE; i++) {
 		j = i + LRU_ARRAY_SIZE;
 		rc = lrua_alloc(ts_arg->array, &stress_entries[j].idx, &entry);
-		assert_int_equal(rc, 0);
+		assert_rc_equal(rc, 0);
 		assert_non_null(entry);
 		entry->record = &stress_entries[j];
 		stress_entries[j].value = j;
@@ -561,7 +561,7 @@ lru_array_stress_test(void **state)
 	for (i = LRU_ARRAY_SIZE - 1; i >= 0; i--) {
 		j = i +  2 * LRU_ARRAY_SIZE;
 		rc = lrua_alloc(ts_arg->array, &stress_entries[j].idx, &entry);
-		assert_int_equal(rc, 0);
+		assert_rc_equal(rc, 0);
 		assert_non_null(entry);
 		entry->record = &stress_entries[j];
 		stress_entries[j].value = j;
@@ -602,7 +602,7 @@ lru_array_multi_test_iter(void **state)
 			rc = lrua_alloc(ts_arg->array, &ts_arg->indexes[i].idx,
 					&entry);
 		}
-		assert_int_equal(rc, 0);
+		assert_rc_equal(rc, 0);
 		assert_non_null(entry);
 		entry->record = &ts_arg->indexes[i];
 		ts_arg->indexes[i].value = i;
@@ -638,7 +638,7 @@ inplace_test(struct lru_arg *ts_arg, uint32_t idx, uint64_t key1, uint64_t key2)
 
 	rc = lrua_allocx_inplace(ts_arg->array, idx, key1,
 				 &entry);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
 	assert_non_null(entry);
 	assert_true(entry->magic1 == MAGIC1);
 	assert_true(entry->magic2 == MAGIC2);


### PR DESCRIPTION
This macro converts the return codes to DAOS rc strings and compare
them, in order to have the rc logged as strings and not hexadecimal
number in case of an error.

Signed-off-by: Marcela Rosales <marcela.a.rosales.jimenez@intel.com>