### PR TITLE
DAOS-5579 doc: remove OPA reference from daos_server.yml

### DIFF
--- a/utils/config/daos_server.yml
+++ b/utils/config/daos_server.yml
@@ -72,8 +72,8 @@
 #
 ## Force a specific provider to be used by all the engines.
 ## The default provider depends on the interfaces that will be auto-detected:
-## ofi+psm2 for Omni-Path, ofi+verbs;ofi_rxm for Infiniband/RoCE and finally
-## ofi+socket for non-RDMA-capable Ethernet.
+##  ofi+verbs;ofi_rxm for Infiniband/RoCE and
+##  ofi+socket for non-RDMA-capable Ethernet.
 #
 #provider: ofi+verbs;ofi_rxm
 #
@@ -289,7 +289,7 @@
 #  # If VMD-enabled NVMe SSDs are used, the bdev_list should consist of the VMD
 #  # PCIe addresses, and not the BDF format transport IDs of the backing NVMe SSDs
 #  # behind the VMD address. Also, 'disable_vmd' needs to be set to false.
-#  bdev_list: ["0000:5d:05.5]
+#  bdev_list: ["0000:5d:05.5"]
 
 #-
 #  # Rank to be assigned as identifier for this engine.


### PR DESCRIPTION
remove OPA reference from daos_server.yml, fix " typo

Signed-off-by: Michael Hennecke <mhennecke@lenovo.com>