### PR TITLE
DAOS-6458 utils: make daos_hdlr.c a lib

### DIFF
--- a/src/utils/SConscript
+++ b/src/utils/SConscript
@@ -26,7 +26,15 @@ def scons():
 
     Import('cmd_parser', 'dc_credit')
     daos_obj = [cmd_parser, dc_credit]
-    daos_src = ['daos.c', 'daos_obj_ctl.c', 'daos_hdlr.c', 'daos_autotest.c']
+    daos_src = ['daos.c', 'daos_obj_ctl.c', 'daos_autotest.c']
+    daos_hdlrs_src = ['daos_hdlr.c']
+
+    daos_hdlrs_lib = daos_build.library(denv, 'daos_hdlrs',
+                                        daos_hdlrs_src, LIBS=libs)
+
+    denv.Install('$PREFIX/lib64/', daos_hdlrs_lib)
+    libs = libs + ['daos_hdlrs']
+    denv.AppendUnique(LIBPATH=[Dir('.')])
 
     daos = daos_build.program(denv, 'daos', [daos_src, daos_obj], LIBS=libs)
     denv.Install('$PREFIX/bin/', daos)

--- a/src/utils/daos.c
+++ b/src/utils/daos.c
@@ -1138,7 +1138,9 @@ cont_op_hdlr(struct cmd_args_s *ap)
 		rc = cont_create_snap_hdlr(ap);
 		break;
 	case CONT_LIST_SNAPS:
-		rc = cont_list_snaps_hdlr(ap, NULL, NULL);
+		ap->snapname_str = NULL;
+		ap->epc = 0;
+		rc = cont_list_snaps_hdlr(ap);
 		break;
 	case CONT_DESTROY_SNAP:
 		rc = cont_destroy_snap_hdlr(ap);

--- a/src/utils/daos_hdlr.h
+++ b/src/utils/daos_hdlr.h
@@ -192,8 +192,7 @@ int cont_set_attr_hdlr(struct cmd_args_s *ap);
 int cont_get_attr_hdlr(struct cmd_args_s *ap);
 int cont_del_attr_hdlr(struct cmd_args_s *ap);
 int cont_create_snap_hdlr(struct cmd_args_s *ap);
-int cont_list_snaps_hdlr(struct cmd_args_s *ap, char *snapname,
-			 daos_epoch_t *epoch);
+int cont_list_snaps_hdlr(struct cmd_args_s *ap);
 int cont_destroy_snap_hdlr(struct cmd_args_s *ap);
 int cont_get_acl_hdlr(struct cmd_args_s *ap);
 int cont_overwrite_acl_hdlr(struct cmd_args_s *ap);


### PR DESCRIPTION
This patch make daos_hdlr.c a lib so that the daos util handlers
can be exported. This will be used by new go front-end which will
do the cmd parsing and help.
A few changes have been required to simplify arguments passing for
the go binding.

Change-Id: Idbfd3d43ef466630e84c0b8300f74a2d21a5f7d9
Signed-off-by: Bruno Faccini <bruno.faccini@intel.com>