### PR TITLE
DAOS-6840 rebuild: add iv_sync to rebuild iv. (#4855)

### DIFF
--- a/src/rebuild/rebuild_internal.h
+++ b/src/rebuild/rebuild_internal.h
@@ -249,7 +249,8 @@ struct rebuild_iv {
 	uint32_t	riv_global_done:1,
 			riv_global_scan_done:1,
 			riv_scan_done:1,
-			riv_pull_done:1;
+			riv_pull_done:1,
+			riv_sync:1;
 	int		riv_status;
 };
 

--- a/src/rebuild/rebuild_iv.c
+++ b/src/rebuild/rebuild_iv.c
@@ -108,6 +108,9 @@ rebuild_iv_ent_update(struct ds_iv_entry *entry, struct ds_iv_key *key,
 	if (rank != src_iv->riv_master_rank)
 		return -DER_IVCB_FORWARD;
 
+	if (src_iv->riv_sync)
+		return 0;
+
 	dst_iv->riv_master_rank = src_iv->riv_master_rank;
 	uuid_copy(dst_iv->riv_pool_uuid, src_iv->riv_pool_uuid);
 

--- a/src/rebuild/srv.c
+++ b/src/rebuild/srv.c
@@ -565,6 +565,7 @@ rebuild_leader_status_check(struct ds_pool *pool, uint32_t map_ver, uint32_t op,
 			iv.riv_stable_epoch = rgt->rgt_stable_epoch;
 			iv.riv_ver = rgt->rgt_rebuild_ver;
 			iv.riv_leader_term = rgt->rgt_leader_term;
+			iv.riv_sync = 1;
 
 			/* Notify others the global scan is done, then
 			 * each target can reliablly report its pull status


### PR DESCRIPTION
During rebuild,  the leader IV sync(rebuild_leader_status_check)
is used to sync the global status to all other server, but it
might also call local iv update entry callback on the leader,
which might then update rebuild global staus. So add iv_sync to
avoid the rebuild global status being updated in this case.

Signed-off-by: Di Wang <di.wang@intel.com>