### PR TITLE
DAOS-6853 engine: Introduce dss_drpc_call (#4717)

### DIFF
--- a/src/engine/drpc_client.c
+++ b/src/engine/drpc_client.c
@@ -10,6 +10,8 @@
 
 #define D_LOGFAC DD_FAC(server)
 
+#include <daos_srv/daos_engine.h>
+
 #include <daos_types.h>
 #include <daos/drpc.h>
 #include <daos/drpc_modules.h>
@@ -17,17 +19,147 @@
 #include "srv_internal.h"
 #include "drpc_internal.h"
 
-/** dRPC client context */
-struct drpc *dss_drpc_ctx;
+/** dRPC UNIX-domain socket path (full, not directory-only) */
+static char *dss_drpc_path;
+
+struct dss_drpc_thread_arg {
+	int32_t		  cta_module;
+	int32_t		  cta_method;
+	int		  cta_flags;
+	void		 *cta_req;
+	size_t		  cta_req_size;
+	Drpc__Response	**cta_resp;
+};
+
+static void *
+dss_drpc_thread(void *varg)
+{
+	struct dss_drpc_thread_arg	*arg = varg;
+	struct drpc			*ctx;
+	Drpc__Call			*call;
+	Drpc__Response			*resp;
+	int				 flags = R_SYNC;
+	int				 rc;
+
+	/* Establish a private connection to avoid dRPC concurrency problems. */
+	rc = drpc_connect(dss_drpc_path, &ctx);
+	if (rc != 0) {
+		D_ERROR("failed to connect to dRPC server at %s: "DF_RC"\n",
+			dss_drpc_path, DP_RC(rc));
+		goto out;
+	}
+
+	rc = drpc_call_create(ctx, arg->cta_module, arg->cta_method, &call);
+	if (rc != 0) {
+		D_ERROR("failed to create dRPC %d/%d: "DF_RC"\n",
+			arg->cta_module, arg->cta_method, DP_RC(rc));
+		goto out_ctx;
+	}
+	call->body.data = arg->cta_req;
+	call->body.len = arg->cta_req_size;
+
+	if (arg->cta_flags & DSS_DRPC_NO_RESP)
+		flags &= ~R_SYNC;
+
+	rc = drpc_call(ctx, flags, call, &resp);
+	if (rc != 0) {
+		D_ERROR("failed to invoke dRPC %d/%d: "DF_RC"\n",
+			arg->cta_module, arg->cta_method, DP_RC(rc));
+		goto out_call;
+	}
+
+	if (arg->cta_flags & DSS_DRPC_NO_RESP)
+		drpc_response_free(resp);
+	else
+		*arg->cta_resp = resp;
+out_call:
+	/* Let the caller free its own buffer. */
+	call->body.data = NULL;
+	call->body.len = 0;
+	drpc_call_free(call);
+out_ctx:
+	drpc_close(ctx);
+out:
+	return (void *)(intptr_t)rc;
+}
+
+/**
+ * Invoke a dRPC. See dss_drpc_call_flag for the usage of \a flags. If \a flags
+ * includes DSS_DRPC_NO_RESP, \a resp is ignored; otherwise, the caller must
+ * specify \a resp, and is responsible for freeing the response with
+ * drpc_response_free.
+ */
+int
+dss_drpc_call(int32_t module, int32_t method, void *req, size_t req_size,
+	      unsigned int flags, Drpc__Response **resp)
+{
+	struct dss_drpc_thread_arg	 arg;
+	struct sched_req_attr		 attr = {0};
+	uuid_t				 anonym_uuid;
+	struct sched_request		*sched_req;
+	pthread_t			 thread;
+	struct d_backoff_seq		 backoff_seq;
+	void				*thread_rc;
+	int				 rc;
+
+	arg.cta_module = module;
+	arg.cta_method = method;
+	arg.cta_flags = flags;
+	arg.cta_req = req;
+	arg.cta_req_size = req_size;
+	arg.cta_resp = resp;
+
+	if (flags & (DSS_DRPC_NO_RESP | DSS_DRPC_NO_SCHED))
+		return (int)(intptr_t)dss_drpc_thread(&arg);
+
+	/* Initialize sched_req for the backoffs below. */
+	uuid_clear(anonym_uuid);
+	sched_req_attr_init(&attr, SCHED_REQ_ANONYM, &anonym_uuid);
+	sched_req = sched_req_get(&attr, ABT_THREAD_NULL);
+	if (sched_req == NULL) {
+		D_ERROR("failed to get sched req\n");
+		return -DER_NOMEM;
+	}
+
+	/* Create a thread to avoid blocking the current xstream. */
+	rc = pthread_create(&thread, NULL /* attr */, dss_drpc_thread, &arg);
+	if (rc != 0) {
+		D_ERROR("failed to create thread for dRPC: %d "DF_RC"\n", rc,
+			DP_RC(daos_errno2der(rc)));
+		rc = daos_errno2der(rc);
+		return rc;
+	}
+
+	/* Poll the thread for its completion. */
+	rc = d_backoff_seq_init(&backoff_seq, 0 /* nzeros */,
+				2 /* factor */, 8 /* next (ms) */,
+				1 << 10 /* max (ms) */);
+	D_ASSERTF(rc == 0, "d_backoff_seq_init: "DF_RC"\n", DP_RC(rc));
+	do {
+		sched_req_sleep(sched_req, d_backoff_seq_next(&backoff_seq));
+		rc = pthread_tryjoin_np(thread, &thread_rc);
+	} while (rc == EBUSY);
+	/*
+	 * The pthread_tryjoin_np call is expected to return either EBUSY or 0,
+	 * unless there is a bug somewhere affecting its internal logic. If the
+	 * thread may still be running, then we can't return safely, for arg is
+	 * on the stack. Allocating arg on the heap seems to be a overkill.
+	 * Hence, we simply assert that rc must be 0.
+	 */
+	D_ASSERTF(rc == 0, "failed to join dRPC thread: %d\n", rc);
+	d_backoff_seq_fini(&backoff_seq);
+
+	sched_req_put(sched_req);
+	return (int)(intptr_t)thread_rc;
+}
 
 /* Notify daos_server that we are ready (e.g., to receive dRPC requests). */
-static int
-notify_ready(void)
+int
+drpc_notify_ready(void)
 {
 	Srv__NotifyReadyReq	req = SRV__NOTIFY_READY_REQ__INIT;
 	uint8_t		       *reqb;
 	size_t			reqb_size;
-	Drpc__Call	       *dreq;
 	Drpc__Response	       *dresp;
 	int			rc;
 
@@ -44,21 +176,12 @@ notify_ready(void)
 	D_ALLOC(reqb, reqb_size);
 	if (reqb == NULL)
 		D_GOTO(out_uri, rc = -DER_NOMEM);
-
 	srv__notify_ready_req__pack(&req, reqb);
-	rc = drpc_call_create(dss_drpc_ctx, DRPC_MODULE_SRV,
-			      DRPC_METHOD_SRV_NOTIFY_READY, &dreq);
-	if (rc != 0) {
-		D_FREE(reqb);
-		goto out_uri;
-	}
 
-	dreq->body.len = reqb_size;
-	dreq->body.data = reqb;
-
-	rc = drpc_call(dss_drpc_ctx, R_SYNC, dreq, &dresp);
+	rc = dss_drpc_call(DRPC_MODULE_SRV, DRPC_METHOD_SRV_NOTIFY_READY, reqb,
+			   reqb_size, DSS_DRPC_NO_SCHED, &dresp);
 	if (rc != 0)
-		goto out_dreq;
+		goto out_reqb;
 	if (dresp->status != DRPC__STATUS__SUCCESS) {
 		D_ERROR("received erroneous dRPC response: %d\n",
 			dresp->status);
@@ -66,30 +189,26 @@ notify_ready(void)
 	}
 
 	drpc_response_free(dresp);
-out_dreq:
-	/* This also frees reqb via dreq->body.data. */
-	drpc_call_free(dreq);
+out_reqb:
+	D_FREE(reqb);
 out_uri:
 	D_FREE(req.uri);
 out:
 	return rc;
 }
 
-/* Notify daos_server that there has been a I/O error. */
+/*
+ * Notify daos_server that there has been a I/O error. This function doesn't
+ * Argobots-schedule.
+ */
 int
 ds_notify_bio_error(int media_err_type, int tgt_id)
 {
 	Srv__BioErrorReq	 bioerr_req = SRV__BIO_ERROR_REQ__INIT;
-	Drpc__Call		*dreq;
-	Drpc__Response		*dresp;
 	uint8_t			*req;
 	size_t			 req_size;
 	int			 rc;
 
-	if (dss_drpc_ctx == NULL) {
-		D_ERROR("dRPC not connected\n");
-		return -DER_INVAL;
-	}
 	rc = crt_self_uri_get(0 /* tag */, &bioerr_req.uri);
 	if (rc != 0)
 		return rc;
@@ -109,31 +228,19 @@ ds_notify_bio_error(int media_err_type, int tgt_id)
 	D_ALLOC(req, req_size);
 	if (req == NULL)
 		D_GOTO(out_uri, rc = -DER_NOMEM);
-
 	srv__bio_error_req__pack(&bioerr_req, req);
-	rc = drpc_call_create(dss_drpc_ctx, DRPC_MODULE_SRV,
-			      DRPC_METHOD_SRV_BIO_ERR, &dreq);
-	if (rc != 0) {
-		D_FREE(req);
-		goto out_uri;
-	}
 
-	dreq->body.len = req_size;
-	dreq->body.data = req;
-
-	rc = drpc_call(dss_drpc_ctx, R_SYNC, dreq, &dresp);
+	/*
+	 * Do not wait for the response, so that we don't Argobots-schedule or
+	 * pthread-block.
+	 */
+	rc = dss_drpc_call(DRPC_MODULE_SRV, DRPC_METHOD_SRV_BIO_ERR, req,
+			   req_size, DSS_DRPC_NO_RESP, NULL /* resp */);
 	if (rc != 0)
-		goto out_dreq;
-	if (dresp->status != DRPC__STATUS__SUCCESS) {
-		D_ERROR("received erroneous dRPC response: %d\n",
-			dresp->status);
-		rc = -DER_IO;
-	}
+		goto out_req;
 
-	drpc_response_free(dresp);
-
-out_dreq:
-	drpc_call_free(dreq);
+out_req:
+	D_FREE(req);
 out_uri:
 	D_FREE(bioerr_req.uri);
 
@@ -146,17 +253,11 @@ ds_get_pool_svc_ranks(uuid_t pool_uuid, d_rank_list_t **svc_ranks)
 	struct drpc_alloc	alloc = PROTO_ALLOCATOR_INIT(alloc);
 	Srv__GetPoolSvcReq	gps_req = SRV__GET_POOL_SVC_REQ__INIT;
 	Srv__GetPoolSvcResp	*gps_resp = NULL;
-	Drpc__Call		*dreq;
 	Drpc__Response		*dresp;
 	uint8_t			*req;
 	size_t			 req_size;
 	d_rank_list_t		*ranks;
 	int			 rc;
-
-	if (dss_drpc_ctx == NULL) {
-		D_ERROR("dRPC not connected\n");
-		return -DER_UNINIT;
-	}
 
 	D_ALLOC(gps_req.uuid, DAOS_UUID_STR_SIZE);
 	if (gps_req.uuid == NULL) {
@@ -172,21 +273,12 @@ ds_get_pool_svc_ranks(uuid_t pool_uuid, d_rank_list_t **svc_ranks)
 	D_ALLOC(req, req_size);
 	if (req == NULL)
 		D_GOTO(out_uuid, rc = -DER_NOMEM);
-
 	srv__get_pool_svc_req__pack(&gps_req, req);
-	rc = drpc_call_create(dss_drpc_ctx, DRPC_MODULE_SRV,
-			      DRPC_METHOD_SRV_GET_POOL_SVC, &dreq);
-	if (rc != 0) {
-		D_FREE(req);
-		goto out_uuid;
-	}
 
-	dreq->body.len = req_size;
-	dreq->body.data = req;
-
-	rc = drpc_call(dss_drpc_ctx, R_SYNC, dreq, &dresp);
+	rc = dss_drpc_call(DRPC_MODULE_SRV, DRPC_METHOD_SRV_GET_POOL_SVC, req,
+			   req_size, 0 /* flags */, &dresp);
 	if (rc != 0)
-		goto out_dreq;
+		goto out_req;
 	if (dresp->status != DRPC__STATUS__SUCCESS) {
 		D_ERROR("received erroneous dRPC response: %d\n",
 			dresp->status);
@@ -220,9 +312,8 @@ ds_get_pool_svc_ranks(uuid_t pool_uuid, d_rank_list_t **svc_ranks)
 
 out_dresp:
 	drpc_response_free(dresp);
-out_dreq:
-	/* also frees req via dreq->body.data */
-	drpc_call_free(dreq);
+out_req:
+	D_FREE(req);
 out_uuid:
 	D_FREE(gps_req.uuid);
 out:
@@ -232,37 +323,16 @@ out:
 int
 drpc_init(void)
 {
-	char	*path;
-	int	 rc;
-
-	D_ASPRINTF(path, "%s/%s", dss_socket_dir, "daos_server.sock");
-	if (path == NULL)
-		D_GOTO(out, rc = -DER_NOMEM);
-
-	D_ASSERT(dss_drpc_ctx == NULL);
-	rc = drpc_connect(path, &dss_drpc_ctx);
-	if (dss_drpc_ctx == NULL)
-		D_GOTO(out_path, 0);
-
-	rc = notify_ready();
-	if (rc != 0) {
-		drpc_close(dss_drpc_ctx);
-		dss_drpc_ctx = NULL;
-	}
-
-out_path:
-	D_FREE(path);
-out:
-	return rc;
+	D_ASSERT(dss_drpc_path == NULL);
+	D_ASPRINTF(dss_drpc_path, "%s/%s", dss_socket_dir, "daos_server.sock");
+	if (dss_drpc_path == NULL)
+		return -DER_NOMEM;
+	return 0;
 }
 
 void
 drpc_fini(void)
 {
-	int rc;
-
-	D_ASSERT(dss_drpc_ctx != NULL);
-	rc = drpc_close(dss_drpc_ctx);
-	D_ASSERTF(rc == 0, ""DF_RC"\n", DP_RC(rc));
-	dss_drpc_ctx = NULL;
+	D_ASSERT(dss_drpc_path != NULL);
+	D_FREE(dss_drpc_path);
 }

--- a/src/engine/drpc_internal.h
+++ b/src/engine/drpc_internal.h
@@ -25,11 +25,6 @@
 extern char *drpc_listener_socket_path;
 
 /**
- * Client context
- */
-extern struct drpc *dss_drpc_ctx;
-
-/**
  * Context for listener's drpc_progress loop. Includes the context for the
  * listener, and a list of contexts for all open sessions.
  */
@@ -122,10 +117,12 @@ int drpc_listener_fini(void);
  */
 const char *drpc_listener_get_socket_path(void);
 
-/** Initialize the dRPC client (dss_drpc_ctx). */
+/** Initialize the dRPC client. */
 int drpc_init(void);
 
-/** Finalize the dRPC client (dss_drpc_ctx). */
+/** Finalize the dRPC client. */
 void drpc_fini(void);
+
+int drpc_notify_ready(void);
 
 #endif /* __DAOS_DRPC_INTERNAL_H__ */

--- a/src/engine/init.c
+++ b/src/engine/init.c
@@ -502,18 +502,24 @@ server_init(int argc, char *argv[])
 	/** Report timestamp when engine was started */
 	d_tm_record_timestamp(NULL, "started_at", NULL);
 
+	rc = drpc_init();
+	if (rc != 0) {
+		D_ERROR("Failed to initialize dRPC: "DF_RC"\n", DP_RC(rc));
+		goto exit_telemetry_init;
+	}
+
 	rc = register_dbtree_classes();
 	if (rc != 0)
-		D_GOTO(exit_telemetry_init, rc);
+		D_GOTO(exit_drpc_fini, rc);
 
 	/** initialize server topology data */
 	rc = dss_topo_init();
 	if (rc != 0)
-		D_GOTO(exit_telemetry_init, rc);
+		D_GOTO(exit_drpc_fini, rc);
 
 	rc = abt_init(argc, argv);
 	if (rc != 0)
-		goto exit_telemetry_init;
+		goto exit_drpc_fini;
 
 	/* initialize the modular interface */
 	rc = dss_module_init();
@@ -595,9 +601,9 @@ server_init(int argc, char *argv[])
 		goto exit_srv_init;
 	}
 
-	rc = drpc_init();
+	rc = drpc_notify_ready();
 	if (rc != 0) {
-		D_ERROR("Failed to initialize dRPC: "DF_RC"\n", DP_RC(rc));
+		D_ERROR("Failed to notify daos_server: "DF_RC"\n", DP_RC(rc));
 		goto exit_init_state;
 	}
 
@@ -629,12 +635,12 @@ server_init(int argc, char *argv[])
 
 	rc = dss_module_setup_all();
 	if (rc != 0)
-		goto exit_drpc_fini;
+		goto exit_init_state;
 	D_INFO("Modules successfully set up\n");
 
 	rc = crt_register_event_cb(dss_crt_event_cb, NULL);
 	if (rc)
-		D_GOTO(exit_drpc_fini, rc);
+		D_GOTO(exit_init_state, rc);
 
 	dss_xstreams_open_barrier();
 	D_INFO("Service fully up\n");
@@ -655,8 +661,6 @@ server_init(int argc, char *argv[])
 
 	return 0;
 
-exit_drpc_fini:
-	drpc_fini();
 exit_init_state:
 	server_init_state_fini();
 exit_srv_init:
@@ -676,6 +680,8 @@ exit_mod_init:
 	dss_module_fini(true);
 exit_abt_init:
 	abt_fini();
+exit_drpc_fini:
+	drpc_fini();
 exit_telemetry_init:
 	d_tm_fini();
 exit_debug_init:
@@ -691,8 +697,6 @@ server_fini(bool force)
 	D_INFO("unregister event callbacks done\n");
 	dss_module_cleanup_all();
 	D_INFO("dss_module_cleanup_all() done\n");
-	drpc_fini();
-	D_INFO("drpc_fini() done\n");
 	server_init_state_fini();
 	D_INFO("server_init_state_fini() done\n");
 	dss_srv_fini(force);
@@ -718,6 +722,8 @@ server_fini(bool force)
 	D_INFO("dss_module_fini() done\n");
 	abt_fini();
 	D_INFO("abt_fini() done\n");
+	drpc_fini();
+	D_INFO("drpc_fini() done\n");
 	d_tm_fini();
 	D_INFO("d_tm_fini() done\n");
 	daos_debug_fini();

--- a/src/engine/tests/SConscript
+++ b/src/engine/tests/SConscript
@@ -32,7 +32,7 @@ def scons():
                      '../drpc_client.c', '../drpc_ras.c', '../srv.pb-c.c',
                      '../event.pb-c.c'],
                     LIBS=['daos_common', 'protobuf-c', 'gurt', 'cmocka',
-                          'uuid'])
+                          'uuid', 'pthread', 'abt'])
 
 if __name__ == "SCons.Script":
     scons()

