### PR TITLE
DAOS-6790 tests: Fix daos_agent start-up issues. (#4636)

### DIFF
--- a/src/tests/ftest/control/daos_admin_privileged.yaml
+++ b/src/tests/ftest/control/daos_admin_privileged.yaml
@@ -7,6 +7,7 @@ timeout: 60
 setup:
   start_agents: False
   start_servers: False
+  start_agents_once: False
   start_servers_once: False
   agent_manager_class: Orterun
   server_manager_class: Orterun

--- a/src/tests/ftest/control/daos_agent_config.py
+++ b/src/tests/ftest/control/daos_agent_config.py
@@ -21,6 +21,7 @@ class DaosAgentConfigTest(TestWithServers):
     def __init__(self, *args, **kwargs):
         """Initialize a DaosAgentConfigTest object."""
         super(DaosAgentConfigTest, self).__init__(*args, **kwargs)
+        self.start_agents_once = False
         self.start_servers_once = False
         self.setup_start_agents = False
         self.setup_start_servers = False
@@ -32,7 +33,10 @@ class DaosAgentConfigTest(TestWithServers):
         Test Description: Test daos_agent start/stops properly.
         on the system.
 
-        :avocado: tags=all,small,control,daily_regression,agent_start,basic
+        :avocado: tags=all,daily_regression
+        :avocado: tags=small,agent_start,basic
+        :avocado: tags=control,daos_agent_config_test
+        :avocado: tags=test_daos_agent_config_basic
         """
         # Setup the agents
         self.add_agent_manager()
@@ -52,7 +56,9 @@ class DaosAgentConfigTest(TestWithServers):
                 c_val[0], c_val[1]))
 
         # Setup the access points with the server hosts
-        self.log.info("Starting agent with %s = %s", c_val[0], c_val[1])
+        self.log.info(
+            "Starting agent with %s = %s, expecting it to %s",
+            c_val[0], c_val[1], c_val[2])
 
         try:
             self.agent_managers[-1].start()
@@ -72,3 +78,7 @@ class DaosAgentConfigTest(TestWithServers):
                 "Starting agent failed when it was expected to complete "
                 "successfully with {} = {}: {}".format(
                     c_val[0], c_val[1], exception))
+
+        self.log.info(
+            "Test passed - starting the agent with %s = %s %sed",
+            c_val[0], c_val[1], c_val[2].lower())

--- a/src/tests/ftest/control/daos_agent_config.yaml
+++ b/src/tests/ftest/control/daos_agent_config.yaml
@@ -45,7 +45,7 @@ agent_config_val: !mux
     config_val:
       - "name"
       - [amjustin, 12345, abcdef]
-      - "FAIl"
+      - "FAIL"
   access_point_noport:
     config_val:
       - "access_points"

--- a/src/tests/ftest/control/dmg_network_scan.py
+++ b/src/tests/ftest/control/dmg_network_scan.py
@@ -117,6 +117,7 @@ class DmgNetworkScanTest(TestWithServers):
     def __init__(self, *args, **kwargs):
         """Initialize a DmgNetworkScanTest object."""
         super(DmgNetworkScanTest, self).__init__(*args, **kwargs)
+        self.start_agents_once = False
         self.start_servers_once = False
         self.setup_start_agents = False
         self.setup_start_servers = False

--- a/src/tests/ftest/control/dmg_nvme_scan_test.py
+++ b/src/tests/ftest/control/dmg_nvme_scan_test.py
@@ -22,6 +22,7 @@ class DmgNvmeScanTest(TestWithServers):
     def __init__(self, *args, **kwargs):
         """Initialize a DmgNvmeScanTest object."""
         super(DmgNvmeScanTest, self).__init__(*args, **kwargs)
+        self.start_agents_once = False
         self.start_servers_once = False
         self.setup_start_agents = False
 

--- a/src/tests/ftest/daos_test/daos_core_test.py
+++ b/src/tests/ftest/daos_test/daos_core_test.py
@@ -4,12 +4,11 @@
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
-
 from daos_core_base import DaosCoreBase
 
 
 class DaosCoreTest(DaosCoreBase):
-    # pylint: disable=too-many-ancestors
+    # pylint: disable=too-many-ancestors,too-many-public-methods
     """Runs just the non-rebuild daos_test tests.
 
     :avocado: recursive

--- a/src/tests/ftest/network/cart_self_test.yaml
+++ b/src/tests/ftest/network/cart_self_test.yaml
@@ -6,6 +6,7 @@ hosts:
 timeout: 110
 setup:
   start_servers: False
+  start_agents_once: False
   start_servers_once: False
   agent_manager_class: Orterun
   server_manager_class: Orterun

--- a/src/tests/ftest/pool/pool_svc.yaml
+++ b/src/tests/ftest/pool/pool_svc.yaml
@@ -4,27 +4,30 @@ hosts:
     - server-B
     - server-C
     - server-D
+    - server-E
 server_config:
     name: daos_server
-timeout: 60
+timeout: 150
 pool:
     control_method: dmg
     mode: 146
     name: daos_server
     scm_size: 134217728
     pool_query_timeout: 30
-createtests:
-    createsvc: !mux
-        svc0:
-            svc:
-                - 0
-                - 'FAIL'
-        svc1:
-            svc:
-                - 1
-                - 'PASS'
-# Uncomment once DAOS-2979 is resolved.
-#        svc3:
-#            svc:
-#                - 3
-#                - 'PASS'
+svc_params_mux: !mux
+    svc_params_none:
+        svc_params: [None, 3]
+    svc_params_0:
+        svc_params: [0, 3]
+    svc_params_1:
+        svc_params: [1, 1]
+    svc_params_2:
+        svc_params: [2, 2]
+    svc_params_3:
+        svc_params: [3, 3]
+    svc_params_4:
+        svc_params: [4, 4]
+    svc_params_5:
+        svc_params: [5, 4]
+    svc_params_6:
+        svc_params: [6, 0]

--- a/src/tests/ftest/server/daos_server_config.py
+++ b/src/tests/ftest/server/daos_server_config.py
@@ -23,6 +23,7 @@ class DaosServerConfigTest(TestWithServers):
     def __init__(self, *args, **kwargs):
         """Initialize a DaosServerConfigTest object."""
         super(DaosServerConfigTest, self).__init__(*args, **kwargs)
+        self.start_agents_once = False
         self.start_servers_once = False
         self.setup_start_agents = False
         self.setup_start_servers = False

--- a/src/tests/ftest/server/dynamic_start_stop.py
+++ b/src/tests/ftest/server/dynamic_start_stop.py
@@ -4,7 +4,6 @@
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
-import json
 from apricot import TestWithServers
 
 
@@ -31,13 +30,11 @@ class DynamicStartStop(TestWithServers):
         rank is in self.stopped_ranks, verify that its status is Stopped.
         Otherwise, Joined.
         """
-        output = self.dmg_cmd.system_query().stdout
-        data = json.loads(output)
-        members = data["response"]["members"]
-        for member in members:
+        output = self.dmg_cmd.system_query()
+        for member in output["response"]["members"]:
             if member["rank"] in self.stopped_ranks:
-                self.assertEqual(
-                    member["state"], "stopped",
+                self.assertIn(
+                    member["state"], ["stopped", "evicted"],
                     "State isn't stopped! Actual: {}".format(member["state"]))
                 self.assertEqual(
                     member["info"], "system stop",
@@ -47,6 +44,26 @@ class DynamicStartStop(TestWithServers):
                 self.assertEqual(
                     member["state"], "joined",
                     "State isn't joined! Actual: {}".format(member["state"]))
+
+    def stop_server_ranks(self, ranks):
+        """Stop one or more server ranks.
+
+        Args:
+            ranks (list): [description]
+        """
+        # Stop the requested server ranks
+        ranks_str = ",".join([str(rank) for rank in ranks])
+        self.dmg_cmd.system_stop(ranks=ranks_str)
+
+        # Mark which ranks are now stopped
+        for manager in self.server_managers:
+            manager.update_expected_states(ranks, ["stopped", "evicted"])
+        for rank in ranks:
+            self.stopped_ranks.add(rank)
+
+        # Verify that the State of the stopped servers is Stopped and Reason is
+        # system stop.
+        self.verify_system_query()
 
     def test_dynamic_server_addition(self):
         """JIRA ID: DAOS-3598
@@ -75,29 +92,13 @@ class DynamicStartStop(TestWithServers):
         self.verify_system_query()
 
         # Stop one of the added servers - Single stop.
-        self.dmg_cmd.system_stop(ranks="4")
-
-        # Verify that the State of the stopped server is Stopped and Reason is
-        # system stop.
-        self.stopped_ranks.add(4)
-        self.verify_system_query()
+        self.stop_server_ranks([4])
 
         # Stop two of the added servers - Multiple stop.
-        self.dmg_cmd.system_stop(ranks="2,3")
-
-        # Verify that the State of the stopped servers is Stopped and Reason is
-        # system stop.
-        self.stopped_ranks.add(2)
-        self.stopped_ranks.add(3)
-        self.verify_system_query()
+        self.stop_server_ranks([2, 3])
 
         # Stop one of the original servers.
-        self.dmg_cmd.system_stop(ranks="1")
-
-        # Verify that the State of the stopped servers is Stopped and Reason is
-        # system stop.
-        self.stopped_ranks.add(1)
-        self.verify_system_query()
+        self.stop_server_ranks([1])
 
         # Stopping newly added server and destroy pool causes -1006. DAOS-5606
         self.pool = None

--- a/src/tests/ftest/util/agent_utils.py
+++ b/src/tests/ftest/util/agent_utils.py
@@ -245,7 +245,7 @@ class DaosAgentManager(SubprocessManager):
                     self.manager.command, error))
 
         # Kill any leftover processes that may not have been stopped correctly
