### PR TITLE
DAOS-623 build: Fix issue with builds where no MPI is present

### DIFF
--- a/src/common/SConscript
+++ b/src/common/SConscript
@@ -51,14 +51,11 @@ def build_dts_library(env):
 
     denv.AppendUnique(CPPPATH=["../tests/suite"])
 
-    dc_credit = denv.SharedObject(['credit.c'])
-    Export('dc_credit')
+    denv.Replace(SHOBJPREFIX='mpi_')
+    mpi_cmd_parser = denv.SharedObject(['cmd_parser.c'])
+    Export('mpi_cmd_parser')
 
-    denv.Replace(SHOBJPREFIX='t_')
-    t_cmd_parser = denv.SharedObject(['cmd_parser.c'])
-    Export('t_cmd_parser')
-
-    dts_lib = daos_build.library(denv, 'libdts', [dc_credit, 'dts.c'],
+    dts_lib = daos_build.library(denv, 'libdts', ['credit.c', 'dts.c'],
                                  LIBS=libraries)
     denv.Install('$PREFIX/lib64/', dts_lib)
 
@@ -93,6 +90,8 @@ def scons():
 
     cmd_parser = denv.SharedObject(['cmd_parser.c'])
     Export('cmd_parser')
+    dc_credit = denv.SharedObject(['credit.c'])
+    Export('dc_credit')
 
     prereqs.require(tlib_env, 'argobots')
 

--- a/src/tests/SConscript
+++ b/src/tests/SConscript
@@ -38,9 +38,9 @@ def scons():
                                     LIBS=libs)
     denv.Install('$PREFIX/bin/', daos_racer)
 
-    Import('t_cmd_parser')
+    Import('mpi_cmd_parser')
     obj_ctl = daos_build.program(denv, 'obj_ctl',
-                                 ['obj_ctl.c', t_cmd_parser],
+                                 ['obj_ctl.c', mpi_cmd_parser],
                                  LIBS=libs)
     denv.Install('$PREFIX/bin/', obj_ctl)
 


### PR DESCRIPTION
A regression in the build was landed recently that broke builds
when MPI is not available.   This addresses that issue by ensuring
that dc_credit built even when mpi is not present

Skip-bullseye: false

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>