### PR TITLE
DAOS-7282 pool: allow rank 0 as a pool svc replacement rank

### DIFF
--- a/src/pool/srv_util.c
+++ b/src/pool/srv_util.c
@@ -261,8 +261,6 @@ ds_pool_check_failed_replicas(struct pool_map *map, d_rank_list_t *replicas,
 	 * in the pool map and not present in the list of replicas.
 	 **/
 	for (i = 0, nreplaced = 0; i < nnodes && nreplaced < nfailed; i++) {
-		if (nodes[i].do_comp.co_rank == 0 /* Skip rank 0 */)
-			continue;
 		if (!map_ranks_include(MAP_RANKS_UP,
 				       nodes[i].do_comp.co_status))
 			continue;


### PR DESCRIPTION
With this change, during pool updates the function
ds_pool_check_failed_replicas() will consider daos_engine rank 0
a candidate to replace a failed replica in the pool service.
Previous implementation constraints to avoid rank 0 (at the time,
the only management service instance) have been alleviated
(due to the service now running in the control plane).

This change helps some small pool configurations in which replica
replacement may have only one viable option (rank 0). Using all
available ranks in this situation can prevent - or at least delay
the pool service reaching a state in which it cannot achieve a
Raft quorum.

Test-tag-vm: pr,-hw nocap rebuildwithio pool_svc rebuildwithior test_simple_rebuild test_multipool_rebuild destroypoolrebuild multitarget

Signed-off-by: Kenneth Cain <kenneth.c.cain@intel.com>