--- a/src/engine/tests/drpc_client_tests.c
+++ b/src/engine/tests/drpc_client_tests.c
@@ -16,6 +16,7 @@
 #include <daos/test_mocks.h>
 #include <daos/test_utils.h>
 #include <daos/drpc_modules.h>
+#include <daos_srv/daos_engine.h>
 
 /*
  * Mocks of DAOS internals
@@ -64,6 +65,24 @@ get_module_info(void)
 	return mock_dmi;
 }
 
+static struct sched_request {
+} mock_sched_req;
+struct sched_request *
+sched_req_get(struct sched_req_attr *attr, ABT_thread ult)
+{
+	return &mock_sched_req;
+}
+
+void
+sched_req_sleep(struct sched_request *req, uint32_t msecs)
+{
+}
+
+void
+sched_req_put(struct sched_request *req)
+{
+}
+
 /*
  * Test setup and teardown
  */
@@ -97,35 +116,56 @@ drpc_client_test_teardown(void **state)
  * Unit tests
  */
 static void
-test_drpc_init_connect_fails(void **state)
+test_drpc_call_connect_fails(void **state)
 {
-	skip(); /* DAOS-6436 */
+	Drpc__Response	*resp;
+	int		 rc;
+
+	/*
+	 * errno is not set for the dss_drpc_thread; connect_return = -1 also
+	 * isn't working.
+	 */
+	skip();
+
+	assert_int_equal(drpc_init(), 0);
+
 	connect_return = -1;
+	errno = EACCES;
 
-	assert_int_equal(drpc_init(), -DER_NOMEM);
-}
-
-static void
-test_drpc_init_crt_get_uri_fails(void **state)
-{
-	crt_self_uri_get_return = -DER_BUSY;
-	assert_int_equal(drpc_init(), crt_self_uri_get_return);
+	rc = dss_drpc_call(DRPC_MODULE_SRV, DRPC_METHOD_SRV_NOTIFY_READY,
+			   NULL /* req */, 0 /* req_size */, 0 /* flags */,
+			   &resp);
+	assert_int_equal(rc, -DER_NO_PERM);
 
 	/* make sure socket was closed */
 	assert_int_equal(close_call_count, 1);
+
+	drpc_fini();
 }
 
 static void
