### PR TITLE
CART-943 bug: Fix thee node cart self test

### DIFF
--- a/src/tests/ftest/cart/selftest/cart_selftest_three_node.py
+++ b/src/tests/ftest/cart/selftest/cart_selftest_three_node.py
@@ -61,9 +61,10 @@ class CartSelfThreeNodeTest(TestWithoutServers):
                 self, self.env, "test_clients", index=index)
             self.utils.launch_test(self, clicmd, srv_rtn)
 
-        # Give few seconds for servers to fully shut down before next
-        # iteration of tests will start up
-        sleep(2)
+        # Give few seconds for servers to fully shut down before exiting
+        # from this test.
+        if not self.utils.wait_process(srv_rtn, 5):
+            self.utils.stop_process(srv_rtn)
 
 if __name__ == "__main__":
     main()

--- a/src/tests/ftest/cart/selftest/cart_selftest_three_node.py
+++ b/src/tests/ftest/cart/selftest/cart_selftest_three_node.py
@@ -61,5 +61,9 @@ class CartSelfThreeNodeTest(TestWithoutServers):
                 self, self.env, "test_clients", index=index)
             self.utils.launch_test(self, clicmd, srv_rtn)
 
+        # Give few seconds for servers to fully shut down before next
+        # iteration of tests will start up
+        sleep(2)
+
 if __name__ == "__main__":
     main()

--- a/src/tests/ftest/cart/test_group_np_srv.c
+++ b/src/tests/ftest/cart/test_group_np_srv.c
@@ -40,6 +40,9 @@ test_run(d_rank_t my_rank)
 	D_ASSERTF(rc == 0, "crt_proto_register() failed. rc: %d\n",
 			rc);
 
+	/* Do not delay shutdown for this server */
+	tc_set_shutdown_delay(0);
+
 	DBG_PRINT("Protocol registered\n");
 	for (i = 1; i < test_g.t_srv_ctx_num; i++) {
 		rc = crt_context_create(&test_g.t_crt_ctx[i]);


### PR DESCRIPTION
During cart_selftest_three_node run the same test runs twice - once in
sep mode and one in non-sep mode.
Previous patch caused all servers by default to delay their shutdown by 2
seconds. In this test test_group_np_srv servers are shutdown by client
sending an RPC to the server to which server responds right away and then
initiates a shutdown sequence.

Python self-test script executes clients in order for this test. Once it
executes client to perform shutdown it will then start another iteration of
the test with different SEP setting, while old servers are still up (due to
2 second default delay on shutdown). This then causes servers to clash,
occasionally causing problems with new servers not being able to connect.

Signed-off-by: Alexander Oganezov <alexander.a.oganezov@intel.com>