### PR TITLE
DAOS-4008 SMD: store SMD in VOS

### DIFF
--- a/src/bio/bio_context.c
+++ b/src/bio/bio_context.c
@@ -315,7 +315,7 @@ bio_blob_delete(uuid_t uuid, struct bio_xs_context *xs_ctxt)
 		D_DEBUG(DB_MGMT, "Successfully deleted blobID "DF_U64" for "
 			"pool:"DF_UUID" xs:%p\n", blob_id, DP_UUID(uuid),
 			xs_ctxt);
-		rc = smd_pool_unassign(uuid, xs_ctxt->bxc_tgt_id);
+		rc = smd_pool_del_tgt(uuid, xs_ctxt->bxc_tgt_id);
 		if (rc)
 			D_ERROR("Failed to unassign blob:"DF_U64" from pool: "
 				""DF_UUID":%d. %d\n", blob_id, DP_UUID(uuid),
@@ -396,8 +396,8 @@ bio_blob_create(uuid_t uuid, struct bio_xs_context *xs_ctxt, uint64_t blob_sz)
 			ba->bca_id, xs_ctxt, DP_UUID(uuid),
 			bma.bma_opts.num_clusters);
 
-		rc = smd_pool_assign(uuid, xs_ctxt->bxc_tgt_id, ba->bca_id,
-				     blob_sz);
+		rc = smd_pool_add_tgt(uuid, xs_ctxt->bxc_tgt_id, ba->bca_id,
+				      blob_sz);
 		if (rc != 0) {
 			D_ERROR("Failed to assign pool blob:"DF_U64" to pool: "
 				""DF_UUID":%d. %d\n", ba->bca_id, DP_UUID(uuid),
@@ -748,7 +748,7 @@ bio_write_blob_hdr(struct bio_io_context *ioctxt, struct bio_blob_hdr *bio_bh)
 	}
 
 	uuid_copy(bio_bh->bbh_blobstore, dev_info->sdi_id);
-	smd_free_dev_info(dev_info);
+	smd_dev_free_info(dev_info);
 
 	/* Create an iov to store blob header structure */
 	d_iov_set(&iov, (void *)bio_bh, sizeof(*bio_bh));

--- a/src/bio/bio_device.c
+++ b/src/bio/bio_device.c
@@ -279,7 +279,7 @@ free_pool_list(d_list_t *pool_list)
 
 	d_list_for_each_entry_safe(pool_info, tmp, pool_list, spi_link) {
 		d_list_del_init(&pool_info->spi_link);
-		smd_free_pool_info(pool_info);
+		smd_pool_free_info(pool_info);
 	}
 }
 
@@ -443,9 +443,9 @@ bio_replace_dev(struct bio_xs_context *xs_ctxt, uuid_t old_dev_id,
 	rc = replace_dev(xs_ctxt, old_info, old_dev, new_dev);
 out:
 	if (old_info)
-		smd_free_dev_info(old_info);
+		smd_dev_free_info(old_info);
 	if (new_info)
-		smd_free_dev_info(new_info);
+		smd_dev_free_info(new_info);
 	return rc;
 }
 
@@ -624,7 +624,7 @@ bio_dev_list(struct bio_xs_context *xs_ctxt, d_list_t *dev_list, int *dev_cnt)
 		/* delete the found device in SMD dev list */
 		if (s_info != NULL) {
 			d_list_del_init(&s_info->sdi_link);
-			smd_free_dev_info(s_info);
+			smd_dev_free_info(s_info);
 		}
 	}
 
@@ -651,7 +651,7 @@ bio_dev_list(struct bio_xs_context *xs_ctxt, d_list_t *dev_list, int *dev_cnt)
 out:
 	d_list_for_each_entry_safe(s_info, s_tmp, &s_dev_list, sdi_link) {
 		d_list_del_init(&s_info->sdi_link);
-		smd_free_dev_info(s_info);
+		smd_dev_free_info(s_info);
 	}
 
 	if (rc != 0) {

--- a/src/bio/smd/SConscript
+++ b/src/bio/smd/SConscript
@@ -7,7 +7,7 @@ def scons():
 
     denv = env.Clone()
 
-    prereqs.require(denv, 'argobots')
+    prereqs.require(denv, 'argobots', 'protobufc')
 
     denv.Library('smd', Glob('*.c'), LIBS=['daos_common', 'gurt', 'pmemobj'])
 

--- a/src/bio/smd/smd_device.c
+++ b/src/bio/smd/smd_device.c
@@ -9,34 +9,29 @@
 #include <daos/dtx.h>
 #include "smd_internal.h"
 
-struct smd_dev_entry {
-	enum smd_dev_state	sde_state;
-	uint32_t		sde_tgt_cnt;
-	int			sde_tgts[SMD_MAX_TGT_CNT];
+struct smd_device {
+	enum smd_dev_state	sd_state;
+	uint32_t		sd_tgt_cnt;
+	uint32_t		sd_tgts[SMD_MAX_TGT_CNT];
 };
 
 int
-smd_dev_assign(uuid_t dev_id, int tgt_id)
+smd_dev_add_tgt(uuid_t dev_id, uint32_t tgt_id)
 {
-	struct smd_dev_entry	entry = { 0 };
-	d_iov_t			key, val;
-	struct d_uuid		key_dev, bond_dev;
+	struct smd_device	dev;
+	struct d_uuid		id_org;
+	struct d_uuid		id;
 	int			rc;
 
-	D_ASSERT(daos_handle_is_valid(smd_store.ss_dev_hdl));
-	D_ASSERT(daos_handle_is_valid(smd_store.ss_tgt_hdl));
-
-	uuid_copy(key_dev.uuid, dev_id);
-	smd_lock(&smd_store);
+	uuid_copy(id.uuid, dev_id);
+	smd_db_lock();
 
 	/* Check if the target is already bound to a device */
-	d_iov_set(&key, &tgt_id, sizeof(tgt_id));
-	d_iov_set(&val, &bond_dev, sizeof(bond_dev));
-	rc = dbtree_fetch(smd_store.ss_tgt_hdl, BTR_PROBE_EQ,
-			  DAOS_INTENT_DEFAULT, &key, NULL, &val);
+	rc = smd_db_fetch(TABLE_TGT, &tgt_id, sizeof(tgt_id),
+			  &id_org, sizeof(id_org));
 	if (rc == 0) {
 		D_ERROR("Target %d is already bound to dev "DF_UUID"\n",
-			tgt_id, DP_UUID(&bond_dev.uuid));
+			tgt_id, DP_UUID(&id_org.uuid));
 		rc = -DER_EXIST;
 		goto out;
 	} else if (rc != -DER_NONEXIST) {
@@ -45,115 +40,105 @@ smd_dev_assign(uuid_t dev_id, int tgt_id)
 	}
 
 	/* Fetch device if it's already existing */
-	d_iov_set(&key, &key_dev, sizeof(key_dev));
-	d_iov_set(&val, &entry, sizeof(entry));
-	rc = dbtree_fetch(smd_store.ss_dev_hdl, BTR_PROBE_EQ,
-			  DAOS_INTENT_DEFAULT, &key, NULL, &val);
+	rc = smd_db_fetch(TABLE_DEV, &id, sizeof(id), &dev, sizeof(dev));
 	if (rc == 0) {
-		if (entry.sde_tgt_cnt >= SMD_MAX_TGT_CNT) {
+		if (dev.sd_tgt_cnt >= SMD_MAX_TGT_CNT) {
 			D_ERROR("Dev "DF_UUID" is assigned to too many "
-				"targets (%d)\n", DP_UUID(&key_dev.uuid),
-				entry.sde_tgt_cnt);
+				"targets (%d)\n", DP_UUID(&id.uuid),
+				dev.sd_tgt_cnt);
 			rc = -DER_OVERFLOW;
 			goto out;
 		}
-		entry.sde_tgts[entry.sde_tgt_cnt] = tgt_id;
-		entry.sde_tgt_cnt += 1;
+		dev.sd_tgts[dev.sd_tgt_cnt] = tgt_id;
+		dev.sd_tgt_cnt += 1;
 	} else if (rc == -DER_NONEXIST) {
-		entry.sde_state = SMD_DEV_NORMAL;
-		entry.sde_tgt_cnt = 1;
-		entry.sde_tgts[0] = tgt_id;
+		dev.sd_state	= SMD_DEV_NORMAL;
+		dev.sd_tgt_cnt	= 1;
+		dev.sd_tgts[0]	= tgt_id;
 	} else {
 		D_ERROR("Fetch dev "DF_UUID" failed. "DF_RC"\n",
-			DP_UUID(&key_dev.uuid), DP_RC(rc));
+			DP_UUID(&id.uuid), DP_RC(rc));
 		goto out;
 	}
 
 	/* Update device and target tables in same transaction */
-	rc = smd_tx_begin(&smd_store);
+	rc = smd_db_tx_begin();
 	if (rc)
 		goto out;
 
-	rc = dbtree_update(smd_store.ss_dev_hdl, &key, &val);
+	rc = smd_db_upsert(TABLE_DEV, &id, sizeof(id), &dev, sizeof(dev));
 	if (rc) {
-		D_ERROR("Update dev "DF_UUID" failed. "DF_RC"\n",
-			DP_UUID(&key_dev.uuid), DP_RC(rc));
-		goto tx_end;
+		D_ERROR("Fetch dev "DF_UUID" failed. "DF_RC"\n",
+			DP_UUID(&id.uuid), DP_RC(rc));
+		goto out_tx;
 	}
 
-	d_iov_set(&key, &tgt_id, sizeof(tgt_id));
-	d_iov_set(&val, &key_dev, sizeof(key_dev));
-	rc = dbtree_update(smd_store.ss_tgt_hdl, &key, &val);
+	rc = smd_db_upsert(TABLE_TGT, &tgt_id, sizeof(tgt_id), &id, sizeof(id));
 	if (rc) {
-		D_ERROR("Update target %d failed. "DF_RC"\n", tgt_id,
-			DP_RC(rc));
-		goto tx_end;
+		D_ERROR("Update target %d failed: "DF_RC"\n",
+			tgt_id, DP_RC(rc));
+		goto out_tx;
 	}
-tx_end:
-	rc = smd_tx_end(&smd_store, rc);
+out_tx:
+	rc = smd_db_tx_end(rc);
 out:
-	smd_unlock(&smd_store);
+	smd_db_unlock();
 	return rc;
 }
 
 int
-smd_dev_unassign(uuid_t dev_id, int tgt_id)
+smd_dev_del_tgt(uuid_t dev_id, uint32_t tgt_id)
 {
 	return -DER_NOSYS;
 }
 
 char *
-smd_state_enum_to_str(enum smd_dev_state state)
+smd_dev_stat2str(enum smd_dev_state state)
 {
 	switch (state) {
-	case SMD_DEV_NORMAL: return "NORMAL";
-	case SMD_DEV_FAULTY: return "FAULTY";
+	default:
+		return "UNKNOWN";
+	case SMD_DEV_NORMAL:
+		return "NORMAL";
+	case SMD_DEV_FAULTY:
+		return "FAULTY";
 	}
-
-	return "Undefined state";
 }
 
 int
 smd_dev_set_state(uuid_t dev_id, enum smd_dev_state state)
 {
-	struct smd_dev_entry	entry = { 0 };
-	d_iov_t			key, val;
-	struct d_uuid		key_dev;
+	struct smd_device	dev;
+	struct d_uuid		id;
 	int			rc;
 
 	D_ASSERT(state == SMD_DEV_NORMAL || state == SMD_DEV_FAULTY);
-	D_ASSERT(daos_handle_is_valid(smd_store.ss_dev_hdl));
+	uuid_copy(id.uuid, dev_id);
 
-	uuid_copy(key_dev.uuid, dev_id);
-	smd_lock(&smd_store);
-
-	d_iov_set(&key, &key_dev, sizeof(key_dev));
-	d_iov_set(&val, &entry, sizeof(entry));
-	rc = dbtree_fetch(smd_store.ss_dev_hdl, BTR_PROBE_EQ,
-			  DAOS_INTENT_DEFAULT, &key, NULL, &val);
+	smd_db_lock();
+	rc = smd_db_fetch(TABLE_DEV, &id, sizeof(id), &dev, sizeof(dev));
 	if (rc) {
 		D_ERROR("Fetch dev "DF_UUID" failed. "DF_RC"\n",
-			DP_UUID(&key_dev.uuid), DP_RC(rc));
+			DP_UUID(&id.uuid), DP_RC(rc));
 		goto out;
 	}
 
-	entry.sde_state = state;
-	rc = dbtree_update(smd_store.ss_dev_hdl, &key, &val);
+	dev.sd_state = state;
+	rc = smd_db_upsert(TABLE_DEV, &id, sizeof(id), &dev, sizeof(dev));
 	if (rc) {
 		D_ERROR("SMD dev "DF_UUID" state set failed. "DF_RC"\n",
-			DP_UUID(&key_dev.uuid), DP_RC(rc));
+			DP_UUID(&id.uuid), DP_RC(rc));
 		goto out;
-	} else
-		D_DEBUG(DB_MGMT, "SMD dev "DF_UUID" state set to %s\n",
-			DP_UUID(&key_dev.uuid),
-			smd_state_enum_to_str(state));
+	}
+	D_DEBUG(DB_MGMT, "SMD dev "DF_UUID" state set to %s\n",
+		DP_UUID(&id.uuid), smd_dev_stat2str(state));
 out:
-	smd_unlock(&smd_store);
+	smd_db_unlock();
 	return rc;
 }
 
 static struct smd_dev_info *
-create_dev_info(uuid_t dev_id, struct smd_dev_entry *entry)
+smd_dev_alloc_info(struct d_uuid *id, struct smd_device *dev)
 {
 	struct smd_dev_info	*info;
 	int			 i;
@@ -164,45 +149,36 @@ create_dev_info(uuid_t dev_id, struct smd_dev_entry *entry)
 
 	D_ALLOC_ARRAY(info->sdi_tgts, SMD_MAX_TGT_CNT);
 	if (info->sdi_tgts == NULL) {
-		D_FREE(info);
+		smd_dev_free_info(info);
 		return NULL;
 	}
 
 	D_INIT_LIST_HEAD(&info->sdi_link);
-	uuid_copy(info->sdi_id, dev_id);
-	info->sdi_state = entry->sde_state;
-	info->sdi_tgt_cnt = entry->sde_tgt_cnt;
+	uuid_copy(info->sdi_id, id->uuid);
+	info->sdi_state	= dev->sd_state;
+	info->sdi_tgt_cnt = dev->sd_tgt_cnt;
 	for (i = 0; i < info->sdi_tgt_cnt; i++)
-		info->sdi_tgts[i] = entry->sde_tgts[i];
+		info->sdi_tgts[i] = dev->sd_tgts[i];
 
 	return info;
 }
 
 static int
-fetch_dev_info(uuid_t dev_id, struct smd_dev_info **dev_info)
+smd_dev_get_info(struct d_uuid *id, struct smd_dev_info **dev_info)
 {
 	struct smd_dev_info	*info;
-	struct smd_dev_entry	 entry = { 0 };
-	struct d_uuid		 key_dev;
-	d_iov_t			 key, val;
+	struct smd_device	 dev;
 	int			 rc;
 
-	D_ASSERT(daos_handle_is_valid(smd_store.ss_dev_hdl));
-
-	uuid_copy(key_dev.uuid, dev_id);
-
-	d_iov_set(&key, &key_dev, sizeof(key_dev));
-	d_iov_set(&val, &entry, sizeof(entry));
-	rc = dbtree_fetch(smd_store.ss_dev_hdl, BTR_PROBE_EQ,
-			  DAOS_INTENT_DEFAULT, &key, NULL, &val);
+	rc = smd_db_fetch(TABLE_DEV, id, sizeof(*id), &dev, sizeof(dev));
 	if (rc) {
 		D_CDEBUG(rc != -DER_NONEXIST, DLOG_ERR, DB_MGMT,
 			 "Fetch dev "DF_UUID" failed. "DF_RC"\n",
-			 DP_UUID(&key_dev.uuid), DP_RC(rc));
+			 DP_UUID(&id->uuid), DP_RC(rc));
 		return rc;
 	}
 
-	info = create_dev_info(dev_id, &entry);
+	info = smd_dev_alloc_info(id, &dev);
 	if (info == NULL)
 		return -DER_NOMEM;
 
@@ -213,203 +189,165 @@ fetch_dev_info(uuid_t dev_id, struct smd_dev_info **dev_info)
 int
 smd_dev_get_by_id(uuid_t dev_id, struct smd_dev_info **dev_info)
 {
-	int	rc;
+	struct d_uuid	id;
+	int		rc;
 
-	smd_lock(&smd_store);
-	rc = fetch_dev_info(dev_id, dev_info);
-	smd_unlock(&smd_store);
+	uuid_copy(id.uuid, dev_id);
+	smd_db_lock();
+	rc = smd_dev_get_info(&id, dev_info);
+	smd_db_unlock();
 	return rc;
 }
 
 int
