### PR TITLE
DAOS-6808 rpc: Fix cleanuping resources

### DIFF
--- a/src/cart/crt_hg.c
+++ b/src/cart/crt_hg.c
@@ -713,8 +713,7 @@ crt_rpc_handler_common(hg_handle_t hg_hdl)
 		D_GOTO(out, hg_ret = HG_PROTOCOL_ERROR);
 	}
 
-	crt_ctx = (struct crt_context *)HG_Context_get_data(
-			hg_info->context);
+	crt_ctx = HG_Context_get_data(hg_info->context);
 	if (crt_ctx == NULL) {
 		D_ERROR("HG_Context_get_data failed.\n");
 		D_GOTO(out, hg_ret = HG_PROTOCOL_ERROR);
@@ -755,7 +754,6 @@ crt_rpc_handler_common(hg_handle_t hg_hdl)
 		 */
 		crt_hg_reply_error_send(&rpc_tmp, -DER_UNREG);
 		crt_hg_unpack_cleanup(proc);
-
 		HG_Destroy(rpc_tmp.crp_hg_hdl);
 		D_GOTO(out, hg_ret = HG_SUCCESS);
 	}
@@ -790,8 +788,10 @@ crt_rpc_handler_common(hg_handle_t hg_hdl)
 	rc = crt_rpc_priv_init(rpc_priv, crt_ctx, true /* srv_flag */);
 	if (rc != 0) {
 		D_ERROR("crt_rpc_priv_init rc=%d, opc=%#x\n", rc, opc);
-		crt_hg_reply_error_send(rpc_priv, -DER_MISC);
+		crt_hg_reply_error_send(&rpc_tmp, -DER_MISC);
+		crt_hg_unpack_cleanup(proc);
 		HG_Destroy(rpc_tmp.crp_hg_hdl);
+		D_FREE(rpc_priv);
 		D_GOTO(out, hg_ret = HG_SUCCESS);
 	}
 
@@ -836,14 +836,11 @@ crt_rpc_handler_common(hg_handle_t hg_hdl)
 			  "failed to invoke RPC handler, rc: %d, opc: %#x\n",
 			  rc, opc);
 		crt_hg_reply_error_send(rpc_priv, rc);
+		D_GOTO(decref, hg_ret = HG_SUCCESS);
 	}
 
 decref:
-	/* If rpc call back is customized, then it might be handled
-	 * asynchronously, Let's hold the RPC, and the real handler
-	 * (crt_handle_rpc())will release it
-	 */
-	if (rc != 0 || !crt_rpc_cb_customized(crt_ctx, &rpc_priv->crp_pub))
+	if (rc != 0)
 		RPC_DECREF(rpc_priv);
 out:
 	return hg_ret;

--- a/src/cart/crt_iv.c
+++ b/src/cart/crt_iv.c
@@ -2686,7 +2686,6 @@ handle_response_internal(void *arg)
 	crt_rpc_t		 *rpc = cb_info->cci_rpc;
 	void			 *cb_arg = cb_info->cci_arg;
 
-
 	switch (rpc->cr_opc) {
 	case CRT_OPC_IV_FETCH:
 		handle_ivfetch_response(cb_info);
@@ -2867,16 +2866,15 @@ bulk_update_transfer_done_aux(const struct crt_bulk_cb_info *info)
 			D_GOTO(exit, rc);
 		}
 
-		rc = iv_ops->ivo_on_put(ivns_internal,
-					&cb_info->buc_iv_value,
-					cb_info->buc_user_priv);
-		output->rc = rc;
-		crt_reply_send(info->bci_bulk_desc->bd_rpc);
+		output->rc = iv_ops->ivo_on_put(ivns_internal,
+						&cb_info->buc_iv_value,
+						cb_info->buc_user_priv);
 
+		crt_reply_send(info->bci_bulk_desc->bd_rpc);
 		RPC_PUB_DECREF(info->bci_bulk_desc->bd_rpc);
+
 		IVNS_DECREF(update_cb_info->uci_ivns_internal);
 		D_FREE(update_cb_info);
-
 	} else {
 		D_GOTO(send_error, rc = update_rc);
 	}
@@ -2890,16 +2888,16 @@ send_error:
 			   cb_info->buc_user_priv);
 
 	rc = crt_bulk_free(cb_info->buc_bulk_hdl);
+	output->rc = rc;
+
+	crt_reply_send(info->bci_bulk_desc->bd_rpc);
+	RPC_PUB_DECREF(info->bci_bulk_desc->bd_rpc);
 
 	if (update_cb_info) {
 		IVNS_DECREF(update_cb_info->uci_ivns_internal);
 		D_FREE(update_cb_info);
 	}
 
-	output->rc = rc;
-
-	crt_reply_send(info->bci_bulk_desc->bd_rpc);
-	RPC_PUB_DECREF(info->bci_bulk_desc->bd_rpc);
 	return rc;
 }
 
