### PR TITLE
DAOS-5612 test: Re-enable pool rebuild tests

### DIFF
--- a/src/tests/ftest/pool/rebuild_tests.py
+++ b/src/tests/ftest/pool/rebuild_tests.py
@@ -129,7 +129,6 @@ class RebuildTests(TestWithServers):
                 "Data verification error after rebuild")
         self.log.info("Test Passed")
 
-    @skipForTicket("DAOS-6359")
     def test_simple_rebuild(self):
         """JIRA ID: DAOS-XXXX Rebuild-001.
 
@@ -143,7 +142,6 @@ class RebuildTests(TestWithServers):
         """
         self.run_rebuild_test(1)
 
-    @skipForTicket("DAOS-6359")
     def test_multipool_rebuild(self):
         """JIRA ID: DAOS-XXXX (Rebuild-002).
 

--- a/src/tests/ftest/pool/rebuild_tests.py
+++ b/src/tests/ftest/pool/rebuild_tests.py
@@ -21,7 +21,7 @@
   Any reproduction of computer software, computer software documentation, or
   portions thereof marked with this legend must also reproduce the markings.
 """
-from apricot import TestWithServers, skipForTicket
+from apricot import TestWithServers
 from test_utils_pool import TestPool
 from test_utils_container import TestContainer
 

--- a/src/tests/ftest/pool/rebuild_tests.yaml
+++ b/src/tests/ftest/pool/rebuild_tests.yaml
@@ -47,5 +47,5 @@ testparams:
     rank3:
       rank: 3
   quantity: 2
-  object_class: DAOS_OC_R3_RW
+  object_class: OC_RP_3G1
 


### PR DESCRIPTION
DAOS-5612 test: Re-enable pool rebuild tests
after the fixes of DAOS-6359: pool rebuild failed data verification after rebuild

Test-tag-hw-large: pr,hw,large
Signed-off-by: Ding Ho <ding-hwa.ho@intel.com>