### PR TITLE
DAOS-7179 vos: Don't skip aggregation for full scan

### DIFF
--- a/src/include/daos_srv/vos.h
+++ b/src/include/daos_srv/vos.h
@@ -382,13 +382,14 @@ vos_cont_query(daos_handle_t coh, vos_cont_info_t *cinfo);
  * \param csum_func  [IN]	Pointer to csum recalculation function
  * \param yield_func [IN]	Pointer to customized yield function
  * \param yield_arg  [IN]	Argument of yield function
+ * \param full_scan  [IN]	Full scan for snapshot deletion
  *
  * \return			Zero on success, negative value if error
  */
 int
 vos_aggregate(daos_handle_t coh, daos_epoch_range_t *epr,
 	      void (*csum_func)(void *), bool (*yield_func)(void *arg),
-	      void *yield_arg);
+	      void *yield_arg, bool full_scan);
 
 /**
  * Discards changes in all epochs with the epoch range \a epr

--- a/src/rdb/rdb_util.c
+++ b/src/rdb/rdb_util.c
@@ -540,7 +540,7 @@ rdb_vos_aggregate(daos_handle_t cont, daos_epoch_t high)
 	epr.epr_lo = 0;
 	epr.epr_hi = high;
 
-	return vos_aggregate(cont, &epr, NULL, NULL, NULL);
+	return vos_aggregate(cont, &epr, NULL, NULL, NULL, true);
 }
 
 /* Return amount of vos pool SCM memory available accounting for

--- a/src/vos/tests/vts_aggregate.c
+++ b/src/vos/tests/vts_aggregate.c
@@ -414,7 +414,7 @@ aggregate_basic(struct io_test_args *arg, struct agg_tst_dataset *ds,
 		rc = vos_discard(arg->ctx.tc_co_hdl, epr_a, NULL, NULL);
 	else
 		rc = vos_aggregate(arg->ctx.tc_co_hdl, epr_a,
-				   ds_csum_agg_recalc, NULL, NULL);
+				   ds_csum_agg_recalc, NULL, NULL, false);
 	if (rc != -DER_CSUM) {
 		assert_rc_equal(rc, 0);
 		verify_view(arg, oid, dkey, akey, ds);
@@ -585,7 +585,8 @@ aggregate_multi(struct io_test_args *arg, struct agg_tst_dataset *ds_sample)
 	if (ds_sample->td_discard)
 		rc = vos_discard(arg->ctx.tc_co_hdl, epr_a, NULL, NULL);
 	else
-		rc = vos_aggregate(arg->ctx.tc_co_hdl, epr_a, NULL, NULL, NULL);
+		rc = vos_aggregate(arg->ctx.tc_co_hdl, epr_a, NULL, NULL, NULL,
+				   false);
 	assert_rc_equal(rc, 0);
 
 	multi_view(arg, oids, dkeys, akeys, AT_OBJ_KEY_NR, ds_arr, true);
@@ -1137,7 +1138,7 @@ agg_punches_test_helper(void **state, int record_type, int type, bool discard,
 			rc = vos_discard(arg->ctx.tc_co_hdl, &epr, NULL, NULL);
 		else
 			rc = vos_aggregate(arg->ctx.tc_co_hdl, &epr, NULL,
-					   NULL, NULL);
+					   NULL, NULL, false);
 
 		assert_rc_equal(rc, 0);
 
@@ -1844,7 +1845,8 @@ aggregate_14(void **state)
 
 		VERBOSE_MSG("Aggregate round: %d\n", i);
 		epr.epr_hi = epc_hi;
-		rc = vos_aggregate(arg->ctx.tc_co_hdl, &epr, NULL, NULL, NULL);
+		rc = vos_aggregate(arg->ctx.tc_co_hdl, &epr, NULL, NULL, NULL,
+				   false);
 		if (rc) {
 			print_error("aggregate %d failed:%d\n", i, rc);
 			break;
@@ -2034,7 +2036,7 @@ aggregate_22(void **state)
 
 	epr.epr_hi = epoch++;
 
-	rc = vos_aggregate(arg->ctx.tc_co_hdl, &epr, NULL, NULL, NULL);
+	rc = vos_aggregate(arg->ctx.tc_co_hdl, &epr, NULL, NULL, NULL, false);
 	assert_rc_equal(rc, 0);
 
 	fetch_value(arg, oid, epoch++,

--- a/src/vos/tests/vts_pm.c
+++ b/src/vos/tests/vts_pm.c
@@ -2302,7 +2302,7 @@ start_over:
 		if ((epoch - 200) < epr.epr_lo)
 			continue;
 		epr.epr_hi = epoch - 200;
-		rc = vos_aggregate(coh, &epr, NULL, NULL, NULL);
+		rc = vos_aggregate(coh, &epr, NULL, NULL, NULL, false);
 		assert_rc_equal(rc, 0);
 	}
 	for (i = 0; i < NR_TX - 1; i++) {


### PR DESCRIPTION
Don't try to skip aggregating untouched obj/dkey/akey if the
aggregation is a 'full scan' caused by snapshot deletion.

Signed-off-by: Niu Yawei <yawei.niu@intel.com>