### PR TITLE
DAOS-7054 Telemetry: Coverity scan fixes

### DIFF
--- a/src/engine/init.c
+++ b/src/engine/init.c
@@ -471,8 +471,9 @@ dss_crt_event_cb(d_rank_t rank, enum crt_event_source src,
 		return;
 	}
 
-	d_tm_increment_counter(&dead_rank_cnt, "events/dead_rank_cnt", NULL);
-	d_tm_record_timestamp(&last_ts, "events/last_event_ts", NULL);
+	(void)d_tm_increment_counter(&dead_rank_cnt, "events/dead_rank_cnt",
+				     NULL);
+	(void)d_tm_record_timestamp(&last_ts, "events/last_event_ts", NULL);
 
 	rc = ds_notify_swim_rank_dead(rank);
 	if (rc)
@@ -500,7 +501,7 @@ server_init(int argc, char *argv[])
 		goto exit_debug_init;
 
 	/** Report timestamp when engine was started */
-	d_tm_record_timestamp(NULL, "started_at", NULL);
+	(void)d_tm_record_timestamp(NULL, "started_at", NULL);
 
 	rc = drpc_init();
 	if (rc != 0) {
@@ -646,10 +647,10 @@ server_init(int argc, char *argv[])
 	D_INFO("Service fully up\n");
 
 	/** Report timestamp when engine was open for business */
-	d_tm_record_timestamp(NULL, "servicing_at", NULL);
+	(void)d_tm_record_timestamp(NULL, "servicing_at", NULL);
 
 	/** Report rank */
-	d_tm_set_gauge(NULL, dss_self_rank(), "rank", NULL);
+	(void)d_tm_set_gauge(NULL, dss_self_rank(), "rank", NULL);
 
 	D_PRINT("DAOS I/O Engine (v%s) process %u started on rank %u "
 		"with %u target, %d helper XS, firstcore %d, host %s.\n",

--- a/src/object/srv_mod.c
+++ b/src/object/srv_mod.c
@@ -79,7 +79,6 @@ obj_tls_init(int xs_id, int tgt_id)
 	struct obj_tls	*tls;
 	uint32_t	opc;
 	char		*path;
-	int		rc;
 
 	D_ALLOC_PTR(tls);
 	if (tls == NULL)
@@ -96,53 +95,39 @@ obj_tls_init(int xs_id, int tgt_id)
 		/** Start with latency, of type gauge */
 		D_ASPRINTF(path, "io/%u/ops/%s/latency_us", tgt_id,
 			   obj_opc_to_str(opc));
-		rc = d_tm_add_metric(&tls->ot_op_lat[opc], path, D_TM_GAUGE,
-				     "object RPC processing time", "");
-		if (rc)
-			D_WARN("Failed to create latency sensor: "DF_RC"\n",
-			       DP_RC(rc));
+		(void)d_tm_add_metric(&tls->ot_op_lat[opc], path, D_TM_GAUGE,
+				      "object RPC processing time", "");
 		D_FREE(path);
 
 		/** Continue with number of active requests, of type gauge */
 		D_ASPRINTF(path, "io/%u/ops/%s/active_cnt", tgt_id,
 			   obj_opc_to_str(opc));
-		rc = d_tm_add_metric(&tls->ot_op_active[opc], path, D_TM_GAUGE,
-				     "number of active object RPCs", "");
-		if (rc)
-			D_WARN("Failed to create active cnt sensor: "DF_RC"\n",
-			       DP_RC(rc));
+		(void)d_tm_add_metric(&tls->ot_op_active[opc], path, D_TM_GAUGE,
+				      "number of active object RPCs", "");
 		D_FREE(path);
 
 		/** And finally the total number of requests, of type counter */
 		D_ASPRINTF(path, "io/%u/ops/%s/total_cnt", tgt_id,
 			   obj_opc_to_str(opc));
-		rc = d_tm_add_metric(&tls->ot_op_total[opc], path, D_TM_COUNTER,
-				     "total number of processed object RPCs",
-				     "");
-		if (rc)
-			D_WARN("Failed to create total cnt sensor: "DF_RC"\n",
-			       DP_RC(rc));
+		(void)d_tm_add_metric(&tls->ot_op_total[opc], path,
+				      D_TM_COUNTER,
+				      "total number of processed object RPCs",
+				      "");
 		D_FREE(path);
 	}
 
 	/** Total number of silently restarted updates, of type counter */
 	D_ASPRINTF(path, "io/%u/ops/%s/restarted_cnt", tgt_id,
 		   obj_opc_to_str(DAOS_OBJ_RPC_UPDATE));
-	rc = d_tm_add_metric(&tls->ot_update_restart, path, D_TM_COUNTER,
-			     "total number of restarted update ops", "");
-	if (rc)
-		D_WARN("Failed to create restarted cnt sensor: "DF_RC"\n",
-		       DP_RC(rc));
+	(void)d_tm_add_metric(&tls->ot_update_restart, path, D_TM_COUNTER,
+			      "total number of restarted update ops", "");
 	D_FREE(path);
 
 	/** Total number of resent updates, of type counter */
 	D_ASPRINTF(path, "io/%u/ops/%s/resent_cnt", tgt_id,
 		   obj_opc_to_str(DAOS_OBJ_RPC_UPDATE));
-	rc = d_tm_add_metric(&tls->ot_update_resent, path, D_TM_COUNTER,
-			     "total number of resent update RPCs", "");
-	if (rc)
-		D_WARN("Failed to create resent cnt sensor: "DF_RC"\n",
-		       DP_RC(rc));
+	(void)d_tm_add_metric(&tls->ot_update_resent, path, D_TM_COUNTER,
+			      "total number of resent update RPCs", "");
 	D_FREE(path);
 
 	return tls;

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -1730,12 +1730,12 @@ obj_ioc_end(struct obj_io_context *ioc, int err)
 		/** Update sensors */
 		if (err == 0)
 			/** measure latency of successful I/O only */
-			d_tm_set_gauge(&tls->ot_op_lat[opc],
-				       (daos_get_ntime() -
-					ioc->ioc_start_time) / 1000,
-				       NULL);
-		d_tm_decrement_gauge(&tls->ot_op_active[opc], 1, NULL);
-		d_tm_increment_counter(&tls->ot_op_total[opc], NULL);
+			(void)d_tm_set_gauge(&tls->ot_op_lat[opc],
+					     (daos_get_ntime() -
+					     ioc->ioc_start_time) / 1000,
+					     NULL);
+		(void)d_tm_decrement_gauge(&tls->ot_op_active[opc], 1, NULL);
+		(void)d_tm_increment_counter(&tls->ot_op_total[opc], NULL);
 	}
 	obj_ioc_fini(ioc);
 }
