### PR TITLE
DAOS-6702 rdb,test: fix conditional in printf, Coverity issue

### DIFF
--- a/src/rdb/tests/rdbt.c
+++ b/src/rdb/tests/rdbt.c
@@ -259,7 +259,7 @@ resp_valid_check:
 		if (!resp_isvalid) {
 			printf("ERR: rank %u invalid reply: rc="DF_RC", "
 			       "hint is %s valid (rank=%u, term="DF_U64")\n",
-			       rank, DP_RC(rc_svc), resp_isvalid ? "" : "NOT",
+			       rank, DP_RC(rc_svc), hint_isvalid ? "" : "NOT",
 			       h.sh_rank, h.sh_term);
 			rc = -1;
 			break;


### PR DESCRIPTION
Coverity issue ID 303781 revealed a bug in PR 2708 in the
rdbt_find_leader() function. Change the check for resp_invalid
to hint_isvalid since that is what the printf argument refers to.

Skip-test: true

Signed-off-by: Kenneth Cain <kenneth.c.cain@intel.com>