### PR TITLE
DAOS-7342 engine: clean up all modules regardless of errors

### DIFF
--- a/src/engine/module.c
+++ b/src/engine/module.c
@@ -327,7 +327,7 @@ dss_module_cleanup_all(void)
 		if (rc != 0) {
 			D_ERROR("failed to clean up module %s: "DF_RC"\n",
 				m->sm_name, DP_RC(rc));
-			break;
+			/** continue clean-ups regardless ... */
 		}
 		D_INFO("Module %s: cleaned up\n", m->sm_name);
 	}


### PR DESCRIPTION
While looking into recent leap 15 failures, I noticed the following message:

dss_module_cleanup_all() failed to clean up module mgmt: DER_NOTLEADER(-2008): 'Not service leader'

This caused dss_module_cleanup_all() to abort the cleanup and leave
some modules behind that are still up & running.

The DER_NOTLEADER error will be addressed in a different patch,
but let's continue the cleanup regardless of errors for now.

Signed-off-by: Johann Lombardi <johann.lombardi@intel.com>