### PR TITLE
DAOS-7244 sched: bump SCHED_DELAY_THRESH

### DIFF
--- a/src/engine/sched.c
+++ b/src/engine/sched.c
@@ -82,7 +82,16 @@ enum {
 
 static int	sched_policy;
 
-#define SCHED_DELAY_THRESH	20000	/* msecs */
+/*
+ * Time threshold for giving IO up throttling. If space pressure stays in the
+ * highest level for enough long time, we assume that no more space can be
+ * reclaimed and choose to give up IO throttling, so that ENOSPACE error could
+ * be returned to client earlier.
+ *
+ * To make time for aggregation reclaiming overwriteen space, this threshold
+ * should be longer than the DAOS_AGG_THRESHOLD.
+ */
+#define SCHED_DELAY_THRESH	40000	/* msecs */
 
 static unsigned int max_delay_msecs[SCHED_REQ_MAX] = {
 	20000,	/* SCHED_REQ_UPDATE */


### PR DESCRIPTION
To make time for aggregation reclaiming overwritten space, the
SCHED_DELAY_THRESH should be larger than the DAOS_AGG_THRESHOLD.

Signed-off-by: Niu Yawei <yawei.niu@intel.com>