### PR TITLE
DAOS-5868 rebuild: check rgt in rebuild_task_ult

### DIFF
--- a/src/include/daos_srv/iv.h
+++ b/src/include/daos_srv/iv.h
@@ -30,8 +30,8 @@ struct ds_iv_ns {
 	/* pool uuid */
 	uuid_t		iv_pool_uuid;
 
-	int		iv_refcount;
 	ABT_eventual	iv_done_eventual;
+	int		iv_refcount;
 	/**
 	 * iv_fini: the IV namespace will be stopped, usually happens
 	 * the pool will be destroyed.

--- a/src/rebuild/srv.c
+++ b/src/rebuild/srv.c
@@ -1308,11 +1308,12 @@ output:
 			DP_UUID(task->dst_pool_uuid));
 
 	ds_pool_put(pool);
-	ABT_mutex_lock(rgt->rgt_lock);
-	ABT_cond_signal(rgt->rgt_done_cond);
-	ABT_mutex_unlock(rgt->rgt_lock);
-	if (rgt)
+	if (rgt) {
+		ABT_mutex_lock(rgt->rgt_lock);
+		ABT_cond_signal(rgt->rgt_done_cond);
+		ABT_mutex_unlock(rgt->rgt_lock);
 		rgt_put(rgt);
+	}
 
 	rebuild_task_destroy(task);
 	rebuild_gst.rg_inflight--;


### PR DESCRIPTION
1. check rgt in rebuild_task_ult.

2. reverse iv_refcount and iv_done_eventual
in ds_iv_ns to save some bytes.

Signed-off-by: Di Wang <di.wang@intel.com>