### PR TITLE
DAOS-7126 test: Create unique files in unit tests

### DIFF
--- a/src/control/cmd/dmg/json_test.go
+++ b/src/control/cmd/dmg/json_test.go
@@ -11,7 +11,6 @@ import (
 	"encoding/json"
 	"io"
 	"os"
-	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
@@ -58,9 +57,10 @@ func TestDmg_JsonOutput(t *testing.T) {
 		cmdArgs = append(cmdArgs, cmd)
 	})
 
-	aclPath := filepath.Join(os.TempDir(), "testACLFile.txt")
-	createTestFile(t, aclPath, "A::OWNER@:rw\nA::user1@:rw\nA:g:group1@:r\n")
-	defer os.Remove(aclPath)
+	testDir, cleanup := common.CreateTestDir(t)
+	defer cleanup()
+	aclContent := "A::OWNER@:rw\nA::user1@:rw\nA:g:group1@:r\n"
+	aclPath := common.CreateTestFile(t, testDir, aclContent)
 
 	for _, args := range cmdArgs {
 		t.Run(strings.Join(args, " "), func(t *testing.T) {

--- a/src/control/common/test_utils.go
+++ b/src/control/common/test_utils.go
@@ -188,6 +188,25 @@ func CreateTestDir(t *testing.T) (string, func()) {
 	}
 }
 
+// CreateTestFile creates a file in the given directory with a random name, and
+// writes the content string to the file. It returns the path to the file.
+func CreateTestFile(t *testing.T, dir, content string) string {
+	t.Helper()
+
+	file, err := ioutil.TempFile(dir, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer file.Close()
+
+	_, err = file.WriteString(content)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return file.Name()
+}
+
 // CreateTestSocket creates a Unix Domain Socket that can listen for connections
 // on a given path. It returns the listener and a cleanup function.
 func CreateTestSocket(t *testing.T, sockPath string) (*net.UnixListener, func()) {

--- a/src/control/lib/control/acl_test.go
+++ b/src/control/lib/control/acl_test.go
@@ -10,8 +10,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 
@@ -65,23 +63,10 @@ func TestControl_ReadACLFile_FileOpenFailed(t *testing.T) {
 	}
 }
 
-func createTestFile(t *testing.T, filePath string, content string) {
-	file, err := os.Create(filePath)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer file.Close()
-
-	_, err = file.WriteString(content)
-	if err != nil {
-		t.Fatal(err)
-	}
-}
-
 func TestControl_ReadACLFile_Success(t *testing.T) {
-	path := filepath.Join(os.TempDir(), "testACLFile.txt")
-	createTestFile(t, path, "A::OWNER@:rw\nA::user1@:rw\nA:g:group1@:r\n")
-	defer os.Remove(path)
+	dir, cleanup := common.CreateTestDir(t)
+	defer cleanup()
+	path := common.CreateTestFile(t, dir, "A::OWNER@:rw\nA::user1@:rw\nA:g:group1@:r\n")
 
 	expectedNumACEs := 3
 
@@ -102,9 +87,9 @@ func TestControl_ReadACLFile_Success(t *testing.T) {
 }
 
 func TestReadACLFile_Empty(t *testing.T) {
-	path := filepath.Join(os.TempDir(), "empty.txt")
-	createTestFile(t, path, "")
-	defer os.Remove(path)
+	dir, cleanup := common.CreateTestDir(t)
+	defer cleanup()
+	path := common.CreateTestFile(t, dir, "")
 
 	result, err := ReadACLFile(path)
 

--- a/src/control/server/drpc_test.go
+++ b/src/control/server/drpc_test.go
@@ -60,15 +60,9 @@ func TestCheckDrpcClientSocketPath_FileNotSocket(t *testing.T) {
 	tmpDir, tmpCleanup := common.CreateTestDir(t)
 	defer tmpCleanup()
 
-	path := filepath.Join(tmpDir, "drpc_test.sock")
-	f, err := os.Create(path)
-	if err != nil {
-		t.Fatalf("Failed to create temp file: %v", err)
-	}
-	f.Close()
-	defer os.Remove(path)
+	path := common.CreateTestFile(t, tmpDir, "")
 
-	err = checkDrpcClientSocketPath(path)
+	err := checkDrpcClientSocketPath(path)
 
 	if err == nil {
 		t.Fatal("Expected an error, got nil")


### PR DESCRIPTION
Some unit tests were depositing identically-named files into
the system temporary directory. This could create conflicts
if two instances of unit tests were running on the same
system.

Signed-off-by: Kris Jacque <kristin.jacque@intel.com>