### PR TITLE
DAOS-6923 test: Offline Reintegration : More tests (cherry_pick 1.2)

### DIFF
--- a/src/tests/ftest/osa/osa_offline_drain.py
+++ b/src/tests/ftest/osa/osa_offline_drain.py
@@ -23,26 +23,27 @@ class OSAOfflineDrain(OSAUtils):
         """Set up for test case."""
         super().setUp()
         self.dmg_command = self.get_dmg_command()
-        self.ior_apis = self.params.get("ior_api", '/run/ior/iorflags/*')
         self.ior_test_sequence = self.params.get(
             "ior_test_sequence", '/run/ior/iorflags/*')
-        self.ior_dfs_oclass = self.params.get(
-            "obj_class", '/run/ior/iorflags/*')
         # Recreate the client hostfile without slots defined
         self.hostfile_clients = write_host_file(
             self.hostlist_clients, self.workdir, None)
 
-    def run_offline_drain_test(self, num_pool, data=False):
+    def run_offline_drain_test(self, num_pool, data=False,
+                               oclass=None):
         """Run the offline drain without data.
             Args:
             num_pool (int) : total pools to create for testing purposes.
             data (bool) : whether pool has no data or to create
                           some data in pool. Defaults to False.
+            oclass (str): DAOS object class (eg: RP_2G1,etc)
         """
         # Create a pool
         pool = {}
-        pool_uuid = []
         target_list = []
+
+        if oclass is None:
+            oclass = self.ior_cmd.dfs_oclass.value
 
         # Exclude target : random two targets  (target idx : 0-7)
         n = random.randint(0, 6)
@@ -62,25 +63,28 @@ class OSAOfflineDrain(OSAUtils):
             pool[val].nvme_size.value = int(pool[val].nvme_size.value /
                                             num_pool)
             pool[val].create()
-            pool_uuid.append(pool[val].uuid)
             self.pool = pool[val]
-            if data:
-                self.run_ior_thread("Write", self.ior_dfs_oclass[0],
-                                    self.ior_apis[0],
-                                    self.ior_test_sequence[0])
+            self.pool.set_property("reclaim", "disabled")
+            test_seq = self.ior_test_sequence[0]
 
-        # Drain the pool_uuid, rank and targets
+            if data:
+                self.run_ior_thread("Write", oclass, test_seq)
+                self.run_mdtest_thread()
+
+        # Drain rank and targets
         for val in range(0, num_pool):
             self.pool = pool[val]
             rank = rank + val
             self.pool.display_pool_daos_space("Pool space: Beginning")
             pver_begin = self.get_pool_version()
             self.log.info("Pool Version at the beginning %s", pver_begin)
+            if self.test_during_aggregation is True:
+                self.pool.set_property("reclaim", "time")
+                self.delete_extra_container(self.pool)
+                self.simple_exclude_reintegrate_loop(rank)
             output = self.dmg_command.pool_drain(self.pool.uuid,
                                                  rank, t_string)
-            self.log.info(output)
-            self.is_rebuild_done(3)
-            self.assert_on_rebuild_failure()
+            self.print_and_assert_on_rebuild_failure(output)
 
             pver_drain = self.get_pool_version()
             self.log.info("Pool Version after drain %d", pver_drain)
@@ -93,8 +97,8 @@ class OSAOfflineDrain(OSAUtils):
             pool[val].display_pool_daos_space(display_string)
 
         if data:
-            self.run_ior_thread("Read", self.ior_dfs_oclass[0],
-                                self.ior_apis[0], self.ior_test_sequence[0])
+            self.run_ior_thread("Read", oclass, test_seq)
+            self.run_mdtest_thread()
 
     @skipForTicket("DAOS-6668")
     def test_osa_offline_drain(self):

--- a/src/tests/ftest/osa/osa_offline_drain.yaml
+++ b/src/tests/ftest/osa/osa_offline_drain.yaml
@@ -73,12 +73,37 @@ ior:
     iorflags:
       write_flags: "-w -F -k -G 1"
       read_flags: "-F -r -R -k -G 1"
