### PR TITLE
DAOS-7140 bio: introduce DMA chunk type

### DIFF
--- a/src/bio/bio_buffer.c
+++ b/src/bio/bio_buffer.c
@@ -97,7 +97,6 @@ dma_buffer_destroy(struct bio_dma_buffer *buf)
 	dma_buffer_shrink(buf, buf->bdb_tot_cnt);
 
 	D_ASSERT(buf->bdb_tot_cnt == 0);
-	buf->bdb_cur_chk = NULL;
 	ABT_mutex_free(&buf->bdb_mutex);
 	ABT_cond_free(&buf->bdb_wait_iods);
 
@@ -116,7 +115,6 @@ dma_buffer_create(unsigned int init_cnt)
 
 	D_INIT_LIST_HEAD(&buf->bdb_idle_list);
 	D_INIT_LIST_HEAD(&buf->bdb_used_list);
-	buf->bdb_cur_chk = NULL;
 	buf->bdb_tot_cnt = 0;
 	buf->bdb_active_iods = 0;
 
@@ -235,18 +233,22 @@ iod_release_buffer(struct bio_desc *biod)
 
 		D_ASSERT(chunk != NULL);
 		D_ASSERT(chunk->bdc_ref > 0);
+		D_ASSERT(chunk->bdc_type == biod->bd_chk_type);
 		chunk->bdc_ref--;
 
-		D_DEBUG(DB_IO, "Release chunk:%p[%p] idx:%u ref:%u huge:%d\n",
-			chunk, chunk->bdc_ptr, chunk->bdc_pg_idx,
-			chunk->bdc_ref, dma_chunk_is_huge(chunk));
+		D_DEBUG(DB_IO, "Release chunk:%p[%p] idx:%u ref:%u huge:%d "
+			"type:%u\n", chunk, chunk->bdc_ptr, chunk->bdc_pg_idx,
+			chunk->bdc_ref, dma_chunk_is_huge(chunk),
+			chunk->bdc_type);
 
 		if (dma_chunk_is_huge(chunk)) {
 			dma_free_chunk(chunk);
 		} else if (chunk->bdc_ref == 0) {
 			chunk->bdc_pg_idx = 0;
-			if (chunk == bdb->bdb_cur_chk)
-				bdb->bdb_cur_chk = NULL;
+			D_ASSERT(bdb->bdb_used_cnt[chunk->bdc_type] > 0);
+			bdb->bdb_used_cnt[chunk->bdc_type] -= 1;
+			if (chunk == bdb->bdb_cur_chk[chunk->bdc_type])
+				bdb->bdb_cur_chk[chunk->bdc_type] = NULL;
 			d_list_move_tail(&chunk->bdc_link, &bdb->bdb_idle_list);
 		}
 		rsrvd_dma->brd_dma_chks[i] = NULL;
