### PR TITLE
DAOS-7235 obj: turn off read/write perm when cont_rf broken (#5681)

### DIFF
--- a/src/client/api/container.c
+++ b/src/client/api/container.c
@@ -199,6 +199,55 @@ daos_cont_set_prop(daos_handle_t coh, daos_prop_t *prop, daos_event_t *ev)
 	return dc_task_schedule(task, true);
 }
 
+static int
+dcsc_prop_free(tse_task_t *task, void *data)
+{
+	daos_prop_t *prop = *((daos_prop_t **)data);
+
+	daos_prop_free(prop);
+	return task->dt_result;
+}
+
+int
+daos_cont_status_clear(daos_handle_t coh, daos_event_t *ev)
+{
+	daos_cont_set_prop_t	*args;
+	daos_prop_t		*prop;
+	struct daos_prop_entry	*entry;
+	tse_task_t		*task;
+	int			 rc;
+
+	prop = daos_prop_alloc(1);
+	if (prop == NULL)
+		return -DER_NOMEM;
+
+	entry = &prop->dpp_entries[0];
+	entry->dpe_type = DAOS_PROP_CO_STATUS;
+	entry->dpe_val = DAOS_PROP_CO_STATUS_VAL(DAOS_PROP_CO_HEALTHY,
+						 DAOS_PROP_CO_CLEAR, 0);
+
+	DAOS_API_ARG_ASSERT(*args, CONT_SET_PROP);
+	rc = dc_task_create(dc_cont_set_prop, NULL, ev, &task);
+	if (rc) {
+		daos_prop_free(prop);
+		return rc;
+	}
+
+	args = dc_task_get_args(task);
+	args->coh	= coh;
+	args->prop	= prop;
+
+	rc = tse_task_register_comp_cb(task, dcsc_prop_free, &prop,
+				       sizeof(prop));
+	if (rc) {
+		daos_prop_free(prop);
+		tse_task_complete(task, rc);
+		return rc;
+	}
+
+	return dc_task_schedule(task, true);
+}
+
 int
 daos_cont_overwrite_acl(daos_handle_t coh, struct daos_acl *acl,
 			daos_event_t *ev)

--- a/src/common/pool_map.c
+++ b/src/common/pool_map.c
@@ -2329,10 +2329,12 @@ pmap_comp_failed(struct pool_component *comp)
 }
 
 static bool
-pmap_comp_execlude_out_earlier(struct pool_component *comp, uint32_t ver)
+pmap_comp_failed_earlier(struct pool_component *comp, uint32_t ver)
 {
-	return (comp->co_status == PO_COMP_ST_DOWNOUT &&
-		comp->co_out_ver <= ver);
+	return ((comp->co_status == PO_COMP_ST_DOWNOUT &&
+		 comp->co_out_ver <= ver) ||
+		(comp->co_status == PO_COMP_ST_DOWN &&
+		 comp->co_fseq <= ver));
 }
 
 static int
