### PR TITLE
DAOS-5036 doc: update for 1.2

### DIFF
--- a/doc/admin/installation.md
+++ b/doc/admin/installation.md
@@ -5,7 +5,7 @@ to select the appropriate software combination.
 
 ## Distribution Packages
 
-DAOS packages are available for CentOS7, openSUSE Leap 15 and Ubuntu 20.04.
+DAOS packages are available for CentOS7 and openSUSE Leap 15.
 For other distribution, manual building is required (see next section).
 
 ### CentOS 7.9

--- a/doc/admin/installation.md
+++ b/doc/admin/installation.md
@@ -8,22 +8,25 @@ to select the appropriate software combination.
 DAOS packages are available for CentOS7, openSUSE Leap 15 and Ubuntu 20.04.
 For other distribution, manual building is required (see next section).
 
-### CentOS7
+### CentOS 7.9
 
 Configure the DAOS package repository as follows:
 ``` bash
 $ sudo wget -O /etc/yum.repos.d/daos-packages.repo http://packages.daos.io/v1.2/CentOS7/packages/x86_64/daos_packages.repo
 ```
 
-To install the DAOS client packages:
+epel-release is required for both client and server:
 ``` bash
 $ sudo yum install -y epel-release
+```
+
+To install the DAOS client packages:
+``` bash
 $ sudo yum install -y daos-client
 ```
 
 To install the DAOS server packages:
 ``` bash
-$ sudo yum install -y epel-release
 $ sudo yum install -y daos-server
 ```
 
@@ -33,11 +36,25 @@ repositories.
 
 ### openSUSE Leap 15
 
-TBD
+Add the DAOS package repository via zypper:
+``` bash
+$ sudo zypper ar http://packages.daos.io/v1.2/Leap15.2/packages x86_64/daos_packages
+$ sudo rpm --import http://packages.daos.io/RPM-GPG-KEY
+$ sudo zypper --non-interactive ref
+```
+To install the DAOS client packages:
+``` bash
+$ sudo zypper install -y daos-client
+```
 
-### Ubuntu 20.04
+To install the DAOS server packages:
+``` bash
+$ sudo zypper install -y daos-server
+```
 
