### PR TITLE
DAOS-6992 test: Enable debug output for dmg in CI

### DIFF
--- a/src/control/cmd/dmg/main.go
+++ b/src/control/cmd/dmg/main.go
@@ -224,7 +224,7 @@ func parseOpts(args []string, opts *cliOptions, invoker control.Invoker, log *lo
 			jsonCmd.enableJsonOutput(opts.JSON, os.Stdout, &wroteJSON)
 			if opts.JSON {
 				// disable output on stdout other than JSON
-				log.SetLevel(logging.LogLevelError)
+				log.ClearLevel(logging.LogLevelInfo)
 			}
 		}
 

--- a/src/control/logging/defaults.go
+++ b/src/control/logging/defaults.go
@@ -17,7 +17,7 @@ const (
 )
 
 // NewCommandLineLogger returns a logger configured
-// to send non-error output to stdout and error
+// to send non-error output to stdout and error/debug
 // output to stderr. The output format is suitable
 // for command line utilities which don't want output
 // to include timestamps and filenames.
@@ -25,7 +25,7 @@ func NewCommandLineLogger() *LeveledLogger {
 	return &LeveledLogger{
 		level: DefaultLogLevel,
 		debugLoggers: []DebugLogger{
-			NewDebugLogger(os.Stdout),
+			NewDebugLogger(os.Stderr),
 		},
 		infoLoggers: []InfoLogger{
 			NewCommandLineInfoLogger(os.Stdout),

--- a/src/control/logging/logger.go
+++ b/src/control/logging/logger.go
@@ -76,6 +76,20 @@ func (ll *LeveledLogger) Level() LogLevel {
 	return ll.level.Get()
 }
 
+// ClearLevel clears all loggers for the specified level.
+func (ll *LeveledLogger) ClearLevel(level LogLevel) {
+	switch level {
+	case LogLevelDebug:
+		ll.debugLoggers = nil
+	case LogLevelInfo:
+		ll.infoLoggers = nil
+	case LogLevelError:
+		ll.errorLoggers = nil
+	default:
+		ll.Errorf("unable to clear level %s", level)
+	}
+}
+
 // WithLogLevel allows the logger's LogLevel to be set
 // as part of a chained method call.
 func (ll *LeveledLogger) WithLogLevel(level LogLevel) *LeveledLogger {

--- a/src/tests/ftest/util/dmg_utils_base.py
+++ b/src/tests/ftest/util/dmg_utils_base.py
@@ -39,7 +39,7 @@ class DmgCommandBase(YamlCommand):
         self.hostfile = FormattedParameter("-f {}")
         self.configpath = FormattedParameter("-o {}", default_yaml_file)
         self.insecure = FormattedParameter("-i", False)
-        self.debug = FormattedParameter("-d", False)
+        self.debug = FormattedParameter("-d", True)
         self.json = FormattedParameter("-j", False)
 
     @property


### PR DESCRIPTION
Changes the logger to emit debug on stderr so that we can
get debug output without affecting JSON consumers, and
enables dmg debug output by default.