### PR TITLE
DAOS-623 test: Add compatibility for new Python 3 Avocado 69.2 RPMs

### DIFF
--- a/ci/provisioning/post_provision_config_nodes_EL_7.sh
+++ b/ci/provisioning/post_provision_config_nodes_EL_7.sh
@@ -3,6 +3,7 @@
 REPOS_DIR=/etc/yum.repos.d
 DISTRO_NAME=centos7
 LSB_RELEASE=redhat-lsb-core
+PYTHON_MACROS_RPM=("python2-rpm-macros" "python3-rpm-macros")
 
 timeout_yum() {
     local timeout="$1"
@@ -122,6 +123,14 @@ EOF
         dump_repos
         exit 1
     fi
+
+    if ! time dnf -y install "${PYTHON_MACROS_RPM[@]}" ; then
+        dump_repos
+        exit 1
+    fi
+
+    cat /etc/do-release
+    cat /etc/os-release
 
     exit 0
 }

--- a/ci/provisioning/post_provision_config_nodes_LEAP_15.sh
+++ b/ci/provisioning/post_provision_config_nodes_LEAP_15.sh
@@ -4,6 +4,7 @@ REPOS_DIR=/etc/dnf.repos.d
 DISTRO_NAME=leap15
 LSB_RELEASE=lsb-release
 EXCLUDE_UPGRADE=fuse,fuse-libs,fuse-devel,mercury,daos,daos-\*
+PYTHON_MACROS_RPM=("python-rpm-macros")
 
 bootstrap_dnf() {
     time zypper --non-interactive install dnf
@@ -102,6 +103,14 @@ post_provision_config_nodes() {
         dump_repos
         exit 1
     fi
+
+    if ! time dnf -y install "${PYTHON_MACROS_RPM[@]}" ; then
+        dump_repos
+        exit 1
+    fi
+
+    cat /etc/do-release
+    cat /etc/os-release
 
     exit 0
 }

--- a/src/tests/ftest/launch.py
+++ b/src/tests/ftest/launch.py
@@ -15,6 +15,7 @@ import re
 import socket
 import subprocess
 from sys import version_info
+import sys
 import time
 import yaml
 import errno
@@ -196,7 +197,7 @@ def set_test_environment(args):
                 print(
                     "Error obtaining a default interface from: {}".format(
                         os.listdir(net_path)))
-                exit(1)
+                sys.exit(1)
         print("Using {} as the default interface".format(interface))
 
         # Update env definitions
@@ -291,7 +292,7 @@ def get_output(cmd, check=True):
     except RuntimeError as error:
         if check:
             print(error)
-            exit(1)
+            sys.exit(1)
         stdout = str(error)
     return stdout
 
@@ -482,7 +483,7 @@ def find_values(obj, keys, key=None, val_type=list):
     return matches
 
 
-def get_test_list(tags):
+def get_test_list(tags, python_version):
     """Generate a list of tests and avocado tag filter from a list of tags.
 
     Args:
@@ -524,7 +525,7 @@ def get_test_list(tags):
     if test_tags or not test_list:
         if not test_list:
             test_list = ["./"]
-        command = ["avocado", "list", "--paginator=off"]
+        command = ["avocado-" + python_version, "list", "--paginator=off"]
         for test_tag in test_tags:
             command.append(str(test_tag))
         command.extend(test_list if test_list else ["./"])
@@ -591,7 +592,7 @@ def get_nvme_replacement(args):
     # A list of server host is required to able to auto-detect NVMe devices
     if not args.test_servers:
         print("ERROR: Missing a test_servers list to auto-detect NVMe devices")
-        exit(1)
+        sys.exit(1)
 
     # Get a list of NVMe devices from each specified server host
     host_list = list(args.test_servers)
@@ -605,13 +606,13 @@ def get_nvme_replacement(args):
     # Verify the command was successful on each server host
     if not check_remote_output(task, command):
         print("ERROR: Issuing commands to detect NVMe PCI addresses.")
-        exit(1)
+        sys.exit(1)
 
     # Verify each server host has the same NVMe PCI addresses
     output_data = list(task.iter_buffers())
     if len(output_data) > 1:
         print("ERROR: Non-homogeneous NVMe PCI addresses.")
-        exit(1)
+        sys.exit(1)
 
     # Get the list of NVMe PCI addresses found in the output
     devices = find_pci_address(output_data[0][0])
@@ -826,7 +827,7 @@ def generate_certs():
          daos_test_log_dir])
 
 
-def run_tests(test_files, tag_filter, args):
+def run_tests(test_files, tag_filter, args, python_version):
     """Run or display the test commands.
 
     Args:
@@ -841,14 +842,14 @@ def run_tests(test_files, tag_filter, args):
     return_code = 0
 
     # Determine the location of the avocado logs for archiving or renaming
-    data = get_output(["avocado", "config"]).strip()
+    data = get_output(["avocado-" + python_version, "config"]).strip()
     avocado_logs_dir = re.findall(r"datadir\.paths\.logs_dir\s+(.*)", data)
     avocado_logs_dir = os.path.expanduser(avocado_logs_dir[0])
     print("Avocado logs stored in {}".format(avocado_logs_dir))
 
     # Create the base avocado run command
     command_list = [
-        "avocado",
+        "avocado-" + python_version,
         "run",
         "--ignore-missing-references", "on",
         "--html-job-result", "on",
@@ -867,7 +868,7 @@ def run_tests(test_files, tag_filter, args):
             # this is typically an indication of a communication issue with one
             # of the hosts, do not attempt to run subsequent tests.
             if not report_skipped_test(
-                    test_file["py"], avocado_logs_dir, skip_reason, args):
+                    test_file["py"], avocado_logs_dir, skip_reason):
                 return_code |= 64
 
         elif not isinstance(test_file["yaml"], str):
@@ -875,7 +876,7 @@ def run_tests(test_files, tag_filter, args):
             # in the yaml file.  Treat this like a failed avocado command.
             reason = "error replacing yaml file placeholders"
             if not report_skipped_test(
-                    test_file["py"], avocado_logs_dir, reason, args):
+                    test_file["py"], avocado_logs_dir, reason):
                 return_code |= 64
             return_code |= 4
 
