### PR TITLE
DAOS-6562 iosrv: check ioh validness

### DIFF
--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -1518,9 +1518,11 @@ out:
 	if (bsgls_dup != NULL) {
 		int	i;
 
-		for (i = 0; i < orw->orw_nr; i++) {
-			vos_dedup_free_bsgl(ioh, &bsgls_dup[i]);
-			bio_sgl_fini(&bsgls_dup[i]);
+		if (daos_handle_is_valid(ioh)) {
+			for (i = 0; i < orw->orw_nr; i++) {
+				vos_dedup_free_bsgl(ioh, &bsgls_dup[i]);
+				bio_sgl_fini(&bsgls_dup[i]);
+			}
 		}
 		D_FREE(bsgls_dup);
 	}


### PR DESCRIPTION
Check 'ioh' validness before calling vos_dedup_sgl_fini(), the 'ioh'
could be invalid in some error cases.

Signed-off-by: Niu Yawei <yawei.niu@intel.com>