@@ -3294,6 +3292,7 @@ crt_iv_update_internal(crt_iv_namespace_t ivns, uint32_t class_id,
 		if (sync_type.ivs_flags & CRT_IV_SYNC_BIDIRECTIONAL) {
 			rc = update_comp_cb(ivns_internal, class_id, iv_key,
 					    NULL, iv_value, rc, cb_arg);
+			D_ASSERT(sync_type.ivs_comp_cb == NULL);
 		} else {
 			/* issue sync. will call completion callback */
 			rc = crt_ivsync_rpc_issue(ivns_internal, class_id,

--- a/src/cart/crt_rpc.c
+++ b/src/cart/crt_rpc.c
@@ -1689,6 +1689,12 @@ crt_rpc_common_hdlr(struct crt_rpc_priv *rpc_priv)
 					crt_ctx->cc_rpc_cb_arg);
 	} else {
 		rpc_priv->crp_opc_info->coi_rpc_cb(&rpc_priv->crp_pub);
+		/*
+		 * Correspond to crt_rpc_handler_common -> crt_rpc_priv_init's
+		 * set refcount as 1.
+		 */
+		if (rpc_priv->crp_srv)
+			RPC_DECREF(rpc_priv);
 	}
 
 out:

--- a/src/cart/crt_rpc.h
+++ b/src/cart/crt_rpc.h
@@ -591,8 +591,8 @@ CRT_RPC_DECLARE(crt_ctl_log_add_msg, CRT_ISEQ_CTL_LOG_ADD_MSG,
 		D_ASSERTF((RPC)->crp_refcount != 0,			\
 			  "%p decref from zero\n", (RPC));		\
 		__ref = --(RPC)->crp_refcount;				\
-		RPC_TRACE(DB_NET, RPC, "decref to %d.\n", __ref);	\
 		D_SPIN_UNLOCK(&(RPC)->crp_lock);			\
+		RPC_TRACE(DB_NET, RPC, "decref to %d.\n", __ref);	\
 		if (__ref == 0)						\
 			crt_req_destroy(RPC);				\
 	} while (0)

--- a/src/cart/crt_swim.c
+++ b/src/cart/crt_swim.c
@@ -297,7 +297,7 @@ static int crt_swim_send_message(struct swim_context *ctx, swim_id_t to,
 	struct crt_swim_membs	*csm = &grp_priv->gp_membs_swim;
 	struct crt_rpc_swim_in	*rpc_swim_input;
 	crt_context_t		 crt_ctx;
-	crt_rpc_t		*rpc_req;
+	crt_rpc_t		*rpc_req = NULL;
 	crt_endpoint_t		 ep;
 	crt_opcode_t		 opc;
 	swim_id_t		 self_id = swim_self_get(ctx);
@@ -342,7 +342,6 @@ static int crt_swim_send_message(struct swim_context *ctx, swim_id_t to,
 			D_TRACE_ERROR(rpc_req,
 				      "crt_req_set_timeout() failed "
 				      DF_RC"\n", DP_RC(rc));
-			crt_req_decref(rpc_req);
 			D_GOTO(out, rc);
 		}
 	}
@@ -356,13 +355,11 @@ static int crt_swim_send_message(struct swim_context *ctx, swim_id_t to,
 		      "sending opc %#x with %zu updates %lu => %lu\n",
 		      opc, nupds, self_id, to);
 
-	rc = crt_req_send(rpc_req, crt_swim_cli_cb, ctx);
-	if (rc) {
-		D_TRACE_ERROR(rpc_req, "crt_req_send() failed "DF_RC"\n",
-			      DP_RC(rc));
-		D_GOTO(out, rc);
-	}
+	return crt_req_send(rpc_req, crt_swim_cli_cb, ctx);
+
 out:
+	if (rc && rpc_req != NULL)
+		crt_req_decref(rpc_req);
 	return rc;
 }
 

--- a/src/container/cli.c
+++ b/src/container/cli.c
@@ -2211,13 +2211,8 @@ dc_cont_list_attr(tse_task_t *task)
 	}
 
 	crt_req_addref(cb_args.cra_rpc);
-	rc = daos_rpc_send(cb_args.cra_rpc, task);
-	if (rc != 0) {
-		cont_req_cleanup(CLEANUP_ALL, &cb_args);
-		D_GOTO(out, rc);
-	}
+	return daos_rpc_send(cb_args.cra_rpc, task);
 
-	return rc;
 out:
 	tse_task_complete(task, rc);
 	D_DEBUG(DF_DSMC, "Failed to list container attributes: "DF_RC"\n",
@@ -2369,13 +2364,8 @@ dc_cont_get_attr(tse_task_t *task)
 	}
 
 	crt_req_addref(cb_args.cra_rpc);
-	rc = daos_rpc_send(cb_args.cra_rpc, task);
-	if (rc != 0) {
-		cont_req_cleanup(CLEANUP_ALL, &cb_args);
-		D_GOTO(out, rc);
-	}
+	return daos_rpc_send(cb_args.cra_rpc, task);
 
-	return rc;
 out:
 	tse_task_complete(task, rc);
 	D_DEBUG(DF_DSMC, "Failed to get container attributes: "DF_RC"\n",
@@ -2428,13 +2418,8 @@ dc_cont_set_attr(tse_task_t *task)
 	}
 
 	crt_req_addref(cb_args.cra_rpc);
-	rc = daos_rpc_send(cb_args.cra_rpc, task);
-	if (rc != 0) {
-		cont_req_cleanup(CLEANUP_ALL, &cb_args);
-		D_GOTO(out, rc);
-	}
+	return daos_rpc_send(cb_args.cra_rpc, task);
 
