### PR TITLE
DAOS-6526 object: refine stats

### DIFF
--- a/src/cart/crt_context.c
+++ b/src/cart/crt_context.c
@@ -245,8 +245,8 @@ crt_context_create(crt_context_t *crt_ctx)
 				      "requests", "",
 				      "net/%u/uri_lookup_timeout", ctx->cc_idx);
 		if (ret)
-			D_WARN("Failed to create timed out uri req counter: "DF_RC
-			       "\n", DP_RC(ret));
+			D_WARN("Failed to create timed out uri req counter: "
+			       DF_RC"\n", DP_RC(ret));
 
 		ret = d_tm_add_metric(&ctx->cc_timedout_uri, D_TM_COUNTER,
 				      "Total number of failed address "

--- a/src/cart/crt_context.c
+++ b/src/cart/crt_context.c
@@ -154,13 +154,14 @@ crt_context_init(crt_context_t crt_ctx)
 	}
 
 	/* create epi table, use external lock */
-	rc =  d_hash_table_create_inplace(D_HASH_FT_NOLOCK, CRT_EPI_TABLE_BITS,
-					  NULL, &epi_table_ops,
-					  &ctx->cc_epi_table);
+	rc = d_hash_table_create_inplace(D_HASH_FT_NOLOCK, CRT_EPI_TABLE_BITS,
+					 NULL, &epi_table_ops,
+					 &ctx->cc_epi_table);
 	if (rc != 0) {
 		D_ERROR("d_hash_table_create() failed, " DF_RC "\n", DP_RC(rc));
 		D_GOTO(out_binheap_destroy, rc);
 	}
+
 	D_GOTO(out, rc);
 
 out_binheap_destroy:
@@ -203,8 +204,8 @@ crt_context_create(crt_context_t *crt_ctx)
 
 	D_RWLOCK_WRLOCK(&crt_gdata.cg_rwlock);
 
