### PR TITLE
DAOS-6859 control: increase stop rank deadline

### DIFF
--- a/src/control/server/ctl_ranks_rpc.go
+++ b/src/control/server/ctl_ranks_rpc.go
@@ -21,6 +21,7 @@ import (
 )
 
 const (
+	// instanceUpdateDelay is the polling time period
 	instanceUpdateDelay = 500 * time.Millisecond
 )
 
@@ -183,11 +184,9 @@ func (svc *ControlService) StopRanks(ctx context.Context, req *ctlpb.RanksReq) (
 	defer svc.events.EnableEventIDs(events.RASRankDown)
 
 	for _, srv := range instances {
-		svc.log.Debugf("%d: check started", srv.Index())
 		if !srv.isStarted() {
 			continue
 		}
-		svc.log.Debugf("%d: call Stop()", srv.Index())
 		if err := srv.Stop(signal); err != nil {
 			return nil, errors.Wrapf(err, "sending %s", signal)
 		}

--- a/src/control/server/harness.go
+++ b/src/control/server/harness.go
@@ -23,8 +23,8 @@ import (
 )
 
 const (
-	defaultRequestTimeout = 3 * time.Second
-	defaultStartTimeout   = 10 * defaultRequestTimeout
+	rankReqTimeout   = 10 * time.Second
+	rankStartTimeout = 3 * rankReqTimeout
 )
 
 // EngineHarness is responsible for managing Engine instances.
@@ -43,8 +43,8 @@ func NewEngineHarness(log logging.Logger) *EngineHarness {
 	return &EngineHarness{
 		log:              log,
 		instances:        make([]*EngineInstance, 0),
-		rankReqTimeout:   defaultRequestTimeout,
-		rankStartTimeout: defaultStartTimeout,
+		rankReqTimeout:   rankReqTimeout,
+		rankStartTimeout: rankStartTimeout,
 	}
 }
 


### PR DESCRIPTION
Allow longer for ranks to terminate when requested during system stop,
under I/O load 3 seconds is not enough and system stop may report
errors. Increase to 10 seconds (start rank deadline remains at 30).

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>