### PR TITLE
DAOS-3688 rsvc: Yield during ds_rsvc_start (#5032)

### DIFF
--- a/src/common/dts.c
+++ b/src/common/dts.c
@@ -215,11 +215,7 @@ pool_init(struct dts_context *tsc)
 
 		/* Use pool size as blob size for this moment. */
 		rc = vos_pool_create(pmem_file, tsc->tsc_pool_uuid, 0,
-				     tsc->tsc_nvme_size);
-		if (rc)
-			goto out;
-
-		rc = vos_pool_open(pmem_file, tsc->tsc_pool_uuid, false, &poh);
+				     tsc->tsc_nvme_size, 0, &poh);
 		if (rc)
 			goto out;
 

--- a/src/include/daos_srv/rdb.h
+++ b/src/include/daos_srv/rdb.h
@@ -137,11 +137,12 @@ struct rdb_cbs {
 
 /** Database methods */
 int rdb_create(const char *path, const uuid_t uuid, size_t size,
-	       const d_rank_list_t *replicas);
-int rdb_destroy(const char *path, const uuid_t uuid);
+	       const d_rank_list_t *replicas, struct rdb_cbs *cbs, void *arg,
+	       struct rdb **dbp);
 int rdb_start(const char *path, const uuid_t uuid, struct rdb_cbs *cbs,
 	      void *arg, struct rdb **dbp);
 void rdb_stop(struct rdb *db);
+int rdb_destroy(const char *path, const uuid_t uuid);
 void rdb_resign(struct rdb *db, uint64_t term);
 int rdb_campaign(struct rdb *db);
 bool rdb_is_leader(struct rdb *db, uint64_t *term);

--- a/src/include/daos_srv/vos.h
+++ b/src/include/daos_srv/vos.h
@@ -209,18 +209,21 @@ vos_self_fini(void);
  */
 
 /**
- * Create a Versioning Object Storage Pool (VOSP) and its root object.
+ * Create a Versioning Object Storage Pool (VOSP), and open it if \a poh is not
+ * NULL
  *
  * \param path	[IN]	Path of the memory pool
  * \param uuid	[IN]    Pool UUID
  * \param scm_sz [IN]	Size of SCM for the pool
  * \param blob_sz[IN]	Size of blob for the pool
+ * \param flags [IN]	Pool open flags (see vos_pool_open_flags)
+ * \param poh	[OUT]	Returned pool handle if not NULL
  *
  * \return              Zero on success, negative value if error
  */
 int
 vos_pool_create(const char *path, uuid_t uuid, daos_size_t scm_sz,
-		daos_size_t blob_sz);
+		daos_size_t blob_sz, unsigned int flags, daos_handle_t *poh);
 
 /**
  * Kill a VOS pool before destroy
@@ -246,19 +249,18 @@ int
 vos_pool_destroy(const char *path, uuid_t uuid);
 
 /**
- * Open a Versioning Object Storage Pool (VOSP), load its root object
- * and other internal data structures.
+ * Open a Versioning Object Storage Pool (VOSP)
  *
  * \param path	[IN]	Path of the memory pool
  * \param uuid	[IN]    Pool UUID
- * \param small	[IN]	Pool is small
- *			(system memory reservation shall be small, to fit)
+ * \param flags [IN]	Pool open flags (see vos_pool_open_flags)
  * \param poh	[OUT]	Returned pool handle
  *
  * \return              Zero on success, negative value if error
  */
 int
-vos_pool_open(const char *path, uuid_t uuid, bool small, daos_handle_t *poh);
+vos_pool_open(const char *path, uuid_t uuid, unsigned int flags,
+	      daos_handle_t *poh);
 
 /**
  * Close a VOSP, all opened containers sharing this pool handle

--- a/src/include/daos_srv/vos_types.h
+++ b/src/include/daos_srv/vos_types.h
@@ -66,6 +66,14 @@ D_CASSERT(sizeof(struct dtx_entry) ==
 	  offsetof(struct dtx_entry, dte_mbs) +
 	  sizeof(struct dtx_memberships *));
 
+/** Pool open flags (for vos_pool_create and vos_pool_open) */
+enum vos_pool_open_flags {
+	/** Pool is small (for sys space reservation); implies VOS_POF_EXCL */
+	VOS_POF_SMALL	= (1 << 0),
+	/** Exclusive (-DER_BUSY if already opened) */
+	VOS_POF_EXCL	= (1 << 1),
+};
+
 enum vos_oi_attr {
 	/** Marks object as failed */
 	VOS_OI_FAILED		= (1U << 0),

--- a/src/mgmt/srv_target.c
+++ b/src/mgmt/srv_target.c
@@ -466,7 +466,7 @@ tgt_vos_create_one(void *varg)
 		return rc;
 
 	rc = vos_pool_create(path, (unsigned char *)vpa->vpa_uuid,
-			     vpa->vpa_scm_size, vpa->vpa_nvme_size);
+			     vpa->vpa_scm_size, vpa->vpa_nvme_size, 0, NULL);
 	if (rc)
 		D_ERROR(DF_UUID": failed to init vos pool %s: %d\n",
 			DP_UUID(vpa->vpa_uuid), path, rc);

--- a/src/pool/srv_target.c
+++ b/src/pool/srv_target.c
@@ -192,7 +192,7 @@ pool_child_add_one(void *varg)
 		return rc;
 	}
 
