### PR TITLE
CART-89 debug: Cleanups, remove error prints from -DER_GRPVER

### DIFF
--- a/src/cart/crt_corpc.c
+++ b/src/cart/crt_corpc.c
@@ -502,14 +502,14 @@ corpc_del_child_rpc_locked(struct crt_rpc_priv *parent_rpc_priv,
 static inline void
 crt_corpc_fail_parent_rpc(struct crt_rpc_priv *parent_rpc_priv, int failed_rc)
 {
-	d_rank_t	 myrank;
-
-	crt_group_rank(NULL, &myrank);
-
 	parent_rpc_priv->crp_reply_hdr.cch_rc = failed_rc;
 	parent_rpc_priv->crp_corpc_info->co_rc = failed_rc;
-	D_ERROR("myrank %d, set parent rpc (opc %#x) as failed, rc: %d.\n",
-		myrank, parent_rpc_priv->crp_pub.cr_opc, failed_rc);
+	if (failed_rc != -DER_GRPVER)
+		RPC_ERROR(parent_rpc_priv,
+			  "Failing CORPC with rc=%d\n", failed_rc);
+	else
+		RPC_TRACE(DB_NET, parent_rpc_priv,
+			  "Failing CORPC with rc=%d\n", failed_rc);
 }
 
 static inline void

--- a/src/cart/crt_group.c
+++ b/src/cart/crt_group.c
@@ -1932,6 +1932,8 @@ done:
 			tmp_name, filename, strerror(errno));
 		rc = d_errno2der(errno);
 	}
+
+	D_DEBUG(DB_ALL, "Group config saved in %s\n", filename);
 out:
 	if (grp_priv && locked)
 		D_RWLOCK_UNLOCK(&grp_priv->gp_rwlock);
@@ -2440,7 +2442,7 @@ crt_rank_self_set(d_rank_t rank)
 
 	default_grp_priv = crt_gdata.cg_grp->gg_primary_grp;
 
-	D_DEBUG(DB_ALL, "Setting default group primary rank=%d\n", rank);
+	D_EMIT("Setting self rank to %d\n", rank);
 
 	if (!crt_is_service()) {
 		D_WARN("Setting self rank is not supported on client\n");

--- a/src/cart/crt_group.c
+++ b/src/cart/crt_group.c
@@ -2442,7 +2442,7 @@ crt_rank_self_set(d_rank_t rank)
 
 	default_grp_priv = crt_gdata.cg_grp->gg_primary_grp;
 
-	D_EMIT("Setting self rank to %d\n", rank);
+	D_INFO("Setting self rank to %d\n", rank);
 
 	if (!crt_is_service()) {
 		D_WARN("Setting self rank is not supported on client\n");

--- a/src/cart/crt_hg_proc.c
+++ b/src/cart/crt_hg_proc.c
@@ -620,6 +620,7 @@ crt_proc_out_common(crt_proc_t proc, crt_rpc_output_t *data)
 	struct crt_rpc_priv	*rpc_priv;
 	crt_proc_op_t		 proc_op;
 	int			 rc = 0;
+	int			 rc2;
 
 	if (proc == CRT_PROC_NULL)
 		D_GOTO(out, rc = -DER_INVAL);
@@ -676,18 +677,17 @@ crt_proc_out_common(crt_proc_t proc, crt_rpc_output_t *data)
 			}
 		}
 
-		if (rpc_priv->crp_reply_hdr.cch_rc != 0) {
+		rc2 = rpc->priv->crp_reply_hdr.cch_rc;
+		if (rc2 != 0) {
 
 			if (rpc_priv->crp_reply_hdr.cch_rc != -DER_GRPVER)
 				RPC_ERROR(rpc_priv,
 					  "RPC failed to execute on target. "
-					  "error code: "DF_RC"\n",
-					  DP_RC(rpc_priv->crp_reply_hdr.cch_rc));
+					  "error code: "DF_RC"\n", DP_RC(rc2));
 			else
 				RPC_TRACE(DB_NET, rpc_priv,
 					  "RPC failed to execute on target. "
-					  "error code: "DF_RC"\n",
-					  DP_RC(rpc_priv->crp_reply_hdr.cch_rc));
+					  "error code: "DF_RC"\n", DP_RC(rc2));
 
 			D_GOTO(out, rc);
 		}

