### PR TITLE
DAOS-5621 test: add all test servers in dmg.yaml hostlist

### DIFF
--- a/src/tests/ftest/daos_test/daos_core_test-nvme_recovery.py
+++ b/src/tests/ftest/daos_test/daos_core_test-nvme_recovery.py
@@ -31,7 +31,7 @@ class DaosCoreTestNvme(DaosCoreBase):
         """
         self.run_subtest()
 
-    @skipForTicket("DAOS-6767")
+    @skipForTicket("DAOS-5134")
     def test_daos_nvme_recovery_2(self):
         """Jira ID: DAOS-3846.
 
@@ -48,7 +48,7 @@ class DaosCoreTestNvme(DaosCoreBase):
         """
         self.run_subtest()
 
-    @skipForTicket("DAOS-6767")
+    @skipForTicket("DAOS-5134")
     def test_daos_nvme_recovery_3(self):
         """Jira ID: DAOS-3846.
 
@@ -65,7 +65,7 @@ class DaosCoreTestNvme(DaosCoreBase):
         """
         self.run_subtest()
 
-    @skipForTicket("DAOS-6767")
+    @skipForTicket("DAOS-5134")
     def test_daos_nvme_recovery_4(self):
         """Jira ID: DAOS-3846.
 

--- a/src/tests/ftest/util/server_utils.py
+++ b/src/tests/ftest/util/server_utils.py
@@ -413,10 +413,10 @@ class DaosServerManager(SubprocessManager):
 
         Args:
             hosts (list, optional): dmg hostlist value. Defaults to None which
-                results in using the 'access_points' host list.
+                results in using the entire host list.
         """
         if hosts is None:
-            hosts = self.get_config_value("access_points")
+            hosts = self._hosts
         self.dmg.hostlist = hosts
 
     def prepare(self, storage=True):


### PR DESCRIPTION
List all servers to dmg.yaml hostlist parameter in tests to enable dmg
non-MS commands to run across all hosts.

Master PR: https://github.com/daos-stack/daos/pull/4973

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>

Conflicts:
	src/tests/ftest/daos_test/daos_core_test-nvme_recovery.py