### PR TITLE
DAOS-7056 pool: convert sp_fetch_hdls_cond to sp_map_cond

### DIFF
--- a/src/container/srv_target.c
+++ b/src/container/srv_target.c
@@ -172,6 +172,17 @@ cont_aggregate_runnable(struct ds_cont_child *cont)
 	struct ds_pool		*pool = cont->sc_pool->spc_pool;
 	struct sched_request	*req = cont->sc_agg_req;
 
+	if (unlikely(pool->sp_map == NULL)) {
+		/* If it does not get the pool map from the pool leader,
+		 * see pool_iv_pre_sync(), the IV fetch from the following
+		 * ds_cont_csummer_init() will fail anyway.
+		 */
+		D_DEBUG(DB_EPC, DF_CONT": skip aggregation "
+			"No pool map yet\n",
+			DP_CONT(cont->sc_pool->spc_uuid, cont->sc_uuid));
+		return false;
+	}
+
 	if (!cont->sc_props_fetched)
 		ds_cont_csummer_init(cont);
 
@@ -2267,6 +2278,9 @@ ds_cont_tgt_ec_eph_query_ult(void *data)
 	while (!dss_ult_exiting(pool->sp_ec_ephs_req)) {
 		struct dss_coll_ops	coll_ops = { 0 };
 		struct dss_coll_args	coll_args = { 0 };
+
+		if (pool->sp_map == NULL)
+			goto yield;
 
 		/* collective operations */
 		coll_ops.co_func = cont_ec_eph_query_one;


### PR DESCRIPTION
1. Convert sp_fetch_hdls_cond to sp_map_cond. so
all ULTs, which waits for the local pool map can
wait on the condition. Then if the target is excluded
from the pool map, i.e. pool leader will not send
the pool map to these nodes, then these ULT will not
proceed.

2. If the pool map is NULL, then let's do not start
aggregation, since fetch prop by IV will fail anyway.

Signed-off-by: Di Wang <di.wang@intel.com>