### PR TITLE
DAOS-7152 test: reduce the number of threads in dfs unit test

### DIFF
--- a/src/tests/suite/dfs_unit_test.c
+++ b/src/tests/suite/dfs_unit_test.c
@@ -412,8 +412,8 @@ dfs_test_rm(const char *name)
 	assert_int_equal(rc, 0);
 }
 
-int dfs_test_thread_nr		= 100;
-#define DFS_TEST_MAX_THREAD_NR	(200)
+int dfs_test_thread_nr		= 32;
+#define DFS_TEST_MAX_THREAD_NR	(64)
 pthread_t dfs_test_tid[DFS_TEST_MAX_THREAD_NR];
 
 struct dfs_test_thread_arg {


### PR DESCRIPTION
Quick-Functional: true
Skip-func-test-vm: true
Skip-func-hw-test-small: true
Skip-func-hw-test-medium: true
Test-tag-hw-large: daos_core_test_dfs

Signed-off-by: Mohamad Chaarawi <mohamad.chaarawi@intel.com>