### PR TITLE
CART-831 TEST: add support for arbitrary envariables in yaml files (2)

### DIFF
--- a/src/tests/ftest/cart/corpc/cart_corpc_five_node.py
+++ b/src/tests/ftest/cart/corpc/cart_corpc_five_node.py
@@ -26,6 +26,7 @@ class CartCoRpcFiveNodeTest(TestWithoutServers):
     def setUp(self):
         """ Test setup """
         print("Running setup\n")
+        super(CartCoRpcFiveNodeTest, self).setUp()
         self.utils = CartUtils()
         self.env = self.utils.get_env(self)
 

--- a/src/tests/ftest/cart/corpc/cart_corpc_five_node.yaml
+++ b/src/tests/ftest/cart/corpc/cart_corpc_five_node.yaml
@@ -1,13 +1,14 @@
 # change host names to your reserved nodes, the
 # required quantity is indicated by the placeholders
 
-defaultENV:
-  #!filter-only : /run/envs_CRT_CTX_SHARE_ADDR/no_sep
-  #!filter-only : /run/tests/corpc_prefwd
-  D_LOG_MASK: "WARN,CORPC=DEBUG"
-  CRT_PHY_ADDR_STR: "ofi+sockets"
-  OFI_INTERFACE: "eth0"
-  test_servers_CRT_CTX_NUM: "0"
+ENV:
+  default:
+    #!filter-only : /run/envs_CRT_CTX_SHARE_ADDR/no_sep
+    #!filter-only : /run/tests/corpc_prefwd
+    - D_LOG_MASK: "WARN,CORPC=DEBUG"
+    - CRT_PHY_ADDR_STR: "ofi+sockets"
+    - OFI_INTERFACE: "eth0"
+    - test_servers_CRT_CTX_NUM: "0"
 env_CRT_CTX_SHARE_ADDR: !mux
   no_sep:
     env: no_sep

--- a/src/tests/ftest/cart/corpc/cart_corpc_one_node.py
+++ b/src/tests/ftest/cart/corpc/cart_corpc_one_node.py
@@ -26,6 +26,7 @@ class CartCoRpcOneNodeTest(TestWithoutServers):
     def setUp(self):
         """ Test setup """
         print("Running setup\n")
+        super(CartCoRpcOneNodeTest, self).setUp()
         self.utils = CartUtils()
         self.env = self.utils.get_env(self)
 

--- a/src/tests/ftest/cart/corpc/cart_corpc_one_node.yaml
+++ b/src/tests/ftest/cart/corpc/cart_corpc_one_node.yaml
@@ -1,13 +1,14 @@
 # change host names to your reserved nodes, the
 # required quantity is indicated by the placeholders
 
-defaultENV:
-  #!filter-only : /run/envs_CRT_CTX_SHARE_ADDR/sep
-  #!filter-only : /run/tests/corpc_prefwd
-  D_LOG_MASK: "WARN,CORPC=DEBUG"
-  CRT_PHY_ADDR_STR: "ofi+sockets"
-  OFI_INTERFACE: "eth0"
-  test_servers_CRT_CTX_NUM: "16"
+ENV:
+  default:
+    #!filter-only : /run/envs_CRT_CTX_SHARE_ADDR/sep
+    #!filter-only : /run/tests/corpc_prefwd
+    - D_LOG_MASK: "WARN,CORPC=DEBUG"
+    - CRT_PHY_ADDR_STR: "ofi+sockets"
+    - OFI_INTERFACE: "eth0"
+    - test_servers_CRT_CTX_NUM: "16"
 env_CRT_CTX_SHARE_ADDR: !mux
   sep:
     env: sep

--- a/src/tests/ftest/cart/corpc/cart_corpc_two_node.py
+++ b/src/tests/ftest/cart/corpc/cart_corpc_two_node.py
@@ -26,6 +26,7 @@ class CartCoRpcTwoNodeTest(TestWithoutServers):
     def setUp(self):
         """ Test setup """
         print("Running setup\n")
+        super(CartCoRpcTwoNodeTest, self).setUp()
         self.utils = CartUtils()
         self.env = self.utils.get_env(self)
 

