### PR TITLE
DAOS-6593 control: updates to ras event handlers

### DIFF
--- a/src/control/events/generic.go
+++ b/src/control/events/generic.go
@@ -1,24 +1,7 @@
 //
-// (C) Copyright 2020-2021 Intel Corporation.
+// (C) Copyright 2021 Intel Corporation.
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//    http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-//
-// GOVERNMENT LICENSE RIGHTS-OPEN SOURCE SOFTWARE
-// The Government's rights to use, modify, reproduce, release, perform, display,
-// or disclose this software are subject to the terms of the Apache License as
-// provided in Contract No. 8F-30005.
-// Any reproduction of computer software, computer software documentation, or
-// portions thereof marked with this legend must also reproduce the markings.
+// SPDX-License-Identifier: BSD-2-Clause-Patent
 //
 
 package events

--- a/src/control/events/generic_test.go
+++ b/src/control/events/generic_test.go
@@ -1,24 +1,7 @@
 //
-// (C) Copyright 2020-2021 Intel Corporation.
+// (C) Copyright 2021 Intel Corporation.
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//    http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-//
-// GOVERNMENT LICENSE RIGHTS-OPEN SOURCE SOFTWARE
-// The Government's rights to use, modify, reproduce, release, perform, display,
-// or disclose this software are subject to the terms of the Apache License as
-// provided in Contract No. 8F-30005.
-// Any reproduction of computer software, computer software documentation, or
-// portions thereof marked with this legend must also reproduce the markings.
+// SPDX-License-Identifier: BSD-2-Clause-Patent
 //
 
 package events
