### PR TITLE
DAOS-7066 control: populate system name in control api

### DIFF
--- a/doc/man/man8/dmg.8
+++ b/doc/man/man8/dmg.8
@@ -1,4 +1,4 @@
-.TH dmg 1 "23 March 2021"
+.TH dmg 1 "12 April 2021"
 .SH NAME
 dmg \- Administrative tool for managing DAOS clusters
 .SH SYNOPSIS
@@ -139,9 +139,6 @@ Per-server NVMe allocation for DAOS pool (manual)
 .TP
 \fB\fB\-r\fR, \fB\-\-ranks\fR\fP
 Storage server unique identifiers (ranks) for DAOS pool
-.TP
-\fB\fB\-S\fR, \fB\-\-sys\fR <default: \fI"daos_server"\fR>\fP
-DAOS system that pool is to be a part of
 .SS pool delete-acl
 Delete an entry from a DAOS pool's Access Control List
 
@@ -198,9 +195,6 @@ Evict all pool connections to a DAOS pool
 .TP
 \fB\fB\-\-pool\fR (\fIrequired\fR)\fP
 Unique ID of DAOS pool
-.TP
-\fB\fB\-S\fR, \fB\-\-sys\fR <default: \fI"daos_server"\fR>\fP
-DAOS system that the pools connections be evicted from.
 .SS pool exclude
 Exclude targets from a rank
 

