### PR TITLE
DAOS-7010 control: dmg system query output consistent for single rank

### DIFF
--- a/src/control/cmd/dmg/pretty/system.go
+++ b/src/control/cmd/dmg/pretty/system.go
@@ -108,21 +108,6 @@ func printSystemQueryVerbose(out io.Writer, members system.Members) {
 	fmt.Fprintln(out, formatter.Format(table))
 }
 
-func printSystemQuerySingle(out io.Writer, members system.Members) {
-	m := members[0]
-
-	table := []txtfmt.TableRow{
-		{"address": m.Addr.String()},
-		{"uuid": m.UUID.String()},
-		{"fault domain": m.FaultDomain.String()},
-		{"status": m.State().String()},
-		{"reason": m.Info},
-	}
-
-	title := fmt.Sprintf("Rank %d", m.Rank)
-	fmt.Fprintln(out, txtfmt.FormatEntity(title, table))
-}
-
 // PrintSystemQueryResponse generates a human-readable representation of the supplied
 // SystemQueryResp struct and writes it to the supplied io.Writer.
 func PrintSystemQueryResponse(out, outErr io.Writer, resp *control.SystemQueryResp, opts ...PrintConfigOption) error {
@@ -133,8 +118,6 @@ func PrintSystemQueryResponse(out, outErr io.Writer, resp *control.SystemQueryRe
 	switch {
 	case len(resp.Members) == 0:
 		fmt.Fprintln(out, "Query matches no ranks in system")
-	case len(resp.Members) == 1:
-		printSystemQuerySingle(out, resp.Members)
 	case getPrintConfig(opts...).Verbose:
 		printSystemQueryVerbose(out, resp.Members)
 	default:

--- a/src/control/cmd/dmg/pretty/system_test.go
+++ b/src/control/cmd/dmg/pretty/system_test.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2020-2021 Intel Corporation.
+// (C) Copyright 2021 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -112,13 +112,9 @@ Unknown 3 ranks: 7-9
 				},
 			},
 			expPrintStr: `
-Rank 0
-------
-  address      : 127.0.0.0:10001                     
-  uuid         : 00000000-0000-0000-0000-000000000000
-  fault domain : /                                   
-  status       : Joined                              
-  reason       :                                     
+Rank State  
+---- -----  
+0    Joined 
 
 `,
 		},
@@ -131,13 +127,41 @@ Rank 0
 			absentHosts: "foo[7,8,9]",
 			absentRanks: "7-9",
 			expPrintStr: `
-Rank 0
-------
-  address      : 127.0.0.0:10001                     
-  uuid         : 00000000-0000-0000-0000-000000000000
-  fault domain : /                                   
-  status       : Joined                              
-  reason       :                                     
+Rank  State        
+----  -----        
+[7-9] Unknown Rank 
+0     Joined       
+
+Unknown 3 hosts: foo[7-9]
+`,
+		},
+		"single response verbose": {
+			resp: &control.SystemQueryResp{
+				Members: Members{
+					MockMember(t, 0, MemberStateJoined),
+				},
+			},
+			verbose: true,
+			expPrintStr: `
+Rank UUID                                 Control Address Fault Domain State  Reason 
+---- ----                                 --------------- ------------ -----  ------ 
+0    00000000-0000-0000-0000-000000000000 127.0.0.0:10001 /            Joined        
+
+`,
+		},
+		"single response verbose with missing hosts and ranks": {
+			resp: &control.SystemQueryResp{
+				Members: Members{
+					MockMember(t, 0, MemberStateJoined),
+				},
+			},
+			absentHosts: "foo[7,8,9]",
+			absentRanks: "7-9",
+			verbose:     true,
+			expPrintStr: `
+Rank UUID                                 Control Address Fault Domain State  Reason 
+---- ----                                 --------------- ------------ -----  ------ 
+0    00000000-0000-0000-0000-000000000000 127.0.0.0:10001 /            Joined        
 
 Unknown 3 hosts: foo[7-9]
 Unknown 3 ranks: 7-9


### PR DESCRIPTION
Make dmg system query [--verbose] output format when displaying results
for a single rank consistent with the output format when displaying
multiple rank results.

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>