### PR TITLE
DAOS-7074 control: support multiple hyphens in hostlist names

### DIFF
--- a/src/control/lib/hostlist/hostlist.go
+++ b/src/control/lib/hostlist/hostlist.go
@@ -17,7 +17,9 @@ import (
 )
 
 var (
-	ErrEmpty    = errors.New("hostlist is empty")
+	// ErrEmpty indicates empty host list
+	ErrEmpty = errors.New("hostlist is empty")
+	// ErrNotFound indicates valid hostname could not be found
 	ErrNotFound = errors.New("hostname not found")
 )
 
@@ -54,8 +56,8 @@ func (hn *hostName) Parse(input string) error {
 	// prefixN (default)
 	re := regexp.MustCompile(`^([a-zA-Z]+)(\d+)?(.*)?`)
 	if strings.Contains(input, "-") {
-		// handle hosts in the format prefixN-N
-		re = regexp.MustCompile(`^(\w+-?)(\d+)?(.*)?`)
+		// handle hosts with one or more hyphens in name
+		re = regexp.MustCompile(`^([a-zA-Z0-9\-]+\-)(\d+)?(.*)?`)
 	}
 
 	matches := re.FindStringSubmatch(input)
@@ -687,7 +689,7 @@ func (hl *HostList) DeleteNth(n int) error {
 		return err
 	}
 
-	hl.hostCount -= 1
+	hl.hostCount--
 
 	if newHr != nil {
 		hl.insertRangeAt(idx+1, newHr)

--- a/src/control/lib/hostlist/hostlist_test.go
+++ b/src/control/lib/hostlist/hostlist_test.go
@@ -136,6 +136,30 @@ func TestHostList_Create(t *testing.T) {
 			startList: "[0-1,3-5]",
 			expErr:    errors.New("invalid range"),
 		},
+		"single hyphen": {
+			startList:    "dserver-0001,dserver-0002,dserver-0003",
+			expRawOut:    "dserver-[0001-0003]",
+			expUniqOut:   "dserver-[0001-0003]",
+			expUniqCount: 3,
+		},
+		"multiple hyphens": {
+			startList:    "d-server-0001,d-server-0002,d-server-0003",
+			expRawOut:    "d-server-[0001-0003]",
+			expUniqOut:   "d-server-[0001-0003]",
+			expUniqCount: 3,
+		},
+		"multiple hyphens range": {
+			startList:    "d-server-[0001-0003]",
+			expRawOut:    "d-server-[0001-0003]",
+			expUniqOut:   "d-server-[0001-0003]",
+			expUniqCount: 3,
+		},
+		"multiple hyphens with suffix": {
+			startList:    "d-server-0001ab,d-server-0002ab",
+			expRawOut:    "d-server-[0001-0002]ab",
+			expUniqOut:   "d-server-[0001-0002]ab",
+			expUniqCount: 2,
+		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			hl, gotErr := hostlist.Create(tc.startList)

--- a/src/control/lib/hostlist/hostset_test.go
+++ b/src/control/lib/hostlist/hostset_test.go
@@ -37,6 +37,16 @@ func TestHostSet_Create(t *testing.T) {
 			expOut:    "server[1,3,5,7,9]:10000,server[2,4,6,8,10]:10001",
 			expCount:  10,
 		},
+		"single hyphen": {
+			startList: "dserver-0001,dserver-0002,dserver-0003",
+			expOut:    "dserver-[0001-0003]",
+			expCount:  3,
+		},
+		"multiple hyphens": {
+			startList: "d-server-j-0001,d-server-j-0002,d-server-j-0003",
+			expOut:    "d-server-j-[0001-0003]",
+			expCount:  3,
+		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			hs, gotErr := hostlist.CreateSet(tc.startList)


### PR DESCRIPTION
Accept multiple hyphens in hostname when parsing and coalescing
hostlists. Make the assumption that the numeric identifier to be ranged
occurs after the rightmost hyphen.

daos-server-j-0001,daos-server-j-0002,daos-server-j-0001 will now be
compressed into daos-server-j-[0001-0003] by the hostlist library.

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>