### PR TITLE
DAOS-6783 bio: timeout for spdk_subsystem_fini() (#4977)

### DIFF
--- a/src/bio/bio_buffer.c
+++ b/src/bio/bio_buffer.c
@@ -756,8 +756,11 @@ dma_rw(struct bio_desc *biod, bool prep)
 	}
 
 	if (xs_ctxt->bxc_tgt_id == -1) {
+		int	rc;
+
 		D_DEBUG(DB_IO, "Self poll completion, blob:%p\n", blob);
-		xs_poll_completion(xs_ctxt, &biod->bd_inflights);
+		rc = xs_poll_completion(xs_ctxt, &biod->bd_inflights, 0);
+		D_ASSERT(rc == 0);
 	} else {
 		biod->bd_dma_issued = 1;
 		if (biod->bd_inflights != 0)

--- a/src/bio/bio_context.c
+++ b/src/bio/bio_context.c
@@ -173,7 +173,8 @@ blob_wait_completion(struct bio_xs_context *xs_ctxt, struct blob_cp_arg *ba)
 	D_ASSERT(xs_ctxt != NULL);
 	if (xs_ctxt->bxc_tgt_id == -1) {
 		D_DEBUG(DB_IO, "Self poll xs_ctxt:%p\n", xs_ctxt);
-		xs_poll_completion(xs_ctxt, &ba->bca_inflights);
+		rc = xs_poll_completion(xs_ctxt, &ba->bca_inflights, 0);
+		D_ASSERT(rc == 0);
 	} else {
 		rc = ABT_eventual_wait(ba->bca_eventual, NULL);
 		if (rc != ABT_SUCCESS)

--- a/src/bio/bio_internal.h
+++ b/src/bio/bio_internal.h
@@ -268,7 +268,8 @@ struct media_error_msg {
 extern unsigned int	bio_chk_sz;
 extern unsigned int	bio_chk_cnt_max;
 extern uint64_t		io_stat_period;
-void xs_poll_completion(struct bio_xs_context *ctxt, unsigned int *inflights);
+int xs_poll_completion(struct bio_xs_context *ctxt, unsigned int *inflights,
+		       uint64_t timeout);
 void bio_bdev_event_cb(enum spdk_bdev_event_type type, struct spdk_bdev *bdev,
 		       void *event_ctx);
 struct spdk_thread *init_thread(void);

--- a/src/engine/sched.c
+++ b/src/engine/sched.c
@@ -415,7 +415,7 @@ sched_info_init(struct dss_xstream *dx)
 	struct sched_info	*info = &dx->dx_sched_info;
 	int			 rc;
 
-	info->si_cur_ts = daos_getntime_coarse() / NSEC_PER_MSEC;
+	info->si_cur_ts = daos_getmtime_coarse();
 	info->si_stats.ss_tot_time = 0;
 	info->si_stats.ss_relax_time = 0;
 	info->si_stats.ss_busy_ts = info->si_cur_ts;
@@ -1091,7 +1091,7 @@ wakeup_all(struct dss_xstream *dx)
 	uint64_t		 cur_ts;
 
 	/* Update current ts stored in sched_info */
-	cur_ts = daos_getntime_coarse() / NSEC_PER_MSEC;
+	cur_ts = daos_getmtime_coarse();
 	D_ASSERT(cur_ts >= info->si_cur_ts);
 	info->si_stats.ss_tot_time += (cur_ts - info->si_cur_ts);
 	info->si_cur_ts = cur_ts;

--- a/src/include/daos/common.h
+++ b/src/include/daos/common.h
@@ -224,6 +224,12 @@ daos_getntime_coarse(void)
 }
 
 static inline uint64_t
+daos_getmtime_coarse(void)
+{
+	return daos_getntime_coarse() / NSEC_PER_MSEC;
+}
+
+static inline uint64_t
 daos_getutime(void)
 {
 	struct timespec tv;


### PR DESCRIPTION
spdk_subsystem_fini() won't run to completion if any bdev is
held by open blobs, we set a timeout as temporary workaround.

This patch makes 'dmg system stop' able to shutdown io engine
even when there are leakded ds_pool_child holding opened blob.

Cleanup ds_pool_child on shutdown (even when pool connected,
container opened) will be fixed in other ticket.

Signed-off-by: Niu Yawei <yawei.niu@intel.com>