### PR TITLE
DAOS-7281 Test:Fix Coverity Issue in NVMe Recovery Test

### DIFF
--- a/src/tests/suite/daos_nvme_recovery.c
+++ b/src/tests/suite/daos_nvme_recovery.c
@@ -236,6 +236,7 @@ nvme_test_verify_device_stats(void **state)
 
 	if (ndisks <= 1) {
 		print_message("Need Minimum 2 disks for test\n");
+		D_FREE(devices);
 		skip();
 	}
 
@@ -267,6 +268,9 @@ nvme_test_verify_device_stats(void **state)
 	if (rc) {
 		print_message("Log Mask != DEBUG in %s.\n",
 			      server_config_file);
+		D_FREE(server_config_file);
+		D_FREE(devices);
+		D_FREE(log_file);
 		skip();
 	}
 


### PR DESCRIPTION
Fix CID 329259 issue.

Quick-Functional: true
Test-tag: csum_error_log nvme_io

Signed-off-by: Samir Raval <samir.raval@intel.com>