### PR TITLE
DAOS-623 vos: Add some logs that would help with debugging assertion

### DIFF
--- a/src/vos/ilog.c
+++ b/src/vos/ilog.c
@@ -181,7 +181,7 @@ ilog_log_add(struct ilog_context *lctx, struct ilog_id *id)
 		return rc;
 	}
 
-	D_DEBUG(DB_TRACE, "Registered ilog="DF_X64" epoch="DF_X64" tx_id=%d\n",
+	D_DEBUG(DB_TRACE, "Registered ilog="DF_X64" epoch="DF_X64" lid=%d\n",
 		lctx->ic_root_off, id->id_epoch, id->id_tx_id);
 
 	return 0;
@@ -206,7 +206,7 @@ ilog_log_del(struct ilog_context *lctx, const struct ilog_id *id,
 	}
 
 	D_DEBUG(DB_TRACE, "%s ilog="DF_X64" epoch="DF_X64
-		" tx_id=%d\n", deregister ? "Deregistered" : "Removed",
+		" lid=%d\n", deregister ? "Deregistered" : "Removed",
 		lctx->ic_root_off, id->id_epoch, id->id_tx_id);
 
 	return 0;
@@ -489,13 +489,15 @@ ilog_create(struct umem_instance *umm, struct ilog_df *root)
 	return rc;
 }
 
-#define ILOG_ASSERT_VALID(root_df)				\
-	do {							\
-		struct ilog_root	*__root;		\
-								\
-		__root = (struct ilog_root *)(root_df);		\
-		D_ASSERT((__root != NULL) &&			\
-			 ILOG_MAGIC_VALID(__root->lr_magic));	\
+#define ILOG_ASSERT_VALID(root_df)					\
+	do {								\
+		struct ilog_root	*_root;				\
+									\
+		_root = (struct ilog_root *)(root_df);			\
+		D_ASSERTF((_root != NULL) &&				\
+			  ILOG_MAGIC_VALID(_root->lr_magic),		\
+			  "Invalid ilog root detected %p magic=%#x\n",	\
+			  _root, _root == NULL ? 0 : _root->lr_magic);	\
 	} while (0)
 
 int


### PR DESCRIPTION
In debugging DAOS-5758, I found it useful if we change logs to use
lid, as is done with DTX and to log the failing address associated
with the ILOG_ASSERT_VALID assertion.

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>