### PR TITLE
DAOS-7492 test: Add packages to CentOS 8 docker to run dfuse.

### DIFF
--- a/utils/docker/Dockerfile.centos.8
+++ b/utils/docker/Dockerfile.centos.8
@@ -92,6 +92,7 @@ RUN dnf -y upgrade && \
         e2fsprogs \
         file \
         flex \
+        fuse3 \
         fuse3-devel \
         gcc \
         gcc-c++ \
@@ -120,6 +121,7 @@ RUN dnf -y upgrade && \
         maven \
         nasm \
         ndctl \
+        numactl \
         numactl-devel \
         openmpi-devel \
         openssl-devel \


### PR DESCRIPTION
Add missing packages to be able to use and test dfuse.

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>
