### PR TITLE
DAOS-7210 obj: use shard iod_size for csum verify

### DIFF
--- a/src/common/checksum.c
+++ b/src/common/checksum.c
@@ -918,7 +918,8 @@ daos_csummer_verify_iod(struct daos_csummer *obj, daos_iod_t *iod,
 	int			 rc;
 	bool			 match;
 
-	if (!daos_csummer_initialized(obj) || obj->dcs_skip_data_verify)
+	if (!daos_csummer_initialized(obj) || obj->dcs_skip_data_verify ||
+	    iod->iod_size == 0)
 		return 0;
 
 	if (iod == NULL || sgl == NULL || iod_csum == NULL) {

--- a/src/object/cli_shard.c
+++ b/src/object/cli_shard.c
@@ -277,11 +277,14 @@ dc_rw_cb_csum_verify(const struct rw_cb_args *rw_args)
 		daos_iod_t		 shard_iod = *iod;
 		d_sg_list_t		 shard_sgl = sgls[i];
 		struct dcs_iod_csums	*iod_csum = &iods_csums[i];
+		uint64_t		*sizes;
 		daos_iom_t		*map = &maps[i];
 
 		if (!csum_iod_is_supported(iod))
 			continue;
 
+		sizes = orwo->orw_iod_sizes.ca_arrays;
+		shard_iod.iod_size = sizes[i];
 		if (iod->iod_type == DAOS_IOD_ARRAY && oiods != NULL) {
 			rc = dc_rw_cb_iod_sgl_copy(iod, &sgls[i], &shard_iod,
 					&shard_sgl, &oiods->oiod_siods[i],


### PR DESCRIPTION
For EC obj, it possibly get different iod_size (orwo->orw_iod_sizes)
from different shard, should use that for shard csum verify for the
case of partial shards return zero iod_size.

Signed-off-by: Xuezhao Liu <xuezhao.liu@intel.com>