### PR TITLE
DAOS-6898 systemd: Add missing line to pre230 systemd unit files

### DIFF
--- a/utils/systemd/daos_agent.service.pre230
+++ b/utils/systemd/daos_agent.service.pre230
@@ -14,6 +14,7 @@ StandardOutput=journal
 StandardError=journal
 Restart=always
 RestartSec=10
+LimitMEMLOCK=infinity
 LimitCORE=infinity
 StartLimitInterval=60
 StartLimitBurst=5


### PR DESCRIPTION
The LimitMEMLOCK=infinity line that was added to fix verbs support in
daos_agent landed after the file was copied to create the pre230 version of the
daos_agent service file. This adds the line into the pre230 version of the
daos_agent service file to get verbs working again by default on centos 7. This
change only affects the centos 7 builds.

Signed-off-by: David Quigley <david.quigley@intel.com>