### PR TITLE
DAOS-6828 pool: move iv_ns destroy after container agg stop

### DIFF
--- a/src/pool/srv_target.c
+++ b/src/pool/srv_target.c
@@ -380,13 +380,6 @@ pool_free_ref(struct daos_llink *llink)
 
 	D_DEBUG(DF_DSMS, DF_UUID": freeing\n", DP_UUID(pool->sp_uuid));
 
-	ds_iv_ns_put(pool->sp_iv_ns);
-
-	rc = crt_group_secondary_destroy(pool->sp_group);
-	if (rc != 0)
-		D_ERROR(DF_UUID": failed to destroy pool group: %d\n",
-			DP_UUID(pool->sp_uuid), rc);
-
 	rc = dss_thread_collective(pool_child_delete_one, pool->sp_uuid, 0);
 	if (rc == -DER_CANCELED)
 		D_DEBUG(DB_MD, DF_UUID": no ESs\n", DP_UUID(pool->sp_uuid));
@@ -397,6 +390,13 @@ pool_free_ref(struct daos_llink *llink)
 	pl_map_disconnect(pool->sp_uuid);
 	if (pool->sp_map != NULL)
 		pool_map_decref(pool->sp_map);
+
+	ds_iv_ns_put(pool->sp_iv_ns);
+
+	rc = crt_group_secondary_destroy(pool->sp_group);
+	if (rc != 0)
+		D_ERROR(DF_UUID": failed to destroy pool group: %d\n",
+			DP_UUID(pool->sp_uuid), rc);
 
 	ABT_cond_free(&pool->sp_fetch_hdls_cond);
 	ABT_cond_free(&pool->sp_fetch_hdls_done_cond);


### PR DESCRIPTION
Move iv_ns destory after container agg ULT stop, which might
access IV ns.

Signed-off-by: Di Wang <di.wang@intel.com>