### PR TITLE
DAOS-7169 control: Fix intermittent deadlock on server startup

### DIFF
--- a/src/control/server/ctl_storage_rpc.go
+++ b/src/control/server/ctl_storage_rpc.go
@@ -424,6 +424,10 @@ func (c *ControlService) StorageFormat(ctx context.Context, req *ctlpb.StorageFo
 
 	// TODO: perform bdev format in parallel
 	for _, srv := range instances {
+		if len(srv.bdevConfig().DeviceList) == 0 {
+			continue
+		}
+
 		if instanceErrored[srv.Index()] {
 			// if scm errored, indicate skipping bdev format
 			if len(srv.bdevConfig().DeviceList) > 0 {
@@ -451,7 +455,7 @@ func (c *ControlService) StorageFormat(ctx context.Context, req *ctlpb.StorageFo
 			srv.log.Errorf(msgFormatErr, srv.Index())
 			continue
 		}
-		srv.NotifyStorageReady(ctx)
+		srv.NotifyStorageReady()
 	}
 
 	return resp, nil

--- a/src/control/server/instance_storage.go
+++ b/src/control/server/instance_storage.go
@@ -92,12 +92,9 @@ func (srv *EngineInstance) NeedsScmFormat() (bool, error) {
 }
 
 // NotifyStorageReady releases any blocks on awaitStorageReady().
-func (srv *EngineInstance) NotifyStorageReady(ctx context.Context) {
+func (srv *EngineInstance) NotifyStorageReady() {
 	go func() {
-		select {
-		case <-ctx.Done():
-		case srv.storageReady <- true:
-		}
+		srv.storageReady <- true
 	}()
 }
 


### PR DESCRIPTION
The work for DAOS-6004 modified EngineInstance.NotifyStorageFormat()
to accept a context, on the theory that the goroutine should be
cancelable if the parent context is canceled. Normally this is a
good idea, but in this case it was an error because on highly-loaded
systems the gRPC context from StorageFormat() could be canceled before
the starting instance is able to read from the storageReady channel,
leading to a deadlock on startup.

Also bypasses the NVMe format logic if the engine config has no
block devices. This avoids printing a confusing message about
formatting NVMe even though there's no NVMe in the config.

Master-PR: https://github.com/daos-stack/daos/pull/5345