### PR TITLE
DAOS-7046 Java: Update Hadoop from 3.2.2 to 3.3.0

### DIFF
--- a/src/client/java/hadoop-daos/pom.xml
+++ b/src/client/java/hadoop-daos/pom.xml
@@ -15,7 +15,7 @@
   <packaging>jar</packaging>
 
   <properties>
-    <hadoop.version>3.2.2</hadoop.version>
+    <hadoop.version>3.3.0</hadoop.version>
     <native.build.path>${project.basedir}/build</native.build.path>
     <daos.install.path>${project.basedir}/install</daos.install.path>
   </properties>


### PR DESCRIPTION
This is the last update we can possible do for the hadoop package. It should
address a significant number of the outstanding security issues found with the
hadoop 3.2.2 dependency.

Signed-off-by: David Quigley <david.quigley@intel.com>