### PR TITLE
DAOS-7266 test: correct data mover function call

### DIFF
--- a/src/tests/ftest/util/data_mover_test_base.py
+++ b/src/tests/ftest/util/data_mover_test_base.py
@@ -629,8 +629,8 @@ class DataMoverTestBase(IorTestBase, MdtestBase):
             assert src_path is None # nosec
             assert dst_type in (None, "DAOS", "DAOS_UUID") # nosec
             assert dst_path is None # nosec
-            self.set_cont_clone_params(src_pool, src_cont,
-                                       dst_pool, dst_cont)
+            self._set_cont_clone_params(src_pool, src_cont,
+                                        dst_pool, dst_cont)
         else:
             self.fail("Invalid tool: {}".format(str(self.tool)))
 


### PR DESCRIPTION
Test-tag: pr cont_clone

- Fix call to self._set_cont_clone_params

Signed-off-by: Dalton Bohning <daltonx.bohning@intel.com>