### PR TITLE
DAOS-7342 tests: Forcing agent restart when servers are restarted.

### DIFF
--- a/src/tests/ftest/util/apricot/apricot/test.py
+++ b/src/tests/ftest/util/apricot/apricot/test.py
@@ -7,9 +7,6 @@
 # pylint: disable=too-many-lines
 
 # Some useful test classes inherited from avocado.Test
-
-
-
 import os
 import json
 import re
@@ -41,6 +38,7 @@ from write_host_file import write_host_file
 def skipForTicket(ticket): # pylint: disable=invalid-name
     """Skip a test with a comment about a ticket."""
     return skip("Skipping until {} is fixed.".format(ticket))
+
 
 def get_log_file(name):
     """Get the full log file name and path.
@@ -155,8 +153,7 @@ class Test(avocadoTest):
         super().setUp()
 
     def add_test_data(self, filename, data):
-        """Add a file containing the specified data to the test variant
-           specific data directory.
+        """Add a file to the test variant specific data directory.
 
         Args:
             filename (str): name of the file to create
@@ -170,8 +167,7 @@ class Test(avocadoTest):
             self.fail("Error writing {}: {}".format(filename, error))
 
     def cancel_from_list(self):
-        """Check if test is in skip list"""
-
+        """Check if test is in skip list."""
         def skip_process_error(message):
             self.log.info(message)
             self.log.info("Trudging on without skipping known failing tests")
@@ -196,7 +192,7 @@ class Test(avocadoTest):
                 # first see if it's being fixed in this PR
                 try:
                     with open(os.path.join(os.sep, 'tmp',
-                              'commit_title')) as commit_handle:
+                                           'commit_title')) as commit_handle:
                         if commit_handle.read().strip().startswith(
                                 ticket + " "):
                             # fix is in this PR
@@ -225,9 +221,9 @@ class Test(avocadoTest):
                     if commits and vals[1] in commits:
                         # fix is in this code base
                         self.log.info("This test variant is included in the "
-                                     "skip list for ticket %s, but is fixed "
-                                     "in %s.  Test will not be "
-                                     "skipped", ticket, vals[1])
+                                      "skip list for ticket %s, but is fixed "
+                                      "in %s.  Test will not be "
+                                      "skipped", ticket, vals[1])
                         return
                     # fix is not in this code base
                     self.log.info("Skipping due to being on the "
@@ -631,6 +627,7 @@ class TestWithServers(TestWithoutServers):
             "access_points", "/run/setup/*", self.hostlist_servers[:1])
 
         # Display host information
+        self.log.info("-" * 100)
         self.log.info("--- HOST INFORMATION ---")
         self.log.info("hostlist_servers:    %s", self.hostlist_servers)
         self.log.info("hostlist_clients:    %s", self.hostlist_clients)
@@ -641,6 +638,7 @@ class TestWithServers(TestWithoutServers):
         self.log.info("access_points:       %s", self.access_points)
 
         # List common test directory contents before running the test
+        self.log.info("-" * 100)
         self.log.debug("Common test directory (%s) contents:", self.test_dir)
         hosts = list(self.hostlist_servers)
         if self.hostlist_clients:
@@ -656,6 +654,7 @@ class TestWithServers(TestWithoutServers):
             hosts = list(self.hostlist_servers)
             if self.hostlist_clients:
                 hosts.extend(self.hostlist_clients)
+            self.log.info("-" * 100)
             self.stop_leftover_processes(["orterun"], hosts)
 
             # Ensure write permissions for the daos command log files when
@@ -663,18 +662,20 @@ class TestWithServers(TestWithoutServers):
             if (self.agent_manager_class == "Systemctl" or
                     self.server_manager_class == "Systemctl"):
                 log_dir = os.environ.get("DAOS_TEST_LOG_DIR", "/tmp")
+                self.log.info("-" * 100)
                 self.log.info(
                     "Updating file permissions for %s for use with systemctl",
                     log_dir)
                 pcmd(hosts, "chmod a+rw {}".format(log_dir))
 
+        # Start the servers
+        force_agent_start = False
+        if self.setup_start_servers:
+            force_agent_start = self.start_servers()
+
         # Start the clients (agents)
         if self.setup_start_agents:
-            self.start_agents()
-
-        # Start the servers
-        if self.setup_start_servers:
-            self.start_servers()
+            self.start_agents(force=force_agent_start)
 
         # Setup a job manager command for running the test command
         manager_class_name = self.params.get(
@@ -687,6 +688,9 @@ class TestWithServers(TestWithoutServers):
             self.job_manager = get_job_manager_class(
                 manager_class_name, None, manager_subprocess, manager_mpi_type)
             self.set_job_manager_timeout()
+
+        # Mark the end of setup
+        self.log.info("=" * 100)
 
     def set_job_manager_timeout(self):
         """Set the timeout for the job manager.