-        self.kill()
+        self.manager.kill()
 
         # Report any errors after all stop actions have been attempted
         if messages:

--- a/src/tests/ftest/util/command_utils.py
+++ b/src/tests/ftest/util/command_utils.py
@@ -6,6 +6,7 @@
 """
 # pylint: disable=too-many-lines
 from logging import getLogger
+from datetime import datetime
 from getpass import getuser
 import re
 import time
@@ -13,13 +14,14 @@ import signal
 import os
 
 from avocado.utils import process
+from ClusterShell.NodeSet import NodeSet
 
 from command_utils_base import \
     CommandFailure, BasicParameter, ObjectWithParameters, \
     CommandWithParameters, YamlParameters, EnvironmentVariables, LogParameter
-from general_utils import check_file_exists, stop_processes, get_log_file, \
+from general_utils import check_file_exists, get_log_file, \
     run_command, DaosTestError, get_job_manager_class, create_directory, \
-    distribute_files, change_file_owner, get_file_listing
+    distribute_files, change_file_owner, get_file_listing, run_task
 
 
 class ExecutableCommand(CommandWithParameters):
@@ -904,12 +906,34 @@ class SubprocessManager(object):
 
         # Define the JobManager class used to manage the command as a subprocess
         self.manager = get_job_manager_class(manager, command, True)
+        self._id = self.manager.job.command.replace("daos_", "")
 
         # Define the list of hosts that will execute the daos command
         self._hosts = []
 
         # The socket directory verification is not required with systemctl
         self._verify_socket_dir = manager != "Systemctl"
+
+        # An internal dictionary used to define the expected states of each
+        # job process. It will be populated when any of the following methods
+        # are called:
+        #   - start()
+        #   - verify_expected_states(set_expected=True)
+        # Individual states may also be updated by calling the
+        # update_expected_states() method. This is required to avoid any errors
+        # being raised during tearDown() if a test variant intentional affects
+        # the state of a job process.
+        self._expected_states = {}
+
+        # States for verify_expected_states()
+        self._states = {
+            "all": [
+                "active", "inactive", "activating", "deactivating", "failed",
+                "unknown"],
+            "running": ["active"],
+            "stopped": ["inactive", "deactivating", "failed", "unknown"],
+            "errored": ["failed"],
+        }
 
     def __str__(self):
         """Get the complete manager command string.
