### PR TITLE
DAOS-6585 common: bump cpf_ver for interoperability issues

### DIFF
--- a/src/cart/crt_rpc.h
+++ b/src/cart/crt_rpc.h
@@ -185,8 +185,8 @@ struct crt_rpc_priv {
 	struct crt_corpc_hdr	crp_coreq_hdr; /* collective request header */
 };
 
-#define CRT_PROTO_INTERNAL_VERSION 2
-#define CRT_PROTO_FI_VERSION 0
+#define CRT_PROTO_INTERNAL_VERSION 3
+#define CRT_PROTO_FI_VERSION 1
 
 /* LIST of internal RPCS in form of:
  * OPCODE, flags, FMT, handler, corpc_hdlr,

--- a/src/container/rpc.h
+++ b/src/container/rpc.h
@@ -24,7 +24,7 @@
  * These are for daos_rpc::dr_opc and DAOS_RPC_OPCODE(opc, ...) rather than
  * crt_req_create(..., opc, ...). See src/include/daos/rpc.h.
  */
-#define DAOS_CONT_VERSION 1
+#define DAOS_CONT_VERSION 2
 /* LIST of internal RPCS in form of:
  * OPCODE, flags, FMT, handler, corpc_hdlr,
  */

--- a/src/container/srv_container.c
+++ b/src/container/srv_container.c
@@ -233,7 +233,7 @@ ds_cont_bcast_create(crt_context_t ctx, struct cont_svc *svc,
 		     crt_opcode_t opcode, crt_rpc_t **rpc)
 {
 	return ds_pool_bcast_create(ctx, svc->cs_pool, DAOS_CONT_MODULE, opcode,
-				    rpc, NULL, NULL);
+				    DAOS_CONT_VERSION, rpc, NULL, NULL);
 }
 
 void

--- a/src/include/daos_srv/pool.h
+++ b/src/include/daos_srv/pool.h
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2016-2020 Intel Corporation.
+ * (C) Copyright 2016-2021 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -132,7 +132,7 @@ void ds_pool_child_put(struct ds_pool_child *child);
 
 int ds_pool_bcast_create(crt_context_t ctx, struct ds_pool *pool,
 			 enum daos_module_id module, crt_opcode_t opcode,
-			 crt_rpc_t **rpc, crt_bulk_t bulk_hdl,
+			 uint32_t version, crt_rpc_t **rpc, crt_bulk_t bulk_hdl,
 			 d_rank_list_t *excluded_list);
 
 int ds_pool_map_buf_get(uuid_t uuid, d_iov_t *iov, uint32_t *map_ver);

--- a/src/mgmt/rpc.h
+++ b/src/mgmt/rpc.h
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2020 Intel Corporation.
+ * (C) Copyright 2016-2021 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,7 +35,7 @@
  * These are for daos_rpc::dr_opc and DAOS_RPC_OPCODE(opc, ...) rather than
  * crt_req_create(..., opc, ...). See daos_rpc.h.
  */
-#define DAOS_MGMT_VERSION 1
+#define DAOS_MGMT_VERSION 2
 /* LIST of internal RPCS in form of:
  * OPCODE, flags, FMT, handler, corpc_hdlr,
  */

