### PR TITLE
DAOS-7246 Fix Coverity issue in CaRT Test code

### DIFF
--- a/src/tests/ftest/cart/test_group_np_common.h
+++ b/src/tests/ftest/cart/test_group_np_common.h
@@ -146,7 +146,13 @@ test_swim_status_handler(crt_rpc_t *rpc_req)
 	regex_t				 regex_dead;
 	static const char		*dead_regex = ".?0*1";
 	static const char		*alive_regex = ".?0*";
-	char				*swim_seq = malloc(MAX_SWIM_STATUSES);
+	char				*swim_seq;
+
+	D_ALLOC(swim_seq, MAX_SWIM_STATUSES);
+
+	D_ASSERTF(swim_seq != NULL,
+		  "Cannot allocate %d chars for SWIM sequence.\n",
+		  MAX_SWIM_STATUSES);
 
 	/* CaRT internally already allocated the input/output buffer */
 	e_req = crt_req_get(rpc_req);

--- a/src/tests/ftest/cart/test_group_np_common.h
+++ b/src/tests/ftest/cart/test_group_np_common.h
@@ -147,12 +147,15 @@ test_swim_status_handler(crt_rpc_t *rpc_req)
 	static const char		*dead_regex = ".?0*1";
 	static const char		*alive_regex = ".?0*";
 	char				swim_seq[MAX_SWIM_STATUSES];
+	size_t				sc = sizeof(char);
 
 	/* CaRT internally already allocated the input/output buffer */
 	e_req = crt_req_get(rpc_req);
 
 	if (swim_status_by_rank[e_req->rank] != NULL)
-		strcpy(swim_seq, swim_status_by_rank[e_req->rank]);
+		memcpy(swim_seq,
+		       swim_status_by_rank[e_req->rank],
+		       strlen(swim_status_by_rank[e_req->rank]) * sc);
 	else
 		memset(swim_seq, 0x0, MAX_SWIM_STATUSES);
 

--- a/src/tests/ftest/cart/test_group_np_common.h
+++ b/src/tests/ftest/cart/test_group_np_common.h
@@ -146,13 +146,7 @@ test_swim_status_handler(crt_rpc_t *rpc_req)
 	regex_t				 regex_dead;
 	static const char		*dead_regex = ".?0*1";
 	static const char		*alive_regex = ".?0*";
-	char				*swim_seq;
-
-	D_ALLOC(swim_seq, MAX_SWIM_STATUSES);
-
-	D_ASSERTF(swim_seq != NULL,
-		  "Cannot allocate %d chars for SWIM sequence.\n",
-		  MAX_SWIM_STATUSES);
+	char				swim_seq[MAX_SWIM_STATUSES];
 
 	/* CaRT internally already allocated the input/output buffer */
 	e_req = crt_req_get(rpc_req);
@@ -160,7 +154,7 @@ test_swim_status_handler(crt_rpc_t *rpc_req)
 	if (swim_status_by_rank[e_req->rank] != NULL)
 		strcpy(swim_seq, swim_status_by_rank[e_req->rank]);
 	else
-		swim_seq = "";
+		memset(swim_seq, 0x0, MAX_SWIM_STATUSES);
 
 	/* compile and run regex's */
 	regcomp(&regex_dead, dead_regex, REG_EXTENDED);
@@ -192,8 +186,6 @@ test_swim_status_handler(crt_rpc_t *rpc_req)
 		  "status [%d] is as expected.\n",
 		  e_req->rank, swim_seq,
 		  e_req->exp_status);
-
-	D_FREE(swim_seq);
 
 	e_reply = crt_reply_get(rpc_req);
 

--- a/src/tests/ftest/cart/test_group_np_common.h
+++ b/src/tests/ftest/cart/test_group_np_common.h
@@ -187,6 +187,8 @@ test_swim_status_handler(crt_rpc_t *rpc_req)
 		  e_req->rank, swim_seq,
 		  e_req->exp_status);
 
+	D_FREE(swim_seq);
+
 	e_reply = crt_reply_get(rpc_req);
 
 	/* If we got past the previous assert, then we've succeeded */


### PR DESCRIPTION
swim_seq gets malloc'd, but never freed.  It's only used to print the sequence of swim states in the swim test -- nowhere else, so freeing it shouldn't cause any unintended side-effects.

Signed-off-by: Ethan Mallove <ethanx.a.mallove@intel.com>