### PR TITLE
CART-89 ofi: Compile ofi without gdrapi linkage

### DIFF
--- a/utils/sl/components/__init__.py
+++ b/utils/sl/components/__init__.py
@@ -132,6 +132,7 @@ def define_mercury(reqs):
                 commands=['./autogen.sh',
                           './configure --prefix=$OFI_PREFIX ' +
                           '--disable-efa ' +
+                          '--with-gdrcopy=no ' +
                           OFI_DEBUG +
                           exclude(reqs, 'psm2',
                                   '--enable-psm2' +

--- a/utils/sl/components/__init__.py
+++ b/utils/sl/components/__init__.py
@@ -133,7 +133,7 @@ def define_mercury(reqs):
                 commands=['./autogen.sh',
                           './configure --prefix=$OFI_PREFIX ' +
                           '--disable-efa ' +
-                          '--with-gdrcopy=no ' +
+                          '--without-gdrcopy ' +
                           OFI_DEBUG +
                           exclude(reqs, 'psm2',
                                   '--enable-psm2' +

--- a/utils/sl/components/__init__.py
+++ b/utils/sl/components/__init__.py
@@ -126,6 +126,7 @@ def define_mercury(reqs):
         OFI_DEBUG = '--enable-debug '
     else:
         OFI_DEBUG = '--disable-debug '
+
     retriever = GitRepoRetriever('https://github.com/ofiwg/libfabric')
     reqs.define('ofi',
                 retriever=retriever,


### PR DESCRIPTION
- Compile ofi with --with-gdrcopy=no to disable gdrapi linkage

Signed-off-by: Alexander Oganezov <alexander.a.oganezov@intel.com>