### PR TITLE
DAOS-6452 test: dmg pool query test failed due to unexpected output

### DIFF
--- a/src/tests/ftest/control/dmg_pool_query_test.py
+++ b/src/tests/ftest/control/dmg_pool_query_test.py
@@ -6,7 +6,6 @@
 """
 from __future__ import print_function
 
-from apricot import skipForTicket
 from ior_test_base import IorTestBase
 from test_utils_pool import TestPool
 from control_test_base import ControlTestBase

--- a/src/tests/ftest/control/dmg_pool_query_test.py
+++ b/src/tests/ftest/control/dmg_pool_query_test.py
@@ -42,7 +42,6 @@ class DmgPoolQueryTest(ControlTestBase, IorTestBase):
         self.log.info("==>   Running dmg pool query:")
         return self.dmg.pool_query(uuid)
 
-    @skipForTicket("DAOS-6452")
     def test_pool_query_basic(self):
         """
         JIRA ID: DAOS-2976
@@ -93,9 +92,9 @@ class DmgPoolQueryTest(ControlTestBase, IorTestBase):
             "rebuild": {
                 "status": self.params.get(
                     "status", path="/run/exp_vals/rebuild/*"),
-                "objects": self.params.get(
+                "status3": self.params.get(
                     "objects", path="/run/exp_vals/rebuild/*"),
-                "records": self.params.get(
+                "status2": self.params.get(
                     "records", path="/run/exp_vals/rebuild/*"),
             }
         }


### PR DESCRIPTION
Fixed issue by modifying dictionary key names to
match those in utils/dmg_utils.py.

Test-tag-hw-small: pr,hw,small dmg
Signed-off-by: Anders Skaar <ajskaar@gmail.com>