@@ -65,7 +48,7 @@ func TestEvents_ConvertGeneric(t *testing.T) {
 
 	t.Logf("native event: %+v, %s", returnedEvent, *returnedEvent.GetStrInfo())
 
-	if diff := cmp.Diff(event, returnedEvent); diff != "" {
+	if diff := cmp.Diff(event, returnedEvent, defEvtCmpOpts...); diff != "" {
 		t.Fatalf("unexpected event (-want, +got):\n%s\n", diff)
 	}
 }

--- a/src/control/events/psr_update_test.go
+++ b/src/control/events/psr_update_test.go
@@ -48,7 +48,7 @@ func TestEvents_ConvertPoolSvcReplicasUpdate(t *testing.T) {
 
 	t.Logf("native event: %+v, %+v", returnedEvent, returnedEvent.ExtendedInfo)
 
-	if diff := cmp.Diff(event, returnedEvent); diff != "" {
+	if diff := cmp.Diff(event, returnedEvent, defEvtCmpOpts...); diff != "" {
 		t.Fatalf("unexpected event (-want, +got):\n%s\n", diff)
 	}
 }

--- a/src/control/events/rank_down_test.go
+++ b/src/control/events/rank_down_test.go
@@ -48,7 +48,7 @@ func TestEvents_ConvertRankDown(t *testing.T) {
 
 	t.Logf("native event: %+v, %+v", returnedEvent, returnedEvent.ExtendedInfo)
 
-	if diff := cmp.Diff(event, returnedEvent); diff != "" {
+	if diff := cmp.Diff(event, returnedEvent, defEvtCmpOpts...); diff != "" {
 		t.Fatalf("unexpected event (-want, +got):\n%s\n", diff)
 	}
 }

--- a/src/control/events/ras.go
+++ b/src/control/events/ras.go
@@ -30,6 +30,8 @@ import "C"
 
 import (
 	"encoding/json"
+	"fmt"
+	"strings"
 
 	"github.com/pkg/errors"
 
@@ -127,6 +129,20 @@ type RASEvent struct {
 	ObjID        string          `json:"obj_id"`
 	CtlOp        string          `json:"ctl_op"`
 	ExtendedInfo RASExtendedInfo `json:"extended_info"`
+
+	forwarded bool
+}
+
+// IsForwarded returns true if event has been forwarded between hosts.
+func (evt *RASEvent) IsForwarded() bool {
+	return evt.forwarded
+}
+
+// WithIsForwarded sets the forwarded state of this event.
+func (evt *RASEvent) WithIsForwarded(isForwarded bool) *RASEvent {
+	evt.forwarded = isForwarded
+
+	return evt
 }
 
 // MarshalJSON marshals RASEvent to JSON.
@@ -222,6 +238,57 @@ func (evt *RASEvent) FromProto(pbEvt *sharedpb.RASEvent) (err error) {
 	return
 }
 
+// PrintRAS generates a string representation of the event consistent with
+// what is logged in the data plane.
+func (evt *RASEvent) PrintRAS() string {
+	var b strings.Builder
+
+	/* Log mandatory RAS fields. */
+	fmt.Fprintf(&b, "&&& RAS EVENT id: [%s]", evt.ID)
+	if evt.Timestamp != "" {
+		fmt.Fprintf(&b, " ts: [%s]", evt.Timestamp)
+	}
+	if evt.Hostname != "" {
+		fmt.Fprintf(&b, " host: [%s]", evt.Hostname)
+	}
+	fmt.Fprintf(&b, " type: [%s] sev: [%s]", evt.Type, evt.Severity)
+	if evt.Msg != "" {
+		fmt.Fprintf(&b, " msg: [%s]", evt.Msg)
+	}
+	fmt.Fprintf(&b, " pid: [%d]", evt.ProcID)
+	fmt.Fprintf(&b, " tid: [%d]", evt.ThreadID)
+
+	/* Log optional RAS fields. */
+	if evt.HWID != "" {
+		fmt.Fprintf(&b, " hwid: [%s]", evt.HWID)
+	}
+	if evt.Rank != C.CRT_NO_RANK {
+		fmt.Fprintf(&b, " rank: [%d]", evt.Rank)
+	}
+	if evt.JobID != "" {
+		fmt.Fprintf(&b, " jobid: [%s]", evt.JobID)
+	}
+	if evt.PoolUUID != "" {
+		fmt.Fprintf(&b, " pool: [%s]", evt.PoolUUID)
+	}
+	if evt.ContUUID != "" {
+		fmt.Fprintf(&b, " container: [%s]", evt.ContUUID)
+	}
+	if evt.ObjID != "" {
+		fmt.Fprintf(&b, " objid: [%s]", evt.ObjID)
+	}
+	if evt.CtlOp != "" {
+		fmt.Fprintf(&b, " ctlop: [%s]", evt.CtlOp)
+	}
+
+	/* Log data blob if event info is non-specific */
+	if ei := evt.GetStrInfo(); ei != nil {
+		fmt.Fprintf(&b, " data: [%s]", *ei)
+	}
+
+	return b.String()
+}
+
 // HandleClusterEvent extracts event field from protobuf request message and
 // converts to concrete event type that implements the Event interface.
 // The Event is then published to make available to locally subscribed consumers
@@ -232,8 +299,6 @@ func (ps *PubSub) HandleClusterEvent(req *sharedpb.ClusterEventReq) (*sharedpb.C
 		return nil, errors.New("nil request")
 	case req.Event == nil:
 		return nil, errors.New("nil event in request")
-	case req.Sequence == 0:
-		ps.log.Debug("no sequence number in request")
 	}
 
 	event, err := NewFromProto(req.Event)

--- a/src/control/events/ras_test.go
+++ b/src/control/events/ras_test.go
@@ -29,12 +29,15 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/pkg/errors"
 
 	"github.com/daos-stack/daos/src/control/common"
 	sharedpb "github.com/daos-stack/daos/src/control/common/proto/shared"
 	"github.com/daos-stack/daos/src/control/logging"
 )
+
+var defEvtCmpOpts = []cmp.Option{cmpopts.IgnoreUnexported(RASEvent{})}
 
 func TestEvents_HandleClusterEvent(t *testing.T) {
 	genericEvent := mockGenericEvent()

--- a/src/control/lib/control/system.go
+++ b/src/control/lib/control/system.go
@@ -248,7 +248,7 @@ func (fwdr *EventForwarder) OnEvent(ctx context.Context, evt *events.RASEvent) {
 
 	req := &SystemNotifyReq{
 		Sequence: <-fwdr.seq,
-		Event:    evt,
+		Event:    evt.WithIsForwarded(true),
 	}
 	req.SetHostList(fwdr.accessPts)
 	fwdr.client.Debugf("forwarding %s event to MS access points %v (seq: %d)",
@@ -283,7 +283,10 @@ type EventLogger struct {
 
 // OnEvent implements the events.Handler interface.
 func (el *EventLogger) OnEvent(_ context.Context, evt *events.RASEvent) {
-	el.log.Infof("RAS event received: %+v", evt)
+	if evt.IsForwarded() {
+		return // event has already been logged at source
+	}
+	el.log.Info(evt.PrintRAS())
 }
 
 // NewEventLogger returns an initialized EventLogger.

--- a/src/control/server/mgmt_drpc_test.go
+++ b/src/control/server/mgmt_drpc_test.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2019-2020 Intel Corporation.
+// (C) Copyright 2019-2021 Intel Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -32,7 +32,6 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/daos-stack/daos/src/control/common"
-	"github.com/daos-stack/daos/src/control/common/proto/shared"
 	sharedpb "github.com/daos-stack/daos/src/control/common/proto/shared"
 	"github.com/daos-stack/daos/src/control/drpc"
 	"github.com/daos-stack/daos/src/control/logging"
@@ -345,7 +344,7 @@ func TestSrvModule_HandleBioErr_IdxOutOfRange(t *testing.T) {
 }
 
 func getTestClusterEventReqBytes(t *testing.T, event *sharedpb.RASEvent, seq uint64) []byte {
-	req := &shared.ClusterEventReq{Event: event, Sequence: seq}
+	req := &sharedpb.ClusterEventReq{Event: event, Sequence: seq}
 	reqBytes, err := proto.Marshal(req)
 
 	if err != nil {

--- a/src/control/server/server.go
+++ b/src/control/server/server.go
@@ -231,12 +231,13 @@ func Start(log *logging.LeveledLogger, cfg *config.Server) error {
 	// Init management RPC subsystem.
 	mgmtSvc := newMgmtSvc(harness, membership, sysdb, rpcClient, eventPubSub)
 
-	// By default, forward received RASTypeStateChange events to management
-	// service leader to be handled and log RASTypeInfoOnly to INFO.
+	// Forward published actionable events (type RASTypeStateChange) to the
+	// management service leader, behavior is updated on leadership change.
 	eventForwarder := control.NewEventForwarder(rpcClient, cfg.AccessPoints)
 	eventPubSub.Subscribe(events.RASTypeStateChange, eventForwarder)
+	// Log events on the host that they were raised (and first published) on.
 	eventLogger := control.NewEventLogger(log)
-	eventPubSub.Subscribe(events.RASTypeInfoOnly, eventLogger)
+	eventPubSub.Subscribe(events.RASTypeAny, eventLogger)
 
 	var netDevClass uint32
 


### PR DESCRIPTION
- Log events on the control-plane instance that manages the I/O
  Server that raised the event but don't log forwarded events at
  destination.
- Make format of the logged event consistent across data and control
  planes.
- Address other minor updates requested in PR-4394 code review.

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>