### PR TITLE
DAOS-6808 rpc: fix memleak in MGMT_TGT_CREATE corpc (#5037)

### DIFF
--- a/src/cart/crt_corpc.c
+++ b/src/cart/crt_corpc.c
@@ -725,10 +725,14 @@ aggregate_done:
 	D_SPIN_UNLOCK(&parent_rpc_priv->crp_lock);
 
 	if (req_done) {
+		bool am_root;
+
 		RPC_ADDREF(parent_rpc_priv);
 		crt_corpc_complete(parent_rpc_priv);
 
-		if (co_ops && co_ops->co_post_reply)
+		am_root = (co_info->co_grp_priv->gp_self ==
+			   co_info->co_root);
+		if (co_ops && co_ops->co_post_reply && !am_root)
 			co_ops->co_post_reply(&parent_rpc_priv->crp_pub,
 					co_info->co_priv);
 		RPC_DECREF(parent_rpc_priv);

--- a/src/mgmt/srv.c
+++ b/src/mgmt/srv.c
@@ -30,6 +30,7 @@ const int max_svc_nreplicas = 13;
 static struct crt_corpc_ops ds_mgmt_hdlr_tgt_create_co_ops = {
 	.co_aggregate	= ds_mgmt_tgt_create_aggregator,
 	.co_pre_forward	= NULL,
+	.co_post_reply = ds_mgmt_tgt_create_post_reply,
 };
 
 static struct crt_corpc_ops ds_mgmt_hdlr_tgt_map_update_co_ops = {

--- a/src/mgmt/srv_internal.h
+++ b/src/mgmt/srv_internal.h
@@ -126,6 +126,7 @@ void ds_mgmt_hdlr_tgt_create(crt_rpc_t *rpc_req);
 void ds_mgmt_hdlr_tgt_destroy(crt_rpc_t *rpc_req);
 int ds_mgmt_tgt_create_aggregator(crt_rpc_t *source, crt_rpc_t *result,
 				  void *priv);
+int ds_mgmt_tgt_create_post_reply(crt_rpc_t *rpc, void *priv);
 void ds_mgmt_tgt_profile_hdlr(crt_rpc_t *rpc);
 int ds_mgmt_tgt_map_update_pre_forward(crt_rpc_t *rpc, void *arg);
 void ds_mgmt_hdlr_tgt_map_update(crt_rpc_t *rpc);

--- a/src/mgmt/srv_target.c
+++ b/src/mgmt/srv_target.c
@@ -683,6 +683,18 @@ out:
 }
 
 int
+ds_mgmt_tgt_create_post_reply(crt_rpc_t *rpc, void *priv)
+{
+	struct mgmt_tgt_create_out	*tc_out;
+
+	tc_out = crt_reply_get(rpc);
+	D_FREE(tc_out->tc_tgt_uuids.ca_arrays);
+	D_FREE(tc_out->tc_ranks.ca_arrays);
+
+	return 0;
+}
+
+int
 ds_mgmt_tgt_create_aggregator(crt_rpc_t *source, crt_rpc_t *result,
 			      void *priv)
 {


### PR DESCRIPTION
1. provide co_post_reply to free memory
2. change corpc to not call co_post_reply on root node.

Signed-off-by: Xuezhao Liu <xuezhao.liu@intel.com>