### PR TITLE
DAOS-1457 Tests: Add nvme tag to avocado tests that are worth running on SSDs

### DIFF
--- a/src/tests/ftest/aggregation/aggregation_basic.py
+++ b/src/tests/ftest/aggregation/aggregation_basic.py
@@ -55,6 +55,7 @@ class DaosAggregationBasic(IorTestBase):
 
         :avocado: tags=all,pr,daily_regression
         :avocado: tags=hw,large
+        :avocado: tags=nvme,pmem
         :avocado: tags=aggregate,daosio,mpich
         :avocado: tags=aggregatebasic
         :avocado: tags=DAOS_5610

--- a/src/tests/ftest/aggregation/aggregation_checksum.py
+++ b/src/tests/ftest/aggregation/aggregation_checksum.py
@@ -39,6 +39,7 @@ class AggregationChecksum(IorTestBase):
             option enabled.
         :avocado: tags=all,pr,daily_regression
         :avocado: tags=hw,small
+        :avocado: tags=nvme
         :avocado: tags=daosio,checksum,mpich
         :avocado: tags=aggregationchecksum
         """

--- a/src/tests/ftest/aggregation/aggregation_io_small.py
+++ b/src/tests/ftest/aggregation/aggregation_io_small.py
@@ -30,7 +30,10 @@ class DaosAggregationIOSmall(IorTestBase):
             and verify the data is initially written into SCM and later
             moved to SSD NV DIMMs.
 
-        :avocado: tags=all,full_regression,hw,large,aggregate,daosio
+        :avocado: tags=all,full_regression
+        :avocado: tags=hw,large
+        :avocado: tags=nvme,pmem
+        :avocado: tags=aggregate,daosio
         :avocado: tags=aggregateiosmall
         """
         # Create pool and container

--- a/src/tests/ftest/aggregation/aggregation_punching.py
+++ b/src/tests/ftest/aggregation/aggregation_punching.py
@@ -30,6 +30,7 @@ class AggregationPunching(MdtestBase):
 
         :avocado: tags=all,pr,daily_regression
         :avocado: tags=hw,medium,ib2
+        :avocado: tags=nvme,pmem
         :avocado: tags=aggregation,mdtest,mpich
         :avocado: tags=aggregatepunching
         """

--- a/src/tests/ftest/aggregation/aggregation_throttling.py
+++ b/src/tests/ftest/aggregation/aggregation_throttling.py
@@ -40,7 +40,11 @@ class DaosAggregationThrottling(IorTestBase):
             Also, verify the aggregation reclaimed the space used by
             second ior.
 
-        :avocado: tags=all,hw,large,full_regression,aggregate,daosio
+        :avocado: tags=all,full_regression
+        :avocado: tags=hw,large
+        :avocado: tags=nvme,pmem
+        :avocado: tags=performance
+        :avocado: tags=aggregate,daosio
         :avocado: tags=aggregatethrottling
         """
 

--- a/src/tests/ftest/aggregation/dfuse_space_check.py
+++ b/src/tests/ftest/aggregation/dfuse_space_check.py
@@ -89,7 +89,12 @@ class DfuseSpaceCheck(IorTestBase):
             return all the space back.
             Now create small files again until pool is out of space and check,
             whether out of space happens at the same file count as before.
-        :avocado: tags=all,hw,daosio,small,full_regression,dfusespacecheck
+
+        :avocado: tags=all,full_regression
+        :avocado: tags=hw,small
+        :avocado: tags=nvme
+        :avocado: tags=daosio
+        :avocado: tags=dfusespacecheck
         """
         # get test params for cont and pool count
         self.block_size = self.params.get("block_size",

--- a/src/tests/ftest/checksum/csum_error_logging.py
+++ b/src/tests/ftest/checksum/csum_error_logging.py
@@ -87,6 +87,7 @@ class CSumErrorLog(DaosCoreBase):
                           pool/container disconnect/reconnect.
         :avocado: tags=all,daily_regression
         :avocado: tags=hw,medium,ib2
+        :avocado: tags=nvme,pmem
         :avocado: tags=checksum,faults
         :avocado: tags=csum_error_log
         """

--- a/src/tests/ftest/container/autotest.py
+++ b/src/tests/ftest/container/autotest.py
@@ -20,6 +20,7 @@ class ContainerAutotestTest(TestWithServers):
 
         :avocado: tags=all,full_regression,daily_regression
         :avocado: tags=hw,small
+        :avocado: tags=nvme
         :avocado: tags=container,autotest,containerautotest,quick
         """
         self.log.info("Create a pool")

--- a/src/tests/ftest/container/multiple_container_delete.py
+++ b/src/tests/ftest/container/multiple_container_delete.py
@@ -30,7 +30,10 @@ class MultipleContainerDelete(IorTestBase):
             times.
             Verify both the SCM and SSD pool spaces are recovered
 
-        :avocado: tags=all,hw,large,full_regression,container
+        :avocado: tags=all,full_regression
+        :avocado: tags=hw,large
+        :avocado: tags=nvme,pmem
+        :avocado: tags=container
         :avocado: tags=multicontainerdelete
         """
 

--- a/src/tests/ftest/container/root_container_test.py
+++ b/src/tests/ftest/container/root_container_test.py
@@ -86,7 +86,10 @@ class RootContainerTest(DfuseTestBase):
             Test the above procedure with 100 sub containers.
             Test the above procedure with 5 pools and 50 containers
             spread across the pools.
