### PR TITLE
DAOS-4888 vos: Fix lowest supported version

### DIFF
--- a/src/vos/vos_layout.h
+++ b/src/vos/vos_layout.h
@@ -104,8 +104,10 @@ enum vos_gc_type {
 
 #define POOL_DF_MAGIC				0x5ca1ab1e
 
-#define POOL_DF_VER_1				1
-#define POOL_DF_VERSION				12
+/** Lowest supported durable format version */
+#define POOL_DF_VER_1				12
+/** Current durable format version */
+#define POOL_DF_VERSION				POOL_DF_VER_1
 
 /**
  * Durable format for VOS pool


### PR DESCRIPTION
We've made several incompatible changes.  A misunderstanding of the
code here means we are assuming compatiblity with older versions
which is just wrong.   Set the lowest compatible version and
add comments to make it clearer.

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>