### PR TITLE
DAOS-7492 dfuse: Do not set max_read or max_write.

### DIFF
--- a/src/client/dfuse/dfuse.h
+++ b/src/client/dfuse/dfuse.h
@@ -38,8 +38,6 @@ struct dfuse_info {
 
 struct dfuse_projection_info {
 	struct dfuse_info		*dpi_info;
-	uint32_t			dpi_max_read;
-	uint32_t			dpi_max_write;
 	/** Hash table of open inodes, this matches kernel ref counts */
 	struct d_hash_table		dpi_iet;
 	/** Hash table of open pools */

--- a/src/client/dfuse/dfuse_core.c
+++ b/src/client/dfuse/dfuse_core.c
@@ -801,12 +801,6 @@ dfuse_fs_init(struct dfuse_info *dfuse_info,
 
 	fs_handle->dpi_info = dfuse_info;
 
-	/* Max read and max write are handled differently because of the way
-	 * the interception library handles reads vs writes
-	 */
-	fs_handle->dpi_max_read = 1024 * 1024 * 4;
-	fs_handle->dpi_max_write = 1024 * 1024;
-
 	rc = d_hash_table_create_inplace(D_HASH_FT_LRU | D_HASH_FT_EPHEMERAL,
 					 3, fs_handle, &pool_hops,
 					 &fs_handle->dpi_pool_table);
@@ -888,7 +882,7 @@ dfuse_start(struct dfuse_projection_info *fs_handle,
 	struct dfuse_inode_entry	*ie = NULL;
 	int				rc;
 
-	args.argc = 5;
+	args.argc = 4;
 
 	/* These allocations are freed later by libfuse so do not use the
 	 * standard allocation macros
@@ -910,12 +904,8 @@ dfuse_start(struct dfuse_projection_info *fs_handle,
 	if (!args.argv[2])
 		D_GOTO(err, rc = -DER_NOMEM);
 
-	rc = asprintf(&args.argv[3], "-omax_read=%u", fs_handle->dpi_max_read);
-	if (rc < 0 || !args.argv[3])
-		D_GOTO(err, rc = -DER_NOMEM);
-
-	args.argv[4] = strdup("-odefault_permissions");
-	if (!args.argv[4])
+	args.argv[3] = strdup("-odefault_permissions");
+	if (!args.argv[3])
 		D_GOTO(err, rc = -DER_NOMEM);
 
 	fuse_ops = dfuse_get_fuse_ops();

--- a/src/client/dfuse/dfuse_fuseops.c
+++ b/src/client/dfuse/dfuse_fuseops.c
@@ -57,13 +57,6 @@ dfuse_fuse_init(void *arg, struct fuse_conn_info *conn)
 	DFUSE_TRA_INFO(fs_handle, "Proto %d %d", conn->proto_major,
 		       conn->proto_minor);
 
-	/* This value has to be set here to the same value passed to
-	 * register_fuse().  Fuse always sets this value to zero so
-	 * set it before reporting the value.
-	 */
-	conn->max_read = fs_handle->dpi_max_read;
-	conn->max_write = fs_handle->dpi_max_write;
-
 	DFUSE_TRA_INFO(fs_handle, "max read %#x", conn->max_read);
 	DFUSE_TRA_INFO(fs_handle, "max write %#x", conn->max_write);
 	DFUSE_TRA_INFO(fs_handle, "readahead %#x", conn->max_readahead);


### PR DESCRIPTION
Rather than setting a desired value for max_read or max_write
just go with the defaults.

On newer systems this will default to the largest possible size
for read, on older systems this will default to 4k.

This avoids a issue on CentOS 8 where dfuse was requesting
a larger size for perforamnce, however CentOS 8 has a newer
kernel which checks buffer size and a older libfuse which
doesn't, so requesting a larger size on CentOS 8 results
in the kernel rejecting fuse requests.

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>
