### PR TITLE
DAOS-6328 engine: raise event on clock drift

### DIFF
--- a/src/engine/drpc_ras.c
+++ b/src/engine/drpc_ras.c
@@ -332,8 +332,7 @@ ds_notify_swim_rank_dead(d_rank_t rank)
 {
 	Shared__RASEvent	evt = SHARED__RASEVENT__INIT;
 
-	return raise_ras(RAS_SWIM_RANK_DEAD,
-			 "SWIM marked rank as dead.",
+	return raise_ras(RAS_SWIM_RANK_DEAD, "SWIM marked rank as dead.",
 			 RAS_TYPE_STATE_CHANGE, RAS_SEV_NOTICE, NULL /* hwid */,
 			 &rank /* rank */, NULL /* jobid */, NULL /* pool */,
 			 NULL /* cont */, NULL /* objid */, NULL /* ctlop */,

--- a/src/engine/init.c
+++ b/src/engine/init.c
@@ -482,6 +482,18 @@ dss_crt_event_cb(d_rank_t rank, enum crt_event_source src,
 }
 
 static void
+dss_crt_hlc_error_cb(void *arg)
+{
+	/* Rank will be populated automatically */
+	ds_notify_ras_eventf(RAS_ENGINE_CLOCK_DRIFT, RAS_TYPE_INFO,
+			     RAS_SEV_ERROR, NULL /* hwid */, NULL /* rank */,
+			     NULL /* jobid */, NULL /* pool */,
+			     NULL /* cont */, NULL /* objid */,
+			     NULL /* ctlop */, NULL /* data */,
+			     "clock drift detected");
+}
+
+static void
 server_id_cb(uint32_t *tid, uint64_t *uid)
 {
 	if (uid != NULL)
@@ -668,6 +680,10 @@ server_init(int argc, char *argv[])
 	D_INFO("Modules successfully set up\n");
 
 	rc = crt_register_event_cb(dss_crt_event_cb, NULL);
+	if (rc)
+		D_GOTO(exit_init_state, rc);
+
+	rc = crt_register_hlc_error_cb(dss_crt_hlc_error_cb, NULL);
 	if (rc)
 		D_GOTO(exit_init_state, rc);
 

--- a/src/include/daos_srv/ras.h
+++ b/src/include/daos_srv/ras.h
@@ -40,6 +40,7 @@
 	X(RAS_ENGINE_FORMAT_REQUIRED,	"engine_format_required")	\
 	X(RAS_ENGINE_DIED,		"engine_died")			\
 	X(RAS_ENGINE_ASSERTED,		"engine_asserted")		\
+	X(RAS_ENGINE_CLOCK_DRIFT,	"engine_clock_drift")		\
 	X(RAS_POOL_REBUILD_START,	"pool_rebuild_started")		\
 	X(RAS_POOL_REBUILD_END,		"pool_rebuild_finished")	\
 	X(RAS_POOL_REBUILD_FAILED,	"pool_rebuild_failed")		\
@@ -113,7 +114,7 @@ ras_sev2str(ras_sev_t severity)
 }
 
 /**
- * Raise a RAS event and forward to the control-plane.
+ * Raise a RAS event and forward to the control plane.
  *
  * \param[in] id	Unique event identifier.
  * \param[in] msg	Human readable message.
@@ -149,7 +150,7 @@ ds_notify_ras_eventf(ras_event_t id, ras_type_t type, ras_sev_t sev, char *hwid,
 		     const char *fmt, ...);
 
 /**
- * Notify control-plane of an update to a pool's service replicas and wait for
+ * Notify control plane of an update to a pool's service replicas and wait for
  * a response.
  *
  * \param[in] pool	UUID of DAOS pool with updated service replicas.


### PR DESCRIPTION
Raise RAS event when clock drift is detected on engine.

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>