-smd_dev_get_by_tgt(int tgt_id, struct smd_dev_info **dev_info)
+smd_dev_get_by_tgt(uint32_t tgt_id, struct smd_dev_info **dev_info)
 {
-	struct d_uuid	bond_dev;
-	d_iov_t		key, val;
+	struct d_uuid	id;
 	int		rc;
 
-	D_ASSERT(daos_handle_is_valid(smd_store.ss_tgt_hdl));
-	smd_lock(&smd_store);
-
-	d_iov_set(&key, &tgt_id, sizeof(tgt_id));
-	d_iov_set(&val, &bond_dev, sizeof(bond_dev));
-	rc = dbtree_fetch(smd_store.ss_tgt_hdl, BTR_PROBE_EQ,
-			  DAOS_INTENT_DEFAULT, &key, NULL, &val);
+	smd_db_lock();
+	rc = smd_db_fetch(TABLE_TGT, &tgt_id, sizeof(tgt_id), &id, sizeof(id));
 	if (rc) {
 		D_CDEBUG(rc != -DER_NONEXIST, DLOG_ERR, DB_MGMT,
 			 "Fetch target %d failed. "DF_RC"\n", tgt_id,
 			 DP_RC(rc));
 		goto out;
 	}
-
-	rc = fetch_dev_info(bond_dev.uuid, dev_info);
+	rc = smd_dev_get_info(&id, dev_info);
 out:
-	smd_unlock(&smd_store);
+	smd_db_unlock();
 	return rc;
+}
+
+static int
+smd_dev_list_cb(struct sys_db *db, char *table, d_iov_t *key, void *args)
+{
+	struct smd_trav_data    *td = args;
+	struct smd_dev_info     *info;
+	struct smd_device        dev;
+	struct d_uuid            id;
+	int                      rc;
+
+	D_ASSERT(key->iov_len == sizeof(id));
+	id = *(struct d_uuid *)key->iov_buf;
+	rc = smd_db_fetch(TABLE_DEV, &id, sizeof(id), &dev, sizeof(dev));
+	if (rc)
+		return rc;
+
+	info = smd_dev_alloc_info(&id, &dev);
+	if (!info)
+		return -DER_NOMEM;
+
+	d_list_add_tail(&info->sdi_link, &td->td_list);
+	td->td_count++;
+	return 0;
 }
 
 int
 smd_dev_list(d_list_t *dev_list, int *devs)
 {
-	struct smd_dev_info	*info;
-	struct smd_dev_entry	 entry = { 0 };
-	daos_handle_t		 iter_hdl;
-	struct d_uuid		 key_dev;
-	d_iov_t			 key, val;
-	int			 dev_cnt = 0;
-	int			 rc;
+	struct smd_trav_data td;
+	int		     rc;
 
-	D_ASSERT(dev_list && d_list_empty(dev_list));
-	D_ASSERT(daos_handle_is_valid(smd_store.ss_dev_hdl));
+	td.td_count = 0;
+	D_INIT_LIST_HEAD(&td.td_list);
 
-	smd_lock(&smd_store);
+	smd_db_lock();
+	rc = smd_db_traverse(TABLE_DEV, smd_dev_list_cb, &td);
+	smd_db_unlock();
 
-	rc = dbtree_iter_prepare(smd_store.ss_dev_hdl, 0, &iter_hdl);
-	if (rc) {
-		D_ERROR("Prepare device iterator failed. "DF_RC"\n", DP_RC(rc));
-		goto out;
+	if (rc == 0) { /* success */
+		*devs = td.td_count;
+		d_list_splice_init(&td.td_list, dev_list);
 	}
 
-	rc = dbtree_iter_probe(iter_hdl, BTR_PROBE_FIRST, DAOS_INTENT_DEFAULT,
-			       NULL, NULL);
-	if (rc) {
-		if (rc != -DER_NONEXIST)
-			D_ERROR("Probe first device failed. "DF_RC"\n",
-				DP_RC(rc));
-		else
-			rc = 0;
-		goto done;
+	while (!d_list_empty(&td.td_list)) { /* failure handling */
+		struct smd_dev_info	*info;
+
+		info = d_list_entry(td.td_list.next,
+				    struct smd_dev_info, sdi_link);
+		d_list_del(&info->sdi_link);
+		smd_dev_free_info(info);
 	}
-
-	d_iov_set(&key, &key_dev, sizeof(key_dev));
-	d_iov_set(&val, &entry, sizeof(entry));
-
-	while (1) {
-		rc = dbtree_iter_fetch(iter_hdl, &key, &val, NULL);
-		if (rc != 0) {
-			D_ERROR("Iterate fetch failed. "DF_RC"\n", DP_RC(rc));
-			break;
-		}
-
-		info = create_dev_info(key_dev.uuid, &entry);
-		if (info == NULL) {
-			rc = -DER_NOMEM;
-			D_ERROR("Create device info failed. "DF_RC"\n",
-				DP_RC(rc));
-			break;
-		}
-		d_list_add_tail(&info->sdi_link, dev_list);
-
-		dev_cnt++;
-
-		rc = dbtree_iter_next(iter_hdl);
-		if (rc) {
-			if (rc != -DER_NONEXIST)
-				D_ERROR("Iterate next failed. "DF_RC"\n",
-					DP_RC(rc));
-			else
-				rc = 0;
-			break;
-		}
-	}
-done:
-	dbtree_iter_finish(iter_hdl);
-out:
-	smd_unlock(&smd_store);
-
-	/* return device count along with dev list */
-	*devs = dev_cnt;
-
 	return rc;
 }
 
 int
 smd_dev_replace(uuid_t old_id, uuid_t new_id, d_list_t *pool_list)
 {
-	struct smd_dev_entry	 entry = { 0 };
-	d_iov_t			 key, val;
-	struct d_uuid		 key_dev;
+	struct smd_device	 dev;
+	struct d_uuid		 id;
 	struct smd_pool_info	*pool_info;
-	int			 i, tgt_id, rc;
+	int			 i, rc;
 
 	D_ASSERT(uuid_compare(old_id, new_id) != 0);
-	D_ASSERT(daos_handle_is_valid(smd_store.ss_dev_hdl));
-	D_ASSERT(daos_handle_is_valid(smd_store.ss_tgt_hdl));
 
-	uuid_copy(key_dev.uuid, new_id);
-	smd_lock(&smd_store);
-
+	smd_db_lock();
 	/* Fetch new device */
-	d_iov_set(&key, &key_dev, sizeof(key_dev));
-	d_iov_set(&val, &entry, sizeof(entry));
-	rc = dbtree_fetch(smd_store.ss_dev_hdl, BTR_PROBE_EQ,
-			  DAOS_INTENT_DEFAULT, &key, NULL, &val);
+	uuid_copy(id.uuid, new_id);
+	rc = smd_db_fetch(TABLE_DEV, &id, sizeof(id), &dev, sizeof(dev));
 	if (rc == 0) {
-		D_ERROR("New dev "DF_UUID" is inuse\n",
-			DP_UUID(&key_dev.uuid));
+		D_ERROR("New dev "DF_UUID" is inuse\n", DP_UUID(&id.uuid));
 		rc = -DER_INVAL;
 		goto out;
 	} else if (rc != -DER_NONEXIST) {
 		D_ERROR("Fetch new dev "DF_UUID" failed. "DF_RC"\n",
-			DP_UUID(&key_dev.uuid), DP_RC(rc));
+			DP_UUID(id.uuid), DP_RC(rc));
 		goto out;
 	}
 
 	/* Fetch old device */
-	uuid_copy(key_dev.uuid, old_id);
-	rc = dbtree_fetch(smd_store.ss_dev_hdl, BTR_PROBE_EQ,
-			  DAOS_INTENT_DEFAULT, &key, NULL, &val);
+	uuid_copy(id.uuid, old_id);
+	rc = smd_db_fetch(TABLE_DEV, &id, sizeof(id), &dev, sizeof(dev));
 	if (rc) {
 		D_ERROR("Fetch dev "DF_UUID" failed. "DF_RC"\n",
-			DP_UUID(&key_dev.uuid), DP_RC(rc));
+			DP_UUID(&id.uuid), DP_RC(rc));
 		goto out;
 	}
 
 	/* Sanity check to old device */
-	if (entry.sde_state != SMD_DEV_FAULTY) {
-		D_ERROR("Dev "DF_UUID" isn't in faulty\n",
-			DP_UUID(&key_dev.uuid));
+	if (dev.sd_state != SMD_DEV_FAULTY) {
+		D_ERROR("Dev "DF_UUID" isn't in faulty\n", DP_UUID(&id.uuid));
 		rc = -DER_INVAL;
 		goto out;
 	}
 
-	if (entry.sde_tgt_cnt >= SMD_MAX_TGT_CNT || entry.sde_tgt_cnt == 0) {
+	if (dev.sd_tgt_cnt >= SMD_MAX_TGT_CNT || dev.sd_tgt_cnt == 0) {
 		D_ERROR("Invalid targets (%d) for dev "DF_UUID"\n",
-			entry.sde_tgt_cnt, DP_UUID(&key_dev.uuid));
+			dev.sd_tgt_cnt, DP_UUID(&id.uuid));
 		rc = -DER_INVAL;
 		goto out;
 	}
 
 	/* Update device, target and pool tables in one transaction */
-	rc = smd_tx_begin(&smd_store);
+	rc = smd_db_tx_begin();
 	if (rc)
 		goto out;
 
 	/* Delete old device in device table */
-	rc = dbtree_delete(smd_store.ss_dev_hdl, BTR_PROBE_EQ, &key, NULL);
+	rc = smd_db_delete(TABLE_DEV, &id, sizeof(id));
 	if (rc) {
 		D_ERROR("Failed to delete old dev "DF_UUID". "DF_RC"\n",
-			DP_UUID(&key_dev.uuid), DP_RC(rc));
+			DP_UUID(&id.uuid), DP_RC(rc));
 		goto tx_end;
 	}
 
 	/* Insert new device in device table */
-	uuid_copy(key_dev.uuid, new_id);
-	entry.sde_state = SMD_DEV_NORMAL;
-	rc = dbtree_update(smd_store.ss_dev_hdl, &key, &val);
+	uuid_copy(id.uuid, new_id);
+	dev.sd_state = SMD_DEV_NORMAL;
+	rc = smd_db_upsert(TABLE_DEV, &id, sizeof(id), &dev, sizeof(dev));
 	if (rc) {
 		D_ERROR("Failed to insert new dev "DF_UUID". "DF_RC"\n",
-			DP_UUID(&key_dev.uuid), DP_RC(rc));
+			DP_UUID(&id.uuid), DP_RC(rc));
 		goto tx_end;
 	}
 
 	/* Replace old device ID with new device ID in target table */
