### PR TITLE
DAOS-6871 test: disable datamover copy_space (#4758)

### DIFF
--- a/src/tests/ftest/datamover/copy_negative.py
+++ b/src/tests/ftest/datamover/copy_negative.py
@@ -256,6 +256,7 @@ class CopyNegativeTest(DataMoverTestBase):
             expected_rc=1,
             expected_output=self.MFU_ERR_INVAL_ARG)
 
+    @skipForTicket("DAOS-6871")
     def test_copy_space_dcp(self):
         """Jira ID: DAOS-5515
         Test Description:


### PR DESCRIPTION
Disable test_copy_space_dcp until the timeout issue
is resolved.

Signed-off-by: Dalton Bohning <daltonx.bohning@intel.com>