### PR TITLE
CORCI-1052 build: Fix pipeline API breakage

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1327,11 +1327,12 @@ pipeline {
                     }
                     steps {
                         functionalTest inst_repos: daos_repos(),
-                                       inst_rpms: functional_packages()
+                                       inst_rpms: functional_packages(),
+                                       test_function: 'runTestFunctionalV2'
                     }
                     post {
                         always {
-                            functionalTestPost()
+                            functionalTestPostV2()
                         }
                     }
                 } // stage('Functional on CentOS 7')
@@ -1345,11 +1346,12 @@ pipeline {
                     }
                     steps {
                         functionalTest inst_repos: daos_repos(),
-                                       inst_rpms: functional_packages()
+                                       inst_rpms: functional_packages(),
+                                       test_function: 'runTestFunctionalV2'
                     }
                     post {
                         always {
-                            functionalTestPost()
+                            functionalTestPostV2()
                         }
                     } // post
                 } // stage('Functional on Leap 15')
@@ -1363,11 +1365,12 @@ pipeline {
                     }
                     steps {
                         functionalTest inst_repos: daos_repos(),
-                                       inst_rpms: functional_packages()
+                                       inst_rpms: functional_packages(),
+                                       test_function: 'runTestFunctionalV2'
                     }
                     post {
                         always {
-                            functionalTestPost()
+                            functionalTestPostV2()
                         }
                     } // post
                 } // stage('Functional on Ubuntu 20.04')
@@ -1383,11 +1386,12 @@ pipeline {
                     steps {
                         functionalTest target: hw_distro_target(),
                                        inst_repos: daos_repos(),
-                                       inst_rpms: functional_packages()
+                                       inst_rpms: functional_packages(),
+                                       test_function: 'runTestFunctionalV2'
                     }
                     post {
                         always {
-                            functionalTestPost()
+                            functionalTestPostV2()
                         }
                     }
                 } // stage('Functional_Hardware_Small')
@@ -1403,11 +1407,12 @@ pipeline {
                     steps {
                         functionalTest target: hw_distro_target(),
                                        inst_repos: daos_repos(),
-                                       inst_rpms: functional_packages()
+                                       inst_rpms: functional_packages(),
+                                       test_function: 'runTestFunctionalV2'
                    }
                     post {
                         always {
-                            functionalTestPost()
+                            functionalTestPostV2()
                         }
                     }
                 } // stage('Functional_Hardware_Medium')
@@ -1423,11 +1428,12 @@ pipeline {
                     steps {
                         functionalTest target: hw_distro_target(),
                                        inst_repos: daos_repos(),
-                                       inst_rpms: functional_packages()
+                                       inst_rpms: functional_packages(),
+                                       test_function: 'runTestFunctionalV2'
                     }
                     post {
                         always {
-                            functionalTestPost()
+                            functionalTestPostV2()
                         }
                     }
                 } // stage('Functional_Hardware_Large')

--- a/ci/functional/job_cleanup.sh
+++ b/ci/functional/job_cleanup.sh
@@ -15,16 +15,15 @@ fi
 
 rm -rf install/lib/daos/TESTING/ftest/avocado/job-results/*/*/html/
 
+# Remove the latest avocado symlink directory to avoid inclusion in the
+# jenkins build artifacts
+rm -f install/lib/daos/TESTING/ftest/avocado/job-results/latest
+
 arts="$arts$(ls ./*daos{,_agent}.log* 2>/dev/null)" && arts="$arts"$'\n'
+arts="$arts$(ls -d \
+   install/lib/daos/TESTING/ftest/avocado/job-results/* 2>/dev/null)" && \
+  arts="$arts"$'\n'
 if [ -n "$arts" ]; then
     # shellcheck disable=SC2046,SC2086
     mv $(echo $arts | tr '\n' ' ') "${STAGE_NAME}/"
 fi
-
-TESTS=(install/lib/daos/TESTING/ftest/avocado/job-results/*)
-for art in "${TESTS[@]}"
-do
-    if ! [[ "$art" =~ latest ]]; then
-        mv "$art" "${STAGE_NAME}/"
-    fi
-done


### PR DESCRIPTION
When daos-stack/pipeline-lib@370aff9 landed, it broke the pipeline-lib API such that no daos commit prior to it would build with the current pipeline-lib master.

The original API needs to be restored and a new API created for the desired changes and DAOS updated to use the new API.

