### PR TITLE
DAOS-7192 rebuild: Check if the container is destroyed (#5354)

### DIFF
--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -1636,8 +1636,11 @@ obj_ioc_init(uuid_t pool_uuid, uuid_t coh_uuid, uuid_t cont_uuid, int opc,
 
 	/* load VOS container on demand for rebuild */
 	rc = ds_cont_child_lookup(pool_uuid, cont_uuid, &coc);
-	if (rc)
+	if (rc) {
+		D_ERROR("Can not find the container "DF_UUID"/"DF_UUID"\n",
+			DP_UUID(pool_uuid), DP_UUID(cont_uuid));
 		D_GOTO(failed, rc);
+	}
 
 	/* load csummer on demand for rebuild if not already loaded */
 	rc = ds_cont_csummer_init(coc);

--- a/src/object/srv_obj_migrate.c
+++ b/src/object/srv_obj_migrate.c
@@ -1315,8 +1315,14 @@ migrate_dkey(struct migrate_pool_tls *tls, struct migrate_one *mrone,
 
 	rc = ds_cont_child_open_create(tls->mpt_pool_uuid, mrone->mo_cont_uuid,
 				       &cont);
-	if (rc)
+	if (rc) {
+		if (rc == -DER_SHUTDOWN) {
+			D_DEBUG(DB_REBUILD, DF_UUID "container is being"
+				" destroyed\n", DP_UUID(mrone->mo_cont_uuid));
+			rc = 0;
+		}
 		D_GOTO(out, rc);
+	}
 
 	rc = dsc_pool_open(tls->mpt_pool_uuid, tls->mpt_poh_uuid, 0,
 			   NULL, tls->mpt_pool->spc_pool->sp_map,
@@ -1432,7 +1438,7 @@ migrate_one_ult(void *arg)
 				      mrone->mo_pool_tls_version);
 	if (tls == NULL || tls->mpt_fini) {
 		D_WARN("some one abort the rebuild "DF_UUID"\n",
-			DP_UUID(mrone->mo_pool_uuid));
+		       DP_UUID(mrone->mo_pool_uuid));
 		goto out;
 	}
 
@@ -1785,7 +1791,11 @@ migrate_one_insert(struct enum_unpack_arg *arg,
 		iod_eph_total);
 
 	tls = migrate_pool_tls_lookup(iter_arg->pool_uuid, iter_arg->version);
-	D_ASSERT(tls != NULL);
+	if (tls == NULL || tls->mpt_fini) {
+		D_WARN("some one abort the rebuild "DF_UUID"\n",
+		       DP_UUID(iter_arg->pool_uuid));
+		D_GOTO(put, rc = 0);
+	}
 	if (iod_eph_total == 0 || tls->mpt_version <= version ||
 	    tls->mpt_fini) {
 		D_DEBUG(DB_REBUILD, "No need eph_total %d version %u"
@@ -1885,7 +1895,8 @@ free:
 		migrate_one_destroy(mrone);
 	}
 put:
-	migrate_pool_tls_put(tls);
+	if (tls)
+		migrate_pool_tls_put(tls);
 	return rc;
 }
 
@@ -1973,7 +1984,11 @@ migrate_obj_punch_one(void *data)
 	int			rc;
 
 	tls = migrate_pool_tls_lookup(arg->pool_uuid, arg->version);
-	D_ASSERT(tls != NULL);
+	if (tls == NULL || tls->mpt_fini) {
+		D_WARN("some one abort the rebuild "DF_UUID"\n",
+		       DP_UUID(arg->pool_uuid));
+		D_GOTO(put, rc = 0);
+	}
 	D_DEBUG(DB_REBUILD, "tls %p "DF_UUID" version %d punch "DF_UOID"\n",
 		tls, DP_UUID(tls->mpt_pool_uuid), arg->version,
 		DP_UOID(arg->oid));
@@ -1987,7 +2002,9 @@ migrate_obj_punch_one(void *data)
 	if (rc)
 		D_ERROR(DF_UOID" migrate punch failed: "DF_RC"\n",
 			DP_UOID(arg->oid), DP_RC(rc));
-	migrate_pool_tls_put(tls);
+put:
+	if (tls)
+		migrate_pool_tls_put(tls);
 	return rc;
 }
 
@@ -2001,7 +2018,11 @@ migrate_start_ult(struct enum_unpack_arg *unpack_arg)
 	int			rc = 0;
 
 	tls = migrate_pool_tls_lookup(arg->pool_uuid, arg->version);
-	D_ASSERT(tls != NULL);
+	if (tls == NULL || tls->mpt_fini) {
+		D_WARN("some one abort the rebuild "DF_UUID"\n",
+		       DP_UUID(arg->pool_uuid));
+		D_GOTO(put, rc = 0);
+	}
 	d_list_for_each_entry_safe(mrone, tmp, &unpack_arg->merge_list,
 				   mo_list) {
 		/* Recover the OID (with correct shard) after merging IOD
@@ -2023,7 +2044,9 @@ migrate_start_ult(struct enum_unpack_arg *unpack_arg)
 		tls->mpt_generated_ult++;
 	}
 
-	migrate_pool_tls_put(tls);
+put:
+	if (tls)
+		migrate_pool_tls_put(tls);
 	return rc;
 }
 
@@ -2166,9 +2189,12 @@ retry:
 			/* DER_DATA_LOSS means it can not find any replicas
 			 * to rebuild the data, see obj_list_common.
 			 */
-			if (rc == -DER_DATA_LOSS) {
+			/* If the container is being destroyed, it may return
+			 * -DER_NONEXIST, see obj_ioc_init().
+			 */
+			if (rc == -DER_DATA_LOSS || rc == -DER_NONEXIST) {
 				D_DEBUG(DB_REBUILD, "No replicas for "DF_UOID
-					"\n", DP_UOID(arg->oid));
+					" %d\n", DP_UOID(arg->oid), rc);
 				num = 0;
 				rc = 0;
 			}
@@ -2304,9 +2330,13 @@ destroy_existing_obj(struct migrate_pool_tls *tls, unsigned int tgt_idx,
 	int rc;
 
 	rc = ds_cont_child_open_create(tls->mpt_pool_uuid, cont_uuid, &cont);
-	if (rc == DER_NONEXIST) {
-		return DER_SUCCESS;
-	} else if (rc != 0) {
+	if (rc == -DER_SHUTDOWN) {
+		D_DEBUG(DB_REBUILD, DF_UUID "container is being destroyed\n",
+			DP_UUID(cont_uuid));
+		return 0;
+	}
+
+	if (rc != 0) {
 		D_ERROR("Failed to open cont to clear obj before migrate; pool="
 			DF_UUID" cont="DF_UUID"\n",
 			DP_UUID(tls->mpt_pool_uuid), DP_UUID(cont_uuid));
@@ -2314,9 +2344,7 @@ destroy_existing_obj(struct migrate_pool_tls *tls, unsigned int tgt_idx,
 	}
 
 	rc = vos_obj_delete(cont->sc_hdl, *oid);
-	if (rc == DER_NONEXIST) {
-		return DER_SUCCESS;
-	} else if (rc != 0) {
+	if (rc != 0) {
 		D_ERROR("Migrate failed to destroy object prior to "
 			"reintegration: pool/object "DF_UUID"/"DF_UOID
 			" rc: "DF_RC"\n", DP_UUID(tls->mpt_pool_uuid),
@@ -2357,7 +2385,11 @@ migrate_obj_ult(void *data)
 	int			 rc;
 
 	tls = migrate_pool_tls_lookup(arg->pool_uuid, arg->version);
-	D_ASSERT(tls != NULL);
+	if (tls == NULL || tls->mpt_fini) {
+		D_WARN("some one abort the rebuild "DF_UUID"\n",
+		       DP_UUID(arg->pool_uuid));
+		D_GOTO(free, rc = 0);
+	}
 
 	if (tls->mpt_del_local_objs) {
 		/* Destroy this object ID locally prior to migration */
@@ -2400,6 +2432,27 @@ free:
 		tls->mpt_obj_count++;
 
 	tls->mpt_obj_executed_ult++;
+	if (rc == -DER_NONEXIST) {
+		struct ds_cont_child *cont_child = NULL;
+		int ret;
+
+		ret = ds_cont_child_lookup(tls->mpt_pool_uuid, arg->cont_uuid,
+					   &cont_child);
+		if (ret != 0 || cont_child->sc_stopping) {
+			/**
+			 * If the current container is being destroyed, let's
+			 * ignore the -DER_NONEXIST failure.
+			 */
+			D_DEBUG(DB_REBUILD, DF_UUID" status %d:%d\n",
+				DP_UUID(arg->cont_uuid), ret,
+				cont_child ? cont_child->sc_stopping : 0);
+			rc = 0;
+		}
+
+		if (cont_child)
+			ds_cont_child_put(cont_child);
+	}
+
 	if (tls->mpt_status == 0 && rc < 0)
 		tls->mpt_status = rc;
 	D_DEBUG(DB_REBUILD, "stop migrate obj "DF_UOID" for shard %u: "

--- a/src/rebuild/srv.c
+++ b/src/rebuild/srv.c
@@ -825,7 +825,6 @@ rebuild_scan_broadcast(struct ds_pool *pool,
 	crt_rpc_t		*rpc;
 	int			rc;
 
-retry:
 	/* Send rebuild RPC to all targets of the pool to initialize rebuild.
 	 * XXX this should be idempotent as well as query and fini.
 	 */
@@ -854,12 +853,6 @@ retry:
 	rso = crt_reply_get(rpc);
 	if (rc == 0)
 		rc = rso->rso_status;
-	if (rc == -DER_BUSY) {
-		crt_req_decref(rpc);
-		D_DEBUG(DB_REBUILD, "rebuild "DF_UUID" scan retry\n",
-			DP_UUID(pool->sp_uuid));
-		goto retry;
-	}
 
 	rgt->rgt_init_scan = 1;
 	rgt->rgt_stable_epoch = rso->rso_stable_epoch;


### PR DESCRIPTION
If enumeration or fetch return -DER_NONEXIST, let's ignore
the failure if the container is destroyed.

For DER_BUSY, let's retry outside scan_request(), so it can
be delay for a few seconds.

Remove incorrect assertion for migrate tls.

Ignore -DER_SHUTDOWN if the container is about to be destoryed
during migration.

Signed-off-by: Di Wang <di.wang@intel.com>