### PR TITLE
DAOS-6931 test: Fix pool/evict_test.yaml (#4846)

### DIFF
--- a/src/tests/ftest/pool/evict_test.yaml
+++ b/src/tests/ftest/pool/evict_test.yaml
@@ -6,7 +6,7 @@ hosts:
     - server-D
 server_config:
    name: daos_server
-timeout: 60
+timeout: 170
 pool:
    mode: 146
    name: daos_server


### PR DESCRIPTION
Increase timeout as the pool create operations are taking longer now.

Signed-off-by: Makito Kano <makito.kano@intel.com>