@@ -981,26 +1005,16 @@ class SubprocessManager(object):
             self.manager.run()
         except CommandFailure:
             # Kill the subprocess, anything that might have started
-            self.kill()
+            self.manager.kill()
             raise CommandFailure(
                 "Failed to start {}.".format(str(self.manager.job)))
+        finally:
+            # Define the expected states for each rank
+            self._expected_states = self.get_current_state()
 
     def stop(self):
         """Stop the daos command."""
         self.manager.stop()
-
-    def kill(self):
-        """Forcibly terminate any sub process running on hosts."""
-        regex = self.manager.job.command_regex
-        result = stop_processes(self._hosts, regex)
-        if 0 in result and len(result) == 1:
-            print(
-                "No remote {} processes killed (none found), done.".format(
-                    regex))
-        else:
-            print(
-                "***At least one remote {} process needed to be killed! Please "
-                "investigate/report.***".format(regex))
 
     def verify_socket_directory(self, user):
         """Verify the domain socket directory is present and owned by this user.
@@ -1047,6 +1061,180 @@ class SubprocessManager(object):
         if self.manager.job and hasattr(self.manager.job, "get_config_value"):
             value = self.manager.job.get_config_value(name)
         return value
+
+    def get_current_state(self):
+        """Get the current state of the daos_server ranks.
+
+        Returns:
+            dict: dictionary of server rank keys, each referencing a dictionary
+                of information containing at least the following information:
+                    {"host": <>, "uuid": <>, "state": <>}
+                This will be empty if there was error obtaining the dmg system
+                query output.
+
+        """
+        data = {}
+        ranks = {host: rank for rank, host in enumerate(self._hosts)}
+        if not self._verify_socket_dir:
+            command = "systemctl is-active {}".format(
+                self.manager.job.service_name)
+        else:
+            command = "prep {}".format(self.manager.job.command)
+        task = run_task(self._hosts, command, 30)
+        for output, nodelist in task.iter_buffers():
+            for node in nodelist:
+                data[ranks[node]] = {
+                    "host": node, "uuid": "-", "state": str(output)}
+        return data
+
+    def update_expected_states(self, ranks, state):
+        """Update the expected state of the specified job rank.
+
+        Args:
+            ranks (object): job ranks to update. Can be a single rank (int),
+                multiple ranks (list), or all the ranks (None).
+            state (object): new state to assign as the expected state of this
+                rank. Can be a str or a list of str.
+        """
+        if ranks is None:
+            ranks = list(self._expected_states.keys())
+        elif not isinstance(ranks, (list, tuple)):
+            ranks = [ranks]
+
+        for rank in ranks:
+            if rank in self._expected_states:
+                self.log.info(
+                    "Updating the expected state for rank %s on %s: %s -> %s",
+                    rank, self._expected_states[rank]["host"],
+                    self._expected_states[rank]["state"], state)
+                self._expected_states[rank]["state"] = state
+
+    def verify_expected_states(self, set_expected=False):
+        """Verify that the expected job process states match the current states.
+
+        Args:
+            set_expected (bool, optional): option to update the expected job
+                process states to the current states prior to verification.
+                Defaults to False.
+
+        Returns:
+            dict: a dictionary of whether or not any of the job process states
+                were not 'expected' (which should warrant an error) and whether
+                or not the job process require a 'restart' (either due to any
+                unexpected states or because at least one job process was no
+                longer found to be running)
+
+        """
+        status = {"expected": True, "restart": False}
+        show_log_hosts = []
+
+        # Get the current state of each job process
+        current_states = self.get_current_state()
+        if set_expected:
+            # Assign the expected states to the current job process states
+            self.log.info(
+                "<%s> Assigning expected %s states.",
+                self._id.upper(), self._id)
+            self._expected_states = current_states.copy()
+
+        # Verify the expected states match the current states
+        self.log.info(
+            "<%s> Verifying %s states: group=%s, hosts=%s",
+            self._id.upper(), self._id, self.get_config_value("name"),
+            NodeSet.fromlist(self._hosts))
+        if current_states:
+            log_format = "  %-4s  %-15s  %-36s  %-22s  %-14s  %s"
+            self.log.info(
+                log_format,
+                "Rank", "Host", "UUID", "Expected State", "Current State",
+                "Result")
+            self.log.info(
+                log_format,
+                "-" * 4, "-" * 15, "-" * 36, "-" * 22, "-" * 14, "-" * 6)
+
+            # Verify that each expected rank appears in the current states
+            for rank in sorted(self._expected_states):
+                current_host = self._expected_states[rank]["host"]
+                expected = self._expected_states[rank]["state"]
+                if isinstance(expected, (list, tuple)):
+                    expected = [item.lower() for item in expected]
+                else:
+                    expected = [expected.lower()]
+                try:
+                    current_rank = current_states.pop(rank)
+                    current = current_rank["state"].lower()
+                except KeyError:
+                    current = "not detected"
+
+                # Check if the job's expected state matches the current state
+                result = "PASS" if current in expected else "RESTART"
+                status["expected"] &= current in expected
+
+                # Restart all job processes if the expected rank is not running
+                if current not in self._states["running"]:
+                    status["restart"] = True
+                    result = "RESTART"
+
+                # Keep track of any server in the errored state or in an
+                # unexpected state in order to display its log
+                if (current in self._states["errored"] or
+                        current not in expected):
+                    if current_host not in show_log_hosts:
+                        show_log_hosts.append(current_host)
+
+                self.log.info(
+                    log_format, rank, current_host,
+                    self._expected_states[rank]["uuid"], "|".join(expected),
+                    current, result)
+
+        elif not self._expected_states:
+            # Expected states are populated as part of start() procedure,
+            # so if it is empty there was an error starting the job processes.
+            self.log.info(
+                "  Unable to obtain current %s state.  Undefined expected %s "
+                "states due to a failure starting the %s.",
+                self._id, self._id, self._id,)
+            status["restart"] = True
+
+        else:
+            # Any failure to obtain the current rank information is an error
+            self.log.info(
+                "  Unable to obtain current %s state.  If the %ss are "
+                "not running this is expected.", self._id, self._id)
+
+            # Do not report an error if all servers are expected to be stopped
+            all_stopped = bool(self._expected_states)
+            for rank in sorted(self._expected_states):
+                states = self._expected_states[rank]["state"]
+                if not isinstance(states, (list, tuple)):
+                    states = [states]
+                if "stopped" not in [item.lower() for item in states]:
+                    all_stopped = False
+                    break
+            if all_stopped:
+                self.log.info("  All %s are expected to be stopped.", self._id)
+                status["restart"] = True
+            else:
+                status["expected"] = False
+
+        # Any unexpected state detected warrants a restart of all job processes
+        if not status["expected"]:
+            status["restart"] = True
+
+        # Set the verified timestamp
+        if set_expected and hasattr(self.manager, "timestamps"):
+            self.manager.timestamps["verified"] = datetime.now().strftime(
+                "%Y-%m-%d %H:%M:%S")
+
+        # Dump the server logs for any identified server
+        if show_log_hosts:
+            self.log.info(
+                "<SERVER> logs for ranks in the errored state since start "
+                "detection or detected in an unexpected state")
+            if hasattr(self.manager, "dump_logs"):
+                self.manager.dump_logs(show_log_hosts)
+
+        return status
 
 
 class SystemctlCommand(ExecutableCommand):

--- a/src/tests/ftest/util/dmg_utils.py
+++ b/src/tests/ftest/util/dmg_utils.py
@@ -4,7 +4,6 @@
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
-# pylint: disable=too-many-lines
 from __future__ import print_function
 
 from getpass import getuser
@@ -84,7 +83,7 @@ class DmgCommand(DmgCommandBase):
     }
 
     def _get_json_result(self, sub_command_list=None, **kwargs):
-        """Wraps the base _get_result method to force JSON output."""
+        """Wrap the base _get_result method to force JSON output."""
         prev_json_val = self.json.value
         self.json.update(True)
         prev_output_check = self.output_check
@@ -795,72 +794,37 @@ class DmgCommand(DmgCommandBase):
             dict: a dictionary of host ranks and their unique states.
 
         """
