### PR TITLE
DAOS-6902 control: Perform async group update on rank eviction

### DIFF
--- a/src/control/server/mgmt_svc.go
+++ b/src/control/server/mgmt_svc.go
@@ -29,6 +29,7 @@ type mgmtSvc struct {
 	events           *events.PubSub
 	clientNetworkCfg *config.ClientNetworkCfg
 	joinReqs         joinReqChan
+	groupUpdateReqs  chan struct{}
 }
 
 func newMgmtSvc(h *EngineHarness, m *system.Membership, s *system.Database, c control.UnaryInvoker, p *events.PubSub) *mgmtSvc {
@@ -41,6 +42,7 @@ func newMgmtSvc(h *EngineHarness, m *system.Membership, s *system.Database, c co
 		events:           p,
 		clientNetworkCfg: new(config.ClientNetworkCfg),
 		joinReqs:         make(joinReqChan),
+		groupUpdateReqs:  make(chan struct{}),
 	}
 }
 

--- a/src/control/server/server.go
+++ b/src/control/server/server.go
@@ -408,12 +408,7 @@ func Start(log *logging.LeveledLogger, cfg *config.Server) error {
 					log.Errorf("failed to mark rank %d as dead: %s", evt.Rank, err)
 					return
 				}
-				// FIXME CART-944: We should be able to update the
-				// primary group in order to remove the dead rank,
-				// but for the moment this will cause problems.
-				if err := mgmtSvc.doGroupUpdate(ctx); err != nil {
-					log.Errorf("GroupUpdate failed: %s", err)
-				}
+				mgmtSvc.reqGroupUpdate(ctx)
 			}
 		}))
 


### PR DESCRIPTION
When a rank is marked as evicted after a swim down event, request
an asynchronous group update instead of making concurrent blocking
calls. This change eliminates potential out-of-order updates and
performs better at scale due to batching.