### PR TITLE
DAOS-6959 control: generate spdk json conf on start-up

### DIFF
--- a/src/control/server/storage/bdev/backend_json.go
+++ b/src/control/server/storage/bdev/backend_json.go
@@ -1,0 +1,113 @@
+//
+// (C) Copyright 2021 Intel Corporation.
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+
+package bdev
+
+import (
+	"fmt"
+
+	"github.com/dustin/go-humanize"
+)
+
+// SPDK bdev subsystem configuration method name definitions.
+const (
+	BdevSetOptions           = "bdev_set_options"
+	BdevNvmeSetOptions       = "bdev_nvme_set_options"
+	BdevNvmeAttachController = "bdev_nvme_attach_controller"
+	BdevNvmeSetHotplug       = "bdev_nvme_set_hotplug"
+)
+
+// SpdkSubsystemConfigParams can apply to any SpdkSubsystemConfig method.
+type SpdkSubsystemConfigParams struct {
+	BdevIoPoolSize           uint64 `json:"bdev_io_pool_size,omitempty"`
+	BdevIoCacheSize          uint64 `json:"bdev_io_cache_size,omitempty"`
+	RetryCount               uint32 `json:"retry_count,omitempty"`
+	TimeoutUsec              uint64 `json:"timeout_us,omitempty"`
+	NvmeAdminqPollPeriodUsec uint32 `json:"nvme_adminq_poll_period_us,omitempty"`
+	ActionOnTimeout          string `json:"action_on_timeout,omitempty"`
+	NvmeIoqPollPeriodUsec    uint32 `json:"nvme_ioq_poll_period_us,omitempty"`
+	TransportType            string `json:"trtype,omitempty"`
+	DeviceName               string `json:"name,omitempty"`
+	TransportAddress         string `json:"traddr,omitempty"`
+	Enable                   bool   `json:"enable,omitempty"`
+	PeriodUsec               uint64 `json:"period_us,omitempty"`
+}
+
+// SpdkSubsystemConfig entries apply to any SpdkSubsystem.
+type SpdkSubsystemConfig struct {
+	Params SpdkSubsystemConfigParams `json:"params"`
+	Method string                    `json:"method"`
+}
+
+// SpdkSubsystem entries make up the Subsystems field of a SpdkConfig.
+type SpdkSubsystem struct {
+	Name    string                 `json:"subsystem"`
+	Configs []*SpdkSubsystemConfig `json:"config"`
+}
+
+// SpdkConfig is used to indicate which devices are to be used by SPDK and the
+// desired behaviour of SPDK subsystems.
+type SpdkConfig struct {
+	Subsystems []*SpdkSubsystem `json:"subsystems"`
+}
+
+func defaultSpdkConfig() *SpdkConfig {
+	bdevSubsystemConfigs := []*SpdkSubsystemConfig{
+		{
+			Method: BdevSetOptions,
+			Params: SpdkSubsystemConfigParams{
+				BdevIoPoolSize:  humanize.KiByte * 64,
+				BdevIoCacheSize: 256,
+			},
+		},
+		{
+			Method: BdevNvmeSetOptions,
+			Params: SpdkSubsystemConfigParams{
+				RetryCount:               4,
+				NvmeAdminqPollPeriodUsec: 100 * 1000,
+				ActionOnTimeout:          "none",
+			},
+		},
+		{
+			Method: BdevNvmeSetHotplug,
+			Params: SpdkSubsystemConfigParams{
+				PeriodUsec: 10 * 1000 * 1000,
+			},
+		},
+	}
+
+	subsystems := []*SpdkSubsystem{
+		{
+			Name:    "bdev",
+			Configs: bdevSubsystemConfigs,
+		},
+	}
+
+	return &SpdkConfig{
+		Subsystems: subsystems,
+	}
+}
+
+func newNvmeSpdkConfig(deviceList []string, host string) *SpdkConfig {
+	var sscs []*SpdkSubsystemConfig
+	for i, d := range deviceList {
+		sscs = append(sscs, &SpdkSubsystemConfig{
+			Method: BdevNvmeAttachController,
+			Params: SpdkSubsystemConfigParams{
+				TransportType:    "PCIe",
+				DeviceName:       fmt.Sprintf("Nvme_%s_%d", host, i),
+				TransportAddress: d,
+			},
+		})
+	}
+
+	sc := defaultSpdkConfig()
+	// default spdk config will have only one bdev subsystem, append device
+	// attach config method calls
+	sc.Subsystems[0].Configs = append(sc.Subsystems[0].Configs, sscs...)
+
+	return sc
+}

--- a/src/control/server/storage/bdev/backend_test.go
+++ b/src/control/server/storage/bdev/backend_test.go
@@ -333,6 +333,7 @@ func TestBackend_Format(t *testing.T) {
 			defer common.ShowBufferOnFailure(t, buf)
 
 			b := backendWithMockBinding(log, tc.mec, tc.mnc)
+			b.script = mockScriptRunner(log)
 
 			// output path would be set during config validate
 			tc.req.ConfigPath = filepath.Join(testDir, storage.BdevOutConfName)

--- a/src/control/server/storage/bdev/runner_test.go
+++ b/src/control/server/storage/bdev/runner_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 	"os/user"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -17,6 +18,22 @@ import (
 	"github.com/daos-stack/daos/src/control/common"
 	"github.com/daos-stack/daos/src/control/logging"
 )
+
+func mockRun(log logging.Logger, env []string, cmdStr string, args ...string) (string, error) {
+	log.Debugf("running: %s", cmdStr+" "+strings.Join(args, " "))
+	return "", nil
+}
+
+func mockScriptRunner(log logging.Logger) *spdkSetupScript {
+	return &spdkSetupScript{
+		log:    log,
+		runCmd: mockRun,
+	}
+}
+
+func defaultBackendWithMockRunner(log logging.Logger) *spdkBackend {
+	return newBackend(log, mockScriptRunner(log))
+}
 
 func TestRunner_Prepare(t *testing.T) {
 	const (


### PR DESCRIPTION
Write JSON NVMe SPDK configuration file on storage format. The file is
to be consumed by SPDK running in the DAOS engine to indicate which
devices and what behaviour to apply to the SPDK subsystems (e.g. bdev).
Producing this format of configuration file is a prerequisite task to be
completed before being able to upgrade from v20 to v21 of SPDK.

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>