### PR TITLE
DAOS-3105 test: Pass env from NLT to engine though config file.

### DIFF
--- a/utils/nlt_server.yaml
+++ b/utils/nlt_server.yaml
@@ -4,7 +4,6 @@ provider: ofi+sockets
 socket_dir: /tmp/dnt_sockets
 nr_hugepages: 4096
 control_log_mask: DEBUG
-control_log_file: /tmp/dnt_control.log
 access_points: ['localhost:10001']
 engines:
 -
@@ -13,14 +12,12 @@ engines:
   nr_xs_helpers: 2
   fabric_iface: eth0
   fabric_iface_port: 31416
-  log_mask: DEBUG
-  log_file: /tmp/dnt_server.log
   env_vars:
   - DAOS_MD_CAP=1024
   - CRT_CTX_SHARE_ADDR=0
-  - CRT_TIMEOUT=30
   - FI_SOCKETS_MAX_CONN_RETRY=1
   - FI_SOCKETS_CONN_TIMEOUT=2000
+  - DAOS_DISABLE_REQ_FWD=1
   scm_mount: /mnt/daos
   scm_class: ram
   scm_size: 32


### PR DESCRIPTION
Now the engine scrubs the environment by default configure
NLT to set all env vars via the config file.

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>