### PR TITLE
DAOS-NNNN rebuild, telemetry: count rebuild fetch bytes

### DIFF
--- a/src/object/obj_internal.h
+++ b/src/object/obj_internal.h
@@ -278,8 +278,9 @@ struct obj_tls {
 	struct d_tm_node_t	*ot_update_lat[NR_LATENCY_BUCKETS];
 	struct d_tm_node_t	*ot_fetch_lat[NR_LATENCY_BUCKETS];
 
-	/** Total number of bytes fetched (type = counter) */
+	/** Total number of bytes fetched and rebuild subset (type = counter) */
 	struct d_tm_node_t	*ot_fetch_bytes;
+	struct d_tm_node_t	*ot_rb_fetch_bytes;
 	/** Total number of bytes updated (type = counter) */
 	struct d_tm_node_t	*ot_update_bytes;
 
@@ -608,7 +609,8 @@ struct obj_io_context {
 	uint64_t		 ioc_io_size;
 	uint32_t		 ioc_began:1,
 				 ioc_free_sgls:1,
-				 ioc_lost_reply:1;
+				 ioc_lost_reply:1,
+				 ioc_rb_fetch:1;
 };
 
 struct ds_obj_exec_arg {

--- a/src/object/srv_mod.c
+++ b/src/object/srv_mod.c
@@ -190,6 +190,14 @@ obj_tls_init(int xs_id, int tgt_id)
 		D_WARN("Failed to create bytes fetch sensor: "DF_RC"\n",
 		       DP_RC(rc));
 
+	/** Rebuild bytes read (subset of total bytes read) */
+	rc = d_tm_add_metric(&tls->ot_rb_fetch_bytes, D_TM_COUNTER,
+			     "total number of bytes fetched/read (by rebuild)",
+			     "", "io/%u/rb_fetch_bytes", tgt_id);
+	if (rc)
+		D_WARN("Failed to create rebuild bytes fetch sensor: "DF_RC"\n",
+		       DP_RC(rc));
+
 	/** Total bytes written */
 	rc = d_tm_add_metric(&tls->ot_update_bytes, D_TM_COUNTER,
 			     "total number of bytes updated/written", "",


### PR DESCRIPTION
Before this change, the fetch_bytes telemetry counter does not
reveal how much data is served by a daos_engine target for client I/O
compared to rebuild (that is also done via object fetch RPCs).

With this change, a new telemetry counter rb_fetch_bytes is added.
This value represents the subset of the total (fetch_bytes) retrieved
during rebuild. The function ds_obj_rw_handler() inspects the
DAOS_OBJ_RPC_FETCH orw_flags for the ORF_FOR_MIGRATION bit (set by
another daos_engine initiator in rebuild). And the obj_io_context has
a new bit ioc_rb_fetch used by the telemetry sensor update function
to know when to increment this rebuild-specific counter.

Signed-off-by: Kenneth Cain <kenneth.c.cain@intel.com>