### PR TITLE
DAOS-7278 control: improve unit test coverage of bdev config params

### DIFF
--- a/src/control/server/engine/config_test.go
+++ b/src/control/server/engine/config_test.go
@@ -175,7 +175,7 @@ func TestConstructedConfig(t *testing.T) {
 	}
 }
 
-func TestEngine_SCMConfigValidation(t *testing.T) {
+func TestEngine_ScmConfigValidation(t *testing.T) {
 	baseValidConfig := func() *Config {
 		return NewConfig().
 			WithFabricProvider("test"). // valid enough to pass "not-blank" test
@@ -249,6 +249,70 @@ func TestEngine_SCMConfigValidation(t *testing.T) {
 				WithScmRamdiskSize(1).
 				WithScmMountPoint("test"),
 			expErr: errors.New("scm_size"),
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			common.CmpErr(t, tc.expErr, tc.cfg.Validate())
+		})
+	}
+}
+
+func TestEngine_BdevConfigValidation(t *testing.T) {
+	baseValidConfig := func() *Config {
+		return NewConfig().
+			WithFabricProvider("test"). // valid enough to pass "not-blank" test
+			WithFabricInterface("test").
+			WithFabricInterfacePort(42).
+			WithScmClass("dcpm").
+			WithScmDeviceList("foo").
+			WithScmMountPoint("test")
+	}
+
+	for name, tc := range map[string]struct {
+		cfg    *Config
+		expErr error
+	}{
+		"missing bdev_class": {
+			// default is applied so no error
+			cfg: baseValidConfig(),
+		},
+		"good pci addresses": {
+			cfg: baseValidConfig().
+				WithBdevClass("nvme").
+				WithBdevDeviceList(common.MockPCIAddr(1), common.MockPCIAddr(2)),
+		},
+		"duplicate pci address": {
+			cfg: baseValidConfig().
+				WithBdevClass("nvme").
+				WithBdevDeviceList(common.MockPCIAddr(1), common.MockPCIAddr(1)),
+			expErr: errors.New("bdev_list"),
+		},
+		"bad pci address": {
+			cfg: baseValidConfig().
+				WithBdevClass("nvme").
+				WithBdevDeviceList(common.MockPCIAddr(1), "0000:00:00"),
+			expErr: errors.New("unexpected pci address"),
+		},
+		"kdev class but no devices": {
+			cfg: baseValidConfig().
+				WithBdevClass("kdev"),
+			expErr: errors.New("kdev requires non-empty bdev_list"),
+		},
+		"malloc class but no size": {
+			cfg: baseValidConfig().
+				WithBdevClass("malloc"),
+			expErr: errors.New("malloc requires non-zero bdev_size"),
+		},
+		"malloc class but no number of devices": {
+			cfg: baseValidConfig().
+				WithBdevClass("malloc").
+				WithBdevFileSize(10),
+			expErr: errors.New("malloc requires non-zero bdev_number"),
+		},
+		"file class but no size": {
+			cfg: baseValidConfig().
+				WithBdevClass("file"),
+			expErr: errors.New("file requires non-zero bdev_size"),
 		},
 	} {
 		t.Run(name, func(t *testing.T) {


### PR DESCRIPTION
Improve validation and expand unit test coverage for bdev parameters in
the server config file.

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>