### PR TITLE
DAOS-5928: crash_ior.py failure to stop ior command (#4370)

### DIFF
--- a/src/tests/ftest/ior/crash_ior.py
+++ b/src/tests/ftest/ior/crash_ior.py
@@ -7,8 +7,6 @@
 
 import time
 
-from apricot import skipForTicket
-
 from ior_test_base import IorTestBase
 from dmg_utils import check_system_query_status
 
@@ -25,7 +23,6 @@ class CrashIor(IorTestBase):
         super().setUp()
         self.dmg = self.get_dmg_command()
 
-    @skipForTicket("DAOS-5928")
     def test_crashior(self):
         """Jira ID: DAOS-4332.
 

--- a/src/tests/ftest/util/command_utils.py
+++ b/src/tests/ftest/util/command_utils.py
@@ -182,9 +182,12 @@ class ExecutableCommand(CommandWithParameters):
 
         """
         if self._process is not None:
-            # Send a SIGTERM to the stop the subprocess and if it is still
-            # running after 5 seconds send a SIGKILL and report an error
-            signal_list = [signal.SIGTERM, signal.SIGKILL]
+            # Send a SIGTERM to stop the subprocess and if it is still
+            # running after 5 seconds give it another try. If that doesn't
+            # stop the process send a SIGKILL and report an error.
+            # Sending 2 SIGTERM signals is a known issue based on
+            # DAOS-6850.
+            signal_list = [signal.SIGTERM, signal.SIGTERM, signal.SIGKILL]
 
             # Turn off verbosity to keep the logs clean as the server stops
             self._process.verbose = False


### PR DESCRIPTION
Observed that the SIGTERM signal is not being propagated through the test
client so the IOR command is never killed in that node and after 5 secs
the parent PID in test server is killed with SIGKILL signal and the test
fails.

Modified the "def stop()" function in command_utils.py source file adding
another SIGTERM signal to the signal_list list. By doing this the
SIGTERM signal is now killing the child process and the test finish
successfully.

Test-tag-hw-medium: pr,hw,medium,ib2 crashior

Signed-off-by: David Maldonado Moreno <david.maldonado.moreno@intel.com>