### PR TITLE
DAOS-7222 build: Build debuginfo packages on SUSE

### DIFF
--- a/ci/provisioning/post_provision_config_nodes_EL_8.sh
+++ b/ci/provisioning/post_provision_config_nodes_EL_8.sh
@@ -15,16 +15,6 @@ group_repo_post() {
 }
 
 distro_custom() {
-    # install the debuginfo repo in case we get segfaults
-    cat <<"EOF" > $REPOS_DIR/CentOS-Debuginfo.repo
-[core-0-debuginfo]
-name=CentOS-8 - Debuginfo
-baseurl=http://debuginfo.centos.org/8/$basearch/
-gpgcheck=1
-gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-Debug-8
-enabled=0
-EOF
-
     # force install of avocado 69.x
     dnf -y erase avocado{,-common}                                              \
                  python2-avocado{,-plugins-{output-html,varianter-yaml-to-mux}} \

--- a/ci/provisioning/post_provision_config_nodes_LEAP_15.sh
+++ b/ci/provisioning/post_provision_config_nodes_LEAP_15.sh
@@ -52,6 +52,8 @@ post_provision_config_nodes() {
     time dnf repolist
     # the group repo is always on the test image
     #add_group_repo
+    # in fact is's on the Leap image twice so remove one
+    rm -f $REPOS_DIR/daos-stack-ext-opensuse-15-stable-group.repo
     add_local_repo
     time dnf repolist
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+daos (1.3.0-16) unstable; urgency=medium
+  [ Brian J. Murrell ]
+  * Enable debuginfo package building on SUSE platforms
+
+ -- Brian J. Murrell <brian.murrell@intel.com>  Fri, 07 May 2021 13:37:45 -0400
+
 daos (1.3.0-15) unstable; urgency=medium
   [ Brian J. Murrell ]
   * Update to build on EL8

--- a/src/tests/ftest/launch.py
+++ b/src/tests/ftest/launch.py
@@ -1587,7 +1587,11 @@ def resolve_debuginfo_dnf(pkg):
 
 def install_debuginfos():
     """Install debuginfo packages."""
-    install_pkgs = [{'name': 'gdb'}, {'name': 'python3-debuginfo'}]
+    distro_info = detect()
+    if "centos" in distro_info.name.lower():
+        install_pkgs = [{'name': 'gdb'}, {'name': 'python3-debuginfo'}]
+    else:
+        install_pkgs = []
 
     cmds = []
 
@@ -1609,25 +1613,27 @@ def install_debuginfos():
         cmds.append(["sudo", "rm", "-f", path])
 
     if USE_DEBUGINFO_INSTALL:
-        distro_info = detect()
-        yum_args = ["--exclude", "ompi-debuginfo"]
-        if "suse" in distro_info.name.lower():
-            yum_args.extend(["libpmemobj1", "python3", "openmpi3"])
-        elif "centos" in distro_info.name.lower() and \
-             distro_info.version == "7":
-            yum_args.extend(["--exclude", "nvml-debuginfo", "libpmemobj",
-                             "python36", "openmpi3"])
-        elif "centos" in distro_info.name.lower() and \
-             distro_info.version == "8":
-            yum_args.extend(["libpmemobj", "python3", "openmpi"])
-        else:
-            raise RuntimeError(
-                "install_debuginfos(): Unsupported distro: {}".format(
-                    distro_info))
-        cmds.append(["sudo", "dnf", "-y", "install"] + yum_args)
+        dnf_args = ["--exclude", "ompi-debuginfo"]
+        if os.getenv("TEST_RPMS", 'false') == 'true':
+            if "suse" in distro_info.name.lower():
+                dnf_args.extend(["libpmemobj1", "python3", "openmpi3"])
+            elif "centos" in distro_info.name.lower() and \
+                 distro_info.version == "7":
+                dnf_args.extend(["--enablerepo=*-debuginfo", "--exclude",
+                                 "nvml-debuginfo", "libpmemobj",
+                                 "python36", "openmpi3", "gcc"])
+            elif "centos" in distro_info.name.lower() and \
+                 distro_info.version == "8":
+                dnf_args.extend(["--enablerepo=*-debuginfo", "libpmemobj",
+                                 "python3", "openmpi", "gcc"])
+            else:
+                raise RuntimeError(
+                    "install_debuginfos(): Unsupported distro: {}".format(
+                        distro_info))
+            cmds.append(["sudo", "dnf", "-y", "install"] + dnf_args)
         cmds.append(
-            ["sudo", "dnf", "debuginfo-install", "--enablerepo=*-debuginfo",
-             "-y"] + yum_args + ["daos-server", "gcc"])
+            ["sudo", "dnf", "debuginfo-install",
+             "-y"] + dnf_args + ["daos-server"])
     else:
         # We're not using the yum API to install packages
         # See the comments below.
@@ -1648,7 +1654,10 @@ def install_debuginfos():
     # yum_base.processTransaction(rpmDisplay=yum.rpmtrans.NoOutputCallBack())
 
     # Now install a few pkgs that debuginfo-install wouldn't
-    cmd = ["sudo", "dnf", "-y", "--enablerepo=*debug*", "install"]
+    cmd = ["sudo", "dnf", "-y"]
+    if "centos" in distro_info.name.lower():
+        cmd.append("--enablerepo=*debug*")
+    cmd.append("install")
     for pkg in install_pkgs:
         try:
             cmd.append(
@@ -1664,13 +1673,15 @@ def install_debuginfos():
             print(run_command(cmd))
         except RuntimeError as error:
             # got an error, so abort this list of commands and re-run
-            # it with a yum clean, makecache first
+            # it with a dnf clean, makecache first
             print(error)
             retry = True
             break
     if retry:
         print("Going to refresh caches and try again")
-        cmd_prefix = ["sudo", "dnf", "--enablerepo=*debug*"]
+        cmd_prefix = ["sudo", "dnf"]
+        if "centos" in distro_info.name.lower():
+            cmd_prefix.append("--enablerepo=*debug*")
         cmds.insert(0, cmd_prefix + ["clean", "all"])
         cmds.insert(1, cmd_prefix + ["makecache"])
         for cmd in cmds:

--- a/src/tests/ftest/scripts/main.sh
+++ b/src/tests/ftest/scripts/main.sh
@@ -225,7 +225,8 @@ ulimit -n 4096
 
 launch_args="-jcrisa"
 # can only process cores on EL7 currently
-if [ "$(lsb_release -s -i)" = "CentOS" ]; then
+if [ "$(lsb_release -s -i)" = "CentOS" ] ||
+   [ "$(lsb_release -s -i)" = "openSUSE" ]; then
     launch_args="-jcrispa"
 fi
 

--- a/utils/rpms/daos.spec
+++ b/utils/rpms/daos.spec
@@ -14,7 +14,7 @@
 
 Name:          daos
 Version:       1.3.0
-Release:       15%{?relval}%{?dist}
+Release:       16%{?relval}%{?dist}
 Summary:       DAOS Storage Engine
 
 License:       BSD-2-Clause-Patent
@@ -246,6 +246,12 @@ Requires: %{name}-server%{?_isa} = %{version}-%{release}
 %description firmware
 This is the package needed to manage server storage firmware on DAOS servers.
 
+%if (0%{?suse_version} > 0)
+%global __debug_package 1
+%global _debuginfo_subpackages 0
+%debug_package
+%endif
+
 %prep
 %autosetup
 
@@ -376,7 +382,7 @@ getent passwd daos_agent >/dev/null || useradd -s /sbin/nologin -r -g daos_agent
 %{_libdir}/python3/site-packages/storage_estimator/__pycache__/*.pyc
 %endif
 %{_datadir}/%{name}
-%{_datadir}/%{name}/ioil-ld-opts
+%exclude %{_datadir}/%{name}/ioil-ld-opts
 %{_unitdir}/%{server_svc_name}
 
 %files client
@@ -454,6 +460,9 @@ getent passwd daos_agent >/dev/null || useradd -s /sbin/nologin -r -g daos_agent
 %attr(4750,root,daos_server) %{_bindir}/daos_firmware
 
 %changelog
+* Fri May 07 2021 Brian J. Murrell <brian.murrell@intel.com> 1.3.0-16
+- Enable debuginfo package building on SUSE platforms
+
 * Thu May 06 2021 Brian J. Murrell <brian.murrell@intel.com> 1.3.0-15
 - Update to build on EL8
 


### PR DESCRIPTION
Whereas RH distros do this automatically, it would appear that one needs
to specifically configure one's specfile to generate debuginfo packages
on SUSE platforms.