### PR TITLE
DAOS-6593 control: handle generic ras events received over drpc

### DIFF
--- a/src/control/events/generic.go
+++ b/src/control/events/generic.go
@@ -1,0 +1,60 @@
+//
+// (C) Copyright 2020-2021 Intel Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// GOVERNMENT LICENSE RIGHTS-OPEN SOURCE SOFTWARE
+// The Government's rights to use, modify, reproduce, release, perform, display,
+// or disclose this software are subject to the terms of the Apache License as
+// provided in Contract No. 8F-30005.
+// Any reproduction of computer software, computer software documentation, or
+// portions thereof marked with this legend must also reproduce the markings.
+//
+
+package events
+
+import (
+	sharedpb "github.com/daos-stack/daos/src/control/common/proto/shared"
+)
+
+// StrInfo contains opaque blob of type string to hold custom details for a
+// generic RAS event to be forwarded through the control-plane from the
+// data-plane to an external consumer e.g. syslog.
+type StrInfo string
+
+func (si *StrInfo) isExtendedInfo() {}
+
+// GetStrInfo returns extended info if of type StrInfo.
+func (evt *RASEvent) GetStrInfo() *StrInfo {
+	if ei, ok := evt.ExtendedInfo.(*StrInfo); ok {
+		return ei
+	}
+
+	return nil
+}
+
+// StrInfoFromProto converts event info from proto to native format.
+func StrInfoFromProto(pbInfo *sharedpb.RASEvent_StrInfo) (*StrInfo, error) {
+	si := StrInfo(pbInfo.StrInfo)
+
+	return &si, nil
+}
+
+// StrInfoToProto converts event info from native to proto format.
+func StrInfoToProto(si *StrInfo) (*sharedpb.RASEvent_StrInfo, error) {
+	pbInfo := &sharedpb.RASEvent_StrInfo{
+		StrInfo: string(*si),
+	}
+
+	return pbInfo, nil
+}

--- a/src/control/events/generic_test.go
+++ b/src/control/events/generic_test.go
@@ -1,0 +1,71 @@
+//
+// (C) Copyright 2020-2021 Intel Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// GOVERNMENT LICENSE RIGHTS-OPEN SOURCE SOFTWARE
+// The Government's rights to use, modify, reproduce, release, perform, display,
+// or disclose this software are subject to the terms of the Apache License as
+// provided in Contract No. 8F-30005.
+// Any reproduction of computer software, computer software documentation, or
+// portions thereof marked with this legend must also reproduce the markings.
+//
+
+package events
+
+import (
+	"math"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/daos-stack/daos/src/control/common"
+)
+
+func mockGenericEvent() *RASEvent {
+	si := StrInfo("{\"people\":[\"bill\",\"steve\",\"bob\"]}")
+
+	return &RASEvent{
+		Timestamp:    common.FormatTime(time.Now()),
+		Msg:          "DAOS generic test event",
+		ID:           math.MaxInt32 - 1,
+		Hostname:     "foo",
+		Rank:         1,
+		Type:         RASTypeInfoOnly,
+		Severity:     RASSeverityError,
+		ExtendedInfo: &si,
+	}
+}
+
+func TestEvents_ConvertGeneric(t *testing.T) {
+	event := mockGenericEvent()
+
+	pbEvent, err := event.ToProto()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Logf("proto event: %+v (%T)", pbEvent, pbEvent)
+
+	returnedEvent := new(RASEvent)
+	if err := returnedEvent.FromProto(pbEvent); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Logf("native event: %+v, %s", returnedEvent, *returnedEvent.GetStrInfo())
+
+	if diff := cmp.Diff(event, returnedEvent); diff != "" {
+		t.Fatalf("unexpected event (-want, +got):\n%s\n", diff)
+	}
+}

--- a/src/control/events/pubsub_test.go
+++ b/src/control/events/pubsub_test.go
@@ -172,8 +172,6 @@ func TestEvents_PubSub_DisableEvent(t *testing.T) {
 	common.AssertEqual(t, 2, len(tly1.getRx()), "unexpected number of received events")
 }
 
