### PR TITLE
DAOS-7284 build: Fix compile with debug + clang

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,7 +12,7 @@
 
 // To use a test branch (i.e. PR) until it lands to master
 // I.e. for testing library changes
-//@Library(value="pipeline-lib@your_branch") _
+@Library(value="pipeline-lib@dbohninx-clang")
 
 // For master, this is just some wildly high number
 next_version = "1000"
@@ -499,11 +499,50 @@ pipeline {
                         }
                     }
                 }
+                stage('Build on CentOS 7 with Clang debug') {
+                    when {
+                        beforeAgent true
+                        expression { ! skipStage() }
+                    }
+                    agent {
+                        dockerfile {
+                            filename 'utils/docker/Dockerfile.centos.7'
+                            label 'docker_runner'
+                            additionalBuildArgs dockerBuildArgs(qb: quickBuild(),
+                                                                deps_build: true) +
+                                                " -t ${sanitized_JOB_NAME}-centos7 " +
+                                                ' --build-arg QUICKBUILD_DEPS="' +
+                                                quickBuildDeps('centos7') + '"' +
+                                                ' --build-arg REPOS="' + prRepos() + '"'
+                        }
+                    }
+                    steps {
+                        sconsBuild parallel_build: parallelBuild(),
+                                   scons_exe: 'scons-3',
+                                   scons_args: "PREFIX=/opt/daos TARGET_TYPE=release",
+                                   build_deps: "no"
+                    }
+                    post {
+                        always {
+                            recordIssues enabledForFailure: true,
+                                         aggregatingResults: true,
+                                         tool: clang(pattern: 'centos7-clang-debug-build.log',
+                                                     id: "analysis-centos7-debug-clang")
+                        }
+                        unsuccessful {
+                            sh """if [ -f config.log ]; then
+                                      mv config.log config.log-centos7-clang-debug
+                                  fi"""
+                            archiveArtifacts artifacts: 'config.log-centos7-clang-debug',
+                                             allowEmptyArchive: true
+                        }
+                    }
+                }
                 stage('Build on CentOS 8') {
                     when {
                         beforeAgent true
                         expression { ! skipStage() }
-                     }
+                    }
                     agent {
                         dockerfile {
                             filename 'utils/docker/Dockerfile.centos.8'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,7 +12,7 @@
 
 // To use a test branch (i.e. PR) until it lands to master
 // I.e. for testing library changes
-@Library(value="pipeline-lib@dbohninx-clang")
+//@Library(value="pipeline-lib@your_branch") _
 
 // For master, this is just some wildly high number
 next_version = "1000"

--- a/src/utils/daos_hdlr.c
+++ b/src/utils/daos_hdlr.c
@@ -2579,7 +2579,7 @@ out:
 	return rc;
 }
 
-inline void
+static inline void
 set_dm_args_default(struct dm_args *dm)
 {
 	dm->src = NULL;
@@ -2853,7 +2853,7 @@ out:
 	return rc;
 }
 
-inline void
+static inline void
 file_set_defaults_dfs(struct file_dfs *file_dfs)
 {
 	/* set defaults for file_dfs struct */


### PR DESCRIPTION
- Update instances of "inline void" to "static inline void"
- Add build stage for centos7 + clang + debug

Since the new stage is skipped for non-master runs, it is important to look at the previous runs that had temporary fixes to allow the stage to run on this PR.

- Step 1 - verify new stage fails in CI WITHOUT the code fix
    - https://build.hpdd.intel.com/blue/organizations/jenkins/daos-stack%2Fdaos/detail/PR-5542/4/pipeline/90
- Step 2 - verify new stage passes in CI WITH the code fix
    - https://build.hpdd.intel.com/blue/organizations/jenkins/daos-stack%2Fdaos/detail/PR-5542/5/pipeline/177
- Step 3 - clean run
    - https://build.hpdd.intel.com/blue/organizations/jenkins/daos-stack%2Fdaos/detail/PR-5542/6/pipeline

Signed-off-by: Dalton Bohning <daltonx.bohning@intel.com>