### PR TITLE
DAOS-6731 sdl: Fix coverity defect in CaRT IV server test

### DIFF
--- a/src/tests/ftest/cart/iv_server.c
+++ b/src/tests/ftest/cart/iv_server.c
@@ -863,6 +863,7 @@ fetch_done(crt_iv_namespace_t ivns, uint32_t class_id,
 		if (keys_equal(iv_key, &entry->key) == true) {
 			rc = crt_bulk_create(g_main_ctx, &entry->value,
 					     perms, &bulk_hdl);
+			assert(rc == 0);
 			found = true;
 			break;
 		}


### PR DESCRIPTION
Fixes unused value defect in cart iv server functional test.

Signed-off-by: Sydney Vanda <sydney.m.vanda@intel.com>