@@ -2472,7 +2474,7 @@ pmap_node_check(struct pool_domain *node_dom, struct pmap_fail_stat *fstat)
 		tgt = &node_dom->do_targets[i];
 		comp = &tgt->ta_comp;
 		if (!pmap_comp_failed(comp) ||
-		    pmap_comp_execlude_out_earlier(comp, fstat->pf_last_ver))
+		    pmap_comp_failed_earlier(comp, fstat->pf_last_ver))
 			continue;
 		if (fnode == NULL) {
 			fnode = pmap_fail_node_get(fstat);
@@ -2499,9 +2501,9 @@ pmap_node_check(struct pool_domain *node_dom, struct pmap_fail_stat *fstat)
 		fstat->pf_newfail_nr++;
 	if ((fstat->pf_down_nr > fstat->pf_rf) && (fstat->pf_newfail_nr > 0)) {
 		rc = -DER_RF;
-		D_ERROR("RF broken, found %d DOWN node, newly fail %d, rf %d, "
-			DF_RC"\n", fstat->pf_down_nr, fstat->pf_newfail_nr,
-			fstat->pf_rf, DP_RC(rc));
+		D_DEBUG(DB_TRACE, "RF broken, found %d DOWN node, "
+			"newly fail %d, rf %d, "DF_RC"\n", fstat->pf_down_nr,
+			fstat->pf_newfail_nr, fstat->pf_rf, DP_RC(rc));
 	}
 
 	return rc;
@@ -2577,8 +2579,8 @@ pmap_fail_stat_check(struct pmap_fail_stat *fstat)
 
 fail:
 	if (rc == -DER_RF) {
-		D_ERROR("RF broken, found %d fail, DOWN %d, newly fail %d, "
-			"max_overlapped %d, rf %d, "DF_RC"\n",
+		D_DEBUG(DB_TRACE, "RF broken, found %d fail, DOWN %d, newly "
+			"fail %d, max_overlapped %d, rf %d, "DF_RC"\n",
 			fstat->pf_node_nr, fstat->pf_down_nr,
 			fstat->pf_newfail_nr, max_fail_nr,
 			fstat->pf_rf, DP_RC(rc));

--- a/src/container/container_iv.c
+++ b/src/container/container_iv.c
@@ -19,6 +19,9 @@
 /* INIT snap count */
 #define INIT_SNAP_CNT	10
 
+static int
+cont_iv_prop_g2l(struct cont_iv_prop *iv_prop, daos_prop_t *prop);
+
 static struct cont_iv_key *
 key2priv(struct ds_iv_key *iv_key)
 {
@@ -177,6 +180,7 @@ cont_iv_ent_copy(struct ds_iv_entry *entry, struct cont_iv_key *key,
 	case IV_CONT_CAPA:
 		dst->iv_capa.flags = src->iv_capa.flags;
 		dst->iv_capa.sec_capas = src->iv_capa.sec_capas;
+		dst->iv_capa.status_pm_ver = src->iv_capa.status_pm_ver;
 		break;
 	case IV_CONT_PROP:
 		D_ASSERT(dst_sgl->sg_iovs[0].iov_buf_len >=
@@ -483,9 +487,42 @@ cont_iv_ent_update(struct ds_iv_entry *entry, struct ds_iv_key *key,
 					      civ_key->cont_uuid,
 					      civ_ent->cont_uuid,
 					      civ_ent->iv_capa.flags,
-					      civ_ent->iv_capa.sec_capas);
+					      civ_ent->iv_capa.sec_capas,
+					      civ_ent->iv_capa.status_pm_ver);
 			if (rc)
 				D_GOTO(out, rc);
+		} else if (entry->iv_class->iv_class_id == IV_CONT_PROP) {
+			daos_prop_t		*prop = NULL;
+			struct daos_prop_entry	*iv_entry;
+			struct daos_co_status	 co_stat = {0};
+
+			prop = daos_prop_alloc(CONT_PROP_NUM);
+			if (prop == NULL)
+				D_GOTO(out, rc = -DER_NOMEM);
+
+			rc = cont_iv_prop_g2l(&civ_ent->iv_prop, prop);
+			if (rc) {
+				D_ERROR("cont_iv_prop_g2l failed "DF_RC"\n",
+					DP_RC(rc));
+				daos_prop_free(prop);
+				D_GOTO(out, rc);
+			}
+
+			iv_entry = daos_prop_entry_get(prop,
+						       DAOS_PROP_CO_STATUS);
+			if (iv_entry != NULL) {
+				daos_prop_val_2_co_status(iv_entry->dpe_val,
+							  &co_stat);
+				rc = ds_cont_status_pm_ver_update(
+					entry->ns->iv_pool_uuid,
+					civ_ent->cont_uuid,
+					co_stat.dcs_pm_ver);
+				if (rc) {
+					daos_prop_free(prop);
+					goto out;
+				}
+			}
+			daos_prop_free(prop);
 		} else if (entry->iv_class->iv_class_id == IV_CONT_SNAP &&
 			   civ_ent->iv_snap.snap_cnt != (uint64_t)(-1)) {
 			rc = ds_cont_tgt_snapshots_update(
@@ -952,7 +989,7 @@ cont_iv_ec_agg_eph_refresh(void *ns, uuid_t cont_uuid, daos_epoch_t eph)
 
 int
 cont_iv_capability_update(void *ns, uuid_t cont_hdl_uuid, uuid_t cont_uuid,
-			  uint64_t flags, uint64_t sec_capas)
+			  uint64_t flags, uint64_t sec_capas, uint32_t pm_ver)
 {
 	struct cont_iv_entry	iv_entry = { 0 };
 	int			rc;
@@ -961,6 +998,7 @@ cont_iv_capability_update(void *ns, uuid_t cont_hdl_uuid, uuid_t cont_uuid,
 	D_ASSERT(dss_get_module_info()->dmi_xs_id == 0);
 	iv_entry.iv_capa.flags = flags;
 	iv_entry.iv_capa.sec_capas = sec_capas;
+	iv_entry.iv_capa.status_pm_ver = pm_ver;
 	uuid_copy(iv_entry.cont_uuid, cont_uuid);
 
 	rc = cont_iv_update(ns, IV_CONT_CAPA, cont_hdl_uuid, &iv_entry,

--- a/src/container/srv_internal.h
+++ b/src/container/srv_internal.h
@@ -117,6 +117,8 @@ struct cont_iv_snapshot {
 struct cont_iv_capa {
 	uint64_t	flags;
 	uint64_t	sec_capas;
+	/* the pool map_ver of updating DAOS_PROP_CO_STATUS property */
+	uint32_t	status_pm_ver;
 };
 
 /* flattened container properties */
@@ -251,13 +253,16 @@ void ds_cont_hdl_hash_destroy(struct d_hash_table *hash);
 void ds_cont_oid_alloc_handler(crt_rpc_t *rpc);
 
 int ds_cont_tgt_open(uuid_t pool_uuid, uuid_t cont_hdl_uuid,
-		     uuid_t cont_uuid, uint64_t flags, uint64_t sec_capas);
+		     uuid_t cont_uuid, uint64_t flags, uint64_t sec_capas,
+		     uint32_t status_pm_ver);
 int ds_cont_tgt_snapshots_update(uuid_t pool_uuid, uuid_t cont_uuid,
 				 uint64_t *snapshots, int snap_count);
 int ds_cont_tgt_snapshots_refresh(uuid_t pool_uuid, uuid_t cont_uuid);
 int ds_cont_tgt_close(uuid_t cont_hdl_uuid);
 int ds_cont_tgt_refresh_agg_eph(uuid_t pool_uuid, uuid_t cont_uuid,
 				daos_epoch_t eph);
+int ds_cont_status_pm_ver_update(uuid_t pool_uuid, uuid_t cont_uuid,
+				 uint32_t pm_ver);
 /**
  * oid_iv.c
  */
@@ -270,7 +275,8 @@ int oid_iv_reserve(void *ns, uuid_t poh_uuid, uuid_t co_uuid, uuid_t coh_uuid,
 int ds_cont_iv_init(void);
 int ds_cont_iv_fini(void);
 int cont_iv_capability_update(void *ns, uuid_t cont_hdl_uuid, uuid_t cont_uuid,
-			      uint64_t flags, uint64_t sec_capas);
+			      uint64_t flags, uint64_t sec_capas,
+			      uint32_t pm_ver);
 int cont_iv_capability_invalidate(void *ns, uuid_t cont_hdl_uuid,
 				  int sync_mode);
 int cont_iv_prop_fetch(uuid_t pool_uuid, uuid_t cont_uuid,

--- a/src/container/srv_layout.c
+++ b/src/container/srv_layout.c
@@ -104,7 +104,7 @@ struct daos_prop_entry cont_prop_entries_default[CONT_PROP_NUM] = {
 	}, {
 		.dpe_type	= DAOS_PROP_CO_STATUS,
 		.dpe_val	= DAOS_PROP_CO_STATUS_VAL(DAOS_PROP_CO_HEALTHY,
-							  0),
+							  0, 0),
 	}, {
 		.dpe_type	= DAOS_PROP_CO_ALLOCED_OID,
 		.dpe_val	= 0,

--- a/src/container/srv_target.c
+++ b/src/container/srv_target.c
@@ -22,6 +22,7 @@
 #define D_LOGFAC	DD_FAC(container)
 
 #include <daos_srv/container.h>
+#include <daos_srv/security.h>
 
 #include <daos/checksum.h>
 #include <daos/rpc.h>
@@ -1299,7 +1300,7 @@ ds_cont_child_lookup(uuid_t pool_uuid, uuid_t cont_uuid,
  * it will return 1, otherwise return 0 or error code.
  **/
 static int
-cont_child_create_start(uuid_t pool_uuid, uuid_t cont_uuid,
+cont_child_create_start(uuid_t pool_uuid, uuid_t cont_uuid, uint32_t pm_ver,
 			struct ds_cont_child **cont_out)
 {
 	struct ds_pool_child	*pool_child;
@@ -1314,6 +1315,10 @@ cont_child_create_start(uuid_t pool_uuid, uuid_t cont_uuid,
 
 	rc = cont_child_start(pool_child, cont_uuid, cont_out);
 	if (rc != -DER_NONEXIST) {
+		if (rc == 0) {
+			D_ASSERT(*cont_out != NULL);
+			(*cont_out)->sc_status_pm_ver = pm_ver;
+		}
 		ds_pool_child_put(pool_child);
 		return rc;
 	}
@@ -1324,7 +1329,9 @@ cont_child_create_start(uuid_t pool_uuid, uuid_t cont_uuid,
 	rc = vos_cont_create(pool_child->spc_hdl, cont_uuid);
 	if (!rc) {
 		rc = cont_child_start(pool_child, cont_uuid, cont_out);
-		if (rc != 0)
+		if (rc == 0)
+			(*cont_out)->sc_status_pm_ver = pm_ver;
+		else
 			vos_cont_destroy(pool_child->spc_hdl, cont_uuid);
 	}
 
@@ -1393,16 +1400,17 @@ ds_cont_child_open_create(uuid_t pool_uuid, uuid_t cont_uuid,
 {
 	int rc;
 
-	rc = cont_child_create_start(pool_uuid, cont_uuid, cont);
+	/* status_pm_ver has no sense for rebuild container */
+	rc = cont_child_create_start(pool_uuid, cont_uuid, 0, cont);
 	if (rc == 1)
 		rc = 0;
 
 	return rc;
 }
 
-int
+static int
 ds_cont_local_open(uuid_t pool_uuid, uuid_t cont_hdl_uuid, uuid_t cont_uuid,
-		   uint64_t flags, uint64_t sec_capas,
+		   uint64_t flags, uint64_t sec_capas, uint32_t status_pm_ver,
 		   struct ds_cont_hdl **cont_hdl)
 {
 	struct dsm_tls		*tls = dsm_tls_get();
@@ -1445,7 +1453,8 @@ ds_cont_local_open(uuid_t pool_uuid, uuid_t cont_hdl_uuid, uuid_t cont_uuid,
 
 	/* cont_uuid is NULL when open rebuild global cont handle */
 	if (cont_uuid != NULL && !uuid_is_null(cont_uuid)) {
-		rc = cont_child_create_start(pool_uuid, cont_uuid, &cont);
+		rc = cont_child_create_start(pool_uuid, cont_uuid,
+					     status_pm_ver, &cont);
 		if (rc < 0)
 			D_GOTO(err_hdl, rc);
 
@@ -1588,6 +1597,7 @@ struct cont_tgt_open_arg {
 	uuid_t		cont_hdl_uuid;
 	uint64_t	flags;
 	uint64_t	sec_capas;
+	uint32_t	status_pm_ver;
 };
 
 /*
@@ -1601,12 +1611,13 @@ cont_open_one(void *vin)
 
 	return ds_cont_local_open(arg->pool_uuid, arg->cont_hdl_uuid,
 				  arg->cont_uuid, arg->flags, arg->sec_capas,
-				  NULL);
+				  arg->status_pm_ver, NULL);
 }
 
 int
 ds_cont_tgt_open(uuid_t pool_uuid, uuid_t cont_hdl_uuid,
-		 uuid_t cont_uuid, uint64_t flags, uint64_t sec_capas)
+		 uuid_t cont_uuid, uint64_t flags, uint64_t sec_capas,
+		 uint32_t status_pm_ver)
 {
 	struct cont_tgt_open_arg arg = { 0 };
 	struct dss_coll_ops	coll_ops = { 0 };
@@ -1619,6 +1630,7 @@ ds_cont_tgt_open(uuid_t pool_uuid, uuid_t cont_hdl_uuid,
 		uuid_copy(arg.cont_uuid, cont_uuid);
 	arg.flags = flags;
 	arg.sec_capas = sec_capas;
+	arg.status_pm_ver = status_pm_ver;
 
 	D_DEBUG(DB_TRACE, "open pool/cont/hdl "DF_UUID"/"DF_UUID"/"DF_UUID"\n",
 		DP_UUID(pool_uuid), DP_UUID(cont_uuid), DP_UUID(cont_hdl_uuid));
@@ -1938,7 +1950,7 @@ cont_snapshots_refresh_ult(void *data)
 	ds_pool_put(pool);
 out:
 	if (rc != 0)
-		D_WARN(DF_UUID": failed to refresh snapshots IV: "
+		D_DEBUG(DB_TRACE, DF_UUID": failed to refresh snapshots IV: "
 		       "Aggregation may not work correctly "DF_RC"\n",
 		       DP_UUID(args->cont_uuid), DP_RC(rc));
 	D_FREE(args);
@@ -2461,4 +2473,243 @@ yield:
 	d_list_for_each_entry_safe(ec_eph, tmp, &pool->sp_ec_ephs_list,
 				   ce_list)
 		cont_ec_eph_destroy(ec_eph);
+}
+
+struct cont_rf_check_arg {
+	uuid_t			 crc_pool_uuid;
+	ABT_eventual		 crc_eventual;
+};
+
+struct cont_set_arg {
+	uuid_t			csa_pool_uuid;
+	uuid_t			csa_cont_uuid;
+	uint32_t		csa_status_pm_ver;
+	bool			csa_rw_disable;
+};
+
+static int
+cont_rw_capa_set(void *data)
+{
+	struct dsm_tls		*tls = dsm_tls_get();
+	struct cont_set_arg	*arg = data;
+	struct ds_cont_child	*cont_child;
+	int			 rc = 0;
+
+	rc = cont_child_lookup(tls->dt_cont_cache, arg->csa_cont_uuid,
+			       arg->csa_pool_uuid, false /* create */,
+			       &cont_child);
+	if (rc) {
+		if (rc == -DER_NONEXIST)
+			rc = 0;
+		else
+			D_ERROR(DF_CONT" cont_child_lookup failed, "DF_RC"\n",
+				DP_CONT(arg->csa_pool_uuid, arg->csa_cont_uuid),
+				DP_RC(rc));
+		return rc;
+	}
+	D_ASSERT(cont_child != NULL);
+
+	cont_child->sc_rw_disabled = arg->csa_rw_disable;
+	if (dss_get_module_info()->dmi_tgt_id == 0)
+		D_ERROR(DF_CONT" read/write permission %s.\n",
+			DP_CONT(arg->csa_pool_uuid, arg->csa_cont_uuid),
+			cont_child->sc_rw_disabled ? "disabled" : "enabled");
+
+	ds_cont_child_put(cont_child);
+	return rc;
+}
+
+static int
+cont_rf_check(struct ds_pool *ds_pool, struct ds_cont_child *cont_child)
+{
+	struct cont_set_arg		rw_arg;
+	int				rc = 0;
+
+	rc = ds_pool_rf_verify(ds_pool, cont_child->sc_status_pm_ver,
+			       cont_child->sc_props.dcp_redun_fac);
+	if (rc != 0 && rc != -DER_RF)
+		goto out;
+
+	rw_arg.csa_rw_disable = (rc == -DER_RF);
+	if (rw_arg.csa_rw_disable == cont_child->sc_rw_disabled)
+		D_GOTO(out, rc = 0);
+
+	uuid_copy(rw_arg.csa_cont_uuid, cont_child->sc_uuid);
+	uuid_copy(rw_arg.csa_pool_uuid, ds_pool->sp_uuid);
+	rc = dss_task_collective(cont_rw_capa_set, &rw_arg, 0);
+	if (rc)
+		D_ERROR("collective cont_write_data_turn_off failed, "DF_RC"\n",
+			DP_RC(rc));
+
+out:
+	return rc;
+}
+
+static void
+cont_rf_check_ult(void *data)
+{
+	struct cont_rf_check_arg	*arg = data;
+	struct ds_pool			*ds_pool;
+	struct ds_pool_child		*pool_child;
+	struct ds_cont_child		*cont_child;
+	int				 rc = 0;
+
+	pool_child = ds_pool_child_lookup(arg->crc_pool_uuid);
+	D_ASSERTF(pool_child != NULL, DF_UUID" : failed to find pool child\n",
+		 DP_UUID(arg->crc_pool_uuid));
+
+	ds_pool = pool_child->spc_pool;
+	d_list_for_each_entry(cont_child, &pool_child->spc_cont_list, sc_link) {
+		if (cont_child->sc_stopping)
+			continue;
+		rc = cont_rf_check(ds_pool, cont_child);
+		if (rc) {
+			D_DEBUG(DB_TRACE, DF_CONT" cont_rf_check failed, "
+				DF_RC"\n",
+				DP_CONT(ds_pool->sp_uuid, cont_child->sc_uuid),
+				DP_RC(rc));
+			break;
+		}
+	}
+
+	ds_pool_child_put(pool_child);
+	ABT_eventual_set(arg->crc_eventual, (void *)&rc, sizeof(rc));
+}
+
+static int
+cont_rf_check_get_tgt(uuid_t pool_uuid)
+{
+	int		*failed_tgts = NULL;
+	unsigned int	 failed_tgts_cnt;
+	bool		 alive;
+	int		 rc, i, j;
+
+	rc = ds_pool_get_failed_tgt_idx(pool_uuid, &failed_tgts,
+					&failed_tgts_cnt);
+	if (rc) {
+		D_ERROR(DF_UUID "failed to get tgt_idx, "DF_RC"\n",
+			DP_UUID(pool_uuid), DP_RC(rc));
+		return rc;
+	}
+
+	D_ASSERTF(failed_tgts_cnt <= dss_tgt_nr,
+		  "BAD failed_tgts_cnt %d, dss_tgt_nr %d\n",
+		  failed_tgts_cnt, dss_tgt_nr);
+	if (failed_tgts_cnt == dss_tgt_nr) {
+		D_GOTO(out, rc = -DER_NONEXIST);
+	} else if (failed_tgts_cnt == 0) {
+		/* if all alive, select one random tgt */
+		rc = rand() % dss_tgt_nr;
+		goto out;
+	} else {
+		/* if partial failed, select first alive tgt */
+		for (i = 0; i < dss_tgt_nr; i++) {
+			alive = true;
+			for (j = 0; j < failed_tgts_cnt; j++) {
+				if (i == failed_tgts[j]) {
+					alive = false;
+					break;
+				}
+			}
+			if (alive) {
+				rc = i;
+				goto out;
+			}
+		}
+	}
+
+out:
+	if (failed_tgts != NULL)
+		D_FREE(failed_tgts);
+	return rc;
+}
+
+/** Check active container, if its RF value match with new pool map */
+int
+ds_cont_rf_check(uuid_t pool_uuid)
+{
+	struct cont_rf_check_arg	 check_arg;
+	int				*status;
+	int				 tgt_idx;
+	int				 rc = 0;
+
+	uuid_copy(check_arg.crc_pool_uuid, pool_uuid);
+	rc = ABT_eventual_create(sizeof(*status), &check_arg.crc_eventual);
+	if (rc != ABT_SUCCESS)
+		return dss_abterr2der(rc);
+
+	/* check RF on one alive tgt's VOS main XS */
+	rc = cont_rf_check_get_tgt(pool_uuid);
+	if (rc < 0) {
+		if (rc == -DER_NONEXIST)
+			rc = 0;
+		goto out;
+	}
+	tgt_idx = rc;
+	rc = dss_ult_create(cont_rf_check_ult, &check_arg, DSS_XS_VOS, tgt_idx,
+			    0, NULL);
+	if (rc)
+		D_GOTO(out, rc);
+
+	rc = ABT_eventual_wait(check_arg.crc_eventual, (void **)&status);
+	if (rc != ABT_SUCCESS)
+		D_GOTO(out, rc = dss_abterr2der(rc));
+	rc = *status;
+
+out:
+	ABT_eventual_free(&check_arg.crc_eventual);
+	return rc;
+}
+
+static int
+cont_status_pm_ver_set(void *data)
+{
+	struct dsm_tls		*tls = dsm_tls_get();
+	struct cont_set_arg	*arg = data;
+	struct ds_cont_child	*cont_child;
+	int			 rc = 0;
+
+	rc = cont_child_lookup(tls->dt_cont_cache, arg->csa_cont_uuid,
+			       arg->csa_pool_uuid, false /* create */,
+			       &cont_child);
+	if (rc) {
+		if (rc == -DER_NONEXIST)
+			rc = 0;
+		else
+			D_ERROR(DF_CONT" cont_child_lookup failed, "DF_RC"\n",
+				DP_CONT(arg->csa_pool_uuid, arg->csa_cont_uuid),
+				DP_RC(rc));
+		return rc;
+	}
+	D_ASSERT(cont_child != NULL);
+
+	if (arg->csa_status_pm_ver <= cont_child->sc_status_pm_ver)
+		goto out;
+	if (dss_get_module_info()->dmi_tgt_id == 0)
+		D_DEBUG(DB_TRACE, DF_CONT" statu_pm_ver set from %d to %d.\n",
+			DP_CONT(arg->csa_pool_uuid, arg->csa_cont_uuid),
+			cont_child->sc_status_pm_ver, arg->csa_status_pm_ver);
+	cont_child->sc_status_pm_ver = arg->csa_status_pm_ver;
+
+out:
+	ds_cont_child_put(cont_child);
+	return rc;
+}
+
+int
+ds_cont_status_pm_ver_update(uuid_t pool_uuid, uuid_t cont_uuid,
+			     uint32_t pm_ver)
+{
+	struct cont_set_arg	arg;
+	int			rc = 0;
+
+	uuid_copy(arg.csa_cont_uuid, cont_uuid);
+	uuid_copy(arg.csa_pool_uuid, pool_uuid);
+	arg.csa_status_pm_ver = pm_ver;
+	rc = dss_task_collective(cont_status_pm_ver_set, &arg, 0);
+	if (rc)
+		D_ERROR("collective cont_write_data_turn_off failed, "DF_RC"\n",
+			DP_RC(rc));
+
+	return rc;
 }

--- a/src/include/daos/object.h
+++ b/src/include/daos/object.h
@@ -503,6 +503,8 @@ enum daos_io_flags {
 	DIOF_TO_SPEC_GROUP	= 0x20,
 	/* For data migration. */
 	DIOF_FOR_MIGRATION	= 0x40,
+	/* For EC aggregation. */
+	DIOF_FOR_EC_AGG		= 0x80,
 };
 
 /**

--- a/src/include/daos_cont.h
+++ b/src/include/daos_cont.h
@@ -31,10 +31,10 @@ extern "C" {
  * DAOS_COO_FORCE skips the check to see if the pool meets the redundancy
  * factor/level requirements of the container.
  */
-#define DAOS_COO_RO	(1U << 0)
-#define DAOS_COO_RW	(1U << 1)
-#define DAOS_COO_NOSLIP	(1U << 2)
-#define DAOS_COO_FORCE	(1U << 3)
+#define DAOS_COO_RO		(1U << 0)
+#define DAOS_COO_RW		(1U << 1)
+#define DAOS_COO_NOSLIP		(1U << 2)
+#define DAOS_COO_FORCE		(1U << 3)
 
 #define DAOS_COO_NBITS	(4)
 #define DAOS_COO_MASK	((1U << DAOS_COO_NBITS) - 1)
@@ -289,6 +289,25 @@ daos_cont_get_acl(daos_handle_t container, daos_prop_t **acl_prop,
  */
 int
 daos_cont_set_prop(daos_handle_t coh, daos_prop_t *prop, daos_event_t *ev);
+
+
+/**
+ * Clear container status, to clear container's DAOS_PROP_CO_STATUS property
+ * from DAOS_PROP_CO_UNCLEAN status to DAOS_PROP_CO_HEALTHY (with same purpose
+ * with "daos cont set-prop --properties=status:healthy --pool= --cont= ".
+ *
+ * \param[in]	coh	Container handle
+ * \param[in]	ev	Completion event, it is optional and can be NULL.
+ *			The function will run in blocking mode if \a ev is NULL.
+ *
+ * \return		These values will be returned by \a ev::ev_error in
+ *			non-blocking mode:
+ *			0		Success
+ *			-DER_UNREACH	Network is unreachable
+ *			-DER_NO_HDL	Invalid container handle
+ */
+int
+daos_cont_status_clear(daos_handle_t coh, daos_event_t *ev);
 
 /**
  * Overwrites the container ACL with a new one.

--- a/src/include/daos_prop.h
+++ b/src/include/daos_prop.h
@@ -289,26 +289,35 @@ enum {
 	DAOS_PROP_CO_UNCLEAN,
 };
 
+/** clear the UNCLEAN status */
+#define DAOS_PROP_CO_CLEAR	(0x1)
 struct daos_co_status {
 	/* DAOS_PROP_CO_HEALTHY/DAOS_PROP_CO_UNCLEAN */
-	uint32_t	dcs_status;
+	uint16_t	dcs_status;
+	/* flags for DAOS internal usage, DAOS_PROP_CO_CLEAR */
+	uint16_t	dcs_flags;
 	/* pool map version when setting the dcs_status */
 	uint32_t	dcs_pm_ver;
 };
 
-#define DAOS_PROP_CO_STATUS_VAL(status, pm_ver)				\
-	((((uint64_t)(status)) << 32) | ((uint64_t)(pm_ver)))
+#define DAOS_PROP_CO_STATUS_VAL(status, flag, pm_ver)			\
+	((((uint64_t)(flag)) << 48)		|			\
+	 (((uint64_t)(status) & 0xFFFF) << 32)	|			\
+	 ((uint64_t)(pm_ver)))
+
 static inline uint64_t
 daos_prop_co_status_2_val(struct daos_co_status *co_status)
 {
 	return DAOS_PROP_CO_STATUS_VAL(co_status->dcs_status,
+				       co_status->dcs_flags,
 				       co_status->dcs_pm_ver);
 }
 
 static inline void
 daos_prop_val_2_co_status(uint64_t val, struct daos_co_status *co_status)
 {
-	co_status->dcs_status = (uint32_t)(val >> 32);
+	co_status->dcs_flags = (uint16_t)(val >> 48);
+	co_status->dcs_status = (uint16_t)((val >> 32) & 0xFFFF);
 	co_status->dcs_pm_ver = (uint32_t)(val & 0xFFFFFFFF);
 }
 

--- a/src/include/daos_srv/container.h
+++ b/src/include/daos_srv/container.h
@@ -41,7 +41,8 @@ int ds_cont_list(uuid_t pool_uuid, struct daos_pool_cont_info **conts,
 
 int ds_cont_tgt_close(uuid_t hdl_uuid);
 int ds_cont_tgt_open(uuid_t pool_uuid, uuid_t cont_hdl_uuid,
-		     uuid_t cont_uuid, uint64_t flags, uint64_t sec_capas);
+		     uuid_t cont_uuid, uint64_t flags, uint64_t sec_capas,
+		     uint32_t status_pm_ver);
 /*
  * Per-thread container (memory) object
  *
@@ -111,6 +112,10 @@ struct ds_cont_child {
 	d_list_t		 sc_dtx_cos_list;
 	/* The pool map version for the latest DTX resync on the container. */
 	uint32_t		 sc_dtx_resync_ver;
+	/* the pool map version of updating DAOS_PROP_CO_STATUS prop */
+	uint32_t		 sc_status_pm_ver;
+	/* flag of CONT_CAPA_READ_DATA/_WRITE_DATA disabled */
+	uint32_t		 sc_rw_disabled:1;
 };
 
 typedef uint64_t (*agg_param_get_eph_t)(struct ds_cont_child *cont);
@@ -142,7 +147,7 @@ struct ds_cont_hdl {
 	uint64_t		sch_flags;	/* user-supplied flags */
 	uint64_t		sch_sec_capas;	/* access control capas */
 	struct ds_cont_child	*sch_cont;
-	int			sch_ref;
+	int32_t			sch_ref;
 };
 
 struct ds_cont_hdl *ds_cont_hdl_lookup(const uuid_t uuid);
@@ -151,9 +156,6 @@ void ds_cont_hdl_get(struct ds_cont_hdl *hdl);
 
 int ds_cont_close_by_pool_hdls(uuid_t pool_uuid, uuid_t *pool_hdls,
 			       int n_pool_hdls, crt_context_t ctx);
-int ds_cont_local_open(uuid_t pool_uuid, uuid_t cont_hdl_uuid,
-		       uuid_t cont_uuid, uint64_t flags,
-		       uint64_t sec_capas, struct ds_cont_hdl **cont_hdl);
 int ds_cont_local_close(uuid_t cont_hdl_uuid);
 
 int ds_cont_child_start_all(struct ds_pool_child *pool_child);
@@ -161,6 +163,7 @@ void ds_cont_child_stop_all(struct ds_pool_child *pool_child);
 
 int ds_cont_child_lookup(uuid_t pool_uuid, uuid_t cont_uuid,
 			 struct ds_cont_child **ds_cont);
+int ds_cont_rf_check(uuid_t pool_uuid);
 
 /** initialize a csummer based on container properties. Will retrieve the
  * checksum related properties from IV
@@ -252,7 +255,6 @@ ds_csum_agg_recalc(void *args);
 int dsc_cont_open(daos_handle_t poh, uuid_t cont_uuid, uuid_t cont_hdl_uuid,
 		  unsigned int flags, daos_handle_t *coh);
 int dsc_cont_close(daos_handle_t poh, daos_handle_t coh);
-
 
 void ds_cont_tgt_ec_eph_query_ult(void *data);
 #endif /* ___DAOS_SRV_CONTAINER_H_ */

--- a/src/include/daos_srv/pool.h
+++ b/src/include/daos_srv/pool.h
@@ -255,10 +255,11 @@ int dsc_pool_close(daos_handle_t ph);
 static inline int
 ds_pool_rf_verify(struct ds_pool *pool, uint32_t last_ver, uint32_t rf)
 {
-	int	rc;
+	int	rc = 0;
 
 	ABT_rwlock_rdlock(pool->sp_lock);
-	rc = pool_map_rf_verify(pool->sp_map, last_ver, rf);
+	if (last_ver < pool_map_get_version(pool->sp_map))
+		rc = pool_map_rf_verify(pool->sp_map, last_ver, rf);
 	ABT_rwlock_unlock(pool->sp_lock);
 
 	return rc;

--- a/src/include/daos_srv/security.h
+++ b/src/include/daos_srv/security.h
@@ -234,6 +234,26 @@ bool
 ds_sec_cont_can_write_data(uint64_t cont_capas);
 
 /**
+ * Calculate the new capability after enable CONT_CAPA_WRITE_DATA.
+ *
+ * \param	cont_capas	Input capability.
+ *
+ * \return	Output capability
+ */
+uint64_t
+ds_sec_cont_capa_write_data_enable(uint64_t cont_capas);
+
+/**
+ * Calculate the new capability after disable CONT_CAPA_WRITE_DATA.
+ *
+ * \param	cont_capas	Input capability.
+ *
+ * \return	Output capability
+ */
+uint64_t
+ds_sec_cont_capa_write_data_disable(uint64_t cont_capas);
+
+/**
  * Determine if the container can be read based on the container security
  * capabilities.
  *

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -4179,6 +4179,8 @@ dc_obj_fetch_task(tse_task_t *task)
 		obj_auxi->flags |= ORF_FOR_MIGRATION;
 		obj_auxi->no_retry = 1;
 	}
+	if (args->extra_flags & DIOF_FOR_EC_AGG)
+		obj_auxi->flags |= ORF_FOR_EC_AGG;
 
 	if (args->extra_flags & DIOF_CHECK_EXISTENCE) {
 		obj_auxi->flags |= ORF_CHECK_EXISTENCE;

--- a/src/object/cli_shard.c
+++ b/src/object/cli_shard.c
@@ -784,7 +784,7 @@ dc_rw_cb(tse_task_t *task, void *arg)
 		 * rec2big errors which can be expected.
 		 */
 		if (rc == -DER_REC2BIG || rc == -DER_NONEXIST ||
-		    rc == -DER_EXIST)
+		    rc == -DER_EXIST || rc == -DER_RF)
 			D_DEBUG(DB_IO, "rpc %p opc %d to rank %d tag %d"
 				" failed: "DF_RC"\n", rw_args->rpc, opc,
 				rw_args->rpc->cr_ep.ep_rank,

--- a/src/object/obj_rpc.h
+++ b/src/object/obj_rpc.h
@@ -160,6 +160,8 @@ enum obj_rpc_flags {
 	ORF_FOR_MIGRATION	= (1 << 14),
 	/* Force DTX refresh if hit non-committed DTX on non-leader. */
 	ORF_DTX_REFRESH		= (1 << 15),
+	/* for EC aggregate (to bypass read perm check related with RF) */
+	ORF_FOR_EC_AGG		= (1 << 16),
 };
 
 /* common for update/fetch */
@@ -578,9 +580,14 @@ obj_is_modification_opc(uint32_t opc)
 		opc == DAOS_OBJ_RPC_PUNCH_DKEYS ||
 		opc == DAOS_OBJ_RPC_TGT_PUNCH_DKEYS ||
 		opc == DAOS_OBJ_RPC_PUNCH_AKEYS ||
-		opc == DAOS_OBJ_RPC_TGT_PUNCH_AKEYS ||
-		opc == DAOS_OBJ_RPC_EC_AGGREGATE ||
-		opc == DAOS_OBJ_RPC_EC_REPLICATE;
+		opc == DAOS_OBJ_RPC_TGT_PUNCH_AKEYS;
+}
+
+static inline bool
+obj_is_ec_agg_opc(uint32_t opc)
+{
+	return opc == DAOS_OBJ_RPC_EC_AGGREGATE ||
+	       opc == DAOS_OBJ_RPC_EC_REPLICATE;
 }
 
 static inline bool

--- a/src/object/srv_ec_aggregate.c
+++ b/src/object/srv_ec_aggregate.c
@@ -605,7 +605,7 @@ agg_fetch_odata_cells(struct ec_agg_entry *entry, uint8_t *bit_map,
 	epoch = is_recalc ? stripe->as_hi_epoch :
 		entry->ae_par_extent.ape_epoch;
 	rc = dsc_obj_fetch(entry->ae_obj_hdl, epoch, &entry->ae_dkey, 1, &iod,
-			   &sgl, NULL, 0, NULL, NULL);
+			   &sgl, NULL, DIOF_FOR_EC_AGG, NULL, NULL);
 	if (rc)
 		D_ERROR("dsc_obj_fetch failed: "DF_RC"\n", DP_RC(rc));
 
@@ -1032,7 +1032,8 @@ agg_fetch_remote_parity(struct ec_agg_entry *entry)
 		rc = dsc_obj_fetch(entry->ae_obj_hdl,
 				   entry->ae_par_extent.ape_epoch,
 				   &entry->ae_dkey, 1, &iod, &sgl, NULL,
-				   DIOF_TO_SPEC_SHARD, &peer_shard, NULL);
+				   DIOF_TO_SPEC_SHARD | DIOF_FOR_EC_AGG,
+				   &peer_shard, NULL);
 		D_DEBUG(DB_TRACE, DF_UOID" fetch parity from peer shard %d, "
 			DF_RC".\n", DP_UOID(entry->ae_oid), peer_shard,
 			DP_RC(rc));
@@ -1632,7 +1633,7 @@ agg_process_holes_ult(void *arg)
 		rc = dsc_obj_fetch(entry->ae_obj_hdl,
 				   entry->ae_cur_stripe.as_hi_epoch,
 				   &entry->ae_dkey, 1, &iod, &entry->ae_sgl,
-				   NULL, 0, NULL, NULL);
+				   NULL, DIOF_FOR_EC_AGG, NULL, NULL);
 		if (rc) {
 			D_ERROR("dsc_obj_fetch failed: "DF_RC"\n", DP_RC(rc));
 			goto out;

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -1640,7 +1640,7 @@ again:
 }
 
 static int
-obj_capa_check(struct ds_cont_hdl *coh, bool is_write)
+obj_capa_check(struct ds_cont_hdl *coh, bool is_write, bool is_agg_migrate)
 {
 	if (!is_write && !ds_sec_cont_can_read_data(coh->sch_sec_capas)) {
 		D_ERROR("cont hdl "DF_UUID" sec_capas "DF_U64", "
@@ -1655,6 +1655,9 @@ obj_capa_check(struct ds_cont_hdl *coh, bool is_write)
 			DP_UUID(coh->sch_uuid), coh->sch_sec_capas);
 		return -DER_NO_PERM;
 	}
+
+	if (!is_agg_migrate && coh->sch_cont && coh->sch_cont->sc_rw_disabled)
+		return -DER_RF;
 
 	return 0;
 }
@@ -1889,8 +1892,8 @@ obj_ioc_end(struct obj_io_context *ioc, int err)
 
 /* Various check before access VOS */
 static int
-obj_ioc_begin(uint32_t rpc_map_ver, uuid_t pool_uuid,
-	      uuid_t coh_uuid, uuid_t cont_uuid, uint32_t opc,
+obj_ioc_begin(uint32_t rpc_map_ver, uuid_t pool_uuid, uuid_t coh_uuid,
+	      uuid_t cont_uuid, uint32_t opc, uint32_t flags,
 	      struct obj_io_context *ioc)
 {
 	int		rc;
@@ -1900,7 +1903,10 @@ obj_ioc_begin(uint32_t rpc_map_ver, uuid_t pool_uuid,
 	if (rc != 0)
 		return rc;
 
-	rc = obj_capa_check(ioc->ioc_coh, obj_is_modification_opc(opc));
+	rc = obj_capa_check(ioc->ioc_coh, obj_is_modification_opc(opc),
+			    obj_is_ec_agg_opc(opc) ||
+			    (flags & ORF_FOR_MIGRATION) ||
+			    (flags & ORF_FOR_EC_AGG));
 	if (rc != 0)
 		obj_ioc_end(ioc, rc);
 
@@ -1938,7 +1944,7 @@ ds_obj_ec_rep_handler(crt_rpc_t *rpc)
 	D_ASSERT(daos_oclass_is_ec(oer->er_oid.id_pub, &oca));
 
 	rc = obj_ioc_begin(oer->er_map_ver, oer->er_pool_uuid, oer->er_coh_uuid,
-			   oer->er_cont_uuid, opc_get(rpc->cr_opc), &ioc);
+			   oer->er_cont_uuid, opc_get(rpc->cr_opc), 0, &ioc);
 
 	if (rc)	{
 		D_ERROR("ioc_begin failed: "DF_RC"\n", DP_RC(rc));
@@ -2013,7 +2019,7 @@ ds_obj_ec_agg_handler(crt_rpc_t *rpc)
 	D_ASSERT(daos_oclass_is_ec(oea->ea_oid.id_pub, &oca));
 
 	rc = obj_ioc_begin(oea->ea_map_ver, oea->ea_pool_uuid, oea->ea_coh_uuid,
-			   oea->ea_cont_uuid, opc_get(rpc->cr_opc), &ioc);
+			   oea->ea_cont_uuid, opc_get(rpc->cr_opc), 0, &ioc);
 
 	if (rc)	{
 		D_ERROR("ioc_begin failed: "DF_RC"\n", DP_RC(rc));
@@ -2123,7 +2129,7 @@ ds_obj_tgt_update_handler(crt_rpc_t *rpc)
 
 	rc = obj_ioc_begin(orw->orw_map_ver, orw->orw_pool_uuid,
 			   orw->orw_co_hdl, orw->orw_co_uuid,
-			   opc_get(rpc->cr_opc), &ioc);
+			   opc_get(rpc->cr_opc), orw->orw_flags, &ioc);
 	if (rc)
 		goto out;
 
@@ -2367,7 +2373,7 @@ ds_obj_rw_handler(crt_rpc_t *rpc)
 
 	rc = obj_ioc_begin(orw->orw_map_ver, orw->orw_pool_uuid,
 			   orw->orw_co_hdl, orw->orw_co_uuid,
-			   opc_get(rpc->cr_opc), &ioc);
+			   opc_get(rpc->cr_opc), orw->orw_flags, &ioc);
 	if (rc != 0) {
 		D_ASSERTF(rc < 0, "unexpected error# "DF_RC"\n", DP_RC(rc));
 		goto out;
@@ -2944,7 +2950,8 @@ ds_obj_enum_handler(crt_rpc_t *rpc)
 	/* prepare buffer for enumerate */
 
 	rc = obj_ioc_begin(oei->oei_map_ver, oei->oei_pool_uuid,
-			   oei->oei_co_hdl, oei->oei_co_uuid, opc, &ioc);
+			   oei->oei_co_hdl, oei->oei_co_uuid, opc,
+			   oei->oei_flags, &ioc);
 	if (rc)
 		D_GOTO(out, rc);
 
@@ -3132,7 +3139,7 @@ ds_obj_tgt_punch_handler(crt_rpc_t *rpc)
 	D_ASSERT(opi != NULL);
 	rc = obj_ioc_begin(opi->opi_map_ver, opi->opi_pool_uuid,
 			   opi->opi_co_hdl, opi->opi_co_uuid,
-			   opc_get(rpc->cr_opc), &ioc);
+			   opc_get(rpc->cr_opc), opi->opi_flags, &ioc);
 	if (rc)
 		goto out;
 
@@ -3310,7 +3317,7 @@ ds_obj_punch_handler(crt_rpc_t *rpc)
 	D_ASSERT(opi != NULL);
 	rc = obj_ioc_begin(opi->opi_map_ver, opi->opi_pool_uuid,
 			   opi->opi_co_hdl, opi->opi_co_uuid,
-			   opc_get(rpc->cr_opc), &ioc);
+			   opc_get(rpc->cr_opc), opi->opi_flags, &ioc);
 	if (rc)
 		goto out;
 
@@ -3505,7 +3512,7 @@ ds_obj_query_key_handler(crt_rpc_t *rpc)
 
 	rc = obj_ioc_begin(okqi->okqi_map_ver, okqi->okqi_pool_uuid,
 			   okqi->okqi_co_hdl, okqi->okqi_co_uuid,
-			   opc_get(rpc->cr_opc), &ioc);
+			   opc_get(rpc->cr_opc), okqi->okqi_flags, &ioc);
 	if (rc)
 		D_GOTO(out, rc);
 
@@ -3611,7 +3618,7 @@ ds_obj_sync_handler(crt_rpc_t *rpc)
 
 	rc = obj_ioc_begin(osi->osi_map_ver, osi->osi_pool_uuid,
 			   osi->osi_co_hdl, osi->osi_co_uuid,
-			   opc_get(rpc->cr_opc), &ioc);
+			   opc_get(rpc->cr_opc), 0, &ioc);
 	if (rc != 0)
 		D_GOTO(out, rc);
 
@@ -4176,7 +4183,7 @@ ds_obj_dtx_follower(crt_rpc_t *rpc, struct obj_io_context *ioc)
 	 * So here, only need to check the write capa.
 	 */
 	if (dcde->dcde_write_cnt != 0) {
-		rc = obj_capa_check(ioc->ioc_coh, true);
+		rc = obj_capa_check(ioc->ioc_coh, true, false);
 		if (rc != 0)
 			goto out;
 	}
@@ -4249,7 +4256,7 @@ obj_obj_dtx_leader(struct dtx_leader_handle *dlh, void *arg, int idx,
 			 * the CPD RPC. Here, only need to check the write capa.
 			 */
 			if (dcde->dcde_write_cnt != 0) {
-				rc = obj_capa_check(ioc->ioc_coh, true);
+				rc = obj_capa_check(ioc->ioc_coh, true, false);
 				if (rc != 0) {
 					comp_cb(dlh, idx, rc);
 

--- a/src/object/srv_obj_migrate.c
+++ b/src/object/srv_obj_migrate.c
@@ -568,7 +568,7 @@ mrone_obj_fetch(struct migrate_one *mrone, daos_handle_t oh, d_sg_list_t *sgls,
 
 		rc = dsc_obj_fetch(oh, mrone->mo_epoch, &mrone->mo_dkey,
 				   mrone->mo_iod_num, mrone->mo_iods, sgls,
-				   NULL, DIOF_TO_LEADER, NULL, csum_iov_fetch);
+				   NULL, flags, NULL, csum_iov_fetch);
 	}
 
 	return rc;

--- a/src/pool/srv_iv.c
+++ b/src/pool/srv_iv.c
@@ -574,7 +574,6 @@ pool_iv_map_ent_update(d_sg_list_t *dst_sgl, struct pool_iv_entry *src_iv)
 	}
 
 	pb_nr = src_iv->piv_map.piv_pool_buf.pb_nr;
-	D_ASSERT(pb_nr > 0);
 	src_pbuf_size = pool_buf_size(pb_nr);
 	dst_pbuf_size = dst_sgl->sg_iovs[0].iov_buf_len -
 			sizeof(struct pool_iv_map) + sizeof(struct pool_buf);
@@ -762,7 +761,7 @@ ds_pool_iv_refresh_hdl(struct ds_pool *pool, struct pool_iv_hdl *pih)
 	}
 
 	rc = ds_cont_tgt_open(pool->sp_uuid, pih->pih_cont_hdl, NULL, 0,
-			      ds_sec_get_rebuild_cont_capabilities());
+			      ds_sec_get_rebuild_cont_capabilities(), 0);
 	if (rc == 0) {
 		uuid_copy(pool->sp_srv_cont_hdl, pih->pih_cont_hdl);
 		uuid_copy(pool->sp_srv_pool_hdl, pih->pih_pool_hdl);
@@ -1012,19 +1011,24 @@ ds_pool_iv_map_update(struct ds_pool *pool, struct pool_buf *buf,
 {
 	struct pool_iv_entry	*iv_entry;
 	uint32_t		 iv_entry_size;
+	uint32_t		 nr;
 	int			 rc;
 
 	D_DEBUG(DB_MD, DF_UUID": map_ver=%u\n", DP_UUID(pool->sp_uuid),
 		map_ver);
 
-	iv_entry_size = pool_iv_map_ent_size(buf->pb_nr);
+	nr = buf != NULL ? buf->pb_nr : 0;
+	iv_entry_size = pool_iv_map_ent_size(nr);
 	D_ALLOC(iv_entry, iv_entry_size);
 	if (iv_entry == NULL)
 		return -DER_NOMEM;
 
 	crt_group_rank(pool->sp_group, &iv_entry->piv_map.piv_master_rank);
-	iv_entry->piv_map.piv_pool_map_ver = pool->sp_map_version;
-	memcpy(&iv_entry->piv_map.piv_pool_buf, buf, pool_buf_size(buf->pb_nr));
+	iv_entry->piv_map.piv_pool_map_ver =
+		buf == NULL ? 0 : pool->sp_map_version;
+	if (buf != NULL)
+		memcpy(&iv_entry->piv_map.piv_pool_buf, buf,
+		       pool_buf_size(buf->pb_nr));
 
 	/* FIXME: Let's update the pool map synchronously for the moment,
 	 * since there is no easy way to free the iv_entry buffer. Needs

--- a/src/pool/srv_target.c
+++ b/src/pool/srv_target.c
@@ -1265,6 +1265,8 @@ out:
 	ABT_rwlock_unlock(pool->sp_lock);
 	if (map != NULL)
 		pool_map_decref(map);
+	if (rc == 0)
+		rc = ds_cont_rf_check(pool->sp_uuid);
 	return rc;
 }
 

--- a/src/security/srv_acl.c
+++ b/src/security/srv_acl.c
@@ -771,6 +771,18 @@ ds_sec_cont_can_write_data(uint64_t cont_capas)
 	return (cont_capas & CONT_CAPA_WRITE_DATA) != 0;
 }
 
+uint64_t
+ds_sec_cont_capa_write_data_enable(uint64_t cont_capas)
+{
+	return cont_capas | ((uint64_t)CONT_CAPA_WRITE_DATA);
+}
+
+uint64_t
+ds_sec_cont_capa_write_data_disable(uint64_t cont_capas)
+{
+	return cont_capas & (~(uint64_t)CONT_CAPA_WRITE_DATA);
+}
+
 bool
 ds_sec_cont_can_read_data(uint64_t cont_capas)
 {

--- a/src/tests/ftest/pool/rebuild_tests.py
+++ b/src/tests/ftest/pool/rebuild_tests.py
@@ -59,6 +59,7 @@ class RebuildTests(TestWithServers):
         rs_obj_nr = []
         rs_rec_nr = []
         for index in range(pool_quantity):
+            self.container[index].properties.value = "rf:2"
             self.container[index].create()
             self.container[index].write_objects(rank, obj_class)
 

--- a/src/tests/suite/daos_checksum.c
+++ b/src/tests/suite/daos_checksum.c
@@ -1835,6 +1835,8 @@ rebuild_test(void **state, int chunksize, int data_len_bytes, int iod_type)
 	/** wait for rebuild */
 	test_rebuild_wait(&arg, 1);
 
+	daos_cont_status_clear(arg->coh, NULL);
+
 	rc = daos_obj_layout_get(ctx.coh, ctx.oid, &layout2);
 	assert_success(rc);
 
@@ -1851,6 +1853,7 @@ rebuild_test(void **state, int chunksize, int data_len_bytes, int iod_type)
 
 	daos_fail_loc_set(DAOS_OBJ_SPECIAL_SHARD | DAOS_FAIL_ALWAYS);
 	daos_fail_num_set(rank_to_fetch);
+	daos_cont_status_clear(ctx.coh, NULL);
 	rc = daos_obj_fetch(ctx.oh, DAOS_TX_NONE, 0, &ctx.dkey,
 			    1, &ctx.fetch_iod, &ctx.fetch_sgl, NULL, NULL);
 	assert_success(rc);

--- a/src/tests/suite/daos_container.c
+++ b/src/tests/suite/daos_container.c
@@ -2084,6 +2084,7 @@ co_open_fail_destroy(void **state)
 static void
 co_rf_simple(void **state)
 {
+#define STACK_BUF_LEN	(128)
 	test_arg_t		*arg0 = *state;
 	test_arg_t		*arg = NULL;
 	daos_obj_id_t		 oid;
@@ -2093,6 +2094,14 @@ co_rf_simple(void **state)
 	struct daos_prop_entry	*entry;
 	struct daos_co_status	 stat = { 0 };
 	daos_cont_info_t	 info = { 0 };
+	daos_obj_id_t		 io_oid;
+	daos_handle_t		 io_oh;
+	d_iov_t			 dkey;
+	char			 stack_buf[STACK_BUF_LEN];
+	d_sg_list_t		 sgl;
+	d_iov_t			 sg_iov;
+	daos_iod_t		 iod;
+	daos_recx_t		 recx;
 	int			 rc;
 
 	/* needs 3 alive nodes after excluding 3 */
@@ -2171,6 +2180,29 @@ co_rf_simple(void **state)
 	rc = daos_cont_close(coh, NULL);
 	assert_rc_equal(rc, 0);
 
+	/* IO testing */
+	io_oid = daos_test_oid_gen(arg->coh, OC_RP_4G1, 0, 0, arg->myrank);
+	rc = daos_obj_open(arg->coh, io_oid, 0, &io_oh, NULL);
+	assert_rc_equal(rc, 0);
+
+	d_iov_set(&dkey, "dkey", strlen("dkey"));
+	dts_buf_render(stack_buf, STACK_BUF_LEN);
+	d_iov_set(&sg_iov, stack_buf, STACK_BUF_LEN);
+	sgl.sg_nr	= 1;
+	sgl.sg_nr_out	= 1;
+	sgl.sg_iovs	= &sg_iov;
+	d_iov_set(&iod.iod_name, "akey", strlen("akey"));
+	recx.rx_idx = 0;
+	recx.rx_nr  = STACK_BUF_LEN;
+	iod.iod_size	= 1;
+	iod.iod_nr	= 1;
+	iod.iod_recxs	= &recx;
+	iod.iod_type	= DAOS_IOD_ARRAY;
+	print_message("obj update should success before RF broken\n");
+	rc = daos_obj_update(io_oh, DAOS_TX_NONE, 0, &dkey, 1, &iod, &sgl,
+			     NULL);
+	assert_rc_equal(rc, 0);
+
 	if (arg->myrank == 0)
 		daos_exclude_server(arg->pool.pool_uuid, arg->group,
 				    arg->dmg_config, 3);
@@ -2182,6 +2214,14 @@ co_rf_simple(void **state)
 	assert_int_equal(stat.dcs_status, DAOS_PROP_CO_UNCLEAN);
 	rc = daos_cont_open(arg->pool.poh, arg->co_uuid, arg->cont_open_flags,
 			    &coh, NULL, NULL);
+	assert_rc_equal(rc, -DER_RF);
+	print_message("obj update should fail after RF broken\n");
+	rc = daos_obj_update(io_oh, DAOS_TX_NONE, 0, &dkey, 1, &iod, &sgl,
+			     NULL);
+	assert_rc_equal(rc, -DER_RF);
+	print_message("obj fetch should fail after RF broken\n");
+	rc = daos_obj_fetch(io_oh, DAOS_TX_NONE, 0, &dkey, 1, &iod, &sgl, NULL,
+			    NULL);
 	assert_rc_equal(rc, -DER_RF);
 
 	if (arg->myrank == 0) {
@@ -2197,11 +2237,13 @@ co_rf_simple(void **state)
 	}
 	MPI_Barrier(MPI_COMM_WORLD);
 
+	print_message("obj update should success after re-integrate\n");
+	rc = daos_obj_update(io_oh, DAOS_TX_NONE, 0, &dkey, 1, &iod, &sgl,
+			     NULL);
+	assert_rc_equal(rc, 0);
+
 	/* clear the UNCLEAN status */
-	prop->dpp_entries[0].dpe_type = DAOS_PROP_CO_STATUS;
-	prop->dpp_entries[0].dpe_val = DAOS_PROP_CO_STATUS_VAL(
-						DAOS_PROP_CO_HEALTHY, 0);
-	rc = daos_cont_set_prop(arg->coh, prop, NULL);
+	rc = daos_cont_status_clear(arg->coh, NULL);
 	assert_rc_equal(rc, 0);
 
 	rc = daos_cont_query(arg->coh, NULL, prop, NULL);
@@ -2225,6 +2267,9 @@ co_rf_simple(void **state)
 	rc = daos_cont_close(coh_g2l, NULL);
 	assert_int_equal(rc, 0);
 	free(ghdl.iov_buf);
+
+	rc = daos_obj_close(io_oh, NULL);
+	assert_rc_equal(rc, 0);
 
 	rc = daos_cont_close(coh, NULL);
 	assert_rc_equal(rc, 0);

--- a/src/tests/suite/daos_degrade_ec.c
+++ b/src/tests/suite/daos_degrade_ec.c
@@ -84,6 +84,10 @@ static void
 degrade_ec_verify(test_arg_t *arg, daos_obj_id_t oid, int write_type)
 {
 	struct ioreq	req;
+	int		rc;
+
+	rc = daos_cont_status_clear(arg->coh, NULL);
+	assert_rc_equal(rc, 0);
 
 	ioreq_init(&req, arg->coh, oid, DAOS_IOD_ARRAY, arg);
 

--- a/src/tests/suite/daos_rebuild_common.c
+++ b/src/tests/suite/daos_rebuild_common.c
@@ -156,9 +156,12 @@ rebuild_targets(test_arg_t **args, int args_cnt, d_rank_t *ranks,
 		test_rebuild_wait(args, args_cnt);
 
 	MPI_Barrier(MPI_COMM_WORLD);
-	for (i = 0; i < args_cnt; i++)
+	for (i = 0; i < args_cnt; i++) {
+		daos_cont_status_clear(args[i]->coh, NULL);
+
 		if (args[i]->rebuild_post_cb)
 			args[i]->rebuild_post_cb(args[i]);
+	}
 }
 
 
@@ -559,6 +562,9 @@ rebuild_io_verify(test_arg_t *arg, daos_obj_id_t *oids, int oids_nr)
 	int	rc;
 	int	i;
 
+	rc = daos_cont_status_clear(arg->coh, NULL);
+	assert_rc_equal(rc, 0);
+
 	print_message("rebuild io verify obj %d\n", oids_nr);
 	for (i = 0; i < oids_nr; i++) {
 		/* XXX: skip punch object. */
@@ -825,6 +831,7 @@ dfs_ec_rebuild_io(void **state, int *shards, int shards_nr)
 		idx++;
 	}
 	rebuild_pools_ranks(&arg, 1, ranks, idx, false);
+	daos_cont_status_clear(co_hdl, NULL);
 
 	/* Verify full stripe */
 	d_iov_set(&iov, buf, buf_size);

--- a/src/tests/suite/daos_rebuild_ec.c
+++ b/src/tests/suite/daos_rebuild_ec.c
@@ -497,6 +497,7 @@ dfs_ec_seq_fail(void **state, int *shards, int shards_nr)
 		rebuild_pools_ranks(&arg, 1, &ranks[idx], 1, false);
 		idx++;
 
+		daos_cont_status_clear(co_hdl, NULL);
 		/* Verify full stripe */
 		d_iov_set(&iov, buf, buf_size);
 		memset(buf, 0, buf_size);

--- a/src/tests/suite/daos_test_common.c
+++ b/src/tests/suite/daos_test_common.c
@@ -937,7 +937,9 @@ daos_kill_server(test_arg_t *arg, const uuid_t pool_uuid,
 
 	rc = system(dmg_cmd);
 	print_message(" %s rc %#x\n", dmg_cmd, rc);
-	assert_int_equal(rc, 0);
+	assert_rc_equal(rc, 0);
+
+	daos_cont_status_clear(arg->coh, NULL);
 }
 
 struct daos_acl *

--- a/src/utils/daos.c
+++ b/src/utils/daos.c
@@ -464,6 +464,7 @@ daos_parse_property(char *name, char *value, daos_prop_t *props)
 		if (!strcmp(value, "healthy")) {
 			entry->dpe_val =
 				DAOS_PROP_CO_STATUS_VAL(DAOS_PROP_CO_HEALTHY,
+							DAOS_PROP_CO_CLEAR,
 							0);
 		} else {
 			fprintf(stderr, "status prop value can only be "


### PR DESCRIPTION
For active opened container handle, DAOS will internally -
1. turn off read/write permission when cont_rf broken
2. turn on  read/write permission when cont_rf recovered by -
   reintegrate the failed devices, or by clearing the UNCLEAN container
   status - "daos cont set-prop --properties=status:healthy ..."
Add test case to co_rf_simple().

Now DAOS_PROP_CO_STATUS only used for storing the pm_ver for
cont_create, and when user clear the UNCLEAN status. And don't
set UNCLEAN status to RDB to avoid ambiguity when checking
with active container handle.

Test-tag: pr daily_regression

Signed-off-by: Xuezhao Liu <xuezhao.liu@intel.com>