### PR TITLE
DAOS-6915 control: Don't allow new ranks to claim existing

### DIFF
--- a/src/control/cmd/dmg/system.go
+++ b/src/control/cmd/dmg/system.go
@@ -65,7 +65,7 @@ func rankStateGroups(members system.Members) (system.RankGroups, error) {
 
 	for _, m := range members {
 		if _, exists := ranksSeen[m.Rank]; exists {
-			return nil, &system.ErrMemberExists{Rank: m.Rank}
+			return nil, &system.ErrMemberExists{Rank: &m.Rank}
 		}
 		ranksSeen[m.Rank] = struct{}{}
 
@@ -234,7 +234,7 @@ func rankActionGroups(results system.MemberResults) (system.RankGroups, error) {
 
 	for _, r := range results {
 		if _, exists := ranksSeen[r.Rank]; exists {
-			return nil, &system.ErrMemberExists{Rank: r.Rank}
+			return nil, &system.ErrMemberExists{Rank: &r.Rank}
 		}
 		ranksSeen[r.Rank] = struct{}{}
 

--- a/src/control/cmd/dmg/system_test.go
+++ b/src/control/cmd/dmg/system_test.go
@@ -251,7 +251,7 @@ func TestDmg_System_rankStateGroups(t *testing.T) {
 				MockMember(t, 4, MemberStateEvicted),
 				MockMember(t, 1, MemberStateJoined),
 			},
-			expErr: &ErrMemberExists{Rank: Rank(4)},
+			expErr: &ErrMemberExists{Rank: NewRankPtr(4)},
 		},
 		"multiple groups": {
 			members: Members{
@@ -314,7 +314,7 @@ func TestDmg_System_rankActionGroups(t *testing.T) {
 				MockMemberResult(4, "ping", nil, MemberStateEvicted),
 				MockMemberResult(4, "ping", nil, MemberStateEvicted),
 			},
-			expErr: &ErrMemberExists{Rank: Rank(4)},
+			expErr: &ErrMemberExists{Rank: NewRankPtr(4)},
 		},
 		"successful results": {
 			results: MemberResults{


### PR DESCRIPTION
As a leftover from some older logic, servers with a new
UUID were being allowed to present a join request for an
existing rank, with the result that the new server replaced
the old one in the system membership. This commit removes
the ability to implicitly replace an existing server. Future
work will add support for explicit replacement via new API
surface.

Master-PR: https://github.com/daos-stack/daos/pull/4833