### PR TITLE
DAOS-6726 vos: rollback DTX commit entry if fail to commit

### DIFF
--- a/src/vos/vos_dtx.c
+++ b/src/vos/vos_dtx.c
@@ -377,7 +377,10 @@ static int
 dtx_cmt_ent_update(struct btr_instance *tins, struct btr_record *rec,
 		   d_iov_t *key, d_iov_t *val)
 {
-	struct vos_dtx_cmt_ent	*dce = val->iov_buf;
+	struct vos_dtx_cmt_ent	*dce_new = val->iov_buf;
+	struct vos_dtx_cmt_ent	*dce_old;
+
+	dce_old = umem_off2ptr(&tins->ti_umm, rec->rec_off);
 
 	/* Two possible cases for that:
 	 *
@@ -387,8 +390,8 @@ dtx_cmt_ent_update(struct btr_instance *tins, struct btr_record *rec,
 	 * at that time the DTX entry has already been added into the
 	 * committed table that is in DRAM. Currently, we do not have
 	 * efficient way to recover such DRAM based btree structure,
-	 * so just keep it there. Then when we re-commit such DTX, we
-	 * may come here.
+	 * so just keep it there with 'dce_invalid' flags. Then when
+	 * we re-commit such DTX, we may come here.
 	 *
 	 * Case two:
 	 * As the vos_dtx_cmt_reindex() logic going, some RPC handler
@@ -398,8 +401,13 @@ dtx_cmt_ent_update(struct btr_instance *tins, struct btr_record *rec,
 	 * indexed table.
 	 */
 
-	if (!dce->dce_reindex)
-		dce->dce_exist = 1;
+	if (dce_old->dce_invalid) {
+		rec->rec_off = umem_ptr2off(&tins->ti_umm, dce_new);
+		D_FREE(dce_old);
+	} else if (!dce_old->dce_reindex) {
+		D_ASSERT(dce_new->dce_reindex);
+		dce_new->dce_exist = 1;
+	}
 
 	return 0;
 }
