### PR TITLE
DAOS-6742 build: Remove incorrect pipeline-lib reference.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,7 +13,6 @@
 // To use a test branch (i.e. PR) until it lands to master
 // I.e. for testing library changes
 //@Library(value="pipeline-lib@your_branch") _
-@Library(value="pipeline-lib@groovy-container") _
 
 boolean doc_only_change() {
     if (cachedCommitPragma(pragma: 'Doc-only') == 'true') {


### PR DESCRIPTION
The Docker update was landed without landing the pipeline-lib update
first, so back out the reference to the branch in Jeninksfile.

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>