### PR TITLE
DAOS-6464 tests: add extend simple test (#4837)

### DIFF
--- a/src/pool/srv_iv.c
+++ b/src/pool/srv_iv.c
@@ -523,7 +523,8 @@ pool_iv_map_ent_fetch(d_sg_list_t *dst_sgl, struct pool_iv_entry *src_iv)
 	dst_iv = dst_sgl->sg_iovs[0].iov_buf;
 	if (src_iv->piv_map.piv_pool_buf.pb_target_nr == (uint32_t)(-1)) {
 		memcpy(&dst_iv->piv_map.piv_pool_buf,
-		       &src_iv->piv_map.piv_pool_buf, sizeof(*src_iv));
+		       &src_iv->piv_map.piv_pool_buf,
+		       sizeof(src_iv->piv_map.piv_pool_buf));
 		return -DER_IVCB_FORWARD;
 	}
 
@@ -564,7 +565,8 @@ pool_iv_map_ent_update(d_sg_list_t *dst_sgl, struct pool_iv_entry *src_iv)
 		 * be called to store these -1 entry.
 		 **/
 		memcpy(&dst_iv->piv_map.piv_pool_buf,
-		       &src_iv->piv_map.piv_pool_buf, sizeof(*src_iv));
+		       &src_iv->piv_map.piv_pool_buf,
+		       sizeof(src_iv->piv_map.piv_pool_buf));
 		return 0;
 	}
 
@@ -573,7 +575,7 @@ pool_iv_map_ent_update(d_sg_list_t *dst_sgl, struct pool_iv_entry *src_iv)
 	src_pbuf_size = pool_buf_size(pb_nr);
 	dst_pbuf_size = dst_sgl->sg_iovs[0].iov_buf_len -
 			sizeof(struct pool_iv_map) + sizeof(struct pool_buf);
