### PR TITLE
DAOS-7638 tests: racer test for EC object

### DIFF
--- a/src/tests/daos_racer.c
+++ b/src/tests/daos_racer.c
@@ -46,6 +46,12 @@ enum {
 	RP_2G2,
 	RP_3G1,
 	RP_3G2,
+	EC_2P1G1,
+	EC_2P1G2,
+	EC_2P2G1,
+	EC_2P2G2,
+	EC_4P1G1,
+	EC_4P2G1,
 	OBJ_CNT
 };
 
@@ -79,6 +85,18 @@ oclass_get(unsigned int random)
 		return OC_RP_3G1;
 	case RP_3G2:
 		return OC_RP_3G2;
+	case EC_2P1G1:
+		return OC_EC_2P1G1;
+	case EC_2P1G2:
+		return OC_EC_2P1G2;
+	case EC_2P2G1:
+		return OC_EC_2P2G1;
+	case EC_2P2G2:
+		return OC_EC_2P2G2;
+	case EC_4P1G1:
+		return OC_EC_4P1G1;
+	case EC_4P2G1:
+		return OC_EC_4P2G1;
 	default:
 		assert(0);
 	}

--- a/src/tests/ftest/daos_racer/daos_racer.py
+++ b/src/tests/ftest/daos_racer/daos_racer.py
@@ -29,7 +29,9 @@ class DaosRacerTest(TestWithServers):
         Use Cases:
             Running simultaneous, conflicting I/O requests.
 
-        :avocado: tags=all,full_regression,hw,large,io,daosracer
+        :avocado: tags=all,pr,full_regression,daily_regression
+        :avocado: tags=hw,large,io,daosracer
+
         """
         dmg = self.get_dmg_command()
         self.assertGreater(

--- a/src/tests/ftest/daos_racer/daos_racer.yaml
+++ b/src/tests/ftest/daos_racer/daos_racer.yaml
@@ -9,7 +9,7 @@ hosts:
     - server-G
   test_clients:
     - client-H
-timeout: 10800
+timeout: 1800
 server_config:
     name: daos_server
     servers:
@@ -19,5 +19,5 @@ server_config:
         scm_class: dcpm
         scm_list: ["/dev/pmem0"]
 daos_racer:
-  runtime: 7200
-  clush_timeout: 10080
+  runtime: 600
+  clush_timeout: 900


### PR DESCRIPTION
Kinds of upadte, fetch, enumerate, query reqeusts for EC objects,
and contains conditional operations. But consistency verification
after racer test still skip EC objects.

Signed-off-by: Fan Yong <fan.yong@intel.com>