### PR TITLE
DAOS-6792 test: Fix daostest rebuild 27 to use 6 svcs

### DIFF
--- a/src/tests/ftest/daos_test/daos_core_test-rebuild.yaml
+++ b/src/tests/ftest/daos_test/daos_core_test-rebuild.yaml
@@ -104,7 +104,7 @@ daos_tests:
     test_rebuild_24: -s3 -u subtests="24"
     test_rebuild_25: -s3 -u subtests="25"
     test_rebuild_26: -s3 -u subtests="26"
-    test_rebuild_27: -s3 -u subtests="27"
+    test_rebuild_27: -s6 -u subtests="27"
     test_rebuild_28: -s3 -u subtests="28"
   stopped_ranks:
     test_rebuild_22: [7]


### PR DESCRIPTION
Fix daostest rebuild 27 to use 6 svcs

Skip-func-hw-test-large: true
Skip-func-hw-test-small: true