### PR TITLE
DAOS-6721 build: Update submodule raft (#4589)

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+daos (1.1.3-4) unstable; urgency=medium
+  [ Li Wei ]
+  * Require raft-devel 0.7.3 that fixes an unstable leadership problem caused
+    by removed replicas as well as some Coverity issues
+
+ -- Li Wei <wei.g.li@intel.com> Tue, 02 Mar 2021 13:59:00 +0800
+
 daos (1.1.3-3) unstable; urgency=medium
   [ Brian J. Murrell ]
   * NOOP bump just to keep in parity with RPM changes

--- a/debian/control
+++ b/debian/control
@@ -29,7 +29,7 @@ Build-Depends: debhelper (>= 10),
                libboost-dev,
                libspdk-dev,
                libipmctl-dev,
-               libraft-dev (= 0.7.1-1378.g2f76d6b),
+               libraft-dev (= 0.7.3-1382.g3fa7f4e),
                python3-tabulate,
                liblz4-dev
 Standards-Version: 4.1.2

--- a/utils/rpms/daos.spec
+++ b/utils/rpms/daos.spec
@@ -7,7 +7,7 @@
 
 Name:          daos
 Version:       1.1.3
-Release:       3%{?relval}%{?dist}
+Release:       4%{?relval}%{?dist}
 Summary:       DAOS Storage Engine
 
 License:       BSD-2-Clause-Patent
@@ -51,7 +51,7 @@ BuildRequires: libisa-l_crypto-devel
 BuildRequires: libisal-devel
 BuildRequires: libisal_crypto-devel
 %endif
-BuildRequires: raft-devel = 0.7.1
+BuildRequires: raft-devel = 0.7.3
 BuildRequires: openssl-devel
 BuildRequires: libevent-devel
 BuildRequires: libyaml-devel
@@ -401,6 +401,10 @@ getent passwd daos_agent >/dev/null || useradd -s /sbin/nologin -r -g daos_agent
 %{_libdir}/*.a
 
 %changelog
+* Thu Mar 02 2021 Li Wei <wei.g.li@intel.com> 1.1.3-4
+- Require raft-devel 0.7.3 that fixes an unstable leadership problem caused by
+  removed replicas as well as some Coverity issues
+
 * Mon Feb 22 2021 Brian J. Murrell <brian.murrell@intel.com> 1.1.3-3
 - Remove all *-devel Requires from daos-devel as none of those are
   actually necessary to build libdaos clients


### PR DESCRIPTION
Update submodule raft to pick up a fix that avoids removed replicas from
disrupting current replicas as well as fixes for some Coverity issues.

Signed-off-by: Li Wei <wei.g.li@intel.com>