### PR TITLE
DAOS-2450 Test: Fix tag=quick such that it is a quick verification

### DIFF
--- a/src/tests/ftest/container/autotest.py
+++ b/src/tests/ftest/container/autotest.py
@@ -1,0 +1,34 @@
+#!/usr/bin/python
+"""
+  (C) Copyright 2018-2021 Intel Corporation.
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+"""
+from apricot import TestWithServers
+from test_utils_container import TestContainer
+
+
+class ContainerAutotestTest(TestWithServers):
+    # pylint: disable=too-few-public-methods
+    """Tests container autotest.
+
+    :avocado: recursive
+    """
+
+    def __init__(self, *args, **kwargs):
+        """Initialize object."""
+        super().__init__(*args, **kwargs)
+        self.pool = None
+        self.container = None
+
+    def test_container_autotest(self):
+        """Test container autotest.
+
+        :avocado: tags=all,full_regression,daily,hw,quick,autotest
+        """
+        # Create a pool
+        self.log.info("Create a pool")
+        self.add_pool()
+        self.daos_cmd = self.get_daos_command()
+        self.log.info("Autotest start")
+        self.daos_cmd.pool_autotest(pool=self.pool.uuid)

--- a/src/tests/ftest/container/autotest.yaml
+++ b/src/tests/ftest/container/autotest.yaml
@@ -1,0 +1,19 @@
+hosts:
+  test_servers:
+    - server-A
+  test_clients:
+    - server-A
+timeout: 360
+server_config:
+  name: daos_server
+  servers:
+    scm_size: 20
+    bdev_class: nvme
+    bdev_list: ["aaaa:aa:aa.a"]
+pool:
+  mode: 146
+  scm_size: 16G
+  nvme_size: 128G
+  control_method: dmg
+
+

--- a/src/tests/ftest/util/daos_utils.py
+++ b/src/tests/ftest/util/daos_utils.py
@@ -73,6 +73,22 @@ class DaosCommand(DaosCommandBase):
         return self._get_result(
             ("pool", "query"), pool=pool, sys_name=sys_name, sys=sys)
 
+    def pool_autotest(self, pool):
+        """Runs autotest for pool
+
+        Args:
+            pool (str): pool UUID
+
+        Returns:
+            CmdResult: Object that contains exit status, stdout, and other
+                information.
+
+        Raises:
+            CommandFailure: if the daos pool autotest command fails.
+        """
+        return self._get_result(
+            ("pool", "autotest"), pool=pool)
+
     def container_create(self, pool, sys_name=None, cont=None,
                          path=None, cont_type=None, oclass=None,
                          chunk_size=None, properties=None, acl_file=None):

--- a/src/tests/ftest/util/daos_utils_base.py
+++ b/src/tests/ftest/util/daos_utils_base.py
@@ -56,6 +56,8 @@ class DaosCommandBase(CommandWithSubCommand):
                 self.sub_command_class = self.GetAttrSubCommand()
             elif self.sub_command.value == "set-attr":
                 self.sub_command_class = self.SetAttrSubCommand()
+            elif self.sub_command.value == "autotest":
+                self.sub_command_class = self.AutotestSubCommand()
             else:
                 self.sub_command_class = None
 
@@ -118,6 +120,13 @@ class DaosCommandBase(CommandWithSubCommand):
                 super().__init__("set-attr")
                 self.attr = FormattedParameter("--attr={}")
                 self.value = FormattedParameter("--value={}")
+
+        class AutotestSubCommand(CommonPoolSubCommand):
+            """Defines an object for the daos pool autotest command."""
+
+            def __init__(self):
+                """Create a daos pool autotest command object."""
+                super().__init__("autotest")
 
     class ContainerSubCommand(CommandWithSubCommand):
         """Defines an object for the daos container sub command."""


### PR DESCRIPTION
    Added daos cont autotest subcommand to daos_utils.
    Command "daos cont autotest" is now tested within container/autotest.py.

Features: quick
Signed-off-by: Omar Ocampo <omar.ocampo.coronado@intel.com>