-	d_iov_set(&key, &tgt_id, sizeof(tgt_id));
-	d_iov_set(&val, &key_dev, sizeof(key_dev));
-	for (i = 0; i < entry.sde_tgt_cnt; i++) {
-		tgt_id = entry.sde_tgts[i];
+	for (i = 0; i < dev.sd_tgt_cnt; i++) {
+		uint32_t tgt_id = dev.sd_tgts[i];
 
-		rc = dbtree_update(smd_store.ss_tgt_hdl, &key, &val);
+		rc = smd_db_upsert(TABLE_TGT, &tgt_id, sizeof(tgt_id),
+				   &id, sizeof(id));
 		if (rc) {
 			D_ERROR("Update target %d failed. "DF_RC"\n",
 				tgt_id, DP_RC(rc));
@@ -422,18 +360,17 @@ smd_dev_replace(uuid_t old_id, uuid_t new_id, d_list_t *pool_list)
 
 	/* Replace old blob IDs with new blob IDs in pool map */
 	d_list_for_each_entry(pool_info, pool_list, spi_link) {
-		rc = smd_replace_blobs(pool_info, entry.sde_tgt_cnt,
-				       &entry.sde_tgts[0]);
+		rc = smd_pool_replace_blobs_locked(pool_info, dev.sd_tgt_cnt,
+						   &dev.sd_tgts[0]);
 		if (rc) {
 			D_ERROR("Update pool "DF_UUID" failed. "DF_RC"\n",
 				DP_UUID(pool_info->spi_id), DP_RC(rc));
 			goto tx_end;
 		}
 	}
-
 tx_end:
-	rc = smd_tx_end(&smd_store, rc);
+	rc = smd_db_tx_end(rc);
 out:
-	smd_unlock(&smd_store);
+	smd_db_unlock();
 	return rc;
 }

--- a/src/bio/smd/smd_internal.h
+++ b/src/bio/smd/smd_internal.h
@@ -19,80 +19,30 @@
 #include <daos/mem.h>
 #include <daos_srv/smd.h>
 
-POBJ_LAYOUT_BEGIN(smd_md_layout);
-POBJ_LAYOUT_ROOT(smd_md_layout, struct smd_df);
-POBJ_LAYOUT_END(smd_md_layout);
+#define TABLE_DEV	"device"
+#define TABLE_TGT	"target"
+#define TABLE_POOL	"pool"
 
-/* Maximum target(VOS xstream) count */
 #define SMD_MAX_TGT_CNT		64
 
-#define SMD_DF_MAGIC		0x5eaf00d
-
-/* The lowest supported version */
-#define SMD_DF_VER_1		2
-/* The current SMD DF version */
-#define SMD_DF_VERSION		SMD_DF_VER_1
-
-/* SMD root durable format */
-struct smd_df {
-	/** magic number to idenfity durable formatn */
-	uint32_t	smd_magic;
-	/** the current version of durable format */
-	uint32_t	smd_version;
-	struct btr_root	smd_dev_tab;	/* device table */
-	struct btr_root	smd_pool_tab;	/* pool table */
-	struct btr_root	smd_tgt_tab;	/* target table */
+/** callback parameter for smd_db_traverse */
+struct smd_trav_data {
+	d_list_t		td_list;
+	int			td_count;
 };
 
-/* SMD store (DRAM structure) */
-struct smd_store {
-	struct umem_instance	ss_umm;
-	ABT_mutex		ss_mutex;
-	daos_handle_t		ss_dev_hdl;
-	daos_handle_t		ss_pool_hdl;
-	daos_handle_t		ss_tgt_hdl;
-};
-
-static inline struct smd_df *
-smd_pop2df(PMEMobjpool *pop)
-{
-	TOID(struct smd_df) smd_df;
-
-	smd_df = POBJ_ROOT(pop, struct smd_df);
-	return D_RW(smd_df);
-}
-
-static inline int
-smd_tx_begin(struct smd_store *store)
-{
-	return umem_tx_begin(&store->ss_umm, NULL);
-}
-
-static inline int
-smd_tx_end(struct smd_store *store, int rc)
-{
-	if (rc != 0)
-		return umem_tx_abort(&store->ss_umm, rc);
-
-	return umem_tx_commit(&store->ss_umm);
-}
-
-static inline void
-smd_lock(struct smd_store *store)
-{
-	ABT_mutex_lock(store->ss_mutex);
-}
-
-static inline void
-smd_unlock(struct smd_store *store)
-{
-	ABT_mutex_unlock(store->ss_mutex);
-}
-
-extern struct smd_store		smd_store;
+int smd_db_fetch(char *table, void *key, int key_sz, void *val, int val_sz);
+int smd_db_upsert(char *table, void *key, int key_sz, void *val, int val_sz);
+int smd_db_delete(char *table, void *key, int key_sz);
+int smd_db_traverse(char *table, sys_db_trav_cb_t cb, struct smd_trav_data *td);
+int smd_db_tx_begin(void);
+int smd_db_tx_end(int rc);
+void smd_db_lock(void);
+void smd_db_unlock(void);
 
 /* smd_pool.c */
 int
-smd_replace_blobs(struct smd_pool_info *info, uint32_t tgt_cnt, int *tgts);
+smd_pool_replace_blobs_locked(struct smd_pool_info *info, int tgt_cnt,
+			      uint32_t *tgts);
 
 #endif /** __SMD_INTERNAL_H__ */

--- a/src/bio/smd/smd_pool.c
+++ b/src/bio/smd/smd_pool.c
@@ -9,159 +9,145 @@
 #include <daos/dtx.h>
 #include "smd_internal.h"
 
-struct smd_pool_entry {
-	uint64_t	spe_blob_sz;
-	uint32_t	spe_tgt_cnt;
-	int		spe_tgts[SMD_MAX_TGT_CNT];
-	uint64_t	spe_blobs[SMD_MAX_TGT_CNT];
+struct smd_pool {
+	uint64_t	sp_blob_sz;
+	uint32_t	sp_tgt_cnt;
+	uint32_t	sp_tgts[SMD_MAX_TGT_CNT];
+	uint64_t	sp_blobs[SMD_MAX_TGT_CNT];
 };
 
 static int
-get_tgt_idx(struct smd_pool_entry *entry, int tgt_id)
+smd_pool_find_tgt(struct smd_pool *pool, int tgt_id)
 {
 	int	i;
 
-	for (i = 0; i < entry->spe_tgt_cnt; i++) {
-		if (entry->spe_tgts[i] == tgt_id)
-			break;
+	for (i = 0; i < pool->sp_tgt_cnt; i++) {
+		if (pool->sp_tgts[i] == tgt_id)
+			return i;
 	}
-	return (i == entry->spe_tgt_cnt) ? -1 : i;
+	return -1;
 }
 
 int
-smd_pool_assign(uuid_t pool_id, int tgt_id, uint64_t blob_id, uint64_t blob_sz)
+smd_pool_add_tgt(uuid_t pool_id, uint32_t tgt_id, uint64_t blob_id,
+		 uint64_t blob_sz)
 {
-	struct smd_pool_entry	entry = { 0 };
-	struct d_uuid		key_pool;
-	d_iov_t			key, val;
-	int			tgt_idx, rc;
+	struct smd_pool	pool;
+	struct d_uuid	id;
+	int		rc;
 
-	D_ASSERT(daos_handle_is_valid(smd_store.ss_pool_hdl));
+	uuid_copy(id.uuid, pool_id);
 
-	uuid_copy(key_pool.uuid, pool_id);
-	smd_lock(&smd_store);
-
+	smd_db_lock();
 	/* Fetch pool if it's already existing */
-	d_iov_set(&key, &key_pool, sizeof(key_pool));
-	d_iov_set(&val, &entry, sizeof(entry));
-	rc = dbtree_fetch(smd_store.ss_pool_hdl, BTR_PROBE_EQ,
-			  DAOS_INTENT_DEFAULT, &key, NULL, &val);
+	rc = smd_db_fetch(TABLE_POOL, &id, sizeof(id), &pool, sizeof(pool));
 	if (rc == 0) {
-		if (entry.spe_blob_sz != blob_sz) {
+		if (pool.sp_blob_sz != blob_sz) {
 			D_ERROR("Pool "DF_UUID" blob size mismatch. "
 				""DF_U64" != "DF_U64"\n",
-				DP_UUID(&key_pool.uuid), entry.spe_blob_sz,
+				DP_UUID(&id.uuid), pool.sp_blob_sz,
 				blob_sz);
 			rc = -DER_INVAL;
 			goto out;
 		}
 
-		if (entry.spe_tgt_cnt >= SMD_MAX_TGT_CNT) {
+		if (pool.sp_tgt_cnt >= SMD_MAX_TGT_CNT) {
 			D_ERROR("Pool "DF_UUID" is assigned to too many "
-				"targets (%d)\n", DP_UUID(&key_pool.uuid),
-				entry.spe_tgt_cnt);
+				"targets (%d)\n", DP_UUID(&id.uuid),
+				pool.sp_tgt_cnt);
 			rc = -DER_OVERFLOW;
 			goto out;
 		}
 
-		tgt_idx = get_tgt_idx(&entry, tgt_id);
-		if (tgt_idx != -1) {
-			D_ERROR("Dup target %d, idx: %d\n", tgt_id, tgt_idx);
+		rc = smd_pool_find_tgt(&pool, tgt_id);
+		if (rc >= 0) {
+			D_ERROR("Dup target %d, idx: %d\n", tgt_id, rc);
 			rc = -DER_EXIST;
 			goto out;
 		}
 
-		entry.spe_tgts[entry.spe_tgt_cnt] = tgt_id;
-		entry.spe_blobs[entry.spe_tgt_cnt] = blob_id;
-		entry.spe_tgt_cnt += 1;
+		pool.sp_tgts[pool.sp_tgt_cnt] = tgt_id;
+		pool.sp_blobs[pool.sp_tgt_cnt] = blob_id;
+		pool.sp_tgt_cnt += 1;
+
 	} else if (rc == -DER_NONEXIST) {
-		entry.spe_tgts[0] = tgt_id;
-		entry.spe_blobs[0] = blob_id;
-		entry.spe_tgt_cnt = 1;
-		entry.spe_blob_sz = blob_sz;
+		pool.sp_tgts[0]	 = tgt_id;
+		pool.sp_blobs[0] = blob_id;
+		pool.sp_tgt_cnt	 = 1;
+		pool.sp_blob_sz  = blob_sz;
+
 	} else {
-		D_ERROR("Fetch pool "DF_UUID" failed. %d\n",
-			DP_UUID(&key_pool.uuid), rc);
+		D_ERROR("Fetch pool "DF_UUID" failed. "DF_RC"\n",
+			DP_UUID(&id.uuid), DP_RC(rc));
 		goto out;
 	}
 
-	rc = dbtree_update(smd_store.ss_pool_hdl, &key, &val);
+	rc = smd_db_upsert(TABLE_POOL, &id, sizeof(id), &pool, sizeof(pool));
 	if (rc) {
-		D_ERROR("Update pool "DF_UUID" failed. %d\n",
-			DP_UUID(&key_pool.uuid), rc);
+		D_ERROR("Update pool "DF_UUID" failed. "DF_RC"\n",
+			DP_UUID(&id.uuid), DP_RC(rc));
 		goto out;
 	}
 out:
-	smd_unlock(&smd_store);
+	smd_db_unlock();
 	return rc;
 }
 
 int
-smd_pool_unassign(uuid_t pool_id, int tgt_id)
+smd_pool_del_tgt(uuid_t pool_id, uint32_t tgt_id)
 {
-	struct smd_pool_entry	 entry = { 0 };
-	struct d_uuid		 key_pool;
-	d_iov_t			 key, val;
-	int			*tgt_src, *tgt_tgt;
-	uint64_t		*blob_src, *blob_tgt;
-	int			 tgt_idx, rc, move_cnt;
+	struct smd_pool	pool;
+	struct d_uuid	id;
+	int		i;
+	int		rc;
 
-	D_ASSERT(daos_handle_is_valid(smd_store.ss_pool_hdl));
+	uuid_copy(id.uuid, pool_id);
 
-	uuid_copy(key_pool.uuid, pool_id);
-	smd_lock(&smd_store);
-
-	d_iov_set(&key, &key_pool, sizeof(key_pool));
-	d_iov_set(&val, &entry, sizeof(entry));
-	rc = dbtree_fetch(smd_store.ss_pool_hdl, BTR_PROBE_EQ,
-			  DAOS_INTENT_DEFAULT, &key, NULL, &val);
+	smd_db_lock();
+	rc = smd_db_fetch(TABLE_POOL, &id, sizeof(id), &pool, sizeof(pool));
 	if (rc) {
-		D_ERROR("Fetch pool "DF_UUID" failed. %d\n",
-			DP_UUID(key_pool.uuid), rc);
+		D_ERROR("Fetch pool "DF_UUID" failed. "DF_RC"\n",
+			DP_UUID(id.uuid), DP_RC(rc));
 		goto out;
 	}
 
-	tgt_idx = get_tgt_idx(&entry, tgt_id);
-	if (tgt_idx == -1) {
+	rc = smd_pool_find_tgt(&pool, tgt_id);
+	if (rc < 0) {
 		D_ERROR("Pool "DF_UUID" target %d not found.\n",
-			DP_UUID(key_pool.uuid), tgt_id);
+			DP_UUID(id.uuid), tgt_id);
 		rc = -DER_NONEXIST;
 		goto out;
 	}
 
-	tgt_src = &entry.spe_tgts[tgt_idx + 1];
-	tgt_tgt = &entry.spe_tgts[tgt_idx];
-	blob_src = &entry.spe_blobs[tgt_idx + 1];
-	blob_tgt = &entry.spe_blobs[tgt_idx];
-
-	D_ASSERT(entry.spe_tgt_cnt >= (tgt_idx + 1));
-	move_cnt = entry.spe_tgt_cnt - 1 - tgt_idx;
-	entry.spe_tgt_cnt -= 1;
-
-	if (move_cnt && entry.spe_tgt_cnt) {
-		memmove(tgt_tgt, tgt_src, move_cnt * sizeof(int));
-		memmove(blob_tgt, blob_src, move_cnt * sizeof(uint64_t));
+	for (i = rc; i < pool.sp_tgt_cnt - 1; i++) {
+		pool.sp_tgts[i] = pool.sp_tgts[i + 1];
+		pool.sp_blobs[i] = pool.sp_blobs[i + 1];
 	}
 
-	if (entry.spe_tgt_cnt) {
-		rc = dbtree_update(smd_store.ss_pool_hdl, &key, &val);
-		if (rc)
-			D_ERROR("Update pool "DF_UUID" failed. %d\n",
-				DP_UUID(&key_pool.uuid), rc);
+	pool.sp_tgt_cnt -= 1;
+	if (pool.sp_tgt_cnt > 0) {
+		rc = smd_db_upsert(TABLE_POOL, &id, sizeof(id),
+				   &pool, sizeof(pool));
+		if (rc) {
+			D_ERROR("Update pool "DF_UUID" failed: "DF_RC"\n",
+				DP_UUID(&id.uuid), DP_RC(rc));
+			goto out;
+		}
 	} else {
-		rc = dbtree_delete(smd_store.ss_pool_hdl, BTR_PROBE_EQ, &key,
-				   NULL);
-		if (rc)
-			D_ERROR("Delete pool "DF_UUID" failed. %d\n",
-				DP_UUID(&key_pool.uuid), rc);
+		rc = smd_db_delete(TABLE_POOL, &id, sizeof(id));
+		if (rc) {
+			D_ERROR("Delete pool "DF_UUID" failed: "DF_RC"\n",
+				DP_UUID(&id.uuid), DP_RC(rc));
+			goto out;
+		}
 	}
 out:
-	smd_unlock(&smd_store);
+	smd_db_unlock();
 	return rc;
 }
 
 static struct smd_pool_info *
-create_pool_info(uuid_t pool_id, struct smd_pool_entry *entry)
+smd_pool_alloc_info(struct d_uuid *id, struct smd_pool *pool)
 {
 	struct smd_pool_info	*info;
 	int			 i;
@@ -172,218 +158,179 @@ create_pool_info(uuid_t pool_id, struct smd_pool_entry *entry)
 
 	D_ALLOC_ARRAY(info->spi_tgts, SMD_MAX_TGT_CNT);
 	if (info->spi_tgts == NULL) {
-		D_FREE(info);
+		smd_pool_free_info(info);
 		return NULL;
 	}
 	D_ALLOC_ARRAY(info->spi_blobs, SMD_MAX_TGT_CNT);
 	if (info->spi_blobs == NULL) {
-		D_FREE(info->spi_tgts);
-		D_FREE(info);
+		smd_pool_free_info(info);
 		return NULL;
 	}
 
 	D_INIT_LIST_HEAD(&info->spi_link);
-	uuid_copy(info->spi_id, pool_id);
-	info->spi_blob_sz = entry->spe_blob_sz;
-	info->spi_tgt_cnt = entry->spe_tgt_cnt;
+	uuid_copy(info->spi_id, id->uuid);
+	info->spi_blob_sz = pool->sp_blob_sz;
+	info->spi_tgt_cnt = pool->sp_tgt_cnt;
 	for (i = 0; i < info->spi_tgt_cnt; i++) {
-		info->spi_tgts[i] = entry->spe_tgts[i];
-		info->spi_blobs[i] = entry->spe_blobs[i];
+		info->spi_tgts[i] = pool->sp_tgts[i];
+		info->spi_blobs[i] = pool->sp_blobs[i];
 	}
-
 	return info;
 }
 
 int
-smd_pool_get(uuid_t pool_id, struct smd_pool_info **pool_info)
+smd_pool_get_info(uuid_t pool_id, struct smd_pool_info **pool_info)
 {
 	struct smd_pool_info	*info;
-	struct smd_pool_entry	 entry = { 0 };
-	struct d_uuid		 key_pool;
-	d_iov_t			 key, val;
+	struct smd_pool		 pool;
+	struct d_uuid		 id;
 	int			 rc;
 
-	D_ASSERT(daos_handle_is_valid(smd_store.ss_pool_hdl));
-
-	uuid_copy(key_pool.uuid, pool_id);
-	smd_lock(&smd_store);
-
-	d_iov_set(&key, &key_pool, sizeof(key_pool));
-	d_iov_set(&val, &entry, sizeof(entry));
-	rc = dbtree_fetch(smd_store.ss_pool_hdl, BTR_PROBE_EQ,
-			  DAOS_INTENT_DEFAULT, &key, NULL, &val);
+	uuid_copy(id.uuid, pool_id);
+	smd_db_lock();
+	rc = smd_db_fetch(TABLE_POOL, &id, sizeof(id), &pool, sizeof(pool));
 	if (rc) {
-		D_ERROR("Fetch pool "DF_UUID" failed. %d\n",
-			DP_UUID(&key_pool.uuid), rc);
+		D_ERROR("Fetch pool "DF_UUID" failed: "DF_RC"\n",
+			DP_UUID(&id.uuid), DP_RC(rc));
 		goto out;
 	}
 
-	info = create_pool_info(pool_id, &entry);
+	info = smd_pool_alloc_info(&id, &pool);
 	if (info == NULL) {
 		rc = -DER_NOMEM;
 		goto out;
 	}
 	*pool_info = info;
 out:
-	smd_unlock(&smd_store);
+	smd_db_unlock();
 	return rc;
 }
 
 int
-smd_pool_get_blob(uuid_t pool_id, int tgt_id, uint64_t *blob_id)
+smd_pool_get_blob(uuid_t pool_id, uint32_t tgt_id, uint64_t *blob_id)
 {
-	struct smd_pool_entry	entry = { 0 };
-	struct d_uuid		key_pool;
-	d_iov_t			key, val;
-	int			tgt_idx, rc;
+	struct smd_pool	pool;
+	struct d_uuid	id;
+	int		rc;
 
-	D_ASSERT(daos_handle_is_valid(smd_store.ss_pool_hdl));
+	uuid_copy(id.uuid, pool_id);
 
-	uuid_copy(key_pool.uuid, pool_id);
-	smd_lock(&smd_store);
-
-	d_iov_set(&key, &key_pool, sizeof(key_pool));
-	d_iov_set(&val, &entry, sizeof(entry));
-	rc = dbtree_fetch(smd_store.ss_pool_hdl, BTR_PROBE_EQ,
-			  DAOS_INTENT_DEFAULT, &key, NULL, &val);
+	smd_db_lock();
+	rc = smd_db_fetch(TABLE_POOL, &id, sizeof(id), &pool, sizeof(pool));
 	if (rc) {
 		D_CDEBUG(rc != -DER_NONEXIST, DLOG_ERR, DB_MGMT,
-			 "Fetch pool "DF_UUID" failed. %d\n",
-			 DP_UUID(&key_pool.uuid), rc);
+			 "Fetch pool "DF_UUID" failed. "DF_RC"\n",
+			 DP_UUID(&id.uuid), DP_RC(rc));
 		goto out;
 	}
 
-	tgt_idx = get_tgt_idx(&entry, tgt_id);
-	if (tgt_idx == -1) {
+	rc = smd_pool_find_tgt(&pool, tgt_id);
+	if (rc < 0) {
 		D_DEBUG(DB_MGMT, "Pool "DF_UUID" target %d not found.\n",
-			DP_UUID(key_pool.uuid), tgt_id);
+			DP_UUID(id.uuid), tgt_id);
 		rc = -DER_NONEXIST;
 		goto out;
 	}
-	*blob_id = entry.spe_blobs[tgt_idx];
+	*blob_id = pool.sp_blobs[rc];
+	rc = 0;
 out:
-	smd_unlock(&smd_store);
+	smd_db_unlock();
 	return rc;
+}
+
+static int
+smd_pool_list_cb(struct sys_db *db, char *table, d_iov_t *key, void *args)
+{
+	struct smd_trav_data    *td = args;
+	struct smd_pool_info    *info;
+	struct smd_pool          pool;
+	struct d_uuid            id;
+	int                      rc;
+
+	D_ASSERT(key->iov_len == sizeof(id));
+	id = *(struct d_uuid *)key->iov_buf;
+	rc = smd_db_fetch(TABLE_POOL, &id, sizeof(id), &pool, sizeof(pool));
+	if (rc)
+		return rc;
+
+	info = smd_pool_alloc_info(&id, &pool);
+	if (!info)
+		return -DER_NOMEM;
+
+	d_list_add_tail(&info->spi_link, &td->td_list);
+	td->td_count++;
+	return 0;
 }
 
 int
 smd_pool_list(d_list_t *pool_list, int *pools)
 {
-	struct smd_pool_info	*info;
-	struct smd_pool_entry	 entry = { 0 };
-	daos_handle_t		 iter_hdl;
-	struct d_uuid		 key_pool;
-	d_iov_t			 key, val;
-	int			 pool_cnt = 0;
-	int			 rc;
+	struct smd_trav_data td;
+	int		     rc;
 
-	D_ASSERT(pool_list && d_list_empty(pool_list));
-	D_ASSERT(daos_handle_is_valid(smd_store.ss_pool_hdl));
+	td.td_count = 0;
+	D_INIT_LIST_HEAD(&td.td_list);
 
-	smd_lock(&smd_store);
+	smd_db_lock();
+	rc = smd_db_traverse(TABLE_POOL, smd_pool_list_cb, &td);
+	smd_db_unlock();
 
-	rc = dbtree_iter_prepare(smd_store.ss_pool_hdl, 0, &iter_hdl);
-	if (rc) {
-		D_ERROR("Prepare pool iterator failed. "DF_RC"\n", DP_RC(rc));
-		goto out;
+	if (rc == 0) { /* success */
+		*pools = td.td_count;
+		d_list_splice_init(&td.td_list, pool_list);
 	}
 
-	rc = dbtree_iter_probe(iter_hdl, BTR_PROBE_FIRST, DAOS_INTENT_DEFAULT,
-			       NULL, NULL);
-	if (rc) {
-		if (rc != -DER_NONEXIST)
-			D_ERROR("Probe first pool failed. "DF_RC"\n",
-				DP_RC(rc));
-		else
-			rc = 0;
-		goto done;
+	while (!d_list_empty(&td.td_list)) {
+		struct smd_pool_info	*info;
+
+		info = d_list_entry(td.td_list.next, struct smd_pool_info,
+				    spi_link);
+		d_list_del(&info->spi_link);
+		smd_pool_free_info(info);
+
 	}
-
-	d_iov_set(&key, &key_pool, sizeof(key_pool));
-	d_iov_set(&val, &entry, sizeof(entry));
-
-	while (1) {
-		rc = dbtree_iter_fetch(iter_hdl, &key, &val, NULL);
-		if (rc != 0) {
-			D_ERROR("Iterate fetch failed. "DF_RC"\n", DP_RC(rc));
-			break;
-		}
-
-		info = create_pool_info(key_pool.uuid, &entry);
-		if (info == NULL) {
-			rc = -DER_NOMEM;
-			D_ERROR("Create pool info failed. "DF_RC"\n",
-				DP_RC(rc));
-			break;
-		}
-		d_list_add_tail(&info->spi_link, pool_list);
-
-		pool_cnt++;
-		rc = dbtree_iter_next(iter_hdl);
-		if (rc) {
-			if (rc != -DER_NONEXIST)
-				D_ERROR("Iterate next failed. "DF_RC"\n",
-					DP_RC(rc));
-			else
-				rc = 0;
-			break;
-		}
-	}
-done:
-	dbtree_iter_finish(iter_hdl);
-out:
-	smd_unlock(&smd_store);
-
-	/* return pool count along with the pool list */
-	*pools = pool_cnt;
-
 	return rc;
 }
 
 /* smd_lock() and smd_tx_begin() are called by caller */
 int
-smd_replace_blobs(struct smd_pool_info *info, uint32_t tgt_cnt, int *tgts)
+smd_pool_replace_blobs_locked(struct smd_pool_info *info, int tgt_cnt,
+			      uint32_t *tgts)
 {
-	struct smd_pool_entry	entry = { 0 };
-	struct d_uuid		key_pool;
-	d_iov_t			key, val;
-	int			tgt_id, tgt_idx;
+	struct smd_pool		pool;
+	struct d_uuid		id;
 	int			i, rc;
 
-	D_ASSERT(daos_handle_is_valid(smd_store.ss_pool_hdl));
-
-	uuid_copy(key_pool.uuid, info->spi_id);
-
-	d_iov_set(&key, &key_pool, sizeof(key_pool));
-	d_iov_set(&val, &entry, sizeof(entry));
-	rc = dbtree_fetch(smd_store.ss_pool_hdl, BTR_PROBE_EQ,
-			  DAOS_INTENT_DEFAULT, &key, NULL, &val);
+	uuid_copy(id.uuid, info->spi_id);
+	rc = smd_db_fetch(TABLE_POOL, &id, sizeof(id), &pool, sizeof(pool));
 	if (rc) {
 		D_ERROR("Fetch pool "DF_UUID" failed. %d\n",
-			DP_UUID(&key_pool.uuid), rc);
+			DP_UUID(&id.uuid), rc);
 		return rc;
 	}
 
-	D_ASSERT(info->spi_blob_sz == entry.spe_blob_sz);
-	D_ASSERT(info->spi_tgt_cnt == entry.spe_tgt_cnt);
-	D_ASSERT(entry.spe_tgt_cnt >= tgt_cnt);
+	D_ASSERT(info->spi_blob_sz == pool.sp_blob_sz);
+	D_ASSERT(info->spi_tgt_cnt == pool.sp_tgt_cnt);
+	D_ASSERT(pool.sp_tgt_cnt >= tgt_cnt);
 
 	for (i = 0; i < tgt_cnt; i++) {
+		int	tgt_id;
+		int	tgt_idx;
+
 		tgt_id = tgts[i];
-		tgt_idx = get_tgt_idx(&entry, tgt_id);
-		if (tgt_idx == -1) {
+		tgt_idx = smd_pool_find_tgt(&pool, tgt_id);
+		if (tgt_idx < 0) {
 			D_ERROR("Invalid tgt %d for pool "DF_UUID"\n",
-				tgt_id, DP_UUID(&key_pool.uuid));
+				tgt_id, DP_UUID(&id.uuid));
 			return -DER_INVAL;
 		}
-
-		entry.spe_blobs[tgt_idx] = info->spi_blobs[tgt_idx];
+		pool.sp_blobs[tgt_idx] = info->spi_blobs[tgt_idx];
 	}
 
-	rc = dbtree_update(smd_store.ss_pool_hdl, &key, &val);
-	if (rc)
+	rc = smd_db_upsert(TABLE_POOL, &id, sizeof(id), &pool, sizeof(pool));
+	if (rc) {
 		D_ERROR("Replace blobs for pool "DF_UUID" failed. "DF_RC"\n",
-			DP_UUID(&key_pool.uuid), DP_RC(rc));
-
+			DP_UUID(&id.uuid), DP_RC(rc));
+	}
 	return rc;
 }

--- a/src/bio/smd/smd_store.c
+++ b/src/bio/smd/smd_store.c
@@ -15,351 +15,93 @@
 #include <daos/btree_class.h>
 #include "smd_internal.h"
 
-struct smd_store	smd_store;
+static struct sys_db	*smd_db;
 
-#define SMD_STORE_DIR	"daos-srv_meta"
-#define	SMD_STORE_FILE	"nvme-meta"
-
-static int
-smd_store_gen_fname(const char *path, char **store_fname)
+int
+smd_db_fetch(char *table, void *key, int key_size, void *val, int val_size)
 {
-	D_ASSERT(path != NULL);
-	D_ASSERT(store_fname != NULL);
+	d_iov_t	key_iov;
+	d_iov_t	val_iov;
 
-	D_ASPRINTF(*store_fname, "%s/%s/%s", path, SMD_STORE_DIR,
-		   SMD_STORE_FILE);
-	if (!*store_fname) {
-		return -DER_NOMEM;
-	}
+	d_iov_set(&key_iov, key, key_size);
+	d_iov_set(&val_iov, val, val_size);
 
-	return 0;
+	return smd_db->sd_fetch(smd_db, table, &key_iov, &val_iov);
 }
 
 int
-smd_store_destroy(const char *path)
+smd_db_upsert(char *table, void *key, int key_size, void *val, int val_size)
 {
-	char	*fname;
-	int	 rc;
+	d_iov_t	key_iov;
+	d_iov_t	val_iov;
 
-	rc = smd_store_gen_fname(path, &fname);
-	if (rc)
-		return rc;
+	d_iov_set(&key_iov, key, key_size);
+	d_iov_set(&val_iov, val, val_size);
 
-	rc = unlink(fname);
-	if (rc < 0 && errno != ENOENT) {
-		D_ERROR("Unlink SMD store file %s failed. %s\n",
-			fname, strerror(errno));
-		rc = daos_errno2der(errno);
-		goto out;
-	}
-
-	rc = rmdir(dirname(fname));
-	if (rc < 0 && errno != ENOENT) {
-		D_ERROR("Unlink SMD store dir %s failed. %s\n",
-			fname, strerror(errno));
-		rc = daos_errno2der(errno);
-		goto out;
-	}
-	rc = 0;
-out:
-	D_FREE(fname);
-	return rc;
+	return smd_db->sd_upsert(smd_db, table, &key_iov, &val_iov);
 }
 
-static int
-smd_store_check(char *fname, bool *existing)
+int
+smd_db_delete(char *table, void *key, int key_size)
 {
-	int	rc;
+	d_iov_t	key_iov;
 
-	*existing = false;
-	rc = access(fname, R_OK | W_OK);
-	if (rc && errno == ENOENT)
-		rc = 0;
-	else if (rc)
-		rc = daos_errno2der(errno);
+	d_iov_set(&key_iov, key, key_size);
+	return smd_db->sd_delete(smd_db, table, &key_iov);
+}
+
+int
+smd_db_traverse(char *table, sys_db_trav_cb_t cb, struct smd_trav_data *td)
+{
+	return smd_db->sd_traverse(smd_db, table, cb, td);
+}
+
+int
+smd_db_tx_begin(void)
+{
+	if (smd_db->sd_tx_begin)
+		return smd_db->sd_tx_begin(smd_db);
 	else
-		*existing = true;
-
-	return rc;
+		return 0;
 }
 
-#define SMD_FILE_SIZE	(128UL << 20)	/* 128MB */
-#define SMD_TREE_ODR	32
-
-static int
-smd_store_create(char *fname)
+int
+smd_db_tx_end(int rc)
 {
-	struct umem_attr	 uma = {0};
-	struct umem_instance	 umm = {0};
-	char			*dir;
-	struct smd_df		*smd_df;
-	PMEMobjpool		*ph;
-	daos_handle_t		 btr_hdl;
-	int			 fd, rc;
-
-	dir = strdup(fname);
-	if (dir == NULL)
-		return -DER_NOMEM;
-	dir = dirname(dir);
-
-	rc = mkdir(dir, 0700);
-	if (rc < 0 && errno != EEXIST) {
-		D_ERROR("Create SMD dir %s failed. %s\n",
-			dir, strerror(errno));
-		free(dir);
-		return daos_errno2der(errno);
-	}
-	free(dir);
-
-	fd = open(fname, O_WRONLY | O_CREAT, 0600);
-	if (fd < 0) {
-		D_ERROR("Create SMD file %s failed. %s\n",
-			fname, strerror(errno));
-		return daos_errno2der(errno);
-	}
-
-	rc = fallocate(fd, 0, 0, SMD_FILE_SIZE);
-	if (rc) {
-		D_ERROR("Pre-alloc SMD file size:"DF_U64" failed. %s\n",
-			SMD_FILE_SIZE, strerror(errno));
-		rc = daos_errno2der(errno);
-		close(fd);
-		return rc;
-	}
-	close(fd);
-
-	ph = pmemobj_create(fname, POBJ_LAYOUT_NAME(smd_md_layout), 0, 0600);
-	if (!ph) {
-		D_ERROR("Create SMD pmemobj pool %s failed. %s\n",
-			fname, pmemobj_errormsg());
-		return -DER_INVAL;
-	}
-
-	smd_df = smd_pop2df(ph);
-	uma.uma_id = UMEM_CLASS_PMEM;
-	uma.uma_pool = ph;
-
-	rc = umem_class_init(&uma, &umm);
-	if (rc != 0)
-		goto close;
-
-	rc = umem_tx_begin(&umm, NULL);
-	if (rc != 0)
-		goto close;
-
-	rc = pmemobj_tx_add_range_direct(smd_df, sizeof(*smd_df));
-	if (rc != 0)
-		goto tx_end;
-
-	memset(smd_df, 0, sizeof(*smd_df));
-	smd_df->smd_magic = SMD_DF_MAGIC;
-	if (DAOS_FAIL_CHECK(FLC_SMD_DF_VER))
-		smd_df->smd_version = 0;
+	if (smd_db->sd_tx_end)
+		return smd_db->sd_tx_end(smd_db, rc);
 	else
-		smd_df->smd_version = SMD_DF_VERSION;
-
-	/* Create device table */
-	rc = dbtree_create_inplace(DBTREE_CLASS_UV, 0, SMD_TREE_ODR, &uma,
-				   &smd_df->smd_dev_tab, &btr_hdl);
-	if (rc) {
-		D_ERROR("Create SMD device table failed: "DF_RC"\n", DP_RC(rc));
-		goto tx_end;
-	}
-	dbtree_close(btr_hdl);
-
-	/* Create pool table */
-	rc = dbtree_create_inplace(DBTREE_CLASS_UV, 0, SMD_TREE_ODR, &uma,
-				   &smd_df->smd_pool_tab, &btr_hdl);
-	if (rc) {
-		D_ERROR("Create SMD pool table failed: "DF_RC"\n", DP_RC(rc));
-		goto tx_end;
-	}
-	dbtree_close(btr_hdl);
-
-	/* Create target table */
-	rc = dbtree_create_inplace(DBTREE_CLASS_KV, 0, SMD_TREE_ODR, &uma,
-				   &smd_df->smd_tgt_tab, &btr_hdl);
-	if (rc) {
-		D_ERROR("Create SMD target table failed: "DF_RC"\n", DP_RC(rc));
-		goto tx_end;
-	}
-	dbtree_close(btr_hdl);
-
-tx_end:
-	if (rc == 0)
-		rc = umem_tx_commit(&umm);
-	else
-		rc = umem_tx_abort(&umm, rc);
-close:
-	pmemobj_close(ph);
-	return rc;
-}
-
-static void
-smd_store_close(void)
-{
-	if (daos_handle_is_valid(smd_store.ss_dev_hdl)) {
-		dbtree_close(smd_store.ss_dev_hdl);
-		smd_store.ss_dev_hdl = DAOS_HDL_INVAL;
-	}
-
-	if (daos_handle_is_valid(smd_store.ss_pool_hdl)) {
-		dbtree_close(smd_store.ss_pool_hdl);
-		smd_store.ss_pool_hdl = DAOS_HDL_INVAL;
-	}
-
-	if (daos_handle_is_valid(smd_store.ss_tgt_hdl)) {
-		dbtree_close(smd_store.ss_tgt_hdl);
-		smd_store.ss_tgt_hdl = DAOS_HDL_INVAL;
-	}
-
-	if (smd_store.ss_umm.umm_pool != NULL) {
-		pmemobj_close(smd_store.ss_umm.umm_pool);
-		smd_store.ss_umm.umm_pool = NULL;
-	}
-}
-
-static int
-smd_store_open(char *fname)
-{
-	struct umem_attr	 uma = {0};
-	struct smd_df		*smd_df;
-	PMEMobjpool		*ph;
-	int			 rc;
-
-	ph = pmemobj_open(fname, POBJ_LAYOUT_NAME(smd_md_layout));
-	if (ph == NULL) {
-		D_ERROR("Open SMD pmemobj pool %s failed: %s\n",
-			fname, pmemobj_errormsg());
-		return -DER_INVAL;
-	}
-
-	uma.uma_id = UMEM_CLASS_PMEM;
-	uma.uma_pool = ph;
-
-	rc = umem_class_init(&uma, &smd_store.ss_umm);
-	if (rc != 0) {
-		pmemobj_close(ph);
-		smd_store.ss_umm.umm_pool = NULL;
 		return rc;
-	}
+}
 
-	smd_df = smd_pop2df(ph);
-	if (smd_df->smd_magic != SMD_DF_MAGIC) {
-		D_CRIT("Unknown DF magic %x\n", smd_df->smd_magic);
-		rc = -DER_DF_INVAL;
-		goto error;
-	}
+void
+smd_db_lock(void)
+{
+	if (smd_db->sd_lock)
+		smd_db->sd_lock(smd_db);
+}
 
-	if (smd_df->smd_version > SMD_DF_VERSION ||
-	    smd_df->smd_version < SMD_DF_VER_1) {
-		D_CRIT("Unsupported DF version %d.  Supported range: %d-%d\n",
-		       smd_df->smd_version, SMD_DF_VER_1, SMD_DF_VERSION);
-		rc = -DER_DF_INCOMPT;
-		goto error;
-	}
-
-	/* Open device table */
-	rc = dbtree_open_inplace(&smd_df->smd_dev_tab, &uma,
-				 &smd_store.ss_dev_hdl);
-	if (rc) {
-		D_ERROR("Open SMD device table failed: "DF_RC"\n", DP_RC(rc));
-		goto error;
-	}
-
-	/* Open pool table */
-	rc = dbtree_open_inplace(&smd_df->smd_pool_tab, &uma,
-				 &smd_store.ss_pool_hdl);
-	if (rc) {
-		D_ERROR("Open SMD pool table failed: "DF_RC"\n", DP_RC(rc));
-		goto error;
-	}
-
-	/* Open target table */
-	rc = dbtree_open_inplace(&smd_df->smd_tgt_tab, &uma,
-				 &smd_store.ss_tgt_hdl);
-	if (rc) {
-		D_ERROR("Open SMD target table failed: "DF_RC"\n", DP_RC(rc));
-		goto error;
-	}
-
-	return 0;
-error:
-	smd_store_close();
-	return rc;
+void
+smd_db_unlock(void)
+{
+	if (smd_db->sd_unlock)
+		smd_db->sd_unlock(smd_db);
 }
 
 void
 smd_fini(void)
 {
-	smd_lock(&smd_store);
-	smd_store_close();
-	smd_unlock(&smd_store);
-	ABT_mutex_free(&smd_store.ss_mutex);
+	smd_db = NULL;
 }
 
 int
-smd_init(const char *path)
+smd_init(struct sys_db *db)
 {
-	char	*fname;
-	bool	 existing;
-	int	 rc;
+	D_ASSERT(db->sd_fetch);
+	D_ASSERT(db->sd_upsert);
+	D_ASSERT(db->sd_delete);
+	D_ASSERT(db->sd_traverse);
 
-	rc = dbtree_class_register(DBTREE_CLASS_KV, 0, &dbtree_kv_ops);
-	if (rc != 0 && rc != -DER_EXIST)
-		return rc;
-
-	rc = dbtree_class_register(DBTREE_CLASS_UV, 0, &dbtree_uv_ops);
-	if (rc != 0 && rc != -DER_EXIST)
-		return rc;
-
-	rc = smd_store_gen_fname(path, &fname);
-	if (rc)
-		return rc;
-
-	memset(&smd_store, 0, sizeof(smd_store));
-	smd_store.ss_dev_hdl = DAOS_HDL_INVAL;
-	smd_store.ss_pool_hdl = DAOS_HDL_INVAL;
-	smd_store.ss_tgt_hdl = DAOS_HDL_INVAL;
-
-	rc = ABT_mutex_create(&smd_store.ss_mutex);
-	if (rc != ABT_SUCCESS) {
-		rc = -DER_NOMEM;
-		D_FREE(fname);
-		return rc;
-	}
-
-	smd_lock(&smd_store);
-
-	rc = smd_store_check(fname, &existing);
-	if (rc) {
-		D_ERROR("Check SMD store %s failed. "DF_RC"\n", fname,
-			DP_RC(rc));
-		goto out;
-	}
-
-	/* Create the SMD store if it's not existing */
-	if (!existing) {
-		rc = smd_store_create(fname);
-		if (rc) {
-			D_ERROR("Create SMD store failed. "DF_RC"\n",
-				DP_RC(rc));
-			goto out;
-		}
-	}
-
-	rc = smd_store_open(fname);
-	if (rc) {
-		D_ERROR("Open SMD store failed. "DF_RC"\n", DP_RC(rc));
-		goto out;
-	}
-
-	D_DEBUG(DB_MGMT, "SMD store initialized\n");
-out:
-	smd_unlock(&smd_store);
-	D_FREE(fname);
-
-	if (rc)
-		smd_fini();
-	return rc;
+	smd_db = db;
+	return 0;
 }

--- a/src/bio/smd/tests/smd_ut.c
+++ b/src/bio/smd/tests/smd_ut.c
@@ -18,6 +18,178 @@
 #include "../smd_internal.h"
 
 #define SMD_STORAGE_PATH	"/mnt/daos"
+#define DB_LIST_NR	3
+
+struct ut_db {
+	struct sys_db	ud_db;
+	d_list_t	ud_lists[DB_LIST_NR];
+};
+
+static struct ut_db	ut_db;
+
+struct ut_chain {
+	d_list_t	 uc_link;
+	void		*uc_key;
+	void		*uc_val;
+	int		 uc_key_size;
+	int		 uc_val_size;
+};
+
+d_list_t *
+db_name2list(struct sys_db *db, char *name)
+{
+	struct ut_db *ud = container_of(db, struct ut_db, ud_db);
+
+	if (!strcmp(name, TABLE_DEV))
+		return &ud->ud_lists[0];
+	if (!strcmp(name, TABLE_TGT))
+		return &ud->ud_lists[1];
+	if (!strcmp(name, TABLE_POOL))
+		return &ud->ud_lists[2];
+
+	D_ASSERT(0);
+	return NULL;
+}
+
+struct ut_chain *
+db_chain_alloc(int key_size, int val_size)
+{
+	struct ut_chain	*chain;
+
+	chain = calloc(1, sizeof(*chain));
+	D_ASSERT(chain);
+	chain->uc_key_size = key_size;
+	chain->uc_key = calloc(1, key_size);
+	D_ASSERT(chain->uc_key);
+
+	chain->uc_val_size = val_size;
+	chain->uc_val = calloc(1, val_size);
+	D_ASSERT(chain->uc_val);
+
+	return chain;
+}
+
+void
+db_chain_free(struct ut_chain *chain)
+{
+	if (chain->uc_key)
+		free(chain->uc_key);
+	if (chain->uc_val)
+		free(chain->uc_val);
+	free(chain);
+}
+
+struct ut_chain *
+db_find(d_list_t *head, d_iov_t *key)
+{
+	struct ut_chain *chain;
+
+	d_list_for_each_entry(chain, head, uc_link) {
+		D_ASSERT(key->iov_len == chain->uc_key_size);
+		if (!memcmp(key->iov_buf, chain->uc_key, chain->uc_key_size))
+			return chain;
+	}
+	return NULL;
+}
+
+static int
+db_fetch(struct sys_db *db, char *table, d_iov_t *key, d_iov_t *val)
+{
+	d_list_t	*head = db_name2list(db, table);
+	struct ut_chain *chain;
+
+	chain = db_find(head, key);
+	if (chain) {
+		memcpy(val->iov_buf, chain->uc_val, chain->uc_val_size);
+		val->iov_len = chain->uc_val_size;
+		return 0;
+	}
+	val->iov_len = 0;
+	return -DER_NONEXIST;
+}
+
+static int
+db_upsert(struct sys_db *db, char *table, d_iov_t *key, d_iov_t *val)
+{
+	d_list_t	*head = db_name2list(db, table);
+	struct ut_chain *chain;
+
+	chain = db_find(head, key);
+	if (chain) {
+		D_ASSERT(val->iov_len == chain->uc_val_size);
+		memcpy(chain->uc_val, val->iov_buf, val->iov_len);
+		return 0;
+	}
+	chain = db_chain_alloc(key->iov_len, val->iov_len);
+	D_ASSERT(chain);
+
+	memcpy(chain->uc_key, key->iov_buf, key->iov_len);
+	memcpy(chain->uc_val, val->iov_buf, val->iov_len);
+	d_list_add_tail(&chain->uc_link, head);
+	return 0;
+}
+
+static int
+db_delete(struct sys_db *db, char *table, d_iov_t *key)
+{
+	d_list_t	*head = db_name2list(db, table);
+	struct ut_chain *chain;
+
+	chain = db_find(head, key);
+	if (chain) {
+		d_list_del(&chain->uc_link);
+		db_chain_free(chain);
+		return 0;
+	}
+	return -DER_NONEXIST;
+}
+
+static int
+db_traverse(struct sys_db *db, char *table, sys_db_trav_cb_t cb, void *args)
+{
+	d_list_t	*head = db_name2list(db, table);
+	struct ut_chain *chain;
+
+	d_list_for_each_entry(chain, head, uc_link) {
+		d_iov_t		key;
+
+		d_iov_set(&key, chain->uc_key, chain->uc_key_size);
+		cb(db, table, &key, args);
+	}
+	return 0;
+}
+
+static int
+db_init(void)
+{
+	int	i;
+
+	ut_db.ud_db.sd_fetch	= db_fetch;
+	ut_db.ud_db.sd_upsert	= db_upsert;
+	ut_db.ud_db.sd_delete	= db_delete;
+	ut_db.ud_db.sd_traverse	= db_traverse;
+
+	for (i = 0; i < DB_LIST_NR; i++)
+		D_INIT_LIST_HEAD(&ut_db.ud_lists[i]);
+	return 0;
+}
+
+static void
+db_fini(void)
+{
+	int	i;
+
+	for (i = 0; i < DB_LIST_NR; i++) {
+		while (!d_list_empty(&ut_db.ud_lists[i])) {
+			struct ut_chain	*chain;
+
+			chain = d_list_entry(ut_db.ud_lists[i].next,
+					     struct ut_chain, uc_link);
+			d_list_del(&chain->uc_link);
+			db_chain_free(chain);
+		}
+	}
+}
 
 uuid_t	dev_id1;
 uuid_t	dev_id2;
@@ -32,8 +204,9 @@ smd_ut_setup(void **state)
 		print_error("Error initializing the debug instance\n");
 		return rc;
 	}
+	db_init();
 
-	rc = smd_init(SMD_STORAGE_PATH);
+	rc = smd_init(&ut_db.ud_db);
 	if (rc) {
 		print_error("Error initializing SMD store: %d\n", rc);
 		daos_debug_fini();
@@ -47,7 +220,7 @@ static int
 smd_ut_teardown(void **state)
 {
 	smd_fini();
-	smd_store_destroy(SMD_STORAGE_PATH);
+	db_fini();
 	daos_debug_fini();
 	return 0;
 }
@@ -83,21 +256,21 @@ ut_device(void **state)
 	uuid_generate(id3);
 
 	/* Assigned dev1 to target 0, 1, 2, dev2 to target 3 */
-	rc = smd_dev_assign(dev_id1, 0);
+	rc = smd_dev_add_tgt(dev_id1, 0);
 	assert_int_equal(rc, 0);
 
-	rc = smd_dev_assign(dev_id1, 0);
+	rc = smd_dev_add_tgt(dev_id1, 0);
 	assert_int_equal(rc, -DER_EXIST);
 
 	for (i = 1; i < 3; i++) {
-		rc = smd_dev_assign(dev_id1, i);
+		rc = smd_dev_add_tgt(dev_id1, i);
 		assert_int_equal(rc, 0);
 	}
 
-	rc = smd_dev_assign(dev_id2, 1);
+	rc = smd_dev_add_tgt(dev_id2, 1);
 	assert_int_equal(rc, -DER_EXIST);
 
-	rc = smd_dev_assign(dev_id2, 3);
+	rc = smd_dev_add_tgt(dev_id2, 3);
 	assert_int_equal(rc, 0);
 
 	rc = smd_dev_set_state(dev_id2, SMD_DEV_FAULTY);
@@ -110,7 +283,7 @@ ut_device(void **state)
 	assert_int_equal(rc, 0);
 	verify_dev(dev_info, dev_id1, 1);
 
-	smd_free_dev_info(dev_info);
+	smd_dev_free_info(dev_info);
 
 	rc = smd_dev_get_by_tgt(4, &dev_info);
 	assert_int_equal(rc, -DER_NONEXIST);
@@ -119,7 +292,7 @@ ut_device(void **state)
 	assert_int_equal(rc, 0);
 	verify_dev(dev_info, dev_id2, 2);
 
-	smd_free_dev_info(dev_info);
+	smd_dev_free_info(dev_info);
 
 	D_INIT_LIST_HEAD(&dev_list);
 	rc = smd_dev_list(&dev_list, &dev_cnt);
@@ -135,7 +308,7 @@ ut_device(void **state)
 			assert_true(false);
 
 		d_list_del(&dev_info->sdi_link);
-		smd_free_dev_info(dev_info);
+		smd_dev_free_info(dev_info);
 	}
 }
 
@@ -167,26 +340,26 @@ ut_pool(void **state)
 	uuid_generate(id3);
 
 	for (i = 0; i < 4; i++) {
-		rc = smd_pool_assign(id1, i, i << 10, 100);
+		rc = smd_pool_add_tgt(id1, i, i << 10, 100);
 		assert_int_equal(rc, 0);
 
-		rc = smd_pool_assign(id2, i, i << 20, 200);
+		rc = smd_pool_add_tgt(id2, i, i << 20, 200);
 		assert_int_equal(rc, 0);
 	}
 
-	rc = smd_pool_assign(id1, 0, 5000, 100);
+	rc = smd_pool_add_tgt(id1, 0, 5000, 100);
 	assert_int_equal(rc, -DER_EXIST);
 
-	rc = smd_pool_assign(id1, 4, 4 << 10, 200);
+	rc = smd_pool_add_tgt(id1, 4, 4 << 10, 200);
 	assert_int_equal(rc, -DER_INVAL);
 
-	rc = smd_pool_get(id1, &pool_info);
+	rc = smd_pool_get_info(id1, &pool_info);
 	assert_int_equal(rc, 0);
 	verify_pool(pool_info, id1, 10);
 
-	smd_free_pool_info(pool_info);
+	smd_pool_free_info(pool_info);
 
-	rc = smd_pool_get(id3, &pool_info);
+	rc = smd_pool_get_info(id3, &pool_info);
 	assert_int_equal(rc, -DER_NONEXIST);
 
 	for (i = 0; i < 4; i++) {
@@ -216,21 +389,21 @@ ut_pool(void **state)
 			assert_true(false);
 
 		d_list_del(&pool_info->spi_link);
-		smd_free_pool_info(pool_info);
+		smd_pool_free_info(pool_info);
 	}
 
-	rc = smd_pool_unassign(id1, 5);
+	rc = smd_pool_del_tgt(id1, 5);
 	assert_int_equal(rc, -DER_NONEXIST);
 
 	for (i = 0; i < 4; i++) {
-		rc = smd_pool_unassign(id1, i);
+		rc = smd_pool_del_tgt(id1, i);
 		assert_int_equal(rc, 0);
 
-		rc = smd_pool_unassign(id2, i);
+		rc = smd_pool_del_tgt(id2, i);
 		assert_int_equal(rc, 0);
 	}
 
-	rc = smd_pool_get(id1, &pool_info);
+	rc = smd_pool_get_info(id1, &pool_info);
 	assert_int_equal(rc, -DER_NONEXIST);
 }
 
@@ -250,10 +423,10 @@ ut_dev_replace(void **state)
 
 	/* Assign pools, they were unassigned in prior pool test */
 	for (i = 0; i < 4; i++) {
-		rc = smd_pool_assign(pool_id1, i, i << 10, 100);
+		rc = smd_pool_add_tgt(pool_id1, i, i << 10, 100);
 		assert_int_equal(rc, 0);
 
-		rc = smd_pool_assign(pool_id2, i, i << 20, 200);
+		rc = smd_pool_add_tgt(pool_id2, i, i << 20, 200);
 		assert_int_equal(rc, 0);
 	}
 
@@ -299,7 +472,7 @@ ut_dev_replace(void **state)
 			assert_true(false);
 
 		d_list_del(&dev_info->sdi_link);
-		smd_free_dev_info(dev_info);
+		smd_dev_free_info(dev_info);
 	}
 
 	/* Verify blob IDs after device replace */
@@ -315,7 +488,7 @@ ut_dev_replace(void **state)
 				assert_int_equal(blob_id, 777);
 		}
 		d_list_del(&pool_info->spi_link);
-		smd_free_pool_info(pool_info);
+		smd_pool_free_info(pool_info);
 	}
 }
 
@@ -334,7 +507,6 @@ int main(int argc, char **argv)
 		D_PRINT("Error initializing ABT\n");
 		return rc;
 	}
