### PR TITLE
DAOS-5915 dmg: Add metrics access

### DIFF
--- a/doc/man/man8/dmg.8
+++ b/doc/man/man8/dmg.8
@@ -1,4 +1,4 @@
-.TH dmg 1 "9 March 2021"
+.TH dmg 1 "17 March 2021"
 .SH NAME
 dmg \- Administrative tool for managing DAOS clusters
 .SH SYNOPSIS
@@ -606,6 +606,27 @@ Install directory for telemetry binary
 .TP
 \fB\fB\-s\fR, \fB\-\-system\fR <default: \fI"prometheus"\fR>\fP
 Telemetry system to configure
+.SS telemetry metrics
+Interact with metrics
+.SS telemetry metrics list
+List available metrics on a DAOS storage node
+
+\fBUsage\fP: metrics list [list-OPTIONS]
+.TP
+.TP
+\fB\fB\-p\fR, \fB\-\-port\fR (\fIrequired\fR)\fP
+Telemetry port on the host
+.SS telemetry metrics query
+Query metrics on a DAOS storage node
+
+\fBUsage\fP: metrics query [query-OPTIONS]
+.TP
+.TP
+\fB\fB\-p\fR, \fB\-\-port\fR (\fIrequired\fR)\fP
+Telemetry port on the host
+.TP
+\fB\fB\-m\fR, \fB\-\-metrics\fR <default: \fI""\fR>\fP
+Comma-separated list of metric names
 .SS telemetry run
 Launch telemetry system
 

--- a/src/control/cmd/dmg/json_test.go
+++ b/src/control/cmd/dmg/json_test.go
@@ -96,6 +96,8 @@ func TestDmg_JsonOutput(t *testing.T) {
 				testArgs = append(testArgs, []string{"--pool", common.MockUUID(), "--rank", "0"}...)
 			case "cont set-owner":
 				testArgs = append(testArgs, []string{"--user", "foo", "--pool", common.MockUUID(), "--cont", common.MockUUID()}...)
+			case "telemetry metrics list", "telemetry metrics query":
+				return // These commands query via http directly
 			}
 
 			// replace os.Stdout so that we can verify the generated output

--- a/src/control/cmd/dmg/pretty/telemetry.go
+++ b/src/control/cmd/dmg/pretty/telemetry.go
@@ -1,0 +1,178 @@
+//
+// (C) Copyright 2021 Intel Corporation.
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+
+package pretty
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/daos-stack/daos/src/control/lib/control"
+	"github.com/daos-stack/daos/src/control/lib/txtfmt"
+)
+
+// PrintMetricsListResp formats the MetricsListResp for human-readable output,
+// and writes it to the io.Writer.
+func PrintMetricsListResp(resp *control.MetricsListResp, out io.Writer) error {
+	if resp == nil {
+		return errors.New("nil response")
+	}
+
+	if len(resp.AvailableMetricSets) == 0 {
+		return nil
+	}
+
+	nameTitle := "Metric Set"
+	typeTitle := "Type"
+	descTitle := "Description"
+
+	tablePrint := txtfmt.NewTableFormatter(nameTitle, typeTitle, descTitle)
+	tablePrint.InitWriter(out)
+	table := []txtfmt.TableRow{}
+
+	for _, m := range resp.AvailableMetricSets {
+		row := txtfmt.TableRow{
+			nameTitle: m.Name,
+			typeTitle: m.Type.String(),
+			descTitle: m.Description,
+		}
+
+		table = append(table, row)
+	}
+
+	tablePrint.Format(table)
+
+	return nil
+}
+
+// PrintMetricsQueryResp formats a MetricsQueryResp for human-readable output,
+// and writes it to the io.Writer.
+func PrintMetricsQueryResp(resp *control.MetricsQueryResp, out io.Writer) error {
+	if resp == nil {
+		return errors.New("nil response")
+	}
+
+	if len(resp.MetricSets) == 0 {
+		return nil
+	}
+
+	for i, set := range resp.MetricSets {
+		if i > 0 { // a little space between metric sets
+			fmt.Fprintf(out, "\n")
+		}
+		fmt.Fprintf(out, "- Metric Set: %s (Type: %s)\n", set.Name, set.Type.String())
+
+		dw := txtfmt.NewIndentWriter(out)
+		fmt.Fprintf(dw, "%s\n", set.Description)
+
+		iw := txtfmt.NewIndentWriter(dw)
+		printMetrics(iw, set.Metrics, set.Type)
+
+	}
+	return nil
+}
+
+func printMetrics(out io.Writer, metrics []control.Metric, metricType control.MetricType) {
+	if len(metrics) == 0 {
+		fmt.Fprintf(out, "No metrics found\n")
+		return
+	}
+
+	nameTitle := "Metric"
+	labelTitle := "Labels"
+	valTitle := "Value"
+
+	tablePrint := txtfmt.NewTableFormatter(nameTitle, labelTitle, valTitle)
+	tablePrint.InitWriter(out)
+	table := []txtfmt.TableRow{}
+
+	for _, m := range metrics {
+		switch m.(type) {
+		case *control.SimpleMetric:
+			sm, _ := m.(*control.SimpleMetric)
+			labels := metricLabelsToStr(sm.Labels)
+			name := metricType.String()
+			table = append(table, txtfmt.TableRow{
+				nameTitle:  name,
+				labelTitle: labels,
+				valTitle:   fmt.Sprintf("%g", sm.Value),
+			})
+		case *control.SummaryMetric:
+			sm, _ := m.(*control.SummaryMetric)
+
+			labels := metricLabelsToStr(sm.Labels)
+			table = append(table, txtfmt.TableRow{
+				nameTitle:  "Sample Count",
+				labelTitle: labels,
+				valTitle:   fmt.Sprintf("%d", sm.SampleCount),
+			})
+			table = append(table, txtfmt.TableRow{
+				nameTitle:  "Sample Sum",
+				labelTitle: labels,
+				valTitle:   fmt.Sprintf("%g", sm.SampleSum),
+			})
+			for _, quant := range sm.Quantiles.Keys() {
+				table = append(table, txtfmt.TableRow{
+					nameTitle:  fmt.Sprintf("Quantile(%g)", quant),
+					labelTitle: labels,
+					valTitle:   fmt.Sprintf("%g", sm.Quantiles[quant]),
+				})
+			}
+		case *control.HistogramMetric:
+			hm, _ := m.(*control.HistogramMetric)
+
+			labels := metricLabelsToStr(hm.Labels)
+			table = append(table, txtfmt.TableRow{
+				nameTitle:  "Sample Count",
+				labelTitle: labels,
+				valTitle:   fmt.Sprintf("%d", hm.SampleCount),
+			})
+			table = append(table, txtfmt.TableRow{
+				nameTitle:  "Sample Sum",
+				labelTitle: labels,
+				valTitle:   fmt.Sprintf("%g", hm.SampleSum),
+			})
+			for i, bucket := range hm.Buckets {
+				name := fmt.Sprintf("Bucket(%d)", i)
+				table = append(table, txtfmt.TableRow{
+					nameTitle:  fmt.Sprintf("%s Upper Bound", name),
+					labelTitle: labels,
+					valTitle:   fmt.Sprintf("%g", bucket.UpperBound),
+				})
+				table = append(table, txtfmt.TableRow{
+					nameTitle:  fmt.Sprintf("%s Cumulative Count", name),
+					labelTitle: labels,
+					valTitle:   fmt.Sprintf("%d", bucket.CumulativeCount),
+				})
+			}
+		default:
+		}
+	}
+
+	tablePrint.Format(table)
+}
+
+func metricLabelsToStr(labels control.LabelMap) string {
+	if len(labels) == 0 {
+		return "N/A"
+	}
+
+	var b strings.Builder
+
+	first := true
+	for _, k := range labels.Keys() {
+		if first {
+			first = false
+		} else {
+			b.WriteString(", ")
+		}
+		fmt.Fprintf(&b, "%s=%s", k, labels[k])
+	}
+
+	return fmt.Sprintf("(%s)", b.String())
+}

