### PR TITLE
DAOS-7359 dtx: handle noop update properly

### DIFF
--- a/src/dtx/dtx_common.c
+++ b/src/dtx/dtx_common.c
@@ -693,6 +693,7 @@ dtx_leader_end(struct dtx_leader_handle *dlh, struct ds_cont_child *cont,
 	int				 status = -1;
 	int				 rc = 0;
 	bool				 aborted = false;
+	bool				 unpin = false;
 
 	D_ASSERT(cont != NULL);
 
@@ -722,7 +723,8 @@ dtx_leader_end(struct dtx_leader_handle *dlh, struct ds_cont_child *cont,
 	case DTX_ST_PREPARED:
 		break;
 	case DTX_ST_INITED:
-		if (dth->dth_modification_cnt == 0)
+		if (dth->dth_modification_cnt == 0 ||
+		    !dth->dth_active)
 			break;
 		/* full through */
 	case DTX_ST_ABORTED:
@@ -739,6 +741,14 @@ dtx_leader_end(struct dtx_leader_handle *dlh, struct ds_cont_child *cont,
 		 */
 		dth->dth_sync = 1;
 		goto sync;
+	}
+
+	/* For standalone modification, if leader modified nothing, then
+	 * non-leader(s) must be the same, unpin the DTX via dtx_abort().
+	 */
+	if (!dth->dth_active) {
+		unpin = true;
+		D_GOTO(abort, result = 0);
 	}
 
 	/* If the DTX is started befoe DTX resync (for rebuild), then it is
@@ -860,7 +870,7 @@ abort:
 	 * to locally retry for avoiding RPC timeout. The leader replica
 	 * will trigger retry globally without aborting 'prepared' ones.
 	 */
-	if (result < 0 && result != -DER_AGAIN && !dth->dth_solo) {
+	if (unpin || (result < 0 && result != -DER_AGAIN && !dth->dth_solo)) {
 		/* Drop partial modification for distributed transaction. */
 		vos_dtx_cleanup(dth);
 		dte = &dth->dth_dte;

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -4058,10 +4058,10 @@ ds_obj_dtx_follower(crt_rpc_t *rpc, struct obj_io_context *ioc)
 				    dth.dth_modification_cnt > 0 ?
 				    true : false);
 
-	/* For the case of only containing read sub operations,
-	 *  we will generate DTX entry for DTX recovery.
+	/* For the case of only containing read sub operations, we will
+	 * generate DTX entry for DTX recovery. Similarly for noop case.
 	 */
-	if (rc == 0 && dth.dth_modification_cnt == 0)
+	if (rc == 0 && (dth.dth_modification_cnt == 0 || !dth.dth_active))
 		rc = vos_dtx_pin(&dth, true);
 
 	rc = dtx_end(&dth, ioc->ioc_coc, rc);

--- a/src/vos/vos_dtx.c
+++ b/src/vos/vos_dtx.c
@@ -2691,22 +2691,27 @@ vos_dtx_cleanup(struct dtx_handle *dth)
 int
 vos_dtx_pin(struct dtx_handle *dth, bool persistent)
 {
+	struct vos_container	*cont;
 	struct umem_instance	*umm = NULL;
 	struct vos_dtx_blob_df	*dbd = NULL;
 	bool			 began = false;
-	int			 rc;
+	int			 rc = 0;
 
-	if (!dtx_is_valid_handle(dth) || dth->dth_ent != NULL)
+	if (!dtx_is_valid_handle(dth))
 		return 0;
 
-	D_ASSERT(dth->dth_pinned == 0);
+	if (dth->dth_ent != NULL) {
+		if (!persistent || dth->dth_active)
+			return 0;
+	} else {
+		D_ASSERT(dth->dth_pinned == 0);
+	}
+
+	cont = vos_hdl2cont(dth->dth_coh);
+	D_ASSERT(cont != NULL);
 
 	if (persistent) {
-		struct vos_container	*cont;
 		struct vos_cont_df	*cont_df;
-
-		cont = vos_hdl2cont(dth->dth_coh);
-		D_ASSERT(cont != NULL);
 
 		umm = vos_cont2umm(cont);
 		cont_df = cont->vc_cont_df;
@@ -2726,7 +2731,20 @@ vos_dtx_pin(struct dtx_handle *dth, bool persistent)
 		}
 	}
 
-	rc = vos_dtx_alloc(dbd, dth);
+	if (dth->dth_ent == NULL) {
+		rc = vos_dtx_alloc(dbd, dth);
+	} else {
+		struct vos_dtx_act_ent	*dae = dth->dth_ent;
+
+		D_ASSERT(dbd != NULL);
+		D_ASSERT(dbd->dbd_magic == DTX_ACT_BLOB_MAGIC);
+
+		dae->dae_df_off = cont->vc_cont_df->cd_dtx_active_tail +
+			offsetof(struct vos_dtx_blob_df, dbd_active_data) +
+			sizeof(struct vos_dtx_act_ent_df) * dbd->dbd_index;
+		dae->dae_dbd = dbd;
+	}
+
 	if (rc == 0) {
 		if (persistent) {
 			dth->dth_active = 1;
@@ -2738,8 +2756,10 @@ vos_dtx_pin(struct dtx_handle *dth, bool persistent)
 
 out:
 	if (rc != 0) {
-		if (dth->dth_ent != NULL)
+		if (dth->dth_ent != NULL) {
+			dth->dth_pinned = 0;
 			vos_dtx_cleanup_internal(dth);
+		}
 
 		D_ERROR("Failed to pin DTX entry for "DF_DTI": "DF_RC"\n",
 			DP_DTI(&dth->dth_xid), DP_RC(rc));


### PR DESCRIPTION
It is possible that a update RPC changes nothing on the target
but without failure because of empty IOD. Under such case, the
leader should not regard it as DTX entry re-allocation by race;
instead, by checking dth::dth_active, it can know that this is
a noop update, and avoid generating improper "-DER_INPROGRESS"
that will cause the client to retry again and again.

Master-PR: https://github.com/daos-stack/daos/pull/5597

Signed-off-by: Fan Yong <fan.yong@intel.com>