### PR TITLE
DAOS-6259 test: Remove Ring Placement Test from Weekly Test

### DIFF
--- a/src/tests/ftest/unittest/unittest.py
+++ b/src/tests/ftest/unittest/unittest.py
@@ -62,14 +62,6 @@ class UnitTestWithoutServers(TestWithoutServers):
         """
         unittest_runner(self, "vea_ut")
 
-    def test_ring_pl_map(self):
-        """
-        Test Description: Test ring_pl_map unittest.
-        Use Case: This tests the ring placement map
-        :avocado: tags=all,unittest,tiny,full_regression,ring_pl_map
-        """
-        unittest_runner(self, "ring_pl_map")
-
     def test_jump_pl_map(self):
         """
         Test Description: Test jump_pl_map unittest.

--- a/src/tests/ftest/unittest/unittest.yaml
+++ b/src/tests/ftest/unittest/unittest.yaml
@@ -10,8 +10,6 @@ UnitTest:
     testname: smd_ut
   vea_ut:
     testname: vea_ut
-  ring_pl_map:
-    testname: ring_pl_map
   jump_pl_map:
     testname: jump_pl_map
   eq_tests:


### PR DESCRIPTION
Ring placement algorithm is obsolete now and the tests are failing
the weekly test run, so removing.

Signed-off-by: Ryon Jensen <ryon.jensen@intel.com>