### PR TITLE
DAOS-6659 continue renaming of daos_io_server to daos_engine

### DIFF
--- a/src/control/server/config/server_test.go
+++ b/src/control/server/config/server_test.go
@@ -211,7 +211,7 @@ func TestServerConfig_Constructed(t *testing.T) {
 		WithDisableVMD(false). // vmd disabled by default
 		WithNrHugePages(4096).
 		WithControlLogMask(ControlLogLevelError).
-		WithControlLogFile("/tmp/daos_control.log").
+		WithControlLogFile("/tmp/daos_server.log").
 		WithHelperLogFile("/tmp/daos_admin.log").
 		WithFirmwareHelperLogFile("/tmp/daos_firmware.log").
 		WithSystemName("daos_server").
@@ -241,7 +241,7 @@ func TestServerConfig_Constructed(t *testing.T) {
 				WithFabricInterfacePort(20000).
 				WithPinnedNumaNode(&numaNode0).
 				WithEnvVars("CRT_TIMEOUT=30").
-				WithLogFile("/tmp/daos_server1.log").
+				WithLogFile("/tmp/daos_engine.0.log").
 				WithLogMask("WARN"),
 			engine.NewConfig().
 				WithRank(1).
@@ -259,7 +259,7 @@ func TestServerConfig_Constructed(t *testing.T) {
 				WithFabricInterfacePort(20000).
 				WithPinnedNumaNode(&numaNode1).
 				WithEnvVars("CRT_TIMEOUT=100").
-				WithLogFile("/tmp/daos_server2.log").
+				WithLogFile("/tmp/daos_engine.1.log").
 				WithLogMask("WARN"),
 		)
 	constructed.Path = testFile // just to avoid failing the cmp

--- a/utils/config/daos_server.yml
+++ b/utils/config/daos_server.yml
@@ -2,7 +2,7 @@
 #
 ## Location of this configuration file is determined by first checking for the
 ## path specified through the -o option of the daos_server command line.
-## Otherwise, /etc/daos/daos_server.conf is used.
+## Otherwise, /etc/daos/daos_server.yml is used.
 #
 #
 ## Name associated with the DAOS system.
@@ -169,7 +169,7 @@
 ## Force specific path for daos_server (control plane) logs.
 #
 ## default: print to stderr
-#control_log_file: /tmp/daos_control.log
+#control_log_file: /tmp/daos_server.log
 #
 #
 ## Enable daos_admin (privileged helper) logging.
@@ -191,20 +191,20 @@
 #
 #engines:
 #-
-#  # Rank to be assigned as identifier for server.
+#  # Rank to be assigned as identifier for this engine.
 #  # Immutable after reformat.
 #  # Optional parameter, will be auto generated if not supplied.
 #
 #  rank: 0
 #
 #  # Targets (VOS) represent the count of storage targets per data plane
-#  # server starting at core offset specified by first_core.
+#  # engine starting at core offset specified by first_core.
 #
 #  # Immutable after reformat.
 #
 #  targets: 20
 #
-#  # Count of offload/helper xstreams per server.
+#  # Count of offload/helper xstreams per engine.
 #  # Immutable after reformat.
 #
 #  nr_xs_helpers: 20
@@ -216,15 +216,15 @@
 #  first_core: 1
 #
 #  # Use specific OFI interfaces.
-#  # Specify the fabric network interface that will be used by this server.
+#  # Specify the fabric network interface that will be used by this engine.
 #  # Optionally specify the fabric network interface port that will be used
-#  # by this server but please only if you have a specific need, this will
+#  # by this engine but please only if you have a specific need, this will
 #  # normally be chosen automatically.
 #
 #  fabric_iface: qib0
 #  fabric_iface_port: 20000
 #
-#  # The server instance binds itself to cores and memory that are related
+#  # The engine instance binds itself to cores and memory that are related
 #  # to the specified NUMA node.  For best performance, it is necessary to
 #  # select a NUMA node that matches that of the fabric_iface.
 #  pinned_numa_node: 0
@@ -239,17 +239,17 @@
 #  # Force specific path for DAOS debug logs (D_LOG_FILE).
 #
 #  # default: /tmp/daos.log
-#  log_file: /tmp/daos_server1.log
+#  log_file: /tmp/daos_engine.0.log
 #
-#  # Pass specific environment variables to the DAOS server.
+#  # Pass specific environment variables to the DAOS engine.
 #  # Empty by default. Values should be supplied without encapsulating quotes.
 #
 #  env_vars:
 #      - CRT_TIMEOUT=30
 #
 #  # Define a pre-configured mountpoint for storage class memory to be used
-#  # by this server.
-#  # Path should be unique to server instance (can use different subdirs).
+#  # by this engine.
+#  # Path should be unique to engine instance (can use different subdirs).
 #  # Either the specified directory or its parent must be a mount point.
 #
 #  scm_mount: /mnt/daos/1
@@ -268,7 +268,7 @@
 #  # The size of ram is specified by scm_size in GB units.
 #  scm_size: 16
 #
-#  # Backend block device type. Force a SPDK driver to be used by this server
+#  # Backend block device type. Force a SPDK driver to be used by this engine
 #  # instance.
 #  # Options are:
 #  # - "nvme" for NVMe SSDs (preferred option), bdev_{size,number} ignored
@@ -279,9 +279,9 @@
 #
 #  bdev_class: nvme
 #
-#  # Backend block device configuration to be used by this server instance.
+#  # Backend block device configuration to be used by this engine instance.
 #  # When bdev_class is set to nvme, bdev_list is the list of unique NVMe IDs
-#  # that should be different across different server instance.
+#  # that should be different across different engine instance.
 #  # Immutable after reformat.
 #  bdev_list: ["0000:81:00.0"]  # generate regular nvme.conf
 #  # If VMD-enabled NVMe SSDs are used, the bdev_list should consist of the VMD
@@ -290,7 +290,7 @@
 #  bdev_list: ["0000:5d:05.5]
 
 #-
-#  # Rank to be assigned as identifier for server.
+#  # Rank to be assigned as identifier for this engine.
 #  # Immutable after reformat.
 #  # Optional parameter, will be auto generated if not supplied.
 #
@@ -304,7 +304,7 @@
 #
 #  targets: 20
 #
-#  # Number of helper XStreams per VOS server.
+#  # Number of helper XStreams per VOS engine.
 #  # Immutable after reformat.
 #
 #  nr_xs_helpers: 20
@@ -316,15 +316,15 @@
 #  first_core: 22
 #
 #  # Use specific OFI interfaces.
-#  # Specify the fabric network interface that will be used by this server.
+#  # Specify the fabric network interface that will be used by this engine.
 #  # Optionally specify the fabric network interface port that will be used
-#  # by this server but please only if you have a specific need, this will
+#  # by this engine but please only if you have a specific need, this will
 #  # normally be chosen automatically.
 #
 #  fabric_iface: qib1
 #  fabric_iface_port: 20000
 #
-#  # The server instance binds itself to cores and memory that are related
+#  # The engine instance binds itself to cores and memory that are related
 #  # to the specified NUMA node.  For best performance, it is necessary to
 #  # select a NUMA node that matches that of the fabric_iface.
 #  pinned_numa_node: 1
@@ -339,17 +339,17 @@
 #  # Force specific path for DAOS debug logs.
 #
 #  # default: /tmp/daos.log
-#  log_file: /tmp/daos_server2.log
+#  log_file: /tmp/daos_engine.1.log
 #
-#  # Pass specific environment variables to the DAOS server
+#  # Pass specific environment variables to the DAOS engine
 #  # Empty by default. Values should be supplied without encapsulating quotes.
 #
 #  env_vars:
 #      - CRT_TIMEOUT=100
 #
 #  # Define a pre-configured mountpoint for storage class memory to be used
-#  # by this server.
-#  # Path should be unique to server instance (can use different subdirs).
+#  # by this engine.
+#  # Path should be unique to engine instance (can use different subdirs).
 #
 #  scm_mount: /mnt/daos/2
 #
@@ -364,10 +364,10 @@
 #  scm_class: dcpm
 #
 #  # When scm_class is set to dcpm, scm_list is the list of device paths for
-#  # PMem namespaces (currently only one per server supported).
+#  # PMem namespaces (currently only one per engine supported).
 #  scm_list: [/dev/pmem0]
 #
-#  # Backend block device type. Force a SPDK driver to be used by this server
+#  # Backend block device type. Force a SPDK driver to be used by this engine
 #  # instance.
 #  # Options are:
 #  # - "nvme" for NVMe SSDs (preferred option), bdev_{size,number} ignored
@@ -390,7 +390,7 @@
 #  bdev_size: 16
 #
 #  # When bdev_class is set to kdev, bdev_list is the list of unique kernel
-#  # block devices that should be different across different server instance.
+#  # block devices that should be different across different engine instance.
 #  bdev_class: kdev
 #  bdev_list: [/dev/sdc,/dev/sdd]
 #

--- a/utils/config/examples/daos_server_local.yml
+++ b/utils/config/examples/daos_server_local.yml
@@ -5,7 +5,7 @@ access_points: ['localhost']
 # port: 10001
 provider: ofi+sockets
 nr_hugepages: 4096
-control_log_file: /tmp/daos_control.log
+control_log_file: /tmp/daos_server.log
 transport_config:
    allow_insecure: true
 
@@ -16,7 +16,7 @@ engines:
   nr_xs_helpers: 0
   fabric_iface: eth0
   fabric_iface_port: 31416
-  log_file: /tmp/daos_server.log
+  log_file: /tmp/daos_engine.0.log
 
   env_vars:
   - DAOS_MD_CAP=1024

--- a/utils/config/examples/daos_server_psm2.yml
+++ b/utils/config/examples/daos_server_psm2.yml
@@ -7,7 +7,7 @@ provider: ofi+psm2          # map to CRT_PHY_ADDR_STR=ofi+psm2
 socket_dir: /tmp/daos_psm2
 nr_hugepages: 4096
 control_log_mask: DEBUG
-control_log_file: /tmp/daos_control.log
+control_log_file: /tmp/daos_server.log
 
 ## Transport Credentials Specifying certificates to secure communications
 ##
@@ -26,13 +26,13 @@ control_log_file: /tmp/daos_control.log
 
 engines:
 -
-  targets: 8                # count of storage targets per each server
+  targets: 8                # count of storage targets per each engine
   first_core: 1             # offset of the first core for service xstreams
-  nr_xs_helpers: 0          # count of offload/helper xstreams per server
+  nr_xs_helpers: 0          # count of offload/helper xstreams per engine
   fabric_iface: ib0         # map to OFI_INTERFACE=ib0
   fabric_iface_port: 31416  # map to OFI_PORT=31416
   log_mask: ERR             # map to D_LOG_MASK=ERR
-  log_file: /tmp/server0.log # map to D_LOG_FILE=/tmp/server0.log
+  log_file: /tmp/daos_engine.0.log # map to D_LOG_FILE=/tmp/daos_engine.0.log
 
   # Environment variable values should be supplied without encapsulating quotes.
   env_vars:                 # influence DAOS IO Server behavior by setting env variables
@@ -53,12 +53,12 @@ engines:
   # scm_size: 6
 
   # When scm_class is set to dcpm, scm_list is the list of device paths for
-  # PMem namespaces (currently only one per server supported).
+  # PMem namespaces (currently only one per engine supported).
   scm_class: dcpm
   scm_list: [/dev/pmem0]
 
   # If using NVMe SSD (will write /mnt/daos/daos_nvme.conf and start I/O
-  # server with -n <path>).
+  # engine with -n <path>).
   bdev_class: nvme
   bdev_list: ["0000:81:00.0"]  # generate regular nvme.conf
 
@@ -85,13 +85,13 @@ engines:
               # [AIO]
               #   AIO /tmp/aiofile AIO1 4096
 -
-  targets: 8                # count of storage targets per each server
+  targets: 8                # count of storage targets per each engine
   first_core: 25            # offset of the first core for service xstreams
-  nr_xs_helpers: 0          # count of offload/helper xstreams per server
+  nr_xs_helpers: 0          # count of offload/helper xstreams per engine
   fabric_iface: ib1         # map to OFI_INTERFACE=ib0
-  fabric_iface_port: 31416  # OFI_PORT same as server0, different iface
+  fabric_iface_port: 31416  # OFI_PORT same as engine 0, different iface
   log_mask: ERR             # map to D_LOG_MASK=ERR
-  log_file: /tmp/server1.log # map to D_LOG_FILE=/tmp/server1.log
+  log_file: /tmp/daos_engine.1.log # map to D_LOG_FILE=/tmp/daos_engine.1.log
 
   env_vars:                 # influence DAOS IO Server behavior by setting env variables
   - CRT_TIMEOUT=30

--- a/utils/config/examples/daos_server_sockets.yml
+++ b/utils/config/examples/daos_server_sockets.yml
@@ -7,7 +7,7 @@ provider: ofi+sockets       # map to CRT_PHY_ADDR_STR=ofi+sockets
 socket_dir: /tmp/daos_sockets
 nr_hugepages: 4096
 control_log_mask: DEBUG
-control_log_file: /tmp/daos_control.log
+control_log_file: /tmp/daos_server.log
 
 ## Transport Credentials Specifying certificates to secure communications
 ##
@@ -26,13 +26,13 @@ control_log_file: /tmp/daos_control.log
 
 engines:
 -
-  targets: 8                # count of storage targets per each server
+  targets: 8                # count of storage targets per each engine
   first_core: 1             # offset of the first core for service xstreams
-  nr_xs_helpers: 0          # count of offload/helper xstreams per server
+  nr_xs_helpers: 0          # count of offload/helper xstreams per engine
   fabric_iface: eth0        # map to OFI_INTERFACE=eth0
   fabric_iface_port: 31316  # map to OFI_PORT=31316
   log_mask: ERR             # map to D_LOG_MASK=ERR
-  log_file: /tmp/server0.log # map to D_LOG_FILE=/tmp/server.log
+  log_file: /tmp/daos_engine.0.log # map to D_LOG_FILE=/tmp/daos_engine.0.log
 
   # Environment variable values should be supplied without encapsulating quotes.
   env_vars:                 # influence DAOS IO Server behavior by setting env variables
@@ -57,12 +57,12 @@ engines:
   # scm_size: 6
 
   # When scm_class is set to dcpm, scm_list is the list of device paths for
-  # PMem namespaces (currently only one per server supported).
+  # PMem namespaces (currently only one per engine supported).
   scm_class: dcpm
   scm_list: [/dev/pmem0]
 
   # If using NVMe SSD (will write /mnt/daos/daos_nvme.conf and start I/O
-  # server with -n <path>).
+  # engine with -n <path>).
   bdev_class: nvme
   bdev_list: ["0000:81:00.0"]  # generate regular nvme.conf
 
@@ -89,13 +89,13 @@ engines:
               # [AIO]
               #   AIO /tmp/aiofile AIO1 4096
 -
-  targets: 8                # count of storage targets per each server
+  targets: 8                # count of storage targets per each engine
   first_core: 25            # offset of the first core for service xstreams
-  nr_xs_helpers: 0          # count of offload/helper xstreams per server
+  nr_xs_helpers: 0          # count of offload/helper xstreams per engine
   fabric_iface: eth1        # map to OFI_INTERFACE=eth1
-  fabric_iface_port: 31416  # OFI_PORT same as server0, different iface
+  fabric_iface_port: 31416  # OFI_PORT same as engine 0, different iface
   log_mask: ERR             # map to D_LOG_MASK=ERR
-  log_file: /tmp/server1.log # map to D_LOG_FILE=/tmp/server1.log
+  log_file: /tmp/daos_engine.1.log # map to D_LOG_FILE=/tmp/daos_engine.1.log
 
   env_vars:                 # influence DAOS IO Server behavior by setting env variables
   - DAOS_MD_CAP=1024

--- a/utils/config/examples/daos_server_unittests.yml
+++ b/utils/config/examples/daos_server_unittests.yml
@@ -6,7 +6,7 @@ access_points: ['example']  # management service leader (bootstrap)
 provider: ofi+sockets       # map to CRT_PHY_ADDR_STR=ofi+sockets
 socket_dir: /tmp/daos_sockets
 control_log_mask: DEBUG
-control_log_file: /tmp/daos_server.log
+control_log_file: /tmp/daos_control.log
 
 ## Transport Credentials Specifying certificates to secure communications
 ##
@@ -30,7 +30,7 @@ engines:
   nr_xs_helpers: 0          # count of offload/helper xstreams per engine
   fabric_iface: lo          # map to OFI_INTERFACE=lo
   log_mask: DEBUG,RPC=ERR,MEM=ERR
-  log_file: /tmp/daos_engine.0.log # map to D_LOG_FILE=/tmp/daos_engine.0.log
+  log_file: /tmp/server0.log # map to D_LOG_FILE=/tmp/server0.log
 
   # Environment variable values should be supplied without encapsulating quotes.
   env_vars:                 # influence DAOS IO Server behavior by setting env variables

--- a/utils/config/examples/daos_server_unittests.yml
+++ b/utils/config/examples/daos_server_unittests.yml
@@ -6,7 +6,7 @@ access_points: ['example']  # management service leader (bootstrap)
 provider: ofi+sockets       # map to CRT_PHY_ADDR_STR=ofi+sockets
 socket_dir: /tmp/daos_sockets
 control_log_mask: DEBUG
-control_log_file: /tmp/daos_control.log
+control_log_file: /tmp/daos_server.log
 
 ## Transport Credentials Specifying certificates to secure communications
 ##
@@ -25,12 +25,12 @@ control_log_file: /tmp/daos_control.log
 
 engines:
 -
-  targets: 1                # count of storage targets per each server
+  targets: 1                # count of storage targets per each engine
   first_core: 0             # offset of the first core for service xstreams
-  nr_xs_helpers: 0          # count of offload/helper xstreams per server
+  nr_xs_helpers: 0          # count of offload/helper xstreams per engine
   fabric_iface: lo          # map to OFI_INTERFACE=lo
   log_mask: DEBUG,RPC=ERR,MEM=ERR
-  log_file: /tmp/server0.log # map to D_LOG_FILE=/tmp/server0.log
+  log_file: /tmp/daos_engine.0.log # map to D_LOG_FILE=/tmp/daos_engine.0.log
 
   # Environment variable values should be supplied without encapsulating quotes.
   env_vars:                 # influence DAOS IO Server behavior by setting env variables
@@ -56,11 +56,11 @@ engines:
   scm_size: 1
 
   # When scm_class is set to dcpm, scm_list is the list of device paths for
-  # PMem namespaces (currently only one per server supported).
+  # PMem namespaces (currently only one per engine supported).
   # scm_class: dcpm
   # scm_list: [/dev/pmem0]
 
   # If using NVMe SSD (will write /mnt/daos/daos_nvme.conf and start I/O
-  # server with -n <path>)
+  # engine with -n <path>)
   bdev_class: nvme
   bdev_list: []


### PR DESCRIPTION
rename daemon logfiles to daos_server.log and daos_engine.N.log
where needed, change server to engine in config file comments

Signed-off-by: Michael Hennecke <mhennecke@lenovo.com>