### PR TITLE
DAOS-6746 build: Fix some RPM building issues

### DIFF
--- a/utils/rpms/Makefile
+++ b/utils/rpms/Makefile
@@ -13,7 +13,7 @@ ON_TAG          := $(shell if git diff-index --name-only HEAD^ | grep -q TAG; th
 PACKAGING_CHECK_DIR := ../../../rpm/packaging/
 
 ifeq ($(ON_TAG),false)
-BUILD_DEFINES     := --define "%relval .$(GIT_NUM_COMMITS).g$(GIT_SHORT)"
+BUILD_DEFINES     := --define "relval .$(GIT_NUM_COMMITS).g$(GIT_SHORT)"
 endif
 
 RPM_BUILD_OPTIONS := $(BUILD_DEFINES)

--- a/utils/rpms/daos.spec
+++ b/utils/rpms/daos.spec
@@ -94,9 +94,9 @@ BuildRequires: libcurl4
 # have choice for libpsm_infinipath.so.1()(64bit) needed by libfabric1: libpsm2-compat libpsm_infinipath1
 # have choice for libpsm_infinipath.so.1()(64bit) needed by openmpi-libs: libpsm2-compat libpsm_infinipath1
 BuildRequires: libpsm_infinipath1
-%endif # 0%{?is_opensuse}
-%endif # (0%{?suse_version} >= 1315)
-%endif # (0%{?rhel} >= 7)
+%endif
+%endif
+%endif
 %if (0%{?suse_version} >= 1500)
 Requires: libpmem1 >= 1.8, libpmemobj1 >= 1.8
 %else
@@ -138,7 +138,7 @@ Requires(post): /sbin/ldconfig
 Requires(postun): /sbin/ldconfig
 Requires: libfabric >= %{libfabric_version}
 %{?systemd_requires}
-Obsoletes: cart
+Obsoletes: cart < 1000
 
 %description server
 This is the package needed to run a DAOS server
@@ -149,7 +149,7 @@ Requires: %{name} = %{version}-%{release}
 Requires: mercury = %{mercury_version}
 Requires: libfabric >= %{libfabric_version}
 Requires: fuse3 >= 3.4.2
-Obsoletes: cart
+Obsoletes: cart < 1000
 %if (0%{?suse_version} >= 1500)
 Requires: libfuse3-3 >= 3.4.2
 %else


### PR DESCRIPTION
The linter doesn't like anything on a %endif line.
When defining macros, don't include the % in the macro name.