### PR TITLE
DAOS-7202 rebuild: check if rgt is NULL (#5431)

### DIFF
--- a/src/rebuild/srv.c
+++ b/src/rebuild/srv.c
@@ -1295,7 +1295,8 @@ try_reschedule:
 		 * rebuild sequence, which has to be done by failure
 		 * sequence order.
 		 */
-		rgt->rgt_status.rs_done = 0;
+		if (rgt)
+			rgt->rgt_status.rs_done = 0;
 		ret = ds_rebuild_schedule(pool, task->dst_map_ver,
 					  &task->dst_tgts,
 					  task->dst_rebuild_op, 5);


### PR DESCRIPTION
Fix a typo in rebuild_task_ult, to check if rgt is
NULL before reset done.

Signed-off-by: Di Wang <di.wang@intel.com>