### PR TITLE
DAOS-623 build: Use shallow clone when building deps.

### DIFF
--- a/utils/sl/components/__init__.py
+++ b/utils/sl/components/__init__.py
@@ -282,7 +282,8 @@ def define_components(reqs):
                                  True)
     reqs.define('argobots',
                 retriever=retriever,
-                commands=['./autogen.sh',
+                commands=['git clean -dxf',
+                          './autogen.sh',
                           './configure --prefix=$ARGOBOTS_PREFIX CC=gcc'
                           ' --enable-valgrind'
                           ' --enable-stack-unwind',
@@ -298,9 +299,9 @@ def define_components(reqs):
     retriever = GitRepoRetriever("https://github.com/spdk/spdk.git", True)
     reqs.define('spdk',
                 retriever=retriever,
-                # git -C would be a better option here, however does not play
-                # with older versions of git.
-                commands=['git --git-dir dpdk/.git --work-tree dpdk checkout origin/spdk-19.11.6', \
+                commands=['cd dpdk; '                            \
+                          'git fetch; '                          \
+                          'git checkout origin/spdk-19.11.6',    \
                           './configure --prefix="$SPDK_PREFIX"'                \
                           ' --disable-tests --without-vhost --without-crypto'  \
                           ' --without-pmdk --without-vpp --without-rbd'        \

--- a/utils/sl/components/__init__.py
+++ b/utils/sl/components/__init__.py
@@ -282,8 +282,7 @@ def define_components(reqs):
                                  True)
     reqs.define('argobots',
                 retriever=retriever,
-                commands=['git clean -dxf',
-                          './autogen.sh',
+                commands=['./autogen.sh',
                           './configure --prefix=$ARGOBOTS_PREFIX CC=gcc'
                           ' --enable-valgrind'
                           ' --enable-stack-unwind',
@@ -299,9 +298,9 @@ def define_components(reqs):
     retriever = GitRepoRetriever("https://github.com/spdk/spdk.git", True)
     reqs.define('spdk',
                 retriever=retriever,
-                commands=['cd dpdk; '                            \
-                          'git fetch; '                          \
-                          'git checkout origin/spdk-19.11.6',    \
+                # git -C would be a better option here, however does not play
+                # with older versions of git.
+                commands=['git --git-dir dpdk/.git --work-tree dpdk checkout origin/spdk-19.11.6', \
                           './configure --prefix="$SPDK_PREFIX"'                \
                           ' --disable-tests --without-vhost --without-crypto'  \
                           ' --without-pmdk --without-vpp --without-rbd'        \

--- a/utils/sl/prereq_tools/base.py
+++ b/utils/sl/prereq_tools/base.py
@@ -356,6 +356,7 @@ class GitRepoRetriever():
 
         # Now checkout the commit_sha if specified
         passed_commit_sha = kw.get("commit_sha", None)
+        branch = kw.get("branch", None)
         if passed_commit_sha is None:
             comp = os.path.basename(subdir)
             print("""
@@ -366,28 +367,14 @@ build with random upstream changes.
 *********************** ERROR ************************\n""" % comp)
             raise DownloadFailure(self.url, subdir)
 
-        commands = ['git clone %s %s' % (self.url, subdir)]
-        if not RUNNER.run_commands(commands):
+        if (passed_commit_sha and not branch):
+            commands = ['git clone %s --branch %s --single-branch %s' % (self.url,
+                                                                         passed_commit_sha,
+                                                                         subdir)]
+            if not RUNNER.run_commands(commands):
+                raise DownloadFailure(self.url, subdir)
+        else:
             raise DownloadFailure(self.url, subdir)
-        self.get_specific(subdir, **kw)
-
-    def get_specific(self, subdir, **kw):
-        """Checkout the configured commit"""
-        # If the config overrides the branch, use it.  If a branch is
-        # specified, check it out first.
-        branch = kw.get("branch", None)
-        if branch is None:
-            branch = self.branch
-        self.branch = branch
-        if self.branch:
-            self.commit_sha = self.branch
-            self.checkout_commit(subdir)
-
-        # Now checkout the commit_sha if specified
-        passed_commit_sha = kw.get("commit_sha", None)
-        if passed_commit_sha is not None:
-            self.commit_sha = passed_commit_sha
-            self.checkout_commit(subdir)
 
         # Now apply any patches specified
         self.apply_patches(subdir, kw.get("patches", None))

--- a/utils/sl/prereq_tools/base.py
+++ b/utils/sl/prereq_tools/base.py
@@ -368,10 +368,16 @@ build with random upstream changes.
             raise DownloadFailure(self.url, subdir)
 
         if (passed_commit_sha and not branch):
-            commands = ['git clone %s --branch %s --single-branch %s' % (self.url,
-                                                                         passed_commit_sha,
-                                                                         subdir)]
-            if not RUNNER.run_commands(commands):
+            commands = ['git',
+                        'clone',
+                        self.url,
+                        '--branch',
+                        passed_commit_sha,
+                        '--single-branch',
+                        '--depth',
+                        '1',
+                        subdir]
+            if not RUNNER.run_commands([' '.join(commands)]):
                 raise DownloadFailure(self.url, subdir)
         else:
             raise DownloadFailure(self.url, subdir)


### PR DESCRIPTION
Try to improve performance of builds and reduce resource
usage by doing a shallow clone of dependencies.

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>