--- a/src/control/cmd/dmg/pretty/telemetry_test.go
+++ b/src/control/cmd/dmg/pretty/telemetry_test.go
@@ -1,0 +1,435 @@
+//
+// (C) Copyright 2021 Intel Corporation.
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+
+package pretty
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/daos-stack/daos/src/control/common"
+	"github.com/daos-stack/daos/src/control/lib/control"
+)
+
+func TestPretty_PrintMetricsListResp(t *testing.T) {
+	for name, tc := range map[string]struct {
+		resp      *control.MetricsListResp
+		writeErr  error
+		expOutput string
+		expErr    error
+	}{
+		"nil resp": {
+			expErr: errors.New("nil response"),
+		},
+		"nil list": {
+			resp: &control.MetricsListResp{},
+		},
+		"empty list": {
+			resp: &control.MetricsListResp{
+				AvailableMetricSets: []*control.MetricSet{},
+			},
+		},
+		"one item": {
+			resp: &control.MetricsListResp{
+				AvailableMetricSets: []*control.MetricSet{
+					{
+						Name:        "test_metric_1",
+						Description: "Test Metric",
+						Type:        control.MetricTypeGeneric,
+					},
+				},
+			},
+			expOutput: `
+Metric Set    Type    Description 
+----------    ----    ----------- 
+test_metric_1 Generic Test Metric 
+`,
+		},
+		"multi item": {
+			resp: &control.MetricsListResp{
+				AvailableMetricSets: []*control.MetricSet{
+					{
+						Name:        "test_metric_1",
+						Description: "Test metric",
+						Type:        control.MetricTypeGauge,
+					},
+					{
+						Name:        "test_metric_2",
+						Description: "Another test metric",
+						Type:        control.MetricTypeSummary,
+					},
+					{
+						Name:        "funny_hats",
+						Description: "Hilarious headwear",
+						Type:        control.MetricTypeCounter,
+					},
+				},
+			},
+			expOutput: `
+Metric Set    Type    Description         
+----------    ----    -----------         
+test_metric_1 Gauge   Test metric         
+test_metric_2 Summary Another test metric 
+funny_hats    Counter Hilarious headwear  
+`,
+		},
+		"write failure": {
+			resp: &control.MetricsListResp{
+				AvailableMetricSets: []*control.MetricSet{
+					{
+						Name:        "test_metric_1",
+						Description: "Test Metric",
+					},
+				},
+			},
+			writeErr: errors.New("mock write"),
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			writer := &common.MockWriter{
+				WriteErr: tc.writeErr,
+			}
+
+			err := PrintMetricsListResp(tc.resp, writer)
+
+			common.CmpErr(t, tc.expErr, err)
+			common.AssertEqual(t, strings.TrimLeft(tc.expOutput, "\n"), writer.GetWritten(), "")
+		})
+	}
+}
+
+func TestPretty_PrintMetricsQueryResp(t *testing.T) {
+	for name, tc := range map[string]struct {
+		resp      *control.MetricsQueryResp
+		writeErr  error
+		expOutput string
+		expErr    error
+	}{
+		"nil resp": {
+			expErr: errors.New("nil response"),
+		},
+		"nil list": {
+			resp: &control.MetricsQueryResp{},
+		},
+		"empty list": {
+			resp: &control.MetricsQueryResp{
+				MetricSets: []*control.MetricSet{},
+			},
+		},
+		"set without values": {
+			resp: &control.MetricsQueryResp{
+				MetricSets: []*control.MetricSet{
+					{
+						Name:        "test_metric_1",
+						Description: "Test Metric",
+					},
+				},
+			},
+			expOutput: `
+- Metric Set: test_metric_1 (Type: Unknown)
+  Test Metric
+    No metrics found
+`,
+		},
+		"untyped": {
+			resp: &control.MetricsQueryResp{
+				MetricSets: []*control.MetricSet{
+					{
+						Name:        "my_metric",
+						Description: "A test metric",
+						Type:        control.MetricTypeGeneric,
+						Metrics: []control.Metric{
+							&control.SimpleMetric{
+								Labels: map[string]string{
+									"foo": "bar",
+								},
+								Value: 2.25,
+							},
+							&control.SimpleMetric{
+								Labels: map[string]string{
+									"ring":   "one",
+									"bearer": "frodo",
+								},
+								Value: 5,
+							},
+							&control.SimpleMetric{
+								Labels: map[string]string{},
+								Value:  125,
+							},
+						},
+					},
+				},
+			},
+			expOutput: `
+- Metric Set: my_metric (Type: Generic)
+  A test metric
+    Metric  Labels                   Value 
+    ------  ------                   ----- 
+    Generic (foo=bar)                2.25  
+    Generic (bearer=frodo, ring=one) 5     
+    Generic N/A                      125   
+`,
+		},
+		"counter type": {
+			resp: &control.MetricsQueryResp{
+				MetricSets: []*control.MetricSet{
+					{
+						Name:        "my_counter",
+						Description: "A test metric",
+						Type:        control.MetricTypeCounter,
+						Metrics: []control.Metric{
+							&control.SimpleMetric{
+								Labels: map[string]string{
+									"foo": "bar",
+								},
+								Value: 2.25,
+							},
+							&control.SimpleMetric{
+								Labels: map[string]string{
+									"ring":   "one",
+									"bearer": "frodo",
+								},
+								Value: 5,
+							},
+							&control.SimpleMetric{
+								Labels: map[string]string{},
+								Value:  125,
+							},
+						},
+					},
+				},
+			},
+			expOutput: `
+- Metric Set: my_counter (Type: Counter)
+  A test metric
+    Metric  Labels                   Value 
+    ------  ------                   ----- 
+    Counter (foo=bar)                2.25  
+    Counter (bearer=frodo, ring=one) 5     
+    Counter N/A                      125   
+`,
+		},
+		"gauge type": {
+			resp: &control.MetricsQueryResp{
+				MetricSets: []*control.MetricSet{
+					{
+						Name:        "my_gauge",
+						Description: "A test metric",
+						Type:        control.MetricTypeGauge,
+						Metrics: []control.Metric{
+							&control.SimpleMetric{
+								Labels: map[string]string{
+									"foo": "bar",
+								},
+								Value: 2.25,
+							},
+							&control.SimpleMetric{
+								Labels: map[string]string{
+									"ring":   "one",
+									"bearer": "frodo",
+								},
+								Value: 5,
+							},
+							&control.SimpleMetric{
+								Labels: map[string]string{},
+								Value:  125,
+							},
+						},
+					},
+				},
+			},
+			expOutput: `
+- Metric Set: my_gauge (Type: Gauge)
+  A test metric
+    Metric Labels                   Value 
+    ------ ------                   ----- 
+    Gauge  (foo=bar)                2.25  
+    Gauge  (bearer=frodo, ring=one) 5     
+    Gauge  N/A                      125   
+`,
+		},
+		"summary type": {
+			resp: &control.MetricsQueryResp{
+				MetricSets: []*control.MetricSet{
+					{
+						Name:        "my_summary",
+						Description: "A test metric",
+						Type:        control.MetricTypeSummary,
+						Metrics: []control.Metric{
+							&control.SummaryMetric{
+								Labels: control.LabelMap{
+									"foo": "bar",
+								},
+								SampleCount: 55,
+								SampleSum:   6094.27,
+								Quantiles: map[float64]float64{
+									0.25: 2034,
+									0.5:  33.333,
+								},
+							},
+							&control.SummaryMetric{
+								Labels:      control.LabelMap{},
+								SampleCount: 102,
+								SampleSum:   19.84,
+								Quantiles: map[float64]float64{
+									0.25: 4,
+								},
+							},
+						},
+					},
+				},
+			},
+			expOutput: `
+- Metric Set: my_summary (Type: Summary)
+  A test metric
+    Metric         Labels    Value   
+    ------         ------    -----   
+    Sample Count   (foo=bar) 55      
+    Sample Sum     (foo=bar) 6094.27 
+    Quantile(0.25) (foo=bar) 2034    
+    Quantile(0.5)  (foo=bar) 33.333  
+    Sample Count   N/A       102     
+    Sample Sum     N/A       19.84   
+    Quantile(0.25) N/A       4       
+`,
+		},
+		"histogram type": {
+			resp: &control.MetricsQueryResp{
+				MetricSets: []*control.MetricSet{
+					{
+						Name:        "my_histogram",
+						Description: "A test metric",
+						Type:        control.MetricTypeHistogram,
+						Metrics: []control.Metric{
+							&control.HistogramMetric{
+								Labels: control.LabelMap{
+									"foo": "bar",
+								},
+								SampleCount: 55,
+								SampleSum:   6094.27,
+								Buckets: []*control.MetricBucket{
+									{
+										UpperBound:      500,
+										CumulativeCount: 2,
+									},
+									{
+										UpperBound:      100,
+										CumulativeCount: 1,
+									},
+								},
+							},
+							&control.HistogramMetric{
+								Labels:      control.LabelMap{},
+								SampleCount: 22,
+								SampleSum:   102,
+							},
+						},
+					},
+				},
+			},
+			expOutput: `
+- Metric Set: my_histogram (Type: Histogram)
+  A test metric
+    Metric                     Labels    Value   
+    ------                     ------    -----   
+    Sample Count               (foo=bar) 55      
+    Sample Sum                 (foo=bar) 6094.27 
+    Bucket(0) Upper Bound      (foo=bar) 500     
+    Bucket(0) Cumulative Count (foo=bar) 2       
+    Bucket(1) Upper Bound      (foo=bar) 100     
+    Bucket(1) Cumulative Count (foo=bar) 1       
+    Sample Count               N/A       22      
+    Sample Sum                 N/A       102     
+`,
+		},
+		"multiple sets": {
+			resp: &control.MetricsQueryResp{
+				MetricSets: []*control.MetricSet{
+					{
+						Name:        "my_counter",
+						Description: "A test metric",
+						Type:        control.MetricTypeCounter,
+						Metrics: []control.Metric{
+							&control.SimpleMetric{
+								Labels: map[string]string{
+									"foo": "bar",
+								},
+								Value: 2.25,
+							},
+							&control.SimpleMetric{
+								Labels: map[string]string{
+									"ring":   "one",
+									"bearer": "frodo",
+								},
+								Value: 5,
+							},
+							&control.SimpleMetric{
+								Labels: map[string]string{},
+								Value:  125,
+							},
+						},
+					},
+					{
+						Name:        "my_summary",
+						Description: "Another test metric",
+						Type:        control.MetricTypeSummary,
+						Metrics: []control.Metric{
+							&control.SummaryMetric{
+								SampleCount: 55,
+								SampleSum:   6094.27,
+								Quantiles: map[float64]float64{
+									0.25: 2034,
+									0.5:  33.333,
+								},
+							},
+						},
+					},
+				},
+			},
+			expOutput: `
+- Metric Set: my_counter (Type: Counter)
+  A test metric
+    Metric  Labels                   Value 
+    ------  ------                   ----- 
+    Counter (foo=bar)                2.25  
+    Counter (bearer=frodo, ring=one) 5     
+    Counter N/A                      125   
+
+- Metric Set: my_summary (Type: Summary)
+  Another test metric
+    Metric         Labels Value   
+    ------         ------ -----   
+    Sample Count   N/A    55      
+    Sample Sum     N/A    6094.27 
+    Quantile(0.25) N/A    2034    
+    Quantile(0.5)  N/A    33.333  
+`,
+		},
+		"write failure": {
+			resp: &control.MetricsQueryResp{
+				MetricSets: []*control.MetricSet{
+					{
+						Name:        "test_metric_1",
+						Description: "Test Metric",
+					},
+				},
+			},
+			writeErr: errors.New("mock write"),
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			writer := &common.MockWriter{
+				WriteErr: tc.writeErr,
+			}
+
+			err := PrintMetricsQueryResp(tc.resp, writer)
+
+			common.CmpErr(t, tc.expErr, err)
+			common.AssertEqual(t, strings.TrimLeft(tc.expOutput, "\n"), writer.GetWritten(), "")
+		})
+	}
+}

