### PR TITLE
DAOS-623 build: Do not attempt to re-install packages on leap VMs.

### DIFF
--- a/ci/provisioning/post_provision_config_nodes_LEAP_15.sh
+++ b/ci/provisioning/post_provision_config_nodes_LEAP_15.sh
@@ -2,9 +2,7 @@
 
 REPOS_DIR=/etc/dnf/repos.d
 DISTRO_NAME=leap15
-LSB_RELEASE=lsb-release
 EXCLUDE_UPGRADE=fuse,fuse-libs,fuse-devel,mercury,daos,daos-\*
-
 
 bootstrap_dnf() {
     rm -rf "$REPOS_DIR"

--- a/ci/provisioning/post_provision_config_nodes_LEAP_15.sh
+++ b/ci/provisioning/post_provision_config_nodes_LEAP_15.sh
@@ -7,7 +7,6 @@ EXCLUDE_UPGRADE=fuse,fuse-libs,fuse-devel,mercury,daos,daos-\*
 
 
 bootstrap_dnf() {
-    time zypper --non-interactive install dnf
     rm -rf "$REPOS_DIR"
     ln -s ../zypp/repos.d "$REPOS_DIR"
 }
@@ -82,7 +81,6 @@ post_provision_config_nodes() {
     fi
     rm -f /etc/profile.d/openmpi.sh
     rm -f /tmp/daos_control.log
-    time dnf -y install $LSB_RELEASE
 
     # shellcheck disable=SC2086
     if [ -n "$INST_RPMS" ] &&


### PR DESCRIPTION
dnf is slow to search/validate already installed packages so remove the two
instances where it's asked to install a package that's already present.  This cuts
the VM deployment time down from 40 to 28 minutes, and increases throughput
on the test nodes by 20%.

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>