### PR TITLE
DAOS-6863 bio: Remove hardcoded 1GB DMA buffer upper limit

### DIFF
--- a/src/bio/bio_xstream.c
+++ b/src/bio/bio_xstream.c
@@ -342,19 +342,6 @@ bio_nvme_init(const char *nvme_conf, int shm_id, int mem_size,
 	int		rc, fd;
 	uint64_t	size_mb = DAOS_DMA_CHUNK_MB;
 
-	D_ASSERT(tgt_nr > 0);
-	D_ASSERT(mem_size > 0);
-	/*
-	 * Hugepages are not enough to sustain average I/O workload
-	 * (~1GB per xstream).
-	 */
-	if ((mem_size / tgt_nr) < DAOS_DMA_MIN_UB_BUF_MB) {
-		D_ERROR("Per-xstream DMA buffer upper bound limit < 1GB!\n");
-		D_DEBUG(DB_MGMT, "mem_size:%dMB, DMA upper bound:%dMB\n",
-			mem_size, (mem_size / tgt_nr));
-		return -DER_INVAL;
-	}
-
 	nvme_glb.bd_xstream_cnt = 0;
 	nvme_glb.bd_init_thread = NULL;
 	D_INIT_LIST_HEAD(&nvme_glb.bd_bdevs);
@@ -375,6 +362,19 @@ bio_nvme_init(const char *nvme_conf, int shm_id, int mem_size,
 		D_INFO("NVMe config isn't specified, skip NVMe setup.\n");
 		nvme_glb.bd_nvme_conf = NULL;
 		return 0;
+	}
+
+	D_ASSERT(tgt_nr > 0);
+	D_ASSERT(mem_size > 0);
+	/*
+	 * Hugepages are not enough to sustain average I/O workload
+	 * (~1GB per xstream).
+	 */
+	if ((mem_size / tgt_nr) < DAOS_DMA_MIN_UB_BUF_MB) {
+		D_ERROR("Per-xstream DMA buffer upper bound limit < 1GB!\n");
+		D_DEBUG(DB_MGMT, "mem_size:%dMB, DMA upper bound:%dMB\n",
+			mem_size, (mem_size / tgt_nr));
+		return -DER_INVAL;
 	}
 
 	fd = open(nvme_conf, O_RDONLY, 0600);

--- a/src/bio/bio_xstream.c
+++ b/src/bio/bio_xstream.c
@@ -300,7 +300,7 @@ bio_spdk_env_init(void)
 
 	spdk_env_opts_init(&opts);
 	opts.name = "daos";
-	opts.mem_size = nvme_glb.bd_mem_size;
+	//opts.mem_size = nvme_glb.bd_mem_size;
 
 	rc = populate_whitelist(&opts);
 	if (rc != 0)

--- a/src/bio/bio_xstream.c
+++ b/src/bio/bio_xstream.c
@@ -30,7 +30,7 @@
 /* DMA buffer parameters */
 #define DAOS_DMA_CHUNK_MB	8	/* 8MB DMA chunks */
 #define DAOS_DMA_CHUNK_CNT_INIT	32	/* Per-xstream init chunks */
-#define DAOS_DMA_MIN_UB_BUF_MB	1024	/* 1GB min upperbound DMA buffer */
+#define DAOS_DMA_MIN_UB_BUF_MB	1024	/* 1GB min upper bound DMA buffer */
 #define DAOS_NVME_MAX_CTRLRS	1024	/* Max read from nvme_conf */
 
 /* Max inflight blob IOs per io channel */
@@ -349,7 +349,7 @@ bio_nvme_init(const char *nvme_conf, int shm_id, int mem_size,
 	 * (~1GB per xstream).
 	 */
 	if ((mem_size / tgt_nr) < DAOS_DMA_MIN_UB_BUF_MB) {
-		D_ERROR("Per-xstream DMA buffer upperbound limit < 1GB!\n");
+		D_ERROR("Per-xstream DMA buffer upper bound limit < 1GB!\n");
 		D_DEBUG(DB_MGMT, "mem_size:%dMB, DMA upper bound:%dMB\n",
 			mem_size, (mem_size / tgt_nr));
 		return -DER_INVAL;

--- a/src/bio/bio_xstream.c
+++ b/src/bio/bio_xstream.c
@@ -350,7 +350,7 @@ bio_nvme_init(const char *nvme_conf, int shm_id, int mem_size,
 	 */
 	if ((mem_size / tgt_nr) < DAOS_DMA_MIN_UB_BUF_MB) {
 		D_ERROR("Per-xstream DMA buffer upperbound limit < 1GB!\n");
-		D_DEBUG(DB_MGMT, "mem_size:%d, DMA upper bound:%dMB\n",
+		D_DEBUG(DB_MGMT, "mem_size:%dMB, DMA upper bound:%dMB\n",
 			mem_size, (mem_size / tgt_nr));
 		return -DER_INVAL;
 	}

--- a/src/control/lib/spdk/spdk.go
+++ b/src/control/lib/spdk/spdk.go
@@ -49,7 +49,6 @@ func Rc2err(label string, rc C.int) error {
 // EnvOptions describe parameters to be used when initializing a processes
 // SPDK environment.
 type EnvOptions struct {
-	MemSize        int      // size in MiB to be allocated to SPDK proc
 	PciIncludeList []string // restrict SPDK device access
 	DisableVMD     bool     // flag if VMD devices should not be included
 }
@@ -58,10 +57,6 @@ func (o *EnvOptions) toC(log logging.Logger) (*C.struct_spdk_env_opts, func(), e
 	opts := new(C.struct_spdk_env_opts)
 
 	C.spdk_env_opts_init(opts)
-
-	if o.MemSize > 0 {
-		opts.mem_size = C.int(o.MemSize)
-	}
 
 	// quiet DPDK EAL logging by setting log level to ERROR
 	opts.env_context = unsafe.Pointer(C.CString("--log-level=lib.eal:4"))

--- a/src/control/server/config/server.go
+++ b/src/control/server/config/server.go
@@ -61,7 +61,6 @@ type Server struct {
 	DisableVFIO         bool             `yaml:"disable_vfio"`
 	DisableVMD          bool             `yaml:"disable_vmd"`
 	NrHugepages         int              `yaml:"nr_hugepages"`
-	SetHugepages        bool             `yaml:"set_hugepages"`
 	ControlLogMask      ControlLogLevel  `yaml:"control_log_mask"`
 	ControlLogFile      string           `yaml:"control_log_file"`
 	ControlLogJSON      bool             `yaml:"control_log_json,omitempty"`

--- a/src/control/server/engine/config.go
+++ b/src/control/server/engine/config.go
@@ -172,6 +172,7 @@ type Config struct {
 	EnvVars           []string      `yaml:"env_vars,omitempty"`
 	EnvPassThrough    []string      `yaml:"env_pass_through,omitempty"`
 	Index             uint32        `yaml:"-" cmdLongFlag:"--instance_idx" cmdShortFlag:"-I"`
+	MemSize		  int		`yaml:"-" cmdLongFlag:"--mem_size" cmdShortFlag:"-r,nonzero"`
 }
 
 // NewConfig returns an I/O Engine config.

--- a/src/control/server/engine/config.go
+++ b/src/control/server/engine/config.go
@@ -172,7 +172,7 @@ type Config struct {
 	EnvVars           []string      `yaml:"env_vars,omitempty"`
 	EnvPassThrough    []string      `yaml:"env_pass_through,omitempty"`
 	Index             uint32        `yaml:"-" cmdLongFlag:"--instance_idx" cmdShortFlag:"-I"`
-	MemSize		  int		`yaml:"-" cmdLongFlag:"--mem_size" cmdShortFlag:"-r,nonzero"`
+	MemSize           int           `yaml:"-" cmdLongFlag:"--mem_size" cmdShortFlag:"-r,nonzero"`
 }
 
 // NewConfig returns an I/O Engine config.

--- a/src/control/server/instance_storage_rpc.go
+++ b/src/control/server/instance_storage_rpc.go
@@ -92,7 +92,6 @@ func (ei *EngineInstance) bdevFormat(p *bdev.Provider) (results proto.NvmeContro
 	res, err := p.Format(bdev.FormatRequest{
 		Class:      cfg.Class,
 		DeviceList: cfg.DeviceList,
-		MemSize:    cfg.MemSize,
 	})
 	if err != nil {
 		results = append(results, ei.newCret("", err))

--- a/src/control/server/server_utils.go
+++ b/src/control/server/server_utils.go
@@ -216,6 +216,17 @@ func prepBdevStorage(srv *server, usr *user.User, iommuEnabled bool, hpiGetter g
 		}
 	}
 
+	for _, engineCfg := range srv.cfg.Engines {
+		// Calculate mem_size per I/O engine (in MB)
+		engineCfg.MemSize = hugePages.Free / len(srv.cfg.Engines);
+		engineCfg.MemSize *= (hugePages.PageSizeKb >> 10);
+		// TODO: Warn if hugepages are not enough to sustain average
+		// I/O workload (~1GB)
+		if ((engineCfg.MemSize / engineCfg.TargetCount) < 1024) {
+			srv.log.Debugf("Not enough hugepages are allocated!")
+		}
+	}
+
 	return nil
 }
 

--- a/src/control/server/server_utils.go
+++ b/src/control/server/server_utils.go
@@ -223,7 +223,7 @@ func prepBdevStorage(srv *server, usr *user.User, iommuEnabled bool, hpiGetter g
 		// Warn if hugepages are not enough to sustain average
 		// I/O workload (~1GB)
 		if (engineCfg.MemSize / engineCfg.TargetCount) < 1024 {
-			srv.log.Infof("Not enough hugepages are allocated!")
+			srv.log.Errorf("Not enough hugepages are allocated!")
 		}
 	}
 

--- a/src/control/server/server_utils.go
+++ b/src/control/server/server_utils.go
@@ -220,10 +220,10 @@ func prepBdevStorage(srv *server, usr *user.User, iommuEnabled bool, hpiGetter g
 		// Calculate mem_size per I/O engine (in MB)
 		engineCfg.MemSize = hugePages.Free / len(srv.cfg.Engines);
 		engineCfg.MemSize *= (hugePages.PageSizeKb >> 10);
-		// TODO: Warn if hugepages are not enough to sustain average
+		// Warn if hugepages are not enough to sustain average
 		// I/O workload (~1GB)
 		if ((engineCfg.MemSize / engineCfg.TargetCount) < 1024) {
-			srv.log.Debugf("Not enough hugepages are allocated!")
+			srv.log.Infof("Not enough hugepages are allocated!")
 		}
 	}
 

--- a/src/control/server/server_utils.go
+++ b/src/control/server/server_utils.go
@@ -218,11 +218,11 @@ func prepBdevStorage(srv *server, usr *user.User, iommuEnabled bool, hpiGetter g
 
 	for _, engineCfg := range srv.cfg.Engines {
 		// Calculate mem_size per I/O engine (in MB)
-		engineCfg.MemSize = hugePages.Free / len(srv.cfg.Engines);
-		engineCfg.MemSize *= (hugePages.PageSizeKb >> 10);
+		engineCfg.MemSize = hugePages.Free / len(srv.cfg.Engines)
+		engineCfg.MemSize *= (hugePages.PageSizeKb >> 10)
 		// Warn if hugepages are not enough to sustain average
 		// I/O workload (~1GB)
-		if ((engineCfg.MemSize / engineCfg.TargetCount) < 1024) {
+		if (engineCfg.MemSize / engineCfg.TargetCount) < 1024 {
 			srv.log.Infof("Not enough hugepages are allocated!")
 		}
 	}

--- a/src/control/server/storage/bdev/backend.go
+++ b/src/control/server/storage/bdev/backend.go
@@ -199,7 +199,6 @@ func (b *spdkBackend) formatRespFromResults(results []*spdk.FormatResult) (*Form
 
 func (b *spdkBackend) formatNvme(req FormatRequest) (*FormatResponse, error) {
 	spdkOpts := &spdk.EnvOptions{
-		MemSize:        req.MemSize,
 		PciIncludeList: req.DeviceList,
 		DisableVMD:     b.IsVMDDisabled(),
 	}

--- a/src/control/server/storage/bdev/provider.go
+++ b/src/control/server/storage/bdev/provider.go
@@ -56,13 +56,11 @@ type (
 		pbin.ForwardableRequest
 		Class      storage.BdevClass
 		DeviceList []string
-		MemSize    int // size MiB memory to be used by SPDK proc
 		DisableVMD bool
 	}
 
 	// DeviceFormatRequest designs the parameters for a device-specific format.
 	DeviceFormatRequest struct {
-		MemSize int // size MiB memory to be used by SPDK proc
 		Device  string
 		Class   storage.BdevClass
 	}

--- a/src/control/server/storage/bdev/provider.go
+++ b/src/control/server/storage/bdev/provider.go
@@ -61,8 +61,8 @@ type (
 
 	// DeviceFormatRequest designs the parameters for a device-specific format.
 	DeviceFormatRequest struct {
-		Device  string
-		Class   storage.BdevClass
+		Device string
+		Class  storage.BdevClass
 	}
 
 	// DeviceFormatResponse contains device-specific Format operation results.

--- a/src/control/server/storage/config.go
+++ b/src/control/server/storage/config.go
@@ -144,7 +144,6 @@ type BdevConfig struct {
 	VmdDisabled bool      `yaml:"-"` // set during start-up
 	DeviceCount int       `yaml:"bdev_number,omitempty"`
 	FileSize    int       `yaml:"bdev_size,omitempty"`
-	MemSize     int       `yaml:"-" cmdLongFlag:"--mem_size,nonzero" cmdShortFlag:"-r,nonzero"`
 	VosEnv      string    `yaml:"-" cmdEnv:"VOS_BDEV_CLASS"`
 	Hostname    string    `yaml:"-"` // used when generating templates
 }

--- a/src/engine/srv.c
+++ b/src/engine/srv.c
@@ -1209,8 +1209,8 @@ dss_srv_init(void)
 		D_GOTO(failed, rc);
 	xstream_data.xd_init_step = XD_INIT_SYS_DB;
 
-	rc = bio_nvme_init(dss_nvme_conf, dss_nvme_shm_id,
-			   dss_nvme_mem_size, vos_db_get());
+	rc = bio_nvme_init(dss_nvme_conf, dss_nvme_shm_id, dss_nvme_mem_size,
+			   dss_tgt_nr, vos_db_get());
 	if (rc != 0)
 		D_GOTO(failed, rc);
 	xstream_data.xd_init_step = XD_INIT_NVME;

--- a/src/include/daos_srv/bio.h
+++ b/src/include/daos_srv/bio.h
@@ -395,7 +395,7 @@ void bio_register_bulk_ops(int (*bulk_create)(void *ctxt, d_sg_list_t *sgl,
  * \param[IN] nvme_conf		NVMe config file
  * \param[IN] shm_id		shm id to enable multiprocess mode in SPDK
  * \param[IN] mem_size		SPDK memory alloc size when using primary mode
- * \paran[IN] tgt_nr		Number of threads
+ * \paran[IN] tgt_nr		Number of targets
  * \param[IN] db		persistent database to store SMD data
  *
  * \return		Zero on success, negative value on error

--- a/src/include/daos_srv/bio.h
+++ b/src/include/daos_srv/bio.h
@@ -395,12 +395,13 @@ void bio_register_bulk_ops(int (*bulk_create)(void *ctxt, d_sg_list_t *sgl,
  * \param[IN] nvme_conf		NVMe config file
  * \param[IN] shm_id		shm id to enable multiprocess mode in SPDK
  * \param[IN] mem_size		SPDK memory alloc size when using primary mode
+ * \paran[IN] tgt_nr		Number of threads
  * \param[IN] db		persistent database to store SMD data
  *
  * \return		Zero on success, negative value on error
  */
 int bio_nvme_init(const char *nvme_conf, int shm_id, int mem_size,
-		  struct sys_db *db);
+		  int tgt_nr, struct sys_db *db);
 
 /**
  * Global NVMe finilization.

--- a/src/include/daos_srv/daos_engine.h
+++ b/src/include/daos_srv/daos_engine.h
@@ -41,7 +41,7 @@ extern const char	*dss_socket_dir;
 /** NVMe shm_id for enabling SPDK multi-process mode */
 extern int		 dss_nvme_shm_id;
 
-/** NVMe mem_size for SPDK memory allocation when using primary mode */
+/** NVMe mem_size for SPDK memory allocation when using primary mode (in MB) */
 extern int		 dss_nvme_mem_size;
 
 /** I/O Engine instance index */

--- a/src/tests/ftest/util/dmg_utils.py
+++ b/src/tests/ftest/util/dmg_utils.py
@@ -228,7 +228,7 @@ class DmgCommand(DmgCommandBase):
         self.timeout = saved_timeout
         return self.result
 
-    def storage_prepare(self, user=None, hugepages=None, nvme=False,
+    def storage_prepare(self, user=None, nvme=False,
                         scm=False, reset=False, force=True):
         """Get the result of the dmg storage format command.
 

--- a/src/tests/ftest/util/dmg_utils.py
+++ b/src/tests/ftest/util/dmg_utils.py
@@ -228,7 +228,7 @@ class DmgCommand(DmgCommandBase):
         self.timeout = saved_timeout
         return self.result
 
-    def storage_prepare(self, user=None, hugepages="4096", nvme=False,
+    def storage_prepare(self, user=None, hugepages=None, nvme=False,
                         scm=False, reset=False, force=True):
         """Get the result of the dmg storage format command.
 
@@ -244,7 +244,6 @@ class DmgCommand(DmgCommandBase):
             "nvme_only": nvme,
             "scm_only": scm,
             "target_user": getuser() if user is None else user,
-            "hugepages": hugepages,
             "reset": reset,
             "force": force
         }

--- a/src/tests/ftest/util/server_utils_params.py
+++ b/src/tests/ftest/util/server_utils_params.py
@@ -107,7 +107,7 @@ class DaosServerYamlParameters(YamlParameters):
         self.provider = BasicParameter(None, default_provider)
         self.hyperthreads = BasicParameter(None, False)
         self.socket_dir = BasicParameter(None, "/var/run/daos_server")
-        self.nr_hugepages = BasicParameter(None, 4096)
+        self.nr_hugepages = BasicParameter(None, 1024)
         self.control_log_mask = BasicParameter(None, "DEBUG")
         self.control_log_file = LogParameter(log_dir, None, "daos_control.log")
         self.helper_log_file = LogParameter(log_dir, None, "daos_admin.log")

--- a/src/vos/vos_common.c
+++ b/src/vos/vos_common.c
@@ -490,7 +490,7 @@ vos_self_nvme_fini(void)
 #define VOS_STORAGE_PATH	"/mnt/daos"
 #define VOS_NVME_CONF		"/etc/daos_nvme.conf"
 #define VOS_NVME_SHM_ID		DAOS_NVME_SHMID_NONE
-#define VOS_NVME_MEM_SIZE	DAOS_NVME_MEM_PRIMARY
+#define VOS_NVME_MEM_SIZE	1024
 #define VOS_NVME_NR_TARGET	1
 
 static int

--- a/src/vos/vos_common.c
+++ b/src/vos/vos_common.c
@@ -491,6 +491,7 @@ vos_self_nvme_fini(void)
 #define VOS_NVME_CONF		"/etc/daos_nvme.conf"
 #define VOS_NVME_SHM_ID		DAOS_NVME_SHMID_NONE
 #define VOS_NVME_MEM_SIZE	DAOS_NVME_MEM_PRIMARY
+#define VOS_NVME_NR_THREADS	1
 
 static int
 vos_self_nvme_init()
@@ -504,8 +505,8 @@ vos_self_nvme_init()
 	if (rc != 0 && rc != -DER_EXIST)
 		return rc;
 
-	rc = bio_nvme_init(VOS_NVME_CONF, VOS_NVME_SHM_ID,
-			   VOS_NVME_MEM_SIZE, vos_db_get());
+	rc = bio_nvme_init(VOS_NVME_CONF, VOS_NVME_SHM_ID, VOS_NVME_MEM_SIZE,
+			   VOS_NVME_NR_THREADS, vos_db_get());
 	if (rc)
 		return rc;
 

--- a/src/vos/vos_common.c
+++ b/src/vos/vos_common.c
@@ -491,7 +491,7 @@ vos_self_nvme_fini(void)
 #define VOS_NVME_CONF		"/etc/daos_nvme.conf"
 #define VOS_NVME_SHM_ID		DAOS_NVME_SHMID_NONE
 #define VOS_NVME_MEM_SIZE	DAOS_NVME_MEM_PRIMARY
-#define VOS_NVME_NR_THREADS	1
+#define VOS_NVME_NR_TARGET	1
 
 static int
 vos_self_nvme_init()
@@ -506,7 +506,7 @@ vos_self_nvme_init()
 		return rc;
 
 	rc = bio_nvme_init(VOS_NVME_CONF, VOS_NVME_SHM_ID, VOS_NVME_MEM_SIZE,
-			   VOS_NVME_NR_THREADS, vos_db_get());
+			   VOS_NVME_NR_TARGET, vos_db_get());
 	if (rc)
 		return rc;
 

--- a/utils/nlt_server.yaml
+++ b/utils/nlt_server.yaml
@@ -2,7 +2,7 @@ name: daos_server
 port: 10001
 provider: ofi+sockets
 socket_dir: /tmp/dnt_sockets
-nr_hugepages: 16384
+nr_hugepages: 32768
 control_log_mask: DEBUG
 access_points: ['localhost:10001']
 engines:

--- a/utils/nlt_server.yaml
+++ b/utils/nlt_server.yaml
@@ -2,7 +2,7 @@ name: daos_server
 port: 10001
 provider: ofi+sockets
 socket_dir: /tmp/dnt_sockets
-nr_hugepages: 4096
+nr_hugepages: 16384
 control_log_mask: DEBUG
 access_points: ['localhost:10001']
 engines:

--- a/utils/nlt_server.yaml
+++ b/utils/nlt_server.yaml
@@ -2,7 +2,6 @@ name: daos_server
 port: 10001
 provider: ofi+sockets
 socket_dir: /tmp/dnt_sockets
-nr_hugepages: 32768
 control_log_mask: DEBUG
 access_points: ['localhost:10001']
 engines:


### PR DESCRIPTION
Calculate per-xstream DMA upperbound buffer by number of hugepages,
instead of hardcoding to 1GB.
mem_size = # of hugepages * hugepage size
per-xstream DMA upperbound = mem_size / # of targets

Add warning in control plane if hugepages are not enough to sustain
average I/O workload (min 1GB per xstream).

Removed all other instances of mem_size, including option to set
mem_size per bdev. Removed SetHugepages option as well since it seems
to remain unused/unsupported.

Signed-off-by: Sydney Vanda <sydney.m.vanda@intel.com>