### PR TITLE
DAOS-5868 iv: add rebuild leader stop condition

### DIFF
--- a/src/include/daos_srv/iv.h
+++ b/src/include/daos_srv/iv.h
@@ -23,14 +23,20 @@ struct ds_iv_ns {
 	unsigned int	iv_ns_id;
 	/* Link to global ns list (ds_iv_list) */
 	d_list_t	iv_ns_link;
-	/* Protect to the key list */
-	ABT_mutex	iv_lock;
 	/* all of entries under the ns links here */
 	d_list_t	iv_entry_list;
 	/* Cart IV namespace */
 	crt_iv_namespace_t	iv_ns;
 	/* pool uuid */
 	uuid_t		iv_pool_uuid;
+
+	int		iv_refcount;
+	ABT_eventual	iv_done_eventual;
+	/**
+	 * iv_fini: the IV namespace will be stopped, usually happens
+	 * the pool will be destroyed.
+	 */
+	uint32_t	iv_stop:1;
 };
 
 struct ds_iv_class_ops;
@@ -297,7 +303,10 @@ int ds_iv_ns_create(crt_context_t ctx, uuid_t pool_uuid, crt_group_t *grp,
 		    unsigned int *ns_id, struct ds_iv_ns **p_iv_ns);
 
 void ds_iv_ns_update(struct ds_iv_ns *ns, unsigned int master_rank);
-
+void ds_iv_ns_stop(struct ds_iv_ns *ns);
+void ds_iv_ns_start(struct ds_iv_ns *ns);
+void ds_iv_ns_put(struct ds_iv_ns *ns);
+void ds_iv_ns_get(struct ds_iv_ns *ns);
 void ds_iv_ns_destroy(void *ns);
 
 unsigned int ds_iv_ns_id_get(void *ns);

--- a/src/include/daos_srv/rebuild.h
+++ b/src/include/daos_srv/rebuild.h
@@ -35,7 +35,7 @@ typedef enum {
 			  (rb_op) == RB_OP_RECLAIM ? "Reclaim" : \
 			  "Unknown")
 
