### PR TITLE
DAOS-7139 test: datamover container metadata

### DIFF
--- a/src/tests/ftest/datamover/dm_dst_create.py
+++ b/src/tests/ftest/datamover/dm_dst_create.py
@@ -173,10 +173,6 @@ class DmDstCreate(DataMoverTestBase):
                 Required when check_attr_prop is True.
 
         """
-        # Disable attribute and property checking until the relevant
-        # mpifileutils commit is in CI
-        check_attr_prop = False
-
         # It's important to check the properties first, since when ior
         # mounts DFS the alloc'ed OID might be incremented.
         if check_attr_prop:


### PR DESCRIPTION
Quick-Functional: true
Skip-checkpatch: false

Test-tag: dm_dst_create

- Verify container properties and user attributes of containers
  created with dcp.

Signed-off-by: Dalton Bohning <daltonx.bohning@intel.com>