### PR TITLE
DAOS-6432 dtx: clean stale DTX entries

### DIFF
--- a/src/dtx/dtx_common.c
+++ b/src/dtx/dtx_common.c
@@ -22,6 +22,11 @@ struct dtx_batched_commit_args {
 	struct ds_cont_child	*dbca_cont;
 };
 
+struct dtx_cleanup_stale_cb_args {
+	d_list_t		dcsca_list;
+	int			dcsca_count;
+};
+
 static void
 dtx_stat(struct ds_cont_child *cont, struct dtx_stat *stat)
 {
@@ -31,7 +36,7 @@ dtx_stat(struct ds_cont_child *cont, struct dtx_stat *stat)
 	stat->dtx_oldest_committable_time = dtx_cos_oldest(cont);
 }
 
-void
+static void
 dtx_aggregate(void *arg)
 {
 	struct ds_cont_child	*cont = arg;
@@ -61,6 +66,98 @@ dtx_aggregate(void *arg)
 	}
 
 	cont->sc_dtx_aggregating = 0;
+	ds_cont_child_put(cont);
+}
+
+static int
+dtx_cleanup_stale_iter_cb(uuid_t co_uuid, vos_iter_entry_t *ent, void *args)
+{
+	struct dtx_cleanup_stale_cb_args	*dcsca = args;
+	struct dtx_share_peer			*dsp;
+
+	/* We commit the DTXs periodically, there will be very limited DTXs
+	 * to be checked when cleanup. So we can load all those uncommitted
+	 * DTXs in RAM firstly, then check the state one by one. That avoid
+	 * the race trouble between iteration of active-DTX tree and commit
+	 * (or abort) the DTXs (that will change the active-DTX tree).
+	 */
+
+	D_ASSERT(!(ent->ie_dtx_flags & DTE_INVALID));
+
+	/* Skip corrupted entry that will be handled via other special tool. */
+	if (ent->ie_dtx_flags & DTE_CORRUPTED)
+		return 0;
+
+	/* Stop cleanup iteration if current DTX is not too old. */
+	if (dtx_hlc_age2sec(ent->ie_dtx_start_time) <=
+	    DTX_CLEANUP_THRESHOLD_AGE_LOWER)
+		return 1;
+
+	D_ALLOC_PTR(dsp);
+	if (dsp == NULL)
+		return -DER_NOMEM;
+
+	dsp->dsp_xid = ent->ie_dtx_xid;
+	dsp->dsp_oid = ent->ie_dtx_oid;
+	if (ent->ie_dtx_mbs_flags & DMF_CONTAIN_LEADER) {
+		struct dtx_daos_target	*ddt = ent->ie_dtx_mbs;
+
+		D_ASSERT(ddt != NULL);
+		dsp->dsp_leader = ddt->ddt_id;
+	} else {
+		dsp->dsp_leader = PO_COMP_ID_ALL;
+	}
+
+	d_list_add_tail(&dsp->dsp_link, &dcsca->dcsca_list);
+	dcsca->dcsca_count++;
+
+	return 0;
+}
+
+static void
+dtx_cleanup_stale(void *arg)
+{
+	struct ds_cont_child			*cont = arg;
+	struct dtx_share_peer			*dsp;
+	struct dtx_cleanup_stale_cb_args	 dcsca;
+	d_rank_t				 myrank;
+	int					 count;
+	int					 rc;
+
+	crt_group_rank(NULL, &myrank);
+	D_INIT_LIST_HEAD(&dcsca.dcsca_list);
+	dcsca.dcsca_count = 0;
+	rc = ds_cont_iter(cont->sc_pool->spc_hdl, cont->sc_uuid,
+			  dtx_cleanup_stale_iter_cb, &dcsca, VOS_ITER_DTX);
+	if (rc < 0)
+		D_WARN("Failed to scan stale DTX entry for "
+		       DF_UUID": "DF_RC"\n", DP_UUID(cont->sc_uuid), DP_RC(rc));
+
+	while (!cont->sc_closing && !cont->sc_dtx_cos_shutdown &&
+	       !d_list_empty(&dcsca.dcsca_list)) {
+		if (dcsca.dcsca_count > DTX_REFRESH_MAX) {
+			count = DTX_REFRESH_MAX;
+			dcsca.dcsca_count -= DTX_REFRESH_MAX;
+		} else {
+			D_ASSERT(dcsca.dcsca_count > 0);
+
+			count = dcsca.dcsca_count;
+			dcsca.dcsca_count = 0;
+		}
+
+		rc = dtx_refresh_internal(cont, myrank,
+					  cont->sc_pool->spc_map_version,
+					  &count, &dcsca.dcsca_list,
+					  NULL, NULL, false);
+		D_ASSERT(count == 0);
+	}
+
+	while ((dsp = d_list_pop_entry(&dcsca.dcsca_list,
+				       struct dtx_share_peer,
+				       dsp_link)) != NULL)
+		D_FREE(dsp);
+
+	cont->sc_dtx_cleanup_stale = 0;
 	ds_cont_child_put(cont);
 }
 
