### PR TITLE
DAOS-7137 debug: add ABT ult id and xstream id to log

### DIFF
--- a/src/common/debug.c
+++ b/src/common/debug.c
@@ -22,6 +22,7 @@ static pthread_mutex_t dd_lock = PTHREAD_MUTEX_INITIALIZER;
 DAOS_FOREACH_DB(D_LOG_INSTANTIATE_DB, DAOS_FOREACH_DB)
 DAOS_FOREACH_LOG_FAC(D_LOG_INSTANTIATE_FAC, DAOS_FOREACH_DB)
 
+static d_log_id_cb_t	log_id_cb;
 /* debug bit groups */
 #define DB_GRP1 (DB_IO | DB_MD | DB_PL | DB_REBUILD | DB_SEC | DB_CSUM)
 
@@ -122,6 +123,12 @@ daos_debug_fini(void)
 	D_MUTEX_UNLOCK(&dd_lock);
 }
 
+void
+daos_debug_set_id_cb(d_log_id_cb_t cb)
+{
+	log_id_cb = cb;
+}
+
 /** Initialize debug system */
 int
 daos_debug_init(char *logfile)
@@ -143,8 +150,8 @@ daos_debug_init(char *logfile)
 		logfile = NULL;
 	}
 
-
-	rc = d_log_init_adv("DAOS", logfile, flags, DLOG_ERR, DLOG_CRIT);
+	rc = d_log_init_adv("DAOS", logfile, flags, DLOG_ERR, DLOG_CRIT,
+			    log_id_cb);
 	if (rc != 0) {
 		D_PRINT_ERR("Failed to init DAOS debug log: "DF_RC"\n",
 			DP_RC(rc));

--- a/src/engine/init.c
+++ b/src/engine/init.c
@@ -480,6 +480,25 @@ dss_crt_event_cb(d_rank_t rank, enum crt_event_source src,
 			src, type, DP_RC(rc));
 }
 
