### PR TITLE
DAOS-6466 object: a few fixes for Drain

### DIFF
--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -517,8 +517,8 @@ obj_grp_valid_shard_get(struct dc_object *obj, int grp_idx,
 	 */
 	D_ASSERT(grp_size >= obj_get_replicas(obj));
 	grp_start = grp_idx * grp_size;
-	idx = grp_start + random() % obj_get_replicas(obj);
-	for (i = 0; i < obj_get_replicas(obj); i++, idx++) {
+	idx = grp_start + random() % grp_size;
+	for (i = 0; i < grp_size; i++, idx++) {
 		uint32_t tgt_id;
 		int index;
 
@@ -544,7 +544,7 @@ obj_grp_valid_shard_get(struct dc_object *obj, int grp_idx,
 
 	D_RWLOCK_UNLOCK(&obj->cob_lock);
 
-	if (i == obj_get_replicas(obj))
+	if (i == grp_size)
 		return -DER_NONEXIST;
 
 	return idx;

--- a/src/object/srv_obj_migrate.c
+++ b/src/object/srv_obj_migrate.c
@@ -549,25 +549,31 @@ migrate_fetch_update_inline(struct migrate_one *mrone, daos_handle_t oh,
 		DP_KEY(&mrone->mo_dkey), mrone->mo_iod_num,
 		mrone->mo_epoch, fetch ? "yes":"no");
 
-	if (fetch) {
-		rc = dsc_obj_fetch(oh, mrone->mo_epoch, &mrone->mo_dkey,
-				   mrone->mo_iod_num, mrone->mo_iods, sgls,
-				   NULL, DIOF_TO_LEADER | DIOF_FOR_MIGRATION,
-				   NULL);
-		if (rc) {
-			D_ERROR("dsc_obj_fetch %d\n", rc);
-			return rc;
-		}
-	}
-
 	if (DAOS_FAIL_CHECK(DAOS_REBUILD_NO_UPDATE))
 		return 0;
 
 	if (DAOS_FAIL_CHECK(DAOS_REBUILD_UPDATE_FAIL))
 		return -DER_INVAL;
 
-	if (daos_oclass_is_ec(mrone->mo_oid.id_pub, &oca) &&
-	    !obj_shard_is_ec_parity(mrone->mo_oid, &oca))
+
+	oca = daos_oclass_attr_find(mrone->mo_oid.id_pub);
+	D_ASSERT(oca != NULL);
+	if (fetch) {
+		uint32_t flags = DIOF_FOR_MIGRATION;
+
+		if (daos_oclass_grp_size(oca) > 1)
+			flags |= DIOF_TO_LEADER;
+
+		rc = dsc_obj_fetch(oh, mrone->mo_epoch, &mrone->mo_dkey,
+				   mrone->mo_iod_num, mrone->mo_iods, sgls,
+				   NULL, flags, NULL);
+		if (rc) {
+			D_ERROR("dsc_obj_fetch %d\n", rc);
+			return rc;
+		}
+	}
+
+	if (DAOS_OC_IS_EC(oca) && !obj_shard_is_ec_parity(mrone->mo_oid, NULL))
 		mrone_recx_daos2_vos(mrone, oca);
 
 	for (i = 0, start = 0; i < mrone->mo_iod_num; i++) {
@@ -804,12 +810,13 @@ migrate_fetch_update_single(struct migrate_one *mrone, daos_handle_t oh,
 			    struct ds_cont_child *ds_cont)
 {
 	struct daos_oclass_attr	*oca;
-	d_sg_list_t	 	sgls[DSS_ENUM_UNPACK_MAX_IODS];
-	d_iov_t		 	iov[DSS_ENUM_UNPACK_MAX_IODS] = { 0 };
-	char		 	*data;
-	daos_size_t	 	size;
-	int		 	i;
-	int		 	rc;
+	d_sg_list_t		sgls[DSS_ENUM_UNPACK_MAX_IODS];
+	d_iov_t			iov[DSS_ENUM_UNPACK_MAX_IODS] = { 0 };
+	uint32_t		flags = DIOF_FOR_MIGRATION;
+	char			*data;
+	daos_size_t		size;
+	int			i;
+	int			rc;
 
 	oca = daos_oclass_attr_find(mrone->mo_oid.id_pub);
 	D_ASSERT(oca != NULL);
@@ -834,9 +841,12 @@ migrate_fetch_update_single(struct migrate_one *mrone, daos_handle_t oh,
 		DP_UOID(mrone->mo_oid), mrone, DP_KEY(&mrone->mo_dkey),
 		mrone->mo_iod_num, mrone->mo_epoch);
 
+	if (daos_oclass_grp_size(oca) > 1)
+		flags |= DIOF_TO_LEADER;
+
 	rc = dsc_obj_fetch(oh, mrone->mo_epoch, &mrone->mo_dkey,
 			   mrone->mo_iod_num, mrone->mo_iods, sgls, NULL,
-			   DIOF_TO_LEADER | DIOF_FOR_MIGRATION, NULL);
+			   flags, NULL);
 	if (rc) {
 		D_ERROR("migrate dkey "DF_KEY" failed rc %d\n",
 			DP_KEY(&mrone->mo_dkey), rc);
@@ -899,10 +909,11 @@ static int
 migrate_fetch_update_bulk(struct migrate_one *mrone, daos_handle_t oh,
 			  struct ds_cont_child *ds_cont)
 {
-	d_sg_list_t	 sgls[DSS_ENUM_UNPACK_MAX_IODS];
-	daos_handle_t	 ioh;
+	d_sg_list_t	sgls[DSS_ENUM_UNPACK_MAX_IODS];
+	daos_handle_t	ioh;
 	struct daos_oclass_attr *oca;
-	int		 rc, rc1, i, ret, sgl_cnt = 0;
+	uint32_t	flags = DIOF_FOR_MIGRATION;
+	int		rc, rc1, i, ret, sgl_cnt = 0;
 
 	if (obj_shard_is_ec_parity(mrone->mo_oid, &oca))
 		return migrate_fetch_update_parity(mrone, oh, ds_cont, oca);
@@ -948,9 +959,12 @@ migrate_fetch_update_bulk(struct migrate_one *mrone, daos_handle_t oh,
 	if (DAOS_OC_IS_EC(oca))
 		mrone_recx_vos2_daos(mrone, oca, mrone->mo_oid.id_shard);
 
+	if (daos_oclass_grp_size(oca) > 1)
+		flags |= DIOF_TO_LEADER;
+
 	rc = dsc_obj_fetch(oh, mrone->mo_epoch, &mrone->mo_dkey,
 			   mrone->mo_iod_num, mrone->mo_iods, sgls, NULL,
-			   DIOF_TO_LEADER | DIOF_FOR_MIGRATION, NULL);
+			   flags, NULL);
 	if (rc)
 		D_ERROR("migrate dkey "DF_KEY" failed rc %d\n",
 			DP_KEY(&mrone->mo_dkey), rc);

--- a/src/placement/pl_map_common.c
+++ b/src/placement/pl_map_common.c
@@ -453,7 +453,8 @@ pl_map_extend(struct pl_obj_layout *layout, d_list_t *extended_list)
 		new_shards[grp_idx].po_fseq = f_shard->fs_fseq;
 		new_shards[grp_idx].po_shard = f_shard->fs_shard_idx;
 		new_shards[grp_idx].po_target = f_shard->fs_tgt_id;
-		new_shards[grp_idx].po_rebuilding = 1;
+		if (f_shard->fs_status != PO_COMP_ST_DRAIN)
+			new_shards[grp_idx].po_rebuilding = 1;
 	}
 
 	layout->ol_grp_size += max_fail_grp;

--- a/src/tests/suite/daos_drain_simple.c
+++ b/src/tests/suite/daos_drain_simple.c
@@ -40,7 +40,7 @@ drain_dkeys(void **state)
 	if (!test_runable(arg, 4))
 		return;
 
-	oid = daos_test_oid_gen(arg->coh, DAOS_OC_R3S_SPEC_RANK, 0, 0,
+	oid = daos_test_oid_gen(arg->coh, DAOS_OC_R1S_SPEC_RANK, 0, 0,
 				arg->myrank);
 	oid = dts_oid_set_rank(oid, ranks_to_kill[0]);
 	oid = dts_oid_set_tgt(oid, tgt);
@@ -56,10 +56,23 @@ drain_dkeys(void **state)
 		insert_single(key, "a_key", 0, "data", strlen("data") + 1,
 			      DAOS_TX_NONE, &req);
 	}
-	ioreq_fini(&req);
 
 	drain_single_pool_target(arg, ranks_to_kill[0], tgt, false);
 
+	for (i = 0; i < KEY_NR; i++) {
+		char key[16];
+		char buf[16];
+
+		sprintf(key, "dkey_0_%d", i);
+		/** Lookup */
+		memset(buf, 0, 10);
+		lookup_single(key, "a_key", 0, buf, 10, DAOS_TX_NONE, &req);
+		assert_int_equal(req.iod[0].iod_size, strlen("data") + 1);
+
+		/** Verify data consistency */
+		assert_string_equal(buf, "data");
+	}
+	ioreq_fini(&req);
 }
 
 static void
@@ -74,7 +87,7 @@ drain_akeys(void **state)
 	if (!test_runable(arg, 4))
 		return;
 
-	oid = daos_test_oid_gen(arg->coh, DAOS_OC_R3S_SPEC_RANK, 0, 0,
+	oid = daos_test_oid_gen(arg->coh, DAOS_OC_R1S_SPEC_RANK, 0, 0,
 				arg->myrank);
 	oid = dts_oid_set_rank(oid, ranks_to_kill[0]);
 	oid = dts_oid_set_tgt(oid, tgt);
@@ -90,11 +103,23 @@ drain_akeys(void **state)
 		insert_single("dkey_1_0", akey, 0, "data", strlen("data") + 1,
 			      DAOS_TX_NONE, &req);
 	}
-	ioreq_fini(&req);
 
 	drain_single_pool_target(arg, ranks_to_kill[0], tgt, false);
+	for (i = 0; i < KEY_NR; i++) {
+		char akey[16];
+		char buf[16];
 
-	reintegrate_single_pool_target(arg, ranks_to_kill[0], tgt);
+		sprintf(akey, "%d", i);
+		/** Lookup */
+		memset(buf, 0, 10);
+		lookup_single("dkey_1_0", akey, 0, buf, 10, DAOS_TX_NONE, &req);
+		assert_int_equal(req.iod[0].iod_size, strlen("data") + 1);
+
+		/** Verify data consistency */
+		assert_string_equal(buf, "data");
+	}
+
+	ioreq_fini(&req);
 }
 
 static void
@@ -110,7 +135,7 @@ drain_indexes(void **state)
 	if (!test_runable(arg, 4))
 		return;
 
-	oid = daos_test_oid_gen(arg->coh, DAOS_OC_R3S_SPEC_RANK, 0, 0,
+	oid = daos_test_oid_gen(arg->coh, DAOS_OC_R1S_SPEC_RANK, 0, 0,
 				arg->myrank);
 	oid = dts_oid_set_rank(oid, ranks_to_kill[0]);
 	oid = dts_oid_set_tgt(oid, tgt);
@@ -127,120 +152,25 @@ drain_indexes(void **state)
 			insert_single(key, "a_key", j, "data",
 				      strlen("data") + 1, DAOS_TX_NONE, &req);
 	}
-	ioreq_fini(&req);
 
 	/* Drain rank 1 */
 	drain_single_pool_target(arg, ranks_to_kill[0], tgt, false);
+	for (i = 0; i < KEY_NR; i++) {
+		char	key[16];
+		char	buf[16];
 
-	reintegrate_single_pool_target(arg, ranks_to_kill[0], tgt);
-}
-
-static void
-drain_snap_update_recs(void **state)
-{
-	test_arg_t	*arg = *state;
-	daos_obj_id_t	oid;
-	struct ioreq	req;
-	daos_recx_t	recx;
-	int		tgt = DEFAULT_FAIL_TGT;
-	char		string[100] = { 0 };
-	daos_epoch_t	snap_epoch[5];
-	int		i;
-	int		rc;
-
-	if (!test_runable(arg, 4))
-		return;
-
-	oid = daos_test_oid_gen(arg->coh, DAOS_OC_R3S_SPEC_RANK, 0, 0,
-				arg->myrank);
-	oid = dts_oid_set_rank(oid, ranks_to_kill[0]);
-	oid = dts_oid_set_tgt(oid, tgt);
-	ioreq_init(&req, arg->coh, oid, DAOS_IOD_ARRAY, arg);
-	for (i = 0; i < 5; i++)
-		sprintf(string + strlen(string), "old-snap%d", i);
-
-	recx.rx_idx = 0;
-	recx.rx_nr = strlen(string);
-	insert_recxs("d_key", "a_key", 1, DAOS_TX_NONE, &recx, 1, string,
-		     strlen(string) + 1, &req);
-
-	for (i = 0; i < 5; i++) {
-		char data[20] = { 0 };
-
-		/* Update string for each snapshot */
-		daos_cont_create_snap(arg->coh, &snap_epoch[i], NULL, NULL);
-		sprintf(data, "new-snap%d", i);
-		recx.rx_idx = i * strlen(data);
-		recx.rx_nr = strlen(data);
-		insert_recxs("d_key", "a_key", 1, DAOS_TX_NONE, &recx, 1, data,
-			      strlen(data) + 1, &req);
+		sprintf(key, "dkey_2_%d", i);
+		for (j = 0; j < 20; j++) {
+			memset(buf, 0, 10);
+			lookup_single(key, "a_key", j, buf, 10, DAOS_TX_NONE,
+				      &req);
+			assert_int_equal(req.iod[0].iod_size,
+					 strlen("data") + 1);
+			assert_string_equal(buf, "data");
+		}
 	}
-
-	drain_single_pool_target(arg, ranks_to_kill[0], tgt, false);
-
-	for (i = 0; i < 5; i++) {
-		rc = daos_obj_verify(arg->coh, oid, snap_epoch[i]);
-		assert_rc_equal(rc, 0);
-	}
-
-	rc = daos_obj_verify(arg->coh, oid, DAOS_EPOCH_MAX);
-	assert_rc_equal(rc, 0);
 
 	ioreq_fini(&req);
-
-	reintegrate_single_pool_target(arg, ranks_to_kill[0], tgt);
-}
-
-static void
-drain_snap_punch_recs(void **state)
-{
-	test_arg_t	*arg = *state;
-	daos_obj_id_t	oid;
-	struct ioreq	req;
-	daos_recx_t	recx;
-	int		tgt = DEFAULT_FAIL_TGT;
-	char		string[100];
-	daos_epoch_t	snap_epoch[5];
-	int		i;
-	int		rc;
-
-	if (!test_runable(arg, 4))
-		return;
-
-	oid = daos_test_oid_gen(arg->coh, DAOS_OC_R3S_SPEC_RANK, 0, 0,
-				arg->myrank);
-	oid = dts_oid_set_rank(oid, ranks_to_kill[0]);
-	oid = dts_oid_set_tgt(oid, tgt);
-	ioreq_init(&req, arg->coh, oid, DAOS_IOD_ARRAY, arg);
-	for (i = 0; i < 5; i++)
-		sprintf(string + strlen(string), "old-snap%d", i);
-
-	recx.rx_idx = 0;
-	recx.rx_nr = strlen(string);
-	insert_recxs("d_key", "a_key", 1, DAOS_TX_NONE, &recx, 1, string,
-		     strlen(string) + 1, &req);
-
-	for (i = 0; i < 5; i++) {
-		/* punch string */
-		daos_cont_create_snap(arg->coh, &snap_epoch[i], NULL, NULL);
-		recx.rx_idx = i * 9; /* strlen("old-snap%d") */
-		recx.rx_nr = 9;
-		punch_recxs("d_key", "a_key", &recx, 1, DAOS_TX_NONE, &req);
-	}
-
-	drain_single_pool_target(arg, ranks_to_kill[0], tgt, false);
-
-	for (i = 0; i < 5; i++) {
-		rc = daos_obj_verify(arg->coh, oid, snap_epoch[i]);
-		assert_rc_equal(rc, 0);
-	}
-
-	rc = daos_obj_verify(arg->coh, oid, DAOS_EPOCH_MAX);
-	assert_rc_equal(rc, 0);
-
-	ioreq_fini(&req);
-
-	reintegrate_single_pool_target(arg, ranks_to_kill[0], tgt);
 }
 
 static void
@@ -252,11 +182,17 @@ drain_snap_update_keys(void **state)
 	int		tgt = DEFAULT_FAIL_TGT;
 	daos_epoch_t	snap_epoch[5];
 	int		i;
+	uint32_t	number;
+	daos_key_desc_t kds[10];
+	daos_anchor_t	anchor = { 0 };
+	char		buf[256];
+	int		buf_len = 256;
+
 
 	if (!test_runable(arg, 4))
 		return;
 
-	oid = daos_test_oid_gen(arg->coh, DAOS_OC_R3S_SPEC_RANK, 0, 0,
+	oid = daos_test_oid_gen(arg->coh, DAOS_OC_R1S_SPEC_RANK, 0, 0,
 				arg->myrank);
 	oid = dts_oid_set_rank(oid, ranks_to_kill[0]);
 	oid = dts_oid_set_tgt(oid, tgt);
@@ -276,51 +212,37 @@ drain_snap_update_keys(void **state)
 
 	drain_single_pool_target(arg, ranks_to_kill[0], tgt, false);
 
-	daos_fail_loc_set(DAOS_OBJ_SPECIAL_SHARD);
-	for (i = 0; i < OBJ_REPLICAS; i++) {
-		uint32_t	number;
-		daos_key_desc_t kds[10];
-		daos_anchor_t	anchor = { 0 };
-		char		buf[256];
-		int		buf_len = 256;
-		int		j;
+	for (i = 0; i < 5; i++) {
+		daos_handle_t	th_open;
 
-		daos_fail_value_set(i);
-		for (j = 0; j < 5; j++) {
-			daos_handle_t	th_open;
-
-			memset(&anchor, 0, sizeof(anchor));
-			daos_tx_open_snap(arg->coh, snap_epoch[j], &th_open,
-					  NULL);
-			number = 10;
-			enumerate_dkey(th_open, &number, kds, &anchor, buf,
-				       buf_len, &req);
-
-			assert_int_equal(number, j > 0 ? j+1 : 0);
-
-			number = 10;
-			memset(&anchor, 0, sizeof(anchor));
-			enumerate_akey(th_open, "dkey", &number, kds, &anchor,
-				       buf, buf_len, &req);
-
-			assert_int_equal(number, j);
-			daos_tx_close(th_open, NULL);
-		}
-		number = 10;
 		memset(&anchor, 0, sizeof(anchor));
-		enumerate_dkey(DAOS_TX_NONE, &number, kds, &anchor, buf,
+		daos_tx_open_snap(arg->coh, snap_epoch[i], &th_open, NULL);
+		number = 10;
+		enumerate_dkey(th_open, &number, kds, &anchor, buf,
 			       buf_len, &req);
-		assert_int_equal(number, 6);
+
+		assert_int_equal(number, i > 0 ? i + 1 : 0);
 
 		number = 10;
 		memset(&anchor, 0, sizeof(anchor));
-		enumerate_akey(DAOS_TX_NONE, "dkey", &number, kds, &anchor,
+		enumerate_akey(th_open, "dkey", &number, kds, &anchor,
 			       buf, buf_len, &req);
-		assert_int_equal(number, 5);
+
+		assert_int_equal(number, i);
+		daos_tx_close(th_open, NULL);
 	}
+	number = 10;
+	memset(&anchor, 0, sizeof(anchor));
+	enumerate_dkey(DAOS_TX_NONE, &number, kds, &anchor, buf, buf_len, &req);
+	assert_int_equal(number, 6);
+
+	number = 10;
+	memset(&anchor, 0, sizeof(anchor));
+	enumerate_akey(DAOS_TX_NONE, "dkey", &number, kds, &anchor,
+		       buf, buf_len, &req);
+	assert_int_equal(number, 5);
 
 	ioreq_fini(&req);
-	reintegrate_single_pool_target(arg, ranks_to_kill[0], tgt);
 }
 
 static void
@@ -332,6 +254,11 @@ drain_snap_punch_keys(void **state)
 	int		tgt = DEFAULT_FAIL_TGT;
 	daos_epoch_t	snap_epoch[5];
 	int		i;
+	daos_key_desc_t  kds[10];
+	daos_anchor_t	 anchor;
+	char		 buf[256];
+	int		 buf_len = 256;
+	uint32_t	 number;
 
 	if (!test_runable(arg, 4))
 		return;
@@ -371,51 +298,38 @@ drain_snap_punch_keys(void **state)
 
 	drain_single_pool_target(arg, ranks_to_kill[0], tgt, false);
 
-	daos_fail_loc_set(DAOS_OBJ_SPECIAL_SHARD);
-	for (i = 0; i < OBJ_REPLICAS; i++) {
-		daos_key_desc_t  kds[10];
-		daos_anchor_t	 anchor;
-		char		 buf[256];
-		int		 buf_len = 256;
-		uint32_t	 number;
-		int		 j;
+	for (i = 0; i < 5; i++) {
+		daos_handle_t th_open;
 
-		daos_fail_value_set(i);
-		for (j = 0; j < 5; j++) {
-			daos_handle_t th_open;
-
-			daos_tx_open_snap(arg->coh, snap_epoch[j], &th_open,
-					  NULL);
-			number = 10;
-			memset(&anchor, 0, sizeof(anchor));
-			enumerate_dkey(th_open, &number, kds, &anchor, buf,
-				       buf_len, &req);
-			assert_int_equal(number, 6 - j);
-
-			number = 10;
-			memset(&anchor, 0, sizeof(anchor));
-			enumerate_akey(th_open, "dkey", &number, kds,
-				       &anchor, buf, buf_len, &req);
-			assert_int_equal(number, 10 - j);
-
-			daos_tx_close(th_open, NULL);
-		}
-
+		daos_tx_open_snap(arg->coh, snap_epoch[i], &th_open, NULL);
 		number = 10;
 		memset(&anchor, 0, sizeof(anchor));
-		enumerate_dkey(DAOS_TX_NONE, &number, kds, &anchor, buf,
+		enumerate_dkey(th_open, &number, kds, &anchor, buf,
 			       buf_len, &req);
-		assert_int_equal(number, 1);
+		assert_int_equal(number, 6 - i);
 
 		number = 10;
 		memset(&anchor, 0, sizeof(anchor));
-		enumerate_akey(DAOS_TX_NONE, "dkey", &number, kds, &anchor,
-			       buf, buf_len, &req);
-		assert_int_equal(number, 5);
+		enumerate_akey(th_open, "dkey", &number, kds,
+			       &anchor, buf, buf_len, &req);
+		assert_int_equal(number, 10 - i);
+
+		daos_tx_close(th_open, NULL);
 	}
 
+	number = 10;
+	memset(&anchor, 0, sizeof(anchor));
+	enumerate_dkey(DAOS_TX_NONE, &number, kds, &anchor, buf,
+		       buf_len, &req);
+	assert_int_equal(number, 1);
+
+	number = 10;
+	memset(&anchor, 0, sizeof(anchor));
+	enumerate_akey(DAOS_TX_NONE, "dkey", &number, kds, &anchor,
+		       buf, buf_len, &req);
+	assert_int_equal(number, 5);
+
 	ioreq_fini(&req);
-	reintegrate_single_pool_target(arg, ranks_to_kill[0], tgt);
 }
 
 static void
@@ -432,7 +346,7 @@ drain_multiple(void **state)
 	if (!test_runable(arg, 4))
 		return;
 
-	oid = daos_test_oid_gen(arg->coh, DAOS_OC_R3S_SPEC_RANK, 0, 0,
+	oid = daos_test_oid_gen(arg->coh, DAOS_OC_R1S_SPEC_RANK, 0, 0,
 				arg->myrank);
 	oid = dts_oid_set_rank(oid, ranks_to_kill[0]);
 	oid = dts_oid_set_tgt(oid, tgt);
@@ -455,9 +369,30 @@ drain_multiple(void **state)
 					      DAOS_TX_NONE, &req);
 		}
 	}
-	ioreq_fini(&req);
 
 	drain_single_pool_target(arg, ranks_to_kill[0], tgt, false);
+	for (i = 0; i < 10; i++) {
+		char	dkey[16];
+
+		sprintf(dkey, "dkey_3_%d", i);
+		for (j = 0; j < 10; j++) {
+			char	akey[16];
+			char	buf[10];
+
+			memset(buf, 0, 10);
+			sprintf(akey, "akey_%d", j);
+			for (k = 0; k < 10; k++) {
+				lookup_single(dkey, akey, k, buf,
+					      strlen("data") + 1,
+					      DAOS_TX_NONE, &req);
+				assert_int_equal(req.iod[0].iod_size,
+						 strlen("data") + 1);
+				assert_string_equal(buf, "data");
+			}
+		}
+	}
+
+	ioreq_fini(&req);
 }
 
 static void
@@ -469,11 +404,12 @@ drain_large_rec(void **state)
 	int			tgt = DEFAULT_FAIL_TGT;
 	int			i;
 	char			buffer[5000];
+	char			v_buffer[5000];
 
 	if (!test_runable(arg, 4))
 		return;
 
-	oid = daos_test_oid_gen(arg->coh, DAOS_OC_R3S_SPEC_RANK, 0, 0,
+	oid = daos_test_oid_gen(arg->coh, DAOS_OC_R1S_SPEC_RANK, 0, 0,
 				arg->myrank);
 	oid = dts_oid_set_rank(oid, ranks_to_kill[0]);
 	oid = dts_oid_set_tgt(oid, tgt);
@@ -490,9 +426,20 @@ drain_large_rec(void **state)
 		insert_single(key, "a_key", 0, buffer, 5000, DAOS_TX_NONE,
 			      &req);
 	}
-	ioreq_fini(&req);
 
 	drain_single_pool_target(arg, ranks_to_kill[0], tgt, false);
+	memset(v_buffer, 'a', 5000);
+	for (i = 0; i < KEY_NR; i++) {
+		char	key[16];
+
+		sprintf(key, "dkey_4_%d", i);
+		memset(buffer, 0, 5000);
+		lookup_single(key, "a_key", 0, buffer, 5000, DAOS_TX_NONE,
+			      &req);
+		assert_memory_equal(v_buffer, buffer, 5000);
+	}
+
+	ioreq_fini(&req);
 }
 
 static void
@@ -507,17 +454,16 @@ drain_objects(void **state)
 		return;
 
 	for (i = 0; i < OBJ_NR; i++) {
-		oids[i] = daos_test_oid_gen(arg->coh, DAOS_OC_R3S_SPEC_RANK, 0,
+		oids[i] = daos_test_oid_gen(arg->coh, DAOS_OC_R1S_SPEC_RANK, 0,
 					    0, arg->myrank);
 		oids[i] = dts_oid_set_rank(oids[i], ranks_to_kill[0]);
 		oids[i] = dts_oid_set_tgt(oids[i], DEFAULT_FAIL_TGT);
 	}
 
 	rebuild_io(arg, oids, OBJ_NR);
-
 	drain_single_pool_target(arg, ranks_to_kill[0], tgt, false);
 
-	reintegrate_single_pool_target(arg, ranks_to_kill[0], tgt);
+	rebuild_io_validate(arg, oids, OBJ_NR);
 }
 
 /** create a new pool/container for each test */
@@ -532,15 +478,11 @@ static const struct CMUnitTest drain_tests[] = {
 	 drain_multiple, rebuild_small_sub_setup, test_teardown},
 	{"DRAIN5: drain large rec single index",
 	 drain_large_rec, rebuild_small_sub_setup, test_teardown},
-	{"DRAIN6: drain records with multiple snapshots",
-	 drain_snap_update_recs, rebuild_small_sub_setup, test_teardown},
-	{"DRAIN7: drain punch/records with multiple snapshots",
-	 drain_snap_punch_recs, rebuild_small_sub_setup, test_teardown},
-	{"DRAIN8: drain keys with multiple snapshots",
+	{"DRAIN7: drain keys with multiple snapshots",
 	 drain_snap_update_keys, rebuild_small_sub_setup, test_teardown},
-	{"DRAIN9: drain keys/punch with multiple snapshots",
+	{"DRAIN8: drain keys/punch with multiple snapshots",
 	 drain_snap_punch_keys, rebuild_small_sub_setup, test_teardown},
-	{"DRAIN10: drain multiple objects",
+	{"DRAIN9: drain multiple objects",
 	 drain_objects, rebuild_sub_setup, test_teardown},
 };
 

--- a/src/tests/suite/daos_rebuild.c
+++ b/src/tests/suite/daos_rebuild.c
@@ -63,10 +63,10 @@ rebuild_drop_scan(void **state)
 
 	MPI_Barrier(MPI_COMM_WORLD);
 	rebuild_single_pool_target(arg, ranks_to_kill[0], tgt, false);
-	rebuild_io_validate(arg, oids, OBJ_NR, true);
+	rebuild_io_verify(arg, oids, OBJ_NR);
 
 	reintegrate_single_pool_target(arg, ranks_to_kill[0], tgt);
-	rebuild_io_validate(arg, oids, OBJ_NR, true);
+	rebuild_io_verify(arg, oids, OBJ_NR);
 }
 
 static void
@@ -96,10 +96,10 @@ rebuild_retry_rebuild(void **state)
 				     0, NULL);
 	MPI_Barrier(MPI_COMM_WORLD);
 	rebuild_single_pool_target(arg, ranks_to_kill[0], tgt, false);
-	rebuild_io_validate(arg, oids, OBJ_NR, true);
+	rebuild_io_verify(arg, oids, OBJ_NR);
 
 	reintegrate_single_pool_target(arg, ranks_to_kill[0], tgt);
-	rebuild_io_validate(arg, oids, OBJ_NR, true);
+	rebuild_io_verify(arg, oids, OBJ_NR);
 }
 
 static void
@@ -132,10 +132,10 @@ rebuild_retry_for_stale_pool(void **state)
 
 	MPI_Barrier(MPI_COMM_WORLD);
 	rebuild_single_pool_rank(arg, ranks_to_kill[0], false);
-	rebuild_io_validate(arg, oids, OBJ_NR, true);
+	rebuild_io_verify(arg, oids, OBJ_NR);
 
 	reintegrate_single_pool_rank(arg, ranks_to_kill[0]);
-	rebuild_io_validate(arg, oids, OBJ_NR, true);
+	rebuild_io_verify(arg, oids, OBJ_NR);
 }
 
 static void
@@ -163,10 +163,10 @@ rebuild_drop_obj(void **state)
 				     0, NULL);
 	MPI_Barrier(MPI_COMM_WORLD);
 	rebuild_single_pool_rank(arg, ranks_to_kill[0], false);
-	rebuild_io_validate(arg, oids, OBJ_NR, true);
+	rebuild_io_verify(arg, oids, OBJ_NR);
 
 	reintegrate_single_pool_rank(arg, ranks_to_kill[0]);
-	rebuild_io_validate(arg, oids, OBJ_NR, true);
+	rebuild_io_verify(arg, oids, OBJ_NR);
 }
 
 static void
