### PR TITLE
DAOS-6876 test: Fix aggregation test issue

### DIFF
--- a/src/tests/ftest/util/ior_test_base.py
+++ b/src/tests/ftest/util/ior_test_base.py
@@ -65,7 +65,7 @@ class IorTestBase(DfuseTestBase):
         # Create a pool
         self.pool.create()
 
-    def create_cont(self, oclass):
+    def create_cont(self, oclass="SX"):
         """Create a TestContainer object to be used to create container.
 
         Args:


### PR DESCRIPTION
DAOS-6876 test: Fix aggregation test script issue
Update: ior_test_base.py with default object_class
Skip-unit-tests: true
Skip-nlt: true
Test-tag: dfusespacecheck
Signed-off-by: Ding Ho <ding-hwa.ho@intel.com>