### PR TITLE
DAOS-6864 build: Don't use libdaos.so from server (#5706)

### DIFF
--- a/src/client/api/SConscript
+++ b/src/client/api/SConscript
@@ -9,13 +9,14 @@ def scons():
     il_env.AppendUnique(LIBPATH=[Dir('.')])
     denv = env.Clone()
     prereqs.require(denv, 'protobufc')
-    dc_tgts = denv.SharedObject(Glob('*.c'))
+    libdaos_tgts = denv.SharedObject(Glob('*.c'))
 
     Import('dc_pool_tgts', 'dc_co_tgts', 'dc_obj_tgts', 'dc_placement_tgts')
     Import('dc_mgmt_tgts', 'dc_array_tgts', 'dc_kv_tgts', 'dc_security_tgts')
-    dc_tgts += dc_pool_tgts + dc_co_tgts + dc_placement_tgts + dc_obj_tgts
-    dc_tgts += dc_mgmt_tgts + dc_array_tgts + dc_kv_tgts + dc_security_tgts
-    libdaos = daos_build.library(env, 'daos', dc_tgts,
+    libdaos_tgts += dc_pool_tgts + dc_co_tgts + dc_placement_tgts + dc_obj_tgts
+    libdaos_tgts += dc_mgmt_tgts + dc_array_tgts + dc_kv_tgts + dc_security_tgts
+    Export('libdaos_tgts')
+    libdaos = daos_build.library(env, 'daos', libdaos_tgts,
                                  SHLIBVERSION=API_VERSION,
                                  LIBS=['daos_common'])
     if hasattr(env, 'InstallVersionedLib'):

--- a/src/engine/SConscript
+++ b/src/engine/SConscript
@@ -3,16 +3,16 @@ import daos_build
 
 def scons():
     """Execute build"""
-    Import('env', 'prereqs')
+    Import('env', 'prereqs', 'libdaos_tgts')
 
     denv = env.Clone()
 
     denv.Append(CPPDEFINES=['-DDAOS_PMEM_BUILD'])
-    libraries = ['daos_common_pmem', 'gurt', 'cart', 'vos_srv', 'daos']
+    libraries = ['daos_common_pmem', 'gurt', 'cart', 'vos_srv']
     libraries += ['bio', 'dl', 'uuid', 'pthread', 'abt']
-    libraries += ['hwloc', 'pmemobj', 'protobuf-c']
+    libraries += ['hwloc', 'pmemobj', 'protobuf-c', 'isal']
 
-    prereqs.require(denv, 'hwloc', 'argobots', 'protobufc')
+    prereqs.require(denv, 'hwloc', 'argobots', 'protobufc', 'isal')
 
     # the "-rdynamic" is to allow other dll to refer symbol defined in
     # daos_engine such as dss_tls_key etc.
@@ -28,7 +28,8 @@ def scons():
                                  'drpc_progress.c', 'init.c', 'module.c',
                                  'srv_cli.c', 'profile.c', 'rpc.c',
                                  'server_iv.c', 'srv.c', 'srv.pb-c.c', 'tls.c',
-                                 'sched.c', 'ult.c', 'event.pb-c.c'],
+                                 'sched.c', 'ult.c',
+                                 'event.pb-c.c'] + libdaos_tgts,
                                 LIBS=libraries)
     denv.Install('$PREFIX/bin', engine)
 

--- a/utils/node_local_test.py
+++ b/utils/node_local_test.py
@@ -146,8 +146,7 @@ class WarningsFactory():
             return
 
         entry = {}
-        entry['fileName'] = os.path.basename(self._file)
-        entry['directory'] = os.path.dirname(self._file)
+        entry['fileName'] = self._file
         # pylint: disable=protected-access
         entry['lineStart'] = sys._getframe().f_lineno
         entry['message'] = 'Tests exited without shutting down properly'
@@ -201,8 +200,7 @@ class WarningsFactory():
         Add it to the pending array, for later clarification
         """
         entry = {}
-        entry['directory'] = os.path.dirname(line.filename)
-        entry['fileName'] = os.path.basename(line.filename)
+        entry['fileName'] = line.filename
         if mtype:
             entry['type'] = mtype
         else:
@@ -242,8 +240,7 @@ class WarningsFactory():
             # When the test is running insert an error in case of abnormal
             # exit, so that crashes in this code can be identified.
             entry = {}
-            entry['fileName'] = os.path.basename(self._file)
-            entry['directory'] = os.path.dirname(self._file)
+            entry['fileName'] = self._file
             # pylint: disable=protected-access
             entry['lineStart'] = sys._getframe().f_lineno
             entry['severity'] = 'ERROR'
@@ -548,8 +545,7 @@ class DaosServer():
 
         if len(procs) != 1:
             entry = {}
-            entry['fileName'] = os.path.basename(self._file)
-            entry['directory'] = os.path.dirname(self._file)
+            entry['fileName'] = self._file
             # pylint: disable=protected-access
             entry['lineStart'] = sys._getframe().f_lineno
             entry['severity'] = 'ERROR'


### PR DESCRIPTION
libdaos.so depends on a conflicting version of libdaos_common
with pmem enabled.  We don't want two versions of
libdaos_common pulled in at the same time.

Instead, statically link all of the libdaos targets into
the daos_engine binary and use libdaos_common_pmem.so
to resolve the needed symbols.

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>