### PR TITLE
DAOS-7038 mgmt: Reduce logging noise

### DIFF
--- a/src/engine/drpc_client.c
+++ b/src/engine/drpc_client.c
@@ -296,8 +296,14 @@ ds_get_pool_svc_ranks(uuid_t pool_uuid, d_rank_list_t **svc_ranks)
 	}
 
 	if (gps_resp->status != 0) {
-		D_ERROR("failure fetching svc_ranks for "DF_UUID": "DF_RC"\n",
-			DP_UUID(pool_uuid), DP_RC(gps_resp->status));
+		if (gps_resp->status == -DER_NONEXIST) /* not an error */
+			D_DEBUG(DB_MGMT, "pool svc "DF_UUID" not found: "
+				DF_RC"\n",
+				DP_UUID(pool_uuid), DP_RC(gps_resp->status));
+		else
+			D_ERROR("failure fetching svc_ranks for "DF_UUID": "
+				DF_RC"\n",
+				DP_UUID(pool_uuid), DP_RC(gps_resp->status));
 		D_GOTO(out_resp, rc = gps_resp->status);
 	}
 

--- a/src/mgmt/srv.c
+++ b/src/mgmt/srv.c
@@ -373,7 +373,10 @@ void ds_mgmt_pool_get_svcranks_hdlr(crt_rpc_t *rpc)
 	out = crt_reply_get(rpc);
 
 	rc =  ds_get_pool_svc_ranks(in->gsr_puuid, &out->gsr_ranks);
-	if (rc != 0)
+	if (rc == -DER_NONEXIST) /* not an error */
+		D_DEBUG(DB_MGMT, DF_UUID": get_pool_svc_ranks() upcall failed, "
+			DF_RC"\n", DP_UUID(in->gsr_puuid), DP_RC(rc));
+	else if (rc != 0)
 		D_ERROR(DF_UUID": get_pool_svc_ranks() upcall failed, "
 			DF_RC"\n", DP_UUID(in->gsr_puuid), DP_RC(rc));
 	out->gsr_rc = rc;


### PR DESCRIPTION
A user could pass a nonexistent pool ID during normal operation.
This shouldn't be logged as an error.

Signed-off-by: Kris Jacque <kristin.jacque@intel.com>