### PR TITLE
DAOS-623 test: Install unversioned python for pylint.

### DIFF
--- a/utils/docker/Dockerfile.checkpatch
+++ b/utils/docker/Dockerfile.checkpatch
@@ -17,9 +17,11 @@ RUN dnf -y upgrade &&						\
     dnf -y install codespell diffutils file findutils git	\
 	python3-clustershell python3-pygithub python3-numpy	\
 	python3-paramiko python3-pylint python3-pyxattr		\
-	python3-tabulate ShellCheck &&				\
+	python3-tabulate python-unversioned-command		\
+        ShellCheck &&						\
     dnf -y module enable avocado:latest &&			\
-    dnf -y module install avocado
+    dnf -y module install avocado &&				\
+    dnf clean all
 
 ARG UID=1000
 


### PR DESCRIPTION
This was fixed in master in https://github.com/daos-stack/daos/pull/4964 however we do not need/want that full PR on 1.2 so I've just taken the additional package to resolve the pylint issue.