### PR TITLE
DAOS-7264 control: modify controlled stop and start events to indicate failure

### DIFF
--- a/src/control/cmd/dmg/system.go
+++ b/src/control/cmd/dmg/system.go
@@ -171,7 +171,7 @@ func (cmd *systemStopCmd) Execute(_ []string) (errOut error) {
 	if err != nil {
 		return err
 	}
-	req := &control.SystemStopReq{Prep: true, Kill: true, Force: cmd.Force}
+	req := &control.SystemStopReq{Force: cmd.Force}
 	req.Hosts.ReplaceSet(hostSet)
 	req.Ranks.ReplaceSet(rankSet)
 

--- a/src/control/cmd/dmg/system_test.go
+++ b/src/control/cmd/dmg/system_test.go
@@ -93,10 +93,7 @@ func TestDmg_SystemCommands(t *testing.T) {
 			"system stop with no arguments",
 			"system stop",
 			strings.Join([]string{
-				printRequest(t, &control.SystemStopReq{
-					Prep: true,
-					Kill: true,
-				}),
+				printRequest(t, &control.SystemStopReq{}),
 			}, " "),
 			nil,
 		},
@@ -104,11 +101,7 @@ func TestDmg_SystemCommands(t *testing.T) {
 			"system stop with force",
 			"system stop --force",
 			strings.Join([]string{
-				printRequest(t, &control.SystemStopReq{
-					Prep:  true,
-					Kill:  true,
-					Force: true,
-				}),
+				printRequest(t, &control.SystemStopReq{Force: true}),
 			}, " "),
 			nil,
 		},
@@ -116,7 +109,7 @@ func TestDmg_SystemCommands(t *testing.T) {
 			"system stop with single rank",
 			"system stop --ranks 0",
 			strings.Join([]string{
-				`*control.SystemStopReq-{"Sys":"","HostList":null,"Ranks":"0","Hosts":"","Prep":true,"Kill":true,"Force":false}`,
+				`*control.SystemStopReq-{"Sys":"","HostList":null,"Ranks":"0","Hosts":"","Force":false}`,
 			}, " "),
 			nil,
 		},
@@ -124,7 +117,7 @@ func TestDmg_SystemCommands(t *testing.T) {
 			"system stop with multiple ranks",
 			"system stop --ranks 0,1,4",
 			strings.Join([]string{
-				`*control.SystemStopReq-{"Sys":"","HostList":null,"Ranks":"[0-1,4]","Hosts":"","Prep":true,"Kill":true,"Force":false}`,
+				`*control.SystemStopReq-{"Sys":"","HostList":null,"Ranks":"[0-1,4]","Hosts":"","Force":false}`,
 			}, " "),
 			nil,
 		},
@@ -132,7 +125,7 @@ func TestDmg_SystemCommands(t *testing.T) {
 			"system stop with multiple hosts",
 			"system stop --rank-hosts bar9,foo-[0-100]",
 			strings.Join([]string{
-				`*control.SystemStopReq-{"Sys":"","HostList":null,"Ranks":"","Hosts":"bar9,foo-[0-100]","Prep":true,"Kill":true,"Force":false}`,
+				`*control.SystemStopReq-{"Sys":"","HostList":null,"Ranks":"","Hosts":"bar9,foo-[0-100]","Force":false}`,
 			}, " "),
 			nil,
 		},

--- a/src/control/events/engine.go
+++ b/src/control/events/engine.go
@@ -59,7 +59,7 @@ func EngineStateInfoToProto(rsi *EngineStateInfo) (*sharedpb.RASEvent_EngineStat
 
 // NewEngineDiedEvent creates a specific EngineDied event from given inputs.
 func NewEngineDiedEvent(hostname string, instanceIdx uint32, rank uint32, exitErr common.ExitStatus, exPid uint64) *RASEvent {
-	return New(&RASEvent{
+	return fill(&RASEvent{
 		Msg:      fmt.Sprintf("DAOS engine %d exited unexpectedly: %s", instanceIdx, exitErr),
 		ID:       RASEngineDied,
 		Hostname: hostname,
@@ -76,7 +76,7 @@ func NewEngineDiedEvent(hostname string, instanceIdx uint32, rank uint32, exitEr
 
 // NewEngineFormatRequiredEvent creates a EngineFormatRequired event from given inputs.
 func NewEngineFormatRequiredEvent(hostname string, instanceIdx uint32, formatType string) *RASEvent {
-	return New(&RASEvent{
+	return fill(&RASEvent{
 		Msg:      fmt.Sprintf("DAOS engine %d requires a %s format", instanceIdx, formatType),
 		ID:       RASEngineFormatRequired,
 		Hostname: hostname,

--- a/src/control/events/engine_test.go
+++ b/src/control/events/engine_test.go
@@ -26,18 +26,18 @@ var (
 	tExitErr = common.ExitStatus("test")
 )
 
-func mockDiedEvt(t *testing.T) *RASEvent {
+func mockEvtDied(t *testing.T) *RASEvent {
 	t.Helper()
 	return NewEngineDiedEvent(tHost, tInstanceIdx, tRank, tExitErr, tPid)
 }
 
-func mockFmtReqEvt(t *testing.T) *RASEvent {
+func mockEvtFmtReq(t *testing.T) *RASEvent {
 	t.Helper()
 	return NewEngineFormatRequiredEvent(tHost, tInstanceIdx, tFmtType)
 }
 
 func TestEvents_ConvertEngineDied(t *testing.T) {
-	event := mockDiedEvt(t)
+	event := mockEvtDied(t)
 
 	pbEvent, err := event.ToProto()
 	if err != nil {
@@ -59,7 +59,7 @@ func TestEvents_ConvertEngineDied(t *testing.T) {
 }
 
 func TestEvents_ConvertEngineFormatRequired(t *testing.T) {
-	event := mockFmtReqEvt(t)
+	event := mockEvtFmtReq(t)
 
 	pbEvent, err := event.ToProto()
 	if err != nil {

--- a/src/control/events/generic.go
+++ b/src/control/events/generic.go
@@ -52,7 +52,7 @@ func StrInfoToProto(si *StrInfo) (*sharedpb.RASEvent_StrInfo, error) {
 
 // NewGenericEvent returns a generic RAS event with supplied ID.
 func NewGenericEvent(id RASID, sev RASSeverityID, msg, info string) *RASEvent {
-	return New(&RASEvent{
+	return fill(&RASEvent{
 		ID:           id,
 		Type:         RASTypeInfoOnly,
 		Severity:     sev,

--- a/src/control/events/generic_test.go
+++ b/src/control/events/generic_test.go
@@ -13,14 +13,14 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
-func mockGenericEvent(t *testing.T) *RASEvent {
+func mockEvtGeneric(t *testing.T) *RASEvent {
 	t.Helper()
 	return NewGenericEvent(RASID(math.MaxInt32-1), RASSeverityError,
 		"DAOS generic test event", `{"people":["bill","steve","bob"]}`)
 }
 
 func TestEvents_ConvertGeneric(t *testing.T) {
-	event := mockGenericEvent(t)
+	event := mockEvtGeneric(t)
 
 	pbEvent, err := event.ToProto()
 	if err != nil {

--- a/src/control/events/psr_update.go
+++ b/src/control/events/psr_update.go
@@ -48,7 +48,7 @@ func PoolSvcInfoToProto(psi *PoolSvcInfo) (*sharedpb.RASEvent_PoolSvcInfo, error
 
 // NewPoolSvcReplicasUpdateEvent creates a specific PoolSvcRanksUpdate event from given inputs.
 func NewPoolSvcReplicasUpdateEvent(hostname string, rank uint32, poolUUID string, svcReps []uint32, leaderTerm uint64) *RASEvent {
-	return New(&RASEvent{
+	return fill(&RASEvent{
 		Msg:      fmt.Sprintf("DAOS pool service replica list updated to %v", svcReps),
 		ID:       RASPoolRepsUpdate,
 		Hostname: hostname,

--- a/src/control/events/psr_update_test.go
+++ b/src/control/events/psr_update_test.go
@@ -23,13 +23,13 @@ var (
 	tSvcReps = []uint32{0, 1}
 )
 
-func mockSvcRepsEvt(t *testing.T) *RASEvent {
+func mockEvtSvcReps(t *testing.T) *RASEvent {
 	t.Helper()
 	return NewPoolSvcReplicasUpdateEvent(tHost, tRank, tUuid, tSvcReps, tLdrTerm)
 }
 
 func TestEvents_ConvertPoolSvcReplicasUpdate(t *testing.T) {
-	event := mockSvcRepsEvt(t)
+	event := mockEvtSvcReps(t)
 
 	pbEvent, err := event.ToProto()
 	if err != nil {

--- a/src/control/events/pubsub.go
+++ b/src/control/events/pubsub.go
@@ -105,7 +105,7 @@ func (ps *PubSub) EnableEventIDs(ids ...RASID) {
 }
 
 // Publish passes an event to the event channel to be processed by subscribers.
-// Ignore disabled events. Implements the Publisher interface.
+// Ignore disabled events.
 func (ps *PubSub) Publish(event *RASEvent) {
 	if common.InterfaceIsNil(event) {
 		ps.log.Error("nil event")

--- a/src/control/events/pubsub.go
+++ b/src/control/events/pubsub.go
@@ -35,6 +35,12 @@ func (f HandlerFunc) OnEvent(ctx context.Context, evt *RASEvent) {
 	f(ctx, evt)
 }
 
+// Publisher defines an interface to be implemented by event publishers.
+type Publisher interface {
+	// Publish takes an event to be published.
+	Publish(event *RASEvent)
+}
+
 type subscriber struct {
 	topic   RASTypeID
 	handler Handler
@@ -99,7 +105,7 @@ func (ps *PubSub) EnableEventIDs(ids ...RASID) {
 }
 
 // Publish passes an event to the event channel to be processed by subscribers.
-// Ignore disabled events.
+// Ignore disabled events. Implements the Publisher interface.
 func (ps *PubSub) Publish(event *RASEvent) {
 	if common.InterfaceIsNil(event) {
 		ps.log.Error("nil event")

--- a/src/control/events/pubsub_test.go
+++ b/src/control/events/pubsub_test.go
@@ -48,7 +48,7 @@ func (tly *tally) getRx() []string {
 }
 
 func TestEvents_PubSub_Basic(t *testing.T) {
-	evt1 := mockDiedEvt(t)
+	evt1 := mockEvtDied(t)
 
 	log, buf := logging.NewTestLogger(t.Name())
 	defer common.ShowBufferOnFailure(t, buf)
@@ -79,7 +79,7 @@ func TestEvents_PubSub_Basic(t *testing.T) {
 }
 
 func TestEvents_PubSub_Reset(t *testing.T) {
-	evt1 := mockDiedEvt(t)
+	evt1 := mockEvtDied(t)
 
 	log, buf := logging.NewTestLogger(t.Name())
 	defer common.ShowBufferOnFailure(t, buf)
@@ -123,8 +123,8 @@ func TestEvents_PubSub_Reset(t *testing.T) {
 }
 
 func TestEvents_PubSub_DisableEvent(t *testing.T) {
-	evt1 := mockDiedEvt(t)
-	evt2 := mockSvcRepsEvt(t)
+	evt1 := mockEvtDied(t)
+	evt2 := mockEvtSvcReps(t)
 
 	log, buf := logging.NewTestLogger(t.Name())
 	defer common.ShowBufferOnFailure(t, buf)
@@ -157,7 +157,7 @@ func TestEvents_PubSub_DisableEvent(t *testing.T) {
 }
 
 func TestEvents_PubSub_SubscribeAnyTopic(t *testing.T) {
-	evt1 := mockDiedEvt(t)
+	evt1 := mockEvtDied(t)
 
 	log, buf := logging.NewTestLogger(t.Name())
 	defer common.ShowBufferOnFailure(t, buf)
@@ -175,7 +175,7 @@ func TestEvents_PubSub_SubscribeAnyTopic(t *testing.T) {
 
 	ps.Publish(evt1)
 	ps.Publish(evt1)
-	ps.Publish(mockGenericEvent(t)) // of type InfoOnly will only match Any
+	ps.Publish(mockEvtGeneric(t)) // of type InfoOnly will only match Any
 
 	<-tly1.finished
 	<-tly2.finished

--- a/src/control/events/ras.go
+++ b/src/control/events/ras.go
@@ -166,9 +166,9 @@ func (evt *RASEvent) WithRank(rid uint32) *RASEvent {
 	return evt
 }
 
-// New accepts a pointer to a RASEvent and fills in any
+// fill accepts a pointer to a RASEvent and fills in any
 // missing fields before returning the event.
-func New(evt *RASEvent) *RASEvent {
+func fill(evt *RASEvent) *RASEvent {
 	if evt == nil {
 		evt = &RASEvent{}
 	}

--- a/src/control/events/ras_test.go
+++ b/src/control/events/ras_test.go
@@ -42,11 +42,11 @@ var defEvtCmpOpts = append(common.DefaultCmpOpts(),
 )
 
 func TestEvents_HandleClusterEvent(t *testing.T) {
-	genericEvent := mockGenericEvent(t)
+	genericEvent := mockEvtGeneric(t)
 	pbGenericEvent, _ := genericEvent.ToProto()
-	engineDiedEvent := mockDiedEvt(t)
+	engineDiedEvent := mockEvtDied(t)
 	pbEngineDiedEvent, _ := engineDiedEvent.ToProto()
-	psrEvent := mockSvcRepsEvt(t)
+	psrEvent := mockEvtSvcReps(t)
 	pbPSREvent, _ := psrEvent.ToProto()
 
 	for name, tc := range map[string]struct {

--- a/src/control/lib/control/event_test.go
+++ b/src/control/lib/control/event_test.go
@@ -24,13 +24,13 @@ import (
 	"github.com/daos-stack/daos/src/control/logging"
 )
 
-func mockEngineDiedEvt(t *testing.T) *events.RASEvent {
+func mockEvtEngineDied(t *testing.T) *events.RASEvent {
 	t.Helper()
 	return events.NewEngineDiedEvent("foo", 0, 0, common.NormalExit, 1234)
 }
 
 func TestControl_eventNotify(t *testing.T) {
-	rasEventEngineDied := mockEngineDiedEvt(t)
+	rasEventEngineDied := mockEvtEngineDied(t)
 
 	for name, tc := range map[string]struct {
 		seq    uint64
@@ -85,8 +85,8 @@ func TestControl_eventNotify(t *testing.T) {
 }
 
 func TestControl_EventForwarder_OnEvent(t *testing.T) {
-	rasEventEngineDied := mockEngineDiedEvt(t).WithForwardable(false)
-	rasEventEngineDiedFwdable := mockEngineDiedEvt(t).WithForwardable(true)
+	rasEventEngineDied := mockEvtEngineDied(t).WithForwardable(false)
+	rasEventEngineDiedFwdable := mockEvtEngineDied(t).WithForwardable(true)
 
 	for name, tc := range map[string]struct {
 		aps            []string
@@ -155,8 +155,8 @@ func TestControl_EventLogger_OnEvent(t *testing.T) {
 		return nil, errors.Errorf("failed to create new syslogger (prio %d)", prio)
 	}
 
-	rasEventEngineDied := mockEngineDiedEvt(t).WithForwarded(false)
-	rasEventEngineDiedFwded := mockEngineDiedEvt(t).WithForwarded(true)
+	rasEventEngineDied := mockEvtEngineDied(t).WithForwarded(false)
+	rasEventEngineDiedFwded := mockEvtEngineDied(t).WithForwarded(true)
 
 	for name, tc := range map[string]struct {
 		event              *events.RASEvent

--- a/src/control/lib/control/system.go
+++ b/src/control/lib/control/system.go
@@ -334,8 +334,6 @@ type SystemStopReq struct {
 	unaryRequest
 	msRequest
 	sysRequest
-	Prep  bool
-	Kill  bool
 	Force bool
 }
 
@@ -386,8 +384,6 @@ func SystemStop(ctx context.Context, rpcClient UnaryInvoker, req *SystemStopReq)
 	pbReq := new(mgmtpb.SystemStopReq)
 	pbReq.Hosts = req.Hosts.String()
 	pbReq.Ranks = req.Ranks.String()
-	pbReq.Prep = req.Prep
-	pbReq.Kill = req.Kill
 	pbReq.Force = req.Force
 	pbReq.Sys = req.getSystem(rpcClient)
 
@@ -446,6 +442,7 @@ type SystemEraseResp struct {
 	Results system.MemberResults
 }
 
+// Errors returns error if any of the results indicate a failure.
 func (resp *SystemEraseResp) Errors() error {
 	return resp.Results.Errors()
 }

--- a/src/control/lib/netdetect/netdetect.go
+++ b/src/control/lib/netdetect/netdetect.go
@@ -1227,6 +1227,7 @@ func ScanFabric(ctx context.Context, provider string, excludes ...string) ([]*Fa
 						if err != nil {
 							continue
 						}
+						log.Debugf("scan result: %v\n", devScanResults)
 						ScanResults = append(ScanResults, devScanResults)
 						devCount++
 					}

--- a/src/control/server/ctl_ranks_rpc_test.go
+++ b/src/control/server/ctl_ranks_rpc_test.go
@@ -43,7 +43,7 @@ var (
 	)
 )
 
-func mockEngineDiedEvt(t *testing.T) *events.RASEvent {
+func mockEvtEngineDied(t *testing.T) *events.RASEvent {
 	t.Helper()
 	return events.NewEngineDiedEvent("foo", 0, 0, common.NormalExit, 1234)
 }
@@ -391,7 +391,7 @@ func TestServer_CtlSvc_StopRanks(t *testing.T) {
 
 				srv.OnInstanceExit(
 					func(_ context.Context, _ uint32, _ system.Rank, _ error, _ uint64) error {
-						svc.events.Publish(mockEngineDiedEvt(t))
+						svc.events.Publish(mockEvtEngineDied(t))
 						return nil
 					})
 			}

--- a/src/control/server/mgmt_system.go
+++ b/src/control/server/mgmt_system.go
@@ -648,7 +648,8 @@ func (svc *mgmtSvc) SystemStop(ctx context.Context, req *mgmtpb.SystemStopReq) (
 	var fResp *fanoutResponse
 
 	fReq.Method = control.PrepShutdownRanks
-	fResp, _, err = svc.rpcFanout(ctx, fReq, false)
+	// if not forced, update membership on rank error
+	fResp, _, err = svc.rpcFanout(ctx, fReq, !req.Force)
 	if err != nil {
 		return
 	}

--- a/src/control/server/server.go
+++ b/src/control/server/server.go
@@ -291,7 +291,7 @@ func (srv *server) setupGrpc() error {
 }
 
 func (srv *server) registerEvents() {
-	registerInitialSubscriptions(srv)
+	registerFollowerSubscriptions(srv)
 
 	srv.sysdb.OnLeadershipGained(func(ctx context.Context) error {
 		srv.log.Infof("MS leader running on %s", hostname())

--- a/src/control/server/server_utils.go
+++ b/src/control/server/server_utils.go
@@ -316,7 +316,7 @@ func registerTelemetryCallbacks(ctx context.Context, srv *server) {
 // registerFollowerSubscriptions stops handling received forwarded (in addition
 // to local) events and starts forwarding events to the new MS leader.
 // Log events on the host that they were raised (and first published) on.
-// This the initial behaviour before leadership has been determined.
+// This is the initial behavior before leadership has been determined.
 func registerFollowerSubscriptions(srv *server) {
 	srv.pubSub.Reset()
 	srv.pubSub.Subscribe(events.RASTypeAny, srv.evtLogger)

--- a/src/control/server/server_utils.go
+++ b/src/control/server/server_utils.go
@@ -313,13 +313,14 @@ func registerTelemetryCallbacks(ctx context.Context, srv *server) {
 	})
 }
 
-// registerInitialSubscriptions sets up forwarding of published actionable
-// events (type RASTypeStateChange) to the management service leader, behavior
-// is updated on leadership change.
+// registerFollowerSubscriptions stops handling received forwarded (in addition
+// to local) events and starts forwarding events to the new MS leader.
 // Log events on the host that they were raised (and first published) on.
-func registerInitialSubscriptions(srv *server) {
-	srv.pubSub.Subscribe(events.RASTypeStateChange, srv.evtForwarder)
+// This the initial behaviour before leadership has been determined.
+func registerFollowerSubscriptions(srv *server) {
+	srv.pubSub.Reset()
 	srv.pubSub.Subscribe(events.RASTypeAny, srv.evtLogger)
+	srv.pubSub.Subscribe(events.RASTypeStateChange, srv.evtForwarder)
 }
 
 // registerLeaderSubscriptions stops forwarding events to MS and instead starts
@@ -340,14 +341,6 @@ func registerLeaderSubscriptions(srv *server) {
 				}
 			}
 		}))
-}
-
-// registerFollowerSubscriptions stops handling received forwarded (in addition
-// to local) events and starts forwarding events to the new MS leader.
-func registerFollowerSubscriptions(srv *server) {
-	srv.pubSub.Reset()
-	srv.pubSub.Subscribe(events.RASTypeAny, srv.evtLogger)
-	srv.pubSub.Subscribe(events.RASTypeStateChange, srv.evtForwarder)
 }
 
 func getGrpcOpts(cfgTransport *security.TransportConfig) ([]grpc.ServerOption, error) {

--- a/src/control/system/membership.go
+++ b/src/control/system/membership.go
@@ -355,18 +355,20 @@ func (m *Membership) UpdateMemberStates(results MemberResults, updateOnFail bool
 			result.Addr = member.Addr.String()
 		}
 
-		// don't update members if:
-		// - result reports an error and updateOnFail is false or
+		// don't update members if any of the following is true:
+		// - result reports an error and state != errored
+		// - result reports an error and updateOnFail is false
 		// - if transition from current to result state is illegal
+
 		if result.Errored {
-			if !updateOnFail {
-				continue
-			}
 			if result.State != MemberStateErrored {
-				// this indicates a programming error
+				// result content mismatch (programming error)
 				return errors.Errorf(
 					"errored result for rank %d has conflicting state '%s'",
 					result.Rank, result.State)
+			}
+			if !updateOnFail {
+				continue
 			}
 		}
 

--- a/src/control/system/membership_test.go
+++ b/src/control/system/membership_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/daos-stack/daos/src/control/logging"
 )
 
-func mockEngineDiedEvt(t *testing.T, r uint32) *events.RASEvent {
+func mockEvtEngineDied(t *testing.T, r uint32) *events.RASEvent {
 	t.Helper()
 	return events.NewEngineDiedEvent("foo", 0, r, common.NormalExit, 1234)
 }
@@ -863,12 +863,12 @@ func TestSystem_Membership_OnEvent(t *testing.T) {
 		},
 		"event on unrecognized rank": {
 			members:    members,
-			event:      mockEngineDiedEvt(t, 4),
+			event:      mockEvtEngineDied(t, 4),
 			expMembers: members,
 		},
 		"state updated on unscheduled exit": {
 			members: members,
-			event:   mockEngineDiedEvt(t, 1),
+			event:   mockEvtEngineDied(t, 1),
 			expMembers: Members{
 				MockMember(t, 0, MemberStateJoined),
 				MockMember(t, 1, MemberStateErrored).WithInfo(


### PR DESCRIPTION
Replace system stop/start events with a failure event indicating the
list of ranks that failed to perform the given operation.

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>