### PR TITLE
Example of per container metrics

### DIFF
--- a/src/container/srv_internal.h
+++ b/src/container/srv_internal.h
@@ -38,16 +38,6 @@ struct cont_metrics {
 
 extern struct cont_metrics ds_cont_metrics;
 
-/* Metrics for each individual active container */
-struct active_cont_metrics {
-	uuid_t			pool_uuid;
-	uuid_t			cont_uuid;
-	d_list_t		link;
-
-	struct d_tm_node_t	*start_timestamp;
-	/* TODO: add more per-container metrics */
-};
-
 /* ds_cont thread local storage structure */
 struct dsm_tls {
 	struct daos_lru_cache  *dt_cont_cache;
@@ -303,7 +293,5 @@ int ds_cont_metrics_get_path(const uuid_t pool_uuid, const uuid_t cont_uuid,
 			     char *path, size_t path_len);
 void ds_cont_metrics_start(const uuid_t pool_uuid, const uuid_t cont_uuid);
 void ds_cont_metrics_stop(const uuid_t pool_uuid, const uuid_t cont_uuid);
-struct active_cont_metrics *ds_cont_metrics_get(const uuid_t pool_uuid,
-						const uuid_t cont_uuid);
 
 #endif /* __CONTAINER_SRV_INTERNAL_H__ */

--- a/src/container/srv_internal.h
+++ b/src/container/srv_internal.h
@@ -16,6 +16,7 @@
 #include <daos_srv/rdb.h>
 #include <daos_srv/rsvc.h>
 #include <daos_srv/container.h>
+#include <gurt/list.h>
 #include <gurt/telemetry_common.h>
 
 #include "srv_layout.h"
@@ -36,6 +37,16 @@ struct cont_metrics {
 };
 
 extern struct cont_metrics ds_cont_metrics;
+
+/* Metrics for each individual active container */
+struct active_cont_metrics {
+	uuid_t			pool_uuid;
+	uuid_t			cont_uuid;
+	d_list_t		link;
+
+	struct d_tm_node_t	*start_timestamp;
+	/* TODO: add more per-container metrics */
+};
 
 /* ds_cont thread local storage structure */
 struct dsm_tls {
@@ -288,5 +299,11 @@ int cont_iv_ec_agg_eph_refresh(void *ns, uuid_t cont_uuid, daos_epoch_t eph);
 /* srv_metrics.c */
 int ds_cont_metrics_init(void);
 int ds_cont_metrics_fini(void);
+int ds_cont_metrics_get_path(const uuid_t pool_uuid, const uuid_t cont_uuid,
+			     char *path, size_t path_len);
+void ds_cont_metrics_start(const uuid_t pool_uuid, const uuid_t cont_uuid);
+void ds_cont_metrics_stop(const uuid_t pool_uuid, const uuid_t cont_uuid);
+struct active_cont_metrics *ds_cont_metrics_get(const uuid_t pool_uuid,
+						const uuid_t cont_uuid);
 
 #endif /* __CONTAINER_SRV_INTERNAL_H__ */

--- a/src/container/srv_metrics.c
+++ b/src/container/srv_metrics.c
@@ -132,7 +132,7 @@ ds_cont_metrics_get_path(const uuid_t pool_uuid, const uuid_t cont_uuid,
 void
 ds_cont_metrics_start(const uuid_t pool_uuid, const uuid_t cont_uuid)
 {
-	struct active_cont_metrics	*metrics;
+	struct ds_active_cont_metrics	*metrics;
 	char				 path[D_TM_MAX_NAME_LEN] = {0};
 	int				 rc;
 
@@ -188,7 +188,7 @@ ds_cont_metrics_start(const uuid_t pool_uuid, const uuid_t cont_uuid)
 void
 ds_cont_metrics_stop(const uuid_t pool_uuid, const uuid_t cont_uuid)
 {
-	struct active_cont_metrics	*metrics;
+	struct ds_active_cont_metrics	*metrics;
 	char				 path[D_TM_MAX_NAME_LEN] = {0};
 	int				 rc;
 
@@ -224,10 +224,10 @@ ds_cont_metrics_stop(const uuid_t pool_uuid, const uuid_t cont_uuid)
  *
  * \return	Container's metrics structure, or NULL if not found
  */
-struct active_cont_metrics *
+struct ds_active_cont_metrics *
 ds_cont_metrics_get(const uuid_t pool_uuid, const uuid_t cont_uuid)
 {
-	struct active_cont_metrics *cur = NULL;
+	struct ds_active_cont_metrics *cur = NULL;
 
 	d_list_for_each_entry(cur, &per_cont_metrics, link) {
 		if (uuid_compare(pool_uuid, cur->pool_uuid) == 0 &&

--- a/src/container/srv_metrics.c
+++ b/src/container/srv_metrics.c
@@ -12,9 +12,25 @@
 
 #include "srv_internal.h"
 #include <gurt/telemetry_producer.h>
+#include <daos_srv/pool.h>
+
+/*
+ * Format for generating the container metrics directory path
+ */
+#define CONT_METRICS_DIR_FMT	"%s/cont/%s"
+
+/*
+ * Size in bytes of each per-container metric directory.
+ */
+#define CONT_METRICS_DIR_BYTES	(2 * 1024)
 
 /* Global container metrics */
 struct cont_metrics ds_cont_metrics;
+
+/**
+ * Per-container metrics
+ */
+static d_list_t per_cont_metrics;
 
 /**
  * Initialize global metrics used in the server container module.
@@ -54,6 +70,8 @@ ds_cont_metrics_init(void)
 		D_ERROR("failed to add close counter: "
 			DF_RC "\n", DP_RC(rc));
 
+	D_INIT_LIST_HEAD(&per_cont_metrics);
+
 	return 0;
 }
 
@@ -65,4 +83,157 @@ ds_cont_metrics_fini(void)
 {
 	/* nothing to do - shared memory will be cleaned up automatically */
 	return 0;
+}
+
+/**
+ * Fetch metrics path for a specific container.
+ *
+ * \param[in]	pool_uuid	UUID of the pool
+ * \param[in]	cont_uuid	UUID of the container
+ * \param[out]	path		Path to the container metrics
+ * \param[in]	path_len	Length of path array
+ *
+ * \return	0		Success
+ *		-DER_INVAL	Invalid inputs
+ */
+int
+ds_cont_metrics_get_path(const uuid_t pool_uuid, const uuid_t cont_uuid,
+			 char *path, size_t path_len)
+{
+	char	pool_path[D_TM_MAX_NAME_LEN] = {0};
+	char	c_uuid_str[DAOS_UUID_STR_SIZE];
+	int	rc;
+
+	if (!daos_uuid_valid(cont_uuid)) {
+		D_ERROR(DF_CONT ": bad container UUID\n",
+			DP_CONT(pool_uuid, cont_uuid));
+		return -DER_INVAL;
+	}
+	uuid_unparse(cont_uuid, c_uuid_str);
+
+	rc = ds_pool_metrics_get_path(pool_uuid, pool_path, sizeof(pool_path));
+	if (rc != 0) {
+		D_ERROR(DF_CONT ": unable to get path for pool uuid, " DF_RC
+			"\n", DP_CONT(pool_uuid, cont_uuid), DP_RC(rc));
+		return rc;
+	}
+
+	snprintf(path, path_len, CONT_METRICS_DIR_FMT, pool_path, c_uuid_str);
+	path[path_len - 1] = '\0';
+	return 0;
+}
+
+/**
+ * Add metrics for a specific container.
+ *
+ * \param[in]	pool_uuid	Pool UUID
+ * \param[in]	cont_uuid	Container UUID
+ */
+void
+ds_cont_metrics_start(const uuid_t pool_uuid, const uuid_t cont_uuid)
+{
+	struct active_cont_metrics	*metrics;
+	char				 path[D_TM_MAX_NAME_LEN] = {0};
+	int				 rc;
+
+	metrics = ds_cont_metrics_get(pool_uuid, cont_uuid);
+	if (metrics != NULL) /* already exists - nothing to do */
+		return;
+
+	rc = ds_cont_metrics_get_path(pool_uuid, cont_uuid, path, sizeof(path));
+	if (rc != 0) {
+		D_ERROR(DF_CONT ": unable to get pool metrics path, "DF_RC"\n",
+			DP_CONT(pool_uuid, cont_uuid), DP_RC(rc));
+		return;
+	}
+
+	rc = d_tm_add_ephemeral_dir(NULL, CONT_METRICS_DIR_BYTES, path);
+	if (rc != 0) {
+		D_ERROR(DF_CONT ": unable to create cont metrics dir, "
+			DF_RC "\n", DP_CONT(pool_uuid, cont_uuid), DP_RC(rc));
+		return;
+	}
+
+	D_ALLOC_PTR(metrics);
+	if (metrics == NULL) {
+		D_ERROR(DF_CONT ": failed to allocate metrics struct\n",
+			DP_CONT(pool_uuid, cont_uuid));
+		return;
+	}
+
+	uuid_copy(metrics->pool_uuid, pool_uuid);
+	uuid_copy(metrics->cont_uuid, cont_uuid);
+
+	/* Init all of the per-container metrics */
+	rc = d_tm_add_metric(&metrics->start_timestamp, D_TM_TIMESTAMP,
+			     "Last time the container started", NULL,
+			     "%s/started_at", path);
+	if (rc != 0)
+		D_ERROR(DF_CONT ": failed to add started_timestamp metric, "
+			DF_RC "\n", DP_CONT(pool_uuid, cont_uuid), DP_RC(rc));
+
+	/* Track with the per-container metrics */
+	d_list_add(&metrics->link, &per_cont_metrics);
+
+	D_INFO(DF_CONT ": created metrics for cont\n",
+	       DP_CONT(pool_uuid, cont_uuid));
+}
+
+/**
+ * Destroy metrics for a specific container.
+ *
+ * \param[in]	pool_uuid	Pool UUID
+ * \param[in]	cont_uuid	Container UUID
+ */
+void
+ds_cont_metrics_stop(const uuid_t pool_uuid, const uuid_t cont_uuid)
+{
+	struct active_cont_metrics	*metrics;
+	char				 path[D_TM_MAX_NAME_LEN] = {0};
+	int				 rc;
+
+	metrics = ds_cont_metrics_get(pool_uuid, cont_uuid);
+	if (metrics != NULL) {
+		d_list_del(&metrics->link);
+		D_FREE(metrics);
+	}
+
+	rc = ds_cont_metrics_get_path(pool_uuid, cont_uuid, path, sizeof(path));
+	if (rc != 0) {
+		D_ERROR(DF_CONT ": unable to get cont metrics path, "DF_RC"\n",
+			DP_CONT(pool_uuid, cont_uuid), DP_RC(rc));
+		return;
+	}
+
+	rc = d_tm_del_ephemeral_dir(path);
+	if (rc != 0) {
+		D_ERROR(DF_CONT ": unable to remove metrics dir for cont, "
+			DF_RC "\n", DP_CONT(pool_uuid, cont_uuid), DP_RC(rc));
+		return;
+	}
+
+	D_INFO(DF_CONT ": destroyed metrics for container\n",
+	       DP_CONT(pool_uuid, cont_uuid));
+}
+
+/**
+ * Get metrics for a specific active container.
+ *
+ * \param[in]	pool_uuid	Pool UUID
+ * \param[in]	cont_uuid	Container UUID
+ *
+ * \return	Container's metrics structure, or NULL if not found
+ */
+struct active_cont_metrics *
+ds_cont_metrics_get(const uuid_t pool_uuid, const uuid_t cont_uuid)
+{
+	struct active_cont_metrics *cur = NULL;
+
+	d_list_for_each_entry(cur, &per_cont_metrics, link) {
+		if (uuid_compare(pool_uuid, cur->pool_uuid) == 0 &&
+		    uuid_compare(cont_uuid, cur->cont_uuid) == 0)
+			return cur;
+	}
+
+	return NULL;
 }

--- a/src/container/srv_target.c
+++ b/src/container/srv_target.c
@@ -821,7 +821,7 @@ ds_cont_child_stop_all(struct ds_pool_child *pool_child)
 static void
 cont_metrics_start(const uuid_t pool_uuid, const uuid_t cont_uuid)
 {
-	struct active_cont_metrics *metrics;
+	struct ds_active_cont_metrics *metrics;
 
 	ds_cont_metrics_start(pool_uuid, cont_uuid);
 

--- a/src/control/lib/telemetry/promexp/collector.go
+++ b/src/control/lib/telemetry/promexp/collector.go
@@ -113,6 +113,25 @@ func sanitizeMetricName(in string) string {
 	}, strings.TrimLeft(in, "/"))
 }
 
+func parseNameSubstr(labels labelMap, name string, matchRE string, replacement string,
+	assignLabels func(labelMap, []string)) string {
+	re := regexp.MustCompile(matchRE)
+	matches := re.FindStringSubmatch(name)
+	if len(matches) > 0 {
+		assignLabels(labels, matches)
+
+		if replacement == "" {
+			return name
+		}
+		if strings.HasSuffix(matches[0], "_") {
+			replacement += "_"
+		}
+		name = re.ReplaceAllString(name, replacement)
+	}
+
+	return name
+}
+
 func fixPath(in string) (labels labelMap, name string) {
 	name = sanitizeMetricName(in)
 
@@ -123,42 +142,32 @@ func fixPath(in string) (labels labelMap, name string) {
 	ID_re := regexp.MustCompile(`ID_+(\d+)_?`)
 	name = ID_re.ReplaceAllString(name, "")
 
-	io_re := regexp.MustCompile(`io_+(\d+)_?`)
-	io_matches := io_re.FindStringSubmatch(name)
-	if len(io_matches) > 0 {
-		labels["target"] = io_matches[1]
-		replacement := "io"
-		if strings.HasSuffix(io_matches[0], "_") {
-			replacement += "_"
-		}
-		name = io_re.ReplaceAllString(name, replacement)
-	}
+	name = parseNameSubstr(labels, name, `io_+(\d+)_?`, "io",
+		func(labels labelMap, matches []string) {
+			labels["target"] = matches[1]
+		})
 
-	net_re := regexp.MustCompile(`net_+(\d+)_+(\d+)_?`)
-	net_matches := net_re.FindStringSubmatch(name)
-	if len(net_matches) > 0 {
-		labels["rank"] = net_matches[1]
-		labels["context"] = net_matches[2]
-
-		replacement := "net"
-		if strings.HasSuffix(net_matches[0], "_") {
-			replacement += "_"
-		}
-		name = net_re.ReplaceAllString(name, replacement)
-	}
+	name = parseNameSubstr(labels, name, `net_+(\d+)_+(\d+)_?`, "net",
+		func(labels labelMap, matches []string) {
+			labels["rank"] = matches[1]
+			labels["context"] = matches[2]
+		})
 
 	getHexRE := func(numDigits int) string {
 		return strings.Repeat(`[[:xdigit:]]`, numDigits)
 	}
 	uuid_re := fmt.Sprintf("%s_%s_%s_%s_%s", getHexRE(8), getHexRE(4), getHexRE(4),
 		getHexRE(4), getHexRE(12))
-	pool_re := regexp.MustCompile(`pool_current_+(` + uuid_re + `)`)
-	pool_matches := pool_re.FindStringSubmatch(name)
-	if len(pool_matches) > 0 {
-		labels["pool"] = strings.Replace(pool_matches[1], "_", "-", -1)
-		replacement := "pool"
-		name = pool_re.ReplaceAllString(name, replacement)
-	}
+
+	name = parseNameSubstr(labels, name, `pool_current_+(`+uuid_re+`)`, "pool",
+		func(labels labelMap, matches []string) {
+			labels["pool"] = strings.Replace(matches[1], "_", "-", -1)
+		})
+
+	name = parseNameSubstr(labels, name, `pool_cont_+(`+uuid_re+`)`, "cont",
+		func(labels labelMap, matches []string) {
+			labels["cont"] = strings.Replace(matches[1], "_", "-", -1)
+		})
 	return
 }
 

--- a/src/control/lib/telemetry/telemetry.go
+++ b/src/control/lib/telemetry/telemetry.go
@@ -303,6 +303,7 @@ func CollectMetrics(ctx context.Context, dirname string, out chan<- Metric) erro
 	if err != nil {
 		return err
 	}
+	C.d_tm_gc_ctx(hdl.ctx)
 
 	node := hdl.root
 

--- a/src/gurt/telemetry.c
+++ b/src/gurt/telemetry.c
@@ -3282,6 +3282,28 @@ d_tm_close(struct d_tm_context **ctx)
 }
 
 /**
+ * Releases deleted resources cached by the context.
+ *
+ * Recommended as a periodic task for telemetry clients.
+ *
+ * \param[in]	ctx	Context to be garbage collected
+ */
+void
+d_tm_gc_ctx(struct d_tm_context *ctx)
+{
+	struct local_shmem_list *cur = NULL;
+	struct local_shmem_list *next = NULL;
+
+	if (ctx == NULL)
+		return;
+
+	d_list_for_each_entry_safe(cur, next, &ctx->open_shmem, link) {
+		if (cur->region == NULL || cur->region->sh_deleted)
+			close_local_shmem_entry(cur, false);
+	}
+}
+
+/**
  * Allocates memory from within the shared memory pool with 64-bit alignment
  * Clears the allocated buffer.
  *

--- a/src/gurt/tests/test_gurt_telem_producer.c
+++ b/src/gurt/tests/test_gurt_telem_producer.c
@@ -636,6 +636,7 @@ static void
 verify_ephemeral_gone(char *path, key_t key)
 {
 	struct d_tm_node_t	*node;
+	int			 got_errno;
 	int			 rc;
 
 	D_PRINT("Verifying path [%s] (key=0x%x) is gone\n", path, key);
@@ -643,7 +644,9 @@ verify_ephemeral_gone(char *path, key_t key)
 	node = d_tm_find_metric(cli_ctx, path);
 	assert_null(node);
 	rc = shmget(key, 0, 0);
+	got_errno = errno;
 	assert_true(rc < 0);
+	assert_int_equal(got_errno, ENOENT);
 }
 
 static void
@@ -895,6 +898,75 @@ test_ephemeral_nested(void **state)
 }
 
 static void
+expect_num_attached(int shmid, int expected)
+{
+	struct shmid_ds	shm_info = {0};
+	int		rc;
+
+	D_PRINT("expecting %d attached to shmid 0x%x\n", expected, shmid);
+
+	rc = shmctl(shmid, IPC_STAT, &shm_info);
+	assert_true(rc >= 0);
+	assert_int_equal(shm_info.shm_nattch, expected);
+}
+
+static void
+expect_shm_released(int shmid)
+{
+	struct shmid_ds	shm_info = {0};
+	int		rc;
+	int		got_errno;
+
+	rc = shmctl(shmid, IPC_STAT, &shm_info);
+	got_errno = errno;
+
+	assert_true(rc < 0);
+	assert_int_equal(got_errno, EINVAL);
+}
+
+static void
+test_gc_ctx(void **state)
+{
+	struct d_tm_node_t	*node = NULL;
+	char			*path = "gurt/tmp/gc";
+	key_t			 key;
+	int			 shmid;
+	int			 rc;
+
+	/* shouldn't crash with NULL */
+	d_tm_gc_ctx(NULL);
+
+	/* add an ephemeral path */
+	rc = d_tm_add_ephemeral_dir(&node, 1024, path);
+	assert_rc_equal(rc, 0);
+	assert_non_null(node);
+
+	/* Verify producer attached to new shmem */
+	key = node->dtn_shmem_key;
+	shmid = shmget(key, 0, 0);
+	assert_true(shmid > 0);
+	expect_num_attached(shmid, 1);
+
+	/* fetching from the client side attaches again */
+	node = d_tm_find_metric(cli_ctx, path);
+	assert_non_null(node);
+	expect_num_attached(shmid, 2);
+
+	/* garbage collection shouldn't change anything at this point */
+	d_tm_gc_ctx(cli_ctx);
+	expect_num_attached(shmid, 2);
+
+	/* When the ephemeral dir is removed, client ctx is still attached */
+	rc = d_tm_del_ephemeral_dir(path);
+	assert_rc_equal(rc, 0);
+	expect_num_attached(shmid, 1);
+
+	/* after cleaning up the client ctx, should be released */
+	d_tm_gc_ctx(cli_ctx);
+	expect_shm_released(shmid);
+}
+
+static void
 expect_list_has_num_of_type(struct d_tm_node_t *dir, int type, int expected)
 {
 	struct d_tm_nodeList_t	*list = NULL;
@@ -1140,6 +1212,7 @@ main(int argc, char **argv)
 		cmocka_unit_test(test_units),
 		cmocka_unit_test(test_ephemeral_simple),
 		cmocka_unit_test(test_ephemeral_nested),
+		cmocka_unit_test(test_gc_ctx),
 		/* Run after the tests that populate the metrics */
 		cmocka_unit_test(test_list_ephemeral),
 		cmocka_unit_test(test_follow_link),

--- a/src/include/daos_srv/container.h
+++ b/src/include/daos_srv/container.h
@@ -241,4 +241,18 @@ int dsc_cont_close(daos_handle_t poh, daos_handle_t coh);
 
 
 void ds_cont_tgt_ec_eph_query_ult(void *data);
+
+/** Metrics for each individual active container */
+struct ds_active_cont_metrics {
+	uuid_t			pool_uuid;
+	uuid_t			cont_uuid;
+	d_list_t		link;
+
+	struct d_tm_node_t	*start_timestamp;
+	/* TODO: add more per-container metrics */
+};
+
+struct ds_active_cont_metrics *ds_cont_metrics_get(const uuid_t pool_uuid,
+						   const uuid_t cont_uuid);
+
 #endif /* ___DAOS_SRV_CONTAINER_H_ */

--- a/src/include/daos_srv/pool.h
+++ b/src/include/daos_srv/pool.h
@@ -246,6 +246,16 @@ int dsc_pool_open(uuid_t pool_uuid, uuid_t pool_hdl_uuid,
 		       daos_handle_t *ph);
 int dsc_pool_close(daos_handle_t ph);
 
+/** Metrics for each individual active pool */
+struct ds_active_pool_metrics {
+	uuid_t			pool_uuid;
+	d_list_t		link;
+
+	struct d_tm_node_t	*started_timestamp;
+	/* TODO: add more per-pool metrics */
+};
+
+struct ds_active_pool_metrics *ds_pool_metrics_get(const uuid_t pool_uuid);
 int ds_pool_metrics_get_path(const uuid_t pool_uuid, char *path,
 			     size_t path_len);
 

--- a/src/include/daos_srv/pool.h
+++ b/src/include/daos_srv/pool.h
@@ -246,6 +246,9 @@ int dsc_pool_open(uuid_t pool_uuid, uuid_t pool_hdl_uuid,
 		       daos_handle_t *ph);
 int dsc_pool_close(daos_handle_t ph);
 
+int ds_pool_metrics_get_path(const uuid_t pool_uuid, char *path,
+			     size_t path_len);
+
 /**
  * Verify if pool status satisfy Redundancy Factor requirement, by checking
  * pool map device status.

--- a/src/include/gurt/telemetry_consumer.h
+++ b/src/include/gurt/telemetry_consumer.h
@@ -31,6 +31,7 @@ int d_tm_get_bucket_range(struct d_tm_context *ctx,
 /* Developer facing client API to discover topology and manage results */
 struct d_tm_context *d_tm_open(int id);
 void d_tm_close(struct d_tm_context **ctx);
+void d_tm_gc_ctx(struct d_tm_context *ctx);
 void *d_tm_conv_ptr(struct d_tm_context *ctx, struct d_tm_node_t *node,
 		    void *ptr);
 struct d_tm_node_t *d_tm_get_root(struct d_tm_context *ctx);

--- a/src/pool/srv_internal.h
+++ b/src/pool/srv_internal.h
@@ -22,15 +22,6 @@ struct pool_metrics {
 	struct d_tm_node_t	*open_hdl_gauge;
 };
 
-/* Metrics for each individual active pool */
-struct active_pool_metrics {
-	uuid_t			pool_uuid;
-	d_list_t		link;
-
-	struct d_tm_node_t	*started_timestamp;
-	/* TODO: add more per-pool metrics */
-};
-
 extern struct pool_metrics ds_pool_metrics;
 
 /**
@@ -199,6 +190,5 @@ int ds_pool_metrics_init(void);
 int ds_pool_metrics_fini(void);
 void ds_pool_metrics_start(const uuid_t pool_uuid);
 void ds_pool_metrics_stop(const uuid_t pool_uuid);
-struct active_pool_metrics *ds_pool_metrics_get(const uuid_t pool_uuid);
 
 #endif /* __POOL_SRV_INTERNAL_H__ */

--- a/src/pool/srv_internal.h
+++ b/src/pool/srv_internal.h
@@ -197,8 +197,8 @@ void ds_stop_scrubbing_ult(struct ds_pool_child *child);
  */
 int ds_pool_metrics_init(void);
 int ds_pool_metrics_fini(void);
-void ds_pool_metrics_start(uuid_t pool_uuid);
-void ds_pool_metrics_stop(uuid_t pool_uuid);
-struct active_pool_metrics *ds_pool_metrics_get(uuid_t pool_uuid);
+void ds_pool_metrics_start(const uuid_t pool_uuid);
+void ds_pool_metrics_stop(const uuid_t pool_uuid);
+struct active_pool_metrics *ds_pool_metrics_get(const uuid_t pool_uuid);
 
 #endif /* __POOL_SRV_INTERNAL_H__ */

--- a/src/pool/srv_metrics.c
+++ b/src/pool/srv_metrics.c
@@ -56,8 +56,8 @@ ds_pool_metrics_init(void)
 int
 ds_pool_metrics_fini(void)
 {
-	struct active_pool_metrics *cur = NULL;
-	struct active_pool_metrics *next = NULL;
+	struct ds_active_pool_metrics *cur = NULL;
+	struct ds_active_pool_metrics *next = NULL;
 
 	d_list_for_each_entry_safe(cur, next, &per_pool_metrics, link) {
 		d_list_del(&cur->link);
@@ -100,7 +100,7 @@ ds_pool_metrics_get_path(const uuid_t pool_uuid, char *path, size_t path_len)
 void
 ds_pool_metrics_start(const uuid_t pool_uuid)
 {
-	struct active_pool_metrics	*metrics;
+	struct ds_active_pool_metrics	*metrics;
 	char				 path[D_TM_MAX_NAME_LEN] = {0};
 	int				 rc;
 
@@ -153,7 +153,7 @@ ds_pool_metrics_start(const uuid_t pool_uuid)
 void
 ds_pool_metrics_stop(const uuid_t pool_uuid)
 {
-	struct active_pool_metrics	*metrics;
+	struct ds_active_pool_metrics	*metrics;
 	char				 path[D_TM_MAX_NAME_LEN] = {0};
 	int				 rc;
 
@@ -192,10 +192,10 @@ ds_pool_metrics_stop(const uuid_t pool_uuid)
  *
  * \return	Pool's metrics structure, or NULL if not found
  */
-struct active_pool_metrics *
+struct ds_active_pool_metrics *
 ds_pool_metrics_get(const uuid_t pool_uuid)
 {
-	struct active_pool_metrics *cur = NULL;
+	struct ds_active_pool_metrics *cur = NULL;
 
 	d_list_for_each_entry(cur, &per_pool_metrics, link) {
 		if (uuid_compare(pool_uuid, cur->pool_uuid) == 0)

--- a/src/pool/srv_target.c
+++ b/src/pool/srv_target.c
@@ -596,7 +596,7 @@ ds_pool_start(uuid_t uuid)
 	struct ds_pool			*pool;
 	struct daos_llink		*llink;
 	struct ds_pool_create_arg	arg = {};
-	struct active_pool_metrics	*metrics = NULL;
+	struct ds_active_pool_metrics	*metrics = NULL;
 	int				rc;
 
 	D_ASSERT(dss_get_module_info()->dmi_xs_id == 0);


### PR DESCRIPTION
With the caveat here that we're not actually doing per container metrics, here's an example of nesting different types of metrics. Wouldn't need to necessarily do this with targets (depends on how the targets are organized, under what circumstances can they be added or removed while the engine is running, etc.) but it's an idea.

I think an easy way to let the object level manage the per-target metrics is to expose the method to generate the pool metrics path, to make it easy for them to generate a correct path for metrics to add, similar to what I did with the containers here.

