### PR TITLE
DAOS-7367 documentation: daos fs copy 1.2 limitation

### DIFF
--- a/doc/user/datamover.md
+++ b/doc/user/datamover.md
@@ -45,6 +45,10 @@ There are two mandatory command-line options; these are:
 | --src=daos://<pool/cont\> \| <path\>  | the source path      |
 | --dst=daos://<pool/cont\> \| <path\>  | the destination path |
 
+!!! note
+    In DAOS 1.2, only directories are supported as the source or destination.
+    Files, directories, and symbolic links are copied from the source directory.
+
 #### Examples
 
 Copy a POSIX container to a POSIX filesystem:


### PR DESCRIPTION
Document limitations of daos fs copy in v1.2

Signed-off-by: Dalton Bohning <daltonx.bohning@intel.com>