@@ -228,12 +228,12 @@ rebuild_multiple_pools(void **state)
 
 	rebuild_pools_ranks(args, 2, ranks_to_kill, 1, false);
 
-	rebuild_io_validate(args[0], oids, OBJ_NR, true);
-	rebuild_io_validate(args[1], oids, OBJ_NR, true);
+	rebuild_io_verify(args[0], oids, OBJ_NR);
+	rebuild_io_verify(args[1], oids, OBJ_NR);
 
 	reintegrate_pools_ranks(args, 2, ranks_to_kill, 1);
-	rebuild_io_validate(args[0], oids, OBJ_NR, true);
-	rebuild_io_validate(args[1], oids, OBJ_NR, true);
+	rebuild_io_verify(args[0], oids, OBJ_NR);
+	rebuild_io_verify(args[1], oids, OBJ_NR);
 
 	rebuild_pool_destroy(args[1]);
 }
@@ -470,10 +470,10 @@ rebuild_iv_tgt_fail(void **state)
 				     DAOS_FAIL_ONCE, 0, NULL);
 	MPI_Barrier(MPI_COMM_WORLD);
 	rebuild_single_pool_rank(arg, ranks_to_kill[0], false);
-	rebuild_io_validate(arg, oids, OBJ_NR, true);
+	rebuild_io_verify(arg, oids, OBJ_NR);
 
 	reintegrate_single_pool_rank(arg, ranks_to_kill[0]);
