### PR TITLE
DAOS-7004 Java: Update Netty to latest version (#4962)

### DIFF
--- a/src/client/java/daos-java/pom.xml
+++ b/src/client/java/daos-java/pom.xml
@@ -45,7 +45,7 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-buffer</artifactId>
-      <version>4.1.45.Final</version>
+      <version>4.1.59.Final</version>
     </dependency>
     <dependency>
       <groupId>com.google.code.findbugs</groupId>


### PR DESCRIPTION
SNYK found a vulnerability in the version of netty that we use so we need to
update to the latest version.

Master-PR: https://github.com/daos-stack/daos/pull/4962

Signed-off-by: David Quigley <david.quigley@intel.com>