### PR TITLE
DAOS-6446 Test: Update tags on tests.

### DIFF
--- a/src/tests/ftest/container/basic_snapshot.py
+++ b/src/tests/ftest/container/basic_snapshot.py
@@ -45,7 +45,7 @@ class BasicSnapshot(TestWithServers):
             Verify the snapshot is still available and the contents remain in
             their original state.
 
-        :avocado: tags=snap,basicsnap
+        :avocado: tags=all,daily_regression,snap,basicsnap
         """
         # Set up the pool and container.
         try:

--- a/src/tests/ftest/object/same_key_different_value.py
+++ b/src/tests/ftest/object/same_key_different_value.py
@@ -8,7 +8,7 @@
 
 import traceback
 
-from apricot import TestWithServers
+from apricot import TestWithServers, skipForTicket
 from pydaos.raw import DaosContainer, DaosApiError
 
 
@@ -35,6 +35,7 @@ class SameKeyDifferentValue(TestWithServers):
             self.log.info(traceback.format_exc())
             self.fail("Test failed during setup.\n")
 
+    @skipForTicket("DAOS-7220")
     def test_single_to_array_value(self):
         """
         Jira ID: DAOS-2218
@@ -52,7 +53,8 @@ class SameKeyDifferentValue(TestWithServers):
                Trigger aggregation
                Insert same akey,dkey under same object with array value
                Result: should either pass or return -1001 ERR
-        :avocado: tags=object,samekeydifferentvalue,singletoarray,vm,small
+        :avocado: tags=all,daily_regression,object,samekeydifferentvalue
+        :avocado: tags=singletoarray,vm,small
         """
 
         # define akey,dkey, single value data and array value data
@@ -139,6 +141,7 @@ class SameKeyDifferentValue(TestWithServers):
             except DaosApiError as excp:
                 self.fail("Failed to write to akey/dkey or punch the object")
 
+    @skipForTicket("DAOS-7220")
     def test_array_to_single_value(self):
         """
         Jira ID: DAOS-2218
@@ -156,7 +159,8 @@ class SameKeyDifferentValue(TestWithServers):
                Trigger aggregation
                Insert same akey,dkey under same object with single value
                Result: should either pass or return -1001 ERR
-        :avocado: tags=object,samekeydifferentvalue,arraytosingle,vm,small
+        :avocado: tags=all,daily_regression,object,samekeydifferentvalue
+        :avocado: tags=arraytosingle,vm,small
         """
 
         # define akey,dkey, single value data and array value data

--- a/src/tests/ftest/pool/permission.py
+++ b/src/tests/ftest/pool/permission.py
@@ -4,7 +4,7 @@
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
-from apricot import TestWithServers
+from apricot import TestWithServers, skipForTicket
 from pydaos.raw import DaosContainer, DaosApiError
 from avocado.core.exceptions import TestFail
 from test_utils_pool import TestPool
@@ -37,7 +37,7 @@ class Permission(TestWithServers):
         Test Description:
             Test pool connections with specific permissions.
 
-        :avocado: tags=pool,permission,connectpermission
+        :avocado: tags=all,daily_regression,pool,permission,connectpermission
         """
         # parameter used in pool create
         createmode = self.params.get("mode", '/run/createtests/createmode/*/')
@@ -81,6 +81,7 @@ class Permission(TestWithServers):
                     "Test was expected to pass but it failed at " +
                     "pool.connect.\n")
 
+    @skipForTicket("DAOS-7221")
     def test_filemodification(self):
         """Test ID: DAOS-???.
 
@@ -88,7 +89,7 @@ class Permission(TestWithServers):
             Test whether file modification happens as expected under different
             permission levels.
 
-        :avocado: tags=pool,permission,filemodification
+        :avocado: tags=all,daily_regression,pool,permission,filemodification
         """
         # parameters used in pool create
         createmode = self.params.get("mode", '/run/createtests/createmode/*/')


### PR DESCRIPTION
    Added all and daily_regression tags to:
        container/basic_snapshot.py
        object/same_key_different_value.py
        pool/permission.py

Features: basicsnap,samekeydifferentvalue,connectpermission,filemodification
Signed-off-by: Omar Ocampo <omar.ocampo.coronado@intel.com>