### PR TITLE
daos-6962-test: Rebuild test script verify and update follow the resolution of DAOS-3550

### DIFF
--- a/src/tests/ftest/rebuild/container_create.py
+++ b/src/tests/ftest/rebuild/container_create.py
@@ -4,7 +4,7 @@
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
 from avocado.core.exceptions import TestFail
-from apricot import TestWithServers, skipForTicket
+from apricot import TestWithServers
 from command_utils_base import CommandFailure
 from job_manager_utils import Mpirun
 from ior_utils import IorCommand
@@ -21,12 +21,6 @@ class ContainerCreate(TestWithServers):
 
     :avocado: recursive
     """
-
-    # Cancel any tests with tickets already assigned
-    CANCEL_FOR_TICKET = [
-        ["DAOS-2434", "rank", 1],
-        ["DAOS-2434", "rank", 2],
-    ]
 
     def add_containers_during_rebuild(self, loop_id, qty, pool1, pool2):
         """Add containers to a pool while rebuild is still in progress.
@@ -102,7 +96,6 @@ class ContainerCreate(TestWithServers):
 
         return status
 
-    @skipForTicket("DAOS-3550")
     def test_rebuild_container_create(self):
         """Jira ID: DAOS-1168.
 

--- a/src/tests/ftest/rebuild/container_create.yaml
+++ b/src/tests/ftest/rebuild/container_create.yaml
@@ -11,7 +11,7 @@ timeout: 700
 server_config:
   name: daos_server
   servers:
-    targets: 2
+    targets: 1
 pool:
   mode: 511
   name: daos_server

--- a/src/tests/ftest/rebuild/container_create.yaml
+++ b/src/tests/ftest/rebuild/container_create.yaml
@@ -10,6 +10,8 @@ hosts:
 timeout: 700
 server_config:
   name: daos_server
+  servers:
+    targets: 2
 pool:
   mode: 511
   name: daos_server
@@ -30,7 +32,7 @@ ior:
   block_size: 16m
   segment_count: 16
   transfer_size: 16m
-  dfs_oclass: RP_3GX
+  dfs_oclass: RP_3G1
 test:
   loop_quantity: !mux
     one_loop:
@@ -46,5 +48,5 @@ test:
     last_rank:
       rank: 4
   containers: 70
-  container_obj_class: "OC_RP_3GX"
+  container_obj_class: OC_RP_3G1
   use_ior: True


### PR DESCRIPTION
daos-6962-test: Rebuild test script verify and update follow the resolution of DAOS-3550
modified: rebuild/container_create.py
Skip-unit-tests: true
Skip-nlt: true
Quick-Functional: true
Test-tag: rebuildcontcreate
Signed-off-by: Ding Ho <ding-hwa.ho@intel.com>