@@ -760,11 +768,18 @@ vos_dtx_commit_one(struct vos_container *cont, struct dtx_id *dti,
 		if (rc == -DER_NONEXIST) {
 			rc = dbtree_lookup(cont->vc_dtx_committed_hdl,
 					   &kiov, &riov);
-			if (rc == 0 && dck != NULL) {
+			if (rc == 0) {
 				dce = (struct vos_dtx_cmt_ent *)riov.iov_buf;
-				dck->oid = DCE_OID(dce);
-				dck->dkey_hash = DCE_DKEY_HASH(dce);
-				dce = NULL;
+				if (dce->dce_invalid) {
+					dce = NULL;
+					D_GOTO(out, rc = -DER_NONEXIST);
+				}
+
+				if (dck != NULL) {
+					dck->oid = DCE_OID(dce);
+					dck->dkey_hash = DCE_DKEY_HASH(dce);
+					dce = NULL;
+				}
 			}
 
 			goto out;
@@ -863,7 +878,13 @@ insert:
 	d_iov_set(&riov, dce, sizeof(*dce));
 	rc = dbtree_upsert(cont->vc_dtx_committed_hdl, BTR_PROBE_EQ,
 			   DAOS_INTENT_UPDATE, &kiov, &riov);
-	if (rc != 0 || epoch != 0)
+	if (rc != 0)
+		goto out;
+
+	*dce_p = dce;
+	dce = NULL;
+
+	if (epoch != 0)
 		goto out;
 
 	rc = dtx_rec_release(cont, dae, false);
@@ -884,16 +905,12 @@ out:
 	D_CDEBUG(rc != 0 && rc != -DER_NONEXIST, DLOG_ERR, DB_IO,
 		 "Commit the DTX "DF_DTI": rc = "DF_RC"\n",
 		 DP_DTI(dti), DP_RC(rc));
-	if (rc != 0) {
-		if (dce != NULL) {
-			if (dce->dce_oids != NULL &&
-			    dce->dce_oids != &dce->dce_oid_inline &&
-			    dce->dce_oids != &DCE_OID(dce))
-				D_FREE(dce->dce_oids);
-			D_FREE_PTR(dce);
-		}
-	} else {
-		*dce_p = dce;
+	if (rc != 0 && dce != NULL) {
+		if (dce->dce_oids != NULL &&
+		    dce->dce_oids != &dce->dce_oid_inline &&
+		    dce->dce_oids != &DCE_OID(dce))
+			D_FREE(dce->dce_oids);
+		D_FREE(dce);
 	}
 
 	return rc;
@@ -1552,7 +1569,7 @@ vos_dtx_prepared(struct dtx_handle *dth)
 
 	if (dth->dth_solo) {
 		rc = vos_dtx_commit_internal(cont, &dth->dth_xid, 1,
-					     dth->dth_epoch, NULL, NULL);
+					     dth->dth_epoch, NULL, NULL, NULL);
 		dth->dth_active = 0;
 		if (rc >= 0)
 			dth->dth_sync = 1;
@@ -1749,9 +1766,16 @@ vos_dtx_check(daos_handle_t coh, struct dtx_id *dti, daos_epoch_t *epoch,
 	}
 
 	if (rc == -DER_NONEXIST) {
-		rc = dbtree_lookup(cont->vc_dtx_committed_hdl, &kiov, NULL);
-		if (rc == 0)
+		rc = dbtree_lookup(cont->vc_dtx_committed_hdl, &kiov, &riov);
+		if (rc == 0) {
+			struct vos_dtx_cmt_ent	*dce;
+
+			dce = (struct vos_dtx_cmt_ent *)riov.iov_buf;
+			if (dce->dce_invalid)
+				return -DER_NONEXIST;
+
 			return DTX_ST_COMMITTED;
+		}
 	}
 
 	if (rc == -DER_NONEXIST && for_resent && cont->vc_reindex_cmt_dtx)
@@ -1763,7 +1787,8 @@ vos_dtx_check(daos_handle_t coh, struct dtx_id *dti, daos_epoch_t *epoch,
 int
 vos_dtx_commit_internal(struct vos_container *cont, struct dtx_id *dtis,
 			int count, daos_epoch_t epoch, struct dtx_cos_key *dcks,
-			struct vos_dtx_act_ent **daes)
+			struct vos_dtx_act_ent **daes,
+			struct vos_dtx_cmt_ent **dces)
 {
 	struct vos_cont_df		*cont_df = cont->vc_cont_df;
 	struct umem_instance		*umm = vos_cont2umm(cont);
@@ -1820,6 +1845,9 @@ again:
 					dcks != NULL ? &dcks[cur] : NULL,
 					daes != NULL ? &daes[cur] : NULL,
 					&fatal);
+		if (dces != NULL)
+			dces[cur] = dce;
+
 		if (fatal)
 			goto out;
 
@@ -1932,6 +1960,9 @@ new_blob:
 					dcks != NULL ? &dcks[cur] : NULL,
 					daes != NULL ? &daes[cur] : NULL,
 					&fatal);
+		if (dces != NULL)
+			dces[cur] = dce;
+
 		if (fatal)
 			goto out;
 
@@ -1968,7 +1999,7 @@ out:
 
 void
 vos_dtx_post_handle(struct vos_container *cont, struct vos_dtx_act_ent **daes,
-		    int count, bool abort)
+		    struct vos_dtx_cmt_ent **dces, int count, bool abort)
 {
 	int	rc;
 	int	i;
@@ -1978,6 +2009,26 @@ vos_dtx_post_handle(struct vos_container *cont, struct vos_dtx_act_ent **daes,
 
 		if (daes[i] == NULL)
 			continue;
+
+		if (dces != NULL) {
+			D_ASSERT(!abort);
+
+			if (dces[i] == NULL)
+				continue;
+
+			d_iov_set(&kiov, &DCE_XID(dces[i]),
+				  sizeof(DCE_XID(dces[i])));
+			rc = dbtree_delete(cont->vc_dtx_committed_hdl,
+					   BTR_PROBE_EQ, &kiov, NULL);
+			if (rc != 0 && rc != -DER_NONEXIST) {
+				D_WARN("Failed to rollback cmt DTX entry "
+				       DF_DTI": "DF_RC"\n",
+				       DP_DTI(&DCE_XID(dces[i])), DP_RC(rc));
+				dces[i]->dce_invalid = 1;
+			}
+
+			continue;
+		}
 
 		d_iov_set(&kiov, &DAE_XID(daes[i]), sizeof(DAE_XID(daes[i])));
 		rc = dbtree_delete(cont->vc_dtx_active_hdl, BTR_PROBE_EQ,
@@ -2010,15 +2061,20 @@ vos_dtx_commit(daos_handle_t coh, struct dtx_id *dtis, int count,
 	       struct dtx_cos_key *dcks)
 {
 	struct vos_dtx_act_ent	**daes = NULL;
+	struct vos_dtx_cmt_ent	**dces = NULL;
 	struct vos_container	 *cont;
 	int			  committed = 0;
-	int			  rc;
+	int			  rc = 0;
 
 	D_ASSERT(count > 0);
 
 	D_ALLOC_ARRAY(daes, count);
 	if (daes == NULL)
-		return -DER_NOMEM;
+		D_GOTO(out, rc = -DER_NOMEM);
+
+	D_ALLOC_ARRAY(dces, count);
+	if (dces == NULL)
+		D_GOTO(out, rc = -DER_NOMEM);
 
 	cont = vos_hdl2cont(coh);
 	D_ASSERT(cont != NULL);
@@ -2027,14 +2083,18 @@ vos_dtx_commit(daos_handle_t coh, struct dtx_id *dtis, int count,
 	rc = umem_tx_begin(vos_cont2umm(cont), NULL);
 	if (rc == 0) {
 		committed = vos_dtx_commit_internal(cont, dtis, count,
-						    0, dcks, daes);
+						    0, dcks, daes, dces);
 		rc = umem_tx_end(vos_cont2umm(cont),
 				 committed > 0 ? 0 : committed);
 		if (rc == 0)
-			vos_dtx_post_handle(cont, daes, count, false);
+			vos_dtx_post_handle(cont, daes, NULL, count, false);
+		else
+			vos_dtx_post_handle(cont, daes, dces, count, false);
 	}
 
+out:
 	D_FREE(daes);
+	D_FREE(dces);
 
 	return rc < 0 ? rc : committed;
 }
@@ -2076,7 +2136,7 @@ vos_dtx_abort(daos_handle_t coh, daos_epoch_t epoch, struct dtx_id *dtis,
 
 		rc = umem_tx_end(vos_cont2umm(cont), aborted > 0 ? 0 : rc);
 		if (rc == 0)
-			vos_dtx_post_handle(cont, daes, count, true);
+			vos_dtx_post_handle(cont, daes, NULL, count, true);
 	}
 
 	D_FREE(daes);
@@ -2381,14 +2441,18 @@ vos_dtx_cmt_reindex(daos_handle_t coh, void *hint)
 		d_iov_set(&riov, dce, sizeof(*dce));
 		rc = dbtree_upsert(cont->vc_dtx_committed_hdl, BTR_PROBE_EQ,
 				   DAOS_INTENT_UPDATE, &kiov, &riov);
-		if (rc != 0)
+		if (rc != 0) {
+			D_FREE(dce);
 			goto out;
+		}
 
 		/* The committed DTX entry is already in the index.
 		 * Related re-index logic can stop.
 		 */
-		if (dce->dce_exist)
+		if (dce->dce_exist) {
+			D_FREE(dce);
 			D_GOTO(out, rc = 1);
+		}
 	}
 
 	if (dbd->dbd_count < dbd->dbd_cap || umoff_is_null(dbd->dbd_next))

--- a/src/vos/vos_internal.h
+++ b/src/vos/vos_internal.h
@@ -312,7 +312,8 @@ struct vos_dtx_cmt_ent {
 	int				 dce_oid_cnt;
 
 	uint32_t			 dce_reindex:1,
-					 dce_exist:1;
+					 dce_exist:1,
+					 dce_invalid:1;
 };
 
 #define DCE_XID(dce)		((dce)->dce_base.dce_xid)
@@ -500,10 +501,11 @@ int
 vos_dtx_commit_internal(struct vos_container *cont, struct dtx_id *dtis,
 			int counti, daos_epoch_t epoch,
 			struct dtx_cos_key *dcks,
-			struct vos_dtx_act_ent **daes);
+			struct vos_dtx_act_ent **daes,
+			struct vos_dtx_cmt_ent **dces);
 void
 vos_dtx_post_handle(struct vos_container *cont, struct vos_dtx_act_ent **daes,
-		    int count, bool abort);
+		    struct vos_dtx_cmt_ent **dces, int count, bool abort);
 
 /**
  * Establish indexed active DTX table in DRAM.

--- a/src/vos/vos_io.c
+++ b/src/vos/vos_io.c
@@ -2019,6 +2019,7 @@ vos_update_end(daos_handle_t ioh, uint32_t pm_ver, daos_key_t *dkey, int err,
 	       struct dtx_handle *dth)
 {
 	struct vos_dtx_act_ent	**daes = NULL;
+	struct vos_dtx_cmt_ent	**dces = NULL;
 	struct vos_io_context	*ioc = vos_ioh2ioc(ioh);
 	struct umem_instance	*umem;
 	uint64_t		 time = 0;
@@ -2050,9 +2051,13 @@ vos_update_end(daos_handle_t ioh, uint32_t pm_ver, daos_key_t *dkey, int err,
 		if (daes == NULL)
 			D_GOTO(abort, err = -DER_NOMEM);
 
+		D_ALLOC_ARRAY(dces, dth->dth_dti_cos_count);
+		if (dces == NULL)
+			D_GOTO(abort, err = -DER_NOMEM);
+
 		err = vos_dtx_commit_internal(ioc->ic_cont, dth->dth_dti_cos,
 					      dth->dth_dti_cos_count,
-					      0, NULL, daes);
+					      0, NULL, daes, dces);
 		if (err <= 0)
 			D_FREE(daes);
 	}
@@ -2095,12 +2100,16 @@ abort:
 	if (err == 0) {
 		vos_ts_set_upgrade(ioc->ic_ts_set);
 		if (daes != NULL) {
-			vos_dtx_post_handle(ioc->ic_cont, daes,
+			vos_dtx_post_handle(ioc->ic_cont, daes, NULL,
 					    dth->dth_dti_cos_count, false);
 			dth->dth_cos_done = 1;
 		}
 		vos_dedup_process(vos_cont2pool(ioc->ic_cont),
 				  &ioc->ic_dedup_entries, false);
+	} else if (daes != NULL) {
+		vos_dtx_post_handle(ioc->ic_cont, daes, dces,
+				    dth->dth_dti_cos_count, false);
+		dth->dth_cos_done = 0;
 	}
 
 	if (err == -DER_NONEXIST || err == -DER_EXIST || err == 0) {
@@ -2116,6 +2125,7 @@ abort:
 	vos_space_unhold(vos_cont2pool(ioc->ic_cont), &ioc->ic_space_held[0]);
 
 	D_FREE(daes);
+	D_FREE(dces);
 	vos_ioc_destroy(ioc, err != 0);
 	vos_dth_set(NULL);
 

--- a/src/vos/vos_obj.c
+++ b/src/vos/vos_obj.c
@@ -288,6 +288,7 @@ vos_obj_punch(daos_handle_t coh, daos_unit_oid_t oid, daos_epoch_t epoch,
 	      unsigned int akey_nr, daos_key_t *akeys, struct dtx_handle *dth)
 {
 	struct vos_dtx_act_ent	**daes = NULL;
+	struct vos_dtx_cmt_ent	**dces = NULL;
 	struct vos_ts_set	*ts_set;
 	struct vos_container	*cont;
 	struct vos_object	*obj = NULL;
@@ -351,9 +352,13 @@ vos_obj_punch(daos_handle_t coh, daos_unit_oid_t oid, daos_epoch_t epoch,
 		if (daes == NULL)
 			D_GOTO(reset, rc = -DER_NOMEM);
 
+		D_ALLOC_ARRAY(dces, dth->dth_dti_cos_count);
+		if (dces == NULL)
+			D_GOTO(reset, rc = -DER_NOMEM);
+
 		rc = vos_dtx_commit_internal(cont, dth->dth_dti_cos,
 					     dth->dth_dti_cos_count,
-					     0, NULL, daes);
+					     0, NULL, daes, dces);
 		if (rc <= 0)
 			D_FREE(daes);
 	}
@@ -398,10 +403,14 @@ reset:
 	if (rc == 0) {
 		vos_ts_set_upgrade(ts_set);
 		if (daes != NULL) {
-			vos_dtx_post_handle(cont, daes, dth->dth_dti_cos_count,
-					    false);
+			vos_dtx_post_handle(cont, daes, NULL,
+					    dth->dth_dti_cos_count, false);
 			dth->dth_cos_done = 1;
 		}
+	} else if (daes != NULL) {
+		vos_dtx_post_handle(cont, daes, dces, dth->dth_dti_cos_count,
+				    false);
+		dth->dth_cos_done = 1;
 	}
 
 	if (rc == -DER_NONEXIST || rc == 0) {
@@ -412,6 +421,7 @@ reset:
 	}
 
 	D_FREE(daes);
+	D_FREE(dces);
 	vos_ts_set_free(ts_set);
 	vos_dth_set(NULL);
 


### PR DESCRIPTION
For DTX commit, we may have already inserted the DTX commit
entry into the committed DTX table (in DRAM) but the commit
is aborted in subsequent process because of some failure.
Under such case, we need to remove the DTX committed entry,
otherwise, such DTX may be committed again sometime later,
at that time, another commit entry will be allocated, but
such entry will be invisible in the committed table. That
will cause DRAM leak.

Signed-off-by: Fan Yong <fan.yong@intel.com>