### PR TITLE
DAOS-7238 test: another check of pool create svc_reps length

### DIFF
--- a/src/common/tests_dmg_helpers.c
+++ b/src/common/tests_dmg_helpers.c
@@ -467,6 +467,11 @@ dmg_pool_create(const char *dmg_config_file,
 	if (svc == NULL)
 		goto out_svc;
 
+	if (pool_info.mgpi_svc->rl_nr == 0) {
+		D_ERROR("unexpected zero-length pool svc ranks list\n");
+		rc = -DER_INVAL;
+		goto out_svc;
+	}
 	rc = d_rank_list_copy(svc, pool_info.mgpi_svc);
 	if (rc != 0) {
 		D_ERROR("failed to dup svc rank list\n");


### PR DESCRIPTION
Cherry-pick solution from a master-based branch.

As part of dmg_pool_create() flow, following successful execution
of the dmg pool create command, it is expected that the svc_reps
returned by dmg shall be of length > 0. Coverity CID 313058 reports
that a length of 0 would result in freeing of outpool->svc and a later
use after free. A fix was attempted in commit 353e115, adding a check
in parse_pool_info(). With this change, another check is made within
dmg_pool_create() closer to the d_rank_list_copy() call that would
free outpool->svc in this (believed to be theoretical) condition.

Signed-off-by: Kenneth Cain <kenneth.c.cain@intel.com>