### PR TITLE
DAOS-7203 control: Add histogram support to Prometheus exporter

### DIFF
--- a/src/control/cmd/dmg/telemetry.go
+++ b/src/control/cmd/dmg/telemetry.go
@@ -254,13 +254,11 @@ func (cmd *telemConfigCmd) configurePrometheus() (*installInfo, error) {
 	}
 
 	sc := &staticConfig{}
-	for _, h := range cmd.config.HostList {
-		host, _, err := common.SplitPort(h, 0)
-		if err != nil {
-			return nil, err
-		}
-		sc.Targets = append(sc.Targets, host+":9191")
+	sc.Targets, err = common.ParseHostList(cmd.config.HostList, 9191)
+	if err != nil {
+		return nil, err
 	}
+
 	cfg.ScrapeConfigs = []*scrapeConfig{
 		{
 			JobName:        "daos",

--- a/src/control/lib/control/telemetry_test.go
+++ b/src/control/lib/control/telemetry_test.go
@@ -617,6 +617,10 @@ func TestControl_Metric_JSON(t *testing.T) {
 						CumulativeCount: 55,
 						UpperBound:      500,
 					},
+					{
+						CumulativeCount: 4242,
+						UpperBound:      math.Inf(1),
+					},
 				},
 			},
 		},

--- a/src/control/lib/telemetry/counter.go
+++ b/src/control/lib/telemetry/counter.go
@@ -24,6 +24,9 @@ import (
 	"fmt"
 )
 
+var _ Metric = (*Counter)(nil)
+
+// Counter is a counter metric.
 type Counter struct {
 	metricBase
 }

--- a/src/control/lib/telemetry/duration.go
+++ b/src/control/lib/telemetry/duration.go
@@ -25,8 +25,11 @@ import (
 	"time"
 )
 
+var _ StatsMetric = (*Duration)(nil)
+
 type Duration struct {
 	statsMetric
+	hist *Histogram // optional histogram data
 }
 
 func (d *Duration) Type() MetricType {
@@ -67,6 +70,7 @@ func newDuration(hdl *handle, path string, name *string, node *C.struct_d_tm_nod
 			},
 		},
 	}
+	d.hist = newHistogram(&d.statsMetric)
 
 	// Load up statistics
 	_ = d.Value()

--- a/src/control/lib/telemetry/gauge.go
+++ b/src/control/lib/telemetry/gauge.go
@@ -24,6 +24,9 @@ import (
 	"fmt"
 )
 
+var _ Metric = (*Gauge)(nil)
+var _ StatsMetric = (*StatsGauge)(nil)
+
 // Gauge is a metric that consists of a single value that may increase or decrease.
 type Gauge struct {
 	metricBase
@@ -93,6 +96,7 @@ func GetGauge(ctx context.Context, name string) (*Gauge, error) {
 // StatsGauge is a gauge with statistics gathered.
 type StatsGauge struct {
 	statsMetric
+	hist *Histogram // optional histogram data
 }
 
 // Type returns the type of the gauge with stats.
@@ -136,9 +140,11 @@ func newStatsGauge(hdl *handle, path string, name *string, node *C.struct_d_tm_n
 			},
 		},
 	}
+	g.hist = newHistogram(&g.statsMetric)
 
 	// Load up the stats
 	_ = g.Value()
+
 	return g
 }
 

