### PR TITLE
DAOS-6620 cart: Split CaRT protocols into smaller units.

### DIFF
--- a/src/cart/crt_internal_fns.h
+++ b/src/cart/crt_internal_fns.h
@@ -65,4 +65,7 @@ crt_hdlr_proto_query(crt_rpc_t *rpc_req);
 int
 crt_register_proto_fi(crt_endpoint_t *ep);
 
+int
+crt_register_proto_ctl(crt_endpoint_t *ep);
+
 #endif /* __CRT_INTERNAL_FNS_H__ */

--- a/src/cart/crt_register.c
+++ b/src/cart/crt_register.c
@@ -519,6 +519,9 @@ crt_proto_register_internal(struct crt_proto_format *cpf)
 	}
 
 	/* validate base_opc is in range */
+	/* TODO: This doesn't make any sense, a XOR used as a truth value is
+	 * just checking equlity so only one mask would be allowed here
+	 */
 	if (cpf->cpf_base ^ CRT_PROTO_BASEOPC_MASK) {
 		D_ERROR("Invalid base_opc: %#x.\n", cpf->cpf_base);
 		return -DER_INVAL;

--- a/src/cart/crt_rpc.c
+++ b/src/cart/crt_rpc.c
@@ -256,8 +256,7 @@ crt_internal_rpc_register(bool server)
 
 	rc = crt_proto_register(&cpf);
 	if (rc != 0) {
-		D_ERROR("crt_proto_register_internal() failed, "DF_RC"\n",
-			DP_RC(rc));
+		D_ERROR("crt_proto_register() failed, "DF_RC"\n", DP_RC(rc));
 		return rc;
 	}
 
@@ -284,8 +283,7 @@ crt_internal_rpc_register(bool server)
 
 	rc = crt_proto_register(&cpf);
 	if (rc != 0) {
-		D_ERROR("crt_proto_register_internal() failed, "DF_RC"\n",
-			DP_RC(rc));
+		D_ERROR("crt_proto_register() failed, "DF_RC"\n", DP_RC(rc));
 		return rc;
 	}
 

--- a/src/cart/crt_rpc.c
+++ b/src/cart/crt_rpc.c
@@ -189,6 +189,18 @@ static struct crt_proto_rpc_format crt_fi_rpcs[] = {
 	CRT_FI_RPCS_LIST
 };
 
+static struct crt_proto_rpc_format crt_st_rpcs[] = {
+	CRT_ST_RPCS_LIST
+};
+
+static struct crt_proto_rpc_format crt_ctl_rpcs[] = {
+	CRT_CTL_RPCS_LIST
+};
+
+static struct crt_proto_rpc_format crt_iv_rpcs[] = {
+	CRT_IV_RPCS_LIST
+};
+
 #undef X
 
 #define X(a, b, c, d, e) case a: return #a;
@@ -224,13 +236,30 @@ crt_internal_rpc_register(bool server)
 
 	rc = crt_proto_register_internal(&cpf);
 	if (rc != 0) {
-		D_ERROR("crt_proto_register_internal() failed, " DF_RC "\n",
+		D_ERROR("crt_proto_register_internal() failed, "DF_RC"\n",
+			DP_RC(rc));
+		return rc;
+	}
+
+	/* TODO: The self-test protocols should not be registered on the client
+	 * by default.
+	 */
+
+	cpf.cpf_name  = "self-test";
+	cpf.cpf_ver   = CRT_PROTO_ST_VERSION;
+	cpf.cpf_count = ARRAY_SIZE(crt_st_rpcs);
+	cpf.cpf_prf   = crt_st_rpcs;
+	cpf.cpf_base  = CRT_OPC_ST_BASE;
+
+	rc = crt_proto_register(&cpf);
+	if (rc != 0) {
+		D_ERROR("crt_proto_register_internal() failed, "DF_RC"\n",
 			DP_RC(rc));
 		return rc;
 	}
 
 	if (!server)
-		return rc;
+		return -DER_SUCCESS;
 
 	cpf.cpf_name  = "fault-injection";
 	cpf.cpf_ver   = CRT_PROTO_FI_VERSION;
@@ -239,8 +268,33 @@ crt_internal_rpc_register(bool server)
 	cpf.cpf_base  = CRT_OPC_FI_BASE;
 
 	rc = crt_proto_register(&cpf);
+	if (rc != 0) {
+		D_ERROR("crt_proto_register() failed, "DF_RC"\n", DP_RC(rc));
+		return rc;
+	}
+
+	cpf.cpf_name  = "ctl";
+	cpf.cpf_ver   = CRT_PROTO_CTL_VERSION;
+	cpf.cpf_count = ARRAY_SIZE(crt_ctl_rpcs);
+	cpf.cpf_prf   = crt_ctl_rpcs;
+	cpf.cpf_base  = CRT_OPC_CTL_BASE;
+
+	rc = crt_proto_register(&cpf);
+	if (rc != 0) {
+		D_ERROR("crt_proto_register_internal() failed, "DF_RC"\n",
+			DP_RC(rc));
+		return rc;
+	}
+
+	cpf.cpf_name  = "incast";
+	cpf.cpf_ver   = CRT_PROTO_IV_VERSION;
+	cpf.cpf_count = ARRAY_SIZE(crt_iv_rpcs);
+	cpf.cpf_prf   = crt_iv_rpcs;
+	cpf.cpf_base  = CRT_OPC_IV_BASE;
+
+	rc = crt_proto_register(&cpf);
 	if (rc != 0)
-		D_ERROR("crt_proto_register() failed, " DF_RC "\n", DP_RC(rc));
+		D_ERROR("crt_proto_register() failed, "DF_RC"\n", DP_RC(rc));
 
 	return rc;
 }
@@ -283,7 +337,7 @@ crt_register_proto_fi(crt_endpoint_t *ep)
 	if (rc != 0)
 		return -DER_MISC;
 
-	rc = crt_proto_query(ep, CRT_OPC_FI_BASE, &cpf.cpf_ver,
+	rc = crt_proto_query(ep, cpf.cpf_base, &cpf.cpf_ver,
 			     1, crt_pfi_cb, &pfi);
 	if (rc != -DER_SUCCESS)
 		D_GOTO(out, rc);
@@ -293,12 +347,52 @@ crt_register_proto_fi(crt_endpoint_t *ep)
 	if (pfi.pfi_rc != -DER_SUCCESS)
 		D_GOTO(out, rc = pfi.pfi_rc);
 
-	if (pfi.pfi_ver != CRT_PROTO_FI_VERSION)
+	if (pfi.pfi_ver != cpf.cpf_ver)
 		D_GOTO(out, rc = -DER_MISMATCH);
 
 	rc = crt_proto_register(&cpf);
 	if (rc != 0)
-		D_ERROR("crt_proto_register() failed, " DF_RC "\n", DP_RC(rc));
+		D_ERROR("crt_proto_register() failed, "DF_RC"\n", DP_RC(rc));
+
+out:
+	sem_destroy(&pfi.pfi_sem);
+
+	return rc;
+}
+
+int
+crt_register_proto_ctl(crt_endpoint_t *ep)
+{
+	struct crt_proto_format cpf;
+	struct crt_pfi	pfi = {};
+	int		rc;
+
+	cpf.cpf_name  = "ctl";
+	cpf.cpf_ver   = CRT_PROTO_CTL_VERSION;
+	cpf.cpf_count = ARRAY_SIZE(crt_ctl_rpcs);
+	cpf.cpf_prf   = crt_ctl_rpcs;
+	cpf.cpf_base  = CRT_OPC_CTL_BASE;
+
+	rc = sem_init(&pfi.pfi_sem, 0, 0);
+	if (rc != 0)
+		return -DER_MISC;
+
+	rc = crt_proto_query(ep, cpf.cpf_base, &cpf.cpf_ver,
+			     1, crt_pfi_cb, &pfi);
+	if (rc != -DER_SUCCESS)
+		D_GOTO(out, rc);
+
+	sem_wait(&pfi.pfi_sem);
+
+	if (pfi.pfi_rc != -DER_SUCCESS)
+		D_GOTO(out, rc = pfi.pfi_rc);
+
+	if (pfi.pfi_ver != cpf.cpf_ver)
+		D_GOTO(out, rc = -DER_MISMATCH);
+
+	rc = crt_proto_register(&cpf);
+	if (rc != 0)
+		D_ERROR("crt_proto_register() failed, "DF_RC"\n", DP_RC(rc));
 
 out:
 	sem_destroy(&pfi.pfi_sem);

--- a/src/cart/crt_rpc.c
+++ b/src/cart/crt_rpc.c
@@ -215,6 +215,9 @@ char
 	switch (opc) {
 		CRT_INTERNAL_RPCS_LIST
 		CRT_FI_RPCS_LIST
+		CRT_IV_RPCS_LIST
+		CRT_ST_RPCS_LIST
+		CRT_CTL_RPCS_LIST
 	}
 	return "DAOS";
 }

--- a/src/cart/crt_swim.c
+++ b/src/cart/crt_swim.c
@@ -14,7 +14,7 @@
 #include "swim/swim_internal.h"
 
 #define CRT_OPC_SWIM_VERSION	1
-#define CRT_SWIM_FAIL_BASE	((CRT_OPC_SWIM_PROTO >> 16) | \
+#define CRT_SWIM_FAIL_BASE	((CRT_OPC_SWIM_BASE >> 16) | \
 				 (CRT_OPC_SWIM_VERSION << 4))
 #define CRT_SWIM_FAIL_DROP_RPC	(CRT_SWIM_FAIL_BASE | 0x1)	/* id: 65025 */
 
