### PR TITLE
DAOS-6889 control: add ras event for engine format required

### DIFF
--- a/src/control/events/engine.go
+++ b/src/control/events/engine.go
@@ -7,6 +7,8 @@
 package events
 
 import (
+	"fmt"
+
 	"github.com/daos-stack/daos/src/control/common"
 	sharedpb "github.com/daos-stack/daos/src/control/common/proto/shared"
 )
@@ -72,9 +74,9 @@ func NewEngineDiedEvent(hostname string, instanceIdx uint32, rank uint32, exitEr
 }
 
 // NewEngineFormatRequiredEvent creates a EngineFormatRequired event from given inputs.
-func NewEngineFormatRequiredEvent(hostname string, instanceIdx uint32) *RASEvent {
+func NewEngineFormatRequiredEvent(hostname string, instanceIdx uint32, formatType string) *RASEvent {
 	return New(&RASEvent{
-		Msg:      "DAOS engine requires a storage format",
+		Msg:      fmt.Sprintf("DAOS engine %d requires a %s format", instanceIdx, formatType),
 		ID:       RASEngineFormatRequired,
 		Hostname: hostname,
 		Type:     RASTypeInfoOnly,

--- a/src/control/events/engine.go
+++ b/src/control/events/engine.go
@@ -55,11 +55,11 @@ func EngineStateInfoToProto(rsi *EngineStateInfo) (*sharedpb.RASEvent_EngineStat
 	return pbInfo, nil
 }
 
-// NewEngineFailedEvent creates a specific EngineFailed event from given inputs.
-func NewEngineFailedEvent(hostname string, instanceIdx uint32, rank uint32, exitErr common.ExitStatus) *RASEvent {
+// NewEngineDiedEvent creates a specific EngineDied event from given inputs.
+func NewEngineDiedEvent(hostname string, instanceIdx uint32, rank uint32, exitErr common.ExitStatus) *RASEvent {
 	return New(&RASEvent{
 		Msg:      "DAOS engine exited unexpectedly",
-		ID:       RASEngineFailed,
+		ID:       RASEngineDied,
 		Hostname: hostname,
 		Rank:     rank,
 		Type:     RASTypeStateChange,

--- a/src/control/events/engine_failed.go
+++ b/src/control/events/engine_failed.go
@@ -70,3 +70,17 @@ func NewEngineFailedEvent(hostname string, instanceIdx uint32, rank uint32, exit
 		},
 	})
 }
+
+// NewEngineFormatRequiredEvent creates a EngineFormatRequired event from given inputs.
+func NewEngineFormatRequiredEvent(hostname string, instanceIdx uint32) *RASEvent {
+	return New(&RASEvent{
+		Msg:      "DAOS engine requires a storage format",
+		ID:       RASEngineFormatRequired,
+		Hostname: hostname,
+		Type:     RASTypeInfoOnly,
+		Severity: RASSeverityNotice,
+		ExtendedInfo: &EngineStateInfo{
+			InstanceIdx: instanceIdx,
+		},
+	})
+}

--- a/src/control/events/engine_test.go
+++ b/src/control/events/engine_test.go
@@ -14,8 +14,8 @@ import (
 	"github.com/daos-stack/daos/src/control/common"
 )
 
-func TestEvents_ConvertRankDown(t *testing.T) {
-	event := NewEngineFailedEvent("foo", 1, 1, common.ExitStatus("test"))
+func TestEvents_ConvertEngineDied(t *testing.T) {
+	event := NewEngineDiedEvent("foo", 1, 1, common.ExitStatus("test"))
 
 	pbEvent, err := event.ToProto()
 	if err != nil {

--- a/src/control/events/pubsub_test.go
+++ b/src/control/events/pubsub_test.go
@@ -48,7 +48,7 @@ func (tly *tally) getRx() []string {
 }
 
 func TestEvents_PubSub_Basic(t *testing.T) {
-	evt1 := NewEngineFailedEvent("foo", 1, 1, common.ExitStatus("test"))
+	evt1 := NewEngineDiedEvent("foo", 1, 1, common.ExitStatus("test"))
 
 	log, buf := logging.NewTestLogger(t.Name())
 	defer common.ShowBufferOnFailure(t, buf)
@@ -79,7 +79,7 @@ func TestEvents_PubSub_Basic(t *testing.T) {
 }
 
 func TestEvents_PubSub_Reset(t *testing.T) {
-	evt1 := NewEngineFailedEvent("foo", 1, 1, common.ExitStatus("test"))
+	evt1 := NewEngineDiedEvent("foo", 1, 1, common.ExitStatus("test"))
 
 	log, buf := logging.NewTestLogger(t.Name())
 	defer common.ShowBufferOnFailure(t, buf)
@@ -123,7 +123,7 @@ func TestEvents_PubSub_Reset(t *testing.T) {
 }
 
 func TestEvents_PubSub_DisableEvent(t *testing.T) {
-	evt1 := NewEngineFailedEvent("foo", 1, 1, common.ExitStatus("test"))
+	evt1 := NewEngineDiedEvent("foo", 1, 1, common.ExitStatus("test"))
 	evt2 := NewPoolSvcReplicasUpdateEvent("foo", 1, common.MockUUID(), []uint32{0, 1}, 1)
 
 	log, buf := logging.NewTestLogger(t.Name())
@@ -157,7 +157,7 @@ func TestEvents_PubSub_DisableEvent(t *testing.T) {
 }
 
 func TestEvents_PubSub_SubscribeAnyTopic(t *testing.T) {
-	evt1 := NewEngineFailedEvent("foo", 1, 1, common.ExitStatus("test"))
+	evt1 := NewEngineDiedEvent("foo", 1, 1, common.ExitStatus("test"))
 
 	log, buf := logging.NewTestLogger(t.Name())
 	defer common.ShowBufferOnFailure(t, buf)

--- a/src/control/events/ras.go
+++ b/src/control/events/ras.go
@@ -145,7 +145,6 @@ func (evt *RASEvent) IsForwarded() bool {
 // WithForwarded sets the forwarded state of this event.
 func (evt *RASEvent) WithForwarded(forwarded bool) *RASEvent {
 	evt.forwarded.Store(forwarded)
-
 	return evt
 }
 
@@ -158,7 +157,12 @@ func (evt *RASEvent) ShouldForward() bool {
 // WithForwardable sets the forwardable state of this event.
 func (evt *RASEvent) WithForwardable(forwardable bool) *RASEvent {
 	evt.forwardable.Store(forwardable)
+	return evt
+}
 
+// WithRank sets the rank identifier on the event.
+func (evt *RASEvent) WithRank(rid uint32) *RASEvent {
+	evt.Rank = rid
 	return evt
 }
 

--- a/src/control/events/ras.go
+++ b/src/control/events/ras.go
@@ -47,7 +47,7 @@ type RASID uint32
 const (
 	RASUnknownEvent         RASID = C.RAS_UNKNOWN_EVENT
 	RASEngineFormatRequired RASID = C.RAS_ENGINE_FORMAT_REQUIRED // notice
-	RASEngineFailed         RASID = C.RAS_ENGINE_FAILED          // error
+	RASEngineDied           RASID = C.RAS_ENGINE_DIED            // error
 	RASPoolRepsUpdate       RASID = C.RAS_POOL_REPS_UPDATE       // info
 	RASSwimRankAlive        RASID = C.RAS_SWIM_RANK_ALIVE        // info
 	RASSwimRankDead         RASID = C.RAS_SWIM_RANK_DEAD         // info

--- a/src/control/events/ras_test.go
+++ b/src/control/events/ras_test.go
@@ -44,8 +44,8 @@ var defEvtCmpOpts = append(common.DefaultCmpOpts(),
 func TestEvents_HandleClusterEvent(t *testing.T) {
 	genericEvent := mockGenericEvent()
 	pbGenericEvent, _ := genericEvent.ToProto()
-	rankDownEvent := NewEngineFailedEvent("foo", 1, 1, common.ExitStatus("test"))
-	pbRankDownEvent, _ := rankDownEvent.ToProto()
+	rankDownEvent := NewEngineDiedEvent("foo", 1, 1, common.ExitStatus("test"))
+	pbEngineDiedEvent, _ := rankDownEvent.ToProto()
 	psrEvent := NewPoolSvcReplicasUpdateEvent("foo", 1, common.MockUUID(), []uint32{0, 1}, 1)
 	pbPSREvent, _ := psrEvent.ToProto()
 
@@ -81,7 +81,7 @@ func TestEvents_HandleClusterEvent(t *testing.T) {
 		},
 		"rank down event": {
 			req: &sharedpb.ClusterEventReq{
-				Event: pbRankDownEvent,
+				Event: pbEngineDiedEvent,
 			},
 			subType:     RASTypeStateChange,
 			expEvtTypes: []string{RASTypeStateChange.String()},
@@ -89,7 +89,7 @@ func TestEvents_HandleClusterEvent(t *testing.T) {
 		},
 		"filtered rank down event": {
 			req: &sharedpb.ClusterEventReq{
-				Event: pbRankDownEvent,
+				Event: pbEngineDiedEvent,
 			},
 			subType: RASTypeInfoOnly,
 			expResp: &sharedpb.ClusterEventResp{},

--- a/src/control/lib/control/system_test.go
+++ b/src/control/lib/control/system_test.go
@@ -1298,7 +1298,7 @@ func TestControl_SystemErase(t *testing.T) {
 }
 
 func TestControl_SystemNotify(t *testing.T) {
-	rasEventRankDown := events.NewEngineFailedEvent("foo", 0, 0, common.NormalExit)
+	rasEventEngineDied := events.NewEngineDiedEvent("foo", 0, 0, common.NormalExit)
 
 	for name, tc := range map[string]struct {
 		req     *SystemNotifyReq
@@ -1316,12 +1316,12 @@ func TestControl_SystemNotify(t *testing.T) {
 			expErr: errors.New("nil event in request"),
 		},
 		"zero sequence number": {
-			req:    &SystemNotifyReq{Event: rasEventRankDown},
+			req:    &SystemNotifyReq{Event: rasEventEngineDied},
 			expErr: errors.New("invalid sequence"),
 		},
 		"local failure": {
 			req: &SystemNotifyReq{
-				Event:    rasEventRankDown,
+				Event:    rasEventEngineDied,
 				Sequence: 1,
 			},
 			uErr:   errors.New("local failed"),
@@ -1329,7 +1329,7 @@ func TestControl_SystemNotify(t *testing.T) {
 		},
 		"remote failure": {
 			req: &SystemNotifyReq{
-				Event:    rasEventRankDown,
+				Event:    rasEventEngineDied,
 				Sequence: 1,
 			},
 			uResp:  MockMSResponse("host1", errors.New("remote failed"), nil),
@@ -1337,7 +1337,7 @@ func TestControl_SystemNotify(t *testing.T) {
 		},
 		"empty response": {
 			req: &SystemNotifyReq{
-				Event:    rasEventRankDown,
+				Event:    rasEventEngineDied,
 				Sequence: 1,
 			},
 			uResp:   MockMSResponse("10.0.0.1:10001", nil, &sharedpb.ClusterEventResp{}),
@@ -1367,8 +1367,8 @@ func TestControl_SystemNotify(t *testing.T) {
 }
 
 func TestControl_EventForwarder_OnEvent(t *testing.T) {
-	rasEventRankDownFwdable := events.NewEngineFailedEvent("foo", 0, 0, common.NormalExit)
-	rasEventRankDown := events.NewEngineFailedEvent("foo", 0, 0, common.NormalExit).
+	rasEventEngineDiedFwdable := events.NewEngineDiedEvent("foo", 0, 0, common.NormalExit)
+	rasEventEngineDied := events.NewEngineDiedEvent("foo", 0, 0, common.NormalExit).
 		WithForwardable(false)
 
 	for name, tc := range map[string]struct {
@@ -1381,15 +1381,15 @@ func TestControl_EventForwarder_OnEvent(t *testing.T) {
 			event: nil,
 		},
 		"missing access points": {
-			event: rasEventRankDownFwdable,
+			event: rasEventEngineDiedFwdable,
 		},
 		"successful forward": {
-			event:          rasEventRankDownFwdable,
+			event:          rasEventEngineDiedFwdable,
 			aps:            []string{"192.168.1.1"},
 			expInvokeCount: 2,
 		},
 		"skip non-forwardable event": {
-			event: rasEventRankDown,
+			event: rasEventEngineDied,
 			aps:   []string{"192.168.1.1"},
 		},
 	} {
@@ -1434,8 +1434,8 @@ func TestControl_EventLogger_OnEvent(t *testing.T) {
 		return nil, errors.Errorf("failed to create new syslogger (prio %d)", prio)
 	}
 
-	rasEventRankDown := events.NewEngineFailedEvent("foo", 0, 0, common.NormalExit)
-	rasEventRankDownFwded := events.NewEngineFailedEvent("foo", 0, 0, common.NormalExit).
+	rasEventEngineDied := events.NewEngineDiedEvent("foo", 0, 0, common.NormalExit)
+	rasEventEngineDiedFwded := events.NewEngineDiedEvent("foo", 0, 0, common.NormalExit).
 		WithForwarded(true)
 
 	for name, tc := range map[string]struct {
@@ -1448,10 +1448,10 @@ func TestControl_EventLogger_OnEvent(t *testing.T) {
 			event: nil,
 		},
 		"forwarded event is not logged": {
-			event: rasEventRankDownFwded,
+			event: rasEventEngineDiedFwded,
 		},
 		"not forwarded error event gets logged": {
-			event:           rasEventRankDown,
+			event:           rasEventEngineDied,
 			expShouldLog:    true,
 			expShouldLogSys: true,
 		},
@@ -1463,7 +1463,7 @@ func TestControl_EventLogger_OnEvent(t *testing.T) {
 			expShouldLogSys: true,
 		},
 		"sysloggers not created": {
-			event:           rasEventRankDown,
+			event:           rasEventEngineDied,
 			newSyslogger:    mockNewSysloggerFail,
 			expShouldLog:    true,
 			expShouldLogSys: false,

--- a/src/control/server/ctl_ranks_rpc.go
+++ b/src/control/server/ctl_ranks_rpc.go
@@ -180,8 +180,8 @@ func (svc *ControlService) StopRanks(ctx context.Context, req *ctlpb.RanksReq) (
 	}
 
 	// don't publish rank down events whilst performing controlled shutdown
-	svc.events.DisableEventIDs(events.RASEngineFailed)
-	defer svc.events.EnableEventIDs(events.RASEngineFailed)
+	svc.events.DisableEventIDs(events.RASEngineDied)
+	defer svc.events.EnableEventIDs(events.RASEngineDied)
 
 	for _, srv := range instances {
 		if !srv.isStarted() {

--- a/src/control/server/ctl_ranks_rpc_test.go
+++ b/src/control/server/ctl_ranks_rpc_test.go
@@ -386,7 +386,7 @@ func TestServer_CtlSvc_StopRanks(t *testing.T) {
 
 				srv.OnInstanceExit(
 					func(_ context.Context, _ system.Rank, _ error) error {
-						svc.events.Publish(events.NewEngineFailedEvent("foo",
+						svc.events.Publish(events.NewEngineDiedEvent("foo",
 							0, 0, common.NormalExit))
 						return nil
 					})

--- a/src/control/server/instance.go
+++ b/src/control/server/instance.go
@@ -28,6 +28,7 @@ import (
 
 type (
 	systemJoinFn     func(context.Context, *control.SystemJoinReq) (*control.SystemJoinResp, error)
+	onAwaitFormatFn  func(context.Context) error
 	onStorageReadyFn func(context.Context) error
 	onReadyFn        func(context.Context) error
 	onInstanceExitFn func(context.Context, system.Rank, error) error
@@ -54,6 +55,7 @@ type EngineInstance struct {
 	fsRoot            string
 	hostFaultDomain   *system.FaultDomain
 	joinSystem        systemJoinFn
+	onAwaitFormat     []onAwaitFormatFn
 	onStorageReady    []onStorageReadyFn
 	onReady           []onReadyFn
 	onInstanceExit    []onInstanceExitFn
@@ -109,6 +111,12 @@ func (ei *EngineInstance) isStarted() bool {
 // drpc and storage ready states, and currently active.
 func (ei *EngineInstance) isReady() bool {
 	return ei.ready.Load() && ei.isStarted()
+}
+
+// OnAwaitFormat adds a list of callbacks to invoke when the instance
+// requires formatting.
+func (ei *EngineInstance) OnAwaitFormat(fns ...onAwaitFormatFn) {
+	ei.onAwaitFormat = append(ei.onAwaitFormat, fns...)
 }
 
 // OnStorageReady adds a list of callbacks to invoke when the instance

--- a/src/control/server/instance.go
+++ b/src/control/server/instance.go
@@ -28,7 +28,7 @@ import (
 
 type (
 	systemJoinFn     func(context.Context, *control.SystemJoinReq) (*control.SystemJoinResp, error)
-	onAwaitFormatFn  func(context.Context) error
+	onAwaitFormatFn  func(context.Context, string) error
 	onStorageReadyFn func(context.Context) error
 	onReadyFn        func(context.Context) error
 	onInstanceExitFn func(context.Context, system.Rank, error) error

--- a/src/control/server/instance_exec.go
+++ b/src/control/server/instance_exec.go
@@ -120,7 +120,7 @@ func publishInstanceExitFn(publishFn func(*events.RASEvent), hostname string, en
 			return errors.New("expected non-nil exit error")
 		}
 
-		evt := events.NewEngineFailedEvent(hostname, engineIdx, rank.Uint32(),
+		evt := events.NewEngineDiedEvent(hostname, engineIdx, rank.Uint32(),
 			common.ExitStatus(exitErr.Error()))
 
 		// set forwardable if there is a rank for the MS to operate on

--- a/src/control/server/instance_exec_test.go
+++ b/src/control/server/instance_exec_test.go
@@ -19,8 +19,8 @@ import (
 	"github.com/daos-stack/daos/src/control/system"
 )
 
-// TestIOEngineInstance_EngineDied establishes that event is published on exit.
-func TestIOEngineInstance_EngineDied(t *testing.T) {
+// TestIOEngineInstance_exit establishes that event is published on exit.
+func TestIOEngineInstance_exit(t *testing.T) {
 	var (
 		rxEvts      []*events.RASEvent
 		fakePublish = func(evt *events.RASEvent) {

--- a/src/control/server/instance_exec_test.go
+++ b/src/control/server/instance_exec_test.go
@@ -19,8 +19,8 @@ import (
 	"github.com/daos-stack/daos/src/control/system"
 )
 
-// TestIOEngineInstance_RankDown establishes that event is published on exit.
-func TestIOEngineInstance_RankDown(t *testing.T) {
+// TestIOEngineInstance_EngineDied establishes that event is published on exit.
+func TestIOEngineInstance_EngineDied(t *testing.T) {
 	var (
 		rxEvts      []*events.RASEvent
 		fakePublish = func(evt *events.RASEvent) {

--- a/src/control/server/instance_storage.go
+++ b/src/control/server/instance_storage.go
@@ -18,6 +18,7 @@ import (
 	"github.com/daos-stack/daos/src/control/events"
 	"github.com/daos-stack/daos/src/control/server/storage"
 	"github.com/daos-stack/daos/src/control/server/storage/scm"
+	"github.com/daos-stack/daos/src/control/system"
 )
 
 // scmConfig returns the scm configuration assigned to this instance.
@@ -104,7 +105,9 @@ func (ei *EngineInstance) NotifyStorageReady() {
 // storage format.
 func publishFormatRequiredFn(publishFn func(*events.RASEvent), hostname string, engineIdx uint32) onAwaitFormatFn {
 	return func(_ context.Context) error {
-		publishFn(events.NewEngineFormatRequiredEvent(hostname, engineIdx))
+		evt := events.NewEngineFormatRequiredEvent(hostname, engineIdx).
+			WithRank(uint32(system.NilRank))
+		publishFn(evt)
 
 		return nil
 	}

--- a/src/control/server/instance_storage.go
+++ b/src/control/server/instance_storage.go
@@ -104,8 +104,8 @@ func (ei *EngineInstance) NotifyStorageReady() {
 // event using the provided publish function to indicate that host is awaiting
 // storage format.
 func publishFormatRequiredFn(publishFn func(*events.RASEvent), hostname string, engineIdx uint32) onAwaitFormatFn {
-	return func(_ context.Context) error {
-		evt := events.NewEngineFormatRequiredEvent(hostname, engineIdx).
+	return func(_ context.Context, formatType string) error {
+		evt := events.NewEngineFormatRequiredEvent(hostname, engineIdx, formatType).
 			WithRank(uint32(system.NilRank))
 		publishFn(evt)
 
@@ -159,7 +159,7 @@ func (ei *EngineInstance) awaitStorageReady(ctx context.Context, skipMissingSupe
 	// After we know that the instance is awaiting format, fire off
 	// any callbacks that are waiting for this state.
 	for _, fn := range ei.onAwaitFormat {
-		if err := fn(ctx); err != nil {
+		if err := fn(ctx, formatType); err != nil {
 			return err
 		}
 	}

--- a/src/control/server/instance_storage.go
+++ b/src/control/server/instance_storage.go
@@ -15,6 +15,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/daos-stack/daos/src/control/build"
+	"github.com/daos-stack/daos/src/control/events"
 	"github.com/daos-stack/daos/src/control/server/storage"
 	"github.com/daos-stack/daos/src/control/server/storage/scm"
 )
@@ -98,6 +99,17 @@ func (ei *EngineInstance) NotifyStorageReady() {
 	}()
 }
 
+// publishFormatRequiredFn returns onAwaitFormatFn which will publish an
+// event using the provided publish function to indicate that host is awaiting
+// storage format.
+func publishFormatRequiredFn(publishFn func(*events.RASEvent), hostname string, engineIdx uint32) onAwaitFormatFn {
+	return func(_ context.Context) error {
+		publishFn(events.NewEngineFormatRequiredEvent(hostname, engineIdx))
+
+		return nil
+	}
+}
+
 // awaitStorageReady blocks until instance has storage available and ready to be used.
 func (ei *EngineInstance) awaitStorageReady(ctx context.Context, skipMissingSuperblock bool) error {
 	idx := ei.Index()
@@ -141,6 +153,13 @@ func (ei *EngineInstance) awaitStorageReady(ctx context.Context, skipMissingSupe
 	ei.log.Infof("%s format required on instance %d", formatType, ei.Index())
 
 	ei.waitFormat.SetTrue()
+	// After we know that the instance is awaiting format, fire off
+	// any callbacks that are waiting for this state.
+	for _, fn := range ei.onAwaitFormat {
+		if err := fn(ctx); err != nil {
+			return err
+		}
+	}
 
 	select {
 	case <-ctx.Done():

--- a/src/control/server/instance_storage_test.go
+++ b/src/control/server/instance_storage_test.go
@@ -7,17 +7,23 @@
 package server
 
 import (
+	"context"
+	"fmt"
 	"os"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
 
 	"github.com/daos-stack/daos/src/control/common"
+	"github.com/daos-stack/daos/src/control/events"
 	"github.com/daos-stack/daos/src/control/logging"
 	"github.com/daos-stack/daos/src/control/server/engine"
 	"github.com/daos-stack/daos/src/control/server/storage"
 	"github.com/daos-stack/daos/src/control/server/storage/scm"
+	"github.com/daos-stack/daos/src/control/system"
 )
 
 func TestIOEngineInstance_MountScmDevice(t *testing.T) {
@@ -239,6 +245,124 @@ func TestEngineInstance_NeedsScmFormat(t *testing.T) {
 			common.CmpErr(t, tc.expErr, gotErr)
 			if diff := cmp.Diff(tc.expNeedsFormat, gotNeedsFormat); diff != "" {
 				t.Fatalf("unexpected needs format (-want, +got):\n%s\n", diff)
+			}
+		})
+	}
+}
+
+type tally struct {
+	sync.Mutex
+	evtDesc      string
+	storageReady chan bool
+	finished     chan struct{}
+}
+
+func newTally(sr chan bool) *tally {
+	return &tally{
+		storageReady: sr,
+		finished:     make(chan struct{}),
+	}
+}
+
+func (tly *tally) fakePublish(evt *events.RASEvent) {
+	tly.Lock()
+	defer tly.Unlock()
+
+	tly.evtDesc = evt.Msg
+	close(tly.storageReady)
+	close(tly.finished)
+}
+
+func TestIOEngineInstance_awaitStorageReady(t *testing.T) {
+	errStarted := errors.New("already started")
+	dcpmCfg := &engine.Config{
+		Storage: engine.StorageConfig{
+			SCM: storage.ScmConfig{
+				MountPoint: "/mnt/daos",
+				Class:      storage.ScmClassDCPM,
+				DeviceList: []string{"/dev/foo"},
+			},
+		},
+	}
+
+	for name, tc := range map[string]struct {
+		engineStarted  bool
+		needsScmFormat bool
+		hasSB          bool
+		skipMissingSB  bool
+		expFmtType     string
+		expErr         error
+	}{
+		"already started": {
+			engineStarted: true,
+			expErr:        errStarted,
+		},
+		"needs format but skip missing superblock": {
+			needsScmFormat: true,
+			skipMissingSB:  true,
+			expErr:         FaultScmUnmanaged("/mnt/daos"),
+		},
+		"no need to format and skip missing superblock": {
+			skipMissingSB: true,
+		},
+		"no need to format and existing superblock": {
+			hasSB: true,
+		},
+		"needs scm format": {
+			needsScmFormat: true,
+			expFmtType:     "SCM",
+		},
+		"needs metadata format": {
+			expFmtType: "Metadata",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			log, buf := logging.NewTestLogger(t.Name())
+			defer common.ShowBufferOnFailure(t, buf)
+
+			trc := &engine.TestRunnerConfig{}
+			if tc.engineStarted {
+				trc.Running.SetTrue()
+			}
+			runner := engine.NewTestRunner(trc, dcpmCfg)
+
+			fs := "none"
+			if !tc.needsScmFormat {
+				fs = "ext4"
+			}
+			mp := scm.NewMockProvider(log, nil, &scm.MockSysConfig{GetfsStr: fs})
+
+			engine := NewEngineInstance(log, nil, mp, nil, runner)
+
+			if tc.hasSB {
+				engine.setSuperblock(&Superblock{
+					Rank: system.NewRankPtr(0), ValidRank: true,
+				})
+			}
+
+			tly1 := newTally(engine.storageReady)
+
+			engine.OnAwaitFormat(publishFormatRequiredFn(tly1.fakePublish,
+				hostname(), engine.Index()))
+
+			ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond*100)
+			defer cancel()
+
+			gotErr := engine.awaitStorageReady(ctx, tc.skipMissingSB)
+			common.CmpErr(t, tc.expErr, gotErr)
+			if tc.expErr == errStarted || tc.skipMissingSB == true || tc.hasSB == true {
+				return
+			}
+
+			select {
+			case <-tly1.finished:
+			case <-ctx.Done():
+				t.Fatal("unexpected timeout waiting for format required event")
+			}
+
+			expDescription := fmt.Sprintf("DAOS engine 0 requires a %s format", tc.expFmtType)
+			if diff := cmp.Diff(expDescription, tly1.evtDesc); diff != "" {
+				t.Fatalf("unexpected event description (-want, +got):\n%s\n", diff)
 			}
 		})
 	}

--- a/src/control/server/mgmt_system_test.go
+++ b/src/control/server/mgmt_system_test.go
@@ -241,7 +241,7 @@ func (d *eventsDispatched) OnEvent(ctx context.Context, e *events.RASEvent) {
 }
 
 func TestServer_MgmtSvc_ClusterEvent(t *testing.T) {
-	eventRankDown := events.NewEngineFailedEvent("foo", 0, 0, common.NormalExit)
+	eventEngineDied := events.NewEngineDiedEvent("foo", 0, 0, common.NormalExit)
 
 	for name, tc := range map[string]struct {
 		nilReq        bool
@@ -256,12 +256,12 @@ func TestServer_MgmtSvc_ClusterEvent(t *testing.T) {
 			expErr: errors.New("nil request"),
 		},
 		"successful notification": {
-			event: eventRankDown,
+			event: eventEngineDied,
 			expResp: &sharedpb.ClusterEventResp{
 				Sequence: 1,
 			},
 			expDispatched: []*events.RASEvent{
-				eventRankDown.WithForwarded(true),
+				eventEngineDied.WithForwarded(true),
 			},
 		},
 	} {

--- a/src/control/server/server_utils.go
+++ b/src/control/server/server_utils.go
@@ -236,8 +236,11 @@ func setDaosHelperEnvs(cfg *config.Server, setenv func(k, v string) error) error
 }
 
 func registerEngineCallbacks(engine *EngineInstance, pubSub *events.PubSub, allStarted *sync.WaitGroup) {
-	// Register callback to publish I/O Engine process exit events.
+	// Register callback to publish engine process exit events.
 	engine.OnInstanceExit(publishInstanceExitFn(pubSub.Publish, hostname(), engine.Index()))
+
+	// Register callback to publish engine format requested events.
+	engine.OnAwaitFormat(publishFormatRequiredFn(pubSub.Publish, hostname(), engine.Index()))
 
 	var onceReady sync.Once
 	engine.OnReady(func(_ context.Context) error {

--- a/src/control/system/membership.go
+++ b/src/control/system/membership.go
@@ -491,7 +491,7 @@ func (m *Membership) MarkRankDead(rank Rank) error {
 func (m *Membership) handleEngineFailure(evt *events.RASEvent) {
 	ei := evt.GetEngineStateInfo()
 	if ei == nil {
-		m.log.Error("no extended info in EngineFailed event received")
+		m.log.Error("no extended info in EngineDied event received")
 		return
 	}
 
@@ -525,7 +525,7 @@ func (m *Membership) handleEngineFailure(evt *events.RASEvent) {
 // OnEvent handles events on channel and updates member states accordingly.
 func (m *Membership) OnEvent(_ context.Context, evt *events.RASEvent) {
 	switch evt.ID {
-	case events.RASEngineFailed:
+	case events.RASEngineDied:
 		m.handleEngineFailure(evt)
 	}
 }

--- a/src/control/system/membership_test.go
+++ b/src/control/system/membership_test.go
@@ -858,12 +858,12 @@ func TestSystem_Membership_OnEvent(t *testing.T) {
 		},
 		"event on unrecognized rank": {
 			members:    members,
-			event:      events.NewEngineFailedEvent("foo", 0, 4, common.NormalExit),
+			event:      events.NewEngineDiedEvent("foo", 0, 4, common.NormalExit),
 			expMembers: members,
 		},
 		"state updated on unscheduled exit": {
 			members: members,
-			event:   events.NewEngineFailedEvent("foo", 0, 1, common.NormalExit),
+			event:   events.NewEngineDiedEvent("foo", 0, 1, common.NormalExit),
 			expMembers: Members{
 				MockMember(t, 0, MemberStateJoined),
 				MockMember(t, 1, MemberStateErrored).WithInfo(

--- a/src/engine/tests/drpc_client_tests.c
+++ b/src/engine/tests/drpc_client_tests.c
@@ -437,10 +437,10 @@ test_drpc_verify_cluster_event_min_viable(void **state)
 	mock_valid_drpc_resp_in_recvmsg(DRPC__STATUS__SUCCESS);
 	assert_rc_equal(drpc_init(), 0);
 
-	ds_notify_ras_event(RAS_ENGINE_FAILED, "rank down",
+	ds_notify_ras_event(RAS_ENGINE_DIED, "rank down",
 			    RAS_TYPE_STATE_CHANGE, RAS_SEV_WARNING, NULL, NULL,
 			    NULL, NULL, NULL, NULL, NULL, NULL);
-	verify_cluster_event((uint32_t)RAS_ENGINE_FAILED, "rank down",
+	verify_cluster_event((uint32_t)RAS_ENGINE_DIED, "rank down",
 			     (uint32_t)RAS_TYPE_STATE_CHANGE,
 			     (uint32_t)RAS_SEV_WARNING, "", mock_self_rank, "",
 			     "", "", "", "", "");
@@ -454,7 +454,7 @@ test_drpc_verify_cluster_event_emptymsg(void **state)
 	mock_valid_drpc_resp_in_recvmsg(DRPC__STATUS__SUCCESS);
 	assert_rc_equal(drpc_init(), 0);
 
-	ds_notify_ras_event(RAS_ENGINE_FAILED, "", RAS_TYPE_STATE_CHANGE,
+	ds_notify_ras_event(RAS_ENGINE_DIED, "", RAS_TYPE_STATE_CHANGE,
 			    RAS_SEV_ERROR, NULL, NULL, NULL, NULL, NULL, NULL,
 			    NULL, NULL);
 	assert_int_equal(sendmsg_call_count, 0);
@@ -468,7 +468,7 @@ test_drpc_verify_cluster_event_nomsg(void **state)
 	mock_valid_drpc_resp_in_recvmsg(DRPC__STATUS__SUCCESS);
 	assert_rc_equal(drpc_init(), 0);
 
-	ds_notify_ras_event(RAS_ENGINE_FAILED, NULL, RAS_TYPE_STATE_CHANGE,
+	ds_notify_ras_event(RAS_ENGINE_DIED, NULL, RAS_TYPE_STATE_CHANGE,
 			    RAS_SEV_ERROR, NULL, NULL, NULL, NULL, NULL, NULL,
 			    NULL, NULL);
 	assert_int_equal(sendmsg_call_count, 0);

--- a/src/engine/tests/drpc_client_tests.c
+++ b/src/engine/tests/drpc_client_tests.c
@@ -423,7 +423,7 @@ test_drpc_verify_cluster_event(void **state)
 			    "exjobid", &pool, &cont, &objid, "exctlop",
 			    "{\"people\":[\"bill\",\"steve\",\"bob\"]}");
 	verify_cluster_event((uint32_t)RAS_SYSTEM_STOP_FAILED, "ranks failed",
-			     (uint32_t)RAS_TYPE_INFO, (uint32_t)RAS_SEV_NOTICE,
+			     (uint32_t)RAS_TYPE_INFO, (uint32_t)RAS_SEV_ERROR,
 			     "exhwid", 1, "exjobid", pool_str, cont_str, "1.1",
 			     "exctlop",
 			     "{\"people\":[\"bill\",\"steve\",\"bob\"]}");

--- a/src/include/daos_srv/ras.h
+++ b/src/include/daos_srv/ras.h
@@ -38,8 +38,8 @@
 #define RAS_EVENT_LIST							\
 	X(RAS_UNKNOWN_EVENT,		"unknown_ras_event")		\
 	X(RAS_ENGINE_FORMAT_REQUIRED,	"engine_format_required")	\
-	X(RAS_ENGINE_FAILED,		"engine_failed")		\
-	X(RAS_ENGINE_ASSERTION_FAILED,	"engine_assertion_failed")	\
+	X(RAS_ENGINE_DIED,		"engine_died")			\
+	X(RAS_ENGINE_ASSERTED,		"engine_asserted")		\
 	X(RAS_POOL_REBUILD_START,	"pool_rebuild_started")		\
 	X(RAS_POOL_REBUILD_END,		"pool_rebuild_finished")	\
 	X(RAS_POOL_REBUILD_FAILED,	"pool_rebuild_failed")		\


### PR DESCRIPTION
Raise RAS event when engine format is required to indicate that
administratior intervention is required (to run dmg storage format).

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>