-
 
 	rc = cmocka_run_group_tests_name("SMD unit tests", smd_uts,
 					 smd_ut_setup, smd_ut_teardown);

--- a/src/common/dts.c
+++ b/src/common/dts.c
@@ -357,7 +357,7 @@ dts_ctx_init(struct dts_context *tsc)
 	tsc->tsc_init = DTS_INIT_DEBUG;
 
 	if (tsc->tsc_pmem_file) /* VOS mode */
-		rc = vos_init();
+		rc = vos_self_init("/mnt/daos");
 	else
 		rc = daos_init();
 	if (rc)
@@ -404,7 +404,7 @@ dts_ctx_fini(struct dts_context *tsc)
 		/* fall through */
 	case DTS_INIT_MODULE:	/* finalize module */
 		if (tsc->tsc_pmem_file)
-			vos_fini();
+			vos_self_fini();
 		else
 			daos_fini();
 		/* fall through */

--- a/src/include/daos_errno.h
+++ b/src/include/daos_errno.h
@@ -246,9 +246,7 @@ extern "C" {
 	       Agent is incompatible with libdaos)			\
 	/** Multiple shards locate on the same target */		\
 	ACTION(DER_SHARDS_OVERLAP,	(DER_ERR_DAOS_BASE + 30),	\
-	       Shards overlap)						\
-	ACTION(DER_DF_IMCOMPAT,		(DER_ERR_DAOS_BASE + 31),	\
-	       Incompatible durable format)
+	       Shards overlap)
 
 /** Defines the gurt error codes */
 #define D_FOREACH_ERR_RANGE(ACTION)	\

