### PR TITLE
DAOS-6734 misc: coverity defects

### DIFF
--- a/ci/codespell.ignores
+++ b/ci/codespell.ignores
@@ -21,3 +21,4 @@ cancelled
 controllerd
 ether
 expport
+coo

--- a/src/common/pool_map.c
+++ b/src/common/pool_map.c
@@ -1395,6 +1395,7 @@ gen_pool_buf(struct pool_map *map, struct pool_buf **map_buf_out,
 		map_comp.co_id = i + num_comps;
 		map_comp.co_rank = 0;
 		map_comp.co_ver = map_version;
+		map_comp.co_out_ver = map_version;
 		map_comp.co_fseq = 1;
 		map_comp.co_nr = domains[i];
 

--- a/src/container/srv_container.c
+++ b/src/container/srv_container.c
@@ -1236,7 +1236,7 @@ cont_agg_eph_leader_ult(void *arg)
 
 			/**
 			 * NB: during extending or reintegration, the new
-			 * server might cause the minum epoch is less than
+			 * server might cause the minimum epoch is less than
 			 * ea_current_eph.
 			 */
 			D_DEBUG(DB_MD, DF_CONT" minimum "DF_U64" current "
@@ -3145,6 +3145,10 @@ out:
 		struct cont_query_out  *cqo = crt_reply_get(rpc);
 
 		prop = cqo->cqo_prop;
+	} else if (opc == CONT_OPEN) {
+		struct cont_open_out *coo = crt_reply_get(rpc);
+
+		prop = coo->coo_prop;
 	}
 	out->co_rc = rc;
 	crt_reply_send(rpc);


### PR DESCRIPTION
1. free prop for cont_open handler.
2. initialize co_out_ver during map initialization.

Signed-off-by: Di Wang <di.wang@intel.com>