### PR TITLE
DAOS-6819 build: Reduce daos-devel Requires

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+daos (1.1.3-3) unstable; urgency=medium
+  [ Brian J. Murrell ]
+  * NOOP bump just to keep in parity with RPM changes
+
+ -- Brian J. Murrell <brian.murrell@intel.com>  Mon, 22 Feb 2021 13:08:22 -0500
+
 daos (1.1.3-2) unstable; urgency=medium
   [ Alexander Oganezov ]
   * Update OFI to v1.12.0rc1

--- a/utils/rpms/daos.spec
+++ b/utils/rpms/daos.spec
@@ -7,7 +7,7 @@
 
 Name:          daos
 Version:       1.1.3
-Release:       2%{?relval}%{?dist}
+Release:       3%{?relval}%{?dist}
 Summary:       DAOS Storage Engine
 
 License:       BSD-2-Clause-Patent
@@ -122,8 +122,8 @@ to optimize performance and cost.
 
 %package server
 Summary: The DAOS server
-Requires: %{name} = %{version}-%{release}
-Requires: %{name}-client = %{version}-%{release}
+Requires: %{name}%{?_isa} = %{version}-%{release}
+Requires: %{name}-client%{?_isa} = %{version}-%{release}
 Requires: spdk-tools
 Requires: ndctl
 # needed to set PMem configuration goals in BIOS through control-plane
@@ -145,7 +145,7 @@ This is the package needed to run a DAOS server
 
 %package client
 Summary: The DAOS client
-Requires: %{name} = %{version}-%{release}
+Requires: %{name}%{?_isa} = %{version}-%{release}
 Requires: mercury = %{mercury_version}
 Requires: libfabric >= %{libfabric_version}
 Requires: fuse3 >= 3.4.2
@@ -164,7 +164,7 @@ This is the package needed to run a DAOS client
 
 %package tests
 Summary: The DAOS test suite
-Requires: %{name}-client = %{version}-%{release}
+Requires: %{name}-client%{?_isa} = %{version}-%{release}
 Requires: python-pathlib
 Requires: python-distro
 Requires: python2-tabulate
@@ -183,20 +183,9 @@ This is the package needed to run the DAOS test suite
 # for example, EL7 automatically adds:
 # Requires: libdaos.so.0()(64bit)
 %if (0%{?suse_version} >= 1500)
-Requires: %{name}-client = %{version}-%{release}
-Requires: %{name} = %{version}-%{release}
+Requires: %{name}-client%{?_isa} = %{version}-%{release}
+Requires: %{name}%{?_isa} = %{version}-%{release}
 %endif
-Requires: libuuid-devel
-Requires: libyaml-devel
-Requires: boost-devel
-# Pin mercury to exact version during development
-#Requires: mercury-devel < 2.0.0a1
-# we ideally want to set this minimum version however it seems to confuse yum:
-# https://github.com/rpm-software-management/yum/issues/124
-#Requires: mercury >= 2.0.0~a1
-Requires: mercury-devel = %{mercury_version}
-Requires: openpa-devel
-Requires: hwloc-devel
 Summary: The DAOS development libraries and headers
 
 %description devel
@@ -412,6 +401,10 @@ getent passwd daos_agent >/dev/null || useradd -s /sbin/nologin -r -g daos_agent
 %{_libdir}/*.a
 
 %changelog
+* Mon Feb 22 2021 Brian J. Murrell <brian.murrell@intel.com> 1.1.3-3
+- Remove all *-devel Requires from daos-devel as none of those are
+  actually necessary to build libdaos clients
+
 * Tue Feb 16 2021 Alexander Oganezov <alexander.a.oganezov@intel.com> 1.1.3-2
 - Update libfabric to v1.12.0rc1
 


### PR DESCRIPTION
Many -devel packages were being required by daos- devel that are not
actually needed to build client applications.