### PR TITLE
DAOS-6767 Test: Update the config function to use default server config path. (#4604)

### DIFF
--- a/src/tests/ftest/daos_test/daos_core_test-nvme_recovery.py
+++ b/src/tests/ftest/daos_test/daos_core_test-nvme_recovery.py
@@ -7,7 +7,6 @@
 from apricot import skipForTicket
 from daos_core_base import DaosCoreBase
 
-
 class DaosCoreTestNvme(DaosCoreBase):
     # pylint: disable=too-many-ancestors
     """Run just the daos_test NVMe Recovery tests.

--- a/src/tests/suite/daos_nvme_recovery.c
+++ b/src/tests/suite/daos_nvme_recovery.c
@@ -253,7 +253,7 @@ nvme_test_verify_device_stats(void **state)
 	 * different state of NVMe drives. Skip the test if log_mask is not
 	 * set to DEBUG.
 	 */
-	D_ALLOC(server_config_file, 512);
+	D_ALLOC(server_config_file, DAOS_SERVER_CONF_LENGTH);
 	D_ALLOC(log_file, 1024);
 	rc = get_server_config(devices[rank_pos].host,
 			       server_config_file);
@@ -533,7 +533,7 @@ nvme_test_simulate_IO_error(void **state)
 	 * Get DAOS server file
 	 */
 	D_ALLOC(control_log_file, 1024);
-	D_ALLOC(server_config_file, 512);
+	D_ALLOC(server_config_file, DAOS_SERVER_CONF_LENGTH);
 	rc = get_server_config(devices[rank_pos].host, server_config_file);
 	assert_rc_equal(rc, 0);
 	print_message("server_config_file = %s\n", server_config_file);

--- a/src/tests/suite/daos_test.h
+++ b/src/tests/suite/daos_test.h
@@ -82,6 +82,8 @@ extern const char *test_io_conf;
 
 extern int daos_event_priv_reset(void);
 #define TEST_RANKS_MAX_NUM	(13)
+#define DAOS_SERVER_CONF	"/etc/daos/daos_server.yml"
+#define DAOS_SERVER_CONF_LENGTH		512
 
 /* the pool used for daos test suite */
 struct test_pool {

--- a/src/tests/suite/daos_test_common.c
+++ b/src/tests/suite/daos_test_common.c
@@ -1039,6 +1039,7 @@ get_server_config(char *host, char *server_config_file)
 	char    *dpid;
 	int	rc;
 	char    daos_proc[16] = "daos_server";
+	bool	conf = true;
 
 	D_ALLOC(dpid, 16);
 	rc = get_pid_of_process(host, dpid, daos_proc);
@@ -1057,29 +1058,39 @@ get_server_config(char *host, char *server_config_file)
 	while ((read = getline(&line, &len, fp)) != -1) {
 		print_message("line %s", line);
 		if (strstr(line, "--config") != NULL ||
-		    strstr(line, "-o") != NULL)
+		    strstr(line, "-o") != NULL) {
+			conf = false;
 			break;
+		}
 	}
 
-	pch = strtok(line, " ");
-	while (pch != NULL) {
-		if (strstr(pch, "--config") != NULL) {
-			if (strchr(pch, '=') != NULL)
-				strcpy(server_config_file,
-				       strchr(pch, '=') + 1);
-			else {
-				pch = strtok(NULL, " ");
-				strcpy(server_config_file, pch);
+	if (conf)
+		strncpy(server_config_file, DAOS_SERVER_CONF,
+			DAOS_SERVER_CONF_LENGTH);
+	else {
+		pch = strtok(line, " ");
+		while (pch != NULL) {
+			if (strstr(pch, "--config") != NULL) {
+				if (strchr(pch, '=') != NULL)
+					strncpy(server_config_file,
+						strchr(pch, '=') + 1,
+						DAOS_SERVER_CONF_LENGTH);
+				else {
+					pch = strtok(NULL, " ");
+					strncpy(server_config_file, pch,
+						DAOS_SERVER_CONF_LENGTH);
+				}
+				break;
 			}
-			break;
-		}
 
-		if (strstr(pch, "-o") != NULL) {
+			if (strstr(pch, "-o") != NULL) {
+				pch = strtok(NULL, " ");
+				strncpy(server_config_file, pch,
+					DAOS_SERVER_CONF_LENGTH);
+				break;
+			}
 			pch = strtok(NULL, " ");
-			strcpy(server_config_file, pch);
-			break;
 		}
-		pch = strtok(NULL, " ");
 	}
 
 	pclose(fp);


### PR DESCRIPTION
Updated get_server_config() to use the default config file when daos server started with systemd.

Quick-Functional: true
Test-tag: daos_core_test_nvme

Signed-off-by: Samir Raval <samir.raval@intel.com>