### PR TITLE
DAOS-4950 doc: update container info for DAOS v1.2

### DIFF
--- a/doc/user/container.md
+++ b/doc/user/container.md
@@ -28,7 +28,7 @@ to the POSIX file or directory.
 
 ```bash
 $ daos cont create --pool=a171434a-05a5-4671-8fe2-615aa0d05094 \
-      --path=/tmp/mycontainer --type=POSIX --oclass=large \
+      --path=/tmp/mycontainer --type=POSIX --oclass=SX \
       --chunk_size=4K
 Successfully created container 419b7562-5bb8-453f-bd52-917c8f5d80d1 type POSIX
 
@@ -47,18 +47,70 @@ Chunk Size:     4096
 
 At creation time, a list of container properties can be specified:
 
-| **Container Property**     | **Description** |
-| -------------------------  | --------------- |
+| **Container Property**            | **Description** |
+| -------------------------         | --------------- |
 | `DAOS_PROP_CO_LABEL`<img width=400/>| A string that a user can associate with a container. e.g., "Cat Pics" or "ResNet-50 training data"|
-| `DAOS_PROP_CO_LAYOUT_TYPE` | The container type (POSIX, HDF5, ...)|
-| `DAOS_PROP_CO_LAYOUT_VER`  | A version of the layout that can be used by I/O middleware and application to handle interoperability.|
-| `DAOS_PROP_CO_REDUN_FAC`   | The redundancy factor that drives the minimal data protection required for objects stored in the container. e.g., RF1 means no data protection, RF3 only allows 3-way replication or erasure code N+2.|
-| `DAOS_PROP_CO_REDUN_LVL`   | The fault domain level that should be used to place data redundancy information (e.g., storage nodes, racks...). This information will be eventually consumed to determine object placement.|
+| `DAOS_PROP_CO_LAYOUT_TYPE`        | The container type (POSIX, HDF5, ...)|
+| `DAOS_PROP_CO_LAYOUT_VER`         | A version of the layout that can be used by I/O middleware and application to handle interoperability.|
+| `DAOS_PROP_CO_REDUN_FAC`          | The redundancy factor that drives the minimal data protection required for objects stored in the container. e.g., RF1 means no data protection, RF3 only allows 3-way replication or erasure code N+2.|
+| `DAOS_PROP_CO_REDUN_LVL`          | The fault domain level that should be used to place data redundancy information (e.g., storage nodes, racks...). This information will be eventually consumed to determine object placement.|
+| `DAOS_PROP_CO_CSUM`               | Checksum off, or algorithm to use.|
+| `DAOS_PROP_CO_CSUM_CHUNK_SIZE`    | Checksum chunk size.|
+| `DAOS_PROP_CO_CSUM_SERVER_VERIFY` | Perform additional checksum verification on server (default: off).|
+| `DAOS_PROP_CO_SNAPSHOT_MAX`       | Impose a limit on number of snapshots to retain (default: 0, no limitation).|
+| `DAOS_PROP_CO_ACL                 | Container access control list.|
+| `DAOS_PROP_CO_OWNER`              | User acting as the owner of the container.|
+| `DAOS_PROP_CO_OWNER_GROUP`        | Group acting as the owner of the container.|
+
+Refer to the Data Integrity and Access Control Lists sections for more
+details on the checksum and access-related properties.
+
+Refer to the Inline Deduplication section for details about additional
+properties for that preview feature that are not listed here.
 
 While those properties are currently stored persistently with container
 metadata, many of them are still under development. The ability to modify some
 of these properties on an existing container will also be provided in a future
 release.
