### PR TITLE
DAOS-5157 mgmt: report -DER_PROTO when getattachinfo from new server

### DIFF
--- a/src/mgmt/cli_mgmt.c
+++ b/src/mgmt/cli_mgmt.c
@@ -637,7 +637,7 @@ attach(const char *name, int npsrbs, struct psr_buf *psrbs,
 		goto err_sys;
 	if (sys->sy_npsrs < 1) {
 		D_ERROR(">= 1 PSRs required: %d\n", sys->sy_npsrs);
-		rc = -DER_MISC;
+		rc = -DER_PROTO;
 		goto err_psrs;
 	}
 


### PR DESCRIPTION
When 1.1.x client tries to getattachinfo from 1.2 server, the server
will not reply related ranks information. Currently, client reports
"Miscellaneous error (-1025)" under such case. That is some confused.
The patch changes it as "Incompatible protocol (-1014)".

Signed-off-by: Fan Yong <fan.yong@intel.com>