@@ -709,7 +713,53 @@ class TestWithServers(TestWithoutServers):
                 if self.job_manager.timeout is None:
                     self.job_manager.timeout = self.timeout - 30
 
-    def start_agents(self, agent_groups=None):
+    def start_agents(self, agent_groups=None, force=False):
+        """Start the daos_agent processes.
+
+        Args:
+            agent_groups (dict, optional): dictionary of dictionaries,
+                containing the list of hosts on which to start the daos agent
+                and the list of server access points, using a unique server
+                group name key. Defaults to None which will use the server group
+                name, all of the client hosts, and the access points from the
+                test's yaml file to define a single server group entry.
+            force (bool, optional): whether or not to force starting the agents.
+                Defaults to False.
+
+        Raises:
+            avocado.core.exceptions.TestFail: if there is an error starting the
+                agents
+
+        """
+        self.setup_agents(agent_groups)
+        if self.agent_managers:
+            self.start_agent_managers(force)
+
+    def start_servers(self, server_groups=None, force=False):
+        """Start the daos_server processes.
+
+        Args:
+            server_groups (dict, optional): dictionary of dictionaries,
+                containing the list of hosts on which to start the daos server
+                and the list of access points, using a unique server group name
+                key. Defaults to None which will use the server group name, all
+                of the server hosts, and the access points from the test's yaml
+                file to define a single server group entry.
+            force (bool, optional): whether or not to force starting the
+                servers. Defaults to False.
+
+        Raises:
+            avocado.core.exceptions.TestFail: if there is an error starting the
+                servers
+
+        """
+        force_agent_start = False
+        self.setup_servers(server_groups)
+        if self.server_managers:
+            force_agent_start = self.start_server_managers(force)
+        return force_agent_start
+
+    def setup_agents(self, agent_groups=None):
         """Start the daos_agent processes.
 
         Args:
@@ -735,7 +785,8 @@ class TestWithServers(TestWithoutServers):
                 }
             }
 
-        self.log.debug("--- STARTING AGENT GROUPS: %s ---", agent_groups)
+        self.log.info("-" * 100)
+        self.log.debug("--- SETTING UP AGENT GROUPS: %s ---", agent_groups)
 
         if isinstance(agent_groups, dict):
             for group, info in list(agent_groups.items()):
@@ -746,9 +797,8 @@ class TestWithServers(TestWithoutServers):
                     info["hosts"],
                     self.hostfile_clients_slots,
                     info["access_points"])
-            self.start_agent_managers()
 
-    def start_servers(self, server_groups=None):
+    def setup_servers(self, server_groups=None):
         """Start the daos_server processes.
 
         Args:
@@ -776,7 +826,8 @@ class TestWithServers(TestWithoutServers):
                 }
             }
 
-        self.log.debug("--- STARTING SERVER GROUPS: %s ---", server_groups)
+        self.log.info("-" * 100)
+        self.log.debug("--- SETTING UP SERVER GROUPS: %s ---", server_groups)
 
         if isinstance(server_groups, dict):
             for group, info in list(server_groups.items()):
@@ -789,7 +840,6 @@ class TestWithServers(TestWithoutServers):
                     info["hosts"],
                     self.hostfile_servers_slots,
                     info["access_points"])
-            self.start_server_managers()
 
     def get_config_file(self, name, command, path=None):
         """Get the yaml configuration file.
@@ -927,6 +977,7 @@ class TestWithServers(TestWithoutServers):
             access_points (list, optional): list of access point hosts. Defaults
                 to None which uses self.access_points.
         """
+        self.log.info("-" * 100)
         self.log.info("--- CONFIGURING %s MANAGER ---", name.upper())
         if access_points is None:
             access_points = self.access_points
@@ -938,39 +989,72 @@ class TestWithServers(TestWithoutServers):
         manager.hosts = (hosts, self.workdir, slots)
 
     @fail_on(CommandFailure)
