### PR TITLE
DAOS-6944 test: Increase usage limit and verify CPU usage after runni…

### DIFF
--- a/src/tests/ftest/server/cpu_usage.py
+++ b/src/tests/ftest/server/cpu_usage.py
@@ -6,20 +6,63 @@
 """
 import time
 
-from apricot import TestWithServers
 from general_utils import run_pcmd
+from ior_test_base import IorTestBase
 
 
-class CPUUsage(TestWithServers):
-    # pylint: disable=too-few-public-methods
+class CPUUsage(IorTestBase):
+    # pylint: disable=too-many-ancestors
     """Test Class Description:
-    Measure CPU usage of daos_engine with target = 16 and verify that it's
-    less than 100%.
+    Start daos_engine and measure CPU usage of daos_engine with target = 16,
+    nr_xs_helpers = 16 and verify that it's less than 200%. Run IOR and verify
+    that it goes down.
 
     This test uses "top" command. It aggregates the CPU usage of every core.
     e.g., If engine is using 50% per core for 8 cores, top shows 400%.
     :avocado: recursive
     """
+    def get_cpu_usage(self, pid, usage_limit):
+        """Monitor CPU usage and return if it gets below usage_limit.
+
+        Args:
+            pid (str): daos_engine PID.
+            usage_limit (int): Limit that we want daos_engine to use.
+
+        Returns:
+            str: daos_engine CPU usage.
+        """
+        usage = -1
+        for _ in range(10):
+            # Get (instantaneous) CPU usage of the PID with top.
+            top_pid = "top -p {} -b -n 1".format(pid)
+            usage = -1
+            results = run_pcmd(hosts=self.hostlist_servers, command=top_pid)
+            for result in results:
+                process_row = result["stdout"][-1]
+                self.log.info("Process row = %s", process_row)
+                values = process_row.split()
+                self.log.info("Values = %s", values)
+                if len(values) < 9:
+                    self.fail("{} returned invalid output!".format(top_pid))
+                usage = values[8]
+                self.log.info("CPU Usage = %s", usage)
+            if usage != -1 and float(usage) < usage_limit:
+                break
+            time.sleep(2)
+        return usage
+
+    def verify_usage(self, usage, usage_limit):
+        """Verify CPU usage.
+
+        Args:
+            usage (str): daos_engine CPU usage.
+            usage_limit (int): Limit that we want daos_engine to use.
+        """
+        self.assertTrue(
+            usage != -1, "daos_engine CPU usage couldn't be obtained!")
+        self.assertTrue(
+            float(usage) < usage_limit,
+            "CPU usage is above {}%: {}%".format(usage, usage_limit))
 
     def test_cpu_usage(self):
         """
@@ -28,8 +71,8 @@ class CPUUsage(TestWithServers):
         Test Description: Test CPU usage of formatted and idle engine.
 
         :avocado: tags=all,full_regression
-        :avocado: tags=server
-        :avocado: tags=cpu_usage
+        :avocado: tags=hw,small
+        :avocado: tags=server,cpu_usage
         """
         # Get PID of daos_engine with ps.
         ps_engine = r"ps -C daos_engine -o %\p"
@@ -50,25 +93,15 @@ class CPUUsage(TestWithServers):
         if not pid_found:
             self.fail("daos_engine PID couldn't be obtained!")
 
-        for _ in range(10):
-            # Get (instantaneous) CPU usage of the PID with top.
-            top_pid = "top -p {} -b -n 1".format(pid)
-            usage = -1
-            results = run_pcmd(hosts=self.hostlist_servers, command=top_pid)
-            for result in results:
-                process_row = result["stdout"][-1]
-                self.log.info("Process row = %s", process_row)
-                values = process_row.split()
-                self.log.info("Values = %s", values)
-                if len(values) < 9:
-                    self.fail("{} returned invalid output!".format(top_pid))
-                usage = values[8]
-                self.log.info("CPU Usage = %s", usage)
-            if usage != -1 and float(usage) < 100:
-                break
-            time.sleep(2)
+        # Get and verify CPU usage.
+        usage_limit = self.params.get("usage_limit", '/run/*')
+        usage = self.get_cpu_usage(pid=pid, usage_limit=usage_limit)
+        self.verify_usage(usage=usage, usage_limit=usage_limit)
 
-        self.assertTrue(
-            usage != -1, "daos_engine CPU usage couldn't be obtained!")
-        self.assertTrue(
-            float(usage) < 100, "CPU usage is above 100%: {}%".format(usage))
+        # Create a pool, container, and run IOR. IO will invoke CPU usage by
+        # daos_engine.
+        self.run_ior_with_pool()
+
+        # Verify that the CPU usage goes down after IO.
+        usage = self.get_cpu_usage(pid=pid, usage_limit=usage_limit)
+        self.verify_usage(usage=usage, usage_limit=usage_limit)

--- a/src/tests/ftest/server/cpu_usage.yaml
+++ b/src/tests/ftest/server/cpu_usage.yaml
@@ -1,7 +1,32 @@
 hosts:
   test_servers:
     - server-A
-timeout: 80
+  test_clients:
+    - client-A
+timeout: 130
 server_config:
   servers:
+    # 16 targets and 16 nr_xs_helpers are the requirements.
     targets: 16
+    nr_xs_helpers: 16
+    bdev_class: nvme
+    bdev_list: ["0000:00:00.0"]
+    scm_class: dcpm
+    scm_list: ["/dev/pmem0"]
+    scm_mount: /mnt/daos0
+    interface:
+      fabric_iface: ib0
+ior:
+  client_processes:
+    np: 1
+  flags: "-v -D 60 -w -r"
+  transfer_size: 1M
+  block_size: 1G
+pool:
+  scm_size: 10G
+  nvme_size: 100G
+  control_method: dmg
+container:
+  type: POSIX
+  control_method: daos
+usage_limit: 200


### PR DESCRIPTION
…… (#5214)

Increased CPU usage limit to 200%.
Added a step to run some IOR and verify that the CPU usage goes down again.

Quick-build: true
Skip-unit-tests: true
Test-tag: cpu_usage
Signed-off-by: Makito Kano <makito.kano@intel.com>