### PR TITLE
DAOS-7254 EC: force refetch cross boundry inline data.

### DIFF
--- a/src/tests/ftest/daos_test/daos_core_test.yaml
+++ b/src/tests/ftest/daos_test/daos_core_test.yaml
@@ -28,7 +28,7 @@ timeouts:
     test_daos_drain_simple: 500
     test_daos_oid_allocator: 320
     test_daos_checksum: 240
-    test_daos_rebuild_ec: 900
+    test_daos_rebuild_ec: 1500
     test_daos_degraded_ec_0to6: 900
     test_daos_degraded_ec_8to23: 950
     test_daos_dedup: 220


### PR DESCRIPTION
1. During EC rebuild, if inline migrate data(<32 bytes)
needs to re-aligned with cell size, then let's invalidate
the inline data and fetch the data again, to avoid align
the inline data.

2. Add more EC rebuild tests to verify the cross cell
size rebuild.

Signed-off-by: Di Wang <di.wang@intel.com>