### PR TITLE
DAOS-7242 coverity: fixes in ds_mgmt_drpc_pool_create

### DIFF
--- a/src/mgmt/srv_drpc.c
+++ b/src/mgmt/srv_drpc.c
@@ -321,8 +321,6 @@ ds_mgmt_drpc_pool_create(Drpc__Call *drpc_req, Drpc__Response *drpc_resp)
 				 req->scmbytes, req->nvmebytes,
 				 prop, req->numsvcreps, &svc,
 				 req->n_faultdomains, req->faultdomains);
-	if (targets != NULL)
-		d_rank_list_free(targets);
 	if (rc != 0) {
 		D_ERROR("failed to create pool: "DF_RC"\n", DP_RC(rc));
 		goto out;
@@ -354,6 +352,8 @@ out:
 	mgmt__pool_create_req__free_unpacked(req, &alloc.alloc);
 
 	daos_prop_free(prop);
+	if (targets != NULL)
+		d_rank_list_free(targets);
 
 	D_FREE(resp.svc_reps);
 }


### PR DESCRIPTION
Fix targets leak in ds_mgmt_drpc_pool_create.

Signed-off-by: Di Wang <di.wang@intel.com>