### PR TITLE
DAOS-4698 vos: Report future object punch with iterator (#4854)

### DIFF
--- a/src/include/daos_srv/vos_types.h
+++ b/src/include/daos_srv/vos_types.h
@@ -358,6 +358,8 @@ typedef struct {
 		struct {
 			/** Non-zero if punched */
 			daos_epoch_t		ie_punch;
+			/** If applicable, non-zero if object is punched */
+			daos_epoch_t		ie_obj_punch;
 			union {
 				/** key value */
 				daos_key_t	ie_key;

--- a/src/vos/vos_obj.c
+++ b/src/vos/vos_obj.c
@@ -657,6 +657,7 @@ key_iter_fetch(struct vos_obj_iter *oiter, vos_iter_entry_t *ent,
 
 	ent->ie_epoch = epr.epr_hi;
 	ent->ie_punch = oiter->it_ilog_info.ii_next_punch;
+	ent->ie_obj_punch = oiter->it_obj->obj_ilog_info.ii_next_punch;
 	ent->ie_vis_flags = VOS_VIS_FLAG_VISIBLE;
 	if (oiter->it_ilog_info.ii_create == 0) {
 		/* The key has no visible subtrees so mark it covered */

--- a/src/vos/vos_obj_index.c
+++ b/src/vos/vos_obj_index.c
@@ -608,6 +608,7 @@ oi_iter_fetch(struct vos_iterator *iter, vos_iter_entry_t *it_entry,
 
 	it_entry->ie_oid = obj->vo_id;
 	it_entry->ie_punch = oiter->oit_ilog_info.ii_next_punch;
+	it_entry->ie_obj_punch = it_entry->ie_punch;
 	it_entry->ie_epoch = epr.epr_hi;
 	it_entry->ie_vis_flags = VOS_VIS_FLAG_VISIBLE;
 	if (oiter->oit_ilog_info.ii_create == 0) {


### PR DESCRIPTION
Add future object punch epoch to key iterator.  Needed for
rebuild migration so we can rebuild punched objects that
are visible in a prior snapshot.

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>