-	if (src_pbuf_size < dst_pbuf_size) {
+	if (src_pbuf_size > dst_pbuf_size) {
 		void *new_buf;
 		uint32_t new_size;
 

--- a/src/tests/ftest/daos_test/daos_core_test.yaml
+++ b/src/tests/ftest/daos_test/daos_core_test.yaml
@@ -108,6 +108,7 @@ daos_tests:
     test_daos_md_replication: DAOS_MD_Replication
     test_daos_rebuild_simple: DAOS_Rebuild_Simple
     test_daos_drain_simple: DAOS_Drain_Simple
+    test_daos_extend_simple: DAOS_Extend_Simple
     test_daos_oid_allocator: DAOS_OID_Allocator
     test_daos_checksum: DAOS_Checksum
     test_daos_rebuild_ec: DAOS_Rebuild_EC
@@ -133,6 +134,7 @@ daos_tests:
     test_daos_md_replication: R
     test_daos_rebuild_simple: v
     test_daos_drain_simple: b
+    test_daos_extend_simple: B
     test_daos_oid_allocator: O
     test_daos_checksum: z
     test_daos_rebuild_ec: S

--- a/src/tests/suite/SConscript
+++ b/src/tests/suite/SConscript
@@ -104,7 +104,8 @@ def scons():
                     daos_obj_array.c daos_obj.c daos_oid_alloc.c daos_pool.c
                     daos_rebuild.c daos_rebuild_common.c daos_rebuild_ec.c
                     daos_rebuild_simple.c daos_test.c daos_verify_consistency.c
-                    daos_aggregate_ec.c daos_degrade_ec.c""")
+                    daos_aggregate_ec.c daos_degrade_ec.c
+                    daos_extend_simple.c""")
     daostest = daos_build.program(newenv, 'daos_test', c_files + daos_test_tgt,
                                   LIBS=libraries)
 

--- a/src/tests/suite/daos_extend_simple.c
+++ b/src/tests/suite/daos_extend_simple.c
@@ -1,0 +1,268 @@
+/**
+ * (C) Copyright 2016-2021 Intel Corporation.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause-Patent
+ */
+/**
+ * This file is for simple tests of extend, which does not need to kill the
+ * rank, and only used to verify the consistency after different data model
+ * extend.
+ *
+ * tests/suite/daos_extend_simple.c
+ *
+ *
+ */
+#define D_LOGFAC	DD_FAC(tests)
+
+#include "daos_iotest.h"
+#include <daos/pool.h>
+#include <daos/mgmt.h>
+#include <daos/container.h>
+
+#define KEY_NR		10
+#define OBJ_NR		10
+#define EXTEND_SMALL_POOL_SIZE	(4ULL << 30)
+
+static void
+extend_dkeys(void **state)
+{
+	test_arg_t	*arg = *state;
+	daos_obj_id_t	oids[OBJ_NR];
+	struct ioreq	req;
+	int		i;
+	int		j;
+	int		rc;
+
+	if (!test_runable(arg, 3))
+		return;
+
+	for (i = 0; i < OBJ_NR; i++) {
+		oids[i] = daos_test_oid_gen(arg->coh, OC_RP_3G1, 0, 0,
+					    arg->myrank);
+		ioreq_init(&req, arg->coh, oids[i], DAOS_IOD_ARRAY, arg);
+
+		/** Insert 10 records */
+		print_message("Insert %d kv record in object "DF_OID"\n",
+			      KEY_NR, DP_OID(oids[i]));
+		for (j = 0; j < KEY_NR; j++) {
+			char	key[16];
+
+			sprintf(key, "dkey_0_%d", j);
+			insert_single(key, "a_key", 0, "data",
+				      strlen("data") + 1,
+				      DAOS_TX_NONE, &req);
+		}
+		ioreq_fini(&req);
+	}
+
+	extend_single_pool_rank(arg, 3);
+
+	for (i = 0; i < OBJ_NR; i++) {
+		rc = daos_obj_verify(arg->coh, oids[i], DAOS_EPOCH_MAX);
+		assert_rc_equal(rc, 0);
+	}
+}
+
+static void
+extend_akeys(void **state)
+{
+	test_arg_t	*arg = *state;
+	daos_obj_id_t	oids[OBJ_NR];
+	struct ioreq	req;
+	int		i;
+	int		j;
+	int		rc;
+
+	if (!test_runable(arg, 3))
+		return;
+
+	for (i = 0; i < OBJ_NR; i++) {
+		oids[i] = daos_test_oid_gen(arg->coh, OC_RP_3G1, 0, 0,
+					    arg->myrank);
+		ioreq_init(&req, arg->coh, oids[i], DAOS_IOD_ARRAY, arg);
+
+		/** Insert 10 records */
+		print_message("Insert %d kv record in object "DF_OID"\n",
+			      KEY_NR, DP_OID(oids[i]));
+		for (j = 0; j < KEY_NR; j++) {
+			char	akey[16];
+
+			sprintf(akey, "%d", j);
+			insert_single("dkey_1_0", akey, 0, "data",
+				      strlen("data") + 1,
+				      DAOS_TX_NONE, &req);
+		}
+		ioreq_fini(&req);
+	}
+
+	extend_single_pool_rank(arg, 3);
+	for (i = 0; i < OBJ_NR; i++) {
+		rc = daos_obj_verify(arg->coh, oids[i], DAOS_EPOCH_MAX);
+		assert_rc_equal(rc, 0);
+	}
+}
+
+static void
+extend_indexes(void **state)
+{
+	test_arg_t	*arg = *state;
+	daos_obj_id_t	oids[OBJ_NR];
+	struct ioreq	req;
+	int		i;
+	int		j;
+	int		k;
+	int		rc;
+
+	if (!test_runable(arg, 3))
+		return;
+
+	for (i = 0; i < OBJ_NR; i++) {
+		oids[i] = daos_test_oid_gen(arg->coh, OC_RP_3G1, 0, 0,
+					    arg->myrank);
+		ioreq_init(&req, arg->coh, oids[i], DAOS_IOD_ARRAY, arg);
+
+		/** Insert 10 records */
+		print_message("Insert %d kv record in object "DF_OID"\n",
+			      KEY_NR, DP_OID(oids[i]));
+
+		for (j = 0; j < KEY_NR; j++) {
+			char	key[16];
+
+			sprintf(key, "dkey_2_%d", j);
+			for (k = 0; k < 20; k++)
+				insert_single(key, "a_key", k, "data",
+					      strlen("data") + 1, DAOS_TX_NONE,
+					      &req);
+		}
+		ioreq_fini(&req);
+	}
+
+	extend_single_pool_rank(arg, 3);
+	for (i = 0; i < OBJ_NR; i++) {
+		rc = daos_obj_verify(arg->coh, oids[i], DAOS_EPOCH_MAX);
+		assert_rc_equal(rc, 0);
+	}
+}
+
+static void
+extend_large_rec(void **state)
+{
+	test_arg_t	*arg = *state;
+	daos_obj_id_t	oids[OBJ_NR];
+	struct ioreq	req;
+	char		buffer[5000];
+	int		i;
+	int		j;
+	int		rc;
+
+	if (!test_runable(arg, 3))
+		return;
+
+	memset(buffer, 'a', 5000);
+	for (i = 0; i < OBJ_NR; i++) {
+		oids[i] = daos_test_oid_gen(arg->coh, OC_RP_3G1, 0, 0,
+					    arg->myrank);
+		ioreq_init(&req, arg->coh, oids[i], DAOS_IOD_ARRAY, arg);
+
+		/** Insert 10 records */
+		print_message("Insert %d kv record in object "DF_OID"\n",
+			      KEY_NR, DP_OID(oids[i]));
+		for (j = 0; j < KEY_NR; j++) {
+			char	key[16];
+
+			sprintf(key, "dkey_3_%d", j);
+			insert_single(key, "a_key", 0, buffer, 5000,
+				      DAOS_TX_NONE, &req);
+		}
+		ioreq_fini(&req);
+	}
+
+	extend_single_pool_rank(arg, 3);
+	for (i = 0; i < OBJ_NR; i++) {
+		rc = daos_obj_verify(arg->coh, oids[i], DAOS_EPOCH_MAX);
+		assert_rc_equal(rc, 0);
+	}
+}
+
+static void
+extend_objects(void **state)
+{
+	test_arg_t	*arg = *state;
+	struct ioreq	req;
+	daos_obj_id_t	oids[OBJ_NR];
+	int		i;
+
+	if (!test_runable(arg, 4))
+		return;
+
+	for (i = 0; i < OBJ_NR; i++) {
+		oids[i] = daos_test_oid_gen(arg->coh, OC_S1, 0,
+					    0, arg->myrank);
+		ioreq_init(&req, arg->coh, oids[i], DAOS_IOD_ARRAY, arg);
+
+		insert_single("dkey", "akey", 0, "data", strlen("data") + 1,
+			      DAOS_TX_NONE, &req);
+		ioreq_fini(&req);
+	}
+
+	extend_single_pool_rank(arg, 3);
+
+	for (i = 0; i < OBJ_NR; i++) {
+		char buffer[16];
+
+		oids[i] = daos_test_oid_gen(arg->coh, DAOS_OC_TINY_RW, 0,
+					    0, arg->myrank);
+		ioreq_init(&req, arg->coh, oids[i], DAOS_IOD_ARRAY, arg);
+		memset(buffer, 0, 16);
+		lookup_single("dkey", "akey", 0, buffer, 16,
+			      DAOS_TX_NONE, &req);
+		assert_string_equal(buffer, "data");
+		ioreq_fini(&req);
+	}
+}
+
+int
+extend_small_sub_setup(void **state)
+{
+	int rc;
+
+	save_group_state(state);
+	rc = test_setup(state, SETUP_CONT_CONNECT, true,
+			EXTEND_SMALL_POOL_SIZE, 3, NULL);
+	return rc;
+}
+
+/** create a new pool/container for each test */
+static const struct CMUnitTest extend_tests[] = {
+	{"EXTEND1: extend small rec multiple dkeys",
+	 extend_dkeys, extend_small_sub_setup, test_teardown},
+	{"EXTEND2: extend small rec multiple akeys",
+	 extend_akeys, extend_small_sub_setup, test_teardown},
+	{"EXTEND3: extend small rec multiple indexes",
+	 extend_indexes, extend_small_sub_setup, test_teardown},
+	{"EXTEND4: extend large rec single index",
+	 extend_large_rec, extend_small_sub_setup, test_teardown},
+	{"EXTEND5: extend multiple objects",
+	 extend_objects, extend_small_sub_setup, test_teardown},
+};
+
+int
+run_daos_extend_simple_test(int rank, int size, int *sub_tests,
+			    int sub_tests_size)
+{
+	int rc = 0;
+
+	MPI_Barrier(MPI_COMM_WORLD);
+	if (sub_tests_size == 0) {
+		sub_tests_size = ARRAY_SIZE(extend_tests);
+		sub_tests = NULL;
+	}
+
+	run_daos_sub_tests_only("DAOS_Extend_Simple", extend_tests,
+				ARRAY_SIZE(extend_tests), sub_tests,
+				sub_tests_size);
+
+	MPI_Barrier(MPI_COMM_WORLD);
+
+	return rc;
+}

--- a/src/tests/suite/daos_rebuild_common.c
+++ b/src/tests/suite/daos_rebuild_common.c
@@ -23,6 +23,7 @@ static test_arg_t *save_arg;
 enum REBUILD_TEST_OP_TYPE {
 	RB_OP_TYPE_FAIL,
 	RB_OP_TYPE_DRAIN,
+	RB_OP_TYPE_REINT,
 	RB_OP_TYPE_ADD,
 	RB_OP_TYPE_RECLAIM,
 };
@@ -52,7 +53,7 @@ rebuild_exclude_tgt(test_arg_t **args, int arg_cnt, d_rank_t rank,
 }
 
 static void
-rebuild_add_tgt(test_arg_t **args, int args_cnt, d_rank_t rank,
+rebuild_reint_tgt(test_arg_t **args, int args_cnt, d_rank_t rank,
 		int tgt_idx)
 {
 	int i;
@@ -63,6 +64,22 @@ rebuild_add_tgt(test_arg_t **args, int args_cnt, d_rank_t rank,
 					  args[i]->group,
 					  args[i]->dmg_config,
 					  rank, tgt_idx);
+		sleep(2);
+	}
+}
+
+static void
+rebuild_extend_tgt(test_arg_t **args, int args_cnt, d_rank_t rank,
+		   int tgt_idx, daos_size_t nvme_size)
+{
+	int i;
+
+	for (i = 0; i < args_cnt; i++) {
+		if (!args[i]->pool.destroyed)
+			daos_extend_target(args[i]->pool.pool_uuid,
+					   args[i]->group,
+					   args[i]->dmg_config,
+					   rank, tgt_idx, nvme_size);
 		sleep(2);
 	}
 }
@@ -104,9 +121,14 @@ rebuild_targets(test_arg_t **args, int args_cnt, d_rank_t *ranks,
 						ranks[i], tgts ? tgts[i] : -1,
 						kill);
 				break;
-			case RB_OP_TYPE_ADD:
-				rebuild_add_tgt(args, args_cnt, ranks[i],
+			case RB_OP_TYPE_REINT:
+				rebuild_reint_tgt(args, args_cnt, ranks[i],
 						tgts ? tgts[i] : -1);
+				break;
+			case RB_OP_TYPE_ADD:
+				rebuild_extend_tgt(args, args_cnt, ranks[i],
+						   tgts ? tgts[i] : -1,
+						   args[i]->pool.pool_size);
 				break;
 			case RB_OP_TYPE_DRAIN:
 				rebuild_drain_tgt(args, args_cnt, ranks[i],
@@ -174,6 +196,12 @@ void
 drain_single_pool_rank(test_arg_t *arg, d_rank_t failed_rank, bool kill)
 {
 	rebuild_targets(&arg, 1, &failed_rank, NULL, 1, kill, RB_OP_TYPE_DRAIN);
+}
+
+void
+extend_single_pool_rank(test_arg_t *arg, d_rank_t failed_rank)
+{
+	rebuild_targets(&arg, 1, &failed_rank, NULL, 1, false, RB_OP_TYPE_ADD);
 }
 
 void
@@ -295,7 +323,7 @@ reintegrate_single_pool_target(test_arg_t *arg, d_rank_t failed_rank,
 	 */
 	rebuild_pool_disconnect_internal(arg);
 	rebuild_targets(&arg, 1, &failed_rank, &failed_tgt, 1, false,
-			RB_OP_TYPE_ADD);
+			RB_OP_TYPE_REINT);
 	rebuild_pool_connect_internal(arg);
 }
 
@@ -312,7 +340,8 @@ reintegrate_single_pool_rank(test_arg_t *arg, d_rank_t failed_rank)
 	 * removed
 	 */
 	rebuild_pool_disconnect_internal(arg);
-	rebuild_targets(&arg, 1, &failed_rank, NULL, 1, false, RB_OP_TYPE_ADD);
+	rebuild_targets(&arg, 1, &failed_rank, NULL, 1, false,
+			RB_OP_TYPE_REINT);
 	rebuild_pool_connect_internal(arg);
 }
 
@@ -333,7 +362,7 @@ reintegrate_pools_ranks(test_arg_t **args, int args_cnt, d_rank_t *failed_ranks,
 	for (i = 0; i < args_cnt; i++)
 		rebuild_pool_disconnect_internal(args[i]);
 	rebuild_targets(args, args_cnt, failed_ranks, NULL, ranks_nr,
-			false, RB_OP_TYPE_ADD);
+			false, RB_OP_TYPE_REINT);
 	for (i = 0; i < args_cnt; i++)
 		rebuild_pool_connect_internal(args[i]);
 }

