### PR TITLE
DAOS-7199 rebuild: check if leader change before IV

### DIFF
--- a/src/rebuild/srv.c
+++ b/src/rebuild/srv.c
@@ -498,12 +498,17 @@ static void
 rebuild_leader_status_check(struct ds_pool *pool, uint32_t map_ver, uint32_t op,
 			    struct rebuild_global_pool_tracker *rgt)
 {
-	double		last_print = 0;
-	unsigned int	total;
-	int		rc;
+	double			last_print = 0;
+	unsigned int		total;
 	struct sched_req_attr	attr = { 0 };
+	d_rank_t		myrank;
+	int			rc;
 
 	rc = crt_group_size(pool->sp_group, &total);
+	if (rc)
+		return;
+
+	rc = crt_group_rank(pool->sp_group, &myrank);
 	if (rc)
 		return;
 
@@ -550,7 +555,14 @@ rebuild_leader_status_check(struct ds_pool *pool, uint32_t map_ver, uint32_t op,
 			D_FREE(targets);
 		}
 
+		if (myrank != pool->sp_iv_ns->iv_master_rank &&
+		    pool->sp_iv_ns->iv_master_rank != -1)
+			D_DEBUG(DB_REBUILD, DF_UUID" leader is being changed"
+				" %u->%u.\n", DP_UUID(pool->sp_uuid), myrank,
+				pool->sp_iv_ns->iv_master_rank);
+
 		if (!rgt->rgt_abort &&
+		    myrank == pool->sp_iv_ns->iv_master_rank &&
 		    ((!is_rebuild_global_pull_done(rgt) &&
 		      is_rebuild_global_scan_done(rgt)) ||
 		      !rgt->rgt_notify_stable_epoch)) {
@@ -1264,6 +1276,21 @@ iv_stop:
 	 * rebuild.
 	 */
 	if (rgt->rgt_init_scan) {
+		d_rank_t	myrank;
+		int		ret;
+
+		ret = crt_group_rank(pool->sp_group, &myrank);
+		D_ASSERT(ret == 0);
+		if (myrank != pool->sp_iv_ns->iv_master_rank) {
+			/* If master has been changed, then let's skip
+			 * iv sync, and the new leader will take over
+			 * the rebuild process anyway.
+			 */
+			D_DEBUG(DB_REBUILD, "rank %u != master %u\n",
+				myrank, pool->sp_iv_ns->iv_master_rank);
+			D_GOTO(try_reschedule, rc);
+		}
+
 		uuid_copy(iv.riv_pool_uuid, task->dst_pool_uuid);
 		iv.riv_master_rank	= pool->sp_iv_ns->iv_master_rank;
 		iv.riv_ver		= rgt->rgt_rebuild_ver;


### PR DESCRIPTION
Check if the leader has been changed before IV sync,
otherwise it will confuse cart IV, and cause Assertion
failure.

Signed-off-by: Di Wang <di.wang@intel.com>