### PR TITLE
DAOS-7088 Test: Fix NVMe util for calculating IOR block size. (#5136)

### DIFF
--- a/src/tests/ftest/util/nvme_utils.py
+++ b/src/tests/ftest/util/nvme_utils.py
@@ -162,7 +162,7 @@ class ServerFillUp(IorTestBase):
         _tmp_block_size = (((free_space/100)*self.capacity)/self.processes)
         _tmp_block_size = int(_tmp_block_size / int(replica_server))
         block_size = (
-            (_tmp_block_size / int(self.ior_cmd.transfer_size.value)) *
+            int(_tmp_block_size / int(self.ior_cmd.transfer_size.value)) *
             int(self.ior_cmd.transfer_size.value))
         return block_size
 


### PR DESCRIPTION
Blocksize variable need to be int type to get the IOR blocksize
multiple of Transfer size.

Quick-Functional: true
Test-tag: nvme_fault

Signed-off-by: Samir Raval <samir.raval@intel.com>