### PR TITLE
DAOS-7272 EC: various fixes to make daos_obj pass with EC obj

### DIFF
--- a/src/object/cli_ec.c
+++ b/src/object/cli_ec.c
@@ -325,7 +325,7 @@ obj_ec_recx_scan(daos_iod_t *iod, d_sg_list_t *sgl,
 						tgt_recx_nrs, j, update);
 			/* replica with one segment on each parity cell */
 			if (update) {
-				if (!frag_seg_counted) {
+				if (!frag_seg_counted && sgl) {
 					seg_nr += oca->u.ec.e_p * sgl->sg_nr;
 					frag_seg_counted = true;
 				} else {
@@ -384,7 +384,7 @@ obj_ec_recx_scan(daos_iod_t *iod, d_sg_list_t *sgl,
 			ec_parity_tgt_recx_nrs(oca, tgt_recx_nrs, j,
 					       partial_nr);
 			/* replica to each parity cell */
-			if (!frag_seg_counted) {
+			if (!frag_seg_counted && sgl) {
 				seg_nr += oca->u.ec.e_p * sgl->sg_nr *
 						partial_nr;
 				frag_seg_counted = true;
@@ -1617,7 +1617,8 @@ obj_ec_req_reasb(daos_iod_t *iods, d_sg_list_t *sgls, daos_obj_id_t oid,
 		int tgt_nr = 0;
 
 		if (iods[i].iod_type == DAOS_IOD_SINGLE) {
-			rc = obj_ec_singv_req_reasb(oid, &iods[i], &sgls[i],
+			rc = obj_ec_singv_req_reasb(oid, &iods[i],
+						    sgls ? &sgls[i] : NULL,
 						    oca, reasb_req, i, update);
 			if (rc) {
 				D_ERROR(DF_OID" singv_req_reasb failed %d.\n",
@@ -1629,16 +1630,16 @@ obj_ec_req_reasb(daos_iod_t *iods, d_sg_list_t *sgls, daos_obj_id_t oid,
 
 		singv_only = false;
 		/* For array EC obj, scan/encode/reasb for each iod */
-		rc = obj_ec_recx_scan(&iods[i], &sgls[i], oca, reasb_req, i,
-				      update);
+		rc = obj_ec_recx_scan(&iods[i], sgls ? &sgls[i] : NULL, oca,
+				      reasb_req, i, update);
 		if (rc) {
 			D_ERROR(DF_OID" obj_ec_recx_scan failed %d.\n",
 				DP_OID(oid), rc);
 			goto out;
 		}
 
-		rc = obj_ec_recx_reasb(&iods[i], &sgls[i], oca, reasb_req, i,
-				       update, &tgt_nr);
+		rc = obj_ec_recx_reasb(&iods[i], sgls ? &sgls[i] : NULL, oca,
+				       reasb_req, i, update, &tgt_nr);
 		if (rc) {
 			D_ERROR(DF_OID" obj_ec_recx_reasb failed %d.\n",
 				DP_OID(oid), rc);
@@ -1688,8 +1689,9 @@ out:
 void
 obj_ec_update_iod_size(struct obj_reasb_req *reasb_req, uint32_t iod_nr)
 {
-	daos_iod_t	*u_iods = reasb_req->orr_uiods;
-	daos_iod_t	*re_iods = reasb_req->orr_iods;
+	daos_iod_t		*u_iods = reasb_req->orr_uiods;
+	daos_iod_t		*re_iods = reasb_req->orr_iods;
+	struct obj_ec_fail_info *fail_info = reasb_req->orr_fail;
 	int i;
 
 	if (re_iods == NULL || u_iods == re_iods)
@@ -1698,6 +1700,17 @@ obj_ec_update_iod_size(struct obj_reasb_req *reasb_req, uint32_t iod_nr)
 	for (i = 0; i < iod_nr; i++) {
 		D_ASSERT(re_iods[i].iod_type == u_iods[i].iod_type);
 		u_iods[i].iod_size = re_iods[i].iod_size;
+	}
+
+	/* Set back the size if it is recovery task */
+	if (unlikely(fail_info != NULL)) {
+		for (i = 0; i < fail_info->efi_recov_ntasks; i++) {
+			if (fail_info->efi_recov_tasks[i].ert_iod.iod_type !=
+							DAOS_IOD_SINGLE)
+				continue;
+			fail_info->efi_recov_tasks[i].ert_oiod->iod_size =
+				fail_info->efi_recov_tasks[i].ert_iod.iod_size;
+		}
 	}
 }
 
@@ -2184,7 +2197,6 @@ obj_ec_recov_task_init(struct obj_reasb_req *reasb_req, daos_obj_id_t oid,
 	if (fail_info->efi_stripe_sgls == NULL)
 		D_GOTO(out, rc = -DER_NOMEM);
 
-	fail_info->efi_uiods = reasb_req->orr_uiods;
 	recx_ep_nr = 0;
 	for (i = 0; i < iod_nr; i++) {
 		stripe_list = &stripe_lists[i];
@@ -2274,6 +2286,7 @@ obj_ec_recov_task_init(struct obj_reasb_req *reasb_req, daos_obj_id_t oid,
 			}
 			D_ASSERT(tidx < fail_info->efi_recov_ntasks);
 			rtask = &fail_info->efi_recov_tasks[tidx++];
+			rtask->ert_oiod = iod;
 			rtask->ert_iod.iod_name = iod->iod_name;
 			rtask->ert_iod.iod_type = iod->iod_type;
 			rtask->ert_iod.iod_size = recx_ep == NULL ?
@@ -2553,6 +2566,7 @@ obj_ec_recov_data(struct obj_reasb_req *reasb_req, daos_obj_id_t oid,
 		sgl = &sgls[i];
 		singv = (iod->iod_type == DAOS_IOD_SINGLE);
 		stripe_sgl = &stripe_sgls[i];
+		iod->iod_size = reasb_req->orr_iods[i].iod_size;
 		cell_sz = singv ? obj_ec_singv_cell_bytes(iod->iod_size, oca) :
 				  obj_ec_cell_rec_nr(oca) * iod->iod_size;
 		stripe_total_sz = cell_sz * obj_ec_tgt_nr(oca);

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -3763,15 +3763,17 @@ obj_comp_cb(tse_task_t *task, void *data)
 				obj_ec_recov_cb(task, obj, obj_auxi);
 			}
 		} else {
-			if (obj_auxi->is_ec_obj && task->dt_result == 0 &&
+			if (obj_auxi->is_ec_obj &&
+			    (task->dt_result == 0 ||
+			     task->dt_result == -DER_REC2BIG) &&
 			    obj_auxi->opc == DAOS_OBJ_RPC_FETCH) {
 				daos_obj_fetch_t *args = dc_task_get_args(task);
 
+				obj_ec_update_iod_size(&obj_auxi->reasb_req,
+						       args->nr);
 				if (obj_auxi->bulks != NULL)
 					obj_ec_fetch_set_sgl(
 						&obj_auxi->reasb_req, args->nr);
-				obj_ec_update_iod_size(&obj_auxi->reasb_req,
-						       args->nr);
 			}
 
 			obj_bulk_fini(obj_auxi);

--- a/src/object/cli_shard.c
+++ b/src/object/cli_shard.c
@@ -629,6 +629,48 @@ dc_shard_csum_report(tse_task_t *task, crt_endpoint_t *tgt_ep, crt_rpc_t *rpc)
 	return crt_req_send(csum_rpc, csum_report_cb, rpc);
 }
 
+static void
+dc_shard_update_size(struct rw_cb_args *rw_args)
+{
+	struct obj_rw_in	*orw;
+	struct obj_rw_out	*orwo;
+	daos_iod_t		*iods;
+	uint64_t		*sizes;
+	struct obj_reasb_req	*reasb_req;
+	bool			is_ec_obj;
+	int			i;
+
+	orw = crt_req_get(rw_args->rpc);
+	orwo = crt_reply_get(rw_args->rpc);
+	D_ASSERT(orw != NULL && orwo != NULL);
+
+	iods = orw->orw_iod_array.oia_iods;
+	sizes = orwo->orw_iod_sizes.ca_arrays;
+
+	reasb_req = rw_args->shard_args->reasb_req;
+	is_ec_obj = (reasb_req != NULL) &&
+		    DAOS_OC_IS_EC(reasb_req->orr_oca);
+	/* update the sizes in iods */
+	for (i = 0; i < orw->orw_nr; i++) {
+		daos_iod_t	*iod;
+
+		D_DEBUG(DB_IO, DF_UOID" size "DF_U64
+			" eph "DF_U64"\n", DP_UOID(orw->orw_oid),
+			sizes[i], orw->orw_epoch);
+
+		if (!is_ec_obj) {
+			iods[i].iod_size = sizes[i];
+			continue;
+		}
+
+		iod = &reasb_req->orr_iods[i];
+		if (!reasb_req->orr_size_set || iod->iod_size == 0) {
+			iod->iod_size = sizes[i];
+			reasb_req->orr_size_set = 1;
+		}
+	}
+}
+
 static int
 dc_rw_cb(tse_task_t *task, void *arg)
 {
@@ -636,8 +678,6 @@ dc_rw_cb(tse_task_t *task, void *arg)
 	struct obj_rw_in	*orw;
 	struct obj_rw_out	*orwo;
 	daos_handle_t		th;
-	daos_iod_t		*iods;
-	uint64_t		*sizes;
 	struct obj_reasb_req	*reasb_req;
 	bool			 is_ec_obj;
 	int			 opc;
@@ -701,6 +741,8 @@ dc_rw_cb(tse_task_t *task, void *arg)
 		}
 	}
 
+	reasb_req = rw_args->shard_args->reasb_req;
+	is_ec_obj = (reasb_req != NULL) && DAOS_OC_IS_EC(reasb_req->orr_oca);
 	if (rc != 0) {
 		if (rc == -DER_INPROGRESS || rc == -DER_TX_BUSY) {
 			D_DEBUG(DB_IO, "rpc %p opc %d to rank %d tag %d may "
@@ -731,10 +773,6 @@ dc_rw_cb(tse_task_t *task, void *arg)
 				rw_args->rpc->cr_ep.ep_tag, DP_RC(rc));
 
 		if (opc == DAOS_OBJ_RPC_FETCH) {
-			reasb_req = rw_args->shard_args->reasb_req;
-			is_ec_obj = (reasb_req != NULL) &&
-				    DAOS_OC_IS_EC(reasb_req->orr_oca);
-
 			/* For EC obj fetch, set orr_epoch as highest server
 			 * epoch, so if need to recovery data (-DER_CSUM etc)
 			 * can use that epoch (see obj_ec_recov_task_init).
@@ -759,11 +797,7 @@ dc_rw_cb(tse_task_t *task, void *arg)
 						DP_RC(rc));
 				rc = -DER_CSUM;
 			} else if (rc == -DER_REC2BIG) {
-				/* update the sizes in iods */
-				iods = orw->orw_iod_array.oia_iods;
-				sizes = orwo->orw_iod_sizes.ca_arrays;
-				for (i = 0; i < orw->orw_nr; i++)
-					iods[i].iod_size = sizes[i];
+				dc_shard_update_size(rw_args);
 			}
 		}
 		D_GOTO(out, rc);
@@ -771,21 +805,13 @@ dc_rw_cb(tse_task_t *task, void *arg)
 	*rw_args->map_ver = obj_reply_map_version_get(rw_args->rpc);
 
 	if (opc == DAOS_OBJ_RPC_FETCH) {
-		reasb_req = rw_args->shard_args->reasb_req;
-
 		if (rw_args->shard_args->auxi.flags & ORF_CHECK_EXISTENCE)
 			goto out;
-
-		is_ec_obj = (reasb_req != NULL) &&
-			    DAOS_OC_IS_EC(reasb_req->orr_oca);
 
 		if (is_ec_obj &&
 		    (reasb_req->orr_epoch.oe_value == DAOS_EPOCH_MAX ||
 		     reasb_req->orr_epoch.oe_value < orwo->orw_epoch))
 			reasb_req->orr_epoch.oe_value = orwo->orw_epoch;
-
-		iods = orw->orw_iod_array.oia_iods;
-		sizes = orwo->orw_iod_sizes.ca_arrays;
 
 		if (orwo->orw_iod_sizes.ca_count != orw->orw_nr) {
 			D_ERROR("out:%u != in:%u for "DF_UOID" with eph "
@@ -807,38 +833,7 @@ dc_rw_cb(tse_task_t *task, void *arg)
 			}
 		}
 
-		/* update the sizes in iods */
-		for (i = 0; i < orw->orw_nr; i++) {
-			daos_iod_t	*iod;
-			daos_iod_t	*orig_iod = NULL;
-
-			D_DEBUG(DB_IO, DF_UOID" size "DF_U64
-				" eph "DF_X64"\n", DP_UOID(orw->orw_oid),
-				sizes[i], orw->orw_epoch);
-
-			if (!is_ec_obj) {
-				iods[i].iod_size = sizes[i];
-				continue;
-			}
-
-			iod = &reasb_req->orr_iods[i];
-			if (reasb_req->orr_recov) {
-				/* For recover tasks, let's update the iod in
-				 * original task.
-				 */
-				D_ASSERT(reasb_req->orr_fail != NULL);
-				orig_iod = &reasb_req->orr_fail->efi_uiods[i];
-			}
-
-			if (!reasb_req->orr_size_set || iod->iod_size == 0 ||
-			   (orig_iod != NULL && orig_iod->iod_size == 0)) {
-				iod->iod_size = sizes[i];
-				if (orig_iod)
-					orig_iod->iod_size = sizes[i];
-				reasb_req->orr_size_set = 1;
-			}
-		}
-
+		dc_shard_update_size(rw_args);
 		if (is_ec_obj && reasb_req->orr_size_fetch)
 			goto out;
 
@@ -877,6 +872,8 @@ dc_rw_cb(tse_task_t *task, void *arg)
 			}
 
 			for (i = 0; i < orw->orw_nr; i++) {
+				daos_iod_t *iod;
+
 				/* server returned bs_nr_out is only to check
 				 * if it is empty record in that case just set
 				 * sg_nr_out as zero, or will set sg_nr_out and
@@ -887,7 +884,9 @@ dc_rw_cb(tse_task_t *task, void *arg)
 					sgls[i].sg_nr_out = 0;
 					continue;
 				}
-				size_in_iod = daos_iods_len(&iods[i], 1);
+
+				iod = &orw->orw_iod_array.oia_iods[i];
+				size_in_iod = daos_iods_len(iod, 1);
 				if (size_in_iod == -1) {
 					/* only for echo mode */
 					sgls[i].sg_nr_out = sgls[i].sg_nr;

--- a/src/object/obj_ec.h
+++ b/src/object/obj_ec.h
@@ -219,6 +219,10 @@ struct obj_ec_recov_codec {
 /* EC recovery task */
 struct obj_ec_recov_task {
 	daos_iod_t		ert_iod;
+	/* the original user iod pointer, used for the case that in singv
+	 * degraded fetch, set the iod_size.
+	 */
+	daos_iod_t		*ert_oiod;
 	d_sg_list_t		ert_sgl;
 	daos_epoch_t		ert_epoch;
 	daos_handle_t		ert_th; /* read-only tx handle */
@@ -226,10 +230,6 @@ struct obj_ec_recov_task {
 
 /** EC obj IO failure information */
 struct obj_ec_fail_info {
-	/* the original user iods pointer, used for the case that in singv
-	 * degraded fetch, set the iod_size.
-	 */
-	daos_iod_t			*efi_uiods;
 	/* missed (to be recovered) recx list */
 	struct daos_recx_ep_list	*efi_recx_lists;
 	/* list of error targets */

--- a/src/object/obj_enum.c
+++ b/src/object/obj_enum.c
@@ -644,7 +644,7 @@ fill_rec(daos_handle_t ih, vos_iter_entry_t *key_ent, struct dss_enum_arg *arg,
 		" rsize "DF_U64" ver %u kd_len "DF_U64" type %d sgl_idx %d/%zd"
 		"kds_len %d inline "DF_U64" epr "DF_U64"/"DF_U64"\n",
 		key_ent->ie_recx.rx_idx, key_ent->ie_recx.rx_nr,
-		key_ent->ie_rsize, rec->rec_version,
+		rec->rec_size, rec->rec_version,
 		arg->kds[arg->kds_len].kd_key_len, type, arg->sgl_idx,
 		iovs[arg->sgl_idx].iov_len, arg->kds_len,
 		rec->rec_flags & RECX_INLINE ? data_size : 0,

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -381,7 +381,7 @@ obj_bulk_transfer(crt_rpc_t *rpc, crt_bulk_op_t bulk_op, bool bulk_bind,
 			if (rc)
 				break;
 
-			if (length > remote_bulk_size) {
+			if ((offset + length) > remote_bulk_size) {
 				D_DEBUG(DLOG_DBG, DF_U64 " > %zu : %d\n",
 					length,	remote_bulk_size,
 					-DER_OVERFLOW);

--- a/src/tests/ftest/daos_test/daos_core_test.py
+++ b/src/tests/ftest/daos_test/daos_core_test.py
@@ -149,6 +149,21 @@ class DaosCoreTest(DaosCoreBase):
         """
         self.run_subtest()
 
+    def test_daos_ec_io(self):
+        """Jira ID: DAOS-1568
+
+        Test Description:
+            Run daos_test -i -l"EC_4P2G1"
+
+        Use cases:
+            Core tests for daos_test
+
+        :avocado: tags=all,pr,daily_regression
+        :avocado: tags=hw,ib2,medium
+        :avocado: tags=daos_test,daos_core_test,test_daos_io
+        """
+        self.run_subtest()
+
     def test_daos_object_array(self):
         """Jira ID: DAOS-1568
 

--- a/src/tests/ftest/daos_test/daos_core_test.yaml
+++ b/src/tests/ftest/daos_test/daos_core_test.yaml
@@ -88,6 +88,7 @@ daos_tests:
     test_daos_distributed_tx: DAOS_Distributed_TX
     test_daos_verify_consistency: DAOS_Verify_Consistency
     test_daos_io: DAOS_IO
+    test_daos_ec_io: DAOS_EC_IO
     test_daos_object_array: DAOS_Object_Array
     test_daos_array: DAOS_Array
     test_daos_kv: DAOS_KV
@@ -126,6 +127,7 @@ daos_tests:
     test_daos_distributed_tx: T
     test_daos_verify_consistency: V
     test_daos_io: i
+    test_daos_ec_io: i
     test_daos_object_array: A
     test_daos_array: D
     test_daos_kv: K
@@ -145,6 +147,7 @@ daos_tests:
   args:
     test_daos_degraded_ec_0to6: -u subtests="0-6"
     test_daos_degraded_ec_8to23: -u subtests="8-23"
+    test_daos_ec_io: -l"EC_4P2G1"
   scalable_endpoint:
     test_daos_degraded_mode: True
   stopped_ranks:

--- a/src/tests/suite/daos_epoch_io.c
+++ b/src/tests/suite/daos_epoch_io.c
@@ -10,6 +10,9 @@
 
 #include "daos_iotest.h"
 
+int dts_ec_obj_class;
+int dts_ec_grp_size;
+
 /* the temporary IO dir */
 char *test_io_dir;
 /* the temporary IO working dir, will be cleanup for every running */

--- a/src/tests/suite/daos_obj.c
+++ b/src/tests/suite/daos_obj.c
@@ -19,9 +19,6 @@
 int dts_obj_class	= OC_RP_2G1;
 int dts_obj_replica_cnt	= 2;
 
-int dts_ec_obj_class	= OC_EC_2P2G1;
-int dts_ec_grp_size	= 4;
-
 void
 ioreq_init(struct ioreq *req, daos_handle_t coh, daos_obj_id_t oid,
 	   daos_iod_type_t iod_type, test_arg_t *arg)
@@ -2129,7 +2126,6 @@ basic_byte_array(void **state)
 	char		 *buf;
 	char		 *buf_out;
 	int		 buf_len, tmp_len;
-	bool		 test_ec = false;
 	int		 step = 1;
 	int		 rc;
 
@@ -2140,14 +2136,7 @@ basic_byte_array(void **state)
 	dts_buf_render(stack_buf, STACK_BUF_LEN);
 	dts_buf_render(bulk_buf, TEST_BULK_BUF_LEN);
 
-test_ec_obj:
-	/** open object */
-	if (test_ec)
-		oid = daos_test_oid_gen(arg->coh, dts_ec_obj_class, 0, 0,
-					arg->myrank);
-	else
-		oid = daos_test_oid_gen(arg->coh, dts_obj_class, 0, 0,
-					arg->myrank);
+	oid = daos_test_oid_gen(arg->coh, dts_obj_class, 0, 0, arg->myrank);
 	rc = daos_obj_open(arg->coh, oid, 0, &oh, NULL);
 	assert_rc_equal(rc, 0);
 
@@ -2258,13 +2247,6 @@ next_step:
 	/** close object */
 	rc = daos_obj_close(oh, NULL);
 	assert_rc_equal(rc, 0);
-
-	if (test_runable(arg, dts_ec_grp_size) && !test_ec) {
-		print_message("\nrun same test fr EC object ...\n");
-		test_ec = true;
-		step = 1;
-		goto test_ec_obj;
-	}
 
 	print_message("all good\n");
 	D_FREE(bulk_buf);


### PR DESCRIPTION
1. Check sgl in punch recxs path and single value path.
2. Since each iod will use separate recovery task, then in
dc_rw_cb(), it might update size to the wrong original iod
(efi_uiods), since it will always update the first iod in
efi_uiods. so let's add ert_oiod for each recovery task, and
update the size in obj_ec_recov_data().
3. mov ec_update_io_size ahead of ec_fetch_set_sgl, since the
updated iod_size will be needed during set_sgl.
4. update iod size for REC2BIG case.
5. in obj_bulk_transfer(), it should compare the end offset of
the transferring buffer with remote bulk size.
6. Add ec object to daos obj CI test.

Signed-off-by: Di Wang <di.wang@intel.com>