-	ctx->provider = crt_gdata.cg_na_plugin;
-	rc = crt_hg_ctx_init(&ctx->cc_hg_ctx, ctx->provider,
+	ctx->cc_provider = crt_gdata.cg_na_plugin;
+	rc = crt_hg_ctx_init(&ctx->cc_hg_ctx, ctx->cc_provider,
 			     crt_gdata.cg_ctx_num);
 	if (rc != 0) {
 		D_ERROR("crt_hg_ctx_init() failed, " DF_RC "\n", DP_RC(rc));
@@ -227,6 +228,34 @@ crt_context_create(crt_context_t *crt_ctx)
 	crt_gdata.cg_ctx_num++;
 
 	D_RWLOCK_UNLOCK(&crt_gdata.cg_rwlock);
+
+	/** initialize sensors */
+	if (crt_gdata.cg_use_sensors) {
+		int	ret;
+
+		ret = d_tm_add_metric(&ctx->cc_timedout, D_TM_COUNTER,
+				      "Total number of timed out RPC requests",
+				      "", "net/%u/req_timeout", ctx->cc_idx);
+		if (ret)
+			D_WARN("Failed to create timed out req counter: "DF_RC
+			       "\n", DP_RC(ret));
+
+		ret = d_tm_add_metric(&ctx->cc_timedout_uri, D_TM_COUNTER,
+				      "Total number of timed out URI lookup "
+				      "requests", "",
+				      "net/%u/uri_lookup_timeout", ctx->cc_idx);
+		if (ret)
+			D_WARN("Failed to create timed out uri req counter: "DF_RC
+			       "\n", DP_RC(ret));
+
+		ret = d_tm_add_metric(&ctx->cc_timedout_uri, D_TM_COUNTER,
+				      "Total number of failed address "
+				      "resolution attempts", "",
+				      "net/%u/failed_addr", ctx->cc_idx);
+		if (ret)
+			D_WARN("Failed to create failed addr counter: "DF_RC
+			       "\n", DP_RC(ret));
+	}
 
 	if (crt_is_service() &&
 	    crt_gdata.cg_auto_swim_disable == 0 &&
@@ -690,6 +719,7 @@ crt_req_timeout_reset(struct crt_rpc_priv *rpc_priv)
 static inline void
 crt_req_timeout_hdlr(struct crt_rpc_priv *rpc_priv)
 {
+	struct crt_context		*crt_ctx;
 	struct crt_grp_priv		*grp_priv;
 	crt_endpoint_t			*tgt_ep;
 	crt_rpc_t			*ul_req;
@@ -704,6 +734,7 @@ crt_req_timeout_hdlr(struct crt_rpc_priv *rpc_priv)
 
 	tgt_ep = &rpc_priv->crp_pub.cr_ep;
 	grp_priv = crt_grp_pub2priv(tgt_ep->ep_grp);
+	crt_ctx = rpc_priv->crp_pub.cr_ctx;
 
 	switch (rpc_priv->crp_state) {
 	case RPC_STATE_URI_LOOKUP:
@@ -717,6 +748,10 @@ crt_req_timeout_hdlr(struct crt_rpc_priv *rpc_priv)
 			  ul_in->ul_grp_id,
 			  ul_in->ul_rank,
 			  ul_req->cr_ep.ep_rank);
+
+		if (crt_gdata.cg_use_sensors)
+			(void)d_tm_increment_counter(&crt_ctx->cc_timedout_uri,
+						     1, NULL);
 		crt_req_abort(ul_req);
 		/*
 		 * don't crt_rpc_complete rpc_priv here, because crt_req_abort
@@ -732,6 +767,9 @@ crt_req_timeout_hdlr(struct crt_rpc_priv *rpc_priv)
 			  grp_priv->gp_pub.cg_grpid,
 			  tgt_ep->ep_rank,
 			  rpc_priv->crp_tgt_uri);
+		if (crt_gdata.cg_use_sensors)
+			(void)d_tm_increment_counter(&crt_ctx->cc_failed_addr,
+						     1, NULL);
 		crt_context_req_untrack(rpc_priv);
 		crt_rpc_complete(rpc_priv, -DER_UNREACH);
 		break;
@@ -768,6 +806,7 @@ crt_context_timeout_check(struct crt_context *crt_ctx)
 	struct d_binheap_node		*bh_node;
 	d_list_t			 timeout_list;
 	uint64_t			 ts_now;
+	int				 count = 0;
 
 	D_ASSERT(crt_ctx != NULL);
 
@@ -786,6 +825,7 @@ crt_context_timeout_check(struct crt_context *crt_ctx)
 
 		/* +1 to prevent it from being released in timeout_untrack */
 		RPC_ADDREF(rpc_priv);
+		count++;
 		crt_req_timeout_untrack(rpc_priv);
 
 		d_list_add_tail(&rpc_priv->crp_tmp_link, &timeout_list);
@@ -804,6 +844,10 @@ crt_context_timeout_check(struct crt_context *crt_ctx)
 			  rpc_priv->crp_timeout_sec,
 			  rpc_priv->crp_pub.cr_ep.ep_rank,
 			  rpc_priv->crp_pub.cr_ep.ep_tag);
+
+		if (crt_gdata.cg_use_sensors)
+			(void)d_tm_increment_counter(&crt_ctx->cc_timedout,
+						     count, NULL);
 
 		/* check for and execute RPC timeout callbacks here */
 		crt_exec_timeout_cb(rpc_priv);

--- a/src/cart/crt_context.c
+++ b/src/cart/crt_context.c
@@ -740,8 +740,7 @@ crt_req_timeout_hdlr(struct crt_rpc_priv *rpc_priv)
 	crt_ctx = rpc_priv->crp_pub.cr_ctx;
 
 	if (crt_gdata.cg_use_sensors)
-		(void)d_tm_increment_counter(&crt_ctx->cc_timedout, count,
-					     NULL);
+		(void)d_tm_increment_counter(&crt_ctx->cc_timedout, 1, NULL);
 
 	switch (rpc_priv->crp_state) {
 	case RPC_STATE_URI_LOOKUP:

--- a/src/cart/crt_group.c
+++ b/src/cart/crt_group.c
@@ -1563,9 +1563,6 @@ crt_hdlr_uri_lookup(crt_rpc_t *rpc_req)
 	ul_out->ul_uri = cached_uri;
 	if (ul_out->ul_uri == NULL)
 		D_GOTO(out, rc = -DER_OOG);
-	if (crt_gdata.cg_use_sensors)
-		(void)d_tm_increment_counter(&crt_gdata.cg_uri_fwd, 1,
-					     NULL);
 
 out:
 	if (should_decref)

--- a/src/cart/crt_group.c
+++ b/src/cart/crt_group.c
@@ -1507,7 +1507,7 @@ crt_hdlr_uri_lookup(crt_rpc_t *rpc_req)
 
 	crt_ctx = rpc_req->cr_ctx;
 
-	if (ul_in->ul_tag >= CRT_SRV_CONTEXT_NUM) {
+	if (unlikely(ul_in->ul_tag >= CRT_SRV_CONTEXT_NUM)) {
 		D_WARN("Looking up invalid tag %d of rank %d "
 		       "in group %s (%d)\n",
 		       ul_in->ul_tag, ul_in->ul_rank,
@@ -1531,6 +1531,9 @@ crt_hdlr_uri_lookup(crt_rpc_t *rpc_req)
 				"rc %d\n", ul_in->ul_tag, rc);
 		ul_out->ul_uri = tmp_uri;
 		ul_out->ul_tag = ul_in->ul_tag;
+		if (crt_gdata.cg_use_sensors)
+			(void)d_tm_increment_counter(&crt_gdata.cg_uri_self,
+						     1, NULL);
 		D_GOTO(out, rc);
 	}
 
@@ -1540,8 +1543,12 @@ crt_hdlr_uri_lookup(crt_rpc_t *rpc_req)
 	ul_out->ul_uri = cached_uri;
 	ul_out->ul_tag = ul_in->ul_tag;
 
-	if (ul_out->ul_uri != NULL)
+	if (ul_out->ul_uri != NULL) {
+		if (crt_gdata.cg_use_sensors)
+			(void)d_tm_increment_counter(&crt_gdata.cg_uri_other,
+						     1, NULL);
 		D_GOTO(out, rc);
+	}
 
 	/* If this server does not know rank:0 then return error */
 	if (ul_in->ul_tag == 0)
@@ -1556,6 +1563,9 @@ crt_hdlr_uri_lookup(crt_rpc_t *rpc_req)
 	ul_out->ul_uri = cached_uri;
 	if (ul_out->ul_uri == NULL)
 		D_GOTO(out, rc = -DER_OOG);
+	if (crt_gdata.cg_use_sensors)
+		(void)d_tm_increment_counter(&crt_gdata.cg_uri_fwd, 1,
+					     NULL);
 
 out:
 	if (should_decref)

--- a/src/cart/crt_hg.c
+++ b/src/cart/crt_hg.c
@@ -708,14 +708,14 @@ crt_rpc_handler_common(hg_handle_t hg_hdl)
 	struct crt_rpc_priv	 rpc_tmp = {0};
 
 	hg_info = HG_Get_info(hg_hdl);
-	if (hg_info == NULL) {
+	if (unlikely(hg_info == NULL)) {
 		D_ERROR("HG_Get_info failed.\n");
 		D_GOTO(out, hg_ret = HG_PROTOCOL_ERROR);
 	}
 
 	crt_ctx = (struct crt_context *)HG_Context_get_data(
 			hg_info->context);
-	if (crt_ctx == NULL) {
+	if (unlikely(crt_ctx == NULL)) {
 		D_ERROR("HG_Context_get_data failed.\n");
 		D_GOTO(out, hg_ret = HG_PROTOCOL_ERROR);
 	}
@@ -728,7 +728,7 @@ crt_rpc_handler_common(hg_handle_t hg_hdl)
 	rpc_tmp.crp_pub.cr_ctx = crt_ctx;
 
 	rc = crt_hg_unpack_header(hg_hdl, &rpc_tmp, &proc);
-	if (rc != 0) {
+	if (unlikely(rc != 0)) {
 		D_ERROR("crt_hg_unpack_header failed, rc: %d.\n", rc);
 		crt_hg_reply_error_send(&rpc_tmp, -DER_MISC);
 		/** safe to return here because relevant portion of rpc_tmp is
@@ -746,7 +746,7 @@ crt_rpc_handler_common(hg_handle_t hg_hdl)
 	rpc_tmp.crp_pub.cr_opc = opc;
 
 	opc_info = crt_opc_lookup(crt_gdata.cg_opc_map, opc, CRT_UNLOCK);
-	if (opc_info == NULL) {
+	if (unlikely(opc_info == NULL)) {
 		D_ERROR("opc: %#x, lookup failed.\n", opc);
 		/*
 		 * The RPC is not registered on the server, we don't know how to
@@ -762,7 +762,7 @@ crt_rpc_handler_common(hg_handle_t hg_hdl)
 	D_ASSERT(opc_info->coi_opc == opc);
 
 	D_ALLOC(rpc_priv, opc_info->coi_rpc_size);
-	if (rpc_priv == NULL) {
+	if (unlikely(rpc_priv == NULL)) {
 		crt_hg_reply_error_send(&rpc_tmp, -DER_DOS);
 		crt_hg_unpack_cleanup(proc);
 		HG_Destroy(rpc_tmp.crp_hg_hdl);
@@ -788,7 +788,7 @@ crt_rpc_handler_common(hg_handle_t hg_hdl)
 		  &rpc_priv->crp_pub);
 
 	rc = crt_rpc_priv_init(rpc_priv, crt_ctx, true /* srv_flag */);
-	if (rc != 0) {
+	if (unlikely(rc != 0)) {
 		D_ERROR("crt_rpc_priv_init rc=%d, opc=%#x\n", rc, opc);
 		crt_hg_reply_error_send(rpc_priv, -DER_MISC);
 		HG_Destroy(rpc_tmp.crp_hg_hdl);
@@ -816,13 +816,13 @@ crt_rpc_handler_common(hg_handle_t hg_hdl)
 		crt_hg_unpack_cleanup(proc);
 	}
 
-	if (opc_info->coi_rpc_cb == NULL) {
+	if (unlikely(opc_info->coi_rpc_cb == NULL)) {
 		D_ERROR("NULL crp_hg_hdl, opc: %#x.\n", opc);
 		crt_hg_reply_error_send(rpc_priv, -DER_UNREG);
 		D_GOTO(decref, hg_ret = HG_SUCCESS);
 	}
 
-	if (rpc_priv->crp_fail_hlc) {
+	if (unlikely(rpc_priv->crp_fail_hlc)) {
 		crt_hg_reply_error_send(rpc_priv, -DER_HLC_SYNC);
 		D_GOTO(decref, hg_ret = HG_SUCCESS);
 	}
@@ -831,7 +831,7 @@ crt_rpc_handler_common(hg_handle_t hg_hdl)
 		rc = crt_rpc_common_hdlr(rpc_priv);
 	else
 		rc = crt_corpc_common_hdlr(rpc_priv);
-	if (rc != 0) {
+	if (unlikely(rc != 0)) {
 		RPC_ERROR(rpc_priv,
 			  "failed to invoke RPC handler, rc: %d, opc: %#x\n",
 			  rc, opc);
@@ -841,7 +841,7 @@ crt_rpc_handler_common(hg_handle_t hg_hdl)
 decref:
 	/* If rpc call back is customized, then it might be handled
 	 * asynchronously, Let's hold the RPC, and the real handler
-	 * (crt_handle_rpc())will release it
+	 * (crt_handle_rpc()) will release it
 	 */
 	if (rc != 0 || !crt_rpc_cb_customized(crt_ctx, &rpc_priv->crp_pub))
 		RPC_DECREF(rpc_priv);

--- a/src/cart/crt_init.c
+++ b/src/cart/crt_init.c
@@ -211,15 +211,6 @@ static int data_init(int server, crt_init_options_t *opt)
 		if (ret)
 			D_WARN("Failed to create uri other sensor: "DF_RC"\n",
 			       DP_RC(ret));
-
-		ret = d_tm_add_metric(&crt_gdata.cg_uri_fwd, D_TM_COUNTER,
-				      "total number of URI requests forwarded "
-				      "to rank 0", "",
-				      "net/uri/lookup_forward");
-		if (ret)
-			D_WARN("Failed to create uri forward sensor: "DF_RC"\n",
-			       DP_RC(ret));
-
 	}
 
 	gdata_init_flag = 1;

--- a/src/cart/crt_init.c
+++ b/src/cart/crt_init.c
@@ -191,7 +191,8 @@ static int data_init(int server, crt_init_options_t *opt)
 		D_WARN("CRT_CTX_NUM has no effect because CRT_CTX_SHARE_ADDR "
 		       "is not set or set to 0\n");
 
-	if (opt && opt->cio_use_sensors) {
+	/** Enable statistics only for the server side and if requested */
+	if (opt && opt->cio_use_sensors && server) {
 		int	ret;
 
 		/** enable sensors */

--- a/src/cart/crt_init.c
+++ b/src/cart/crt_init.c
@@ -191,6 +191,37 @@ static int data_init(int server, crt_init_options_t *opt)
 		D_WARN("CRT_CTX_NUM has no effect because CRT_CTX_SHARE_ADDR "
 		       "is not set or set to 0\n");
 
+	if (opt && opt->cio_use_sensors) {
+		int	ret;
+
+		/** enable sensors */
+		crt_gdata.cg_use_sensors = true;
+
+		/** set up the global sensors */
+		ret = d_tm_add_metric(&crt_gdata.cg_uri_self, D_TM_COUNTER,
+				      "total number of URI requests for self",
+				      "", "net/uri/lookup_self");
+		if (ret)
+			D_WARN("Failed to create uri self sensor: "DF_RC"\n",
+			       DP_RC(ret));
+
+		ret = d_tm_add_metric(&crt_gdata.cg_uri_other, D_TM_COUNTER,
+				      "total number of URI requests for other "
+				      "ranks", "", "net/uri/lookup_other");
+		if (ret)
+			D_WARN("Failed to create uri other sensor: "DF_RC"\n",
+			       DP_RC(ret));
+
+		ret = d_tm_add_metric(&crt_gdata.cg_uri_fwd, D_TM_COUNTER,
+				      "total number of URI requests forwarded "
+				      "to rank 0", "",
+				      "net/uri/lookup_forward");
+		if (ret)
+			D_WARN("Failed to create uri forward sensor: "DF_RC"\n",
+			       DP_RC(ret));
+
+	}
+
 	gdata_init_flag = 1;
 exit:
 	return rc;

--- a/src/cart/crt_internal_types.h
+++ b/src/cart/crt_internal_types.h
@@ -20,58 +20,79 @@
 #include <gurt/hash.h>
 #include <gurt/heap.h>
 #include <gurt/atomic.h>
+#include <gurt/telemetry_common.h>
+#include <gurt/telemetry_producer.h>
 
 struct crt_hg_gdata;
 struct crt_grp_gdata;
 
 /* CaRT global data */
 struct crt_gdata {
-	/*
+	/**
 	 * TODO: Temporary storage for context0 URI, used during group
 	 * attach info file population for self address. Per-provider
 	 * context0 URIs need to be stored for multi-provider support
 	 */
 	char			cg_addr[CRT_ADDR_STR_MAX_LEN];
 
-	/* Flag indicating whether it is a client or server */
-	bool			cg_server;
-	/* Flag indicating whether scalable endpoint mode is enabled */
-	bool			cg_sep_mode;
-	/* Flag indicating to use contiguous port ranges for contexts */
-	bool			cg_contig_ports;
-	int			cg_na_plugin; /* NA plugin type */
+	/** NA pluging type */
+	int			cg_na_plugin;
 
-	/* global timeout value (second) for all RPCs */
+	/** global timeout value (second) for all RPCs */
 	uint32_t		cg_timeout;
-	/* credits limitation for #inflight RPCs per target EP CTX */
+	/** credits limitation for #inflight RPCs per target EP CTX */
 	uint32_t		cg_credit_ep_ctx;
 
-	/* CaRT contexts list */
+	/** CaRT contexts list */
 	d_list_t		cg_ctx_list;
-	/* actual number of items in CaRT contexts list */
+	/** actual number of items in CaRT contexts list */
 	int			cg_ctx_num;
-	/* maximum number of contexts user wants to create */
+	/** maximum number of contexts user wants to create */
 	uint32_t		cg_ctx_max_num;
-	/* the global opcode map */
+	/** the global opcode map */
 	struct crt_opc_map	*cg_opc_map;
-	/* HG level global data */
+	/** HG level global data */
 	struct crt_hg_gdata	*cg_hg;
 
 	struct crt_grp_gdata	*cg_grp;
 
-	/* refcount to protect crt_init/crt_finalize */
+	/** refcount to protect crt_init/crt_finalize */
 	volatile unsigned int	cg_refcount;
 
-	/* flags to keep track of states */
-	volatile unsigned int	cg_inited		: 1,
+	/** flags to keep track of states */
+	unsigned int		cg_inited		: 1,
 				cg_grp_inited		: 1,
 				cg_swim_inited		: 1,
-				cg_auto_swim_disable	: 1;
+				cg_auto_swim_disable	: 1,
+				/** whether it is a client or server */
+				cg_server		: 1,
+				/** whether scalable endpoint is enabled */
+				cg_sep_mode		: 1,
+				/** whether to use contiguous port ranges */
+				cg_contig_ports		: 1,
+				/** whether sensors are enabled */
+				cg_use_sensors		: 1;
 
 	ATOMIC uint64_t		cg_rpcid; /* rpc id */
 
 	/* protects crt_gdata */
 	pthread_rwlock_t	cg_rwlock;
+
+	/** Global statistics (when cg_use_sensors = true) */
+	/**
+	 * Total number of successfully served URI lookup for self,
+	 * of type counter
+	 */
+	struct d_tm_node_t	*cg_uri_self;
+	/**
+	 * Total number of successfully served (from cache) URI lookup for
+	 * others, of type counter
+	 */
+	struct d_tm_node_t	*cg_uri_other;
+	/**
+	 * Total number of forwarded URI lookup requests, of type counter
+	 */
+	struct d_tm_node_t	*cg_uri_fwd;
 };
 
 extern struct crt_gdata		crt_gdata;
@@ -128,24 +149,38 @@ extern struct crt_plugin_gdata		crt_plugin_gdata;
 
 /* crt_context */
 struct crt_context {
-	d_list_t		 cc_link; /* link to gdata.cg_ctx_list */
-	int			 cc_idx; /* context index */
-	struct crt_hg_context	 cc_hg_ctx; /* HG context */
+	d_list_t		 cc_link;	/** link to gdata.cg_ctx_list */
+	int			 cc_idx;	/** context index */
+	struct crt_hg_context	 cc_hg_ctx;	/** HG context */
+
+	/* callbacks */
 	void			*cc_rpc_cb_arg;
-	crt_rpc_task_t		 cc_rpc_cb; /* rpc callback */
+	crt_rpc_task_t		 cc_rpc_cb;	/** rpc callback */
 	crt_rpc_task_t		 cc_iv_resp_cb;
-	/* in-flight endpoint tracking hash table */
+
+	/** RPC tracking */
+	/** in-flight endpoint tracking hash table */
 	struct d_hash_table	 cc_epi_table;
-	/* binheap for inflight RPC timeout tracking */
+	/** binheap for inflight RPC timeout tracking */
 	struct d_binheap	 cc_bh_timeout;
-	/* mutex to protect cc_epi_table and timeout binheap */
+	/** mutex to protect cc_epi_table and timeout binheap */
 	pthread_mutex_t		 cc_mutex;
-	/* timeout per-context */
+
+	/** timeout per-context */
 	uint32_t		 cc_timeout_sec;
-	/* Stores self uri for the current context */
+	/** provider on which context is allocated */
+	int			 cc_provider;
+
+	/** Per-context statistics (server-side only) */
+	/** Total number of timed out requests, of type counter */
+	struct d_tm_node_t	*cc_timedout;
+	/** Total number of timed out URI lookup requests, of type counter */
+	struct d_tm_node_t	*cc_timedout_uri;
+	/** Total number of failed address resolution, of type counter */
+	struct d_tm_node_t	*cc_failed_addr;
+
+	/** Stores self uri for the current context */
 	char			 cc_self_uri[CRT_ADDR_STR_MAX_LEN];
-	/* provider on which context is allocated */
-	int			provider;
 };
 
 /* in-flight RPC req list, be tracked per endpoint for every crt_context */

--- a/src/cart/crt_internal_types.h
+++ b/src/cart/crt_internal_types.h
@@ -89,10 +89,6 @@ struct crt_gdata {
 	 * others, of type counter
 	 */
 	struct d_tm_node_t	*cg_uri_other;
-	/**
-	 * Total number of forwarded URI lookup requests, of type counter
-	 */
-	struct d_tm_node_t	*cg_uri_fwd;
 };
 
 extern struct crt_gdata		crt_gdata;

--- a/src/cart/crt_rpc.c
+++ b/src/cart/crt_rpc.c
@@ -802,7 +802,7 @@ uri_lookup_cb(const struct crt_cb_info *cb_info)
 	char *fill_uri = NULL;
 
 	if (ul_in->ul_tag != ul_out->ul_tag) {
-		if (crt_provider_is_contig_ep(ctx->provider) == false) {
+		if (crt_provider_is_contig_ep(ctx->cc_provider) == false) {
 			rc = crt_issue_uri_lookup(lookup_rpc->cr_ctx,
 						  lookup_rpc->cr_ep.ep_grp,
 						  ul_in->ul_rank, 0,
@@ -1576,7 +1576,9 @@ crt_rpc_priv_init(struct crt_rpc_priv *rpc_priv, crt_context_t crt_ctx,
 	rpc_priv->crp_hdl_reuse = NULL;
 	rpc_priv->crp_srv = srv_flag;
 	rpc_priv->crp_ul_retry = 0;
-	/* initialize as 1, so user can cal crt_req_decref to destroy new req */
+	/**
+	 * initialized to 1, so user can call crt_req_decref to destroy new req
+	 */
 	rpc_priv->crp_refcount = 1;
 
 	rpc_priv->crp_pub.cr_opc = opc;

--- a/src/common/misc.c
+++ b/src/common/misc.c
@@ -616,11 +616,14 @@ daos_crt_init_opt_get(bool server, int ctx_nr)
 	crt_phy_addr_t	addr_env;
 	bool		sep = false;
 
+	/** enable statistics on the server side */
+	daos_crt_init_opt.cio_use_sensors = server;
+
+	/** Scalable EndPoint-related settings */
 	d_getenv_bool("CRT_CTX_SHARE_ADDR", &sep);
 	if (!sep)
-		return NULL;
+		goto out;
 
-	daos_crt_init_opt.cio_crt_timeout = 0;
 	daos_crt_init_opt.cio_sep_override = 1;
 
 	/* for socket provider, force it to use regular EP rather than SEP for:
@@ -632,7 +635,7 @@ daos_crt_init_opt_get(bool server, int ctx_nr)
 	    strncmp(addr_env, CRT_SOCKET_PROV, strlen(CRT_SOCKET_PROV)) == 0) {
 		D_INFO("for sockets provider force it to use regular EP.\n");
 		daos_crt_init_opt.cio_use_sep = 0;
-		return &daos_crt_init_opt;
+		goto out;
 	}
 
 	/* for psm2 provider, set a reasonable cio_ctx_max_num for cart */
@@ -647,6 +650,7 @@ daos_crt_init_opt_get(bool server, int ctx_nr)
 		daos_crt_init_opt.cio_ctx_max_num = ctx_nr;
 	}
 
+out:
 	return &daos_crt_init_opt;
 }
 

--- a/src/engine/init.c
+++ b/src/engine/init.c
@@ -460,7 +460,7 @@ static void
 dss_crt_event_cb(d_rank_t rank, enum crt_event_source src,
 		 enum crt_event_type type, void *arg)
 {
-	static struct d_tm_node_t	*dead_rank_cnt;
+	static struct d_tm_node_t	*dead_ranks;
 	static struct d_tm_node_t	*last_ts;
 	int				 rc = 0;
 
@@ -471,8 +471,8 @@ dss_crt_event_cb(d_rank_t rank, enum crt_event_source src,
 		return;
 	}
 
-	d_tm_increment_counter(&dead_rank_cnt, 1, "events/dead_rank_cnt");
-	d_tm_record_timestamp(&last_ts, "events/last_event_ts");
+	(void)d_tm_increment_counter(&dead_ranks, 1, "events/dead_ranks");
+	(void)d_tm_record_timestamp(&last_ts, "events/last_event_ts");
 
 	rc = ds_notify_swim_rank_dead(rank);
 	if (rc)
@@ -500,7 +500,7 @@ server_init(int argc, char *argv[])
 		goto exit_debug_init;
 
 	/** Report timestamp when engine was started */
-	d_tm_record_timestamp(NULL, "started_at");
+	(void)d_tm_record_timestamp(NULL, "started_at");
 
 	rc = drpc_init();
 	if (rc != 0) {
@@ -646,10 +646,10 @@ server_init(int argc, char *argv[])
 	D_INFO("Service fully up\n");
 
 	/** Report timestamp when engine was open for business */
-	d_tm_record_timestamp(NULL, "servicing_at");
+	(void)d_tm_record_timestamp(NULL, "servicing_at");
 
 	/** Report rank */
-	d_tm_increment_counter(NULL, dss_self_rank(), "rank");
+	(void)d_tm_increment_counter(NULL, dss_self_rank(), "rank");
 
 	D_PRINT("DAOS I/O Engine (v%s) process %u started on rank %u "
 		"with %u target, %d helper XS, firstcore %d, host %s.\n",

--- a/src/include/cart/types.h
+++ b/src/include/cart/types.h
@@ -39,23 +39,26 @@ typedef struct crt_init_options {
 	 */
 	uint32_t	cio_sep_override:1,
 			/**
-			* overrides the value of the environment variable
-			* CRT_CTX_SHARE_ADDR
-			*/
+			 * overrides the value of the environment variable
+			 * CRT_CTX_SHARE_ADDR
+			 */
 			cio_use_sep:1,
 			/** whether or not to inject faults */
 			cio_fault_inject:1,
-			/** whether or not to override credits. When set
-			* overrides CRT_CTX_EP_CREDITS envariable
-			*/
-			cio_use_credits:1;
 			/**
-			* overrides the value of the environment variable
-			* CRT_CTX_NUM
-			*/
+			 * whether or not to override credits. When set
+			 * overrides CRT_CTX_EP_CREDITS envariable
+			 */
+			cio_use_credits:1,
+			/** whether or not to enable per-context sensors */
+			cio_use_sensors:1;
+	/**
+	 * overrides the value of the environment variable
+	 * CRT_CTX_NUM
+	 */
 	int		cio_ctx_max_num;
 
-			/** Used with cio_use_credits to set credit limit */
+	/** Used with cio_use_credits to set credit limit */
 	int		cio_ep_credits;
 } crt_init_options_t;
 

--- a/src/include/daos_srv/vos.h
+++ b/src/include/daos_srv/vos.h
@@ -663,12 +663,13 @@ vos_fetch_begin(daos_handle_t coh, daos_unit_oid_t oid, daos_epoch_t epoch,
  * Finish the fetch operation and release the responding resources.
  *
  * \param ioh	[IN]	The I/O handle created by \a vos_fetch_begin
+ * \param size	[OUT]	The total IO size for the fetch.
  * \param err	[IN]	Errno of the current fetch, zero if there is no error.
  *
  * \return		Zero on success, negative value if error
  */
 int
-vos_fetch_end(daos_handle_t ioh, int err);
+vos_fetch_end(daos_handle_t ioh, daos_size_t *size, int err);
 
 /**
  * Prepare IO sink buffers for the specified arrays of the given
@@ -712,13 +713,14 @@ vos_update_begin(daos_handle_t coh, daos_unit_oid_t oid, daos_epoch_t epoch,
  * \param err	[IN]	Errno of the current update, zero if there is no error.
  *			All updates will be dropped if this function is called
  *			for \a vos_update_begin with a non-zero error code.
+ * \param size	[OUT]	The total IO size for the update.
  * \param dth	[IN]	Pointer to the DTX handle.
  *
  * \return		Zero on success, negative value if error
  */
 int
 vos_update_end(daos_handle_t ioh, uint32_t pm_ver, daos_key_t *dkey, int err,
-	       struct dtx_handle *dth);
+	       daos_size_t *size, struct dtx_handle *dth);
 
 /**
  * Get the recx/epoch list.

--- a/src/object/srv_mod.c
+++ b/src/object/srv_mod.c
@@ -99,7 +99,7 @@ obj_tls_init(int xs_id, int tgt_id)
 				     obj_opc_to_str(opc));
 		if (rc)
 			D_WARN("Failed to create active cnt sensor: "DF_RC"\n",
-					DP_RC(rc));
+			       DP_RC(rc));
 
 		/** Then the total number of requests, of type counter */
 		rc = d_tm_add_metric(&tls->ot_op_total[opc], D_TM_COUNTER,
@@ -108,7 +108,7 @@ obj_tls_init(int xs_id, int tgt_id)
 				     obj_opc_to_str(opc));
 		if (rc)
 			D_WARN("Failed to create total cnt sensor: "DF_RC"\n",
-					DP_RC(rc));
+			       DP_RC(rc));
 
 		if (opc == DAOS_OBJ_RPC_UPDATE ||
 		    opc == DAOS_OBJ_RPC_TGT_UPDATE ||

--- a/src/object/srv_mod.c
+++ b/src/object/srv_mod.c
@@ -195,7 +195,7 @@ obj_tls_init(int xs_id, int tgt_id)
 			     "total number of bytes updated/written", "",
 			     "io/%u/update_bytes", tgt_id);
 	if (rc)
-		D_WARN("Failed to create bytes udpate sensor: "DF_RC"\n",
+		D_WARN("Failed to create bytes update sensor: "DF_RC"\n",
 		       DP_RC(rc));
 
 	return tls;

--- a/src/object/srv_mod.c
+++ b/src/object/srv_mod.c
@@ -92,33 +92,76 @@ obj_tls_init(int xs_id, int tgt_id)
 
 	/** register different per-opcode sensors */
 	for (opc = 0; opc < OBJ_PROTO_CLI_COUNT; opc++) {
-		/** Start with latency, of type gauge */
-		rc = d_tm_add_metric(&tls->ot_op_lat[opc], D_TM_GAUGE,
-				     "object RPC processing time", "",
-				     "io/%u/ops/%s/latency", tgt_id,
-				     obj_opc_to_str(opc));
-		if (rc)
-			D_WARN("Failed to create latency sensor: "DF_RC"\n",
-			       DP_RC(rc));
-
-		/** Continue with number of active requests, of type gauge */
+		/** Start with number of active requests, of type gauge */
 		rc = d_tm_add_metric(&tls->ot_op_active[opc], D_TM_GAUGE,
 				     "number of active object RPCs", "",
 				     "io/%u/ops/%s/active", tgt_id,
 				     obj_opc_to_str(opc));
 		if (rc)
 			D_WARN("Failed to create active cnt sensor: "DF_RC"\n",
-			       DP_RC(rc));
+					DP_RC(rc));
 
-		/** And finally the total number of requests, of type counter */
+		/** Then the total number of requests, of type counter */
 		rc = d_tm_add_metric(&tls->ot_op_total[opc], D_TM_COUNTER,
 				     "total number of processed object RPCs",
-				     "",
-				     "io/%u/ops/%s/total", tgt_id,
+				     "", "io/%u/ops/%s/total", tgt_id,
 				     obj_opc_to_str(opc));
 		if (rc)
 			D_WARN("Failed to create total cnt sensor: "DF_RC"\n",
+					DP_RC(rc));
+
+		if (opc == DAOS_OBJ_RPC_UPDATE ||
+		    opc == DAOS_OBJ_RPC_TGT_UPDATE ||
+		    opc == DAOS_OBJ_RPC_FETCH)
+			/** See below, latency reported per size for those */
+			continue;
+
+		/** And finally the per-opcode latency, of type gauge */
+		rc = d_tm_add_metric(&tls->ot_op_lat[opc], D_TM_GAUGE,
+				     "object RPC processing time (in us)", "",
+				     "io/%u/ops/%s/latency", tgt_id,
+				     obj_opc_to_str(opc));
+		if (rc)
+			D_WARN("Failed to create latency sensor: "DF_RC"\n",
 			       DP_RC(rc));
+	}
+
+	/**
+	 * Maintain per-I/O size latency for update & fetch RPCs
+	 * of type gauge
+	 */
+	for (opc = 0; opc < 2; opc++) {
+		int			i;
+		unsigned int		bucket_max = 256;
+		struct d_tm_node_t	**tm[2] = { tls->ot_update_lat,
+						    tls->ot_fetch_lat };
+		for (i = 0; i < NR_LATENCY_BUCKETS; i++) {
+			char *path;
+
+			if (bucket_max < 1024) /** B */
+				D_ASPRINTF(path, "io/%u/%s_latency_%uB",
+					   tgt_id, opc ? "fetch" : "update",
+					   bucket_max);
+			else if (bucket_max < 1024 * 1024) /** KB */
+				D_ASPRINTF(path, "io/%u/%s_latency_%uKB",
+					   tgt_id, opc ? "fetch" : "update",
+					   bucket_max / 1024);
+			else if (bucket_max <= 1024 * 1024 * 4) /** MB */
+				D_ASPRINTF(path, "io/%u/%s_latency_%uMB",
+					   tgt_id, opc ? "fetch" : "update",
+					   bucket_max / (1024 * 1024));
+			else /** >4MB */
+				D_ASPRINTF(path, "io/%u/%s_latency_>4MB",
+					   tgt_id, opc ? "fetch" : "update");
+			rc = d_tm_add_metric(&tm[opc][i], D_TM_GAUGE,
+					     "Per-I/O size RPC processing time "
+					     "(in us)", "", path);
+			D_FREE(path);
+			if (rc)
+				D_WARN("Failed to create per-I/O size latency "
+				       "sensor: "DF_RC"\n", DP_RC(rc));
+			bucket_max <<= 1;
+		}
 	}
 
 	/** Total number of silently restarted updates, of type counter */
@@ -137,6 +180,22 @@ obj_tls_init(int xs_id, int tgt_id)
 			     obj_opc_to_str(DAOS_OBJ_RPC_UPDATE));
 	if (rc)
 		D_WARN("Failed to create resent cnt sensor: "DF_RC"\n",
+		       DP_RC(rc));
+
+	/** Total bytes read */
+	rc = d_tm_add_metric(&tls->ot_fetch_bytes, D_TM_COUNTER,
+			     "total number of bytes fetched/read", "",
+			     "io/%u/fetch_bytes", tgt_id);
+	if (rc)
+		D_WARN("Failed to create bytes fetch sensor: "DF_RC"\n",
+		       DP_RC(rc));
+
+	/** Total bytes written */
+	rc = d_tm_add_metric(&tls->ot_update_bytes, D_TM_COUNTER,
+			     "total number of bytes updated/written", "",
+			     "io/%u/update_bytes", tgt_id);
+	if (rc)
+		D_WARN("Failed to create bytes udpate sensor: "DF_RC"\n",
 		       DP_RC(rc));
 
 	return tls;

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -81,11 +81,11 @@ obj_gen_dtx_mbs(struct daos_shard_tgt *tgts, bool is_ec, uint32_t *tgt_cnt,
  * After bulk finish, let's send reply, then release the resource.
  */
 static int
-obj_rw_complete(crt_rpc_t *rpc, unsigned int map_version,
+obj_rw_complete(crt_rpc_t *rpc, struct obj_io_context *ioc,
 		daos_handle_t ioh, int status, struct dtx_handle *dth)
 {
 	struct obj_rw_in	*orwi = crt_req_get(rpc);
-	int			 rc;
+	int			rc;
 
 	if (daos_handle_is_valid(ioh)) {
 		bool update = obj_rpc_is_update(rpc);
@@ -94,10 +94,11 @@ obj_rw_complete(crt_rpc_t *rpc, unsigned int map_version,
 			rc = dtx_sub_init(dth, &orwi->orw_oid,
 					  orwi->orw_dkey_hash);
 			if (rc == 0)
-				rc = vos_update_end(ioh, map_version,
-						&orwi->orw_dkey, status, dth);
+				rc = vos_update_end(ioh, ioc->ioc_map_ver,
+						    &orwi->orw_dkey, status,
+						    &ioc->ioc_io_size, dth);
 		} else {
-			rc = vos_fetch_end(ioh, status);
+			rc = vos_fetch_end(ioh, &ioc->ioc_io_size, status);
 		}
 
 		if (rc != 0) {
@@ -1117,7 +1118,7 @@ obj_fetch_shadow(daos_handle_t coh, daos_unit_oid_t oid, daos_epoch_t epoch,
 	}
 
 	*pshadows = vos_ioh2recx_list(ioh);
-	vos_fetch_end(ioh, 0);
+	vos_fetch_end(ioh, NULL, 0);
 
 out:
 	obj_iod_idx_parity2vos(iod_nr, iods);
@@ -1521,7 +1522,7 @@ out:
 		D_FREE(bsgls_dup);
 	}
 
-	rc = obj_rw_complete(rpc, ioc->ioc_map_ver, ioh, rc, dth);
+	rc = obj_rw_complete(rpc, ioc, ioh, rc, dth);
 	if (iods_dup != NULL)
 		daos_iod_recx_free(iods_dup, orw->orw_nr);
 	return rc;
@@ -1654,8 +1655,9 @@ do_obj_ioc_begin(uint32_t rpc_map_ver, uuid_t pool_uuid,
 		 uuid_t coh_uuid, uuid_t cont_uuid, uint32_t opc,
 		 struct obj_io_context *ioc)
 {
-	struct ds_pool_child *poc;
-	int		      rc;
+	struct obj_tls		*tls;
+	struct ds_pool_child	*poc;
+	int			rc;
 
 	rc = obj_ioc_init(pool_uuid, coh_uuid, cont_uuid, opc, ioc);
 	if (rc)
@@ -1664,8 +1666,8 @@ do_obj_ioc_begin(uint32_t rpc_map_ver, uuid_t pool_uuid,
 	poc = ioc->ioc_coc->sc_pool;
 	D_ASSERT(poc != NULL);
 
-	if (poc->spc_pool->sp_map == NULL ||
-	    DAOS_FAIL_CHECK(DAOS_FORCE_REFRESH_POOL_MAP)) {
+	if (unlikely(poc->spc_pool->sp_map == NULL ||
+		     DAOS_FAIL_CHECK(DAOS_FORCE_REFRESH_POOL_MAP))) {
 		/* XXX: Client (or leader replica) has newer pool map than
 		 *	current replica. Two possible cases:
 		 *
@@ -1696,7 +1698,7 @@ do_obj_ioc_begin(uint32_t rpc_map_ver, uuid_t pool_uuid,
 		}
 
 		D_GOTO(out, rc);
-	} else if (rpc_map_ver < ioc->ioc_map_ver) {
+	} else if (unlikely(rpc_map_ver < ioc->ioc_map_ver)) {
 		D_DEBUG(DB_IO, "stale version req %d map_version %d\n",
 			rpc_map_ver, ioc->ioc_map_ver);
 
@@ -1713,29 +1715,80 @@ do_obj_ioc_begin(uint32_t rpc_map_ver, uuid_t pool_uuid,
 
 out:
 	dss_rpc_cntr_enter(DSS_RC_OBJ);
+	/** increment active request counter and start the chrono */
+	tls = obj_tls_get();
+	(void)d_tm_increment_gauge(&tls->ot_op_active[opc], 1, NULL);
+	ioc->ioc_start_time = daos_get_ntime();
 	ioc->ioc_began = 1;
 	return rc;
+}
+
+static inline unsigned int
+lat_bucket(uint64_t size)
+{
+	int nr;
+
+	if (size <= 256)
+		return 0;
+
+	/** return number of leading zero-bits */
+	nr =  __builtin_clzl(size - 1);
+
+	/** >4MB, return last bucket */
+	if (nr < 42)
+		return NR_LATENCY_BUCKETS - 1;
+
+	return 56 - nr;
+}
+
+static inline void
+obj_update_sensors(struct obj_io_context *ioc, int err)
+{
+	struct obj_tls		*tls = obj_tls_get();
+	struct d_tm_node_t	**lat;
+	uint32_t		opc = ioc->ioc_opc;
+	uint64_t		time;
+
+	(void)d_tm_decrement_gauge(&tls->ot_op_active[opc], 1, NULL);
+	(void)d_tm_increment_counter(&tls->ot_op_total[opc], 1, NULL);
+
+	if (unlikely(err != 0))
+		return;
+
+	/**
+	 * Measure latency of successful I/O only.
+	 * Use bit shift for performance and tolerate some inaccuracy.
+	 */
+	time = daos_get_ntime() - ioc->ioc_start_time;
+	time >>= 10;
+
+	switch (opc) {
+		case DAOS_OBJ_RPC_UPDATE:
+		case DAOS_OBJ_RPC_TGT_UPDATE:
+			(void)d_tm_increment_counter(&tls->ot_update_bytes,
+						     ioc->ioc_io_size, NULL);
+			lat = &tls->ot_update_lat[lat_bucket(ioc->ioc_io_size)];
+			break;
+		case DAOS_OBJ_RPC_FETCH:
+			(void)d_tm_increment_counter(&tls->ot_fetch_bytes,
+						     ioc->ioc_io_size, NULL);
+			lat = &tls->ot_fetch_lat[lat_bucket(ioc->ioc_io_size)];
+			break;
+		default:
+			lat = &tls->ot_op_lat[opc];
+	}
+	(void)d_tm_set_gauge(lat, time, NULL);
 }
 
 static void
 obj_ioc_end(struct obj_io_context *ioc, int err)
 {
-	if (ioc->ioc_began) {
-		struct obj_tls	*tls = obj_tls_get();
-		uint32_t	opc = ioc->ioc_opc;
-
+	if (likely(ioc->ioc_began)) {
 		dss_rpc_cntr_exit(DSS_RC_OBJ, !!err);
 		ioc->ioc_began = 0;
 
 		/** Update sensors */
-		if (err == 0)
-			/** measure latency of successful I/O only */
-			d_tm_set_gauge(&tls->ot_op_lat[opc],
-				       (daos_get_ntime() -
-					ioc->ioc_start_time) / 1000,
-				       NULL);
-		d_tm_decrement_gauge(&tls->ot_op_active[opc], 1, NULL);
-		d_tm_increment_counter(&tls->ot_op_total[opc], 1, NULL);
+		obj_update_sensors(ioc, err);
 	}
 	obj_ioc_fini(ioc);
 }
@@ -1746,18 +1799,12 @@ obj_ioc_begin(uint32_t rpc_map_ver, uuid_t pool_uuid,
 	      uuid_t coh_uuid, uuid_t cont_uuid, uint32_t opc,
 	      struct obj_io_context *ioc)
 {
-	struct obj_tls	*tls;
 	int		rc;
 
 	rc = do_obj_ioc_begin(rpc_map_ver, pool_uuid, coh_uuid, cont_uuid,
 			      opc, ioc);
 	if (rc != 0)
 		return rc;
-
-	/** increment active request counter and start the chrono */
-	tls = obj_tls_get();
-	d_tm_increment_gauge(&tls->ot_op_active[opc], 1, NULL);
-	ioc->ioc_start_time = daos_get_ntime();
 
 	rc = obj_capa_check(ioc->ioc_coh, obj_is_modification_opc(opc));
 	if (rc != 0)
@@ -1834,7 +1881,8 @@ ds_obj_ec_rep_handler(crt_rpc_t *rpc)
 			DP_UOID(oer->er_oid), DP_RC(rc));
 		goto out;
 	}
-	rc = vos_update_end(ioh, ioc.ioc_map_ver, dkey, rc, NULL);
+	rc = vos_update_end(ioh, ioc.ioc_map_ver, dkey, rc,
+			    &ioc.ioc_io_size, NULL);
 	if (rc) {
 		D_ERROR(DF_UOID" vos_update_end failed: "DF_RC".\n",
 			DP_UOID(oer->er_oid), DP_RC(rc));
@@ -1915,7 +1963,8 @@ ds_obj_ec_agg_handler(crt_rpc_t *rpc)
 				DP_UOID(oea->ea_oid), DP_RC(rc));
 			goto out;
 		}
-		rc = vos_update_end(ioh, ioc.ioc_map_ver, dkey, rc, NULL);
+		rc = vos_update_end(ioh, ioc.ioc_map_ver, dkey, rc,
+				    &ioc.ioc_io_size, NULL);
 		if (rc) {
 			D_ERROR(DF_UOID" vos_update_end failed: "DF_RC".\n",
 				DP_UOID(oea->ea_oid), DP_RC(rc));
@@ -2263,7 +2312,7 @@ again:
 		daos_epoch_t	e = 0;
 		struct obj_tls  *tls = obj_tls_get();
 
-		d_tm_increment_counter(&tls->ot_update_resent, 1, NULL);
+		(void)d_tm_increment_counter(&tls->ot_update_resent, 1, NULL);
 
 		rc = dtx_handle_resend(ioc.ioc_vos_coh, &orw->orw_dti,
 				       &e, &version);
@@ -2370,8 +2419,8 @@ again:
 			orw->orw_epoch = crt_hlc_get();
 			orw->orw_flags &= ~ORF_RESEND;
 			flags = 0;
-			d_tm_increment_counter(&tls->ot_update_restart, 1,
-					       NULL);
+			(void)d_tm_increment_counter(&tls->ot_update_restart, 1,
+						     NULL);
 			goto again;
 		}
 
@@ -3534,7 +3583,7 @@ ds_obj_dtx_handle_one(crt_rpc_t *rpc, struct daos_cpd_sub_head *dcsh,
 				     dcsr->dcsr_read.dcr_iods,
 				     VOS_OF_FETCH_SET_TS_ONLY, NULL, &ioh, dth);
 		if (rc == 0)
-			rc = vos_fetch_end(ioh, 0);
+			rc = vos_fetch_end(ioh, NULL, 0);
 		else if (rc == -DER_NONEXIST)
 			rc = 0;
 
@@ -3774,7 +3823,7 @@ ds_obj_dtx_handle_one(crt_rpc_t *rpc, struct daos_cpd_sub_head *dcsh,
 				goto out;
 
 			rc = vos_update_end(iohs[i], dth->dth_ver,
-					    &dcsr->dcsr_dkey, rc, dth);
+					    &dcsr->dcsr_dkey, rc, NULL, dth);
 			iohs[i] = DAOS_HDL_INVAL;
 			if (rc != 0)
 				goto out;
@@ -3860,7 +3909,7 @@ out:
 				dcri = dcde->dcde_reqs + dcde->dcde_read_cnt;
 				dcsr = &dcsrs[dcri[i].dcri_req_idx];
 				vos_update_end(iohs[i], dth->dth_ver,
-					       &dcsr->dcsr_dkey, rc, dth);
+					       &dcsr->dcsr_dkey, rc, NULL, dth);
 			}
 		}
 

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -1763,19 +1763,19 @@ obj_update_sensors(struct obj_io_context *ioc, int err)
 	time >>= 10;
 
 	switch (opc) {
-		case DAOS_OBJ_RPC_UPDATE:
-		case DAOS_OBJ_RPC_TGT_UPDATE:
-			(void)d_tm_increment_counter(&tls->ot_update_bytes,
-						     ioc->ioc_io_size, NULL);
-			lat = &tls->ot_update_lat[lat_bucket(ioc->ioc_io_size)];
-			break;
-		case DAOS_OBJ_RPC_FETCH:
-			(void)d_tm_increment_counter(&tls->ot_fetch_bytes,
-						     ioc->ioc_io_size, NULL);
-			lat = &tls->ot_fetch_lat[lat_bucket(ioc->ioc_io_size)];
-			break;
-		default:
-			lat = &tls->ot_op_lat[opc];
+	case DAOS_OBJ_RPC_UPDATE:
+	case DAOS_OBJ_RPC_TGT_UPDATE:
+		(void)d_tm_increment_counter(&tls->ot_update_bytes,
+					     ioc->ioc_io_size, NULL);
+		lat = &tls->ot_update_lat[lat_bucket(ioc->ioc_io_size)];
+		break;
+	case DAOS_OBJ_RPC_FETCH:
+		(void)d_tm_increment_counter(&tls->ot_fetch_bytes,
+					     ioc->ioc_io_size, NULL);
+		lat = &tls->ot_fetch_lat[lat_bucket(ioc->ioc_io_size)];
+		break;
+	default:
+		lat = &tls->ot_op_lat[opc];
 	}
 	(void)d_tm_set_gauge(lat, time, NULL);
 }

--- a/src/object/srv_obj_migrate.c
+++ b/src/object/srv_obj_migrate.c
@@ -1205,7 +1205,8 @@ post:
 		}
 	}
 end:
-	rc1 = vos_update_end(ioh, mrone->mo_version, &mrone->mo_dkey, rc, NULL);
+	rc1 = vos_update_end(ioh, mrone->mo_version, &mrone->mo_dkey, rc, NULL,
+			     NULL);
 	daos_csummer_free_ic(csummer, &iod_csums);
 	daos_csummer_destroy(&csummer);
 	daos_iov_free(&csum_iov_fetch);

--- a/src/rdb/rdb_util.c
+++ b/src/rdb/rdb_util.c
@@ -356,7 +356,7 @@ rdb_vos_fetch_addr(daos_handle_t cont, daos_epoch_t epoch, rdb_oid_t oid,
 	rc = bio_iod_post(vos_ioh2desc(io));
 	D_ASSERTF(rc == 0, ""DF_RC"\n", DP_RC(rc));
 out:
-	rc = vos_fetch_end(io, 0 /* err */);
+	rc = vos_fetch_end(io, NULL, 0 /* err */);
 	D_ASSERTF(rc == 0, ""DF_RC"\n", DP_RC(rc));
 
 	return rdb_vos_fetch_check(value, &value_orig);

--- a/src/tests/daos_perf.c
+++ b/src/tests/daos_perf.c
@@ -383,9 +383,9 @@ _vos_update_or_fetch(int obj_idx, enum ts_op_type op_type,
 		rc = bio_iod_post(vos_ioh2desc(ioh));
 end:
 		if (op_type == TS_DO_UPDATE)
-			rc = vos_update_end(ioh, 0, &cred->tc_dkey, rc, NULL);
+			rc = vos_update_end(ioh, 0, &cred->tc_dkey, rc, NULL, NULL);
 		else
-			rc = vos_fetch_end(ioh, rc);
+			rc = vos_fetch_end(ioh, NULL, rc);
 	}
 
 	TS_TIME_END(duration, start);

--- a/src/tests/daos_perf.c
+++ b/src/tests/daos_perf.c
@@ -383,7 +383,8 @@ _vos_update_or_fetch(int obj_idx, enum ts_op_type op_type,
 		rc = bio_iod_post(vos_ioh2desc(ioh));
 end:
 		if (op_type == TS_DO_UPDATE)
-			rc = vos_update_end(ioh, 0, &cred->tc_dkey, rc, NULL, NULL);
+			rc = vos_update_end(ioh, 0, &cred->tc_dkey, rc, NULL,
+					    NULL);
 		else
 			rc = vos_fetch_end(ioh, NULL, rc);
 	}

--- a/src/vos/tests/vts_checksum.c
+++ b/src/vos/tests/vts_checksum.c
@@ -206,7 +206,7 @@ csum_for_arrays_test_case(void *const *state, const struct test_case_args *test)
 		cia_idx_next(&f_csums_idx, f_csums, f_csums_nr));
 
 	/** Clean up */
-	vos_fetch_end(ioh, rc);
+	vos_fetch_end(ioh, NULL, rc);
 	d_sgl_fini(&sgl, true);
 
 	for (i = 0; i < update_recx_nr; i++)

--- a/src/vos/tests/vts_gc.c
+++ b/src/vos/tests/vts_gc.c
@@ -132,7 +132,7 @@ gc_obj_update(struct gc_test_args *args, daos_handle_t coh, daos_unit_oid_t oid,
 			return rc;
 		}
 
-		rc = vos_update_end(ioh, 0, &cred->tc_dkey, rc, NULL);
+		rc = vos_update_end(ioh, 0, &cred->tc_dkey, rc, NULL, NULL);
 		if (rc != 0) {
 			print_error("Failed to submit ZC update\n");
 			return rc;

--- a/src/vos/tests/vts_io.c
+++ b/src/vos/tests/vts_io.c
@@ -599,7 +599,7 @@ io_test_obj_update(struct io_test_args *arg, daos_epoch_t epoch, uint64_t flags,
 	rc = bio_iod_post(vos_ioh2desc(ioh));
 end:
 	if (rc == 0 && (arg->ta_flags & TF_ZERO_COPY))
-		rc = vos_update_end(ioh, 0, dkey, rc, dth);
+		rc = vos_update_end(ioh, 0, dkey, rc, NULL, dth);
 	if (rc != 0 && verbose && rc != -DER_INPROGRESS &&
 		(arg->ta_flags & TF_ZERO_COPY))
 		print_error("Failed to submit ZC update: "DF_RC"\n", DP_RC(rc));
@@ -662,7 +662,7 @@ io_test_obj_fetch(struct io_test_args *arg, daos_epoch_t epoch, uint64_t flags,
 
 	rc = bio_iod_post(vos_ioh2desc(ioh));
 end:
-	rc = vos_fetch_end(ioh, rc);
+	rc = vos_fetch_end(ioh, NULL, rc);
 	if (((flags & VOS_COND_FETCH_MASK) && rc == -DER_NONEXIST) ||
 	    rc == -DER_INPROGRESS)
 		goto skip;

--- a/src/vos/vos_io.c
+++ b/src/vos/vos_io.c
@@ -59,6 +59,8 @@ struct vos_io_context {
 	uint32_t		 ic_dedup_th;
 	/** dedup entries to be inserted after transaction done */
 	d_list_t		 ic_dedup_entries;
+	/** the total size of the IO */
+	uint64_t		 ic_io_size;
 	/** flags */
 	unsigned int		 ic_update:1,
 				 ic_size_fetch:1,
@@ -466,6 +468,7 @@ vos_ioc_create(daos_handle_t coh, daos_unit_oid_t oid, bool read_only,
 	if (ioc == NULL)
 		return -DER_NOMEM;
 
+	ioc->ic_io_size = 0;
 	ioc->ic_iod_nr = iod_nr;
 	ioc->ic_iods = iods;
 	ioc->ic_epr.epr_hi = dtx_is_valid_handle(dth) ? dth->dth_epoch : epoch;
@@ -863,7 +866,7 @@ akey_fetch_recx(daos_handle_t toh, const daos_epoch_range_t *epr,
 				goto failed;
 		}
 		bio_iov_set(&biov, ent->en_addr, nr * ent_array.ea_inob);
-
+		ioc->ic_io_size += nr * ent_array.ea_inob;
 		if (ci_is_valid(&ent->en_csum)) {
 			rc = save_csum(ioc, &ent->en_csum, ent, rsize);
 			if (rc != 0)
@@ -1253,12 +1256,14 @@ out:
 }
 
 int
-vos_fetch_end(daos_handle_t ioh, int err)
+vos_fetch_end(daos_handle_t ioh, daos_size_t *size, int err)
 {
 	struct vos_io_context *ioc = vos_ioh2ioc(ioh);
 
 	/* NB: it's OK to use the stale ioc->ic_obj for fetch_end */
 	D_ASSERT(!ioc->ic_update);
+	if (size != NULL && err == 0)
+		*size = ioc->ic_io_size;
 	vos_ioc_destroy(ioc, false);
 	return err;
 }
@@ -1349,7 +1354,7 @@ out:
 	if (rc != 0) {
 		daos_recx_ep_list_free(ioc->ic_recx_lists, ioc->ic_iod_nr);
 		ioc->ic_recx_lists = NULL;
-		return vos_fetch_end(vos_ioc2ioh(ioc), rc);
+		return vos_fetch_end(vos_ioc2ioh(ioc), NULL, rc);
 	}
 	return 0;
 }
@@ -1458,7 +1463,7 @@ akey_update_recx(daos_handle_t toh, uint32_t pm_ver, daos_recx_t *recx,
 
 	if (csum != NULL)
 		ent.ei_csum = *csum;
-
+	ioc->ic_io_size += recx->rx_nr * rsize;
 	biov = iod_update_biov(ioc);
 	ent.ei_addr = biov->bi_addr;
 	ent.ei_addr.ba_dedup = false;	/* Don't make this flag persistent */
@@ -2016,7 +2021,7 @@ update_cancel(struct vos_io_context *ioc)
 
 int
 vos_update_end(daos_handle_t ioh, uint32_t pm_ver, daos_key_t *dkey, int err,
-	       struct dtx_handle *dth)
+	       daos_size_t *size, struct dtx_handle *dth)
 {
 	struct vos_dtx_act_ent	**daes = NULL;
 	struct vos_dtx_cmt_ent	**dces = NULL;
@@ -2124,6 +2129,8 @@ abort:
 	VOS_TIME_END(time, VOS_UPDATE_END);
 	vos_space_unhold(vos_cont2pool(ioc->ic_cont), &ioc->ic_space_held[0]);
 
+	if (size != NULL && err == 0)
+		*size = ioc->ic_io_size;
 	D_FREE(daes);
 	D_FREE(dces);
 	vos_ioc_destroy(ioc, err != 0);
@@ -2210,7 +2217,7 @@ vos_update_begin(daos_handle_t coh, daos_unit_oid_t oid, daos_epoch_t epoch,
 	*ioh = vos_ioc2ioh(ioc);
 	return 0;
 error:
-	vos_update_end(vos_ioc2ioh(ioc), 0, dkey, rc, dth);
+	vos_update_end(vos_ioc2ioh(ioc), 0, dkey, rc, NULL, dth);
 	return rc;
 }
 
@@ -2420,7 +2427,7 @@ vos_obj_update_ex(daos_handle_t coh, daos_unit_oid_t oid, daos_epoch_t epoch,
 				DP_RC(rc));
 	}
 
-	rc = vos_update_end(ioh, pm_ver, dkey, rc, dth);
+	rc = vos_update_end(ioh, pm_ver, dkey, rc, NULL, dth);
 	return rc;
 }
 
@@ -2464,7 +2471,7 @@ vos_obj_array_remove(daos_handle_t coh, daos_unit_oid_t oid,
 	ioc->ic_epr.epr_lo = epr->epr_lo;
 
 	rc = vos_update_end(ioh, 0 /* don't care */, (daos_key_t *)dkey, rc,
-			    NULL);
+			    NULL, NULL);
 	return rc;
 }
 
@@ -2508,7 +2515,7 @@ vos_obj_fetch_ex(daos_handle_t coh, daos_unit_oid_t oid, daos_epoch_t epoch,
 				DP_UOID(oid), DP_RC(rc));
 	}
 
-	rc = vos_fetch_end(ioh, rc);
+	rc = vos_fetch_end(ioh, NULL, rc);
 	return rc;
 }
 


### PR DESCRIPTION
Change latency measurement for update and fetch RPCs to be reported
on per-size range. To do so, VOS had to be changed to report total
I/O size back to object layer.

Move start time calculation to do_obj_ioc_begin() since compound RPCs
bypass obj_ioc_begin().

Add cart counters for URI lookups and failed RPCs.

Signed-off-by: Johann Lombardi <johann.lombardi@intel.com>