### PR TITLE
DAOS-6929 Java: Update Hadoop dependency from 3.1.3 to 3.2.2 (#4844)

### DIFF
--- a/src/client/java/hadoop-daos/pom.xml
+++ b/src/client/java/hadoop-daos/pom.xml
@@ -15,7 +15,7 @@
   <packaging>jar</packaging>
 
   <properties>
-    <hadoop.version>3.1.3</hadoop.version>
+    <hadoop.version>3.2.2</hadoop.version>
     <native.build.path>${project.basedir}/build</native.build.path>
     <daos.install.path>${project.basedir}/install</daos.install.path>
   </properties>


### PR DESCRIPTION
Snyk updated its recommendation again to upgrade from 3.1.3 to 3.2.1 so we are
updating to the latest which is 3.2.2

Signed-off-by: David Quigley <david.quigley@intel.com>

Master-PR: https://github.com/daos-stack/daos/pull/4844