-	rebuild_io_validate(arg, oids, OBJ_NR, true);
+	rebuild_io_verify(arg, oids, OBJ_NR);
 }
 
 static void
@@ -679,7 +679,7 @@ rebuild_offline_pool_connect_internal(void **state, unsigned int fail_loc)
 	arg->rebuild_pre_cb = NULL;
 	arg->rebuild_cb = NULL;
 
-	rebuild_io_validate(arg, oids, OBJ_NR, true);
+	rebuild_io_verify(arg, oids, OBJ_NR);
 }
 
 static void
@@ -721,7 +721,7 @@ rebuild_offline(void **state)
 	arg->rebuild_pre_cb = NULL;
 	arg->rebuild_post_cb = NULL;
 
-	rebuild_io_validate(arg, oids, OBJ_NR, true);
+	rebuild_io_verify(arg, oids, OBJ_NR);
 }
 
 static void
@@ -794,7 +794,7 @@ rebuild_master_change_during_scan(void **state)
 	rebuild_single_pool_rank(arg, ranks_to_kill[0], false);
 
 	/* Verify the data */
-	rebuild_io_validate(arg, oids, OBJ_NR, true);
+	rebuild_io_verify(arg, oids, OBJ_NR);
 }
 
 static void
@@ -825,7 +825,7 @@ rebuild_master_change_during_rebuild(void **state)
 	rebuild_single_pool_rank(arg, ranks_to_kill[0], false);
 
 	/* Verify the data */
