### PR TITLE
DAOS-7645 proc: Fix crash on error path.

### DIFF
--- a/src/common/proc.c
+++ b/src/common/proc.c
@@ -177,7 +177,8 @@ crt_proc_daos_prop_t(crt_proc_t proc, crt_proc_op_t proc_op, daos_prop_t **data)
 		prop->dpp_reserv = tmp;
 		rc = crt_proc_prop_entries(proc, proc_op, prop);
 		if (rc) {
-			daos_prop_free(prop);
+			D_FREE(prop->dpp_entries);
+			D_FREE(prop);
 			return rc;
 		}
 		*data = prop;
@@ -187,12 +188,12 @@ crt_proc_daos_prop_t(crt_proc_t proc, crt_proc_op_t proc_op, daos_prop_t **data)
 		if (prop == NULL)
 			return 0;
 		if (prop->dpp_nr == 0 || prop->dpp_entries == NULL) {
-			D_FREE_PTR(prop);
+			D_FREE(prop);
 			return 0;
 		}
 		crt_proc_prop_entries(proc, proc_op, prop);
 		D_FREE(prop->dpp_entries);
-		D_FREE_PTR(prop);
+		D_FREE(prop);
 		return 0;
 	default:
 		D_ERROR("bad proc_op %d.\n", proc_op);


### PR DESCRIPTION
Avoid a crash on free by calling D_FREE, rather than
daos_prop_free().

This crash was caught by fault injection testing.

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>
