### PR TITLE
DAOS-5465 csum: Corrupt BIO Address through VOS

### DIFF
--- a/doc/overview/data_integrity.md
+++ b/doc/overview/data_integrity.md
@@ -385,7 +385,7 @@ obj_iter_scrub(coh, epr, csummer, pool_uuid, event_handlers, entry, type)
   includes a CORRUPTED bit.
 - The vos update api already accepts a flag, so a CORRUPTED flag is added and
   handled during an update so that, if set, the bio address will be updated to
-  be corrupted.
+  be corrupted. (Implemented by DAOS-5465 and documented in src/vos/README.md)
 - On fetch, if a value is already marked corrupted, return -DER_CSUM
 
 ### Object Layer

--- a/src/common/tests_lib.c
+++ b/src/common/tests_lib.c
@@ -205,6 +205,7 @@ v_dts_sgl_init_with_strings_repeat(d_sg_list_t *sgl, uint32_t repeat,
 
 		arg = va_arg(valist, char *);
 	}
+	sgl->sg_nr_out = count;
 }
 
 void
@@ -226,4 +227,13 @@ dts_sgl_init_with_strings_repeat(d_sg_list_t *sgl, uint32_t repeat,
 	va_start(valist, d);
 	v_dts_sgl_init_with_strings_repeat(sgl, repeat, count, d, valist);
 	va_end(valist);
+}
+
+void
+dts_sgl_alloc_single_iov(d_sg_list_t *sgl, daos_size_t size)
+{
+	d_sgl_init(sgl, 1);
+	D_ALLOC(sgl->sg_iovs[0].iov_buf, size);
+	D_ASSERT(sgl->sg_iovs[0].iov_buf != NULL);
+	sgl->sg_iovs[0].iov_buf_len = size;
 }

--- a/src/include/daos/tests_lib.h
+++ b/src/include/daos/tests_lib.h
@@ -131,6 +131,9 @@ void
 dts_sgl_init_with_strings_repeat(d_sg_list_t *sgl, uint32_t repeat,
 				 uint32_t count, char *d, ...);
 
+void
+dts_sgl_alloc_single_iov(d_sg_list_t *sgl, daos_size_t size);
+
 #define DTS_CFG_MAX 256
 __attribute__ ((__format__(__printf__, 2, 3)))
 static inline void

--- a/src/include/daos_srv/bio.h
+++ b/src/include/daos_srv/bio.h
@@ -17,6 +17,13 @@
 #include <daos_srv/control.h>
 #include <abt.h>
 
+#define BIO_ADDR_IS_CORRUPTED(addr) ((addr)->ba_flags == BIO_FLAG_CORRUPTED)
+#define BIO_ADDR_SET_CORRUPTED(addr) ((addr)->ba_flags |= BIO_FLAG_CORRUPTED)
+
+enum BIO_FLAG {
+	BIO_FLAG_CORRUPTED = (1 << 0),
+};
+
 typedef struct {
 	/*
 	 * Byte offset within PMDK pmemobj pool for SCM;
@@ -28,7 +35,7 @@ typedef struct {
 	/* Is the address a hole ? */
 	uint16_t	ba_hole;
 	uint16_t	ba_dedup;
-	uint16_t	ba_padding;
+	uint16_t	ba_flags;
 } bio_addr_t;
 
 struct sys_db;