-TBD
+Debug and source RPMs available in the respective [debug](http://packages.daos.io/v1.2/Leap15.2/debug/x86_64/daos_debug.repo)
+and [source](http://packages.daos.io/v1.2/Leaps15.2/source/daos_source.repo)
+repositories.
 
 ## DAOS from Scratch
 

--- a/doc/admin/installation.md
+++ b/doc/admin/installation.md
@@ -6,7 +6,7 @@ to select the appropriate software combination.
 ## Distribution Packages
 
 DAOS packages are available for CentOS7, openSUSE Leap 15 and Ubuntu 20.04.
-For other distrubution, manual building is required (see next section).
+For other distribution, manual building is required (see next section).
 
 ### CentOS7
 

--- a/doc/admin/installation.md
+++ b/doc/admin/installation.md
@@ -3,66 +3,41 @@
 Please check the [support matrix](https://daos-stack.github.io/release/support_matrix)
 to select the appropriate software combination.
 
-## Software Dependencies
-
-DAOS requires a C99-capable compiler, a Go compiler, and the scons build tool.
-Moreover, the DAOS stack leverages the following open source projects:
-
--   [*gRPC*](https://grpc.io/) provides a secured out-of-band channel for
-    DAOS administration.
-
--   [*PMDK*](https://github.com/pmem/pmdk.git) for persistent memory
-    programming.
-
--   [*SPDK*](http://spdk.io/) for userspace NVMe device access and management.
-
--   [*ISA-L*](https://github.com/01org/isa-l) and
-    [*ISA-L_Crypto*](https://github.com/01org/isa-l_crypto) for checksum and
-    erasure code
-
--   [*Argobots*](https://github.com/pmodels/argobots) for thread management.
-
--   [*hwloc*](https://github.com/open-mpi/hwloc) for discovering system devices,
-    detecting their NUMA node affinity and for CPU binding
-
--   [*libfabric*](https://github.com/ofiwg/libfabric) for detecting fabric
-    interfaces, providers, and connection management.
-
-The DAOS build system can be configured to download and build any missing
-dependencies automatically.
-
 ## Distribution Packages
 
-DAOS RPM packaging is currently available, and DEB packaging is under
-development and will be available in a future DAOS release.
-Integration with the [Spack](https://spack.io/) package manager is also
-under consideration.
+DAOS packages are available for CentOS7, openSUSE Leap 15 and Ubuntu 20.04.
+For other distrubution, manual building is required (see next section).
 
-### Installing DAOS from RPMs
+### CentOS7
 
-DAOS RPMs are available from the Intel&copy; Registration Center.
-Clicking the [Intel&copy; Registration Center](https://registrationcenter.intel.com/forms/?productid=3412)
-link will take you to the registration center, where you will create an account.
-After creating an account, the following files can be downloaded:
-
-- daos_debug.tar - _debuginfo_ packages
-- daos_packages.tar - client and server main packages
-- daos_source.tar - source RPMs
-
-Recommended steps after download:
-
-```bash
-$ sudo tar -C / -xf daos_packages.tar
-$ sudo cp /opt/intel/daos_rpms/packages/daos_packages.repo /etc/yum.repos.d
-$ rm /opt/intel/daos_rpms/packages/libabt*
-  (cd /opt/intel/daos_rpms/packages/ && createrepo .)
-$ sudo yum install epel-release
-$ sudo yum install daos-server
-$ sudo yum install daos-client
+Configure the DAOS package repository as follows:
+``` bash
+$ sudo wget -O /etc/yum.repos.d/daos-packages.repo http://packages.daos.io/v1.2/CentOS7/packages/x86_64/daos_packages.repo
 ```
 
-!!! note
-    Only daos-client OR daos-server needs to be specified on the yum command line.
+To install the DAOS client packages:
+``` bash
+$ sudo yum install -y epel-release
+$ sudo yum install -y daos-client
+```
+
+To install the DAOS server packages:
+``` bash
+$ sudo yum install -y epel-release
+$ sudo yum install -y daos-server
+```
+
+Debug and source RPMs available in the respective [debug](http://packages.daos.io/v1.2/CentOS7/debug/x86_64/daos_debug.repo)
+and [source](http://packages.daos.io/v1.2/CentOS7/source/daos_source.repo)
+repositories.
+
+### openSUSE Leap 15
+
+TBD
+
+### Ubuntu 20.04
+
+TBD
 
 ## DAOS from Scratch
 
@@ -82,13 +57,13 @@ version of at least 1.10 is required.
 An exhaustive list of packages for each supported Linux distribution is
 maintained in the Docker files (please click on the link):
 
--    [CentOS](https://github.com/daos-stack/daos/blob/master/utils/docker/Dockerfile.centos.7#L53-L79)
--    [OpenSUSE](https://github.com/daos-stack/daos/blob/master/utils/docker/Dockerfile.leap.15#L71-L100)
--    [Ubuntu](https://github.com/daos-stack/daos/blob/master/utils/docker/Dockerfile.ubuntu.20.04#L21-L39)
+-    [CentOS 7](https://github.com/daos-stack/daos/tree/release/1.2/utils/docker/Dockerfile.centos.7#L19-L79)
+-    [openSUSE Leap 15](https://github.com/daos-stack/daos/tree/release/1.2/utils/docker/Dockerfile.leap.15#L36-L85)
+-    [Ubuntu 20.04](https://github.com/daos-stack/daos/tree/release/1.2/utils/docker/Dockerfile.ubuntu.20.04#L14-L22)
 
 The command lines to install the required packages can be extracted from
 the Docker files by removing the "RUN" command, which is specific to Docker.
-Check the [utils/docker](https://github.com/daos-stack/daos/tree/master/utils/docker)
+Check the [utils/docker](https://github.com/daos-stack/daos/tree/release/1.2/utils/docker)
 directory for different Linux distribution versions.
 
 Some DAOS tests use MPI. The DAOS build process uses the environment modules
@@ -99,16 +74,10 @@ building those tests.
 
 The DAOS repository is hosted on [GitHub](https://github.com/daos-stack/daos).
 
-To checkout the latest stable version, simply run:
+To checkout the latest 1.2 version, simply run:
 
 ```bash
-$ git clone --recurse-submodules -b v1.0.1 https://github.com/daos-stack/daos.git
-```
-
-For the current development version, then run:
-
-```bash
-$ git clone --recurse-submodules https://github.com/daos-stack/daos.git
+$ git clone --recurse-submodules -b release/1.2 https://github.com/daos-stack/daos.git
 ```
 
 This command clones the DAOS git repository (path referred as ${daospath}
@@ -174,7 +143,7 @@ On Mac, please make sure that the Docker settings under
 To build the Docker image directly from GitHub, run the following command:
 
 ```bash
-$ docker build https://github.com/daos-stack/daos.git#master \
+$ docker build https://github.com/daos-stack/daos.git#release/1.2 \
         -f utils/docker/Dockerfile.centos.7 -t daos
 ```
 
@@ -188,8 +157,6 @@ This creates a CentOS 7 image, fetches the latest DAOS version from GitHub,
 builds it, and installs it in the image.
 For Ubuntu and other Linux distributions, replace Dockerfile.centos.7 with
 Dockerfile.ubuntu.20.04 and the appropriate version of interest.
-`master` should be replaced by the relevant release tag (e.g. v1.0.1) to
-build a stable version.
 
 ### Simple Docker Setup
 

--- a/doc/admin/performance_tuning.md
+++ b/doc/admin/performance_tuning.md
@@ -19,7 +19,7 @@ bulk transfers, multiple targets, and the following test scenarios:
     servers that will issue cross-server RPCs. This model supports a
     many to many communication model.
 
-### Getting DAOS CaRT self_test
+### Building CaRT self_test
 
 The CaRT `self_test` and its tests are delivered as part of the daos_client
 and daos_tests [distribution packages][2]. It can also be built from scratch.
@@ -136,10 +136,10 @@ IOR (<https://github.com/hpc/ior>) with the following backends:
 -   When using the IOR API=MPIIO, the ROMIO ADIO driver for DAOS can be used by
     providing the `daos://` prefix to the filename. This ADIO driver bypasses `dfuse`
     and directly invkes the `libdfs` calls to perform I/O to a DAOS POSIX container.
-    The DAOS-enabled MPIIO driver is available in the upstream MPICH repository 
+    The DAOS-enabled MPIIO driver is available in the upstream MPICH repository
     (MPICH 3.4.1 or higher).
 
--   An HDF5 VOL connector for DAOS is under development. This maps the HDF5 data model 
+-   An HDF5 VOL connector for DAOS is under development. This maps the HDF5 data model
     directly to the DAOS data model, and works in conjunction with DAOS containers of
     `--type=HDF5` (in contrast to DAOS container of `--type=POSIX` that are used for
     the other IOR APIs).
@@ -152,10 +152,37 @@ only designed to support IOR.
 
 ### FIO
 
+A DAOS engine is integrated into FIO and available upstream.
+To build it, just run:
+
+```bash
+$ git clone http://git.kernel.dk/fio.git
+$ cd fio
+$ ./configure
+$ make install
+```
+
+If DAOS is installed via packages, it should be automatically detected.
+If not, please specific the path to the DAOS library and headers to configure
+as follows:
+```
+$ CFLAGS="-I/path/to/daos/install/include" LDFLAGS="-L/path/to/daos/install/lib64" ./configure
+```
+
+Once successfully build, once can run the default example:
+```bash
+$ export POOL= # your pool UUID
+$ export CONT= # your container UUID
+$ fio ./examples/dfs.fio
+```
+
+Please note that DAOS does not transfer data (i.e. zeros) over the network
+when reading a hole in a sparse POSIX file. Very high read bandwidth can
+thus be reported if fio reads unallocated extents in a file. It is thus
+a good practice to start fio with a first write phase.
+
 FIO can also be used to benchmark DAOS performance using dfuse and the
-interception library with all the POSIX based engines like sync and libaio. We
-do, however, provide a native DFS engine for FIO similar to what we do for
-IOR. That engine is available on GitHub: <https://github.com/daos-stack/dfio>
+interception library with all the POSIX based engines like sync and libaio.
 
 ### daos_perf
 
@@ -239,8 +266,8 @@ please refer to the [System Deployment: Agent Startup][6] documentation
 section.
 
 [1]: <https://github.com/daos-stack/daos/tree/master/src/cart> (Collective and RPC Transport)
-[2]: <https://github.com/daos-stack/daos/blob/master/doc/admin/installation.md#distribution-packages> (DAOS distribution packages)
-[3]: <https://github.com/daos-stack/daos/blob/master/doc/admin/installation.md#building-daos--dependencies> (DAOS build documentation)
-[4]: <https://github.com/daos-stack/daos/blob/master/doc/admin/deployment.md#server-startup> (DAOS server startup documentation)
+[2]: <https://github.com/daos-stack/daos/tree/release/1.2/doc/admin/installation.md#distribution-packages> (DAOS distribution packages)
+[3]: <https://github.com/daos-stack/daos/tree/release/1.2/doc/admin/installation.md#building-daos--dependencies> (DAOS build documentation)
+[4]: <https://github.com/daos-stack/daos/tree/release/1.2/doc/admin/deployment.md#server-startup> (DAOS server startup documentation)
 [5]: <https://www.open-mpi.org/faq/?category=running#mpirun-hostfile> (mpirun hostfile)
-[6]: <https://github.com/daos-stack/daos/blob/master/doc/admin/deployment.md#disable-agent-cache-optional> (System Deployment Agent Startup)
+[6]: <https://github.com/daos-stack/daos/tree/release/1.2/doc/admin/deployment.md#disable-agent-cache-optional> (System Deployment Agent Startup)

--- a/doc/dev/coding.md
+++ b/doc/dev/coding.md
@@ -1,1 +1,0 @@
-# DAOS Coding Rules

--- a/doc/dev/contributing.md
+++ b/doc/dev/contributing.md
@@ -4,8 +4,11 @@ Your contributions are most welcome! There are several good ways to suggest new
 features, offer to add a feature, or just begin a dialog about DAOS:
 
 - Open an issue in [jira](https://jira.hpdd.intel.com)
-- Suggest a feature, ask a question, start a discussion, etc. in our [user group](https://daos.groups.io/g/daos)
-- Chat with members of the DAOS community real-time on [Gitter](https://gitter.im/daos-storage)
+- Suggest a feature, ask a question, start a discussion, etc. in our
+  [community mailing list](https://daos.groups.io/g/daos)
+- Chat with members of the DAOS community real-time on [slack](https://daos-stack.slack.com/).
+  An invitation to join the slack workspace is automatically sent when joining
+  the community mailing list.
 
 ## Coding Rules
 

--- a/doc/dev/development.md
+++ b/doc/dev/development.md
@@ -7,14 +7,18 @@ only required for development purposes.
 
 ## Building DAOS for Development
 
-Prerequisite when built using `--build-deps` are installed in component
-specific directories under PREFIX/prereq/$TARGET_TYPE.  Initialize and update
-the git submodules:
+The DAOS repository is hosted on [GitHub](https://github.com/daos-stack/daos).
+To checkout the current development version, simply run:
 
 ```bash
-$ git submodule init
-$ git submodule update
+$ git clone --recurse-submodules https://github.com/daos-stack/daos.git
 ```
+
+For a specific branch or tag (e.g. v1.2), add `-b v1.2` to the command
+line above.
+
+Prerequisite when built using `--build-deps` are installed in component
+specific directories under PREFIX/prereq/$TARGET_TYPE.
 
 Run the following `scons` command:
 

--- a/doc/overview/fault.md
+++ b/doc/overview/fault.md
@@ -1,87 +1,85 @@
 <a id="4.3"></a>
 # Fault Model
 
-DAOS relies on massively distributed single-ported storage. Each target 
-is thus effectively a single point of failure. DAOS achieves availability 
-and durability of both data and metadata by providing redundancy across 
-targets in different fault domains. DAOS internal pool and container 
-metadata are replicated via a robust consensus algorithm. DAOS objects 
+DAOS relies on massively distributed single-ported storage. Each target
+is thus effectively a single point of failure. DAOS achieves availability
+and durability of both data and metadata by providing redundancy across
+targets in different fault domains. DAOS internal pool and container
+metadata are replicated via a robust consensus algorithm. DAOS objects
 are then safely replicated or erasure-coded by transparently leveraging
- the DAOS distributed transaction mechanisms internally. The purpose of 
+ the DAOS distributed transaction mechanisms internally. The purpose of
 this section is to provide details on how DAOS achieves fault tolerance
  and guarantees object resilience.
 
 <a id="4.3.1"></a>
 ## Hierarchical Fault Domains
 
-A fault domain is a set of servers sharing the same point of failure and 
-which are thus likely to fail altogether. DAOS assumes that fault domains 
-are hierarchical and do not overlap. The actual hierarchy and fault domain 
-membership must be supplied by an external database used by DAOS to 
+A fault domain is a set of servers sharing the same point of failure and
+which are thus likely to fail altogether. DAOS assumes that fault domains
+are hierarchical and do not overlap. The actual hierarchy and fault domain
+membership must be supplied by an external database used by DAOS to
 generate the pool map.
 
-Pool metadata are replicated on several nodes from different high-level 
-fault domains for high availability, whereas object data is replicated 
-or erasure-coded over a variable number of fault domains depending on 
+Pool metadata are replicated on several nodes from different high-level
+fault domains for high availability, whereas object data is replicated
+or erasure-coded over a variable number of fault domains depending on
 the selected object class.
 
 <a id="4.3.2"></a>
 ## Fault Detection
 
-DAOS servers are monitored within a DAOS system through a gossip-based protocol 
-called [SWIM](http://ieeexplore.ieee.org/stamp/stamp.jsp?arnumber=1028914) 
+DAOS servers are monitored within a DAOS system through a gossip-based protocol
+called [SWIM](http://ieeexplore.ieee.org/stamp/stamp.jsp?arnumber=1028914)
 that provides accurate, efficient, and scalable server fault detection.
-Storage attached to each DAOS target is monitored through periodic local 
-health assessment. Whenever a local storage I/O error is returned to the 
-DAOS server, an internal health check procedure will be called automatically. 
-This procedure will make an overall health assessment by analyzing the 
-IO error code and device SMART/Health data. If the result is negative, 
-the target will be marked as faulty, and further I/Os to this target will be 
+Storage attached to each DAOS target is monitored through periodic local
+health assessment. Whenever a local storage I/O error is returned to the
+DAOS server, an internal health check procedure will be called automatically.
+This procedure will make an overall health assessment by analyzing the
+IO error code and device SMART/Health data. If the result is negative,
+the target will be marked as faulty, and further I/Os to this target will be
 rejected and re-routed.
 
 <a id="4.3.3"></a>
 ## Fault Isolation
 
-Once detected, the faulty target or servers (effectivelly a set of targets) 
+Once detected, the faulty target or servers (effectivelly a set of targets)
 must be excluded from the pool map. This process is triggered either manually
-by the administrator or automatically. Upon exclusion, the new version of 
-the pool map is eagerly pushed to all storage targets. At this point, the pool 
-enters a degraded mode that might require extra processing on access (e.g. 
-reconstructing data out of erasure code). Consequently, DAOS client and storage 
-nodes retry RPC indefinitely until they find an alternative replacement target 
-from the new pool map. At this point, all outstanding communications with the 
-evicted target are aborted, and no further messages should be sent to the 
-target until it is explicitly reintegrated (possibly only after maintenance 
+by the administrator or automatically. Upon exclusion, the new version of
+the pool map is eagerly pushed to all storage targets. At this point, the pool
+enters a degraded mode that might require extra processing on access (e.g.
+reconstructing data out of erasure code). Consequently, DAOS client and storage
+nodes retry RPC indefinitely until they find an alternative replacement target
+from the new pool map. At this point, all outstanding communications with the
+evicted target are aborted, and no further messages should be sent to the
+target until it is explicitly reintegrated (possibly only after maintenance
 action).
 
-All storage targets are promptly notified of pool map changes by the pool 
-service. This is not the case for client nodes, which are lazily informed 
-of pool map invalidation each time they communicate with servers. To do so, 
-clients pack in every RPC their current pool map version. Servers reply not 
-only with the current pool map version. Consequently, when a DAOS client 
-experiences RPC timeout, it regularly communicates with the other DAOS 
-target to guarantee that its pool map is always current. Clients will then 
+All storage targets are promptly notified of pool map changes by the pool
+service. This is not the case for client nodes, which are lazily informed
+of pool map invalidation each time they communicate with servers. To do so,
+clients pack in every RPC their current pool map version. Servers reply not
+only with the current pool map version. Consequently, when a DAOS client
+experiences RPC timeout, it regularly communicates with the other DAOS
+target to guarantee that its pool map is always current. Clients will then
 eventually be informed of the target exclusion and enter into degraded mode.
 
-This mechanism guarantees global node eviction and that all nodes eventually 
+This mechanism guarantees global node eviction and that all nodes eventually
 share the same view of target aliveness.
 
 <a id="4.3.4"></a>
 ## Fault Recovery
 
-Upon exclusion from the pool map, each target starts the rebuild process 
-automatically to restore data redundancy. First, each target creates a list 
-of local objects impacted by the target exclusion. This is done by scanning 
-a local object table maintained by the underlying storage layer. Then for 
-each impacted object, the location of the new object shard is determined and 
-redundancy of the object restored for the whole history (i.e., snapshots). 
-Once all impacted objects have been rebuilt, the pool map is updated a second 
-time to report the target as failed out. This marks the end of collective 
-rebuild process and the exit from degraded mode for this particular fault. 
-At this point, the pool has fully recovered from the fault and client nodes 
+Upon exclusion from the pool map, each target starts the rebuild process
+automatically to restore data redundancy. First, each target creates a list
+of local objects impacted by the target exclusion. This is done by scanning
+a local object table maintained by the underlying storage layer. Then for
+each impacted object, the location of the new object shard is determined and
+redundancy of the object restored for the whole history (i.e., snapshots).
+Once all impacted objects have been rebuilt, the pool map is updated a second
+time to report the target as failed out. This marks the end of collective
+rebuild process and the exit from degraded mode for this particular fault.
+At this point, the pool has fully recovered from the fault and client nodes
 can now read from the rebuilt object shards.
 
-This rebuild process is executed online while applications continue accessing 
+This rebuild process is executed online while applications continue accessing
 and updating objects.
-
-

--- a/doc/overview/terminology.md
+++ b/doc/overview/terminology.md
@@ -24,7 +24,7 @@
 |[ISA-L](https://01.org/intel®-storage-acceleration-library-open-source-version)|Intel Storage Acceleration Library|
 |I/O|Input/Output|
 |KV store|Key-Value store|
-|libfabric|A user-space library that exports the Open Fabrics Interface|
+|[libfabric](https://ofiwg.github.io/libfabric/)|Open Fabrics Interface|
 |Mercury|A user-space RPC library that can use libfabrics as a transport|
 |MTBF|Mean Time Between Failures|
 |NVM|Non-Volatile Memory|

--- a/doc/release/support_matrix.md
+++ b/doc/release/support_matrix.md
@@ -5,10 +5,9 @@ that have been tested with the different tags.
 
 Information for future tags/releases is indicative only and may change.
 
-| **Tag** | CentOS | OpenSuse | Ubuntu | MOFED |
+| **Tag** | CentOS | openSUSE | Ubuntu | MOFED |
 |---------|--------|----------|--------|-------|
 | v1.0.1  |  7.7   |    No    |   No   | 5.0.1 |
-| v1.1.2  |  7.8   |   15.2   |  20.04 | 5.1.x |
 | v1.2    |  7.9   |   15.2   |  20.04 | 5.1.x |
 
 DAOS is primarily validated on Intel x86_64 architecture. 

--- a/doc/user/container.md
+++ b/doc/user/container.md
@@ -8,12 +8,6 @@ Containers can be created and destroyed through the daos_cont_create/destroy()
 functions exported by the DAOS API. A user tool called `daos` is also
 provided to manage containers.
 
-!!! note
-    In DAOS 1.0, in order to use the `daos` command the following environment
-    variables need to be set (this is no longer needed in later versions of DAOS):
-     * For Omni-Path: `export OFI_INTERFACE="ib0"; export CRT_PHY_ADDR_STR="ofi+psm2"`
-     * For InfiniBand: `export OFI_INTERFACE="ib0"; export CRT_PHY_ADDR_STR="ofi+verbs;ofi_rxm"; export OFI_DOMAIN="mlx5_0"`
-
 To create a container:
 ```bash
 $ daos cont create --pool=a171434a-05a5-4671-8fe2-615aa0d05094
@@ -103,9 +97,6 @@ during container create.
 !!! note
     Note that currently, once a container is created, its checksum configuration
     cannot be changed.
-
-!!! warning
-    The checksum feature is only supported in DAOS 1.2.
 
 ## Inline Deduplication (Preview)
 
@@ -228,11 +219,6 @@ permissions on that container.
 If the user does not have Delete permission on the pool, they will only be able
 to delete containers for which they have been explicitly granted Delete
 permission in the container's ACL.
-
-!!! note
-    In DAOS version 1.0, permissions are set on the _pool_ level and all containers
-    in the pool inherit the permissions of the pool. Starting with DAOS version 1.2,
-    pool and container permissions are controlled individually.
 
 ### Creating Containers with Custom ACL
 

--- a/doc/user/interface.md
+++ b/doc/user/interface.md
@@ -9,7 +9,7 @@ available under `src/tests`.
 ## DAOS API Reference
 
 `libdaos` is written in C and uses Doxygen comments that are added to C header
-files. The Doxygen documentation is available 
+files. The Doxygen documentation is available
 [here](https://daos-stack.github.io/html/).
 
 ## Python Bindings
@@ -140,8 +140,7 @@ C function being cast via ctypes. This also demonstrates struct representation v
 
 int
 daos_pool_tgt_exclude_out(const uuid_t uuid, const char *grp,
-                          const d_rank_list_t *svc, struct d_tgt_list *tgts,
-                          daos_event_t *ev);
+                          struct d_tgt_list *tgts, daos_event_t *ev);
 ```
 
 All input parameters must be represented via ctypes. If a struct is required as
@@ -179,14 +178,13 @@ p_ranks = DaosPool.__pylist_to_array([2])
 # cast python variables via ctypes as necessary
 c_uuid = str_to_c_uuid(p_uuid)
 c_grp = ctypes.create_string_buffer(b"daos_group_name")
-c_svc = ctypes.POINTER(2) # ensure pointers are cast/passed as such
 c_tgt_list = ctypes.POINTER(DTgtList(p_ranks, p_tgts, 2))) # again, DTgtList must be passed as pointer
 
 # load the shared object
 my_lib = ctypes.CDLL('/full/path/to/daos_exclude.so')
 
 # now call it
-my_lib.daos_pool_tgt_exclude_out(c_uuid, c_grp, c_svc, c_tgt_list, None)
+my_lib.daos_pool_tgt_exclude_out(c_uuid, c_grp, c_tgt_list, None)
 ```
 
 #### Error Handling

--- a/doc/user/mpi-io.md
+++ b/doc/user/mpi-io.md
@@ -1,8 +1,8 @@
 # MPI-IO Support
 
-The Message Passing Interface (MPI) Standard, 
+The Message Passing Interface (MPI) Standard,
 maintained by the [MPI Forum](https://www.mpi-forum.org/docs/),
-includes a chapter on MPI-IO. 
+includes a chapter on MPI-IO.
 
 [ROMIO](https://www.mcs.anl.gov/projects/romio/) is a well-known
 implementation of MPI-IO and is included in many MPI implementations.
@@ -12,11 +12,11 @@ https://github.com/pmodels/mpich/tree/main/src/mpi/romio/adio/ad_daos
 for details.
 
 !!! note
-    Starting with DAOS 1.1.3, the `--svc` parameter (number of service replicas) 
-    is no longer needed, and the DAOS API has been changed accordingly.
+    Starting with DAOS 1.2, the `--svc` parameter (number of service replicas)
+    is no longer needed, and the DAOS API has been changed accordingly
     Patches have been contributed to MPICH that detect the DAOS API version
     to gracefully handle this change, but those patches have not yet been
-    picked up in the MPI releases below. For details check the latest commits 
+    picked up in the MPI releases below. For details check the latest commits
     [here](https://github.com/pmodels/mpich/commits/main?author=mchaarawi).
 
 
@@ -66,19 +66,19 @@ apps or libs that use MPI to the path of the installed MPICH.
 
 ### Intel MPI
 
-The [Intel MPI Library](https://software.intel.com/content/www/us/en/develop/tools/mpi-library.html) 
-includes DAOS support since the 
+The [Intel MPI Library](https://software.intel.com/content/www/us/en/develop/tools/mpi-library.html)
+includes DAOS support since the
 [2019.8 release](https://software.intel.com/content/www/us/en/develop/articles/intel-mpi-library-release-notes-linux.html).
 
-Note that Intel MPI uses `libfabric` (both 2019.8 and 2019.9 use 
-`libfabric-1.10.1-impi`).  
-Care must be taken to ensure that the version of libfabric that is used 
+Note that Intel MPI uses `libfabric` (both 2019.8 and 2019.9 use
+`libfabric-1.10.1-impi`).
+Care must be taken to ensure that the version of libfabric that is used
 is at a level that includes the patches that are critical for DAOS.
-DAOS 1.0.1 includes `libfabric-1.9.0`, and the DAOS 1.1.2 pre-release 
-includes `libfabric-1.11.1`. 
+DAOS 1.0.1 includes `libfabric-1.9.0`, and the DAOS 1.2 releases
+includes `libfabric-1.12`.
 
-To use DAOS 1.1 with Intel MPI 2019.8 or 2019.9, the `libfabric` that 
-is supplied by DAOS (and that is installed into `/usr/lib64` by default) 
+To use DAOS 1.1 with Intel MPI 2019.8 or 2019.9, the `libfabric` that
+is supplied by DAOS (and that is installed into `/usr/lib64` by default)
 needs to be used by listing it first in the library search path:
 
 ```bash
@@ -86,21 +86,21 @@ export LD_LIBRARY_PATH="/usr/lib64/:$LD_LIBRARY_PATH"
 ```
 
 The next Intel MPI release is expected to contain a version of `libfabric`
-that includes all patches to work with DAOS. 
-It will then no longer be necessary to override the `libfabric` version that is 
+that includes all patches to work with DAOS.
+It will then no longer be necessary to override the `libfabric` version that is
 shipped with Intel MPI by the version provided by DAOS.
 
 
 ### Open MPI
 
 [Open MPI](https://www.open-mpi.org/) 4.0.5 does not yet provide DAOS support.
-Since one of its MPI-IO implementations is based on ROMIO, 
+Since one of its MPI-IO implementations is based on ROMIO,
 it will likely pick up DAOS support in an upcoming release.
 
 ### MVAPICH2
 
 [MVAPICH2](https://mvapich.cse.ohio-state.edu/) 2.3.4 does not yet provide DAOS support.
-Since its MPI-IO implementation is based on ROMIO, 
+Since its MPI-IO implementation is based on ROMIO,
 it will likely pick up DAOS support in an upcoming release.
 
 
@@ -112,15 +112,15 @@ and mpich library installed above (see child pages).
 To run an example with MPI-IO:
 
 1. Create a DAOS pool on the DAOS server(s).
-   This will return a pool uuid "puuid" and service rank list "svcl".
+   This will return a pool uuid "puuid".
 2. Create a POSIX type container:
    `daos cont create --pool=puuid --type=POSIX`
    This will return a container uuid "cuuid".
 3. At the client side, the following environment variables need to be set:
-   `export DAOS_POOL=puuid; export DAOS_SVCL=svcl; export DAOS_CONT=cuuid`.
+   `export DAOS_POOL=puuid; export DAOS_CONT=cuuid`.
    Alternatively, the unified namespace mode can be used instead.
-3. Run the client application or test. 
-   MPI-IO applications should work seamlessly by just prepending `daos:` 
+3. Run the client application or test.
+   MPI-IO applications should work seamlessly by just prepending `daos:`
    to the filename/path to use the DAOS ADIO driver.
 
 
@@ -128,7 +128,4 @@ To run an example with MPI-IO:
 
 Limitations of the current implementation include:
 
--   Reading Holes does not return 0, but leaves the buffer untouched.
-
 -   No support for MPI file atomicity, preallocate, or shared file pointers.
-

--- a/doc/user/spark.md
+++ b/doc/user/spark.md
@@ -21,9 +21,6 @@ We assume that the DAOS servers and agents have already been deployed in the
 environment. Otherwise, they can be deployed by following the
 [DAOS Installation Guide](https://daos-stack.github.io/admin/installation/).
 
-!!! note DAOS support for Spark and Hadoop is not available in DAOS 1.0. 
-         It is targeted for the DAOS 1.2 release.
-
 ## Download DAOS Hadoop Filesystem
 
 There are two artifacts to download, daos-java and hadoop-daos, from maven.
@@ -109,7 +106,7 @@ loadable by Hadoop DAOS FileSystem.
 
 ### Validate Hadoop Access
 
-If everything goes well, you should see “/user” directory being listed after
+If everything goes well, you should see `/user` directory being listed after
 issuing below command.
 
 ```bash


### PR DESCRIPTION
- Add instructions to install RPMs from packages.daos.io
- Update references to point at release/1.2 branch.
- Remove stale 1.0 and svcl reference.
- Add fio instructions.
- Various cleanups.

doc-only: true

Signed-off-by: Johann Lombardi <johann.lombardi@intel.com>