### PR TITLE
DAOS-7043 engine: switch module unload and iv fini (#5065)

### DIFF
--- a/src/cart/crt_iv.c
+++ b/src/cart/crt_iv.c
@@ -617,7 +617,7 @@ crt_ivns_internal_lookup(struct crt_ivns_id *ivns_id)
 	}
 	D_MUTEX_UNLOCK(&ns_list_lock);
 
-	D_ERROR("Failed to lookup IVNS for %s:%d\n",
+	D_DEBUG(DB_ALL, "Failed to lookup IVNS for %s:%d\n",
 		ivns_id->ii_group_name,
 		ivns_id->ii_nsid);
 
@@ -853,12 +853,11 @@ crt_iv_namespace_destroy(crt_iv_namespace_t ivns,
 			 void *cb_arg)
 {
 	struct crt_ivns_internal	*ivns_internal;
-	int				rc = 0;
 
 	ivns_internal = crt_ivns_internal_get(ivns);
 	if (ivns_internal == NULL) {
-		D_ERROR("Invalid ivns passed\n");
-		D_GOTO(exit, rc = -DER_INVAL);
+		D_DEBUG(DB_ALL, "ivns does not exist\n");
+		return 0;
 	}
 
 	ivns_internal->cii_destroy_cb = destroy_cb;
@@ -866,8 +865,8 @@ crt_iv_namespace_destroy(crt_iv_namespace_t ivns,
 
 	/* addref done in crt_ivns_internal_get() and at attach/create time  */
 	IVNS_DECREF_N(ivns_internal, 2);
-exit:
-	return rc;
+
+	return 0;
 }
 
 /* Return iv_ops based on class_id passed */

--- a/src/engine/init.c
+++ b/src/engine/init.c
@@ -667,8 +667,8 @@ exit_init_state:
 exit_srv_init:
 	dss_srv_fini(true);
 exit_mod_loaded:
-	dss_module_unload_all();
 	ds_iv_fini();
+	dss_module_unload_all();
 	if (dss_mod_facs & DSS_FAC_LOAD_CLI) {
 		daos_fini();
 	} else {
@@ -702,10 +702,10 @@ server_fini(bool force)
 	D_INFO("server_init_state_fini() done\n");
 	dss_srv_fini(force);
 	D_INFO("dss_srv_fini() done\n");
-	dss_module_unload_all();
-	D_INFO("dss_module_unload_all() done\n");
 	ds_iv_fini();
 	D_INFO("ds_iv_fini() done\n");
+	dss_module_unload_all();
+	D_INFO("dss_module_unload_all() done\n");
 	/*
 	 * Client stuff finalization needs be done after all ULTs drained
 	 * in dss_srv_fini().

--- a/src/engine/server_iv.c
+++ b/src/engine/server_iv.c
@@ -853,6 +853,7 @@ ds_iv_fini(void)
 	struct ds_iv_class	*class_tmp;
 
 	d_list_for_each_entry_safe(ns, tmp, &ds_iv_ns_list, iv_ns_link) {
+		d_list_del_init(&ns->iv_ns_link);
 		iv_ns_destroy_internal(ns);
 	}
 


### PR DESCRIPTION
Do IV fini before module unload, because iv_fini will
need some iv class operation, which might be destoryed
during module unload.

Remove some error message in CRT IV, which might be
possible during shutdown process, to satisfy the
NLT checking.

Signed-off-by: Di Wang <di.wang@intel.com>