-        self._get_result(("system", "query"), ranks=ranks, verbose=verbose)
-
-        data = {}
-        if re.findall(r"Rank \d+", self.result.stdout):
-            # Process the unique single rank system query output, e.g.
-            #   Rank 1
-            #   ------
-            #   address      : 10.8.1.68:10001
-            #   uuid         : bcc5b010-1ffa-4525-96a9-11f1904374d6
-            #   fault domain : /wolf-68.wolf.hpdd.intel.com
-            #   status       : Joined
-            #   reason       :
-            match = re.findall(
-                r"(?:Rank|address\s+:|uuid\s+:|domain\s+:|status\s+:|"
-                r"reason\s+:)\s+(.*)",
-                self.result.stdout)
-            if match:
-                print("--- match: {}".format(match))
-                data[int(match[0])] = {
-                    "address": match[1].strip(),
-                    "uuid": match[2].strip(),
-                    "domain": match[3].strip(),
-                    "state": match[4].strip(),
-                    "reason": match[5].strip(),
-                }
-        elif verbose:
-            # Process the verbose multiple rank system query output, e.g.
-            #   Rank UUID                                 Control Address State
-            #   ---- ----                                 --------------- -----
-            #   0    385af2f9-1863-406c-ae94-bffdcd02f379 10.8.1.10:10001 Joined
-            #   1    d7a69a41-59a2-4dec-a620-a52217851285 10.8.1.11:10001 Joined
-            #   Rank UUID   Control Address  Fault Domain  State  Reason
-            #   ---- ----   ---------------  ------------  -----  ------
-            #   0    <uuid> <address>        <domain>      Joined system stop
-            #   1    <uuid> <address>        <domain>      Joined system stop
-            #
-            #       Where the above placeholders have values similar to:
-            #           <uuid>    = 0c21d700-0e2b-46fb-be49-1fca490ce5b0
-            #           <address> = 10.8.1.142:10001
-            #           <domain>  = /wolf-142.wolf.hpdd.intel.com
-            #
-            match = re.findall(
-                r"(\d+)\s+([0-9a-f-]+)\s+([0-9.:]+)\s+([/A-Za-z0-9-_.]+)"
-                r"\s+([A-Za-z]+)(.*)",
-                self.result.stdout)
-            for info in match:
-                data[int(info[0])] = {
-                    "uuid": info[1],
-                    "address": info[2],
-                    "domain": info[3],
-                    "state": info[4],
-                    "reason": info[5].strip(),
-                }
-        else:
-            # Process the non-verbose multiple rank system query output, e.g.
-            #   Rank  State
-            #   ----  -----
-            #   [0-1] Joined
-            match = re.findall(
-                r"(?:\[*([0-9-,]+)\]*)\s+([A-Za-z]+)", self.result.stdout)
-            for info in match:
-                for rank in get_numeric_list(info[0]):
-                    data[rank] = {"state": info[1]}
-
-        self.log.info("system_query data: %s", str(data))
-        return data
+        # Sample output:
+        # {
+        # "response": {
+        #     "members": [
+        #     {
+        #         "addr": "10.8.1.11:10001",
+        #         "state": "joined",
+        #         "fault_domain": "/wolf-11.wolf.hpdd.intel.com",
+        #         "rank": 0,
+        #         "uuid": "e7f2cb06-a111-4d55-a6a5-b494b70d62ab",
+        #         "fabric_uri": "ofi+sockets://192.168.100.11:31416",
+        #         "fabric_contexts": 17,
+        #         "info": ""
+        #     },
+        #     {
+        #         "addr": "10.8.1.74:10001",
+        #         "state": "evicted",
+        #         "fault_domain": "/wolf-74.wolf.hpdd.intel.com",
+        #         "rank": 1,
+        #         "uuid": "db36ab28-fdb0-4822-97e6-89547393ed03",
+        #         "fabric_uri": "ofi+sockets://192.168.100.74:31416",
+        #         "fabric_contexts": 17,
+        #         "info": ""
+        #     }
+        #     ]
+        # },
+        # "error": null,
+        # "status": 0
+        # }
+        return self._get_json_result(
+            ("system", "query"), ranks=ranks, verbose=verbose)
 
     def system_leader_query(self):
         """Query system to obtain the MS leader and replica information.
@@ -972,25 +936,25 @@ def check_system_query_status(data):
         bool: True if no server crashed, False otherwise.
 
     """