@@ -1756,7 +1756,7 @@ obj_ioc_begin(uint32_t rpc_map_ver, uuid_t pool_uuid,
 
 	/** increment active request counter and start the chrono */
 	tls = obj_tls_get();
-	d_tm_increment_gauge(&tls->ot_op_active[opc], 1, NULL);
+	(void)d_tm_increment_gauge(&tls->ot_op_active[opc], 1, NULL);
 	ioc->ioc_start_time = daos_get_ntime();
 
 	rc = obj_capa_check(ioc->ioc_coh, obj_is_modification_opc(opc));
@@ -2263,7 +2263,7 @@ again:
 		daos_epoch_t	e = 0;
 		struct obj_tls  *tls = obj_tls_get();
 
-		d_tm_increment_counter(&tls->ot_update_resent, NULL);
+		(void)d_tm_increment_counter(&tls->ot_update_resent, NULL);
 
 		rc = dtx_handle_resend(ioc.ioc_vos_coh, &orw->orw_dti,
 				       &e, &version);
@@ -2370,7 +2370,8 @@ again:
 			orw->orw_epoch = crt_hlc_get();
 			orw->orw_flags &= ~ORF_RESEND;
 			flags = 0;
-			d_tm_increment_counter(&tls->ot_update_restart, NULL);
+			(void)d_tm_increment_counter(&tls->ot_update_restart,
+						     NULL);
 			goto again;
 		}
 


### PR DESCRIPTION
    Cast d_tm_* producer functions to (void) to address Coverity
    scan failures, because there is no interest in processing these
    return codes at this time.

    A separate story exists (DAOS-7032) to change the return type
    of these functions to void.

    This quick change was requested as an intermediate step towards
    that change.

Signed-off-by: Joel Rosenzweig <joel.b.rosenzweig@intel.com>