### PR TITLE
DAOS-7115 test: Fix rebuild_test.py failing in CI

### DIFF
--- a/src/tests/ftest/pool/rebuild_tests.yaml
+++ b/src/tests/ftest/pool/rebuild_tests.yaml
@@ -12,7 +12,7 @@ timeout: 600
 server_config:
   name: daos_server
   servers:
-    targets: 8
+    targets: 2
 pool:
   mode: 511
   name: daos_server


### PR DESCRIPTION
Due to recent increase of resources on vms the test
started failing and brought up some test code issues
as well as daos handling of server start when resources
available on nodes are limited. As a workaround number
of targets for the test is reduced and the way calculations
are done for expected values is modified a little.

Quick-Functional: true
Test-tag: rebuild_tests

Signed-off-by: Saurabh Tandan <saurabh.tandan@intel.com>