### PR TITLE
DAOS-7709 object: fix obj leak caused by transactional modification

### DIFF
--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -2072,7 +2072,7 @@ obj_req_valid(tse_task_t *task, void *args, int opc, struct dtx_epoch *epoch,
 		}
 
 		if (daos_handle_is_valid(u_args->th))
-			return 0;
+			D_GOTO(out_tx, rc = 0);
 
 		oh = u_args->oh;
 		th = u_args->th;
@@ -2082,7 +2082,7 @@ obj_req_valid(tse_task_t *task, void *args, int opc, struct dtx_epoch *epoch,
 		daos_obj_punch_t *p_args = args;
 
 		if (daos_handle_is_valid(p_args->th))
-			return 0;
+			D_GOTO(out_tx, rc = 0);
 
 		oh = p_args->oh;
 		th = p_args->th;
@@ -2101,7 +2101,7 @@ obj_req_valid(tse_task_t *task, void *args, int opc, struct dtx_epoch *epoch,
 		}
 
 		if (daos_handle_is_valid(p_args->th))
-			return 0;
+			D_GOTO(out_tx, rc = 0);
 
 		oh = p_args->oh;
 		th = p_args->th;
@@ -2131,7 +2131,7 @@ obj_req_valid(tse_task_t *task, void *args, int opc, struct dtx_epoch *epoch,
 		}
 
 		if (daos_handle_is_valid(p_args->th))
-			return 0;
+			D_GOTO(out_tx, rc = 0);
 
 		oh = p_args->oh;
 		th = p_args->th;
@@ -2227,11 +2227,16 @@ obj_req_valid(tse_task_t *task, void *args, int opc, struct dtx_epoch *epoch,
 			D_GOTO(out, rc);
 	}
 
+	*pm_ver = map_ver;
+
+out_tx:
+	D_ASSERT(rc == 0);
+
 	if (p_obj != NULL)
 		*p_obj = obj;
 	else
 		obj_decref(obj);
-	*pm_ver = map_ver;
+
 out:
 	if (rc && obj)
 		obj_decref(obj);
@@ -3736,10 +3741,12 @@ obj_comp_cb(tse_task_t *task, void *data)
 			if (daos_handle_is_valid(obj_auxi->th) &&
 			    !(args->extra_flags & DIOF_CHECK_EXISTENCE) &&
 				 (task->dt_result == 0 ||
-				  task->dt_result == -DER_NONEXIST))
+				  task->dt_result == -DER_NONEXIST)) {
+				obj_addref(obj);
 				/* Cache transactional read if exist or not. */
-				dc_tx_attach(obj_auxi->th, DAOS_OBJ_RPC_FETCH,
-					     task);
+				dc_tx_attach(obj_auxi->th, obj,
+					     DAOS_OBJ_RPC_FETCH, task);
+			}
 			break;
 		}
 		case DAOS_OBJ_RPC_PUNCH:
@@ -3753,10 +3760,12 @@ obj_comp_cb(tse_task_t *task, void *data)
 		case DAOS_OBJ_DKEY_RPC_ENUMERATE:
 			if (daos_handle_is_valid(obj_auxi->th) &&
 			    (task->dt_result == 0 ||
-			     task->dt_result == -DER_NONEXIST))
+			     task->dt_result == -DER_NONEXIST)) {
+				obj_addref(obj);
 				/* Cache transactional read if exist or not. */
-				dc_tx_attach(obj_auxi->th,
+				dc_tx_attach(obj_auxi->th, NULL,
 					     obj_auxi->opc, task);
+			}
 			break;
 		case DAOS_OBJ_RPC_ENUMERATE:
 			/* XXX: For list dkey recursively, that is mainly used
@@ -4283,6 +4292,8 @@ dc_obj_update(tse_task_t *task, struct dtx_epoch *epoch, uint32_t map_ver,
 			      obj_auxi->reasb_req.tgt_bitmap, map_ver, false,
 			      false, obj_auxi);
 	if (rc != 0) {
+		if (rc == -DER_SHARDS_OVERLAP)
+			obj_addref(obj);
 		obj_comp_cb(task, NULL);
 		if (rc != -DER_SHARDS_OVERLAP)
 			goto out_task;
@@ -4291,7 +4302,7 @@ dc_obj_update(tse_task_t *task, struct dtx_epoch *epoch, uint32_t map_ver,
 		 * VOS target. We will handle such case via internal
 		 * transaction.
 		 */
-		return dc_tx_convert(DAOS_OBJ_RPC_UPDATE, task);
+		return dc_tx_convert(obj, DAOS_OBJ_RPC_UPDATE, task);
 	}
 
 	rc = tse_task_register_comp_cb(task, obj_comp_cb, NULL, 0);
