### PR TITLE
DAOS-5737 tests: Removing oclass param from create_cont() (#4729)

### DIFF
--- a/src/tests/ftest/container/multiple_container_delete.py
+++ b/src/tests/ftest/container/multiple_container_delete.py
@@ -81,6 +81,7 @@ class MultipleContainerDelete(IorTestBase):
         """
         if self.pool is not None:
             scm_index, ssd_index = 0, 1
+            self.pool.connect()
             pool_info = self.pool.pool.pool_query()
             scm_fs = pool_info.pi_space.ps_space.s_free[scm_index]
             ssd_fs = pool_info.pi_space.ps_space.s_free[ssd_index]

--- a/src/tests/ftest/io/io_aggregation.yaml
+++ b/src/tests/ftest/io/io_aggregation.yaml
@@ -28,6 +28,7 @@ pool:
     nvme_size: 10000000000
   createsvc:
     svcn: 1
+  control_method: dmg
 container:
   type: POSIX
   control_method: daos

--- a/src/tests/ftest/util/ior_test_base.py
+++ b/src/tests/ftest/util/ior_test_base.py
@@ -65,21 +65,14 @@ class IorTestBase(DfuseTestBase):
         # Create a pool
         self.pool.create()
 
-    def create_cont(self, oclass):
+    def create_cont(self):
         """Create a TestContainer object to be used to create container.
 
-        Args:
-            oclass: Explicitly supply object class for container create
         """
         # Get container params
         self.container = TestContainer(
             self.pool, daos_command=DaosCommand(self.bin))
         self.container.get_params(self)
-
-        # update object class for container create, if supplied
-        # explicitly.
-        if oclass:
-            self.container.oclass.update(oclass)
 
         # create container
         self.container.create()
@@ -164,12 +157,11 @@ class IorTestBase(DfuseTestBase):
 
         return out
 
-    def update_ior_cmd_with_pool(self, create_cont=True, oclass=None):
+    def update_ior_cmd_with_pool(self, create_cont=True):
         """Update ior_cmd with pool.
 
         Args:
           create_cont (bool, optional): create a container. Defaults to True.
-          oclass (string, optional): Specify object class
         """
         # Create a pool if one does not already exist
         if self.pool is None:
@@ -179,7 +171,7 @@ class IorTestBase(DfuseTestBase):
         # It will not enable checksum feature
         if create_cont:
             self.pool.connect()
-            self.create_cont(oclass)
+            self.create_cont()
         # Update IOR params with the pool and container params
         self.ior_cmd.set_daos_params(self.server_group, self.pool,
                                      self.container.uuid)


### PR DESCRIPTION
Removing oclass param from create_cont() inside
ftest/util/ior_test_base.py as it is breaking some
of the weekly tests.
The change was earlier added to the code for datamover
tests which now use an overriden version of this method.

Hence 'oclass' param is not needed anymore andn ot used
anywhere else.

Test-tag-hw-small: pr,hw,small dfusespacecheck ioaggregation dfusesparsefile
Test-tag-hw-large: pr,hw,large multicontainerdelete

Signed-off-by: Saurabh Tandan <saurabh.tandan@intel.com>