### PR TITLE
DAOS-7126 test: Create unique files in unit tests

### DIFF
--- a/src/control/cmd/dmg/json_test.go
+++ b/src/control/cmd/dmg/json_test.go
@@ -11,7 +11,6 @@ import (
 	"encoding/json"
 	"io"
 	"os"
-	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
@@ -58,9 +57,10 @@ func TestDmg_JsonOutput(t *testing.T) {
 		cmdArgs = append(cmdArgs, cmd)
 	})
 
-	aclPath := filepath.Join(os.TempDir(), "testACLFile.txt")
-	createTestFile(t, aclPath, "A::OWNER@:rw\nA::user1@:rw\nA:g:group1@:r\n")
-	defer os.Remove(aclPath)
+	testDir, cleanup := common.CreateTestDir(t)
+	defer cleanup()
+	aclContent := "A::OWNER@:rw\nA::user1@:rw\nA:g:group1@:r\n"
+	aclPath := common.CreateTestFile(t, testDir, aclContent)
 
 	for _, args := range cmdArgs {
 		t.Run(strings.Join(args, " "), func(t *testing.T) {

--- a/src/control/cmd/dmg/pool_test.go
+++ b/src/control/cmd/dmg/pool_test.go
@@ -20,29 +20,20 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/daos-stack/daos/src/control/build"
-	. "github.com/daos-stack/daos/src/control/common"
+	"github.com/daos-stack/daos/src/control/common"
 	"github.com/daos-stack/daos/src/control/lib/control"
 	"github.com/daos-stack/daos/src/control/logging"
 	"github.com/daos-stack/daos/src/control/system"
 )
 
 var (
-	defaultPoolUUID = MockUUID()
+	defaultPoolUUID = common.MockUUID()
 )
 
-func createACLFile(t *testing.T, path string, acl *control.AccessControlList) {
+func createACLFile(t *testing.T, dir string, acl *control.AccessControlList) string {
 	t.Helper()
 
-	file, err := os.Create(path)
-	if err != nil {
-		t.Fatalf("Couldn't create ACL file: %v", err)
-	}
-	defer file.Close()
-
-	_, err = file.WriteString(control.FormatACLDefault(acl))
-	if err != nil {
-		t.Fatalf("Couldn't write to file: %v", err)
-	}
+	return common.CreateTestFile(t, dir, control.FormatACLDefault(acl))
 }
 
 func createWithSystem(req *control.PoolCreateReq, system string) *control.PoolCreateReq {
@@ -69,34 +60,26 @@ func TestPoolCommands(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	tmpDir, tmpCleanup := CreateTestDir(t)
+	tmpDir, tmpCleanup := common.CreateTestDir(t)
 	defer tmpCleanup()
 
 	// Some tests need a valid ACL file
-	testACLFile := filepath.Join(tmpDir, "test_acl.txt")
 	testACL := &control.AccessControlList{
 		Entries: []string{"A::OWNER@:rw", "A:G:GROUP@:rw"},
 	}
-	createACLFile(t, testACLFile, testACL)
+	testACLFile := createACLFile(t, tmpDir, testACL)
 
 	// An existing file with contents for tests that need to verify overwrite
-	testExistingFile := filepath.Join(tmpDir, "existing.txt")
-	createACLFile(t, testExistingFile, testACL)
+	testExistingFile := createACLFile(t, tmpDir, testACL)
 
 	// An existing file with write-only perms
-	testWriteOnlyFile := filepath.Join(tmpDir, "write.txt")
-	createACLFile(t, testWriteOnlyFile, testACL)
+	testWriteOnlyFile := createACLFile(t, tmpDir, testACL)
 	err = os.Chmod(testWriteOnlyFile, 0222)
 	if err != nil {
 		t.Fatalf("Couldn't set file writable only")
 	}
 
-	testEmptyFile := filepath.Join(tmpDir, "empty.txt")
-	empty, err := os.Create(testEmptyFile)
-	if err != nil {
-		t.Fatalf("Failed to create empty file: %s", err)
-	}
-	empty.Close()
+	testEmptyFile := common.CreateTestFile(t, tmpDir, "")
 
 	// Subdirectory with no write perms
 	testNoPermDir := filepath.Join(tmpDir, "badpermsdir")
@@ -652,9 +635,9 @@ func TestPoolCommands(t *testing.T) {
 
 func TestPoolGetACLToFile_Success(t *testing.T) {
 	log, buf := logging.NewTestLogger(t.Name())
-	defer ShowBufferOnFailure(t, buf)
+	defer common.ShowBufferOnFailure(t, buf)
 
-	tmpDir, tmpCleanup := CreateTestDir(t)
+	tmpDir, tmpCleanup := common.CreateTestDir(t)
 	defer tmpCleanup()
 
 	aclFile := filepath.Join(tmpDir, "out.txt")

--- a/src/control/common/test_utils.go
+++ b/src/control/common/test_utils.go
@@ -191,6 +191,25 @@ func CreateTestDir(t *testing.T) (string, func()) {
 	}
 }
 
+// CreateTestFile creates a file in the given directory with a random name, and
+// writes the content string to the file. It returns the path to the file.
+func CreateTestFile(t *testing.T, dir, content string) string {
+	t.Helper()
+
+	file, err := ioutil.TempFile(dir, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer file.Close()
+
+	_, err = file.WriteString(content)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return file.Name()
+}
+
 // CreateTestSocket creates a Unix Domain Socket that can listen for connections
 // on a given path. It returns the listener and a cleanup function.
 func CreateTestSocket(t *testing.T, sockPath string) (*net.UnixListener, func()) {

--- a/src/control/lib/control/acl_test.go
+++ b/src/control/lib/control/acl_test.go
@@ -10,8 +10,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 
@@ -65,23 +63,10 @@ func TestControl_ReadACLFile_FileOpenFailed(t *testing.T) {
 	}
 }
 
-func createTestFile(t *testing.T, filePath string, content string) {
-	file, err := os.Create(filePath)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer file.Close()
-
-	_, err = file.WriteString(content)
-	if err != nil {
-		t.Fatal(err)
-	}
-}
-
 func TestControl_ReadACLFile_Success(t *testing.T) {
-	path := filepath.Join(os.TempDir(), "testACLFile.txt")
-	createTestFile(t, path, "A::OWNER@:rw\nA::user1@:rw\nA:g:group1@:r\n")
-	defer os.Remove(path)
+	dir, cleanup := common.CreateTestDir(t)
+	defer cleanup()
+	path := common.CreateTestFile(t, dir, "A::OWNER@:rw\nA::user1@:rw\nA:g:group1@:r\n")
 
 	expectedNumACEs := 3
 
@@ -102,9 +87,9 @@ func TestControl_ReadACLFile_Success(t *testing.T) {
 }
 
 func TestReadACLFile_Empty(t *testing.T) {
-	path := filepath.Join(os.TempDir(), "empty.txt")
-	createTestFile(t, path, "")
-	defer os.Remove(path)
+	dir, cleanup := common.CreateTestDir(t)
+	defer cleanup()
+	path := common.CreateTestFile(t, dir, "")
 
 	result, err := ReadACLFile(path)
 

--- a/src/control/server/drpc_test.go
+++ b/src/control/server/drpc_test.go
@@ -60,15 +60,9 @@ func TestCheckDrpcClientSocketPath_FileNotSocket(t *testing.T) {
 	tmpDir, tmpCleanup := common.CreateTestDir(t)
 	defer tmpCleanup()
 
-	path := filepath.Join(tmpDir, "drpc_test.sock")
-	f, err := os.Create(path)
-	if err != nil {
-		t.Fatalf("Failed to create temp file: %v", err)
-	}
-	f.Close()
-	defer os.Remove(path)
+	path := common.CreateTestFile(t, tmpDir, "")
 
-	err = checkDrpcClientSocketPath(path)
+	err := checkDrpcClientSocketPath(path)
 
 	if err == nil {
 		t.Fatal("Expected an error, got nil")


### PR DESCRIPTION
Some unit tests were depositing identically-named files into
the system temporary directory. This could create conflicts
if two instances of unit tests were running on the same
system.

Signed-off-by: Kris Jacque <kristin.jacque@intel.com>