--- a/src/tests/ftest/cart/corpc/cart_corpc_two_node.yaml
+++ b/src/tests/ftest/cart/corpc/cart_corpc_two_node.yaml
@@ -1,13 +1,14 @@
 # change host names to your reserved nodes, the
 # required quantity is indicated by the placeholders
 
-defaultENV:
-  #!filter-only : /run/envs_CRT_CTX_SHARE_ADDR/sep
-  #!filter-only : /run/tests/corpc_prefwd
-  D_LOG_MASK: "WARN,CORPC=DEBUG"
-  CRT_PHY_ADDR_STR: "ofi+sockets"
-  OFI_INTERFACE: "eth0"
-  test_servers_CRT_CTX_NUM: "16"
+ENV:
+  default:
+    #!filter-only : /run/envs_CRT_CTX_SHARE_ADDR/sep
+    #!filter-only : /run/tests/corpc_prefwd
+    - D_LOG_MASK: "WARN,CORPC=DEBUG"
+    - CRT_PHY_ADDR_STR: "ofi+sockets"
+    - OFI_INTERFACE: "eth0"
+    - test_servers_CRT_CTX_NUM: "16"
 env_CRT_CTX_SHARE_ADDR: !mux
   sep:
     env: sep

--- a/src/tests/ftest/cart/ctl/cart_ctl_five_node.py
+++ b/src/tests/ftest/cart/ctl/cart_ctl_five_node.py
@@ -26,6 +26,7 @@ class CartCtlFiveNodeTest(TestWithoutServers):
     def setUp(self):
         """ Test setup """
         print("Running setup\n")
+        super(CartCtlFiveNodeTest, self).setUp()
         self.utils = CartUtils()
         self.env = self.utils.get_env(self)
 

--- a/src/tests/ftest/cart/ctl/cart_ctl_five_node.yaml
+++ b/src/tests/ftest/cart/ctl/cart_ctl_five_node.yaml
@@ -1,14 +1,15 @@
 # change host names to your reserved nodes, the
 # required quantity is indicated by the placeholders
 
-defaultENV:
-  #!filter-only : /run/env_CRT_CTX_SHARE_ADDR/sep
-  #!filter-only : /run/tests/ctl
-  D_LOG_MASK: "WARN"
-  CRT_PHY_ADDR_STR: "ofi+sockets"
-  OFI_INTERFACE: "eth0"
-  test_servers_CRT_CTX_NUM: "0"
-  test_clients_CRT_CTX_NUM: "0"
+ENV:
+  default:
+    #!filter-only : /run/env_CRT_CTX_SHARE_ADDR/sep
+    #!filter-only : /run/tests/ctl
+    - D_LOG_MASK: "WARN"
+    - CRT_PHY_ADDR_STR: "ofi+sockets"
+    - OFI_INTERFACE: "eth0"
+    - test_servers_CRT_CTX_NUM: "0"
+    - test_clients_CRT_CTX_NUM: "0"
 env_CRT_CTX_SHARE_ADDR: !mux
   no_sep:
     env: no_sep

--- a/src/tests/ftest/cart/ctl/cart_ctl_one_node.py
+++ b/src/tests/ftest/cart/ctl/cart_ctl_one_node.py
@@ -26,6 +26,7 @@ class CartCtlOneNodeTest(TestWithoutServers):
     def setUp(self):
         """ Test setup """
         print("Running setup\n")
+        super(CartCtlOneNodeTest, self).setUp()
         self.utils = CartUtils()
         self.env = self.utils.get_env(self)
 

--- a/src/tests/ftest/cart/ctl/cart_ctl_one_node.yaml
+++ b/src/tests/ftest/cart/ctl/cart_ctl_one_node.yaml
@@ -1,14 +1,15 @@
 # change host names to your reserved nodes, the
 # required quantity is indicated by the placeholders
 
-defaultENV:
-  #!filter-only : /run/env_CRT_CTX_SHARE_ADDR/sep
-  #!filter-only : /run/tests/ctl
-  D_LOG_MASK: "WARN"
-  CRT_PHY_ADDR_STR: "ofi+sockets"
-  OFI_INTERFACE: "eth0"
-  test_servers_CRT_CTX_NUM: "16"
-  test_clients_CRT_CTX_NUM: "16"
+ENV:
+  default:
+    #!filter-only : /run/env_CRT_CTX_SHARE_ADDR/sep
+    #!filter-only : /run/tests/ctl
+    - D_LOG_MASK: "WARN"
+    - CRT_PHY_ADDR_STR: "ofi+sockets"
+    - OFI_INTERFACE: "eth0"
+    - test_servers_CRT_CTX_NUM: "16"
+    - test_clients_CRT_CTX_NUM: "16"
 env_CRT_CTX_SHARE_ADDR: !mux
   sep:
     env: sep

