### PR TITLE
DAOS-6539 object: refresh DTX status during EC aggregation

### DIFF
--- a/src/object/obj_internal.h
+++ b/src/object/obj_internal.h
@@ -761,6 +761,12 @@ daos_iom_dump(daos_iom_t *iom)
 	D_PRINT("\n");
 }
 
+static inline bool
+obj_dtx_need_refresh(struct dtx_handle *dth, int rc)
+{
+	return rc == -DER_INPROGRESS && dth->dth_share_tbd_count > 0;
+}
+
 int  obj_class_init(void);
 void obj_class_fini(void);
 int  obj_utils_init(void);

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -29,12 +29,6 @@
 #include "obj_rpc.h"
 #include "obj_internal.h"
 
-static inline bool
-obj_dtx_need_refresh(struct dtx_handle *dth, int rc)
-{
-	return rc == -DER_INPROGRESS && dth->dth_share_tbd_count > 0;
-}
-
 static int
 obj_verify_bio_csum(daos_obj_id_t oid, daos_iod_t *iods,
 		    struct dcs_iod_csums *iod_csums, struct bio_desc *biod,

--- a/src/tests/suite/daos_dist_tx.c
+++ b/src/tests/suite/daos_dist_tx.c
@@ -2579,9 +2579,6 @@ dtx_37(void **state)
 	d_rank_t	 kill_rank = CRT_NO_RANK;
 	int		 i;
 
-	/* Skip for DAOS-6615 */
-	skip();
-
 	FAULT_INJECTION_REQUIRED();
 
 	print_message("DTX37: resync - leader failed during prepare\n");


### PR DESCRIPTION
It is possible that the EC aggregation may hit non-committed DTX
that be garbage DTX entry left by some test failure injection.
Under such case, the EC aggregation needs to call DTX refresh to
check with related DTX leader. Otherwise, the EC aggregation may
hung there. That is why dtx_37 is reported timeout in CI test.

Enable dtx_37.

Signed-off-by: Fan Yong <fan.yong@intel.com>