### PR TITLE
DAOS-6905 tests: Fixing false failures in llnl_mpi4py and romio tests…

### DIFF
--- a/src/tests/ftest/util/mpio_test_base.py
+++ b/src/tests/ftest/util/mpio_test_base.py
@@ -88,21 +88,18 @@ class MpiioTests(TestWithServers):
 
         try:
             # running tests
-            self.mpio.run_mpiio_tests(
+            result = self.mpio.run_mpiio_tests(
                 self.hostfile_clients, self.pool.uuid, test_repo, test_name,
                 client_processes, self.cont_uuid)
         except MpioFailed as excep:
             self.fail("<{0} Test Failed> \n{1}".format(test_name, excep))
 
-        # Parsing output to look for failures
-        # stderr directed to stdout
-        stdout = os.path.join(self.logdir, "stdout")
-        searchfile = open(stdout, "r")
-        error_message = ["non-zero exit code", "MPI_Abort", "MPI_ABORT",
-                         "ERROR"]
-
-        for line in searchfile:
-            for error in error_message:
-                if error in line:
-                    self.fail(
-                        "Test Failed with error_message: {}".format(error))
+        # Check output for errors
+        error_message = [
+            "non-zero exit code", "MPI_Abort", "MPI_ABORT", "ERROR"]
+        for output in (result.stdout, result.stderr):
+            for line in output:
+                for error in error_message:
+                    if error in line:
+                        self.fail(
+                            "Test Failed with error_message: {}".format(error))

--- a/src/tests/ftest/util/mpio_utils.py
+++ b/src/tests/ftest/util/mpio_utils.py
@@ -75,6 +75,10 @@ class MpioUtils():
         Raises:
             MpioFailed: for an invalid test name or test execution failure
 
+        Return:
+            CmdResult: an avocado.utils.process CmdResult object containing the
+                result of the command execution.
+
         """
         print("self.mpichinstall: {}".format(self.mpichinstall))
 
@@ -133,8 +137,11 @@ class MpioUtils():
         for command in commands:
             print("run command: {}".format(command))
             try:
-                run_command(command, timeout=None, verbose=True, env=env)
+                result = run_command(
+                    command, timeout=None, verbose=True, env=env)
 
             except DaosTestError as excep:
                 raise MpioFailed(
                     "<Test FAILED> \nException occurred: {}".format(str(excep)))
+
+        return result


### PR DESCRIPTION
… (#4825)

Checking for command failures in the command output rather thean the
entire stdout for the MpiioTests-based tests.

Quick-Functional: true
Test-tag-vm: llnlmpi4pyhdf5,-hw llnl,-hw romio,-hw
Test-tag-hw-small: llnlmpi4pyhdf5,hw,small llnl,hw,small romio,hw,small
Skip-func-hw-test-medium: true
Skip-func-hw-test-large: true

Signed-off-by: Phillip Henderson <phillip.henderson@intel.com>