### PR TITLE
DAOS-6978 rebuild: return NOTLEADER for -1 master rank

### DIFF
--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -435,7 +435,7 @@ init_pool_metadata(struct rdb_tx *tx, const rdb_path_t *kvs,
 		   uint32_t ndomains, const uint32_t *domains)
 {
 	uint32_t		version = DS_POOL_MD_VERSION;
-	struct pool_buf	       *map_buf;
+	struct pool_buf	       *map_buf = NULL;
 	uint32_t		map_version = 1;
 	uint32_t		connectable;
 	uint32_t		nhandles = 0;
@@ -498,7 +498,8 @@ init_pool_metadata(struct rdb_tx *tx, const rdb_path_t *kvs,
 out_uuids:
 	D_FREE(uuids);
 out_map_buf:
-	pool_buf_free(map_buf);
+	if (map_buf)
+		pool_buf_free(map_buf);
 out:
 	return rc;
 }

--- a/src/rebuild/rebuild_iv.c
+++ b/src/rebuild/rebuild_iv.c
@@ -98,12 +98,15 @@ rebuild_iv_ent_update(struct ds_iv_entry *entry, struct ds_iv_key *key,
 	d_rank_t	  rank;
 	int		  rc;
 
+	D_DEBUG(DB_REBUILD, "rank %d master rank %d\n", src_iv->riv_rank,
+		src_iv->riv_master_rank);
+
+	if (src_iv->riv_master_rank == -1)
+		return -DER_NOTLEADER;
+
 	rc = crt_group_rank(NULL, &rank);
 	if (rc)
 		return rc;
-
-	D_DEBUG(DB_TRACE, "rank %d master rank %d\n", src_iv->riv_rank,
-		src_iv->riv_master_rank);
 
 	if (rank != src_iv->riv_master_rank)
 		return -DER_IVCB_FORWARD;


### PR DESCRIPTION
If the leader is stepping down/up during rebuild, then
iv_master_rank might be set to -1, so let's check that
in rebuild_iv_ent_update(), and return ENOTLEADER in this
case.

Fix memory cleanup error in ds_mgmt_create_pool().

Signed-off-by: Di Wang <di.wang@intel.com>