-      ior_api:
-        - DFS
-      obj_class:
-        - RP_2G1
+      api: DFS
+      dfs_oclass: RP_2G1
+      dfs_dir_oclass: RP_2G1
     ior_test_sequence:
     #   - [scmsize, nvmesize, transfersize, blocksize]
     #    The values are set to be in the multiples of 10.
     #    Values are appx GB.
       - [6000000000, 54000000000, 500000, 500000000]
+mdtest:
+  api: DFS
+  client_processes:
+    np: 30
+  num_of_files_dirs: 4067         # creating total of 120K files
+  test_dir: "/"
+  iteration: 1
+  dfs_destroy: False
+  dfs_oclass: RP_2G1
+  dfs_dir_oclass: RP_2G1
+  manager: "MPICH"
+  flags: "-u"
+  wr_size:
+    32K:
+      write_bytes: 32768
+      read_bytes: 32768
+  verbosity_value: 1
+  depth: 0
+test_obj_class:
+  oclass:
+    - RP_2G8
+    - RP_3G6
+    - RP_4G1
+aggregation:
+  test_with_aggregation: True
+

--- a/src/tests/ftest/osa/osa_offline_reintegration.py
+++ b/src/tests/ftest/osa/osa_offline_reintegration.py
@@ -6,6 +6,7 @@
 """
 import random
 from osa_utils import OSAUtils
+from daos_utils import DaosCommand
 from test_utils_pool import TestPool
 from write_host_file import write_host_file
 from apricot import skipForTicket
@@ -25,17 +26,18 @@ class OSAOfflineReintegration(OSAUtils):
         """Set up for test case."""
         super().setUp()
         self.dmg_command = self.get_dmg_command()
-        self.ior_apis = self.params.get("ior_api", '/run/ior/iorflags/*')
-        self.ior_test_sequence = self.params.get(
-            "ior_test_sequence", '/run/ior/iorflags/*')
-        self.ior_dfs_oclass = self.params.get(
-            "obj_class", '/run/ior/iorflags/*')
+        self.daos_command = DaosCommand(self.bin)
+        self.ior_test_sequence = self.params.get("ior_test_sequence",
+                                                 '/run/ior/iorflags/*')
+        self.test_oclass = self.params.get("oclass", '/run/test_obj_class/*')
+        self.loop_test_cnt = 1
         # Recreate the client hostfile without slots defined
         self.hostfile_clients = write_host_file(
             self.hostlist_clients, self.workdir, None)
+        self.dmg_command.exit_status_exception = True
 
     def run_offline_reintegration_test(self, num_pool, data=False,
-                                       server_boot=False):
+                                       server_boot=False, oclass=None):
         """Run the offline reintegration without data.
 
         Args:
@@ -43,97 +45,189 @@ class OSAOfflineReintegration(OSAUtils):
             data (bool) : whether pool has no data or to create
                 some data in pool. Defaults to False.
             server_boot (bool) : Perform system stop/start on a rank.
