### PR TITLE
DAOS-6911 bio: bulk handle cache

### DIFF
--- a/src/bio/bio_buffer.c
+++ b/src/bio/bio_buffer.c
@@ -129,13 +129,15 @@ dma_buffer_create(unsigned int init_cnt)
 		return NULL;
 	}
 
-	rc = dma_buffer_grow(buf, init_cnt);
+	rc = bulk_cache_create(buf);
 	if (rc != 0) {
-		dma_buffer_destroy(buf);
+		ABT_mutex_free(&buf->bdb_mutex);
+		ABT_cond_free(&buf->bdb_wait_iods);
+		D_FREE(buf);
 		return NULL;
 	}
 
-	rc = bulk_cache_create(buf);
+	rc = dma_buffer_grow(buf, init_cnt);
 	if (rc != 0) {
 		dma_buffer_destroy(buf);
 		return NULL;

--- a/src/bio/bio_buffer.c
+++ b/src/bio/bio_buffer.c
@@ -587,6 +587,7 @@ dma_map_one(struct bio_desc *biod, struct bio_iov *biov, void *arg)
 		if (chk == NULL)
 			return -DER_NOMEM;
 
+		chk->bdc_type = biod->bd_chk_type;
 		rc = iod_add_chunk(biod, chk);
 		if (rc) {
 			dma_free_chunk(chk);

--- a/src/bio/bio_buffer.c
+++ b/src/bio/bio_buffer.c
@@ -45,7 +45,6 @@ dma_alloc_chunk(unsigned int cnt)
 	return chunk;
 }
 
-
 static void
 dma_buffer_shrink(struct bio_dma_buffer *buf, unsigned int cnt)
 {
@@ -64,16 +63,13 @@ dma_buffer_shrink(struct bio_dma_buffer *buf, unsigned int cnt)
 	}
 }
 
