### PR TITLE
DAOS-5313 tests: reset fail loc

### DIFF
--- a/src/tests/suite/daos_container.c
+++ b/src/tests/suite/daos_container.c
@@ -2058,8 +2058,9 @@ co_open_fail_destroy(void **state)
 
 	rc = daos_cont_open(arg->pool.poh, uuid, DAOS_COO_RW, &coh, &info,
 			    NULL);
+	daos_debug_set_params(arg->group, -1, DMG_KEY_FAIL_LOC,
+			      0, 0, NULL);
 	assert_rc_equal(rc, -DER_IO);
-
 	print_message("destroying container ... ");
 	rc = daos_cont_destroy(arg->pool.poh, uuid, 1 /* force */, NULL);
 	assert_rc_equal(rc, 0);


### PR DESCRIPTION
reset fail loc on all servers in container
test 23, otherwise it may cause failures
in following test.

Signed-off-by: Di Wang <di.wang@intel.com>