@@ -890,8 +891,7 @@ def run_tests(test_files, tag_filter, args):
                         "leftover logs from a previous test run prior to "
                         "running this test")
                     if not report_skipped_test(
-                            test_file["py"], avocado_logs_dir, skip_reason,
-                            args):
+                            test_file["py"], avocado_logs_dir, skip_reason):
                         return_code |= 64
                     return_code |= 128
                     continue
@@ -950,7 +950,7 @@ def get_yaml_data(yaml_file):
                 yaml_data = yaml.safe_load(file_data.replace("!mux", ""))
             except yaml.YAMLError as error:
                 print("Error reading {}: {}".format(yaml_file, error))
-                exit(1)
+                sys.exit(1)
     return yaml_data
 
 
@@ -1276,7 +1276,7 @@ def check_big_files(avocado_logs_dir, task, test_name, args):
     return status
 
 
-def report_skipped_test(test_file, avocado_logs_dir, reason, args):
+def report_skipped_test(test_file, avocado_logs_dir, reason):
     """Report an error for the skipped test.
 
     Args:
@@ -1858,18 +1858,26 @@ def main():
     if args.nvme and args.nvme.startswith("auto"):
         args.nvme = get_nvme_replacement(args)
 
+    # Figure out which python version we are running with
+    python_version = get_output(['rpm', '--eval', '%python{}_version'.format(
+        version_info.major)]).strip()
+    if python_version.startswith("%python"):
+        print("Failure getting python version.  Is python{{2,3}}-rpm-macros "
+              "installed on {}?".format(socket.gethostname()))
+        sys.exit(1)
+
     # Process the tags argument to determine which tests to run
-    tag_filter, test_list = get_test_list(args.tags)
+    tag_filter, test_list = get_test_list(args.tags, python_version)
 
     # Verify at least one test was requested
     if not test_list:
         print("ERROR: No tests or tags found via {}".format(args.tags))
-        exit(1)
+        sys.exit(1)
 
     # Display a list of the tests matching the tags
     print("Detected tests:  \n{}".format("  \n".join(test_list)))
     if args.list:
-        exit(0)
+        sys.exit(0)
 
     # Create a temporary directory
     tmp_dir = TemporaryDirectory()
@@ -1877,7 +1885,7 @@ def main():
     # Create a dictionary of test and their yaml files
     test_files = get_test_files(test_list, args, tmp_dir)
     if args.modify:
-        exit(0)
+        sys.exit(0)
 
     # Setup (clean/create/list) the common test directory
     setup_test_directory(args)
@@ -1886,7 +1894,7 @@ def main():
     generate_certs()
 
     # Run all the tests
-    status = run_tests(test_files, tag_filter, args)
+    status = run_tests(test_files, tag_filter, args, python_version)
 
     # Process the avocado run return codes and only treat job and command
     # failures as errors.
@@ -1927,7 +1935,7 @@ def main():
             print("ERROR: Detected one or more failures in renaming logs and "
                   "results for Jenkins!")
             ret_code = 1
-    exit(ret_code)
+    sys.exit(ret_code)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Call avocado using it's avocado-%python-version name instead of just
bare avocado as an introduction to being able to run it with Python 3.

Install python-macros RPM(s) to support the above.