### PR TITLE
DAOS-7623 control: bump system stop timeout to fix nlt failure

### DIFF
--- a/src/control/server/harness.go
+++ b/src/control/server/harness.go
@@ -23,8 +23,8 @@ import (
 )
 
 const (
-	rankReqTimeout   = 10 * time.Second
-	rankStartTimeout = 3 * rankReqTimeout
+	rankReqTimeout   = 30 * time.Second
+	rankStartTimeout = 2 * rankReqTimeout
 )
 
 // EngineHarness is responsible for managing Engine instances.


### PR DESCRIPTION
Increase fanout rank stop/start request timeouts from 10/30 to 30/60
seconds respectively.

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>