### PR TITLE
DAOS-7205 DFS: use auto object class selection

### DIFF
--- a/src/client/dfs/README.md
+++ b/src/client/dfs/README.md
@@ -14,15 +14,17 @@ container handle where the namespace will be located.
 When the file system is created (i.e. when the DAOS container is initialized as
 an encapsulated namespace), a reserved object (with a predefined object ID) will
 be added to the container and will record superblock (SB) information about the
-namespace. The SB object is replicated with object class `OC_RP_XSF`, and has the
-reserved OID 0.0.
+namespace. The SB object has the reserved OID 0.0. The object class is
+determined either through the oclass parameter passed to container creation or
+through automatic selection based on container properties such as the redundancy
+factor.
 
 The SB object contains an entry with a magic value to indicate it is a POSIX
 filesystem. The SB object will contain also an entry to the root directory of
 the filesystem, which will be another reserved object with a predefined OID
-(1.0), replicated with object class `OC_RP_XSF`, and will have the same
-representation as a directory (see next section). The OID of the root id will be
-inserted as an entry in the superblock object.
+(1.0) and will have the same representation as a directory (see next
+section). The OID of the root id will be inserted as an entry in the superblock
+object.
 
 The SB will look like this:
 

--- a/src/client/dfs/dfs.c
+++ b/src/client/dfs/dfs.c
@@ -1220,7 +1220,7 @@ dfs_cont_create(daos_handle_t poh, uuid_t co_uuid, dfs_attr_t *attr,
 	rc = daos_obj_generate_oid_by_rf(poh, rf_factor, &roots.cr_oids[0],
 					 0, dattr.da_oclass_id, 0, 0);
 	if (rc) {
-		D_ERROR("Failed to generate DB OID "DF_RC"\n", DP_RC(rc));
+		D_ERROR("Failed to generate SB OID "DF_RC"\n", DP_RC(rc));
 		return daos_der2errno(rc);
 	}
 
@@ -1230,7 +1230,7 @@ dfs_cont_create(daos_handle_t poh, uuid_t co_uuid, dfs_attr_t *attr,
 	rc = daos_obj_generate_oid_by_rf(poh, rf_factor, &roots.cr_oids[1],
 					 0, dattr.da_oclass_id, 0, 0);
 	if (rc) {
-		D_ERROR("Failed to generate DB OID "DF_RC"\n", DP_RC(rc));
+		D_ERROR("Failed to generate ROOT OID "DF_RC"\n", DP_RC(rc));
 		return daos_der2errno(rc);
 	}
 

--- a/src/client/dfs/dfs.c
+++ b/src/client/dfs/dfs.c
@@ -15,6 +15,7 @@
 #include <daos/event.h>
 #include <daos/pool.h>
 #include <daos/container.h>
+#include <daos/cont_props.h>
 #include <daos/array.h>
 #include <daos/object.h>
 #include <daos/placement.h>
@@ -47,8 +48,6 @@
 #define DFS_LAYOUT_VERSION	1
 /** Array object stripe size for regular files */
 #define DFS_DEFAULT_CHUNK_SIZE	1048576
-/** default object class for files & dirs */
-#define DFS_DEFAULT_OBJ_CLASS	OC_SX
 /** Magic value for serializing / deserializing a DFS handle */
 #define DFS_GLOB_MAGIC		0xda05df50
 /** Magic value for serializing / deserializing a DFS object handle */
@@ -298,10 +297,6 @@ oid_gen(dfs_t *dfs, daos_oclass_id_t oclass, bool file, daos_obj_id_t *oid)
 	if (oclass == 0)
 		oclass = dfs->attr.da_oclass_id;
 
-	rc = dfs_oclass_select(dfs->poh, oclass, &oclass);
-	if (rc)
-		return rc;
-
 	D_MUTEX_LOCK(&dfs->lock);
 	/** If we ran out of local OIDs, alloc one from the container */
 	if (dfs->oid.hi >= MAX_OID_HI) {
@@ -326,7 +321,11 @@ oid_gen(dfs_t *dfs, daos_oclass_id_t oclass, bool file, daos_obj_id_t *oid)
 			DAOS_OF_ARRAY_BYTE;
 
 	/** generate the daos object ID (set the DAOS owned bits) */
-	daos_obj_set_oid(oid, feat, oclass, 0);
+	rc = daos_obj_generate_oid(dfs->coh, oid, feat, oclass, 0, 0);
+	if (rc) {
+		D_ERROR("daos_obj_generate_oid() failed "DF_RC"\n", DP_RC(rc));
+		return daos_der2errno(rc);
+	}
 
 	return 0;
 }
@@ -1094,10 +1093,7 @@ open_sb(daos_handle_t coh, bool create, daos_obj_id_t super_oid,
 		else
 			chunk_size = DFS_DEFAULT_CHUNK_SIZE;
 
-		if (attr->da_oclass_id != OC_UNKNOWN)
-			oclass = attr->da_oclass_id;
-		else
-			oclass = DFS_DEFAULT_OBJ_CLASS;
+		oclass = attr->da_oclass_id;
 
 		rc = daos_obj_update(*oh, DAOS_TX_NONE, DAOS_COND_DKEY_INSERT,
 				     &dkey, SB_AKEYS, iods, sgls, NULL);
@@ -1145,8 +1141,7 @@ open_sb(daos_handle_t coh, bool create, daos_obj_id_t super_oid,
 
 	attr->da_chunk_size = (chunk_size) ? chunk_size :
 		DFS_DEFAULT_CHUNK_SIZE;
-	attr->da_oclass_id = (oclass != OC_UNKNOWN) ? oclass :
-		DFS_DEFAULT_OBJ_CLASS;
+	attr->da_oclass_id = oclass;
 
 	return 0;
 err:
@@ -1180,11 +1175,11 @@ dfs_cont_create(daos_handle_t poh, uuid_t co_uuid, dfs_attr_t *attr,
 	daos_handle_t		coh, super_oh;
 	struct dfs_entry	entry = {0};
 	daos_prop_t		*prop = NULL;
+	uint64_t		rf_factor;
 	daos_cont_info_t	co_info;
 	dfs_t			*dfs;
 	dfs_attr_t		dattr;
 	struct daos_prop_co_roots roots;
-	daos_oclass_id_t	oclass;
 	int			rc;
 
 	if (_dfs && _coh == NULL) {
@@ -1209,30 +1204,35 @@ dfs_cont_create(daos_handle_t poh, uuid_t co_uuid, dfs_attr_t *attr,
 			D_GOTO(err_prop, rc);
 		}
 	}
-	if (attr && attr->da_oclass_id != OC_UNKNOWN)
+
+	/** set the oclass id from passed in attr, otherwise use default (0) */
+	if (attr)
 		dattr.da_oclass_id = attr->da_oclass_id;
 	else
-		dattr.da_oclass_id = DFS_DEFAULT_OBJ_CLASS;
+		dattr.da_oclass_id = 0;
+
+	/** check if RF factor is set on property */
+	rf_factor = daos_cont_prop2redunfac(prop);
 
 	/* select oclass and generate SB OID */
-	rc = dfs_oclass_select(poh, OC_RP_XSF, &oclass);
-	if (rc) {
-		rc = daos_der2errno(rc);
-		D_GOTO(err_prop, rc);
-	}
 	roots.cr_oids[0].lo = RESERVED_LO;
 	roots.cr_oids[0].hi = SB_HI;
-	daos_obj_set_oid(&roots.cr_oids[0], 0, oclass, 0);
+	rc = daos_obj_generate_oid_by_rf(poh, rf_factor, &roots.cr_oids[0],
+					 0, dattr.da_oclass_id, 0, 0);
+	if (rc) {
+		D_ERROR("Failed to generate DB OID "DF_RC"\n", DP_RC(rc));
+		return daos_der2errno(rc);
+	}
 
 	/* select oclass and generate ROOT OID */
-	rc = dfs_oclass_select(poh, dattr.da_oclass_id, &oclass);
-	if (rc) {
-		rc = daos_der2errno(rc);
-		D_GOTO(err_prop, rc);
-	}
 	roots.cr_oids[1].lo = RESERVED_LO;
 	roots.cr_oids[1].hi = ROOT_HI;
-	daos_obj_set_oid(&roots.cr_oids[1], 0, oclass, 0);
+	rc = daos_obj_generate_oid_by_rf(poh, rf_factor, &roots.cr_oids[1],
+					 0, dattr.da_oclass_id, 0, 0);
+	if (rc) {
+		D_ERROR("Failed to generate DB OID "DF_RC"\n", DP_RC(rc));
+		return daos_der2errno(rc);
+	}
 
 	/* store SB & root OIDs as container property */
 	roots.cr_oids[2] = roots.cr_oids[3] = DAOS_OBJ_NIL;

--- a/src/include/daos/object.h
+++ b/src/include/daos/object.h
@@ -429,6 +429,11 @@ int daos_iod_copy(daos_iod_t *dst, daos_iod_t *src);
 void daos_iods_free(daos_iod_t *iods, int nr, bool free);
 daos_size_t daos_iods_len(daos_iod_t *iods, int nr);
 
+int daos_obj_generate_oid_by_rf(daos_handle_t poh, uint64_t rf_factor,
+				daos_obj_id_t *oid, daos_ofeat_t ofeats,
+				daos_oclass_id_t cid, daos_oclass_hints_t hints,
+				uint32_t args);
+
 int dc_obj_init(void);
 void dc_obj_fini(void);
 

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -5489,10 +5489,45 @@ daos_obj_generate_oid(daos_handle_t coh, daos_obj_id_t *oid,
 	D_DEBUG(DB_TRACE, "available domain=%d, targets=%d\n",
 		attr.pa_domain_nr, attr.pa_target_nr);
 
-	/** TODO - unsupported for now */
+	if (cid == OC_UNKNOWN) {
+		uint64_t rf_factor;
+
+		rf_factor = dc_cont_hdl2redunfac(coh);
+		rc = dc_set_oclass(rf_factor, attr.pa_domain_nr,
+				   attr.pa_target_nr, ofeats, hints, &cid);
+	} else {
+		rc = daos_oclass_fit_max(cid, attr.pa_domain_nr,
+					 attr.pa_target_nr, &cid);
+	}
+
+	if (rc)
+		return rc;
+
+	daos_obj_set_oid(oid, ofeats, cid, args);
+
+	return rc;
+}
+
+int
+daos_obj_generate_oid_by_rf(daos_handle_t poh, uint64_t rf_factor,
+			    daos_obj_id_t *oid, daos_ofeat_t ofeats,
+			    daos_oclass_id_t cid, daos_oclass_hints_t hints,
+			    uint32_t args)
+{
+	struct dc_pool		*pool;
+	struct pl_map_attr	attr;
+	int			rc;
+
+	pool = dc_hdl2pool(poh);
+	D_ASSERT(pool);
+
+	rc = pl_map_query(pool->dp_pool, &attr);
+	D_ASSERT(rc == 0);
+	dc_pool_put(pool);
+
 	if (cid == OC_UNKNOWN)
-		rc = dc_set_oclass(coh, attr.pa_domain_nr, attr.pa_target_nr,
-				   ofeats, hints, &cid);
+		rc = dc_set_oclass(rf_factor, attr.pa_domain_nr,
+				   attr.pa_target_nr, ofeats, hints, &cid);
 	else
 		rc = daos_oclass_fit_max(cid, attr.pa_domain_nr,
 					 attr.pa_target_nr, &cid);

--- a/src/object/obj_class.c
+++ b/src/object/obj_class.c
@@ -193,18 +193,16 @@ daos_oclass_fit_max(daos_oclass_id_t oc_id, int domain_nr, int target_nr,
 }
 
 int
-dc_set_oclass(daos_handle_t coh, int domain_nr, int target_nr,
+dc_set_oclass(uint64_t rf_factor, int domain_nr, int target_nr,
 	      daos_ofeat_t ofeats, daos_oclass_hints_t hints,
 	      daos_oclass_id_t *oc_id_p)
 {
-	uint64_t		rf_factor;
 	daos_oclass_id_t	cid = 0;
 	struct daos_obj_class	*oc;
 	struct daos_oclass_attr	ca;
 	uint16_t		shd, rdd;
 	int			grp_size;
 
-	rf_factor = dc_cont_hdl2redunfac(coh);
 	rdd = hints & DAOS_OCH_RDD_MASK;
 	shd = hints & DAOS_OCH_SHD_MASK;
 

--- a/src/object/obj_internal.h
+++ b/src/object/obj_internal.h
@@ -451,7 +451,7 @@ struct dc_obj_verify_args {
 };
 
 int
-dc_set_oclass(daos_handle_t coh, int domain_nr, int target_nr,
+dc_set_oclass(uint64_t rf_factor, int domain_nr, int target_nr,
 	      daos_ofeat_t ofeats, daos_oclass_hints_t hints,
 	      daos_oclass_id_t *oc_id_);
 


### PR DESCRIPTION
Remove the SX default object class from DFS and generate oids using
the new API for oid generation. this means that if an oclass is not
specified to the DFS API or the DFS container creation:
- we use the container rf factor property to select the oclass for
  files and dirs.
- dirs use 1 single group for faster iteration / ls; files use MAX
  grps for better read/write BW.

Signed-off-by: Mohamad Chaarawi <mohamad.chaarawi@intel.com>