-test_drpc_init_sendmsg_fails(void **state)
+test_drpc_call_sendmsg_fails(void **state)
 {
-	skip(); /* DAOS-6436 */
+	Drpc__Response	*resp;
+	int		 rc;
+
+	/* See test_drpc_call_connect_fails. */
+	skip();
+
+	assert_int_equal(drpc_init(), 0);
+
 	sendmsg_return = -1;
-	errno = EPERM;
+	errno = EACCES;
 
-	assert_int_equal(drpc_init(), -DER_NO_PERM);
+	rc = dss_drpc_call(DRPC_MODULE_SRV, DRPC_METHOD_SRV_NOTIFY_READY,
+			   NULL /* req */, 0 /* req_size */, 0 /* flags */,
+			   &resp);
+	assert_int_equal(rc, -DER_NO_PERM);
 
 	/* make sure socket was closed */
 	assert_int_equal(close_call_count, 1);
+
+	drpc_fini();
 }
 
 static void
@@ -156,16 +196,16 @@ verify_notify_ready_message(void)
 }
 
 static void
-test_drpc_init_fini(void **state)
+test_drpc_verify_notify_ready(void **state)
 {
-	mock_valid_drpc_resp_in_recvmsg(DRPC__STATUS__SUCCESS);
 	assert_int_equal(drpc_init(), 0);
 
-	/* drpc connection created */
-	assert_int_equal(connect_sockfd, socket_return);
+	mock_valid_drpc_resp_in_recvmsg(DRPC__STATUS__SUCCESS);
 
-	/* socket was left open */
-	assert_int_equal(close_call_count, 0);
+	assert_int_equal(drpc_notify_ready(), 0);
+
+	/* socket was closed */
+	assert_int_equal(close_call_count, 1);
 
 	/* Message was sent */
 	assert_non_null(sendmsg_msg_ptr);
@@ -173,19 +213,6 @@ test_drpc_init_fini(void **state)
 
 	/* Now let's shut things down... */
 	drpc_fini();
-
-	/* socket was closed */
-	assert_int_equal(close_call_count, 1);
-}
-
-static void
-test_drpc_init_bad_response(void **state)
-{
-	mock_valid_drpc_resp_in_recvmsg(DRPC__STATUS__FAILURE);
-	assert_int_equal(drpc_init(), -DER_IO);
-
-	/* make sure socket was closed */
-	assert_int_equal(close_call_count, 1);
 }
 
 static void
