### PR TITLE
DAOS-7155 proc: improve serialization functions

### DIFF
--- a/src/cart/crt_hg_proc.c
+++ b/src/cart/crt_hg_proc.c
@@ -13,28 +13,18 @@
 
 #define CRT_PROC_NULL (NULL)
 #define CRT_PROC_TYPE_FUNC(type)				\
-	int crt_proc_##type(crt_proc_t proc, type *data)	\
+	int crt_proc_##type(crt_proc_t proc,			\
+			     crt_proc_op_t proc_op, type *data)	\
 	{							\
-		crt_proc_op_t	 proc_op;			\
-		type		*buf;				\
-		int		 rc;				\
-		rc = crt_proc_get_op(proc, &proc_op);		\
-		if (unlikely(rc))				\
-			return rc;				\
-		if (proc_op == CRT_PROC_FREE)			\
+		type *buf;					\
+		if (FREEING(proc_op))				\
 			return 0;				\
 		buf = hg_proc_save_ptr(proc, sizeof(*buf));	\
-		switch (proc_op) {				\
-		case CRT_PROC_ENCODE:				\
+		if (ENCODING(proc_op))				\
 			*buf = *data;				\
-			break;					\
-		case CRT_PROC_DECODE:				\
+		else /* DECODING(proc_op) */			\
 			*data = *buf;				\
-			break;					\
-		default:					\
-			break;					\
-		}						\
-		return rc;					\
+		return 0;					\
 	}
 
 int
@@ -49,7 +39,7 @@ crt_proc_get_op(crt_proc_t proc, crt_proc_op_t *proc_op)
 	}
 
 	if (unlikely(proc_op == NULL)) {
-		D_ERROR("invalid parameter - NULL proc_op.\n");
+		D_ERROR("Invalid parameter - NULL proc_op.\n");
 		D_GOTO(out, rc = -DER_INVAL);
 	}
 
@@ -65,7 +55,7 @@ crt_proc_get_op(crt_proc_t proc, crt_proc_op_t *proc_op)
 		*proc_op = CRT_PROC_FREE;
 		break;
 	default:
-		D_ERROR("bad hg_proc_op: %d.\n", hg_proc_op);
+		D_ERROR("Bad hg_proc_op: %d.\n", hg_proc_op);
 		rc = -DER_INVAL;
 	}
 
@@ -74,33 +64,21 @@ out:
 }
 
 int
-crt_proc_memcpy(crt_proc_t proc, void *data, size_t data_size)
+crt_proc_memcpy(crt_proc_t proc, crt_proc_op_t proc_op,
+		void *data, size_t data_size)
 {
-	crt_proc_op_t	 proc_op;
-	void		*buf;
-	int		 rc;
+	void *buf;
 
-	rc = crt_proc_get_op(proc, &proc_op);
-	if (unlikely(rc))
-		D_GOTO(out, rc);
-
-	if (proc_op == CRT_PROC_FREE)
-		D_GOTO(out, rc = 0);
+	if (FREEING(proc_op))
+		return 0;
 
 	buf = hg_proc_save_ptr(proc, data_size);
-	switch (proc_op) {
-	case CRT_PROC_ENCODE:
+	if (ENCODING(proc_op))
 		memcpy(buf, data, data_size);
-		break;
-	case CRT_PROC_DECODE:
+	else /* DECODING(proc_op) */
 		memcpy(data, buf, data_size);
-		break;
-	default:
-		break;
-	}
 
-out:
-	return rc;
+	return 0;
 }
 
 CRT_PROC_TYPE_FUNC(int8_t)
@@ -114,7 +92,8 @@ CRT_PROC_TYPE_FUNC(uint64_t)
 CRT_PROC_TYPE_FUNC(bool)
 
 int
-crt_proc_crt_bulk_t(crt_proc_t proc, crt_bulk_t *bulk_hdl)
+crt_proc_crt_bulk_t(crt_proc_t proc, crt_proc_op_t proc_op,
+		    crt_bulk_t *bulk_hdl)
 {
 	hg_return_t	hg_ret;
 
@@ -124,7 +103,7 @@ crt_proc_crt_bulk_t(crt_proc_t proc, crt_bulk_t *bulk_hdl)
 }
 
 int
-crt_proc_d_string_t(crt_proc_t proc, d_string_t *data)
+crt_proc_d_string_t(crt_proc_t proc, crt_proc_op_t proc_op, d_string_t *data)
 {
 	hg_return_t	hg_ret;
 
@@ -134,7 +113,8 @@ crt_proc_d_string_t(crt_proc_t proc, d_string_t *data)
 }
 
 int
-crt_proc_d_const_string_t(crt_proc_t proc, d_const_string_t *data)
+crt_proc_d_const_string_t(crt_proc_t proc, crt_proc_op_t proc_op,
+			  d_const_string_t *data)
 {
 	hg_return_t	hg_ret;
 
@@ -144,28 +124,24 @@ crt_proc_d_const_string_t(crt_proc_t proc, d_const_string_t *data)
 }
 
 int
-crt_proc_uuid_t(crt_proc_t proc, uuid_t *data)
+crt_proc_uuid_t(crt_proc_t proc, crt_proc_op_t proc_op, uuid_t *data)
 {
-	return crt_proc_memcpy(proc, data, sizeof(uuid_t));
+	return crt_proc_memcpy(proc, proc_op, data, sizeof(uuid_t));
 }
 
 int
-crt_proc_d_rank_list_t(crt_proc_t proc, d_rank_list_t **data)
+crt_proc_d_rank_list_t(crt_proc_t proc, crt_proc_op_t proc_op,
+		       d_rank_list_t **data)
 {
 	d_rank_list_t	*rank_list;
-	crt_proc_op_t	 proc_op;
 	uint32_t	*buf;
 	uint32_t	 nr;
-	int		 rc;
+	int		 rc = 0;
 
 	if (unlikely(data == NULL)) {
 		D_ERROR("Invalid parameter data: %p.\n", data);
 		D_GOTO(out, rc = -DER_INVAL);
 	}
-
-	rc = crt_proc_get_op(proc, &proc_op);
-	if (unlikely(rc))
-		D_GOTO(out, rc);
 
 	switch (proc_op) {
 	case CRT_PROC_ENCODE:
@@ -192,7 +168,7 @@ crt_proc_d_rank_list_t(crt_proc_t proc, d_rank_list_t **data)
 		}
 
 		rank_list = d_rank_list_alloc(nr);
-		if (rank_list == NULL)
+		if (unlikely(rank_list == NULL))
 			D_GOTO(out, rc = -DER_NOMEM);
 		buf = hg_proc_save_ptr(proc, nr * sizeof(*buf));
 		memcpy(rank_list->rl_ranks, buf, nr * sizeof(*buf));
@@ -210,30 +186,25 @@ out:
 }
 
 int
