### PR TITLE
DAOS-7115 test: Fix rebuild_test.py failing in CI (#5226)

### DIFF
--- a/src/tests/ftest/pool/rebuild_tests.py
+++ b/src/tests/ftest/pool/rebuild_tests.py
@@ -30,14 +30,23 @@ class RebuildTests(TestWithServers):
         rank = self.params.get("rank", "/run/testparams/*")
         obj_class = self.params.get("object_class", "/run/testparams/*")
 
-        # Create the pools and confirm their status
+        # Collect server configuration information
         server_count = len(self.hostlist_servers)
+        engine_count = self.server_managers[0].get_config_value(
+            "engines_per_host")
+        engine_count = 1 if engine_count is None else int(engine_count)
+        target_count = int(self.server_managers[0].get_config_value("targets"))
+        self.log.info(
+            "Running with %s servers, %s engines per server, and %s targets "
+            "per engine", server_count, engine_count, target_count)
+
+        # Create the pools and confirm their status
         status = True
         for index in range(pool_quantity):
             self.pool[index].create()
             status &= self.pool[index].check_pool_info(
-                pi_nnodes=server_count,
-                pi_ntargets=server_count,               # DAOS-2799
+                pi_nnodes=server_count * engine_count,
+                pi_ntargets=server_count * engine_count * target_count,
                 pi_ndisabled=0
             )
             status &= self.pool[index].check_rebuild_status(
@@ -90,9 +99,9 @@ class RebuildTests(TestWithServers):
         status = True
         for index in range(pool_quantity):
             status &= self.pool[index].check_pool_info(
-                pi_nnodes=server_count,
-                pi_ntargets=server_count,              # DAOS-2799
-                pi_ndisabled=1
+                pi_nnodes=server_count * engine_count,
+                pi_ntargets=server_count * engine_count * target_count,
+                pi_ndisabled=target_count
             )
             status &= self.pool[index].check_rebuild_status(
                 rs_done=1, rs_obj_nr=rs_obj_nr[index],
@@ -113,7 +122,11 @@ class RebuildTests(TestWithServers):
             The most basic rebuild test.
         Use Cases:
             single pool rebuild, single client, various record/object counts
-        :avocado: tags=all,daily_regression,large,pool,rebuild,rebuildsimple
+
+        :avocado: tags=all,daily_regression
+        :avocado: tags=vm,large
+        :avocado: tags=rebuild
+        :avocado: tags=pool,rebuild_tests,test_simple_rebuild
         """
         self.run_rebuild_test(1)
 
@@ -124,6 +137,10 @@ class RebuildTests(TestWithServers):
             Expand on the basic test by rebuilding 2 pools at once.
         Use Cases:
             multipool rebuild, single client, various object and record counts
-        :avocado: tags=all,daily_regression,large,pool,rebuild,rebuildmulti
+
+        :avocado: tags=all,daily_regression
+        :avocado: tags=vm,large
+        :avocado: tags=rebuild
+        :avocado: tags=pool,rebuild_tests,test_multipool_rebuild
         """
         self.run_rebuild_test(self.params.get("quantity", "/run/testparams/*"))

--- a/src/tests/ftest/pool/rebuild_tests.yaml
+++ b/src/tests/ftest/pool/rebuild_tests.yaml
@@ -12,7 +12,7 @@ timeout: 600
 server_config:
   name: daos_server
   servers:
-    targets: 8
+    targets: 2
 pool:
   mode: 511
   name: daos_server


### PR DESCRIPTION
Due to recent increase of resources on vms the test
started failing and brought up some test code issues
as well as daos handling of server start when resources
available on nodes are limited. As a workaround number
of targets for the test is reduced and the way calculations
are done for expected values is modified a little.

Signed-off-by: Saurabh Tandan <saurabh.tandan@intel.com>
Conflicts:
	src/tests/ftest/pool/rebuild_tests.py

Quick-Functional: true
Test-tag: rebuild_tests