-	rebuild_io_validate(arg, oids, OBJ_NR, true);
+	rebuild_io_verify(arg, oids, OBJ_NR);
 }
 
 static int
@@ -881,10 +881,10 @@ rebuild_nospace(void **state)
 	rebuild_single_pool_rank(arg, ranks_to_kill[0], false);
 
 	arg->rebuild_cb = NULL;
-	rebuild_io_validate(arg, oids, OBJ_NR, true);
+	rebuild_io_verify(arg, oids, OBJ_NR);
 
 	reintegrate_single_pool_rank(arg, ranks_to_kill[0]);
-	rebuild_io_validate(arg, oids, OBJ_NR, true);
+	rebuild_io_verify(arg, oids, OBJ_NR);
 }
 
 static void
@@ -943,7 +943,7 @@ rebuild_multiple_tgts(void **state)
 		test_rebuild_wait(&arg, 1);
 
 	/* Verify the data */
-	rebuild_io_validate(arg, &oid, 1, true);
+	rebuild_io_verify(arg, &oid, 1);
 
 	daos_obj_layout_free(layout);
 
@@ -977,7 +977,7 @@ rebuild_io_post_cb(void *arg)
 	daos_obj_id_t	*oids = test_arg->rebuild_post_cb_arg;
 
 	if (daos_handle_is_valid(test_arg->coh))
