### PR TITLE
DAOS-6967 vos: Data loss on updates after uncommitted punch (#4899)

### DIFF
--- a/src/common/btree.c
+++ b/src/common/btree.c
@@ -957,6 +957,8 @@ btr_check_availability(struct btr_context *tcx, struct btr_check_alb *alb)
 		 *	for the case in the new aggregation logic.
 		 *	But before that, just make it fall through.
 		 */
+	case ALB_AVAILABLE_ABORTED:
+		/** NB: Entry is aborted flag set and we can purge it */
 	case ALB_AVAILABLE_CLEAN:
 		return PROBE_RC_OK;
 	case ALB_UNAVAILABLE:

--- a/src/include/daos_srv/vos_types.h
+++ b/src/include/daos_srv/vos_types.h
@@ -434,6 +434,8 @@ enum {
 	VOS_ITER_CB_SKIP	= (1UL << 2),
 	/** Abort current level iteration */
 	VOS_ITER_CB_ABORT	= (1UL << 3),
+	/** Abort the current level iterator and restart */
+	VOS_ITER_CB_RESTART	= (1UL << 4),
 };
 
 /**

--- a/src/vos/ilog.c
+++ b/src/vos/ilog.c
@@ -1465,6 +1465,7 @@ struct agg_arg {
 	const struct ilog_entry		*aa_prior_punch;
 	daos_epoch_t			 aa_punched;
 	bool				 aa_discard;
+	uint16_t			 aa_punched_minor;
 };
 
 enum {
@@ -1475,26 +1476,47 @@ enum {
 	AGG_RC_ABORT,
 };
 
+static bool
+entry_punched(const struct ilog_entry *entry, const struct agg_arg *agg_arg)
+{
+	uint16_t	minor_epc = MAX(entry->ie_id.id_punch_minor_eph,
+					entry->ie_id.id_update_minor_eph);
+
+	if (entry->ie_id.id_epoch > agg_arg->aa_punched)
+		return false;
+
+	if (entry->ie_id.id_epoch < agg_arg->aa_punched)
+		return true;
+
+	return minor_epc <= agg_arg->aa_punched_minor;
+
+}
+
 static int
 check_agg_entry(const struct ilog_entry *entry, struct agg_arg *agg_arg)
 {
-	int	rc;
+	int		rc;
+	bool		parent_punched = false;
+	uint16_t	minor_epc = MAX(entry->ie_id.id_punch_minor_eph,
+					entry->ie_id.id_update_minor_eph);
 
-	D_DEBUG(DB_TRACE, "Entry "DF_X64" punch=%s prev="DF_X64
+	D_DEBUG(DB_TRACE, "Entry "DF_X64".%d punch=%s prev="DF_X64
 		" prior_punch="DF_X64"\n", entry->ie_id.id_epoch,
-		ilog_is_punch(entry) ? "yes" : "no",
+		minor_epc, ilog_is_punch(entry) ? "yes" : "no",
 		agg_arg->aa_prev ? agg_arg->aa_prev->ie_id.id_epoch : 0,
 		agg_arg->aa_prior_punch ?
 		agg_arg->aa_prior_punch->ie_id.id_epoch : 0);
+
+	if (entry->ie_id.id_epoch > agg_arg->aa_epr->epr_hi)
+		D_GOTO(done, rc = AGG_RC_DONE);
 
 	/* Abort ilog aggregation on hitting any uncommitted entry */
 	if (entry->ie_status == ILOG_UNCOMMITTED)
 		D_GOTO(done, rc = AGG_RC_ABORT);
 
-	if (entry->ie_id.id_epoch > agg_arg->aa_epr->epr_hi)
-		D_GOTO(done, rc = AGG_RC_DONE);
+	parent_punched = entry_punched(entry, agg_arg);
 	if (entry->ie_id.id_epoch < agg_arg->aa_epr->epr_lo) {
-		if (entry->ie_id.id_epoch <= agg_arg->aa_punched) {
+		if (parent_punched) {
 			/* Skip entries outside of the range and
 			 * punched by the parent
 			 */
@@ -1514,7 +1536,7 @@ check_agg_entry(const struct ilog_entry *entry, struct agg_arg *agg_arg)
 	D_ASSERT(entry->ie_status != ILOG_UNCOMMITTED);
 
 	if (agg_arg->aa_discard || entry->ie_status == ILOG_REMOVED ||
-	    agg_arg->aa_punched >= entry->ie_id.id_epoch) {
+	    parent_punched) {
 		/* Remove stale entry or punched entry */
 		D_GOTO(done, rc = AGG_RC_REMOVE);
 	}
@@ -1525,7 +1547,7 @@ check_agg_entry(const struct ilog_entry *entry, struct agg_arg *agg_arg)
 
 		if (!punch) {
 			/* punched by outer level */
-			punch = prev->ie_id.id_epoch <= agg_arg->aa_punched;
+			punch = entry_punched(prev, agg_arg);
 		}
 		if (ilog_is_punch(entry) == punch) {
 			/* Remove redundant entry */
@@ -1560,7 +1582,8 @@ done:
 int
 ilog_aggregate(struct umem_instance *umm, struct ilog_df *ilog,
 	       const struct ilog_desc_cbs *cbs, const daos_epoch_range_t *epr,
-	       bool discard, daos_epoch_t punched, struct ilog_entries *entries)
+	       bool discard, daos_epoch_t punched_major, uint16_t punched_minor,
+	       struct ilog_entries *entries)
 {
 	struct ilog_priv	*priv = ilog_ent2priv(entries);
 	struct ilog_context	*lctx;
@@ -1576,11 +1599,11 @@ ilog_aggregate(struct umem_instance *umm, struct ilog_df *ilog,
 	daos_handle_t		 toh = DAOS_HDL_INVAL;
 
 	D_ASSERT(epr != NULL);
-	D_ASSERT(punched <= epr->epr_hi);
+	D_ASSERT(punched_major <= epr->epr_hi);
 
 	D_DEBUG(DB_TRACE, "%s incarnation log: epr: "DF_X64"-"DF_X64" punched="
-		DF_X64"\n", discard ? "Discard" : "Aggregate", epr->epr_lo,
-		epr->epr_hi, punched);
+		DF_X64".%d\n", discard ? "Discard" : "Aggregate", epr->epr_lo,
+		epr->epr_hi, punched_major, punched_minor);
 
 	/* This can potentially be optimized but using ilog_fetch gets some code
 	 * reuse.
@@ -1603,7 +1626,8 @@ ilog_aggregate(struct umem_instance *umm, struct ilog_df *ilog,
 	agg_arg.aa_epr = epr;
 	agg_arg.aa_prev = NULL;
 	agg_arg.aa_prior_punch = NULL;
-	agg_arg.aa_punched = punched;
+	agg_arg.aa_punched = punched_major;
+	agg_arg.aa_punched_minor = punched_minor;
 	agg_arg.aa_discard = discard;
 
 	if (root->lr_tree.it_embedded) {

--- a/src/vos/ilog.h
+++ b/src/vos/ilog.h
@@ -190,7 +190,8 @@ struct ilog_entries {
  *				that are provably not needed.  If discard is
  *				set, it will remove everything in the epoch
  *				range.
- *  \param	punched[in]	Max punch of parent incarnation log
+ *  \param	punch_major[in]	Max major epoch punch of parent incarnation log
+ *  \param	punch_major[in]	Max minor epoch punch of parent incarnation log
  *  \param	entries[in]	Used for efficiency since aggregation is used
  *				by vos_iterator
  *
@@ -201,7 +202,7 @@ struct ilog_entries {
 int
 ilog_aggregate(struct umem_instance *umm, struct ilog_df *root,
 	       const struct ilog_desc_cbs *cbs, const daos_epoch_range_t *epr,
-	       bool discard, daos_epoch_t punched,
+	       bool discard, daos_epoch_t punch_major, uint16_t punch_minor,
 	       struct ilog_entries *entries);
 
 /** Initialize an ilog_entries struct for fetch

--- a/src/vos/tests/vts_ilog.c
+++ b/src/vos/tests/vts_ilog.c
@@ -871,7 +871,7 @@ ilog_test_aggregate(void **state)
 	commit_all();
 	epr.epr_lo = 2;
 	epr.epr_hi = 4;
-	rc = ilog_aggregate(umm, ilog, &ilog_callbacks, &epr, false, 0,
+	rc = ilog_aggregate(umm, ilog, &ilog_callbacks, &epr, false, 0, 0,
 			    &ilents);
 	LOG_FAIL(rc, 0, "Failed to aggregate ilog\n");
 	version_cache_fetch(&version_cache, loh, true);
@@ -895,7 +895,7 @@ ilog_test_aggregate(void **state)
 
 	epr.epr_lo = 0;
 	epr.epr_hi = 6;
-	rc = ilog_aggregate(umm, ilog, &ilog_callbacks, &epr, false, 0,
+	rc = ilog_aggregate(umm, ilog, &ilog_callbacks, &epr, false, 0, 0,
 			    &ilents);
 	LOG_FAIL(rc, 0, "Failed to aggregate ilog\n");
 	version_cache_fetch(&version_cache, loh, true);
@@ -910,7 +910,7 @@ ilog_test_aggregate(void **state)
 	version_cache_fetch(&version_cache, loh, true);
 	commit_all();
 	epr.epr_hi = 7;
-	rc = ilog_aggregate(umm, ilog, &ilog_callbacks, &epr, false, 0,
+	rc = ilog_aggregate(umm, ilog, &ilog_callbacks, &epr, false, 0, 0,
 			    &ilents);
 	/* 1 means empty */
 	LOG_FAIL(rc, 1, "Failed to aggregate log entry\n");
@@ -987,7 +987,8 @@ ilog_test_discard(void **state)
 	commit_all();
 	epr.epr_lo = 2;
 	epr.epr_hi = 4;
-	rc = ilog_aggregate(umm, ilog, &ilog_callbacks, &epr, true, 0, &ilents);
+	rc = ilog_aggregate(umm, ilog, &ilog_callbacks, &epr, true, 0, 0,
+			    &ilents);
 	LOG_FAIL(rc, 0, "Failed to aggregate ilog\n");
 	version_cache_fetch(&version_cache, loh, true);
 
@@ -1009,7 +1010,8 @@ ilog_test_discard(void **state)
 	commit_all();
 	epr.epr_lo = 0;
 	epr.epr_hi = 6;
-	rc = ilog_aggregate(umm, ilog, &ilog_callbacks, &epr, true, 0, &ilents);
+	rc = ilog_aggregate(umm, ilog, &ilog_callbacks, &epr, true, 0, 0,
+			    &ilents);
 	/* 1 means empty */
 	LOG_FAIL(rc, 1, "Failed to aggregate ilog\n");
 	version_cache_fetch(&version_cache, loh, true);
@@ -1026,7 +1028,8 @@ ilog_test_discard(void **state)
 	commit_all();
 
 	epr.epr_hi = 7;
-	rc = ilog_aggregate(umm, ilog, &ilog_callbacks, &epr, true, 0, &ilents);
+	rc = ilog_aggregate(umm, ilog, &ilog_callbacks, &epr, true, 0, 0,
+			    &ilents);
 	/* 1 means empty */
 	LOG_FAIL(rc, 1, "Failed to aggregate ilog\n");
 	version_cache_fetch(&version_cache, loh, true);

--- a/src/vos/vos_ilog.c
+++ b/src/vos/vos_ilog.c
@@ -266,6 +266,7 @@ init:
 	if (punched != NULL)
 		punch = *punched;
 	if (parent != NULL) {
+		info->ii_prior_any_punch = parent->ii_prior_any_punch;
 		punch = parent->ii_prior_punch;
 		info->ii_uncommitted = parent->ii_uncommitted;
 	}
@@ -506,20 +507,23 @@ punch_log:
 int
 vos_ilog_aggregate(daos_handle_t coh, struct ilog_df *ilog,
 		   const daos_epoch_range_t *epr,
-		   bool discard, daos_epoch_t punched,
+		   bool discard, const struct vos_punch_record *parent_punch,
 		   struct vos_ilog_info *info)
 {
 	struct vos_container	*cont = vos_hdl2cont(coh);
 	struct umem_instance	*umm = vos_cont2umm(cont);
 	struct ilog_desc_cbs	 cbs;
-	struct vos_punch_record	 punch_rec = {punched, 0};
+	struct vos_punch_record	 punch_rec = {0, 0};
 	int			 rc;
+
+	if (parent_punch)
+		punch_rec = *parent_punch;
 
 	vos_ilog_desc_cbs_init(&cbs, coh);
 	D_DEBUG(DB_TRACE, "log="DF_X64"\n", umem_ptr2off(umm, ilog));
 
-	rc = ilog_aggregate(umm, ilog, &cbs, epr, discard, punched,
-			    &info->ii_entries);
+	rc = ilog_aggregate(umm, ilog, &cbs, epr, discard, punch_rec.pr_epc,
+			    punch_rec.pr_minor_epc, &info->ii_entries);
 
 	if (rc != 0)
 		return rc;

--- a/src/vos/vos_ilog.h
+++ b/src/vos/vos_ilog.h
@@ -199,7 +199,8 @@ vos_ilog_desc_cbs_init(struct ilog_desc_cbs *cbs, daos_handle_t coh);
 int
 vos_ilog_aggregate(daos_handle_t coh, struct ilog_df *ilog,
 		   const daos_epoch_range_t *epr, bool discard,
-		   daos_epoch_t punched, struct vos_ilog_info *info);
+		   const struct vos_punch_record *parent_punch,
+		   struct vos_ilog_info *info);
 
 /* #define ILOG_TRACE */
 #ifdef ILOG_TRACE

--- a/src/vos/vos_obj.c
+++ b/src/vos/vos_obj.c
@@ -1790,7 +1790,8 @@ obj_iter_delete(struct vos_obj_iter *oiter, void *args)
 	rc = umem_tx_end(umm, rc);
 exit:
 	if (rc != 0)
-		D_ERROR("Failed to delete iter entry: "DF_RC"\n", DP_RC(rc));
+		D_CDEBUG(rc == -DER_TX_BUSY, DB_TRACE, DLOG_ERR,
+			 "Failed to delete iter entry: "DF_RC"\n", DP_RC(rc));
 	return rc;
 }
 
@@ -1827,25 +1828,25 @@ vos_obj_iter_aggregate(daos_handle_t ih, bool discard)
 
 	rc = vos_ilog_aggregate(vos_cont2hdl(obj->obj_cont), &krec->kr_ilog,
 				&oiter->it_epr, discard,
-				oiter->it_punched.pr_epc, &oiter->it_ilog_info);
+				&oiter->it_punched, &oiter->it_ilog_info);
 
 	if (rc == 1) {
 		/* Incarnation log is empty so delete the key */
 		reprobe = true;
 		D_DEBUG(DB_IO, "Removing %s from tree\n",
 			iter->it_type == VOS_ITER_DKEY ? "dkey" : "akey");
-		if (krec->kr_bmap & KREC_BF_BTR &&
-		    !dbtree_is_empty_inplace(&krec->kr_btr)) {
-			/* This should be an assert eventually but we can't
-			 * at present prevent underpunch
-			 */
-			D_ERROR("Removing orphaned single value tree\n");
-		} else if (krec->kr_bmap & KREC_BF_EVT &&
-			   !evt_is_empty(&krec->kr_evt)) {
-			/* This should be an assert eventually but we can't
-			 * at present prevent underpunch
-			 */
-			D_ERROR("Removing orphaned array value tree\n");
+		/** Orphaned values indicate an incarnation log bug.  It happens
+		 *  when the key containing the subtree doesn't have a creation
+		 *  timestamp for updates in the subtree.
+		 */
+		if (krec->kr_bmap & KREC_BF_BTR) {
+			D_ASSERTF(dbtree_is_empty_inplace(&krec->kr_btr),
+				  "Orphaned %s detected\n",
+				  iter->it_type == VOS_ITER_DKEY ?
+				  "akey" : "single value");
+		} else if (krec->kr_bmap & KREC_BF_EVT) {
+			D_ASSERTF(evt_is_empty(&krec->kr_evt),
+				  "Orphaned array value detected\n");
 		}
 		rc = dbtree_iter_delete(oiter->it_hdl, NULL);
 		D_ASSERT(rc != -DER_NONEXIST);

--- a/src/vos/vos_obj_index.c
+++ b/src/vos/vos_obj_index.c
@@ -669,7 +669,7 @@ oi_iter_aggregate(daos_handle_t ih, bool discard)
 		goto exit;
 
 	rc = vos_ilog_aggregate(vos_cont2hdl(oiter->oit_cont), &obj->vo_ilog,
-				&oiter->oit_epr, discard, 0,
+				&oiter->oit_epr, discard, NULL,
 				&oiter->oit_ilog_info);
 	if (rc == 1) {
 		/* Incarnation log is empty, delete the object */


### PR DESCRIPTION
The main issue we are trying to prevent is removal of a subtree that isn't empty.
This typically means that we have a bug in aggregation or in the incarnation log

This patch does the following:

Modifies the btree code so that it returns aborted entries during aggregation.
Modify ilog_aggregate so it takes a minor epoch into account. Previously, if we had a punch of a parent, it would remove the child at the same major epoch even if it had updates afterward.
Modify the incarnation log to ensure we take the punch of a parent into account when doing an update
4.Modify aggregation so that we skip aggregation of parent objects if a child iterator hits -DER_TX_BUSY. This avoids removing orphaned subtrees.
Aggregation of the incarnation log was returning -DER_TX_BUSY for entries that are after the aggregated range. Moved the check to after the range check.
Modify evtree aggregation to restart the current tree in case of removing an aborted entry rather than returning -DER_TX_BUSY which would cause upper layer to abort too.
Fixed a few other issues with aggregation.

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>