--- a/src/tests/ftest/cart/ghost_rank_rpc/cart_ghost_rank_prc_one_node.py
+++ b/src/tests/ftest/cart/ghost_rank_rpc/cart_ghost_rank_prc_one_node.py
@@ -26,6 +26,7 @@ class CartCoRpcOneNodeTest(TestWithoutServers):
     def setUp(self):
         """ Test setup """
         print("Running setup\n")
+        super(CartCoRpcOneNodeTest, self).setUp()
         self.utils = CartUtils()
         self.env = self.utils.get_env(self)
 

--- a/src/tests/ftest/cart/ghost_rank_rpc/cart_ghost_rank_prc_one_node.yaml
+++ b/src/tests/ftest/cart/ghost_rank_rpc/cart_ghost_rank_prc_one_node.yaml
@@ -1,13 +1,14 @@
 # change host names to your reserved nodes, the
 # required quantity is indicated by the placeholders
 
-defaultENV:
-  #!filter-only : /run/envs_CRT_CTX_SHARE_ADDR/sep
-  #!filter-only : /run/tests/corpc_prefwd
-  D_LOG_MASK: "WARN,RPC=DEBUG,HG=DEBUG"
-  CRT_PHY_ADDR_STR: "ofi+sockets"
-  OFI_INTERFACE: "eth0"
-  test_servers_CRT_CTX_NUM: "16"
+ENV:
+  default:
+    #!filter-only : /run/envs_CRT_CTX_SHARE_ADDR/sep
+    #!filter-only : /run/tests/corpc_prefwd
+    - D_LOG_MASK: "WARN,RPC=DEBUG,HG=DEBUG"
+    - CRT_PHY_ADDR_STR: "ofi+sockets"
+    - OFI_INTERFACE: "eth0"
+    - test_servers_CRT_CTX_NUM: "16"
 env_CRT_CTX_SHARE_ADDR: !mux
   sep:
     env: sep

--- a/src/tests/ftest/cart/group_test/group_test.py
+++ b/src/tests/ftest/cart/group_test/group_test.py
@@ -26,6 +26,7 @@ class GroupTest(TestWithoutServers):
     def setUp(self):
         """ Test setup """
         print("Running setup\n")
+        super(GroupTest, self).setUp()
         self.utils = CartUtils()
         self.env = self.utils.get_env(self)
 

--- a/src/tests/ftest/cart/group_test/group_test.yaml
+++ b/src/tests/ftest/cart/group_test/group_test.yaml
@@ -1,11 +1,12 @@
 # change host names to your reserved nodes, the
 # required quantity is indicated by the placeholders
 
-defaultENV:
-  #!filter-only : /run/tests/no_pmix_launcher
-  D_LOG_MASK: "WARN,RPC=DEBUG,HG=DEBUG"
-  CRT_PHY_ADDR_STR: "ofi+sockets"
-  OFI_INTERFACE: "eth0"
+ENV:
+  default:
+    #!filter-only : /run/tests/no_pmix_launcher
+    - D_LOG_MASK: "WARN,RPC=DEBUG,HG=DEBUG"
+    - CRT_PHY_ADDR_STR: "ofi+sockets"
+    - OFI_INTERFACE: "eth0"
 hosts: !mux
   hosts_1:
     config: one_node

--- a/src/tests/ftest/cart/iv/cart_iv_one_node.py
+++ b/src/tests/ftest/cart/iv/cart_iv_one_node.py
@@ -89,6 +89,7 @@ class CartIvOneNodeTest(TestWithoutServers):
     def setUp(self):
         """ Test setup """
         print("Running setup\n")
+        super(CartIvOneNodeTest, self).setUp()
         self.utils = CartUtils()
         self.env = self.utils.get_env(self)
 

