### PR TITLE
DAOS-6255 placement: few fixes for placement

### DIFF
--- a/src/container/srv_container.c
+++ b/src/container/srv_container.c
@@ -1231,14 +1231,19 @@ cont_agg_eph_leader_ult(void *arg)
 					min_eph = ec_agg->ea_server_ephs[i].eph;
 			}
 
-			D_ASSERTF(min_eph >= ec_agg->ea_current_eph, DF_U64" < "
-				  DF_U64"\n", min_eph, ec_agg->ea_current_eph);
 			if (min_eph == ec_agg->ea_current_eph)
 				continue;
 
-			D_DEBUG(DB_MD, DF_CONT" sync "DF_U64"\n",
+			/**
+			 * NB: during extending or reintegration, the new
+			 * server might cause the minum epoch is less than
+			 * ea_current_eph.
+			 */
+			D_DEBUG(DB_MD, DF_CONT" minimum "DF_U64" current "
+				DF_U64"\n",
 				DP_CONT(svc->cs_pool_uuid,
-					ec_agg->ea_cont_uuid), min_eph);
+					ec_agg->ea_cont_uuid),
+				min_eph, ec_agg->ea_current_eph);
 			rc = cont_iv_ec_agg_eph_refresh(pool->sp_iv_ns,
 							ec_agg->ea_cont_uuid,
 							min_eph);

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -940,11 +940,10 @@ ec_deg_get:
 		D_GOTO(out, rc);
 
 	shard_tgt->st_rank	= obj_shard->do_target_rank;
-	shard_tgt->st_shard	= obj_shard->do_shard,
+	shard_tgt->st_shard	= shard;
 	shard_tgt->st_tgt_idx	= obj_shard->do_target_idx;
 	rc = obj_shard2tgtid(obj, shard, map_ver, &shard_tgt->st_tgt_id);
 	obj_shard_close(obj_shard);
-
 out:
 	return rc;
 }

--- a/src/object/srv_obj_migrate.c
+++ b/src/object/srv_obj_migrate.c
@@ -1897,6 +1897,13 @@ retry:
 			/* DER_DATA_LOSS means it can not find any replicas
 			 * to rebuild the data, see obj_list_common.
 			 */
+			if (rc == -DER_DATA_LOSS) {
+				D_DEBUG(DB_REBUILD, "No replicas for "DF_UOID
+					"\n", DP_UOID(arg->oid));
+				num = 0;
+				rc = 0;
+			}
+
 			D_DEBUG(DB_REBUILD, "Can not rebuild "
 				DF_UOID"\n", DP_UOID(arg->oid));
 			break;
@@ -2635,8 +2642,13 @@ migrate_check_one(void *data)
 	arg->executed_ult += tls->mpt_executed_ult;
 	if (arg->dms.dm_status == 0)
 		arg->dms.dm_status = tls->mpt_status;
-
 	ABT_mutex_unlock(arg->status_lock);
+
+	D_DEBUG(DB_REBUILD, "status %d/%d  rec/obj/size "
+		DF_U64"/"DF_U64"/"DF_U64"\n", tls->mpt_status,
+		arg->dms.dm_status, tls->mpt_rec_count,
+		tls->mpt_obj_count, tls->mpt_size);
+
 	migrate_pool_tls_put(tls);
 	return 0;
 }