--- a/src/cart/crt_hg_proc.c
+++ b/src/cart/crt_hg_proc.c
@@ -675,10 +675,20 @@ crt_proc_out_common(crt_proc_t proc, crt_rpc_output_t *data)
 				crt_hlct_sync(hdr->cch_hlc);
 			}
 		}
+
 		if (rpc_priv->crp_reply_hdr.cch_rc != 0) {
-			RPC_ERROR(rpc_priv,
-				  "RPC failed to execute on target. error code: %d\n",
-				  rpc_priv->crp_reply_hdr.cch_rc);
+
+			if (rpc_priv->crp_reply_hdr.cch_rc != -DER_GRPVER)
+				RPC_ERROR(rpc_priv,
+					  "RPC failed to execute on target. "
+					  "error code: "DF_RC"\n",
+					  DP_RC(rpc_priv->crp_reply_hdr.cch_rc));
+			else
+				RPC_TRACE(DB_NET, rpc_priv,
+					  "RPC failed to execute on target. "
+					  "error code: "DF_RC"\n",
+					  DP_RC(rpc_priv->crp_reply_hdr.cch_rc));
+
 			D_GOTO(out, rc);
 		}
 	}

--- a/src/cart/crt_hg_proc.c
+++ b/src/cart/crt_hg_proc.c
@@ -677,7 +677,7 @@ crt_proc_out_common(crt_proc_t proc, crt_rpc_output_t *data)
 			}
 		}
 
-		rc2 = rpc->priv->crp_reply_hdr.cch_rc;
+		rc2 = rpc_priv->crp_reply_hdr.cch_rc;
 		if (rc2 != 0) {
 
 			if (rpc_priv->crp_reply_hdr.cch_rc != -DER_GRPVER)

--- a/src/cart/crt_init.c
+++ b/src/cart/crt_init.c
@@ -29,10 +29,10 @@ dump_envariables(void)
 		"FI_UNIVERSE_SIZE", "CRT_DISABLE_MEM_PIN",
 		"FI_OFI_RXM_USE_SRX" };
 
-	D_DEBUG(DB_ALL, "-- ENVARS: --\n");
+	D_INFO("-- ENVARS: --\n");
 	for (i = 0; i < ARRAY_SIZE(envars); i++) {
 		val = getenv(envars[i]);
-		D_DEBUG(DB_ALL, "%s = %s\n", envars[i], val);
+		D_INFO("%s = %s\n", envars[i], val);
 	}
 }
 
@@ -183,8 +183,10 @@ static int data_init(int server, crt_init_options_t *opt)
 		d_getenv_int("CRT_CTX_NUM", &ctx_num);
 		crt_gdata.cg_ctx_max_num = ctx_num;
 	}
+
 	D_DEBUG(DB_ALL, "set cg_sep_mode %d, cg_ctx_max_num %d.\n",
 		crt_gdata.cg_sep_mode, crt_gdata.cg_ctx_max_num);
+
 	if (crt_gdata.cg_sep_mode == false && crt_gdata.cg_ctx_max_num > 1)
 		D_WARN("CRT_CTX_NUM has no effect because CRT_CTX_SHARE_ADDR "
 		       "is not set or set to 0\n");

