### PR TITLE
DAOS-7144-test: enable erasurecode/ec_offline_rebuild

### DIFF
--- a/src/tests/ftest/erasurecode/ec_offline_rebuild.py
+++ b/src/tests/ftest/erasurecode/ec_offline_rebuild.py
@@ -5,7 +5,6 @@
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
 from ec_utils import ErasureCodeIor
-from apricot import skipForTicket
 
 
 class EcOfflineRebuild(ErasureCodeIor):
@@ -16,7 +15,6 @@ class EcOfflineRebuild(ErasureCodeIor):
     :avocado: recursive
     """
 
-    @skipForTicket("DAOS-6450")
     def test_ec_offline_rebuild(self):
         """Jira ID: DAOS-5894.
 


### PR DESCRIPTION
Modified: erasurecode/ec_offline_rebuild.py
Allow-unstable-test: true
Test-tag: ec_offline_rebuild
Signed-off-by: Ding Ho <ding-hwa.ho@intel.com>