### PR TITLE
DAOS-5944 test: strdup const*const strings in test

### DIFF
--- a/src/tests/suite/daos_container.c
+++ b/src/tests/suite/daos_container.c
@@ -95,14 +95,14 @@ co_attribute(void **state)
 	daos_event_t	 ev;
 	int		 rc;
 
-	char const *const names[] = { "AVeryLongName", "Name" };
+	char const *const names[] = { strdup("AVeryLongName"), strdup("Name") };
 	size_t const name_sizes[] = {
 				strlen(names[0]) + 1,
 				strlen(names[1]) + 1,
 	};
 	void const *const in_values[] = {
-				"value",
-				"this is a long value"
+				strdup("value"),
+				strdup("this is a long value")
 	};
 	size_t const in_sizes[] = {
 				strlen(in_values[0]),

--- a/src/tests/suite/daos_obj.c
+++ b/src/tests/suite/daos_obj.c
@@ -590,7 +590,7 @@ set_pool_reclaim_strategy(void **state, void const *const strategy[])
 {
 	test_arg_t *arg = *state;
 	int rc;
-	char const *const names[] = {"reclaim"};
+	char const *const names[] = {strdup("reclaim")};
 	size_t const in_sizes[] = {strlen(strategy[0])};
 	int			 n = (int) ARRAY_SIZE(names);
 
@@ -680,8 +680,8 @@ io_overwrite_large(void **state, daos_obj_id_t oid)
 	daos_pool_info_t pinfo;
 	daos_size_t	 nvme_initial_size;
 	daos_size_t	 nvme_current_size;
-	void const *const aggr_disabled[] = {"disabled"};
-	void const *const aggr_set_time[] = {"time"};
+	void const *const aggr_disabled[] = {strdup("disabled")};
+	void const *const aggr_set_time[] = {strdup("time")};
 
 	/* Disabled Pool Aggrgation */
 	rc = set_pool_reclaim_strategy(state, aggr_disabled);
@@ -894,8 +894,8 @@ io_rewritten_array_with_mixed_size(void **state)
 	int			total_run_time = 20;
 	daos_size_t		nvme_initial_size;
 	daos_size_t		nvme_current_size;
-	void const *const aggr_disabled[] = {"disabled"};
-	void const *const aggr_set_time[] = {"time"};
+	void const *const aggr_disabled[] = {strdup("disabled")};
+	void const *const aggr_set_time[] = {strdup("time")};
 
 	/* choose random object */
 	oid = daos_test_oid_gen(arg->coh, dts_obj_class, 0, 0, arg->myrank);

--- a/src/tests/suite/daos_pool.c
+++ b/src/tests/suite/daos_pool.c
@@ -230,14 +230,14 @@ pool_attribute(void **state)
 	daos_event_t	 ev;
 	int		 rc;
 
-	char const *const names[] = { "AVeryLongName", "Name" };
+	char const *const names[] = { strdup("AVeryLongName"), strdup("Name") };
 	size_t const name_sizes[] = {
 				strlen(names[0]) + 1,
 				strlen(names[1]) + 1,
 	};
 	void const *const in_values[] = {
-				"value",
-				"this is a long value"
+				strdup("value"),
+				strdup("this is a long value")
 	};
 	size_t const in_sizes[] = {
 				strlen(in_values[0]),


### PR DESCRIPTION
Under MOFED environment, the pool tests failed trying to register
read-only addresses. Make a copy of the string to prevent.

Signed-off-by: Ryon Jensen <ryon.jensen@intel.com>