### PR TITLE
DAOS-6878 test: Fix control daos_snapshot script issue

### DIFF
--- a/src/tests/ftest/util/daos_utils.py
+++ b/src/tests/ftest/util/daos_utils.py
@@ -545,7 +545,7 @@ class DaosCommand(DaosCommandBase):
         # Container's snapshots :
         # 1598478249040609297 1598478258840600594 1598478287952543761
         data = {}
-        match = re.findall(r"(\d{19})", self.result.stdout)
+        match = re.findall(r"(\d+)", self.result.stdout)
         if match:
             data["epochs"] = match
         return data


### PR DESCRIPTION
DAOS-6878 test: Fix control daos_snapshot script issue
Update: daos_utils.py
Skip-unit-tests: true
Skip-nlt: true
Test-tag: daos_snapshot
Signed-off-by: Ding Ho <ding-hwa.ho@intel.com>