### PR TITLE
DAOS-7098 test: dfs test increment nr fail

### DIFF
--- a/src/tests/suite/dfs_test.c
+++ b/src/tests/suite/dfs_test.c
@@ -58,7 +58,7 @@ run_specified_tests(const char *tests, int rank, int size,
 			daos_test_print(rank, "\n\n=================");
 			daos_test_print(rank, "DFS unit tests..");
 			daos_test_print(rank, "=====================");
-			nr_failed = run_dfs_unit_test(rank, size);
+			nr_failed += run_dfs_unit_test(rank, size);
 			break;
 
 		default:


### PR DESCRIPTION
Correct a "=" to "+=" when tracking total test failures.

Signed-off-by: Dalton Bohning <daltonx.bohning@intel.com>