--- a/src/include/daos_errno.h
+++ b/src/include/daos_errno.h
@@ -246,7 +246,9 @@ extern "C" {
 	       Agent is incompatible with libdaos)			\
 	/** Multiple shards locate on the same target */		\
 	ACTION(DER_SHARDS_OVERLAP,	(DER_ERR_DAOS_BASE + 30),	\
-	       Shards overlap)
+	       Shards overlap)						\
+	ACTION(DER_DF_IMCOMPAT,		(DER_ERR_DAOS_BASE + 31),	\
+	       Incompatible durable format)
 
 /** Defines the gurt error codes */
 #define D_FOREACH_ERR_RANGE(ACTION)	\

--- a/src/include/daos_srv/bio.h
+++ b/src/include/daos_srv/bio.h
@@ -31,6 +31,8 @@ typedef struct {
 	uint16_t	ba_padding;
 } bio_addr_t;
 
+struct sys_db;
+
 /** Ensure this remains compatible */
 D_CASSERT(sizeof(((bio_addr_t *)0)->ba_off) == sizeof(umem_off_t));
 
@@ -363,15 +365,15 @@ void bio_register_ract_ops(struct bio_reaction_ops *ops);
 /**
  * Global NVMe initialization.
  *
- * \param[IN] storage_path	daos storage directory path
  * \param[IN] nvme_conf		NVMe config file
  * \param[IN] shm_id		shm id to enable multiprocess mode in SPDK
  * \param[IN] mem_size		SPDK memory alloc size when using primary mode
+ * \param[IN] db		persistent database to store SMD data
  *
  * \return		Zero on success, negative value on error
  */
-int bio_nvme_init(const char *storage_path, const char *nvme_conf, int shm_id,
-		  int mem_size);
+int bio_nvme_init(const char *nvme_conf, int shm_id, int mem_size,
+		  struct sys_db *db);
 
 /**
  * Global NVMe finilization.

--- a/src/include/daos_srv/daos_server.h
+++ b/src/include/daos_srv/daos_server.h
@@ -816,4 +816,37 @@ ds_get_pool_svc_ranks(uuid_t pool_uuid, d_rank_list_t **svc_ranks);
 
 bool is_container_from_srv(uuid_t pool_uuid, uuid_t coh_uuid);
 bool is_pool_from_srv(uuid_t pool_uuid, uuid_t poh_uuid);
+
+struct sys_db;
+typedef int (*sys_db_trav_cb_t)(struct sys_db *db, char *table, d_iov_t *key,
+				void *args);
+
+#define SYS_DB_NAME_SZ		32
+
+/** system database is a simple local KV store */
+struct sys_db {
+	char	 sd_name[SYS_DB_NAME_SZ];
+	/** look up the provided key in \a table and return its value */
+	int	(*sd_fetch)(struct sys_db *db, char *table,
+			    d_iov_t *key, d_iov_t *val);
+	/** update or insert a KV pair to \a table */
+	int	(*sd_upsert)(struct sys_db *db, char *table,
+			     d_iov_t *key, d_iov_t *val);
+	/** reserved */
+	int	(*sd_insert)(struct sys_db *db, char *table,
+			     d_iov_t *key, d_iov_t *val);
+	/** reserved */
+	int	(*sd_update)(struct sys_db *db, char *table,
+			     d_iov_t *key, d_iov_t *val);
+	/** delete provided key and its value from the \a table */
+	int	(*sd_delete)(struct sys_db *db, char *table, d_iov_t *key);
+	/** traverse all keys in the \a table */
+	int	(*sd_traverse)(struct sys_db *db, char *table,
+			       sys_db_trav_cb_t cb, void *args);
+	int	(*sd_tx_begin)(struct sys_db *db);
+	int	(*sd_tx_end)(struct sys_db *db, int rc);
+	void	(*sd_lock)(struct sys_db *db);
+	void	(*sd_unlock)(struct sys_db *db);
+};
+
 #endif /* __DSS_API_H__ */

--- a/src/include/daos_srv/smd.h
+++ b/src/include/daos_srv/smd.h
@@ -13,6 +13,9 @@
 #include <uuid/uuid.h>
 #include <gurt/common.h>
 #include <gurt/list.h>
+#include <daos/common.h>
+#include <daos_types.h>
+#include <daos_srv/daos_server.h>
 
 enum smd_dev_state {
 	SMD_DEV_NORMAL	= 0,
@@ -36,44 +39,19 @@ struct smd_pool_info {
 	uint64_t	*spi_blobs;
 };
 
-static inline void
-smd_free_dev_info(struct smd_dev_info *dev_info)
-{
-	if (dev_info->sdi_tgts != NULL)
-		D_FREE(dev_info->sdi_tgts);
-	D_FREE(dev_info);
-}
-
-static inline void
-smd_free_pool_info(struct smd_pool_info *pool_info)
-{
-	if (pool_info->spi_tgts != NULL)
-		D_FREE(pool_info->spi_tgts);
-	if (pool_info->spi_blobs != NULL)
-		D_FREE(pool_info->spi_blobs);
-	D_FREE(pool_info);
-}
-
 /**
  * Initialize SMD store, create store if it's not existing
  *
- * \param [IN]	path	Path of SMD store
+ * \param [IN]	db	system database
  *
  * \return		Zero on success, negative value on error
  */
-int smd_init(const char *path);
+int smd_init(struct sys_db *db);
 
 /**
  * Finalize SMD store
  */
 void smd_fini(void);
-
-/**
- * Destroy SMD store
- *
- * \param [IN]	path	Path of SMD store
- */
-int smd_store_destroy(const char *path);
 
 /**
  * Assign a NVMe device to a target (VOS xstream)
@@ -83,7 +61,7 @@ int smd_store_destroy(const char *path);
  *
  * \return		Zero on success, negative value on error
  */
-int smd_dev_assign(uuid_t dev_id, int tgt_id);
+int smd_dev_add_tgt(uuid_t dev_id, uint32_t tgt_id);
 
 /**
  * Unassign a NVMe device from a target (VOS xstream)
@@ -93,7 +71,7 @@ int smd_dev_assign(uuid_t dev_id, int tgt_id);
  *
  * \return		Zero on success, negative value on error
  */
-int smd_dev_unassign(uuid_t dev_id, int tgt_id);
+int smd_dev_del_tgt(uuid_t dev_id, uint32_t tgt_id);
 
 /**
  * Set a NVMe device state
@@ -123,7 +101,7 @@ int smd_dev_get_by_id(uuid_t dev_id, struct smd_dev_info **dev_info);
  *
  * \return			Zero on success, negative value on error
  */
-int smd_dev_get_by_tgt(int tgt_id, struct smd_dev_info **dev_info);
+int smd_dev_get_by_tgt(uint32_t tgt_id, struct smd_dev_info **dev_info);
 
 /**
  * List all NVMe devices, caller is responsible to free list items
@@ -134,6 +112,13 @@ int smd_dev_get_by_tgt(int tgt_id, struct smd_dev_info **dev_info);
  * \return			Zero on success, negative value on error
  */
 int smd_dev_list(d_list_t *dev_list, int *dev_cnt);
+
+static inline void smd_dev_free_info(struct smd_dev_info *dev_info)
+{
+	if (dev_info->sdi_tgts != NULL)
+		D_FREE(dev_info->sdi_tgts);
+	D_FREE(dev_info);
+}
 
 /**
  * Replace an old device ID with new device ID, change it's state from
@@ -157,8 +142,8 @@ int smd_dev_replace(uuid_t old_id, uuid_t new_id, d_list_t *pool_list);
  *
  * \return			Zero on success, negative value on error
  */
-int smd_pool_assign(uuid_t pool_id, int tgt_id, uint64_t blob_id,
-		    uint64_t blob_sz);
+int smd_pool_add_tgt(uuid_t pool_id, uint32_t tgt_id, uint64_t blob_id,
+		     uint64_t blob_sz);
 
 /**
  * Unassign a VOS pool target
@@ -168,7 +153,7 @@ int smd_pool_assign(uuid_t pool_id, int tgt_id, uint64_t blob_id,
  *
  * \return			Zero on success, negative value on error
  */
-int smd_pool_unassign(uuid_t pool_id, int tgt_id);
+int smd_pool_del_tgt(uuid_t pool_id, uint32_t tgt_id);
 
 /**
  * Get pool info, caller is responsible to free @pool_info
@@ -178,7 +163,7 @@ int smd_pool_unassign(uuid_t pool_id, int tgt_id);
  *
  * \return			Zero on success, negative value on error
  */
-int smd_pool_get(uuid_t pool_id, struct smd_pool_info **pool_info);
+int smd_pool_get_info(uuid_t pool_id, struct smd_pool_info **pool_info);
 
 /**
  * Get blob ID mapped to pool:target
@@ -189,7 +174,7 @@ int smd_pool_get(uuid_t pool_id, struct smd_pool_info **pool_info);
  *
  * \return			Zero on success, negative value on error
  */
-int smd_pool_get_blob(uuid_t pool_id, int tgt_id, uint64_t *blob_id);
+int smd_pool_get_blob(uuid_t pool_id, uint32_t tgt_id, uint64_t *blob_id);
 
 /**
  * Get pool info, caller is responsible to free list items
@@ -208,6 +193,16 @@ int smd_pool_list(d_list_t *pool_list, int *pool_cnt);
  *
  * \return			Static string representing enum value
  */
-char *smd_state_enum_to_str(enum smd_dev_state state);
+char *smd_dev_stat2str(enum smd_dev_state state);
+
+static inline void
+smd_pool_free_info(struct smd_pool_info *pool_info)
+{
+	if (pool_info->spi_blobs != NULL)
+		D_FREE(pool_info->spi_blobs);
+	if (pool_info->spi_tgts != NULL)
+		D_FREE(pool_info->spi_tgts);
+	D_FREE(pool_info);
+}
 
 #endif /* __SMD_H__ */

--- a/src/iosrv/srv.c
+++ b/src/iosrv/srv.c
@@ -115,6 +115,7 @@ struct dss_xstream_data {
 	/** barrier for all ULTs to enter handling loop */
 	ABT_cond		  xd_ult_barrier;
 	ABT_mutex		  xd_mutex;
+	struct dss_thread_local_storage *xd_dtc;
 };
 
 static struct dss_xstream_data	xstream_data;
@@ -746,11 +747,6 @@ dss_xstreams_fini(bool force)
 	xstream_data.xd_xs_nr = 0;
 	dss_tgt_nr = 0;
 
-	/* release local storage */
-	rc = pthread_key_delete(dss_tls_key);
-	if (rc)
-		D_ERROR("failed to delete dtc: %d\n", rc);
-
 	D_DEBUG(DB_TRACE, "Execution streams stopped\n");
 }
 
