### PR TITLE
DAOS-7133 tse: add lock to protect tse_task_complete_callback()

### DIFF
--- a/src/common/tse_internal.h
+++ b/src/common/tse_internal.h
@@ -93,6 +93,8 @@ struct tse_task_cb {
 struct tse_sched_private {
 	/* lock to protect schedule status and sub task list */
 	pthread_mutex_t dsp_lock;
+	/* lock to protect sub task's dtp_comp_cb_list */
+	pthread_mutex_t dsp_comp_lock;
 
 	/* The task will be added to init list when it is initially
 	 * added to scheduler without any delay. A task with a delay


### PR DESCRIPTION
tse_task_complete_callback() possibly be concurrently called by
multi-threads, if one parent task with multiple dep tasks.
This patch add a special dsp lock to protect it, why don't add
a per-task lock is to save task space.

Signed-off-by: Xuezhao Liu <xuezhao.liu@intel.com>