### PR TITLE
DAOS-6842

### DIFF
--- a/src/tests/ftest/launch.py
+++ b/src/tests/ftest/launch.py
@@ -1549,6 +1549,8 @@ def install_debuginfos():
     install_pkgs = [{'name': 'gdb'}]
 
     cmds = []
+    timeout_cmd = "timeout"
+    timeout_wait = "5m"
 
     # -debuginfo packages that don't get installed with debuginfo-install
     for pkg in ['python', 'daos', 'systemd', 'ndctl', 'mercury', 'hdf5']:
@@ -1573,9 +1575,11 @@ def install_debuginfos():
             raise RuntimeError(
                 "install_debuginfos(): Unsupported distro: {}".format(
                     distro_info))
-        cmds.append(["sudo", "yum", "-y", "install"] + yum_args)
+        cmds.append(["sudo", timeout_cmd, timeout_wait,
+                     "yum", "-y", "install"] + yum_args)
         cmds.append(
-            ["sudo", "debuginfo-install", "--enablerepo=*-debuginfo", "-y"] +
+            ["sudo", timeout_cmd, timeout_wait,
+             "debuginfo-install", "--enablerepo=*-debuginfo", "-y"] +
             yum_args + ["daos-server", "gcc"])
     else:
         # We're not using the yum API to install packages
@@ -1597,7 +1601,8 @@ def install_debuginfos():
     # yum_base.processTransaction(rpmDisplay=yum.rpmtrans.NoOutputCallBack())
 
     # Now install a few pkgs that debuginfo-install wouldn't
-    cmd = ["sudo", "yum", "-y", "--enablerepo=*debug*", "install"]
+    cmd = ["sudo", timeout_cmd, timeout_wait,
+           "yum", "-y", "--enablerepo=*debug*", "install"]
     for pkg in install_pkgs:
         try:
             cmd.append(


### PR DESCRIPTION
DAOS-6842 test: Functional tests hanging up on yum install of debuginfo packages

    Added a timeout of 5m to yum install commands to avoid
    functional tests to hang indefinitely.

    Test-tag: test_core_files

Signed-off-by: Omar Ocampo <omar.ocampo.coronado@intel.com>