### PR TITLE
DAOS-6486 dfuse: Use new dfs_lookupx function to check for xattrs.

### DIFF
--- a/src/client/dfuse/ops/lookup.c
+++ b/src/client/dfuse/ops/lookup.c
@@ -145,11 +145,9 @@ out_err:
  */
 static int
 check_for_uns_ep(struct dfuse_projection_info *fs_handle,
-		 struct dfuse_inode_entry *ie)
+		 struct dfuse_inode_entry *ie, char *attr, daos_size_t len)
 {
 	int			rc;
-	char			str[DUNS_MAX_XATTR_LEN];
-	daos_size_t		str_len = DUNS_MAX_XATTR_LEN;
 	struct duns_attr_t	dattr = {};
 	struct dfuse_dfs	*dfs = NULL;
 	struct dfuse_dfs	*dfsi;
@@ -159,15 +157,7 @@ check_for_uns_ep(struct dfuse_projection_info *fs_handle,
 	int			new_cont = false;
 	int ret;
 
-	rc = dfs_getxattr(ie->ie_dfs->dfs_ns, ie->ie_obj, DUNS_XATTR_NAME,
-			  &str, &str_len);
-
-	if (rc == ENODATA)
-		return 0;
-	if (rc)
-		return rc;
-
-	rc = duns_parse_attr(&str[0], str_len, &dattr);
+	rc = duns_parse_attr(attr, len, &dattr);
 	if (rc)
 		return rc;
 
@@ -332,6 +322,10 @@ dfuse_cb_lookup(fuse_req_t req, struct dfuse_inode_entry *parent,
 	struct dfuse_projection_info	*fs_handle = fuse_req_userdata(req);
 	struct dfuse_inode_entry	*ie = NULL;
 	int				rc;
+	char				*attr_name = DUNS_XATTR_NAME;
+	char				out[DUNS_MAX_XATTR_LEN];
+	char				*outp = &out[0];
+	daos_size_t			attr_len = DUNS_MAX_XATTR_LEN;
 
 	DFUSE_TRA_DEBUG(fs_handle,
 			"Parent:%lu '%s'", parent->ie_stat.st_ino, name);
@@ -345,9 +339,9 @@ dfuse_cb_lookup(fuse_req_t req, struct dfuse_inode_entry *parent,
 	ie->ie_parent = parent->ie_stat.st_ino;
 	ie->ie_dfs = parent->ie_dfs;
 
-	rc = dfs_lookup_rel(parent->ie_dfs->dfs_ns, parent->ie_obj, name,
-			    O_RDWR | O_NOFOLLOW, &ie->ie_obj,
-			    NULL, &ie->ie_stat);
+	rc = dfs_lookupx(parent->ie_dfs->dfs_ns, parent->ie_obj, name,
+			 O_RDWR | O_NOFOLLOW, &ie->ie_obj, NULL, &ie->ie_stat,
+			 1, &attr_name, (void **)&outp, &attr_len);
 	if (rc) {
 		DFUSE_TRA_DEBUG(parent, "dfs_lookup() failed: (%s)",
 				strerror(rc));
@@ -364,12 +358,14 @@ dfuse_cb_lookup(fuse_req_t req, struct dfuse_inode_entry *parent,
 		D_GOTO(err, rc);
 	}
 
+	DFUSE_TRA_DEBUG(ie, "Attr len is %zi", attr_len);
+
 	strncpy(ie->ie_name, name, NAME_MAX);
 	ie->ie_name[NAME_MAX] = '\0';
 	atomic_store_relaxed(&ie->ie_ref, 1);
 
-	if (S_ISFIFO(ie->ie_stat.st_mode)) {
-		rc = check_for_uns_ep(fs_handle, ie);
+	if (S_ISFIFO(ie->ie_stat.st_mode) && attr_len) {
+		rc = check_for_uns_ep(fs_handle, ie, out, attr_len);
 		DFUSE_TRA_DEBUG(ie,
 				"check_for_uns_ep() returned %d", rc);
 		if (rc != 0 && rc != EPERM)

--- a/utils/node_local_test.py
+++ b/utils/node_local_test.py
@@ -1097,6 +1097,17 @@ class posix_tests():
         nf = os.stat(fname)
         assert stat.S_IMODE(nf.st_mode) == e_mode
 
+    @needs_dfuse
+    def test_uns_create(self):
+        """Simple test to create a container using a path in dfuse"""
+        path = os.path.join(self.dfuse.dir, 'mycont')
+        cmd = ['container', 'create',
+               '--pool', self.pool, '--path', path,
+               '--type', 'POSIX']
+        rc = run_daos_cmd(self.conf, cmd)
+        assert rc.returncode == 0
+        print(os.listdir(path))
+
 def run_posix_tests(server, conf, test=None):
     """Run one or all posix tests"""
 


### PR DESCRIPTION
Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>