### PR TITLE
DAOS-7379 daos: Fix double free issue in daos utility

### DIFF
--- a/src/utils/daos.c
+++ b/src/utils/daos.c
@@ -554,6 +554,7 @@ args_free(struct cmd_args_s *ap)
 		/* restore number of entries in array for freeing */
 		ap->props->dpp_nr = DAOS_PROP_ENTRIES_MAX_NR;
 		daos_prop_free(ap->props);
+		ap->props = NULL;
 	}
 	D_FREE(ap->outfile);
 	D_FREE(ap->aclfile);


### PR DESCRIPTION
Reset ap->props to NULL after daos_prop_free to avoid double free

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>