@@ -116,7 +116,7 @@ static struct crt_proto_format crt_swim_proto_fmt = {
 	.cpf_ver	= CRT_OPC_SWIM_VERSION,
 	.cpf_count	= ARRAY_SIZE(crt_swim_proto_rpc_fmt),
 	.cpf_prf	= crt_swim_proto_rpc_fmt,
-	.cpf_base	= CRT_OPC_SWIM_PROTO,
+	.cpf_base	= CRT_OPC_SWIM_BASE,
 };
 
 static void crt_swim_srv_cb(crt_rpc_t *rpc_req)
@@ -308,7 +308,7 @@ static int crt_swim_send_message(struct swim_context *ctx, swim_id_t to,
 	if (nupds > 0 && upds[0].smu_state.sms_status == SWIM_MEMBER_INACTIVE)
 		opc_idx = 1;
 
-	opc = CRT_PROTO_OPC(CRT_OPC_SWIM_PROTO, CRT_OPC_SWIM_VERSION, opc_idx);
+	opc = CRT_PROTO_OPC(CRT_OPC_SWIM_BASE, CRT_OPC_SWIM_VERSION, opc_idx);
 
 	if (CRT_SWIM_SHOULD_FAIL(d_fa_swim_drop_rpc, self_id)) {
 		rc = d_fa_swim_drop_rpc->fa_err_code;

--- a/src/include/cart/types.h
+++ b/src/include/cart/types.h
@@ -109,7 +109,6 @@ typedef d_string_t crt_phy_addr_t;
  * expected.
  */
 typedef uint32_t crt_opcode_t;
-#define CRT_OPC_INTERNAL_BASE	0xFF000000UL
 
 /**
  * Check if the opcode is reserved by CRT internally.
@@ -267,7 +266,6 @@ typedef enum {
  */
 #define CRT_RPC_FEAT_QUEUE_FRONT	(1U << 3)
 
-
 typedef void *crt_bulk_opid_t;
 
 /** Bulk transfer permissions */
@@ -395,7 +393,6 @@ typedef enum {
 	/** Total count of supported operations */
 	CRT_GROUP_MOD_OP_COUNT,
 } crt_group_mod_op_t;
-
 
 /** @}
  */

--- a/src/utils/ctl/cart_ctl.c
+++ b/src/utils/ctl/cart_ctl.c
@@ -546,6 +546,12 @@ ctl_register_fi(crt_endpoint_t *ep)
 }
 
 static int
+ctl_register_ctl(crt_endpoint_t *ep)
+{
+	return crt_register_proto_ctl(ep);
+}
+
+static int
 ctl_init()
 {
 	int			 i;
@@ -598,14 +604,18 @@ ctl_init()
 		ranks_to_send = ctl_gdata.cg_ranks;
 	}
 
+	ep.ep_grp = grp;
+	ep.ep_rank = ranks_to_send[0];
+	ep.ep_tag = 0;
+
 	if (ctl_gdata.cg_cmd_code == CMD_SET_FI_ATTR ||
 	    ctl_gdata.cg_cmd_code == CMD_DISABLE_FI ||
 	    ctl_gdata.cg_cmd_code == CMD_ENABLE_FI) {
-		ep.ep_grp = grp;
-		ep.ep_rank = ranks_to_send[0];
-		ep.ep_tag = 0;
-
 		rc = ctl_register_fi(&ep);
+		if (rc != -DER_SUCCESS)
+			return rc;
+	} else {
+		rc = ctl_register_ctl(&ep);
 		if (rc != -DER_SUCCESS)
 			return rc;
 	}


### PR DESCRIPTION
Rather than have one big "internal" protocol containing
a number of server<=>server and client<=>server RPCs split
it into several.  This avoids needing to change the client
protocol on server changes and isolates things like the
self-test code from needing to change when other things do.

This brings us a big step forward towards interoperability.

Create protocols for IV, self-test and ctl. Update cart_ctl
to query the protocol before use.

There is one RPC the cart_ctl uses to ping the servers looking
for startup, so leave this one in the internal protocol, cart_ctl
should be updated to use the register itself to perform the ping.

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>