### PR TITLE
DAOS-7007 md,test: fix NO_OF_MAX_CONTAINER setting

### DIFF
--- a/src/tests/ftest/server/metadata.py
+++ b/src/tests/ftest/server/metadata.py
@@ -34,7 +34,8 @@ from test_utils_pool import TestPool
 #  ~48MB for background aggregation use
 # 52% of remaining free space set aside for staging log container
 # (installsnapshot RPC handling in raft)
-NO_OF_MAX_CONTAINER = 4150
+#NO_OF_MAX_CONTAINER = 4150
+NO_OF_MAX_CONTAINER = 3465
 
 def ior_runner_thread(manager, uuids, results):
     """IOR run thread method.
@@ -214,9 +215,16 @@ class ObjectMetadata(TestWithServers):
             self.log.info("Container Create Iteration %d / 9", k)
             for cont in range(NO_OF_MAX_CONTAINER):
                 container = DaosContainer(self.context)
-                container.create(self.pool.pool.handle)
+                try:
+                    container.create(self.pool.pool.handle)
+                except DaosApiError as exc:
+                    self.log.info("Container create %d/%d failed: %s",
+                                  cont, NO_OF_MAX_CONTAINER, exc)
+                    self.fail("Container create failed")
+
                 container_array.append(container)
 
+            self.log.info("Created %d containers", (cont+1))
             self.log.info("Container Remove Iteration %d / 9", k)
             for cont in container_array:
                 cont.destroy()

--- a/src/tests/ftest/server/metadata.yaml
+++ b/src/tests/ftest/server/metadata.yaml
@@ -10,10 +10,9 @@ hosts:
   test_clients:
     - client-C
 timeouts:
-  test_metadata_find_svc: 100
   test_metadata_fillup: 300
   test_metadata_addremove: 900
-  test_container_removal_after_der_nospace: 150
+  test_container_removal_after_der_nospace: 180
 server_config:
   name: daos_server
   engines_per_host: 2
@@ -26,9 +25,9 @@ server_config:
       fabric_iface_port: 31317
       log_file: daos_server0.log
       scm_mount: /mnt/daos0
+      scm_list: ["/dev/pmem0"]
       # common items below (same in server 0 and server 1)
-      scm_class: ram
-      scm_size: 6
+      scm_class: dcpm
       nr_xs_helpers: 16
       log_mask: DEBUG,MEM=ERR
       env_vars:
@@ -38,13 +37,13 @@ server_config:
       targets: 8
       first_core: 0
       pinned_numa_node: 1
-      fabric_iface: ib0
+      fabric_iface: ib1
       fabric_iface_port: 31417
       log_file: daos_server1.log
       scm_mount: /mnt/daos1
+      scm_list: ["/dev/pmem1"]
       # common items below (same in server 0 and server 1)
-      scm_class: ram
-      scm_size: 6
+      scm_class: dcpm
       nr_xs_helpers: 16
       log_mask: DEBUG,MEM=ERR
       env_vars:


### PR DESCRIPTION
Cherry pick daos master branch commit 91e3375 PR #4970 to release/1.2.

Previous commit 0b86a68 inadvertently set this constant too high.
The constant is intended to represent a near-maximum number of
containers that can be created in a pool, from the perspective of the
pool's metadata (rdb) capacity, based on empirical testing.

That commit worked for the existing metadatafill tests, which currently
passes in testing. However it negatively impacted metadata_free_space,
and also impacts a subsequently-developed test metadata_der_nospace.

With this change the constant is set based on the actual number of
containers that can be created before the pool service would return
DER_NOSPACE.

Also with this change, a setting that is no longer applicable is
removed from metadata.yaml. And, the scm_class is now set to dcpm
to exercise persistent memory rather than tmpfs in regression testing.

Parallel-build: true
Skip-unit-tests: true
Skip-coverity-test: true
Test-tag: metadatafill metadata_free_space metadata_der_nospace

Signed-off-by: Kenneth Cain <kenneth.c.cain@intel.com>