### PR TITLE
DAOS-6319 rsvc: Optimize bootstrapping latencies (#4873)

### DIFF
--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -590,6 +590,7 @@ ds_pool_svc_create(const uuid_t pool_uuid, int ntargets, uuid_t target_uuids[],
 	crt_rpc_t	       *rpc;
 	struct pool_create_in  *in;
 	struct pool_create_out *out;
+	struct d_backoff_seq	backoff_seq;
 	int			rc;
 
 	D_ASSERTF(ntargets == target_addrs->rl_nr, "ntargets=%u num=%u\n",
@@ -612,6 +613,10 @@ ds_pool_svc_create(const uuid_t pool_uuid, int ntargets, uuid_t target_uuids[],
 	if (rc != 0)
 		D_GOTO(out_creation, rc);
 
+	rc = d_backoff_seq_init(&backoff_seq, 0 /* nzeros */, 16 /* factor */,
+				8 /* next (ms) */, 1 << 10 /* max (ms) */);
+	D_ASSERTF(rc == 0, "d_backoff_seq_init: "DF_RC"\n", DP_RC(rc));
+
 rechoose:
 	/* Create a POOL_CREATE request. */
 	ep.ep_grp = NULL;
@@ -619,13 +624,13 @@ rechoose:
 	if (rc != 0) {
 		D_ERROR(DF_UUID": cannot find pool service: "DF_RC"\n",
 			DP_UUID(pool_uuid), DP_RC(rc));
-		goto out_client;
+		goto out_backoff_seq;
 	}
 	rc = pool_req_create(info->dmi_ctx, &ep, POOL_CREATE, &rpc);
 	if (rc != 0) {
 		D_ERROR(DF_UUID": failed to create POOL_CREATE RPC: "DF_RC"\n",
 			DP_UUID(pool_uuid), DP_RC(rc));
-		D_GOTO(out_client, rc);
+		goto out_backoff_seq;
 	}
 	in = crt_req_get(rpc);
 	uuid_copy(in->pri_op.pi_uuid, pool_uuid);
@@ -648,7 +653,7 @@ rechoose:
 				      rc == 0 ? &out->pro_op.po_hint : NULL);
 	if (rc == RSVC_CLIENT_RECHOOSE) {
 		crt_req_decref(rpc);
-		dss_sleep(1000 /* ms */);
+		dss_sleep(d_backoff_seq_next(&backoff_seq));
 		D_GOTO(rechoose, rc);
 	}
 	rc = out->pro_op.po_rc;
@@ -662,7 +667,8 @@ rechoose:
 	D_ASSERTF(rc == 0, "daos_rank_list_copy: "DF_RC"\n", DP_RC(rc));
 out_rpc:
 	crt_req_decref(rpc);
-out_client:
+out_backoff_seq:
+	d_backoff_seq_fini(&backoff_seq);
 	rsvc_client_fini(&client);
 out_creation:
 	if (rc != 0)

--- a/src/rsvc/srv.c
+++ b/src/rsvc/srv.c
@@ -643,15 +643,32 @@ ds_rsvc_request_map_dist(struct ds_rsvc *svc)
 }
 
 static bool
+nominated(d_rank_list_t *replicas, uuid_t db_uuid)
+{
+	int i;
+
+	/* No initial membership. */
+	if (replicas == NULL || replicas->rl_nr < 1)
+		return false;
+
+	/* Only one replica. */
+	if (replicas->rl_nr == 1)
+		return true;
+
+	/*
+	 * Nominate by hashing the DB UUID. The only requirement is that every
+	 * replica shall end up with the same nomination.
+	 */
+	i = d_hash_murmur64(db_uuid, sizeof(uuid_t), 0x2db) % replicas->rl_nr;
+
+	return (replicas->rl_ranks[i] == dss_self_rank());
+}
+
+static bool
 self_only(d_rank_list_t *replicas)
 {
-	d_rank_t	self;
-	int		rc;
-
-	rc = crt_group_rank(NULL /* grp */, &self);
-	D_ASSERTF(rc == 0, ""DF_RC"\n", DP_RC(rc));
-	return replicas != NULL && replicas->rl_nr == 1 &&
-	       replicas->rl_ranks[0] == self;
+	return (replicas != NULL && replicas->rl_nr == 1 &&
+		replicas->rl_ranks[0] == dss_self_rank());
 }
 
 static int
@@ -676,6 +693,20 @@ start(enum ds_rsvc_class_id class, d_iov_t *id, uuid_t db_uuid, bool create,
 		       &svc->s_db);
 	if (rc != 0)
 		goto err_creation;
+
+	/*
+	 * If creating a replica with an initial membership, we are
+	 * bootstrapping the DB (via sc_bootstrap or an external mechanism). If
+	 * we are the "nominated" replica, start a campaign without waiting for
+	 * the election timeout.
+	 */
+	if (create && nominated(replicas, db_uuid)) {
+		/* Give others a chance to get ready for voting. */
+		dss_sleep(1 /* ms */);
+		rc = rdb_campaign(svc->s_db);
+		if (rc != 0)
+			goto err_db;
+	}
 
 	if (create && self_only(replicas) &&
 	    rsvc_class(class)->sc_bootstrap != NULL) {


### PR DESCRIPTION
To optimize pool create latencies, when creating and bootstrapping an
rsvc with an initial membership, this patch lets one replica to start
campaigning without waiting for the election timeout. Also, the patch
replaces the 1 s constant backoff in ds_pool_svc_create with an
exponential one starting from a few milliseconds. The greatest factor of
the latency of a pool create operation will more likely be the creation
of the PMDK pools, as a result.

Master-PR: https://github.com/daos-stack/daos/pull/4873

Signed-off-by: Li Wei <wei.g.li@intel.com>