### PR TITLE
DAOS-6475 dtx: debug patch for IO callback

### DIFF
--- a/src/common/checksum.c
+++ b/src/common/checksum.c
@@ -61,6 +61,8 @@ daos_csummer_init(struct daos_csummer **obj, struct hash_ft *ft,
 
 	if (rc == 0)
 		*obj = result;
+	else
+		D_FREE_PTR(result);
 
 	return rc;
 }

--- a/src/include/daos_fs.h
+++ b/src/include/daos_fs.h
@@ -37,6 +37,19 @@ typedef struct dfs_obj dfs_obj_t;
 /** DFS mount handle struct */
 typedef struct dfs dfs_t;
 
+/*
+ * Consistency modes of the DFS container. A container created with balanced
+ * mode, can only be accessed with balanced mode with dfs_mount. A container
+ * created with relaxed mode, can be accessed with either mode in the future.
+ *
+ * Reserve bit 3 in the access flags for dfs_mount() - bits 1 and 2 are used
+ * for read / write access (O_RDONLY, O_RDRW).
+ */
+#define DFS_BALANCED	0 /** DFS operations using a DTX (default mode) */
+#define DFS_RELAXED	4 /** DFS operations do not use a DTX. */
+#define DFS_RDONLY	O_RDONLY
+#define DFS_RDWR	O_RDWR
+
 /** struct holding attributes for a DFS container */
 typedef struct {
 	/** Optional user ID for DFS container. */
@@ -47,6 +60,12 @@ typedef struct {
 	daos_oclass_id_t	da_oclass_id;
 	/** DAOS properties on the DFS container */
 	daos_prop_t		*da_props;
+	/*
+	 * Consistency mode for the DFS container: D_RELAXED, D_BALANCED.
+	 * If set to 0 or more generally not set to relaxed explicitly, balanced
+	 * mode will be used.
+	 */
+	uint32_t		da_mode;
 } dfs_attr_t;
 
 /** IO descriptor of ranges in a file to access */

--- a/src/object/cli_shard.c
+++ b/src/object/cli_shard.c
@@ -599,6 +599,8 @@ dc_rw_cb(tse_task_t *task, void *arg)
 	opc = opc_get(rw_args->rpc->cr_opc);
 	D_DEBUG(DB_IO, "rpc %p opc:%d completed, dt_result %d.\n",
 		rw_args->rpc, opc, ret);
+	D_ASSERTF(ret != -DER_TX_RESTART, "Invalid RW task result\n");
+
 	if (opc == DAOS_OBJ_RPC_FETCH &&
 	    DAOS_FAIL_CHECK(DAOS_SHARD_OBJ_FETCH_TIMEOUT)) {
 		D_ERROR("Inducing -DER_TIMEDOUT error on shard I/O fetch\n");
@@ -623,7 +625,7 @@ dc_rw_cb(tse_task_t *task, void *arg)
 	orw = crt_req_get(rw_args->rpc);
 	orwo = crt_reply_get(rw_args->rpc);
 	D_ASSERT(orw != NULL && orwo != NULL);
-	if (ret != 0) {
+	if (ret != 0 && ret != -DER_TX_RESTART) {
 		/*
 		 * If any failure happens inside Cart, let's reset failure to
 		 * TIMEDOUT, so the upper layer can retry.
@@ -642,15 +644,22 @@ dc_rw_cb(tse_task_t *task, void *arg)
 		int rc_tmp;
 
 		rc_tmp = dc_tx_op_end(task, th,
-				      &rw_args->shard_args->auxi.epoch, rc,
-				      orwo->orw_epoch);
+				      &rw_args->shard_args->auxi.epoch,
+				      ret ? ret : rc, orwo->orw_epoch);
 		if (rc_tmp != 0) {
 			D_ERROR("failed to end transaction operation (rc=%d "
-				"epoch="DF_U64": "DF_RC"\n", rc,
+				"epoch="DF_U64": "DF_RC"\n", ret ? ret : rc,
 				orwo->orw_epoch, DP_RC(rc_tmp));
 			goto out;
 		}
+
+		if (ret == -DER_TX_RESTART) {
+			D_DEBUG(DB_IO, "RPC %d needs to be restarted\n", opc);
+			goto out;
+		}
 	}
+
+	D_ASSERT(ret == 0);
 
 	if (rc != 0) {
 		if (rc == -DER_INPROGRESS || rc == -DER_TX_BUSY) {
@@ -1425,7 +1434,9 @@ dc_enumerate_cb(tse_task_t *task, void *arg)
 	oei = crt_req_get(enum_args->rpc);
 	D_ASSERT(oei != NULL);
 
-	if (ret != 0) {
+	D_ASSERTF(ret != -DER_TX_RESTART, "Invalid ENUM task result\n");
+
+	if (ret != 0 && ret != -DER_TX_RESTART) {
 		/* If any failure happens inside Cart, let's reset
 		 * failure to TIMEDOUT, so the upper layer can retry
 		 **/
@@ -1442,14 +1453,21 @@ dc_enumerate_cb(tse_task_t *task, void *arg)
 		int rc_tmp;
 
 		rc_tmp = dc_tx_op_end(task, *enum_args->th, enum_args->epoch,
-				      rc, oeo->oeo_epoch);
+				      ret ? ret : rc, oeo->oeo_epoch);
 		if (rc_tmp != 0) {
 			D_ERROR("failed to end transaction operation (rc=%d "
-				"epoch="DF_U64": "DF_RC"\n", rc,
+				"epoch="DF_U64": "DF_RC"\n", ret ? ret : rc,
 				oeo->oeo_epoch, DP_RC(rc_tmp));
 			goto out;
 		}
+
+		if (ret == -DER_TX_RESTART) {
+			D_DEBUG(DB_IO, "RPC %d needs to be restarted\n", opc);
+			goto out;
+		}
 	}
+
+	D_ASSERT(ret == 0);
 
 	if (rc != 0) {
 		if (rc == -DER_KEY2BIG) {
@@ -1838,28 +1856,37 @@ obj_shard_query_key_cb(tse_task_t *task, void *data)
 	flags = okqi->okqi_api_flags;
 	opc = opc_get(cb_args->rpc->cr_opc);
 
-	if (ret != 0) {
+	D_ASSERTF(ret != -DER_TX_RESTART, "Invalid QUERY task result\n");
+
+	if (ret != 0 && ret != -DER_TX_RESTART) {
 		D_ERROR("RPC %d failed: %d\n", opc, ret);
 		D_GOTO(out, ret);
 	}
 
 	okqo = crt_reply_get(cb_args->rpc);
+	rc = obj_reply_get_status(rpc);
 
 	/* See the similar dc_rw_cb. */
 	if (daos_handle_is_valid(cb_args->th)) {
 		int rc_tmp;
 
-		rc_tmp = dc_tx_op_end(task, cb_args->th, &cb_args->epoch, rc,
-				      okqo->okqo_epoch);
+		rc_tmp = dc_tx_op_end(task, cb_args->th, &cb_args->epoch,
+				      ret ? ret : rc, okqo->okqo_epoch);
 		if (rc_tmp != 0) {
 			D_ERROR("failed to end transaction operation (rc=%d "
-				"epoch="DF_U64": "DF_RC"\n", rc,
+				"epoch="DF_U64": "DF_RC"\n", ret ? ret : rc,
 				okqo->okqo_epoch, DP_RC(rc_tmp));
+			goto out;
+		}
+
+		if (ret == -DER_TX_RESTART) {
+			D_DEBUG(DB_IO, "RPC %d needs to be restarted\n", opc);
 			goto out;
 		}
 	}
 
-	rc = obj_reply_get_status(rpc);
+	D_ASSERT(ret == 0);
+
 	if (rc != 0) {
 		if (rc == -DER_NONEXIST)
 			D_GOTO(out, rc = 0);

--- a/src/tests/ftest/erasurecode/ec_mdtest_smoke.yaml
+++ b/src/tests/ftest/erasurecode/ec_mdtest_smoke.yaml
@@ -9,7 +9,7 @@ hosts:
     - server-F
     - server-G
     - server-H
-timeout: 300
+timeout: 1500
 server_config:
   servers_per_host: 2
   name: daos_server
@@ -25,7 +25,10 @@ server_config:
       scm_class: dcpm
       scm_list: ["/dev/pmem0"]
       scm_mount: /mnt/daos0
-      log_mask: ERR
+      log_mask: DEBUG,MEM=ERR
+      env_vars:
+        - DD_MASK=io,trace
+        - D_LOG_MASK=DEBUG,MEM=ERR
     1:
       pinned_numa_node: 1
       nr_xs_helpers: 1
@@ -37,7 +40,10 @@ server_config:
       scm_class: dcpm
       scm_list: ["/dev/pmem1"]
       scm_mount: /mnt/daos1
-      log_mask: ERR
+      log_mask: DEBUG,MEM=ERR
+      env_vars:
+        - DD_MASK=io,trace
+        - D_LOG_MASK=DEBUG,MEM=ERR
 pool:
     mode: 146
     name: daos_server

--- a/src/tests/ftest/io/llnl_mpi4py.yaml
+++ b/src/tests/ftest/io/llnl_mpi4py.yaml
@@ -6,9 +6,14 @@ hosts:
         - boro-C
         - boro-D
         - boro-E
-timeout: 180
+timeout: 240
 server_config:
     name: daos_server
+    servers:
+        log_mask: DEBUG,MEM=ERR
+        env_vars:
+          - DD_MASK=all
+          - D_LOG_MASK=DEBUG,MEM=ERR
 pool:
     mode: 146
     name: daos_server

--- a/src/tests/ftest/io/mdtest_small.yaml
+++ b/src/tests/ftest/io/mdtest_small.yaml
@@ -7,9 +7,14 @@ hosts:
   test_clients:
     - client-E
     - client-F
-timeout: 605
+timeout: 2400
 server_config:
   name: daos_server
+  servers:
+    log_mask: DEBUG,MEM=ERR
+    env_vars:
+      - DD_MASK=all
+      - D_LOG_MASK=DEBUG,MEM=ERR
   transport_config:
     allow_insecure: True
 agent_config:

--- a/src/tests/ftest/util/mpio_utils.py
+++ b/src/tests/ftest/util/mpio_utils.py
@@ -83,6 +83,7 @@ class MpioUtils():
         env["DAOS_POOL"] = "{}".format(pool_uuid)
         env["DAOS_CONT"] = "{}".format(cont_uuid)
         env["DAOS_BYPASS_DUNS"] = "1"
+        env["D_LOG_MASK"] = "debug"
         mpirun = os.path.join(self.mpichinstall, "bin", "mpirun")
 
         executables = {

--- a/src/tests/suite/dfs_unit_test.c
+++ b/src/tests/suite/dfs_unit_test.c
@@ -68,6 +68,96 @@ dfs_test_mount(void **state)
 }
 
 static void
+dfs_test_modes(void **state)
+{
+	test_arg_t		*arg = *state;
+	uuid_t			cuuid;
+	daos_cont_info_t	co_info;
+	daos_handle_t		coh;
+	dfs_attr_t		attr = {0};
+	dfs_t			*dfs;
+	int			rc;
+
+	if (arg->myrank != 0)
+		return;
+
+	/** create a DFS container in Relaxed mode */
+	attr.da_mode = DFS_RELAXED;
+	rc = dfs_cont_create(arg->pool.poh, cuuid, &attr, NULL, NULL);
+	assert_int_equal(rc, 0);
+	rc = daos_cont_open(arg->pool.poh, cuuid, DAOS_COO_RW,
+			    &coh, &co_info, NULL);
+	assert_int_equal(rc, 0);
+	/** mount in Relaxed mode should succeed */
+	rc = dfs_mount(arg->pool.poh, coh, O_RDWR | DFS_RELAXED, &dfs);
+	assert_int_equal(rc, 0);
+	rc = dfs_umount(dfs);
+	assert_int_equal(rc, 0);
+	rc = dfs_mount(arg->pool.poh, coh, O_RDONLY | DFS_RELAXED, &dfs);
+	assert_int_equal(rc, 0);
+	rc = dfs_umount(dfs);
+	assert_int_equal(rc, 0);
+	/** mount in Balanced mode should succeed */
+	rc = dfs_mount(arg->pool.poh, coh, O_RDWR | DFS_BALANCED, &dfs);
+	assert_int_equal(rc, 0);
+	rc = dfs_umount(dfs);
+	assert_int_equal(rc, 0);
+	rc = dfs_mount(arg->pool.poh, coh, O_RDONLY | DFS_BALANCED, &dfs);
+	assert_int_equal(rc, 0);
+	rc = dfs_umount(dfs);
+	assert_int_equal(rc, 0);
+	/** destroy */
+	rc = daos_cont_close(coh, NULL);
+	assert_int_equal(rc, 0);
+	rc = daos_cont_destroy(arg->pool.poh, cuuid, 1, NULL);
+	assert_int_equal(rc, 0);
+
+	/** create a DFS container in Balanced mode */
+	attr.da_mode = DFS_BALANCED;
+	rc = dfs_cont_create(arg->pool.poh, cuuid, &attr, NULL, NULL);
+	assert_int_equal(rc, 0);
+	rc = daos_cont_open(arg->pool.poh, cuuid, DAOS_COO_RW,
+			    &coh, &co_info, NULL);
+	assert_int_equal(rc, 0);
+	/** mount in Relaxed mode should fail with EPERM */
+	rc = dfs_mount(arg->pool.poh, coh, O_RDWR | DFS_RELAXED, &dfs);
+	assert_int_equal(rc, EPERM);
+	rc = dfs_mount(arg->pool.poh, coh, O_RDONLY | DFS_RELAXED, &dfs);
+	assert_int_equal(rc, EPERM);
+	/** mount in Balanced / default mode should succeed */
+	rc = dfs_mount(arg->pool.poh, coh, O_RDWR, &dfs);
+	assert_int_equal(rc, 0);
+	rc = dfs_umount(dfs);
+	assert_int_equal(rc, 0);
+	rc = dfs_mount(arg->pool.poh, coh, O_RDONLY | DFS_BALANCED, &dfs);
+	assert_int_equal(rc, 0);
+	rc = dfs_umount(dfs);
+	assert_int_equal(rc, 0);
+	/** destroy */
+	rc = daos_cont_close(coh, NULL);
+	assert_int_equal(rc, 0);
+	rc = daos_cont_destroy(arg->pool.poh, cuuid, 1, NULL);
+	assert_int_equal(rc, 0);
+
+	/** create a DFS container with no mode specified */
+	rc = dfs_cont_create(arg->pool.poh, cuuid, NULL, NULL, NULL);
+	assert_int_equal(rc, 0);
+	rc = daos_cont_open(arg->pool.poh, cuuid, DAOS_COO_RW,
+			    &coh, &co_info, NULL);
+	assert_int_equal(rc, 0);
+	/** mount in Relaxed mode should fail with EPERM */
+	rc = dfs_mount(arg->pool.poh, coh, O_RDWR | DFS_RELAXED, &dfs);
+	assert_int_equal(rc, EPERM);
+	rc = dfs_mount(arg->pool.poh, coh, O_RDONLY | DFS_RELAXED, &dfs);
+	assert_int_equal(rc, EPERM);
+	/** destroy */
+	rc = daos_cont_close(coh, NULL);
+	assert_int_equal(rc, 0);
+	rc = daos_cont_destroy(arg->pool.poh, cuuid, 1, NULL);
+	assert_int_equal(rc, 0);
+}
+
+static void
 dfs_test_lookup_hlpr(const char *name, mode_t mode)
 {
 	dfs_obj_t		*obj;
@@ -522,13 +612,15 @@ dfs_test_read_shared_file(void **state)
 static const struct CMUnitTest dfs_unit_tests[] = {
 	{ "DFS_UNIT_TEST1: DFS mount / umount",
 	  dfs_test_mount, async_disable, test_case_teardown},
-	{ "DFS_UNIT_TEST2: DFS lookup / lookup_rel",
+	{ "DFS_UNIT_TEST2: DFS container modes",
+	  dfs_test_modes, async_disable, test_case_teardown},
+	{ "DFS_UNIT_TEST3: DFS lookup / lookup_rel",
 	  dfs_test_lookup, async_disable, test_case_teardown},
-	{ "DFS_UNIT_TEST3: Simple Symlinks",
+	{ "DFS_UNIT_TEST4: Simple Symlinks",
 	  dfs_test_syml, async_disable, test_case_teardown},
-	{ "DFS_UNIT_TEST4: Symlinks with / without O_NOFOLLOW",
+	{ "DFS_UNIT_TEST5: Symlinks with / without O_NOFOLLOW",
 	  dfs_test_syml_follow, async_disable, test_case_teardown},
-	{ "DFS_UNIT_TEST5: multi-threads read shared file",
+	{ "DFS_UNIT_TEST6: multi-threads read shared file",
 	  dfs_test_read_shared_file, async_disable, test_case_teardown},
 };
 

--- a/src/utils/daos.c
+++ b/src/utils/daos.c
@@ -31,12 +31,25 @@
 
 #include "daos_types.h"
 #include "daos_api.h"
+#include "daos_fs.h"
 #include "daos_uns.h"
 #include "daos_fs.h"
 #include "daos_hdlr.h"
 #include "dfuse_ioctl.h"
 
 const char		*default_sysname = DAOS_DEFAULT_SYS_NAME;
+
+static inline int
+daos_parse_cmode(const char *string, uint32_t *mode)
+{
+	if (strcasecmp(string, "relaxed") == 0)
+		*mode = DFS_RELAXED;
+	else if (strcasecmp(string, "balanced") == 0)
+		*mode = DFS_BALANCED;
+	else
+		return -1;
+	return 0;
+}
 
 static enum fs_op
 filesystem_op_parse(const char *str)
@@ -533,6 +546,7 @@ common_op_parse_hdlr(int argc, char *argv[], struct cmd_args_s *ap)
 		{"src",		required_argument,	NULL,	'S'},
 		{"dst",		required_argument,	NULL,	'D'},
 		{"type",	required_argument,	NULL,	't'},
+		{"mode",	required_argument,	NULL,	'M'},
 		{"oclass",	required_argument,	NULL,	'o'},
 		{"chunk_size",	required_argument,	NULL,	'z'},
 		{"snap",	required_argument,	NULL,	's'},
@@ -550,16 +564,20 @@ common_op_parse_hdlr(int argc, char *argv[], struct cmd_args_s *ap)
 		{"principal",	required_argument,	NULL,	'P'},
 		{NULL,		0,			NULL,	0}
 	};
+	bool			posix_mode_set = false;
 	int			rc;
 	const int		RC_PRINT_HELP = 2;
 	const int		RC_NO_HELP = -2;
 	char			*cmdname = NULL;
 
 	assert(ap != NULL);
+
 	ap->p_op  = -1;
 	ap->c_op  = -1;
 	ap->o_op  = -1;
+	ap->mode  = 0;
 	ap->fs_op = -1;
+
 	D_STRNDUP(ap->sysname, default_sysname, strlen(default_sysname));
 	if (ap->sysname == NULL)
 		return RC_NO_HELP;
@@ -678,6 +696,15 @@ common_op_parse_hdlr(int argc, char *argv[], struct cmd_args_s *ap)
 				D_GOTO(out_free, rc = RC_PRINT_HELP);
 			}
 			break;
+		case 'M':
+			posix_mode_set = true;
+			if (daos_parse_cmode(optarg, &ap->mode) != 0) {
+				fprintf(stderr,
+					"Invalid POSIX consistency mode: %s\n",
+					optarg);
+				D_GOTO(out_free, rc = RC_PRINT_HELP);
+			}
+			break;
 		case 'o':
 			ap->oclass = daos_oclass_name2id(optarg);
 			if (ap->oclass == OC_UNKNOWN) {
@@ -793,6 +820,11 @@ common_op_parse_hdlr(int argc, char *argv[], struct cmd_args_s *ap)
 	}
 
 	cmd_args_print(ap);
+
+	if (posix_mode_set && ap->type != DAOS_PROP_CO_LAYOUT_POSIX) {
+		fprintf(stderr, "--mode is valid only for a POSIX container\n");
+		D_GOTO(out_free, rc = RC_NO_HELP);
+	}
 
 	/* Check for any unimplemented commands, print help */
 	if (ap->p_op != -1 &&
@@ -1378,6 +1410,9 @@ help_hdlr(int argc, char *argv[], struct cmd_args_s *ap)
 			"	--path=PATHSTR     container namespace path\n"
 			"container create common optional options:\n"
 			"	--type=CTYPESTR    container type (HDF5, POSIX)\n"
+			"	--mode=FLAG        In case of POSIX type, select consistency mode:\n"
+			"			   relaxed: weaker consistency semantics.\n"
+			"			   balanced (default): stronger consistency semantics.\n"
 			"	--oclass=OCLSSTR   container object class\n"
 			"			   (");
 			/* vs hardcoded list like "tiny, small, large, R2, R2S, repl_max" */

--- a/src/utils/daos_hdlr.c
+++ b/src/utils/daos_hdlr.c
@@ -1511,6 +1511,7 @@ cont_create_hdlr(struct cmd_args_s *ap)
 		attr.da_oclass_id = ap->oclass;
 		attr.da_chunk_size = ap->chunk_size;
 		attr.da_props = ap->props;
+		attr.da_mode = ap->mode;
 		rc = dfs_cont_create(ap->pool, ap->c_uuid, &attr, NULL, NULL);
 	} else {
 		rc = daos_cont_create(ap->pool, ap->c_uuid, ap->props, NULL);

--- a/src/utils/daos_hdlr.h
+++ b/src/utils/daos_hdlr.h
@@ -74,6 +74,7 @@ struct cmd_args_s {
 	char			*dst;		/* --dst path for fs copy */
 	daos_cont_layout_t	type;		/* --type cont type */
 	daos_oclass_id_t	oclass;		/* --oclass object class */
+	uint32_t		mode;		/* --posix consistency mode */
 	daos_size_t		chunk_size;	/* --chunk_size of cont objs */
 
 	/* Container snapshot/rollback related */


### PR DESCRIPTION
To catch what caused the  unexpected -DER_TX_RESTART in the
IO (read/enum/query) task callback.

Contains the patches:
https://github.com/daos-stack/daos/pull/4013
https://github.com/daos-stack/daos/pull/4303
https://github.com/daos-stack/daos/pull/4326
https://github.com/daos-stack/daos/pull/4354

Just for test.

Skip-nlt: true

Signed-off-by: Fan Yong <fan.yong@intel.com>