### PR TITLE
DAOS-6773 swim: Dynamically accommodate PING timeout

### DIFF
--- a/src/cart/crt_context.c
+++ b/src/cart/crt_context.c
@@ -452,6 +452,7 @@ int
 crt_context_destroy(crt_context_t crt_ctx, int force)
 {
 	struct crt_context	*ctx;
+	uint32_t		 timeout;
 	int			 flags;
 	int			 rc = 0;
 	int			 i;
@@ -473,6 +474,7 @@ crt_context_destroy(crt_context_t crt_ctx, int force)
 			D_GOTO(out, rc);
 	}
 
+	timeout = 1 + swim_ping_timeout_get() / NSEC_PER_USEC;
 	flags = force ? (CRT_EPI_ABORT_FORCE | CRT_EPI_ABORT_WAIT) : 0;
 	D_MUTEX_LOCK(&ctx->cc_mutex);
 	for (i = 0; i < CRT_SWIM_FLUSH_ATTEMPTS; i++) {
@@ -486,7 +488,7 @@ crt_context_destroy(crt_context_t crt_ctx, int force)
 			"d_hash_table_traverse failed rc: %d.\n",
 			ctx->cc_idx, force, rc);
 		/* Flush SWIM RPC already sent */
-		rc = crt_context_flush(crt_ctx, crt_swim_rpc_timeout);
+		rc = crt_context_flush(crt_ctx, timeout);
 		if (rc)
 			/* give a chance to other threads to complete */
 			usleep(1000); /* 1ms */
@@ -851,9 +853,33 @@ crt_context_timeout_check(struct crt_context *crt_ctx)
 	struct d_binheap_node		*bh_node;
 	d_list_t			 timeout_list;
 	uint64_t			 ts_now;
-	int				 count = 0;
 
 	D_ASSERT(crt_ctx != NULL);
+
+	if (crt_initialized() && crt_is_service() && crt_gdata.cg_swim_inited) {
+		struct crt_grp_priv	*gp = crt_gdata.cg_grp->gg_primary_grp;
+		struct crt_swim_membs	*csm = &gp->gp_membs_swim;
+		swim_id_t		 self_id = swim_self_get(csm->csm_ctx);
+
+		if (crt_ctx->cc_idx == csm->csm_crt_ctx_idx &&
+		    crt_ctx->cc_last_unpack_hlc != 0 &&
+		    self_id != SWIM_ID_INVALID) {
+			uint64_t delay = crt_hlc2msec(crt_hlc_get() -
+						   crt_ctx->cc_last_unpack_hlc);
+			uint64_t max_delay = swim_suspect_timeout_get() * 2 / 3;
+
+			if (delay > max_delay) {
+				D_ERROR("Network outage detected (idle during "
+					"%lu.%lu sec >  maximum allowed "
+					"%lu.%lu sec). Suspend SWIM eviction "
+					"until network stabilized.\n",
+					delay / 1000, delay % 1000,
+					max_delay / 1000, max_delay % 1000);
+				crt_swim_suspend_all();
+				crt_ctx->cc_last_unpack_hlc = 0;
+			}
+		}
+	}
 
 	D_INIT_LIST_HEAD(&timeout_list);
 	ts_now = d_timeus_secdiff(0);
@@ -870,7 +896,6 @@ crt_context_timeout_check(struct crt_context *crt_ctx)
 
 		/* +1 to prevent it from being released in timeout_untrack */
 		RPC_ADDREF(rpc_priv);
-		count++;
 		crt_req_timeout_untrack(rpc_priv);
 
 		d_list_add_tail(&rpc_priv->crp_tmp_link, &timeout_list);

