### PR TITLE
DAOS-7577 engine fix a compiling warning

### DIFF
--- a/src/include/daos_srv/daos_engine.h
+++ b/src/include/daos_srv/daos_engine.h
@@ -125,7 +125,7 @@ void dss_register_key(struct dss_module_key *key);
 void dss_unregister_key(struct dss_module_key *key);
 
 /** pthread names are limited to 16 chars */
-#define DSS_XS_NAME_LEN		16
+#define DSS_XS_NAME_LEN		(32)
 
 struct srv_profile_chunk {
 	d_list_t	spc_chunk_list;

--- a/src/tests/simple_obj.c
+++ b/src/tests/simple_obj.c
@@ -166,7 +166,7 @@ example_daos_key_array()
 	daos_obj_id_t	oid;
 	d_iov_t		dkey;
 	int		total_nr = 0;
-	char		dkey_str[10];
+	char		dkey_str[32] = {0};
 	int		i, rc;
 
 	if (rank == 0)
@@ -327,8 +327,8 @@ example_daos_key_sv()
 	daos_obj_id_t	oid;
 	d_iov_t		dkey;
 	int		total_nr = 0;
-	char		dkey_str[10];
-	char		akey_str[10];
+	char		dkey_str[32] = {0};
+	char		akey_str[32] = {0};
 	int		i, rc;
 
 	MPI_Barrier(MPI_COMM_WORLD);
@@ -594,7 +594,7 @@ example_daos_kv()
 	daos_handle_t	oh;
 	char		buf[BUFLEN], rbuf[BUFLEN];
 	daos_obj_id_t	oid;
-	char		key[10];
+	char		key[32] = {0};
 	int		i, rc;
 
 	MPI_Barrier(MPI_COMM_WORLD);

--- a/src/tests/suite/daos_dist_tx.c
+++ b/src/tests/suite/daos_dist_tx.c
@@ -1901,7 +1901,7 @@ dtx_30(void **state)
 	daos_iod_type_t	 types[2] = { DAOS_IOD_ARRAY, DAOS_IOD_SINGLE };
 	uint16_t	 ocs[2] = { OC_EC_2P1G1, OC_RP_2G2 };
 	int		 base = 10000;
-	int		 akey_size = 8;
+	int		 akey_size = 32;
 	daos_size_t	 buf_len = DTX_NC_CNT * 2 * akey_size;
 	char		 buf[buf_len];
 	daos_key_desc_t  kds[DTX_NC_CNT * 2];

--- a/src/tests/suite/daos_drain_simple.c
+++ b/src/tests/suite/daos_drain_simple.c
@@ -50,7 +50,7 @@ drain_dkeys(void **state)
 	print_message("Insert %d kv record in object "DF_OID"\n",
 		      KEY_NR, DP_OID(oid));
 	for (i = 0; i < KEY_NR; i++) {
-		char	key[16];
+		char	key[32] = {0};
 
 		sprintf(key, "dkey_0_%d", i);
 		insert_single(key, "a_key", 0, "data", strlen("data") + 1,
@@ -60,8 +60,8 @@ drain_dkeys(void **state)
 	drain_single_pool_target(arg, ranks_to_kill[0], tgt, false);
 
 	for (i = 0; i < KEY_NR; i++) {
-		char key[16];
-		char buf[16];
+		char key[32] = {0};
+		char buf[16] = {0};
 
 		sprintf(key, "dkey_0_%d", i);
 		/** Lookup */
@@ -106,7 +106,7 @@ drain_akeys(void **state)
 
 	drain_single_pool_target(arg, ranks_to_kill[0], tgt, false);
 	for (i = 0; i < KEY_NR; i++) {
-		char akey[16];
+		char akey[32] = {0};
 		char buf[16];
 
 		sprintf(akey, "%d", i);
@@ -145,7 +145,7 @@ drain_indexes(void **state)
 	print_message("Insert %d kv record in object "DF_OID"\n",
 		      2000, DP_OID(oid));
 	for (i = 0; i < KEY_NR; i++) {
-		char	key[16];
+		char	key[32] = {0};
 
 		sprintf(key, "dkey_2_%d", i);
 		for (j = 0; j < 20; j++)
@@ -156,7 +156,7 @@ drain_indexes(void **state)
 	/* Drain rank 1 */
 	drain_single_pool_target(arg, ranks_to_kill[0], tgt, false);
 	for (i = 0; i < KEY_NR; i++) {
-		char	key[16];
+		char	key[32] = {0};
 		char	buf[16];
 
 		sprintf(key, "dkey_2_%d", i);
@@ -356,11 +356,11 @@ drain_multiple(void **state)
 	print_message("Insert %d kv record in object "DF_OID"\n",
 		      1000, DP_OID(oid));
 	for (i = 0; i < 10; i++) {
-		char	dkey[16];
+		char	dkey[32] = {0};
 
 		sprintf(dkey, "dkey_3_%d", i);
 		for (j = 0; j < 10; j++) {
-			char	akey[16];
+			char	akey[32] = {0};
 
 			sprintf(akey, "akey_%d", j);
 			for (k = 0; k < 10; k++)
@@ -372,11 +372,11 @@ drain_multiple(void **state)
 
 	drain_single_pool_target(arg, ranks_to_kill[0], tgt, false);
 	for (i = 0; i < 10; i++) {
-		char	dkey[16];
+		char	dkey[32] = {0};
 
 		sprintf(dkey, "dkey_3_%d", i);
 		for (j = 0; j < 10; j++) {
-			char	akey[16];
+			char	akey[32] = {0};
 			char	buf[10];
 
 			memset(buf, 0, 10);
@@ -420,7 +420,7 @@ drain_large_rec(void **state)
 		      KEY_NR, DP_OID(oid));
 	memset(buffer, 'a', 5000);
 	for (i = 0; i < KEY_NR; i++) {
-		char	key[16];
+		char	key[32] = {0};
 
 		sprintf(key, "dkey_4_%d", i);
 		insert_single(key, "a_key", 0, buffer, 5000, DAOS_TX_NONE,
@@ -430,7 +430,7 @@ drain_large_rec(void **state)
 	drain_single_pool_target(arg, ranks_to_kill[0], tgt, false);
 	memset(v_buffer, 'a', 5000);
 	for (i = 0; i < KEY_NR; i++) {
-		char	key[16];
+		char	key[32] = {0};
 
 		sprintf(key, "dkey_4_%d", i);
 		memset(buffer, 0, 5000);

--- a/src/tests/suite/daos_extend_simple.c
+++ b/src/tests/suite/daos_extend_simple.c
@@ -45,7 +45,7 @@ extend_dkeys(void **state)
 		print_message("Insert %d kv record in object "DF_OID"\n",
 			      KEY_NR, DP_OID(oids[i]));
 		for (j = 0; j < KEY_NR; j++) {
-			char	key[16];
+			char	key[32] = {0};
 
 			sprintf(key, "dkey_0_%d", j);
 			insert_single(key, "a_key", 0, "data",
@@ -126,7 +126,7 @@ extend_indexes(void **state)
 			      KEY_NR, DP_OID(oids[i]));
 
 		for (j = 0; j < KEY_NR; j++) {
-			char	key[16];
+			char	key[32] = {0};
 
 			sprintf(key, "dkey_2_%d", j);
 			for (k = 0; k < 20; k++)
@@ -168,7 +168,7 @@ extend_large_rec(void **state)
 		print_message("Insert %d kv record in object "DF_OID"\n",
 			      KEY_NR, DP_OID(oids[i]));
 		for (j = 0; j < KEY_NR; j++) {
-			char	key[16];
+			char	key[32] = {0};
 
 			sprintf(key, "dkey_3_%d", j);
 			insert_single(key, "a_key", 0, buffer, 5000,

--- a/src/tests/suite/daos_kv.c
+++ b/src/tests/suite/daos_kv.c
@@ -79,7 +79,7 @@ simple_put_get(void **state)
 	daos_size_t	buf_size = 1024, size;
 	daos_event_t	ev;
 	const char      *key_fmt = "key%d";
-	char		key[10];
+	char		key[32] = {0};
 	char		*buf;
 	char		*buf_out;
 	int		i, num_keys;

--- a/src/tests/suite/daos_obj.c
+++ b/src/tests/suite/daos_obj.c
@@ -2909,7 +2909,7 @@ io_nospace(void **state)
 	struct ioreq	req;
 	int		buf_size = 1 << 20;
 	char		*large_buf;
-	char		key[10];
+	char		key[32];
 	int		i;
 
 	FAULT_INJECTION_REQUIRED();

--- a/src/tests/suite/daos_obj_array.c
+++ b/src/tests/suite/daos_obj_array.c
@@ -541,7 +541,7 @@ array_dkey_punch_enumerate(void **state)
 
 	print_message("Inserting %d dkeys...\n", KEYS);
 	for (i = 0; i < KEYS; i++) {
-		char dkey_str[10];
+		char dkey_str[32] = {0};
 
 		/** init dkey */
 		sprintf(dkey_str, "dkey_%d", i);
@@ -561,7 +561,7 @@ array_dkey_punch_enumerate(void **state)
 	print_message("Punching %d dkeys, and %d dkeys that don't exist.\n",
 		      E_KEYS2PUNCH, NE_KEYS2PUNCH);
 	for (i = KEYS - E_KEYS2PUNCH; i < KEYS + NE_KEYS2PUNCH; i++) {
-		char dkey_str[10];
+		char dkey_str[32] = {0};
 
 		/** init dkey */
 		sprintf(dkey_str, "dkey_%d", i);
@@ -624,7 +624,7 @@ array_akey_punch_enumerate(void **state)
 
 	print_message("Inserting %d akeys...\n", KEYS);
 	for (i = 0; i < KEYS; i++) {
-		char akey_str[10];
+		char akey_str[32] = {0};
 
 		sprintf(akey_str, "akey_%d", i);
 		d_iov_set(&iod.iod_name, akey_str, strlen(akey_str));
@@ -643,7 +643,7 @@ array_akey_punch_enumerate(void **state)
 	print_message("Punching %d akeys, and %d akeys that don't exist.\n",
 		      E_KEYS2PUNCH, NE_KEYS2PUNCH);
 	for (i = KEYS - E_KEYS2PUNCH; i < KEYS + NE_KEYS2PUNCH; i++) {
-		char akey_str[10];
+		char akey_str[32] = {0};
 		daos_key_t akey;
 
 		sprintf(akey_str, "akey_%d", i);
@@ -661,7 +661,7 @@ array_akey_punch_enumerate(void **state)
 
 	print_message("Fetch akeys after punch and verify size...\n");
 	for (i = 0; i < KEYS; i++) {
-		char akey_str[10];
+		char akey_str[32] = {0};
 
 		sprintf(akey_str, "akey_%d", i);
 		d_iov_set(&iod.iod_name, akey_str, strlen(akey_str));

--- a/src/tests/suite/daos_rebuild_simple.c
+++ b/src/tests/suite/daos_rebuild_simple.c
@@ -120,7 +120,7 @@ rebuild_dkeys(void **state)
 	print_message("Insert %d kv record in object "DF_OID"\n",
 		      KEY_NR, DP_OID(oid));
 	for (i = 0; i < 5; i++) {
-		char	key[16];
+		char	key[32] = {0};
 		daos_recx_t recx;
 		char	data[DATA_SIZE];
 
@@ -174,7 +174,7 @@ rebuild_akeys(void **state)
 	print_message("Insert %d kv record in object "DF_OID"\n",
 		      KEY_NR, DP_OID(oid));
 	for (i = 0; i < KEY_NR; i++) {
-		char		key[16];
+		char		key[32] = {0};
 		daos_recx_t	recx;
 		char		data[DATA_SIZE];
 
@@ -229,7 +229,7 @@ rebuild_indexes(void **state)
 	print_message("Insert %d kv record in object "DF_OID"\n",
 		      2000, DP_OID(oid));
 	for (i = 0; i < KEY_NR; i++) {
-		char	key[16];
+		char	key[32] = {0};
 
 		sprintf(key, "dkey_2_%d", i);
 		for (j = 0; j < 20; j++)
@@ -656,11 +656,11 @@ rebuild_multiple(void **state)
 	print_message("Insert %d kv record in object "DF_OID"\n",
 		      1000, DP_OID(oid));
 	for (i = 0; i < 10; i++) {
-		char	dkey[16];
+		char	dkey[32] = {0};
 
 		sprintf(dkey, "dkey_3_%d", i);
 		for (j = 0; j < 10; j++) {
-			char	akey[16];
+			char	akey[32] = {0};
 
 			sprintf(akey, "akey_%d", j);
 			for (k = 0; k < 10; k++)
@@ -702,7 +702,7 @@ rebuild_large_rec(void **state)
 		      KEY_NR, DP_OID(oid));
 	memset(buffer, 'a', LARGE_BUFFER_SIZE);
 	for (i = 0; i < KEY_NR; i++) {
-		char	key[16];
+		char	key[32] = {0};
 		const char *lakey = "a_key_L";
 		daos_size_t iod_size = 1;
 		int	rx_nr = LARGE_BUFFER_SIZE;
@@ -1034,10 +1034,10 @@ rebuild_multiple_group(void **state)
 	print_message("Insert %d kv record in object "DF_OID"\n",
 		      KEY_NR, DP_OID(oid));
 	for (i = 0; i < 50; i++) {
-		char	key[16];
+		char	key[32] = {0};
 		daos_recx_t recx;
 		char	data[10];
-		char	akey[16];
+		char	akey[32] = {0};
 		int	j;
 
 		sprintf(key, "dkey_0_%d", i);

--- a/src/vos/tests/vts_io.h
+++ b/src/vos/tests/vts_io.h
@@ -27,9 +27,9 @@
 #include <vos_obj.h>
 #include <vos_internal.h>
 
-#define UPDATE_DKEY_SIZE	32
+#define UPDATE_DKEY_SIZE	64
 #define UPDATE_DKEY		"dkey"
-#define UPDATE_AKEY_SIZE	32
+#define UPDATE_AKEY_SIZE	64
 #define UPDATE_AKEY		"akey"
 #define UPDATE_AKEY_SV		"akey.sv"
 #define UPDATE_AKEY_ARRAY	"akey.array"


### PR DESCRIPTION
Fix compiling warning of -
src/engine/srv.c:102:33: error: '%d' directive output may be truncated
writing between 1 and 10 bytes into a region of size 7

Signed-off-by: Xuezhao Liu <xuezhao.liu@intel.com>