### PR TITLE
DAOS-6714 rebuild: Delete redundant objects prior to reintegration (#4739)

### DIFF
--- a/src/container/srv_target.c
+++ b/src/container/srv_target.c
@@ -1553,59 +1553,6 @@ cont_close_hdl(uuid_t cont_hdl_uuid)
 	return 0;
 }
 
-static int
-cont_close_all_cb(d_list_t *rlink, void *arg)
-{
-	uuid_t *cont_uuid = arg;
-	struct ds_cont_hdl *hdl = cont_hdl_obj(rlink);
-	int rc;
-
-	if (hdl->sch_cont == NULL)
-		return DER_SUCCESS;
-
-	if (uuid_compare(*cont_uuid, hdl->sch_cont->sc_uuid) == 0) {
-		rc = cont_close_hdl(hdl->sch_uuid);
-		if (rc != 0) {
-			D_ERROR("cont_close_hdl failed: rc="DF_RC, DP_RC(rc));
-			return rc;
-		}
-	}
-
-	return DER_SUCCESS;
-}
-
-/* Called via dss_collective() to close all container handles for this thread */
-static int
-cont_close_all(void *vin)
-{
-	struct dsm_tls *tls = dsm_tls_get();
-	uuid_t *cont_uuid = vin;
-	int rc;
-
-	rc = d_hash_table_traverse(&tls->dt_cont_hdl_hash, cont_close_all_cb,
-				   cont_uuid);
-	if (rc != 0) {
-		D_ERROR("d_hash_table_traverse failed: rc="DF_RC, DP_RC(rc));
-		return rc;
-	}
-
-	return DER_SUCCESS;
-}
-
-int
-ds_cont_tgt_force_close(uuid_t cont_uuid)
-{
-	int rc;
-
-	D_DEBUG(DF_DSMS, "Force closing all handles for container "
-		DF_UUID"\n", DP_UUID(cont_uuid));
-
-	rc = dss_thread_collective(cont_close_all, &cont_uuid, 0);
-	if (rc != 0)
-		D_ERROR("dss_thread_collective failed: rc="DF_RC, DP_RC(rc));
-	return rc;
-}
-
 struct coll_close_arg {
 	uuid_t	uuid;
 };

