### PR TITLE
DAOS-623 build: Disable new pylint warning in SCons checks

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -17,6 +17,8 @@ except NameError:
 
 sys.path.insert(0, os.path.join(Dir('#').abspath, 'utils/sl'))
 import daos_build
+from prereq_tools import PreReqComponent
+
 
 DESIRED_FLAGS = ['-Wno-gnu-designator',
                  '-Wno-missing-braces',
@@ -178,13 +180,15 @@ def scons(): # pylint: disable=too-many-locals
     """Execute build"""
     if COMMAND_LINE_TARGETS == ['release']:
         try:
+            # pylint: disable=import-outside-toplevel
             import pygit2
             import github
             import yaml
+            # pylint: enable=import-outside-toplevel
         except ImportError:
             print("You need yaml, pygit2 and pygithub python modules to "
                   "create releases")
-            exit(1)
+            sys.exit(1)
 
         variables = Variables()
 
@@ -205,7 +209,7 @@ def scons(): # pylint: disable=too-many-locals
             tag = env['RELEASE']
         except KeyError:
             print("Usage: scons RELEASE=x.y.z release")
-            exit(1)
+            sys.exit(1)
 
         dash = tag.find('-')    # pylint: disable=no-member
         if dash > 0:
@@ -218,7 +222,7 @@ def scons(): # pylint: disable=too-many-locals
             while answer not in ["y", "n", ""]:
                 answer = input(question).lower().strip()
             if answer != 'y':
-                exit(1)
+                sys.exit(1)
 
             version = tag
 
@@ -231,7 +235,7 @@ def scons(): # pylint: disable=too-many-locals
                 print("You need to install hub (from the hub RPM on EL7) to "
                       "and run it at least once to create an authorization "
                       "token in order to create releases")
-                exit(1)
+                sys.exit(1)
             raise
 
         # create a branch for the PR
@@ -245,7 +249,7 @@ def scons(): # pylint: disable=too-many-locals
             print("Branch {}/{} is not a valid branch\n"
                   "See https://github.com/{}/daos/branches".format(
                       remote_name, base_branch, org_name))
-            exit(1)
+            sys.exit(1)
 
         # older pygit2 didn't have AlreadyExistsError
         try:
@@ -259,7 +263,7 @@ def scons(): # pylint: disable=too-many-locals
             print("Branch {} exists locally already.\n"
                   "You need to delete it or rename it to try again.".format(
                       branch))
-            exit(1)
+            sys.exit(1)
 
         # and check it out
         print("Checking out branch for the PR...")
@@ -269,7 +273,7 @@ def scons(): # pylint: disable=too-many-locals
         if not update_rpm_version(version, tag):
             print("Branch has been left in the created state.  You will have "
                   "to clean it up manually.")
-            exit(1)
+            sys.exit(1)
 
         print("Updating the VERSION and TAG files...")
         with open("VERSION", "w") as version_file:
@@ -330,12 +334,14 @@ def scons(): # pylint: disable=too-many-locals
         # and push it
         print("Pushing the changes to GitHub...")
         remote = repo.remotes[remote_name]
+        # pylint: disable=no-member
         try:
             remote.push(['refs/heads/{}'.format(branch)],
                         callbacks=MyCallbacks())
         except pygit2.GitError as excpt:
             print("Error pushing branch: {}".format(excpt))
-            exit(1)
+            sys.exit(1)
+        # pylint: enable=no-member
 
         print("Creating the PR...")
         # now create a PR for it
@@ -361,9 +367,7 @@ def scons(): # pylint: disable=too-many-locals
 
         print("Done.")
 
-        exit(0)
-
-    from prereq_tools import PreReqComponent
+        sys.exit(0)
 
     env = Environment(TOOLS=['extra', 'default', 'textfile'])
 

--- a/SConstruct
+++ b/SConstruct
@@ -188,7 +188,7 @@ def scons(): # pylint: disable=too-many-locals
         except ImportError:
             print("You need yaml, pygit2 and pygithub python modules to "
                   "create releases")
-            sys.exit(1)
+            Exit(1)
 
         variables = Variables()
 
@@ -209,7 +209,7 @@ def scons(): # pylint: disable=too-many-locals
             tag = env['RELEASE']
         except KeyError:
             print("Usage: scons RELEASE=x.y.z release")
-            sys.exit(1)
+            Exit(1)
 
         dash = tag.find('-')    # pylint: disable=no-member
         if dash > 0:
@@ -222,7 +222,7 @@ def scons(): # pylint: disable=too-many-locals
             while answer not in ["y", "n", ""]:
                 answer = input(question).lower().strip()
             if answer != 'y':
-                sys.exit(1)
+                Exit(1)
 
             version = tag
 
@@ -235,7 +235,7 @@ def scons(): # pylint: disable=too-many-locals
                 print("You need to install hub (from the hub RPM on EL7) to "
                       "and run it at least once to create an authorization "
                       "token in order to create releases")
-                sys.exit(1)
+                Exit(1)
             raise
 
         # create a branch for the PR
@@ -249,7 +249,7 @@ def scons(): # pylint: disable=too-many-locals
             print("Branch {}/{} is not a valid branch\n"
                   "See https://github.com/{}/daos/branches".format(
                       remote_name, base_branch, org_name))
-            sys.exit(1)
+            Exit(1)
 
         # older pygit2 didn't have AlreadyExistsError
         try:
@@ -263,7 +263,7 @@ def scons(): # pylint: disable=too-many-locals
             print("Branch {} exists locally already.\n"
                   "You need to delete it or rename it to try again.".format(
                       branch))
-            sys.exit(1)
+            Exit(1)
 
         # and check it out
         print("Checking out branch for the PR...")
@@ -273,7 +273,7 @@ def scons(): # pylint: disable=too-many-locals
         if not update_rpm_version(version, tag):
             print("Branch has been left in the created state.  You will have "
                   "to clean it up manually.")
-            sys.exit(1)
+            Exit(1)
 
         print("Updating the VERSION and TAG files...")
         with open("VERSION", "w") as version_file:
@@ -340,7 +340,7 @@ def scons(): # pylint: disable=too-many-locals
                         callbacks=MyCallbacks())
         except pygit2.GitError as excpt:
             print("Error pushing branch: {}".format(excpt))