-static int
+int
 dma_buffer_grow(struct bio_dma_buffer *buf, unsigned int cnt)
 {
 	struct bio_dma_chunk *chunk;
 	int i, rc = 0;
 
-	if ((buf->bdb_tot_cnt + cnt) > bio_chk_cnt_max) {
-		D_ERROR("Exceeding per-xstream DMA buffer size\n");
-		return -DER_OVERFLOW;
-	}
+	D_ASSERT((buf->bdb_tot_cnt + cnt) <= bio_chk_cnt_max);
 
 	for (i = 0; i < cnt; i++) {
 		chunk = dma_alloc_chunk(bio_chk_sz);
@@ -94,6 +90,8 @@ dma_buffer_destroy(struct bio_dma_buffer *buf)
 {
 	D_ASSERT(d_list_empty(&buf->bdb_used_list));
 	D_ASSERT(buf->bdb_active_iods == 0);
+
+	bulk_cache_destroy(buf);
 	dma_buffer_shrink(buf, buf->bdb_tot_cnt);
 
 	D_ASSERT(buf->bdb_tot_cnt == 0);
@@ -132,6 +130,12 @@ dma_buffer_create(unsigned int init_cnt)
 	}
 
 	rc = dma_buffer_grow(buf, init_cnt);
+	if (rc != 0) {
+		dma_buffer_destroy(buf);
+		return NULL;
+	}
+
+	rc = bulk_cache_create(buf);
 	if (rc != 0) {
 		dma_buffer_destroy(buf);
 		return NULL;
@@ -186,16 +190,11 @@ bio_iod_free(struct bio_desc *biod)
 
 	for (i = 0; i < biod->bd_sgl_cnt; i++)
 		bio_sgl_fini(&biod->bd_sgls[i]);
+
+	if (biod->bd_bulk_hdls != NULL)
+		D_FREE(biod->bd_bulk_hdls);
+
 	D_FREE(biod);
-}
-
-static inline struct bio_dma_buffer *
-iod_dma_buf(struct bio_desc *biod)
-{
-	D_ASSERT(biod->bd_ctxt->bic_xs_ctxt);
-	D_ASSERT(biod->bd_ctxt->bic_xs_ctxt->bxc_dma_buf);
-
-	return biod->bd_ctxt->bic_xs_ctxt->bxc_dma_buf;
 }
 
 static inline bool
@@ -215,8 +214,13 @@ iod_release_buffer(struct bio_desc *biod)
 	struct bio_rsrvd_dma *rsrvd_dma = &biod->bd_rsrvd;
 	int i;
 
-	if (rsrvd_dma->brd_chk_max == 0) {
+	/* Release bulk handles */
+	bulk_iod_release(biod);
+
+	/* No reserved DMA regions */
+	if (rsrvd_dma->brd_rg_cnt == 0) {
 		D_ASSERT(rsrvd_dma->brd_rg_max == 0);
+		D_ASSERT(rsrvd_dma->brd_chk_max == 0);
 		biod->bd_buffer_prep = 0;
 		return;
 	}
@@ -226,8 +230,17 @@ iod_release_buffer(struct bio_desc *biod)
 	rsrvd_dma->brd_regions = NULL;
 	rsrvd_dma->brd_rg_max = rsrvd_dma->brd_rg_cnt = 0;
 
-	bdb = iod_dma_buf(biod);
+	/* All DMA chunks are used through cached bulk handle */
+	if (rsrvd_dma->brd_chk_cnt == 0) {
+		D_ASSERT(rsrvd_dma->brd_dma_chks == NULL);
+		D_ASSERT(rsrvd_dma->brd_chk_max == 0);
+		biod->bd_buffer_prep = 0;
+		return;
+	}
+
+	/* Release the DMA chunks not from cached bulk handle */
 	D_ASSERT(rsrvd_dma->brd_dma_chks != NULL);
+	bdb = iod_dma_buf(biod);
 	for (i = 0; i < rsrvd_dma->brd_chk_cnt; i++) {
 		struct bio_dma_chunk *chunk = rsrvd_dma->brd_dma_chks[i];
 
@@ -274,17 +287,91 @@ struct bio_copy_args {
 };
 
 static int
+copy_one(struct bio_desc *biod, struct bio_iov *biov, void *data)
+{
+	struct bio_copy_args	*arg = data;
+	d_sg_list_t		*sgl;
+	void			*addr = bio_iov2req_buf(biov);
+	ssize_t			 size = bio_iov2req_len(biov);
+	uint16_t		 media = bio_iov2media(biov);
+
+	D_ASSERT(arg->ca_sgl_idx < arg->ca_sgl_cnt);
+	sgl = &arg->ca_sgls[arg->ca_sgl_idx];
+
+	while (arg->ca_iov_idx < sgl->sg_nr) {
+		d_iov_t *iov;
+		ssize_t nob, buf_len;
+
+		iov = &sgl->sg_iovs[arg->ca_iov_idx];
+		buf_len = biod->bd_update ? iov->iov_len : iov->iov_buf_len;
+
+		if (buf_len <= arg->ca_iov_off) {
+			D_ERROR("Invalid iov[%d] "DF_U64"/"DF_U64" %d\n",
+				arg->ca_iov_idx, arg->ca_iov_off,
+				buf_len, biod->bd_update);
+			return -DER_INVAL;
+		}
+
+		if (iov->iov_buf == NULL) {
+			D_ERROR("Invalid iov[%d], iov_buf is NULL\n",
+				arg->ca_iov_idx);
+			return -DER_INVAL;
+		}
+
+		nob = min(size, buf_len - arg->ca_iov_off);
+		if (addr != NULL) {
+			D_DEBUG(DB_TRACE, "bio copy %p size %zd\n",
+				addr, nob);
+			bio_memcpy(biod, media, addr, iov->iov_buf +
+					arg->ca_iov_off, nob);
+			addr += nob;
+		} else {
+			/* fetch on hole */
+			D_ASSERT(!biod->bd_update);
+		}
+
+		arg->ca_iov_off += nob;
+		if (!biod->bd_update) {
+			/* the first population for fetch */
+			if (arg->ca_iov_off == nob)
+				sgl->sg_nr_out++;
+
+			iov->iov_len = arg->ca_iov_off;
+			/* consumed an iov, move to the next */
+			if (iov->iov_len == iov->iov_buf_len) {
+				arg->ca_iov_off = 0;
+				arg->ca_iov_idx++;
+			}
+		} else {
+			/* consumed an iov, move to the next */
+			if (arg->ca_iov_off == iov->iov_len) {
+				arg->ca_iov_off = 0;
+				arg->ca_iov_idx++;
+			}
+		}
+
+		size -= nob;
+		if (size == 0)
+			return 0;
+	}
+
+	D_DEBUG(DB_TRACE, "Consumed all iovs, "DF_U64" bytes left\n", size);
+	return -DER_REC2BIG;
+}
+
+static int
 iterate_biov(struct bio_desc *biod,
-	     int (*cb_fn)(struct bio_desc *, struct bio_iov *,
-			  struct bio_copy_args *),
-	     struct bio_copy_args *arg)
+	     int (*cb_fn)(struct bio_desc *, struct bio_iov *, void *data),
+	     void *data)
 {
 	int i, j, rc = 0;
 
 	for (i = 0; i < biod->bd_sgl_cnt; i++) {
 		struct bio_sglist *bsgl = &biod->bd_sgls[i];
 
-		if (arg != NULL) {
+		if (data != NULL && cb_fn == copy_one) {
+			struct bio_copy_args *arg = data;
+
 			D_ASSERT(i < arg->ca_sgl_cnt);
 			arg->ca_sgl_idx = i;
 			arg->ca_iov_idx = 0;
@@ -302,7 +389,7 @@ iterate_biov(struct bio_desc *biod,
 			if (bio_iov2req_len(biov) == 0)
 				continue;
 
-			rc = cb_fn(biod, biov, arg);
+			rc = cb_fn(biod, biov, data);
 			if (rc)
 				break;
 		}
@@ -350,38 +437,33 @@ iod_last_region(struct bio_desc *biod)
 	return (cnt != 0) ? &biod->bd_rsrvd.brd_regions[cnt - 1] : NULL;
 }
 
-static struct bio_dma_chunk *
-chunk_get_idle(struct bio_dma_buffer *bdb, struct bio_desc *biod)
+static int
+chunk_get_idle(struct bio_dma_buffer *bdb, struct bio_dma_chunk **chk_ptr)
 {
 	struct bio_dma_chunk *chk;
 	int rc;
 
 	if (d_list_empty(&bdb->bdb_idle_list)) {
-		if (bdb->bdb_tot_cnt == bio_chk_cnt_max) {
-			D_CRIT("Maximum per-xstream DMA buffer isn't big "
-			       "enough (chk_sz:%u chk_cnt:%u iods:%u "
-			       "used:%u,%u,%u) to sustain the workload.\n",
-			       bio_chk_sz, bio_chk_cnt_max,
-			       bdb->bdb_active_iods,
-			       bdb->bdb_used_cnt[BIO_CHK_TYPE_IO],
-			       bdb->bdb_used_cnt[BIO_CHK_TYPE_LOCAL],
-			       bdb->bdb_used_cnt[BIO_CHK_TYPE_REBUILD]);
-
-			biod->bd_retry = 1;
-			return NULL;
+		/* Try grow buffer first */
+		if (bdb->bdb_tot_cnt < bio_chk_cnt_max) {
+			rc = dma_buffer_grow(bdb, 1);
+			if (rc != 0)
+				return rc;
 		}
 
-		rc = dma_buffer_grow(bdb, 1);
-		if (rc != 0)
-			return NULL;
+		/* Try to reclaim an unused chunk from bulk groups */
+		rc = bulk_reclaim_chunk(bdb, NULL);
+		if (rc)
+			return rc;
 	}
 
 	D_ASSERT(!d_list_empty(&bdb->bdb_idle_list));
 	chk = d_list_entry(bdb->bdb_idle_list.next, struct bio_dma_chunk,
 			   bdc_link);
 	d_list_move_tail(&chk->bdc_link, &bdb->bdb_used_list);
+	*chk_ptr = chk;
 
-	return chk;
+	return 0;
 }
 
 static int
@@ -417,7 +499,7 @@ iod_add_chunk(struct bio_desc *biod, struct bio_dma_chunk *chk)
 	return 0;
 }
 
-static int
+int
 iod_add_region(struct bio_desc *biod, struct bio_dma_chunk *chk,
 	       unsigned int chk_pg_idx, uint64_t off, uint64_t end)
 {
@@ -454,9 +536,8 @@ iod_add_region(struct bio_desc *biod, struct bio_dma_chunk *chk,
 }
 
 /* Convert offset of @biov into memory pointer */
-static int
-dma_map_one(struct bio_desc *biod, struct bio_iov *biov,
-	    struct bio_copy_args *arg)
+int
+dma_map_one(struct bio_desc *biod, struct bio_iov *biov, void *arg)
 {
 	struct bio_rsrvd_region *last_rg;
 	struct bio_dma_buffer *bdb;
@@ -585,10 +666,22 @@ dma_map_one(struct bio_desc *biod, struct bio_iov *biov,
 	 * Switch to another idle chunk, if there isn't any idle chunk
 	 * available, grow buffer.
 	 */
-	chk = chunk_get_idle(bdb, biod);
-	if (chk == NULL)
-		return -DER_OVERFLOW;
+	rc = chunk_get_idle(bdb, &chk);
+	if (rc) {
+		if (rc == -DER_AGAIN) {
+			D_ERROR("DMA buffer isn't sufficient to sustain "
+				"current IO workload\n");
+			biod->bd_retry = 1;
+		} else {
+			D_ERROR("Failed to get idle chunk. "DF_RC"\n",
+				DP_RC(rc));
+		}
 
+		dump_dma_info(bdb);
+		return rc;
+	}
+
+	D_ASSERT(chk != NULL);
 	chk->bdc_type = biod->bd_chk_type;
 	bdb->bdb_cur_chk[chk->bdc_type] = chk;
 	bdb->bdb_used_cnt[chk->bdc_type] += 1;
@@ -813,79 +906,6 @@ bio_memcpy(struct bio_desc *biod, uint16_t media, void *media_addr,
 	}
 }
 
-static int
-copy_one(struct bio_desc *biod, struct bio_iov *biov,
-	 struct bio_copy_args *arg)
-{
-	d_sg_list_t	*sgl;
-	void		*addr = bio_iov2req_buf(biov);
-	ssize_t		 size = bio_iov2req_len(biov);
-	uint16_t	 media = bio_iov2media(biov);
-
-	D_ASSERT(arg->ca_sgl_idx < arg->ca_sgl_cnt);
-	sgl = &arg->ca_sgls[arg->ca_sgl_idx];
-
-	while (arg->ca_iov_idx < sgl->sg_nr) {
-		d_iov_t *iov;
-		ssize_t nob, buf_len;
-
-		iov = &sgl->sg_iovs[arg->ca_iov_idx];
-		buf_len = biod->bd_update ? iov->iov_len : iov->iov_buf_len;
-
-		if (buf_len <= arg->ca_iov_off) {
-			D_ERROR("Invalid iov[%d] "DF_U64"/"DF_U64" %d\n",
-				arg->ca_iov_idx, arg->ca_iov_off,
-				buf_len, biod->bd_update);
-			return -DER_INVAL;
-		}
-
-		if (iov->iov_buf == NULL) {
-			D_ERROR("Invalid iov[%d], iov_buf is NULL\n",
-				arg->ca_iov_idx);
-			return -DER_INVAL;
-		}
-
-		nob = min(size, buf_len - arg->ca_iov_off);
-		if (addr != NULL) {
-			D_DEBUG(DB_TRACE, "bio copy %p size %zd\n",
-				addr, nob);
-			bio_memcpy(biod, media, addr, iov->iov_buf +
-					arg->ca_iov_off, nob);
-			addr += nob;
-		} else {
-			/* fetch on hole */
-			D_ASSERT(!biod->bd_update);
-		}
-
-		arg->ca_iov_off += nob;
-		if (!biod->bd_update) {
-			/* the first population for fetch */
-			if (arg->ca_iov_off == nob)
-				sgl->sg_nr_out++;
-
-			iov->iov_len = arg->ca_iov_off;
-			/* consumed an iov, move to the next */
-			if (iov->iov_len == iov->iov_buf_len) {
-				arg->ca_iov_off = 0;
-				arg->ca_iov_idx++;
-			}
-		} else {
-			/* consumed an iov, move to the next */
-			if (arg->ca_iov_off == iov->iov_len) {
-				arg->ca_iov_off = 0;
-				arg->ca_iov_idx++;
-			}
-		}
-
-		size -= nob;
-		if (size == 0)
-			return 0;
-	}
-
-	D_DEBUG(DB_TRACE, "Consumed all iovs, "DF_U64" bytes left\n", size);
-	return -DER_REC2BIG;
-}
-
 static void
 dma_drop_iod(struct bio_dma_buffer *bdb)
 {
@@ -898,17 +918,26 @@ dma_drop_iod(struct bio_dma_buffer *bdb)
 }
 
 int
-bio_iod_prep(struct bio_desc *biod, unsigned int type)
+bio_iod_prep(struct bio_desc *biod, unsigned int type, void *bulk_ctxt,
+	     unsigned int bulk_perm)
 {
-	struct bio_dma_buffer *bdb;
-	int rc, retry_cnt = 0;
+	struct bio_bulk_args	 bulk_arg;
+	struct bio_dma_buffer	*bdb;
+	void			*arg = NULL;
+	int			 rc, retry_cnt = 0;
 
 	if (biod->bd_buffer_prep)
 		return -DER_INVAL;
 
 	biod->bd_chk_type = type;
+
+	if (bulk_ctxt != NULL && !(daos_io_bypass & IOBP_SRV_BULK_CACHE)) {
+		bulk_arg.ba_bulk_ctxt = bulk_ctxt;
+		bulk_arg.ba_bulk_perm = bulk_perm;
+		arg = &bulk_arg;
+	}
 retry:
-	rc = iterate_biov(biod, dma_map_one, NULL);
+	rc = iterate_biov(biod, arg ? bulk_map_one : dma_map_one, arg);
 	if (rc) {
 		/*
 		 * To avoid deadlock, held buffers need be released
@@ -1011,8 +1040,7 @@ bio_iod_copy(struct bio_desc *biod, d_sg_list_t *sgls, unsigned int nr_sgl)
 }
 
 static int
-flush_one(struct bio_desc *biod, struct bio_iov *biov,
-	  struct bio_copy_args *arg)
+flush_one(struct bio_desc *biod, struct bio_iov *biov, void *arg)
 {
 	struct umem_instance *umem = biod->bd_ctxt->bic_umem;
 
@@ -1071,7 +1099,7 @@ bio_rwv(struct bio_io_context *ioctxt, struct bio_sglist *bsgl_in,
 	bsgl->bs_nr_out = bsgl->bs_nr;
 
 	/* map the biov to DMA safe buffer, fill DMA buffer if read operation */
-	rc = bio_iod_prep(biod, BIO_CHK_TYPE_LOCAL);
+	rc = bio_iod_prep(biod, BIO_CHK_TYPE_LOCAL, NULL, 0);
 	if (rc)
 		goto out;
 

--- a/src/bio/bio_buffer.c
+++ b/src/bio/bio_buffer.c
@@ -249,6 +249,7 @@ iod_release_buffer(struct bio_desc *biod)
 		D_ASSERT(chunk != NULL);
 		D_ASSERT(chunk->bdc_ref > 0);
 		D_ASSERT(chunk->bdc_type == biod->bd_chk_type);
+		D_ASSERT(chunk->bdc_bulk_grp == NULL);
 		chunk->bdc_ref--;
 
 		D_DEBUG(DB_IO, "Release chunk:%p[%p] idx:%u ref:%u huge:%d "
@@ -570,6 +571,7 @@ dma_map_one(struct bio_desc *biod, struct bio_iov *biov, void *arg)
 	end = bio_iov2raw_off(biov) + bio_iov2raw_len(biov);
 	pg_cnt = ((end + BIO_DMA_PAGE_SZ - 1) >> BIO_DMA_PAGE_SHIFT) -
 			(off >> BIO_DMA_PAGE_SHIFT);
+	D_ASSERT(pg_cnt > 0);
 	pg_off = off & ((uint64_t)BIO_DMA_PAGE_SZ - 1);
 
 	/*

--- a/src/bio/bio_bulk.c
+++ b/src/bio/bio_bulk.c
@@ -655,6 +655,7 @@ bulk_cache_create(struct bio_dma_buffer *bdb)
 	int			 i;
 
 	D_ASSERT(bbc->bbc_grps == NULL);
+	D_INIT_LIST_HEAD(&bbc->bbc_grp_lru);
 
 	D_ALLOC_ARRAY(bbc->bbc_grps, BIO_BULK_GRPS_MAX);
 	if (bbc->bbc_grps == NULL)
@@ -667,7 +668,6 @@ bulk_cache_create(struct bio_dma_buffer *bdb)
 		return -DER_NOMEM;
 	}
 
-	D_INIT_LIST_HEAD(&bbc->bbc_grp_lru);
 	bbc->bbc_grp_max = BIO_BULK_GRPS_MAX;
 	bbc->bbc_grp_cnt = 0;
 
@@ -711,6 +711,7 @@ bio_iod_bulk(struct bio_desc *biod, int sgl_idx, int iov_idx,
 	bsgl = &biod->bd_sgls[sgl_idx];
 	D_ASSERT(iov_idx < bsgl->bs_nr_out);
 	bulk_idx += iov_idx;
+	D_ASSERT(bulk_idx < biod->bd_bulk_cnt);
 
 	hdl = biod->bd_bulk_hdls[bulk_idx];
 	if (hdl == NULL)

--- a/src/bio/bio_bulk.c
+++ b/src/bio/bio_bulk.c
@@ -1,0 +1,723 @@
+/**
+ * (C) Copyright 2021 Intel Corporation.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause-Patent
+ */
+#define D_LOGFAC	DD_FAC(bio)
+#include "bio_internal.h"
+
+static int (*bulk_create_fn)(void *ctxt, d_sg_list_t *sgl, unsigned int perm,
+			     void **bulk_hdl);
+static int (*bulk_free_fn)(void *bulk_hdl);
+
+void bio_register_bulk_ops(int (*bulk_create)(void *ctxt, d_sg_list_t *sgl,
+					      unsigned int perm,
+					      void **bulk_hdl),
+			   int (*bulk_free)(void *bulk_hdl))
+{
+	bulk_create_fn = bulk_create;
+	bulk_free_fn = bulk_free;
+}
+
+static void
+grp_sop_swap(void *array, int a, int b)
+{
+	struct bio_bulk_group	**bbgs = (struct bio_bulk_group **)array;
+	struct bio_bulk_group	 *tmp;
+
+	tmp = bbgs[a];
+	bbgs[a] = bbgs[b];
+	bbgs[b] = tmp;
+}
+
+static int
+grp_sop_cmp(void *array, int a, int b)
+{
+	struct bio_bulk_group	**bbgs = (struct bio_bulk_group **)array;
+
+	if (bbgs[a]->bbg_bulk_pgs > bbgs[b]->bbg_bulk_pgs)
+		return 1;
+	if (bbgs[a]->bbg_bulk_pgs < bbgs[b]->bbg_bulk_pgs)
+		return -1;
+	return 0;
+}
+
+static int
+grp_sop_cmp_key(void *array, int i, uint64_t key)
+{
+	struct bio_bulk_group	**bbgs = (struct bio_bulk_group **)array;
+	unsigned int		  pg_cnt = (unsigned int)key;
+
+	if (bbgs[i]->bbg_bulk_pgs > pg_cnt)
+		return 1;
+	if (bbgs[i]->bbg_bulk_pgs < pg_cnt)
+		return -1;
+	return 0;
+}
+
+static daos_sort_ops_t	bulk_grp_sort_ops = {
+	.so_swap	= grp_sop_swap,
+	.so_cmp		= grp_sop_cmp,
+	.so_cmp_key	= grp_sop_cmp_key,
+};
+
+static inline bool
+bulk_hdl_is_inuse(struct bio_bulk_hdl *hdl)
+{
+	D_ASSERT(hdl->bbh_chunk != NULL);
+	D_ASSERT(hdl->bbh_bulk != NULL);
+
+	if (hdl->bbh_inuse) {
+		D_ASSERT(d_list_empty(&hdl->bbh_link));
+		return true;
+	}
+	D_ASSERT(!d_list_empty(&hdl->bbh_link));
+	return false;
+}
+
+static inline bool
+bulk_chunk_is_idle(struct bio_dma_chunk *chk)
+{
+	D_ASSERT(chk->bdc_ref == 0);
+	D_ASSERT(chk->bdc_pg_idx == 0);
+	D_ASSERT(chk->bdc_bulks != NULL);
+	D_ASSERT(chk->bdc_bulk_cnt >= chk->bdc_bulk_idle);
+
+	return chk->bdc_bulk_cnt == chk->bdc_bulk_idle;
+}
+
+static inline bool
+bulk_grp_is_idle(struct bio_bulk_group *bbg)
+{
+	struct bio_dma_chunk	*chk;
+
+	d_list_for_each_entry(chk, &bbg->bbg_dma_chks, bdc_link) {
+		if (!bulk_chunk_is_idle(chk))
+			return false;
+	}
+	return true;
+}
+
+static void
+bulk_chunk_depopulate(struct bio_dma_chunk *chk, bool fini)
+{
+	struct bio_bulk_hdl	*hdl;
+	int			 i, rc;
+
+	D_ASSERT(bulk_chunk_is_idle(chk));
+
+	for (i = 0; i < chk->bdc_bulk_cnt; i++) {
+		hdl = &chk->bdc_bulks[i];
+
+		D_ASSERT(!bulk_hdl_is_inuse(hdl));
+		d_list_del_init(&hdl->bbh_link);
+		rc = bulk_free_fn(hdl->bbh_bulk);
+		if (rc)
+			D_ERROR("Failed to free bulk hdl %p "DF_RC"\n",
+				hdl->bbh_bulk, DP_RC(rc));
+		hdl->bbh_bulk = NULL;
+	}
+	chk->bdc_bulk_cnt = chk->bdc_bulk_idle = 0;
+	chk->bdc_bulk_grp = NULL;
+
+	if (fini) {
+		D_FREE(chk->bdc_bulks);
+		chk->bdc_bulks = NULL;
+	}
+}
+
+static inline void
+bulk_grp_evict_one(struct bio_dma_buffer *bdb, struct bio_dma_chunk *chk,
+		   bool fini)
+{
+	struct bio_bulk_group	*bbg = chk->bdc_bulk_grp;
+
+	D_ASSERT(bbg != NULL);
+	D_ASSERT(bbg->bbg_chk_cnt > 0);
+
+	bulk_chunk_depopulate(chk, fini);
+	bbg->bbg_chk_cnt--;
+	d_list_move_tail(&chk->bdc_link, &bdb->bdb_idle_list);
+}
+
+static inline void
+bulk_grp_reset(struct bio_bulk_group *bbg, unsigned int pg_cnt)
+{
+	D_ASSERT(d_list_empty(&bbg->bbg_lru_link));
+	D_ASSERT(d_list_empty(&bbg->bbg_dma_chks));
+	D_ASSERT(d_list_empty(&bbg->bbg_idle_bulks));
+	D_ASSERT(bbg->bbg_chk_cnt == 0);
+
+	bbg->bbg_bulk_pgs = pg_cnt;
+}
+
+static void
+bulk_grp_evict(struct bio_dma_buffer *bdb, struct bio_bulk_group *bbg,
+	       bool fini)
+{
+	struct bio_dma_chunk	*chk, *tmp;
+
+	D_ASSERT(d_list_empty(&bbg->bbg_lru_link));
+
+	d_list_for_each_entry_safe(chk, tmp, &bbg->bbg_dma_chks, bdc_link)
+		bulk_grp_evict_one(bdb, chk, fini);
+
+	D_ASSERT(d_list_empty(&bbg->bbg_idle_bulks));
+}
+
+static struct bio_bulk_group *
+bulk_grp_add(struct bio_dma_buffer *bdb, unsigned int pgs)
+{
+	struct bio_bulk_cache	*bbc = &bdb->bdb_bulk_cache;
+	struct bio_bulk_group	*bbg;
+	int			 grp_idx, rc;
+
+	/* If there is empty bulk group slot, add new bulk group */
+	if (bbc->bbc_grp_cnt < bbc->bbc_grp_max) {
+		grp_idx = bbc->bbc_grp_cnt;
+
+		bbg = &bbc->bbc_grps[grp_idx];
+		bbc->bbc_sorted[grp_idx] = bbg;
+
+		bbc->bbc_grp_cnt++;
+		goto done;
+	}
+
+	D_ASSERT(bbc->bbc_grp_cnt == bbc->bbc_grp_max);
+	/* Try to evict an idle unused group */
+	D_ASSERT(!d_list_empty(&bbc->bbc_grp_lru));
+	d_list_for_each_entry(bbg, &bbc->bbc_grp_lru, bbg_lru_link) {
+		if (bulk_grp_is_idle(bbg)) {
+			/* Replace victim with new bulk group */
+			d_list_del_init(&bbg->bbg_lru_link);
+			bulk_grp_evict(bdb, bbg, false);
+			goto done;
+		}
+	}
+
+	/* Group array is full, and all groups are inuse */
+	return NULL;
+done:
+	bulk_grp_reset(bbg, pgs);
+	rc = daos_array_sort(bbc->bbc_sorted, bbc->bbc_grp_cnt, true,
+			     &bulk_grp_sort_ops);
+	D_ASSERT(rc == 0);
+
+	return bbg;
+}
+
+static struct bio_bulk_group *
+bulk_grp_get(struct bio_dma_buffer *bdb, unsigned int pgs)
+{
+	struct bio_bulk_cache	*bbc = &bdb->bdb_bulk_cache;
+	struct bio_bulk_group	*bbg = NULL;
+	int			 grp_idx;
+
+	if (d_list_empty(&bbc->bbc_grp_lru))
+		goto add_grp;
+
+	D_ASSERT(bbc->bbc_grp_cnt > 0);
+	/* Quick check on the last used bulk group */
+	bbg = d_list_entry(&bbc->bbc_grp_lru.prev, struct bio_bulk_group,
+			   bbg_lru_link);
+	if (bbg->bbg_bulk_pgs == pgs)
+		return bbg;
+
+	/* Find bulk group with bulk size >= requested size */
+	grp_idx = daos_array_find_ge(bbc->bbc_sorted, bbc->bbc_grp_cnt, pgs,
+				     &bulk_grp_sort_ops);
+	if (grp_idx >= 0) {
+		bbg = bbc->bbc_sorted[grp_idx];
+		/* The group has exact matched bulk size */
+		if (bbg->bbg_bulk_pgs == pgs)
+			goto done;
+	}
+add_grp:
+	/* Add new group with specified bulk size */
+	bbg = bulk_grp_add(bdb, pgs);
+done:
+	if (bbg) {
+		D_ASSERT(bbg->bbg_bulk_pgs >= pgs);
+		d_list_del_init(&bbg->bbg_lru_link);
+		d_list_add_tail(&bbg->bbg_lru_link, &bbc->bbc_grp_lru);
+	}
+
+	return bbg;
+}
+
+int
+bulk_reclaim_chunk(struct bio_dma_buffer *bdb, struct bio_bulk_group *ex_grp)
+{
+	struct bio_bulk_cache	*bbc = &bdb->bdb_bulk_cache;
+	struct bio_bulk_group	*bbg;
+	struct bio_dma_chunk	*chk;
+
+	d_list_for_each_entry(bbg, &bbc->bbc_grp_lru, bbg_lru_link) {
+		if (ex_grp != NULL && ex_grp == bbg)
+			continue;
+
+		d_list_for_each_entry(chk, &bbg->bbg_dma_chks, bdc_link) {
+			if (bulk_chunk_is_idle(chk)) {
+				D_DEBUG(DB_IO, "Reclaim a bulk chunk (%u)\n",
+					bbg->bbg_bulk_pgs);
+				bulk_grp_evict_one(bdb, chk, false);
+				return 0;
+			}
+		}
+	}
+	/* All bulk chunks are inuse */
+	return -DER_AGAIN;
+}
+
+static int
+bulk_create_hdl(struct bio_dma_chunk *chk, struct bio_bulk_args *arg)
+{
+	struct bio_bulk_group	*bbg = chk->bdc_bulk_grp;
+	d_sg_list_t		 sgl;
+	struct bio_bulk_hdl	*bbh;
+	unsigned int		 bulk_idx, pgs;
+	int			 rc;
+
+	D_ASSERT(chk->bdc_bulk_cnt == chk->bdc_bulk_idle);
+	bulk_idx = chk->bdc_bulk_cnt;
+	D_ASSERT(bulk_idx < bio_chk_sz);
+
+	bbh = &chk->bdc_bulks[bulk_idx];
+	D_ASSERT(bbh->bbh_chunk == chk);
+	D_ASSERT(bbh->bbh_bulk == NULL);
+	D_ASSERT(d_list_empty(&bbh->bbh_link));
+
+	D_ASSERT(bbg != NULL);
+	pgs = bbg->bbg_bulk_pgs;
+	bbh->bbh_pg_idx = (bulk_idx * pgs);
+	D_ASSERT(bbh->bbh_pg_idx < bio_chk_sz);
+
+	rc = d_sgl_init(&sgl, 1);
+	if (rc)
+		return rc;
+
+	sgl.sg_nr_out = sgl.sg_nr;
+	sgl.sg_iovs[0].iov_buf = chk->bdc_ptr +
+				(bbh->bbh_pg_idx << BIO_DMA_PAGE_SHIFT);
+	sgl.sg_iovs[0].iov_buf_len = (pgs << BIO_DMA_PAGE_SHIFT);
+	sgl.sg_iovs[0].iov_len = (pgs << BIO_DMA_PAGE_SHIFT);
+
+	rc = bulk_create_fn(arg->ba_bulk_ctxt, &sgl, arg->ba_bulk_perm,
+			    &bbh->bbh_bulk);
+	if (rc) {
+		D_ERROR("Create bulk handle failed. "DF_RC"\n", DP_RC(rc));
+		bbh->bbh_bulk = NULL;
+	} else {
+		D_ASSERT(bbh->bbh_bulk != NULL);
+		chk->bdc_bulk_cnt++;
+		chk->bdc_bulk_idle++;
+		d_list_add_tail(&bbh->bbh_link, &bbg->bbg_idle_bulks);
+	}
+
+	d_sgl_fini(&sgl, false);
+	return 0;
+}
+
+static int
+bulk_chunk_populate(struct bio_dma_chunk *chk, struct bio_bulk_group *bbg,
+		    struct bio_bulk_args *arg)
+{
+	struct bio_bulk_hdl	*hdl;
+	int			 i, tot_bulks, rc;
+
+	if (chk->bdc_bulks == NULL) {
+		D_ALLOC_ARRAY(chk->bdc_bulks, bio_chk_sz);
+		if (chk->bdc_bulks == NULL)
+			return -DER_NOMEM;
+
+		for (i = 0; i < bio_chk_sz; i++) {
+			hdl = &chk->bdc_bulks[i];
+
+			D_INIT_LIST_HEAD(&hdl->bbh_link);
+			hdl->bbh_chunk = chk;
+		}
+	}
+
+	D_ASSERT(bulk_chunk_is_idle(chk));
+	D_ASSERT(chk->bdc_bulk_cnt == 0);
+
+	chk->bdc_bulk_grp = bbg;
+	chk->bdc_type = BIO_CHK_TYPE_IO;
+
+	D_ASSERT(bbg->bbg_bulk_pgs <= bio_chk_sz);
+	tot_bulks = bio_chk_sz / bbg->bbg_bulk_pgs;
+
+	for (i = 0; i < tot_bulks; i++) {
+		rc = bulk_create_hdl(chk, arg);
+		if (rc)
+			goto error;
+	}
+	return 0;
+error:
+	bulk_chunk_depopulate(chk, true);
+	return rc;
+}
+
+static int
+bulk_grp_grow(struct bio_dma_buffer *bdb, struct bio_bulk_group *bbg,
+	      struct bio_bulk_args *arg)
+{
+	struct bio_dma_chunk	*chk;
+	int			 rc;
+
+	/* Try grab an idle chunk first */
+	if (!d_list_empty(&bdb->bdb_idle_list))
+		goto populate;
+
+	/* Grow DMA buffer when not reaching DMA upper bound */
+	if (bdb->bdb_tot_cnt < bio_chk_cnt_max) {
+		rc = dma_buffer_grow(bdb, 1);
+		if (rc != 0)
+			return rc;
+	}
+
+	/* Try to evict an unused chunk from other bulk group */
+	rc = bulk_reclaim_chunk(bdb, bbg);
+	if (rc)
+		return rc;
+
+populate:
+	D_ASSERT(!d_list_empty(&bdb->bdb_idle_list));
+
+	chk = d_list_entry(bdb->bdb_idle_list.next,
+			   struct bio_dma_chunk, bdc_link);
+	rc = bulk_chunk_populate(chk, bbg, arg);
+	if (rc)
+		return rc;
+
+	d_list_move_tail(&chk->bdc_link, &bbg->bbg_dma_chks);
+	bbg->bbg_chk_cnt++;
+
+	return 0;
+}
+
+static void
+bulk_hdl_unhold(struct bio_bulk_hdl *hdl)
+{
+	struct bio_dma_chunk	*chk = hdl->bbh_chunk;
+	struct bio_bulk_group	*bbg;
+
+	D_ASSERT(bulk_hdl_is_inuse(hdl));
+
+	hdl->bbh_inuse = false;
+	hdl->bbh_bulk_off = 0;
+
+	D_ASSERT(chk != NULL);
+	D_ASSERT(chk->bdc_bulk_idle < chk->bdc_bulk_cnt);
+	chk->bdc_bulk_idle++;
+
+	bbg = chk->bdc_bulk_grp;
+	D_ASSERT(bbg != NULL);
+	d_list_add_tail(&hdl->bbh_link, &bbg->bbg_idle_bulks);
+}
+
+static void
+bulk_hdl_hold(struct bio_bulk_hdl *hdl, unsigned int pg_off)
+{
+	struct bio_dma_chunk	*chk = hdl->bbh_chunk;
+
+	D_ASSERT(!bulk_hdl_is_inuse(hdl));
+
+	d_list_del_init(&hdl->bbh_link);
+	hdl->bbh_inuse = true;
+	hdl->bbh_bulk_off = pg_off;
+
+	D_ASSERT(chk != NULL);
+	D_ASSERT(chk->bdc_bulk_idle > 0);
+	chk->bdc_bulk_idle--;
+}
+
+static struct bio_bulk_hdl *
+bulk_get_hdl(struct bio_desc *biod, unsigned int pg_cnt,
+	     unsigned int pg_off, struct bio_bulk_args *arg)
+{
+	struct bio_dma_buffer	*bdb = iod_dma_buf(biod);
+	struct bio_bulk_group	*bbg;
+	struct bio_bulk_hdl	*hdl;
+	int			 rc;
+
+	bbg = bulk_grp_get(bdb, pg_cnt);
+	if (bbg == NULL) {
+		D_ERROR("Failed to get bulk group (%u pages)\n", pg_cnt);
+		dump_dma_info(bdb);
+
+		biod->bd_retry = 1;
+		return NULL;
+	}
+
+	if (!d_list_empty(&bbg->bbg_idle_bulks))
+		goto done;
+
+	rc = bulk_grp_grow(bdb, bbg, arg);
+	if (rc) {
+		D_ERROR("Failed to grow bulk grp (%u pages) "DF_RC"\n",
+			pg_cnt, DP_RC(rc));
+		dump_dma_info(bdb);
+
+		if (rc == -DER_AGAIN)
+			biod->bd_retry = 1;
+
+		return NULL;
+	}
+done:
+	D_ASSERT(!d_list_empty(&bbg->bbg_idle_bulks));
+	hdl = d_list_entry(bbg->bbg_idle_bulks.next, struct bio_bulk_hdl,
+			   bbh_link);
+
+	bulk_hdl_hold(hdl, pg_off);
+	return hdl;
+}
+
+static inline bool
+bypass_bulk_cache(struct bio_iov *biov, unsigned int pg_cnt)
+{
+	/* Hole, no RDMA */
+	if (bio_addr_is_hole(&biov->bi_addr))
+		return true;
+	/* SCM, RDMA to SCM directly */
+	if (biov->bi_addr.ba_type == DAOS_MEDIA_SCM)
+		return true;
+	/* Huge IOV, allocate DMA buffer & create bulk handle on-the-fly */
+	if (pg_cnt > bio_chk_sz)
+		return true;
+
+	return false;
+}
+
+static int
+bulk_iod_init(struct bio_desc *biod)
+{
+	int	i, max_bulks = 0;
+
+	D_ASSERT(biod->bd_bulk_hdls == NULL);
+	for (i = 0; i < biod->bd_sgl_cnt; i++) {
+		struct bio_sglist *bsgl = &biod->bd_sgls[i];
+
+		max_bulks += bsgl->bs_nr_out;
+	}
+
+	D_ALLOC_ARRAY(biod->bd_bulk_hdls, max_bulks);
+	if (biod->bd_bulk_hdls == NULL) {
+		D_ERROR("Failed to allocate bulk handle array\n");
+		return -DER_NOMEM;
+	}
+	biod->bd_bulk_max = max_bulks;
+	biod->bd_bulk_cnt = 0;
+
+	return 0;
+}
+
+static inline void *
+bulk_hdl2addr(struct bio_bulk_hdl *hdl)
+{
+	struct bio_dma_chunk	*chk = hdl->bbh_chunk;
+	unsigned int		 chk_pg_idx = hdl->bbh_pg_idx;
+	unsigned int		 pg_off = hdl->bbh_bulk_off;
+
+	return chk->bdc_ptr + (chk_pg_idx << BIO_DMA_PAGE_SHIFT) + pg_off;
+}
+
+/* Try to round up the bulk size to fully utilize the chunk */
+static inline unsigned int
+roundup_pgs(unsigned int pgs)
+{
+	D_ASSERT(bio_chk_sz % 2 == 0);
+	D_ASSERT(bio_chk_sz >= pgs);
+	return bio_chk_sz / (bio_chk_sz / pgs);
+}
+
+int
+bulk_map_one(struct bio_desc *biod, struct bio_iov *biov, void *data)
+{
+	struct bio_bulk_args	*arg = data;
+	struct bio_bulk_hdl	*hdl = NULL;
+	uint64_t		 off, end;
+	unsigned int		 pg_cnt, pg_off;
+	int			 rc = 0;
+
+	D_ASSERT(bulk_create_fn != NULL && bulk_free_fn != NULL);
+	D_ASSERT(arg != NULL && arg->ba_bulk_ctxt != NULL);
+
+	D_ASSERT(biod && biod->bd_chk_type == BIO_CHK_TYPE_IO);
+	D_ASSERT(biov && bio_iov2raw_len(biov) != 0);
+
+	if (biod->bd_bulk_hdls == NULL) {
+		rc = bulk_iod_init(biod);
+		if (rc)
+			return rc;
+	}
+
+	off = bio_iov2raw_off(biov);
+	end = bio_iov2raw_off(biov) + bio_iov2raw_len(biov);
+	pg_cnt = ((end + BIO_DMA_PAGE_SZ - 1) >> BIO_DMA_PAGE_SHIFT) -
+			(off >> BIO_DMA_PAGE_SHIFT);
+	pg_off = off & ((uint64_t)BIO_DMA_PAGE_SZ - 1);
+
+	if (bypass_bulk_cache(biov, pg_cnt)) {
+		rc = dma_map_one(biod, biov, NULL);
+		goto done;
+	}
+
+	hdl = bulk_get_hdl(biod, roundup_pgs(pg_cnt), pg_off, arg);
+	if (hdl == NULL) {
+		if (biod->bd_retry)
+			return -DER_AGAIN;
+
+		D_ERROR("Failed to grab cached bulk (%d pages)\n", pg_cnt);
+		return -DER_NOMEM;
+	}
+
+	bio_iov_set_raw_buf(biov, bulk_hdl2addr(hdl));
+	rc = iod_add_region(biod, hdl->bbh_chunk, hdl->bbh_pg_idx, off, end);
+	if (rc) {
+		bulk_hdl_unhold(hdl);
+		return rc;
+	}
+done:
+	D_ASSERT(biod->bd_bulk_hdls != NULL);
+	D_ASSERT(biod->bd_bulk_cnt < biod->bd_bulk_max);
+
+	biod->bd_bulk_hdls[biod->bd_bulk_cnt] = hdl;
+	biod->bd_bulk_cnt++;
+
+	return 0;
+}
+
+void
+bulk_iod_release(struct bio_desc *biod)
+{
+	struct bio_bulk_hdl	*hdl;
+	int			 i;
+
+	if (biod->bd_bulk_hdls == NULL) {
+		D_ASSERT(biod->bd_bulk_cnt == 0);
+		return;
+	}
+
+	D_ASSERT(biod->bd_chk_type == BIO_CHK_TYPE_IO);
+	for (i = 0; i < biod->bd_bulk_cnt; i++) {
+		hdl = biod->bd_bulk_hdls[i];
+
+		/* Bypassed bulk cache */
+		if (hdl == NULL)
+			continue;
+
+		bulk_hdl_unhold(hdl);
+		biod->bd_bulk_hdls[i] = NULL;
+	}
+
+	biod->bd_bulk_cnt = 0;
+}
+
+void
+bulk_cache_destroy(struct bio_dma_buffer *bdb)
+{
+	struct bio_bulk_cache	*bbc = &bdb->bdb_bulk_cache;
+	struct bio_bulk_group	*bbg, *tmp;
+	int			 i;
+
+	if (bbc->bbc_grps == NULL) {
+		D_ASSERT(d_list_empty(&bbc->bbc_grp_lru));
+		return;
+	}
+
+	D_ASSERT(bbc->bbc_grp_cnt <= bbc->bbc_grp_max);
+
+	d_list_for_each_entry_safe(bbg, tmp, &bbc->bbc_grp_lru, bbg_lru_link) {
+		d_list_del_init(&bbg->bbg_lru_link);
+		bulk_grp_evict(bdb, bbg, true);
+	}
+
+	for (i = 0; i < bbc->bbc_grp_max; i++) {
+		bbg = &bbc->bbc_grps[i];
+		bulk_grp_reset(bbg, 0);
+	}
+
+	D_FREE(bbc->bbc_grps);
+	bbc->bbc_grps = NULL;
+	bbc->bbc_grp_max = bbc->bbc_grp_cnt = 0;
+
+	D_FREE(bbc->bbc_sorted);
+	bbc->bbc_sorted = NULL;
+}
+
+#define BIO_BULK_GRPS_MAX	64
+int
+bulk_cache_create(struct bio_dma_buffer *bdb)
+{
+	struct bio_bulk_cache	*bbc = &bdb->bdb_bulk_cache;
+	struct bio_bulk_group	*bbg;
+	int			 i;
+
+	D_ASSERT(bbc->bbc_grps == NULL);
+
+	D_ALLOC_ARRAY(bbc->bbc_grps, BIO_BULK_GRPS_MAX);
+	if (bbc->bbc_grps == NULL)
+		return -DER_NOMEM;
+
+	D_ALLOC_ARRAY(bbc->bbc_sorted, BIO_BULK_GRPS_MAX);
+	if (bbc->bbc_sorted == NULL) {
+		D_FREE(bbc->bbc_grps);
+		bbc->bbc_grps = NULL;
+		return -DER_NOMEM;
+	}
+
+	D_INIT_LIST_HEAD(&bbc->bbc_grp_lru);
+	bbc->bbc_grp_max = BIO_BULK_GRPS_MAX;
+	bbc->bbc_grp_cnt = 0;
+
+	for (i = 0; i < bbc->bbc_grp_max; i++) {
+		bbg = &bbc->bbc_grps[i];
+
+		D_INIT_LIST_HEAD(&bbg->bbg_lru_link);
+		D_INIT_LIST_HEAD(&bbg->bbg_dma_chks);
+		D_INIT_LIST_HEAD(&bbg->bbg_idle_bulks);
+		bbg->bbg_bulk_pgs = 0;
+		bbg->bbg_chk_cnt = 0;
+	}
+	return 0;
+}
+
+void *
+bio_iod_bulk(struct bio_desc *biod, int sgl_idx, int iov_idx,
+	     unsigned int *bulk_off)
+{
+	struct bio_bulk_hdl	*hdl;
+	struct bio_sglist	*bsgl = NULL;
+	int			 i, bulk_idx = 0;
+
+	/* Pass in NULL 'biod' is allowed */
+	if (biod == NULL)
+		return NULL;
+
+	/* Bulk cache bypassed */
+	if (biod->bd_bulk_hdls == NULL)
+		return NULL;
+
+	D_ASSERT(biod->bd_bulk_cnt == biod->bd_bulk_max);
+	D_ASSERT(sgl_idx < biod->bd_sgl_cnt);
+
+	for (i = 0; i < sgl_idx; i++) {
+		bsgl = &biod->bd_sgls[i];
+
+		bulk_idx += bsgl->bs_nr_out;
+	}
+
+	bsgl = &biod->bd_sgls[sgl_idx];
+	D_ASSERT(iov_idx < bsgl->bs_nr_out);
+	bulk_idx += iov_idx;
+
+	hdl = biod->bd_bulk_hdls[bulk_idx];
+	if (hdl == NULL)
+		return NULL;
+
+	D_ASSERT(bulk_hdl_is_inuse(hdl));
+	*bulk_off = hdl->bbh_bulk_off;
+
+	return hdl->bbh_bulk;
+}

--- a/src/bio/bio_bulk.c
+++ b/src/bio/bio_bulk.c
@@ -315,7 +315,7 @@ bulk_create_hdl(struct bio_dma_chunk *chk, struct bio_bulk_args *arg)
 	}
 
 	d_sgl_fini(&sgl, false);
-	return 0;
+	return rc;
 }
 
 static int
@@ -556,6 +556,7 @@ bulk_map_one(struct bio_desc *biod, struct bio_iov *biov, void *data)
 	end = bio_iov2raw_off(biov) + bio_iov2raw_len(biov);
 	pg_cnt = ((end + BIO_DMA_PAGE_SZ - 1) >> BIO_DMA_PAGE_SHIFT) -
 			(off >> BIO_DMA_PAGE_SHIFT);
+	D_ASSERT(pg_cnt > 0);
 	pg_off = off & ((uint64_t)BIO_DMA_PAGE_SZ - 1);
 
 	if (bypass_bulk_cache(biov, pg_cnt)) {

--- a/src/bio/bio_bulk.c
+++ b/src/bio/bio_bulk.c
@@ -218,7 +218,7 @@ bulk_grp_get(struct bio_dma_buffer *bdb, unsigned int pgs)
 
 	D_ASSERT(bbc->bbc_grp_cnt > 0);
 	/* Quick check on the last used bulk group */
-	bbg = d_list_entry(&bbc->bbc_grp_lru.prev, struct bio_bulk_group,
+	bbg = d_list_entry(bbc->bbc_grp_lru.prev, struct bio_bulk_group,
 			   bbg_lru_link);
 	if (bbg->bbg_bulk_pgs == pgs)
 		return bbg;

--- a/src/bio/bio_internal.h
+++ b/src/bio/bio_internal.h
@@ -32,7 +32,7 @@ struct bio_bulk_args {
 
 /* Cached bulk handle for avoiding expensive MR */
 struct bio_bulk_hdl {
-	/* Link to bbg_free_bulks */
+	/* Link to bbg_idle_bulks */
 	d_list_t		 bbh_link;
 	/* Bulk handle used by upper layer caller */
 	void			*bbh_bulk;
@@ -466,7 +466,7 @@ dump_dma_info(struct bio_dma_buffer *bdb)
 	struct bio_bulk_group	*bbg;
 	int			 i, bulk_grps = 0, bulk_chunks = 0;
 
-	D_ERROR("chunk_size:%u, tot_chunk:%u, active_iods:%u, used:%u,%u,%u\n",
+	D_EMIT("chunk_size:%u, tot_chunk:%u, active_iods:%u, used:%u,%u,%u\n",
 		bio_chk_sz, bdb->bdb_tot_cnt, bdb->bdb_active_iods,
 		bdb->bdb_used_cnt[BIO_CHK_TYPE_IO],
 		bdb->bdb_used_cnt[BIO_CHK_TYPE_LOCAL],
@@ -482,10 +482,10 @@ dump_dma_info(struct bio_dma_buffer *bdb)
 		bulk_grps++;
 		bulk_chunks += bbg->bbg_chk_cnt;
 
-		D_DEBUG(DB_IO, "bulk_grp %d: bulk_size:%u, chunks:%u\n",
+		D_EMIT("bulk_grp %d: bulk_size:%u, chunks:%u\n",
 			i, bbg->bbg_bulk_pgs, bbg->bbg_chk_cnt);
 	}
-	D_ERROR("bulk_grps:%d, bulk_chunks:%d\n", bulk_grps, bulk_chunks);
+	D_EMIT("bulk_grps:%d, bulk_chunks:%d\n", bulk_grps, bulk_chunks);
 }
 
 /* bio_monitor.c */

--- a/src/bio/bio_internal.h
+++ b/src/bio/bio_internal.h
@@ -12,6 +12,7 @@
 #include <gurt/telemetry_common.h>
 #include <gurt/telemetry_producer.h>
 #include <spdk/bdev.h>
+#include <spdk/thread.h>
 
 #define BIO_DMA_PAGE_SHIFT	12	/* 4K */
 #define BIO_DMA_PAGE_SZ		(1UL << BIO_DMA_PAGE_SHIFT)
@@ -24,9 +25,44 @@
 #define NVME_MONITOR_PERIOD	    (60ULL * (NSEC_PER_SEC / NSEC_PER_USEC))
 #define NVME_MONITOR_SHORT_PERIOD   (3ULL * (NSEC_PER_SEC / NSEC_PER_USEC))
 
+struct bio_bulk_args {
+	void		*ba_bulk_ctxt;
+	unsigned int	 ba_bulk_perm;
+};
+
+/* Cached bulk handle for avoiding expensive MR */
+struct bio_bulk_hdl {
+	/* Link to bbg_free_bulks */
+	d_list_t		 bbh_link;
+	/* Bulk handle used by upper layer caller */
+	void			*bbh_bulk;
+	/* DMA chunk the hdl localted on */
+	struct bio_dma_chunk	*bbh_chunk;
+	/* Page offset (4k pages) within the chunk */
+	unsigned int		 bbh_pg_idx;
+	/* Bulk offset in bytes */
+	unsigned int		 bbh_bulk_off;
+	/* Flags */
+	unsigned int		 bbh_inuse:1;
+};
+
+/* Bulk handle group, categorized by bulk size */
+struct bio_bulk_group {
+	/* Link to bbc_grp_lru */
+	d_list_t		 bbg_lru_link;
+	/* All DMA chunks in this group */
+	d_list_t		 bbg_dma_chks;
+	/* All free bulk handles in this group */
+	d_list_t		 bbg_idle_bulks;
+	/* Bulk size in pages (4k page) */
+	unsigned int		 bbg_bulk_pgs;
+	/* How many chunks used for this group */
+	unsigned int		 bbg_chk_cnt;
+};
+
 /* DMA buffer is managed in chunks */
 struct bio_dma_chunk {
-	/* Link to edb_idle_list or edb_used_list */
+	/* Link to edb_idle_list or edb_used_list or bbg_dma_chks */
 	d_list_t	 bdc_link;
 	/* Base pointer of the chunk address */
 	void		*bdc_ptr;
@@ -36,6 +72,22 @@ struct bio_dma_chunk {
 	unsigned int	 bdc_ref;
 	/* Chunk type */
 	unsigned int	 bdc_type;
+	/* == Bulk handle caching related fields == */
+	struct bio_bulk_group	*bdc_bulk_grp;
+	struct bio_bulk_hdl	*bdc_bulks;
+	unsigned int		 bdc_bulk_cnt;
+	unsigned int		 bdc_bulk_idle;
+};
+
+/* Bulk handle cache for caching various sized bulk handles */
+struct bio_bulk_cache {
+	/* Bulk group array */
+	struct bio_bulk_group	 *bbc_grps;
+	struct bio_bulk_group	**bbc_sorted;
+	unsigned int		  bbc_grp_max;
+	unsigned int		  bbc_grp_cnt;
+	/* All groups in LRU */
+	d_list_t		  bbc_grp_lru;
 };
 
 /*
@@ -51,6 +103,7 @@ struct bio_dma_buffer {
 	unsigned int		 bdb_active_iods;
 	ABT_cond		 bdb_wait_iods;
 	ABT_mutex		 bdb_mutex;
+	struct bio_bulk_cache	 bdb_bulk_cache;
 };
 
 #define BIO_PROTO_NVME_STATS_LIST					\
@@ -289,6 +342,10 @@ struct bio_desc {
 				 bd_update:1,
 				 bd_dma_issued:1,
 				 bd_retry:1;
+	/* Cached bulk handles being used by this IOD */
+	struct bio_bulk_hdl    **bd_bulk_hdls;
+	unsigned int		 bd_bulk_max;
+	unsigned int		 bd_bulk_cnt;
 	/* SG lists involved in this io descriptor */
 	unsigned int		 bd_sgl_cnt;
 	struct bio_sglist	 bd_sgls[0];
@@ -381,6 +438,55 @@ void dma_buffer_destroy(struct bio_dma_buffer *buf);
 struct bio_dma_buffer *dma_buffer_create(unsigned int init_cnt);
 void bio_memcpy(struct bio_desc *biod, uint16_t media, void *media_addr,
 		void *addr, ssize_t n);
+int dma_map_one(struct bio_desc *biod, struct bio_iov *biov, void *arg);
+int iod_add_region(struct bio_desc *biod, struct bio_dma_chunk *chk,
+		   unsigned int chk_pg_idx, uint64_t off, uint64_t end);
+int dma_buffer_grow(struct bio_dma_buffer *buf, unsigned int cnt);
+
+static inline struct bio_dma_buffer *
+iod_dma_buf(struct bio_desc *biod)
+{
+	D_ASSERT(biod->bd_ctxt->bic_xs_ctxt);
+	D_ASSERT(biod->bd_ctxt->bic_xs_ctxt->bxc_dma_buf);
+
+	return biod->bd_ctxt->bic_xs_ctxt->bxc_dma_buf;
+}
+
+/* bio_bulk.c */
+int bulk_map_one(struct bio_desc *biod, struct bio_iov *biov, void *data);
+void bulk_iod_release(struct bio_desc *biod);
+int bulk_cache_create(struct bio_dma_buffer *bdb);
+void bulk_cache_destroy(struct bio_dma_buffer *bdb);
+int bulk_reclaim_chunk(struct bio_dma_buffer *bdb,
+		       struct bio_bulk_group *ex_grp);
+static inline void
+dump_dma_info(struct bio_dma_buffer *bdb)
+{
+	struct bio_bulk_cache	*bbc = &bdb->bdb_bulk_cache;
+	struct bio_bulk_group	*bbg;
+	int			 i, bulk_grps = 0, bulk_chunks = 0;
+
+	D_ERROR("chunk_size:%u, tot_chunk:%u, active_iods:%u, used:%u,%u,%u\n",
+		bio_chk_sz, bdb->bdb_tot_cnt, bdb->bdb_active_iods,
+		bdb->bdb_used_cnt[BIO_CHK_TYPE_IO],
+		bdb->bdb_used_cnt[BIO_CHK_TYPE_LOCAL],
+		bdb->bdb_used_cnt[BIO_CHK_TYPE_REBUILD]);
+
+	/* cached bulk info */
+	for (i = 0; i < bbc->bbc_grp_cnt; i++) {
+		bbg = &bbc->bbc_grps[i];
+
+		if (bbg->bbg_chk_cnt == 0)
+			continue;
+
+		bulk_grps++;
+		bulk_chunks += bbg->bbg_chk_cnt;
+
+		D_DEBUG(DB_IO, "bulk_grp %d: bulk_size:%u, chunks:%u\n",
+			i, bbg->bbg_bulk_pgs, bbg->bbg_chk_cnt);
+	}
+	D_ERROR("bulk_grps:%d, bulk_chunks:%d\n", bulk_grps, bulk_chunks);
+}
 
 /* bio_monitor.c */
 int bio_init_health_monitoring(struct bio_blobstore *bb, char *bdev_name);

--- a/src/common/debug.c
+++ b/src/common/debug.c
@@ -77,6 +77,10 @@ struct io_bypass io_bypass_dict[] = {
 		.iob_str	= IOBP_ENV_PM_SNAP,
 	},
 	{
+		.iob_bit	= IOBP_SRV_BULK_CACHE,
+		.iob_str	= IOBP_ENV_SRV_BULK_CACHE,
+	},
+	{
 		.iob_bit	= IOBP_OFF,
 		.iob_str	= NULL,
 	},

--- a/src/engine/srv.c
+++ b/src/engine/srv.c
@@ -1214,6 +1214,7 @@ dss_srv_init(void)
 	if (rc != 0)
 		D_GOTO(failed, rc);
 	xstream_data.xd_init_step = XD_INIT_NVME;
+	bio_register_bulk_ops(crt_bulk_create, crt_bulk_free);
 
 	/* start xstreams */
 	rc = dss_xstreams_init();

--- a/src/include/daos/debug.h
+++ b/src/include/daos/debug.h
@@ -103,6 +103,8 @@ enum {
 	IOBP_PM			= (1 << 4),
 	/** no PMDK snapshot (PMDK transaction will be broken) */
 	IOBP_PM_SNAP		= (1 << 5),
+	/** bypass bulk handle cache */
+	IOBP_SRV_BULK_CACHE	= (1 << 6),
 };
 
 /**
@@ -117,6 +119,7 @@ enum {
 #define IOBP_ENV_NVME		"nvme"
 #define IOBP_ENV_PM		"pm"
 #define IOBP_ENV_PM_SNAP	"pm_snap"
+#define IOBP_ENV_SRV_BULK_CACHE	"srv_bulk_cache"
 
 extern unsigned int daos_io_bypass;
 

--- a/src/include/daos_srv/bio.h
+++ b/src/include/daos_srv/bio.h
@@ -379,6 +379,16 @@ struct bio_reaction_ops {
  */
 void bio_register_ract_ops(struct bio_reaction_ops *ops);
 
+/*
+ * Register bulk operations for bulk cache.
+ *
+ * \param[IN]	bulk_create	Bulk create operation
+ * \param[IN]	bulk_free	Bulk free operation
+ */
+void bio_register_bulk_ops(int (*bulk_create)(void *ctxt, d_sg_list_t *sgl,
+					      unsigned int perm,
+					      void **bulk_hdl),
+			   int (*bulk_free)(void *bulk_hdl));
 /**
  * Global NVMe initialization.
  *
@@ -594,10 +604,13 @@ enum bio_chunk_type {
  *
  * \param biod       [IN]	io descriptor
  * \param type       [IN]	chunk type used by this iod
+ * \param bulk_ctxt  [IN]	Bulk context for bulk operations
+ * \param bulk_perm  [IN]	Bulk permission
  *
  * \return			Zero on success, negative value on error
  */
-int bio_iod_prep(struct bio_desc *biod, unsigned int type);
+int bio_iod_prep(struct bio_desc *biod, unsigned int type, void *bulk_ctxt,
+		 unsigned int bulk_perm);
 
 /*
  * Post operation after the RDMA transfer or local copy done for the io
@@ -643,6 +656,19 @@ void bio_iod_flush(struct bio_desc *biod);
  * \return			SG list, or NULL on error
  */
 struct bio_sglist *bio_iod_sgl(struct bio_desc *biod, unsigned int idx);
+
+/*
+ * Helper function to get the specified bulk for an io descriptor
+ *
+ * \param biod       [IN]	io descriptor
+ * \param sgl_idx    [IN]	Index of the SG list
+ * \param iov_idx    [IN]	IOV index within the SG list
+ * \param bulk_off   [OUT]	Bulk offset
+ *
+ * \return			Cached bulk, or NULL if no cached bulk
+ */
+void *bio_iod_bulk(struct bio_desc *biod, int sgl_idx, int iov_idx,
+		   unsigned int *bulk_off);
 
 /*
  * Wrapper of ABT_thread_yield()

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -199,13 +199,11 @@ obj_bulk_comp_cb(const struct crt_bulk_cb_info *cb_info)
 	struct obj_bulk_args	*arg;
 	struct crt_bulk_desc	*bulk_desc;
 	crt_rpc_t		*rpc;
-	crt_bulk_t		 local_bulk_hdl;
 
 	if (cb_info->bci_rc != 0)
 		D_ERROR("bulk transfer failed: %d\n", cb_info->bci_rc);
 
 	bulk_desc = cb_info->bci_bulk_desc;
-	local_bulk_hdl = bulk_desc->bd_local_hdl;
 	rpc = bulk_desc->bd_rpc;
 	arg = (struct obj_bulk_args *)cb_info->bci_arg;
 	/**
@@ -221,9 +219,27 @@ obj_bulk_comp_cb(const struct crt_bulk_cb_info *cb_info)
 		ABT_eventual_set(arg->eventual, &arg->result,
 				 sizeof(arg->result));
 
-	crt_bulk_free(local_bulk_hdl);
 	crt_req_decref(rpc);
 	return cb_info->bci_rc;
+}
+
+static inline int
+bulk_cp(const struct crt_bulk_cb_info *cb_info)
+{
+	struct crt_bulk_desc	*bulk_desc;
+
+	bulk_desc = cb_info->bci_bulk_desc;
+	D_ASSERT(bulk_desc->bd_local_hdl != CRT_BULK_NULL);
+	crt_bulk_free(bulk_desc->bd_local_hdl);
+	bulk_desc->bd_local_hdl = CRT_BULK_NULL;
+
+	return obj_bulk_comp_cb(cb_info);
+}
+
+static inline int
+cached_bulk_cp(const struct crt_bulk_cb_info *cb_info)
+{
+	return obj_bulk_comp_cb(cb_info);
 }
 
 /**
@@ -266,6 +282,151 @@ obj_bulk_bypass(d_sg_list_t *sgl, crt_bulk_op_t bulk_op)
 }
 
 static int
+bulk_transfer_sgl(daos_handle_t ioh, crt_rpc_t *rpc, crt_bulk_t remote_bulk,
+		  off_t remote_off, crt_bulk_op_t bulk_op, bool bulk_bind,
+		  d_sg_list_t *sgl, int sgl_idx, struct obj_bulk_args *p_arg)
+{
+	struct bio_desc		*biod;
+	struct crt_bulk_desc	bulk_desc;
+	crt_bulk_perm_t		bulk_perm;
+	crt_bulk_opid_t		bulk_opid;
+	crt_bulk_t		local_bulk;
+	unsigned int		local_off;
+	unsigned int		iov_idx = 0;
+	size_t			remote_size;
+	int			rc;
+
+	if (remote_bulk == NULL) {
+		D_ERROR("Remote bulk is NULL\n");
+		return -DER_INVAL;
+	}
+
+	rc = crt_bulk_get_len(remote_bulk, &remote_size);
+	if (rc) {
+		D_ERROR("Failed to get remote bulk size "DF_RC"\n", DP_RC(rc));
+		return rc;
+	}
+
+	if (remote_off >= remote_size) {
+		D_ERROR("remote_bulk_off %zu >= remote_bulk_size %zu\n",
+			remote_off, remote_size);
+		return -DER_INVAL;
+	}
+
+	if (daos_io_bypass & IOBP_SRV_BULK) {
+		obj_bulk_bypass(sgl, bulk_op);
+		return 0;
+	}
+
+	biod = daos_handle_is_valid(ioh) ? vos_ioh2desc(ioh) : NULL;
+	bulk_perm = bulk_op == CRT_BULK_PUT ? CRT_BULK_RO : CRT_BULK_RW;
+
+	while (iov_idx < sgl->sg_nr_out) {
+		d_sg_list_t	sgl_sent;
+		size_t		length = 0;
+		unsigned int	start;
+		bool		cached_bulk = false;
+
+		/*
+		 * Skip bulk transfer over IOVs with NULL buffer address,
+		 * these NULL IOVs are 'holes' or deduped records.
+		 */
+		while (iov_idx < sgl->sg_nr_out &&
+		       sgl->sg_iovs[iov_idx].iov_buf == NULL) {
+			remote_off += sgl->sg_iovs[iov_idx].iov_len;
+			iov_idx++;
+		}
+
+		if (iov_idx == sgl->sg_nr_out)
+			break;
+
+		if (remote_off >= remote_size) {
+			D_ERROR("Remote bulk is used up. off:%zu, size:%zu\n",
+				remote_off, remote_size);
+			rc = -DER_OVERFLOW;
+			break;
+		}
+
+		local_bulk = bio_iod_bulk(biod, sgl_idx, iov_idx, &local_off);
+		if (local_bulk != NULL) {
+			length = sgl->sg_iovs[iov_idx].iov_len;
+			iov_idx++;
+			cached_bulk = true;
+		} else {
+			start = iov_idx;
+			sgl_sent.sg_iovs = &sgl->sg_iovs[start];
+
+			/*
+			 * For the IOVs not using cached bulk, creates bulk
+			 * handle on-the-fly.
+			 */
+			while (iov_idx < sgl->sg_nr_out &&
+			       sgl->sg_iovs[iov_idx].iov_buf != NULL &&
+			       bio_iod_bulk(biod, sgl_idx, iov_idx,
+						&local_off) == NULL) {
+				length += sgl->sg_iovs[iov_idx].iov_len;
+				iov_idx++;
+
+			};
+			D_ASSERT(iov_idx > start);
+
+			local_off = 0;
+			sgl_sent.sg_nr = sgl_sent.sg_nr_out = iov_idx - start;
+
+			rc = crt_bulk_create(rpc->cr_ctx, &sgl_sent, bulk_perm,
+					     &local_bulk);
+			if (rc != 0) {
+				D_ERROR("crt_bulk_create %d error "DF_RC".\n",
+					sgl_idx, DP_RC(rc));
+				break;
+			}
+			D_ASSERT(local_bulk != NULL);
+		}
+
+		D_ASSERT(remote_size > remote_off);
+		if (length > (remote_size - remote_off)) {
+			D_ERROR("Remote bulk isn't large enough. "
+				"local_sz:%zu, remote_sz:%zu, remote_off:%zu\n",
+				length, remote_size, remote_off);
+			rc = -DER_OVERFLOW;
+			break;
+		}
+
+		crt_req_addref(rpc);
+
+		bulk_desc.bd_rpc	= rpc;
+		bulk_desc.bd_bulk_op	= bulk_op;
+		bulk_desc.bd_remote_hdl	= remote_bulk;
+		bulk_desc.bd_local_hdl	= local_bulk;
+		bulk_desc.bd_len	= length;
+		bulk_desc.bd_remote_off	= remote_off;
+		bulk_desc.bd_local_off	= local_off;
+
+		p_arg->bulks_inflight++;
+		if (bulk_bind)
+			rc = crt_bulk_bind_transfer(&bulk_desc,
+				cached_bulk ? cached_bulk_cp : bulk_cp, p_arg,
+				&bulk_opid);
+		else
+			rc = crt_bulk_transfer(&bulk_desc,
+				cached_bulk ? cached_bulk_cp : bulk_cp, p_arg,
+				&bulk_opid);
+		if (rc < 0) {
+			D_ERROR("crt_bulk_transfer %d error "DF_RC".\n",
+				sgl_idx, DP_RC(rc));
+			p_arg->bulks_inflight--;
+			if (!cached_bulk)
+				crt_bulk_free(local_bulk);
+			crt_req_decref(rpc);
+			break;
+		}
+		remote_off += length;
+	}
+
+	return rc;
+}
+
+static int
 obj_bulk_transfer(crt_rpc_t *rpc, crt_bulk_op_t bulk_op, bool bulk_bind,
 		  crt_bulk_t *remote_bulks, uint64_t *remote_offs,
 		  daos_handle_t ioh, d_sg_list_t **sgls,
@@ -273,8 +434,6 @@ obj_bulk_transfer(crt_rpc_t *rpc, crt_bulk_op_t bulk_op, bool bulk_bind,
 		  struct obj_bulk_args *p_arg)
 {
 	struct obj_bulk_args	arg = { 0 };
-	crt_bulk_opid_t		bulk_opid;
-	crt_bulk_perm_t		bulk_perm;
 	int			i, rc, *status, ret;
 	bool			async = true;
 
@@ -288,7 +447,6 @@ obj_bulk_transfer(crt_rpc_t *rpc, crt_bulk_op_t bulk_op, bool bulk_bind,
 		async = false;
 	}
 
-	bulk_perm = bulk_op == CRT_BULK_PUT ? CRT_BULK_RO : CRT_BULK_RW;
 	rc = ABT_eventual_create(sizeof(*status), &p_arg->eventual);
 	if (rc != 0)
 		return dss_abterr2der(rc);
@@ -298,16 +456,11 @@ obj_bulk_transfer(crt_rpc_t *rpc, crt_bulk_op_t bulk_op, bool bulk_bind,
 
 	p_arg->bulks_inflight++;
 	for (i = 0; i < sgl_nr; i++) {
-		d_sg_list_t		*sgl, tmp_sgl;
-		struct crt_bulk_desc	 bulk_desc;
-		crt_bulk_t		 local_bulk_hdl;
-		daos_size_t		 offset;
-		unsigned int		 idx = 0;
+		d_sg_list_t	*sgl, tmp_sgl;
 
 		if (remote_bulks[i] == NULL)
 			continue;
 
-		offset = remote_offs != NULL ? remote_offs[i] : 0;
 		if (sgls != NULL) {
 			D_ASSERT(bsgls_dup == NULL);
 			sgl = sgls[i];
@@ -333,100 +486,9 @@ obj_bulk_transfer(crt_rpc_t *rpc, crt_bulk_op_t bulk_op, bool bulk_bind,
 				break;
 		}
 
-		if (daos_io_bypass & IOBP_SRV_BULK) {
-			/* this mode will bypass network bulk transfer and
-			 * only copy data from/to dummy buffer. This is for
-			 * performance evaluation on low bandwidth network.
-			 */
-			obj_bulk_bypass(sgl, bulk_op);
-			goto next;
-		}
-
-		/**
-		 * Let's walk through the sgl to check if the iov is empty,
-		 * which is usually gotten from punched/empty records (see
-		 * akey_fetch()), and skip these empty iov during bulk
-		 * transfer to avoid touching the input buffer.
-		 */
-		while (idx < sgl->sg_nr_out) {
-			d_sg_list_t	sgl_sent;
-			daos_size_t	length = 0;
-			size_t		remote_bulk_size;
-			unsigned int	start;
-
-			/**
-			 * Skip the punched/empty record, let's also skip the
-			 * record in the input buffer instead of memset to 0.
-			 */
-			while (idx < sgl->sg_nr_out &&
-				sgl->sg_iovs[idx].iov_buf == NULL) {
-				offset += sgl->sg_iovs[idx].iov_len;
-				idx++;
-			}
-
-			if (idx == sgl->sg_nr_out)
-				break;
-
-			start = idx;
-			sgl_sent.sg_iovs = &sgl->sg_iovs[start];
-			/* Find the end of the non-empty record */
-			while (sgl->sg_iovs[idx].iov_buf != NULL &&
-			       idx < sgl->sg_nr_out) {
-				length += sgl->sg_iovs[idx].iov_len;
-				idx++;
-			}
-
-			rc = crt_bulk_get_len(remote_bulks[i],
-					      &remote_bulk_size);
-			if (rc)
-				break;
-
-			if ((offset + length) > remote_bulk_size) {
-				D_DEBUG(DLOG_DBG, DF_U64 " > %zu : %d\n",
-					length,	remote_bulk_size,
-					-DER_OVERFLOW);
-				rc = -DER_OVERFLOW;
-				break;
-			}
-			sgl_sent.sg_nr = idx - start;
-			sgl_sent.sg_nr_out = idx - start;
-
-			rc = crt_bulk_create(rpc->cr_ctx, &sgl_sent,
-					     bulk_perm, &local_bulk_hdl);
-			if (rc != 0) {
-				D_ERROR("crt_bulk_create %d error (%d).\n",
-					i, rc);
-				break;
-			}
-
-			crt_req_addref(rpc);
-
-			bulk_desc.bd_rpc	= rpc;
-			bulk_desc.bd_bulk_op	= bulk_op;
-			bulk_desc.bd_remote_hdl	= remote_bulks[i];
-			bulk_desc.bd_local_hdl	= local_bulk_hdl;
-			bulk_desc.bd_len	= length;
-			bulk_desc.bd_remote_off	= offset;
-			bulk_desc.bd_local_off	= 0;
-
-			p_arg->bulks_inflight++;
-			if (bulk_bind)
-				rc = crt_bulk_bind_transfer(&bulk_desc,
-					obj_bulk_comp_cb, p_arg, &bulk_opid);
-			else
-				rc = crt_bulk_transfer(&bulk_desc,
-					obj_bulk_comp_cb, p_arg, &bulk_opid);
-			if (rc < 0) {
-				D_ERROR("crt_bulk_transfer %d error (%d).\n",
-					i, rc);
-				p_arg->bulks_inflight--;
-				crt_bulk_free(local_bulk_hdl);
-				crt_req_decref(rpc);
-				break;
-			}
-			offset += length;
-		}
-	next:
+		rc = bulk_transfer_sgl(ioh, rpc, remote_bulks[i],
+				       remote_offs ? remote_offs[i] : 0,
+				       bulk_op, bulk_bind, sgl, i, p_arg);
 		if (sgls == NULL)
 			d_sgl_fini(sgl, false);
 		if (rc)
@@ -1421,7 +1483,8 @@ obj_local_rw_internal(crt_rpc_t *rpc, struct obj_io_context *ioc,
 		goto out;
 
 	biod = vos_ioh2desc(ioh);
-	rc = bio_iod_prep(biod, BIO_CHK_TYPE_IO);
+	rc = bio_iod_prep(biod, BIO_CHK_TYPE_IO, rma ? rpc->cr_ctx : NULL,
+			  CRT_BULK_RW);
 	if (rc) {
 		D_ERROR(DF_UOID" bio_iod_prep failed: "DF_RC".\n",
 			DP_UOID(orw->orw_oid), DP_RC(rc));
@@ -1872,7 +1935,7 @@ ds_obj_ec_rep_handler(crt_rpc_t *rpc)
 		goto out;
 	}
 	biod = vos_ioh2desc(ioh);
-	rc = bio_iod_prep(biod, BIO_CHK_TYPE_IO);
+	rc = bio_iod_prep(biod, BIO_CHK_TYPE_IO, rpc->cr_ctx, CRT_BULK_RW);
 	if (rc) {
 		D_ERROR(DF_UOID" bio_iod_prep failed: "DF_RC".\n",
 			DP_UOID(oer->er_oid), DP_RC(rc));
@@ -1955,7 +2018,8 @@ ds_obj_ec_agg_handler(crt_rpc_t *rpc)
 			goto out;
 		}
 		biod = vos_ioh2desc(ioh);
-		rc = bio_iod_prep(biod, BIO_CHK_TYPE_IO);
+		rc = bio_iod_prep(biod, BIO_CHK_TYPE_IO, rpc->cr_ctx,
+				  CRT_BULK_RW);
 		if (rc) {
 			D_ERROR(DF_UOID" bio_iod_prep failed: "DF_RC".\n",
 				DP_UOID(oea->ea_oid), DP_RC(rc));
@@ -3773,7 +3837,9 @@ ds_cpd_handle_one(crt_rpc_t *rpc, struct daos_cpd_sub_head *dcsh,
 			goto out;
 
 		biods[i] = vos_ioh2desc(iohs[i]);
-		rc = bio_iod_prep(biods[i], BIO_CHK_TYPE_IO);
+		rc = bio_iod_prep(biods[i], BIO_CHK_TYPE_IO,
+				  dcu->dcu_flags & ORF_CPD_BULK ?
+					rpc->cr_ctx : NULL, CRT_BULK_RW);
 		if (rc != 0) {
 			D_ERROR("bio_iod_prep failed for obj "DF_UOID
 				", DTX "DF_DTI": "DF_RC"\n",

--- a/src/object/srv_obj_migrate.c
+++ b/src/object/srv_obj_migrate.c
@@ -1151,7 +1151,8 @@ migrate_fetch_update_bulk(struct migrate_one *mrone, daos_handle_t oh,
 		return rc;
 	}
 
-	rc = bio_iod_prep(vos_ioh2desc(ioh), BIO_CHK_TYPE_REBUILD);
+	rc = bio_iod_prep(vos_ioh2desc(ioh), BIO_CHK_TYPE_REBUILD, NULL,
+			  CRT_BULK_RW);
 	if (rc) {
 		D_ERROR("Prepare EIOD for "DF_UOID" error: "DF_RC"\n",
 			DP_UOID(mrone->mo_oid), DP_RC(rc));

--- a/src/rdb/rdb_util.c
+++ b/src/rdb/rdb_util.c
@@ -326,7 +326,7 @@ rdb_vos_fetch_addr(daos_handle_t cont, daos_epoch_t epoch, rdb_oid_t oid,
 	if (rc != 0)
 		return rc;
 
-	rc = bio_iod_prep(vos_ioh2desc(io), BIO_CHK_TYPE_IO);
+	rc = bio_iod_prep(vos_ioh2desc(io), BIO_CHK_TYPE_IO, NULL, 0);
 	if (rc) {
 		D_ERROR("prep io descriptor error:"DF_RC"\n", DP_RC(rc));
 		goto out;

--- a/src/tests/daos_perf.c
+++ b/src/tests/daos_perf.c
@@ -362,7 +362,7 @@ _vos_update_or_fetch(int obj_idx, enum ts_op_type op_type,
 		if (rc)
 			return rc;
 
-		rc = bio_iod_prep(vos_ioh2desc(ioh), BIO_CHK_TYPE_IO);
+		rc = bio_iod_prep(vos_ioh2desc(ioh), BIO_CHK_TYPE_IO, NULL, 0);
 		if (rc)
 			goto end;
 

--- a/src/vos/tests/vts_gc.c
+++ b/src/vos/tests/vts_gc.c
@@ -119,7 +119,7 @@ gc_obj_update(struct gc_test_args *args, daos_handle_t coh, daos_unit_oid_t oid,
 			return rc;
 		}
 
-		rc = bio_iod_prep(vos_ioh2desc(ioh), BIO_CHK_TYPE_IO);
+		rc = bio_iod_prep(vos_ioh2desc(ioh), BIO_CHK_TYPE_IO, NULL, 0);
 		if (rc) {
 			print_error("Failed to prepare bio desc\n");
 			return rc;

--- a/src/vos/tests/vts_io.c
+++ b/src/vos/tests/vts_io.c
@@ -576,7 +576,7 @@ io_test_obj_update(struct io_test_args *arg, daos_epoch_t epoch, uint64_t flags,
 	}
 
 	srv_iov = &sgl->sg_iovs[0];
-	rc = bio_iod_prep(vos_ioh2desc(ioh), BIO_CHK_TYPE_IO);
+	rc = bio_iod_prep(vos_ioh2desc(ioh), BIO_CHK_TYPE_IO, NULL, 0);
 	if (rc)
 		goto end;
 
@@ -643,7 +643,7 @@ io_test_obj_fetch(struct io_test_args *arg, daos_epoch_t epoch, uint64_t flags,
 	}
 
 	dst_iov = &sgl->sg_iovs[0];
-	rc = bio_iod_prep(vos_ioh2desc(ioh), BIO_CHK_TYPE_IO);
+	rc = bio_iod_prep(vos_ioh2desc(ioh), BIO_CHK_TYPE_IO, NULL, 0);
 	if (rc)
 		goto end;
 

--- a/src/vos/vos_io.c
+++ b/src/vos/vos_io.c
@@ -2395,7 +2395,7 @@ vos_obj_copy(struct vos_io_context *ioc, d_sg_list_t *sgls,
 	int rc, err;
 
 	D_ASSERT(sgl_nr == ioc->ic_iod_nr);
-	rc = bio_iod_prep(ioc->ic_biod, BIO_CHK_TYPE_IO);
+	rc = bio_iod_prep(ioc->ic_biod, BIO_CHK_TYPE_IO, NULL, 0);
 	if (rc)
 		return rc;
 


### PR DESCRIPTION
To reduce heavy MR operations, BIO caches bulk handles created over
DMA buffer chunks. The cached bulk handles are categorized by bulk
size, one DMA buffer chunk is populated with same sized bulk handles,
if certain sized bulk handles aren't sufficient, it'll try to populate
an idle chunk by growing DMA buffer, or evicting an unused bulk chunk
when the DMA buffer size reached upper bound.

Bulk cached is only used for NVMe I/Os so far. (not for RDMA to SCM),
to bypass bulk cache, specify "srv_bulk_cache" in the bypass env of
"DAOS_IO_BYPASS".

Signed-off-by: Niu Yawei <yawei.niu@intel.com>