### PR TITLE
DAOS-6381 csum: Fixes for ec, csum, and rebuild

### DIFF
--- a/src/common/checksum.c
+++ b/src/common/checksum.c
@@ -17,7 +17,7 @@
 #include <daos/cont_props.h>
 
 #define C_TRACE(...) D_DEBUG(DB_CSUM, __VA_ARGS__)
-#define C_TRACE_ENABLED() D_LOG_ENABLED(DB_TRACE)
+#define C_TRACE_ENABLED() D_LOG_ENABLED(DB_CSUM)
 
 /** File function signatures */
 static int
@@ -423,7 +423,6 @@ daos_csummer_alloc_iods_csums(struct daos_csummer *obj, daos_iod_t *iods,
 
 			csum_info = &iod_csum->ic_data[j];
 			if (is_array(iod)) {
-
 				daos_recx_t *recx;
 
 				recx = &iod->iod_recxs[j];
@@ -526,7 +525,7 @@ get_maps_idx_nr_for_range(struct daos_csum_range *req_range, daos_iom_t *map)
 	return result;
 }
 
-static int
+static uint64_t
 recx_hi(daos_recx_t *r)
 {
 	return r->rx_idx + r->rx_nr - 1;
@@ -556,6 +555,9 @@ calc_csum_recx_with_map(struct daos_csummer *obj, size_t csum_nr,
 	uint64_t		 prev_idx = recx->rx_idx;
 	struct daos_csum_range	 maps_in_chunk;
 	daos_size_t		 consumed_bytes = 0;
+
+	C_TRACE("recx: "DF_RECX", map: "DF_IOM"\n",
+		DP_RECX(*recx), DP_IOM(map));
 
 	for (i = 0; i < csum_nr; i++) {
 		buf = ci_idx2csum(csum_info, i);
@@ -640,7 +642,7 @@ calc_csum_recx(struct daos_csummer *obj, d_sg_list_t *sgl, size_t rec_len,
 		if (rc != 0)
 			return rc;
 
-		C_TRACE("Calculating %zu checksum(s) for Array Value "
+		C_TRACE("Calculated %zu checksum(s) for Array Value "
 				DF_RECX", data_len: %lu -> "DF_CI"\n",
 			csum_nr, DP_RECX(recxs[i]), sgl->sg_iovs[0].iov_len,
 			DP_CI(csums[i]));
@@ -702,6 +704,10 @@ calc_csum_sv(struct daos_csummer *obj, d_sg_list_t *sgl, size_t rec_len,
 	}
 
 	bytes_for_csum = data_len;
+	D_DEBUG(DB_CSUM, "csums->cs_nr: %d, data_tgt_nr: %d, "
+			 "data_len: %lu, last_size: %lu\n",
+		csums->cs_nr, data_tgt_nr, data_len, last_size);
+
 	for (idx = 0; idx < csums->cs_nr; idx++) {
 		if (singv_lo != NULL && singv_lo->cs_even_dist == 1 &&
 		    singv_idx == -1) {
@@ -723,7 +729,7 @@ calc_csum_sv(struct daos_csummer *obj, d_sg_list_t *sgl, size_t rec_len,
 		daos_csummer_finish(obj);
 	}
 
-	C_TRACE("Calculating checksum for Single Value (len=%lu) -> "
+	C_TRACE("Calculated checksum for Single Value (len=%lu) -> "
 		DF_CI"\n", rec_len, DP_CI(csums[0]));
 
 	return 0;
@@ -823,6 +829,11 @@ daos_csummer_calc_iods(struct daos_csummer *obj, d_sg_list_t *sgls,
 			}
 		}
 
+		C_TRACE("iod: "DF_C_IOD ", akey_only: %s, iod is supported: %s,"
+			       " akey csum: "DF_CI"\n",
+			DP_C_IOD(iod), DP_BOOL(akey_only),
+			DP_BOOL(csum_iod_is_supported(iod)),
+			DP_CI(csums->ic_akey));
 		if (akey_only || !csum_iod_is_supported(iod))
 			continue;
 
@@ -966,8 +977,16 @@ daos_csummer_verify_key(struct daos_csummer *obj, daos_key_t *key,
 		return 0;
 
 	if (!ci_is_valid(csum)) {
-		D_ERROR("checksums is enabled, but dcs_csum_info is invalid, "
-			"key: "DF_KEY", csum = %p\n", DP_KEY(key), csum);
+		if (csum == NULL) {
+			D_ERROR("checksums is enabled, but "
+				"dcs_csum_info is NULL, "
+				"key: "DF_KEY"\n", DP_KEY(key));
+		} else {
+			D_ERROR("checksums is enabled, but "
+				"dcs_csum_info is invalid, "
+				"key: "DF_KEY", csum: "DF_CI"\n", DP_KEY(key),
+				DP_CI(*csum));
+		}
 		return -DER_CSUM;
 	}
 
@@ -1158,7 +1177,7 @@ ci_buf2uint64(const uint8_t *buf, uint16_t len)
 uint64_t
 ci2csum(struct dcs_csum_info ci)
 {
-	if (ci.cs_csum == 0)
+	if (ci.cs_csum == NULL)
 		return 0;
 	return ci_buf2uint64(ci.cs_csum, ci.cs_len);
 }

--- a/src/include/daos/checksum.h
+++ b/src/include/daos/checksum.h
@@ -15,6 +15,33 @@
 
 #define	CSUM_NO_CHUNK -1
 
+/*
+ * Tag used in debug logs to easily find important checksum info, making it
+ * easier to trace checksums through the log files
+ */
+#define CSTAG "[CSUM]"
+
+#define DF_C_IOD CSTAG"IOD {akey: "DF_KEY", type: %s, nr: %d, size: %lu} CSUM"
+#define DP_C_IOD(i) DP_KEY(&(i)->iod_name), \
+	(i)->iod_type == DAOS_IOD_SINGLE ? "SINGLE" : \
+	(i)->iod_type == DAOS_IOD_ARRAY ? "ARRAY" : "UNKNOWN", \
+	(i)->iod_nr, (i)->iod_size
+
+#define DF_C_UOID_DKEY CSTAG"OBJ ("DF_UOID", "DF_KEY")"
+#define DP_C_UOID_DKEY(oid, dkey) DP_UOID(oid), DP_KEY(dkey)
+
+#define DF_C_OID_DKEY CSTAG"OBJ ("DF_OID", "DF_KEY")"
+#define DP_C_OID_DKEY(oid, dkey) DP_OID(oid), DP_KEY(dkey)
+
+#define DF_LAYOUT "{bytes: %lu, nr: %d, even_dist: %s, cell_align: %s}"
+#define DP_LAYOUT(l) (l).cs_bytes, (l).cs_nr, DP_BOOL((l).cs_even_dist), \
+			DP_BOOL((l).cs_cell_align)
+#define	DF_CI_BUF "%"PRIu64
+#define	DP_CI_BUF(buf, len) ci_buf2uint64(buf, len)
+#define	DF_CI "{nr: %d, len: %d, first_csum: %lu, csum_buf_len: %d}"
+#define	DP_CI(ci) (ci).cs_nr, (ci).cs_len, ci2csum(ci), (ci).cs_buf_len
+#define DF_RANGE "{lo: %lu, hi: %lu, nr: %lu}"
+#define DP_RANGE(r) (r).dcr_lo, (r).dcr_hi, (r).dcr_nr
 /**
  * -----------------------------------------------------------
  * DAOS Checksummer
@@ -462,10 +489,6 @@ ci_buf2uint64(const uint8_t *buf, uint16_t len);
 uint64_t
 ci2csum(struct dcs_csum_info ci);
 
-#define	DF_CI_BUF "%"PRIu64
-#define	DP_CI_BUF(buf, len) ci_buf2uint64(buf, len)
-#define	DF_CI "{nr: %d, len: %d, first_csum: %lu, csum_buf_len: %d}"
-#define	DP_CI(ci) (ci).cs_nr, (ci).cs_len, ci2csum(ci), (ci).cs_buf_len
 
 /**
  * return the number of bytes needed to serialize a dcs_csum_info into a

--- a/src/include/daos/common.h
+++ b/src/include/daos/common.h
@@ -44,7 +44,10 @@
 
 #define DF_UOID		DF_OID".%u"
 #define DP_UOID(uo)	DP_OID((uo).id_pub), (uo).id_shard
-
+#define DF_BOOL "%s"
+#define DP_BOOL(b) ((b) ? "true" : "false")
+#define DF_IOV "<%p, %lu/%lu>"
+#define DP_IOV(i) (i)->iov_buf, (i)->iov_len, (i)->iov_buf_len
 #define MAX_TREE_ORDER_INC	7
 
 struct daos_node_overhead {
@@ -159,6 +162,9 @@ char *daos_key2str(daos_key_t *key);
 
 #define DF_RECX			"["DF_U64"-"DF_U64"]"
 #define DP_RECX(r)		(r).rx_idx, ((r).rx_idx + (r).rx_nr - 1)
+#define DF_IOM			"{nr: %d, lo: "DF_RECX", hi: "DF_RECX"}"
+#define DP_IOM(m)		(m)->iom_nr, DP_RECX((m)->iom_recx_lo), \
+				DP_RECX((m)->iom_recx_hi)
 
 static inline uint64_t
 daos_u64_hash(uint64_t val, unsigned int bits)

--- a/src/include/daos/common.h
+++ b/src/include/daos/common.h
@@ -46,7 +46,7 @@
 #define DP_UOID(uo)	DP_OID((uo).id_pub), (uo).id_shard
 #define DF_BOOL "%s"
 #define DP_BOOL(b) ((b) ? "true" : "false")
-#define DF_IOV "<%p, %lu/%lu>"
+#define DF_IOV "<%p, %zu/%zu>"
 #define DP_IOV(i) (i)->iov_buf, (i)->iov_len, (i)->iov_buf_len
 #define MAX_TREE_ORDER_INC	7
 

--- a/src/object/cli_ec.c
+++ b/src/object/cli_ec.c
@@ -280,7 +280,8 @@ obj_ec_recov_tgt_recx_nrs(struct obj_reasb_req *reasb_req,
 		if (tgt_nr == obj_ec_data_tgt_nr(oca))
 			break;
 	}
-	D_ASSERT(tgt_nr == obj_ec_data_tgt_nr(oca));
+	D_ASSERTF(tgt_nr == obj_ec_data_tgt_nr(oca), "%d != %d",
+		  tgt_nr, obj_ec_data_tgt_nr(oca));
 }
 
 /** scan the iod to find the full_stripe recxs and some help info */

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -1575,7 +1575,7 @@ recov_task_abort(tse_task_t *task, void *arg)
 
 static void
 obj_ec_recov_cb(tse_task_t *task, struct dc_object *obj,
-		struct obj_auxi_args *obj_auxi)
+		struct obj_auxi_args *obj_auxi, d_iov_t *csum_iov)
 {
 	struct obj_reasb_req		*reasb_req = &obj_auxi->reasb_req;
 	struct obj_ec_fail_info		*fail_info = reasb_req->orr_fail;
@@ -1616,12 +1616,13 @@ obj_ec_recov_cb(tse_task_t *task, struct dc_object *obj,
 			goto out;
 		}
 		recov_task->ert_th = th;
-
+		D_DEBUG(DB_REBUILD, DF_C_OID_DKEY" Fetching to recover\n",
+			DP_C_OID_DKEY(obj->cob_md.omd_id, args->dkey));
 		rc = dc_obj_fetch_task_create(args->oh, th, 0, args->dkey, 1,
 					      DIOF_EC_RECOV,
 					      &recov_task->ert_iod,
 					      &recov_task->ert_sgl, NULL,
-					      fail_info, NULL,
+					      fail_info, csum_iov,
 					      NULL, sched, &sub_task);
 		if (rc) {
 			D_ERROR("task %p "DF_OID" dc_obj_fetch_task_create "
@@ -3760,8 +3761,11 @@ obj_comp_cb(tse_task_t *task, void *data)
 						   obj_auxi->iod_nr);
 				memset(obj_auxi, 0, sizeof(*obj_auxi));
 			} else {
+				daos_obj_fetch_t *args = dc_task_get_args(task);
+
 				task->dt_result = 0;
-				obj_ec_recov_cb(task, obj, obj_auxi);
+				obj_ec_recov_cb(task, obj, obj_auxi,
+						args->csum_iov);
 			}
 		} else {
 			if (obj_auxi->is_ec_obj &&
@@ -3942,11 +3946,12 @@ obj_csum_update(struct dc_object *obj, daos_obj_update_t *args,
 	struct dcs_iod_csums	*iod_csums = NULL;
 	int			 rc;
 
-	D_DEBUG(DB_CSUM, "obj: %p, args: %p, obj_auxi: %p, csummer: %p, "
+	D_DEBUG(DB_CSUM, DF_C_OID_DKEY " UPDATE - csummer: %p, "
 			 "csum_type: %d, csum_enabled: %s\n",
-		obj, args, obj_auxi, csummer,
-		cont_props.dcp_csum_type,
-		cont_props.dcp_csum_enabled ? "Yes" : "No");
+		DP_C_OID_DKEY(obj->cob_md.omd_id, args->dkey),
+		csummer, cont_props.dcp_csum_type,
+		DP_BOOL(cont_props.dcp_csum_enabled));
+
 	if (!daos_csummer_initialized(csummer)) /** Not configured */
 		return 0;
 

--- a/src/object/cli_shard.c
+++ b/src/object/cli_shard.c
@@ -195,23 +195,37 @@ static void
 rw_args_store_csum(const struct rw_cb_args *rw_args,
 		   const struct dcs_iod_csums *iod_csum)
 {
-	int	c, rc;
-	int	csum_iov_too_small = false;
-	d_iov_t *csum_iov;
+	d_iov_t			*csum_iov;
+	struct obj_rw_in	*orw;
+	int			 c, rc;
+	int			 csum_iov_too_small = false;
 
 	if (!rw_args_has_csum_iov(rw_args) || iod_csum == NULL)
 		return;
 
+	orw = crt_req_get(rw_args->rpc);
 	csum_iov = rw_args2csum_iov(rw_args);
+	D_DEBUG(DB_CSUM, DF_C_UOID_DKEY "Storing %d csum(s) in iov: "DF_IOV"\n",
+		DP_C_UOID_DKEY(orw->orw_oid, &orw->orw_dkey),
+		iod_csum->ic_nr,
+		DP_IOV(csum_iov));
 	for (c = 0; c < iod_csum->ic_nr; c++) {
 		if (!csum_iov_too_small) {
+			D_DEBUG(DB_CSUM, DF_C_UOID_DKEY
+					"Serializing "DF_CI
+					" into iov: "DF_IOV"\n",
+				DP_C_UOID_DKEY(orw->orw_oid, &orw->orw_dkey),
+				DP_CI(iod_csum->ic_data[c]),
+				DP_IOV(csum_iov));
 			rc = ci_serialize(&iod_csum->ic_data[c],
 					  csum_iov);
 			csum_iov_too_small = rc == -DER_REC2BIG;
 		}
 
-		if (csum_iov_too_small)
+		if (csum_iov_too_small) {
+			D_DEBUG(DB_CSUM, "IOV is too small\n");
 			csum_iov->iov_len += ci_size(iod_csum->ic_data[c]);
+		}
 	}
 }
 
@@ -272,6 +286,11 @@ dc_rw_cb_csum_verify(const struct rw_cb_args *rw_args)
 	shard_idx = rw_args->shard_args->auxi.shard -
 		    rw_args->shard_args->auxi.start_shard;
 	singv_los = dc_rw_cb_singv_lo_get(iods, sgls, orw->orw_nr, reasb_req);
+
+	D_DEBUG(DB_CSUM, DF_C_UOID_DKEY"VERIFY %d iods\n",
+		DP_C_UOID_DKEY(orw->orw_oid, &orw->orw_dkey),
+		orw->orw_nr);
+
 	for (i = 0; i < orw->orw_nr; i++) {
 		daos_iod_t		*iod = &iods[i];
 		daos_iod_t		 shard_iod = *iod;
@@ -309,14 +328,18 @@ dc_rw_cb_csum_verify(const struct rw_cb_args *rw_args)
 
 			if (iod->iod_type == DAOS_IOD_SINGLE) {
 				D_ERROR("Data Verification failed (object: "
-					DF_OID" shard %d): "DF_RC"\n",
-					DP_OID(orw->orw_oid.id_pub), shard_idx,
+					DF_C_UOID_DKEY" shard %d): "DF_RC"\n",
+					DP_C_UOID_DKEY(orw->orw_oid,
+						     &orw->orw_dkey),
+					shard_idx,
 					DP_RC(rc));
 			} else  if (iod->iod_type == DAOS_IOD_ARRAY) {
 				D_ERROR("Data Verification failed (object: "
-					DF_OID" shard %d, extent: "DF_RECX"): "
+					DF_C_UOID_DKEY" shard %d, extent: "
+						DF_RECX"): "
 					DF_RC"\n",
-					DP_OID(orw->orw_oid.id_pub),
+					DP_C_UOID_DKEY(orw->orw_oid,
+						     &orw->orw_dkey),
 					shard_idx, DP_RECX(iod->iod_recxs[i]),
 					DP_RC(rc));
 			}

--- a/src/object/obj_rpc.c
+++ b/src/object/obj_rpc.c
@@ -180,6 +180,16 @@ crt_proc_daos_iod_and_csum(crt_proc_t proc, crt_proc_op_t proc_op,
 	if (unlikely(rc))
 		D_GOTO(out, rc);
 
+	if (iod_csum) {
+		rc = crt_proc_struct_dcs_iod_csums_adv(proc, proc_op, iod_csum,
+						       singv, start, nr);
+		if (unlikely(rc)) {
+			if (DECODING(proc_op))
+				D_GOTO(out_free, rc);
+			D_GOTO(out, rc);
+		}
+	}
+
 #if 0
 	if (iod->iod_nr == 0 && iod->iod_type != DAOS_IOD_ARRAY) {
 		D_ERROR("invalid I/O descriptor, iod_nr = 0\n");
@@ -224,16 +234,6 @@ crt_proc_daos_iod_and_csum(crt_proc_t proc, crt_proc_op_t proc_op,
 					D_GOTO(out_free, rc);
 				D_GOTO(out, rc);
 			}
-		}
-	}
-
-	if (iod_csum) {
-		rc = crt_proc_struct_dcs_iod_csums_adv(proc, proc_op, iod_csum,
-						       singv, start, nr);
-		if (unlikely(rc)) {
-			if (DECODING(proc_op))
-				D_GOTO(out_free, rc);
-			D_GOTO(out, rc);
 		}
 	}
 

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -716,7 +716,8 @@ get_iod_csum(struct dcs_iod_csums *iod_csums, int i)
 static int
 csum_add2iods(daos_handle_t ioh, daos_iod_t *iods, uint32_t iods_nr,
 	      struct daos_csummer *csummer,
-	      struct dcs_iod_csums *iod_csums)
+	      struct dcs_iod_csums *iod_csums, daos_unit_oid_t oid,
+	      daos_key_t *dkey)
 {
 	int	 rc = 0;
 	uint32_t biov_csums_idx = 0;
@@ -730,7 +731,10 @@ csum_add2iods(daos_handle_t ioh, daos_iod_t *iods, uint32_t iods_nr,
 	for (i = 0; i < iods_nr; i++) {
 		if (biov_csums_idx >= csum_info_nr)
 			break; /** no more csums to add */
-
+		D_DEBUG(DB_CSUM, DF_C_UOID_DKEY"Adding fetched to IOD: "
+				 DF_C_IOD", csum: "DF_CI"\n",
+			DP_C_UOID_DKEY(oid, dkey),
+			DP_C_IOD(&iods[i]), DP_CI(csum_infos[biov_csums_idx]));
 		rc = ds_csum_add2iod(
 			&iods[i], csummer,
 			bio_iod_sgl(biod, i),
@@ -749,7 +753,8 @@ csum_add2iods(daos_handle_t ioh, daos_iod_t *iods, uint32_t iods_nr,
 
 static int
 csum_verify_keys(struct daos_csummer *csummer, daos_key_t *dkey,
-		 struct dcs_csum_info *dci, struct obj_iod_array *oia)
+		 struct dcs_csum_info *dkey_csum,
+		 struct obj_iod_array *oia, daos_unit_oid_t *uoid)
 {
 	uint32_t	i;
 	int		rc;
@@ -763,13 +768,13 @@ csum_verify_keys(struct daos_csummer *csummer, daos_key_t *dkey,
 		 * for object verification tests. Don't reject the
 		 * update in this case
 		 */
-		rc = daos_csummer_verify_key(csummer, dkey, dci);
+		rc = daos_csummer_verify_key(csummer, dkey, dkey_csum);
 		if (rc != 0) {
-			D_ERROR("daos_csummer_verify_key error for dkey: %d",
-				rc);
+			D_ERROR("daos_csummer_verify_key error for dkey: "
+					DF_RC"\n",
+				DP_RC(rc));
 			return rc;
 		}
-
 	}
 
 	for (i = 0; i < oia->oia_iod_nr; i++) {
@@ -778,12 +783,21 @@ csum_verify_keys(struct daos_csummer *csummer, daos_key_t *dkey,
 
 		if (!csum_iod_is_supported(iod))
 			continue;
+
+		D_DEBUG(DB_CSUM, DF_C_UOID_DKEY"iod[%d]: "DF_C_IOD","
+				 " csum_nr: %d, first data csum: "DF_CI"\n",
+			DP_C_UOID_DKEY(*uoid, dkey), i,
+			DP_C_IOD(iod), csum->ic_nr, DP_CI(*csum->ic_data));
 		rc = daos_csummer_verify_key(csummer,
 					     &iod->iod_name,
 					     &csum->ic_akey);
 		if (rc != 0) {
-			D_ERROR("daos_csummer_verify_key error for akey: %d",
-				rc);
+			D_ERROR(DF_C_UOID_DKEY"iod[%d]: "DF_C_IOD" verify_key "
+				"failed for akey: "DF_KEY", csum: "DF_CI", "
+				"error: "DF_RC"\n",
+				DP_C_UOID_DKEY(*uoid, dkey), i,
+				DP_C_IOD(iod), DP_KEY(&iod->iod_name),
+				DP_CI(csum->ic_akey), DP_RC(rc));
 			return rc;
 		}
 	}
@@ -984,6 +998,8 @@ obj_fetch_create_maps(crt_rpc_t *rpc, struct bio_desc *biod, daos_iod_t *iods)
 		for (r = 0; r < iod->iod_nr; r++) {
 			daos_recx_t recx = iod->iod_recxs[r];
 
+			D_DEBUG(DB_CSUM, "processing recx[%d]: "DF_RECX"\n",
+				r, DP_RECX(recx));
 			rec_idx = recx.rx_idx;
 
 			while (rec_idx <= recx.rx_idx + recx.rx_nr - 1) {
@@ -1262,9 +1278,13 @@ obj_local_rw_internal(crt_rpc_t *rpc, struct obj_io_context *ioc,
 	}
 
 	rc = csum_verify_keys(ioc->ioc_coc->sc_csummer, &orw->orw_dkey,
-			      orw->orw_dkey_csum, &orw->orw_iod_array);
+			      orw->orw_dkey_csum, &orw->orw_iod_array,
+			      &orw->orw_oid);
+
 	if (rc != 0) {
-		D_ERROR("csum_verify_keys error: %d", rc);
+		D_ERROR(DF_C_UOID_DKEY"verify_keys error: "DF_RC"\n",
+			DP_C_UOID_DKEY(orw->orw_oid, &orw->orw_dkey),
+			DP_RC(rc));
 		if (rc == -DER_CSUM)
 			obj_log_csum_err();
 		return rc;
@@ -1442,7 +1462,8 @@ obj_local_rw_internal(crt_rpc_t *rpc, struct obj_io_context *ioc,
 					   orw->orw_iod_array.oia_iods,
 					   orw->orw_iod_array.oia_iod_nr,
 					   ioc->ioc_coc->sc_csummer,
-					   orwo->orw_iod_csums.ca_arrays);
+					   orwo->orw_iod_csums.ca_arrays,
+					   orw->orw_oid, &orw->orw_dkey);
 			if (rc) {
 				D_ERROR(DF_UOID" fetch verify failed: %d.\n",
 					DP_UOID(orw->orw_oid), rc);
@@ -1504,7 +1525,8 @@ obj_local_rw_internal(crt_rpc_t *rpc, struct obj_io_context *ioc,
 		}
 	}
 	if (obj_rpc_is_fetch(rpc) && create_map)
-		rc = obj_fetch_create_maps(rpc, biod, iods);
+		rc = obj_fetch_create_maps(rpc, biod,
+					   orw->orw_iod_array.oia_iods);
 
 	if (rc == -DER_CSUM)
 		obj_log_csum_err();
@@ -3724,7 +3746,7 @@ ds_cpd_handle_one(crt_rpc_t *rpc, struct daos_cpd_sub_head *dcsh,
 
 		rc = csum_verify_keys(ioc->ioc_coc->sc_csummer,
 				      &dcsr->dcsr_dkey, dcu->dcu_dkey_csum,
-				      &dcu->dcu_iod_array);
+				      &dcu->dcu_iod_array, &dcsr->dcsr_oid);
 		if (rc != 0) {
 			if (rc == -DER_CSUM)
 				obj_log_csum_err();

--- a/src/object/srv_obj_migrate.c
+++ b/src/object/srv_obj_migrate.c
@@ -736,9 +736,9 @@ migrate_fetch_update_inline(struct migrate_one *mrone, daos_handle_t oh,
 
 		if (DAOS_OC_IS_EC(oca)) {
 			rc = daos_csummer_calc_iods(csummer,
-						    &sgls[start],  &mrone->mo_iods[start],
-						    NULL, iod_cnt, false, NULL, 0,
-						    &iod_csums);
+					&sgls[start],  &mrone->mo_iods[start],
+					NULL, iod_cnt, false, NULL, 0,
+					&iod_csums);
 			if (rc != 0) {
 				D_ERROR("Error calculating checksums: "
 						DF_RC"\n",

--- a/src/object/srv_obj_migrate.c
+++ b/src/object/srv_obj_migrate.c
@@ -833,19 +833,12 @@ migrate_update_parity(struct migrate_one *mrone, struct ds_cont_child *ds_cont,
 			D_GOTO(out, rc);
 		}
 
-		rc = daos_csummer_alloc_iods_csums_with_packed(
-			csummer,
-			iod,
-			1, csum_iov, &iod_csums);
+		rc = daos_csummer_calc_iods(csummer, &tmp_sgl, iod, NULL, 1,
+					    false, NULL, 0, &iod_csums);
 		if (rc != 0) {
 			D_ERROR("Error allocating iods");
 			D_GOTO(out, rc);
 		}
-
-		D_ASSERTF(iod_csums == NULL, "DAOS-6811 - EC Rebuild with "
-					     "checksums is currently "
-					     "unsupported.");
-
 
 		rc = vos_obj_update(ds_cont->sc_hdl, mrone->mo_oid,
 				    mrone->mo_epoch,
@@ -1072,6 +1065,8 @@ migrate_fetch_update_single(struct migrate_one *mrone, daos_handle_t oh,
 		los[i].cs_bytes = obj_ec_singv_cell_bytes(
 					mrone->mo_iods[i].iod_size, oca);
 		los[i].cs_nr = obj_ec_tgt_nr(oca);
+		D_DEBUG(DB_CSUM, "los[%d]: "DF_LAYOUT"\n", i,
+			DP_LAYOUT(los[i]));
 	}
 
 	rc = daos_csummer_csum_init_with_packed(&csummer, &csum_iov_fetch);
@@ -1082,10 +1077,16 @@ migrate_fetch_update_single(struct migrate_one *mrone, daos_handle_t oh,
 		/** Calc checksum for EC single value, since it may be striped,
 		 * and we need re-calculate the single stripe checksum.
 		 */
+		D_DEBUG(DB_CSUM,
+			DF_C_UOID_DKEY" REBUILD: Calculating csums\n",
+			DP_C_UOID_DKEY(mrone->mo_oid, &mrone->mo_dkey));
 		rc = daos_csummer_calc_iods(csummer, sgls, mrone->mo_iods, NULL,
-					    mrone->mo_iod_num, false, los,
+					    mrone->mo_iod_num, false, NULL,
 					    -1, &iod_csums);
 	} else {
+		D_DEBUG(DB_CSUM,
+			DF_C_UOID_DKEY" REBUILD: Using packed csums\n",
+			DP_C_UOID_DKEY(mrone->mo_oid, &mrone->mo_dkey));
 		tmp_csum_iov = csum_iov_fetch;
 		rc = daos_csummer_alloc_iods_csums_with_packed(csummer,
 							       mrone->mo_iods,
@@ -1193,15 +1194,30 @@ migrate_fetch_update_bulk(struct migrate_one *mrone, daos_handle_t oh,
 	if (rc != 0)
 		D_GOTO(post, rc);
 
-	tmp_csum_iov = csum_iov_fetch;
-	rc = daos_csummer_alloc_iods_csums_with_packed(csummer,
-						       mrone->mo_iods,
-						       mrone->mo_iod_num,
-						       &tmp_csum_iov,
-						       &iod_csums);
-	if (rc != 0) {
-		D_ERROR("Failed to alloc iod csums: "DF_RC"\n", DP_RC(rc));
-		D_GOTO(post, rc);
+	if (DAOS_OC_IS_EC(oca)) {
+		D_DEBUG(DB_CSUM,
+			DF_C_UOID_DKEY" REBUILD: Calculating csums. "
+			"IOD count: %d\n",
+			DP_C_UOID_DKEY(mrone->mo_oid, &mrone->mo_dkey),
+			mrone->mo_iod_num);
+		rc = daos_csummer_calc_iods(csummer, sgls, mrone->mo_iods, NULL,
+					    mrone->mo_iod_num, false, NULL, -1,
+					    &iod_csums);
+	} else {
+		D_DEBUG(DB_CSUM,
+			DF_C_UOID_DKEY" REBUILD: Using packed csums\n",
+			DP_C_UOID_DKEY(mrone->mo_oid, &mrone->mo_dkey));
+		tmp_csum_iov = csum_iov_fetch;
+		rc = daos_csummer_alloc_iods_csums_with_packed(csummer,
+							mrone->mo_iods,
+							mrone->mo_iod_num,
+							&tmp_csum_iov,
+							&iod_csums);
+		if (rc != 0) {
+			D_ERROR("Failed to alloc iod csums: "DF_RC"\n",
+				DP_RC(rc));
+			D_GOTO(post, rc);
+		}
 	}
 
 	vos_set_io_csum(ioh, iod_csums);

--- a/src/rdb/rdb_internal.h
+++ b/src/rdb/rdb_internal.h
@@ -290,9 +290,6 @@ int rdb_path_pop(rdb_path_t *path);
 
 /* rdb_util.c *****************************************************************/
 
-#define DF_IOV		"<%p,"DF_U64">"
-#define DP_IOV(iov)	(iov)->iov_buf, (iov)->iov_len
-
 extern const daos_size_t rdb_iov_max;
 size_t rdb_encode_iov(const d_iov_t *iov, void *buf);
 ssize_t rdb_decode_iov(const void *buf, size_t len, d_iov_t *iov);

--- a/src/tests/suite/daos_degrade_ec.c
+++ b/src/tests/suite/daos_degrade_ec.c
@@ -494,7 +494,7 @@ run_daos_degrade_simple_ec_test(int rank, int size, int *sub_tests,
 		sub_tests_size = ARRAY_SIZE(degrade_tests);
 		sub_tests = NULL;
 	}
-	run_daos_sub_tests_only("DAOS_Degrade_EC", degrade_tests,
+	rc += run_daos_sub_tests_only("DAOS_Degrade_EC", degrade_tests,
 				ARRAY_SIZE(degrade_tests), sub_tests,
 				sub_tests_size);
 

--- a/src/vos/tests/vts_ilog.c
+++ b/src/vos/tests/vts_ilog.c
@@ -16,9 +16,6 @@
 #include "vts_io.h"
 #include <vos_internal.h>
 
-#define DF_BOOL "%s"
-#define DP_BOOL(punch) ((punch) ? "true" : "false")
-
 #define LOG_FAIL(rc, expected_value, format, ...)			\
 	do {								\
 		if ((rc) == (expected_value))				\


### PR DESCRIPTION
Degraded EC tests (daos_test -X) where failing with checksums
enabled. There were several small issues that contributed to the
failures. The following are a list of fixes/changes:

- Added csum_iov to objec_recov_cb so that the checksum info is
  passed through on ec recovery. While the actual checksums
  won't be used, they will be recalcuated, the checksum info
  (type, len, etc) is needed.
- Fixed SV shard rebuild
- Reordered iod and csum RPC proc so that iod akey csum is
  not skipped. Otherwise, when iod.nr is 0, the akey checksum
  wasn't sent
- Range with very large numbers was incorrect because recx_hi
  function was returning int instead of uint64
- Addedd calculations of new checksums for EC objects on
  migrating bulk or parity

Also added a bunch of logging and defined string formats to help
with consistent logging

Signed-off-by: Ryon Jensen <ryon.jensen@intel.com>