### PR TITLE
DAOS-6789 mgmt: filter svc_ranks by pool ranks for RSVC_STOP

### DIFF
--- a/src/tests/ftest/daos_test/daos_core_test-rebuild.yaml
+++ b/src/tests/ftest/daos_test/daos_core_test-rebuild.yaml
@@ -104,7 +104,7 @@ daos_tests:
     test_rebuild_24: -s3 -u subtests="24"
     test_rebuild_25: -s3 -u subtests="25"
     test_rebuild_26: -s3 -u subtests="26"
-    test_rebuild_27: -s3 -u subtests="27"
+    test_rebuild_27: -s6 -u subtests="27"
     test_rebuild_28: -s3 -u subtests="28"
   stopped_ranks:
     test_rebuild_22: [7]


### PR DESCRIPTION
Before this change, intermittently the svc_ranks argument provided
by the control plane to the ioserver ds_mgmt_destroy_pool() function
could have (due to close timing, or even a failure to raise a RAS event)
some pool service ranks that have actually been excluded from
the pool. With the recent change to the pool destroy corpc protocols,
this results RSVC_STOP broadcast RPCin ds_pool_svc_destroy()
failing with DER_UNREACH.

With this change, ds_mgmt_destroy_pool(), after retrieving the full
list of pool ranks from the PS leader, filters svc_ranks so it only
contains ranks understood to be part of the pool at destroy-time.

Signed-off-by: Kenneth Cain <kenneth.c.cain@intel.com>