### PR TITLE
DAOS-7015 event: proper event handing in case of progress errors

### DIFF
--- a/src/client/api/event.c
+++ b/src/client/api/event.c
@@ -1251,6 +1251,8 @@ daos_event_priv_wait()
 		/** progress succeeded, loop can exit if event completed */
 		if (rc == 0) {
 			rc = ev_thpriv.ev_error;
+			if (rc)
+				break;
 			continue;
 		}
 
@@ -1263,8 +1265,7 @@ daos_event_priv_wait()
 		 * the private event first so it can be resused.
 		 */
 		rc2 = daos_event_priv_reset();
-		if (rc2)
-			return rc2;
+		D_ASSERT(rc2 == 0);
 		ev_thpriv_is_init = true;
 		break;
 	}


### PR DESCRIPTION
- exit loop if event error is reported to match original behavior

Signed-off-by: Mohamad Chaarawi <mohamad.chaarawi@intel.com>