### PR TITLE
DAOS-6648 test: Bump timeout value for test

### DIFF
--- a/src/tests/ftest/cart/no_pmix/cart_nopmix_multictx_one_node.py
+++ b/src/tests/ftest/cart/no_pmix/cart_nopmix_multictx_one_node.py
@@ -59,7 +59,7 @@ class CartNoPmixOneNodeTest(TestWithoutServers):
         test_env = self.pass_env
         p = subprocess.Popen([cmd], env=test_env, stdout=subprocess.PIPE)
 
-        rc = self.utils.wait_process(p, 10)
+        rc = self.utils.wait_process(p, 30)
         if rc != 0:
             self.utils.print("Error waiting for process.")
             self.utils.print("returning {}".format(rc))

--- a/src/tests/ftest/cart/no_pmix_multi_ctx.c
+++ b/src/tests/ftest/cart/no_pmix_multi_ctx.c
@@ -90,7 +90,7 @@ int main(int argc, char **argv)
 	}
 
 	D_FREE(my_uri);
-	sleep(1);
+	tc_set_shutdown_delay(0);
 	tc_progress_stop();
 
 	for (i = 0; i < NUM_CTX; i++)


### PR DESCRIPTION
Test under normal conditions ended up running in 8-9 seconds, and
with default 10 second timeout it ended up occasionally going over
board and as such being marked as a failure.

- Test timeout/wait bumped to 30 seconds
- Test modified to not perform sleep(1) as well as not set any
delay for shutdown sequence (2 seconds by default).

Singed-off-by: Alexander Oganezov <alexander.a.oganezov@intel.com>