### PR TITLE
DAOS-6772 doc: update dedup limitations (#5004)

### DIFF
--- a/doc/user/container.md
+++ b/doc/user/container.md
@@ -147,6 +147,8 @@ configure dedup, the following container properties are used:
     checksum tree isn't persistent yet. This means that aggregation is disabled
     for a container with dedplication enabled and duplicated extents won't be
     matched after a server restart.
+    NVMe isn't supported for dedup enabled container, so please make sure not
+    using dedup on the pool with NVMe enabled.
 
 ## Compression & Encryption
 


### PR DESCRIPTION
Update dedup limitation of NVMe support on memcpy mode.

Skip-test: true
Doc-only: true

Signed-off-by: Niu Yawei <yawei.niu@intel.com>