### PR TITLE
DAOS-623 build: Add textfile tool for systems where it's not default

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -370,7 +370,7 @@ def scons(): # pylint: disable=too-many-locals
     sys.path.insert(0, os.path.join(Dir('#').abspath, 'utils/sl'))
     from prereq_tools import PreReqComponent
 
-    env = Environment(TOOLS=['extra', 'default'])
+    env = Environment(TOOLS=['extra', 'default', 'textfile'])
 
     if os.path.exists("daos_m.conf"):
         os.rename("daos_m.conf", "daos.conf")


### PR DESCRIPTION
Some platforms don't add the textfile tool which provides the Substfile
builder so add the tool explicitly when loading the scons environment.

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>