### PR TITLE
DAOS-racer_ec tests: racer test for EC object

### DIFF
--- a/src/tests/daos_racer.c
+++ b/src/tests/daos_racer.c
@@ -46,6 +46,10 @@ enum {
 	RP_2G2,
 	RP_3G1,
 	RP_3G2,
+	EC_2P1G1,
+	EC_2P1G2,
+	EC_2P2G1,
+	EC_2P2G2,
 	OBJ_CNT
 };
 
@@ -79,6 +83,14 @@ oclass_get(unsigned int random)
 		return OC_RP_3G1;
 	case RP_3G2:
 		return OC_RP_3G2;
+	case EC_2P1G1:
+		return OC_EC_2P1G1;
+	case EC_2P1G2:
+		return OC_EC_2P1G2;
+	case EC_2P2G1:
+		return OC_EC_2P2G1;
+	case EC_2P2G2:
+		return OC_EC_2P2G2;
 	default:
 		assert(0);
 	}


### PR DESCRIPTION
Kinds of upadte, fetch, enumerate, query reqeusts for EC objects,
and contains conditional operations. But consistency verification
after racer test still skip EC objects.

Signed-off-by: Fan Yong <fan.yong@intel.com>