### PR TITLE
DAOS-6376 container: Get Props with Open Container Handle

### DIFF
--- a/src/common/checksum.c
+++ b/src/common/checksum.c
@@ -965,7 +965,8 @@ daos_csummer_verify_key(struct daos_csummer *obj, daos_key_t *key,
 		return 0;
 
 	if (!ci_is_valid(csum)) {
-		D_ERROR("checksums is enabled, but dcs_csum_info is invalid\n");
+		D_ERROR("checksums is enabled, but dcs_csum_info is invalid, "
+			"key: "DF_KEY", csum = %p\n", DP_KEY(key), csum);
 		return -DER_CSUM;
 	}
 

--- a/src/common/cont_props.c
+++ b/src/common/cont_props.c
@@ -5,13 +5,16 @@
  */
 
 #include <daos/cont_props.h>
-#include <common.h>
+#include <daos/common.h>
 
 void
 daos_props_2cont_props(daos_prop_t *props, struct cont_props *cont_prop)
 {
-	if (props == NULL || cont_prop == NULL)
+	if (props == NULL || cont_prop == NULL) {
+		D_DEBUG(DB_TRACE, "No props to set, props=%p, cont_prop=%p\n",
+			props, cont_prop);
 		return;
+	}
 
 	/** deduplication */
 	cont_prop->dcp_dedup_enabled	= daos_cont_prop2dedup(props);

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -3864,6 +3864,11 @@ obj_csum_update(struct dc_object *obj, daos_obj_update_t *args,
 	struct dcs_iod_csums	*iod_csums = NULL;
 	int			 rc;
 
+	D_DEBUG(DB_CSUM, "obj: %p, args: %p, obj_auxi: %p, csummer: %p, "
+			 "csum_type: %d, csum_enabled: %s\n",
+		obj, args, obj_auxi, csummer,
+		cont_props.dcp_csum_type,
+		cont_props.dcp_csum_enabled ? "Yes" : "No");
 	if (!daos_csummer_initialized(csummer)) /** Not configured */
 		return 0;
 


### PR DESCRIPTION
In the server, on a container open, the output properties are set
based on requested prop bits. This was being skipped when the
container handle was already open. This patch moves where the
requested props are read so they will always be set.

Signed-off-by: Ryon Jensen <ryon.jensen@intel.com>