-                Defaults to False.
+                                 Defaults to False.
+            oclass (str) : daos object class string (eg: "RP_2G8")
         """
         # Create a pool
         pool = {}
-        pool_uuid = []
-        exclude_servers = (len(self.hostlist_servers) * 2) - 1
+        random_pool = 0
+        if oclass is None:
+            oclass = self.ior_cmd.dfs_oclass.value
 
-        # Exclude rank : two ranks other than rank 0.
-        rank = random.randint(1, exclude_servers)
-
+        # Exclude ranks [0, 3, 4]
+        rank = [0, 3, 4]
         for val in range(0, num_pool):
             pool[val] = TestPool(self.context,
                                  dmg_command=self.get_dmg_command())
             pool[val].get_params(self)
-            # Split total SCM and NVME size for creating multiple pools.
-            pool[val].scm_size.value = int(pool[val].scm_size.value /
-                                           num_pool)
-            pool[val].nvme_size.value = int(pool[val].nvme_size.value /
-                                            num_pool)
             pool[val].create()
-            pool_uuid.append(pool[val].uuid)
             self.pool = pool[val]
+            self.pool.set_property("reclaim", "disabled")
+            test_seq = self.ior_test_sequence[0]
             if data:
-                self.run_ior_thread("Write", self.ior_dfs_oclass[0],
-                                    self.ior_apis[0], self.ior_test_sequence[0])
+                self.run_ior_thread("Write", oclass, test_seq)
+                self.run_mdtest_thread()
+                if self.test_during_aggregation is True:
+                    self.run_ior_thread("Write", oclass, test_seq)
 
-        # Exclude and reintegrate the pool_uuid, rank and targets
-        for val in range(0, num_pool):
-            self.pool = pool[val]
-            self.pool.display_pool_daos_space("Pool space: Beginning")
-            pver_begin = self.get_pool_version()
-            self.log.info("Pool Version at the beginning %s", pver_begin)
-            if server_boot is False:
-                output = self.dmg_command.pool_exclude(self.pool.uuid,
-                                                       rank)
-            else:
-                output = self.dmg_command.system_stop(ranks=rank)
-                self.pool.wait_for_rebuild(True)
-                self.log.info(output)
-                output = self.dmg_command.system_start(ranks=rank)
+        # Exclude all the ranks
+        random_pool = random.randint(0, (num_pool-1))
+        for _ in range(0, self.loop_test_cnt):
+            for val, _ in enumerate(rank):
+                self.pool = pool[random_pool]
+                self.pool.display_pool_daos_space("Pool space: Beginning")
+                pver_begin = self.get_pool_version()
+                self.log.info("Pool Version at the beginning %s", pver_begin)
+                if server_boot is False:
+                    if (self.test_during_rebuild is True and val == 0):
+                        # Exclude rank 5
+                        output = self.dmg_command.pool_exclude(self.pool.uuid,
+                                                               "5")
+                        self.print_and_assert_on_rebuild_failure(output)
+                    if self.test_during_aggregation is True:
+                        self.delete_extra_container(self.pool)
+                        self.simple_exclude_reintegrate_loop(rank[val])
+                    output = self.dmg_command.pool_exclude(self.pool.uuid,
+                                                           rank[val])
+                    # Check the IOR data after exclude
+                    if data:
+                        self.run_ior_thread("Read", oclass, test_seq)
+                else:
+                    output = self.dmg_command.system_stop(ranks=rank[val],
+                                                          force=True)
+                    self.print_and_assert_on_rebuild_failure(output)
+                    # Check the IOR data after system stop
+                    if data and (val == 0):
+                        self.run_ior_thread("Read", oclass, test_seq)
+                    output = self.dmg_command.system_start(ranks=rank[val])
+                # Just try to reintegrate rank 5
+                if (self.test_during_rebuild is True and val == 2):
+                    # Reintegrate rank 5
+                    output = self.dmg_command.pool_reintegrate(self.pool.uuid,
+                                                               "5")
+                self.print_and_assert_on_rebuild_failure(output)
 
-            self.log.info(output)
-            self.is_rebuild_done(3)
-            self.assert_on_rebuild_failure()
+                pver_exclude = self.get_pool_version()
+                self.log.info("Pool Version after exclude %s", pver_exclude)
+                # Check pool version incremented after pool exclude
+                # pver_exclude should be greater than
+                # pver_begin + 3 (2 targets + exclude)
+                self.assertTrue(pver_exclude > (pver_begin + 3),
+                                "Pool Version Error: After exclude")
 
-            pver_exclude = self.get_pool_version()
-            self.log.info("Pool Version after exclude %s", pver_exclude)
-            # Check pool version incremented after pool exclude
-            # pver_exclude should be greater than
-            # pver_begin + 8 targets.
-            self.assertTrue(pver_exclude > (pver_begin + 8),
-                            "Pool Version Error:  After exclude")
-            output = self.dmg_command.pool_reintegrate(self.pool.uuid,
-                                                       rank)
-            self.log.info(output)
-            self.is_rebuild_done(3)
-            self.assert_on_rebuild_failure()
+            # Reintegrate the ranks which was excluded
+            for val, _ in enumerate(rank):
+                if (val == 2 and "RP_2G" in oclass):
+                    output = self.dmg_command.pool_reintegrate(self.pool.uuid,
+                                                               rank[val],
+                                                               "0,2")
+                else:
+                    output = self.dmg_command.pool_reintegrate(self.pool.uuid,
+                                                               rank[val])
+                self.print_and_assert_on_rebuild_failure(output)
 
-            pver_reint = self.get_pool_version()
-            self.log.info("Pool Version after reintegrate %d", pver_reint)
-            # Check pool version incremented after pool reintegrate
-            self.assertTrue(pver_reint > (pver_exclude + 1),
-                            "Pool Version Error:  After reintegrate")
+                pver_reint = self.get_pool_version()
+                self.log.info("Pool Version after reintegrate %d", pver_reint)
+                # Check pool version incremented after pool reintegrate
+                self.assertTrue(pver_reint > (pver_exclude + 1),
+                                "Pool Version Error:  After reintegrate")
 
-        for val in range(0, num_pool):
-            display_string = "Pool{} space at the End".format(val)
-            self.pool = pool[val]
+            display_string = "Pool{} space at the End".format(random_pool)
+            self.pool = pool[random_pool]
             self.pool.display_pool_daos_space(display_string)
 
-        if data:
-            self.run_ior_thread("Read", self.ior_dfs_oclass[0],
-                                self.ior_apis[0], self.ior_test_sequence[0])
+        # Finally check whether the written data can be accessed.
+        # Also, run the daos cont check (for object integrity)
+        for val in range(0, num_pool):
+            self.pool = pool[val]
+            if data:
+                self.run_ior_thread("Read", oclass, test_seq)
+                self.run_mdtest_thread()
+                self.container = self.pool_cont_dict[self.pool][0]
+                kwargs = {"pool": self.pool.uuid,
+                          "cont": self.container.uuid}
+                output = self.daos_command.container_check(**kwargs)
+                self.log.info(output)
 
-    def test_osa_offline_reintegration(self):
-        """Test ID: DAOS-4749.
-
+    def test_osa_offline_reintegration_without_checksum(self):
+        """Test ID: DAOS-6923
         Test Description: Validate Offline Reintegration
+        without enabling checksum in container properties.
+
+        :avocado: tags=all,pr,daily_regression,hw,medium,ib2
+        :avocado: tags=osa,offline_reintegration_daily
+        :avocado: tags=offline_reintegration_without_csum
+        """
+        self.test_with_checksum = self.params.get("test_with_checksum",
+                                                  '/run/checksum/*')
+        self.log.info("Offline Reintegration : Without Checksum")
+        self.run_offline_reintegration_test(1, data=True)
+
+    def test_osa_offline_reintegration_multiple_pools(self):
+        """Test ID: DAOS-6923
+        Test Description: Validate Offline Reintegration
+        with multiple pools
 
         :avocado: tags=all,daily_regression,hw,medium,ib2
-        :avocado: tags=osa,offline_reintegration
+        :avocado: tags=osa,offline_reintegration_daily
+        :avocado: tags=offline_reintegration_multiple_pools
         """
