### PR TITLE
DAOS-7238 test: check pool create svc_reps length for Coverity issue

### DIFF
--- a/src/common/tests_dmg_helpers.c
+++ b/src/common/tests_dmg_helpers.c
@@ -259,6 +259,10 @@ parse_pool_info(struct json_object *json_pool, daos_mgmt_pool_info_t *pool_info)
 	}
 
 	n_svcranks = json_object_array_length(tmp);
+	if (n_svcranks <= 0) {
+		D_ERROR("unexpected svc_reps length: %d\n", n_svcranks);
+		return -DER_INVAL;
+	}
 	if (pool_info->mgpi_svc == NULL) {
 		pool_info->mgpi_svc = d_rank_list_alloc(n_svcranks);
 		if (pool_info->mgpi_svc == NULL) {


### PR DESCRIPTION
As part of dmg_pool_create() flow, following successful execution
of the dmg pool create command, it is expected that the svc_reps
returned by dmg shall be of length > 0. Before this change, that is not
checked in the code, and Coverity CID 313058 suggests that
a use after free could occur with outpool->svc in the daos_test.
This change adds a check in parse_pool_info, returning -DER_INVAL
when the length of the svc_reps json array is less than or equal to 0.
If this were to actually occur, the dmg_pool_create() function would
return, instead of calling the d_rank_list_copy() that the CID suggests
would cause the list to be freed (as part of a realloc).

Signed-off-by: Kenneth Cain <kenneth.c.cain@intel.com>