### PR TITLE
CART-89 debug: Enable NA logging

### DIFF
--- a/src/cart/crt_hg.c
+++ b/src/cart/crt_hg.c
@@ -453,6 +453,10 @@ crt_hg_init(void)
 	if (!env)
 		HG_Set_log_level("warning");
 
+	env = getenv("HG_NA_LOG_LEVEL");
+	if (!env)
+		NA_Set_log_level("warning");
+
 	/* import HG log */
 	hg_log_set_func(crt_hg_log);
 	hg_log_set_stream_debug((FILE *)(intptr_t)(EXT_FAC | DLOG_DBG));


### PR DESCRIPTION
- Enable default NA logging of warnings/errors.

Signed-off-by: Alexander Oganezov <alexander.a.oganezov@intel.com>