### PR TITLE
Add log debugging, try to find what's up with daos_vol tests.

### DIFF
--- a/src/tests/ftest/daos_vol/daos_vol.yaml
+++ b/src/tests/ftest/daos_vol/daos_vol.yaml
@@ -12,6 +12,10 @@ server_config:
         bdev_list: ["0000:81:00.0","0000:da:00.0"]
         scm_class: dcpm
         scm_list: ["/dev/pmem0"]
+        log_mask: DEBUG,MEM=ERR
+        env_vars:
+          - DD_MASK=mgmt,md,dsms,any
+
 pool:
     control_method: dmg
     mode: 511
@@ -24,30 +28,30 @@ container:
 dfuse:
   mount_dir: "/tmp/daos_dfuse"
 daos_vol_tests:  !mux
-    test1:
-        testname: h5_partest_t_shapesame
-        client_processes: 6
-    test2:
-        testname: h5vl_test_parallel
-        client_processes: 6
-    test3:
-        testname: h5vl_test
-        client_processes: 1
+    #test1:
+    #    testname: h5_partest_t_shapesame
+    #    client_processes: 6
+    #test2:
+    #    testname: h5vl_test_parallel
+    #    client_processes: 6
+    #test3:
+    #    testname: h5vl_test
+    #    client_processes: 1
     test4:
         testname: h5_test_testhdf5
         client_processes: 1
-    test5:
-        testname: h5_partest_testphdf5
-        client_processes: 6
-    test6:
-        testname: h5daos_test_map
-        client_processes: 1
-    test7:
-        testname: h5daos_test_map_parallel
-        client_processes: 6
-    test8:
-        testname: h5daos_test_oclass
-        client_processes: 1
-    test9:
-        testname: h5daos_test_metadata_parallel -U -u
-        client_processes: 6
+    #test5:
+    #    testname: h5_partest_testphdf5
+    #    client_processes: 6
+    #test6:
+    #    testname: h5daos_test_map
+    #    client_processes: 1
+    #test7:
+    #    testname: h5daos_test_map_parallel
+    #    client_processes: 6
+    #test8:
+    #    testname: h5daos_test_oclass
+    #    client_processes: 1
+    #test9:
+    #    testname: h5daos_test_metadata_parallel -U -u
+    #    client_processes: 6


### PR DESCRIPTION
Skip-python-bandit: true
Quick-build: true
Parallel-build: true
Skip-unit-tests: true
Skip-coverity-test: true
Skip-scan-centos-rpms: true
Skip-test-centos-rpms: true
Test-tag: volmpich test_daos_pool test_daos_container

Signed-off-by: Kenneth Cain <kenneth.c.cain@intel.com>