### PR TITLE
DAOS-7162 security: Fix coverity issues found in cert loading code (#…

### DIFF
--- a/src/control/security/pem.go
+++ b/src/control/security/pem.go
@@ -168,7 +168,7 @@ func LoadPrivateKey(keyPath string) (crypto.PrivateKey, error) {
 				keyPath)
 		}
 	}
-	return nil, fmt.Errorf("Invalid key data in PRIVATE KEY block")
+	return nil, errors.Wrapf(err, "Invalid key data in PRIVATE KEY block")
 }
 
 // ValidateCertDirectory ensures the certificate directory has safe permissions


### PR DESCRIPTION
…5447)

If both pkcs1 and pkcs8 decoding fail return the error appropriately instead of
squelching it.

Master-PR: https://github.com/daos-stack/daos/pull/5447

Signed-off-by: David Quigley <david.quigley@intel.com>