### PR TITLE
DAOS-623 build: Do not try and install the python3 package (#5127)

### DIFF
--- a/ci/provisioning/post_provision_config_nodes_EL_7.sh
+++ b/ci/provisioning/post_provision_config_nodes_EL_7.sh
@@ -38,9 +38,6 @@ group_repo_post() {
 }
 
 distro_custom() {
-    # shellcheck disable=SC2086
-    time dnf -y install python3
-
     if [ ! -e /usr/bin/pip3 ] &&
        [ -e /usr/bin/pip3.6 ]; then
         ln -s pip3.6 /usr/bin/pip3


### PR DESCRIPTION
The package is already installed, and for some reason dnf
takes a long time to establist this.

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>