### PR TITLE
DAOS-6726 engine: Resolve two leaks in the drpc code. (#4782)

### DIFF
--- a/src/engine/drpc_client.c
+++ b/src/engine/drpc_client.c
@@ -298,18 +298,20 @@ ds_get_pool_svc_ranks(uuid_t pool_uuid, d_rank_list_t **svc_ranks)
 	if (gps_resp->status != 0) {
 		D_ERROR("failure fetching svc_ranks for "DF_UUID": "DF_RC"\n",
 			DP_UUID(pool_uuid), DP_RC(gps_resp->status));
-		D_GOTO(out_dresp, rc = gps_resp->status);
+		D_GOTO(out_resp, rc = gps_resp->status);
 	}
 
 	ranks = uint32_array_to_rank_list(gps_resp->svcreps,
 					  gps_resp->n_svcreps);
 	if (ranks == NULL)
-		D_GOTO(out_dresp, rc = -DER_NOMEM);
+		D_GOTO(out_resp, rc = -DER_NOMEM);
 
 	D_DEBUG(DB_MGMT, "fetched %d svc_ranks for "DF_UUID"\n",
 		ranks->rl_nr, DP_UUID(pool_uuid));
 	*svc_ranks = ranks;
 
+out_resp:
+	srv__get_pool_svc_resp__free_unpacked(gps_resp, &alloc.alloc);
 out_dresp:
 	drpc_response_free(dresp);
 out_req:

--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -2826,6 +2826,7 @@ out:
 	D_DEBUG(DF_DSMS, DF_UUID": replying rpc %p: "DF_RC"\n",
 		DP_UUID(in->pqi_op.pi_uuid), rpc, DP_RC(rc));
 	crt_reply_send(rpc);
+	daos_prop_free(prop);
 }
 
 /* Convert pool_comp_state_t to daos_target_state_t */


### PR DESCRIPTION
The normal code-paths for two entries was not cleaning up resources
leading to small leaks every time a pool was queried.

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>