### PR TITLE
DAOS-5851 tests: add RP_XSF rebuild

### DIFF
--- a/src/include/daos_srv/rebuild.h
+++ b/src/include/daos_srv/rebuild.h
@@ -28,12 +28,12 @@ typedef enum {
 	RB_OP_RECLAIM,
 } daos_rebuild_opc_t;
 
-#define RB_OP_STR(rb_op) ((rb_op) == RB_OP_FAIL ? "RB_OP_FAIL" : \
-			  (rb_op) == RB_OP_DRAIN ? "RB_OP_DRAIN" : \
-			  (rb_op) == RB_OP_REINT ? "RB_OP_REINT" : \
-			  (rb_op) == RB_OP_EXTEND ? "RB_OP_EXTEND" : \
-			  (rb_op) == RB_OP_RECLAIM ? "RB_OP_RECLAIM" : \
-			  "RB_OP_UNKNOWN")
+#define RB_OP_STR(rb_op) ((rb_op) == RB_OP_FAIL ? "Rebuild" : \
+			  (rb_op) == RB_OP_DRAIN ? "Drain" : \
+			  (rb_op) == RB_OP_REINT ? "Reintegrate" : \
+			  (rb_op) == RB_OP_EXTEND ? "Extend" : \
+			  (rb_op) == RB_OP_RECLAIM ? "Reclaim" : \
+			  "Unknown")
 
 int ds_rebuild_schedule(const uuid_t uuid, uint32_t map_ver,
 			struct pool_target_id_list *tgts,

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -1432,6 +1432,9 @@ dc_obj_layout_get(daos_handle_t oh, struct daos_obj_layout **p_layout)
 	if (grp_nr == DAOS_OBJ_GRP_MAX)
 		grp_nr = obj->cob_shards_nr / grp_size;
 
+	if (grp_size == DAOS_OBJ_GRP_MAX)
+		grp_size = obj->cob_shards_nr;
+
 	rc = daos_obj_layout_alloc(&layout, grp_nr, grp_size);
 	if (rc)
 		D_GOTO(out, rc);

--- a/src/rebuild/srv.c
+++ b/src/rebuild/srv.c
@@ -515,7 +515,7 @@ enum {
  * its own rebuild status by IV.
  */
 static void
-rebuild_leader_status_check(struct ds_pool *pool, uint32_t map_ver,
+rebuild_leader_status_check(struct ds_pool *pool, uint32_t map_ver, uint32_t op,
 			    struct rebuild_global_pool_tracker *rgt)
 {
 	double		last_print = 0;
@@ -620,13 +620,13 @@ rebuild_leader_status_check(struct ds_pool *pool, uint32_t map_ver,
 		rs->rs_seconds =
 			(d_timeus_secdiff(0) - rgt->rgt_time_start) / 1e6;
 		snprintf(sbuf, RBLD_SBUF_LEN,
-			"Rebuild [%s] (pool "DF_UUID" ver=%u, toberb_obj="
-			DF_U64", rb_obj="DF_U64", rec="DF_U64", size="DF_U64
-			" done %d status %d/%d duration=%d secs)\n",
-			str, DP_UUID(pool->sp_uuid), map_ver,
-			rs->rs_toberb_obj_nr, rs->rs_obj_nr, rs->rs_rec_nr,
-			rs->rs_size, rs->rs_done, rs->rs_errno,
-			rs->rs_fail_rank, rs->rs_seconds);
+			 "%s [%s] (pool "DF_UUID" ver=%u, toberb_obj="
+			 DF_U64", rb_obj="DF_U64", rec="DF_U64", size="DF_U64
+			 " done %d status %d/%d duration=%d secs)\n",
+			 RB_OP_STR(op), str, DP_UUID(pool->sp_uuid), map_ver,
+			 rs->rs_toberb_obj_nr, rs->rs_obj_nr, rs->rs_rec_nr,
+			 rs->rs_size, rs->rs_done, rs->rs_errno,
+			 rs->rs_fail_rank, rs->rs_seconds);
 
 		D_DEBUG(DB_REBUILD, "%s", sbuf);
 		if (rs->rs_done || rebuild_gst.rg_abort || rgt->rgt_abort) {
@@ -1022,9 +1022,9 @@ rebuild_try_merge_tgts(const uuid_t pool_uuid, uint32_t map_ver,
 		merge_task->dst_map_ver = map_ver;
 	}
 
-	D_PRINT("Rebuild [queued] ("DF_UUID" ver=%u) id %u op=%s\n",
-		DP_UUID(pool_uuid), map_ver, tgts->pti_ids[0].pti_id,
-		RB_OP_STR(rebuild_op));
+	D_PRINT("%s [queued] ("DF_UUID" ver=%u) id %u\n",
+		RB_OP_STR(rebuild_op), DP_UUID(pool_uuid), map_ver,
+		tgts->pti_ids[0].pti_id);
 
 	/* Print out the current queue to the debug log */
 	rebuild_debug_print_queue();
@@ -1140,9 +1140,9 @@ rebuild_task_ult(void *arg)
 		D_ERROR(DF_UUID": failed to send RAS event\n",
 			DP_UUID(task->dst_pool_uuid));
 
-	D_PRINT("Rebuild [started] (pool "DF_UUID" ver=%u, op=%s)\n",
-		DP_UUID(task->dst_pool_uuid), task->dst_map_ver,
-		RB_OP_STR(task->dst_rebuild_op));
+	D_PRINT("%s [started] (pool "DF_UUID" ver=%u)\n",
+		RB_OP_STR(task->dst_rebuild_op), DP_UUID(task->dst_pool_uuid),
+		task->dst_map_ver);
 
 	rc = rebuild_leader_start(pool, task->dst_map_ver, &task->dst_tgts,
 				  task->dst_rebuild_op, &rgt);
@@ -1152,13 +1152,15 @@ rebuild_task_ult(void *arg)
 				" canceled.\n", DP_UUID(task->dst_pool_uuid),
 				task->dst_map_ver);
 			rc = 0;
-			D_PRINT("Rebuild [canceled] (pool "DF_UUID" ver=%u"
+			D_PRINT("%s [canceled] (pool "DF_UUID" ver=%u"
 				" status=%d)\n", DP_UUID(task->dst_pool_uuid),
+				RB_OP_STR(task->dst_rebuild_op),
 				task->dst_map_ver, rc);
 			D_GOTO(output, rc);
 		}
 
-		D_PRINT("Rebuild [failed] (pool "DF_UUID" ver=%u status=%d)\n",
+		D_PRINT("%s [failed] (pool "DF_UUID" ver=%u status=%d)\n",
+			RB_OP_STR(task->dst_rebuild_op),
 			DP_UUID(task->dst_pool_uuid), task->dst_map_ver, rc);
 
 		D_ERROR(""DF_UUID" (ver=%u) rebuild failed: rc %d\n",
@@ -1175,7 +1177,8 @@ rebuild_task_ult(void *arg)
 	}
 
 	/* Wait until rebuild finished */
-	rebuild_leader_status_check(pool, task->dst_map_ver, rgt);
+	rebuild_leader_status_check(pool, task->dst_map_ver,
+				    task->dst_rebuild_op, rgt);
 done:
 	if (!is_rebuild_global_done(rgt)) {
 		D_DEBUG(DB_REBUILD, DF_UUID" rebuild is not done: %d\n",
@@ -1456,14 +1459,13 @@ ds_rebuild_leader_stop_all()
 }
 
 static void
-rebuild_print_list_update(const char *const str, const uuid_t uuid,
-			  const uint32_t map_ver,
+rebuild_print_list_update(const uuid_t uuid, const uint32_t map_ver,
 			  daos_rebuild_opc_t rebuild_op,
 			  struct pool_target_id_list *tgts) {
 	int i;
 
-	D_PRINT("%s (pool="DF_UUID" ver=%u, op=%s) tgts=", str, DP_UUID(uuid),
-		map_ver, RB_OP_STR(rebuild_op));
+	D_PRINT("%s [queued] (pool="DF_UUID" ver=%u) tgts=",
+		RB_OP_STR(rebuild_op), DP_UUID(uuid), map_ver);
 	for (i = 0; i < tgts->pti_number; i++) {
 		if (i > 0)
 			D_PRINT(",");
@@ -1504,8 +1506,7 @@ ds_rebuild_schedule(const uuid_t uuid, uint32_t map_ver,
 	if (rc)
 		D_GOTO(free, rc);
 
-	rebuild_print_list_update("Rebuild queued",
-				  uuid, map_ver, rebuild_op, tgts);
+	rebuild_print_list_update(uuid, map_ver, rebuild_op, tgts);
 	d_list_add_tail(&task->dst_list, &rebuild_gst.rg_queue_list);
 
 	/* Print out the current queue to the debug log */

--- a/src/tests/suite/daos_rebuild_simple.c
+++ b/src/tests/suite/daos_rebuild_simple.c
@@ -694,7 +694,7 @@ rebuild_objects(void **state)
 }
 
 static void
-rebuild_sx_object(void **state)
+rebuild_sx_object_internal(void **state, uint16_t oclass)
 {
 	test_arg_t	*arg = *state;
 	daos_obj_id_t	oid;
@@ -709,7 +709,7 @@ rebuild_sx_object(void **state)
 	if (!test_runable(arg, 4))
 		return;
 
-	oid = dts_oid_gen(OC_SX, 0, arg->myrank);
+	oid = dts_oid_gen(oclass, 0, arg->myrank);
 	ioreq_init(&req, arg->coh, oid, DAOS_IOD_ARRAY, arg);
 	print_message("insert 100 dkeys\n");
 	for (i = 0; i < 100; i++) {
@@ -733,6 +733,18 @@ rebuild_sx_object(void **state)
 	/* wait until reintegration is done */
 	test_rebuild_wait(&arg, 1);
 	ioreq_fini(&req);
+}
+
+static void
+rebuild_sx_object(void **state)
+{
+	rebuild_sx_object_internal(state, OC_SX);
+}
+
+static void
+rebuild_xsf_object(void **state)
+{
+	rebuild_sx_object_internal(state, OC_RP_XSF);
 }
 
 /** create a new pool/container for each test */
@@ -761,6 +773,8 @@ static const struct CMUnitTest rebuild_tests[] = {
 	 rebuild_snap_punch_empty, rebuild_small_sub_setup, test_teardown},
 	{"REBUILD12: rebuild sx object",
 	 rebuild_sx_object, rebuild_small_sub_setup, test_teardown},
+	{"REBUILD13: rebuild xsf object",
+	 rebuild_xsf_object, rebuild_small_sub_setup, test_teardown},
 };
 
 int


### PR DESCRIPTION
1. Add RP_XSF tests.
2. Ouput rebuild/reintegrate/drain/extend operation
by console.

Signed-off-by: Di Wang <di.wang@intel.com>