### PR TITLE
DAOS-7241 pool: coverity fix map_comp.co_flags assignment

### DIFF
--- a/src/common/pool_map.c
+++ b/src/common/pool_map.c
@@ -1515,6 +1515,7 @@ gen_pool_buf(struct pool_map *map, struct pool_buf **map_buf_out,
 		map_comp.co_rank = target_addrs->rl_ranks[i];
 		map_comp.co_ver = map_version;
 		map_comp.co_fseq = 1;
+		map_comp.co_flags = PO_COMPF_NONE;
 		map_comp.co_nr = dss_tgt_nr;
 
 		rc = pool_buf_attach(map_buf, &map_comp, 1 /* comp_nr */);
@@ -1542,6 +1543,7 @@ gen_pool_buf(struct pool_map *map, struct pool_buf **map_buf_out,
 			map_comp.co_rank = target_addrs->rl_ranks[i];
 			map_comp.co_ver = map_version;
 			map_comp.co_fseq = 1;
+			map_comp.co_flags = PO_COMPF_NONE;
 			map_comp.co_nr = 1;
 
 			rc = pool_buf_attach(map_buf, &map_comp, 1);


### PR DESCRIPTION
Fix for Coverity CID 318157. In gen_pool_buf() map_comp is allocated on
the stack without an initializer. Before this change, in the nodes and
targets loops calling pool_buf_attach(), many map_comp members are
assigned, though not co_flags. The CID cites the first call only.
This patch assigns co_flags=PO_COMPF_NONE before both calls.

Signed-off-by: Kenneth Cain <kenneth.c.cain@intel.com>