### PR TITLE
DAOS-6154 ras: Add GCC format attribute

### DIFF
--- a/src/include/daos_srv/ras.h
+++ b/src/include/daos_srv/ras.h
@@ -146,7 +146,7 @@ ds_notify_ras_event(ras_event_t id, char *msg, ras_type_t type, ras_sev_t sev,
  * with a '$' to indicate so. See ds_notify_ras_event for parameter
  * documentation.
  */
-void
+void __attribute__((__format__(__printf__, 12, 13)))
 ds_notify_ras_eventf(ras_event_t id, ras_type_t type, ras_sev_t sev, char *hwid,
 		     d_rank_t *rank, char *jobid, uuid_t *pool, uuid_t *cont,
 		     daos_obj_id_t *objid, char *ctlop, char *data,


### PR DESCRIPTION
Add a GCC format attribute so that the compiler checks the format string
and arguments, as Jeff suggested.

Signed-off-by: Li Wei <wei.g.li@intel.com>