-int ds_rebuild_schedule(const uuid_t uuid, uint32_t map_ver,
+int ds_rebuild_schedule(struct ds_pool *pool, uint32_t map_ver,
 			struct pool_target_id_list *tgts,
 			daos_rebuild_opc_t rebuild_op);
 int ds_rebuild_query(uuid_t pool_uuid,

--- a/src/pool/srv_internal.h
+++ b/src/pool/srv_internal.h
@@ -166,6 +166,9 @@ int ds_pool_iv_conn_hdl_fetch(struct ds_pool *pool, uuid_t key_uuid,
 			      d_iov_t *conn_iov);
 int ds_pool_iv_conn_hdl_invalidate(struct ds_pool *pool, uuid_t hdl_uuid);
 
+int ds_pool_iv_srv_hdl_fetch_non_sys(struct ds_pool *pool,
+				     uuid_t *srv_cont_hdl,
+				     uuid_t *srv_pool_hdl);
 /*
  * srv_pool_scrub.c
  */

--- a/src/pool/srv_iv.c
+++ b/src/pool/srv_iv.c
@@ -1142,6 +1142,63 @@ out:
 	return rc;
 }
 
+struct srv_hdl_ult_arg {
+	struct ds_pool	*pool;
+	ABT_eventual	eventual;
+};
+
+static void
+pool_iv_srv_hdl_fetch_ult(void *data)
+{
+	struct srv_hdl_ult_arg *arg = data;
+	int rc;
+
+	rc = ds_pool_iv_srv_hdl_fetch(arg->pool, NULL, NULL);
+
+	ABT_eventual_set(arg->eventual, (void *)&rc, sizeof(rc));
+}
+
+int
+ds_pool_iv_srv_hdl_fetch_non_sys(struct ds_pool *pool, uuid_t *srv_cont_hdl,
+				 uuid_t *srv_pool_hdl)
+{
+	struct srv_hdl_ult_arg	arg;
+	ABT_eventual		eventual;
+	int			*status;
+	int			rc;
+
+	/* Fetch the capability from the leader. To avoid extra locks,
+	 * all metadatas are maintained by xstream 0, so let's create
+	 * an ULT on xstream 0 to let xstream 0 to handle capa fetch
+	 * and update.
+	 */
+	rc = ABT_eventual_create(sizeof(*status), &eventual);
+	if (rc != ABT_SUCCESS)
+		return dss_abterr2der(rc);
+
+	arg.pool = pool;
+	arg.eventual = eventual;
+	rc = dss_ult_create(pool_iv_srv_hdl_fetch_ult, &arg, DSS_XS_SYS,
+			    0, 0, NULL);
+	if (rc)
+		D_GOTO(out_eventual, rc);
+
+	rc = ABT_eventual_wait(eventual, (void **)&status);
+	if (rc != ABT_SUCCESS)
+		D_GOTO(out_eventual, rc = dss_abterr2der(rc));
+	if (*status != 0)
+		D_GOTO(out_eventual, rc = *status);
+
+	if (srv_cont_hdl)
+		uuid_copy(*srv_cont_hdl, pool->sp_srv_cont_hdl);
+	if (srv_pool_hdl)
+		uuid_copy(*srv_pool_hdl, pool->sp_srv_pool_hdl);
+
+out_eventual:
+	ABT_eventual_free(&eventual);
+	return rc;
+}
+
 int
 ds_pool_iv_prop_update(struct ds_pool *pool, daos_prop_t *prop)
 {

--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -681,7 +681,6 @@ ds_pool_svc_destroy(const uuid_t pool_uuid)
 	d_rank_list_t	excluded = { 0 };
 	int		rc;
 
-	ds_rebuild_leader_stop(pool_uuid, -1);
 	rc = ds_pool_get_ranks(pool_uuid, MAP_RANKS_DOWN, &excluded);
 	if (rc)
 		return rc;
@@ -1271,9 +1270,6 @@ pool_svc_step_down_cb(struct ds_rsvc *rsvc)
 static void
 pool_svc_drain_cb(struct ds_rsvc *rsvc)
 {
-	struct pool_svc *svc = pool_svc_obj(rsvc);
-
-	ds_rebuild_leader_stop(svc->ps_uuid, -1);
 }
 
 static int
@@ -3963,7 +3959,7 @@ ds_pool_update_internal(uuid_t pool_uuid, struct pool_target_id_list *tgts,
 		 * operation to garbage collect any unreachable data moved
 		 * during reintegration/addition
 		 */
-		rc = ds_rebuild_schedule(pool_uuid, map_version, tgts,
+		rc = ds_rebuild_schedule(svc->ps_pool, map_version, tgts,
 					 RB_OP_RECLAIM);
 		if (rc != 0) {
 			D_ERROR("failed to schedule reclaim rc: "DF_RC"\n",
@@ -4344,8 +4340,7 @@ ds_pool_update(uuid_t pool_uuid, crt_opcode_t opc,
 	D_DEBUG(DF_DSMS, "map ver %u/%u\n", map_version ? *map_version : -1,
 		tgt_map_ver);
 	if (tgt_map_ver != 0) {
-		rc = ds_rebuild_schedule(pool_uuid, tgt_map_ver, &target_list,
-					 op);
+		rc = ds_rebuild_schedule(pool, tgt_map_ver, &target_list, op);
 		if (rc != 0) {
 			D_ERROR("rebuild fails rc: "DF_RC"\n", DP_RC(rc));
 			D_GOTO(out, rc);
@@ -4489,7 +4484,7 @@ pool_extend_internal(uuid_t pool_uuid, struct rsvc_hint *hint,
 	}
 
 	/* Schedule an extension rebuild for those targets */
-	rc = ds_rebuild_schedule(pool_uuid, *map_version_p, &tgts,
+	rc = ds_rebuild_schedule(svc->ps_pool, *map_version_p, &tgts,
 				 RB_OP_EXTEND);
 	if (rc != 0) {
 		D_ERROR("failed to schedule extend rc: "DF_RC"\n", DP_RC(rc));
@@ -5342,6 +5337,7 @@ is_container_from_srv(uuid_t pool_uuid, uuid_t coh_uuid)
 	struct ds_pool	*pool;
 	uuid_t		hdl_uuid;
 	int		rc;
+	bool		result = false;
 
 	pool = ds_pool_lookup(pool_uuid);
 	if (pool == NULL) {
@@ -5350,14 +5346,22 @@ is_container_from_srv(uuid_t pool_uuid, uuid_t coh_uuid)
 		return false;
 	}
 
-	rc = ds_pool_iv_srv_hdl_fetch(pool, NULL, &hdl_uuid);
-	ds_pool_put(pool);
-	if (rc) {
-		D_ERROR(DF_UUID" fetch srv hdl: %d\n", DP_UUID(pool_uuid), rc);
-		return false;
+	if (uuid_compare(coh_uuid, pool->sp_srv_cont_hdl) == 0) {
+		/* Compare if the handle uuid is from another server */
+		result = true;
+		D_GOTO(output, result);
 	}
 
-	return !uuid_compare(coh_uuid, hdl_uuid);
+	rc = ds_pool_iv_srv_hdl_fetch_non_sys(pool, &hdl_uuid, NULL);
+	if (rc) {
+		D_ERROR(DF_UUID" fetch srv hdl: %d\n", DP_UUID(pool_uuid), rc);
+		D_GOTO(output, result);
+	}
+
+	result = !uuid_compare(coh_uuid, hdl_uuid);
+output:
+	ds_pool_put(pool);
+	return result;
 }
 
 bool

--- a/src/pool/srv_target.c
+++ b/src/pool/srv_target.c
@@ -352,7 +352,7 @@ pool_alloc_ref(void *key, unsigned int ksize, void *varg,
 	return 0;
 
 err_iv_ns:
-	ds_iv_ns_destroy(pool->sp_iv_ns);
+	ds_iv_ns_put(pool->sp_iv_ns);
 err_group:
 	rc_tmp = crt_group_secondary_destroy(pool->sp_group);
 	if (rc_tmp != 0)
@@ -380,7 +380,7 @@ pool_free_ref(struct daos_llink *llink)
 
 	D_DEBUG(DF_DSMS, DF_UUID": freeing\n", DP_UUID(pool->sp_uuid));
 
-	ds_iv_ns_destroy(pool->sp_iv_ns);
+	ds_iv_ns_put(pool->sp_iv_ns);
 
 	rc = crt_group_secondary_destroy(pool->sp_group);
 	if (rc != 0)
@@ -655,6 +655,7 @@ ds_pool_start(uuid_t uuid)
 		ds_pool_put(pool);
 		D_GOTO(out_lock, rc);
 	}
+	ds_iv_ns_start(pool->sp_iv_ns);
 out_lock:
 	ABT_mutex_unlock(pool_cache_lock);
 	return rc;
@@ -694,6 +695,7 @@ ds_pool_stop(uuid_t uuid)
 	ds_pool_tgt_ec_eph_query_abort(pool);
 	pool_fetch_hdls_ult_abort(pool);
 
+	ds_iv_ns_stop(pool->sp_iv_ns);
 	ds_rebuild_abort(pool->sp_uuid, -1);
 	ds_migrate_abort(pool->sp_uuid, -1);
 	ds_pool_put(pool); /* held by ds_pool_start */

--- a/src/rebuild/rebuild_internal.h
+++ b/src/rebuild/rebuild_internal.h
@@ -123,6 +123,12 @@ struct rebuild_global_pool_tracker {
 	/* stable epoch of the rebuild */
 	uint64_t	rgt_stable_epoch;
 
+	ABT_mutex	rgt_lock;
+	/* The current rebuild is done on the leader */
+	ABT_cond	rgt_done_cond;
+
+	uint32_t	rgt_refcount;
+
 	unsigned int	rgt_abort:1,
 			rgt_notify_stable_epoch:1,
 			rgt_init_scan:1;
@@ -316,6 +322,12 @@ rebuilt_btr_destroy(daos_handle_t btr_hdl);
 
 struct rebuild_tgt_pool_tracker *
 rpt_lookup(uuid_t pool_uuid, unsigned int ver);
+
+void
+rgt_get(struct rebuild_global_pool_tracker *rgt);
+
+void
+rgt_put(struct rebuild_global_pool_tracker *rgt);
 
 struct rebuild_global_pool_tracker *
 rebuild_global_pool_tracker_lookup(const uuid_t pool_uuid, unsigned int ver);

--- a/src/rebuild/rebuild_iv.c
+++ b/src/rebuild/rebuild_iv.c
@@ -114,7 +114,10 @@ rebuild_iv_ent_update(struct ds_iv_entry *entry, struct ds_iv_key *key,
 	/* Gathering the rebuild status here */
 	rgt = rebuild_global_pool_tracker_lookup(src_iv->riv_pool_uuid,
 						 src_iv->riv_ver);
-	if (rgt && rgt->rgt_leader_term == src_iv->riv_leader_term) {
+	if (rgt == NULL)
+		D_GOTO(out, rc);
+
+	if (rgt->rgt_leader_term == src_iv->riv_leader_term) {
 		/* update the rebuild global status */
 		if (!src_iv->riv_global_done) {
 			rgt->rgt_status.rs_toberb_obj_nr +=
@@ -139,9 +142,10 @@ rebuild_iv_ent_update(struct ds_iv_entry *entry, struct ds_iv_key *key,
 			rgt->rgt_status.rs_done, rgt->rgt_status.rs_errno,
 			src_iv->riv_rank);
 	}
-
+	rgt_put(rgt);
+out:
 	D_DEBUG(DB_TRACE, "pool "DF_UUID" master_rank %d\n",
-		 DP_UUID(dst_iv->riv_pool_uuid), dst_iv->riv_master_rank);
+		DP_UUID(dst_iv->riv_pool_uuid), dst_iv->riv_master_rank);
 
 	return 0;
 }

--- a/src/rebuild/srv.c
+++ b/src/rebuild/srv.c
@@ -203,26 +203,6 @@ rpt_lookup(uuid_t pool_uuid, unsigned int ver)
 	return found;
 }
 
-struct rebuild_global_pool_tracker *
-rebuild_global_pool_tracker_lookup(const uuid_t pool_uuid, unsigned int ver)
-{
-	struct rebuild_global_pool_tracker	*rgt;
-	struct rebuild_global_pool_tracker	*found = NULL;
-
-	/* Only stream 0 will access the list */
-	d_list_for_each_entry(rgt, &rebuild_gst.rg_global_tracker_list,
-			      rgt_list) {
-		if (uuid_compare(rgt->rgt_pool_uuid, pool_uuid) == 0 &&
-		    (ver == (unsigned int)(-1) ||
-		     rgt->rgt_rebuild_ver == ver)) {
-			found = rgt;
-			break;
-		}
-	}
-
-	return found;
-}
-
 int
 rebuild_global_status_update(struct rebuild_global_pool_tracker *rgt,
 			     struct rebuild_iv *iv)
@@ -476,6 +456,7 @@ ds_rebuild_query(uuid_t pool_uuid, struct daos_rebuild_status *status)
 	} else {
 		memcpy(status, &rgt->rgt_status, sizeof(*status));
 		status->rs_version = rgt->rgt_rebuild_ver;
+		rgt_put(rgt);
 	}
 
 	/* If there are still rebuild task queued for the pool, let's reset
@@ -651,9 +632,16 @@ rebuild_leader_status_check(struct ds_pool *pool, uint32_t map_ver, uint32_t op,
 static void
 rebuild_global_pool_tracker_destroy(struct rebuild_global_pool_tracker *rgt)
 {
+	D_ASSERT(rgt->rgt_refcount == 0);
 	d_list_del(&rgt->rgt_list);
 	if (rgt->rgt_servers)
 		D_FREE(rgt->rgt_servers);
+
+	if (rgt->rgt_lock)
+		ABT_mutex_free(&rgt->rgt_lock);
+
+	if (rgt->rgt_done_cond)
+		ABT_cond_free(&rgt->rgt_done_cond);
 
 	D_FREE(rgt);
 }
@@ -681,6 +669,14 @@ rebuild_global_pool_tracker_create(struct ds_pool *pool, uint32_t ver,
 	if (rgt->rgt_servers == NULL)
 		D_GOTO(out, rc = -DER_NOMEM);
 
+	rc = ABT_mutex_create(&rgt->rgt_lock);
+	if (rc != ABT_SUCCESS)
+		D_GOTO(out, rc = dss_abterr2der(rc));
+
+	rc = ABT_cond_create(&rgt->rgt_done_cond);
+	if (rc != ABT_SUCCESS)
+		D_GOTO(out, rc = dss_abterr2der(rc));
+
 	for (i = 0; i < node_nr; i++)
 		rgt->rgt_servers[i].rank = doms[i].do_comp.co_rank;
 	rgt->rgt_servers_number = node_nr;
@@ -690,10 +686,46 @@ rebuild_global_pool_tracker_create(struct ds_pool *pool, uint32_t ver,
 	rgt->rgt_status.rs_version = ver;
 	d_list_add(&rgt->rgt_list, &rebuild_gst.rg_global_tracker_list);
 	*p_rgt = rgt;
+	rgt->rgt_refcount = 1;
 out:
 	if (rc)
 		rebuild_global_pool_tracker_destroy(rgt);
 	return rc;
+}
+
+void
+rgt_get(struct rebuild_global_pool_tracker *rgt)
+{
+	rgt->rgt_refcount++;
+}
+
+void
+rgt_put(struct rebuild_global_pool_tracker *rgt)
+{
+	rgt->rgt_refcount--;
+	if (rgt->rgt_refcount == 0)
+		rebuild_global_pool_tracker_destroy(rgt);
+}
+
+struct rebuild_global_pool_tracker *
+rebuild_global_pool_tracker_lookup(const uuid_t pool_uuid, unsigned int ver)
+{
+	struct rebuild_global_pool_tracker	*rgt;
+	struct rebuild_global_pool_tracker	*found = NULL;
+
+	/* Only stream 0 will access the list */
+	d_list_for_each_entry(rgt, &rebuild_gst.rg_global_tracker_list,
+			      rgt_list) {
+		if (uuid_compare(rgt->rgt_pool_uuid, pool_uuid) == 0 &&
+		    (ver == (unsigned int)(-1) ||
+		     rgt->rgt_rebuild_ver == ver)) {
+			rgt_get(rgt);
+			found = rgt;
+			break;
+		}
+	}
+
+	return found;
 }
 
 /* To notify all targets to prepare the rebuild */
@@ -1259,8 +1291,7 @@ try_reschedule:
 		 * rebuild sequence, which has to be done by failure
 		 * sequence order.
 		 */
-		ret = ds_rebuild_schedule(pool->sp_uuid,
-					  task->dst_map_ver,
+		ret = ds_rebuild_schedule(pool, task->dst_map_ver,
 					  &task->dst_tgts, RB_OP_FAIL);
 		if (ret != 0)
 			D_ERROR("reschedule "DF_RC"\n", DP_RC(ret));
@@ -1277,8 +1308,11 @@ output:
 			DP_UUID(task->dst_pool_uuid));
 
 	ds_pool_put(pool);
+	ABT_mutex_lock(rgt->rgt_lock);
+	ABT_cond_signal(rgt->rgt_done_cond);
+	ABT_mutex_unlock(rgt->rgt_lock);
 	if (rgt)
-		rebuild_global_pool_tracker_destroy(rgt);
+		rgt_put(rgt);
 
 	rebuild_task_destroy(task);
 	rebuild_gst.rg_inflight--;
@@ -1370,7 +1404,6 @@ ds_rebuild_abort(uuid_t pool_uuid, unsigned int version)
 {
 	struct rebuild_tgt_pool_tracker *rpt;
 
-	/* If this is called on non-leader node, it will do nothing */
 	ds_rebuild_leader_stop(pool_uuid, version);
 
 	rpt = rpt_lookup(pool_uuid, version);
@@ -1396,6 +1429,7 @@ ds_rebuild_abort(uuid_t pool_uuid, unsigned int version)
 	ABT_mutex_unlock(rebuild_gst.rg_lock);
 }
 
+/* If this is called on non-leader node, it will do nothing */
 void
 ds_rebuild_leader_stop(const uuid_t pool_uuid, unsigned int version)
 {
@@ -1422,9 +1456,21 @@ ds_rebuild_leader_stop(const uuid_t pool_uuid, unsigned int version)
 	if (rgt == NULL)
 		return;
 
-	D_DEBUG(DB_REBUILD, "abort rebuild "DF_UUID" version %d\n",
+	D_DEBUG(DB_REBUILD, "try abort rebuild "DF_UUID" version %d\n",
 		DP_UUID(pool_uuid), version);
 	rgt->rgt_abort = 1;
+
+	/* Since the rpt will be destroyed after signal rt_done_cond,
+	 * so we have to use another lock here.
+	 */
+	ABT_mutex_lock(rgt->rgt_lock);
+	ABT_cond_wait(rgt->rgt_done_cond, rgt->rgt_lock);
+	ABT_mutex_unlock(rgt->rgt_lock);
+
+	D_DEBUG(DB_REBUILD, "rebuild "DF_UUID"/ %d is stopped.\n",
+		DP_UUID(pool_uuid), version);
+
+	rgt_put(rgt);
 }
 
 void
@@ -1479,15 +1525,22 @@ rebuild_print_list_update(const uuid_t uuid, const uint32_t map_ver,
  * pool.
  */
 int
-ds_rebuild_schedule(const uuid_t uuid, uint32_t map_ver,
+ds_rebuild_schedule(struct ds_pool *pool, uint32_t map_ver,
 		    struct pool_target_id_list *tgts,
 		    daos_rebuild_opc_t rebuild_op)
 {
 	struct rebuild_task	*task;
 	int			rc;
 
+	if (pool->sp_stopping) {
+		D_DEBUG(DB_REBUILD, DF_UUID" is stopping,"
+			"do not need schedule here\n",
+			DP_UUID(pool->sp_uuid));
+		return 0;
+	}
+
 	/* Check if the pool already in the queue list */
-	rc = rebuild_try_merge_tgts(uuid, map_ver, rebuild_op, tgts);
+	rc = rebuild_try_merge_tgts(pool->sp_uuid, map_ver, rebuild_op, tgts);
 	if (rc)
 		return rc == 1 ? 0 : rc;
 
@@ -1498,7 +1551,7 @@ ds_rebuild_schedule(const uuid_t uuid, uint32_t map_ver,
 
 	task->dst_map_ver = map_ver;
 	task->dst_rebuild_op = rebuild_op;
-	uuid_copy(task->dst_pool_uuid, uuid);
+	uuid_copy(task->dst_pool_uuid, pool->sp_uuid);
 	D_INIT_LIST_HEAD(&task->dst_list);
 
 	/* TODO: Merge everything for reclaim */
@@ -1506,14 +1559,14 @@ ds_rebuild_schedule(const uuid_t uuid, uint32_t map_ver,
 	if (rc)
 		D_GOTO(free, rc);
 
-	rebuild_print_list_update(uuid, map_ver, rebuild_op, tgts);
+	rebuild_print_list_update(pool->sp_uuid, map_ver, rebuild_op, tgts);
 	d_list_add_tail(&task->dst_list, &rebuild_gst.rg_queue_list);
 
 	/* Print out the current queue to the debug log */
 	rebuild_debug_print_queue();
 
 	D_DEBUG(DB_REBUILD, "rebuild queue "DF_UUID" ver=%u, op=%s",
-		DP_UUID(uuid), map_ver, RB_OP_STR(rebuild_op));
+		DP_UUID(pool->sp_uuid), map_ver, RB_OP_STR(rebuild_op));
 
 	if (!rebuild_gst.rg_rebuild_running) {
 		rc = ABT_cond_create(&rebuild_gst.rg_stop_cond);
@@ -1521,7 +1574,7 @@ ds_rebuild_schedule(const uuid_t uuid, uint32_t map_ver,
 			D_GOTO(free, rc = dss_abterr2der(rc));
 
 		D_DEBUG(DB_REBUILD, "rebuild ult "DF_UUID" ver=%u, op=%s",
-			DP_UUID(uuid), map_ver, RB_OP_STR(rebuild_op));
+			DP_UUID(pool->sp_uuid), map_ver, RB_OP_STR(rebuild_op));
 		rebuild_gst.rg_rebuild_running = 1;
 		rc = dss_ult_create(rebuild_ults, NULL, DSS_XS_SELF,
 				    0, 0, NULL);
@@ -1553,7 +1606,7 @@ regenerate_task_internal(struct ds_pool *pool, struct pool_target *tgts,
 		id_list.pti_ids = &tgt_id;
 		id_list.pti_number = 1;
 
-		rc = ds_rebuild_schedule(pool->sp_uuid, tgt->ta_comp.co_fseq,
+		rc = ds_rebuild_schedule(pool, tgt->ta_comp.co_fseq,
 					 &id_list, rebuild_op);
 		if (rc) {
 			D_ERROR(DF_UUID" schedule op %d ver %d failed: rc %d\n",

--- a/src/tests/suite/daos_mgmt.c
+++ b/src/tests/suite/daos_mgmt.c
@@ -360,9 +360,6 @@ pool_create_and_destroy_retry(void **state)
 	uuid_t		 uuid;
 	int		 rc;
 
-	/* Skip for DAOS-6544 */
-	skip();
-
 	FAULT_INJECTION_REQUIRED();
 
 	if (arg->myrank != 0)


### PR DESCRIPTION
Add rebuild leader stop condition, so ds_pool_stop
will wait for rebuild_task_ult() to stop on the leader.

Add iv_stop in iv_ns to avoid retry during pool destory.

Add iv_ns refcount and wait all iv reference
before pool stop.

Signed-off-by: Di Wang <di.wang@intel.com>