### PR TITLE
DAOS-6918-test: pool destroy-test destroymutliloop

### DIFF
--- a/src/tests/ftest/pool/destroy_tests.yaml
+++ b/src/tests/ftest/pool/destroy_tests.yaml
@@ -13,7 +13,7 @@ setup:
   start_servers_once: False
 server_config:
   name: daos_server
-timeout: 60
+timeout: 120
 pool:
   mode: 146
   name: daos_server


### PR DESCRIPTION
DAOS-6918-test pool destroy-test destroymutliloop

updated: pool/destroy_tests.yaml
Quick-Functional: true
Skip-unit-test: true
Test-tag: destroysingleloop destroymutliloop
Signed-off-by: Ding Ho <ding-hwa.ho@intel.com>