### PR TITLE
DAOS-7066 test: Remove system name from additional tests

### DIFF
--- a/src/tests/ftest/pool/connect_test.py
+++ b/src/tests/ftest/pool/connect_test.py
@@ -48,7 +48,7 @@ class ConnectTest(TestWithServers):
         scm_size = self.params.get("scm_size", "/run/pool*")
 
         try:
-            data = dmg.pool_create(scm_size=scm_size, group=set_id)
+            data = dmg.pool_create(scm_size=scm_size)
             if dmg.result.exit_status != 0:
                 self.fail("    Unable to parse the Pool's UUID and SVC.")
 

--- a/src/tests/ftest/pool/multi_server_create_delete_test.py
+++ b/src/tests/ftest/pool/multi_server_create_delete_test.py
@@ -52,11 +52,6 @@ class MultiServerCreateDeleteTest(TestWithServers):
         group = os.getlogin() if grouplist[0] == 'valid' else grouplist[0]
         expected_for_param.append(grouplist[1])
 
-        systemnamelist = self.params.get(
-            "systemname", '/run/tests/systemnames/*')
-        system_name = systemnamelist[0]
-        expected_for_param.append(systemnamelist[1])
-
         tgtlistlist = self.params.get("tgt", '/run/tests/tgtlist/*')
         tgtlist = tgtlistlist[0]
         expected_for_param.append(tgtlistlist[1])
@@ -70,7 +65,7 @@ class MultiServerCreateDeleteTest(TestWithServers):
         host2 = self.hostlist_servers[1]
         test_destroy = True
         data = dmg.pool_create(
-            "1GB", user, group, None, tgtlist, None, system_name)
+            "1GB", user, group, None, tgtlist, None)
         if dmg.result.exit_status == 0:
             if expected_result == RESULT_FAIL:
                 self.fail(


### PR DESCRIPTION
PR #5139 modified the dmg.pool_create() method to remove the
group/system parameter as it is now set in the configuration,
but missed a couple of tests that are not run for PR landings.

Test-tag: poolconnect multiserver_create_delete