-        # Perform reintegration testing with a pool
-        self.run_offline_reintegration_test(1, True)
+        self.log.info("Offline Reintegration : Multiple Pools")
+        self.run_offline_reintegration_test(5, data=True)
 
-    @skipForTicket("DAOS-6766, DAOS-6783")
+    @skipForTicket("DAOS-6807")
     def test_osa_offline_reintegration_server_stop(self):
         """Test ID: DAOS-6748.
 
         Test Description: Validate Offline Reintegration with server stop
-
-        :avocado: tags=all,pr,daily_regression,hw,medium,ib2,osa
+        :avocado: tags=all,pr,daily_regression,hw,medium,ib2
+        :avocado: tags=osa,offline_reintegration_daily
         :avocado: tags=offline_reintegration_srv_stop
         """
+        self.log.info("Offline Reintegration : System Start/Stop")
         self.run_offline_reintegration_test(1, data=True, server_boot=True)
+
+    def test_osa_offline_reintegrate_during_rebuild(self):
+        """Test ID: DAOS-6923
+        Test Description: Reintegrate rank while rebuild
+        is happening in parallel
+
+        :avocado: tags=all,full_regression,hw,medium,ib2
+        :avocado: tags=osa,offline_reintegration_full
+        :avocado: tags=offline_reintegrate_during_rebuild
+        """
+        self.loop_test_cnt = self.params.get("iterations",
+                                             '/run/loop_test/*')
+        self.test_during_rebuild = self.params.get("test_with_rebuild",
+                                                   '/run/rebuild/*')
+        self.log.info("Offline Reintegration : Rebuild")
+        self.run_offline_reintegration_test(1, data=True)
+
+    def test_osa_offline_reintegration_oclass(self):
+        """Test ID: DAOS-6923
+        Test Description: Validate Offline Reintegration
+        with different object class
+
+        :avocado: tags=all,full_regression,hw,medium,ib2
+        :avocado: tags=osa,offline_reintegration_full
+        :avocado: tags=offline_reintegration_oclass
+        """
+        self.log.info("Offline Reintegration : Object Class")
+        for oclass in self.test_oclass:
+            self.run_offline_reintegration_test(1, data=True,
+                                                server_boot=False,
+                                                oclass=oclass)
+
+    def test_osa_offline_reintegrate_during_aggregation(self):
+        """Test ID: DAOS-6923
+        Test Description: Reintegrate rank while aggregation
+        is happening in parallel
+
+        :avocado: tags=all,full_regression,hw,medium,ib2
+        :avocado: tags=osa,offline_reintegration_full
+        :avocado: tags=offline_reintegrate_during_aggregation
+        """
+        self.test_during_aggregation = self.params.get("test_with_aggregation",
+                                                       '/run/aggregation/*')
+        self.log.info("Offline Reintegration : Aggregation")
+        self.run_offline_reintegration_test(1, data=True)

