### PR TITLE
DAOS-1968 control: Simplify control.ConfigGenerate() API

### DIFF
--- a/src/control/cmd/dmg/auto.go
+++ b/src/control/cmd/dmg/auto.go
@@ -66,24 +66,24 @@ func (cmd *configGenCmd) Execute(_ []string) error {
 
 	// TODO: decide whether we want meaningful JSON output
 	if cmd.jsonOutputEnabled() {
-		return cmd.outputJSON(new(control.ConfigGenerateResp), nil)
+		return cmd.outputJSON(nil, errors.New("JSON output not supported"))
 	}
 
 	resp, err := control.ConfigGenerate(ctx, req)
-	if resp == nil {
-		if err == nil {
-			return errors.New("nil response from config generate")
-		}
-		return err
-	}
-
-	if resp.Errors() != nil {
-		// host level errors e.g. unresponsive daos_server process
-		var bld strings.Builder
-		if err := pretty.PrintResponseErrors(resp, &bld); err != nil {
+	if err != nil {
+		cge, ok := errors.Cause(err).(*control.ConfigGenerateError)
+		if !ok {
+			// includes hardware validation errors e.g. hardware across hostset differs
 			return err
 		}
-		cmd.log.Error(bld.String()) // no-op if no host level errors
+
+		// host level errors e.g. unresponsive daos_server process
+		var bld strings.Builder
+		if err := pretty.PrintResponseErrors(cge, &bld); err != nil {
+			return err
+		}
+		cmd.log.Error(bld.String())
+		return err
 	}
 
 	// includes hardware validation errors e.g. hardware across hostset differs

--- a/src/control/cmd/dmg/json_test.go
+++ b/src/control/cmd/dmg/json_test.go
@@ -66,7 +66,7 @@ func TestDmg_JsonOutput(t *testing.T) {
 		t.Run(strings.Join(args, " "), func(t *testing.T) {
 			testArgs := append([]string{"-i", "--json"}, args...)
 			switch strings.Join(args, " ") {
-			case "version", "telemetry config", "telemetry run":
+			case "version", "telemetry config", "telemetry run", "config generate":
 				return
 			case "storage prepare":
 				testArgs = append(testArgs, "--force")

--- a/src/control/lib/control/auto_test.go
+++ b/src/control/lib/control/auto_test.go
@@ -313,8 +313,12 @@ func TestControl_AutoConfig_getNetworkDetails(t *testing.T) {
 				Log:       log,
 			}
 
-			netDetails, gotHostErrs, gotErr := getNetworkDetails(context.TODO(), req)
+			netDetails, gotErr := getNetworkDetails(context.TODO(), req)
 			common.CmpErr(t, tc.expErr, gotErr)
+			var gotHostErrs *HostErrorsResp
+			if cge, ok := gotErr.(*ConfigGenerateError); ok {
+				gotHostErrs = &cge.HostErrorsResp
+			}
 			cmpHostErrs(t, tc.expHostErrs, gotHostErrs)
 			if tc.expErr != nil {
 				return
@@ -510,9 +514,13 @@ func TestControl_AutoConfig_getStorageDetails(t *testing.T) {
 				Log:       log,
 			}
 
-			storageDetails, gotHostErrs, gotErr := getStorageDetails(
+			storageDetails, gotErr := getStorageDetails(
 				context.TODO(), req, tc.engineCount)
 			common.CmpErr(t, tc.expErr, gotErr)
+			var gotHostErrs *HostErrorsResp
+			if cge, ok := gotErr.(*ConfigGenerateError); ok {
+				gotHostErrs = &cge.HostErrorsResp
+			}
 			cmpHostErrs(t, tc.expHostErrs, gotHostErrs)
 			if tc.expErr != nil {
 				return


### PR DESCRIPTION
This is an all-or-nothing method so it should return a
valid response or an error, not both. This change simplifies
the error handling required by callers.