### PR TITLE
CART-89-dlog DEBUG: Extension of CART-933. Fixed range check in pristr

### DIFF
--- a/src/gurt/dlog.c
+++ b/src/gurt/dlog.c
@@ -128,7 +128,7 @@ static const char *clog_pristr(int pri)
 	int s;
 
 	s = DLOG_PRI(pri);
-	if (s > (sizeof(norm) / sizeof(char *))) {
+	if (s >= (sizeof(norm) / sizeof(char *))) {
 		/* prevent checksum warning */
 		s = 0;
 	}


### PR DESCRIPTION
Signed-off-by: Steven Bollinger <stevenx.bollinger@intel.com>