### PR TITLE
DAOS-7235 obj: turn off read/write perm when cont_rf broken

### DIFF
--- a/src/client/api/container.c
+++ b/src/client/api/container.c
@@ -199,6 +199,55 @@ daos_cont_set_prop(daos_handle_t coh, daos_prop_t *prop, daos_event_t *ev)
 	return dc_task_schedule(task, true);
 }
 
+static int
+dcsc_prop_free(tse_task_t *task, void *data)
+{
+	daos_prop_t *prop = *((daos_prop_t **)data);
+
+	daos_prop_free(prop);
+	return task->dt_result;
+}
+
+int
+daos_cont_status_clear(daos_handle_t coh, daos_event_t *ev)
+{
+	daos_cont_set_prop_t	*args;
+	daos_prop_t		*prop;
+	struct daos_prop_entry	*entry;
+	tse_task_t		*task;
+	int			 rc;
+
+	prop = daos_prop_alloc(1);
+	if (prop == NULL)
+		return -DER_NOMEM;
+
+	entry = &prop->dpp_entries[0];
+	entry->dpe_type = DAOS_PROP_CO_STATUS;
+	entry->dpe_val = DAOS_PROP_CO_STATUS_VAL(DAOS_PROP_CO_HEALTHY,
+						 DAOS_PROP_CO_CLEAR, 0);
+
+	DAOS_API_ARG_ASSERT(*args, CONT_SET_PROP);
+	rc = dc_task_create(dc_cont_set_prop, NULL, ev, &task);
+	if (rc) {
+		daos_prop_free(prop);
+		return rc;
+	}
+
+	args = dc_task_get_args(task);
+	args->coh	= coh;
+	args->prop	= prop;
+
+	rc = tse_task_register_comp_cb(task, dcsc_prop_free, &prop,
+				       sizeof(prop));
+	if (rc) {
+		daos_prop_free(prop);
+		tse_task_complete(task, rc);
+		return rc;
+	}
+
+	return dc_task_schedule(task, true);
+}
+
 int
 daos_cont_overwrite_acl(daos_handle_t coh, struct daos_acl *acl,
 			daos_event_t *ev)

