### PR TITLE
DAOS-623 vos: Fix consistency statements in README

### DIFF
--- a/src/vos/README.md
+++ b/src/vos/README.md
@@ -539,7 +539,7 @@ transaction performs all operations using its epoch.
 
 The MVCC rules ensure that transactions execute as if they are serialized in
 their epoch order while ensuring that every transaction observes all
-conflicting transactions commit before it openes, as long as the
+conflicting transactions commit before it opens, as long as the
 system clock offsets are always within the expected maximum system clock offset
 (epsilon). For convenience, the rules classify the I/O operations into reads
 and writes:

--- a/src/vos/README.md
+++ b/src/vos/README.md
@@ -538,7 +538,8 @@ Trackers that track the highest server HLC timestamps clients have heard of.) A
 transaction performs all operations using its epoch.
 
 The MVCC rules ensure that transactions execute as if they are serialized in
-their epoch order while complying with external consistency, as long as the
+their epoch order while ensuring that every transaction observes all
+conflicting transactions commit before it openes, as long as the
 system clock offsets are always within the expected maximum system clock offset
 (epsilon). For convenience, the rules classify the I/O operations into reads
 and writes:


### PR DESCRIPTION
Thanks to Duan Shibo <duanshibo.d@gmail.com> on the daos mailing list,
an inaccuracy about the external consistency statement is found. This
patch fixes the comment to reflect the current implementation.

Doc-only: true
Signed-off-by: Li Wei <wei.g.li@intel.com>