### PR TITLE
CORCI-1055: Turn of clamAV scanning by default

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -365,7 +365,7 @@ boolean skip_test_rpms_centos7() {
 
 boolean skip_scan_rpms_centos7() {
     return target_branch == 'weekly-testing' ||
-           skip_stage('scan-centos-rpms') ||
+           skip_stage('scan-centos-rpms', true) ||
            quick_functional()
 }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -462,7 +462,8 @@ boolean skip_unit_testing_stage() {
 
 boolean skip_coverity() {
     return skip_stage('coverity-test') ||
-           quick_functional()
+           quick_functional() ||
+           skip_stage('build')
 }
 
 boolean skip_testing_stage() {


### PR DESCRIPTION
ClamAV seems to have implemented some type of throttle so turning off
by default until the scans can use a local mirror.

Skip-checkpatch: true
Skip-build: true
Skip-test-centos-rpms: true
Skip-func-test: true
Skip-unit-tests: true

Signed-off-by: John E Malmberg <john.e.malmberg@intel.com>