--- a/src/control/lib/telemetry/histogram.go
+++ b/src/control/lib/telemetry/histogram.go
@@ -1,0 +1,170 @@
+//
+// (C) Copyright 2024 Intel Corporation.
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+//go:build linux && (amd64 || arm64)
+// +build linux
+// +build amd64 arm64
+
+package telemetry
+
+/*
+#cgo LDFLAGS: -lgurt
+
+#include "gurt/telemetry_common.h"
+#include "gurt/telemetry_consumer.h"
+*/
+import "C"
+
+import (
+	"github.com/pkg/errors"
+)
+
+// HistogramBucket contains the min/max values and count for a single bucket.
+type HistogramBucket struct {
+	Min   uint64
+	Max   uint64
+	Count uint64
+}
+
+// HistogramSample contains the results of a histogram sample.
+type HistogramSample struct {
+	Count   uint64
+	Sum     uint64
+	Buckets []HistogramBucket
+	Values  []uint64
+}
+
+// Histogram provides access to histogram data associated with
+// a parent metric.
+type Histogram struct {
+	parent *statsMetric
+	cHist  C.struct_d_tm_histogram_t
+}
+
+func (h *Histogram) sample() (uint64, []uint64, []HistogramBucket) {
+	if h.parent.handle == nil || h.parent.node == nil || h.cHist.dth_num_buckets == 0 {
+		return 0, nil, nil
+	}
+
+	if h.NumBuckets() == 0 {
+		return 0, nil, nil
+	}
+
+	var cBucket C.struct_d_tm_bucket_t
+	var cVal C.uint64_t
+	var sum uint64
+	// NB: We don't need to include the final bucket as its max is +Inf,
+	// and its min value can be derived from the max of the previous bucket.
+	// This plays well with Prometheus Histograms... May need to be adjusted
+	// if other implementations don't like this.
+	buckets := make([]HistogramBucket, h.cHist.dth_num_buckets-1)
+	vals := make([]uint64, len(buckets))
+	for i := 0; i < len(buckets); i++ {
+		res := C.d_tm_get_bucket_range(h.parent.handle.ctx, &cBucket, C.int(i), h.parent.node)
+		if res != C.DER_SUCCESS {
+			return 0, nil, nil
+		}
+
+		res = C.d_tm_get_counter(h.parent.handle.ctx, &cVal, cBucket.dtb_bucket)
+		if res != C.DER_SUCCESS {
+			return 0, nil, nil
+		}
+
+		// NB: Histogram bucket values are cumulative!
+		// https://en.wikipedia.org/wiki/Histogram#Cumulative_histogram
+		sum += uint64(cVal)
+		buckets[i] = HistogramBucket{
+			Min:   uint64(cBucket.dtb_min),
+			Max:   uint64(cBucket.dtb_max),
+			Count: sum,
+		}
+		vals[i] = buckets[i].Count
+	}
+
+	return h.parent.Sum(), vals, buckets
+}
+
+// NumBuckets returns a count of buckets in the histogram.
+func (h *Histogram) NumBuckets() uint64 {
+	res := C.d_tm_get_num_buckets(h.parent.handle.ctx, &h.cHist, h.parent.node)
+	if res != C.DER_SUCCESS {
+		return 0
+	}
+
+	return uint64(h.cHist.dth_num_buckets - 1)
+}
+
+// Buckets returns the histogram buckets.
+func (h *Histogram) Buckets() []HistogramBucket {
+	_, _, buckets := h.sample()
+	return buckets
+}
+
+// Sample returns a point-in-time sample of the histogram.
+func (h *Histogram) Sample(cur float64) *HistogramSample {
+	_, vals, buckets := h.sample()
+
+	return &HistogramSample{
+		Count:   h.parent.SampleSize(),
+		Sum:     uint64(cur),
+		Buckets: buckets,
+		Values:  vals,
+	}
+}
+
+func newHistogram(parent *statsMetric) *Histogram {
+	h := &Histogram{
+		parent: parent,
+	}
+
+	if h.NumBuckets() == 0 {
+		return nil
+	}
+
+	return h
+}
+
+func getHistogram(m Metric) *Histogram {
+	if m == nil {
+		return nil
+	}
+
+	switch o := m.(type) {
+	case *StatsGauge:
+		return o.hist
+	case *Duration:
+		return o.hist
+	default:
+		return nil
+	}
+}
+
+// HasBuckets returns true if the metric has histogram data.
+func HasBuckets(m Metric) bool {
+	if h := getHistogram(m); h != nil {
+		return h.NumBuckets() > 0
+	}
+
+	return false
+}
+
+// GetBuckets returns the histogram buckets for the metric, if available.
+func GetBuckets(m Metric) ([]HistogramBucket, error) {
+	if h := getHistogram(m); h != nil {
+		return h.Buckets(), nil
+	}
+
+	return nil, errors.Errorf("[%s]: no histogram data", m.FullPath())
+}
+
+// SampleHistogram returns a point-in-time sample of the histogram for
+// the metric, if available.
+func SampleHistogram(m Metric) (*HistogramSample, error) {
+	if h := getHistogram(m); h != nil {
+		return h.Sample(m.FloatValue()), nil
+	}
+
+	return nil, errors.Errorf("[%s]: no histogram data", m.FullPath())
+}

