### PR TITLE
DAOS-6818 sched: race in purging spi

### DIFF
--- a/src/engine/sched.c
+++ b/src/engine/sched.c
@@ -234,12 +234,19 @@ spi_rec_decref(struct d_hash_table *htable, d_list_t *rlink)
 	return spi->spi_ref == 0;
 }
 
+static inline bool
+is_spi_inuse(struct sched_pool_info *spi)
+{
+	return spi->spi_req_cnt != 0 || spi->spi_gc_ults != 0;
+}
+
 static void
 spi_rec_free(struct d_hash_table *htable, d_list_t *rlink)
 {
 	struct sched_pool_info	*spi = sched_rlink2spi(rlink);
 	unsigned int		 type;
 
+	D_ASSERT(!is_spi_inuse(spi));
 	for (type = SCHED_REQ_UPDATE; type < SCHED_REQ_MAX; type++) {
 		D_ASSERTF(pool2req_cnt(spi, type) == 0, "type:%u cnt:%u\n",
 			  type, pool2req_cnt(spi, type));
@@ -285,7 +292,7 @@ prune_purge_list(struct dss_xstream *dx)
 		spi = sched_rlink2spi(rlink);
 		D_ASSERT(spi->spi_ref > 1);
 		d_hash_rec_decref(info->si_pool_hash, rlink);
-		if (spi->spi_req_cnt == 0) {
+		if (!is_spi_inuse(spi)) {
 			deleted = d_hash_rec_delete(info->si_pool_hash,
 						    pi->pi_pool_id,
 						    sizeof(uuid_t));
@@ -295,9 +302,10 @@ prune_purge_list(struct dss_xstream *dx)
 		} else {
 			unsigned int type;
 
-			D_ERROR("XS(%d): Pool "DF_UUID", req_cnt:%u\n",
-				dx->dx_xs_id, DP_UUID(pi->pi_pool_id),
-				spi->spi_req_cnt);
+			D_ERROR("XS(%d): Pool "DF_UUID", req_cnt:%u, "
+				"gc_ults:%d\n", dx->dx_xs_id,
+				DP_UUID(pi->pi_pool_id), spi->spi_req_cnt,
+				spi->spi_gc_ults);
 
 			for (type = SCHED_REQ_UPDATE; type < SCHED_REQ_MAX;
 			     type++) {
@@ -318,12 +326,14 @@ add_purge_list(struct dss_xstream *dx, struct sched_pool_info *spi)
 	struct sched_info	*info = &dx->dx_sched_info;
 	struct purge_item	*pi;
 
-	D_CDEBUG(spi->spi_req_cnt == 0, DB_TRACE, DLOG_ERR,
-		 "XS(%d): vos pool:"DF_UUID" is destroyed. req_cnt:%u\n",
-		 dx->dx_xs_id, DP_UUID(spi->spi_pool_id), spi->spi_req_cnt);
+	D_CDEBUG(!is_spi_inuse(spi), DB_TRACE, DLOG_ERR,
+		 "XS(%d): vos pool:"DF_UUID" is destroyed. "
+		 "req_cnt:%u, gc_ults:%u\n", dx->dx_xs_id,
+		 DP_UUID(spi->spi_pool_id), spi->spi_req_cnt,
+		 spi->spi_gc_ults);
 
-	/* Don't purge the spi when there is queued request */
-	if (spi->spi_req_cnt != 0)
+	/* Don't purge the spi when it's still inuse */
+	if (is_spi_inuse(spi))
 		return;
 
 	d_list_for_each_entry(pi, &info->si_purge_list, pi_link) {
@@ -969,9 +979,10 @@ sleep_counting(struct dss_xstream *dx, struct sched_request *req, int sleep)
 
 	spi->spi_gc_sleeping += sleep;
 
-	D_ASSERT(spi->spi_gc_sleeping >= 0);
-	D_ASSERTF(spi->spi_gc_sleeping <= spi->spi_gc_ults,
-		  "gc:%d, sleeping:%d\n", spi->spi_gc_ults,
+	D_ASSERTF(spi->spi_gc_sleeping >= 0 &&
+		  spi->spi_gc_sleeping <= spi->spi_gc_ults,
+		  "XS(%d): pool:"DF_UUID", gc_ults:%d, sleeping:%d\n",
+		  dx->dx_xs_id, DP_UUID(spi->spi_pool_id), spi->spi_gc_ults,
 		  spi->spi_gc_sleeping);
 }
 


### PR DESCRIPTION
Scheduler maintains a 'spi' for each active VOS pool, when the
pool is destroyed, scheduler will purge the 'spi' if it won't
be accessed by any outstanding sched_request.

However, current purging code overlooked the sleeping GC ULT, so
the spi could be purged even if it'll be accessed by sleeping GC
ULTs later. Such race happens only when a pool is destroyed and
a new pool with same UUID being created immediately (before the
old 'spi' purged).

Signed-off-by: Niu Yawei <yawei.niu@intel.com>