### PR TITLE
DAOS-6681 sdl: Various coverity defects in object and EC code (#4919)

### DIFF
--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -1579,6 +1579,7 @@ obj_ioc_init(uuid_t pool_uuid, uuid_t coh_uuid, uuid_t cont_uuid, int opc,
 	struct ds_cont_child *coc;
 	int		      rc;
 
+	D_ASSERT(ioc != NULL);
 	memset(ioc, 0, sizeof(*ioc));
 	ioc->ioc_opc = opc;
 
@@ -1803,6 +1804,7 @@ ds_obj_ec_rep_handler(crt_rpc_t *rpc)
 		D_ERROR("ioc_begin failed: "DF_RC"\n", DP_RC(rc));
 		goto out;
 	}
+	D_ASSERT(ioc.ioc_coc != NULL);
 	dkey = (daos_key_t *)&oer->er_dkey;
 	iod = (daos_iod_t *)&oer->er_iod;
 	rc = vos_update_begin(ioc.ioc_coc->sc_hdl, oer->er_oid,
@@ -1876,6 +1878,7 @@ ds_obj_ec_agg_handler(crt_rpc_t *rpc)
 		D_ERROR("ioc_begin failed: "DF_RC"\n", DP_RC(rc));
 		goto out;
 	}
+	D_ASSERT(ioc.ioc_coc != NULL);
 	dkey = (daos_key_t *)&oea->ea_dkey;
 	iod.iod_name = oea->ea_akey;
 	iod.iod_type = DAOS_IOD_ARRAY;

--- a/src/tests/suite/daos_aggregate_ec.c
+++ b/src/tests/suite/daos_aggregate_ec.c
@@ -287,8 +287,8 @@ verify_1p(struct ec_agg_test_ctx *ctx, daos_oclass_id_t ec_agg_oc,
 		assert_int_equal(!parity[i], 0);
 	}
 
-	ec_setup_single_recx_data(ctx, EC_SPECIFIED, 0, k * len, 0, false,
-				  false, 0);
+	ec_setup_single_recx_data(ctx, EC_SPECIFIED, 0, (daos_size_t)k * len, 0,
+				  false, false, 0);
 	if (shard > 2)
 		iov_update_fill(ctx->update_sgl.sg_iovs, 1, len, true);
 


### PR DESCRIPTION
CID 316292: Unintentional integer overflow
CID 316293: Explicit null dereferenced
CID 316294: Explicit null dereferenced
CID 316295: Explicit null dereferenced
CID 316297: Unused value
CID 316299: Missing break in switch
CID 316300: Missing break in switch

Also includes updates from DAOS-6806 rpc: Fix cleanup resources (#4807)
(srv_ec_aggregate.c file updates only)

Signed-off-by: Sydney Vanda <sydney.m.vanda@intel.com>