--- a/src/control/cmd/dmg/telemetry.go
+++ b/src/control/cmd/dmg/telemetry.go
@@ -9,6 +9,7 @@ package main
 import (
 	"archive/tar"
 	"compress/gzip"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -26,12 +27,15 @@ import (
 	"golang.org/x/sys/unix"
 	yaml "gopkg.in/yaml.v2"
 
+	"github.com/daos-stack/daos/src/control/cmd/dmg/pretty"
 	"github.com/daos-stack/daos/src/control/common"
+	"github.com/daos-stack/daos/src/control/lib/control"
 )
 
 type telemCmd struct {
 	Configure telemConfigCmd `command:"config" description:"Configure telemetry"`
 	Run       telemRunCmd    `command:"run" description:"Launch telemetry system"`
+	Metrics   metricsCmd     `command:"metrics" description:"Interact with metrics"`
 }
 
 type telemConfigCmd struct {
@@ -331,4 +335,82 @@ func (cmd *telemRunCmd) Execute(_ []string) error {
 	default:
 		return errors.Errorf("unsupported telemetry system: %q", cmd.System)
 	}
+}
+
+// metricsCmd includes the commands that act directly on metrics on the DAOS hosts.
+type metricsCmd struct {
+	List  metricsListCmd  `command:"list" description:"List available metrics on a DAOS storage node"`
+	Query metricsQueryCmd `command:"query" description:"Query metrics on a DAOS storage node"`
+}
+
+// metricsListCmd provides a list of metrics available from the requested DAOS servers.
+type metricsListCmd struct {
+	logCmd
+	cfgCmd
+	ctlInvokerCmd
+	hostListCmd
+	jsonOutputCmd
+	Port uint32 `short:"p" long:"port" required:"true" description:"Telemetry port on the host"`
+}
+
+// Execute runs the command to list metrics from the DAOS storage nodes.
+func (cmd *metricsListCmd) Execute(args []string) error {
+	req := new(control.MetricsListReq)
+	req.Port = cmd.Port
+	req.SetHostList(cmd.hostlist)
+
+	resp, err := control.MetricsList(context.Background(), req)
+
+	if cmd.shouldEmitJSON {
+		return cmd.outputJSON(resp, err)
+	}
+
+	if err != nil {
+		return err
+	}
+
+	var b strings.Builder
+	err = pretty.PrintMetricsListResp(resp, &b)
+	if err != nil {
+		return err
+	}
+	cmd.log.Info(b.String())
+	return nil
+}
+
+// metricsQueryCmd collects the requested metrics from the requested DAOS servers.
+type metricsQueryCmd struct {
+	logCmd
+	cfgCmd
+	ctlInvokerCmd
+	hostListCmd
+	jsonOutputCmd
+	Port    uint32 `short:"p" long:"port" required:"true" description:"Telemetry port on the host"`
+	Metrics string `short:"m" long:"metrics" default:"" description:"Comma-separated list of metric names"`
+}
+
+// Execute runs the command to query metrics from the DAOS storage nodes.
+func (cmd *metricsQueryCmd) Execute(args []string) error {
+	req := new(control.MetricsQueryReq)
+	req.Port = cmd.Port
+	req.SetHostList(cmd.hostlist)
+	req.MetricNames = strings.Split(cmd.Metrics, ",")
+
+	resp, err := control.MetricsQuery(context.Background(), req)
+
+	if cmd.shouldEmitJSON {
+		return cmd.outputJSON(resp, err)
+	}
+
+	if err != nil {
+		return err
+	}
+
+	var b strings.Builder
+	err = pretty.PrintMetricsQueryResp(resp, &b)
+	if err != nil {
+		return err
+	}
+	cmd.log.Info(b.String())
+	return nil
 }

--- a/src/control/cmd/dmg/telemetry_test.go
+++ b/src/control/cmd/dmg/telemetry_test.go
@@ -1,0 +1,49 @@
+//
+// (C) Copyright 2019-2021 Intel Corporation.
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+
+package main
+
+import (
+	"testing"
+
+	"github.com/daos-stack/daos/src/control/common"
+	"github.com/daos-stack/daos/src/control/lib/control"
+	"github.com/daos-stack/daos/src/control/logging"
+	"github.com/pkg/errors"
+)
+
+func TestDmg_MetricsCmds(t *testing.T) {
+	for name, tc := range map[string]struct {
+		cmd    string
+		expErr error
+	}{
+		"metrics list without port": {
+			cmd:    "telemetry metrics list -l host",
+			expErr: errors.New("--port"),
+		},
+		"metrics query without port": {
+			cmd:    "telemetry metrics query -l host",
+			expErr: errors.New("--port"),
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			log, buf := logging.NewTestLogger(t.Name())
+			defer common.ShowBufferOnFailure(t, buf)
+
+			ctlClient := control.DefaultMockInvoker(log)
+			conn := newTestConn(t)
+			bridge := &bridgeConnInvoker{
+				MockInvoker: *ctlClient,
+				t:           t,
+				conn:        conn,
+			}
+
+			err := runCmd(t, tc.cmd, log, bridge)
+
+			common.CmpErr(t, tc.expErr, err)
+		})
+	}
+}

