### PR TITLE
DAOS-7558 tests: daos_racer for daily_regression and full_regression

### DIFF
--- a/src/tests/ftest/daos_racer/daos_racer_simple.py
+++ b/src/tests/ftest/daos_racer/daos_racer_simple.py
@@ -1,0 +1,44 @@
+#!/usr/bin/python
+"""
+  (C) Copyright 2020-2021 Intel Corporation.
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+"""
+
+from apricot import TestWithServers
+from daos_racer_utils import DaosRacerCommand
+
+
+class DaosRacerTest(TestWithServers):
+    """Test cases that utilize the daos_racer tool.
+
+    :avocado: recursive
+    """
+
+    def test_daos_racer_simple(self):
+        """JIRA-3855: daos_racer/consistency checker test.
+
+        Test Description:
+            The daos_racer test tool generates a bunch of simultaneous,
+            conflicting I/O requests. After it is run it will verify that all
+            the replicas of a given object are consistent.
+
+            Run daos_racer for 5-10 minutes or so on 3-way replicated object
+            data (at least 6 servers) and verify the object replicas.
+
+        Use Cases:
+            Running simultaneous, conflicting I/O requests.
+
+        :avocado: tags=all,daily_regression,pr
+        :avocado: tags=hw,large,io,daosracer
+
+        """
+        dmg = self.get_dmg_command()
+        self.assertGreater(
+            len(self.hostlist_clients), 0,
+            "This test requires one client: {}".format(self.hostlist_clients))
+        daos_racer = DaosRacerCommand(self.bin, self.hostlist_clients[0], dmg)
+        daos_racer.get_params(self)
+        daos_racer.set_environment(
+            daos_racer.get_environment(self.server_managers[0]))
+        daos_racer.run()

--- a/src/tests/ftest/daos_racer/daos_racer_simple.yaml
+++ b/src/tests/ftest/daos_racer/daos_racer_simple.yaml
@@ -1,0 +1,23 @@
+hosts:
+  test_servers:
+    - server-A
+    - server-B
+    - server-C
+    - server-D
+    - server-E
+    - server-F
+    - server-G
+  test_clients:
+    - client-H
+timeout: 1800
+server_config:
+    name: daos_server
+    servers:
+        log_mask: "ERR"
+        bdev_class: nvme
+        bdev_list: ["aaaa:aa:aa.a","bbbb:bb:bb.b"]
+        scm_class: dcpm
+        scm_list: ["/dev/pmem0"]
+daos_racer:
+  runtime: 600
+  clush_timeout: 900


### PR DESCRIPTION
For checking system stability and robustness.

Signed-off-by: Fan Yong <fan.yong@intel.com>