### PR TITLE
CART-970 refactor: Refactor code for multi-provider support

### DIFF
--- a/src/cart/crt_context.c
+++ b/src/cart/crt_context.c
@@ -173,21 +173,28 @@ out:
 }
 
 int
-crt_context_create(crt_context_t *crt_ctx)
+crt_context_provider_create(crt_context_t *crt_ctx, int provider)
 {
 	struct crt_context	*ctx = NULL;
 	int			rc = 0;
 	na_size_t		uri_len = CRT_ADDR_STR_MAX_LEN;
+	bool			sep_mode;
+	int			cur_ctx_num;
+	int			max_ctx_num;
 
 	if (crt_ctx == NULL) {
 		D_ERROR("invalid parameter of NULL crt_ctx.\n");
 		D_GOTO(out, rc = -DER_INVAL);
 	}
 
-	if (crt_gdata.cg_sep_mode &&
-	    crt_gdata.cg_ctx_num >= crt_gdata.cg_ctx_max_num) {
+	sep_mode = crt_provider_is_sep(provider);
+	cur_ctx_num = crt_provider_get_cur_ctx_num(provider);
+	max_ctx_num = crt_provider_get_max_ctx_num(provider);
+
+	if (sep_mode &&
+	    cur_ctx_num >= max_ctx_num) {
 		D_ERROR("Number of active contexts (%d) reached limit (%d).\n",
-			crt_gdata.cg_ctx_num, crt_gdata.cg_ctx_max_num);
+			cur_ctx_num, max_ctx_num);
 		D_GOTO(out, -DER_AGAIN);
 	}
 
@@ -204,9 +211,8 @@ crt_context_create(crt_context_t *crt_ctx)
 
 	D_RWLOCK_WRLOCK(&crt_gdata.cg_rwlock);
 
-	ctx->cc_provider = crt_gdata.cg_na_plugin;
-	rc = crt_hg_ctx_init(&ctx->cc_hg_ctx, ctx->cc_provider,
-			     crt_gdata.cg_ctx_num);
+	rc = crt_hg_ctx_init(&ctx->cc_hg_ctx, provider, cur_ctx_num);
+
 	if (rc != 0) {
 		D_ERROR("crt_hg_ctx_init() failed, " DF_RC "\n", DP_RC(rc));
 		D_RWLOCK_UNLOCK(&crt_gdata.cg_rwlock);
@@ -223,9 +229,9 @@ crt_context_create(crt_context_t *crt_ctx)
 		D_GOTO(out, rc);
 	}
 
-	ctx->cc_idx = crt_gdata.cg_ctx_num;
-	d_list_add_tail(&ctx->cc_link, &crt_gdata.cg_ctx_list);
-	crt_gdata.cg_ctx_num++;
+	ctx->cc_idx = cur_ctx_num;
+	crt_provider_add_ctx_list(provider, &ctx->cc_link);
+	crt_provider_inc_cur_ctx_num(provider);
 
 	D_RWLOCK_UNLOCK(&crt_gdata.cg_rwlock);
 
@@ -236,7 +242,7 @@ crt_context_create(crt_context_t *crt_ctx)
 		ret = d_tm_add_metric(&ctx->cc_timedout, D_TM_COUNTER,
 				      "Total number of timed out RPC requests",
 				      "", "net/%d/%u/req_timeout",
-				      ctx->cc_provider, ctx->cc_idx);
+				      ctx->cc_hg_ctx.chc_provider, ctx->cc_idx);
 		if (ret)
 			D_WARN("Failed to create timed out req counter: "DF_RC
 			       "\n", DP_RC(ret));
@@ -245,7 +251,7 @@ crt_context_create(crt_context_t *crt_ctx)
 				      "Total number of timed out URI lookup "
 				      "requests", "",
 				      "net/%d/%u/uri_lookup_timeout",
-				      ctx->cc_provider, ctx->cc_idx);
+				      ctx->cc_hg_ctx.chc_provider, ctx->cc_idx);
 		if (ret)
 			D_WARN("Failed to create timed out uri req counter: "
 			       DF_RC"\n", DP_RC(ret));
@@ -254,7 +260,7 @@ crt_context_create(crt_context_t *crt_ctx)
 				      "Total number of failed address "
 				      "resolution attempts", "",
 				      "net/%d/%u/failed_addr",
-				      ctx->cc_provider, ctx->cc_idx);
+				      ctx->cc_hg_ctx.chc_provider, ctx->cc_idx);
 		if (ret)
 			D_WARN("Failed to create failed addr counter: "DF_RC
 			       "\n", DP_RC(ret));
@@ -276,6 +282,12 @@ crt_context_create(crt_context_t *crt_ctx)
 
 out:
 	return rc;
+}
+
+int
+crt_context_create(crt_context_t *crt_ctx)
+{
+	return crt_context_provider_create(crt_ctx, crt_gdata.cg_init_prov);
 }
 
 int
@@ -509,6 +521,7 @@ crt_context_destroy(crt_context_t crt_ctx, int force)
 
 	D_MUTEX_UNLOCK(&ctx->cc_mutex);
 
+	int provider = ctx->cc_hg_ctx.chc_provider;
 	rc = crt_hg_ctx_fini(&ctx->cc_hg_ctx);
 	if (rc) {
 		D_ERROR("crt_hg_ctx_fini failed rc: %d.\n", rc);
@@ -516,7 +529,7 @@ crt_context_destroy(crt_context_t crt_ctx, int force)
 	}
 
 	D_RWLOCK_WRLOCK(&crt_gdata.cg_rwlock);
-	crt_gdata.cg_ctx_num--;
+	crt_provider_dec_cur_ctx_num(provider);
 	d_list_del(&ctx->cc_link);
 	D_RWLOCK_UNLOCK(&crt_gdata.cg_rwlock);
 
