### PR TITLE
DAOS-7363 control: set target user if empty in remote nvme prepare

### DIFF
--- a/src/control/server/ctl_storage_rpc.go
+++ b/src/control/server/ctl_storage_rpc.go
@@ -8,6 +8,7 @@ package server
 
 import (
 	"fmt"
+	"os/user"
 	"path/filepath"
 	"strings"
 
@@ -42,6 +43,12 @@ func newResponseState(inErr error, badStatus ctlpb.ResponseStatus, infoMsg strin
 
 // doNvmePrepare issues prepare request and returns response.
 func (c *StorageControlService) doNvmePrepare(req *ctlpb.PrepareNvmeReq) *ctlpb.PrepareNvmeResp {
+	if req.GetTargetuser() == "" {
+		if runningUser, err := user.Current(); err != nil {
+			req.Targetuser = runningUser.Username
+		}
+	}
+
 	_, err := c.NvmePrepare(bdev.PrepareRequest{
 		HugePageCount: int(req.GetNrhugepages()),
 		TargetUser:    req.GetTargetuser(),

--- a/src/control/server/ctl_storage_rpc.go
+++ b/src/control/server/ctl_storage_rpc.go
@@ -44,7 +44,7 @@ func newResponseState(inErr error, badStatus ctlpb.ResponseStatus, infoMsg strin
 // doNvmePrepare issues prepare request and returns response.
 func (c *StorageControlService) doNvmePrepare(req *ctlpb.PrepareNvmeReq) *ctlpb.PrepareNvmeResp {
 	if req.GetTargetuser() == "" {
-		if runningUser, err := user.Current(); err != nil {
+		if runningUser, err := user.Current(); err == nil {
 			req.Targetuser = runningUser.Username
 		}
 	}


### PR DESCRIPTION
During dmg storage prepare, before calling in to provider prepare, set
target user to current if unset in protobuf request.

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>