### PR TITLE
DAOS-6989 dtx: initialize daos_unit_oid_t::id_pad_32

### DIFF
--- a/src/object/obj_rpc.c
+++ b/src/object/obj_rpc.c
@@ -711,10 +711,13 @@ crt_proc_struct_daos_cpd_sub_req(crt_proc_t proc,
 	if (with_oid) {
 		rc = crt_proc_daos_unit_oid_t(proc, &dcsr->dcsr_oid);
 	} else if (ENCODING(proc_op)) {
-		daos_unit_oid_t		 oid;
+		daos_unit_oid_t		 oid = { 0 };
 
 		daos_dc_obj2id(dcsr->dcsr_obj, &oid.id_pub);
-		/* It is not important what the id_shard is, that
+		/* id_pad_32 must be initialized as zero, it will
+		 * be used as part of the vos object cache index.
+		 *
+		 * It is not important what the id_shard is, that
 		 * is packed via daos_cpd_req_idx::dcri_shard_idx.
 		 */
 		rc = crt_proc_daos_unit_oid_t(proc, &oid);


### PR DESCRIPTION
It must be initialized as zero, because it will be used as
part of the vos object cache index. If it is uninitialized,
then we may cannot find out former created object or others
cannot find out the object created by current udpate.

Master-PR: https://github.com/daos-stack/daos/pull/4940

Signed-off-by: Fan Yong <fan.yong@intel.com>