### PR TITLE
DAOS-7379 tools: Fix memory issues in daos tool

### DIFF
--- a/src/utils/daos.c
+++ b/src/utils/daos.c
@@ -869,8 +869,9 @@ common_op_parse_hdlr(int argc, char *argv[], struct cmd_args_s *ap)
 	return 0;
 
 out_free:
-	/* restore number of entries in array for freeing */
-	ap->props->dpp_nr = DAOS_PROP_ENTRIES_MAX_NR;
+	if (ap->props != NULL)
+		/* restore number of entries in array for freeing */
+		ap->props->dpp_nr = DAOS_PROP_ENTRIES_MAX_NR;
 	args_free(ap);
 	D_FREE(cmdname);
 	return rc;

--- a/src/utils/daos.c
+++ b/src/utils/daos.c
@@ -550,11 +550,7 @@ args_free(struct cmd_args_s *ap)
 	D_FREE(ap->dst);
 	D_FREE(ap->snapname_str);
 	D_FREE(ap->epcrange_str);
-	if (ap->props) {
-		/* restore number of entries in array for freeing */
-		ap->props->dpp_nr = DAOS_PROP_ENTRIES_MAX_NR;
-		daos_prop_free(ap->props);
-	}
+	daos_prop_free(ap->props);
 	D_FREE(ap->outfile);
 	D_FREE(ap->aclfile);
 	D_FREE(ap->entry);
@@ -870,6 +866,8 @@ common_op_parse_hdlr(int argc, char *argv[], struct cmd_args_s *ap)
 	return 0;
 
 out_free:
+	/* restore number of entries in array for freeing */
+	ap->props->dpp_nr = DAOS_PROP_ENTRIES_MAX_NR;
 	args_free(ap);
 	D_FREE(cmdname);
 	return rc;

--- a/src/utils/daos.c
+++ b/src/utils/daos.c
@@ -550,7 +550,10 @@ args_free(struct cmd_args_s *ap)
 	D_FREE(ap->dst);
 	D_FREE(ap->snapname_str);
 	D_FREE(ap->epcrange_str);
+
 	daos_prop_free(ap->props);
+	ap->props = NULL;
+
 	D_FREE(ap->outfile);
 	D_FREE(ap->aclfile);
 	D_FREE(ap->entry);

--- a/src/utils/daos_hdlr.c
+++ b/src/utils/daos_hdlr.c
@@ -3844,9 +3844,9 @@ parse_acl_file(const char *path, struct daos_acl **acl)
 	D_GOTO(out, rc = 0);
 
 parse_err:
-	D_FREE(line);
 	daos_acl_free(tmp_acl);
 out:
+	D_FREE(line);
 	fclose(instream);
 	return rc;
 }


### PR DESCRIPTION
- Fix case where daos_prop_free() could go out of range of
  allocated memory. The daos_prop_t is typically allocated
  with the max number of entries during argument parsing,
  but the prop can also be allocated later, while parsing
  the ACL file and/or setting the ownership for a container.
  In that case it is not necessary to allocate the max,
  because we know the number of entries needed. args_free()
  needs to be general enough for both cases.
- Fix case where the pointer result of the final getline()
  call is not freed during ACL file parsing.
- Reset ap->props to NULL after daos_prop_free to avoid
  double free

Signed-off-by: Kris Jacque <kristin.jacque@intel.com>
Co-authored-by: Jeff Olivier <jeffrey.v.olivier@intel.com>