### PR TITLE
DAOS-6753 test: Reenable skipped test: delete_objects.py (#5171)

### DIFF
--- a/src/tests/ftest/rebuild/delete_objects.py
+++ b/src/tests/ftest/rebuild/delete_objects.py
@@ -18,18 +18,6 @@ class RebuildDeleteObjects(RebuildTestBase):
     :avocado: recursive
     """
 
-    CANCEL_FOR_TICKET = [
-        [
-            "DAOS-6751",
-            "test_method_name", "test_rebuild_delete_records",
-            "record_qty", 1
-        ],
-        [
-            "DAOS-6865",
-            "rank", 4
-        ],
-    ]
-
     def __init__(self, *args, **kwargs):
         """Initialize a RebuildDeleteObjects object."""
         super().__init__(*args, **kwargs)
@@ -90,7 +78,9 @@ class RebuildDeleteObjects(RebuildTestBase):
         Use Cases:
             foo
 
-        :avocado: tags=all,large,full_regression,rebuild,rebuilddeleteobject
+        :avocado: tags=all,full_regression
+        :avocado: tags=large
+        :avocado: tags=rebuild,delete_objects,rebuilddeleteobject
         """
         self.punch_type = "object"
         self.execute_rebuild_test()
@@ -107,7 +97,9 @@ class RebuildDeleteObjects(RebuildTestBase):
         Use Cases:
             foo
 
-        :avocado: tags=all,large,full_regression,rebuild,rebuilddeleterecord
+        :avocado: tags=all,full_regression
+        :avocado: tags=large
+        :avocado: tags=rebuild,delete_objects,rebuilddeleterecord
         """
         self.punch_type = "record"
         self.execute_rebuild_test()

--- a/src/tests/ftest/util/rebuild_test_base.py
+++ b/src/tests/ftest/util/rebuild_test_base.py
@@ -9,6 +9,7 @@ from command_utils_base import ObjectWithParameters, BasicParameter
 
 
 class RebuildTestParams(ObjectWithParameters):
+    # pylint: disable=too-few-public-methods
     """Class for gathering test parameters."""
 
     def __init__(self):

--- a/src/tests/ftest/util/test_utils_container.py
+++ b/src/tests/ftest/util/test_utils_container.py
@@ -221,7 +221,7 @@ class TestContainerData():
                 status = False
                 continue
 
-            expect = "" if record_info["punched"] else record_info["data"]
+            expect = b"" if record_info["punched"] else record_info["data"]
             if actual != expect:
                 self.log.error(
                     "    Error data mismatch (akey=%s, dkey=%s, punched=%s): "


### PR DESCRIPTION
Reenable skipped test: delete_objects.py

Signed-off-by: Maureen Jean <maureen.jean@intel.com>