### PR TITLE
DAOS-6755 obj: fix a bug in migrate_fetch_update_parity

### DIFF
--- a/src/object/obj_ec.h
+++ b/src/object/obj_ec.h
@@ -16,7 +16,7 @@
 /** MAX number of data cells */
 #define OBJ_EC_MAX_K		(64)
 /** MAX number of parity cells */
-#define OBJ_EC_MAX_P		(16)
+#define OBJ_EC_MAX_P		(8)
 #define OBJ_EC_MAX_M		(OBJ_EC_MAX_K + OBJ_EC_MAX_P)
 /** Length of target bitmap */
 #define OBJ_TGT_BITMAP_LEN						\

--- a/src/object/srv_obj_migrate.c
+++ b/src/object/srv_obj_migrate.c
@@ -856,7 +856,7 @@ migrate_fetch_update_parity(struct migrate_one *mrone, daos_handle_t oh,
 	char		*data;
 	daos_size_t	 size;
 	unsigned int	 p = obj_ec_parity_tgt_nr(oca);
-	unsigned char	*p_bufs[p];
+	unsigned char	*p_bufs[OBJ_EC_MAX_P] = { 0 };
 	unsigned char	*ptr;
 	int		 i;
 	int		 rc;
@@ -868,7 +868,6 @@ migrate_fetch_update_parity(struct migrate_one *mrone, daos_handle_t oh,
 		if (data == NULL)
 			D_GOTO(out, rc =-DER_NOMEM);
 
-		memset(p_bufs, 0, p * sizeof(p_bufs));
 		d_iov_set(&iov[i], data, size);
 		sgls[i].sg_nr = 1;
 		sgls[i].sg_nr_out = 1;


### PR DESCRIPTION
1. fix a bug in migrate_fetch_update_parity()
2. change OBJ_EC_MAX_P from 16 to 8 (as 8 is enough for now).

Signed-off-by: Xuezhao Liu <xuezhao.liu@intel.com>