### PR TITLE
DAOS-7254 tests: add multiple group rebuild test

### DIFF
--- a/src/include/daos_obj_class.h
+++ b/src/include/daos_obj_class.h
@@ -201,6 +201,7 @@ enum {
 	OC_RP_2G6K,
 	OC_RP_2G8K,
 	OC_RP_2GX,
+	OC_RP_2G3,
 
 	/** 3-way replicated object classes */
 	OC_RP_3G1	= 280,

--- a/src/object/obj_class_def.c
+++ b/src/object/obj_class_def.c
@@ -252,6 +252,7 @@ struct daos_obj_class daos_obj_classes[] = {
 	/* 2-replica classes */
 	OC_RP_DEF(2, 1),
 	OC_RP_DEF(2, 2),
+	OC_RP_DEF(2, 3),
 	OC_RP_DEF(2, 4),
 	OC_RP_DEF(2, 6),
 	OC_RP_DEF(2, 8),


### PR DESCRIPTION
Add multiple group rebuild tests.
Upgrade inflight I/O to do i/o on the same object,
which is being rebuilt.

Signed-off-by: Di Wang <di.wang@intel.com>