### PR TITLE
DAOS-6833 rdb: Update raft for PreVote

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+daos (1.3.102-3) unstable; urgency=medium
+  [ Li Wei ]
+  * Update raft to pick Pre-Vote
+
+ -- Li Wei <wei.g.li@intel.com>  Mon, 23 Jun 2021 14:46:00 +0800
+
 daos (1.3.102-1) unstable; urgency=medium
   [ Johann Lombardi]
   * Version bump to 1.3.102 for 2.0 test build 2

--- a/debian/control
+++ b/debian/control
@@ -28,7 +28,7 @@ Build-Depends: debhelper (>= 10),
                libboost-dev,
                libspdk-dev,
                libipmctl-dev,
-               libraft-dev (= 0.7.3-1382.g3fa7f4e),
+               libraft-dev (= 0.8.0-1386.g7509891),
                python3-tabulate,
                liblz4-dev
 Standards-Version: 4.1.2

--- a/src/rdb/rdb_rpc.c
+++ b/src/rdb/rdb_rpc.c
@@ -29,6 +29,9 @@ crt_proc_msg_requestvote_response_t(crt_proc_t proc, crt_proc_op_t proc_op,
 	rc = crt_proc_int32_t(proc, proc_op, &p->vote_granted);
 	if (unlikely(rc))
 		return rc;
+	rc = crt_proc_int32_t(proc, proc_op, &p->prevote);
+	if (unlikely(rc))
+		return rc;
 
 	return 0;
 }

--- a/utils/rpms/daos.spec
+++ b/utils/rpms/daos.spec
@@ -14,7 +14,7 @@
 
 Name:          daos
 Version:       1.3.102
-Release:       2%{?relval}%{?dist}
+Release:       3%{?relval}%{?dist}
 Summary:       DAOS Storage Engine
 
 License:       BSD-2-Clause-Patent
@@ -84,7 +84,7 @@ BuildRequires: libisa-l_crypto-devel
 BuildRequires: libisal-devel
 BuildRequires: libisal_crypto-devel
 %endif
-BuildRequires: daos-raft-devel = 0.7.3
+BuildRequires: daos-raft-devel = 0.8.0
 BuildRequires: openssl-devel
 BuildRequires: libevent-devel
 BuildRequires: libyaml-devel
@@ -464,6 +464,9 @@ getent passwd daos_agent >/dev/null || useradd -s /sbin/nologin -r -g daos_agent
 %attr(4750,root,daos_server) %{_bindir}/daos_firmware
 
 %changelog
+* Mon Jun 23 2021 Li Wei <wei.g.li@intel.com> 1.3.102-3
+- Update raft to pick up Pre-Vote
+
 * Mon Jun 14 2021 Jeff Olivier <jeffrey.v.olivier@intel.com> 1.3.102-2
 - Update to pmdk 1.11.0-rc1
 - Remove dependence on libpmem since we use libpmemobj directly


### PR DESCRIPTION
Update raft for the Pre-Vote feature. Increment the RDB RPC protocol
version to prevent mix-version engines from causing further harm.

Signed-off-by: Li Wei wei.g.li@intel.com