### PR TITLE
DAOS-5911 test: enable RP_3GX large_file_count, DAOS-5841 fix

### DIFF
--- a/src/tests/ftest/io/large_file_count.yaml
+++ b/src/tests/ftest/io/large_file_count.yaml
@@ -40,9 +40,7 @@ largefilecount:
     - POSIX
   object_class:
     - SX
-# Uncomment when DAOS-5841 is resolved.
-# Ticket for re-enabling this is DAOS-5911
-#    - RP_3GX
+    - RP_3GX
 ior:
   np: 30
   dfs_destroy: False


### PR DESCRIPTION
With resolution of DAOS-5841, the large_file_count test case
exercising objectclass RP_3GX can be re-enabled.

Skip-checkpatch: true
Skip-unit-tests: true
Skip-func-test-vm: true
Skip-func-hw-test-small: true
Skip-func-hw-test-medium: true
Test-tag-hw-large: largefilecount

Signed-off-by: Kenneth Cain <kenneth.c.cain@intel.com>