--- a/src/control/common/mocks.go
+++ b/src/control/common/mocks.go
@@ -9,6 +9,7 @@ package common
 import (
 	"fmt"
 	"net"
+	"strings"
 )
 
 var hostAddrs = make(map[int32]*net.TCPAddr)
@@ -63,4 +64,23 @@ func MockPCIAddrs(num int) (addrs []string) {
 	}
 
 	return
+}
+
+// MockWriter is a mock io.Writer that can be used to inject errors and check
+// values written.
+type MockWriter struct {
+	builder  strings.Builder
+	WriteErr error
+}
+
+func (w *MockWriter) Write(p []byte) (int, error) {
+	if w.WriteErr != nil {
+		return 0, w.WriteErr
+	}
+	return w.builder.Write(p)
+}
+
+// GetWritten gets the string value written using Write.
+func (w *MockWriter) GetWritten() string {
+	return w.builder.String()
 }

--- a/src/control/go.mod
+++ b/src/control/go.mod
@@ -16,6 +16,8 @@ require (
 	github.com/mitchellh/hashstructure v1.0.0
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v0.9.2
+	github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4
+	github.com/prometheus/common v0.0.0-20181126121408-4724e9255275
 	golang.org/x/net v0.0.0-20200301022130-244492dfa37a
 	golang.org/x/sys v0.0.0-20200317113312-5766fd39f98d
 	golang.org/x/text v0.3.2 // indirect

--- a/src/control/lib/control/http.go
+++ b/src/control/lib/control/http.go
@@ -1,0 +1,75 @@
+//
+// (C) Copyright 2021 Intel Corporation.
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+
+package control
+
+import (
+	"context"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+// httpReqTimeout is the default timeout for HTTP requests, if the caller
+// didn't set a shorter one on the context.
+const httpReqTimeout = 30 * time.Second
+
+// httpGetFn represents a function that conforms to the parameters/return values
+// of http.Get
+type httpGetFn func(string) (*http.Response, error)
+
+// httpGetBody executes a simple HTTP GET request to a given URL and returns the
+// content of the response body.
+func httpGetBody(ctx context.Context, url *url.URL, get httpGetFn) ([]byte, error) {
+	if url == nil {
+		return nil, errors.New("nil URL")
+	}
+
+	if len(url.Host) == 0 {
+		return nil, errors.New("host address is required")
+	}
+
+	if get == nil {
+		return nil, errors.New("nil get function")
+	}
+
+	httpCtx, cancel := context.WithTimeout(ctx, httpReqTimeout)
+	defer cancel()
+
+	respChan := make(chan *http.Response)
+	errChan := make(chan error)
+
+	go func() {
+		httpResp, err := get(url.String())
+		if err != nil {
+			errChan <- err
+			return
+		}
+
+		respChan <- httpResp
+	}()
+
+	select {
+	case <-httpCtx.Done():
+		return nil, httpCtx.Err()
+	case resp := <-respChan:
+		defer resp.Body.Close()
+		if resp.StatusCode < 200 || resp.StatusCode > 299 {
+			return nil, errors.Errorf("HTTP response error: %d %s", resp.StatusCode, http.StatusText(resp.StatusCode))
+		}
+
+		result, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return nil, errors.Wrap(err, "reading HTTP response body")
+		}
+		return result, nil
+	case err := <-errChan:
+		return nil, err
+	}
+}

--- a/src/control/lib/control/http_test.go
+++ b/src/control/lib/control/http_test.go
@@ -1,0 +1,149 @@
+//
+// (C) Copyright 2021 Intel Corporation.
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+
+package control
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/pkg/errors"
+
+	"github.com/daos-stack/daos/src/control/common"
+)
+
+type mockReadCloser struct {
+	reader  io.Reader
+	readErr error
+}
+
+func (m *mockReadCloser) Read(buf []byte) (int, error) {
+	if m.readErr != nil {
+		return 0, m.readErr
+	}
+	return m.reader.Read(buf)
+}
+
+func (m *mockReadCloser) Close() error {
+	return nil
+}
+
+func newMockReadCloser(content string) *mockReadCloser {
+	return &mockReadCloser{
+		reader: strings.NewReader(content),
+	}
+}
+
+func newErrMockReadCloser(err error) *mockReadCloser {
+	return &mockReadCloser{
+		readErr: err,
+	}
+}
+
+func TestControl_httpGetBody(t *testing.T) {
+	defaultURL := &url.URL{Host: "testhost"}
+
+	for name, tc := range map[string]struct {
+		url       *url.URL
+		timeout   time.Duration
+		getFn     httpGetFn
+		expResult []byte
+		expErr    error
+	}{
+		"nil url": {
+			expErr: errors.New("nil URL"),
+		},
+		"empty URL": {
+			url:    &url.URL{},
+			expErr: errors.New("host address is required"),
+		},
+		"nil getFn": {
+			url:    defaultURL,
+			expErr: errors.New("nil get function"),
+		},
+		"getFn error": {
+			url: defaultURL,
+			getFn: func(_ string) (*http.Response, error) {
+				return nil, errors.New("mock getFn")
+			},
+			expErr: errors.New("mock getFn"),
+		},
+		"http.Response error": {
+			url: defaultURL,
+			getFn: func(_ string) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusNotFound,
+					Body:       newMockReadCloser(""),
+				}, nil
+			},
+			expErr: errors.New("HTTP response error: 404 Not Found"),
+		},
+		"empty body": {
+			url: defaultURL,
+			getFn: func(_ string) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       newMockReadCloser(""),
+				}, nil
+			},
+			expResult: []byte{},
+		},
+		"success with body": {
+			url: defaultURL,
+			getFn: func(_ string) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       newMockReadCloser("this is the body of an HTTP response"),
+				}, nil
+			},
+			expResult: []byte("this is the body of an HTTP response"),
+		},
+		"reading body fails": {
+			url: defaultURL,
+			getFn: func(_ string) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       newErrMockReadCloser(errors.New("mock Read")),
+				}, nil
+			},
+			expErr: errors.New("reading HTTP response body: mock Read"),
+		},
+		"request times out": {
+			url:     defaultURL,
+			timeout: 5 * time.Millisecond,
+			getFn: func(_ string) (*http.Response, error) {
+				time.Sleep(1 * time.Second)
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       newMockReadCloser(""),
+				}, nil
+			},
+			expErr: errors.New("context deadline exceeded"),
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			ctx := context.Background()
+			if tc.timeout != 0 {
+				timedCtx, cancel := context.WithTimeout(ctx, tc.timeout)
+				defer cancel()
+				ctx = timedCtx
+			}
+
+			result, err := httpGetBody(ctx, tc.url, tc.getFn)
+
+			common.CmpErr(t, tc.expErr, err)
+			if diff := cmp.Diff(tc.expResult, result); diff != "" {
+				t.Fatalf("unexpected response (-want, +got):\n%s\n", diff)
+			}
+		})
+	}
+}

