### PR TITLE
DAOS-7653 test: Update NLT to not check for dmg return code.

### DIFF
--- a/utils/node_local_test.py
+++ b/utils/node_local_test.py
@@ -599,21 +599,26 @@ class DaosServer():
         }
 
         cmd = ['storage', 'format', '--json']
+        prev_cmd = None
         while True:
-            try:
-                self._sp.wait(timeout=5)
-                res = 'daos server died waiting for start'
-                self._add_test_case('format', failure=res)
-                raise Exception(res)
-            except subprocess.TimeoutExpired:
-                pass
+            # Wait between commands, but only if running the same command as
+            # before.  If the command is different then just run it.
+            # The intention here is to not flood the server/logs with failing
+            # commands in a loop.
+            if cmd == prev_cmd:
+                try:
+                    self._sp.wait(timeout=0.5)
+                    res = 'daos server died waiting for start'
+                    self._add_test_case('format', failure=res)
+                    raise Exception(res)
+                except subprocess.TimeoutExpired:
+                    pass
+            prev_cmd = cmd
             rc = self.run_dmg(cmd)
 
             data = json.loads(rc.stdout.decode('utf-8'))
             print('cmd: {} data: {}'.format(cmd, data))
 
-            if rc.returncode == 0:
-                break
             if data['error'] is not None:
                 resolved = False
                 for res in error_resolutions.values():


### PR DESCRIPTION
A recent change to dmg meant that some commands return with
an exit code of 0 indicating success.  NLT was incorrectly
returning in this case, so was not retrying format commands.

Remove the incorrect check from NLT, and improve timing of
server startup to make it quicker by not waiting so long
between issueing commands.

Quick-build: true

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>