@@ -841,22 +837,14 @@ dss_start_xs_id(int xs_id)
 static int
 dss_xstreams_init(void)
 {
-	int	rc;
+	int	rc = 0;
 	int	i, xs_id;
 
 	D_ASSERT(dss_tgt_nr >= 1);
 
-	/* initialize xstream-local storage */
-	rc = pthread_key_create(&dss_tls_key, NULL);
-	if (rc) {
-		D_ERROR("failed to create dtc: %d\n", rc);
-		return -DER_NOMEM;
-	}
-
 	/* start the execution streams */
 	D_DEBUG(DB_TRACE,
-		"%d cores total detected "
-		"starting %d main xstreams\n",
+		"%d cores total detected starting %d main xstreams\n",
 		dss_core_nr, dss_tgt_nr);
 
 	if (dss_numa_node != -1) {
@@ -912,9 +900,6 @@ dss_xstreams_init(void)
 	D_DEBUG(DB_TRACE, "%d execution streams successfully started "
 		"(first core %d)\n", dss_tgt_nr, dss_core_offset);
 out:
-	if (dss_xstreams_empty()) /* started nothing */
-		pthread_key_delete(dss_tls_key);
-
 	return rc;
 }
 
@@ -1057,6 +1042,9 @@ enum {
 	XD_INIT_MUTEX,
 	XD_INIT_ULT_INIT,
 	XD_INIT_ULT_BARRIER,
+	XD_INIT_TLS_REG,
+	XD_INIT_TLS_INIT,
+	XD_INIT_SYS_DB,
 	XD_INIT_NVME,
 	XD_INIT_XSTREAMS,
 	XD_INIT_DRPC,
@@ -1080,6 +1068,15 @@ dss_srv_fini(bool force)
 	case XD_INIT_NVME:
 		bio_nvme_fini();
 		/* fall through */
+	case XD_INIT_SYS_DB:
+		vos_db_fini();
+		/* fall through */
+	case XD_INIT_TLS_INIT:
+		dss_tls_fini(xstream_data.xd_dtc);
+		/* fall through */
+	case XD_INIT_TLS_REG:
+		pthread_key_delete(dss_tls_key);
+		/* fall through */
 	case XD_INIT_ULT_BARRIER:
 		ABT_cond_free(&xstream_data.xd_ult_barrier);
 		/* fall through */
@@ -1098,10 +1095,10 @@ dss_srv_fini(bool force)
 }
 
 int
-dss_srv_init()
+dss_srv_init(void)
 {
-	int	rc;
-	bool	started = true;
+	int		 rc;
+	bool		 started = true;
 
 	xstream_data.xd_init_step  = XD_INIT_NONE;
 	xstream_data.xd_ult_signal = false;
@@ -1132,8 +1129,27 @@ dss_srv_init()
 	}
 	xstream_data.xd_init_step = XD_INIT_ULT_BARRIER;
 
-	rc = bio_nvme_init(dss_storage_path, dss_nvme_conf, dss_nvme_shm_id,
-		dss_nvme_mem_size);
+	/* register xstream-local storage key */
+	rc = pthread_key_create(&dss_tls_key, NULL);
+	if (rc) {
+		rc = dss_abterr2der(rc);
+		D_GOTO(failed, rc);
+	}
+	xstream_data.xd_init_step = XD_INIT_TLS_REG;
+
+	/* initialize xstream-local storage */
+	xstream_data.xd_dtc = dss_tls_init(DAOS_SERVER_TAG);
+	if (!xstream_data.xd_dtc)
+		D_GOTO(failed, rc);
+	xstream_data.xd_init_step = XD_INIT_TLS_INIT;
+
+	rc = vos_db_init(dss_storage_path, NULL, false);
+	if (rc != 0)
+		D_GOTO(failed, rc);
+	xstream_data.xd_init_step = XD_INIT_SYS_DB;
+
+	rc = bio_nvme_init(dss_nvme_conf, dss_nvme_shm_id,
+			   dss_nvme_mem_size, vos_db_get());
 	if (rc != 0)
 		D_GOTO(failed, rc);
 	xstream_data.xd_init_step = XD_INIT_NVME;

--- a/src/mgmt/srv_query.c
+++ b/src/mgmt/srv_query.c
@@ -83,7 +83,7 @@ int ds_mgmt_get_bs_state(uuid_t bs_uuid, int *bs_state)
 	ABT_thread_free(&thread);
 
 out:
-	smd_free_dev_info(dev_info);
+	smd_dev_free_info(dev_info);
 	return rc;
 }
 
@@ -201,7 +201,7 @@ ds_mgmt_bio_health_query(struct mgmt_bio_health *mbh, uuid_t dev_uuid,
 	ABT_thread_free(&thread);
 
 out:
-	smd_free_dev_info(dev_info);
+	smd_dev_free_info(dev_info);
 	return rc;
 }
 
@@ -438,7 +438,7 @@ ds_mgmt_smd_list_pools(Ctl__SmdPoolResp *resp)
 
 		d_list_del(&pool_info->spi_link);
 		/* Frees spi_tgts, spi_blobs, and pool_info */
-		smd_free_pool_info(pool_info);
+		smd_pool_free_info(pool_info);
 		pool_info = NULL;
 
 		i++;
@@ -449,7 +449,7 @@ ds_mgmt_smd_list_pools(Ctl__SmdPoolResp *resp)
 		d_list_for_each_entry_safe(pool_info, tmp, &pool_list,
 					   spi_link) {
 			d_list_del(&pool_info->spi_link);
-			smd_free_pool_info(pool_info);
+			smd_pool_free_info(pool_info);
 		}
 		for (; i >= 0; i--) {
 			if (resp->pools[i] != NULL) {
@@ -502,7 +502,7 @@ ds_mgmt_dev_state_query(uuid_t dev_uuid, Ctl__DevStateResp *resp)
 		goto out;
 	}
 	strncpy(resp->dev_state,
-		smd_state_enum_to_str(dev_info->sdi_state), buflen);
+		smd_dev_stat2str(dev_info->sdi_state), buflen);
 
 	D_ALLOC(resp->dev_uuid, DAOS_UUID_STR_SIZE);
 	if (resp->dev_uuid == NULL) {
@@ -514,7 +514,7 @@ ds_mgmt_dev_state_query(uuid_t dev_uuid, Ctl__DevStateResp *resp)
 	uuid_unparse_lower(dev_uuid, resp->dev_uuid);
 
 out:
-	smd_free_dev_info(dev_info);
+	smd_dev_free_info(dev_info);
 
 	if (rc != 0) {
 		if (resp->dev_state != NULL)
@@ -657,9 +657,8 @@ ds_mgmt_dev_set_faulty(uuid_t dev_uuid, Ctl__DevStateResp *resp)
 
 out:
 	dev_info->sdi_state = SMD_DEV_FAULTY;
-	strncpy(resp->dev_state,
-		smd_state_enum_to_str(dev_info->sdi_state), buflen);
-	smd_free_dev_info(dev_info);
+	strncpy(resp->dev_state, smd_dev_stat2str(dev_info->sdi_state), buflen);
+	smd_dev_free_info(dev_info);
 
 	if (rc != 0) {
 		if (resp->dev_state != NULL)
@@ -744,7 +743,7 @@ ds_mgmt_dev_replace(uuid_t old_dev_uuid, uuid_t new_dev_uuid,
 	}
 
 	/* BIO device state after reintegration should be NORMAL */
-	strncpy(resp->dev_state, smd_state_enum_to_str(SMD_DEV_NORMAL),
+	strncpy(resp->dev_state, smd_dev_stat2str(SMD_DEV_NORMAL),
 		buflen);
 out:
 

--- a/src/pool/srv_util.c
+++ b/src/pool/srv_util.c
@@ -606,7 +606,7 @@ nvme_reaction(int *tgt_ids, int tgt_cnt, bool reint)
 		}
 
 		d_list_del(&pool_info->spi_link);
-		smd_free_pool_info(pool_info);
+		smd_pool_free_info(pool_info);
 	}
 
 	D_DEBUG(DB_MGMT, "Faulty reaction done. tgt_cnt:%d, rc:%d\n",

--- a/src/vos/SConscript
+++ b/src/vos/SConscript
@@ -7,7 +7,7 @@ FILES = ["evt_iter.c", "vos_common.c", "vos_iterator.c", "vos_io.c",
          "vos_obj_cache.c", "vos_obj_index.c", "vos_tree.c", "evtree.c",
          "vos_dtx.c", "vos_query.c", "vos_overhead.c",
          "vos_dtx_iter.c", "vos_gc.c", "vos_ilog.c", "ilog.c", "vos_ts.c",
-         "lru_array.c", "vos_space.c"]
+         "lru_array.c", "vos_space.c", "sys_db.c"]
 
 def build_vos(env, standalone):
     """build vos"""

--- a/src/vos/sys_db.c
+++ b/src/vos/sys_db.c
@@ -1,0 +1,432 @@
+/**
+ * (C) Copyright 2020 Intel Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * GOVERNMENT LICENSE RIGHTS-OPEN SOURCE SOFTWARE
+ * The Government's rights to use, modify, reproduce, release, perform, display,
+ * or disclose this software are subject to the terms of the Apache License as
+ * provided in Contract No. B609815.
+ * Any reproduction of computer software, computer software documentation, or
+ * portions thereof marked with this legend must also reproduce the markings.
+ */
+/**
+ * This file is part of daos
+ *
+ * vos/sys_db.c
+ */
+#define D_LOGFAC	DD_FAC(vos)
+
+#include <sys/stat.h>
+#include <daos_srv/vos.h>
+#include "vos_internal.h"
+
+/* Reserved system pool and container UUIDs
+ * TODO: check and reject pool/container creation with reserved IDs
+ */
+#define SYS_DB_POOL		"00000000-DA05-C001-CAFE-000020200101"
+#define SYS_DB_CONT		"00000000-DA05-C001-CAFE-000020191231"
+
+#define SYS_DB_DIR		"daos_sys"
+#define	SYS_DB_NAME		"sys_db"
+
+#define SYS_DB_MD		"metadata"
+#define SYS_DB_MD_VER		"version"
+
+#define SYS_DB_VERSION		1
+
+#define SYS_DB_SIZE		(128UL << 20)	/* 128MB */
+#define SYS_DB_EPC		1
+
+/** private information of VOS system DB (pool & container) */
+struct vos_sys_db {
+	/** exported part of VOS system DB */
+	struct sys_db		 db_pub;
+	char			*db_file;
+	char			*db_path;
+	struct umem_instance	*db_umm;
+	/* DB should be destroyed on exit */
+	bool			 db_vos_self;
+	ABT_mutex		 db_lock;
+	uuid_t			 db_pool;
+	uuid_t			 db_cont;
+	daos_handle_t		 db_poh;
+	daos_handle_t		 db_coh;
+	daos_unit_oid_t		 db_obj;
+};
+
+static struct vos_sys_db	vos_db;
+
+/** data structure for VOS I/O */
+struct sys_db_io {
+	d_iov_t			io_key;
+	daos_iod_t		io_iod;
+	d_sg_list_t		io_sgl;
+};
+
+static int
+db_upsert(struct sys_db *db, char *table, d_iov_t *key, d_iov_t *val);
+
+static int
+db_fetch(struct sys_db *db, char *table, d_iov_t *key, d_iov_t *val);
+
+struct vos_sys_db *
+db2vos(struct sys_db *db)
+{
+	return container_of(db, struct vos_sys_db, db_pub);
+}
+
+static void
+db_close(struct sys_db *db)
+{
+	struct vos_sys_db *vdb = db2vos(db);
+
+	if (!daos_handle_is_inval(vdb->db_coh)) {
+		vos_cont_close(vdb->db_coh);
+		vdb->db_coh = DAOS_HDL_INVAL;
+	}
+
+	if (!daos_handle_is_inval(vdb->db_poh)) {
+		vos_pool_close(vdb->db_poh);
+		vdb->db_poh = DAOS_HDL_INVAL;
+	}
+}
+
+static void
+db_unlink(struct sys_db *db)
+{
+	struct vos_sys_db *vdb = db2vos(db);
+
+	unlink(vdb->db_file); /* ignore error code */
+}
+
+/* open or create system DB stored in pmemfile */
+static int
+db_open_create(struct sys_db *db, bool try_create)
+{
+	struct vos_sys_db *vdb = db2vos(db);
+	d_iov_t		   key;
+	d_iov_t		   val;
+	uint32_t	   ver;
+	int		   rc;
+
+	if (try_create) {
+		rc = mkdir(vdb->db_path, 0777);
+		if (rc < 0 && errno != EEXIST) {
+			rc = daos_errno2der(errno);
+			goto failed;
+		}
+
+		rc = vos_pool_create(vdb->db_file, vdb->db_pool,
+				     SYS_DB_SIZE, 0);
+		if (rc) {
+			D_CRIT("sys pool create error: "DF_RC"\n", DP_RC(rc));
+			goto failed;
+		}
+	}
+	rc = vos_pool_open(vdb->db_file, vdb->db_pool, false, &vdb->db_poh);
+	if (rc) {
+		if (rc != -DER_NONEXIST || try_create)
+			D_CRIT("sys pool open error: "DF_RC"\n", DP_RC(rc));
+		goto failed;
+	}
+
+	if (try_create) {
+		rc = vos_cont_create(vdb->db_poh, vdb->db_cont);
+		if (rc) {
+			D_CRIT("sys cont create error: "DF_RC"\n", DP_RC(rc));
+			goto failed;
+		}
+	}
+	rc = vos_cont_open(vdb->db_poh, vdb->db_cont, &vdb->db_coh);
+	if (rc) {
+		D_CRIT("sys cont open error: "DF_RC"\n", DP_RC(rc));
+		goto failed;
+	}
+
+	vdb->db_umm = vos_pool2umm(vos_hdl2pool(vdb->db_poh));
+	d_iov_set(&key, SYS_DB_MD_VER, strlen(SYS_DB_MD_VER));
+	d_iov_set(&val, &ver, sizeof(ver));
+	if (try_create) {
+		ver = SYS_DB_VERSION;
+		rc = db_upsert(db, SYS_DB_MD, &key, &val);
+		if (rc) {
+			D_CRIT("Failed to set version for sysdb: "DF_RC"\n",
+			       DP_RC(rc));
+			goto failed;
+		}
+	} else {
+		rc = db_fetch(db, SYS_DB_MD, &key, &val);
+		if (rc) {
+			D_CRIT("Failed to read sysdb version: "DF_RC"\n",
+			       DP_RC(rc));
+			goto failed;
+		}
+
+		if (ver != SYS_DB_VERSION) {
+			D_CRIT("Incompatible sysdb version %d/%d\n",
+			       ver, SYS_DB_VERSION);
+			rc = -DER_DF_IMCOMPAT;
+			goto failed;
+		}
+	}
+	return 0;
+failed:
+	db_close(db);
+	return rc;
+}
+
+static void
+db_io_init(struct sys_db_io *io, char *table, d_iov_t *key, d_iov_t *val)
+{
+	memset(io, 0, sizeof(*io));
+
+	d_iov_set(&io->io_key, table, strlen(table));
+	io->io_iod.iod_type = DAOS_IOD_SINGLE;
+	io->io_iod.iod_name = *key;
+	io->io_iod.iod_nr   = 1;
+	if (val) {
+		io->io_iod.iod_size = val->iov_len;
+		io->io_sgl.sg_iovs  = val;
+		io->io_sgl.sg_nr    = 1;
+	}
+}
+
+static int
+db_fetch(struct sys_db *db, char *table, d_iov_t *key, d_iov_t *val)
+{
+	struct vos_sys_db *vdb = db2vos(db);
+	struct sys_db_io   io;
+	int		   rc;
+
+	D_ASSERT(!daos_handle_is_inval(vdb->db_coh));
+
+	db_io_init(&io, table, key, val);
+	rc = vos_obj_fetch(vdb->db_coh, vdb->db_obj, SYS_DB_EPC, 0,
+			   &io.io_key, 1, &io.io_iod, &io.io_sgl);
+	/* NB: VOS returns zero for empty key */
+	if (rc == 0 && val->iov_len == 0)
+		rc = -DER_NONEXIST;
+
+	return rc;
+}
+
+static int
+db_upsert(struct sys_db *db, char *table, d_iov_t *key, d_iov_t *val)
+{
+	struct vos_sys_db *vdb = db2vos(db);
+	struct sys_db_io   io;
+	int		   rc;
+
+	D_ASSERT(!daos_handle_is_inval(vdb->db_coh));
+
+	db_io_init(&io, table, key, val);
+	rc = vos_obj_update(vdb->db_coh, vdb->db_obj, SYS_DB_EPC, 0, 0,
+			    &io.io_key, 1, &io.io_iod, NULL, &io.io_sgl);
+	return rc;
+}
+
+static int
+db_delete(struct sys_db *db, char *table, d_iov_t *key)
+{
+	struct vos_sys_db *vdb = db2vos(db);
+	struct sys_db_io   io;
+	int		   rc;
+
+	D_ASSERT(!daos_handle_is_inval(vdb->db_coh));
+
+	db_io_init(&io, table, key, NULL);
+	rc = vos_obj_del_key(vdb->db_coh, vdb->db_obj, &io.io_key,
+			     &io.io_iod.iod_name);
+	if (rc == 0) {
+		int creds = 100;
+		/* vos_obj_del_key() wouldn't free space */
+		vos_gc_pool(vdb->db_poh, &creds);
+	}
+	return rc;
+}
+
+struct db_trav_args {
+	struct sys_db		*ta_db;
+	char			*ta_table;
+	void			*ta_cb_args;
+	sys_db_trav_cb_t	 ta_cb;
+};
+
+/* private iterator callback that ignores those unused parameters for user */
+static int
+db_trav_cb(daos_handle_t ih, vos_iter_entry_t *entry, vos_iter_type_t type,
+	   vos_iter_param_t *iter_param, void *data, unsigned *acts)
+{
+	struct db_trav_args	*ta = data;
+
+	return ta->ta_cb(ta->ta_db, ta->ta_table, &entry->ie_key,
+			 ta->ta_cb_args);
+}
+
+static int
+db_traverse(struct sys_db *db, char *table, sys_db_trav_cb_t cb, void *args)
+{
+	struct vos_sys_db	*vdb = db2vos(db);
+	struct vos_iter_anchors  anchors = { 0 };
+	struct db_trav_args	 ta;
+	vos_iter_param_t	 ip;
+	int			 rc;
+
+	D_ASSERT(!daos_handle_is_inval(vdb->db_coh));
+
+	memset(&ip, 0, sizeof(ip));
+	d_iov_set(&ip.ip_dkey, table, strlen(table));
+	ip.ip_epr.epr_hi = DAOS_EPOCH_MAX;
+	ip.ip_hdl	 = vdb->db_coh;
+	ip.ip_oid	 = vdb->db_obj;
+
+	ta.ta_db	 = db;
+	ta.ta_table	 = table;
+	ta.ta_cb_args	 = args;
+	ta.ta_cb	 = cb;
+	rc = vos_iterate(&ip, VOS_ITER_AKEY, false, &anchors,
+			 db_trav_cb, NULL, &ta, NULL);
+	return rc;
+}
+
+int
+db_tx_begin(struct sys_db *db)
+{
+	struct vos_sys_db *vdb = db2vos(db);
+
+	/* NB: it's OK to start nested PMDK transaction */
+	D_ASSERT(vdb->db_umm);
+	return umem_tx_begin(vdb->db_umm, NULL);
+}
+
+int
+db_tx_end(struct sys_db *db, int rc)
+{
+	struct vos_sys_db *vdb = db2vos(db);
+
+	D_ASSERT(vdb->db_umm);
+	return umem_tx_end(vdb->db_umm, rc);
+}
+
+void
+db_lock(struct sys_db *db)
+{
+	ABT_mutex_lock(db2vos(db)->db_lock);
+}
+
+void
+db_unlock(struct sys_db *db)
+{
+	ABT_mutex_unlock(db2vos(db)->db_lock);
+}
+
+/** Initialize system DB of VOS */
+int
+vos_db_init(const char *db_path, const char *db_name, bool self_mode)
+{
+	int	create;
+	int	rc;
+
+	memset(&vos_db, 0, sizeof(vos_db));
+	vos_db.db_vos_self = self_mode;
+
+	rc = asprintf(&vos_db.db_path, "%s/%s", db_path, SYS_DB_DIR);
+	if (rc < 0) {
+		D_ERROR("Generate sysdb path failed. %d\n", rc);
+		return -DER_NOMEM;
+	}
+
+	if (!db_name)
+		db_name = SYS_DB_NAME;
+
+	rc = asprintf(&vos_db.db_file, "%s/%s", vos_db.db_path, db_name);
+	if (rc < 0) {
+		D_ERROR("Generate sysdb filename failed. %d\n", rc);
+		rc = -DER_NOMEM;
+		goto failed;
+	}
+
+	rc = ABT_mutex_create(&vos_db.db_lock);
+	if (rc != ABT_SUCCESS) {
+		rc = -DER_NOMEM;
+		goto failed;
+	}
+
+	vos_db.db_poh = DAOS_HDL_INVAL;
+	vos_db.db_coh = DAOS_HDL_INVAL;
+
+	strncpy(vos_db.db_pub.sd_name, db_name, SYS_DB_NAME_SZ - 1);
+	vos_db.db_pub.sd_fetch	  = db_fetch;
+	vos_db.db_pub.sd_upsert	  = db_upsert;
+	vos_db.db_pub.sd_delete	  = db_delete;
+	vos_db.db_pub.sd_traverse = db_traverse;
+	vos_db.db_pub.sd_tx_begin = db_tx_begin;
+	vos_db.db_pub.sd_tx_end	  = db_tx_end;
+	vos_db.db_pub.sd_lock	  = db_lock;
+	vos_db.db_pub.sd_unlock	  = db_unlock;
+
+	rc = uuid_parse(SYS_DB_POOL, vos_db.db_pool);
+	D_ASSERTF(rc == 0, "Failed to parse sys pool uuid: %s\n", SYS_DB_POOL);
+
+	rc = uuid_parse(SYS_DB_CONT, vos_db.db_cont);
+	D_ASSERTF(rc == 0, "Failed to parse sys cont uuid: %s\n", SYS_DB_CONT);
+
+	if (self_mode)
+		db_unlink(&vos_db.db_pub);
+
+	for (create = 0; create <= 1; create++) {
+		rc = db_open_create(&vos_db.db_pub, !!create);
+		if (rc == 0) {
+			D_DEBUG(DB_IO, "successfully open system DB\n");
+			break;
+		}
+		if (create || rc != -DER_NONEXIST) {
+			D_ERROR("Failed to open/create(%d) sys DB: "DF_RC"\n",
+				create, DP_RC(rc));
+			goto failed;
+		}
+		D_DEBUG(DB_DF, "Try to create system DB\n");
+	}
+	return 0;
+failed:
+	vos_db_fini();
+	return rc;
+}
+
+/** Finalize system DB of VOS */
+void
+vos_db_fini(void)
+{
+	db_close(&vos_db.db_pub);
+	if (vos_db.db_lock)
+		ABT_mutex_free(&vos_db.db_lock);
+
+	if (vos_db.db_file) {
+		if (vos_db.db_vos_self)
+			vos_pool_destroy(vos_db.db_file, vos_db.db_pool);
+		free(vos_db.db_file);
+	}
+
+	if (vos_db.db_path)
+		free(vos_db.db_path);
+
+	memset(&vos_db, 0, sizeof(vos_db));
+}
+
+/** Export system DB of VOS */
+struct sys_db *
+vos_db_get(void)
+{
+	return &vos_db.db_pub;
+}

--- a/src/vos/sys_db.c
+++ b/src/vos/sys_db.c
@@ -43,7 +43,8 @@
 #define SYS_DB_MD		"metadata"
 #define SYS_DB_MD_VER		"version"
 
-#define SYS_DB_VERSION		1
+#define SYS_DB_VERSION_1	1
+#define SYS_DB_VERSION		SYS_DB_VERSION_1
 
 #define SYS_DB_SIZE		(128UL << 20)	/* 128MB */
 #define SYS_DB_EPC		1
@@ -173,10 +174,11 @@ db_open_create(struct sys_db *db, bool try_create)
 			goto failed;
 		}
 
-		if (ver != SYS_DB_VERSION) {
-			D_CRIT("Incompatible sysdb version %d/%d\n",
-			       ver, SYS_DB_VERSION);
-			rc = -DER_DF_IMCOMPAT;
+		if (ver <SYS_DB_VERSION_1 || ver > SYS_DB_VERSION) {
+			vos_report_layout_incompat("SMD", SYS_DB_VERSION_1,
+						   SYS_DB_VERSION,
+						   vdb->db_pool);
+			rc = -DER_DF_INCOMPAT;
 			goto failed;
 		}
 	}

--- a/src/vos/sys_db.c
+++ b/src/vos/sys_db.c
@@ -175,10 +175,11 @@ db_open_create(struct sys_db *db, bool try_create)
 		}
 
 		if (ver <SYS_DB_VERSION_1 || ver > SYS_DB_VERSION) {
-			vos_report_layout_incompat("SMD", SYS_DB_VERSION_1,
+			vos_report_layout_incompat("SMD", ver,
+						   SYS_DB_VERSION_1,
 						   SYS_DB_VERSION,
-						   vdb->db_pool);
-			rc = -DER_DF_INCOMPAT;
+						   &vdb->db_pool);
+			rc = -DER_DF_INCOMPT;
 			goto failed;
 		}
 	}