--- a/src/control/cmd/daos_agent/procmon.go
+++ b/src/control/cmd/daos_agent/procmon.go
@@ -238,7 +238,8 @@ func (p *procMon) cleanupLeakedHandles(ctx context.Context, info *procInfo) {
 		p.log.Debugf("Cleaning up %d leaked handles from Pool UUID: %s\n", len(element), poolUUID)
 
 		handles := handleMapToList(info.handles[poolUUID])
-		req := &control.PoolEvictReq{UUID: poolUUID, Sys: p.systemName, Handles: handles}
+		req := &control.PoolEvictReq{UUID: poolUUID, Handles: handles}
+		req.SetSystem(p.systemName)
 
 		err := control.PoolEvict(ctx, p.ctlInvoker, req)
 		if err != nil {

--- a/src/control/cmd/dmg/pool_test.go
+++ b/src/control/cmd/dmg/pool_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
 
-	"github.com/daos-stack/daos/src/control/build"
 	"github.com/daos-stack/daos/src/control/common"
 	. "github.com/daos-stack/daos/src/control/common"
 	mgmtpb "github.com/daos-stack/daos/src/control/common/proto/mgmt"
@@ -36,16 +35,6 @@ func createACLFile(t *testing.T, dir string, acl *control.AccessControlList) str
 	t.Helper()
 
 	return common.CreateTestFile(t, dir, control.FormatACLDefault(acl))
-}
-
-func createWithSystem(req *control.PoolCreateReq, system string) *control.PoolCreateReq {
-	req.SetSystem(system)
-	return req
-}
-
-func evictWithSystem(req *control.PoolEvictReq, system string) *control.PoolEvictReq {
-	req.SetSystem(system)
-	return req
 }
 
 func TestPoolCommands(t *testing.T) {
@@ -130,13 +119,13 @@ func TestPoolCommands(t *testing.T) {
 			"Create pool with minimal arguments",
 			fmt.Sprintf("pool create --scm-size %s --nsvc 3", testScmSizeStr),
 			strings.Join([]string{
-				printRequest(t, createWithSystem(&control.PoolCreateReq{
+				printRequest(t, &control.PoolCreateReq{
 					ScmBytes:   uint64(testScmSize),
 					NumSvcReps: 3,
 					User:       eUsr.Username + "@",
 					UserGroup:  eGrp.Name + "@",
 					Ranks:      []system.Rank{},
-				}, build.DefaultSystemName)),
+				}),
 			}, " "),
 			nil,
 		},
@@ -144,23 +133,23 @@ func TestPoolCommands(t *testing.T) {
 			"Create pool with auto storage parameters",
 			fmt.Sprintf("pool create --size %s --scm-ratio 2 --nranks 8", testScmSizeStr),
 			strings.Join([]string{
-				printRequest(t, createWithSystem(&control.PoolCreateReq{
+				printRequest(t, &control.PoolCreateReq{
 					TotalBytes: uint64(testScmSize),
 					ScmRatio:   0.02,
 					NumRanks:   8,
 					User:       eUsr.Username + "@",
 					UserGroup:  eGrp.Name + "@",
 					Ranks:      []system.Rank{},
-				}, build.DefaultSystemName)),
+				}),
 			}, " "),
 			nil,
 		},
 		{
 			"Create pool with all arguments",
-			fmt.Sprintf("pool create --scm-size %s --nsvc 3 --user foo --group bar --nvme-size %s --sys fnord --acl-file %s",
+			fmt.Sprintf("pool create --scm-size %s --nsvc 3 --user foo --group bar --nvme-size %s --acl-file %s",
 				testScmSizeStr, testNvmeSizeStr, testACLFile),
 			strings.Join([]string{
-				printRequest(t, createWithSystem(&control.PoolCreateReq{
+				printRequest(t, &control.PoolCreateReq{
 					ScmBytes:   uint64(testScmSize),
 					NvmeBytes:  uint64(testNvmeSize),
 					NumSvcReps: 3,
@@ -168,16 +157,16 @@ func TestPoolCommands(t *testing.T) {
 					UserGroup:  "bar@",
 					Ranks:      []system.Rank{},
 					ACL:        testACL,
-				}, "fnord")),
+				}),
 			}, " "),
 			nil,
 		},
 		{
 			"Create pool with raw byte count size args",
-			fmt.Sprintf("pool create --scm-size %s --nsvc 3 --user foo --group bar --nvme-size %s --sys fnord --acl-file %s",
+			fmt.Sprintf("pool create --scm-size %s --nsvc 3 --user foo --group bar --nvme-size %s --acl-file %s",
 				strconv.Itoa(testScmSize), strconv.Itoa(testNvmeSize), testACLFile),
 			strings.Join([]string{
-				printRequest(t, createWithSystem(&control.PoolCreateReq{
+				printRequest(t, &control.PoolCreateReq{
 					ScmBytes:   uint64(testScmSize),
 					NvmeBytes:  uint64(testNvmeSize),
 					NumSvcReps: 3,
@@ -185,7 +174,7 @@ func TestPoolCommands(t *testing.T) {
 					UserGroup:  "bar@",
 					Ranks:      []system.Rank{},
 					ACL:        testACL,
-				}, "fnord")),
+				}),
 			}, " "),
 			nil,
 		},
@@ -193,13 +182,13 @@ func TestPoolCommands(t *testing.T) {
 			"Create pool with user and group domains",
 			fmt.Sprintf("pool create --scm-size %s --nsvc 3 --user foo@home --group bar@home", testScmSizeStr),
 			strings.Join([]string{
-				printRequest(t, createWithSystem(&control.PoolCreateReq{
+				printRequest(t, &control.PoolCreateReq{
 					ScmBytes:   uint64(testScmSize),
 					NumSvcReps: 3,
 					User:       "foo@home",
 					UserGroup:  "bar@home",
 					Ranks:      []system.Rank{},
-				}, build.DefaultSystemName)),
+				}),
 			}, " "),
 			nil,
 		},
@@ -207,13 +196,13 @@ func TestPoolCommands(t *testing.T) {
 			"Create pool with user but no group",
 			fmt.Sprintf("pool create --scm-size %s --nsvc 3 --user foo", testScmSizeStr),
 			strings.Join([]string{
-				printRequest(t, createWithSystem(&control.PoolCreateReq{
+				printRequest(t, &control.PoolCreateReq{
 					ScmBytes:   uint64(testScmSize),
 					NumSvcReps: 3,
 					User:       "foo@",
 					UserGroup:  eGrp.Name + "@",
 					Ranks:      []system.Rank{},
-				}, build.DefaultSystemName)),
+				}),
 			}, " "),
 			nil,
 		},
@@ -221,13 +210,13 @@ func TestPoolCommands(t *testing.T) {
 			"Create pool with group but no user",
 			fmt.Sprintf("pool create --scm-size %s --nsvc 3 --group foo", testScmSizeStr),
 			strings.Join([]string{
-				printRequest(t, createWithSystem(&control.PoolCreateReq{
+				printRequest(t, &control.PoolCreateReq{
 					ScmBytes:   uint64(testScmSize),
 					NumSvcReps: 3,
 					User:       eUsr.Username + "@",
 					UserGroup:  "foo@",
 					Ranks:      []system.Rank{},
-				}, build.DefaultSystemName)),
+				}),
 			}, " "),
 			nil,
 		},
@@ -397,9 +386,9 @@ func TestPoolCommands(t *testing.T) {
 			"Evict pool",
 			"pool evict --pool 031bcaf8-f0f5-42ef-b3c5-ee048676dceb",
 			strings.Join([]string{
-				printRequest(t, evictWithSystem(&control.PoolEvictReq{
+				printRequest(t, &control.PoolEvictReq{
 					UUID: "031bcaf8-f0f5-42ef-b3c5-ee048676dceb",
-				}, build.DefaultSystemName)),
+				}),
 			}, " "),
 			nil,
 		},
@@ -407,7 +396,7 @@ func TestPoolCommands(t *testing.T) {
 			"List pools",
 			"pool list",
 			strings.Join([]string{
-				printRequest(t, listWithSystem(&control.ListPoolsReq{}, build.DefaultSystemName)),
+				printRequest(t, &control.ListPoolsReq{}),
 			}, " "),
 			nil,
 		},

--- a/src/control/cmd/dmg/system.go
+++ b/src/control/cmd/dmg/system.go
@@ -46,7 +46,6 @@ func (cmd *leaderQueryCmd) Execute(_ []string) (errOut error) {
 
 	ctx := context.Background()
 	req := new(control.LeaderQueryReq)
-	req.SetSystem(cmd.config.SystemName)
 
 	resp, err := control.LeaderQuery(ctx, cmd.ctlInvoker, req)
 	if err != nil {
@@ -93,6 +92,7 @@ func (cmd *rankListCmd) validateHostsRanks() (outHosts *hostlist.HostSet, outRan
 // systemQueryCmd is the struct representing the command to query system status.
 type systemQueryCmd struct {
 	logCmd
+	cfgCmd
 	ctlInvokerCmd
 	jsonOutputCmd
 	rankListCmd
@@ -152,6 +152,7 @@ func (cmd *systemEraseCmd) Execute(_ []string) error {
 // systemStopCmd is the struct representing the command to shutdown DAOS system.
 type systemStopCmd struct {
 	logCmd
+	cfgCmd
 	ctlInvokerCmd
 	jsonOutputCmd
 	rankListCmd
@@ -198,6 +199,7 @@ func (cmd *systemStopCmd) Execute(_ []string) (errOut error) {
 // systemStartCmd is the struct representing the command to start system.
 type systemStartCmd struct {
 	logCmd
+	cfgCmd
 	ctlInvokerCmd
 	jsonOutputCmd
 	rankListCmd

--- a/src/control/cmd/dmg/system_test.go
+++ b/src/control/cmd/dmg/system_test.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/daos-stack/daos/src/control/build"
 	"github.com/daos-stack/daos/src/control/common"
 	mgmtpb "github.com/daos-stack/daos/src/control/common/proto/mgmt"
 	sharedpb "github.com/daos-stack/daos/src/control/common/proto/shared"
@@ -21,16 +20,6 @@ import (
 	"github.com/daos-stack/daos/src/control/logging"
 	"github.com/daos-stack/daos/src/control/system"
 )
-
-func listWithSystem(req *control.ListPoolsReq, sysName string) *control.ListPoolsReq {
-	req.SetSystem(sysName)
-	return req
-}
-
-func queryWithSystem(req *control.LeaderQueryReq, sysName string) *control.LeaderQueryReq {
-	req.SetSystem(sysName)
-	return req
-}
 
 func TestDmg_SystemCommands(t *testing.T) {
 	runCmdTests(t, []cmdTest{
@@ -207,7 +196,7 @@ func TestDmg_SystemCommands(t *testing.T) {
 			"leader query",
 			"system leader-query",
 			strings.Join([]string{
-				printRequest(t, queryWithSystem(&control.LeaderQueryReq{}, build.DefaultSystemName)),
+				printRequest(t, &control.LeaderQueryReq{}),
 			}, " "),
 			nil,
 		},
@@ -215,7 +204,7 @@ func TestDmg_SystemCommands(t *testing.T) {
 			"system list-pools with default config",
 			"system list-pools",
 			strings.Join([]string{
-				printRequest(t, listWithSystem(&control.ListPoolsReq{}, build.DefaultSystemName)),
+				printRequest(t, &control.ListPoolsReq{}),
 			}, " "),
 			nil,
 		},

--- a/src/control/lib/control/cont.go
+++ b/src/control/lib/control/cont.go
@@ -46,7 +46,7 @@ func ContSetOwner(ctx context.Context, rpcClient UnaryInvoker, req *ContSetOwner
 
 	req.setRPC(func(ctx context.Context, conn *grpc.ClientConn) (proto.Message, error) {
 		return mgmtpb.NewMgmtSvcClient(conn).ContSetOwner(ctx, &mgmtpb.ContSetOwnerReq{
-			Sys:        req.getSystem(),
+			Sys:        req.getSystem(rpcClient),
 			ContUUID:   req.ContUUID,
 			PoolUUID:   req.PoolUUID,
 			Owneruser:  req.User,

--- a/src/control/lib/control/mocks.go
+++ b/src/control/lib/control/mocks.go
@@ -33,6 +33,7 @@ type (
 	// MockInvokerConfig defines the configured responses
 	// for a MockInvoker.
 	MockInvokerConfig struct {
+		Sys              string
 		UnaryError       error
 		UnaryResponse    *UnaryResponse
 		UnaryResponseSet []*UnaryResponse
@@ -69,6 +70,10 @@ func (mi *MockInvoker) Debug(msg string) {
 
 func (mi *MockInvoker) Debugf(fmtStr string, args ...interface{}) {
 	mi.log.Debugf(fmtStr, args...)
+}
+
+func (mi *MockInvoker) GetSystem() string {
+	return mi.cfg.Sys
 }
 
 func (mi *MockInvoker) InvokeUnaryRPC(ctx context.Context, uReq UnaryRequest) (*UnaryResponse, error) {

--- a/src/control/lib/control/network.go
+++ b/src/control/lib/control/network.go
@@ -242,7 +242,7 @@ func (gair *GetAttachInfoResp) String() string {
 func GetAttachInfo(ctx context.Context, rpcClient UnaryInvoker, req *GetAttachInfoReq) (*GetAttachInfoResp, error) {
 	req.setRPC(func(ctx context.Context, conn *grpc.ClientConn) (proto.Message, error) {
 		return mgmtpb.NewMgmtSvcClient(conn).GetAttachInfo(ctx, &mgmtpb.GetAttachInfoReq{
-			Sys:      req.getSystem(),
+			Sys:      req.getSystem(rpcClient),
 			AllRanks: req.AllRanks,
 		})
 	})

--- a/src/control/lib/control/pool.go
+++ b/src/control/lib/control/pool.go
@@ -280,7 +280,6 @@ type PoolEvictReq struct {
 	msRequest
 	unaryRequest
 	UUID    string
-	Sys     string
 	Handles []string
 }
 
@@ -292,8 +291,8 @@ func PoolEvict(ctx context.Context, rpcClient UnaryInvoker, req *PoolEvictReq) e
 
 	req.setRPC(func(ctx context.Context, conn *grpc.ClientConn) (proto.Message, error) {
 		return mgmtpb.NewMgmtSvcClient(conn).PoolEvict(ctx, &mgmtpb.PoolEvictReq{
-			Uuid:    req.UUID,
 			Sys:     req.getSystem(),
+			Uuid:    req.UUID,
 			Handles: req.Handles,
 		})
 	})

--- a/src/control/lib/control/pool.go
+++ b/src/control/lib/control/pool.go
@@ -110,7 +110,6 @@ func genPoolCreateRequest(in *PoolCreateReq) (out *mgmtpb.PoolCreateReq, err err
 		return nil, err
 	}
 
-	out.Sys = in.getSystem()
 	out.Uuid = uuid.New().String()
 
 	return
@@ -155,6 +154,7 @@ func PoolCreate(ctx context.Context, rpcClient UnaryInvoker, req *PoolCreateReq)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to generate PoolCreate request")
 	}
+	pbReq.Sys = req.getSystem(rpcClient)
 	// TODO: Set this timeout based on the SCM size, when we have a
 	// better understanding of the relationship.
 	req.SetTimeout(PoolCreateTimeout)
@@ -219,7 +219,7 @@ type (
 func PoolResolveID(ctx context.Context, rpcClient UnaryInvoker, req *PoolResolveIDReq) (*PoolResolveIDResp, error) {
 	req.setRPC(func(ctx context.Context, conn *grpc.ClientConn) (proto.Message, error) {
 		return mgmtpb.NewMgmtSvcClient(conn).PoolResolveID(ctx, &mgmtpb.PoolResolveIDReq{
-			Sys:     req.getSystem(),
+			Sys:     req.getSystem(rpcClient),
 			HumanID: req.HumanID,
 		})
 	})
@@ -254,7 +254,7 @@ func PoolDestroy(ctx context.Context, rpcClient UnaryInvoker, req *PoolDestroyRe
 	}
 	req.setRPC(func(ctx context.Context, conn *grpc.ClientConn) (proto.Message, error) {
 		return mgmtpb.NewMgmtSvcClient(conn).PoolDestroy(ctx, &mgmtpb.PoolDestroyReq{
-			Sys:   req.getSystem(),
+			Sys:   req.getSystem(rpcClient),
 			Uuid:  req.UUID,
 			Force: req.Force,
 		})
@@ -291,7 +291,7 @@ func PoolEvict(ctx context.Context, rpcClient UnaryInvoker, req *PoolEvictReq) e
 
 	req.setRPC(func(ctx context.Context, conn *grpc.ClientConn) (proto.Message, error) {
 		return mgmtpb.NewMgmtSvcClient(conn).PoolEvict(ctx, &mgmtpb.PoolEvictReq{
-			Sys:     req.getSystem(),
+			Sys:     req.getSystem(rpcClient),
 			Uuid:    req.UUID,
 			Handles: req.Handles,
 		})
@@ -411,7 +411,7 @@ func PoolQuery(ctx context.Context, rpcClient UnaryInvoker, req *PoolQueryReq) (
 	}
 	req.setRPC(func(ctx context.Context, conn *grpc.ClientConn) (proto.Message, error) {
 		return mgmtpb.NewMgmtSvcClient(conn).PoolQuery(ctx, &mgmtpb.PoolQueryReq{
-			Sys:  req.getSystem(),
+			Sys:  req.getSystem(rpcClient),
 			Uuid: req.UUID,
 		})
 	})
@@ -470,7 +470,7 @@ func PoolSetProp(ctx context.Context, rpcClient UnaryInvoker, req *PoolSetPropRe
 	}
 
 	pbReq := &mgmtpb.PoolSetPropReq{
-		Sys:  req.getSystem(),
+		Sys:  req.getSystem(rpcClient),
 		Uuid: req.UUID,
 	}
 	pbReq.SetPropertyName(req.Property)
@@ -541,7 +541,7 @@ func PoolExclude(ctx context.Context, rpcClient UnaryInvoker, req *PoolExcludeRe
 	}
 	req.setRPC(func(ctx context.Context, conn *grpc.ClientConn) (proto.Message, error) {
 		return mgmtpb.NewMgmtSvcClient(conn).PoolExclude(ctx, &mgmtpb.PoolExcludeReq{
-			Sys:       req.getSystem(),
+			Sys:       req.getSystem(rpcClient),
 			Uuid:      req.UUID,
 			Rank:      req.Rank.Uint32(),
 			Targetidx: req.Targetidx,
@@ -584,7 +584,7 @@ func PoolDrain(ctx context.Context, rpcClient UnaryInvoker, req *PoolDrainReq) e
 	}
 	req.setRPC(func(ctx context.Context, conn *grpc.ClientConn) (proto.Message, error) {
 		return mgmtpb.NewMgmtSvcClient(conn).PoolDrain(ctx, &mgmtpb.PoolDrainReq{
-			Sys:       req.getSystem(),
+			Sys:       req.getSystem(rpcClient),
 			Uuid:      req.UUID,
 			Rank:      req.Rank.Uint32(),
 			Targetidx: req.Targetidx,
@@ -612,7 +612,6 @@ func genPoolExtendRequest(in *PoolExtendReq) (out *mgmtpb.PoolExtendReq, err err
 	if err = convert.Types(in, out); err != nil {
 		return nil, err
 	}
-	out.Sys = in.getSystem()
 
 	return
 }
@@ -637,6 +636,7 @@ func PoolExtend(ctx context.Context, rpcClient UnaryInvoker, req *PoolExtendReq)
 	if err != nil {
 		return errors.Wrap(err, "failed to generate PoolExtend request")
 	}
+	pbReq.Sys = req.getSystem(rpcClient)
 
 	if err := checkUUID(req.UUID); err != nil {
 		return err
@@ -681,7 +681,7 @@ func PoolReintegrate(ctx context.Context, rpcClient UnaryInvoker, req *PoolReint
 	}
 	req.setRPC(func(ctx context.Context, conn *grpc.ClientConn) (proto.Message, error) {
 		return mgmtpb.NewMgmtSvcClient(conn).PoolReintegrate(ctx, &mgmtpb.PoolReintegrateReq{
-			Sys:       req.getSystem(),
+			Sys:       req.getSystem(rpcClient),
 			Uuid:      req.UUID,
 			Rank:      req.Rank.Uint32(),
 			Targetidx: req.Targetidx,

--- a/src/control/lib/control/pool_acl.go
+++ b/src/control/lib/control/pool_acl.go
@@ -35,7 +35,7 @@ func PoolGetACL(ctx context.Context, rpcClient UnaryInvoker, req *PoolGetACLReq)
 	}
 	req.setRPC(func(ctx context.Context, conn *grpc.ClientConn) (proto.Message, error) {
 		return mgmtpb.NewMgmtSvcClient(conn).PoolGetACL(ctx, &mgmtpb.GetACLReq{
-			Sys:  req.getSystem(),
+			Sys:  req.getSystem(rpcClient),
 			Uuid: req.UUID,
 		})
 	})
@@ -79,7 +79,7 @@ func PoolOverwriteACL(ctx context.Context, rpcClient UnaryInvoker, req *PoolOver
 
 	req.setRPC(func(ctx context.Context, conn *grpc.ClientConn) (proto.Message, error) {
 		return mgmtpb.NewMgmtSvcClient(conn).PoolOverwriteACL(ctx, &mgmtpb.ModifyACLReq{
-			Sys:  req.getSystem(),
+			Sys:  req.getSystem(rpcClient),
 			Uuid: req.UUID,
 			ACL:  req.ACL.Entries,
 		})
@@ -125,7 +125,7 @@ func PoolUpdateACL(ctx context.Context, rpcClient UnaryInvoker, req *PoolUpdateA
 
 	req.setRPC(func(ctx context.Context, conn *grpc.ClientConn) (proto.Message, error) {
 		return mgmtpb.NewMgmtSvcClient(conn).PoolUpdateACL(ctx, &mgmtpb.ModifyACLReq{
-			Sys:  req.getSystem(),
+			Sys:  req.getSystem(rpcClient),
 			Uuid: req.UUID,
 			ACL:  req.ACL.Entries,
 		})
@@ -171,7 +171,7 @@ func PoolDeleteACL(ctx context.Context, rpcClient UnaryInvoker, req *PoolDeleteA
 
 	req.setRPC(func(ctx context.Context, conn *grpc.ClientConn) (proto.Message, error) {
 		return mgmtpb.NewMgmtSvcClient(conn).PoolDeleteACL(ctx, &mgmtpb.DeleteACLReq{
-			Sys:       req.getSystem(),
+			Sys:       req.getSystem(rpcClient),
 			Uuid:      req.UUID,
 			Principal: req.Principal,
 		})

--- a/src/control/lib/control/request.go
+++ b/src/control/lib/control/request.go
@@ -60,6 +60,12 @@ type (
 		getDeadline() time.Time
 	}
 
+	// sysSetter defines an interface to be implemented by
+	// requests that can set the system name Field.
+	sysSetter interface {
+		SetSystem(string)
+	}
+
 	// UnaryRequest defines an interface to be implemented by
 	// unary request types (1 response to 1 request).
 	UnaryRequest interface {
@@ -67,6 +73,7 @@ type (
 		deadliner
 		retryer
 		unaryRPCGetter
+		sysSetter
 	}
 )
 

--- a/src/control/lib/control/rpc.go
+++ b/src/control/lib/control/rpc.go
@@ -404,5 +404,7 @@ func invokeUnaryRPC(parentCtx context.Context, log debugLogger, c UnaryInvoker, 
 // items which represent the success or failure of the RPC invocation for each host
 // in the request.
 func (c *Client) InvokeUnaryRPC(ctx context.Context, req UnaryRequest) (*UnaryResponse, error) {
+	req.SetSystem(c.config.SystemName)
+
 	return invokeUnaryRPC(ctx, c.log, c, req, c.config.HostList)
 }

--- a/src/control/lib/control/rpc.go
+++ b/src/control/lib/control/rpc.go
@@ -43,15 +43,22 @@ type (
 	// a gRPC method and returns a protobuf response or error.
 	unaryRPC func(context.Context, *grpc.ClientConn) (proto.Message, error)
 
-	// unaryRPCGetter defines the interface to be implemented by
-	// requests that can invoke a gRPC method.
+	// unaryRPCGetter defines the interface to be implemented by requests
+	// that can invoke a gRPC method.
 	unaryRPCGetter interface {
 		getRPC() unaryRPC
+	}
+
+	// sysGetter defines an interface to be implemented by clients that can
+	// retrieve the system name field.
+	sysGetter interface {
+		GetSystem() string
 	}
 
 	// UnaryInvoker defines an interface to be implemented by clients
 	// capable of invoking a unary RPC (1 response for 1 request).
 	UnaryInvoker interface {
+		sysGetter
 		debugLogger
 		InvokeUnaryRPC(ctx context.Context, req UnaryRequest) (*UnaryResponse, error)
 		InvokeUnaryRPCAsync(ctx context.Context, req UnaryRequest) (HostResponseChan, error)
@@ -140,6 +147,12 @@ func DefaultClient() *Client {
 // existing Client.
 func (c *Client) SetConfig(cfg *Config) {
 	c.config = cfg
+}
+
+// GetConfig retrieves the system name from the client configuration and
+// implements the sysGetter interface.
+func (c *Client) GetSystem() string {
+	return c.config.SystemName
 }
 
 func (c *Client) Debug(msg string) {
@@ -404,7 +417,5 @@ func invokeUnaryRPC(parentCtx context.Context, log debugLogger, c UnaryInvoker, 
 // items which represent the success or failure of the RPC invocation for each host
 // in the request.
 func (c *Client) InvokeUnaryRPC(ctx context.Context, req UnaryRequest) (*UnaryResponse, error) {
-	req.SetSystem(c.config.SystemName)
-
 	return invokeUnaryRPC(ctx, c.log, c, req, c.config.HostList)
 }

--- a/src/control/lib/control/rpc_test.go
+++ b/src/control/lib/control/rpc_test.go
@@ -36,6 +36,7 @@ type testRequest struct {
 	toMS     bool
 	HostList []string
 	Deadline time.Time
+	Sys      string
 }
 
 func (tr *testRequest) isMSRequest() bool {
@@ -56,6 +57,10 @@ func (tr *testRequest) SetTimeout(to time.Duration) {
 
 func (tr *testRequest) getDeadline() time.Time {
 	return tr.Deadline
+}
+
+func (tr *testRequest) SetSystem(sys string) {
+	tr.Sys = sys
 }
 
 func (tr *testRequest) getRPC() unaryRPC {

--- a/src/control/lib/control/system.go
+++ b/src/control/lib/control/system.go
@@ -132,7 +132,7 @@ func SystemJoin(ctx context.Context, rpcClient UnaryInvoker, req *SystemJoinReq)
 	if err := convert.Types(req, pbReq); err != nil {
 		return nil, err
 	}
-	pbReq.Sys = req.getSystem()
+	pbReq.Sys = req.getSystem(rpcClient)
 	req.setRPC(func(ctx context.Context, conn *grpc.ClientConn) (proto.Message, error) {
 		return mgmtpb.NewMgmtSvcClient(conn).Join(ctx, pbReq)
 	})
@@ -385,7 +385,7 @@ func SystemQuery(ctx context.Context, rpcClient UnaryInvoker, req *SystemQueryRe
 	pbReq := new(mgmtpb.SystemQueryReq)
 	pbReq.Hosts = req.Hosts.String()
 	pbReq.Ranks = req.Ranks.String()
-	pbReq.Sys = req.getSystem()
+	pbReq.Sys = req.getSystem(rpcClient)
 
 	req.setRPC(func(ctx context.Context, conn *grpc.ClientConn) (proto.Message, error) {
 		return mgmtpb.NewMgmtSvcClient(conn).SystemQuery(ctx, pbReq)
@@ -485,7 +485,7 @@ func SystemStart(ctx context.Context, rpcClient UnaryInvoker, req *SystemStartRe
 	pbReq := new(mgmtpb.SystemStartReq)
 	pbReq.Hosts = req.Hosts.String()
 	pbReq.Ranks = req.Ranks.String()
-	pbReq.Sys = req.getSystem()
+	pbReq.Sys = req.getSystem(rpcClient)
 
 	req.setRPC(func(ctx context.Context, conn *grpc.ClientConn) (proto.Message, error) {
 		return mgmtpb.NewMgmtSvcClient(conn).SystemStart(ctx, pbReq)
@@ -561,7 +561,7 @@ func SystemStop(ctx context.Context, rpcClient UnaryInvoker, req *SystemStopReq)
 	pbReq.Prep = req.Prep
 	pbReq.Kill = req.Kill
 	pbReq.Force = req.Force
-	pbReq.Sys = req.getSystem()
+	pbReq.Sys = req.getSystem(rpcClient)
 
 	req.setRPC(func(ctx context.Context, conn *grpc.ClientConn) (proto.Message, error) {
 		return mgmtpb.NewMgmtSvcClient(conn).SystemStop(ctx, pbReq)
@@ -669,7 +669,7 @@ func SystemErase(ctx context.Context, rpcClient UnaryInvoker, req *SystemEraseRe
 	}
 
 	pbReq := new(mgmtpb.SystemEraseReq)
-	pbReq.Sys = req.getSystem()
+	pbReq.Sys = req.getSystem(rpcClient)
 
 	req.setRPC(func(ctx context.Context, conn *grpc.ClientConn) (proto.Message, error) {
 		return mgmtpb.NewMgmtSvcClient(conn).SystemErase(ctx, pbReq)
@@ -737,7 +737,7 @@ type LeaderQueryResp struct {
 func LeaderQuery(ctx context.Context, rpcClient UnaryInvoker, req *LeaderQueryReq) (*LeaderQueryResp, error) {
 	req.setRPC(func(ctx context.Context, conn *grpc.ClientConn) (proto.Message, error) {
 		return mgmtpb.NewMgmtSvcClient(conn).LeaderQuery(ctx, &mgmtpb.LeaderQueryReq{
-			Sys: req.getSystem(),
+			Sys: req.getSystem(rpcClient),
 		})
 	})
 	rpcClient.Debugf("DAOS system leader-query request: %s", req)
@@ -769,7 +769,7 @@ type ListPoolsResp struct {
 func ListPools(ctx context.Context, rpcClient UnaryInvoker, req *ListPoolsReq) (*ListPoolsResp, error) {
 	req.setRPC(func(ctx context.Context, conn *grpc.ClientConn) (proto.Message, error) {
 		return mgmtpb.NewMgmtSvcClient(conn).ListPools(ctx, &mgmtpb.ListPoolsReq{
-			Sys: req.getSystem(),
+			Sys: req.getSystem(rpcClient),
 		})
 	})
 	rpcClient.Debugf("DAOS system list-pools request: %s", req)

--- a/src/control/lib/control/system.go
+++ b/src/control/lib/control/system.go
@@ -132,6 +132,7 @@ func SystemJoin(ctx context.Context, rpcClient UnaryInvoker, req *SystemJoinReq)
 	if err := convert.Types(req, pbReq); err != nil {
 		return nil, err
 	}
+	pbReq.Sys = req.getSystem()
 	req.setRPC(func(ctx context.Context, conn *grpc.ClientConn) (proto.Message, error) {
 		return mgmtpb.NewMgmtSvcClient(conn).Join(ctx, pbReq)
 	})

--- a/src/tests/ftest/container/global_handle.py
+++ b/src/tests/ftest/container/global_handle.py
@@ -41,7 +41,6 @@ class GlobalHandle(TestWithServers):
         pool = DaosPool(self.context)
         pool.uuid = uuidstr
         pool.set_svc(rank)
-        pool.group = "daos_server"
         buf = ctypes.cast(
             pool_glob_handle.iov_buf,
             ctypes.POINTER(ctypes.c_byte * pool_glob_handle.iov_buf_len))

--- a/src/tests/ftest/pool/bad_connect.py
+++ b/src/tests/ftest/pool/bad_connect.py
@@ -53,7 +53,6 @@ class BadConnectTest(TestWithServers):
                 break
 
         puuid = (ctypes.c_ubyte * 16)()
-        pgroup = create_string_buffer(0)
         # initialize a python pool object then create the underlying
         # daos storage
         self.pool = TestPool(self.context, self.get_dmg_command())
@@ -61,11 +60,6 @@ class BadConnectTest(TestWithServers):
         self.pool.create()
         # save this uuid since we might trash it as part of the test
         ctypes.memmove(puuid, self.pool.pool.uuid, 16)
-
-        # trash the pool group value
-        pgroup = self.pool.pool.group
-        if connectset == 'NULLPTR':
-            self.pool.pool.group = None
 
         # trash the UUID value in various ways
         if connectuuid == 'NULLPTR':
@@ -89,7 +83,6 @@ class BadConnectTest(TestWithServers):
         finally:
             if self.pool is not None and self.pool.pool.attached == 1:
                 # restore values in case we trashed them during test
-                self.pool.pool.group = pgroup
                 if self.pool.pool.uuid is None:
                     self.pool.pool.uuid = (ctypes.c_ubyte * 16)()
                 ctypes.memmove(self.pool.pool.uuid, puuid, 16)

--- a/src/tests/ftest/pool/bad_create.py
+++ b/src/tests/ftest/pool/bad_create.py
@@ -105,7 +105,6 @@ class BadCreateTest(TestWithServers):
         self.pool.uid = uid
         self.pool.gid = gid
         self.pool.scm_size.value = size
-        self.pool.name.value = group
 
         try:
             self.pool.create()

--- a/src/tests/ftest/pool/destroy_tests.py
+++ b/src/tests/ftest/pool/destroy_tests.py
@@ -79,7 +79,6 @@ class DestroyTests(TestWithServers):
         # Create a pool
         self.log.info("Create a pool")
         self.add_pool(create=False)
-        self.pool.name.value = group_name
         self.pool.create()
         self.log.info("Pool UUID is %s", self.pool.uuid)
 
@@ -298,7 +297,6 @@ class DestroyTests(TestWithServers):
 
         self.log.info("Create a pool in server group %s", group_names[0])
         self.add_pool(create=False)
-        self.pool.name.value = group_names[0]
         self.pool.create()
         self.log.info("Pool UUID is %s", self.pool.uuid)
 
@@ -495,7 +493,6 @@ class DestroyTests(TestWithServers):
         self.start_servers(group_hosts)
 
         self.add_pool(create=False)
-        self.pool.name.value = group_names[0]
         self.pool.create()
         self.log.info("Pool UUID is %s on server_group %s",
                       self.pool.uuid, group_names[0])
@@ -530,7 +527,6 @@ class DestroyTests(TestWithServers):
         # Destroy pool with callback while stopping other server
         # Create new pool on server_group_a
         self.add_pool(create=False)
-        self.pool.name.value = group_names[0]
         self.pool.create()
         self.log.info("Pool UUID is %s on server_group %s",
                       self.pool.uuid, group_names[0])

--- a/src/tests/ftest/pool/evict_test.py
+++ b/src/tests/ftest/pool/evict_test.py
@@ -58,7 +58,7 @@ class EvictTests(TestWithServers):
         """Check if pool handle still exists.
 
         Args:
-            test_param (str): either invalid UUID or bad server name
+            test_param (str): invalid UUID
 
         Returns:
             True or False, depending if the handle exists or not
@@ -76,7 +76,7 @@ class EvictTests(TestWithServers):
         """Connect to pool, connect and try to evict with a bad param.
 
         Args:
-            test_param (str): either invalid UUID or bad server name
+            test_param (str): invalid UUID
 
         Returns:
             TestPool (bool)
@@ -86,19 +86,10 @@ class EvictTests(TestWithServers):
         self.pool = self.connected_pool(self.hostlist_servers)
 
         self.log.info(
-            "Pool UUID: %s\n Pool handle: %s\n Server group: %s\n",
-            self.pool.uuid, self.pool.pool.handle.value, self.pool.name)
+            "Pool UUID: %s\n Pool handle: %s\n",
+            self.pool.uuid, self.pool.pool.handle.value,)
 
-        server_name = None
-
-        if test_param == "BAD_SERVER_NAME":
-            # Attempt to evict pool with invalid server group name
-            # set the server group name directly
-            server_name = test_param
-            self.pool.pool.group = create_string_buffer(test_param)
-            self.log.info(
-                "Evicting pool with invalid Server Group Name: %s", test_param)
-        elif test_param == "invalid_uuid":
+        if test_param == "invalid_uuid":
             # Attempt to evict pool with invalid UUID
             bogus_uuid = self.pool.uuid
             # in case uuid4() generates pool.uuid
@@ -113,8 +104,7 @@ class EvictTests(TestWithServers):
             self.fail("Invalid yaml parameters - check \"params\" values")
         try:
             # call dmg pool_evict directly
-            self.pool.dmg.pool_evict(pool=self.pool.pool.get_uuid_str(),
-	    	                               sys=server_name)
+            self.pool.dmg.pool_evict(pool=self.pool.pool.get_uuid_str())
         # exception is expected
         except CommandFailure as result:
             self.log.info("Expected exception - invalid param %s\n %s\n",
@@ -124,11 +114,7 @@ class EvictTests(TestWithServers):
             self.log.info("Check if pool handle still exist")
             return self.pool_handle_exist(test_param)
         finally:
-            # Restore the valid server group name or uuid
-            if "BAD_SERVER_NAME" in test_param:
-                self.pool.pool.group = create_string_buffer(self.server_group)
-            else:
-                self.pool.pool.set_uuid_str(self.pool.uuid)
+            self.pool.pool.set_uuid_str(self.pool.uuid)
 
         # if here then pool-evict did not raise an exception as expected
         # restore the valid server group name and check if valid pool
@@ -247,17 +233,6 @@ class EvictTests(TestWithServers):
                         "{} != {}".format(
                             count+1, pool[count].uuid, c_uuid_to_str(
                                 pool_info.pi_uuid)))
-
-    def test_evict_bad_server_name(self):
-        """
-        Test evicting a pool using an invalid server group name.
-
-        :avocado: tags=all,pool,pr,daily_regression,full_regression,small
-        :avocado: tags=poolevict
-        :avocado: tags=poolevict_bad_server_name,DAOS_5610
-        """
-        test_param = self.params.get("server_name", '/run/badparams/*')
-        self.assertTrue(self.evict_badparam(test_param))
 
     def test_evict_bad_uuid(self):
         """

--- a/src/tests/ftest/pool/evict_test.yaml
+++ b/src/tests/ftest/pool/evict_test.yaml
@@ -5,13 +5,13 @@ hosts:
     - server-C
     - server-D
 server_config:
-   name: daos_server
+  name: daos_server
 timeout: 170
 pool:
-   mode: 146
-   name: daos_server
-   scm_size: 1073741824
-   control_method: dmg
+  mode: 146
+  name: daos_server
+  scm_size: 1073741824
+  control_method: dmg
 container:
   akey_size: 5
   dkey_size: 5
@@ -19,5 +19,4 @@ container:
   object_qty: 1
   record_qty: 1
 badparams:
-    server_name: BAD_SERVER_NAME
-    uuid: invalid_uuid
+  uuid: invalid_uuid

--- a/src/tests/ftest/pool/global_handle.py
+++ b/src/tests/ftest/pool/global_handle.py
@@ -39,7 +39,6 @@ class GlobalHandle(TestWithServers):
         pool = DaosPool(self.context)
         pool.set_uuid_str(uuidstr)
         pool.set_svc(rank)
-        pool.group = "daos_server"
 
         # note that the handle is stored inside the pool as well
         dummy_local_handle = pool.global2local(self.context, iov_len,

--- a/src/tests/ftest/pool/simple_create_delete_test.py
+++ b/src/tests/ftest/pool/simple_create_delete_test.py
@@ -61,7 +61,6 @@ class SimpleCreateDeleteTest(TestWithServers):
             self.pool.get_params(self)
             self.pool.uid = uid
             self.pool.gid = gid
-            self.pool.name.update(setid)
             self.pool.create()
             if expected_result == 'FAIL':
                 self.fail("Test was expected to fail but it passed.\n")

--- a/src/tests/ftest/util/dmg_utils.py
+++ b/src/tests/ftest/util/dmg_utils.py
@@ -351,7 +351,7 @@ class DmgCommand(DmgCommandBase):
         return self._get_result(("storage", "scan"), nvme_health=True)
 
     def pool_create(self, scm_size, uid=None, gid=None, nvme_size=None,
-                    target_list=None, svcn=None, group=None, acl_file=None):
+                    target_list=None, svcn=None, acl_file=None):
         """Create a pool with the dmg command.
 
         The uid and gid method arguments can be specified as either an integer
@@ -367,9 +367,6 @@ class DmgCommand(DmgCommandBase):
                 identifiers (ranks) for the DAOS pool
             svcn (str, optional): Number of pool service replicas. Defaults to
                 None, in which case the default value is set by the server.
-            group (str, optional): DAOS system group name in which to create the
-                pool. Defaults to None, in which case "daos_server" is used by
-                default.
             acl_file (str, optional): ACL file. Defaults to None.
 
         Raises:
@@ -387,7 +384,6 @@ class DmgCommand(DmgCommandBase):
             "scm_size": scm_size,
             "nvme_size": nvme_size,
             "nsvc": svcn,
-            "sys": group,
             "acl_file": acl_file
         }
         if target_list is not None:
@@ -836,13 +832,11 @@ class DmgCommand(DmgCommandBase):
                 data[rank] = info[1].strip()
         return data
 
-    def pool_evict(self, pool, sys=None):
+    def pool_evict(self, pool):
         """Evict a pool.
 
         Args:
             pool (str):  UUID of DAOS pool to evict connection to
-            sys (str, optional): DAOS system that the pools connections be
-                evicted from. Defaults to None.
 
         Returns:
             CmdResult: Object that contains exit status, stdout, and other
@@ -852,7 +846,7 @@ class DmgCommand(DmgCommandBase):
             CommandFailure: if the dmg pool evict command fails.
 
         """
-        return self._get_result(("pool", "evict"), pool=pool, sys=sys)
+        return self._get_result(("pool", "evict"), pool=pool)
 
 
 def check_system_query_status(data):

--- a/src/tests/ftest/util/test_utils_pool.py
+++ b/src/tests/ftest/util/test_utils_pool.py
@@ -95,7 +95,6 @@ class TestPool(TestDaosApiBase):
             "uid": self.uid,
             "gid": self.gid,
             "scm_size": self.scm_size.value,
-            "group": self.name.value}
         for key in ("target_list", "svcn", "nvme_size"):
             value = getattr(self, key).value
             if value is not None:
@@ -111,11 +110,6 @@ class TestPool(TestDaosApiBase):
             self._log_method("dmg.pool_create", kwargs)
             data = self.dmg.pool_create(**kwargs)
             if self.dmg.result.exit_status == 0:
-                # Populate the empty DaosPool object with the properties of the
-                # pool created with dmg pool create.
-                if self.name.value:
-                    self.pool.group = create_string_buffer(self.name.value)
-
                 # Convert the string of service replicas from the dmg command
                 # output into an ctype array for the DaosPool object using the
                 # same technique used in DaosPool.create().

--- a/src/tests/ftest/util/test_utils_pool.py
+++ b/src/tests/ftest/util/test_utils_pool.py
@@ -95,6 +95,7 @@ class TestPool(TestDaosApiBase):
             "uid": self.uid,
             "gid": self.gid,
             "scm_size": self.scm_size.value,
+        }
         for key in ("target_list", "svcn", "nvme_size"):
             value = getattr(self, key).value
             if value is not None:


### PR DESCRIPTION
System name can be configured in the server and dmg config files. When
set for dmg, the control API needs to apply the new system name in
protobuf requests that are issued to the gRPC server. This PR applies
the logic for selecting the system name into the control API and takes
the system name from either the supplied request, the supplied control
config or uses the build default (in that order of preference).

In dmg, make all pool and system subcommands config aware and remove the
ability to set the system name from the commandline. Changing the system
name should instead be performed through the dmg config file which will
work reliably for pool and system commands.

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>