### PR TITLE
DAOS-7174 pool: coverity fixes

### DIFF
--- a/src/common/tests_dmg_helpers.c
+++ b/src/common/tests_dmg_helpers.c
@@ -488,6 +488,8 @@ dmg_pool_create(const char *dmg_config_file,
 		if (entry != NULL) {
 			args = cmd_push_arg(args, &argcount, "--label=%s ",
 					    entry->dpe_str);
+			if (args == NULL)
+				D_GOTO(out, rc = -DER_NOMEM);
 		}
 	}
 

--- a/src/engine/drpc_client.c
+++ b/src/engine/drpc_client.c
@@ -390,7 +390,12 @@ ds_pool_find_bylabel(d_const_string_t label, uuid_t pool_uuid,
 	if (ranks == NULL)
 		D_GOTO(out_resp, rc = -DER_NOMEM);
 	*svc_ranks = ranks;
-	uuid_parse(frsp->uuid, pool_uuid);
+	rc = uuid_parse(frsp->uuid, pool_uuid);
+	if (rc != 0) {
+		D_ERROR("Unable to parse pool UUID %s: "DF_RC"\n", frsp->uuid,
+			DP_RC(rc));
+		D_GOTO(out_resp, rc = -DER_INVAL);
+	}
 	D_DEBUG(DB_MGMT, "pool %s: UUID="DF_UUID", %u svc replicas\n",
 		frq.label, DP_UUID(pool_uuid), ranks->rl_nr);
 

--- a/src/engine/drpc_client.c
+++ b/src/engine/drpc_client.c
@@ -385,17 +385,18 @@ ds_pool_find_bylabel(d_const_string_t label, uuid_t pool_uuid,
 		D_GOTO(out_resp, rc = frsp->status);
 	}
 
+	rc = uuid_parse(frsp->uuid, pool_uuid);
+	if (rc != 0) {
+		D_ERROR("Unable to parse pool UUID %s: "DF_RC"\n", frsp->uuid,
+			DP_RC(rc));
+		D_GOTO(out_resp, rc = -DER_IO);
+	}
+
 	ranks = uint32_array_to_rank_list(frsp->svcreps,
 					  frsp->n_svcreps);
 	if (ranks == NULL)
 		D_GOTO(out_resp, rc = -DER_NOMEM);
 	*svc_ranks = ranks;
-	rc = uuid_parse(frsp->uuid, pool_uuid);
-	if (rc != 0) {
-		D_ERROR("Unable to parse pool UUID %s: "DF_RC"\n", frsp->uuid,
-			DP_RC(rc));
-		D_GOTO(out_resp, rc = -DER_INVAL);
-	}
 	D_DEBUG(DB_MGMT, "pool %s: UUID="DF_UUID", %u svc replicas\n",
 		frq.label, DP_UUID(pool_uuid), ranks->rl_nr);
 


### PR DESCRIPTION
CID 331793 - unchecked return of uuid_parse()
CID 331792 - unchecked return of cmd_push_arg()

Signed-off-by: Kenneth Cain <kenneth.c.cain@intel.com>