### PR TITLE
CART-809 common: memset new space in D_REALLOC macros

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -381,7 +381,7 @@ def scons(): # pylint: disable=too-many-locals
         daos_build.load_mpi_path(env)
     preload_prereqs(prereqs)
     if prereqs.check_component('valgrind_devel'):
-        env.AppendUnique(CPPDEFINES=["DAOS_HAS_VALGRIND"])
+        env.AppendUnique(CPPDEFINES=["D_HAS_VALGRIND"])
 
     AddOption('--deps-only',
               dest='deps_only',

--- a/src/bio/bio_xstream.c
+++ b/src/bio/bio_xstream.c
@@ -109,7 +109,7 @@ opts_add_pci_addr(struct spdk_env_opts *opts, struct spdk_pci_addr **list,
 		return 0;
 	}
 
-	D_REALLOC_ARRAY(new, tmp, count + 1);
+	D_REALLOC_ARRAY(new, tmp, count, count + 1);
 	if (new == NULL)
 		return -DER_NOMEM;
 

--- a/src/cart/crt_register.c
+++ b/src/cart/crt_register.c
@@ -324,13 +324,10 @@ crt_proto_reg_L3(struct crt_opc_map_L3 *L3_map,
 
 	/* make sure array is big enough, realloc if necessary */
 	if (L3_map->L3_num_slots_total < cpf->cpf_count) {
-		D_REALLOC_ARRAY(info_array, L3_map->L3_map, cpf->cpf_count);
+		D_REALLOC_ARRAY(info_array, L3_map->L3_map,
+				L3_map->L3_num_slots_total, cpf->cpf_count);
 		if (info_array == NULL)
 			return -DER_NOMEM;
-		/* set new space to 0 */
-		memset(&info_array[L3_map->L3_num_slots_total], 0,
-		       (cpf->cpf_count - L3_map->L3_num_slots_total)
-			* sizeof(struct crt_opc_info));
 		L3_map->L3_map = info_array;
 		L3_map->L3_num_slots_total = cpf->cpf_count;
 	}
@@ -360,12 +357,10 @@ get_L3_map(struct crt_opc_map_L2 *L2_map, struct crt_proto_format *cpf)
 	struct crt_opc_map_L3 *new_map;
 
 	if (L2_map->L2_num_slots_total < cpf->cpf_ver + 1) {
-		D_REALLOC_ARRAY(new_map, L2_map->L2_map, (cpf->cpf_ver + 1));
+		D_REALLOC_ARRAY(new_map, L2_map->L2_map,
+				L2_map->L2_num_slots_total, cpf->cpf_ver + 1);
 		if (new_map == NULL)
 			return NULL;
-		memset(&new_map[L2_map->L2_num_slots_total], 0,
-		       (cpf->cpf_ver + 1 - L2_map->L2_num_slots_total)
-			* sizeof(struct crt_opc_map_L3));
 		L2_map->L2_map = new_map;
 		L2_map->L2_num_slots_total = cpf->cpf_ver + 1;
 	}

--- a/src/client/array/dc_array.c
+++ b/src/client/array/dc_array.c
@@ -1052,11 +1052,11 @@ create_sgl(d_sg_list_t *user_sgl, daos_size_t cell_size,
 
 		D_ASSERT(user_sgl->sg_nr > cur_i);
 
-		sgl->sg_nr++;
-		D_REALLOC_ARRAY(new_sg_iovs, sgl->sg_iovs, sgl->sg_nr - 1,
-				sgl->sg_nr);
+		D_REALLOC_ARRAY(new_sg_iovs, sgl->sg_iovs, sgl->sg_nr,
+				sgl->sg_nr + 1);
 		if (new_sg_iovs == NULL)
 			return -DER_NOMEM;
+		sgl->sg_nr++;
 		sgl->sg_iovs = new_sg_iovs;
 
 		sgl->sg_iovs[k].iov_buf = user_sgl->sg_iovs[cur_i].iov_buf +
@@ -1590,14 +1590,13 @@ dc_array_io(daos_handle_t array_oh, daos_handle_t th,
 			daos_off_t	old_array_idx;
 			daos_recx_t	*new_recxs;
 
-			iod->iod_nr++;
-
 			/** add another element to recxs */
 			D_REALLOC_ARRAY(new_recxs, iod->iod_recxs,
-					iod->iod_nr - 1, iod->iod_nr);
+					iod->iod_nr, iod->iod_nr + 1);
 			if (new_recxs == NULL) {
 				D_GOTO(err_stask, rc = -DER_NOMEM);
 			}
+			iod->iod_nr++;
 			iod->iod_recxs = new_recxs;
 
 			/** set the record access for this range */

--- a/src/client/array/dc_array.c
+++ b/src/client/array/dc_array.c
@@ -1053,7 +1053,8 @@ create_sgl(d_sg_list_t *user_sgl, daos_size_t cell_size,
 		D_ASSERT(user_sgl->sg_nr > cur_i);
 
 		sgl->sg_nr++;
-		D_REALLOC_ARRAY(new_sg_iovs, sgl->sg_iovs, sgl->sg_nr);
+		D_REALLOC_ARRAY(new_sg_iovs, sgl->sg_iovs, sgl->sg_nr - 1,
+				sgl->sg_nr);
 		if (new_sg_iovs == NULL)
 			return -DER_NOMEM;
 		sgl->sg_iovs = new_sg_iovs;
@@ -1592,7 +1593,8 @@ dc_array_io(daos_handle_t array_oh, daos_handle_t th,
 			iod->iod_nr++;
 
 			/** add another element to recxs */
-			D_REALLOC_ARRAY(new_recxs, iod->iod_recxs, iod->iod_nr);
+			D_REALLOC_ARRAY(new_recxs, iod->iod_recxs,
+					iod->iod_nr - 1, iod->iod_nr);
 			if (new_recxs == NULL) {
 				D_GOTO(err_stask, rc = -DER_NOMEM);
 			}

--- a/src/client/dfuse/dfuse_vector.c
+++ b/src/client/dfuse/dfuse_vector.c
@@ -96,7 +96,6 @@ static int
 expand_vector(struct vector *vector, unsigned int new_index)
 {
 	unsigned int num_entries = get_new_size(new_index);
-	unsigned int new_entries;
 	void *data;
 
 	if (num_entries < MIN_SIZE)
@@ -105,15 +104,12 @@ expand_vector(struct vector *vector, unsigned int new_index)
 	if (num_entries > vector->max_entries)
 		num_entries = vector->max_entries;
 
-	D_REALLOC_ARRAY(data, vector->data, num_entries);
+	D_REALLOC_ARRAY(data, vector->data, vector->num_entries,
+			num_entries);
 	if (!data)
 		return -DER_NOMEM;
 	vector->data = data;
 
-	/* Now fill in the data from the old size onward */
-	data = &vector->data[vector->num_entries];
-	new_entries = num_entries - vector->num_entries;
-	memset(data, 0, new_entries * sizeof(union ptr_lock));
 	vector->num_entries = num_entries;
 
 	return -DER_SUCCESS;

--- a/src/client/pydaos/pydaos_shim.c
+++ b/src/client/pydaos/pydaos_shim.c
@@ -560,11 +560,7 @@ rewait:
 			} else if (evp->ev_error == -DER_REC2BIG) {
 				char *new_buff;
 
-				/** No need to clear the buffer so size doesn't
-				 * matter.
-				 */
-				D_REALLOC(new_buff, op->buf, op->size,
-					  op->size);
+				D_REALLOC_NZ(new_buff, op->buf, op->size);
 				if (new_buff == NULL) {
 					rc = -DER_NOMEM;
 					break;
@@ -627,11 +623,7 @@ rewait:
 				daos_event_fini(evp);
 				rc2 = daos_event_init(evp, eq, NULL);
 
-				/** No need to clear the buffer so size doesn't
-				 * matter.
-				 */
-				D_REALLOC(new_buff, op->buf, op->size,
-					  op->size);
+				D_REALLOC_NZ(new_buff, op->buf, op->size);
 				if (new_buff == NULL)
 					D_GOTO(out, rc = -DER_NOMEM);
 

--- a/src/client/pydaos/pydaos_shim.c
+++ b/src/client/pydaos/pydaos_shim.c
@@ -560,7 +560,11 @@ rewait:
 			} else if (evp->ev_error == -DER_REC2BIG) {
 				char *new_buff;
 
-				D_REALLOC(new_buff, op->buf, op->size);
+				/** No need to clear the buffer so size doesn't
+				 * matter.
+				 */
+				D_REALLOC(new_buff, op->buf, op->size,
+					  op->size);
 				if (new_buff == NULL) {
 					rc = -DER_NOMEM;
 					break;
@@ -623,7 +627,11 @@ rewait:
 				daos_event_fini(evp);
 				rc2 = daos_event_init(evp, eq, NULL);
 
-				D_REALLOC(new_buff, op->buf, op->size);
+				/** No need to clear the buffer so size doesn't
+				 * matter.
+				 */
+				D_REALLOC(new_buff, op->buf, op->size,
+					  op->size);
 				if (new_buff == NULL)
 					D_GOTO(out, rc = -DER_NOMEM);
 
@@ -802,6 +810,7 @@ __shim_handle__kv_iter(PyObject *self, PyObject *args)
 	PyObject	*anchor_cap;
 	char		*enum_buf = NULL;
 	daos_size_t	 size;
+	daos_size_t	 oldsize;
 	char		*ptr;
 	uint32_t	 i;
 	int		 rc = 0;
@@ -813,6 +822,8 @@ __shim_handle__kv_iter(PyObject *self, PyObject *args)
 		rc = -DER_INVAL;
 		goto out;
 	}
+
+	oldsize = size;
 
 	/** Allocate an anchor for the first iteration */
 	if (anchor_cap == Py_None) {
@@ -875,11 +886,12 @@ __shim_handle__kv_iter(PyObject *self, PyObject *args)
 			size = kds[0].kd_key_len;
 
 			/** realloc buffer twice as big */
-			D_REALLOC(new_buf, enum_buf, size);
+			D_REALLOC(new_buf, enum_buf, oldsize, size);
 			if (new_buf == NULL) {
 				rc = -DER_NOMEM;
 				goto out;
 			}
+			oldsize = size;
 
 			/** refresh daos structures to point at new buffer */
 			d_iov_set(&iov, (void *)new_buf, size);

--- a/src/common/acl_principal.c
+++ b/src/common/acl_principal.c
@@ -30,9 +30,10 @@
 	int	__rc = 0;						\
 	char	*new_buf = NULL;					\
 	size_t	buflen = DEFAULT_BUF_LEN;				\
+	size_t	oldlen = 0; /* default to clearing buffer */		\
 									\
 	do {								\
-		D_REALLOC(new_buf, _buf, buflen);			\
+		D_REALLOC(new_buf, _buf, oldlen, buflen);		\
 		if (new_buf == NULL) {					\
 			__rc = -DER_NOMEM;				\
 			break;						\
@@ -41,6 +42,7 @@
 									\
 		__rc = _func(_arg1, _arg2, _buf, buflen, _result);	\
 									\
+		oldlen = buflen;					\
 		buflen *= 2;						\
 	} while (__rc == ERANGE);					\
 	__rc;								\

--- a/src/common/mem.c
+++ b/src/common/mem.c
@@ -324,7 +324,7 @@ pmem_tx_add_callback(struct umem_instance *umm, struct umem_tx_stage_data *txd,
 		}
 
 		new_max = min((*cnt_max) << 1, TXD_CB_MAX);
-		D_REALLOC_ARRAY(txi, *pvec, new_max);
+		D_REALLOC_ARRAY(txi, *pvec, *cnt_max, new_max);
 		if (txi == NULL)
 			return -DER_NOMEM;
 

--- a/src/common/misc.c
+++ b/src/common/misc.c
@@ -164,7 +164,7 @@ daos_sgl_merge(d_sg_list_t *dst, d_sg_list_t *src)
 	for (i = dst->sg_nr; i < total; i++) {
 		int idx = i - dst->sg_nr;
 
-		D_ALLOC(new_iovs[i].iov_buf, src->sg_iovs[idx].iov_buf_len);
+		D_ALLOC_NZ(new_iovs[i].iov_buf, src->sg_iovs[idx].iov_buf_len);
 		if (new_iovs[i].iov_buf == NULL)
 			D_GOTO(free, rc = -DER_NOMEM);
 

--- a/src/common/misc.c
+++ b/src/common/misc.c
@@ -157,7 +157,7 @@ daos_sgl_merge(d_sg_list_t *dst, d_sg_list_t *src)
 		return 0;
 
 	total = dst->sg_nr + src->sg_nr;
-	D_REALLOC_ARRAY(new_iovs, dst->sg_iovs, total);
+	D_REALLOC_ARRAY(new_iovs, dst->sg_iovs, dst->sg_nr, total);
 	if (new_iovs == NULL)
 		return -DER_NOMEM;
 
@@ -237,7 +237,8 @@ daos_sgl_buf_extend(d_sg_list_t *sgl, int idx, size_t new_size)
 	if (sgl->sg_iovs[idx].iov_buf_len >= new_size)
 		return 0;
 
-	D_REALLOC(new_buf, sgl->sg_iovs[idx].iov_buf, new_size);
+	D_REALLOC(new_buf, sgl->sg_iovs[idx].iov_buf,
+		  sgl->sg_iovs[idx].iov_buf_len, new_size);
 	if (new_buf == NULL)
 		return -DER_NOMEM;
 

--- a/src/common/pool_map.c
+++ b/src/common/pool_map.c
@@ -1475,7 +1475,7 @@ gen_pool_buf(struct pool_map *map, struct pool_buf **map_buf_out,
 		D_GOTO(out_map_buf, rc = -DER_NOMEM);
 
 	/* Make a sorted target UUID array to determine target IDs. */
-	D_ALLOC_ARRAY(uuids, nnodes);
+	D_ALLOC_ARRAY_NZ(uuids, nnodes);
 	if (uuids == NULL)
 		D_GOTO(out_map_buf, rc = -DER_NOMEM);
 	memcpy(uuids, target_uuids, sizeof(uuid_t) * nnodes);

--- a/src/common/pool_map.c
+++ b/src/common/pool_map.c
@@ -2861,7 +2861,8 @@ pool_target_id_list_append(struct pool_target_id_list *id_list,
 	if (pool_target_id_found(id_list, id))
 		return 0;
 
-	D_REALLOC_ARRAY(new_ids, id_list->pti_ids, id_list->pti_number + 1);
+	D_REALLOC_ARRAY(new_ids, id_list->pti_ids, id_list->pti_number,
+			id_list->pti_number + 1);
 	if (new_ids == NULL)
 		return -DER_NOMEM;
 

--- a/src/common/tests_dmg_helpers.c
+++ b/src/common/tests_dmg_helpers.c
@@ -42,7 +42,7 @@ cmd_push_arg(char *args[], int *argcount, const char *fmt, ...)
 		return NULL;
 	}
 
-	D_REALLOC(tmp, args, sizeof(char *) * (*argcount + 1));
+	D_REALLOC_ARRAY(tmp, args, *argcount, *argcount + 1);
 	if (tmp == NULL) {
 		D_ERROR("realloc failed\n");
 		D_FREE(arg);
@@ -61,13 +61,13 @@ cmd_string(const char *cmd_base, char *args[], int argcount)
 {
 	char		*tmp = NULL;
 	char		*cmd_str = NULL;
-	size_t		size;
+	size_t		size, old;
 	int		i;
 
 	if (cmd_base == NULL)
 		return NULL;
 
-	size = strnlen(cmd_base, ARG_MAX - 1) + 1;
+	old = size = strnlen(cmd_base, ARG_MAX - 1) + 1;
 	D_STRNDUP(cmd_str, cmd_base, size);
 	if (cmd_str == NULL)
 		return NULL;
@@ -80,13 +80,14 @@ cmd_string(const char *cmd_base, char *args[], int argcount)
 			return NULL;
 		}
 
-		D_REALLOC(tmp, cmd_str, size);
+		D_REALLOC(tmp, cmd_str, old, size);
 		if (tmp == NULL) {
 			D_FREE(cmd_str);
 			return NULL;
 		}
 		strncat(tmp, args[i], size);
 		cmd_str = tmp;
+		old = size;
 	}
 
 	return cmd_str;
@@ -150,7 +151,7 @@ daos_dmg_json_pipe(const char *dmg_cmd, const char *dmg_config_file,
 				D_GOTO(out_jbuf, rc = -DER_REC2BIG);
 			}
 
-			D_REALLOC(temp, jbuf, size);
+			D_REALLOC(temp, jbuf, total, size);
 			if (temp == NULL)
 				D_GOTO(out_jbuf, rc = -DER_NOMEM);
 			jbuf = temp;
@@ -163,7 +164,7 @@ daos_dmg_json_pipe(const char *dmg_cmd, const char *dmg_config_file,
 		total += n;
 	}
 
-	D_REALLOC(temp, jbuf, total + 1);
+	D_REALLOC(temp, jbuf, total, total + 1);
 	if (temp == NULL)
 		D_GOTO(out_jbuf, rc = -DER_NOMEM);
 	jbuf = temp;

--- a/src/container/srv_container.c
+++ b/src/container/srv_container.c
@@ -2890,7 +2890,7 @@ enum_cont_cb(daos_handle_t ih, d_iov_t *key, d_iov_t *val, void *varg)
 		size_t	realloc_elems = (ap->conts_len == 0) ? 1 :
 					ap->conts_len * 2;
 
-		D_REALLOC_ARRAY(ptr, ap->conts, realloc_elems);
+		D_REALLOC_ARRAY(ptr, ap->conts, ap->conts_len, realloc_elems);
 		if (ptr == NULL)
 			return -DER_NOMEM;
 		ap->conts = ptr;

--- a/src/container/srv_epoch.c
+++ b/src/container/srv_epoch.c
@@ -46,6 +46,7 @@ snap_list_iter_cb(daos_handle_t ih, d_iov_t *key, d_iov_t *val,
 				void *ptr;
 
 				D_REALLOC_ARRAY(ptr, i_args->sla_buf,
+						i_args->sla_index,
 						i_args->sla_count);
 				if (ptr == NULL)
 					return -DER_NOMEM;

--- a/src/container/srv_target.c
+++ b/src/container/srv_target.c
@@ -1814,8 +1814,7 @@ cont_snap_update_one(void *vin)
 		size_t	 bufsize;
 
 		bufsize = args->snap_count * sizeof(*args->snapshots);
-		/* Old size doesn't matter here, we overwrite the buffer */
-		D_REALLOC(buf, cont->sc_snapshots, bufsize, bufsize);
+		D_REALLOC_NZ(buf, cont->sc_snapshots, bufsize);
 		if (buf == NULL) {
 			rc = -DER_NOMEM;
 			goto out_cont;

--- a/src/container/srv_target.c
+++ b/src/container/srv_target.c
@@ -1814,7 +1814,8 @@ cont_snap_update_one(void *vin)
 		size_t	 bufsize;
 
 		bufsize = args->snap_count * sizeof(*args->snapshots);
-		D_REALLOC(buf, cont->sc_snapshots, bufsize);
+		/* Old size doesn't matter here, we overwrite the buffer */
+		D_REALLOC(buf, cont->sc_snapshots, bufsize, bufsize);
 		if (buf == NULL) {
 			rc = -DER_NOMEM;
 			goto out_cont;

--- a/src/gurt/misc.c
+++ b/src/gurt/misc.c
@@ -343,7 +343,7 @@ d_rank_list_append(d_rank_list_t *rank_list, d_rank_t rank)
 	d_rank_list_t		*new_rank_list;
 	int			 rc = 0;
 
-	new_rank_list = d_rank_list_realloc(rank_list, rank_list->rl_nr + 1);
+	new_rank_list = d_rank_list_realloc(rank_list, old_num + 1);
 	if (new_rank_list == NULL) {
 		D_ERROR("d_rank_list_realloc() failed.\n");
 		D_GOTO(out, rc = -DER_NOMEM);

--- a/src/gurt/misc.c
+++ b/src/gurt/misc.c
@@ -26,6 +26,13 @@ d_calloc(size_t count, size_t eltsize)
 }
 
 void *
+d_malloc(size_t size)
+{
+	return malloc(size);
+}
+
+
+void *
 d_realloc(void *ptr, size_t size)
 {
 	return realloc(ptr, size);

--- a/src/gurt/misc.c
+++ b/src/gurt/misc.c
@@ -203,7 +203,7 @@ d_rank_list_realloc(d_rank_list_t *ptr, uint32_t size)
 		d_rank_list_free(ptr);
 		return NULL;
 	}
-	D_REALLOC_ARRAY(new_rl_ranks, ptr->rl_ranks, size);
+	D_REALLOC_ARRAY(new_rl_ranks, ptr->rl_ranks, ptr->rl_nr, size);
 	if (new_rl_ranks != NULL) {
 		ptr->rl_ranks = new_rl_ranks;
 		ptr->rl_nr = size;
@@ -332,12 +332,11 @@ out:
 int
 d_rank_list_append(d_rank_list_t *rank_list, d_rank_t rank)
 {
-	uint32_t		 old_num;
+	uint32_t		 old_num = rank_list->rl_nr;
 	d_rank_list_t		*new_rank_list;
 	int			 rc = 0;
 
-	old_num = rank_list->rl_nr;
-	new_rank_list = d_rank_list_realloc(rank_list, old_num + 1);
+	new_rank_list = d_rank_list_realloc(rank_list, rank_list->rl_nr + 1);
 	if (new_rank_list == NULL) {
 		D_ERROR("d_rank_list_realloc() failed.\n");
 		D_GOTO(out, rc = -DER_NOMEM);
@@ -625,7 +624,7 @@ d_write_string_buffer(struct d_string_buffer_t *buf, const char *format, ...)
 		}
 
 		size = buf->buf_size * 2;
-		D_REALLOC(new_buf, buf->str, size);
+		D_REALLOC(new_buf, buf->str, buf->buf_size, size);
 		if (new_buf == NULL) {
 			buf->status = -DER_NOMEM;
 			return -DER_NOMEM;

--- a/src/gurt/tests/test_gurt.c
+++ b/src/gurt/tests/test_gurt.c
@@ -809,9 +809,9 @@ test_log(void **state)
 	d_log_fini();
 }
 
-#define TEST_GURT_HASH_NUM_BITS (12)
+#define TEST_GURT_HASH_NUM_BITS (D_ON_VALGRIND ? 4 : 12)
 #define TEST_GURT_HASH_NUM_ENTRIES (1 << TEST_GURT_HASH_NUM_BITS)
-#define TEST_GURT_HASH_NUM_THREADS (16)
+#define TEST_GURT_HASH_NUM_THREADS (D_ON_VALGRIND ? 4 : 16)
 #define TEST_GURT_HASH_ENTRIES_PER_THREAD \
 	(TEST_GURT_HASH_NUM_ENTRIES / TEST_GURT_HASH_NUM_THREADS)
 #define TEST_GURT_HASH_KEY_LEN (65L)
@@ -2104,7 +2104,8 @@ hash_perf(int hash_type, unsigned int buckets, unsigned int loop)
 static void
 test_hash_perf(void **state)
 {
-	unsigned el = (16 << 10); /* elements per buckert */
+	unsigned shift = D_ON_VALGRIND ? 3 : 10;
+	unsigned el = (16 << shift); /* elements per buckert */
 	unsigned i;
 
 	/* hash buckets: 2, 4, 8... 8192 */

--- a/src/gurt/tests/test_gurt.c
+++ b/src/gurt/tests/test_gurt.c
@@ -1197,10 +1197,10 @@ test_gurt_alloc(void **state)
 	assert_string_equal(testptr, str2);
 	D_FREE(testptr);
 	assert_null(testptr);
-	D_REALLOC(newptr, testptr, 10);
+	D_REALLOC(newptr, testptr, 0, 10);
 	assert_non_null(newptr);
 	assert_null(testptr);
-	D_REALLOC(testptr, newptr, 20);
+	D_REALLOC(testptr, newptr, 10, 20);
 	assert_non_null(testptr);
 	assert_null(newptr);
 	D_FREE(testptr);
@@ -1222,12 +1222,10 @@ test_gurt_alloc(void **state)
 	D_ALLOC_ARRAY(ptr1, nr);
 	assert_non_null(ptr1);
 
-	D_REALLOC_ARRAY(ptr2, ptr1, nr + 10);
+	D_REALLOC_ARRAY(ptr2, ptr1, nr, nr + 10);
 
 	assert_non_null(ptr2);
 	assert_null(ptr1);
-	/* Fill memory to catch wrong allocation via valgrind */
-	memset(ptr2, 0x0, (nr + 10) * sizeof(*ptr2));
 
 	D_FREE(ptr2);
 	assert_null(ptr2);

--- a/src/include/daos/common.h
+++ b/src/include/daos/common.h
@@ -23,12 +23,6 @@
 #include <stdio.h>
 #include <pthread.h>
 #include <byteswap.h>
-#ifdef DAOS_HAS_VALGRIND
-#include <valgrind/valgrind.h>
-#define DAOS_ON_VALGRIND RUNNING_ON_VALGRIND
-#else
-#define DAOS_ON_VALGRIND 0
-#endif
 
 #include <daos_errno.h>
 #include <daos/debug.h>
@@ -42,6 +36,8 @@
 #include <daos/profile.h>
 #include <daos/dtx.h>
 #include <daos/cmd_parser.h>
+
+#define DAOS_ON_VALGRIND D_ON_VALGRIND
 
 #define DF_OID		DF_U64"."DF_U64
 #define DP_OID(o)	(o).hi, (o).lo

--- a/src/include/daos/object.h
+++ b/src/include/daos/object.h
@@ -583,7 +583,8 @@ daos_recx_ep_add(struct daos_recx_ep_list *list, struct daos_recx_ep *recx)
 		if (list->re_total == 0)
 			D_ALLOC_ARRAY(new_items, nr);
 		else
-			D_REALLOC_ARRAY(new_items, list->re_items, nr);
+			D_REALLOC_ARRAY(new_items, list->re_items,
+					list->re_total, nr);
 		if (new_items == NULL)
 			return -DER_NOMEM;
 		list->re_items = new_items;

--- a/src/include/gurt/common.h
+++ b/src/include/gurt/common.h
@@ -28,6 +28,12 @@
 #include <pthread.h>
 #include <byteswap.h>
 #include <daos_errno.h>
+#ifdef D_HAS_VALGRIND
+#include <valgrind/valgrind.h>
+#define D_ON_VALGRIND RUNNING_ON_VALGRIND
+#else
+#define D_ON_VALGRIND 0
+#endif
 
 #include <gurt/types.h>
 #include <gurt/debug.h>

--- a/src/include/gurt/common.h
+++ b/src/include/gurt/common.h
@@ -172,15 +172,17 @@ void *d_realloc(void *, size_t);
 				D_DEBUG(DB_MEM,				\
 					"realloc '" #newptr		\
 					"': %zu at %p (old '" #oldptr	\
-					"':%p).\n",			\
-					_esz, (newptr), (oldptr));	\
+					"': %zu at %p).\n",		\
+					_esz, (newptr), _oldsz,		\
+					(oldptr));			\
 			else						\
 				D_DEBUG(DB_MEM,				\
 					"realloc '" #newptr		\
 					"': %zu * '" #cnt		\
 					"':%zu at %p (old '" #oldptr	\
-					"':%p).\n",			\
-					_esz, _cnt, (newptr), (oldptr));\
+					"': %zu at %p).\n",		\
+					_esz, _cnt, (newptr), _oldsz,	\
+					(oldptr));			\
 			(oldptr) = NULL;				\
 			if (_oldsz < _sz)				\
 				memset((char *)(newptr) + _oldsz, 0,	\

--- a/src/include/gurt/common.h
+++ b/src/include/gurt/common.h
@@ -60,6 +60,7 @@ extern "C" {
 /* memory allocating macros */
 void  d_free(void *);
 void *d_calloc(size_t, size_t);
+void *d_malloc(size_t);
 void *d_realloc(void *, size_t);
 
 #define D_CHECK_ALLOC(func, cond, ptr, name, size, count, cname,	\
@@ -97,6 +98,13 @@ void *d_realloc(void *, size_t);
 	do {								\
 		(ptr) = (__typeof__(ptr))d_calloc((count), (size));	\
 		D_CHECK_ALLOC(calloc, true, ptr, #ptr, size,		\
+			      count, #count, 0);			\
+	} while (0)
+
+#define D_ALLOC_CORE_NZ(ptr, size, count)				\
+	do {								\
+		(ptr) = (__typeof__(ptr))d_malloc((count) * (size));	\
+		D_CHECK_ALLOC(malloc, true, ptr, #ptr, size,		\
 			      count, #count, 0);			\
 	} while (0)
 
@@ -191,6 +199,30 @@ void *d_realloc(void *, size_t);
 			 (oldcount) * sizeof(*(oldptr)),		\
 					     sizeof(*(oldptr)), count)
 
+#define D_REALLOC_NZ(newptr, oldptr, size)				\
+	D_REALLOC_COMMON(newptr, oldptr, size, size, 1)
+
+#define D_REALLOC_ARRAY_NZ(newptr, oldptr, count)			\
+	D_REALLOC_COMMON(newptr, oldptr,				\
+			 (count) * sizeof(*(oldptr)),			\
+			 sizeof(*(oldptr)), count)
+
+/** realloc macros that do not clear the new memory */
+#define D_REALLOC_NZ(newptr, oldptr, size)				\
+	D_REALLOC_COMMON(newptr, oldptr, size, size, 1)
+
+#define D_REALLOC_ARRAY_NZ(newptr, oldptr, count)			\
+	D_REALLOC_COMMON(newptr, oldptr,				\
+			 (count) * sizeof(*(oldptr)),			\
+			 sizeof(*(oldptr)), count)
+
+/** realloc macros that clear the whole allocation */
+#define D_REALLOC_Z(newptr, oldptr, size)				\
+	D_REALLOC_COMMON(newptr, oldptr, 0, size, 1)
+
+#define D_REALLOC_ARRAY_Z(newptr, oldptr, count)			\
+	D_REALLOC_COMMON(newptr, oldptr, 0, sizeof(*(oldptr)), count)
+
 #define D_FREE(ptr)							\
 	do {								\
 		D_DEBUG(DB_MEM, "free '" #ptr "' at %p.\n", (ptr));	\
@@ -201,6 +233,9 @@ void *d_realloc(void *, size_t);
 #define D_ALLOC(ptr, size)	D_ALLOC_CORE(ptr, size, 1)
 #define D_ALLOC_PTR(ptr)	D_ALLOC(ptr, sizeof(*ptr))
 #define D_ALLOC_ARRAY(ptr, count) D_ALLOC_CORE(ptr, sizeof(*ptr), count)
+#define D_ALLOC_NZ(ptr, size)	D_ALLOC_CORE_NZ(ptr, size, 1)
+#define D_ALLOC_PTR_NZ(ptr)	D_ALLOC_NZ(ptr, sizeof(*ptr))
+#define D_ALLOC_ARRAY_NZ(ptr, count) D_ALLOC_CORE_NZ(ptr, sizeof(*ptr), count)
 #define D_FREE_PTR(ptr)		D_FREE(ptr)
 
 #define D_GOTO(label, rc)			\

--- a/src/include/gurt/common.h
+++ b/src/include/gurt/common.h
@@ -130,10 +130,11 @@ void *d_realloc(void *, size_t);
  * there is no way to tell the difference between successful and
  * failed realloc.
  */
-#define D_REALLOC_COMMON(newptr, oldptr, size, cnt)			\
+#define D_REALLOC_COMMON(newptr, oldptr, oldsize, size, cnt)		\
 	do {								\
 		size_t _esz = (size_t)(size);				\
 		size_t _sz = (size_t)(size) * (cnt);			\
+		size_t _oldsz = (size_t)(oldsize);			\
 		size_t _cnt = (size_t)(cnt);				\
 		/* Compiler check to ensure type match */		\
 		__typeof__(newptr) optr = oldptr;			\
@@ -167,6 +168,9 @@ void *d_realloc(void *, size_t);
 					"':%p).\n",			\
 					_esz, _cnt, (newptr), (oldptr));\
 			(oldptr) = NULL;				\
+			if (_oldsz < _sz)				\
+				memset((char *)(newptr) + _oldsz, 0,	\
+				       _sz - _oldsz);			\
 			break;						\
 		}							\
 		if (_cnt <= 1)						\
@@ -179,11 +183,13 @@ void *d_realloc(void *, size_t);
 				_esz, _cnt);				\
 	} while (0)
 
-#define D_REALLOC(newptr, oldptr, size)					\
-	D_REALLOC_COMMON(newptr, oldptr, size, 1)
+#define D_REALLOC(newptr, oldptr, oldsize, size)			\
+	D_REALLOC_COMMON(newptr, oldptr, oldsize, size, 1)
 
-#define D_REALLOC_ARRAY(newptr, oldptr, count)				\
-	D_REALLOC_COMMON(newptr, oldptr, sizeof(*(oldptr)), count)
+#define D_REALLOC_ARRAY(newptr, oldptr, oldcount, count)		\
+	D_REALLOC_COMMON(newptr, oldptr,				\
+			 (oldcount) * sizeof(*(oldptr)),		\
+					     sizeof(*(oldptr)), count)
 
 #define D_FREE(ptr)							\
 	do {								\

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -418,7 +418,8 @@ obj_auxi_add_failed_tgt(struct obj_auxi_args *obj_auxi, uint32_t tgt)
 		}
 	}
 
-	D_REALLOC_ARRAY(tgts, tgt_list->tl_tgts, tgt_list->tl_nr + 1);
+	D_REALLOC_ARRAY(tgts, tgt_list->tl_tgts, tgt_list->tl_nr,
+			tgt_list->tl_nr + 1);
 	if (tgts == NULL) {
 		if (allocated)
 			D_FREE(tgt_list);

--- a/src/object/cli_shard.c
+++ b/src/object/cli_shard.c
@@ -367,7 +367,7 @@ iom_recx_merge(daos_iom_t *dst, daos_recx_t *recx, bool iom_realloc)
 	D_ASSERT(dst->iom_nr_out <= dst->iom_nr);
 	if (iom_realloc && dst->iom_nr_out == dst->iom_nr) {
 		iom_nr = dst->iom_nr + 32;
-		D_REALLOC_ARRAY(tmpr, dst->iom_recxs, iom_nr);
+		D_REALLOC_ARRAY(tmpr, dst->iom_recxs, dst->iom_nr, iom_nr);
 		if (tmpr == NULL)
 			return -DER_NOMEM;
 		dst->iom_recxs = tmpr;

--- a/src/object/obj_enum.c
+++ b/src/object/obj_enum.c
@@ -152,7 +152,7 @@ iov_alloc_for_csum_info(d_iov_t *iov, struct dcs_csum_info *csum_info)
 		size_t	 new_size = max(iov->iov_buf_len * 2,
 					      iov->iov_len + size_needed);
 
-		D_REALLOC(p, iov->iov_buf, new_size);
+		D_REALLOC(p, iov->iov_buf, iov->iov_buf_len, new_size);
 		if (p == NULL)
 			return -DER_NOMEM;
 		iov->iov_buf = p;
@@ -730,11 +730,9 @@ grow_array(void **arrayp, size_t elem_size, int old_len, int new_len)
 	void *p;
 
 	D_ASSERTF(old_len < new_len, "%d < %d\n", old_len, new_len);
-	D_REALLOC(p, *arrayp, elem_size * new_len);
+	D_REALLOC(p, *arrayp, elem_size * old_len, elem_size * new_len);
 	if (p == NULL)
 		return -DER_NOMEM;
-	/* Until D_REALLOC does this, zero the new segment. */
-	memset(p + elem_size * old_len, 0, elem_size * (new_len - old_len));
 	*arrayp = p;
 	return 0;
 }

--- a/src/object/srv_ec_aggregate.c
+++ b/src/object/srv_ec_aggregate.c
@@ -383,7 +383,8 @@ agg_alloc_buf(d_sg_list_t *sgl, size_t ent_buf_len, unsigned int iov_entry,
 	} else {
 		unsigned int *buf = NULL;
 
-		D_REALLOC(buf, sgl->sg_iovs[iov_entry].iov_buf, ent_buf_len);
+		D_REALLOC(buf, sgl->sg_iovs[iov_entry].iov_buf,
+			  sgl->sg_iovs[iov_entry].iov_buf_len, ent_buf_len);
 		 if (buf == NULL) {
 			rc = -DER_NOMEM;
 			goto out;

--- a/src/object/srv_obj_migrate.c
+++ b/src/object/srv_obj_migrate.c
@@ -558,7 +558,8 @@ mrone_obj_fetch(struct migrate_one *mrone, daos_handle_t oh, d_sg_list_t *sgls,
 		 */
 		void *p;
 
-		D_REALLOC(p, csum_iov_fetch->iov_buf, csum_iov_fetch->iov_len);
+		D_REALLOC(p, csum_iov_fetch->iov_buf,
+			  csum_iov_fetch->iov_buf_len, csum_iov_fetch->iov_len);
 		if (p == NULL)
 			return -DER_NOMEM;
 		csum_iov_fetch->iov_buf_len = csum_iov_fetch->iov_len;

--- a/src/placement/pl_map_common.c
+++ b/src/placement/pl_map_common.c
@@ -359,7 +359,8 @@ grp_map_extend(uint32_t *grp_map, uint32_t *grp_map_size)
 	int	 i;
 
 	if (*grp_map_size > STACK_TGTS_SIZE)
-		D_REALLOC_ARRAY(new_grp_map, grp_map, new_grp_size);
+		D_REALLOC_ARRAY(new_grp_map, grp_map, *grp_map_size,
+				new_grp_size);
 	else
 		D_ALLOC_ARRAY(new_grp_map, new_grp_size);
 

--- a/src/pool/rpc.c
+++ b/src/pool/rpc.c
@@ -171,7 +171,7 @@ pool_target_addr_list_append(struct pool_target_addr_list *addr_list,
 		return 0;
 
 	D_REALLOC_ARRAY(new_addrs, addr_list->pta_addrs,
-			addr_list->pta_number + 1);
+			addr_list->pta_number, addr_list->pta_number + 1);
 	if (new_addrs == NULL)
 		return -DER_NOMEM;
 

--- a/src/pool/srv_iv.c
+++ b/src/pool/srv_iv.c
@@ -583,9 +583,7 @@ pool_iv_map_ent_update(d_sg_list_t *dst_sgl, struct pool_iv_entry *src_iv)
 		uint32_t new_size;
 
 		new_size = pool_iv_map_ent_size(pb_nr);
-		/* Old size doesn't matter, buffer is immediately overwritten */
-		D_REALLOC(new_buf, dst_sgl->sg_iovs[0].iov_buf, new_size,
-			  new_size);
+		D_REALLOC_NZ(new_buf, dst_sgl->sg_iovs[0].iov_buf, new_size);
 		if (new_buf == NULL)
 			return -DER_NOMEM;
 

--- a/src/pool/srv_iv.c
+++ b/src/pool/srv_iv.c
@@ -416,13 +416,14 @@ pool_iv_conns_ent_fetch(d_sg_list_t *dst_sgl, struct pool_iv_entry *src_iv)
 }
 
 static int
-pool_iv_conns_resize(d_sg_list_t *sgl, unsigned int new_size)
+pool_iv_conns_resize(d_sg_list_t *sgl, unsigned int old_size,
+		     unsigned int new_size)
 {
 	struct pool_iv_entry *old_ent = sgl->sg_iovs[0].iov_buf;
 	struct pool_iv_entry *new_ent;
 	struct pool_iv_conns *new_conns;
 
-	D_REALLOC(new_ent, old_ent, new_size);
+	D_REALLOC(new_ent, old_ent, old_size, new_size);
 	if (new_ent == NULL)
 		return -DER_NOMEM;
 
@@ -462,10 +463,12 @@ pool_iv_conns_ent_update(d_sg_list_t *dst_sgl, struct pool_iv_entry *src_iv)
 	dst_conns = &dst_entry->piv_conn_hdls;
 	dst_conns_size = dst_conns->pic_size + src_conns->pic_size;
 	if (dst_conns_size > dst_conns->pic_buf_size) {
+		unsigned int old_size;
 		unsigned int new_size;
 
 		new_size = sizeof(*dst_conns) + dst_conns_size;
-		rc = pool_iv_conns_resize(dst_sgl, new_size);
+		old_size = sizeof(*dst_conns) + dst_conns->pic_buf_size;
+		rc = pool_iv_conns_resize(dst_sgl, old_size, new_size);
 		if (rc)
 			return rc;
 
@@ -580,7 +583,9 @@ pool_iv_map_ent_update(d_sg_list_t *dst_sgl, struct pool_iv_entry *src_iv)
 		uint32_t new_size;
 
 		new_size = pool_iv_map_ent_size(pb_nr);
-		D_REALLOC(new_buf, dst_sgl->sg_iovs[0].iov_buf, new_size);
+		/* Old size doesn't matter, buffer is immediately overwritten */
+		D_REALLOC(new_buf, dst_sgl->sg_iovs[0].iov_buf, new_size,
+			  new_size);
 		if (new_buf == NULL)
 			return -DER_NOMEM;
 

--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -4162,7 +4162,7 @@ get_open_handles_cb(daos_handle_t ih, d_iov_t *key, d_iov_t *val, void *varg)
 	if (size_needed > arg->hdls_size) {
 		void *newbuf = NULL;
 
-		D_REALLOC(newbuf, *arg->hdls, size_needed);
+		D_REALLOC(newbuf, *arg->hdls, arg->hdls_size, size_needed);
 		if (newbuf == NULL)
 			D_GOTO(out_hdl, rc = -DER_NOMEM);
 

--- a/src/rdb/rdb_util.c
+++ b/src/rdb/rdb_util.c
@@ -232,6 +232,7 @@ rdb_vos_set_iods(enum rdb_vos_op op, int n, d_iov_t akeys[],
 		iods[i].iod_name = akeys[i];
 		iods[i].iod_type = DAOS_IOD_SINGLE;
 		iods[i].iod_size = 0;
+		iods[i].iod_flags = 0;
 		iods[i].iod_recxs = NULL;
 		if (op == RDB_VOS_UPDATE) {
 			D_ASSERT(values[i].iov_len > 0);

--- a/src/rsvc/srv_common.c
+++ b/src/rsvc/srv_common.c
@@ -430,7 +430,7 @@ attr_list_iter_cb(daos_handle_t ih, d_iov_t *key, d_iov_t *val, void *arg)
 		if (i_args->iov_index == i_args->iov_count) {
 			void *ptr;
 
-			D_REALLOC_ARRAY(ptr, i_args->iovs,
+			D_REALLOC_ARRAY(ptr, i_args->iovs, i_args->iov_count,
 					i_args->iov_count * 2);
 			/*
 			 * TODO: Fail or continue transferring

--- a/src/tests/ftest/cart/util/cart_logparse.py
+++ b/src/tests/ftest/cart/util/cart_logparse.py
@@ -345,7 +345,7 @@ class LogLine():
         """Returns the size of the allocation"""
         if self.get_field(5) == '*':
             if self.is_realloc():
-                field = -10
+                field = -8
             else:
                 field = -3
             count = int(self.get_field(field).split(':')[-1])

--- a/src/tests/ftest/cart/util/cart_logparse.py
+++ b/src/tests/ftest/cart/util/cart_logparse.py
@@ -345,7 +345,7 @@ class LogLine():
         """Returns the size of the allocation"""
         if self.get_field(5) == '*':
             if self.is_realloc():
-                field = -5
+                field = -10
             else:
                 field = -3
             count = int(self.get_field(field).split(':')[-1])

--- a/src/tests/ftest/cart/util/cart_logtest.py
+++ b/src/tests/ftest/cart/util/cart_logtest.py
@@ -528,10 +528,16 @@ class LogTest():
                             show_line(line, 'HIGH', 'free of unknown memory')
                         err_count += 1
                 elif line.is_realloc():
-                    new_pointer = line.get_field(-3)
-                    old_pointer = line.get_field(-1)[:-2].split(':')[-1]
+                    new_pointer = line.get_field(-6)
+                    old_pointer = line.get_field(-1)[0:-2]
+                    old_sz = int(line.get_field(-3))
+                    new_sz = line.calloc_size()
                     if new_pointer != '(nil)' and old_pointer != '(nil)':
-                        memsize.subtract(regions[old_pointer].calloc_size())
+                        exp_sz = regions[old_pointer].calloc_size()
+                        if old_sz not in [0, exp_sz, new_sz]:
+                            show_line(line, 'HIGH',
+                                      'realloc used invalid old size')
+                        memsize.subtract(exp_sz)
                     regions[new_pointer] = line
                     memsize.add(line.calloc_size())
                     if old_pointer not in (new_pointer, '(nil)'):

--- a/src/utils/daos_hdlr.c
+++ b/src/utils/daos_hdlr.c
@@ -3195,7 +3195,7 @@ cont_clone_recx_array(daos_key_t *dkey,
 		}
 		buf_len *= size;
 		if (buf_len > buf_len_alloc) {
-			D_REALLOC(buf, prev_buf, buf_len_alloc, buf_len);
+			D_REALLOC_NZ(buf, prev_buf, buf_len);
 			if (buf == NULL)
 				D_GOTO(out, rc = -DER_NOMEM);
 			buf_len_alloc = buf_len;

--- a/src/utils/daos_hdlr.c
+++ b/src/utils/daos_hdlr.c
@@ -3195,7 +3195,7 @@ cont_clone_recx_array(daos_key_t *dkey,
 		}
 		buf_len *= size;
 		if (buf_len > buf_len_alloc) {
-			D_REALLOC(buf, prev_buf, buf_len);
+			D_REALLOC(buf, prev_buf, buf_len_alloc, buf_len);
 			if (buf == NULL)
 				D_GOTO(out, rc = -DER_NOMEM);
 			buf_len_alloc = buf_len;

--- a/src/utils/self_test/self_test.c
+++ b/src/utils/self_test/self_test.c
@@ -895,8 +895,8 @@ static int run_self_test(struct st_size_params all_params[],
 		if (num_ms_endpts != num_ms_endpts_in) {
 			struct st_master_endpt *realloc_ptr;
 
-			D_REALLOC(realloc_ptr, ms_endpts,
-				  num_ms_endpts * sizeof(*ms_endpts));
+			D_REALLOC_ARRAY(realloc_ptr, ms_endpts,
+					num_ms_endpts_in, num_ms_endpts);
 			if (realloc_ptr == NULL)
 				D_GOTO(cleanup, ret = -DER_NOMEM);
 			ms_endpts = realloc_ptr;
@@ -1317,7 +1317,7 @@ int parse_endpoint_string(char *const opt_arg,
 	uint32_t		 num_ranks = 0;
 	char			*tag_valid_str = NULL;
 	uint32_t		 num_tags = 0;
-	void			*realloced_mem;
+	struct st_endpoint	*realloced_mem;
 	struct st_endpoint	*next_endpoint;
 
 	/*
@@ -1398,11 +1398,11 @@ int parse_endpoint_string(char *const opt_arg,
 	printf("  tags: %s (# tags = %u)\n", tag_valid_str, num_tags);
 
 	/* Reallocate/expand the endpoints array */
-	*num_endpts += num_ranks * num_tags;
-	D_REALLOC(realloced_mem, *endpts,
-		  sizeof(struct st_endpoint) * (*num_endpts));
+	D_REALLOC_ARRAY(realloced_mem, *endpts, *num_endpts,
+			*num_endpts + num_ranks * num_tags);
 	if (realloced_mem == NULL)
 		D_GOTO(cleanup, ret = -DER_NOMEM);
+	*num_endpts += num_ranks * num_tags;
 	*endpts = (struct st_endpoint *)realloced_mem;
 
 	/* Populate the newly expanded values in the endpoints array */
@@ -1822,11 +1822,11 @@ int main(int argc, char *argv[])
 
 	/* Shrink the buffer if some of the user's tokens weren't kept */
 	if (num_msg_sizes < num_tokens + 1) {
-		void *realloced_mem;
+		struct st_size_params *realloced_mem;
 
 		/* This should always succeed since the buffer is shrinking.. */
-		D_REALLOC(realloced_mem, all_params,
-			  num_msg_sizes * sizeof(all_params[0]));
+		D_REALLOC_ARRAY(realloced_mem, all_params, num_tokens + 1,
+				num_msg_sizes);
 		if (realloced_mem == NULL)
 			D_GOTO(cleanup, ret = -DER_NOMEM);
 		all_params = (struct st_size_params *)realloced_mem;

--- a/src/vos/evtree.c
+++ b/src/vos/evtree.c
@@ -313,14 +313,14 @@ ent_array_resize(struct evt_context *tcx, struct evt_entry_array *ent_array,
 {
 	struct evt_list_entry	*ents;
 
-	D_ALLOC_ARRAY(ents, new_size);
+	if (ent_array->ea_ents != ent_array->ea_embedded_ents)
+		D_REALLOC_ARRAY(ents, ent_array->ea_ents, ent_array->ea_ent_nr,
+				new_size);
+	else
+		D_ALLOC_ARRAY(ents, new_size);
 	if (ents == NULL)
 		return -DER_NOMEM;
 
-	memcpy(ents, ent_array->ea_ents,
-	       sizeof(ents[0]) * ent_array->ea_ent_nr);
-	if (ent_array->ea_ents != ent_array->ea_embedded_ents)
-		D_FREE(ent_array->ea_ents);
 	ent_array->ea_ents = ents;
 	ent_array->ea_size = new_size;
 

--- a/src/vos/evtree.c
+++ b/src/vos/evtree.c
@@ -313,14 +313,14 @@ ent_array_resize(struct evt_context *tcx, struct evt_entry_array *ent_array,
 {
 	struct evt_list_entry	*ents;
 
-	if (ent_array->ea_ents != ent_array->ea_embedded_ents)
-		D_REALLOC_ARRAY(ents, ent_array->ea_ents, ent_array->ea_ent_nr,
-				new_size);
-	else
-		D_ALLOC_ARRAY(ents, new_size);
+	D_ALLOC_ARRAY(ents, new_size);
 	if (ents == NULL)
 		return -DER_NOMEM;
 
+	memcpy(ents, ent_array->ea_ents,
+	       sizeof(ents[0]) * ent_array->ea_ent_nr);
+	if (ent_array->ea_ents != ent_array->ea_embedded_ents)
+		D_FREE(ent_array->ea_ents);
 	ent_array->ea_ents = ents;
 	ent_array->ea_size = new_size;
 

--- a/src/vos/ilog.c
+++ b/src/vos/ilog.c
@@ -1263,8 +1263,6 @@ alloc_entry(struct ilog_entries *entries)
 	struct ilog_entry	*new_data;
 	struct ilog_priv	*priv = ilog_ent2priv(entries);
 	struct ilog_entry	*item;
-	bool			 dealloc;
-	size_t			 old_count;
 	size_t			 new_count;
 
 	if (entries->ie_num_entries < NUM_EMBEDDED)
@@ -1274,24 +1272,18 @@ alloc_entry(struct ilog_entries *entries)
 		goto out;
 
 	if (priv->ip_alloc_size) {
-		old_count = priv->ip_alloc_size;
-		dealloc = true;
+		new_count = priv->ip_alloc_size * 2;
+		D_REALLOC_ARRAY(new_data, entries->ie_entries,
+				priv->ip_alloc_size, new_count);
 	} else {
-		old_count = NUM_EMBEDDED;
-		dealloc = false;
+		new_count = NUM_EMBEDDED * 2;
+		D_ALLOC_ARRAY(new_data, new_count);
 	}
-	new_count = old_count * 2;
 
-	D_ALLOC_ARRAY(new_data, new_count);
 	if (new_data == NULL) {
 		D_ERROR("No memory available for iterating ilog\n");
 		return NULL;
 	}
-
-	memcpy(new_data, entries->ie_entries,
-	       sizeof(*new_data) * old_count);
-	if (dealloc)
-		D_FREE(entries->ie_entries);
 
 	entries->ie_entries = new_data;
 	priv->ip_alloc_size = new_count;

--- a/src/vos/vos_aggregate.c
+++ b/src/vos/vos_aggregate.c
@@ -500,7 +500,11 @@ csum_prepare_buf(struct agg_lgc_seg *segs, unsigned int seg_cnt,
 	int		 i;
 
 	if (new_len > cur_len) {
-		D_REALLOC(buffer, *csum_bufp, new_len);
+		/* We should probably use D_FREE/D_ALLOC here but since we
+		 * reset the whole array, just avoid any memset by setting
+		 * old size to new size
+		 */
+		D_REALLOC(buffer, *csum_bufp, new_len, new_len);
 		if (buffer == NULL)
 			return -DER_NOMEM;
 	} else
@@ -545,7 +549,8 @@ prepare_segments(struct agg_merge_window *mw)
 	D_ASSERT(mw->mw_phy_cnt > 0);
 	seg_max = MAX((mw->mw_lgc_cnt + mw->mw_phy_cnt), 200);
 	if (io->ic_seg_max < seg_max) {
-		D_REALLOC_ARRAY(lgc_seg, io->ic_segs, seg_max);
+		/* Avoid double memset by using seg_max as old size */
+		D_REALLOC_ARRAY(lgc_seg, io->ic_segs, seg_max, seg_max);
 		if (lgc_seg == NULL)
 			return -DER_NOMEM;
 
@@ -761,14 +766,11 @@ csum_append_added_segs(struct bio_sglist *bsgl, unsigned int added_segs)
 	void		*buffer;
 	unsigned int	 i, add_idx = bsgl->bs_nr;
 
-	D_REALLOC_ARRAY(buffer, bsgl->bs_iovs, bsgl->bs_nr + added_segs);
+	D_REALLOC_ARRAY(buffer, bsgl->bs_iovs, bsgl->bs_nr,
+			bsgl->bs_nr + added_segs);
 	if (buffer == NULL)
 		return -DER_NOMEM;
 	bsgl->bs_iovs = buffer;
-
-	/* Initialize new segments */
-	memset(&bsgl->bs_iovs[bsgl->bs_nr], 0,
-		sizeof(bsgl->bs_iovs[0]) * added_segs);
 
 	for (i = 0; i < bsgl->bs_nr; i++) {
 		if (bsgl->bs_iovs[i].bi_prefix_len) {
@@ -924,7 +926,8 @@ fill_one_segment(daos_handle_t ih, struct agg_merge_window *mw,
 		void *buffer;
 
 		/* An array of recalc structs (one per output segment). */
-		D_REALLOC_ARRAY(buffer, io->ic_csum_recalcs, seg_count);
+		D_REALLOC_ARRAY(buffer, io->ic_csum_recalcs,
+				io->ic_csum_recalc_cnt, seg_count);
 		if (buffer == NULL)
 			D_GOTO(out, rc = -DER_NOMEM);
 
@@ -1003,7 +1006,8 @@ fill_one_segment(daos_handle_t ih, struct agg_merge_window *mw,
 	if (io->ic_buf_len < buf_max + buf_add) {
 		void *buffer;
 
-		D_REALLOC(buffer, io->ic_buf, buf_max + buf_add);
+		D_REALLOC(buffer, io->ic_buf, io->ic_buf_len,
+			  buf_max + buf_add);
 		if (buffer == NULL) {
 			rc = -DER_NOMEM;
 			goto out;
@@ -1098,7 +1102,9 @@ fill_segments(daos_handle_t ih, struct agg_merge_window *mw,
 		if (io->ic_rsrvd_scm == NULL)
 			D_ALLOC(rsrvd_scm, size);
 		else
-			D_REALLOC(rsrvd_scm, io->ic_rsrvd_scm, size);
+			D_REALLOC(rsrvd_scm, io->ic_rsrvd_scm,
+				  sizeof(*io->ic_rsrvd_scm) * sizeof(*scm_exts)
+				  * io->ic_rsrvd_scm->rs_actv_cnt, size);
 		if (rsrvd_scm == NULL)
 			return -DER_NOMEM;
 
@@ -1485,7 +1491,7 @@ enqueue_lgc_ent(struct agg_merge_window *mw, struct evt_extent *lgc_ext,
 	if (cnt == max) {
 		unsigned int new_max = max ? max * 2 : 10;
 
-		D_REALLOC_ARRAY(lgc_ent, mw->mw_lgc_ents, new_max);
+		D_REALLOC_ARRAY(lgc_ent, mw->mw_lgc_ents, max, new_max);
 		if (lgc_ent == NULL)
 			return -DER_NOMEM;
 

--- a/src/vos/vos_dtx.c
+++ b/src/vos/vos_dtx.c
@@ -1761,7 +1761,7 @@ vos_dtx_prepared(struct dtx_handle *dth)
 			dae->dae_oids = &dae->dae_oid_inline;
 		} else {
 			size = sizeof(daos_unit_oid_t) * dth->dth_oid_cnt;
-			D_ALLOC(dae->dae_oids, size);
+			D_ALLOC_NZ(dae->dae_oids, size);
 			if (dae->dae_oids == NULL) {
 				/* Not fatal. */
 				D_WARN("No DRAM to store ACT DTX OIDs "

--- a/src/vos/vos_io.c
+++ b/src/vos/vos_io.c
@@ -601,7 +601,7 @@ iod_fetch(struct vos_io_context *ioc, struct bio_iov *biov)
 	if (iov_at == iov_nr - 1) {
 		struct bio_iov *biovs;
 
-		D_REALLOC_ARRAY(biovs, bsgl->bs_iovs, (iov_nr * 2));
+		D_REALLOC_ARRAY(biovs, bsgl->bs_iovs, iov_nr, (iov_nr * 2));
 		if (biovs == NULL)
 			return -DER_NOMEM;
 
@@ -625,7 +625,7 @@ bsgl_csums_resize(struct vos_io_context *ioc)
 		struct dcs_csum_info *new_infos;
 		uint32_t	 new_nr = dcb_nr * 2;
 
-		D_REALLOC_ARRAY(new_infos, csums, new_nr);
+		D_REALLOC_ARRAY(new_infos, csums, dcb_nr, new_nr);
 		if (new_infos == NULL)
 			return -DER_NOMEM;
 
@@ -694,17 +694,17 @@ akey_fetch_single(daos_handle_t toh, const daos_epoch_range_t *epr,
 		D_GOTO(out, rc = (rc == 0 ? -DER_INPROGRESS : rc));
 
 	if (rc == -DER_NONEXIST) {
-		rbund.rb_rsize = 0;
+		rbund.rb_gsize = 0;
 		bio_addr_set_hole(&biov.bi_addr, 1);
 		rc = 0;
 	} else if (rc != 0) {
 		goto out;
 	} else if (key.sk_epoch < epr->epr_lo) {
 		/* The single value is before the valid epoch range (after a
-		 * punch when incarnation log is available
+		 * punch when incarnation log is available)
 		 */
 		rc = 0;
-		rbund.rb_rsize = 0;
+		rbund.rb_gsize = 0;
 		bio_addr_set_hole(&biov.bi_addr, 1);
 	} else if (key.sk_epoch > epr->epr_hi) {
 		/* Uncertainty violation */


### PR DESCRIPTION
1. Modify D_REALLOC* to take old size so it can do memset
2. Add non-zero (NZ) and full zero (Z) versions of allocation routines
3. Modify several code blocks to use these macros
4. Move DAOS_ON_VALGRIND to gurt header, rename to D_ON_VALGRIND
5. Use D_ON_VALGRIND to avoid running valgrind on full benchmark(s)
6. Make sure iod_size gets set to 0 for non-existent values
7. Set iod_flags to 0 in rdb usages.  This should be benign.
8. Add a size check to cart_logtest.py

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>