### PR TITLE
DAOS-6582 build: Update fuse version back to 34 for CentOS 8 builds.

### DIFF
--- a/src/client/dfs/SConscript
+++ b/src/client/dfs/SConscript
@@ -33,8 +33,6 @@ def scons():
 
     configure_lustre(denv)
 
-    denv.AppendUnique(CPPDEFINES=['-DFUSE_USE_VERSION=35'])
-
     libraries = ['$LIBS', 'daos_common', 'daos', 'uuid', 'gurt']
 
     dfs_src = ['dfs.c']

--- a/src/client/dfuse/SConscript
+++ b/src/client/dfuse/SConscript
@@ -158,9 +158,6 @@ def scons():
     libs += build_client_libs_static(static_env, common)
 
     cenv = dfuse_env.Clone()
-    # Set the define in SConscript so that it's in place for the prereqs.require
-    # check which will verify fuse3/fuse.h can be loaded.
-    cenv.AppendUnique(CPPDEFINES=['-DFUSE_USE_VERSION=35'])
     cenv.AppendUnique(LIBPATH=["../dfs"])
     cenv.AppendUnique(CPPPATH=["../dfs"])
 

--- a/utils/sl/components/__init__.py
+++ b/utils/sl/components/__init__.py
@@ -294,7 +294,7 @@ def define_components(reqs):
                 libs=['abt'],
                 headers=['abt.h'])
 
-    reqs.define('fuse', libs=['fuse3'], defines=["FUSE_USE_VERSION=35"],
+    reqs.define('fuse', libs=['fuse3'], defines=["FUSE_USE_VERSION=34"],
                 headers=['fuse3/fuse.h'], package='fuse3-devel')
 
     retriever = GitRepoRetriever("https://github.com/spdk/spdk.git", True)


### PR DESCRIPTION
Remove FUSE_USE_VERSION from the dfuse build to use the sl version only.
Chang the version to be 34 so we are compatible with all versions we
want to support.

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>