@@ -201,7 +298,8 @@ dtx_batched_commit(void *arg)
 					D_WARN("Fail to batched commit dtx: "
 					       DF_RC"\n", DP_RC(rc));
 
-				if (!cont->sc_dtx_aggregating)
+				if (!cont->sc_dtx_aggregating ||
+				    !cont->sc_dtx_cleanup_stale)
 					dtx_stat(cont, &stat);
 			}
 		}
@@ -219,6 +317,21 @@ dtx_batched_commit(void *arg)
 					    0, 0, NULL);
 			if (rc != 0) {
 				cont->sc_dtx_aggregating = 0;
+				ds_cont_child_put(cont);
+			}
+		}
+
+		if (!cont->sc_closing && !cont->sc_dtx_cleanup_stale &&
+		    stat.dtx_oldest_active_time != 0 &&
+		    dtx_hlc_age2sec(stat.dtx_oldest_active_time) >=
+		    DTX_CLEANUP_THRESHOLD_AGE_UPPER) {
+			sleep_time = 0;
+			ds_cont_child_get(cont);
+			cont->sc_dtx_cleanup_stale = 1;
+			rc = dss_ult_create(dtx_cleanup_stale, cont,
+					    DSS_XS_SELF, 0, 0, NULL);
+			if (rc != 0) {
+				cont->sc_dtx_cleanup_stale = 0;
 				ds_cont_child_put(cont);
 			}
 		}

--- a/src/dtx/dtx_internal.h
+++ b/src/dtx/dtx_internal.h
@@ -54,26 +54,42 @@ CRT_RPC_DECLARE(dtx, DAOS_ISEQ_DTX, DAOS_OSEQ_DTX);
 
 /* The age unit is second. */
 
-/* The count threshould for triggerring DTX aggregation.
- * This threshould should consider the real SCM size.
- */
-#define DTX_AGG_THRESHOLD_CNT_UPPER	(1 << 27)
-
-/* If the DTX entries are not more than this count threshould,
+/* If the DTX entries are not more than this count threshold,
  * then no need DTX aggregation.
+ *
+ * XXX: This threshold should consider the real SCM size. But
+ *	it cannot be too small; otherwise, handing resent RPC
+ *	make hit uncertain case and got failure -DER_EP_OLD.
  */
-#define DTX_AGG_THRESHOLD_CNT_LOWER	(1 << 17)
+#define DTX_AGG_THRESHOLD_CNT_LOWER	(1 << 24)
 
-/* The time threshould for triggerring DTX aggregation. If the oldest
- * DTX in the DTX table exceeds such threshould, it will trigger DTX
+/* The count threshold for triggerring DTX aggregation. */
+#define DTX_AGG_THRESHOLD_CNT_UPPER	(DTX_AGG_THRESHOLD_CNT_LOWER << 1)
+
+/* The time threshold for triggerring DTX aggregation. If the oldest
+ * DTX in the DTX table exceeds such threshold, it will trigger DTX
  * aggregation locally.
  */
-#define DTX_AGG_THRESHOLD_AGE_UPPER	4800
+#define DTX_AGG_THRESHOLD_AGE_UPPER	1200
 
-/* If DTX aggregation is triggered, then he DTXs with older ages than
+/* If DTX aggregation is triggered, then the DTXs with older ages than
  * this threshold will be aggregated.
+ *
+ * XXX: It cannot be too small; otherwise, handing resent RPC
+ *	make hit uncertain case and got failure -DER_EP_OLD.
  */
-#define DTX_AGG_THRESHOLD_AGE_LOWER	3600
+#define DTX_AGG_THRESHOLD_AGE_LOWER	900
+
+/* The time threshold for triggerring DTX cleanup of stale entries.
+ * If the oldest active DTX exceeds such threshold, it will trigger
+ * DTX cleanup locally.
+ */
+#define DTX_CLEANUP_THRESHOLD_AGE_UPPER	240
+
+/* If DTX cleanup for stale entries is triggered, then the DTXs with
+ * older ages than this threshold will be cleanup.
+ */
+#define DTX_CLEANUP_THRESHOLD_AGE_LOWER	180
 
 extern struct crt_proto_format dtx_proto_fmt;
 extern btr_ops_t dbtree_dtx_cf_ops;
@@ -101,5 +117,8 @@ int dtx_abort(struct ds_cont_child *cont, daos_epoch_t epoch,
 	      struct dtx_entry **dtes, int count);
 int dtx_check(struct ds_cont_child *cont, struct dtx_entry *dte,
 	      daos_epoch_t epoch);
+int dtx_refresh_internal(struct ds_cont_child *cont, d_rank_t myrank,
+			 uint32_t ver, int *check_count, d_list_t *check_list,
+			 d_list_t *act_list, d_list_t *cmt_list, bool failout);
 
 #endif /* __DTX_INTERNAL_H__ */

