### PR TITLE
DAOS-5033 uns: Update comments in daos_uns.h and remove defines.

### DIFF
--- a/src/client/dfs/duns.c
+++ b/src/client/dfs/duns.c
@@ -30,8 +30,6 @@
 #include "daos_fs.h"
 #include "daos_uns.h"
 
-#define DUNS_MAX_XATTR_LEN	170
-#define DUNS_MIN_XATTR_LEN	85
 #define DUNS_XATTR_FMT		"DAOS.%s://%36s/%36s"
 
 #ifndef FUSE_SUPER_MAGIC
@@ -539,8 +537,9 @@ duns_create_lustre_path(daos_handle_t poh, const char *path,
 	/* XXX should file with foreign LOV be expected/supoorted here ? */
 
 	/** create dir and store the daos attributes in the path LMV */
-	len = sprintf(str, DUNS_XATTR_FMT, type, pool, cont);
-	if (len < DUNS_MIN_XATTR_LEN) {
+	len = snprintf(str,
+		       DUNS_MAX_XATTR_LEN, DUNS_XATTR_FMT, type, pool, cont);
+	if (len < 0) {
 		D_ERROR("Failed to create LMV value\n");
 		D_GOTO(err_cont, rc = EINVAL);
 	}
@@ -676,8 +675,13 @@ duns_create_path(daos_handle_t poh, const char *path, struct duns_attr_t *attrp)
 		}
 
 		/** store the daos attributes in the path xattr */
-		len = sprintf(str, DUNS_XATTR_FMT, type, pool, cont);
-		if (len < DUNS_MIN_XATTR_LEN) {
+		len = snprintf(str,
+			       DUNS_MAX_XATTR_LEN,
+			       DUNS_XATTR_FMT,
+			       type,
+			       pool,
+			       cont);
+		if (len < 0) {
 			D_ERROR("Failed to create xattr value\n");
 			D_GOTO(err_link, rc = EINVAL);
 		}

--- a/src/include/daos_fs.h
+++ b/src/include/daos_fs.h
@@ -461,7 +461,7 @@ dfs_iterate(dfs_t *dfs, dfs_obj_t *obj, daos_anchor_t *anchor,
  * feature is not supported yet.
  *
  * \param[in]	obj	Dir object to split anchor for.
- * \param[in/out]
+ * \param[in,out]
  *		nr	[in]: Number of anchors requested and allocated in
  *			\a anchors. Pass 0 for DAOS to recommend split num.
  *			[out]: Number of anchors recommended if 0 is passed in.

--- a/src/include/daos_uns.h
+++ b/src/include/daos_uns.h
@@ -32,7 +32,8 @@ struct duns_attr_t {
 	daos_oclass_id_t	da_oclass_id;
 	/** Default Chunks size for all files in container */
 	daos_size_t		da_chunk_size;
-	/*
+	/** Relative component of path.
+	 *
 	 * If using direct access to a POSIX container with the prefix, return
 	 * path without the prefix.
 	 */
@@ -41,7 +42,8 @@ struct duns_attr_t {
 	daos_prop_t		*da_props;
 	/** Path is on Lustre */
 	bool			da_on_lustre;
-	/*
+	/** String does not include daos:// prefix
+	 *
 	 * Path that is passed does not have daos: prefix but is direct:
 	 * (/puuid/cuuid/xyz) and does not need to parse a path UNS attrs.
 	 */
@@ -93,7 +95,7 @@ duns_create_path(daos_handle_t poh, const char *path,
  * an HDF5 file.
  *
  * \param[in]		path	Valid path in an existing namespace.
- * \param[in,out]	attr	Struct containing the xattrs on the path.
+ * \param[in,out]	attr	Struct containing the attrs on the path.
  *
  * \return		0 on Success. errno code on failure.
  */
@@ -116,7 +118,7 @@ duns_destroy_path(daos_handle_t poh, const char *path);
  *
  * \param[in]	str	Input string
  * \param[in]	len	Length of input string
- * \param[out]	attr	Struct containing the xattrs on the path.
+ * \param[out]	attr	Struct containing the attrs on the path.
  *
  * \return		0 on Success. errno code on failure.
  */


### PR DESCRIPTION
Check header file is correct, and resolve some Doxygen issues.

Only define max_len in one location
Do not define min_men at all.
Use snprintf() in preference to sprintf.

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>