### PR TITLE
DAOS-7283 EC: check size_fetched for retry IO

### DIFF
--- a/src/object/cli_ec.c
+++ b/src/object/cli_ec.c
@@ -1597,9 +1597,8 @@ obj_ec_req_reasb(daos_iod_t *iods, d_sg_list_t *sgls, daos_obj_id_t oid,
 	 * request to server to query it, and then retry the IO request to do
 	 * the real fetch. If only with single-value, need not size_fetch ahead.
 	 */
-	if (reasb_req->orr_size_fetch) {
+	if (reasb_req->orr_size_fetched) {
 		reasb_req->orr_size_fetch = 0;
-		reasb_req->orr_size_fetched = 1;
 		iods = reasb_req->orr_uiods;
 	} else if (!update) {
 		for (i = 0; i < iod_nr; i++) {

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -798,7 +798,7 @@ obj_rw_req_reassemb(struct dc_object *obj, daos_obj_rw_t *args,
 	if (epoch != NULL && !obj_auxi->req_reasbed)
 		reasb_req->orr_epoch = *epoch;
 	reasb_req->orr_size_set = 0;
-	if (obj_auxi->req_reasbed && !reasb_req->orr_size_fetch) {
+	if (obj_auxi->req_reasbed && !reasb_req->orr_size_fetched) {
 		D_DEBUG(DB_TRACE, DF_OID" req reassembled (retry case).\n",
 			DP_OID(oid));
 		return 0;
@@ -3549,6 +3549,7 @@ obj_size_fetch_cb(const struct dc_object *obj, struct obj_auxi_args *obj_auxi)
 		}
 	}
 
+	obj_auxi->reasb_req.orr_size_fetched = 1;
 	usgls = obj_auxi->reasb_req.orr_usgls;
 	if (usgls == NULL)
 		return;


### PR DESCRIPTION
Let's set size_fetched in obj_size_fetch_cb(),
then it can be used to check if the RPC needs
to be reassemblied again, otherwise the failed
size_fetch RPC might be reassemblied again.

Signed-off-by: Di Wang <di.wang@intel.com>