### PR TITLE
DAOS-6572 engine: Use CDEBUG to silence shutdown warnings. (#4859)

### DIFF
--- a/src/container/srv_target.c
+++ b/src/container/srv_target.c
@@ -63,10 +63,11 @@ cont_aggregate_epr(struct ds_cont_child *cont, daos_epoch_range_t *epr,
 	rc = ds_obj_ec_aggregate(cont, epr, dss_ult_yield,
 				 (void *)cont->sc_agg_req, is_current);
 	if (rc) {
+		D_CDEBUG(rc == -DER_NOTLEADER || rc == -DER_SHUTDOWN,
+			 DB_ANY, DLOG_ERR,
+			 "EC aggregation returned: "DF_RC"\n", DP_RC(rc));
 		if (rc == -DER_NOTLEADER)
 			return -DER_SHUTDOWN;
-		D_ERROR("EC aggregation returned: "DF_RC"\n",
-			DP_RC(rc));
 	}
 
 	if (dss_ult_exiting(cont->sc_agg_req))

--- a/src/pool/srv_iv.c
+++ b/src/pool/srv_iv.c
@@ -1266,7 +1266,8 @@ ds_pool_iv_srv_hdl_fetch(struct ds_pool *pool, uuid_t *pool_hdl_uuid,
 	pool_key->pik_entry_size = sizeof(struct pool_iv_entry);
 	rc = ds_iv_fetch(pool->sp_iv_ns, &key, &sgl, false /* retry */);
 	if (rc) {
-		D_CDEBUG(rc == -DER_NOTLEADER, DB_ANY, DLOG_ERR,
+		D_CDEBUG(rc == -DER_NOTLEADER || rc == -DER_SHUTDOWN,
+			 DB_ANY, DLOG_ERR,
 			 "iv fetch failed "DF_RC"\n", DP_RC(rc));
 		D_GOTO(out, rc);
 	}

--- a/src/tests/ftest/cart/util/cart_logparse.py
+++ b/src/tests/ftest/cart/util/cart_logparse.py
@@ -630,7 +630,7 @@ class LogIter():
             if not line:
                 raise StopIteration
             fields = line.split(' ', 8)
-            if len(fields) < 6 or len(fields[0]) != 17:
+            if len(fields) < 6 or len(fields[0]) != 17 or fields[0][2] != '/':
                 return LogRaw(line)
             return LogLine(line)
 

--- a/src/tests/ftest/cart/util/cart_logtest.py
+++ b/src/tests/ftest/cart/util/cart_logtest.py
@@ -350,6 +350,7 @@ class LogTest():
         err_count = 0
         warnings_strict = False
         warnings_mode = False
+        server_shutdown = False
 
         regions = OrderedDict()
         memsize = hwm_counter()
@@ -376,6 +377,9 @@ class LogTest():
             except AttributeError:
                 pass
             if abort_on_warning:
+                if not server_shutdown and \
+                   line.fac != 'external' and line.function == 'server_fini':
+                    server_shutdown = True
                 if line.level <= cart_logparse.LOG_LEVELS['WARN']:
                     show = True
                     if self.hide_fi_calls:
@@ -415,6 +419,9 @@ class LogTest():
                         if line.rpc_opcode == '0xfe000000':
                             show = False
                     if line.fac == 'external':
+                        show = False
+                    if show and server_shutdown and line.get_msg().endswith(
+                            "DER_SHUTDOWN(-2017): 'Service should shut down'"):
                         show = False
                     if show:
                         # Allow WARNING or ERROR messages, but anything higher
@@ -690,6 +697,7 @@ def run():
     parser.add_argument('--dfuse',
                         help='Summarise dfuse I/O',
                         action='store_true')
+    parser.add_argument('--warnings', action='store_true')
     parser.add_argument('file', help='input file')
     args = parser.parse_args()
     try:
@@ -709,7 +717,7 @@ def run():
         test_iter.check_dfuse_io()
     else:
         try:
-            test_iter.check_log_file(False)
+            test_iter.check_log_file(args.warnings)
         except LogError:
             print('Errors in log file, ignoring')
         except NotAllFreed:


### PR DESCRIPTION
Silence errors at shutdown.

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>