### PR TITLE
DAOS-6801 Security: Implement Secure Erase for Credential memory (#4690)

### DIFF
--- a/src/SConscript
+++ b/src/SConscript
@@ -38,6 +38,12 @@ def scons():
     env.AppendUnique(RPATH_FULL=[Dir('gurt')])
     env.AppendUnique(LINKFLAGS=["-Wl,-rpath-link=%s" % Dir('gurt').path])
 
+    # Detect if we have explicit_bzero
+    conf = Configure(env)
+    if not conf.CheckFunc('explicit_bzero'):
+        env.Append(CCFLAGS=['-DNEED_EXPLICIT_BZERO'])
+    conf.Finish()
+
     # Generic DAOS includes
     env.AppendUnique(CPPPATH=[Dir('include').srcnode()])
     env.AppendUnique(CPPPATH=[Dir('include')])

--- a/src/include/daos/common.h
+++ b/src/include/daos/common.h
@@ -833,4 +833,13 @@ daos_anchor_is_zero(daos_anchor_t *anchor)
 /* default debug log file */
 #define DAOS_LOG_DEFAULT	"/tmp/daos.log"
 
+#ifdef NEED_EXPLICIT_BZERO
+/* Secure memory scrub */
+static inline void
+explicit_bzero(void *s, size_t count) {
+	memset(s, 0, count);
+	asm volatile("" :  : "r"(s) : "memory");
+}
+#endif /* NEED_EXPLICIT_BZERO */
+
 #endif /* __DAOS_COMMON_H__ */

--- a/src/pool/cli.c
+++ b/src/pool/cli.c
@@ -423,6 +423,8 @@ pool_connect_cp(tse_task_t *task, void *data)
 out:
 	crt_req_decref(arg->rpc);
 	map_bulk_destroy(pci->pci_map_bulk, map_buf);
+	/* Ensure credential memory is wiped clean */
+	explicit_bzero(pci->pci_cred.iov_buf, pci->pci_cred.iov_buf_len);
 	daos_iov_free(&pci->pci_cred);
 	if (put_pool)
 		dc_pool_put(pool);
@@ -560,6 +562,8 @@ dc_pool_connect(tse_task_t *task)
 out_bulk:
 	map_bulk_destroy(pci->pci_map_bulk, map_buf);
 out_cred:
+	/* Ensure credential memory is wiped clean */
+	explicit_bzero(pci->pci_cred.iov_buf, pci->pci_cred.iov_buf_len);
 	daos_iov_free(&pci->pci_cred);
 out_req:
 	crt_req_decref(rpc);

--- a/src/security/tests/cli_security_tests.c
+++ b/src/security/tests/cli_security_tests.c
@@ -39,17 +39,20 @@ char *getenv(const char *name)
 }
 
 /* unpacked content of response body */
-static Auth__Credential *drpc_call_resp_return_auth_credential;
+static Auth__Credential *drpc_call_resp_return_auth_cred;
 char *dc_agent_sockpath;
 
 static void
 init_default_drpc_resp_auth_credential(void)
 {
-	D_ALLOC_PTR(drpc_call_resp_return_auth_credential);
-	auth__credential__init(drpc_call_resp_return_auth_credential);
+	D_ALLOC_PTR(drpc_call_resp_return_auth_cred);
+	auth__credential__init(drpc_call_resp_return_auth_cred);
 
-	D_ALLOC_PTR(drpc_call_resp_return_auth_credential->token);
-	auth__token__init(drpc_call_resp_return_auth_credential->token);
+	D_ALLOC_PTR(drpc_call_resp_return_auth_cred->token);
+	auth__token__init(drpc_call_resp_return_auth_cred->token);
+
+	D_ALLOC_PTR(drpc_call_resp_return_auth_cred->verifier);
+	auth__token__init(drpc_call_resp_return_auth_cred->verifier);
 }
 
 static void
@@ -65,13 +68,13 @@ static void
 init_drpc_resp_with_default_cred(void)
 {
 	init_default_drpc_resp_auth_credential();
-	init_drpc_resp_with_cred(drpc_call_resp_return_auth_credential);
+	init_drpc_resp_with_cred(drpc_call_resp_return_auth_cred);
 }
 
 void
 free_drpc_call_resp_auth_credential()
 {
-	auth__credential__free_unpacked(drpc_call_resp_return_auth_credential,
+	auth__credential__free_unpacked(drpc_call_resp_return_auth_cred,
 					NULL);
 }
 
@@ -292,16 +295,31 @@ test_request_credentials_fails_if_reply_token_missing(void **state)
 	d_iov_t creds;
 
 	memset(&creds, 0, sizeof(d_iov_t));
-	auth__token__free_unpacked(drpc_call_resp_return_auth_credential->token,
+	auth__token__free_unpacked(drpc_call_resp_return_auth_cred->token,
 				   NULL);
-	drpc_call_resp_return_auth_credential->token = NULL;
-	init_drpc_resp_with_cred(drpc_call_resp_return_auth_credential);
+	drpc_call_resp_return_auth_cred->token = NULL;
+	init_drpc_resp_with_cred(drpc_call_resp_return_auth_cred);
 
 	assert_int_equal(dc_sec_request_creds(&creds), -DER_PROTO);
 
 	daos_iov_free(&creds);
 }
 
+static void
+test_request_cred_fails_if_reply_verifier_missing(void **state)
+{
+	d_iov_t creds;
+
+	memset(&creds, 0, sizeof(d_iov_t));
+	auth__token__free_unpacked(drpc_call_resp_return_auth_cred->verifier,
+				   NULL);
+	drpc_call_resp_return_auth_cred->verifier = NULL;
+	init_drpc_resp_with_cred(drpc_call_resp_return_auth_cred);
+
+	assert_int_equal(dc_sec_request_creds(&creds), -DER_PROTO);
+
+	daos_iov_free(&creds);
+}
 static void
 test_request_credentials_fails_if_reply_cred_status(void **state)
 {
@@ -328,9 +346,9 @@ test_request_credentials_returns_raw_bytes(void **state)
 	 * Credential bytes == raw bytes of the packed Auth__Credential
 	 */
 	expected_len = auth__credential__get_packed_size(
-			drpc_call_resp_return_auth_credential);
+			drpc_call_resp_return_auth_cred);
 	D_ALLOC(expected_data, expected_len);
-	auth__credential__pack(drpc_call_resp_return_auth_credential,
+	auth__credential__pack(drpc_call_resp_return_auth_cred,
 			expected_data);
 
 	assert_int_equal(dc_sec_request_creds(&creds), DER_SUCCESS);
@@ -378,6 +396,8 @@ main(void)
 			test_request_credentials_fails_if_reply_token_missing),
 		SECURITY_UTEST(
 			test_request_credentials_fails_if_reply_cred_missing),
+		SECURITY_UTEST(
+			test_request_cred_fails_if_reply_verifier_missing),
 		SECURITY_UTEST(
 			test_request_credentials_fails_if_reply_cred_status),
 		SECURITY_UTEST(


### PR DESCRIPTION
Security credentials could be grabbed from a core dump or memory dump and used
later if not freed securely. Implement a secure erase of the memory used for
the security credential.

Master-PR: https://github.com/daos-stack/daos/pull/4690

Signed-off-by: David Quigley <david.quigley@intel.com>