@@ -571,10 +584,12 @@ crt_rank_abort(d_rank_t rank)
 	d_list_t		*rlink;
 	int			 flags;
 	int			 rc = 0;
+	d_list_t		*ctx_list;
 
 	D_RWLOCK_RDLOCK(&crt_gdata.cg_rwlock);
 
-	d_list_for_each_entry(ctx, &crt_gdata.cg_ctx_list, cc_link) {
+	ctx_list = crt_provider_get_ctx_list(crt_gdata.cg_init_prov);
+	d_list_for_each_entry(ctx, ctx_list, cc_link) {
 		rc = 0;
 		D_MUTEX_LOCK(&ctx->cc_mutex);
 		rlink = d_hash_rec_find(&ctx->cc_epi_table,
@@ -1139,12 +1154,16 @@ crt_context_req_untrack(struct crt_rpc_priv *rpc_priv)
 	}
 }
 
+/* TODO: Need per-provider call */
 crt_context_t
 crt_context_lookup_locked(int ctx_idx)
 {
 	struct crt_context	*ctx;
+	d_list_t		*ctx_list;
 
-	d_list_for_each_entry(ctx, &crt_gdata.cg_ctx_list, cc_link) {
+	ctx_list = crt_provider_get_ctx_list(crt_gdata.cg_init_prov);
+
+	d_list_for_each_entry(ctx, ctx_list, cc_link) {
 		if (ctx->cc_idx == ctx_idx)
 			return ctx;
 	}
@@ -1152,14 +1171,19 @@ crt_context_lookup_locked(int ctx_idx)
 	return NULL;
 }
 
+/* TODO: Need per-provider call */
 crt_context_t
 crt_context_lookup(int ctx_idx)
 {
 	struct crt_context	*ctx;
 	bool			found = false;
+	d_list_t		*ctx_list;
 
 	D_RWLOCK_RDLOCK(&crt_gdata.cg_rwlock);
-	d_list_for_each_entry(ctx, &crt_gdata.cg_ctx_list, cc_link) {
+
+	ctx_list = crt_provider_get_ctx_list(crt_gdata.cg_init_prov);
+
+	d_list_for_each_entry(ctx, ctx_list, cc_link) {
 		if (ctx->cc_idx == ctx_idx) {
 			found = true;
 			break;
@@ -1223,19 +1247,19 @@ crt_context_num(int *ctx_num)
 		return -DER_INVAL;
 	}
 
-	*ctx_num = crt_gdata.cg_ctx_num;
+	*ctx_num = crt_gdata.cg_prov_gdata[crt_gdata.cg_init_prov].cpg_ctx_num;
 	return 0;
 }
 
 bool
-crt_context_empty(int locked)
+crt_context_empty(int provider, int locked)
 {
 	bool rc = false;
 
 	if (locked == 0)
 		D_RWLOCK_RDLOCK(&crt_gdata.cg_rwlock);
 
-	rc = d_list_empty(&crt_gdata.cg_ctx_list);
+	rc = d_list_empty(&crt_gdata.cg_prov_gdata[provider].cpg_ctx_list);
 
 	if (locked == 0)
 		D_RWLOCK_UNLOCK(&crt_gdata.cg_rwlock);

--- a/src/cart/crt_context.c
+++ b/src/cart/crt_context.c
@@ -181,6 +181,7 @@ crt_context_provider_create(crt_context_t *crt_ctx, int provider)
 	bool			sep_mode;
 	int			cur_ctx_num;
 	int			max_ctx_num;
+	d_list_t		*ctx_list;
 
 	if (crt_ctx == NULL) {
 		D_ERROR("invalid parameter of NULL crt_ctx.\n");
@@ -230,7 +231,10 @@ crt_context_provider_create(crt_context_t *crt_ctx, int provider)
 	}
 
 	ctx->cc_idx = cur_ctx_num;
-	crt_provider_add_ctx_list(provider, &ctx->cc_link);
+
+	ctx_list = crt_provider_get_ctx_list(provider);
+
+	d_list_add_tail(&ctx->cc_link, ctx_list);
 	crt_provider_inc_cur_ctx_num(provider);
 
 	D_RWLOCK_UNLOCK(&crt_gdata.cg_rwlock);

--- a/src/cart/crt_ctl.c
+++ b/src/cart/crt_ctl.c
@@ -184,6 +184,8 @@ crt_hdlr_ctl_ls(crt_rpc_t *rpc_req)
 	int				 count;
 	struct crt_context		*ctx = NULL;
 	int				 rc = 0;
+	d_list_t 			*ctx_list;
+	int				 provider;
 
 	D_ASSERTF(crt_is_service(), "Must be called in a service process\n");
 	in_args = crt_req_get(rpc_req);
@@ -198,9 +200,15 @@ crt_hdlr_ctl_ls(crt_rpc_t *rpc_req)
 	addr_buf_len = 0;
 
 	D_RWLOCK_RDLOCK(&crt_gdata.cg_rwlock);
-	out_args->cel_ctx_num = crt_gdata.cg_ctx_num;
 
-	d_list_for_each_entry(ctx, &crt_gdata.cg_ctx_list, cc_link) {
+	/* TODO: Need to derive provider from rpc struct */
+	provider = crt_gdata.cg_init_prov;
+
+	ctx_list = crt_provider_get_ctx_list(provider);
+
+	out_args->cel_ctx_num = crt_provider_get_cur_ctx_num(provider);
+
+	d_list_for_each_entry(ctx, ctx_list, cc_link) {
 		str_size = CRT_ADDR_STR_MAX_LEN;
 
 		D_MUTEX_LOCK(&ctx->cc_mutex);
@@ -223,7 +231,7 @@ crt_hdlr_ctl_ls(crt_rpc_t *rpc_req)
 
 	count = 0;
 
-	d_list_for_each_entry(ctx, &crt_gdata.cg_ctx_list, cc_link) {
+	d_list_for_each_entry(ctx, ctx_list, cc_link) {
 		str_size = CRT_ADDR_STR_MAX_LEN;
 		rc = 0;
 

--- a/src/cart/crt_ctl.c
+++ b/src/cart/crt_ctl.c
@@ -183,9 +183,9 @@ crt_hdlr_ctl_ls(crt_rpc_t *rpc_req)
 	uint32_t			 addr_buf_len;
 	int				 count;
 	struct crt_context		*ctx = NULL;
-	int				 rc = 0;
-	d_list_t 			*ctx_list;
+	d_list_t			*ctx_list;
 	int				 provider;
+	int				 rc = 0;
 
 	D_ASSERTF(crt_is_service(), "Must be called in a service process\n");
 	in_args = crt_req_get(rpc_req);

--- a/src/cart/crt_group.c
+++ b/src/cart/crt_group.c
@@ -303,7 +303,8 @@ grp_li_uri_set(struct crt_lookup_item *li, int tag, const char *uri)
 		ui->ui_initialized = 1;
 		ui->ui_rank = li->li_rank;
 
-		if (crt_provider_is_contig_ep(crt_gdata.cg_na_plugin)) {
+		/* TODO: Derive provider instead of using default one */
+		if (crt_provider_is_contig_ep(crt_gdata.cg_init_prov)) {
 			char tmp_uri[CRT_ADDR_STR_MAX_LEN];
 
 			strncpy(tmp_uri, uri, CRT_ADDR_STR_MAX_LEN - 1);
@@ -366,7 +367,8 @@ grp_li_uri_set(struct crt_lookup_item *li, int tag, const char *uri)
 		if (rc != 0) {
 			D_ERROR("Entry already present\n");
 
-			if (crt_provider_is_contig_ep(crt_gdata.cg_na_plugin)) {
+			/* TODO: Derive rprovider from context */
+			if (crt_provider_is_contig_ep(crt_gdata.cg_init_prov)) {
 				for (i = 0; i < CRT_SRV_CONTEXT_NUM; i++)
 					D_FREE(ui->ui_uri[i]);
 			} else {
@@ -797,7 +799,7 @@ crt_grp_lc_addr_insert(struct crt_grp_priv *passed_grp_priv,
 
 	D_ASSERT(crt_ctx != NULL);
 
-	if (crt_gdata.cg_sep_mode == true)
+	if (crt_provider_is_sep(crt_ctx->cc_hg_ctx.chc_provider))
 		tag = 0;
 
 	grp_priv = passed_grp_priv;
@@ -865,7 +867,8 @@ crt_grp_lc_lookup(struct crt_grp_priv *grp_priv, int ctx_idx,
 	D_ASSERT(uri != NULL || hg_addr != NULL);
 	D_ASSERT(ctx_idx >= 0 && ctx_idx < CRT_SRV_CONTEXT_NUM);
 
-	if (crt_gdata.cg_sep_mode == true)
+	/* TODO: Derive from context */
+	if (crt_provider_is_sep(crt_gdata.cg_init_prov))
 		tag = 0;
 
 	default_grp_priv = grp_priv;
@@ -1833,7 +1836,7 @@ crt_group_config_save(crt_group_t *grp, bool forall)
 	rank = grp_priv->gp_self;
 
 	/* TODO: Per provider address needs to be stored in future */
-	addr = crt_gdata.cg_addr;
+	addr = crt_gdata.cg_prov_gdata[crt_gdata.cg_init_prov].cpg_addr;
 
 	grpid = grp_priv->gp_pub.cg_grpid;
 	filename = crt_grp_attach_info_filename(grp_priv);
@@ -2430,6 +2433,7 @@ crt_rank_self_set(d_rank_t rank)
 	hg_size_t		size = CRT_ADDR_STR_MAX_LEN;
 	struct crt_context	*ctx;
 	char			uri_addr[CRT_ADDR_STR_MAX_LEN] = {'\0'};
+	d_list_t		*ctx_list;
 
 	default_grp_priv = crt_gdata.cg_grp->gg_primary_grp;
 
@@ -2457,7 +2461,10 @@ crt_rank_self_set(d_rank_t rank)
 	}
 
 	D_RWLOCK_RDLOCK(&crt_gdata.cg_rwlock);
-	d_list_for_each_entry(ctx, &crt_gdata.cg_ctx_list, cc_link) {
+
+	ctx_list = crt_provider_get_ctx_list(crt_gdata.cg_init_prov);
+
+	d_list_for_each_entry(ctx, ctx_list, cc_link) {
 		hg_class =  ctx->cc_hg_ctx.chc_hgcla;
 
 		rc = crt_hg_get_addr(hg_class, uri_addr, &size);

--- a/src/cart/crt_hg.c
+++ b/src/cart/crt_hg.c
@@ -434,14 +434,6 @@ crt_provider_dec_cur_ctx_num(int provider)
 	prov_data->cpg_ctx_num--;
 }
 
-void
-crt_provider_add_ctx_list(int provider, d_list_t *cc_link)
-{
-	struct crt_prov_gdata *prov_data = crt_get_prov_gdata(provider);
-
-	d_list_add_tail(cc_link, &(prov_data->cpg_ctx_list));
-}
-
 d_list_t
 *crt_provider_get_ctx_list(int provider)
 {

--- a/src/cart/crt_hg.c
+++ b/src/cart/crt_hg.c
@@ -574,8 +574,8 @@ crt_hg_class_init(int provider, int idx, hg_class_t **ret_hg_class)
 	hg_class_t		*hg_class = NULL;
 	char			addr_str[CRT_ADDR_STR_MAX_LEN] = {'\0'};
 	na_size_t		str_size = CRT_ADDR_STR_MAX_LEN;
+	struct crt_prov_gdata	*prov_data;
 	int			rc = DER_SUCCESS;
-	struct crt_prov_gdata 	*prov_data;
 
 	prov_data = crt_get_prov_gdata(provider);
 	rc = crt_get_info_string(provider, &info_string, idx);

--- a/src/cart/crt_hg.h
+++ b/src/cart/crt_hg.h
@@ -88,7 +88,7 @@ struct crt_hg_context {
 	hg_class_t		*chc_bulkcla; /* bulk class */
 	hg_context_t		*chc_bulkctx; /* bulk context */
 	struct crt_hg_pool	 chc_hg_pool; /* HG handle pool */
-	int			 chc_provider;
+	int			 chc_provider; /* provider */
 };
 
 /* crt_hg.c */
@@ -126,7 +126,6 @@ void crt_provider_inc_cur_ctx_num(int provider);
 void crt_provider_dec_cur_ctx_num(int provider);
 
 int crt_provider_get_max_ctx_num(int provider);
-void crt_provider_add_ctx_list(int provider, d_list_t *cc_link);
 d_list_t *crt_provider_get_ctx_list(int provider);
 
 static inline int

--- a/src/cart/crt_hg.h
+++ b/src/cart/crt_hg.h
@@ -88,6 +88,7 @@ struct crt_hg_context {
 	hg_class_t		*chc_bulkcla; /* bulk class */
 	hg_context_t		*chc_bulkctx; /* bulk context */
 	struct crt_hg_pool	 chc_hg_pool; /* HG handle pool */
+	int			 chc_provider;
 };
 
 /* crt_hg.c */
@@ -118,6 +119,15 @@ int crt_proc_in_common(crt_proc_t proc, crt_rpc_input_t *data);
 int crt_proc_out_common(crt_proc_t proc, crt_rpc_output_t *data);
 
 bool crt_provider_is_contig_ep(int provider);
+bool crt_provider_is_sep(int provider);
+void crt_provider_set_sep(int provider, bool enable);
+int crt_provider_get_cur_ctx_num(int provider);
+void crt_provider_inc_cur_ctx_num(int provider);
+void crt_provider_dec_cur_ctx_num(int provider);
+
+int crt_provider_get_max_ctx_num(int provider);
+void crt_provider_add_ctx_list(int provider, d_list_t *cc_link);
+d_list_t *crt_provider_get_ctx_list(int provider);
 
 static inline int
 crt_hgret_2_der(int hg_ret)

--- a/src/cart/crt_init.c
+++ b/src/cart/crt_init.c
@@ -399,12 +399,12 @@ crt_init_opt(crt_group_id_t grpid, uint32_t flags, crt_init_options_t *opt)
 		     plugin_idx++) {
 			if (!strncmp(addr_env, crt_na_dict[plugin_idx].nad_str,
 				     strlen(crt_na_dict[plugin_idx].nad_str) + 1)) {
+				bool		set_sep = false;
+				int		max_num_ctx = 256;
+				uint32_t	ctx_num;
+				bool		share_addr;
 
 				prov = crt_na_dict[plugin_idx].nad_type;
-				bool set_sep = false;
-				int max_num_ctx = 256;
-				uint32_t ctx_num;
-				bool share_addr;
 
 				if (opt && opt->cio_sep_override) {
 					if (opt->cio_use_sep)
@@ -412,7 +412,8 @@ crt_init_opt(crt_group_id_t grpid, uint32_t flags, crt_init_options_t *opt)
 
 					max_num_ctx = opt->cio_ctx_max_num;
 				} else {
-					d_getenv_bool("CRT_CTX_SHARE_ADDR", &share_addr);
+					d_getenv_bool("CRT_CTX_SHARE_ADDR",
+						      &share_addr);
 					if (share_addr)
 						set_sep = true;
 

--- a/src/cart/crt_init.c
+++ b/src/cart/crt_init.c
@@ -405,7 +405,8 @@ crt_init_opt(crt_group_id_t grpid, uint32_t flags, crt_init_options_t *opt)
 			if (!strncmp(addr_env, crt_na_dict[plugin_idx].nad_str,
 				     strlen(crt_na_dict[plugin_idx].nad_str) + 1)) {
 				provider_found = true;
-				crt_gdata.cg_init_prov = crt_na_dict[plugin_idx].nad_type;
+				crt_gdata.cg_init_prov = 
+					crt_na_dict[plugin_idx].nad_type;
 				break;
 			}
 		}

--- a/src/cart/crt_init.c
+++ b/src/cart/crt_init.c
@@ -825,7 +825,7 @@ int crt_na_ofi_config_init(int provider)
 	}
 	freeifaddrs(if_addrs);
 	if (ip_str == NULL) {
-		D_ERROR("no IP addr found.\n");
+		D_ERROR("no IP addr found on interface %s\n", interface);
 		D_GOTO(out, rc = -DER_PROTO);
 	}
 

--- a/src/cart/crt_init.c
+++ b/src/cart/crt_init.c
@@ -83,13 +83,25 @@ exit:
 	return;
 }
 
+static void
+prov_data_init(struct crt_prov_gdata *prov_data, int provider,
+		bool sep_mode, int max_ctx_num)
+{
+	prov_data->cpg_inited = true;
+	prov_data->cpg_provider = provider;
+	prov_data->cpg_ctx_num = 0;
+	prov_data->cpg_sep_mode = sep_mode;
+	prov_data->cpg_contig_ports = true;
+	prov_data->cpg_ctx_max_num = max_ctx_num;
+
+	D_INIT_LIST_HEAD(&(prov_data->cpg_ctx_list));
+}
+
 /* first step init - for initializing crt_gdata */
 static int data_init(int server, crt_init_options_t *opt)
 {
 	uint32_t	timeout;
 	uint32_t	credits;
-	bool		share_addr = false;
-	uint32_t	ctx_num = 1;
 	uint32_t	fi_univ_size = 0;
 	uint32_t	mem_pin_disable = 0;
 	uint32_t	mrc_enable = 0;
@@ -106,20 +118,14 @@ static int data_init(int server, crt_init_options_t *opt)
 	 */
 	D_CASSERT(sizeof(uuid_t) == 16);
 
-	D_INIT_LIST_HEAD(&crt_gdata.cg_ctx_list);
-
 	rc = D_RWLOCK_INIT(&crt_gdata.cg_rwlock, NULL);
 	if (rc != 0) {
 		D_ERROR("Failed to init cg_rwlock\n");
 		D_GOTO(exit, rc);
 	}
 
-	crt_gdata.cg_ctx_num = 0;
 	crt_gdata.cg_refcount = 0;
 	crt_gdata.cg_inited = 0;
-	crt_gdata.cg_na_plugin = CRT_NA_OFI_SOCKETS;
-	crt_gdata.cg_sep_mode = false;
-	crt_gdata.cg_contig_ports = true;
 
 	srand(d_timeus_secdiff(0) + getpid());
 	start_rpcid = ((uint64_t)rand()) << 32;
@@ -186,29 +192,6 @@ static int data_init(int server, crt_init_options_t *opt)
 	crt_gdata.cg_credit_ep_ctx = credits;
 	D_ASSERT(crt_gdata.cg_credit_ep_ctx <= CRT_MAX_CREDITS_PER_EP_CTX);
 
-	if (opt && opt->cio_sep_override) {
-		if (opt->cio_use_sep) {
-			crt_gdata.cg_sep_mode = true;
-			D_DEBUG(DB_ALL, "crt_gdata.cg_sep_mode turned on.\n");
-		}
-		crt_gdata.cg_ctx_max_num = opt->cio_ctx_max_num;
-	} else {
-		d_getenv_bool("CRT_CTX_SHARE_ADDR", &share_addr);
-		if (share_addr) {
-			crt_gdata.cg_sep_mode = true;
-			D_DEBUG(DB_ALL, "crt_gdata.cg_sep_mode turned on.\n");
-		}
-
-		d_getenv_int("CRT_CTX_NUM", &ctx_num);
-		crt_gdata.cg_ctx_max_num = ctx_num;
-	}
-
-	D_DEBUG(DB_ALL, "set cg_sep_mode %d, cg_ctx_max_num %d.\n",
-		crt_gdata.cg_sep_mode, crt_gdata.cg_ctx_max_num);
-
-	if (crt_gdata.cg_sep_mode == false && crt_gdata.cg_ctx_max_num > 1)
-		D_WARN("CRT_CTX_NUM has no effect because CRT_CTX_SHARE_ADDR "
-		       "is not set or set to 0\n");
 
 	/** Enable statistics only for the server side and if requested */
 	if (opt && opt->cio_use_sensors && server) {
@@ -329,6 +312,7 @@ crt_init_opt(crt_group_id_t grpid, uint32_t flags, crt_init_options_t *opt)
 	bool		provider_found = false;
 	int		plugin_idx;
 	int		rc = 0;
+	int		prov = -1;
 
 	server = flags & CRT_FLAG_BIT_SERVER;
 
@@ -415,9 +399,33 @@ crt_init_opt(crt_group_id_t grpid, uint32_t flags, crt_init_options_t *opt)
 		     plugin_idx++) {
 			if (!strncmp(addr_env, crt_na_dict[plugin_idx].nad_str,
 				     strlen(crt_na_dict[plugin_idx].nad_str) + 1)) {
-				crt_gdata.cg_na_plugin =
-					crt_na_dict[plugin_idx].nad_type;
+
+				prov = crt_na_dict[plugin_idx].nad_type;
+				bool set_sep = false;
+				int max_num_ctx = 256;
+				uint32_t ctx_num;
+				bool share_addr;
+
+				if (opt && opt->cio_sep_override) {
+					if (opt->cio_use_sep)
+						set_sep = true;
+
+					max_num_ctx = opt->cio_ctx_max_num;
+				} else {
+					d_getenv_bool("CRT_CTX_SHARE_ADDR", &share_addr);
+					if (share_addr)
+						set_sep = true;
+
+					d_getenv_int("CRT_CTX_NUM", &ctx_num);
+					max_num_ctx = ctx_num;
+				}
+
+
+				prov_data_init(&crt_gdata.cg_prov_gdata[prov],
+					       prov, set_sep, max_num_ctx);
+
 				provider_found = true;
+				crt_gdata.cg_init_prov = prov;
 				break;
 			}
 		}
@@ -428,7 +436,7 @@ crt_init_opt(crt_group_id_t grpid, uint32_t flags, crt_init_options_t *opt)
 		}
 do_init:
 		/* Print notice that "ofi+verbs" is legacy */
-		if (crt_gdata.cg_na_plugin == CRT_NA_OFI_VERBS) {
+		if (prov == CRT_NA_OFI_VERBS) {
 			D_ERROR("\"ofi+verbs\" is no longer supported. "
 				"Use \"ofi+verbs;ofi_rxm\" instead for %s env",
 				CRT_PHY_ADDR_ENV);
@@ -436,17 +444,17 @@ do_init:
 		}
 
 		/* the verbs provider only works with regular EP */
-		if ((crt_gdata.cg_na_plugin == CRT_NA_OFI_VERBS_RXM ||
-		     crt_gdata.cg_na_plugin == CRT_NA_OFI_VERBS ||
-		     crt_gdata.cg_na_plugin == CRT_NA_OFI_TCP_RXM) &&
-		    crt_gdata.cg_sep_mode) {
+		if ((prov == CRT_NA_OFI_VERBS_RXM ||
+		     prov == CRT_NA_OFI_VERBS ||
+		     prov == CRT_NA_OFI_TCP_RXM) &&
+		    crt_provider_is_sep(prov)) {
 			D_WARN("set CRT_CTX_SHARE_ADDR as 1 is invalid "
 			       "for current provider, ignore it.\n");
-			crt_gdata.cg_sep_mode = false;
+			crt_provider_set_sep(prov, false);
 		}
 
-		if (crt_gdata.cg_na_plugin == CRT_NA_OFI_VERBS_RXM ||
-		    crt_gdata.cg_na_plugin == CRT_NA_OFI_TCP_RXM) {
+		if (prov == CRT_NA_OFI_VERBS_RXM ||
+		    prov == CRT_NA_OFI_TCP_RXM) {
 			char *srx_env;
 
 			srx_env = getenv("FI_OFI_RXM_USE_SRX");
@@ -456,12 +464,12 @@ do_init:
 			}
 		}
 
-		if (crt_gdata.cg_na_plugin == CRT_NA_OFI_PSM2) {
+		if (prov == CRT_NA_OFI_PSM2) {
 			setenv("FI_PSM2_NAME_SERVER", "1", true);
 			D_DEBUG(DB_ALL, "Setting FI_PSM2_NAME_SERVER to 1\n");
 		}
-		if (crt_na_type_is_ofi(crt_gdata.cg_na_plugin)) {
-			rc = crt_na_ofi_config_init();
+		if (crt_na_type_is_ofi(prov)) {
+			rc = crt_na_ofi_config_init(prov);
 			if (rc != 0) {
 				D_ERROR("crt_na_ofi_config_init() failed, "
 					DF_RC"\n", DP_RC(rc));
@@ -535,7 +543,7 @@ cleanup:
 	if (crt_gdata.cg_opc_map != NULL)
 		crt_opc_map_destroy(crt_gdata.cg_opc_map);
 
-	crt_na_ofi_config_fini();
+	crt_na_ofi_config_fini(crt_gdata.cg_init_prov);
 
 unlock:
 	D_RWLOCK_UNLOCK(&crt_gdata.cg_rwlock);
@@ -561,6 +569,8 @@ crt_finalize(void)
 	int local_rc;
 	int rc = 0;
 
+	struct crt_prov_gdata *prov_data;
+
 	D_RWLOCK_WRLOCK(&crt_gdata.cg_rwlock);
 
 	if (!crt_initialized()) {
@@ -573,15 +583,20 @@ crt_finalize(void)
 	if (crt_gdata.cg_refcount == 0) {
 		crt_self_test_fini();
 
-		if (crt_gdata.cg_ctx_num > 0) {
-			D_ASSERT(!crt_context_empty(CRT_LOCKED));
+		/* TODO: Needs to happen for every initialized provider */
+		prov_data = &(crt_gdata.cg_prov_gdata[crt_gdata.cg_init_prov]);
+
+		if (prov_data->cpg_ctx_num > 0) {
+			D_ASSERT(!crt_context_empty(crt_gdata.cg_init_prov,
+				 CRT_LOCKED));
 			D_ERROR("cannot finalize, current ctx_num(%d).\n",
-				crt_gdata.cg_ctx_num);
+				prov_data->cpg_ctx_num);
 			crt_gdata.cg_refcount++;
 			D_RWLOCK_UNLOCK(&crt_gdata.cg_rwlock);
 			D_GOTO(out, rc = -DER_NO_PERM);
 		} else {
-			D_ASSERT(crt_context_empty(CRT_LOCKED));
+			D_ASSERT(crt_context_empty(crt_gdata.cg_init_prov,
+				 CRT_LOCKED));
 		}
 
 		if (crt_plugin_gdata.cpg_inited == 1)
@@ -614,7 +629,7 @@ crt_finalize(void)
 		crt_gdata.cg_inited = 0;
 		gdata_init_flag = 0;
 
-		crt_na_ofi_config_fini();
+		crt_na_ofi_config_fini(crt_gdata.cg_init_prov);
 	} else {
 		D_RWLOCK_UNLOCK(&crt_gdata.cg_rwlock);
 	}
@@ -634,8 +649,6 @@ direct_out:
 	return rc;
 }
 
-/* global NA OFI plugin configuration */
-struct na_ofi_config crt_na_ofi_conf;
 
 static inline na_bool_t is_integer_str(char *str)
 {
@@ -729,7 +742,7 @@ crt_port_range_verify(int port)
 	}
 }
 
-int crt_na_ofi_config_init(void)
+int crt_na_ofi_config_init(int provider)
 {
 	char		*port_str;
 	char		*interface;
@@ -741,13 +754,17 @@ int crt_na_ofi_config_init(void)
 	char		*domain = NULL;
 	int		rc = 0;
 
+	struct crt_na_ofi_config *na_ofi_cfg;
+
+	na_ofi_cfg = &crt_gdata.cg_prov_gdata[provider].cpg_na_ofi_config;
+
 	interface = getenv("OFI_INTERFACE");
 	if (interface != NULL && strlen(interface) > 0) {
-		D_STRNDUP(crt_na_ofi_conf.noc_interface, interface, 64);
-		if (crt_na_ofi_conf.noc_interface == NULL)
+		D_STRNDUP(na_ofi_cfg->noc_interface, interface, 64);
+		if (na_ofi_cfg->noc_interface == NULL)
 			D_GOTO(out, rc = -DER_NOMEM);
 	} else {
-		crt_na_ofi_conf.noc_interface = NULL;
+		na_ofi_cfg->noc_interface = NULL;
 		D_ERROR("ENV OFI_INTERFACE not set.");
 		D_GOTO(out, rc = -DER_INVAL);
 	}
@@ -759,8 +776,8 @@ int crt_na_ofi_config_init(void)
 		domain = interface;
 	}
 
-	D_STRNDUP(crt_na_ofi_conf.noc_domain, domain, 64);
-	if (!crt_na_ofi_conf.noc_domain)
+	D_STRNDUP(na_ofi_cfg->noc_domain, domain, 64);
+	if (!na_ofi_cfg->noc_domain)
 		D_GOTO(out, rc = -DER_NOMEM);
 
 	rc = getifaddrs(&if_addrs);
@@ -771,17 +788,17 @@ int crt_na_ofi_config_init(void)
 	}
 
 	for (ifa = if_addrs; ifa != NULL; ifa = ifa->ifa_next) {
-		if (strcmp(ifa->ifa_name, crt_na_ofi_conf.noc_interface))
+		if (strcmp(ifa->ifa_name, na_ofi_cfg->noc_interface))
 			continue;
 		if (ifa->ifa_addr == NULL)
 			continue;
-		memset(crt_na_ofi_conf.noc_ip_str, 0, INET_ADDRSTRLEN);
+		memset(na_ofi_cfg->noc_ip_str, 0, INET_ADDRSTRLEN);
 		if (ifa->ifa_addr->sa_family == AF_INET) {
 			/* check it is a valid IPv4 Address */
 			tmp_ptr =
 			&((struct sockaddr_in *)ifa->ifa_addr)->sin_addr;
 			ip_str = inet_ntop(AF_INET, tmp_ptr,
-					   crt_na_ofi_conf.noc_ip_str,
+					   na_ofi_cfg->noc_ip_str,
 					   INET_ADDRSTRLEN);
 			if (ip_str == NULL) {
 				D_ERROR("inet_ntop failed, errno: %d(%s).\n",
@@ -823,31 +840,34 @@ int crt_na_ofi_config_init(void)
 
 			crt_port_range_verify(port);
 
-			if (crt_gdata.cg_na_plugin == CRT_NA_OFI_PSM2)
+			if (provider == CRT_NA_OFI_PSM2)
 				port = (uint16_t)port << 8;
 			D_DEBUG(DB_ALL, "OFI_PORT %d, using it as service "
 					"port.\n", port);
 		}
-	} else if (crt_gdata.cg_na_plugin == CRT_NA_OFI_PSM2) {
+	} else if (provider == CRT_NA_OFI_PSM2) {
 		rc = crt_get_port_psm2(&port);
 		if (rc != 0) {
 			D_ERROR("crt_get_port failed, rc: %d.\n", rc);
 			D_GOTO(out, rc);
 		}
 	}
-	crt_na_ofi_conf.noc_port = port;
+	na_ofi_cfg->noc_port = port;
 
 out:
 	if (rc != -DER_SUCCESS) {
-		D_FREE(crt_na_ofi_conf.noc_interface);
-		D_FREE(crt_na_ofi_conf.noc_domain);
+		D_FREE(na_ofi_cfg->noc_interface);
+		D_FREE(na_ofi_cfg->noc_domain);
 	}
 	return rc;
 }
 
-void crt_na_ofi_config_fini(void)
+void crt_na_ofi_config_fini(int provider)
 {
-	D_FREE(crt_na_ofi_conf.noc_interface);
-	D_FREE(crt_na_ofi_conf.noc_domain);
-	crt_na_ofi_conf.noc_port = 0;
+	struct crt_na_ofi_config *na_ofi_cfg;
+
+	na_ofi_cfg = &crt_gdata.cg_prov_gdata[provider].cpg_na_ofi_config;
+	D_FREE(na_ofi_cfg->noc_interface);
+	D_FREE(na_ofi_cfg->noc_domain);
+	na_ofi_cfg->noc_port = 0;
 }

--- a/src/cart/crt_init.c
+++ b/src/cart/crt_init.c
@@ -405,7 +405,7 @@ crt_init_opt(crt_group_id_t grpid, uint32_t flags, crt_init_options_t *opt)
 			if (!strncmp(addr_env, crt_na_dict[plugin_idx].nad_str,
 				     strlen(crt_na_dict[plugin_idx].nad_str) + 1)) {
 				provider_found = true;
-				crt_gdata.cg_init_prov = 
+				crt_gdata.cg_init_prov =
 					crt_na_dict[plugin_idx].nad_type;
 				break;
 			}

--- a/src/cart/crt_internal_fns.h
+++ b/src/cart/crt_internal_fns.h
@@ -30,7 +30,7 @@ enum {
 };
 
 int crt_context_req_track(struct crt_rpc_priv *rpc_priv);
-bool crt_context_empty(int locked);
+bool crt_context_empty(int provider, int locked);
 void crt_context_req_untrack(struct crt_rpc_priv *rpc_priv);
 crt_context_t crt_context_lookup(int ctx_idx);
 crt_context_t crt_context_lookup_locked(int ctx_idx);

--- a/src/cart/crt_internal_types.h
+++ b/src/cart/crt_internal_types.h
@@ -26,29 +26,54 @@
 struct crt_hg_gdata;
 struct crt_grp_gdata;
 
-/* CaRT global data */
-struct crt_gdata {
+struct crt_na_ofi_config {
+	int32_t		 noc_port;
+	char		*noc_interface;
+	char		*noc_domain;
+	/* IP addr str for the noc_interface */
+	char		 noc_ip_str[INET_ADDRSTRLEN];
+};
+
+struct crt_prov_gdata {
+	/** NA pluging type */
+	int			cpg_provider;
+	bool			cpg_inited;
+
+	struct crt_na_ofi_config cpg_na_ofi_config;
 	/**
 	 * TODO: Temporary storage for context0 URI, used during group
 	 * attach info file population for self address. Per-provider
 	 * context0 URIs need to be stored for multi-provider support
 	 */
-	char			cg_addr[CRT_ADDR_STR_MAX_LEN];
+	char			cpg_addr[CRT_ADDR_STR_MAX_LEN];
 
-	/** NA pluging type */
-	int			cg_na_plugin;
+	/** CaRT contexts list */
+	d_list_t		cpg_ctx_list;
+	/** actual number of items in CaRT contexts list */
+	int			cpg_ctx_num;
+	/** maximum number of contexts user wants to create */
+	uint32_t		cpg_ctx_max_num;
+
+	unsigned int		cpg_sep_mode		: 1,
+				cpg_contig_ports	: 1;
+
+};
+
+
+/* CaRT global data */
+struct crt_gdata {
+	/** Provider initialized at crt_init() time */
+	int			cg_init_prov;
+
+	/** Provider specific data */
+	struct crt_prov_gdata	cg_prov_gdata[CRT_NA_OFI_COUNT];
 
 	/** global timeout value (second) for all RPCs */
 	uint32_t		cg_timeout;
+
 	/** credits limitation for #inflight RPCs per target EP CTX */
 	uint32_t		cg_credit_ep_ctx;
 
-	/** CaRT contexts list */
-	d_list_t		cg_ctx_list;
-	/** actual number of items in CaRT contexts list */
-	int			cg_ctx_num;
-	/** maximum number of contexts user wants to create */
-	uint32_t		cg_ctx_max_num;
 	/** the global opcode map */
 	struct crt_opc_map	*cg_opc_map;
 	/** HG level global data */
@@ -67,10 +92,6 @@ struct crt_gdata {
 				/** whether it is a client or server */
 				cg_server		: 1,
 				/** whether scalable endpoint is enabled */
-				cg_sep_mode		: 1,
-				/** whether to use contiguous port ranges */
-				cg_contig_ports		: 1,
-				/** whether sensors are enabled */
 				cg_use_sensors		: 1;
 
 	ATOMIC uint64_t		cg_rpcid; /* rpc id */
@@ -168,8 +189,6 @@ struct crt_context {
 
 	/** timeout per-context */
 	uint32_t		 cc_timeout_sec;
-	/** provider on which context is allocated */
-	int			 cc_provider;
 
 	/** Per-context statistics (server-side only) */
 	/** Total number of timed out requests, of type counter */
@@ -267,17 +286,8 @@ struct crt_opc_map {
 	struct crt_opc_map_L2	*com_map;
 };
 
-struct na_ofi_config {
-	int32_t		 noc_port;
-	char		*noc_interface;
-	char		*noc_domain;
-	/* IP addr str for the noc_interface */
-	char		 noc_ip_str[INET_ADDRSTRLEN];
-};
 
-int crt_na_ofi_config_init(void);
-void crt_na_ofi_config_fini(void);
-
-extern struct na_ofi_config crt_na_ofi_conf;
+int crt_na_ofi_config_init(int provider);
+void crt_na_ofi_config_fini(int provider);
 
 #endif /* __CRT_INTERNAL_TYPES_H__ */

--- a/src/cart/crt_internal_types.h
+++ b/src/cart/crt_internal_types.h
@@ -37,14 +37,9 @@ struct crt_na_ofi_config {
 struct crt_prov_gdata {
 	/** NA pluging type */
 	int			cpg_provider;
-	bool			cpg_inited;
 
 	struct crt_na_ofi_config cpg_na_ofi_config;
-	/**
-	 * TODO: Temporary storage for context0 URI, used during group
-	 * attach info file population for self address. Per-provider
-	 * context0 URIs need to be stored for multi-provider support
-	 */
+	/** Context0 URI */
 	char			cpg_addr[CRT_ADDR_STR_MAX_LEN];
 
 	/** CaRT contexts list */
@@ -54,8 +49,10 @@ struct crt_prov_gdata {
 	/** maximum number of contexts user wants to create */
 	uint32_t		cpg_ctx_max_num;
 
+	/** Set of flags */
 	unsigned int		cpg_sep_mode		: 1,
-				cpg_contig_ports	: 1;
+				cpg_contig_ports	: 1,
+				cpg_inited		: 1;
 
 };
 

--- a/src/cart/crt_rpc.c
+++ b/src/cart/crt_rpc.c
@@ -810,7 +810,7 @@ uri_lookup_cb(const struct crt_cb_info *cb_info)
 	char *fill_uri = NULL;
 
 	if (ul_in->ul_tag != ul_out->ul_tag) {
-		if (crt_provider_is_contig_ep(ctx->cc_provider) == false) {
+		if (!crt_provider_is_contig_ep(ctx->cc_hg_ctx.chc_provider)) {
 			rc = crt_issue_uri_lookup(lookup_rpc->cr_ctx,
 						  lookup_rpc->cr_ep.ep_grp,
 						  ul_in->ul_rank, 0,


### PR DESCRIPTION
- Refactor code for multiprovider support
- Internal structures split between global shared data and per-provider
  data.
- Provider identifier moved from crt_context_t to hg_context_t
- For now default provider is used in few places, where provider
  cannot be easily derived
- Additional helper functions added to return and set per-provider
  data.

Signed-off-by: Alexander Oganezov <alexander.a.oganezov@intel.com>