### PR TITLE
DAOS-623 test: Fix % substitutions in repo paths

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -302,7 +302,8 @@ def getuid() {
 // in faster time-to-result for PRs.
 
 String get_priority() {
-    if (env.BRANCH_NAME == 'master') {
+    if (env.BRANCH_NAME == 'master' ||
+        env.BRANCH_NAME.startsWith("release/")) {
         string p = '2'
     } else {
         string p = ''

--- a/ci/provisioning/post_provision_config_nodes.sh
+++ b/ci/provisioning/post_provision_config_nodes.sh
@@ -2,6 +2,46 @@
 
 set -eux
 
+# functions common to more than one distro specific provisioning
+url_to_repo() {
+    local url="$1"
+
+    local repo=${url#*://}
+    repo="${repo//%/}"
+    repo="${repo//\//_}"
+
+    echo "$repo"
+}
+
+add_repo() {
+    local repo="$1"
+    local gpg_check="${2:-true}"
+
+    if [ -n "$repo" ]; then
+        repo="${REPOSITORY_URL}${repo}"
+        if ! dnf repolist | grep "$(url_to_repo "$repo")"; then
+            dnf config-manager --add-repo="${repo}"
+            if ! $gpg_check; then
+                disable_gpg_check "$repo"
+            fi
+        fi
+    fi
+}
+
+disable_gpg_check() {
+    local url="$1"
+
+    repo="$(url_to_repo "$url")"
+    # bug in EL7 DNF: this needs to be enabled before it can be disabled
+    dnf config-manager --save --setopt="$repo".gpgcheck=1
+    dnf config-manager --save --setopt="$repo".gpgcheck=0
+    # but even that seems to be not enough, so just brute-force it
+    if [ -d /etc/yum.repos.d ] &&
+       ! grep gpgcheck /etc/yum.repos.d/"$repo".repo; then
+        echo "gpgcheck=0" >> /etc/yum.repos.d/"$repo".repo
+    fi
+}
+
 env > /root/last_run-env.txt
 if ! grep ":$MY_UID:" /etc/group; then
   groupadd -g "$MY_UID" jenkins


### PR DESCRIPTION
DNF seems to have changed how it substitutes % encodings in URLs into
repository path names.

DRY out some common code across EL7 and LEAP15's use of DNF to provision
nodes.