### PR TITLE
DAOS-7655 csum: Fixed for degraded EC tests

### DIFF
--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -1588,8 +1588,7 @@ obj_local_rw_internal(crt_rpc_t *rpc, struct obj_io_context *ioc,
 		}
 	}
 	if (obj_rpc_is_fetch(rpc) && create_map)
-		rc = obj_fetch_create_maps(rpc, biod,
-					   orw->orw_iod_array.oia_iods);
+		rc = obj_fetch_create_maps(rpc, biod, iods);
 
 	if (rc == -DER_CSUM)
 		obj_log_csum_err();


### PR DESCRIPTION
PR #5666 changed which iods were used to create the io maps. This
reverts that change because it's causing the degraded EC tests
to fail.

Signed-off-by: Ryon Jensen <ryon.jensen@intel.com>