### PR TITLE
DAOS-6595 rebuild: Add RAS events for Pool rebuild

### DIFF
--- a/src/control/events/generic.go
+++ b/src/control/events/generic.go
@@ -7,18 +7,18 @@
 package events
 
 import (
-	"os"
-	"time"
-
-	"github.com/daos-stack/daos/src/control/common"
 	sharedpb "github.com/daos-stack/daos/src/control/common/proto/shared"
-	"github.com/daos-stack/daos/src/control/lib/atm"
 )
 
 // StrInfo contains opaque blob of type string to hold custom details for a
 // generic RAS event to be forwarded through the control-plane from the
 // data-plane to an external consumer e.g. syslog.
 type StrInfo string
+
+func NewStrInfo(in string) *StrInfo {
+	si := StrInfo(in)
+	return &si
+}
 
 func (si *StrInfo) isExtendedInfo() {}
 
@@ -45,34 +45,4 @@ func StrInfoToProto(si *StrInfo) (*sharedpb.RASEvent_StrInfo, error) {
 	}
 
 	return pbInfo, nil
-}
-
-// NewGenericEvent creates a generic RAS event from given inputs.
-func NewGenericEvent(id RASID, typ RASTypeID, sev RASSeverityID, msg string,
-	rank uint32, hwID, jobID, poolUUID, contUUID, objID, ctlOp, data string) (*RASEvent, error) {
-
-	hn, err := os.Hostname()
-	if err != nil {
-		return nil, err
-	}
-	si := StrInfo(data)
-
-	return &RASEvent{
-		Timestamp:    common.FormatTime(time.Now()),
-		Msg:          msg,
-		ID:           id,
-		Hostname:     hn,
-		ProcID:       uint64(os.Getpid()),
-		Rank:         rank,
-		Type:         typ,
-		Severity:     sev,
-		HWID:         hwID,
-		JobID:        jobID,
-		PoolUUID:     poolUUID,
-		ContUUID:     contUUID,
-		ObjID:        objID,
-		CtlOp:        ctlOp,
-		ExtendedInfo: &si,
-		forwarded:    atm.NewBool(false),
-	}, nil
 }