--- a/src/cart/crt_iv.c
+++ b/src/cart/crt_iv.c
@@ -1207,7 +1207,7 @@ crt_ivf_rpc_issue(d_rank_t dest_node, crt_iv_key_t *iv_key,
 	if (local_grp_ver == grp_ver) {
 		input->ifi_grp_ver = grp_ver;
 	} else {
-		D_ERROR("Group Version Changed: From %d: To %d\n",
+		D_DEBUG(DB_ALL, "Group Version Changed: From %d: To %d\n",
 			grp_ver, local_grp_ver);
 		D_GOTO(exit, rc = -DER_GRPVER);
 	}
@@ -1281,7 +1281,7 @@ crt_iv_parent_get(struct crt_ivns_internal *ivns_internal,
 	d_rank_t self = ivns_internal->cii_grp_priv->gp_self;
 
 	if (self == CRT_NO_RANK) {
-		D_DEBUG(DB_TRACE, "%s: self rank not known yet\n",
+		D_DEBUG(DB_ALL, "%s: self rank not known yet\n",
 			ivns_internal->cii_grp_priv->gp_pub.cg_grpid);
 		return -DER_GRPVER;
 	}
@@ -1335,7 +1335,8 @@ crt_hdlr_iv_fetch_aux(void *arg)
 	 */
 	grp_ver_entry = ivns_internal->cii_grp_priv->gp_membs_ver;
 	if (grp_ver_entry != input->ifi_grp_ver) {
-		D_ERROR("Group (%s) version mismatch. Local: %d Remote :%d\n",
+		D_DEBUG(DB_ALL,
+			"Group (%s) version mismatch. Local: %d Remote :%d\n",
 			ivns_id.ii_group_name, grp_ver_entry,
 			input->ifi_grp_ver);
 		D_GOTO(send_error, rc = -DER_GRPVER);
@@ -1415,7 +1416,7 @@ crt_hdlr_iv_fetch_aux(void *arg)
 
 		/* Check here for change in group */
 		if (grp_ver_entry != grp_ver_current) {
-			D_ERROR("Group (%s) version changed. "
+			D_DEBUG(DB_ALL, "Group (%s) version changed. "
 				"On Entry: %d:: Changed To :%d\n",
 				ivns_id.ii_group_name,
 				grp_ver_entry, grp_ver_current);
@@ -1515,7 +1516,8 @@ crt_hdlr_iv_fetch(crt_rpc_t *rpc_req)
 	grp_ver = ivns_internal->cii_grp_priv->gp_membs_ver;
 
 	if (grp_ver != input->ifi_grp_ver) {
-		D_ERROR("Group (%s) version mismatch. Local: %d Remote :%d\n",
+		D_DEBUG(DB_ALL,
+			"Group (%s) version mismatch. Local: %d Remote :%d\n",
 			ivns_id.ii_group_name, grp_ver,
 			input->ifi_grp_ver);
 		D_GOTO(send_error, rc = -DER_GRPVER);
@@ -1823,7 +1825,8 @@ crt_hdlr_iv_sync_aux(void *arg)
 	/* Check group version match */
 	grp_ver = ivns_internal->cii_grp_priv->gp_membs_ver;
 	if (grp_ver != input->ivs_grp_ver) {
-		D_ERROR("Group (%s) version mismatch. Local: %d Remote :%d\n",
+		D_DEBUG(DB_ALL,
+			"Group (%s) version mismatch. Local: %d Remote :%d\n",
 			ivns_id.ii_group_name, grp_ver,
 			input->ivs_grp_ver);
 		D_GOTO(exit, rc = -DER_GRPVER);
@@ -1963,7 +1966,8 @@ crt_hdlr_iv_sync(crt_rpc_t *rpc_req)
 	/* Check group version match */
 	grp_ver = ivns_internal->cii_grp_priv->gp_membs_ver;
 	if (grp_ver != input->ivs_grp_ver) {
-		D_ERROR("Group (%s) version mismatch. Local: %d Remote :%d\n",
+		D_DEBUG(DB_ALL,
+			"Group (%s) version mismatch. Local: %d Remote :%d\n",
 			ivns_id.ii_group_name, grp_ver,
 			input->ivs_grp_ver);
 		D_GOTO(exit, rc = -DER_GRPVER);
@@ -2650,7 +2654,8 @@ crt_ivu_rpc_issue(d_rank_t dest_rank, crt_iv_key_t *iv_key,
 	 */
 	local_grp_ver =  ivns_internal->cii_grp_priv->gp_membs_ver;
 	if (grp_ver != local_grp_ver) {
-		D_ERROR("Group (%s) version mismatch. "
+		D_DEBUG(DB_ALL,
+			"Group (%s) version mismatch. "
 			"On entry: %d: Changed to :%d\n",
 			ivns_internal->cii_gns.gn_ivns_id.ii_group_name,
 			grp_ver, local_grp_ver);
@@ -3035,7 +3040,8 @@ crt_hdlr_iv_update(crt_rpc_t *rpc_req)
 	/* Check group version match with rpc request*/
 	grp_ver_entry = ivns_internal->cii_grp_priv->gp_membs_ver;
 	if (grp_ver_entry != input->ivu_grp_ver) {
-		D_ERROR("Group (%s) version mismatch. Local: %d Remote :%d\n",
+		D_DEBUG(DB_ALL,
+			"Group (%s) version mismatch. Local: %d Remote :%d\n",
 			ivns_id.ii_group_name, grp_ver_entry,
 			input->ivu_grp_ver);
 		D_GOTO(send_error, rc = -DER_GRPVER);
@@ -3074,7 +3080,8 @@ crt_hdlr_iv_update(crt_rpc_t *rpc_req)
 			grp_ver_current = ivns_internal->cii_grp_priv->
 							  gp_membs_ver;
 			if (grp_ver_entry != grp_ver_current) {
-				D_ERROR("Group (%s) version mismatch. "
+				D_DEBUG(DB_ALL,
+					"Group (%s) version mismatch. "
 					"On Entry: %d:: Changed to:%d\n",
 					ivns_id.ii_group_name,
 					grp_ver_entry, grp_ver_current);
@@ -3316,7 +3323,8 @@ crt_iv_update_internal(crt_iv_namespace_t ivns, uint32_t class_id,
 			D_GOTO(put, rc);
 
 		if (grp_ver != grp_ver2) {
-			D_ERROR("Group (%s) version mismatch. "
+			D_DEBUG(DB_ALL,
+				"Group (%s) version mismatch. "
 				"On Entry: %d:: Changed to:%d\n",
 				ivns_internal->cii_gns.gn_ivns_id.ii_group_name,
 				grp_ver, grp_ver2);
@@ -3441,7 +3449,7 @@ crt_iv_get_nchildren(crt_iv_namespace_t ivns, uint32_t class_id,
 
 	self_rank = ivns_internal->cii_grp_priv->gp_self;
 	if (self_rank == CRT_NO_RANK) {
-		D_DEBUG(DB_TRACE, "%s: self rank not known yet\n",
+		D_DEBUG(DB_ALL, "%s: self rank not known yet\n",
 			ivns_internal->cii_grp_priv->gp_pub.cg_grpid);
 		D_GOTO(exit, rc = -DER_GRPVER);
 	}

--- a/src/cart/crt_tree.c
+++ b/src/cart/crt_tree.c
@@ -190,7 +190,8 @@ crt_tree_get_children(struct crt_grp_priv *grp_priv, uint32_t grp_ver,
 		*ver_match = (bool)(grp_ver == grp_priv->gp_membs_ver);
 
 		if (*ver_match == false) {
-			D_ERROR("Version mismatch. Passed: %u current:%u\n",
+			D_DEBUG(DB_ALL,
+				"Version mismatch. Passed: %u current:%u\n",
 				grp_ver, grp_priv->gp_membs_ver);
 			D_GOTO(out, rc = -DER_GRPVER);
 		}

--- a/src/tests/ftest/cart/no_pmix_group_test.c
+++ b/src/tests/ftest/cart/no_pmix_group_test.c
@@ -509,10 +509,6 @@ int main(int argc, char **argv)
 	if (my_rank != 1)
 		D_GOTO(join, 0);
 
-	/* Wait for all servers to load up */
-	/* TODO: This will be replaced by proper sync when CART-715 is done */
-	sleep(10);
-
 	rc = crt_group_ranks_get(grp, &rank_list);
 	if (rc != 0) {
 		D_ERROR("crt_group_ranks_get() failed; rc=%d\n", rc);


### PR DESCRIPTION
- -DER_GRPVER errors are no longer emitted as errors
- Rank is emitted once into log, instead of on every failed corpc
- group_test modified to remove 10 second sleep that is no longer needed
- Envariables affecting CART are now printed as D_INFO

Signed-off-by: Alexander Oganezov <alexander.a.oganezov@intel.com>