### PR TITLE
CART-89 tests: Fix five node tests

### DIFF
--- a/src/tests/ftest/cart/ctl/cart_ctl_five_node.py
+++ b/src/tests/ftest/cart/ctl/cart_ctl_five_node.py
@@ -57,9 +57,7 @@ class CartCtlFiveNodeTest(TestWithoutServers):
             self.fail("Server did not launch, return code %s" \
                        % procrtn)
 
-        time.sleep(5)
-
-        for index in range(2):
+        for index in range(3):
             clicmd = self.utils.build_cmd(
                 self, self.env, "test_clients", index=index)
             self.utils.launch_test(self, clicmd, srv_rtn)

--- a/src/tests/ftest/cart/ctl/cart_ctl_five_node.py
+++ b/src/tests/ftest/cart/ctl/cart_ctl_five_node.py
@@ -8,7 +8,6 @@
 from __future__ import print_function
 
 import sys
-import time
 
 from apricot  import TestWithoutServers
 
@@ -63,7 +62,3 @@ class CartCtlFiveNodeTest(TestWithoutServers):
             self.utils.launch_test(self, clicmd, srv_rtn)
 
         self.utils.stop_process(srv_rtn)
-
-
-if __name__ == "__main__":
-    main()

--- a/src/tests/ftest/cart/ctl/cart_ctl_five_node.yaml
+++ b/src/tests/ftest/cart/ctl/cart_ctl_five_node.yaml
@@ -29,13 +29,16 @@ tests: !mux
   ctl:
     name: ctl_basic
     test_servers_bin: crt_launch
-    test_servers_arg: "-e ../tests/test_group_np_srv --name server_grp"
+    test_servers_arg: "-e ../tests/test_group_np_srv --name server_grp_five_node"
     test_servers_env: ""
     test_servers_ppn: "1"
-
-    test_clients_bin: cart_ctl
+    test_clients_bin:
+      - cart_ctl
+      - cart_ctl
+      - ../tests/test_group_np_cli
     test_clients_env: ""
     test_clients_ppn: "1"
     test_clients_arg:
-      - "get_uri_cache --group-name server_grp --rank 0,2-3,4"
-      - "list_ctx --group-name server_grp --rank 0,2-3,4"
+      - "get_uri_cache --group-name server_grp_five_node --rank 0,2-3,4"
+      - "list_ctx --group-name server_grp_five_node --rank 0,2-3,4"
+      - "--name client-group --attach_to server_grp_five_node --shut_only"


### PR DESCRIPTION
- Add client shutdown command to five node test, instead of letting
servers to expire.
- Remove unneeded sleeps in the test as cart_ctl will perform retries
to connect to the group

Signed-off-by: Alexander Oganezov <alexander.a.oganezov@intel.com>