### PR TITLE
DAOS-6615 test: Disable daos core test -m and -T

### DIFF
--- a/src/tests/ftest/daos_test/daos_core_test.py
+++ b/src/tests/ftest/daos_test/daos_core_test.py
@@ -32,6 +32,12 @@ class DaosCoreTest(DaosCoreBase):
     :avocado: recursive
     """
 
+    # Test variants that should be skipped
+    CANCEL_FOR_TICKET = [
+        ["DAOS-5852", "test_name", "Management tests"],
+        ["DAOS-6615", "test_name", "Distributed TX tests"]
+    ]
+
     def test_subtest(self):
         """Run daos_test tests/subtests.
 


### PR DESCRIPTION
Disable daos core test -m (DAOS-5852) and -T (DAOS-6615)