### PR TITLE
DAOS-623 build: Fix prerequisite build source directory

### DIFF
--- a/utils/sl/prereq_tools/base.py
+++ b/utils/sl/prereq_tools/base.py
@@ -663,7 +663,8 @@ class PreReqComponent():
                         CONFIGURELOG='#/config-%s.log' % arch)
 
         # Build pre-reqs in sub-dir based on selected build type
-        build_dir_name = os.path.join(build_dir_name, self.build_type)
+        build_dir_name = os.path.join(build_dir_name,
+                                      self.__env.subst("$TTYPE_REAL"))
 
         self.add_opts(PathVariable('ENV_SCRIPT',
                                    "Location of environment script",


### PR DESCRIPTION
We were using the build_type setting for the source directory rather
than TARGET_TYPE.  In theory, it wouldn't matter but it's best
to keep the sources separate for different types of builds. At the
very least, this makes it consistent rather than arbitrary based
on the BUILD_TYPE.

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>