### PR TITLE
DAOS-6923 test: Offline Reintegration - More tests

### DIFF
--- a/src/tests/ftest/osa/osa_offline_reintegration.yaml
+++ b/src/tests/ftest/osa/osa_offline_reintegration.yaml
@@ -78,3 +78,9 @@ ior:
     #    The values are set to be in the multiples of 10.
     #    Values are appx GB.
       - [6000000000, 54000000000, 500000, 500000000]
+test_obj_class:
+    oclass:
+      - RP_2G8
+      - RP_3G6
+      - EC_2P2G4
+      - RP_4G1

--- a/src/tests/ftest/util/osa_utils.py
+++ b/src/tests/ftest/util/osa_utils.py
@@ -6,6 +6,7 @@
 """
 import ctypes
 import time
+import threading
 
 from avocado import fail_on
 from ior_test_base import IorTestBase
@@ -15,6 +16,14 @@ from job_manager_utils import Mpirun
 from mpio_utils import MpioUtils
 from pydaos.raw import (DaosContainer, IORequest,
                         DaosObj, DaosApiError)
+
+try:
+    # python 3.x
+    import queue as queue
+except ImportError:
+    # python 2.7
+    import Queue as queue
+
 
 class OSAUtils(IorTestBase):
     # pylint: disable=too-many-ancestors
@@ -37,6 +46,10 @@ class OSAUtils(IorTestBase):
                                            default=[0])[0]
         self.record_length = self.params.get("length", '/run/record/*',
                                              default=[0])[0]
+        self.ior_w_flags = self.params.get("write_flags", '/run/ior/iorflags/*',
+                                           default="")
+        self.ior_r_flags = self.params.get("read_flags", '/run/ior/iorflags/*')
+        self.out_queue = queue.Queue()
 
     @fail_on(CommandFailure)
     def get_pool_leader(self):
@@ -162,6 +175,36 @@ class OSAUtils(IorTestBase):
                                       "akey {0}".format(akey)))
         self.obj.close()
         self.container.close()
+
+    def run_ior_thread(self, action, oclass, api, test):
+        """Start the IOR thread for either writing or
+        reading data to/from a container.
+        Args:
+            action (str): Start the IOR thread with Read or
+                          Write
+            oclass (str): IOR object class
+            API (str): IOR API
+            test (list): IOR test sequence
+            flags (str): IOR flags
+        """
+        if action == "Write":
+            flags = self.ior_w_flags
+        else:
+            flags = self.ior_r_flags
+
+        # Add a thread for these IOR arguments
+        process = threading.Thread(target=self.ior_thread,
+                                   kwargs={"pool": self.pool,
+                                           "oclass": oclass,
+                                           "api": api,
+                                           "test": test,
+                                           "flags": flags,
+                                           "results":
+                                           self.out_queue})
+        # Launch the IOR thread
+        process.start()
+        # Wait for the thread to finish
+        process.join()
 
     def ior_thread(self, pool, oclass, api, test, flags, results):
         """Start threads and wait until all threads are finished.


### PR DESCRIPTION
Test-tag-hw-medium: pr,hw,medium,ib2 offline_reintegration

Summary:
   - Moved some more common files to osa_utils.py
   - Added the 200 pool test method
   - Test with different object class
   - More ranks excluded and reintegrated

Signed-off-by: rpadma2 <ravindran.padmanabhan@intel.com>