### PR TITLE
DAOS-6798 iv: stop the iv ns leader first during destroy

### DIFF
--- a/src/engine/server_iv.c
+++ b/src/engine/server_iv.c
@@ -798,6 +798,15 @@ ds_iv_ns_start(struct ds_iv_ns *ns)
 }
 
 void
+ds_iv_ns_leader_stop(struct ds_iv_ns *ns)
+{
+	/* Set iv_stop on the leader, so all arriving IV requests will return
+	 * failure after this.
+	 */
+	ns->iv_stop = 1;
+}
+
+void
 ds_iv_ns_stop(struct ds_iv_ns *ns)
 {
 	ns->iv_stop = 1;

--- a/src/include/daos_srv/iv.h
+++ b/src/include/daos_srv/iv.h
@@ -304,6 +304,7 @@ int ds_iv_ns_create(crt_context_t ctx, uuid_t pool_uuid, crt_group_t *grp,
 
 void ds_iv_ns_update(struct ds_iv_ns *ns, unsigned int master_rank);
 void ds_iv_ns_stop(struct ds_iv_ns *ns);
+void ds_iv_ns_leader_stop(struct ds_iv_ns *ns);
 void ds_iv_ns_start(struct ds_iv_ns *ns);
 void ds_iv_ns_put(struct ds_iv_ns *ns);
 void ds_iv_ns_get(struct ds_iv_ns *ns);

--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -4805,6 +4805,7 @@ ds_pool_evict_handler(crt_rpc_t *rpc)
 			D_GOTO(out_free, rc);
 
 		ds_pool_iv_srv_hdl_invalidate(svc->ps_pool);
+		ds_iv_ns_leader_stop(svc->ps_pool->sp_iv_ns);
 		D_DEBUG(DF_DSMS, DF_UUID": pool destroy/evict: mark pool for "
 			"no new connections\n", DP_UUID(in->pvi_op.pi_uuid));
 	}

--- a/src/tests/ftest/mdtest/mdtest_small.py
+++ b/src/tests/ftest/mdtest/mdtest_small.py
@@ -31,7 +31,7 @@ class MdtestSmall(MdtestBase):
             read bytes: 0|4K
             depth of hierarchical directory structure: 0|5
 
-        :avocado: tags=all,daily_regression,hw,large,mdtest,mdtestsmall
+        :avocado: tags=all,pr,daily_regression,hw,large,mdtest,mdtestsmall
         :avocado: tags=DAOS_5610
         """
         # local params


### PR DESCRIPTION
Cherry-pick of PR #4827 from daos master to daos release/1.2.

Let's stop the iv ns leader during the destory first, so
all arriving IV requests will fail and return immediately.

And with this change the mdtest_small test is re-enabled for PRs.

Signed-off-by: Di Wang <di.wang@intel.com>
Signed-off-by: Kenneth Cain <kenneth.c.cain@intel.com>