### PR TITLE
DAOSSDE-54 build: Update isa-l to 2.30.0

### DIFF
--- a/utils/build.config
+++ b/utils/build.config
@@ -4,11 +4,9 @@ component=daos
 [commit_versions]
 ARGOBOTS = v1.0
 PMDK = 1.9.2
-ISAL = v2.26.0
+ISAL = v2.30.0
 ISAL_CRYPTO = v2.23.0
 SPDK = v20.01.1
-FUSE = fuse-3.6.1
-FIO = e3ccbdd5f93d33162a93000586461ac6bba5a7d3
 OFI = v1.11.1
 OPENPA = v1.0.4
 MERCURY = v2.0.1rc1


### PR DESCRIPTION
Also remove FUSE and FIO from build.config since we don't buid those any
more.

Signed-off-by: Brian J. Murrell <brian.murrell@intel.com>