### PR TITLE
DAOS-7076 rebuild: remove some obsolete code

### DIFF
--- a/src/include/daos_srv/rebuild.h
+++ b/src/include/daos_srv/rebuild.h
@@ -41,7 +41,6 @@ int ds_rebuild_schedule(struct ds_pool *pool, uint32_t map_ver,
 int ds_rebuild_query(uuid_t pool_uuid,
 		     struct daos_rebuild_status *status);
 int ds_rebuild_regenerate_task(struct ds_pool *pool);
-int ds_rebuild_pool_map_update(struct ds_pool *pool);
 void ds_rebuild_leader_stop_all(void);
 void ds_rebuild_leader_stop(const uuid_t pool_uuid, unsigned int version);
 void ds_rebuild_abort(uuid_t pool_uuid, unsigned int version);

--- a/src/pool/srv_target.c
+++ b/src/pool/srv_target.c
@@ -1138,7 +1138,6 @@ update_child_map(void *data)
 	if (child == NULL)
 		return -DER_NONEXIST;
 
-	ds_rebuild_pool_map_update(pool);
 	child->spc_map_version = pool->sp_map_version;
 	ds_pool_child_put(child);
 	return 0;

--- a/src/rebuild/rebuild_internal.h
+++ b/src/rebuild/rebuild_internal.h
@@ -199,9 +199,6 @@ struct rebuild_task {
  */
 struct rebuild_pool_tls {
 	uuid_t		rebuild_pool_uuid;
-	uuid_t		rebuild_poh_uuid;
-	uuid_t		rebuild_coh_uuid;
-	daos_handle_t	rebuild_pool_hdl;
 	daos_handle_t	rebuild_tree_hdl; /*hold objects being rebuilt */
 	d_list_t	rebuild_pool_list;
 	uint64_t	rebuild_pool_obj_count;


### PR DESCRIPTION
Since we already move server to server handle outside
of rebuild, so these poh/coh handles are not needed
anymore.

Signed-off-by: Di Wang <di.wang@intel.com>