-	rc = vos_pool_open(path, arg->pla_uuid, false, &child->spc_hdl);
+	rc = vos_pool_open(path, arg->pla_uuid, 0, &child->spc_hdl);
 
 	D_FREE(path);
 

--- a/src/rdb/rdb.c
+++ b/src/rdb/rdb.c
@@ -17,17 +17,26 @@
 #include "rdb_internal.h"
 #include "rdb_layout.h"
 
+static int rdb_start_internal(daos_handle_t pool, daos_handle_t mc,
+			      const uuid_t uuid, struct rdb_cbs *cbs, void *arg,
+			      struct rdb **dbp);
+
 /**
- * Create an RDB replica at \a path with \a uuid, \a size, and \a replicas.
+ * Create an RDB replica at \a path with \a uuid, \a size, and \a replicas, and
+ * start it with \a cbs and \a arg.
  *
  * \param[in]	path		replica path
  * \param[in]	uuid		database UUID
  * \param[in]	size		replica size in bytes
  * \param[in]	replicas	list of replica ranks
+ * \param[in]	cbs		callbacks (not copied)
+ * \param[in]	arg		argument for cbs
+ * \param[out]	dbp		database
  */
 int
 rdb_create(const char *path, const uuid_t uuid, size_t size,
-	   const d_rank_list_t *replicas)
+	   const d_rank_list_t *replicas, struct rdb_cbs *cbs, void *arg,
+	   struct rdb **dbp)
 {
 	daos_handle_t	pool;
 	daos_handle_t	mc;
@@ -38,14 +47,16 @@ rdb_create(const char *path, const uuid_t uuid, size_t size,
 	D_DEBUG(DB_MD, DF_UUID": creating db %s with %u replicas\n",
 		DP_UUID(uuid), path, replicas == NULL ? 0 : replicas->rl_nr);
 
-	/* Create and open a VOS pool. */
-	rc = vos_pool_create(path, (unsigned char *)uuid, size, 0);
+	/*
+	 * Create and open a VOS pool. RDB pools specify VOS_POF_SMALL for
+	 * basic system memory reservation and VOS_POF_EXCL for concurrent
+	 * access protection.
+	 */
+	rc = vos_pool_create(path, (unsigned char *)uuid, size, 0 /* nvme_sz */,
+			     VOS_POF_SMALL | VOS_POF_EXCL, &pool);
 	if (rc != 0)
 		goto out;
-	/* RDB pools specify small=true for basic system memory reservation */
-	rc = vos_pool_open(path, (unsigned char *)uuid, true, &pool);
-	if (rc != 0)
-		goto out_pool;
+	ABT_thread_yield();
 
 	/* Create and open the metadata container. */
 	rc = vos_cont_create(pool, (unsigned char *)uuid);
@@ -73,15 +84,19 @@ rdb_create(const char *path, const uuid_t uuid, size_t size,
 	 */
 	d_iov_set(&value, (void *)uuid, sizeof(uuid_t));
 	rc = rdb_mc_update(mc, RDB_MC_ATTRS, 1 /* n */, &rdb_mc_uuid, &value);
+	if (rc != 0)
+		goto out_mc_hdl;
+
+	rc = rdb_start_internal(pool, mc, uuid, cbs, arg, dbp);
 
 out_mc_hdl:
-	vos_cont_close(mc);
+	if (rc != 0)
+		vos_cont_close(mc);
 out_pool_hdl:
-	vos_pool_close(pool);
-out_pool:
 	if (rc != 0) {
 		int rc_tmp;
 
+		vos_pool_close(pool);
 		rc_tmp = vos_pool_destroy(path, (unsigned char *)uuid);
 		if (rc_tmp != 0)
 			D_ERROR(DF_UUID": failed to destroy %s: %d\n",
@@ -202,29 +217,20 @@ rdb_lookup(const uuid_t uuid)
 	return rdb_obj(entry);
 }
 
-/**
- * Start an RDB replica at \a path.
- *
- * \param[in]	path	replica path
- * \param[in]	uuid	database UUID
- * \param[in]	cbs	callbacks (not copied)
- * \param[in]	arg	argument for cbs
- * \param[out]	dbp	database
+/*
+ * If created successfully, the new DB handle will consume pool and mc, which
+ * the caller shall not close in this case.
  */
-int
-rdb_start(const char *path, const uuid_t uuid, struct rdb_cbs *cbs, void *arg,
-	  struct rdb **dbp)
+static int
+rdb_start_internal(daos_handle_t pool, daos_handle_t mc, const uuid_t uuid,
+		   struct rdb_cbs *cbs, void *arg, struct rdb **dbp)
 {
 	struct rdb	       *db;
-	d_iov_t			value;
-	uuid_t			uuid_persist;
-	uint32_t		version;
 	int			rc;
 	struct vos_pool_space	vps;
 	uint64_t		rdb_extra_sys[DAOS_MEDIA_MAX];
 
 	D_ASSERT(cbs->dc_stop != NULL);
-	D_INFO(DF_UUID": starting RDB %s\n", DP_UUID(uuid), path);
 
 	D_ALLOC_PTR(db);
 	if (db == NULL) {
@@ -238,6 +244,8 @@ rdb_start(const char *path, const uuid_t uuid, struct rdb_cbs *cbs, void *arg,
 	db->d_ref = 1;
 	db->d_cbs = cbs;
 	db->d_arg = arg;
+	db->d_pool = pool;
+	db->d_mc = mc;
 
 	rc = ABT_mutex_create(&db->d_mutex);
 	if (rc != ABT_SUCCESS) {
@@ -265,14 +273,6 @@ rdb_start(const char *path, const uuid_t uuid, struct rdb_cbs *cbs, void *arg,
 	if (rc != 0)
 		goto err_ref_cv;
 
-	/* RDB pools specify small=true for basic system memory reservation */
-	rc = vos_pool_open(path, (unsigned char *)uuid, true, &db->d_pool);
-	if (rc != 0) {
-		D_ERROR(DF_DB": failed to open %s: "DF_RC"\n", DP_DB(db), path,
-			DP_RC(rc));
-		goto err_kvss;
-	}
-
 	/* metadata vos pool management: reserved memory:
 	 * vos sets aside a portion of a pool for system activity:
 	 *   fragmentation overhead (e.g., 5%), aggregation, GC
@@ -283,7 +283,7 @@ rdb_start(const char *path, const uuid_t uuid, struct rdb_cbs *cbs, void *arg,
 	if (rc != 0) {
 		D_ERROR(DF_DB": failed to query vos pool space: "DF_RC"\n",
 			DP_DB(db), DP_RC(rc));
-		goto err_pool;
+		goto err_kvss;
 	}
 	rdb_extra_sys[DAOS_MEDIA_SCM] = 0;
 	rdb_extra_sys[DAOS_MEDIA_NVME] = 0;
@@ -295,7 +295,7 @@ rdb_start(const char *path, const uuid_t uuid, struct rdb_cbs *cbs, void *arg,
 			D_ERROR(DF_DB": failed to reserve more vos pool SCM "
 				DF_U64" : "DF_RC"\n", DP_DB(db),
 				rdb_extra_sys[DAOS_MEDIA_SCM], DP_RC(rc));
-			goto err_pool;
+			goto err_kvss;
 		}
 	} else {
 		D_WARN(DF_DB": vos pool SCM not reserved for SLC: "
@@ -307,63 +307,9 @@ rdb_start(const char *path, const uuid_t uuid, struct rdb_cbs *cbs, void *arg,
 		SCM_TOTAL(&vps), SCM_FREE(&vps), SCM_SYS(&vps),
 		rdb_extra_sys[DAOS_MEDIA_SCM]);
 
-	rc = vos_cont_open(db->d_pool, (unsigned char *)uuid, &db->d_mc);
-	if (rc != 0) {
-		D_ERROR(DF_DB": failed to open metadata container: "DF_RC"\n",
-			DP_DB(db), DP_RC(rc));
-		goto err_pool;
-	}
-
-	/* Check if this replica is fully initialized. See rdb_create(). */
-	d_iov_set(&value, uuid_persist, sizeof(uuid_t));
-	rc = rdb_mc_lookup(db->d_mc, RDB_MC_ATTRS, &rdb_mc_uuid, &value);
-	if (rc == -DER_NONEXIST) {
-		D_ERROR(DF_DB": not fully initialized\n", DP_DB(db));
-		rc = -DER_DF_INVAL;
-		goto err_mc;
-	} else if (rc != 0) {
-		D_ERROR(DF_DB": failed to look up UUID: "DF_RC"\n", DP_DB(db),
-			DP_RC(rc));
-		goto err_mc;
-	}
-
-	/* Check if the layout version is compatible. */
-	d_iov_set(&value, &version, sizeof(version));
-	rc = rdb_mc_lookup(db->d_mc, RDB_MC_ATTRS, &rdb_mc_version, &value);
-	if (rc == -DER_NONEXIST) {
-		ds_notify_ras_eventf(RAS_RDB_DF_INCOMPAT, RAS_TYPE_INFO,
-				     RAS_SEV_ERROR, NULL /* hwid */,
-				     NULL /* rank */, NULL /* jobid */,
-				     NULL /* pool */, NULL /* cont */,
-				     NULL /* objid */, NULL /* ctlop */,
-				     NULL /* data */,
-				     DF_DB": %s: incompatible layout version",
-				     DP_DB(db), path);
-		rc = -DER_DF_INCOMPT;
-		goto err_mc;
-	} else if (rc != 0) {
-		D_ERROR(DF_DB": failed to look up layout version: "DF_RC"\n",
-			DP_DB(db), DP_RC(rc));
-		goto err_mc;
-	}
-	if (version < RDB_LAYOUT_VERSION_LOW || version > RDB_LAYOUT_VERSION) {
-		ds_notify_ras_eventf(RAS_RDB_DF_INCOMPAT, RAS_TYPE_INFO,
-				     RAS_SEV_ERROR, NULL /* hwid */,
-				     NULL /* rank */, NULL /* jobid */,
-				     NULL /* pool */, NULL /* cont */,
-				     NULL /* objid */, NULL /* ctlop */,
-				     NULL /* data */,
-				     DF_DB": %s: incompatible layout version: "
-				     "%u not in [%u, %u]", DP_DB(db), path,
-				     version, RDB_LAYOUT_VERSION_LOW,
-				     RDB_LAYOUT_VERSION);
-		rc = -DER_DF_INCOMPT;
-		goto err_mc;
-	}
-
 	rc = rdb_raft_start(db);
 	if (rc != 0)
-		goto err_mc;
+		goto err_kvss;
 
 	ABT_mutex_lock(rdb_hash_lock);
 	rc = d_hash_rec_insert(&rdb_hash, db->d_uuid, sizeof(uuid_t),
@@ -376,16 +322,10 @@ rdb_start(const char *path, const uuid_t uuid, struct rdb_cbs *cbs, void *arg,
 	}
 
 	*dbp = db;
-	D_DEBUG(DB_MD, DF_DB": started db %s %p with %u replicas\n", DP_DB(db),
-		path, db, db->d_replicas == NULL ? 0 : db->d_replicas->rl_nr);
 	return 0;
 
 err_raft:
 	rdb_raft_stop(db);
-err_mc:
-	vos_cont_close(db->d_mc);
-err_pool:
-	vos_pool_close(db->d_pool);
 err_kvss:
 	rdb_kvs_cache_destroy(db->d_kvss);
 err_ref_cv:
@@ -396,6 +336,112 @@ err_mutex:
 	ABT_mutex_free(&db->d_mutex);
 err_db:
 	D_FREE(db);
+err:
+	return rc;
+}
+
+/**
+ * Start an RDB replica at \a path.
+ *
+ * \param[in]	path	replica path
+ * \param[in]	uuid	database UUID
+ * \param[in]	cbs	callbacks (not copied)
+ * \param[in]	arg	argument for cbs
+ * \param[out]	dbp	database
+ */
+int
+rdb_start(const char *path, const uuid_t uuid, struct rdb_cbs *cbs, void *arg,
+	  struct rdb **dbp)
+{
+	daos_handle_t		pool;
+	daos_handle_t		mc;
+	d_iov_t			value;
+	uuid_t			uuid_persist;
+	uint32_t		version;
+	int			rc;
+
+	D_INFO(DF_UUID": starting RDB %s\n", DP_UUID(uuid), path);
+
+	/*
+	 * RDB pools specify VOS_POF_SMALL for basic system memory reservation
+	 * and VOS_POF_EXCL for concurrent access protection.
+	 */
+	rc = vos_pool_open(path, (unsigned char *)uuid,
+			   VOS_POF_SMALL | VOS_POF_EXCL, &pool);
+	if (rc != 0) {
+		D_ERROR(DF_UUID": failed to open %s: "DF_RC"\n", DP_UUID(uuid),
+			path, DP_RC(rc));
+		goto err;
+	}
+	ABT_thread_yield();
+
+	rc = vos_cont_open(pool, (unsigned char *)uuid, &mc);
+	if (rc != 0) {
+		D_ERROR(DF_UUID": failed to open metadata container: "DF_RC"\n",
+			DP_UUID(uuid), DP_RC(rc));
+		goto err_pool;
+	}
+
+	/* Check if this replica is fully initialized. See rdb_create(). */
+	d_iov_set(&value, uuid_persist, sizeof(uuid_t));
+	rc = rdb_mc_lookup(mc, RDB_MC_ATTRS, &rdb_mc_uuid, &value);
+	if (rc == -DER_NONEXIST) {
+		D_ERROR(DF_UUID": not fully initialized\n", DP_UUID(uuid));
+		rc = -DER_DF_INVAL;
+		goto err_mc;
+	} else if (rc != 0) {
+		D_ERROR(DF_UUID": failed to look up UUID: "DF_RC"\n",
+			DP_UUID(uuid), DP_RC(rc));
+		goto err_mc;
+	}
+
+	/* Check if the layout version is compatible. */
+	d_iov_set(&value, &version, sizeof(version));
+	rc = rdb_mc_lookup(mc, RDB_MC_ATTRS, &rdb_mc_version, &value);
+	if (rc == -DER_NONEXIST) {
+		ds_notify_ras_eventf(RAS_RDB_DF_INCOMPAT, RAS_TYPE_INFO,
+				     RAS_SEV_ERROR, NULL /* hwid */,
+				     NULL /* rank */, NULL /* jobid */,
+				     NULL /* pool */, NULL /* cont */,
+				     NULL /* objid */, NULL /* ctlop */,
+				     NULL /* data */,
+				     DF_UUID": %s: incompatible layout version",
+				     DP_UUID(uuid), path);
+		rc = -DER_DF_INCOMPT;
+		goto err_mc;
+	} else if (rc != 0) {
+		D_ERROR(DF_UUID": failed to look up layout version: "DF_RC"\n",
+			DP_UUID(uuid), DP_RC(rc));
+		goto err_mc;
+	}
+	if (version < RDB_LAYOUT_VERSION_LOW || version > RDB_LAYOUT_VERSION) {
+		ds_notify_ras_eventf(RAS_RDB_DF_INCOMPAT, RAS_TYPE_INFO,
+				     RAS_SEV_ERROR, NULL /* hwid */,
+				     NULL /* rank */, NULL /* jobid */,
+				     NULL /* pool */, NULL /* cont */,
+				     NULL /* objid */, NULL /* ctlop */,
+				     NULL /* data */,
+				     DF_UUID": %s: incompatible layout version:"
+				     " %u not in [%u, %u]", DP_UUID(uuid), path,
+				     version, RDB_LAYOUT_VERSION_LOW,
+				     RDB_LAYOUT_VERSION);
+		rc = -DER_DF_INCOMPT;
+		goto err_mc;
+	}
+
+	rc = rdb_start_internal(pool, mc, uuid, cbs, arg, dbp);
+	if (rc != 0)
+		goto err_mc;
+
+	D_DEBUG(DB_MD, DF_DB": started db %s %p with %u replicas\n",
+		DP_DB(*dbp), path, *dbp,
+		(*dbp)->d_replicas == NULL ? 0 : (*dbp)->d_replicas->rl_nr);
+	return 0;
+
+err_mc:
+	vos_cont_close(mc);
+err_pool:
+	vos_pool_close(pool);
 err:
 	return rc;
 }

--- a/src/rdb/rdb_internal.h
+++ b/src/rdb/rdb_internal.h
@@ -102,7 +102,7 @@ DP_RANK(void)
 }
 
 #define DF_DB		DF_UUID"["DF_RANK"]"
-#define DP_DB(db)	DP_UUID(db->d_uuid), DP_RANK()
+#define DP_DB(db)	DP_UUID((db)->d_uuid), DP_RANK()
 
 /* Number of "base" references that the rdb_stop() path expects to remain */
 #define RDB_BASE_REFS 1

--- a/src/rdb/rdb_raft.c
+++ b/src/rdb/rdb_raft.c
@@ -2287,6 +2287,12 @@ lc:
 	/* Load the log entries. */
 	for (i = db->d_lc_record.dlr_base + 1; i < db->d_lc_record.dlr_tail;
 	     i++) {
+		/*
+		 * Yield before loading the first entry (for the rdb_lc_discard
+		 * call above) and every a few entries.
+		 */
+		if ((i - db->d_lc_record.dlr_base - 1) % 64 == 0)
+			ABT_thread_yield();
 		rc = rdb_raft_load_entry(db, i);
 		if (rc != 0)
 			goto err_lc;

--- a/src/rsvc/srv.c
+++ b/src/rsvc/srv.c
@@ -683,16 +683,14 @@ start(enum ds_rsvc_class_id class, d_iov_t *id, uuid_t db_uuid, bool create,
 		goto err;
 	svc->s_ref++;
 
-	if (create) {
-		rc = rdb_create(svc->s_db_path, svc->s_db_uuid, size, replicas);
-		if (rc != 0)
-			goto err_svc;
-	}
-
-	rc = rdb_start(svc->s_db_path, svc->s_db_uuid, &rsvc_rdb_cbs, svc,
-		       &svc->s_db);
+	if (create)
+		rc = rdb_create(svc->s_db_path, svc->s_db_uuid, size, replicas,
+				&rsvc_rdb_cbs, svc, &svc->s_db);
+	else
+		rc = rdb_start(svc->s_db_path, svc->s_db_uuid, &rsvc_rdb_cbs,
+			       svc, &svc->s_db);
 	if (rc != 0)
-		goto err_creation;
+		goto err_svc;
 
 	/*
 	 * If creating a replica with an initial membership, we are
@@ -720,7 +718,6 @@ start(enum ds_rsvc_class_id class, d_iov_t *id, uuid_t db_uuid, bool create,
 
 err_db:
 	rdb_stop(svc->s_db);
-err_creation:
 	if (create)
 		rdb_destroy(svc->s_db_path, svc->s_db_uuid);
 err_svc:

--- a/src/vos/sys_db.c
+++ b/src/vos/sys_db.c
@@ -110,13 +110,6 @@ db_open_create(struct sys_db *db, bool try_create)
 			rc = daos_errno2der(errno);
 			goto failed;
 		}
-
-		rc = vos_pool_create(vdb->db_file, vdb->db_pool,
-				     SYS_DB_SIZE, 0);
-		if (rc) {
-			D_CRIT("sys pool create error: "DF_RC"\n", DP_RC(rc));
-			goto failed;
-		}
 	} else if (access(vdb->db_file, F_OK) != 0) {
 		D_DEBUG(DB_IO, "%s doesn't exist, bypassing vos_pool_open\n",
 			vdb->db_file);
@@ -128,12 +121,23 @@ db_open_create(struct sys_db *db, bool try_create)
 		goto failed;
 	}
 	D_DEBUG(DB_IO, "Opening %s, try_create=%d\n", vdb->db_file, try_create);
-	rc = vos_pool_open(vdb->db_file, vdb->db_pool, false, &vdb->db_poh);
-	if (rc) {
-		/** The access checks above should ensure the file exists. */
-		if (try_create)
+	if (try_create) {
+		rc = vos_pool_create(vdb->db_file, vdb->db_pool, SYS_DB_SIZE, 0,
+				     0, &vdb->db_poh);
+		if (rc) {
+			D_CRIT("sys pool create error: "DF_RC"\n", DP_RC(rc));
+			goto failed;
+		}
+	} else {
+		rc = vos_pool_open(vdb->db_file, vdb->db_pool, 0, &vdb->db_poh);
+		if (rc) {
+			/**
+			 * The access checks above should ensure the file
+			 * exists.
+			 */
 			D_CRIT("sys pool open error: "DF_RC"\n", DP_RC(rc));
-		goto failed;
+			goto failed;
+		}
 	}
 
 	if (try_create) {

--- a/src/vos/tests/vts_common.c
+++ b/src/vos/tests/vts_common.c
@@ -32,8 +32,7 @@
 
 enum {
 	TCX_NONE,
-	TCX_PO_CREATE,
-	TCX_PO_OPEN,
+	TCX_PO_CREATE_OPEN,
 	TCX_CO_CREATE,
 	TCX_CO_OPEN,
 	TCX_READY,
@@ -105,22 +104,14 @@ vts_ctx_init(struct vos_test_ctx *tcx, size_t psize)
 	uuid_generate_time_safe(tcx->tc_co_uuid);
 
 	/* specify @psize as both NVMe size and SCM size */
-	rc = vos_pool_create(tcx->tc_po_name, tcx->tc_po_uuid, psize, psize);
+	rc = vos_pool_create(tcx->tc_po_name, tcx->tc_po_uuid, psize, psize, 0,
+			     &tcx->tc_po_hdl);
 	if (rc) {
 		print_error("vpool create %s failed with error : %d\n",
 			    tcx->tc_po_name, rc);
 		goto failed;
 	}
-	tcx->tc_step = TCX_PO_CREATE;
-
-	rc = vos_pool_open(tcx->tc_po_name, tcx->tc_po_uuid, false,
-			   &tcx->tc_po_hdl);
-	if (rc) {
-		print_error("vos pool open %s "DF_UUIDF" error: %d\n",
-			    tcx->tc_po_name, DP_UUID(tcx->tc_po_uuid), rc);
-		goto failed;
-	}
-	tcx->tc_step = TCX_PO_OPEN;
+	tcx->tc_step = TCX_PO_CREATE_OPEN;
 
 	rc = vos_cont_create(tcx->tc_po_hdl, tcx->tc_co_uuid);
 	if (rc) {
@@ -164,14 +155,13 @@ vts_ctx_fini(struct vos_test_ctx *tcx)
 		rc = vos_cont_destroy(tcx->tc_po_hdl, tcx->tc_co_uuid);
 		assert_int_equal(rc, 0);
 		/* fallthrough */
-	case TCX_PO_OPEN:
+	case TCX_PO_CREATE_OPEN:
 		rc = vos_pool_close(tcx->tc_po_hdl);
 		assert_int_equal(rc, 0);
-	case TCX_PO_CREATE:
 		rc = vos_pool_destroy(tcx->tc_po_name, tcx->tc_po_uuid);
 		assert_int_equal(rc, 0);
-		/* fallthrough */
 		free(tcx->tc_po_name);
+		/* fallthrough */
 	}
 	memset(tcx, 0, sizeof(*tcx));
 }
@@ -277,11 +267,7 @@ pool_init(struct dts_context *tsc)
 
 	/* Use pool size as blob size for this moment. */
 	rc = vos_pool_create(pmem_file, tsc->tsc_pool_uuid, 0,
-			     tsc->tsc_nvme_size);
-	if (rc)
-		goto out;
-
-	rc = vos_pool_open(pmem_file, tsc->tsc_pool_uuid, false, &poh);
+			     tsc->tsc_nvme_size, 0, &poh);
 	if (rc)
 		goto out;
 

--- a/src/vos/tests/vts_common.h
+++ b/src/vos/tests/vts_common.h
@@ -48,6 +48,7 @@ extern int gc;
 
 enum vts_ops_type {
 	CREAT,
+	CREAT_OPEN,
 	OPEN,
 	CLOSE,
 	DESTROY,

--- a/src/vos/tests/vts_container.c
+++ b/src/vos/tests/vts_container.c
@@ -161,10 +161,8 @@ setup(void **state)
 
 	uuid_generate_time_safe(test_arg->pool_uuid);
 	vts_pool_fallocate(&test_arg->fname);
-	ret = vos_pool_create(test_arg->fname, test_arg->pool_uuid, 0, 0);
-	assert_int_equal(ret, 0);
-	ret = vos_pool_open(test_arg->fname, test_arg->pool_uuid, false,
-			    &test_arg->poh);
+	ret = vos_pool_create(test_arg->fname, test_arg->pool_uuid, 0, 0, 0,
+			      &test_arg->poh);
 	assert_int_equal(ret, 0);
 	*state = test_arg;
 	return 0;

--- a/src/vos/tests/vts_io.c
+++ b/src/vos/tests/vts_io.c
@@ -830,10 +830,7 @@ io_obj_cache_test(void **state)
 	assert_int_equal(rc, 0);
 
 	uuid_generate_time_safe(pool_uuid);
-	rc = vos_pool_create(po_name, pool_uuid, VPOOL_16M, 0);
-	assert_rc_equal(rc, 0);
-
-	rc = vos_pool_open(po_name, pool_uuid, false /* small */, &l_poh);
+	rc = vos_pool_create(po_name, pool_uuid, VPOOL_16M, 0, 0, &l_poh);
 	assert_rc_equal(rc, 0);
 
 	rc = vos_cont_create(l_poh, ctx->tc_co_uuid);
@@ -1370,10 +1367,7 @@ pool_cont_same_uuid(void **state)
 	uuid_generate(pool_uuid);
 	uuid_copy(co_uuid, pool_uuid);
 
-	ret = vos_pool_create(arg->fname, pool_uuid, VPOOL_16M, 0);
-	assert_rc_equal(ret, 0);
-
-	ret = vos_pool_open(arg->fname, pool_uuid, false /* small */, &poh);
+	ret = vos_pool_create(arg->fname, pool_uuid, VPOOL_16M, 0, 0, &poh);
 	assert_rc_equal(ret, 0);
 
 	ret = vos_cont_create(poh, co_uuid);
@@ -1383,7 +1377,7 @@ pool_cont_same_uuid(void **state)
 	assert_rc_equal(ret, 0);
 
 	poh = DAOS_HDL_INVAL;
-	ret = vos_pool_open(arg->fname, pool_uuid, false /* small */, &poh);
+	ret = vos_pool_open(arg->fname, pool_uuid, 0, &poh);
 	assert_rc_equal(ret, 0);
 
 	ret = vos_cont_open(poh, co_uuid, &coh);

--- a/src/vos/tests/vts_pool.c
+++ b/src/vos/tests/vts_pool.c
@@ -85,10 +85,9 @@ pool_ref_count_test(void **state)
 	int			num = 10;
 
 	uuid_generate(uuid);
-	ret = vos_pool_create(arg->fname[0], uuid, VPOOL_16M, 0);
+	ret = vos_pool_create(arg->fname[0], uuid, VPOOL_16M, 0, 0, NULL);
 	for (i = 0; i < num; i++) {
-		ret = vos_pool_open(arg->fname[0], uuid, false /*small */,
-				    &arg->poh[i]);
+		ret = vos_pool_open(arg->fname[0], uuid, 0, &arg->poh[i]);
 		assert_rc_equal(ret, 0);
 	}
 	for (i = 0; i < num - 1; i++) {
@@ -116,10 +115,10 @@ pool_interop(void **state)
 	uuid_generate(uuid);
 
 	daos_fail_loc_set(FLC_POOL_DF_VER | DAOS_FAIL_ONCE);
-	ret = vos_pool_create(arg->fname[0], uuid, VPOOL_16M, 0);
+	ret = vos_pool_create(arg->fname[0], uuid, VPOOL_16M, 0, 0, NULL);
 	assert_rc_equal(ret, 0);
 
-	ret = vos_pool_open(arg->fname[0], uuid, false, &poh);
+	ret = vos_pool_open(arg->fname[0], uuid, 0, &poh);
 	assert_rc_equal(ret, -DER_DF_INCOMPT);
 
 	ret = vos_pool_destroy(arg->fname[0], uuid);
@@ -133,10 +132,14 @@ pool_ops_run(void **state)
 	struct vp_test_args	*arg = *state;
 	vos_pool_info_t		pinfo;
 
-
 	for (j = 0; j < arg->nfiles; j++) {
 		for (i = 0; i < arg->seq_cnt[j]; i++) {
+			daos_handle_t *poh = NULL;
+
 			switch (arg->ops_seq[j][i]) {
+			case CREAT_OPEN:
+				poh = &arg->poh[j];
+				/* fall through */
 			case CREAT:
 				uuid_generate(arg->uuid[j]);
 				if (arg->fcreate[j]) {
@@ -145,25 +148,24 @@ pool_ops_run(void **state)
 					assert_int_equal(ret, 0);
 					ret = vos_pool_create(arg->fname[j],
 							      arg->uuid[j],
-							      0, 0);
+							      0, 0, 0, poh);
 				} else {
 					ret =
 					vts_alloc_gen_fname(&arg->fname[j]);
 					assert_int_equal(ret, 0);
 					ret = vos_pool_create(arg->fname[j],
 							      arg->uuid[j],
-							      VPOOL_16M, 0);
+							      VPOOL_16M, 0, 0,
+							      poh);
 				}
 				break;
 			case OPEN:
-				ret = vos_pool_open(arg->fname[j],
-						    arg->uuid[j],
-						    false /* small */,
-						    &arg->poh[j]);
+				ret = vos_pool_open(arg->fname[j], arg->uuid[j],
+						    0, &arg->poh[j]);
 				break;
 			case CLOSE:
 				ret = vos_pool_close(arg->poh[j]);
-			break;
+				break;
 			case DESTROY:
 				ret = vos_pool_destroy(arg->fname[j],
 						       arg->uuid[j]);
@@ -387,6 +389,96 @@ pool_all(void **state)
 	return 0;
 }
 
+static int
+pool_create_open_close(void **state)
+{
+	enum vts_ops_type tmp[] = {CREAT_OPEN, CLOSE};
+	int num_ops = sizeof(tmp) / sizeof(enum vts_ops_type);
+
+	pool_set_sequence(state, false, num_ops, tmp);
+	return 0;
+}
+
+static void
+pool_open_excl_test(void **state)
+{
+	int			ret = 0;
+	uuid_t			uuid;
+	struct vp_test_args	*arg = *state;
+
+	uuid_generate(uuid);
+
+	print_message("open EXCL shall fail upon existing create opener\n");
+	ret = vos_pool_create(arg->fname[0], uuid, VPOOL_16M, 0, 0,
+			      &arg->poh[0]);
+	assert_rc_equal(ret, 0);
+	ret = vos_pool_open(arg->fname[0], uuid, VOS_POF_EXCL, &arg->poh[1]);
+	assert_rc_equal(ret, -DER_BUSY);
+	ret = vos_pool_close(arg->poh[0]);
+	assert_rc_equal(ret, 0);
+	ret = vos_pool_destroy(arg->fname[0], uuid);
+	assert_rc_equal(ret, 0);
+
+	print_message("open EXCL shall fail upon existing opener\n");
+	ret = vos_pool_create(arg->fname[0], uuid, VPOOL_16M, 0, 0, NULL);
+	assert_rc_equal(ret, 0);
+	ret = vos_pool_open(arg->fname[0], uuid, 0, &arg->poh[0]);
+	assert_rc_equal(ret, 0);
+	ret = vos_pool_open(arg->fname[0], uuid, VOS_POF_EXCL, &arg->poh[1]);
+	assert_rc_equal(ret, -DER_BUSY);
+	ret = vos_pool_close(arg->poh[0]);
+	assert_rc_equal(ret, 0);
+	ret = vos_pool_destroy(arg->fname[0], uuid);
+	assert_rc_equal(ret, 0);
+
+	print_message("open EXCL shall fail upon existing EXCL opener\n");
+	ret = vos_pool_create(arg->fname[0], uuid, VPOOL_16M, 0, 0, NULL);
+	assert_rc_equal(ret, 0);
+	ret = vos_pool_open(arg->fname[0], uuid, VOS_POF_EXCL, &arg->poh[0]);
+	assert_rc_equal(ret, 0);
+	ret = vos_pool_open(arg->fname[0], uuid, VOS_POF_EXCL, &arg->poh[1]);
+	assert_rc_equal(ret, -DER_BUSY);
+	ret = vos_pool_close(arg->poh[0]);
+	assert_rc_equal(ret, 0);
+	ret = vos_pool_destroy(arg->fname[0], uuid);
+	assert_rc_equal(ret, 0);
+
+	print_message("open EXCL shall fail upon existing EXCL create "
+		      "opener\n");
+	ret = vos_pool_create(arg->fname[0], uuid, VPOOL_16M, 0, VOS_POF_EXCL,
+			      &arg->poh[0]);
+	assert_rc_equal(ret, 0);
+	ret = vos_pool_open(arg->fname[0], uuid, VOS_POF_EXCL, &arg->poh[1]);
+	assert_rc_equal(ret, -DER_BUSY);
+	ret = vos_pool_close(arg->poh[0]);
+	assert_rc_equal(ret, 0);
+	ret = vos_pool_destroy(arg->fname[0], uuid);
+	assert_rc_equal(ret, 0);
+
+	print_message("open shall fail upon existing EXCL opener\n");
+	ret = vos_pool_create(arg->fname[0], uuid, VPOOL_16M, 0, 0, NULL);
+	assert_rc_equal(ret, 0);
+	ret = vos_pool_open(arg->fname[0], uuid, VOS_POF_EXCL, &arg->poh[0]);
+	assert_rc_equal(ret, 0);
+	ret = vos_pool_open(arg->fname[0], uuid, 0, &arg->poh[1]);
+	assert_rc_equal(ret, -DER_BUSY);
+	ret = vos_pool_close(arg->poh[0]);
+	assert_rc_equal(ret, 0);
+	ret = vos_pool_destroy(arg->fname[0], uuid);
+	assert_rc_equal(ret, 0);
+
+	print_message("open shall fail upon existing EXCL create opener\n");
+	ret = vos_pool_create(arg->fname[0], uuid, VPOOL_16M, 0, VOS_POF_EXCL,
+			      &arg->poh[0]);
+	assert_rc_equal(ret, 0);
+	ret = vos_pool_open(arg->fname[0], uuid, 0, &arg->poh[1]);
+	assert_rc_equal(ret, -DER_BUSY);
+	ret = vos_pool_close(arg->poh[0]);
+	assert_rc_equal(ret, 0);
+	ret = vos_pool_destroy(arg->fname[0], uuid);
+	assert_rc_equal(ret, 0);
+}
+
 static const struct CMUnitTest pool_tests[] = {
 	{ "VOS1: Create Pool with existing files (File Count no:of cpus)",
 		pool_ops_run, pool_create_exists, pool_unit_teardown},
@@ -406,6 +498,10 @@ static const struct CMUnitTest pool_tests[] = {
 		pool_all_empty_file, pool_unit_teardown},
 	{ "VOS9: Pool all APIs with existing file", pool_ops_run,
 		pool_all, pool_unit_teardown},
+	{ "VOS10: Pool Close after create and open", pool_ops_run,
+		pool_create_open_close, pool_unit_teardown},
+	{ "VOS11: Pool exclusive open", pool_open_excl_test,
+		pool_file_setup, pool_file_destroy},
 };
 
 

--- a/src/vos/vos_internal.h
+++ b/src/vos/vos_internal.h
@@ -136,6 +136,8 @@ struct vos_pool {
 	/** number of openers */
 	int			vp_opened:30;
 	int			vp_dying:1;
+	/** exclusive handle (see VOS_POF_EXCL) */
+	int			vp_excl:1;
 	/** caller specifies pool is small (for sys space reservation) */
 	bool			vp_small;
 	/** UUID of vos pool */


### PR DESCRIPTION
A ds_rsvc_start call may involve the following PMEMobjpool operations:

  rdb_create
    vos_pool_create
      pmemobj_create
      pmemobj_close	// for vos_pool_create doesn't open the VOS pool
    vos_pool_open
      pmemobj_open
    vos_pool_close
      pmemobj_close	// for rdb_create doesn't start the DB
  rdb_start
    vos_pool_open
      pmemobj_open

Each pmemobj_create and pmemobj_open call may take more than 20 ms. To
avoid disrupting swim and rdb_timerd, this patch yields during a
ds_rsvc_start call:

  - vos
      - Enable rdb to take advantage of PMEMobjpool's concurrent access
	protection, so that rdb can yield safely
          - Change vos_pool_create to optionally open the VOS pool
          - Support opening a VOS pool exclusively
  - rdb
      - Change rdb_create to start the DB
      - Yield after vos_pool_create and vos_pool_open calls
      - Yield when loading log entries
  - rsvc
      - Use the new rdb create/start methods

The ds_rsvc_start call above will become:

  rdb_create
    vos_pool_create
      pmemobj_create

Signed-off-by: Li Wei <wei.g.li@intel.com>