-    def start_agent_managers(self):
-        """Start the daos_agent processes on each specified list of hosts."""
-        self.log.info("-" * 100)
-        start_agents = True
-        if self.start_agents_once:
-            # Starting agents for each test variant is enabled.  The agents
-            # will still need be started if any agent is down.
-            status = self.check_running(
-                "agents", self.agent_managers, False, True)
-            start_agents = status["restart"]
-        if start_agents:
+    def start_agent_managers(self, force=False):
+        """Start the daos_agent processes on each specified list of hosts.
+
+        Args:
+            force (bool, optional): whether or not to force starting the agents.
+                Defaults to False.
+        """
+        # Determine if all the expected agents are currently running
+        status = self.check_running("agents", self.agent_managers, False, True)
+
+        # Start/restart the agents
+        if force or status["restart"] or not self.start_agents_once:
+            # Stop any running agents
+            self.log.info("-" * 100)
+            self.log.info("--- STOPPING AGENTS ---")
+            self.test_log.info(
+                "Stopping %s group(s) of agents", len(self.agent_managers))
+            self._stop_managers(self.agent_managers, "agents")
+
+            # Start the agents
+            self.log.info("-" * 100)
             self.log.info("--- STARTING AGENTS ---")
             self._start_manager_list("agent", self.agent_managers)
-        self.log.info("-" * 100)
 
     @fail_on(CommandFailure)
-    def start_server_managers(self):
-        """Start the daos_server processes on each specified list of hosts."""
-        self.log.info("-" * 100)
-        start_servers = True
-        if self.start_servers_once:
-            # Starting servers for each test variant is enabled.  The servers
-            # will still need be started if any server is down.  Since the
-            # ServerManager objects have been initialized but start() has not
-            # been called, the dmg command will need to be prepared and the
-            # expected states will need to be assigned.
-            status = self.check_running(
-                "servers", self.server_managers, True, True)
-            start_servers = status["restart"]
-        if start_servers:
+    def start_server_managers(self, force=False):
+        """Start the daos_server processes on each specified list of hosts.
+
+        Args:
+            force (bool, optional): whether or not to force starting the
+                servers. Defaults to False.
+
+        Returns:
+            bool: whether or not to force the starting of the agents
+
+        """
+        force_agent_start = False
+
+        # Determine if all the expected servers are currently running
+        status = self.check_running(
+            "servers", self.server_managers, True, True)
+
+        # Start/restart the severs
+        if force or status["restart"] or not self.start_servers_once:
+            # Stop any running servers
+            self.log.info("-" * 100)
+            self.log.info("--- STOPPING SERVERS ---")
+            self.test_log.info(
+                "Stopping %s group(s) of servers", len(self.server_managers))
+            self._stop_managers(self.server_managers, "servers")
+
+            # Start the servers
+            self.log.info("-" * 100)
             self.log.info("--- STARTING SERVERS ---")
             self._start_manager_list("server", self.server_managers)
-        self.log.info("-" * 100)
+
+            # Force agent restart whenever servers are restarted
+            force_agent_start = True
+            self.log.info(
+                "-- Forcing the start/restart of agents due to the server "
+                "start/restart --")
+
+        elif self.start_servers_once:
+            self.log.info()
+
+        return force_agent_start
 
     def check_running(self, name, manager_list, prepare_dmg=False,
                       set_expected=False):
@@ -995,6 +1079,7 @@ class TestWithServers(TestWithoutServers):
 
         """
         status = {"expected": True, "restart": False}
+        self.log.info("-" * 100)
         self.log.info(
             "--- VERIFYING STATES OF %s %s GROUP%s ---",
             len(manager_list), name.upper(),
@@ -1155,6 +1240,8 @@ class TestWithServers(TestWithoutServers):
             list: a list of exceptions raised stopping the agents
 
         """
+        self.log.info("-" * 100)
+        self.log.info("--- STOPPING AGENTS ---")
         errors = []
         status = self.check_running("agents", self.agent_managers)
         if self.start_agents_once and not status["restart"]:
@@ -1178,6 +1265,8 @@ class TestWithServers(TestWithoutServers):
             list: a list of exceptions raised stopping the servers
 
         """
+        self.log.info("-" * 100)
+        self.log.info("--- STOPPING SERVERS ---")
         errors = []
         status = self.check_running("servers", self.server_managers)
         if self.start_servers_once and not status["restart"]:


### PR DESCRIPTION
Enhancing the test harness set up to handle situations where servers
have not been stopped correctly by a prior test variant.  This includes
forcing a restart of the agents if the servers need to be restarted.

Test-tag-vm: pr rebuild_tests

Signed-off-by: Phillip Henderson <phillip.henderson@intel.com>