### PR TITLE
DAOS-6722 placement: placement algorithm improvements

### DIFF
--- a/src/include/daos/placement.h
+++ b/src/include/daos/placement.h
@@ -52,7 +52,7 @@ struct pl_target_grp {
 	/** pool map version to generate this layout */
 	uint32_t		 tg_ver;
 	/** number of targets */
-	unsigned int		 tg_target_nr;
+	uint32_t		 tg_target_nr;
 	/** array of targets */
 	struct pl_target	*tg_targets;
 };

--- a/src/include/daos/pool_map.h
+++ b/src/include/daos/pool_map.h
@@ -59,14 +59,16 @@ enum pool_component_flags {
 
 /** parent class of all all pool components: target, domain */
 struct pool_component {
+	/** Immutable component ID. */
+	uint32_t		co_id;
 	/** pool_comp_type_t */
 	uint16_t		co_type;
 	/** pool_comp_state_t */
 	uint8_t			co_status;
 	/** target index inside the node */
 	uint8_t			co_index;
-	/** Immutable component ID. */
-	uint32_t		co_id;
+	/** number of children or storage partitions */
+	uint32_t		co_nr;
 	/**
 	 * e.g. rank in the communication group, only used by PO_COMP_TARGET
 	 * for the time being.
@@ -83,8 +85,6 @@ struct pool_component {
 	uint32_t		co_out_ver;
 	/** flags, see enum pool_component_flags */
 	uint32_t		co_flags;
-	/** number of children or storage partitions */
-	uint32_t		co_nr;
 };
 
 /** a leaf of pool map */
@@ -102,7 +102,7 @@ struct pool_domain {
 	/** embedded component for myself */
 	struct pool_component	 do_comp;
 	/** # all targets within this domain */
-	unsigned int		 do_target_nr;
+	uint32_t		 do_target_nr;
 	/**
 	 * child domains within current domain, it is NULL for the last
 	 * level domain.

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -327,9 +327,6 @@ obj_layout_create(struct dc_object *obj, bool refresh)
 		layout->ol_ver);
 	D_ASSERT(layout->ol_nr == layout->ol_grp_size * layout->ol_grp_nr);
 
-	if (refresh)
-		obj_layout_dump(obj->cob_md.omd_id, layout);
-
 	obj->cob_version = layout->ol_ver;
 
 	D_ASSERT(obj->cob_shards == NULL);
@@ -345,8 +342,7 @@ obj_layout_create(struct dc_object *obj, bool refresh)
 
 	if (obj->cob_grp_size > 1 && srv_io_mode == DIM_DTX_FULL_ENABLED &&
 	    old < obj->cob_grp_nr) {
-		if (obj->cob_time_fetch_leader != NULL)
-			D_FREE(obj->cob_time_fetch_leader);
+		D_FREE(obj->cob_time_fetch_leader);
 
 		D_ALLOC_ARRAY(obj->cob_time_fetch_leader, obj->cob_grp_nr);
 		if (obj->cob_time_fetch_leader == NULL)

--- a/src/placement/jump_map.c
+++ b/src/placement/jump_map.c
@@ -329,10 +329,10 @@ find_rth_bit(uint64_t v, uint32_t r)
 	uint32_t s = 64;
 	uint32_t t;
 
-	a =  v - ((v >> 1) & ~0UL/3);
-	b = (a & ~0UL/5) + ((a >> 2) & ~0UL/5);
-	c = (b + (b >> 4)) & ~0UL/0x11;
-	d = (c + (c >> 8)) & ~0UL/0x101;
+	a =  v - ((v >> 1) & ~0UL / 3);
+	b = (a & ~0UL / 5) + ((a >> 2) & ~0UL / 5);
+	c = (b + (b >> 4)) & ~0UL / 0x11;
+	d = (c + (c >> 8)) & ~0UL / 0x101;
 	t = (d >> 32) + (d >> 48);
 
 	s -= ((t - r) & 256) >> 3; r -= (t & ((t - r) >> 8));
@@ -371,23 +371,28 @@ find_unused(uint8_t *array, uint32_t start, uint32_t end)
 
 	do {
 		if (n <= 8) {
-			uint8_t *p8 = (uint8_t*)((char*)array + i);
+			uint8_t *p8 = (uint8_t *)((char *)array + i);
+
 			v = ~*p8 & (0xFFUL >> (8 - n));
 			n = 0;
 		} else if (n <= 16) {
-			uint16_t *p16 = (uint16_t*)((char*)array + i);
+			uint16_t *p16 = (uint16_t *)((char *)array + i);
+
 			v = ~*p16 & (0xFFFFUL >> (16 - n));
 			n = 0;
 		} else if (n <= 32) {
-			uint32_t *p32 = (uint32_t*)((char*)array + i);
+			uint32_t *p32 = (uint32_t *)((char *)array + i);
+
 			v = ~*p32 & (0xFFFFFFFFUL >> (32 - n));
 			n = 0;
 		} else if (n <= 64) {
-			uint64_t *p64 = (uint64_t*)((char*)array + i);
+			uint64_t *p64 = (uint64_t *)((char *)array + i);
+
 			v = ~*p64 & (0xFFFFFFFFFFFFFFFFUL >> (64 - n));
 			n = 0;
 		} else {
-			uint64_t *p64 = (uint64_t*)((char*)array + i);
+			uint64_t *p64 = (uint64_t *)((char *)array + i);
+
 			v = ~*p64;
 			n -= 64;
 		}

--- a/src/placement/pl_map_common.c
+++ b/src/placement/pl_map_common.c
@@ -447,9 +447,9 @@ pl_map_extend(struct pl_obj_layout *layout, d_list_t *extended_list,
 		grp_count[grp]--;
 		grp_idx += grp_count[grp];
 
-		new_shards[grp_idx].po_fseq = f_shard->fs_fseq;
-		new_shards[grp_idx].po_shard = f_shard->fs_shard_idx;
+		new_shards[grp_idx].po_shard  = f_shard->fs_shard_idx;
 		new_shards[grp_idx].po_target = f_shard->fs_tgt_id;
+		new_shards[grp_idx].po_fseq   = f_shard->fs_fseq;
 		if (org_shard->po_target != -1 &&
 		    (is_pool_adding ||
 		     org_shard->po_fseq > f_shard->fs_fseq))


### PR DESCRIPTION
The issue with current implementation is it spend a lot of time to
find unused target when try to widely place. It calculate new hash
in the loop until it will point to next unused target. The time of
this calculation is unpredictable and in worst case can take a very
long time.

The idea of improvement is to make the time of placement predictable
and independent from widely placing. Now if first hash points to
used target it try to find first unused target around proposed in
the window of 64 targets size. If it still fails (all 64 targets
are used in this window) it search unused target in whole available
targets array. So, only one hash calculation is required now and in
worst case two linear searches into bits arrays.

Additionally it searches for root domain only once and then pass it
into subsequent functions.

Same of structure members were rearranged for better cache utilization
and prefetching.

The debug dumps functions are called only if appropriate debug level
is set.