### PR TITLE
DAOS-6686 cart: Fix coverity defect

### DIFF
--- a/src/cart/crt_hg.c
+++ b/src/cart/crt_hg.c
@@ -874,7 +874,7 @@ crt_hg_req_create(struct crt_hg_context *hg_ctx, struct crt_rpc_priv *rpc_priv)
 			RPC_ERROR(rpc_priv,
 				  "HG_Create failed, hg_ret: %d\n",
 				  hg_ret);
-			rc = -DER_HG;
+			D_GOTO(out, rc = -DER_HG);
 		}
 	} else {
 		rpc_priv->crp_hg_hdl = rpc_priv->crp_hdl_reuse->chh_hdl;
@@ -885,7 +885,7 @@ crt_hg_req_create(struct crt_hg_context *hg_ctx, struct crt_rpc_priv *rpc_priv)
 			RPC_ERROR(rpc_priv,
 				  "HG_Reset failed, hg_ret: %d\n",
 				  hg_ret);
-			rc = -DER_HG;
+			D_GOTO(out, rc = -DER_HG);
 		}
 	}
 
@@ -898,10 +898,10 @@ crt_hg_req_create(struct crt_hg_context *hg_ctx, struct crt_rpc_priv *rpc_priv)
 			RPC_ERROR(rpc_priv,
 				  "HG_Set_target_id failed, hg_ret: %d\n",
 				  hg_ret);
-			rc = -DER_HG;
+			D_GOTO(out, rc = -DER_HG);
 		}
 	}
-
+out:
 	return rc;
 }
 


### PR DESCRIPTION
Fix possible NULL pointer dereference on error pass handling.
```
    	22. assign_zero: Assigning: rpc_priv->crp_hg_hdl = NULL.
 884                        rpc_priv->crp_hg_hdl = NULL;
 885                        RPC_ERROR(rpc_priv,
 886                                  "HG_Reset failed, hg_ret: %d\n",
 887                                  hg_ret);
 888                        rc = -DER_HG;
 889                }
 890        }
 891
 892        if (crt_gdata.cg_sep_mode == true) {
    	
CID 290781 (#1 of 1): Explicit null dereferenced (FORWARD_NULL)
28. var_deref_model: Passing null pointer rpc_priv->crp_hg_hdl to HG_Set_target_id, which dereferences it. [hide details]
 893                hg_ret = HG_Set_target_id(rpc_priv->crp_hg_hdl,
/install/prereq/release/mercury/include/mercury.h
1110HG_Set_target_id(hg_handle_t handle, hg_uint8_t id)
1111{
    	1. deref_parm: Directly dereferencing parameter handle.
1112    handle->info.context_id = id;
1113
1114    return HG_Core_set_target_id(handle->core_handle, id);
1115}
```