### PR TITLE
DAOS-623 ci: Use python3 boost for UT packages

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,14 +1,14 @@
 # have release-engineering added as a reviewer to any PR that updates
 # a component sha1
-utils/build.config @daos-stack/release-engineering
+utils/build.config @release-engineering
 # or updates packaging in any way
-utils/rpms @daos-stack/release-engineering
+utils/rpms @release-engineering
 
 # any PR that touches Go files should get a review from go-owners
-*.go @daos-stack/go-owners
+*.go @go-owners
 
 # any PR that touches VOS files should get a review from VOS
-src/vos/* src/common/btree*.* @daos-stack/VOS
+src/vos/* src/common/btree*.* @VOS
 
 # Jenkinsfile changes should be reviewed by Brian
 Jenkinsfile @brianjmurrell

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -964,7 +964,7 @@ pipeline {
                     }
                     agent {
                         // 2 node cluster with 1 IB/node + 1 test control node
-                        label 'stage_nvme3'
+                        label 'ci_nvme3'
                     }
                     steps {
                         functionalTest inst_repos: daosRepos(),

--- a/ci/unit/required_packages.sh
+++ b/ci/unit/required_packages.sh
@@ -8,7 +8,7 @@ quick_build="${2:-false}"
 pkgs="gotestsum openmpi3                 \
       hwloc-devel argobots               \
       fuse3-libs fuse3                   \
-      boost-devel                        \
+      boost-python36-devel               \
       libisa-l-devel libpmem             \
       libpmemobj protobuf-c              \
       spdk-devel libfabric-devel         \
@@ -21,7 +21,7 @@ pkgs="gotestsum openmpi3                 \
 if $quick_build; then
     read -r mercury_version < "$distro"-required-mercury-rpm-version
     pkgs="$pkgs spdk-tools mercury-$mercury_version         \
-          boost-devel libisa-l_crypto libfabric-debuginfo   \
+          libisa-l_crypto libfabric-debuginfo   \
           argobots-debuginfo protobuf-c-debuginfo"
 fi
 


### PR DESCRIPTION
Since we are using python36 now, we should use the python36 boost when
installing packages for unit testing.

Signed-off-by: Brian J. Murrell <brian.murrell@intel.com>