### PR TITLE
DAOS-6388 vos: remove DTX pre-detection from vos iterator

### DIFF
--- a/src/dtx/dtx_common.c
+++ b/src/dtx/dtx_common.c
@@ -274,7 +274,6 @@ dtx_shares_init(struct dtx_handle *dth)
 	D_INIT_LIST_HEAD(&dth->dth_share_act_list);
 	D_INIT_LIST_HEAD(&dth->dth_share_tbd_list);
 	dth->dth_share_tbd_count = 0;
-	dth->dth_share_tbd_scanned = 0;
 	dth->dth_shares_inited = 1;
 }
 
@@ -302,7 +301,6 @@ dtx_shares_fini(struct dtx_handle *dth)
 		D_FREE(dsp);
 
 	dth->dth_share_tbd_count = 0;
-	dth->dth_share_tbd_scanned = 0;
 }
 
 int

--- a/src/include/daos_srv/dtx_srv.h
+++ b/src/include/daos_srv/dtx_srv.h
@@ -14,8 +14,7 @@
 #include <daos_srv/pool.h>
 #include <daos_srv/container.h>
 
-#define DTX_REFRESH_MAX		4
-#define DTX_DETECT_SCAN_MAX	(1 << 10)
+#define DTX_REFRESH_MAX 4
 
 struct dtx_share_peer {
 	d_list_t		dsp_link;
@@ -117,7 +116,6 @@ struct dtx_handle {
 	d_list_t			 dth_share_act_list;
 	d_list_t			 dth_share_tbd_list;
 	int				 dth_share_tbd_count;
-	int				 dth_share_tbd_scanned;
 };
 
 /* Each sub transaction handle to manage each sub thandle */

--- a/src/vos/tests/vts_dtx.c
+++ b/src/vos/tests/vts_dtx.c
@@ -83,7 +83,6 @@ vts_dtx_begin(const daos_unit_oid_t *oid, daos_handle_t coh, daos_epoch_t epoch,
 	D_INIT_LIST_HEAD(&dth->dth_share_act_list);
 	D_INIT_LIST_HEAD(&dth->dth_share_tbd_list);
 	dth->dth_share_tbd_count = 0;
-	dth->dth_share_tbd_scanned = 0;
 	dth->dth_shares_inited = 1;
 
 	vos_dtx_rsrvd_init(dth);
@@ -113,7 +112,6 @@ vts_dtx_end(struct dtx_handle *dth)
 			D_FREE(dsp);
 
 		dth->dth_share_tbd_count = 0;
-		dth->dth_share_tbd_scanned = 0;
 	}
 
 	vos_dtx_rsrvd_fini(dth);

--- a/src/vos/vos_internal.h
+++ b/src/vos/vos_internal.h
@@ -805,6 +805,7 @@ struct vos_iter_ops;
 
 /** the common part of vos iterators */
 struct vos_iterator {
+	struct dtx_handle	*it_dth;
 	struct vos_iter_ops	*it_ops;
 	struct vos_iterator	*it_parent; /* parent iterator */
 	struct vos_ts_set	*it_ts_set;
@@ -1222,8 +1223,7 @@ vos_dtx_continue_detect(int rc)
 	/* Continue to detect other potential in-prepared DTX. */
 	return rc == -DER_INPROGRESS && dth != NULL &&
 		dth->dth_share_tbd_count > 0 &&
-		dth->dth_share_tbd_count < DTX_REFRESH_MAX &&
-		dth->dth_share_tbd_scanned < DTX_DETECT_SCAN_MAX;
+		dth->dth_share_tbd_count < DTX_REFRESH_MAX;
 }
 
 static inline bool

--- a/src/vos/vos_iterator.c
+++ b/src/vos/vos_iterator.c
@@ -91,6 +91,7 @@ nested_prepare(vos_iter_type_t type, struct vos_iter_dict *dict,
 {
 	struct vos_iterator	*iter = vos_hdl2iter(param->ip_ih);
 	struct vos_iterator	*citer;
+	struct dtx_handle	*old;
 	struct vos_iter_info	 info;
 	int			 rc;
 
@@ -113,13 +114,14 @@ nested_prepare(vos_iter_type_t type, struct vos_iter_dict *dict,
 		return -DER_NONEXIST;
 	}
 
+	old = vos_dth_get();
+	vos_dth_set(iter->it_dth);
 	rc = iter->it_ops->iop_nested_tree_fetch(iter, type, &info);
-
 	if (rc != 0) {
 		VOS_TX_TRACE_FAIL(rc, "Problem fetching nested tree (%s) from "
 				  "iterator: "DF_RC"\n", dict->id_name,
 				  DP_RC(rc));
-		return rc;
+		goto out;
 	}
 
 	info.ii_epc_expr = param->ip_epc_expr;
@@ -131,11 +133,12 @@ nested_prepare(vos_iter_type_t type, struct vos_iter_dict *dict,
 	if (rc != 0) {
 		D_ERROR("Failed to prepare %s iterator: %d\n", dict->id_name,
 			rc);
-		return rc;
+		goto out;
 	}
 
 	iter->it_ref_cnt++;
 
+	citer->it_dth		= iter->it_dth;
 	citer->it_type		= type;
 	citer->it_ops		= dict->id_ops;
 	citer->it_state		= VOS_ITS_NONE;
@@ -144,7 +147,10 @@ nested_prepare(vos_iter_type_t type, struct vos_iter_dict *dict,
 	citer->it_from_parent	= 1;
 
 	*cih = vos_iter2hdl(citer);
-	return 0;
+
+out:
+	vos_dth_set(old);
+	return rc;
 }
 
 int
@@ -153,7 +159,7 @@ vos_iter_prepare(vos_iter_type_t type, vos_iter_param_t *param,
 {
 	struct vos_iter_dict	*dict;
 	struct vos_iterator	*iter;
-	struct dtx_handle	*old = NULL;
+	struct dtx_handle	*old;
 	struct vos_ts_set	*ts_set = NULL;
 	int			 rc;
 	int			 rlevel;
@@ -219,11 +225,11 @@ vos_iter_prepare(vos_iter_type_t type, vos_iter_param_t *param,
 	if (rc != 0)
 		goto out;
 
-	old = vos_dth_get();
-	vos_dth_set(dth);
-
 	D_DEBUG(DB_TRACE, "Preparing standalone iterator of type %s\n",
 		dict->id_name);
+
+	old = vos_dth_get();
+	vos_dth_set(dth);
 	rc = dict->id_ops->iop_prepare(type, param, &iter, ts_set);
 	vos_dth_set(old);
 	if (rc != 0) {
@@ -235,6 +241,7 @@ vos_iter_prepare(vos_iter_type_t type, vos_iter_param_t *param,
 
 	D_ASSERT(iter->it_type == type);
 
+	iter->it_dth		= dth;
 	iter->it_ops		= dict->id_ops;
 	iter->it_state		= VOS_ITS_NONE;
 	iter->it_ref_cnt	= 1;
@@ -316,11 +323,16 @@ int
 vos_iter_probe(daos_handle_t ih, daos_anchor_t *anchor)
 {
 	struct vos_iterator *iter = vos_hdl2iter(ih);
+	struct dtx_handle   *old;
 	int		     rc;
 
 	D_DEBUG(DB_IO, "probing iterator\n");
 	D_ASSERT(iter->it_ops != NULL);
+
+	old = vos_dth_get();
+	vos_dth_set(iter->it_dth);
 	rc = iter->it_ops->iop_probe(iter, anchor);
+	vos_dth_set(old);
 	if (rc == 0)
 		iter->it_state = VOS_ITS_OK;
 	else if (rc == -DER_NONEXIST)
@@ -350,6 +362,7 @@ int
 vos_iter_next(daos_handle_t ih)
 {
 	struct vos_iterator *iter = vos_hdl2iter(ih);
+	struct dtx_handle   *old;
 	int		     rc;
 
 	rc = iter_verify_state(iter);
@@ -357,7 +370,11 @@ vos_iter_next(daos_handle_t ih)
 		return rc;
 
 	D_ASSERT(iter->it_ops != NULL);
+
+	old = vos_dth_get();
+	vos_dth_set(iter->it_dth);
 	rc = iter->it_ops->iop_next(iter);
+	vos_dth_set(old);
 	if (rc == 0)
 		iter->it_state = VOS_ITS_OK;
 	else if (rc == -DER_NONEXIST)
@@ -373,6 +390,7 @@ vos_iter_fetch(daos_handle_t ih, vos_iter_entry_t *it_entry,
 	       daos_anchor_t *anchor)
 {
 	struct vos_iterator *iter = vos_hdl2iter(ih);
+	struct dtx_handle   *old;
 	int rc;
 
 	rc = iter_verify_state(iter);
@@ -380,7 +398,13 @@ vos_iter_fetch(daos_handle_t ih, vos_iter_entry_t *it_entry,
 		return rc;
 
 	D_ASSERT(iter->it_ops != NULL);
-	return iter->it_ops->iop_fetch(iter, it_entry, anchor);
+
+	old = vos_dth_get();
+	vos_dth_set(iter->it_dth);
+	rc = iter->it_ops->iop_fetch(iter, it_entry, anchor);
+	vos_dth_set(old);
+
+	return rc;
 }
 
 int
@@ -571,21 +595,6 @@ need_reprobe(vos_iter_type_t type, struct vos_iter_anchors *anchors)
 	return reprobe;
 }
 
-static int
-vos_iter_detect_dtx_cb(daos_handle_t ih, vos_iter_entry_t *entry,
-		       vos_iter_type_t type, vos_iter_param_t *param,
-		       void *cb_arg, unsigned int *acts)
-{
-	struct dtx_handle	*dth = vos_dth_get();
-
-	D_ASSERT(dth != NULL);
-
-	if (++(dth->dth_share_tbd_scanned) >= DTX_DETECT_SCAN_MAX)
-		return -DER_INPROGRESS;
-
-	return 0;
-}
-
 /**
  * Iterate VOS entries (i.e., containers, objects, dkeys, etc.) and call \a
  * cb(\a arg) for each entry.
@@ -598,7 +607,6 @@ vos_iterate_internal(vos_iter_param_t *param, vos_iter_type_t type,
 		     struct dtx_handle *dth)
 {
 	daos_anchor_t		*anchor, *probe_anchor = NULL;
-	struct dtx_handle	*old = NULL;
 	struct vos_iterator	*iter;
 	vos_iter_entry_t	iter_ent = {0};
 	daos_epoch_t		read_time = 0;
@@ -616,10 +624,6 @@ vos_iterate_internal(vos_iter_param_t *param, vos_iter_type_t type,
 		return -DER_NOSYS;
 
 	anchor = type2anchor(type, anchors);
-
-	old = vos_dth_get();
-	vos_dth_set(dth);
-
 	rc = vos_iter_prepare(type, param, &ih, dth);
 	if (rc != 0) {
 		if (rc == -DER_NONEXIST) {
@@ -630,8 +634,6 @@ vos_iterate_internal(vos_iter_param_t *param, vos_iter_type_t type,
 					"(type=%d): "DF_RC"\n", type,
 					DP_RC(rc));
 		}
-
-		vos_dth_set(old);
 		return rc;
 	}
 
@@ -661,12 +663,6 @@ probe:
 	while (1) {
 		rc = vos_iter_fetch(ih, &iter_ent, anchor);
 		if (rc != 0) {
-			if (vos_dtx_continue_detect(rc)) {
-				pre_cb = NULL;
-				post_cb = vos_iter_detect_dtx_cb;
-				goto next;
-			}
-
 			VOS_TX_TRACE_FAIL(rc, "Failed to fetch iterator "
 					  "(type=%d): "DF_RC"\n", type,
 					  DP_RC(rc));
@@ -719,28 +715,19 @@ probe:
 			rc = vos_iterate(&child_param, iter_ent.ie_child_type,
 					 recursive, anchors, pre_cb, post_cb,
 					 arg, dth);
-			if (rc != 0) {
-				if (vos_dtx_continue_detect(rc)) {
-					pre_cb = NULL;
-					post_cb = vos_iter_detect_dtx_cb;
-				} else {
-					D_GOTO(out, rc);
-				}
-			}
+			if (rc != 0)
+				D_GOTO(out, rc);
 
 			reset_anchors(iter_ent.ie_child_type, anchors);
 		}
 
-next:
 		if (post_cb) {
 			acts = 0;
 			rc = post_cb(ih, &iter_ent, type, param, arg, &acts);
 			if (rc != 0)
 				break;
 
-			if (!vos_dtx_hit_inprogress())
-				set_reprobe(type, acts, anchors,
-					    param->ip_flags);
+			set_reprobe(type, acts, anchors, param->ip_flags);
 
 			if (acts & VOS_ITER_CB_ABORT)
 				break;
@@ -766,9 +753,6 @@ next:
 		rc = 0;
 	}
 out:
-	if (vos_dtx_hit_inprogress())
-		rc = -DER_INPROGRESS;
-
 	if (rc >= 0)
 		rc = vos_iter_ts_set_update(ih, read_time, rc);
 
@@ -776,7 +760,6 @@ out:
 			DP_RC(rc));
 
 	vos_iter_finish(ih);
-	vos_dth_set(old);
 	return rc;
 }
 


### PR DESCRIPTION
The pre-detect uncommitted DTX during vos iteration is some
kind optimization for try to reduce the RPC overhead caused
by related DTX refresh. But the optimization may cause some
issues as following:

1. It cannot handle non-committed DTX when vos_iter_probe().
   That is the first place to detect non-committed DTX entry
   that may affect current iteration. If we skip over it, we
   may skip related tree under such point. That may make the
   pre-detection of uncommitted DTX to become meaningless or
   cause more overhead.

2. Similarly for non-committed DTX when handle vos_iter_next.

3. Need to consider CPU yield during the pre-detection scan.
   For the object with a lot of keys/values, hundreds of or
   thousands of pre-detection may not find more uncommitted
   DTX but introduce more overhead. But if we do not do CPU
   yield during that, other ULTs may be starve.

So before we have enough verification for the effectiveness,
we will restore the original vos iteration logic before the
optimization.

On the other hand, the patch also resolves the issue of DTX
handle mess-up caused by the vos iteration CPU yield: every
iteration stores its DTX handle in vos_iterator::it_dth when
prepare the iteration, then in subsequent prober/fetch/next,
the iteration can set DTX handle on TLS when need and reset
(as original value) after using immediately. CPU yield for
iteration only happens during pre_cb or post_cb callback,
the DTX handle on TLS has already been restored at that time.

Signed-off-by: Fan Yong <fan.yong@intel.com>