### PR TITLE
DAOS-7061 rebuild: avoid single replica object (#5084)

### DIFF
--- a/src/include/daos/placement.h
+++ b/src/include/daos/placement.h
@@ -134,6 +134,11 @@ int pl_obj_find_rebuild(struct pl_map *map,
 			uint32_t rebuild_ver, uint32_t *tgt_rank,
 			uint32_t *shard_id, unsigned int array_size);
 
+int pl_obj_find_drain(struct pl_map *map, struct daos_obj_md *md,
+		      struct daos_obj_shard_md *shard_md,
+		      uint32_t rebuild_ver, uint32_t *tgt_rank,
+		      uint32_t *shard_id, unsigned int array_size);
+
 int pl_obj_find_reint(struct pl_map *map,
 			struct daos_obj_md *md,
 			struct daos_obj_shard_md *shard_md,

--- a/src/placement/pl_map.c
+++ b/src/placement/pl_map.c
@@ -149,6 +149,27 @@ pl_obj_find_rebuild(struct pl_map *map, struct daos_obj_md *md,
 		    uint32_t rebuild_ver, uint32_t *tgt_rank,
 		    uint32_t *shard_id, unsigned int array_size)
 {
+	struct daos_oclass_attr *oc_attr;
+
+	D_ASSERT(map->pl_ops != NULL);
+
+	oc_attr = daos_oclass_attr_find(md->omd_id);
+	if (daos_oclass_grp_size(oc_attr) == 1)
+		return 0;
+
+	if (!map->pl_ops->o_obj_find_rebuild)
+		return -DER_NOSYS;
+
+	return map->pl_ops->o_obj_find_rebuild(map, md, shard_md, rebuild_ver,
+					       tgt_rank, shard_id, array_size);
+}
+
+int
+pl_obj_find_drain(struct pl_map *map, struct daos_obj_md *md,
+		  struct daos_obj_shard_md *shard_md,
+		  uint32_t rebuild_ver, uint32_t *tgt_rank,
+		  uint32_t *shard_id, unsigned int array_size)
+{
 	D_ASSERT(map->pl_ops != NULL);
 
 	if (!map->pl_ops->o_obj_find_rebuild)
@@ -164,13 +185,19 @@ pl_obj_find_reint(struct pl_map *map, struct daos_obj_md *md,
 		    uint32_t reint_ver, uint32_t *tgt_rank,
 		    uint32_t *shard_id, unsigned int array_size)
 {
+	struct daos_oclass_attr *oc_attr;
+
 	D_ASSERT(map->pl_ops != NULL);
+
+	oc_attr = daos_oclass_attr_find(md->omd_id);
+	if (daos_oclass_grp_size(oc_attr) == 1)
+		return 0;
 
 	if (!map->pl_ops->o_obj_find_reint)
 		return -DER_NOSYS;
 
 	return map->pl_ops->o_obj_find_reint(map, md, shard_md, reint_ver,
-					       tgt_rank, shard_id, array_size);
+					     tgt_rank, shard_id, array_size);
 }
 
 int

--- a/src/rebuild/scan.c
+++ b/src/rebuild/scan.c
@@ -406,10 +406,8 @@ find_rebuild_shards(unsigned int *tgt_stack_array,
 						 *tgts, *shards,
 						 max_shards);
 		} else if (rebuild_op == RB_OP_DRAIN) {
-			rc = pl_obj_find_rebuild(map, md, NULL,
-						 rebuild_ver,
-						 *tgts, *shards,
-						 max_shards);
+			rc = pl_obj_find_drain(map, md, NULL, rebuild_ver,
+					       *tgts, *shards, max_shards);
 		} else if (rebuild_op == RB_OP_REINT) {
 			rc = pl_obj_find_reint(map, md, NULL,
 					       rebuild_ver,

--- a/src/tests/suite/daos_rebuild_simple.c
+++ b/src/tests/suite/daos_rebuild_simple.c
@@ -796,6 +796,16 @@ rebuild_sx_object_internal(void **state, uint16_t oclass)
 
 	/* wait until reintegration is done */
 	test_rebuild_wait(&arg, 1);
+
+	print_message("lookup 100 dkeys\n");
+	for (i = 0; i < 100; i++) {
+		char buffer[32];
+
+		memset(buffer, 0, 32);
+		sprintf(dkey, "dkey_%d\n", i);
+		lookup_single(dkey, akey, 0, buffer, 32, DAOS_TX_NONE, &req);
+		assert_string_equal(buffer, rec);
+	}
 	ioreq_fini(&req);
 }
 


### PR DESCRIPTION
Avoid single replica object so to avoid those data missing
error(-2026) during migration.

Signed-off-by: Di Wang <di.wang@intel.com>