### PR TITLE
DAOS-6729 SDL: Two coverity defects

### DIFF
--- a/src/bio/bio_context.c
+++ b/src/bio/bio_context.c
@@ -168,12 +168,16 @@ blob_cb(void *arg, int rc)
 static void
 blob_wait_completion(struct bio_xs_context *xs_ctxt, struct blob_cp_arg *ba)
 {
+	int	rc;
+
 	D_ASSERT(xs_ctxt != NULL);
 	if (xs_ctxt->bxc_tgt_id == -1) {
 		D_DEBUG(DB_IO, "Self poll xs_ctxt:%p\n", xs_ctxt);
 		xs_poll_completion(xs_ctxt, &ba->bca_inflights);
 	} else {
-		ABT_eventual_wait(ba->bca_eventual, NULL);
+		rc = ABT_eventual_wait(ba->bca_eventual, NULL);
+		if (rc != ABT_SUCCESS)
+			D_ERROR("ABT eventual wait failed. %d", rc);
 	}
 }
 

--- a/src/container/srv_target.c
+++ b/src/container/srv_target.c
@@ -1358,6 +1358,7 @@ ds_cont_local_open(uuid_t pool_uuid, uuid_t cont_hdl_uuid, uuid_t cont_uuid,
 		 * NB: When cont_uuid == NULL, it's not a real container open
 		 *     but for creating rebuild global container handle.
 		 */
+		D_ASSERT(hdl->sch_cont != NULL);
 		hdl->sch_cont->sc_open++;
 
 		if (hdl->sch_cont->sc_open > 1)
@@ -1414,8 +1415,7 @@ err_register:
 	if (hdl->sch_cont->sc_open == 0)
 		dtx_batched_commit_deregister(hdl->sch_cont);
 err_reindex:
-	if (hdl->sch_cont)
-		cont_stop_dtx_reindex_ult(hdl->sch_cont);
+	cont_stop_dtx_reindex_ult(hdl->sch_cont);
 err_cont:
 	if (daos_handle_is_valid(poh)) {
 		D_DEBUG(DF_DSMS, DF_CONT": destroying new vos container\n",


### PR DESCRIPTION
- Dereference before NULL check in src/container/srv_target.c
- Unchecked return value in src/bio/bio_context.c

Signed-off-by: Niu Yawei <yawei.niu@intel.com>