### PR TITLE
DAOS-7064 object: EEXIST or NOEXIST for conditional ops should not be logged as errors (#5094)

### DIFF
--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -102,7 +102,8 @@ obj_rw_complete(crt_rpc_t *rpc, unsigned int map_version,
 
 		if (rc != 0) {
 			D_CDEBUG(rc == -DER_REC2BIG || rc == -DER_INPROGRESS ||
-				 rc == -DER_TX_RESTART,
+				 rc == -DER_TX_RESTART || rc == -DER_EXIST ||
+				 rc == -DER_NONEXIST,
 				 DLOG_DBG, DLOG_ERR,
 				 DF_UOID " %s end failed: %d\n",
 				 DP_UOID(orwi->orw_oid),


### PR DESCRIPTION
just change the error to debug.

Signed-off-by: <Mohamad Chaarawi mohamad.chaarawi@intel.com>