### PR TITLE
DAOS-5428 EC: add csum support for EC aggregation

### DIFF
--- a/src/container/srv_cli.c
+++ b/src/container/srv_cli.c
@@ -124,3 +124,18 @@ out:
 
 	return rc;
 }
+
+struct daos_csummer *
+dsc_cont2csummer(daos_handle_t coh)
+{
+	struct dc_cont		*cont = NULL;
+	struct daos_csummer	*csummer;
+
+	cont = dc_hdl2cont(coh);
+	if (cont == NULL)
+		return NULL;
+	csummer = cont->dc_csummer;
+	dc_cont_put(cont);
+
+	return csummer;
+}

--- a/src/include/daos/common.h
+++ b/src/include/daos/common.h
@@ -160,7 +160,7 @@ char *daos_key2str(daos_key_t *key);
 				daos_key2str(key)
 #endif
 
-#define DF_RECX			"["DF_U64"-"DF_U64"]"
+#define DF_RECX			"["DF_X64"-"DF_X64"]"
 #define DP_RECX(r)		(r).rx_idx, ((r).rx_idx + (r).rx_nr - 1)
 #define DF_IOM			"{nr: %d, lo: "DF_RECX", hi: "DF_RECX"}"
 #define DP_IOM(m)		(m)->iom_nr, DP_RECX((m)->iom_recx_lo), \

--- a/src/include/daos_srv/container.h
+++ b/src/include/daos_srv/container.h
@@ -252,6 +252,7 @@ ds_csum_agg_recalc(void *args);
 int dsc_cont_open(daos_handle_t poh, uuid_t cont_uuid, uuid_t cont_hdl_uuid,
 		  unsigned int flags, daos_handle_t *coh);
 int dsc_cont_close(daos_handle_t poh, daos_handle_t coh);
+struct daos_csummer *dsc_cont2csummer(daos_handle_t coh);
 
 
 void ds_cont_tgt_ec_eph_query_ult(void *data);

--- a/src/object/cli_shard.c
+++ b/src/object/cli_shard.c
@@ -340,7 +340,7 @@ dc_rw_cb_csum_verify(const struct rw_cb_args *rw_args)
 					DF_RC"\n",
 					DP_C_UOID_DKEY(orw->orw_oid,
 						     &orw->orw_dkey),
-					shard_idx, DP_RECX(iod->iod_recxs[i]),
+					shard_idx, DP_RECX(iod->iod_recxs[0]),
 					DP_RC(rc));
 			}
 
