### PR TITLE
DAOS-6767 Test: Update the config function to use default server config path.

### DIFF
--- a/src/tests/suite/daos_test.h
+++ b/src/tests/suite/daos_test.h
@@ -82,6 +82,7 @@ extern const char *test_io_conf;
 
 extern int daos_event_priv_reset(void);
 #define TEST_RANKS_MAX_NUM	(13)
+#define DAOS_SERVRE_CONF          "/etc/daos/daos_server.yml"
 
 /* the pool used for daos test suite */
 struct test_pool {

--- a/src/tests/suite/daos_test_common.c
+++ b/src/tests/suite/daos_test_common.c
@@ -1082,7 +1082,7 @@ get_server_config(char *host, char *server_config_file)
 			if (strstr(pch, "--config") != NULL) {
 				if (strchr(pch, '=') != NULL)
 					strcpy(server_config_file,
-						   strchr(pch, '=') + 1);
+					       strchr(pch, '=') + 1);
 				else {
 					pch = strtok(NULL, " ");
 					strcpy(server_config_file, pch);

--- a/src/tests/suite/daos_test_common.c
+++ b/src/tests/suite/daos_test_common.c
@@ -1047,9 +1047,10 @@ get_server_config(char *host, char *server_config_file)
 	size_t	read;
 	char	*line = NULL;
 	char	*pch;
-	char    *dpid;
+	char	*dpid;
 	int	rc;
-	char    daos_proc[16] = "daos_server";
+	char	daos_proc[16] = "daos_server";
+	bool	conf = true;
 
 	D_ALLOC(dpid, 16);
 	rc = get_pid_of_process(host, dpid, daos_proc);
@@ -1060,37 +1061,43 @@ get_server_config(char *host, char *server_config_file)
 	FILE *fp = popen(command, "r");
 
 	print_message("Command %s", command);
-	if (fp == NULL)
+	if (fp == NULL) {
+		D_FREE(dpid);
 		return -DER_INVAL;
+	}
 
 	while ((read = getline(&line, &len, fp)) != -1) {
 		print_message("line %s", line);
 		if (strstr(line, "--config") != NULL ||
 		    strstr(line, "-o") != NULL)
+			conf = false;
 			break;
 	}
 
-	pch = strtok(line, " ");
-	while (pch != NULL) {
-		if (strstr(pch, "--config") != NULL) {
-			if (strchr(pch, '=') != NULL)
-				strcpy(server_config_file,
-				       strchr(pch, '=') + 1);
-			else {
+	if (conf)
+		strcpy(server_config_file, DAOS_SERVRE_CONF);
+	else {
+		pch = strtok(line, " ");
+		while (pch != NULL) {
+			if (strstr(pch, "--config") != NULL) {
+				if (strchr(pch, '=') != NULL)
+					strcpy(server_config_file,
+						   strchr(pch, '=') + 1);
+				else {
+					pch = strtok(NULL, " ");
+					strcpy(server_config_file, pch);
+				}
+				break;
+			}
+
+			if (strstr(pch, "-o") != NULL) {
 				pch = strtok(NULL, " ");
 				strcpy(server_config_file, pch);
+				break;
 			}
-			break;
-		}
-
-		if (strstr(pch, "-o") != NULL) {
 			pch = strtok(NULL, " ");
-			strcpy(server_config_file, pch);
-			break;
 		}
-		pch = strtok(NULL, " ");
 	}
-
 	pclose(fp);
 
 	D_FREE(dpid);


### PR DESCRIPTION
Updated get_server_config() to use the default config file
when daos server started with systemd.

Quick-build: true
Test-tag: nvme,unittest

Signed-off-by: Samir Raval <samir.raval@intel.com>