--- a/src/tests/ftest/osa/osa_offline_reintegration.yaml
+++ b/src/tests/ftest/osa/osa_offline_reintegration.yaml
@@ -5,7 +5,7 @@ hosts:
     - server-C
   test_clients:
     - client-D
-timeout: 1000
+timeout: 800
 server_config:
   name: daos_server
   engines_per_host: 2
@@ -47,34 +47,65 @@ dmg:
   transport_config:
     allow_insecure: True
 pool:
-    mode: 146
-    name: daos_server
-    scm_size: 6000000000
-    nvme_size: 54000000000
-    svcn: 4
-    control_method: dmg
-    rebuild_timeout: 120
-    pool_query_timeout: 30
+  mode: 146
+  name: daos_server
+  scm_size: 6000000000
+  nvme_size: 54000000000
+  svcn: 4
+  control_method: dmg
+  rebuild_timeout: 120
+  pool_query_timeout: 30
 container:
-    type: POSIX
-    control_method: daos
-    oclass: RP_2G1
-    properties: cksum:crc64,cksum_size:16384,srv_cksum:on
+  type: POSIX
+  control_method: daos
+  oclass: RP_2G1
+  properties: cksum:crc64,cksum_size:16384,srv_cksum:on,rf:1
 ior:
-    clientslots:
-      slots: 48
-    test_file: /testFile
-    repetitions: 1
-    dfs_destroy: False
-    iorflags:
-      write_flags: "-w -F -k -G 1"
-      read_flags: "-F -r -R -k -G 1"
-      ior_api:
-        - DFS
-      obj_class:
-        - RP_2G1
-    ior_test_sequence:
-    #   - [scmsize, nvmesize, transfersize, blocksize]
-    #    The values are set to be in the multiples of 10.
-    #    Values are appx GB.
-      - [6000000000, 54000000000, 500000, 500000000]
+  clientslots:
+    slots: 48
+  test_file: /testFile
+  repetitions: 2
+  dfs_destroy: False
+  iorflags:
+    write_flags: "-w -F -k -G 1"
+    read_flags: "-F -r -R -k -G 1"
+    api: DFS
+    dfs_oclass: RP_2G1
+    dfs_dir_oclass: RP_2G1
+  ior_test_sequence:
+  #   - [scmsize, nvmesize, transfersize, blocksize]
+  #    The values are set to be in the multiples of 10.
+  #    Values are appx GB.
+    - [6000000000, 54000000000, 500000, 500000000]
+mdtest:
+  api: DFS
+  client_processes:
+    np: 2
+  num_of_files_dirs: 100
+  test_dir: "/"
+  iteration: 1
+  dfs_destroy: False
+  dfs_oclass: RP_2G1
+  dfs_dir_oclass: RP_2G1
+  manager: "MPICH"
+  flags: "-u"
+  wr_size:
+    32K:
+      write_bytes: 32768
+      read_bytes: 32768
+  verbosity_value: 1
+  depth: 0
+test_obj_class:
+  oclass:
+    - RP_2G8
+    - RP_3G6
+    - RP_4G1
+    - S1
+loop_test:
+  iterations: 3
+aggregation:
+  test_with_aggregation: True
+rebuild:
+  test_with_rebuild: True
+checksum:
+  test_with_checksum: False

