### PR TITLE
DAOS-7114-test_rel_1.2: security pool_connect_init failed -1025 due t…

### DIFF
--- a/src/tests/ftest/security/pool_connect_init.yaml
+++ b/src/tests/ftest/security/pool_connect_init.yaml
@@ -17,7 +17,7 @@ server_config:
 pool:
   mode: 511
   name: daos_server
-  scm_size: 16777216
+  scm_size: 186777216
   control_method: dmg
   tests: !mux
       user_root:


### PR DESCRIPTION
…o SCM request too small

updated: security/pool_connect_init.yaml
Skip-unit-tests: true
Skip-nlt: true
Quick-Functional: true
Test-tag: sec_basic
Signed-off-by: Ding Ho ding-hwa.ho@intel.com