### PR TITLE
DAOS-5279 bio: change dma chunk size to 2MB (#5087)

### DIFF
--- a/src/bio/bio_xstream.c
+++ b/src/bio/bio_xstream.c
@@ -28,9 +28,9 @@
 #define DAOS_BS_CLUSTER_SZ	(1ULL << 30)	/* 1GB */
 #define DAOS_BS_MD_PAGES	(1024 * 20)	/* 20k blobs per device */
 /* DMA buffer parameters */
-#define DAOS_DMA_CHUNK_MB	32		/* 32MB DMA chunks */
-#define DAOS_DMA_CHUNK_CNT_INIT	2		/* Per-xstream init chunks */
-#define DAOS_DMA_CHUNK_CNT_MAX	32		/* Per-xstream max chunks */
+#define DAOS_DMA_CHUNK_MB	2		/* 2MB DMA chunks */
+#define DAOS_DMA_CHUNK_CNT_INIT	128		/* Per-xstream init chunks */
+#define DAOS_DMA_CHUNK_CNT_MAX	512		/* Per-xstream max chunks */
 #define DAOS_NVME_MAX_CTRLRS	1024		/* Max read from nvme_conf */
 
 /* Max inflight blob IOs per io channel */


### PR DESCRIPTION
Change DMA chunk size from 32MB to 2MB.

Signed-off-by: Niu Yawei <yawei.niu@intel.com>

Co-authored-by: Jeff Olivier <jeffrey.v.olivier@intel.com>