--- a/src/cart/crt_hg_proc.c
+++ b/src/cart/crt_hg_proc.c
@@ -415,8 +415,8 @@ crt_hg_unpack_header(hg_handle_t handle, struct crt_rpc_priv *rpc_priv,
 
 	/* Sync the HLC. Clients never decode requests. */
 	D_ASSERT(crt_is_service());
-	rc = crt_hlc_get_msg(rpc_priv->crp_req_hdr.cch_hlc, NULL /* hlc_out */,
-			     &clock_offset);
+	rc = crt_hlc_get_msg(rpc_priv->crp_req_hdr.cch_hlc,
+			     &ctx->cc_last_unpack_hlc, &clock_offset);
 	if (rc != 0) {
 		REPORT_HLC_SYNC_ERR("failed to sync HLC for request: opc=%x ts="
 				    DF_U64" offset="DF_U64" from=%u\n",

--- a/src/cart/crt_internal.h
+++ b/src/cart/crt_internal.h
@@ -26,6 +26,7 @@
 #include "crt_self_test.h"
 #include "crt_ctl.h"
 #include "crt_swim.h"
+#include "swim/swim_internal.h"
 
 /* A wrapper around D_TRACE_DEBUG that ensures the ptr option is a RPC */
 #define RPC_TRACE(mask, rpc, fmt, ...)					\
@@ -51,8 +52,6 @@
 			(rpc)->crp_pub.cr_ep.ep_tag,			\
 			## __VA_ARGS__);				\
 	} while (0)
-
-extern uint32_t crt_swim_rpc_timeout;
 
 #ifdef CRT_DEBUG_TRACE
 #	define CRT_ENTRY()					\

--- a/src/cart/crt_internal_types.h
+++ b/src/cart/crt_internal_types.h
@@ -166,6 +166,8 @@ struct crt_context {
 	uint32_t		 cc_timeout_sec;
 	/** provider on which context is allocated */
 	int			 cc_provider;
+	/** HLC time of last received RPC */
+	uint64_t		 cc_last_unpack_hlc;
 
 	/** Per-context statistics (server-side only) */
 	/** Total number of timed out requests, of type counter */

--- a/src/cart/crt_swim.h
+++ b/src/cart/crt_swim.h
@@ -13,7 +13,6 @@
 #include "gurt/list.h"
 #include "cart/swim.h"
 
-#define CRT_SWIM_RPC_TIMEOUT		1	/* 1 sec */
 #define CRT_SWIM_FLUSH_ATTEMPTS		100
 #define CRT_SWIM_PROGRESS_TIMEOUT	0	/* minimal progressing time */
 #define CRT_DEFAULT_PROGRESS_CTX_IDX	0
@@ -29,13 +28,14 @@ struct crt_swim_membs {
 	D_CIRCLEQ_HEAD(, crt_swim_target) csm_head;
 	struct crt_swim_target		*csm_target;
 	struct swim_context		*csm_ctx;
-	uint64_t			 csm_hlc;
 	int				 csm_crt_ctx_idx;
 };
 
 int  crt_swim_enable(struct crt_grp_priv *grp_priv, int crt_ctx_idx);
 int  crt_swim_disable(struct crt_grp_priv *grp_priv, int crt_ctx_idx);
 void crt_swim_disable_all(void);
+void crt_swim_suspend_all(void);
+void crt_swim_accommodate(void);
 int  crt_swim_rank_add(struct crt_grp_priv *grp_priv, d_rank_t rank);
 int  crt_swim_rank_del(struct crt_grp_priv *grp_priv, d_rank_t rank);
 void crt_swim_rank_del_all(struct crt_grp_priv *grp_priv);

--- a/src/cart/swim/swim_internal.h
+++ b/src/cart/swim/swim_internal.h
@@ -62,19 +62,13 @@ enum swim_context_state {
 	SCS_BEGIN = 0,		/**< initial state when next target was already
 				 * selected.
 				 */
-	SCS_DPINGED,		/**< the state after dping was sent and we are
+	SCS_PINGED,		/**< the state after dping was sent and we are
 				 * waiting for response.
-				 */
-	SCS_IPINGED,		/**< the state after ipings were sent and we are
-				 * waiting for any response.
 				 */
 	SCS_TIMEDOUT,		/**< the state when no dping response was
 				 * received and we should select iping targets.
 				 */
-	SCS_ACKED,		/**< the state when dping or iping response was
-				 * successfully received
-				 */
-	SCS_DEAD,		/**< the state to select next target */
+	SCS_SELECT,		/**< the state to select next target */
 };
 
 struct swim_item {
@@ -103,10 +97,10 @@ struct swim_context {
 	swim_id_t		 sc_target;
 	swim_id_t		 sc_self;
 
+	uint64_t		 sc_default_ping_timeout;
 	uint64_t		 sc_expect_progress_time;
 	uint64_t		 sc_next_tick_time;
-	uint64_t		 sc_dping_deadline;
-	uint64_t		 sc_iping_deadline;
+	uint64_t		 sc_deadline;
 
 	uint64_t		 sc_piggyback_tx_max;
 };

--- a/src/tests/ftest/cart/test_swim_emu.c
+++ b/src/tests/ftest/cart/test_swim_emu.c
@@ -137,7 +137,7 @@ static int test_get_member_state(struct swim_context *ctx,
 	int rc = 0;
 
 	if (self == SWIM_ID_INVALID)
-		return -EINVAL;
+		return -DER_INVAL;
 
 	*state = g.swim_state[self][id];
 	return rc;
@@ -153,7 +153,7 @@ static int test_set_member_state(struct swim_context *ctx,
 	int i, cnt, rc = 0;
 
 	if (self_id == SWIM_ID_INVALID)
-		return -EINVAL;
+		return -DER_INVAL;
 
 	switch (state->sms_status) {
 	case SWIM_MEMBER_INACTIVE:
@@ -328,12 +328,12 @@ static void deliver_pkt(struct network_pkt *item)
 
 	if (rcv_delay > max_delay)
 		swim_net_glitch_update(ctx, self_id, rcv_delay - max_delay);
-	else if (snd_delay > max_delay)
+	if (snd_delay > max_delay)
 		swim_net_glitch_update(ctx, from_id, snd_delay - max_delay);
 
 	/* emulate RPC receive by target */
 	rc = swim_parse_message(ctx, from_id, item->np_upds, item->np_nupds);
-	if (rc == -ESHUTDOWN)
+	if (rc == -DER_SHUTDOWN)
 		swim_self_set(ctx, SWIM_ID_INVALID);
 	else if (rc)
 		fprintf(stderr, "swim_parse_message() rc=%d\n", rc);
@@ -406,9 +406,9 @@ static void *progress_thread(void *arg)
 	do {
 		for (i = 0; i < members_count; i++) {
 			rc = swim_progress(g.swim_ctx[i], timeout);
-			if (rc == -ESHUTDOWN)
+			if (rc == -DER_SHUTDOWN)
 				swim_self_set(g.swim_ctx[i], SWIM_ID_INVALID);
-			else if (rc && rc != -ETIMEDOUT)
+			else if (rc && rc != -DER_TIMEDOUT)
 				fprintf(stderr, "swim_progress() rc=%d\n", rc);
 		}
 		usleep(100);


### PR DESCRIPTION
- Check HLC of each incoming RPC and if network idle is detected
  suspend SWIM eviction until network issue is resolved.
- Used network delay from SWIM communication to estimate PING timeout.
- Removed crt_swim_rpc_timeout and use swim_ping_timeout_get() instead.
- Removed separate IPINGED state (detect and monitor it in background).
- Use DER_ errors in test.