### PR TITLE
DAOS-6723 iosrv: Call sm_fini when shutting down server modules.

### DIFF
--- a/src/iosrv/module.c
+++ b/src/iosrv/module.c
@@ -218,7 +218,6 @@ dss_module_unload_internal(struct loaded_mod *lmod)
 	if (rc) {
 		D_ERROR("module finalization failed for: "DF_RC"\n", DP_RC(rc));
 		return rc;
-
 	}
 
 close_mod:
@@ -259,7 +258,6 @@ dss_module_init_all(uint64_t *mod_facs)
 
 	return rc;
 }
-
 
 int
 dss_module_unload(const char *modname)
@@ -361,6 +359,7 @@ dss_module_unload_all(void)
 	D_INIT_LIST_HEAD(&destroy_list);
 	D_MUTEX_LOCK(&loaded_mod_list_lock);
 	d_list_for_each_entry_safe(mod, tmp, &loaded_mod_list, lm_lk) {
+		dss_module_unload_internal(mod);
 		d_list_del_init(&mod->lm_lk);
 		d_list_add(&mod->lm_lk, &destroy_list);
 	}

--- a/src/rdb/rdb.c
+++ b/src/rdb/rdb.c
@@ -175,8 +175,8 @@ rdb_hash_init(void)
 	if (rc != ABT_SUCCESS)
 		return dss_abterr2der(rc);
 	rc = d_hash_table_create_inplace(D_HASH_FT_NOLOCK, 4 /* bits */,
-					NULL /* priv */, &rdb_hash_ops,
-					&rdb_hash);
+					 NULL /* priv */, &rdb_hash_ops,
+					 &rdb_hash);
 	if (rc != 0)
 		ABT_mutex_free(&rdb_hash_lock);
 	return rc;
@@ -410,6 +410,11 @@ void
 rdb_stop(struct rdb *db)
 {
 	bool deleted;
+
+	if (db == NULL) {
+		D_ERROR("db is NULL\n");
+		return;
+	}
 
 	D_DEBUG(DB_MD, DF_DB": stopping db %p\n", DP_DB(db), db);
 	ABT_mutex_lock(rdb_hash_lock);

--- a/src/tests/ftest/cart/util/cart_logtest.py
+++ b/src/tests/ftest/cart/util/cart_logtest.py
@@ -175,11 +175,11 @@ shown_logs = set()
 # specifically, key is function name, value is list of variables.
 # Both the alloc and free function need to be whitelisted.
 
-mismatch_table = {'container': ('common'),
-                  'client': ('array'),
+mismatch_table = {'client': ('array'),
+                  'daos': ('common', 'container', 'pool'),
                   'common': ('container', 'pool'),
-                  'daos': ('common'),
-                  'mgmt': ('common', 'daos', 'pool'),
+                  'container': ('common'),
+                  'mgmt': ('common', 'daos', 'pool', 'rscv'),
                   'misc': ('common', 'mgmt'),
                   'pool': ('common'),
                   'server': ('daos')}

--- a/src/tests/ftest/cart/util/cart_logtest.py
+++ b/src/tests/ftest/cart/util/cart_logtest.py
@@ -179,7 +179,7 @@ mismatch_table = {'client': ('array'),
                   'daos': ('common', 'container', 'pool'),
                   'common': ('container', 'pool'),
                   'container': ('common'),
-                  'mgmt': ('common', 'daos', 'pool', 'rscv'),
+                  'mgmt': ('common', 'daos', 'pool', 'rsvc'),
                   'misc': ('common', 'mgmt'),
                   'pool': ('common'),
                   'server': ('daos')}


### PR DESCRIPTION
This call must have been dropped at some point in the past and
was causing a number of server memory leaks.
Fix a crash caused by double-shutdown of the rdb code.
Add D_ALLOC logging to one place in the drpc code.

Overall this improves the shutdown, and closes a number of
memory leaks in the server.

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>