### PR TITLE
DAOS-623 test: Force cmocka xml to be in unique file

### DIFF
--- a/src/tests/ftest/util/daos_core_base.py
+++ b/src/tests/ftest/util/daos_core_base.py
@@ -129,7 +129,8 @@ class DaosCoreBase(TestWithServers):
         )
 
         env = {}
-        env['CMOCKA_XML_FILE'] = os.path.join(self.outputdir, "%g_results.xml")
+        env['CMOCKA_XML_FILE'] = os.path.join(self.outputdir,
+                                              "%g_cmocka_results.xml")
         env['CMOCKA_MESSAGE_OUTPUT'] = "xml"
         env['POOL_SCM_SIZE'] = "{}".format(scm_size)
         if not nvme_size:

--- a/src/tests/suite/daos_pool.c
+++ b/src/tests/suite/daos_pool.c
@@ -30,8 +30,6 @@ pool_connect_nonexist(void **state)
 	rc = daos_pool_connect(uuid, arg->group, DAOS_PC_RW,
 			       &poh, NULL /* info */, NULL /* ev */);
 	assert_rc_equal(rc, -DER_NONEXIST);
-	/* Temporary to force a failure */
-	assert_rc_equal(rc, 0);
 }
 
 /** connect/disconnect to/from a valid pool */

--- a/src/tests/suite/daos_pool.c
+++ b/src/tests/suite/daos_pool.c
@@ -30,6 +30,8 @@ pool_connect_nonexist(void **state)
 	rc = daos_pool_connect(uuid, arg->group, DAOS_PC_RW,
 			       &poh, NULL /* info */, NULL /* ev */);
 	assert_rc_equal(rc, -DER_NONEXIST);
+	/* Temporary to force a failure */
+	assert_rc_equal(rc, 0);
 }
 
 /** connect/disconnect to/from a valid pool */


### PR DESCRIPTION
The cmocka xml file name was the same as the avocado xml file name so any cmocka
failures in a test would get overwritten in the results making it impossible to figure out
what actually failed to cause the test failure.   This simply renames the file.  I verified
with first version of this patch that this works.

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>