### PR TITLE
DAOS-4757-test: remove skipForTicket rebuild read_array.py

### DIFF
--- a/src/tests/ftest/rebuild/cascading_failures.py
+++ b/src/tests/ftest/rebuild/cascading_failures.py
@@ -14,7 +14,7 @@ class CascadingFailures(RebuildTestBase):
     :avocado: recursive
     """
 
-    CANCEL_FOR_TICKET = [["DAOS-2799", "targets", 8]]
+    CANCEL_FOR_TICKET = [["DAOS-6728"]]
 
     def __init__(self, *args, **kwargs):
         """Initialize a CascadingFailures object."""

--- a/src/tests/ftest/rebuild/cascading_failures.py
+++ b/src/tests/ftest/rebuild/cascading_failures.py
@@ -5,7 +5,7 @@
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
 from rebuild_test_base import RebuildTestBase
-
+from apricot import skipForTicket
 
 class CascadingFailures(RebuildTestBase):
     # pylint: disable=too-many-ancestors
@@ -13,8 +13,6 @@ class CascadingFailures(RebuildTestBase):
 
     :avocado: recursive
     """
-
-    CANCEL_FOR_TICKET = [["DAOS-6728"]]
 
     def __init__(self, *args, **kwargs):
         """Initialize a CascadingFailures object."""
@@ -79,6 +77,7 @@ class CascadingFailures(RebuildTestBase):
         # Populate the container with additional data during rebuild
         self.container.write_objects(obj_class=self.inputs.object_class.value)
 
+    @skipForTicket("DAOS-6728")
     def test_simultaneous_failures(self):
         """Jira ID: DAOS-842.
 
@@ -98,6 +97,7 @@ class CascadingFailures(RebuildTestBase):
         self.mode = "simultaneous"
         self.execute_rebuild_test()
 
+    @skipForTicket("DAOS-6728")
     def test_sequential_failures(self):
         """Jira ID: DAOS-843.
 
@@ -118,6 +118,7 @@ class CascadingFailures(RebuildTestBase):
         self.mode = "sequential"
         self.execute_rebuild_test()
 
+    @skipForTicket("DAOS-6728")
     def test_cascading_failures(self):
         """Jira ID: DAOS-844.
 

--- a/src/tests/ftest/rebuild/cascading_failures.yaml
+++ b/src/tests/ftest/rebuild/cascading_failures.yaml
@@ -12,7 +12,7 @@ timeout: 360
 server_config:
   name: daos_server
   servers:
-    targets: 8
+    targets: 2
 pool:
   mode: 511
   name: daos_server

--- a/src/tests/ftest/rebuild/read_array.py
+++ b/src/tests/ftest/rebuild/read_array.py
@@ -42,7 +42,6 @@ class ReadArrayTest(RebuildTestBase):
             numbers of rebuild targets and no available rebuild targets.
 
         :avocado: tags=all,full_regression
-        :avocado: tags=vm,large,rebuild
-        :avocado: tags=rebuild_tests,rebuildreadarray
+        :avocado: tags=vm,large,rebuild,rebuildreadarray
         """
         self.execute_rebuild_test()

--- a/src/tests/ftest/rebuild/read_array.py
+++ b/src/tests/ftest/rebuild/read_array.py
@@ -14,8 +14,6 @@ class ReadArrayTest(RebuildTestBase):
     :avocado: recursive
     """
 
-    CANCEL_FOR_TICKET = [["DAOS-2799", "targets", 8]]
-
     def execute_during_rebuild(self):
         """Read the objects during rebuild."""
         message = "Reading the array objects during rebuild"
@@ -43,6 +41,8 @@ class ReadArrayTest(RebuildTestBase):
             Basic rebuild of container objects of array values with sufficient
             numbers of rebuild targets and no available rebuild targets.
 
-        :avocado: tags=all,large,full_regression,rebuild,rebuildreadarray
+        :avocado: tags=all,full_regression
+        :avocado: tags=vm,large,rebuild
+        :avocado: tags=rebuild_tests,rebuildreadarray
         """
         self.execute_rebuild_test()

--- a/src/tests/ftest/rebuild/read_array.yaml
+++ b/src/tests/ftest/rebuild/read_array.yaml
@@ -13,8 +13,8 @@ server_config:
   servers: !mux
     1_target:
       targets: 1
-    8_targets:
-      targets: 8
+    2_targets:
+      targets: 2
 pool:
   mode: 511
   name: daos_server


### PR DESCRIPTION
modified:   read_array.py
modified:   read_array.yaml
Skip-unit-tests: true
Skip-nlt: true
Quick-Functional: true
Test-tag: rebuildreadarray
Signed-off-by: Ding Ho ding-hwa.ho@intel.com