### PR TITLE
DAOS-6849 test: fix coverity warning

### DIFF
--- a/src/common/dts.c
+++ b/src/common/dts.c
@@ -270,7 +270,9 @@ pool_fini(struct dts_context *tsc)
 			DP_RC(rc));
 
 	} else { /* DAOS mode */
-		daos_pool_disconnect(tsc->tsc_poh, NULL);
+		rc = daos_pool_disconnect(tsc->tsc_poh, NULL);
+		D_ASSERTF(rc == 0 || rc == -DER_NO_HDL, "rc="DF_RC"\n",
+			  DP_RC(rc));
 		MPI_Barrier(MPI_COMM_WORLD);
 		if (tsc->tsc_mpi_rank == 0) {
 			rc = dmg_pool_destroy(dmg_config_file,

--- a/src/include/daos_prop.h
+++ b/src/include/daos_prop.h
@@ -126,7 +126,7 @@ enum daos_cont_props {
 	/**
 	 * Redundancy factor:
 	 * RF(n): Container I/O restricted after n faults.
-	 * default = RF1 (DAOS_PROP_CO_REDUN_RF1)
+	 * default = RF0 (DAOS_PROP_CO_REDUN_RF0)
 	 */
 	DAOS_PROP_CO_REDUN_FAC,
 	/**


### PR DESCRIPTION
Fix a coverity warning in dts.c, fix a typo in daos_prop.h

Signed-off-by: Xuezhao Liu <xuezhao.liu@intel.com>