### PR TITLE
DAOS-7489 tests: Add launch.py option to repeat test

### DIFF
--- a/ci/functional/test_main.sh
+++ b/ci/functional/test_main.sh
@@ -12,6 +12,12 @@ fi
 tnodes=$(echo "$NODELIST" | cut -d ',' -f 1-"$NODE_COUNT")
 first_node=${NODELIST%%,*}
 
+test_repeat=$(git show -s --format=%B | \
+              sed -ne "/^Test-repeat$PRAGMA_SUFFIX:/s/^.*: *//p")
+if [ -z "$test_repeat" ]; then
+    test_repeat=${TEST_REPEAT:-1}
+fi
+
 clush -B -S -o '-i ci_key' -l root -w "${first_node}" \
     "NODELIST=${NODELIST} $(cat ci/functional/setup_nfs.sh)"
 
@@ -41,7 +47,8 @@ if $TEST_RPMS; then
       "TEST_TAG=\"$test_tag\"                        \
        TNODES=\"$tnodes\"                            \
        FTEST_ARG=\"$FTEST_ARG\"                      \
+       TEST_REPEAT=\"$test_repeat\"                  \
        $(cat ci/functional/test_main_node.sh)"
 else
-    ./ftest.sh "$test_tag" "$tnodes" "$FTEST_ARG"
+    ./ftest.sh "$test_tag" "$tnodes" "$FTEST_ARG" "$test_repeat"
 fi

--- a/ci/functional/test_main_node.sh
+++ b/ci/functional/test_main_node.sh
@@ -9,4 +9,5 @@ export DAOS_TEST_SHARED_DIR
 export TEST_RPMS=true
 export REMOTE_ACCT=jenkins
 
-/usr/lib/daos/TESTING/ftest/ftest.sh "$TEST_TAG" "$TNODES" "$FTEST_ARG"
+/usr/lib/daos/TESTING/ftest/ftest.sh \
+    "$TEST_TAG" "$TNODES" "$FTEST_ARG" "$TEST_REPEAT"

--- a/ftest.sh
+++ b/ftest.sh
@@ -61,6 +61,12 @@ if [ -n "${3}" ]; then
     NVME_ARG="-n ${3}"
 fi
 
+# Number of times to repeat the tests run by launch.py
+TEST_REPEAT=""
+if [ -n "${4}" ]; then
+    TEST_REPEAT="--repeat ${4}"
+fi
+
 # Log size threshold
 LOGS_THRESHOLD="1G"
 
@@ -148,6 +154,7 @@ if ! ssh -A $SSH_KEY_ARGS ${REMOTE_ACCT:-jenkins}@"${nodes[0]}" \
      TEST_TAG_ARG=\"$TEST_TAG_ARG\"
      TEST_NODES=\"$TEST_NODES\"
      NVME_ARG=\"$NVME_ARG\"
+     TEST_REPEAT=\"$TEST_REPEAT\"
      LOGS_THRESHOLD=\"$LOGS_THRESHOLD\"
      $(sed -e '1,/^$/d' "$SCRIPT_LOC"/main.sh)"; then
     rc=${PIPESTATUS[0]}

--- a/src/tests/ftest/launch.py
+++ b/src/tests/ftest/launch.py
@@ -1193,6 +1193,7 @@ def archive_config_files(avocado_logs_dir, args):
         status = 16
     return status
 
+
 def archive_cov_usrlib_logs(avocado_logs_dir, args):
     """Archive daos cov files to the avocado results directory.
     Args:
@@ -1218,6 +1219,7 @@ def archive_cov_usrlib_logs(avocado_logs_dir, args):
     if not check_remote_output(task, "archive_daos_covs command"):
         status |= 16
     return status
+
 
 def archive_files(destination, hosts, source_files, cart, args):
     """Archive all of the remote files to the destination directory.
@@ -2018,6 +2020,12 @@ def main():
         action="store_true",
         help="rename the avocado test logs directory to include the test name")
     parser.add_argument(
+        "-re", "--repeat",
+        action="store",
+        default=1,
+        type=int,
+        help="number of times to repeat test execution")
+    parser.add_argument(
         "-p", "--process_cores",
         action="store_true",
         help="process core files from tests")
@@ -2102,7 +2110,11 @@ def main():
     generate_certs()
 
     # Run all the tests
-    status = run_tests(test_files, tag_filter, args)
+    status = 0
+    for loop in range(1, args.repeat + 1):
+        if args.repeat > 1:
+            print("Starting test loop {}/{}".format(loop, args.repeat + 1))
+        status |= run_tests(test_files, tag_filter, args)
 
     # Process the avocado run return codes and only treat job and command
     # failures as errors.

--- a/src/tests/ftest/launch.py
+++ b/src/tests/ftest/launch.py
@@ -1183,10 +1183,9 @@ def archive_config_files(avocado_logs_dir, args):
     print("Archiving config files from {} in {}".format(host_list, destination))
 
     # Copy any config files
-    base_dir = get_build_environment(args)["PREFIX"]
-    configs_dir = get_temporary_directory(args, base_dir)
+    configs_dir = os.path.join(os.sep, "etc", "daos")
     task = archive_files(
-        destination, host_list, "{}/*_*_*.yaml".format(configs_dir), False,
+        destination, host_list, "{}/daos_*.yml".format(configs_dir), False,
         args)
 
     status = 0

--- a/src/tests/ftest/scripts/main.sh
+++ b/src/tests/ftest/scripts/main.sh
@@ -235,7 +235,8 @@ fi
 # now run it!
 # shellcheck disable=SC2086
 if ! ./launch.py "${launch_args}" -th "${LOGS_THRESHOLD}" \
-                 -ts "${TEST_NODES}" ${NVME_ARG} ${TEST_TAG_ARR[*]}; then
+                 -ts "${TEST_NODES}" ${NVME_ARG} ${TEST_REPEAT} \
+                 ${TEST_TAG_ARR[*]}; then
     rc=${PIPESTATUS[0]}
 else
     rc=0


### PR DESCRIPTION
Adding the '--repeat <int>' option to the launch.py command to allow the
user to repeat the execution of the tests <int> times.  The default is
to run the tests once.  This command line option can be used in CI
through the 'Test-repeat-<stage>' pragma.

Test-tag: test_pool_svc iorsmall
Test-repeat-vm: 3

Signed-off-by: Phillip Henderson <phillip.henderson@intel.com>
