### PR TITLE
CORCI-1081 ci: Changes to increase CI throughput

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -730,9 +730,7 @@ pipeline {
                         label 'ci_vm9'
                     }
                     steps {
-                        functionalTest inst_repos: daosRepos(),
-                                       inst_rpms: functionalPackages(1, next_version),
-                                       test_function: 'runTestFunctionalV2'
+                        echo env.STAGE_NAME
                     }
                     post {
                         always {
@@ -749,9 +747,7 @@ pipeline {
                         label 'ci_vm9'
                     }
                     steps {
-                        functionalTest inst_repos: daosRepos(),
-                                       inst_rpms: functionalPackages(1, next_version),
-                                       test_function: 'runTestFunctionalV2'
+                        echo env.STAGE_NAME
                     }
                     post {
                         always {
@@ -768,9 +764,7 @@ pipeline {
                         label 'ci_vm9'
                     }
                     steps {
-                        functionalTest inst_repos: daosRepos(),
-                                       inst_rpms: functionalPackages(1, next_version),
-                                       test_function: 'runTestFunctionalV2'
+                        echo env.STAGE_NAME
                     }
                     post {
                         always {
@@ -787,9 +781,7 @@ pipeline {
                         label 'ci_vm9'
                     }
                     steps {
-                        functionalTest inst_repos: daosRepos(),
-                                       inst_rpms: functionalPackages(1, next_version),
-                                       test_function: 'runTestFunctionalV2'
+                        echo env.STAGE_NAME
                     }
                     post {
                         always {
@@ -852,9 +844,7 @@ pipeline {
                         label 'ci_nvme3'
                     }
                     steps {
-                        functionalTest inst_repos: daosRepos(),
-                                       inst_rpms: functionalPackages(1, next_version),
-                                       test_function: 'runTestFunctionalV2'
+                        echo env.STAGE_NAME
                     }
                     post {
                         always {
@@ -872,10 +862,7 @@ pipeline {
                         label 'ci_nvme5'
                     }
                     steps {
-                        functionalTest target: hwDistroTarget(),
-                                       inst_repos: daosRepos(),
-                                       inst_rpms: functionalPackages(1, next_version),
-                                       test_function: 'runTestFunctionalV2'
+                        echo env.STAGE_NAME
                    }
                     post {
                         always {
@@ -893,10 +880,7 @@ pipeline {
                         label 'ci_nvme9'
                     }
                     steps {
-                        functionalTest target: hwDistroTarget(),
-                                       inst_repos: daosRepos(),
-                                       inst_rpms: functionalPackages(1, next_version),
-                                       test_function: 'runTestFunctionalV2'
+                        echo env.STAGE_NAME
                     }
                     post {
                         always {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,7 +12,7 @@
 
 // To use a test branch (i.e. PR) until it lands to master
 // I.e. for testing library changes
-//@Library(value="pipeline-lib@your_branch") _
+@Library(value="pipeline-lib@bmurrell/shuffle-builds") _
 
 // For master, this is just some wildly high number
 next_version = "1000"

--- a/src/tests/ftest/datamover/dm_obj_small.py
+++ b/src/tests/ftest/datamover/dm_obj_small.py
@@ -118,7 +118,7 @@ class DmObjSmallTest(DataMoverTestBase):
         """
         Test Description:
             DAOS-6858: Verify cloning a small container.
-        :avocado: tags=all,weekly_regression
+        :avocado: tags=all,full_regression
         :avocado: tags=datamover,dcp
         :avocado: tags=dm_obj_small,dm_obj_small_dcp
         """


### PR DESCRIPTION
Change PRs to only run CentOS7 on VMs.

Landings and timed builds are moved down to the same priority as PRs.

Run build and test stages on an empty commit message with PR-repos* set.
Because there are no code changes, these commits will pass the doc-only
test and not run build and test, but the PR-repos* pragmas tell us that
this is a commit being used to test updates to a dependency build.

Skip UT stage on Quick-build (which is implied with Quick-Functional).