### PR TITLE
DAOS-7222 build: Build debuginfo packages on SUSE

### DIFF
--- a/ci/provisioning/post_provision_config_nodes_LEAP_15.sh
+++ b/ci/provisioning/post_provision_config_nodes_LEAP_15.sh
@@ -54,6 +54,8 @@ post_provision_config_nodes() {
     time dnf repolist
     # the group repo is always on the test image
     #add_group_repo
+    # in fact is's on the Leap image twice so remove one
+    rm -f $REPOS_DIR/daos-stack-ext-opensuse-15-stable-group.repo
     add_local_repo
     time dnf repolist
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+daos (1.2.0-4) unstable; urgency=medium
+  [ Brian J. Murrell ]
+  * Enable debuginfo package building on SUSE platforms
+
+ -- Brian J. Murrell <brian.murrell@intel.com>  Mon, 17 May 2021 18:30:05 -0400
+
 daos (1.2.0-3) unstable; urgency=medium
   [ Brian J. Murrell ]
   * Package /etc/daos/certs in main/common package so that both server

--- a/src/tests/ftest/launch.py
+++ b/src/tests/ftest/launch.py
@@ -1575,7 +1575,11 @@ def resolve_debuginfo_dnf(pkg):
 
 def install_debuginfos():
     """Install debuginfo packages."""
-    install_pkgs = [{'name': 'gdb'}]
+    distro_info = detect()
+    if "centos" in distro_info.name.lower():
+        install_pkgs = [{'name': 'gdb'}, {'name': 'python3-debuginfo'}]
+    else:
+        install_pkgs = []
 
     cmds = []
 
@@ -1592,20 +1596,27 @@ def install_debuginfos():
         cmds.append(["sudo", "rm", "-f", path])
 
     if USE_DEBUGINFO_INSTALL:
-        distro_info = detect()
-        yum_args = ["--exclude", "ompi-debuginfo", "openmpi3"]
-        if "suse" in distro_info.name.lower():
-            yum_args.extend(["libpmemobj1", "python3"])
-        elif "centos" in distro_info.name.lower():
-            yum_args.extend(["libpmemobj", "python36"])
-        else:
-            raise RuntimeError(
-                "install_debuginfos(): Unsupported distro: {}".format(
-                    distro_info))
-        cmds.append(["sudo", "yum", "-y", "install"] + yum_args)
+        dnf_args = ["--exclude", "ompi-debuginfo"]
+        if os.getenv("TEST_RPMS", 'false') == 'true':
+            if "suse" in distro_info.name.lower():
+                dnf_args.extend(["libpmemobj1", "python3", "openmpi3"])
+            elif "centos" in distro_info.name.lower() and \
+                 distro_info.version == "7":
+                dnf_args.extend(["--enablerepo=*-debuginfo", "--exclude",
+                                 "nvml-debuginfo", "libpmemobj",
+                                 "python36", "openmpi3", "gcc"])
+            elif "centos" in distro_info.name.lower() and \
+                 distro_info.version == "8":
+                dnf_args.extend(["--enablerepo=*-debuginfo", "libpmemobj",
+                                 "python3", "openmpi", "gcc"])
+            else:
+                raise RuntimeError(
+                    "install_debuginfos(): Unsupported distro: {}".format(
+                        distro_info))
+            cmds.append(["sudo", "dnf", "-y", "install"] + dnf_args)
         cmds.append(
-            ["sudo", "debuginfo-install", "--enablerepo=*-debuginfo", "-y"] +
-            yum_args + ["daos-server", "gcc"])
+            ["sudo", "dnf", "debuginfo-install",
+             "-y"] + dnf_args + ["daos-server"])
     else:
         # We're not using the yum API to install packages
         # See the comments below.
@@ -1626,7 +1637,10 @@ def install_debuginfos():
     # yum_base.processTransaction(rpmDisplay=yum.rpmtrans.NoOutputCallBack())
 
     # Now install a few pkgs that debuginfo-install wouldn't
-    cmd = ["sudo", "yum", "-y", "--enablerepo=*debug*", "install"]
+    cmd = ["sudo", "dnf", "-y"]
+    if "centos" in distro_info.name.lower():
+        cmd.append("--enablerepo=*debug*")
+    cmd.append("install")
     for pkg in install_pkgs:
         try:
             cmd.append(
@@ -1642,13 +1656,15 @@ def install_debuginfos():
             print(run_command(cmd))
         except RuntimeError as error:
             # got an error, so abort this list of commands and re-run
-            # it with a yum clean, makecache first
+            # it with a dnf clean, makecache first
             print(error)
             retry = True
             break
     if retry:
         print("Going to refresh caches and try again")
-        cmd_prefix = ["sudo", "yum", "--enablerepo=*debug*"]
+        cmd_prefix = ["sudo", "dnf"]
+        if "centos" in distro_info.name.lower():
+            cmd_prefix.append("--enablerepo=*debug*")
         cmds.insert(0, cmd_prefix + ["clean", "all"])
         cmds.insert(1, cmd_prefix + ["makecache"])
         for cmd in cmds:

--- a/src/tests/ftest/scripts/main.sh
+++ b/src/tests/ftest/scripts/main.sh
@@ -223,7 +223,8 @@ fi
 
 launch_args="-jcrisa"
 # can only process cores on EL7 currently
-if [ "$(lsb_release -s -i)" = "CentOS" ]; then
+if [ "$(lsb_release -s -i)" = "CentOS" ] ||
+   [ "$(lsb_release -s -i)" = "openSUSE" ]; then
     launch_args="-jcrispa"
 fi
 

--- a/utils/rpms/daos.spec
+++ b/utils/rpms/daos.spec
@@ -8,7 +8,7 @@
 
 Name:          daos
 Version:       1.2.0
-Release:       3%{?relval}%{?dist}
+Release:       4%{?relval}%{?dist}
 Summary:       DAOS Storage Engine
 
 License:       BSD-2-Clause-Patent
@@ -204,6 +204,12 @@ Summary: The DAOS development libraries and headers
 
 %description devel
 This is the package needed to build software with the DAOS library.
+
+%if (0%{?suse_version} > 0)
+%global __debug_package 1
+%global _debuginfo_subpackages 0
+%debug_package
+%endif
 
 %prep
 %autosetup
@@ -403,6 +409,9 @@ getent passwd daos_agent >/dev/null || useradd -s /sbin/nologin -r -g daos_agent
 %{_libdir}/*.a
 
 %changelog
+* Mon May 17 2021 Brian J. Murrell <brian.murrell@intel.com> 1.2.0-4
+- Enable debuginfo package building on SUSE platforms
+
 * Wed May 06 2021 Brian J. Murrell <brian.murrell@intel.com> 1.2.0-3
 - Package /etc/daos/certs in main/common package so that both server
   and client get it created


### PR DESCRIPTION
Whereas RH distros do this automatically, it would appear that one needs
to specifically configure one's specfile to generate debuginfo packages
on SUSE platforms.