### PR TITLE
DAOS-6864 build: Don't use libdaos.so from server

### DIFF
--- a/src/client/api/SConscript
+++ b/src/client/api/SConscript
@@ -9,13 +9,14 @@ def scons():
     il_env.AppendUnique(LIBPATH=[Dir('.')])
     denv = env.Clone()
     prereqs.require(denv, 'protobufc')
-    dc_tgts = denv.SharedObject(Glob('*.c'))
+    libdaos_tgts = denv.SharedObject(Glob('*.c'))
 
     Import('dc_pool_tgts', 'dc_co_tgts', 'dc_obj_tgts', 'dc_placement_tgts')
     Import('dc_mgmt_tgts', 'dc_array_tgts', 'dc_kv_tgts', 'dc_security_tgts')
-    dc_tgts += dc_pool_tgts + dc_co_tgts + dc_placement_tgts + dc_obj_tgts
-    dc_tgts += dc_mgmt_tgts + dc_array_tgts + dc_kv_tgts + dc_security_tgts
-    libdaos = daos_build.library(env, 'daos', dc_tgts,
+    libdaos_tgts += dc_pool_tgts + dc_co_tgts + dc_placement_tgts + dc_obj_tgts
+    libdaos_tgts += dc_mgmt_tgts + dc_array_tgts + dc_kv_tgts + dc_security_tgts
+    Export('libdaos_tgts')
+    libdaos = daos_build.library(env, 'daos', libdaos_tgts,
                                  SHLIBVERSION=API_VERSION,
                                  LIBS=['daos_common'])
     if hasattr(env, 'InstallVersionedLib'):

--- a/src/engine/SConscript
+++ b/src/engine/SConscript
@@ -3,16 +3,16 @@ import daos_build
 
 def scons():
     """Execute build"""
-    Import('env', 'prereqs')
+    Import('env', 'prereqs', 'libdaos_tgts')
 
     denv = env.Clone()
 
     denv.Append(CPPDEFINES=['-DDAOS_PMEM_BUILD'])
-    libraries = ['daos_common_pmem', 'gurt', 'cart', 'vos_srv', 'daos']
+    libraries = ['daos_common_pmem', 'gurt', 'cart', 'vos_srv']
     libraries += ['bio', 'dl', 'uuid', 'pthread', 'abt']
-    libraries += ['hwloc', 'pmemobj', 'protobuf-c']
+    libraries += ['hwloc', 'pmemobj', 'protobuf-c', 'isal']
 
-    prereqs.require(denv, 'hwloc', 'argobots', 'protobufc')
+    prereqs.require(denv, 'hwloc', 'argobots', 'protobufc', 'isal')
 
     # the "-rdynamic" is to allow other dll to refer symbol defined in
     # daos_engine such as dss_tls_key etc.
@@ -29,7 +29,7 @@ def scons():
                                  'srv_cli.c', 'profile.c', 'rpc.c',
                                  'server_iv.c', 'srv.c', 'srv.pb-c.c', 'tls.c',
                                  'sched.c', 'ult.c', 'event.pb-c.c',
-                                 'srv_metrics.c'],
+                                 'srv_metrics.c'] + libdaos_tgts,
                                 LIBS=libraries)
     denv.Install('$PREFIX/bin', engine)
 


### PR DESCRIPTION
libdaos.so depends on a conflicting version of libdaos_common
with pmem enabled.  We don't want two versions of
libdaos_common pulled in at the same time.

Instead, statically link all of the libdaos targets into
the daos_engine binary and use libdaos_common_pmem.so
to resolve the needed symbols.

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>