-        :avocado: tags=all,hw,small,full_regression,container
+        :avocado: tags=all,full_regression
+        :avocado: tags=hw,small
+        :avocado: tags=pmem
+        :avocado: tags=container
         :avocado: tags=rootcontainer
         """
         # Create a pool and start dfuse.

--- a/src/tests/ftest/container/snapshot_aggregation.py
+++ b/src/tests/ftest/container/snapshot_aggregation.py
@@ -43,7 +43,10 @@ class SnapshotAggregation(IorTestBase):
             the writes and confirm that deleting the snapshot reduces the pool
             capacity by half.
 
-        :avocado: tags=all,pr,daily_regression,hw,large,container,snapshot
+        :avocado: tags=all,pr,daily_regression
+        :avocado: tags=hw,large
+        :avocado: tags=nvme,pmem
+        :avocado: tags=container,snapshot
         :avocado: tags=snapshot_aggregation
         """
         self.dmg = self.get_dmg_command()

--- a/src/tests/ftest/control/daos_admin_privileged.py
+++ b/src/tests/ftest/control/daos_admin_privileged.py
@@ -31,7 +31,10 @@ class DaosAdminPrivTest(TestWithServers):
             Test daos_admin functionality to perform format privileged
             operations while daos_server is run as normal user.
 
-        :avocado: tags=all,pr,daily_regression,hw,small,daos_admin,basic
+        :avocado: tags=all,pr,daily_regression
+        :avocado: tags=hw,small
+        :avocado: tags=pmem
+        :avocado: tags=daos_admin,basic
         """
         # Verify that daos_admin has the correct permissions
         self.log.info("Checking daos_admin binary permissions")

--- a/src/tests/ftest/control/daos_scm_config.py
+++ b/src/tests/ftest/control/daos_scm_config.py
@@ -46,7 +46,10 @@ class SCMConfigTest(TestWithServers):
         Test Description: Verify that an attempt to configure devices that have
         already been configured and are in use by DAOS fails.
 
-        :avocado: tags=all,small,pr,daily_regression,hw,scm_in_use,basic
+        :avocado: tags=all,pr,daily_regression
+        :avocado: tags=nvme,pmem
+        :avocado: tags=hw,small
+        :avocado: tags=scm_in_use,basic
         """
         # Create pool and container
         self.prepare_pool()

--- a/src/tests/ftest/control/dmg_pool_query_test.py
+++ b/src/tests/ftest/control/dmg_pool_query_test.py
@@ -54,6 +54,7 @@ class DmgPoolQueryTest(ControlTestBase, IorTestBase):
 
         :avocado: tags=all,daily_regression
         :avocado: tags=small,hw
+        :avocado: tags=nvme,pmem
         :avocado: tags=dmg,pool_query,basic
         :avocado: tags=pool_query_basic
         """
@@ -124,6 +125,7 @@ class DmgPoolQueryTest(ControlTestBase, IorTestBase):
 
         :avocado: tags=all,daily_regression
         :avocado: tags=small,hw
+        :avocado: tags=nvme,pmem
         :avocado: tags=dmg,pool_query,basic
         :avocado: tags=pool_query_inputs
         """
@@ -171,6 +173,7 @@ class DmgPoolQueryTest(ControlTestBase, IorTestBase):
 
         :avocado: tags=all,daily_regression
         :avocado: tags=small,hw
+        :avocado: tags=nvme,pmem
         :avocado: tags=dmg,pool_query,basic
         :avocado: tags=pool_query_write
         """

--- a/src/tests/ftest/control/dmg_storage_query.py
+++ b/src/tests/ftest/control/dmg_storage_query.py
@@ -74,7 +74,10 @@ class DmgStorageQuery(ControlTestBase):
 
         Test Description: Test 'dmg storage query list-pools' command.
 
-        :avocado: tags=all,daily_regression,hw,small,storage_query_pools,basic
+        :avocado: tags=all,daily_regression
+        :avocado: tags=hw,small
+        :avocado: tags=nvme
+        :avocado: tags=storage_query_pools,basic
         :avocado: tags=dmg
         """
         # Create pool and get the storage smd information, then verfify info
@@ -111,7 +114,10 @@ class DmgStorageQuery(ControlTestBase):
 
         Test Description: Test 'dmg storage query list-devices --health' cmd.
 
-        :avocado: tags=all,daily_regression,hw,small,storage_query_health,basic
+        :avocado: tags=all,daily_regression
+        :avocado: tags=hw,small
+        :avocado: tags=nvme
+        :avocado: tags=storage_query_health,basic
         """
         dmg_info = self.get_device_info(health=True)
 
@@ -148,7 +154,10 @@ class DmgStorageQuery(ControlTestBase):
         In addition this test also does a basic test of nvme-faulty cmd:
         'dmg storage set nvme-faulty'
 
-        :avocado: tags=all,daily_regression,hw,small,storage_query_faulty,basic
+        :avocado: tags=all,daily_regression
+        :avocado: tags=hw,small
+        :avocado: tags=nvme
+        :avocado: tags=storage_query_faulty,basic
         """
         # Get device info and check state is NORMAL
         devs_info = self.get_device_info()

--- a/src/tests/ftest/control/dmg_system_reformat.py
+++ b/src/tests/ftest/control/dmg_system_reformat.py
@@ -29,7 +29,10 @@ class DmgSystemReformatTest(PoolTestBase):
 
         Test Description: Test dmg system reformat functionality.
 
-        :avocado: tags=all,small,daily_regression,hw,control,sys_reformat,dmg
+        :avocado: tags=all,daily_regression
+        :avocado: tags=hw,small
+        :avocado: tags=nvme
+        :avocado: tags=control,sys_reformat,dmg
         """
         # Create pool using 90% of the available SCM capacity
         self.pool = self.get_pool_list(1, None, 0.9)


### PR DESCRIPTION
Added nvme,pmem and performance tags to the appropiate tests
based on their yaml configuration.

Signed-off-by: Omar Ocampo <omar.ocampo.coronado@intel.com>
Features: nvme pmem performance