-    failed_states = ("Unknown", "Evicted", "Errored", "Unresponsive")
-    failed_rank_list = []
+    failed_states = ("unknown", "evicted", "errored", "unresponsive")
+    failed_rank_list = {}
 
     # Check the state of each rank.
-    for rank in data:
-        rank_info = [
-            "{}: {}".format(key, data[rank][key])
-            for key in sorted(data[rank].keys())
-        ]
-        print("Rank {} info:\n  {}".format(rank, "\n  ".join(rank_info)))
-        if "state" in data[rank] and data[rank]["state"] in failed_states:
-            failed_rank_list.append(rank)
+    if "response" in data and "members" in data["response"]:
+        for member in data["response"]["members"]:
+            rank_info = [
+                "{}: {}".format(key, member[key]) for key in sorted(member)]
+            print(
+                "Rank {} info:\n  {}".format(
+                    member["rank"], "\n  ".join(rank_info)))
+            if "state" in member and member["state"].lower() in failed_states:
+                failed_rank_list[member["rank"]] = member["state"]
 
     # Display the details of any failed ranks
-    if failed_rank_list:
-        for rank in failed_rank_list:
-            print(
-                "Rank {} failed with state '{}'".format(
-                    rank, data[rank]["state"]))
+    for rank in sorted(failed_rank_list):
+        print(
+            "Rank {} failed with state '{}'".format(
+                rank, failed_rank_list[rank]))
 
     # Return True if no ranks failed
     return not bool(failed_rank_list)

