### PR TITLE
DAOS-6602 Test: Updated skip ticket for EC tests.

### DIFF
--- a/src/tests/ftest/erasurecode/ec_offline_rebuild.py
+++ b/src/tests/ftest/erasurecode/ec_offline_rebuild.py
@@ -16,7 +16,7 @@ class EcOfflineRebuild(ErasureCodeIor):
     :avocado: recursive
     """
 
-    @skipForTicket("DAOS-6450")
+    @skipForTicket("DAOS-7212")
     def test_ec_offline_rebuild(self):
         """Jira ID: DAOS-5894.
 

--- a/src/tests/ftest/erasurecode/ec_offline_rebuild.yaml
+++ b/src/tests/ftest/erasurecode/ec_offline_rebuild.yaml
@@ -77,9 +77,6 @@ ior:
    dfs_oclass:
     #- [EC_Object_Class, Minimum number of servers]
     - ["EC_2P1G1", 6]
-    - ["EC_2P2G1", 6]
-    - ["DAOS_OC_EC_K2P2_L32K", 6]
     - ["EC_4P1G1", 8]
     - ["EC_4P2G1", 8]
-    - ["DAOS_OC_EC_K4P2_L32K", 8]
     - ["EC_8P2G1", 12]

--- a/src/tests/ftest/erasurecode/ec_online_rebuild.py
+++ b/src/tests/ftest/erasurecode/ec_online_rebuild.py
@@ -21,7 +21,7 @@ class EcOnlineRebuild(ErasureCodeIor):
         super().__init__(*args, **kwargs)
         self.set_online_rebuild = True
 
-    @skipForTicket("DAOS-6546")
+    @skipForTicket("DAOS-7293")
     def test_ec_offline_rebuild(self):
         """Jira ID: DAOS-5894.
 

--- a/src/tests/ftest/erasurecode/ec_rebuild_disabled.yaml
+++ b/src/tests/ftest/erasurecode/ec_rebuild_disabled.yaml
@@ -76,9 +76,6 @@ ior:
    dfs_oclass:
     #- [EC_Object_Class, Minimum number of servers]
     - ["EC_2P1G1", 4]
-    - ["EC_2P2G1", 4]
-    - ["DAOS_OC_EC_K2P2_L32K", 4]
     - ["EC_4P1G1", 6]
     - ["EC_4P2G1", 6]
-    - ["DAOS_OC_EC_K4P2_L32K", 6]
     - ["EC_8P2G1", 10]


### PR DESCRIPTION
- Update the Skip tickets for EC tests.
- Removed some of the EC objects which we do not want to test anymore.

Doc-only: true

Signed-off-by: Samir Raval <samir.raval@intel.com>