--- a/src/vos/tests/vos_tests.c
+++ b/src/vos/tests/vos_tests.c
@@ -149,7 +149,7 @@ main(int argc, char **argv)
 		return rc;
 	}
 
-	rc = vos_init();
+	rc = vos_self_init("/mnt/daos");
 	if (rc) {
 		print_error("Error initializing VOS instance\n");
 		goto exit_0;
@@ -278,7 +278,7 @@ main(int argc, char **argv)
 		print_message("\nSUCCESS! NO TEST FAILURES\n");
 
 exit_1:
-	vos_fini();
+	vos_self_fini();
 exit_0:
 	daos_debug_fini();
 	return nr_failed;

--- a/src/vos/tests/vts_common.h
+++ b/src/vos/tests/vts_common.h
@@ -105,6 +105,9 @@ void dts_ctx_fini(struct dts_context *tsc);
  */
 struct dts_io_credit *dts_credit_take(struct dts_context *tsc);
 
+/** return the IO credit to the I/O context */
+void dts_credit_return(struct dts_context *tsc, struct dts_io_credit *cred);
+
 /**
  * VOS test suite run tests
  */

--- a/src/vos/tests/vts_gc.c
+++ b/src/vos/tests/vts_gc.c
@@ -29,6 +29,8 @@ struct gc_test_args {
 	bool			 gc_array;
 };
 
+#define CREDS_MAX		16
+
 static struct gc_test_args	gc_args;
 
 static const int cont_nr	= 4;
@@ -148,7 +150,7 @@ gc_obj_prepare(struct gc_test_args *args, daos_handle_t coh,
 	int		         i;
 	int			 j;
 	int			 k;
-	int			 rc;
+	int			 rc = 0;
 
 	cred = dts_credit_take(&args->gc_ctx);
 	D_ASSERT(cred);
@@ -175,10 +177,12 @@ gc_obj_prepare(struct gc_test_args *args, daos_handle_t coh,
 
 				rc = gc_obj_update(args, coh, oid, 1, cred);
 				if (rc)
-					return rc;
+					goto out;
 			}
 		}
 	}
+out:
+	dts_credit_return(&args->gc_ctx, cred);
 	return 0;
 }
 
@@ -232,6 +236,69 @@ gc_wait_check(struct gc_test_args *args, bool cont_delete)
 	}
 	print_message("Test successfully completed\n");
 	return 0;
+}
+
+int
+gc_key_run(struct gc_test_args *args)
+{
+	struct dts_io_credit *creds[CREDS_MAX] = {NULL};
+	struct dts_io_credit *cred;
+	daos_unit_oid_t	      oid;
+	int		      i;
+	int		      rc;
+
+	oid = dts_unit_oid_gen(0, 0, 0);
+	for (i = 0; i < CREDS_MAX; i++) {
+		daos_iod_t *iod;
+
+		cred = creds[i] = dts_credit_take(&args->gc_ctx);
+		D_ASSERT(cred);
+
+		iod = &cred->tc_iod;
+		d_iov_set(&cred->tc_dkey, cred->tc_dbuf, DTS_KEY_LEN);
+		d_iov_set(&iod->iod_name, cred->tc_abuf, DTS_KEY_LEN);
+
+		gc_add_stat(STAT_DKEY);
+		dts_key_gen(cred->tc_dbuf, DTS_KEY_LEN, NULL);
+
+		gc_add_stat(STAT_AKEY);
+		dts_key_gen(cred->tc_abuf, DTS_KEY_LEN, NULL);
+
+		rc = gc_obj_update(args, args->gc_ctx.tsc_coh, oid, 1, cred);
+		if (rc) {
+			print_error("failed to insert key: %s\n",
+				    d_errstr(rc));
+			goto out;
+		}
+	}
+
+	gc_print_stat();
+	for (i = 0; i < CREDS_MAX; i++) {
+		rc = vos_obj_del_key(args->gc_ctx.tsc_coh, oid,
+				     &creds[i]->tc_dkey, NULL);
+		if (rc) {
+			print_error("failed to delete objects: %s\n",
+				    d_errstr(rc));
+			goto out;
+		}
+	}
+	rc = gc_wait_check(args, false);
+out:
+	for (i = 0; i < CREDS_MAX; i++) {
+		if (creds[i])
+			dts_credit_return(&args->gc_ctx, creds[i]);
+	}
+	return rc;
+}
+
+static void
+gc_key_test(void **state)
+{
+	struct gc_test_args *args = *state;
+	int		     rc;
+
+	rc = gc_key_run(args);
+	assert_int_equal(rc, 0);
 }
 
 static int
@@ -367,7 +434,7 @@ gc_setup(void **state)
 	tc->tsc_scm_size	= (2ULL << 30);
 	tc->tsc_nvme_size	= (4ULL << 30);
 	tc->tsc_cred_vsize	= max(recx_size, singv_size);
-	tc->tsc_cred_nr		= -1; /* sync mode */
+	tc->tsc_cred_nr		= CREDS_MAX;
 	tc->tsc_mpi_rank	= 0;
 	tc->tsc_mpi_size	= 1;
 	uuid_generate(tc->tsc_pool_uuid);
