### PR TITLE
DAOS-7199 rebuild: Do not add complete status in refresh iv

### DIFF
--- a/src/rebuild/rebuild_internal.h
+++ b/src/rebuild/rebuild_internal.h
@@ -333,9 +333,6 @@ struct rebuild_global_pool_tracker *
 rebuild_global_pool_tracker_lookup(const uuid_t pool_uuid, unsigned int ver);
 
 int
-rebuild_status_completed_update(const uuid_t pool_uuid,
-				struct daos_rebuild_status *rs);
-int
 rebuild_global_status_update(struct rebuild_global_pool_tracker *master_rpt,
 			     struct rebuild_iv *iv);
 void

--- a/src/rebuild/rebuild_iv.c
+++ b/src/rebuild/rebuild_iv.c
@@ -174,7 +174,6 @@ rebuild_iv_ent_refresh(struct ds_iv_entry *entry, struct ds_iv_key *key,
 	if (dst_iv->riv_global_done || dst_iv->riv_global_scan_done ||
 	    dst_iv->riv_stable_epoch) {
 		struct rebuild_tgt_pool_tracker *rpt;
-		d_rank_t	rank;
 
 		rpt = rpt_lookup(src_iv->riv_pool_uuid, src_iv->riv_ver);
 		if (rpt == NULL)
@@ -197,53 +196,6 @@ rebuild_iv_ent_refresh(struct ds_iv_entry *entry, struct ds_iv_key *key,
 			D_WARN("leader change stable epoch from "DF_U64" to "
 			       DF_U64 "\n", rpt->rt_stable_epoch,
 			       dst_iv->riv_stable_epoch);
-
-		/* on svc nodes update the rebuild status completed list
-		 * to serve rebuild status querying in case of master
-		 * node changed.
-		 */
-		rc = crt_group_rank(NULL, &rank);
-		if (dst_iv->riv_global_done && rc == 0) {
-			struct daos_rebuild_status rs = { 0 };
-			daos_prop_t	*prop = NULL;
-			struct daos_prop_entry *prop_entry;
-			d_rank_list_t	*svc_list;
-
-			D_ALLOC_PTR(prop);
-			if (prop == NULL)
-				D_GOTO(out, rc = -DER_NOMEM);
-
-			rc = ds_pool_iv_prop_fetch(rpt->rt_pool, prop);
-			if (rc)
-				D_GOTO(free, rc);
-
-			prop_entry = daos_prop_entry_get(prop,
-						    DAOS_PROP_PO_SVC_LIST);
-			D_ASSERT(prop_entry != NULL);
-			svc_list = prop_entry->dpe_val_ptr;
-			if (d_rank_in_rank_list(svc_list, rank)) {
-				rs.rs_version	= src_iv->riv_ver;
-				rs.rs_errno	= src_iv->riv_status;
-				rs.rs_done	= 1;
-				rs.rs_obj_nr	= src_iv->riv_obj_count;
-				rs.rs_rec_nr	= src_iv->riv_rec_count;
-				rs.rs_toberb_obj_nr	=
-					src_iv->riv_toberb_obj_count;
-				rs.rs_size	= src_iv->riv_size;
-				rs.rs_seconds   = src_iv->riv_seconds;
-				rc = rebuild_status_completed_update(
-						src_iv->riv_pool_uuid, &rs);
-				if (rc != 0)
-					D_ERROR("_status_completed_update, "
-						DF_UUID" failed, rc %d.\n",
-						DP_UUID(src_iv->riv_pool_uuid),
-						rc);
-			}
-free:
-			if (prop)
-				daos_prop_free(prop);
-		}
-out:
 		rpt->rt_global_done = dst_iv->riv_global_done;
 		rpt->rt_global_scan_done = dst_iv->riv_global_scan_done;
 		rpt_put(rpt);

--- a/src/rebuild/srv.c
+++ b/src/rebuild/srv.c
@@ -251,7 +251,7 @@ rebuild_status_completed_lookup(const uuid_t pool_uuid)
 	return rs;
 }
 
-int
+static int
 rebuild_status_completed_update(const uuid_t pool_uuid,
 				struct daos_rebuild_status *rs)
 {


### PR DESCRIPTION
Do not add complete status inside refresh_iv callback, because
the current rebuild job might need retry. So let's only update
rebuild complete status inside rebuild_task_ult(), and pool query
can get correct rebuild status.

Signed-off-by: Di Wang <di.wang@intel.com>