### PR TITLE
DAOS-7141 object: Object enum support multiple iovs

### DIFF
--- a/src/include/daos/common.h
+++ b/src/include/daos/common.h
@@ -80,6 +80,9 @@ struct daos_sgl_idx {
 	daos_off_t	iov_offset; /** byte offset of iov buf */
 };
 
+#define DF_SGL_IDX "{idx: %d, offset: "DF_U64"}"
+#define DP_SGL_IDX(i) (i)->iov_idx, (i)->iov_offset
+
 /*
  * add bytes to the sgl index offset. If the new offset is greater than or
  * equal to the indexed iov len, move the index to the next iov in the sgl.
@@ -88,19 +91,27 @@ static inline void
 sgl_move_forward(d_sg_list_t *sgl, struct daos_sgl_idx *sgl_idx, uint64_t bytes)
 {
 	sgl_idx->iov_offset += bytes;
+	D_DEBUG(DB_TRACE, "Moving sgl index formward by %lu bytes."
+			  "Idx: "DF_SGL_IDX"\n",
+		bytes, DP_SGL_IDX(sgl_idx));
 
 	/** move to next iov if necessary */
 	if (sgl_idx->iov_offset >= sgl->sg_iovs[sgl_idx->iov_idx].iov_len) {
 		sgl_idx->iov_idx++;
 		sgl_idx->iov_offset = 0;
+		D_DEBUG(DB_TRACE, "Moving to next iov in sgl\n");
 	}
+	D_DEBUG(DB_TRACE, "Idx: "DF_SGL_IDX"\n", DP_SGL_IDX(sgl_idx));
 }
 
 static inline void *
 sgl_indexed_byte(d_sg_list_t *sgl, struct daos_sgl_idx *sgl_idx)
 {
-	if (sgl_idx->iov_idx > sgl->sg_nr_out - 1)
+	D_DEBUG(DB_TRACE, "Idx: "DF_SGL_IDX"\n", DP_SGL_IDX(sgl_idx));
+	if (sgl_idx->iov_idx > sgl->sg_nr_out - 1) {
+		D_DEBUG(DB_TRACE, "Index too high. Returning NULL\n");
 		return NULL;
+	}
 	return sgl->sg_iovs[sgl_idx->iov_idx].iov_buf + sgl_idx->iov_offset;
 }
 
@@ -111,11 +122,13 @@ sgl_indexed_byte(d_sg_list_t *sgl, struct daos_sgl_idx *sgl_idx)
 static inline void
 sgl_test_forward(d_sg_list_t *sgl, struct daos_sgl_idx *sgl_idx, uint64_t bytes)
 {
+	D_DEBUG(DB_TRACE, "Before Idx: "DF_SGL_IDX"\n", DP_SGL_IDX(sgl_idx));
 	if (sgl_idx->iov_offset + bytes >
 	    sgl->sg_iovs[sgl_idx->iov_idx].iov_len) {
 		sgl_idx->iov_idx++;
 		sgl_idx->iov_offset = 0;
 	}
+	D_DEBUG(DB_TRACE, "After Idx: "DF_SGL_IDX"\n", DP_SGL_IDX(sgl_idx));
 }
 
 /*

--- a/src/include/daos/common.h
+++ b/src/include/daos/common.h
@@ -96,7 +96,7 @@ sgl_move_forward(d_sg_list_t *sgl, struct daos_sgl_idx *sgl_idx, uint64_t bytes)
 		bytes, DP_SGL_IDX(sgl_idx));
 
 	/** move to next iov if necessary */
-	if (sgl_idx->iov_offset >= sgl->sg_iovs[sgl_idx->iov_idx].iov_len) {
+	if (sgl_idx->iov_offset >= sgl->sg_iovs[sgl_idx->iov_idx].iov_buf_len) {
 		sgl_idx->iov_idx++;
 		sgl_idx->iov_offset = 0;
 		D_DEBUG(DB_TRACE, "Moving to next iov in sgl\n");

--- a/src/object/obj_enum.c
+++ b/src/object/obj_enum.c
@@ -1351,22 +1351,25 @@ obj_enum_iterate(daos_key_desc_t *kdss, d_sg_list_t *sgl, int nr,
 		 unsigned int type, obj_enum_process_cb_t cb,
 		 void *cb_arg)
 {
+	struct daos_sgl_idx sgl_idx = {0};
 	char		*ptr;
 	unsigned int	i;
 	int		rc = 0;
 
 	D_ASSERTF(sgl->sg_nr > 0, "%u\n", sgl->sg_nr);
 	D_ASSERT(sgl->sg_iovs != NULL);
-	ptr = sgl->sg_iovs[0].iov_buf;
 	for (i = 0; i < nr; i++) {
 		daos_key_desc_t *kds = &kdss[i];
 
-		D_DEBUG(DB_REBUILD, "process %d type %d ptr %p len "DF_U64
-			" total %zd\n", i, kds->kd_val_type, ptr,
+		ptr = sgl_indexed_byte(sgl, &sgl_idx);
+		D_ASSERTF(ptr != NULL, "kds and sgl don't line up");
+
+		D_DEBUG(DB_REBUILD, "process %d, type %d, ptr %p, len "DF_U64
+			", total %zd\n", i, kds->kd_val_type, ptr,
 			kds->kd_key_len, sgl->sg_iovs[0].iov_len);
 		if (kds->kd_val_type == 0 ||
 		    (kds->kd_val_type != type && type != -1)) {
-			ptr += kds->kd_key_len;
+			sgl_move_forward(sgl, &sgl_idx, kds->kd_key_len);
 			D_DEBUG(DB_REBUILD, "skip type/size %d/%zd\n",
 				kds->kd_val_type, kds->kd_key_len);
 			continue;
@@ -1374,6 +1377,10 @@ obj_enum_iterate(daos_key_desc_t *kdss, d_sg_list_t *sgl, int nr,
 
 		if (kds->kd_val_type == OBJ_ITER_RECX ||
 		    kds->kd_val_type == OBJ_ITER_SINGLE) {
+			/*
+			 * XXX: Assuming that data for a single kds is entirely
+			 * contained in a single iov
+			 */
 			char *end = ptr + kds->kd_key_len;
 			char *data = ptr;
 
@@ -1395,7 +1402,7 @@ obj_enum_iterate(daos_key_desc_t *kdss, d_sg_list_t *sgl, int nr,
 		} else {
 			rc = cb(kds, ptr, kds->kd_key_len, cb_arg);
 		}
-		ptr += kds->kd_key_len;
+		sgl_move_forward(sgl, &sgl_idx, kds->kd_key_len);
 		if (rc) {
 			D_ERROR("iterate %dth failed: rc"DF_RC"\n", i,
 				DP_RC(rc));


### PR DESCRIPTION
Add usage of sgl_idx to support multiple iovs in the sgl
while using obj_enum_iterate.

Signed-off-by: Ryon Jensen <ryon.jensen@intel.com>