### PR TITLE
DAOS-7384 object: Prevent server assertion if key invalid

### DIFF
--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -1817,11 +1817,13 @@ obj_req_size_valid(daos_size_t iod_size, daos_size_t sgl_size)
 }
 
 static int
-obj_iod_sgl_valid(unsigned int nr, daos_iod_t *iods, d_sg_list_t *sgls,
-		  bool update, bool size_fetch, bool spec_shard)
+obj_iod_sgl_valid(daos_obj_id_t oid, unsigned int nr, daos_iod_t *iods,
+		  d_sg_list_t *sgls, bool update, bool size_fetch,
+		  bool spec_shard)
 {
-	int	i, j;
-	int	rc;
+	int		i, j;
+	daos_ofeat_t	ofeat = daos_obj_id2feat(oid);
+	int		rc;
 
 	if (iods == NULL) {
 		if (nr == 0)
@@ -1835,6 +1837,9 @@ obj_iod_sgl_valid(unsigned int nr, daos_iod_t *iods, d_sg_list_t *sgls,
 			D_ERROR("Invalid argument of NULL akey\n");
 			return -DER_INVAL;
 		}
+		if (ofeat & DAOS_OF_AKEY_UINT64 &&
+		    iods[i].iod_name.iov_len > sizeof(uint64_t))
+			return -DER_INVAL;
 		for (j = 0; j < iods[i].iod_nr; j++) {
 			if (iods[i].iod_recxs != NULL && (!spec_shard &&
 			   (iods[i].iod_recxs[j].rx_idx & PARITY_INDICATOR)
@@ -1970,8 +1975,20 @@ check_query_flags(daos_obj_id_t oid, uint32_t flags, daos_key_t *dkey,
 }
 
 static inline bool
-obj_key_valid(daos_key_t *key)
+obj_key_valid(daos_obj_id_t oid, daos_key_t *key, bool check_dkey)
 {
+	daos_ofeat_t ofeat = daos_obj_id2feat(oid);
+
+	if (check_dkey) {
+		if (ofeat & DAOS_OF_DKEY_UINT64 &&
+		    key->iov_len > sizeof(uint64_t))
+			return false;
+	} else {
+		if (ofeat & DAOS_OF_AKEY_UINT64 &&
+		    key->iov_len > sizeof(uint64_t))
+			return false;
+	}
+
 	return key != NULL && key->iov_buf != NULL && key->iov_len != 0;
 }
 
@@ -1988,6 +2005,7 @@ obj_req_valid(tse_task_t *task, void *args, int opc, struct dtx_epoch *epoch,
 	int			rc = 0;
 
 	obj_auxi = tse_task_stack_push(task, sizeof(*obj_auxi));
+
 	switch (opc) {
 	case DAOS_OBJ_RPC_FETCH: {
 		daos_obj_fetch_t	*f_args = args;
@@ -1996,17 +2014,23 @@ obj_req_valid(tse_task_t *task, void *args, int opc, struct dtx_epoch *epoch,
 		spec_shard  = f_args->extra_flags & DIOF_TO_SPEC_SHARD;
 		check_exist = f_args->extra_flags & DIOF_CHECK_EXISTENCE;
 		size_fetch  = obj_auxi->reasb_req.orr_size_fetch;
+
+		obj = obj_hdl2ptr(f_args->oh);
+		if (obj == NULL)
+			D_GOTO(out, rc = -DER_NO_HDL);
+
 		if ((!obj_auxi->io_retry && !obj_auxi->req_reasbed) ||
 		    size_fetch) {
-			if (!obj_key_valid(f_args->dkey) ||
+			if (!obj_key_valid(obj->cob_md.omd_id, f_args->dkey,
+					   true) ||
 			    (f_args->nr == 0 && !check_exist)) {
 				D_ERROR("Invalid fetch parameter.\n");
 				D_GOTO(out, rc = -DER_INVAL);
 			}
 
-			rc = obj_iod_sgl_valid(f_args->nr, f_args->iods,
-					       f_args->sgls, false, size_fetch,
-					       spec_shard);
+			rc = obj_iod_sgl_valid(obj->cob_md.omd_id, f_args->nr,
+					       f_args->iods, f_args->sgls,
+					       false, size_fetch, spec_shard);
 			if (rc)
 				goto out;
 		}
@@ -2017,15 +2041,20 @@ obj_req_valid(tse_task_t *task, void *args, int opc, struct dtx_epoch *epoch,
 	case DAOS_OBJ_RPC_UPDATE: {
 		daos_obj_update_t	*u_args = args;
 
+		obj = obj_hdl2ptr(u_args->oh);
+		if (obj == NULL)
+			D_GOTO(out, rc = -DER_NO_HDL);
+
 		if (!obj_auxi->io_retry && !obj_auxi->req_reasbed) {
-			if (!obj_key_valid(u_args->dkey) || u_args->nr == 0) {
+			if (!obj_key_valid(obj->cob_md.omd_id, u_args->dkey,
+					   true) || u_args->nr == 0) {
 				D_ERROR("Invalid update parameter.\n");
 				D_GOTO(out, rc = -DER_INVAL);
 			}
 
-			rc = obj_iod_sgl_valid(u_args->nr, u_args->iods,
-					       u_args->sgls, true, false,
-					       false);
+			rc = obj_iod_sgl_valid(obj->cob_md.omd_id, u_args->nr,
+					       u_args->iods, u_args->sgls, true,
+					       false, false);
 			if (rc)
 				D_GOTO(out, rc);
 		}
@@ -2050,7 +2079,11 @@ obj_req_valid(tse_task_t *task, void *args, int opc, struct dtx_epoch *epoch,
 	case DAOS_OBJ_RPC_PUNCH_DKEYS: {
 		daos_obj_punch_t *p_args = args;
 
-		if (!obj_key_valid(p_args->dkey)) {
+		obj = obj_hdl2ptr(p_args->oh);
+		if (obj == NULL)
+			D_GOTO(out, rc = -DER_NO_HDL);
+
+		if (!obj_key_valid(obj->cob_md.omd_id, p_args->dkey, true)) {
 			D_ERROR("invalid punch dkey parameter.\n");
 			D_GOTO(out, rc = -DER_INVAL);
 		}
@@ -2067,13 +2100,19 @@ obj_req_valid(tse_task_t *task, void *args, int opc, struct dtx_epoch *epoch,
 		daos_obj_punch_t *p_args = args;
 		int		  i;
 
-		if (!obj_key_valid(p_args->dkey) || p_args->akey_nr == 0) {
+		obj = obj_hdl2ptr(p_args->oh);
+		if (obj == NULL)
+			D_GOTO(out, rc = -DER_NO_HDL);
+
+		if (!obj_key_valid(obj->cob_md.omd_id, p_args->dkey, true) ||
+		    p_args->akey_nr == 0) {
 			D_ERROR("invalid punch akey parameter.\n");
 			D_GOTO(out, rc = -DER_INVAL);
 		}
 
 		for (i = 0; i < p_args->akey_nr; i++) {
-			if (!obj_key_valid(&p_args->akeys[i])) {
+			if (!obj_key_valid(obj->cob_md.omd_id,
+					   &p_args->akeys[i], false)) {
 				D_ERROR("invalid punch akeys parameter.\n");
 				D_GOTO(out, rc = -DER_INVAL);
 			}

--- a/src/tests/suite/daos_obj.c
+++ b/src/tests/suite/daos_obj.c
@@ -3236,9 +3236,9 @@ update_overlapped_recxs(void **state)
 	test_arg_t	*arg = *state;
 	daos_obj_id_t	 oid;
 	daos_handle_t	 oh;
-	d_iov_t	 dkey;
+	d_iov_t		dkey;
 	d_sg_list_t	 sgl;
-	d_iov_t	 sg_iov;
+	d_iov_t		sg_iov;
 	daos_iod_t	 iod;
 	daos_recx_t	 recx[128];
 	char		 buf[STACK_BUF_LEN];
@@ -3307,9 +3307,9 @@ io_obj_key_query(void **state)
 	daos_iod_t	iod = {0};
 	d_sg_list_t	sgl = {0};
 	uint32_t	update_var = 0xdeadbeef;
-	d_iov_t	val_iov;
-	d_iov_t	dkey;
-	d_iov_t	akey;
+	d_iov_t		val_iov;
+	d_iov_t		dkey;
+	d_iov_t		akey;
 	daos_recx_t	recx;
 	uint64_t	dkey_val, akey_val;
 	uint32_t	flags;
@@ -4467,6 +4467,100 @@ oclass_auto_setting(void **state)
 
 }
 
+static void
+int_key_setting(void **state)
+{
+	test_arg_t              *arg = *state;
+	daos_obj_id_t		oid;
+	daos_handle_t		oh;
+	d_iov_t			dkey;
+	char			dkey_buf[128];
+	char			akey_buf[128];
+	d_sg_list_t		sgl;
+	d_iov_t			sg_iov;
+	daos_iod_t		iod;
+	char			buf[STACK_BUF_LEN];
+	int                     rc;
+
+	/*
+	 * Object with integer dkey / akey should fail IO with -DER_INVAL if
+	 * key size is not correct.
+	 */
+	oid = daos_test_oid_gen(arg->coh, OC_S1, DAOS_OF_DKEY_UINT64, 0,
+				arg->myrank);
+
+	dts_buf_render(buf, STACK_BUF_LEN);
+	dts_buf_render(dkey_buf, 128);
+	dts_buf_render(akey_buf, 128);
+
+	/** init dkey */
+	d_iov_set(&dkey, dkey_buf, sizeof(dkey_buf));
+
+	/** init scatter/gather */
+	d_iov_set(&sg_iov, buf, sizeof(buf));
+	sgl.sg_nr		= 1;
+	sgl.sg_nr_out		= 0;
+	sgl.sg_iovs		= &sg_iov;
+
+	/** init I/O descriptor */
+	d_iov_set(&iod.iod_name, akey_buf, sizeof(akey_buf));
+	iod.iod_size    = STACK_BUF_LEN;
+	iod.iod_type	= DAOS_IOD_SINGLE;
+	iod.iod_recxs	= NULL;
+	iod.iod_nr	= 1;
+
+	rc = daos_obj_open(arg->coh, oid, 0, &oh, NULL);
+	assert_rc_equal(rc, 0);
+
+	print_message("Update with invalid DKEY\n");
+	/** update record */
+	rc = daos_obj_update(oh, DAOS_TX_NONE, 0, &dkey, 1, &iod, &sgl, NULL);
+	assert_rc_equal(rc, -DER_INVAL);
+
+	print_message("Fetch with invalid DKEY\n");
+	/** fetch record size */
+	iod.iod_size	= DAOS_REC_ANY;
+	rc = daos_obj_fetch(oh, DAOS_TX_NONE, 0, &dkey, 1, &iod,
+			    NULL, NULL, NULL);
+	assert_rc_equal(rc, -DER_INVAL);
+
+	print_message("Punch with invalid DKEY\n");
+	/** Punch Dkey */
+	rc = daos_obj_punch_dkeys(oh, DAOS_TX_NONE, 0, 1, &dkey, NULL);
+	assert_rc_equal(rc, -DER_INVAL);
+
+	rc = daos_obj_close(oh, NULL);
+	assert_rc_equal(rc, 0);
+
+	oid = daos_test_oid_gen(arg->coh, OC_S1, DAOS_OF_AKEY_UINT64, 0,
+				arg->myrank);
+
+	rc = daos_obj_open(arg->coh, oid, 0, &oh, NULL);
+	assert_rc_equal(rc, 0);
+
+	print_message("Update with invalid AKEY\n");
+	/** update record */
+	iod.iod_size	= STACK_BUF_LEN;
+	rc = daos_obj_update(oh, DAOS_TX_NONE, 0, &dkey, 1, &iod, &sgl, NULL);
+	assert_rc_equal(rc, -DER_INVAL);
+
+	print_message("Fetch with invalid AKEY\n");
+	/** fetch record size */
+	iod.iod_size	= DAOS_REC_ANY;
+	rc = daos_obj_fetch(oh, DAOS_TX_NONE, 0, &dkey, 1, &iod,
+			    NULL, NULL, NULL);
+	assert_rc_equal(rc, -DER_INVAL);
+
+	print_message("Punch with invalid AKEY\n");
+	/** Punch Akey */
+	rc = daos_obj_punch_akeys(oh, DAOS_TX_NONE, 0, &dkey, 1,
+				  &iod.iod_name, NULL);
+	assert_rc_equal(rc, -DER_INVAL);
+
+	rc = daos_obj_close(oh, NULL);
+	assert_rc_equal(rc, 0);
+}
+
 static const struct CMUnitTest io_tests[] = {
 	{ "IO1: simple update/fetch/verify",
 	  io_simple, async_disable, test_case_teardown},
@@ -4556,6 +4650,8 @@ static const struct CMUnitTest io_tests[] = {
 	  test_case_teardown},
 	{ "IO43: Object class selection",
 	  oclass_auto_setting, async_disable, test_case_teardown},
+	{ "IO44: INT dkey/akey checks",
+	  int_key_setting, async_disable, test_case_teardown},
 };
 
 int


### PR DESCRIPTION
If an object oid is generated with an integer akey or dkey, object
access with an invalid dkey or akey should not cause a server assert.
This PR adds checks on client side to make sure such operations
fails with -DER_INVAL.

Signed-off-by: Mohamad Chaarawi <mohamad.chaarawi@intel.com>