### PR TITLE
DAOS-7130 metrics: Add state to telemetry shmem

### DIFF
--- a/src/control/lib/telemetry/counter.go
+++ b/src/control/lib/telemetry/counter.go
@@ -39,7 +39,7 @@ func (c *Counter) Value() uint64 {
 
 	var val C.uint64_t
 
-	res := C.d_tm_get_counter(&val, c.handle.shmem, c.node)
+	res := C.d_tm_get_counter(c.handle.apiCtx, &val, c.node)
 	if res == C.DER_SUCCESS {
 		return uint64(val)
 	}

--- a/src/control/lib/telemetry/duration.go
+++ b/src/control/lib/telemetry/duration.go
@@ -32,7 +32,7 @@ func (d *Duration) Value() time.Duration {
 
 	var tms C.struct_timespec
 
-	res := C.d_tm_get_duration(&tms, &d.stats, d.handle.shmem, d.node)
+	res := C.d_tm_get_duration(d.handle.apiCtx, &tms, &d.stats, d.node)
 	if res == C.DER_SUCCESS {
 		return time.Duration(tms.tv_sec)*time.Second + time.Duration(tms.tv_nsec)
 	}

--- a/src/control/lib/telemetry/gauge.go
+++ b/src/control/lib/telemetry/gauge.go
@@ -39,7 +39,7 @@ func (g *Gauge) Value() uint64 {
 
 	var val C.uint64_t
 
-	res := C.d_tm_get_gauge(&val, &g.stats, g.handle.shmem, g.node)
+	res := C.d_tm_get_gauge(g.handle.apiCtx, &val, &g.stats, g.node)
 	if res == C.DER_SUCCESS {
 		return uint64(val)
 	}

--- a/src/control/lib/telemetry/promexp/collector.go
+++ b/src/control/lib/telemetry/promexp/collector.go
@@ -43,17 +43,21 @@ type (
 	labelMap map[string]string
 )
 
-func NewEngineSource(parent context.Context, idx uint32, rank uint32) (*EngineSource, error) {
+func NewEngineSource(parent context.Context, idx uint32, rank uint32) (*EngineSource, func(), error) {
 	ctx, err := telemetry.Init(parent, idx)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to init telemetry")
+		return nil, nil, errors.Wrap(err, "failed to init telemetry")
+	}
+
+	cleanupFn := func() {
+		telemetry.Detach(ctx)
 	}
 
 	return &EngineSource{
 		ctx:   ctx,
 		Index: idx,
 		Rank:  rank,
-	}, nil
+	}, cleanupFn, nil
 }
 
 func defaultCollectorOpts() *CollectorOpts {

--- a/src/control/lib/telemetry/telemetry.go
+++ b/src/control/lib/telemetry/telemetry.go
@@ -70,10 +70,10 @@ type (
 type (
 	handle struct {
 		sync.RWMutex
-		idx   uint32
-		rank  *uint32
-		shmem *C.uint64_t
-		root  *C.struct_d_tm_node_t
+		idx    uint32
+		rank   *uint32
+		apiCtx *C.struct_d_tm_context
+		root   *C.struct_d_tm_node_t
 	}
 
 	metricBase struct {
@@ -111,7 +111,7 @@ func findNode(hdl *handle, name string) (*C.struct_d_tm_node_t, error) {
 		return nil, errors.New("nil handle")
 	}
 
-	node := C.d_tm_find_metric(hdl.shmem, C.CString(name))
+	node := C.d_tm_find_metric(hdl.apiCtx, C.CString(name))
 	if node == nil {
 		return nil, errors.Errorf("unable to find metric named %q", name)
 	}
@@ -136,7 +136,7 @@ func (mb *metricBase) Name() string {
 	}
 
 	if mb.name == nil {
-		name := C.GoString((*C.char)(C.d_tm_conv_ptr(mb.handle.shmem, unsafe.Pointer(mb.node.dtn_name))))
+		name := C.GoString((*C.char)(C.d_tm_conv_ptr(mb.handle.apiCtx, unsafe.Pointer(mb.node.dtn_name))))
 		mb.name = &name
 	}
 
@@ -150,7 +150,7 @@ func (mb *metricBase) fillMetadata() {
 
 	var desc *C.char
 	var units *C.char
-	res := C.d_tm_get_metadata(&desc, &units, mb.handle.shmem, mb.node)
+	res := C.d_tm_get_metadata(mb.handle.apiCtx, &desc, &units, mb.node)
 	if res == C.DER_SUCCESS {
 		descStr := C.GoString(desc)
 		mb.desc = &descStr
@@ -196,7 +196,7 @@ func (mb *metricBase) String() string {
 	}
 
 	go func() {
-		C.d_tm_print_node(mb.handle.shmem, mb.node, C.int(0), C.CString(""), C.D_TM_STANDARD, C.int(0), f)
+		C.d_tm_print_node(mb.handle.apiCtx, mb.node, C.int(0), C.CString(""), C.D_TM_STANDARD, C.int(0), f)
 		C.fclose(f)
 	}()
 
@@ -234,24 +234,32 @@ func (sm *statsMetric) SampleSize() uint64 {
 	return uint64(sm.stats.sample_size)
 }
 
+// Init initializes the telemetry bindings
 func Init(parent context.Context, idx uint32) (context.Context, error) {
-	shmemRoot := C.d_tm_get_shared_memory(C.int(idx))
-	if shmemRoot == nil {
+	tmCtx := C.d_tm_open(C.int(idx))
+	if tmCtx == nil {
 		return nil, errors.Errorf("no shared memory segment found for idx: %d", idx)
 	}
 
-	root := C.d_tm_get_root(shmemRoot)
+	root := C.d_tm_get_root(tmCtx)
 	if root == nil {
 		return nil, errors.Errorf("no root node found in shared memory segment for idx: %d", idx)
 	}
 
 	handle := &handle{
-		idx:   idx,
-		shmem: shmemRoot,
-		root:  root,
+		idx:    idx,
+		apiCtx: tmCtx,
+		root:   root,
 	}
 
 	return context.WithValue(parent, handleKey, handle), nil
+}
+
+// Detach detaches from the telemetry handle
+func Detach(ctx context.Context) {
+	if hdl, err := getHandle(ctx); err != nil {
+		C.d_tm_close(&hdl.apiCtx)
+	}
 }
 
 func visit(hdl *handle, node *C.struct_d_tm_node_t, pathComps []string, out chan<- Metric) {
@@ -261,11 +269,11 @@ func visit(hdl *handle, node *C.struct_d_tm_node_t, pathComps []string, out chan
 		return
 	}
 	path := strings.Join(pathComps, "/")
-	name := C.GoString((*C.char)(C.d_tm_conv_ptr(hdl.shmem, unsafe.Pointer(node.dtn_name))))
+	name := C.GoString((*C.char)(C.d_tm_conv_ptr(hdl.apiCtx, unsafe.Pointer(node.dtn_name))))
 
 	switch node.dtn_type {
 	case C.D_TM_DIRECTORY:
-		next = (*C.struct_d_tm_node_t)(C.d_tm_conv_ptr(hdl.shmem, unsafe.Pointer(node.dtn_child)))
+		next = (*C.struct_d_tm_node_t)(C.d_tm_conv_ptr(hdl.apiCtx, unsafe.Pointer(node.dtn_child)))
 		if next != nil {
 			visit(hdl, next, append(pathComps, name), out)
 		}
@@ -276,7 +284,7 @@ func visit(hdl *handle, node *C.struct_d_tm_node_t, pathComps []string, out chan
 	default:
 	}
 
-	next = (*C.struct_d_tm_node_t)(C.d_tm_conv_ptr(hdl.shmem, unsafe.Pointer(node.dtn_sibling)))
+	next = (*C.struct_d_tm_node_t)(C.d_tm_conv_ptr(hdl.apiCtx, unsafe.Pointer(node.dtn_sibling)))
 	if next != nil && next != node {
 		visit(hdl, next, pathComps, out)
 	}
@@ -304,7 +312,7 @@ func CollectMetrics(ctx context.Context, dirname string, out chan<- Metric) erro
 	var nl *C.struct_d_tm_nodeList_t
 
 	filter := C.D_TM_ALL_NODES
-	rc := C.d_tm_list(&nl, hdl.shmem, node, C.int(filter))
+	rc := C.d_tm_list(hdl.apiCtx, &nl, node, C.int(filter))
 
 	if rc != C.DER_SUCCESS {
 		return errors.Errorf("unable to find entry for %s.  rc = %d\n", dirname, rc)

--- a/src/control/lib/telemetry/telemetry_test.go
+++ b/src/control/lib/telemetry/telemetry_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestTelemetry_Basics(t *testing.T) {
 	ctx, testMetrics := setupTestMetrics(t)
-	defer cleanupTestMetrics(t)
+	defer cleanupTestMetrics(ctx, t)
 
 	var m Metric
 	var err error

--- a/src/control/lib/telemetry/test_helpers.go
+++ b/src/control/lib/telemetry/test_helpers.go
@@ -106,6 +106,7 @@ func setupTestMetrics(t *testing.T) (context.Context, testMetricsMap) {
 	return ctx, testMetrics
 }
 
-func cleanupTestMetrics(t *testing.T) {
+func cleanupTestMetrics(ctx context.Context, t *testing.T) {
+	Detach(ctx)
 	C.d_tm_fini()
 }

--- a/src/control/lib/telemetry/timestamp.go
+++ b/src/control/lib/telemetry/timestamp.go
@@ -31,7 +31,7 @@ func (t *Timestamp) Value() time.Time {
 		return zero
 	}
 	var clk C.time_t
-	res := C.d_tm_get_timestamp(&clk, t.handle.shmem, t.node)
+	res := C.d_tm_get_timestamp(t.handle.apiCtx, &clk, t.node)
 	if res == C.DER_SUCCESS {
 		return time.Unix(int64(clk), 0)
 	}

--- a/src/control/server/server.go
+++ b/src/control/server/server.go
@@ -150,6 +150,7 @@ func (srv *server) OnEnginesStarted(fns ...func(context.Context) error) {
 
 func (srv *server) shutdown() {
 	srv.pubSub.Close()
+	stopPrometheusExporter()
 }
 
 // initNetwork resolves local address and starts TCP listener then calls

--- a/src/gurt/examples/telem_consumer_example.c
+++ b/src/gurt/examples/telem_consumer_example.c
@@ -18,8 +18,8 @@
  * This example doesn't _do_ anything with the data it reads other than print
  * it out.
  */
-void read_metrics(uint64_t *shmem_root, struct d_tm_node_t *root, char *dirname,
-		  int filter, bool show_meta)
+void read_metrics(struct d_tm_context *ctx, struct d_tm_node_t *root,
+		  char *dirname, int filter, bool show_meta)
 {
 	struct d_tm_nodeList_t	*nodelist = NULL;
 	struct d_tm_nodeList_t	*head = NULL;
@@ -37,7 +37,7 @@ void read_metrics(uint64_t *shmem_root, struct d_tm_node_t *root, char *dirname,
 	node = root;
 	if (dirname != NULL) {
 		if (strncmp(dirname, "/", D_TM_MAX_NAME_LEN) != 0) {
-			node = d_tm_find_metric(shmem_root, dirname);
+			node = d_tm_find_metric(ctx, dirname);
 			if (node == NULL) {
 				printf("Cannot find directory or metric: %s\n",
 				       dirname);
@@ -46,7 +46,7 @@ void read_metrics(uint64_t *shmem_root, struct d_tm_node_t *root, char *dirname,
 		}
 	}
 
-	rc = d_tm_list(&nodelist, shmem_root, node, filter);
+	rc = d_tm_list(ctx, &nodelist, node, filter);
 	if (rc != DER_SUCCESS) {
 		printf("d_tm_list failure: " DF_RC "\n", DP_RC(rc));
 		return;
@@ -54,15 +54,15 @@ void read_metrics(uint64_t *shmem_root, struct d_tm_node_t *root, char *dirname,
 	head = nodelist;
 
 	printf("\nThere are %" PRIu64 " metrics in the directory %s\n",
-	       d_tm_count_metrics(shmem_root, node, filter),
+	       d_tm_count_metrics(ctx, node, filter),
 	       dirname ? dirname : "/");
 
 	while (nodelist) {
-		name = d_tm_conv_ptr(shmem_root, nodelist->dtnl_node->dtn_name);
+		name = d_tm_conv_ptr(ctx, nodelist->dtnl_node->dtn_name);
 		if (name == NULL)
 			return;
 
-		d_tm_get_metadata(&desc, &units, shmem_root,
+		d_tm_get_metadata(ctx, &desc, &units,
 				  nodelist->dtnl_node);
 
 		switch (nodelist->dtnl_node->dtn_type) {
@@ -70,7 +70,7 @@ void read_metrics(uint64_t *shmem_root, struct d_tm_node_t *root, char *dirname,
 			fprintf(stdout, "Directory: %-20s\n", name);
 			break;
 		case D_TM_COUNTER:
-			rc = d_tm_get_counter(&val, shmem_root,
+			rc = d_tm_get_counter(ctx, &val,
 					      nodelist->dtnl_node);
 			if (rc != DER_SUCCESS) {
 				printf("Error on counter read: " DF_RC "\n",
@@ -81,7 +81,7 @@ void read_metrics(uint64_t *shmem_root, struct d_tm_node_t *root, char *dirname,
 					   options, stdout);
 			break;
 		case D_TM_TIMESTAMP:
-			rc = d_tm_get_timestamp(&clk, shmem_root,
+			rc = d_tm_get_timestamp(ctx, &clk,
 						nodelist->dtnl_node);
 			if (rc != DER_SUCCESS) {
 				printf("Error on timestamp read: " DF_RC "\n",
@@ -94,7 +94,7 @@ void read_metrics(uint64_t *shmem_root, struct d_tm_node_t *root, char *dirname,
 		case (D_TM_TIMER_SNAPSHOT | D_TM_CLOCK_REALTIME):
 		case (D_TM_TIMER_SNAPSHOT | D_TM_CLOCK_PROCESS_CPUTIME):
 		case (D_TM_TIMER_SNAPSHOT | D_TM_CLOCK_THREAD_CPUTIME):
-			rc = d_tm_get_timer_snapshot(&tms, shmem_root,
+			rc = d_tm_get_timer_snapshot(ctx, &tms,
 						     nodelist->dtnl_node);
 			if (rc != DER_SUCCESS) {
 				printf("Error on highres timer read: " DF_RC
@@ -109,7 +109,7 @@ void read_metrics(uint64_t *shmem_root, struct d_tm_node_t *root, char *dirname,
 		case D_TM_DURATION | D_TM_CLOCK_REALTIME:
 		case D_TM_DURATION | D_TM_CLOCK_PROCESS_CPUTIME:
 		case D_TM_DURATION | D_TM_CLOCK_THREAD_CPUTIME:
-			rc = d_tm_get_duration(&tms, &stats, shmem_root,
+			rc = d_tm_get_duration(ctx, &tms, &stats,
 					       nodelist->dtnl_node);
 			if (rc != DER_SUCCESS) {
 				printf("Error on duration read: " DF_RC "\n",
@@ -121,7 +121,7 @@ void read_metrics(uint64_t *shmem_root, struct d_tm_node_t *root, char *dirname,
 					    D_TM_STANDARD, options, stdout);
 			break;
 		case D_TM_GAUGE:
-			rc = d_tm_get_gauge(&val, &stats, shmem_root,
+			rc = d_tm_get_gauge(ctx, &val, &stats,
 					    nodelist->dtnl_node);
 			if (rc != DER_SUCCESS) {
 				printf("Error on gauge read: " DF_RC "\n",
@@ -155,7 +155,7 @@ int
 main(int argc, char **argv)
 {
 	struct d_tm_node_t	*root = NULL;
-	uint64_t		*shmem_root = NULL;
+	struct d_tm_context	*ctx = NULL;
 	char			dirname[D_TM_MAX_NAME_LEN] = {0};
 	bool			show_meta = false;
 	int			simulated_srv_idx = 0;
@@ -171,29 +171,30 @@ main(int argc, char **argv)
 	printf("This simulated server instance has ID: %d\n",
 	       simulated_srv_idx);
 
-	shmem_root = d_tm_get_shared_memory(simulated_srv_idx);
-	if (!shmem_root)
+	ctx = d_tm_open(simulated_srv_idx);
+	if (ctx == NULL)
 		goto failure;
 
-	root = d_tm_get_root(shmem_root);
+	root = d_tm_get_root(ctx);
 
 	printf("Full directory tree from root node:\n");
 	filter = (D_TM_COUNTER | D_TM_TIMESTAMP | D_TM_TIMER_SNAPSHOT |
 		  D_TM_DURATION | D_TM_GAUGE | D_TM_DIRECTORY);
 	show_meta = true;
-	d_tm_print_my_children(shmem_root, root, 0, filter, NULL,
+	d_tm_print_my_children(ctx, root, 0, filter, NULL,
 			       D_TM_STANDARD, D_TM_INCLUDE_METADATA, stdout);
 
 	sprintf(dirname, "manually added");
 	filter = (D_TM_COUNTER | D_TM_TIMESTAMP | D_TM_TIMER_SNAPSHOT |
 			D_TM_DURATION | D_TM_GAUGE);
 	show_meta = false;
-	read_metrics(shmem_root, root, dirname, filter, show_meta);
+	read_metrics(ctx, root, dirname, filter, show_meta);
 
 	filter = D_TM_COUNTER;
 	show_meta = true;
-	read_metrics(shmem_root, root, dirname, filter, show_meta);
+	read_metrics(ctx, root, dirname, filter, show_meta);
 
+	d_tm_close(&ctx);
 	return 0;
 
 failure:

--- a/src/gurt/examples/telem_producer_example.c
+++ b/src/gurt/examples/telem_producer_example.c
@@ -209,7 +209,7 @@ struct d_tm_nodeList_t *add_metrics_manually(void)
 		return NULL;
 	}
 
-	rc = d_tm_add_node(counter1, &node_list);
+	rc = d_tm_list_add_node(counter1, &node_list);
 	if (rc != DER_SUCCESS) {
 		printf("d_tm_add_metric failed: " DF_RC "\n", DP_RC(rc));
 		return NULL;
@@ -225,7 +225,7 @@ struct d_tm_nodeList_t *add_metrics_manually(void)
 		return NULL;
 	}
 
-	rc = d_tm_add_node(counter2, &node_list);
+	rc = d_tm_list_add_node(counter2, &node_list);
 	if (rc != DER_SUCCESS) {
 		d_tm_list_free(node_list);
 		printf("d_tm_add_metric failed: " DF_RC "\n", DP_RC(rc));

--- a/src/gurt/telemetry.c
+++ b/src/gurt/telemetry.c
@@ -17,63 +17,88 @@
 #include "gurt/telemetry_producer.h"
 #include "gurt/telemetry_consumer.h"
 
+/** Header of a shared memory region */
+struct d_tm_shmem_hdr {
+	uint64_t		sh_base_addr;	/** address of this struct */
+	uint32_t		sh_id;		/** shmid */
+	uint8_t			sh_reserved[4];	/** for alignment */
+	uint64_t		sh_bytes_total;	/** total size of region */
+	uint64_t		sh_bytes_free;	/** free bytes in this region */
+	void			*sh_free_addr;	/** start of free space */
+	struct d_tm_node_t	*sh_root;	/** root of metric tree */
+};
+
+struct d_tm_context {
+	struct d_tm_shmem_hdr *shmem_root; /** primary shared memory region */
+};
+
 /**
- * These globals are used for all data producers sharing the same process space
+ * Internal tracking data for shared memory for this process.
  */
+static struct d_tm_shmem {
+	struct d_tm_context	*dts_ctx; /** context for the producer */
+	struct d_tm_node_t	*dts_root; /** root node of shmem */
+	pthread_mutex_t		dts_add_lock; /** for synchronized access */
+	bool			dts_sync_access; /** whether to sync access */
+	bool			dts_retain; /** retain shmem region on exit */
+} tm_shmem;
 
-/** Points to the root directory node */
-struct d_tm_node_t	*d_tm_root;
-
-/** Protects d_tm_add_metric operations */
-pthread_mutex_t		d_tm_add_lock;
-
-/** Points to the base address of the shared memory segment */
-uint64_t		*d_tm_shmem_root;
-
-/** Tracks amount of shared memory bytes available for allocation */
-uint64_t		d_tm_shmem_free;
-
-/** Points to the base address of the free shared memory */
-uint8_t			*d_tm_shmem_idx;
-
-/** Shared memory ID for the segment of shared memory created by the producer */
-int			d_tm_shmid;
-
-/** Enables metric read/write serialization */
-bool			d_tm_serialization;
-
-/** Enables shared memory retention on process exit */
-bool			d_tm_retain_shmem;
+/* Internal helper functions */
+static struct d_tm_shmem_hdr *allocate_shared_memory(int srv_idx,
+						     size_t mem_size);
+static void *d_tm_shmalloc(struct d_tm_shmem_hdr *region, int length);
+static bool d_tm_validate_shmem_ptr(struct d_tm_shmem_hdr *shmem_root,
+				    void *ptr);
+static int d_tm_alloc_node(struct d_tm_shmem_hdr *shmem,
+			   struct d_tm_node_t **newnode, char *name);
+static struct d_tm_node_t *d_tm_find_child(struct d_tm_context *ctx,
+					   struct d_tm_node_t *parent,
+					   char *name);
+static int d_tm_add_child(struct d_tm_node_t **newnode,
+			  struct d_tm_node_t *parent, char *name);
 
 /**
  * Returns a pointer to the root node for the given shared memory segment
  *
- * \param[in]	shmem	Shared memory segment
+ * \param[in]	ctx	Client context
  *
  * \return		Pointer to the root node
  */
 struct d_tm_node_t *
-d_tm_get_root(uint64_t *shmem)
+d_tm_get_root(struct d_tm_context *ctx)
 {
-	if (shmem != NULL)
-		return (struct d_tm_node_t *)(shmem + 1);
-	else
-		return NULL;
+	if (ctx != NULL && ctx->shmem_root != NULL)
+		return d_tm_conv_ptr(ctx, ctx->shmem_root->sh_root);
+
+	return NULL;
+}
+
+static int
+d_tm_lock_shmem(void)
+{
+	return D_MUTEX_LOCK(&tm_shmem.dts_add_lock);
+}
+
+static int
+d_tm_unlock_shmem(void)
+{
+	return D_MUTEX_UNLOCK(&tm_shmem.dts_add_lock);
 }
 
 /**
  * Search for a \a parent's child with the given \a name.
  * Return a pointer to the child if found.
  *
- * \param[in]	shmem_root	Pointer to the shared memory segment
- * \param[in]	parent		The parent node
- * \param[in]	name		The name of the child to find
+ * \param[in]	ctx	Telemetry context
+ * \param[in]	parent	The parent node
+ * \param[in]	name	The name of the child to find
  *
- * \return			Pointer to the child node
- *				NULL if not found
+ * \return		Pointer to the child node
+ *			NULL if not found
  */
-struct d_tm_node_t *
-d_tm_find_child(uint64_t *shmem_root, struct d_tm_node_t *parent, char *name)
+static struct d_tm_node_t *
+d_tm_find_child(struct d_tm_context *ctx, struct d_tm_node_t *parent,
+		char *name)
 {
 	struct d_tm_node_t	*child = NULL;
 	char			*client_name;
@@ -84,19 +109,19 @@ d_tm_find_child(uint64_t *shmem_root, struct d_tm_node_t *parent, char *name)
 	if (parent->dtn_child == NULL)
 		return NULL;
 
-	child = d_tm_conv_ptr(shmem_root, parent->dtn_child);
+	child = d_tm_conv_ptr(ctx, parent->dtn_child);
 
 	client_name = NULL;
 	if (child != NULL)
-		client_name = d_tm_conv_ptr(shmem_root, child->dtn_name);
+		client_name = d_tm_conv_ptr(ctx, child->dtn_name);
 
 	while ((child != NULL) && (client_name != NULL) &&
 	       strncmp(client_name, name, D_TM_MAX_NAME_LEN) != 0) {
-		child = d_tm_conv_ptr(shmem_root, child->dtn_sibling);
+		child = d_tm_conv_ptr(ctx, child->dtn_sibling);
 		client_name = NULL;
 		if (child == NULL)
 			break;
-		client_name = d_tm_conv_ptr(shmem_root, child->dtn_name);
+		client_name = d_tm_conv_ptr(ctx, child->dtn_name);
 	}
 
 	return child;
@@ -105,28 +130,30 @@ d_tm_find_child(uint64_t *shmem_root, struct d_tm_node_t *parent, char *name)
 /**
  * Allocate a \a newnode and initialize its \a name.
  *
- * \param[in,out]	newnode	A pointer for the new node
- * \param[in]		name	The name of the new node
+ * \param[in]	shmem	Shared memory region
+ * \param[out]	newnode	A pointer for the new node
+ * \param[in]	name	The name of the new node
  *
- * \return		DER_SUCCESS		Success
- *			-DER_NO_SHMEM		No shared memory available
- *			-DER_EXCEEDS_PATH_LEN	The full name length is
- *						too long
- *			-DER_INVAL		bad pointers given
+ * \return	DER_SUCCESS		Success
+ *		-DER_NO_SHMEM		No shared memory available
+ *		-DER_EXCEEDS_PATH_LEN	The full name length is
+ *					too long
+ *		-DER_INVAL		bad pointers given
  */
-int
-d_tm_alloc_node(struct d_tm_node_t **newnode, char *name)
+static int
+d_tm_alloc_node(struct d_tm_shmem_hdr *shmem, struct d_tm_node_t **newnode,
+		char *name)
 {
 	struct d_tm_node_t	*node = NULL;
 	int			buff_len = 0;
 	int			rc = DER_SUCCESS;
 
-	if ((newnode == NULL) || (name == NULL)) {
+	if (shmem == NULL || newnode == NULL || name == NULL) {
 		rc = -DER_INVAL;
 		goto out;
 	}
 
-	node = d_tm_shmalloc(sizeof(struct d_tm_node_t));
+	node = d_tm_shmalloc(shmem, sizeof(struct d_tm_node_t));
 	if (node == NULL) {
 		rc = -DER_NO_SHMEM;
 		goto out;
@@ -137,12 +164,13 @@ d_tm_alloc_node(struct d_tm_node_t **newnode, char *name)
 		goto out;
 	}
 	buff_len += 1; /* make room for the trailing null */
-	node->dtn_name = d_tm_shmalloc(buff_len);
+	node->dtn_name = d_tm_shmalloc(shmem, buff_len);
 	if (node->dtn_name == NULL) {
 		rc = -DER_NO_SHMEM;
 		goto out;
 	}
 	strncpy(node->dtn_name, name, buff_len);
+	node->dtn_region = shmem;
 	node->dtn_child = NULL;
 	node->dtn_sibling = NULL;
 	node->dtn_metric = NULL;
@@ -166,7 +194,7 @@ out:
  *						too long
  *			-DER_INVAL		Bad pointers given
  */
-int
+static int
 d_tm_add_child(struct d_tm_node_t **newnode, struct d_tm_node_t *parent,
 	       char *name)
 {
@@ -182,7 +210,8 @@ d_tm_add_child(struct d_tm_node_t **newnode, struct d_tm_node_t *parent,
 
 	child = parent->dtn_child;
 	sibling = parent->dtn_child;
-	rc = d_tm_alloc_node(&node, name);
+	/** Same region as parent */
+	rc = d_tm_alloc_node(parent->dtn_region, &node, name);
 	if (rc != DER_SUCCESS)
 		goto failure;
 
@@ -214,6 +243,24 @@ failure:
 	return rc;
 }
 
+static int
+alloc_ctx(struct d_tm_context **ctx, struct d_tm_shmem_hdr *shmem)
+{
+	struct d_tm_context *new_ctx;
+
+	D_ASSERT(ctx != NULL);
+	D_ASSERT(shmem != NULL);
+
+	D_ALLOC_PTR(new_ctx);
+	if (new_ctx == NULL)
+		return -DER_NOMEM;
+
+	new_ctx->shmem_root = shmem;
+
+	*ctx = new_ctx;
+	return 0;
+}
+
 /**
  * Initialize an instance of the telemetry and metrics API for the producer
  * process.
@@ -237,61 +284,50 @@ failure:
 int
 d_tm_init(int id, uint64_t mem_size, int flags)
 {
-	uint64_t	*base_addr = NULL;
-	char		tmp[D_TM_MAX_NAME_LEN];
-	int		rc = DER_SUCCESS;
+	struct d_tm_shmem_hdr	*new_shmem;
+	char			tmp[D_TM_MAX_NAME_LEN];
+	int			rc = DER_SUCCESS;
 
-	if ((d_tm_shmem_root != NULL) && (d_tm_root != NULL)) {
-		D_INFO("d_tm_init already completed for id %d\n", id);
-		return rc;
-	}
+	memset(&tm_shmem, 0, sizeof(tm_shmem));
 
 	if ((flags & ~(D_TM_SERIALIZATION | D_TM_RETAIN_SHMEM)) != 0) {
+		D_ERROR("Invalid flags\n");
 		rc = -DER_INVAL;
 		goto failure;
 	}
 
 	if (flags & D_TM_SERIALIZATION) {
-		d_tm_serialization = true;
+		tm_shmem.dts_sync_access = true;
 		D_INFO("Serialization enabled for id %d\n", id);
 	}
 
 	if (flags & D_TM_RETAIN_SHMEM) {
-		d_tm_retain_shmem = true;
+		tm_shmem.dts_retain = true;
 		D_INFO("Retaining shared memory for id %d\n", id);
 	}
 
-	d_tm_shmem_root = d_tm_allocate_shared_memory(id, mem_size);
-
-	if (d_tm_shmem_root == NULL) {
+	new_shmem = allocate_shared_memory(id, mem_size);
+	if (new_shmem == NULL) {
 		rc = -DER_SHMEM_PERMS;
 		goto failure;
 	}
 
-	d_tm_shmem_idx = (uint8_t *)d_tm_shmem_root;
-	d_tm_shmem_free = mem_size;
+	rc = alloc_ctx(&tm_shmem.dts_ctx, new_shmem);
+	if (rc != 0)
+		goto failure;
+
 	D_DEBUG(DB_TRACE, "Shared memory allocation success!\n"
 		"Memory size is %" PRIu64 " bytes at address 0x%" PRIx64
-		"\n", mem_size, (uint64_t)d_tm_shmem_root);
-	/**
-	 * Store the base address of the shared memory as seen by the
-	 * server in this first uint64_t sized slot.
-	 * Used by the client to adjust pointers in the shared memory
-	 * to its own address space.
-	 */
-	base_addr = d_tm_shmalloc(sizeof(uint64_t));
-	if (base_addr == NULL) {
-		rc = -DER_NO_SHMEM;
-		goto failure;
-	}
-	*base_addr = (uint64_t)d_tm_shmem_root;
+		"\n", mem_size, new_shmem->sh_base_addr);
 
 	snprintf(tmp, sizeof(tmp), "ID: %d", id);
-	rc = d_tm_alloc_node(&d_tm_root, tmp);
+	rc = d_tm_alloc_node(new_shmem, &tm_shmem.dts_root, tmp);
 	if (rc != DER_SUCCESS)
 		goto failure;
 
-	rc = D_MUTEX_INIT(&d_tm_add_lock, NULL);
+	new_shmem->sh_root = tm_shmem.dts_root;
+
+	rc = D_MUTEX_INIT(&tm_shmem.dts_add_lock, NULL);
 	if (rc != 0) {
 		D_ERROR("Mutex init failure: " DF_RC "\n", DP_RC(rc));
 		goto failure;
@@ -304,81 +340,39 @@ d_tm_init(int id, uint64_t mem_size, int flags)
 failure:
 	D_ERROR("Failed to initialize telemetry and metrics for ID %u: "
 		DF_RC "\n", id, DP_RC(rc));
+	d_tm_close(&tm_shmem.dts_ctx);
 	return rc;
 }
 
 /**
  * Releases resources claimed by init
  */
-void d_tm_fini(void)
+void
+d_tm_fini(void)
 {
-	int	rc = 0;
+	int		rc;
+	bool		needs_cleanup = false;
+	uint32_t	shmid = 0;
 
-	if (d_tm_shmem_root == NULL)
-		return;
+	if (tm_shmem.dts_ctx == NULL)
+		goto out;
 
-	rc = shmdt(d_tm_shmem_root);
-	if (rc < 0)
-		D_ERROR("Unable to detach from shared memory segment.  "
-			"shmdt failed, %s.\n", strerror(errno));
+	if (tm_shmem.dts_ctx->shmem_root != NULL) {
+		shmid = tm_shmem.dts_ctx->shmem_root->sh_id;
+		if (!tm_shmem.dts_retain)
+			needs_cleanup = true;
+	}
 
-	if ((rc == 0) && !d_tm_retain_shmem) {
-		rc = shmctl(d_tm_shmid, IPC_RMID, NULL);
+	d_tm_close(&tm_shmem.dts_ctx);
+
+	if (needs_cleanup) {
+		rc = shmctl(shmid, IPC_RMID, NULL);
 		if (rc < 0)
 			D_ERROR("Unable to remove shared memory segment.  "
 				"shmctl failed, %s.\n", strerror(errno));
 	}
-
-	d_tm_serialization = false;
-	d_tm_retain_shmem = false;
-	d_tm_shmem_root = NULL;
-	d_tm_root = NULL;
-	d_tm_shmem_idx = NULL;
-	d_tm_shmid = 0;
-}
-
-/**
- * Recursively free resources underneath the given node.
- *
- * \param[in]	shmem_root	Pointer to the shared memory segment
- * \param[in]	node		Pointer to the node containing the resources
- *				to free
- */
-void
-d_tm_free_node(uint64_t *shmem_root, struct d_tm_node_t *node)
-{
-	char	*name;
-	int	rc = 0;
-
-	if (node == NULL)
-		return;
-
-	if (!d_tm_serialization)
-		return;
-
-	if (node->dtn_type != D_TM_DIRECTORY) {
-		rc = D_MUTEX_DESTROY(&node->dtn_lock);
-		if (rc != 0) {
-			name = d_tm_conv_ptr(shmem_root, node->dtn_name);
-			D_ERROR("Failed to destroy mutex for node [%s]: "
-				DF_RC "\n", name, DP_RC(rc));
-			return;
-		}
-	}
-
-	node = node->dtn_child;
-	node = d_tm_conv_ptr(shmem_root, node);
-	if (node == NULL)
-		return;
-
-	d_tm_free_node(shmem_root, node);
-	node = node->dtn_sibling;
-	node = d_tm_conv_ptr(shmem_root, node);
-	while (node != NULL) {
-		d_tm_free_node(shmem_root, node);
-		node = node->dtn_sibling;
-		node = d_tm_conv_ptr(shmem_root, node);
-	}
+out:
+	memset(&tm_shmem, 0, sizeof(tm_shmem));
 }
 
 /**
@@ -680,7 +674,7 @@ d_tm_print_metadata(char *desc, char *units, int format, FILE *stream)
  * Prints a single \a node.
  * Used as a convenience function to demonstrate usage for the client
  *
- * \param[in]	shmem_root	Pointer to the shared memory segment
+ * \param[in]	ctx		Client context
  * \param[in]	node		Pointer to a parent or child node
  * \param[in]	level		Indicates level of indentation when printing
  *				this \a node
@@ -696,7 +690,7 @@ d_tm_print_metadata(char *desc, char *units, int format, FILE *stream)
  * \param[in]	stream		Direct output to this stream (stdout, stderr)
  */
 void
-d_tm_print_node(uint64_t *shmem_root, struct d_tm_node_t *node, int level,
+d_tm_print_node(struct d_tm_context *ctx, struct d_tm_node_t *node, int level,
 		char *path, int format, int opt_fields, FILE *stream)
 {
 	struct d_tm_stats_t	stats = {0};
@@ -714,7 +708,10 @@ d_tm_print_node(uint64_t *shmem_root, struct d_tm_node_t *node, int level,
 	int			i = 0;
 	int			rc;
 
-	name = d_tm_conv_ptr(shmem_root, node->dtn_name);
+	if (node == NULL)
+		return;
+
+	name = d_tm_conv_ptr(ctx, node->dtn_name);
 	if (name == NULL)
 		return;
 
@@ -739,7 +736,7 @@ d_tm_print_node(uint64_t *shmem_root, struct d_tm_node_t *node, int level,
 			fprintf(stream, "%s, ", timestamp);
 	}
 
-	d_tm_get_metadata(&desc, &units, shmem_root, node);
+	d_tm_get_metadata(ctx, &desc, &units, node);
 
 	switch (node->dtn_type) {
 	case D_TM_DIRECTORY:
@@ -752,7 +749,7 @@ d_tm_print_node(uint64_t *shmem_root, struct d_tm_node_t *node, int level,
 			fprintf(stream, "%-20s\n", name);
 		break;
 	case D_TM_COUNTER:
-		rc = d_tm_get_counter(&val, shmem_root, node);
+		rc = d_tm_get_counter(ctx, &val, node);
 		if (rc != DER_SUCCESS) {
 			fprintf(stream, "Error on counter read: %d\n", rc);
 			break;
@@ -761,7 +758,7 @@ d_tm_print_node(uint64_t *shmem_root, struct d_tm_node_t *node, int level,
 				   stream);
 		break;
 	case D_TM_TIMESTAMP:
-		rc = d_tm_get_timestamp(&clk, shmem_root, node);
+		rc = d_tm_get_timestamp(ctx, &clk, node);
 		if (rc != DER_SUCCESS) {
 			fprintf(stream, "Error on timestamp read: %d\n", rc);
 			break;
@@ -771,7 +768,7 @@ d_tm_print_node(uint64_t *shmem_root, struct d_tm_node_t *node, int level,
 	case (D_TM_TIMER_SNAPSHOT | D_TM_CLOCK_REALTIME):
 	case (D_TM_TIMER_SNAPSHOT | D_TM_CLOCK_PROCESS_CPUTIME):
 	case (D_TM_TIMER_SNAPSHOT | D_TM_CLOCK_THREAD_CPUTIME):
-		rc = d_tm_get_timer_snapshot(&tms, shmem_root, node);
+		rc = d_tm_get_timer_snapshot(ctx, &tms, node);
 		if (rc != DER_SUCCESS) {
 			fprintf(stream, "Error on highres timer read: %d\n",
 				rc);
@@ -783,7 +780,7 @@ d_tm_print_node(uint64_t *shmem_root, struct d_tm_node_t *node, int level,
 	case (D_TM_DURATION | D_TM_CLOCK_REALTIME):
 	case (D_TM_DURATION | D_TM_CLOCK_PROCESS_CPUTIME):
 	case (D_TM_DURATION | D_TM_CLOCK_THREAD_CPUTIME):
-		rc = d_tm_get_duration(&tms, &stats, shmem_root, node);
+		rc = d_tm_get_duration(ctx, &tms, &stats, node);
 		if (rc != DER_SUCCESS) {
 			fprintf(stream, "Error on duration read: %d\n", rc);
 			break;
@@ -794,7 +791,7 @@ d_tm_print_node(uint64_t *shmem_root, struct d_tm_node_t *node, int level,
 			stats_printed = true;
 		break;
 	case D_TM_GAUGE:
-		rc = d_tm_get_gauge(&val, &stats, shmem_root, node);
+		rc = d_tm_get_gauge(ctx, &val, &stats, node);
 		if (rc != DER_SUCCESS) {
 			fprintf(stream, "Error on gauge read: %d\n", rc);
 			break;
@@ -864,7 +861,7 @@ d_tm_print_stats(FILE *stream, struct d_tm_stats_t *stats, int format)
  * Recursively prints all nodes underneath the given \a node.
  * Used as a convenience function to demonstrate usage for the client
  *
- * \param[in]	shmem_root	Pointer to the shared memory segment
+ * \param[in]	ctx		Client context
  * \param[in]	node		Pointer to a parent or child node
  * \param[in]	level		Indicates level of indentation when printing
  *				this \a node
@@ -881,7 +878,7 @@ d_tm_print_stats(FILE *stream, struct d_tm_stats_t *stats, int format)
  * \param[in]	stream		Direct output to this stream (stdout, stderr)
  */
 void
-d_tm_print_my_children(uint64_t *shmem_root, struct d_tm_node_t *node,
+d_tm_print_my_children(struct d_tm_context *ctx, struct d_tm_node_t *node,
 		       int level, int filter, char *path, int format,
 		       int opt_fields, FILE *stream)
 {
@@ -893,16 +890,16 @@ d_tm_print_my_children(uint64_t *shmem_root, struct d_tm_node_t *node,
 		return;
 
 	if (node->dtn_type & filter)
-		d_tm_print_node(shmem_root, node, level, path, format,
+		d_tm_print_node(ctx, node, level, path, format,
 				opt_fields, stream);
-	parent_name = d_tm_conv_ptr(shmem_root, node->dtn_name);
+	parent_name = d_tm_conv_ptr(ctx, node->dtn_name);
 	node = node->dtn_child;
-	node = d_tm_conv_ptr(shmem_root, node);
+	node = d_tm_conv_ptr(ctx, node);
 	if (node == NULL)
 		return;
 
 	while (node != NULL) {
-		node_name = d_tm_conv_ptr(shmem_root, node->dtn_name);
+		node_name = d_tm_conv_ptr(ctx, node->dtn_name);
 		if (node_name == NULL)
 			break;
 
@@ -912,11 +909,11 @@ d_tm_print_my_children(uint64_t *shmem_root, struct d_tm_node_t *node,
 		else
 			D_ASPRINTF(fullpath, "%s/%s", path, parent_name);
 
-		d_tm_print_my_children(shmem_root, node, level + 1, filter,
+		d_tm_print_my_children(ctx, node, level + 1, filter,
 				       fullpath, format, opt_fields, stream);
 		D_FREE_PTR(fullpath);
 		node = node->dtn_sibling;
-		node = d_tm_conv_ptr(shmem_root, node);
+		node = d_tm_conv_ptr(ctx, node);
 	}
 }
 
@@ -949,7 +946,7 @@ d_tm_print_field_descriptors(int opt_fields, FILE *stream)
 /**
  * Recursively counts number of metrics at and underneath the given \a node.
  *
- * \param[in]	shmem_root	Pointer to the shared memory segment
+ * \param[in]	ctx		Telemetry context
  * \param[in]	node		Pointer to a parent or child node
  * \param[in]	d_tm_type	A bitmask of d_tm_metric_types that
  *				determines if an item should be counted
@@ -957,10 +954,10 @@ d_tm_print_field_descriptors(int opt_fields, FILE *stream)
  * \return			Number of metrics found
  */
 uint64_t
-d_tm_count_metrics(uint64_t *shmem_root, struct d_tm_node_t *node,
+d_tm_count_metrics(struct d_tm_context *ctx, struct d_tm_node_t *node,
 		   int d_tm_type)
 {
-	uint64_t	count = 0;
+	uint64_t count = 0;
 
 	if (node == NULL)
 		return 0;
@@ -969,17 +966,12 @@ d_tm_count_metrics(uint64_t *shmem_root, struct d_tm_node_t *node,
 		count++;
 
 	node = node->dtn_child;
-	node = d_tm_conv_ptr(shmem_root, node);
-	if (node == NULL)
-		return count;
+	node = d_tm_conv_ptr(ctx, node);
 
-	count += d_tm_count_metrics(shmem_root, node, d_tm_type);
-	node = node->dtn_sibling;
-	node = d_tm_conv_ptr(shmem_root, node);
 	while (node != NULL) {
-		count += d_tm_count_metrics(shmem_root, node, d_tm_type);
+		count += d_tm_count_metrics(ctx, node, d_tm_type);
 		node = node->dtn_sibling;
-		node = d_tm_conv_ptr(shmem_root, node);
+		node = d_tm_conv_ptr(ctx, node);
 	}
 	return count;
 }
@@ -1081,7 +1073,7 @@ d_tm_node_unlock(struct d_tm_node_t *node) {
 void
 d_tm_set_counter(struct d_tm_node_t *metric, uint64_t value)
 {
-	if (unlikely(d_tm_shmem_root == NULL || metric == NULL))
+	if (unlikely(metric == NULL))
 		return;
 
 	if (unlikely(metric->dtn_type != D_TM_COUNTER)) {
@@ -1105,7 +1097,7 @@ void
 d_tm_inc_counter(struct d_tm_node_t *metric, uint64_t value)
 {
 
-	if (unlikely(d_tm_shmem_root == NULL || metric == NULL))
+	if (unlikely(metric == NULL))
 		return;
 
 	if (unlikely(metric->dtn_type != D_TM_COUNTER)) {
@@ -1127,7 +1119,7 @@ d_tm_inc_counter(struct d_tm_node_t *metric, uint64_t value)
 void
 d_tm_record_timestamp(struct d_tm_node_t *metric)
 {
-	if (metric == NULL || d_tm_shmem_root == NULL)
+	if (metric == NULL)
 		return;
 
 	if (metric->dtn_type != D_TM_TIMESTAMP) {
@@ -1151,7 +1143,7 @@ d_tm_record_timestamp(struct d_tm_node_t *metric)
 void
 d_tm_take_timer_snapshot(struct d_tm_node_t *metric, int clk_id)
 {
-	if (metric == NULL || d_tm_shmem_root == NULL)
+	if (metric == NULL)
 		return;
 
 	if (!(metric->dtn_type & D_TM_TIMER_SNAPSHOT)) {
@@ -1177,7 +1169,7 @@ d_tm_take_timer_snapshot(struct d_tm_node_t *metric, int clk_id)
 void
 d_tm_mark_duration_start(struct d_tm_node_t *metric, int clk_id)
 {
-	if (d_tm_shmem_root == NULL || metric == NULL)
+	if (metric == NULL)
 		return;
 
 	if (!(metric->dtn_type & D_TM_DURATION)) {
@@ -1207,7 +1199,7 @@ d_tm_mark_duration_end(struct d_tm_node_t *metric)
 	struct timespec	*tms;
 	uint64_t	us;
 
-	if (d_tm_shmem_root == NULL || metric == NULL)
+	if (metric == NULL)
 		return;
 
 	if (!(metric->dtn_type & D_TM_DURATION)) {
@@ -1237,7 +1229,7 @@ d_tm_mark_duration_end(struct d_tm_node_t *metric)
 void
 d_tm_set_gauge(struct d_tm_node_t *metric, uint64_t value)
 {
-	if (d_tm_shmem_root == NULL || metric == NULL)
+	if (metric == NULL)
 		return;
 
 	if (metric->dtn_type != D_TM_GAUGE) {
@@ -1263,7 +1255,7 @@ d_tm_set_gauge(struct d_tm_node_t *metric, uint64_t value)
 void
 d_tm_inc_gauge(struct d_tm_node_t *metric, uint64_t value)
 {
-	if (d_tm_shmem_root == NULL || metric == NULL)
+	if (metric == NULL)
 		return;
 
 	if (metric->dtn_type != D_TM_GAUGE) {
@@ -1289,7 +1281,7 @@ d_tm_inc_gauge(struct d_tm_node_t *metric, uint64_t value)
 void
 d_tm_dec_gauge(struct d_tm_node_t *metric, uint64_t value)
 {
-	if (d_tm_shmem_root == NULL || metric == NULL)
+	if (metric == NULL)
 		return;
 
 	if (metric->dtn_type != D_TM_GAUGE) {
@@ -1353,13 +1345,13 @@ d_tm_clock_string(int clk_id) {
 /**
  * Finds the node pointing to the given metric described by path name provided
  *
- * \param[in]	shmem_root	Pointer to the shared memory segment
- * \param[in]	path		The full name of the metric to find
+ * \param[in]	ctx	Telemetry context
+ * \param[in]	path	The full name of the metric to find
  *
- * \return			A pointer to the metric node
+ * \return		A pointer to the metric node
  */
 struct d_tm_node_t *
-d_tm_find_metric(uint64_t *shmem_root, char *path)
+d_tm_find_metric(struct d_tm_context *ctx, char *path)
 {
 	struct d_tm_node_t	*parent_node;
 	struct d_tm_node_t	*node = NULL;
@@ -1367,10 +1359,10 @@ d_tm_find_metric(uint64_t *shmem_root, char *path)
 	char			*token;
 	char			*rest = str;
 
-	if ((shmem_root == NULL) || (path == NULL))
+	if ((ctx == NULL) || (path == NULL))
 		return NULL;
 
-	parent_node = d_tm_get_root(shmem_root);
+	parent_node = d_tm_get_root(ctx);
 
 	if (parent_node == NULL)
 		return NULL;
@@ -1378,7 +1370,7 @@ d_tm_find_metric(uint64_t *shmem_root, char *path)
 	snprintf(str, sizeof(str), "%s", path);
 	token = strtok_r(rest, "/", &rest);
 	while (token != NULL) {
-		node = d_tm_find_child(shmem_root, parent_node, token);
+		node = d_tm_find_child(ctx, parent_node, token);
 		if (node == NULL)
 			return NULL;
 		parent_node =  node;
@@ -1421,7 +1413,8 @@ int d_tm_add_metric(struct d_tm_node_t **node, int metric_type, char *desc,
 {
 	pthread_mutexattr_t	mattr;
 	struct d_tm_node_t	*parent_node;
-	struct d_tm_node_t	*temp;
+	struct d_tm_node_t	*temp = NULL;
+	struct d_tm_shmem_hdr	*shmem;
 	char			path[D_TM_MAX_NAME_LEN] = {};
 	char			*token;
 	char			*rest;
@@ -1431,7 +1424,7 @@ int d_tm_add_metric(struct d_tm_node_t **node, int metric_type, char *desc,
 	int			ret;
 	va_list			args;
 
-	if (d_tm_shmem_root == NULL)
+	if (tm_shmem.dts_ctx == NULL || tm_shmem.dts_ctx->shmem_root == NULL)
 		return -DER_UNINIT;
 
 	if (node == NULL)
@@ -1440,7 +1433,7 @@ int d_tm_add_metric(struct d_tm_node_t **node, int metric_type, char *desc,
 	if (fmt == NULL)
 		return -DER_INVAL;
 
-	rc = D_MUTEX_LOCK(&d_tm_add_lock);
+	rc = d_tm_lock_shmem();
 	if (rc != 0) {
 		D_ERROR("Failed to get mutex: " DF_RC "\n", DP_RC(rc));
 		goto failure;
@@ -1462,17 +1455,19 @@ int d_tm_add_metric(struct d_tm_node_t **node, int metric_type, char *desc,
 	 * which leads to this d_tm_add_metric() call.
 	 * If the metric is found, it's not an error.  Just return.
 	 */
-	*node = d_tm_find_metric(d_tm_shmem_root, path);
+	*node = d_tm_find_metric(tm_shmem.dts_ctx, path);
 	if (*node != NULL) {
-		D_MUTEX_UNLOCK(&d_tm_add_lock);
+		d_tm_unlock_shmem();
 		return DER_SUCCESS;
 	}
 
 	rest = path;
-	parent_node = d_tm_get_root(d_tm_shmem_root);
+	parent_node = d_tm_get_root(tm_shmem.dts_ctx);
 	token = strtok_r(rest, "/", &rest);
 	while (token != NULL) {
-		temp = d_tm_find_child(d_tm_shmem_root, parent_node, token);
+		temp = d_tm_find_child(tm_shmem.dts_ctx,
+				       parent_node,
+				       token);
 		if (temp == NULL) {
 			rc = d_tm_add_child(&temp, parent_node, token);
 			if (rc != DER_SUCCESS)
@@ -1488,8 +1483,10 @@ int d_tm_add_metric(struct d_tm_node_t **node, int metric_type, char *desc,
 		goto failure;
 	}
 
+	shmem = temp->dtn_region;
+
 	temp->dtn_type = metric_type;
-	temp->dtn_metric = d_tm_shmalloc(sizeof(struct d_tm_metric_t));
+	temp->dtn_metric = d_tm_shmalloc(shmem, sizeof(struct d_tm_metric_t));
 	if (temp->dtn_metric == NULL) {
 		rc = -DER_NO_SHMEM;
 		goto failure;
@@ -1498,7 +1495,8 @@ int d_tm_add_metric(struct d_tm_node_t **node, int metric_type, char *desc,
 	temp->dtn_metric->dtm_stats = NULL;
 	if ((metric_type == D_TM_GAUGE) || (metric_type & D_TM_DURATION)) {
 		temp->dtn_metric->dtm_stats =
-				     d_tm_shmalloc(sizeof(struct d_tm_stats_t));
+				     d_tm_shmalloc(shmem,
+						   sizeof(struct d_tm_stats_t));
 		if (temp->dtn_metric->dtm_stats == NULL) {
 			rc = -DER_NO_SHMEM;
 			goto failure;
@@ -1517,7 +1515,7 @@ int d_tm_add_metric(struct d_tm_node_t **node, int metric_type, char *desc,
 
 	if (buff_len > 0) {
 		buff_len += 1; /** make room for the trailing null */
-		temp->dtn_metric->dtm_desc = d_tm_shmalloc(buff_len);
+		temp->dtn_metric->dtm_desc = d_tm_shmalloc(shmem, buff_len);
 		if (temp->dtn_metric->dtm_desc == NULL) {
 			rc = -DER_NO_SHMEM;
 			goto failure;
@@ -1558,7 +1556,7 @@ int d_tm_add_metric(struct d_tm_node_t **node, int metric_type, char *desc,
 
 	if (buff_len > 0) {
 		buff_len += 1; /** make room for the trailing null */
-		temp->dtn_metric->dtm_units = d_tm_shmalloc(buff_len);
+		temp->dtn_metric->dtm_units = d_tm_shmalloc(shmem, buff_len);
 		if (temp->dtn_metric->dtm_units == NULL) {
 			rc = -DER_NO_SHMEM;
 			goto failure;
@@ -1569,7 +1567,8 @@ int d_tm_add_metric(struct d_tm_node_t **node, int metric_type, char *desc,
 	}
 
 	temp->dtn_protect = false;
-	if (d_tm_serialization && (temp->dtn_type != D_TM_DIRECTORY)) {
+	if (tm_shmem.dts_sync_access &&
+	    (temp->dtn_type != D_TM_DIRECTORY)) {
 		rc = pthread_mutexattr_init(&mattr);
 		if (rc != 0) {
 			D_ERROR("pthread_mutexattr_init failed: " DF_RC "\n",
@@ -1597,12 +1596,11 @@ int d_tm_add_metric(struct d_tm_node_t **node, int metric_type, char *desc,
 	*node = temp;
 
 	D_DEBUG(DB_TRACE, "successfully added item: [%s]\n", path);
-	D_MUTEX_UNLOCK(&d_tm_add_lock);
+	d_tm_unlock_shmem();
 	return DER_SUCCESS;
 
 failure:
-	D_MUTEX_UNLOCK(&d_tm_add_lock);
-	*node = NULL;
+	d_tm_unlock_shmem();
 	D_ERROR("Failed to add metric [%s]: " DF_RC "\n", path, DP_RC(rc));
 	return rc;
 }
@@ -1646,7 +1644,9 @@ d_tm_init_histogram(struct d_tm_node_t *node, char *path, int num_buckets,
 		    int initial_width, int multiplier)
 {
 	struct d_tm_metric_t	*metric;
+	struct d_tm_histogram_t	*histogram;
 	struct d_tm_bucket_t	*dth_buckets;
+	struct d_tm_shmem_hdr	*shmem;
 	uint64_t		min = 0;
 	uint64_t		max = 0;
 	uint64_t		prev_width = 0;
@@ -1674,33 +1674,36 @@ d_tm_init_histogram(struct d_tm_node_t *node, char *path, int num_buckets,
 	      (node->dtn_type & D_TM_DURATION)))
 		return -DER_OP_NOT_PERMITTED;
 
-	rc = D_MUTEX_LOCK(&d_tm_add_lock);
+	rc = d_tm_lock_shmem();
 	if (rc != 0) {
 		D_ERROR("Failed to get mutex: " DF_RC "\n", DP_RC(rc));
 		goto failure;
 	}
 
+	shmem = node->dtn_region;
 	metric = node->dtn_metric;
+	histogram = d_tm_shmalloc(shmem, sizeof(struct d_tm_histogram_t));
 
-	metric->dtm_histogram = d_tm_shmalloc(sizeof(struct d_tm_histogram_t));
-	if (metric->dtm_histogram == NULL) {
-		D_MUTEX_UNLOCK(&d_tm_add_lock);
+	if (histogram == NULL) {
+		d_tm_unlock_shmem();
 		rc = -DER_NO_SHMEM;
 		goto failure;
 	}
 
-	metric->dtm_histogram->dth_buckets = d_tm_shmalloc(num_buckets *
-						  sizeof(struct d_tm_bucket_t));
-	if (metric->dtm_histogram->dth_buckets == NULL) {
-		D_MUTEX_UNLOCK(&d_tm_add_lock);
+	histogram->dth_buckets = d_tm_shmalloc(shmem, num_buckets *
+					       sizeof(struct d_tm_bucket_t));
+	if (histogram->dth_buckets == NULL) {
+		d_tm_unlock_shmem();
 		rc = -DER_NO_SHMEM;
 		goto failure;
 	}
-	metric->dtm_histogram->dth_num_buckets = num_buckets;
-	metric->dtm_histogram->dth_initial_width = initial_width;
-	metric->dtm_histogram->dth_value_multiplier = multiplier;
+	histogram->dth_num_buckets = num_buckets;
+	histogram->dth_initial_width = initial_width;
+	histogram->dth_value_multiplier = multiplier;
 
-	D_MUTEX_UNLOCK(&d_tm_add_lock);
+	metric->dtm_histogram = histogram;
+
+	d_tm_unlock_shmem();
 
 	dth_buckets = metric->dtm_histogram->dth_buckets;
 
@@ -1757,34 +1760,35 @@ failure:
  * the number of buckets, initial width and multiplier used to create the
  * given histogram.
  *
- * \param[in,out]	histogram	Pointer to a d_tm_histogram_t used to
- *					store the results.
- * \param[in]		shmem_root	Pointer to the shared memory segment.
- * \param[in]		node		Pointer to the metric node with a
- *					histogram.
+ * \param[in]	ctx		Client context
+ * \param[out]	histogram	Pointer to a d_tm_histogram_t used to
+ *				store the results.
+ * \param[in]	node		Pointer to the metric node with a
+ *				histogram.
  *
- * \return			DER_SUCCESS		Success
- *				-DER_INVAL		node or histogram is
- *							invalid.
- *				-DER_METRIC_NOT_FOUND	The metric node, the
- *							metric data or histogram
- *							was not found.
- *				-DER_OP_NOT_PERMITTED	Node was not a gauge
- *							or duration with
- *							an associated histogram.
+ * \return	DER_SUCCESS		Success
+ *		-DER_INVAL		node or histogram is
+ *					invalid.
+ *		-DER_METRIC_NOT_FOUND	The metric node, the
+ *					metric data or histogram
+ *					was not found.
+ *		-DER_OP_NOT_PERMITTED	Node was not a gauge
+ *					or duration with
+ *					an associated histogram.
  */
 int
-d_tm_get_num_buckets(struct d_tm_histogram_t *histogram,
-		     uint64_t *shmem_root, struct d_tm_node_t *node)
+d_tm_get_num_buckets(struct d_tm_context *ctx,
+		     struct d_tm_histogram_t *histogram,
+		     struct d_tm_node_t *node)
 {
 	struct d_tm_histogram_t	*dtm_histogram = NULL;
 	struct d_tm_metric_t	*metric_data = NULL;
+	struct d_tm_shmem_hdr	*shmem_root;
 
-	if (node == NULL)
+	if (ctx == NULL || histogram == NULL || node == NULL)
 		return -DER_INVAL;
 
-	if (histogram == NULL)
-		return -DER_INVAL;
+	shmem_root = ctx->shmem_root;
 
 	if (!d_tm_validate_shmem_ptr(shmem_root, (void *)node))
 		return -DER_METRIC_NOT_FOUND;
@@ -1793,11 +1797,11 @@ d_tm_get_num_buckets(struct d_tm_histogram_t *histogram,
 	      (node->dtn_type & D_TM_DURATION)))
 		return -DER_OP_NOT_PERMITTED;
 
-	metric_data = d_tm_conv_ptr(shmem_root, node->dtn_metric);
+	metric_data = d_tm_conv_ptr(ctx, node->dtn_metric);
 	if (metric_data == NULL)
 		return -DER_METRIC_NOT_FOUND;
 
-	dtm_histogram = d_tm_conv_ptr(shmem_root, metric_data->dtm_histogram);
+	dtm_histogram = d_tm_conv_ptr(ctx, metric_data->dtm_histogram);
 	if (dtm_histogram == NULL)
 		return -DER_METRIC_NOT_FOUND;
 
@@ -1811,40 +1815,41 @@ d_tm_get_num_buckets(struct d_tm_histogram_t *histogram,
 /**
  * Retrieves the range of the given bucket for the node with a histogram.
  *
- * \param[in,out]	bucket		Pointer to a d_tm_bucket_t used to
- *					store the results.
- * \param[in]		bucket_id	Identifies which bucket (0 .. n-1)
- * \param[in]		shmem_root	Pointer to the shared memory segment.
- * \param[in]		node		Pointer to the metric node with a
- *					histogram.
+ * \param[in]	ctx		Client context
+ * \param[out]	bucket		Pointer to a d_tm_bucket_t used to
+ *				store the results.
+ * \param[in]	bucket_id	Identifies which bucket (0 .. n-1)
+ * \param[in]	node		Pointer to the metric node with a
+ *				histogram.
  *
- * \return			DER_SUCCESS		Success
- *				-DER_INVAL		node, bucket, or bucket
- *							ID is invalid.
- *				-DER_METRIC_NOT_FOUND	The metric node, the
- *							metric data, histogram
- *							or bucket data was
- *							not found.
- *				-DER_OP_NOT_PERMITTED	Node was not a gauge
- *							or duration with
- *							an associated histogram.
+ * \return	DER_SUCCESS		Success
+ *		-DER_INVAL		node, bucket, or bucket
+ *					ID is invalid.
+ *		-DER_METRIC_NOT_FOUND	The metric node, the
+ *					metric data, histogram
+ *					or bucket data was
+ *					not found.
+ *		-DER_OP_NOT_PERMITTED	Node was not a gauge
+ *					or duration with
+ *					an associated histogram.
  */
 int
-d_tm_get_bucket_range(struct d_tm_bucket_t *bucket, int bucket_id,
-		      uint64_t *shmem_root, struct d_tm_node_t *node)
+d_tm_get_bucket_range(struct d_tm_context *ctx, struct d_tm_bucket_t *bucket,
+		      int bucket_id,
+		      struct d_tm_node_t *node)
 {
 	struct d_tm_histogram_t	*dtm_histogram = NULL;
 	struct d_tm_bucket_t	*dth_bucket = NULL;
 	struct d_tm_metric_t	*metric_data = NULL;
+	struct d_tm_shmem_hdr	*shmem_root;
 
-	if (node == NULL)
-		return -DER_INVAL;
-
-	if (bucket == NULL)
+	if (ctx == NULL || node == NULL || bucket == NULL)
 		return -DER_INVAL;
 
 	if (bucket_id < 0)
 		return -DER_INVAL;
+
+	shmem_root = ctx->shmem_root;
 
 	if (!d_tm_validate_shmem_ptr(shmem_root, (void *)node))
 		return -DER_METRIC_NOT_FOUND;
@@ -1853,24 +1858,24 @@ d_tm_get_bucket_range(struct d_tm_bucket_t *bucket, int bucket_id,
 	      (node->dtn_type & D_TM_DURATION)))
 		return -DER_OP_NOT_PERMITTED;
 
-	metric_data = d_tm_conv_ptr(shmem_root, node->dtn_metric);
+	metric_data = d_tm_conv_ptr(ctx, node->dtn_metric);
 	if (metric_data == NULL)
 		return -DER_METRIC_NOT_FOUND;
 
-	dtm_histogram = d_tm_conv_ptr(shmem_root, metric_data->dtm_histogram);
+	dtm_histogram = d_tm_conv_ptr(ctx, metric_data->dtm_histogram);
 	if (dtm_histogram == NULL)
 		return -DER_METRIC_NOT_FOUND;
 
 	if (bucket_id >= dtm_histogram->dth_num_buckets)
 		return -DER_INVAL;
 
-	dth_bucket = d_tm_conv_ptr(shmem_root, dtm_histogram->dth_buckets);
+	dth_bucket = d_tm_conv_ptr(ctx, dtm_histogram->dth_buckets);
 	if (dth_bucket == NULL)
 		return -DER_METRIC_NOT_FOUND;
 
 	bucket->dtb_min = dth_bucket[bucket_id].dtb_min;
 	bucket->dtb_max = dth_bucket[bucket_id].dtb_max;
-	bucket->dtb_bucket = d_tm_conv_ptr(shmem_root,
+	bucket->dtb_bucket = d_tm_conv_ptr(ctx,
 					   dth_bucket[bucket_id].dtb_bucket);
 	return DER_SUCCESS;
 }
@@ -1878,25 +1883,26 @@ d_tm_get_bucket_range(struct d_tm_bucket_t *bucket, int bucket_id,
 /**
  * Client function to read the specified counter.
  *
- * \param[in,out]	val		The value of the counter is stored here
- * \param[in]		shmem_root	Pointer to the shared memory segment
- * \param[in]		node		Pointer to the stored metric node
+ * \param[in]	ctx	Client context
+ * \param[out]	val	The value of the counter is stored here
+ * \param[in]	node	Pointer to the stored metric node
  *
- * \return		DER_SUCCESS		Success
- *			-DER_INVAL		Invalid input
- *			-DER_METRIC_NOT_FOUND	Metric not found
- *			-DER_OP_NOT_PERMITTED	Metric was not a counter
+ * \return	DER_SUCCESS		Success
+ *		-DER_INVAL		Invalid input
+ *		-DER_METRIC_NOT_FOUND	Metric not found
+ *		-DER_OP_NOT_PERMITTED	Metric was not a counter
  */
 int
-d_tm_get_counter(uint64_t *val, uint64_t *shmem_root, struct d_tm_node_t *node)
+d_tm_get_counter(struct d_tm_context *ctx, uint64_t *val,
+		 struct d_tm_node_t *node)
 {
 	struct d_tm_metric_t	*metric_data = NULL;
+	struct d_tm_shmem_hdr	*shmem_root;
 
-	if (val == NULL)
+	if (ctx == NULL || val == NULL || node == NULL)
 		return -DER_INVAL;
 
-	if (node == NULL)
-		return -DER_INVAL;
+	shmem_root = ctx->shmem_root;
 
 	if (!d_tm_validate_shmem_ptr(shmem_root, (void *)node))
 		return -DER_METRIC_NOT_FOUND;
@@ -1904,7 +1910,7 @@ d_tm_get_counter(uint64_t *val, uint64_t *shmem_root, struct d_tm_node_t *node)
 	if (node->dtn_type != D_TM_COUNTER)
 		return -DER_OP_NOT_PERMITTED;
 
-	metric_data = d_tm_conv_ptr(shmem_root, node->dtn_metric);
+	metric_data = d_tm_conv_ptr(ctx, node->dtn_metric);
 	if (metric_data != NULL) {
 		if (node->dtn_protect)
 			D_MUTEX_LOCK(&node->dtn_lock);
@@ -1920,10 +1926,9 @@ d_tm_get_counter(uint64_t *val, uint64_t *shmem_root, struct d_tm_node_t *node)
 /**
  * Client function to read the specified timestamp.
  *
- * \param[in,out]	val		The value of the timestamp is stored
- *					here
- * \param[in]		shmem_root	Pointer to the shared memory segment
- * \param[in]		node		Pointer to the stored metric node
+ * \param[in]	ctx	Client context
+ * \param[out]	val	The value of the timestamp is stored here
+ * \param[in]	node	Pointer to the stored metric node
  *
  * \return		DER_SUCCESS		Success
  *			-DER_INVAL		Invalid input
@@ -1931,15 +1936,16 @@ d_tm_get_counter(uint64_t *val, uint64_t *shmem_root, struct d_tm_node_t *node)
  *			-DER_OP_NOT_PERMITTED	Metric was not a timestamp
  */
 int
-d_tm_get_timestamp(time_t *val, uint64_t *shmem_root, struct d_tm_node_t *node)
+d_tm_get_timestamp(struct d_tm_context *ctx, time_t *val,
+		   struct d_tm_node_t *node)
 {
 	struct d_tm_metric_t	*metric_data = NULL;
+	struct d_tm_shmem_hdr	*shmem_root;
 
-	if (val == NULL)
+	if (ctx == NULL || val == NULL || node == NULL)
 		return -DER_INVAL;
 
-	if (node == NULL)
-		return -DER_INVAL;
+	shmem_root = ctx->shmem_root;
 
 	if (!d_tm_validate_shmem_ptr(shmem_root, (void *)node))
 		return -DER_METRIC_NOT_FOUND;
@@ -1947,13 +1953,11 @@ d_tm_get_timestamp(time_t *val, uint64_t *shmem_root, struct d_tm_node_t *node)
 	if (node->dtn_type != D_TM_TIMESTAMP)
 		return -DER_OP_NOT_PERMITTED;
 
-	metric_data = d_tm_conv_ptr(shmem_root, node->dtn_metric);
+	metric_data = d_tm_conv_ptr(ctx, node->dtn_metric);
 	if (metric_data != NULL) {
-		if (node->dtn_protect)
-			D_MUTEX_LOCK(&node->dtn_lock);
+		d_tm_node_lock(node);
 		*val = metric_data->dtm_data.value;
-		if (node->dtn_protect)
-			D_MUTEX_UNLOCK(&node->dtn_lock);
+		d_tm_node_unlock(node);
 	} else {
 		return -DER_METRIC_NOT_FOUND;
 	}
@@ -1963,27 +1967,27 @@ d_tm_get_timestamp(time_t *val, uint64_t *shmem_root, struct d_tm_node_t *node)
 /**
  * Client function to read the specified high resolution timer.
  *
- * \param[in,out]	tms		The value of the timer is stored here
- * \param[in]		shmem_root	Pointer to the shared memory segment
- * \param[in]		node		Pointer to the stored metric node
+ * \param[in]	ctx	Client context
+ * \param[out]	tms	The value of the timer is stored here
+ * \param[in]	node	Pointer to the stored metric node
  *
- * \return		DER_SUCCESS		Success
- *			-DER_INVAL		Invalid input
- *			-DER_METRIC_NOT_FOUND	Metric not found
- *			-DER_OP_NOT_PERMITTED	Metric was not a high resolution
- *						timer
+ * \return	DER_SUCCESS		Success
+ *		-DER_INVAL		Invalid input
+ *		-DER_METRIC_NOT_FOUND	Metric not found
+ *		-DER_OP_NOT_PERMITTED	Metric was not a high resolution
+ *					timer
  */
 int
-d_tm_get_timer_snapshot(struct timespec *tms, uint64_t *shmem_root,
+d_tm_get_timer_snapshot(struct d_tm_context *ctx, struct timespec *tms,
 			struct d_tm_node_t *node)
 {
 	struct d_tm_metric_t	*metric_data = NULL;
+	struct d_tm_shmem_hdr	*shmem_root;
 
-	if (tms == NULL)
+	if (ctx == NULL || tms == NULL || node == NULL)
 		return -DER_INVAL;
 
-	if (node == NULL)
-		return -DER_INVAL;
+	shmem_root = ctx->shmem_root;
 
 	if (!d_tm_validate_shmem_ptr(shmem_root, (void *)node))
 		return -DER_METRIC_NOT_FOUND;
@@ -1991,14 +1995,12 @@ d_tm_get_timer_snapshot(struct timespec *tms, uint64_t *shmem_root,
 	if (!(node->dtn_type & D_TM_TIMER_SNAPSHOT))
 		return -DER_OP_NOT_PERMITTED;
 
-	metric_data = d_tm_conv_ptr(shmem_root, node->dtn_metric);
+	metric_data = d_tm_conv_ptr(ctx, node->dtn_metric);
 	if (metric_data != NULL) {
-		if (node->dtn_protect)
-			D_MUTEX_LOCK(&node->dtn_lock);
+		d_tm_node_lock(node);
 		tms->tv_sec = metric_data->dtm_data.tms[0].tv_sec;
 		tms->tv_nsec = metric_data->dtm_data.tms[0].tv_nsec;
-		if (node->dtn_protect)
-			D_MUTEX_UNLOCK(&node->dtn_lock);
+		d_tm_node_unlock(node);
 	} else {
 		return -DER_METRIC_NOT_FOUND;
 	}
@@ -2012,29 +2014,30 @@ d_tm_get_timer_snapshot(struct timespec *tms, uint64_t *shmem_root,
  * The computation of mean and standard deviation are completed upon this
  * read operation.
  *
- * \param[in,out]	tms		The value of the duration is stored here
- * \param[in,out]	stats		The statistics are stored here
- * \param[in]		shmem_root	Pointer to the shared memory segment
- * \param[in]		node		Pointer to the stored metric node
+ * \param[in]	ctx	Client context
+ * \param[out]	tms	The value of the duration is stored here
+ * \param[out]	stats	The statistics are stored here
+ * \param[in]	node	Pointer to the stored metric node
  *
- * \return		DER_SUCCESS		Success
- *			-DER_INVAL		Invalid input
- *			-DER_METRIC_NOT_FOUND	Metric not found
- *			-DER_OP_NOT_PERMITTED	Metric was not a duration
+ * \return	DER_SUCCESS		Success
+ *		-DER_INVAL		Invalid input
+ *		-DER_METRIC_NOT_FOUND	Metric not found
+ *		-DER_OP_NOT_PERMITTED	Metric was not a duration
  */
 int
-d_tm_get_duration(struct timespec *tms, struct d_tm_stats_t *stats,
-		  uint64_t *shmem_root, struct d_tm_node_t *node)
+d_tm_get_duration(struct d_tm_context *ctx, struct timespec *tms,
+		  struct d_tm_stats_t *stats,
+		  struct d_tm_node_t *node)
 {
 	struct d_tm_metric_t	*metric_data = NULL;
 	struct d_tm_stats_t	*dtm_stats = NULL;
 	double			sum = 0;
+	struct d_tm_shmem_hdr	*shmem_root;
 
-	if (tms == NULL)
+	if (ctx == NULL || tms == NULL || node == NULL)
 		return -DER_INVAL;
 
-	if (node == NULL)
-		return -DER_INVAL;
+	shmem_root = ctx->shmem_root;
 
 	if (!d_tm_validate_shmem_ptr(shmem_root, (void *)node))
 		return -DER_METRIC_NOT_FOUND;
@@ -2042,11 +2045,10 @@ d_tm_get_duration(struct timespec *tms, struct d_tm_stats_t *stats,
 	if (!(node->dtn_type & D_TM_DURATION))
 		return -DER_OP_NOT_PERMITTED;
 
-	metric_data = d_tm_conv_ptr(shmem_root, node->dtn_metric);
+	metric_data = d_tm_conv_ptr(ctx, node->dtn_metric);
 	if (metric_data != NULL) {
-		dtm_stats = d_tm_conv_ptr(shmem_root, metric_data->dtm_stats);
-		if (node->dtn_protect)
-			D_MUTEX_LOCK(&node->dtn_lock);
+		dtm_stats = d_tm_conv_ptr(ctx, metric_data->dtm_stats);
+		d_tm_node_lock(node);
 		tms->tv_sec = metric_data->dtm_data.tms[0].tv_sec;
 		tms->tv_nsec = metric_data->dtm_data.tms[0].tv_nsec;
 		if ((stats != NULL) && (dtm_stats != NULL)) {
@@ -2064,8 +2066,7 @@ d_tm_get_duration(struct timespec *tms, struct d_tm_stats_t *stats,
 			stats->sum_of_squares = dtm_stats->sum_of_squares;
 			stats->sample_size = dtm_stats->sample_size;
 		}
-		if (node->dtn_protect)
-			D_MUTEX_UNLOCK(&node->dtn_lock);
+		d_tm_node_unlock(node);
 	} else {
 		return -DER_METRIC_NOT_FOUND;
 	}
@@ -2079,30 +2080,30 @@ d_tm_get_duration(struct timespec *tms, struct d_tm_stats_t *stats,
  * The computation of mean and standard deviation are completed upon this
  * read operation.
  *
- * \param[in,out]	val		The value of the gauge is stored here
- * \param[in,out]	stats		The statistics are stored here
- * \param[in]		shmem_root	Pointer to the shared memory segment
- * \param[in]		node		Pointer to the stored metric node
+ * \param[in]	ctx	Client context
+ * \param[out]	val	The value of the gauge is stored here
+ * \param[out]	stats	The statistics are stored here
+ * \param[in]	node	Pointer to the stored metric node
  *
- * \return		DER_SUCCESS		Success
- *			-DER_INVAL		Invalid input
- *			-DER_METRIC_NOT_FOUND	Metric not found
- *			-DER_OP_NOT_PERMITTED	Metric was not a gauge
+ * \return	DER_SUCCESS		Success
+ *		-DER_INVAL		Invalid input
+ *		-DER_METRIC_NOT_FOUND	Metric not found
+ *		-DER_OP_NOT_PERMITTED	Metric was not a gauge
  */
 
 int
-d_tm_get_gauge(uint64_t *val, struct d_tm_stats_t *stats, uint64_t *shmem_root,
-	       struct d_tm_node_t *node)
+d_tm_get_gauge(struct d_tm_context *ctx, uint64_t *val,
+	       struct d_tm_stats_t *stats, struct d_tm_node_t *node)
 {
 	struct d_tm_metric_t	*metric_data = NULL;
 	struct d_tm_stats_t	*dtm_stats = NULL;
 	double			sum = 0;
+	struct d_tm_shmem_hdr	*shmem_root;
 
-	if (val == NULL)
+	if (ctx == NULL || val == NULL || node == NULL)
 		return -DER_INVAL;
 
-	if (node == NULL)
-		return -DER_INVAL;
+	shmem_root = ctx->shmem_root;
 
 	if (!d_tm_validate_shmem_ptr(shmem_root, (void *)node))
 		return -DER_METRIC_NOT_FOUND;
@@ -2110,11 +2111,10 @@ d_tm_get_gauge(uint64_t *val, struct d_tm_stats_t *stats, uint64_t *shmem_root,
 	if (node->dtn_type != D_TM_GAUGE)
 		return -DER_OP_NOT_PERMITTED;
 
-	metric_data = d_tm_conv_ptr(shmem_root, node->dtn_metric);
+	metric_data = d_tm_conv_ptr(ctx, node->dtn_metric);
 	if (metric_data != NULL) {
-		dtm_stats = d_tm_conv_ptr(shmem_root, metric_data->dtm_stats);
-		if (node->dtn_protect)
-			D_MUTEX_LOCK(&node->dtn_lock);
+		dtm_stats = d_tm_conv_ptr(ctx, metric_data->dtm_stats);
+		d_tm_node_lock(node);
 		*val = metric_data->dtm_data.value;
 		if ((stats != NULL) && (dtm_stats != NULL)) {
 			stats->dtm_min = dtm_stats->dtm_min;
@@ -2131,8 +2131,7 @@ d_tm_get_gauge(uint64_t *val, struct d_tm_stats_t *stats, uint64_t *shmem_root,
 			stats->sum_of_squares = dtm_stats->sum_of_squares;
 			stats->sample_size = dtm_stats->sample_size;
 		}
-		if (node->dtn_protect)
-			D_MUTEX_UNLOCK(&node->dtn_lock);
+		d_tm_node_unlock(node);
 	} else {
 		return -DER_METRIC_NOT_FOUND;
 	}
@@ -2144,24 +2143,28 @@ d_tm_get_gauge(uint64_t *val, struct d_tm_stats_t *stats, uint64_t *shmem_root,
  * Memory is allocated for the \a desc and \a units and should be freed by the
  * caller.
  *
- * \param[in,out]	desc		Memory is allocated and the
- *					description is copied here
- * \param[in,out]	units		Memory is allocated and the unit
- *					description is copied here
- * \param[in]		shmem_root	Pointer to the shared memory segment
- * \param[in]		node		Pointer to the stored metric node
+ * \param[in]	ctx	Client context
+ * \param[out]	desc	Memory is allocated and the
+ *			description is copied here
+ * \param[out]	units	Memory is allocated and the unit
+ *			description is copied here
+ * \param[in]	node	Pointer to the stored metric node
  *
- * \return		DER_SUCCESS		Success
- *			-DER_INVAL		Invalid input
- *			-DER_METRIC_NOT_FOUND	Metric node not found
- *			-DER_OP_NOT_PERMITTED	Node is not a metric
+ * \return	DER_SUCCESS		Success
+ *		-DER_INVAL		Invalid input
+ *		-DER_METRIC_NOT_FOUND	Metric node not found
+ *		-DER_OP_NOT_PERMITTED	Node is not a metric
  */
-int d_tm_get_metadata(char **desc, char **units, uint64_t *shmem_root,
+int d_tm_get_metadata(struct d_tm_context *ctx, char **desc, char **units,
 		      struct d_tm_node_t *node)
 {
 	struct d_tm_metric_t	*metric_data = NULL;
 	char			*desc_str;
 	char			*units_str;
+	struct d_tm_shmem_hdr	*shmem_root;
+
+	if (ctx == NULL || node == NULL)
+		return -DER_INVAL;
 
 	if ((desc == NULL) && (units == NULL))
 		return -DER_INVAL;
@@ -2172,8 +2175,7 @@ int d_tm_get_metadata(char **desc, char **units, uint64_t *shmem_root,
 	if (units != NULL)
 		*units = NULL;
 
-	if (node == NULL)
-		return -DER_INVAL;
+	shmem_root = ctx->shmem_root;
 
 	if (!d_tm_validate_shmem_ptr(shmem_root, (void *)node))
 		return -DER_METRIC_NOT_FOUND;
@@ -2181,18 +2183,16 @@ int d_tm_get_metadata(char **desc, char **units, uint64_t *shmem_root,
 	if (node->dtn_type == D_TM_DIRECTORY)
 		return -DER_OP_NOT_PERMITTED;
 
-	metric_data = d_tm_conv_ptr(shmem_root, node->dtn_metric);
+	metric_data = d_tm_conv_ptr(ctx, node->dtn_metric);
 	if (metric_data != NULL) {
-		if (node->dtn_protect)
-			D_MUTEX_LOCK(&node->dtn_lock);
-		desc_str = d_tm_conv_ptr(shmem_root, metric_data->dtm_desc);
+		d_tm_node_lock(node);
+		desc_str = d_tm_conv_ptr(ctx, metric_data->dtm_desc);
 		if ((desc != NULL) && (desc_str != NULL))
 			D_STRNDUP(*desc, desc_str, D_TM_MAX_DESC_LEN);
-		units_str = d_tm_conv_ptr(shmem_root, metric_data->dtm_units);
+		units_str = d_tm_conv_ptr(ctx, metric_data->dtm_units);
 		if ((units != NULL) && (units_str != NULL))
 			D_STRNDUP(*units, units_str, D_TM_MAX_UNIT_LEN);
-		if (node->dtn_protect)
-			D_MUTEX_UNLOCK(&node->dtn_lock);
+		d_tm_node_unlock(node);
 	} else {
 		return -DER_METRIC_NOT_FOUND;
 	}
@@ -2223,8 +2223,8 @@ d_tm_get_version(void)
  * existing node list if head is already initialized. The client should free the
  * memory with d_tm_list_free().
  *
+ * \param[in]		ctx		Telemetry context
  * \param[in,out]	head		Pointer to a nodelist
- * \param[in]		shmem_root	Pointer to the shared memory segment
  * \param[in]		node		The recursive directory listing starts
  *					from this node.
  * \param[in]		d_tm_type	A bitmask of d_tm_metric_types that
@@ -2236,10 +2236,10 @@ d_tm_get_version(void)
  *						\a node
  */
 int
-d_tm_list(struct d_tm_nodeList_t **head, uint64_t *shmem_root,
+d_tm_list(struct d_tm_context *ctx, struct d_tm_nodeList_t **head,
 	  struct d_tm_node_t *node, int d_tm_type)
 {
-	int	rc = DER_SUCCESS;
+	int rc = DER_SUCCESS;
 
 	if ((head == NULL) || (node == NULL)) {
 		rc = -DER_INVAL;
@@ -2247,7 +2247,7 @@ d_tm_list(struct d_tm_nodeList_t **head, uint64_t *shmem_root,
 	}
 
 	if (d_tm_type & node->dtn_type) {
-		rc = d_tm_add_node(node, head);
+		rc = d_tm_list_add_node(node, head);
 		if (rc != DER_SUCCESS)
 			goto out;
 	}
@@ -2256,13 +2256,13 @@ d_tm_list(struct d_tm_nodeList_t **head, uint64_t *shmem_root,
 	if (node == NULL)
 		goto out;
 
-	node = d_tm_conv_ptr(shmem_root, node);
+	node = d_tm_conv_ptr(ctx, node);
 	if (node == NULL) {
 		rc = -DER_INVAL;
 		goto out;
 	}
 
-	rc = d_tm_list(head, shmem_root, node, d_tm_type);
+	rc = d_tm_list(ctx, head, node, d_tm_type);
 	if (rc != DER_SUCCESS)
 		goto out;
 
@@ -2270,13 +2270,13 @@ d_tm_list(struct d_tm_nodeList_t **head, uint64_t *shmem_root,
 	if (node == NULL)
 		return rc;
 
-	node = d_tm_conv_ptr(shmem_root, node);
+	node = d_tm_conv_ptr(ctx, node);
 	while (node != NULL) {
-		rc = d_tm_list(head, shmem_root, node, d_tm_type);
+		rc = d_tm_list(ctx, head, node, d_tm_type);
 		if (rc != DER_SUCCESS)
 			goto out;
 		node = node->dtn_sibling;
-		node = d_tm_conv_ptr(shmem_root, node);
+		node = d_tm_conv_ptr(ctx, node);
 	}
 
 out:
@@ -2313,7 +2313,7 @@ d_tm_list_free(struct d_tm_nodeList_t *nodeList)
  *					\a node
  */
 int
-d_tm_add_node(struct d_tm_node_t *src, struct d_tm_nodeList_t **nodelist)
+d_tm_list_add_node(struct d_tm_node_t *src, struct d_tm_nodeList_t **nodelist)
 {
 	struct d_tm_nodeList_t	*list = NULL;
 
@@ -2364,46 +2364,62 @@ d_tm_get_key(int srv_idx)
  * \return			Address of the shared memory region
  *				NULL if failure
  */
-uint64_t *
-d_tm_allocate_shared_memory(int srv_idx, size_t mem_size)
+static struct d_tm_shmem_hdr *
+allocate_shared_memory(int srv_idx, size_t mem_size)
 {
-	uint64_t	*addr;
-	key_t		key;
+	void			*addr;
+	key_t			key;
+	int			shmid;
+	struct d_tm_shmem_hdr	*header;
 
 	key = d_tm_get_key(srv_idx);
-	d_tm_shmid = shmget(key, mem_size, IPC_CREAT | 0660);
-	if (d_tm_shmid < 0) {
+	shmid = shmget(key, mem_size, IPC_CREAT | 0660);
+	if (shmid < 0) {
 		D_ERROR("Unable to allocate shared memory.  shmget failed, "
 			"%s\n", strerror(errno));
 		return NULL;
 	}
 
-	addr = shmat(d_tm_shmid, NULL, 0);
+	addr = shmat(shmid, NULL, 0);
 	if (addr == (void *)-1) {
 		D_ERROR("Unable to allocate shared memory.  shmat failed, "
 			"%s\n", strerror(errno));
 		return NULL;
 	}
-	return addr;
+
+	header = (struct d_tm_shmem_hdr *)addr;
+	/**
+	 * Store the base address of the shared memory as seen by the
+	 * server.
+	 * Used by the client to adjust pointers in the shared memory
+	 * to its own address space.
+	 */
+	header->sh_base_addr = (uint64_t)addr;
+	header->sh_id = (uint32_t)shmid;
+	header->sh_bytes_total = mem_size;
+	header->sh_bytes_free = mem_size - sizeof(struct d_tm_shmem_hdr);
+	header->sh_free_addr = addr + sizeof(struct d_tm_shmem_hdr);
+	return header;
 }
 
 /**
- * Client side function that retrieves a pointer to the shared memory segment
- * for this server instance.
+ * Opens the given telemetry memory region for reading. Returns a context for
+ * this session that must be closed by the caller.
  *
- * \param[in]	srv_idx		A unique value that identifies the producer
- *				process that the client seeks to read data from
- * \return			Address of the shared memory region
- *				NULL if failure
+ * \param[in]	id	A unique value that identifies the telemetry region
+ *
+ * \return		New context, or NULL if failure
  */
-uint64_t *
-d_tm_get_shared_memory(int srv_idx)
+struct d_tm_context *
+d_tm_open(int id)
 {
-	uint64_t	*addr;
-	key_t		key;
-	int		shmid;
+	struct d_tm_context	*new_ctx;
+	struct d_tm_shmem_hdr	*addr;
+	key_t			key;
+	int			shmid;
+	int			rc;
 
-	key = d_tm_get_key(srv_idx);
+	key = d_tm_get_key(id);
 	shmid = shmget(key, 0, 0);
 	if (shmid < 0) {
 		D_ERROR("Unable to access shared memory.  shmget failed, "
@@ -2417,37 +2433,73 @@ d_tm_get_shared_memory(int srv_idx)
 			"%s\n", strerror(errno));
 		return NULL;
 	}
-	return addr;
+
+	rc = alloc_ctx(&new_ctx, addr);
+	if (rc != 0)
+		return NULL;
+
+	return new_ctx;
+}
+
+/**
+ * Detaches from a telemetry memory region and frees the context.
+ *
+ * \param[in]	ctx	Context to be freed
+ */
+void
+d_tm_close(struct d_tm_context **ctx)
+{
+	int			 rc;
+	struct d_tm_shmem_hdr	*shmem_root;
+
+	if (ctx == NULL || *ctx == NULL)
+		return;
+
+	shmem_root = (*ctx)->shmem_root;
+
+	if (shmem_root == NULL)
+		goto out;
+
+	rc = shmdt((void *)shmem_root);
+	if (rc < 0)
+		D_ERROR("Unable to detach from shared memory segment.  "
+			"shmdt failed, %s.\n", strerror(errno));
+out:
+	D_FREE(*ctx);
 }
 
 /**
  * Allocates memory from within the shared memory pool with 64-bit alignment
  * Clears the allocated buffer.
  *
+ * param[in]	shmem	The shmem pool in which to alloc
  * param[in]	length	Size in bytes of the region within the shared memory
  *			pool to allocate
  *
  * \return		Address of the allocated memory
  *			NULL if there was no more memory available
  */
-void *
-d_tm_shmalloc(int length)
+static void *
+d_tm_shmalloc(struct d_tm_shmem_hdr *shmem, int length)
 {
+	if (shmem == NULL || length == 0)
+		return NULL;
+
 	if (length % sizeof(uint64_t) != 0) {
 		length += sizeof(uint64_t);
 		length &= ~(sizeof(uint64_t) - 1);
 	}
 
-	if (d_tm_shmem_idx) {
-		if ((d_tm_shmem_free - length) > 0) {
-			d_tm_shmem_free -= length;
-			d_tm_shmem_idx += length;
-			D_DEBUG(DB_TRACE,
-				"Allocated %d bytes.  Now %" PRIu64 " remain\n",
-				length, d_tm_shmem_free);
-			memset((void *)(d_tm_shmem_idx - length), 0, length);
-			return d_tm_shmem_idx - length;
-		}
+	if (shmem->sh_bytes_free > 0 && length <= shmem->sh_bytes_free) {
+		void *new_mem = shmem->sh_free_addr;
+
+		shmem->sh_bytes_free -= length;
+		shmem->sh_free_addr += length;
+		D_DEBUG(DB_TRACE,
+			"Allocated %d bytes.  Now %" PRIu64 " remain\n",
+			length, shmem->sh_bytes_free);
+		memset(new_mem, 0, length);
+		return new_mem;
 	}
 	D_CRIT("Shared memory allocation failure!\n");
 	return NULL;
@@ -2464,15 +2516,17 @@ d_tm_shmalloc(int length)
  *		false		The the pointer is invalid
  */
 bool
-d_tm_validate_shmem_ptr(uint64_t *shmem_root, void *ptr)
+d_tm_validate_shmem_ptr(struct d_tm_shmem_hdr *shmem_root, void *ptr)
 {
+	uint64_t shmem_max_addr;
+
+	shmem_max_addr = (uint64_t)shmem_root + shmem_root->sh_bytes_total;
 	if (((uint64_t)ptr < (uint64_t)shmem_root) ||
-	    ((uint64_t)ptr >= (uint64_t)shmem_root + D_TM_SHARED_MEMORY_SIZE)) {
+	    ((uint64_t)ptr >= shmem_max_addr)) {
 		D_DEBUG(DB_TRACE,
 			"shmem ptr 0x%" PRIx64 " was outside the shmem range "
-			"0x%" PRIx64 " to 0x%" PRIx64, (uint64_t)ptr,
-			(uint64_t)shmem_root, (uint64_t)shmem_root +
-			D_TM_SHARED_MEMORY_SIZE);
+			"0x%" PRIx64 " to 0x%" PRIx64 "\n", (uint64_t)ptr,
+			(uint64_t)shmem_root, shmem_max_addr);
 		return false;
 	}
 	return true;
@@ -2482,23 +2536,26 @@ d_tm_validate_shmem_ptr(uint64_t *shmem_root, void *ptr)
  * Convert the virtual address of the pointer in shared memory from a server
  * address to a client side virtual address.
  *
- * \param[in]	shmem_root	Pointer to the shared memory segment
- * \param[in]	ptr		The pointer to convert
+ * \param[in]	ctx	Telemetry context
+ * \param[in]	ptr	The pointer to convert
  *
- * \return			A pointer to the item in the clients address
- *				space
- *				NULL if the pointer is invalid
+ * \return		A pointer to the item in the clients address
+ *			space
+ *			NULL if the pointer is invalid
  */
 void *
-d_tm_conv_ptr(uint64_t *shmem_root, void *ptr)
+d_tm_conv_ptr(struct d_tm_context *ctx, void *ptr)
 {
-	void	*temp;
+	void			*temp;
+	struct d_tm_shmem_hdr	*shmem_root;
 
-	if ((ptr == NULL) || (shmem_root == NULL))
+	if (ptr == NULL || ctx == NULL || ctx->shmem_root == NULL)
 		return NULL;
 
-	temp = (void *)((uint64_t)shmem_root + ((uint64_t)ptr) -
-			*(uint64_t *)shmem_root);
+	shmem_root = ctx->shmem_root;
+
+	temp = (void *)((uint64_t)shmem_root + (uint64_t)ptr -
+			shmem_root->sh_base_addr);
 
 	if (d_tm_validate_shmem_ptr(shmem_root, temp))
 		return temp;

--- a/src/gurt/tests/test_gurt_telem_producer.c
+++ b/src/gurt/tests/test_gurt_telem_producer.c
@@ -20,7 +20,8 @@
 #define STATS_EPSILON	(0.00001)
 #define TEST_IDX	(99)
 
-static uint64_t	*shmem_root;
+/* Context for checking results as a client */
+static struct d_tm_context	*cli_ctx;
 
 static int
 init_tests(void **state)
@@ -32,8 +33,8 @@ init_tests(void **state)
 		       D_TM_RETAIN_SHMEM);
 	assert_rc_equal(rc, DER_SUCCESS);
 
-	shmem_root = d_tm_get_shared_memory(simulated_srv_idx);
-	assert_non_null(shmem_root);
+	cli_ctx = d_tm_open(simulated_srv_idx);
+	assert_non_null(cli_ctx);
 
 	return d_log_init();
 }
@@ -55,8 +56,7 @@ test_increment_counter(void **state)
 		d_tm_inc_counter(loop, 1);
 	}
 
-	rc = d_tm_get_counter(&val, shmem_root,
-			      d_tm_conv_ptr(shmem_root, loop));
+	rc = d_tm_get_counter(cli_ctx, &val, d_tm_conv_ptr(cli_ctx, loop));
 	assert_rc_equal(rc, DER_SUCCESS);
 	assert_int_equal(val, count);
 }
@@ -76,8 +76,7 @@ test_add_to_counter(void **state)
 	d_tm_inc_counter(loop, count);
 	d_tm_inc_counter(loop, 1);
 
-	rc = d_tm_get_counter(&val, shmem_root,
-			      d_tm_conv_ptr(shmem_root, loop));
+	rc = d_tm_get_counter(cli_ctx, &val, d_tm_conv_ptr(cli_ctx, loop));
 	assert_rc_equal(rc, DER_SUCCESS);
 	assert_int_equal(val, count + 1);
 }
@@ -103,8 +102,7 @@ test_gauge(void **state)
 		d_tm_inc_gauge(gauge, 1);
 	}
 
-	rc = d_tm_get_gauge(&val, NULL, shmem_root,
-			    d_tm_conv_ptr(shmem_root, gauge));
+	rc = d_tm_get_gauge(cli_ctx, &val, NULL, d_tm_conv_ptr(cli_ctx, gauge));
 	assert_rc_equal(rc, DER_SUCCESS);
 	assert_int_equal(val, init_val + inc_count);
 
@@ -112,8 +110,7 @@ test_gauge(void **state)
 		d_tm_dec_gauge(gauge, 1);
 	}
 
-	rc = d_tm_get_gauge(&val, NULL, shmem_root,
-			    d_tm_conv_ptr(shmem_root, gauge));
+	rc = d_tm_get_gauge(cli_ctx, &val, NULL, d_tm_conv_ptr(cli_ctx, gauge));
 	assert_rc_equal(rc, DER_SUCCESS);
 	assert_int_equal(val, init_val + inc_count - dec_count);
 }
@@ -131,8 +128,7 @@ test_record_timestamp(void **state)
 
 	d_tm_record_timestamp(ts);
 
-	rc = d_tm_get_timestamp(&val, shmem_root,
-				d_tm_conv_ptr(shmem_root, ts));
+	rc = d_tm_get_timestamp(cli_ctx, &val, d_tm_conv_ptr(cli_ctx, ts));
 	assert_rc_equal(rc, DER_SUCCESS);
 	/*
 	 * Hard to determine exact timestamp at this point, so just verify
@@ -162,8 +158,7 @@ test_interval_timer(void **state)
 
 	d_tm_mark_duration_end(timer);
 
-	rc = d_tm_get_duration(&result, &stats, shmem_root,
-			       d_tm_conv_ptr(shmem_root, timer));
+	rc = d_tm_get_duration(cli_ctx, &result, &stats, d_tm_conv_ptr(cli_ctx, timer));
 	assert_int_equal(rc, DER_SUCCESS);
 	/* very rough estimation, based on the sleep timing */
 	assert_true(result.tv_nsec > ts.tv_nsec || result.tv_sec > 0);
@@ -195,12 +190,10 @@ test_timer_snapshot(void **state)
 	d_tm_take_timer_snapshot(snapshot2, D_TM_CLOCK_REALTIME);
 
 	/* check values */
-	rc = d_tm_get_timer_snapshot(&tms1, shmem_root,
-				     d_tm_conv_ptr(shmem_root, snapshot1));
+	rc = d_tm_get_timer_snapshot(cli_ctx, &tms1, d_tm_conv_ptr(cli_ctx, snapshot1));
 	assert_rc_equal(rc, 0);
 
-	rc = d_tm_get_timer_snapshot(&tms2, shmem_root,
-				     d_tm_conv_ptr(shmem_root, snapshot2));
+	rc = d_tm_get_timer_snapshot(cli_ctx, &tms2, d_tm_conv_ptr(cli_ctx, snapshot2));
 	assert_rc_equal(rc, 0);
 
 	tms3 = d_timediff(tms1, tms2);
@@ -235,8 +228,7 @@ test_gauge_stats(void **state)
 		d_tm_set_gauge(gauge, test_values[i]);
 	}
 
-	rc = d_tm_get_gauge(&val, &stats, shmem_root,
-			    d_tm_conv_ptr(shmem_root, gauge));
+	rc = d_tm_get_gauge(cli_ctx, &val, &stats, d_tm_conv_ptr(cli_ctx, gauge));
 	assert_rc_equal(rc, DER_SUCCESS);
 
 	assert_int_equal(val, 20);
@@ -302,8 +294,7 @@ test_duration_stats(void **state)
 	d_tm_compute_stats(timer, microseconds);
 
 	/* Verify the results - figured out empirically */
-	rc = d_tm_get_duration(&tms, &stats, shmem_root,
-			       d_tm_conv_ptr(shmem_root, timer));
+	rc = d_tm_get_duration(cli_ctx, &tms, &stats, d_tm_conv_ptr(cli_ctx, timer));
 	assert_rc_equal(rc, DER_SUCCESS);
 
 	assert_int_equal(stats.dtm_min, 1125000);
@@ -323,9 +314,9 @@ check_bucket_counter(char *path, int bucket_id, uint64_t exp_val)
 	snprintf(bucket_path, sizeof(bucket_path), "%s/bucket %d",
 		 path, bucket_id);
 
-	node = d_tm_find_metric(shmem_root, bucket_path);
+	node = d_tm_find_metric(cli_ctx, bucket_path);
 	assert_non_null(node);
-	rc = d_tm_get_counter(&val, shmem_root, node);
+	rc = d_tm_get_counter(cli_ctx, &val, node);
 	assert_rc_equal(rc, DER_SUCCESS);
 	assert_int_equal(val, exp_val);
 }
@@ -356,7 +347,7 @@ check_bucket_metadata(struct d_tm_node_t *node, int bucket_id)
 
 	printf("Checking bucket %d\n", bucket_id);
 
-	rc = d_tm_get_bucket_range(&bucket, bucket_id, shmem_root, node);
+	rc = d_tm_get_bucket_range(cli_ctx, &bucket, bucket_id, node);
 	assert_rc_equal(rc, DER_SUCCESS);
 	assert_non_null(bucket.dtb_bucket);
 
@@ -364,7 +355,7 @@ check_bucket_metadata(struct d_tm_node_t *node, int bucket_id)
 		 "histogram bucket %d [%lu .. %lu]",
 		 bucket_id, bucket.dtb_min, bucket.dtb_max);
 
-	rc = d_tm_get_metadata(&desc, &units, shmem_root, bucket.dtb_bucket);
+	rc = d_tm_get_metadata(cli_ctx, &desc, &units, bucket.dtb_bucket);
 	assert_rc_equal(rc, DER_SUCCESS);
 	assert_string_equal(desc, exp_desc);
 	free(desc);
@@ -380,10 +371,10 @@ check_histogram_metadata(char *path)
 	int			rc;
 	int			i;
 
-	node = d_tm_find_metric(shmem_root, path);
+	node = d_tm_find_metric(cli_ctx, path);
 	assert_non_null(node);
 
-	rc = d_tm_get_num_buckets(&histogram, shmem_root, node);
+	rc = d_tm_get_num_buckets(cli_ctx, &histogram, node);
 	assert_rc_equal(rc, 0);
 
 	for (i = 0; i < histogram.dth_num_buckets; i++)
@@ -398,32 +389,32 @@ check_histogram_m1_data(char *path)
 	struct d_tm_bucket_t	bucket;
 	int			rc;
 
-	gauge = d_tm_find_metric(shmem_root, path);
+	gauge = d_tm_find_metric(cli_ctx, path);
 	assert_non_null(gauge);
 
-	rc = d_tm_get_num_buckets(&histogram, shmem_root, gauge);
+	rc = d_tm_get_num_buckets(cli_ctx, &histogram, gauge);
 	assert_rc_equal(rc, DER_SUCCESS);
 
 	assert_int_equal(histogram.dth_num_buckets, 10);
 	assert_int_equal(histogram.dth_initial_width, 5);
 	assert_int_equal(histogram.dth_value_multiplier, 1);
 
-	rc = d_tm_get_bucket_range(&bucket, 0, shmem_root, gauge);
+	rc = d_tm_get_bucket_range(cli_ctx, &bucket, 0, gauge);
 	assert_rc_equal(rc, DER_SUCCESS);
 	assert_int_equal(bucket.dtb_min, 0);
 	assert_int_equal(bucket.dtb_max, 4);
 
-	rc = d_tm_get_bucket_range(&bucket, 1, shmem_root, gauge);
+	rc = d_tm_get_bucket_range(cli_ctx, &bucket, 1, gauge);
 	assert_rc_equal(rc, DER_SUCCESS);
 	assert_int_equal(bucket.dtb_min, 5);
 	assert_int_equal(bucket.dtb_max, 9);
 
-	rc = d_tm_get_bucket_range(&bucket, 2, shmem_root, gauge);
+	rc = d_tm_get_bucket_range(cli_ctx, &bucket, 2, gauge);
 	assert_rc_equal(rc, DER_SUCCESS);
 	assert_int_equal(bucket.dtb_min, 10);
 	assert_int_equal(bucket.dtb_max, 14);
 
-	rc = d_tm_get_bucket_range(&bucket, 10, shmem_root, gauge);
+	rc = d_tm_get_bucket_range(cli_ctx, &bucket, 10, gauge);
 	assert_rc_equal(rc, -DER_INVAL);
 }
 
@@ -501,42 +492,42 @@ check_histogram_m2_data(char *path)
 	struct d_tm_bucket_t	bucket;
 	int			rc;
 
-	gauge = d_tm_find_metric(shmem_root, path);
+	gauge = d_tm_find_metric(cli_ctx, path);
 	assert_non_null(gauge);
 
-	rc = d_tm_get_num_buckets(&histogram, shmem_root, gauge);
+	rc = d_tm_get_num_buckets(cli_ctx, &histogram, gauge);
 	assert_rc_equal(rc, DER_SUCCESS);
 
 	assert_int_equal(histogram.dth_num_buckets, 5);
 	assert_int_equal(histogram.dth_initial_width, 2048);
 	assert_int_equal(histogram.dth_value_multiplier, 2);
 
-	rc = d_tm_get_bucket_range(&bucket, 0, shmem_root, gauge);
+	rc = d_tm_get_bucket_range(cli_ctx, &bucket, 0, gauge);
 	assert_rc_equal(rc, DER_SUCCESS);
 	assert_int_equal(bucket.dtb_min, 0);
 	assert_int_equal(bucket.dtb_max, 2047);
 
-	rc = d_tm_get_bucket_range(&bucket, 1, shmem_root, gauge);
+	rc = d_tm_get_bucket_range(cli_ctx, &bucket, 1, gauge);
 	assert_rc_equal(rc, DER_SUCCESS);
 	assert_int_equal(bucket.dtb_min, 2048);
 	assert_int_equal(bucket.dtb_max, 6143);
 
-	rc = d_tm_get_bucket_range(&bucket, 2, shmem_root, gauge);
+	rc = d_tm_get_bucket_range(cli_ctx, &bucket, 2, gauge);
 	assert_rc_equal(rc, DER_SUCCESS);
 	assert_int_equal(bucket.dtb_min, 6144);
 	assert_int_equal(bucket.dtb_max, 14335);
 
-	rc = d_tm_get_bucket_range(&bucket, 3, shmem_root, gauge);
+	rc = d_tm_get_bucket_range(cli_ctx, &bucket, 3, gauge);
 	assert_rc_equal(rc, DER_SUCCESS);
 	assert_int_equal(bucket.dtb_min, 14336);
 	assert_int_equal(bucket.dtb_max, 30719);
 
-	rc = d_tm_get_bucket_range(&bucket, 4, shmem_root, gauge);
+	rc = d_tm_get_bucket_range(cli_ctx, &bucket, 4, gauge);
 	assert_rc_equal(rc, DER_SUCCESS);
 	assert_int_equal(bucket.dtb_min, 30720);
 	assert_true(bucket.dtb_max == UINT64_MAX);
 
-	rc = d_tm_get_bucket_range(&bucket, 5, shmem_root, gauge);
+	rc = d_tm_get_bucket_range(cli_ctx, &bucket, 5, gauge);
 	assert_rc_equal(rc, -DER_INVAL);
 }
 
@@ -609,8 +600,7 @@ test_units(void **state)
 			     "gurt/tests/telem/kibibyte-counter");
 	assert_rc_equal(rc, DER_SUCCESS);
 
-	rc = d_tm_get_metadata(NULL, &units, shmem_root,
-			       d_tm_conv_ptr(shmem_root, counter));
+	rc = d_tm_get_metadata(cli_ctx, NULL, &units, d_tm_conv_ptr(cli_ctx, counter));
 	assert_rc_equal(rc, DER_SUCCESS);
 	assert_string_equal(units, D_TM_KIBIBYTE);
 	free(units);
@@ -618,8 +608,7 @@ test_units(void **state)
 	rc = d_tm_add_metric(&gauge, D_TM_GAUGE, NULL, D_TM_GIGIBYTE_PER_SECOND,
 			     "gurt/tests/telem/gigibyte-per-second-gauge");
 	assert_rc_equal(rc, DER_SUCCESS);
-	rc = d_tm_get_metadata(NULL, &units, shmem_root,
-			       d_tm_conv_ptr(shmem_root, gauge));
+	rc = d_tm_get_metadata(cli_ctx, NULL, &units, d_tm_conv_ptr(cli_ctx, gauge));
 	assert_rc_equal(rc, DER_SUCCESS);
 	assert_string_equal(units, D_TM_GIGIBYTE_PER_SECOND);
 	free(units);
@@ -631,26 +620,22 @@ test_find_metric(void **state)
 	struct d_tm_node_t	*node;
 
 	/** should find this one */
-	node = d_tm_find_metric(shmem_root, "gurt");
+	node = d_tm_find_metric(cli_ctx, "gurt");
 	assert_non_null(node);
 
 	/** should find this one */
-	node = d_tm_find_metric(shmem_root, "gurt/tests/telem/gauge");
+	node = d_tm_find_metric(cli_ctx, "gurt/tests/telem/gauge");
 	assert_non_null(node);
 
 	/** should not find this one */
-	node = d_tm_find_metric(shmem_root, "gurts");
+	node = d_tm_find_metric(cli_ctx, "gurts");
 	assert_null(node);
 
-	/** should not find this one */
+	/** no context */
 	node = d_tm_find_metric(NULL, "gurts");
 	assert_null(node);
 
-	/** should not find this one */
-	node = d_tm_find_metric(NULL, "gurt");
-	assert_null(node);
-
-	/** should not find this one */
+	/** all null inputs */
 	node = d_tm_find_metric(NULL, NULL);
 	assert_null(node);
 }
@@ -670,25 +655,25 @@ test_verify_object_count(void **state)
 	exp_total = exp_num_ctr + exp_num_gauge + exp_num_dur +
 		    exp_num_timestamp + exp_num_snap;
 
-	node = d_tm_find_metric(shmem_root, "gurt/tests/telem");
+	node = d_tm_find_metric(cli_ctx, "gurt/tests/telem");
 	assert_non_null(node);
 
-	num = d_tm_count_metrics(shmem_root, node, D_TM_COUNTER);
+	num = d_tm_count_metrics(cli_ctx, node, D_TM_COUNTER);
 	assert_int_equal(num, exp_num_ctr);
 
-	num = d_tm_count_metrics(shmem_root, node, D_TM_GAUGE);
+	num = d_tm_count_metrics(cli_ctx, node, D_TM_GAUGE);
 	assert_int_equal(num, exp_num_gauge);
 
-	num = d_tm_count_metrics(shmem_root, node, D_TM_DURATION);
+	num = d_tm_count_metrics(cli_ctx, node, D_TM_DURATION);
 	assert_int_equal(num, exp_num_dur);
 
-	num = d_tm_count_metrics(shmem_root, node, D_TM_TIMESTAMP);
+	num = d_tm_count_metrics(cli_ctx, node, D_TM_TIMESTAMP);
 	assert_int_equal(num, exp_num_timestamp);
 
-	num = d_tm_count_metrics(shmem_root, node, D_TM_TIMER_SNAPSHOT);
+	num = d_tm_count_metrics(cli_ctx, node, D_TM_TIMER_SNAPSHOT);
 	assert_int_equal(num, exp_num_snap);
 
-	num = d_tm_count_metrics(shmem_root, node,
+	num = d_tm_count_metrics(cli_ctx, node,
 				 D_TM_COUNTER | D_TM_GAUGE | D_TM_DURATION |
 				 D_TM_TIMESTAMP | D_TM_TIMER_SNAPSHOT);
 	assert_int_equal(num, exp_total);
@@ -700,29 +685,29 @@ test_print_metrics(void **state)
 	struct d_tm_node_t	*node;
 	int			filter;
 
-	node = d_tm_find_metric(shmem_root, "gurt");
+	node = d_tm_find_metric(cli_ctx, "gurt");
 	assert_non_null(node);
 
 	filter = (D_TM_COUNTER | D_TM_TIMESTAMP | D_TM_TIMER_SNAPSHOT |
 		  D_TM_DURATION | D_TM_GAUGE | D_TM_DIRECTORY);
 
-	d_tm_print_my_children(shmem_root, node, 0, filter, NULL, D_TM_STANDARD,
+	d_tm_print_my_children(cli_ctx, node, 0, filter, NULL, D_TM_STANDARD,
 			       D_TM_INCLUDE_METADATA, stdout);
 
 	d_tm_print_field_descriptors(D_TM_INCLUDE_TIMESTAMP |
 				     D_TM_INCLUDE_METADATA, stdout);
 
 	filter &= ~D_TM_DIRECTORY;
-	d_tm_print_my_children(shmem_root, node, 0, filter, NULL, D_TM_CSV,
+	d_tm_print_my_children(cli_ctx, node, 0, filter, NULL, D_TM_CSV,
 			       D_TM_INCLUDE_METADATA, stdout);
 }
 
 static void
 test_shared_memory_cleanup(void **state)
 {
-	int		simulated_srv_idx = TEST_IDX + 1;
-	int		rc;
-	uint64_t	*shmem;
+	int			simulated_srv_idx = TEST_IDX + 1;
+	int			rc;
+	struct d_tm_context	*ctx2;
 
 	/**
 	 * Cleanup from all other tests
@@ -743,17 +728,19 @@ test_shared_memory_cleanup(void **state)
 
 	/* Should be gone */
 	printf("This operation is expected to generate an error:\n");
-	shmem = d_tm_get_shared_memory(simulated_srv_idx);
-	assert_null(shmem);
+	ctx2 = d_tm_open(simulated_srv_idx);
+	assert_null(ctx2);
 
 	/* can still get original region */
-	shmem = d_tm_get_shared_memory(TEST_IDX);
-	assert_non_null(shmem);
+	ctx2 = d_tm_open(TEST_IDX);
+	assert_non_null(ctx2);
+	d_tm_close(&ctx2);
 }
 
 static int
 fini_tests(void **state)
 {
+	d_tm_close(&cli_ctx);
 	d_tm_fini();
 	d_log_fini();
 

--- a/src/include/gurt/telemetry_common.h
+++ b/src/include/gurt/telemetry_common.h
@@ -171,67 +171,61 @@ enum {
  * and sample size.
  */
 struct d_tm_stats_t {
-	uint64_t dtm_min;
-	uint64_t dtm_max;
-	uint64_t dtm_sum;
-	double std_dev;
-	double mean;
-	double sum_of_squares;
-	uint64_t sample_size;
+	uint64_t	dtm_min;
+	uint64_t	dtm_max;
+	uint64_t	dtm_sum;
+	double		std_dev;
+	double		mean;
+	double		sum_of_squares;
+	uint64_t	sample_size;
 };
 
 struct d_tm_bucket_t {
-	uint64_t dtb_min;
-	uint64_t dtb_max;
-	struct d_tm_node_t *dtb_bucket;
+	uint64_t		dtb_min;
+	uint64_t		dtb_max;
+	struct d_tm_node_t	*dtb_bucket;
 };
 
 struct d_tm_histogram_t {
-	struct d_tm_bucket_t *dth_buckets;
-	int dth_num_buckets;
-	int dth_initial_width;
-	int dth_value_multiplier;
+	struct d_tm_bucket_t	*dth_buckets;
+	int			dth_num_buckets;
+	int			dth_initial_width;
+	int			dth_value_multiplier;
 };
 
 struct d_tm_metric_t {
 	union data {
-		uint64_t value;
-		struct timespec tms[2];
-	} dtm_data;
-	struct d_tm_stats_t *dtm_stats;
-	struct d_tm_histogram_t *dtm_histogram;
-	char *dtm_desc;
-	char *dtm_units;
+		uint64_t	value;
+		struct		timespec tms[2];
+	}			dtm_data;
+	struct d_tm_stats_t	*dtm_stats;
+	struct d_tm_histogram_t	*dtm_histogram;
+	char			*dtm_desc;
+	char			*dtm_units;
 };
 
 struct d_tm_node_t {
-	struct d_tm_node_t *dtn_child;
-	struct d_tm_node_t *dtn_sibling;
-	char *dtn_name;
-	int dtn_type;
-	pthread_mutex_t dtn_lock;
-	struct d_tm_metric_t *dtn_metric;
-	bool dtn_protect;
+	struct d_tm_shmem_hdr	*dtn_region; /** head of shmem region */
+	struct d_tm_node_t	*dtn_child; /** first child */
+	struct d_tm_node_t	*dtn_sibling; /** first sibling */
+	char			*dtn_name; /** metric name */
+	int			dtn_type; /** mask of D_TM_ types */
+	pthread_mutex_t		dtn_lock; /** individual mutex */
+	struct d_tm_metric_t	*dtn_metric; /** values */
+	bool			dtn_protect; /** synchronized access */
 };
 
 struct d_tm_nodeList_t {
-	struct d_tm_node_t *dtnl_node;
-	struct d_tm_nodeList_t *dtnl_next;
+	struct d_tm_node_t	*dtnl_node;
+	struct d_tm_nodeList_t	*dtnl_next;
 };
 
-void *d_tm_shmalloc(int length);
-uint64_t *d_tm_allocate_shared_memory(int srv_idx, size_t mem_size);
-int d_tm_clock_id(int clk_id);
-char *d_tm_clock_string(int clk_id);
-bool d_tm_validate_shmem_ptr(uint64_t *shmem_root, void *ptr);
-int d_tm_add_node(struct d_tm_node_t *src, struct d_tm_nodeList_t **nodelist);
+/** Context for a telemetry instance */
+struct d_tm_context;
+
+int d_tm_list_add_node(struct d_tm_node_t *src,
+		       struct d_tm_nodeList_t **nodelist);
 void d_tm_list_free(struct d_tm_nodeList_t *nodeList);
-void d_tm_free_node(uint64_t *shmem_root, struct d_tm_node_t *node);
-struct d_tm_node_t *d_tm_find_child(uint64_t *shmem_root,
-				    struct d_tm_node_t *parent, char *name);
-int d_tm_alloc_node(struct d_tm_node_t **newnode, char *name);
-int d_tm_add_child(struct d_tm_node_t **newnode, struct d_tm_node_t *parent,
-		   char *name);
 int d_tm_get_version(void);
 void d_tm_compute_stats(struct d_tm_node_t *node, uint64_t value);
 double d_tm_compute_standard_dev(double sum_of_squares, uint64_t sample_size,

--- a/src/include/gurt/telemetry_consumer.h
+++ b/src/include/gurt/telemetry_consumer.h
@@ -6,43 +6,49 @@
 #ifndef __TELEMETRY_CONSUMER_H__
 #define __TELEMETRY_CONSUMER_H__
 
+
 /* Developer facing client API to read data */
-int d_tm_get_counter(uint64_t *val, uint64_t *shmem_root,
+int d_tm_get_counter(struct d_tm_context *ctx, uint64_t *val,
 		     struct d_tm_node_t *node);
-int d_tm_get_timestamp(time_t *val, uint64_t *shmem_root,
+int d_tm_get_timestamp(struct d_tm_context *ctx, time_t *val,
 		       struct d_tm_node_t *node);
-int d_tm_get_timer_snapshot(struct timespec *tms, uint64_t *shmem_root,
+int d_tm_get_timer_snapshot(struct d_tm_context *ctx, struct timespec *tms,
 			    struct d_tm_node_t *node);
-int d_tm_get_gauge(uint64_t *val, struct d_tm_stats_t *stats,
-		   uint64_t *shmem_root, struct d_tm_node_t *node);
-int d_tm_get_duration(struct timespec *tms, struct d_tm_stats_t *stats,
-		      uint64_t *shmem_root, struct d_tm_node_t *node);
-int d_tm_get_metadata(char **desc, char **units, uint64_t *shmem_root,
+int d_tm_get_gauge(struct d_tm_context *ctx, uint64_t *val,
+		   struct d_tm_stats_t *stats, struct d_tm_node_t *node);
+int d_tm_get_duration(struct d_tm_context *ctx, struct timespec *tms,
+		      struct d_tm_stats_t *stats, struct d_tm_node_t *node);
+int d_tm_get_metadata(struct d_tm_context *ctx, char **desc, char **units,
 		      struct d_tm_node_t *node);
-int d_tm_get_num_buckets(struct d_tm_histogram_t *histogram,
-			 uint64_t *shmem_root, struct d_tm_node_t *node);
-int d_tm_get_bucket_range(struct d_tm_bucket_t *bucket, int bucket_id,
-			  uint64_t *shmem_root, struct d_tm_node_t *node);
+int d_tm_get_num_buckets(struct d_tm_context *ctx,
+			 struct d_tm_histogram_t *histogram,
+			 struct d_tm_node_t *node);
+int d_tm_get_bucket_range(struct d_tm_context *ctx,
+			  struct d_tm_bucket_t *bucket, int bucket_id,
+			  struct d_tm_node_t *node);
 
 /* Developer facing client API to discover topology and manage results */
-uint64_t *d_tm_get_shared_memory(int srv_idx);
-void *d_tm_conv_ptr(uint64_t *shmem_root, void *ptr);
-struct d_tm_node_t *d_tm_get_root(uint64_t *shmem);
-struct d_tm_node_t *d_tm_find_metric(uint64_t *shmem_root, char *path);
-uint64_t d_tm_count_metrics(uint64_t *shmem_root, struct d_tm_node_t *node,
+struct d_tm_context *d_tm_open(int id);
+void d_tm_close(struct d_tm_context **ctx);
+void *d_tm_conv_ptr(struct d_tm_context *ctx, void *ptr);
+struct d_tm_node_t *d_tm_get_root(struct d_tm_context *ctx);
+struct d_tm_node_t *d_tm_find_metric(struct d_tm_context *ctx,
+				     char *path);
+uint64_t d_tm_count_metrics(struct d_tm_context *ctx, struct d_tm_node_t *node,
 			    int d_tm_type);
-int d_tm_list(struct d_tm_nodeList_t **head, uint64_t *shmem_root,
+int d_tm_list(struct d_tm_context *ctx, struct d_tm_nodeList_t **head,
 	      struct d_tm_node_t *node, int d_tm_type);
-void d_tm_print_my_children(uint64_t *shmem_root, struct d_tm_node_t *node,
+void d_tm_print_my_children(struct d_tm_context *ctx, struct d_tm_node_t *node,
 			    int level, int filter, char *path, int format,
 			    int opt_fields, FILE *stream);
-void d_tm_print_node(uint64_t *shmem_root, struct d_tm_node_t *node, int level,
-		     char *name, int format, int opt_fields, FILE *stream);
+void d_tm_print_node(struct d_tm_context *ctx, struct d_tm_node_t *node,
+		     int level, char *name, int format, int opt_fields,
+		     FILE *stream);
 void d_tm_print_field_descriptors(int opt_fields, FILE *stream);
 void d_tm_print_counter(uint64_t val, char *name, int format, char *units,
 			int opt_fields, FILE *stream);
 void d_tm_print_timestamp(time_t *clk, char *name, int format, int opt_fields,
-			  FILE *stream);
+			 FILE *stream);
 void d_tm_print_timer_snapshot(struct timespec *tms, char *name, int tm_type,
 			       int format, int opt_fields, FILE *stream);
 void d_tm_print_duration(struct timespec *tms, struct d_tm_stats_t *stats,
@@ -51,4 +57,7 @@ void d_tm_print_duration(struct timespec *tms, struct d_tm_stats_t *stats,
 void d_tm_print_gauge(uint64_t val, struct d_tm_stats_t *stats, char *name,
 		      int format, char *units, int opt_fields, FILE *stream);
 void d_tm_print_metadata(char *desc, char *units, int format, FILE *stream);
+int d_tm_clock_id(int clk_id);
+char *d_tm_clock_string(int clk_id);
+
 #endif /* __TELEMETRY_CONSUMER_H__ */


### PR DESCRIPTION
The goal of this patch is to encapsulate the details
of the shared memory layout inside the telemetry
library.

- Add shmem region pointer to struct d_tm_node_t.
- Start shmem region with a header describing the region.
- Use a context to hold state for telemetry clients'
  sessions. Clients are expected to open a server's
  telemetry region, read, and clean up by closing.
- Allocate new nodes by shmem region.
- Make shmem-aware helper functions private.

Signed-off-by: Kris Jacque <kristin.jacque@intel.com>