### PR TITLE
DAOS-7103 control: clean leftover hugepages on startup

### DIFF
--- a/src/control/server/storage/bdev/backend.go
+++ b/src/control/server/storage/bdev/backend.go
@@ -11,7 +11,10 @@ import (
 	"bytes"
 	"os"
 	"os/exec"
+	"os/user"
+	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 	"syscall"
 
@@ -20,6 +23,11 @@ import (
 	"github.com/daos-stack/daos/src/control/lib/spdk"
 	"github.com/daos-stack/daos/src/control/logging"
 	"github.com/daos-stack/daos/src/control/server/storage"
+)
+
+const (
+	hugePageDir    = "/dev/hugepages"
+	hugePagePrefix = "spdk"
 )
 
 type (
@@ -35,6 +43,8 @@ type (
 		binding *spdkWrapper
 		script  *spdkSetupScript
 	}
+
+	removeFn func(string) error
 )
 
 // suppressOutput is a horrible, horrible hack necessitated by the fact that
@@ -302,27 +312,56 @@ func detectVMD() ([]string, error) {
 	return vmdAddrs, nil
 }
 
-// Prepare will execute SPDK setup.sh script to rebind PCI devices as selected
-// by bdev_include and bdev_exclude white and black list filters provided in the
-// server config file. This will make the devices available though SPDK.
-func (b *spdkBackend) Prepare(req PrepareRequest) (*PrepareResponse, error) {
-	resp := &PrepareResponse{}
+// hugePageWalkFunc returns a filepath.WalkFunc that will remove any file whose
+// name begins with prefix and owner has uid equal to tgtUid.
+func hugePageWalkFunc(hugePageDir, prefix, tgtUid string, remove removeFn) filepath.WalkFunc {
+	return func(path string, info os.FileInfo, err error) error {
+		switch {
+		case err != nil:
+			return err
+		case info == nil:
+			return errors.New("nil fileinfo")
+		case info.IsDir():
+			if path == hugePageDir {
+				return nil
+			}
+			return filepath.SkipDir // skip subdirectories
+		case !strings.HasPrefix(info.Name(), prefix):
+			return nil // skip files without prefix
+		}
 
-	if err := b.script.Prepare(req); err != nil {
-		return nil, errors.Wrap(err, "re-binding ssds to attach with spdk")
+		stat, ok := info.Sys().(*syscall.Stat_t)
+		if !ok || stat == nil {
+			return errors.New("stat missing for file")
+		}
+		if strconv.Itoa(int(stat.Uid)) != tgtUid {
+			return nil // skip not owned by target user
+		}
+
+		if err := remove(path); err != nil {
+			return err
+		}
+
+		return nil
 	}
+}
 
-	if req.DisableVMD {
-		return resp, nil
-	}
+// cleanHugePages removes hugepage files with pathPrefix that are owned by the
+// user with username tgtUsr by processing directory tree with filepath.WalkFunc
+// returned from hugePageWalkFunc.
+func cleanHugePages(hugePageDir, prefix, tgtUid string) error {
+	return filepath.Walk(hugePageDir,
+		hugePageWalkFunc(hugePageDir, prefix, tgtUid, os.Remove))
+}
 
+func (b *spdkBackend) vmdPrep(req PrepareRequest) (bool, error) {
 	vmdDevs, err := detectVMD()
 	if err != nil {
-		return nil, errors.Wrap(err, "VMD could not be enabled")
+		return false, errors.Wrap(err, "VMD could not be enabled")
 	}
 
 	if len(vmdDevs) == 0 {
-		return resp, nil
+		return false, nil
 	}
 
 	vmdReq := req
@@ -333,16 +372,51 @@ func (b *spdkBackend) Prepare(req PrepareRequest) (*PrepareResponse, error) {
 	vmdReq.PCIWhitelist = strings.Join(vmdDevs, " ")
 
 	if err := b.script.Prepare(vmdReq); err != nil {
-		return nil, errors.Wrap(err, "re-binding vmd ssds to attach with spdk")
+		return false, errors.Wrap(err, "re-binding vmd ssds to attach with spdk")
 	}
 
-	resp.VmdDetected = true
 	b.log.Debugf("volume management devices detected: %v", vmdDevs)
+	return true, nil
+}
+
+// Prepare will cleanup any leftover hugepages owned by the target user and then
+// executes the SPDK setup.sh script to rebind PCI devices as selected by
+// bdev_include and bdev_exclude list filters provided in the server config file.
+// This will make the devices available though SPDK.
+func (b *spdkBackend) Prepare(req PrepareRequest) (*PrepareResponse, error) {
+	b.log.Debugf("provider backend prepare %v", req)
+	resp := &PrepareResponse{}
+
+	usr, err := user.Lookup(req.TargetUser)
+	if err != nil {
+		return nil, errors.Wrapf(err, "lookup on local host")
+	}
+
+	if err := b.script.Prepare(req); err != nil {
+		return nil, errors.Wrap(err, "re-binding ssds to attach with spdk")
+	}
+
+	if !req.DisableCleanHugePages {
+		// remove hugepages matching /dev/hugepages/spdk* owned by target user
+		err := cleanHugePages(hugePageDir, hugePagePrefix, usr.Uid)
+		if err != nil {
+			return nil, errors.Wrapf(err, "clean spdk hugepages")
+		}
+	}
+
+	if !req.DisableVMD {
+		vmdDetected, err := b.vmdPrep(req)
+		if err != nil {
+			return nil, err
+		}
+		resp.VmdDetected = vmdDetected
+	}
 
 	return resp, nil
 }
 
 func (b *spdkBackend) PrepareReset() error {
+	b.log.Debugf("provider backend prepare reset")
 	return b.script.Reset()
 }
 

--- a/src/control/server/storage/bdev/provider.go
+++ b/src/control/server/storage/bdev/provider.go
@@ -36,13 +36,14 @@ type (
 	// PrepareRequest defines the parameters for a Prepare operation.
 	PrepareRequest struct {
 		pbin.ForwardableRequest
-		HugePageCount int
-		PCIWhitelist  string
-		PCIBlacklist  string
-		TargetUser    string
-		ResetOnly     bool
-		DisableVFIO   bool
-		DisableVMD    bool
+		HugePageCount         int
+		DisableCleanHugePages bool
+		PCIWhitelist          string
+		PCIBlacklist          string
+		TargetUser            string
+		ResetOnly             bool
+		DisableVFIO           bool
+		DisableVMD            bool
 	}
 
 	// PrepareResponse contains the results of a successful Prepare operation.

--- a/src/control/server/storage/bdev/runner_test.go
+++ b/src/control/server/storage/bdev/runner_test.go
@@ -8,6 +8,7 @@ package bdev
 import (
 	"fmt"
 	"os"
+	"os/user"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -17,13 +18,15 @@ import (
 	"github.com/daos-stack/daos/src/control/logging"
 )
 
-func TestBdevRunnerPrepare(t *testing.T) {
+func TestBdev_Runner_Prepare(t *testing.T) {
 	const (
-		testNrHugePages  = 42
-		testTargetUser   = "amos"
-		testPciWhitelist = "a,b,c"
-		testPciBlacklist = "x,y,z"
+		testNrHugePages       = 42
+		nonexistentTargetUser = "nonexistentTargetUser"
+		testPciWhitelist      = "a,b,c"
+		testPciBlacklist      = "x,y,z"
 	)
+	usrCurrent, _ := user.Current()
+	username := usrCurrent.Username
 
 	for name, tc := range map[string]struct {
 		req    PrepareRequest
@@ -32,67 +35,85 @@ func TestBdevRunnerPrepare(t *testing.T) {
 		expErr error
 	}{
 		"prepare reset fails": {
-			req: PrepareRequest{},
+			req: PrepareRequest{
+				TargetUser: username,
+			},
 			mbc: &MockBackendConfig{
 				PrepareResetErr: errors.New("reset failed"),
 			},
 			expErr: errors.New("reset failed"),
 		},
 		"prepare fails": {
-			req: PrepareRequest{},
+			req: PrepareRequest{
+				TargetUser: username,
+			},
 			mbc: &MockBackendConfig{
 				PrepareErr: errors.New("prepare failed"),
 			},
 			expErr: errors.New("prepare failed"),
 		},
 		"defaults": {
-			req: PrepareRequest{},
+			req: PrepareRequest{
+				TargetUser: username,
+			},
 			expEnv: []string{
 				fmt.Sprintf("PATH=%s", os.Getenv("PATH")),
 				fmt.Sprintf("%s=%d", nrHugepagesEnv, defaultNrHugepages),
-				fmt.Sprintf("%s=", targetUserEnv),
+				fmt.Sprintf("%s=%s", targetUserEnv, username),
 			},
 		},
 		"user-specified values": {
 			req: PrepareRequest{
-				HugePageCount: testNrHugePages,
-				TargetUser:    testTargetUser,
-				PCIWhitelist:  testPciWhitelist,
-				DisableVFIO:   true,
+				HugePageCount:         testNrHugePages,
+				DisableCleanHugePages: true,
+				TargetUser:            username,
+				PCIWhitelist:          testPciWhitelist,
+				DisableVFIO:           true,
 			},
 			expEnv: []string{
 				fmt.Sprintf("PATH=%s", os.Getenv("PATH")),
 				fmt.Sprintf("%s=%d", nrHugepagesEnv, testNrHugePages),
-				fmt.Sprintf("%s=%s", targetUserEnv, testTargetUser),
+				fmt.Sprintf("%s=%s", targetUserEnv, username),
 				fmt.Sprintf("%s=%s", pciWhiteListEnv, testPciWhitelist),
 				fmt.Sprintf("%s=%s", driverOverrideEnv, vfioDisabledDriver),
 			},
 		},
-		"blacklist": {
+		"blocklist": {
 			req: PrepareRequest{
-				HugePageCount: testNrHugePages,
-				TargetUser:    testTargetUser,
-				PCIBlacklist:  testPciBlacklist,
-				DisableVFIO:   true,
+				HugePageCount:         testNrHugePages,
+				DisableCleanHugePages: true,
+				TargetUser:            username,
+				PCIBlacklist:          testPciBlacklist,
+				DisableVFIO:           true,
 			},
 			expEnv: []string{
 				fmt.Sprintf("PATH=%s", os.Getenv("PATH")),
 				fmt.Sprintf("%s=%d", nrHugepagesEnv, testNrHugePages),
-				fmt.Sprintf("%s=%s", targetUserEnv, testTargetUser),
+				fmt.Sprintf("%s=%s", targetUserEnv, username),
 				fmt.Sprintf("%s=%s", pciBlackListEnv, testPciBlacklist),
 				fmt.Sprintf("%s=%s", driverOverrideEnv, vfioDisabledDriver),
 			},
 		},
-		"blacklist whitelist fails": {
+		"blocklist allowlist fails": {
 			req: PrepareRequest{
-				HugePageCount: testNrHugePages,
-				TargetUser:    testTargetUser,
-				PCIBlacklist:  testPciBlacklist,
-				PCIWhitelist:  testPciWhitelist,
-				DisableVFIO:   true,
+				HugePageCount:         testNrHugePages,
+				DisableCleanHugePages: true,
+				TargetUser:            username,
+				PCIBlacklist:          testPciBlacklist,
+				PCIWhitelist:          testPciWhitelist,
+				DisableVFIO:           true,
 			},
 			expErr: errors.New(
 				"bdev_include and bdev_exclude can't be used together"),
+		},
+		"unknown target user fails": {
+			req: PrepareRequest{
+				DisableCleanHugePages: true,
+				TargetUser:            nonexistentTargetUser,
+				DisableVFIO:           true,
+			},
+			expErr: errors.New(
+				"lookup on local host: user: unknown user nonexistentTargetUser"),
 		},
 	} {
 		t.Run(name, func(t *testing.T) {


### PR DESCRIPTION
During NVMe prepare step in daos_server init, cleanup leftover hugepages
from previous SPDK sessions that can be left after a crash.

Master PR: https://github.com/daos-stack/daos/pull/5232

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>