### PR TITLE
DAOS-6965 Test: Increased the SCM size as recent layout change need more space with current dataset.

### DIFF
--- a/src/tests/ftest/nvme/nvme_object.py
+++ b/src/tests/ftest/nvme/nvme_object.py
@@ -8,6 +8,7 @@
 
 import threading
 import avocado
+import time
 
 from pydaos.raw import DaosApiError
 from test_utils_pool import TestPool
@@ -194,6 +195,7 @@ class NvmeObject(TestWithServers):
         threads = []
         index = 0
         for size in self.pool_size[:-1]:
+            time.sleep(1)
             thread = threading.Thread(target=test_runner,
                                       args=(self, size, self.record_size,
                                             index, self.array_size))

--- a/src/tests/ftest/nvme/nvme_object.yaml
+++ b/src/tests/ftest/nvme/nvme_object.yaml
@@ -19,6 +19,8 @@ server_config:
   servers:
     bdev_class: nvme
     bdev_list: ["0000:81:00.0","0000:da:00.0"]
+    scm_class: dcpm
+    scm_list: ["/dev/pmem0"]
   transport_config:
     allow_insecure: True
 agent_config:
@@ -33,7 +35,7 @@ pool:
   createset:
     group: daos_server
   createsize:
-    scm_size: 1000000000
+    scm_size: 4000000000
     size:
       - 20000000000
       - 100000000000


### PR DESCRIPTION
The test is failing because of SCM size target size is getting low 9MB with the dataset.
This test has no requirement to use low size so increase enough so the test
should not fail with ENOSPACE.
Updated test to use PCMEM instead of using tmpfs.

Quick-build: true
Test-tag: nvme_object_multiple_pools

Signed-off-by: Samir Raval <samir.raval@intel.com>