### PR TITLE
DAOS-6916 test: Fix ior/ior_intercept_verify_data_integrity.py in weekly

### DIFF
--- a/src/tests/ftest/ior/ior_intercept_verify_data_integrity.py
+++ b/src/tests/ftest/ior/ior_intercept_verify_data_integrity.py
@@ -35,8 +35,9 @@ class IorInterceptVerifyDataIntegrity(IorTestBase):
             Run ior with read, write, read verify
             write verify for 30 minutes
 
-        :avocado: tags=all,full_regression,hw,large
-        :avocado: tags=daosio,iorinterceptverifydata
+        :avocado: tags=all,full_regression
+        :avocado: tags=hw,large
+        :avocado: tags=daos_io,ior_intercept_verify_data
         """
         intercept = os.path.join(self.prefix, 'lib64', 'libioil.so')
         with_intercept = dict()

--- a/src/tests/ftest/ior/ior_intercept_verify_data_integrity.yaml
+++ b/src/tests/ftest/ior/ior_intercept_verify_data_integrity.yaml
@@ -31,6 +31,7 @@ pool:
         nvme_size: 200000000000
     createsvc:
         svcn: 1
+    control_method: dmg
 container:
     type: POSIX
     control_method: daos


### PR DESCRIPTION
Added control_method: dmg to yaml.
Also refactored tags.

Quick-build: true
Skip-unit-tests: true
Test-tag: ior_intercept_verify_data
Signed-off-by: Makito Kano <makito.kano@intel.com>