### PR TITLE
DAOS-7150-test_release1.2: Enable cascading testcase

### DIFF
--- a/src/tests/ftest/rebuild/cascading_failures.py
+++ b/src/tests/ftest/rebuild/cascading_failures.py
@@ -118,7 +118,6 @@ class CascadingFailures(RebuildTestBase):
         self.mode = "sequential"
         self.execute_rebuild_test()
 
-    @skipForTicket("DAOS-6728")
     def test_cascading_failures(self):
         """Jira ID: DAOS-844.
 


### PR DESCRIPTION
modify: cascading_failure.py
Skip-unit-tests: true
Skip-nlt: true
Quick-Functional: true
Test-tag: cascading
Signed-off-by: Ding Ho <ding-hwa.ho@intel.com>