### PR TITLE
DAOS-6632 object: refine oclass and num grp settings for auto class selection

### DIFF
--- a/src/include/daos_obj.h
+++ b/src/include/daos_obj.h
@@ -364,7 +364,9 @@ enum {
 	DAOS_OCH_RDD_RP		= (1 << 2),	/** Replication */
 	DAOS_OCH_RDD_EC		= (1 << 3),	/** Erasure Code */
 	/** Flags to control OC Sharding */
-	DAOS_OCH_SHD_DEF	= (1 << 4),	/** Default - use MAX */
+	DAOS_OCH_SHD_DEF	= (1 << 4),	/** Default: Use MAX for array &
+						 * flat KV; 1 grp for others.
+						 */
 	DAOS_OCH_SHD_TINY	= (1 << 5),	/** <= 4 grps */
 	DAOS_OCH_SHD_REG	= (1 << 6),	/** max(128, 25%) */
 	DAOS_OCH_SHD_HI		= (1 << 7),	/** max(256, 50%) */

--- a/src/object/obj_class.c
+++ b/src/object/obj_class.c
@@ -211,36 +211,57 @@ dc_set_oclass(daos_handle_t coh, int domain_nr, int target_nr,
 	/** first set a reasonable default based on RF & RDD hint (if set) */
 	switch (rf_factor) {
 	case DAOS_PROP_CO_REDUN_RF0:
-		if (rdd == DAOS_OCH_RDD_RP)
+		if (rdd == DAOS_OCH_RDD_RP) {
 			cid = OC_RP_2GX;
-		else if (rdd == DAOS_OCH_RDD_EC)
-			cid = OC_EC_2P1G1;
-		else
+		} else if (rdd == DAOS_OCH_RDD_EC) {
+			if (domain_nr >= 10)
+				cid = OC_EC_8P1GX;
+			else if (domain_nr >= 6)
+				cid = OC_EC_4P1GX;
+			else
+				cid = OC_EC_2P1GX;
+		} else {
 			cid = OC_SX;
+		}
 		break;
 	case DAOS_PROP_CO_REDUN_RF1:
-		if (rdd == DAOS_OCH_RDD_EC)
-			cid = OC_EC_2P1G1;
-		else
+		if (rdd == DAOS_OCH_RDD_EC) {
+			if (domain_nr >= 10)
+				cid = OC_EC_8P1GX;
+			else if (domain_nr >= 6)
+				cid = OC_EC_4P1GX;
+			else
+				cid = OC_EC_2P1GX;
+		} else {
 			cid = OC_RP_2GX;
+		}
 		break;
 	case DAOS_PROP_CO_REDUN_RF2:
-		if (rdd == DAOS_OCH_RDD_EC)
-			cid = OC_EC_2P2G1;
-		else
+		if (rdd == DAOS_OCH_RDD_EC) {
+			if (domain_nr >= 10)
+				cid = OC_EC_8P2GX;
+			else if (domain_nr >= 6)
+				cid = OC_EC_4P2GX;
+			else
+				cid = OC_EC_2P2GX;
+		} else {
 			cid = OC_RP_3GX;
+		}
 		break;
 	case DAOS_PROP_CO_REDUN_RF3:
+		/** EC not supported here */
+		cid = OC_RP_4GX;
+		break;
 	case DAOS_PROP_CO_REDUN_RF4:
-		return -DER_INVAL;
+		/** EC not supported here */
+		cid = OC_RP_6GX;
+		break;
 	}
 
 	/*
 	 * If there are no sharding hints, we can return.
-	 * TODO - since all EC classes are only G1, no need to check sharding.
-	 * hint for that.
 	 */
-	if (shd == 0 || cid == OC_EC_2P2G1 || cid == OC_EC_2P1G1) {
+	if (shd == 0) {
 		oc = oclass_fit_max(cid, domain_nr, target_nr);
 		if (oc)
 			*oc_id_p = oc->oc_id;

--- a/src/object/obj_class.c
+++ b/src/object/obj_class.c
@@ -258,16 +258,7 @@ dc_set_oclass(daos_handle_t coh, int domain_nr, int target_nr,
 		break;
 	}
 
-	/*
-	 * If there are no sharding hints, we can return.
-	 */
-	if (shd == 0) {
-		oc = oclass_fit_max(cid, domain_nr, target_nr);
-		if (oc)
-			*oc_id_p = oc->oc_id;
-
-		return oc ? 0 : -DER_NONEXIST;
-	}
+	/** we have determined the resilience part, now set the grp size */
 
 	oc = oclass_ident2cl(cid);
 	if (!oc)
@@ -278,7 +269,14 @@ dc_set_oclass(daos_handle_t coh, int domain_nr, int target_nr,
 
 	/** adjust the group size based on the sharding hint */
 	switch (shd) {
+	case 0:
 	case DAOS_OCH_SHD_DEF:
+		if (ofeats & DAOS_OF_ARRAY || ofeats & DAOS_OF_ARRAY_BYTE ||
+		    ofeats & DAOS_OF_KV_FLAT)
+			ca.ca_grp_nr = DAOS_OBJ_GRP_MAX;
+		else
+			ca.ca_grp_nr = 1;
+		break;
 	case DAOS_OCH_SHD_MAX:
 		ca.ca_grp_nr = DAOS_OBJ_GRP_MAX;
 		break;

--- a/src/tests/suite/daos_obj.c
+++ b/src/tests/suite/daos_obj.c
@@ -14,6 +14,7 @@
 #include "daos_iotest.h"
 #include <daos_types.h>
 #include <daos/checksum.h>
+#include <daos/placement.h>
 
 int dts_obj_class	= OC_RP_2G1;
 int dts_obj_replica_cnt	= 2;
@@ -4142,8 +4143,9 @@ compare_oclass(daos_handle_t coh, daos_obj_id_t oid, daos_oclass_id_t ecid)
 }
 
 static int
-check_oclass(daos_handle_t coh, daos_oclass_hints_t hints, daos_ofeat_t feats,
-	     enum daos_obj_resil res, unsigned int nr, daos_oclass_id_t ecid)
+check_oclass(daos_handle_t coh, int domain_nr, daos_oclass_hints_t hints,
+	     daos_ofeat_t feats, enum daos_obj_resil res, unsigned int nr,
+	     daos_oclass_id_t ecid)
 {
 	daos_obj_id_t		oid;
 	daos_oclass_id_t        cid;
@@ -4166,13 +4168,21 @@ check_oclass(daos_handle_t coh, daos_oclass_hints_t hints, daos_ofeat_t feats,
 		assert_int_equal(attr->u.rp.r_num, nr);
 	} else if (res == DAOS_RES_EC) {
 		assert_int_equal(attr->u.ec.e_p, nr - 1);
-		assert_int_equal(attr->u.ec.e_k, 2);
+		if (domain_nr >= 10)
+			assert_int_equal(attr->u.ec.e_k, 8);
+		else if (domain_nr >= 6)
+			assert_int_equal(attr->u.ec.e_k, 4);
+		else
+			assert_int_equal(attr->u.ec.e_k, 2);
 	}
 
 	/** need an easier way to determine grp nr. for now use fit for GX */
 	rc = compare_oclass(coh, oid, ecid);
 	if (rc) {
-		fail_msg("Mismatch oclass %d vs %d\n", cid, OC_RP_2GX);
+		char ename[10];
+
+		daos_oclass_id2name(ecid, ename);
+		fail_msg("Mismatch oclass %s vs %s\n", name, ename);
 		rc = -DER_MISMATCH;
 	}
 
@@ -4187,12 +4197,25 @@ oclass_auto_setting(void **state)
 	uuid_t			uuid;
 	daos_handle_t		coh;
 	daos_pool_info_t	info = {0};
+	struct pl_map_attr	attr;
+	daos_oclass_id_t	ecid;
 	daos_prop_t             *prop = NULL;
 	daos_ofeat_t		feat_kv, feat_array, feat_byte_array;
 	int			rc;
 
 	rc = daos_pool_query(arg->pool.poh, NULL, &info, NULL, NULL);
 	assert_rc_equal(rc, 0);
+
+	rc = pl_map_query(arg->pool.pool_uuid, &attr);
+	assert_rc_equal(rc, 0);
+
+	/** set the expect EC object class ID based on domain nr */
+	if (attr.pa_domain_nr >= 10)
+		ecid = OC_EC_8P1GX;
+	else if (attr.pa_domain_nr >= 6)
+		ecid = OC_EC_4P1GX;
+	else
+		ecid = OC_EC_2P1GX;
 
 	feat_array = DAOS_OF_DKEY_UINT64 | DAOS_OF_KV_FLAT | DAOS_OF_ARRAY;
 	feat_byte_array = DAOS_OF_DKEY_UINT64 | DAOS_OF_KV_FLAT |
@@ -4214,36 +4237,42 @@ oclass_auto_setting(void **state)
 
 	/** ALL oids by default should use OC_SX fit to current DAOS system */
 	print_message("DEFAULT oid class:\t");
-	rc = check_oclass(coh, 0, 0, DAOS_RES_REPL, 1, OC_SX);
+	rc = check_oclass(coh, attr.pa_domain_nr, 0, 0,
+			  DAOS_RES_REPL, 1, OC_SX);
 	assert_rc_equal(rc, 0);
 
 	print_message("KV oid class:\t");
-	rc = check_oclass(coh, 0, feat_kv, DAOS_RES_REPL, 1, OC_SX);
+	rc = check_oclass(coh, attr.pa_domain_nr, 0, feat_kv,
+			  DAOS_RES_REPL, 1, OC_SX);
 	assert_rc_equal(rc, 0);
 
 	print_message("ARRAY oid class:\t");
-	rc = check_oclass(coh, 0, feat_array, DAOS_RES_REPL, 1, OC_SX);
+	rc = check_oclass(coh, attr.pa_domain_nr, 0, feat_array,
+			  DAOS_RES_REPL, 1, OC_SX);
 	assert_rc_equal(rc, 0);
 
 	print_message("BYTE ARRAY oid class:\t");
-	rc = check_oclass(coh, 0, feat_byte_array, DAOS_RES_REPL, 1, OC_SX);
+	rc = check_oclass(coh, attr.pa_domain_nr, 0, feat_byte_array,
+			  DAOS_RES_REPL, 1, OC_SX);
 	assert_rc_equal(rc, 0);
 
 	/** RP hint should use RP_2GX fit to current DAOS system */
 	print_message("oid with DAOS_OCH_RDD_RP hint:\t");
-	rc = check_oclass(coh, DAOS_OCH_RDD_RP, 0, DAOS_RES_REPL, 2, OC_RP_2GX);
+	rc = check_oclass(coh, attr.pa_domain_nr, DAOS_OCH_RDD_RP, 0,
+			  DAOS_RES_REPL, 2, OC_RP_2GX);
 	assert_rc_equal(rc, 0);
 
-	/** EC hint should use OC_EC_2P1G1 */
-	print_message("KC oid with DAOS_OCH_RDD_EC hint:\t");
-	rc = check_oclass(coh, DAOS_OCH_RDD_EC, feat_kv, DAOS_RES_EC, 2,
-			  OC_EC_2P1G1);
+	/** EC hint should use OC_EC_NP1GX */
+	print_message("KV oid with DAOS_OCH_RDD_EC hint:\t");
+	rc = check_oclass(coh, attr.pa_domain_nr, DAOS_OCH_RDD_EC, feat_kv,
+			  DAOS_RES_EC, 2, ecid);
 	assert_rc_equal(rc, 0);
 
 	/** RP hint with Tiny sharding should use RP_2G4 */
 	print_message("oid with DAOS_OCH_RDD_RP | DAOS_OCH_SHD_TINY hint:\t");
-	rc = check_oclass(coh, DAOS_OCH_RDD_RP | DAOS_OCH_SHD_TINY,
-			  feat_byte_array, DAOS_RES_REPL, 2, OC_RP_2G4);
+	rc = check_oclass(coh, attr.pa_domain_nr,
+			  DAOS_OCH_RDD_RP | DAOS_OCH_SHD_TINY, feat_byte_array,
+			  DAOS_RES_REPL, 2, OC_RP_2G4);
 	assert_rc_equal(rc, 0);
 
 	rc = daos_cont_close(coh, NULL);
@@ -4263,22 +4292,26 @@ oclass_auto_setting(void **state)
 
 	/** default oid should be OC_RP_2GX fit to daos system*/
 	print_message("DEFAULT oid class:\t");
-	rc = check_oclass(coh, 0, 0, DAOS_RES_REPL, 2, OC_RP_2GX);
+	rc = check_oclass(coh, attr.pa_domain_nr, 0, 0,
+			  DAOS_RES_REPL, 2, OC_RP_2GX);
 	assert_rc_equal(rc, 0);
 
 	/** KV oid should be OC_RP_2GX fit to daos system */
 	print_message("KV oid class:\t");
-	rc = check_oclass(coh, 0, feat_kv, DAOS_RES_REPL, 2, OC_RP_2GX);
+	rc = check_oclass(coh, attr.pa_domain_nr, 0, feat_kv,
+			  DAOS_RES_REPL, 2, OC_RP_2GX);
 	assert_rc_equal(rc, 0);
 
 	/** ARRAY oid should be OC_RP_2GX fit to daos system */
 	print_message("ARRAY oid class:\t");
-	rc = check_oclass(coh, 0, feat_array, DAOS_RES_REPL, 2, OC_RP_2GX);
+	rc = check_oclass(coh, attr.pa_domain_nr, 0, feat_array,
+			  DAOS_RES_REPL, 2, OC_RP_2GX);
 	assert_rc_equal(rc, 0);
 
 	/** Byte Array oid should be OC_RP_2GX fit to daos system */
 	print_message("BYTE ARRAY oid class:\t");
-	rc = check_oclass(coh, 0, feat_byte_array, DAOS_RES_REPL, 2, OC_RP_2GX);
+	rc = check_oclass(coh, attr.pa_domain_nr, 0, feat_byte_array,
+			  DAOS_RES_REPL, 2, OC_RP_2GX);
 	assert_rc_equal(rc, 0);
 
 	rc = daos_cont_close(coh, NULL);
@@ -4287,7 +4320,7 @@ oclass_auto_setting(void **state)
 	assert_rc_equal(rc, 0);
 
 	print_message("OID settings with container RF2:\n");
-	/** create container with rf = 1 */
+	/** create container with rf = 2 */
 	prop->dpp_entries[0].dpe_type = DAOS_PROP_CO_REDUN_FAC;
 	prop->dpp_entries[0].dpe_val = DAOS_PROP_CO_REDUN_RF2;
 	uuid_generate(uuid);
@@ -4296,24 +4329,36 @@ oclass_auto_setting(void **state)
 	rc = daos_cont_open(arg->pool.poh, uuid, DAOS_COO_RW, &coh, NULL, NULL);
 	assert_rc_equal(rc, 0);
 
+	/** adjust the expected EC object class ID based on domain nr */
+	if (attr.pa_domain_nr >= 10)
+		ecid = OC_EC_8P2GX;
+	else if (attr.pa_domain_nr >= 6)
+		ecid = OC_EC_4P2GX;
+	else
+		ecid = OC_EC_2P2GX;
+
 	/** default oid should be OC_RP_3GX fit to daos system*/
 	print_message("DEFAULT oid class:\t");
-	rc = check_oclass(coh, 0, 0, DAOS_RES_REPL, 3, OC_RP_3GX);
+	rc = check_oclass(coh, attr.pa_domain_nr, 0, 0,
+			  DAOS_RES_REPL, 3, OC_RP_3GX);
 	assert_rc_equal(rc, 0);
 
 	/** KV oid should be OC_RP_3GX fit to daos system */
 	print_message("KV oid class:\t");
-	rc = check_oclass(coh, 0, feat_kv, DAOS_RES_REPL, 3, OC_RP_3GX);
+	rc = check_oclass(coh, attr.pa_domain_nr, 0, feat_kv,
+			  DAOS_RES_REPL, 3, OC_RP_3GX);
 	assert_rc_equal(rc, 0);
 
 	/** ARRAY oid should be OC_RP_3GX fit to daos system */
 	print_message("ARRAY oid class:\t");
-	rc = check_oclass(coh, 0, feat_array, DAOS_RES_REPL, 3, OC_RP_3GX);
+	rc = check_oclass(coh, attr.pa_domain_nr, 0, feat_array,
+			  DAOS_RES_REPL, 3, OC_RP_3GX);
 	assert_rc_equal(rc, 0);
 
 	/** Byte Array oid should be OC_RP_3GX fit to daos system */
 	print_message("BYTE ARRAY oid class:\t");
-	rc = check_oclass(coh, 0, feat_byte_array, DAOS_RES_REPL, 3, OC_RP_3GX);
+	rc = check_oclass(coh, attr.pa_domain_nr, 0, feat_byte_array,
+			  DAOS_RES_REPL, 3, OC_RP_3GX);
 	assert_rc_equal(rc, 0);
 
 	rc = daos_cont_close(coh, NULL);

--- a/src/tests/suite/daos_obj.c
+++ b/src/tests/suite/daos_obj.c
@@ -4198,7 +4198,7 @@ oclass_auto_setting(void **state)
 	daos_handle_t		coh;
 	daos_pool_info_t	info = {0};
 	struct pl_map_attr	attr;
-	daos_oclass_id_t	ecid;
+	daos_oclass_id_t	ecidx, ecid1;
 	daos_prop_t             *prop = NULL;
 	daos_ofeat_t		feat_kv, feat_array, feat_byte_array;
 	int			rc;
@@ -4210,12 +4210,16 @@ oclass_auto_setting(void **state)
 	assert_rc_equal(rc, 0);
 
 	/** set the expect EC object class ID based on domain nr */
-	if (attr.pa_domain_nr >= 10)
-		ecid = OC_EC_8P1GX;
-	else if (attr.pa_domain_nr >= 6)
-		ecid = OC_EC_4P1GX;
-	else
-		ecid = OC_EC_2P1GX;
+	if (attr.pa_domain_nr >= 10) {
+		ecidx = OC_EC_8P1GX;
+		ecid1 = OC_EC_8P1G1;
+	} else if (attr.pa_domain_nr >= 6) {
+		ecidx = OC_EC_4P1GX;
+		ecid1 = OC_EC_4P1G1;
+	} else {
+		ecidx = OC_EC_2P1GX;
+		ecid1 = OC_EC_2P1G1;
+	}
 
 	feat_array = DAOS_OF_DKEY_UINT64 | DAOS_OF_KV_FLAT | DAOS_OF_ARRAY;
 	feat_byte_array = DAOS_OF_DKEY_UINT64 | DAOS_OF_KV_FLAT |
@@ -4235,17 +4239,19 @@ oclass_auto_setting(void **state)
 	rc = daos_cont_open(arg->pool.poh, uuid, DAOS_COO_RW, &coh, NULL, NULL);
 	assert_rc_equal(rc, 0);
 
-	/** ALL oids by default should use OC_SX fit to current DAOS system */
+	/** ALL oids by default will use OC_S1. */
 	print_message("DEFAULT oid class:\t");
 	rc = check_oclass(coh, attr.pa_domain_nr, 0, 0,
-			  DAOS_RES_REPL, 1, OC_SX);
+			  DAOS_RES_REPL, 1, OC_S1);
 	assert_rc_equal(rc, 0);
 
+	/** KV object will select SX */
 	print_message("KV oid class:\t");
 	rc = check_oclass(coh, attr.pa_domain_nr, 0, feat_kv,
 			  DAOS_RES_REPL, 1, OC_SX);
 	assert_rc_equal(rc, 0);
 
+	/** Array object will select SX */
 	print_message("ARRAY oid class:\t");
 	rc = check_oclass(coh, attr.pa_domain_nr, 0, feat_array,
 			  DAOS_RES_REPL, 1, OC_SX);
@@ -4256,16 +4262,33 @@ oclass_auto_setting(void **state)
 			  DAOS_RES_REPL, 1, OC_SX);
 	assert_rc_equal(rc, 0);
 
-	/** RP hint should use RP_2GX fit to current DAOS system */
 	print_message("oid with DAOS_OCH_RDD_RP hint:\t");
 	rc = check_oclass(coh, attr.pa_domain_nr, DAOS_OCH_RDD_RP, 0,
+			  DAOS_RES_REPL, 2, OC_RP_2G1);
+	assert_rc_equal(rc, 0);
+
+	/** KV object with EC hint should use OC_EC_NP1GX */
+	print_message("KV oid with DAOS_OCH_RDD_EC hint:\t");
+	rc = check_oclass(coh, attr.pa_domain_nr, DAOS_OCH_RDD_EC, feat_kv,
+			  DAOS_RES_EC, 2, ecidx);
+	assert_rc_equal(rc, 0);
+
+	/** KV object with REPL hint should use OC_RP_GX */
+	print_message("KV oid with DAOS_OCH_RDD_RP hint:\t");
+	rc = check_oclass(coh, attr.pa_domain_nr, DAOS_OCH_RDD_RP, feat_kv,
 			  DAOS_RES_REPL, 2, OC_RP_2GX);
 	assert_rc_equal(rc, 0);
 
-	/** EC hint should use OC_EC_NP1GX */
-	print_message("KV oid with DAOS_OCH_RDD_EC hint:\t");
-	rc = check_oclass(coh, attr.pa_domain_nr, DAOS_OCH_RDD_EC, feat_kv,
-			  DAOS_RES_EC, 2, ecid);
+	/** object with EC hint should use OC_EC_NP1G1 */
+	print_message("oid with DAOS_OCH_RDD_EC hint:\t");
+	rc = check_oclass(coh, attr.pa_domain_nr, DAOS_OCH_RDD_EC, 0,
+			  DAOS_RES_EC, 2, ecid1);
+	assert_rc_equal(rc, 0);
+
+	/** object with REPL hint should use OC_RP_G1 */
+	print_message("oid with DAOS_OCH_RDD_RP hint:\t");
+	rc = check_oclass(coh, attr.pa_domain_nr, DAOS_OCH_RDD_RP, 0,
+			  DAOS_RES_REPL, 2, OC_RP_2G1);
 	assert_rc_equal(rc, 0);
 
 	/** RP hint with Tiny sharding should use RP_2G4 */
@@ -4280,7 +4303,7 @@ oclass_auto_setting(void **state)
 	rc = daos_cont_destroy(arg->pool.poh, uuid, 0, NULL);
 	assert_rc_equal(rc, 0);
 
-	print_message("OID settings with container RF1:\n");
+	print_message("\nOID settings with container RF1:\n");
 	/** create container with rf = 1 */
 	prop->dpp_entries[0].dpe_type = DAOS_PROP_CO_REDUN_FAC;
 	prop->dpp_entries[0].dpe_val = DAOS_PROP_CO_REDUN_RF1;
@@ -4290,10 +4313,16 @@ oclass_auto_setting(void **state)
 	rc = daos_cont_open(arg->pool.poh, uuid, DAOS_COO_RW, &coh, NULL, NULL);
 	assert_rc_equal(rc, 0);
 
-	/** default oid should be OC_RP_2GX fit to daos system*/
+	/** default oid should be OC_RP_2G1 */
 	print_message("DEFAULT oid class:\t");
 	rc = check_oclass(coh, attr.pa_domain_nr, 0, 0,
-			  DAOS_RES_REPL, 2, OC_RP_2GX);
+			  DAOS_RES_REPL, 2, OC_RP_2G1);
+	assert_rc_equal(rc, 0);
+
+	/** oid with EC hint should be OC_EC_NP1G1 */
+	print_message("oid with EC hint class:\t");
+	rc = check_oclass(coh, attr.pa_domain_nr, DAOS_OCH_RDD_EC, 0,
+			  DAOS_RES_EC, 2, ecid1);
 	assert_rc_equal(rc, 0);
 
 	/** KV oid should be OC_RP_2GX fit to daos system */
@@ -4314,12 +4343,17 @@ oclass_auto_setting(void **state)
 			  DAOS_RES_REPL, 2, OC_RP_2GX);
 	assert_rc_equal(rc, 0);
 
+	print_message("KV oid with DAOS_OCH_RDD_EC hint:\t");
+	rc = check_oclass(coh, attr.pa_domain_nr, DAOS_OCH_RDD_EC, feat_kv,
+			  DAOS_RES_EC, 2, ecidx);
+	assert_rc_equal(rc, 0);
+
 	rc = daos_cont_close(coh, NULL);
 	assert_rc_equal(rc, 0);
 	rc = daos_cont_destroy(arg->pool.poh, uuid, 0, NULL);
 	assert_rc_equal(rc, 0);
 
-	print_message("OID settings with container RF2:\n");
+	print_message("\nOID settings with container RF2:\n");
 	/** create container with rf = 2 */
 	prop->dpp_entries[0].dpe_type = DAOS_PROP_CO_REDUN_FAC;
 	prop->dpp_entries[0].dpe_val = DAOS_PROP_CO_REDUN_RF2;
@@ -4330,17 +4364,21 @@ oclass_auto_setting(void **state)
 	assert_rc_equal(rc, 0);
 
 	/** adjust the expected EC object class ID based on domain nr */
-	if (attr.pa_domain_nr >= 10)
-		ecid = OC_EC_8P2GX;
-	else if (attr.pa_domain_nr >= 6)
-		ecid = OC_EC_4P2GX;
-	else
-		ecid = OC_EC_2P2GX;
+	if (attr.pa_domain_nr >= 10) {
+		ecidx = OC_EC_8P2GX;
+		ecid1 = OC_EC_8P2G1;
+	} else if (attr.pa_domain_nr >= 6) {
+		ecidx = OC_EC_4P2GX;
+		ecid1 = OC_EC_4P2G1;
+	} else {
+		ecidx = OC_EC_2P2GX;
+		ecid1 = OC_EC_2P2G1;
+	}
 
-	/** default oid should be OC_RP_3GX fit to daos system*/
+	/** default oid should be OC_RP_3G1 */
 	print_message("DEFAULT oid class:\t");
 	rc = check_oclass(coh, attr.pa_domain_nr, 0, 0,
-			  DAOS_RES_REPL, 3, OC_RP_3GX);
+			  DAOS_RES_REPL, 3, OC_RP_3G1);
 	assert_rc_equal(rc, 0);
 
 	/** KV oid should be OC_RP_3GX fit to daos system */
@@ -4355,16 +4393,78 @@ oclass_auto_setting(void **state)
 			  DAOS_RES_REPL, 3, OC_RP_3GX);
 	assert_rc_equal(rc, 0);
 
