### PR TITLE
DAOS-6737 smd: Fix storage query with no NVMe

### DIFF
--- a/src/bio/smd/smd_internal.h
+++ b/src/bio/smd/smd_internal.h
@@ -39,6 +39,7 @@ int smd_db_tx_begin(void);
 int smd_db_tx_end(int rc);
 void smd_db_lock(void);
 void smd_db_unlock(void);
+bool smd_db_ready(void);
 
 /* smd_pool.c */
 int

--- a/src/bio/smd/smd_pool.c
+++ b/src/bio/smd/smd_pool.c
@@ -271,6 +271,9 @@ smd_pool_list(d_list_t *pool_list, int *pools)
 	td.td_count = 0;
 	D_INIT_LIST_HEAD(&td.td_list);
 
+	if (!smd_db_ready())
+		return 0; /* There is no NVMe, smd will not be initialized */
+
 	smd_db_lock();
 	rc = smd_db_traverse(TABLE_POOL, smd_pool_list_cb, &td);
 	smd_db_unlock();

--- a/src/bio/smd/smd_store.c
+++ b/src/bio/smd/smd_store.c
@@ -74,6 +74,12 @@ smd_db_tx_end(int rc)
 		return rc;
 }
 
+bool
+smd_db_ready(void)
+{
+	return smd_db != NULL;
+}
+
 void
 smd_db_lock(void)
 {


### PR DESCRIPTION
If there is no NVMe storage, the storage query
seg faults trying to list smd pools.  Add
smd_db_ready() API to avoid trying to list the pools
in such case.

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>