--- a/src/tests/ftest/util/general_utils.py
+++ b/src/tests/ftest/util/general_utils.py
@@ -607,22 +607,23 @@ def stop_processes(hosts, pattern, verbose=True, timeout=60, added_filter=None):
     log.info("Killing any processes on %s that match: %s", hosts, pattern)
 
     if added_filter:
-        ps_cmd = "ps x | grep -E {} | grep -vE {}".format(pattern, added_filter)
+        ps_cmd = "/usr/bin/ps x | grep -E {} | grep -vE {}".format(
+            pattern, added_filter)
     else:
-        ps_cmd = "pgrep --list-full {}".format(pattern)
+        ps_cmd = "/usr/bin/pgrep --list-full {}".format(pattern)
 
     if hosts is not None:
         commands = [
             "rc=0",
             "if " + ps_cmd,
             "then rc=1",
-            "sudo pkill {}".format(pattern),
+            "sudo /usr/bin/pkill {}".format(pattern),
             "sleep 5",
             "if " + ps_cmd,
-            "then pkill --signal ABRT {}".format(pattern),
+            "then /usr/bin/pkill --signal ABRT {}".format(pattern),
             "sleep 1",
             "if " + ps_cmd,
-            "then pkill --signal KILL {}".format(pattern),
+            "then /usr/bin/pkill --signal KILL {}".format(pattern),
             "fi",
             "fi",
             "fi",

--- a/src/tests/ftest/util/server_utils.py
+++ b/src/tests/ftest/util/server_utils.py
@@ -4,15 +4,12 @@
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
-# pylint: disable=too-many-lines
-from datetime import datetime
 from getpass import getuser
 import os
 import socket
 import time
 
 from avocado import fail_on
-from ClusterShell.NodeSet import NodeSet
 
 from command_utils_base import \
     CommandFailure, FormattedParameter, YamlParameters, CommandWithParameters, \
@@ -361,17 +358,17 @@ class DaosServerManager(SubprocessManager):
             self.manager.job.certificate_owner = "daos_server"
             self.dmg.certificate_owner = getuser()
 
-        # An internal dictionary used to define the expected states of each
-        # server rank when checking their states. It will be populated with
-        # the dictionary output of DmgCommand.system_query() when any of the
-        # following methods are called:
-        #   - start()
-        #   - verify_expected_states(set_expected=True)
-        # Individual rank states may also be updated by calling the
-        # update_expected_states() method. This is required to mark any rank
-        # stopped by a test with the correct state to avoid errors being raised
-        # during tearDown().
-        self._expected_states = {}
+        # Server states
+        self._states = {
+            "all": [
+                "awaitformat", "starting", "ready", "joined", "stopping",
+                "stopped", "evicted", "errored", "unresponsive", "unknown"],
+            "running": ["ready", "joined"],
+            "stopped": [
+                "stopping", "stopped", "evicted", "errored", "unresponsive",
+                "unknown"],
+            "errored": ["errored"],
+        }
 
     def get_params(self, test):
         """Get values for all of the command params from the yaml file.
@@ -448,7 +445,7 @@ class DaosServerManager(SubprocessManager):
                 self.get_config_value("allow_insecure"), "dmg.insecure")
 
         # Kill any daos servers running on the hosts
-        self.kill()
+        self.manager.kill()
 
         # Clean up any files that exist on the hosts
         self.clean_files()
@@ -581,7 +578,7 @@ class DaosServerManager(SubprocessManager):
         try:
             self.manager.run()
         except CommandFailure as error:
-            self.kill()
+            self.manager.kill()
             raise ServerFailed(
                 "Failed to start servers before format: {}".format(error))
 
@@ -601,14 +598,14 @@ class DaosServerManager(SubprocessManager):
         self.log.info("<SERVER> Waiting for the daos_engine to start")
         self.manager.job.update_pattern("normal", hosts_qty)
         if not self.manager.check_subprocess_status(self.manager.process):
-            self.kill()
+            self.manager.kill()
             raise ServerFailed("Failed to start servers after format")
 
         # Update the dmg command host list to work with pool create/destroy
         self._prepare_dmg_hostlist()
 
         # Define the expected states for each rank
-        self._expected_states = self.system_query()
+        self._expected_states = self.get_current_state()
 
     def reset_storage(self):
         """Reset the server storage.
@@ -693,7 +690,7 @@ class DaosServerManager(SubprocessManager):
                     self.manager.command, error))
 
         # Kill any leftover processes that may not have been stopped correctly
