### PR TITLE
DAOS-7298 doc: refresh DTX leader related document

### DIFF
--- a/src/vos/README.md
+++ b/src/vos/README.md
@@ -759,45 +759,58 @@ overhead and complexity.  DAOS instead uses an optimized two-phase commit
 transaction to guarantee consistency among replicas.
 
 <a id="811"></a>
-### DAOS Two-Phase Commit (DTX)
+### Single redundancy group based DAOS Two-Phase Commit (DTX)
 
-When an application wants to modify (update or punch) an object with multiple
-replicas, the client sends the modification RPC to the leader replica (Via
-<a href="#812">DTX Leader Election</a> algorithm discussed below).  The leader
-dispatches the RPC to the other replicas, and each replica makes its
-modification in parallel.  Bulk transfers are not forwarded by the leader but
-rather transferred directly from the client, improving load balance and
+When an application wants to modify (update or punch) a multiple replicated
+object or EC object, the client sends the modification RPC to the leader shard
+(via <a href="#812">DTX Leader Election</a> algorithm discussed below). The
+leader dispatches the RPC to the other related shards, and each shard makes
+its modification in parallel.  Bulk transfers are not forwarded by the leader
+but rather transferred directly from the client, improving load balance and
 decreasing latency by utilizing the full client-server bandwidth.
 
-Before modifications are made, a local transaction, called 'DTX', is started on
-each replica with a client selected DTX identifier that is unique for the
-current RPC within the container.  All modifications in a DTX are logged in a
-DTX transaction table and back references to the table are kept in each modified
-record.  After local modifications are done, each non-leader replica marks the
-DTX state as 'prepared' and replies to the leader replica.  The leader sets the
-DTX state to 'committable' as soon as it has completed its modifications and
-has received successful replies from all replicas.  If any replica(s) failed to
-execute the modification, it will reply to the leader with failure, and the
-leader will ask remaining replicas to 'abort' the DTX.   Once the DTX is set
-by the leader to 'committable' or 'abort', it replies to the client with the
-appropriate status.
+Before modifications are made, a local transaction, called 'DTX', is started
+on each related shard (both leader and non-leaders) with a client generated
+DTX identifier that is unique for the modification within the container. All
+the modifications in a DTX are logged in the DTX transaction table and back
+references to the table are kept in related modified record.  After local
+modifications are done, each non-leader marks the DTX state as 'prepared' and
+replies to the leader. The leader sets the DTX state to 'committable' as soon
+as it has completed its modifications and has received successful replies from
+all non-leaders.  If any shard(s) fail to execute the modification, it will
+reply to the leader with failure, and the leader will globally abort the DTX.
+Once the DTX is set by the leader to 'committable' or 'aborted', it replies to
+the client with the appropriate status.
 
 The client may consider a modification complete as soon as it receives a
 successful reply from the leader, regardless of whether the DTX is actually
-'committed' or not.   It is the responsibility of the leader replica to commit
-the 'committable' DTX asynchronously, when the 'committable' DTX count exceeds
-some threshold or piggybacked via dispatched RPCs due to potential conflict with
-subsequent modifications.
+'committed' or not. It is the responsibility of the leader to commit the
+'committable' DTX asynchronously. This can happen if the 'committable' count
+or DTX age exceed some thresholds or the DTX is piggybacked via other
+dispatched RPCs due to potential conflict with subsequent modifications.
 
 When an application wants to read something from an object with multiple
-replicas, the client can send the RPC to any replica.  On the server side, if
-the related DTX has been committed or is committable, the record can be returned to.
-If the DTX state is prepared, and the replica is not the leader, it will reply
-to the client telling it to send the RPC to the leader instead.  If it is the
-leader and is in any state other than 'committed' or 'committable', the entry
-is ignored, and the latest committed modification is returned to the client.
+replicas, the client can send the RPC to any replica.  On the server side,
+if the related DTX has been committed or is committable, the record can be
+returned to. If the DTX state is prepared, and the replica is not the leader,
+it will reply to the client telling it to send the RPC to the leader instead.
+If it is the leader and is in the state 'committed' or 'committable', then
+such entry is visible to the application. Otherwise, if the DTX on the leader
+is also 'prepared', then for transactional read, ask the client to wait and
+retry via returning -DER_INPROGRESS; for non-transactional read, related entry
+is ignored and the latest committed modification is returned to the client.
 
-The DTX model is built inside a DAOS container.  Each container maintains its own
+If the read operation refers to an EC object and the data read from a data
+shard (non-leader) has a 'prepared' DTX, the data may be 'committable' on the
+leader due to the aforementioned asynchronous batched commit mechanism.
+In such case, the non-leader will refresh related DTX status with the leader.
+If the DTX status after refresh is 'committed', then related data can be
+returned to the client; otherwise, if the DTX state is still 'prepared', then
+for transactional read, ask the client to wait and retry via returning
+-DER_INPROGRESS; for non-transactional read, related entry is ignored and the
+latest committed modification is returned to the client.
+
+The DTX model is built inside a DAOS container. Each container maintains its own
 DTX table that is organized as two B+trees in SCM: one for active DTXs and the
 other for committed DTXs.
 The following diagram represents the modification of a replicated object under
@@ -809,20 +822,10 @@ the DTX model.
 
 <a id="812"></a>
 
-### DTX Leader Election
+### Single redundancy group based DTX Leader Election
 
-In the DTX model, the leader is a special replica that does more work than other
-replicas, including:
-
-1. All modification RPCs are sent to the leader.  The leader performs necessary
-sanity checks before dispatching modifications to other replicas.
-
-2. Non-leader replicas tell the client to redirect reads in 'prepared' DTX state to
-the leader replica.  The leader, therefore, may handle a heavier load on reads
-than non-leaders.
-
-To avoid general load imbalance, the leader selection is done for each object or
-dkey following these general guidelines:
+In single redundancy group based DTX model, the leader selection is done for
+each object or dkey following these general guidelines:
 
 R1: When different replicated objects share the same redundancy group, the same
 leader should not be used for each object.
@@ -833,3 +836,6 @@ servers.
 
 R3: Servers that fail frequently should be avoided in leader selection to avoid
 frequent leader migration.
+
+R4: For EC object, the leader will be one of the parity nodes within current
+redundancy group.


### PR DESCRIPTION
Some documents and comments about single redundancy group based
DTX leader become stale after introducing distributed transaction
that may cross multiple redundancy groups. This patch refresh them
to avoid confusing.

Skip-test: true
Doc-only: true

Signed-off-by: Fan Yong <fan.yong@intel.com>