### PR TITLE
DAOS-5948 daos(8): Integrate obj_ctl utility into the daos utility

### DIFF
--- a/src/utils/daos.c
+++ b/src/utils/daos.c
@@ -1560,7 +1560,7 @@ help_hdlr(int argc, char *argv[], struct cmd_args_s *ap)
 			"shell commands:\n"
 		"	  daos             open shell for DAOS operations\n"
 		"shell (sh) options:\n"
-		"	  <pool options>   (--pool, --sys-name)\n");
+		"	  <pool/cont opts> (--pool, --sys-name, --cont [optional])\n");
 
 	} else {
 		FIRST_LEVEL_HELP();


### PR DESCRIPTION
* Make container parameter optional for daos shell. If
  the container parameter is not provided, daos shell
  will create a new container.
* Remove epoch from daos shell interface.

Signed-off-by: Jonathan Martinez Montes <jonathan.martinez.montes@intel.com>