### PR TITLE
DAOS-7216 object: checksums for dedup transactional update

### DIFF
--- a/src/object/obj_internal.h
+++ b/src/object/obj_internal.h
@@ -486,6 +486,8 @@ int obj_shard_open(struct dc_object *obj, unsigned int shard,
 int obj_dkey2grpidx(struct dc_object *obj, uint64_t hash, unsigned int map_ver);
 int obj_pool_query_task(tse_sched_t *sched, struct dc_object *obj,
 			tse_task_t **taskp);
+bool obj_csum_dedup_candidate(struct cont_props *props, daos_iod_t *iods,
+			      uint32_t iod_nr);
 
 #define obj_shard_close(shard)	dc_obj_shard_close(shard)
 int obj_recx_ec_daos2shard(struct daos_oclass_attr *oca, int shard,


### PR DESCRIPTION
If checksums are only enabled for dedup purpose, then we need
to verify whether the I/O is a candidate for dedup or not. If
not, then do not need to provide a checksum to the server.

Master-PR: https://github.com/daos-stack/daos/pull/5423

Signed-off-by: Fan Yong <fan.yong@intel.com>