### PR TITLE
DAOS-6793 pool: move iv_fini after ds_pool_hdl_hash_fini

### DIFF
--- a/src/pool/srv.c
+++ b/src/pool/srv.c
@@ -59,8 +59,8 @@ static int
 fini(void)
 {
 	ds_pool_rsvc_class_unregister();
-	ds_pool_iv_fini();
 	ds_pool_hdl_hash_fini();
+	ds_pool_iv_fini();
 	ds_pool_cache_fini();
 	ds_pool_prop_default_fini();
 	return 0;


### PR DESCRIPTION
Move iv_fini after ds_pool_hdl_hash_fini(), because
ds_pool_hdl_hash_fini might call pool_free_ref()->
ds_iv_ns_fini(), which need iv_class.

Signed-off-by: Di Wang <di.wang@intel.com>