### PR TITLE
DAOS-6678 sdl: Fix various coverity defects in placement tests (#4794)

### DIFF
--- a/src/placement/tests/jump_map_place_obj.c
+++ b/src/placement/tests/jump_map_place_obj.c
@@ -453,6 +453,9 @@ jtc_create_layout(struct jm_test_ctx *ctx)
 {
 	int rc;
 
+	D_ASSERT(ctx != NULL);
+	D_ASSERT(ctx->pl_map != NULL);
+
 	/* place object will allocate the layout so need to free first
 	 * if already allocated
 	 */
@@ -584,6 +587,8 @@ jtc_layout_has_duplicate(struct jm_test_ctx *ctx)
 	bool *target_set;
 	bool result = false;
 
+	D_ASSERT(ctx != NULL);
+	D_ASSERT(ctx->po_map != NULL);
 	const uint32_t total_targets = pool_map_target_nr(ctx->po_map);
 
 	D_ALLOC_ARRAY(target_set, total_targets);

--- a/src/placement/tests/place_obj_common.c
+++ b/src/placement/tests/place_obj_common.c
@@ -48,6 +48,7 @@ plt_obj_place(daos_obj_id_t oid, struct pl_obj_layout **layout,
 
 	memset(&md, 0, sizeof(md));
 	md.omd_id  = oid;
+	D_ASSERT(pl_map != NULL);
 	md.omd_ver = pool_map_get_version(pl_map->pl_poolmap);
 
 	rc = pl_obj_place(pl_map, &md, NULL, layout);
@@ -805,7 +806,7 @@ extend_test_pool_map(struct pool_map *map,
 		int32_t *domains, bool *updated_p, uint32_t *map_version_p,
 		uint32_t dss_tgt_nr)
 {
-	struct pool_buf	*map_buf;
+	struct pool_buf	*map_buf = NULL;
 	uint32_t	map_version;
 	int		ntargets;
 	int		rc;
@@ -821,6 +822,11 @@ extend_test_pool_map(struct pool_map *map,
 
 	/* Extend the current pool map */
 	rc = pool_map_extend(map, map_version, map_buf);
+	if (rc != 0) {
+		if (map_buf != NULL)
+			pool_buf_free(map_buf);
+	}
+
 	assert_success(rc);
 
 	return rc;


### PR DESCRIPTION
CID 316617 (resource leak)
CID 316613 (explicit null dereferenced)
CID 316615 (explicit null dereferenced)

Signed-off-by: Sydney Vanda <sydney.m.vanda@intel.com>