### PR TITLE
DAOS-6783 control: return non-zero on dmg system action result error

### DIFF
--- a/src/control/lib/control/system.go
+++ b/src/control/lib/control/system.go
@@ -9,8 +9,8 @@ package control
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"net"
+	"strings"
 	"time"
 
 	"github.com/dustin/go-humanize/english"
@@ -65,23 +65,24 @@ func (resp *sysResponse) getAbsentHostsRanks(inHosts, inRanks string) error {
 	return nil
 }
 
-func (resp *sysResponse) DisplayAbsentHostsRanks() string {
-	switch {
-	case resp.AbsentHosts.Count() > 0:
-		return fmt.Sprintf("\nUnknown %s: %s",
-			english.Plural(resp.AbsentHosts.Count(), "host", "hosts"),
-			resp.AbsentHosts.String())
-	case resp.AbsentRanks.Count() > 0:
-		return fmt.Sprintf("\nUnknown %s: %s",
-			english.Plural(resp.AbsentRanks.Count(), "rank", "ranks"),
-			resp.AbsentRanks.String())
-	default:
-		return ""
+func (resp *sysResponse) getAbsentHostsRanksErrors() error {
+	var errMsgs []string
+
+	if resp.AbsentHosts.Count() > 0 {
+		errMsgs = append(errMsgs, "non-existent hosts "+resp.AbsentHosts.String())
 	}
+	if resp.AbsentRanks.Count() > 0 {
+		errMsgs = append(errMsgs, "non-existent ranks "+resp.AbsentRanks.String())
+	}
+
+	if len(errMsgs) > 0 {
+		return errors.New(strings.Join(errMsgs, ", "))
+	}
+
+	return nil
 }
 
 // SystemJoinReq contains the inputs for the system join request.
-// TODO: Unify this with system.JoinRequest
 type SystemJoinReq struct {
 	unaryRequest
 	msRequest
@@ -318,6 +319,12 @@ func (resp *SystemQueryResp) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+// Errors returns a single error combining all error messages associated with a
+// system query response.
+func (resp *SystemQueryResp) Errors() error {
+	return resp.getAbsentHostsRanksErrors()
+}
+
 // SystemQuery requests DAOS system status.
 //
 // Handles MS requests sent from management client app e.g. 'dmg' and calls into
@@ -346,6 +353,23 @@ func SystemQuery(ctx context.Context, rpcClient UnaryInvoker, req *SystemQueryRe
 
 	resp := new(SystemQueryResp)
 	return resp, convertMSResponse(ur, resp)
+}
+
+func concatSysErrs(errSys, errRes error) error {
+	var errMsgs []string
+
+	if errSys != nil {
+		errMsgs = append(errMsgs, errSys.Error())
+	}
+	if errRes != nil {
+		errMsgs = append(errMsgs, "check results for "+errRes.Error())
+	}
+
+	if len(errMsgs) > 0 {
+		return errors.New(strings.Join(errMsgs, ", "))
+	}
+
+	return nil
 }
 
 // SystemStartReq contains the inputs for the system start request.
@@ -379,6 +403,12 @@ func (resp *SystemStartResp) UnmarshalJSON(data []byte) error {
 	}
 
 	return nil
+}
+
+// Errors returns a single error combining all error messages associated with a
+// system start response.
+func (resp *SystemStartResp) Errors() error {
+	return concatSysErrs(resp.getAbsentHostsRanksErrors(), resp.Results.Errors())
 }
 
 // SystemStart will perform a start after a controlled shutdown of DAOS system.
@@ -445,6 +475,12 @@ func (resp *SystemStopResp) UnmarshalJSON(data []byte) error {
 	}
 
 	return nil
+}
+
+// Errors returns a single error combining all error messages associated with a
+// system stop response.
+func (resp *SystemStopResp) Errors() error {
+	return concatSysErrs(resp.getAbsentHostsRanksErrors(), resp.Results.Errors())
 }
 
 // SystemStop will perform a two-phase controlled shutdown of DAOS system and a

--- a/src/control/server/ctl_ranks_rpc.go
+++ b/src/control/server/ctl_ranks_rpc.go
@@ -130,24 +130,24 @@ func (svc *ControlService) PrepShutdownRanks(ctx context.Context, req *ctlpb.Ran
 
 // memberStateResults returns system member results reflecting whether the state
 // of the given member is equivalent to the supplied desired state value.
-func (svc *ControlService) memberStateResults(instances []*EngineInstance, desiredState system.MemberState, successMsg string) (system.MemberResults, error) {
+func (svc *ControlService) memberStateResults(instances []*EngineInstance, tgtState system.MemberState, okMsg, failMsg string) (system.MemberResults, error) {
 	results := make(system.MemberResults, 0, len(instances))
 	for _, srv := range instances {
 		rank, err := srv.GetRank()
 		if err != nil {
-			svc.log.Debugf("Instance %d GetRank(): %s", srv.Index(), err)
+			svc.log.Debugf("skip MemberResult, Instance %d GetRank(): %s", srv.Index(), err)
 			continue
 		}
 
 		state := srv.LocalState()
-		if state != desiredState {
-			results = append(results, system.NewMemberResult(rank,
-				errors.Errorf("want %s, got %s", desiredState, state), state))
+		if state != tgtState {
+			results = append(results, system.NewMemberResult(rank, errors.Errorf(failMsg),
+				system.MemberStateErrored))
 			continue
 		}
 
 		results = append(results, &system.MemberResult{
-			Rank: rank, Msg: successMsg, State: state,
+			Rank: rank, Msg: okMsg, State: state,
 		})
 	}
 
@@ -200,7 +200,8 @@ func (svc *ControlService) StopRanks(ctx context.Context, req *ctlpb.RanksReq) (
 		return nil, err
 	}
 
-	results, err := svc.memberStateResults(instances, system.MemberStateStopped, "system stop")
+	results, err := svc.memberStateResults(instances, system.MemberStateStopped, "system stop",
+		"system stop: rank failed to stop within "+svc.harness.rankReqTimeout.String())
 	if err != nil {
 		return nil, err
 	}
@@ -385,7 +386,8 @@ func (svc *ControlService) StartRanks(ctx context.Context, req *ctlpb.RanksReq) 
 
 	// instances will update state to "Started" through join or
 	// bootstrap in membership, here just make sure instances are "Ready"
-	results, err := svc.memberStateResults(instances, system.MemberStateReady, "system start")
+	results, err := svc.memberStateResults(instances, system.MemberStateReady, "system start",
+		"system start: rank failed to start within "+svc.harness.rankStartTimeout.String())
 	if err != nil {
 		return nil, err
 	}

--- a/src/control/server/ctl_ranks_rpc_test.go
+++ b/src/control/server/ctl_ranks_rpc_test.go
@@ -294,16 +294,16 @@ func TestServer_CtlSvc_StopRanks(t *testing.T) {
 			req:            &ctlpb.RanksReq{Ranks: "0-3"},
 			expSignalsSent: map[uint32]os.Signal{0: syscall.SIGINT, 1: syscall.SIGINT},
 			expResults: []*sharedpb.RankResult{
-				{Rank: 1, State: msReady, Errored: true},
-				{Rank: 2, State: msReady, Errored: true},
+				{Rank: 1, State: msErrored, Errored: true},
+				{Rank: 2, State: msErrored, Errored: true},
 			},
 		},
 		"force stop instances started": { // unsuccessful result for kill
 			req:            &ctlpb.RanksReq{Ranks: "0-3", Force: true},
 			expSignalsSent: map[uint32]os.Signal{0: syscall.SIGKILL, 1: syscall.SIGKILL},
 			expResults: []*sharedpb.RankResult{
-				{Rank: 1, State: msReady, Errored: true},
-				{Rank: 2, State: msReady, Errored: true},
+				{Rank: 1, State: msErrored, Errored: true},
+				{Rank: 2, State: msErrored, Errored: true},
 			},
 		},
 		"instances already stopped": { // successful result for kill
@@ -318,7 +318,7 @@ func TestServer_CtlSvc_StopRanks(t *testing.T) {
 			req:            &ctlpb.RanksReq{Ranks: "1", Force: true},
 			expSignalsSent: map[uint32]os.Signal{0: syscall.SIGKILL},
 			expResults: []*sharedpb.RankResult{
-				{Rank: 1, State: msReady, Errored: true},
+				{Rank: 1, State: msErrored, Errored: true},
 			},
 		},
 		"single instance already stopped": {
@@ -838,8 +838,8 @@ func TestServer_CtlSvc_StartRanks(t *testing.T) {
 			instancesStopped: true,
 			startFails:       true,
 			expResults: []*sharedpb.RankResult{
-				{Rank: 1, State: msStopped, Errored: true},
-				{Rank: 2, State: msStopped, Errored: true},
+				{Rank: 1, State: msErrored, Errored: true},
+				{Rank: 2, State: msErrored, Errored: true},
 			},
 		},
 	} {

--- a/src/control/server/mgmt_system.go
+++ b/src/control/server/mgmt_system.go
@@ -422,14 +422,10 @@ func (svc *mgmtSvc) resolveRanks(hosts, ranks string) (hitRS, missRS *system.Ran
 		if hitRS, missHS, err = svc.membership.CheckHosts(hosts, build.DefaultControlPort); err != nil {
 			return
 		}
-		svc.log.Debugf("resolveRanks(): req hosts %s, hit ranks %s, miss hosts %s",
-			hosts, hitRS, missHS)
 	case hasRanks:
 		if hitRS, missRS, err = svc.membership.CheckRanks(ranks); err != nil {
 			return
 		}
-		svc.log.Debugf("resolveRanks(): req ranks %s, hit ranks %s, miss ranks %s",
-			ranks, hitRS, missRS)
 	default:
 		// empty rank/host sets implies include all ranks so pass empty
 		// string to CheckRanks()
@@ -584,6 +580,10 @@ func (svc *mgmtSvc) SystemStop(ctx context.Context, pbReq *mgmtpb.SystemStopReq)
 	}
 	svc.log.Debug("Received SystemStop RPC")
 
+	if !pbReq.GetPrep() && !pbReq.GetKill() {
+		return nil, errors.New("invalid request, no action specified")
+	}
+
 	// Raise event on systemwide shutdown
 	if pbReq.GetHosts() == "" && pbReq.GetRanks() == "" && pbReq.GetKill() {
 		svc.events.Publish(events.New(&events.RASEvent{
@@ -594,7 +594,6 @@ func (svc *mgmtSvc) SystemStop(ctx context.Context, pbReq *mgmtpb.SystemStopReq)
 		}))
 	}
 
-	// TODO: consider locking to prevent join attempts when shutting down
 	pbResp := new(mgmtpb.SystemStopResp)
 
 	fanReq := fanoutRequest{
@@ -604,8 +603,6 @@ func (svc *mgmtSvc) SystemStop(ctx context.Context, pbReq *mgmtpb.SystemStopReq)
 	}
 
 	if pbReq.GetPrep() {
-		svc.log.Debug("prepping ranks for shutdown")
-
 		fanReq.Method = control.PrepShutdownRanks
 		fanResp, _, err := svc.rpcFanout(ctx, fanReq, false)
 		if err != nil {
@@ -614,25 +611,19 @@ func (svc *mgmtSvc) SystemStop(ctx context.Context, pbReq *mgmtpb.SystemStopReq)
 		if err := populateStopResp(fanResp, pbResp, "prep shutdown"); err != nil {
 			return nil, err
 		}
-		if !fanReq.Force && fanResp.Results.HasErrors() {
+		if !fanReq.Force && fanResp.Results.Errors() != nil {
 			return pbResp, errors.New("PrepShutdown HasErrors")
 		}
 	}
 	if pbReq.GetKill() {
-		svc.log.Debug("shutting down ranks")
-
 		fanReq.Method = control.StopRanks
-		fanResp, _, err := svc.rpcFanout(ctx, fanReq, false)
+		fanResp, _, err := svc.rpcFanout(ctx, fanReq, true)
 		if err != nil {
 			return nil, err
 		}
 		if err := populateStopResp(fanResp, pbResp, "stop"); err != nil {
 			return nil, err
 		}
-	}
-
-	if pbResp.GetResults() == nil {
-		return nil, errors.New("response results not populated")
 	}
 
 	svc.log.Debugf("Responding to SystemStop RPC: %+v", pbResp)
@@ -668,7 +659,7 @@ func (svc *mgmtSvc) SystemStart(ctx context.Context, pbReq *mgmtpb.SystemStartRe
 		Method: control.StartRanks,
 		Hosts:  pbReq.GetHosts(),
 		Ranks:  pbReq.GetRanks(),
-	}, false)
+	}, true)
 	if err != nil {
 		return nil, err
 	}

--- a/src/control/server/mgmt_system_test.go
+++ b/src/control/server/mgmt_system_test.go
@@ -388,6 +388,21 @@ func mockMember(t *testing.T, r, a int32, s string) *system.Member {
 	return system.NewMember(system.Rank(r), common.MockUUID(r), "", common.MockHostAddr(a), state)
 }
 
+func checkMembers(t *testing.T, exp system.Members, ms *system.Membership) {
+	t.Helper()
+
+	common.AssertEqual(t, len(exp), len(ms.Members(nil)),
+		"unexpected number of members")
+	for _, em := range exp {
+		am, err := ms.Get(em.Rank)
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Logf("want %#v, got %#v", em, am)
+		common.AssertEqual(t, em, am, "unexpected member")
+	}
+}
+
 func mgmtSystemTestSetup(t *testing.T, l logging.Logger, mbs system.Members, r []*control.HostResponse) *mgmtSvc {
 	t.Helper()
 
@@ -754,12 +769,7 @@ func TestServer_MgmtSvc_rpcFanout(t *testing.T) {
 				t.Logf("unexpected results (-want, +got)\n%s\n", diff) // prints on err
 			}
 			common.AssertEqual(t, tc.expResults, gotResp.Results, name)
-
-			if diff := cmp.Diff(tc.expMembers, cs.membership.Members(nil), cmpOpts...); diff != "" {
-				t.Logf("unexpected members (-want, +got)\n%s\n", diff) // prints on err
-			}
-			common.AssertEqual(t, tc.expMembers, cs.membership.Members(nil), name)
-
+			checkMembers(t, tc.expMembers, cs.membership)
 			if diff := cmp.Diff(tc.expRanks, gotRankSet.String(), common.DefaultCmpOpts()...); diff != "" {
 				t.Fatalf("unexpected ranks (-want, +got)\n%s\n", diff) // prints on err
 			}
@@ -984,8 +994,8 @@ func TestServer_MgmtSvc_SystemStart(t *testing.T) {
 					Message: &mgmtpb.SystemStartResp{
 						Results: []*sharedpb.RankResult{
 							{
-								Rank: 0, Errored: true, Msg: "couldn't start",
-								State: stateString(system.MemberStateStopped),
+								Rank: 0, Errored: true, Msg: "",
+								State: stateString(system.MemberStateErrored),
 							},
 							{
 								Rank: 1, State: stateString(system.MemberStateReady),
@@ -1010,8 +1020,8 @@ func TestServer_MgmtSvc_SystemStart(t *testing.T) {
 			expResults: []*sharedpb.RankResult{
 				{
 					Rank: 0, Action: "start", Errored: true,
-					Msg: "couldn't start", Addr: common.MockHostAddr(1).String(),
-					State: stateString(system.MemberStateStopped),
+					Msg: "", Addr: common.MockHostAddr(1).String(),
+					State: stateString(system.MemberStateErrored),
 				},
 				{
 					Rank: 1, Action: "start", Addr: common.MockHostAddr(1).String(),
@@ -1027,7 +1037,7 @@ func TestServer_MgmtSvc_SystemStart(t *testing.T) {
 				},
 			},
 			expMembers: system.Members{
-				mockMember(t, 0, 1, "stopped"),
+				mockMember(t, 0, 1, "errored"),
 				mockMember(t, 1, 1, "ready"),
 				mockMember(t, 2, 2, "ready"),
 				mockMember(t, 3, 2, "ready"),
@@ -1047,8 +1057,8 @@ func TestServer_MgmtSvc_SystemStart(t *testing.T) {
 					Message: &mgmtpb.SystemStartResp{
 						Results: []*sharedpb.RankResult{
 							{
-								Rank: 0, Errored: true, Msg: "couldn't start",
-								State: stateString(system.MemberStateStopped),
+								Rank: 0, Errored: true, Msg: "",
+								State: stateString(system.MemberStateErrored),
 							},
 							{
 								Rank: 1, State: stateString(system.MemberStateReady),
@@ -1060,8 +1070,8 @@ func TestServer_MgmtSvc_SystemStart(t *testing.T) {
 			expResults: []*sharedpb.RankResult{
 				{
 					Rank: 0, Action: "start", Errored: true,
-					Msg: "couldn't start", Addr: common.MockHostAddr(1).String(),
-					State: stateString(system.MemberStateStopped),
+					Msg: "", Addr: common.MockHostAddr(1).String(),
+					State: stateString(system.MemberStateErrored),
 				},
 				{
 					Rank: 1, Action: "start", Addr: common.MockHostAddr(1).String(),
@@ -1069,7 +1079,7 @@ func TestServer_MgmtSvc_SystemStart(t *testing.T) {
 				},
 			},
 			expMembers: system.Members{
-				mockMember(t, 0, 1, "stopped"),
+				mockMember(t, 0, 1, "errored"),
 				mockMember(t, 1, 1, "joined"),
 				mockMember(t, 2, 2, "stopped"),
 				mockMember(t, 3, 2, "stopped"),
@@ -1090,8 +1100,8 @@ func TestServer_MgmtSvc_SystemStart(t *testing.T) {
 					Message: &mgmtpb.SystemStartResp{
 						Results: []*sharedpb.RankResult{
 							{
-								Rank: 2, Errored: true, Msg: "couldn't start",
-								State: stateString(system.MemberStateStopped),
+								Rank: 2, Errored: true, Msg: "",
+								State: stateString(system.MemberStateErrored),
 							},
 							{
 								Rank: 3, State: stateString(system.MemberStateReady),
@@ -1103,8 +1113,8 @@ func TestServer_MgmtSvc_SystemStart(t *testing.T) {
 			expResults: []*sharedpb.RankResult{
 				{
 					Rank: 2, Action: "start", Errored: true,
-					Msg: "couldn't start", Addr: common.MockHostAddr(2).String(),
-					State: stateString(system.MemberStateStopped),
+					Msg: "", Addr: common.MockHostAddr(2).String(),
+					State: stateString(system.MemberStateErrored),
 				},
 				{
 					Rank: 3, Action: "start", Addr: common.MockHostAddr(2).String(),
@@ -1114,7 +1124,7 @@ func TestServer_MgmtSvc_SystemStart(t *testing.T) {
 			expMembers: system.Members{
 				mockMember(t, 0, 1, "stopped"),
 				mockMember(t, 1, 1, "joined"),
-				mockMember(t, 2, 2, "stopped"),
+				mockMember(t, 2, 2, "errored"),
 				mockMember(t, 3, 2, "ready"),
 			},
 			expAbsentHosts: "10.0.0.[3-5]",
@@ -1205,7 +1215,7 @@ func TestServer_MgmtSvc_SystemStart(t *testing.T) {
 				t.Logf("unexpected results (-want, +got)\n%s\n", diff) // prints on err
 			}
 			common.AssertEqual(t, tc.expResults, gotResp.Results, name)
-			common.AssertEqual(t, tc.expMembers, cs.membership.Members(nil), name)
+			checkMembers(t, tc.expMembers, cs.membership)
 			common.AssertEqual(t, tc.expAbsentHosts, gotResp.Absenthosts, "absent hosts")
 			common.AssertEqual(t, tc.expAbsentRanks, gotResp.Absentranks, "absent ranks")
 		})
@@ -1229,7 +1239,7 @@ func TestServer_MgmtSvc_SystemStop(t *testing.T) {
 		},
 		"invalid req": {
 			req:       new(mgmtpb.SystemStopReq),
-			expErrMsg: "response results not populated",
+			expErrMsg: "invalid request, no action specified",
 		},
 		"unfiltered prep fail": {
 			req: &mgmtpb.SystemStopReq{Prep: true, Kill: true},
@@ -1368,8 +1378,8 @@ func TestServer_MgmtSvc_SystemStop(t *testing.T) {
 					Message: &mgmtpb.SystemStopResp{
 						Results: []*sharedpb.RankResult{
 							{
-								Rank: 0, Errored: true, Msg: "couldn't stop",
-								State: stateString(system.MemberStateJoined),
+								Rank: 0, Errored: true, Msg: "",
+								State: stateString(system.MemberStateErrored),
 							},
 							{
 								Rank: 1, State: stateString(system.MemberStateStopped),
@@ -1394,8 +1404,8 @@ func TestServer_MgmtSvc_SystemStop(t *testing.T) {
 			expResults: []*sharedpb.RankResult{
 				{
 					Rank: 0, Action: "stop", Errored: true,
-					Msg: "couldn't stop", Addr: common.MockHostAddr(1).String(),
-					State: stateString(system.MemberStateJoined),
+					Msg: "", Addr: common.MockHostAddr(1).String(),
+					State: stateString(system.MemberStateErrored),
 				},
 				{
 					Rank: 1, Action: "stop", Addr: common.MockHostAddr(1).String(),
@@ -1411,7 +1421,7 @@ func TestServer_MgmtSvc_SystemStop(t *testing.T) {
 				},
 			},
 			expMembers: system.Members{
-				mockMember(t, 0, 1, "joined"),
+				mockMember(t, 0, 1, "errored"),
 				mockMember(t, 1, 1, "stopped"),
 				mockMember(t, 2, 2, "stopped"),
 				mockMember(t, 3, 2, "stopped"),
@@ -1431,8 +1441,8 @@ func TestServer_MgmtSvc_SystemStop(t *testing.T) {
 					Message: &mgmtpb.SystemStopResp{
 						Results: []*sharedpb.RankResult{
 							{
-								Rank: 0, Errored: true, Msg: "couldn't stop",
-								State: stateString(system.MemberStateJoined),
+								Rank: 0, Errored: true, Msg: "",
+								State: stateString(system.MemberStateErrored),
 							},
 						},
 					},
@@ -1454,8 +1464,8 @@ func TestServer_MgmtSvc_SystemStop(t *testing.T) {
 			expResults: []*sharedpb.RankResult{
 				{
 					Rank: 0, Action: "stop", Errored: true,
-					Msg: "couldn't stop", Addr: common.MockHostAddr(1).String(),
-					State: stateString(system.MemberStateJoined),
+					Msg: "", Addr: common.MockHostAddr(1).String(),
+					State: stateString(system.MemberStateErrored),
 				},
 				{
 					Rank: 2, Action: "stop", Addr: common.MockHostAddr(2).String(),
@@ -1467,7 +1477,7 @@ func TestServer_MgmtSvc_SystemStop(t *testing.T) {
 				},
 			},
 			expMembers: system.Members{
-				mockMember(t, 0, 1, "joined"),
+				mockMember(t, 0, 1, "errored"),
 				mockMember(t, 1, 1, "joined"),
 				mockMember(t, 2, 2, "stopped"),
 				mockMember(t, 3, 2, "stopped"),
@@ -1596,18 +1606,7 @@ func TestServer_MgmtSvc_SystemStop(t *testing.T) {
 				t.Logf("unexpected results (-want, +got)\n%s\n", diff) // prints on err
 			}
 			common.AssertEqual(t, tc.expResults, gotResp.Results, name)
-
-			for _, m := range tc.expMembers {
-				member, err := cs.membership.Get(m.Rank)
-				if err != nil {
-					t.Fatal(err)
-				}
-				t.Logf("got %#v, want %#v", member, m)
-				common.AssertEqual(t, m.State().String(), member.State().String(),
-					name+": compare state rank"+m.Rank.String())
-			}
-
-			common.AssertEqual(t, tc.expMembers, cs.membership.Members(nil), name)
+			checkMembers(t, tc.expMembers, cs.membership)
 			common.AssertEqual(t, tc.expAbsentHosts, gotResp.Absenthosts, "absent hosts")
 			common.AssertEqual(t, tc.expAbsentRanks, gotResp.Absentranks, "absent ranks")
 		})
@@ -1805,8 +1804,7 @@ func TestServer_MgmtSvc_SystemResetFormat(t *testing.T) {
 				t.Logf("unexpected results (-want, +got)\n%s\n", diff) // prints on err
 			}
 			common.AssertEqual(t, tc.expResults, gotResp.Results, name)
-
-			common.AssertEqual(t, tc.expMembers, cs.membership.Members(nil), name)
+			checkMembers(t, tc.expMembers, cs.membership)
 			common.AssertEqual(t, tc.expAbsentHosts, gotResp.Absenthosts, "absent hosts")
 			common.AssertEqual(t, tc.expAbsentRanks, gotResp.Absentranks, "absent ranks")
 		})

--- a/src/control/system/member.go
+++ b/src/control/system/member.go
@@ -12,6 +12,7 @@ import (
 	"net"
 	"strings"
 
+	"github.com/dustin/go-humanize/english"
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
 )
@@ -110,6 +111,7 @@ func (ms MemberState) isTransitionIllegal(to MemberState) bool {
 	if ms == to {
 		return true // identical state
 	}
+
 	return map[MemberState]map[MemberState]bool{
 		MemberStateAwaitFormat: {
 			MemberStateEvicted: true,
@@ -125,6 +127,9 @@ func (ms MemberState) isTransitionIllegal(to MemberState) bool {
 		},
 		MemberStateStopping: {
 			MemberStateReady: true,
+		},
+		MemberStateStopped: {
+			MemberStateEvicted: true,
 		},
 		MemberStateEvicted: {
 			MemberStateReady:    true,
@@ -322,13 +327,24 @@ func NewMemberResult(rank Rank, err error, state MemberState) *MemberResult {
 // MemberResults is a type alias for a slice of member result references.
 type MemberResults []*MemberResult
 
-// HasErrors returns true if any of the member results errored.
-func (smr MemberResults) HasErrors() bool {
-	for _, res := range smr {
-		if res.Errored {
-			return true
+// Errors returns an error indicating if and which ranks failed.
+func (mrs MemberResults) Errors() error {
+	rs, err := CreateRankSet("")
+	if err != nil {
+		return err
+	}
+
+	for _, mr := range mrs {
+		if mr.Errored {
+			rs.Add(mr.Rank)
 		}
 	}
 
-	return false
+	if rs.Count() > 0 {
+		return errors.Errorf("failed %s %s",
+			english.PluralWord(rs.Count(), "rank", "ranks"),
+			rs.String())
+	}
+
+	return nil
 }

--- a/src/control/system/member_test.go
+++ b/src/control/system/member_test.go
@@ -146,8 +146,8 @@ func TestSystem_MemberResult_Convert(t *testing.T) {
 	}
 	mrsOut := MemberResults{}
 
-	AssertTrue(t, mrsIn.HasErrors(), "")
-	AssertFalse(t, mrsOut.HasErrors(), "")
+	CmpErr(t, errors.New("failed ranks 1-2"), mrsIn.Errors())
+	CmpErr(t, nil, mrsOut.Errors())
 
 	if err := convert.Types(mrsIn, &mrsOut); err != nil {
 		t.Fatal(err)

--- a/src/control/system/membership.go
+++ b/src/control/system/membership.go
@@ -56,12 +56,6 @@ func (m *Membership) addMember(member *Member) error {
 	return m.db.AddMember(member)
 }
 
-func (m *Membership) updateMember(member *Member) error {
-	m.log.Debugf("updating system member: %s", member)
-
-	return m.db.UpdateMember(member)
-}
-
 // Add adds member to membership, returns member count.
 func (m *Membership) Add(member *Member) (int, error) {
 	m.Lock()
@@ -181,7 +175,7 @@ func (m *Membership) AddOrReplace(newMember *Member) error {
 		return nil
 	}
 
-	return m.updateMember(newMember)
+	return m.db.UpdateMember(newMember)
 }
 
 // Remove removes member from membership, idempotent.
@@ -335,7 +329,10 @@ func (m *Membership) UpdateMemberStates(results MemberResults, updateOnFail bool
 					result.Rank, result.State)
 			}
 		}
+
 		if member.State().isTransitionIllegal(result.State) {
+			m.log.Debugf("skipping illegal member state update for rank %d: %s->%s",
+				member.Rank, member.state, result.State)
 			continue
 		}
 		member.state = result.State
@@ -430,12 +427,17 @@ func (m *Membership) CheckHosts(hosts string, ctlPort int) (*RankSet, *hostlist.
 	return rs, missHS, nil
 }
 
-// MarkRankDead is a helper method to mark a rank as dead in
-// response to a swim_rank_dead event.
+// MarkRankDead is a helper method to mark a rank as dead in response to a
+// swim_rank_dead event.
 func (m *Membership) MarkRankDead(rank Rank) error {
 	member, err := m.db.FindMemberByRank(rank)
 	if err != nil {
 		return err
+	}
+
+	if member.State().isTransitionIllegal(MemberStateEvicted) {
+		return errors.Errorf("llegal member state update for rank %d: %s->%s",
+			member.Rank, member.state, MemberStateEvicted)
 	}
 
 	member.state = MemberStateEvicted
@@ -448,26 +450,29 @@ func (m *Membership) handleRankDown(evt *events.RASEvent) {
 		m.log.Error("no extended info in RankDown event received")
 		return
 	}
-	m.log.Debugf("processing RAS event %q from rank %d on host %q",
-		evt.Msg, evt.Rank, evt.Hostname)
 
 	// TODO: sanity check that the correct member is being updated by
 	// performing lookup on provided hostname and matching returned
 	// addresses with the member address with matching rank.
 
-	mr := NewMemberResult(Rank(evt.Rank), errors.Wrap(ei.ExitErr, evt.Msg), MemberStateErrored)
-
-	if err := m.UpdateMemberStates(MemberResults{mr}, true); err != nil {
-		m.log.Errorf("updating member states: %s", err)
-		return
-	}
-
-	member, err := m.Get(Rank(evt.Rank))
+	member, err := m.db.FindMemberByRank(Rank(evt.Rank))
 	if err != nil {
 		m.log.Errorf("member with rank %d not found", evt.Rank)
 		return
 	}
-	m.log.Debugf("update rank %d to %+v (%s)", evt.Rank, member, member.Info)
+
+	if member.State().isTransitionIllegal(MemberStateErrored) {
+		m.log.Debugf("skipping illegal member state update for rank %d: %s->%s",
+			member.Rank, member.state, MemberStateErrored)
+		return
+	}
+
+	member.state = MemberStateErrored
+	member.Info = errors.Wrap(ei.ExitErr, evt.Msg).Error()
+
+	if err := m.db.UpdateMember(member); err != nil {
+		m.log.Errorf("updating member with rank %d: %s", member.Rank, err)
+	}
 }
 
 // OnEvent handles events on channel and updates member states accordingly.


### PR DESCRIPTION
Return a non-zero exit code from dmg if unrecognised hosts or ranks are
specified on the commandline or if any host operations were unsuccessful.

Return informative errors from dmg system commands when --json output
is selected as log messages may not be consumed and the reason for
failure may not otherwise be clear.

Update system membership with a clear reason for failure when dmg system
command results contain errors.

Disallow stopped->evicted state transition.

Signed-off-by: Tom Nabarro tom.nabarro@intel.com