### PR TITLE
DAOSSDE-52 sec: Remove potentially sensitive logging

### DIFF
--- a/src/control/security/domain_info.go
+++ b/src/control/security/domain_info.go
@@ -60,6 +60,5 @@ func DomainInfoFromUnixConn(log logging.Logger, sock *net.UnixConn) (*DomainInfo
 	if err != nil {
 		ctx = ""
 	}
-	log.Debugf("client pid: %d uid: %d gid %d ctx: %s", creds.Pid, creds.Uid, creds.Gid, ctx)
 	return InitDomainInfo(creds, ctx), nil
 }

--- a/src/control/server/security_rpc.go
+++ b/src/control/server/security_rpc.go
@@ -8,7 +8,6 @@ package server
 
 import (
 	"crypto"
-	"encoding/hex"
 	"fmt"
 	"path/filepath"
 
@@ -43,7 +42,7 @@ func (m *SecurityModule) processValidateCredentials(body []byte) ([]byte, error)
 
 	cred := req.Cred
 	if cred == nil || cred.GetToken() == nil || cred.GetVerifier() == nil {
-		m.log.Errorf("Invalid credential: %+v", cred)
+		m.log.Error("malformed credential")
 		return m.validateRespWithStatus(drpc.DaosInvalidInput)
 	}
 
@@ -64,7 +63,7 @@ func (m *SecurityModule) processValidateCredentials(body []byte) ([]byte, error)
 	// Check our verifier
 	err = auth.VerifyToken(key, cred.GetToken(), cred.GetVerifier().GetData())
 	if err != nil {
-		m.log.Errorf("cred verification failed: %v for verifier %s", err, hex.Dump(cred.GetVerifier().GetData()))
+		m.log.Errorf("cred verification failed: %v", err)
 		return m.validateRespWithStatus(drpc.DaosNoPermission)
 	}
 


### PR DESCRIPTION
- Genericize errors to avoid revealing security credential
  details.
- Remove debug logging of auth_sys token information.

Signed-off-by: Kris Jacque <kristin.jacque@intel.com>