### PR TITLE
DAOS-7359 dtx: handle noop update properly

### DIFF
--- a/src/dtx/dtx_common.c
+++ b/src/dtx/dtx_common.c
@@ -811,6 +811,7 @@ dtx_leader_end(struct dtx_leader_handle *dlh, struct ds_cont_child *cont,
 	int				 status = -1;
 	int				 rc = 0;
 	bool				 aborted = false;
+	bool				 unpin = false;
 
 	D_ASSERT(cont != NULL);
 
@@ -840,7 +841,8 @@ dtx_leader_end(struct dtx_leader_handle *dlh, struct ds_cont_child *cont,
 	case DTX_ST_PREPARED:
 		break;
 	case DTX_ST_INITED:
-		if (dth->dth_modification_cnt == 0)
+		if (dth->dth_modification_cnt == 0 ||
+		    !dth->dth_active)
 			break;
 		/* full through */
 	case DTX_ST_ABORTED:
@@ -857,6 +859,14 @@ dtx_leader_end(struct dtx_leader_handle *dlh, struct ds_cont_child *cont,
 		 */
 		dth->dth_sync = 1;
 		goto sync;
+	}
+
+	/* For standalone modification, if leader modified nothing, then
+	 * non-leader(s) must be the same, unpin the DTX via dtx_abort().
+	 */
+	if (!dth->dth_active) {
+		unpin = true;
+		D_GOTO(abort, result = 0);
 	}
 
 	/* If the DTX is started befoe DTX resync (for rebuild), then it is
@@ -978,7 +988,7 @@ abort:
 	 * to locally retry for avoiding RPC timeout. The leader replica
 	 * will trigger retry globally without aborting 'prepared' ones.
 	 */
-	if (result < 0 && result != -DER_AGAIN && !dth->dth_solo) {
+	if (unpin || (result < 0 && result != -DER_AGAIN && !dth->dth_solo)) {
 		/* Drop partial modification for distributed transaction. */
 		vos_dtx_cleanup(dth);
 		dte = &dth->dth_dte;

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -4122,10 +4122,10 @@ ds_obj_dtx_follower(crt_rpc_t *rpc, struct obj_io_context *ioc)
 				    dth.dth_modification_cnt > 0 ?
 				    true : false);
 
-	/* For the case of only containing read sub operations,
-	 *  we will generate DTX entry for DTX recovery.
+	/* For the case of only containing read sub operations, we will
+	 * generate DTX entry for DTX recovery. Similarly for noop case.
 	 */
-	if (rc == 0 && dth.dth_modification_cnt == 0)
+	if (rc == 0 && (dth.dth_modification_cnt == 0 || !dth.dth_active))
 		rc = vos_dtx_pin(&dth, true);
 
 	rc = dtx_end(&dth, ioc->ioc_coc, rc);


### PR DESCRIPTION
It is possible that a update RPC changes nothing on the target
but without failure because of empty IOD. Under such case, the
leader should not regard it as DTX entry re-allocation by race;
instead, by checking dth::dth_active, it can know that this is
a noop update, and avoid generating improper "-DER_INPROGRESS"
that will cause the client to retry again and again.

Signed-off-by: Fan Yong <fan.yong@intel.com>