### PR TITLE
DAOS-623 ci: Update old test_tag logic

### DIFF
--- a/ci/functional/test_main.sh
+++ b/ci/functional/test_main.sh
@@ -2,12 +2,12 @@
 
 set -eux
 
-test_tag=$(git show -s --format=%B | \
-           sed -ne "/^Test-tag$PRAGMA_SUFFIX:/s/^.*: *//p")
-if [ -z "$test_tag" ]; then
-    # shellcheck disable=SC2153
-    test_tag=$TEST_TAG
+if [ -z "$TEST_TAG" ]; then
+    echo "TEST_TAG must be set"
+    exit 1
 fi
+
+test_tag="$TEST_TAG"
 
 tnodes=$(echo "$NODELIST" | cut -d ',' -f 1-"$NODE_COUNT")
 first_node=${NODELIST%%,*}


### PR DESCRIPTION
The pipeline library has been updated to properly set TEST_TAG for any
of the Test-tag-* pragmas, so it doesn't need to be done in
test_main.sh any more.

Require that the caller set TEST_TAG and error out if they don't.  There
is no reasonable default for this value.
