### PR TITLE
DAOS-6748 rebuild: abort the rebuild correctly

### DIFF
--- a/src/rebuild/srv.c
+++ b/src/rebuild/srv.c
@@ -573,8 +573,8 @@ rebuild_leader_status_check(struct ds_pool *pool, uint32_t map_ver, uint32_t op,
 					       &iv, CRT_IV_SHORTCUT_NONE,
 					       CRT_IV_SYNC_LAZY, false);
 			if (rc) {
-				D_WARN("rebuild master iv update failed: %d\n",
-				       rc);
+				D_WARN("master %u iv update failed: %d\n",
+				       pool->sp_iv_ns->iv_master_rank, rc);
 			} else {
 				/* Each server uses IV to notify the leader
 				 * its rebuild stable epoch, then the leader
@@ -1904,24 +1904,11 @@ rebuild_tgt_status_check_ult(void *arg)
 				if (rc == -DER_NONEXIST && !status.rebuilding)
 					rpt->rt_global_done = 1;
 
-				if (rc == -DER_NOTLEADER) {
-					/* If the leader is changed, let's
-					 * check if it needs to abort the
-					 * current rebuild and wait the new
-					 * leader to re-start the rebuild.
-					 */
-					if (iv.riv_master_rank !=
-					    ns->iv_master_rank) {
-						D_DEBUG(DB_REBUILD, "master %u"
-							"-> %u ignore %d\n",
-							iv.riv_master_rank,
-							ns->iv_master_rank, rc);
-					} else {
-						D_DEBUG(DB_REBUILD, "abort"
-							" rebuild "DF_UUID"\n",
-						    DP_UUID(rpt->rt_pool_uuid));
-						rpt->rt_abort = 1;
-					}
+				if (ns->iv_stop) {
+					D_DEBUG(DB_REBUILD, "abort rebuild "
+						DF_UUID"\n",
+						DP_UUID(rpt->rt_pool_uuid));
+					rpt->rt_abort = 1;
 				}
 			}
 		}


### PR DESCRIPTION
Let's abort the rebuild only when IV ns is stopped, i.e.
destory the pool, so during leader change, the rebuild
will hang for IV until the new leader step up and update
the master.

Signed-off-by: Di Wang <di.wang@intel.com>