--- a/src/control/lib/control/telemetry.go
+++ b/src/control/lib/control/telemetry.go
@@ -1,0 +1,364 @@
+//
+// (C) Copyright 2021 Intel Corporation.
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+
+package control
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"sort"
+	"strings"
+
+	"github.com/pkg/errors"
+	pclient "github.com/prometheus/client_model/go"
+	"github.com/prometheus/common/expfmt"
+)
+
+// httpScrapeFn is the function that is used to scrape content from an HTTP
+// endpoint.
+var httpScrapeFn = httpGetBody
+
+// pbMetricMap is the map returned by the prometheus scraper.
+type pbMetricMap map[string]*pclient.MetricFamily
+
+// Keys gets the sorted keys for the pbMetricMap
+func (m pbMetricMap) Keys() []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// scrapeMetrics fetches the metrics published by the DAOS server in the
+// Prometheus-compatible endpoint.
+func scrapeMetrics(ctx context.Context, host string, port uint32) (pbMetricMap, error) {
+	addr := &url.URL{
+		Scheme: "http",
+		Host:   fmt.Sprintf("%s:%d", host, port),
+		Path:   "metrics",
+	}
+	body, err := httpScrapeFn(ctx, addr, http.Get)
+	if err != nil {
+		return nil, err
+	}
+
+	parser := expfmt.TextParser{}
+	reader := strings.NewReader(string(body))
+	result, err := parser.TextToMetricFamilies(reader)
+	if err != nil {
+		return nil, err
+	}
+	return pbMetricMap(result), nil
+}
+
+// MetricType defines the different types of metrics.
+type MetricType uint32
+
+const (
+	MetricTypeUnknown MetricType = iota
+	MetricTypeGeneric
+	MetricTypeCounter
+	MetricTypeGauge
+	MetricTypeSummary
+	MetricTypeHistogram
+)
+
+func (t MetricType) String() string {
+	switch t {
+	case MetricTypeGeneric:
+		return "Generic"
+	case MetricTypeCounter:
+		return "Counter"
+	case MetricTypeGauge:
+		return "Gauge"
+	case MetricTypeSummary:
+		return "Summary"
+	case MetricTypeHistogram:
+		return "Histogram"
+	}
+
+	return "Unknown"
+}
+
+func metricTypeFromPrometheus(pType pclient.MetricType) MetricType {
+	switch pType {
+	case pclient.MetricType_COUNTER:
+		return MetricTypeCounter
+	case pclient.MetricType_GAUGE:
+		return MetricTypeGauge
+	case pclient.MetricType_SUMMARY:
+		return MetricTypeSummary
+	case pclient.MetricType_HISTOGRAM:
+		return MetricTypeHistogram
+	case pclient.MetricType_UNTYPED:
+		return MetricTypeGeneric
+	}
+
+	return MetricTypeUnknown
+}
+
+type (
+	// Metric is an interface implemented by all metric types.
+	Metric interface {
+		IsMetric()
+	}
+
+	// LabelMap is the set of key-value label pairs.
+	LabelMap map[string]string
+
+	// SimpleMetric is a specific metric with a value.
+	SimpleMetric struct {
+		Labels LabelMap `json:"labels"`
+		Value  float64  `json:"value"`
+	}
+
+	// QuantileMap is the set of quantile measurements.
+	QuantileMap map[float64]float64
+
+	// SummaryMetric represents a group of observations.
+	SummaryMetric struct {
+		Labels      LabelMap    `json:"labels"`
+		SampleCount uint64      `json:"sample_count"`
+		SampleSum   float64     `json:"sample_sum"`
+		Quantiles   QuantileMap `json:"quantiles"`
+	}
+
+	// MetricBucket represents a bucket for observations to be sorted into.
+	MetricBucket struct {
+		CumulativeCount uint64  `json:"cumulative_count"`
+		UpperBound      float64 `json:"upper_bound"`
+	}
+
+	// HistogramMetric represents a group of observations sorted into
+	// buckets.
+	HistogramMetric struct {
+		Labels      LabelMap        `json:"labels"`
+		SampleCount uint64          `json:"sample_count"`
+		SampleSum   float64         `json:"sample_sum"`
+		Buckets     []*MetricBucket `json:"buckets"`
+	}
+
+	// MetricSet is a group of related metrics.
+	MetricSet struct {
+		Name        string     `json:"name"`
+		Description string     `json:"description"`
+		Type        MetricType `json:"type"`
+		Metrics     []Metric   `json:"metrics"`
+	}
+)
+
+// IsMetric identifies SimpleMetric as a Metric.
+func (_ *SimpleMetric) IsMetric() {}
+
+// IsMetric identifies SummaryMetric as a Metric.
+func (_ *SummaryMetric) IsMetric() {}
+
+// IsMetric identifies HistogramMetric as a Metric.
+func (_ *HistogramMetric) IsMetric() {}
+
+// Keys gets the sorted list of label keys.
+func (m LabelMap) Keys() []string {
+	result := make([]string, 0, len(m))
+	for label := range m {
+		result = append(result, label)
+	}
+	sort.Strings(result)
+	return result
+}
+
+// Keys gets the sorted list of quantile keys.
+func (m QuantileMap) Keys() []float64 {
+	result := make([]float64, 0, len(m))
+	for q := range m {
+		result = append(result, q)
+	}
+	sort.Float64s(result)
+	return result
+}
+
+type (
+	// MetricsListReq is used to request the list of metrics.
+	MetricsListReq struct {
+		request
+		Port uint32 // Port to use for collecting telemetry data
+	}
+
+	// MetricsListResp contains the list of available metrics.
+	MetricsListResp struct {
+		AvailableMetricSets []*MetricSet `json:"available_metric_sets"`
+	}
+)
+
+// MetricsList fetches the list of available metric types from the DAOS nodes.
+func MetricsList(ctx context.Context, req *MetricsListReq) (*MetricsListResp, error) {
+	if req == nil {
+		return nil, errors.New("nil request")
+	}
+
+	if err := checkHostList(req); err != nil {
+		return nil, err
+	}
+
+	if req.Port == 0 {
+		return nil, errors.New("port must be specified")
+	}
+
+	scraped, err := scrapeMetrics(ctx, req.HostList[0], req.Port)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to list metrics")
+	}
+
+	resp := new(MetricsListResp)
+
+	list := make([]*MetricSet, 0)
+	for _, name := range scraped.Keys() {
+		mf := scraped[name]
+		newMetric := &MetricSet{
+			Name:        name,
+			Description: mf.GetHelp(),
+			Type:        metricTypeFromPrometheus(mf.GetType()),
+		}
+		list = append(list, newMetric)
+	}
+
+	resp.AvailableMetricSets = list
+	return resp, nil
+}
+
+func checkHostList(req hostListGetter) error {
+	if len(req.getHostList()) != 1 {
+		return errors.New("exactly one host must be specified")
+	}
+	return nil
+}
+
+type (
+	// MetricsQueryReq is used to query telemetry values.
+	MetricsQueryReq struct {
+		request
+		Port        uint32   // port to use for collecting telemetry data
+		MetricNames []string // if empty, collects all metrics
+	}
+
+	// MetricsQueryResp contains the list of telemetry values per host.
+	MetricsQueryResp struct {
+		MetricSets []*MetricSet `json:"metric_sets"`
+	}
+)
+
+// MetricsQuery fetches the requested metrics values from the DAOS nodes.
+func MetricsQuery(ctx context.Context, req *MetricsQueryReq) (*MetricsQueryResp, error) {
+	if req == nil {
+		return nil, errors.New("nil request")
+	}
+
+	if err := checkHostList(req); err != nil {
+		return nil, err
+	}
+
+	if req.Port == 0 {
+		return nil, errors.New("port must be specified")
+	}
+
+	scraped, err := scrapeMetrics(ctx, req.HostList[0], req.Port)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to query metrics")
+	}
+
+	metricNames := req.MetricNames
+	if len(metricNames) == 0 {
+		// when caller doesn't specify metrics, we include all of them
+		metricNames = scraped.Keys()
+	}
+
+	return newMetricsQueryResp(scraped, metricNames)
+}
+
+func newMetricsQueryResp(scraped pbMetricMap, metricNames []string) (*MetricsQueryResp, error) {
+	resp := new(MetricsQueryResp)
+
+	list := make([]*MetricSet, 0)
+	for _, name := range metricNames {
+		mf, found := scraped[name]
+		if !found {
+			return nil, errors.Errorf("metric %q not found on host", name)
+		}
+
+		newSet := &MetricSet{
+			Name:        name,
+			Description: mf.GetHelp(),
+			Type:        metricTypeFromPrometheus(mf.GetType()),
+		}
+
+		for _, m := range mf.Metric {
+			newSet.Metrics = append(newSet.Metrics, getMetricFromPrometheus(m, mf.GetType()))
+		}
+
+		list = append(list, newSet)
+	}
+
+	resp.MetricSets = list
+	return resp, nil
+}
+
+func getMetricFromPrometheus(pMetric *pclient.Metric, metricType pclient.MetricType) Metric {
+	labels := metricsLabelsToMap(pMetric)
+	switch metricType {
+	case pclient.MetricType_COUNTER:
+		return newSimpleMetric(labels, pMetric.GetCounter().GetValue())
+	case pclient.MetricType_GAUGE:
+		return newSimpleMetric(labels, pMetric.GetGauge().GetValue())
+	case pclient.MetricType_SUMMARY:
+		summary := pMetric.GetSummary()
+		newMetric := &SummaryMetric{
+			Labels:      labels,
+			SampleSum:   summary.GetSampleSum(),
+			SampleCount: summary.GetSampleCount(),
+			Quantiles:   QuantileMap{},
+		}
+		for _, q := range summary.Quantile {
+			newMetric.Quantiles[q.GetQuantile()] = q.GetValue()
+		}
+		return newMetric
+	case pclient.MetricType_HISTOGRAM:
+		histogram := pMetric.GetHistogram()
+		newMetric := &HistogramMetric{
+			Labels:      labels,
+			SampleSum:   histogram.GetSampleSum(),
+			SampleCount: histogram.GetSampleCount(),
+		}
+		for _, b := range histogram.Bucket {
+			newMetric.Buckets = append(newMetric.Buckets,
+				&MetricBucket{
+					UpperBound:      b.GetUpperBound(),
+					CumulativeCount: b.GetCumulativeCount(),
+				})
+		}
+		return newMetric
+	}
+
+	return newSimpleMetric(labels, pMetric.GetUntyped().GetValue())
+}
+
+func newSimpleMetric(labels map[string]string, value float64) *SimpleMetric {
+	return &SimpleMetric{
+		Labels: labels,
+		Value:  value,
+	}
+}
+
+func metricsLabelsToMap(m *pclient.Metric) map[string]string {
+	result := make(map[string]string)
+
+	for _, label := range m.GetLabel() {
+		result[label.GetName()] = label.GetValue()
+	}
+	return result
+}

