### PR TITLE
Revert "DAOS-6799 log: Add D_LOG_FLUSH envariable"

### DIFF
--- a/src/cart/README.env
+++ b/src/cart/README.env
@@ -64,11 +64,6 @@ This file lists the environment variables used in CaRT.
    set ("D_LOG_MASK=DEBUG"), otherwise other priorities take precedence. The bit
    streams are passed as a parameter to D_DEBUG(mask, fmt, ...).
 
- . D_LOG_FLUSH
-   Specifies priority level for flushing of messages into the log file.
-   Can be set to one of the following "DBUG,INFO,NOTE,WARN,ERR,CRIT,ALRT,EMRG,EMIT"
-   If not set will default to "WARN".
-
  . DD_STDERR
    User can specify the priority level to output to stderr, for example:
    "DD_STDERR="info"" will log all DLOG_INFO priority messages to stderr.

--- a/src/cart/crt_init.c
+++ b/src/cart/crt_init.c
@@ -27,7 +27,7 @@ dump_envariables(void)
 		"OFI_PORT", "OFI_INTERFACE", "OFI_DOMAIN", "CRT_CREDIT_EP_CTX",
 		"CRT_CTX_SHARE_ADDR", "CRT_CTX_NUM", "D_FI_CONFIG",
 		"FI_UNIVERSE_SIZE", "CRT_DISABLE_MEM_PIN",
-		"FI_OFI_RXM_USE_SRX", "D_LOG_FLUSH", "CRT_MRC_ENABLE" };
+		"FI_OFI_RXM_USE_SRX" };
 
 	D_INFO("-- ENVARS: --\n");
 	for (i = 0; i < ARRAY_SIZE(envars); i++) {

--- a/src/gurt/dlog.c
+++ b/src/gurt/dlog.c
@@ -78,7 +78,6 @@ struct d_log_state {
 	struct utsname uts;	/* for hostname, from uname(3) */
 	int stdout_isatty;	/* non-zero if stdout is a tty */
 	int stderr_isatty;	/* non-zero if stderr is a tty */
-	int flush_pri;		/* flush priority */
 #ifdef DLOG_MUTEX
 	pthread_mutex_t clogmux;	/* protect clog in threaded env */
 #endif
@@ -637,10 +636,7 @@ void d_vlog(int flags, const char *fmt, va_list ap)
 	 * NB: flush to logfile if the message is important (warning/error...)
 	 * or the last flush was 1+ second ago.
 	 */
-	if (mst.flush_pri == DLOG_DBG)
-		flush = true;
-	else
-		flush = (lvl >= mst.flush_pri) || (tv.tv_sec > last_flush);
+	flush = (lvl >= DLOG_WARN) || (tv.tv_sec > last_flush);
 	if (flush)
 		last_flush = tv.tv_sec;
 
@@ -766,23 +762,12 @@ int
 d_log_open(char *tag, int maxfac_hint, int default_mask, int stderr_mask,
 	   char *logfile, int flags)
 {
-	int		tagblen;
-	char		*newtag = NULL, *cp;
-	int		truncate = 0, rc;
-	char		*env;
-	char		*buffer = NULL;
-	uint64_t	log_size = LOG_SIZE_DEF;
-	int		pri;
-
-	mst.flush_pri = DLOG_WARN;
-
-	env = getenv(D_LOG_FLUSH_ENV);
-	if (env) {
-		pri = d_log_str2pri(env, strlen(env) + 1);
-
-		if (pri != -1)
-			mst.flush_pri = pri;
-	}
+	int	tagblen;
+	char	*newtag = NULL, *cp;
+	int	truncate = 0, rc;
+	char	*env;
+	char	*buffer = NULL;
+	uint64_t log_size = LOG_SIZE_DEF;
 
 	env = getenv(D_LOG_TRUNCATE_ENV);
 	if (env != NULL && atoi(env) > 0)

--- a/src/include/gurt/debug.h
+++ b/src/include/gurt/debug.h
@@ -53,9 +53,6 @@ extern void (*d_alt_assert)(const int, const char*, const char*, const int);
 
 #define D_LOG_TRUNCATE_ENV		"D_LOG_TRUNCATE"
 
-/**< Env to specify flush priority */
-#define D_LOG_FLUSH_ENV			"D_LOG_FLUSH"
-
 /**< Env to specify stderr merge with logfile*/
 #define D_LOG_STDERR_IN_LOG_ENV	"D_LOG_STDERR_IN_LOG"
 


### PR DESCRIPTION
Reverts daos-stack/daos#4728

mst.flush_pri is being set before mst is memset to zero, and I don't think d_log_str2pri is returning what you expect either, I appears to be returning 0x3000000 when later on it's compared to lvl which is typically 400 or 10000 so I think there's a mask or shifting that needs to be made here.