### PR TITLE
DAOS-623 test: Fix allocation of counters in hash perf test

### DIFF
--- a/src/gurt/tests/test_gurt.c
+++ b/src/gurt/tests/test_gurt.c
@@ -2023,7 +2023,7 @@ hash_perf(int hash_type, unsigned int buckets, unsigned int loop)
 	struct timespec	 now;
 	int		 i;
 
-	D_ALLOC_PTR(counters);
+	D_ALLOC_ARRAY(counters, buckets);
 	D_ASSERT(counters);
 
 	d_gettime(&then);


### PR DESCRIPTION
Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>