### PR TITLE
DAOS-4891 test: Use multiple access points

### DIFF
--- a/src/tests/ftest/util/apricot/apricot/test.py
+++ b/src/tests/ftest/util/apricot/apricot/test.py
@@ -527,8 +527,15 @@ class TestWithServers(TestWithoutServers):
                 self.hostfile_clients_slots)
 
         # Access points to use by default when starting servers and agents
-        self.access_points = self.params.get(
-            "access_points", "/run/setup/*", self.hostlist_servers[:1])
+        self.log.debug("## Server count = {}".format(len(self.hostlist_servers)))
+        if len(self.hostlist_servers) <= 4:
+            self.log.debug("## Use all servers as AP")
+            self.access_points = self.params.get(
+                "access_points", "/run/setup/*", self.hostlist_servers)
+        else:
+            self.log.debug("## Use 4 servers as AP")
+            self.access_points = self.params.get(
+                "access_points", "/run/setup/*", self.hostlist_servers[:4])
 
         # Display host information
         self.log.info("--- HOST INFORMATION ---")


### PR DESCRIPTION
Bump up the number of access points to the number of servers used or 4, whichever is lower.

Updated test.py where it sets self.access_points. It used to set just the first host in
self.hostlist_servers (daos_server host). Now it checks the number of servers and if it's 4
or less, use all servers as AP. If it's above 4, use the first 4 servers as AP.

Quick-Functional: true
Test-tag: daos_object_query server_restart server_reformat dynamic_start_stop
Signed-off-by: Makito Kano <makito.kano@intel.com>