### PR TITLE
DAOS-7350 obj: refine ds_pool_check_dtx_leader

### DIFF
--- a/src/dtx/dtx_resync.c
+++ b/src/dtx/dtx_resync.c
@@ -141,7 +141,7 @@ dtx_is_leader(struct ds_pool *pool, struct dtx_resync_args *dra,
 	 *	data shard for EC object in the future.
 	 */
 	return ds_pool_check_dtx_leader(pool, &dre->dre_oid,
-					pool->sp_map_version);
+					pool->sp_map_version, false);
 }
 
 static bool

--- a/src/include/daos/placement.h
+++ b/src/include/daos/placement.h
@@ -163,7 +163,7 @@ pl_obj_get_shard(void *data, int idx)
 }
 
 int pl_select_leader(daos_obj_id_t oid, uint32_t shard_idx, uint32_t grp_size,
-		     bool for_tgt_id, pl_get_shard_t pl_get_shard, void *data);
+		     int *tgt_id, pl_get_shard_t pl_get_shard, void *data);
 
 void obj_layout_dump(daos_obj_id_t oid, struct pl_obj_layout *layout);
 

--- a/src/include/daos_srv/pool.h
+++ b/src/include/daos_srv/pool.h
@@ -200,7 +200,7 @@ int ds_pool_iv_srv_hdl_fetch(struct ds_pool *pool, uuid_t *pool_hdl_uuid,
 int ds_pool_svc_term_get(uuid_t uuid, uint64_t *term);
 
 int ds_pool_elect_dtx_leader(struct ds_pool *pool, daos_unit_oid_t *oid,
-			     uint32_t version);
+			     uint32_t version, int *tgt_id);
 int ds_pool_check_dtx_leader(struct ds_pool *pool, daos_unit_oid_t *oid,
 			     uint32_t version);
 

--- a/src/include/daos_srv/pool.h
+++ b/src/include/daos_srv/pool.h
@@ -202,7 +202,7 @@ int ds_pool_svc_term_get(uuid_t uuid, uint64_t *term);
 int ds_pool_elect_dtx_leader(struct ds_pool *pool, daos_unit_oid_t *oid,
 			     uint32_t version, int *tgt_id);
 int ds_pool_check_dtx_leader(struct ds_pool *pool, daos_unit_oid_t *oid,
-			     uint32_t version);
+			     uint32_t version, bool check_shard);
 
 int
 ds_pool_child_map_refresh_sync(struct ds_pool_child *dpc);

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -581,7 +581,7 @@ obj_grp_leader_get(struct dc_object *obj, int idx, unsigned int map_ver)
 	if (obj->cob_version == map_ver)
 		rc = pl_select_leader(obj->cob_md.omd_id,
 				      idx / obj->cob_grp_size,
-				      obj->cob_grp_size, false,
+				      obj->cob_grp_size, NULL,
 				      obj_get_shard, obj);
 	D_RWLOCK_UNLOCK(&obj->cob_lock);
 

--- a/src/object/obj_tx.c
+++ b/src/object/obj_tx.c
@@ -1606,7 +1606,7 @@ dc_tx_commit_prepare(struct dc_tx *tx, tse_task_t *task)
 			D_GOTO(out, rc = grp_idx);
 
 		i = pl_select_leader(obj->cob_md.omd_id, grp_idx,
-				     obj->cob_grp_size, false,
+				     obj->cob_grp_size, NULL,
 				     obj_get_shard, obj);
 		if (i < 0)
 			D_GOTO(out, rc = i);

--- a/src/object/srv_ec_aggregate.c
+++ b/src/object/srv_ec_aggregate.c
@@ -2232,7 +2232,8 @@ agg_object(daos_handle_t ih, vos_iter_entry_t *entry,
 
 	rc = ds_pool_check_dtx_leader(agg_param->ap_pool_info.api_pool,
 				      &entry->ie_oid, agg_param->
-				      ap_pool_info.api_pool->sp_map_version);
+				      ap_pool_info.api_pool->sp_map_version,
+				      true);
 
 	if (rc == 1 && entry->ie_oid.id_shard >= oca->u.ec.e_k) {
 		agg_reset_entry(&agg_param->ap_agg_entry, entry, oca);

--- a/src/placement/pl_map.c
+++ b/src/placement/pl_map.c
@@ -598,17 +598,17 @@ pl_map_query(uuid_t po_uuid, struct pl_map_attr *attr)
  * \param [IN]  oid             The object identifier.
  * \param [IN]  grp_idx         The group index.
  * \param [IN]  grp_size        Group size of obj layout.
- * \param [IN]  for_tgt_id      Require leader target id or leader shard index.
+ * \param [OUT] tgt_id          If non-NULL, Require leader target id.
  * \param [IN]  pl_get_shard    The callback function to parse out pl_obj_shard
  *                              from the given @data.
  * \param [IN]  data            The parameter used by the @pl_get_shard.
  *
- * \return                      The selected leader on success: its tgt_id or
- *                              shard index. Negative value if error.
+ * \return                      The selected leader shard on success
+ *                              Negative value if error.
  */
 int
 pl_select_leader(daos_obj_id_t oid, uint32_t grp_idx, uint32_t grp_size,
-		 bool for_tgt_id, pl_get_shard_t pl_get_shard, void *data)
+		 int *tgt_id, pl_get_shard_t pl_get_shard, void *data)
 {
 	struct pl_obj_shard             *shard;
 	struct daos_oclass_attr         *oc_attr;
@@ -636,9 +636,12 @@ pl_select_leader(daos_obj_id_t oid, uint32_t grp_idx, uint32_t grp_size,
 			shard = pl_get_shard(data, idx);
 		}
 
-		if (for_tgt_id)
-			return shard->po_target == -1 ? -DER_IO :
-						shard->po_target;
+		if (tgt_id != NULL) {
+			if (shard->po_target == -1)
+				return -DER_IO;
+
+			*tgt_id = shard->po_target;
+		}
 
 		return shard->po_shard == -1 ? -DER_IO : shard->po_shard;
 	}
