### PR TITLE
DAOS-5827 csum: Checksum Verify During Object Enumerate

### DIFF
--- a/doc/overview/data_integrity.md
+++ b/doc/overview/data_integrity.md
@@ -183,10 +183,52 @@ export DAOS_CSUM_TEST_ALL_TYPE=1
 
 # Life of a checksum (WIP)
 ## Rebuild
-- migrate_one_insert - mrone.iods_csums is allocated, iods_csums copied from
-  dss_enum_unpack_io. Memory reference removed from iods_csums.data. It will be
-  freed in migrate_one_destory
-- migrate_fetch_update_inline - mrone.iods_csums sent to vos_obj_update
+In order for rebuild/migrate process to get checksums so it doesn't have to
+recalculate them, the object list and object fetch task api's provide a checksum
+iov parameter. If memory is allocated for the iov, then the daos client will
+pack the checksums into the it. If insufficient memory is allocated in the
+buffer, the iov_len will be set to the required capacity and the checksums
+packed into the buffer is truncated.
+
+### Client Task API Touch Points
+- **dc_obj_fetch_task_create**: sets csum iov to daos_obj_fetch_t args. These
+  args are set to the rw_cb_args.shard_args.api_args and accessed through an
+  accessor function (rw_args2csum_iov) in cli_shard.c so that rw_args_store_csum
+  can easily access it. This function, called from dc_rw_cb_csum_verify, will
+  pack the data checksums received from the server into the iov.
+- **dc_obj_list_obj_task_create**: sets csum iov to daos_obj_list_obj_t args.
+  args.csum is then copied to obj_enum_args.csum in dc_obj_shard_list(). On enum
+  callback (dc_enumerate_cb()) the packed csum buffer is copied from the rpc
+  args to obj_enum_args.csum (which points to the same buffer as the caller's)
+
+### Rebuild Touch Points
+- migrate_fetch_update_(inline|single|bulk) - the rebuild/migrate functions that
+  write to vos locally must ensure that the checksum is also written. These must
+  use the csum iov param for fetch to get the checksum, then unpack the csums
+  into iod_csum.
+- obj_enum.c is relied on for enumerating the objects to be rebuilt. Because the
+  fetch_update functions will unpack the csums from fetch, it will also unpack
+  the csums for enum, so the unpacking process in obj_enum.c will simply copy
+  the csum_iov to the io (dss_enum_unpack_io) structure in
+  **enum_unpack_recxs()** and then deep copy to the mrone (migrate_one)
+  structure in **migrate_one_insert()**.
+
+### Packing/unpacking checksums
+When checksums are packed (either for fetch or object list) only the data
+checksums are included. For object list, only checksums for data that is inlined
+is included. During a rebuild, if the data is not inlined, then the rebuild
+process will fetch the rest of the data and also get the checksums.
+
+- ci_serialize() - "packs" checksums by appending the struct to an iov and then
+  appending the checksum info buffer to the iov. This puts the actual checksum
+  just after the checksum structure that describes the checksum.
+- ci_cast() - "unpacks" the checksum and describing structure. It does this by
+  casting an iov's buffer to a dcs_csum_info struct and setting the csum_info's
+  checksum pointer to point to the memory just after the structure. It does not
+  copy anything, but really just "casts". To get all dcs_csum_infos, a caller
+  would cast the iov, copy the csum_info to a destination, then move to the next
+  csum_info(ci_move_next_iov) in the iov. Because this process modifies the iov
+  structure it is best to use a copy of the iov as a temp structure.
 
 ## VOS
 - akey_update_begin - determines how much extra space needs to be allocated in
@@ -194,11 +236,11 @@ export DAOS_CSUM_TEST_ALL_TYPE=1
 ### Arrays
 - evt_root_activate - evtree root is activated. If has a csum them the root csum
   properties are set (csum_len, csum_type, csum_chunk_size)
-- evt_desc_csum_fill - if root was activated with a punched record then it won't
-  have had the csum fields set correctly so set them here. Main purpose is to
-  copy the csum to the end of persistent evt record (evt_desc). Enough SCM
+- *evt_desc_csum_fill* - if root was activated with a punched record then it
+  won't have had the csum fields set correctly so set them here. Main purpose is
+  to copy the csum to the end of persistent evt record (evt_desc). Enough SCM
   should have been reserved in akey_update_begin.
-- evt_entry_csum_fill - Copy the csum from the persistent memory to the
+- *evt_entry_csum_fill* - Copy the csum from the persistent memory to the
   evt_entry returned. Also copy the csum fields from the evtree root to complete
   the csum_info structure in the evt_entry.
 - akey_fetch_recx - checksums are saved to the ioc for each found extent. Will
@@ -215,6 +257,9 @@ For enumeration the csums for the keys and values are packed into an iov
 dedicated to csums.
 - fill_key_csum - Checksum is calcuated for the key and packed into the iov
 - fill_data_csum - pack/serialize the csum_info structure into the iov.
+
+## Aggregation
+- srv_csum_recalc.c - the checksum verification and calculations occur here
 
 ---
 

--- a/src/client/api/object.c
+++ b/src/client/api/object.c
@@ -146,7 +146,7 @@ daos_obj_fetch(daos_handle_t oh, daos_handle_t th, uint64_t flags,
 	int		 rc;
 
 	rc = dc_obj_fetch_task_create(oh, th, flags, dkey, nr, 0, iods,
-				      sgls, maps, NULL, ev, NULL, &task);
+				      sgls, maps, NULL, NULL, ev, NULL, &task);
 	if (rc)
 		return rc;
 

--- a/src/common/misc.c
+++ b/src/common/misc.c
@@ -374,6 +374,7 @@ daos_iov_copy(d_iov_t *dst, d_iov_t *src)
 	if (src == NULL || src->iov_buf == NULL)
 		return 0;
 	D_ASSERT(src->iov_buf_len > 0);
+	D_ASSERT(dst != NULL);
 
 	D_ALLOC(dst->iov_buf, src->iov_buf_len);
 	if (dst->iov_buf == NULL)
@@ -382,6 +383,24 @@ daos_iov_copy(d_iov_t *dst, d_iov_t *src)
 	memcpy(dst->iov_buf, src->iov_buf, src->iov_len);
 	dst->iov_len = src->iov_len;
 	D_DEBUG(DB_TRACE, "iov_len %d\n", (int)dst->iov_len);
+	return 0;
+}
+
+int
+daos_iov_alloc(d_iov_t *iov, daos_size_t size, bool set_full)
+{
+	D_ASSERT(iov != NULL);
+	D_ASSERT(size > 0);
+
+	memset(iov, 0, sizeof(*iov));
+	D_ALLOC(iov->iov_buf, size);
+	if (iov->iov_buf == NULL)
+		return -DER_NOMEM;
+
+	iov->iov_buf_len = size;
+	if (set_full)
+		iov->iov_len = size;
+
 	return 0;
 }
 
@@ -414,7 +433,9 @@ daos_iov_cmp(d_iov_t *iov1, d_iov_t *iov2)
 void
 daos_iov_append(d_iov_t *iov, void *buf, uint64_t buf_len)
 {
-	D_ASSERT(iov->iov_len + buf_len <= iov->iov_buf_len);
+	D_ASSERTF(iov->iov_len + buf_len <= iov->iov_buf_len,
+		  "iov->iov_len(%lu) + buf_len(%lu) <= iov->iov_buf_len(%lu)",
+		  iov->iov_len, buf_len, iov->iov_buf_len);
 	memcpy(iov->iov_buf + iov->iov_len, buf, buf_len);
 	iov->iov_len += buf_len;
 }

--- a/src/common/tests/checksum_tests.c
+++ b/src/common/tests/checksum_tests.c
@@ -1722,7 +1722,8 @@ test_formatter(void **state)
 		};
 
 	sprintf(result, DF_CI, DP_CI(ci));
-	assert_string_equal("{nr: 1, len: 8, first_csum: 1234567890123456789}",
+	assert_string_equal("{nr: 1, len: 8, first_csum: 1234567890123456789, "
+		     "csum_buf_len: 8}",
 			    result);
 }
 

