### PR TITLE
DAOS-6938 tests: keep the pool after racer test if required

### DIFF
--- a/src/vos/tests/vts_common.c
+++ b/src/vos/tests/vts_common.c
@@ -298,8 +298,11 @@ pool_fini(struct dts_context *tsc)
 	int	rc;
 
 	vos_pool_close(tsc->tsc_poh);
-	rc = vos_pool_destroy(tsc->tsc_pmem_file, tsc->tsc_pool_uuid);
-	D_ASSERTF(rc == 0 || rc == -DER_NONEXIST, "rc="DF_RC"\n", DP_RC(rc));
+	if (tsc_create_pool(tsc)) {
+		rc = vos_pool_destroy(tsc->tsc_pmem_file, tsc->tsc_pool_uuid);
+		D_ASSERTF(rc == 0 || rc == -DER_NONEXIST, "rc="DF_RC"\n",
+			  DP_RC(rc));
+	}
 }
 
 static int


### PR DESCRIPTION
By default, daos_racer will automatically create pool for test.
But if the user wants to use existing pool via "-p" option, then
no pool will be created by daos_racer. Under such case, after the
daos_racer finished, it should not destroy such specified pool.

Signed-off-by: Fan Yong <fan.yong@intel.com>