### PR TITLE
DAOS-6629 EC: Update EC aggregation and EC client code to support arr…

### DIFF
--- a/src/object/cli_ec.c
+++ b/src/object/cli_ec.c
@@ -1120,7 +1120,7 @@ obj_ec_recx_reasb(daos_iod_t *iod, d_sg_list_t *sgl,
 		recx = &iod->iod_recxs[i];
 		with_full_stripe = recx_with_full_stripe(i, ec_recx_array,
 							 &full_ec_recx);
-		if (!with_full_stripe || !update) {
+		if (punch || !with_full_stripe || !update) {
 			if (reasb_req->orr_recov) {
 				D_ASSERT(!update);
 				D_ASSERT(iod->iod_nr == 1);
@@ -1132,6 +1132,8 @@ obj_ec_recx_reasb(daos_iod_t *iod, d_sg_list_t *sgl,
 			if (!reasb_req->orr_size_fetched)
 				ec_data_recx_add(recx, riod->iod_recxs, ridx,
 						 tgt_recx_idxs, oca, update);
+			if (punch)
+				continue;
 			if (!reasb_req->orr_size_fetch) {
 				/* After size query, server returns as zero
 				 * iod_size (Empty tree or all holes, DAOS array
@@ -1161,9 +1163,9 @@ obj_ec_recx_reasb(daos_iod_t *iod, d_sg_list_t *sgl,
 				  "bad recx\n");
 			ec_data_recx_add(&tmp_recx, riod->iod_recxs, ridx,
 					 tgt_recx_idxs, oca, true);
-			ec_data_seg_add(&tmp_recx, iod_size, sgl, &iov_idx,
-					&iov_off, oca, iovs, iov_nr, sorter,
-					true);
+			ec_data_seg_add(&tmp_recx, iod_size,
+					sgl, &iov_idx, &iov_off, oca,
+					iovs, iov_nr, sorter, true);
 		}
 		ec_data_recx_add(full_recx, riod->iod_recxs, ridx,
 				 tgt_recx_idxs, oca, false);
@@ -1183,7 +1185,7 @@ obj_ec_recx_reasb(daos_iod_t *iod, d_sg_list_t *sgl,
 		}
 	}
 
-	if (update) {
+	if (update && !punch) {
 		for (i = 0; i < ec_recx_array->oer_nr; i++) {
 			full_ec_recx = &ec_recx_array->oer_recxs[i];
 			full_recx = &full_ec_recx->oer_recx;

--- a/src/object/obj_rpc.h
+++ b/src/object/obj_rpc.h
@@ -97,7 +97,7 @@
 		0, &CQF_obj_ec_agg,					\
 		ds_obj_ec_agg_handler, NULL, "ec_agg")			\
 	X(DAOS_OBJ_RPC_EC_REPLICATE,					\
-		0, &CQF_obj_ec_agg,					\
+		0, &CQF_obj_ec_rep,					\
 		ds_obj_ec_rep_handler, NULL, "ec_rep")			\
 	X(DAOS_OBJ_RPC_CPD,						\
 		0, &CQF_obj_cpd,					\

--- a/src/tests/suite/daos_aggregate_ec.c
+++ b/src/tests/suite/daos_aggregate_ec.c
@@ -58,6 +58,7 @@ struct ec_agg_test_ctx {
 	daos_key_t		dkey;
 	daos_iod_t		update_iod;
 	d_sg_list_t		update_sgl;
+	d_sg_list_t		punch_sgl;
 	daos_iom_t		fetch_iom;
 	daos_iod_t		fetch_iod;
 	d_sg_list_t             fetch_sgl;
@@ -136,6 +137,55 @@ ec_setup_obj(struct ec_agg_test_ctx *ctx, daos_oclass_id_t oclass, int low)
 }
 
 static void
+ec_setup_punch_recx_data(struct ec_agg_test_ctx *ctx, unsigned int mode,
+			 daos_size_t offset, daos_size_t data_bytes,
+			 unsigned char switch_akey, unsigned int cell)
+{
+	struct daos_oclass_attr	*oca;
+	unsigned int		len;
+
+	if (mode != EC_SPECIFIED)
+		return;
+	/* else set databytes based on oclass */
+
+	assert_int_equal(daos_oclass_is_ec(ctx->oid, &oca), true);
+	len = oca->u.ec.e_len;
+	iov_alloc_str(&ctx->dkey, "dkey");
+	if (switch_akey == 1)
+		iov_alloc_str(&ctx->update_iod.iod_name, "bkey");
+	else if (switch_akey == 2)
+		iov_alloc_str(&ctx->update_iod.iod_name, "ckey");
+	else
+		iov_alloc_str(&ctx->update_iod.iod_name, "akey");
+
+	d_sgl_init(&ctx->update_sgl, 1);
+
+	d_sgl_init(&ctx->fetch_sgl, 1);
+	iov_alloc(&ctx->fetch_sgl.sg_iovs[0], data_bytes);
+
+	ctx->recx[0].rx_idx = offset;
+	ctx->recx[0].rx_nr = data_bytes;
+	ctx->update_iod.iod_size = 0;
+	ctx->update_iod.iod_nr	= 1;
+	ctx->update_iod.iod_recxs = &ctx->recx[0];
+	ctx->update_iod.iod_type  = DAOS_IOD_ARRAY;
+
+	ctx->iom_recx.rx_idx = offset;
+	ctx->iom_recx.rx_nr = len;
+
+	ctx->fetch_iom.iom_recxs = &ctx->iom_recx;
+	ctx->fetch_iom.iom_nr = 1;
+	ctx->fetch_iom.iom_nr_out = 0;
+
+	/** Setup Fetch IOD*/
+	ctx->fetch_iod.iod_name = ctx->update_iod.iod_name;
+	ctx->fetch_iod.iod_size = 1;
+	ctx->fetch_iod.iod_recxs = ctx->update_iod.iod_recxs;
+	ctx->fetch_iod.iod_nr = ctx->update_iod.iod_nr;
+	ctx->fetch_iod.iod_type = ctx->update_iod.iod_type;
+}
+
+static void
 ec_setup_single_recx_data(struct ec_agg_test_ctx *ctx, unsigned int mode,
 			  daos_size_t offset, daos_size_t data_bytes,
 			  unsigned char switch_akey, bool partial_write,
@@ -161,13 +211,14 @@ ec_setup_single_recx_data(struct ec_agg_test_ctx *ctx, unsigned int mode,
 
 	d_sgl_init(&ctx->update_sgl, 1);
 	iov_alloc(&ctx->update_sgl.sg_iovs[0], data_bytes);
-	if (overwrite)
+	if (overwrite) {
 		iov_update_fill(ctx->update_sgl.sg_iovs, 1, len, true);
-	else if (partial_write)
-		iov_update_pfill(ctx->update_sgl.sg_iovs, cell, data_bytes,
-				 false);
-	else
+	} else if (partial_write) {
+		iov_update_pfill(ctx->update_sgl.sg_iovs, cell,
+				 data_bytes, false);
+	} else {
 		iov_update_fill(ctx->update_sgl.sg_iovs, k, len, false);
+	}
 
 	d_sgl_init(&ctx->fetch_sgl, 1);
 	iov_alloc(&ctx->fetch_sgl.sg_iovs[0], data_bytes);
@@ -197,7 +248,7 @@ ec_setup_single_recx_data(struct ec_agg_test_ctx *ctx, unsigned int mode,
 static daos_oclass_id_t dts_ec_agg_oc = DAOS_OC_EC_K2P1_L32K;
 
 static int
-	incremental_fill(void **statep)
+incremental_fill(void **statep)
 {
 	dts_ec_agg_oc = DAOS_OC_EC_K2P1_L32K;
 	return 0;
@@ -347,7 +398,6 @@ verify_1p(struct ec_agg_test_ctx *ctx, daos_oclass_id_t ec_agg_oc,
 	assert_rc_equal(rc, 0);
 }
 
-#ifdef LAYER_COORD
 static void
 test_half_stripe(struct ec_agg_test_ctx *ctx)
 {
@@ -512,7 +562,6 @@ verify_2p(struct ec_agg_test_ctx *ctx, daos_oclass_id_t ec_agg_oc)
 	rc = daos_obj_close(ctx->oh, NULL);
 	assert_rc_equal(rc, 0);
 }
-#endif
 
 static void
 test_partial_stripe(struct ec_agg_test_ctx *ctx)
@@ -557,6 +606,164 @@ test_partial_stripe(struct ec_agg_test_ctx *ctx)
 }
 
 static void
+test_range_punch(struct ec_agg_test_ctx *ctx)
+{
+	struct daos_oclass_attr	*oca;
+	unsigned int		 len, k;
+	int			 i, j, rc;
+
+	dts_ec_agg_oc = DAOS_OC_EC_K4P1_L32K;
+	ec_setup_obj(ctx, dts_ec_agg_oc, 4);
+	assert_int_equal(daos_oclass_is_ec(ctx->oid, &oca), true);
+	len = oca->u.ec.e_len;
+	k = oca->u.ec.e_k;
+	for (j = 0; j < NUM_KEYS; j++)
+		for (i = 0; i < NUM_STRIPES; i++) {
+			ec_setup_single_recx_data(ctx, EC_SPECIFIED,
+						  i * (len * 4), len * 4, j,
+						  false, false, 0);
+			rc = daos_obj_update(ctx->oh, DAOS_TX_NONE, 0,
+					     &ctx->dkey, 1, &ctx->update_iod,
+					     &ctx->update_sgl, NULL);
+			assert_int_equal(rc, 0);
+			ec_cleanup_data(ctx);
+		}
+
+	sleep(1);
+
+	for (j = 0; j < NUM_KEYS; j++)
+		for (i = 0; i < NUM_STRIPES; i++) {
+			ec_setup_punch_recx_data(ctx, EC_SPECIFIED,
+						 i * len * k, len, j, 0);
+			rc = daos_obj_update(ctx->oh, DAOS_TX_NONE, 0,
+					     &ctx->dkey, 1, &ctx->update_iod,
+					     &ctx->update_sgl, NULL);
+			assert_int_equal(rc, 0);
+			ec_cleanup_data(ctx);
+		}
+
+	for (j = 0; j < NUM_KEYS; j++)
+		for (i = 0; i < NUM_STRIPES; i++) {
+			ec_setup_single_recx_data(ctx, EC_SPECIFIED,
+						  i * len * k + 2 * len, len,
+						  j, false, true, 0);
+			rc = daos_obj_update(ctx->oh, DAOS_TX_NONE, 0,
+					     &ctx->dkey, 1, &ctx->update_iod,
+					     &ctx->update_sgl, NULL);
+			assert_int_equal(rc, 0);
+			ec_cleanup_data(ctx);
+		}
+
+	rc = daos_obj_close(ctx->oh, NULL);
+	assert_int_equal(rc, 0);
+}
+
+static void
+verify_rp1p(struct ec_agg_test_ctx *ctx, daos_oclass_id_t ec_agg_oc,
+	    unsigned int shard)
+{
+	struct daos_oclass_attr	*oca;
+	tse_task_t		*task = NULL;
+	unsigned int		 k, len;
+	int			 i, j, rc;
+
+	ec_setup_obj(ctx, ec_agg_oc, 4);
+
+	assert_int_equal(daos_oclass_is_ec(ctx->oid, &oca), true);
+	len = oca->u.ec.e_len;
+	k = oca->u.ec.e_k;
+
+	for (j = 0; j < NUM_KEYS; j++)
+		for (i = 0; i < NUM_STRIPES; i++) {
+			ec_setup_single_recx_data(ctx, EC_SPECIFIED,
+						  i * len * k + len,
+						  len,
+						  j, true, false, 0);
+			memset(&ctx->fetch_iom, 0, sizeof(daos_iom_t));
+			ctx->fetch_iom.iom_flags = DAOS_IOMF_DETAIL;
+			ctx->fetch_iod.iod_recxs[0].rx_idx = i * k * len + len;
+			ctx->fetch_iod.iod_recxs[0].rx_nr = len;
+			ctx->iom_recx.rx_nr = len;
+			ctx->iom_recx.rx_idx = i * k * len + len;
+			rc = dc_obj_fetch_task_create(ctx->oh, DAOS_TX_NONE, 0,
+						      &ctx->dkey, 1,
+						      DIOF_TO_SPEC_SHARD,
+						      &ctx->fetch_iod,
+						      &ctx->fetch_sgl,
+						      &ctx->fetch_iom, &shard,
+						      NULL, NULL, NULL, &task);
+			assert_rc_equal(rc, 0);
+			rc = dc_task_schedule(task, true);
+			assert_rc_equal(rc, 0);
+			/* verify replicas on parity tgt */
+			assert_int_equal(ctx->fetch_iom.iom_nr_out, 1);
+			task = NULL;
+			memset(&ctx->fetch_iom, 0, sizeof(daos_iom_t));
+			ctx->fetch_iom.iom_flags = DAOS_IOMF_DETAIL;
+			ctx->fetch_iod.iod_recxs[0].rx_idx = i * k * len +
+				2 * len;
+			ctx->fetch_iod.iod_recxs[0].rx_nr = len;
+			ctx->iom_recx.rx_nr = len;
+			ctx->iom_recx.rx_idx = i * k * len + 2 * len;
+			rc = dc_obj_fetch_task_create(ctx->oh, DAOS_TX_NONE, 0,
+						      &ctx->dkey, 1,
+						      DIOF_TO_SPEC_SHARD,
+						      &ctx->fetch_iod,
+						      &ctx->fetch_sgl,
+						      &ctx->fetch_iom, &shard,
+						      NULL, NULL, NULL, &task);
+			assert_rc_equal(rc, 0);
+			rc = dc_task_schedule(task, true);
+			assert_rc_equal(rc, 0);
+			/* verify replicas on parity tgt */
+			assert_int_equal(ctx->fetch_iom.iom_nr_out, 1);
+			task = NULL;
+			memset(&ctx->fetch_iom, 0, sizeof(daos_iom_t));
+			ctx->fetch_iom.iom_flags = DAOS_IOMF_DETAIL;
+			ctx->fetch_iod.iod_recxs[0].rx_idx = i * k * len +
+				3 * len;
+			ctx->fetch_iod.iod_recxs[0].rx_nr = len;
+			ctx->iom_recx.rx_nr = len;
+			ctx->iom_recx.rx_idx = i * k * len + 3 * len;
+			rc = dc_obj_fetch_task_create(ctx->oh, DAOS_TX_NONE, 0,
+						      &ctx->dkey, 1,
+						      DIOF_TO_SPEC_SHARD,
+						      &ctx->fetch_iod,
+						      &ctx->fetch_sgl,
+						      &ctx->fetch_iom, &shard,
+						      NULL, NULL, NULL, &task);
+			assert_rc_equal(rc, 0);
+			rc = dc_task_schedule(task, true);
+			assert_rc_equal(rc, 0);
+			/* verify replicas on parity tgt */
+			assert_int_equal(ctx->fetch_iom.iom_nr_out, 1);
+			task = NULL;
+			memset(&ctx->fetch_iom, 0, sizeof(daos_iom_t));
+			ctx->fetch_iom.iom_flags = DAOS_IOMF_DETAIL;
+			ctx->fetch_iod.iod_recxs[0].rx_idx = (i * len) |
+							     PARITY_INDICATOR;
+			ctx->fetch_iod.iod_recxs[0].rx_nr = len;
+			ctx->iom_recx.rx_nr = len;
+			rc = dc_obj_fetch_task_create(ctx->oh, DAOS_TX_NONE, 0,
+						      &ctx->dkey, 1,
+						      DIOF_TO_SPEC_SHARD,
+						      &ctx->fetch_iod,
+						      &ctx->fetch_sgl,
+						      &ctx->fetch_iom, &shard,
+						      NULL, NULL, NULL, &task);
+			assert_rc_equal(rc, 0);
+			rc = dc_task_schedule(task, true);
+			assert_rc_equal(rc, 0);
+			/* verify parity no longer exists on parity target */
+			assert_int_equal(ctx->fetch_iom.iom_nr_out, 0);
+			task = NULL;
+			ec_cleanup_data(ctx);
+		}
+	rc = daos_obj_close(ctx->oh, NULL);
+	assert_rc_equal(rc, 0);
+}
+
+static void
 setup_ec_agg_tests(void **statep, struct ec_agg_test_ctx *ctx)
 {
 	ec_setup_from_test_args(ctx, (test_arg_t *)*statep);
@@ -575,16 +782,14 @@ test_all_ec_agg(void **statep)
 
 	setup_ec_agg_tests(statep, &ctx);
 	test_filled_stripe(&ctx);
-#ifdef LAYER_COORD
 	test_half_stripe(&ctx);
-#endif
 	test_partial_stripe(&ctx);
-	sleep(60);
+	test_range_punch(&ctx);
+	sleep(40);
 	verify_1p(&ctx, DAOS_OC_EC_K2P1_L32K, 2);
-#ifdef LAYER_COORD
 	verify_2p(&ctx, DAOS_OC_EC_K2P2_L32K);
-#endif
 	verify_1p(&ctx, DAOS_OC_EC_K4P1_L32K, 4);
+	verify_rp1p(&ctx, DAOS_OC_EC_K4P1_L32K, 4);
 	cleanup_ec_agg_tests(&ctx);
 }
 


### PR DESCRIPTION
…ay range punch (#4730)

This PR resolves the three open JIRA tickets concerning range punch support:

DAOS-6576 - Develop tests for EC range punch.

DAOS-6665 - EC array extent range punch hole records cause EC aggregation to fail.

DAOS-6629 - Update EC aggregation and EC client code to support array range punch.

Signed-off-by: Joseph Moore <joseph.moore@intel.com>