### PR TITLE
DAOS-623 test: Fix % substitutions in repo paths

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -302,7 +302,8 @@ def getuid() {
 // in faster time-to-result for PRs.
 
 String get_priority() {
-    if (env.BRANCH_NAME == 'master') {
+    if (env.BRANCH_NAME == 'master' ||
+        env.BRANCH_NAME.startsWith("release/")) {
         string p = '2'
     } else {
         string p = ''

--- a/ci/provisioning/post_provision_config_nodes.sh
+++ b/ci/provisioning/post_provision_config_nodes.sh
@@ -2,6 +2,53 @@
 
 set -eux
 
+# functions common to more than one distro specific provisioning
+url_to_repo() {
+    local url="$1"
+
+    local repo=${url#*://}
+    repo="${repo//%/}"
+    repo="${repo//\//_}"
+
+    echo "$repo"
+}
+
+add_repo() {
+    local repo="$1"
+    local gpg_check="${2:-true}"
+
+    if [ -n "$repo" ]; then
+        repo="${REPOSITORY_URL}${repo}"
+        if ! dnf repolist | grep "$(url_to_repo "$repo")"; then
+            dnf config-manager --add-repo="${repo}"
+            if ! $gpg_check; then
+                disable_gpg_check "$repo"
+            fi
+        fi
+    fi
+}
+
+disable_gpg_check() {
+    local url="$1"
+
+    repo="$(url_to_repo "$url")"
+    # bug in EL7 DNF: this needs to be enabled before it can be disabled
+    dnf config-manager --save --setopt="$repo".gpgcheck=1
+    dnf config-manager --save --setopt="$repo".gpgcheck=0
+    # but even that seems to be not enough, so just brute-force it
+    if [ -d /etc/yum.repos.d ] &&
+       ! grep gpgcheck /etc/yum.repos.d/"$repo".repo; then
+        echo "gpgcheck=0" >> /etc/yum.repos.d/"$repo".repo
+    fi
+}
+
+dump_repos() {
+        for file in "$REPOS_DIR"/*.repo; do
+            echo "---- $file ----"
+            cat "$file"
+        done
+}
+
 env > /root/last_run-env.txt
 if ! grep ":$MY_UID:" /etc/group; then
   groupadd -g "$MY_UID" jenkins

--- a/ci/provisioning/post_provision_config_nodes_EL_7.sh
+++ b/ci/provisioning/post_provision_config_nodes_EL_7.sh
@@ -1,29 +1,8 @@
 #!/bin/bash
 
-url_to_repo() {
-    local url="$1"
-
-    local repo=${url#*://}
-    repo="${repo//%252F/_}"
-    repo="${repo//\//_}"
-
-    echo "$repo"
-}
-
-add_repo() {
-    local repo="$1"
-    local gpg_check="${2:-true}"
-
-    if [ -n "$repo" ]; then
-        repo="${REPOSITORY_URL}${repo}"
-        if ! dnf repolist | grep "$(url_to_repo "$repo")"; then
-            dnf config-manager --add-repo="${repo}"
-            if ! $gpg_check; then
-                disable_gpg_check "$repo"
-            fi
-        fi
-    fi
-}
+REPOS_DIR=/etc/yum.repos.d
+DISTRO_NAME=centos7
+LSB_RELEASE=redhat-lsb-core
 
 timeout_yum() {
     local timeout="$1"
@@ -48,34 +27,23 @@ timeout_yum() {
     return 1
 }
 
-disable_gpg_check() {
-    local url="$1"
-
-    repo="$(url_to_repo "$repo")"
-    # bug in EL7 DNF: this needs to be enabled before it can be disabled
-    dnf config-manager --save --setopt="$repo".gpgcheck=1
-    dnf config-manager --save --setopt="$repo".gpgcheck=0
-    # but even that seems to be not enough, so just brute-force it
-    if ! grep gpgcheck /etc/yum.repos.d/"$repo".repo; then
-        echo "gpgcheck=0" >> /etc/yum.repos.d/"$repo".repo
-    fi
+bootstrap_dnf() {
+    timeout_yum 5m install dnf 'dnf-command(config-manager)'
 }
 
-dump_repos() {
-        for file in /etc/yum.repos.d/*.repo; do
-            echo "---- $file ----"
-            cat "$file"
-        done
+group_repo_post() {
+    # nothing for EL7
+    :
 }
 
 post_provision_config_nodes() {
-    timeout_yum 5m install dnf 'dnf-command(config-manager)'
+    bootstrap_dnf
 
     # Reserve port ranges 31416-31516 for DAOS and CART servers
     echo 31416-31516 > /proc/sys/net/ipv4/ip_local_reserved_ports
 
     if $CONFIG_POWER_ONLY; then
-        rm -f /etc/yum.repos.d/*.hpdd.intel.com_job_daos-stack_job_*_job_*.repo
+        rm -f $REPOS_DIR/*.hpdd.intel.com_job_daos-stack_job_*_job_*.repo
         dnf -y erase fio fuse ior-hpc mpich-autoload               \
                      ompi argobots cart daos daos-client dpdk      \
                      fuse-libs libisa-l libpmemobj mercury mpich   \
@@ -87,6 +55,7 @@ post_provision_config_nodes() {
     local dnf_repo_args="--disablerepo=*"
 
     add_repo "$DAOS_STACK_GROUP_REPO"
+    group_repo_post
 
     add_repo "${DAOS_STACK_LOCAL_REPO}" false
 
@@ -94,6 +63,7 @@ post_provision_config_nodes() {
     dnf_repo_args+=" --enablerepo=repo.dc.hpdd.intel.com_repository_*"
 
     if [ -n "$INST_REPOS" ]; then
+        local repo
         for repo in $INST_REPOS; do
             branch="master"
             build_number="lastSuccessfulBuild"
@@ -105,9 +75,9 @@ post_provision_config_nodes() {
                     branch="${branch%:*}"
                 fi
             fi
-            local repo="${JENKINS_URL}"job/daos-stack/job/"${repo}"/job/"${branch//\//%252F}"/"${build_number}"/artifact/artifacts/centos7/
-            dnf config-manager --add-repo="${repo}"
-            disable_gpg_check "$repo"
+            local repo_url="${JENKINS_URL}"job/daos-stack/job/"${repo}"/job/"${branch//\//%252F}"/"${build_number}"/artifact/artifacts/$DISTRO_NAME/
+            dnf config-manager --add-repo="${repo_url}"
+            disable_gpg_check "$repo_url"
             # TODO: this should be per repo in the above loop
             if [ -n "$INST_REPOS" ]; then
                 dnf_repo_args+=",build.hpdd.intel.com_job_daos-stack*"
@@ -120,7 +90,7 @@ post_provision_config_nodes() {
     fi
     rm -f /etc/profile.d/openmpi.sh
     rm -f /tmp/daos_control.log
-    dnf -y install redhat-lsb-core
+    dnf -y install $LSB_RELEASE
     # shellcheck disable=SC2086
     if [ -n "$INST_RPMS" ] &&
        ! dnf -y $dnf_repo_args install $INST_RPMS; then
@@ -137,7 +107,7 @@ post_provision_config_nodes() {
         ln -s python3.6 /usr/bin/python3
     fi
     # install the debuginfo repo in case we get segfaults
-    cat <<"EOF" > /etc/yum.repos.d/CentOS-Debuginfo.repo
+    cat <<"EOF" > $REPOS_DIR/CentOS-Debuginfo.repo
 [core-0-debuginfo]
 name=CentOS-7 - Debuginfo
 baseurl=http://debuginfo.centos.org/7/$basearch/

--- a/ci/provisioning/post_provision_config_nodes_LEAP_15.sh
+++ b/ci/provisioning/post_provision_config_nodes_LEAP_15.sh
@@ -1,45 +1,43 @@
 #!/bin/bash
 
-url_to_repo() {
-    local url="$1"
+REPOS_DIR=/etc/dnf.repos.d
+DISTRO_NAME=leap15
+LSB_RELEASE=lsb-release
+EXCLUDE_UPGRADE=fuse,fuse-libs,fuse-devel,mercury,daos,daos-\*
 
-    local repo=${url#*://}
-    repo="${repo//%252F/_}"
-    repo="${repo//\//_}"
-
-    echo "$repo"
+bootstrap_dnf() {
+    time zypper --non-interactive install dnf
 }
 
-add_repo() {
-    local repo="$1"
-    local gpg_check="${2:-true}"
-
-    if [ -n "$repo" ]; then
-        repo="${REPOSITORY_URL}${repo}"
-        if ! dnf repolist | grep "$(url_to_repo "$repo")"; then
-            dnf config-manager --add-repo="${repo}"
-            if ! $gpg_check; then
-                disable_gpg_check "$repo"
-            fi
-        fi
+group_repo_post() {
+    if [ -n "$DAOS_STACK_GROUP_REPO" ]; then
+        rpm --import \
+            "${REPOSITORY_URL}${DAOS_STACK_GROUP_REPO%/*}/opensuse-15.2-devel-languages-go-x86_64-proxy/repodata/repomd.xml.key"
     fi
 }
 
+distro_custom() {
+    # monkey-patch lua-lmod
+    if ! grep MODULEPATH=".*"/usr/share/modules /etc/profile.d/lmod.sh; then \
+        sed -e '/MODULEPATH=/s/$/:\/usr\/share\/modules/'                     \
+               /etc/profile.d/lmod.sh;                                        \
+    fi
 
-disable_gpg_check() {
-    local repo="$1"
+    # force install of avocado 52.1
+    dnf -y erase avocado{,-common} \
+           python2-avocado{,-plugins-{output-html,varianter-yaml-to-mux}}
+    dnf -y install {avocado-common,python2-avocado{,-plugins-{output-html,varianter-yaml-to-mux}}}-52.1
 
-    dnf config-manager --save --setopt="$(url_to_repo "$repo")".gpgcheck=0
 }
 
 post_provision_config_nodes() {
-    time zypper --non-interactive install dnf
+    bootstrap_dnf
 
     # Reserve port ranges 31416-31516 for DAOS and CART servers
     echo 31416-31516 > /proc/sys/net/ipv4/ip_local_reserved_ports
 
     if $CONFIG_POWER_ONLY; then
-        rm -f /etc/dnf.repos.d/*.hpdd.intel.com_job_daos-stack_job_*_job_*.repo
+        rm -f $REPOS_DIR/*.hpdd.intel.com_job_daos-stack_job_*_job_*.repo
         dnf -y erase fio fuse ior-hpc mpich-autoload               \
                      ompi argobots cart daos daos-client dpdk      \
                      fuse-libs libisa-l libpmemobj mercury mpich   \
@@ -51,10 +49,7 @@ post_provision_config_nodes() {
     local dnf_repo_args="--disablerepo=*"
 
     add_repo "$DAOS_STACK_GROUP_REPO"
-    if [ -n "$DAOS_STACK_GROUP_REPO" ]; then
-        rpm --import \
-            "${REPOSITORY_URL}${DAOS_STACK_GROUP_REPO%/*}/opensuse-15.2-devel-languages-go-x86_64-proxy/repodata/repomd.xml.key"
-    fi
+    group_repo_post
 
     add_repo "${DAOS_STACK_LOCAL_REPO}" false
 
@@ -62,6 +57,7 @@ post_provision_config_nodes() {
     dnf_repo_args+=" --enablerepo=repo.dc.hpdd.intel.com_repository_*"
 
     if [ -n "$INST_REPOS" ]; then
+        local repo
         for repo in $INST_REPOS; do
             branch="master"
             build_number="lastSuccessfulBuild"
@@ -73,9 +69,9 @@ post_provision_config_nodes() {
                     branch="${branch%:*}"
                 fi
             fi
-            local repo="${JENKINS_URL}"job/daos-stack/job/"${repo}"/job/"${branch//\//%252F}"/"${build_number}"/artifact/artifacts/leap15/
-            dnf config-manager --add-repo="${repo}"
-            disable_gpg_check "$repo"
+            local repo_url="${JENKINS_URL}"job/daos-stack/job/"${repo}"/job/"${branch//\//%252F}"/"${build_number}"/artifact/artifacts/$DISTRO_NAME/
+            dnf config-manager --add-repo="${repo_url}"
+            disable_gpg_check "$repo_url"
             # TODO: this should be per repo in the above loop
             if [ -n "$INST_REPOS" ]; then
                 dnf_repo_args+=",build.hpdd.intel.com_job_daos-stack*"
@@ -88,32 +84,22 @@ post_provision_config_nodes() {
     fi
     rm -f /etc/profile.d/openmpi.sh
     rm -f /tmp/daos_control.log
-    dnf -y install lsb-release
-
-    # monkey-patch lua-lmod
-    if ! grep MODULEPATH=".*"/usr/share/modules /etc/profile.d/lmod.sh; then \
-        sed -e '/MODULEPATH=/s/$/:\/usr\/share\/modules/'                     \
-               /etc/profile.d/lmod.sh;                                        \
-    fi
-
-    # force install of avocado 52.1
-    dnf -y erase avocado{,-common} python2-avocado{,-plugins-{output-html,varianter-yaml-to-mux}}
-    dnf -y install {avocado-common,python2-avocado{,-plugins-{output-html,varianter-yaml-to-mux}}}-52.1
+    dnf -y install $LSB_RELEASE
 
     # shellcheck disable=SC2086
     if [ -n "$INST_RPMS" ] &&
        ! dnf -y $dnf_repo_args install $INST_RPMS; then
         rc=${PIPESTATUS[0]}
-        for file in /etc/dnf.repos.d/*.repo; do
-            echo "---- $file ----"
-            cat "$file"
-        done
+        dump_repos
         exit "$rc"
     fi
 
+    distro_custom
+
     # now make sure everything is fully up-to-date
     if ! time dnf -y upgrade \
-                  --exclude fuse,fuse-libs,fuse-devel,mercury,daos,daos-\*; then
+                  --exclude "$EXCLUDE_UPGRADE"; then
+        dump_repos
         exit 1
     fi
 


### PR DESCRIPTION
DNF seems to have changed how it substitutes % encodings in URLs into
repository path names.

DRY out some common code across EL7 and LEAP15's use of DNF to provision
nodes.