+
+### Querying a container's properties
+
+The user-level administration `daos` utility may be used to query a
+container's properties. Refer to the manual page for full usage details.
+
+```bash
+# daos cont get-prop --pool=<UUID> --cont=<UUID>
+# -OR- --path interface shown below
+
+$ daos cont get-prop --path=/tmp/mycontainer
+Container properties for 419b7562-5bb8-453f-bd52-917c8f5d80d1 :
+label:                  container label not set
+layout type:            POSIX (1)
+layout version:         1
+checksum type:          off
+checksum chunk-size:    32768
+cksum verif. on server: off
+deduplication:          off
+dedup threshold:        4096
+redundancy factor:      rf0
+redundancy level:       rack
+max snapshots:          0
+compression type:       off
+encryption type:        off
+Allocated OID:          0
+owner:                  username@
+owner-group:            groupname@
+status:                 HEALTHY
+acl:
+# Entries:
+A::OWNER@:rwdtTaAo
+A:G:GROUP@:rwtT
+```
+
+Additionally, a container's properties may be retrieved using the
+libdaos API daos_cont_query() function. Refer to the file
+src/incldue/daos_cont.h Doxygen comments and the online documentation
+available [here](https://daos-stack.github.io/html/).
 
 ## Data Integrity
 
@@ -105,7 +157,7 @@ during container create.
     cannot be changed.
 
 !!! warning
-    The checksum feature is only supported in DAOS 1.2.
+    The checksum feature is only supported in DAOS 1.2 and later.
 
 ## Inline Deduplication (Preview)
 
@@ -142,7 +194,7 @@ configure dedup, the following container properties are used:
   the I/O for dedup (default is 4K).
 
 !!! warning
-    Dedup is a feature preview in 1.2 (i.e. master) and has some known
+    Dedup is a feature preview in 1.2 and has some known
     limitations. Aggregation of deduplicated extents isn't supported and the
     checksum tree isn't persistent yet. This means that aggregation is disabled
     for a container with dedplication enabled and duplicated extents won't be
@@ -160,12 +212,16 @@ Similar to container create/destroy, a container can be snapshotted through the
 DAOS API by calling daos_cont_create_snap(). Additional functions are provided
 to destroy and list container snapshots.
 
-The API also provides the ability to subscribe to container snapshot events and
+The API also provides interfaces to subscribe to container snapshot events and
 to rollback the content of a container to a previous snapshot, but those
 operations are not yet fully implemented.
 
-This section will be updated once support for container snapshot is supported by
-the `daos` tool.
+The `daos` tool provides container {create/destroy}-snap and list-snaps
+commands. It provides access to basic snapshot create/destroy according
+to the constraints of the implementation (e.g., no named snapshots).
+It provides interfaces (commands and arguments) for the broader set of
+snapshot features, for when they are implemented later (e.g., specified
+epoch/epoch range, rollback).
 
 The `DAOS_PROP_CO_SNAPSHOT_MAX` property is used to limit the maximum number of
 snapshots to retain. When a new snapshot is taken, and the threshold is reached,
@@ -177,7 +233,8 @@ versions.
 ## User Attributes
 
 Similar to POSIX extended attributes, users can attach some metadata to each
-container through the daos_cont_{list/get/set}_attr() API.
+container through the daos_cont_{list/get/set}_attr() API, and through the
+utility commands: daos cont {get/set}-attr and list-attrs.
 
 ## Access Control Lists
 

--- a/doc/user/container.md
+++ b/doc/user/container.md
@@ -109,7 +109,7 @@ A:G:GROUP@:rwtT
 
 Additionally, a container's properties may be retrieved using the
 libdaos API daos_cont_query() function. Refer to the file
-src/incldue/daos_cont.h Doxygen comments and the online documentation
+src/include/daos_cont.h Doxygen comments and the online documentation
 available [here](https://daos-stack.github.io/html/).
 
 ## Data Integrity


### PR DESCRIPTION
Add to list of container properties that may be set at create-time.

Refer to daos cont get-prop and daos_cont_get_prop() API ;
and daos cont get/set/list attr commands.

Update description of container snapshot, including reference
to new daos cont commands in this area.

Doc-only: true

Signed-off-by: Kenneth Cain <kenneth.c.cain@intel.com>