### PR TITLE
DAOS-6798 test: re-enable mdtest_small on PRs

### DIFF
--- a/src/tests/ftest/mdtest/mdtest_small.py
+++ b/src/tests/ftest/mdtest/mdtest_small.py
@@ -31,7 +31,7 @@ class MdtestSmall(MdtestBase):
             read bytes: 0|4K
             depth of hierarchical directory structure: 0|5
 
-        :avocado: tags=all,daily_regression,hw,large,mdtest,mdtestsmall
+        :avocado: tags=all,pr,daily_regression,hw,large,mdtest,mdtestsmall
         :avocado: tags=DAOS_5610
         """
         # local params


### PR DESCRIPTION
Add the pr avocado tag to the test after PR #4827 landed a solution
for pool destroy timeouts.

Quick-Functional: true
Test-tag: mdtestsmall

Signed-off-by: Kenneth Cain <kenneth.c.cain@intel.com>