### PR TITLE
DAOS-6833 rdb: Update raft for Pre-Vote

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -28,7 +28,7 @@ Build-Depends: debhelper (>= 10),
                libboost-dev,
                libspdk-dev,
                libipmctl-dev,
-               libraft-dev (= 0.7.3-1382.g3fa7f4e),
+               libraft-dev (= 0.7.3-1384.gd3593cb),
                python3-tabulate,
                liblz4-dev
 Standards-Version: 4.1.2

--- a/src/rdb/rdb_internal.h
+++ b/src/rdb/rdb_internal.h
@@ -162,7 +162,7 @@ void rdb_raft_free_request(struct rdb *db, crt_rpc_t *rpc);
  * These are for daos_rpc::dr_opc and DAOS_RPC_OPCODE(opc, ...) rather than
  * crt_req_create(..., opc, ...). See src/include/daos/rpc.h.
  */
-#define DAOS_RDB_VERSION 2
+#define DAOS_RDB_VERSION 3
 /* LIST of internal RPCS in form of:
  * OPCODE, flags, FMT, handler, corpc_hdlr,
  */

--- a/src/rdb/rdb_rpc.c
+++ b/src/rdb/rdb_rpc.c
@@ -29,6 +29,9 @@ crt_proc_msg_requestvote_response_t(crt_proc_t proc, crt_proc_op_t proc_op,
 	rc = crt_proc_int32_t(proc, proc_op, &p->vote_granted);
 	if (unlikely(rc))
 		return rc;
+	rc = crt_proc_int32_t(proc, proc_op, &p->prevote);
+	if (unlikely(rc))
+		return rc;
 
 	return 0;
 }


### PR DESCRIPTION
Update raft for the Pre-Vote feature. Increment the RDB RPC protocol
version to prevent mix-version engines from causing further harm.

PR-repos: raft@PR-46
Signed-off-by: Li Wei <wei.g.li@intel.com>