### PR TITLE
DAOS-7437 ec: Don't ingore status of patch_holes_ult

### DIFF
--- a/src/object/srv_ec_aggregate.c
+++ b/src/object/srv_ec_aggregate.c
@@ -1774,6 +1774,9 @@ agg_process_holes(struct ec_agg_entry *entry)
 		rc = dss_abterr2der(rc);
 		goto ev_out;
 	}
+	if (*status != 0)
+		D_GOTO(ev_out, rc = *status);
+
 	/* Update local vos with replicate */
 	iod.iod_name = entry->ae_akey;
 	iod.iod_type = DAOS_IOD_ARRAY;


### PR DESCRIPTION
PR #5159 removed this line

if (*status != 0)
        rc = *status;

But this ignores the fact that the ult failed.  It was
likely changed due to a coverity warning that it would
potentially get overwritten by subsequent rc settings.
But rather than removing it, change it to a goto.

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>