--- a/src/tests/suite/daos_test.c
+++ b/src/tests/suite/daos_test.c
@@ -17,7 +17,7 @@
  * all will be run if no test is specified. Tests will be run in order
  * so tests that kill nodes must be last.
  */
-#define TESTS "mpcetTViADKCoRvSXbOzZUdrNb"
+#define TESTS "mpcetTViADKCoRvSXbOzZUdrNbB"
 
 /**
  * These tests will only be run if explicitly specified. They don't get
@@ -67,6 +67,7 @@ print_usage(int rank)
 	print_message("daos_test -S|--rebuild_ec\n");
 	print_message("daos_test -X|--degrade_ec\n");
 	print_message("daos_test -b|--drain_simple\n");
+	print_message("daos_test -B|--extend_simple\n");
 	print_message("daos_test -N|--nvme_recovery\n");
 	print_message("daos_test -a|--daos_all_tests\n");
 	print_message("Default <daos_tests> runs all tests\n=============\n");
@@ -256,6 +257,13 @@ run_specified_tests(const char *tests, int rank, int size,
 			nr_failed += run_daos_drain_simple_test(rank, size,
 						sub_tests, sub_tests_size);
 			break;
+		case 'B':
+			daos_test_print(rank, "\n\n=================");
+			daos_test_print(rank, "DAOS extend simple tests..");
+			daos_test_print(rank, "=================");
+			nr_failed += run_daos_extend_simple_test(rank, size,
+						sub_tests, sub_tests_size);
+			break;
 		case 'S':
 			daos_test_print(rank, "\n\n=================");
 			daos_test_print(rank, "DAOS rebuild ec tests..");
@@ -367,7 +375,7 @@ main(int argc, char **argv)
 
 	while ((opt =
 		getopt_long(argc, argv,
-			    "ampcCdtTVizUZxADKeoROg:n:s:u:E:f:w:W:hrNvbSXl:",
+			    "ampcCdtTVizUZxADKeoROg:n:s:u:E:f:w:W:hrNvbBSXl:",
 			     long_options, &index)) != -1) {
 		if (strchr(all_tests_defined, opt) != NULL) {
 			tests[ntests] = opt;

--- a/src/tests/suite/daos_test.h
+++ b/src/tests/suite/daos_test.h
@@ -356,6 +356,7 @@ int run_daos_nvme_recov_test(int rank, int size, int *sub_tests,
 			     int sub_tests_size);
 int run_daos_rebuild_simple_test(int rank, int size, int *tests, int test_size);
 int run_daos_drain_simple_test(int rank, int size, int *tests, int test_size);
+int run_daos_extend_simple_test(int rank, int size, int *tests, int test_size);
 int run_daos_rebuild_simple_ec_test(int rank, int size, int *tests,
 				    int test_size);
 int run_daos_degrade_simple_ec_test(int rank, int size, int *sub_tests,
@@ -386,6 +387,9 @@ void daos_reint_target(const uuid_t pool_uuid, const char *grp,
 void daos_drain_target(const uuid_t pool_uuid, const char *grp,
 		       const char *dmg_config,
 		       d_rank_t rank, int tgt);
+void daos_extend_target(const uuid_t pool_uuid, const char *grp,
+			const char *dmg_config,
+			d_rank_t rank, int tgt, daos_size_t nvme_size);
 void daos_exclude_server(const uuid_t pool_uuid, const char *grp,
 			 const char *dmg_config,
 			 d_rank_t rank);
@@ -429,6 +433,7 @@ void drain_single_pool_target(test_arg_t *arg, d_rank_t failed_rank,
 void drain_single_pool_rank(test_arg_t *arg, d_rank_t failed_rank, bool kill);
 void drain_pools_ranks(test_arg_t **args, int args_cnt,
 		d_rank_t *failed_ranks, int ranks_nr, bool kill);
+void extend_single_pool_rank(test_arg_t *arg, d_rank_t failed_rank);
 
 int rebuild_pool_create(test_arg_t **new_arg, test_arg_t *old_arg, int flag,
 		struct test_pool *pool);

--- a/src/tests/suite/daos_test_common.c
+++ b/src/tests/suite/daos_test_common.c
@@ -825,14 +825,20 @@ run_daos_sub_tests(char *test_name, const struct CMUnitTest *tests,
 static void
 daos_dmg_pool_target(const char *sub_cmd, const uuid_t pool_uuid,
 		     const char *grp, const char *dmg_config,
-		     d_rank_t rank, int tgt_idx)
+		     d_rank_t rank, int tgt_idx, daos_size_t scm_size)
 {
 	char		dmg_cmd[DTS_CFG_MAX];
 	int		rc;
 
 	/* build and invoke dmg cmd */