@@ -407,11 +474,13 @@ gc_prepare(void **state)
 }
 
 static const struct CMUnitTest gc_tests[] = {
-	{ "GC01: object garbage collecting",
+	{ "GC01: key garbage collecting",
+	  gc_key_test, gc_prepare, NULL},
+	{ "GC02: object garbage collecting",
 	  gc_obj_test, gc_prepare, NULL},
-	{ "GC02: object garbage collecting (array)",
+	{ "GC03: object garbage collecting (array)",
 	  gc_obj_bio_test, gc_prepare, NULL},
-	{ "GC03: container garbage collecting",
+	{ "GC04: container garbage collecting",
 	  gc_cont_test, gc_prepare, NULL},
 };
 

--- a/src/vos/vos_common.c
+++ b/src/vos/vos_common.c
@@ -13,18 +13,24 @@
 
 #include <daos/common.h>
 #include <daos/rpc.h>
-#include <daos_srv/daos_server.h>
-#include <vos_internal.h>
 #include <daos/lru.h>
 #include <daos/btree_class.h>
 #include <daos_srv/vos.h>
 #include <daos_srv/ras.h>
+#include <daos_srv/daos_server.h>
+#include <vos_internal.h>
 
-struct bio_xs_context	*vsa_xsctxt_inst;
-static pthread_mutex_t	mutex = PTHREAD_MUTEX_INITIALIZER;
+struct vos_self_mode {
+	struct vos_tls		*self_tls;
+	struct bio_xs_context	*self_xs_ctxt;
+	pthread_mutex_t		 self_lock;
+	bool			 self_nvme_init;
+	int			 self_ref;
+};
 
-static bool vsa_nvme_init;
-struct vos_tls	*standalone_tls;
+struct vos_self_mode		 self_mode = {
+	.self_lock	= PTHREAD_MUTEX_INITIALIZER,
+};
 
 #define DF_MAX_BUF 128
 void
@@ -52,15 +58,10 @@ struct vos_tls *
 vos_tls_get(void)
 {
 #ifdef VOS_STANDALONE
-	return standalone_tls;
+	return self_mode.self_tls;
 #else
-	struct vos_tls			*tls;
-	struct dss_thread_local_storage	*dtc;
-
-	dtc = dss_tls_get();
-	tls = (struct vos_tls *)dss_module_key_get(dtc, &vos_module_key);
-	return tls;
-#endif /* VOS_STANDALONE */
+	return dss_module_key_get(dss_tls_get(), &vos_module_key);
+#endif
 }
 
 /** Add missing timestamp cache entries.  This should be called
@@ -103,40 +104,44 @@ vos_ts_add_missing(struct vos_ts_set *ts_set, daos_key_t *dkey, int akey_nr,
 int
 vos_profile_start(char *path, int avg)
 {
+	struct vos_tls *tls = vos_tls_get();
 	struct daos_profile *dp;
 	int rc;
 
-	if (standalone_tls == NULL)
+	if (tls == NULL)
 		return 0;
 
 	rc = daos_profile_init(&dp, path, avg, 0, 0);
 	if (rc)
 		return rc;
 
-	standalone_tls->vtl_dp = dp;
+	tls->vtl_dp = dp;
 	return 0;
 }
 
 void
 vos_profile_stop()
 {
-	if (standalone_tls == NULL || standalone_tls->vtl_dp == NULL)
+	struct vos_tls *tls = vos_tls_get();
+
+	if (tls == NULL || tls->vtl_dp == NULL)
 		return;
 
-	daos_profile_dump(standalone_tls->vtl_dp);
-	daos_profile_destroy(standalone_tls->vtl_dp);
-	standalone_tls->vtl_dp = NULL;
+	daos_profile_dump(tls->vtl_dp);
+	daos_profile_destroy(tls->vtl_dp);
+	tls->vtl_dp = NULL;
 }
 
 #endif
 
-/**
- * Object cache based on mode of instantiation
- */
-struct daos_lru_cache*
-vos_get_obj_cache(void)
+struct bio_xs_context *
+vos_xsctxt_get(void)
 {
-	return vos_tls_get()->vtl_imems_inst.vis_ocache;
+#ifdef VOS_STANDALONE
+	return self_mode.self_xs_ctxt;
+#else
+	return dss_get_module_info()->dmi_nvme_ctxt;
+#endif
 }
 
 int
@@ -315,52 +320,24 @@ cancel:
  * TLS instance.
  */
 
-static inline void
-vos_imem_strts_destroy(struct vos_imem_strts *imem_inst)
+static void
+vos_tls_fini(const struct dss_thread_local_storage *dtls,
+	     struct dss_module_key *key, void *data)
 {
-	if (imem_inst->vis_ocache)
-		vos_obj_cache_destroy(imem_inst->vis_ocache);
+	struct vos_tls *tls = data;
 
-	if (imem_inst->vis_pool_hhash)
-		d_uhash_destroy(imem_inst->vis_pool_hhash);
+	D_ASSERT(d_list_empty(&tls->vtl_gc_pools));
+	if (tls->vtl_ocache)
+		vos_obj_cache_destroy(tls->vtl_ocache);
 
-	if (imem_inst->vis_cont_hhash)
-		d_uhash_destroy(imem_inst->vis_cont_hhash);
-}
+	if (tls->vtl_pool_hhash)
+		d_uhash_destroy(tls->vtl_pool_hhash);
 
-static inline int
-vos_imem_strts_create(struct vos_imem_strts *imem_inst)
-{
-	int		rc;
+	if (tls->vtl_cont_hhash)
+		d_uhash_destroy(tls->vtl_cont_hhash);
 
-	rc = vos_obj_cache_create(LRU_CACHE_BITS,
-				  &imem_inst->vis_ocache);
-	if (rc) {
-		D_ERROR("Error in creating object cache\n");
-		return rc;
-	}
-
-	rc = d_uhash_create(D_HASH_FT_NOLOCK, VOS_POOL_HHASH_BITS,
-			    &imem_inst->vis_pool_hhash);
-	if (rc) {
-		D_ERROR("Error in creating POOL ref hash: "DF_RC"\n",
-			DP_RC(rc));
-		goto failed;
-	}
-
-	rc = d_uhash_create(D_HASH_FT_NOLOCK | D_HASH_FT_EPHEMERAL,
-			    VOS_CONT_HHASH_BITS, &imem_inst->vis_cont_hhash);
-	if (rc) {
-		D_ERROR("Error in creating CONT ref hash: "DF_RC"\n",
-			DP_RC(rc));
-		goto failed;
-	}
-
-	return 0;
-
-failed:
-	vos_imem_strts_destroy(imem_inst);
-	return rc;
+	umem_fini_txd(&tls->vtl_txd);
+	D_FREE(tls);
 }
 
 static void *
@@ -375,42 +352,44 @@ vos_tls_init(const struct dss_thread_local_storage *dtls,
 		return NULL;
 
 	D_INIT_LIST_HEAD(&tls->vtl_gc_pools);
-	if (vos_imem_strts_create(&tls->vtl_imems_inst)) {
-		D_FREE(tls);
-		return NULL;
+	rc = vos_obj_cache_create(LRU_CACHE_BITS, &tls->vtl_ocache);
+	if (rc) {
+		D_ERROR("Error in creating object cache\n");
+		goto failed;
+	}
+
+	rc = d_uhash_create(D_HASH_FT_NOLOCK, VOS_POOL_HHASH_BITS,
+			    &tls->vtl_pool_hhash);
+	if (rc) {
+		D_ERROR("Error in creating POOL ref hash: "DF_RC"\n",
+			DP_RC(rc));
+		goto failed;
+	}
+
+	rc = d_uhash_create(D_HASH_FT_NOLOCK | D_HASH_FT_EPHEMERAL,
+			    VOS_CONT_HHASH_BITS, &tls->vtl_cont_hhash);
+	if (rc) {
+		D_ERROR("Error in creating CONT ref hash: "DF_RC"\n",
+			DP_RC(rc));
+		goto failed;
 	}
 
 	rc = umem_init_txd(&tls->vtl_txd);
 	if (rc) {
-		vos_imem_strts_destroy(&tls->vtl_imems_inst);
-		D_FREE(tls);
-		return NULL;
+		D_ERROR("Error in creating txd: %d\n", rc);
+		goto failed;
 	}
-
-	tls->vtl_dth = NULL;
 
 	rc = vos_ts_table_alloc(&tls->vtl_ts_table);
 	if (rc) {
-		umem_fini_txd(&tls->vtl_txd);
-		vos_imem_strts_destroy(&tls->vtl_imems_inst);
-		D_FREE(tls);
-		return NULL;
+		D_ERROR("Error in creating timestamp table: %d\n", rc);
+		goto failed;
 	}
 
 	return tls;
-}
-
-static void
-vos_tls_fini(const struct dss_thread_local_storage *dtls,
-	     struct dss_module_key *key, void *data)
-{
-	struct vos_tls *tls = data;
-
-	vos_imem_strts_destroy(&tls->vtl_imems_inst);
-	umem_fini_txd(&tls->vtl_txd);
-	vos_ts_table_free(&tls->vtl_ts_table);
-
-	D_FREE(tls);
+failed:
+	vos_tls_fini(dtls, key, tls);
+	return NULL;
 }
 
 struct dss_module_key vos_module_key = {
@@ -462,7 +441,6 @@ vos_mod_init(void)
 	if (rc)
 		D_ERROR("Failed to initialize incarnation log capability\n");
 
-
 	return rc;
 }
 
@@ -482,15 +460,15 @@ struct dss_module vos_srv_module =  {
 };
 
 static void
-vos_nvme_fini(void)
+vos_self_nvme_fini(void)
 {
-	if (vsa_xsctxt_inst != NULL) {
-		bio_xsctxt_free(vsa_xsctxt_inst);
-		vsa_xsctxt_inst = NULL;
+	if (self_mode.self_xs_ctxt != NULL) {
+		bio_xsctxt_free(self_mode.self_xs_ctxt);
+		self_mode.self_xs_ctxt = NULL;
 	}
-	if (vsa_nvme_init) {
+	if (self_mode.self_nvme_init) {
 		bio_nvme_fini();
-		vsa_nvme_init = false;
+		self_mode.self_nvme_init = false;
 	}
 }
 
@@ -501,7 +479,7 @@ vos_nvme_fini(void)
 #define VOS_NVME_MEM_SIZE	DAOS_NVME_MEM_PRIMARY
 
 static int
-vos_nvme_init(void)
+vos_self_nvme_init()
 {
 	int rc;
 
@@ -512,72 +490,72 @@ vos_nvme_init(void)
 	if (rc != 0 && rc != -DER_EXIST)
 		return rc;
 
-	rc = bio_nvme_init(VOS_STORAGE_PATH, VOS_NVME_CONF, VOS_NVME_SHM_ID,
-		VOS_NVME_MEM_SIZE);
+	rc = bio_nvme_init(VOS_NVME_CONF, VOS_NVME_SHM_ID,
+			   VOS_NVME_MEM_SIZE, vos_db_get());
 	if (rc)
 		return rc;
-	vsa_nvme_init = true;
 
-	rc = bio_xsctxt_alloc(&vsa_xsctxt_inst, -1 /* Self poll */);
+	self_mode.self_nvme_init = true;
+	rc = bio_xsctxt_alloc(&self_mode.self_xs_ctxt, -1 /* Self poll */);
 	return rc;
 }
 
-static int	vos_inited;
-
 static void
-vos_fini_locked(void)
+vos_self_fini_locked(void)
 {
-	if (standalone_tls) {
-		vos_tls_fini(NULL, NULL, standalone_tls);
-		standalone_tls = NULL;
+	vos_self_nvme_fini();
+	vos_db_fini();
+
+	if (self_mode.self_tls) {
+		vos_tls_fini(NULL, NULL, self_mode.self_tls);
+		self_mode.self_tls = NULL;
 	}
-	vos_nvme_fini();
 	ABT_finalize();
 }
 
 void
-vos_fini(void)
+vos_self_fini(void)
 {
 	/* Clean up things left behind in standalone mode.
 	 * NB: this function is only defined for standalone mode.
 	 */
 	gc_wait();
 
-	D_MUTEX_LOCK(&mutex);
+	D_MUTEX_LOCK(&self_mode.self_lock);
 
-	D_ASSERT(vos_inited > 0);
-	vos_inited--;
-	if (vos_inited == 0)
-		vos_fini_locked();
+	D_ASSERT(self_mode.self_ref > 0);
+	self_mode.self_ref--;
+	if (self_mode.self_ref == 0)
+		vos_self_fini_locked();
 
-	D_MUTEX_UNLOCK(&mutex);
+	D_MUTEX_UNLOCK(&self_mode.self_lock);
 }
 
 int
-vos_init(void)
+vos_self_init(const char *db_path)
 {
-	char		*evt_mode;
-	int		 rc = 0;
+	char	*evt_mode;
+	int	 rc = 0;
 
-	D_MUTEX_LOCK(&mutex);
-	if (vos_inited) {
-		vos_inited++;
+	D_MUTEX_LOCK(&self_mode.self_lock);
+	if (self_mode.self_ref) {
+		self_mode.self_ref++;
 		D_GOTO(out, rc);
 	}
 
 	rc = ABT_init(0, NULL);
 	if (rc != 0) {
-		D_MUTEX_UNLOCK(&mutex);
+		D_MUTEX_UNLOCK(&self_mode.self_lock);
 		return rc;
 	}
 
 	vos_start_epoch = 0;
 
 #if VOS_STANDALONE
-	standalone_tls = vos_tls_init(NULL, NULL);
-	if (!standalone_tls) {
+	self_mode.self_tls = vos_tls_init(NULL, NULL);
+	if (!self_mode.self_tls) {
 		ABT_finalize();
-		D_MUTEX_UNLOCK(&mutex);
+		D_MUTEX_UNLOCK(&self_mode.self_lock);
 		return rc;
 	}
 #endif
@@ -585,7 +563,11 @@ vos_init(void)
 	if (rc)
 		D_GOTO(failed, rc);
 
-	rc = vos_nvme_init();
+	rc = vos_db_init(db_path, "self_db", true);
+	if (rc)
+		D_GOTO(failed, rc);
+
+	rc = vos_self_nvme_init();
 	if (rc)
 		D_GOTO(failed, rc);
 
@@ -607,12 +589,13 @@ vos_init(void)
 		D_INFO("Using distance with closest side split for evtree "
 		       "(default)\n");
 	}
-	vos_inited = 1;
+
+	self_mode.self_ref = 1;
 out:
-	D_MUTEX_UNLOCK(&mutex);
+	D_MUTEX_UNLOCK(&self_mode.self_lock);
 	return 0;
 failed:
-	vos_fini_locked();
-	D_MUTEX_UNLOCK(&mutex);
+	vos_self_fini_locked();
+	D_MUTEX_UNLOCK(&self_mode.self_lock);
 	return rc;
 }

--- a/src/vos/vos_common.c
+++ b/src/vos/vos_common.c
@@ -337,6 +337,7 @@ vos_tls_fini(const struct dss_thread_local_storage *dtls,
 		d_uhash_destroy(tls->vtl_cont_hhash);
 
 	umem_fini_txd(&tls->vtl_txd);
+	vos_ts_table_free(&tls->vtl_ts_table);
 	D_FREE(tls);
 }
 

--- a/src/vos/vos_internal.h
+++ b/src/vos/vos_internal.h
@@ -250,11 +250,10 @@ struct vos_dtx_act_ent {
 					 dae_prepared:1;
 };
 
-extern struct vos_tls	*standalone_tls;
 #ifdef VOS_STANDALONE
 #define VOS_TIME_START(start, op)		\
 do {						\
-	if (standalone_tls->vtl_dp == NULL)	\
+	if (vos_tls_get()->vtl_dp == NULL)	\
 		break;				\
 	start = daos_get_ntime();		\
 } while (0)
@@ -264,7 +263,7 @@ do {						\
 	struct daos_profile *dp;		\
 	int time_msec;				\
 						\
-	dp = standalone_tls->vtl_dp;		\
+	dp = vos_tls_get()->vtl_dp;		\
 	if ((dp) == NULL || start == 0)		\
 		break;				\
 	time_msec = (daos_get_ntime() - start)/1000; \
@@ -321,19 +320,7 @@ struct vos_dtx_cmt_ent {
 #define DCE_OID(dce)		((dce)->dce_base.dce_oid)
 #define DCE_DKEY_HASH(dce)	((dce)->dce_base.dce_dkey_hash)
 
-/* in-memory structures standalone instance */
-extern struct bio_xs_context		*vsa_xsctxt_inst;
 extern int vos_evt_feats;
-
-static inline struct bio_xs_context *
-vos_xsctxt_get(void)
-{
-#ifdef VOS_STANDALONE
-	return vsa_xsctxt_inst;
-#else
-	return dss_get_module_info()->dmi_nvme_ctxt;
-#endif
-}
 
 #define VOS_KEY_CMP_LEXICAL	(1ULL << 63)
 
@@ -371,7 +358,11 @@ vos_pool_hash_del(struct vos_pool *pool)
  * Getting object cache
  * Wrapper for TLS and standalone mode
  */
-struct daos_lru_cache *vos_get_obj_cache(void);
+static inline struct daos_lru_cache *
+vos_get_obj_cache(void)
+{
+	return vos_tls_get()->vtl_ocache;
+}
 
 /**
  * Register btree class for container table, it is called within vos_init()
@@ -1011,6 +1002,8 @@ key_tree_punch(struct vos_object *obj, daos_handle_t toh, daos_epoch_t epoch,
 	       daos_epoch_t bound, d_iov_t *key_iov, d_iov_t *val_iov,
 	       uint64_t flags, struct vos_ts_set *ts_set,
 	       struct vos_ilog_info *parent, struct vos_ilog_info *info);
+int
+key_tree_delete(struct vos_object *obj, daos_handle_t toh, d_iov_t *key_iov);
 
 /* vos_io.c */
 daos_size_t

--- a/src/vos/vos_obj.c
+++ b/src/vos/vos_obj.c
@@ -453,6 +453,75 @@ out:
 	return rc;
 }
 
+/* Delete a key in its parent tree.
+ * NB: there is no "delete" in DAOS data model, this is really for the
+ * system DB, or space reclaim after data movement.
+ */
+int
+vos_obj_del_key(daos_handle_t coh, daos_unit_oid_t oid, daos_key_t *dkey,
+		daos_key_t *akey)
+{
+	struct daos_lru_cache	*occ  = vos_obj_cache_current();
+	struct vos_container	*cont = vos_hdl2cont(coh);
+	struct umem_instance	*umm  = vos_cont2umm(cont);
+	struct vos_object	*obj;
+	daos_key_t		*key;
+	daos_epoch_range_t	 epr = {0, DAOS_EPOCH_MAX};
+	daos_handle_t		 toh;
+	int			 rc;
+
+	rc = vos_obj_hold(occ, cont, oid, &epr, 0, VOS_OBJ_VISIBLE,
+			  DAOS_INTENT_KILL, &obj, NULL);
+	if (rc == -DER_NONEXIST)
+		return 0;
+
+	if (rc) {
+		D_ERROR("object hold error: "DF_RC"\n", DP_RC(rc));
+		return rc;
+	}
+
+	rc = umem_tx_begin(umm, NULL);
+	if (rc) {
+		D_ERROR("memory TX start error: "DF_RC"\n", DP_RC(rc));
+		goto out;
+	}
+
+	rc = obj_tree_init(obj);
+	if (rc) {
+		D_ERROR("init dkey tree error: "DF_RC"\n", DP_RC(rc));
+		goto out_tx;
+	}
+
+	if (akey) { /* delete akey */
+		key = akey;
+		rc = key_tree_prepare(obj, obj->obj_toh, VOS_BTR_DKEY,
+				      dkey, 0, DAOS_INTENT_PUNCH, NULL,
+				      &toh, NULL);
+		if (rc) {
+			D_ERROR("open akey tree error: "DF_RC"\n", DP_RC(rc));
+			goto out_tx;
+		}
+	} else { /* delete dkey */
+		key = dkey;
+		toh = obj->obj_toh;
+	}
+
+	key_tree_delete(obj, toh, key);
+	if (rc) {
+		D_ERROR("delete key error: "DF_RC"\n", DP_RC(rc));
+		goto out_tx;
+	}
+out_tx:
+	rc = umem_tx_end(umm, rc);
+	gc_wait(); /* NB: noop for full-stack mode */
+out:
+	if (akey)
+		key_tree_release(toh, false);
+
+	vos_obj_release(occ, obj, true);
+	return rc;
+}
+
 static int
 key_iter_ilog_check(struct vos_krec_df *krec, struct vos_obj_iter *oiter,
 		    vos_iter_type_t type, daos_epoch_range_t *epr,

--- a/src/vos/vos_obj_cache.c
+++ b/src/vos/vos_obj_cache.c
@@ -182,7 +182,7 @@ vos_obj_cache_evict(struct daos_lru_cache *cache, struct vos_container *cont)
 struct daos_lru_cache *
 vos_obj_cache_current(void)
 {
-	return vos_get_obj_cache();
+	return vos_obj_cache_get();
 }
 
 void

--- a/src/vos/vos_size.c
+++ b/src/vos/vos_size.c
@@ -147,7 +147,7 @@ get_vos_structure_sizes_yaml(int alloc_overhead, struct d_string_buffer_t *buf)
 		goto exit_0;
 	}
 
-	rc = vos_init();
+	rc = vos_self_init("/mnt/daos");
 	if (rc) {
 		goto exit_1;
 	}
@@ -174,7 +174,7 @@ get_vos_structure_sizes_yaml(int alloc_overhead, struct d_string_buffer_t *buf)
 	}
 
 exit_2:
-	vos_fini();
+	vos_self_fini();
 exit_1:
 	daos_debug_fini();
 exit_0:

--- a/src/vos/vos_tls.h
+++ b/src/vos/vos_tls.h
@@ -22,29 +22,12 @@
 #include <daos_srv/bio.h>
 #include <daos_srv/dtx_srv.h>
 
-struct vos_imem_strts {
-	/**
-	 * In-memory object cache for the PMEM
-	 * object table
-	 */
-	struct daos_lru_cache	*vis_ocache;
-	/** Hash table to refcount VOS handles */
-	/** (container/pool, etc.,) */
-	struct d_hash_table	*vis_pool_hhash;
-	struct d_hash_table	*vis_cont_hhash;
-};
-
 /* Forward declarations */
 struct vos_ts_table;
 struct dtx_handle;
 
 /** VOS thread local storage structure */
 struct vos_tls {
-	/* in-memory structures TLS instance */
-	/* TODO: move those members to vos_tls, nosense to have another
-	 * data structure for it.
-	 */
-	struct vos_imem_strts		 vtl_imems_inst;
 	/** pools registered for GC */
 	d_list_t			 vtl_gc_pools;
 	/* PMDK transaction stage callback data */
@@ -66,6 +49,12 @@ struct vos_tls {
 	struct vos_ts_table		*vtl_ts_table;
 	/** profile for standalone vos test */
 	struct daos_profile		*vtl_dp;
+	/** In-memory object cache for the PMEM object table */
+	struct daos_lru_cache		*vtl_ocache;
+	/** pool open handle hash table */
+	struct d_hash_table		*vtl_pool_hhash;
+	/** container open handle hash table */
+	struct d_hash_table		*vtl_cont_hhash;
 	/** saved hash value */
 	struct {
 		uint64_t		 vtl_hash;
@@ -73,19 +62,25 @@ struct vos_tls {
 	};
 };
 
-struct vos_tls *
-vos_tls_get();
+struct bio_xs_context *vos_xsctxt_get(void);
+struct vos_tls *vos_tls_get();
 
 static inline struct d_hash_table *
 vos_pool_hhash_get(void)
 {
-	return vos_tls_get()->vtl_imems_inst.vis_pool_hhash;
+	return vos_tls_get()->vtl_pool_hhash;
 }
 
 static inline struct d_hash_table *
 vos_cont_hhash_get(void)
 {
-	return vos_tls_get()->vtl_imems_inst.vis_cont_hhash;
+	return vos_tls_get()->vtl_cont_hhash;
+}
+
+static inline struct daos_lru_cache *
+vos_obj_cache_get(void)
+{
+	return vos_tls_get()->vtl_ocache;
 }
 
 static inline struct umem_tx_stage_data *

--- a/src/vos/vos_tree.c
+++ b/src/vos/vos_tree.c
@@ -1172,6 +1172,13 @@ done:
 	return rc;
 }
 
+int
+key_tree_delete(struct vos_object *obj, daos_handle_t toh, d_iov_t *key_iov)
+{
+	/* Delete a dkey or akey from tree @toh */
+	return dbtree_delete(toh, BTR_PROBE_EQ, key_iov, NULL);
+}
+
 /** initialize tree for an object */
 int
 obj_tree_init(struct vos_object *obj)


### PR DESCRIPTION
- Implement a single KV store (sysdb) within VOS
  . it is implemented as a private container within VOS
  . it provides API to upsert or delete KV
  . it provides API to traverse all keys
  . it is exposed as a abstraction layer "sysdb"

- Add a new VOS API daos_obj_del_key()
  . this function is not part of DAOS data model
  . it can only be used by data migratation protocol and sysdb
  . add unit test for this function

- Store SMD in sysdb of VOS, instead of using individual layout
  . provides API to initialize and expose sysdb of VOS
  . SMD uses sysdb as KV store to save metadata

- code cleanup for VOS and SMD

Signed-off-by: Liang Zhen <liang.zhen@intel.com>