--- a/src/tests/ftest/util/daos_utils.py
+++ b/src/tests/ftest/util/daos_utils.py
@@ -131,6 +131,28 @@ class DaosCommand(DaosCommandBase):
             ("container", "destroy"), pool=pool, sys_name=sys_name,
             cont=cont, force=force)
 
+    def container_check(self, pool, cont, sys_name=None, path=None):
+        """Check the integrity of container objects.
+
+        Args:
+            pool (str): UUID of the pool in which to create the container
+            cont (str): container UUID.
+            sys_name (str, optional):  DAOS system name context for servers.
+                Defaults to None.
+            path (str): Container namespace path. Defaults to None
+
+        Returns:
+            CmdResult: Object that contains exit status, stdout, and other
+                information.
+
+        Raises:
+            CommandFailure: if the daos container check command fails.
+
+        """
+        return self._get_result(
+            ("container", "check"), pool=pool, cont=cont,
+            sys_name=sys_name, path=path)
+
     def container_get_acl(self, pool, cont,
                           verbose=False, outfile=None):
         """Get the ACL for a given container.

--- a/src/tests/ftest/util/daos_utils_base.py
+++ b/src/tests/ftest/util/daos_utils_base.py
@@ -133,6 +133,8 @@ class DaosCommandBase(CommandWithSubCommand):
                 self.sub_command_class = self.CreateSubCommand()
             elif self.sub_command.value == "destroy":
                 self.sub_command_class = self.DestroySubCommand()
+            elif self.sub_command.value == "check":
+                self.sub_command_class = self.CheckSubCommand()
             elif self.sub_command.value == "list-objects":
                 self.sub_command_class = self.ListObjectsSubCommand()
             elif self.sub_command.value == "query":
@@ -246,6 +248,15 @@ class DaosCommandBase(CommandWithSubCommand):
             def __init__(self):
                 """Create a daos container query command object."""
                 super().__init__("query")
+
+        class CheckSubCommand(CommonContainerSubCommand):
+            """Defines an object for the daos container check command."""
+
+            def __init__(self):
+                """Create a daos container check command object."""
+                super(
+                    DaosCommandBase.ContainerSubCommand.CheckSubCommand,
+                    self).__init__("check")
 
         class GetAclSubCommand(CommonContainerSubCommand):
             """Defines an object for the daos container get-acl command."""

--- a/src/tests/ftest/util/mdtest_test_base.py
+++ b/src/tests/ftest/util/mdtest_test_base.py
@@ -61,10 +61,10 @@ class MdtestBase(DfuseTestBase):
         # Run Mdtest
         self.run_mdtest(self.get_mdtest_job_manager_command(self.manager),
                         self.processes)
-        # reset self.container if dfs_destroy is True
-        if self.mdtest_cmd.dfs_destroy:
-            self.container = None
 
+        # reset self.container if dfs_destroy is True or None.
+        if self.mdtest_cmd.dfs_destroy is not False:
+            self.container = None
         self.stop_dfuse()
 
     def get_mdtest_job_manager_command(self, manager):


### PR DESCRIPTION
Test-tag-hw-medium: pr,hw,medium,ib2 offline_reintegration_daily

Summary:
(Cherry pick PR:4835 changes on master to 1.2)
- Moved some more common files to osa_utils.py
- Offline reintegration test changes
- Added multiple pool infrastructure to test multiple pools fore offline reintegration
- Test with different object class
- More ranks excluded and reintegrated
- Add mechanism to test exclude, reintegration with aggregation turned on.
- Added daos container check changes.
- Add mdtest thread methods.
- Update offline drain to accomodate osa_utils.py changes.
- Handle multiple containers for OSA testing.
- Test without checksum enabled.