### PR TITLE
DAOS-7304 Test: Mdtest small pool destroy failed with DER_TIMEOUT

### DIFF
--- a/src/tests/ftest/mdtest/mdtest_small.py
+++ b/src/tests/ftest/mdtest/mdtest_small.py
@@ -58,3 +58,17 @@ class MdtestSmall(MdtestBase):
             self.execute_mdtest()
             # re-set mdtest params before next iteration
             self.mdtest_cmd.get_params(self)
+
+    def tearDown(self):
+        """ To avoid the issue from DAOS-7304, timeout when destroying a pool,
+        the plan is to delete each container within pool, this should simplify
+        the pool delete process.
+        """
+        daos_cmd = self.get_daos_command()
+        pool_uuid = self.pool.uuid
+        containers = daos_cmd.pool_list_cont(pool_uuid)
+
+        for cont in containers["uuids"]:
+            daos_cmd.container_destroy(pool_uuid, cont, force=True)
+
+        super().tearDown()

--- a/src/tests/ftest/mdtest/mdtest_small.yaml
+++ b/src/tests/ftest/mdtest/mdtest_small.yaml
@@ -7,7 +7,7 @@ hosts:
   test_clients:
     - client-E
     - client-F
-timeout: 605
+timeout: 720
 server_config:
   name: daos_server
   transport_config:


### PR DESCRIPTION
    Delete pool containers before deleting the pool.

Test-tag-hw-large: pr,hw,large mdtestsmall

Signed-off-by: Omar Ocampo <omar.ocampo.coronado@intel.com>