### PR TITLE
DAOS-7254 rebuild: schedule reclaim job by reintegration

### DIFF
--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -4057,21 +4057,6 @@ pool_svc_update_map_internal(struct pool_svc *svc, unsigned int opc,
 
 	replace_failed_replicas(svc, map);
 
-	if (opc == POOL_ADD_IN) {
-		/*
-		 * If we are setting ranks from UP -> UPIN, schedule a reclaim
-		 * operation to garbage collect any unreachable data moved
-		 * during reintegration/addition
-		 */
-		rc = ds_rebuild_schedule(svc->ps_pool, map_version, tgts,
-					 RB_OP_RECLAIM, 0);
-		if (rc != 0) {
-			D_ERROR("failed to schedule reclaim rc: "DF_RC"\n",
-				DP_RC(rc));
-			goto out_map_buf;
-		}
-	}
-
 out_map_buf:
 	pool_buf_free(map_buf);
 out_map:

--- a/src/tests/ftest/daos_test/daos_core_test.yaml
+++ b/src/tests/ftest/daos_test/daos_core_test.yaml
@@ -24,11 +24,11 @@ timeouts:
     test_daos_capability: 104
     test_daos_epoch_recovery: 104
     test_daos_md_replication: 104
-    test_daos_rebuild_simple: 500
+    test_daos_rebuild_simple: 900
     test_daos_drain_simple: 500
     test_daos_oid_allocator: 320
-    test_daos_checksum: 240
-    test_daos_rebuild_ec: 1500
+    test_daos_checksum: 500
+    test_daos_rebuild_ec: 1800
     test_daos_degraded_ec_0to6: 900
     test_daos_degraded_ec_8to23: 950
     test_daos_dedup: 220

--- a/src/tests/suite/daos_rebuild_common.c
+++ b/src/tests/suite/daos_rebuild_common.c
@@ -694,19 +694,23 @@ verify_ec(struct ioreq *req, int index, char *verify_data, daos_off_t off,
 void
 write_ec_partial(struct ioreq *req, int test_idx, daos_off_t off)
 {
-	char	buffer[PARTIAL_DATA_SIZE];
+	char	*buffer;
 
+	buffer = (char *)malloc(PARTIAL_DATA_SIZE);
 	make_buffer(buffer, 'a', PARTIAL_DATA_SIZE);
 	write_ec(req, test_idx, buffer, off, PARTIAL_DATA_SIZE);
+	free(buffer);
 }
 
 void
 verify_ec_partial(struct ioreq *req, int test_idx, daos_off_t off)
 {
-	char	buffer[PARTIAL_DATA_SIZE];
+	char	*buffer;
 
+	buffer = (char *)malloc(PARTIAL_DATA_SIZE);
 	make_buffer(buffer, 'a', PARTIAL_DATA_SIZE);
 	verify_ec(req, test_idx, buffer, off, PARTIAL_DATA_SIZE);
+	free(buffer);
 }
 
 void
@@ -748,11 +752,13 @@ write_ec_partial_full(struct ioreq *req, int test_idx, daos_off_t off)
 void
 verify_ec_full_partial(struct ioreq *req, int test_idx, daos_off_t off)
 {
-	char	buffer[DATA_SIZE];
+	char	*buffer;
 
+	buffer = (char *)malloc(DATA_SIZE);
 	make_buffer(buffer, 'b', DATA_SIZE);
 	make_buffer(buffer, 'a', PARTIAL_DATA_SIZE);
 	verify_ec(req, test_idx, buffer, off, DATA_SIZE);
+	free(buffer);
 }
 
 void

--- a/src/tests/suite/daos_rebuild_simple.c
+++ b/src/tests/suite/daos_rebuild_simple.c
@@ -68,14 +68,16 @@ reintegrate_with_inflight_io(test_arg_t *arg, daos_obj_id_t *oid,
 {
 	daos_obj_id_t inflight_oid;
 
+#if 0
+	/* Disable it due to DAOS-7420 */
 	if (oid != NULL) {
 		inflight_oid = *oid;
 	} else {
-		inflight_oid = daos_test_oid_gen(arg->coh,
-						 DAOS_OC_R3S_SPEC_RANK, 0,
-						 0, arg->myrank);
-		inflight_oid = dts_oid_set_rank(inflight_oid, rank);
-	}
+#endif
+	inflight_oid = daos_test_oid_gen(arg->coh,
+					 DAOS_OC_R3S_SPEC_RANK, 0,
+					 0, arg->myrank);
+	inflight_oid = dts_oid_set_rank(inflight_oid, rank);
 
 	arg->rebuild_cb = reintegrate_inflight_io;
 	arg->rebuild_cb_arg = &inflight_oid;


### PR DESCRIPTION
Schedule reclaim job with reintegrate pool map version, to make
sure reclaim happening before any following reintegration,
otherwise, reintegration might get some orphan objects during
scan cause reintegration failure.

Add reintegration into EC object rebuild test to verify this.

Signed-off-by: Di Wang <di.wang@intel.com>