@@ -4346,7 +4357,7 @@ dc_obj_update_task(tse_task_t *task)
 
 	if (daos_handle_is_valid(args->th)) {
 		/* add the operation to DTX and complete immediately */
-		rc = dc_tx_attach(args->th, DAOS_OBJ_RPC_UPDATE, task);
+		rc = dc_tx_attach(args->th, obj, DAOS_OBJ_RPC_UPDATE, task);
 		goto comp;
 	}
 
@@ -4902,26 +4913,19 @@ shard_punch_prep(struct shard_auxi_args *shard_auxi, struct dc_object *obj,
 }
 
 static int
-dc_obj_punch(tse_task_t *task, struct dtx_epoch *epoch, uint32_t map_ver,
-	     enum obj_rpc_opc opc, daos_obj_punch_t *api_args)
+dc_obj_punch(tse_task_t *task, struct dc_object *obj, struct dtx_epoch *epoch,
+	     uint32_t map_ver, enum obj_rpc_opc opc, daos_obj_punch_t *api_args)
 {
 	struct obj_auxi_args	*obj_auxi;
-	struct dc_object	*obj;
 	uint64_t		 dkey_hash;
 	int			 rc;
 
-	obj = obj_hdl2ptr(api_args->oh);
-	D_ASSERT(obj != NULL);
-
-	if (opc == DAOS_OBJ_RPC_PUNCH && obj->cob_grp_nr > 1) {
-		obj_decref(obj);
-
+	if (opc == DAOS_OBJ_RPC_PUNCH && obj->cob_grp_nr > 1)
 		/* The object have multiple redundancy groups, use DAOS
 		 * internal transaction to handle that to guarantee the
 		 * atomicity of punch object.
 		 */
-		return dc_tx_convert(opc, task);
-	}
+		return dc_tx_convert(obj, opc, task);
 
 	obj_task_init_common(task, opc, map_ver, api_args->th, &obj_auxi, obj);
 
@@ -4929,6 +4933,8 @@ dc_obj_punch(tse_task_t *task, struct dtx_epoch *epoch, uint32_t map_ver,
 	rc = obj_req_get_tgts(obj, NULL, api_args->dkey, dkey_hash, NIL_BITMAP,
 			      map_ver, false, false, obj_auxi);
 	if (rc != 0) {
+		if (rc == -DER_SHARDS_OVERLAP)
+			obj_addref(obj);
 		obj_comp_cb(task, NULL);
 		if (rc != -DER_SHARDS_OVERLAP)
 			goto out_task;
@@ -4937,7 +4943,7 @@ dc_obj_punch(tse_task_t *task, struct dtx_epoch *epoch, uint32_t map_ver,
 		 * VOS target. We will handle such case via internal
 		 * transaction.
 		 */
-		return dc_tx_convert(opc, task);
+		return dc_tx_convert(obj, opc, task);
 	}
 
 	rc = tse_task_register_comp_cb(task, obj_comp_cb, NULL, 0);
@@ -4970,20 +4976,21 @@ obj_punch_common(tse_task_t *task, enum obj_rpc_opc opc, daos_obj_punch_t *args)
 {
 	struct dtx_epoch	 epoch = {0};
 	unsigned int		 map_ver = 0;
+	struct dc_object	*obj = NULL;
 	int			 rc;
 
-	rc = obj_req_valid(task, args, opc, &epoch, &map_ver, NULL);
+	rc = obj_req_valid(task, args, opc, &epoch, &map_ver, &obj);
 	if (rc != 0)
 		goto comp; /* invalid parameters */
 
 	if (daos_handle_is_valid(args->th)) {
 
 		/* add the operation to DTX and complete immediately */
-		rc = dc_tx_attach(args->th, opc, task);
+		rc = dc_tx_attach(args->th, obj, opc, task);
 		goto comp;
 	}
 	/* submit the punch */
-	return dc_obj_punch(task, &epoch, map_ver, opc, args);
+	return dc_obj_punch(task, obj, &epoch, map_ver, opc, args);
 comp:
 	if (rc <= 0)
 		tse_task_complete(task, rc);

--- a/src/object/obj_internal.h
+++ b/src/object/obj_internal.h
@@ -849,10 +849,11 @@ int
 dc_tx_get_dti(daos_handle_t th, struct dtx_id *dti);
 
 int
-dc_tx_attach(daos_handle_t th, enum obj_rpc_opc opc, tse_task_t *task);
+dc_tx_attach(daos_handle_t th, struct dc_object *obj, enum obj_rpc_opc opc,
+	     tse_task_t *task);
 
 int
-dc_tx_convert(enum obj_rpc_opc opc, tse_task_t *task);
+dc_tx_convert(struct dc_object *obj, enum obj_rpc_opc opc, tse_task_t *task);
 
 /* obj_enum.c */
 int

--- a/src/object/obj_tx.c
+++ b/src/object/obj_tx.c
@@ -2165,26 +2165,28 @@ dc_tx_dcsr2oid(struct daos_cpd_sub_req *dcsr)
 }
 
 static int
-dc_tx_add_update(struct dc_tx *tx, daos_handle_t oh, uint64_t flags,
+dc_tx_add_update(struct dc_tx *tx, struct dc_object **obj, uint64_t flags,
 		 daos_key_t *dkey, uint32_t nr, daos_iod_t *iods,
 		 d_sg_list_t *sgls)
 {
 	struct daos_cpd_sub_req	*dcsr;
-	struct dc_object	*obj = NULL;
 	struct daos_cpd_update	*dcu = NULL;
 	struct obj_iod_array	*iod_array;
 	int			 rc;
 	int			 i;
 
 	D_ASSERT(nr != 0);
+	D_ASSERT(obj != NULL);
+
+	if (*obj == NULL)
+		return -DER_NO_HDL;
 
 	rc = dc_tx_get_next_slot(tx, false, &dcsr);
 	if (rc != 0)
 		return rc;
 
-	obj = dcsr->dcsr_obj = obj_hdl2ptr(oh);
-	if (dcsr->dcsr_obj == NULL)
-		return -DER_NO_HDL;
+	dcsr->dcsr_obj = *obj;
+	*obj = NULL;
 
 	rc = daos_iov_copy(&dcsr->dcsr_dkey, dkey);
 	if (rc != 0)
@@ -2195,7 +2197,7 @@ dc_tx_add_update(struct dc_tx *tx, daos_handle_t oh, uint64_t flags,
 
 	dcsr->dcsr_opc = DCSO_UPDATE;
 	dcsr->dcsr_nr = nr;
-	dcsr->dcsr_dkey_hash = obj_dkey2hash(obj->cob_md.omd_id, dkey);
+	dcsr->dcsr_dkey_hash = obj_dkey2hash(dc_tx_dcsr2oid(dcsr), dkey);
 	dcsr->dcsr_api_flags = flags & ~DAOS_COND_MASK;
 
 	dcu = &dcsr->dcsr_update;
@@ -2276,18 +2278,22 @@ fail:
 }
 
 static int
-dc_tx_add_punch_obj(struct dc_tx *tx, daos_handle_t oh, uint64_t flags)
+dc_tx_add_punch_obj(struct dc_tx *tx, struct dc_object **obj, uint64_t flags)
 {
 	struct daos_cpd_sub_req	*dcsr;
 	int			 rc;
+
+	D_ASSERT(obj != NULL);
+
+	if (*obj == NULL)
+		return -DER_NO_HDL;
 
 	rc = dc_tx_get_next_slot(tx, false, &dcsr);
 	if (rc != 0)
 		return rc;
 
-	dcsr->dcsr_obj = obj_hdl2ptr(oh);
-	if (dcsr->dcsr_obj == NULL)
-		return -DER_NO_HDL;
+	dcsr->dcsr_obj = *obj;
+	*obj = NULL;
 
 	dcsr->dcsr_opc = DCSO_PUNCH_OBJ;
 	dcsr->dcsr_api_flags = flags & ~DAOS_COND_MASK;
@@ -2303,20 +2309,23 @@ dc_tx_add_punch_obj(struct dc_tx *tx, daos_handle_t oh, uint64_t flags)
 }
 
 static int
-dc_tx_add_punch_dkey(struct dc_tx *tx, daos_handle_t oh, uint64_t flags,
+dc_tx_add_punch_dkey(struct dc_tx *tx, struct dc_object **obj, uint64_t flags,
 		     daos_key_t *dkey)
 {
 	struct daos_cpd_sub_req	*dcsr;
-	struct dc_object	*obj = NULL;
 	int			 rc;
+
+	D_ASSERT(obj != NULL);
+
+	if (*obj == NULL)
+		return -DER_NO_HDL;
 
 	rc = dc_tx_get_next_slot(tx, false, &dcsr);
 	if (rc != 0)
 		return rc;
 
-	obj = dcsr->dcsr_obj = obj_hdl2ptr(oh);
-	if (dcsr->dcsr_obj == NULL)
-		return -DER_NO_HDL;
+	dcsr->dcsr_obj = *obj;
+	*obj = NULL;
 
 	rc = daos_iov_copy(&dcsr->dcsr_dkey, dkey);
 	if (rc != 0) {
@@ -2325,7 +2334,7 @@ dc_tx_add_punch_dkey(struct dc_tx *tx, daos_handle_t oh, uint64_t flags,
 	}
 
 	dcsr->dcsr_opc = DCSO_PUNCH_DKEY;
-	dcsr->dcsr_dkey_hash = obj_dkey2hash(obj->cob_md.omd_id, dkey);
+	dcsr->dcsr_dkey_hash = obj_dkey2hash(dc_tx_dcsr2oid(dcsr), dkey);
 	dcsr->dcsr_api_flags = flags & ~DAOS_COND_MASK;
 
 	tx->tx_write_cnt++;
@@ -2339,24 +2348,26 @@ dc_tx_add_punch_dkey(struct dc_tx *tx, daos_handle_t oh, uint64_t flags,
 }
 
 static int
-dc_tx_add_punch_akeys(struct dc_tx *tx, daos_handle_t oh, uint64_t flags,
+dc_tx_add_punch_akeys(struct dc_tx *tx, struct dc_object **obj, uint64_t flags,
 		      daos_key_t *dkey, uint32_t nr, daos_key_t *akeys)
 {
 	struct daos_cpd_sub_req	*dcsr = NULL;
 	struct daos_cpd_punch	*dcp = NULL;
-	struct dc_object	*obj = NULL;
 	int			 rc;
 	int			 i;
 
 	D_ASSERT(nr != 0);
+	D_ASSERT(obj != NULL);
+
+	if (*obj == NULL)
+		return -DER_NO_HDL;
 
 	rc = dc_tx_get_next_slot(tx, false, &dcsr);
 	if (rc != 0)
 		return rc;
 
-	obj = dcsr->dcsr_obj = obj_hdl2ptr(oh);
-	if (dcsr->dcsr_obj == NULL)
-		return -DER_NO_HDL;
+	dcsr->dcsr_obj = *obj;
+	*obj = NULL;
 
 	rc = daos_iov_copy(&dcsr->dcsr_dkey, dkey);
 	if (rc != 0)
@@ -2375,7 +2386,7 @@ dc_tx_add_punch_akeys(struct dc_tx *tx, daos_handle_t oh, uint64_t flags,
 
 	dcsr->dcsr_opc = DCSO_PUNCH_AKEY;
 	dcsr->dcsr_nr = nr;
-	dcsr->dcsr_dkey_hash = obj_dkey2hash(obj->cob_md.omd_id, dkey);
+	dcsr->dcsr_dkey_hash = obj_dkey2hash(dc_tx_dcsr2oid(dcsr), dkey);
 	dcsr->dcsr_api_flags = flags & ~DAOS_COND_MASK;
 
 	tx->tx_write_cnt++;
@@ -2402,11 +2413,11 @@ fail:
 }
 
 static int
-dc_tx_add_read(struct dc_tx *tx, int opc, daos_handle_t oh, uint64_t flags,
-	       daos_key_t *dkey, uint32_t nr, void *iods_or_akey)
+dc_tx_add_read(struct dc_tx *tx, struct dc_object **obj, int opc,
+	       uint64_t flags, daos_key_t *dkey, uint32_t nr,
+	       void *iods_or_akey)
 {
 	struct daos_cpd_sub_req	*dcsr = NULL;
-	struct dc_object	*obj = NULL;
 	struct daos_cpd_read	*dcr = NULL;
 	int			 rc;
 	int			 i;
@@ -2417,13 +2428,17 @@ dc_tx_add_read(struct dc_tx *tx, int opc, daos_handle_t oh, uint64_t flags,
 	if (tx->tx_fixed_epoch)
 		return 0;
 
+	D_ASSERT(obj != NULL);
+
+	if (*obj == NULL)
+		return -DER_NO_HDL;
+
 	rc = dc_tx_get_next_slot(tx, true, &dcsr);
 	if (rc != 0)
 		return rc;
 
-	obj = dcsr->dcsr_obj = obj_hdl2ptr(oh);
-	if (dcsr->dcsr_obj == NULL)
-		return -DER_NO_HDL;
+	dcsr->dcsr_obj = *obj;
+	*obj = NULL;
 
 	/* Set read TS on object shard. */
 	if (dkey == NULL)
@@ -2464,7 +2479,7 @@ dc_tx_add_read(struct dc_tx *tx, int opc, daos_handle_t oh, uint64_t flags,
 done:
 	dcsr->dcsr_opc = DCSO_READ;
 	dcsr->dcsr_nr = nr;
-	dcsr->dcsr_dkey_hash = obj_dkey2hash(obj->cob_md.omd_id, dkey);
+	dcsr->dcsr_dkey_hash = obj_dkey2hash(dc_tx_dcsr2oid(dcsr), dkey);
 	dcsr->dcsr_api_flags = flags & ~DAOS_COND_MASK;
 
 	tx->tx_read_cnt++;
@@ -2512,9 +2527,11 @@ static int
 dc_tx_check_existence_cb(tse_task_t *task, void *data)
 {
 	struct dc_tx_check_existence_cb_args	*args = data;
+	struct dc_object			*obj = NULL;
 	struct dc_tx				*tx = args->tx;
 	int					 rc = 0;
 
+	obj = obj_hdl2ptr(args->oh);
 	D_MUTEX_LOCK(&tx->tx_lock);
 
 	switch (args->opc) {
@@ -2532,7 +2549,7 @@ dc_tx_check_existence_cb(tse_task_t *task, void *data)
 				D_GOTO(out, rc = task->dt_result);
 		}
 
-		rc = dc_tx_add_update(tx, args->oh, args->flags,
+		rc = dc_tx_add_update(tx, &obj, args->flags,
 				      args->dkey, args->nr,
 				      args->iods_or_akeys, args->sgls);
 		break;
@@ -2542,7 +2559,7 @@ dc_tx_check_existence_cb(tse_task_t *task, void *data)
 		if (task->dt_result != 0)
 			D_GOTO(out, rc = task->dt_result);
 
-		rc = dc_tx_add_punch_dkey(tx, args->oh, args->flags,
+		rc = dc_tx_add_punch_dkey(tx, &obj, args->flags,
 					  args->dkey);
 		break;
 	case DAOS_OBJ_RPC_PUNCH_AKEYS:
@@ -2551,7 +2568,7 @@ dc_tx_check_existence_cb(tse_task_t *task, void *data)
 		if (task->dt_result != 0)
 			D_GOTO(out, rc = task->dt_result);
 
-		rc = dc_tx_add_punch_akeys(tx, args->oh, args->flags,
+		rc = dc_tx_add_punch_akeys(tx, &obj, args->flags,
 					   args->dkey, args->nr,
 					   args->iods_or_akeys);
 		break;
@@ -2576,6 +2593,9 @@ out:
 
 	/* Drop the reference that is held via dc_tx_attach(). */
 	dc_tx_decref(tx);
+
+	if (obj != NULL)
+		obj_decref(obj);
 
 	return 0;
 }
@@ -2683,14 +2703,15 @@ out:
 }
 
 int
-dc_tx_attach(daos_handle_t th, enum obj_rpc_opc opc, tse_task_t *task)
+dc_tx_attach(daos_handle_t th, struct dc_object *obj, enum obj_rpc_opc opc,
+	     tse_task_t *task)
 {
 	struct dc_tx	*tx;
 	int		 rc;
 
 	rc = dc_tx_check(th, obj_is_modification_opc(opc) ? true : false, &tx);
 	if (rc != 0)
-		return rc;
+		goto out;
 
 	switch (opc) {
 	case DAOS_OBJ_RPC_UPDATE: {
@@ -2702,12 +2723,15 @@ dc_tx_attach(daos_handle_t th, enum obj_rpc_opc opc, tse_task_t *task)
 				 DAOS_COND_AKEY_UPDATE)) {
 			D_MUTEX_UNLOCK(&tx->tx_lock);
 
+			if (obj != NULL)
+				obj_decref(obj);
+
 			return dc_tx_check_existence_task(opc, up->oh, tx,
 						up->flags, up->dkey, up->nr,
 						up->iods, up->sgls, task);
 		}
 
-		rc = dc_tx_add_update(tx, up->oh, up->flags, up->dkey,
+		rc = dc_tx_add_update(tx, &obj, up->flags, up->dkey,
 				      up->nr, up->iods, up->sgls);
 		break;
 	}
@@ -2718,7 +2742,7 @@ dc_tx_attach(daos_handle_t th, enum obj_rpc_opc opc, tse_task_t *task)
 			  "Unexpected cond flag %lx for punch obj\n",
 			  pu->flags);
 
-		rc = dc_tx_add_punch_obj(tx, pu->oh, pu->flags);
+		rc = dc_tx_add_punch_obj(tx, &obj, pu->flags);
 		break;
 	}
 	case DAOS_OBJ_RPC_PUNCH_DKEYS: {
@@ -2727,12 +2751,15 @@ dc_tx_attach(daos_handle_t th, enum obj_rpc_opc opc, tse_task_t *task)
 		if (pu->flags & DAOS_COND_PUNCH) {
 			D_MUTEX_UNLOCK(&tx->tx_lock);
 
+			if (obj != NULL)
+				obj_decref(obj);
+
 			return dc_tx_check_existence_task(opc, pu->oh, tx,
 							  pu->flags, pu->dkey,
 							  0, NULL, NULL, task);
 		}
 
-		rc = dc_tx_add_punch_dkey(tx, pu->oh, pu->flags, pu->dkey);
+		rc = dc_tx_add_punch_dkey(tx, &obj, pu->flags, pu->dkey);
 		break;
 	}
 	case DAOS_OBJ_RPC_PUNCH_AKEYS: {
@@ -2741,19 +2768,22 @@ dc_tx_attach(daos_handle_t th, enum obj_rpc_opc opc, tse_task_t *task)
 		if (pu->flags & DAOS_COND_PUNCH) {
 			D_MUTEX_UNLOCK(&tx->tx_lock);
 
+			if (obj != NULL)
+				obj_decref(obj);
+
 			return dc_tx_check_existence_task(opc, pu->oh, tx,
 					pu->flags, pu->dkey, pu->akey_nr,
 					pu->akeys, NULL, task);
 		}
 
-		rc = dc_tx_add_punch_akeys(tx, pu->oh, pu->flags, pu->dkey,
+		rc = dc_tx_add_punch_akeys(tx, &obj, pu->flags, pu->dkey,
 					   pu->akey_nr, pu->akeys);
 		break;
 	}
 	case DAOS_OBJ_RPC_FETCH: {
 		daos_obj_fetch_t	*fe = dc_task_get_args(task);
 
-		rc = dc_tx_add_read(tx, opc, fe->oh, fe->flags, fe->dkey,
+		rc = dc_tx_add_read(tx, &obj, opc, fe->flags, fe->dkey,
 				    fe->nr, fe->nr != 1 ? fe->iods :
 				    (void *)&fe->iods[0].iod_name);
 		break;
@@ -2774,27 +2804,24 @@ dc_tx_attach(daos_handle_t th, enum obj_rpc_opc opc, tse_task_t *task)
 			nr = 1;
 		}
 
-		rc = dc_tx_add_read(tx, opc, qu->oh, 0, dkey, nr, qu->akey);
+		rc = dc_tx_add_read(tx, &obj, opc, 0, dkey, nr, qu->akey);
 		break;
 	}
 	case DAOS_OBJ_RECX_RPC_ENUMERATE: {
 		daos_obj_list_recx_t	*lr = dc_task_get_args(task);
 
-		rc = dc_tx_add_read(tx, opc, lr->oh, 0, lr->dkey, 1, lr->akey);
+		rc = dc_tx_add_read(tx, &obj, opc, 0, lr->dkey, 1, lr->akey);
 		break;
 	}
 	case DAOS_OBJ_AKEY_RPC_ENUMERATE: {
 		daos_obj_list_akey_t	*la = dc_task_get_args(task);
 
-		rc = dc_tx_add_read(tx, opc, la->oh, 0, la->dkey, 0, NULL);
+		rc = dc_tx_add_read(tx, &obj, opc, 0, la->dkey, 0, NULL);
 		break;
 	}
-	case DAOS_OBJ_DKEY_RPC_ENUMERATE: {
-		daos_obj_list_dkey_t	*ld = dc_task_get_args(task);
-
-		rc = dc_tx_add_read(tx, opc, ld->oh, 0, NULL, 0, NULL);
+	case DAOS_OBJ_DKEY_RPC_ENUMERATE:
+		rc = dc_tx_add_read(tx, &obj, opc, 0, NULL, 0, NULL);
 		break;
-	}
 	default:
 		D_ERROR("Unsupportted TX attach opc %d\n", opc);
 		rc = -DER_INVAL;
@@ -2803,6 +2830,10 @@ dc_tx_attach(daos_handle_t th, enum obj_rpc_opc opc, tse_task_t *task)
 
 	D_MUTEX_UNLOCK(&tx->tx_lock);
 	dc_tx_decref(tx);
+
+out:
+	if (obj != NULL)
+		obj_decref(obj);
 
 	return rc;
 }
@@ -2817,6 +2848,7 @@ static int
 dc_tx_convert_cb(tse_task_t *task, void *data)
 {
 	struct tx_convert_cb_args	*conv = data;
+	struct dc_object		*obj = NULL;
 	struct dc_tx			*tx = conv->conv_tx;
 	tse_task_t			*parent = conv->conv_task;
 	int				 rc = task->dt_result;
@@ -2846,27 +2878,31 @@ dc_tx_convert_cb(tse_task_t *task, void *data)
 		case DAOS_OBJ_RPC_UPDATE: {
 			daos_obj_update_t	*up = dc_task_get_args(parent);
 
-			rc = dc_tx_add_update(tx, up->oh, up->flags, up->dkey,
+			obj = obj_hdl2ptr(up->oh);
+			rc = dc_tx_add_update(tx, &obj, up->flags, up->dkey,
 					      up->nr, up->iods, up->sgls);
 			break;
 		}
 		case DAOS_OBJ_RPC_PUNCH: {
 			daos_obj_punch_t	*pu = dc_task_get_args(parent);
 
-			rc = dc_tx_add_punch_obj(tx, pu->oh, pu->flags);
+			obj = obj_hdl2ptr(pu->oh);
+			rc = dc_tx_add_punch_obj(tx, &obj, pu->flags);
 			break;
 		}
 		case DAOS_OBJ_RPC_PUNCH_DKEYS: {
 			daos_obj_punch_t	*pu = dc_task_get_args(parent);
 
-			rc = dc_tx_add_punch_dkey(tx, pu->oh, pu->flags,
+			obj = obj_hdl2ptr(pu->oh);
+			rc = dc_tx_add_punch_dkey(tx, &obj, pu->flags,
 						  pu->dkey);
 			break;
 		}
 		case DAOS_OBJ_RPC_PUNCH_AKEYS: {
 			daos_obj_punch_t	*pu = dc_task_get_args(parent);
 
-			rc = dc_tx_add_punch_akeys(tx, pu->oh, pu->flags,
+			obj = obj_hdl2ptr(pu->oh);
+			rc = dc_tx_add_punch_akeys(tx, &obj, pu->flags,
 						   pu->dkey, pu->akey_nr,
 						   pu->akeys);
 			break;
@@ -2896,11 +2932,14 @@ dc_tx_convert_cb(tse_task_t *task, void *data)
 out:
 	dc_tx_close_internal(tx);
 
+	if (obj != NULL)
+		obj_decref(obj);
+
 	return rc;
 }
 
 int
-dc_tx_convert(enum obj_rpc_opc opc, tse_task_t *task)
+dc_tx_convert(struct dc_object *obj, enum obj_rpc_opc opc, tse_task_t *task)
 {
 	struct tx_convert_cb_args	 conv = { 0 };
 	daos_handle_t			 coh;
@@ -2910,6 +2949,8 @@ dc_tx_convert(enum obj_rpc_opc opc, tse_task_t *task)
 	tse_task_t			*tx_task = NULL;
 	struct dc_tx			*tx = NULL;
 	int				 rc = 0;
+
+	D_ASSERT(obj != NULL);
 
 	switch (opc) {
 	case DAOS_OBJ_RPC_UPDATE:
@@ -2938,17 +2979,17 @@ dc_tx_convert(enum obj_rpc_opc opc, tse_task_t *task)
 
 	switch (opc) {
 	case DAOS_OBJ_RPC_UPDATE:
-		rc = dc_tx_add_update(tx, up->oh, up->flags, up->dkey,
+		rc = dc_tx_add_update(tx, &obj, up->flags, up->dkey,
 				      up->nr, up->iods, up->sgls);
 		break;
 	case DAOS_OBJ_RPC_PUNCH:
-		rc = dc_tx_add_punch_obj(tx, pu->oh, pu->flags);
+		rc = dc_tx_add_punch_obj(tx, &obj, pu->flags);
 		break;
 	case DAOS_OBJ_RPC_PUNCH_DKEYS:
-		rc = dc_tx_add_punch_dkey(tx, pu->oh, pu->flags, pu->dkey);
+		rc = dc_tx_add_punch_dkey(tx, &obj, pu->flags, pu->dkey);
 		break;
 	case DAOS_OBJ_RPC_PUNCH_AKEYS:
-		rc = dc_tx_add_punch_akeys(tx, pu->oh, pu->flags, pu->dkey,
+		rc = dc_tx_add_punch_akeys(tx, &obj, pu->flags, pu->dkey,
 					   pu->akey_nr, pu->akeys);
 		break;
 	default:
@@ -3003,6 +3044,9 @@ out:
 
 	if (tx != NULL)
 		dc_tx_close_internal(tx);
+
+	if (obj != NULL)
+		obj_decref(obj);
 
 	return rc;
 }


### PR DESCRIPTION
When do transactional modification, the reference that is held via
obj_req_valid() on the object being modified is leaked. This patch
fixes such issue.

Signed-off-by: Fan Yong <fan.yong@intel.com>