### PR TITLE
DAOS-7158 control: Lock system database on restore

### DIFF
--- a/src/control/system/raft.go
+++ b/src/control/system/raft.go
@@ -424,10 +424,12 @@ func (f *fsm) Restore(rc io.ReadCloser) error {
 			db.data.SchemaVersion, CurrentSchemaVersion)
 	}
 
+	f.data.Lock()
 	f.data.Members = db.data.Members
 	f.data.Pools = db.data.Pools
 	f.data.NextRank = db.data.NextRank
 	f.data.MapVersion = db.data.MapVersion
+	f.data.Unlock()
 	f.log.Debugf("db snapshot loaded (map version %d)", db.data.MapVersion)
 	return nil
 }


### PR DESCRIPTION
Avoid a rare race warning which could happen if a system query
happens before the database is restored from snapshot on
server startup.