### PR TITLE
DAOS-623 githooks: Fix pre-commit for BSDs

### DIFF
--- a/utils/githooks/pre-commit
+++ b/utils/githooks/pre-commit
@@ -5,7 +5,7 @@ if [ -n "${NO_PRE_COMMIT:=""}" ]; then
     exit 0
 fi
 
-regex='(^\s*[\*/]*.*)((Copyright\s*)([0-9]{4})(-([0-9]{4}))?)(\s*(Intel.*$))'
+regex='(^[[:blank:]]*[\*/]*.*)((Copyright[[:blank:]]*)([0-9]{4})(-([0-9]{4}))?)([[:blank:]]*(Intel.*$))'
 year=$(date +%Y)
 errors=0
 


### PR DESCRIPTION
"\s" seems to be GNU specific. To make pre-commit work on BSDs, like
macOS, change "\s" to "[[:blank:]]".

Signed-off-by: Li Wei <wei.g.li@intel.com>