### PR TITLE
DAOS-5952 obj: use server replied epoch for EC data recovery

### DIFF
--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -794,7 +794,7 @@ obj_rw_req_reassemb(struct dc_object *obj, daos_obj_rw_t *args,
 	struct daos_oclass_attr	*oca;
 	int			 rc = 0;
 
-	if (epoch != NULL)
+	if (epoch != NULL && !obj_auxi->req_reasbed)
 		reasb_req->orr_epoch = *epoch;
 	reasb_req->orr_size_set = 0;
 	if (obj_auxi->req_reasbed && !reasb_req->orr_size_fetch) {

--- a/src/object/cli_shard.c
+++ b/src/object/cli_shard.c
@@ -730,6 +730,16 @@ dc_rw_cb(tse_task_t *task, void *arg)
 			reasb_req = rw_args->shard_args->reasb_req;
 			is_ec_obj = (reasb_req != NULL) &&
 				    DAOS_OC_IS_EC(reasb_req->orr_oca);
+
+			/* For EC obj fetch, set orr_epoch as highest server
+			 * epoch, so if need to recovery data (-DER_CSUM etc)
+			 * can use that epoch (see obj_ec_recov_task_init).
+			 */
+			if (is_ec_obj &&
+			    (reasb_req->orr_epoch.oe_value == DAOS_EPOCH_MAX ||
+			     reasb_req->orr_epoch.oe_value < orwo->orw_epoch))
+				reasb_req->orr_epoch.oe_value = orwo->orw_epoch;
+
 			if (rc == -DER_CSUM && is_ec_obj) {
 				struct shard_auxi_args	*sa;
 				uint32_t		 tgt_idx;
@@ -764,6 +774,11 @@ dc_rw_cb(tse_task_t *task, void *arg)
 
 		is_ec_obj = (reasb_req != NULL) &&
 			    DAOS_OC_IS_EC(reasb_req->orr_oca);
+
+		if (is_ec_obj &&
+		    (reasb_req->orr_epoch.oe_value == DAOS_EPOCH_MAX ||
+		     reasb_req->orr_epoch.oe_value < orwo->orw_epoch))
+			reasb_req->orr_epoch.oe_value = orwo->orw_epoch;
 
 		if (rw_args->maps != NULL && orwo->orw_maps.ca_count > 0) {
 			daos_iom_t			*reply_maps;


### PR DESCRIPTION
Use highest epoch replied from server, for EC data recovery, for the
case that server does not provide shadow epoch through recovery-list,
for example the CSUM error cause singlv data recovery.

Signed-off-by: Xuezhao Liu <xuezhao.liu@intel.com>