--- a/src/placement/jump_map.c
+++ b/src/placement/jump_map.c
@@ -519,12 +519,6 @@ obj_remap_shards(struct pl_jump_map *jmap, struct daos_obj_md *md,
 			get_target(root, &spare_tgt, crc(key, rebuild_key),
 				   dom_used, tgts_used, shard_id, op_type);
 			spares_left--;
-			if (can_extend(op_type, spare_tgt->ta_comp.co_status)) {
-				rc = remap_alloc_one(extend_list, shard_id,
-						spare_tgt, true);
-				if (rc)
-					return rc;
-			}
 		}
 
 		determine_valid_spares(spare_tgt, md, spare_avail,
@@ -533,7 +527,7 @@ obj_remap_shards(struct pl_jump_map *jmap, struct daos_obj_md *md,
 	}
 
 	if (op_type == PL_PLACE_EXTENDED) {
-		rc = pl_map_extend(layout, extend_list, false);
+		rc = pl_map_extend(layout, extend_list);
 		if (rc != 0)
 			return rc;
 	}
@@ -925,7 +919,7 @@ jump_map_obj_place(struct pl_map *map, struct daos_obj_md *md,
 		layout_find_diff(jmap, layout, add_layout, &add_list);
 
 		if (!d_list_empty(&add_list))
-			rc = pl_map_extend(layout, &add_list, true);
+			rc = pl_map_extend(layout, &add_list);
 	}
 out:
 	remap_list_free_all(&remap_list);

--- a/src/placement/pl_map.h
+++ b/src/placement/pl_map.h
@@ -124,8 +124,7 @@ spec_place_rank_get(unsigned int *pos, daos_obj_id_t oid,
 		    struct pool_map *pl_poolmap);
 
 int
-pl_map_extend(struct pl_obj_layout *layout, d_list_t *extended_list,
-	      bool is_pool_adding);
+pl_map_extend(struct pl_obj_layout *layout, d_list_t *extended_list);
 
 bool
 is_pool_adding(struct pool_domain *dom);

--- a/src/placement/pl_map_common.c
+++ b/src/placement/pl_map_common.c
@@ -365,11 +365,9 @@ grp_map_extend(uint32_t *grp_map, uint32_t *grp_map_size)
 }
 
 int
-pl_map_extend(struct pl_obj_layout *layout, d_list_t *extended_list,
-	      bool is_pool_adding)
+pl_map_extend(struct pl_obj_layout *layout, d_list_t *extended_list)
 {
 	struct pl_obj_shard	*new_shards;
-	struct pl_obj_shard     *org_shard;
 	struct failed_shard	*f_shard;
 	struct failed_shard	*tmp;
 	uint32_t                *grp_map = NULL;
@@ -440,8 +438,6 @@ pl_map_extend(struct pl_obj_layout *layout, d_list_t *extended_list,
 	}
 
 	d_list_for_each_entry(f_shard, extended_list, fs_list) {
-		org_shard = &new_shards[f_shard->fs_shard_idx];
-
 		grp = f_shard->fs_shard_idx / layout->ol_grp_size;
 		grp_idx = ((grp + 1) * layout->ol_grp_size) + grp;
 		grp_count[grp]--;
@@ -450,12 +446,7 @@ pl_map_extend(struct pl_obj_layout *layout, d_list_t *extended_list,
 		new_shards[grp_idx].po_fseq = f_shard->fs_fseq;
 		new_shards[grp_idx].po_shard = f_shard->fs_shard_idx;
 		new_shards[grp_idx].po_target = f_shard->fs_tgt_id;
-		if (org_shard->po_target != -1 &&
-		    (is_pool_adding ||
-		     org_shard->po_fseq > f_shard->fs_fseq))
-			new_shards[grp_idx].po_rebuilding = 1;
-		else
-			new_shards[grp_idx].po_rebuilding = 0;
+		new_shards[grp_idx].po_rebuilding = 1;
 	}
 
 	layout->ol_grp_size += max_fail_grp;

--- a/src/pool/srv_target.c
+++ b/src/pool/srv_target.c
@@ -692,10 +692,10 @@ ds_pool_stop(uuid_t uuid)
 		return;
 	pool->sp_stopping = 1;
 
+	ds_iv_ns_stop(pool->sp_iv_ns);
 	ds_pool_tgt_ec_eph_query_abort(pool);
 	pool_fetch_hdls_ult_abort(pool);
 
-	ds_iv_ns_stop(pool->sp_iv_ns);
 	ds_rebuild_abort(pool->sp_uuid, -1);
 	ds_migrate_abort(pool->sp_uuid, -1);
 	ds_pool_put(pool); /* held by ds_pool_start */


### PR DESCRIPTION
1. st_shard in shard_tgt should be the real offset
of the shard in object shards array.

2. Do not add new remap shards to the extend list for
remap shards for reintegration layout.

3. Using real group size, instead of object class group
size to calculate the group index.

4 add tests to verify large stripe rebuild/reintegration.

Signed-off-by: Di Wang <di.wang@intel.com>