### PR TITLE
DAOS-7722 engine: adapt pool extend for storage tiering

### DIFF
--- a/src/mgmt/srv_drpc.c
+++ b/src/mgmt/srv_drpc.c
@@ -678,7 +678,8 @@ ds_mgmt_drpc_pool_extend(Drpc__Call *drpc_req, Drpc__Response *drpc_resp)
 	}
 
 	if (req->n_tierbytes == 0 || req->n_tierbytes > DAOS_MEDIA_MAX) {
-		D_ERROR("Invalid number of storage tiers: "DF_U64"\n", req->n_tierbytes);
+		D_ERROR("Invalid number of storage tiers: "DF_U64"\n",
+			req->n_tierbytes);
 		D_GOTO(out, rc = -DER_INVAL);
 	}
 

--- a/src/mgmt/srv_drpc.c
+++ b/src/mgmt/srv_drpc.c
@@ -717,17 +717,8 @@ ds_mgmt_drpc_pool_extend(Drpc__Call *drpc_req, Drpc__Response *drpc_resp)
 	 * In the future, we may need to adjust the allocations somehow and
 	 * this is how we would let the caller know.
 	 */
-	D_ALLOC_ARRAY(resp.tier_bytes, req->n_tierbytes);
-	if (resp.tier_bytes != NULL) {
-		resp.n_tier_bytes = req->n_tierbytes;
-		resp.tier_bytes[DAOS_MEDIA_SCM] = scm_bytes;
-		if (req->n_tierbytes > DAOS_MEDIA_NVME) {
-			resp.tier_bytes[DAOS_MEDIA_NVME] = nvme_bytes;
-		}
-	} else {
-		resp.n_tier_bytes = 0;
-		resp.tier_bytes = NULL;
-	}
+	resp.n_tier_bytes = req->n_tierbytes;
+	resp.tier_bytes = req->tierbytes;
 
 out_list:
 	d_rank_list_free(rank_list);
@@ -745,9 +736,6 @@ out:
 	}
 
 	mgmt__pool_extend_req__free_unpacked(req, &alloc.alloc);
-
-	if (resp.tier_bytes != NULL)
-		D_FREE(resp.tier_bytes);
 }
 
 void

--- a/src/mgmt/srv_drpc.c
+++ b/src/mgmt/srv_drpc.c
@@ -661,6 +661,7 @@ ds_mgmt_drpc_pool_extend(Drpc__Call *drpc_req, Drpc__Response *drpc_resp)
 	uuid_t			uuid;
 	uint8_t			*body;
 	size_t			len;
+	uint64_t		scm_bytes, nvme_bytes = 0;
 	int			rc;
 
 	mgmt__pool_extend_resp__init(&resp);
@@ -674,6 +675,16 @@ ds_mgmt_drpc_pool_extend(Drpc__Call *drpc_req, Drpc__Response *drpc_resp)
 		drpc_resp->status = DRPC__STATUS__FAILED_UNMARSHAL_PAYLOAD;
 		D_ERROR("Failed to unpack req (Extend target)\n");
 		return;
+	}
+
+	if (req->n_tierbytes == 0 || req->n_tierbytes > DAOS_MEDIA_MAX) {
+		D_ERROR("Invalid number of storage tiers: "DF_U64"\n", req->n_tierbytes);
+		D_GOTO(out, rc = -DER_INVAL);
+	}
+
+	scm_bytes = req->tierbytes[DAOS_MEDIA_SCM];
+	if (req->n_tierbytes > DAOS_MEDIA_NVME) {
+		nvme_bytes = req->tierbytes[DAOS_MEDIA_NVME];
 	}
 
 	rc = uuid_parse(req->uuid, uuid);
@@ -692,7 +703,7 @@ ds_mgmt_drpc_pool_extend(Drpc__Call *drpc_req, Drpc__Response *drpc_resp)
 		D_GOTO(out_list, rc = -DER_NOMEM);
 
 	rc = ds_mgmt_pool_extend(uuid, svc_ranks, rank_list, "pmem",
-				 req->scmbytes, req->nvmebytes,
+				 scm_bytes, nvme_bytes,
 				 req->n_faultdomains, req->faultdomains);
 
 	if (rc != 0)
@@ -705,8 +716,17 @@ ds_mgmt_drpc_pool_extend(Drpc__Call *drpc_req, Drpc__Response *drpc_resp)
 	 * In the future, we may need to adjust the allocations somehow and
 	 * this is how we would let the caller know.
 	 */
-	resp.scm_bytes = req->scmbytes;
-	resp.nvme_bytes = req->nvmebytes;
+	D_ALLOC_ARRAY(resp.tier_bytes, req->n_tierbytes);
+	if (resp.tier_bytes != NULL) {
+		resp.n_tier_bytes = req->n_tierbytes;
+		resp.tier_bytes[DAOS_MEDIA_SCM] = scm_bytes;
+		if (req->n_tierbytes > DAOS_MEDIA_NVME) {
+			resp.tier_bytes[DAOS_MEDIA_NVME] = nvme_bytes;
+		}
+	} else {
+		resp.n_tier_bytes = 0;
+		resp.tier_bytes = NULL;
+	}
 
 out_list:
 	d_rank_list_free(rank_list);
@@ -724,6 +744,9 @@ out:
 	}
 
 	mgmt__pool_extend_req__free_unpacked(req, &alloc.alloc);
+
+	if (resp.tier_bytes != NULL)
+		D_FREE(resp.tier_bytes);
 }
 
 void

--- a/src/mgmt/tests/srv_drpc_tests.c
+++ b/src/mgmt/tests/srv_drpc_tests.c
@@ -1564,10 +1564,12 @@ static void
 setup_extend_drpc_call(Drpc__Call *call, char *uuid)
 {
 	Mgmt__PoolExtendReq req = MGMT__POOL_EXTEND_REQ__INIT;
+	uint64_t tierbytes = 1000000000;
 
 	req.uuid = uuid;
 	req.n_ranks = 3;
-	req.scmbytes = 1000000000;
+	req.n_tierbytes = 1;
+	req.tierbytes = &tierbytes;
 	req.ranks = TEST_RANKS;
 	pack_pool_extend_req(call, &req);
 }


### PR DESCRIPTION
Use tierbytes[] in place of scm_bytes and nvme_bytes in context of pool
extend RPC.

Signed-off-by: Lukasz Lasek <lukasz.lasek@intel.com>