### PR TITLE
DAOS-3835 drpc: Add d_errdesc() to DaosStatus stringer

### DIFF
--- a/src/control/drpc/status.go
+++ b/src/control/drpc/status.go
@@ -21,12 +21,9 @@ import "C"
 type DaosStatus int32
 
 func (ds DaosStatus) Error() string {
-	// NB: Currently, d_errstr() just returns a string of the status
-	// name, e.g. -1007 -> "DER_NOSPACE". This is better than nothing,
-	// but hopefully d_errstr() will be extended to provide better strings
-	// similar to perror().
 	dErrStr := C.GoString(C.d_errstr(C.int(ds)))
-	return fmt.Sprintf("DAOS error (%d): %s", ds, dErrStr)
+	dErrDesc := C.GoString(C.d_errdesc(C.int(ds)))
+	return fmt.Sprintf("%s(%d): %s", dErrStr, ds, dErrDesc)
 }
 
 const (

--- a/src/control/drpc/status_test.go
+++ b/src/control/drpc/status_test.go
@@ -37,3 +37,17 @@ func TestDrpc_Status(t *testing.T) {
 		})
 	}
 }
+
+func TestDrpc_Error(t *testing.T) {
+	// Light test to make sure the error stringer works as expected.
+	for ds, expStr := range map[drpc.DaosStatus]string{
+		drpc.DaosSuccess:        "DER_SUCCESS(0): Success",
+		drpc.DaosProtocolError:  "DER_PROTO(-1014): Incompatible protocol",
+		drpc.DaosNotReplica:     "DER_NOTREPLICA(-2020): Not a service replica",
+		drpc.DaosStatus(424242): "DER_UNKNOWN(424242): Unknown error code 424242",
+	} {
+		t.Run(expStr, func(t *testing.T) {
+			common.AssertEqual(t, expStr, ds.Error(), "not equal")
+		})
+	}
+}


### PR DESCRIPTION
Use the d_errdesc() helper to provide more context for
a DAOS status code. Output is in line with the C side,
e.g.

DER_NOSPACE(-1007): No space on storage target