### PR TITLE
DAOS-6327 control: write ras events to syslog unit tests

### DIFF
--- a/src/control/events/generic.go
+++ b/src/control/events/generic.go
@@ -7,6 +7,8 @@
 package events
 
 import (
+	"math"
+
 	sharedpb "github.com/daos-stack/daos/src/control/common/proto/shared"
 )
 
@@ -46,4 +48,16 @@ func StrInfoToProto(si *StrInfo) (*sharedpb.RASEvent_StrInfo, error) {
 	}
 
 	return pbInfo, nil
+}
+
+// NewGenericEvent returns a generic RAS event with supplied ID.
+func NewGenericEvent(id RASID, sev RASSeverityID, msg, info string) *RASEvent {
+	return New(&RASEvent{
+		ID:           id,
+		Type:         RASTypeInfoOnly,
+		Severity:     sev,
+		Msg:          msg,
+		Rank:         math.MaxUint32,
+		ExtendedInfo: NewStrInfo(info),
+	})
 }

--- a/src/control/events/generic_test.go
+++ b/src/control/events/generic_test.go
@@ -14,14 +14,8 @@ import (
 )
 
 func mockGenericEvent() *RASEvent {
-	return New(&RASEvent{
-		ID:           math.MaxInt32 - 1,
-		Type:         RASTypeInfoOnly,
-		Severity:     RASSeverityError,
-		Msg:          "DAOS generic test event",
-		Rank:         1,
-		ExtendedInfo: NewStrInfo(`{"people":["bill","steve","bob"]}`),
-	})
+	return NewGenericEvent(RASID(math.MaxInt32-1), RASSeverityError,
+		"DAOS generic test event", `{"people":["bill","steve","bob"]}`)
 }
 
 func TestEvents_ConvertGeneric(t *testing.T) {

--- a/src/control/lib/control/system_test.go
+++ b/src/control/lib/control/system_test.go
@@ -1329,12 +1329,12 @@ func TestControl_EventForwarder_OnEvent(t *testing.T) {
 	}
 }
 
+// In real syslog implementation we would see entries logged to logger specific
+// to a given priority, here we just check the correct prefix (maps to severity)
+// is printed which verifies the event was written to the correct logger.
 func TestControl_EventLogger_OnEvent(t *testing.T) {
 	var mockSyslogBuf *strings.Builder
 	getMockSyslogger := func(sev events.RASSeverityID) *log.Logger {
-		// in real syslog implementation we would see entries logged to
-		// logger specific to a given priority, here we just check the
-		// correct prefix (maps to severity)has been set on the entry.
 		return log.New(mockSyslogBuf, sev.String(), log.LstdFlags)
 	}
 


### PR DESCRIPTION
Add coverage for writing RAS events to syslog at the correct priority.

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>