### PR TITLE
DAOS-6589 test: Add .git to codespell skips

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,6 @@ jobs:
     - name: Run check
       uses: codespell-project/actions-codespell@master
       with:
-        skip: ./src/control/vendor
+        skip: ./src/control/vendor,./.git
         ignore_words_file: ci/codespell.ignores
         builtin: clear,rare,informal,names,en-GB_to_en-US


### PR DESCRIPTION
No need to check the git hooks, etc.

doc-only: true