### PR TITLE
DAOS-6678 csum: Fixed issues caught by coverity

### DIFF
--- a/src/container/cli.c
+++ b/src/container/cli.c
@@ -666,8 +666,11 @@ cont_open_complete(tse_task_t *task, void *data)
 
 	daos_props_2cont_props(out->coo_prop, &cont->dc_props);
 	rc = dc_cont_props_init(cont);
-	if (rc != 0)
+	if (rc != 0) {
+		D_ERROR("container props failed to initialize");
+		D_RWLOCK_UNLOCK(&pool->dp_co_list_lock);
 		D_GOTO(out, rc);
+	}
 
 	D_RWLOCK_UNLOCK(&pool->dp_co_list_lock);
 

--- a/src/vos/tests/vts_checksum.c
+++ b/src/vos/tests/vts_checksum.c
@@ -60,8 +60,11 @@ struct test_case_args {
 	uint32_t		holes_nr;
 };
 
-#define	CSUM_FOR_ARRAYS_TEST_CASE(state, ...) \
-	csum_for_arrays_test_case(state, (struct test_case_args)__VA_ARGS__)
+#define	CSUM_FOR_ARRAYS_TEST_CASE(state, args...) do { \
+	struct test_case_args __args = args; \
+	csum_for_arrays_test_case(state, &__args); \
+	} while (0)
+
 /** index to a specific csum within a csum info array */
 struct cia_idx {
 	uint32_t ci_idx;
@@ -86,8 +89,8 @@ cia_idx_get_csum(struct cia_idx *idx, struct dcs_csum_info *infos)
 	return ci_idx2csum(&infos[idx->ci_idx], idx->csum_idx);
 }
 
-void
-csum_for_arrays_test_case(void *const *state, struct test_case_args test)
+static void
+csum_for_arrays_test_case(void *const *state, const struct test_case_args *test)
 {
 	struct dcs_csum_info	*csum_infos;
 	struct dcs_iod_csums	 iod_csums = {0};
@@ -113,18 +116,18 @@ csum_for_arrays_test_case(void *const *state, struct test_case_args test)
 	extent_key_from_test_args(&k, *state);
 	csum_size = 8;
 
-	while (test.update_recxs[update_recx_nr].nr > 0) {
-		data_size += test.update_recxs[update_recx_nr].nr *
-			     test.rec_size;
+	while (test->update_recxs[update_recx_nr].nr > 0) {
+		data_size += test->update_recxs[update_recx_nr].nr *
+			     test->rec_size;
 		update_recx_nr++;
 	}
 
-	while (test.fetch_recxs[fetch_recx_nr].nr > 0)
+	while (test->fetch_recxs[fetch_recx_nr].nr > 0)
 		fetch_recx_nr++;
 
 	for (i = 0; i < update_recx_nr; i++) {
-		recx[i].rx_nr = test.update_recxs[i].nr;
-		recx[i].rx_idx = test.update_recxs[i].idx;
+		recx[i].rx_nr = test->update_recxs[i].nr;
+		recx[i].rx_idx = test->update_recxs[i].idx;
 	}
 
 	D_ALLOC_ARRAY(csum_infos, update_recx_nr);
@@ -135,10 +138,10 @@ csum_for_arrays_test_case(void *const *state, struct test_case_args test)
 		uint64_t csum_buf_len;
 
 		csum_buf_len = (uint64_t)csum_size *
-				test.update_recxs[i].csum_count;
+				test->update_recxs[i].csum_count;
 		csum_infos[i].cs_type = 1;
-		csum_infos[i].cs_nr = test.update_recxs[i].csum_count;
-		csum_infos[i].cs_chunksize = test.chunksize;
+		csum_infos[i].cs_nr = test->update_recxs[i].csum_count;
+		csum_infos[i].cs_chunksize = test->chunksize;
 		D_ALLOC(csum_infos[i].cs_csum, csum_buf_len);
 		memset(csum_infos[i].cs_csum, i + 1, csum_buf_len);
 
@@ -147,7 +150,7 @@ csum_for_arrays_test_case(void *const *state, struct test_case_args test)
 	}
 
 	iod.iod_name = k.akey;
-	iod.iod_size = test.rec_size;
+	iod.iod_size = test->rec_size;
 	iod.iod_nr = update_recx_nr;
 	iod.iod_recxs = recx;
 	iod.iod_type = DAOS_IOD_ARRAY;
@@ -163,8 +166,8 @@ csum_for_arrays_test_case(void *const *state, struct test_case_args test)
 
 	iod.iod_nr = fetch_recx_nr;
 	for (i = 0; i < fetch_recx_nr; i++) {
-		recx[i].rx_nr = test.fetch_recxs[i].nr;
-		recx[i].rx_idx = test.fetch_recxs[i].idx;
+		recx[i].rx_nr = test->fetch_recxs[i].nr;
+		recx[i].rx_idx = test->fetch_recxs[i].idx;
 	}
 
 	/**
@@ -180,18 +183,18 @@ csum_for_arrays_test_case(void *const *state, struct test_case_args test)
 	f_csums_nr = vos_ioh2ci_nr(ioh);
 	f_csums = vos_ioh2ci(ioh);
 
-	assert_int_equal(test.biovs_nr, bsgl->bs_nr_out);
+	assert_int_equal(test->biovs_nr, bsgl->bs_nr_out);
 
 	for (i = 0; i < bsgl->bs_nr_out; i++) {
 		struct bio_iov *biov = &bsgl->bs_iovs[i];
-		struct expected_biov *expected_biov = &test.biovs[i];
+		const struct expected_biov *expected_biov = &test->biovs[i];
 
 		assert_int_equal(expected_biov->prefix, biov->bi_prefix_len);
 		assert_int_equal(expected_biov->suffix, biov->bi_suffix_len);
 	}
 
 	/** should be 1 csum info per biov (minus holes) */
-	expected_csums_nr = test.biovs_nr - test.holes_nr;
+	expected_csums_nr = test->biovs_nr - test->holes_nr;
 	assert_int_equal(expected_csums_nr, f_csums_nr);
 	assert_non_null(f_csums);
 


### PR DESCRIPTION
The following coverity issues are fixed.

Coverity CID 280727 - vts_checksum.c passed a large structure
by value instead of by reference. Changed it to pass by
reference.
Coverity CID 319831 - pool lock wasn't being unlocked if
dc_cont_props_init failed.

Master PR: #4916
Master commit cherry picked: 769ae9a5b239d9df1cbfa0d2e78bcde01a33340c 

Signed-off-by: Ryon Jensen <ryon.jensen@intel.com>