--- a/src/dtx/dtx_rpc.c
+++ b/src/dtx/dtx_rpc.c
@@ -58,10 +58,12 @@ struct dtx_req_args {
 	int				 dra_length;
 	/* The collective RPC result. */
 	int				 dra_result;
-	/* Pointer to the DTX handle, used for DTX_REFRESH case. */
-	struct dtx_handle		*dra_dth;
 	/* Pointer to the container, used for DTX_REFRESH case. */
 	struct ds_cont_child		*dra_cont;
+	/* Pointer to the active DTX list, used for DTX_REFRESH case. */
+	d_list_t			*dra_act_list;
+	/* Pointer to the committed DTX list, used for DTX_REFRESH case. */
+	d_list_t			*dra_cmt_list;
 };
 
 /* The record for the DTX classify-tree in DRAM.
@@ -128,7 +130,6 @@ dtx_req_cb(const struct crt_cb_info *cb_info)
 		D_GOTO(out, rc = -DER_PROTO);
 
 	for (i = 0; i < dout->do_sub_rets.ca_count; i++) {
-		struct dtx_handle	*dth = dra->dra_dth;
 		struct dtx_share_peer	*dsp;
 		int			*ret;
 		int			 rc1;
@@ -144,13 +145,19 @@ dtx_req_cb(const struct crt_cb_info *cb_info)
 		case DTX_ST_PREPARED:
 		case -DER_INPROGRESS:
 			/* Not committable yet. */
-			d_list_add_tail(&dsp->dsp_link,
-					&dth->dth_share_act_list);
+			if (dra->dra_act_list != NULL)
+				d_list_add_tail(&dsp->dsp_link,
+						dra->dra_act_list);
+			else
+				D_FREE(dsp);
 			break;
 		case DTX_ST_COMMITTABLE:
 			/* Committable, will be committed soon. */
-			d_list_add_tail(&dsp->dsp_link,
-					&dth->dth_share_cmt_list);
+			if (dra->dra_cmt_list != NULL)
+				d_list_add_tail(&dsp->dsp_link,
+						dra->dra_cmt_list);
+			else
+				D_FREE(dsp);
 			break;
 		case DTX_ST_COMMITTED:
 			/* Has been committed on leader, we may miss related
@@ -158,9 +165,10 @@ dtx_req_cb(const struct crt_cb_info *cb_info)
 			 */
 			rc1 = vos_dtx_commit(dra->dra_cont->sc_hdl,
 					     &dsp->dsp_xid, 1, NULL);
-			if (rc1 < 0 && rc1 != -DER_NONEXIST)
+			if (rc1 < 0 && rc1 != -DER_NONEXIST &&
+			    dra->dra_cmt_list != NULL)
 				d_list_add_tail(&dsp->dsp_link,
-						&dth->dth_share_cmt_list);
+						dra->dra_cmt_list);
 			else
 				D_FREE(dsp);
 			break;
@@ -175,9 +183,10 @@ dtx_req_cb(const struct crt_cb_info *cb_info)
 			 */
 			rc1 = vos_dtx_abort(dra->dra_cont->sc_hdl,
 					    DAOS_EPOCH_MAX, &dsp->dsp_xid, 1);
-			if (rc1 < 0 && rc1 != -DER_NONEXIST)
+			if (rc1 < 0 && rc1 != -DER_NONEXIST &&
+			    dra->dra_act_list != NULL)
 				d_list_add_tail(&dsp->dsp_link,
-						&dth->dth_share_act_list);
+						dra->dra_act_list);
 			else
 				D_FREE(dsp);
 			break;
