### PR TITLE
DAOS-6759 java: Update Hadoop from v 2.6.7 to 3.1.3

### DIFF
--- a/src/client/java/daos-java/pom.xml
+++ b/src/client/java/daos-java/pom.xml
@@ -16,7 +16,7 @@
 
   <properties>
     <native.build.path>${project.basedir}/build</native.build.path>
-    <daos.install.path>/usr/local/daos</daos.install.path>
+    <daos.install.path>${project.basedir}/install</daos.install.path>
     <compile.proto>false</compile.proto>
   </properties>
 

--- a/src/client/java/daos-java/src/main/java/io/daos/dfs/DaosFsClient.java
+++ b/src/client/java/daos-java/src/main/java/io/daos/dfs/DaosFsClient.java
@@ -299,7 +299,12 @@ public final class DaosFsClient extends ShareableClient implements ForceCloseabl
    * {@link DaosIOException}
    */
   public void move(String srcPath, String destPath) throws IOException {
-    move(dfsPtr, DaosUtils.normalize(srcPath), DaosUtils.normalize(destPath));
+    String src = DaosUtils.normalize(srcPath);
+    String dest = DaosUtils.normalize(destPath);
+    if (dest.length() > src.length() && dest.startsWith(src + '/')) {
+      throw new IOException("cannot move to subdirectory of itself. " + src + " to " + dest);
+    }
+    move(dfsPtr, src, dest);
   }
 
   /**

--- a/src/client/java/hadoop-daos/pom.xml
+++ b/src/client/java/hadoop-daos/pom.xml
@@ -15,9 +15,9 @@
   <packaging>jar</packaging>
 
   <properties>
-    <hadoop.version>2.7.6</hadoop.version>
+    <hadoop.version>3.1.3</hadoop.version>
     <native.build.path>${project.basedir}/build</native.build.path>
-    <daos.install.path>/usr/local/daos</daos.install.path>
+    <daos.install.path>${project.basedir}/install</daos.install.path>
   </properties>
 
   <dependencies>

--- a/src/client/java/hadoop-daos/src/main/java/io/daos/fs/hadoop/DaosConfigFile.java
+++ b/src/client/java/hadoop-daos/src/main/java/io/daos/fs/hadoop/DaosConfigFile.java
@@ -17,7 +17,7 @@ import java.util.Set;
 
 import javax.xml.parsers.DocumentBuilderFactory;
 
-import org.apache.commons.configuration.ConfigurationException;
+import org.apache.commons.configuration2.ex.ConfigurationException;
 import org.apache.commons.lang.StringUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.slf4j.Logger;

--- a/src/client/java/hadoop-daos/src/test/java/io/daos/fs/hadoop/DaosFileSystemContractIT.java
+++ b/src/client/java/hadoop-daos/src/test/java/io/daos/fs/hadoop/DaosFileSystemContractIT.java
@@ -11,24 +11,22 @@ import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystemContractBaseTest;
 import org.apache.hadoop.fs.Path;
 import org.junit.Test;
+import org.junit.Before;
 
 import java.io.IOException;
 
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assume.assumeTrue;
 
 public class DaosFileSystemContractIT extends FileSystemContractBaseTest {
 
   private static final Log LOG = LogFactory.getLog(DaosFileSystemContractIT.class);
 
-  @Override
-  protected void setUp() throws Exception {
+  public DaosFileSystemContractIT() throws IOException {
     fs = DaosFSFactory.getFS();
     fs.mkdirs(new Path("/test"));
-  }
-
-  @Override
-  protected void tearDown() throws Exception {
-    super.tearDown();
   }
 
   @Override
@@ -74,8 +72,7 @@ public class DaosFileSystemContractIT extends FileSystemContractBaseTest {
     assertTrue("Parent should exist", this.fs.exists(parentDir));
   }
 
-  @Test
-  protected boolean renameSupported() {
+  public boolean renameSupported() {
     return true;
   }
 
@@ -101,6 +98,13 @@ public class DaosFileSystemContractIT extends FileSystemContractBaseTest {
     assertFalse(fs.exists(src));
   }
 
+  @Test
+  public void testRenameFailed() throws Exception {
+    Path parentdir = path("testRenameChildDirForbidden");
+    fs.mkdirs(parentdir);
+    Path childdir = new Path(parentdir, "childdir");
+    fs.rename(parentdir, childdir);
+  }
 
   @Test
   public void testGetFileStatusFileAndDirectory() throws Exception {
@@ -130,6 +134,7 @@ public class DaosFileSystemContractIT extends FileSystemContractBaseTest {
     }
   }
 
+  @Test
   public void testRenameDirectoryMoveToExistingDirectory() throws Exception {
     if (!renameSupported()) return;
 
@@ -234,6 +239,7 @@ public class DaosFileSystemContractIT extends FileSystemContractBaseTest {
     assertEquals(0, paths.length);
   }
 
+  @Test
   public void testRenameDirMoveToDescentdantDir() throws Exception {
     if (!renameSupported()) return;
 
@@ -247,6 +253,7 @@ public class DaosFileSystemContractIT extends FileSystemContractBaseTest {
         fs.exists(path("/test/hadoop/dir/subdir/dir")));
   }
 
+  @Test
   public void testRenameDirMoveToItSelf() throws Exception {
     if (!renameSupported()) return;
 
@@ -259,6 +266,7 @@ public class DaosFileSystemContractIT extends FileSystemContractBaseTest {
         fs.exists(path("/test/hadoop/dir")));
   }
 
+  @Test
   public void testRenameFileToItSelf() throws Exception {
     if (!renameSupported()) return;
 

--- a/src/client/java/hadoop-daos/src/test/java/io/daos/fs/hadoop/DaosFileSystemTest.java
+++ b/src/client/java/hadoop-daos/src/test/java/io/daos/fs/hadoop/DaosFileSystemTest.java
@@ -84,7 +84,7 @@ public class DaosFileSystemTest {
       eie = e;
     }
     Assert.assertNotNull(eie);
-    Assert.assertTrue(eie.getMessage().contains("No FileSystem for scheme: daosss"));
+    Assert.assertTrue(eie.getMessage().contains("No FileSystem for scheme \"daosss\""));
   }
 
   @Test

--- a/src/client/java/hadoop-daos/src/test/java/io/daos/fs/hadoop/contract/DaosContractCreateIT.java
+++ b/src/client/java/hadoop-daos/src/test/java/io/daos/fs/hadoop/contract/DaosContractCreateIT.java
@@ -7,8 +7,20 @@ package io.daos.fs.hadoop.contract;
 import io.daos.fs.hadoop.Constants;
 import io.daos.fs.hadoop.DaosFSFactory;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileAlreadyExistsException;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.contract.AbstractContractCreateTest;
 import org.apache.hadoop.fs.contract.AbstractFSContract;
+import org.apache.hadoop.fs.contract.ContractTestUtils;
+import org.junit.Test;
+import org.junit.internal.AssumptionViolatedException;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+
+import static org.apache.hadoop.fs.contract.ContractTestUtils.*;
+import static org.apache.hadoop.fs.contract.ContractTestUtils.skip;
 
 public class DaosContractCreateIT extends AbstractContractCreateTest {
   @Override
@@ -18,5 +30,128 @@ public class DaosContractCreateIT extends AbstractContractCreateTest {
     configuration.set(Constants.DAOS_CONTAINER_UUID, DaosFSFactory.contuuid);
     configuration.set(Constants.DAOS_POOL_SVC, DaosFSFactory.svc);
     return new DaosContractIT(configuration);
+  }
+
+  @Override
+  public void testOverwriteNonEmptyDirectory() throws Throwable {
+    describe("verify trying to create a file over an empty dir fails, " +
+        "use builder API=" + false);
+    Path path = path("testOverwriteEmptyDirectory");
+    mkdirs(path);
+    assertIsDirectory(path);
+    byte[] data = dataset(256, 'a', 'z');
+    try {
+      writeDataset(getFileSystem(), path, data, data.length, 1024, true,
+          false);
+      assertIsDirectory(path);
+      fail("write of file over empty dir succeeded");
+    } catch (FileAlreadyExistsException expected) {
+      //expected
+      handleExpectedException(expected);
+    } catch (FileNotFoundException e) {
+      handleRelaxedException("overwriting a dir with a file ",
+          "FileAlreadyExistsException",
+          e);
+    } catch (IOException e) {
+      handleRelaxedException("overwriting a dir with a file ",
+          "FileAlreadyExistsException",
+          e);
+    }
+    assertIsDirectory(path);
+  }
+
+  @Override
+  public void testOverwriteEmptyDirectory() throws Throwable {
+    describe("verify trying to create a file over a non-empty dir fails, " +
+        "use builder API=" + false);
+    Path path = path("testOverwriteNonEmptyDirectory");
+    mkdirs(path);
+    try {
+      assertIsDirectory(path);
+    } catch (AssertionError failure) {
+      if (isSupported(CREATE_OVERWRITES_DIRECTORY)) {
+        // file/directory hack surfaces here
+        throw new AssumptionViolatedException(failure.toString(), failure);
+      }
+      // else: rethrow
+      throw failure;
+    }
+    Path child = new Path(path, "child");
+    writeTextFile(getFileSystem(), child, "child file", true);
+    byte[] data = dataset(256, 'a', 'z');
+    try {
+      writeDataset(getFileSystem(), path, data, data.length, 1024,
+          true, false);
+      FileStatus status = getFileSystem().getFileStatus(path);
+
+      boolean isDir = status.isDirectory();
+      if (!isDir && isSupported(CREATE_OVERWRITES_DIRECTORY)) {
+        // For some file systems, downgrade to a skip so that the failure is
+        // visible in test results.
+        skip("This Filesystem allows a file to overwrite a directory");
+      }
+      fail("write of file over dir succeeded");
+    } catch (FileAlreadyExistsException expected) {
+      //expected
+      handleExpectedException(expected);
+    } catch (FileNotFoundException e) {
+      handleRelaxedException("overwriting a dir with a file ",
+          "FileAlreadyExistsException",
+          e);
+    } catch (IOException e) {
+      handleRelaxedException("overwriting a dir with a file ",
+          "FileAlreadyExistsException",
+          e);
+    }
+    assertIsDirectory(path);
+    assertIsFile(child);
+  }
+
+  @Override
+  public void testCreateFileOverExistingFileNoOverwrite() throws Throwable {
+    describe("Verify overwriting an existing file fails, using builder API=" +
+        false);
+    Path path = path("testCreateFileOverExistingFileNoOverwrite", false);
+    byte[] data = dataset(256, 'a', 'z');
+    writeDataset(getFileSystem(), path, data, data.length, 1024, false);
+    byte[] data2 = dataset(10 * 1024, 'A', 'Z');
+    try {
+      writeDataset(getFileSystem(), path, data2, data2.length, 1024, false,
+          false);
+      fail("writing without overwrite unexpectedly succeeded");
+    } catch (FileAlreadyExistsException expected) {
+      //expected
+      handleExpectedException(expected);
+    } catch (IOException relaxed) {
+      handleRelaxedException("Creating a file over a file with overwrite==false",
+          "FileAlreadyExistsException",
+          relaxed);
+    }
+  }
+
+  @Override
+  public void testOverwriteExistingFile() throws Throwable {
+    describe("Overwrite an existing file and verify the new data is there, " +
+        "use builder API=" + false);
+    Path path = path("testOverwriteExistingFile", false);
+    byte[] data = dataset(256, 'a', 'z');
+    writeDataset(getFileSystem(), path, data, data.length, 1024, false,
+        false);
+    ContractTestUtils.verifyFileContents(getFileSystem(), path, data);
+    byte[] data2 = dataset(10 * 1024, 'A', 'Z');
+    writeDataset(getFileSystem(), path, data2, data2.length, 1024, true,
+        false);
+    ContractTestUtils.verifyFileContents(getFileSystem(), path, data2);
+  }
+
+  @Test
+  public void testCreateNewFile() throws Throwable {
+    describe("Foundational 'create a file' test, using builder API=" +
+        false);
+    Path path = path("testCreateNewFile", false);
+    byte[] data = dataset(256, 'a', 'z');
+    writeDataset(getFileSystem(), path, data, data.length, 1024 * 1024, false,
+        false);
+    ContractTestUtils.verifyFileContents(getFileSystem(), path, data);
   }
 }


### PR DESCRIPTION
Code scanning tools identified the need to upgrade hadoop to eliminate dependency on packages with known vulnerabilities.

Signed-off-by: David Quigley <david.quigley@intel.com>