### PR TITLE
DAOS-6798 pool: fix deadlock on pool destroy (#5494)

### DIFF
--- a/src/common/lru.c
+++ b/src/common/lru.c
@@ -251,7 +251,10 @@ daos_lru_ref_hold(struct daos_lru_cache *lcache, void *key,
 
 	rc = d_hash_rec_insert(&lcache->dlc_htable, key, key_size,
 			       &llink->ll_link, true);
-	D_ASSERT(rc == 0);
+	if (rc) {
+		lcache->dlc_ops->lop_free_ref(llink);
+		return rc;
+	}
 	lcache->dlc_count++;
 found:
 	*llink_pp = llink;

--- a/src/container/srv_cli.c
+++ b/src/container/srv_cli.c
@@ -59,14 +59,10 @@ static int
 dsc_cont_csummer_init(struct daos_csummer **csummer,
 		      uuid_t pool_uuid, uuid_t cont_uuid)
 {
-	struct ds_pool	*pool;
 	int		 rc;
 	struct cont_props cont_props;
 
-	pool = ds_pool_lookup(pool_uuid);
-	if (pool == NULL)
-		return -DER_NONEXIST;
-	rc = ds_get_cont_props(&cont_props, pool->sp_iv_ns, cont_uuid);
+	rc = ds_get_cont_props(&cont_props, pool_uuid, cont_uuid);
 
 	if (rc == 0 &&
 	    daos_cont_csum_prop_is_enabled(cont_props.dcp_csum_type))
@@ -74,8 +70,6 @@ dsc_cont_csummer_init(struct daos_csummer **csummer,
 			 daos_contprop2hashtype(cont_props.dcp_csum_type),
 			 cont_props.dcp_chunksize,
 			 cont_props.dcp_srv_verify);
-
-	ds_pool_put(pool);
 
 	return rc;
 }

--- a/src/container/srv_container.c
+++ b/src/container/srv_container.c
@@ -2291,7 +2291,7 @@ cont_query(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl, struct cont *cont,
 		if (iv_prop == NULL)
 			return -DER_NOMEM;
 
-		rc = cont_iv_prop_fetch(pool_hdl->sph_pool->sp_iv_ns,
+		rc = cont_iv_prop_fetch(pool_hdl->sph_pool->sp_uuid,
 					in->cqi_op.ci_uuid, iv_prop);
 		if (rc) {
 			D_ERROR("cont_iv_prop_fetch failed "DF_RC"\n",

--- a/src/container/srv_internal.h
+++ b/src/container/srv_internal.h
@@ -261,7 +261,7 @@ int cont_iv_capability_update(void *ns, uuid_t cont_hdl_uuid, uuid_t cont_uuid,
 			      uint64_t flags, uint64_t sec_capas);
 int cont_iv_capability_invalidate(void *ns, uuid_t cont_hdl_uuid,
 				  int sync_mode);
-int cont_iv_prop_fetch(struct ds_iv_ns *ns, uuid_t cont_uuid,
+int cont_iv_prop_fetch(uuid_t pool_uuid, uuid_t cont_uuid,
 		       daos_prop_t *cont_prop);
 int cont_iv_prop_update(void *ns, uuid_t cont_uuid, daos_prop_t *prop);
 int cont_iv_snapshots_refresh(void *ns, uuid_t cont_uuid);

--- a/src/container/srv_target.c
+++ b/src/container/srv_target.c
@@ -90,7 +90,7 @@ cont_aggregate_epr(struct ds_cont_child *cont, daos_epoch_range_t *epr,
 }
 
 int
-ds_get_cont_props(struct cont_props *cont_props, struct ds_iv_ns *pool_ns,
+ds_get_cont_props(struct cont_props *cont_props, uuid_t pool_uuid,
 		  uuid_t cont_uuid)
 {
 	daos_prop_t	*props;
@@ -113,7 +113,7 @@ ds_get_cont_props(struct cont_props *cont_props, struct ds_iv_ns *pool_ns,
 	props->dpp_entries[7].dpe_type = DAOS_PROP_CO_REDUN_FAC;
 	props->dpp_entries[8].dpe_type = DAOS_PROP_CO_ALLOCED_OID;
 
-	rc = cont_iv_prop_fetch(pool_ns, cont_uuid, props);
+	rc = cont_iv_prop_fetch(pool_uuid, cont_uuid, props);
 
 	if (rc == DER_SUCCESS)
 		daos_props_2cont_props(props, cont_props);
@@ -141,8 +141,7 @@ ds_cont_csummer_init(struct ds_cont_child *cont)
 	 * Need the pool for the IV namespace
 	 */
 	D_ASSERT(cont->sc_csummer == NULL);
-	rc = ds_get_cont_props(cont_props, cont->sc_pool->spc_pool->sp_iv_ns,
-			       cont->sc_uuid);
+	rc = ds_get_cont_props(cont_props, cont->sc_pool_uuid, cont->sc_uuid);
 	if (rc != 0)
 		goto done;
 

--- a/src/container/srv_target.c
+++ b/src/container/srv_target.c
@@ -141,7 +141,8 @@ ds_cont_csummer_init(struct ds_cont_child *cont)
 	 * Need the pool for the IV namespace
 	 */
 	D_ASSERT(cont->sc_csummer == NULL);
-	rc = ds_get_cont_props(cont_props, cont->sc_pool_uuid, cont->sc_uuid);
+	rc = ds_get_cont_props(cont_props, cont->sc_pool->spc_uuid,
+			       cont->sc_uuid);
 	if (rc != 0)
 		goto done;
 

--- a/src/gurt/hash.c
+++ b/src/gurt/hash.c
@@ -475,8 +475,10 @@ d_hash_rec_insert(struct d_hash_table *htable, const void *key,
 
 	if (exclusive) {
 		tmp = ch_rec_find(htable, bucket, key, ksize, D_HASH_LRU_NONE);
-		if (tmp)
+		if (tmp) {
+			D_DEBUG(DB_TRACE, "Dup key detected\n");
 			D_GOTO(out_unlock, rc = -DER_EXIST);
+		}
 	}
 	ch_rec_insert_addref(htable, bucket, link);
 

--- a/src/include/daos_srv/container.h
+++ b/src/include/daos_srv/container.h
@@ -153,7 +153,7 @@ int ds_cont_child_lookup(uuid_t pool_uuid, uuid_t cont_uuid,
  * checksum related properties from IV
  */
 int ds_cont_csummer_init(struct ds_cont_child *cont);
-int ds_get_cont_props(struct cont_props *cont_props, struct ds_iv_ns *pool_ns,
+int ds_get_cont_props(struct cont_props *cont_props, uuid_t pool_uuid,
 		      uuid_t cont_uuid);
 
 void ds_cont_child_put(struct ds_cont_child *cont);
@@ -169,9 +169,8 @@ int ds_cont_iter(daos_handle_t ph, uuid_t co_uuid, cont_iter_cb_t callback,
 /**
  * Query container properties.
  *
- * \param[in]	ns	pool IV namespace
- * \param[in]	co_uuid
- *			container uuid
+ * \param[in]	po_uuid	pool uuid
+ * \param[in]	co_uuid	container uuid
  * \param[out]	cont_prop
  *			returned container properties
  *			If it is NULL, return -DER_INVAL;
@@ -189,7 +188,7 @@ int ds_cont_iter(daos_handle_t ph, uuid_t co_uuid, cont_iter_cb_t callback,
  *
  * \return		0 if Success, negative if failed.
  */
-int ds_cont_fetch_prop(struct ds_iv_ns *ns, uuid_t co_uuid,
+int ds_cont_fetch_prop(uuid_t po_uuid, uuid_t co_uuid,
 		       daos_prop_t *cont_prop);
 
 /** get all snapshots of the container from IV */

--- a/src/include/daos_srv/daos_engine.h
+++ b/src/include/daos_srv/daos_engine.h
@@ -831,7 +831,6 @@ ds_notify_bio_error(int media_err_type, int tgt_id);
 int
 ds_get_pool_svc_ranks(uuid_t pool_uuid, d_rank_list_t **svc_ranks);
 
-bool is_container_from_srv(uuid_t pool_uuid, uuid_t coh_uuid);
 bool is_pool_from_srv(uuid_t pool_uuid, uuid_t poh_uuid);
 
 struct sys_db;

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -450,15 +450,9 @@ obj_bulk_transfer(crt_rpc_t *rpc, crt_bulk_op_t bulk_op, bool bulk_bind,
 	ABT_eventual_free(&p_arg->eventual);
 	/* After RDMA is done, corrupt the server data */
 	if (DAOS_FAIL_CHECK(DAOS_CSUM_CORRUPT_DISK)) {
-		struct obj_rw_in	*orw = crt_req_get(rpc);
-		struct ds_pool		*pool;
 		struct bio_sglist	*fbsgl;
 		d_sg_list_t		 fsgl;
 		int			*fbuffer;
-
-		pool = ds_pool_lookup(orw->orw_pool_uuid);
-		if (pool == NULL)
-			return -DER_NONEXIST;
 
 		D_DEBUG(DB_IO, "Data corruption after RDMA\n");
 		fbsgl = vos_iod_sgl_at(ioh, 0);
@@ -466,7 +460,6 @@ obj_bulk_transfer(crt_rpc_t *rpc, crt_bulk_op_t bulk_op, bool bulk_bind,
 		fbuffer = (int *)fsgl.sg_iovs[0].iov_buf;
 		*fbuffer += 0x2;
 		d_sgl_fini(&fsgl, false);
-		ds_pool_put(pool);
 	}
 	return rc;
 }

--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -5634,39 +5634,6 @@ out_svc:
 }
 
 bool
-is_container_from_srv(uuid_t pool_uuid, uuid_t coh_uuid)
-{
-	struct ds_pool	*pool;
-	uuid_t		hdl_uuid;
-	int		rc;
-	bool		result = false;
-
-	pool = ds_pool_lookup(pool_uuid);
-	if (pool == NULL) {
-		D_ERROR(DF_UUID": failed to get ds_pool\n",
-			DP_UUID(pool_uuid));
-		return false;
-	}
-
-	if (uuid_compare(coh_uuid, pool->sp_srv_cont_hdl) == 0) {
-		/* Compare if the handle uuid is from another server */
-		result = true;
-		D_GOTO(output, result);
-	}
-
-	rc = ds_pool_iv_srv_hdl_fetch_non_sys(pool, &hdl_uuid, NULL);
-	if (rc) {
-		D_ERROR(DF_UUID" fetch srv hdl: %d\n", DP_UUID(pool_uuid), rc);
-		D_GOTO(output, result);
-	}
-
-	result = !uuid_compare(coh_uuid, hdl_uuid);
-output:
-	ds_pool_put(pool);
-	return result;
-}
-
-bool
 is_pool_from_srv(uuid_t pool_uuid, uuid_t poh_uuid)
 {
 	struct ds_pool	*pool;

--- a/src/pool/srv_target.c
+++ b/src/pool/srv_target.c
@@ -257,13 +257,18 @@ pool_child_delete_one(void *uuid)
 	ds_pool_child_put(child); /* -1 for the list */
 
 	ds_pool_child_put(child); /* -1 for lookup */
+
+	/*
+	 * FIXME: Need to wait for last reference of ds_pool_child dropped,
+	 * since the ds_pool_child references ds_pool by 'spc_pool' without
+	 * holding ds_pool refcount.
+	 */
 	return 0;
 }
 
 /* ds_pool ********************************************************************/
 
 static struct daos_lru_cache   *pool_cache;
-static ABT_mutex		pool_cache_lock;
 
 static inline struct ds_pool *
 pool_obj(struct daos_llink *llink)
@@ -433,59 +438,54 @@ ds_pool_cache_init(void)
 {
 	int rc;
 
-	rc = ABT_mutex_create(&pool_cache_lock);
-	if (rc != ABT_SUCCESS)
-		return dss_abterr2der(rc);
 	rc = daos_lru_cache_create(-1 /* bits */, D_HASH_FT_NOLOCK /* feats */,
 				   &pool_cache_ops, &pool_cache);
-	if (rc != 0)
-		ABT_mutex_free(&pool_cache_lock);
 	return rc;
 }
 
 void
 ds_pool_cache_fini(void)
 {
-	ABT_mutex_lock(pool_cache_lock);
 	daos_lru_cache_destroy(pool_cache);
-	ABT_mutex_unlock(pool_cache_lock);
-	ABT_mutex_free(&pool_cache_lock);
 }
 
 struct ds_pool *
 ds_pool_lookup(const uuid_t uuid)
 {
-	struct daos_llink      *llink;
-	int			rc;
+	struct daos_llink	*llink;
+	struct ds_pool		*pool;
+	int			 rc;
 
-	ABT_mutex_lock(pool_cache_lock);
+	D_ASSERT(dss_get_module_info()->dmi_xs_id == 0);
 	rc = daos_lru_ref_hold(pool_cache, (void *)uuid, sizeof(uuid_t),
 			       NULL /* create_args */, &llink);
-	ABT_mutex_unlock(pool_cache_lock);
 	if (rc != 0)
 		return NULL;
-	return pool_obj(llink);
+
+	pool = pool_obj(llink);
+	if (pool->sp_stopping) {
+		D_ERROR(DF_UUID": is in stopping\n", DP_UUID(uuid));
+		ds_pool_put(pool);
+		return NULL;
+	}
+
+	return pool;
 }
 
 void
 ds_pool_get(struct ds_pool *pool)
 {
-	struct daos_llink	*llink;
-	int			rc;
-
-	ABT_mutex_lock(pool_cache_lock);
-	rc = daos_lru_ref_hold(pool_cache, (void *)pool->sp_uuid,
-			       sizeof(uuid_t), NULL, &llink);
-	ABT_mutex_unlock(pool_cache_lock);
-	D_ASSERT(rc == 0);
+	D_ASSERT(pool != NULL);
+	D_ASSERT(dss_get_module_info()->dmi_xs_id == 0);
+	daos_lru_ref_add(&pool->sp_entry);
 }
 
 void
 ds_pool_put(struct ds_pool *pool)
 {
-	ABT_mutex_lock(pool_cache_lock);
+	D_ASSERT(pool != NULL);
+	D_ASSERT(dss_get_module_info()->dmi_xs_id == 0);
 	daos_lru_ref_release(pool_cache, &pool->sp_entry);
-	ABT_mutex_unlock(pool_cache_lock);
 }
 
 void
@@ -570,75 +570,7 @@ ds_pool_tgt_ec_eph_query_abort(struct ds_pool *pool)
 	pool->sp_ec_ephs_req = NULL;
 }
 
-/*
- * Start a pool. Must be called on the system xstream. Hold the ds_pool object
- * till ds_pool_stop. Only for mgmt and pool modules.
- */
-int
-ds_pool_start(uuid_t uuid)
-{
-	struct ds_pool			*pool;
-	struct daos_llink		*llink;
-	struct ds_pool_create_arg	arg = {};
-	int				rc;
-
-	ABT_mutex_lock(pool_cache_lock);
-
-	/*
-	 * Look up the pool without create_args (see pool_alloc_ref) to see if
-	 * the pool is started already.
-	 */
-	rc = daos_lru_ref_hold(pool_cache, (void *)uuid, sizeof(uuid_t),
-			       NULL /* create_args */, &llink);
-	if (rc == 0) {
-		pool = pool_obj(llink);
-		if (pool->sp_stopping)
-			/* Restart it and hold the reference. */
-			pool->sp_stopping = 0;
-		else
-			/* Already started; drop our reference. */
-			daos_lru_ref_release(pool_cache, &pool->sp_entry);
-		goto out_lock;
-	} else if (rc != -DER_NONEXIST) {
-		D_ERROR(DF_UUID": failed to look up pool: %d\n", DP_UUID(uuid),
-			rc);
-		goto out_lock;
-	}
-
-	/* Start it by creating the ds_pool object and hold the reference. */
-	rc = daos_lru_ref_hold(pool_cache, (void *)uuid, sizeof(uuid_t), &arg,
-			       &llink);
-	if (rc != 0) {
-		D_ERROR(DF_UUID": failed to start pool: %d\n", DP_UUID(uuid),
-			rc);
-		D_GOTO(out_lock, rc);
-	}
-
-	pool = pool_obj(llink);
-	rc = dss_ult_create(pool_fetch_hdls_ult, pool, DSS_XS_SYS,
-			    0, 0, NULL);
-	if (rc != 0) {
-		D_ERROR(DF_UUID": failed to create fetch ult: %d\n",
-			DP_UUID(uuid), rc);
-		ds_pool_put(pool);
-		D_GOTO(out_lock, rc);
-	}
-
-	pool->sp_fetch_hdls = 1;
-	rc = ds_pool_start_ec_eph_query_ult(pool);
-	if (rc != 0) {
-		D_ERROR(DF_UUID": failed to start ec eph query ult: %d\n",
-			DP_UUID(uuid), rc);
-		ds_pool_put(pool);
-		D_GOTO(out_lock, rc);
-	}
-	ds_iv_ns_start(pool->sp_iv_ns);
-out_lock:
-	ABT_mutex_unlock(pool_cache_lock);
-	return rc;
-}
-
-void
+static void
 pool_fetch_hdls_ult_abort(struct ds_pool *pool)
 {
 	if (!pool->sp_fetch_hdls)
@@ -651,6 +583,74 @@ pool_fetch_hdls_ult_abort(struct ds_pool *pool)
 	ABT_mutex_lock(pool->sp_mutex);
 	ABT_cond_wait(pool->sp_fetch_hdls_done_cond, pool->sp_mutex);
 	ABT_mutex_unlock(pool->sp_mutex);
+}
+
+/*
+ * Start a pool. Must be called on the system xstream. Hold the ds_pool object
+ * till ds_pool_stop. Only for mgmt and pool modules.
+ */
+int
+ds_pool_start(uuid_t uuid)
+{
+	struct ds_pool			*pool;
+	struct daos_llink		*llink;
+	struct ds_pool_create_arg	arg = {};
+	int				rc;
+
+	D_ASSERT(dss_get_module_info()->dmi_xs_id == 0);
+	/*
+	 * Look up the pool without create_args (see pool_alloc_ref) to see if
+	 * the pool is started already.
+	 */
+	rc = daos_lru_ref_hold(pool_cache, (void *)uuid, sizeof(uuid_t),
+			       NULL /* create_args */, &llink);
+	if (rc == 0) {
+		pool = pool_obj(llink);
+		if (pool->sp_stopping) {
+			D_ERROR(DF_UUID": stopping isn't done yet\n",
+				DP_UUID(uuid));
+			rc = -DER_BUSY;
+		}
+		/* Already started; drop our reference. */
+		daos_lru_ref_release(pool_cache, &pool->sp_entry);
+		return rc;
+	} else if (rc != -DER_NONEXIST) {
+		D_ERROR(DF_UUID": failed to look up pool: %d\n", DP_UUID(uuid),
+			rc);
+		return rc;
+	}
+
+	/* Start it by creating the ds_pool object and hold the reference. */
+	rc = daos_lru_ref_hold(pool_cache, (void *)uuid, sizeof(uuid_t), &arg,
+			       &llink);
+	if (rc != 0) {
+		D_ERROR(DF_UUID": failed to start pool: %d\n", DP_UUID(uuid),
+			rc);
+		return rc;
+	}
+
+	pool = pool_obj(llink);
+	rc = dss_ult_create(pool_fetch_hdls_ult, pool, DSS_XS_SYS,
+			    0, 0, NULL);
+	if (rc != 0) {
+		D_ERROR(DF_UUID": failed to create fetch ult: %d\n",
+			DP_UUID(uuid), rc);
+		ds_pool_put(pool);
+		return rc;
+	}
+
+	pool->sp_fetch_hdls = 1;
+	rc = ds_pool_start_ec_eph_query_ult(pool);
+	if (rc != 0) {
+		D_ERROR(DF_UUID": failed to start ec eph query ult: %d\n",
+			DP_UUID(uuid), rc);
+		pool_fetch_hdls_ult_abort(pool);
+		ds_pool_put(pool);
+		return rc;
+	}
+
+	ds_iv_ns_start(pool->sp_iv_ns);
+	return rc;
 }
 
 /*
@@ -742,7 +742,17 @@ pool_hdl_rec_free(struct d_hash_table *htable, d_list_t *rlink)
 	D_ASSERT(d_hash_rec_unlinked(&hdl->sph_entry));
 	D_ASSERTF(hdl->sph_ref == 0, "%d\n", hdl->sph_ref);
 	daos_iov_free(&hdl->sph_cred);
-	ds_pool_put(hdl->sph_pool);
+
+	/*
+	 * FIXME: We currently don't guarantee all caches are cleared before
+	 * TLS fini on server shutdown, so we have to avoid calling into
+	 * ds_pool_put() (where asserting on xtream ID) if it's from cache
+	 * destroy on pool module fini.
+	 */
+	if (dss_tls_get() == NULL)
+		daos_lru_ref_release(pool_cache, &hdl->sph_pool->sp_entry);
+	else
+		ds_pool_put(hdl->sph_pool);
 	D_FREE(hdl);
 }
 
@@ -1003,10 +1013,10 @@ ds_pool_tgt_connect(struct ds_pool *pool, struct pool_iv_conn *pic)
 	if (hdl == NULL)
 		D_GOTO(out, rc = -DER_NOMEM);
 
-	ds_pool_get(pool);
 	uuid_copy(hdl->sph_uuid, pic->pic_hdl);
 	hdl->sph_flags = pic->pic_flags;
 	hdl->sph_sec_capas = pic->pic_capas;
+	ds_pool_get(pool);
 	hdl->sph_pool = pool;
 
 	cred_iov.iov_len = pic->pic_cred_size;


### PR DESCRIPTION
DAOS-6798 pool: fix deadlock on pool destroy (#5494)

There is a deadlock on pool destroy:

1. ds_pool_stop() is called xstream 0 to put the last reference of
   ds_pool;
2. On last reference of ds_pool put, it holds 'pool_cache_lock' and
   does a collective call to clear ds_pool_child on each VOS xstream;
   (see ds_pool_put() -> pool_free_ref())
3. VOS xstreams needs to wait for aggregation ULTs exited before
   clearing the ds_pool_child; (see pool_child_delete_one() ->
   ds_cont_child_stop_all() -> cont_child_stop())
4. Aggregation ULT may running in EC aggregation code to fetch cont
   IV, and that requires calling ds_pool_lookup(), ds_pool_lookup()
   needs to acquire 'pool_cache_lock';

This patch removed 'pool_cache_lock' and ensured ds_pool cache being
accessed by xstream 0 only. If VOS xstreams need to access ds_pool,
it either uses the 'ds_pool_child->spc_pool' directly or schedules a
ULT on xstream 0.

Signed-off-by: Niu Yawei <yawei.niu@intel.com>