### PR TITLE
DAOS-6932 tests: Resolving DmgCommand JSON parsing error (#4858)

### DIFF
--- a/src/tests/ftest/util/command_utils.py
+++ b/src/tests/ftest/util/command_utils.py
@@ -48,6 +48,7 @@ class ExecutableCommand(CommandWithParameters):
         self.run_as_subprocess = subprocess
         self.timeout = None
         self.exit_status_exception = True
+        self.output_check = "both"
         self.verbose = True
         self.env = None
         self.sudo = False
@@ -117,7 +118,7 @@ class ExecutableCommand(CommandWithParameters):
             # Block until the command is complete or times out
             return run_command(
                 command, self.timeout, self.verbose, self.exit_status_exception,
-                "combined", env=self.env)
+                self.output_check, env=self.env)
 
         except DaosTestError as error:
             # Command failed or possibly timed out

--- a/src/tests/ftest/util/dmg_utils.py
+++ b/src/tests/ftest/util/dmg_utils.py
@@ -87,10 +87,13 @@ class DmgCommand(DmgCommandBase):
         """Wraps the base _get_result method to force JSON output."""
         prev_json_val = self.json.value
         self.json.update(True)
+        prev_output_check = self.output_check
+        self.output_check = "both"
         try:
             self._get_result(sub_command_list, **kwargs)
         finally:
             self.json.update(prev_json_val)
+            self.output_check = prev_output_check
         return json.loads(self.result.stdout)
 
     def network_scan(self, provider=None, all_devs=False):

--- a/src/tests/ftest/util/general_utils.py
+++ b/src/tests/ftest/util/general_utils.py
@@ -217,7 +217,7 @@ def bytes_to_human(size, digits=2, binary=True):
 
 
 def run_command(command, timeout=60, verbose=True, raise_exception=True,
-                output_check="combined", env=None):
+                output_check="both", env=None):
     """Run the command on the local host.
 
     This method uses the avocado.utils.process.run() method to run the specified
@@ -242,7 +242,7 @@ def run_command(command, timeout=60, verbose=True, raise_exception=True,
                 "both"      - both standard output and error in separate files
                 "combined"  - standard output and error in a single file
                 "none"      - disable all recording
-            Defaults to "combined".
+            Defaults to "both".
         env (dict, optional): dictionary of environment variable names and
             values to set when running the command. Defaults to None.
 


### PR DESCRIPTION
Resolving a JSON parsing encountered by the pool/create_test.py when
failing to create a pool by replacing the "combined" stdout/stderr
output currently produced by avocado's process.run() with the "both"
option.

Master-PR: https://github.com/daos-stack/daos/pull/4858

Signed-off-by: Phillip Henderson <phillip.henderson@intel.com>