### PR TITLE
DAOS-7181 csum: Disable checksum for IO Tests

### DIFF
--- a/src/tests/ftest/daos_test/daos_core_test.yaml
+++ b/src/tests/ftest/daos_test/daos_core_test.yaml
@@ -140,7 +140,7 @@ daos_tests:
     test_daos_single_rdg_tx: --csum_type=crc32
     test_daos_distributed_tx: --csum_type=crc32
     test_daos_verify_consistency: --csum_type=crc32
-    test_daos_io: --csum_type=crc32
+    test_daos_io: --csum_type=off
     test_daos_object_array: --csum_type=crc32
     test_daos_array: --csum_type=crc32
     test_daos_kv: --csum_type=crc32


### PR DESCRIPTION
There are a couple I/O tests (daos_test -i) that use EC object class
and rebuild. This currently isn't supported with checksums. DAOS-7182
will re-enable checksums for these tests when it is supported.

Signed-off-by: Ryon Jensen <ryon.jensen@intel.com>

Test-tag-hw-medium: pr,hw,medium,ib2,test_daos_io
Skip-unit-tests: true
Skip-func-hw-test-small: true
Skip-func-hw-test-large: true