--- a/src/container/srv_container.c
+++ b/src/container/srv_container.c
@@ -427,7 +427,7 @@ cont_create_prop_prepare(daos_prop_t *prop_def, daos_prop_t *prop,
 	/* for new container set HEALTHY status with current pm ver */
 	entry_def = daos_prop_entry_get(prop_def, DAOS_PROP_CO_STATUS);
 	D_ASSERT(entry_def != NULL);
-	entry_def->dpe_val = DAOS_PROP_CO_STATUS_VAL(DAOS_PROP_CO_HEALTHY,
+	entry_def->dpe_val = DAOS_PROP_CO_STATUS_VAL(DAOS_PROP_CO_HEALTHY, 0,
 						     pm_ver);
 
 	return 0;
@@ -438,6 +438,7 @@ cont_prop_write(struct rdb_tx *tx, const rdb_path_t *kvs, daos_prop_t *prop)
 {
 	struct daos_prop_entry	*entry;
 	d_iov_t			value;
+	struct daos_co_status	stat;
 	int			i;
 	int			rc = 0;
 
@@ -593,6 +594,10 @@ cont_prop_write(struct rdb_tx *tx, const rdb_path_t *kvs, daos_prop_t *prop)
 			}
 			break;
 		case DAOS_PROP_CO_STATUS:
+			/* DAOS_PROP_CO_CLEAR only used for iv_prop_update */
+			daos_prop_val_2_co_status(entry->dpe_val, &stat);
+			stat.dcs_flags = 0;
+			entry->dpe_val = daos_prop_co_status_2_val(&stat);
 			d_iov_set(&value, &entry->dpe_val,
 				  sizeof(entry->dpe_val));
 			rc = rdb_tx_update(tx, kvs, &ds_cont_prop_co_status,
@@ -1423,31 +1428,18 @@ cont_status_is_healthy(daos_prop_t *prop, uint32_t *pm_ver)
 	return (stat.dcs_status == DAOS_PROP_CO_HEALTHY);
 }
 
-/* set DAOS_PROP_CO_UNCLEAN to container property (write to RDB, and update
- * \a prop so caller can update that prop to IV.
- */
-static int
+static void
 cont_status_set_unclean(struct rdb_tx *tx, struct ds_pool *pool,
 			struct cont *cont, daos_prop_t *prop)
 {
-	daos_prop_t		 tmp_prop = { 0 };
 	struct daos_prop_entry	*pentry;
-	uint32_t		 pm_ver;
-	int			 rc;
+	struct daos_co_status	 stat;
 
 	pentry = daos_prop_entry_get(prop, DAOS_PROP_CO_STATUS);
 	D_ASSERT(pentry != NULL);
-	pm_ver = ds_pool_get_version(pool);
-	pentry->dpe_val = DAOS_PROP_CO_STATUS_VAL(DAOS_PROP_CO_UNCLEAN, pm_ver);
-	tmp_prop.dpp_nr = 1;
-	tmp_prop.dpp_entries = pentry;
-
-	rc = cont_prop_write(tx, &cont->c_prop, &tmp_prop);
-	if (rc)
-		D_ERROR(DF_UUID": failed to cont_prop_write "DF_RC"\n",
-			DP_UUID(cont->c_uuid), DP_RC(rc));
-
-	return rc;
+	daos_prop_val_2_co_status(pentry->dpe_val, &stat);
+	stat.dcs_status = DAOS_PROP_CO_UNCLEAN;
+	pentry->dpe_val = daos_prop_co_status_2_val(&stat);
 }
 
 static int
@@ -1461,7 +1453,7 @@ cont_open(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl, struct cont *cont,
 	daos_prop_t	       *prop = NULL;
 	struct container_hdl	chdl;
 	char			zero = 0;
-	int			rc, rc1;
+	int			rc;
 	struct ownership	owner;
 	struct daos_acl		*acl;
 	bool			is_healthy;
@@ -1534,16 +1526,6 @@ cont_open(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl, struct cont *cont,
 		rf = daos_cont_prop2redunfac(prop);
 		rc = ds_pool_rf_verify(pool_hdl->sph_pool, stat_pm_ver, rf);
 		if (rc == -DER_RF) {
-			rc1 = cont_status_set_unclean(tx, pool_hdl->sph_pool,
-						      cont, prop);
-			if (rc1 != 0) {
-				D_ERROR(DF_CONT":set_unclean failed, "DF_RC"\n",
-					DP_CONT(cont->c_svc->cs_pool_uuid,
-						cont->c_uuid), DP_RC(rc1));
-				daos_prop_free(prop);
-				D_GOTO(out, rc1);
-			}
-
 			is_healthy = false;
 		} else if (rc) {
 			daos_prop_free(prop);
@@ -2180,8 +2162,6 @@ cont_status_check(struct rdb_tx *tx, struct ds_pool *pool, struct cont *cont,
 		  uint32_t last_ver)
 {
 	struct daos_prop_entry	*entry;
-	struct daos_prop_entry	*iv_entry;
-	daos_prop_t		*iv_prop = NULL;
 	int			 rf;
 	int			 rc;
 
@@ -2190,35 +2170,10 @@ cont_status_check(struct rdb_tx *tx, struct ds_pool *pool, struct cont *cont,
 	rf = daos_cont_prop2redunfac(prop);
 	rc = ds_pool_rf_verify(pool, last_ver, rf);
 	if (rc == -DER_RF) {
-		rc = cont_status_set_unclean(tx, pool, cont, prop);
-		if (rc) {
-			D_ERROR(DF_CONT": set_unclean failed, "DF_RC"\n",
-				DP_CONT(cont->c_svc->cs_pool_uuid,
-					cont->c_uuid), DP_RC(rc));
-			goto out;
-		}
-
-		/* update the prop to IV to keep consistency */
-		rc = cont_prop_read(tx, cont, DAOS_CO_QUERY_PROP_ALL, &iv_prop);
-		if (rc != 0)
-			goto out;
-		D_ASSERT(iv_prop != NULL);
-		D_ASSERT(iv_prop->dpp_nr == CONT_PROP_NUM);
-		entry = daos_prop_entry_get(prop, DAOS_PROP_CO_STATUS);
-		D_ASSERT(entry != NULL);
-		iv_entry = daos_prop_entry_get(iv_prop, DAOS_PROP_CO_STATUS);
-		D_ASSERT(iv_entry != NULL);
-		iv_entry->dpe_val = entry->dpe_val;
-		rc = cont_iv_prop_update(pool->sp_iv_ns, in->cqi_op.ci_uuid,
-					 iv_prop);
-		daos_prop_free(iv_prop);
-		if (rc)
-			D_ERROR(DF_CONT": iv_prop_update failed, "DF_RC"\n",
-				DP_CONT(cont->c_svc->cs_pool_uuid,
-					cont->c_uuid), DP_RC(rc));
+		rc = 0;
+		cont_status_set_unclean(tx, pool, cont, prop);
 	}
 
-out:
 	return rc;
 }
 
@@ -2442,27 +2397,32 @@ capas_can_set_prop(struct cont *cont, uint64_t sec_capas,
 }
 
 /* pre-processing for DAOS_PROP_CO_STATUS, set the pool map version */
-static void
+static bool
 set_prop_co_status_pre_process(struct ds_pool *pool, struct cont *cont,
 			       daos_prop_t *prop_in)
 {
 	struct daos_prop_entry	*entry;
 	struct daos_co_status	 co_status = { 0 };
+	bool			 clear_stat;
 
 	entry = daos_prop_entry_get(prop_in, DAOS_PROP_CO_STATUS);
 	if (entry == NULL)
-		return;
+		return false;
 
 	daos_prop_val_2_co_status(entry->dpe_val, &co_status);
 	D_ASSERT(co_status.dcs_status == DAOS_PROP_CO_HEALTHY ||
 		 co_status.dcs_status == DAOS_PROP_CO_UNCLEAN);
+	clear_stat = (co_status.dcs_flags == DAOS_PROP_CO_CLEAR);
 	co_status.dcs_pm_ver = ds_pool_get_version(pool);
+	co_status.dcs_flags = 0;
 	entry->dpe_val = daos_prop_co_status_2_val(&co_status);
 	D_DEBUG(DF_DSMS, DF_CONT" updating co_status - status %s, pm_ver %d.\n",
 		DP_CONT(pool->sp_uuid, cont->c_uuid),
 		co_status.dcs_status == DAOS_PROP_CO_HEALTHY ?
 		"DAOS_PROP_CO_HEALTHY" : "DAOS_PROP_CO_UNCLEAN",
 		co_status.dcs_pm_ver);
+
+	return clear_stat;
 }
 
 static int
@@ -2473,6 +2433,7 @@ set_prop(struct rdb_tx *tx, struct ds_pool *pool,
 	int		rc;
 	daos_prop_t	*prop_old = NULL;
 	daos_prop_t	*prop_iv = NULL;
+	bool		 clear_stat;
 
 	if (!daos_prop_valid(prop_in, false, true))
 		D_GOTO(out, rc = -DER_INVAL);
@@ -2488,7 +2449,7 @@ set_prop(struct rdb_tx *tx, struct ds_pool *pool,
 		D_GOTO(out, rc);
 	}
 	D_ASSERT(prop_old != NULL);
-	set_prop_co_status_pre_process(pool, cont, prop_in);
+	clear_stat = set_prop_co_status_pre_process(pool, cont, prop_in);
 	prop_iv = daos_prop_merge(prop_old, prop_in);
 	if (prop_iv == NULL)
 		D_GOTO(out, rc = -DER_NOMEM);
@@ -2499,9 +2460,19 @@ set_prop(struct rdb_tx *tx, struct ds_pool *pool,
 
 	/* Update prop IV with merged prop */
 	rc = cont_iv_prop_update(pool->sp_iv_ns, cont->c_uuid, prop_iv);
-	if (rc)
+	if (rc) {
 		D_ERROR(DF_UUID": failed to update prop IV for cont, "
-			"%d.\n", DP_UUID(cont->c_uuid), rc);
+			DF_RC"\n", DP_UUID(cont->c_uuid), DP_RC(rc));
+		goto out;
+	}
+
+	if (clear_stat) {
+		/* to notify each tgt server to do ds_cont_rf_check() */
+		rc = ds_pool_iv_map_update(pool, NULL, 0);
+		if (rc)
+			D_ERROR(DF_UUID": ds_pool_iv_map_update failed, "
+				DF_RC"\n", DP_UUID(cont->c_uuid), DP_RC(rc));
+	}
 
 out:
 	daos_prop_free(prop_old);

--- a/src/container/srv_layout.c
+++ b/src/container/srv_layout.c
@@ -104,7 +104,7 @@ struct daos_prop_entry cont_prop_entries_default[CONT_PROP_NUM] = {
 	}, {
 		.dpe_type	= DAOS_PROP_CO_STATUS,
 		.dpe_val	= DAOS_PROP_CO_STATUS_VAL(DAOS_PROP_CO_HEALTHY,
-							  0),
+							  0, 0),
 	}, {
 		.dpe_type	= DAOS_PROP_CO_ALLOCED_OID,
 		.dpe_val	= 0,

--- a/src/container/srv_target.c
+++ b/src/container/srv_target.c
@@ -22,6 +22,7 @@
 #define D_LOGFAC	DD_FAC(container)
 
 #include <daos_srv/container.h>
+#include <daos_srv/security.h>
 
 #include <daos/checksum.h>
 #include <daos/rpc.h>
@@ -1865,7 +1866,7 @@ cont_snapshots_refresh_ult(void *data)
 	ds_pool_put(pool);
 out:
 	if (rc != 0)
-		D_WARN(DF_UUID": failed to refresh snapshots IV: "
+		D_DEBUG(DB_TRACE, DF_UUID": failed to refresh snapshots IV: "
 		       "Aggregation may not work correctly "DF_RC"\n",
 		       DP_UUID(args->cont_uuid), DP_RC(rc));
 	D_FREE(args);
@@ -2389,4 +2390,196 @@ yield:
 	d_list_for_each_entry_safe(ec_eph, tmp, &pool->sp_ec_ephs_list,
 				   ce_list)
 		cont_ec_eph_destroy(ec_eph);
+}
+
+struct cont_rf_check_arg {
+	uuid_t			 crc_pool_uuid;
+	ABT_eventual		 crc_eventual;
+};
+
+struct cont_rw_set_arg {
+	uuid_t			crs_pool_uuid;
+	uuid_t			crs_cont_uuid;
+	bool			crs_rw_disable;
+};
+
+static int
+cont_rw_capa_set(void *data)
+{
+	struct dsm_tls		*tls = dsm_tls_get();
+	struct cont_rw_set_arg	*arg = data;
+	struct ds_cont_child	*cont_child;
+	int			 rc = 0;
+
+	rc = cont_child_lookup(tls->dt_cont_cache, arg->crs_cont_uuid,
+			       arg->crs_pool_uuid, false /* create */,
+			       &cont_child);
+	if (rc) {
+		D_ERROR(DF_CONT" cont_child_lookup failed, "DF_RC"\n",
+			DP_CONT(arg->crs_pool_uuid, arg->crs_cont_uuid),
+			DP_RC(rc));
+		if (rc == -DER_NONEXIST)
+			rc = 0;
+		return rc;
+	}
+	D_ASSERT(cont_child != NULL);
+
+	cont_child->sc_rw_disabled = arg->crs_rw_disable;
+	if (dss_get_module_info()->dmi_tgt_id == 0)
+		D_ERROR(DF_CONT" read/write permission %s.\n",
+			DP_CONT(arg->crs_pool_uuid, arg->crs_cont_uuid),
+			cont_child->sc_rw_disabled ? "disabled" : "enabled");
+
+	ds_cont_child_put(cont_child);
+	return rc;
+}
+
+static int
+cont_rf_check(struct ds_pool *ds_pool, struct ds_cont_child *cont_child)
+{
+	struct cont_rw_set_arg		rw_arg;
+	daos_prop_t			props;
+	struct daos_prop_entry		entry = {0};
+	struct daos_co_status		co_stat;
+	int				rc = 0;
+
+	props.dpp_nr = 1;
+	props.dpp_entries = &entry;
+	props.dpp_entries[0].dpe_type = DAOS_PROP_CO_STATUS;
+	cont_iv_prop_fetch(ds_pool->sp_uuid, cont_child->sc_uuid, &props);
+	daos_prop_val_2_co_status(entry.dpe_val, &co_stat);
+	rc = ds_pool_rf_verify(ds_pool, co_stat.dcs_pm_ver,
+			       cont_child->sc_props.dcp_redun_fac);
+	if (rc != 0 && rc != -DER_RF)
+		goto out;
+
+	rw_arg.crs_rw_disable = (rc == -DER_RF);
+	if (rw_arg.crs_rw_disable == cont_child->sc_rw_disabled)
+		D_GOTO(out, rc = 0);
+
+	uuid_copy(rw_arg.crs_cont_uuid, cont_child->sc_uuid);
+	uuid_copy(rw_arg.crs_pool_uuid, ds_pool->sp_uuid);
+	rc = dss_task_collective(cont_rw_capa_set, &rw_arg, 0);
+	if (rc)
+		D_ERROR("collective cont_write_data_turn_off failed, "DF_RC"\n",
+			DP_RC(rc));
+
+out:
+	return rc;
+}
+
+static void
+cont_rf_check_ult(void *data)
+{
+	struct cont_rf_check_arg	*arg = data;
+	struct ds_pool			*ds_pool;
+	struct ds_pool_child		*pool_child;
+	struct ds_cont_child		*cont_child;
+	int				 rc = 0;
+
+	pool_child = ds_pool_child_lookup(arg->crc_pool_uuid);
+	D_ASSERTF(pool_child != NULL, DF_UUID" : failed to find pool child\n",
+		 DP_UUID(arg->crc_pool_uuid));
+
+	ds_pool = pool_child->spc_pool;
+	d_list_for_each_entry(cont_child, &pool_child->spc_cont_list, sc_link) {
+		if (cont_child->sc_stopping)
+			continue;
+		rc = cont_rf_check(ds_pool, cont_child);
+		if (rc) {
+			D_DEBUG(DB_TRACE, DF_CONT" cont_rf_check failed, "
+				DF_RC"\n",
+				DP_CONT(ds_pool->sp_uuid, cont_child->sc_uuid),
+				DP_RC(rc));
+			break;
+		}
+	}
+
+	ds_pool_child_put(pool_child);
+	ABT_eventual_set(arg->crc_eventual, (void *)&rc, sizeof(rc));
+}
+
+static int
+cont_rf_check_get_tgt(uuid_t pool_uuid)
+{
+	int		*failed_tgts = NULL;
+	unsigned int	 failed_tgts_cnt;
+	bool		 alive;
+	int		 rc, i, j;
+
+	rc = ds_pool_get_failed_tgt_idx(pool_uuid, &failed_tgts,
+					&failed_tgts_cnt);
+	if (rc) {
+		D_ERROR(DF_UUID "failed to get index : rc "DF_RC"\n",
+			DP_UUID(pool_uuid), DP_RC(rc));
+		return rc;
+	}
+
+	D_ASSERTF(failed_tgts_cnt <= dss_tgt_nr,
+		  "BAD failed_tgts_cnt %d, dss_tgt_nr %d\n",
+		  failed_tgts_cnt, dss_tgt_nr);
+	if (failed_tgts_cnt == dss_tgt_nr) {
+		D_GOTO(out, rc = -DER_NONEXIST);
+	} else if (failed_tgts_cnt == 0) {
+		/* if all alive, select one random tgt */
+		rc = rand() % dss_tgt_nr;
+		goto out;
+	} else {
+		/* if partial failed, select first alive tgt */
+		for (i = 0; i < dss_tgt_nr; i++) {
+			alive = true;
+			for (j = 0; j < failed_tgts_cnt; j++) {
+				if (i == failed_tgts[j]) {
+					alive = false;
+					break;
+				}
+			}
+			if (alive) {
+				rc = i;
+				goto out;
+			}
+		}
+	}
+
+out:
+	if (failed_tgts != NULL)
+		D_FREE(failed_tgts);
+	return rc;
+}
+
+/** Check active container, it its RF value match with new pool map */
+int
+ds_cont_rf_check(uuid_t pool_uuid)
+{
+	struct cont_rf_check_arg	 check_arg;
+	int				*status;
+	int				 tgt_idx;
+	int				 rc = 0;
+
+	uuid_copy(check_arg.crc_pool_uuid, pool_uuid);
+	rc = ABT_eventual_create(sizeof(*status), &check_arg.crc_eventual);
+	if (rc != ABT_SUCCESS)
+		return dss_abterr2der(rc);
+
+	/* check RF on one alive tgt's VOS main XS */
+	rc = cont_rf_check_get_tgt(pool_uuid);
+	if (rc < 0) {
+		if (rc == -DER_NONEXIST)
+			rc = 0;
+		goto out;
+	}
+	tgt_idx = rc;
+	rc = dss_ult_create(cont_rf_check_ult, &check_arg, DSS_XS_VOS, tgt_idx,
+			    0, NULL);
+	if (rc)
+		D_GOTO(out, rc);
+
+	rc = ABT_eventual_wait(check_arg.crc_eventual, (void **)&status);
+	if (rc != ABT_SUCCESS)
+		D_GOTO(out, rc = dss_abterr2der(rc));
+	rc = *status;
+
+out:
+	ABT_eventual_free(&check_arg.crc_eventual);
+	return rc;
 }

--- a/src/include/daos/object.h
+++ b/src/include/daos/object.h
@@ -500,6 +500,8 @@ enum daos_io_flags {
 	DIOF_TO_SPEC_GROUP	= 0x20,
 	/* For data migration. */
 	DIOF_FOR_MIGRATION	= 0x40,
+	/* For EC aggregation. */
+	DIOF_FOR_EC_AGG		= 0x80,
 };
 
 /**

--- a/src/include/daos_cont.h
+++ b/src/include/daos_cont.h
@@ -31,12 +31,12 @@ extern "C" {
  * DAOS_COO_FORCE skips the check to see if the pool meets the redundancy
  * factor/level requirements of the container.
  */
-#define DAOS_COO_RO	(1U << 0)
-#define DAOS_COO_RW	(1U << 1)
-#define DAOS_COO_NOSLIP	(1U << 2)
-#define DAOS_COO_FORCE	(1U << 3)
+#define DAOS_COO_RO		(1U << 0)
+#define DAOS_COO_RW		(1U << 1)
+#define DAOS_COO_NOSLIP		(1U << 2)
+#define DAOS_COO_FORCE		(1U << 3)
 
-#define DAOS_COO_NBITS	(4)
+#define DAOS_COO_NBITS	(5)
 #define DAOS_COO_MASK	((1U << DAOS_COO_NBITS) - 1)
 
 /** Container information */
@@ -289,6 +289,25 @@ daos_cont_get_acl(daos_handle_t container, daos_prop_t **acl_prop,
  */
 int
 daos_cont_set_prop(daos_handle_t coh, daos_prop_t *prop, daos_event_t *ev);
+
+
+/**
+ * Clear container status, to clear container's DAOS_PROP_CO_STATUS property
+ * from DAOS_PROP_CO_UNCLEAN status to DAOS_PROP_CO_HEALTHY (with same purpose
+ * with "daos cont set-prop --properties=status:healthy --pool= --cont= ".
+ *
+ * \param[in]	coh	Container handle
+ * \param[in]	ev	Completion event, it is optional and can be NULL.
+ *			The function will run in blocking mode if \a ev is NULL.
+ *
+ * \return		These values will be returned by \a ev::ev_error in
+ *			non-blocking mode:
+ *			0		Success
+ *			-DER_UNREACH	Network is unreachable
+ *			-DER_NO_HDL	Invalid container handle
+ */
+int
+daos_cont_status_clear(daos_handle_t coh, daos_event_t *ev);
 
 /**
  * Overwrites the container ACL with a new one.

--- a/src/include/daos_prop.h
+++ b/src/include/daos_prop.h
@@ -289,26 +289,35 @@ enum {
 	DAOS_PROP_CO_UNCLEAN,
 };
 
+/** clear the UNCLEAN status */
+#define DAOS_PROP_CO_CLEAR	(0x1)
 struct daos_co_status {
 	/* DAOS_PROP_CO_HEALTHY/DAOS_PROP_CO_UNCLEAN */
-	uint32_t	dcs_status;
+	uint16_t	dcs_status;
+	/* flags for DAOS internal usage, DAOS_PROP_CO_CLEAR */
+	uint16_t	dcs_flags;
 	/* pool map version when setting the dcs_status */
 	uint32_t	dcs_pm_ver;
 };
 
-#define DAOS_PROP_CO_STATUS_VAL(status, pm_ver)				\
-	((((uint64_t)(status)) << 32) | ((uint64_t)(pm_ver)))
+#define DAOS_PROP_CO_STATUS_VAL(status, flag, pm_ver)			\
+	((((uint64_t)(status)) << 48)		|			\
+	 (((uint64_t)flag & 0xFFFF) << 32)	|			\
+	 ((uint64_t)(pm_ver)))
+
 static inline uint64_t
 daos_prop_co_status_2_val(struct daos_co_status *co_status)
 {
 	return DAOS_PROP_CO_STATUS_VAL(co_status->dcs_status,
+				       co_status->dcs_flags,
 				       co_status->dcs_pm_ver);
 }
 
 static inline void
 daos_prop_val_2_co_status(uint64_t val, struct daos_co_status *co_status)
 {
-	co_status->dcs_status = (uint32_t)(val >> 32);
+	co_status->dcs_status = (uint16_t)(val >> 48);
+	co_status->dcs_flags = (uint16_t)((val >> 32) & 0xFFFF);
 	co_status->dcs_pm_ver = (uint32_t)(val & 0xFFFFFFFF);
 }
 

--- a/src/include/daos_srv/container.h
+++ b/src/include/daos_srv/container.h
@@ -118,6 +118,8 @@ struct ds_cont_child {
 	d_list_t		 sc_dtx_cos_list;
 	/* The pool map version for the latest DTX resync on the container. */
 	uint32_t		 sc_dtx_resync_ver;
+	/* flag of CONT_CAPA_READ_DATA/_WRITE_DATA disabled */
+	uint32_t		 sc_rw_disabled:1;
 };
 
 /*
@@ -132,7 +134,7 @@ struct ds_cont_hdl {
 	uint64_t		sch_flags;	/* user-supplied flags */
 	uint64_t		sch_sec_capas;	/* access control capas */
 	struct ds_cont_child	*sch_cont;
-	int			sch_ref;
+	int32_t			sch_ref;
 };
 
 struct ds_cont_hdl *ds_cont_hdl_lookup(const uuid_t uuid);
@@ -151,6 +153,7 @@ void ds_cont_child_stop_all(struct ds_pool_child *pool_child);
 
 int ds_cont_child_lookup(uuid_t pool_uuid, uuid_t cont_uuid,
 			 struct ds_cont_child **ds_cont);
+int ds_cont_rf_check(uuid_t pool_uuid);
 
 /** initialize a csummer based on container properties. Will retrieve the
  * checksum related properties from IV
@@ -242,7 +245,6 @@ ds_csum_agg_recalc(void *args);
 int dsc_cont_open(daos_handle_t poh, uuid_t cont_uuid, uuid_t cont_hdl_uuid,
 		  unsigned int flags, daos_handle_t *coh);
 int dsc_cont_close(daos_handle_t poh, daos_handle_t coh);
-
 
 void ds_cont_tgt_ec_eph_query_ult(void *data);
 #endif /* ___DAOS_SRV_CONTAINER_H_ */

--- a/src/include/daos_srv/pool.h
+++ b/src/include/daos_srv/pool.h
@@ -253,10 +253,11 @@ int dsc_pool_close(daos_handle_t ph);
 static inline int
 ds_pool_rf_verify(struct ds_pool *pool, uint32_t last_ver, uint32_t rf)
 {
-	int	rc;
+	int	rc = 0;
 
 	ABT_rwlock_rdlock(pool->sp_lock);
-	rc = pool_map_rf_verify(pool->sp_map, last_ver, rf);
+	if (last_ver < pool_map_get_version(pool->sp_map))
+		rc = pool_map_rf_verify(pool->sp_map, last_ver, rf);
 	ABT_rwlock_unlock(pool->sp_lock);
 
 	return rc;

--- a/src/include/daos_srv/security.h
+++ b/src/include/daos_srv/security.h
@@ -234,6 +234,26 @@ bool
 ds_sec_cont_can_write_data(uint64_t cont_capas);
 
 /**
+ * Calculate the new capability after enable CONT_CAPA_WRITE_DATA.
+ *
+ * \param	cont_capas	Input capability.
+ *
+ * \return	Output capability
+ */
+uint64_t
+ds_sec_cont_capa_write_data_enable(uint64_t cont_capas);
+
+/**
+ * Calculate the new capability after disable CONT_CAPA_WRITE_DATA.
+ *
+ * \param	cont_capas	Input capability.
+ *
+ * \return	Output capability
+ */
+uint64_t
+ds_sec_cont_capa_write_data_disable(uint64_t cont_capas);
+
+/**
  * Determine if the container can be read based on the container security
  * capabilities.
  *

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -4171,6 +4171,8 @@ dc_obj_fetch_task(tse_task_t *task)
 		obj_auxi->flags |= ORF_FOR_MIGRATION;
 		obj_auxi->no_retry = 1;
 	}
+	if (args->extra_flags & DIOF_FOR_EC_AGG)
+		obj_auxi->flags |= ORF_FOR_EC_AGG;
 
 	if (args->extra_flags & DIOF_CHECK_EXISTENCE) {
 		obj_auxi->flags |= ORF_CHECK_EXISTENCE;

--- a/src/object/cli_shard.c
+++ b/src/object/cli_shard.c
@@ -761,7 +761,7 @@ dc_rw_cb(tse_task_t *task, void *arg)
 		 * rec2big errors which can be expected.
 		 */
 		if (rc == -DER_REC2BIG || rc == -DER_NONEXIST ||
-		    rc == -DER_EXIST)
+		    rc == -DER_EXIST || rc == -DER_RF)
 			D_DEBUG(DB_IO, "rpc %p opc %d to rank %d tag %d"
 				" failed: "DF_RC"\n", rw_args->rpc, opc,
 				rw_args->rpc->cr_ep.ep_rank,

--- a/src/object/obj_rpc.h
+++ b/src/object/obj_rpc.h
@@ -160,6 +160,8 @@ enum obj_rpc_flags {
 	ORF_FOR_MIGRATION	= (1 << 14),
 	/* Force DTX refresh if hit non-committed DTX on non-leader. */
 	ORF_DTX_REFRESH		= (1 << 15),
+	/* for EC aggregate (to bypass read perm check related with RF) */
+	ORF_FOR_EC_AGG		= (1 << 16),
 };
 
 /* common for update/fetch */
@@ -578,9 +580,14 @@ obj_is_modification_opc(uint32_t opc)
 		opc == DAOS_OBJ_RPC_PUNCH_DKEYS ||
 		opc == DAOS_OBJ_RPC_TGT_PUNCH_DKEYS ||
 		opc == DAOS_OBJ_RPC_PUNCH_AKEYS ||
-		opc == DAOS_OBJ_RPC_TGT_PUNCH_AKEYS ||
-		opc == DAOS_OBJ_RPC_EC_AGGREGATE ||
-		opc == DAOS_OBJ_RPC_EC_REPLICATE;
+		opc == DAOS_OBJ_RPC_TGT_PUNCH_AKEYS;
+}
+
+static inline bool
+obj_is_ec_agg_opc(uint32_t opc)
+{
+	return opc == DAOS_OBJ_RPC_EC_AGGREGATE ||
+	       opc == DAOS_OBJ_RPC_EC_REPLICATE;
 }
 
 static inline bool

--- a/src/object/srv_ec_aggregate.c
+++ b/src/object/srv_ec_aggregate.c
@@ -604,7 +604,7 @@ agg_fetch_odata_cells(struct ec_agg_entry *entry, uint8_t *bit_map,
 	epoch = is_recalc ? stripe->as_hi_epoch :
 		entry->ae_par_extent.ape_epoch;
 	rc = dsc_obj_fetch(entry->ae_obj_hdl, epoch, &entry->ae_dkey, 1, &iod,
-			   &sgl, NULL, 0, NULL, NULL);
+			   &sgl, NULL, DIOF_FOR_EC_AGG, NULL, NULL);
 	if (rc)
 		D_ERROR("dsc_obj_fetch failed: "DF_RC"\n", DP_RC(rc));
 
@@ -1031,7 +1031,8 @@ agg_fetch_remote_parity(struct ec_agg_entry *entry)
 		rc = dsc_obj_fetch(entry->ae_obj_hdl,
 				   entry->ae_par_extent.ape_epoch,
 				   &entry->ae_dkey, 1, &iod, &sgl, NULL,
-				   DIOF_TO_SPEC_SHARD, &peer_shard, NULL);
+				   DIOF_TO_SPEC_SHARD | DIOF_FOR_EC_AGG,
+				   &peer_shard, NULL);
 		D_DEBUG(DB_TRACE, DF_UOID" fetch parity from peer shard %d, "
 			DF_RC".\n", DP_UOID(entry->ae_oid), peer_shard,
 			DP_RC(rc));
@@ -1631,7 +1632,7 @@ agg_process_holes_ult(void *arg)
 		rc = dsc_obj_fetch(entry->ae_obj_hdl,
 				   entry->ae_cur_stripe.as_hi_epoch,
 				   &entry->ae_dkey, 1, &iod, &entry->ae_sgl,
-				   NULL, 0, NULL, NULL);
+				   NULL, DIOF_FOR_EC_AGG, NULL, NULL);
 		if (rc) {
 			D_ERROR("dsc_obj_fetch failed: "DF_RC"\n", DP_RC(rc));
 			goto out;

--- a/src/object/srv_obj_migrate.c
+++ b/src/object/srv_obj_migrate.c
@@ -568,7 +568,7 @@ mrone_obj_fetch(struct migrate_one *mrone, daos_handle_t oh, d_sg_list_t *sgls,
 
 		rc = dsc_obj_fetch(oh, mrone->mo_epoch, &mrone->mo_dkey,
 				   mrone->mo_iod_num, mrone->mo_iods, sgls,
-				   NULL, DIOF_TO_LEADER, NULL, csum_iov_fetch);
+				   NULL, flags, NULL, csum_iov_fetch);
 	}
 
 	return rc;

--- a/src/pool/srv_iv.c
+++ b/src/pool/srv_iv.c
@@ -574,7 +574,6 @@ pool_iv_map_ent_update(d_sg_list_t *dst_sgl, struct pool_iv_entry *src_iv)
 	}
 
 	pb_nr = src_iv->piv_map.piv_pool_buf.pb_nr;
-	D_ASSERT(pb_nr > 0);
 	src_pbuf_size = pool_buf_size(pb_nr);
 	dst_pbuf_size = dst_sgl->sg_iovs[0].iov_buf_len -
 			sizeof(struct pool_iv_map) + sizeof(struct pool_buf);
@@ -1012,19 +1011,24 @@ ds_pool_iv_map_update(struct ds_pool *pool, struct pool_buf *buf,
 {
 	struct pool_iv_entry	*iv_entry;
 	uint32_t		 iv_entry_size;
+	uint32_t		 nr;
 	int			 rc;
 
 	D_DEBUG(DB_MD, DF_UUID": map_ver=%u\n", DP_UUID(pool->sp_uuid),
 		map_ver);
 
-	iv_entry_size = pool_iv_map_ent_size(buf->pb_nr);
+	nr = buf != NULL ? buf->pb_nr : 0;
+	iv_entry_size = pool_iv_map_ent_size(nr);
 	D_ALLOC(iv_entry, iv_entry_size);
 	if (iv_entry == NULL)
 		return -DER_NOMEM;
 
 	crt_group_rank(pool->sp_group, &iv_entry->piv_map.piv_master_rank);
-	iv_entry->piv_map.piv_pool_map_ver = pool->sp_map_version;
-	memcpy(&iv_entry->piv_map.piv_pool_buf, buf, pool_buf_size(buf->pb_nr));
+	iv_entry->piv_map.piv_pool_map_ver =
+		buf == NULL ? 0 : pool->sp_map_version;
+	if (buf != NULL)
+		memcpy(&iv_entry->piv_map.piv_pool_buf, buf,
+		       pool_buf_size(buf->pb_nr));
 
 	/* FIXME: Let's update the pool map synchronously for the moment,
 	 * since there is no easy way to free the iv_entry buffer. Needs

--- a/src/pool/srv_target.c
+++ b/src/pool/srv_target.c
@@ -1253,6 +1253,8 @@ out:
 	ABT_rwlock_unlock(pool->sp_lock);
 	if (map != NULL)
 		pool_map_decref(map);
+	if (rc == 0)
+		rc = ds_cont_rf_check(pool->sp_uuid);
 	return rc;
 }
 

--- a/src/security/srv_acl.c
+++ b/src/security/srv_acl.c
@@ -771,6 +771,18 @@ ds_sec_cont_can_write_data(uint64_t cont_capas)
 	return (cont_capas & CONT_CAPA_WRITE_DATA) != 0;
 }
 
+uint64_t
+ds_sec_cont_capa_write_data_enable(uint64_t cont_capas)
+{
+	return cont_capas | ((uint64_t)CONT_CAPA_WRITE_DATA);
+}
+
+uint64_t
+ds_sec_cont_capa_write_data_disable(uint64_t cont_capas)
+{
+	return cont_capas & (~(uint64_t)CONT_CAPA_WRITE_DATA);
+}
+
 bool
 ds_sec_cont_can_read_data(uint64_t cont_capas)
 {

--- a/src/tests/ftest/osa/osa_offline_reintegration.py
+++ b/src/tests/ftest/osa/osa_offline_reintegration.py
@@ -83,11 +83,19 @@ class OSAOfflineReintegration(OSAUtils):
                         output = self.dmg_command.pool_exclude(self.pool.uuid,
                                                                "5")
                         self.print_and_assert_on_rebuild_failure(output)
+                        self.daos_command.container_set_prop(
+                                    self.pool.uuid,
+                                    self.container.uuid,
+                                    "status", "healthy")
                     if self.test_during_aggregation is True:
                         self.delete_extra_container(self.pool)
                         self.simple_exclude_reintegrate_loop(rank[val])
                     output = self.dmg_command.pool_exclude(self.pool.uuid,
                                                            rank[val])
+                    self.daos_command.container_set_prop(
+                                    self.pool.uuid,
+                                    self.container.uuid,
+                                    "status", "healthy")
                     # Check the IOR data after exclude
                     if data:
                         self.run_ior_thread("Read", oclass, test_seq)
@@ -95,6 +103,10 @@ class OSAOfflineReintegration(OSAUtils):
                     output = self.dmg_command.system_stop(ranks=rank[val],
                                                           force=True)
                     self.print_and_assert_on_rebuild_failure(output)
+                    self.daos_command.container_set_prop(
+                                    self.pool.uuid,
+                                    self.container.uuid,
+                                    "status", "healthy")
                     # Check the IOR data after system stop
                     if data and (val == 0):
                         self.run_ior_thread("Read", oclass, test_seq)

--- a/src/tests/suite/daos_checksum.c
+++ b/src/tests/suite/daos_checksum.c
@@ -1835,6 +1835,8 @@ rebuild_test(void **state, int chunksize, int data_len_bytes, int iod_type)
 	/** wait for rebuild */
 	test_rebuild_wait(&arg, 1);
 
+	daos_cont_status_clear(arg->coh, NULL);
+
 	rc = daos_obj_layout_get(ctx.coh, ctx.oid, &layout2);
 	assert_success(rc);
 
@@ -1851,6 +1853,7 @@ rebuild_test(void **state, int chunksize, int data_len_bytes, int iod_type)
 
 	daos_fail_loc_set(DAOS_OBJ_SPECIAL_SHARD | DAOS_FAIL_ALWAYS);
 	daos_fail_num_set(rank_to_fetch);
+	daos_cont_status_clear(ctx.coh, NULL);
 	rc = daos_obj_fetch(ctx.oh, DAOS_TX_NONE, 0, &ctx.dkey,
 			    1, &ctx.fetch_iod, &ctx.fetch_sgl, NULL, NULL);
 	assert_success(rc);

--- a/src/tests/suite/daos_container.c
+++ b/src/tests/suite/daos_container.c
@@ -2071,6 +2071,7 @@ co_open_fail_destroy(void **state)
 static void
 co_rf_simple(void **state)
 {
+#define STACK_BUF_LEN	(128)
 	test_arg_t		*arg0 = *state;
 	test_arg_t		*arg = NULL;
 	daos_obj_id_t		 oid;
@@ -2080,6 +2081,14 @@ co_rf_simple(void **state)
 	struct daos_prop_entry	*entry;
 	struct daos_co_status	 stat = { 0 };
 	daos_cont_info_t	 info = { 0 };
+	daos_obj_id_t		 io_oid;
+	daos_handle_t		 io_oh;
+	d_iov_t			 dkey;
+	char			 stack_buf[STACK_BUF_LEN];
+	d_sg_list_t		 sgl;
+	d_iov_t			 sg_iov;
+	daos_iod_t		 iod;
+	daos_recx_t		 recx;
 	int			 rc;
 
 	/* needs 3 alive nodes after excluding 3 */
@@ -2158,6 +2167,29 @@ co_rf_simple(void **state)
 	rc = daos_cont_close(coh, NULL);
 	assert_rc_equal(rc, 0);
 
+	/* IO testing */
+	io_oid = daos_test_oid_gen(arg->coh, OC_RP_4G1, 0, 0, arg->myrank);
+	rc = daos_obj_open(arg->coh, io_oid, 0, &io_oh, NULL);
+	assert_rc_equal(rc, 0);
+
+	d_iov_set(&dkey, "dkey", strlen("dkey"));
+	dts_buf_render(stack_buf, STACK_BUF_LEN);
+	d_iov_set(&sg_iov, stack_buf, STACK_BUF_LEN);
+	sgl.sg_nr	= 1;
+	sgl.sg_nr_out	= 1;
+	sgl.sg_iovs	= &sg_iov;
+	d_iov_set(&iod.iod_name, "akey", strlen("akey"));
+	recx.rx_idx = 0;
+	recx.rx_nr  = STACK_BUF_LEN;
+	iod.iod_size	= 1;
+	iod.iod_nr	= 1;
+	iod.iod_recxs	= &recx;
+	iod.iod_type	= DAOS_IOD_ARRAY;
+	print_message("obj update should success before RF broken\n");
+	rc = daos_obj_update(io_oh, DAOS_TX_NONE, 0, &dkey, 1, &iod, &sgl,
+			     NULL);
+	assert_rc_equal(rc, 0);
+
 	if (arg->myrank == 0)
 		daos_exclude_server(arg->pool.pool_uuid, arg->group,
 				    arg->dmg_config, 3);
@@ -2169,6 +2201,14 @@ co_rf_simple(void **state)
 	assert_int_equal(stat.dcs_status, DAOS_PROP_CO_UNCLEAN);
 	rc = daos_cont_open(arg->pool.poh, arg->co_uuid, arg->cont_open_flags,
 			    &coh, NULL, NULL);
+	assert_rc_equal(rc, -DER_RF);
+	print_message("obj update should fail after RF broken\n");
+	rc = daos_obj_update(io_oh, DAOS_TX_NONE, 0, &dkey, 1, &iod, &sgl,
+			     NULL);
+	assert_rc_equal(rc, -DER_RF);
+	print_message("obj fetch should fail after RF broken\n");
+	rc = daos_obj_fetch(io_oh, DAOS_TX_NONE, 0, &dkey, 1, &iod, &sgl, NULL,
+			    NULL);
 	assert_rc_equal(rc, -DER_RF);
 
 	if (arg->myrank == 0) {
@@ -2184,11 +2224,13 @@ co_rf_simple(void **state)
 	}
 	MPI_Barrier(MPI_COMM_WORLD);
 
+	print_message("obj update should success after re-integrate\n");
+	rc = daos_obj_update(io_oh, DAOS_TX_NONE, 0, &dkey, 1, &iod, &sgl,
+			     NULL);
+	assert_rc_equal(rc, 0);
+
 	/* clear the UNCLEAN status */
-	prop->dpp_entries[0].dpe_type = DAOS_PROP_CO_STATUS;
-	prop->dpp_entries[0].dpe_val = DAOS_PROP_CO_STATUS_VAL(
-						DAOS_PROP_CO_HEALTHY, 0);
-	rc = daos_cont_set_prop(arg->coh, prop, NULL);
+	rc = daos_cont_status_clear(arg->coh, NULL);
 	assert_rc_equal(rc, 0);
 
 	rc = daos_cont_query(arg->coh, NULL, prop, NULL);
@@ -2212,6 +2254,9 @@ co_rf_simple(void **state)
 	rc = daos_cont_close(coh_g2l, NULL);
 	assert_int_equal(rc, 0);
 	free(ghdl.iov_buf);
+
+	rc = daos_obj_close(io_oh, NULL);
+	assert_rc_equal(rc, 0);
 
 	rc = daos_cont_close(coh, NULL);
 	assert_rc_equal(rc, 0);

--- a/src/tests/suite/daos_degrade_ec.c
+++ b/src/tests/suite/daos_degrade_ec.c
@@ -84,6 +84,10 @@ static void
 degrade_ec_verify(test_arg_t *arg, daos_obj_id_t oid, int write_type)
 {
 	struct ioreq	req;
+	int		rc;
+
+	rc = daos_cont_status_clear(arg->coh, NULL);
+	assert_rc_equal(rc, 0);
 
 	ioreq_init(&req, arg->coh, oid, DAOS_IOD_ARRAY, arg);
 

--- a/src/tests/suite/daos_rebuild_common.c
+++ b/src/tests/suite/daos_rebuild_common.c
@@ -156,9 +156,12 @@ rebuild_targets(test_arg_t **args, int args_cnt, d_rank_t *ranks,
 		test_rebuild_wait(args, args_cnt);
 
 	MPI_Barrier(MPI_COMM_WORLD);
-	for (i = 0; i < args_cnt; i++)
+	for (i = 0; i < args_cnt; i++) {
+		daos_cont_status_clear(args[i]->coh, NULL);
+
 		if (args[i]->rebuild_post_cb)
 			args[i]->rebuild_post_cb(args[i]);
+	}
 }
 
 
@@ -559,6 +562,9 @@ rebuild_io_verify(test_arg_t *arg, daos_obj_id_t *oids, int oids_nr)
 	int	rc;
 	int	i;
 
+	rc = daos_cont_status_clear(arg->coh, NULL);
+	assert_rc_equal(rc, 0);
+
 	print_message("rebuild io verify obj %d\n", oids_nr);
 	for (i = 0; i < oids_nr; i++) {
 		/* XXX: skip punch object. */
@@ -825,6 +831,7 @@ dfs_ec_rebuild_io(void **state, int *shards, int shards_nr)
 		idx++;
 	}
 	rebuild_pools_ranks(&arg, 1, ranks, idx, false);
+	daos_cont_status_clear(co_hdl, NULL);
 
 	/* Verify full stripe */
 	d_iov_set(&iov, buf, buf_size);

--- a/src/tests/suite/daos_rebuild_ec.c
+++ b/src/tests/suite/daos_rebuild_ec.c
@@ -497,6 +497,7 @@ dfs_ec_seq_fail(void **state, int *shards, int shards_nr)
 		rebuild_pools_ranks(&arg, 1, &ranks[idx], 1, false);
 		idx++;
 
+		daos_cont_status_clear(co_hdl, NULL);
 		/* Verify full stripe */
 		d_iov_set(&iov, buf, buf_size);
 		memset(buf, 0, buf_size);

--- a/src/tests/suite/daos_test_common.c
+++ b/src/tests/suite/daos_test_common.c
@@ -926,7 +926,9 @@ daos_kill_server(test_arg_t *arg, const uuid_t pool_uuid,
 
 	rc = system(dmg_cmd);
 	print_message(" %s rc %#x\n", dmg_cmd, rc);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
+
+	daos_cont_status_clear(arg->coh, NULL);
 }
 
 struct daos_acl *

--- a/src/utils/daos.c
+++ b/src/utils/daos.c
@@ -450,6 +450,7 @@ daos_parse_property(char *name, char *value, daos_prop_t *props)
 		if (!strcmp(value, "healthy")) {
 			entry->dpe_val =
 				DAOS_PROP_CO_STATUS_VAL(DAOS_PROP_CO_HEALTHY,
+							DAOS_PROP_CO_CLEAR,
 							0);
 		} else {
 			fprintf(stderr, "status prop value can only be "


### PR DESCRIPTION
    For active opened container handle, DAOS will internally -
    1. turn off read/write permission when cont_rf broken
    2. turn on  read/write permission when cont_rf recovered by -
       reintegrate the failed devices, or by clearing the UNCLEAN container
       status - "daos cont set-prop --properties=status:healthy ..."
    Add test case to co_rf_simple().
    
    Now DAOS_PROP_CO_STATUS only used for storing the pm_ver for
    cont_create, and when user clear the UNCLEAN status. And don't
    set UNCLEAN status to RDB to avoid ambiguity when checking
    with active container handle.
    
    Signed-off-by: Xuezhao Liu <xuezhao.liu@intel.com>