### PR TITLE
DAOS-7042 cont: fix a bug in ds_get_cont_props()

### DIFF
--- a/src/common/cont_props.c
+++ b/src/common/cont_props.c
@@ -3,6 +3,7 @@
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
+#define D_LOGFAC	DD_FAC(common)
 
 #include <daos/cont_props.h>
 #include <daos/common.h>
@@ -15,6 +16,20 @@ daos_props_2cont_props(daos_prop_t *props, struct cont_props *cont_prop)
 			props, cont_prop);
 		return;
 	}
+
+	/* input props should cover needed entries, see ds_get_cont_props() */
+	if (daos_prop_entry_get(props, DAOS_PROP_CO_DEDUP) == NULL	     ||
+	    daos_prop_entry_get(props, DAOS_PROP_CO_DEDUP_THRESHOLD) == NULL ||
+	    daos_prop_entry_get(props, DAOS_PROP_CO_CSUM_SERVER_VERIFY)
+	    == NULL							     ||
+	    daos_prop_entry_get(props, DAOS_PROP_CO_CSUM) == NULL	     ||
+	    daos_prop_entry_get(props, DAOS_PROP_CO_CSUM_CHUNK_SIZE) == NULL ||
+	    daos_prop_entry_get(props, DAOS_PROP_CO_COMPRESS) == NULL	     ||
+	    daos_prop_entry_get(props, DAOS_PROP_CO_ENCRYPT) == NULL	     ||
+	    daos_prop_entry_get(props, DAOS_PROP_CO_REDUN_FAC) == NULL	     ||
+	    daos_prop_entry_get(props, DAOS_PROP_CO_ALLOCED_OID) == NULL)
+		D_DEBUG(DB_TRACE, "some prop entry type not found, "
+			"use default value.\n");
 
 	/** deduplication */
 	cont_prop->dcp_dedup_enabled	= daos_cont_prop2dedup(props);

--- a/src/container/srv_target.c
+++ b/src/container/srv_target.c
@@ -123,7 +123,10 @@ ds_get_cont_props(struct cont_props *cont_props, struct ds_iv_ns *pool_ns,
 	daos_prop_t	*props;
 	int		 rc;
 
-	props = daos_prop_alloc(7);
+	/* The provided prop entry types should cover the types used in
+	 * daos_props_2cont_props().
+	 */
+	props = daos_prop_alloc(9);
 	if (props == NULL)
 		return -DER_NOMEM;
 
@@ -134,6 +137,8 @@ ds_get_cont_props(struct cont_props *cont_props, struct ds_iv_ns *pool_ns,
 	props->dpp_entries[4].dpe_type = DAOS_PROP_CO_DEDUP_THRESHOLD;
 	props->dpp_entries[5].dpe_type = DAOS_PROP_CO_COMPRESS;
 	props->dpp_entries[6].dpe_type = DAOS_PROP_CO_ENCRYPT;
+	props->dpp_entries[7].dpe_type = DAOS_PROP_CO_REDUN_FAC;
+	props->dpp_entries[8].dpe_type = DAOS_PROP_CO_ALLOCED_OID;
 
 	rc = cont_iv_prop_fetch(pool_ns, cont_uuid, props);
 


### PR DESCRIPTION
ds_get_cont_props() is used to fetch prop and set cont->sc_props,
it should cover all the prop entry types needed for "struct cont_props".

Test-tag-hw-medium: pr,hw,medium,ib2 offline_reintegration_daily

Signed-off-by: Xuezhao Liu <xuezhao.liu@intel.com>