-// TODO: update subscribe any topic test to use events of different types when
-// more events exist.
 func TestEvents_PubSub_SubscribeAnyTopic(t *testing.T) {
 	evt1 := NewRankDownEvent("foo", 1, 1, common.ExitStatus("test"))
 
@@ -185,7 +183,7 @@ func TestEvents_PubSub_SubscribeAnyTopic(t *testing.T) {
 	ps := NewPubSub(ctx, log)
 	defer ps.Close()
 
-	tly1 := newTally(2)
+	tly1 := newTally(3)
 	tly2 := newTally(2)
 
 	ps.Subscribe(RASTypeAny, tly1)
@@ -193,14 +191,19 @@ func TestEvents_PubSub_SubscribeAnyTopic(t *testing.T) {
 
 	ps.Publish(evt1)
 	ps.Publish(evt1)
+	ps.Publish(mockGenericEvent()) // of type InfoOnly will only match Any
 
 	<-tly1.finished
 	<-tly2.finished
 
 	common.AssertStringsEqual(t, []string{
-		RASTypeStateChange.String(), RASTypeStateChange.String(),
+		RASTypeInfoOnly.String(),
+		RASTypeStateChange.String(),
+		RASTypeStateChange.String(),
 	}, tly1.getRx(), "tly1 unexpected slice of received events")
+
 	common.AssertStringsEqual(t, []string{
-		RASTypeStateChange.String(), RASTypeStateChange.String(),
+		RASTypeStateChange.String(),
+		RASTypeStateChange.String(),
 	}, tly2.getRx(), "tly2 unexpected slice of received events")
 }

--- a/src/control/events/ras.go
+++ b/src/control/events/ras.go
@@ -47,12 +47,7 @@ type RASExtendedInfo interface {
 func NewFromProto(pbEvt *sharedpb.RASEvent) (*RASEvent, error) {
 	evt := new(RASEvent)
 
-	switch RASID(pbEvt.Id) {
-	case RASRankDown, RASPoolRepsUpdate:
-		return evt, evt.FromProto(pbEvt)
-	default:
-		return nil, errors.Errorf("unsupported event ID: %d", pbEvt.Id)
-	}
+	return evt, evt.FromProto(pbEvt)
 }
 
 // RASID identifies a given RAS event.
@@ -186,6 +181,8 @@ func (evt *RASEvent) ToProto() (*sharedpb.RASEvent, error) {
 		pbEvt.ExtendedInfo, err = RankStateInfoToProto(ei)
 	case *PoolSvcInfo:
 		pbEvt.ExtendedInfo, err = PoolSvcInfoToProto(ei)
+	case *StrInfo:
+		pbEvt.ExtendedInfo, err = StrInfoToProto(ei)
 	}
 
 	return pbEvt, err
@@ -216,7 +213,34 @@ func (evt *RASEvent) FromProto(pbEvt *sharedpb.RASEvent) (err error) {
 		evt.ExtendedInfo, err = RankStateInfoFromProto(ei)
 	case *sharedpb.RASEvent_PoolSvcInfo:
 		evt.ExtendedInfo, err = PoolSvcInfoFromProto(ei)
+	case *sharedpb.RASEvent_StrInfo:
+		evt.ExtendedInfo, err = StrInfoFromProto(ei)
+	default:
+		err = errors.New("unknown extended info type")
 	}
 
 	return
+}
+
+// HandleClusterEvent extracts event field from protobuf request message and
+// converts to concrete event type that implements the Event interface.
+// The Event is then published to make available to locally subscribed consumers
+// to act upon.
+func (ps *PubSub) HandleClusterEvent(req *sharedpb.ClusterEventReq) (*sharedpb.ClusterEventResp, error) {
+	switch {
+	case req == nil:
+		return nil, errors.New("nil request")
+	case req.Event == nil:
+		return nil, errors.New("nil event in request")
+	case req.Sequence == 0:
+		ps.log.Debug("no sequence number in request")
+	}
+
+	event, err := NewFromProto(req.Event)
+	if err != nil {
+		return nil, err
+	}
+	ps.Publish(event)
+
+	return &sharedpb.ClusterEventResp{Sequence: req.Sequence}, nil
 }

--- a/src/control/events/ras_test.go
+++ b/src/control/events/ras_test.go
@@ -1,0 +1,139 @@
+//
+// (C) Copyright 2020-2021 Intel Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// GOVERNMENT LICENSE RIGHTS-OPEN SOURCE SOFTWARE
+// The Government's rights to use, modify, reproduce, release, perform, display,
+// or disclose this software are subject to the terms of the Apache License as
+// provided in Contract No. 8F-30005.
+// Any reproduction of computer software, computer software documentation, or
+// portions thereof marked with this legend must also reproduce the markings.
+//
+
+package events
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/pkg/errors"
+
+	"github.com/daos-stack/daos/src/control/common"
+	sharedpb "github.com/daos-stack/daos/src/control/common/proto/shared"
+	"github.com/daos-stack/daos/src/control/logging"
+)
+
+func TestEvents_HandleClusterEvent(t *testing.T) {
+	genericEvent := mockGenericEvent()
+	pbGenericEvent, _ := genericEvent.ToProto()
+	rankDownEvent := NewRankDownEvent("foo", 1, 1, common.ExitStatus("test"))
+	pbRankDownEvent, _ := rankDownEvent.ToProto()
+	psrEvent := NewPoolSvcReplicasUpdateEvent("foo", 1, common.MockUUID(), []uint32{0, 1}, 1)
+	pbPSREvent, _ := psrEvent.ToProto()
+
+	for name, tc := range map[string]struct {
+		req         *sharedpb.ClusterEventReq
+		subType     RASTypeID
+		expEvtTypes []string
+		expResp     *sharedpb.ClusterEventResp
+		expErr      error
+	}{
+		"nil req": {
+			expErr: errors.New("nil request"),
+		},
+		"nil event": {
+			req:    &sharedpb.ClusterEventReq{},
+			expErr: errors.New("nil event in request"),
+		},
+		"generic event": {
+			req: &sharedpb.ClusterEventReq{
+				Event: pbGenericEvent,
+			},
+			subType:     RASTypeInfoOnly,
+			expEvtTypes: []string{RASTypeInfoOnly.String()},
+			expResp:     &sharedpb.ClusterEventResp{},
+		},
+		"filtered generic event": {
+			req: &sharedpb.ClusterEventReq{
+				Event: pbGenericEvent,
+			},
+			subType: RASTypeStateChange,
+			expResp: &sharedpb.ClusterEventResp{},
+		},
+		"rank down event": {
+			req: &sharedpb.ClusterEventReq{
+				Event: pbRankDownEvent,
+			},
+			subType:     RASTypeStateChange,
+			expEvtTypes: []string{RASTypeStateChange.String()},
+			expResp:     &sharedpb.ClusterEventResp{},
+		},
+		"filtered rank down event": {
+			req: &sharedpb.ClusterEventReq{
+				Event: pbRankDownEvent,
+			},
+			subType: RASTypeInfoOnly,
+			expResp: &sharedpb.ClusterEventResp{},
+		},
+		"pool svc replica update event": {
+			req: &sharedpb.ClusterEventReq{
+				Event: pbPSREvent,
+			},
+			subType:     RASTypeStateChange,
+			expEvtTypes: []string{RASTypeStateChange.String()},
+			expResp:     &sharedpb.ClusterEventResp{},
+		},
+		"filtered pool svc replica update event": {
+			req: &sharedpb.ClusterEventReq{
+				Event: pbPSREvent,
+			},
+			subType: RASTypeInfoOnly,
+			expResp: &sharedpb.ClusterEventResp{},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			log, buf := logging.NewTestLogger(t.Name())
+			defer common.ShowBufferOnFailure(t, buf)
+
+			ctx := context.Background()
+
+			ps := NewPubSub(ctx, log)
+			defer ps.Close()
+
+			tly1 := newTally(len(tc.expEvtTypes))
+
+			ps.Subscribe(tc.subType, tly1)
+
+			resp, err := ps.HandleClusterEvent(tc.req)
+			common.CmpErr(t, tc.expErr, err)
+			if err != nil {
+				return
+			}
+
+			select {
+			case <-time.After(50 * time.Millisecond):
+			case <-tly1.finished:
+			}
+
+			common.AssertStringsEqual(t, tc.expEvtTypes, tly1.getRx(),
+				"unexpected received events")
+
+			if diff := cmp.Diff(tc.expResp, resp); diff != "" {
+				t.Fatalf("unexpected response (-want, +got):\n%s\n", diff)
+			}
+		})
+	}
+}

