### PR TITLE
DAOS-6327 control: write ras events to syslog

### DIFF
--- a/src/control/events/ras.go
+++ b/src/control/events/ras.go
@@ -14,6 +14,7 @@ import "C"
 import (
 	"encoding/json"
 	"fmt"
+	"log/syslog"
 	"os"
 	"strings"
 	"time"
@@ -102,6 +103,18 @@ func (sev RASSeverityID) String() string {
 // Uint32 returns uint32 representation of event severity.
 func (sev RASSeverityID) Uint32() uint32 {
 	return uint32(sev)
+}
+
+// SyslogPriority maps RAS severity to syslog package priority.
+func (sev RASSeverityID) SyslogPriority() syslog.Priority {
+	slSev := map[RASSeverityID]syslog.Priority{
+		RASSeverityFatal:   syslog.LOG_CRIT,
+		RASSeverityError:   syslog.LOG_ERR,
+		RASSeverityWarn:    syslog.LOG_WARNING,
+		RASSeverityInfo:    syslog.LOG_INFO,
+	}[sev]
+
+	return slSev | syslog.LOG_DAEMON
 }
 
 // RASEvent describes details of a specific RAS event.

--- a/src/control/events/ras.go
+++ b/src/control/events/ras.go
@@ -108,10 +108,10 @@ func (sev RASSeverityID) Uint32() uint32 {
 // SyslogPriority maps RAS severity to syslog package priority.
 func (sev RASSeverityID) SyslogPriority() syslog.Priority {
 	slSev := map[RASSeverityID]syslog.Priority{
-		RASSeverityFatal:   syslog.LOG_CRIT,
-		RASSeverityError:   syslog.LOG_ERR,
-		RASSeverityWarn:    syslog.LOG_WARNING,
-		RASSeverityInfo:    syslog.LOG_INFO,
+		RASSeverityFatal: syslog.LOG_CRIT,
+		RASSeverityError: syslog.LOG_ERR,
+		RASSeverityWarn:  syslog.LOG_WARNING,
+		RASSeverityInfo:  syslog.LOG_INFO,
 	}[sev]
 
 	return slSev | syslog.LOG_DAEMON


### PR DESCRIPTION
With this change, RAS events are written directly to SYSLOG on the host
that they are first raised. This now occurs regardless of how daos_server
is launched (doesn't depend on systemd forwarding events to SYSLOG).

In production deployments it may be preferable to disable systemd
forwarding to SYSLOG to restrict logging to RAS events only as currently
a significant amount of logging is forwarded by daos_server.

RAS events written to SYSLOG have a DAOS specific structure and do not
currently adhere to RFC 3164 or RFC 5424.

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>