### PR TITLE
DAOS-7363 control: set target user if empty in local nvme prepare

### DIFF
--- a/src/control/cmd/daos_server/storage.go
+++ b/src/control/cmd/daos_server/storage.go
@@ -8,6 +8,7 @@ package main
 
 import (
 	"fmt"
+	"os/user"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -56,6 +57,14 @@ func (cmd *storagePrepareCmd) Execute(args []string) error {
 
 	if prepNvme {
 		cmd.log.Info(op + " locally-attached NVMe storage...")
+
+		if cmd.TargetUser == "" {
+			runningUser, err := user.Current()
+			if err != nil {
+				return errors.Wrap(err, "couldn't lookup running user")
+			}
+			cmd.TargetUser = runningUser.Username
+		}
 
 		// Prepare NVMe access through SPDK
 		if _, err := cmd.scs.NvmePrepare(bdev.PrepareRequest{


### PR DESCRIPTION
User is looked up during storage prepare NVMe when cleaning huge pages
so failure can occur if target user is unset. Before calling in to
provider prepare, set target user to current if unset.

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>