### PR TITLE
DAOS-623 ci: Make TestTag parameter default empty

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -74,7 +74,7 @@ pipeline {
                description: 'Priority of this build.  DO NOT USE WITHOUT PERMISSION.')
         string(name: 'TestTag',
                defaultValue: "",
-               description: 'Test-tag to use for this run (i.e. pr, daily_regression, full_regression, etc.')
+               description: 'Test-tag to use for this run (i.e. pr, daily_regression, full_regression, etc.)')
     }
 
     stages {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -74,7 +74,7 @@ pipeline {
                description: 'Priority of this build.  DO NOT USE WITHOUT PERMISSION.')
         string(name: 'TestTag',
                defaultValue: "",
-               description: 'Test-tag to use for this run (i.e pr, daily_regression, full_regression, etc.')
+               description: 'Test-tag to use for this run (i.e. pr, daily_regression, full_regression, etc.')
     }
 
     stages {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -73,7 +73,7 @@ pipeline {
                defaultValue: getPriority(),
                description: 'Priority of this build.  DO NOT USE WITHOUT PERMISSION.')
         string(name: 'TestTag',
-               defaultValue: "daily_regression",
+               defaultValue: "",
                description: 'Test-tag to use for this run (i.e pr, daily_regression, full_regression, etc.')
     }
 


### PR DESCRIPTION
Jenkins seems to be applying the default parameter values to more than
just parameterized build requests, so make the default value for TestTag
empty so that the usual rules for test tag selection will be followed.