### PR TITLE
DAOS-7093 Test: attribute.py failing with "Test died without reporting the status".

### DIFF
--- a/src/tests/ftest/container/attribute.yaml
+++ b/src/tests/ftest/container/attribute.yaml
@@ -3,7 +3,7 @@
 hosts:
   test_servers:
     - server-A
-timeout: 120
+timeout: 60
 server_config:
   name: daos_server
 pool:

--- a/src/tests/ftest/container/attribute.yaml
+++ b/src/tests/ftest/container/attribute.yaml
@@ -3,7 +3,7 @@
 hosts:
   test_servers:
     - server-A
-timeout: 60
+timeout: 120
 server_config:
   name: daos_server
 pool:

--- a/src/tests/ftest/pool/attribute.yaml
+++ b/src/tests/ftest/pool/attribute.yaml
@@ -3,7 +3,7 @@
 hosts:
   test_servers:
     - server-A
-timeout: 60
+timeout: 120
 server_config:
   name: daos_server
 pool:


### PR DESCRIPTION
Increased timeout for attribute.py
Test tag: large_conattribute, sync_conattribute, async_conattribute

Signed-off-by: Omar Ocampo <omar.ocampo.coronado@intel.com>