### PR TITLE
DAOS-6941 build: Disable telemetry on 1.2 branch

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+daos (1.1.4-6) unstable; urgency=medium
+  [ Michael MacDonald ]
+  * Remove daos_metrics from 1.2 release
+
+ -- Michael MacDonald <mjmac.macdonald@intel.com>  Wed, 21 Apr 2021 17:58:03 -0000
+
 daos (1.1.4-5) unstable; urgency=medium
   [ Jeff Olivier ]
   * Remove client dependencies on PMDK, SPDK, and argobots

--- a/debian/daos-server.preinst
+++ b/debian/daos-server.preinst
@@ -3,5 +3,3 @@ set -e
 
 addgroup --system daos_server
 adduser --system --ingroup daos_server daos_server
-addgroup --system daos_metrics
-usermod -G -a daos_metrics daos_server

--- a/debian/daos-tests.install
+++ b/debian/daos-tests.install
@@ -3,7 +3,6 @@ usr/bin/hello_drpc
 usr/bin/acl_dump_test
 usr/bin/agent_tests
 usr/bin/common_test
-usr/bin/daos_metrics
 usr/bin/daos_test
 usr/bin/dfs_test
 usr/bin/drpc_engine_test

--- a/src/gurt/telemetry.c
+++ b/src/gurt/telemetry.c
@@ -242,6 +242,9 @@ d_tm_init(int id, uint64_t mem_size, int flags)
 	char		tmp[D_TM_MAX_NAME_LEN];
 	int		rc = D_TM_SUCCESS;
 
+	/* telemetry disabled for this release. */
+	return rc;
+
 	if ((d_tm_shmem_root != NULL) && (d_tm_root != NULL)) {
 		D_INFO("d_tm_init already completed for id %d\n", id);
 		return rc;

--- a/src/gurt/tests/SConscript
+++ b/src/gurt/tests/SConscript
@@ -7,9 +7,7 @@
 import os
 import daos_build
 
-TEST_SRC = ['test_gurt.c',
-            'test_gurt_telem_producer.c',
-            'test_gurt_telem_consumer.c']
+TEST_SRC = ['test_gurt.c']
 
 def scons():
     """Scons function"""

--- a/src/utils/SConscript
+++ b/src/utils/SConscript
@@ -18,9 +18,6 @@ def scons():
     # Build cart_ctl
     SConscript('ctl/SConscript')
 
-    # Build daos_metrics
-    SConscript('daos_metrics/SConscript')
-
     # Can remove this when pmdk is not needed on client
     denv.AppendUnique(LIBPATH=["../client/dfs"])
 

--- a/utils/rpms/daos.spec
+++ b/utils/rpms/daos.spec
@@ -8,7 +8,7 @@
 
 Name:          daos
 Version:       1.1.4
-Release:       5%{?relval}%{?dist}
+Release:       6%{?relval}%{?dist}
 Summary:       DAOS Storage Engine
 
 License:       BSD-2-Clause-Patent
@@ -259,9 +259,8 @@ mkdir -p %{buildroot}/%{conf_dir}/certs/clients
 mv %{buildroot}/%{_sysconfdir}/daos/bash_completion.d %{buildroot}/%{_sysconfdir}
 
 %pre server
-getent group daos_metrics >/dev/null || groupadd -r daos_metrics
 getent group daos_server >/dev/null || groupadd -r daos_server
-getent passwd daos_server >/dev/null || useradd -s /sbin/nologin -r -g daos_server -G daos_metrics daos_server
+getent passwd daos_server >/dev/null || useradd -s /sbin/nologin -r -g daos_server daos_server
 %post server
 /sbin/ldconfig
 %systemd_post %{server_svc_name}
@@ -395,7 +394,6 @@ getent passwd daos_agent >/dev/null || useradd -s /sbin/nologin -r -g daos_agent
 %{_bindir}/daos_gen_io_conf
 %{_bindir}/daos_run_io_conf
 %{_bindir}/crt_launch
-%{_bindir}/daos_metrics
 %{_sysconfdir}/daos/fault-inject-cart.yaml
 %{_bindir}/fault_status
 # For avocado tests
@@ -409,6 +407,9 @@ getent passwd daos_agent >/dev/null || useradd -s /sbin/nologin -r -g daos_agent
 %{_libdir}/*.a
 
 %changelog
+* Wed Apr 21 2021 Michael MacDonald <mjmac.macdonald@intel.com> 1.1.4-6
+- Remove daos_metrics utility from 1.2 release
+
 * Wed Apr 14 2021 Jeff Olivier <jeffrey.v.olivier@intel.com> - 1.1.4-5
 - Remove storage_estimator and io_conf from client packages to remove
   any client side dependence on bio and vos (and and PMDK/SPDK)

--- a/utils/run_test.sh
+++ b/utils/run_test.sh
@@ -124,8 +124,6 @@ if [ -d "/mnt/daos" ]; then
 
     COMP="UTEST_gurt"
     run_test "${SL_BUILD_DIR}/src/gurt/tests/test_gurt"
-    run_test "${SL_BUILD_DIR}/src/gurt/tests/test_gurt_telem_producer"
-    run_test "${SL_BUILD_DIR}/src/gurt/tests/test_gurt_telem_consumer"
 
     COMP="UTEST_vos"
     run_test "${SL_PREFIX}/bin/vos_tests" -A 500


### PR DESCRIPTION
As the feature is still being actively developed for the
release after 1.2, disabling it on the current release
branch will reduce risk and maintenance burden.