### PR TITLE
DAOS-7303 control: improve port number validation in server config

### DIFF
--- a/src/control/cmd/dmg/auto_test.go
+++ b/src/control/cmd/dmg/auto_test.go
@@ -18,8 +18,16 @@ import (
 func TestDmg_ConfigCommands(t *testing.T) {
 	runCmdTests(t, []cmdTest{
 		{
-			"Generate with defaults",
+			"Generate with no access point",
 			"config generate",
+			strings.Join([]string{
+				printRequest(t, &control.NetworkScanReq{}),
+			}, " "),
+			errors.New("no access points"),
+		},
+		{
+			"Generate with defaults",
+			"config generate -a foo",
 			strings.Join([]string{
 				printRequest(t, &control.NetworkScanReq{}),
 			}, " "),
@@ -27,7 +35,7 @@ func TestDmg_ConfigCommands(t *testing.T) {
 		},
 		{
 			"Generate with no nvme",
-			"config generate --min-ssds 0",
+			"config generate -a foo --min-ssds 0",
 			strings.Join([]string{
 				printRequest(t, &control.NetworkScanReq{}),
 			}, " "),
@@ -35,7 +43,7 @@ func TestDmg_ConfigCommands(t *testing.T) {
 		},
 		{
 			"Generate with storage parameters",
-			"config generate --num-engines 2 --min-ssds 4",
+			"config generate -a foo --num-engines 2 --min-ssds 4",
 			strings.Join([]string{
 				printRequest(t, &control.NetworkScanReq{}),
 			}, " "),
@@ -43,7 +51,7 @@ func TestDmg_ConfigCommands(t *testing.T) {
 		},
 		{
 			"Generate with short option storage parameters",
-			"config generate -e 2 -s 4",
+			"config generate -a foo -e 2 -s 4",
 			strings.Join([]string{
 				printRequest(t, &control.NetworkScanReq{}),
 			}, " "),
@@ -51,7 +59,7 @@ func TestDmg_ConfigCommands(t *testing.T) {
 		},
 		{
 			"Generate with ethernet network device class",
-			"config generate --net-class ethernet",
+			"config generate -a foo --net-class ethernet",
 			strings.Join([]string{
 				printRequest(t, &control.NetworkScanReq{}),
 			}, " "),
@@ -59,7 +67,7 @@ func TestDmg_ConfigCommands(t *testing.T) {
 		},
 		{
 			"Generate with infiniband network device class",
-			"config generate --net-class infiniband",
+			"config generate -a foo --net-class infiniband",
 			strings.Join([]string{
 				printRequest(t, &control.NetworkScanReq{}),
 			}, " "),
@@ -67,7 +75,7 @@ func TestDmg_ConfigCommands(t *testing.T) {
 		},
 		{
 			"Generate with best-available network device class",
-			"config generate --net-class best-available",
+			"config generate -a foo --net-class best-available",
 			strings.Join([]string{
 				printRequest(t, &control.NetworkScanReq{}),
 			}, " "),
@@ -75,7 +83,7 @@ func TestDmg_ConfigCommands(t *testing.T) {
 		},
 		{
 			"Generate with unsupported network device class",
-			"config generate --net-class loopback",
+			"config generate -a foo --net-class loopback",
 			strings.Join([]string{
 				printRequest(t, &control.NetworkScanReq{}),
 			}, " "),

--- a/src/control/common/collection_utils.go
+++ b/src/control/common/collection_utils.go
@@ -144,16 +144,18 @@ func DedupeStringSlice(in []string) []string {
 }
 
 // StringSliceHasDuplicates checks whether there are duplicate strings in the
-// slice. If so, it returns true.
+// slice. Comparisons are case insensitive. If duplicates found, return true.
 func StringSliceHasDuplicates(slice []string) bool {
-	found := make(map[string]bool)
+	seen := make(map[string]struct{})
 
 	for _, s := range slice {
-		if _, ok := found[s]; ok {
+		sl := strings.ToLower(s)
+		if _, already := seen[sl]; already {
 			return true
 		}
-		found[s] = true
+		seen[sl] = struct{}{}
 	}
+
 	return false
 }
 

--- a/src/control/common/mocks.go
+++ b/src/control/common/mocks.go
@@ -58,8 +58,8 @@ func MockPCIAddr(varIdx ...int32) string {
 	return fmt.Sprintf("0000:%02d:00.0", idx)
 }
 
-func MockPCIAddrs(num int) (addrs []string) {
-	for i := 1; i < num+1; i++ {
+func MockPCIAddrs(idxs ...int) (addrs []string) {
+	for _, i := range idxs {
 		addrs = append(addrs, MockPCIAddr(int32(i)))
 	}
 

--- a/src/control/fault/code/codes.go
+++ b/src/control/fault/code/codes.go
@@ -42,8 +42,8 @@ func (c *Code) UnmarshalJSON(data []byte) (err error) {
 	return
 }
 
+// general fault codes
 const (
-	// general fault codes
 	Unknown Code = iota
 	MissingSoftwareDependency
 	BadVersionSoftwareDependency
@@ -52,8 +52,8 @@ const (
 	PrivilegedHelperRequestFailed
 )
 
+// generic storage fault codes
 const (
-	// generic storage fault codes
 	StorageUnknown Code = iota + 100
 	StorageAlreadyFormatted
 	StorageFilesystemAlreadyMounted
@@ -61,8 +61,8 @@ const (
 	StorageTargetAlreadyMounted
 )
 
+// SCM fault codes
 const (
-	// SCM fault codes
 	ScmUnknown Code = iota + 200
 	ScmFormatInvalidSize
 	ScmFormatInvalidDeviceCount
@@ -75,8 +75,8 @@ const (
 	ScmNoDevicesMatchFilter
 )
 
+// Bdev fault codes
 const (
-	// Bdev fault codes
 	BdevUnknown Code = iota + 300
 	BdevFormatUnknownClass
 	BdevFormatFailure
@@ -86,14 +86,14 @@ const (
 	BdevNoDevicesMatchFilter
 )
 
+// DAOS system fault codes
 const (
-	// DAOS system fault codes
 	SystemUnknown Code = iota + 400
 	SystemBadFaultDomainDepth
 )
 
+// client fault codes
 const (
-	// client fault codes
 	ClientUnknown Code = iota + 500
 	ClientConfigBadControlPort
 	ClientConfigBadAccessPoints
@@ -105,8 +105,8 @@ const (
 	ClientFormatRunningSystem
 )
 
+// server fault codes
 const (
-	// server fault codes
 	ServerUnknown Code = iota + 600
 	ServerScmUnmanaged
 	ServerBdevNotFound
@@ -125,12 +125,13 @@ const (
 	ServerVfioDisabled
 )
 
+// server config fault codes
 const (
-	// server config fault codes
 	ServerConfigUnknown Code = iota + 700
 	ServerBadConfig
 	ServerNoConfigPath
 	ServerConfigBadControlPort
+	ServerConfigBadTelemetryPort
 	ServerConfigBadAccessPoints
 	ServerConfigEvenAccessPoints
 	ServerConfigBadProvider
@@ -150,15 +151,15 @@ const (
 	ServerConfigFaultDomainTooManyLayers
 )
 
+// SPDK library bindings codes
 const (
-	// SPDK library bindings codes
 	SpdkUnknown Code = iota + 800
 	SpdkCtrlrNoHealth
 	SpdkBindingRetNull
 	SpdkBindingFailed
 )
 
+// security fault codes
 const (
-	// security fault codes
 	SecurityUnknown Code = iota + 900
 )

--- a/src/control/lib/control/auto_test.go
+++ b/src/control/lib/control/auto_test.go
@@ -678,7 +678,33 @@ func TestControl_AutoConfig_genConfig(t *testing.T) {
 			numaIfaces:     numaNetIfaceMap{0: ib0},
 			numaSSDs:       numaSSDsMap{0: []string{}},
 			numaCoreCounts: numaCoreCountsMap{0: &coreCounts{16, 7}},
-			expErr:         errors.New("invalid hostname"),
+			expErr:         config.FaultConfigBadControlPort,
+		},
+		"access point ip with valid port": {
+			engineCount:    1,
+			accessPoints:   []string{"192.168.1.1:10002"},
+			numaPMems:      numaPMemsMap{0: []string{"/dev/pmem0"}},
+			numaIfaces:     numaNetIfaceMap{0: ib0},
+			numaSSDs:       numaSSDsMap{0: []string{}},
+			numaCoreCounts: numaCoreCountsMap{0: &coreCounts{16, 7}},
+			expCfg: baseConfig("ofi+psm2").WithAccessPoints("192.168.1.1:10002").WithEngines(
+				defaultEngineCfg(0).
+					WithFabricInterface("ib0").
+					WithFabricInterfacePort(defaultFiPort).
+					WithFabricProvider("ofi+psm2").
+					WithPinnedNumaNode(&numa0).
+					WithScmDeviceList("/dev/pmem0").
+					WithScmMountPoint("/mnt/daos0").
+					WithHelperStreamCount(7)),
+		},
+		"access point ip with invalid port": {
+			engineCount:    1,
+			accessPoints:   []string{"192.168.1.1:-10001"},
+			numaPMems:      numaPMemsMap{0: []string{"/dev/pmem0"}},
+			numaIfaces:     numaNetIfaceMap{0: ib0},
+			numaSSDs:       numaSSDsMap{0: []string{}},
+			numaCoreCounts: numaCoreCountsMap{0: &coreCounts{16, 7}},
+			expErr:         config.FaultConfigBadControlPort,
 		},
 		"single pmem single ssd": {
 			engineCount:    1,

--- a/src/control/lib/control/auto_test.go
+++ b/src/control/lib/control/auto_test.go
@@ -171,7 +171,6 @@ func TestControl_AutoConfig_getNetworkDetails(t *testing.T) {
 	for name, tc := range map[string]struct {
 		engineCount     int
 		netDevClass     uint32
-		accessPoints    []string
 		uErr            error
 		hostResponses   []*HostResponse
 		expHostErrs     []*MockHostError
@@ -282,8 +281,7 @@ func TestControl_AutoConfig_getNetworkDetails(t *testing.T) {
 			expIfs:          []*HostFabricInterface{ib0r, ib1r},
 			expCoresPerNuma: 24,
 		},
-		"engine count unset and dual numa with typical fabric scan output and access points": {
-			accessPoints:    []string{"hostX"},
+		"engine count unset and dual numa with typical fabric scan output": {
 			hostResponses:   dualHostRespSame(typicalFabIfs),
 			expIfs:          []*HostFabricInterface{ib0r, ib1r},
 			expCoresPerNuma: 24,
@@ -309,11 +307,10 @@ func TestControl_AutoConfig_getNetworkDetails(t *testing.T) {
 				tc.netDevClass = NetDevAny
 			}
 			req := ConfigGenerateReq{
-				NrEngines:    tc.engineCount,
-				NetClass:     tc.netDevClass,
-				AccessPoints: tc.accessPoints,
-				Client:       mi,
-				Log:          log,
+				NrEngines: tc.engineCount,
+				NetClass:  tc.netDevClass,
+				Client:    mi,
+				Log:       log,
 			}
 
 			netDetails, gotHostErrs, gotErr := getNetworkDetails(context.TODO(), req)
@@ -593,7 +590,9 @@ func TestControl_AutoConfig_getCPUDetails(t *testing.T) {
 
 			numaSSDs := make(numaSSDsMap)
 			for nn, count := range tc.ssdListSizes {
-				numaSSDs[nn] = common.MockPCIAddrs(count)
+				for i := 0; i < count; i++ {
+					numaSSDs[nn] = append(numaSSDs[nn], common.MockPCIAddr(int32(i)))
+				}
 			}
 
 			nccs, gotErr := getCPUDetails(log, numaSSDs, tc.numaCoreCount)
@@ -634,8 +633,9 @@ func TestControl_AutoConfig_genConfig(t *testing.T) {
 		expErr         error
 	}{
 		"no engines": {
-			numaPMems: numaPMemsMap{0: []string{"/dev/pmem0"}},
-			expErr:    errors.Errorf(errInvalNrEngines, 1, 0),
+			numaPMems:    numaPMemsMap{0: []string{"/dev/pmem0"}},
+			accessPoints: []string{"hostX:10002"},
+			expErr:       errors.Errorf(errInvalNrEngines, 1, 0),
 		},
 		"single pmem zero ssd with access point": {
 			engineCount:    1,
@@ -644,7 +644,7 @@ func TestControl_AutoConfig_genConfig(t *testing.T) {
 			numaIfaces:     numaNetIfaceMap{0: ib0},
 			numaSSDs:       numaSSDsMap{0: []string{}},
 			numaCoreCounts: numaCoreCountsMap{0: &coreCounts{16, 7}},
-			expCfg: baseConfig("ofi+psm2").WithAccessPoints("hostX").WithEngines(
+			expCfg: baseConfig("ofi+psm2").WithAccessPoints("hostX:10001").WithEngines(
 				defaultEngineCfg(0).
 					WithFabricInterface("ib0").
 					WithFabricInterfacePort(defaultFiPort).
@@ -654,13 +654,40 @@ func TestControl_AutoConfig_genConfig(t *testing.T) {
 					WithScmMountPoint("/mnt/daos0").
 					WithHelperStreamCount(7)),
 		},
+		"access point with valid port": {
+			engineCount:    1,
+			accessPoints:   []string{"hostX:10002"},
+			numaPMems:      numaPMemsMap{0: []string{"/dev/pmem0"}},
+			numaIfaces:     numaNetIfaceMap{0: ib0},
+			numaSSDs:       numaSSDsMap{0: []string{}},
+			numaCoreCounts: numaCoreCountsMap{0: &coreCounts{16, 7}},
+			expCfg: baseConfig("ofi+psm2").WithAccessPoints("hostX:10002").WithEngines(
+				defaultEngineCfg(0).
+					WithFabricInterface("ib0").
+					WithFabricInterfacePort(defaultFiPort).
+					WithFabricProvider("ofi+psm2").
+					WithPinnedNumaNode(&numa0).
+					WithScmDeviceList("/dev/pmem0").
+					WithScmMountPoint("/mnt/daos0").
+					WithHelperStreamCount(7)),
+		},
+		"access point with invalid port": {
+			engineCount:    1,
+			accessPoints:   []string{"hostX:-10001"},
+			numaPMems:      numaPMemsMap{0: []string{"/dev/pmem0"}},
+			numaIfaces:     numaNetIfaceMap{0: ib0},
+			numaSSDs:       numaSSDsMap{0: []string{}},
+			numaCoreCounts: numaCoreCountsMap{0: &coreCounts{16, 7}},
+			expErr:         errors.New("invalid hostname"),
+		},
 		"single pmem single ssd": {
 			engineCount:    1,
+			accessPoints:   []string{"hostX:10002"},
 			numaPMems:      numaPMemsMap{0: []string{"/dev/pmem0"}},
 			numaIfaces:     numaNetIfaceMap{0: ib0},
 			numaSSDs:       numaSSDsMap{0: []string{common.MockPCIAddr(1)}},
 			numaCoreCounts: numaCoreCountsMap{0: &coreCounts{16, 7}},
-			expCfg: baseConfig("ofi+psm2").WithEngines(
+			expCfg: baseConfig("ofi+psm2").WithAccessPoints("hostX:10002").WithEngines(
 				defaultEngineCfg(0).
 					WithFabricInterface("ib0").
 					WithFabricInterfacePort(defaultFiPort).
@@ -672,16 +699,17 @@ func TestControl_AutoConfig_genConfig(t *testing.T) {
 					WithHelperStreamCount(7)),
 		},
 		"dual pmem dual ssd": {
-			engineCount: 2,
-			numaPMems:   numaPMemsMap{0: []string{"/dev/pmem0"}, 1: []string{"/dev/pmem1"}},
-			numaIfaces:  numaNetIfaceMap{0: ib0, 1: ib1},
+			engineCount:  2,
+			accessPoints: []string{"hostX:10002"},
+			numaPMems:    numaPMemsMap{0: []string{"/dev/pmem0"}, 1: []string{"/dev/pmem1"}},
+			numaIfaces:   numaNetIfaceMap{0: ib0, 1: ib1},
 			numaSSDs: numaSSDsMap{
-				0: common.MockPCIAddrs(4), 1: common.MockPCIAddrs(3),
+				0: common.MockPCIAddrs(0, 1, 2, 3), 1: common.MockPCIAddrs(4, 5, 6),
 			},
 			numaCoreCounts: numaCoreCountsMap{
 				0: &coreCounts{16, 7}, 1: &coreCounts{15, 6},
 			},
-			expCfg: baseConfig("ofi+psm2").WithEngines(
+			expCfg: baseConfig("ofi+psm2").WithAccessPoints("hostX:10002").WithEngines(
 				defaultEngineCfg(0).
 					WithFabricInterface("ib0").
 					WithFabricInterfacePort(defaultFiPort).
@@ -689,7 +717,7 @@ func TestControl_AutoConfig_genConfig(t *testing.T) {
 					WithPinnedNumaNode(&numa0).
 					WithScmDeviceList("/dev/pmem0").
 					WithScmMountPoint("/mnt/daos0").
-					WithBdevDeviceList(common.MockPCIAddrs(4)...).
+					WithBdevDeviceList(common.MockPCIAddrs(0, 1, 2, 3)...).
 					WithHelperStreamCount(7),
 				defaultEngineCfg(1).
 					WithFabricInterface("ib1").
@@ -699,13 +727,13 @@ func TestControl_AutoConfig_genConfig(t *testing.T) {
 					WithPinnedNumaNode(&numa1).
 					WithScmDeviceList("/dev/pmem1").
 					WithScmMountPoint("/mnt/daos1").
-					WithBdevDeviceList(common.MockPCIAddrs(3)...).
+					WithBdevDeviceList(common.MockPCIAddrs(4, 5, 6)...).
 					WithTargetCount(15).
 					WithHelperStreamCount(6)),
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			_, buf := logging.NewTestLogger(t.Name())
+			log, buf := logging.NewTestLogger(t.Name())
 			defer common.ShowBufferOnFailure(t, buf)
 
 			nd := &networkDetails{
@@ -717,7 +745,7 @@ func TestControl_AutoConfig_genConfig(t *testing.T) {
 				numaSSDs:  tc.numaSSDs,
 			}
 
-			gotCfg, gotErr := genConfig(tc.accessPoints, nd, sd, tc.numaCoreCounts)
+			gotCfg, gotErr := genConfig(log, tc.accessPoints, nd, sd, tc.numaCoreCounts)
 			common.CmpErr(t, tc.expErr, gotErr)
 			if tc.expErr != nil {
 				return

--- a/src/control/lib/hostlist/hostlist_test.go
+++ b/src/control/lib/hostlist/hostlist_test.go
@@ -160,7 +160,8 @@ func TestHostList_Create(t *testing.T) {
 			expUniqOut:   "d-server-[0001-0002]ab",
 			expUniqCount: 2,
 		},
-		// TODO: fix irregularity
+		// TODO DAOS-7332: fix irregularity where hostlist recognizes
+		//                 negative port as bad hostname
 		"negative port": {
 			startList: "node4:10001,node5:-10001",
 			expErr:    errors.New("invalid hostname"),

--- a/src/control/lib/hostlist/hostlist_test.go
+++ b/src/control/lib/hostlist/hostlist_test.go
@@ -160,6 +160,17 @@ func TestHostList_Create(t *testing.T) {
 			expUniqOut:   "d-server-[0001-0002]ab",
 			expUniqCount: 2,
 		},
+		// TODO: fix irregularity
+		"negative port": {
+			startList: "node4:10001,node5:-10001",
+			expErr:    errors.New("invalid hostname"),
+		},
+		"negative port with ip": {
+			startList:    "1.2.3.4:10001,1.2.3.5:-10001",
+			expRawOut:    "1.2.3.4:10001,1.2.3.5:-10001",
+			expUniqOut:   "1.2.3.5:-10001,1.2.3.4:10001",
+			expUniqCount: 2,
+		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			hl, gotErr := hostlist.Create(tc.startList)

--- a/src/control/server/config/faults.go
+++ b/src/control/server/config/faults.go
@@ -33,7 +33,12 @@ var (
 	FaultConfigBadControlPort = serverConfigFault(
 		code.ServerConfigBadControlPort,
 		"invalid control port in configuration",
-		"specify a nonzero control port in configuration ('port' parameter) and restart the control server",
+		"specify a positive non-zero network port in configuration ('port' parameter) and restart the control server",
+	)
+	FaultConfigBadTelemetryPort = serverConfigFault(
+		code.ServerConfigBadTelemetryPort,
+		"invalid telemetry port in configuration",
+		"specify a positive non-zero network port in configuration ('telemetry_port' parameter) and restart the control server",
 	)
 	FaultConfigBadAccessPoints = serverConfigFault(
 		code.ServerConfigBadAccessPoints,

--- a/src/control/server/config/server.go
+++ b/src/control/server/config/server.go
@@ -402,6 +402,40 @@ func (cfg *Server) SaveActiveConfig(log logging.Logger) {
 	log.Debugf("active config saved to %s (read-only)", activeConfig)
 }
 
+func getAccessPointAddrWithPort(log logging.Logger, addr string, portDefault int) (string, error) {
+	if !common.HasPort(addr) {
+		return fmt.Sprintf("%s:%d", addr, portDefault), nil
+	}
+
+	host, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		log.Errorf("invalid access point %q: %s", addr, err)
+		return "", FaultConfigBadAccessPoints
+	}
+
+	portNum, err := strconv.Atoi(port)
+	if err != nil {
+		log.Errorf("invalid access point port: %s", err)
+		return "", FaultConfigBadControlPort
+	}
+	if portNum <= 0 {
+		m := "zero"
+		if portNum < 0 {
+			m = "negative"
+		}
+		log.Errorf("access point port cannot be %s", m)
+		return "", FaultConfigBadControlPort
+	}
+
+	// warn if access point port differs from config control port
+	if portDefault != portNum {
+		log.Debugf("access point (%s) port (%s) differs from default port (%d)",
+			host, port, portDefault)
+	}
+
+	return addr, nil
+}
+
 // Validate asserts that config meets minimum requirements.
 func (cfg *Server) Validate(log logging.Logger) (err error) {
 	msg := "validating config file"
@@ -410,7 +444,7 @@ func (cfg *Server) Validate(log logging.Logger) (err error) {
 	}
 	log.Debug(msg)
 
-	// append the user-friendly message to any error
+	// Append the user-friendly message to any error.
 	defer func() {
 		if err != nil && !fault.HasResolution(err) {
 			examplesPath, _ := common.GetAdjacentPath(relConfExamplesPath)
@@ -430,8 +464,8 @@ func (cfg *Server) Validate(log logging.Logger) (err error) {
 	}
 	cfg.Servers = nil
 
-	// config without engines is valid when initially discovering hardware
-	// prior to adding per-engine sections with device allocations
+	// A config without engines is valid when initially discovering hardware
+	// prior to adding per-engine sections with device allocations.
 	if len(cfg.Engines) == 0 {
 		log.Infof("No %ss in configuration, %s starting in discovery mode", build.DataPlaneName,
 			build.ControlPlaneName)
@@ -439,14 +473,31 @@ func (cfg *Server) Validate(log logging.Logger) (err error) {
 		return nil
 	}
 
-	if cfg.Fabric.Provider == "" {
+	switch {
+	case cfg.Fabric.Provider == "":
 		return FaultConfigNoProvider
+	case cfg.ControlPort <= 0:
+		return FaultConfigBadControlPort
+	case cfg.TelemetryPort < 0:
+		return FaultConfigBadTelemetryPort
 	}
 
-	cfg.AccessPoints, err = common.ParseHostList(cfg.AccessPoints, cfg.ControlPort)
-	if err != nil {
-		return errors.Wrap(err, "unable to parse access_points")
+	// Update access point addresses with control port if port is not
+	// supplied.
+	newAPs := make([]string, 0, len(cfg.AccessPoints))
+	for _, ap := range cfg.AccessPoints {
+		newAP, err := getAccessPointAddrWithPort(log, ap, cfg.ControlPort)
+		if err != nil {
+			return err
+		}
+		newAPs = append(newAPs, newAP)
 	}
+	if common.StringSliceHasDuplicates(newAPs) {
+		log.Error("duplicate access points addresses")
+		return FaultConfigBadAccessPoints
+	}
+	cfg.AccessPoints = newAPs
+
 	switch {
 	case len(cfg.AccessPoints) < 1:
 		return FaultConfigBadAccessPoints
@@ -455,33 +506,6 @@ func (cfg *Server) Validate(log logging.Logger) (err error) {
 	case len(cfg.AccessPoints) > 1:
 		// temporary notification while the feature is still being polished.
 		log.Info("\n*******\nNOTICE: Support for multiple access points is an alpha feature and is not well-tested!\n*******\n\n")
-	case cfg.ControlPort <= 0:
-		return FaultConfigBadControlPort
-	case cfg.TelemetryPort < 0:
-		return FaultConfigBadTelemetryPort
-	}
-
-	for _, ap := range cfg.AccessPoints {
-		host, port, err := net.SplitHostPort(ap)
-		if err != nil {
-			log.Errorf("invalid access point %q: %s", ap, err)
-			return FaultConfigBadControlPort
-		}
-
-		portNum, err := strconv.Atoi(port)
-		if err != nil {
-			log.Errorf("invalid access point port: %s", err)
-			return FaultConfigBadControlPort
-		}
-		if portNum <= 0 {
-			log.Errorf("non-zero or negative access point port %d", portNum)
-			return FaultConfigBadControlPort
-		}
-		// warn if access point port differs from config control port
-		if cfg.ControlPort != portNum {
-			log.Debugf("access point (%s) port (%s) differs from control port (%d)",
-				host, port, cfg.ControlPort)
-		}
 	}
 
 	for i, engine := range cfg.Engines {

--- a/src/control/server/config/server_test.go
+++ b/src/control/server/config/server_test.go
@@ -391,6 +391,18 @@ func TestServerConfig_Validation(t *testing.T) {
 			},
 			expErr: FaultConfigBadControlPort,
 		},
+		"single access point including negative port": {
+			extraConfig: func(c *Server) *Server {
+				return c.WithAccessPoints("1.2.3.4:-10002")
+			},
+			expErr: FaultConfigBadControlPort,
+		},
+		"single access point hostname including negative port": {
+			extraConfig: func(c *Server) *Server {
+				return c.WithAccessPoints("hostX:-10002")
+			},
+			expErr: errors.New("invalid hostname"),
+		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			log, buf := logging.NewTestLogger(t.Name())

--- a/src/control/server/config/server_test.go
+++ b/src/control/server/config/server_test.go
@@ -443,13 +443,28 @@ func TestServerConfig_Validation(t *testing.T) {
 			},
 			expErr: FaultConfigBadControlPort,
 		},
-		"bad control port": {
+		"good control port": {
 			extraConfig: func(c *Server) *Server {
-				return c.WithControlPort(-123)
+				return c.WithControlPort(1234)
+			},
+		},
+		"bad control port (zero)": {
+			extraConfig: func(c *Server) *Server {
+				return c.WithControlPort(0)
 			},
 			expErr: FaultConfigBadControlPort,
 		},
-		"bad telemetry port": {
+		"good telemetry port": {
+			extraConfig: func(c *Server) *Server {
+				return c.WithTelemetryPort(1234)
+			},
+		},
+		"good telemetry port (zero)": {
+			extraConfig: func(c *Server) *Server {
+				return c.WithTelemetryPort(0)
+			},
+		},
+		"bad telemetry port (negative)": {
 			extraConfig: func(c *Server) *Server {
 				return c.WithTelemetryPort(-123)
 			},

--- a/src/control/server/config/server_test.go
+++ b/src/control/server/config/server_test.go
@@ -338,12 +338,29 @@ func TestServerConfig_Validation(t *testing.T) {
 		expErr      error
 	}{
 		"example config": {},
-		"nil server entry": {
+		"nil engine entry": {
 			extraConfig: func(c *Server) *Server {
 				var nilEngineConfig *engine.Config
 				return c.WithEngines(nilEngineConfig)
 			},
 			expErr: errors.New("validation"),
+		},
+		"no engine entries": {
+			extraConfig: func(c *Server) *Server {
+				return c.WithEngines()
+			},
+		},
+		"no fabric provider": {
+			extraConfig: func(c *Server) *Server {
+				return c.WithFabricProvider("")
+			},
+			expErr: FaultConfigNoProvider,
+		},
+		"no access point": {
+			extraConfig: func(c *Server) *Server {
+				return c.WithAccessPoints()
+			},
+			expErr: FaultConfigBadAccessPoints,
 		},
 		"single access point": {
 			extraConfig: func(c *Server) *Server {
@@ -363,9 +380,26 @@ func TestServerConfig_Validation(t *testing.T) {
 		},
 		"multiple access points (dupes)": {
 			extraConfig: func(c *Server) *Server {
+				return c.WithAccessPoints("1.2.3.4", "5.6.7.8", "1.2.3.4")
+			},
+			expErr: FaultConfigBadAccessPoints,
+		},
+		"multiple access points (dupes with ports)": {
+			extraConfig: func(c *Server) *Server {
 				return c.WithAccessPoints("1.2.3.4:1234", "5.6.7.8:5678", "1.2.3.4:1234")
 			},
-			expErr: FaultConfigEvenAccessPoints,
+			expErr: FaultConfigBadAccessPoints,
+		},
+		"multiple access points (dupes with and without ports)": {
+			extraConfig: func(c *Server) *Server {
+				return c.WithAccessPoints("1.2.3.4:10001", "5.6.7.8:5678", "1.2.3.4")
+			},
+			expErr: FaultConfigBadAccessPoints,
+		},
+		"multiple access points (dupes with different ports)": {
+			extraConfig: func(c *Server) *Server {
+				return c.WithAccessPoints("1.2.3.4:10002", "5.6.7.8:5678", "1.2.3.4")
+			},
 		},
 		"no access points": {
 			extraConfig: func(c *Server) *Server {
@@ -385,7 +419,13 @@ func TestServerConfig_Validation(t *testing.T) {
 			},
 			expErr: FaultConfigBadControlPort,
 		},
-		"single access point including invalid port": {
+		"single access point including invalid port (alphanumeric)": {
+			extraConfig: func(c *Server) *Server {
+				return c.WithAccessPoints("1.2.3.4:0a0")
+			},
+			expErr: FaultConfigBadControlPort,
+		},
+		"single access point including invalid port (zero)": {
 			extraConfig: func(c *Server) *Server {
 				return c.WithAccessPoints("1.2.3.4:0")
 			},
@@ -401,7 +441,19 @@ func TestServerConfig_Validation(t *testing.T) {
 			extraConfig: func(c *Server) *Server {
 				return c.WithAccessPoints("hostX:-10002")
 			},
-			expErr: errors.New("invalid hostname"),
+			expErr: FaultConfigBadControlPort,
+		},
+		"bad control port": {
+			extraConfig: func(c *Server) *Server {
+				return c.WithControlPort(-123)
+			},
+			expErr: FaultConfigBadControlPort,
+		},
+		"bad telemetry port": {
+			extraConfig: func(c *Server) *Server {
+				return c.WithTelemetryPort(-123)
+			},
+			expErr: FaultConfigBadTelemetryPort,
 		},
 	} {
 		t.Run(name, func(t *testing.T) {

--- a/src/control/server/engine/config.go
+++ b/src/control/server/engine/config.go
@@ -78,16 +78,18 @@ func (fc *FabricConfig) GetNumaNode() (uint, error) {
 
 // Validate ensures that the configuration meets minimum standards.
 func (fc *FabricConfig) Validate() error {
-	if fc.Provider == "" {
+	switch {
+	case fc.Provider == "":
 		return errors.New("provider not set")
-	}
-	if fc.Interface == "" {
+	case fc.Interface == "":
 		return errors.New("fabric_iface not set")
-	}
-	if fc.InterfacePort == 0 {
+	case fc.InterfacePort == 0:
 		return errors.New("fabric_iface_port not set")
+	case fc.InterfacePort < 0:
+		return errors.New("fabric_iface_port cannot be negative")
+	default:
+		return nil
 	}
-	return nil
 }
 
 // cleanEnvVars scrubs the supplied slice of environment

--- a/src/control/server/engine/config_test.go
+++ b/src/control/server/engine/config_test.go
@@ -367,6 +367,14 @@ func TestEngine_FabricConfigValidation(t *testing.T) {
 			},
 			expErr: errors.New("fabric_iface_port"),
 		},
+		"negative port number": {
+			cfg: FabricConfig{
+				Provider:      "foo",
+				Interface:     "bar",
+				InterfacePort: -42,
+			},
+			expErr: errors.New("fabric_iface_port"),
+		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			gotErr := tc.cfg.Validate()


### PR DESCRIPTION
Improve validation of port number parameters in the server config file
and expand relevant test coverage.

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>