### PR TITLE
DAOS-6661 Test: Fix EC rebuild disabled tests because of recent regression in IOR utile library.

### DIFF
--- a/src/tests/ftest/erasurecode/ec_rebuild_disabled.py
+++ b/src/tests/ftest/erasurecode/ec_rebuild_disabled.py
@@ -17,7 +17,7 @@ class EcDisabledRebuild(ErasureCodeIor):
     :avocado: recursive
     """
 
-    @skipForTicket("DAOS-6660")
+    #@skipForTicket("DAOS-6660")
     def test_ec_degrade(self):
         """Jira ID: DAOS-5893.
 
@@ -38,7 +38,8 @@ class EcDisabledRebuild(ErasureCodeIor):
 
         # Kill the last server rank and wait for 20 seconds, Rebuild is disabled
         # so data should not be rebuild
-        self.server_managers[0].stop_ranks([self.server_count - 1], self.d_log)
+        self.server_managers[0].stop_ranks([self.server_count - 1], self.d_log,
+                                           force=True)
         time.sleep(20)
 
         # Read IOR data and verify for different EC object and different sizes
@@ -47,7 +48,8 @@ class EcDisabledRebuild(ErasureCodeIor):
 
         # Kill the another server rank and wait for 20 seconds,Rebuild will
         # not happens because i's disabled.Read/verify data with Parity 2.
-        self.server_managers[0].stop_ranks([self.server_count - 2], self.d_log)
+        self.server_managers[0].stop_ranks([self.server_count - 2], self.d_log,
+                                           force=True)
         time.sleep(20)
 
         # Read IOR data and verify for different EC object and different sizes

--- a/src/tests/ftest/erasurecode/ec_rebuild_disabled.py
+++ b/src/tests/ftest/erasurecode/ec_rebuild_disabled.py
@@ -17,7 +17,7 @@ class EcDisabledRebuild(ErasureCodeIor):
     :avocado: recursive
     """
 
-    #@skipForTicket("DAOS-6660")
+    @skipForTicket("DAOS-6660")
     def test_ec_degrade(self):
         """Jira ID: DAOS-5893.
 

--- a/src/tests/ftest/util/ec_utils.py
+++ b/src/tests/ftest/util/ec_utils.py
@@ -100,8 +100,7 @@ class ErasureCodeIor(ServerFillUp):
                 # Create the new container with correct redundancy factor
                 # for EC object type
                 self.ec_contaier_create(oclass[0])
-                self.update_ior_cmd_with_pool(oclass=oclass[0],
-                                              create_cont=False)
+                self.update_ior_cmd_with_pool(create_cont=False)
                 # Start IOR Write
                 self.container.uuid = self.ec_container.uuid
                 self.start_ior_load(operation="WriteRead", percent=1,


### PR DESCRIPTION
Quick-Functional: true
Test-tag: ec_disabled_rebuild

Signed-off-by: Samir Raval <samir.raval@intel.com>