### PR TITLE
DAOS-6764 md: add svcl argument to dsc_pool_tgt_exclude/reint

### DIFF
--- a/src/include/daos_srv/daos_engine.h
+++ b/src/include/daos_srv/daos_engine.h
@@ -666,9 +666,9 @@ int dsc_obj_list_obj(daos_handle_t oh, daos_epoch_range_t *epr,
 		     daos_anchor_t *akey_anchor, d_iov_t *csum);
 
 int dsc_pool_tgt_exclude(const uuid_t uuid, const char *grp,
-			 struct d_tgt_list *tgts);
+			 const d_rank_list_t *svc, struct d_tgt_list *tgts);
 int dsc_pool_tgt_reint(const uuid_t uuid, const char *grp,
-		       struct d_tgt_list *tgts);
+		       const d_rank_list_t *svc, struct d_tgt_list *tgts);
 
 int dsc_task_run(tse_task_t *task, tse_task_cb_t retry_cb, void *arg,
 		 int arg_size, bool sync);

--- a/src/include/daos_task.h
+++ b/src/include/daos_task.h
@@ -194,9 +194,11 @@ typedef struct {
 /** pool target update (add/exclude) args */
 typedef struct {
 	/** UUID of the pool. */
-	uuid_t			uuid;
+	uuid_t			 uuid;
 	/** Process set name of the DAOS servers managing the pool */
 	const char		*grp;
+	/** Pool service replica ranks (used by server only). */
+	d_rank_list_t		*svc;
 	/** Target array */
 	struct d_tgt_list	*tgts;
 } daos_pool_update_t;

--- a/src/mgmt/cli_mgmt.c
+++ b/src/mgmt/cli_mgmt.c
@@ -735,7 +735,7 @@ dc_mgmt_sys_decode(void *buf, size_t len, struct dc_mgmt_sys **sysp)
 /* For a given pool UUID, contact mgmt. service for up to date list
  * of pool service replica ranks. Note: synchronous RPC with caller already
  * in a task execution context. On successful return, caller is responsible
- * for freeing the d_rank_list_t allocated here.
+ * for freeing the d_rank_list_t allocated here. Must not be called by server.
  */
 int
 dc_mgmt_get_pool_svc_ranks(struct dc_mgmt_sys *sys, const uuid_t puuid,
@@ -752,6 +752,8 @@ dc_mgmt_get_pool_svc_ranks(struct dc_mgmt_sys *sys, const uuid_t puuid,
 	crt_context_t				ctx;
 	bool					success = false;
 	int					rc = 0;
+
+	D_ASSERT(sys->sy_server == 0);
 
 	/* NB: ms_ranks may have multiple entries even for single MS replica,
 	 * since there may be multiple engines there. Some of which may have

--- a/src/pool/cli.c
+++ b/src/pool/cli.c
@@ -168,7 +168,7 @@ failed:
 }
 
 /* Choose a pool service replica rank. If the rsvc module indicates
- * DER_NOTREPLICA, attempt to refresh the list by querying the MS.
+ * DER_NOTREPLICA, (clients only) try to refresh the list by querying the MS.
  */
 int
 dc_pool_choose_svc_rank(const uuid_t puuid, struct rsvc_client *cli,
@@ -182,7 +182,7 @@ dc_pool_choose_svc_rank(const uuid_t puuid, struct rsvc_client *cli,
 		D_MUTEX_LOCK(cli_lock);
 choose:
 	rc = rsvc_client_choose(cli, ep);
-	if (rc == -DER_NOTREPLICA) {
+	if ((rc == -DER_NOTREPLICA) && !sys->sy_server) {
 		d_rank_list_t	*new_ranklist = NULL;
 
 		/* Query MS for replica ranks. Not under client lock. */
@@ -1096,7 +1096,8 @@ dc_pool_update_internal(tse_task_t *task, daos_pool_update_t *args,
 				DP_UUID(args->uuid), rc);
 			D_GOTO(out_state, rc);
 		}
-		rc = rsvc_client_init(&state->client, NULL);
+		rc = rsvc_client_init(&state->client,
+				      state->sys->sy_server ? args->svc : NULL);
 		if (rc != 0) {
 			D_ERROR(DF_UUID": failed to rsvc_client_init, rc %d.\n",
 				DP_UUID(args->uuid), rc);

--- a/src/pool/srv_cli.c
+++ b/src/pool/srv_cli.c
@@ -86,7 +86,7 @@ out:
 
 int
 dsc_pool_tgt_exclude(const uuid_t uuid, const char *grp,
-		     struct d_tgt_list *tgts)
+		     const d_rank_list_t *svc, struct d_tgt_list *tgts)
 {
 	daos_pool_update_t	*args;
 	tse_task_t		*task;
@@ -100,6 +100,7 @@ dsc_pool_tgt_exclude(const uuid_t uuid, const char *grp,
 
 	args = dc_task_get_args(task);
 	args->grp	= grp;
+	args->svc	= (d_rank_list_t *)svc;
 	args->tgts	= tgts;
 	uuid_copy((unsigned char *)args->uuid, uuid);
 
@@ -108,7 +109,7 @@ dsc_pool_tgt_exclude(const uuid_t uuid, const char *grp,
 
 int
 dsc_pool_tgt_reint(const uuid_t uuid, const char *grp,
-		   struct d_tgt_list *tgts)
+		   const d_rank_list_t *svc, struct d_tgt_list *tgts)
 {
 	daos_pool_update_t	*args;
 	tse_task_t		*task;
@@ -122,6 +123,7 @@ dsc_pool_tgt_reint(const uuid_t uuid, const char *grp,
 
 	args = dc_task_get_args(task);
 	args->grp	= grp;
+	args->svc	= (d_rank_list_t *)svc;
 	args->tgts	= tgts;
 	uuid_copy((unsigned char *)args->uuid, uuid);
 

--- a/src/pool/srv_util.c
+++ b/src/pool/srv_util.c
@@ -502,7 +502,11 @@ update_targets_ult(void *arg)
 {
 	struct update_targets_arg	*uta = arg;
 	struct d_tgt_list		 tgt_list;
+	d_rank_list_t			 svc;
 	int				 rc;
+
+	svc.rl_ranks = &uta->uta_pl_rank;
+	svc.rl_nr = 1;
 
 	tgt_list.tl_nr = uta->uta_nr;
 	tgt_list.tl_ranks = uta->uta_ranks;
@@ -510,10 +514,10 @@ update_targets_ult(void *arg)
 
 	if (uta->uta_reint)
 		rc = dsc_pool_tgt_reint(uta->uta_pool_id, NULL /* grp */,
-					&tgt_list);
+					&svc, &tgt_list);
 	else
 		rc = dsc_pool_tgt_exclude(uta->uta_pool_id, NULL /* grp */,
-					  &tgt_list);
+					  &svc, &tgt_list);
 	if (rc)
 		D_ERROR(DF_UUID": %s targets failed. "DF_RC"\n",
 			DP_UUID(uta->uta_pool_id),

--- a/src/tests/ftest/daos_test/daos_core_test-nvme_recovery.py
+++ b/src/tests/ftest/daos_test/daos_core_test-nvme_recovery.py
@@ -15,7 +15,6 @@ class DaosCoreTestNvme(DaosCoreBase):
     :avocado: recursive
     """
 
-    @skipForTicket("DAOS-6764")
     def test_daos_nvme_recovery_1(self):
         """Jira ID: DAOS-3846.
 


### PR DESCRIPTION
PR 3935 inadvertently removed the svcl argument to the functions
dsc_pool_tgt_exclude() and dsc_pool_tgt_reint(). This resulted in a
segmentation fault in the daos engine in dc_mgmt_get_pool_svc_ranks()
during internal pool updates (e.g., as part of nvme faulty reaction).
The crash is due to the code going too far into the client RPC stack,
attempting a client-only MGMT_POOL_GET_SVCRANKS RPC. And relying on
struct dc_mgmt_sys.sy_info.ms_ranks, only filled for clients.

With this change the arguments are restored, and the calling function,
update_targets_ult() provides the pool service server rank to contact
for the exclude/reintegration operation. And some defensive checks
are made to prevent the engine from calling certain client-only code.

Test-tag-hw-medium: pr,hw,medium,ib2 test_daos_nvme_recovery_1 nvme_fault

Signed-off-by: Kenneth Cain <kenneth.c.cain@intel.com>