### PR TITLE
DAOS-6808 misc: Fix a memory leak in IV fetch

### DIFF
--- a/src/cart/crt_iv.c
+++ b/src/cart/crt_iv.c
@@ -2684,6 +2684,8 @@ handle_response_internal(void *arg)
 {
 	const struct crt_cb_info *cb_info = arg;
 	crt_rpc_t		 *rpc = cb_info->cci_rpc;
+	void			 *cb_arg = cb_info->cci_arg;
+
 
 	switch (rpc->cr_opc) {
 	case CRT_OPC_IV_FETCH:
@@ -2700,6 +2702,7 @@ handle_response_internal(void *arg)
 	default:
 		D_ERROR("wrong opc: cb_info %p: rpc %p: opc %#x\n",
 			cb_info, rpc, rpc->cr_opc);
+		D_FREE(cb_arg);
 	}
 }
 

--- a/src/engine/server_iv.c
+++ b/src/engine/server_iv.c
@@ -607,7 +607,7 @@ ivc_on_put(crt_iv_namespace_t ivns, d_sg_list_t *iv_value, void *priv)
 	D_ASSERT(entry != NULL);
 
 	/* Let's deal with iv_value first */
-	d_sgl_fini(iv_value, false);
+	d_sgl_fini(iv_value, true);
 
 	rc = entry->iv_class->iv_class_ops->ivc_ent_put(entry,
 							priv_entry->priv);

--- a/src/object/obj_rpc.c
+++ b/src/object/obj_rpc.c
@@ -1209,8 +1209,10 @@ obj_reply_map_version_set(crt_rpc_t *rpc, uint32_t map_version)
 		break;
 	case DAOS_OBJ_RPC_EC_AGGREGATE:
 		((struct obj_ec_agg_out *)reply)->ea_map_ver = map_version;
+		break;
 	case DAOS_OBJ_RPC_CPD:
 		((struct obj_cpd_out *)reply)->oco_map_version = map_version;
+		break;
 	case DAOS_OBJ_RPC_EC_REPLICATE:
 		((struct obj_ec_rep_out *)reply)->er_map_ver = map_version;
 		break;


### PR DESCRIPTION
- IV ivc_on_put() should release the value buffer
- Add missing "break" for the switch in obj_reply_map_version_set()
- minor fix for memory leak in failure handling of IV
    
Signed-off-by: Dmitry Eremin <dmitry.eremin@intel.com>
Signed-off-by: Liang Zhen <liang.zhen@intel.com>
