### PR TITLE
DAOS-6599 test: env is not set for romio test

### DIFF
--- a/src/tests/ftest/io/romio.yaml
+++ b/src/tests/ftest/io/romio.yaml
@@ -3,7 +3,7 @@ hosts:
     - server-A
   test_clients:
     - client-B
-timeout: 70
+timeout: 150
 # below mentioned path should be replaced by path of
 # romio test suite directory in CI nodes when available.
 server_config:

--- a/src/tests/ftest/util/mpio_utils.py
+++ b/src/tests/ftest/util/mpio_utils.py
@@ -109,7 +109,6 @@ class MpioUtils():
         # Setup the commands to run for this test name
         commands = []
         if test_name == "romio":
-            env = None
             commands.append(
                 "{} -fname=daos:test1 -subset".format(
                     executables[test_name][0]))


### PR DESCRIPTION
The CI functional test for romio is unsetting env. this will cause the test to fail. CI however was not reporting that failure due to a different bug. this patch just fixes the failure.

Quick-Functional: true
Test-tag: romio

Signed-off-by: Mohamad Chaarawi <mohamad.chaarawi@intel.com>