-	dts_create_config(dmg_cmd, "dmg pool %s --pool=" DF_UUIDF " --rank=%d",
-			  sub_cmd, DP_UUID(pool_uuid), rank);
+	if (strncmp(sub_cmd, "extend", strlen("extend")) == 0)
+		dts_create_config(dmg_cmd, "dmg pool %s --pool=" DF_UUIDF
+				  " --ranks=%d --scm-size="DF_U64, sub_cmd,
+				  DP_UUID(pool_uuid), rank, scm_size);
+	else
+		dts_create_config(dmg_cmd, "dmg pool %s --pool=" DF_UUIDF
+				  " --rank=%d", sub_cmd, DP_UUID(pool_uuid),
+				  rank);
 
 	if (tgt_idx != -1)
 		dts_append_config(dmg_cmd, " --target-idx=%d", tgt_idx);
@@ -850,7 +856,7 @@ daos_exclude_target(const uuid_t pool_uuid, const char *grp,
 		    d_rank_t rank, int tgt_idx)
 {
 	daos_dmg_pool_target("exclude", pool_uuid, grp, dmg_config,
-			     rank, tgt_idx);
+			     rank, tgt_idx, 0);
 }
 
 void
@@ -858,7 +864,16 @@ daos_reint_target(const uuid_t pool_uuid, const char *grp,
 		  const char *dmg_config, d_rank_t rank, int tgt_idx)
 {
 	daos_dmg_pool_target("reintegrate", pool_uuid, grp, dmg_config,
-			     rank, tgt_idx);
+			     rank, tgt_idx, 0);
+}
+
+void
+daos_extend_target(const uuid_t pool_uuid, const char *grp,
+		   const char *dmg_config, d_rank_t rank, int tgt_idx,
+		   daos_size_t nvme_size)
+{
+	daos_dmg_pool_target("extend", pool_uuid, grp, dmg_config,
+			     rank, tgt_idx, nvme_size);
 }
 
 void
@@ -867,7 +882,7 @@ daos_drain_target(const uuid_t pool_uuid, const char *grp,
 {
 
 	daos_dmg_pool_target("drain", pool_uuid, grp, dmg_config,
-			     rank, tgt_idx);
+			     rank, tgt_idx, 0);
 }
 
 void


### PR DESCRIPTION
1. Add extend simple test.

2. Fix memory corruption in IV pool map, which
might cause extend tests segfault.

Signed-off-by: Di Wang <di.wang@intel.com>