### PR TITLE
DAOS-6691 vos: exclude sys reserved space

### DIFF
--- a/src/pool/srv_target.c
+++ b/src/pool/srv_target.c
@@ -926,8 +926,19 @@ pool_query_one(void *vin)
 	x_ps->ps_ntargets = 1;
 	x_ps->ps_space.s_total[DAOS_MEDIA_SCM] = SCM_TOTAL(vps);
 	x_ps->ps_space.s_total[DAOS_MEDIA_NVME] = NVME_TOTAL(vps);
-	x_ps->ps_space.s_free[DAOS_MEDIA_SCM] = SCM_FREE(vps);
-	x_ps->ps_space.s_free[DAOS_MEDIA_NVME] = NVME_FREE(vps);
+
+	/* Exclude the sys reserved space before reporting to user */
+	if (SCM_FREE(vps) > SCM_SYS(vps))
+		x_ps->ps_space.s_free[DAOS_MEDIA_SCM] =
+				SCM_FREE(vps) - SCM_SYS(vps);
+	else
+		x_ps->ps_space.s_free[DAOS_MEDIA_SCM] = 0;
+
+	if (NVME_FREE(vps) > NVME_SYS(vps))
+		x_ps->ps_space.s_free[DAOS_MEDIA_NVME] =
+				NVME_FREE(vps) - NVME_SYS(vps);
+	else
+		x_ps->ps_space.s_free[DAOS_MEDIA_NVME] = 0;
 
 	for (i = DAOS_MEDIA_SCM; i < DAOS_MEDIA_MAX; i++) {
 		x_ps->ps_free_max[i] = x_ps->ps_space.s_free[i];


### PR DESCRIPTION
Exclude sys reserved space from the pool space query result.

Signed-off-by: Niu Yawei <yawei.niu@intel.com>