### PR TITLE
DAOS-623 tse: fix mem leak when task is completed in prep cb (#5642)

### DIFF
--- a/src/common/tse.c
+++ b/src/common/tse.c
@@ -448,6 +448,7 @@ tse_task_prep_callback(tse_task_t *task)
 	struct tse_task_private	*dtp = tse_task2priv(task);
 	struct tse_task_cb	*dtc;
 	struct tse_task_cb	*tmp;
+	bool			 ret = true;
 	int			 rc;
 
 	d_list_for_each_entry_safe(dtc, tmp, &dtp->dtp_prep_cb_list, dtc_list) {
@@ -461,12 +462,12 @@ tse_task_prep_callback(tse_task_t *task)
 
 		D_FREE(dtc);
 
-		/** Task was re-initialized; break */
+		/** Task was re-initialized; */
 		if (!dtp->dtp_running && !dtp->dtp_completing)
-			return false;
+			ret = false;
 	}
 
-	return true;
+	return ret;
 }
 
 /*

--- a/utils/test_memcheck.supp
+++ b/utils/test_memcheck.supp
@@ -128,17 +128,6 @@
 {
    <insert_a_suppression_name_here>
    Memcheck:Leak
-   match-leak-kinds:definite
-   fun:calloc
-   ...
-   fun:register_cb
-   fun:tse_task_register_cbs
-   fun:sched_test_2
-   ...
-}
-{
-   <insert_a_suppression_name_here>
-   Memcheck:Leak
    ...
    fun:calloc
    fun:gc_bin_find_bag


### PR DESCRIPTION
subsequent prep cbs need to be freed (not executed) before we return.

Signed-off-by: Mohamad Chaarawi <mohamad.chaarawi@intel.com>

Conflicts:
	utils/test_memcheck.supp