### PR TITLE
DAOS-7517 doc: Clarify container ACL docs

### DIFF
--- a/doc/user/container.md
+++ b/doc/user/container.md
@@ -285,7 +285,8 @@ To create a container with a custom ACL:
 $ daos cont create --pool=<UUID> --acl-file=<path>
 ```
 
-The ACL file format is detailed in the [ACL section](https://daos-stack.github.io/overview/security/#acl-file).
+The ACL file format is detailed in the
+[security overview](https://daos-stack.github.io/overview/security/#acl-file).
 
 ### Displaying a Container's ACL
 
@@ -340,9 +341,11 @@ $ daos cont delete-acl --pool=<UUID> --cont=<UUID> \
       --principal=<principal>
 ```
 
-The principal corresponds to the principal portion of an ACE that was
-set during container creation or a previous container ACL operation. For the
-delete operation, the principal argument must be formatted as follows:
+The `principal` argument refers to the
+[principal](https://daos-stack.github.io/overview/security/#principal), or
+identity, of the entry to be removed.
+
+For the delete operation, the `principal` argument must be formatted as follows:
 
 * Named user: `u:username@`
 * Named group: `g:groupname@`
@@ -363,17 +366,26 @@ They may be set on container creation and changed later.
 
 #### Privileges
 
-The owner-user (`OWNER@`) has implicit privileges on their container. The
-owner-user can always open the container, and has set-ACL (A) and get-ACL (a)
-permissions. These permissions are included alongside any permissions that the
+The owner-user (`OWNER@`) has some implicit privileges on their container.
+These permissions are silently included alongside any permissions that the
 user was explicitly granted by entries in the ACL.
 
-Because the owner's special permissions are implicit, they apply to access
-control decisions even if they do not appear in the `OWNER@` entry, and even if
-the `OWNER@` entry is deleted.
+The owner-user will always have the following implicit capabilities:
 
-The owner-group (`GROUP@`) has no special permissions outside what they are
-granted by the ACL.
+* Open container
+* Set ACL (A)
+* Get ACL (a)
+
+Because the owner's special permissions are implicit, they do not need to be
+specified in the `OWNER@` entry. After
+[determining](https://daos-stack.github.io/overview/security/#enforcement)
+the user's privileges from the container ACL, DAOS checks whether the user
+requesting access is the owner-user. If so, DAOS grants the owner's
+implicit permissions to that user, in addition to any permissions granted by
+the ACL.
+
+In contrast, the owner-group (`GROUP@`) has no special permissions beyond those
+explicitly granted by the `GROUP@` entry in the ACL.
 
 #### Creating Containers with Specific Ownership
 


### PR DESCRIPTION
- Clarify discussion on implicit owner privileges.
- Add link to security overview discussion about ACL
  principals.
- Rename a link that now points to the security overview.

Doc-only: true

Signed-off-by: Kris Jacque <kristin.jacque@intel.com>