### PR TITLE
DAOS-7073 dtx: use latest pool map for DTX resync and refresh

### DIFF
--- a/src/dtx/dtx_common.c
+++ b/src/dtx/dtx_common.c
@@ -272,6 +272,7 @@ static void
 dtx_shares_init(struct dtx_handle *dth)
 {
 	D_INIT_LIST_HEAD(&dth->dth_share_cmt_list);
+	D_INIT_LIST_HEAD(&dth->dth_share_abt_list);
 	D_INIT_LIST_HEAD(&dth->dth_share_act_list);
 	D_INIT_LIST_HEAD(&dth->dth_share_tbd_list);
 	dth->dth_share_tbd_count = 0;
@@ -287,6 +288,11 @@ dtx_shares_fini(struct dtx_handle *dth)
 		return;
 
 	while ((dsp = d_list_pop_entry(&dth->dth_share_cmt_list,
+				       struct dtx_share_peer,
+				       dsp_link)) != NULL)
+		D_FREE(dsp);
+
+	while ((dsp = d_list_pop_entry(&dth->dth_share_abt_list,
 				       struct dtx_share_peer,
 				       dsp_link)) != NULL)
 		D_FREE(dsp);

--- a/src/dtx/dtx_internal.h
+++ b/src/dtx/dtx_internal.h
@@ -100,4 +100,19 @@ int dtx_commit(struct ds_cont_child *cont, struct dtx_entry **dtes,
 int dtx_check(struct ds_cont_child *cont, struct dtx_entry *dte,
 	      daos_epoch_t epoch);
 
+int dtx_refresh_internal(struct ds_cont_child *cont, int *check_count,
+			 d_list_t *check_list, d_list_t *cmt_list,
+			 d_list_t *abt_list, d_list_t *act_list, bool failout);
+int dtx_status_handle_one(struct ds_cont_child *cont, struct dtx_entry *dte,
+			  daos_epoch_t epoch, int *tgt_array, int *err);
+
+enum dtx_status_handle_result {
+	DSHR_NEED_COMMIT	= 1,
+	DSHR_NEED_RETRY		= 2,
+	DSHR_COMMITTED		= 3,
+	DSHR_ABORTED		= 4,
+	DSHR_ABORT_FAILED	= 5,
+	DSHR_CORRUPT		= 6,
+};
+
 #endif /* __DTX_INTERNAL_H__ */

--- a/src/dtx/dtx_resync.c
+++ b/src/dtx/dtx_resync.c
@@ -140,7 +140,8 @@ dtx_is_leader(struct ds_pool *pool, struct dtx_resync_args *dra,
 	/* XXX: need more work when we support to elect DTX leader from
 	 *	data shard for EC object in the future.
 	 */
-	return ds_pool_check_dtx_leader(pool, &dre->dre_oid, dra->version);
+	return ds_pool_check_dtx_leader(pool, &dre->dre_oid,
+					pool->sp_map_version);
 }
 
 static bool
@@ -159,18 +160,22 @@ dtx_verify_groups(struct ds_pool *pool, struct dtx_memberships *mbs,
 			rdonly = false;
 
 		for (j = 0, k = 0; j < group->drg_tgt_cnt; j++) {
-			if (tgt_array[group->drg_ids[j]] > 0)
+			if (tgt_array != NULL &&
+			    tgt_array[group->drg_ids[j]] > 0)
 				continue;
 
-			if (tgt_array[group->drg_ids[j]] < 0) {
+			if (tgt_array != NULL &&
+			    tgt_array[group->drg_ids[j]] < 0) {
 				k++;
 				continue;
 			}
 
 			if (dtx_target_alive(pool, group->drg_ids[j])) {
-				tgt_array[group->drg_ids[j]] = 1;
+				if (tgt_array != NULL)
+					tgt_array[group->drg_ids[j]] = 1;
 			} else {
-				tgt_array[group->drg_ids[j]] = -1;
+				if (tgt_array != NULL)
+					tgt_array[group->drg_ids[j]] = -1;
 				k++;
 			}
 		}
@@ -196,6 +201,114 @@ dtx_verify_groups(struct ds_pool *pool, struct dtx_memberships *mbs,
 	return true;
 }
 
+int
+dtx_status_handle_one(struct ds_cont_child *cont, struct dtx_entry *dte,
+		      daos_epoch_t epoch, int *tgt_array, int *err)
+{
+	int	rc = 0;
+
+	rc = dtx_check(cont, dte, epoch);
+	switch (rc) {
+	case DTX_ST_COMMITTED:
+	case DTX_ST_COMMITTABLE:
+		/* The DTX has been committed on some remote replica(s),
+		 * let's commit the DTX globally.
+		 */
+		return DSHR_NEED_COMMIT;
+	case -DER_INPROGRESS:
+	case -DER_TIMEDOUT:
+		D_WARN("Other participants not sure about whether the "
+		       "DTX "DF_DTI" is committed or not, need retry.\n",
+		       DP_DTI(&dte->dte_xid));
+		return DSHR_NEED_RETRY;
+	case DTX_ST_PREPARED: {
+		struct dtx_memberships	*mbs = dte->dte_mbs;
+
+		/* If the transaction across multiple redundancy groups,
+		 * need to check whether there are enough alive targets.
+		 */
+		if (mbs->dm_grp_cnt > 1 &&
+		    !dtx_verify_groups(cont->sc_pool->spc_pool, mbs,
+				       &dte->dte_xid, tgt_array)) {
+			/* XXX: For the distributed transaction that lose too
+			 *	many particiants (the whole redundancy group),
+			 *	it's difficult to make decision whether commit
+			 *	or abort the DTX. we need more human knowledge
+			 *	to manually recover related things.
+			 *
+			 *	Then we mark the TX as corrupted via special
+			 *	dtx_abort() with 0 @epoch.
+			 */
+			rc = dtx_abort(cont, 0, &dte, 1);
+			if (rc < 0 && err != NULL)
+				*err = rc;
+
+			return DSHR_CORRUPT;
+		}
+
+		return DSHR_NEED_COMMIT;
+	}
+	case -DER_NONEXIST:
+		/* Someone (the DTX owner or batched commit ULT) may have
+		 * committed or aborted the DTX during we handling other
+		 * DTXs. So double check the status before next action.
+		 */
+		rc = vos_dtx_check(cont->sc_hdl, &dte->dte_xid,
+				   NULL, NULL, NULL, false);
+
+		/* Skip this DTX that it may has been committed or aborted. */
+		if (rc == DTX_ST_COMMITTED || rc == DTX_ST_COMMITTABLE ||
+		    rc == -DER_NONEXIST)
+			D_GOTO(out, rc = DSHR_COMMITTED);
+
+		/* Skip this DTX if failed to get the status. */
+		if (rc != DTX_ST_PREPARED) {
+			D_WARN("Not sure about whether the DTX "DF_DTI
+			       " can be abort or not: %d, skip it.\n",
+			       DP_DTI(&dte->dte_xid), rc);
+			D_GOTO(out, rc = (rc > 0 ? -DER_IO : rc));
+		}
+
+		/* To be aborted. It is possible that the client has resent
+		 * related RPC to the new leader, but such DTX is still not
+		 * committable yet. Here, the resync logic will abort it by
+		 * race during the new leader waiting for other replica(s).
+		 * The dtx_abort() logic will abort the local DTX firstly.
+		 * When the leader get replies from other replicas, it will
+		 * check whether local DTX is still valid or not.
+		 *
+		 * If we abort multiple non-ready DTXs together, then there
+		 * is race that one DTX may become committable when we abort
+		 * some other DTX(s). To avoid complex rollback logic, let's
+		 * abort the DTXs one by one, not batched.
+		 */
+		rc = dtx_abort(cont, epoch, &dte, 1);
+
+		D_DEBUG(DB_TRACE,
+			"As the new leader for TX "DF_DTI", abort it: "
+			DF_RC"\n", DP_DTI(&dte->dte_xid), DP_RC(rc));
+
+		if (rc < 0) {
+			if (err != NULL)
+				*err = rc;
+
+			return DSHR_ABORT_FAILED;
+		}
+
+		return DSHR_ABORTED;
+	default:
+		D_WARN("Not sure about whether the DTX "DF_DTI
+		       " can be committed or not: %d, skip it.\n",
+		       DP_DTI(&dte->dte_xid), rc);
+		if (rc > 0)
+			rc = -DER_IO;
+		break;
+	}
+
+out:
+	return rc;
+}
+
 static int
 dtx_status_handle(struct dtx_resync_args *dra)
 {
@@ -203,7 +316,6 @@ dtx_status_handle(struct dtx_resync_args *dra)
 	struct dtx_resync_head		*drh = &dra->tables;
 	struct dtx_resync_entry		*dre;
 	struct dtx_resync_entry		*next;
-	struct dtx_entry		*dte;
 	struct ds_pool			*pool = cont->sc_pool->spc_pool;
 	int				*tgt_array = NULL;
 	int				 tgt_cnt;
@@ -224,12 +336,10 @@ dtx_status_handle(struct dtx_resync_args *dra)
 		D_GOTO(out, err = -DER_NOMEM);
 
 	d_list_for_each_entry_safe(dre, next, &drh->drh_list, dre_link) {
-		struct dtx_memberships	*mbs = dre->dre_dte.dte_mbs;
-
 		if (cont->sc_closing)
 			goto out;
 
-		if (mbs->dm_dte_flags & DTE_LEADER)
+		if (dre->dre_dte.dte_mbs->dm_dte_flags & DTE_LEADER)
 			goto commit;
 
 		rc = dtx_is_leader(pool, dra, dre);
@@ -246,108 +356,23 @@ dtx_status_handle(struct dtx_resync_args *dra)
 			continue;
 		}
 
-		rc = dtx_check(cont, &dre->dre_dte, dre->dre_epoch);
-
-		/* The DTX has been committed on some remote replica(s),
-		 * let's commit the DTX globally.
-		 */
-		if (rc == DTX_ST_COMMITTED || rc == DTX_ST_COMMITTABLE)
+		rc = dtx_status_handle_one(cont, &dre->dre_dte, dre->dre_epoch,
+					   tgt_array, &err);
+		switch (rc) {
+		case DSHR_NEED_COMMIT:
 			goto commit;
-
-		if (rc == DTX_ST_PREPARED) {
-			/* If the transaction across multiple redundancy groups,
-			 * need to check whether there are enough alive targets.
-			 */
-			if (mbs->dm_grp_cnt > 1 &&
-			    !dtx_verify_groups(pool, mbs, &dre->dre_xid,
-					       tgt_array)) {
-				/* XXX: For the distributed transaction that
-				 *	lose too many particiants (the whole
-				 *	redundancy group), it's difficult to
-				 *	make decision whether commit or abort
-				 *	the DTX. we need more human knowledge
-				 *	to manually recover related things.
-				 *
-				 *	Then we will mark the TX as corrupted
-				 *	via special dtx_abort() with 0 @epoch.
-				 */
-				dte = &dre->dre_dte;
-				rc = dtx_abort(cont, 0, &dte, 1);
-				if (rc < 0)
-					err = rc;
-
-				dtx_dre_release(drh, dre);
-				continue;
-			}
-
-			goto commit;
-		}
-
-		if (rc == -DER_INPROGRESS) {
-			D_WARN("Other participants not sure about whether the "
-			       "DTX "DF_DTI" can be committed or not, retry.\n",
-			       DP_DTI(&dre->dre_xid));
+		case DSHR_NEED_RETRY:
 			d_list_del(&dre->dre_link);
 			d_list_add_tail(&dre->dre_link, &drh->drh_list);
 			continue;
-		}
-
-		if (rc != -DER_NONEXIST) {
-			D_WARN("Not sure about whether the DTX "DF_DTI
-			       " can be committed or not: %d, skip it.\n",
-			       DP_DTI(&dre->dre_xid), rc);
+		case DSHR_COMMITTED:
+		case DSHR_ABORTED:
+		case DSHR_ABORT_FAILED:
+		case DSHR_CORRUPT:
+		default:
 			dtx_dre_release(drh, dre);
 			continue;
 		}
-
-		/* Someone (the DTX owner or batched commit ULT) may have
-		 * committed or aborted the DTX during we handling other
-		 * DTXs. So double check the status before next action.
-		 */
-		rc = vos_dtx_check(cont->sc_hdl, &dre->dre_xid,
-				   NULL, NULL, NULL, false);
-
-		/* Skip this DTX that it may has been committed or aborted. */
-		if (rc == DTX_ST_COMMITTED || rc == DTX_ST_COMMITTABLE ||
-		    rc == -DER_NONEXIST) {
-			dtx_dre_release(drh, dre);
-			continue;
-		}
-
-		/* Skip this DTX if failed to get the status. */
-		if (rc != DTX_ST_PREPARED) {
-			D_WARN("Not sure about whether the DTX "DF_DTI
-			       " can be abort or not: %d, skip it.\n",
-			       DP_DTI(&dre->dre_xid), rc);
-			dtx_dre_release(drh, dre);
-			continue;
-		}
-
-		/* To be aborted. It is possible that the client has resent
-		 * related RPC to the new leader, but such DTX is still not
-		 * committable yet. Here, the resync logic will abort it by
-		 * race during the new leader waiting for other replica(s).
-		 * The dtx_abort() logic will abort the local DTX firstly.
-		 * When the leader get replies from other replicas, it will
-		 * check whether local DTX is still valid or not.
-		 *
-		 * If we abort multiple non-ready DTXs together, then there
-		 * is race that one DTX may become committable when we abort
-		 * some other DTX(s). To avoid complex rollback logic, let's
-		 * abort the DTXs one by one, not batched.
-		 */
-		dte = &dre->dre_dte;
-		rc = dtx_abort(cont, dre->dre_epoch, &dte, 1);
-
-		D_DEBUG(DB_TRACE, "As the new leader for TX "
-			DF_DTI", abort it: "DF_RC"\n",
-			DP_DTI(&dre->dre_xid), DP_RC(rc));
-
-		if (rc < 0)
-			err = rc;
-
-		dtx_dre_release(drh, dre);
-		continue;
 
 commit:
 		D_DEBUG(DB_TRACE, "As the new leader for TX "

--- a/src/dtx/dtx_rpc.c
+++ b/src/dtx/dtx_rpc.c
@@ -58,10 +58,14 @@ struct dtx_req_args {
 	int				 dra_length;
 	/* The collective RPC result. */
 	int				 dra_result;
-	/* Pointer to the DTX handle, used for DTX_REFRESH case. */
-	struct dtx_handle		*dra_dth;
 	/* Pointer to the container, used for DTX_REFRESH case. */
 	struct ds_cont_child		*dra_cont;
+	/* Pointer to the committed DTX list, used for DTX_REFRESH case. */
+	d_list_t			*dra_cmt_list;
+	/* Pointer to the aborted DTX list, used for DTX_REFRESH case. */
+	d_list_t			*dra_abt_list;
+	/* Pointer to the active DTX list, used for DTX_REFRESH case. */
+	d_list_t			*dra_act_list;
 };
 
 /* The record for the DTX classify-tree in DRAM.
@@ -128,7 +132,6 @@ dtx_req_cb(const struct crt_cb_info *cb_info)
 		D_GOTO(out, rc = -DER_PROTO);
 
 	for (i = 0; i < dout->do_sub_rets.ca_count; i++) {
-		struct dtx_handle	*dth = dra->dra_dth;
 		struct dtx_share_peer	*dsp;
 		int			*ret;
 		int			 rc1;
@@ -142,15 +145,20 @@ dtx_req_cb(const struct crt_cb_info *cb_info)
 
 		switch (*ret) {
 		case DTX_ST_PREPARED:
-		case -DER_INPROGRESS:
 			/* Not committable yet. */
-			d_list_add_tail(&dsp->dsp_link,
-					&dth->dth_share_act_list);
+			if (dra->dra_act_list != NULL)
+				d_list_add_tail(&dsp->dsp_link,
+						dra->dra_act_list);
+			else
+				D_FREE(dsp);
 			break;
 		case DTX_ST_COMMITTABLE:
 			/* Committable, will be committed soon. */
-			d_list_add_tail(&dsp->dsp_link,
-					&dth->dth_share_cmt_list);
+			if (dra->dra_cmt_list != NULL)
+				d_list_add_tail(&dsp->dsp_link,
+						dra->dra_cmt_list);
+			else
+				D_FREE(dsp);
 			break;
 		case DTX_ST_COMMITTED:
 			/* Has been committed on leader, we may miss related
@@ -158,9 +166,10 @@ dtx_req_cb(const struct crt_cb_info *cb_info)
 			 */
 			rc1 = vos_dtx_commit(dra->dra_cont->sc_hdl,
 					     &dsp->dsp_xid, 1, NULL);
-			if (rc1 < 0 && rc1 != -DER_NONEXIST)
+			if (rc1 < 0 && rc1 != -DER_NONEXIST &&
+			    dra->dra_cmt_list != NULL)
 				d_list_add_tail(&dsp->dsp_link,
-						&dth->dth_share_cmt_list);
+						dra->dra_cmt_list);
 			else
 				D_FREE(dsp);
 			break;
@@ -175,9 +184,10 @@ dtx_req_cb(const struct crt_cb_info *cb_info)
 			 */
 			rc1 = vos_dtx_abort(dra->dra_cont->sc_hdl,
 					    DAOS_EPOCH_MAX, &dsp->dsp_xid, 1);
-			if (rc1 < 0 && rc1 != -DER_NONEXIST)
+			if (rc1 < 0 && rc1 != -DER_NONEXIST &&
+			    dra->dra_abt_list != NULL)
 				d_list_add_tail(&dsp->dsp_link,
-						&dth->dth_share_act_list);
+						dra->dra_abt_list);
 			else
 				D_FREE(dsp);
 			break;
@@ -263,6 +273,12 @@ dtx_req_list_cb(void **args)
 					"on %d/%d.\n", DP_DTI(drr->drr_dti),
 					drr->drr_rank, drr->drr_tag);
 				return;
+			case -DER_EVICTED:
+				/* If non-leader is evicted, handle it
+				 * as 'prepared'. If other non-leaders
+				 * also 'prepared' then related DTX is
+				 * committable. Fall through.
+				 */
 			case DTX_ST_PREPARED:
 				if (dra->dra_result == 0 ||
 				    dra->dra_result == DTX_ST_CORRUPTED)
@@ -321,7 +337,8 @@ dtx_req_wait(struct dtx_req_args *dra)
 static int
 dtx_req_list_send(struct dtx_req_args *dra, crt_opcode_t opc, d_list_t *head,
 		  int len, uuid_t po_uuid, uuid_t co_uuid, daos_epoch_t epoch,
-		  struct dtx_handle *dth, struct ds_cont_child *cont)
+		  struct ds_cont_child *cont, d_list_t *cmt_list,
+		  d_list_t *abt_list, d_list_t *act_list)
 {
 	ABT_future		 future;
 	struct dtx_req_rec	*drr;
@@ -334,8 +351,10 @@ dtx_req_list_send(struct dtx_req_args *dra, crt_opcode_t opc, d_list_t *head,
 	dra->dra_list = head;
 	dra->dra_length = len;
 	dra->dra_result = 0;
-	dra->dra_dth = dth;
 	dra->dra_cont = cont;
+	dra->dra_cmt_list = cmt_list;
+	dra->dra_abt_list = abt_list;
+	dra->dra_act_list = act_list;
 
 	rc = ABT_future_create(len, dtx_req_list_cb, &future);
 	if (rc != ABT_SUCCESS) {
@@ -590,7 +609,7 @@ dtx_commit(struct ds_cont_child *cont, struct dtx_entry **dtes,
 	if (!d_list_empty(&head)) {
 		rc = dtx_req_list_send(&dra, DTX_COMMIT, &head, length,
 				       pool->sp_uuid, cont->sc_uuid, 0,
-				       NULL, NULL);
+				       NULL, NULL, NULL, NULL);
 		if (rc != 0)
 			goto out;
 	}
@@ -676,7 +695,7 @@ dtx_abort(struct ds_cont_child *cont, daos_epoch_t epoch,
 	if (rc == 0 && !d_list_empty(&head)) {
 		rc = dtx_req_list_send(&dra, DTX_ABORT, &head, length,
 				       pool->sp_uuid, cont->sc_uuid, epoch,
-				       NULL, NULL);
+				       NULL, NULL, NULL, NULL);
 		if (rc != 0)
 			goto out;
 
@@ -772,7 +791,7 @@ dtx_check(struct ds_cont_child *cont, struct dtx_entry *dte, daos_epoch_t epoch)
 	}
 
 	rc = dtx_req_list_send(&dra, DTX_CHECK, &head, length, pool->sp_uuid,
-			       cont->sc_uuid, epoch, NULL, NULL);
+			       cont->sc_uuid, epoch, NULL, NULL, NULL, NULL);
 	if (rc == 0)
 		rc = dtx_req_wait(&dra);
 
@@ -785,60 +804,92 @@ out:
 	return rc;
 }
 
-/*
- * Because of async batched commit semantics, the DTX status on the leader
- * maybe different from the one on non-leaders. For the leader, it exactly
- * knows whether the DTX is committable or not, but the non-leader does not
- * know if the DTX is in 'prepared' status. If someone on non-leader wants
- * to know whether some 'prepared' DTX is real committable or not, it needs
- * to refresh such DTX status from the leader. The DTX_REFRESH RPC is used
- * for such purpose.
- */
 int
-dtx_refresh(struct dtx_handle *dth, struct ds_cont_child *cont)
+dtx_refresh_internal(struct ds_cont_child *cont, int *check_count,
+		     d_list_t *check_list, d_list_t *cmt_list,
+		     d_list_t *abt_list, d_list_t *act_list, bool failout)
 {
 	struct ds_pool		*pool = cont->sc_pool->spc_pool;
 	struct pool_target	*target;
 	struct dtx_share_peer	*dsp;
+	struct dtx_share_peer	*tmp;
 	struct dtx_req_rec	*drr;
 	struct dtx_req_args	 dra;
 	d_list_t		 head;
+	d_list_t		 self;
+	d_rank_t		 myrank;
 	int			 len = 0;
 	int			 rc = 0;
 
-	if (DAOS_FAIL_CHECK(DAOS_DTX_NO_RETRY))
-		return -DER_IO;
-
 	D_INIT_LIST_HEAD(&head);
+	D_INIT_LIST_HEAD(&self);
+	crt_group_rank(NULL, &myrank);
 
-	d_list_for_each_entry(dsp, &dth->dth_share_tbd_list, dsp_link) {
-		if (dsp->dsp_leader == PO_COMP_ID_ALL) {
+	d_list_for_each_entry_safe(dsp, tmp, check_list, dsp_link) {
+		uint32_t	leader = PO_COMP_ID_ALL;
+		bool		drop = false;
+
+		if (!(dsp->dsp_mbs.dm_flags & DMF_CONTAIN_LEADER)) {
 
 again:
 			rc = ds_pool_elect_dtx_leader(pool, &dsp->dsp_oid,
-						      dth->dth_ver);
+						      pool->sp_map_version);
 			if (rc < 0) {
-				D_ERROR("Failed to find DTX leader for "DF_DTI
-					": "DF_RC"\n",
-					DP_DTI(&dsp->dsp_xid), DP_RC(rc));
-				goto out;
+				D_ERROR("Failed to find DTX leader for "
+					DF_DTI", ver %d: "DF_RC"\n",
+					DP_DTI(&dsp->dsp_xid),
+					pool->sp_map_version, DP_RC(rc));
+
+				if (failout)
+					goto out;
+
+				drop = true;
+				goto next;
 			}
 
-			/* Still get the same leader, ask client to retry. */
-			if (dsp->dsp_leader == rc)
-				D_GOTO(out, rc = -DER_INPROGRESS);
+			/* Still get the same leader. That is abnormal. */
+			if (leader == rc) {
+				D_ERROR("Get DTX leader on %d (rebuilding) for "
+					DF_DTI", that is abnormal, ver is %d\n",
+					rc, DP_DTI(&dsp->dsp_xid),
+					pool->sp_map_version);
 
-			dsp->dsp_leader = rc;
+				if (failout)
+					D_GOTO(out, rc = -DER_IO);
+
+				drop = true;
+				goto next;
+			}
+
+			leader = rc;
+		} else {
+			leader = dsp->dsp_mbs.dm_tgts[0].ddt_id;
 		}
 
 		ABT_rwlock_wrlock(pool->sp_lock);
-		rc = pool_map_find_target(pool->sp_map, dsp->dsp_leader,
-					  &target);
+		rc = pool_map_find_target(pool->sp_map, leader, &target);
 		ABT_rwlock_unlock(pool->sp_lock);
 		D_ASSERT(rc == 1);
 
-		/* The leader is not healthy, related DTX will be resynced
-		 * by the new leader, let's find out new leader and retry.
+		/* If current server is the leader, then two possible cases:
+		 *
+		 * 1. In DTX resync, the status may be resolved sometime later.
+		 * 2. The DTX resync is done, but failed to handle related DTX.
+		 */
+		if (myrank == target->ta_comp.co_rank &&
+		    dss_get_module_info()->dmi_tgt_id ==
+		    target->ta_comp.co_index) {
+			d_list_del(&dsp->dsp_link);
+			d_list_add_tail(&dsp->dsp_link, &self);
+			if (--(*check_count) == 0)
+				break;
+			continue;
+		}
+
+		/* Usually, we will not elect in-rebuilding server as DTX
+		 * leader. But we may be blocked by the ABT_rwlock_wrlock,
+		 * then pool map may be refreshed during that. Let's retry
+		 * to find out the new leader.
 		 */
 		if (target->ta_comp.co_status != PO_COMP_ST_UPIN)
 			goto again;
@@ -856,13 +907,13 @@ again:
 		if (drr == NULL)
 			D_GOTO(out, rc = -DER_NOMEM);
 
-		D_ALLOC_ARRAY(drr->drr_dti, dth->dth_share_tbd_count);
+		D_ALLOC_ARRAY(drr->drr_dti, *check_count);
 		if (drr->drr_dti == NULL) {
 			D_FREE(drr);
 			D_GOTO(out, rc = -DER_NOMEM);
 		}
 
-		D_ALLOC_ARRAY(drr->drr_cb_args, dth->dth_share_tbd_count);
+		D_ALLOC_ARRAY(drr->drr_cb_args, *check_count);
 		if (drr->drr_cb_args == NULL) {
 			D_FREE(drr->drr_dti);
 			D_FREE(drr);
@@ -878,15 +929,77 @@ again:
 		len++;
 
 next:
-		d_list_del(&dsp->dsp_link);
-		dth->dth_share_tbd_count--;
-		D_ASSERT(dth->dth_share_tbd_count >= 0);
+		d_list_del_init(&dsp->dsp_link);
+		if (drop)
+			D_FREE(dsp);
+		if (--(*check_count) == 0)
+			break;
 	}
 
-	rc = dtx_req_list_send(&dra, DTX_REFRESH, &head, len,
-			       pool->sp_uuid, cont->sc_uuid, 0, dth, cont);
-	if (rc == 0)
-		rc = dtx_req_wait(&dra);
+	if (len > 0) {
+		rc = dtx_req_list_send(&dra, DTX_REFRESH, &head, len,
+				       pool->sp_uuid, cont->sc_uuid, 0, cont,
+				       cmt_list, abt_list, act_list);
+		if (rc == 0)
+			rc = dtx_req_wait(&dra);
+
+		if (rc != 0)
+			goto out;
+	}
+
+	/* Handle the entries whose leaders are on current server. */
+	d_list_for_each_entry_safe(dsp, tmp, &self, dsp_link) {
+		struct dtx_entry	 dte;
+
+		d_list_del(&dsp->dsp_link);
+
+		dte.dte_xid = dsp->dsp_xid;
+		dte.dte_ver = pool->sp_map_version;
+		dte.dte_refs = 1;
+		dte.dte_mbs = &dsp->dsp_mbs;
+
+		rc = dtx_status_handle_one(cont, &dte, dsp->dsp_epoch,
+					   NULL, NULL);
+		switch (rc) {
+		case DSHR_NEED_COMMIT: {
+			struct dtx_entry	*pdte = &dte;
+
+			rc = dtx_commit(cont, &pdte, 1, true);
+			if (rc < 0 && rc != -DER_NONEXIST && cmt_list != NULL)
+				d_list_add_tail(&dsp->dsp_link, cmt_list);
+			else
+				D_FREE(dsp);
+			continue;
+		}
+		case DSHR_NEED_RETRY:
+			D_FREE(dsp);
+			if (failout)
+				D_GOTO(out, rc = -DER_INPROGRESS);
+			continue;
+		case DSHR_COMMITTED:
+		case DSHR_ABORTED:
+			D_FREE(dsp);
+			continue;
+		case DSHR_ABORT_FAILED:
+			if (abt_list != NULL)
+				d_list_add_tail(&dsp->dsp_link, abt_list);
+			else
+				D_FREE(dsp);
+			continue;
+		case DSHR_CORRUPT:
+			D_FREE(dsp);
+			if (failout)
+				D_GOTO(out, rc = -DER_DATA_LOSS);
+			continue;
+		default:
+			D_FREE(dsp);
+			if (failout)
+				goto out;
+			continue;
+		}
+	}
+
+	rc = 0;
 
 out:
 	while ((drr = d_list_pop_entry(&head, struct dtx_req_rec,
@@ -896,19 +1009,46 @@ out:
 		D_FREE(drr);
 	}
 
-	/* If some DTX entry is corrupted, then reply -DER_DATA_LOSS.
-	 * Otherwise if we cannot resolve the DTX status, then reply
-	 * -DER_INPROGRESS to the client for retry in further. As for
-	 * the other cases, return -DER_AGAIN for retry locally.
+	while ((dsp = d_list_pop_entry(&self, struct dtx_share_peer,
+				       dsp_link)) != NULL)
+		D_FREE(dsp);
+
+	return rc;
+}
+
+/*
+ * Because of async batched commit semantics, the DTX status on the leader
+ * maybe different from the one on non-leaders. For the leader, it exactly
+ * knows whether the DTX is committable or not, but the non-leader does not
+ * know if the DTX is in 'prepared' status. If someone on non-leader wants
+ * to know whether some 'prepared' DTX is real committable or not, it needs
+ * to refresh such DTX status from the leader. The DTX_REFRESH RPC is used
+ * for such purpose.
+ */
+int
+dtx_refresh(struct dtx_handle *dth, struct ds_cont_child *cont)
+{
+	int	rc;
+
+	if (DAOS_FAIL_CHECK(DAOS_DTX_NO_RETRY))
+		return -DER_IO;
+
+	rc = dtx_refresh_internal(cont, &dth->dth_share_tbd_count,
+				  &dth->dth_share_tbd_list,
+				  &dth->dth_share_cmt_list,
+				  &dth->dth_share_abt_list,
+				  &dth->dth_share_act_list, true);
+
+	/* If we can resolve the DTX status, then return -DER_AGAIN
+	 * to the caller that will retry related operation locally.
 	 */
+	if (rc == 0) {
+		D_ASSERT(dth->dth_share_tbd_count == 0);
 
-	if (rc < 0)
-		return rc == -DER_DATA_LOSS ? rc : -DER_INPROGRESS;
+		vos_dtx_cleanup(dth);
+		dtx_handle_reinit(dth);
+		rc = -DER_AGAIN;
+	}
 
-	vos_dtx_cleanup(dth);
-	dtx_handle_reinit(dth);
-
-	D_ASSERT(dth->dth_share_tbd_count == 0);
-
-	return -DER_AGAIN;
+	return rc;
 }

--- a/src/include/daos_srv/dtx_srv.h
+++ b/src/include/daos_srv/dtx_srv.h
@@ -20,7 +20,8 @@ struct dtx_share_peer {
 	d_list_t		dsp_link;
 	struct dtx_id		dsp_xid;
 	daos_unit_oid_t		dsp_oid;
-	uint32_t		dsp_leader;
+	daos_epoch_t		dsp_epoch;
+	struct dtx_memberships	dsp_mbs;
 };
 
 /**
@@ -115,8 +116,13 @@ struct dtx_handle {
 	void				**dth_deferred;
 	/* NVME extents to release */
 	d_list_t			 dth_deferred_nvme;
+	/* Committed or comittable DTX list */
 	d_list_t			 dth_share_cmt_list;
+	/* Aborted DTX list */
+	d_list_t			 dth_share_abt_list;
+	/* Active DTX list */
 	d_list_t			 dth_share_act_list;
+	/* DTX list to be checked */
 	d_list_t			 dth_share_tbd_list;
 	int				 dth_share_tbd_count;
 };

--- a/src/vos/tests/vts_dtx.c
+++ b/src/vos/tests/vts_dtx.c
@@ -82,6 +82,7 @@ vts_dtx_begin(const daos_unit_oid_t *oid, daos_handle_t coh, daos_epoch_t epoch,
 	dth->dth_dkey_hash = dkey_hash;
 
 	D_INIT_LIST_HEAD(&dth->dth_share_cmt_list);
+	D_INIT_LIST_HEAD(&dth->dth_share_abt_list);
 	D_INIT_LIST_HEAD(&dth->dth_share_act_list);
 	D_INIT_LIST_HEAD(&dth->dth_share_tbd_list);
 	dth->dth_share_tbd_count = 0;
@@ -99,6 +100,11 @@ vts_dtx_end(struct dtx_handle *dth)
 
 	if (dth->dth_shares_inited) {
 		while ((dsp = d_list_pop_entry(&dth->dth_share_cmt_list,
+					       struct dtx_share_peer,
+					       dsp_link)) != NULL)
+			D_FREE(dsp);
+
+		while ((dsp = d_list_pop_entry(&dth->dth_share_abt_list,
 					       struct dtx_share_peer,
 					       dsp_link)) != NULL)
 			D_FREE(dsp);


### PR DESCRIPTION
There may be leader switch during the DTX resync and refresh.
If we used stale pool map, then we may find the wrong leader
that may be dead or does not know related DTX status.

If current server is the new DTX leader for DTX refresh, then
we need to do DTX check with other replicas as DTX resync does
to avoid blocking the refresh sponsor for very long time.

Signed-off-by: Fan Yong <fan.yong@intel.com>