### PR TITLE
1.2 proc

### DIFF
--- a/src/common/proc.c
+++ b/src/common/proc.c
@@ -182,7 +182,8 @@ crt_proc_daos_prop_t(crt_proc_t proc, daos_prop_t **data)
 		prop->dpp_reserv = tmp;
 		rc = crt_proc_prop_entries(proc, proc_op, prop);
 		if (rc) {
-			daos_prop_free(prop);
+			D_FREE(prop->dpp_entries);
+			D_FREE(prop);
 			return rc;
 		}
 		*data = prop;
@@ -192,12 +193,12 @@ crt_proc_daos_prop_t(crt_proc_t proc, daos_prop_t **data)
 		if (prop == NULL)
 			return 0;
 		if (prop->dpp_nr == 0 || prop->dpp_entries == NULL) {
-			D_FREE_PTR(prop);
+			D_FREE(prop);
 			return 0;
 		}
 		crt_proc_prop_entries(proc, proc_op, prop);
 		D_FREE(prop->dpp_entries);
-		D_FREE_PTR(prop);
+		D_FREE(prop);
 		return 0;
 	default:
 		D_ERROR("bad proc_op %d.\n", proc_op);


### PR DESCRIPTION
- DAOS-623 test: Fix % substitutions in repo paths (#4755)
- DAOS-6714 rebuild: Delete redundant objects prior to reintegration (#4657) (#4756)
- DAOS-5157 control: Make GetAttachInfo() backward-compatible (#4753)
- DAOS-6851 test: Fixed and improved daos object query test (#4716) (#4780)
- DAOS-623 test: Run daily integration testing (#4796)
- DAOS-2614 doc: Update common README (#4775) (#4788)
- DAOS-2615 docs: update README for some client APIs (#4799) (#4809)
- DAOS-6759 java: Update Hadoop from v 2.6.7 to 3.1.3 (#4774)
- DAOS-6900 test: Fix avocado monkey patching (#4818)
- DAOS-5866 test: Negative testing (OSA dmg command) (#4633) (#4778)
- DAOS-6699 misc: Fix coverity issues (#4824)
- DAOS-6869 tests: Fix large_file_count.py in weekly run (#4744) (#4783)
- DAOS-6860 test: Fix broken NvmeIoVerification in weekly run (#4731) (#4784)
- DAOS-6905 tests: Fixing false failures in llnl_mpi4py and romio tests (#4825) (#4826)
- DAOS-6745 build: Install correct systemd units based on version (#4800)
- DAOS-6748 placement: Do not clear used_tgts in get_target (#4751) (#4829)
- DAOS-4935 rdb: Update README.md (#4871)
- DAOS-6929 Java: Update Hadoop dependency from 3.1.3 to 3.2.2 (#4870)
- DAOS-6932 tests: Resolving DmgCommand JSON parsing error (#4890)
- DAOS-6466 object: a few fixes for Drain (#4813) (#4830)
- DAOS-6891 control: Clean up JSON output for errors (#4864)
- DAOS-6927 control: Clamp max allowed pool svc reps (#4887)
- DAOS-4698 vos: Report future object punch with iterator (#4854) (#4891)
- daos-6683 SDL: coverity fix 316578 (#4885)
- DAOS-6840 rebuild: add iv_sync to rebuild iv. (#4855) (#4884)
- DAOS-6721 build: Update submodule raft (#4589) (#4820)
- DAOS-6931 test: Fix pool/evict_test.yaml (#4846) (#4889)
- DAOS-6731 sdl: Fix coverity defect in CaRT IV server test (#4793) (#4896)
- DAOS-6878 test: Fix control daos_snapshot script issue (#4863)
- DAOS-6915 control: Don't allow new ranks to claim existing (#4888)
- DAOS-6359 tests: Replacing rebuild tests 'start_rebuild' method (#4527) (#4892)
- DAOS-4555 vos: Reprobe iterator if nested iterator yields (#4865) (#4910)
- DAOS-6783 control: return non-zero on dmg system stop result error (#4909)
- DAOS-6879 object: Select I/O RDG by JCH (#4772) (#4894)
- DAOS-6840 objects: check zero iod during migration (#4760) (#4882)
- DAOS-5737 tests: Removing oclass param from create_cont() (#4729) (#4853)
- DAOS-6464 tests: add extend simple test (#4837) (#4883)
- DAOS-6899 control: Fix JSON representation of pool rebuild state (#4936)
- DAOS-6895 tests: Fix BadEvict test in weekly run. (#4805) (#4862)
- DAOS-6798 iv: stop the iv ns leader first during destroy (#4886)
- DAOS-6988 dtx: avoid leader switch during server reintegration (#4935)
- DAOS-6989 dtx: initialize daos_unit_oid_t::id_pad_32 (#4941)
- DAOS-6925 rebuild: remove obsolote check in scan (#4872) (#4927)
- DAOS-6953 vos: Avoid under punch under normal I/O (#4868) (#4954)
- DAOS-6678 csum: Fixed issues caught by coverity (#4916) (#4951)
- DAOS-6853 engine: Introduce dss_drpc_call (#4717) (#4931)
- DAOS-6918-test_rel_1.2: pool_destroy testcase failed due to Timeout (#4957)
- DAOS-6732 coverity: Remove line of code that is not reached (#4797) (#4942)
- DAOS-6515 placement: Find spare targets even when fault domains are used (#4906) (#4965)
- DAOS-6947 test: remove pool storage ratio tests (#5003)
- DAOS-5827 csum: Checksum Verify During Object Enumerate (#4923)
- DAOS-6574 duns: some bug fixes and features to DUNS (#4798) (#4937)
- DAOS-623 test: Add compatibility for new Python 3 Avocado 69.2 RPMs (#4985)
- DAOS-6801 Security: Implement Secure Erase for Credential memory (#4690) (#4963)
- CORCI-1060 ci: Use correct builds for warnings-ng/NLT reference. (#4984)
- DAOS-6808 misc: Fix the server IV memmory leak (#4944) (#5013)
- DAOS-6790 tests: Fix daos_agent start-up issues. (#4636) (#5016)
- DAOS-7010 control: dmg system query output consistent for single rank (#4992)
- DAOS-5621 test: add all test servers in dmg.yaml hostlist (#4996)
- DAOS-7007 md,test: fix NO_OF_MAX_CONTAINER setting (#4988)
- DAOS-6928 test: Daos pool list-containers succeed after the pool already been evicted (#5022)
- DAOS-7009 dfs: dfs async IO should return errno instead of -der (#4987) (#5011)
- DAOS-7015 event: proper event handing in case of progress errors (#4911) (#4961)
- DAOS-6726 vos: rollback DTX commit entry if fail to commit (#4933)
- DAOS-7004 Java: Update Netty to latest version (#4962)
- DAOS-6979 csum: Fixes detected by NLT (#4915) (#5033)
- DAOS-6678 sdl: Fix various coverity defects in placement tests (#4794) (#5044)
- DAOS-6926 logging: Do not check for facility used in alloc/free. (#4839) (#5030)
- DAOS-7046 Java: Update Hadoop from 3.2.2 to 3.3.0 (#5067)
- DAOS-7054 Telemetry: Coverity scan fixes (#5082)
- DAOS-623 CI: Skip a test based on a list (#5093)
- DAOS-623 test: Don't add repos that are already present (#5035) (#5047)
- DAOS-6967 vos: Data loss on updates after uncommitted punch (#4899) (#5059)
- DAOS-5758 vos: Add garbage collection at container level (#4997) (#5060)
- DAOS-6808 pool: Fix cleanuping resources (#5057)
- DAOS-3105 control: Scrub engine environment (#4968)
- DAOS-6999 object: add shard id to daos_shard_tgt (#4959) (#5055)
- DAOS-6978 rebuild: return NOTLEADER for -1 master rank (#4921) (#4966)
- DAOS-6968 test: Lower performance threshold with interception library (#4924) (#5091)
- DAOS-6321 test: Unskip and fix container/full_pool_container_create.py (#4972) (#5054)
- DAOS-6259 test: Remove Ring Placement Test from Weekly Test (#5034) (#5081)
- DAOS-6997 rebuild: Not set complete for reschedule rebuild (#4953) (#5046)
- DAOS-6995 dtx: check dlh_future in dtx_leader_wait (#4952) (#5045)
- Python3 update: Avocado 82.0 LTS (#4615) (#5100)
- DAOS-7024 build: Update Argobots to 1.1rc1 (#5048)
- DAOS-7052 control: Vendor forked raft-boltdb (#5104)
- DAOS-623 build: Do not try and install the python3 package (#5127) (#5138)
- DAOS-6961-test-1.2: Pool rebuild test scripts update work around for JIRA DAOS-6865 (#5148)
- DAOS-6970 iv: avoid pool connect/disconnect failure (#4903) (#5112)
- DAOS-7074 control: support multiple hyphens in hostlist names (#5151)
- DAOS-6319 rsvc: Optimize bootstrapping latencies (#4873) (#5107)
- DAOS-7089 test: Fix object/obj_update_bad_param.py in release/1.2 (#5163)
- DAOS-6871 test: disable datamover copy_space (#4758) (#5156)
- DAOS-7013 obj: OIT should match with cont_rf (#5000) (#5102)
- DAOS-6999 tests: add tests to verify reintegrate inflight IO (#5058) (#5115)
- DAOS-7090 test: Fix failing weekly test object_integrity.py on release/1.2 (#5140)
- DAOS-7085-test_rel-1.2: pool destroy multi-loop test failed on 1.2 CI due to timeout. (#5179)
- DAOS-6772 doc: update dedup limitations (#5004) (#5197)
- DAOS-6783 bio: timeout for spdk_subsystem_fini() (#5113)
- DAOS-4698 rebuild: Rebuild object migration should execute applicable object punch for each migration. (#4895) (#5188)
- DAOS-6808 rpc: fix memleak in MGMT_TGT_CREATE corpc (#5110)
- DAOS-7095 test: Fix weekly test nvme_io_verification (#5161)
- DAOS-5279 rebuild: add rebuild inflight control (#4656) (#5172)
- DAOS-5279 bio: change DMA chunk size to 8MB (#5169) (#5196)
- DAOS-6632 obj: add support for hints on the oclass generate API (#4831) (#5181)
- DAOS-7098 test: dfs test increment nr fail (#5180)
- DAOS-7042 test: adjust daos container check output (#5143)
- DAOS-6792 sched: fix improper assert (#5005) (#5128)
- DAOS-6733 vos: handle resend RPC when original one is not prepared (#5213)
- DAOS-5830 release: Update version to v1.1.4 (#5123)
- DAOS-623 ci: Add release/1.2 PRs to priority level 2 (#5155)
- DAOS-5758 pl: fixes for placement (#5146) (#5173)
- DAOS-6726 engine: Resolve two leaks in the drpc code. (#4782) (#4861)
- DAOS-6572 container: Use CDEBUG to silence more warnings. (#5216)
- DAOS-6709 rsvc: xfer only attr size and fix tests (#4745) (#5152)
- DAOS-7040 vos: reserved bytes for pool & container (#5051) (#5103)
- DAOS-7092 object: define more object classes (#5075) (#5194)
- DAOS-623 build: Split hardware tests into a new pipeline stage (#5144)
- DAOS-7064 object: EEXIST or NOEXIST for conditional ops should not be logged as errors (#5094) (#5118)
- DAOS-6452 test: Use JSON for dmg pool query and update tests (#4803) (#5090)
- DAOS-6767 Test: Update the config function to use default server config path. (#4604) (#5135)
- DAOS-7114-test_rel_1.2: security pool_connect_init failed -1025 due to SCM request too small (#5212)
- DAOS-6681 sdl: Various coverity defects in object and EC code (#4919) (#5159)
- DAOS-6581 test: make valgrind suppression file more general (#4532) (#5099)
- DAOS-6632 object: fix comment about default sharding hint for oclass (#5231)
- DAOS-4855 debug: set default log mask to DLOG_ERR (#5174) (#5235)
- DAOS-5758 tests: fix typo in placement test (#5191) (#5223)
- DAOS-7102 DFS: correct name of max len instead of path (#5190) (#5215)
- DAOS-6376 container: Get Props with Open Container Handle (#5114)
- DAOS-7115 test: Fix rebuild_test.py failing in CI (#5226) (#5244)
- DAOS-6965 Test: Increased the SCM size as recent layout change need more space with current dataset. (#4928) (#5228)
- DAOS-6923 test: Offline Reintegration - More tests (#4835) (#5253)
- CART-89 ofi: Update ofi to 1.12 (#5224)
- DAOS-7061 rebuild: avoid single replica object (#5084) (#5205)
- DAOS-7088 Test: Fix NVMe util for calculating IOR block size. (#5136) (#5239)
- DAOS-6996 packaging: Move libdts.so to daos-tests (#5122)
- DAOS-6916 test: Fix interception library tests by letting threads to have independent data (#4828) (#5243)
- DAOS-5952 dtx: not restart TX if with specified epoch (#5142)
- DAOS-6944 test: Increase usage limit and verify CPU usage after runni… (#5214) (#5269)
- DAOS-7062 test: Fixing pool/pool_svc.py KeyError: 'leader' error (#5133) (#5270)
- DAOS-6572 engine: Use CDEBUG to silence shutdown warnings. (#4859) (#5199)
- DAOS-4757-test: remove skipForTicket rebuild read_array.py (#5307)
- DAOS-6903 Test: Fix regression in NVMe health test code. (#4832) (#5240)
- DAOS-7123 dfuse: Fix race condition in dfuse. (#5284)
- DAOS-6865 tests: Providing debug info (#4902) (#5288)
- DAOS-4817 test: Enable cov file generation on functional tests (#5021) (#5310)
- DAOS-6004 control: Fix system reformat (#5283)
- DAOS-7126 test: Create unique files in unit tests (#5308)
- DAOS-7117 build: Update Argobots to 1.1 (#5220)
- DAOS-3688 rsvc: Yield during ds_rsvc_start (#5032) (#5302)
- DAOS-7056 pool: check sp_map during aggregation (#5083) (#5225)
- DAOS-6808 container: Fix cleanuping resources (#5304)
- DAOS-7121 control: Separate fault code groups (#5245)
- DAOS-7175 test: Update pool_query_test to use json output (#5316)
- DAOS-5529 doc: update spark.md to reflect latest Java wrapper update (#4553) (#5341)
- DAOS-7150-test_release1.2: Enable cascading testcase (#5320)
- DAOS-7138 test: Enable skipped tests of bad_create.py (#5258)
- DAOS-7169 control: Fix intermittent deadlock on server startup (#5346)
- DAOS-7176-test_rel_1.2: enable pool/bad_create.yaml cancelled testcases (#5323)
- DAOS-7132 Control: ulimit on daos_server service too low (#5294)
- DAOS-7056 object: do not retry internally for migration (#5106) (#5351)
- DAOS-7111 test: Cleanup python2.7 references (#5206) (#5297)
- DAOS-7103 control: clean leftover hugepages on startup (#5366)
- DAOS-7119 control: exit nonzero from dmg storage cmd --json (#5330)
- DAOS-7071 dtx: pre-alloc DTX entry before local modification (#5209)
- DAOS-7086 test: Fixed UTF-8 string and bytes comparison bug (#5317) (#5359)
- DAOS-7140 bio: introduce DMA chunk type (#5312)
- DAOS-7162 control: Fix coverity issues (#5386)
- DAOS-7043 engine: switch module unload and iv fini (#5065) (#5392)
- DAOS-6629 EC: Update EC aggregation and EC client code to support array range punch (#4730) (#5395)
- DAOS-7136 object: merged recxs during punch migration (#5300) (#5396)
- DAOS-6753 test: Reenable skipped test: delete_objects.py (#5171) (#5389)
- DAOS-7198 control: Use join request context instead of timeout (#5398)
- DAOS-7133 tse: add lock to protect tse_task_complete_callback() (#5264) (#5402)
- DAOS-7194 control: fix coverity issues (#5412)
- DAOS-7141 object: Object enum support multiple iovs (#5404)
- DAOS-6632 object: refine oclass and num grp settings for auto class selection (#5383)
- DAOS-623 ci: Move functions to pipeline-lib (#5371)
- DAOS-7042 cont: fix a bug in ds_get_cont_props() (#5237) (#5421)
- DAOS-7199 rebuild: Do not add complete status in refresh iv (#5403) (#5432)
- DAOS-7196-test_rel_1.2: Enable negative testcases in pool/multi_server_create_delete_test.py (#5405)
- DAOS-623 doc: fix object header comment on flags to indicate supporte… (#5434)
- DAOS-7192 rebuild: Check if the container is destroyed (#5354) (#5458)
- DAOS-7202 rebuild: check if rgt is NULL (#5431) (#5460)
- DAOS-7073 dtx: use latest pool map for DTX resync and refresh (#5454)
- DAOS-7215 object: validity check for transactional modification (#5451)
- DAOS-6572 test: Silence more IV warnings on -DER_NOTLEADER. (#5201) (#5234)
- DAOS-7238 Test: Fixed coverity issue in test code. (#5471)
- DAOS-7173 dtx: wait container to be detached from batched commit ULT (#5388)
- DAOS-7162 security: Fix coverity issues found in cert loading code (#… (#5465)
- DAOS-7241 pool: coverity fix map_comp.co_flags assignment (#5473)
- DAOS-623 ci: Fix a skip-list logic error (#5461)
- DAOS-7234 object: set size for EC obj with multiple group (#5450) (#5485)
- DAOS-7229 build: Remove client dependence on server libraries (#5445) (#5476)
- DAOS-7239 coverity: various fixes in placement (#5463) (#5481)
- bmurrell/simplify-cron-trigger-matches (#5515)
- daos-7249 doc: document 3rd party code usage (#5486) (#5518)
- DAOS-7242 coverity: fixes in ds_mgmt_drpc_pool_create (#5462) (#5482)
- DAOS-6604 coverity: defect in fs_copy (#5457) (#5505)
- DAOS-7238 test: check pool create svc_reps length for Coverity issue (#5517)
- DAOS-7123 dfuse: Fix coverity issues arising from recent changes. (#5335) (#5477)
- DAOS-7240 obj: Coverity fixes (#5507)
- DAOS-7281 Test:Fix Coverity Issue in NVMe Recovery Test (#5531)
- DAOS-7152 test: increase timeout of dfs unit test, and run on SCM only (#5464) (#5480)
- DAOS-6941 build: Remove telemetry from 1.2 branch (#4912)
- DAOS-623 ci: Make TestTag parameter default empty (#5544)
- DAOS-7246 Fix Coverity issue in CaRT Test code (#5495)
- DAOS-623 test: Install unversioned python for pylint. (#5497)
- DAOS-7259 dfs: dfs does not require fuse3 to build. (#5489) (#5506)
- DAOS-7170 obj: fix bug in obj_list_get_shard (#5334) (#5555)
- DAOS-7165 VOS: free VOS pools attached on GC (#5472) (#5561)
- DAOS-7092 object: add 96-group for replications (#5563)
- DAOS-6038 build: relax ipmctl version requirement for leap15 in spec (#5491) (#5551)
- DAOS-7238 test: another check of pool create svc_reps length (#5558)
- DAOS-6798 pool: fix deadlock on pool destroy (#5494) (#5566)
- Update version to v1.2-rc1 (#5567)
- DAOS-7365 doc: update storage prepare usage in admin guide (#5602) (#5611)
- DAOS-7359 dtx: handle noop update properly (#5600)
- DAOS-7244 dtx: Fix a bug in dtx_aggregate (#5610)
- CART-960 msg: Downgrade warning message (#5241) (#5568)
- DAOS-5830 release: Update version to v1.2-rc2 (#5608)
- DAOS-623 doc: Update README.md (#5614) (#5620)
- DAOS-5036 doc: update for 1.2 (#5616)
- DAOS-7191 rebuild: check if leader change before IV (#5394) (#5580)
- DAOS-7363 control: set target user if empty in remote nvme prepare (#5609)
- DAOS-7363 control: set target user if empty in local nvme prepare (#5606)
- DAOS-5036 doc: fix Leap15 package path (#5640)
- DAOS-7193 test: Ignore rdb_stop() warning in server logs.(#5360) (#5574)
- DAOS-7388 doc: Update deployment.md for certs (#5631)
- DAOS-623 common: Cherry pick several bug fixes (#5665)
- DAOS-2617 documentation: update and refresh release notes (#5627)
- DAOS-6358 Test: Pool destroy failed with DER_TIMEOUT (#5358) (#5668)
- DAOS-7385 packaging: Move /etc/daos/certs … (#5662)
- DAOS-623 tse: fix mem leak when task is completed in prep cb (#5642) (#5683)
- DAOS-5847 dfs: chmod and setattr fixes (#5650) (#5686)
- DAOS-6808 misc: Fix cleaning up resources (#5010) (#5340)
- DAOS-7384 object: Prevent server assertion if key invalid (#5687)
- DAOS-5685 il: Force use of gcc for the interception library. (#5193) (#5659)
- DAOS-7222 build: Build debuginfo packages on SUSE (#5730)
- DAOS-7645 proc: Fix crash on error path. (#5743)
