### PR TITLE
DAOS-7123 dfuse: Fix coverity issues arising from recent changes. (#5335)

### DIFF
--- a/src/client/dfuse/dfuse_cont.c
+++ b/src/client/dfuse/dfuse_cont.c
@@ -54,6 +54,7 @@ dfuse_cont_helper(fuse_req_t req, struct dfuse_inode_entry *parent,
 			DFUSE_TRA_ERROR(parent,
 					"dfs_cont_create() failed: (%d)",
 					rc);
+			D_FREE(dfc);
 			D_GOTO(err, rc);
 		}
 	}

--- a/src/client/dfuse/dfuse_core.c
+++ b/src/client/dfuse/dfuse_core.c
@@ -405,7 +405,7 @@ dfuse_pool_open(struct dfuse_projection_info *fs_handle, uuid_t *pool,
 	if (rc != -DER_SUCCESS) {
 		DFUSE_TRA_ERROR(dfp, "Failed to create hash table: "DF_RC,
 				DP_RC(rc));
-		D_GOTO(err_disconnect, rc);
+		D_GOTO(err_disconnect, rc = daos_der2errno(rc));
 	}
 
 	rlink = d_hash_rec_find_insert(&fs_handle->dpi_pool_table,


### PR DESCRIPTION
Improve error handling and freeing resources correctly.

Most of these changes are the result of the pool-connect rewrite
and were found by coverity.

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>
Co-authored-by: Mohamad Chaarawi <mohamad.chaarawi@intel.com>
Conflicts:
	src/client/dfuse/ops/lookup.c