### PR TITLE
DAOS-6032 control: Increase drpc message size limit

### DIFF
--- a/src/control/drpc/drpc_server.go
+++ b/src/control/drpc/drpc_server.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2018-2020 Intel Corporation.
+// (C) Copyright 2018-2021 Intel Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -41,7 +41,7 @@ import (
 // buffer to put all of the information in. Corresponding C definition is
 // found in include/daos/drpc.h
 //
-const MaxMsgSize = 16384
+const MaxMsgSize = 1 << 17
 
 // DomainSocketServer is the object that listens for incoming dRPC connections,
 // maintains the connections for sessions, and manages the message processing.

--- a/src/control/server/drpc.go
+++ b/src/control/server/drpc.go
@@ -240,7 +240,7 @@ func makeDrpcCall(ctx context.Context, log logging.Logger, client drpc.DomainSoc
 		defer client.Close()
 
 		if drpcResp, err = client.SendMsg(drpcCall); err != nil {
-			return nil, errors.Wrap(err, "send message")
+			return nil, errors.Wrapf(err, "failed to send %dB message", proto.Size(msg))
 		}
 
 		if err = checkDrpcResponse(drpcResp); err != nil {

--- a/src/control/server/instance_drpc.go
+++ b/src/control/server/instance_drpc.go
@@ -91,7 +91,7 @@ func (srv *IOServerInstance) CallDrpc(ctx context.Context, method drpc.Method, b
 	if sb := srv.getSuperblock(); sb != nil {
 		rankMsg = fmt.Sprintf(" (rank %s)", sb.Rank)
 	}
-	srv.log.Debugf("dRPC to index %d%s: %s", srv.Index(), rankMsg, method)
+	srv.log.Debugf("%dB dRPC to index %d%s: %s", proto.Size(body), srv.Index(), rankMsg, method)
 
 	return makeDrpcCall(ctx, srv.log, dc, method, body)
 }

--- a/src/include/daos/drpc.h
+++ b/src/include/daos/drpc.h
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2018-2020 Intel Corporation.
+ * (C) Copyright 2018-2021 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,10 +32,10 @@
  * a whole message at a time without knowing its size. So for this reason
  * we need to restrict the maximum message size so we can preallocate a
  * buffer to put all of the information in. This value is also defined in
- * the corresponding golang file domain_socket_server.go. If changed here
+ * the corresponding control plane file drpc_server.go. If changed here
  * it must be changed in that file as well
  */
-#define UNIXCOMM_MAXMSGSIZE 16384
+#define UNIXCOMM_MAXMSGSIZE (1 << 17)
 
 struct unixcomm {
 	int fd; /** File descriptor of the unix domain socket */


### PR DESCRIPTION
The previous size was 16K, which is too small for large systems.
Increasing it to 128K should be plenty.