### PR TITLE
DAOS-6724 object: unexpected opc in function obj_embedded_shard_arg()

### DIFF
--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -2421,6 +2421,12 @@ obj_embedded_shard_arg(struct obj_auxi_args *obj_auxi)
 		return &obj_auxi->l_args.la_auxi;
 	case DAOS_OBJ_RPC_SYNC:
 		return &obj_auxi->s_args.sa_auxi;
+	case DAOS_OBJ_RPC_QUERY_KEY:
+		/*
+		 * called from obj_comp_cb_internal() and
+		 * checked in obj_shard_comp_cb() correctly
+		 */
+		return NULL;
 	default:
 		D_ERROR("bad opc %d.\n", obj_auxi->opc);
 		return NULL;


### PR DESCRIPTION
It was discovered the call from obj_comp_cb_internal() during error path
and it is checked in obj_shard_comp_cb() correctly but reports an error.