-            sys.exit(1)
+            Exit(1)
         # pylint: enable=no-member
 
         print("Creating the PR...")
@@ -367,7 +367,7 @@ def scons(): # pylint: disable=too-many-locals
 
         print("Done.")
 
-        sys.exit(0)
+        Exit(0)
 
     env = Environment(TOOLS=['extra', 'default', 'textfile'])
 

--- a/utils/sl/check_script.py
+++ b/utils/sl/check_script.py
@@ -223,7 +223,7 @@ def check_script(fname, *args, **kw):
     rc_file = "tmp_pylint3.rc"
     if pycmd is None:
         print("Required pylint isn't installed on this machine")
-        return 0
+        return
 
     rc_dir = os.path.dirname(os.path.realpath(__file__))
 
@@ -247,7 +247,7 @@ def check_script(fname, *args, **kw):
     except OSError as exception:
         if exception.errno == errno.ENOENT:
             print("pylint could not be found")
-            return 1
+            return
         raise
     except subprocess.CalledProcessError:
         pass

--- a/utils/sl/check_script.py
+++ b/utils/sl/check_script.py
@@ -102,8 +102,9 @@ class WrapScript():
     @staticmethod
     def write_variables(outfile, prefix, variables):
         """Add code to define fake variables for pylint"""
-        newlines = 2
+        newlines = 4
         outfile.write("# pylint: disable=invalid-name\n")
+        outfile.write("# pylint: disable=import-outside-toplevel\n")
 
         for variable in variables:
             if variable.upper() == 'PREREQS':
@@ -135,17 +136,20 @@ class WrapScript():
                 outfile.write("%s%s = None\n" % (prefix, variable))
 
         outfile.write("# pylint: enable=invalid-name\n")
+        outfile.write("# pylint: enable=import-outside-toplevel\n")
         return newlines
 
     @staticmethod
     def write_header(outfile):
         """write the header"""
         outfile.write("""# pylint: disable=wildcard-import
+# pylint: disable=import-outside-toplevel
 from __future__ import print_function
 from SCons.Script import *
 from SCons.Variables import *
-# pylint: enable=wildcard-import\n""")
-        return 5
+# pylint: enable=wildcard-import
+# pylint: enable=import-outside-toplevel\n""")
+        return 7
 
     def fix_log(self, log_file, fname):
         """Get the line number"""


### PR DESCRIPTION
A new warning started happening recently caused by check_script.py
inserting code in SCons that causes import functions to be
inserted inline

Cleanup pylint warnings in top-level SConstruct

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>