### PR TITLE
bmurrell/simplify-cron-trigger-matches

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -51,7 +51,8 @@ pipeline {
     triggers {
         cron(env.BRANCH_NAME == 'master' ? 'TZ=America/Toronto\n0 0 * * *\n' : '' +
              env.BRANCH_NAME == 'release/1.2' ? 'TZ=America/Toronto\n0 12 * * *\n' : '' +
-             env.BRANCH_NAME.startsWith('weekly-testing') ? 'H 0 * * 6' : '')
+             env.BRANCH_NAME == 'weekly-testing' ? 'H 0 * * 6' : '' +
+             env.BRANCH_NAME == 'weekly-testing-1.2' ? 'H 0 * * 6' : '')
     }
 
     environment {


### PR DESCRIPTION
Due to what appears to be a bug in Jenkins
(https://issues.jenkins.io/browse/JENKINS-65410) simplify a startsWith()
match for 'weekly-testing*' down into simple == matches for
weekly-testing and weekly-testing-1.2.