+	/** oid with EC hint should be OC_EC_NP2G1 */
+	print_message("oid with hint class:\t");
+	rc = check_oclass(coh, attr.pa_domain_nr, DAOS_OCH_RDD_EC, 0,
+			  DAOS_RES_EC, 3, ecid1);
+	assert_rc_equal(rc, 0);
+
 	/** Byte Array oid should be OC_RP_3GX fit to daos system */
 	print_message("BYTE ARRAY oid class:\t");
 	rc = check_oclass(coh, attr.pa_domain_nr, 0, feat_byte_array,
 			  DAOS_RES_REPL, 3, OC_RP_3GX);
 	assert_rc_equal(rc, 0);
 
+	print_message("KV oid with DAOS_OCH_RDD_EC hint:\t");
+	rc = check_oclass(coh, attr.pa_domain_nr, DAOS_OCH_RDD_EC, feat_kv,
+			  DAOS_RES_EC, 3, ecidx);
+	assert_rc_equal(rc, 0);
+
 	rc = daos_cont_close(coh, NULL);
 	assert_rc_equal(rc, 0);
 	rc = daos_cont_destroy(arg->pool.poh, uuid, 0, NULL);
 	assert_rc_equal(rc, 0);
+
+	print_message("\nOID settings with container RF3:\n");
+	/** create container with rf = 3 */
+	prop->dpp_entries[0].dpe_type = DAOS_PROP_CO_REDUN_FAC;
+	prop->dpp_entries[0].dpe_val = DAOS_PROP_CO_REDUN_RF3;
+	uuid_generate(uuid);
+	rc = daos_cont_create(arg->pool.poh, uuid, prop, NULL);
+	assert_rc_equal(rc, 0);
+	rc = daos_cont_open(arg->pool.poh, uuid, DAOS_COO_RW, &coh, NULL, NULL);
+	assert_rc_equal(rc, 0);
+
+	/** default oid should be OC_RP_4G1 */
+	print_message("DEFAULT oid class:\t");
+	rc = check_oclass(coh, attr.pa_domain_nr, 0, 0,
+			  DAOS_RES_REPL, 4, OC_RP_4G1);
+	assert_rc_equal(rc, 0);
+
+	/** KV oid should be OC_RP_4GX fit to current DAOS system */
+	print_message("KV oid class:\t");
+	rc = check_oclass(coh, attr.pa_domain_nr, 0, feat_kv,
+			  DAOS_RES_REPL, 4, OC_RP_4GX);
+	assert_rc_equal(rc, 0);
+
+	/** oid with EC hint should still be OC_RP_4GX */
+	print_message("oid with EC hint class:\t");
+	rc = check_oclass(coh, attr.pa_domain_nr, DAOS_OCH_RDD_EC, 0,
+			  DAOS_RES_REPL, 4, OC_RP_4G1);
+	assert_rc_equal(rc, 0);
+
+	/** ARRAY oid should be OC_RP_4GX */
+	print_message("ARRAY oid class:\t");
+	rc = check_oclass(coh, attr.pa_domain_nr, 0, feat_array,
+			  DAOS_RES_REPL, 4, OC_RP_4GX);
+	assert_rc_equal(rc, 0);
+
+	/** Byte Array oid should be OC_RP_4GX */
+	print_message("BYTE ARRAY oid class:\t");
+	rc = check_oclass(coh, attr.pa_domain_nr, 0, feat_byte_array,
+			  DAOS_RES_REPL, 4, OC_RP_4GX);
+	assert_rc_equal(rc, 0);
+
+	print_message("KV oid with DAOS_OCH_RDD_EC hint:\t");
+	rc = check_oclass(coh, attr.pa_domain_nr, DAOS_OCH_RDD_EC, feat_kv,
+			  DAOS_RES_REPL, 4, OC_RP_4GX);
+	assert_rc_equal(rc, 0);
+
+	rc = daos_cont_close(coh, NULL);
+	assert_rc_equal(rc, 0);
+	rc = daos_cont_destroy(arg->pool.poh, uuid, 0, NULL);
+	assert_rc_equal(rc, 0);
+
 }
 
 static const struct CMUnitTest io_tests[] = {


### PR DESCRIPTION
- more EC object classes were added, so extend the auto object class
  selection to take advantage of that (only when EC hint is explicitly specified).
- also consider the domain_nr for selecting the EC data cell num
- For group number, G1 is used by default; unless user sets array or flat KV feat type, use GX
- add some more test cases