### PR TITLE
DAOS-7176-test: enable pool/bad_create.yaml commented-out testcases

### DIFF
--- a/src/tests/ftest/pool/bad_create.py
+++ b/src/tests/ftest/pool/bad_create.py
@@ -54,6 +54,7 @@ class BadCreateTest(TestWithServers):
         setidlist = self.params.get("setname", '/run/createtests/setnames/*')
         if setidlist[0] == 'NULLPTR':
             group = None
+            self.cancel("skipping this test until DAOS-1991 is fixed")
         else:
             group = setidlist[0]
         expected_for_param.append(setidlist[1])

--- a/src/tests/ftest/pool/bad_create.py
+++ b/src/tests/ftest/pool/bad_create.py
@@ -54,7 +54,6 @@ class BadCreateTest(TestWithServers):
         setidlist = self.params.get("setname", '/run/createtests/setnames/*')
         if setidlist[0] == 'NULLPTR':
             group = None
-            self.cancel("skipping this test until DAOS-1991 is fixed")
         else:
             group = setidlist[0]
         expected_for_param.append(setidlist[1])

--- a/src/tests/ftest/pool/bad_create.yaml
+++ b/src/tests/ftest/pool/bad_create.yaml
@@ -38,10 +38,10 @@ createtests:
              - daos_server
              - PASS
    target: !mux
-      #nullptr:
-      #   rankptr:
-      #       - NULL
-      #       - FAIL
+      nullptr:
+         rankptr:
+             - NULL
+             - FAIL
       goodtgt:
          rankptr:
              - VALID
@@ -51,29 +51,28 @@ createtests:
          devptr:
              - NULL
              - FAIL
-      #badstr:
-      #   devptr:
-      #       - complete_rubbish
-      #       - PASS
+      badstr:
+         devptr:
+             - complete_rubbish
+             - PASS
    psize: !mux
       toobig:
          size:
              - 999999999999999999999999
              - FAIL
-      # broken now
-      #toosmall:
-      #   size:
-      #       - 1
-      #       - FAIL
+      toosmall:
+         size:
+             - 1
+             - FAIL
       justright:
          size:
              - 1073741824
              - PASS
    svc: !mux
-      #nullptr:
-      #   rankptr:
-      #       - NULL
-      #       - FAIL
+      nullptr:
+         rankptr:
+             - NULL
+             - FAIL
       goodptr:
          rankptr:
              - VALID

--- a/src/tests/ftest/pool/bad_create.yaml
+++ b/src/tests/ftest/pool/bad_create.yaml
@@ -77,4 +77,3 @@ createtests:
          rankptr:
              - VALID
              - PASS
-


### PR DESCRIPTION
modified: pool/bad_create.yaml
          pool/bad_create.py
Skip-unit-tests: true
Skip-nlt: true
Quick-Functional: true
Test-tag: badcreate
Signed-off-by: Ding Ho <ding-hwa.ho@intel.com>