--- a/src/container/srv_csum_recalc.c
+++ b/src/container/srv_csum_recalc.c
@@ -122,6 +122,7 @@ csum_agg_verify(struct csum_recalc *recalc, struct dcs_csum_info *new_csum,
 		unsigned int rec_size, unsigned int prefix_len)
 {
 	unsigned int	j = 0;
+	bool		match;
 
 	if (recalc->cr_phy_off && DAOS_FAIL_CHECK(DAOS_VOS_AGG_MW_THRESH)) {
 		D_INFO("CHECKSUM merge window failure injection.\n");
@@ -166,9 +167,14 @@ csum_agg_verify(struct csum_recalc *recalc, struct dcs_csum_info *new_csum,
 	 * starting at the correct offset of the checksum array for the input
 	 * segment.
 	 */
-	return !memcmp(new_csum->cs_csum,
+	match = memcmp(new_csum->cs_csum,
 		       &recalc->cr_phy_csum->cs_csum[j * new_csum->cs_len],
-		       new_csum->cs_nr * new_csum->cs_len);
+		       new_csum->cs_nr * new_csum->cs_len) == 0;
+	if (!match) {
+		D_ERROR("calc ("DF_CI") != phy ("DF_CI")\n",
+			DP_CI(*new_csum), DP_CI(*recalc->cr_phy_csum));
+	}
+	return match;
 }
 
 /* Driver for the checksum verification of input segments, and calculation

--- a/src/include/daos/common.h
+++ b/src/include/daos/common.h
@@ -74,6 +74,44 @@ struct daos_sgl_idx {
 };
 
 /*
+ * add bytes to the sgl index offset. If the new offset is greater than or
+ * equal to the indexed iov len, move the index to the next iov in the sgl.
+ */
+static inline void
+sgl_move_forward(d_sg_list_t *sgl, struct daos_sgl_idx *sgl_idx, uint64_t bytes)
+{
+	sgl_idx->iov_offset += bytes;
+
+	/** move to next iov if necessary */
+	if (sgl_idx->iov_offset >= sgl->sg_iovs[sgl_idx->iov_idx].iov_len) {
+		sgl_idx->iov_idx++;
+		sgl_idx->iov_offset = 0;
+	}
+}
+
+static inline void *
+sgl_indexed_byte(d_sg_list_t *sgl, struct daos_sgl_idx *sgl_idx)
+{
+	if (sgl_idx->iov_idx > sgl->sg_nr_out - 1)
+		return NULL;
+	return sgl->sg_iovs[sgl_idx->iov_idx].iov_buf + sgl_idx->iov_offset;
+}
+
+/*
+ * If the byte count will exceed the current indexed iov, then move to
+ * the next.
+ */
+static inline void
+sgl_test_forward(d_sg_list_t *sgl, struct daos_sgl_idx *sgl_idx, uint64_t bytes)
+{
+	if (sgl_idx->iov_offset + bytes >
+	    sgl->sg_iovs[sgl_idx->iov_idx].iov_len) {
+		sgl_idx->iov_idx++;
+		sgl_idx->iov_offset = 0;
+	}
+}
+
+/*
  * Each thread has DF_UUID_MAX number of thread-local buffers for UUID strings.
  * Each debug message can have at most this many DP_UUIDs.
  *
@@ -261,7 +299,8 @@ daos_sgl_buf_extend(d_sg_list_t *sgl, int idx, size_t new_size);
 /** get remaining space in an iov, assuming that iov_len is used and
  * iov_buf_len is total in buf
  */
-#define daos_iov_remaining(iov) ((iov).iov_buf_len - (iov).iov_len)
+#define daos_iov_remaining(iov) ((iov).iov_buf_len > (iov).iov_len ? \
+				(iov).iov_buf_len - (iov).iov_len : 0)
 /**
  * Move sgl forward from iov_idx/iov_off, with move_dist distance. It is
  * caller's responsibility to check the boundary.
@@ -361,6 +400,7 @@ int daos_sgl_processor(d_sg_list_t *sgl, bool check_buf,
 
 char *daos_str_trimwhite(char *str);
 int daos_iov_copy(d_iov_t *dst, d_iov_t *src);
+int daos_iov_alloc(d_iov_t *iov, daos_size_t size, bool set_full);
 void daos_iov_free(d_iov_t *iov);
 bool daos_iov_cmp(d_iov_t *iov1, d_iov_t *iov2);
 void daos_iov_append(d_iov_t *iov, void *buf, uint64_t buf_len);

--- a/src/include/daos/task.h
+++ b/src/include/daos/task.h
@@ -209,8 +209,8 @@ int
 dc_obj_fetch_task_create(daos_handle_t oh, daos_handle_t th, uint64_t api_flags,
 			 daos_key_t *dkey, uint32_t nr, uint32_t extra_flags,
 			 daos_iod_t *iods, d_sg_list_t *sgls, daos_iom_t *ioms,
-			 void *extra_arg, daos_event_t *ev, tse_sched_t *tse,
-			 tse_task_t **task);
+			 void *extra_arg, d_iov_t *csum, daos_event_t *ev,
+			 tse_sched_t *tse, tse_task_t **task);
 int
 dc_obj_update_task_create(daos_handle_t oh, daos_handle_t th, uint64_t flags,
 			  daos_key_t *dkey, unsigned int nr,

--- a/src/include/daos_srv/daos_engine.h
+++ b/src/include/daos_srv/daos_engine.h
@@ -651,7 +651,7 @@ int dsc_obj_list_akey(daos_handle_t oh, daos_epoch_t epoch,
 int dsc_obj_fetch(daos_handle_t oh, daos_epoch_t epoch, daos_key_t *dkey,
 		  unsigned int nr, daos_iod_t *iods, d_sg_list_t *sgls,
 		  daos_iom_t *maps, unsigned int extra_flag,
-		  unsigned int *extra_arg);
+		  unsigned int *extra_arg, d_iov_t *csum_iov);
 
 int dsc_obj_update(daos_handle_t oh, uint64_t flags, daos_key_t *dkey,
 		   unsigned int nr, daos_iod_t *iods, d_sg_list_t *sgls);
@@ -743,7 +743,7 @@ struct dss_enum_unpack_io {
 	daos_unit_oid_t		 ui_oid;	/**< type <= OBJ */
 	daos_key_t		 ui_dkey;	/**< type <= DKEY */
 	daos_iod_t		*ui_iods;
-	struct dcs_iod_csums	*ui_iods_csums;
+	d_iov_t			 ui_csum_iov;
 	/* punched epochs per akey */
 	daos_epoch_t		*ui_akey_punch_ephs;
 	daos_epoch_t		*ui_rec_punch_ephs;

--- a/src/include/daos_srv/vos.h
+++ b/src/include/daos_srv/vos.h
@@ -672,7 +672,7 @@ vos_fetch_end(daos_handle_t ioh, int err);
 
 /**
  * Prepare IO sink buffers for the specified arrays of the given
- * object. The caller can directly use thse buffers for RMA write.
+ * object. The caller can directly use those buffers for RMA write.
  *
  * The upper layer must explicitly call \a vos_update_end to finalize the
  * ZC I/O and release resources.
@@ -756,6 +756,9 @@ vos_ioh2ci_nr(daos_handle_t ioh);
  */
 struct bio_sglist *
 vos_iod_sgl_at(daos_handle_t ioh, unsigned int idx);
+
+void
+vos_set_io_csum(daos_handle_t ioh, struct dcs_iod_csums *csums);
 
 /**
  * VOS iterator APIs

--- a/src/include/daos_task.h
+++ b/src/include/daos_task.h
@@ -691,6 +691,10 @@ typedef struct {
 	daos_iom_t		*ioms;
 	/** extra arguments, for example obj_ec_fail_info for DIOF_EC_RECOV */
 	void			*extra_arg;
+	/** Pre-allocated buffer to pack checksums into (Optional, intended for
+	 * internal use only
+	 */
+	d_iov_t			*csum_iov;
 } daos_obj_rw_t;
 
 /** fetch args struct */

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -1610,9 +1610,11 @@ obj_ec_recov_cb(tse_task_t *task, struct dc_object *obj,
 		recov_task->ert_th = th;
 
 		rc = dc_obj_fetch_task_create(args->oh, th, 0, args->dkey, 1,
-					DIOF_EC_RECOV, &recov_task->ert_iod,
-					&recov_task->ert_sgl, NULL, fail_info,
-					NULL, sched, &sub_task);
+					      DIOF_EC_RECOV,
+					      &recov_task->ert_iod,
+					      &recov_task->ert_sgl, NULL,
+					      fail_info, NULL,
+					      NULL, sched, &sub_task);
 		if (rc) {
 			D_ERROR("task %p "DF_OID" dc_obj_fetch_task_create "
 				"failed "DF_RC"\n", task,

--- a/src/object/obj_enum.c
+++ b/src/object/obj_enum.c
@@ -14,12 +14,10 @@
 #include <daos_srv/vos.h>
 #include <daos/object.h>
 
-static struct dcs_iod_csums *
-io_iod_csums(const struct dss_enum_unpack_io *io, int i)
+static d_iov_t *
+io_csums_iov(struct dss_enum_unpack_io *io)
 {
-	if (io->ui_iods_csums != NULL)
-		return &io->ui_iods_csums[i];
-	return NULL;
+	return &io->ui_csum_iov;
 }
 
 static int
@@ -144,9 +142,6 @@ iov_alloc_for_csum_info(d_iov_t *iov, struct dcs_csum_info *csum_info)
 
 	/** Make sure the csum buffer is big enough ... resize if needed */
 	if (iov->iov_buf == NULL) {
-		/** This must be freed by the object layer
-		 * (currently in obj_enum_complete)
-		 */
 		D_ALLOC(iov->iov_buf, size_needed);
 		if (iov->iov_buf == NULL)
 			return -DER_NOMEM;
@@ -176,6 +171,9 @@ fill_data_csum(struct dcs_csum_info *src_csum_info, d_iov_t *csum_iov)
 	if (csum_iov  == NULL || !ci_is_valid(src_csum_info))
 		return 0;
 
+	/** This must be freed by the object layer
+	 * (currently in obj_enum_complete)
+	 */
 	rc = iov_alloc_for_csum_info(csum_iov, src_csum_info);
 	if (rc != 0)
 		return rc;
@@ -207,6 +205,9 @@ fill_key_csum(vos_iter_entry_t *key_ent, struct dss_enum_arg *arg)
 	if (rc != 0)
 		return rc;
 
+	/** This must be freed by the object layer
+	 * (currently in obj_enum_complete)
+	 */
 	iov_alloc_for_csum_info(csum_iov, csum_info);
 	rc = ci_serialize(csum_info, csum_iov);
 	/** iov_alloc_for_csum_info should have allocated enough so this
@@ -297,6 +298,207 @@ fill_key(daos_handle_t ih, vos_iter_entry_t *key_ent, struct dss_enum_arg *arg,
 	return 0;
 }
 
+static bool
+recx_eq(const daos_recx_t *a, const daos_recx_t *b)
+{
+	D_ASSERT(a != NULL);
+	D_ASSERT(b != NULL);
+
+	return a->rx_nr == b->rx_nr && a->rx_idx == b->rx_idx;
+}
+
+static bool
+entry_is_partial_extent(const vos_iter_entry_t *key_ent)
+{
+	D_ASSERT(key_ent != NULL);
+
+	return !recx_eq(&key_ent->ie_orig_recx, &key_ent->ie_recx);
+}
+
+static int
+csummer_verify_recx(struct daos_csummer *csummer, d_iov_t *data_to_verify,
+		    daos_recx_t *recx, daos_size_t rsize,
+		    struct dcs_csum_info *csum_info)
+{
+	int			rc;
+	struct dcs_iod_csums	iod_csum = {0};
+	daos_iod_t		iod = {0};
+	d_sg_list_t		sgl = {0};
+
+	iod.iod_type = DAOS_IOD_ARRAY;
+	iod.iod_recxs = recx;
+	iod.iod_nr = 1;
+	iod.iod_size = rsize;
+
+	sgl.sg_iovs = data_to_verify;
+	sgl.sg_nr = 1;
+	sgl.sg_nr_out = 1;
+
+	iod_csum.ic_nr = 1;
+	iod_csum.ic_data = csum_info;
+
+	rc = daos_csummer_verify_iod(csummer, &iod, &sgl,
+				     &iod_csum, NULL, 0, NULL);
+	if (rc != 0)
+		D_ERROR("Corruption found for recx "DF_RECX"\n",
+			DP_RECX(*recx));
+
+	return rc;
+}
+
+int
+csummer_alloc_csum_info(struct daos_csummer *csummer,
+			daos_recx_t *recx, daos_size_t rsize,
+			struct dcs_csum_info **csum_info)
+{
+	daos_size_t		 chunksize;
+	daos_size_t		 csum_nr;
+	struct dcs_csum_info	*result = NULL;
+	uint16_t		 csum_len;
+
+	D_ASSERT(recx != NULL);
+	D_ASSERT(csum_info != NULL);
+	D_ASSERT(csummer != NULL);
+	D_ASSERT(rsize > 0);
+
+	csum_len = daos_csummer_get_csum_len(csummer);
+	chunksize = daos_csummer_get_rec_chunksize(csummer, rsize);
+	csum_nr = daos_recx_calc_chunks(*recx, rsize, chunksize);
+
+	D_ALLOC(result, sizeof(*result) + csum_len * csum_nr);
+	if (result == NULL)
+		return -DER_NOMEM;
+
+	result->cs_csum = (uint8_t *)&result[1];
+	result->cs_type = daos_csummer_get_type(csummer);
+	result->cs_chunksize = chunksize;
+	result->cs_nr = csum_nr;
+	result->cs_len = csum_len;
+	result->cs_buf_len = csum_len * csum_nr;
+
+	(*csum_info) = result;
+
+	return 0;
+}
+
+/**
+ * Allocate memory for the csum_info struct and buffer for actual checksum, then
+ * calculate the checksum.
+ */
+static int
+csummer_alloc_calc_recx_csum(struct daos_csummer *csummer, daos_recx_t *recx,
+			     daos_size_t rsize, d_iov_t *data,
+			     struct dcs_csum_info **p_csum_info)
+{
+	int rc;
+	d_sg_list_t sgl;
+	struct dcs_csum_info *csum_info;
+
+	rc = csummer_alloc_csum_info(csummer, recx, rsize, &csum_info);
+	if (rc != 0)
+		return rc;
+
+	sgl.sg_nr = 1;
+	sgl.sg_nr_out = 1;
+	sgl.sg_iovs = data;
+
+	rc = daos_csummer_calc_one(csummer, &sgl, csum_info, rsize,
+				   recx->rx_nr, recx->rx_idx);
+
+	if (rc != 0) {
+		D_ERROR("Error calculating checksum: "DF_RC"\n", DP_RC(rc));
+		daos_csummer_free_ci(csummer, &csum_info);
+		return rc;
+	}
+
+	(*p_csum_info) = csum_info;
+	return 0;
+}
+
+/**
+ * If the entry's extent is a partial extent, then calculate a new checksum for
+ * it and verify the original extent. Otherwise just pack the existing checksum
+ * into the output buffer
+ */
+static int
+csum_copy_inline(int type, vos_iter_entry_t *ent, struct dss_enum_arg *arg,
+		 daos_handle_t ih, d_iov_t *iov_out)
+{
+	int rc;
+
+	D_ASSERT(arg != NULL);
+	D_ASSERT(ent != NULL);
+	D_ASSERT(iov_out != NULL);
+
+	if (type == OBJ_ITER_RECX && entry_is_partial_extent(ent) &&
+	    daos_csummer_initialized(arg->csummer)) {
+		struct daos_csummer	*csummer = arg->csummer;
+		struct dcs_csum_info	*new_csum_info = NULL;
+		vos_iter_entry_t	 ent_to_verify = *ent;
+		d_iov_t			 data_to_verify = {0};
+		uint64_t		 orig_data_len = 0;
+
+		/**
+		 * Verify original extent
+		 * First, make a copy of the entity and update the copy to read
+		 * all data that will be verified.
+		 */
+		orig_data_len = ent->ie_orig_recx.rx_nr * ent->ie_rsize;
+		ent_to_verify.ie_recx = ent->ie_orig_recx;
+		ent_to_verify.ie_biov.bi_data_len = orig_data_len;
+		ent_to_verify.ie_biov.bi_addr.ba_off -=
+			ent->ie_recx.rx_idx -
+			ent->ie_orig_recx.rx_idx;
+
+		D_ALLOC(data_to_verify.iov_buf, orig_data_len);
+		if (data_to_verify.iov_buf == NULL)
+			return -DER_NOMEM;
+
+		data_to_verify.iov_buf_len = orig_data_len;
+
+		rc = arg->copy_data_cb(ih, &ent_to_verify, &data_to_verify);
+		if (rc != 0) {
+			D_ERROR("Issue copying data");
+			return rc;
+		}
+
+		rc = csummer_verify_recx(csummer,
+					 &data_to_verify,
+					 &ent_to_verify.ie_orig_recx,
+					 ent_to_verify.ie_rsize,
+					 &ent_to_verify.ie_csum);
+
+		D_FREE(data_to_verify.iov_buf);
+		if (rc != 0) {
+			D_ERROR("Found corruption!");
+			return rc;
+		}
+
+		rc = csummer_alloc_calc_recx_csum(csummer, &ent->ie_recx,
+						  ent->ie_rsize, iov_out,
+						  &new_csum_info);
+		if (rc != 0) {
+			D_ERROR("Issue calculating checksum");
+			return rc;
+		}
+
+		rc = fill_data_csum(new_csum_info, &arg->csum_iov);
+		if (rc != 0) {
+			D_ERROR("Issue filling csum data");
+			return rc;
+		}
+		daos_csummer_free_ci(csummer, &new_csum_info);
+	} else {
+		rc = fill_data_csum(&ent->ie_csum, &arg->csum_iov);
+		if (rc != 0) {
+			D_ERROR("Issue filling csum data");
+			return rc;
+		}
+	}
+
+	return 0;
+}
+
 /* Callers are responsible for incrementing arg->kds_len. See iter_akey_cb. */
 static int
 fill_rec(daos_handle_t ih, vos_iter_entry_t *key_ent, struct dss_enum_arg *arg,
@@ -345,8 +547,6 @@ fill_rec(daos_handle_t ih, vos_iter_entry_t *key_ent, struct dss_enum_arg *arg,
 		arg->kds_len--;
 		bump_kds_len = true;
 	}
-
-	fill_data_csum(&key_ent->ie_csum, &arg->csum_iov);
 
 	if (is_sgl_full(arg, size) || arg->kds_len >= arg->kds_cap) {
 		/* NB: if it is rebuild object iteration, let's
@@ -403,7 +603,15 @@ fill_rec(daos_handle_t ih, vos_iter_entry_t *key_ent, struct dss_enum_arg *arg,
 		d_iov_set(&iov_out, iovs[arg->sgl_idx].iov_buf +
 				       iovs[arg->sgl_idx].iov_len, data_size);
 		D_ASSERT(arg->copy_data_cb != NULL);
+
+		rc = csum_copy_inline(type, key_ent, arg, ih, &iov_out);
+		if (rc != 0) {
+			D_ERROR("Issue copying csum");
+			return rc;
+		}
+
 		rc = arg->copy_data_cb(ih, key_ent, &iov_out);
+
 		if (rc != 0) {
 			D_ERROR("Copy recx data failed "DF_RC"\n", DP_RC(rc));
 		} else {
@@ -517,29 +725,40 @@ enum {
 	UNPACK_COMPLETE_IOD = 2,	/* Only finish current IOD */
 };
 
+/**
+ * Deserialize the next csum_info in the iov and increment the iov. If a
+ * csum_iov_out is provided, then serialize to it.
+ */
 static int
-unpack_csum(d_iov_t *csum_iov, struct dcs_iod_csums *iod_csums)
+unpack_recx_csum(d_iov_t *csum_iov, d_iov_t *csum_iov_out)
 {
-	if (csum_iov != NULL && csum_iov->iov_buf) {
-		/** unpack csums */
-		struct dcs_csum_info *tmp_csum_info;
+	int rc;
 
-		ci_cast(&tmp_csum_info, csum_iov);
-		if (tmp_csum_info == NULL)
-			return 0;
+	if (csum_iov == NULL || csum_iov->iov_len <= 0)
+		return 0;
 
-		ci_move_next_iov(tmp_csum_info, csum_iov);
-		iod_csums->ic_data[iod_csums->ic_nr] = *tmp_csum_info;
-		/** will be freed in clear_iod_csum() */
-		D_ALLOC(iod_csums->ic_data[iod_csums->ic_nr].cs_csum,
-			ci_csums_len(*tmp_csum_info));
-		if (iod_csums->ic_data[iod_csums->ic_nr].cs_csum == NULL)
-			return -DER_NOMEM;
-		memcpy(iod_csums->ic_data[iod_csums->ic_nr].cs_csum,
-		       tmp_csum_info->cs_csum, ci_csums_len(*tmp_csum_info));
+	/** unpack csums */
+	struct dcs_csum_info *tmp_csum_info;
 
-		iod_csums->ic_nr++;
+	D_ASSERT(csum_iov->iov_buf != NULL);
+	ci_cast(&tmp_csum_info, csum_iov);
+	if (tmp_csum_info == NULL) {
+		D_ERROR("Expected a valid checksum info to unpack");
+		return -DER_CSUM;
 	}
+
+	ci_move_next_iov(tmp_csum_info, csum_iov);
+
+	if (csum_iov_out == NULL)
+		return 0;
+
+	/** will be freed with iod.recxs in clear_top_iod */
+	rc = iov_alloc_for_csum_info(csum_iov_out, tmp_csum_info);
+	if (rc != 0)
+		return rc;
+
+	rc = ci_serialize(tmp_csum_info, csum_iov_out);
+	D_ASSERT(rc == 0);
 
 	return 0;
 }
@@ -547,9 +766,8 @@ unpack_csum(d_iov_t *csum_iov, struct dcs_iod_csums *iod_csums)
 /* Parse recxs in <*data, len> and append them to iod and sgl. */
 static int
 unpack_recxs(daos_iod_t *iod, int *recxs_cap, daos_epoch_t *eph,
-	     daos_epoch_t *min_eph, d_sg_list_t *sgl,
-	     daos_key_desc_t *kds, void *data,
-	     d_iov_t *csum_iov, struct dcs_iod_csums *iod_csums,
+	     daos_epoch_t *min_eph, d_sg_list_t *sgl, daos_key_desc_t *kds,
+	     void *data, d_iov_t *csum_iov_in, d_iov_t *csum_iov_out,
 	     unsigned int type)
 {
 	struct obj_enum_rec	*rec = data;
@@ -580,15 +798,6 @@ unpack_recxs(daos_iod_t *iod, int *recxs_cap, daos_epoch_t *eph,
 				D_GOTO(out, rc);
 		}
 
-		/** will be freed with iod.recxs in clear_top_iod */
-		if (csum_iov != NULL && csum_iov->iov_buf) {
-			rc = grow_array((void **)&iod_csums->ic_data,
-					sizeof(*iod_csums->ic_data),
-					*recxs_cap, cap);
-			if (rc != 0)
-				D_GOTO(out, rc);
-		}
-
 		/* If we execute any of the three breaks above,
 		 * *recxs_cap will be < the real capacities of some of
 		 * the arrays. This is harmless, as it only causes the
@@ -611,20 +820,21 @@ unpack_recxs(daos_iod_t *iod, int *recxs_cap, daos_epoch_t *eph,
 	iod->iod_nr++;
 	iod->iod_size = rec->rec_size;
 
-	/* Append the data, if inline. */
+	/* Append the data and checksum (if enabled), if inline. */
 	if (sgl != NULL && rec->rec_size > 0) {
 		d_iov_t *iov = &sgl->sg_iovs[sgl->sg_nr];
 
 		if (rec->rec_flags & RECX_INLINE) {
 			d_iov_set(iov, data + sizeof(*rec), rec->rec_size *
 					     rec->rec_recx.rx_nr);
+			/** will be freed with iod.recxs in clear_top_iod */
+			rc = unpack_recx_csum(csum_iov_in, csum_iov_out);
+			if (rc != 0)
+				D_GOTO(out, rc);
 		} else {
 			d_iov_set(iov, NULL, 0);
 		}
 
-		rc = unpack_csum(csum_iov, iod_csums);
-		if (rc != 0)
-			return rc;
 		sgl->sg_nr++;
 		D_ASSERTF(sgl->sg_nr <= iod->iod_nr, "%u == %u\n",
 			  sgl->sg_nr, iod->iod_nr);
@@ -658,8 +868,7 @@ out:
  */
 static void
 dss_enum_unpack_io_init(struct dss_enum_unpack_io *io, daos_unit_oid_t oid,
-			daos_iod_t *iods, struct dcs_iod_csums *iods_csums,
-			int *recxs_caps, d_sg_list_t *sgls,
+			daos_iod_t *iods, int *recxs_caps, d_sg_list_t *sgls,
 			daos_epoch_t *akey_ephs, daos_epoch_t *rec_ephs,
 			daos_epoch_t *rec_min_ephs, int iods_cap)
 {
@@ -671,10 +880,6 @@ dss_enum_unpack_io_init(struct dss_enum_unpack_io *io, daos_unit_oid_t oid,
 	D_ASSERT(iods != NULL);
 	memset(iods, 0, sizeof(*iods) * iods_cap);
 	io->ui_iods = iods;
-
-	D_ASSERT(iods_csums != NULL);
-	memset(iods_csums, 0, sizeof(*iods_csums) * iods_cap);
-	io->ui_iods_csums = iods_csums;
 
 	D_ASSERT(recxs_caps != NULL);
 	memset(recxs_caps, 0, sizeof(*recxs_caps) * iods_cap);
@@ -703,20 +908,6 @@ dss_enum_unpack_io_init(struct dss_enum_unpack_io *io, daos_unit_oid_t oid,
 
 }
 
-static void
-clear_iod_csum(struct dcs_iod_csums *iod_csum)
-{
-	int i;
-
-	if (iod_csum == NULL || iod_csum->ic_data == NULL)
-		return;
-
-	for (i = 0; i < iod_csum->ic_nr; i++)
-		D_FREE(iod_csum->ic_data[i].cs_csum);
-
-	D_FREE(iod_csum->ic_data);
-}
-
 /**
  * Clear the iods/sgls in \a io.
  *
@@ -730,8 +921,8 @@ dss_enum_unpack_io_clear(struct dss_enum_unpack_io *io)
 	for (i = 0; i <= io->ui_iods_top; i++) {
 		if (io->ui_sgls != NULL)
 			d_sgl_fini(&io->ui_sgls[i], false);
+		daos_iov_free(&io->ui_csum_iov);
 
-		clear_iod_csum(io_iod_csums(io, i));
 
 		daos_iov_free(&io->ui_iods[i].iod_name);
 		D_FREE(io->ui_iods[i].iod_recxs);
@@ -760,6 +951,7 @@ static void
 dss_enum_unpack_io_fini(struct dss_enum_unpack_io *io)
 {
 	D_ASSERTF(io->ui_iods_top == -1, "%d\n", io->ui_iods_top);
+	daos_iov_free(&io->ui_csum_iov);
 	daos_iov_free(&io->ui_dkey);
 }
 
@@ -776,8 +968,6 @@ clear_top_iod(struct dss_enum_unpack_io *io)
 
 		if (io->ui_sgls != NULL)
 			d_sgl_fini(&io->ui_sgls[idx], false);
-
-		clear_iod_csum(io_iod_csums(io, idx));
 
 		daos_iov_free(&io->ui_iods[idx].iod_name);
 		D_FREE(io->ui_iods[idx].iod_recxs);
@@ -1042,7 +1232,7 @@ enum_unpack_recxs(daos_key_desc_t *kds, void *data,
 			  &io->ui_rec_punch_ephs[top],
 			  &io->ui_rec_min_ephs[top],
 			  io->ui_sgls == NULL ?  NULL : &io->ui_sgls[top],
-			  kds, ptr, csum_iov, &io->ui_iods_csums[top], type);
+			  kds, ptr, csum_iov, io_csums_iov(io), type);
 free:
 	daos_iov_free(&iod_akey);
 	D_DEBUG(DB_IO, "unpack recxs: "DF_RC"\n", DP_RC(rc));
@@ -1213,30 +1403,34 @@ dss_enum_unpack(daos_unit_oid_t oid, daos_key_desc_t *kds, int kds_num,
 {
 	struct dss_enum_unpack_io	io = { 0 };
 	daos_iod_t			iods[DSS_ENUM_UNPACK_MAX_IODS];
-	struct dcs_iod_csums		iods_csums[DSS_ENUM_UNPACK_MAX_IODS];
 	int				recxs_caps[DSS_ENUM_UNPACK_MAX_IODS];
 	d_sg_list_t			sgls[DSS_ENUM_UNPACK_MAX_IODS];
 	daos_epoch_t			ephs[DSS_ENUM_UNPACK_MAX_IODS];
 	daos_epoch_t			rec_ephs[DSS_ENUM_UNPACK_MAX_IODS];
 	daos_epoch_t			rec_min_ephs[DSS_ENUM_UNPACK_MAX_IODS];
-	d_iov_t				csum_iov = { 0 };
+	d_iov_t				csum_iov_in = {0};
 	struct io_unpack_arg		unpack_arg;
 	int				rc = 0;
 
 	D_ASSERT(kds_num > 0);
 	D_ASSERT(kds != NULL);
-	dss_enum_unpack_io_init(&io, oid, iods, iods_csums, recxs_caps, sgls,
+
+	if (csum != NULL)
+		/** make a copy of it because the iteration processes modifies
+		 * the iov
+		 */
+		csum_iov_in = *csum;
+
+	dss_enum_unpack_io_init(&io, oid, iods, recxs_caps, sgls,
 				ephs, rec_ephs, rec_min_ephs,
 				DSS_ENUM_UNPACK_MAX_IODS);
 
-	if (csum)
-		csum_iov = *csum;
 	D_ASSERTF(sgl->sg_nr > 0, "%u\n", sgl->sg_nr);
 	D_ASSERT(sgl->sg_iovs != NULL);
 	unpack_arg.cb = cb;
 	unpack_arg.io = &io;
 	unpack_arg.cb_arg = cb_arg;
-	unpack_arg.csum_iov = &csum_iov;
+	unpack_arg.csum_iov = &csum_iov_in;
 	rc = obj_enum_iterate(kds, sgl, kds_num, -1, enum_obj_io_unpack_cb,
 			      &unpack_arg);
 	if (rc)

--- a/src/object/obj_task.c
+++ b/src/object/obj_task.c
@@ -178,8 +178,8 @@ int
 dc_obj_fetch_task_create(daos_handle_t oh, daos_handle_t th, uint64_t api_flags,
 			 daos_key_t *dkey, uint32_t nr, uint32_t extra_flags,
 			 daos_iod_t *iods, d_sg_list_t *sgls, daos_iom_t *ioms,
-			 void *extra_arg, daos_event_t *ev, tse_sched_t *tse,
-			 tse_task_t **task)
+			 void *extra_arg, d_iov_t *csum, daos_event_t *ev,
+			 tse_sched_t *tse, tse_task_t **task)
 {
 	daos_obj_fetch_t	*args;
 	int			 rc;
@@ -200,6 +200,7 @@ dc_obj_fetch_task_create(daos_handle_t oh, daos_handle_t th, uint64_t api_flags,
 	args->sgls		= sgls;
 	args->ioms		= ioms;
 	args->extra_arg		= extra_arg;
+	args->csum_iov		= csum;
 
 	return 0;
 }

--- a/src/object/obj_tx.c
+++ b/src/object/obj_tx.c
@@ -2623,7 +2623,7 @@ dc_tx_check_existence_task(enum obj_rpc_opc opc, daos_handle_t oh,
 
 	rc = dc_obj_fetch_task_create(oh, dc_tx_ptr2hdl(tx), api_flags, dkey,
 				      nr, DIOF_CHECK_EXISTENCE | DIOF_TO_LEADER,
-				      iods, NULL, NULL, NULL, NULL,
+				      iods, NULL, NULL, NULL, NULL, NULL,
 				      tse_task2sched(parent), &task);
 	if (rc != 0)
 		goto out;

--- a/src/object/obj_verify.c
+++ b/src/object/obj_verify.c
@@ -121,7 +121,7 @@ dc_obj_verify_fetch(struct dc_obj_verify_args *dova)
 	shard = dc_obj_anchor2shard(&dova->dkey_anchor);
 	rc = dc_obj_fetch_task_create(dova->oh, dova->th, 0, &cursor->dkey, 1,
 				      DIOF_TO_SPEC_SHARD, iod, &dova->fetch_sgl,
-				      NULL, &shard, NULL, NULL, &task);
+				      NULL, &shard, NULL, NULL, NULL, &task);
 	if (rc == 0)
 		rc = dc_task_schedule(task, true);
 

--- a/src/object/srv_cli.c
+++ b/src/object/srv_cli.c
@@ -127,7 +127,8 @@ dsc_obj_list_akey(daos_handle_t oh, daos_epoch_t epoch, daos_key_t *dkey,
 int
 dsc_obj_fetch(daos_handle_t oh, daos_epoch_t epoch, daos_key_t *dkey,
 	      unsigned int nr, daos_iod_t *iods, d_sg_list_t *sgls,
-	      daos_iom_t *maps, uint32_t extra_flag, uint32_t *extra_arg)
+	      daos_iom_t *maps, uint32_t extra_flag, uint32_t *extra_arg,
+	      d_iov_t *csum_iov)
 {
 	tse_task_t	*task;
 	daos_handle_t	coh, th;
@@ -139,8 +140,8 @@ dsc_obj_fetch(daos_handle_t oh, daos_epoch_t epoch, daos_key_t *dkey,
 		return rc;
 
 	rc = dc_obj_fetch_task_create(oh, th, 0, dkey, nr, extra_flag,
-				      iods, sgls, maps, extra_arg, NULL,
-				      dsc_scheduler(), &task);
+				      iods, sgls, maps, extra_arg, csum_iov,
+				      NULL, dsc_scheduler(), &task);
 	if (rc)
 		return rc;
 

--- a/src/object/srv_csum.c
+++ b/src/object/srv_csum.c
@@ -586,20 +586,6 @@ ds_csum_add2iod_array(daos_iod_t *iod, struct daos_csummer *csummer,
 	if (biov_csums_used != NULL)
 		*biov_csums_used = 0;
 
-	if (!daos_csummer_initialized(csummer) || !bsgl)
-		return 0;
-
-	if (!csum_iod_is_supported(iod))
-		return 0;
-
-	if (iod->iod_type == DAOS_IOD_SINGLE) {
-		ci_insert(&iod_csums->ic_data[0], 0,
-			   biov_csums[0].cs_csum, biov_csums[0].cs_len);
-		if (biov_csums_used != NULL)
-			(*biov_csums_used) = 1;
-		return 0;
-	}
-
 	/** Verify have correct csums for extents returned.
 	 * Should be 1 biov_csums for each non-hole biov in bsgl
 	 */

--- a/src/object/srv_ec_aggregate.c
+++ b/src/object/srv_ec_aggregate.c
@@ -544,7 +544,7 @@ agg_fetch_odata_cells(struct ec_agg_entry *entry, uint8_t *bit_map,
 	epoch = is_recalc ? stripe->as_hi_epoch :
 		entry->ae_par_extent.ape_epoch;
 	rc = dsc_obj_fetch(entry->ae_obj_hdl, epoch, &entry->ae_dkey, 1, &iod,
-			   &entry->ae_sgl, NULL, 0, NULL);
+			   &entry->ae_sgl, NULL, 0, NULL, NULL);
 	if (rc)
 		D_ERROR("dsc_obj_fetch failed: "DF_RC"\n", DP_RC(rc));
 
@@ -964,7 +964,7 @@ agg_fetch_remote_parity(struct ec_agg_entry *entry)
 		rc = dsc_obj_fetch(entry->ae_obj_hdl,
 				   entry->ae_par_extent.ape_epoch,
 				   &entry->ae_dkey, 1, &iod, &sgl, NULL,
-				   DIOF_TO_SPEC_SHARD, &pshard);
+				   DIOF_TO_SPEC_SHARD, &pshard, NULL);
 		if (rc)
 			goto out;
 		pshard--;
@@ -1470,7 +1470,7 @@ agg_process_holes_ult(void *arg)
 	/* Pull data via dsc_obj_fetch */
 	rc = dsc_obj_fetch(entry->ae_obj_hdl, entry->ae_cur_stripe.as_hi_epoch,
 			   &entry->ae_dkey, 1, &iod, &entry->ae_sgl, NULL, 0,
-			   NULL);
+			   NULL, NULL);
 	if (rc) {
 		D_ERROR("dsc_obj_fetch failed: "DF_RC"\n", DP_RC(rc));
 		goto out;

--- a/src/object/srv_obj_migrate.c
+++ b/src/object/srv_obj_migrate.c
@@ -20,6 +20,7 @@
 #include <daos_srv/daos_engine.h>
 #include <daos_srv/vos.h>
 #include <daos_srv/dtx_srv.h>
+#include <daos_srv/srv_csum.h>
 #include "obj_rpc.h"
 #include "obj_internal.h"
 
@@ -49,6 +50,7 @@ struct migrate_one {
 	uint64_t		 mo_version;
 	uint32_t		 mo_pool_tls_version;
 	d_list_t		 mo_list;
+	d_iov_t			 mo_csum_iov;
 };
 
 struct migrate_obj_key {
@@ -510,8 +512,60 @@ mrone_recx_vos2_daos(struct migrate_one *mrone, struct daos_oclass_attr *oca,
 	mrone_recx_daos_vos_internal(mrone, oca, false, shard);
 }
 
+static int
+mrone_obj_fetch(struct migrate_one *mrone, daos_handle_t oh, d_sg_list_t *sgls,
+		d_iov_t *csum_iov_fetch)
+{
+	uint32_t		 flags = DIOF_FOR_MIGRATION;
+	int			 rc;
+	struct daos_oclass_attr *oca;
+
+	oca = daos_oclass_attr_find(mrone->mo_oid.id_pub);
+	D_ASSERT(oca != NULL);
+
+	if (daos_oclass_grp_size(oca) > 1)
+		flags |= DIOF_TO_LEADER;
+
+	rc = dsc_obj_fetch(oh, mrone->mo_epoch, &mrone->mo_dkey,
+			   mrone->mo_iod_num, mrone->mo_iods, sgls, NULL,
+			   flags, NULL, csum_iov_fetch);
+
+	if (rc != 0)
+		return rc;
+
+	if (csum_iov_fetch != NULL &&
+	    csum_iov_fetch->iov_len > csum_iov_fetch->iov_buf_len) {
+		/** retry dsc_obj_fetch with appropriate csum_iov
+		 * buf length
+		 */
+		void *p;
+
+		D_REALLOC(p, csum_iov_fetch->iov_buf, csum_iov_fetch->iov_len);
+		if (p == NULL)
+			return -DER_NOMEM;
+		csum_iov_fetch->iov_buf_len = csum_iov_fetch->iov_len;
+		csum_iov_fetch->iov_len = 0;
+		csum_iov_fetch->iov_buf = p;
+
+		rc = dsc_obj_fetch(oh, mrone->mo_epoch, &mrone->mo_dkey,
+				   mrone->mo_iod_num, mrone->mo_iods, sgls,
+				   NULL, DIOF_TO_LEADER, NULL, csum_iov_fetch);
+	}
+
+	return rc;
+}
+
 #define MIGRATE_STACK_SIZE	131072
 #define MAX_BUF_SIZE		2048
+#define CSUM_BUF_SIZE		256
+
+/**
+ * allocate the memory for the iods_csums and unpack the csum_iov into the
+ * into the iods_csums.
+ * Note: the csum_iov is modified so a shallow copy should be sent instead of
+ * the original.
+ */
+
 
 static int
 migrate_fetch_update_inline(struct migrate_one *mrone, daos_handle_t oh,
@@ -527,6 +581,10 @@ migrate_fetch_update_inline(struct migrate_one *mrone, daos_handle_t oh,
 	int			 i;
 	int			 rc = 0;
 	struct daos_oclass_attr	*oca;
+	struct daos_csummer	*csummer;
+	d_iov_t			*csums_iov = NULL;
+	d_iov_t			 csum_iov_fetch = {0};
+	d_iov_t			 tmp_csum_iov;
 
 	D_ASSERT(mrone->mo_iod_num <= DSS_ENUM_UNPACK_MAX_IODS);
 	for (i = 0; i < mrone->mo_iod_num; i++) {
@@ -559,22 +617,35 @@ migrate_fetch_update_inline(struct migrate_one *mrone, daos_handle_t oh,
 	oca = daos_oclass_attr_find(mrone->mo_oid.id_pub);
 	D_ASSERT(oca != NULL);
 	if (fetch) {
-		uint32_t flags = DIOF_FOR_MIGRATION;
+		rc = daos_iov_alloc(&csum_iov_fetch, CSUM_BUF_SIZE, false);
+		if (rc != 0)
+			D_GOTO(out, rc);
 
-		if (daos_oclass_grp_size(oca) > 1)
-			flags |= DIOF_TO_LEADER;
+		rc = mrone_obj_fetch(mrone, oh, sgls, &csum_iov_fetch);
 
-		rc = dsc_obj_fetch(oh, mrone->mo_epoch, &mrone->mo_dkey,
-				   mrone->mo_iod_num, mrone->mo_iods, sgls,
-				   NULL, flags, NULL);
 		if (rc) {
-			D_ERROR("dsc_obj_fetch %d\n", rc);
+			D_ERROR("mrone_obj_fetch "DF_RC"\n", DP_RC(rc));
 			return rc;
 		}
+
+		/** Using all fetched data so use all fetched checksums */
+		csums_iov = &csum_iov_fetch;
+	} else {
+		/** csums were packed from obj_enum because data is inlined */
+		csums_iov = &mrone->mo_csum_iov;
 	}
+	D_ASSERT(csums_iov != NULL);
+	/** make a copy of the iov because it will be modified while
+	 * iterating over the csums
+	 */
+	tmp_csum_iov = *csums_iov;
 
 	if (DAOS_OC_IS_EC(oca) && !obj_shard_is_ec_parity(mrone->mo_oid, NULL))
 		mrone_recx_daos2_vos(mrone, oca);
+
+	rc = daos_csummer_csum_init_with_packed(&csummer, csums_iov);
+	if (rc != 0)
+		D_GOTO(out, rc);
 
 	for (i = 0, start = 0; i < mrone->mo_iod_num; i++) {
 		if (mrone->mo_iods[i].iod_size > 0) {
@@ -587,16 +658,28 @@ migrate_fetch_update_inline(struct migrate_one *mrone, daos_handle_t oh,
 				continue;
 			}
 
-			iod_csums = mrone->mo_iods_csums == NULL ? NULL
-					: &mrone->mo_iods_csums[start];
 			D_DEBUG(DB_TRACE, "update start %d cnt %d\n",
 				start, iod_cnt);
+
+			rc = daos_csummer_alloc_iods_csums_with_packed(
+				csummer,
+				&mrone->mo_iods[start],
+				iod_cnt, &tmp_csum_iov,
+				&iod_csums);
+			if (rc != 0) {
+				D_ERROR("setting up iods csums failed: "
+						DF_RC"\n", DP_RC(rc));
+				break;
+			}
+
 			rc = vos_obj_update(ds_cont->sc_hdl, mrone->mo_oid,
 					    mrone->mo_update_epoch,
 					    mrone->mo_version,
 					    0, &mrone->mo_dkey, iod_cnt,
 					    &mrone->mo_iods[start], iod_csums,
 					    &sgls[start]);
+			daos_csummer_free_ic(csummer, &iod_csums);
+
 			if (rc) {
 				D_ERROR("migrate failed: rc %d\n", rc);
 				break;
@@ -607,15 +690,34 @@ migrate_fetch_update_inline(struct migrate_one *mrone, daos_handle_t oh,
 	}
 
 	if (iod_cnt > 0) {
-		iod_csums = mrone->mo_iods_csums == NULL ? NULL
-				: &mrone->mo_iods_csums[start];
+		rc = daos_csummer_alloc_iods_csums_with_packed(
+			csummer,
+			&mrone->mo_iods[start],
+			iod_cnt,
+			&tmp_csum_iov, &iod_csums);
+		if (rc != 0) {
+			D_ERROR("failed to alloc iod csums: rc "DF_RC". "
+				"csum_iov was '%s'\n",
+				DP_RC(rc), fetch ? "FETCHED" : "INLINE");
+			D_GOTO(out, rc);
+		}
 		rc = vos_obj_update(ds_cont->sc_hdl, mrone->mo_oid,
 				    mrone->mo_update_epoch,
 				    mrone->mo_version,
 				    0, &mrone->mo_dkey, iod_cnt,
 				    &mrone->mo_iods[start], iod_csums,
 				    &sgls[start]);
+
+		if (rc) {
+			D_ERROR("migrate failed: rc "DF_RC"\n", DP_RC(rc));
+			D_GOTO(out, rc);
+		}
+		daos_csummer_free_ic(csummer, &iod_csums);
 	}
+
+out:
+	D_FREE(csum_iov_fetch.iov_buf);
+	daos_csummer_destroy(&csummer);
 
 	return rc;
 }
@@ -652,14 +754,17 @@ static int
 migrate_update_parity(struct migrate_one *mrone, struct ds_cont_child *ds_cont,
 		      unsigned char *buffer, daos_off_t offset,
 		      daos_size_t size, struct daos_oclass_attr *oca,
-		      daos_iod_t *iod, unsigned char *p_bufs[])
+		      daos_iod_t *iod, unsigned char *p_bufs[],
+		      d_iov_t *csum_iov)
 {
-	daos_size_t	stride_nr = obj_ec_stripe_rec_nr(oca);
-	daos_size_t	cell_nr = obj_ec_cell_rec_nr(oca);
-	daos_recx_t	tmp_recx;
-	d_iov_t		tmp_iov;
-	d_sg_list_t	tmp_sgl;
-	daos_size_t	write_nr;
+	daos_size_t		 stride_nr = obj_ec_stripe_rec_nr(oca);
+	daos_size_t		 cell_nr = obj_ec_cell_rec_nr(oca);
+	daos_recx_t		 tmp_recx;
+	d_iov_t			 tmp_iov;
+	d_sg_list_t		 tmp_sgl;
+	daos_size_t		 write_nr;
+	struct daos_csummer	*csummer = NULL;
+	struct dcs_iod_csums	*iod_csums = NULL;
 	int		rc = 0;
 
 	tmp_sgl.sg_nr = tmp_sgl.sg_nr_out = 1;
@@ -702,16 +807,39 @@ migrate_update_parity(struct migrate_one *mrone, struct ds_cont_child *ds_cont,
 
 		tmp_sgl.sg_iovs = &tmp_iov;
 		iod->iod_recxs = &tmp_recx;
+
+		rc = daos_csummer_csum_init_with_packed(&csummer, csum_iov);
+		if (rc != 0) {
+			D_ERROR("Error initializing csummer");
+			D_GOTO(out, rc);
+		}
+
+		rc = daos_csummer_alloc_iods_csums_with_packed(
+			csummer,
+			iod,
+			1, csum_iov, &iod_csums);
+		if (rc != 0) {
+			D_ERROR("Error allocating iods");
+			D_GOTO(out, rc);
+		}
+
+		D_ASSERTF(iod_csums == NULL, "DAOS-6811 - EC Rebuild with "
+					     "checksums is currently "
+					     "unsupported.");
+
+
 		rc = vos_obj_update(ds_cont->sc_hdl, mrone->mo_oid,
 				    mrone->mo_epoch,
 				    mrone->mo_version,
-				    0, &mrone->mo_dkey, 1, iod, NULL,
+				    0, &mrone->mo_dkey, 1, iod, iod_csums,
 				    &tmp_sgl);
 		size -= write_nr;
 		offset += write_nr;
 		buffer += write_nr * iod->iod_size;
 	}
 out:
+	daos_csummer_free_ic(csummer, &iod_csums);
+	daos_csummer_destroy(&csummer);
 	return rc;
 }
 
@@ -722,11 +850,13 @@ migrate_fetch_update_parity(struct migrate_one *mrone, daos_handle_t oh,
 {
 	d_sg_list_t	 sgls[DSS_ENUM_UNPACK_MAX_IODS];
 	d_iov_t		 iov[DSS_ENUM_UNPACK_MAX_IODS] = { 0 };
-	char		 *data;
+	d_iov_t		 csum_iov_fetch = { 0 };
+	d_iov_t		 tmp_csum_iov_fetch;
+	char		*data;
 	daos_size_t	 size;
 	unsigned int	 p = obj_ec_parity_tgt_nr(oca);
-	unsigned char	 *p_bufs[p];
-	unsigned char	 *ptr;
+	unsigned char	*p_bufs[p];
+	unsigned char	*ptr;
 	int		 i;
 	int		 rc;
 
@@ -749,9 +879,11 @@ migrate_fetch_update_parity(struct migrate_one *mrone, daos_handle_t oh,
 		DP_UOID(mrone->mo_oid), mrone, DP_KEY(&mrone->mo_dkey),
 		mrone->mo_iod_num, mrone->mo_epoch);
 
-	rc = dsc_obj_fetch(oh, mrone->mo_epoch, &mrone->mo_dkey,
-			   mrone->mo_iod_num, mrone->mo_iods, sgls, NULL,
-			   DIOF_TO_LEADER | DIOF_FOR_MIGRATION, NULL);
+	rc = daos_iov_alloc(&csum_iov_fetch, CSUM_BUF_SIZE, false);
+	if (rc)
+		D_GOTO(out, rc);
+	rc = mrone_obj_fetch(mrone, oh, sgls, &csum_iov_fetch);
+	tmp_csum_iov_fetch = csum_iov_fetch;
 	if (rc) {
 		D_ERROR("migrate dkey "DF_KEY" failed rc %d\n",
 			DP_KEY(&mrone->mo_dkey), rc);
@@ -779,7 +911,8 @@ migrate_fetch_update_parity(struct migrate_one *mrone, daos_handle_t oh,
 
 			tmp_iod.iod_nr = 1;
 			rc = migrate_update_parity(mrone, ds_cont, ptr, offset,
-						   size, oca, &tmp_iod, p_bufs);
+						   size, oca, &tmp_iod, p_bufs,
+						   &tmp_csum_iov_fetch);
 			if (rc)
 				D_GOTO(out, rc);
 			ptr += size * iod->iod_size;
@@ -789,7 +922,8 @@ migrate_fetch_update_parity(struct migrate_one *mrone, daos_handle_t oh,
 
 		if (size > 0)
 			rc = migrate_update_parity(mrone, ds_cont, ptr, offset,
-						   size, oca, &tmp_iod, p_bufs);
+						   size, oca, &tmp_iod, p_bufs,
+						   &tmp_csum_iov_fetch);
 	}
 out:
 	for (i = 0; i < mrone->mo_iod_num; i++) {
@@ -802,6 +936,8 @@ out:
 			D_FREE(p_bufs[i]);
 	}
 
+	daos_iov_free(&csum_iov_fetch);
+
 	return rc;
 }
 
@@ -810,13 +946,16 @@ migrate_fetch_update_single(struct migrate_one *mrone, daos_handle_t oh,
 			    struct ds_cont_child *ds_cont)
 {
 	struct daos_oclass_attr	*oca;
-	d_sg_list_t		sgls[DSS_ENUM_UNPACK_MAX_IODS];
-	d_iov_t			iov[DSS_ENUM_UNPACK_MAX_IODS] = { 0 };
-	uint32_t		flags = DIOF_FOR_MIGRATION;
+	d_sg_list_t		 sgls[DSS_ENUM_UNPACK_MAX_IODS];
+	d_iov_t			 iov[DSS_ENUM_UNPACK_MAX_IODS] = { 0 };
 	char			*data;
-	daos_size_t		size;
-	int			i;
-	int			rc;
+	daos_size_t		 size;
+	int			 i;
+	int			 rc;
+	d_iov_t			 csum_iov_fetch = {0};
+	struct daos_csummer	*csummer = NULL;
+	d_iov_t			 tmp_csum_iov;
+	struct dcs_iod_csums	*iod_csums = NULL;
 
 	oca = daos_oclass_attr_find(mrone->mo_oid.id_pub);
 	D_ASSERT(oca != NULL);
@@ -841,12 +980,11 @@ migrate_fetch_update_single(struct migrate_one *mrone, daos_handle_t oh,
 		DP_UOID(mrone->mo_oid), mrone, DP_KEY(&mrone->mo_dkey),
 		mrone->mo_iod_num, mrone->mo_epoch);
 
-	if (daos_oclass_grp_size(oca) > 1)
-		flags |= DIOF_TO_LEADER;
+	rc = daos_iov_alloc(&csum_iov_fetch, CSUM_BUF_SIZE, false);
+	if (rc != 0)
+		D_GOTO(out, rc);
 
-	rc = dsc_obj_fetch(oh, mrone->mo_epoch, &mrone->mo_dkey,
-			   mrone->mo_iod_num, mrone->mo_iods, sgls, NULL,
-			   flags, NULL);
+	rc = mrone_obj_fetch(mrone, oh, sgls, &csum_iov_fetch);
 	if (rc) {
 		D_ERROR("migrate dkey "DF_KEY" failed rc %d\n",
 			DP_KEY(&mrone->mo_dkey), rc);
@@ -886,10 +1024,24 @@ migrate_fetch_update_single(struct migrate_one *mrone, daos_handle_t oh,
 				       true, false, NULL);
 	}
 
+	rc = daos_csummer_csum_init_with_packed(&csummer, &csum_iov_fetch);
+	if (rc != 0)
+		D_GOTO(out, rc);
+
+	tmp_csum_iov = csum_iov_fetch;
+	rc = daos_csummer_alloc_iods_csums_with_packed(
+		csummer,
+		&mrone->mo_iods[0],
+		mrone->mo_iod_num,
+		&tmp_csum_iov, &iod_csums);
+	if (rc != 0) {
+		D_ERROR("unable to allocate iod csums.");
+		goto out;
+	}
 	rc = vos_obj_update(ds_cont->sc_hdl, mrone->mo_oid,
 			    mrone->mo_update_epoch, mrone->mo_version,
 			    0, &mrone->mo_dkey, mrone->mo_iod_num,
-			    mrone->mo_iods, mrone->mo_iods_csums, sgls);
+			    mrone->mo_iods, iod_csums, sgls);
 out:
 	for (i = 0; i < mrone->mo_iod_num; i++) {
 		if (iov[i].iov_buf)
@@ -902,6 +1054,9 @@ out:
 			mrone->mo_iods[i].iod_recxs = NULL;
 	}
 
+	daos_iov_free(&csum_iov_fetch);
+	daos_csummer_destroy(&csummer);
+
 	return rc;
 }
 
@@ -909,11 +1064,15 @@ static int
 migrate_fetch_update_bulk(struct migrate_one *mrone, daos_handle_t oh,
 			  struct ds_cont_child *ds_cont)
 {
-	d_sg_list_t	sgls[DSS_ENUM_UNPACK_MAX_IODS];
-	daos_handle_t	ioh;
+	d_sg_list_t		 sgls[DSS_ENUM_UNPACK_MAX_IODS];
+	daos_handle_t		 ioh;
 	struct daos_oclass_attr *oca;
-	uint32_t	flags = DIOF_FOR_MIGRATION;
-	int		rc, rc1, i, ret, sgl_cnt = 0;
+	int			 rc, rc1, i, ret, sgl_cnt = 0;
+	struct daos_csummer	*csummer = NULL;
+	d_iov_t			 csum_iov_fetch = {0};
+	struct dcs_iod_csums	*iod_csums = NULL;
+	d_iov_t			 tmp_csum_iov;
+
 
 	if (obj_shard_is_ec_parity(mrone->mo_oid, &oca))
 		return migrate_fetch_update_parity(mrone, oh, ds_cont, oca);
@@ -959,15 +1118,31 @@ migrate_fetch_update_bulk(struct migrate_one *mrone, daos_handle_t oh,
 	if (DAOS_OC_IS_EC(oca))
 		mrone_recx_vos2_daos(mrone, oca, mrone->mo_oid.id_shard);
 
-	if (daos_oclass_grp_size(oca) > 1)
-		flags |= DIOF_TO_LEADER;
+	rc = daos_iov_alloc(&csum_iov_fetch, CSUM_BUF_SIZE, false);
+	if (rc != 0)
+		D_GOTO(post, rc);
 
-	rc = dsc_obj_fetch(oh, mrone->mo_epoch, &mrone->mo_dkey,
-			   mrone->mo_iod_num, mrone->mo_iods, sgls, NULL,
-			   flags, NULL);
+	rc = mrone_obj_fetch(mrone, oh, sgls, &csum_iov_fetch);
 	if (rc)
 		D_ERROR("migrate dkey "DF_KEY" failed rc %d\n",
 			DP_KEY(&mrone->mo_dkey), rc);
+
+	rc = daos_csummer_csum_init_with_packed(&csummer, &csum_iov_fetch);
+	if (rc != 0)
+		D_GOTO(post, rc);
+
+	tmp_csum_iov = csum_iov_fetch;
+	rc = daos_csummer_alloc_iods_csums_with_packed(csummer,
+						       mrone->mo_iods,
+						       mrone->mo_iod_num,
+						       &tmp_csum_iov,
+						       &iod_csums);
+	if (rc != 0) {
+		D_ERROR("Failed to alloc iod csums");
+		D_GOTO(post, rc);
+	}
+
+	vos_set_io_csum(ioh, iod_csums);
 post:
 	for (i = 0; i < sgl_cnt; i++)
 		d_sgl_fini(&sgls[i], false);
@@ -984,6 +1159,9 @@ post:
 
 end:
 	rc1 = vos_update_end(ioh, mrone->mo_version, &mrone->mo_dkey, rc, NULL);
+	daos_csummer_free_ic(csummer, &iod_csums);
+	daos_csummer_destroy(&csummer);
+	daos_iov_free(&csum_iov_fetch);
 	if (rc == 0)
 		rc = rc1;
 	return rc;
@@ -1109,7 +1287,7 @@ migrate_dkey(struct migrate_pool_tls *tls, struct migrate_one *mrone)
 	data_size = daos_iods_len(mrone->mo_iods, mrone->mo_iod_num);
 	D_DEBUG(DB_TRACE, "data size is "DF_U64"\n", data_size);
 	if (data_size == 0) {
-		D_DEBUG(DB_REBUILD, "skipe empty iod\n");
+		D_DEBUG(DB_REBUILD, "skip empty iod\n");
 		D_GOTO(obj_close, rc);
 	}
 
@@ -1156,18 +1334,8 @@ migrate_one_destroy(struct migrate_one *mrone)
 		D_FREE(mrone->mo_sgls);
 	}
 
-	if (mrone->mo_iods_csums) {
-		struct dcs_iod_csums	*iod_csum;
-		int			 j;
-
-		for (i = 0; i < mrone->mo_iod_alloc_num; i++) {
-			iod_csum = &mrone->mo_iods_csums[i];
-			for (j = 0; j < iod_csum->ic_nr; j++)
-				D_FREE(iod_csum->ic_data[j].cs_csum);
-			D_FREE(iod_csum->ic_data);
-		}
+	if (mrone->mo_iods_csums)
 		D_FREE(mrone->mo_iods_csums);
-	}
 
 	D_FREE(mrone);
 }
@@ -1482,7 +1650,6 @@ migrate_one_insert(struct enum_unpack_arg *arg,
 	daos_key_t		*dkey = &io->ui_dkey;
 	daos_epoch_t		dkey_punch_eph = io->ui_dkey_punch_eph;
 	daos_iod_t		*iods = io->ui_iods;
-	struct dcs_iod_csums	*iods_csums = io->ui_iods_csums;
 	daos_epoch_t		*akey_ephs = io->ui_akey_punch_ephs;
 	daos_epoch_t		*rec_ephs = io->ui_rec_punch_ephs;
 	int			iod_eph_total = io->ui_iods_top + 1;
@@ -1514,10 +1681,6 @@ migrate_one_insert(struct enum_unpack_arg *arg,
 	D_INIT_LIST_HEAD(&mrone->mo_list);
 	D_ALLOC_ARRAY(mrone->mo_iods, iod_eph_total);
 	if (mrone->mo_iods == NULL)
-		D_GOTO(free, rc = -DER_NOMEM);
-
-	D_ALLOC_ARRAY(mrone->mo_iods_csums, iod_eph_total);
-	if (mrone->mo_iods_csums == NULL)
 		D_GOTO(free, rc = -DER_NOMEM);
 
 	mrone->mo_epoch = arg->epr.epr_hi;
@@ -1574,16 +1737,12 @@ migrate_one_insert(struct enum_unpack_arg *arg,
 					 inline_copy ? &sgls[i] : NULL);
 			if (rc)
 				D_GOTO(free, rc);
-			/**
-			 * mrone owns the allocated memory now and will free
-			 * it in migrate_one_destroy().
-			 */
-			mrone->mo_iods_csums[mrone->mo_iod_num - 1] =
-				iods_csums[i];
-			iods_csums[i].ic_data = NULL;
-			iods_csums[i].ic_nr = 0;
 		}
 	}
+
+	rc = daos_iov_copy(&mrone->mo_csum_iov, &io->ui_csum_iov);
+	if (rc != 0)
+		D_GOTO(free, rc);
 
 	mrone->mo_version = version;
 	D_DEBUG(DB_TRACE, "create migrate dkey ult %d\n",
@@ -1751,7 +1910,6 @@ migrate_start_ult(struct enum_unpack_arg *unpack_arg)
 
 #define KDS_NUM		16
 #define ITER_BUF_SIZE	2048
-#define CSUM_BUF_SIZE	256
 
 /**
  * Iterate akeys/dkeys of the object

--- a/src/tests/suite/daos_aggregate_ec.c
+++ b/src/tests/suite/daos_aggregate_ec.c
@@ -312,7 +312,7 @@ verify_1p(struct ec_agg_test_ctx *ctx, daos_oclass_id_t ec_agg_oc,
 						      &ctx->fetch_iod,
 						      &ctx->fetch_sgl,
 						      &ctx->fetch_iom, &shard,
-						      NULL, NULL, &task);
+						      NULL, NULL, NULL, &task);
 			assert_rc_equal(rc, 0);
 			rc = dc_task_schedule(task, true);
 			assert_rc_equal(rc, 0);
@@ -331,7 +331,7 @@ verify_1p(struct ec_agg_test_ctx *ctx, daos_oclass_id_t ec_agg_oc,
 						      &ctx->fetch_iod,
 						      &ctx->fetch_sgl,
 						      &ctx->fetch_iom, &shard,
-						      NULL, NULL, &task);
+						      NULL, NULL, NULL, &task);
 			assert_rc_equal(rc, 0);
 			rc = dc_task_schedule(task, true);
 			assert_rc_equal(rc, 0);
@@ -441,7 +441,7 @@ verify_2p(struct ec_agg_test_ctx *ctx, daos_oclass_id_t ec_agg_oc)
 						      &ctx->fetch_iod,
 						      &ctx->fetch_sgl,
 						      &ctx->fetch_iom, &shard,
-						      NULL, NULL, &task);
+						      NULL, NULL, NULL, &task);
 			assert_rc_equal(rc, 0);
 			rc = dc_task_schedule(task, true);
 			assert_rc_equal(rc, 0);
@@ -457,7 +457,7 @@ verify_2p(struct ec_agg_test_ctx *ctx, daos_oclass_id_t ec_agg_oc)
 						      &ctx->fetch_iod,
 						      &ctx->fetch_sgl,
 						      &ctx->fetch_iom, &shard,
-						      NULL, NULL, &task);
+						      NULL, NULL, NULL, &task);
 			assert_rc_equal(rc, 0);
 			rc = dc_task_schedule(task, true);
 			assert_rc_equal(rc, 0);
@@ -477,7 +477,7 @@ verify_2p(struct ec_agg_test_ctx *ctx, daos_oclass_id_t ec_agg_oc)
 						      &ctx->fetch_iod,
 						      &ctx->fetch_sgl,
 						      &ctx->fetch_iom, &shard,
-						      NULL, NULL, &task);
+						      NULL, NULL, NULL, &task);
 			assert_rc_equal(rc, 0);
 			rc = dc_task_schedule(task, true);
 			assert_rc_equal(rc, 0);
@@ -497,7 +497,7 @@ verify_2p(struct ec_agg_test_ctx *ctx, daos_oclass_id_t ec_agg_oc)
 						      &ctx->fetch_iod,
 						      &ctx->fetch_sgl,
 						      &ctx->fetch_iom, &shard,
-						      NULL, NULL, &task);
+						      NULL, NULL, NULL, &task);
 			assert_rc_equal(rc, 0);
 			rc = dc_task_schedule(task, true);
 			assert_rc_equal(rc, 0);

--- a/src/tests/suite/daos_checksum.c
+++ b/src/tests/suite/daos_checksum.c
@@ -6,6 +6,7 @@
 
 #define D_LOGFAC	DD_FAC(tests)
 #include "daos_test.h"
+#include "daos_iotest.h"
 
 #include <daos/checksum.h>
 #include <gurt/types.h>
@@ -13,6 +14,7 @@
 #include <daos/task.h>
 #include <daos/event.h>
 #include <daos/container.h>
+#include <daos_srv/daos_engine.h>
 
 static void
 iov_update_fill(d_iov_t *iov, char *data, uint64_t len_to_fill);
@@ -29,7 +31,7 @@ daos_checksum_test_arg2type(char *str)
 }
 
 /** by default for replica object test */
-static daos_oclass_id_t dts_csum_oc = OC_SX;
+static daos_oclass_id_t dts_csum_oc = OC_S1;
 static uint32_t dts_csum_prop_type = DAOS_PROP_CO_CSUM_SHA512;
 
 /** enable EC obj csum test or replica obj csum test */
@@ -129,26 +131,28 @@ iov_alloc_str(d_iov_t *iov, const char *str)
 /** daos checksum test context */
 struct csum_test_ctx {
 	/** Pool */
-	daos_handle_t		poh;
+	daos_handle_t		 poh;
 	/** Container */
-	daos_handle_t		coh;
-	daos_cont_info_t	info;
-	uuid_t			uuid;
+	daos_handle_t		 coh;
+	daos_cont_info_t	 info;
+	uuid_t			 uuid;
 	/** Object */
-	daos_handle_t		oh;
-	daos_obj_id_t		oid;
-	daos_key_t		dkey;
-	daos_iod_t		update_iod;
-	d_sg_list_t		update_sgl;
-	daos_iod_t		fetch_iod;
-	d_sg_list_t		fetch_sgl;
-	daos_recx_t		recx[8];
+	daos_handle_t		 oh;
+	daos_obj_id_t		 oid;
+	daos_key_t		 dkey;
+	daos_iod_t		 update_iod;
+	d_sg_list_t		 update_sgl;
+	daos_iod_t		 fetch_iod;
+	d_sg_list_t		 fetch_sgl;
+	daos_recx_t		 recx[8];
+	test_arg_t		*test_arg;
 };
 
 static void
 setup_from_test_args(struct csum_test_ctx *ctx, test_arg_t *state)
 {
 	ctx->poh = state->pool.poh;
+	ctx->test_arg = state;
 }
 
 /**
@@ -351,7 +355,7 @@ checksum_disabled(void **state)
 	 */
 	rc = daos_obj_update(ctx.oh, DAOS_TX_NONE, 0, &ctx.dkey, 1,
 			     &ctx.update_iod, &ctx.update_sgl, NULL);
-	assert_rc_equal(rc, 0);
+	assert_success(rc);
 
 	rc = daos_obj_fetch(ctx.oh, DAOS_TX_NONE, 0, &ctx.dkey, 1,
 			    &ctx.fetch_iod, &ctx.fetch_sgl, NULL, NULL);
@@ -626,6 +630,42 @@ struct partial_unaligned_fetch_testcase_args {
 	daos_recx_t		 fetch_recxs[FETCH_RECX_NR];
 	daos_oclass_id_t	 oclass;
 };
+
+static void
+insert_data(const char *akey_format, const char *dkey, struct ioreq *req,
+	    const uint32_t akey_loop, const uint32_t rec_loop, char *data_str,
+	    daos_iod_type_t iod_type)
+{
+	char akey[32];
+	int a, r;
+
+	req->iod_type = iod_type;
+	for (a = 0; a < akey_loop; a++) {
+		sprintf(akey, akey_format, a);
+
+		for (r = 0; r < rec_loop; r++) {
+			insert_single(dkey, akey, r,
+				      data_str,
+				      strlen(data_str) + 1,
+				      DAOS_TX_NONE, req);
+		}
+	}
+}
+
+static int
+disabled_targets(test_arg_t *arg)
+{
+	int			rc;
+	daos_pool_info_t	info;
+
+	rc = daos_pool_query(arg->pool.poh, NULL, &info, NULL, NULL);
+
+	if (rc < 0)
+		return rc;
+
+	return info.pi_ndisabled;
+}
+
 
 static void
 setup_obj_data_for_sv(struct csum_test_ctx *ctx, bool large_buf)
@@ -1263,6 +1303,8 @@ dtx_with_csum(void **state)
 	daos_oclass_id_t	 oc = dts_csum_oc;
 	int			 rc;
 
+	/* Skipping test because of DAOS-6381 */
+	skip();
 
 	if (csum_ec_enabled() && !test_runable(arg, csum_ec_grp_size()))
 		skip();
@@ -1720,20 +1762,6 @@ get_rank_not_in_placement(struct daos_obj_layout *placement,
 	return -1;
 }
 
-static int
-disabled_targets(test_arg_t *arg)
-{
-	int			rc;
-	daos_pool_info_t	info;
-
-	rc = daos_pool_query(arg->pool.poh, NULL, &info, NULL, NULL);
-
-	if (rc < 0)
-		return rc;
-
-	return info.pi_ndisabled;
-}
-
 static void
 rebuild_test(void **state, int chunksize, int data_len_bytes, int iod_type)
 {
@@ -1763,6 +1791,15 @@ rebuild_test(void **state, int chunksize, int data_len_bytes, int iod_type)
 	rc = daos_obj_update(ctx.oh, DAOS_TX_NONE, 0, &ctx.dkey, 1,
 			     &ctx.update_iod, &ctx.update_sgl, NULL);
 	assert_success(rc);
+
+	/** insert another overlapping extent */
+	if (iod_type == DAOS_IOD_ARRAY) {
+		ctx.recx->rx_idx += data_len_bytes / 2;
+		ctx.recx->rx_nr -= data_len_bytes / 2;
+		rc = daos_obj_update(ctx.oh, DAOS_TX_NONE, 0, &ctx.dkey, 1,
+				     &ctx.update_iod, &ctx.update_sgl, NULL);
+		assert_success(rc);
+	}
 
 	rc = daos_obj_layout_get(ctx.coh, ctx.oid, &layout1);
 	assert_success(rc);
@@ -1795,11 +1832,13 @@ rebuild_test(void **state, int chunksize, int data_len_bytes, int iod_type)
 	assert_true(rank_to_fetch >= 0);
 	print_message("Rank to fetch: %d\n", rank_to_fetch);
 
-	daos_fail_loc_set(DAOS_OBJ_SPECIAL_SHARD);
+	daos_fail_loc_set(DAOS_OBJ_SPECIAL_SHARD | DAOS_FAIL_ALWAYS);
 	daos_fail_num_set(rank_to_fetch);
 	rc = daos_obj_fetch(ctx.oh, DAOS_TX_NONE, 0, &ctx.dkey,
 			    1, &ctx.fetch_iod, &ctx.fetch_sgl, NULL, NULL);
 	assert_success(rc);
+	daos_fail_loc_reset();
+	daos_fail_num_set(0);
 
 	daos_reint_server(arg->pool.pool_uuid, arg->group, arg->dmg_config,
 			  rank_to_exclude);
@@ -1814,35 +1853,104 @@ rebuild_test(void **state, int chunksize, int data_len_bytes, int iod_type)
 	cleanup_cont_obj(&ctx);
 }
 
+int
+tst_obj_fetch(daos_handle_t oh, daos_epoch_t epoch, daos_key_t *dkey,
+	      unsigned int nr, daos_iod_t *iods, d_sg_list_t *sgls,
+	      daos_iom_t *maps, uint32_t extra_flag, void *extra_arg,
+	      d_iov_t *csum)
+{
+	tse_task_t	*task;
+	int		rc;
+
+	rc = dc_obj_fetch_task_create(oh, DAOS_TX_NONE, 0, dkey, nr, extra_flag,
+				      iods, sgls, maps, extra_arg, csum, NULL,
+				      NULL, &task);
+
+	assert_rc_equal(0, rc);
+
+	return dc_task_schedule(task, true);
+}
+
+static void
+ctx_obj_update(struct csum_test_ctx *ctx)
+{
+	int rc = daos_obj_update(ctx->oh, DAOS_TX_NONE, 0, &ctx->dkey, 1,
+				 &ctx->update_iod, &ctx->update_sgl, NULL);
+
+
+	assert_success(rc);
+}
+
+static void
+test_fetch_task_api(void **state)
+{
+	struct csum_test_ctx	 ctx;
+	struct dcs_csum_info	*csum_info = NULL;
+	int			 rc;
+
+	setup_from_test_args(&ctx, *state);
+	setup_cont_obj(&ctx, DAOS_PROP_CO_CSUM_CRC64, false, 1024 * 32, OC_SX);
+	setup_single_recx_data(&ctx, "abc", 1024);
+
+	ctx_obj_update(&ctx);
+
+	d_iov_t iov = {0};
+
+	rc = tst_obj_fetch(ctx.oh, 1, &ctx.dkey, 1, &ctx.fetch_iod,
+			   &ctx.fetch_sgl, NULL, 0, NULL, &iov);
+	/** Should still succeed, even with an iov that doesn't have a buffer */
+	assert_success(rc);
+
+	/** fetch should have set the length to what's needed */
+	assert_true(iov.iov_len > 0);
+
+	iov_alloc(&iov, iov.iov_len);
+	iov.iov_len = 0;
+
+	/** fetch again with an allocated buffer */
+	rc = tst_obj_fetch(ctx.oh, 1, &ctx.dkey, 1, &ctx.fetch_iod,
+			   &ctx.fetch_sgl, NULL, 0, NULL, &iov);
+	assert_success(rc);
+
+	ci_cast(&csum_info, &iov);
+	assert_int_equal(1, csum_info->cs_nr);
+	assert_int_equal(8, csum_info->cs_len);
+
+	daos_iov_free(&iov);
+
+	cleanup_cont_obj(&ctx);
+}
+
 #define	INLINE_DATA	10
 #define	FETCHED_DATA	1024
 #define	BULK_DATA	(1024 * 32)
+#define CHUNK_SIZE	(1024 * 32)
 
 /** Test rebuild enumerating objects and getting data inline */
 static void
 rebuild_1(void **state)
 {
-	rebuild_test(state, 1024, INLINE_DATA, DAOS_IOD_ARRAY);
+	rebuild_test(state, CHUNK_SIZE, INLINE_DATA, DAOS_IOD_ARRAY);
 }
 
 /** Test rebuild when data is fetched after enumeration */
 static void
 rebuild_2(void **state)
 {
-	rebuild_test(state, 1024, FETCHED_DATA, DAOS_IOD_ARRAY);
+	rebuild_test(state, CHUNK_SIZE, FETCHED_DATA, DAOS_IOD_ARRAY);
 }
 
 /** Test rebuild when data is bulk transferred */
 static void
 rebuild_3(void **state)
 {
-	rebuild_test(state, 1024, BULK_DATA, DAOS_IOD_ARRAY);
+	rebuild_test(state, CHUNK_SIZE, BULK_DATA, DAOS_IOD_ARRAY);
 }
 
 static void
 rebuild_4(void **state)
 {
-	rebuild_test(state, 1024, INLINE_DATA, DAOS_IOD_SINGLE);
+	rebuild_test(state, CHUNK_SIZE, INLINE_DATA, DAOS_IOD_SINGLE);
 
 }
 
@@ -1850,14 +1958,14 @@ rebuild_4(void **state)
 static void
 rebuild_5(void **state)
 {
-	rebuild_test(state, 1024, FETCHED_DATA, DAOS_IOD_SINGLE);
+	rebuild_test(state, CHUNK_SIZE, FETCHED_DATA, DAOS_IOD_SINGLE);
 }
 
 /** Test rebuild when data is bulk transferred */
 static void
 rebuild_6(void **state)
 {
-	rebuild_test(state, 1024, BULK_DATA, DAOS_IOD_SINGLE);
+	rebuild_test(state, CHUNK_SIZE, BULK_DATA, DAOS_IOD_SINGLE);
 }
 
 static void
@@ -1942,10 +2050,8 @@ test_enumerate_a_key(void **state)
 		((uint8_t *)ctx.update_iod.iod_name.iov_buf)[0] += 1;
 	}
 
-	/** Make sure can handle verifying keys over multiple iovs */
-	d_sgl_init(&sgl, 2);
-	iov_alloc(&sgl.sg_iovs[0], 10);
-	iov_alloc(&sgl.sg_iovs[1], 100);
+	d_sgl_init(&sgl, 1);
+	iov_alloc(&sgl.sg_iovs[0], 100);
 
 	/** inject failure ... should return CSUM error */
 	client_corrupt_akey_on_fetch();
@@ -1997,9 +2103,8 @@ test_enumerate_d_key(void **state)
 	}
 
 	/** Make sure can handle verifying keys over multiple iovs */
-	d_sgl_init(&sgl, 2);
-	iov_alloc(&sgl.sg_iovs[0], 10);
-	iov_alloc(&sgl.sg_iovs[1], 100);
+	d_sgl_init(&sgl, 1);
+	iov_alloc(&sgl.sg_iovs[0], 100);
 
 	/** inject failure ... should return CSUM error */
 	client_corrupt_dkey_on_fetch();
@@ -2050,95 +2155,282 @@ tst_obj_list_obj(daos_handle_t oh, daos_epoch_range_t *epr, daos_key_t *dkey,
 					 size, nr, kds, sgl,
 					 anchor, dkey_anchor, akey_anchor,
 					 true, NULL, NULL, csum_iov, &task);
-	assert_int_equal(0, rc);
+	assert_rc_equal(0, rc);
 	return dc_task_schedule(task, true);
+}
+
+static int
+test_enum_unpack_cb(struct dss_enum_unpack_io *io, void *arg)
+{
+	struct daos_csummer	*csummer = NULL;
+	int			 rc;
+	int			 i;
+	d_iov_t			 tmp_iov;
+
+	rc = daos_csummer_csum_init_with_packed(&csummer, &io->ui_csum_iov);
+	assert_success(rc);
+
+	tmp_iov = io->ui_csum_iov;
+	/* +1 to convert from idx to nr */
+	for (i = 0; i < io->ui_iods_top + 1; i++) {
+		struct dcs_iod_csums *iod_csums = NULL;
+
+		if (io->ui_sgls[i].sg_nr_out == 0 ||
+		    io->ui_sgls[i].sg_iovs == NULL ||
+		    io->ui_iods[i].iod_nr == 0) {
+			/* Not inlined */
+			continue;
+		}
+
+		daos_csummer_alloc_iods_csums_with_packed(
+			csummer,
+			&io->ui_iods[i], 1,
+			&tmp_iov, &iod_csums);
+
+		rc = daos_csummer_verify_iod(csummer, &io->ui_iods[i],
+					     &io->ui_sgls[i], iod_csums,
+					     NULL, 0, NULL);
+
+		assert_success(rc);
+
+		daos_csummer_free_ic(csummer, &iod_csums);
+	}
+
+	daos_csummer_destroy(&csummer);
+
+	return 0;
 }
 
 static void
 test_enumerate_object(void **state)
 {
+	test_arg_t		*arg = *state;
+	struct csum_test_ctx	 ctx = {0};
+	daos_anchor_t		 anchor = {0};
+	daos_anchor_t		 dkey_anchor = {0};
+	daos_anchor_t		 akey_anchor = {0};
+	d_iov_t			 csum_iov = {0};
+	d_iov_t			 tmp_csum_iov = {0};
+	d_sg_list_t		 sgl = {0};
+	struct dcs_csum_info	*csum_info = NULL;
+	void			*end_byte;
+	daos_key_desc_t		*kds = NULL;
+	uint32_t		 csum_count = 0;
+	uint32_t		 nr;
+	int			 rc;
+	char			 dkey[32];
+	int			 d;
+	daos_size_t		 size = 0;
+	struct ioreq		 req;
+	const uint32_t		 dkey_loop = 3;
+	const uint32_t		 akey_loop = 3;
+	const uint32_t		 rec_loop = 3;
+	daos_unit_oid_t		 unit_oid = {0};
+	daos_epoch_range_t	 epr;
+
+	/*
+	 * data less than 32 bytes should be inlined. see ds_obj_enum_handler()
+	 * for inline_thres set on enum args
+	 */
+	char *data_small = "Lorem ipsum dolor sit amet, co";
+	char *data_medium = "Lorem ipsum dolor sit amet, consectetur adipiscing"
+			    " elit, sed do eiusmod tempor incididunt ut labore"
+			    " et dolore magna aliqua. Ut enim ad minim veniam,"
+			    " quis nostrud exercitation ullamco laboris nisi ut"
+			    " aliquip ex ea commodo consequat. Duis aute irure"
+			    " dolor in reprehenderit in voluptate velit esse"
+			    " cillum dolore eu fugiat nulla pariatur. Excepteur"
+			    " sint occaecat cupidatat non proident, sunt in"
+			    " culpa qui officia deserunt mollit anim id est"
+			    " laborum.";
+	char *data_large = NULL;
+
+
+	D_ALLOC(data_large, 1024 * 3);
+	assert_non_null(data_large);
+	memset(data_large, 'L', 1024 * 3 - 1); /* -1: keep \0 */
+
+	FAULT_INJECTION_REQUIRED();
+
+	assert_true(strlen(data_small) + 1 <= 32);
+	assert_true(strlen(data_medium) + 1 > 32);
+	assert_true(strlen(data_large) + 1 > 2048);
+
+	d_sgl_init(&sgl, 1);
+	iov_alloc(&sgl.sg_iovs[0], 2048);
+
+	D_ALLOC_ARRAY(kds, 1024);
+	nr = 1024;
+
+	iov_alloc(&csum_iov, 2048);
+	/* iov_len is used for how much of the buffer is used */
+	csum_iov.iov_len = 0;
+
+	setup_from_test_args(&ctx, *state);
+	setup_cont_obj(&ctx, DAOS_PROP_CO_CSUM_CRC64, false, 10, OC_S1);
+
+	ioreq_init(&req, ctx.coh, ctx.oid, DAOS_IOD_ARRAY, arg);
+
+	/* insert data to be enumerated */
+	for (d = 0; d < dkey_loop; d++) {
+		sprintf(dkey, "dkey-%d", d);
+
+		insert_data("akey-%d-array-small", dkey,
+			    &req, akey_loop, rec_loop, data_small,
+			    DAOS_IOD_ARRAY);
+		insert_data("akey-%d-array-medium", dkey,
+			    &req, akey_loop, rec_loop, data_medium,
+			    DAOS_IOD_ARRAY);
+		insert_data("akey-%d-array-large", dkey,
+			    &req, akey_loop, rec_loop, data_large,
+			    DAOS_IOD_ARRAY);
+		insert_data("akey-%d-single-small", dkey,
+			    &req, akey_loop, rec_loop, data_small,
+			    DAOS_IOD_SINGLE);
+		insert_data("akey-%d-single-medium", dkey,
+			    &req, akey_loop, rec_loop, data_medium,
+			    DAOS_IOD_SINGLE);
+		insert_data("akey-%d-single-large", dkey,
+			    &req, akey_loop, rec_loop, data_large,
+			    DAOS_IOD_SINGLE);
+	}
+
+	/** inject failure ... should return CSUM error */
+	client_corrupt_akey_on_fetch();
+	epr.epr_lo = 0;
+	epr.epr_hi = DAOS_EPOCH_MAX;
+	rc = tst_obj_list_obj(ctx.oh, &epr, NULL, NULL, NULL, &nr, kds,
+		&sgl, &anchor, &dkey_anchor, &akey_anchor, &csum_iov);
+
+	assert_rc_equal(-DER_CSUM, rc);
+	client_clear_fault();
+
+	/** Sanity check that no failure still returns success. Setting
+	 * nr to larger than expected because tst_obj_list_obj will set it to
+	 * what's returned. If there is a bug an tst_obj_list_obj could return
+	 * more than expected, want to catch it.
+	 */
+	memset(&anchor, 0, sizeof(anchor));
+	memset(&dkey_anchor, 0, sizeof(dkey_anchor));
+	memset(&akey_anchor, 0, sizeof(akey_anchor));
+	sgl.sg_nr_out = 0;
+	csum_iov.iov_len = 0;
+	rc = tst_obj_list_obj(ctx.oh, NULL, NULL, NULL, &size, &nr, kds,
+			      &sgl, &anchor, &dkey_anchor, &akey_anchor,
+			      &csum_iov);
+
+	assert_success(rc);
+
+	if (csum_iov.iov_len == 0)
+		fail_msg("Should have had something in csum_iov");
+	ioreq_fini(&req);
+
+	/** Make sure csum iov is correct */
+	tmp_csum_iov = csum_iov;
+	end_byte = tmp_csum_iov.iov_buf + tmp_csum_iov.iov_len;
+	while (tmp_csum_iov.iov_buf < end_byte) {
+		ci_cast(&csum_info, &tmp_csum_iov);
+		tmp_csum_iov.iov_buf += ci_size(*csum_info);
+		tmp_csum_iov.iov_buf_len -= ci_size(*csum_info);
+		tmp_csum_iov.iov_len -= ci_size(*csum_info);
+		csum_count++;
+	}
+
+
+	unit_oid.id_pub = ctx.oid;
+	rc = dss_enum_unpack(unit_oid, kds, nr, &sgl, &csum_iov,
+			     test_enum_unpack_cb, NULL);
+	assert_success(rc);
+
+	/** Clean up */
+	d_sgl_fini(&sgl, true);
+	daos_iov_free(&csum_iov);
+	cleanup_data(&ctx);
+	cleanup_cont_obj(&ctx);
+	D_FREE(kds);
+}
+
+static uint32_t
+get_csum_count(d_iov_t *csum_iov)
+{
+	void			*end_byte;
+	struct dcs_csum_info	*csum_info = NULL;
+	uint32_t		 csum_count = 0;
+
+	end_byte = csum_iov->iov_buf + csum_iov->iov_len;
+
+	while (csum_iov->iov_buf < end_byte) {
+		ci_cast(&csum_info, csum_iov);
+		csum_iov->iov_buf += ci_size(*csum_info);
+		csum_iov->iov_buf_len -= ci_size(*csum_info);
+		csum_iov->iov_len -= ci_size(*csum_info);
+		csum_count++;
+	}
+	return csum_count;
+}
+
+/**
+ * insert overlapping extents. When enumerating visible extents are checksums
+ * must be calculated for the partial extent.
+ */
+static void
+test_enumerate_object2(void **state)
+{
+#define KDS_NR 10
 	struct csum_test_ctx	 ctx = {0};
 	daos_oclass_id_t	 oc = dts_csum_oc;
 	daos_anchor_t		 anchor = {0};
 	daos_anchor_t		 dkey_anchor = {0};
 	daos_anchor_t		 akey_anchor = {0};
 	d_iov_t			 csum_iov = {0};
-	d_sg_list_t		 sgl = {0};
-	struct dcs_csum_info	*csum_info = NULL;
-	void			*end_byte;
-	const uint32_t		 akey_nr = 5;
-	/** will enumerate for each akey, value of each akey, and 1 dkey */
-	const uint32_t		 enum_nr = akey_nr * 2 + 1;
-	daos_key_desc_t		 kds[enum_nr];
-	uint8_t			 csum_buf[1024];
-	uint32_t		 csum_count = 0;
-	uint32_t		 i;
-	uint32_t		 nr;
+	d_sg_list_t		 list_sgl = {0};
+	uint32_t		 nr = KDS_NR;
+	daos_key_desc_t		 kds[KDS_NR] = {0};
+	uint8_t			 csum_buf[2048];
 	int			 rc;
 
-	FAULT_INJECTION_REQUIRED();
-
-	memset(kds, 0, enum_nr * sizeof(*kds));
-
-	d_iov_set(&csum_iov, csum_buf, 1024);
+	d_iov_set(&csum_iov, csum_buf, sizeof(csum_buf));
 	csum_iov.iov_len = 0;
 
 	setup_from_test_args(&ctx, *state);
-	setup_cont_obj(&ctx, DAOS_PROP_CO_CSUM_CRC64, false, 10, oc);
-	setup_simple_data(&ctx);
+	setup_cont_obj(&ctx, DAOS_PROP_CO_CSUM_CRC64, false, 8, oc);
+	setup_single_recx_data(&ctx, "ABCDEF", 1024);
 
-	/** insert multiple a keys.*/
-	for (i = 0; i < akey_nr; i++) {
-		rc = daos_obj_update(ctx.oh, DAOS_TX_NONE, 0, &ctx.dkey, 1,
-				     &ctx.update_iod, &ctx.update_sgl,
-				     NULL);
-		assert_rc_equal(0, rc);
-		((uint8_t *)ctx.update_iod.iod_name.iov_buf)[1] += 1;
-		((uint8_t *)ctx.update_sgl.sg_iovs->iov_buf)[0] += 1;
-	}
-
-	/** Make sure can handle data over multiple iovs */
-	d_sgl_init(&sgl, 2);
-	iov_alloc(&sgl.sg_iovs[0], 10);
-	iov_alloc(&sgl.sg_iovs[1], 1024);
-
-
-
-	/** inject failure ... should return CSUM error */
-	client_corrupt_akey_on_fetch();
-	nr = enum_nr;
-	rc = tst_obj_list_obj(ctx.oh, NULL, &ctx.dkey, NULL, NULL, &nr, kds,
-		&sgl, &anchor, &dkey_anchor, &akey_anchor, &csum_iov);
-
-	assert_rc_equal(-DER_CSUM, rc);
-	client_clear_fault();
-
-	/** Sanity check that no failure still returns success */
-	nr = enum_nr;
-	memset(&anchor, 0, sizeof(anchor));
-	memset(&dkey_anchor, 0, sizeof(dkey_anchor));
-	memset(&akey_anchor, 0, sizeof(akey_anchor));
-	sgl.sg_nr_out = 0;
-	rc = tst_obj_list_obj(ctx.oh, NULL, &ctx.dkey, NULL, NULL, &nr, kds,
-			      &sgl, &anchor, &dkey_anchor, &akey_anchor,
-			      &csum_iov);
+	rc = daos_obj_update(ctx.oh, DAOS_TX_NONE, 0, &ctx.dkey, 1,
+			     &ctx.update_iod, &ctx.update_sgl,
+			     NULL);
 	assert_rc_equal(0, rc);
-	assert_int_equal(enum_nr, nr);
+	ctx.update_iod.iod_recxs->rx_idx += 5;
+	rc = daos_obj_update(ctx.oh, DAOS_TX_NONE, 0, &ctx.dkey, 1,
+			     &ctx.update_iod, &ctx.update_sgl,
+			     NULL);
+	assert_rc_equal(0, rc);
 
-	/** Make sure csum iov is correct */
-	end_byte = csum_iov.iov_buf + csum_iov.iov_len;
-	while (csum_iov.iov_buf < end_byte) {
-		ci_cast(&csum_info, &csum_iov);
-		csum_iov.iov_buf += ci_size(*csum_info);
-		csum_iov.iov_buf_len -= ci_size(*csum_info);
-		csum_iov.iov_len -= ci_size(*csum_info);
-		csum_count++;
-	}
+	d_sgl_init(&list_sgl, 1);
+	iov_alloc(&list_sgl.sg_iovs[0], 1024 * 10);
+	/** Sanity check that no failure still returns success */
+	daos_epoch_range_t epr = {.epr_lo = 0, .epr_hi = DAOS_EPOCH_MAX};
 
-	assert_int_equal(enum_nr, csum_count);
+	/** force to only list visible extents */
+	daos_anchor_set_flags(&dkey_anchor,
+			      DIOF_TO_LEADER | DIOF_WITH_SPEC_EPOCH);
+
+	memset(list_sgl.sg_iovs[0].iov_buf, 0, list_sgl.sg_iovs[0].iov_buf_len);
+	rc = tst_obj_list_obj(ctx.oh, &epr, &ctx.dkey, NULL, NULL, &nr, kds,
+			      &list_sgl, &anchor, &dkey_anchor, &akey_anchor,
+			      &csum_iov);
+	assert_success(rc);
+
+	/** make sure got correct number of key descriptors. Should have gotten
+	 * for: obj, dkey, akey, recx
+	 */
+	assert_int_equal(4, nr);
+
+	/** only 3 checksums, dkey, akey, and inlined recx */
+	assert_int_equal(3, get_csum_count(&csum_iov));
 
 	/** Clean up */
-	d_sgl_fini(&sgl, true);
+	d_sgl_fini(&list_sgl, true);
 	cleanup_data(&ctx);
 	cleanup_cont_obj(&ctx);
 }
@@ -2258,10 +2550,12 @@ setup(void **state)
 			  0, NULL);
 }
 
-#define CSUM_TEST(dsc, test) { dsc, test, csum_replia_enable, \
-				test_case_teardown }
-#define EC_CSUM_TEST(dsc, test) { dsc, test, csum_ec_enable, \
-				test_case_teardown }
+#define STR_HELPER(x) #x
+#define STR(x) STR_HELPER(x)
+#define CSUM_TEST(dsc, test) { STR(__COUNTER__)". " dsc, test, \
+			  csum_replia_enable, test_case_teardown }
+#define EC_CSUM_TEST(dsc, test) { STR(__COUNTER__)". " dsc, test, \
+			  csum_ec_enable, test_case_teardown }
 
 static const struct CMUnitTest csum_tests[] = {
 	CSUM_TEST("DAOS_CSUM00: csum disabled", checksum_disabled),
@@ -2309,8 +2603,12 @@ static const struct CMUnitTest csum_tests[] = {
 	CSUM_TEST("DAOS_CSUM10: Enumerate A Keys", test_enumerate_a_key),
 	CSUM_TEST("DAOS_CSUM11: Enumerate D Keys", test_enumerate_d_key),
 	CSUM_TEST("DAOS_CSUM12: Enumerate objects", test_enumerate_object),
+	CSUM_TEST("DAOS_CSUM12.1: Enumerate objects with overlapping "
+		  "extents", test_enumerate_object2),
 	CSUM_TEST("DAOS_CSUM13: Enumerate objects with too small csum buffer",
 		  test_enumerate_object_csum_buf_too_small),
+	CSUM_TEST("DAOS_CSUM14 - Get checksum through fetch task api",
+		  test_fetch_task_api),
 	CSUM_TEST("DAOS_CSUM14: Many IODs", many_iovs_with_single_values),
 	CSUM_TEST("DAOS_CSUM14.1: two iods and two recx", two_iods_two_recxs),
 	CSUM_TEST("DAOS_CSUM15: Request non existent data",

--- a/src/tests/suite/daos_obj.c
+++ b/src/tests/suite/daos_obj.c
@@ -3181,7 +3181,6 @@ fetch_replica_unavail(void **state)
 	uint32_t		 size = 64;
 	d_rank_t		 rank = 2;
 	char			*buf;
-	int			 rc;
 
 	/* needs at lest 4 targets, exclude one and another 3 raft nodes */
 	if (!test_runable(arg, 4))
@@ -3224,7 +3223,6 @@ fetch_replica_unavail(void **state)
 		/* wait until reintegration is done */
 		test_rebuild_wait(&arg, 1);
 
-		assert_int_equal(rc, 0);
 	}
 	D_FREE(buf);
 	MPI_Barrier(MPI_COMM_WORLD);

--- a/src/tests/suite/daos_rebuild_common.c
+++ b/src/tests/suite/daos_rebuild_common.c
@@ -374,6 +374,7 @@ rebuild_io_obj_internal(struct ioreq *req, bool validate, int index)
 	int	akey_punch_idx = 1;
 	int	dkey_punch_idx = 1;
 	int	rec_punch_idx = 2;
+	int	large_key_idx = 7;
 	int	j;
 	int	k;
 	int	l;
@@ -398,7 +399,7 @@ rebuild_io_obj_internal(struct ioreq *req, bool validate, int index)
 					    l == rec_punch_idx)
 						continue;
 					memset(data, 0, REC_SIZE);
-					if (l == 7)
+					if (l == large_key_idx)
 						lookup_single(large_key, akey,
 							      l, data, REC_SIZE,
 							      DAOS_TX_NONE,
@@ -411,7 +412,7 @@ rebuild_io_obj_internal(struct ioreq *req, bool validate, int index)
 					assert_memory_equal(data, data_verify,
 						    strlen(data_verify));
 				} else {
-					if (l == 7)
+					if (l == large_key_idx)
 						insert_single(large_key, akey,
 							l, data,
 							strlen(data) + 1,

--- a/src/tests/suite/daos_test_common.c
+++ b/src/tests/suite/daos_test_common.c
@@ -744,40 +744,8 @@ int
 run_daos_sub_tests_only(char *test_name, const struct CMUnitTest *tests,
 			int tests_size, int *sub_tests, int sub_tests_size)
 {
-	int i;
-	int rc = 0;
-
-	if (sub_tests != NULL) {
-		struct CMUnitTest *subtests;
-		int subtestsnb = 0;
-
-		D_ALLOC_ARRAY(subtests, sub_tests_size);
-		if (subtests == NULL) {
-			print_message("failed allocating subtests array\n");
-			return -DER_NOMEM;
-		}
-
-		for (i = 0; i < sub_tests_size; i++) {
-			if (sub_tests[i] >= tests_size || sub_tests[i] < 0) {
-				print_message("No subtest %d\n", sub_tests[i]);
-				continue;
-			}
-			subtests[i] = tests[sub_tests[i]];
-			subtestsnb++;
-		}
-
-		/* run the sub-tests */
-		if (subtestsnb > 0)
-			rc = _cmocka_run_group_tests(test_name, subtests,
-						     subtestsnb, NULL, NULL);
-		D_FREE(subtests);
-	} else {
-		/* run the full suite */
-		rc = _cmocka_run_group_tests(test_name, tests, tests_size,
-					     NULL, NULL);
-	}
-
-	return rc;
+	return run_daos_sub_tests(test_name, tests, tests_size, sub_tests,
+				  sub_tests_size, NULL, NULL);
 }
 
 int
@@ -799,11 +767,11 @@ run_daos_sub_tests(char *test_name, const struct CMUnitTest *tests,
 		}
 
 		for (i = 0; i < sub_tests_size; i++) {
-			if (sub_tests[i] > tests_size || sub_tests[i] < 1) {
+			if (sub_tests[i] > tests_size || sub_tests[i] < 0) {
 				print_message("No subtest %d\n", sub_tests[i]);
 				continue;
 			}
-			subtests[i] = tests[sub_tests[i] - 1];
+			subtests[i] = tests[sub_tests[i]];
 			subtestsnb++;
 		}
 

--- a/src/vos/vos_io.c
+++ b/src/vos/vos_io.c
@@ -2248,6 +2248,15 @@ vos_iod_sgl_at(daos_handle_t ioh, unsigned int idx)
 	return bio_iod_sgl(ioc->ic_biod, idx);
 }
 
+void
+vos_set_io_csum(daos_handle_t ioh, struct dcs_iod_csums *csums)
+{
+	struct vos_io_context *ioc = vos_ioh2ioc(ioh);
+
+	D_ASSERT(ioc != NULL);
+
+	ioc->iod_csums = csums;
+}
 /*
  * XXX Dup these two helper functions for this moment, implement
  * non-transactional umem_alloc/free() later.


### PR DESCRIPTION
Because rebuild only enumerates visible extents,
partial extents must have new checksums calculated
and original extents must be verified.

- In order for rebuild to get the checksum through the
  fetch task api, a csum iov param was added. The csums
  will be packed similar to enumeration.
- During enumeration, the unpacking of the key
  descriptors was changed to not unpack the checksums.
  Object migration/rebuild will be responsible for
  unpacking the checksums for data that is inlined.
- Added a call in VOS to be able to set the iod_csums
  of an io context. This is needed because rebuild
  gets the checksums after vos update begin and so
  isn't able to provide them at the beginning of the
  VOS IO.
- Removed some redundant arg checking in srv_csum.c

Cherry-picked from master  (PR: 3746, commit: 6a1e31a7b139476ccc26de427f76f0df1129abec )

Signed-off-by: Ryon Jensen <ryon.jensen@intel.com>