### PR TITLE
DAOS-6928-test: Daos pool list-containers succeed after the pool already been evicted

### DIFF
--- a/src/tests/ftest/control/dmg_pool_evict.py
+++ b/src/tests/ftest/control/dmg_pool_evict.py
@@ -62,7 +62,7 @@ class DmgPoolEvictTest(TestWithServers):
                 "daos pool list-cont with second pool succeeded as expected")
         except CommandFailure:
             self.fail(
-                "daos pool list-cont with first pool failed after pool evict!")
+                "daos pool list-cont with second pool failed after pool evict!")
 
         self.container.pop()
 

--- a/src/tests/ftest/control/dmg_pool_evict.py
+++ b/src/tests/ftest/control/dmg_pool_evict.py
@@ -54,17 +54,15 @@ class DmgPoolEvictTest(TestWithServers):
             self.fail(
                 "daos pool list-cont with first pool failed after pool evict!")
 
-        # Call daos pool list-cont on the evicted pool. It should fail with
-        # -1012.
+        # Call daos pool list-cont on the evicted pool. It should succeed. 
         try:
             daos_cmd.pool_list_cont(
                 pool=self.pool[1].uuid)
-            self.fail(
-                "daos pool list-cont with second pool succeeded after pool " +
-                "evict!")
-        except CommandFailure:
             self.log.info(
-                "daos pool list-cont with second pool failed as expected")
+                "daos pool list-cont with second pool succeeded as expected")
+        except CommandFailure:
+            self.fail(
+                "daos pool list-cont with first pool failed after pool evict!")
 
         self.container.pop()
 

--- a/src/tests/ftest/control/dmg_pool_evict.py
+++ b/src/tests/ftest/control/dmg_pool_evict.py
@@ -54,7 +54,7 @@ class DmgPoolEvictTest(TestWithServers):
             self.fail(
                 "daos pool list-cont with first pool failed after pool evict!")
 
-        # Call daos pool list-cont on the evicted pool. It should succeed. 
+        # Call daos pool list-cont on the evicted pool. It should succeed.
         try:
             daos_cmd.pool_list_cont(
                 pool=self.pool[1].uuid)


### PR DESCRIPTION
DAOS-6928-test: Daos pool list-containers succeed after the pool already been evicted

Updated: control/dmg_pool_evict.py
Skip-unit-tests: true
Skip-nlt: true
Test-tag: dmg_pool_evict
Signed-off-by: Ding Ho <ding-hwa.ho@intel.com>