--- a/src/mgmt/srv_system.c
+++ b/src/mgmt/srv_system.c
@@ -257,7 +257,8 @@ map_update_bcast(crt_context_t ctx, struct mgmt_svc *svc, uint32_t map_version,
 	D_DEBUG(DB_MGMT, "enter: version=%u nservers=%d\n", map_version,
 		nservers);
 
-	opc = DAOS_RPC_OPCODE(MGMT_TGT_MAP_UPDATE, DAOS_MGMT_MODULE, 1);
+	opc = DAOS_RPC_OPCODE(MGMT_TGT_MAP_UPDATE, DAOS_MGMT_MODULE,
+			      DAOS_MGMT_VERSION);
 	rc = crt_corpc_req_create(ctx, NULL /* grp */,
 				  NULL /* excluded_ranks */, opc,
 				  NULL /* co_bulk_hdl */, NULL /* priv */,

--- a/src/object/obj_rpc.h
+++ b/src/object/obj_rpc.h
@@ -57,7 +57,7 @@
  * These are for daos_rpc::dr_opc and DAOS_RPC_OPCODE(opc, ...) rather than
  * crt_req_create(..., opc, ...). See daos_rpc.h.
  */
-#define DAOS_OBJ_VERSION 1
+#define DAOS_OBJ_VERSION 2
 /* LIST of internal RPCS in form of:
  * OPCODE, flags, FMT, handler, corpc_hdlr,
  */

--- a/src/pool/rpc.h
+++ b/src/pool/rpc.h
@@ -45,7 +45,7 @@
  * These are for daos_rpc::dr_opc and DAOS_RPC_OPCODE(opc, ...) rather than
  * crt_req_create(..., opc, ...). See src/include/daos/rpc.h.
  */
-#define DAOS_POOL_VERSION 1
+#define DAOS_POOL_VERSION 2
 /* LIST of internal RPCS in form of:
  * OPCODE, flags, FMT, handler, corpc_hdlr,
  */

--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -1458,7 +1458,7 @@ bcast_create(crt_context_t ctx, struct pool_svc *svc, crt_opcode_t opcode,
 	     crt_bulk_t bulk_hdl, crt_rpc_t **rpc)
 {
 	return ds_pool_bcast_create(ctx, svc->ps_pool, DAOS_POOL_MODULE, opcode,
-				    rpc, bulk_hdl, NULL);
+				    DAOS_POOL_VERSION, rpc, bulk_hdl, NULL);
 }
 
 /**

--- a/src/pool/srv_util.c
+++ b/src/pool/srv_util.c
@@ -177,7 +177,7 @@ free:
 int
 ds_pool_bcast_create(crt_context_t ctx, struct ds_pool *pool,
 		     enum daos_module_id module, crt_opcode_t opcode,
-		     crt_rpc_t **rpc, crt_bulk_t bulk_hdl,
+		     uint32_t version, crt_rpc_t **rpc, crt_bulk_t bulk_hdl,
 		     d_rank_list_t *excluded_list)
 {
 	d_rank_list_t	excluded;
@@ -196,7 +196,7 @@ ds_pool_bcast_create(crt_context_t ctx, struct ds_pool *pool,
 	if (excluded_list != NULL)
 		map_ranks_merge(&excluded, excluded_list);
 
-	opc = DAOS_RPC_OPCODE(opcode, module, 1);
+	opc = DAOS_RPC_OPCODE(opcode, module, version);
 	rc = crt_corpc_req_create(ctx, pool->sp_group,
 			  excluded.rl_nr == 0 ? NULL : &excluded,
 			  opc, bulk_hdl/* co_bulk_hdl */, NULL /* priv */,

--- a/src/rdb/rdb_internal.h
+++ b/src/rdb/rdb_internal.h
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2017-2020 Intel Corporation.
+ * (C) Copyright 2017-2021 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -179,7 +179,7 @@ void rdb_raft_free_request(struct rdb *db, crt_rpc_t *rpc);
  * These are for daos_rpc::dr_opc and DAOS_RPC_OPCODE(opc, ...) rather than
  * crt_req_create(..., opc, ...). See src/include/daos/rpc.h.
  */
-#define DAOS_RDB_VERSION 1
+#define DAOS_RDB_VERSION 2
 /* LIST of internal RPCS in form of:
  * OPCODE, flags, FMT, handler, corpc_hdlr,
  */

--- a/src/rdb/tests/rpc.h
+++ b/src/rdb/tests/rpc.h
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2017-2020 Intel Corporation.
+ * (C) Copyright 2017-2021 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,7 +32,7 @@
  * These are for daos_rpc::dr_opc and DAOS_RPC_OPCODE(opc, ...) rather than
  * crt_req_create(..., opc, ...). See src/include/daos/rpc.h.
  */
-#define DAOS_RDBT_VERSION 1
+#define DAOS_RDBT_VERSION 2
 /* LIST of internal RPCS in form of:
  * OPCODE, flags, FMT, handler, corpc_hdlr,
  */

--- a/src/rebuild/rpc.h
+++ b/src/rebuild/rpc.h
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2017-2020 Intel Corporation.
+ * (C) Copyright 2017-2021 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,7 +40,7 @@
  * These are for daos_rpc::dr_opc and DAOS_RPC_OPCODE(opc, ...) rather than
  * crt_req_create(..., opc, ...). See src/include/daos/rpc.h.
  */
-#define DAOS_REBUILD_VERSION 1
+#define DAOS_REBUILD_VERSION 2
 /* LIST of internal RPCS in form of:
  * OPCODE, flags, FMT, handler, corpc_hdlr,
  */

--- a/src/rebuild/srv.c
+++ b/src/rebuild/srv.c
@@ -814,8 +814,8 @@ retry:
 	 */
 	rc = ds_pool_bcast_create(dss_get_module_info()->dmi_ctx,
 				  pool, DAOS_REBUILD_MODULE,
-				  REBUILD_OBJECTS_SCAN, &rpc, NULL,
-				  NULL);
+				  REBUILD_OBJECTS_SCAN, DAOS_REBUILD_VERSION,
+				  &rpc, NULL, NULL);
 	if (rc != 0) {
 		D_ERROR("pool map broad cast failed: rc "DF_RC"\n", DP_RC(rc));
 		return rc;

--- a/src/rsvc/rpc.h
+++ b/src/rsvc/rpc.h
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2016-2020 Intel Corporation.
+ * (C) Copyright 2016-2021 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,7 +40,7 @@
  * These are for daos_rpc::dr_opc and DAOS_RPC_OPCODE(opc, ...) rather than
  * crt_req_create(..., opc, ...). See src/include/daos/rpc.h.
  */
-#define DAOS_RSVC_VERSION 1
+#define DAOS_RSVC_VERSION 2
 /* LIST of internal RPCS in form of:
  * OPCODE, flags, FMT, handler, corpc_hdlr,
  */


### PR DESCRIPTION
Currently, we do not support old client (1.0) to talk with new
server (1.2), and vice versa. Bump the cpf_ver for RPC related
modules.


Signed-off-by: Fan Yong <fan.yong@intel.com>