### PR TITLE
DAOS-7244 dtx: Fix a bug in dtx_aggregate

### DIFF
--- a/src/dtx/dtx_common.c
+++ b/src/dtx/dtx_common.c
@@ -238,7 +238,7 @@ dtx_batched_commit(void *arg)
 			sleep_time = 0;
 			dtx_get_dbca(dbca);
 			cont->sc_dtx_aggregating = 1;
-			rc = dss_ult_create(dtx_aggregate, cont, DSS_XS_SELF,
+			rc = dss_ult_create(dtx_aggregate, dbca, DSS_XS_SELF,
 					    0, 0, NULL);
 			if (rc != 0) {
 				cont->sc_dtx_aggregating = 0;


### PR DESCRIPTION
The dtx_aggregate routine was changed to take dbca as an argument but
the calling function is still passing cont.  Modify to pass correct
argument.

Master PR: #5603

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>