--- a/src/control/lib/control/system.go
+++ b/src/control/lib/control/system.go
@@ -42,6 +42,7 @@ import (
 	sharedpb "github.com/daos-stack/daos/src/control/common/proto/shared"
 	"github.com/daos-stack/daos/src/control/events"
 	"github.com/daos-stack/daos/src/control/lib/hostlist"
+	"github.com/daos-stack/daos/src/control/logging"
 	"github.com/daos-stack/daos/src/control/system"
 )
 
@@ -264,6 +265,22 @@ func NewEventForwarder(rpcClient UnaryInvoker, accessPts []string) *EventForward
 		client:    rpcClient,
 		accessPts: accessPts,
 	}
+}
+
+// EventLogger implements the events.Handler interface and logs RAS event to
+// INFO.
+type EventLogger struct {
+	log logging.Logger
+}
+
+// OnEvent implements the events.Handler interface.
+func (el *EventLogger) OnEvent(_ context.Context, evt *events.RASEvent) {
+	el.log.Infof("RAS event received: %+v", evt)
+}
+
+// NewEventLogger returns an initialized EventLogger.
+func NewEventLogger(log logging.Logger) *EventLogger {
+	return &EventLogger{log: log}
 }
 
 // SystemQueryReq contains the inputs for the system query request.


### PR DESCRIPTION
Events that are raised through the ds_notify_ras_event API exposed in
daos_srv/ras.h should be handled when received by daos_server over
dRPC. The events should be converted into generic RAS go event and
NOT forwarded to MS leader but published to local instance syslog
(for this ticket just log to INFO in control plane).

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>