### PR TITLE
DAOS-7246: Fix Coverity issue in CaRT Test code

### DIFF
--- a/src/tests/ftest/cart/test_group_np_common.h
+++ b/src/tests/ftest/cart/test_group_np_common.h
@@ -187,6 +187,8 @@ test_swim_status_handler(crt_rpc_t *rpc_req)
 		  e_req->rank, swim_seq,
 		  e_req->exp_status);
 
+	D_FREE(swim_seq);
+
 	e_reply = crt_reply_get(rpc_req);
 
 	/* If we got past the previous assert, then we've succeeded */


### PR DESCRIPTION
swim_seq gets malloc'd, but never freed.  It's only used to print the sequence
of swim states in the swim test -- nowhere else, so freeing it shouldn't cause
any unintended side-effects.