### PR TITLE
DAOS-5579 doc: clarifiy container type and IOR backends

### DIFF
--- a/doc/admin/performance_tuning.md
+++ b/doc/admin/performance_tuning.md
@@ -140,7 +140,7 @@ IOR (<https://github.com/hpc/ior>) with the following backends:
     (MPICH 3.4.1 or higher).
 
 -   An HDF5 VOL connector for DAOS is under development. This maps the HDF5 data model 
-    directly to the DAOS data model, and works in conjuntion with DAOS containers of
+    directly to the DAOS data model, and works in conjunction with DAOS containers of
     `--type=HDF5` (in contrast to DAOS container of `--type=POSIX` that are used for
     the other IOR APIs).
 

--- a/doc/admin/performance_tuning.md
+++ b/doc/admin/performance_tuning.md
@@ -125,19 +125,24 @@ benchmarks.
 
 IOR (<https://github.com/hpc/ior>) with the following backends:
 
--   POSIX, MPIIO & HDF5 drivers over dfuse and the interception library.
+-   The IOR APIs POSIX, MPIIO and HDF5 can be used with DAOS POSIX containers that
+    are accessed over dfuse. This works without or with the I/O interception library
+    (`libioil`). Performance is significantly better when using `libioil`.
 
--   MPI-IO plugin with the ROMIO DAOS ADIO driver to bypass POSIX and dfuse. The
-    MPIIO driver is available in the upstream MPICH repository.
+-   A custom DFS (DAOS File System) plugin for DAOS can be used by building IOR
+    with DAOS support, and selecting API=DFS. This integrates IOR directly with the
+    DAOS File System (`libdfs`), without requiring FUSE or an interception library.
 
--   HDF5 plugin with the HDF5 DAOS connector (under development). This maps the
-    HDF5 data model directly to the DAOS model bypassing POSIX.
+-   When using the IOR API=MPIIO, the ROMIO ADIO driver for DAOS can be used by
+    providing the `daos://` prefix to the filename. This ADIO driver bypasses `dfuse`
+    and directly invkes the `libdfs` calls to perform I/O to a DAOS POSIX container.
+    The DAOS-enabled MPIIO driver is available in the upstream MPICH repository 
+    (MPICH 3.4.1 or higher).
 
--   A custom DFS (DAOS File System) plugin, integrating IOR directly with libfs
-    without requiring FUSE or an interception library
-
--   A custom DAOS plugin, integrating IOR directly with the native DAOS
-    array API.
+-   An HDF5 VOL connector for DAOS is under development. This maps the HDF5 data model 
+    directly to the DAOS data model, and works in conjuntion with DAOS containers of
+    `--type=HDF5` (in contrast to DAOS container of `--type=POSIX` that are used for
+    the other IOR APIs).
 
 ### mdtest
 

--- a/doc/admin/tiering_uns.md
+++ b/doc/admin/tiering_uns.md
@@ -2,53 +2,54 @@
 
 ## Unified Namespace
 
-The DAOS tier can be tightly integrated with the Lustre parallel filesystem in
-which DAOS containers will be represented through the Lustre namespace. This
-capability is under development and is scheduled for DAOS v1.2.
+The DAOS tier can be tightly integrated with the Lustre parallel filesystem,
+in which DAOS containers will be represented through the Lustre namespace.
+This capability is under development and is scheduled for DAOS v1.2.
 
-Current state of work can be summarized as follow :
+The current state of work can be summarized as follow :
 
 -   DAOS integration with Lustre uses the Lustre foreign file/dir feature
-    (from LU-11376 and associated patches)
+    (from LU-11376 and associated patches).
 
--   each time a DAOS POSIX container is created, using `daos` utility and its
+-   Each time a DAOS POSIX container is created, using the `daos` utility and its
     '--path' UNS option, a Lustre foreign file/dir of 'daos' type is being
     created with a specific LOV/LMV EA content that will allow to store the
     DAOS pool and containers UUIDs.
 
 -   Lustre Client patch for LU-12682, adds DAOS specific support to the Lustre
     foreign file/dir feature. It allows for foreign file/dir of `daos` type
-    to be presented and act as `<absolute-prefix>/<pool-uuid>/<container-uuid>`
-    a symlink to the Linux Kernel/VFS.
+    to be presented and act as an `<absolute-prefix>/<pool-uuid>/<container-uuid>`
+    symlink to the Linux Kernel/VFS.
 
--   the <absolute-prefix> can be specified as the new `daos=<absolute-prefix>`
+-   The <absolute-prefix> can be specified as the new `daos=<absolute-prefix>`
     Lustre Client mount option, or also through the new `llite.*.daos_prefix`
-    Lustre dynamic tuneable. And both <pool-uuid> and <container-uuid> are
+    Lustre dynamic tuneable. Both <pool-uuid> and <container-uuid> are
     extracted from foreign file/dir LOV/LMV EA.
 
--   to allow for symlink resolution and transparent access to DAOS concerned
+-   To allow for symlink resolution and transparent access to DAOS
     container content, it is expected that a DFuse/DFS instance/mount, of
     DAOS Server root, exists on <absolute-prefix> presenting all served
     pools/containers as `<pool-uuid>/<container-uuid>` relative paths.
 
--   `daos` foreign support is enabled at mount time with `daos=` option
+-   `daos` foreign support is enabled at mount time with the `daos=` option
     present, or dynamically through `llite.*.daos_enable` setting.
 
 ## Data Migration
 
 ### Migration to/from a POSIX filesystem
 
-A dataset mover tool is under consideration to move a snapshot of a POSIX,
-MPI-IO or HDF5 container to a POSIX filesystem and vice versa. The copy will be
-performed at the POSIX or HDF5 level. The resulting HDF5 file over the POSIX
-filesystem will be accessible through the native HDF5 connector with the POSIX
-VFD.
+A dataset mover tool is under development to move a snapshot of a DAOS POSIX
+container or DAOS HDF5 container to a POSIX filesystem and vice versa. 
+The copy will be performed at the POSIX or HDF5 level. 
+(The MPI-IO ROMIO ADIO driver for DAOS also uses DAOS POSIX containers.)
+For DAOS HDF5 containers, the resulting HDF5 file in the POSIX filesystem 
+will be accessible through the native HDF5 connector with the POSIX VFD.
 
-The first version of the mover tool is currently scheduled for DAOS v1.4.
+The first version of the data mover tool is currently scheduled for DAOS v1.4.
 
 ### Container Parking
 
 The mover tool will also eventually support the ability to serialize and
 deserialize a DAOS container to a set of POSIX files that can be stored or
 "parked" in an external POSIX filesystem. This transformation is agnostic to the
-data model and container type and will retain all DAOS internal metadata.
+data model and container type, and will retain all DAOS internal metadata.

--- a/doc/user/container.md
+++ b/doc/user/container.md
@@ -50,7 +50,7 @@ At creation time, a list of container properties can be specified:
 | **Container Property**     | **Description** |
 | -------------------------  | --------------- |
 | `DAOS_PROP_CO_LABEL`<img width=400/>| A string that a user can associate with a container. e.g., "Cat Pics" or "ResNet-50 training data"|
-| `DAOS_PROP_CO_LAYOUT_TYPE` | The container type (POSIX, MPI-IO, HDF5, ...)|
+| `DAOS_PROP_CO_LAYOUT_TYPE` | The container type (POSIX, HDF5, ...)|
 | `DAOS_PROP_CO_LAYOUT_VER`  | A version of the layout that can be used by I/O middleware and application to handle interoperability.|
 | `DAOS_PROP_CO_REDUN_FAC`   | The redundancy factor that drives the minimal data protection required for objects stored in the container. e.g., RF1 means no data protection, RF3 only allows 3-way replication or erasure code N+2.|
 | `DAOS_PROP_CO_REDUN_LVL`   | The fault domain level that should be used to place data redundancy information (e.g., storage nodes, racks...). This information will be eventually consumed to determine object placement.|


### PR DESCRIPTION
remove references to container type MPI-IO (MPI-IO uses POSIX containers)
clarify IOR usage in performance_tuning.md

Signed-off-by: Michael Hennecke <mhennecke@lenovo.com>