### PR TITLE
DAOS-7480 pool: add co_in_ver to pool map

### DIFF
--- a/src/common/pool_map.c
+++ b/src/common/pool_map.c
@@ -1514,6 +1514,7 @@ gen_pool_buf(struct pool_map *map, struct pool_buf **map_buf_out,
 		map_comp.co_id = (p - uuids) + num_comps;
 		map_comp.co_rank = target_addrs->rl_ranks[i];
 		map_comp.co_ver = map_version;
+		map_comp.co_in_ver = map_version;
 		map_comp.co_fseq = 1;
 		map_comp.co_flags = PO_COMPF_NONE;
 		map_comp.co_nr = dss_tgt_nr;
@@ -1542,6 +1543,7 @@ gen_pool_buf(struct pool_map *map, struct pool_buf **map_buf_out,
 			map_comp.co_id = (i * dss_tgt_nr + j) + num_comps;
 			map_comp.co_rank = target_addrs->rl_ranks[i];
 			map_comp.co_ver = map_version;
+			map_comp.co_in_ver = map_version;
 			map_comp.co_fseq = 1;
 			map_comp.co_flags = PO_COMPF_NONE;
 			map_comp.co_nr = 1;

--- a/src/include/daos/pool_map.h
+++ b/src/include/daos/pool_map.h
@@ -59,6 +59,7 @@ enum pool_component_flags {
 	PO_COMPF_DOWN2OUT	= 1,
 };
 
+#define co_in_ver	co_out_ver
 /** parent class of all all pool components: target, domain */
 struct pool_component {
 	/** pool_comp_type_t */
@@ -78,11 +79,16 @@ struct pool_component {
 	uint32_t		co_ver;
 	/** failure sequence */
 	uint32_t		co_fseq;
+
 	/**
-	 * version it's been EXCLUDE_OUT (when status set to
-	 * PO_COMP_ST_DOWNOUT).
+	 * co_in_ver and co_out_ver are shared the same item here.
+	 * If the target status(co_status) is PO_COMP_ST_DOWNOUT.
+	 * it means the map version when the target is excluded.
+	 * Otherwise, it is the map version when the target is
+	 * extended or reintegrated.
 	 */
-	uint32_t		co_out_ver;
+	uint32_t		co_out_ver; /* co_in_ver */
+
 	/** flags, see enum pool_component_flags */
 	uint32_t		co_flags;
 	/** number of children or storage partitions */

--- a/src/object/srv_obj_migrate.c
+++ b/src/object/srv_obj_migrate.c
@@ -2536,8 +2536,12 @@ free:
 
 	if (tls->mpt_status == 0 && rc < 0)
 		tls->mpt_status = rc;
-	D_DEBUG(DB_REBUILD, "stop migrate obj "DF_UOID" for shard %u: "
-		DF_RC"\n", DP_UOID(arg->oid), arg->shard, DP_RC(rc));
+
+	D_DEBUG(DB_REBUILD, ""DF_UUID"/%u stop migrate obj "DF_UOID
+		" for shard %u executed "DF_U64" : " DF_RC"\n",
+		DP_UUID(tls->mpt_pool_uuid), tls->mpt_version,
+		DP_UOID(arg->oid), arg->shard, tls->mpt_obj_executed_ult,
+		DP_RC(rc));
 	D_FREE(arg->snaps);
 	D_FREE(arg);
 	migrate_pool_tls_put(tls);
@@ -2621,8 +2625,10 @@ migrate_one_object(daos_unit_oid_t oid, daos_epoch_t eph, unsigned int shard,
 
 	d_iov_set(&val_iov, &val, sizeof(struct migrate_obj_val));
 	rc = obj_tree_insert(toh, cont_arg->cont_uuid, oid, &val_iov);
-	D_DEBUG(DB_REBUILD, "Insert "DF_UUID"/"DF_UOID": "DF_RC"\n",
-		DP_UUID(cont_arg->cont_uuid), DP_UOID(oid), DP_RC(rc));
+	D_DEBUG(DB_REBUILD, "Insert "DF_UUID"/"DF_UUID"/"DF_UOID": ver %u "
+		"generated "DF_U64" "DF_RC"\n", DP_UUID(tls->mpt_pool_uuid),
+		DP_UUID(cont_arg->cont_uuid), DP_UOID(oid), tls->mpt_version,
+		tls->mpt_obj_generated_ult, DP_RC(rc));
 
 	return 0;
 
@@ -3112,10 +3118,10 @@ ds_migrate_query_status(uuid_t pool_uuid, uint32_t ver,
 	ABT_cond_broadcast(tls->mpt_inflight_cond);
 	ABT_mutex_unlock(tls->mpt_inflight_mutex);
 
-	D_DEBUG(DB_REBUILD, "pool "DF_UUID" migrating=%s,"
+	D_DEBUG(DB_REBUILD, "pool "DF_UUID" ver %u migrating=%s,"
 		" obj_count="DF_U64", rec_count="DF_U64
 		" size="DF_U64" obj %u/%u general %u/%u status %d\n",
-		DP_UUID(pool_uuid), dms->dm_migrating ? "yes" : "no",
+		DP_UUID(pool_uuid), ver, dms->dm_migrating ? "yes" : "no",
 		dms->dm_obj_count, dms->dm_rec_count, dms->dm_total_size,
 		arg.obj_generated_ult, arg.obj_executed_ult,
 		arg.generated_ult, arg.executed_ult, dms->dm_status);

--- a/src/pool/srv_pool_map.c
+++ b/src/pool/srv_pool_map.c
@@ -119,7 +119,7 @@ update_one_tgt(struct pool_map *map, struct pool_target *target,
 			D_DEBUG(DF_DSMS, "change "DF_TARGET" to UP %p\n",
 				DP_TARGET(target), map);
 			target->ta_comp.co_status = PO_COMP_ST_UP;
-			++(*version);
+			target->ta_comp.co_in_ver = ++(*version);
 			if (print_changes)
 				D_PRINT(DF_TARGET " start reintegration.\n",
 					DP_TARGET(target));
@@ -160,7 +160,7 @@ update_one_tgt(struct pool_map *map, struct pool_target *target,
 			rc = pool_map_activate_new_target(map,
 						target->ta_comp.co_id);
 			D_ASSERT(rc != 0); /* This target must be findable */
-			(*version)++;
+			target->ta_comp.co_in_ver = ++(*version);
 			break;
 		}
 		break;

--- a/src/rebuild/srv.c
+++ b/src/rebuild/srv.c
@@ -1685,8 +1685,13 @@ regenerate_task_internal(struct ds_pool *pool, struct pool_target *tgts,
 		id_list.pti_ids = &tgt_id;
 		id_list.pti_number = 1;
 
-		rc = ds_rebuild_schedule(pool, tgt->ta_comp.co_fseq,
-					 &id_list, rebuild_op, 0);
+		if (rebuild_op == RB_OP_FAIL || rebuild_op == RB_OP_DRAIN)
+			rc = ds_rebuild_schedule(pool, tgt->ta_comp.co_fseq,
+						 &id_list, rebuild_op, 0);
+		else
+			rc = ds_rebuild_schedule(pool, tgt->ta_comp.co_in_ver,
+						 &id_list, rebuild_op, 0);
+
 		if (rc) {
 			D_ERROR(DF_UUID" schedule op %d ver %d failed: "
 				DF_RC"\n",


### PR DESCRIPTION
Add co_in_ver to the pool map, which will share with co_out_ver
to indicate when the target is being reintegrated or extended,
so if the leader is switched or restarted, it can retrieve the
extend or reintegrate job version correctly.

Add more debug information to the rebuild process.

Signed-off-by: Di Wang <di.wang@intel.com>