### PR TITLE
DAOS-6973 dtx: more test cases for transaction logic

### DIFF
--- a/src/container/srv_target.c
+++ b/src/container/srv_target.c
@@ -501,7 +501,7 @@ out:
 	ds_cont_child_put(cont);
 }
 
-static int
+int
 cont_start_dtx_reindex_ult(struct ds_cont_child *cont)
 {
 	int rc;

--- a/src/include/daos/common.h
+++ b/src/include/daos/common.h
@@ -617,6 +617,36 @@ enum {
 	DAOS_FAIL_MAX_GROUP
 };
 
+#define DAOS_RESEND_LEADER_SHIFT	1
+#define DAOS_RESEND_FOLLOWER_SHIFT	2
+#define DAOS_RESEND_EPOCH_SHIFT		3
+
+static inline uint64_t
+daos_resend_gen_fail_value(bool leader, bool follower, bool epoch)
+{
+	return ((leader ? 1 : 0) << DAOS_RESEND_LEADER_SHIFT) |
+	       ((follower ? 1 : 0) << DAOS_RESEND_FOLLOWER_SHIFT) |
+	       ((epoch ? 1 : 0) << DAOS_RESEND_EPOCH_SHIFT);
+}
+
+static inline bool
+daos_resend_leader_prepared(uint64_t value)
+{
+	return ((value >> DAOS_RESEND_LEADER_SHIFT) & 1) ? true : false;
+}
+
+static inline bool
+daos_resend_follower_prepared(uint64_t value)
+{
+	return ((value >> DAOS_RESEND_FOLLOWER_SHIFT) & 1) ? true : false;
+}
+
+static inline bool
+daos_resend_new_epoch(uint64_t value)
+{
+	return ((value >> DAOS_RESEND_EPOCH_SHIFT) & 1) ? true : false;
+}
+
 #define DAOS_FAIL_ID_GET(fail_loc)	(fail_loc & DAOS_FAIL_ID_MASK)
 
 #define DAOS_FAIL_UNIT_TEST_GROUP_LOC	\
@@ -681,7 +711,7 @@ enum {
 
 #define DAOS_DTX_COMMIT_SYNC		(DAOS_FAIL_UNIT_TEST_GROUP_LOC | 0x30)
 #define DAOS_DTX_LEADER_ERROR		(DAOS_FAIL_UNIT_TEST_GROUP_LOC | 0x31)
-#define DAOS_DTX_NONLEADER_ERROR	(DAOS_FAIL_UNIT_TEST_GROUP_LOC | 0x32)
+#define DAOS_DTX_FOLLOWER_ERROR	(DAOS_FAIL_UNIT_TEST_GROUP_LOC | 0x32)
 #define DAOS_DTX_LOST_RPC_REQUEST	(DAOS_FAIL_UNIT_TEST_GROUP_LOC | 0x33)
 #define DAOS_DTX_LOST_RPC_REPLY		(DAOS_FAIL_UNIT_TEST_GROUP_LOC | 0x34)
 #define DAOS_DTX_LONG_TIME_RESEND	(DAOS_FAIL_UNIT_TEST_GROUP_LOC | 0x35)
@@ -704,6 +734,10 @@ enum {
 #define DAOS_DTX_SPEC_LEADER		(DAOS_FAIL_UNIT_TEST_GROUP_LOC | 0x45)
 #define DAOS_DTX_SRV_RESTART		(DAOS_FAIL_UNIT_TEST_GROUP_LOC | 0x46)
 #define DAOS_DTX_NO_RETRY		(DAOS_FAIL_UNIT_TEST_GROUP_LOC | 0x47)
+#define DAOS_DTX_RESEND_DELAY1		(DAOS_FAIL_UNIT_TEST_GROUP_LOC | 0x48)
+#define DAOS_DTX_RESEND_DELAY2		(DAOS_FAIL_UNIT_TEST_GROUP_LOC | 0x49)
+#define DAOS_DTX_RESEND_DELAY3		(DAOS_FAIL_UNIT_TEST_GROUP_LOC | 0x4a)
+#define DAOS_DTX_RESEND_DELAY4		(DAOS_FAIL_UNIT_TEST_GROUP_LOC | 0x4b)
 
 #define DAOS_NVME_FAULTY		(DAOS_FAIL_UNIT_TEST_GROUP_LOC | 0x50)
 #define DAOS_NVME_WRITE_ERR		(DAOS_FAIL_UNIT_TEST_GROUP_LOC | 0x51)

--- a/src/include/daos_srv/container.h
+++ b/src/include/daos_srv/container.h
@@ -117,6 +117,8 @@ struct ds_cont_child {
 	uint32_t		 sc_dtx_resync_ver;
 };
 
+int cont_start_dtx_reindex_ult(struct ds_cont_child *cont);
+
 /*
  * Per-thread container handle (memory) object
  *

--- a/src/object/cli_shard.c
+++ b/src/object/cli_shard.c
@@ -1129,6 +1129,14 @@ dc_obj_shard_rw(struct dc_obj_shard *shard, enum obj_rpc_opc opc,
 	if (daos_io_bypass & IOBP_CLI_RPC) {
 		rc = daos_rpc_complete(req, task);
 	} else {
+		if (!(orw->orw_flags & ORF_RESEND) &&
+		    (DAOS_FAIL_CHECK(DAOS_DTX_RESEND_DELAY1) ||
+		     DAOS_FAIL_CHECK(DAOS_DTX_RESEND_DELAY2) ||
+		     DAOS_FAIL_CHECK(DAOS_DTX_RESEND_DELAY3) ||
+		     DAOS_FAIL_CHECK(DAOS_DTX_LOST_RPC_REQUEST)))
+			/* RPC (to leader) timeout is 3 seconds. */
+			rc = crt_req_set_timeout(req, 3);
+
 		rc = daos_rpc_send(req, task);
 		if (rc != 0) {
 			D_ERROR("update/fetch rpc failed rc "DF_RC"\n",

--- a/src/object/obj_rpc.c
+++ b/src/object/obj_rpc.c
@@ -711,7 +711,7 @@ crt_proc_struct_daos_cpd_sub_req(crt_proc_t proc,
 	if (with_oid) {
 		rc = crt_proc_daos_unit_oid_t(proc, &dcsr->dcsr_oid);
 	} else if (ENCODING(proc_op)) {
-		daos_unit_oid_t		 oid;
+		daos_unit_oid_t		 oid = { 0 };
 
 		daos_dc_obj2id(dcsr->dcsr_obj, &oid.id_pub);
 		/* It is not important what the id_shard is, that
@@ -1209,8 +1209,10 @@ obj_reply_map_version_set(crt_rpc_t *rpc, uint32_t map_version)
 		break;
 	case DAOS_OBJ_RPC_EC_AGGREGATE:
 		((struct obj_ec_agg_out *)reply)->ea_map_ver = map_version;
+		break;
 	case DAOS_OBJ_RPC_CPD:
 		((struct obj_cpd_out *)reply)->oco_map_version = map_version;
+		break;
 	case DAOS_OBJ_RPC_EC_REPLICATE:
 		((struct obj_ec_rep_out *)reply)->er_map_ver = map_version;
 		break;

--- a/src/tests/suite/daos_test.h
+++ b/src/tests/suite/daos_test.h
@@ -477,6 +477,11 @@ void write_ec_full_partial(struct ioreq *req, int test_idx, daos_off_t off);
 void write_ec_partial_full(struct ioreq *req, int test_idx, daos_off_t off);
 void verify_ec_full_partial(struct ioreq *req, int test_idx, daos_off_t off);
 void make_buffer(char *buffer, char start, int total);
+void dtx_share_oid(daos_obj_id_t *oid);
+void dtx_resend_check(test_arg_t *arg, bool leader_prepared,
+		      bool follower_prepared, bool new_epoch, bool distributed);
+int dtx_sub_setup(void **state);
+int dtx_sub_teardown(void **state);
 
 static inline void
 daos_test_print(int rank, char *message)

--- a/src/vos/vos_container.c
+++ b/src/vos/vos_container.c
@@ -369,6 +369,9 @@ vos_cont_open(daos_handle_t poh, uuid_t co_uuid, daos_handle_t *coh)
 	cont->vc_dtx_committed_count = 0;
 	cont->vc_dtx_committed_tmp_count = 0;
 
+	if (umoff_is_null(cont->vc_cont_df->cd_dtx_committed_head))
+		cont->vc_cmt_reindexed = 1;
+
 	/* Cache this btr object ID in container handle */
 	rc = dbtree_open_inplace_ex(&cont->vc_cont_df->cd_obj_root,
 				    &pool->vp_uma, vos_cont2hdl(cont),

--- a/src/vos/vos_dtx.c
+++ b/src/vos/vos_dtx.c
@@ -84,12 +84,6 @@ dtx_umoff_flag2type(umem_off_t umoff)
 }
 
 static inline bool
-umoff_is_null(umem_off_t umoff)
-{
-	return umoff == UMOFF_NULL;
-}
-
-static inline bool
 dtx_is_aborted(uint32_t tx_lid)
 {
 	return tx_lid == DTX_LID_ABORTED;
@@ -329,7 +323,7 @@ dtx_cmt_ent_alloc(struct btr_instance *tins, d_iov_t *key_iov,
 	struct vos_dtx_cmt_ent	*dce = val_iov->iov_buf;
 
 	rec->rec_off = umem_ptr2off(&tins->ti_umm, dce);
-	if (!cont->vc_reindex_cmt_dtx || dce->dce_reindex) {
+	if (cont->vc_cmt_reindexed || dce->dce_reindex) {
 		d_list_add_tail(&dce->dce_committed_link,
 				&cont->vc_dtx_committed_list);
 		cont->vc_dtx_committed_count++;
@@ -358,7 +352,7 @@ dtx_cmt_ent_free(struct btr_instance *tins, struct btr_record *rec,
 
 	rec->rec_off = UMOFF_NULL;
 	d_list_del(&dce->dce_committed_link);
-	if (!cont->vc_reindex_cmt_dtx || dce->dce_reindex)
+	if (cont->vc_cmt_reindexed || dce->dce_reindex)
 		cont->vc_dtx_committed_count--;
 	else
 		cont->vc_dtx_committed_tmp_count--;
@@ -1762,7 +1756,7 @@ vos_dtx_check(daos_handle_t coh, struct dtx_id *dti, daos_epoch_t *epoch,
 			return DTX_ST_COMMITTED;
 	}
 
-	if (rc == -DER_NONEXIST && for_resent && cont->vc_reindex_cmt_dtx)
+	if (rc == -DER_NONEXIST && for_resent && !cont->vc_cmt_reindexed)
 		rc = -DER_AGAIN;
 
 	return rc;
@@ -2369,8 +2363,6 @@ vos_dtx_cmt_reindex(daos_handle_t coh, void *hint)
 
 	D_ASSERT(dbd->dbd_magic == DTX_CMT_BLOB_MAGIC);
 
-	cont->vc_reindex_cmt_dtx = 1;
-
 	for (i = 0; i < dbd->dbd_count; i++) {
 		if (daos_is_zero_dti(&dbd->dbd_committed_data[i].dce_xid) ||
 		    dbd->dbd_committed_data[i].dce_epoch == 0) {
@@ -2412,7 +2404,8 @@ out:
 		cont->vc_dtx_committed_count +=
 				cont->vc_dtx_committed_tmp_count;
 		cont->vc_dtx_committed_tmp_count = 0;
-		cont->vc_reindex_cmt_dtx = 0;
+		cont->vc_cmt_reindexed = 1;
+
 	}
 
 	return rc;
@@ -2583,7 +2576,6 @@ vos_dtx_cache_reset(daos_handle_t coh)
 {
 	struct vos_container	*cont;
 	struct umem_attr	 uma;
-	uint64_t		 hint = 0;
 	int			 rc = 0;
 
 	cont = vos_hdl2cont(coh);
@@ -2613,6 +2605,7 @@ vos_dtx_cache_reset(daos_handle_t coh)
 	cont->vc_dtx_committed_hdl = DAOS_HDL_INVAL;
 	cont->vc_dtx_committed_count = 0;
 	cont->vc_dtx_committed_tmp_count = 0;
+	cont->vc_cmt_reindexed = 0;
 
 	rc = lrua_array_alloc(&cont->vc_dtx_array, DTX_ARRAY_LEN, DTX_ARRAY_NR,
 			      sizeof(struct vos_dtx_act_ent),
@@ -2650,18 +2643,9 @@ vos_dtx_cache_reset(daos_handle_t coh)
 	}
 
 	rc = vos_dtx_act_reindex(cont);
-	if (rc != 0) {
+	if (rc != 0)
 		D_ERROR("Fail to reindex active DTX table: "DF_RC"\n",
 			DP_RC(rc));
-		goto out;
-	}
-
-	do {
-		rc = vos_dtx_cmt_reindex(coh, &hint);
-		if (rc < 0)
-			D_ERROR("Fail to reindex committed DTX table: "
-				DF_RC"\n", DP_RC(rc));
-	} while (rc == 0);
 
 out:
 	D_DEBUG(DB_TRACE, "Reset the DTX cache: "DF_RC"\n", DP_RC(rc));

--- a/src/vos/vos_internal.h
+++ b/src/vos/vos_internal.h
@@ -210,7 +210,7 @@ struct vos_container {
 	/* Various flags */
 	unsigned int		vc_in_aggregation:1,
 				vc_in_discard:1,
-				vc_reindex_cmt_dtx:1;
+				vc_cmt_reindexed:1;
 	unsigned int		vc_open_count;
 };
 
@@ -1228,6 +1228,12 @@ vos_has_uncertainty(struct vos_ts_set *ts_set,
 		return true;
 
 	return vos_ts_wcheck(ts_set, epoch, bound);
+}
+
+static inline bool
+umoff_is_null(umem_off_t umoff)
+{
+	return umoff == UMOFF_NULL;
 }
 
 /** For dealing with common routines between punch and update where akeys are


### PR DESCRIPTION
Mainly focus on kinds of race conditions, including the race
among resent RPC, DTX resync, DTX refresh, DTX table reindex
and failure cases, such as double failure, and so on.

It also contains some simple bugs fixes (complex issues will
be fixed via separated patches), such as don't busy wait DTX
re-index on server (for checking resend RPC), avoid starting
DTX re-index inside VOS, initialize daos_unit_oid_t::id_pad_32
that is used by vos_object cache, and so on.

Signed-off-by: Fan Yong <fan.yong@intel.com>