### PR TITLE
DAOS-6755 obj: fix bugs in EC aggregation

### DIFF
--- a/src/container/srv_target.c
+++ b/src/container/srv_target.c
@@ -289,7 +289,7 @@ cont_child_aggregate(struct ds_cont_child *cont, uint64_t *msecs)
 		 */
 		epoch_min = 0;
 		full_scan = true;
-		D_DEBUG(DB_EPC, "change hlc "DF_U64" > full "DF_U64"\n",
+		D_DEBUG(DB_EPC, "change hlc "DF_X64" > full "DF_X64"\n",
 			change_hlc, cont->sc_aggregation_full_scan_hlc);
 	} else {
 		epoch_min = cinfo.ci_hae;
@@ -321,7 +321,7 @@ cont_child_aggregate(struct ds_cont_child *cont, uint64_t *msecs)
 	if (epoch_max >= cont->sc_aggregation_max)
 		epoch_max = cont->sc_aggregation_max - 1;
 
-	D_ASSERTF(epoch_min <= epoch_max, "Min "DF_U64", Max "DF_U64"\n",
+	D_ASSERTF(epoch_min <= epoch_max, "Min "DF_X64", Max "DF_X64"\n",
 		  epoch_min, epoch_max);
 
 	if (cont->sc_pool->spc_rebuild_fence != 0) {
@@ -329,7 +329,7 @@ cont_child_aggregate(struct ds_cont_child *cont, uint64_t *msecs)
 		int	j;
 		int	insert_idx;
 
-		D_DEBUG(DB_EPC, "rebuild fence "DF_U64"\n", rebuild_fence);
+		D_DEBUG(DB_EPC, "rebuild fence "DF_X64"\n", rebuild_fence);
 		/* Insert the rebuild_epoch into snapshots */
 		D_ALLOC(snapshots, (cont->sc_snapshots_nr + 1) *
 			sizeof(daos_epoch_t));
@@ -2365,7 +2365,7 @@ ds_cont_tgt_ec_eph_query_ult(void *data)
 			    ec_eph->ce_eph < ec_eph->ce_last_eph)
 				ec_eph->ce_eph = 0;
 
-			D_DEBUG(DB_MD, "eph "DF_U64" "DF_UUID"\n",
+			D_DEBUG(DB_MD, "eph "DF_X64" "DF_UUID"\n",
 				ec_eph->ce_eph, DP_UUID(ec_eph->ce_cont_uuid));
 			rc = cont_iv_ec_agg_eph_update(pool->sp_iv_ns,
 						       ec_eph->ce_cont_uuid,

--- a/src/include/daos_srv/evtree.h
+++ b/src/include/daos_srv/evtree.h
@@ -125,7 +125,7 @@ struct evt_filter {
 
 /** Log format of extent */
 #define DF_EXT				\
-	DF_U64"-"DF_U64
+	DF_X64"-"DF_X64
 
 /** Log format of rectangle */
 #define DF_RECT				\

--- a/src/object/cli_shard.c
+++ b/src/object/cli_shard.c
@@ -810,7 +810,7 @@ dc_rw_cb(tse_task_t *task, void *arg)
 			daos_iod_t	*orig_iod = NULL;
 
 			D_DEBUG(DB_IO, DF_UOID" size "DF_U64
-				" eph "DF_U64"\n", DP_UOID(orw->orw_oid),
+				" eph "DF_X64"\n", DP_UOID(orw->orw_oid),
 				sizes[i], orw->orw_epoch);
 
 			if (!is_ec_obj) {

--- a/src/object/srv_ec_aggregate.c
+++ b/src/object/srv_ec_aggregate.c
@@ -111,7 +111,7 @@ struct ec_agg_entry {
 	struct ec_agg_stripe	 ae_cur_stripe;  /* Struct for current stripe */
 	struct ec_agg_par_extent ae_par_extent;	 /* Parity extent             */
 	daos_handle_t		 ae_obj_hdl;	 /* Object handle for cur obj */
-	struct daos_shard_loc	 ae_peer_pshards[OBJ_EC_MAX_P - 1];
+	struct daos_shard_loc	 ae_peer_pshards[OBJ_EC_MAX_P];
 };
 
 /* Parameters used to drive iterate all.
@@ -186,27 +186,82 @@ ec_age2ss(struct ec_agg_entry *age)
 	return obj_ec_stripe_rec_nr(age->ae_oca);
 }
 
+static inline uint32_t
+ec_age2shard(struct ec_agg_entry *entry)
+{
+	return entry->ae_oid.id_shard;
+}
+
+/* return parity index [0, p - 1] */
+static inline uint32_t
+ec_age2pidx(struct ec_agg_entry *entry)
+{
+	uint32_t	k, p, shard;
+
+	k = ec_age2k(entry);
+	p = ec_age2p(entry);
+	shard = ec_age2shard(entry) % (k + p);
+	D_ASSERT(shard >= k && shard < (k + p));
+
+	return (shard - k) % p;
+}
+
+#define EC_AGE_EPOCH_NO_PARITY		((daos_epoch_t)(~(0ULL)))
+
+/* set the aggregate entry as no parity, before vos_iterate the parity space */
+static inline void
+ec_age_set_no_parity(struct ec_agg_entry *age)
+{
+	age->ae_par_extent.ape_epoch = EC_AGE_EPOCH_NO_PARITY;
+}
+
+/* check if parity ext exist, after vos_iterate the parity space */
+static inline bool
+ec_age_with_parity(struct ec_agg_entry *age)
+{
+	return (age->ae_par_extent.ape_epoch != EC_AGE_EPOCH_NO_PARITY);
+}
+
+/* check if existed parity's epoch is higher than all replica exts' epoch */
+static inline bool
+ec_age_parity_higher(struct ec_agg_entry *age)
+{
+	return (age->ae_par_extent.ape_epoch >= age->ae_cur_stripe.as_hi_epoch);
+}
+
+/* check if hole extent exist, after vos_iterate the replica space */
+static inline bool
+ec_age_with_hole(struct ec_agg_entry *age)
+{
+	return age->ae_cur_stripe.as_has_holes;
+}
+
 /* Determines if the extent carries over into the next stripe.
  */
-static unsigned int
+static uint64_t
 agg_carry_over(struct ec_agg_entry *entry, struct ec_agg_extent *agg_extent)
 {
 	unsigned int	stripe_size = ec_age2ss(entry);
 	daos_off_t	start_stripe = agg_extent->ae_recx.rx_idx / stripe_size;
 	daos_off_t	end_stripe = (agg_extent->ae_recx.rx_idx +
 				agg_extent->ae_recx.rx_nr - 1) / stripe_size;
+	uint64_t	tail_size = 0;
 
 	if (end_stripe > start_stripe) {
 		D_ASSERT(end_stripe - start_stripe == 1);
-		return agg_extent->ae_recx.rx_idx + agg_extent->ae_recx.rx_nr -
-			end_stripe * stripe_size;
+		tail_size = DAOS_RECX_END(agg_extent->ae_recx) -
+			    end_stripe * stripe_size;
 		/* What if an extent carries over, and the tail is the only
 		 * extent in the next stripe? (Answer: we retain it, but this
 		 * is okay, since in this case the carryover is a valid
 		 * replica for the next stripe)
 		 */
 	}
-	return 0;
+
+	D_DEBUG(DB_TRACE, DF_UOID", recx "DF_RECX" tail_size "DF_U64"\n",
+		DP_UOID(entry->ae_oid), DP_RECX(agg_extent->ae_recx),
+		tail_size);
+	return tail_size;
 }
 
 /* Clears the extent list of all extents completed for the processed stripe.
@@ -217,7 +272,7 @@ static void
 agg_clear_extents(struct ec_agg_entry *entry)
 {
 	struct ec_agg_extent	*extent, *ext_tmp;
-	unsigned long		 tail, ptail = 0U;
+	uint64_t		 tail, ptail = 0U;
 	bool			 carry_is_hole = false;
 
 	if (entry->ae_cur_stripe.as_ho_ext_cnt) {
@@ -239,34 +294,31 @@ agg_clear_extents(struct ec_agg_entry *entry)
 
 		/* Check for carry-over extent. */
 		tail = agg_carry_over(entry, extent);
-
 		if (extent->ae_hole && tail)
 			carry_is_hole = true;
 
 		if (tail) {
 			D_ASSERT(ptail == 0U);
 			ptail = tail;
+			D_ASSERT(extent->ae_recx.rx_nr >= tail);
 			extent->ae_recx.rx_idx += extent->ae_recx.rx_nr - tail;
-
 			D_ASSERT(extent->ae_recx.rx_idx == next_stripe_st);
-
 			extent->ae_recx.rx_nr = tail;
 			entry->ae_cur_stripe.as_hi_epoch = extent->ae_epoch;
 		}
 
+		entry->ae_cur_stripe.as_extent_cnt--;
+		d_list_del(&extent->ae_link);
 		if (extent->ae_orig_recx.rx_idx + extent->ae_orig_recx.rx_nr >
 		    next_stripe_st && !tail) {
-			entry->ae_cur_stripe.as_extent_cnt--;
-			d_list_del(&extent->ae_link);
 			d_list_add_tail(&extent->ae_link,
 					&entry->ae_cur_stripe.as_hoextents);
 			entry->ae_cur_stripe.as_ho_ext_cnt++;
 		} else if (!tail) {
-			entry->ae_cur_stripe.as_extent_cnt--;
-			d_list_del(&extent->ae_link);
 			D_FREE_PTR(extent);
 		}
 	}
+
 	entry->ae_cur_stripe.as_offset = 0U;
 	/* Account for carry over. */
 	if (ptail) {
@@ -477,7 +529,7 @@ agg_get_obj_handle(struct ec_agg_entry *entry)
 		int p;
 
 		for (j = p = 0; j < sd->os_replica_nr; j++) {
-			if (j >= k && sd->os_shard_loc[j].sd_rank != myrank) {
+			if (j >= k) {
 				entry->ae_peer_pshards[p].sd_rank
 					= sd->os_shard_loc[j].sd_rank;
 				entry->ae_peer_pshards[p].sd_tgt_idx
@@ -503,9 +555,12 @@ agg_fetch_odata_cells(struct ec_agg_entry *entry, uint8_t *bit_map,
 		      unsigned int cell_cnt, bool is_recalc)
 {
 	daos_iod_t		 iod = { 0 };
+	d_sg_list_t		 sgl = { 0 };
 	daos_epoch_t		 epoch = { 0 };	/* epoch used for data fetch */
 	daos_recx_t		*recxs = NULL;
 	struct ec_agg_stripe	*stripe = &entry->ae_cur_stripe;
+	unsigned char		*buf;
+	uint64_t		 cell_b = ec_age2cs_b(entry);
 	unsigned int		 len = ec_age2cs(entry);
 	unsigned int		 k = ec_age2k(entry);
 	unsigned int		 i, j;
@@ -529,28 +584,34 @@ agg_fetch_odata_cells(struct ec_agg_entry *entry, uint8_t *bit_map,
 	iod.iod_size	= entry->ae_rsize;
 	iod.iod_nr	= cell_cnt;
 	iod.iod_recxs	= recxs;
-	entry->ae_sgl.sg_nr = 1;
-	entry->ae_sgl.sg_iovs[AGG_IOV_ODATA].iov_len = cell_cnt * len *
-								entry->ae_rsize;
-	(entry->ae_sgl.sg_iovs)++;
+
+	D_ALLOC_ARRAY(sgl.sg_iovs, cell_cnt);
+	if (sgl.sg_iovs == NULL) {
+		rc = -DER_NOMEM;
+		goto out;
+	}
+	sgl.sg_nr = cell_cnt;
+	buf = entry->ae_sgl.sg_iovs[AGG_IOV_ODATA].iov_buf;
+	for (i = 0; i < cell_cnt; i++)
+		d_iov_set(&sgl.sg_iovs[i], &buf[i * cell_b], cell_b);
 
 	rc = agg_get_obj_handle(entry);
 	if (rc) {
-		(entry->ae_sgl.sg_iovs)--;
 		D_ERROR("Failed to open object: "DF_RC"\n", DP_RC(rc));
 		goto out;
 	}
 	epoch = is_recalc ? stripe->as_hi_epoch :
 		entry->ae_par_extent.ape_epoch;
 	rc = dsc_obj_fetch(entry->ae_obj_hdl, epoch, &entry->ae_dkey, 1, &iod,
-			   &entry->ae_sgl, NULL, 0, NULL, NULL);
+			   &sgl, NULL, 0, NULL, NULL);
 	if (rc)
 		D_ERROR("dsc_obj_fetch failed: "DF_RC"\n", DP_RC(rc));
 
-	(entry->ae_sgl.sg_iovs)--;
-	entry->ae_sgl.sg_nr = AGG_IOV_CNT;
 out:
-	D_FREE(recxs);
+	if (recxs)
+		D_FREE(recxs);
+	if (sgl.sg_iovs)
+		D_FREE(sgl.sg_iovs);
 	return rc;
 }
 
@@ -583,11 +644,11 @@ agg_fetch_data_stripe(struct ec_agg_entry *entry)
 
 	agg_param = container_of(entry, struct ec_agg_param, ap_agg_entry);
 	rc = vos_obj_fetch(agg_param->ap_cont_handle, entry->ae_oid,
-			   entry->ae_cur_stripe.as_hi_epoch,
-			   VOS_OF_FETCH_RECX_LIST, &entry->ae_dkey, 1, &iod,
-			   &entry->ae_sgl);
+			   entry->ae_cur_stripe.as_hi_epoch, 0, &entry->ae_dkey,
+			   1, &iod, &entry->ae_sgl);
 	if (rc)
-		D_ERROR("vos_obj_fetch failed: "DF_RC"\n", DP_RC(rc));
+		D_ERROR(DF_UOID" vos_obj_fetch "DF_RECX" failed: "DF_RC"\n",
+			DP_UOID(entry->ae_oid), DP_RECX(recx), DP_RC(rc));
 	entry->ae_sgl.sg_nr = AGG_IOV_CNT;
 out:
 	return rc;
@@ -615,7 +676,7 @@ agg_encode_full_stripe_ult(void *arg)
 		data[i] = &buf[i * cell_bytes];
 
 	buf = entry->ae_sgl.sg_iovs[AGG_IOV_PARITY].iov_buf;
-	for (i = p - 1; i >= 0; i--)
+	for (i = 0; i < p; i++)
 		parity_bufs[i] = &buf[i * cell_bytes];
 
 	ec_encode_data(cell_bytes, k, p, entry->ae_codec->ec_gftbls, data,
@@ -681,7 +742,7 @@ out:
  * the parity for the stripe.
  */
 static bool
-agg_data_is_newer(struct ec_agg_entry *entry)
+ec_age_data_is_newer(struct ec_agg_entry *entry)
 {
 	struct ec_agg_extent	*agg_extent;
 
@@ -694,19 +755,18 @@ agg_data_is_newer(struct ec_agg_entry *entry)
 }
 
 /* Determines if the replicas present for the current stripe of object entry
- * constitute a full stripe. If parity exists for the the stripe, the replicas
- * making up the full stripe must be a later epoch that the parity.
+ * constitute a full stripe. If parity exists for the stripe, the replicas
+ * making up the full stripe must be a higher epoch than the parity.
  */
 static bool
-agg_stripe_is_filled(struct ec_agg_entry *entry, bool has_parity)
+ec_age_stripe_full(struct ec_agg_entry *entry, bool has_parity)
 {
 	bool	is_filled;
 
 	D_ASSERT(entry->ae_cur_stripe.as_stripe_fill <= ec_age2ss(entry));
+	is_filled = (entry->ae_cur_stripe.as_stripe_fill == ec_age2ss(entry));
 
-	is_filled = entry->ae_cur_stripe.as_stripe_fill == ec_age2ss(entry);
-
-	return is_filled && (!has_parity || agg_data_is_newer(entry));
+	return is_filled && (!has_parity || ec_age_data_is_newer(entry));
 }
 
 /* True if all original extents are contained within the current stripe.
@@ -715,12 +775,10 @@ static bool
 agg_contained(struct ec_agg_entry *entry)
 {
 	struct ec_agg_extent	*extent;
-	unsigned int		 ss, se;
+	uint64_t		 ss, se;
 
-	ss = ec_age2cs(entry) * ec_age2k(entry) *
-		entry->ae_cur_stripe.as_stripenum;
-	se = ss + ec_age2cs(entry) * ec_age2k(entry);
-
+	ss = ec_age2ss(entry) * entry->ae_cur_stripe.as_stripenum;
+	se = ss + ec_age2ss(entry);
 	d_list_for_each_entry(extent, &entry->ae_cur_stripe.as_dextents,
 			      ae_link) {
 		if (extent->ae_orig_recx.rx_idx < ss ||
@@ -772,7 +830,8 @@ agg_update_vos(struct ec_agg_entry *entry, bool write_parity)
 	daos_epoch_range_t	 epoch_range = { 0 };
 	struct ec_agg_param	*ap;
 	struct ec_agg_extent	*ext;
-	unsigned int		 len = ec_age2cs(entry);
+	uint32_t		 len = ec_age2cs(entry);
+	uint32_t		 pidx = ec_age2pidx(entry);
 	int			 rc = 0;
 
 	ap = container_of(entry, struct ec_agg_param, ap_agg_entry);
@@ -780,10 +839,12 @@ agg_update_vos(struct ec_agg_entry *entry, bool write_parity)
 	if (write_parity) {
 		d_sg_list_t	 sgl = { 0 };
 		daos_iod_t	 iod = { 0 };
-		d_iov_t		*iov;
+		d_iov_t		 iov;
 
-		iov = &entry->ae_sgl.sg_iovs[AGG_IOV_PARITY];
-		sgl.sg_iovs = iov;
+		iov = entry->ae_sgl.sg_iovs[AGG_IOV_PARITY];
+		iov.iov_buf += pidx * ec_age2cs_b(entry);
+		iov.iov_len = ec_age2cs_b(entry);
+		sgl.sg_iovs = &iov;
 		sgl.sg_nr = 1;
 		iod.iod_nr = 1;
 		iod.iod_size = entry->ae_rsize;
@@ -815,12 +876,11 @@ agg_update_vos(struct ec_agg_entry *entry, bool write_parity)
 		d_list_for_each_entry(ext, &entry->ae_cur_stripe.as_dextents,
 				      ae_link) {
 			int		erc = 0;
-			unsigned int	se =
-				ec_age2cs(entry) * ec_age2k(entry) *
-				(entry->ae_cur_stripe.as_stripenum + 1);
+			uint64_t	se;
 
-			if (ext->ae_orig_recx.rx_idx +
-			    ext->ae_orig_recx.rx_nr <= se) {
+			se = ec_age2ss(entry) *
+			     (entry->ae_cur_stripe.as_stripenum + 1);
+			if (DAOS_RECX_END(ext->ae_orig_recx) <= se) {
 				epoch_range.epr_lo = epoch_range.epr_hi =
 					ext->ae_epoch;
 
@@ -855,9 +915,11 @@ agg_fetch_local_extents(struct ec_agg_entry *entry, uint8_t *bit_map,
 	daos_recx_t		*recxs = NULL;
 	unsigned char		*buf = NULL;
 	struct ec_agg_param	*agg_param;
-	unsigned int		 len = ec_age2cs(entry);
-	unsigned int		 k = ec_age2k(entry);
-	unsigned int		 i, j;
+	uint64_t		 cell_bytes = ec_age2cs_b(entry);
+	uint32_t		 len = ec_age2cs(entry);
+	uint32_t		 k = ec_age2k(entry);
+	uint32_t		 pidx = ec_age2pidx(entry);
+	uint32_t		 i, j;
 	int			 rc = 0;
 
 	D_ALLOC_ARRAY(recxs, is_recalc ? cell_cnt : cell_cnt + 1);
@@ -892,20 +954,16 @@ agg_fetch_local_extents(struct ec_agg_entry *entry, uint8_t *bit_map,
 	}
 
 	sgl.sg_nr =  is_recalc ? cell_cnt : cell_cnt + 1;
-	buf = (unsigned char *)entry->ae_sgl.sg_iovs[AGG_IOV_DATA].iov_buf;
-	for (i = 0; i < cell_cnt; i++) {
-		d_iov_set(&sgl.sg_iovs[i], &buf[i * len], len);
-		/* zeroed to ensure correctness when cell is partially filled */
-		memset(sgl.sg_iovs[i].iov_buf, 0, len);
-	}
+	buf = entry->ae_sgl.sg_iovs[AGG_IOV_DATA].iov_buf;
+	for (i = 0; i < cell_cnt; i++)
+		d_iov_set(&sgl.sg_iovs[i], &buf[i * cell_bytes], cell_bytes);
 
 	/* fetch the local parity */
-	if (!is_recalc)
-		/* This is correct for p > 1, since the leader is last, but we
-		 * reverse the order in the parity buf.
-		 */
-		d_iov_set(&sgl.sg_iovs[cell_cnt],
-			  entry->ae_sgl.sg_iovs[AGG_IOV_PARITY].iov_buf, len);
+	if (!is_recalc) {
+		buf = entry->ae_sgl.sg_iovs[AGG_IOV_PARITY].iov_buf;
+		d_iov_set(&sgl.sg_iovs[cell_cnt], &buf[pidx * cell_bytes],
+			  cell_bytes);
+	}
 
 	iod.iod_name = entry->ae_akey;
 	iod.iod_type = DAOS_IOD_ARRAY;
@@ -918,6 +976,7 @@ agg_fetch_local_extents(struct ec_agg_entry *entry, uint8_t *bit_map,
 			   &entry->ae_dkey, 1, &iod, &sgl);
 	if (rc)
 		D_ERROR("vos_obj_fetch failed: "DF_RC"\n", DP_RC(rc));
+
 out:
 	if (recxs != NULL)
 		D_FREE(recxs);
@@ -936,17 +995,23 @@ agg_fetch_remote_parity(struct ec_agg_entry *entry)
 	d_sg_list_t	 sgl = { };
 	d_iov_t		 iov = { };
 	unsigned char	*buf = NULL;
-	unsigned int	 len = ec_age2cs(entry);
-	unsigned int	 p = ec_age2p(entry);
-	unsigned int	 pshard  = entry->ae_oid.id_shard - 1;
+	uint32_t	 len = ec_age2cs(entry);
+	uint64_t	 cell_b = ec_age2cs_b(entry);
+	uint32_t	 k = ec_age2k(entry);
+	uint32_t	 p = ec_age2p(entry);
+	uint32_t	 shard  = ec_age2shard(entry);
+	uint32_t	 pidx, sidx, peer_shard;
 	int		 i, rc = 0;
 
 	/* Only called when p > 1. */
 	D_ASSERT(p > 1);
+	sidx = shard % (k + p);
+	D_ASSERT(sidx >= k && sidx < k + p);
+	pidx = sidx - k;
 
+	/* set up the iod */
 	recx.rx_idx = (entry->ae_cur_stripe.as_stripenum * len)
 							| PARITY_INDICATOR;
-	/* set up the iod */
 	recx.rx_nr = len;
 	iod.iod_recxs = &recx;
 	iod.iod_name = entry->ae_akey;
@@ -957,19 +1022,72 @@ agg_fetch_remote_parity(struct ec_agg_entry *entry)
 	buf = entry->ae_sgl.sg_iovs[AGG_IOV_PARITY].iov_buf;
 	sgl.sg_nr = 1;
 	sgl.sg_iovs = &iov;
-	for (i = 1; i < p; i++) {
-		D_ASSERT(pshard >= ec_age2k(entry));
-		d_iov_set(&iov, &buf[i * len], len);
+	for (i = 0; i < p; i++) {
+		if (i == pidx)
+			continue;
+		d_iov_set(&iov, &buf[i * cell_b], cell_b);
+		peer_shard = rounddown(shard, k + p) + k + i;
 		rc = dsc_obj_fetch(entry->ae_obj_hdl,
 				   entry->ae_par_extent.ape_epoch,
 				   &entry->ae_dkey, 1, &iod, &sgl, NULL,
-				   DIOF_TO_SPEC_SHARD, &pshard, NULL);
+				   DIOF_TO_SPEC_SHARD, &peer_shard, NULL);
+		D_DEBUG(DB_TRACE, DF_UOID" fetch parity from peer shard %d, "
+			DF_RC".\n", DP_UOID(entry->ae_oid), peer_shard,
+			DP_RC(rc));
 		if (rc)
 			goto out;
-		pshard--;
 	}
+
 out:
 	return rc;
+}
+
+/** Pre-process the diff data to zero the non-existed replica extends */
+static void
+agg_diff_preprocess(struct ec_agg_entry *entry, unsigned char *diff,
+		    unsigned int cell_idx)
+{
+	struct ec_agg_extent	*extent;
+	unsigned int		 len = ec_age2cs(entry);
+	unsigned int		 k = ec_age2k(entry);
+	uint64_t		 ss, estart, eend, elen;
+	uint64_t		 cell_start, cell_end;
+	uint64_t		 rsize = entry->ae_rsize;
+	uint64_t		 hole_off, hole_end;
+
+	ss = k * len * entry->ae_cur_stripe.as_stripenum;
+	cell_start = cell_idx * len;
+	cell_end = cell_start + len;
+	hole_off = 0;
+	d_list_for_each_entry(extent, &entry->ae_cur_stripe.as_dextents,
+			      ae_link) {
+		D_ASSERT(!extent->ae_hole);
+		if (extent->ae_epoch <= entry->ae_par_extent.ape_epoch)
+			continue;
+		D_ASSERT(extent->ae_recx.rx_idx >= ss);
+		estart = extent->ae_recx.rx_idx - ss;
+		elen = extent->ae_recx.rx_nr;
+		eend = estart + elen;
+		if (estart >= cell_end)
+			break;
+		if (eend <= cell_start)
+			continue;
+		hole_end = cell_start + hole_off;
+		if (estart > hole_end) {
+			memset(diff + hole_off * rsize, 0,
+			       (estart - hole_end) * rsize);
+			D_DEBUG(DB_TRACE, DF_UOID" zero [off "DF_U64
+				", len "DF_U64"]\n", DP_UOID(entry->ae_oid),
+				hole_off, estart - hole_end);
+		}
+		hole_off = eend - cell_start;
+	}
+	if (hole_off > 0 && hole_off < len) {
+		memset(diff + hole_off * rsize, 0,
+		       (len - hole_off) * rsize);
+		D_DEBUG(DB_TRACE, DF_UOID" zero [off "DF_U64", len"DF_U64"]\n",
+			DP_UOID(entry->ae_oid), hole_off, len - hole_off);
+	}
 }
 
 /* Performs an incremental update of the existing parity for the stripe.
@@ -991,9 +1109,8 @@ agg_update_parity(struct ec_agg_entry *entry, uint8_t *bit_map,
 	int		 i, j, rc = 0;
 
 	buf = entry->ae_sgl.sg_iovs[AGG_IOV_PARITY].iov_buf;
-
-	for (i = p - 1, j = 0; i >= 0; i--)
-		parity_bufs[j++] = &buf[i * cell_bytes];
+	for (i = 0; i < p; i++)
+		parity_bufs[i] = &buf[i * cell_bytes];
 
 	obuf = entry->ae_sgl.sg_iovs[AGG_IOV_ODATA].iov_buf;
 	buf  = entry->ae_sgl.sg_iovs[AGG_IOV_DATA].iov_buf;
@@ -1010,6 +1127,7 @@ agg_update_parity(struct ec_agg_entry *entry, uint8_t *bit_map,
 			goto out;
 		while (!isset(bit_map, j))
 			j++;
+		agg_diff_preprocess(entry, diff, j);
 		ec_encode_data_update(cell_bytes, k, p, j,
 				      entry->ae_codec->ec_gftbls, diff,
 				      parity_bufs);
@@ -1033,7 +1151,7 @@ agg_recalc_parity(struct ec_agg_entry *entry, uint8_t *bit_map,
 	unsigned char	*buf;
 	unsigned char	*rbuf = entry->ae_sgl.sg_iovs[AGG_IOV_ODATA].iov_buf;
 	unsigned char	*lbuf = entry->ae_sgl.sg_iovs[AGG_IOV_DATA].iov_buf;
-	int		 i, j, r, l = 0;
+	int		 i, r, l = 0;
 
 	for (i = 0, r = 0; i < k; i++) {
 		if (isset(bit_map, i))
@@ -1044,8 +1162,8 @@ agg_recalc_parity(struct ec_agg_entry *entry, uint8_t *bit_map,
 	D_ASSERT(r == cell_cnt);
 	buf = entry->ae_sgl.sg_iovs[AGG_IOV_PARITY].iov_buf;
 	D_ASSERT(p > 0);
-	for (i = p - 1, j = 0; i >= 0; i--)
-		parity_bufs[j++] = &buf[i * cell_bytes];
+	for (i = 0; i < p; i++)
+		parity_bufs[i] = &buf[i * cell_bytes];
 
 	ec_encode_data(cell_bytes, k, p, entry->ae_codec->ec_gftbls, data,
 		       parity_bufs);
@@ -1214,121 +1332,150 @@ agg_peer_update_ult(void *arg)
 	d_sg_list_t		 sgl = { 0 };
 	crt_endpoint_t		 tgt_ep = { 0 };
 	unsigned char		*buf = NULL;
-	struct obj_ec_agg_in	*ec_agg_in;
+	struct obj_ec_agg_in	*ec_agg_in = NULL;
 	struct obj_ec_agg_out	*ec_agg_out;
 	struct ec_agg_param	*agg_param;
+	struct ec_agg_extent	*ext;
+	crt_bulk_t		 bulk_hdl = NULL;
+	uint32_t		 shard  = ec_age2shard(entry);
+	uint32_t		 pidx = ec_age2pidx(entry);
+	uint64_t		 cell_b = ec_age2cs_b(entry);
+	uint32_t		 k = ec_age2k(entry);
+	uint32_t		 p = ec_age2p(entry);
+	uint32_t		 peer, peer_shard;
 	crt_rpc_t		*rpc = NULL;
+	int			 i = 0;
 	int			 rc = 0;
 
-	tgt_ep.ep_rank = entry->ae_peer_pshards[0].sd_rank;
-	tgt_ep.ep_tag = entry->ae_peer_pshards[0].sd_tgt_idx;
-	rc = obj_req_create(dss_get_module_info()->dmi_ctx, &tgt_ep,
-			    DAOS_OBJ_RPC_EC_AGGREGATE, &rpc);
-	if (rc) {
-		D_ERROR("obj_req_create failed: "DF_RC"\n", DP_RC(rc));
-		goto out;
-	}
-	D_ASSERT(rpc != NULL);
-	ec_agg_in = crt_req_get(rpc);
 	agg_param = container_of(entry, struct ec_agg_param, ap_agg_entry);
-	uuid_copy(ec_agg_in->ea_pool_uuid,
-		  agg_param->ap_pool_info.api_pool_uuid);
-	uuid_copy(ec_agg_in->ea_coh_uuid,
-		  agg_param->ap_pool_info.api_poh_uuid);
-	uuid_copy(ec_agg_in->ea_cont_uuid,
-		  agg_param->ap_pool_info.api_cont_uuid);
-	uuid_copy(ec_agg_in->ea_coh_uuid,
-		  agg_param->ap_pool_info.api_coh_uuid);
-	ec_agg_in->ea_oid = entry->ae_oid;
-	ec_agg_in->ea_oid.id_shard--;
-	ec_agg_in->ea_dkey = entry->ae_dkey;
-	ec_agg_in->ea_akey = entry->ae_akey;
-	ec_agg_in->ea_epoch_range.epr_lo = agg_param->ap_epr.epr_lo;
-	ec_agg_in->ea_epoch_range.epr_hi = entry->ae_cur_stripe.as_hi_epoch;
-	ec_agg_in->ea_stripenum = entry->ae_cur_stripe.as_stripenum;
-	ec_agg_in->ea_map_ver =
-		agg_param->ap_pool_info.api_pool->sp_map_version;
-
-	if (stripe_ud->asu_write_par) {
-		unsigned int	cell_b = ec_age2cs_b(entry);
-
-		ec_agg_in->ea_rsize = entry->ae_rsize;
-		buf = (unsigned char *)
-			entry->ae_sgl.sg_iovs[AGG_IOV_PARITY].iov_buf;
-		d_iov_set(&iov, &buf[cell_b], cell_b);
-		sgl.sg_iovs = &iov;
-		sgl.sg_nr = sgl.sg_nr_out = 1;
-		rc = crt_bulk_create(dss_get_module_info()->dmi_ctx, &sgl,
-				     CRT_BULK_RW, &ec_agg_in->ea_bulk);
+	for (peer = 0; peer < p; peer++) {
+		if (peer == pidx)
+			continue;
+		tgt_ep.ep_rank = entry->ae_peer_pshards[peer].sd_rank;
+		tgt_ep.ep_tag = entry->ae_peer_pshards[peer].sd_tgt_idx;
+		rc = obj_req_create(dss_get_module_info()->dmi_ctx, &tgt_ep,
+				    DAOS_OBJ_RPC_EC_AGGREGATE, &rpc);
 		if (rc) {
-			D_ERROR("crt_bulk_create failed: "DF_RC"\n", DP_RC(rc));
-			goto out_rpc;
+			D_ERROR(DF_UOID" pidx %d to peer %d, obj_req_create "
+				DF_RC"\n", DP_UOID(entry->ae_oid), pidx, peer,
+				DP_RC(rc));
+			goto out;
 		}
-	}
+		ec_agg_in = crt_req_get(rpc);
+		uuid_copy(ec_agg_in->ea_pool_uuid,
+			  agg_param->ap_pool_info.api_pool_uuid);
+		uuid_copy(ec_agg_in->ea_coh_uuid,
+			  agg_param->ap_pool_info.api_poh_uuid);
+		uuid_copy(ec_agg_in->ea_cont_uuid,
+			  agg_param->ap_pool_info.api_cont_uuid);
+		uuid_copy(ec_agg_in->ea_coh_uuid,
+			  agg_param->ap_pool_info.api_coh_uuid);
+		ec_agg_in->ea_oid = entry->ae_oid;
+		peer_shard = rounddown(shard, k + p) + k + peer;
+		ec_agg_in->ea_oid.id_shard = peer_shard;
+		ec_agg_in->ea_dkey = entry->ae_dkey;
+		ec_agg_in->ea_akey = entry->ae_akey;
+		ec_agg_in->ea_epoch_range.epr_lo = agg_param->ap_epr.epr_lo;
+		ec_agg_in->ea_epoch_range.epr_hi =
+			entry->ae_cur_stripe.as_hi_epoch;
+		ec_agg_in->ea_stripenum = entry->ae_cur_stripe.as_stripenum;
+		ec_agg_in->ea_map_ver =
+			agg_param->ap_pool_info.api_pool->sp_map_version;
 
-	if (entry->ae_cur_stripe.as_ho_ext_cnt || !agg_contained(entry)) {
-		struct ec_agg_extent	*ext;
-		int			 i = 0;
+		if (stripe_ud->asu_write_par) {
+			ec_agg_in->ea_rsize = entry->ae_rsize;
+			buf = (unsigned char *)
+				entry->ae_sgl.sg_iovs[AGG_IOV_PARITY].iov_buf;
+			d_iov_set(&iov, &buf[peer * cell_b], cell_b);
+			sgl.sg_iovs = &iov;
+			sgl.sg_nr = sgl.sg_nr_out = 1;
+			rc = crt_bulk_create(dss_get_module_info()->dmi_ctx,
+					     &sgl, CRT_BULK_RW, &bulk_hdl);
+			if (rc) {
+				D_ERROR(DF_UOID" pidx %d to peer %d, "
+					"crt_bulk_create "DF_RC"\n",
+					DP_UOID(entry->ae_oid), pidx, peer,
+					DP_RC(rc));
+				goto out_rpc;
+			}
+			ec_agg_in->ea_bulk = bulk_hdl;
+		}
 
-		ec_agg_in->ea_remove_nr = entry->ae_cur_stripe.as_ho_ext_cnt +
-			entry->ae_cur_stripe.as_extent_cnt;
-		D_ALLOC_ARRAY(ec_agg_in->ea_remove_recxs.ca_arrays,
-			      ec_agg_in->ea_remove_nr);
-		if (ec_agg_in->ea_remove_recxs.ca_arrays == NULL) {
-			rc = -DER_NOMEM;
-			goto out_bulk;
-		}
-		D_ALLOC_ARRAY(ec_agg_in->ea_remove_eps.ca_arrays,
-			      ec_agg_in->ea_remove_nr);
-		if (ec_agg_in->ea_remove_eps.ca_arrays == NULL) {
-			rc = -DER_NOMEM;
-			goto out_bulk;
-		}
+		if (entry->ae_cur_stripe.as_ho_ext_cnt ||
+		    !agg_contained(entry)) {
+			ec_agg_in->ea_remove_nr =
+				entry->ae_cur_stripe.as_ho_ext_cnt +
+				entry->ae_cur_stripe.as_extent_cnt;
+			D_ALLOC_ARRAY(ec_agg_in->ea_remove_recxs.ca_arrays,
+				      ec_agg_in->ea_remove_nr);
+			if (ec_agg_in->ea_remove_recxs.ca_arrays == NULL) {
+				rc = -DER_NOMEM;
+				goto out_bulk;
+			}
+			D_ALLOC_ARRAY(ec_agg_in->ea_remove_eps.ca_arrays,
+				      ec_agg_in->ea_remove_nr);
+			if (ec_agg_in->ea_remove_eps.ca_arrays == NULL) {
+				rc = -DER_NOMEM;
+				goto out_bulk;
+			}
 
-		d_list_for_each_entry(ext, &entry->ae_cur_stripe.as_dextents,
-				      ae_link) {
-			ec_agg_in->ea_remove_recxs.ca_arrays[i] =
-				ext->ae_orig_recx;
-			ec_agg_in->ea_remove_eps.ca_arrays[i++] =
-				ext->ae_epoch;
-		}
-		if (entry->ae_cur_stripe.as_ho_ext_cnt) {
 			d_list_for_each_entry(ext,
-					      &entry->
-					      ae_cur_stripe.as_hoextents,
+					      &entry->ae_cur_stripe.as_dextents,
 					      ae_link) {
 				ec_agg_in->ea_remove_recxs.ca_arrays[i] =
 					ext->ae_orig_recx;
 				ec_agg_in->ea_remove_eps.ca_arrays[i++] =
 					ext->ae_epoch;
 			}
+			if (entry->ae_cur_stripe.as_ho_ext_cnt) {
+				d_list_for_each_entry(ext,
+						      &entry->ae_cur_stripe.
+						      as_hoextents,
+						      ae_link) {
+					ec_agg_in->ea_remove_recxs.ca_arrays[i]
+						= ext->ae_orig_recx;
+					ec_agg_in->ea_remove_eps.ca_arrays[i++]
+						= ext->ae_epoch;
+				}
+			}
+			D_ASSERT(ec_agg_in->ea_remove_nr == i);
+			ec_agg_in->ea_remove_recxs.ca_count = i;
+			ec_agg_in->ea_remove_eps.ca_count = i;
 		}
-		D_ASSERT(ec_agg_in->ea_remove_nr == i);
-		ec_agg_in->ea_remove_recxs.ca_count = i;
-		ec_agg_in->ea_remove_eps.ca_count = i;
-	}
 
-	rc = dss_rpc_send(rpc);
-	if (rc) {
-		D_ERROR("dss_rpc_send failed: "DF_RC"\n", DP_RC(rc));
-		if (stripe_ud->asu_write_par)
-			crt_bulk_free(ec_agg_in->ea_bulk);
-		goto out_bulk;
+		rc = dss_rpc_send(rpc);
+		if (rc) {
+			D_ERROR(DF_UOID" pidx %d to peer %d, dss_rpc_send "
+				DF_RC"\n", DP_UOID(entry->ae_oid), pidx, peer,
+				DP_RC(rc));
+			goto out_bulk;
+		}
+		ec_agg_out = crt_reply_get(rpc);
+		rc = ec_agg_out->ea_status;
+		if (bulk_hdl) {
+			crt_bulk_free(bulk_hdl);
+			bulk_hdl = NULL;
+		}
+		crt_req_decref(rpc);
+		rpc = NULL;
+		if (rc) {
+			D_ERROR(DF_UOID" pidx %d to peer %d, ea_status "
+				DF_RC"\n", DP_UOID(entry->ae_oid), pidx, peer,
+				DP_RC(rc));
+			break;
+		}
 	}
-	ec_agg_out = crt_reply_get(rpc);
-	rc = ec_agg_out->ea_status;
-	if (rc)
-		D_ERROR("remote update rpc failed: "DF_RC"\n", DP_RC(rc));
 
 out_bulk:
-	if (stripe_ud->asu_write_par)
-		crt_bulk_free(ec_agg_in->ea_bulk);
+	if (bulk_hdl)
+		crt_bulk_free(bulk_hdl);
 out_rpc:
-	if (ec_agg_in->ea_remove_nr) {
+	if (ec_agg_in && ec_agg_in->ea_remove_nr) {
 		D_FREE(ec_agg_in->ea_remove_recxs.ca_arrays);
 		D_FREE(ec_agg_in->ea_remove_eps.ca_arrays);
 	}
-	crt_req_decref(rpc);
+	if (rpc)
+		crt_req_decref(rpc);
 out:
 	ABT_eventual_set(stripe_ud->asu_eventual, (void *)&rc, sizeof(rc));
 }
@@ -1343,8 +1490,11 @@ agg_peer_update(struct ec_agg_entry *entry, bool write_parity)
 	struct ec_agg_param	*agg_param;
 	struct pool_target	*targets;
 	int			*status;
-	unsigned int		 failed_tgts_cnt = 0;
-	int			 tid, rc = 0;
+	struct daos_shard_loc	*peer_loc;
+	uint32_t		 failed_tgts_cnt = 0;
+	uint32_t		 p = ec_age2p(entry);
+	uint32_t		 peer;
+	int			 i, tid, rc = 0;
 
 	D_ASSERT(!write_parity ||
 		 entry->ae_sgl.sg_iovs[AGG_IOV_PARITY].iov_buf);
@@ -1353,24 +1503,28 @@ agg_peer_update(struct ec_agg_entry *entry, bool write_parity)
 	rc = pool_map_find_failed_tgts(agg_param->ap_pool_info.api_pool->sp_map,
 				       &targets, &failed_tgts_cnt);
 	if (rc) {
-		D_ERROR("pool_map_find_failed_tgts failed: "DF_RC"\n",
-			DP_RC(rc));
+		D_ERROR(DF_UOID" pool_map_find_failed_tgts failed: "DF_RC"\n",
+			DP_UOID(entry->ae_oid), DP_RC(rc));
 		goto out;
 	}
 	if (targets != NULL) {
-		int i;
-
-		for (i = 0; i < failed_tgts_cnt; i++) {
-			if (targets[i].ta_comp.co_rank ==
-			    entry->ae_peer_pshards[0].sd_rank) {
-				D_ERROR("peer parity tgt failed\n");
-				rc = -1;
-				goto out;
+		for (peer = 0; peer < p; peer++) {
+			peer_loc = &entry->ae_peer_pshards[peer];
+			for (i = 0; i < failed_tgts_cnt; i++) {
+				if (targets[i].ta_comp.co_rank ==
+				    peer_loc->sd_rank) {
+					D_ERROR(DF_UOID" peer parity tgt "
+						"failed rank %d, tgt_idx %d.\n",
+						DP_UOID(entry->ae_oid),
+						peer_loc->sd_rank,
+						peer_loc->sd_tgt_idx);
+					rc = -1;
+					goto out;
+				}
 			}
 		}
 	}
-	if (write_parity)
-		stripe_ud.asu_write_par = true;
+	stripe_ud.asu_write_par = write_parity;
 
 	stripe_ud.asu_agg_entry = entry;
 	rc = agg_get_obj_handle(entry);
@@ -1414,15 +1568,20 @@ agg_process_holes_ult(void *arg)
 	struct obj_ec_rep_in	*ec_rep_in = NULL;
 	struct obj_ec_rep_out	*ec_rep_out = NULL;
 	crt_rpc_t		*rpc = NULL;
-	unsigned int		 len = ec_age2cs(entry);
-	unsigned int		 k = ec_age2k(entry);
-	unsigned long		 ss = entry->ae_cur_stripe.as_stripenum *
+	crt_bulk_t		 bulk_hdl = NULL;
+	uint32_t		 len = ec_age2cs(entry);
+	uint64_t		 cell_b = ec_age2cs_b(entry);
+	uint32_t		 k = ec_age2k(entry);
+	uint32_t		 p = ec_age2p(entry);
+	uint64_t		 ss = entry->ae_cur_stripe.as_stripenum *
 					k * len;
-	unsigned long		 last_ext_end = 0;
-	unsigned int		 ext_cnt = 0;
-	unsigned int		 ext_tot_len = 0;
-	unsigned int		 failed_tgts_cnt = 0;
-	int			 rc = 0;
+	uint64_t		 last_ext_end = 0;
+	uint64_t		 ext_cnt = 0;
+	uint64_t		 ext_tot_len = 0;
+	uint32_t		 failed_tgts_cnt = 0;
+	uint32_t		 pidx = ec_age2pidx(entry);
+	uint32_t		 peer;
+	int			 i, rc = 0;
 	bool			 valid_hole = false;
 
 	/* Process extent list to find what to re-replicate -- build recx array
@@ -1452,13 +1611,10 @@ agg_process_holes_ult(void *arg)
 		goto out;
 
 	if (last_ext_end < k * len) {
-		stripe_ud->asu_recxs[ext_cnt].rx_idx =
-			ss + last_ext_end;
-		stripe_ud->asu_recxs[ext_cnt].rx_nr = k * len -
-			last_ext_end;
+		stripe_ud->asu_recxs[ext_cnt].rx_idx = ss + last_ext_end;
+		stripe_ud->asu_recxs[ext_cnt].rx_nr = k * len - last_ext_end;
 		ext_tot_len += stripe_ud->asu_recxs[ext_cnt++].rx_nr;
 	}
-
 	stripe_ud->asu_cell_cnt = ext_cnt;
 	iod.iod_name = entry->ae_akey;
 	iod.iod_type = DAOS_IOD_ARRAY;
@@ -1466,9 +1622,9 @@ agg_process_holes_ult(void *arg)
 	iod.iod_nr = ext_cnt;
 	iod.iod_recxs = stripe_ud->asu_recxs;
 	entry->ae_sgl.sg_nr = 1;
-	entry->ae_sgl.sg_iovs[AGG_IOV_DATA].iov_len =
-		ext_tot_len * entry->ae_rsize;
-	D_ASSERT(entry->ae_sgl.sg_iovs[AGG_IOV_DATA].iov_len <= k * len);
+	entry->ae_sgl.sg_iovs[AGG_IOV_DATA].iov_len = ext_tot_len *
+						      entry->ae_rsize;
+	D_ASSERT(entry->ae_sgl.sg_iovs[AGG_IOV_DATA].iov_len <= k * cell_b);
 	/* Pull data via dsc_obj_fetch */
 	if (ext_cnt) {
 		rc = dsc_obj_fetch(entry->ae_obj_hdl,
@@ -1484,79 +1640,93 @@ agg_process_holes_ult(void *arg)
 	if (ec_age2p(entry) < 2)
 		goto out;
 
-	/* Invoke peer re-replicate */
-	agg_param = container_of(entry, struct ec_agg_param, ap_agg_entry);
-	rc = pool_map_find_failed_tgts(agg_param->ap_pool_info.api_pool->sp_map,
-				       &targets, &failed_tgts_cnt);
-	if (rc) {
-		D_ERROR("pool_map_find_failed_tgts failed: "DF_RC"\n",
-			DP_RC(rc));
-		goto out;
-	}
-
-	if (targets != NULL) {
-		int i;
-
-		for (i = 0; i < failed_tgts_cnt; i++) {
-			if (targets[i].ta_comp.co_rank ==
-			    entry->ae_peer_pshards[0].sd_rank) {
-				D_ERROR("peer parity tgt failed\n");
-				rc = -1;
-				goto out;
-			}
-		}
-	}
-
-	tgt_ep.ep_rank = entry->ae_peer_pshards[0].sd_rank;
-	tgt_ep.ep_tag = entry->ae_peer_pshards[0].sd_tgt_idx;
-	rc = obj_req_create(dss_get_module_info()->dmi_ctx, &tgt_ep,
-			    DAOS_OBJ_RPC_EC_REPLICATE, &rpc);
-	if (rc) {
-		D_ERROR("obj_req_create failed: "DF_RC"\n", DP_RC(rc));
-		goto out;
-	}
-	ec_rep_in = crt_req_get(rpc);
-	agg_param = container_of(entry, struct ec_agg_param, ap_agg_entry);
-	uuid_copy(ec_rep_in->er_pool_uuid,
-		  agg_param->ap_pool_info.api_pool_uuid);
-	uuid_copy(ec_rep_in->er_coh_uuid,
-		  agg_param->ap_pool_info.api_poh_uuid);
-	uuid_copy(ec_rep_in->er_cont_uuid,
-		  agg_param->ap_pool_info.api_cont_uuid);
-	uuid_copy(ec_rep_in->er_coh_uuid,
-		  agg_param->ap_pool_info.api_coh_uuid);
-	ec_rep_in->er_oid = entry->ae_oid;
-	ec_rep_in->er_oid.id_shard--;
-	ec_rep_in->er_dkey = entry->ae_dkey;
-	ec_rep_in->er_iod = iod;
-	ec_rep_in->er_stripenum = entry->ae_cur_stripe.as_stripenum;
-	ec_rep_in->er_epoch = entry->ae_cur_stripe.as_hi_epoch;
-	ec_rep_in->er_map_ver =
-		agg_param->ap_pool_info.api_pool->sp_map_version;
-	entry->ae_sgl.sg_nr_out = 1;
 	if (ext_cnt) {
 		rc = crt_bulk_create(dss_get_module_info()->dmi_ctx,
-				     &entry->ae_sgl, CRT_BULK_RW,
-				     &ec_rep_in->er_bulk);
+				     &entry->ae_sgl, CRT_BULK_RW, &bulk_hdl);
 		if (rc) {
-			D_ERROR("crt_bulk_create returned: "DF_RC"\n",
-				DP_RC(rc));
+			D_ERROR(DF_UOID" crt_bulk_create returned: "DF_RC"\n",
+				DP_UOID(entry->ae_oid), DP_RC(rc));
 			goto out;
 		}
 	}
-	rc = dss_rpc_send(rpc);
-	if (rc) {
-		D_ERROR("dss_rpc_send failed: "DF_RC"\n", DP_RC(rc));
-		goto out;
+
+	agg_param = container_of(entry, struct ec_agg_param, ap_agg_entry);
+	/* Invoke peer re-replicate */
+	for (peer = 0; peer < p; peer++) {
+		if (pidx == peer)
+			continue;
+		rc = pool_map_find_failed_tgts(
+			agg_param->ap_pool_info.api_pool->sp_map,
+			&targets, &failed_tgts_cnt);
+		if (rc) {
+			D_ERROR(DF_UOID" pool_map_find_failed_tgts failed: "
+				DF_RC"\n", DP_UOID(entry->ae_oid), DP_RC(rc));
+			goto out;
+		}
+
+		if (targets != NULL) {
+			for (i = 0; i < failed_tgts_cnt; i++) {
+				if (targets[i].ta_comp.co_rank ==
+				    entry->ae_peer_pshards[peer].sd_rank) {
+					D_ERROR(DF_UOID" peer %d parity tgt "
+						"failed\n",
+						DP_UOID(entry->ae_oid),
+						peer);
+					rc = -1;
+					goto out;
+				}
+			}
+		}
+
+		tgt_ep.ep_rank = entry->ae_peer_pshards[peer].sd_rank;
+		tgt_ep.ep_tag = entry->ae_peer_pshards[peer].sd_tgt_idx;
+		rc = obj_req_create(dss_get_module_info()->dmi_ctx, &tgt_ep,
+				    DAOS_OBJ_RPC_EC_REPLICATE, &rpc);
+		if (rc) {
+			D_ERROR(DF_UOID" obj_req_create failed: "DF_RC"\n",
+				DP_UOID(entry->ae_oid), DP_RC(rc));
+			goto out;
+		}
+		ec_rep_in = crt_req_get(rpc);
+		uuid_copy(ec_rep_in->er_pool_uuid,
+			  agg_param->ap_pool_info.api_pool_uuid);
+		uuid_copy(ec_rep_in->er_coh_uuid,
+			  agg_param->ap_pool_info.api_poh_uuid);
+		uuid_copy(ec_rep_in->er_cont_uuid,
+			  agg_param->ap_pool_info.api_cont_uuid);
+		uuid_copy(ec_rep_in->er_coh_uuid,
+			  agg_param->ap_pool_info.api_coh_uuid);
+		ec_rep_in->er_oid = entry->ae_oid;
+		ec_rep_in->er_oid.id_shard--;
+		ec_rep_in->er_dkey = entry->ae_dkey;
+		ec_rep_in->er_iod = iod;
+		ec_rep_in->er_stripenum = entry->ae_cur_stripe.as_stripenum;
+		ec_rep_in->er_epoch = entry->ae_cur_stripe.as_hi_epoch;
+		ec_rep_in->er_map_ver =
+			agg_param->ap_pool_info.api_pool->sp_map_version;
+		ec_rep_in->er_bulk = bulk_hdl;
+		rc = dss_rpc_send(rpc);
+		if (rc) {
+			D_ERROR(DF_UOID" peer %d dss_rpc_send failed "DF_RC"\n",
+				DP_UOID(entry->ae_oid), peer, DP_RC(rc));
+			goto out;
+		}
+		ec_rep_out = crt_reply_get(rpc);
+		rc = ec_rep_out->er_status;
+		crt_req_decref(rpc);
+		rpc = NULL;
+		if (rc) {
+			D_ERROR(DF_UOID" peer %d er_status failed "DF_RC"\n",
+				DP_UOID(entry->ae_oid), peer, DP_RC(rc));
+			break;
+		}
 	}
-	ec_rep_out = crt_reply_get(rpc);
-	rc = ec_rep_out->er_status;
-	if (rc)
-		D_ERROR("remote update rpc failed: "DF_RC"\n", DP_RC(rc));
-	crt_bulk_free(ec_rep_in->er_bulk);
+
 out:
 	if (rpc)
 		crt_req_decref(rpc);
+	if (bulk_hdl)
+		crt_bulk_free(bulk_hdl);
 	entry->ae_sgl.sg_nr = AGG_IOV_CNT;
 	ABT_eventual_set(stripe_ud->asu_eventual, (void *)&rc, sizeof(rc));
 }
@@ -1657,8 +1827,9 @@ agg_process_stripe(struct dtx_handle *dth, struct ec_agg_entry *entry)
 	bool			process_holes = false;
 	int			rc = 0;
 
-	entry->ae_par_extent.ape_epoch	= ~(0ULL);
-
+	/* Query the parity, entry->ae_par_extent.ape_epoch will be set to
+	 * parity ext epoch if exist.
+	 */
 	iter_param.ip_hdl		= DAOS_HDL_INVAL;
 	iter_param.ip_ih		= entry->ae_thdl;
 	iter_param.ip_flags		= VOS_IT_RECX_VISIBLE;
@@ -1666,46 +1837,38 @@ agg_process_stripe(struct dtx_handle *dth, struct ec_agg_entry *entry)
 	iter_param.ip_recx.rx_idx	= PARITY_INDICATOR |
 					  (entry->ae_cur_stripe.as_stripenum *
 					   iter_param.ip_recx.rx_nr);
-
-	D_DEBUG(DB_TRACE, "Querying parity for stripe: %lu, offset: %lu\n",
-		entry->ae_cur_stripe.as_stripenum,
-		iter_param.ip_recx.rx_idx);
-
-	/* Query the parity */
+	ec_age_set_no_parity(entry);
 	rc = vos_iterate(&iter_param, VOS_ITER_RECX, false, &anchors,
 			 agg_recx_iter_pre_cb, NULL, entry, dth);
-	/* entry->ae_par_extent.ape_epoch has been set to the parity extent's
-	 * epoch
-	 */
+	D_DEBUG(DB_TRACE, "Querying parity for stripe: %lu, offset: "DF_X64
+		", "DF_RC"\n", entry->ae_cur_stripe.as_stripenum,
+		iter_param.ip_recx.rx_idx, DP_RC(rc));
 	if (rc != 0)
 		goto out;
 
-	if (entry->ae_par_extent.ape_epoch >= entry->ae_cur_stripe.as_hi_epoch
-	    && entry->ae_par_extent.ape_epoch != ~(0ULL)) {
-		/* Parity is as new, or newer than data, so delete the replicas.
-		 */
+	/* with parity and higher than replicas, delete the old replica */
+	if (ec_age_with_parity(entry) && ec_age_parity_higher(entry)) {
 		update_vos = true;
 		write_parity = false;
 		goto out;
 	}
 
-	if ((entry->ae_par_extent.ape_epoch == ~(0ULL) &&
-	     agg_stripe_is_filled(entry, false)) ||
-	    agg_stripe_is_filled(entry, true)) {
-		/* Replicas constitute a full stripe, all extents are new than
-		 * parity, if parity exists for the stripe
-		 */
+	/* Replicas constitute a full stripe, 1) no parity, or 2) with parity
+	 * and all replica extents are newer than parity.
+	 */
+	if (ec_age_stripe_full(entry, ec_age_with_parity(entry))) {
 		rc = agg_encode_local_parity(entry);
 		goto out;
 	}
 
-	if (entry->ae_par_extent.ape_epoch == ~(0ULL)) {
-		/* No parity, partial-stripe worth of replica, nothing to do */
+	/* No parity, partial-stripe worth of replica, nothing to do */
+	if (!ec_age_with_parity(entry)) {
 		update_vos = false;
 		goto out;
 	}
-	/* Parity, some later replicas, possibly holes, not full stripe. */
-	if (entry->ae_cur_stripe.as_has_holes)
+
+	/* With parity and some newer partial replicas, possibly holes */
+	if (ec_age_with_hole(entry))
 		process_holes = true;
 	else
 		rc = agg_process_partial_stripe(entry);
@@ -1783,7 +1946,9 @@ agg_data_extent(struct dtx_handle *dth, vos_iter_entry_t *entry,
 	D_ASSERT(!(entry->ie_recx.rx_idx & PARITY_INDICATOR));
 
 	this_stripenum = agg_stripenum(agg_entry, entry->ie_recx.rx_idx);
-
+	D_DEBUG(DB_TRACE, DF_UOID" get recx "DF_RECX", stripe "DF_U64"\n",
+		DP_UOID(agg_entry->ae_oid), DP_RECX(entry->ie_recx),
+		this_stripenum);
 	if (this_stripenum != agg_entry->ae_cur_stripe.as_stripenum) {
 		/* Iterator has reached next stripe */
 		if (agg_entry->ae_cur_stripe.as_extent_cnt) {
@@ -1851,8 +2016,8 @@ agg_data_extent(struct dtx_handle *dth, vos_iter_entry_t *entry,
 	if (extent->ae_epoch > agg_entry->ae_cur_stripe.as_hi_epoch)
 		agg_entry->ae_cur_stripe.as_hi_epoch = extent->ae_epoch;
 
-	D_DEBUG(DB_TRACE, "adding extent %lu,%lu, to stripe  %lu, shard: %u\n",
-		extent->ae_recx.rx_idx, extent->ae_recx.rx_nr,
+	D_DEBUG(DB_TRACE, "adding extent "DF_RECX", to stripe %lu, shard: %u\n",
+		DP_RECX(extent->ae_recx),
 		agg_stripenum(agg_entry, extent->ae_recx.rx_idx),
 		agg_entry->ae_oid.id_shard);
 out:
@@ -2033,7 +2198,7 @@ agg_reset_entry(struct ec_agg_entry *agg_entry,
 	memset(&agg_entry->ae_dkey, 0, sizeof(agg_entry->ae_dkey));
 	memset(&agg_entry->ae_akey, 0, sizeof(agg_entry->ae_akey));
 	memset(agg_entry->ae_peer_pshards, 0,
-	       (OBJ_EC_MAX_P - 1) * sizeof(struct daos_shard_loc));
+	       (OBJ_EC_MAX_P) * sizeof(struct daos_shard_loc));
 
 	agg_entry->ae_cur_stripe.as_stripenum	= 0UL;
 	agg_entry->ae_cur_stripe.as_hi_epoch	= 0UL;

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -135,7 +135,7 @@ obj_rw_reply(crt_rpc_t *rpc, int status, uint64_t epoch,
 		orwo->orw_epoch = epoch;
 	}
 
-	D_DEBUG(DB_IO, "rpc %p opc %d send reply, pmv %d, epoch "DF_U64
+	D_DEBUG(DB_IO, "rpc %p opc %d send reply, pmv %d, epoch "DF_X64
 		", status %d\n", rpc, opc_get(rpc->cr_opc),
 		ioc->ioc_map_ver, orwo->orw_epoch, status);
 
@@ -484,7 +484,7 @@ obj_set_reply_sizes(crt_rpc_t *rpc, daos_iod_t *iods, int iod_nr)
 
 	if (iod_nr <= 0) {
 		D_ERROR("rpc %p contains invalid sizes count %d for "
-			DF_UOID" with epc "DF_U64".\n",
+			DF_UOID" with epc "DF_X64".\n",
 			rpc, iod_nr, DP_UOID(orw->orw_oid), orw->orw_epoch);
 		return -DER_INVAL;
 	}
@@ -511,7 +511,7 @@ out:
 	orwo->orw_iod_sizes.ca_arrays = sizes;
 
 	D_DEBUG(DB_TRACE, "rpc %p set sizes count as %d for "
-		DF_UOID" with epc "DF_U64".\n",
+		DF_UOID" with epc "DF_X64".\n",
 		rpc, iod_nr, DP_UOID(orw->orw_oid), orw->orw_epoch);
 
 	return 0;
@@ -596,7 +596,7 @@ obj_echo_rw(crt_rpc_t *rpc, daos_iod_t *split_iods, uint64_t *split_offs)
 	int			rc = 0;
 
 	D_DEBUG(DB_TRACE, "opc %d oid "DF_UOID" dkey "DF_KEY
-		" tgt/xs %d/%d epc "DF_U64".\n",
+		" tgt/xs %d/%d epc "DF_X64".\n",
 		opc_get(rpc->cr_opc), DP_UOID(orw->orw_oid),
 		DP_KEY(&orw->orw_dkey),
 		dss_get_module_info()->dmi_tgt_id,
@@ -1277,7 +1277,7 @@ obj_local_rw_internal(crt_rpc_t *rpc, struct obj_io_context *ioc,
 	}
 	dkey = (daos_key_t *)&orw->orw_dkey;
 	D_DEBUG(DB_IO,
-		"opc %d oid "DF_UOID" dkey "DF_KEY" tag %d epc "DF_U64".\n",
+		"opc %d oid "DF_UOID" dkey "DF_KEY" tag %d epc "DF_X64".\n",
 		opc_get(rpc->cr_opc), DP_UOID(orw->orw_oid), DP_KEY(dkey),
 		tag, orw->orw_epoch);
 
@@ -2058,7 +2058,7 @@ ds_obj_tgt_update_handler(crt_rpc_t *rpc)
 
 	D_DEBUG(DB_IO,
 		"rpc %p opc %d oid "DF_UOID" dkey "DF_KEY" tag/xs %d/%d epc "
-		DF_U64", pmv %u/%u dti "DF_DTI".\n",
+		DF_X64", pmv %u/%u dti "DF_DTI".\n",
 		rpc, opc, DP_UOID(orw->orw_oid), DP_KEY(dkey),
 		dss_get_module_info()->dmi_tgt_id,
 		dss_get_module_info()->dmi_xs_id, orw->orw_epoch,
@@ -2259,7 +2259,7 @@ process_epoch(uint64_t *epoch, uint64_t *epoch_first, uint32_t *flags)
 	if (epoch_first != NULL && *epoch_first == 0)
 		*epoch_first = *epoch;
 
-	D_DEBUG(DB_IO, "overwrite epoch "DF_U64"\n", *epoch);
+	D_DEBUG(DB_IO, "overwrite epoch "DF_X64"\n", *epoch);
 	return PE_OK_LOCAL;
 }
 
@@ -2298,7 +2298,7 @@ ds_obj_rw_handler(crt_rpc_t *rpc)
 
 	D_DEBUG(DB_IO,
 		"rpc %p opc %d oid "DF_UOID" dkey "DF_KEY" tag/xs %d/%d epc "
-		DF_U64", pmv %u/%u dti "DF_DTI".\n",
+		DF_X64", pmv %u/%u dti "DF_DTI".\n",
 		rpc, opc, DP_UOID(orw->orw_oid), DP_KEY(&orw->orw_dkey),
 		dss_get_module_info()->dmi_tgt_id,
 		dss_get_module_info()->dmi_xs_id, orw->orw_epoch,
@@ -2783,7 +2783,7 @@ out:
 	if (type == VOS_ITER_SINGLE)
 		anchors->ia_ev = anchors->ia_sv;
 
-	D_DEBUG(DB_IO, ""DF_UOID" iterate "DF_U64"-"DF_U64" type %d tag %d"
+	D_DEBUG(DB_IO, ""DF_UOID" iterate "DF_X64"-"DF_X64" type %d tag %d"
 		" rc %d\n", DP_UOID(oei->oei_oid), param.ip_epr.epr_lo,
 		param.ip_epr.epr_hi, type, dss_get_module_info()->dmi_tgt_id,
 		rc);
@@ -3241,7 +3241,7 @@ ds_obj_punch_handler(crt_rpc_t *rpc)
 	if (opi->opi_dkeys.ca_count == 0)
 		D_DEBUG(DB_TRACE,
 			"punch obj %p oid "DF_UOID" tag/xs %d/%d epc "
-			DF_U64", pmv %u/%u dti "DF_DTI".\n",
+			DF_X64", pmv %u/%u dti "DF_DTI".\n",
 			rpc, DP_UOID(opi->opi_oid),
 			dss_get_module_info()->dmi_tgt_id,
 			dss_get_module_info()->dmi_xs_id, opi->opi_epoch,
@@ -3251,7 +3251,7 @@ ds_obj_punch_handler(crt_rpc_t *rpc)
 		D_DEBUG(DB_TRACE,
 			"punch key %p oid "DF_UOID" dkey "
 			DF_KEY" tag/xs %d/%d epc "
-			DF_U64", pmv %u/%u dti "DF_DTI".\n",
+			DF_X64", pmv %u/%u dti "DF_DTI".\n",
 			rpc, DP_UOID(opi->opi_oid),
 			DP_KEY(&opi->opi_dkeys.ca_arrays[0]),
 			dss_get_module_info()->dmi_tgt_id,
@@ -3530,7 +3530,7 @@ ds_obj_sync_handler(crt_rpc_t *rpc)
 	else
 		oso->oso_epoch = min(epoch, osi->osi_epoch);
 
-	D_DEBUG(DB_IO, "obj_sync start: "DF_UOID", epc "DF_U64"\n",
+	D_DEBUG(DB_IO, "obj_sync start: "DF_UOID", epc "DF_X64"\n",
 		DP_UOID(osi->osi_oid), oso->oso_epoch);
 
 	rc = obj_ioc_begin(osi->osi_map_ver, osi->osi_pool_uuid,
@@ -3546,7 +3546,7 @@ out:
 	obj_reply_set_status(rpc, rc);
 	obj_ioc_end(&ioc, rc);
 
-	D_DEBUG(DB_IO, "obj_sync stop: "DF_UOID", epc "DF_U64", rd = %d\n",
+	D_DEBUG(DB_IO, "obj_sync stop: "DF_UOID", epc "DF_X64", rd = %d\n",
 		DP_UOID(osi->osi_oid), oso->oso_epoch, rc);
 
 	rc = crt_reply_send(rpc);

--- a/src/tests/ftest/daos_test/daos_core_test.py
+++ b/src/tests/ftest/daos_test/daos_core_test.py
@@ -344,18 +344,18 @@ class DaosCoreTest(DaosCoreBase):
         """
         self.run_subtest()
 
-    def test_daos_degraded_ec_8to22(self):
+    def test_daos_degraded_ec_8to23(self):
         """Jira ID: DAOS-1568
 
         Test Description:
-            Run daos_test -X -u subtests="8-22"
+            Run daos_test -X -u subtests="8-23"
 
         Use cases:
             Core tests for daos_test
 
         :avocado: tags=all,pr,daily_regression
         :avocado: tags=hw,ib2,medium
-        :avocado: tags=daos_test,daos_core_test,test_daos_degraded_ec_8to22
+        :avocado: tags=daos_test,daos_core_test,test_daos_degraded_ec_8to23
         """
         self.run_subtest()
 

--- a/src/tests/ftest/daos_test/daos_core_test.yaml
+++ b/src/tests/ftest/daos_test/daos_core_test.yaml
@@ -30,7 +30,7 @@ timeouts:
     test_daos_checksum: 240
     test_daos_rebuild_ec: 900
     test_daos_degraded_ec_0to6: 900
-    test_daos_degraded_ec_8to22: 900
+    test_daos_degraded_ec_8to23: 950
     test_daos_dedup: 220
 pool:
   #This will create 8G of SCM and 16G of NVMe size of pool.
@@ -101,7 +101,7 @@ daos_tests:
     test_daos_rebuild_ec: DAOS_Rebuild_EC
     test_daos_aggregate_ec: DAOS_Aggregate_EC
     test_daos_degraded_ec_0to6: DAOS_Degraded_EC_0to6
-    test_daos_degraded_ec_8to22: DAOS_Degraded_EC_8to22
+    test_daos_degraded_ec_8to23: DAOS_Degraded_EC_8to23
     test_daos_dedup: DAOS_Dedup
     test_daos_capability: DAOS_Capability
     test_daos_epoch_recovery: DAOS_Epoch_Recovery
@@ -114,7 +114,7 @@ daos_tests:
     test_daos_rebuild_ec: DAOS_Rebuild_EC
     test_daos_aggregate_ec: DAOS_Aggregate_EC
     test_daos_degraded_ec_0to6: DAOS_Degraded_EC_0to6
-    test_daos_degraded_ec_8to22: DAOS_Degraded_EC_8to22
+    test_daos_degraded_ec_8to23: DAOS_Degraded_EC_8to23
     test_daos_dedup: DAOS_Dedup
   daos_test:
     test_daos_degraded_mode: d
@@ -140,11 +140,11 @@ daos_tests:
     test_daos_rebuild_ec: S
     test_daos_aggregate_ec: Z
     test_daos_degraded_ec_0to6: X
-    test_daos_degraded_ec_8to22: X
+    test_daos_degraded_ec_8to23: X
     test_daos_dedup: U
   args:
     test_daos_degraded_ec_0to6: -u subtests="0-6"
-    test_daos_degraded_ec_8to22: -u subtests="8-22"
+    test_daos_degraded_ec_8to23: -u subtests="8-23"
   scalable_endpoint:
     test_daos_degraded_mode: True
   stopped_ranks:

--- a/src/tests/suite/daos_degrade_ec.c
+++ b/src/tests/suite/daos_degrade_ec.c
@@ -18,19 +18,39 @@
 #include <daos/mgmt.h>
 #include <daos/container.h>
 
-static void
-degrade_ec_internal(void **state, int *shards, int shards_nr, int write_type)
+#define DEGRADE_SMALL_POOL_SIZE	(1ULL << 28)
+#define DEGRADE_POOL_SIZE	(1ULL << 32)
+#define DEGRADE_RANK_SIZE	(6)
+
+int
+degrade_small_sub_setup(void **state)
 {
-	test_arg_t	*arg = *state;
-	daos_obj_id_t	oid;
+	int rc;
+
+	rc = test_setup(state, SETUP_CONT_CONNECT, true,
+			DEGRADE_SMALL_POOL_SIZE, DEGRADE_RANK_SIZE, NULL);
+	if (rc)
+		print_message("It can not create the pool with 6 ranks"
+			      " probably due to not enough ranks %d\n", rc);
+
+	return rc;
+}
+
+int
+degrade_sub_setup(void **state)
+{
+	int rc;
+
+	rc = test_setup(state, SETUP_CONT_CONNECT, true,
+			DEGRADE_POOL_SIZE, DEGRADE_RANK_SIZE, NULL);
+	return rc;
+}
+
+static void
+degrade_ec_write(test_arg_t *arg, daos_obj_id_t oid, int write_type)
+{
 	struct ioreq	req;
-	d_rank_t	ranks[4] = { -1 };
-	int		idx = 0;
 
-	if (!test_runable(arg, 6))
-		return;
-
-	oid = daos_test_oid_gen(arg->coh, OC_EC_4P2G1, 0, 0, arg->myrank);
 	ioreq_init(&req, arg->coh, oid, DAOS_IOD_ARRAY, arg);
 
 	if (write_type == PARTIAL_UPDATE)
@@ -43,14 +63,15 @@ degrade_ec_internal(void **state, int *shards, int shards_nr, int write_type)
 		write_ec_partial_full(&req, arg->index, 0);
 
 	ioreq_fini(&req);
+}
 
-	while (shards_nr-- > 0) {
-		ranks[idx] = get_rank_by_oid_shard(arg, oid, shards[idx]);
-		idx++;
-	}
-	rebuild_pools_ranks(&arg, 1, ranks, idx, false);
+static void
+degrade_ec_verify(test_arg_t *arg, daos_obj_id_t oid, int write_type)
+{
+	struct ioreq	req;
 
 	ioreq_init(&req, arg->coh, oid, DAOS_IOD_ARRAY, arg);
+
 	if (write_type == PARTIAL_UPDATE)
 		verify_ec_partial(&req, arg->index, 0);
 	else if (write_type == FULL_UPDATE)
@@ -61,6 +82,29 @@ degrade_ec_internal(void **state, int *shards, int shards_nr, int write_type)
 		verify_ec_full(&req, arg->index, 0);
 
 	ioreq_fini(&req);
+}
+
+static void
+degrade_ec_internal(void **state, int *shards, int shards_nr, int write_type)
+{
+	test_arg_t	*arg = *state;
+	daos_obj_id_t	oid;
+	d_rank_t	ranks[4] = { -1 };
+	int		idx = 0;
+
+	if (!test_runable(arg, DEGRADE_RANK_SIZE))
+		return;
+
+	oid = daos_test_oid_gen(arg->coh, OC_EC_4P2G1, 0, 0, arg->myrank);
+	degrade_ec_write(arg, oid, write_type);
+
+	while (shards_nr-- > 0) {
+		ranks[idx] = get_rank_by_oid_shard(arg, oid, shards[idx]);
+		idx++;
+	}
+	rebuild_pools_ranks(&arg, 1, ranks, idx, false);
+
+	degrade_ec_verify(arg, oid, write_type);
 
 	while (idx > 0)
 		rebuild_add_back_tgts(arg, ranks[--idx], NULL, 1);
@@ -294,19 +338,78 @@ degrade_dfs_fail_data_parity_s3p0(void **state)
 	dfs_ec_rebuild_io(state, shards, 2);
 }
 
-#define DEGRADE_SMALL_POOL_SIZE (1ULL << 28)
-int
-degrade_small_sub_setup(void **state)
+static void
+degrade_multi_conts_agg(void **state)
 {
-	int rc;
+#define CONT_PER_POOL	(8)
+	test_arg_t	*arg = *state;
+	test_arg_t	*args[CONT_PER_POOL] = { 0 };
+	daos_obj_id_t	 oids[CONT_PER_POOL] = { 0 };
+	int		 fail_shards[2];
+	d_rank_t	 fail_ranks[4] = { -1 };
+	int		 shards_nr = 2;
+	int		 i;
+	int		 rc;
 
-	rc = test_setup(state, SETUP_CONT_CONNECT, true,
-			DEGRADE_SMALL_POOL_SIZE, 6, NULL);
-	if (rc)
-		print_message("It can not create the pool with 6 ranks"
-			      " probably due to not enough ranks %d\n", rc);
+	if (!test_runable(arg, DEGRADE_RANK_SIZE))
+		return;
 
-	return 0;
+	fail_shards[0] = 0;
+	fail_shards[1] = 2;
+
+	memset(args, 0, sizeof(args[0]) * CONT_PER_POOL);
+	for (i = 0; i < CONT_PER_POOL; i++) {
+		rc = test_setup((void **)&args[i], SETUP_CONT_CONNECT,
+				arg->multi_rank, DEGRADE_SMALL_POOL_SIZE,
+				DEGRADE_RANK_SIZE, &arg->pool);
+		if (rc) {
+			print_message("test_setup failed: rc %d\n", rc);
+			goto out;
+		}
+
+		args[i]->index = arg->index;
+		assert_int_equal(args[i]->pool.slave, 1);
+		oids[i] = daos_test_oid_gen(arg->coh, OC_EC_4P2G1, 0, 0,
+					    arg->myrank);
+	}
+
+	for (i = 0; i < CONT_PER_POOL; i++) {
+		if ((i % 3) == 0)
+			degrade_ec_write(args[i], oids[i], FULL_PARTIAL_UPDATE);
+		else if ((i % 3) == 1)
+			degrade_ec_write(args[i], oids[i], PARTIAL_UPDATE);
+		else
+			degrade_ec_write(args[i], oids[i], PARTIAL_FULL_UPDATE);
+	}
+
+	/* sleep a while to make aggregation triggered */
+	print_message("sleep about 25 second to wait aggregation ...\n");
+	sleep(25);
+
+	for (i = 0; i < shards_nr; i++)
+		fail_ranks[i] = get_rank_by_oid_shard(args[0], oids[0],
+						      fail_shards[i]);
+	rebuild_pools_ranks(&args[0], 1, fail_ranks, shards_nr, false);
+
+	for (i = 0; i < CONT_PER_POOL; i++) {
+		if ((i % 3) == 0)
+			degrade_ec_verify(args[i], oids[i],
+					  FULL_PARTIAL_UPDATE);
+		else if ((i % 3) == 1)
+			degrade_ec_verify(args[i], oids[i], PARTIAL_UPDATE);
+		else
+			degrade_ec_verify(args[i], oids[i],
+					  PARTIAL_FULL_UPDATE);
+	}
+
+	/* XXX Rebuild cannot finish at this step. DAOS-7073
+	 * for (i = 0; i < shards_nr; i++)
+	 *	rebuild_add_back_tgts(args[0], fail_ranks[i], NULL, 1);
+	 */
+
+out:
+	for (i = CONT_PER_POOL - 1; i >= 0; i--)
+		test_teardown((void **)&args[i]);
 }
 
 /** create a new pool/container for each test */
@@ -376,6 +479,8 @@ static const struct CMUnitTest degrade_tests[] = {
 	{"DEGRADE22: degrade io with 1data 1parity(s2, p0)",
 	 degrade_dfs_fail_data_parity_s2p0, degrade_small_sub_setup,
 	 test_teardown},
+	{"DEGRADE23: degrade io with multi-containers and aggregation",
+	 degrade_multi_conts_agg, degrade_sub_setup, test_teardown},
 };
 
 int

--- a/src/tests/suite/daos_rebuild_common.c
+++ b/src/tests/suite/daos_rebuild_common.c
@@ -570,11 +570,12 @@ rebuild_io_verify(test_arg_t *arg, daos_obj_id_t *oids, int oids_nr)
 	}
 }
 
-#define DATA_SIZE		(1048576 * 4 + 512)
-#define PARTIAL_DATA_SIZE	1024
-#define IOD3_DATA_SIZE		300
-#define LARGE_SINGLE_VALUE_SIZE	8500
-#define SMALL_SINGLE_VALUE_SIZE	32
+/* using some un-aligned size */
+#define DATA_SIZE			(1048576 * 4 + 347)
+#define PARTIAL_DATA_SIZE		(933)
+#define IOD3_DATA_SIZE			(311)
+#define LARGE_SINGLE_VALUE_SIZE		(8569)
+#define SMALL_SINGLE_VALUE_SIZE		(37)
 
 #define KEY_NR 5
 void make_buffer(char *buffer, char start, int total)
@@ -607,7 +608,6 @@ write_ec(struct ioreq *req, int index, char *data, daos_off_t off, int size)
 		recx.rx_idx = off + i * 10485760;
 		insert_recxs(key, "a_key", 1, DAOS_TX_NONE, &recx, 1,
 			     data, size, req);
-
 		recx.rx_nr = IOD3_DATA_SIZE;
 		insert_recxs(key, "a_key_iod3", 3, DAOS_TX_NONE, &recx, 1,
 			     data, IOD3_DATA_SIZE * 3, req);
@@ -615,7 +615,8 @@ write_ec(struct ioreq *req, int index, char *data, daos_off_t off, int size)
 		req->iod_type = DAOS_IOD_SINGLE;
 		memset(single_data, 'a' + i, LARGE_SINGLE_VALUE_SIZE);
 		sprintf(key, "dkey_single_small_%d_%d", index, i);
-		insert_single(key, "a_key", 0, single_data, 32, DAOS_TX_NONE,
+		insert_single(key, "a_key", 0, single_data,
+			      SMALL_SINGLE_VALUE_SIZE, DAOS_TX_NONE,
 			      req);
 
 		sprintf(key, "dkey_single_large_%d_%d", index, i);

--- a/src/vos/vos_aggregate.c
+++ b/src/vos/vos_aggregate.c
@@ -1810,7 +1810,7 @@ vos_agg_ev(daos_handle_t ih, vos_iter_entry_t *entry,
 
 	/* Aggregation */
 	D_DEBUG(DB_EPC, "oid:"DF_UOID", lgc_ext:"DF_EXT", "
-		"phy_ext:"DF_EXT", epoch:"DF_U64".%d, flags: %x\n",
+		"phy_ext:"DF_EXT", epoch:"DF_X64".%d, flags: %x\n",
 		DP_UOID(agg_param->ap_oid), DP_EXT(&lgc_ext),
 		DP_EXT(&phy_ext), entry->ie_epoch, entry->ie_minor_epc,
 		entry->ie_vis_flags);

--- a/src/vos/vos_io.c
+++ b/src/vos/vos_io.c
@@ -2472,6 +2472,8 @@ vos_obj_array_remove(daos_handle_t coh, daos_unit_oid_t oid,
 
 	rc = vos_update_end(ioh, 0 /* don't care */, (daos_key_t *)dkey, rc,
 			    NULL, NULL);
+	D_DEBUG(DB_IO, DF_UOID" remove "DF_RECX" "DF_RC"\n",
+		DP_UOID(oid), DP_RECX(*recx), DP_RC(rc));
 	return rc;
 }
 

--- a/src/vos/vos_obj_cache.c
+++ b/src/vos/vos_obj_cache.c
@@ -224,7 +224,7 @@ vos_obj_hold(struct daos_lru_cache *occ, struct vos_container *cont,
 	visible_only = flags & VOS_OBJ_VISIBLE;
 
 	D_DEBUG(DB_TRACE, "Try to hold cont="DF_UUID", obj="DF_UOID
-		" create=%s epr="DF_U64"-"DF_U64"\n",
+		" create=%s epr="DF_X64"-"DF_X64"\n",
 		DP_UUID(cont->vc_id), DP_UOID(oid),
 		create ? "true" : "false", epr->epr_lo, epr->epr_hi);
 
@@ -264,7 +264,7 @@ vos_obj_hold(struct daos_lru_cache *occ, struct vos_container *cont,
 	}
 
 	 /* newly cached object */
-	D_DEBUG(DB_TRACE, "%s Got empty obj "DF_UOID" epr="DF_U64"-"DF_U64"\n",
+	D_DEBUG(DB_TRACE, "%s Got empty obj "DF_UOID" epr="DF_X64"-"DF_X64"\n",
 		create ? "find/create" : "find", DP_UOID(oid), epr->epr_lo,
 		epr->epr_hi);
 


### PR DESCRIPTION
Fix data-corruptions -
1) Fix the diff data process related with agg_update_parity().
2) Fix a bug in obj_ec_rw_req_split() that incorrectly select
   tgt oiod on leader server (when leader is not the last parity).
3) Fix bug of ea_oid.id_shard in agg_peer_update_ult()
4) And several other small refining, such some original data type
   possibly overflow.

Enhance the code to support -
1) When aggregate leader is not the last parity target,
2) #parity_tgts > 2

Add DEGRADE23: degrade io with multi-containers and aggregation.

Signed-off-by: Xuezhao Liu <xuezhao.liu@intel.com>