### PR TITLE
DAOS-7133 tse: add per task spinlock to serialize comp_cb executing

### DIFF
--- a/src/common/tse_internal.h
+++ b/src/common/tse_internal.h
@@ -69,6 +69,8 @@ struct tse_task_private {
 	 * DAOS internal task parameter pointer.
 	 */
 	void				*dtp_priv_internal;
+	/* spinlock to protect dtp_comp_cb_list */
+	pthread_spinlock_t		 dtp_spin;
 	/**
 	 * reserved buffer for user to assign embedded parameters, it also can
 	 * be used as task stack space that can push/pop parameters to

--- a/src/include/daos/tse.h
+++ b/src/include/daos/tse.h
@@ -22,7 +22,7 @@
 /* 8 bytes used for public members */
 #define TSE_PRIV_SIZE		1016
 /* tse_task arguments max length */
-#define TSE_TASK_ARG_LEN		880
+#define TSE_TASK_ARG_LEN		872
 
 typedef struct tse_task {
 	int			dt_result;


### PR DESCRIPTION
Add a per task spinlock, to serialize task's completion callback's
executing, to avoid race condition when one task with multiple
comp CBs.

Signed-off-by: Xuezhao Liu <xuezhao.liu@intel.com>