### PR TITLE
DAOS-7618 common: Update allocation macros

### DIFF
--- a/src/gurt/misc.c
+++ b/src/gurt/misc.c
@@ -38,6 +38,37 @@ d_realloc(void *ptr, size_t size)
 	return realloc(ptr, size);
 }
 
+char *
+d_strndup(const char *s, size_t n)
+{
+	return strndup(s, n);
+}
+
+int
+d_asprintf(char **strp, const char *fmt, ...)
+{
+	va_list	ap;
+	int	rc;
+
+	va_start(ap, fmt);
+	rc = vasprintf(strp, fmt, ap);
+	va_end(ap);
+
+	return rc;
+}
+
+char *
+d_realpath(const char *path, char *resolved_path)
+{
+	return realpath(path, resolved_path);
+}
+
+void *
+d_aligned_alloc(size_t alignment, size_t size)
+{
+	return aligned_alloc(alignment, size);
+}
+
 int
 d_rank_list_dup(d_rank_list_t **dst, const d_rank_list_t *src)
 {

--- a/src/object/srv_ec_aggregate.c
+++ b/src/object/srv_ec_aggregate.c
@@ -370,21 +370,19 @@ static int
 agg_alloc_buf(d_sg_list_t *sgl, size_t ent_buf_len, unsigned int iov_entry,
 	      bool align_data)
 {
-	int		 rc = 0;
+	void	*buf = NULL;
+	int	 rc = 0;
 
 	if (align_data) {
-		D_FREE(sgl->sg_iovs[iov_entry].iov_buf);
-		sgl->sg_iovs[iov_entry].iov_buf =
-			aligned_alloc(32, ent_buf_len);
-		if (sgl->sg_iovs[iov_entry].iov_buf == NULL) {
+		D_ALIGNED_ALLOC(buf, 32, ent_buf_len);
+		if (buf == NULL) {
 			rc = -DER_NOMEM;
 			goto out;
 		}
+		D_FREE(sgl->sg_iovs[iov_entry].iov_buf);
+		sgl->sg_iovs[iov_entry].iov_buf = buf;
 	} else {
-		unsigned int *buf = NULL;
-
-		D_REALLOC(buf, sgl->sg_iovs[iov_entry].iov_buf,
-			  sgl->sg_iovs[iov_entry].iov_buf_len, ent_buf_len);
+		D_REALLOC_NZ(buf, sgl->sg_iovs[iov_entry].iov_buf, ent_buf_len);
 		 if (buf == NULL) {
 			rc = -DER_NOMEM;
 			goto out;


### PR DESCRIPTION
Previously, d_ routines were added for allocations, I presume
to avoid situations where we can get mismatched alloc/free
implementations.   Do the same for the other allocation
routines.  Added D_ALIGNED_ALLOC as well.

In staring at code when investigating DAOS-7441, I noticed
that we do a realloc using D_FREE and aligned_alloc in
agg_alloc_buf.  The problem is the semnatics don't match
the else case where the original buffer would not be freed

Modified to make the semantics consistent for if/else clause

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>