### PR TITLE
DAOS-6640 control: reduce number of qpair creation during format

### DIFF
--- a/src/control/lib/spdk/include/nvme_control_common.h
+++ b/src/control/lib/spdk/include/nvme_control_common.h
@@ -94,7 +94,6 @@ struct ctrlr_entry {
 
 struct ns_entry {
 	struct spdk_nvme_ns	*ns;
-	struct spdk_nvme_qpair	*qpair;
 	struct ns_entry		*next;
 };
 

--- a/src/control/lib/spdk/src/nvme_control.c
+++ b/src/control/lib/spdk/src/nvme_control.c
@@ -34,10 +34,10 @@ enum lba0_write_result {
 	LBA0_WRITE_FAIL		= 0x2,
 };
 
+/** data structure passed to NVMe cmd completion */
 struct lba0_data {
 	struct ns_entry		*ns_entry;
-	char			*buf;
-	enum lba0_write_result	 write_result;
+	enum lba0_write_result	 result;
 };
 
 static void
@@ -56,6 +56,12 @@ get_health_logs(struct spdk_nvme_ctrlr *ctrlr, struct health_entry *health)
 {
 	struct spdk_nvme_health_information_page hp;
 	int					 rc = 0;
+
+	/** NVMe SSDs on GCP do not support this */
+	if (!spdk_nvme_ctrlr_is_log_page_supported(ctrlr,
+					SPDK_NVME_LOG_HEALTH_INFORMATION))
+		/** not much we can do, just skip */
+		return 0;
 
 	health->inflight++;
 	rc = spdk_nvme_ctrlr_cmd_get_log_page(ctrlr,
@@ -81,52 +87,20 @@ nvme_discover(void)
 	return _discover(&spdk_nvme_probe, true, &get_health_logs);
 }
 
-static void
-read_complete(void *arg, const struct spdk_nvme_cpl *completion)
-{
-	struct lba0_data *data = arg;
-
-	spdk_free(data->buf);
-
-	if (spdk_nvme_cpl_is_success(completion)) {
-		data->write_result = LBA0_WRITE_SUCCESS;
-		return;
-	}
-
-	spdk_nvme_qpair_print_completion(data->ns_entry->qpair,
-					 (struct spdk_nvme_cpl *)completion);
-	fprintf(stderr, "I/O error status: %s\n",
-		spdk_nvme_cpl_get_status_string(&completion->status));
-	fprintf(stderr, "Read I/O failed, aborting run\n");
-	data->write_result = LBA0_WRITE_FAIL;
-}
-
+/** callback for write command completion when wiping out a ns */
 static void
 write_complete(void *arg, const struct spdk_nvme_cpl *completion)
 {
-	struct lba0_data	*data = arg;
-	struct ns_entry		*ns_entry = data->ns_entry;
-	int			 rc;
+	struct lba0_data *data = arg;
 
 	if (spdk_nvme_cpl_is_success(completion)) {
-		rc = spdk_nvme_ns_cmd_read(ns_entry->ns, ns_entry->qpair,
-					   data->buf, 0, 1, read_complete,
-					   (void *)data, 0);
-		if (rc != 0) {
-			fprintf(stderr, "starting read I/O failed (%d)\n", rc);
-			data->write_result = LBA0_WRITE_FAIL;
-		}
-		return;
+		data->result = LBA0_WRITE_SUCCESS;
+	} else {
+		fprintf(stderr, "I/O error status: %s\n",
+			spdk_nvme_cpl_get_status_string(&completion->status));
+		fprintf(stderr, "Write I/O failed, aborting run\n");
+		data->result = LBA0_WRITE_FAIL;
 	}
-
-	spdk_nvme_qpair_print_completion(data->ns_entry->qpair,
-					 (struct spdk_nvme_cpl *)completion);
-	fprintf(stderr, "I/O error status: %s\n",
-		spdk_nvme_cpl_get_status_string(&completion->status));
-	fprintf(stderr, "Read I/O failed, aborting run\n");
-	data->write_result = LBA0_WRITE_FAIL;
-
-	spdk_free(data->buf);
 }
 
 static struct wipe_res_t *
@@ -135,60 +109,74 @@ wipe_ctrlr(struct ctrlr_entry *centry, struct ns_entry *nentry)
 	struct lba0_data	 data;
 	struct wipe_res_t	*res = NULL, *tmp = NULL;
 	int			 rc;
+	struct spdk_nvme_qpair	*qpair;
+	char			*buf;
 
+	res = init_wipe_res();
+
+	/** convert pci addr to string */
+	rc = spdk_pci_addr_fmt(res->ctrlr_pci_addr, sizeof(res->ctrlr_pci_addr),
+			       &centry->pci_addr);
+	if (rc != 0) {
+		res->rc = -NVMEC_ERR_PCI_ADDR_FMT;
+		return res;
+	}
+
+	/** allocate NVMe queue pair for the controller */
+	qpair = spdk_nvme_ctrlr_alloc_io_qpair(centry->ctrlr, NULL, 0);
+	if (qpair == NULL) {
+		snprintf(res->info, sizeof(res->info),
+			 "spdk_nvme_ctrlr_alloc_io_qpair()\n");
+		res->rc = -1;
+		return res;
+	}
+
+	/** allocate a 4K page, with 4K alignment */
+	buf =  spdk_dma_zmalloc(4096, 4096, NULL);
+	if (buf == NULL) {
+		snprintf(res->info, sizeof(res->info),
+			 "spdk_dma_zmalloc()\n");
+		res->rc = -1;
+		spdk_nvme_ctrlr_free_io_qpair(qpair);
+		return res;
+	}
+
+	/** iterate over the namespaces and wipe them out individually */
 	while (nentry != NULL) {
-		res = init_wipe_res();
-		res->next = tmp;
-		tmp = res;
+		uint32_t sector_size;
 
+		if (tmp == NULL) {
+			/** first iteration */
+			tmp = res;
+		} else {
+			/** allocate new res */
+			res = init_wipe_res();
+			res->next = tmp;
+			tmp = res;
+		}
+
+		/** retrieve namespace ID and sector size */
 		res->ns_id = spdk_nvme_ns_get_id(nentry->ns);
+		sector_size = spdk_nvme_ns_get_sector_size(nentry->ns);
 
-		rc = spdk_pci_addr_fmt(res->ctrlr_pci_addr,
-				       sizeof(res->ctrlr_pci_addr),
-				       &centry->pci_addr);
-		if (rc != 0) {
-			res->rc = -NVMEC_ERR_PCI_ADDR_FMT;
-			return res;
-		}
-
-		nentry->qpair = spdk_nvme_ctrlr_alloc_io_qpair(centry->ctrlr,
-							       NULL, 0);
-		if (nentry->qpair == NULL) {
-			snprintf(res->info, sizeof(res->info),
-				 "spdk_nvme_ctrlr_alloc_io_qpair()\n");
-			res->rc = -1;
-			return res;
-		}
-
-		data.buf = spdk_zmalloc(0x1000, 0x1000, NULL,
-					SPDK_ENV_SOCKET_ID_ANY,
-					SPDK_MALLOC_DMA);
-		if (data.buf == NULL) {
-			snprintf(res->info, sizeof(res->info),
-				 "spdk_zmalloc()\n");
-			res->rc = -1;
-			spdk_nvme_ctrlr_free_io_qpair(nentry->qpair);
-			return res;
-		}
-		data.write_result = LBA0_WRITE_PENDING;
+		data.result = LBA0_WRITE_PENDING;
 		data.ns_entry = nentry;
 
-		rc = spdk_nvme_ns_cmd_write(nentry->ns, nentry->qpair,
-					    data.buf, 0, /* LBA start */
-					    1, /* number of LBAs */
+		/** zero out the first 4K block */
+		rc = spdk_nvme_ns_cmd_write(nentry->ns, qpair,
+					    buf, 0 /** LBA start */,
+					    4096 / sector_size /** #LBAS */,
 					    write_complete, &data, 0);
 		if (rc != 0) {
 			snprintf(res->info, sizeof(res->info),
 				 "spdk_nvme_ns_cmd_write() (%d)\n", rc);
 			res->rc = -1;
-			spdk_free(data.buf);
-			spdk_nvme_ctrlr_free_io_qpair(nentry->qpair);
-			return res;
+			break;
 		}
 
-		while (data.write_result == LBA0_WRITE_PENDING) {
-			rc = spdk_nvme_qpair_process_completions(nentry->qpair,
-								 0);
+		/** wait for command completion */
+		while (data.result == LBA0_WRITE_PENDING) {
+			rc = spdk_nvme_qpair_process_completions(qpair, 0);
 			if (rc < 0) {
 				fprintf(stderr,
 					"process completions returns %d\n", rc);
@@ -196,17 +184,19 @@ wipe_ctrlr(struct ctrlr_entry *centry, struct ns_entry *nentry)
 			}
 		}
 
-		if (data.write_result != LBA0_WRITE_SUCCESS) {
+		/** check command result */
+		if (data.result != LBA0_WRITE_SUCCESS) {
 			snprintf(res->info, sizeof(res->info),
-				 "spdk_nvme_ns_cmd_write() callback\n");
+				 "spdk_nvme_ns_cmd_write() failed\n");
 			res->rc = -1;
-			spdk_nvme_ctrlr_free_io_qpair(nentry->qpair);
-			return res;
+			break;
 		}
 
-		spdk_nvme_ctrlr_free_io_qpair(nentry->qpair);
 		nentry = nentry->next;
 	}
+
+	spdk_free(buf);
+	spdk_nvme_ctrlr_free_io_qpair(qpair);
 
 	return res;
 }
@@ -251,10 +241,10 @@ nvme_wipe_namespaces(void)
 
 	/*
 	 * Start the SPDK NVMe enumeration process.  probe_cb will be called
-	 *  for each NVMe controller found, giving our application a choice on
-	 *  whether to attach to each controller.  attach_cb will then be
-	 *  called for each controller after the SPDK NVMe driver has completed
-	 *  initializing the controller we chose to attach.
+	 * for each NVMe controller found, giving our application a choice on
+	 * whether to attach to each controller.  attach_cb will then be
+	 * called for each controller after the SPDK NVMe driver has completed
+	 * initializing the controller we chose to attach.
 	 */
 	rc = spdk_nvme_probe(NULL, NULL, probe_cb, attach_cb, NULL);
 	if (rc < 0) {


### PR DESCRIPTION
When formatting multiple NVMe namespace (like on GCP), we should create
one queue pair per controller and reuse it for each namespace otherwise
we expose some bugs with write completion events that are never reported.
This patch also:
- removes the additional read after write which is not necessary
- calculates the number of LBAs based on the sector size to make
  sure that we are really writting 4K (and not 512B).
- uses spdk_dma_zmalloc() for convenience

Signed-off-by: Johann Lombardi <johann.lombardi@intel.com>