@@ -323,7 +332,8 @@ dtx_req_wait(struct dtx_req_args *dra)
 static int
 dtx_req_list_send(struct dtx_req_args *dra, crt_opcode_t opc, d_list_t *head,
 		  int len, uuid_t po_uuid, uuid_t co_uuid, daos_epoch_t epoch,
-		  struct dtx_handle *dth, struct ds_cont_child *cont)
+		  struct ds_cont_child *cont,
+		  d_list_t *act_list, d_list_t *cmt_list)
 {
 	ABT_future		 future;
 	struct dtx_req_rec	*drr;
@@ -336,8 +346,9 @@ dtx_req_list_send(struct dtx_req_args *dra, crt_opcode_t opc, d_list_t *head,
 	dra->dra_list = head;
 	dra->dra_length = len;
 	dra->dra_result = 0;
-	dra->dra_dth = dth;
 	dra->dra_cont = cont;
+	dra->dra_act_list = act_list;
+	dra->dra_cmt_list = cmt_list;
 
 	rc = ABT_future_create(len, dtx_req_list_cb, &future);
 	if (rc != ABT_SUCCESS) {
@@ -592,7 +603,7 @@ dtx_commit(struct ds_cont_child *cont, struct dtx_entry **dtes,
 	if (!d_list_empty(&head)) {
 		rc = dtx_req_list_send(&dra, DTX_COMMIT, &head, length,
 				       pool->sp_uuid, cont->sc_uuid, 0,
-				       NULL, NULL);
+				       NULL, NULL, NULL);
 		if (rc != 0)
 			goto out;
 	}
@@ -678,7 +689,7 @@ dtx_abort(struct ds_cont_child *cont, daos_epoch_t epoch,
 	if (rc == 0 && !d_list_empty(&head)) {
 		rc = dtx_req_list_send(&dra, DTX_ABORT, &head, length,
 				       pool->sp_uuid, cont->sc_uuid, epoch,
-				       NULL, NULL);
+				       NULL, NULL, NULL);
 		if (rc != 0)
 			goto out;
 
@@ -774,7 +785,7 @@ dtx_check(struct ds_cont_child *cont, struct dtx_entry *dte, daos_epoch_t epoch)
 	}
 
 	rc = dtx_req_list_send(&dra, DTX_CHECK, &head, length, pool->sp_uuid,
-			       cont->sc_uuid, epoch, NULL, NULL);
+			       cont->sc_uuid, epoch, NULL, NULL, NULL);
 	if (rc == 0)
 		rc = dtx_req_wait(&dra);
 
@@ -787,48 +798,49 @@ out:
 	return rc;
 }
 
-/*
- * Because of async batched commit semantics, the DTX status on the leader
- * maybe different from the one on non-leaders. For the leader, it exactly
- * knows whether the DTX is committable or not, but the non-leader does not
- * know if the DTX is in 'prepared' status. If someone on non-leader wants
- * to know whether some 'prepared' DTX is real committable or not, it needs
- * to refresh such DTX status from the leader. The DTX_REFRESH RPC is used
- * for such purpose.
- */
 int
-dtx_refresh(struct dtx_handle *dth, struct ds_cont_child *cont)
+dtx_refresh_internal(struct ds_cont_child *cont, d_rank_t myrank, uint32_t ver,
+		     int *check_count, d_list_t *check_list,
+		     d_list_t *act_list, d_list_t *cmt_list, bool failout)
 {
 	struct ds_pool		*pool = cont->sc_pool->spc_pool;
 	struct pool_target	*target;
 	struct dtx_share_peer	*dsp;
+	struct dtx_share_peer	*tmp;
 	struct dtx_req_rec	*drr;
 	struct dtx_req_args	 dra;
 	d_list_t		 head;
 	int			 len = 0;
 	int			 rc = 0;
 
-	if (DAOS_FAIL_CHECK(DAOS_DTX_NO_RETRY))
-		return -DER_IO;
-
 	D_INIT_LIST_HEAD(&head);
 
-	d_list_for_each_entry(dsp, &dth->dth_share_tbd_list, dsp_link) {
+	d_list_for_each_entry_safe(dsp, tmp, check_list, dsp_link) {
+		bool	drop = false;
+
 		if (dsp->dsp_leader == PO_COMP_ID_ALL) {
 
 again:
-			rc = ds_pool_elect_dtx_leader(pool, &dsp->dsp_oid,
-						      dth->dth_ver);
+			rc = ds_pool_elect_dtx_leader(pool, &dsp->dsp_oid, ver);
 			if (rc < 0) {
 				D_ERROR("Failed to find DTX leader for "DF_DTI
 					": "DF_RC"\n",
 					DP_DTI(&dsp->dsp_xid), DP_RC(rc));
-				goto out;
+				if (failout)
+					goto out;
+
+				drop = true;
+				goto next;
 			}
 
-			/* Still get the same leader, ask client to retry. */
-			if (dsp->dsp_leader == rc)
-				D_GOTO(out, rc = -DER_INPROGRESS);
+			/* Still get the same leader. */
+			if (dsp->dsp_leader == rc) {
+				if (failout)
+					D_GOTO(out, rc = -DER_INPROGRESS);
+
+				drop = true;
+				goto next;
+			}
 
 			dsp->dsp_leader = rc;
 		}
@@ -838,6 +850,24 @@ again:
 					  &target);
 		ABT_rwlock_unlock(pool->sp_lock);
 		D_ASSERT(rc == 1);
+
+		/* If myself is the leader, then two possible cases:
+		 * 1. In DTX resync, then let client to retry later.
+		 * 2. The DTX resync is done, but failed to handle related DTX.
+		 *    Under such case, return -DER_IO to avoid application hung.
+		 */
+		if (myrank == target->ta_comp.co_rank &&
+		    dss_get_module_info()->dmi_tgt_id ==
+		    target->ta_comp.co_index) {
+			if (cont->sc_dtx_resyncing)
+				D_GOTO(out, rc = -DER_INPROGRESS);
+
+			if (failout)
+				D_GOTO(out, rc = -DER_IO);
+
+			drop = true;
+			goto next;
+		}
 
 		/* The leader is not healthy, related DTX will be resynced
 		 * by the new leader, let's find out new leader and retry.
@@ -858,13 +888,13 @@ again:
 		if (drr == NULL)
 			D_GOTO(out, rc = -DER_NOMEM);
 
-		D_ALLOC_ARRAY(drr->drr_dti, dth->dth_share_tbd_count);
+		D_ALLOC_ARRAY(drr->drr_dti, *check_count);
 		if (drr->drr_dti == NULL) {
 			D_FREE(drr);
 			D_GOTO(out, rc = -DER_NOMEM);
 		}
 
-		D_ALLOC_ARRAY(drr->drr_cb_args, dth->dth_share_tbd_count);
+		D_ALLOC_ARRAY(drr->drr_cb_args, *check_count);
 		if (drr->drr_cb_args == NULL) {
 			D_FREE(drr->drr_dti);
 			D_FREE(drr);
@@ -880,15 +910,20 @@ again:
 		len++;
 
 next:
-		d_list_del(&dsp->dsp_link);
-		dth->dth_share_tbd_count--;
-		D_ASSERT(dth->dth_share_tbd_count >= 0);
+		d_list_del_init(&dsp->dsp_link);
+		if (drop)
+			D_FREE(dsp);
+		if (--(*check_count) == 0)
+			break;
 	}
 
-	rc = dtx_req_list_send(&dra, DTX_REFRESH, &head, len,
-			       pool->sp_uuid, cont->sc_uuid, 0, dth, cont);
-	if (rc == 0)
-		rc = dtx_req_wait(&dra);
+	if (len > 0) {
+		rc = dtx_req_list_send(&dra, DTX_REFRESH, &head, len,
+				       pool->sp_uuid, cont->sc_uuid, 0, cont,
+				       act_list, cmt_list);
+		if (rc == 0)
+			rc = dtx_req_wait(&dra);
+	}
 
 out:
 	while ((drr = d_list_pop_entry(&head, struct dtx_req_rec,
@@ -897,6 +932,34 @@ out:
 		D_FREE(drr->drr_dti);
 		D_FREE(drr);
 	}
+
+	return rc;
+}
+
+/*
+ * Because of async batched commit semantics, the DTX status on the leader
+ * maybe different from the one on non-leaders. For the leader, it exactly
+ * knows whether the DTX is committable or not, but the non-leader does not
+ * know if the DTX is in 'prepared' status. If someone on non-leader wants
+ * to know whether some 'prepared' DTX is real committable or not, it needs
+ * to refresh such DTX status from the leader. The DTX_REFRESH RPC is used
+ * for such purpose.
+ */
+int
+dtx_refresh(struct dtx_handle *dth, struct ds_cont_child *cont)
+{
+	d_rank_t	myrank;
+	int		rc;
+
+	if (DAOS_FAIL_CHECK(DAOS_DTX_NO_RETRY))
+		return -DER_IO;
+
+	crt_group_rank(NULL, &myrank);
+	rc = dtx_refresh_internal(cont, myrank, dth->dth_ver,
+				  &dth->dth_share_tbd_count,
+				  &dth->dth_share_tbd_list,
+				  &dth->dth_share_act_list,
+				  &dth->dth_share_cmt_list, true);
 
 	/* If some DTX entry is corrupted, then reply -DER_DATA_LOSS.
 	 * Otherwise if we cannot resolve the DTX status, then reply

--- a/src/include/daos_srv/container.h
+++ b/src/include/daos_srv/container.h
@@ -64,6 +64,7 @@ struct ds_cont_child {
 				 sc_dtx_reindex:1,
 				 sc_dtx_reindex_abort:1,
 				 sc_dtx_cos_shutdown:1,
+				 sc_dtx_cleanup_stale:1,
 				 sc_closing:1,
 				 sc_vos_aggregating:1,
 				 sc_abort_vos_aggregating:1,

--- a/src/include/daos_srv/dtx_srv.h
+++ b/src/include/daos_srv/dtx_srv.h
@@ -154,6 +154,7 @@ struct dtx_stat {
 	uint64_t	dtx_oldest_committable_time;
 	uint64_t	dtx_committed_count;
 	uint64_t	dtx_oldest_committed_time;
+	uint64_t	dtx_oldest_active_time;
 };
 
 enum dtx_flags {

--- a/src/include/daos_srv/vos_types.h
+++ b/src/include/daos_srv/vos_types.h
@@ -394,11 +394,13 @@ typedef struct {
 			struct dtx_id		ie_dtx_xid;
 			/** The OID. */
 			daos_unit_oid_t		ie_dtx_oid;
+			/* The time when create the DTX entry. */
+			uint64_t		ie_dtx_start_time;
 			/** The pool map version when handling DTX on server. */
 			uint32_t		ie_dtx_ver;
-			/* The DTX entry flags, see dtx_entry_flags. */
+			/** The DTX entry flags, see dtx_entry_flags. */
 			uint16_t		ie_dtx_flags;
-			/* DTX mbs flags, see dtx_mbs_flags. */
+			/** DTX mbs flags, see dtx_mbs_flags. */
 			uint16_t		ie_dtx_mbs_flags;
 			/** DTX tgt count. */
 			uint32_t		ie_dtx_tgt_cnt;

--- a/src/vos/vos_container.c
+++ b/src/vos/vos_container.c
@@ -185,6 +185,7 @@ cont_free_internal(struct vos_container *cont)
 
 	D_ASSERT(d_list_empty(&cont->vc_dtx_committed_list));
 	D_ASSERT(d_list_empty(&cont->vc_dtx_committed_tmp_list));
+	D_ASSERT(d_list_empty(&cont->vc_dtx_act_list));
 
 	dbtree_close(cont->vc_btr_hdl);
 
@@ -366,6 +367,7 @@ vos_cont_open(daos_handle_t poh, uuid_t co_uuid, daos_handle_t *coh)
 	cont->vc_dtx_committed_hdl = DAOS_HDL_INVAL;
 	D_INIT_LIST_HEAD(&cont->vc_dtx_committed_list);
 	D_INIT_LIST_HEAD(&cont->vc_dtx_committed_tmp_list);
+	D_INIT_LIST_HEAD(&cont->vc_dtx_act_list);
 	cont->vc_dtx_committed_count = 0;
 	cont->vc_dtx_committed_tmp_count = 0;
 

--- a/src/vos/vos_dtx.c
+++ b/src/vos/vos_dtx.c
@@ -615,6 +615,8 @@ do_dtx_rec_release(struct umem_instance *umm, struct vos_container *cont,
 	do {								\
 		D_DEBUG(DB_TRACE, "Evicting lid "DF_DTI": lid=%d\n",	\
 			DP_DTI(&DAE_XID(dae)), DAE_LID(dae));		\
+		if (!d_list_empty(&dae->dae_link))			\
+			d_list_del_init(&dae->dae_link);		\
 		lrua_evictx(cont->vc_dtx_array,				\
 			    DAE_LID(dae) - DTX_LID_RESERVED,		\
 			    DAE_EPOCH(dae));				\
@@ -814,6 +816,7 @@ vos_dtx_commit_one(struct vos_container *cont, struct dtx_id *dti,
 	if (dae != NULL) {
 		memcpy(&dce->dce_base.dce_common, &dae->dae_base.dae_common,
 		       sizeof(dce->dce_base.dce_common));
+		DCE_EPOCH(dce) = dae->dae_start_time;
 		dce->dce_oid_cnt = dae->dae_oid_cnt;
 		if (dce->dce_oid_cnt > 1) {
 			/* Take over OIDs buffer. */
@@ -834,7 +837,7 @@ vos_dtx_commit_one(struct vos_container *cont, struct dtx_id *dti,
 		D_ASSERT(dtx_is_valid_handle(dth));
 
 		DCE_XID(dce) = *dti;
-		DCE_EPOCH(dce) = epoch;
+		DCE_EPOCH(dce) = crt_hlc_get();
 		DCE_OID(dce) = dth->dth_leader_oid;
 		DCE_DKEY_HASH(dce) = dth->dth_dkey_hash;
 
@@ -1085,6 +1088,7 @@ vos_dtx_alloc(struct vos_dtx_blob_df *dbd, struct dtx_handle *dth)
 	DAE_GRP_CNT(dae) = dth->dth_mbs->dm_grp_cnt;
 	DAE_MBS_DSIZE(dae) = dth->dth_mbs->dm_data_size;
 	DAE_MBS_FLAGS(dae) = dth->dth_mbs->dm_flags;
+	D_INIT_LIST_HEAD(&dae->dae_link);
 
 	if (dbd != NULL) {
 		D_ASSERT(dbd->dbd_magic == DTX_ACT_BLOB_MAGIC);
@@ -1104,10 +1108,13 @@ vos_dtx_alloc(struct vos_dtx_blob_df *dbd, struct dtx_handle *dth)
 	d_iov_set(&riov, dae, sizeof(*dae));
 	rc = dbtree_upsert(cont->vc_dtx_active_hdl, BTR_PROBE_EQ,
 			   DAOS_INTENT_UPDATE, &kiov, &riov);
-	if (rc == 0)
+	if (rc == 0) {
+		dae->dae_start_time = crt_hlc_get();
+		d_list_add_tail(&dae->dae_link, &cont->vc_dtx_act_list);
 		dth->dth_ent = dae;
-	else
+	} else {
 		dtx_evict_lid(cont, dae);
+	}
 
 	return rc;
 }
@@ -2182,8 +2189,14 @@ vos_dtx_stat(daos_handle_t coh, struct dtx_stat *stat)
 	stat->dtx_committed_count = cont->vc_dtx_committed_count;
 	if (d_list_empty(&cont->vc_dtx_committed_list)) {
 		stat->dtx_oldest_committed_time = 0;
+		stat->dtx_oldest_active_time = 0;
 	} else {
 		struct vos_dtx_cmt_ent	*dce;
+		struct vos_dtx_act_ent	*dae;
+
+		dae = d_list_entry(cont->vc_dtx_act_list.next,
+				   struct vos_dtx_act_ent, dae_link);
+		stat->dtx_oldest_active_time = dae->dae_start_time;
 
 		dce = d_list_entry(cont->vc_dtx_committed_list.next,
 				   struct vos_dtx_cmt_ent, dce_committed_link);
@@ -2300,6 +2313,7 @@ vos_dtx_act_reindex(struct vos_container *cont)
 			memcpy(&dae->dae_base, dae_df, sizeof(dae->dae_base));
 			dae->dae_df_off = umem_ptr2off(umm, dae_df);
 			dae->dae_dbd = dbd;
+			D_INIT_LIST_HEAD(&dae->dae_link);
 
 			if (DAE_REC_CNT(dae) > DTX_INLINE_REC_CNT) {
 				size_t	size;
@@ -2330,6 +2344,9 @@ vos_dtx_act_reindex(struct vos_container *cont)
 				dtx_evict_lid(cont, dae);
 				goto out;
 			}
+
+			dae->dae_start_time = crt_hlc_get();
+			d_list_add_tail(&dae->dae_link, &cont->vc_dtx_act_list);
 		}
 
 		dbd_off = dbd->dbd_next;

--- a/src/vos/vos_dtx_iter.c
+++ b/src/vos/vos_dtx_iter.c
@@ -21,6 +21,8 @@ struct vos_dtx_iter {
 	daos_handle_t		 oit_hdl;
 	/** Reference to the container */
 	struct vos_container	*oit_cont;
+	struct vos_dtx_act_ent	*oit_cur;
+	bool			 oit_linear;
 };
 
 static struct vos_dtx_iter *
@@ -83,6 +85,8 @@ dtx_iter_prep(vos_iter_type_t type, vos_iter_param_t *param,
 		dtx_iter_fini(&oiter->oit_iter);
 	} else {
 		*iter_pp = &oiter->oit_iter;
+		oiter->oit_cur = NULL;
+		oiter->oit_linear = false;
 	}
 
 	return rc;
@@ -92,13 +96,27 @@ static int
 dtx_iter_probe(struct vos_iterator *iter, daos_anchor_t *anchor)
 {
 	struct vos_dtx_iter	*oiter = iter2oiter(iter);
-	dbtree_probe_opc_t	 opc;
+	int			 rc = 0;
 
 	D_ASSERT(iter->it_type == VOS_ITER_DTX);
 
-	opc = anchor == NULL ? BTR_PROBE_FIRST : BTR_PROBE_GE;
-	return dbtree_iter_probe(oiter->oit_hdl, opc, vos_iter_intent(iter),
-				 NULL, anchor);
+	if (anchor == NULL) {
+		oiter->oit_linear = true;
+		if (d_list_empty(&oiter->oit_cont->vc_dtx_act_list)) {
+			oiter->oit_cur = NULL;
+			rc = -DER_NONEXIST;
+		} else {
+			oiter->oit_cur =
+			d_list_entry(oiter->oit_cont->vc_dtx_act_list.next,
+				     struct vos_dtx_act_ent, dae_link);
+		}
+	} else {
+		oiter->oit_linear = false;
+		rc = dbtree_iter_probe(oiter->oit_hdl, BTR_PROBE_GE,
+				       vos_iter_intent(iter), NULL, anchor);
+	}
+
+	return rc;
 }
 
 static int
@@ -112,17 +130,34 @@ dtx_iter_next(struct vos_iterator *iter)
 	D_ASSERT(iter->it_type == VOS_ITER_DTX);
 
 	while (1) {
-		rc = dbtree_iter_next(oiter->oit_hdl);
-		if (rc != 0)
-			break;
+		if (oiter->oit_linear) {
+			if (oiter->oit_cur == NULL)
+				D_GOTO(out, rc = -DER_NONEXIST);
 
-		d_iov_set(&rec_iov, NULL, 0);
-		rc = dbtree_iter_fetch(oiter->oit_hdl, NULL, &rec_iov, NULL);
-		if (rc != 0)
-			break;
+			if (oiter->oit_cur->dae_link.next ==
+			    &oiter->oit_cont->vc_dtx_act_list) {
+				oiter->oit_cur = NULL;
+				D_GOTO(out, rc = -DER_NONEXIST);
+			}
 
-		D_ASSERT(rec_iov.iov_len == sizeof(struct vos_dtx_act_ent));
-		dae = (struct vos_dtx_act_ent *)rec_iov.iov_buf;
+			dae = oiter->oit_cur =
+				d_list_entry(oiter->oit_cur->dae_link.next,
+					     struct vos_dtx_act_ent, dae_link);
+		} else {
+			rc = dbtree_iter_next(oiter->oit_hdl);
+			if (rc != 0)
+				goto out;
+
+			d_iov_set(&rec_iov, NULL, 0);
+			rc = dbtree_iter_fetch(oiter->oit_hdl, NULL,
+					       &rec_iov, NULL);
+			if (rc != 0)
+				goto out;
+
+			D_ASSERT(rec_iov.iov_len ==
+				 sizeof(struct vos_dtx_act_ent));
+			dae = (struct vos_dtx_act_ent *)rec_iov.iov_buf;
+		}
 
 		/* Only return prepared ones. */
 		if (!dae->dae_committable && !dae->dae_committed &&
@@ -130,6 +165,7 @@ dtx_iter_next(struct vos_iterator *iter)
 			break;
 	}
 
+out:
 	return rc;
 }
 
@@ -144,16 +180,23 @@ dtx_iter_fetch(struct vos_iterator *iter, vos_iter_entry_t *it_entry,
 
 	D_ASSERT(iter->it_type == VOS_ITER_DTX);
 
-	d_iov_set(&rec_iov, NULL, 0);
-	rc = dbtree_iter_fetch(oiter->oit_hdl, NULL, &rec_iov, anchor);
-	if (rc != 0) {
-		D_ERROR("Error while fetching DTX info: rc = "DF_RC"\n",
-			DP_RC(rc));
-		return rc;
-	}
+	if (oiter->oit_linear) {
+		if (oiter->oit_cur == NULL)
+			return -DER_NONEXIST;
 
-	D_ASSERT(rec_iov.iov_len == sizeof(struct vos_dtx_act_ent));
-	dae = (struct vos_dtx_act_ent *)rec_iov.iov_buf;
+		dae = oiter->oit_cur;
+	} else {
+		d_iov_set(&rec_iov, NULL, 0);
+		rc = dbtree_iter_fetch(oiter->oit_hdl, NULL, &rec_iov, anchor);
+		if (rc != 0) {
+			D_ERROR("Error while fetching DTX info: rc = "DF_RC"\n",
+				DP_RC(rc));
+			return rc;
+		}
+
+		D_ASSERT(rec_iov.iov_len == sizeof(struct vos_dtx_act_ent));
+		dae = (struct vos_dtx_act_ent *)rec_iov.iov_buf;
+	}
 
 	it_entry->ie_epoch = DAE_EPOCH(dae);
 	it_entry->ie_dtx_xid = DAE_XID(dae);
@@ -170,6 +213,7 @@ dtx_iter_fetch(struct vos_iterator *iter, vos_iter_entry_t *it_entry,
 		it_entry->ie_dtx_mbs = umem_off2ptr(
 					&oiter->oit_cont->vc_pool->vp_umm,
 					DAE_MBS_OFF(dae));
+	it_entry->ie_dtx_start_time = dae->dae_start_time;
 
 	D_DEBUG(DB_IO, "DTX iterator fetch the one "DF_DTI"\n",
 		DP_DTI(&DAE_XID(dae)));
@@ -180,27 +224,11 @@ dtx_iter_fetch(struct vos_iterator *iter, vos_iter_entry_t *it_entry,
 static int
 dtx_iter_delete(struct vos_iterator *iter, void *args)
 {
-	struct vos_dtx_iter	*oiter = iter2oiter(iter);
-	struct umem_instance	*umm;
-	int			 rc;
-
 	D_ASSERT(iter->it_type == VOS_ITER_DTX);
 
-	umm = &oiter->oit_cont->vc_pool->vp_umm;
-	rc = umem_tx_begin(umm, NULL);
-	if (rc != 0)
-		return rc;
+	D_WARN("NOT allow to remove DTX entry via iteration!\n");
 
-	rc = dbtree_iter_delete(oiter->oit_hdl, args);
-	if (rc != 0) {
-		umem_tx_abort(umm, rc);
-		D_ERROR("Failed to delete DTX entry: rc = "DF_RC"\n",
-			DP_RC(rc));
-	} else {
-		umem_tx_commit(umm);
-	}
-
-	return rc;
+	return -DER_NO_PERM;
 }
 
 struct vos_iter_ops vos_dtx_iter_ops = {

--- a/src/vos/vos_internal.h
+++ b/src/vos/vos_internal.h
@@ -190,6 +190,8 @@ struct vos_container {
 	d_list_t		vc_dtx_committed_list;
 	/* The temporary list for committed DTXs during re-index. */
 	d_list_t		vc_dtx_committed_tmp_list;
+	/* The list for active DTXs, roughly ordered in time. */
+	d_list_t		vc_dtx_act_list;
 	/* The count of committed DTXs. */
 	uint32_t		vc_dtx_committed_count;
 	/* The items count in vc_dtx_committed_tmp_list. */
@@ -242,6 +244,10 @@ struct vos_dtx_act_ent {
 	 * it is not fatal.
 	 */
 	daos_unit_oid_t			*dae_oids;
+	/* The time (hlc) when the DTX entry is created. */
+	daos_epoch_t			 dae_start_time;
+	/* Link into container::vc_dtx_act_list. */
+	d_list_t			 dae_link;
 
 	unsigned int			 dae_committable:1,
 					 dae_committed:1,


### PR DESCRIPTION
It is possible that some server missed or failed to execute
some DTX commit/abort RPC, then related DTX entry will be
kept on such server as garbage information until some other
tries to access related data (and refreshed via DTX refreh).
But if such accessing does not happen in time as to related
committed DTX entry on the leader has been aggregated, then
we will not have efficient way to know whether such DTX can
be committed or aborted.

To avoid above trouble, we will make the DTX batched commit
ULT to periodically scan the active DTX table to find out
those stale 'prepared' DTX entries and force DTX refresh for
them. The threshold for the age of stale DTX entry is much
smaller than the DTX aggregation time threshold, then we will
more chance to cleanup those stale DTX entries before leader
side DTX aggregation.

Implement linear iteration for DTX resync and cleanup stale
DTX entries.

Signed-off-by: Fan Yong <fan.yong@intel.com>