### PR TITLE
add draft of serialization library and preserve option

### DIFF
--- a/src/utils/SConscript
+++ b/src/utils/SConscript
@@ -4,7 +4,7 @@ Import('env')
 
 def scons():
     """Execute build"""
-    libs = ['daos', 'daos_common', 'uuid', 'dfs', 'duns', 'gurt', 'cart']
+    libs = ['daos', 'daos_common', 'uuid', 'dfs', 'duns', 'gurt', 'cart', 'dl']
 
     denv = env.Clone()
 

--- a/src/utils/daos.c
+++ b/src/utils/daos.c
@@ -548,6 +548,7 @@ args_free(struct cmd_args_s *ap)
 	D_FREE(ap->path);
 	D_FREE(ap->src);
 	D_FREE(ap->dst);
+	D_FREE(ap->preserve);
 	D_FREE(ap->snapname_str);
 	D_FREE(ap->epcrange_str);
 
@@ -577,6 +578,7 @@ common_op_parse_hdlr(int argc, char *argv[], struct cmd_args_s *ap)
 		{"path",	required_argument,	NULL,	'd'},
 		{"src",		required_argument,	NULL,	'S'},
 		{"dst",		required_argument,	NULL,	'D'},
+		{"preserve",	required_argument,	NULL,	'm'},
 		{"type",	required_argument,	NULL,	't'},
 		{"oclass",	required_argument,	NULL,	'o'},
 		{"chunk_size",	required_argument,	NULL,	'z'},
@@ -717,6 +719,11 @@ common_op_parse_hdlr(int argc, char *argv[], struct cmd_args_s *ap)
 		case 'D':
 			D_STRNDUP(ap->dst, optarg, strlen(optarg));
 			if (ap->dst == NULL)
+				D_GOTO(out_free, rc = RC_NO_HELP);
+			break;
+		case 'm':
+			D_STRNDUP(ap->preserve, optarg, strlen(optarg));
+			if (ap->preserve == NULL)
 				D_GOTO(out_free, rc = RC_NO_HELP);
 			break;
 		case 't':
@@ -1326,6 +1333,7 @@ do { \
 	" filesystem copy options (copy):\n" \
 	"	--src=daos://<pool/cont> | <path>\n" \
 	"	--dst=daos://<pool/cont> | <path>\n" \
+	"	--preserve=<filename>\n" \
 	"	\t type is daos, only specified if pool/cont used\n"); \
 	fprintf(stream, "\n"); \
 } while (0)

--- a/src/utils/daos_hdlr.c
+++ b/src/utils/daos_hdlr.c
@@ -13,6 +13,8 @@
 #define ENUM_LARGE_KEY_BUF	(512 * 1024) /* 512k large key */
 #define ENUM_DESC_NR		5 /* number of keys/records returned by enum */
 #define ENUM_DESC_BUF		512 /* all keys/records returned by enum */
+/* TODO: hardcoded for initial checks/testing, where will this library go?  */
+#define LIBSERIALIZE		"/home/dsikich/daos-clean/daos/hdf-serialize.so"
 
 #include <stdio.h>
 #include <dirent.h>
@@ -21,6 +23,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
+#include <dlfcn.h>
 #include <daos.h>
 #include <daos/common.h>
 #include <daos/checksum.h>
@@ -69,7 +72,6 @@ struct dm_args {
 	uint32_t cont_prop_oid;
 	uint32_t cont_prop_layout;
 	uint64_t cont_layout;
-	uint64_t cont_oid;
 
 };
 
@@ -2646,45 +2648,425 @@ set_dm_args_default(struct dm_args *dm)
 	dm->cont_prop_oid = DAOS_PROP_CO_ALLOCED_OID;
 	dm->cont_prop_layout = DAOS_PROP_CO_LAYOUT_TYPE;
 	dm->cont_layout = DAOS_PROP_CO_LAYOUT_UNKOWN;
-	dm->cont_oid = 0;
 
 }
 
