### PR TITLE
DAOS-5737 test: Fix broken dfusesparse test

### DIFF
--- a/src/tests/ftest/io/dfuse_sparse_file.py
+++ b/src/tests/ftest/io/dfuse_sparse_file.py
@@ -46,7 +46,7 @@ class DfuseSparseFile(IorTestBase):
         """
         # Create a pool, container and start dfuse.
         self.create_pool()
-        self.create_cont()
+        self.create_cont("SX")
         self.start_dfuse(self.hostlist_clients, self.pool, self.container)
 
         # get scm space before write


### PR DESCRIPTION
Fixing broken dfusesparse test. container create method
was missing one variable

Test-tag-hw-small: pr,hw,small dfusesparsefile

Signed-off-by: Saurabh Tandan <saurabh.tandan@intel.com>