@@ -296,26 +323,6 @@ test_drpc_verify_notify_pool_svc_update(void **state)
 }
 
 static void
-verify_cluster_event_not_sent()
-{
-	Drpc__Call		*call;
-	Shared__ClusterEventReq	*req;
-
-	call = drpc__call__unpack(NULL, sendmsg_msg_iov_len,
-				  sendmsg_msg_content);
-	assert_non_null(call);
-	assert_int_equal(call->module, DRPC_MODULE_SRV);
-
-	/* Verify NULL payload content */
-	req = shared__cluster_event_req__unpack(NULL, call->body.len,
-						call->body.data);
-	assert_true(req == NULL);
-
-	/* Cleanup */
-	drpc__call__free_unpacked(call, NULL);
-}
-
-static void
 test_drpc_verify_notify_pool_svc_update_noreps(void **state)
 {
 	uuid_t	pool_uuid;
@@ -328,7 +335,7 @@ test_drpc_verify_notify_pool_svc_update_noreps(void **state)
 
 	assert_int_equal(ds_notify_pool_svc_update(&pool_uuid, NULL),
 			 -DER_INVAL);
-	verify_cluster_event_not_sent();
+	assert_int_equal(sendmsg_call_count, 0);
 
 	drpc_fini();
 }
@@ -347,7 +354,7 @@ test_drpc_verify_notify_pool_svc_update_nopool(void **state)
 
 	assert_int_equal(ds_notify_pool_svc_update(NULL, svc_ranks),
 			 -DER_INVAL);
