### PR TITLE
DAOS-6619 dtx: hold reference on DTX entry when commit

### DIFF
--- a/src/dtx/dtx_cos.c
+++ b/src/dtx/dtx_cos.c
@@ -297,7 +297,7 @@ dtx_fetch_committable(struct ds_cont_child *cont, uint32_t max_cnt,
 		if (epoch < dcrc->dcrc_epoch)
 			continue;
 
-		dte_buf[i] = dcrc->dcrc_dte;
+		dte_buf[i] = dtx_entry_get(dcrc->dcrc_dte);
 		if (++i >= count)
 			break;
 	}


### PR DESCRIPTION
There may be CPU yield during DTX commit. If we do not hold
reference on the DTX entry, some other may free it by race.

Signed-off-by: Fan Yong <fan.yong@intel.com>