### PR TITLE
DAOS-7196-test_rel_1.2: Enable negative testcases in pool/multi_server_create_delete_test.py

### DIFF
--- a/src/tests/ftest/pool/multi_server_create_delete_test.py
+++ b/src/tests/ftest/pool/multi_server_create_delete_test.py
@@ -28,7 +28,10 @@ class MultiServerCreateDeleteTest(TestWithServers):
 
         Destroy the pool and verify that the directory is deleted.
 
-        :avocado: tags=all,pool,full_regression,small,multitarget
+        :avocado: tags=all,full_regression
+        :avocado: tags=small
+        :avocado: tags=pool,multitarget
+        :avocado: tags=multiserver_create_delete
         """
         # Create a dmg command object
         dmg = self.get_dmg_command()

--- a/src/tests/ftest/pool/multi_server_create_delete_test.yaml
+++ b/src/tests/ftest/pool/multi_server_create_delete_test.yaml
@@ -38,12 +38,10 @@ tests:
       systemname:
         - daos_server
         - PASS
-    # This case doesn't work now, but might become necessary in the future. See
-    # DAOS-4057
-    # badsetname:
-    #   setname:
-    #     - complete_rubbish
-    #     - FAIL
+    badsetname:
+      systemname:
+        - complete_rubbish
+        - FAIL
   tgtlist: !mux
     firsttgt:
       tgt:


### PR DESCRIPTION
Enable negative testcases in pool/multi_server_create_delete_test.py
Modified: pool/multi_server_create_delete_test.py
          pool/multi_server_create_delete_test.yaml
Allow-unstable-test: true
Test-tag: multiserver_create_delete
Signed-off-by: Ding Ho <ding-hwa.ho@intel.com>