-        self.kill()
+        self.manager.kill()
 
         if self.manager.job.using_nvme:
             # Reset the storage
@@ -746,7 +743,7 @@ class DaosServerManager(SubprocessManager):
             str: the current DAOS system state
 
         """
-        data = self.system_query()
+        data = self.get_current_state()
         if not data:
             # The regex failed to get the rank and state
             raise ServerFailed(
@@ -922,175 +919,33 @@ class DaosServerManager(SubprocessManager):
             str(storage[1]), bytes_to_human(storage[1], binary=False))
         return storage
 
-    def system_query(self):
-        """Query the state of the daos_server ranks.
+    def get_current_state(self):
+        """Get the current state of the daos_server ranks.
 
         Returns:
             dict: dictionary of server rank keys, each referencing a dictionary
-                of information.  This will be empty if there was error obtaining
-                the dmg system query output.
+                of information containing at least the following information:
+                    {"host": <>, "uuid": <>, "state": <>}
+                This will be empty if there was error obtaining the dmg system
+                query output.
 
         """
+        data = {}
         try:
-            data = self.dmg.system_query()
+            query_data = self.dmg.system_query()
         except CommandFailure:
-            data = {}
+            query_data = {"status": 1}
+        if query_data["status"] == 0:
+            if "response" in query_data and "members" in query_data["response"]:
+                for member in query_data["response"]["members"]:
+                    host = member["fault_domain"].split(".")[0].replace("/", "")
+                    if host in self._hosts:
+                        data[member["rank"]] = {
+                            "uuid": member["uuid"],
+                            "host": host,
+                            "state": member["state"],
+                        }
         return data
