### PR TITLE
DAOS-7086 test: Fixed UTF-8 string and bytes comparison bug to fix container_async.py

### DIFF
--- a/src/client/pydaos/raw/daos_api.py
+++ b/src/client/pydaos/raw/daos_api.py
@@ -1373,20 +1373,20 @@ class DaosContainer():
         # 2. Enable checksum,
         # 3. Server Verfiy
         # 4. Chunk Size Allocation.
-        if ((self.cont_input_values.type != "Unknown")
+        if ((self.cont_input_values.type.decode("UTF-8") != "Unknown")
                 and (self.cont_input_values.enable_chksum is False)):
             # Only type like posix, hdf5 defined.
             num_prop = 1
-        elif ((self.cont_input_values.type == "Unknown")
+        elif ((self.cont_input_values.type.decode("UTF-8") == "Unknown")
               and (self.cont_input_values.enable_chksum is True)):
             # Obly checksum enabled.
             num_prop = 3
-        elif ((self.cont_input_values.type != "Unknown")
+        elif ((self.cont_input_values.type.decode("UTF-8") != "Unknown")
               and (self.cont_input_values.enable_chksum is True)):
             # Both layout and checksum properties defined
             num_prop = 4
 
-        if ((self.cont_input_values.type != "Unknown")
+        if ((self.cont_input_values.type.decode("UTF-8") != "Unknown")
                 or (self.cont_input_values.enable_chksum is True)):
             self.cont_prop = daos_cref.DaosProperty(num_prop)
         # idx index is used to increment the dpp_entried array
@@ -1395,7 +1395,7 @@ class DaosContainer():
         # dpp_entries will start with idx=0. If layer is not
         # none, checksum dpp_entries will start at idx=1.]
         idx = 0
-        if self.cont_input_values.type != "Unknown":
+        if self.cont_input_values.type.decode("UTF-8") != "Unknown":
             self.cont_prop.dpp_entries[idx].dpe_type = ctypes.c_uint32(
                 DaosContPropEnum.DAOS_PROP_CO_LAYOUT_TYPE.value)
             if self.cont_input_values.type in ("posix", "POSIX"):

--- a/src/tests/ftest/container/container_async.py
+++ b/src/tests/ftest/container/container_async.py
@@ -29,7 +29,7 @@ class ContainerAsync(TestWithServers):
         super().__init__(*args, **kwargs)
         self.container = []
 
-    def test_createasync(self):
+    def test_create_async(self):
         """Test container create for asynchronous mode.
 
         Test both positive and negative cases. For negative case, RC is -1002,
@@ -39,7 +39,7 @@ class ContainerAsync(TestWithServers):
         The negative case is more like a test of the API implementation rather
         than DAOS itself.
 
-        :avocado: tags=all,small,full_regression,container,cont_create_async
+        :avocado: tags=all,full_regression,container,cont_create_async
         """
         self.add_pool()
         ph = self.pool.pool.handle
@@ -68,20 +68,20 @@ class ContainerAsync(TestWithServers):
                 poh=ph, con_uuid=None, cb_func=cbh2.callback)
             cbh2.wait()
             self.assertTrue(
-                cbh2.ret_code is not None and cbh2.ret_code != 0,
+                cbh2.ret_code is not None and cbh2.ret_code != RC_SUCCESS,
                 "Async create of non-existing container succeeded!")
         except DaosApiError as excep:
             print(excep)
             print(traceback.format_exc())
 
-    def test_destroyasync(self):
+    def test_destroy_async(self):
         """Test container destroy for asynchronous mode.
 
         Test only positive case. We don't test negative case because the API is
         implemented so that it returns the error code before executing the
         callback function, so if we try it as it is, the test hangs.
 
-        :avocado: tags=all,small,full_regression,container,cont_destroy_async
+        :avocado: tags=all,full_regression,container,cont_destroy_async
         """
         self.add_pool()
 
@@ -102,14 +102,14 @@ class ContainerAsync(TestWithServers):
             print(excep)
             print(traceback.format_exc())
 
-    def test_openasync(self):
+    def test_open_async(self):
         """Test container open for asynchronous mode.
 
         Test only positive case. We don't test negative case because the API is
         implemented so that it returns the error code before executing the
         callback function, so if we try it as it is, the test hangs.
 
-        :avocado: tags=all,small,full_regression,container,cont_open_async
+        :avocado: tags=all,full_regression,container,cont_open_async
         """
         self.add_pool()
 
@@ -130,12 +130,12 @@ class ContainerAsync(TestWithServers):
             print(excep)
             print(traceback.format_exc())
 
-    def test_closeasync(self):
+    def test_close_async(self):
         """Test container close for asynchronous mode.
 
         Test both positive and negative cases.
 
-        :avocado: tags=all,small,full_regression,container,cont_close_async
+        :avocado: tags=all,full_regression,container,cont_close_async
         """
         self.add_pool()
 
@@ -174,12 +174,12 @@ class ContainerAsync(TestWithServers):
             print(excep)
             print(traceback.format_exc())
 
-    def test_queryasync(self):
+    def test_query_async(self):
         """Test container query for asynchronous mode.
 
         Test both positive and negative cases.
 
-        :avocado: tags=all,small,full_regression,container,cont_query_async
+        :avocado: tags=all,full_regression,container,cont_query_async
         """
         self.add_pool()
 

--- a/src/tests/ftest/container/container_async.yaml
+++ b/src/tests/ftest/container/container_async.yaml
@@ -1,14 +1,9 @@
 hosts:
   test_servers:
     - server-A
-    - server-B
 timeout: 60
-server_config:
-  name: daos_server
 pool:
   control_method: dmg
-  name: daos_server
   scm_size: 1G
-  mode: 146
 container:
   control_method: API


### PR DESCRIPTION
When we migrated to Python3, self.cont_input_values.type in daos_api.py was changed to bytes (I think due to Python3's more
strict type checking). This caused an issue in DaosContainer create(). First, the type mismatch caused the container properties
(self.cont_prop) to have some bogus values even though the test doesn't set any container property. This bogus value was passed
into AsyncWorker1 where it creates a container with the API. The tricky part is that this container creation succeeds and
returns 0. (BTW, this may be a bug.) Instead, the following call to daos_eq_poll() (Line 232 of daos_cref.py) gets stuck for
some reason, hence the test hangs. The solutions is to simply fix the types used during the comparisons; changed to string vs.
string.

Also refactored the test.

Quick-build: true
Skip-unit-tests: true
Test-tag-vm: pr,-hw cont_create_async
Signed-off-by: Makito Kano <makito.kano@intel.com>