### PR TITLE
DAOS-7062 test: Fixing pool/pool_svc.py KeyError: 'leader' error (#5133)

### DIFF
--- a/src/tests/ftest/pool/pool_svc.py
+++ b/src/tests/ftest/pool/pool_svc.py
@@ -30,7 +30,17 @@ class PoolSvc(TestWithServers):
 
         """
         self.pool.set_query_data()
-        current_leader = int(self.pool.query_data["leader"])
+        try:
+            current_leader = int(self.pool.query_data["response"]["leader"])
+        except KeyError as error:
+            self.log.error("self.pool.query_data: %s", self.pool.query_data)
+            self.fail(
+                "Error obtaining [\"response\"][\"leader\"] from dmg pool "
+                "query: {}".format(error))
+        except ValueError as error:
+            self.fail(
+                "Error converting dmg pool query pool leader {} into an "
+                "integer: {}".format(self.pool.query_data, error))
         if previous_leader is not None:
             self.log.info(
                 "Pool leader: previous=%s, current=%s",


### PR DESCRIPTION
Due to a recent change to the DmgCommand.pool_query() method the
pool/pool_svc.py test fails with a KeyError: 'leader' error. This is
being resolved by this change.

Quick-build: true
Skip-unit-tests: true
Test-tag: test_pool_svc
Signed-off-by: Makito Kano <makito.kano@intel.com>