### PR TITLE
DAOS-6953 vos: Avoid under punch under normal I/O (#4868)

### DIFF
--- a/src/vos/tests/vts_mvcc.c
+++ b/src/vos/tests/vts_mvcc.c
@@ -1458,8 +1458,15 @@ uncertainty_check_exec_one(struct io_test_args *arg, int i, int j, bool empty,
 			else if (a->o_rtype == R_E && !empty)
 				expected_arc = -DER_EXIST;
 		}
+		/** If is_punch(a), a is equal to or a parent of w and the
+		 *  punch will execute, then a will be rejected due to VOS's
+		 *  prevention of "under punches".
+		 */
+		if (is_punch(a) && a->o_wlevel <= w->o_wlevel &&
+		    expected_arc == 0)
+			expected_arc = -DER_TX_RESTART;
 	}
-	if (is_punch(w) && we > bound)
+	if (expected_arc != -DER_TX_RESTART && is_punch(w) && we > bound)
 		print_message("  %s(%s, "DF_X64
 			      ") (expect %s or DER_TX_RESTART): ", a->o_name,
 			      ap, ae, d_errstr(expected_arc));


### PR DESCRIPTION
This prevents orphaning updates (updates in subtree with
no creation timestamp in the incarnation log).

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>