### PR TITLE
DAOS-6808 migrate: fix dc_cont memory leak

### DIFF
--- a/src/container/srv_cli.c
+++ b/src/container/srv_cli.c
@@ -21,6 +21,21 @@
 #include <daos_srv/container.h>
 #include "cli_internal.h"
 
+void dsc_coh_get(daos_handle_t coh)
+{
+	dc_hdl2cont(coh);
+}
+
+void dsc_coh_put(daos_handle_t coh)
+{
+	struct dc_cont *cont;
+
+	cont = dc_hdl2cont(coh);
+
+	dc_cont_put(cont);
+	dc_cont_put(cont);
+}
+
 int
 dsc_cont_close(daos_handle_t poh, daos_handle_t coh)
 {
@@ -45,6 +60,7 @@ dsc_cont_close(daos_handle_t poh, daos_handle_t coh)
 
 	daos_csummer_destroy(&cont->dc_csummer);
 
+	dc_cont_put(cont);
 out:
 	if (cont != NULL)
 		dc_cont_put(cont);

--- a/src/include/daos_srv/container.h
+++ b/src/include/daos_srv/container.h
@@ -237,6 +237,9 @@ ds_csum_recalc(void *args);
 void
 ds_csum_agg_recalc(void *args);
 
+void dsc_coh_get(daos_handle_t coh);
+void dsc_coh_put(daos_handle_t coh);
+
 int dsc_cont_open(daos_handle_t poh, uuid_t cont_uuid, uuid_t cont_hdl_uuid,
 		  unsigned int flags, daos_handle_t *coh);
 int dsc_cont_close(daos_handle_t poh, daos_handle_t coh);


### PR DESCRIPTION
fix dc_cont memory leak during migration.

Signed-off-by: Dmitry Eremin <dmitry.eremin@intel.com>
Signed-off-by: Di Wang <di.wang@intel.com>