### PR TITLE
DAOS-623 common: Fix Fedora 34 compiler warnings

### DIFF
--- a/src/client/dfuse/dfuse_core.c
+++ b/src/client/dfuse/dfuse_core.c
@@ -898,15 +898,15 @@ dfuse_start(struct dfuse_projection_info *fs_handle,
 	if (!args.argv)
 		D_GOTO(err, rc = -DER_NOMEM);
 
-	args.argv[0] = strndup("", 1);
+	args.argv[0] = strdup("");
 	if (!args.argv[0])
 		D_GOTO(err, rc = -DER_NOMEM);
 
-	args.argv[1] = strndup("-ofsname=dfuse", 32);
+	args.argv[1] = strdup("-ofsname=dfuse");
 	if (!args.argv[1])
 		D_GOTO(err, rc = -DER_NOMEM);
 
-	args.argv[2] = strndup("-osubtype=daos", 32);
+	args.argv[2] = strdup("-osubtype=daos");
 	if (!args.argv[2])
 		D_GOTO(err, rc = -DER_NOMEM);
 
@@ -914,7 +914,7 @@ dfuse_start(struct dfuse_projection_info *fs_handle,
 	if (rc < 0 || !args.argv[3])
 		D_GOTO(err, rc = -DER_NOMEM);
 
-	args.argv[4] = strndup("-odefault_permissions", 32);
+	args.argv[4] = strdup("-odefault_permissions");
 	if (!args.argv[4])
 		D_GOTO(err, rc = -DER_NOMEM);
 

--- a/src/include/gurt/common.h
+++ b/src/include/gurt/common.h
@@ -125,7 +125,6 @@ char *d_realpath(const char *path, char *resolved_path);
 			      strnlen(s, n) + 1, 0, #ptr, 0);		\
 	} while (0)
 
-
 #define D_ASPRINTF(ptr, ...)						\
 	do {								\
 		int _rc;						\

--- a/src/include/gurt/common.h
+++ b/src/include/gurt/common.h
@@ -122,8 +122,9 @@ char *d_realpath(const char *path, char *resolved_path);
 	do {								\
 		(ptr) = d_strndup(s, n);				\
 		D_CHECK_ALLOC(strndup, true, ptr, #ptr,			\
-			      strnlen(s, n + 1) + 1, 0, #ptr, 0);	\
+			      strnlen(s, n) + 1, 0, #ptr, 0);		\
 	} while (0)
+
 
 #define D_ASPRINTF(ptr, ...)						\
 	do {								\


### PR DESCRIPTION
Some new warnings due to strn routines having bounds larger than
the passed buffer

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>