+static void
+server_id_cb(uint32_t *tid, uint64_t *uid)
+{
+	if (uid != NULL)
+		ABT_self_get_thread_id(uid);
+
+	if (tid != NULL) {
+		struct dss_thread_local_storage *dtc;
+		struct dss_module_info *dmi;
+
+		dtc = dss_tls_get();
+		if (dtc == NULL)
+			return;
+
+		dmi = dss_get_module_info();
+		*tid = dmi->dmi_xs_id;
+	}
+}
+
 static int
 server_init(int argc, char *argv[])
 {
@@ -492,6 +511,7 @@ server_init(int argc, char *argv[])
 
 	gethostname(dss_hostname, DSS_HOSTNAME_MAX_LEN);
 
+	daos_debug_set_id_cb(server_id_cb);
 	rc = daos_debug_init(DAOS_LOG_DEFAULT);
 	if (rc != 0)
 		return rc;

--- a/src/gurt/debug.c
+++ b/src/gurt/debug.c
@@ -508,7 +508,7 @@ setup_dbg_namebit(void)
 
 int
 d_log_init_adv(char *log_tag, char *log_file, unsigned int flavor,
-	       d_dbug_t def_mask, d_dbug_t err_mask)
+	       d_dbug_t def_mask, d_dbug_t err_mask, d_log_id_cb_t id_cb)
 {
 	int rc = 0;
 
@@ -524,7 +524,8 @@ d_log_init_adv(char *log_tag, char *log_file, unsigned int flavor,
 	if (d_dbglog_data.dd_prio_err != 0)
 		err_mask = d_dbglog_data.dd_prio_err;
 
-	rc = d_log_open(log_tag, 0, def_mask, err_mask, log_file, flavor);
+	rc = d_log_open(log_tag, 0, def_mask, err_mask, log_file, flavor,
+			id_cb);
 	if (rc != 0) {
 		D_PRINT_ERR("d_log_open failed: %d\n", rc);
 		D_GOTO(out, rc = -DER_UNINIT);
@@ -559,7 +560,8 @@ d_log_init(void)
 		log_file = NULL;
 	}
 
-	rc = d_log_init_adv("CaRT", log_file, flags, DLOG_WARN, DLOG_EMERG);
+	rc = d_log_init_adv("CaRT", log_file, flags, DLOG_WARN, DLOG_EMERG,
+			    NULL);
 	if (rc != DER_SUCCESS) {
 		D_PRINT_ERR("d_log_init_adv failed, rc: %d.\n", rc);
 		D_GOTO(out, rc);

--- a/src/include/daos/debug.h
+++ b/src/include/daos/debug.h
@@ -84,6 +84,7 @@ DAOS_FOREACH_LOG_FAC(D_LOG_DECLARE_FAC, DAOS_FOREACH_DB);
 
 /** initialize the debug system */
 int  daos_debug_init(char *logfile);
+void daos_debug_set_id_cb(d_log_id_cb_t id_cb);
 /** finalize the debug system */
 void daos_debug_fini(void);
 

--- a/src/include/gurt/dlog.h
+++ b/src/include/gurt/dlog.h
@@ -326,6 +326,11 @@ int d_log_allocfacility(const char *aname, const char *lname);
 int d_log_init(void);
 
 /**
+ * Callback to get XS id and ULT id
+ */
+typedef void (*d_log_id_cb_t)(uint32_t *xs_id, uint64_t *ult_id);
+
+/**
  * Advanced version of log initialing function. User can specify log tag,
  * output log file, the default log mask and the mask for output errors.
  *
@@ -334,11 +339,12 @@ int d_log_init(void);
  * \param[in] flavor		Flavor controlling output
  * \param[in] def_mask		Default log mask
  * \param[in] err_mask		Output errors mask
+ * \param[in] id_cb		callback to get tid/ult id.
  *
  * \return			0 on success, -1 on failure
  */
 int d_log_init_adv(char *log_tag, char *log_file, unsigned int flavor,
-		   d_dbug_t def_mask, d_dbug_t err_mask);
+		   d_dbug_t def_mask, d_dbug_t err_mask, d_log_id_cb_t id_cb);
 
 /**
  * Remove a reference on the default cart log.  Calls d_log_close
@@ -371,11 +377,12 @@ void d_log_sync_mask(void);
  *				in d_log).
  * \param[in] logfile		log file name, or null if no log file
  * \param[in] flags		STDERR, LOGPID
+ * \param[in] id_cb		callback to get tid/ult id.
  *
  * \return			0 on success, -1 on error.
  */
 int d_log_open(char *tag, int maxfac_hint, int default_mask,
-	       int stderr_mask, char *logfile, int flags);
+	       int stderr_mask, char *logfile, int flags, d_log_id_cb_t id_cb);
 
 /**
  * set the logmask for a given facility.

--- a/src/tests/ftest/cart/util/cart_logparse.py
+++ b/src/tests/ftest/cart/util/cart_logparse.py
@@ -604,7 +604,7 @@ class LogIter():
         self._raw = raw
 
         if stateful:
-            if not pid:
+            if pid is None:
                 raise InvalidPid
             return StateIter(self)
 
@@ -614,7 +614,7 @@ class LogIter():
         self._iter_index = 0
         self._iter_count = 0
         if self.__from_file:
-            if not self._pid or self.bz2:
+            if self._pid is None or self.bz2:
                 self._fd.seek(0)
             else:
                 self._fd.seek(self._iter_pid['file_pos'])
@@ -646,7 +646,7 @@ class LogIter():
         while True:
             self._iter_index += 1
 
-            if self._pid and self._iter_index > self._iter_last_index:
+            if self._pid is not None and self._iter_index > self._iter_last_index:
                 assert self._iter_count == self._iter_pid['line_count']  # nosec
                 raise StopIteration
 
@@ -658,7 +658,7 @@ class LogIter():
             if self._trace_only and not line.trace:
                 continue
 
-            if self._pid:
+            if self._pid is not None:
                 if line.pid != self._pid:
                     continue
 

--- a/src/tests/ftest/cart/util/cart_logtest.py
+++ b/src/tests/ftest/cart/util/cart_logtest.py
@@ -291,7 +291,7 @@ class LogTest():
                        show_memleaks=True,
                        leak_wf=None):
         """Check a single log file for consistency"""
-
+        to_raise = None
         for pid in self._li.get_pids():
             if wf:
                 wf.reset_pending()
@@ -299,10 +299,16 @@ class LogTest():
                 self.rpc_reporting(pid)
                 if wf:
                     wf.reset_pending()
-            self._check_pid_from_log_file(pid,
-                                          abort_on_warning,
-                                          leak_wf,
-                                          show_memleaks=show_memleaks)
+            try:
+              self._check_pid_from_log_file(pid,
+                                abort_on_warning,
+                                leak_wf,
+                                show_memleaks=show_memleaks)
+            except LogCheckError as error:
+              if to_raise is None:
+                 to_raise = error
+        if to_raise:
+           raise to_raise
 
     def check_dfuse_io(self):
         """Parse dfuse i/o"""


### PR DESCRIPTION
Add ABT ult id and xstream id to daos log. So daos log become

xxxx DAOS[process_id/xs_id/ABT thread ID] xxxxx

xs_id is -1 before tls is initialized, and thread id on client side,
otherwise it will be the xstream ID.

ABT thread ID is the ABT ult ID, 0 otherwise.

Signed-off-by: Di Wang <di.wang@intel.com>