### PR TITLE
DAOS-6605 doc: report that ndctl numa bug fixed in centos7.9

### DIFF
--- a/doc/admin/deployment.md
+++ b/doc/admin/deployment.md
@@ -176,12 +176,11 @@ host list.
 devices, taking into account any specified network device class preference
 (ethernet or infiniband).
 
-Note that there is currently a [bug](https://github.com/pmem/ndctl/issues/130)
-in `ndctl` that prevents the NUMA affinity of an nvdimm namespace from being
-correctly reported.
+Some CentOS 7.x kernels from before the 7.9 release were known to have a defect
+that prevented `ndctl` from being able to report the NUMA affinity for a
+namespace.
 This prevents generation of dual engine configs using `dmg config generate`
-command on CentOS7 operating systems, the issue has reportedly been fixed on
-CentOS8.
+when running with one of the above-mentioned affected kernels.
 
 #### Certificate Configuration
 

--- a/doc/release/release_notes_v1_0.md
+++ b/doc/release/release_notes_v1_0.md
@@ -277,6 +277,7 @@ different versions of ndctl provisioning different JSON namespace details
 (storage scan command reads the "numa_node" field). The regression also affects
 the operation of the "dmg config generate" command which isn't able to detect
 correct NUMA affinity for the PMem namespaces required for the config.
+The regression has been fixed in the CentOS7.9 kernel.
 
 ### PSM over OPA is not fully functional
 If you must evaluate DAOS on an OPA fabric, we recommend using IP over


### PR DESCRIPTION
Bug in ndctl that causes dmg storage scan and dmg config generate to
work incorrectly because NUMA affinity of pmem bdevs are not correctly
reported has been fixed in CentOS7.9. Update admin guide and release
notes.

Doc-only: true

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>