### PR TITLE
DAOS-6582 dfuse: Add configure check for ioctl type in libfuse.

### DIFF
--- a/src/client/dfuse/SConscript
+++ b/src/client/dfuse/SConscript
@@ -118,18 +118,48 @@ def check_struct_member(env, text, struct, member):
     env.Result(rc)
     return rc
 
+def check_ioctl_def(env, ctype):
+    """scons check for a struct member existing"""
+
+    env.Message('Checking if fuse ioctl is type {} '.format(ctype))
+
+    src = """#include <fuse3/fuse_lowlevel.h>
+
+extern void
+my_ioctl (fuse_req_t req, fuse_ino_t ino, %s cmd,
+    void *arg, struct fuse_file_info *fi, unsigned flags,
+    const void *in_buf, size_t in_bufsz, size_t out_bufsz);
+
+struct fuse_lowlevel_ops ops = {.ioctl = my_ioctl};
+
+""" % ctype
+
+    rc = env.TryCompile(src, '.c')
+    env.Result(rc)
+    return rc
+
 def configure_fuse(cenv):
     """Configure for specific version of fuse"""
     if GetOption('help') or GetOption('clean'):
         return
 
     check = Configure(cenv,
-                      custom_tests={'CheckStructMember': check_struct_member})
+                      custom_tests={'CheckStructMember': check_struct_member,
+                                    'CheckFuseIoctl': check_ioctl_def})
 
     if check.CheckStructMember('#include <fuse3/fuse.h>',
                                'struct fuse_file_info',
                                'cache_readdir'):
         cenv.AppendUnique(CPPDEFINES=['-DHAVE_CACHE_READDIR=1'])
+
+    if check.CheckFuseIoctl('unsigned int'):
+        pass
+    elif check.CheckFuseIoctl('int'):
+        cenv.AppendUnique(CPPDEFINES=['-DFUSE_IOCTL_USE_INT=1'])
+    else:
+        print('Could not determine type of fuse ioctl type')
+        Exit(2)
+
     check.Finish()
 
 def scons():

--- a/utils/docker/Dockerfile.centos.8
+++ b/utils/docker/Dockerfile.centos.8
@@ -163,7 +163,6 @@ COPY ./ .
 
 # Build DAOS & dependencies
 RUN if [ "x$NOBUILD" = "x" ] ; then \
-    echo -e "Import('env')\nenv.AppendUnique(CPPDEFINES=['FUSE_IOCTL_USE_INT'])" > ~/.scons_localrc; \
     scons-3 --build-deps=yes -j 4 install PREFIX=/opt/daos COMPILER=$COMPILER; fi
 
 # Set environment variables

--- a/utils/sl/fake_scons/SCons/Script/__init__.py
+++ b/utils/sl/fake_scons/SCons/Script/__init__.py
@@ -277,6 +277,10 @@ class Configure():
         """Fake CheckStructMember"""
         return True
 
+    def CheckFuseIoctl(self, *_args, **_kw):
+        """Fake CheckFuseIoctl"""
+        return True
+
     def CheckCmockaSkip(self, *_args, **_kw):
         """Fake CheckCmockaSkip"""
         return True


### PR DESCRIPTION
For some reason CentOS 8 has an older version of libfuse than
CentOS 7, so add a compile check to know which ioctl prototype
we need to use.

Newer versions of libfuse have a define you can use for this
however neither CentOS 7 or 8 have this.

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>