### PR TITLE
DAOS-6857 test: Fix dynamic_start_stop.py in weekly regression

### DIFF
--- a/src/tests/ftest/server/dynamic_start_stop.py
+++ b/src/tests/ftest/server/dynamic_start_stop.py
@@ -90,8 +90,7 @@ class DynamicStartStop(TestWithServers):
         self.verify_system_query_all()
 
         # Stop one of the added servers - Single stop.
-        #self.dmg_cmd.system_stop(ranks="4")
-        self.dmg_cmd.system_stop(ranks="2")
+        self.dmg_cmd.system_stop(ranks="4")
 
         # Verify that the State of the stopped server is evicted and Reason is
         # system stop.

--- a/src/tests/ftest/util/apricot/apricot/test.py
+++ b/src/tests/ftest/util/apricot/apricot/test.py
@@ -1243,7 +1243,8 @@ class TestWithServers(TestWithoutServers):
         """
         self.container = self.get_container(pool, namespace, create)
 
-    def start_additional_servers(self, additional_servers, index=0):
+    def start_additional_servers(self, additional_servers, index=0,
+                                 access_points=None):
         """Start additional servers.
 
         This method can be used to start a new daos_server during a test.
@@ -1253,6 +1254,8 @@ class TestWithServers(TestWithoutServers):
                 daos_server.
             index (int): Determines which server_managers to use when creating
                 the new server.
+            access_points (list, optional): list of access point hosts. Defaults
+                to None which uses self.access_points.
         """
         self.add_server_manager(
             self.server_managers[index].manager.job.get_config_value("name"),
@@ -1266,6 +1269,6 @@ class TestWithServers(TestWithoutServers):
             self.server_managers[-1],
             additional_servers,
             self.hostfile_servers_slots,
-            additional_servers
+            access_points
         )
         self._start_manager_list("server", [self.server_managers[-1]])

--- a/src/tests/ftest/util/dmg_utils.py
+++ b/src/tests/ftest/util/dmg_utils.py
@@ -792,69 +792,49 @@ class DmgCommand(DmgCommandBase):
             dict: a dictionary of host ranks and their unique states.
 
         """
-        self._get_result(("system", "query"), ranks=ranks, verbose=verbose)
-
         data = {}
-        if re.findall(r"Rank \d+", self.result.stdout):
-            # Process the unique single rank system query output, e.g.
-            #   Rank 1
-            #   ------
-            #   address      : 10.8.1.68:10001
-            #   uuid         : bcc5b010-1ffa-4525-96a9-11f1904374d6
-            #   fault domain : /wolf-68.wolf.hpdd.intel.com
-            #   status       : Joined
-            #   reason       :
-            match = re.findall(
-                r"(?:Rank|address\s+:|uuid\s+:|domain\s+:|status\s+:|"
-                r"reason\s+:)\s+(.*)",
-                self.result.stdout)
-            if match:
-                print("--- match: {}".format(match))
-                data[int(match[0])] = {
-                    "address": match[1].strip(),
-                    "uuid": match[2].strip(),
-                    "domain": match[3].strip(),
-                    "state": match[4].strip(),
-                    "reason": match[5].strip(),
+        # Sample output:
+        # {
+        # "response": {
+        #     "members": [
+        #     {
+        #         "addr": "10.8.1.11:10001",
+        #         "state": "joined",
+        #         "fault_domain": "/wolf-11.wolf.hpdd.intel.com",
+        #         "rank": 0,
+        #         "uuid": "e7f2cb06-a111-4d55-a6a5-b494b70d62ab",
+        #         "fabric_uri": "ofi+sockets://192.168.100.11:31416",
+        #         "fabric_contexts": 17,
+        #         "info": ""
+        #     },
+        #     {
+        #         "addr": "10.8.1.74:10001",
+        #         "state": "evicted",
+        #         "fault_domain": "/wolf-74.wolf.hpdd.intel.com",
+        #         "rank": 1,
+        #         "uuid": "db36ab28-fdb0-4822-97e6-89547393ed03",
+        #         "fabric_uri": "ofi+sockets://192.168.100.74:31416",
+        #         "fabric_contexts": 17,
+        #         "info": ""
+        #     }
+        #     ]
+        # },
+        # "error": null,
+        # "status": 0
+        # }
+        output = self._get_json_result(
+            ("system", "query"), ranks=ranks, verbose=verbose)
+        if "response" in output and "members" in output["response"]:
+            for member in output["response"]["members"]:
+                data[member["rank"]] = {
+                    "address": member["addr"],
+                    "uuid": member["uuid"],
+                    "domain": member["fault_domain"],
+                    "state": member["state"],
+                    "reason": member["info"],
+                    "fabric_uri": member["fabric_uri"],
+                    "fabric_contexts": member["fabric_contexts"],
                 }
-        elif verbose:
-            # Process the verbose multiple rank system query output, e.g.
-            #   Rank UUID                                 Control Address State
-            #   ---- ----                                 --------------- -----
-            #   0    385af2f9-1863-406c-ae94-bffdcd02f379 10.8.1.10:10001 Joined
-            #   1    d7a69a41-59a2-4dec-a620-a52217851285 10.8.1.11:10001 Joined
-            #   Rank UUID   Control Address  Fault Domain  State  Reason
-            #   ---- ----   ---------------  ------------  -----  ------
-            #   0    <uuid> <address>        <domain>      Joined system stop
-            #   1    <uuid> <address>        <domain>      Joined system stop
-            #
-            #       Where the above placeholders have values similar to:
-            #           <uuid>    = 0c21d700-0e2b-46fb-be49-1fca490ce5b0
-            #           <address> = 10.8.1.142:10001
-            #           <domain>  = /wolf-142.wolf.hpdd.intel.com
-            #
-            match = re.findall(
-                r"(\d+)\s+([0-9a-f-]+)\s+([0-9.:]+)\s+([/A-Za-z0-9-_.]+)"
-                r"\s+([A-Za-z]+)(.*)",
-                self.result.stdout)
-            for info in match:
-                data[int(info[0])] = {
-                    "uuid": info[1],
-                    "address": info[2],
-                    "domain": info[3],
-                    "state": info[4],
-                    "reason": info[5].strip(),
-                }
-        else:
-            # Process the non-verbose multiple rank system query output, e.g.
-            #   Rank  State
-            #   ----  -----
-            #   [0-1] Joined
-            match = re.findall(
-                r"(?:\[*([0-9-,]+)\]*)\s+([A-Za-z]+)", self.result.stdout)
-            for info in match:
-                for rank in get_numeric_list(info[0]):
-                    data[rank] = {"state": info[1]}
 
         self.log.info("system_query data: %s", str(data))
         return data


### PR DESCRIPTION
system_query() is changed to use JSON and the returned data structure is changed, so updated verify_system_query()
to handle the new data structure.

Updated start_additional_servers() to receive access_points since configure_manager() was updated to take access point.

Updated test tags.

Quick-Functional: true
Skip-unit-test: true
Test-tag: dynamic_start_stop
Skip-checkpatch: false
Signed-off-by: Makito Kano <makito.kano@intel.com>