### PR TITLE
DAOS-6564 tests: skip rank 0 in test_27

### DIFF
--- a/src/tests/suite/daos_rebuild.c
+++ b/src/tests/suite/daos_rebuild.c
@@ -1162,7 +1162,7 @@ rebuild_fail_all_replicas(void **state)
 	 * the new leader can be chosen.
 	 */
 	if (!test_runable(arg, 6) || arg->pool.alive_svc->rl_nr < 6) {
-		print_message("need at least 6 svcs, -s5\n");
+		print_message("need at least 6 svcs, -s6\n");
 		return;
 	}
 
@@ -1180,6 +1180,9 @@ rebuild_fail_all_replicas(void **state)
 			d_rank_t rank =
 				layout->ol_shards[i]->os_shard_loc[j].sd_rank;
 
+			/* Skip rank 0 temporarily due to DAOS-6564 XXX */
+			if (rank == 0)
+				continue;
 			daos_kill_server(arg, arg->pool.pool_uuid,
 					 arg->group, arg->pool.alive_svc,
 					 rank);


### PR DESCRIPTION
Skip rank 0 for rebuild test 27 until the test is
configuring replicated MS.

Signed-off-by: Di Wang <di.wang@intel.com>