### PR TITLE
DAOS-7015 event: proper event handing in case of progress errors (#4911)

### DIFF
--- a/src/client/api/event.c
+++ b/src/client/api/event.c
@@ -1251,6 +1251,8 @@ daos_event_priv_wait()
 		/** progress succeeded, loop can exit if event completed */
 		if (rc == 0) {
 			rc = ev_thpriv.ev_error;
+			if (rc)
+				break;
 			continue;
 		}
 
@@ -1263,8 +1265,7 @@ daos_event_priv_wait()
 		 * the private event first so it can be resused.
 		 */
 		rc2 = daos_event_priv_reset();
-		if (rc2)
-			return rc2;
+		D_ASSERT(rc2 == 0);
 		ev_thpriv_is_init = true;
 		break;
 	}

--- a/src/client/api/task.c
+++ b/src/client/api/task.c
@@ -119,7 +119,11 @@ dc_task_schedule(tse_task_t *task, bool instant)
 
 out:
 	if (daos_event_is_priv(ev)) {
-		daos_event_priv_wait();
+		int rc2;
+
+		rc2 = daos_event_priv_wait();
+		if (rc2)
+			return rc2;
 		rc = ev->ev_error;
 	}
 	return rc;


### PR DESCRIPTION
crt_progress can sometimes return errors that are not timeout. Those
are not properly handled in synchronous IO calls and cause the private
event to be in an unusable state for following IOs.

This PR checks the error from cart and reinits the private event in
case an error was returned so it can be resused rather then returning
to the user.

Signed-off-by: Mohamad Chaarawi <mohamad.chaarawi@intel.com>