### PR TITLE
DAOS-6654 bigio: re-enable the HDF5 VOL bigio test

### DIFF
--- a/src/tests/ftest/daos_vol/bigio.py
+++ b/src/tests/ftest/daos_vol/bigio.py
@@ -6,7 +6,6 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 """
 from vol_test_base import VolTestBase
 from job_manager_utils import get_job_manager
-from apricot import skipForTicket
 
 
 class DaosVol(VolTestBase):
@@ -16,7 +15,6 @@ class DaosVol(VolTestBase):
     :avocado: recursive
     """
 
-    @skipForTicket("DAOS-6654")
     def test_daos_vol_bigio(self):
         """Jira ID: DAOS-3656.
 

--- a/src/tests/ftest/daos_vol/bigio.yaml
+++ b/src/tests/ftest/daos_vol/bigio.yaml
@@ -3,22 +3,43 @@ hosts:
         - server-A
     test_clients:
         - client-B
-timeout: 7200
+timeout: 1000
 server_config:
+    engines_per_host: 2
     name: daos_server
+    crt_timeout: 60
     servers:
-        bdev_class: nvme
-        bdev_list: ["0000:81:00.0","0000:da:00.0"]
+      0:
+        pinned_numa_node: 0
+        nr_xs_helpers: 4
+        fabric_iface: ib0
+        fabric_iface_port: 31317
+        log_file: daos_server0.log
         scm_class: dcpm
         scm_list: ["/dev/pmem0"]
+        scm_mount: /mnt/daos0
         env_vars:
-            - SWIM_PING_TIMEOUT=1800
-            - SWIM_SUSPECT_TIMEOUT=16000
+          - D_LOG_FILE_APPEND_PID=1
+          - FI_LOG_LEVEL=warn
+          - D_LOG_STDERR_IN_LOG=1
+      1:
+        pinned_numa_node: 1
+        nr_xs_helpers: 4
+        fabric_iface: ib1
+        fabric_iface_port: 31417
+        log_file: daos_server1.log
+        scm_class: dcpm
+        scm_list: ["/dev/pmem1"]
+        scm_mount: /mnt/daos1
+        env_vars:
+          - D_LOG_FILE_APPEND_PID=1
+          - FI_LOG_LEVEL=warn
+          - D_LOG_STDERR_IN_LOG=1
 pool:
     control_method: dmg
     mode: 511
     name: daos_server
-    scm_size: 100G
+    scm_size: 200G
     nvme_size: 200G
 container:
     type: POSIX

--- a/src/tests/ftest/daos_vol/h5_suite.yaml
+++ b/src/tests/ftest/daos_vol/h5_suite.yaml
@@ -8,6 +8,7 @@ job_manager:
     manager_timeout: 900
 server_config:
     name: daos_server
+    crt_timeout: 60
     servers:
         bdev_class: nvme
         bdev_list: ["0000:81:00.0", "0000:da:00.0"]

--- a/src/tests/ftest/mpiio/hdf5.yaml
+++ b/src/tests/ftest/mpiio/hdf5.yaml
@@ -6,6 +6,7 @@ hosts:
 timeout: 200
 server_config:
     name: daos_server
+    crt_timeout: 60
     servers:
         bdev_class: nvme
         bdev_list: ["0000:81:00.0","0000:da:00.0"]

--- a/src/tests/ftest/scripts/setup_nodes.sh
+++ b/src/tests/ftest/scripts/setup_nodes.sh
@@ -54,12 +54,17 @@ for x in \$(cd /sys/class/net/ && ls -d ib*); do
 done >> /etc/sysctl.d/10-daos-verbs.conf
 sysctl --system
 if [ \"\$(ulimit -c)\" != \"unlimited\" ]; then
-    echo \"*  soft  core  unlimited\" >> /etc/security/limits.conf
+    echo \"*  soft  core  unlimited\" >> /etc/security/limits.d/80_daos_limits.conf
 fi
 if [ \"\$(ulimit -l)\" != \"unlimited\" ]; then
-    echo \"*  soft  memlock  unlimited\" >> /etc/security/limits.conf
-    echo \"*  hard  memlock  unlimited\" >> /etc/security/limits.conf
+    echo \"*  soft  memlock  unlimited\" >> /etc/security/limits.d/80_daos_limits.conf
+    echo \"*  hard  memlock  unlimited\" >> /etc/security/limits.d/80_daos_limits.conf
 fi
+if [ \"\$(ulimit -n)\" != \"1048576\" ]; then
+    echo \"*  soft  nofile 1048576\" >> /etc/security/limits.d/80_daos_limits.conf
+    echo \"*  hard  nofile 1048576\" >> /etc/security/limits.d/80_daos_limits.conf
+fi
+cat /etc/security/limits.d/80_daos_limits.conf
 ulimit -a
 echo \"/var/tmp/core.%e.%t.%p\" > /proc/sys/kernel/core_pattern"
 sudo rm -f /var/tmp/core.*

--- a/src/tests/ftest/util/vol_test_base.py
+++ b/src/tests/ftest/util/vol_test_base.py
@@ -47,8 +47,6 @@ class VolTestBase(DfuseTestBase):
 
         env = EnvironmentVariables()
         env["DAOS_POOL"] = "{}".format(self.pool.uuid)
-        env["DAOS_SVCL"] = "{}".format(",".join([str(item) for item in
-                                                 self.pool.svc_ranks]))
         env["DAOS_CONT"] = "{}".format(self.container.uuid)
         env["HDF5_VOL_CONNECTOR"] = "daos"
         env["HDF5_PLUGIN_PATH"] = "{}".format(plugin_path)


### PR DESCRIPTION
- bump ulimits using 80_daos_limits.conf to override the one deployed by provisioning
- increase crt_timeout for some hdf5 test to 60 (since the timeout used was 10 which will cause RPC timeouts)

Quick-Functional: true
Test-tag: volbigio volunit hdf5testsuite

Signed-off-by: Mohamad Chaarawi <mohamad.chaarawi@intel.com>