### PR TITLE
DAOS-6539 object: refresh DTX status during EC aggregation

### DIFF
--- a/src/dtx/dtx_common.c
+++ b/src/dtx/dtx_common.c
@@ -274,7 +274,6 @@ dtx_shares_init(struct dtx_handle *dth)
 	D_INIT_LIST_HEAD(&dth->dth_share_act_list);
 	D_INIT_LIST_HEAD(&dth->dth_share_tbd_list);
 	dth->dth_share_tbd_count = 0;
-	dth->dth_share_tbd_scanned = 0;
 	dth->dth_shares_inited = 1;
 }
 
@@ -302,7 +301,6 @@ dtx_shares_fini(struct dtx_handle *dth)
 		D_FREE(dsp);
 
 	dth->dth_share_tbd_count = 0;
-	dth->dth_share_tbd_scanned = 0;
 }
 
 int

--- a/src/include/daos_srv/dtx_srv.h
+++ b/src/include/daos_srv/dtx_srv.h
@@ -14,8 +14,7 @@
 #include <daos_srv/pool.h>
 #include <daos_srv/container.h>
 
-#define DTX_REFRESH_MAX		4
-#define DTX_DETECT_SCAN_MAX	(1 << 10)
+#define DTX_REFRESH_MAX 4
 
 struct dtx_share_peer {
 	d_list_t		dsp_link;
@@ -117,7 +116,6 @@ struct dtx_handle {
 	d_list_t			 dth_share_act_list;
 	d_list_t			 dth_share_tbd_list;
 	int				 dth_share_tbd_count;
-	int				 dth_share_tbd_scanned;
 };
 
 /* Each sub transaction handle to manage each sub thandle */

--- a/src/object/obj_internal.h
+++ b/src/object/obj_internal.h
@@ -761,6 +761,12 @@ daos_iom_dump(daos_iom_t *iom)
 	D_PRINT("\n");
 }
 
+static inline bool
+obj_dtx_need_refresh(struct dtx_handle *dth, int rc)
+{
+	return rc == -DER_INPROGRESS && dth->dth_share_tbd_count > 0;
+}
+
 int  obj_class_init(void);
 void obj_class_fini(void);
 int  obj_utils_init(void);

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -29,12 +29,6 @@
 #include "obj_rpc.h"
 #include "obj_internal.h"
 
-static inline bool
-obj_dtx_need_refresh(struct dtx_handle *dth, int rc)
-{
-	return rc == -DER_INPROGRESS && dth->dth_share_tbd_count > 0;
-}
-
 static int
 obj_verify_bio_csum(daos_obj_id_t oid, daos_iod_t *iods,
 		    struct dcs_iod_csums *iod_csums, struct bio_desc *biod,

--- a/src/tests/suite/daos_dist_tx.c
+++ b/src/tests/suite/daos_dist_tx.c
@@ -2579,9 +2579,6 @@ dtx_37(void **state)
 	d_rank_t	 kill_rank = CRT_NO_RANK;
 	int		 i;
 
-	/* Skip for DAOS-6615 */
-	skip();
-
 	FAULT_INJECTION_REQUIRED();
 
 	print_message("DTX37: resync - leader failed during prepare\n");

--- a/src/vos/tests/vts_dtx.c
+++ b/src/vos/tests/vts_dtx.c
@@ -83,7 +83,6 @@ vts_dtx_begin(const daos_unit_oid_t *oid, daos_handle_t coh, daos_epoch_t epoch,
 	D_INIT_LIST_HEAD(&dth->dth_share_act_list);
 	D_INIT_LIST_HEAD(&dth->dth_share_tbd_list);
 	dth->dth_share_tbd_count = 0;
-	dth->dth_share_tbd_scanned = 0;
 	dth->dth_shares_inited = 1;
 
 	vos_dtx_rsrvd_init(dth);
@@ -113,7 +112,6 @@ vts_dtx_end(struct dtx_handle *dth)
 			D_FREE(dsp);
 
 		dth->dth_share_tbd_count = 0;
-		dth->dth_share_tbd_scanned = 0;
 	}
 
 	vos_dtx_rsrvd_fini(dth);

--- a/src/vos/vos_internal.h
+++ b/src/vos/vos_internal.h
@@ -805,6 +805,7 @@ struct vos_iter_ops;
 
 /** the common part of vos iterators */
 struct vos_iterator {
+	struct dtx_handle	*it_dth;
 	struct vos_iter_ops	*it_ops;
 	struct vos_iterator	*it_parent; /* parent iterator */
 	struct vos_ts_set	*it_ts_set;
@@ -1222,8 +1223,7 @@ vos_dtx_continue_detect(int rc)
 	/* Continue to detect other potential in-prepared DTX. */
 	return rc == -DER_INPROGRESS && dth != NULL &&
 		dth->dth_share_tbd_count > 0 &&
-		dth->dth_share_tbd_count < DTX_REFRESH_MAX &&
-		dth->dth_share_tbd_scanned < DTX_DETECT_SCAN_MAX;
+		dth->dth_share_tbd_count < DTX_REFRESH_MAX;
 }
 
 static inline bool


### PR DESCRIPTION
It is possible that the EC aggregation may hit non-committed DTX
that be garbage DTX entry left by some test failure injection.
Under such case, the EC aggregation needs to call DTX refresh to
check with related DTX leader. Otherwise, the EC aggregation may
hung there. That is why dtx_37 is reported timeout in CI test.

Enable dtx_37.

Signed-off-by: Fan Yong <fan.yong@intel.com>