### PR TITLE
DAOS-5685 il: Force use of gcc for the interception library. (#5193)

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -387,7 +387,14 @@ def scons(): # pylint: disable=too-many-locals
               default=False,
               help='Download and build dependencies only, do not build daos')
 
-    run_checks(env)
+    if env['CC'] == 'clang':
+        il_env = env.Clone()
+        il_env['CC'] = 'gcc'
+        run_checks(env)
+        run_checks(il_env)
+    else:
+        run_checks(env)
+        il_env = env.Clone()
 
     res = GetOption('deps_only')
     if res:
@@ -403,7 +410,7 @@ def scons(): # pylint: disable=too-many-locals
     platform_arm = is_platform_arm()
     daos_version = get_version()
     # Export() is handled specially by pylint so do not merge these two lines.
-    Export('daos_version', 'API_VERSION', 'env', 'prereqs')
+    Export('daos_version', 'API_VERSION', 'env', 'il_env', 'prereqs')
     Export('platform_arm', 'conf_dir')
 
     if env['PLATFORM'] == 'darwin':

--- a/src/SConscript
+++ b/src/SConscript
@@ -29,7 +29,7 @@ def generate_daos_version_header(env):
 def scons():
     """Execute build"""
 
-    Import('env')
+    Import('env', 'il_env')
 
     # For Common library (tse.h)
     env.AppendUnique(CPPPATH=[Dir('include/daos').srcnode()])
@@ -47,6 +47,8 @@ def scons():
     # Generic DAOS includes
     env.AppendUnique(CPPPATH=[Dir('include').srcnode()])
     env.AppendUnique(CPPPATH=[Dir('include')])
+    il_env.AppendUnique(CPPPATH=[Dir('include').srcnode()])
+    il_env.AppendUnique(CPPPATH=[Dir('include')])
     generate_daos_version_header(env)
     for header in HEADERS:
         env.Install(os.path.join('$PREFIX', 'include'), 'include/%s' % header)

--- a/src/client/api/SConscript
+++ b/src/client/api/SConscript
@@ -3,9 +3,10 @@ import daos_build
 
 def scons():
     """Execute build"""
-    Import('env', 'API_VERSION', 'prereqs')
+    Import('env', 'il_env', 'API_VERSION', 'prereqs')
 
     env.AppendUnique(LIBPATH=[Dir('.')])
+    il_env.AppendUnique(LIBPATH=[Dir('.')])
     denv = env.Clone()
     prereqs.require(denv, 'protobufc')
     dc_tgts = denv.SharedObject(Glob('*.c'))

--- a/src/client/dfuse/SConscript
+++ b/src/client/dfuse/SConscript
@@ -164,19 +164,24 @@ def configure_fuse(cenv):
 def scons():
     """Scons function"""
 
-    Import('env prereqs')
+    Import('env', 'il_env', 'prereqs')
 
     # Set options which are used throughout the src.
     dfuse_env = env.Clone(LIBS=[])
     dfuse_env.AppendUnique(CPPPATH=['.'])
-    dfuse_env.AppendUnique(CFLAGS=['-pthread', '-fvisibility=hidden'])
+    dfuse_env.AppendUnique(CFLAGS=['-pthread'])
     dfuse_env.AppendUnique(CPPDEFINES=['_GNU_SOURCE'])
-
     dfuse_env.AppendUnique(LIBS=['pthread', 'daos', 'daos_common', 'uuid'])
 
-    libs = build_client_libs_shared(dfuse_env)
+    gcc_env = il_env.Clone(LIBS=[])
+    gcc_env.AppendUnique(CPPPATH=['.'])
+    gcc_env.AppendUnique(CFLAGS=['-pthread', '-fvisibility=hidden'])
+    gcc_env.AppendUnique(CPPDEFINES=['_GNU_SOURCE'])
+    gcc_env.AppendUnique(LIBS=['pthread', 'daos', 'daos_common'])
 
-    static_env = dfuse_env.Clone()
+    libs = build_client_libs_shared(gcc_env)
+
+    static_env = gcc_env.Clone()
 
     # Set this after cloning environment used for interception library.
     # Otherwise, can't define open and open64 entry points

--- a/src/client/dfuse/test/SConscript
+++ b/src/client/dfuse/test/SConscript
@@ -11,7 +11,7 @@ def build_static_tests(env):
     #linker magic.  Disabled for now.
     if IOIL_BUILD_STATIC:
         to_build = env.get('libioil')
-        if to_build == 'none' or to_build == 'shared':
+        if to_build in ('none', 'shared'):
             return []
 
         ilenv = env.Clone()
@@ -33,7 +33,7 @@ def build_static_tests(env):
 def scons():
     """Scons function"""
 
-    Import('dfuse_env prereqs')
+    Import('dfuse_env', 'prereqs')
 
     if not prereqs.check_component('cunit'):
         print("\n************************************************")

--- a/src/common/SConscript
+++ b/src/common/SConscript
@@ -56,9 +56,10 @@ def build_dts_library(env):
 
 def scons():
     """Execute build"""
-    Import('env', 'prereqs')
+    Import('env', 'il_env', 'prereqs')
 
     env.AppendUnique(LIBPATH=[Dir('.')])
+    il_env.AppendUnique(LIBPATH=[Dir('.')])
 
     # Hack alert, the argobots headers are required but the shared
     # library isn't so add the dependency so the include path


### PR DESCRIPTION
clang is missing some symbols, so force use of gcc until we
can resolve this.

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>