### PR TITLE
CART-89 mrc: Automatically disable MR caching

### DIFF
--- a/src/cart/README.env
+++ b/src/cart/README.env
@@ -119,3 +119,7 @@ This file lists the environment variables used in CaRT.
 
  . CRT_DISABLE_MEM_PIN
    Disables server-side memory pinning for CART-890 workaround
+
+ . CRT_MRC_ENABLE
+   When not set automatically disables MR caching via FI_MR_CACHE_MAX_COUNT=0
+   envariable setting. Set to non 0 to re-enable MR caching in the provider.

--- a/src/cart/crt_init.c
+++ b/src/cart/crt_init.c
@@ -70,6 +70,7 @@ static int data_init(int server, crt_init_options_t *opt)
 	uint32_t	ctx_num = 1;
 	uint32_t	fi_univ_size = 0;
 	uint32_t	mem_pin_disable = 0;
+	uint32_t	mrc_enable = 0;
 	uint64_t	start_rpcid;
 	int		rc = 0;
 
@@ -143,6 +144,12 @@ static int data_init(int server, crt_init_options_t *opt)
 	if (fi_univ_size == 0) {
 		D_WARN("FI_UNIVERSE_SIZE was not set; setting to 2048\n");
 		setenv("FI_UNIVERSE_SIZE", "2048", 1);
+	}
+
+	d_getenv_int("CRT_MRC_ENABLE", &mrc_enable);
+	if (mrc_enable == 0) {
+		D_INFO("Disabling MR CACHE (FI_MR_CACHE_COUNT=0)\n");
+		setenv("FI_MR_CACHE_COUNT", "0", 1);
 	}
 
 	if (credits == 0) {


### PR DESCRIPTION
- Automatically disable MR caching unless new CRT_MRC_ENABLE
variable is not set.
- MR caching is disabled as it is causing rdma buffer corruptions.

Signed-off-by: Alexander Oganezov <alexander.a.oganezov@intel.com>