### PR TITLE
DAOS-7009 dfs: dfs async IO should return errno instead of -der (#4987)

### DIFF
--- a/src/client/api/client_internal.h
+++ b/src/client/api/client_internal.h
@@ -54,6 +54,8 @@ struct daos_event_private {
 	unsigned int		evx_nchild_comp;
 	/** flag to indicate whether event is a barrier event */
 	unsigned int		is_barrier:1;
+	/** flag to indicate whether to convert DER to errno */
+	unsigned int		is_errno:1;
 
 	unsigned int		evx_flags;
 	daos_ev_status_t	evx_status;

--- a/src/client/api/event.c
+++ b/src/client/api/event.c
@@ -310,6 +310,14 @@ daos_event_complete_cb(struct daos_event_private *evx, int rc)
 	return ret;
 }
 
+void
+daos_event_errno_rc(struct daos_event *ev)
+{
+	struct daos_event_private *evx = daos_ev2evx(ev);
+
+	evx->is_errno = 1;
+}
+
 static int
 daos_event_complete_locked(struct daos_eq_private *eqx,
 			   struct daos_event_private *evx, int rc)
@@ -323,7 +331,10 @@ daos_event_complete_locked(struct daos_eq_private *eqx,
 
 	evx->evx_status = DAOS_EVS_COMPLETED;
 	rc = daos_event_complete_cb(evx, rc);
-	ev->ev_error = rc;
+	if (evx->is_errno)
+		ev->ev_error = daos_der2errno(rc);
+	else
+		ev->ev_error = rc;
 
 	if (parent_evx != NULL) {
 		daos_event_t *parent_ev = daos_evx2ev(parent_evx);

--- a/src/client/dfs/dfs.c
+++ b/src/client/dfs/dfs.c
@@ -3016,6 +3016,9 @@ dfs_read_int(dfs_t *dfs, dfs_obj_t *obj, daos_off_t off, dfs_iod_t *iod,
 	struct dfs_read_params	*params;
 	int			rc;
 
+	D_ASSERT(ev);
+	daos_event_errno_rc(ev);
+
 	rc = dc_task_create(dc_array_read, NULL, ev, &task);
 	if (rc != 0)
 		return daos_der2errno(rc);
@@ -3046,7 +3049,7 @@ dfs_read_int(dfs_t *dfs, dfs_obj_t *obj, daos_off_t off, dfs_iod_t *iod,
 	daos_task_set_priv(task, params);
 	rc = tse_task_register_cbs(task, NULL, 0, 0, read_cb, NULL, 0);
 	if (rc)
-		D_GOTO(err_params, rc);
+		D_GOTO(err_params, daos_der2errno(rc));
 
 	return dc_task_schedule(task, true);
 
@@ -3142,8 +3145,10 @@ dfs_readx(dfs_t *dfs, dfs_obj_t *obj, dfs_iod_t *iod, d_sg_list_t *sgl,
 		arr_iod.arr_rgs = iod->iod_rgs;
 
 		rc = daos_array_read(obj->oh, DAOS_TX_NONE, &arr_iod, sgl, ev);
-		if (rc)
+		if (rc) {
 			D_ERROR("daos_array_read() failed (%d)\n", rc);
+			return daos_der2errno(rc);
+		}
 
 		*read_size = arr_iod.arr_nr_read;
 		return 0;
@@ -3172,8 +3177,9 @@ dfs_write(dfs_t *dfs, dfs_obj_t *obj, d_sg_list_t *sgl, daos_off_t off,
 		return EPERM;
 
 	buf_size = 0;
-	for (i = 0; i < sgl->sg_nr; i++)
-		buf_size += sgl->sg_iovs[i].iov_len;
+	if (sgl)
+		for (i = 0; i < sgl->sg_nr; i++)
+			buf_size += sgl->sg_iovs[i].iov_len;
 	if (buf_size == 0) {
 		if (ev) {
 			daos_event_launch(ev);
@@ -3189,6 +3195,9 @@ dfs_write(dfs_t *dfs, dfs_obj_t *obj, d_sg_list_t *sgl, daos_off_t off,
 	iod.arr_rgs = &rg;
 
 	D_DEBUG(DB_TRACE, "DFS Write: Off %"PRIu64", Len %zu\n", off, buf_size);
+
+	if (ev)
+		daos_event_errno_rc(ev);
 
 	rc = daos_array_write(obj->oh, DAOS_TX_NONE, &iod, sgl, ev);
 	if (rc)
@@ -3212,6 +3221,8 @@ dfs_writex(dfs_t *dfs, dfs_obj_t *obj, dfs_iod_t *iod, d_sg_list_t *sgl,
 		return EINVAL;
 	if ((obj->flags & O_ACCMODE) == O_RDONLY)
 		return EPERM;
+	if (iod == NULL)
+		return EINVAL;
 
 	if (iod->iod_nr == 0) {
 		if (ev) {
@@ -3224,6 +3235,9 @@ dfs_writex(dfs_t *dfs, dfs_obj_t *obj, dfs_iod_t *iod, d_sg_list_t *sgl,
 	/** set array location */
 	arr_iod.arr_nr = iod->iod_nr;
 	arr_iod.arr_rgs = iod->iod_rgs;
+
+	if (ev)
+		daos_event_errno_rc(ev);
 
 	rc = daos_array_write(obj->oh, DAOS_TX_NONE, &arr_iod, sgl, ev);
 	if (rc)

--- a/src/client/dfs/dfs.c
+++ b/src/client/dfs/dfs.c
@@ -3049,7 +3049,7 @@ dfs_read_int(dfs_t *dfs, dfs_obj_t *obj, daos_off_t off, dfs_iod_t *iod,
 	daos_task_set_priv(task, params);
 	rc = tse_task_register_cbs(task, NULL, 0, 0, read_cb, NULL, 0);
 	if (rc)
-		D_GOTO(err_params, daos_der2errno(rc));
+		D_GOTO(err_params, rc = daos_der2errno(rc));
 
 	return dc_task_schedule(task, true);
 

--- a/src/include/daos/event.h
+++ b/src/include/daos/event.h
@@ -87,6 +87,10 @@ daos_event_complete(daos_event_t *ev, int rc);
 int
 daos_event_launch(struct daos_event *ev);
 
+/** convert event error to positive errno instead of -DER on completion */
+void
+daos_event_errno_rc(struct daos_event *ev);
+
 /**
  * Return transport context associated with a particular event
  *

--- a/src/tests/suite/dfs_unit_test.c
+++ b/src/tests/suite/dfs_unit_test.c
@@ -612,6 +612,85 @@ dfs_test_lookupx(void **state)
 	assert_int_equal(rc, 0);
 }
 
+static void
+dfs_test_io_error_code(void **state)
+{
+	test_arg_t	*arg = *state;
+	dfs_obj_t	*file;
+	daos_event_t	ev, *evp;
+	daos_range_t	iod_rgs;
+	dfs_iod_t	iod;
+	d_sg_list_t	sgl;
+	d_iov_t		iov;
+	char		buf[10];
+	daos_size_t	read_size;
+	int		rc;
+
+	if (arg->myrank != 0)
+		return;
+
+	rc = dfs_open(dfs_mt, NULL, "io_error", S_IFREG | S_IWUSR | S_IRUSR,
+		      O_RDWR | O_CREAT, 0, 0, NULL, &file);
+	assert_int_equal(rc, 0);
+
+	/*
+	 * set an IOD that has writes more data than sgl to trigger error in
+	 * array layer.
+	 */
+	iod.iod_nr = 1;
+	iod_rgs.rg_idx = 0;
+	iod_rgs.rg_len = 10;
+	iod.iod_rgs = &iod_rgs;
+	d_iov_set(&iov, buf, 5);
+	sgl.sg_nr = 1;
+	sgl.sg_nr_out = 1;
+	sgl.sg_iovs = &iov;
+
+	/** Write */
+	if (arg->async) {
+		rc = daos_event_init(&ev, arg->eq, NULL);
+		assert_rc_equal(rc, 0);
+	}
+	rc = dfs_writex(dfs_mt, file, &iod, &sgl, arg->async ? &ev : NULL);
+	if (arg->async) {
+		/** Wait for completion */
+		rc = daos_eq_poll(arg->eq, 0, DAOS_EQ_WAIT, 1, &evp);
+		assert_rc_equal(rc, 1);
+		assert_ptr_equal(evp, &ev);
+		assert_int_equal(evp->ev_error, EINVAL);
+
+		rc = daos_event_fini(&ev);
+		assert_rc_equal(rc, 0);
+	} else {
+		assert_int_equal(rc, EINVAL);
+	}
+
+	/** Read */
+	if (arg->async) {
+		rc = daos_event_init(&ev, arg->eq, NULL);
+		assert_rc_equal(rc, 0);
+	}
+	rc = dfs_readx(dfs_mt, file, &iod, &sgl, &read_size,
+		       arg->async ? &ev : NULL);
+	if (arg->async) {
+		/** Wait for completion */
+		rc = daos_eq_poll(arg->eq, 0, DAOS_EQ_WAIT, 1, &evp);
+		assert_rc_equal(rc, 1);
+		assert_ptr_equal(evp, &ev);
+		assert_int_equal(evp->ev_error, EINVAL);
+
+		rc = daos_event_fini(&ev);
+		assert_rc_equal(rc, 0);
+	} else {
+		assert_int_equal(rc, EINVAL);
+	}
+
+	rc = dfs_release(file);
+	assert_int_equal(rc, 0);
+	rc = dfs_remove(dfs_mt, NULL, "io_error", 0, NULL);
+	assert_int_equal(rc, 0);
+}
+
 static const struct CMUnitTest dfs_unit_tests[] = {
 	{ "DFS_UNIT_TEST1: DFS mount / umount",
 	  dfs_test_mount, async_disable, test_case_teardown},
@@ -625,6 +704,10 @@ static const struct CMUnitTest dfs_unit_tests[] = {
 	  dfs_test_read_shared_file, async_disable, test_case_teardown},
 	{ "DFS_UNIT_TEST6: DFS lookupx",
 	  dfs_test_lookupx, async_disable, test_case_teardown},
+	{ "DFS_UNIT_TEST7: DFS IO sync error code",
+	  dfs_test_io_error_code, async_disable, test_case_teardown},
+	{ "DFS_UNIT_TEST8: DFS IO async error code",
+	  dfs_test_io_error_code, async_enable, test_case_teardown},
 };
 
 static int


### PR DESCRIPTION
also fix some bugs where ret value was not set on dfs_readx.

Signed-off-by: Mohamad Chaarawi <mohamad.chaarawi@intel.com>