--- a/src/control/lib/control/telemetry_test.go
+++ b/src/control/lib/control/telemetry_test.go
@@ -1,0 +1,608 @@
+//
+// (C) Copyright 2021 Intel Corporation.
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+
+package control
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/pkg/errors"
+	pclient "github.com/prometheus/client_model/go"
+	"github.com/prometheus/common/expfmt"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/daos-stack/daos/src/control/common"
+)
+
+func newTestMetricFamily(name string, help string, mType pclient.MetricType) *pclient.MetricFamily {
+	fam := &pclient.MetricFamily{
+		Name: new(string),
+		Help: new(string),
+		Type: new(pclient.MetricType),
+	}
+	*fam.Name = name
+	*fam.Help = help
+	*fam.Type = mType
+	return fam
+}
+
+func addTestMetric(fam *pclient.MetricFamily) {
+	metric := &pclient.Metric{}
+
+	switch *fam.Type {
+	case pclient.MetricType_GAUGE:
+		metric = newTestPBGauge(0)
+	case pclient.MetricType_COUNTER:
+		metric = newTestPBCounter(0)
+	case pclient.MetricType_SUMMARY:
+		metric = newTestPBSummary(1)
+	case pclient.MetricType_HISTOGRAM:
+		metric = newTestPBHistogram(0)
+	default:
+		metric = newTestPBUntyped(0)
+	}
+
+	fam.Metric = append(fam.Metric, metric)
+}
+
+func newTestPBCounter(value float64) *pclient.Metric {
+	metric := &pclient.Metric{}
+
+	metric.Counter = new(pclient.Counter)
+	metric.Counter.Value = proto.Float64(value)
+
+	return metric
+}
+
+func newTestPBGauge(value float64) *pclient.Metric {
+	metric := &pclient.Metric{}
+
+	metric.Gauge = new(pclient.Gauge)
+	metric.Gauge.Value = proto.Float64(value)
+
+	return metric
+}
+
+func newTestPBUntyped(value float64) *pclient.Metric {
+	metric := &pclient.Metric{}
+
+	metric.Untyped = new(pclient.Untyped)
+	metric.Untyped.Value = proto.Float64(value)
+
+	return metric
+}
+
+func newTestPBSummary(numQuantiles int) *pclient.Metric {
+	metric := &pclient.Metric{}
+
+	metric.Summary = new(pclient.Summary)
+	metric.Summary.SampleSum = proto.Float64(0)
+	metric.Summary.SampleCount = proto.Uint64(0)
+	for i := 0; i < numQuantiles; i++ {
+		q := &pclient.Quantile{
+			Quantile: proto.Float64(0),
+			Value:    proto.Float64(0),
+		}
+		metric.Summary.Quantile = append(metric.Summary.Quantile, q)
+	}
+
+	return metric
+}
+
+func newTestPBHistogram(numBuckets int) *pclient.Metric {
+	metric := &pclient.Metric{}
+
+	metric.Histogram = new(pclient.Histogram)
+	metric.Histogram.SampleSum = proto.Float64(0)
+	metric.Histogram.SampleCount = proto.Uint64(0)
+	for i := 0; i < numBuckets; i++ {
+		b := &pclient.Bucket{
+			CumulativeCount: proto.Uint64(0),
+			UpperBound:      proto.Float64(0),
+		}
+		metric.Histogram.Bucket = append(metric.Histogram.Bucket, b)
+	}
+
+	return metric
+}
+
+func mockScrapeFnSuccess(t *testing.T, metricFam ...*pclient.MetricFamily) func(context.Context, *url.URL, httpGetFn) ([]byte, error) {
+	t.Helper()
+
+	return func(_ context.Context, _ *url.URL, _ httpGetFn) ([]byte, error) {
+		var b strings.Builder
+		for _, mf := range metricFam {
+			_, err := expfmt.MetricFamilyToText(&b, mf)
+			if err != nil {
+				t.Fatalf("external metric parsing failed: %s", err.Error())
+			}
+		}
+		return []byte(b.String()), nil
+	}
+}
+
+func TestControl_scrapeMetrics(t *testing.T) {
+	testHost := "dontcare"
+	testPort := uint32(1234)
+
+	testMetricFam := newTestMetricFamily("test_name", "This is the help text", pclient.MetricType_GAUGE)
+	addTestMetric(testMetricFam)
+
+	for name, tc := range map[string]struct {
+		scrapeFn  func(context.Context, *url.URL, httpGetFn) ([]byte, error)
+		expResult pbMetricMap
+		expErr    error
+	}{
+		"check scrape params": {
+			scrapeFn: func(_ context.Context, url *url.URL, getter httpGetFn) ([]byte, error) {
+				common.AssertEqual(t, "http", url.Scheme, "")
+				common.AssertEqual(t, fmt.Sprintf("%s:%d", testHost, testPort), url.Host, "")
+				common.AssertEqual(t, "metrics", url.Path, "")
+
+				if getter == nil {
+					t.Fatal("http getter was not set")
+				}
+				return nil, nil
+			},
+			expResult: pbMetricMap{},
+		},
+		"HTTP scrape error": {
+			scrapeFn: func(_ context.Context, _ *url.URL, _ httpGetFn) ([]byte, error) {
+				return nil, errors.New("mock scrape")
+			},
+			expErr: errors.New("mock scrape"),
+		},
+		"scrape returns no content": {
+			scrapeFn: func(_ context.Context, _ *url.URL, _ httpGetFn) ([]byte, error) {
+				return []byte{}, nil
+			},
+			expResult: pbMetricMap{},
+		},
+		"scrape returns bad content": {
+			scrapeFn: func(_ context.Context, _ *url.URL, _ httpGetFn) ([]byte, error) {
+				return []byte("<h1>Hello world</h1>"), nil
+			},
+			expErr: errors.New("parsing error"),
+		},
+		"parseable content": {
+			scrapeFn: mockScrapeFnSuccess(t, testMetricFam),
+			expResult: pbMetricMap{
+				*testMetricFam.Name: testMetricFam,
+			},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			oldScrapeFn := httpScrapeFn
+			httpScrapeFn = tc.scrapeFn
+
+			result, err := scrapeMetrics(context.TODO(), testHost, testPort)
+
+			httpScrapeFn = oldScrapeFn
+			common.CmpErr(t, tc.expErr, err)
+			if diff := cmp.Diff(tc.expResult, result); diff != "" {
+				t.Fatalf("unexpected response (-want, +got):\n%s\n", diff)
+			}
+		})
+	}
+}
+
+func TestControl_MetricsList(t *testing.T) {
+	testMetricFam := []*pclient.MetricFamily{
+		newTestMetricFamily("counter", "this is the counter help", pclient.MetricType_COUNTER),
+		newTestMetricFamily("gauge", "this is the gauge help", pclient.MetricType_GAUGE),
+	}
+
+	for _, mf := range testMetricFam {
+		addTestMetric(mf)
+	}
+
+	for name, tc := range map[string]struct {
+		scrapeFn func(context.Context, *url.URL, httpGetFn) ([]byte, error)
+		req      *MetricsListReq
+		expResp  *MetricsListResp
+		expErr   error
+	}{
+		"nil request": {
+			expErr: errors.New("nil"),
+		},
+		"no hosts in req": {
+			req:    &MetricsListReq{Port: 2525},
+			expErr: errors.New("exactly one host"),
+		},
+		"too many hosts in req": {
+			req: &MetricsListReq{
+				request: request{
+					HostList: []string{"host1", "host2"},
+				},
+				Port: 4111,
+			},
+			expErr: errors.New("exactly one host"),
+		},
+		"no port": {
+			req: &MetricsListReq{
+				request: request{
+					HostList: []string{"host1"},
+				},
+			},
+			expErr: errors.New("port must be specified"),
+		},
+		"scrape failed": {
+			req: &MetricsListReq{
+				request: request{
+					HostList: []string{"host1"},
+				},
+				Port: 1066,
+			},
+			scrapeFn: func(context.Context, *url.URL, httpGetFn) ([]byte, error) {
+				return nil, errors.New("mock scrape")
+			},
+			expErr: errors.New("mock scrape"),
+		},
+		"no metrics": {
+			req: &MetricsListReq{
+				request: request{
+					HostList: []string{"host1"},
+				},
+				Port: 8888,
+			},
+			scrapeFn: func(context.Context, *url.URL, httpGetFn) ([]byte, error) {
+				return []byte{}, nil
+			},
+			expResp: &MetricsListResp{
+				AvailableMetricSets: []*MetricSet{},
+			},
+		},
+		"success": {
+			req: &MetricsListReq{
+				request: request{
+					HostList: []string{"host1"},
+				},
+				Port: 7777,
+			},
+			scrapeFn: mockScrapeFnSuccess(t, testMetricFam...),
+			expResp: &MetricsListResp{
+				AvailableMetricSets: []*MetricSet{
+					{
+						Name:        "counter",
+						Description: "this is the counter help",
+						Type:        MetricTypeCounter,
+					},
+					{
+						Name:        "gauge",
+						Description: "this is the gauge help",
+						Type:        MetricTypeGauge,
+					},
+				},
+			},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			oldScrapeFn := httpScrapeFn
+			httpScrapeFn = tc.scrapeFn
+			if httpScrapeFn == nil {
+				httpScrapeFn = func(context.Context, *url.URL, httpGetFn) ([]byte, error) {
+					return nil, nil
+				}
+			}
+
+			resp, err := MetricsList(context.TODO(), tc.req)
+
+			httpScrapeFn = oldScrapeFn
+			common.CmpErr(t, tc.expErr, err)
+			if diff := cmp.Diff(tc.expResp, resp); diff != "" {
+				t.Fatalf("unexpected response (-want, +got):\n%s\n", diff)
+			}
+		})
+	}
+}
+
+func TestControl_getMetricFromPrometheus(t *testing.T) {
+	testLabels := LabelMap{
+		"foo": "bar",
+		"baz": "snafu",
+	}
+	testLabelPairs := make([]*pclient.LabelPair, 0)
+	for key, val := range testLabels {
+		testLabelPairs = append(testLabelPairs, &pclient.LabelPair{
+			Name:  proto.String(key),
+			Value: proto.String(val),
+		})
+	}
+
+	testCounter := newTestPBCounter(6.5)
+	testCounter.Label = testLabelPairs
+
+	testGauge := newTestPBGauge(126.56)
+	testGauge.Label = testLabelPairs
+
+	testUntyped := newTestPBUntyped(42)
+	testUntyped.Label = testLabelPairs
+
+	testSummary := newTestPBSummary(4)
+	*testSummary.Summary.SampleSum = 123456.5
+	*testSummary.Summary.SampleCount = 508
+	for i, q := range testSummary.Summary.Quantile {
+		*q.Quantile = float64(i)
+		*q.Value = float64(i + 1)
+	}
+	testSummary.Label = testLabelPairs
+
+	testHistogram := newTestPBHistogram(3)
+	*testHistogram.Histogram.SampleSum = 9876.5
+	*testHistogram.Histogram.SampleCount = 128
+	for i, b := range testHistogram.Histogram.Bucket {
+		*b.UpperBound = 100.0 * float64(i+1)
+		*b.CumulativeCount = uint64(i + 1)
+	}
+	testHistogram.Label = testLabelPairs
+
+	for name, tc := range map[string]struct {
+		input     *pclient.Metric
+		inputType pclient.MetricType
+		expResult Metric
+	}{
+		"counter": {
+			input:     testCounter,
+			inputType: pclient.MetricType_COUNTER,
+			expResult: newSimpleMetric(testLabels, testCounter.Counter.GetValue()),
+		},
+		"gauge": {
+			input:     testGauge,
+			inputType: pclient.MetricType_GAUGE,
+			expResult: newSimpleMetric(testLabels, testGauge.Gauge.GetValue()),
+		},
+		"untyped": {
+			input:     testUntyped,
+			inputType: pclient.MetricType_UNTYPED,
+			expResult: newSimpleMetric(testLabels, testUntyped.Untyped.GetValue()),
+		},
+		"summary": {
+			input:     testSummary,
+			inputType: pclient.MetricType_SUMMARY,
+			expResult: &SummaryMetric{
+				Labels:      testLabels,
+				SampleSum:   testSummary.Summary.GetSampleSum(),
+				SampleCount: testSummary.Summary.GetSampleCount(),
+				Quantiles: QuantileMap{
+					0: 1,
+					1: 2,
+					2: 3,
+					3: 4,
+				},
+			},
+		},
+		"histogram": {
+			input:     testHistogram,
+			inputType: pclient.MetricType_HISTOGRAM,
+			expResult: &HistogramMetric{
+				Labels:      testLabels,
+				SampleSum:   testHistogram.Histogram.GetSampleSum(),
+				SampleCount: testHistogram.Histogram.GetSampleCount(),
+				Buckets: []*MetricBucket{
+					{
+						UpperBound:      100,
+						CumulativeCount: 1,
+					},
+					{
+						UpperBound:      200,
+						CumulativeCount: 2,
+					},
+					{
+						UpperBound:      300,
+						CumulativeCount: 3,
+					},
+				},
+			},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			result := getMetricFromPrometheus(tc.input, tc.inputType)
+			if diff := cmp.Diff(tc.expResult, result); diff != "" {
+				t.Fatalf("unexpected result (-want, +got):\n%s\n", diff)
+			}
+		})
+	}
+}
+
+func TestControl_MetricsQuery(t *testing.T) {
+	testMetricFam := []*pclient.MetricFamily{
+		newTestMetricFamily("my_counter", "this is the counter help", pclient.MetricType_COUNTER),
+		newTestMetricFamily("my_gauge", "this is the gauge help", pclient.MetricType_GAUGE),
+		newTestMetricFamily("my_summary", "this is the summary help", pclient.MetricType_SUMMARY),
+		newTestMetricFamily("my_histogram", "this is the histogram help", pclient.MetricType_HISTOGRAM),
+		newTestMetricFamily("my_generic", "this is the generic help", pclient.MetricType_UNTYPED),
+	}
+
+	for _, mf := range testMetricFam {
+		addTestMetric(mf)
+	}
+
+	for name, tc := range map[string]struct {
+		scrapeFn func(context.Context, *url.URL, httpGetFn) ([]byte, error)
+		req      *MetricsQueryReq
+		expResp  *MetricsQueryResp
+		expErr   error
+	}{
+		"nil request": {
+			expErr: errors.New("nil"),
+		},
+		"no hosts in req": {
+			req:    &MetricsQueryReq{Port: 2525},
+			expErr: errors.New("exactly one host"),
+		},
+		"too many hosts in req": {
+			req: &MetricsQueryReq{
+				request: request{
+					HostList: []string{"host1", "host2"},
+				},
+				Port: 4111,
+			},
+			expErr: errors.New("exactly one host"),
+		},
+		"no port": {
+			req: &MetricsQueryReq{
+				request: request{
+					HostList: []string{"host1"},
+				},
+			},
+			expErr: errors.New("port must be specified"),
+		},
+		"scrape failed": {
+			req: &MetricsQueryReq{
+				request: request{
+					HostList: []string{"host1"},
+				},
+				Port: 1066,
+			},
+			scrapeFn: func(context.Context, *url.URL, httpGetFn) ([]byte, error) {
+				return nil, errors.New("mock scrape")
+			},
+			expErr: errors.New("mock scrape"),
+		},
+		"no metrics": {
+			req: &MetricsQueryReq{
+				request: request{
+					HostList: []string{"host1"},
+				},
+				Port: 8888,
+			},
+			scrapeFn: func(context.Context, *url.URL, httpGetFn) ([]byte, error) {
+				return []byte{}, nil
+			},
+			expResp: &MetricsQueryResp{
+				MetricSets: []*MetricSet{},
+			},
+		},
+		"all metrics": {
+			req: &MetricsQueryReq{
+				request: request{
+					HostList: []string{"host1"},
+				},
+				Port: 7777,
+			},
+			scrapeFn: mockScrapeFnSuccess(t, testMetricFam...),
+			expResp: &MetricsQueryResp{
+				MetricSets: []*MetricSet{
+					{
+						Name:        "my_counter",
+						Description: "this is the counter help",
+						Type:        MetricTypeCounter,
+						Metrics: []Metric{
+							newSimpleMetric(map[string]string{}, 0),
+						},
+					},
+					{
+						Name:        "my_gauge",
+						Description: "this is the gauge help",
+						Type:        MetricTypeGauge,
+						Metrics: []Metric{
+							newSimpleMetric(map[string]string{}, 0),
+						},
+					},
+					{
+						Name:        "my_generic",
+						Description: "this is the generic help",
+						Type:        MetricTypeGeneric,
+						Metrics: []Metric{
+							newSimpleMetric(map[string]string{}, 0),
+						},
+					},
+					{
+						Name:        "my_histogram",
+						Description: "this is the histogram help",
+						Type:        MetricTypeHistogram,
+						Metrics: []Metric{
+							&HistogramMetric{
+								Labels: LabelMap{},
+								Buckets: []*MetricBucket{
+									// Prometheus library parsing
+									// includes inf bucket at minimum
+									{UpperBound: math.Inf(0)},
+								},
+							},
+						},
+					},
+					{
+						Name:        "my_summary",
+						Description: "this is the summary help",
+						Type:        MetricTypeSummary,
+						Metrics: []Metric{
+							&SummaryMetric{
+								Labels:    LabelMap{},
+								Quantiles: QuantileMap{0: 0},
+							},
+						},
+					},
+				},
+			},
+		},
+		"selected metrics": {
+			req: &MetricsQueryReq{
+				request: request{
+					HostList: []string{"host1"},
+				},
+				Port:        7777,
+				MetricNames: []string{"my_generic", "my_counter"},
+			},
+			scrapeFn: mockScrapeFnSuccess(t, testMetricFam...),
+			expResp: &MetricsQueryResp{
+				MetricSets: []*MetricSet{
+					{
+						Name:        "my_generic",
+						Description: "this is the generic help",
+						Type:        MetricTypeGeneric,
+						Metrics: []Metric{
+							newSimpleMetric(map[string]string{}, 0),
+						},
+					},
+					{
+						Name:        "my_counter",
+						Description: "this is the counter help",
+						Type:        MetricTypeCounter,
+						Metrics: []Metric{
+							newSimpleMetric(map[string]string{}, 0),
+						},
+					},
+				},
+			},
+		},
+		"invalid metric name": {
+			req: &MetricsQueryReq{
+				request: request{
+					HostList: []string{"host1"},
+				},
+				Port:        7777,
+				MetricNames: []string{"my_generic", "fake"},
+			},
+			scrapeFn: mockScrapeFnSuccess(t, testMetricFam...),
+			expErr:   errors.New("metric \"fake\" not found"),
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			oldScrapeFn := httpScrapeFn
+			httpScrapeFn = tc.scrapeFn
+			if httpScrapeFn == nil {
+				httpScrapeFn = func(context.Context, *url.URL, httpGetFn) ([]byte, error) {
+					return nil, nil
+				}
+			}
+
+			resp, err := MetricsQuery(context.TODO(), tc.req)
+
+			httpScrapeFn = oldScrapeFn
+			common.CmpErr(t, tc.expErr, err)
+			if diff := cmp.Diff(tc.expResp, resp); diff != "" {
+				t.Fatalf("unexpected response (-want, +got):\n%s\n", diff)
+			}
+		})
+	}
+}

