### PR TITLE
DAOS-6919: dynamic_server_pool testcase failed due to pool request co…

### DIFF
--- a/src/tests/ftest/pool/dynamic_server_pool.yaml
+++ b/src/tests/ftest/pool/dynamic_server_pool.yaml
@@ -9,6 +9,7 @@ server_config:
 # actual server name passed into --test_servers. If above test_servers is hosts,
 # it'll be used as one of the servers at test startup time, so use something
 # other than hosts.
+# Pust to PR for verification aftr discussed with Phil
 extra_servers:
   test_servers:
     - server-C


### PR DESCRIPTION
…ntains invalid ranks: 2

Skip-unit-tests: true
Skip-nlt: true
Test-tag: dynamic_server_pool
Signed-off-by: Ding Ho <ding-hwa.ho@intel.com>