### PR TITLE
DAOS-6177 dtx: keep the CoS tree until container close

### DIFF
--- a/src/dtx/dtx_common.c
+++ b/src/dtx/dtx_common.c
@@ -163,6 +163,7 @@ dtx_batched_commit(void *arg)
 {
 	struct dss_module_info		*dmi = dss_get_module_info();
 	struct dtx_batched_commit_args	*dbca;
+	struct dtx_batched_commit_args	*tmp;
 
 	while (1) {
 		struct dtx_entry		**dtes = NULL;
@@ -236,10 +237,12 @@ check:
 		ABT_thread_yield();
 	}
 
-	while (!d_list_empty(&dmi->dmi_dtx_batched_list)) {
-		dbca = d_list_entry(dmi->dmi_dtx_batched_list.next,
-				    struct dtx_batched_commit_args, dbca_link);
-		dtx_free_dbca(dbca);
+	d_list_for_each_entry_safe(dbca, tmp, &dmi->dmi_dtx_batched_list,
+				   dbca_link) {
+		if (dbca->dbca_cont->sc_cos_shutdown)
+			dtx_free_dbca(dbca);
+		else
+			dbca->dbca_cont->sc_cos_shutdown = 1;
 	}
 }
 
@@ -996,6 +999,7 @@ dtx_batched_commit_register(struct ds_cont_child *cont)
 
 	D_ASSERT(cont != NULL);
 	cont->sc_closing = 0;
+	cont->sc_cos_shutdown = 0;
 
 	head = &dss_get_module_info()->dmi_dtx_batched_list;
 	d_list_for_each_entry(dbca, head, dbca_link) {
@@ -1067,6 +1071,10 @@ dtx_batched_commit_deregister(struct ds_cont_child *cont)
 		if (rc != ABT_SUCCESS) {
 			D_ERROR("ABT_future_create failed for DTX flush on "
 				DF_UUID" %d\n", DP_UUID(cont->sc_uuid), rc);
+			/* Set sc_cos_shutdown, then dtx_free_dbca() will be
+			 * called when the DTX batched commit ULT exits.
+			 */
+			cont->sc_cos_shutdown = 1;
 			return;
 		}
 

--- a/src/dtx/dtx_cos.c
+++ b/src/dtx/dtx_cos.c
@@ -373,6 +373,9 @@ dtx_add_cos(struct ds_cont_child *cont, struct dtx_entry *dte,
 	d_iov_t				riov;
 	int				rc;
 
+	if (cont->sc_cos_shutdown)
+		return -DER_SHUTDOWN;
+
 	D_ASSERT(dte->dte_mbs != NULL);
 	D_ASSERT(epoch != DAOS_EPOCH_MAX);
 

--- a/src/include/daos_srv/container.h
+++ b/src/include/daos_srv/container.h
@@ -84,7 +84,8 @@ struct ds_cont_child {
 				 sc_vos_aggregating:1,
 				 sc_abort_vos_aggregating:1,
 				 sc_props_fetched:1,
-				 sc_stopping:1;
+				 sc_stopping:1,
+				 sc_cos_shutdown:1;
 	/* Tracks the schedule request for aggregation ULT */
 	struct sched_request	*sc_agg_req;
 


### PR DESCRIPTION
If we destroy the CoS tree when the DTX batched commit ULT exits,
then because of ULT schedule race, some other ULTs may still try
to access the CoS, that may cause unexpected error. The solution
is that keep the CoS tree until related container is closed.

Signed-off-by: Fan Yong <fan.yong@intel.com>