### PR TITLE
DAOS-6891 control: Clean up JSON output for errors

### DIFF
--- a/src/control/cmd/dmg/cont.go
+++ b/src/control/cmd/dmg/cont.go
@@ -53,10 +53,6 @@ func (c *ContSetOwnerCmd) Execute(args []string) error {
 		msg = errors.WithMessage(err, "FAILED").Error()
 	}
 
-	if c.jsonOutputEnabled() {
-		return c.errorJSON(err)
-	}
-
 	c.log.Infof("Container-set-owner command %s\n", msg)
 
 	return err

--- a/src/control/cmd/dmg/pool.go
+++ b/src/control/cmd/dmg/pool.go
@@ -211,11 +211,6 @@ func (cmd *PoolDestroyCmd) Execute(args []string) error {
 
 	ctx := context.Background()
 	err := control.PoolDestroy(ctx, cmd.ctlInvoker, req)
-
-	if cmd.jsonOutputEnabled() {
-		return cmd.errorJSON(err)
-	}
-
 	if err != nil {
 		msg = errors.WithMessage(err, "failed").Error()
 	}
@@ -244,11 +239,6 @@ func (cmd *PoolEvictCmd) Execute(args []string) error {
 
 	ctx := context.Background()
 	err := control.PoolEvict(ctx, cmd.ctlInvoker, req)
-
-	if cmd.jsonOutputEnabled() {
-		return cmd.errorJSON(err)
-	}
-
 	if err != nil {
 		msg = errors.WithMessage(err, "failed").Error()
 	}
@@ -282,11 +272,6 @@ func (cmd *PoolExcludeCmd) Execute(args []string) error {
 
 	ctx := context.Background()
 	err := control.PoolExclude(ctx, cmd.ctlInvoker, req)
-
-	if cmd.jsonOutputEnabled() {
-		return cmd.errorJSON(err)
-	}
-
 	if err != nil {
 		msg = errors.WithMessage(err, "failed").Error()
 	}
@@ -314,9 +299,6 @@ func (cmd *PoolDrainCmd) Execute(args []string) error {
 	var idxlist []uint32
 	if err := common.ParseNumberList(cmd.Targetidx, &idxlist); err != nil {
 		err = errors.WithMessage(err, "parsing rank list")
-		if cmd.jsonOutputEnabled() {
-			return cmd.errorJSON(err)
-		}
 		return err
 	}
 
@@ -324,11 +306,6 @@ func (cmd *PoolDrainCmd) Execute(args []string) error {
 
 	ctx := context.Background()
 	err := control.PoolDrain(ctx, cmd.ctlInvoker, req)
-
-	if cmd.jsonOutputEnabled() {
-		return cmd.errorJSON(err)
-	}
-
 	if err != nil {
 		msg = errors.WithMessage(err, "failed").Error()
 	}
@@ -359,9 +336,6 @@ func (cmd *PoolExtendCmd) Execute(args []string) error {
 	ranks, err := system.ParseRanks(cmd.RankList)
 	if err != nil {
 		err = errors.Wrap(err, "parsing rank list")
-		if cmd.jsonOutputEnabled() {
-			return cmd.errorJSON(err)
-		}
 		return err
 	}
 
@@ -388,11 +362,6 @@ func (cmd *PoolExtendCmd) Execute(args []string) error {
 
 	ctx := context.Background()
 	err = control.PoolExtend(ctx, cmd.ctlInvoker, req)
-
-	if cmd.jsonOutputEnabled() {
-		return cmd.errorJSON(err)
-	}
-
 	if err != nil {
 		msg = errors.WithMessage(err, "failed").Error()
 	}
@@ -420,9 +389,6 @@ func (cmd *PoolReintegrateCmd) Execute(args []string) error {
 	var idxlist []uint32
 	if err := common.ParseNumberList(cmd.Targetidx, &idxlist); err != nil {
 		err = errors.WithMessage(err, "parsing rank list")
-		if cmd.jsonOutputEnabled() {
-			return cmd.errorJSON(err)
-		}
 		return err
 	}
 
@@ -430,11 +396,6 @@ func (cmd *PoolReintegrateCmd) Execute(args []string) error {
 
 	ctx := context.Background()
 	err := control.PoolReintegrate(ctx, cmd.ctlInvoker, req)
-
-	if cmd.jsonOutputEnabled() {
-		return cmd.errorJSON(err)
-	}
-
 	if err != nil {
 		msg = errors.WithMessage(err, "failed").Error()
 	}
@@ -605,9 +566,6 @@ func (cmd *PoolOverwriteACLCmd) Execute(args []string) error {
 
 	acl, err := control.ReadACLFile(cmd.ACLFile)
 	if err != nil {
-		if cmd.jsonOutputEnabled() {
-			return cmd.errorJSON(err)
-		}
 		return err
 	}
 
@@ -656,9 +614,6 @@ func (cmd *PoolUpdateACLCmd) Execute(args []string) error {
 	if cmd.ACLFile != "" {
 		aclFileResult, err := control.ReadACLFile(cmd.ACLFile)
 		if err != nil {
-			if cmd.jsonOutputEnabled() {
-				return cmd.errorJSON(err)
-			}
 			return err
 		}
 		acl = aclFileResult

--- a/src/control/cmd/dmg/storage.go
+++ b/src/control/cmd/dmg/storage.go
@@ -48,9 +48,6 @@ type storagePrepareCmd struct {
 func (cmd *storagePrepareCmd) Execute(args []string) error {
 	prepNvme, prepScm, err := cmd.Validate()
 	if err != nil {
-		if cmd.jsonOutputEnabled() {
-			return cmd.errorJSON(err)
-		}
 		return err
 	}
 
@@ -67,7 +64,7 @@ func (cmd *storagePrepareCmd) Execute(args []string) error {
 
 	if prepScm {
 		if cmd.jsonOutputEnabled() && !cmd.Force {
-			return cmd.errorJSON(errors.New("Cannot use --json without --force"))
+			return errors.New("Cannot use --json without --force")
 		}
 		if err := cmd.Warn(cmd.log); err != nil {
 			return err
@@ -252,9 +249,6 @@ func (cmd *storageFormatCmd) Execute(args []string) (err error) {
 
 	sysReformat, err := cmd.shouldReformatSystem(ctx)
 	if err != nil {
-		if cmd.jsonOutputEnabled() {
-			return cmd.errorJSON(err)
-		}
 		return err
 	}
 	if sysReformat {
@@ -308,7 +302,7 @@ func (cmd *nvmeSetFaultyCmd) Execute(_ []string) error {
 	cmd.log.Info("WARNING: This command will permanently mark the device as unusable!")
 	if !cmd.Force {
 		if cmd.jsonOutputEnabled() {
-			return cmd.errorJSON(errors.New("Cannot use --json without --force"))
+			return errors.New("Cannot use --json without --force")
 		}
 		if !common.GetConsent(cmd.log) {
 			return errors.New("consent not given")


### PR DESCRIPTION
Rather than handling errors piecemeal, centralize the
decision about whether or not an error should be formatted
as JSON.

Master-PR: https://github.com/daos-stack/daos/pull/4804