-		rebuild_io_validate(test_arg, oids, OBJ_NR, true);
+		rebuild_io_verify(test_arg, oids, OBJ_NR);
 
 	return 0;
 }
@@ -1012,7 +1012,7 @@ rebuild_master_failure(void **state)
 	rebuild_single_pool_rank(arg, ranks_to_kill[0], true);
 
 	/* Verify the data */
-	rebuild_io_validate(arg, oids, 10 * OBJ_NR, true);
+	rebuild_io_verify(arg, oids, 10 * OBJ_NR);
 
 	/* Verify the POOL_QUERY get same rebuild status after leader change */
 	pinfo.pi_bits = DPI_REBUILD_STATUS;
@@ -1247,7 +1247,7 @@ multi_pools_rebuild_concurrently(void **state)
 			false);
 
 	for (i = POOL_NUM * CONT_PER_POOL - 1; i >= 0; i--)
-		rebuild_io_validate(args[i], oids, OBJ_PER_CONT, true);
+		rebuild_io_verify(args[i], oids, OBJ_PER_CONT);
 
 out:
 	for (i = POOL_NUM * CONT_PER_POOL - 1; i >= 0; i--)

--- a/src/tests/suite/daos_test.h
+++ b/src/tests/suite/daos_test.h
@@ -410,8 +410,8 @@ run_daos_sub_tests_only(char *test_name, const struct CMUnitTest *tests,
 			int tests_size, int *sub_tests, int sub_tests_size);
 
 void rebuild_io(test_arg_t *arg, daos_obj_id_t *oids, int oids_nr);
-void rebuild_io_validate(test_arg_t *arg, daos_obj_id_t *oids, int oids_nr,
-			 bool discard);
+void rebuild_io_validate(test_arg_t *arg, daos_obj_id_t *oids, int oids_nr);
+void rebuild_io_verify(test_arg_t *arg, daos_obj_id_t *oids, int oids_nr);
 void dfs_ec_rebuild_io(void **state, int *shards, int shards_nr);
 
 void rebuild_single_pool_target(test_arg_t *arg, d_rank_t failed_rank,


### PR DESCRIPTION
1. Update daos_drain_simple tests to use R1S to
focus on single replica drain.

2. Use grp_size instead of object replica number
to search the valid replicas.

3. Do not need fetch from leader for migration,
since we already do dtx resync before migration, and
also for single replica case, it will not be
able to find leader in this case.

4. Do not set po_rebuilding for drain case, otherwise
it will not be able to fetch anything during drain.

Signed-off-by: Di Wang <di.wang@intel.com>