-crt_proc_d_iov_t(crt_proc_t proc, d_iov_t *div)
+crt_proc_d_iov_t(crt_proc_t proc, crt_proc_op_t proc_op, d_iov_t *div)
 {
-	crt_proc_op_t	proc_op;
-	int		rc;
+	int rc;
 
 	if (unlikely(div == NULL))
 		D_GOTO(out, rc = -DER_INVAL);
 
-	rc = crt_proc_get_op(proc, &proc_op);
-	if (unlikely(rc))
-		D_GOTO(out, rc);
-
-	if (proc_op == CRT_PROC_FREE) {
+	if (FREEING(proc_op)) {
 		div->iov_buf = NULL;
 		div->iov_buf_len = 0;
 		div->iov_len = 0;
 		D_GOTO(out, rc = 0);
 	}
 
-	rc = crt_proc_uint64_t(proc, &div->iov_buf_len);
+	rc = crt_proc_uint64_t(proc, proc_op, &div->iov_buf_len);
 	if (unlikely(rc))
 		D_GOTO(out, rc);
 
-	rc = crt_proc_uint64_t(proc, &div->iov_len);
+	rc = crt_proc_uint64_t(proc, proc_op, &div->iov_len);
 	if (unlikely(rc))
 		D_GOTO(out, rc);
 
@@ -243,7 +214,7 @@ crt_proc_d_iov_t(crt_proc_t proc, d_iov_t *div)
 		D_GOTO(out, rc = -DER_HG);
 	}
 
-	if (proc_op == CRT_PROC_DECODE) {
+	if (DECODING(proc_op)) {
 		if (div->iov_buf_len == 0) {
 			div->iov_buf = NULL;
 		} else {
@@ -253,8 +224,8 @@ crt_proc_d_iov_t(crt_proc_t proc, d_iov_t *div)
 			 */
 			div->iov_buf = hg_proc_save_ptr(proc, div->iov_len);
 		}
-	} else { /* proc_op == CRT_PROC_ENCODE */
-		rc = crt_proc_memcpy(proc, div->iov_buf, div->iov_len);
+	} else { /* ENCODING(proc_op) */
+		rc = crt_proc_memcpy(proc, proc_op, div->iov_buf, div->iov_len);
 	}
 
 out:
@@ -266,48 +237,45 @@ crt_proc_corpc_hdr(crt_proc_t proc, struct crt_corpc_hdr *hdr)
 {
 	crt_proc_op_t	 proc_op;
 	uint32_t	*buf;
-	int		 rc = 0;
+	int		 rc;
 
-	if (unlikely(proc == CRT_PROC_NULL || hdr == NULL))
+	if (unlikely(hdr == NULL))
 		D_GOTO(out, rc = -DER_INVAL);
 
 	rc = crt_proc_get_op(proc, &proc_op);
 	if (unlikely(rc))
 		D_GOTO(out, rc);
 
-	rc = crt_proc_crt_group_id_t(proc, &hdr->coh_grpid);
+	rc = crt_proc_crt_group_id_t(proc, proc_op, &hdr->coh_grpid);
 	if (unlikely(rc))
 		D_GOTO(out, rc);
 
-	rc = crt_proc_crt_bulk_t(proc, &hdr->coh_bulk_hdl);
+	rc = crt_proc_crt_bulk_t(proc, proc_op, &hdr->coh_bulk_hdl);
 	if (unlikely(rc))
 		D_GOTO(out, rc);
 
-	rc = crt_proc_d_rank_list_t(proc, &hdr->coh_filter_ranks);
+	rc = crt_proc_d_rank_list_t(proc, proc_op, &hdr->coh_filter_ranks);
 	if (unlikely(rc))
 		D_GOTO(out, rc);
 
-	rc = crt_proc_d_rank_list_t(proc, &hdr->coh_inline_ranks);
+	rc = crt_proc_d_rank_list_t(proc, proc_op, &hdr->coh_inline_ranks);
 	if (unlikely(rc))
 		D_GOTO(out, rc);
 
-	switch (proc_op) {
-	case CRT_PROC_ENCODE:
-		buf = hg_proc_save_ptr(proc, 4 * sizeof(*buf));
+	if (FREEING(proc_op))
+		D_GOTO(out, rc = 0);
+
+	buf = hg_proc_save_ptr(proc, 4 * sizeof(*buf));
+	if (ENCODING(proc_op)) {
 		buf[0] = hdr->coh_grp_ver;
 		buf[1] = hdr->coh_tree_topo;
 		buf[2] = hdr->coh_root;
 		buf[3] = hdr->coh_padding;
-		break;
-	case CRT_PROC_DECODE:
-		buf = hg_proc_save_ptr(proc, 4 * sizeof(*buf));
+	} else { /* DECODING(proc_op) */
 		hdr->coh_grp_ver   = buf[0];
 		hdr->coh_tree_topo = buf[1];
 		hdr->coh_root      = buf[2];
 		hdr->coh_padding   = buf[3];
-		break;
-	case CRT_PROC_FREE:
-		break;
 	}
 
 out:
@@ -317,16 +285,21 @@ out:
 static inline int
 crt_proc_common_hdr(crt_proc_t proc, struct crt_common_hdr *hdr)
 {
-	int rc;
+	crt_proc_op_t	proc_op;
+	int		rc;
+
+	if (unlikely(hdr == NULL))
+		D_GOTO(out, rc = -DER_INVAL);
 
 	/*
 	 * D_DEBUG("in crt_proc_common_hdr, opc: %#x.\n", hdr->cch_opc);
 	 */
 
-	if (unlikely(proc == CRT_PROC_NULL || hdr == NULL))
-		D_GOTO(out, rc = -DER_INVAL);
+	rc = crt_proc_get_op(proc, &proc_op);
+	if (unlikely(rc))
+		D_GOTO(out, rc);
 
-	rc = crt_proc_memcpy(proc, hdr, sizeof(*hdr));
+	rc = crt_proc_memcpy(proc, proc_op, hdr, sizeof(*hdr));
 
 out:
 	return rc;
@@ -360,8 +333,6 @@ int
 crt_hg_unpack_header(hg_handle_t handle, struct crt_rpc_priv *rpc_priv,
 		     crt_proc_t *proc)
 {
-	int	rc = 0;
-
 	/*
 	 * Use some low level HG APIs to unpack header first and then unpack the
 	 * body, avoid unpacking two times (which needs to lookup, create the
@@ -371,18 +342,20 @@ crt_hg_unpack_header(hg_handle_t handle, struct crt_rpc_priv *rpc_priv,
 	 * different with future's mercury code change.
 	 */
 	void			*in_buf = NULL;
-	hg_size_t		in_buf_size;
-	hg_return_t		hg_ret = HG_SUCCESS;
+	hg_size_t		 in_buf_size;
 	hg_class_t		*hg_class;
 	struct crt_context	*ctx;
 	struct crt_hg_context	*hg_ctx;
-	uint64_t		clock_offset;
-	hg_proc_t		hg_proc = HG_PROC_NULL;
+	uint64_t		 clock_offset;
+	hg_proc_t		 hg_proc = HG_PROC_NULL;
+	hg_return_t		 hg_ret = HG_SUCCESS;
+	int			 rc;
 
 	/* Get extra input buffer; if it's null, get regular input buffer */
 	hg_ret = HG_Get_input_extra_buf(handle, &in_buf, &in_buf_size);
 	if (hg_ret != HG_SUCCESS) {
-		D_ERROR("Could not get extra input buff, hg_ret: %d.", hg_ret);
+		RPC_ERROR(rpc_priv, "HG_Get_input_extra_buf failed: %d\n",
+			  hg_ret);
 		D_GOTO(out, rc = -DER_HG);
 	}
 
@@ -390,7 +363,8 @@ crt_hg_unpack_header(hg_handle_t handle, struct crt_rpc_priv *rpc_priv,
 	if (in_buf == NULL) {
 		hg_ret = HG_Get_input_buf(handle, &in_buf, &in_buf_size);
 		if (hg_ret != HG_SUCCESS) {
-			D_ERROR("Could not get input buf, hg_ret: %d.", hg_ret);
+			RPC_ERROR(rpc_priv, "HG_Get_input_buf failed: %d\n",
+				  hg_ret);
 			D_GOTO(out, rc = -DER_HG);
 		}
 	}
@@ -402,14 +376,15 @@ crt_hg_unpack_header(hg_handle_t handle, struct crt_rpc_priv *rpc_priv,
 	hg_ret = hg_proc_create_set(hg_class, in_buf, in_buf_size, HG_DECODE,
 				    HG_CRC32, &hg_proc);
 	if (hg_ret != HG_SUCCESS) {
-		D_ERROR("Could not create proc, hg_ret: %d.", hg_ret);
+		RPC_ERROR(rpc_priv, "hg_proc_create_set failed: %d\n", hg_ret);
 		D_GOTO(out, rc = -DER_HG);
 	}
 
 	/* Decode header */
 	rc = crt_proc_common_hdr(hg_proc, &rpc_priv->crp_req_hdr);
 	if (rc != 0) {
-		D_ERROR("crt_proc_common_hdr failed rc: %d.\n", rc);
+		RPC_ERROR(rpc_priv, "crt_proc_common_hdr failed: "DF_RC"\n",
+			  DP_RC(rc));
 		D_GOTO(out, rc);
 	}
 
@@ -434,7 +409,8 @@ crt_hg_unpack_header(hg_handle_t handle, struct crt_rpc_priv *rpc_priv,
 	if (rpc_priv->crp_flags & CRT_RPC_FLAG_COLL) {
 		rc = crt_proc_corpc_hdr(hg_proc, &rpc_priv->crp_coreq_hdr);
 		if (rc != 0) {
-			D_ERROR("crt_proc_corpc_hdr failed rc: %d.\n", rc);
+			RPC_ERROR(rpc_priv, "crt_proc_corpc_hdr failed: "
+				  DF_RC"\n", DP_RC(rc));
 			D_GOTO(out, rc);
 		}
 	}
@@ -491,25 +467,23 @@ crt_proc_output(struct crt_rpc_priv *rpc_priv, crt_proc_t proc)
 int
 crt_hg_unpack_body(struct crt_rpc_priv *rpc_priv, crt_proc_t proc)
 {
-	int	rc = 0;
-
 	hg_return_t	hg_ret;
+	int		rc;
 
 	D_ASSERT(rpc_priv != NULL && proc != HG_PROC_NULL);
 
 	/* Decode input parameters */
 	rc = crt_proc_input(rpc_priv, proc);
 	if (rc != 0) {
-		D_ERROR("crt_hg_unpack_body failed, rc: %d, opc: %#x.\n",
-			rc, rpc_priv->crp_pub.cr_opc);
+		RPC_ERROR(rpc_priv, "crt_proc_input failed: "DF_RC"\n",
+			  DP_RC(rc));
 		D_GOTO(out, rc);
 	}
 
 	/* Flush proc */
 	hg_ret = hg_proc_flush(proc);
 	if (hg_ret != HG_SUCCESS) {
-		D_ERROR("Error in proc flush, hg_ret: %d, opc: %#x.",
-			hg_ret, rpc_priv->crp_pub.cr_opc);
+		RPC_ERROR(rpc_priv, "hg_proc_flush failed: %d\n", hg_ret);
 		D_GOTO(out, rc);
 	}
 out:
@@ -522,12 +496,9 @@ int
 crt_proc_in_common(crt_proc_t proc, crt_rpc_input_t *data)
 {
 	struct crt_rpc_priv	*rpc_priv;
-	crt_proc_op_t		 proc_op;
 	struct crt_common_hdr	*hdr;
-	int			 rc = 0;
-
-	if (proc == CRT_PROC_NULL)
-		D_GOTO(out, rc = -DER_INVAL);
+	crt_proc_op_t		 proc_op;
+	int			 rc;
 
 	rc = crt_proc_get_op(proc, &proc_op);
 	if (rc != 0)
@@ -540,7 +511,7 @@ crt_proc_in_common(crt_proc_t proc, crt_rpc_input_t *data)
 	/* D_DEBUG("in crt_proc_in_common, data: %p\n", *data); */
 
 	if (proc_op != CRT_PROC_FREE) {
-		if (proc_op == CRT_PROC_ENCODE) {
+		if (ENCODING(proc_op)) {
 			hdr = &rpc_priv->crp_req_hdr;
 
 			hdr->cch_flags = rpc_priv->crp_flags;
@@ -570,7 +541,8 @@ crt_proc_in_common(crt_proc_t proc, crt_rpc_input_t *data)
 		}
 		rc = crt_proc_common_hdr(proc, &rpc_priv->crp_req_hdr);
 		if (rc != 0) {
-			D_ERROR("crt_proc_common_hdr failed rc: %d.\n", rc);
+			RPC_ERROR(rpc_priv, "crt_proc_common_hdr failed: "
+				  DF_RC"\n", DP_RC(rc));
 			D_GOTO(out, rc);
 		}
 		/**
@@ -590,7 +562,8 @@ crt_proc_in_common(crt_proc_t proc, crt_rpc_input_t *data)
 	if (rpc_priv->crp_flags & CRT_RPC_FLAG_COLL) {
 		rc = crt_proc_corpc_hdr(proc, &rpc_priv->crp_coreq_hdr);
 		if (rc != 0) {
-			D_ERROR("crt_proc_corpc_hdr failed rc: %d.\n", rc);
+			RPC_ERROR(rpc_priv, "crt_proc_corpc_hdr failed: "
+				  DF_RC"\n", DP_RC(rc));
 			D_GOTO(out, rc);
 		}
 	}
@@ -605,8 +578,8 @@ crt_proc_in_common(crt_proc_t proc, crt_rpc_input_t *data)
 
 	rc = crt_proc_input(rpc_priv, proc);
 	if (rc != 0) {
-		D_ERROR("unpack input fails for opc: %#x\n",
-			rpc_priv->crp_pub.cr_opc);
+		RPC_ERROR(rpc_priv, "crt_proc_input failed: "DF_RC"\n",
+			  DP_RC(rc));
 		D_GOTO(out, rc);
 	}
 out:
@@ -622,9 +595,6 @@ crt_proc_out_common(crt_proc_t proc, crt_rpc_output_t *data)
 	int			 rc = 0;
 	int			 rc2;
 
-	if (proc == CRT_PROC_NULL)
-		D_GOTO(out, rc = -DER_INVAL);
-
 	rc = crt_proc_get_op(proc, &proc_op);
 	if (rc != 0)
 		D_GOTO(out, rc);
@@ -636,18 +606,18 @@ crt_proc_out_common(crt_proc_t proc, crt_rpc_output_t *data)
 	/* D_DEBUG("in crt_proc_out_common, data: %p\n", *data); */
 
 	if (proc_op != CRT_PROC_FREE) {
-		if (proc_op == CRT_PROC_ENCODE) {
+		if (ENCODING(proc_op)) {
 			/* Clients never encode replies. */
 			D_ASSERT(crt_is_service());
 			rpc_priv->crp_reply_hdr.cch_hlc = crt_hlc_get();
 		}
 		rc = crt_proc_common_hdr(proc, &rpc_priv->crp_reply_hdr);
 		if (rc != 0) {
-			RPC_ERROR(rpc_priv,
-				  "crt_proc_common_hdr failed rc: %d\n", rc);
+			RPC_ERROR(rpc_priv, "crt_proc_common_hdr failed: "
+				  DF_RC"\n", DP_RC(rc));
 			D_GOTO(out, rc);
 		}
-		if (proc_op == CRT_PROC_DECODE) {
+		if (DECODING(proc_op)) {
 			struct crt_common_hdr *hdr = &rpc_priv->crp_reply_hdr;
 
 			if (crt_is_service()) {
@@ -679,7 +649,6 @@ crt_proc_out_common(crt_proc_t proc, crt_rpc_output_t *data)
 
 		rc2 = rpc_priv->crp_reply_hdr.cch_rc;
 		if (rc2 != 0) {
-
 			if (rpc_priv->crp_reply_hdr.cch_rc != -DER_GRPVER)
 				RPC_ERROR(rpc_priv,
 					  "RPC failed to execute on target. "

--- a/src/cart/crt_rpc.c
+++ b/src/cart/crt_rpc.c
@@ -150,6 +150,13 @@ static struct crt_corpc_ops crt_iv_sync_co_ops = {
 
 CRT_GEN_PROC_FUNC(crt_grp_cache, CRT_SEQ_GRP_CACHE);
 
+static int
+crt_proc_struct_crt_grp_cache(crt_proc_t proc, crt_proc_op_t proc_op,
+			      struct crt_grp_cache *data)
+{
+	return crt_proc_crt_grp_cache(proc, data);
+}
+
 /* !! All of the following 4 RPC definition should have the same input fields !!
  * All of them are verified in one function:
  * int verify_ctl_in_args(struct crt_ctl_ep_ls_in *in_args)

--- a/src/cart/crt_swim.c
+++ b/src/cart/crt_swim.c
@@ -36,10 +36,10 @@
 	((int32_t)		     (rc)		CRT_VAR)
 
 static inline int
-crt_proc_struct_swim_member_update(crt_proc_t proc,
+crt_proc_struct_swim_member_update(crt_proc_t proc, crt_proc_op_t proc_op,
 				   struct swim_member_update *data)
 {
-	return crt_proc_memcpy(proc, data, sizeof(*data));
+	return crt_proc_memcpy(proc, proc_op, data, sizeof(*data));
 }
 
 /* One way RPC */

--- a/src/container/rpc.c
+++ b/src/container/rpc.c
@@ -12,19 +12,20 @@
 #include "rpc.h"
 
 static int
-crt_proc_struct_rsvc_hint(crt_proc_t proc, struct rsvc_hint *hint)
+crt_proc_struct_rsvc_hint(crt_proc_t proc, crt_proc_op_t proc_op,
+			  struct rsvc_hint *hint)
 {
 	int rc;
 
-	rc = crt_proc_uint32_t(proc, &hint->sh_flags);
+	rc = crt_proc_uint32_t(proc, proc_op, &hint->sh_flags);
 	if (rc != 0)
 		return -DER_HG;
 
-	rc = crt_proc_uint32_t(proc, &hint->sh_rank);
+	rc = crt_proc_uint32_t(proc, proc_op, &hint->sh_rank);
 	if (rc != 0)
 		return -DER_HG;
 
-	rc = crt_proc_uint64_t(proc, &hint->sh_term);
+	rc = crt_proc_uint64_t(proc, proc_op, &hint->sh_term);
 	if (rc != 0)
 		return -DER_HG;
 
@@ -32,15 +33,16 @@ crt_proc_struct_rsvc_hint(crt_proc_t proc, struct rsvc_hint *hint)
 }
 
 static int
-crt_proc_daos_epoch_range_t(crt_proc_t proc, daos_epoch_range_t *erange)
+crt_proc_daos_epoch_range_t(crt_proc_t proc, crt_proc_op_t proc_op,
+			    daos_epoch_range_t *erange)
 {
 	int rc;
 
-	rc = crt_proc_uint64_t(proc, &erange->epr_lo);
+	rc = crt_proc_uint64_t(proc, proc_op, &erange->epr_lo);
 	if (rc != 0)
 		return -DER_HG;
 
-	rc = crt_proc_uint64_t(proc, &erange->epr_hi);
+	rc = crt_proc_uint64_t(proc, proc_op, &erange->epr_hi);
 	if (rc != 0)
 		return -DER_HG;
 
@@ -48,6 +50,21 @@ crt_proc_daos_epoch_range_t(crt_proc_t proc, daos_epoch_range_t *erange)
 }
 
 CRT_RPC_DEFINE(cont_op, DAOS_ISEQ_CONT_OP, DAOS_OSEQ_CONT_OP)
+
+static int
+crt_proc_struct_cont_op_in(crt_proc_t proc, crt_proc_op_t proc_op,
+			   struct cont_op_in *data)
+{
+	return crt_proc_cont_op_in(proc, data);
+}
+
+static int
+crt_proc_struct_cont_op_out(crt_proc_t proc, crt_proc_op_t proc_op,
+			    struct cont_op_out *data)
+{
+	return crt_proc_cont_op_out(proc, data);
+}
+
 CRT_RPC_DEFINE(cont_create, DAOS_ISEQ_CONT_CREATE, DAOS_OSEQ_CONT_CREATE)
 CRT_RPC_DEFINE(cont_destroy, DAOS_ISEQ_CONT_DESTROY, DAOS_OSEQ_CONT_DESTROY)
 CRT_RPC_DEFINE(cont_open, DAOS_ISEQ_CONT_OPEN, DAOS_OSEQ_CONT_OPEN)

--- a/src/include/cart/api.h
+++ b/src/include/cart/api.h
@@ -724,55 +724,57 @@ crt_ep_abort(crt_endpoint_t *ep);
 		CRT_GEN_GET_TYPE(seq)** e_ptrp = &ptr->CRT_GEN_GET_NAME(seq).ca_arrays; \
 		CRT_GEN_GET_TYPE(seq)* e_ptr = ptr->CRT_GEN_GET_NAME(seq).ca_arrays; \
 		int i;							\
-		crt_proc_op_t proc_op;					\
-		rc = crt_proc_get_op(proc, &proc_op);			\
-		if (rc)							\
-			D_GOTO(out, rc);				\
 		/* process the count of array first */			\
-		rc = crt_proc_uint64_t(proc, &count);			\
-		if (rc)							\
-			D_GOTO(out, rc);				\
+		rc = crt_proc_uint64_t(proc, proc_op, &count);		\
+		if (unlikely(rc))					\
+			goto out;					\
 		ptr->CRT_GEN_GET_NAME(seq).ca_count = count;		\
-		if (count == 0) {					\
-			if (proc_op == CRT_PROC_DECODE)			\
+		if (unlikely(count == 0)) {				\
+			if (DECODING(proc_op))				\
 				*e_ptrp = NULL;				\
 			goto next_field_##r;				\
 		}							\
-		if (proc_op == CRT_PROC_DECODE) {			\
+		if (DECODING(proc_op)) {				\
 			D_ALLOC_ARRAY(e_ptr, (int)count);		\
-			if (e_ptr == NULL)				\
-				D_GOTO(out, rc = -DER_NOMEM);		\
+			if (unlikely(e_ptr == NULL)) {			\
+				rc = -DER_NOMEM;			\
+				goto out;				\
+			}						\
 			*e_ptrp = e_ptr;				\
 		}							\
 		/* process the elements of array */			\
 		for (i = 0; i < count; i++) {				\
-			rc = CRT_GEN_GET_FUNC(seq)(proc, &e_ptr[i]);	\
-			if (rc) {					\
-				if (proc_op == CRT_PROC_DECODE)		\
+			rc = CRT_GEN_GET_FUNC(seq)(proc, proc_op, &e_ptr[i]); \
+			if (unlikely(rc)) {				\
+				if (DECODING(proc_op))			\
 					D_FREE(e_ptr);			\
-				D_GOTO(out, rc);			\
+				goto out;				\
 			}						\
 		}							\
-		if (proc_op == CRT_PROC_FREE)				\
+		if (FREEING(proc_op))					\
 			D_FREE(e_ptr);					\
 	}								\
 	next_field_##r:,						\
 	BOOST_PP_IF(BOOST_PP_EQUAL(CRT_RAW, CRT_GEN_GET_KIND(seq)),	\
-	rc = crt_proc_memcpy(proc, &ptr->CRT_GEN_GET_NAME(seq),		\
+	rc = crt_proc_memcpy(proc, proc_op, &ptr->CRT_GEN_GET_NAME(seq), \
 			     sizeof(CRT_GEN_GET_TYPE(seq)));		\
-	if (rc)								\
-		D_GOTO(out, rc);,					\
-	rc = CRT_GEN_GET_FUNC(seq)(proc, &ptr->CRT_GEN_GET_NAME(seq));	\
-	if (rc)								\
-		D_GOTO(out, rc);					\
+	if (unlikely(rc))						\
+		goto out;,						\
+	rc = CRT_GEN_GET_FUNC(seq)(proc, proc_op, &ptr->CRT_GEN_GET_NAME(seq));\
+	if (unlikely(rc))						\
+		goto out;						\
 	))
 
 #define CRT_GEN_PROC_FUNC(type_name, seq)				\
-	static int crt_proc_struct_##type_name(crt_proc_t proc,		\
-					       struct type_name *ptr) {	\
-		int rc = 0;						\
-		if (proc == NULL || ptr == NULL)			\
-			D_GOTO(out, rc = -DER_INVAL);			\
+	static int crt_proc_##type_name(crt_proc_t proc,		\
+					struct type_name *ptr) {	\
+		crt_proc_op_t proc_op;					\
+		int rc = -DER_INVAL;					\
+		if (unlikely(proc == NULL || ptr == NULL))		\
+			goto out;					\
+		rc = crt_proc_get_op(proc, &proc_op);			\
+		if (unlikely(rc))					\
+			goto out;					\
 		BOOST_PP_SEQ_FOR_EACH(CRT_GEN_PROC_FIELD, ptr, seq)	\
 	out:								\
 		return rc;						\
@@ -803,10 +805,10 @@ crt_ep_abort(crt_endpoint_t *ep);
 	struct crt_req_format CQF_##rpc_name = {			\
 		.crf_proc_in  = (crt_proc_cb_t)				\
 		BOOST_PP_IF(BOOST_PP_SEQ_SIZE(fields_in),		\
-			crt_proc_struct_##rpc_name##_in, NULL),		\
+			crt_proc_##rpc_name##_in, NULL),		\
 		.crf_proc_out = (crt_proc_cb_t)				\
 		BOOST_PP_IF(BOOST_PP_SEQ_SIZE(fields_out),		\
-			crt_proc_struct_##rpc_name##_out, NULL),	\
+			crt_proc_##rpc_name##_out, NULL),		\
 		.crf_size_in  =						\
 		BOOST_PP_IF(BOOST_PP_SEQ_SIZE(fields_in),		\
 			sizeof(struct rpc_name##_in), 0),		\
@@ -1427,6 +1429,10 @@ typedef enum {
 	CRT_PROC_FREE
 } crt_proc_op_t;
 
+#define ENCODING(proc_op) (proc_op == CRT_PROC_ENCODE)
+#define DECODING(proc_op) (proc_op == CRT_PROC_DECODE)
+#define FREEING(proc_op)  (proc_op == CRT_PROC_FREE)
+
 #define crt_proc_raw crt_proc_memcpy
 
 /**
@@ -1444,13 +1450,111 @@ crt_proc_get_op(crt_proc_t proc, crt_proc_op_t *proc_op);
  * Base proc routine using memcpy().
  *
  * \param[in,out] proc         abstract processor object
+ * \param[in] proc_op          proc operation type
  * \param[in,out] data         pointer to data
  * \param[in] data_size        data size
  *
  * \return                     DER_SUCCESS on success, negative value if error
  */
 int
-crt_proc_memcpy(crt_proc_t proc, void *data, size_t data_size);
+crt_proc_memcpy(crt_proc_t proc, crt_proc_op_t proc_op,
+		void *data, size_t data_size);
+
+/**
+ * Generic processing routine.
+ *
+ * \param[in,out] proc         abstract processor object
+ * \param[in] proc_op          proc operation type
+ * \param[in,out] data         pointer to data
+ *
+ * \return                     DER_SUCCESS on success, negative value if error
+ */
+int
+crt_proc_int8_t(crt_proc_t proc, crt_proc_op_t proc_op, int8_t *data);
+
+/**
+ * Generic processing routine.
+ *
+ * \param[in,out] proc         abstract processor object
+ * \param[in] proc_op          proc operation type
+ * \param[in,out] data         pointer to data
+ *
+ * \return                     DER_SUCCESS on success, negative value if error
+ */
+int
+crt_proc_uint8_t(crt_proc_t proc, crt_proc_op_t proc_op, uint8_t *data);
+
+/**
+ * Generic processing routine.
+ *
+ * \param[in,out] proc         abstract processor object
+ * \param[in] proc_op          proc operation type
+ * \param[in,out] data         pointer to data
+ *
+ * \return                     DER_SUCCESS on success, negative value if error
+ */
+int
+crt_proc_int16_t(crt_proc_t proc, crt_proc_op_t proc_op, int16_t *data);
+
+/**
+ * Generic processing routine.
+ *
+ * \param[in,out] proc         abstract processor object
+ * \param[in] proc_op          proc operation type
+ * \param[in,out] data         pointer to data
+ *
+ * \return                     DER_SUCCESS on success, negative value if error
+ */
+int
+crt_proc_uint16_t(crt_proc_t proc, crt_proc_op_t proc_op, uint16_t *data);
+
+/**
+ * Generic processing routine.
+ *
+ * \param[in,out] proc         abstract processor object
+ * \param[in] proc_op          proc operation type
+ * \param[in,out] data         pointer to data
+ *
+ * \return                     DER_SUCCESS on success, negative value if error
+ */
+int
+crt_proc_int32_t(crt_proc_t proc, crt_proc_op_t proc_op, int32_t *data);
+
+/**
+ * Generic processing routine.
+ *
+ * \param[in,out] proc         abstract processor object
+ * \param[in] proc_op          proc operation type
+ * \param[in,out] data         pointer to data
+ *
+ * \return                     DER_SUCCESS on success, negative value if error
+ */
+int
+crt_proc_uint32_t(crt_proc_t proc, crt_proc_op_t proc_op, uint32_t *data);
+
+/**
+ * Generic processing routine.
+ *
+ * \param[in,out] proc         abstract processor object
+ * \param[in] proc_op          proc operation type
+ * \param[in,out] data         pointer to data
+ *
+ * \return                     DER_SUCCESS on success, negative value if error
+ */
+int
+crt_proc_int64_t(crt_proc_t proc, crt_proc_op_t proc_op, int64_t *data);
+
+/**
+ * Generic processing routine.
+ *
+ * \param[in,out] proc         abstract processor object
+ * \param[in] proc_op          proc operation type
+ * \param[in,out] data         pointer to data
+ *
+ * \return                     DER_SUCCESS on success, negative value if error
+ */
+int
+crt_proc_uint64_t(crt_proc_t proc, crt_proc_op_t proc_op, uint64_t *data);
 
 /**
  * Generic processing routine.
@@ -1461,144 +1565,63 @@ crt_proc_memcpy(crt_proc_t proc, void *data, size_t data_size);
  * \return                     DER_SUCCESS on success, negative value if error
  */
 int
-crt_proc_int8_t(crt_proc_t proc, int8_t *data);
+crt_proc_bool(crt_proc_t proc, crt_proc_op_t proc_op, bool *data);
 
 /**
  * Generic processing routine.
  *
  * \param[in,out] proc         abstract processor object
- * \param[in,out] data         pointer to data
- *
- * \return                     DER_SUCCESS on success, negative value if error
- */
-int
-crt_proc_uint8_t(crt_proc_t proc, uint8_t *data);
-
-/**
- * Generic processing routine.
- *
- * \param[in,out] proc         abstract processor object
- * \param[in,out] data         pointer to data
- *
- * \return                     DER_SUCCESS on success, negative value if error
- */
-int
-crt_proc_int16_t(crt_proc_t proc, int16_t *data);
-
-/**
- * Generic processing routine.
- *
- * \param[in,out] proc         abstract processor object
- * \param[in,out] data         pointer to data
- *
- * \return                     DER_SUCCESS on success, negative value if error
- */
-int
-crt_proc_uint16_t(crt_proc_t proc, uint16_t *data);
-
-/**
- * Generic processing routine.
- *
- * \param[in,out] proc         abstract processor object
- * \param[in,out] data         pointer to data
- *
- * \return                     DER_SUCCESS on success, negative value if error
- */
-int
-crt_proc_int32_t(crt_proc_t proc, int32_t *data);
-
-/**
- * Generic processing routine.
- *
- * \param[in,out] proc         abstract processor object
- * \param[in,out] data         pointer to data
- *
- * \return                     DER_SUCCESS on success, negative value if error
- */
-int
-crt_proc_uint32_t(crt_proc_t proc, uint32_t *data);
-
-/**
- * Generic processing routine.
- *
- * \param[in,out] proc         abstract processor object
- * \param[in,out] data         pointer to data
- *
- * \return                     DER_SUCCESS on success, negative value if error
- */
-int
-crt_proc_int64_t(crt_proc_t proc, int64_t *data);
-
-/**
- * Generic processing routine.
- *
- * \param[in,out] proc         abstract processor object
- * \param[in,out] data         pointer to data
- *
- * \return                     DER_SUCCESS on success, negative value if error
- */
-int
-crt_proc_uint64_t(crt_proc_t proc, uint64_t *data);
-
-/**
- * Generic processing routine.
- *
- * \param[in,out] proc         abstract processor object
- * \param[in,out] data         pointer to data
- *
- * \return                     DER_SUCCESS on success, negative value if error
- */
-int
-crt_proc_bool(crt_proc_t proc, bool *data);
-
-/**
- * Generic processing routine.
- *
- * \param[in,out] proc         abstract processor object
+ * \param[in] proc_op          proc operation type
  * \param[in,out] bulk_hdl     pointer to bulk handle
  *
  * \return                     DER_SUCCESS on success, negative value if error
  */
 int
-crt_proc_crt_bulk_t(crt_proc_t proc, crt_bulk_t *bulk_hdl);
+crt_proc_crt_bulk_t(crt_proc_t proc, crt_proc_op_t proc_op,
+		    crt_bulk_t *bulk_hdl);
 
 /**
  * Generic processing routine.
  *
  * \param[in,out] proc         abstract processor object
+ * \param[in] proc_op          proc operation type
  * \param[in,out] data         pointer to data
  *
  * \return                     DER_SUCCESS on success, negative value if error
  */
 int
-crt_proc_d_string_t(crt_proc_t proc, d_string_t *data);
+crt_proc_d_string_t(crt_proc_t proc, crt_proc_op_t proc_op, d_string_t *data);
 
 /**
  * Generic processing routine.
  *
  * \param[in,out] proc         abstract processor object
+ * \param[in] proc_op          proc operation type
  * \param[in,out] data         pointer to data
  *
  * \return                     DER_SUCCESS on success, negative value if error
  */
 int
-crt_proc_d_const_string_t(crt_proc_t proc, d_const_string_t *data);
+crt_proc_d_const_string_t(crt_proc_t proc, crt_proc_op_t proc_op,
+			  d_const_string_t *data);
 
 /**
  * Generic processing routine.
  *
  * \param[in,out] proc         abstract processor object
+ * \param[in] proc_op          proc operation type
  * \param[in,out] data         pointer to data
  *
  * \return                     DER_SUCCESS on success, negative value if error
  */
 int
-crt_proc_uuid_t(crt_proc_t proc, uuid_t *data);
+crt_proc_uuid_t(crt_proc_t proc, crt_proc_op_t proc_op, uuid_t *data);
 
 /**
  * Generic processing routine.
  *
  * \param[in,out] proc         abstract processor object
+ * \param[in] proc_op          proc operation type
  * \param[in,out] data         second level pointer to data
  *
  * \return                     DER_SUCCESS on success, negative value if error
@@ -1611,18 +1634,20 @@ crt_proc_uuid_t(crt_proc_t proc, uuid_t *data);
  *    function will internally free the memory when freeing the input or output.
  */
 int
-crt_proc_d_rank_list_t(crt_proc_t proc, d_rank_list_t **data);
+crt_proc_d_rank_list_t(crt_proc_t proc, crt_proc_op_t proc_op,
+		       d_rank_list_t **data);
 
 /**
  * Generic processing routine.
  *
  * \param[in,out] proc         abstract processor object
+ * \param[in] proc_op          proc operation type
  * \param[in,out] data         pointer to data
  *
  * \return                     DER_SUCCESS on success, negative value if error
  */
 int
-crt_proc_d_iov_t(crt_proc_t proc, d_iov_t *data);
+crt_proc_d_iov_t(crt_proc_t proc, crt_proc_op_t proc_op, d_iov_t *data);
 
 typedef void
 (*crt_progress_cb) (crt_context_t ctx, void *arg);

--- a/src/include/daos/common.h
+++ b/src/include/daos/common.h
@@ -827,9 +827,12 @@ daos_recx_merge(daos_recx_t *src, daos_recx_t *dst)
 
 crt_init_options_t *daos_crt_init_opt_get(bool server, int crt_nr);
 
-int crt_proc_struct_dtx_id(crt_proc_t proc, struct dtx_id *dti);
-int crt_proc_daos_prop_t(crt_proc_t proc, daos_prop_t **data);
-int crt_proc_struct_daos_acl(crt_proc_t proc, struct daos_acl **data);
+int crt_proc_struct_dtx_id(crt_proc_t proc, crt_proc_op_t proc_op,
+			   struct dtx_id *dti);
+int crt_proc_daos_prop_t(crt_proc_t proc, crt_proc_op_t proc_op,
+			 daos_prop_t **data);
+int crt_proc_struct_daos_acl(crt_proc_t proc, crt_proc_op_t proc_op,
+			     struct daos_acl **data);
 
 bool daos_prop_valid(daos_prop_t *prop, bool pool, bool input);
 daos_prop_t *daos_prop_dup(daos_prop_t *prop, bool pool);

--- a/src/mgmt/rpc.c
+++ b/src/mgmt/rpc.c
@@ -13,6 +13,13 @@
 
 CRT_GEN_PROC_FUNC(server_entry, DAOS_SEQ_SERVER_ENTRY);
 
+static int
+crt_proc_struct_server_entry(crt_proc_t proc, crt_proc_op_t proc_op,
+			     struct server_entry *data)
+{
+	return crt_proc_server_entry(proc, data);
+}
+
 CRT_RPC_DEFINE(mgmt_svc_rip, DAOS_ISEQ_MGMT_SVR_RIP, DAOS_OSEQ_MGMT_SVR_RIP)
 CRT_RPC_DEFINE(mgmt_params_set, DAOS_ISEQ_MGMT_PARAMS_SET,
 		DAOS_OSEQ_MGMT_PARAMS_SET)

--- a/src/object/obj_rpc.h
+++ b/src/object/obj_rpc.h
@@ -25,10 +25,6 @@
 
 #include "obj_ec.h"
 
-#define ENCODING(proc_op) (proc_op == CRT_PROC_ENCODE)
-#define DECODING(proc_op) (proc_op == CRT_PROC_DECODE)
-#define FREEING(proc_op)  (proc_op == CRT_PROC_FREE)
-
 /* It cannot exceed the mercury unexpected msg size (4KB), reserves half-KB
  * for other RPC fields and cart/HG headers.
  */

--- a/src/object/rpc_csum.h
+++ b/src/object/rpc_csum.h
@@ -8,10 +8,12 @@
 #define __DAOS_RPC_CSUM_H__
 
 int
-crt_proc_struct_dcs_csum_info(crt_proc_t proc, struct dcs_csum_info **csum);
+crt_proc_struct_dcs_csum_info(crt_proc_t proc, crt_proc_op_t proc_op,
+			      struct dcs_csum_info **csum);
 
 int
-crt_proc_struct_dcs_iod_csums(crt_proc_t proc, struct dcs_iod_csums *iod_csum);
+crt_proc_struct_dcs_iod_csums(crt_proc_t proc, crt_proc_op_t proc_op,
+			      struct dcs_iod_csums *iod_csum);
 
 int
 crt_proc_struct_dcs_iod_csums_adv(crt_proc_t proc, crt_proc_op_t proc_op,

--- a/src/pool/rpc.c
+++ b/src/pool/rpc.c
@@ -16,15 +16,16 @@
 #define crt_proc_daos_target_state_t crt_proc_uint32_t
 
 static int
-crt_proc_struct_pool_target_addr(crt_proc_t proc, struct pool_target_addr *tgt)
+crt_proc_struct_pool_target_addr(crt_proc_t proc, crt_proc_op_t proc_op,
+				 struct pool_target_addr *tgt)
 {
 	int rc;
 
-	rc = crt_proc_uint32_t(proc, &tgt->pta_rank);
+	rc = crt_proc_uint32_t(proc, proc_op, &tgt->pta_rank);
 	if (rc != 0)
 		return -DER_HG;
 
-	rc = crt_proc_uint32_t(proc, &tgt->pta_target);
+	rc = crt_proc_uint32_t(proc, proc_op, &tgt->pta_target);
 	if (rc != 0)
 		return -DER_HG;
 
@@ -32,19 +33,20 @@ crt_proc_struct_pool_target_addr(crt_proc_t proc, struct pool_target_addr *tgt)
 }
 
 static int
-crt_proc_struct_rsvc_hint(crt_proc_t proc, struct rsvc_hint *hint)
+crt_proc_struct_rsvc_hint(crt_proc_t proc, crt_proc_op_t proc_op,
+			  struct rsvc_hint *hint)
 {
 	int rc;
 
-	rc = crt_proc_uint32_t(proc, &hint->sh_flags);
+	rc = crt_proc_uint32_t(proc, proc_op, &hint->sh_flags);
 	if (rc != 0)
 		return -DER_HG;
 
-	rc = crt_proc_uint32_t(proc, &hint->sh_rank);
+	rc = crt_proc_uint32_t(proc, proc_op, &hint->sh_rank);
 	if (rc != 0)
 		return -DER_HG;
 
-	rc = crt_proc_uint64_t(proc, &hint->sh_term);
+	rc = crt_proc_uint64_t(proc, proc_op, &hint->sh_term);
 	if (rc != 0)
 		return -DER_HG;
 
@@ -52,6 +54,21 @@ crt_proc_struct_rsvc_hint(crt_proc_t proc, struct rsvc_hint *hint)
 }
 
 CRT_RPC_DEFINE(pool_op, DAOS_ISEQ_POOL_OP, DAOS_OSEQ_POOL_OP)
+
+static int
+crt_proc_struct_pool_op_in(crt_proc_t proc, crt_proc_op_t proc_op,
+			   struct pool_op_in *data)
+{
+	return crt_proc_pool_op_in(proc, data);
+}
+
+static int
+crt_proc_struct_pool_op_out(crt_proc_t proc, crt_proc_op_t proc_op,
+			    struct pool_op_out *data)
+{
+	return crt_proc_pool_op_out(proc, data);
+}
+
 CRT_RPC_DEFINE(pool_create, DAOS_ISEQ_POOL_CREATE, DAOS_OSEQ_POOL_CREATE)
 CRT_RPC_DEFINE(pool_connect, DAOS_ISEQ_POOL_CONNECT, DAOS_OSEQ_POOL_CONNECT)
 CRT_RPC_DEFINE(pool_disconnect, DAOS_ISEQ_POOL_DISCONNECT,

--- a/src/rdb/tests/rpc.c
+++ b/src/rdb/tests/rpc.c
@@ -9,19 +9,20 @@
 #include "rpc.h"
 
 static int
-crt_proc_struct_rsvc_hint(crt_proc_t proc, struct rsvc_hint *hint)
+crt_proc_struct_rsvc_hint(crt_proc_t proc, crt_proc_op_t proc_op,
+			  struct rsvc_hint *hint)
 {
 	int rc;
 
-	rc = crt_proc_uint32_t(proc, &hint->sh_flags);
+	rc = crt_proc_uint32_t(proc, proc_op, &hint->sh_flags);
 	if (rc != 0)
 		return -DER_HG;
 
-	rc = crt_proc_uint32_t(proc, &hint->sh_rank);
+	rc = crt_proc_uint32_t(proc, proc_op, &hint->sh_rank);
 	if (rc != 0)
 		return -DER_HG;
 
-	rc = crt_proc_uint64_t(proc, &hint->sh_term);
+	rc = crt_proc_uint64_t(proc, proc_op, &hint->sh_term);
 	if (rc != 0)
 		return -DER_HG;
 

--- a/src/rebuild/rpc.c
+++ b/src/rebuild/rpc.c
@@ -15,9 +15,10 @@
 #include "rpc.h"
 
 static int
-crt_proc_daos_unit_oid_t(crt_proc_t proc, daos_unit_oid_t *p)
+crt_proc_daos_unit_oid_t(crt_proc_t proc, crt_proc_op_t proc_op,
+			 daos_unit_oid_t *p)
 {
-	return crt_proc_memcpy(proc, p, sizeof(*p));
+	return crt_proc_memcpy(proc, proc_op, p, sizeof(*p));
 }
 
 CRT_RPC_DEFINE(rebuild_scan, DAOS_ISEQ_REBUILD_SCAN, DAOS_OSEQ_REBUILD_SCAN)

--- a/src/tests/ftest/cart/test_swim_net.c
+++ b/src/tests/ftest/cart/test_swim_net.c
@@ -29,12 +29,12 @@
 #define CRT_OSEQ_RPC_SWIM	/* output fields */
 
 static int
-crt_proc_struct_swim_member_update(crt_proc_t proc,
+crt_proc_struct_swim_member_update(crt_proc_t proc, crt_proc_op_t proc_op,
 				   struct swim_member_update *data)
 {
 	int rc;
 
-	rc = crt_proc_memcpy(proc, data, sizeof(*data));
+	rc = crt_proc_memcpy(proc, proc_op, data, sizeof(*data));
 	if (rc != 0)
 		return -DER_HG;
 


### PR DESCRIPTION
Pass proc_op as argument instead of call crt_proc_get_op() inside each proc function.
This give about 6% performance improvements for RPC send/receive.
Fix errno reporting.

For example, daos_perf results:
```
Parameters :
        pool size     : SCM: 8192 MB, NVMe: 0 MB
        credits       : 16 (sync I/O for -ve)
        obj_per_cont  : 1 x 1 (procs)
        dkey_per_obj  : 1024
        akey_per_dkey : 1
        recx_per_akey : 256
        value type    : array
        stride size   : 4096
        zero copy     : no
        VOS file      : <NULL>
Running UPDATE test (iteration=3)
```
Master branch show the following results:
```
UPDATE successfully completed:
        duration : 36.387225  sec
        bandwith : 84.425     MB/sec
        rate     : 21612.86   IO/sec
        latency  : 46.269     us (nonsense if credits > 1)
Duration across processes:
        MAX duration : 36.387225  sec
        MIN duration : 36.387225  sec
        Average duration : 36.387225  sec
```
With this patch results are following:
```
UPDATE successfully completed:
        duration : 33.724163  sec
        bandwith : 91.092     MB/sec
        rate     : 23319.54   IO/sec
        latency  : 42.882     us (nonsense if credits > 1)
Duration across processes:
        MAX duration : 33.724163  sec
        MIN duration : 33.724163  sec
        Average duration : 33.724163  sec
```