### PR TITLE
DAOS-6958 event: proper event handing in case of progress errors

### DIFF
--- a/src/client/api/event.c
+++ b/src/client/api/event.c
@@ -1218,6 +1218,7 @@ daos_event_priv_get(daos_event_t **ev)
 	if (evx->evx_status != DAOS_EVS_READY) {
 		D_CRIT("private event is inuse, status=%d\n",
 		       evx->evx_status);
+		D_ASSERT(0);
 	}
 	*ev = &ev_thpriv;
 	return 0;
@@ -1243,12 +1244,29 @@ daos_event_priv_wait()
 
 	/* Wait on the event to complete */
 	while (evx->evx_status != DAOS_EVS_READY) {
-		rc = crt_progress_cond(evx->evx_ctx, 0, ev_progress_cb, &epa);
-		if (rc == 0)
-			rc = ev_thpriv.ev_error;
+		int rc2;
 
-		if (rc && rc != -DER_TIMEDOUT)
-			break;
+		rc = crt_progress_cond(evx->evx_ctx, 0, ev_progress_cb, &epa);
+
+		/** progress succeeded, loop can exit if event completed */
+		if (rc == 0) {
+			rc = ev_thpriv.ev_error;
+			continue;
+		}
+
+		/** progress timeout, try calling progress again */
+		if (rc == -DER_TIMEDOUT)
+			continue;
+
+		/*
+		 * other progress failure; op should fail with that err. reset
+		 * the private event first so it can be resused.
+		 */
+		rc2 = daos_event_priv_reset();
+		if (rc2)
+			return rc2;
+		ev_thpriv_is_init = true;
+		break;
 	}
 	return rc;
 }

--- a/src/client/api/event.c
+++ b/src/client/api/event.c
@@ -1218,7 +1218,7 @@ daos_event_priv_get(daos_event_t **ev)
 	if (evx->evx_status != DAOS_EVS_READY) {
 		D_CRIT("private event is inuse, status=%d\n",
 		       evx->evx_status);
-		D_ASSERT(0);
+		return -DER_BUSY;
 	}
 	*ev = &ev_thpriv;
 	return 0;

--- a/src/client/api/task.c
+++ b/src/client/api/task.c
@@ -119,7 +119,11 @@ dc_task_schedule(tse_task_t *task, bool instant)
 
 out:
 	if (daos_event_is_priv(ev)) {
-		daos_event_priv_wait();
+		int rc2;
+
+		rc2 = daos_event_priv_wait();
+		if (rc2)
+			return rc2;
 		rc = ev->ev_error;
 	}
 	return rc;


### PR DESCRIPTION
crt_progress can sometimes return errors that are not timeout. Those
are not properly handled in synchronous IO calls and cause the private
event to be in an unusable state for following IOs.

This PR checks the error from cart and reinits the private event in
case an error was returned so it can be resused rather then returning
to the user.

Signed-off-by: Mohamad Chaarawi <mohamad.chaarawi@intel.com>