### PR TITLE
DAOS-6996 packaging: Move libdts.so to daos-tests

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+daos (1.3.0-4) unstable; urgency=medium
+  [ Brian J. Murrell ]
+  * Move libdts.so to the daos-tests subpackage
+
+ -- Brian J. Murrell <brian.murrell@intel.com>  Mon, 22 Mar 2021 16:35:14 -0400
+
 daos (1.3.0-2) unstable; urgency=medium
   [ Li Wei ]
   * Require raft-devel 0.7.3 that fixes an unstable leadership problem caused

--- a/debian/daos-client.install
+++ b/debian/daos-client.install
@@ -13,7 +13,6 @@ usr/lib64/libdfuse.so
 usr/lib64/libioil.so
 usr/lib64/libdfs_internal.so
 usr/lib64/libvos_size.so
-usr/lib64/libdts.so
 usr/lib64/python3/site-packages/pydaos/*.py
 usr/lib64/python3/site-packages/storage_estimator/*.py
 usr/lib64/python3/site-packages/pydaos/pydaos_shim_3.so

--- a/debian/daos-tests.install
+++ b/debian/daos-tests.install
@@ -24,6 +24,7 @@ usr/bin/daos_gen_io_conf
 usr/bin/daos_run_io_conf
 usr/bin/crt_launch
 usr/bin/fault_status
+usr/lib64/libdts.so
 etc/daos/fault-inject-cart.yaml
 # For avocado tests
 usr/lib/daos/.build_vars.json

--- a/utils/rpms/daos.spec
+++ b/utils/rpms/daos.spec
@@ -8,7 +8,7 @@
 
 Name:          daos
 Version:       1.3.0
-Release:       3%{?relval}%{?dist}
+Release:       4%{?relval}%{?dist}
 Summary:       DAOS Storage Engine
 
 License:       BSD-2-Clause-Patent
@@ -346,7 +346,6 @@ getent passwd daos_agent >/dev/null || useradd -s /sbin/nologin -r -g daos_agent
 %{_libdir}/libioil.so
 %{_libdir}/libdfs_internal.so
 %{_libdir}/libvos_size.so
-%{_libdir}/libdts.so
 %dir %{_libdir}/python3/site-packages/pydaos
 %dir %{_libdir}/python3/site-packages/storage_estimator
 %{_libdir}/python3/site-packages/pydaos/*.py
@@ -394,6 +393,7 @@ getent passwd daos_agent >/dev/null || useradd -s /sbin/nologin -r -g daos_agent
 # For avocado tests
 %{_prefix}/lib/daos/.build_vars.json
 %{_prefix}/lib/daos/.build_vars.sh
+%{_libdir}/libdts.so
 
 %files devel
 %{_includedir}/*
@@ -401,6 +401,9 @@ getent passwd daos_agent >/dev/null || useradd -s /sbin/nologin -r -g daos_agent
 %{_libdir}/*.a
 
 %changelog
+* Mon Mar 22 2021 Brian J. Murrell <brian.murrell@intel.com> - 1.3.0-4
+- Move libdts.so to the daos-tests subpackage
+
 * Thu Mar 18 2021 Maureen Jean <maureen.jean@intel.com> 1.3.0-3
 - Update to python3
 


### PR DESCRIPTION
As it introduces a dependency on OpenMPI which we don't want in the
client package.  Additionally, libdts.so is only used by test tools.