--- a/src/tests/ftest/cart/iv/cart_iv_one_node.yaml
+++ b/src/tests/ftest/cart/iv/cart_iv_one_node.yaml
@@ -1,14 +1,15 @@
 # change host names to your reserved nodes, the
 # required quantity is indicated by the placeholders
 
-defaultENV:
-  #!filter-only : /run/env_CRT_CTX_SHARE_ADDR/no_sep
-  #!filter-only : /run/tests/iv
-  D_LOG_MASK: "WARN,IV=DEBUG"
-  CRT_PHY_ADDR_STR: "ofi+sockets"
-  OFI_INTERFACE: "eth0"
-  test_servers_CRT_CTX_NUM: "2"
-  test_clients_CRT_CTX_NUM: "2"
+ENV:
+  default:
+    #!filter-only : /run/env_CRT_CTX_SHARE_ADDR/no_sep
+    #!filter-only : /run/tests/iv
+    - D_LOG_MASK: "WARN,IV=DEBUG"
+    - CRT_PHY_ADDR_STR: "ofi+sockets"
+    - OFI_INTERFACE: "eth0"
+    - test_servers_CRT_CTX_NUM: "2"
+    - test_clients_CRT_CTX_NUM: "2"
 env_CRT_CTX_SHARE_ADDR: !mux
   sep:
     env: sep

--- a/src/tests/ftest/cart/iv/cart_iv_two_node.py
+++ b/src/tests/ftest/cart/iv/cart_iv_two_node.py
@@ -82,6 +82,7 @@ class CartIvTwoNodeTest(TestWithoutServers):
     def setUp(self):
         """ Test setup """
         print("Running setup\n")
+        super(CartIvTwoNodeTest, self).setUp()
         self.utils = CartUtils()
         self.env = self.utils.get_env(self)
 

--- a/src/tests/ftest/cart/iv/cart_iv_two_node.yaml
+++ b/src/tests/ftest/cart/iv/cart_iv_two_node.yaml
@@ -1,14 +1,15 @@
 # change host names to your reserved nodes, the
 # required quantity is indicated by the placeholders
 
-defaultENV:
-  #!filter-only : /run/env_CRT_CTX_SHARE_ADDR/no_sep
-  #!filter-only : /run/tests/iv
-  D_LOG_MASK: "WARN,IV=DEBUG"
-  CRT_PHY_ADDR_STR: "ofi+sockets"
-  OFI_INTERFACE: "eth0"
-  test_servers_CRT_CTX_NUM: "2"
-  test_clients_CRT_CTX_NUM: "2"
+ENV:
+  default:
+    #!filter-only : /run/env_CRT_CTX_SHARE_ADDR/no_sep
+    #!filter-only : /run/tests/iv
+    - D_LOG_MASK: "WARN,IV=DEBUG"
+    - CRT_PHY_ADDR_STR: "ofi+sockets"
+    - OFI_INTERFACE: "eth0"
+    - test_servers_CRT_CTX_NUM: "2"
+    - test_clients_CRT_CTX_NUM: "2"
 env_CRT_CTX_SHARE_ADDR: !mux
   sep:
     env: sep

--- a/src/tests/ftest/cart/no_pmix/cart_nopmix_multictx_one_node.py
+++ b/src/tests/ftest/cart/no_pmix/cart_nopmix_multictx_one_node.py
@@ -9,8 +9,9 @@ from __future__ import print_function
 
 import sys
 import subprocess
+import os
 
-from apricot       import TestWithoutServers
+from apricot import TestWithoutServers
 
 sys.path.append('./util')
 
@@ -27,17 +28,8 @@ class CartNoPmixOneNodeTest(TestWithoutServers):
     def setUp(self):
         """ Test setup """
         print("Running setup\n")
+        super(CartNoPmixOneNodeTest, self).setUp()
         self.utils = CartUtils()