--- a/src/control/lib/telemetry/promexp/client.go
+++ b/src/control/lib/telemetry/promexp/client.go
@@ -60,7 +60,7 @@ func extractClientLabels(log logging.Logger, in string) (labels labelMap, name s
 		compsIdx++
 	}
 
-	for i, label := range []string{"job", "pid", "tid"} {
+	for i, label := range []string{"jobid", "pid", "tid"} {
 		if i > 0 {
 			// After jobid, we should have a pid and/or tid, and
 			// then move on to the engine labels.

--- a/src/control/lib/telemetry/promexp/client_test.go
+++ b/src/control/lib/telemetry/promexp/client_test.go
@@ -50,36 +50,36 @@ func TestPromExp_extractClientLabels(t *testing.T) {
 			input:   testPath("io/ops/update/active"),
 			expName: "io_ops_update_active",
 			expLabels: labelMap{
-				"job": jobID,
-				"pid": pid,
-				"tid": tid,
+				"jobid": jobID,
+				"pid":   pid,
+				"tid":   tid,
 			},
 		},
 		"fetch latency 1MB": {
 			input:   testPath("io/latency/fetch/1MB"),
 			expName: "io_latency_fetch",
 			expLabels: labelMap{
-				"job":  jobID,
-				"pid":  pid,
-				"tid":  tid,
-				"size": "1MB",
+				"jobid": jobID,
+				"pid":   pid,
+				"tid":   tid,
+				"size":  "1MB",
 			},
 		},
 		"started_at": {
 			input:   fmt.Sprintf("ID: %d/%s/%s/started_at", shmID, jobID, pid),
 			expName: "started_at",
 			expLabels: labelMap{
-				"job": jobID,
-				"pid": pid,
+				"jobid": jobID,
+				"pid":   pid,
 			},
 		},
 		"pool ops": {
 			input:   fmt.Sprintf("ID: %d/%s/%s/pool/%s/ops/foo", shmID, jobID, pid, test.MockPoolUUID(1)),
 			expName: "pool_ops_foo",
 			expLabels: labelMap{
-				"job":  jobID,
-				"pid":  pid,
-				"pool": test.MockPoolUUID(1).String(),
+				"jobid": jobID,
+				"pid":   pid,
+				"pool":  test.MockPoolUUID(1).String(),
 			},
 		},
 	} {

--- a/src/control/lib/telemetry/promexp/histogram.go
+++ b/src/control/lib/telemetry/promexp/histogram.go
@@ -1,0 +1,222 @@
+//
+// (C) Copyright 2024 Intel Corporation.
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+
+package promexp
+
+import (
+	"sort"
+	"sync"
+
+	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/prometheus/common/model"
+)
+
+var (
+	_ prometheus.Metric    = &daosHistogram{}
+	_ prometheus.Collector = &daosHistogramVec{}
+)
+
+// daosHistogram is a pass-through structure for pre-bucketed histogram
+// data retrieved from the DAOS telemetry library.
+type daosHistogram struct {
+	desc      *prometheus.Desc
+	name      string
+	help      string
+	sum       float64
+	count     uint64
+	labelVals []string
+	buckets   []float64
+	bucketMap map[float64]uint64
+}
+
+func newDaosHistogram(name, help string, desc *prometheus.Desc, buckets []float64, labelVals []string) *daosHistogram {
+	dh := &daosHistogram{
+		name:      name,
+		help:      help,
+		desc:      desc,
+		labelVals: labelVals,
+		buckets:   buckets,
+		bucketMap: make(map[float64]uint64),
+	}
+
+	for _, b := range buckets {
+		dh.bucketMap[b] = 0
+	}
+
+	return dh
+}
+
+func (dh *daosHistogram) Desc() *prometheus.Desc {
+	return dh.desc
+}
+
+func (dh *daosHistogram) Write(out *dto.Metric) error {
+	ch, err := prometheus.NewConstHistogram(dh.desc, dh.count, dh.sum, dh.bucketMap, dh.labelVals...)
+	if err != nil {
+		return err
+	}
+
+	return ch.Write(out)
+}
+
+func (dh *daosHistogram) AddSample(sampleCount uint64, sum float64, values []uint64) error {
+	if len(values) != len(dh.buckets) {
+		return errors.Errorf("expected %d values, got %d", len(dh.buckets), len(values))
+	}
+
+	for i, b := range dh.buckets {
+		dh.bucketMap[b] = values[i]
+	}
+
+	dh.count = sampleCount
+	dh.sum = sum
+
+	return nil
+}
+
+func (dh *daosHistogram) MustAddSample(sampleCount uint64, sum float64, values []uint64) {
+	if err := dh.AddSample(sampleCount, sum, values); err != nil {
+		panic(err)
+	}
+}
+
+type hashedMetricValue struct {
+	metric    prometheus.Metric
+	labelVals []string
+}
+
+type hashedMetrics map[uint64][]*hashedMetricValue
+
+// daosHistogramVec is a simplified custom implementation of prometheus.HistogramVec.
+// It is not designed for concurrency or currying.
+type daosHistogramVec struct {
+	opts       prometheus.HistogramOpts
+	desc       *prometheus.Desc
+	labelKeys  []string // stored here because prometheus.Desc is opaque to us
+	histograms hashedMetrics
+	mu         sync.RWMutex
+}
+
+func (dhv *daosHistogramVec) Describe(ch chan<- *prometheus.Desc) {
+	ch <- dhv.desc
+}
+
+func (dhv *daosHistogramVec) Collect(ch chan<- prometheus.Metric) {
+	dhv.mu.RLock()
+	defer dhv.mu.RUnlock()
+
+	for _, histograms := range dhv.histograms {
+		for _, histogram := range histograms {
+			ch <- histogram.metric
+		}
+	}
+}
+
+func labelVals(labels prometheus.Labels) []string {
+	keys := make([]string, 0, len(labels))
+	for key := range labels {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	vals := make([]string, 0, len(labels))
+	for _, key := range keys {
+		vals = append(vals, labels[key])
+	}
+	return vals
+}
+
+func cmpLabelVals(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+
+	return true
+}
+
+func (dhv *daosHistogramVec) addWithLabelValues(hashKey uint64, lvs []string) *hashedMetricValue {
+	dh := newDaosHistogram(dhv.opts.Name, dhv.opts.Help, dhv.desc, dhv.opts.Buckets, lvs)
+	hmv := &hashedMetricValue{
+		metric:    dh,
+		labelVals: lvs,
+	}
+	// NB: must be done under lock to be thread-safe
+	dhv.histograms[hashKey] = append(dhv.histograms[hashKey], hmv)
+
+	return hmv
+}
+
+func (dhv *daosHistogramVec) GetWith(labels prometheus.Labels) (*daosHistogram, error) {
+	hashKey := model.LabelsToSignature(labels)
+
+	var hmv *hashedMetricValue
+	lvs := labelVals(labels)
+
+	dhv.mu.Lock()
+	_, found := dhv.histograms[hashKey]
+	if !found {
+		hmv = dhv.addWithLabelValues(hashKey, lvs)
+	}
+
+	if hmv == nil {
+		for _, h := range dhv.histograms[hashKey] {
+			if cmpLabelVals(h.labelVals, lvs) {
+				hmv = h
+				break
+			}
+		}
+
+		if hmv == nil {
+			hmv = dhv.addWithLabelValues(hashKey, lvs)
+		}
+	}
+	dhv.mu.Unlock()
+
+	dh, ok := hmv.metric.(*daosHistogram)
+	if !ok {
+		return nil, errors.New("stored something other than *daosHistogram")
+	}
+	return dh, nil
+}
+
+func (dhv *daosHistogramVec) With(labels prometheus.Labels) *daosHistogram {
+	dh, err := dhv.GetWith(labels)
+	if err != nil {
+		panic(err)
+	}
+	return dh
+}
+
+func (dhv *daosHistogramVec) Reset() {
+	dhv.mu.Lock()
+	defer dhv.mu.Unlock()
+
+	for k := range dhv.histograms {
+		delete(dhv.histograms, k)
+	}
+}
+
+func newDaosHistogramVec(opts prometheus.HistogramOpts, labelNames []string) *daosHistogramVec {
+	return &daosHistogramVec{
+		desc: prometheus.NewDesc(
+			prometheus.BuildFQName(opts.Namespace, opts.Subsystem, opts.Name),
+			opts.Help,
+			labelNames,
+			opts.ConstLabels,
+		),
+		opts:       opts,
+		labelKeys:  labelNames,
+		histograms: make(hashedMetrics),
+	}
+}

--- a/src/control/lib/telemetry/promexp/util.go
+++ b/src/control/lib/telemetry/promexp/util.go
@@ -110,6 +110,28 @@ func (m cvMap) set(name string, value float64, labels labelMap) error {
 	return nil
 }
 
+type hvMap map[string]*daosHistogramVec
+
+func (m hvMap) add(name, help string, labels labelMap, buckets []float64) {
+	if _, found := m[name]; !found {
+		hv := newDaosHistogramVec(prometheus.HistogramOpts{
+			Name:    name,
+			Help:    help,
+			Buckets: buckets,
+		}, labels.keys())
+		m[name] = hv
+	}
+}
+
+func (m hvMap) set(name string, labels labelMap, samples, sum uint64, values []uint64) error {
+	hv, found := m[name]
+	if !found {
+		return errors.Errorf("histogram vector %s not found", name)
+	}
+
+	return hv.With(prometheus.Labels(labels)).AddSample(samples, float64(sum), values)
+}
+
 type metricStat struct {
 	name      string
 	desc      string

--- a/src/control/lib/telemetry/snapshot.go
+++ b/src/control/lib/telemetry/snapshot.go
@@ -25,6 +25,8 @@ import (
 	"time"
 )
 
+var _ Metric = (*Snapshot)(nil)
+
 type Snapshot struct {
 	metricBase
 }

--- a/src/control/lib/telemetry/timestamp.go
+++ b/src/control/lib/telemetry/timestamp.go
@@ -25,6 +25,8 @@ import (
 	"time"
 )
 
+var _ Metric = (*Timestamp)(nil)
+
 type Timestamp struct {
 	metricBase
 }

--- a/src/include/gurt/telemetry_common.h
+++ b/src/include/gurt/telemetry_common.h
@@ -205,9 +205,10 @@ struct d_tm_bucket_t {
 
 struct d_tm_histogram_t {
 	struct d_tm_bucket_t	*dth_buckets;
-	int			dth_num_buckets;
-	int			dth_initial_width;
-	int			dth_value_multiplier;
+	bool                     dth_fast_bucketing;
+	int                      dth_num_buckets;
+	int                      dth_initial_width;
+	int                      dth_value_multiplier;
 };
 
 struct d_tm_meminfo_t {

--- a/src/include/gurt/telemetry_producer.h
+++ b/src/include/gurt/telemetry_producer.h
@@ -25,8 +25,9 @@ void d_tm_dec_gauge(struct d_tm_node_t *metric, uint64_t value);
 int d_tm_init(int id, uint64_t mem_size, int flags);
 int
     d_tm_init_with_name(int id, uint64_t mem_size, int flags, const char *root_name);
-int d_tm_init_histogram(struct d_tm_node_t *node, char *path, int num_buckets,
-			int initial_width, int multiplier);
+int
+    d_tm_init_histogram(struct d_tm_node_t *node, char *path, int num_buckets, int initial_width,
+			int multiplier, const char *unit);
 int d_tm_add_metric(struct d_tm_node_t **node, int metric_type, char *desc,
 		    char *units, const char *fmt, ...);
 int d_tm_add_ephemeral_dir(struct d_tm_node_t **node, size_t size_bytes,


### PR DESCRIPTION
Update the Prometheus exporter to support passthrough histograms
from native DAOS telemetry format. Fixes a few bugs and inefficiencies
in the native histogram implementation.