### PR TITLE
DAOS-623 test: Improve test stability in GA.

### DIFF
--- a/src/control/server/harness.go
+++ b/src/control/server/harness.go
@@ -23,7 +23,7 @@ import (
 )
 
 const (
-	rankReqTimeout   = 10 * time.Second
+	rankReqTimeout   = 25 * time.Second
 	rankStartTimeout = 3 * rankReqTimeout
 )
 

--- a/src/control/server/harness.go
+++ b/src/control/server/harness.go
@@ -23,7 +23,7 @@ import (
 )
 
 const (
-	rankReqTimeout   = 25 * time.Second
+	rankReqTimeout   = 60 * time.Second
 	rankStartTimeout = 3 * rankReqTimeout
 )
 

--- a/utils/node_local_test.py
+++ b/utils/node_local_test.py
@@ -680,8 +680,10 @@ class DaosServer():
             entry['message'] = 'daos_engine died during testing'
             self.conf.wf.issues.append(entry)
 
+        start = time.time()
         rc = self.run_dmg(['system', 'stop'])
         print(rc)
+        print('dmg system stop took {:.2f}s'.format(time.time() - start))
         assert rc.returncode == 0
 
         start = time.time()

--- a/utils/run_in_ga.sh
+++ b/utils/run_in_ga.sh
@@ -33,5 +33,14 @@ echo ::endgroup::
 echo ::group::Container copy test
 # DAOS-7440
 export LD_LIBRARY_PATH=/opt/daos/prereq/release/spdk/lib/
-./utils/node_local_test.py --no-root --test cont_copy
+
+x=1
+while [ $x -le 5 ]
+do
+    echo "Iteration $x"
+    rm -rf /mmt/daos/* || true
+    ./utils/node_local_test.py --no-root --test cont_copy
+    x=$(( $x + 1 ))
+done
+
 echo ::endgroup::

--- a/utils/run_in_ga.sh
+++ b/utils/run_in_ga.sh
@@ -35,7 +35,7 @@ echo ::group::Container copy test
 export LD_LIBRARY_PATH=/opt/daos/prereq/release/spdk/lib/
 
 x=1
-while [ $x -le 5 ]
+while [ $x -le 100 ]
 do
     echo "Iteration $x"
     rm -rf /mmt/daos/* || true


### PR DESCRIPTION
Increase shutdown timeout in dmg from 10 to 25 seconds to
avoid false failures in Github Actions.  This timeout is
scheduled for removal soon, but in the restrictive
environment of Azure the current value is not long ehough
and we're seeing occasional failures.

Run test in a loop to see how frequently we are hitting
this timeout.

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>
