### PR TITLE
DAOS-7217 sched: take NVMe space pressure into account

### DIFF
--- a/src/engine/sched.c
+++ b/src/engine/sched.c
@@ -588,7 +588,7 @@ check_space_pressure(struct dss_xstream *dx, struct sched_pool_info *spi)
 {
 	struct sched_info	*info = &dx->dx_sched_info;
 	struct vos_pool_space	 vps = { 0 };
-	uint64_t		 scm_left;
+	uint64_t		 scm_left, nvme_left;
 	struct pressure_ratio	*pr;
 	int			 orig_pressure, rc;
 
@@ -621,9 +621,17 @@ check_space_pressure(struct dss_xstream *dx, struct sched_pool_info *spi)
 	else
 		scm_left = 0;
 
+	if (NVME_TOTAL(&vps) == 0)      /* NVMe not enabled */
+		nvme_left = UINT64_MAX;
+	else if (NVME_FREE(&vps) > NVME_SYS(&vps))
+		nvme_left = NVME_FREE(&vps) - NVME_SYS(&vps);
+	else
+		nvme_left = 0;
+
 	orig_pressure = spi->spi_space_pressure;
 	for (pr = &pressure_gauge[0]; pr->pr_free != 0; pr++) {
-		if (scm_left > (SCM_TOTAL(&vps) * pr->pr_free / 100))
+		if (scm_left > (SCM_TOTAL(&vps) * pr->pr_free / 100) &&
+		    nvme_left > (NVME_TOTAL(&vps) * pr->pr_free / 100))
 			break;
 	}
 	spi->spi_space_pressure = pr->pr_pressure;


### PR DESCRIPTION
NVMe space pressure needs be taken into account when checking space
pressure level, otherwise, the NVMe space occupied by punched
objs/keys or overwritten records won't be aggressively relaimed even
when NVMe space is running short.

This patch changed check_space_pressure() to return
max(scm_pressure_level, nvme_pressure_level) as pressure level, so
that updates will be throttled and aggregation/GC will be full speed
when either SCM or NVMe is under space pressure. A tolerable downside
of the change is that even when NVMe (or SCM) is soley under pressure,
updates to SCM (or NVMe) will be throttled as well.

Signed-off-by: Niu Yawei <yawei.niu@intel.com>