-	verify_cluster_event_not_sent();
+	assert_int_equal(sendmsg_call_count, 0);
 
 	d_rank_list_free(svc_ranks);
 
@@ -448,7 +455,7 @@ test_drpc_verify_cluster_event_emptymsg(void **state)
 	ds_notify_ras_event(RAS_RANK_DOWN, "", RAS_TYPE_STATE_CHANGE,
 			    RAS_SEV_ERROR, NULL, NULL, NULL, NULL, NULL, NULL,
 			    NULL, NULL);
-	verify_cluster_event_not_sent();
+	assert_int_equal(sendmsg_call_count, 0);
 
 	drpc_fini();
 }
@@ -462,7 +469,7 @@ test_drpc_verify_cluster_event_nomsg(void **state)
 	ds_notify_ras_event(RAS_RANK_DOWN, NULL, RAS_TYPE_STATE_CHANGE,
 			    RAS_SEV_ERROR, NULL, NULL, NULL, NULL, NULL, NULL,
 			    NULL, NULL);
-	verify_cluster_event_not_sent();
+	assert_int_equal(sendmsg_call_count, 0);
 
 	drpc_fini();
 }
@@ -476,11 +483,9 @@ int
 main(void)
 {
 	const struct CMUnitTest tests[] = {
-		UTEST(test_drpc_init_connect_fails),
-		UTEST(test_drpc_init_crt_get_uri_fails),
-		UTEST(test_drpc_init_sendmsg_fails),
-		UTEST(test_drpc_init_fini),
-		UTEST(test_drpc_init_bad_response),
+		UTEST(test_drpc_call_connect_fails),
+		UTEST(test_drpc_call_sendmsg_fails),
+		UTEST(test_drpc_verify_notify_ready),
 		UTEST(test_drpc_verify_notify_bio_error),
 		UTEST(test_drpc_verify_notify_pool_svc_update),
 		UTEST(test_drpc_verify_notify_pool_svc_update_noreps),

--- a/src/include/daos_srv/daos_engine.h
+++ b/src/include/daos_srv/daos_engine.h
@@ -863,4 +863,20 @@ struct sys_db {
 	void	(*sd_unlock)(struct sys_db *db);
 };
 
+/** Flags for dss_drpc_call */
+enum dss_drpc_call_flag {
+	/** Do not wait for a response. Implies DSS_DRPC_NO_SCHED. */
+	DSS_DRPC_NO_RESP	= 1,
+	/**
+	 * Do not Argobots-schedule. If the dRPC requires a response, this will
+	 * block the thread until a response is received. That is usually
+	 * faster than waiting for the response by Argobots-scheduling if the
+	 * dRPC can be quickly handled by the local daos_server alone.
+	 */
+	DSS_DRPC_NO_SCHED	= 2
+};
+
+int dss_drpc_call(int32_t module, int32_t method, void *req, size_t req_size,
+		  unsigned int flags, Drpc__Response **resp);
+
 #endif /* __DSS_API_H__ */

--- a/src/include/daos_srv/ras.h
+++ b/src/include/daos_srv/ras.h
@@ -153,7 +153,8 @@ ds_notify_ras_eventf(ras_event_t id, ras_type_t type, ras_sev_t sev, char *hwid,
 		     const char *fmt, ...);
 
 /**
- * Notify control-plane of an update to a pool's service replicas.
+ * Notify control-plane of an update to a pool's service replicas and wait for
+ * a response.
  *
  * \param[in] pool	UUID of DAOS pool with updated service replicas.
  * \param[in] svcl	New list of pool service replica ranks.

--- a/utils/rpms/daos.spec
+++ b/utils/rpms/daos.spec
@@ -406,7 +406,7 @@ getent passwd daos_agent >/dev/null || useradd -s /sbin/nologin -r -g daos_agent
 %{_libdir}/*.a
 
 %changelog
-* Thu Mar 02 2021 Li Wei <wei.g.li@intel.com> 1.1.3-4
+* Tue Mar 02 2021 Li Wei <wei.g.li@intel.com> 1.1.3-4
 - Require raft-devel 0.7.3 that fixes an unstable leadership problem caused by
   removed replicas as well as some Coverity issues
 


### PR DESCRIPTION
In an engine, we invoke every dRPC synchronously on the calling xstream.
Before a response is received, the calling xstream is blocked, unable to
execute any other ULTs. For the system xstream, this may even affect the
stability of SWIM and Raft.

This patch introduces dss_drpc_call for invoking dRPCs in an engine.
When invoking a synchronous dRPC, dss_drpc_call creates a pthread to
send the request and receive the response using a private dRPC
connection:

  - The impact on the calling xstream will be reduced to the level of
    100 us (roughly).
  - Concurrent dRPCs will be possible.
  - dRPC latencies, however, will increase greatly to the level of 100
    ms (roughly), probably because the pthreads struggle to get CPU
    time from xstreams.

When invoking a dRPC without waiting for a response, dss_drpc_call sends
the request with a private connection directly on the calling xstream:

  - No response will be available.
  - The impact on the calling xstream will be on the level of
    200 us (roughly).

dRPCs that require responses will keep being synchronous; RAS and bio
error dRPCs are changed to not wait for responses, for some of their
callers cannot Argobots-schedule.

The shared dss_drpc_ctx is removed. The initialization of engine's
drpc_client module is tuned so that more code may make dRPC calls.

Signed-off-by: Li Wei <wei.g.li@intel.com>