-
-    def update_expected_states(self, ranks, state):
-        """Update the expected state of the specified server rank.
-
-        Args:
-            ranks (object): server ranks to update. Can be a single rank (int),
-                multiple ranks (list), or all the ranks (None).
-            state (object): new state to assign as the expected state of this
-                rank. Can be a str or a list.
-        """
-        if ranks is None:
-            ranks = [key for key in self._expected_states]
-        elif not isinstance(ranks, (list, tuple)):
-            ranks = [ranks]
-
-        for rank in ranks:
-            if rank in self._expected_states:
-                self.log.info(
-                    "Updating the expected state for rank %s on %s: %s -> %s",
-                    rank, self._expected_states[rank]["domain"],
-                    self._expected_states[rank]["state"], state)
-                self._expected_states[rank]["state"] = state
-
-    def verify_expected_states(self, set_expected=False):
-        """Verify that the expected server rank states match the current states.
-
-        Args:
-            set_expected (bool, optional): option to update the expected server
-                rank states to the current states prior to checking the states.
-                Defaults to False.
-
-        Returns:
-            dict: a dictionary of whether or not any of the server states were
-                not 'expected' (which should warrant an error) and whether or
-                the servers require a 'restart' (either due to any unexpected
-                states or because at least one servers was found to no longer
-                be running)
-
-        """
-        status = {"expected": True, "restart": False}
-        running_states = ["started", "joined"]
-        errored_states = ["errored"]
-        errored_hosts = []
-
-        # Get the current state of the servers
-        current_states = self.system_query()
-        if set_expected:
-            # Assign the expected states to the current server rank states
-            self.log.info("<SERVER> Assigning expected server states.")
-            self._expected_states = current_states.copy()
-
-        # Verify the expected states match the current states
-        self.log.info(
-            "<SERVER> Verifying server states: group=%s, hosts=%s",
-            self.get_config_value("name"), NodeSet.fromlist(self._hosts))
-        if current_states:
-            log_format = "  %-4s  %-15s  %-36s  %-22s  %-14s  %s"
-            self.log.info(
-                log_format,
-                "Rank", "Host", "UUID", "Expected State", "Current State",
-                "Result")
-            self.log.info(
-                log_format,
-                "-" * 4, "-" * 15, "-" * 36, "-" * 22, "-" * 14, "-" * 6)
-
-            # Verify that each expected rank appears in the current states
-            for rank in sorted(self._expected_states):
-                domain = self._expected_states[rank]["domain"].split(".")
-                current_host = domain[0].replace("/", "")
-                expected = self._expected_states[rank]["state"]
-                if isinstance(expected, (list, tuple)):
-                    expected = [item.lower() for item in expected]
-                else:
-                    expected = [expected.lower()]
-                try:
-                    current_rank = current_states.pop(rank)
-                    current = current_rank["state"].lower()
-                except KeyError:
-                    current = "not detected"
-
-                # Check if the rank's expected state matches the current state
-                result = "PASS" if current in expected else "RESTART"
-                status["expected"] &= current in expected
-
-                # Restart all ranks if the expected rank is not running
-                if current not in running_states:
-                    status["restart"] = True
-                    result = "RESTART"
-
-                # Keep track of any hosts with a server in the errored state
-                if current in errored_states:
-                    if current_host not in errored_hosts:
-                        errored_hosts.append(current_host)
-
-                self.log.info(
-                    log_format, rank, current_host,
-                    self._expected_states[rank]["uuid"], "|".join(expected),
-                    current, result)
-
-            # Report any current states that were not expected as an error
-            for rank in sorted(current_states):
-                status["expected"] = False
-                domain = current_states[rank]["domain"].split(".")
-                self.log.info(
-                    log_format, rank, domain[0].replace("/", ""),
-                    current_states[rank]["uuid"], "not detected",
-                    current_states[rank]["state"].lower(), "RESTART")
-
-        elif not self._expected_states:
-            # Expected states are populated as part of detect_io_server_start(),
-            # so if it is empty there was an error starting the servers.
-            self.log.info(
-                "  Unable to obtain current server state.  Undefined expected "
-                "server states due to a failure starting the servers.")
-            status["restart"] = True
-
-        else:
-            # Any failure to obtain the current rank information is an error
-            self.log.info(
-                "  Unable to obtain current server state.  If the servers are "
-                "not running this is expected.")
-
-            # Do not report an error if all servers are expected to be stopped
-            all_stopped = bool(self._expected_states)
-            for rank in sorted(self._expected_states):
-                states = self._expected_states[rank]["state"]
-                if not isinstance(states, (list, tuple)):
-                    states = [states]
-                if "stopped" not in [item.lower() for item in states]:
-                    all_stopped = False
-                    break
-            if all_stopped:
-                self.log.info("  All servers are expected to be stopped.")
-                status["restart"] = True
-            else:
-                status["expected"] = False
-
-        # Any unexpected state detected warrants a restart of all servers
-        if not status["expected"]:
-            status["restart"] = True
-
-        # Set the verified timestamp
-        if set_expected and hasattr(self.manager, "timestamps"):
-            self.manager.timestamps["verified"] = datetime.now().strftime(
-                "%Y-%m-%d %H:%M:%S")
-
-        # Dump the server logs for any server found in the errored state
-        if errored_hosts:
-            self.log.info(
-                "<SERVER> logs for ranks in the errored state since start "
-                "detection")
-            if hasattr(self.manager, "dump_logs"):
-                self.manager.dump_logs(errored_hosts)
-
-        return status
 
     @fail_on(CommandFailure)
     def stop_ranks(self, ranks, daos_log, force=False):


### PR DESCRIPTION
Resolving issues starting up daos_agent processes resulting from still
executing daos_agent processes from a previous test.  If the previous
test's tearDown() process prematurely exits leaving daos_agent processes
running it causes errors in the next test when it attempts to start
daos_agents on the same hosts.  To resolve this daos_agents will make
use of the same code implored by servers to start the agents once per
test file.  This includes code in launch.py that will stop any
daos_agent.service found running on any host after the test file
completes.

Signed-off-by: Phillip Henderson <phillip.henderson@intel.com>