-static int
-dm_get_cont_prop(daos_handle_t coh,
-		 char *sysname,
-		 daos_cont_info_t *cont_info,
-		 int size,
-		 uint32_t *dpe_types,
-		 uint64_t *dpe_vals)
+/*
+ * Free the user attribute buffers created by dm_cont_get_usr_attrs.
+ */
+void
+dm_cont_free_usr_attrs(int n, char ***_names, void ***_buffers,
+		       size_t **_sizes)
 {
-	int                     rc = 0;
-	int                     i = 0;
-	daos_prop_t		*prop = NULL;
+	char	**names = *_names;
+	void	**buffers = *_buffers;
+	size_t	i;
 
-	prop = daos_prop_alloc(size);
-	if (prop == NULL) {
-		fprintf(stderr, "Failed to allocate prop");
-		D_GOTO(out, rc = -DER_NOMEM);
+	if (names != NULL) {
+		for (i = 0; i < n; i++) {
+			D_FREE(names[i]);
+		}
+		D_FREE(*_names);
 	}
-
-	for (i = 0; i < size; i++) {
-		prop->dpp_entries[i].dpe_type = dpe_types[i];
+	if (buffers != NULL) {
+		for (i = 0; i < n; i++) {
+			D_FREE(buffers[i]);
+		}
+		D_FREE(*_buffers);
 	}
+	D_FREE(*_sizes);
+}
 
-	rc = daos_cont_query(coh, NULL, prop, NULL);
-	if (rc) {
-		fprintf(stderr, "daos_cont_query() failed (%d)", rc);
-		daos_prop_free(prop);
+/*
+ * Get the user attributes for a container in a format similar
+ * to what daos_cont_set_attr expects.
+ * cont_free_usr_attrs should be called to free the allocations.
+ * Returns 1 on error, 0 on success.
+ */
+int
+dm_cont_get_usr_attrs(daos_handle_t coh, int *_n, char ***_names,
+		      void ***_buffers, size_t **_sizes)
+{
+	int		rc = 0;
+	uint64_t	total_size = 0;
+	uint64_t	cur_size = 0;
+	uint64_t	num_attrs = 0;
+	uint64_t	name_len = 0;
+	char		*name_buf = NULL;
+	char		**names = NULL;
+	void		**buffers = NULL;
+	size_t		*sizes = NULL;
+	uint64_t	i;
+
+	/* Get the total size needed to store all names */
+	rc = daos_cont_list_attr(coh, NULL, &total_size, NULL);
+	if (rc != 0) {
+		fprintf(stderr, "failed to list user attributes "DF_RC,
+			DP_RC(rc));
+		rc = 1;
 		D_GOTO(out, rc);
 	}
 
-	for (i = 0; i < size; i++) {
-		dpe_vals[i] = prop->dpp_entries[i].dpe_val;
+	/* no attributes found */
+	if (total_size == 0) {
+		*_n = 0;
+		D_GOTO(out, rc);
 	}
 
-	daos_prop_free(prop);
+	/* Allocate a buffer to hold all attribute names */
+	name_buf = calloc(total_size, sizeof(char));
+	if (name_buf == NULL) {
+		fprintf(stderr, "failed to allocate user attribute buffer");
+		rc = 1;
+		D_GOTO(out, rc);
+	}
+
+	/* Get the attribute names */
+	rc = daos_cont_list_attr(coh, name_buf, &total_size, NULL);
+	if (rc != 0) {
+		fprintf(stderr, "failed to list user attributes "DF_RC,
+			DP_RC(rc));
+		rc = 1;
+		D_GOTO(out, rc);
+	}
+
+	/* Figure out the number of attributes */
+	while (cur_size < total_size) {
+		name_len = strnlen(name_buf + cur_size, total_size - cur_size);
+		if (name_len == total_size - cur_size) {
+			/* end of buf reached but no end of string, ignoring */
+			break;
+		}
+		num_attrs++;
+		cur_size += name_len + 1;
+	}
+
+	/* Sanity check */
+	if (num_attrs == 0) {
+		fprintf(stderr, "failed to parse user attributes");
+		rc = 1;
+		D_GOTO(out, rc);
+	}
+
+	/* Allocate arrays for attribute names, buffers, and sizes */
+	names = calloc(num_attrs, sizeof(char *));
+	if (names == NULL) {
+		fprintf(stderr, "failed to allocate user attribute buffer");
+		rc = 1;
+		D_GOTO(out, rc);
+	}
+	sizes = calloc(num_attrs, sizeof(size_t));
+	if (sizes == NULL) {
+		fprintf(stderr, "failed to allocate user attribute buffer");
+		rc = 1;
+		D_GOTO(out, rc);
+	}
+	buffers = calloc(num_attrs, sizeof(void *));
+	if (buffers == NULL) {
+		fprintf(stderr, "failed to allocate user attribute buffer");
+		rc = 1;
+		D_GOTO(out, rc);
+	}
+
+	/* Create the array of names */
+	cur_size = 0;
+	for (i = 0; i < num_attrs; i++) {
+		name_len = strnlen(name_buf + cur_size, total_size - cur_size);
+		if (name_len == total_size - cur_size) {
+			/* end of buf reached but no end of string, ignoring */
+			break;
+		}
+		names[i] = strndup(name_buf + cur_size, name_len + 1);
+		cur_size += name_len + 1;
+	}
+
+	/* Get the buffer sizes */
+	rc = daos_cont_get_attr(coh, num_attrs, (const char * const*)names,
+				NULL, sizes, NULL);
+	if (rc != 0) {
+		fprintf(stderr, "failed to get user attribute sizes "DF_RC,
+			DP_RC(rc));
+		rc = 1;
+		D_GOTO(out, rc);
+	}
+
+	/* Allocate space for each value */
+	for (i = 0; i < num_attrs; i++) {
+		buffers[i] = calloc(sizes[i], sizeof(size_t));
+		if (buffers[i] == NULL) {
+			fprintf(stderr, "failed to allocate user attribute "
+				"buffer");
+			rc = 1;
+			D_GOTO(out, rc);
+		}
+	}
+
+	/* Get the attribute values */
+	rc = daos_cont_get_attr(coh, num_attrs, (const char * const*)names,
+				(void * const*)buffers, sizes, NULL);
+	if (rc != 0) {
+		fprintf(stderr, "failed to get user attribute values "DF_RC,
+			DP_RC(rc));
+		rc = 1;
+		D_GOTO(out, rc);
+	}
+
+	/* Return values to the caller */
+	*_n = num_attrs;
+	*_names = names;
+	*_buffers = buffers;
+	*_sizes = sizes;
 out:
+	if (rc != 0) {
+		dm_cont_free_usr_attrs(num_attrs, &names, &buffers, &sizes);
+	}
+	D_FREE(name_buf);
+	return rc;
+}
+
+/* Copy all user attributes from one container to another.
+ * Returns 1 on error, 0 on success.
+ */
+int
+dm_copy_usr_attrs(daos_handle_t src_coh, daos_handle_t dst_coh)
+{
+	int	num_attrs = 0;
+	char	**names = NULL;
+	void	**buffers = NULL;
+	size_t	*sizes = NULL;
+	int	rc;
+
+	/* Get all user attributes */
+	rc = dm_cont_get_usr_attrs(src_coh, &num_attrs,
+				   &names, &buffers, &sizes);
+	if (rc != 0) {
+		rc = 1;
+		D_GOTO(out, rc);
+	}
+
+	if (num_attrs == 0) {
+		rc = 0;
+		D_GOTO(out, rc);
+	}
+	rc = daos_cont_set_attr(dst_coh, num_attrs, (char const * const*) names,
+				(void const * const*) buffers, sizes, NULL);
+
+	if (rc != 0) {
+		fprintf(stderr, "Failed to set user attrs: "DF_RC, DP_RC(rc));
+		rc = 1;
+		D_GOTO(out, rc);
+	}
+
+out:
+	dm_cont_free_usr_attrs(num_attrs, &names, &buffers, &sizes);
+	return rc;
+
+}
+
+/*
+ * Get the container properties for a container in a format similar
+ * to what daos_cont_set_prop expects.
+ * The last entry is the ACL and is conditionally set only if
+ * the user has permissions.
+ * The properties need to remain in the order expected by serialization.
+ * Returns 1 on error, 0 on success.
+ */
+int
+dm_cont_get_all_props(daos_handle_t coh, daos_prop_t **_props, bool get_oid)
+{
+	int		rc;
+	daos_prop_t	*props = NULL;
+	daos_prop_t	*prop_acl = NULL;
+	daos_prop_t	*props_merged = NULL;
+	uint32_t	num_props = 15;
+
+	if (get_oid) {
+		num_props++;
+	}
+
+	/* Allocate space for all props except ACL. */
+	props = daos_prop_alloc(num_props);
+	if (props == NULL) {
+		fprintf(stderr, "Failed to allocate container properties.");
+		rc = 1;
+		D_GOTO(out, rc);
+	}
+
+	/* The order of properties MUST match the order expected by
+	 * serialization
+	 */
+	props->dpp_entries[0].dpe_type = DAOS_PROP_CO_LABEL;
+	props->dpp_entries[1].dpe_type = DAOS_PROP_CO_LAYOUT_TYPE;
+	props->dpp_entries[2].dpe_type = DAOS_PROP_CO_LAYOUT_VER;
+	props->dpp_entries[3].dpe_type = DAOS_PROP_CO_CSUM;
+	props->dpp_entries[4].dpe_type = DAOS_PROP_CO_CSUM_CHUNK_SIZE;
+	props->dpp_entries[5].dpe_type = DAOS_PROP_CO_CSUM_SERVER_VERIFY;
+	props->dpp_entries[6].dpe_type = DAOS_PROP_CO_REDUN_FAC;
+	props->dpp_entries[7].dpe_type = DAOS_PROP_CO_REDUN_LVL;
+	props->dpp_entries[8].dpe_type = DAOS_PROP_CO_SNAPSHOT_MAX;
+	props->dpp_entries[9].dpe_type = DAOS_PROP_CO_COMPRESS;
+	props->dpp_entries[10].dpe_type = DAOS_PROP_CO_ENCRYPT;
+	props->dpp_entries[11].dpe_type = DAOS_PROP_CO_OWNER;
+	props->dpp_entries[12].dpe_type = DAOS_PROP_CO_OWNER_GROUP;
+	props->dpp_entries[13].dpe_type = DAOS_PROP_CO_DEDUP;
+	props->dpp_entries[14].dpe_type = DAOS_PROP_CO_DEDUP_THRESHOLD;
+
+	/* Conditionally get the OID.
+	 * Should always be true for serialization.
+	 */
+	if (get_oid) {
+		props->dpp_entries[15].dpe_type = DAOS_PROP_CO_ALLOCED_OID;
+	}
+
+	/* Get all props except ACL first. */
+	rc = daos_cont_query(coh, NULL, props, NULL);
+	if (rc != 0) {
+		fprintf(stderr, "Failed to query container: "DF_RC, DP_RC(rc));
+		rc = 1;
+		D_GOTO(out, rc);
+	}
+
+	/* Fetch the ACL separately in case user doesn't have access */
+	rc = daos_cont_get_acl(coh, &prop_acl, NULL);
+	if (rc == 0) {
+		/* ACL will be appended to the end */
+		props_merged = daos_prop_merge(props, prop_acl);
+		if (props_merged == NULL) {
+			fprintf(stderr, "Failed to set container ACL: "DF_RC,
+				DP_RC(rc));
+			rc = 1;
+			D_GOTO(out, rc);
+		}
+		daos_prop_free(props);
+		props = props_merged;
+	} else if (rc && rc != -DER_NO_PERM) {
+		fprintf(stderr, "Failed to query container ACL: "DF_RC,
+			DP_RC(rc));
+		rc = 1;
+		D_GOTO(out, rc);
+	}
+
+	rc = 0;
+	*_props = props;
+out:
+	daos_prop_free(prop_acl);
+	if (rc != 0) {
+		daos_prop_free(props);
+	}
+
+	return rc;
+}
+
+static int
+dm_serialize_metadata(struct dm_args *ca, daos_prop_t *props, char *preserve)
+{
+	int	rc = 0;
+	int	num_attrs = 0;
+	char	**names = NULL;
+	void	**buffers = NULL;
+	size_t	*sizes = NULL;
+	void	*handle;
+
+	int (*serialize_daos_metadata)(char *, daos_prop_t *props,
+				       daos_handle_t, int, char **,
+				       char **, size_t *);
+	/* Get all user attributes if any exist */
+	rc = dm_cont_get_usr_attrs(ca->src_coh, &num_attrs, &names,
+				   &buffers, &sizes);
+	if (rc != 0) {
+		rc = 1;
+		D_GOTO(out, rc);
+	}
+
+	handle = dlopen(LIBSERIALIZE, RTLD_NOW);
+	if (handle == NULL) {
+		rc = EINVAL;
+		D_GOTO(out, rc);
+	}
+	serialize_daos_metadata = dlsym(handle, "serialize_daos_metadata");
+	if (serialize_daos_metadata == NULL)  {
+		rc = EINVAL;
+		D_GOTO(out, rc);
+	}
+	(*serialize_daos_metadata)(preserve, props, ca->src_coh, num_attrs,
+				   names, (char **)buffers, sizes);
+out:
+	if (num_attrs > 0) {
+		dm_cont_free_usr_attrs(num_attrs, &names, &buffers, &sizes);
+	}
+	return rc;
+}
+
+static int
+dm_deserialize_cont_prop_metadata(struct dm_args *ca, char *preserve,
+				  daos_prop_t *props)
+{
+	int	rc = 0;
+	void	*handle;
+
+	int (*deserialize_daos_cont_prop_metadata)(char *,
+						   daos_prop_t *props,
+						   uint64_t *);
+	handle = dlopen(LIBSERIALIZE, RTLD_NOW);
+	if (handle == NULL) {
+		rc = EINVAL;
+		D_GOTO(out, rc);
+	}
+	deserialize_daos_cont_prop_metadata = dlsym(handle,
+						    "deserialize"
+						    "_daos_cont_prop_metadata");
+	if (deserialize_daos_cont_prop_metadata == NULL)  {
+		rc = EINVAL;
+		D_GOTO(out, rc);
+	}
+	(*deserialize_daos_cont_prop_metadata)(preserve, props,
+					       &ca->cont_layout);
+out:
+	return rc;
+}
+
+static int
+dm_deserialize_cont_attrs_metadata(struct dm_args *ca, char *preserve)
+{
+	int		rc = 0;
+	uint64_t	num_attrs = 0;
+	char		**names = NULL;
+	void		**buffers = NULL;
+	size_t		*sizes = NULL;
+	void		*handle;
+
+	int (*deserialize_daos_cont_attrs_metadata)(char *,
+						    uint64_t *,
+						    char ***,
+						    void ***,
+						    size_t **);
+	handle = dlopen(LIBSERIALIZE, RTLD_NOW);
+	if (handle == NULL) {
+		rc = EINVAL;
+		D_GOTO(out, rc);
+	}
+	deserialize_daos_cont_attrs_metadata = dlsym(handle,
+						     "deserialize_daos_cont_"
+						     "attrs_metadata");
+	if (deserialize_daos_cont_attrs_metadata == NULL)  {
+		rc = EINVAL;
+		D_GOTO(out, rc);
+	}
+	(*deserialize_daos_cont_attrs_metadata)(preserve, &num_attrs,
+						&names, &buffers, &sizes);
+
+	rc = daos_cont_set_attr(ca->dst_coh, num_attrs,
+				(const char * const*) names,
+				(const void * const*) buffers,
+				sizes, NULL);
+	if (rc != 0) {
+		fprintf(stderr, "failed to set user attributes "DF_RC,
+			DP_RC(rc));
+		rc = 1;
+		goto out;
+	}
+out:
+	dm_cont_free_usr_attrs(num_attrs, &names, &buffers, &sizes);
 	return rc;
 }
 
@@ -2695,6 +3077,7 @@ dm_connect(bool is_posix_copy,
 	   struct dm_args *ca,
 	   char *sysname,
 	   char *path,
+	   char *preserve,
 	   daos_cont_info_t *src_cont_info,
 	   daos_cont_info_t *dst_cont_info)
 {
@@ -2702,10 +3085,7 @@ dm_connect(bool is_posix_copy,
 	int			rc = 0;
 	struct duns_attr_t	dattr = {0};
 	daos_prop_t		*props = NULL;
-	dfs_attr_t		attr = {0};
-	int			size = 2;
-	uint32_t		dpe_types[size];
-	uint64_t		dpe_vals[size];
+	dfs_attr_t		attr;
 
 	/* open src pool, src cont, and mount dfs */
 	if (src_file_dfs->type == DAOS) {
@@ -2734,51 +3114,46 @@ dm_connect(bool is_posix_copy,
 		}
 	}
 
-	/* only need to query if source is not POSIX, since
-	 * this connect call is used by the filesystem and clone
-	 * tools
-	 */
+	/* Retrieve all source cont properties */
 	if (src_file_dfs->type != POSIX) {
-		/* Need to query source max oid for non-POSIX source
-		 * containers, and the cont type to see if the source
-		 * container is POSIX, and if it is then use dfs_cont_create
-		 * to create the destination container
-		 */
-		dpe_types[0] = ca->cont_prop_layout;
-		dpe_types[1] = ca->cont_prop_oid;
-
-		/* This will be extended to get all props
-		 * from the source container and then
-		 * set them in the destination when
-		 * the --preserve option is added
-		 */
-		rc = dm_get_cont_prop(ca->src_coh, sysname, src_cont_info, size,
-				      dpe_types, dpe_vals);
-		if (rc != 0) {
-			fprintf(stderr, "failed to query source "
-				"container: %d\n", rc);
-			D_GOTO(err_src, rc);
+		/* if using DFS do not retrieve the MAX OID property */
+		if (is_posix_copy) {
+			rc = dm_cont_get_all_props(ca->src_coh, &props, false);
+		} else {
+			rc = dm_cont_get_all_props(ca->src_coh, &props, true);
 		}
-
-		ca->cont_layout = dpe_vals[0];
-		ca->cont_oid = dpe_vals[1];
-
-		if (!is_posix_copy) {
-			props = daos_prop_alloc(2);
-			if (props == NULL) {
-				fprintf(stderr, "Failed to allocate prop\n");
-				D_GOTO(out, rc = -DER_NOMEM);
+		if (rc != 0) {
+			fprintf(stderr, "Failed to set container ACL: "DF_RC,
+				DP_RC(rc));
+			D_GOTO(out, rc);
+		}
+		ca->cont_layout = props->dpp_entries[1].dpe_type;
+		if (preserve != NULL && dst_file_dfs->type == POSIX) {
+			rc = dm_serialize_metadata(ca, props, preserve);
+			if (rc != 0) {
+				fprintf(stderr, "Failed to serialize metadata: "
+					""DF_RC, DP_RC(rc));
+				D_GOTO(out, rc);
 			}
-			props->dpp_entries[0].dpe_type = ca->cont_prop_layout;
-			props->dpp_entries[0].dpe_val = ca->cont_layout;
-
-			props->dpp_entries[1].dpe_type = ca->cont_prop_oid;
-			props->dpp_entries[1].dpe_val = ca->cont_oid;
 		}
 	}
 
 	/* open dst pool, dst cont, and mount dfs */
 	if (dst_file_dfs->type == DAOS) {
+		/* check preserve, if source is from POSIX and destination is
+		 * DAOS we need to read container properties from the file that
+		 * is specified before the DAOS destination container is created
+		 */
+		if (preserve != NULL && src_file_dfs->type == POSIX) {
+			rc = dm_deserialize_cont_prop_metadata(ca, preserve,
+							       props);
+			if (rc != 0) {
+				fprintf(stderr, "Failed to deserialize "
+					"metadata: "DF_RC, DP_RC(rc));
+				D_GOTO(out, rc);
+			}
+		}
+
 		/* only connect if destination pool wasn't already opened */
 		if (!uuid_is_null(ca->dst_p_uuid)) {
 			if (!daos_handle_is_valid(ca->dst_poh)) {
@@ -2829,6 +3204,7 @@ dm_connect(bool is_posix_copy,
 				    dst_cont_info, NULL);
 		if (rc == -DER_NONEXIST) {
 			if (ca->cont_layout == DAOS_PROP_CO_LAYOUT_POSIX) {
+				attr.da_props = props;
 				rc = dfs_cont_create(ca->dst_poh,
 						     ca->dst_c_uuid,
 						     &attr, NULL, NULL);
@@ -2876,6 +3252,33 @@ dm_connect(bool is_posix_copy,
 				D_GOTO(err_dst, rc);
 			}
 		}
+
+		/* check preserve, if source is from POSIX and destination is
+		 * DAOS we need to read user attributes from the file that
+		 * is specified, and set them in the destination container
+		 */
+		if (preserve != NULL && src_file_dfs->type == POSIX) {
+			rc = dm_deserialize_cont_attrs_metadata(ca, preserve);
+			if (rc != 0) {
+				fprintf(stderr, "Failed to deserialize "
+					"metadata: "DF_RC, DP_RC(rc));
+				D_GOTO(out, rc);
+			}
+		}
+
+	}
+
+	/* get source container user attributes and copy them to the
+	 * DAOS destination container
+	 */
+	if (src_file_dfs->type == DAOS && dst_file_dfs->type == DAOS) {
+		rc = dm_copy_usr_attrs(ca->src_coh, ca->dst_coh);
+		if (rc != 0) {
+			fprintf(stderr, "copying user attributes "
+				"failed: %d\n", rc);
+				D_GOTO(err_dst, rc);
+		}
+
 	}
 	D_GOTO(out, rc);
 err_dst:
@@ -3079,7 +3482,8 @@ fs_copy_hdlr(struct cmd_args_s *ap)
 		uuid_generate(ca.dst_c_uuid);
 	}
 	rc = dm_connect(is_posix_copy, &src_file_dfs, &dst_file_dfs, &ca,
-			ap->sysname, ap->dst, &src_cont_info, &dst_cont_info);
+			ap->sysname, ap->dst, ap->preserve, &src_cont_info,
+			&dst_cont_info);
 	if (rc != 0) {
 		fprintf(stderr, "fs copy failed to connect: %d\n", rc);
 		D_GOTO(out, rc = daos_errno2der(rc));
@@ -3577,7 +3981,7 @@ cont_clone_hdlr(struct cmd_args_s *ap)
 	}
 
 	rc = dm_connect(is_posix_copy, &dst_cp_type, &src_cp_type,
-			&ca, ap->sysname, ap->dst, &src_cont_info,
+			&ca, ap->sysname, ap->dst, ap->preserve, &src_cont_info,
 			&dst_cont_info);
 	if (rc != 0) {
 		D_GOTO(out_disconnect, rc);

--- a/src/utils/daos_hdlr.h
+++ b/src/utils/daos_hdlr.h
@@ -82,6 +82,7 @@ struct cmd_args_s {
 	char			*path;		/* --path cont namespace */
 	char			*src;		/* --src path for fs copy */
 	char			*dst;		/* --dst path for fs copy */
+	char			*preserve;	/* --path to metadata file */
 	daos_cont_layout_t	type;		/* --type cont type */
 	daos_oclass_id_t	oclass;		/* --oclass object class */
 	daos_size_t		chunk_size;	/* --chunk_size of cont objs */
@@ -174,6 +175,15 @@ int pool_autotest_hdlr(struct cmd_args_s *ap);
 /* TODO: implement these pool op functions
  * int pool_stat_hdlr(struct cmd_args_s *ap);
  */
+
+/* general datamover operations */
+void dm_cont_free_usr_attrs(int n, char ***_names, void ***_buffers,
+			    size_t **_sizes);
+int dm_cont_get_usr_attrs(daos_handle_t coh, int *_n, char ***_names,
+			  void ***_buffers, size_t **_sizes);
+int dm_cont_get_all_props(daos_handle_t coh, daos_prop_t **_props,
+			  bool get_oid);
+int dm_copy_usr_attrs(daos_handle_t src_coh, daos_handle_t dst_coh);
 
 /* filesystem operations */
 int fs_copy_hdlr(struct cmd_args_s *ap);

--- a/src/utils/hdf-serialize.c
+++ b/src/utils/hdf-serialize.c
@@ -1,0 +1,1033 @@
+#include <stdio.h>
+#include <hdf5.h>
+#include <daos.h>
+#include <daos_cont.h>
+
+/* for user attr dataset */
+typedef struct {
+    char *attr_name;
+    hvl_t attr_val;
+} usr_attr_t;
+
+static int
+cont_serialize_prop_acl(hid_t *file_id, struct daos_prop_entry *entry,
+			const char *prop_str)
+{
+
+	int		rc = 0;
+	hid_t		status = 0;
+	struct daos_acl	*acl = NULL;
+	char		**acl_strs = NULL;
+	size_t		len_acl = 0;
+	hsize_t		attr_dims[1];
+	hid_t		attr_dtype;
+	hid_t		attr_dspace;
+	hid_t		usr_attr;
+
+
+	if (!entry || !entry->dpe_val_ptr) {
+		goto out;
+	}
+
+	/* convert acl to list of strings */
+	acl = (struct daos_acl *)entry->dpe_val_ptr;
+	rc = daos_acl_to_strs(acl, &acl_strs, &len_acl);
+	if (rc != 0) {
+		fprintf(stderr, "failed to convert acl to strs");
+		goto out;
+	}
+	attr_dims[0] = len_acl;
+	attr_dtype = H5Tcopy(H5T_C_S1);
+	if (attr_dtype < 0) {
+		fprintf(stderr, "failed to create acl type");
+		rc = 1;
+		goto out;
+	}
+	status = H5Tset_size(attr_dtype, H5T_VARIABLE);
+	if (status < 0) {
+		fprintf(stderr, "failed to set acl dtype size");
+		rc = 1;
+		goto out;
+	}
+	attr_dspace = H5Screate_simple(1, attr_dims, NULL);
+	if (attr_dspace < 0) {
+		fprintf(stderr, "failed to create version attribute");
+		rc = 1;
+		goto out;
+	}
+	usr_attr = H5Acreate2(*file_id, prop_str, attr_dtype, attr_dspace,
+			      H5P_DEFAULT, H5P_DEFAULT);
+	if (usr_attr < 0) {
+		fprintf(stderr, "failed to create attribute");
+		rc = 1;
+		goto out;
+	}
+	status = H5Awrite(usr_attr, attr_dtype, acl_strs);
+	if (status < 0) {
+		fprintf(stderr, "failed to write attribute");
+		rc = 1;
+		goto out;
+	}
+	status = H5Aclose(usr_attr);
+	if (status < 0) {
+		fprintf(stderr, "failed to close attribute");
+		rc = 1;
+		goto out;
+	}
+	status = H5Tclose(attr_dtype);
+	if (status < 0) {
+		fprintf(stderr, "failed to close dtype");
+		rc = 1;
+		goto out;
+	}
+	status = H5Sclose(attr_dspace);
+	if (status < 0) {
+		fprintf(stderr, "failed to close dspace");
+		rc = 1;
+		goto out;
+	}
+out:
+	return rc;
+}
+
+static int
+cont_serialize_prop_str(hid_t *file_id, struct daos_prop_entry *entry,
+			const char *prop_str)
+{
+
+	int	rc = 0;
+	hid_t	status = 0;
+	hsize_t	attr_dims[1];
+	hid_t	attr_dtype;
+	hid_t	attr_dspace;
+	hid_t	usr_attr;
+
+	if (entry == NULL || entry->dpe_str == NULL) {
+		fprintf(stderr, "Property %s not found", prop_str);
+		rc = 1;
+		goto out;
+	}
+
+	attr_dims[0] = 1;
+	attr_dtype = H5Tcopy(H5T_C_S1);
+	if (attr_dtype < 0) {
+		fprintf(stderr, "failed to create usr attr type");
+		rc = 1;
+		goto out;
+	}
+	status = H5Tset_size(attr_dtype, strlen(entry->dpe_str) + 1);
+	if (status < 0) {
+		fprintf(stderr, "failed to set dtype size");
+		rc = 1;
+		goto out;
+	}
+	status = H5Tset_strpad(attr_dtype, H5T_STR_NULLTERM);
+	if (status < 0) {
+		fprintf(stderr, "failed to set null terminator");
+		rc = 1;
+		goto out;
+	}
+	attr_dspace = H5Screate_simple(1, attr_dims, NULL);
+	if (attr_dspace < 0) {
+		fprintf(stderr, "failed to create version attribute dataspace");
+		rc = 1;
+		goto out;
+	}
+
+	usr_attr = H5Acreate2(*file_id, prop_str, attr_dtype, attr_dspace,
+			      H5P_DEFAULT, H5P_DEFAULT);
+	if (usr_attr < 0) {
+		fprintf(stderr, "failed to create attribute");
+		rc = 1;
+		goto out;
+	}
+	status = H5Awrite(usr_attr, attr_dtype, entry->dpe_str);
+	if (status < 0) {
+		fprintf(stderr, "failed to write attribute");
+		rc = 1;
+		goto out;
+	}
+	status = H5Aclose(usr_attr);
+	if (status < 0) {
+		fprintf(stderr, "failed to close attribute");
+		rc = 1;
+		goto out;
+	}
+	status = H5Tclose(attr_dtype);
+	if (status < 0) {
+		fprintf(stderr, "failed to close dtype");
+		rc = 1;
+		goto out;
+	}
+	status = H5Sclose(attr_dspace);
+	if (status < 0) {
+		fprintf(stderr, "failed to close dspace");
+		rc = 1;
+		goto out;
+	}
+out:
+	return rc;
+}
+
+static int
+cont_serialize_prop_uint(hid_t *file_id,
+			 struct daos_prop_entry *entry,
+			 const char *prop_str)
+{
+	int	rc = 0;
+	hid_t	status = 0;
+	hsize_t	attr_dims[1];
+	hid_t	attr_dtype;
+	hid_t	attr_dspace;
+	hid_t	usr_attr;
+
+
+	attr_dims[0] = 1;
+	attr_dtype = H5Tcopy(H5T_NATIVE_UINT64);
+	status = H5Tset_size(attr_dtype, 8);
+	if (status < 0) {
+		fprintf(stderr, "failed to create version dtype");
+		rc = 1;
+		goto out;
+	}
+	if (attr_dtype < 0) {
+		fprintf(stderr, "failed to create usr attr type");
+		rc = 1;
+		goto out;
+	}
+	attr_dspace = H5Screate_simple(1, attr_dims, NULL);
+	if (attr_dspace < 0) {
+		fprintf(stderr, "failed to create version attr dspace");
+		rc = 1;
+		goto out;
+	}
+	usr_attr = H5Acreate2(*file_id, prop_str, attr_dtype,
+			      attr_dspace, H5P_DEFAULT, H5P_DEFAULT);
+	if (usr_attr < 0) {
+		fprintf(stderr, "failed to create attr");
+		rc = 1;
+		goto out;
+	}
+	status = H5Awrite(usr_attr, attr_dtype, &entry->dpe_val);
+	if (status < 0) {
+		fprintf(stderr, "failed to write attr");
+		rc = 1;
+		goto out;
+	}
+	status = H5Aclose(usr_attr);
+	if (status < 0) {
+		fprintf(stderr, "failed to close attr");
+		rc = 1;
+		goto out;
+	}
+	status = H5Tclose(attr_dtype);
+	if (status < 0) {
+		fprintf(stderr, "failed to close dtype");
+		rc = 1;
+		goto out;
+	}
+	status = H5Sclose(attr_dspace);
+	if (status < 0) {
+		fprintf(stderr, "failed to close dspace");
+		rc = 1;
+		goto out;
+	}
+out:
+	return rc;
+}
+
+static int
+cont_serialize_props(hid_t *file_id, daos_prop_t *prop_query,
+		     daos_handle_t cont)
+{
+	int			rc = 0;
+	struct daos_prop_entry	*entry;
+
+	entry = &prop_query->dpp_entries[0];
+	rc = cont_serialize_prop_str(file_id, entry, "DAOS_PROP_CO_LABEL");
+	if (rc != 0) {
+		goto out;
+	}
+
+	entry = &prop_query->dpp_entries[1];
+	rc = cont_serialize_prop_uint(file_id, entry,
+				      "DAOS_PROP_CO_LAYOUT_TYPE");
+	if (rc != 0) {
+		goto out;
+	}
+
+	entry = &prop_query->dpp_entries[2];
+	rc = cont_serialize_prop_uint(file_id, entry,
+				      "DAOS_PROP_CO_LAYOUT_VER");
+	if (rc != 0) {
+		goto out;
+	}
+
+	entry = &prop_query->dpp_entries[3];
+	rc = cont_serialize_prop_uint(file_id, entry, "DAOS_PROP_CO_CSUM");
+	if (rc != 0) {
+		goto out;
+	}
+
+	entry = &prop_query->dpp_entries[4];
+	rc = cont_serialize_prop_uint(file_id, entry,
+				      "DAOS_PROP_CO_CSUM_CHUNK_SIZE");
+	if (rc != 0) {
+		goto out;
+	}
+
+	entry = &prop_query->dpp_entries[5];
+	rc = cont_serialize_prop_uint(file_id, entry,
+				      "DAOS_PROP_CO_CSUM_SERVER_VERIFY");
+	if (rc != 0) {
+		goto out;
+	}
+
+	entry = &prop_query->dpp_entries[6];
+	rc = cont_serialize_prop_uint(file_id, entry, "DAOS_PROP_CO_REDUN_FAC");
+	if (rc != 0) {
+		goto out;
+	}
+
+	entry = &prop_query->dpp_entries[7];
+	rc = cont_serialize_prop_uint(file_id, entry, "DAOS_PROP_CO_REDUN_LVL");
+	if (rc != 0) {
+		goto out;
+	}
+
+	entry = &prop_query->dpp_entries[8];
+	rc = cont_serialize_prop_uint(file_id, entry,
+				      "DAOS_PROP_CO_SNAPSHOT_MAX");
+	if (rc != 0) {
+		goto out;
+	}
+
+	entry = &prop_query->dpp_entries[9];
+	rc = cont_serialize_prop_uint(file_id, entry, "DAOS_PROP_CO_COMPRESS");
+	if (rc != 0) {
+		goto out;
+	}
+
+	entry = &prop_query->dpp_entries[10];
+	rc = cont_serialize_prop_uint(file_id, entry, "DAOS_PROP_CO_ENCRYPT");
+	if (rc != 0) {
+		goto out;
+	}
+
+	entry = &prop_query->dpp_entries[11];
+	rc = cont_serialize_prop_str(file_id, entry, "DAOS_PROP_CO_OWNER");
+	if (rc != 0) {
+		goto out;
+	}
+
+	entry = &prop_query->dpp_entries[12];
+	rc = cont_serialize_prop_str(file_id, entry,
+				     "DAOS_PROP_CO_OWNER_GROUP");
+	if (rc != 0) {
+		goto out;
+	}
+
+	entry = &prop_query->dpp_entries[13];
+	rc = cont_serialize_prop_uint(file_id, entry, "DAOS_PROP_CO_DEDUP");
+	if (rc != 0) {
+		goto out;
+	}
+
+	entry = &prop_query->dpp_entries[14];
+	rc = cont_serialize_prop_uint(file_id, entry,
+				      "DAOS_PROP_CO_DEDUP_THRESHOLD");
+	if (rc != 0) {
+		goto out;
+	}
+
+	entry = &prop_query->dpp_entries[15];
+	rc = cont_serialize_prop_uint(file_id, entry,
+				      "DAOS_PROP_CO_ALLOCED_OID");
+	if (rc != 0) {
+		goto out;
+	}
+
+	/* serialize ACL */
+	if (prop_query->dpp_nr > 16) {
+		entry = &prop_query->dpp_entries[16];
+		rc = cont_serialize_prop_acl(file_id, entry,
+					     "DAOS_PROP_CO_ACL");
+		if (rc != 0) {
+			goto out;
+		}
+	}
+
+out:
+	return rc;
+}
+
+int
+cont_serialize_usr_attrs(hid_t *file_id, hid_t *usr_attr_memtype, int num_attrs,
+			 char **names, char **buffers, size_t *sizes,
+			 daos_handle_t coh)
+{
+	int		rc = 0;
+	hid_t		status = 0;
+	hid_t		dset = 0;
+	hid_t		dspace = 0;
+	hsize_t		dims[1];
+	usr_attr_t	*attr_data = NULL;
+	int		i;
+
+	if (num_attrs == 0) {
+		goto out_no_attrs;
+	}
+
+	/* Create the user attribute data space */
+	dims[0] = num_attrs;
+	dspace = H5Screate_simple(1, dims, NULL);
+	if (dspace < 0) {
+		fprintf(stderr, "failed to create user attr dspace");
+		rc = 1;
+		goto out;
+	}
+
+	/* Create the user attribute dataset */
+	dset = H5Dcreate(*file_id, "User Attributes",
+			 *usr_attr_memtype, dspace,
+			 H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+	if (dset < 0) {
+		fprintf(stderr, "failed to create user attribute dset");
+		rc = 1;
+		goto out;
+	}
+
+	/* Allocate space for all attributes */
+	attr_data = calloc(num_attrs, sizeof(usr_attr_t));
+	if (attr_data == NULL) {
+		fprintf(stderr, "failed to allocate user attributes");
+		rc = 1;
+		goto out;
+	}
+
+	/* Set the data for all attributes */
+	for (i = 0; i < num_attrs; i++) {
+		attr_data[i].attr_name = names[i];
+		attr_data[i].attr_val.p = buffers[i];
+		attr_data[i].attr_val.len = sizes[i];
+	}
+
+	status = H5Dwrite(dset, *usr_attr_memtype, H5S_ALL,
+			  H5S_ALL, H5P_DEFAULT, attr_data);
+	if (status < 0) {
+		fprintf(stderr, "failed to write user attr dset");
+		rc = 1;
+		goto out;
+	}
+
+out:
+	free(attr_data);
+	H5Dclose(dset);
+	H5Tclose(*usr_attr_memtype);
+	H5Sclose(dspace);
+out_no_attrs:
+	return rc;
+}
+
+int
+serialize_daos_metadata(char *filename, daos_prop_t *props,
+			daos_handle_t coh, int num_attrs,
+			char **names, char **buffers, size_t *sizes)
+{
+	int	rc = 0;
+	hid_t	status;
+	hid_t	file_id;
+	hid_t	usr_attr_memtype;
+	hid_t	usr_attr_name_vtype;
+	hid_t	usr_attr_val_vtype;
+
+	fprintf(stderr, "Writing metadata file: %s\n", filename);
+
+	file_id = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
+	if (file_id < 0) {
+		rc = 1;
+		fprintf(stderr, "failed to create hdf5 file");
+		goto out;
+	}
+	rc = cont_serialize_props(&file_id, props, coh);
+	if (rc != 0) {
+		fprintf(stderr, "failed to serialize cont layout: "DF_RC,
+			DP_RC(rc));
+		goto out;
+	}
+
+	/* serialize usr_attrs if there are any */
+	if (num_attrs > 0) {
+		/* create User Attributes Dataset in daos_metadata file */
+		usr_attr_memtype = H5Tcreate(H5T_COMPOUND, sizeof(usr_attr_t));
+		if (usr_attr_memtype < 0) {
+			rc = 1;
+			fprintf(stderr, "failed to create user attr memtype");
+			goto out;
+		}
+
+		usr_attr_name_vtype = H5Tcopy(H5T_C_S1);
+		if (usr_attr_name_vtype < 0) {
+			rc = 1;
+			fprintf(stderr, "failed to create user attr name "
+				"vtype");
+			goto out;
+		}
+		status = H5Tset_size(usr_attr_name_vtype, H5T_VARIABLE);
+		if (status < 0) {
+			rc = 1;
+			fprintf(stderr, "failed to create user attr name "
+				"vtype");
+			goto out;
+		}
+		usr_attr_val_vtype = H5Tvlen_create(H5T_NATIVE_OPAQUE);
+		if (usr_attr_val_vtype < 0) {
+			rc = 1;
+			fprintf(stderr, "failed to create user attr val vtype");
+			goto out;
+		}
+		status = H5Tinsert(usr_attr_memtype, "Attribute Name",
+				   HOFFSET(usr_attr_t, attr_name),
+				   usr_attr_name_vtype);
+		if (status < 0) {
+			rc = 1;
+			fprintf(stderr, "failed to insert user attr name");
+			goto out;
+		}
+		status = H5Tinsert(usr_attr_memtype, "Attribute Value",
+				   HOFFSET(usr_attr_t, attr_val),
+				   usr_attr_val_vtype);
+		if (status < 0) {
+			rc = 1;
+			fprintf(stderr, "failed to insert user attr val");
+			goto out;
+		}
+		rc = cont_serialize_usr_attrs(&file_id, &usr_attr_memtype,
+					      num_attrs, names, buffers,
+					      sizes, coh);
+		if (rc != 0) {
+			fprintf(stderr, "failed to serialize usr attributes: "
+				""DF_RC, DP_RC(rc));
+			goto out;
+		}
+
+		status = H5Tclose(usr_attr_name_vtype);
+		if (status < 0) {
+			rc = 1;
+			fprintf(stderr, "failed to close user attr name "
+				"datatype");
+		}
+		status = H5Tclose(usr_attr_val_vtype);
+		if (status < 0) {
+			rc = 1;
+			fprintf(stderr, "failed to close user attr value "
+				"datatype");
+		}
+	}
+out:
+	H5Fclose(file_id);
+	return rc;
+}
+
+static int
+cont_deserialize_prop_str(hid_t *file_id, struct daos_prop_entry *entry,
+			  const char *prop_str)
+{
+	hid_t	status = 0;
+	int	rc = 0;
+	hid_t	attr_dtype;
+	hid_t	cont_attr;
+	size_t	buf_size;
+
+	cont_attr = H5Aopen(*file_id, prop_str, H5P_DEFAULT);
+	if (cont_attr < 0) {
+		fprintf(stderr, "failed to open property attribute %s",
+			prop_str);
+		rc = 1;
+		goto out;
+	}
+	attr_dtype = H5Aget_type(cont_attr);
+	if (attr_dtype < 0) {
+		fprintf(stderr, "failed to open property attribute type %s",
+			prop_str);
+		rc = 1;
+		goto out;
+	}
+	buf_size = H5Tget_size(attr_dtype);
+	if (buf_size <= 0) {
+		fprintf(stderr, "failed to get size for property attribute %s",
+			prop_str);
+		rc = 1;
+		goto out;
+	}
+	entry->dpe_str = calloc(1, buf_size);
+	if (entry->dpe_str == NULL) {
+		fprintf(stderr, "failed to allocate property attribute %s",
+			prop_str);
+		rc = 1;
+		goto out;
+	}
+	status = H5Aread(cont_attr, attr_dtype, entry->dpe_str);
+	if (status < 0) {
+		fprintf(stderr, "failed to read property attribute %s",
+			prop_str);
+		rc = 1;
+		goto out;
+	}
+	status = H5Aclose(cont_attr);
+	if (status < 0) {
+		fprintf(stderr, "failed to close property attribute %s",
+			prop_str);
+		rc = 1;
+		goto out;
+	}
+	status = H5Tclose(attr_dtype);
+	if (status < 0) {
+		fprintf(stderr, "failed to close attribute datatype");
+		rc = 1;
+		goto out;
+	}
+out:
+	return rc;
+}
+
+static int
+cont_deserialize_prop_uint(hid_t *file_id, struct daos_prop_entry *entry,
+			   const char *prop_str)
+{
+	hid_t   status = 0;
+	int     rc = 0;
+	hid_t   cont_attr;
+	hid_t   attr_dtype;
+
+	cont_attr = H5Aopen(*file_id, prop_str, H5P_DEFAULT);
+	if (cont_attr < 0) {
+		fprintf(stderr, "failed to open property attribute %s",
+			prop_str);
+		rc = 1;
+		goto out;
+	}
+	attr_dtype = H5Aget_type(cont_attr);
+	if (attr_dtype < 0) {
+		fprintf(stderr, "failed to open property attribute type %s",
+			prop_str);
+		rc = 1;
+		goto out;
+	}
+	status = H5Aread(cont_attr, attr_dtype, &entry->dpe_val);
+	if (status < 0) {
+		fprintf(stderr, "failed to read property attribute %s",
+			prop_str);
+		rc = 1;
+		goto out;
+	}
+	status = H5Aclose(cont_attr);
+	if (status < 0) {
+		fprintf(stderr, "failed to close property attribute %s",
+			prop_str);
+		rc = 1;
+		goto out;
+	}
+	status = H5Tclose(attr_dtype);
+	if (status < 0) {
+		fprintf(stderr, "failed to close attribute datatype: %s",
+			prop_str);
+		rc = 1;
+		goto out;
+	}
+out:
+	return rc;
+}
+
+static int
+cont_deserialize_prop_acl(hid_t *file_id, struct daos_prop_entry *entry,
+			  const char *prop_str)
+{
+	hid_t		status = 0;
+	int		rc = 0;
+	int		ndims = 0;
+	const char      **rdata = NULL;
+	struct daos_acl	*acl;
+	htri_t		acl_exist;
+	hid_t		cont_attr;
+	hid_t		attr_dtype;
+	hid_t		attr_dspace;
+	hsize_t		attr_dims[1];
+
+	/* First check if the ACL * attribute exists. */
+	acl_exist = H5Aexists(*file_id, prop_str);
+	if (acl_exist < 0) {
+		/* Actual error  */
+		fprintf(stderr, "failed to open property attribute type %s",
+			prop_str);
+		rc = 1;
+		goto out;
+	} else if (acl_exist == 0) {
+		/* Does not exist, but that's okay. */
+		rc = 0;
+		goto out;
+	}
+
+	cont_attr = H5Aopen(*file_id, prop_str, H5P_DEFAULT);
+	if (cont_attr < 0) {
+		/* Could not open, but that's okay. */
+		rc = 0;
+		goto out;
+	}
+	attr_dtype = H5Aget_type(cont_attr);
+	if (attr_dtype < 0) {
+		fprintf(stderr, "failed to open property attribute type %s",
+			prop_str);
+		rc = 1;
+		goto out;
+	}
+	attr_dspace = H5Aget_space(cont_attr);
+	if (status < 0) {
+		fprintf(stderr, "failed to read acl dspace");
+		rc = 1;
+		goto out;
+	}
+	ndims = H5Sget_simple_extent_dims(attr_dspace, attr_dims, NULL);
+	if (ndims < 0) {
+		fprintf(stderr, "failed to get dimensions of dspace");
+		rc = 1;
+		goto out;
+	}
+	rdata = calloc(attr_dims[0], sizeof(char *));
+	if (rdata == NULL) {
+		rc = ENOMEM;
+		goto out;
+	}
+	attr_dtype = H5Tcopy(H5T_C_S1);
+	if (status < 0) {
+		fprintf(stderr, "failed to create dtype");
+		rc = 1;
+		goto out;
+	}
+	status = H5Tset_size(attr_dtype, H5T_VARIABLE);
+	if (status < 0) {
+		fprintf(stderr, "failed to set acl dtype size");
+		rc = 1;
+		goto out;
+	}
+	status = H5Aread(cont_attr, attr_dtype, rdata);
+	if (status < 0) {
+		fprintf(stderr, "failed to read property attribute %s",
+			prop_str);
+		rc = 1;
+		goto out;
+	}
+	/* convert acl strings back to struct acl, then store in entry */
+	rc = daos_acl_from_strs(rdata, (size_t)attr_dims[0], &acl);
+	if (rc != 0) {
+		fprintf(stderr, "failed to convert acl strs");
+		goto out;
+	}
+	entry->dpe_val_ptr = (void *)acl;
+	status = H5Aclose(cont_attr);
+	if (status < 0) {
+		fprintf(stderr, "failed to close property attribute %s",
+			prop_str);
+		rc = 1;
+		goto out;
+	}
+	status = H5Tclose(attr_dtype);
+	if (status < 0) {
+		fprintf(stderr, "failed to close attribute datatype");
+		rc = 1;
+		goto out;
+	}
+	status = H5Sclose(attr_dspace);
+	if (status < 0) {
+		fprintf(stderr, "failed to close attribute dataspace");
+		rc = 1;
+		goto out;
+	}
+out:
+	free(rdata);
+	return rc;
+}
+
+static int
+cont_deserialize_all_props(hid_t *file_id, daos_prop_t *prop,
+			   uint64_t *cont_type)
+{
+
+	int			rc = 0;
+	struct daos_prop_entry	*entry;
+
+	prop = daos_prop_alloc(17);
+	if (prop == NULL) {
+		return ENOMEM;
+	}
+
+	prop->dpp_entries[0].dpe_type = DAOS_PROP_CO_LABEL;
+	prop->dpp_entries[1].dpe_type = DAOS_PROP_CO_LAYOUT_TYPE;
+	prop->dpp_entries[2].dpe_type = DAOS_PROP_CO_LAYOUT_VER;
+	prop->dpp_entries[3].dpe_type = DAOS_PROP_CO_CSUM;
+	prop->dpp_entries[4].dpe_type = DAOS_PROP_CO_CSUM_CHUNK_SIZE;
+	prop->dpp_entries[5].dpe_type = DAOS_PROP_CO_CSUM_SERVER_VERIFY;
+	prop->dpp_entries[6].dpe_type = DAOS_PROP_CO_REDUN_FAC;
+	prop->dpp_entries[7].dpe_type = DAOS_PROP_CO_REDUN_LVL;
+	prop->dpp_entries[8].dpe_type = DAOS_PROP_CO_SNAPSHOT_MAX;
+	prop->dpp_entries[9].dpe_type = DAOS_PROP_CO_COMPRESS;
+	prop->dpp_entries[10].dpe_type = DAOS_PROP_CO_ENCRYPT;
+	prop->dpp_entries[11].dpe_type = DAOS_PROP_CO_OWNER;
+	prop->dpp_entries[12].dpe_type = DAOS_PROP_CO_OWNER_GROUP;
+	prop->dpp_entries[13].dpe_type = DAOS_PROP_CO_DEDUP;
+	prop->dpp_entries[14].dpe_type = DAOS_PROP_CO_DEDUP_THRESHOLD;
+	prop->dpp_entries[15].dpe_type = DAOS_PROP_CO_ALLOCED_OID;
+	prop->dpp_entries[16].dpe_type = DAOS_PROP_CO_ACL;
+
+	entry = &prop->dpp_entries[0];
+	rc = cont_deserialize_prop_str(file_id, entry, "DAOS_PROP_CO_LABEL");
+	if (rc != 0) {
+		goto out;
+	}
+	entry = &prop->dpp_entries[1];
+	rc = cont_deserialize_prop_uint(file_id, entry,
+					"DAOS_PROP_CO_LAYOUT_TYPE");
+	if (rc != 0) {
+		goto out;
+	}
+	entry = &prop->dpp_entries[2];
+	rc = cont_deserialize_prop_uint(file_id, entry,
+					"DAOS_PROP_CO_LAYOUT_VER");
+	if (rc != 0) {
+		goto out;
+	}
+	entry = &prop->dpp_entries[3];
+	rc = cont_deserialize_prop_uint(file_id, entry, "DAOS_PROP_CO_CSUM");
+	if (rc != 0) {
+		goto out;
+	}
+	entry = &prop->dpp_entries[4];
+	rc = cont_deserialize_prop_uint(file_id, entry,
+					"DAOS_PROP_CO_CSUM_CHUNK_SIZE");
+	if (rc != 0) {
+		goto out;
+	}
+	entry = &prop->dpp_entries[5];
+	rc = cont_deserialize_prop_uint(file_id, entry,
+					"DAOS_PROP_CO_CSUM_SERVER_VERIFY");
+	if (rc != 0) {
+		goto out;
+	}
+	entry = &prop->dpp_entries[6];
+	rc = cont_deserialize_prop_uint(file_id, entry,
+					"DAOS_PROP_CO_REDUN_FAC");
+	if (rc != 0) {
+		goto out;
+	}
+	entry = &prop->dpp_entries[7];
+	rc = cont_deserialize_prop_uint(file_id, entry,
+					"DAOS_PROP_CO_REDUN_LVL");
+	if (rc != 0) {
+		goto out;
+	}
+	entry = &prop->dpp_entries[8];
+	rc = cont_deserialize_prop_uint(file_id, entry,
+					"DAOS_PROP_CO_SNAPSHOT_MAX");
+	if (rc != 0) {
+		goto out;
+	}
+	entry = &prop->dpp_entries[9];
+	rc = cont_deserialize_prop_uint(file_id, entry,
+					"DAOS_PROP_CO_COMPRESS");
+	if (rc != 0) {
+		goto out;
+	}
+	entry = &prop->dpp_entries[10];
+	rc = cont_deserialize_prop_uint(file_id, entry, "DAOS_PROP_CO_ENCRYPT");
+	if (rc != 0) {
+		goto out;
+	}
+	entry = &prop->dpp_entries[11];
+	rc = cont_deserialize_prop_str(file_id, entry, "DAOS_PROP_CO_OWNER");
+	if (rc != 0) {
+		goto out;
+	}
+	entry = &prop->dpp_entries[12];
+	rc = cont_deserialize_prop_str(file_id, entry,
+				       "DAOS_PROP_CO_OWNER_GROUP");
+	if (rc != 0) {
+		goto out;
+	}
+	entry = &prop->dpp_entries[13];
+	rc = cont_deserialize_prop_uint(file_id, entry, "DAOS_PROP_CO_DEDUP");
+	if (rc != 0) {
+		goto out;
+	}
+	entry = &prop->dpp_entries[14];
+	rc = cont_deserialize_prop_uint(file_id, entry,
+					"DAOS_PROP_CO_DEDUP_THRESHOLD");
+	if (rc != 0) {
+		goto out;
+	}
+	entry = &prop->dpp_entries[15];
+	rc = cont_deserialize_prop_uint(file_id, entry,
+					"DAOS_PROP_CO_ALLOCED_OID");
+	if (rc != 0) {
+		goto out;
+	}
+	entry = &prop->dpp_entries[16];
+	/* read acl as a list of strings in deserialize, then convert back to
+	 * acl for property entry
+	 */
+	rc = cont_deserialize_prop_acl(file_id, entry, "DAOS_PROP_CO_ACL");
+	if (rc != 0) {
+		goto out;
+	}
+	*cont_type = prop->dpp_entries[1].dpe_val;
+out:
+	return rc;
+}
+
+int
+deserialize_daos_cont_prop_metadata(char *filename, daos_prop_t *props,
+				    uint64_t *cont_type)
+{
+	int			rc = 0;
+	hid_t			file_id;
+
+	file_id = H5Fopen(filename, H5F_ACC_RDONLY, H5P_DEFAULT);
+	if (file_id < 0) {
+		fprintf(stderr, "failed to open hdf5 file");
+		rc = 1;
+		goto out;
+	}
+	rc = cont_deserialize_all_props(&file_id, props, cont_type);
+	if (rc != 0) {
+		fprintf(stderr, "failed to deserialize cont props: "
+			""DF_RC, DP_RC(rc));
+		goto out;
+	}
+out:
+	H5Fclose(file_id);
+	return rc;
+}
+
+static int
+cont_deserialize_usr_attrs(hid_t *file_id, uint64_t *_num_attrs,
+			   char ***_names, void ***_buffers, size_t **_sizes)
+{
+	hid_t		status = 0;
+	int		rc = 0;
+	int		num_attrs = 0;
+	int		num_dims = 0;
+	char		**names = NULL;
+	void		**buffers = NULL;
+	size_t		*sizes = NULL;
+	hid_t		dset = 0;
+	hid_t		dspace = 0;
+	hid_t		vtype = 0;
+	hsize_t		dims[1];
+	usr_attr_t	*attr_data = NULL;
+	int		i;
+
+	/* Read the user attributes */
+	dset = H5Dopen(*file_id, "User Attributes", H5P_DEFAULT);
+	if (dset < 0) {
+		fprintf(stderr, "failed to open user attributes dset");
+		rc = 1;
+		goto out;
+	}
+	dspace = H5Dget_space(dset);
+	if (dspace < 0) {
+		fprintf(stderr, "failed to get user attributes dspace");
+		rc = 1;
+		goto out;
+	}
+	vtype = H5Dget_type(dset);
+	if (vtype < 0) {
+		fprintf(stderr, "failed to get user attributes vtype");
+		rc = 1;
+		goto out;
+	}
+	num_dims = H5Sget_simple_extent_dims(dspace, dims, NULL);
+	if (num_dims < 0) {
+		fprintf(stderr, "failed to get user attributes dimensions");
+		rc = 1;
+		goto out;
+	}
+	num_attrs = dims[0];
+	attr_data = calloc(dims[0], sizeof(usr_attr_t));
+	if (attr_data == NULL) {
+		fprintf(stderr, "failed to allocate user attributes");
+		rc = 1;
+		goto out;
+	}
+	status = H5Dread(dset, vtype, H5S_ALL, H5S_ALL, H5P_DEFAULT, attr_data);
+	if (status < 0) {
+		fprintf(stderr, "failed to read user attributes data");
+		rc = 1;
+		goto out;
+	}
+	names = calloc(num_attrs, sizeof(char *));
+	if (!names) {
+		fprintf(stderr, "failed to allocate user attributes");
+		rc = 1;
+		goto out;
+	}
+	buffers = calloc(num_attrs, sizeof(void *));
+	if (!buffers) {
+		fprintf(stderr, "failed to allocate user attributes");
+		rc = 1;
+		goto out;
+	}
+	sizes = calloc(num_attrs, sizeof(size_t));
+	if (!sizes) {
+		fprintf(stderr, "failed to allocate user attributes");
+		rc = 1;
+		goto out;
+	}
+	/* Set the user attribute buffers */
+	for (i = 0; i < num_attrs; i++) {
+		names[i] = attr_data[i].attr_name;
+		buffers[i] = attr_data[i].attr_val.p;
+		sizes[i] = attr_data[i].attr_val.len;
+	}
+	*_num_attrs = num_attrs;
+	*_names = names;
+	*_buffers = buffers;
+	*_sizes = sizes;
+out:
+	H5Dclose(dset);
+	H5Sclose(dspace);
+	H5Tclose(vtype);
+	free(attr_data);
+	return rc;
+}
+
+
+int
+deserialize_daos_cont_attrs_metadata(char *filename, uint64_t *num_attrs,
+				     char ***names, void ***buffers,
+				     size_t **sizes)
+{
+	int			rc = 0;
+	hid_t			file_id;
+	htri_t			usr_attrs_exist;
+
+
+	file_id = H5Fopen(filename, H5F_ACC_RDONLY, H5P_DEFAULT);
+	if (file_id < 0) {
+		fprintf(stderr, "failed to open hdf5 file");
+		rc = 1;
+		goto out;
+	}
+	usr_attrs_exist = H5Lexists(file_id, "User Attributes", H5P_DEFAULT);
+	if (usr_attrs_exist > 0) {
+		rc = cont_deserialize_usr_attrs(&file_id, num_attrs, names,
+						buffers, sizes);
+		if (rc != 0) {
+			fprintf(stderr, "failed to deserialize usr attrs: "
+				""DF_RC, DP_RC(rc));
+			goto out;
+		}
+	}
+out:
+	H5Fclose(file_id);
+	return rc;
+}
+


### PR DESCRIPTION
Draft of preserve option for filesystem copy that uses an hdf-serialize.so library generated with hdf-serialize.c. The hdf library is linked with hdf5, and the daos utility uses dlopen to access the functions that call hdf5. This draft is to share and get feedback on the organization of the library and hdf5 code. 

Questions:
    1. Where will the generated hdf-serialize.so library live?
    2. Where should the hdf-serialize.c file go?
    3. How to go about packaging the library for DAOS?
    4. Is the library named appropriately?
    
Comment:
I have only added the hdf5 code necessary to preserve the container properties and user attributes with the preserve option for daos filesystem copy. A serial version tool for serialization and deserialization will also be created next. Those versions will require adding more hdf5 functions to the hdf-serialize.so library. 