### PR TITLE
DAOS-7679 EC: various fixes for EC aggregation

### DIFF
--- a/src/object/srv_ec_aggregate.c
+++ b/src/object/srv_ec_aggregate.c
@@ -882,7 +882,7 @@ agg_update_vos(struct ec_agg_entry *entry, bool write_parity)
 
 			se = ec_age2ss(entry) *
 			     (entry->ae_cur_stripe.as_stripenum + 1);
-			if (DAOS_RECX_END(ext->ae_orig_recx) <= se) {
+			if (DAOS_RECX_END(ext->ae_orig_recx) < se) {
 				epoch_range.epr_lo = epoch_range.epr_hi =
 					ext->ae_epoch;
 
@@ -2004,10 +2004,13 @@ agg_data_extent(struct dtx_handle *dth, vos_iter_entry_t *entry,
 	d_list_add_tail(&extent->ae_link,
 			&agg_entry->ae_cur_stripe.as_dextents);
 
-	if (!agg_entry->ae_cur_stripe.as_extent_cnt)
+	if (!agg_entry->ae_cur_stripe.as_extent_cnt) {
 		/* first extent in stripe: save the start offset */
 		agg_entry->ae_cur_stripe.as_offset =  extent->ae_recx.rx_idx -
 			rounddown(extent->ae_recx.rx_idx, ec_age2ss(agg_entry));
+		agg_entry->ae_cur_stripe.as_stripenum =
+				agg_stripenum(agg_entry, entry->ie_recx.rx_idx);
+	}
 
 	agg_entry->ae_cur_stripe.as_extent_cnt++;
 	if (BIO_ADDR_IS_HOLE(&entry->ie_biov.bi_addr)) {

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -2070,16 +2070,23 @@ ds_obj_ec_agg_handler(crt_rpc_t *rpc)
 	}
 	if (oea->ea_remove_nr) {
 		daos_epoch_range_t	epr;
+		uint64_t		stripe_end;
 		int			i;
 
+		stripe_end = (oea->ea_stripenum + 1) *
+			      oca->u.ec.e_len * oca->u.ec.e_k;
 		for (i = 0; i < oea->ea_remove_nr; i++) {
+			daos_recx_t *ea_recx;
+
+			ea_recx = &oea->ea_remove_recxs.ca_arrays[i];
+			if (DAOS_RECX_END(*ea_recx) > stripe_end)
+				continue;
+
 			epr.epr_hi = epr.epr_lo =
 				oea->ea_remove_eps.ca_arrays[i];
 			rc = vos_obj_array_remove(ioc.ioc_coc->sc_hdl,
 						  oea->ea_oid, &epr, dkey,
-						  &oea->ea_akey,
-						  &oea->
-						  ea_remove_recxs.ca_arrays[i]);
+						  &oea->ea_akey, ea_recx);
 			if (rc) {
 				D_ERROR(DF_UOID"array_remove failed: "DF_RC"\n",
 					DP_UOID(oea->ea_oid), DP_RC(rc));

--- a/src/tests/suite/daos_rebuild_common.c
+++ b/src/tests/suite/daos_rebuild_common.c
@@ -914,6 +914,26 @@ get_rank_by_oid_shard(test_arg_t *arg, daos_obj_id_t oid,
 	return rank;
 }
 
+int
+ec_data_nr_get(daos_obj_id_t oid)
+{
+	struct daos_oclass_attr *oca;
+
+	oca = daos_oclass_attr_find(oid);
+	assert_true(oca->ca_resil == DAOS_RES_EC);
+	return oca->u.ec.e_k;
+}
+
+int
+ec_parity_nr_get(daos_obj_id_t oid)
+{
+	struct daos_oclass_attr *oca;
+
+	oca = daos_oclass_attr_find(oid);
+	assert_true(oca->ca_resil == DAOS_RES_EC);
+	return oca->u.ec.e_p;
+}
+
 void
 get_killing_rank_by_oid(test_arg_t *arg, daos_obj_id_t oid, int data_nr,
 			int parity_nr, d_rank_t *ranks, int *ranks_num)

--- a/src/tests/suite/daos_test.h
+++ b/src/tests/suite/daos_test.h
@@ -404,6 +404,9 @@ void daos_reint_server(const uuid_t pool_uuid, const char *grp,
 int daos_pool_set_prop(const uuid_t pool_uuid, const char *name,
 		       const char *value);
 
+int ec_data_nr_get(daos_obj_id_t oid);
+int ec_parity_nr_get(daos_obj_id_t oid);
+
 void
 get_killing_rank_by_oid(test_arg_t *arg, daos_obj_id_t oid, int data,
 			int parity, d_rank_t *ranks, int *ranks_num);


### PR DESCRIPTION
1. If the replicate extent cross the stripe boundry,
after EC aggregation, and parity update, it should only
delete the extent until the stripe boundry.

2. Since VOS extent can not be partial deleted, so let's
use current epoch to delete the replicate extent.

3. Add more tests in daos_obj_ec.c to verify the EC aggregation.

Signed-off-by: Di Wang <di.wang@intel.com>