### PR TITLE
DAOS-6572 container: Use CDEBUG to silence more warnings.

### DIFF
--- a/src/container/container_iv.c
+++ b/src/container/container_iv.c
@@ -549,7 +549,8 @@ cont_iv_ent_update(struct ds_iv_entry *entry, struct ds_iv_key *key,
 
 out:
 	if (rc < 0 && rc != -DER_IVCB_FORWARD)
-		D_ERROR("failed to insert: rc "DF_RC"\n", DP_RC(rc));
+		D_CDEBUG(rc == -DER_NONEXIST, DB_ANY, DLOG_ERR,
+			 "failed to insert: rc "DF_RC"\n", DP_RC(rc));
 
 	return rc;
 }
@@ -645,7 +646,7 @@ cont_iv_fetch(void *ns, int class_id, uuid_t key_uuid,
 	civ_key->entry_size = entry_size;
 	rc = ds_iv_fetch(ns, &key, cont_iv ? &sgl : NULL, retry);
 	if (rc)
-		D_CDEBUG(rc != -DER_NOTLEADER, DLOG_ERR, DB_MGMT,
+		D_CDEBUG(rc == -DER_NOTLEADER, DB_MGMT, DLOG_ERR,
 			 DF_UUID" iv fetch failed "DF_RC"\n",
 			 DP_UUID(key_uuid), DP_RC(rc));
 
@@ -1317,4 +1318,3 @@ out:
 
 	return rc;
 }
-


### PR DESCRIPTION
    DAOS-6572 container: Use CDEBUG to silence more warnings. (#4771)

    * DAOS-6572 container: Use CDEBUG to silence more warnings.

    Silence more intermittent startup warnings.

    Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>