-        self.env = self.utils.get_env(self)
-        crt_phy_addr = self.params.get("CRT_PHY_ADDR_STR", '/run/defaultENV/')
-        ofi_interface = self.params.get("OFI_INTERFACE", '/run/defaultENV/')
-        ofi_ctx_num = self.params.get("CRT_CTX_NUM", '/run/defaultENV/')
-        ofi_share_addr = self.params.get("CRT_CTX_SHARE_ADDR",
-                                         '/run/defaultENV/')
-        self.pass_env = {"CRT_PHY_ADDR_STR": crt_phy_addr,
-                         "OFI_INTERFACE": ofi_interface,
-                         "CRT_CTX_SHARE_ADDR": ofi_share_addr,
-                         "CRT_CTX_NUM": ofi_ctx_num}
 
     def tearDown(self):
         """ Tear down """
@@ -52,11 +44,31 @@ class CartNoPmixOneNodeTest(TestWithoutServers):
         :avocado: tags=all,cart,pr,daily_regression,no_pmix,one_node
         """
 
+        crt_phy_addr = os.environ.get("CRT_PHY_ADDR_STR")
+        ofi_interface = os.environ.get("OFI_INTERFACE")
+        ofi_ctx_num = os.environ.get("CRT_CTX_NUM")
+        ofi_share_addr = os.environ.get("CRT_CTX_SHARE_ADDR")
+
+        # env dict keys and values must all be of string type
+        if not isinstance(crt_phy_addr, ("".__class__, u"".__class__)):
+            crt_phy_addr = ""
+        if not isinstance(ofi_interface, ("".__class__, u"".__class__)):
+            ofi_interface = ""
+        if not isinstance(ofi_ctx_num, ("".__class__, u"".__class__)):
+            ofi_ctx_num = ""
+        if not isinstance(ofi_share_addr, ("".__class__, u"".__class__)):
+            ofi_share_addr = ""
+
+        pass_env = {"CRT_PHY_ADDR_STR": crt_phy_addr,
+                    "OFI_INTERFACE": ofi_interface,
+                    "CRT_CTX_SHARE_ADDR": ofi_share_addr,
+                    "CRT_CTX_NUM": ofi_ctx_num}
+
         cmd = self.params.get("tst_bin", '/run/tests/*/')
 
         self.utils.print("\nTest cmd : %s\n" % cmd)
 
-        test_env = self.pass_env
+        test_env = pass_env
         p = subprocess.Popen([cmd], env=test_env, stdout=subprocess.PIPE)
 
         rc = self.utils.wait_process(p, 30)
@@ -66,7 +78,3 @@ class CartNoPmixOneNodeTest(TestWithoutServers):
             self.fail("Test failed.\n")
 
         self.utils.print("Finished waiting for {}".format(p))
-
-
-if __name__ == "__main__":
-    main()

--- a/src/tests/ftest/cart/no_pmix/cart_nopmix_multictx_one_node.yaml
+++ b/src/tests/ftest/cart/no_pmix/cart_nopmix_multictx_one_node.yaml
@@ -1,13 +1,15 @@
 # change host names to your reserved nodes, the
 # required quantity is indicated by the placeholders
 
-defaultENV:
-  #!filter-only : /run/tests/no_pmix_multi_ctx
-  D_LOG_MASK: "WARN"
-  CRT_PHY_ADDR_STR: "ofi+sockets"
-  OFI_INTERFACE: "eth0"
-  CRT_CTX_NUM: "8"
-  CRT_CTX_SHARE_ADDR: "0"
+ENV:
+  default:
+    #!filter-only : /run/env_CRT_CTX_SHARE_ADDR/sep
+    #!filter-only : /run/tests/rpc_error
+    - D_LOG_MASK: "WARN"
+    - CRT_PHY_ADDR_STR: "ofi+sockets"
+    - OFI_INTERFACE: "eth0"
+    - CRT_CTX_NUM: "8"
+    - CRT_CTX_SHARE_ADDR: "0"
 tests: !mux
   no_pmix_multi_ctx:
     name: no_pmix_multi_ctx

--- a/src/tests/ftest/cart/nopmix_launcher/cart_nopmix_launcher_one_node.py
+++ b/src/tests/ftest/cart/nopmix_launcher/cart_nopmix_launcher_one_node.py
@@ -7,6 +7,7 @@
 
 from __future__ import print_function
 
+import os
 import sys
 
 from apricot       import TestWithoutServers
@@ -26,6 +27,7 @@ class CartNoPmixLauncherOneNodeTest(TestWithoutServers):
     def setUp(self):
         """ Test setup """
         print("Running setup\n")
+        super(CartNoPmixLauncherOneNodeTest, self).setUp()
         self.utils = CartUtils()
         self.env = self.utils.get_env(self)
 
@@ -45,10 +47,10 @@ class CartNoPmixLauncherOneNodeTest(TestWithoutServers):
         cli_bin = self.params.get("test_clients_bin", '/run/tests/*/')
         cli_arg = self.params.get("test_clients_arg", '/run/tests/*/')
         cli_ppn = self.params.get("test_clients_ppn", '/run/tests/*/')
-        log_mask = self.params.get("D_LOG_MASK", "/run/defaultENV/")
-        crt_phy_addr = self.params.get("CRT_PHY_ADDR_STR",
-                                       "/run/defaultENV/")
-        ofi_interface = self.params.get("OFI_INTERFACE", "/run/defaultENV/")
+
+        log_mask = os.environ.get("D_LOG_MASK")
+        crt_phy_addr = os.environ.get("CRT_PHY_ADDR_STR")
+        ofi_interface = os.environ.get("OFI_INTERFACE")
 
         srv_cmd = self.utils.build_cmd(self, self.env, "test_servers")
 

--- a/src/tests/ftest/cart/nopmix_launcher/cart_nopmix_launcher_one_node.yaml
+++ b/src/tests/ftest/cart/nopmix_launcher/cart_nopmix_launcher_one_node.yaml
@@ -1,11 +1,12 @@
 # change host names to your reserved nodes, the
 # required quantity is indicated by the placeholders
 
-defaultENV:
-  #!filter-only : /run/tests/no_pmix_launcher
-  D_LOG_MASK: "WARN"
-  CRT_PHY_ADDR_STR: "ofi+sockets"
-  OFI_INTERFACE: "eth0"
+ENV:
+  default:
+    #!filter-only : /run/tests/no_pmix_launcher
+    - D_LOG_MASK: "WARN"
+    - CRT_PHY_ADDR_STR: "ofi+sockets"
+    - OFI_INTERFACE: "eth0"
 hosts: !mux
   hosts_1:
     config: one_node

--- a/src/tests/ftest/cart/rpc/cart_rpc_one_node.py
+++ b/src/tests/ftest/cart/rpc/cart_rpc_one_node.py
@@ -26,6 +26,7 @@ class CartRpcOneNodeTest(TestWithoutServers):
     def setUp(self):
         """ Test setup """
         print("Running setup\n")
+        super(CartRpcOneNodeTest, self).setUp()
         self.utils = CartUtils()
         self.env = self.utils.get_env(self)
 

--- a/src/tests/ftest/cart/rpc/cart_rpc_one_node.yaml
+++ b/src/tests/ftest/cart/rpc/cart_rpc_one_node.yaml
@@ -1,14 +1,17 @@
 # change host names to your reserved nodes, the
 # required quantity is indicated by the placeholders
 
-defaultENV:
-  #!filter-only : /run/env_CRT_CTX_SHARE_ADDR/sep
-  #!filter-only : /run/tests/proto_np
-  D_LOG_MASK: "WARN,RPC=DEBUG,HG=DEBUG"
-  CRT_PHY_ADDR_STR: "ofi+sockets"
-  OFI_INTERFACE: "eth0"
-  test_servers_CRT_CTX_NUM: "16"
-  test_clients_CRT_CTX_NUM: "16"
+customENV:
+  MY_CUSTOM_ENV: "pineapple"
+ENV:
+  default:
+    #!filter-only : /run/env_CRT_CTX_SHARE_ADDR/sep
+    #!filter-only : /run/tests/proto_np
+    - D_LOG_MASK: "WARN,RPC=DEBUG,HG=DEBUG"
+    - CRT_PHY_ADDR_STR: "ofi+sockets"
+    - OFI_INTERFACE: "eth0"
+    - test_servers_CRT_CTX_NUM: "16"
+    - test_clients_CRT_CTX_NUM: "16"
 env_CRT_CTX_SHARE_ADDR: !mux
   sep:
     env: sep

--- a/src/tests/ftest/cart/rpc/cart_rpc_one_node_with_swim_notification_on_rank_eviction.py
+++ b/src/tests/ftest/cart/rpc/cart_rpc_one_node_with_swim_notification_on_rank_eviction.py
@@ -43,6 +43,7 @@ class CartRpcOneNodeSwimNotificationOnRankEvictionTest(TestWithoutServers):
     def setUp(self):
         """ Test setup """
         print("Running setup\n")
+        super(CartRpcOneNodeSwimNotificationOnRankEvictionTest, self).setUp()
         self.utils = CartUtils()
         self.env = self.utils.get_env(self)
 

--- a/src/tests/ftest/cart/rpc/cart_rpc_two_node.py
+++ b/src/tests/ftest/cart/rpc/cart_rpc_two_node.py
@@ -26,6 +26,7 @@ class CartRpcTwoNodeTest(TestWithoutServers):
     def setUp(self):
         """ Test setup """
         print("Running setup\n")
+        super(CartRpcTwoNodeTest, self).setUp()
         self.utils = CartUtils()
         self.env = self.utils.get_env(self)
 

--- a/src/tests/ftest/cart/rpc/cart_rpc_two_node.yaml
+++ b/src/tests/ftest/cart/rpc/cart_rpc_two_node.yaml
@@ -1,14 +1,15 @@
 # change host names to your reserved nodes, the
 # required quantity is indicated by the placeholders
 
-defaultENV:
-  #!filter-only : /run/env_CRT_CTX_SHARE_ADDR/sep
-  #!filter-only : /run/tests/rpc_error
-  D_LOG_MASK: "WARN,RPC=DEBUG,HG=DEBUG"
-  CRT_PHY_ADDR_STR: "ofi+sockets"
-  OFI_INTERFACE: "eth0"
-  test_servers_CRT_CTX_NUM: "16"
-  test_clients_CRT_CTX_NUM: "16"
+ENV:
+  default:
+    #!filter-only : /run/env_CRT_CTX_SHARE_ADDR/sep
+    #!filter-only : /run/tests/rpc_error
+    - D_LOG_MASK: "WARN,RPC=DEBUG,HG=DEBUG"
+    - CRT_PHY_ADDR_STR: "ofi+sockets"
+    - OFI_INTERFACE: "eth0"
+    - test_servers_CRT_CTX_NUM: "16"
+    - test_clients_CRT_CTX_NUM: "16"
 env_CRT_CTX_SHARE_ADDR: !mux
   sep:
     env: sep

--- a/src/tests/ftest/cart/selftest/cart_selftest_three_node.py
+++ b/src/tests/ftest/cart/selftest/cart_selftest_three_node.py
@@ -26,6 +26,7 @@ class CartSelfThreeNodeTest(TestWithoutServers):
     def setUp(self):
         """ Test setup """
         print("Running setup\n")
+        super(CartSelfThreeNodeTest, self).setUp()
         self.utils = CartUtils()
         self.env = self.utils.get_env(self)
 

--- a/src/tests/ftest/cart/selftest/cart_selftest_three_node.yaml
+++ b/src/tests/ftest/cart/selftest/cart_selftest_three_node.yaml
@@ -1,14 +1,15 @@
 # change host names to your reserved nodes, the
 # required quantity is indicated by the placeholders
 
-defaultENV:
-  #!filter-only : /run/env_CRT_CTX_SHARE_ADDR/no_sep
-  #!filter-only : /run/tests/self_np
-  D_LOG_MASK: "WARN"
-  CRT_PHY_ADDR_STR: "ofi+sockets"
-  OFI_INTERFACE: "eth0"
-  test_servers_CRT_CTX_NUM: "16"
-  test_clients_CRT_CTX_NUM: "16"
+ENV:
+  default:
+    #!filter-only : /run/env_CRT_CTX_SHARE_ADDR/no_sep
+    #!filter-only : /run/tests/self_np
+    - D_LOG_MASK: "WARN"
+    - CRT_PHY_ADDR_STR: "ofi+sockets"
+    - OFI_INTERFACE: "eth0"
+    - test_servers_CRT_CTX_NUM: "16"
+    - test_clients_CRT_CTX_NUM: "16"
 env_CRT_CTX_SHARE_ADDR: !mux
   sep:
     env: sep

--- a/src/tests/ftest/cart/util/cart_utils.py
+++ b/src/tests/ftest/cart/util/cart_utils.py
@@ -134,13 +134,27 @@ class CartUtils():
         log_file = os.path.join(log_path, log_dir,
                                 test_name + "_" + env_CCSA + "_cart.log")
 
-        log_mask = cartobj.params.get("D_LOG_MASK", "/run/defaultENV/")
-        self.provider = cartobj.params.get("CRT_PHY_ADDR_STR",
-                                           "/run/defaultENV/")
-        ofi_interface = cartobj.params.get("OFI_INTERFACE", "/run/defaultENV/")
-        ofi_domain = cartobj.params.get("OFI_DOMAIN", "/run/defaultENV/")
-        ofi_share_addr = cartobj.params.get("CRT_CTX_SHARE_ADDR",
-                                            "/run/env_CRT_CTX_SHARE_ADDR/*/")
+        # Default env vars for orterun to None
+        log_mask = None
+        self.provider = None
+        ofi_interface = None
+        ofi_domain = None
+        ofi_share_addr = None
+
+        if "D_LOG_MASK" in os.environ:
+            log_mask = os.environ.get("D_LOG_MASK")
+
+        if "CRT_PHY_ADDR_STR" in os.environ:
+            self.provider = os.environ.get("CRT_PHY_ADDR_STR")
+
+        if "OFI_INTERFACE" in os.environ:
+            ofi_interface = os.environ.get("OFI_INTERFACE")
+
+        if "OFI_DOMAIN" in os.environ:
+            ofi_domain = os.environ.get("OFI_DOMAIN")
+
+        if "CRT_CTX_SHARE_ADDR" in os.environ:
+            ofi_share_addr = os.environ.get("CRT_CTX_SHARE_ADDR")
 
         # Do not use the standard .log file extension, otherwise it'll get
         # removed (cleaned up for disk space savings) before we can archive it.
@@ -245,8 +259,10 @@ class CartUtils():
                                       "/run/tests/*/")
         _tst_slt = cartobj.params.get("{}_slt".format(host),
                                       "/run/tests/*/")
-        _tst_ctx = cartobj.params.get("{}_CRT_CTX_NUM".format(host),
-                                      "/run/defaultENV/")
+
+        _tst_ctx = "16"
+        if "{}_CRT_CTX_NUM".format(host) in os.environ:
+            _tst_ctx = os.environ["{}_CRT_CTX_NUM".format(host)]
 
         # If the yaml parameter is a list, return the n-th element
         tst_bin = self.get_yaml_list_elem(_tst_bin, index)

--- a/src/tests/ftest/util/apricot/apricot/test.py
+++ b/src/tests/ftest/util/apricot/apricot/test.py
@@ -352,6 +352,22 @@ class TestWithoutServers(Test):
         self.d_log = DaosLog(self.context)
         self.test_log.daos_log = self.d_log
 
+        # import and set env vars from yaml file
+        default_env = self.params.get("default", "/run/ENV/")
+        if default_env is None:
+            return
+
+        for kv_pair in default_env:
+            key = next(iter(kv_pair))
+            if key is not None:
+                value = kv_pair[key]
+                print("Adding {}={} to environment.\n".format(key, value))
+                os.environ[key] = value
+
+        # For compatibility with cart tests, which set env vars in oretrun
+        # command via -x options
+        self.env = os.environ
+
     def tearDown(self):
         """Tear down after each test case."""
         self.report_timeout()
@@ -377,7 +393,6 @@ class TestWithoutServers(Test):
                 "Stopping any of the following commands left running on %s: %s",
                 hosts, ",".join(processes))
             stop_processes(hosts, "'({})'".format("|".join(processes)))
-
 
 class TestWithServers(TestWithoutServers):
     # pylint: disable=too-many-public-methods,too-many-instance-attributes


### PR DESCRIPTION
PR-4445 breaks LEAP 15 tests:
  https://build.hpdd.intel.com/job/daos-stack/job/daos/job/master/4073/

Resurrrecting this branch:
  https://github.com/daos-stack/daos/pull/4445

Test-tag: cart
Skip-coverity-test: true
Skip-func-hw-test-small: true
Skip-func-hw-test-medium: true
Skip-func-hw-test-large: true

Signed-off-by: Ethan Mallove <ethanx.a.mallove@intel.com>