### PR TITLE
DAOS-7174 test: Adjust dmg helper to use --label

### DIFF
--- a/src/common/tests_dmg_helpers.c
+++ b/src/common/tests_dmg_helpers.c
@@ -486,7 +486,7 @@ dmg_pool_create(const char *dmg_config_file,
 
 		entry = daos_prop_entry_get(prop, DAOS_PROP_PO_LABEL);
 		if (entry != NULL) {
-			args = cmd_push_arg(args, &argcount, "--name=%s ",
+			args = cmd_push_arg(args, &argcount, "--label=%s ",
 					    entry->dpe_str);
 		}
 	}


### PR DESCRIPTION
The PR that made the change to dmg landed before the PR
that added by-label support, so we need to fix the helper
to use --label instead of --name.