-	return rc;
 out:
 	tse_task_complete(task, rc);
 	D_DEBUG(DF_DSMC, "Failed to set container attributes: "DF_RC"\n",
@@ -2471,23 +2456,22 @@ dc_cont_del_attr(tse_task_t *task)
 	in->cadi_count = args->n;
 	rc = attr_bulk_create(args->n, (char **)args->names, NULL, NULL,
 			      daos_task2ctx(task), CRT_BULK_RO, &in->cadi_bulk);
-	if (rc != 0)
-		D_GOTO(cleanup, rc);
+	if (rc != 0) {
+		cont_req_cleanup(CLEANUP_RPC, &cb_args);
+		D_GOTO(out, rc);
+	}
 
 	cb_args.cra_bulk = in->cadi_bulk;
 	rc = tse_task_register_comp_cb(task, cont_req_complete,
 				       &cb_args, sizeof(cb_args));
-	if (rc != 0)
-		D_GOTO(cleanup, rc);
+	if (rc != 0) {
+		cont_req_cleanup(CLEANUP_BULK, &cb_args);
+		D_GOTO(out, rc);
+	}
 
 	crt_req_addref(cb_args.cra_rpc);
-	rc = daos_rpc_send(cb_args.cra_rpc, task);
-	if (rc != 0)
-		D_GOTO(cleanup, rc);
+	return daos_rpc_send(cb_args.cra_rpc, task);
 
-	return rc;
-cleanup:
-	cont_req_cleanup(CLEANUP_BULK, &cb_args);
 out:
 	tse_task_complete(task, rc);
 	D_DEBUG(DF_DSMC, "Failed to del container attributes: "DF_RC"\n",
@@ -2553,17 +2537,13 @@ dc_epoch_op(daos_handle_t coh, crt_opcode_t opc, daos_epoch_t *epoch,
 	rc = tse_task_register_comp_cb(task, cont_epoch_op_req_complete,
 				       &arg, sizeof(arg));
 	if (rc != 0) {
-		cont_req_cleanup(CLEANUP_ALL, &arg.eoa_req);
+		cont_req_cleanup(CLEANUP_RPC, &arg.eoa_req);
 		goto out;
 	}
 
 	crt_req_addref(arg.eoa_req.cra_rpc);
-	rc = daos_rpc_send(arg.eoa_req.cra_rpc, task);
-	if (rc != 0) {
-		cont_req_cleanup(CLEANUP_ALL, &arg.eoa_req);
-		goto out;
-	}
-	return rc;
+	return daos_rpc_send(arg.eoa_req.cra_rpc, task);
+
 out:
 	tse_task_complete(task, rc);
 	D_DEBUG(DF_DSMC, "epoch op %u("DF_U64") failed: %d\n", opc, *epoch, rc);
@@ -2730,13 +2710,8 @@ dc_cont_list_snap(tse_task_t *task)
 	}
 
 	crt_req_addref(cb_args.cra_rpc);
-	rc = daos_rpc_send(cb_args.cra_rpc, task);
-	if (rc != 0) {
-		cont_req_cleanup(CLEANUP_ALL, &cb_args);
-		D_GOTO(out, rc);
-	}
+	return daos_rpc_send(cb_args.cra_rpc, task);
 
-	return rc;
 out:
 	tse_task_complete(task, rc);
 	D_DEBUG(DF_DSMC, "Failed to list container snapshots: "DF_RC"\n",

--- a/src/dtx/dtx_rpc.c
+++ b/src/dtx/dtx_rpc.c
@@ -226,8 +226,6 @@ dtx_req_send(struct dtx_req_rec *drr, daos_epoch_t epoch)
 		din->di_dtx_array.ca_arrays = drr->drr_dti;
 
 		rc = crt_req_send(req, dtx_req_cb, drr);
-		if (rc != 0)
-			crt_req_decref(req);
 	}
 
 	D_DEBUG(DB_TRACE, "DTX req for opc %x to %d/%d (req %p future %p) sent "

--- a/src/include/cart/api.h
+++ b/src/include/cart/api.h
@@ -725,8 +725,11 @@ crt_ep_abort(crt_endpoint_t *ep);
 		/* process the elements of array */			\
 		for (i = 0; i < count; i++) {				\
 			rc = CRT_GEN_GET_FUNC(seq)(proc, &e_ptr[i]);	\
-			if (rc)						\
+			if (rc) {					\
+				if (proc_op == CRT_PROC_DECODE)		\
+					D_FREE(e_ptr);			\
 				D_GOTO(out, rc);			\
+			}						\
 		}							\
 		if (proc_op == CRT_PROC_FREE)				\
 			D_FREE(e_ptr);					\

--- a/src/mgmt/cli_debug.c
+++ b/src/mgmt/cli_debug.c
@@ -76,10 +76,10 @@ dc_debug_set_params(tse_task_t *task)
 	D_DEBUG(DB_MGMT, "set parameter %d/%u/"DF_U64"\n", args->rank,
 		args->key_id, args->value);
 
-	/** send the request */
 	return daos_rpc_send(rpc, task);
 
 err_rpc:
+	crt_req_decref(rpc);
 	crt_req_decref(rpc);
 err_grp:
 	dc_mgmt_sys_detach(cp_arg.sys);

--- a/src/mgmt/cli_query.c
+++ b/src/mgmt/cli_query.c
@@ -71,7 +71,6 @@ dc_mgmt_get_bs_state(tse_task_t *task)
 	struct mgmt_get_bs_state_arg	 cb_args;
 	int				 rc;
 
-
 	args = dc_task_get_args(task);
 
 	rc = dc_mgmt_sys_attach(args->grp, &cb_args.sys);
@@ -112,7 +111,6 @@ dc_mgmt_get_bs_state(tse_task_t *task)
 	D_DEBUG(DB_MGMT, "getting internal blobstore state in DAOS system:%s\n",
 		args->grp);
 
-	/** send the request */
 	return daos_rpc_send(rpc_req, task);
 
 out_put_req:

--- a/src/mgmt/srv.c
+++ b/src/mgmt/srv.c
@@ -267,8 +267,8 @@ ds_mgmt_profile_hdlr(crt_rpc_t *rpc)
 		D_GOTO(out, rc);
 	}
 out:
-	out = crt_reply_get(rpc);
 	D_DEBUG(DB_MGMT, "profile hdlr: rc "DF_RC"\n", DP_RC(rc));
+	out = crt_reply_get(rpc);
 	out->p_rc = rc;
 	crt_reply_send(rpc);
 }
@@ -315,8 +315,8 @@ ds_mgmt_mark_hdlr(crt_rpc_t *rpc)
 		D_GOTO(out, rc);
 	}
 out:
