### PR TITLE
DAOS-7168 object: properly split request for EC object update

### DIFF
--- a/src/object/obj_ec.h
+++ b/src/object/obj_ec.h
@@ -657,7 +657,8 @@ int obj_ec_get_degrade(struct obj_reasb_req *reasb_req, uint16_t fail_tgt_idx,
 struct obj_rw_in;
 int obj_ec_rw_req_split(daos_unit_oid_t oid, struct obj_iod_array *iod_array,
 			uint32_t iod_nr, uint32_t start_shard,
-			uint32_t max_shard, void *tgt_map, uint32_t map_size,
+			uint32_t max_shard, uint32_t leader_id,
+			void *tgt_map, uint32_t map_size,
 			uint32_t tgt_nr, struct daos_shard_tgt *tgts,
 			struct obj_ec_split_req **split_req);
 void obj_ec_split_req_fini(struct obj_ec_split_req *req);

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -2363,8 +2363,8 @@ again:
 	if (orw->orw_iod_array.oia_oiods != NULL && split_req == NULL) {
 		rc = obj_ec_rw_req_split(orw->orw_oid, &orw->orw_iod_array,
 					 orw->orw_nr, orw->orw_start_shard,
-					 orw->orw_tgt_max, NULL, 0,
-					 orw->orw_shard_tgts.ca_count,
+					 orw->orw_tgt_max, PO_COMP_ID_ALL,
+					 NULL, 0, orw->orw_shard_tgts.ca_count,
 					 orw->orw_shard_tgts.ca_arrays,
 					 &split_req);
 		if (rc != 0) {
@@ -4166,8 +4166,9 @@ ds_obj_dtx_leader_prep_handle(struct daos_cpd_sub_head *dcsh,
 			      struct daos_shard_tgt *tgts,
 			      int tgt_cnt, int req_cnt, uint32_t *flags)
 {
-	int	rc = 0;
-	int	i;
+	struct dtx_daos_target	*ddt = &dcsh->dcsh_mbs->dm_tgts[0];
+	int			 rc = 0;
+	int			 i;
 
 	for (i = 0; i < req_cnt; i++) {
 		struct daos_cpd_sub_req		*dcsr;
@@ -4183,6 +4184,7 @@ ds_obj_dtx_leader_prep_handle(struct daos_cpd_sub_head *dcsh,
 
 		rc = obj_ec_rw_req_split(dcsr->dcsr_oid, &dcu->dcu_iod_array,
 					 dcsr->dcsr_nr, dcu->dcu_start_shard, 0,
+					 ddt->ddt_id,
 					 dcu->dcu_ec_tgts, dcsr->dcsr_ec_tgt_nr,
 					 tgt_cnt, tgts, &dcu->dcu_ec_split_req);
 		if (rc != 0) {


### PR DESCRIPTION
Usually, for a standalone EC object update, the parity shard with
the largest index will be used as related DTX leader. But for the
distributed transaction, the leader can be any shard of EC object,
or the leader can be some server that out of the EC object layout.
Under such case, when split EC object update request on the leader
via obj_ec_rw_req_split(), we cannot assume that the leader always
be the last shard, instead, the caller needs to explicitly specify
which one is the leader. Otherwise the sub-request to the sent to
other non-leader may be dispatched to the leader server (locally).

Master-PR: https://github.com/daos-stack/daos/pull/5408

Signed-off-by: Fan Yong <fan.yong@intel.com>