### PR TITLE
DAOS-6783 control: return non-zero on dmg system action result error

### DIFF
--- a/src/control/cmd/dmg/system.go
+++ b/src/control/cmd/dmg/system.go
@@ -286,14 +286,20 @@ func displaySystemAction(log logging.Logger, results system.MemberResults,
 	}
 
 	if absentHosts.Count() > 0 {
-		out += fmt.Sprintf("\nUnknown %s: %s",
+		log.Infof("%s\nUnknown %s: %s", out,
 			english.Plural(absentHosts.Count(), "host", "hosts"),
 			absentHosts.String())
 	} else {
-		out += "\n"
+		log.Infof("%s\n", out)
 	}
 
-	log.Info(out)
+	if absentRanks.Count() > 0 || absentHosts.Count() > 0 {
+		return errors.New("non-existent ranks or hosts in cmd request")
+	}
+
+	if results.HasErrors() {
+		return errors.New("cmd results contain errors")
+	}
 
 	return nil
 }


### PR DESCRIPTION
Return a non-zero exit code from dmg if unrecognised hosts or ranks are
specified on the commandline or any host operations were unsuccessful.

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>