### PR TITLE
DAOS-6387 test: datamover posix fs space

### DIFF
--- a/src/tests/ftest/datamover/copy_negative.py
+++ b/src/tests/ftest/datamover/copy_negative.py
@@ -256,15 +256,58 @@ class CopyNegativeTest(DataMoverTestBase):
             expected_rc=1,
             expected_output=self.MFU_ERR_INVAL_ARG)
 
+    def test_copy_space_dcp(self):
+        """Jira ID: DAOS-5515
+        Test Description:
+            DAOS-5515: destination pool does not have enough space.
+            DAOS-6387: posix filesystem does not have enough space.
+        :avocado: tags=all,full_regression
+        :avocado: tags=datamover,dcp
+        :avocado: tags=copy_negative,copy_space_dcp
+        """
+        self.set_tool("DCP")
+
+        # Create a large test file in POSIX
+        block_size_large = self.params.get(
+            "block_size_large", "/run/ior/*")
+        self.ior_cmd.block_size.update(block_size_large)
+        self.run_ior_with_params("POSIX", self.posix_test_file)
+
+        # Create destination test pool and container
+        pool1 = self.create_pool()
+        cont1 = self.create_cont(pool1)
+
+        # Try to copy, and expect a proper error message.
+        self.run_datamover(
+            self.test_id + " (dst pool out of space)",
+            "POSIX", self.posix_test_paths[0], None, None,
+            "DAOS_UUID", "/", pool1, cont1,
+            expected_rc=1,
+            expected_output=[self.MFU_ERR_DCP_COPY, "errno=28"])
+
+        # Create another pool and container
+        pool2 = self.create_pool()
+        cont2 = self.create_cont(pool2)
+
+        # Start dfuse on pool2/cont2
+        self.start_dfuse(self.dfuse_hosts, pool2, cont2)
+
+        # Try to copy. For now, we expect this to just abort.
+        self.run_datamover(
+            self.test_id + " (dst posix out of space)",
+            "POSIX", self.posix_test_paths[0], None, None,
+            "POSIX", self.dfuse.mount_dir.value,
+            expected_rc=255,
+            expected_err=["errno=28"])
+
     def test_copy_error_check_dcp(self):
         """Jira ID: DAOS-5515
         Test Description:
-            Tests POSIX copy error checking.
-            This uses the dcp tool.
-            (1) Error checking: destination filename is invalid.
-            (2) Error checking: destination pool out of space.
+            Tests POSIX copy error checking for dcp.
+            Tests the following cases:
+                destination filename is invalid.
         :avocado: tags=all,full_regression
-        :avocado: tags=datamover
+        :avocado: tags=datamover,dcp
         :avocado: tags=copy_negative,copy_error_check_dcp
         """
         self.set_tool("DCP")
@@ -285,17 +328,3 @@ class CopyNegativeTest(DataMoverTestBase):
             "POSIX", dst_path,
             expected_rc=1,
             expected_output=[self.MFU_ERR_DCP_COPY, "errno=36"])
-
-        # Write a large file to POSIX
-        block_size_large = self.params.get(
-            "block_size_large", "/run/ior/*")
-        self.ior_cmd.block_size.update(block_size_large)
-        self.run_ior_with_params("POSIX", self.posix_test_file)
-
-        # Try to copy
-        self.run_datamover(
-            "copy_error_check (dst pool out of space)",
-            "POSIX", self.posix_test_paths[0], None, None,
-            "DAOS_UUID", "/", pool1, cont1,
-            expected_rc=1,
-            expected_output=[self.MFU_ERR_DCP_COPY, "errno=28"])

--- a/src/tests/ftest/datamover/copy_negative.yaml
+++ b/src/tests/ftest/datamover/copy_negative.yaml
@@ -3,7 +3,7 @@ hosts:
         - server-A
     test_clients:
         - server-B
-timeout: 120
+timeout: 300
 server_config:
     name: daos_server
 pool:

--- a/src/tests/ftest/util/data_mover_test_base.py
+++ b/src/tests/ftest/util/data_mover_test_base.py
@@ -543,7 +543,7 @@ class DataMoverTestBase(IorTestBase, MdtestBase):
                       src_pool=None, src_cont=None,
                       dst_type=None, dst_path=None,
                       dst_pool=None, dst_cont=None,
-                      expected_rc=0, expected_output=None,
+                      expected_rc=0, expected_output=None, expected_err=None,
                       processes=None):
         """Run the corresponding command specified by self.tool.
         Calls set_datamover_params if and only if any are passed in.
@@ -558,7 +558,8 @@ class DataMoverTestBase(IorTestBase, MdtestBase):
             dst_path: see set_datamover_params
             dst_cont: see set_datamover_params
             expected_rc (int, optional): rc expected to be returned
-            expected_output (list, optional): substrings expected to be output
+            expected_output (list, optional): substrings expected in stdout
+            expected_err (list, optional): substrings expected in stderr
             processes (int, optional): number of mpi processes.
                 defaults to self.dcp_processes
 
@@ -578,13 +579,17 @@ class DataMoverTestBase(IorTestBase, MdtestBase):
                 src_type, src_path, src_pool, src_cont,
                 dst_type, dst_path, dst_pool, dst_cont)
 
-        # Default expected_output to empty list
+        # Default expected_output and expected_err to empty lists
         if not expected_output:
             expected_output = []
+        if not expected_err:
+            expected_err = []
 
         # Convert singular value to list
         if not isinstance(expected_output, list):
             expected_output = [expected_output]
+        if not isinstance(expected_err, list):
+            expected_err = [expected_err]
 
         if test_desc is not None:
             self.log.info("Running %s: %s", self.tool, test_desc)
@@ -612,6 +617,9 @@ class DataMoverTestBase(IorTestBase, MdtestBase):
         # Check for expected output
         for s in expected_output:
             if s not in result.stdout:
-                self.fail("Expected {}: {}".format(s, test_desc))
+                self.fail("stdout expected {}: {}".format(s, test_desc))
+        for s in expected_err:
+            if s not in result.stderr:
+                self.fail("stderr xpected {}: {}".format(s, test_desc))
 
         return result


### PR DESCRIPTION
Test-tag-vm: pr,-hw datamover,-hw

Added a datamover/dcp test case for a posix
filesystem being out of space.

Adjusted run_datamover to accept a list of
output expected in stderr.

Signed-off-by: Dalton Bohning <daltonx.bohning@intel.com>