### PR TITLE
DAOS-6547 test: Pool info rebuild object and record counters zero-out…

### DIFF
--- a/src/tests/ftest/rebuild/container_create.yaml
+++ b/src/tests/ftest/rebuild/container_create.yaml
@@ -45,5 +45,5 @@ test:
     last_rank:
       rank: 4
   containers: 70
-  container_obj_class: "OC_RP_3GX"
+  container_obj_class: "OC_RP_3G1"
   use_ior: True

--- a/src/tests/ftest/rebuild/read_array.yaml
+++ b/src/tests/ftest/rebuild/read_array.yaml
@@ -28,5 +28,5 @@ container:
   dkey_size: 5
   data_size: 5
 rebuild:
-  object_class: OC_RP_3GX
+  object_class: OC_RP_3G1
   rank: 3


### PR DESCRIPTION
… after rebuild with Object_Class RP_3G2 and RP_3GX

Skip-unit-tests: true
Skip-nlt: true
Skip-func-test-vm: true
Skip-func-hw-test-small: true
Skip-func-hw-test-medium: true
Test-tag-hw-large: pr,hw,large rebuildreadarray
Signed-off-by: Ding Ho <ding-hwa.ho@intel.com>