-	out = crt_reply_get(rpc);
 	D_DEBUG(DB_MGMT, "mark hdlr: rc "DF_RC"\n", DP_RC(rc));
+	out = crt_reply_get(rpc);
 	out->m_rc = rc;
 	crt_reply_send(rpc);
 }

--- a/src/object/cli_shard.c
+++ b/src/object/cli_shard.c
@@ -622,12 +622,7 @@ dc_shard_csum_report(tse_task_t *task, crt_rpc_t *rpc)
 	csum_orw->orw_bulks.ca_arrays = NULL;
 	crt_req_addref(csum_rpc);
 	crt_req_addref(rpc);
-	rc = crt_req_send(csum_rpc, csum_report_cb, rpc);
-	if (rc != 0)
-		D_ERROR("Fail to send csum report, rpc %p, "DF_RC"\n",
-			rpc, DP_RC(rc));
-
-	return rc;
+	return crt_req_send(csum_rpc, csum_report_cb, rpc);
 }
 
 static int
@@ -1126,16 +1121,10 @@ dc_obj_shard_rw(struct dc_obj_shard *shard, enum obj_rpc_opc opc,
 	if (rc != 0)
 		D_GOTO(out_args, rc);
 
-	if (daos_io_bypass & IOBP_CLI_RPC) {
+	if (daos_io_bypass & IOBP_CLI_RPC)
 		rc = daos_rpc_complete(req, task);
-	} else {
+	else
 		rc = daos_rpc_send(req, task);
-		if (rc != 0) {
-			D_ERROR("update/fetch rpc failed rc "DF_RC"\n",
-				DP_RC(rc));
-			D_GOTO(out_args, rc);
-		}
-	}
 	return rc;
 
 out_args:
@@ -1243,15 +1232,11 @@ dc_obj_shard_punch(struct dc_obj_shard *shard, enum obj_rpc_opc opc,
 	opi->opi_dti_cos.ca_arrays = NULL;
 
 	rc = daos_rpc_send(req, task);
-	if (rc != 0) {
-		D_ERROR("punch rpc failed rc "DF_RC"\n", DP_RC(rc));
-		D_GOTO(out_req, rc);
-	}
-
 	dc_pool_put(pool);
-	return 0;
+	return rc;
 
 out_req:
+	crt_req_decref(req);
 	crt_req_decref(req);
 out:
 	if (pool != NULL)
@@ -1739,13 +1724,7 @@ dc_obj_shard_list(struct dc_obj_shard *obj_shard, enum obj_rpc_opc opc,
 		D_GOTO(out_eaa, rc);
 	cb_registered = true;
 
-	rc = daos_rpc_send(req, task);
-	if (rc != 0) {
-		D_ERROR("enumerate rpc failed rc "DF_RC"\n", DP_RC(rc));
-		D_GOTO(out_eaa, rc);
-	}
-
-	return rc;
+	return daos_rpc_send(req, task);
 
 out_eaa:
 	crt_req_decref(req);
@@ -2090,15 +2069,11 @@ dc_obj_shard_query_key(struct dc_obj_shard *shard, struct dtx_epoch *epoch,
 	daos_dti_copy(&okqi->okqi_dti, dti);
 
 	rc = daos_rpc_send(req, task);
-	if (rc != 0) {
-		D_ERROR("query_key rpc failed rc "DF_RC"\n", DP_RC(rc));
-		D_GOTO(out_req, rc);
-	}
-
 	dc_pool_put(pool);
-	return 0;
+	return rc;
 
 out_req:
+	crt_req_decref(req);
 	crt_req_decref(req);
 out:
 	if (pool)
@@ -2216,15 +2191,11 @@ dc_obj_shard_sync(struct dc_obj_shard *shard, enum obj_rpc_opc opc,
 	osi->osi_map_ver	= args->sa_auxi.map_ver;
 
 	rc = daos_rpc_send(req, task);
-	if (rc != 0) {
-		D_ERROR("OBJ_SYNC_RPC failed: rc = "DF_RC"\n", DP_RC(rc));
-		D_GOTO(out_req, rc);
-	}
-
 	dc_pool_put(pool);
-	return 0;
+	return rc;
 
 out_req:
+	crt_req_decref(req);
 	crt_req_decref(req);
 
 out:

--- a/src/object/obj_rpc.c
+++ b/src/object/obj_rpc.c
@@ -138,19 +138,19 @@ crt_proc_daos_iod_and_csum(crt_proc_t proc, crt_proc_op_t proc_op,
 
 	rc = crt_proc_d_iov_t(proc, &iod->iod_name);
 	if (unlikely(rc))
-		return rc;
+		D_GOTO(out, rc);
 
 	rc = crt_proc_memcpy(proc, &iod->iod_type, sizeof(iod->iod_type));
 	if (unlikely(rc))
-		return rc;
+		D_GOTO(out, rc);
 
 	rc = crt_proc_uint64_t(proc, &iod->iod_size);
 	if (unlikely(rc))
-		return rc;
+		D_GOTO(out, rc);
 
 	rc = crt_proc_uint64_t(proc, &iod->iod_flags);
 	if (unlikely(rc))
-		return rc;
+		D_GOTO(out, rc);
 
 	if (ENCODING(proc_op) && oiod != NULL &&
 	    (oiod->oiod_flags & OBJ_SIOD_PROC_ONE) != 0) {
@@ -178,12 +178,12 @@ crt_proc_daos_iod_and_csum(crt_proc_t proc, crt_proc_op_t proc_op,
 		nr = iod->iod_nr;
 	}
 	if (unlikely(rc))
-		return rc;
+		D_GOTO(out, rc);
 
 #if 0
 	if (iod->iod_nr == 0 && iod->iod_type != DAOS_IOD_ARRAY) {
 		D_ERROR("invalid I/O descriptor, iod_nr = 0\n");
-		return -DER_HG;
+		D_GOTO(out, rc = -DER_HG);
 	}
 #else
 	/* Zero nr is possible for EC (even for singv), as different IODs
@@ -193,7 +193,7 @@ crt_proc_daos_iod_and_csum(crt_proc_t proc, crt_proc_op_t proc_op,
 	 * The RW handler can just ignore those invalid IODs.
 	 */
 	if (nr == 0)
-		return 0;
+		D_GOTO(out, rc = 0);
 #endif
 
 	if (ENCODING(proc_op) || FREEING(proc_op)) {
@@ -203,13 +203,13 @@ crt_proc_daos_iod_and_csum(crt_proc_t proc, crt_proc_op_t proc_op,
 
 	rc = crt_proc_uint32_t(proc, &existing_flags);
 	if (unlikely(rc))
-		return rc;
+		D_GOTO(out, rc);
 
 	if (DECODING(proc_op)) {
 		if (existing_flags & IOD_REC_EXIST) {
 			D_ALLOC_ARRAY(iod->iod_recxs, nr);
 			if (iod->iod_recxs == NULL)
-				D_GOTO(out_free, rc = -DER_NOMEM);
+				D_GOTO(out, rc = -DER_NOMEM);
 		}
 	}
 
@@ -221,7 +221,7 @@ crt_proc_daos_iod_and_csum(crt_proc_t proc, crt_proc_op_t proc_op,
 			if (unlikely(rc)) {
 				if (DECODING(proc_op))
 					D_GOTO(out_free, rc);
-				return rc;
+				D_GOTO(out, rc);
 			}
 		}
 	}
@@ -232,7 +232,7 @@ crt_proc_daos_iod_and_csum(crt_proc_t proc, crt_proc_op_t proc_op,
 		if (unlikely(rc)) {
 			if (DECODING(proc_op))
 				D_GOTO(out_free, rc);
-			return rc;
+			D_GOTO(out, rc);
 		}
 	}
 
@@ -241,7 +241,7 @@ crt_proc_daos_iod_and_csum(crt_proc_t proc, crt_proc_op_t proc_op,
 		if (unlikely(rc)) {
 			if (DECODING(proc_op))
 				D_GOTO(out_free, rc);
-			return rc;
+			D_GOTO(out, rc);
 		}
 	}
 
@@ -250,7 +250,7 @@ out_free:
 		if (existing_flags & IOD_REC_EXIST)
 			D_FREE(iod->iod_recxs);
 	}
-
+out:
 	return rc;
 }
 
@@ -295,25 +295,19 @@ static int crt_proc_daos_iom_t(crt_proc_t proc, daos_iom_t *map)
 	if (iom_nr == 0)
 		return 0;
 
-	switch (proc_op) {
-	case CRT_PROC_DECODE:
+	if (DECODING(proc_op)) {
 		map->iom_nr = iom_nr;
 		map->iom_nr_out = iom_nr;
 		D_ALLOC_ARRAY(map->iom_recxs, iom_nr);
 		if (map->iom_recxs == NULL)
 			return -DER_NOMEM;
-		/* fall through to fill iom_recxs */
-	case CRT_PROC_ENCODE:
-		rc = crt_proc_memcpy(proc, map->iom_recxs,
-				     iom_nr * sizeof(*map->iom_recxs));
-		if (unlikely(rc)) {
-			if (DECODING(proc_op))
-				D_FREE(map->iom_recxs);
-			return rc;
-		}
-		break;
-	default:
-		return -DER_INVAL;
+	}
+	rc = crt_proc_memcpy(proc, map->iom_recxs,
+			     iom_nr * sizeof(*map->iom_recxs));
+	if (unlikely(rc)) {
+		if (DECODING(proc_op))
+			D_FREE(map->iom_recxs);
+		return rc;
 	}
 
 	return 0;
@@ -347,29 +341,25 @@ crt_proc_struct_daos_recx_ep_list(crt_proc_t proc,
 	if (list->re_nr == 0)
 		return 0;
 
-	switch (proc_op) {
-	case CRT_PROC_DECODE:
+	if (DECODING(proc_op)) {
 		D_ALLOC_ARRAY(list->re_items, list->re_nr);
 		if (list->re_items == NULL)
 			return -DER_NOMEM;
 		list->re_total = list->re_nr;
-		/* fall through to fill re_items */
-	case CRT_PROC_ENCODE:
-		rc = crt_proc_memcpy(proc, list->re_items,
-				     list->re_nr * sizeof(*list->re_items));
-		if (unlikely(rc && DECODING(proc_op))) {
-			daos_recx_ep_free(list);
-			return rc;
-		}
-
-		if (!list->re_ep_valid && DECODING(proc_op)) {
-			for (i = 0; i < list->re_nr; i++)
-				list->re_items[i].re_ep = 0;
-		}
-		break;
-	default:
-		return -DER_INVAL;
 	}
+	rc = crt_proc_memcpy(proc, list->re_items,
+			     list->re_nr * sizeof(*list->re_items));
+	if (unlikely(rc)) {
+		if (DECODING(proc_op))
+			daos_recx_ep_free(list);
+		return rc;
+	}
+
+	if (!list->re_ep_valid && DECODING(proc_op)) {
+		for (i = 0; i < list->re_nr; i++)
+			list->re_items[i].re_ep = 0;
+	}
+
 	return rc;
 }
 
@@ -497,7 +487,8 @@ crt_proc_struct_obj_iod_array(crt_proc_t proc, struct obj_iod_array *iod_array)
 						iod_csum,
 						oiod);
 		if (unlikely(rc)) {
-			D_FREE(iod_array->oia_iods);
+			if (DECODING(proc_op))
+				D_FREE(iod_array->oia_iods);
 			return rc;
 		}
 	}
@@ -633,15 +624,15 @@ crt_proc_daos_iod_t(crt_proc_t proc, daos_iod_t *iod)
 	if (unlikely(rc))
 		return rc;
 
+	rc = crt_proc_daos_key_t(proc, &iod->iod_name);
+	if (unlikely(rc))
+		return rc;
+
 	if (FREEING(proc_op)) {
 		/* NB: don't need free in crt_proc_d_iov_t() */
 		D_FREE(iod->iod_recxs);
 		return 0;
 	}
-
-	rc = crt_proc_daos_key_t(proc, &iod->iod_name);
-	if (unlikely(rc))
-		return rc;
 
 	rc = crt_proc_memcpy(proc, &iod->iod_type, sizeof(iod->iod_type));
 	if (unlikely(rc))
@@ -662,23 +653,19 @@ crt_proc_daos_iod_t(crt_proc_t proc, daos_iod_t *iod)
 	if (iod->iod_nr == 0)
 		return 0;
 
-	switch (proc_op) {
-	case CRT_PROC_DECODE:
+	if (DECODING(proc_op)) {
 		D_ALLOC_ARRAY(iod->iod_recxs, iod->iod_nr);
 		if (iod->iod_recxs == NULL)
 			return -DER_NOMEM;
-		/* fall through to fill iod_recxs */
-	case CRT_PROC_ENCODE:
-		rc = crt_proc_memcpy(proc, iod->iod_recxs,
-				     iod->iod_nr * sizeof(*iod->iod_recxs));
-		if (unlikely(rc)) {
-			if (DECODING(proc_op))
-				D_FREE(iod->iod_recxs);
-			return rc;
+	}
+	rc = crt_proc_memcpy(proc, iod->iod_recxs,
+			     iod->iod_nr * sizeof(*iod->iod_recxs));
+	if (unlikely(rc)) {
+		if (DECODING(proc_op)) {
+			D_FREE(iod->iod_name.iov_buf);
+			D_FREE(iod->iod_recxs);
 		}
-		break;
-	default:
-		return -DER_INVAL;
+		return rc;
 	}
 
 	return 0;
@@ -820,7 +807,7 @@ crt_proc_struct_daos_cpd_sub_req(crt_proc_t proc,
 		if (DECODING(proc_op)) {
 			D_ALLOC_ARRAY(dcp->dcp_akeys, dcsr->dcsr_nr);
 			if (dcp->dcp_akeys == NULL)
-				return -DER_NOMEM;
+				D_GOTO(out, rc = -DER_NOMEM);
 		}
 
 		for (i = 0; i < dcsr->dcsr_nr; i++) {
@@ -852,7 +839,7 @@ crt_proc_struct_daos_cpd_sub_req(crt_proc_t proc,
 		break;
 	}
 	default:
-		return -DER_INVAL;
+		D_GOTO(out, rc = -DER_INVAL);
 	}
 
 out:
@@ -906,23 +893,17 @@ crt_proc_struct_daos_cpd_disp_ent(crt_proc_t proc,
 	if (count == 0)
 		return 0;
 
-	switch (proc_op) {
-	case CRT_PROC_DECODE:
+	if (DECODING(proc_op)) {
 		D_ALLOC_ARRAY(dcde->dcde_reqs, count);
 		if (dcde->dcde_reqs == NULL)
 			return -DER_NOMEM;
-		/* fall through to fill dcde_reqs */
-	case CRT_PROC_ENCODE:
-		rc = crt_proc_memcpy(proc, dcde->dcde_reqs,
-				     count * sizeof(*dcde->dcde_reqs));
-		if (unlikely(rc)) {
-			if (DECODING(proc_op))
-				D_FREE(dcde->dcde_reqs);
-			return rc;
-		}
-		break;
-	default:
-		return -DER_INVAL;
+	}
+	rc = crt_proc_memcpy(proc, dcde->dcde_reqs,
+			     count * sizeof(*dcde->dcde_reqs));
+	if (unlikely(rc)) {
+		if (DECODING(proc_op))
+			D_FREE(dcde->dcde_reqs);
+		return rc;
 	}
 
 	return 0;

--- a/src/object/srv_ec_aggregate.c
+++ b/src/object/srv_ec_aggregate.c
@@ -1215,10 +1215,10 @@ agg_peer_update_ult(void *arg)
 	d_sg_list_t		 sgl = { 0 };
 	crt_endpoint_t		 tgt_ep = { 0 };
 	unsigned char		*buf = NULL;
-	struct obj_ec_agg_in	*ec_agg_in = NULL;
-	struct obj_ec_agg_out	*ec_agg_out = NULL;
+	struct obj_ec_agg_in	*ec_agg_in;
+	struct obj_ec_agg_out	*ec_agg_out;
 	struct ec_agg_param	*agg_param;
-	crt_rpc_t		*rpc;
+	crt_rpc_t		*rpc = NULL;
 	int			 rc = 0;
 
 	tgt_ep.ep_rank = entry->ae_peer_pshards[0].sd_rank;
@@ -1262,7 +1262,7 @@ agg_peer_update_ult(void *arg)
 				     CRT_BULK_RW, &ec_agg_in->ea_bulk);
 		if (rc) {
 			D_ERROR("crt_bulk_create failed: "DF_RC"\n", DP_RC(rc));
-			goto out;
+			goto out_rpc;
 		}
 	}
 
@@ -1276,13 +1276,13 @@ agg_peer_update_ult(void *arg)
 			      ec_agg_in->ea_remove_nr);
 		if (ec_agg_in->ea_remove_recxs.ca_arrays == NULL) {
 			rc = -DER_NOMEM;
-			goto out;
+			goto out_bulk;
 		}
 		D_ALLOC_ARRAY(ec_agg_in->ea_remove_eps.ca_arrays,
 			      ec_agg_in->ea_remove_nr);
 		if (ec_agg_in->ea_remove_eps.ca_arrays == NULL) {
 			rc = -DER_NOMEM;
-			goto out;
+			goto out_bulk;
 		}
 
 		d_list_for_each_entry(ext, &entry->ae_cur_stripe.as_dextents,
@@ -1313,22 +1313,24 @@ agg_peer_update_ult(void *arg)
 		D_ERROR("dss_rpc_send failed: "DF_RC"\n", DP_RC(rc));
 		if (stripe_ud->asu_write_par)
 			crt_bulk_free(ec_agg_in->ea_bulk);
-		goto out;
+		goto out_bulk;
 	}
 	ec_agg_out = crt_reply_get(rpc);
 	rc = ec_agg_out->ea_status;
 	if (rc)
 		D_ERROR("remote update rpc failed: "DF_RC"\n", DP_RC(rc));
 
+out_bulk:
 	if (stripe_ud->asu_write_par)
 		crt_bulk_free(ec_agg_in->ea_bulk);
-out:
+out_rpc:
 	if (ec_agg_in->ea_remove_nr) {
 		D_FREE(ec_agg_in->ea_remove_recxs.ca_arrays);
 		D_FREE(ec_agg_in->ea_remove_eps.ca_arrays);
 	}
 	if (rpc)
 		crt_req_decref(rpc);
+out:
 	ABT_eventual_set(stripe_ud->asu_eventual, (void *)&rc, sizeof(rc));
 }
 
@@ -1412,7 +1414,7 @@ agg_process_holes_ult(void *arg)
 	struct ec_agg_param	*agg_param;
 	struct obj_ec_rep_in	*ec_rep_in = NULL;
 	struct obj_ec_rep_out	*ec_rep_out = NULL;
-	crt_rpc_t		*rpc;
+	crt_rpc_t		*rpc = NULL;
 	unsigned int		 len = ec_age2cs(entry);
 	unsigned int		 k = ec_age2k(entry);
 	unsigned long		 ss = entry->ae_cur_stripe.as_stripenum *
@@ -1543,6 +1545,8 @@ agg_process_holes_ult(void *arg)
 		D_ERROR("remote update rpc failed: "DF_RC"\n", DP_RC(rc));
 
 out:
+	if (rpc)
+		crt_req_decref(rpc);
 	D_FREE(stripe_ud->asu_recxs);
 	entry->ae_sgl.sg_nr = AGG_IOV_CNT;
 	ABT_eventual_set(stripe_ud->asu_eventual, (void *)&rc, sizeof(rc));

--- a/src/pool/cli.c
+++ b/src/pool/cli.c
@@ -552,12 +552,7 @@ dc_pool_connect(tse_task_t *task)
 	if (rc != 0)
 		D_GOTO(out_bulk, rc);
 
-	/** send the request */
-	rc = daos_rpc_send(rpc, task);
-	if (rc != 0)
-		D_GOTO(out_bulk, rc);
-
-	return rc;
+	return daos_rpc_send(rpc, task);
 
 out_bulk:
 	map_bulk_destroy(pci->pci_map_bulk, map_buf);
@@ -709,12 +704,7 @@ dc_pool_disconnect(tse_task_t *task)
 	if (rc != 0)
 		D_GOTO(out_rpc, rc);
 
-	/** send the request */
-	rc = daos_rpc_send(rpc, task);
-	if (rc != 0)
-		D_GOTO(out_rpc, rc);
-
-	return rc;
+	return daos_rpc_send(rpc, task);
 
 out_rpc:
 	crt_req_decref(rpc);
@@ -1132,8 +1122,7 @@ dc_pool_update_internal(tse_task_t *task, daos_pool_update_t *args,
 	if (rc) {
 		D_ERROR(DF_UUID": pool_target_addr_list_alloc failed, rc %d.\n",
 			DP_UUID(args->uuid), rc);
-		crt_req_decref(rpc);
-		D_GOTO(out_client, rc);
+		D_GOTO(out_rpc, rc);
 	}
 
 	for (i = 0; i < args->tgts->tl_nr; i++) {
@@ -1148,19 +1137,14 @@ dc_pool_update_internal(tse_task_t *task, daos_pool_update_t *args,
 	rc = tse_task_register_comp_cb(task, pool_tgt_update_cp, &rpc,
 				       sizeof(rpc));
 	if (rc != 0)
-		D_GOTO(out_rpc, rc);
+		D_GOTO(out_list, rc);
 
-	/** send the request */
-	rc = daos_rpc_send(rpc, task);
+	return daos_rpc_send(rpc, task);
 
-	if (rc != 0)
-		D_GOTO(out_rpc, rc);
-
-	return rc;
-
-out_rpc:
+out_list:
 	pool_target_addr_list_free(&list);
 	crt_req_decref(rpc);
+out_rpc:
 	crt_req_decref(rpc);
 out_client:
 	rsvc_client_fini(&state->client);
@@ -1358,12 +1342,7 @@ dc_pool_query(tse_task_t *task)
 	if (rc != 0)
 		D_GOTO(out_bulk, rc);
 
-	/** send the request */
-	rc = daos_rpc_send(rpc, task);
-	if (rc != 0)
-		D_GOTO(out_bulk, rc);
-
-	return rc;
+	return daos_rpc_send(rpc, task);
 
 out_bulk:
 	map_bulk_destroy(in->pqi_map_bulk, map_buf);
@@ -1505,12 +1484,8 @@ dc_pool_list_cont(tse_task_t *task)
 	if (rc != 0)
 		D_GOTO(out_bulk, rc);
 
-	/** send the request */
-	rc = daos_rpc_send(rpc, task);
-	if (rc != 0)
-		D_GOTO(out_bulk, rc);
+	return daos_rpc_send(rpc, task);
 
-	return rc;
 out_bulk:
 	if (in->plci_ncont > 0)
 		list_cont_bulk_destroy(in->plci_cont_bulk);
@@ -1659,12 +1634,7 @@ dc_pool_query_target(tse_task_t *task)
 	if (rc != 0)
 		D_GOTO(out_rpc, rc);
 
-	/** send the request */
-	rc = daos_rpc_send(rpc, task);
-	if (rc != 0)
-		D_GOTO(out_rpc, rc);
-
-	return rc;
+	return daos_rpc_send(rpc, task);
 
 out_rpc:
 	crt_req_decref(rpc);
@@ -1674,7 +1644,6 @@ out_pool:
 out_task:
 	tse_task_complete(task, rc);
 	return rc;
-
 }
 
 struct pool_req_arg {
@@ -1849,13 +1818,8 @@ dc_pool_list_attr(tse_task_t *task)
 	}
 
 	crt_req_addref(cb_args.pra_rpc);
-	rc = daos_rpc_send(cb_args.pra_rpc, task);
-	if (rc != 0) {
-		pool_req_cleanup(CLEANUP_ALL, &cb_args);
-		D_GOTO(out, rc);
-	}
+	return daos_rpc_send(cb_args.pra_rpc, task);
 
-	return rc;
 out:
 	tse_task_complete(task, rc);
 	D_DEBUG(DF_DSMC, "Failed to list pool attributes: "DF_RC"\n",
@@ -2006,13 +1970,8 @@ dc_pool_get_attr(tse_task_t *task)
 	}
 
 	crt_req_addref(cb_args.pra_rpc);
-	rc = daos_rpc_send(cb_args.pra_rpc, task);
-	if (rc != 0) {
-		pool_req_cleanup(CLEANUP_ALL, &cb_args);
-		D_GOTO(out, rc);
-	}
+	return daos_rpc_send(cb_args.pra_rpc, task);
 
-	return rc;
 out:
 	tse_task_complete(task, rc);
 	D_DEBUG(DF_DSMC, "Failed to get pool attributes: "DF_RC"\n", DP_RC(rc));
@@ -2063,13 +2022,8 @@ dc_pool_set_attr(tse_task_t *task)
 	}
 
 	crt_req_addref(cb_args.pra_rpc);
-	rc = daos_rpc_send(cb_args.pra_rpc, task);
-	if (rc != 0) {
-		pool_req_cleanup(CLEANUP_ALL, &cb_args);
-		D_GOTO(out, rc);
-	}
+	return daos_rpc_send(cb_args.pra_rpc, task);
 
-	return rc;
 out:
 	tse_task_complete(task, rc);
 	D_DEBUG(DF_DSMC, "Failed to set pool attributes: "DF_RC"\n", DP_RC(rc));
@@ -2104,23 +2058,22 @@ dc_pool_del_attr(tse_task_t *task)
 	in->padi_count = args->n;
 	rc = attr_bulk_create(args->n, (char **)args->names, NULL, NULL,
 			      daos_task2ctx(task), CRT_BULK_RO, &in->padi_bulk);
-	if (rc != 0)
-		D_GOTO(cleanup, rc);
+	if (rc != 0) {
+		pool_req_cleanup(CLEANUP_RPC, &cb_args);
+		D_GOTO(out, rc);
+	}
 
 	cb_args.pra_bulk = in->padi_bulk;
 	rc = tse_task_register_comp_cb(task, pool_req_complete,
 				       &cb_args, sizeof(cb_args));
-	if (rc != 0)
-		D_GOTO(cleanup, rc);
+	if (rc != 0) {
+		pool_req_cleanup(CLEANUP_BULK, &cb_args);
+		D_GOTO(out, rc);
+	}
 
 	crt_req_addref(cb_args.pra_rpc);
-	rc = daos_rpc_send(cb_args.pra_rpc, task);
-	if (rc != 0)
-		D_GOTO(cleanup, rc);
+	return daos_rpc_send(cb_args.pra_rpc, task);
 
-	return rc;
-cleanup:
-	pool_req_cleanup(CLEANUP_BULK, &cb_args);
 out:
 	tse_task_complete(task, rc);
 	D_DEBUG(DF_DSMC, "Failed to del pool attributes: "DF_RC"\n", DP_RC(rc));
@@ -2209,11 +2162,7 @@ dc_pool_stop_svc(tse_task_t *task)
 	if (rc != 0)
 		D_GOTO(out_rpc, rc);
 
-	rc = daos_rpc_send(rpc, task);
-	if (rc != 0)
-		D_GOTO(out_rpc, rc);
-
-	return rc;
+	return daos_rpc_send(rpc, task);
 
 out_rpc:
 	crt_req_decref(rpc);

--- a/src/pool/srv_iv.c
+++ b/src/pool/srv_iv.c
@@ -1372,8 +1372,6 @@ ds_pool_iv_prop_update(struct ds_pool *pool, daos_prop_t *prop)
 
 	D_FREE(iv_entry);
 out:
-	if (iv_entry)
-		D_FREE(iv_entry);
 	return rc;
 }
 


### PR DESCRIPTION
Split this patch into several small patches. This patch is for following:

- Fix reference counting for rpc
- Free memory in an error path