### PR TITLE
DAOS-4855 debug: set default log mask to DLOG_ERR (#5174)

### DIFF
--- a/src/common/debug.c
+++ b/src/common/debug.c
@@ -144,7 +144,7 @@ daos_debug_init(char *logfile)
 	}
 
 
-	rc = d_log_init_adv("DAOS", logfile, flags, DLOG_INFO, DLOG_CRIT);
+	rc = d_log_init_adv("DAOS", logfile, flags, DLOG_ERR, DLOG_CRIT);
 	if (rc != 0) {
 		D_PRINT_ERR("Failed to init DAOS debug log: "DF_RC"\n",
 			DP_RC(rc));


### PR DESCRIPTION
By default log mask was set to DLOG_INFO. This is harmless on
server side since it will be overidden using log_mask parameter
in config file. But on client side, now that default log stream
is stdout since first PR-3048 for DAOS-4855, it causes
unnecessary messages to be printed on interactive terminal.

So set default log mask to DLOG_ERR instead and leave the choice
to the user to change it using D_LOG_MASK environment variable.

Master-PR: https://github.com/daos-stack/daos/pull/5174
Change-Id: If9b89a81764734ccb11e712fb3efc6a442b2713a
Signed-off-by: Bruno Faccini <bruno.faccini@intel.com>