### PR TITLE
DAOS-5279 bio: change DMA chunk size to 8MB

### DIFF
--- a/src/bio/bio_xstream.c
+++ b/src/bio/bio_xstream.c
@@ -28,9 +28,9 @@
 #define DAOS_BS_CLUSTER_SZ	(1ULL << 30)	/* 1GB */
 #define DAOS_BS_MD_PAGES	(1024 * 20)	/* 20k blobs per device */
 /* DMA buffer parameters */
-#define DAOS_DMA_CHUNK_MB	2		/* 2MB DMA chunks */
-#define DAOS_DMA_CHUNK_CNT_INIT	128		/* Per-xstream init chunks */
-#define DAOS_DMA_CHUNK_CNT_MAX	512		/* Per-xstream max chunks */
+#define DAOS_DMA_CHUNK_MB	8		/* 8MB DMA chunks */
+#define DAOS_DMA_CHUNK_CNT_INIT	32		/* Per-xstream init chunks */
+#define DAOS_DMA_CHUNK_CNT_MAX	128		/* Per-xstream max chunks */
 #define DAOS_NVME_MAX_CTRLRS	1024		/* Max read from nvme_conf */
 
 /* Max inflight blob IOs per io channel */


### PR DESCRIPTION
Large DMA chunk size could suffer from fragmentation problem, small
chunk size will hurt large io performance (any io larger than chunk
size has allocate DMA on-the-fly), so we choose a compromised chunk
size: 8MB.

The initial buffer size is still 256MB, upper limit is 1GB. The
hardcoded upper limit will be removed and being derived from the
configured nr_hugepages in later patch.

Signed-off-by: Niu Yawei <yawei.niu@intel.com>