### PR TITLE
DAOS-7295 bio: Fixing uninitialized variable in bio_write_blob_hdr().

### DIFF
--- a/src/bio/bio_context.c
+++ b/src/bio/bio_context.c
@@ -714,7 +714,7 @@ bio_write_blob_hdr(struct bio_io_context *ioctxt, struct bio_blob_hdr *bio_bh)
 	struct smd_dev_info	*dev_info;
 	spdk_blob_id		 blob_id;
 	d_iov_t			 iov;
-	bio_addr_t		 addr;
+	bio_addr_t		 addr = { 0 };
 	uint64_t		 off = 0; /* byte offset in SPDK blob */
 	uint16_t		 dev_type = DAOS_MEDIA_NVME;
 	int			 rc = 0;


### PR DESCRIPTION
Initializing the 'addr' local variable to 0.

Note when left uninitialized, the 'ba_hole' may take a garbage from the stack.
In such scenario, the iov is recognized as a 'hole' and skipped in context of bio_iod_prep/iterate_biov/dma_map_one().
This triggers an assert in ctx of bio_rwv(), after the call to bio_iod_prep() - NULL value in 'bs_iovs[]'.