### PR TITLE
DAOS-5313 tests: fix typo in large_snap test

### DIFF
--- a/src/tests/suite/daos_rebuild_simple.c
+++ b/src/tests/suite/daos_rebuild_simple.c
@@ -825,7 +825,7 @@ rebuild_large_snap(void **state)
 	daos_epoch_t	snap_epoch[100];
 	int		i;
 
-	oid = dts_oid_gen(arg->obj_class, 0, arg->myrank);
+	oid = daos_test_oid_gen(arg->coh, arg->obj_class, 0, 0, arg->myrank);
 	oid = dts_oid_set_rank(oid, ranks_to_kill[0]);
 	oid = dts_oid_set_tgt(oid, tgt);
 	ioreq_init(&req, arg->coh, oid, DAOS_IOD_ARRAY, arg);


### PR DESCRIPTION
fix oid_gen interface for large_snap test.

Signed-off-by: Di Wang <di.wang@intel.com>