### PR TITLE
DAOS-6821 bio: Fix server crash when querying nvme-health

### DIFF
--- a/src/bio/bio_monitor.c
+++ b/src/bio/bio_monitor.c
@@ -44,7 +44,9 @@ collect_bs_usage(struct spdk_blob_store *bs, struct nvme_stats *stats)
 {
 	uint64_t	cl_sz;
 
-	D_ASSERT(bs != NULL);
+	if (bs == NULL)
+		return;
+
 	D_ASSERT(stats != NULL);
 
 	cl_sz = spdk_bs_get_cluster_size(bs);


### PR DESCRIPTION
Server crash seen when querying nvme-health after manually evicting an SSD.
This was due to an assert being hit when the blobstore pointer passed was
NULL, in this case just return before querying blobstore space usage stats
instead of asserting.

Signed-off-by: Sydney Vanda <sydney.m.vanda@intel.com>