--- a/src/control/events/generic_test.go
+++ b/src/control/events/generic_test.go
@@ -14,11 +14,14 @@ import (
 )
 
 func mockGenericEvent() *RASEvent {
-	evt, _ := NewGenericEvent(
-		math.MaxInt32-1, RASTypeInfoOnly, RASSeverityError,
-		"DAOS generic test event", 1, "", "", "", "", "", "",
-		"{\"people\":[\"bill\",\"steve\",\"bob\"]}")
-	return evt
+	return New(&RASEvent{
+		ID:           math.MaxInt32 - 1,
+		Type:         RASTypeInfoOnly,
+		Severity:     RASSeverityError,
+		Msg:          "DAOS generic test event",
+		Rank:         1,
+		ExtendedInfo: NewStrInfo(`{"people":["bill","steve","bob"]}`),
+	})
 }
 
 func TestEvents_ConvertGeneric(t *testing.T) {

--- a/src/control/events/psr_update.go
+++ b/src/control/events/psr_update.go
@@ -7,9 +7,6 @@
 package events
 
 import (
-	"time"
-
-	"github.com/daos-stack/daos/src/control/common"
 	"github.com/daos-stack/daos/src/control/common/proto/convert"
 	sharedpb "github.com/daos-stack/daos/src/control/common/proto/shared"
 	"github.com/daos-stack/daos/src/control/lib/atm"
@@ -50,19 +47,18 @@ func PoolSvcInfoToProto(psi *PoolSvcInfo) (*sharedpb.RASEvent_PoolSvcInfo, error
 
 // NewPoolSvcReplicasUpdateEvent creates a specific PoolSvcRanksUpdate event from given inputs.
 func NewPoolSvcReplicasUpdateEvent(hostname string, rank uint32, poolUUID string, svcReplicas []uint32, leaderTerm uint64) *RASEvent {
-	return &RASEvent{
-		Timestamp: common.FormatTime(time.Now()),
-		Msg:       "DAOS pool service replica rank list updated",
-		ID:        RASPoolRepsUpdate,
-		Hostname:  hostname,
-		Rank:      rank,
-		PoolUUID:  poolUUID,
-		Type:      RASTypeStateChange,
-		Severity:  RASSeverityError,
+	return New(&RASEvent{
+		Msg:      "DAOS pool service replica rank list updated",
+		ID:       RASPoolRepsUpdate,
+		Hostname: hostname,
+		Rank:     rank,
+		PoolUUID: poolUUID,
+		Type:     RASTypeStateChange,
+		Severity: RASSeverityError,
 		ExtendedInfo: &PoolSvcInfo{
 			SvcReplicas:    svcReplicas,
 			RaftLeaderTerm: leaderTerm,
 		},
 		forwarded: atm.NewBool(false),
-	}
+	})
 }

--- a/src/control/events/rank_down.go
+++ b/src/control/events/rank_down.go
@@ -7,8 +7,6 @@
 package events
 
 import (
-	"time"
-
 	"github.com/daos-stack/daos/src/control/common"
 	sharedpb "github.com/daos-stack/daos/src/control/common/proto/shared"
 	"github.com/daos-stack/daos/src/control/lib/atm"
@@ -60,18 +58,17 @@ func RankStateInfoToProto(rsi *RankStateInfo) (*sharedpb.RASEvent_RankStateInfo,
 
 // NewRankDownEvent creates a specific RankDown event from given inputs.
 func NewRankDownEvent(hostname string, instanceIdx uint32, rank uint32, exitErr common.ExitStatus) *RASEvent {
-	return &RASEvent{
-		Timestamp: common.FormatTime(time.Now()),
-		Msg:       "DAOS rank exited unexpectedly",
-		ID:        RASRankDown,
-		Hostname:  hostname,
-		Rank:      rank,
-		Type:      RASTypeStateChange,
-		Severity:  RASSeverityError,
+	return New(&RASEvent{
+		Msg:      "DAOS rank exited unexpectedly",
+		ID:       RASRankDown,
+		Hostname: hostname,
+		Rank:     rank,
+		Type:     RASTypeStateChange,
+		Severity: RASSeverityError,
 		ExtendedInfo: &RankStateInfo{
 			InstanceIdx: instanceIdx,
 			ExitErr:     exitErr,
 		},
 		forwarded: atm.NewBool(false),
-	}
+	})
 }

--- a/src/control/events/ras.go
+++ b/src/control/events/ras.go
@@ -14,7 +14,9 @@ import "C"
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 	"strings"
+	"time"
 
 	"github.com/pkg/errors"
 
@@ -42,6 +44,8 @@ type RASID uint32
 // RASID constant definitions matching those used when creating events either in
 // the control or data (iosrv) planes.
 const (
+	RASUnknownEvent   RASID = C.RAS_UNKNOWN_EVENT
+	RASRankUp         RASID = C.RAS_RANK_UP
 	RASRankDown       RASID = C.RAS_RANK_DOWN
 	RASRankNoResponse RASID = C.RAS_RANK_NO_RESPONSE
 	RASPoolRepsUpdate RASID = C.RAS_POOL_REPS_UPDATE
@@ -84,10 +88,11 @@ type RASSeverityID uint32
 
 // RASSeverityID constant definitions.
 const (
-	RASSeverityFatal RASSeverityID = C.RAS_SEV_FATAL
-	RASSeverityWarn  RASSeverityID = C.RAS_SEV_WARN
-	RASSeverityError RASSeverityID = C.RAS_SEV_ERROR
-	RASSeverityInfo  RASSeverityID = C.RAS_SEV_INFO
+	RASSeverityUnknown RASSeverityID = C.RAS_SEV_UNKNOWN
+	RASSeverityFatal   RASSeverityID = C.RAS_SEV_FATAL
+	RASSeverityWarn    RASSeverityID = C.RAS_SEV_WARN
+	RASSeverityError   RASSeverityID = C.RAS_SEV_ERROR
+	RASSeverityInfo    RASSeverityID = C.RAS_SEV_INFO
 )
 
 func (sev RASSeverityID) String() string {
@@ -129,6 +134,37 @@ func (evt *RASEvent) IsForwarded() bool {
 // WithIsForwarded sets the forwarded state of this event.
 func (evt *RASEvent) WithIsForwarded(isForwarded bool) *RASEvent {
 	evt.forwarded = atm.NewBool(isForwarded)
+
+	return evt
+}
+
+// New accepts a pointer to a RASEvent and fills in any
+// missing fields before returning the event.
+func New(evt *RASEvent) *RASEvent {
+	if evt == nil {
+		evt = &RASEvent{}
+	}
+
+	// Set defaults as necessary.
+	if evt.Timestamp == "" {
+		evt.Timestamp = common.FormatTime(time.Now())
+	}
+	if evt.Hostname == "" {
+		getHostName := func() string {
+			hn, err := os.Hostname()
+			if err != nil {
+				return "failed to get hostname"
+			}
+			return hn
+		}
+		evt.Hostname = getHostName()
+	}
+	if evt.ProcID == 0 {
+		evt.ProcID = uint64(os.Getpid())
+	}
+	if evt.Severity == RASSeverityUnknown {
+		evt.Severity = RASSeverityInfo
+	}
 
 	return evt
 }

--- a/src/control/server/mgmt_system.go
+++ b/src/control/server/mgmt_system.go
@@ -577,15 +577,12 @@ func (svc *mgmtSvc) SystemStop(ctx context.Context, pbReq *mgmtpb.SystemStopReq)
 
 	// Raise event on systemwide shutdown
 	if pbReq.GetHosts() == "" && pbReq.GetRanks() == "" && pbReq.GetKill() {
-		evt, err := events.NewGenericEvent(events.RASSystemStop,
-			events.RASTypeInfoOnly, events.RASSeverityInfo,
-			"System-wide shutdown requested", uint32(system.NilRank),
-			"", "", "", "", "", "", "")
-		if err != nil {
-			svc.log.Errorf("creating generic event: %s", err)
-		} else {
-			svc.events.Publish(evt)
-		}
+		svc.events.Publish(events.New(&events.RASEvent{
+			ID:   events.RASSystemStop,
+			Type: events.RASTypeInfoOnly,
+			Msg:  "System-wide shutdown requested",
+			Rank: uint32(system.NilRank),
+		}))
 	}
 
 	// TODO: consider locking to prevent join attempts when shutting down
@@ -650,15 +647,12 @@ func (svc *mgmtSvc) SystemStart(ctx context.Context, pbReq *mgmtpb.SystemStartRe
 
 	// Raise event on systemwide start
 	if pbReq.GetHosts() == "" && pbReq.GetRanks() == "" {
-		evt, err := events.NewGenericEvent(events.RASSystemStart,
-			events.RASTypeInfoOnly, events.RASSeverityInfo,
-			"System-wide start requested", uint32(system.NilRank),
-			"", "", "", "", "", "", "")
-		if err != nil {
-			svc.log.Errorf("creating generic event: %s", err)
-		} else {
-			svc.events.Publish(evt)
-		}
+		svc.events.Publish(events.New(&events.RASEvent{
+			ID:   events.RASSystemStart,
+			Type: events.RASTypeInfoOnly,
+			Msg:  "System-wide start requested",
+			Rank: uint32(system.NilRank),
+		}))
 	}
 
 	fanResp, _, err := svc.rpcFanout(ctx, fanoutRequest{

--- a/src/include/daos_srv/ras.h
+++ b/src/include/daos_srv/ras.h
@@ -40,6 +40,9 @@
 	X(RAS_RANK_UP,			"engine_status_up")		\
 	X(RAS_RANK_DOWN,		"engine_status_down")		\
 	X(RAS_RANK_NO_RESPONSE,		"engine_status_no_response")	\
+	X(RAS_POOL_REBUILD_START,	"pool_rebuild_started")		\
+	X(RAS_POOL_REBUILD_END,		"pool_rebuild_finished")	\
+	X(RAS_POOL_REBUILD_FAILED,	"pool_rebuild_failed")		\
 	X(RAS_POOL_REPS_UPDATE,		"pool_replicas_updated")	\
 	X(RAS_POOL_DF_INCOMPAT,						\
 	  "pool_durable_format_incompatible")				\
@@ -86,7 +89,8 @@ ras_type2str(ras_type_t type)
 }
 
 typedef enum {
-	RAS_SEV_FATAL	= 1,
+	RAS_SEV_UNKNOWN = 0,
+	RAS_SEV_FATAL,
 	RAS_SEV_WARN,
 	RAS_SEV_ERROR,
 	RAS_SEV_INFO,

--- a/src/iosrv/drpc_ras.c
+++ b/src/iosrv/drpc_ras.c
@@ -316,14 +316,11 @@ int
 ds_notify_swim_rank_dead(d_rank_t rank)
 {
 	Shared__RASEvent			evt = SHARED__RASEVENT__INIT;
-	int					rc;
 
-	rc = raise_ras(RAS_SWIM_RANK_DEAD,
-		       "SWIM marked rank as dead.",
-		       RAS_TYPE_STATE_CHANGE, RAS_SEV_INFO, NULL /* hwid */,
-		       &rank /* rank */, NULL /* jobid */, NULL /* pool */,
-		       NULL /* cont */, NULL /* objid */, NULL /* ctlop */,
-		       &evt);
-
-	return rc;
+	return raise_ras(RAS_SWIM_RANK_DEAD,
+			 "SWIM marked rank as dead.",
+			 RAS_TYPE_STATE_CHANGE, RAS_SEV_INFO, NULL /* hwid */,
+			 &rank /* rank */, NULL /* jobid */, NULL /* pool */,
+			 NULL /* cont */, NULL /* objid */, NULL /* ctlop */,
+			 &evt);
 }

--- a/src/rebuild/SConscript
+++ b/src/rebuild/SConscript
@@ -13,7 +13,7 @@ def scons():
     denv.Append(CCFLAGS=['-Wframe-larger-than=131072'])
     # rebuild
     rebuild = daos_build.library(denv, 'rebuild',
-                                 ['scan.c', 'srv.c', 'rpc.c',
+                                 ['scan.c', 'srv.c', 'rpc.c', 'ras.c',
                                   'rebuild_iv.c'], install_off="../..")
     denv.Install('$PREFIX/lib64/daos_srv', rebuild)
 

--- a/src/rebuild/ras.c
+++ b/src/rebuild/ras.c
@@ -1,0 +1,74 @@
+/**
+ * (C) Copyright 2021 Intel Corporation.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause-Patent
+ */
+/**
+ * rebuild: RAS
+ *
+ * This file contains RAS helpers for rebuild events.
+ */
+#define D_LOGFAC       DD_FAC(rebuild)
+
+#include <daos_srv/daos_server.h>
+
+static int
+raise_ras(ras_event_t id, ras_sev_t sev,
+	  uuid_t *pool, uint32_t map_ver, char *op_str, char *msg)
+{
+	char *data = NULL;
+
+	if ((pool == NULL) || uuid_is_null(*pool)) {
+		D_ERROR("invalid pool\n");
+		return -DER_INVAL;
+	}
+
+	D_ASPRINTF(data, "map_ver: [%"PRIu32"] op: [%s]", map_ver, op_str);
+	if (data == NULL)
+		return -DER_NOMEM;
+
+	ds_notify_ras_event(id, msg, RAS_TYPE_INFO, sev,
+			    NULL /* hwid */, NULL /* rank */,
+			    NULL /* jobid */, pool, NULL /* cont */,
+			    NULL /* objid */, NULL /* ctlop */, data);
+	D_FREE(data);
+	return 0;
+}
+
+int
+rebuild_notify_ras_start(uuid_t *pool, uint32_t map_ver, char *op_str)
+{
+	char *msg = "Pool rebuild started.";
+
+	return raise_ras(RAS_POOL_REBUILD_START, RAS_SEV_INFO,
+			 pool, map_ver, op_str, msg);
+}
+
+int
+rebuild_notify_ras_end(uuid_t *pool, uint32_t map_ver, char *op_str, int op_rc)
+{
+	char		*msg	= NULL;
+	char		*status	= NULL;
+	ras_event_t	 ev_id	= RAS_POOL_REBUILD_END;
+	ras_sev_t	 ev_sev = RAS_SEV_INFO;
+	int		 rc	= 0;
+
+	if (op_rc != 0) {
+		ev_id = RAS_POOL_REBUILD_FAILED;
+		ev_sev = RAS_SEV_FATAL;
+		D_ASPRINTF(status, "failed: "DF_RC, DP_RC(op_rc));
+		if (status == NULL)
+			return -DER_NOMEM;
+	}
+	D_ASPRINTF(msg, "Pool rebuild %s", op_rc ? status : "finished.");
+	if (msg == NULL) {
+		rc = -DER_NOMEM;
+		goto out;
+	}
+
+	rc = raise_ras(ev_id, ev_sev, pool, map_ver, op_str, msg);
+out:
+	D_FREE(status);
+	D_FREE(msg);
+	return rc;
+}

--- a/src/rebuild/rebuild_internal.h
+++ b/src/rebuild/rebuild_internal.h
@@ -328,4 +328,10 @@ rebuild_global_status_update(struct rebuild_global_pool_tracker *master_rpt,
 			     struct rebuild_iv *iv);
 void
 rebuild_hang(void);
+
+int
+rebuild_notify_ras_start(uuid_t *pool, uint32_t map_ver, char *op_str);
+
+int
+rebuild_notify_ras_end(uuid_t *pool, uint32_t map_ver, char *op_str, int op_rc);
 #endif /* __REBUILD_INTERNAL_H_ */

--- a/src/rebuild/srv.c
+++ b/src/rebuild/srv.c
@@ -1134,6 +1134,12 @@ rebuild_task_ult(void *arg)
 		return;
 	}
 
+	rc = rebuild_notify_ras_start(&task->dst_pool_uuid, task->dst_map_ver,
+				      RB_OP_STR(task->dst_rebuild_op));
+	if (rc)
+		D_ERROR(DF_UUID": failed to send RAS event\n",
+			DP_UUID(task->dst_pool_uuid));
+
 	D_PRINT("Rebuild [started] (pool "DF_UUID" ver=%u, op=%s)\n",
 		DP_UUID(task->dst_pool_uuid), task->dst_map_ver,
 		RB_OP_STR(task->dst_rebuild_op));
@@ -1260,6 +1266,13 @@ try_reschedule:
 				DP_UUID(pool->sp_uuid));
 	}
 output:
+	rc = rebuild_notify_ras_end(&task->dst_pool_uuid, task->dst_map_ver,
+				    RB_OP_STR(task->dst_rebuild_op),
+				    rc);
+	if (rc)
+		D_ERROR(DF_UUID": failed to send RAS event\n",
+			DP_UUID(task->dst_pool_uuid));
+
 	ds_pool_put(pool);
 	if (rgt)
 		rebuild_global_pool_tracker_destroy(rgt);


### PR DESCRIPTION
Add RAS events to mark when pool rebuild operations
start, finish, and fail.

Also cleans up the events package API and removes some
overly-chatty debug messages.

Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com>