--- a/src/include/daos_srv/evtree.h
+++ b/src/include/daos_srv/evtree.h
@@ -288,6 +288,7 @@ struct evt_entry_in {
 	uint32_t		ei_inob;
 	/** Address of record to insert */
 	bio_addr_t		ei_addr;
+	bool			ei_corrupted;
 };
 
 enum evt_visibility {
@@ -313,6 +314,7 @@ struct evt_entry {
 	struct evt_extent		en_sel_ext;
 	/** checksums of the actual extent*/
 	struct dcs_csum_info		en_csum;
+	bool				en_corrupted;
 	/** pool map version */
 	uint32_t			en_ver;
 	/** Visibility flags for extent */

--- a/src/include/daos_srv/evtree.h
+++ b/src/include/daos_srv/evtree.h
@@ -288,7 +288,6 @@ struct evt_entry_in {
 	uint32_t		ei_inob;
 	/** Address of record to insert */
 	bio_addr_t		ei_addr;
-	bool			ei_corrupted;
 };
 
 enum evt_visibility {

--- a/src/include/daos_srv/vos_types.h
+++ b/src/include/daos_srv/vos_types.h
@@ -238,6 +238,7 @@ enum {
 	VOS_OF_PUNCH_PROPAGATE		= (1 << 14),
 	/** replay punch (underwrite) */
 	VOS_OF_REPLAY_PC		= (1 << 15),
+	VOS_OF_CORRUPT			= (1 << 16),
 };
 
 /** Mask for any conditionals passed to to the fetch */

--- a/src/include/daos_srv/vos_types.h
+++ b/src/include/daos_srv/vos_types.h
@@ -238,6 +238,7 @@ enum {
 	VOS_OF_PUNCH_PROPAGATE		= (1 << 14),
 	/** replay punch (underwrite) */
 	VOS_OF_REPLAY_PC		= (1 << 15),
+	/** Set when marking data as corrupted  */
 	VOS_OF_CORRUPT			= (1 << 16),
 };
 

--- a/src/vos/README.md
+++ b/src/vos/README.md
@@ -695,45 +695,82 @@ A special aggregation ULT processes aggregation, frequently yielding to avoid bl
 
 ## VOS Checksum Management
 
-VOS is responsible for storing checksums during an object update and retrieve checksums on an object fetch.
-Checksums will be stored with other VOS metadata in storage class memory.  For Single Value types, a single checksum is stored.
+VOS is responsible for storing checksums during an object update and retrieve
+checksums on an object fetch. Checksums will be stored with other VOS metadata
+in storage class memory. For Single Value types, a single checksum is stored.
 For Array Value types, multiple checksums can be stored based on the chunk size.
 
-The **Chunk Size** is defined as the maximum number of bytes of data that a checksum is derived from.
-While extents are defined in terms of records, the chunk size is defined in terms of bytes.
-When calculating the number of checksums needed for an extent, the number of records and the record size is needed.
-Checksums should typically be derived from Chunk Size bytes, however,
-if the extent is smaller than Chunk Size or an extent is not "Chunk Aligned," then a checksum might be derived from bytes smaller than Chunk Size.
+The **Chunk Size** is defined as the maximum number of bytes of data that a
+checksum is derived from. While extents are defined in terms of records, the
+chunk size is defined in terms of bytes. When calculating the number of
+checksums needed for an extent, the number of records and the record size is
+needed. Checksums should typically be derived from Chunk Size bytes, however, if
+the extent is smaller than Chunk Size or an extent is not "Chunk Aligned," then
+a checksum might be derived from bytes smaller than Chunk Size.
 
-The **Chunk Alignment** will have an absolute offset, not an I/O offset. So even if an extent is exactly, or less than, Chunk Size bytes long, it may have more than one Chunk if it crosses the alignment barrier.
+The **Chunk Alignment** will have an absolute offset, not an I/O offset. So even
+if an extent is exactly, or less than, Chunk Size bytes long, it may have more
+than one Chunk if it crosses the alignment barrier.
 
 ### Configuration
-Checksums will be configured for a container when a container is created. Checksum specific properties can be included in the daos_cont_create API.
-This configuration has not been fully implemented yet, but properties might include checksum type, chunk size, and server side verification.
+Checksums will be configured for a container when a container is created.
+Checksum specific properties can be included in the daos_cont_create API. This
+configuration has not been fully implemented yet, but properties might include
+checksum type, chunk size, and server side verification.
 
 ### Storage
-Checksums will be stored in a record(vos_irec_df) or extent(evt_desc) structure for Single Value types and Array Value types respectfully.
-Because the checksum can be of variable size, depending on the type of checksum configured, the checksum itself will be appended to the end of the structure.
-The size needed for checksums is included while allocating memory for the persistent structures on SCM (vos_reserve_single/vos_reserve_recx).
+Checksums will be stored in a record(vos_irec_df) or extent(evt_desc) structure
+for Single Value types and Array Value types respectfully. Because the checksum
+can be of variable size, depending on the type of checksum configured, the
+checksum itself will be appended to the end of the structure. The size needed
+for checksums is included while allocating memory for the persistent structures
+on SCM (vos_reserve_single/vos_reserve_recx).
 
-The following diagram illustrates the overall VOS layout and where checksums will be stored. Note that the checksum type isn't actually stored in vos_cont_df yet.
+The following diagram illustrates the overall VOS layout and where checksums
+will be stored. Note that the checksum type isn't actually stored in vos_cont_df
+yet.
 
 ![../../doc/graph/Fig_021.png](../../doc/graph/Fig_021.png "How checksum fits into the VOS Layout")
 
 
 ### Checksum VOS Flow (vos_obj_update/vos_obj_fetch)
 
-On update, the checksum(s) are part of the I/O Descriptor.
-Then, in akey_update_single/akey_update_recx, the checksum buffer pointer is included in the internal structures used for tree updates (vos_rec_bundle for SV and evt_entry_in for EV). As already mentioned, the size of the persistent structure allocated includes the size of the checksum(s). Finally, while storing the record (svt_rec_store) or extent (evt_insert), the checksum(s) are copied to the end of the persistent structure.
+On update, the checksum(s) are part of the I/O Descriptor. Then, in
+akey_update_single/akey_update_recx, the checksum buffer pointer is included in
+the internal structures used for tree updates (vos_rec_bundle for SV and
+evt_entry_in for EV). As already mentioned, the size of the persistent structure
+allocated includes the size of the checksum(s). Finally, while storing the
+record (svt_rec_store) or extent (evt_insert), the checksum(s) are copied to the
+end of the persistent structure.
 
 On a fetch, the update flow is essentially reversed.
 
 For reference, key junction points in the flows are:
-
  - SV Update: 	vos_update_end 	-> akey_update_single 	-> svt_rec_store
  - Sv Fetch: 	vos_fetch_begin -> akey_fetch_single 	-> svt_rec_load
  - EV Update: 	vos_update_end 	-> akey_update_recx 	-> evt_insert
  - EV Fetch: 	vos_fetch_begin -> akey_fetch_recx 	-> evt_fill_entry
+
+### Marking data as corrupted
+When data is discovered as being corrupted, the bio_addr will be marked with a
+corrupted flag to prevent subsequent verifications on data that is already known
+to be corrupted. The vos_obj_update API is reused to mark a bio_addr as
+corrupted.
+```
+vos_obj_update(container_hdl, object_id,
+               1, /* must be the same epoch that the corruption was found */
+               0, /* pool map version */
+               VOS_OF_CORRUPT, /* flag indicates marking as corrupt*/
+               dkey,
+               1,
+               iod, /* contains the info of what is to be marked as corrupt*/
+               NULL, /* no csum info is sent */
+               NULL) /* no data is sent */
+```
+
+This works because currently, evt_insert() supports "overwrites", which provides
+the ability to update the bio_addr. With NULL passed as the sgl, the data should
+not be overwritten.
 
 <a id="80"></a>
 

--- a/src/vos/evtree.c
+++ b/src/vos/evtree.c
@@ -1910,8 +1910,6 @@ evt_desc_copy(struct evt_context *tcx, const struct evt_entry_in *ent,
 
 	dst_desc->dc_ex_addr = ent->ei_addr;
 	dst_desc->dc_ver = ent->ei_ver;
-	if (ent->ei_corrupted)
-		BIO_ADDR_SET_CORRUPTED(&dst_desc->dc_ex_addr);
 	evt_desc_csum_fill(tcx, dst_desc, ent, csum_bufp);
 
 	return 0;
@@ -2879,8 +2877,6 @@ evt_common_insert(struct evt_context *tcx, struct evt_node *nd,
 		desc->dc_ex_addr = ent->ei_addr;
 		evt_desc_csum_fill(tcx, desc, ent, csum_bufp);
 		desc->dc_ver = ent->ei_ver;
-		if (ent->ei_corrupted)
-			BIO_ADDR_SET_CORRUPTED(&desc->dc_ex_addr);
 	} else {
 		nd->tn_child[i] = in_off;
 	}

--- a/src/vos/tests/vts_checksum.c
+++ b/src/vos/tests/vts_checksum.c
@@ -26,7 +26,7 @@ struct extent_key {
  */
 void
 extent_key_from_test_args(struct extent_key *k,
-			       struct io_test_args *args)
+			  struct io_test_args *args)
 {
 	/* Set up dkey and akey */
 	dts_key_gen(&k->dkey_buf[0], args->dkey_size, args->dkey);
@@ -405,6 +405,91 @@ update_fetch_csum_for_array_10(void **state)
 	});
 }
 
+static void
+mark_sv_corrupted(void **state)
+{
+	struct extent_key	 k = {0};
+	daos_iod_t		 iod = {0};
+	d_sg_list_t		 sgl = {0};
+	int			 rc = 0;
+
+	/** setup */
+	extent_key_from_test_args(&k, *state);
+	dts_sgl_init_with_strings(&sgl, 1, "Going to be corrupted!!");
+
+	iod.iod_name = k.akey;
+	iod.iod_size = daos_sgl_buf_size(&sgl);
+	iod.iod_nr = 1;
+	iod.iod_type = DAOS_IOD_SINGLE;
+
+	assert_success(vos_obj_update(k.container_hdl, k.object_id, 1, 0, 0,
+				      &k.dkey, 1, &iod, NULL, &sgl));
+
+	/** reset sgl and fetch just to sanity check that it works before
+	 * marking as corrupted
+	 */
+	memset(sgl.sg_iovs[0].iov_buf, 0, sgl.sg_iovs[0].iov_buf_len);
+	assert_success(vos_obj_fetch(k.container_hdl, k.object_id, 1, 0,
+				     &k.dkey, 1, &iod, &sgl));
+
+	/** Mark as corrupted using the corrupt flag */
+	assert_success(vos_obj_update(k.container_hdl, k.object_id, 1, 0,
+				      VOS_OF_CORRUPT,
+				      &k.dkey, 1, &iod, NULL, &sgl));
+
+	/** now should return a checksum error */
+	rc = vos_obj_fetch(k.container_hdl, k.object_id, 1, 0, &k.dkey, 1, &iod,
+			   &sgl);
+	assert_int_equal(-DER_CSUM, rc);
+
+	/** clean up */
+	d_sgl_fini(&sgl, true);
+}
+static void
+mark_extent_corrupted(void **state)
+{
+	struct extent_key	k;
+	daos_iod_t		iod = {0};
+	daos_recx_t		recx;
+	d_sg_list_t		sgl;
+	int			rc;
+
+	/** setup */
+	extent_key_from_test_args(&k, *state);
+	dts_sgl_init_with_strings(&sgl, 1, "Going to be corrupted!!");
+
+	recx.rx_nr = daos_sgl_buf_size(&sgl);
+	recx.rx_idx = 0;
+	iod.iod_name = k.akey;
+	iod.iod_size = 1;
+	iod.iod_nr = 1;
+	iod.iod_recxs = &recx;
+	iod.iod_type = DAOS_IOD_ARRAY;
+
+	assert_success(vos_obj_update(k.container_hdl, k.object_id, 1, 0, 0,
+				      &k.dkey, 1, &iod, NULL, &sgl));
+
+	/** reset sgl and fetch just to sanity check that it works before
+	 * marking as corrupted
+	 */
+	memset(sgl.sg_iovs[0].iov_buf, 0, sgl.sg_iovs[0].iov_buf_len);
+	assert_success(vos_obj_fetch(k.container_hdl, k.object_id, 1, 0,
+				     &k.dkey, 1, &iod, &sgl));
+
+	/** Mark as corrupted using the corrupt flag */
+	assert_success(vos_obj_update(k.container_hdl, k.object_id, 1, 0,
+				      VOS_OF_CORRUPT,
+				      &k.dkey, 1, &iod, NULL, &sgl));
+
+	/** now should return a checksum error */
+	rc = vos_obj_fetch(k.container_hdl, k.object_id, 1, 0, &k.dkey, 1, &iod,
+			   &sgl);
+	assert_int_equal(-DER_CSUM, rc);
+
+	/** clean up */
+	d_sgl_fini(&sgl, true);
+}
+
 /**
  * -------------------------------------
  * Helper function tests
@@ -723,18 +808,18 @@ test_evt_entry_csum_update(void **state)
 			 actual.cs_csum);
 }
 
-int setup(void **state)
+int vts_csum_setup(void **state)
 {
 	return 0;
 }
 
-int teardown(void **state)
+int vts_csum_teardown(void **state)
 {
 	return 0;
 }
 
 #define	VOS(desc, test_fn) \
-	{ "VOS_CSUM" desc, test_fn, setup, teardown}
+	{ "VOS_CSUM" desc, test_fn, vts_csum_setup, vts_csum_teardown}
 
 static const struct CMUnitTest update_fetch_checksums_for_array_types[] = {
 	VOS("01: Single chunk", update_fetch_csum_for_array_1),
@@ -747,10 +832,12 @@ static const struct CMUnitTest update_fetch_checksums_for_array_types[] = {
 	VOS("08: Partial -> more partial", update_fetch_csum_for_array_8),
 	VOS("09: Many sequential extents", update_fetch_csum_for_array_9),
 	VOS("10: Holes", update_fetch_csum_for_array_10),
+	VOS("11: Mark corrupted", mark_sv_corrupted),
+	VOS("12: Mark corrupted", mark_extent_corrupted),
 };
 
 #define	EVT(desc, test_fn) \
-	{ "EVT_CSUM" desc, test_fn, setup, teardown}
+	{ "EVT_CSUM" desc, test_fn, vts_csum_setup, vts_csum_teardown}
 static const struct CMUnitTest evt_checksums_tests[] = {
 	EVT("01: Some EVT Checksum Helper Functions",
 		evt_csum_helper_functions_tests),

--- a/src/vos/tests/vts_checksum.c
+++ b/src/vos/tests/vts_checksum.c
@@ -445,6 +445,7 @@ mark_sv_corrupted(void **state)
 	/** clean up */
 	d_sgl_fini(&sgl, true);
 }
+
 static void
 mark_extent_corrupted(void **state)
 {

--- a/src/vos/vos_internal.h
+++ b/src/vos/vos_internal.h
@@ -569,6 +569,8 @@ struct vos_rec_bundle {
 	umem_off_t		 rb_off;
 	/** checksum buffer for the daos key */
 	struct dcs_csum_info	*rb_csum;
+	/** The record is corrupted */
+	bool			 rb_corrupt;
 	/**
 	 * Input  : value buffer (non-rdma data)
 	 *	    TODO also support scatter/gather list input.

--- a/src/vos/vos_io.c
+++ b/src/vos/vos_io.c
@@ -1474,7 +1474,8 @@ akey_update_recx(daos_handle_t toh, uint32_t pm_ver, daos_recx_t *recx,
 	biov = iod_update_biov(ioc);
 	ent.ei_addr = biov->bi_addr;
 	ent.ei_addr.ba_dedup = false;	/* Don't make this flag persistent */
-	ent.ei_corrupted = ioc->ic_corrupt;
+	if (ioc->ic_corrupt)
+		BIO_ADDR_SET_CORRUPTED(&ent.ei_addr);
 
 	if (ioc->ic_remove)
 		return evt_remove_all(toh, &ent.ei_rect.rc_ex, &ioc->ic_epr);

--- a/src/vos/vos_io.c
+++ b/src/vos/vos_io.c
@@ -27,7 +27,7 @@ struct vos_io_context {
 	daos_unit_oid_t		 ic_oid;
 	struct vos_container	*ic_cont;
 	daos_iod_t		*ic_iods;
-	struct dcs_iod_csums	*iod_csums;
+	struct dcs_iod_csums	*ic_iod_csums;
 	/** reference on the object */
 	struct vos_object	*ic_obj;
 	/** BIO descriptor, has ic_iod_nr SGLs */
@@ -68,7 +68,8 @@ struct vos_io_context {
 				 ic_dedup:1, /** candidate for dedup */
 				 ic_read_ts_only:1,
 				 ic_check_existence:1,
-				 ic_remove:1;
+				 ic_remove:1,
+				 ic_corrupt:1;
 	/**
 	 * Input shadow recx lists, one for each iod. Now only used for degraded
 	 * mode EC obj fetch handling.
@@ -341,8 +342,9 @@ static struct dcs_csum_info *
 vos_ioc2csum(struct vos_io_context *ioc)
 {
 	/** is enabled and has csums (might not for punch) */
-	if (ioc->iod_csums != NULL && ioc->iod_csums[ioc->ic_sgl_at].ic_nr > 0)
-		return ioc->iod_csums[ioc->ic_sgl_at].ic_data;
+	if (ioc->ic_iod_csums != NULL &&
+	    ioc->ic_iod_csums[ioc->ic_sgl_at].ic_nr > 0)
+		return ioc->ic_iod_csums[ioc->ic_sgl_at].ic_data;
 	return NULL;
 }
 
@@ -490,7 +492,8 @@ vos_ioc_create(daos_handle_t coh, daos_unit_oid_t oid, bool read_only,
 	ioc->ic_remove =
 		((vos_flags & VOS_OF_REMOVE) != 0);
 	ioc->ic_umoffs_cnt = ioc->ic_umoffs_at = 0;
-	ioc->iod_csums = iod_csums;
+	ioc->ic_iod_csums = iod_csums;
+	ioc->ic_corrupt = (vos_flags & VOS_OF_CORRUPT) != 0;
 	vos_ilog_fetch_init(&ioc->ic_dkey_info);
 	vos_ilog_fetch_init(&ioc->ic_akey_info);
 	D_INIT_LIST_HEAD(&ioc->ic_blk_exts);
@@ -711,6 +714,9 @@ akey_fetch_single(daos_handle_t toh, const daos_epoch_range_t *epr,
 
 	if (ci_is_valid(&csum_info))
 		save_csum(ioc, &csum_info, NULL, 0);
+
+	if (rbund.rb_corrupt)
+		return -DER_CSUM;
 
 	rc = iod_fetch(ioc, &biov);
 	if (rc != 0)
@@ -1424,11 +1430,12 @@ akey_update_single(daos_handle_t toh, uint32_t pm_ver, daos_size_t rsize,
 	else
 		rbund.rb_csum	= &csum;
 
-	rbund.rb_biov	= biov;
-	rbund.rb_rsize	= rsize;
-	rbund.rb_gsize	= gsize;
-	rbund.rb_off	= umoff;
-	rbund.rb_ver	= pm_ver;
+	rbund.rb_biov		= biov;
+	rbund.rb_rsize		= rsize;
+	rbund.rb_gsize		= gsize;
+	rbund.rb_off		= umoff;
+	rbund.rb_ver		= pm_ver;
+	rbund.rb_corrupt	= ioc->ic_corrupt;
 
 	rc = dbtree_update(toh, &kiov, &riov);
 	if (rc != 0)
@@ -1467,6 +1474,7 @@ akey_update_recx(daos_handle_t toh, uint32_t pm_ver, daos_recx_t *recx,
 	biov = iod_update_biov(ioc);
 	ent.ei_addr = biov->bi_addr;
 	ent.ei_addr.ba_dedup = false;	/* Don't make this flag persistent */
+	ent.ei_corrupted = ioc->ic_corrupt;
 
 	if (ioc->ic_remove)
 		return evt_remove_all(toh, &ent.ei_rect.rc_ex, &ioc->ic_epr);
@@ -2272,7 +2280,7 @@ vos_set_io_csum(daos_handle_t ioh, struct dcs_iod_csums *csums)
 
 	D_ASSERT(ioc != NULL);
 
-	ioc->iod_csums = csums;
+	ioc->ic_iod_csums = csums;
 }
 /*
  * XXX Dup these two helper functions for this moment, implement

--- a/src/vos/vos_tree.c
+++ b/src/vos/vos_tree.c
@@ -453,6 +453,8 @@ svt_rec_store(struct btr_instance *tins, struct btr_record *rec,
 	irec->ir_ex_addr	= biov->bi_addr;
 	irec->ir_ver		= rbund->rb_ver;
 	irec->ir_minor_epc	= skey->sk_minor_epc;
+	if (rbund->rb_corrupt)
+		BIO_ADDR_SET_CORRUPTED(&irec->ir_ex_addr);
 
 	if (irec->ir_size == 0) { /* it is a punch */
 		csum->cs_csum = NULL;
@@ -516,6 +518,7 @@ svt_rec_load(struct btr_instance *tins, struct btr_record *rec,
 	rbund->rb_gsize	= irec->ir_gsize;
 	rbund->rb_ver	= irec->ir_ver;
 	rbund->rb_dtx_state = vos_dtx_ent_state(irec->ir_dtx);
+	rbund->rb_corrupt = BIO_ADDR_IS_CORRUPTED(&irec->ir_ex_addr);
 	return 0;
 }
 
@@ -718,8 +721,7 @@ svt_rec_fetch(struct btr_instance *tins, struct btr_record *rec,
 	if (key_iov != NULL)
 		key = iov2svt_key(key_iov);
 
-	svt_rec_load(tins, rec, key, rbund);
-	return 0;
+	return svt_rec_load(tins, rec, key, rbund);
 }
 
 static int


### PR DESCRIPTION
Add the ability to set a bio address as corrupted using the VOS
update API. This will be necessary for the checksum scrubber
to be able to mark data as corrupted when silent data
corruption is detected.

- Use extra padding in the bio_addr_t structure for flags and add a
  corrupted flag to indicate that data is corrupted.
- Add corrupted field to necessary structs in VOS to facilitate
  the setting/getting of the corrupted status of the data.
- Add VOS flag for setting data as corrupted.

Signed-off-by: Ryon Jensen <ryon.jensen@intel.com>