### PR TITLE
DAOS-7276 control: disable forwarding to syslog

### DIFF
--- a/utils/systemd/daos_server.service
+++ b/utils/systemd/daos_server.service
@@ -19,6 +19,8 @@ LimitCORE=infinity
 LimitNOFILE=infinity
 StartLimitIntervalSec=60
 StartLimitBurst=5
+SyslogLevel=debug
+SyslogLevelPrefix=false
 
 [Install]
 WantedBy = multi-user.target

--- a/utils/systemd/daos_server.service.pre230
+++ b/utils/systemd/daos_server.service.pre230
@@ -20,6 +20,8 @@ LimitCORE=infinity
 LimitNOFILE=infinity
 StartLimitInterval=60
 StartLimitBurst=5
+SyslogLevel=debug
+SyslogLevelPrefix=false
 
 [Install]
 WantedBy = multi-user.target


### PR DESCRIPTION
Set daos_server service output to syslog to priority level debug to
avoid automatic forwarding of info level entries to syslog

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>