--- a/src/control/lib/telemetry/promexp/collector.go
+++ b/src/control/lib/telemetry/promexp/collector.go
@@ -94,28 +94,38 @@ func NewCollector(log logging.Logger, opts *CollectorOpts, sources ...*EngineSou
 	return c, nil
 }
 
-func fixPath(in string) (labels labelMap, name string) {
-	name = strings.Map(func(r rune) rune {
-		if !unicode.IsPrint(r) || unicode.IsSpace(r) {
-			return '_'
-		}
-		switch r {
-		case '/', ':':
+func sanitizeMetricName(in string) string {
+	return strings.Map(func(r rune) rune {
+		switch {
+		// Valid names for Prometheus are limited to:
+		case r >= 'a' && r <= 'z': // lowercase letters
+		case r >= 'A' && r <= 'Z': // uppercase letters
+		case unicode.IsDigit(r): // digits
+		case r == ':':
+		default: // sanitize any other character
 			return '_'
 		}
 
 		return r
 	}, strings.TrimLeft(in, "/"))
+}
+
+func fixPath(in string) (labels labelMap, name string) {
+	name = sanitizeMetricName(in)
 
 	labels = make(labelMap)
-	ID_re := regexp.MustCompile(`ID_(\d+)_`)
-	io_re := regexp.MustCompile(`io_(\d+)_`)
+	ID_re := regexp.MustCompile(`ID\:?_+(\d+)_?`)
+	io_re := regexp.MustCompile(`io_+(\d+)_?`)
 
 	name = ID_re.ReplaceAllString(name, "")
 	io_matches := io_re.FindStringSubmatch(name)
 	if len(io_matches) > 0 {
 		labels["target"] = io_matches[1]
-		name = io_re.ReplaceAllString(name, "io_")
+		replacement := "io"
+		if strings.HasSuffix(io_matches[0], "_") {
+			replacement += "_"
+		}
+		name = io_re.ReplaceAllString(name, replacement)
 	}
 
 	return
@@ -258,7 +268,9 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) {
 		labels, path := fixPath(rm.m.Path())
 		labels["rank"] = fmt.Sprintf("%d", rm.r)
 
-		baseName := prometheus.BuildFQName("engine", path, rm.m.Name())
+		name := sanitizeMetricName(rm.m.Name())
+
+		baseName := prometheus.BuildFQName("engine", path, name)
 		shortDesc := rm.m.ShortDesc()
 
 		switch rm.m.Type() {


### PR DESCRIPTION
- Add dmg commands to list and query metrics. Currently
  limited to a single host.
- Fix metric name sanitization in prometheus exporter.

Signed-off-by: Kris Jacque <kristin.jacque@intel.com>