### PR TITLE
DAOS-6988 dtx: avoid leader switch during server reintegration

### DIFF
--- a/src/placement/pl_map.c
+++ b/src/placement/pl_map.c
@@ -617,10 +617,13 @@ pl_select_leader(daos_obj_id_t oid, uint32_t grp_idx, uint32_t grp_size,
 	}
 
 	replicas = oc_attr->u.rp.r_num;
-	if (replicas == DAOS_OBJ_REPL_MAX)
-		replicas = grp_size;
+	if (replicas == DAOS_OBJ_REPL_MAX) {
+		D_ASSERT(grp_idx == 0);
 
-	if (replicas < 1)
+		replicas = grp_size;
+	}
+
+	if (replicas < 1 || replicas > grp_size)
 		return -DER_INVAL;
 
 	if (replicas == 1) {
@@ -651,7 +654,7 @@ pl_select_leader(daos_obj_id_t oid, uint32_t grp_idx, uint32_t grp_size,
 	 *      to avoid leader switch.
 	 */
 	start = grp_idx * grp_size;
-	replica_idx = (oid.lo + grp_idx) % grp_size;
+	replica_idx = (oid.lo + grp_idx) % replicas;
 	for (i = 0, pos = -1; i < replicas;
 	     i++, replica_idx = (replica_idx + 1) % replicas) {
 		int off = start + replica_idx;


### PR DESCRIPTION
During DAOS server reintegration, some objects' shards may be
migrated from existing server(s) to the new server. That will
cause related objects to have more shard than claimed ones as
its object class does in the layout temporarily.

Our current DTX leader election algorithms depends on object's
layout. We need to guarantee that the elected DTX leader during
DAOS server reintegration will be the same as without DAOS server
reintegration; otherwise, there may be unnecessary leader switch
during DAOS server reintegration as to unnecessary DTX resync.

This patch uses claimed object replicas count in related object
class rather than the temporary redundancy group size during the
data migration. That avoids above unnecessary DTX leader switch.

Master-PR: https://github.com/daos-stack/daos/pull/4934

Signed-off-by: Fan Yong <fan.yong@intel.com>