### PR TITLE
DAOS-3105 control: Scrub engine environment

### DIFF
--- a/src/control/server/engine/exec.go
+++ b/src/control/server/engine/exec.go
@@ -53,10 +53,7 @@ func (r *Runner) run(ctx context.Context, args, env []string) error {
 		logFn:  r.log.Error,
 		prefix: fmt.Sprintf("%s:%d", engineBin, r.Config.Index),
 	}
-	// FIXME(DAOS-3105): This shouldn't be the default. The command environment
-	// should be constructed from values in the configuration. This probably
-	// can't go away until PMIx support is removed, though.
-	cmd.Env = mergeEnvVars(os.Environ(), env)
+	cmd.Env = env
 
 	cmd.SysProcAttr = &syscall.SysProcAttr{
 		// I/O Engine should get a SIGKILL if this process dies.
@@ -70,7 +67,7 @@ func (r *Runner) run(ctx context.Context, args, env []string) error {
 	}
 
 	r.log.Debugf("%s:%d args: %s", engineBin, r.Config.Index, args)
-	r.log.Debugf("%s:%d env: %s", engineBin, r.Config.Index, env)
+	r.log.Debugf("%s:%d env: %s", engineBin, r.Config.Index, cmd.Env)
 	r.log.Infof("Starting I/O Engine instance %d: %s", r.Config.Index, binPath)
 
 	if err := cmd.Start(); err != nil {
@@ -96,6 +93,7 @@ func (r *Runner) Start(ctx context.Context, errOut chan<- error) error {
 	if err != nil {
 		return err
 	}
+	env = mergeEnvVars(cleanEnvVars(os.Environ(), r.Config.EnvPassThrough), env)
 
 	go func() {
 		errOut <- r.run(ctx, args, env)

--- a/src/control/server/engine/exec_test.go
+++ b/src/control/server/engine/exec_test.go
@@ -95,7 +95,8 @@ func TestRunnerContextExit(t *testing.T) {
 	log, buf := logging.NewTestLogger(t.Name())
 	defer common.ShowBufferOnFailure(t, buf)
 
-	cfg := NewConfig()
+	cfg := NewConfig().
+		WithEnvPassThrough(testModeVar, "LD_LIBRARY_PATH")
 	cfg.Index = 9
 
 	runner := NewRunner(log, cfg)
@@ -119,13 +120,21 @@ func TestRunnerNormalExit(t *testing.T) {
 
 	// set this to control the behavior in TestMain()
 	os.Setenv(testModeVar, "RunnerNormalExit")
-	// verify that user env gets overridden by config
+	// verify that bad user env is scrubbed
+	os.Setenv("FI_VERBS_PREFER_XRC", "1")
+	// verify that allowed user env gets overridden by config
 	os.Setenv("OFI_INTERFACE", "bob0")
+	// verify that allowed user env without a config override is passed through
+	allowedUserEnv := "MOOD"
+	allowedUserVal := "happy"
+	os.Setenv(allowedUserEnv, allowedUserVal)
 
 	log, buf := logging.NewTestLogger(t.Name())
 	defer common.ShowBufferOnFailure(t, buf)
 
 	cfg := NewConfig().
+		WithEnvPassThrough(testModeVar, "LD_LIBRARY_PATH",
+			"OFI_INTERFACE", allowedUserEnv).
 		WithTargetCount(42).
 		WithHelperStreamCount(1).
 		WithFabricInterface("qib0").
@@ -153,6 +162,7 @@ func TestRunnerNormalExit(t *testing.T) {
 		"CRT_TIMEOUT=30",
 		"OFI_INTERFACE=qib0",
 		"D_LOG_MASK=DEBUG,MGMT=DEBUG,RPC=ERR,MEM=ERR",
+		allowedUserEnv + "=" + allowedUserVal,
 	}
 	sort.Strings(env)
 	wantEnv := strings.Join(env, " ")

--- a/utils/nlt_server.yaml
+++ b/utils/nlt_server.yaml
@@ -4,7 +4,6 @@ provider: ofi+sockets
 socket_dir: /tmp/dnt_sockets
 nr_hugepages: 4096
 control_log_mask: DEBUG
-control_log_file: /tmp/dnt_control.log
 access_points: ['localhost:10001']
 engines:
 -
@@ -13,14 +12,12 @@ engines:
   nr_xs_helpers: 2
   fabric_iface: eth0
   fabric_iface_port: 31416
-  log_mask: DEBUG
-  log_file: /tmp/dnt_server.log
   env_vars:
   - DAOS_MD_CAP=1024
   - CRT_CTX_SHARE_ADDR=0
-  - CRT_TIMEOUT=30
   - FI_SOCKETS_MAX_CONN_RETRY=1
   - FI_SOCKETS_CONN_TIMEOUT=2000
+  - DAOS_DISABLE_REQ_FWD=1
   scm_mount: /mnt/daos
   scm_class: ram
   scm_size: 32

--- a/utils/node_local_test.py
+++ b/utils/node_local_test.py
@@ -278,10 +278,13 @@ def load_conf():
     ofh.close()
     return NLTConf(conf)
 
-def get_base_env():
+def get_base_env(clean=False):
     """Return the base set of env vars needed for DAOS"""
 
-    env = os.environ.copy()
+    if clean:
+        env = OrderedDict()
+    else:
+        env = os.environ.copy()
     env['DD_MASK'] = 'all'
     env['DD_SUBSYS'] = 'all'
     env['D_LOG_MASK'] = 'DEBUG'
@@ -354,31 +357,7 @@ class DaosServer():
     def start(self):
         """Start a DAOS server"""
 
-        daos_server = os.path.join(self.conf['PREFIX'], 'bin', 'daos_server')
-
-        self_dir = os.path.dirname(os.path.abspath(__file__))
-
-        # Create a server yaml file.  To do this open and copy the
-        # nlt_server.yaml file in the current directory, but overwrite
-        # the server log file with a temporary file so that multiple
-        # server runs do not overwrite each other.
-        scfd = open(os.path.join(self_dir, 'nlt_server.yaml'), 'r')
-
-        scyaml = yaml.safe_load(scfd)
-        scyaml['engines'][0]['log_file'] = self.server_log.name
-        if self.conf.args.server_debug:
-            scyaml['control_log_mask'] = 'ERROR'
-            scyaml['engines'][0]['log_mask'] = self.conf.args.server_debug
-        scyaml['control_log_file'] = self.control_log.name
-
-        self._yaml_file = tempfile.NamedTemporaryFile(
-            prefix='nlt-server-config-',
-            suffix='.yaml')
-
-        self._yaml_file.write(yaml.dump(scyaml, encoding='utf-8'))
-        self._yaml_file.flush()
-
-        server_env = get_base_env()
+        server_env = get_base_env(clean=True)
 
         if self.valgrind:
             valgrind_args = ['--fair-sched=yes',
@@ -406,11 +385,37 @@ class DaosServer():
             server_env['PATH'] = '{}:{}'.format(self._io_server_dir.name,
                                                 server_env['PATH'])
 
+        daos_server = os.path.join(self.conf['PREFIX'], 'bin', 'daos_server')
+
+        self_dir = os.path.dirname(os.path.abspath(__file__))
+
+        # Create a server yaml file.  To do this open and copy the
+        # nlt_server.yaml file in the current directory, but overwrite
+        # the server log file with a temporary file so that multiple
+        # server runs do not overwrite each other.
+        scfd = open(os.path.join(self_dir, 'nlt_server.yaml'), 'r')
+
+        scyaml = yaml.safe_load(scfd)
+        scyaml['engines'][0]['log_file'] = self.server_log.name
+        if self.conf.args.server_debug:
+            scyaml['control_log_mask'] = 'ERROR'
+            scyaml['engines'][0]['log_mask'] = self.conf.args.server_debug
+        scyaml['control_log_file'] = self.control_log.name
+
+        for (key, value) in server_env.items():
+            scyaml['engines'][0]['env_vars'].append('{}={}'.format(key, value))
+
+        self._yaml_file = tempfile.NamedTemporaryFile(
+            prefix='nlt-server-config-',
+            suffix='.yaml')
+
+        self._yaml_file.write(yaml.dump(scyaml, encoding='utf-8'))
+        self._yaml_file.flush()
+
         cmd = [daos_server, '--config={}'.format(self._yaml_file.name),
                'start', '-t' '4', '--insecure', '-d', self.agent_dir]
 
-        server_env['DAOS_DISABLE_REQ_FWD'] = '1'
-        self._sp = subprocess.Popen(cmd, env=server_env)
+        self._sp = subprocess.Popen(cmd)
 
         agent_config = os.path.join(self_dir, 'nlt_agent.yaml')
 
@@ -425,8 +430,7 @@ class DaosServer():
         if not self.conf.args.server_debug:
             agent_cmd.append('--debug')
 
-        self._agent = subprocess.Popen(agent_cmd,
-                                       env=os.environ.copy())
+        self._agent = subprocess.Popen(agent_cmd)
         self.conf.agent_dir = self.agent_dir
         self.running = True
 


### PR DESCRIPTION
By default, all environment variables provided to the
engine subprocesses must be set by the control plane.

An optional per-engine config parameter (env_pass_through)
may be set to pass through variables set before the control
plane was started.

Master-PR: https://github.com/daos-stack/daos/pull/4947