### PR TITLE
DAOS-7119 control: exit nonzero from dmg storage cmd --json (#5221)

### DIFF
--- a/utils/node_local_test.py
+++ b/utils/node_local_test.py
@@ -460,9 +460,12 @@ class DaosServer():
         while True:
             time.sleep(0.5)
             rc = self.run_dmg(cmd)
+
             data = json.loads(rc.stdout.decode('utf-8'))
             print('cmd: {} data: {}'.format(cmd, data))
 
+            if rc.returncode == 0:
+                break
             if data['error'] is not None:
                 resolved = False
                 for res in error_resolutions.values():


### PR DESCRIPTION
When a dmg storage command e.g. format is run with --json option set
exit with nonzero rc if host errors are contained in response. Output
error related text to stderr not stdout and update nlt to reflect that.

Signed-off-by: Tom Nabarro tom.nabarro@intel.com