### PR TITLE
DAOS-5465 bio: Reformat of bio_addr_t to support flags (#5510)

### DIFF
--- a/src/include/daos_srv/bio.h
+++ b/src/include/daos_srv/bio.h
@@ -17,6 +17,20 @@
 #include <daos_srv/control.h>
 #include <abt.h>
 
+#define BIO_ADDR_IS_HOLE(addr) ((addr)->ba_flags == BIO_FLAG_HOLE)
+#define BIO_ADDR_SET_HOLE(addr) ((addr)->ba_flags |= BIO_FLAG_HOLE)
+#define BIO_ADDR_SET_NOT_HOLE(addr) ((addr)->ba_flags &= ~(BIO_FLAG_HOLE))
+#define BIO_ADDR_IS_DEDUP(addr) ((addr)->ba_flags == BIO_FLAG_DEDUP)
+#define BIO_ADDR_SET_DEDUP(addr) ((addr)->ba_flags |= BIO_FLAG_DEDUP)
+#define BIO_ADDR_SET_NOT_DEDUP(addr) ((addr)->ba_flags &= ~(BIO_FLAG_DEDUP))
+
+/* Can support up to 16 flags for a BIO address */
+enum BIO_FLAG {
+	/* The address is a hole */
+	BIO_FLAG_HOLE = (1 << 0),
+	BIO_FLAG_DEDUP = (1 << 1),
+};
+
 typedef struct {
 	/*
 	 * Byte offset within PMDK pmemobj pool for SCM;
@@ -24,11 +38,11 @@ typedef struct {
 	 */
 	uint64_t	ba_off;
 	/* DAOS_MEDIA_SCM or DAOS_MEDIA_NVME */
-	uint16_t	ba_type;
-	/* Is the address a hole ? */
-	uint16_t	ba_hole;
-	uint16_t	ba_dedup;
-	uint16_t	ba_padding;
+	uint8_t		ba_type;
+	uint8_t		ba_pad1;
+	/* See BIO_FLAG enum */
+	uint16_t	ba_flags;
+	uint32_t	ba_pad2;
 } bio_addr_t;
 
 struct sys_db;
@@ -104,13 +118,16 @@ bio_addr_set(bio_addr_t *addr, uint16_t type, uint64_t off)
 static inline bool
 bio_addr_is_hole(const bio_addr_t *addr)
 {
-	return addr->ba_hole != 0;
+	return BIO_ADDR_IS_HOLE(addr);
 }
 
 static inline void
 bio_addr_set_hole(bio_addr_t *addr, uint16_t hole)
 {
-	addr->ba_hole = hole;
+	if (hole == 0)
+		BIO_ADDR_SET_NOT_HOLE(addr);
+	else
+		BIO_ADDR_SET_HOLE(addr);
 }
 
 static inline void
@@ -264,7 +281,7 @@ bio_sgl_convert(struct bio_sglist *bsgl, d_sg_list_t *sgl, bool deduped_skip)
 		d_iov_t	*iov = &sgl->sg_iovs[i];
 
 		/* Skip bulk transfer for deduped extent */
-		if (biov->bi_addr.ba_dedup && deduped_skip)
+		if (BIO_ADDR_IS_DEDUP(&biov->bi_addr) && deduped_skip)
 			iov->iov_buf = NULL;
 		else
 			iov->iov_buf = bio_iov2req_buf(biov);

--- a/src/object/srv_ec_aggregate.c
+++ b/src/object/srv_ec_aggregate.c
@@ -1840,7 +1840,7 @@ agg_data_extent(struct dtx_handle *dth, vos_iter_entry_t *entry,
 			rounddown(extent->ae_recx.rx_idx, ec_age2ss(agg_entry));
 
 	agg_entry->ae_cur_stripe.as_extent_cnt++;
-	if (entry->ie_biov.bi_addr.ba_hole) {
+	if (BIO_ADDR_IS_HOLE(&entry->ie_biov.bi_addr)) {
 		extent->ae_hole = true;
 		agg_entry->ae_cur_stripe.as_has_holes = true;
 	} else {

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -1050,11 +1050,12 @@ obj_dedup_verify(daos_handle_t ioh, struct bio_sglist *bsgls_dup, int sgl_nr)
 			}
 
 			/* Didn't use deduped extent */
-			if (!biov->bi_addr.ba_dedup) {
-				D_ASSERT(!biov_dup->bi_addr.ba_dedup);
+			if (!BIO_ADDR_IS_DEDUP(&biov->bi_addr)) {
+				D_ASSERT(
+					!BIO_ADDR_IS_DEDUP(&biov_dup->bi_addr));
 				continue;
 			}
-			D_ASSERT(biov_dup->bi_addr.ba_dedup);
+			D_ASSERT(BIO_ADDR_IS_DEDUP(&biov_dup->bi_addr));
 
 			D_ASSERT(bio_iov2len(biov) == bio_iov2len(biov_dup));
 			rc = memcmp(bio_iov2buf(biov), bio_iov2buf(biov_dup),
@@ -1071,7 +1072,7 @@ obj_dedup_verify(daos_handle_t ioh, struct bio_sglist *bsgls_dup, int sgl_nr)
 			 * failed to commit.
 			 */
 			biov->bi_addr.ba_off = biov_dup->bi_addr.ba_off;
-			biov->bi_addr.ba_dedup = false;
+			BIO_ADDR_SET_NOT_DEDUP(&biov->bi_addr);
 			biov_dup->bi_addr.ba_off = UMOFF_NULL;
 
 			D_DEBUG(DB_IO, "Verify dedup extents failed, "

--- a/src/object/tests/srv_checksum_tests.c
+++ b/src/object/tests/srv_checksum_tests.c
@@ -226,7 +226,7 @@ array_test_case_create(struct vos_fetch_test_context *ctx,
 				  rec_size);
 
 		if (l->is_hole) {
-			biov->bi_addr.ba_hole = true;
+			BIO_ADDR_SET_HOLE(&biov->bi_addr);
 			biov->bi_buf = NULL;
 		} else {
 			D_ALLOC(biov->bi_buf, data_len);

--- a/src/vos/tests/evt_ctl.c
+++ b/src/vos/tests/evt_ctl.c
@@ -294,10 +294,10 @@ bio_alloc_init(struct utest_context *utx, bio_addr_t *addr, const void *src,
 
 	addr->ba_type = DAOS_MEDIA_SCM;
 	if (src == NULL) {
-		addr->ba_hole = 1;
+		BIO_ADDR_SET_HOLE(addr);
 		return 0;
 	} else {
-		addr->ba_hole = 0;
+		BIO_ADDR_SET_NOT_HOLE(addr);
 	}
 	rc = utest_alloc(utx, &umoff, size, init_mem, src);
 

--- a/src/vos/tests/vts_aggregate.c
+++ b/src/vos/tests/vts_aggregate.c
@@ -418,6 +418,12 @@ aggregate_basic(struct io_test_args *arg, struct agg_tst_dataset *ds,
 	if (rc != -DER_CSUM) {
 		assert_rc_equal(rc, 0);
 		verify_view(arg, oid, dkey, akey, ds);
+	} else {
+		/*
+		 * not calling verify_view so must free ds->td_expected_view
+		 * here
+		 */
+		D_FREE(ds->td_expected_view);
 	}
 }
 

--- a/src/vos/vos_aggregate.c
+++ b/src/vos/vos_aggregate.c
@@ -725,6 +725,10 @@ csum_append_added_segs(struct bio_sglist *bsgl, unsigned int added_segs)
 		return -DER_NOMEM;
 	bsgl->bs_iovs = buffer;
 
+	/* Initialize new segments */
+	memset(&bsgl->bs_iovs[bsgl->bs_nr], 0,
+		sizeof(bsgl->bs_iovs[0]) * added_segs);
+
 	for (i = 0; i < bsgl->bs_nr; i++) {
 		if (bsgl->bs_iovs[i].bi_prefix_len) {
 			/* Add the prefix. */
@@ -740,7 +744,8 @@ csum_append_added_segs(struct bio_sglist *bsgl, unsigned int added_segs)
 			bsgl->bs_iovs[add_idx].bi_prefix_len = 0;
 			bsgl->bs_iovs[add_idx].bi_suffix_len = 0;
 			bsgl->bs_iovs[add_idx].bi_buf = NULL;
-			bsgl->bs_iovs[add_idx++].bi_addr.ba_hole = 0;
+			BIO_ADDR_SET_NOT_HOLE(
+				&bsgl->bs_iovs[add_idx++].bi_addr);
 		}
 		if (bsgl->bs_iovs[i].bi_suffix_len) {
 			/* Add the suffix. */
@@ -756,7 +761,8 @@ csum_append_added_segs(struct bio_sglist *bsgl, unsigned int added_segs)
 			bsgl->bs_iovs[add_idx].bi_prefix_len = 0;
 			bsgl->bs_iovs[add_idx].bi_suffix_len = 0;
 			bsgl->bs_iovs[add_idx].bi_buf = NULL;
-			bsgl->bs_iovs[add_idx++].bi_addr.ba_hole = 0;
+			BIO_ADDR_SET_NOT_HOLE(
+				&bsgl->bs_iovs[add_idx++].bi_addr);
 		}
 
 		/* Reset the parameters for the write (non-extended) data. */

--- a/src/vos/vos_io.c
+++ b/src/vos/vos_io.c
@@ -229,7 +229,7 @@ vos_dedup_lookup(struct vos_pool *pool, struct dcs_csum_info *csum,
 	entry = dedup_rlink2entry(rlink);
 	if (biov) {
 		biov->bi_addr = entry->de_addr;
-		biov->bi_addr.ba_dedup = true;
+		BIO_ADDR_SET_DEDUP(&biov->bi_addr);
 		biov->bi_data_len = entry->de_data_len;
 		D_DEBUG(DB_IO, "Found dedup entry\n");
 	}
@@ -247,7 +247,9 @@ vos_dedup_update(struct vos_pool *pool, struct dcs_csum_info *csum,
 {
 	struct dedup_entry	*entry;
 
-	if (!ci_is_valid(csum) || csum_len == 0 || biov->bi_addr.ba_dedup)
+
+	if (!ci_is_valid(csum) || csum_len == 0 ||
+	    BIO_ADDR_IS_DEDUP(&biov->bi_addr))
 		return;
 
 	if (bio_addr_is_hole(&biov->bi_addr))
@@ -1461,7 +1463,8 @@ akey_update_recx(daos_handle_t toh, uint32_t pm_ver, daos_recx_t *recx,
 
 	biov = iod_update_biov(ioc);
 	ent.ei_addr = biov->bi_addr;
-	ent.ei_addr.ba_dedup = false;	/* Don't make this flag persistent */
+	/* Don't make this flag persistent */
+	BIO_ADDR_SET_NOT_DEDUP(&ent.ei_addr);
 
 	if (ioc->ic_remove)
 		return evt_remove_all(toh, &ent.ei_rect.rc_ex, &ioc->ic_epr);
@@ -1762,7 +1765,7 @@ iod_reserve(struct vos_io_context *ioc, struct bio_iov *biov)
 	ioc->ic_iov_at++;
 	bsgl->bs_nr_out++;
 
-	D_DEBUG(DB_TRACE, "media %hu offset "DF_U64" size %zd\n",
+	D_DEBUG(DB_TRACE, "media %d offset "DF_U64" size %zd\n",
 		biov->bi_addr.ba_type, biov->bi_addr.ba_off,
 		bio_iov2len(biov));
 	return 0;
@@ -2322,7 +2325,7 @@ vos_dedup_dup_bsgl(daos_handle_t ioh, struct bio_sglist *bsgl,
 
 		*biov_dup = *biov;
 		/* Original biov isn't deduped, don't duplicate buffer */
-		if (!biov->bi_addr.ba_dedup)
+		if (!BIO_ADDR_IS_DEDUP(&biov->bi_addr))
 			continue;
 
 		D_ASSERT(bio_iov2len(biov) != 0);
@@ -2358,7 +2361,7 @@ vos_dedup_free_bsgl(daos_handle_t ioh, struct bio_sglist *bsgl)
 		if (UMOFF_IS_NULL(bio_iov2off(biov)))
 			continue;
 		/* Not duplicated buffer, don't free it */
-		if (!biov->bi_addr.ba_dedup)
+		if (!BIO_ADDR_IS_DEDUP(&biov->bi_addr))
 			continue;
 
 		oid = umem_off2id(vos_ioc2umm(ioc), bio_iov2off(biov));

--- a/src/vos/vos_layout.h
+++ b/src/vos/vos_layout.h
@@ -88,7 +88,7 @@ enum vos_gc_type {
 #define POOL_DF_MAGIC				0x5ca1ab1e
 
 /** Lowest supported durable format version */
-#define POOL_DF_VER_1				15
+#define POOL_DF_VER_1				16
 /** Current durable format version */
 #define POOL_DF_VERSION				POOL_DF_VER_1
 
@@ -119,6 +119,8 @@ struct vos_pool_df {
 	uint64_t				pd_nvme_sz;
 	/** # of containers in this pool */
 	uint64_t				pd_cont_nr;
+	/** offset for the btree of the dedup table (placeholder) */
+	umem_off_t				pd_dedup;
 	/** Typed PMEMoid pointer for the container index table */
 	struct btr_root				pd_cont_root;
 	/** Free space tracking for NVMe device */


### PR DESCRIPTION
Restructured the bio_addr_t to support flags. Changed hole
and dedup booleans to be a flag. This is to support future
necessary flags/fields without needing to change the structure
again.

Signed-off-by: Ryon Jensen <ryon.jensen@intel.com>