### PR TITLE
DAOS-7246 tests: Use local var -- remove malloc/free

### DIFF
--- a/src/tests/ftest/cart/test_group_np_common.h
+++ b/src/tests/ftest/cart/test_group_np_common.h
@@ -154,7 +154,7 @@ test_swim_status_handler(crt_rpc_t *rpc_req)
 	if (swim_status_by_rank[e_req->rank] != NULL)
 		strcpy(swim_seq, swim_status_by_rank[e_req->rank]);
 	else
-		strcpy(swim_seq, "");
+		memset(swim_seq, 0x0, MAX_SWIM_STATUSES);
 
 	/* compile and run regex's */
 	regcomp(&regex_dead, dead_regex, REG_EXTENDED);

--- a/src/tests/ftest/cart/test_group_np_common.h
+++ b/src/tests/ftest/cart/test_group_np_common.h
@@ -146,13 +146,7 @@ test_swim_status_handler(crt_rpc_t *rpc_req)
 	regex_t				 regex_dead;
 	static const char		*dead_regex = ".?0*1";
 	static const char		*alive_regex = ".?0*";
-	char				*swim_seq;
-
-	D_ALLOC(swim_seq, MAX_SWIM_STATUSES);
-
-	D_ASSERTF(swim_seq != NULL,
-		  "Cannot allocate %d chars for SWIM sequence.\n",
-		  MAX_SWIM_STATUSES);
+	char				swim_seq[MAX_SWIM_STATUSES];
 
 	/* CaRT internally already allocated the input/output buffer */
 	e_req = crt_req_get(rpc_req);
@@ -160,7 +154,7 @@ test_swim_status_handler(crt_rpc_t *rpc_req)
 	if (swim_status_by_rank[e_req->rank] != NULL)
 		strcpy(swim_seq, swim_status_by_rank[e_req->rank]);
 	else
-		memset(swim_seq, 0x0, MAX_SWIM_STATUSES);
+		strcpy(swim_seq, "");
 
 	/* compile and run regex's */
 	regcomp(&regex_dead, dead_regex, REG_EXTENDED);
@@ -192,8 +186,6 @@ test_swim_status_handler(crt_rpc_t *rpc_req)
 		  "status [%d] is as expected.\n",
 		  e_req->rank, swim_seq,
 		  e_req->exp_status);
-
-	D_FREE(swim_seq);
 
 	e_reply = crt_reply_get(rpc_req);
 

--- a/src/tests/ftest/cart/test_group_np_common.h
+++ b/src/tests/ftest/cart/test_group_np_common.h
@@ -147,12 +147,15 @@ test_swim_status_handler(crt_rpc_t *rpc_req)
 	static const char		*dead_regex = ".?0*1";
 	static const char		*alive_regex = ".?0*";
 	char				swim_seq[MAX_SWIM_STATUSES];
+	size_t				sc = sizeof(char);
 
 	/* CaRT internally already allocated the input/output buffer */
 	e_req = crt_req_get(rpc_req);
 
 	if (swim_status_by_rank[e_req->rank] != NULL)
-		strcpy(swim_seq, swim_status_by_rank[e_req->rank]);
+		memcpy(swim_seq,
+		       swim_status_by_rank[e_req->rank],
+		       strlen(swim_status_by_rank[e_req->rank]) * sc);
 	else
 		memset(swim_seq, 0x0, MAX_SWIM_STATUSES);
 


### PR DESCRIPTION
Per @SABollinger:
  Since you know the size to malloc at compile time and since the alloc/free is
  self-contained to just this function, then why don't you declare the swim_seq
  just as a local variable of swim_seq[MAX_SWIM_STATUS] and forget about the alloc
  and free. This will make the code cleaner and save time.
  ..

  The description of this bug is not just a simple thing of checking whether the
  allocation succeeded. The allocation has, succeeded but when the time came to
  free the pointer, the pointer had been modified; i.e. some where in the
  execution there was an overwrite of the pointer. This is probably not in your
  code. A good method of checking this out is to print the pointer after each
  function call. If there is an overwrite of the pointer, then placing the array
  on the local stack may cause the program to seg fault in an un-pleasant way.
  https://github.com/daos-stack/daos/pull/5495#issuecomment-824268591

Signed-off-by: Ethan Mallove <ethanx.a.mallove@intel.com>