### PR TITLE
DAOS-7359 dtx: handle noop update properly

### DIFF
--- a/src/dtx/dtx_common.c
+++ b/src/dtx/dtx_common.c
@@ -722,7 +722,8 @@ dtx_leader_end(struct dtx_leader_handle *dlh, struct ds_cont_child *cont,
 	case DTX_ST_PREPARED:
 		break;
 	case DTX_ST_INITED:
-		if (dth->dth_modification_cnt == 0)
+		if (dth->dth_modification_cnt == 0 ||
+		    !dth->dth_active)
 			break;
 		/* full through */
 	case DTX_ST_ABORTED:


### PR DESCRIPTION
It is possible that a update RPC changes nothing on the target
but without failure because of empty IOD. Under such case, the
leader should not regard it as DTX entry re-allocation by race;
instead, by checking dth::dth_active, it can know that this is
a noop update, and avoid generating improper "-DER_INPROGRESS"
that will cause the client to retry again and again.

Master-PR: https://github.com/daos-stack/daos/pull/5597

Signed-off-by: Fan Yong <fan.yong@intel.com>