### PR TITLE
DAOS-3938 control: Add a Store() method to atm.Bool

### DIFF
--- a/src/control/lib/atm/bool.go
+++ b/src/control/lib/atm/bool.go
@@ -45,3 +45,13 @@ func (b *Bool) IsFalse() bool {
 func (b *Bool) Load() bool {
 	return atomic.LoadUint32((*uint32)(b)) != 0
 }
+
+// Store sets the Bool based on the supplied bool value.
+func (b *Bool) Store(val bool) {
+	if val {
+		b.SetTrue()
+		return
+	}
+
+	b.SetFalse()
+}

--- a/src/control/lib/atm/bool_test.go
+++ b/src/control/lib/atm/bool_test.go
@@ -12,10 +12,25 @@ import (
 	"github.com/daos-stack/daos/src/control/lib/atm"
 )
 
-func TestAtomicBool(t *testing.T) {
+func TestAtomicBool_ZeroValue(t *testing.T) {
+	var b atm.Bool
+
+	if b.Load() {
+		t.Fatal("atm.Bool zero value was not false")
+	}
+
+	b.Store(true)
+
+	if !b.Load() {
+		t.Fatal("atm.Bool didn't store true")
+	}
+}
+
+func TestAtomicBool_Ops(t *testing.T) {
 	for name, tc := range map[string]struct {
 		start      bool
 		op         string
+		val        bool
 		expEnd     bool
 		expChanged bool
 	}{
@@ -59,6 +74,30 @@ func TestAtomicBool(t *testing.T) {
 			op:     "SetFalse",
 			expEnd: false,
 		},
+		"true-Store(true)": {
+			start:  true,
+			val:    true,
+			op:     "Store",
+			expEnd: true,
+		},
+		"true-Store(false)": {
+			start:  true,
+			val:    false,
+			op:     "Store",
+			expEnd: false,
+		},
+		"false-Store(true)": {
+			start:  false,
+			val:    true,
+			op:     "Store",
+			expEnd: true,
+		},
+		"false-Store(false)": {
+			start:  false,
+			val:    false,
+			op:     "Store",
+			expEnd: false,
+		},
 	} {
 		cmpBool := func(t *testing.T, expected, actual bool) {
 			t.Helper()
@@ -82,6 +121,9 @@ func TestAtomicBool(t *testing.T) {
 				cmpBool(t, b.Load(), tc.expEnd)
 			case "IsFalse":
 				cmpBool(t, b.IsFalse(), tc.expEnd)
+			case "Store":
+				b.Store(tc.val)
+				cmpBool(t, b.Load(), tc.expEnd)
 			default:
 				t.Fatalf("unhandled op %q", tc.op)
 			}


### PR DESCRIPTION
Oversight when the original implementation was added. Also
adds a unit test to verify that atm.Bool's zero value works
as expected.