@@ -357,9 +359,13 @@ chunk_get_idle(struct bio_dma_buffer *bdb, struct bio_desc *biod)
 	if (d_list_empty(&bdb->bdb_idle_list)) {
 		if (bdb->bdb_tot_cnt == bio_chk_cnt_max) {
 			D_CRIT("Maximum per-xstream DMA buffer isn't big "
-			       "enough (chk_sz:%u chk_cnt:%u iods:%u) to "
-			       "sustain the workload.\n", bio_chk_sz,
-			       bio_chk_cnt_max, bdb->bdb_active_iods);
+			       "enough (chk_sz:%u chk_cnt:%u iods:%u "
+			       "used:%u,%u,%u) to sustain the workload.\n",
+			       bio_chk_sz, bio_chk_cnt_max,
+			       bdb->bdb_active_iods,
+			       bdb->bdb_used_cnt[BIO_CHK_TYPE_IO],
+			       bdb->bdb_used_cnt[BIO_CHK_TYPE_LOCAL],
+			       bdb->bdb_used_cnt[BIO_CHK_TYPE_REBUILD]);
 
 			biod->bd_retry = 1;
 			return NULL;
@@ -454,13 +460,14 @@ dma_map_one(struct bio_desc *biod, struct bio_iov *biov,
 {
 	struct bio_rsrvd_region *last_rg;
 	struct bio_dma_buffer *bdb;
-	struct bio_dma_chunk *chk = NULL;
+	struct bio_dma_chunk *chk = NULL, *cur_chk;
 	uint64_t off, end;
 	unsigned int pg_cnt, pg_off, chk_pg_idx;
 	int rc;
 
 	D_ASSERT(arg == NULL);
 	D_ASSERT(biov && bio_iov2raw_len(biov) != 0);
+	D_ASSERT(biod && biod->bd_chk_type < BIO_CHK_TYPE_MAX);
 
 	if (bio_addr_is_hole(&biov->bi_addr)) {
 		bio_iov_set_raw_buf(biov, NULL);
@@ -520,6 +527,7 @@ dma_map_one(struct bio_desc *biod, struct bio_iov *biov,
 			last_rg->brr_off, last_rg->brr_end);
 
 		chk = last_rg->brr_chk;
+		D_ASSERT(biod->bd_chk_type == chk->bdc_type);
 		chk_pg_idx = last_rg->brr_pg_idx;
 		D_ASSERT(chk_pg_idx < bio_chk_sz);
 
@@ -544,6 +552,7 @@ dma_map_one(struct bio_desc *biod, struct bio_iov *biov,
 
 	/* Try to reserve from the last DMA chunk in io descriptor */
 	if (chk != NULL) {
+		D_ASSERT(biod->bd_chk_type == chk->bdc_type);
 		chk_pg_idx = chk->bdc_pg_idx;
 		bio_iov_set_raw_buf(biov, chunk_reserve(chk, chk_pg_idx,
 							pg_cnt, pg_off));
@@ -559,8 +568,9 @@ dma_map_one(struct bio_desc *biod, struct bio_iov *biov,
 	 * per-xstream DMA buffer. It could be different with the last chunk
 	 * in io descriptor, because dma_map_one() may yield in the future.
 	 */
-	if (bdb->bdb_cur_chk != NULL && bdb->bdb_cur_chk != chk) {
-		chk = bdb->bdb_cur_chk;
+	cur_chk = bdb->bdb_cur_chk[biod->bd_chk_type];
+	if (cur_chk != NULL && cur_chk != chk) {
+		chk = cur_chk;
 		chk_pg_idx = chk->bdc_pg_idx;
 		bio_iov_set_raw_buf(biov, chunk_reserve(chk, chk_pg_idx,
 							pg_cnt, pg_off));
@@ -579,7 +589,9 @@ dma_map_one(struct bio_desc *biod, struct bio_iov *biov,
 	if (chk == NULL)
 		return -DER_OVERFLOW;
 
-	bdb->bdb_cur_chk = chk;
+	chk->bdc_type = biod->bd_chk_type;
+	bdb->bdb_cur_chk[chk->bdc_type] = chk;
+	bdb->bdb_used_cnt[chk->bdc_type] += 1;
 	chk_pg_idx = chk->bdc_pg_idx;
 
 	D_ASSERT(chk_pg_idx == 0);
@@ -878,7 +890,7 @@ dma_drop_iod(struct bio_dma_buffer *bdb)
 }
 
 int
-bio_iod_prep(struct bio_desc *biod)
+bio_iod_prep(struct bio_desc *biod, unsigned int type)
 {
 	struct bio_dma_buffer *bdb;
 	int rc, retry_cnt = 0;
@@ -886,6 +898,7 @@ bio_iod_prep(struct bio_desc *biod)
 	if (biod->bd_buffer_prep)
 		return -DER_INVAL;
 
+	biod->bd_chk_type = type;
 retry:
 	rc = iterate_biov(biod, dma_map_one, NULL);
 	if (rc) {
@@ -1050,7 +1063,7 @@ bio_rwv(struct bio_io_context *ioctxt, struct bio_sglist *bsgl_in,
 	bsgl->bs_nr_out = bsgl->bs_nr;
 
 	/* map the biov to DMA safe buffer, fill DMA buffer if read operation */
-	rc = bio_iod_prep(biod);
+	rc = bio_iod_prep(biod, BIO_CHK_TYPE_LOCAL);
 	if (rc)
 		goto out;
 

--- a/src/bio/bio_internal.h
+++ b/src/bio/bio_internal.h
@@ -32,6 +32,8 @@ struct bio_dma_chunk {
 	unsigned int	 bdc_pg_idx;
 	/* Being used by how many I/O descriptors */
 	unsigned int	 bdc_ref;
+	/* Chunk type */
+	unsigned int	 bdc_type;
 };
 
 /*
@@ -41,7 +43,8 @@ struct bio_dma_chunk {
 struct bio_dma_buffer {
 	d_list_t		 bdb_idle_list;
 	d_list_t		 bdb_used_list;
-	struct bio_dma_chunk	*bdb_cur_chk;
+	struct bio_dma_chunk	*bdb_cur_chk[BIO_CHK_TYPE_MAX];
+	unsigned int		 bdb_used_cnt[BIO_CHK_TYPE_MAX];
 	unsigned int		 bdb_tot_cnt;
 	unsigned int		 bdb_active_iods;
 	ABT_cond		 bdb_wait_iods;
@@ -196,6 +199,7 @@ struct bio_desc {
 	/* Inflight SPDK DMA transfers */
 	unsigned int		 bd_inflights;
 	int			 bd_result;
+	unsigned int		 bd_chk_type;
 	/* Flags */
 	unsigned int		 bd_buffer_prep:1,
 				 bd_update:1,

--- a/src/include/daos_srv/bio.h
+++ b/src/include/daos_srv/bio.h
@@ -559,6 +559,13 @@ struct bio_desc *bio_iod_alloc(struct bio_io_context *ctxt,
  */
 void bio_iod_free(struct bio_desc *biod);
 
+enum bio_chunk_type {
+	BIO_CHK_TYPE_IO	= 0,	/* For IO request */
+	BIO_CHK_TYPE_LOCAL,	/* For local DMA transfer */
+	BIO_CHK_TYPE_REBUILD,	/* For rebuild pull */
+	BIO_CHK_TYPE_MAX,
+};
+
 /**
  * Prepare all the SG lists of an io descriptor.
  *
@@ -568,10 +575,11 @@ void bio_iod_free(struct bio_desc *biod);
  * operation.
  *
  * \param biod       [IN]	io descriptor
+ * \param type       [IN]	chunk type used by this iod
  *
  * \return			Zero on success, negative value on error
  */
-int bio_iod_prep(struct bio_desc *biod);
+int bio_iod_prep(struct bio_desc *biod, unsigned int type);
 
 /*
  * Post operation after the RDMA transfer or local copy done for the io

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -1431,7 +1431,7 @@ obj_local_rw_internal(crt_rpc_t *rpc, struct obj_io_context *ioc,
 		goto out;
 
 	biod = vos_ioh2desc(ioh);
-	rc = bio_iod_prep(biod);
+	rc = bio_iod_prep(biod, BIO_CHK_TYPE_IO);
 	if (rc) {
 		D_ERROR(DF_UOID" bio_iod_prep failed: "DF_RC".\n",
 			DP_UOID(orw->orw_oid), DP_RC(rc));
@@ -1817,7 +1817,7 @@ ds_obj_ec_rep_handler(crt_rpc_t *rpc)
 		goto out;
 	}
 	biod = vos_ioh2desc(ioh);
-	rc = bio_iod_prep(biod);
+	rc = bio_iod_prep(biod, BIO_CHK_TYPE_IO);
 	if (rc) {
 		D_ERROR(DF_UOID" bio_iod_prep failed: "DF_RC".\n",
 			DP_UOID(oer->er_oid), DP_RC(rc));
@@ -1899,7 +1899,7 @@ ds_obj_ec_agg_handler(crt_rpc_t *rpc)
 			goto out;
 		}
 		biod = vos_ioh2desc(ioh);
-		rc = bio_iod_prep(biod);
+		rc = bio_iod_prep(biod, BIO_CHK_TYPE_IO);
 		if (rc) {
 			D_ERROR(DF_UOID" bio_iod_prep failed: "DF_RC".\n",
 				DP_UOID(oea->ea_oid), DP_RC(rc));
@@ -3622,7 +3622,7 @@ ds_obj_dtx_handle_one(crt_rpc_t *rpc, struct daos_cpd_sub_head *dcsh,
 			goto out;
 
 		biods[i] = vos_ioh2desc(iohs[i]);
-		rc = bio_iod_prep(biods[i]);
+		rc = bio_iod_prep(biods[i], BIO_CHK_TYPE_IO);
 		if (rc != 0) {
 			D_ERROR("bio_iod_prep failed for obj "DF_UOID
 				", DTX "DF_DTI": "DF_RC"\n",

--- a/src/object/srv_obj_migrate.c
+++ b/src/object/srv_obj_migrate.c
@@ -1138,7 +1138,7 @@ migrate_fetch_update_bulk(struct migrate_one *mrone, daos_handle_t oh,
 		return rc;
 	}
 
-	rc = bio_iod_prep(vos_ioh2desc(ioh));
+	rc = bio_iod_prep(vos_ioh2desc(ioh), BIO_CHK_TYPE_REBUILD);
 	if (rc) {
 		D_ERROR("Prepare EIOD for "DF_UOID" error: %d\n",
 			DP_UOID(mrone->mo_oid), rc);

--- a/src/rdb/rdb_util.c
+++ b/src/rdb/rdb_util.c
@@ -325,7 +325,7 @@ rdb_vos_fetch_addr(daos_handle_t cont, daos_epoch_t epoch, rdb_oid_t oid,
 	if (rc != 0)
 		return rc;
 
-	rc = bio_iod_prep(vos_ioh2desc(io));
+	rc = bio_iod_prep(vos_ioh2desc(io), BIO_CHK_TYPE_IO);
 	if (rc) {
 		D_ERROR("prep io descriptor error:"DF_RC"\n", DP_RC(rc));
 		goto out;

--- a/src/tests/daos_perf.c
+++ b/src/tests/daos_perf.c
@@ -361,7 +361,7 @@ _vos_update_or_fetch(int obj_idx, enum ts_op_type op_type,
 		if (rc)
 			return rc;
 
-		rc = bio_iod_prep(vos_ioh2desc(ioh));
+		rc = bio_iod_prep(vos_ioh2desc(ioh), BIO_CHK_TYPE_IO);
 		if (rc)
 			goto end;
 

--- a/src/vos/tests/vts_gc.c
+++ b/src/vos/tests/vts_gc.c
@@ -119,7 +119,7 @@ gc_obj_update(struct gc_test_args *args, daos_handle_t coh, daos_unit_oid_t oid,
 			return rc;
 		}
 
-		rc = bio_iod_prep(vos_ioh2desc(ioh));
+		rc = bio_iod_prep(vos_ioh2desc(ioh), BIO_CHK_TYPE_IO);
 		if (rc) {
 			print_error("Failed to prepare bio desc\n");
 			return rc;

--- a/src/vos/tests/vts_io.c
+++ b/src/vos/tests/vts_io.c
@@ -578,7 +578,7 @@ io_test_obj_update(struct io_test_args *arg, daos_epoch_t epoch, uint64_t flags,
 	}
 
 	srv_iov = &sgl->sg_iovs[0];
-	rc = bio_iod_prep(vos_ioh2desc(ioh));
+	rc = bio_iod_prep(vos_ioh2desc(ioh), BIO_CHK_TYPE_IO);
 	if (rc)
 		goto end;
 
@@ -640,7 +640,7 @@ io_test_obj_fetch(struct io_test_args *arg, daos_epoch_t epoch, uint64_t flags,
 	}
 
 	dst_iov = &sgl->sg_iovs[0];
-	rc = bio_iod_prep(vos_ioh2desc(ioh));
+	rc = bio_iod_prep(vos_ioh2desc(ioh), BIO_CHK_TYPE_IO);
 	if (rc)
 		goto end;
 

--- a/src/vos/vos_io.c
+++ b/src/vos/vos_io.c
@@ -2385,7 +2385,7 @@ vos_obj_copy(struct vos_io_context *ioc, d_sg_list_t *sgls,
 	int rc, err;
 
 	D_ASSERT(sgl_nr == ioc->ic_iod_nr);
-	rc = bio_iod_prep(ioc->ic_biod);
+	rc = bio_iod_prep(ioc->ic_biod, BIO_CHK_TYPE_IO);
 	if (rc)
 		return rc;
 


### PR DESCRIPTION
Introduce DMA chunk types: IO, LOCAL & REBUILD, so that each
chunk only serves same type of request having roughly same expected
latency.

We may extend it later to dynamically throttle chunk consuming by
type, based on the current IO pattern & workload.

Signed-off-by: Niu Yawei <yawei.niu@intel.com>