### PR TITLE
DAOS-7260 dtx: dedicated ULT for each container batched commit

### DIFF
--- a/src/include/daos_srv/container.h
+++ b/src/include/daos_srv/container.h
@@ -62,14 +62,10 @@ struct ds_cont_child {
 	ABT_mutex		 sc_mutex;
 	ABT_cond		 sc_dtx_resync_cond;
 	uint32_t		 sc_dtx_resyncing:1,
-				 sc_dtx_aggregating:1,
 				 sc_dtx_reindex:1,
 				 sc_dtx_reindex_abort:1,
 				 sc_dtx_cos_shutdown:1,
-				 sc_dtx_cleanup_stale:1,
 				 sc_closing:1,
-				 sc_vos_aggregating:1,
-				 sc_abort_vos_aggregating:1,
 				 sc_props_fetched:1,
 				 sc_stopping:1;
 	uint32_t		 sc_dtx_batched_gen;

--- a/src/include/daos_srv/daos_engine.h
+++ b/src/include/daos_srv/daos_engine.h
@@ -260,6 +260,7 @@ sched_req_attr_init(struct sched_req_attr *attr, unsigned int type,
 		    uuid_t *pool_id)
 {
 	attr->sra_type = type;
+	attr->sra_flags = 0;
 	uuid_copy(attr->sra_pool_id, *pool_id);
 }
 


### PR DESCRIPTION
Originally, each xstream has single ULT for DTX async batched commit
in spite of how many containers attached to such xstream. Such model
has some short-comings. For example, if the unique DTX async batched
commit ULT is blocked for some reason when commit for one container,
then the batched commit for all the other containers will be blocked.
That is unreasonable. So in this patch, we start a dedicated ULT for
every container that has something to be batched committed. Such ULT
will automatically exit if become idle (there are no more DTX entries
to be committed at current time). Similarily for DTX aggregation and
stale DTX entries cleanup.

Signed-off-by: Fan Yong <fan.yong@intel.com>