@@ -665,8 +668,8 @@ pl_select_leader(daos_obj_id_t oid, uint32_t grp_idx, uint32_t grp_size,
 		 * it moves between ranks
 		 */
 
-		if (for_tgt_id)
-			return shard->po_target;
+		if (tgt_id != NULL)
+			*tgt_id = shard->po_target;
 
 		/* return pos rather than shard->po_shard for pool extending */
 		return pos;
@@ -699,8 +702,8 @@ pl_select_leader(daos_obj_id_t oid, uint32_t grp_idx, uint32_t grp_size,
 			pos = off;
 	}
 	if (pos != -1) {
-		if (for_tgt_id)
-			return pl_get_shard(data, pos)->po_target;
+		if (tgt_id != NULL)
+			*tgt_id = pl_get_shard(data, pos)->po_target;
 
 		/*
 		 * Here should not return "pl_get_shard(data, pos)->po_shard",

--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -5544,7 +5544,7 @@ out:
 
 int
 ds_pool_elect_dtx_leader(struct ds_pool *pool, daos_unit_oid_t *oid,
-			 uint32_t version)
+			 uint32_t version, int *tgt_id)
 {
 	struct pl_map		*map;
 	struct pl_obj_layout	*layout;
@@ -5565,7 +5565,7 @@ ds_pool_elect_dtx_leader(struct ds_pool *pool, daos_unit_oid_t *oid,
 		goto out;
 
 	rc = pl_select_leader(oid->id_pub, oid->id_shard / layout->ol_grp_size,
-			      layout->ol_grp_size, true,
+			      layout->ol_grp_size, tgt_id,
 			      pl_obj_get_shard, layout);
 	pl_obj_layout_free(layout);
 	if (rc < 0)
@@ -5587,7 +5587,8 @@ out:
  * \param [IN]	version		The pool map version
  *
  * \return			+1 if leader is on current server.
- * \return			Zero if the leader resides on another server.
+ * \return			Zero if the leader resides on another server,
+ *				or the oid->id_shard is not the leader shard.
  * \return			Negative value if error.
  */
 int
@@ -5596,15 +5597,17 @@ ds_pool_check_dtx_leader(struct ds_pool *pool, daos_unit_oid_t *oid,
 {
 	struct pool_target	*target;
 	d_rank_t		 myrank;
-	int			 leader;
+	int			 leader_tgt;
+	int			 leader_shard;
 	int			 rc;
 
-	leader = ds_pool_elect_dtx_leader(pool, oid, version);
-	if (leader < 0)
-		return leader;
+	rc = ds_pool_elect_dtx_leader(pool, oid, version, &leader_tgt);
+	if (rc < 0)
+		return rc;
+	leader_shard = rc;
 
-	D_DEBUG(DB_TRACE, "get new leader tgt id %d\n", leader);
-	rc = pool_map_find_target(pool->sp_map, leader, &target);
+	D_DEBUG(DB_TRACE, "get new leader tgt id %d\n", leader_tgt);
+	rc = pool_map_find_target(pool->sp_map, leader_tgt, &target);
 	if (rc < 0)
 		return rc;
 
@@ -5615,7 +5618,8 @@ ds_pool_check_dtx_leader(struct ds_pool *pool, daos_unit_oid_t *oid,
 	if (rc < 0)
 		return rc;
 
-	if (myrank != target->ta_comp.co_rank)
+	if (myrank != target->ta_comp.co_rank ||
+	    oid->id_shard != leader_shard)
 		rc = 0;
 	else
 		rc = 1;

--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -5593,7 +5593,7 @@ out:
  */
 int
 ds_pool_check_dtx_leader(struct ds_pool *pool, daos_unit_oid_t *oid,
-			 uint32_t version)
+			 uint32_t version, bool check_shard)
 {
 	struct pool_target	*target;
 	d_rank_t		 myrank;
@@ -5618,11 +5618,13 @@ ds_pool_check_dtx_leader(struct ds_pool *pool, daos_unit_oid_t *oid,
 	if (rc < 0)
 		return rc;
 
-	if (myrank != target->ta_comp.co_rank ||
-	    oid->id_shard != leader_shard)
+	if (myrank != target->ta_comp.co_rank) {
 		rc = 0;
-	else
+	} else {
 		rc = 1;
+		if (check_shard && oid->id_shard != leader_shard)
+			rc = 0;
+	}
 
 	return rc;
 }


### PR DESCRIPTION
Refine ds_pool_check_dtx_leader()/pl_select_leader(), not only compare
server rank with leader rank, but also compare oid.id_shard with
leader shard.
For the case that when multiple shards co-locate on same node, previous
ds_pool_check_dtx_leader() possibly cause two shards' caller thread both
treat itself as leader. This may cause problem for EC aggregation.

Signed-off-by: Xuezhao Liu <xuezhao.liu@intel.com>