### PR TITLE
DAOS-6985 tests: skip test_setup failure

### DIFF
--- a/src/tests/suite/daos_degrade_ec.c
+++ b/src/tests/suite/daos_degrade_ec.c
@@ -302,7 +302,11 @@ degrade_small_sub_setup(void **state)
 
 	rc = test_setup(state, SETUP_CONT_CONNECT, true,
 			DEGRADE_SMALL_POOL_SIZE, 6, NULL);
-	return rc;
+	if (rc)
+		print_message("It can not create the pool with 6 ranks"
+			      "probably due to not enough ranks %d\n", rc);
+
+	return 0;
 }
 
 /** create a new pool/container for each test */

--- a/src/tests/suite/daos_extend_simple.c
+++ b/src/tests/suite/daos_extend_simple.c
@@ -229,6 +229,12 @@ extend_small_sub_setup(void **state)
 	save_group_state(state);
 	rc = test_setup(state, SETUP_CONT_CONNECT, true,
 			EXTEND_SMALL_POOL_SIZE, 3, NULL);
+	if (rc) {
+		print_message("It can not create the pool with 4 ranks"
+			      "probably due to not enough ranks %d\n", rc);
+		return 0;
+	}
+
 	return rc;
 }
 

--- a/src/tests/suite/daos_rebuild_ec.c
+++ b/src/tests/suite/daos_rebuild_ec.c
@@ -151,8 +151,15 @@ rebuild_ec_setup(void  **state, int number)
 	save_group_state(state);
 	rc = test_setup(state, SETUP_CONT_CONNECT, true,
 			REBUILD_SMALL_POOL_SIZE, number, NULL);
-	if (rc)
-		return rc;
+	if (rc) {
+		/* Let's skip for this case, since it is possible there
+		 * is not enough ranks here.
+		 */
+		print_message("It can not create the pool with %d ranks"
+			      "probably due to not enough ranks %d\n",
+			      number, rc);
+		return 0;
+	}
 
 	arg = *state;
 	if (dt_obj_class != DAOS_OC_UNKNOWN)

--- a/src/tests/suite/daos_rebuild_simple.c
+++ b/src/tests/suite/daos_rebuild_simple.c
@@ -801,8 +801,14 @@ rebuild_small_pool_n4_setup(void **state)
 	save_group_state(state);
 	rc = test_setup(state, SETUP_CONT_CONNECT, true,
 			REBUILD_SMALL_POOL_SIZE, 4, NULL);
-	if (rc)
-		return rc;
+	if (rc) {
+		/* Let's skip for this case, since it is possible there
+		 * is not enough ranks here.
+		 */
+		print_message("It can not create the pool with 4 ranks"
+			      "probably due to not enough ranks %d\n", rc);
+		return 0;
+	}
 
 	arg = *state;
 	if (dt_obj_class != DAOS_OC_UNKNOWN)
@@ -822,6 +828,9 @@ rebuild_large_snap(void **state)
 	int		tgt = DEFAULT_FAIL_TGT;
 	daos_epoch_t	snap_epoch[100];
 	int		i;
+
+	if (!test_runable(arg, 4))
+		return;
 
 	oid = daos_test_oid_gen(arg->coh, arg->obj_class, 0, 0, arg->myrank);
 	oid = dts_oid_set_rank(oid, ranks_to_kill[0]);

--- a/src/tests/suite/daos_test_common.c
+++ b/src/tests/suite/daos_test_common.c
@@ -588,6 +588,12 @@ test_runable(test_arg_t *arg, unsigned int required_nodes)
 	int		 i;
 	static bool	 runable = true;
 
+	if (arg == NULL) {
+		print_message("state not set, likely due to group-setup"
+			      " issue\n");
+		return false;
+	}
+
 	if (arg->myrank == 0) {
 		int			tgts_per_node;
 		int			disable_nodes;


### PR DESCRIPTION
Skip test_setup failure if pool create fails, since
there might may not be enough ranks avaible.

Ideally, we should check it by system query, but there
is not enough support for this in test-frame work.

Signed-off-by: Di Wang <di.wang@intel.com>