### PR TITLE
DAOS-7165 VOS: free VOS pools attached on GC (#5472)

### DIFF
--- a/src/include/daos_srv/vos.h
+++ b/src/include/daos_srv/vos.h
@@ -1052,8 +1052,8 @@ int
 vos_pool_ctl(daos_handle_t poh, enum vos_pool_opc opc);
 
 int
-vos_gc_pool_run(daos_handle_t poh, int credits,
-		bool (*yield_func)(void *arg), void *yield_arg);
+vos_gc_pool(daos_handle_t poh, int credits, bool (*yield_func)(void *arg),
+	    void *yield_arg);
 bool
 vos_gc_pool_idle(daos_handle_t poh);
 

--- a/src/pool/srv_target.c
+++ b/src/pool/srv_target.c
@@ -87,8 +87,8 @@ gc_ult(void *arg)
 
 	D_ASSERT(child->spc_gc_req != NULL);
 	while (!dss_ult_exiting(child->spc_gc_req)) {
-		rc = vos_gc_pool_run(child->spc_hdl, -1, dss_ult_yield,
-				     (void *)child->spc_gc_req);
+		rc = vos_gc_pool(child->spc_hdl, -1, dss_ult_yield,
+				 (void *)child->spc_gc_req);
 		if (rc < 0)
 			D_ERROR(DF_UUID"[%d]: GC pool run failed. "DF_RC"\n",
 				DP_UUID(child->spc_uuid), dmi->dmi_tgt_id,

--- a/src/rdb/rdb_raft.c
+++ b/src/rdb/rdb_raft.c
@@ -1490,7 +1490,7 @@ rdb_compactd(void *arg)
 				": %d\n", DP_DB(db), base, rc);
 			break;
 		}
-		vos_gc_pool_run(db->d_pool, -1, rdb_gc_yield, NULL);
+		vos_gc_pool(db->d_pool, -1, rdb_gc_yield, NULL);
 	}
 	D_DEBUG(DB_MD, DF_DB": compactd stopping\n", DP_DB(db));
 }

--- a/src/vos/sys_db.c
+++ b/src/vos/sys_db.c
@@ -252,7 +252,7 @@ db_delete(struct sys_db *db, char *table, d_iov_t *key)
 	if (rc == 0) {
 		int creds = 100;
 		/* vos_obj_del_key() wouldn't free space */
-		vos_gc_pool(vdb->db_poh, &creds);
+		vos_gc_pool_tight(vdb->db_poh, &creds);
 	}
 	return rc;
 }

--- a/src/vos/tests/vts_gc.c
+++ b/src/vos/tests/vts_gc.c
@@ -198,7 +198,7 @@ gc_wait_check(struct gc_test_args *args, bool cont_delete)
 	while (1) {
 		int	creds = 64;
 
-		rc = vos_gc_pool(args->gc_ctx.tsc_poh, &creds);
+		rc = vos_gc_pool_tight(args->gc_ctx.tsc_poh, &creds);
 		if (rc) {
 			print_error("gc pool failed: %s\n", d_errstr(rc));
 			return rc;

--- a/src/vos/vos_internal.h
+++ b/src/vos/vos_internal.h
@@ -1093,7 +1093,7 @@ int
 gc_add_item(struct vos_pool *pool, daos_handle_t coh,
 	    enum vos_gc_type type, umem_off_t item_off, uint64_t args);
 int
-vos_gc_pool(daos_handle_t poh, int *credits);
+vos_gc_pool_tight(daos_handle_t poh, int *credits);
 void
 gc_reserve_space(daos_size_t *rsrvd);
 

--- a/src/vos/vos_tls.h
+++ b/src/vos/vos_tls.h
@@ -30,6 +30,8 @@ struct dtx_handle;
 struct vos_tls {
 	/** pools registered for GC */
 	d_list_t			 vtl_gc_pools;
+	/** tracking GC running status */
+	int				 vtl_gc_running;
 	/* PMDK transaction stage callback data */
 	struct umem_tx_stage_data	 vtl_txd;
 	/** XXX: The DTX handle.


### PR DESCRIPTION
A pool is attached on GC when user deleted things from the pool,
it will be removed from GC only if the pool is destroyed or has
nothing to be freed. If DAOS is shutting down before GC frees
everything for a alive pool, it will trigger a false assertion
because this pool is still attached on GC.

- This patch removes the false assertion, it can free all pools
  still attached on GC while finilizing VOS.
- It also includes a small cleanup for VOS API.

Signed-off-by: Liang Zhen <liang.zhen@intel.com>
Co-authored-by: Mohamad Chaarawi <mohamad.chaarawi@intel.com>