### PR TITLE
DAOS-6918-test_rel_1.2: pool_destroy testcase failed due to Timeout

### DIFF
--- a/src/tests/ftest/pool/destroy_tests.yaml
+++ b/src/tests/ftest/pool/destroy_tests.yaml
@@ -13,7 +13,7 @@ setup:
   start_servers_once: False
 server_config:
   name: daos_server
-timeout: 60
+timeout: 90
 pool:
   mode: 146
   name: daos_server


### PR DESCRIPTION
DAOS-6918-test_rel_1.2: pool_destroy testcase failed due to Timeout
Update: pool/destroy_tests.yaml
Skip-unit-tests: true
Skip-nlt: true
Test-tag: destroysingleloop destroymutliloop
Signed-off-by: Ding Ho <ding-hwa.ho@intel.com>