--- a/src/object/obj_internal.h
+++ b/src/object/obj_internal.h
@@ -201,11 +201,6 @@ struct migrate_pool_tls {
 	daos_handle_t		mpt_migrated_root_hdl;
 	struct btr_root		mpt_migrated_root;
 
-	/* Hash table to store the container uuids which have already been
-	 * deleted (used by reintegration)
-	 */
-	struct d_hash_table	mpt_cont_dest_tab;
-
 	/* Service rank list for migrate fetch RPC */
 	d_rank_list_t		mpt_svc_list;
 
@@ -235,10 +230,14 @@ struct migrate_pool_tls {
 	uint64_t		mpt_refcount;
 	/* migrate leader ULT */
 	unsigned int		mpt_ult_running:1,
-	/* Indicates whether containers should be cleared of all contents
-	 * before any data is migrated to them (via destroy & recreate)
+	/* Indicates whether objects on the migration destination should be
+	 * removed prior to migrating new data here. This is primarily useful
+	 * for reintegration to ensure that any data that has adequate replica
+	 * data to reconstruct will prefer the remote data over possibly stale
+	 * existing data. Objects that don't have remote replica data will not
+	 * be removed.
 	 */
-				mpt_clear_conts:1,
+				mpt_del_local_objs:1,
 				mpt_fini:1;
 };
 

--- a/src/object/obj_rpc.h
+++ b/src/object/obj_rpc.h
@@ -320,7 +320,7 @@ CRT_RPC_DECLARE(obj_sync, DAOS_ISEQ_OBJ_SYNC, DAOS_OSEQ_OBJ_SYNC)
 	((uint64_t)		(om_max_eph)		CRT_VAR)	\
 	((uint32_t)		(om_version)		CRT_VAR)	\
 	((uint32_t)		(om_tgt_idx)		CRT_VAR)	\
-	((int32_t)		(om_clear_conts)	CRT_VAR)	\
+	((int32_t)		(om_del_local_obj)	CRT_VAR)	\
 	((daos_unit_oid_t)	(om_oids)		CRT_ARRAY)	\
 	((uint64_t)		(om_ephs)		CRT_ARRAY)	\
 	((uint32_t)		(om_shards)		CRT_ARRAY)

--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -3990,7 +3990,7 @@ static int
 pool_find_all_targets_by_addr(uuid_t pool_uuid,
 			      struct pool_target_addr_list *list,
 			      struct pool_target_id_list *tgt_list,
-			      struct pool_target_addr_list *out_list,
+			      struct pool_target_addr_list *inval_list_out,
 			      struct rsvc_hint *hint)
 {
 	struct pool_svc	*svc;
@@ -4029,11 +4029,11 @@ pool_find_all_targets_by_addr(uuid_t pool_uuid,
 			/* Can not locate the target in pool map, let's
 			 * add it to the output list
 			 */
-			D_WARN("Can not find %u/%d , add to out_list\n",
+			D_WARN("Can not find %u/%d, add to inval_list_out\n",
 				list->pta_addrs[i].pta_rank,
 				(int)list->pta_addrs[i].pta_target);
-			ret = pool_target_addr_list_append(out_list,
-						&list->pta_addrs[i]);
+			ret = pool_target_addr_list_append(inval_list_out,
+							   &list->pta_addrs[i]);
 			if (ret) {
 				rc = ret;
 				break;
@@ -4268,7 +4268,7 @@ ds_pool_tgt_add_in(uuid_t pool_uuid, struct pool_target_id_list *list)
 static int
 ds_pool_update(uuid_t pool_uuid, crt_opcode_t opc,
 	       struct pool_target_addr_list *list,
-	       struct pool_target_addr_list *out_list,
+	       struct pool_target_addr_list *inval_list_out,
 	       uint32_t *map_version, struct rsvc_hint *hint, bool evict_rank)
 {
 	daos_rebuild_opc_t		op;
@@ -4282,11 +4282,11 @@ ds_pool_update(uuid_t pool_uuid, crt_opcode_t opc,
 	char				*env;
 
 	rc = pool_find_all_targets_by_addr(pool_uuid, list, &target_list,
-					   out_list, hint);
+					   inval_list_out, hint);
 	if (rc)
 		D_GOTO(out, rc);
 
-	if (out_list->pta_number > 0) {
+	if (inval_list_out->pta_number > 0) {
 		int i;
 
 		/*
@@ -4296,11 +4296,11 @@ ds_pool_update(uuid_t pool_uuid, crt_opcode_t opc,
 		 * without trying to figure out which arguments were accepted &
 		 * started processing already.
 		 */
-		for (i = 0; i < out_list->pta_number; i++) {
+		for (i = 0; i < inval_list_out->pta_number; i++) {
 			D_WARN("Got request to update nonexistent rank %u "
 			       "target %u\n",
-			       out_list->pta_addrs[i].pta_rank,
-			       out_list->pta_addrs[i].pta_target);
+			       inval_list_out->pta_addrs[i].pta_rank,
+			       inval_list_out->pta_addrs[i].pta_target);
 		}
 		D_GOTO(out, rc = -DER_NONEXIST);
 	}
@@ -4555,7 +4555,7 @@ ds_pool_update_handler(crt_rpc_t *rpc)
 	struct pool_tgt_update_in	*in = crt_req_get(rpc);
 	struct pool_tgt_update_out	*out = crt_reply_get(rpc);
 	struct pool_target_addr_list	list = { 0 };
-	struct pool_target_addr_list	out_list = { 0 };
+	struct pool_target_addr_list	inval_list_out = { 0 };
 	int				rc;
 
 	if (in->pti_addr_list.ca_arrays == NULL ||
@@ -4568,27 +4568,27 @@ ds_pool_update_handler(crt_rpc_t *rpc)
 	list.pta_number = in->pti_addr_list.ca_count;
 	list.pta_addrs = in->pti_addr_list.ca_arrays;
 	rc = ds_pool_update(in->pti_op.pi_uuid, opc_get(rpc->cr_opc), &list,
-			    &out_list, &out->pto_op.po_map_version,
+			    &inval_list_out, &out->pto_op.po_map_version,
 			    &out->pto_op.po_hint, false);
 	if (rc)
 		D_GOTO(out, rc);
 
-	out->pto_addr_list.ca_arrays = out_list.pta_addrs;
-	out->pto_addr_list.ca_count = out_list.pta_number;
+	out->pto_addr_list.ca_arrays = inval_list_out.pta_addrs;
+	out->pto_addr_list.ca_count = inval_list_out.pta_number;
 
 out:
 	out->pto_op.po_rc = rc;
 	D_DEBUG(DF_DSMS, DF_UUID": replying rpc %p: "DF_RC"\n",
 		DP_UUID(in->pti_op.pi_uuid), rpc, DP_RC(rc));
 	crt_reply_send(rpc);
-	pool_target_addr_list_free(&out_list);
+	pool_target_addr_list_free(&inval_list_out);
 }
 
 int
 ds_pool_evict_rank(uuid_t pool_uuid, d_rank_t rank)
 {
 	struct pool_target_addr_list	list;
-	struct pool_target_addr_list	out_list = { 0 };
+	struct pool_target_addr_list	inval_list_out = { 0 };
 	struct pool_target_addr		tgt_rank;
 	uint32_t			map_version = 0;
 	int				rc;
@@ -4598,13 +4598,13 @@ ds_pool_evict_rank(uuid_t pool_uuid, d_rank_t rank)
 	list.pta_number = 1;
 	list.pta_addrs = &tgt_rank;
 
-	rc = ds_pool_update(pool_uuid, POOL_EXCLUDE, &list, &out_list,
+	rc = ds_pool_update(pool_uuid, POOL_EXCLUDE, &list, &inval_list_out,
 			    &map_version, NULL, true);
 
 	D_DEBUG(DB_MGMT, "Exclude pool "DF_UUID"/%u rank %u: rc %d\n",
 		DP_UUID(pool_uuid), map_version, rank, rc);
 
-	pool_target_addr_list_free(&out_list);
+	pool_target_addr_list_free(&inval_list_out);
 
 	return rc;
 }

--- a/src/rebuild/scan.c
+++ b/src/rebuild/scan.c
@@ -121,7 +121,7 @@ rebuild_obj_send_cb(struct tree_cache_root *root, struct rebuild_send_arg *arg)
 				       arg->tgt_id, rpt->rt_rebuild_ver,
 				       rpt->rt_stable_epoch, arg->oids,
 				       arg->ephs, arg->shards, arg->count,
-				       /* Clear containers for reint */
+				       /* Delete local objects for reint */
 				       rpt->rt_rebuild_op == RB_OP_REINT);
 		/* If it does not need retry */
 		if (rc == 0 || (rc != -DER_TIMEDOUT && rc != -DER_GRPVER &&


### PR DESCRIPTION
This patch changes the rebuild migration behavior to delete individual
existing objects prior to reintegration, rather than whole containers.

This means that any object that exists on a server prior to that server
being reintegrated will be deleted only if the rebuild migration process
detects that data as existing on another target and attempts to migrate
it.

There are several practical results of this enhancement:
- Containers will no longer be deleted incorrectly on other local
targets when reintegrating just one target (DAOS-6162)
- Objects that have no rendundancy but are still healthy on the
reintegrating node will still be available after reintegration.
- Objects will still be deleted prior to migration, so that VOS will not
be unhappy about migrating the same data on top of itself.

This also eliminates the hash table that tracked what had been deleted -
rebuild already has a btree-based mechanism to ensure each object is
only migrated once.

Signed-off-by: Byron Marohn <byron.marohn@intel.com>