### PR TITLE
DAOS-623 ci: Revert use of stage_vm9 clusters

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1310,7 +1310,7 @@ pipeline {
                         expression { ! skip_ftest('el7') }
                     }
                     agent {
-                        label 'stage_vm9'
+                        label 'ci_vm9'
                     }
                     steps {
                         functionalTest inst_repos: daos_repos(),
@@ -1329,7 +1329,7 @@ pipeline {
                         expression { ! skip_ftest('leap15') }
                     }
                     agent {
-                        label 'stage_vm9'
+                        label 'ci_vm9'
                     }
                     steps {
                         functionalTest inst_repos: daos_repos(),


### PR DESCRIPTION
It was inadvertently included in a commit that was landed.