### PR TITLE
DAOS-6970 iv: avoid pool connect/disconnect failure (#4903)

### DIFF
--- a/src/cart/crt_corpc.c
+++ b/src/cart/crt_corpc.c
@@ -108,9 +108,13 @@ crt_corpc_initiate(struct crt_rpc_priv *rpc_priv)
 		if (grp_priv != NULL) {
 			grp_ref_taken = true;
 		} else {
-			D_ERROR("crt_grp_lookup_grpid: %s failed.\n",
-				co_hdr->coh_grpid);
-			D_GOTO(out, rc = -DER_INVAL);
+			/* the local SG does not match others SG, so let's
+			 * return GRPVER to retry until pool map is updated
+			 * or the pool is stopped.
+			 */
+			D_ERROR("crt_grp_lookup_grpid: %s failed: %d\n",
+				co_hdr->coh_grpid, -DER_GRPVER);
+			D_GOTO(out, rc = -DER_GRPVER);
 		}
 	}
 

--- a/src/container/srv_container.c
+++ b/src/container/srv_container.c
@@ -1635,6 +1635,16 @@ cont_close_recs(crt_context_t ctx, struct cont_svc *svc,
 		rc = cont_iv_capability_invalidate(
 				svc->cs_pool->sp_iv_ns,
 				recs[i].tcr_hdl, CRT_IV_SYNC_EAGER);
+		if (rc == -DER_SHUTDOWN) {
+			/* If one of rank is being stopped, it may
+			 * return -DER_SHUTDOWN, which can be ignored
+			 * during capability invalidate.
+			 */
+			D_DEBUG(DF_DSMS, DF_CONT"/"DF_UUID" fail %d",
+				DP_CONT(svc->cs_pool_uuid, NULL),
+				DP_UUID(recs[i].tcr_hdl), rc);
+			rc = 0;
+		}
 		if (rc)
 			D_GOTO(out, rc);
 	}

--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -1836,8 +1836,14 @@ pool_connect_iv_dist(struct pool_svc *svc, uuid_t pool_hdl,
 
 	rc = ds_pool_iv_conn_hdl_update(svc->ps_pool, pool_hdl, flags,
 					sec_capas, cred);
-	if (rc)
+	if (rc) {
+		if (rc == -DER_SHUTDOWN) {
+			D_DEBUG(DF_DSMS, DF_UUID":"DF_UUID" some ranks stop.\n",
+				DP_UUID(svc->ps_uuid), DP_UUID(pool_hdl));
+			rc = 0;
+		}
 		D_GOTO(out, rc);
+	}
 out:
 	D_DEBUG(DF_DSMS, DF_UUID": bcasted: "DF_RC"\n", DP_UUID(svc->ps_uuid),
 		DP_RC(rc));


### PR DESCRIPTION
1. If the rank is being stopped, then iv operation might
return DER_SHUTDOWN, let's ignore such failure for pool
disconnect/connect.

2. Return GRPVER if the group can not be found in local
SG, so let's the caller retry until the rank is excluded
from the pool map or the pool service is stopped.

Signed-off-by: Di Wang <di.wang@intel.com>