### PR TITLE
DAOS-5837 control: Check fault domain callback security

### DIFF
--- a/src/control/fault/code/codes.go
+++ b/src/control/fault/code/codes.go
@@ -142,6 +142,7 @@ const (
 	ServerConfigOverlappingBdevDeviceList
 	ServerConfigFaultDomainInvalid
 	ServerConfigFaultCallbackNotFound
+	ServerConfigFaultCallbackInsecure
 	ServerConfigFaultCallbackBadPerms
 	ServerConfigFaultCallbackFailed
 	ServerConfigBothFaultPathAndCb

--- a/src/control/server/config/faults.go
+++ b/src/control/server/config/faults.go
@@ -147,6 +147,18 @@ func FaultConfigFaultCallbackFailed(err error) *fault.Fault {
 	)
 }
 
+// FaultConfigFaultCallbackInsecure creates a fault for the scenario where the
+// fault domain callback path doesn't meet security requirements.
+func FaultConfigFaultCallbackInsecure(requiredDir string) *fault.Fault {
+	return serverConfigFault(
+		code.ServerConfigFaultCallbackInsecure,
+		"fault domain callback script does not meet security requirements",
+		fmt.Sprintf("ensure that the 'fault_cb' path is under the parent directory %q, "+
+			"not a symbolic link, does not have the setuid bit set, and does not have "+
+			"write permissions for non-owners", requiredDir),
+	)
+}
+
 func serverConfigFault(code code.Code, desc, res string) *fault.Fault {
 	return &fault.Fault{
 		Domain:      "serverconfig",

--- a/src/control/server/faultdomain.go
+++ b/src/control/server/faultdomain.go
@@ -92,7 +92,7 @@ func checkFaultDomainCallback(path, requiredDir string) error {
 	// Must be under the required directory
 	absDir, err := filepath.Abs(requiredDir)
 	if err != nil {
-		panic(err) // shouldn't be possible
+		return err
 	}
 	absScriptPath, err := filepath.Abs(path)
 	if err != nil {

--- a/src/control/server/faultdomain.go
+++ b/src/control/server/faultdomain.go
@@ -9,11 +9,12 @@ package server
 import (
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 
 	"github.com/pkg/errors"
-	"golang.org/x/sys/unix"
 
+	"github.com/daos-stack/daos/src/control/build"
 	"github.com/daos-stack/daos/src/control/server/config"
 	"github.com/daos-stack/daos/src/control/system"
 )
@@ -45,7 +46,7 @@ func getFaultDomain(cfg *config.Server) (*system.FaultDomain, error) {
 	}
 
 	if cfg.FaultCb != "" {
-		return getFaultDomainFromCallback(cfg.FaultCb)
+		return getFaultDomainFromCallback(cfg.FaultCb, build.ConfigDir)
 	}
 
 	return getDefaultFaultDomain(os.Hostname)
@@ -63,18 +64,12 @@ func newFaultDomainFromConfig(domainStr string) (*system.FaultDomain, error) {
 	return fd, nil
 }
 
-func getFaultDomainFromCallback(callbackPath string) (*system.FaultDomain, error) {
-	if callbackPath == "" {
-		return nil, errors.New("no callback path supplied")
+func getFaultDomainFromCallback(path, requiredDir string) (*system.FaultDomain, error) {
+	if err := checkFaultDomainCallback(path, requiredDir); err != nil {
+		return nil, err
 	}
 
-	// Fault callback can't be an arbitrary command. Must point to a
-	// specific executable file.
-	if err := unix.Stat(callbackPath, nil); os.IsNotExist(err) {
-		return nil, config.FaultConfigFaultCallbackNotFound
-	}
-
-	output, err := exec.Command(callbackPath).Output()
+	output, err := exec.Command(path).Output()
 	if os.IsPermission(err) {
 		return nil, config.FaultConfigFaultCallbackBadPerms
 	} else if err != nil {
@@ -87,4 +82,47 @@ func getFaultDomainFromCallback(callbackPath string) (*system.FaultDomain, error
 	}
 
 	return newFaultDomainFromConfig(trimmedOutput)
+}
+
+func checkFaultDomainCallback(path, requiredDir string) error {
+	if path == "" {
+		return errors.New("no callback path supplied")
+	}
+
+	// Must be under the required directory
+	absDir, err := filepath.Abs(requiredDir)
+	if err != nil {
+		panic(err) // shouldn't be possible
+	}
+	absScriptPath, err := filepath.Abs(path)
+	if err != nil {
+		return err
+	}
+	if !strings.HasPrefix(absScriptPath, absDir) {
+		return config.FaultConfigFaultCallbackInsecure(absDir)
+	}
+
+	// Fault callback can't be an arbitrary command. Must point to a
+	// specific executable file.
+	fi, err := os.Lstat(path)
+	if err != nil {
+		if os.IsPermission(err) {
+			return config.FaultConfigFaultCallbackBadPerms
+		}
+		return config.FaultConfigFaultCallbackNotFound
+	}
+
+	// Symlinks and setuid scripts are potentially dangerous and shouldn't
+	// be automatically run.
+	mode := fi.Mode()
+	if mode&os.ModeSymlink != 0 || mode&os.ModeSetuid != 0 {
+		return config.FaultConfigFaultCallbackInsecure(absDir)
+	}
+
+	// Script shouldn't be writable by non-owners.
+	if mode.Perm()&0022 != 0 {
+		return config.FaultConfigFaultCallbackInsecure(absDir)
+	}
+
+	return nil
 }

--- a/src/control/server/faultdomain_test.go
+++ b/src/control/server/faultdomain_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/daos-stack/daos/src/control/build"
 	"github.com/daos-stack/daos/src/control/common"
 	"github.com/daos-stack/daos/src/control/server/config"
 	"github.com/daos-stack/daos/src/control/system"
@@ -75,6 +76,12 @@ func TestServer_getFaultDomain(t *testing.T) {
 	validFaultDomain := "/host0"
 	cbScriptPath := filepath.Join(tmpDir, "cb.sh")
 	createFaultCBScriptFile(t, cbScriptPath, 0755, validFaultDomain)
+
+	oldConfigDir := build.ConfigDir
+	build.ConfigDir = tmpDir // overwrite for these tests
+	defer func() {
+		build.ConfigDir = oldConfigDir
+	}()
 
 	for name, tc := range map[string]struct {
 		cfg       *config.Server
@@ -179,13 +186,35 @@ func TestServer_getFaultDomainFromCallback(t *testing.T) {
 	tmpDir, cleanup := common.CreateTestDir(t)
 	defer cleanup()
 
+	workingDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	relTmpDir, err := filepath.Rel(workingDir, tmpDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	validFaultDomain := "/myfaultdomain"
 
 	goodScriptPath := filepath.Join(tmpDir, "good.sh")
 	createFaultCBScriptFile(t, goodScriptPath, 0755, validFaultDomain)
+	relScriptPath, err := filepath.Rel(workingDir, goodScriptPath)
+	if err != nil {
+		t.Fatal(err)
+	}
 
-	badPermsScriptPath := filepath.Join(tmpDir, "noPerms.sh")
+	noPermsScriptPath := filepath.Join(tmpDir, "noPerms.sh")
+	createFaultCBScriptFile(t, noPermsScriptPath, 0000, validFaultDomain)
+
+	badPermsScriptPath := filepath.Join(tmpDir, "noExecPerms.sh")
 	createFaultCBScriptFile(t, badPermsScriptPath, 0600, validFaultDomain)
+
+	setuidScriptPath := filepath.Join(tmpDir, "setuid.sh")
+	createFaultCBScriptFile(t, setuidScriptPath, 0755|os.ModeSetuid, validFaultDomain)
+
+	tooLaxScriptPath := filepath.Join(tmpDir, "toolax.sh")
+	createFaultCBScriptFile(t, tooLaxScriptPath, 0666, validFaultDomain)
 
 	errorScriptPath := filepath.Join(tmpDir, "fail.sh")
 	createErrorScriptFile(t, errorScriptPath)
@@ -205,61 +234,108 @@ func TestServer_getFaultDomainFromCallback(t *testing.T) {
 	rootScriptPath := filepath.Join(tmpDir, "rootdomain.sh")
 	createFaultCBScriptFile(t, rootScriptPath, 0755, "/")
 
+	symlinkPath := filepath.Join(tmpDir, "symlink.sh")
+	if err := os.Symlink(goodScriptPath, symlinkPath); err != nil {
+		t.Fatal(err)
+	}
+
 	for name, tc := range map[string]struct {
-		input     string
-		expResult string
-		expErr    error
+		scriptPath  string
+		callbackDir string
+		expResult   string
+		expErr      error
 	}{
 		"empty path": {
 			expErr: errors.New("no callback path supplied"),
 		},
 		"success": {
-			input:     goodScriptPath,
-			expResult: validFaultDomain,
+			scriptPath: goodScriptPath,
+			expResult:  validFaultDomain,
 		},
 		"script does not exist": {
-			input:  filepath.Join(tmpDir, "notarealfile"),
-			expErr: config.FaultConfigFaultCallbackNotFound,
+			scriptPath: filepath.Join(tmpDir, "notarealfile"),
+			expErr:     config.FaultConfigFaultCallbackNotFound,
 		},
-		"script has bad permissions": {
-			input:  badPermsScriptPath,
-			expErr: config.FaultConfigFaultCallbackBadPerms,
+		"script without read permissions": {
+			scriptPath: noPermsScriptPath,
+			expErr:     config.FaultConfigFaultCallbackBadPerms,
+		},
+		"script without exec permissions": {
+			scriptPath: badPermsScriptPath,
+			expErr:     config.FaultConfigFaultCallbackBadPerms,
 		},
 		"error within the script": {
-			input:  errorScriptPath,
-			expErr: config.FaultConfigFaultCallbackFailed(errors.New("exit status 2")),
+			scriptPath: errorScriptPath,
+			expErr:     config.FaultConfigFaultCallbackFailed(errors.New("exit status 2")),
 		},
 		"script returned no output": {
-			input:  emptyScriptPath,
-			expErr: config.FaultConfigFaultCallbackEmpty,
+			scriptPath: emptyScriptPath,
+			expErr:     config.FaultConfigFaultCallbackEmpty,
 		},
 		"script returned only whitespace": {
-			input:  whitespaceScriptPath,
-			expErr: config.FaultConfigFaultCallbackEmpty,
+			scriptPath: whitespaceScriptPath,
+			expErr:     config.FaultConfigFaultCallbackEmpty,
 		},
 		"script returned invalid fault domain": {
-			input:  invalidScriptPath,
-			expErr: config.FaultConfigFaultDomainInvalid,
+			scriptPath: invalidScriptPath,
+			expErr:     config.FaultConfigFaultDomainInvalid,
 		},
 		"script returned root fault domain": {
-			input:  rootScriptPath,
-			expErr: config.FaultConfigFaultDomainInvalid,
+			scriptPath: rootScriptPath,
+			expErr:     config.FaultConfigFaultDomainInvalid,
 		},
 		"script returned fault domain with too many layers": { // TODO DAOS-6353: change when multiple layers supported
-			input:  multiLayerScriptPath,
-			expErr: config.FaultConfigTooManyLayersInFaultDomain,
+			scriptPath: multiLayerScriptPath,
+			expErr:     config.FaultConfigTooManyLayersInFaultDomain,
 		},
 		"no arbitrary shell commands allowed": {
-			input:  "echo \"my dog has fleas\"",
-			expErr: config.FaultConfigFaultCallbackNotFound,
+			scriptPath: "echo \"my dog has fleas\"",
+			expErr:     config.FaultConfigFaultCallbackInsecure(tmpDir),
 		},
 		"no command line parameters allowed": {
-			input:  fmt.Sprintf("%s arg", goodScriptPath),
-			expErr: config.FaultConfigFaultCallbackNotFound,
+			scriptPath: fmt.Sprintf("%s arg", goodScriptPath),
+			expErr:     config.FaultConfigFaultCallbackNotFound,
+		},
+		"no symlink allowed": {
+			scriptPath: symlinkPath,
+			expErr:     config.FaultConfigFaultCallbackInsecure(tmpDir),
+		},
+		"no setuid bit allowed": {
+			scriptPath: setuidScriptPath,
+			expErr:     config.FaultConfigFaultCallbackInsecure(tmpDir),
+		},
+		"permissions too lax": {
+			scriptPath: tooLaxScriptPath,
+			expErr:     config.FaultConfigFaultCallbackInsecure(tmpDir),
+		},
+		"script not in right directory": {
+			scriptPath:  goodScriptPath,
+			callbackDir: "/root",
+			expErr:      config.FaultConfigFaultCallbackInsecure("/root"),
+		},
+		"script is in a directory below correct dir": {
+			scriptPath:  goodScriptPath,
+			callbackDir: filepath.Dir(tmpDir),
+			expResult:   validFaultDomain,
+		},
+		"relative required callback dir": {
+			scriptPath:  goodScriptPath,
+			callbackDir: relTmpDir,
+			expResult:   validFaultDomain,
+		},
+		"relative script path": {
+			scriptPath:  relScriptPath,
+			callbackDir: tmpDir,
+			expResult:   validFaultDomain,
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			result, err := getFaultDomainFromCallback(tc.input)
+			cbDir := tc.callbackDir
+			if cbDir == "" {
+				cbDir = tmpDir
+			}
+
+			result, err := getFaultDomainFromCallback(tc.scriptPath, cbDir)
 
 			common.CmpErr(t, tc.expErr, err)
 			assertFaultDomainEqualStr(t, tc.expResult, result)


### PR DESCRIPTION
Since the fault domain callback script is untrusted external
code, restrictions are needed to limit possible security
issues.

This patch adds checks to verify:

- The script is not writable by users other than its owner.
- The script does not have its setuid bit set.
- The script is installed within a specific directory.
- The script is not a symlink.

Signed-off-by: Kris Jacque <kristin.jacque@intel.com>