@@ -416,9 +416,10 @@ obj_ec_iom_merge(struct obj_reasb_req *reasb_req, uint32_t shard,
 	uint64_t		 cell_rec_nr = obj_ec_cell_rec_nr(oca);
 	uint64_t		 end, rec_nr;
 	daos_recx_t		 hi, lo, recx, tmpr;
-	daos_recx_t		 recov_hi, recov_lo;
+	daos_recx_t		 recov_hi = { 0 };
+	daos_recx_t		 recov_lo = { 0 };
 	uint32_t		 iom_nr, i;
-	bool			 done, is_data_shard;
+	bool			 done;
 	int			 rc = 0;
 
 	D_ASSERT(tgt_idx < obj_ec_data_tgt_nr(oca));
@@ -426,13 +427,12 @@ obj_ec_iom_merge(struct obj_reasb_req *reasb_req, uint32_t shard,
 	if (recov_list != NULL)
 		daos_recx_ep_list_hilo(recov_list, &recov_hi, &recov_lo);
 
-	is_data_shard = (shard % obj_ec_tgt_nr(oca)) < obj_ec_data_tgt_nr(oca);
 	D_SPIN_LOCK(&reasb_req->orr_spin);
 
 	/* merge iom_recx_hi */
 	hi = src->iom_recx_hi;
 	end = DAOS_RECX_END(hi);
-	if (end > 0 && is_data_shard) {
+	if (end > 0) {
 		hi.rx_idx = max(hi.rx_idx, rounddown(end - 1, cell_rec_nr));
 		hi.rx_nr = end - hi.rx_idx;
 		hi.rx_idx = obj_ec_idx_vos2daos(hi.rx_idx, stripe_rec_nr,
@@ -452,7 +452,7 @@ obj_ec_iom_merge(struct obj_reasb_req *reasb_req, uint32_t shard,
 	/* merge iom_recx_lo */
 	lo = src->iom_recx_lo;
 	end = DAOS_RECX_END(lo);
-	if (end > 0 && is_data_shard) {
+	if (end > 0) {
 		lo.rx_nr = min(end, roundup(lo.rx_idx + 1, cell_rec_nr)) -
 			   lo.rx_idx;
 		lo.rx_idx = obj_ec_idx_vos2daos(lo.rx_idx, stripe_rec_nr,
@@ -501,23 +501,14 @@ obj_ec_iom_merge(struct obj_reasb_req *reasb_req, uint32_t shard,
 		end = DAOS_RECX_END(recx);
 		rec_nr = 0;
 		while (rec_nr < recx.rx_nr) {
-			if (is_data_shard) {
-				tmpr.rx_idx = recx.rx_idx + rec_nr;
-				tmpr.rx_nr = min(roundup(tmpr.rx_idx + 1,
-							 cell_rec_nr), end) -
-						 tmpr.rx_idx;
-				rec_nr += tmpr.rx_nr;
-				tmpr.rx_idx = obj_ec_idx_vos2daos(tmpr.rx_idx,
-								  stripe_rec_nr,
-								  cell_rec_nr,
-								  tgt_idx);
-			} else {
-				/* If it is from parity shard then it is DAOS
-				 * offset already, and need not break to small
-				 * recxs. */
-				tmpr = recx;
-				rec_nr = recx.rx_nr;
-			}
+			tmpr.rx_idx = recx.rx_idx + rec_nr;
+			tmpr.rx_nr = min(roundup(tmpr.rx_idx + 1, cell_rec_nr),
+					 end) - tmpr.rx_idx;
+			rec_nr += tmpr.rx_nr;
+			tmpr.rx_idx = obj_ec_idx_vos2daos(tmpr.rx_idx,
+							  stripe_rec_nr,
+							  cell_rec_nr,
+							  tgt_idx);
 			rc = iom_recx_merge(dst, &tmpr,
 					    reasb_req->orr_iom_realloc);
 			if (rc == -DER_NOMEM)

--- a/src/object/obj_ec.h
+++ b/src/object/obj_ec.h
@@ -512,10 +512,36 @@ obj_iod_break(daos_iod_t *iod, struct daos_oclass_attr *oca)
 	return 0;
 }
 
+/* translate iod's recxs from unmapped daos extend to mapped vos extents */
+static inline void
+obj_iod_recx_daos2vos(uint32_t iod_nr, daos_iod_t *iods,
+		      struct daos_oclass_attr *oca)
+{
+	daos_iod_t	*iod;
+	daos_recx_t	*recx;
+	uint64_t	 stripe_rec_nr = obj_ec_stripe_rec_nr(oca);
+	uint64_t	 cell_rec_nr = obj_ec_cell_rec_nr(oca);
+	uint32_t	 i, j;
+
+	for (i = 0; i < iod_nr; i++) {
+		iod = &iods[i];
+		if (iod->iod_type == DAOS_IOD_SINGLE)
+			continue;
+
+		for (j = 0; j < iod->iod_nr; j++) {
+			recx = &iod->iod_recxs[j];
+			D_ASSERT((recx->rx_idx & PARITY_INDICATOR) == 0);
+			recx->rx_idx = obj_ec_idx_daos2vos(recx->rx_idx,
+							   stripe_rec_nr,
+							   cell_rec_nr);
+		}
+	}
+}
+
 /* translate iod's recxs from mapped VOS extend to unmapped daos extents */
 static inline int
 obj_iod_recx_vos2daos(uint32_t iod_nr, daos_iod_t *iods, uint32_t tgt_idx,
-		     struct daos_oclass_attr *oca)
+		      struct daos_oclass_attr *oca)
 {
 	daos_iod_t	*iod;
 	daos_recx_t	*recx;

--- a/src/object/obj_rpc.h
+++ b/src/object/obj_rpc.h
@@ -333,10 +333,10 @@ CRT_RPC_DECLARE(obj_migrate, DAOS_ISEQ_OBJ_MIGRATE, DAOS_OSEQ_OBJ_MIGRATE)
 	((uuid_t)		(ea_coh_uuid)		CRT_VAR)	\
 	((daos_unit_oid_t)	(ea_oid)		CRT_VAR)	\
 	((daos_key_t)		(ea_dkey)		CRT_VAR)	\
-	((daos_key_t)		(ea_akey)		CRT_VAR)	\
+	((daos_iod_t)		(ea_iod)		CRT_VAR)	\
+	((struct dcs_iod_csums)	(ea_iod_csums)		CRT_ARRAY)	\
 	((daos_epoch_range_t)	(ea_epoch_range)	CRT_VAR)	\
 	((uint64_t)		(ea_stripenum)		CRT_VAR)	\
-	((uint64_t)		(ea_rsize)		CRT_VAR)	\
 	((crt_bulk_t)		(ea_bulk)		CRT_VAR)	\
 	((uint32_t)		(ea_map_ver)		CRT_VAR)	\
 	((uint32_t)		(ea_remove_nr)		CRT_VAR)	\

--- a/src/object/srv_ec_aggregate.c
+++ b/src/object/srv_ec_aggregate.c
@@ -152,6 +152,12 @@ struct ec_agg_extent {
 	bool		ae_hole;        /* extent is a hole   */
 };
 
+static inline struct daos_csummer *
+ec_agg_param2csummer(struct ec_agg_param *agg_param)
+{
+	return dsc_cont2csummer(agg_param->ap_pool_info.api_cont_hdl);
+}
+
 /* return EC(K) in # records */
 static inline unsigned int
 ec_age2k(struct ec_agg_entry *age)
@@ -826,7 +832,8 @@ agg_remove_holdovers(struct ec_agg_entry *entry)
  * in the processed stripe.
  */
 static int
-agg_update_vos(struct ec_agg_entry *entry, bool write_parity)
+agg_update_vos(struct ec_agg_param *agg_param, struct ec_agg_entry *entry,
+	       bool write_parity)
 {
 	daos_recx_t		 recx = { 0 };
 	daos_epoch_range_t	 epoch_range = { 0 };
@@ -834,6 +841,8 @@ agg_update_vos(struct ec_agg_entry *entry, bool write_parity)
 	struct ec_agg_extent	*ext;
 	uint32_t		 len = ec_age2cs(entry);
 	uint32_t		 pidx = ec_age2pidx(entry);
+	struct daos_csummer	*csummer;
+	struct dcs_iod_csums	*iod_csums = NULL;
 	int			 rc = 0;
 
 	ap = container_of(entry, struct ec_agg_param, ap_agg_entry);
@@ -843,6 +852,7 @@ agg_update_vos(struct ec_agg_entry *entry, bool write_parity)
 		daos_iod_t	 iod = { 0 };
 		d_iov_t		 iov;
 
+		csummer = ec_agg_param2csummer(agg_param);
 		iov = entry->ae_sgl.sg_iovs[AGG_IOV_PARITY];
 		iov.iov_buf += pidx * ec_age2cs_b(entry);
 		iov.iov_len = ec_age2cs_b(entry);
@@ -856,9 +866,22 @@ agg_update_vos(struct ec_agg_entry *entry, bool write_parity)
 		recx.rx_idx = (entry->ae_cur_stripe.as_stripenum * len) |
 							PARITY_INDICATOR;
 		recx.rx_nr = len;
+		if (csummer != NULL) {
+			rc = daos_csummer_calc_iods(csummer, &sgl, &iod, NULL,
+						    1, false, NULL, 0,
+						    &iod_csums);
+			if (rc) {
+				D_ERROR("daos_csummer_calc_iods failed: "DF_RC
+					"\n", DP_RC(rc));
+				goto out;
+			}
+			D_ASSERT(iod_csums != NULL);
+		}
 		rc = vos_obj_update(ap->ap_cont_handle, entry->ae_oid,
 				    entry->ae_cur_stripe.as_hi_epoch, 0, 0,
-				    &entry->ae_dkey, 1, &iod, NULL, &sgl);
+				    &entry->ae_dkey, 1, &iod, iod_csums, &sgl);
+		if (csummer != NULL && iod_csums != NULL)
+			daos_csummer_free_ic(csummer, &iod_csums);
 		if (rc) {
 			D_ERROR("vos_obj_update failed: "DF_RC"\n", DP_RC(rc));
 			goto out;
@@ -1330,8 +1353,11 @@ agg_peer_update_ult(void *arg)
 {
 	struct ec_agg_stripe_ud	*stripe_ud = (struct ec_agg_stripe_ud *)arg;
 	struct ec_agg_entry	*entry = stripe_ud->asu_agg_entry;
+	unsigned int		 len = ec_age2cs(entry);
 	d_iov_t			 iov = { 0 };
 	d_sg_list_t		 sgl = { 0 };
+	daos_iod_t		 iod = { 0 };
+	daos_recx_t		 recx = { 0 };
 	crt_endpoint_t		 tgt_ep = { 0 };
 	unsigned char		*buf = NULL;
 	struct obj_ec_agg_in	*ec_agg_in = NULL;
@@ -1339,6 +1365,8 @@ agg_peer_update_ult(void *arg)
 	struct ec_agg_param	*agg_param;
 	struct ec_agg_extent	*ext;
 	crt_bulk_t		 bulk_hdl = NULL;
+	struct daos_csummer	*csummer = NULL;
+	struct dcs_iod_csums	*iod_csums;
 	uint32_t		 shard  = ec_age2shard(entry);
 	uint32_t		 pidx = ec_age2pidx(entry);
 	uint64_t		 cell_b = ec_age2cs_b(entry);
@@ -1350,6 +1378,10 @@ agg_peer_update_ult(void *arg)
 	int			 rc = 0;
 
 	agg_param = container_of(entry, struct ec_agg_param, ap_agg_entry);
+	csummer = ec_agg_param2csummer(agg_param);
+	iod.iod_type = DAOS_IOD_ARRAY;
+	iod.iod_name = entry->ae_akey;
+	iod.iod_size = entry->ae_rsize;
 	for (peer = 0; peer < p; peer++) {
 		if (peer == pidx)
 			continue;
@@ -1376,16 +1408,22 @@ agg_peer_update_ult(void *arg)
 		peer_shard = rounddown(shard, k + p) + k + peer;
 		ec_agg_in->ea_oid.id_shard = peer_shard;
 		ec_agg_in->ea_dkey = entry->ae_dkey;
-		ec_agg_in->ea_akey = entry->ae_akey;
 		ec_agg_in->ea_epoch_range.epr_lo = agg_param->ap_epr.epr_lo;
 		ec_agg_in->ea_epoch_range.epr_hi =
 			entry->ae_cur_stripe.as_hi_epoch;
 		ec_agg_in->ea_stripenum = entry->ae_cur_stripe.as_stripenum;
 		ec_agg_in->ea_map_ver =
 			agg_param->ap_pool_info.api_pool->sp_map_version;
-
+		ec_agg_in->ea_iod_csums.ca_arrays = NULL;
+		ec_agg_in->ea_iod_csums.ca_count = 0;
+		iod_csums = NULL;
+		iod.iod_nr = 0;
 		if (stripe_ud->asu_write_par) {
-			ec_agg_in->ea_rsize = entry->ae_rsize;
+			recx.rx_idx = (ec_agg_in->ea_stripenum * len) |
+				      PARITY_INDICATOR;
+			recx.rx_nr = len;
+			iod.iod_nr = 1;
+			iod.iod_recxs = &recx;
 			buf = (unsigned char *)
 				entry->ae_sgl.sg_iovs[AGG_IOV_PARITY].iov_buf;
 			d_iov_set(&iov, &buf[peer * cell_b], cell_b);
@@ -1401,7 +1439,24 @@ agg_peer_update_ult(void *arg)
 				goto out_rpc;
 			}
 			ec_agg_in->ea_bulk = bulk_hdl;
+
+			if (csummer != NULL) {
+				rc = daos_csummer_calc_iods(csummer, &sgl, &iod,
+							    NULL, 1, false,
+							    NULL, 0,
+							    &iod_csums);
+				if (rc) {
+					D_ERROR("daos_csummer_calc_iods "
+						"failed: "DF_RC"\n", DP_RC(rc));
+					goto out;
+				}
+				D_ASSERT(iod_csums != NULL);
+
+				ec_agg_in->ea_iod_csums.ca_arrays = iod_csums;
+				ec_agg_in->ea_iod_csums.ca_count = 1;
+			}
 		}
+		ec_agg_in->ea_iod = iod;
 
 		if (entry->ae_cur_stripe.as_ho_ext_cnt ||
 		    !agg_contained(entry)) {
@@ -1458,6 +1513,8 @@ agg_peer_update_ult(void *arg)
 			crt_bulk_free(bulk_hdl);
 			bulk_hdl = NULL;
 		}
+		if (csummer != NULL && iod_csums != NULL)
+			daos_csummer_free_ic(csummer, &iod_csums);
 		crt_req_decref(rpc);
 		rpc = NULL;
 		if (rc) {
@@ -1526,9 +1583,10 @@ agg_peer_update(struct ec_agg_entry *entry, bool write_parity)
 			}
 		}
 	}
-	stripe_ud.asu_write_par = write_parity;
 
+	stripe_ud.asu_write_par = write_parity;
 	stripe_ud.asu_agg_entry = entry;
+
 	rc = agg_get_obj_handle(entry);
 	if (rc) {
 		D_ERROR("Failed to open object: "DF_RC"\n", DP_RC(rc));
@@ -1823,8 +1881,9 @@ out:
  * extent in the subsequent.
  */
 static int
-agg_process_stripe(struct dtx_handle *dth, struct ec_agg_entry *entry)
+agg_process_stripe(struct ec_agg_param *agg_param, struct ec_agg_entry *entry)
 {
+	struct dtx_handle	*dth = agg_param->ap_dth;
 	vos_iter_param_t	iter_param = { 0 };
 	struct vos_iter_anchors	anchors = { 0 };
 	bool			update_vos = true;
@@ -1891,7 +1950,7 @@ out:
 		}
 
 		if (rc == 0) {
-			rc = agg_update_vos(entry, write_parity);
+			rc = agg_update_vos(agg_param, entry, write_parity);
 			if (rc)
 				D_ERROR("agg_update_vos failed: "DF_RC"\n",
 					DP_RC(rc));
@@ -1941,9 +2000,10 @@ agg_in_stripe(struct ec_agg_entry *entry, daos_recx_t *recx)
 /* Iterator call back sub-function for handling data extents.
  */
 static int
-agg_data_extent(struct dtx_handle *dth, vos_iter_entry_t *entry,
+agg_data_extent(struct ec_agg_param *agg_param, vos_iter_entry_t *entry,
 		struct ec_agg_entry *agg_entry, unsigned int *acts)
 {
+	struct dtx_handle	*dth = agg_param->ap_dth;
 	struct ec_agg_extent	*extent = NULL;
 	daos_off_t		 cur_stripenum, this_stripenum;
 	int			 rc = 0;
@@ -1958,7 +2018,7 @@ agg_data_extent(struct dtx_handle *dth, vos_iter_entry_t *entry,
 		/* Iterator has reached next stripe */
 		if (agg_entry->ae_cur_stripe.as_extent_cnt) {
 			cur_stripenum = agg_entry->ae_cur_stripe.as_stripenum;
-			rc = agg_process_stripe(dth, agg_entry);
+			rc = agg_process_stripe(agg_param, agg_entry);
 			if (obj_dtx_need_refresh(dth, rc))
 				goto out;
 
@@ -1974,7 +2034,7 @@ agg_data_extent(struct dtx_handle *dth, vos_iter_entry_t *entry,
 			agg_entry->ae_cur_stripe.as_stripenum <
 			this_stripenum) {
 				/* Handle holdover stripe */
-				rc = agg_process_stripe(dth, agg_entry);
+				rc = agg_process_stripe(agg_param, agg_entry);
 				if (obj_dtx_need_refresh(dth, rc))
 					goto out;
 
@@ -1986,8 +2046,6 @@ agg_data_extent(struct dtx_handle *dth, vos_iter_entry_t *entry,
 		}
 		agg_entry->ae_cur_stripe.as_stripenum = this_stripenum;
 	}
-	if (entry->ie_csum.cs_type)
-		return 1;
 
 	/* Add the extent to the entry, for the current stripe */
 	D_ALLOC_PTR(extent);
@@ -2035,15 +2093,17 @@ out:
 /* Post iteration call back for akey.
  */
 static int
-agg_akey_post(daos_handle_t ih, struct dtx_handle *dth, vos_iter_entry_t *entry,
-	      struct ec_agg_entry *agg_entry, unsigned int *acts)
+agg_akey_post(daos_handle_t ih, struct ec_agg_param *agg_param,
+	      vos_iter_entry_t *entry, struct ec_agg_entry *agg_entry,
+	      unsigned int *acts)
 {
-	daos_off_t	cur_stripenum;
-	int		rc = 0;
+	struct dtx_handle	*dth = agg_param->ap_dth;
+	daos_off_t		 cur_stripenum;
+	int			 rc = 0;
 
 	if (agg_entry->ae_cur_stripe.as_extent_cnt) {
 		cur_stripenum = agg_entry->ae_cur_stripe.as_stripenum;
-		rc = agg_process_stripe(dth, agg_entry);
+		rc = agg_process_stripe(agg_param, agg_entry);
 		if (obj_dtx_need_refresh(dth, rc))
 			return rc;
 
@@ -2053,7 +2113,7 @@ agg_akey_post(daos_handle_t ih, struct dtx_handle *dth, vos_iter_entry_t *entry,
 		rc = 0;
 		if (cur_stripenum < agg_entry->ae_cur_stripe.as_stripenum) {
 			/* Handle holdover stripe */
-			rc = agg_process_stripe(dth, agg_entry);
+			rc = agg_process_stripe(agg_param, agg_entry);
 			if (obj_dtx_need_refresh(dth, rc))
 				return rc;
 
@@ -2164,8 +2224,7 @@ agg_iterate_post_cb(daos_handle_t ih, vos_iter_entry_t *entry,
 	case VOS_ITER_DKEY:
 		break;
 	case VOS_ITER_AKEY:
-		rc = agg_akey_post(ih, agg_param->ap_dth,
-				   entry, agg_entry, acts);
+		rc = agg_akey_post(ih, agg_param, entry, agg_entry, acts);
 		break;
 	case VOS_ITER_RECX:
 		break;
@@ -2281,7 +2340,7 @@ agg_iterate_pre_cb(daos_handle_t ih, vos_iter_entry_t *entry,
 		rc = agg_akey(ih, entry, agg_entry, acts);
 		break;
 	case VOS_ITER_RECX:
-		rc = agg_data_extent(agg_param->ap_dth, entry, agg_entry, acts);
+		rc = agg_data_extent(agg_param, entry, agg_entry, acts);
 		break;
 	default:
 		/* Verify that single values are always skipped */

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -1319,6 +1319,7 @@ obj_local_rw_internal(crt_rpc_t *rpc, struct obj_io_context *ioc,
 	bool				bulk_bind;
 	bool				create_map;
 	bool				spec_fetch = false;
+	bool				iod_converted = false;
 	struct daos_recx_ep_list	*recov_lists = NULL;
 	daos_iod_t			*iods;
 	uint64_t			*offs;
@@ -1449,6 +1450,7 @@ obj_local_rw_internal(crt_rpc_t *rpc, struct obj_io_context *ioc,
 					"\n", DP_UOID(orw->orw_oid), DP_RC(rc));
 				goto out;
 			}
+			iod_converted = true;
 		}
 
 		rc = vos_fetch_begin(ioc->ioc_vos_coh, orw->orw_oid,
@@ -1587,8 +1589,20 @@ obj_local_rw_internal(crt_rpc_t *rpc, struct obj_io_context *ioc,
 				    orw->orw_sgls.ca_count);
 		}
 	}
-	if (obj_rpc_is_fetch(rpc) && create_map)
+	if (obj_rpc_is_fetch(rpc) && create_map) {
+		/* EC degraded fetch converted original iod to replica daos ext,
+		 * need to convert back to vos ext before creating iom, or the
+		 * client-side dc_rw_cb_csum_verify() may not work.
+		 */
+		if (iod_converted) {
+			struct daos_oclass_attr	*oca;
+
+			oca = daos_oclass_attr_find(orw->orw_oid.id_pub);
+			D_ASSERT(oca != NULL);
+			obj_iod_recx_daos2vos(orw->orw_nr, iods, oca);
+		}
 		rc = obj_fetch_create_maps(rpc, biod, iods);
+	}
 
 	if (rc == -DER_CSUM)
 		obj_log_csum_err();
@@ -2002,7 +2016,10 @@ ds_obj_ec_agg_handler(crt_rpc_t *rpc)
 	daos_key_t		*dkey;
 	struct daos_oclass_attr	*oca;
 	struct bio_desc		*biod;
-	daos_iod_t		 iod = { 0 };
+	daos_iod_t		*iod = &oea->ea_iod;
+	struct dcs_iod_csums	*iod_csums = oea->ea_iod_csums.ca_arrays;
+
+	crt_bulk_t		 parity_bulk = oea->ea_bulk;
 	daos_recx_t		 recx = { 0 };
 	struct obj_io_context	 ioc;
 	daos_handle_t		 ioh = DAOS_HDL_INVAL;
@@ -2021,18 +2038,10 @@ ds_obj_ec_agg_handler(crt_rpc_t *rpc)
 	}
 	D_ASSERT(ioc.ioc_coc != NULL);
 	dkey = (daos_key_t *)&oea->ea_dkey;
-	iod.iod_name = oea->ea_akey;
-	iod.iod_type = DAOS_IOD_ARRAY;
-	iod.iod_size = oea->ea_rsize;
-	iod.iod_nr = 1;
-	if (iod.iod_size) {
-		recx.rx_idx = (oea->ea_stripenum * oca->u.ec.e_len) |
-			PARITY_INDICATOR;
-		recx.rx_nr = oca->u.ec.e_len;
-		iod.iod_recxs = &recx;
+	if (parity_bulk != CRT_BULK_NULL) {
 		rc = vos_update_begin(ioc.ioc_coc->sc_hdl, oea->ea_oid,
 				      oea->ea_epoch_range.epr_hi, 0, dkey, 1,
-				      &iod, NULL, NULL, 0, &ioh, NULL);
+				      iod, iod_csums, NULL, 0, &ioh, NULL);
 		if (rc) {
 			D_ERROR(DF_UOID" Update begin failed: "DF_RC"\n",
 				DP_UOID(oea->ea_oid), DP_RC(rc));
@@ -2086,7 +2095,7 @@ ds_obj_ec_agg_handler(crt_rpc_t *rpc)
 				oea->ea_remove_eps.ca_arrays[i];
 			rc = vos_obj_array_remove(ioc.ioc_coc->sc_hdl,
 						  oea->ea_oid, &epr, dkey,
-						  &oea->ea_akey, ea_recx);
+						  &iod->iod_name, ea_recx);
 			if (rc) {
 				D_ERROR(DF_UOID"array_remove failed: "DF_RC"\n",
 					DP_UOID(oea->ea_oid), DP_RC(rc));
@@ -2099,7 +2108,7 @@ ds_obj_ec_agg_handler(crt_rpc_t *rpc)
 		recx.rx_nr = oca->u.ec.e_k * oca->u.ec.e_len;
 		rc = vos_obj_array_remove(ioc.ioc_coc->sc_hdl, oea->ea_oid,
 					  &oea->ea_epoch_range, dkey,
-					  &oea->ea_akey, &recx);
+					  &iod->iod_name, &recx);
 		if (rc) {
 			D_ERROR(DF_UOID"array_remove failed: "DF_RC"\n",
 				DP_UOID(oea->ea_oid), DP_RC(rc));

--- a/src/tests/ftest/daos_test/daos_core_test.yaml
+++ b/src/tests/ftest/daos_test/daos_core_test.yaml
@@ -149,8 +149,8 @@ daos_tests:
     test_daos_degraded_ec_8to23: X
     test_daos_dedup: U
   args:
-    test_daos_degraded_ec_0to6: -u subtests="0-6"
-    test_daos_degraded_ec_8to23: -u subtests="8-23"
+    test_daos_degraded_ec_0to6: -u subtests="0-6" --csum_type=crc64
+    test_daos_degraded_ec_8to23: -u subtests="8-23" --csum_type=crc64
     test_daos_ec_io: -l"EC_4P2G1"
   scalable_endpoint:
     test_daos_degraded_mode: True


### PR DESCRIPTION
1. add csum support for EC aggregation
   (punch and re-replicate not changed now)
2. fix an IOM handling for EC degraded fetch
3. add "--csum_type=crc64" option to test_daos_degraded_ec test

Signed-off-by: Xuezhao Liu <xuezhao.liu@intel.com>