### PR TITLE
DAOS-7129 build: Fix link error with Bullseye

### DIFF
--- a/src/common/SConscript
+++ b/src/common/SConscript
@@ -51,7 +51,13 @@ def build_dts_library(env):
 
     denv.AppendUnique(CPPPATH=["../tests/suite"])
 
-    Import('dc_credit')
+    dc_credit = denv.SharedObject(['credit.c'])
+    Export('dc_credit')
+
+    denv.Replace(SHOBJPREFIX='t_')
+    t_cmd_parser = denv.SharedObject(['cmd_parser.c'])
+    Export('t_cmd_parser')
+
     dts_lib = daos_build.library(denv, 'libdts', [dc_credit, 'dts.c'],
                                  LIBS=libraries)
     denv.Install('$PREFIX/lib64/', dts_lib)
@@ -84,9 +90,6 @@ def scons():
 
     tlib_env = denv.Clone()
     tlib_env.AppendUnique(LIBS=['json-c'])
-
-    dc_credit = denv.SharedObject(['credit.c'])
-    Export('dc_credit')
 
     cmd_parser = denv.SharedObject(['cmd_parser.c'])
     Export('cmd_parser')

--- a/src/tests/SConscript
+++ b/src/tests/SConscript
@@ -38,9 +38,9 @@ def scons():
                                     LIBS=libs)
     denv.Install('$PREFIX/bin/', daos_racer)
 
-    Import('cmd_parser')
+    Import('t_cmd_parser')
     obj_ctl = daos_build.program(denv, 'obj_ctl',
-                                 ['obj_ctl.c', cmd_parser],
+                                 ['obj_ctl.c', t_cmd_parser],
                                  LIBS=libs)
     denv.Install('$PREFIX/bin/', obj_ctl)
 


### PR DESCRIPTION
Need to generate mpicc and gcc versions of object files to
avoid link errors when compiling libraries and binaries with
mpicc.

Skip-bullseye: false

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>