### PR TITLE
DAOS-7157 test: datamover refactor

### DIFF
--- a/src/tests/ftest/datamover/dm_dst_create.yaml
+++ b/src/tests/ftest/datamover/dm_dst_create.yaml
@@ -37,5 +37,3 @@ dcp:
             daos_api: DAOS
     client_processes:
         np: 3
-dfuse:
-    mount_dir: "/tmp/daos_dfuse"

--- a/src/tests/ftest/datamover/dm_large_dir.py
+++ b/src/tests/ftest/datamover/dm_large_dir.py
@@ -108,7 +108,7 @@ class DmLargeDir(DataMoverTestBase):
             an external POSIX file system using dcp.
         :avocado: tags=all,full_regression
         :avocado: tags=hw,large
-        :avocado: tags=datamover,dcp
+        :avocado: tags=datamover,dcp,dfuse
         :avocado: tags=dm_large_dir,dm_large_dir_dcp
         """
         self.run_dm_large_dir("DCP")

--- a/src/tests/ftest/datamover/dm_large_dir.yaml
+++ b/src/tests/ftest/datamover/dm_large_dir.yaml
@@ -52,6 +52,7 @@ mdtest:
   bytes: 4096
 dfuse:
   mount_dir: "/tmp/daos_dfuse/"
+  disable_caching: True
 dcp:
   client_processes:
     np: 16

--- a/src/tests/ftest/datamover/dm_large_file.py
+++ b/src/tests/ftest/datamover/dm_large_file.py
@@ -101,7 +101,7 @@ class DmPosixLargeFile(DataMoverTestBase):
             an external POSIX file system using dcp.
         :avocado: tags=all,full_regression
         :avocado: tags=hw,large
-        :avocado: tags=datamover,dcp
+        :avocado: tags=datamover,dcp,dfuse
         :avocado: tags=dm_large_file,dm_large_file_dcp
         """
         self.run_dm_large_file("DCP")
@@ -113,7 +113,7 @@ class DmPosixLargeFile(DataMoverTestBase):
             an external POSIX file system using daos filesystem copy.
         :avocado: tags=all,full_regression
         :avocado: tags=hw,large
-        :avocado: tags=datamover,fs_copy
+        :avocado: tags=datamover,fs_copy,dfuse
         :avocado: tags=dm_large_file,dm_large_file_fs_copy
         """
         self.run_dm_large_file("FS_COPY")

--- a/src/tests/ftest/datamover/dm_large_file.yaml
+++ b/src/tests/ftest/datamover/dm_large_file.yaml
@@ -47,6 +47,7 @@ ior:
       dfs_oclass: "SX"
 dfuse:
   mount_dir: "/tmp/daos_dfuse/"
+  disable_caching: True
 dcp:
   bufsize: "64MB"
   chunksize: "128MB"

--- a/src/tests/ftest/datamover/dm_negative.py
+++ b/src/tests/ftest/datamover/dm_negative.py
@@ -49,7 +49,7 @@ class DmNegativeTest(DataMoverTestBase):
             (3) Bad parameter: daos-prefix is invalid.
             (4) Bad parameter: UUID, UNS, or POSIX path is invalid.
         :avocado: tags=all,full_regression
-        :avocado: tags=datamover,dcp
+        :avocado: tags=datamover,dcp,dfuse
         :avocado: tags=dm_negative,dm_bad_params_dcp
         """
         self.set_tool("DCP")
@@ -249,7 +249,7 @@ class DmNegativeTest(DataMoverTestBase):
             DAOS-5515: destination pool does not have enough space.
             DAOS-6387: posix filesystem does not have enough space.
         :avocado: tags=all,full_regression
-        :avocado: tags=datamover,dcp
+        :avocado: tags=datamover,dcp,dfuse
         :avocado: tags=dm_negative,dm_negative_space_dcp
         """
         self.set_tool("DCP")

--- a/src/tests/ftest/datamover/dm_obj_small.py
+++ b/src/tests/ftest/datamover/dm_obj_small.py
@@ -118,7 +118,7 @@ class DmObjSmallTest(DataMoverTestBase):
         """
         Test Description:
             DAOS-6858: Verify cloning a small container.
-        :avocado: tags=all,weekly_regression
+        :avocado: tags=all,full_regression
         :avocado: tags=datamover,dcp
         :avocado: tags=dm_obj_small,dm_obj_small_dcp
         """

--- a/src/tests/ftest/datamover/dm_posix_meta_entry.py
+++ b/src/tests/ftest/datamover/dm_posix_meta_entry.py
@@ -23,7 +23,7 @@ class DmPosixMetaEntry(DataMoverTestBase):
         Test Description:
             Verifies that POSIX metadata is preserved for dcp.
         :avocado: tags=all,full_regression
-        :avocado: tags=datamover,dcp
+        :avocado: tags=datamover,dcp,dfuse
         :avocado: tags=dm_posix_meta_entry,dm_posix_meta_entry_dcp
         """
         self.run_dm_posix_meta_entry("DCP")

--- a/src/tests/ftest/datamover/dm_posix_meta_entry.yaml
+++ b/src/tests/ftest/datamover/dm_posix_meta_entry.yaml
@@ -24,3 +24,4 @@ dcp:
             preserve: true
 dfuse:
     mount_dir: "/tmp/daos_dfuse"
+    disable_caching: True

--- a/src/tests/ftest/datamover/dm_posix_subsets.py
+++ b/src/tests/ftest/datamover/dm_posix_subsets.py
@@ -135,7 +135,7 @@ class DmPosixSubsetsTest(DataMoverTestBase):
             Tests copying POSIX container subsets with dcp.
             DAOS-5512: Verify ability to copy container subsets
         :avocado: tags=all,full_regression
-        :avocado: tags=datamover,dcp
+        :avocado: tags=datamover,dcp,dfuse
         :avocado: tags=dm_posix_subsets,dm_posix_subsets_dcp
         """
         self.run_dm_posix_subsets("DCP")
@@ -146,7 +146,7 @@ class DmPosixSubsetsTest(DataMoverTestBase):
         Tests copying POSIX container subsets with fs copy.
             DAOS-6752: daos fs copy improvements
         :avocado: tags=all,daily_regression
-        :avocado: tags=datamover,fs_copy
+        :avocado: tags=datamover,fs_copy,dfuse
         :avocado: tags=dm_posix_subsets,dm_posix_subsets_fs_copy
         """
         self.run_dm_posix_subsets("FS_COPY")

--- a/src/tests/ftest/datamover/dm_posix_symlinks.py
+++ b/src/tests/ftest/datamover/dm_posix_symlinks.py
@@ -22,7 +22,7 @@ class DmPosixSymlinks(DataMoverTestBase):
         Test Description:
             Tests copying POSIX symlinks with dcp.
         :avocado: tags=all,full_regression
-        :avocado: tags=datamover,dcp
+        :avocado: tags=datamover,dcp,dfuse
         :avocado: tags=dm_posix_symlinks,dm_posix_symlinks_dcp
         """
         self.run_dm_posix_symlinks("DCP")

--- a/src/tests/ftest/datamover/dm_posix_types.py
+++ b/src/tests/ftest/datamover/dm_posix_types.py
@@ -228,7 +228,7 @@ class DmPosixTypesTest(DataMoverTestBase):
             DAOS-5508: Verify copy between POSIX, UUIDs, and UNS paths.
             Daos-5511: Verify copy across pools.
         :avocado: tags=all,full_regression
-        :avocado: tags=datamover,dcp
+        :avocado: tags=datamover,dcp,dfuse
         :avocado: tags=dm_posix_types,dm_posix_types_dcp
         """
         self.run_dm_posix_types("DCP")
@@ -238,8 +238,8 @@ class DmPosixTypesTest(DataMoverTestBase):
         Test Description:
             Tests POSIX copies with dsync using different src and dst types.
             DAOS-6389: add basic tests for dsync posix
-        :avocado: tags=all,daily_regression
-        :avocado: tags=datamover,dsync
+        :avocado: tags=all,full_regression
+        :avocado: tags=datamover,dsync,dfuse
         :avocado: tags=dm_posix_types,dm_posix_types_dsync
         """
         self.run_dm_posix_types("DSYNC")
@@ -251,7 +251,7 @@ class DmPosixTypesTest(DataMoverTestBase):
             src and dst types.
             DAOS-6233: add tests for daos filesystem copy
         :avocado: tags=all,daily_regression
-        :avocado: tags=datamover,fs_copy
+        :avocado: tags=datamover,fs_copy,dfuse
         :avocado: tags=dm_posix_types,dm_posix_types_fs_copy
         """
         self.run_dm_posix_types("FS_COPY")

--- a/src/tests/ftest/datamover/dm_posix_types.yaml
+++ b/src/tests/ftest/datamover/dm_posix_types.yaml
@@ -3,7 +3,7 @@ hosts:
         - server-A
     test_clients:
         - server-B
-timeout: 300
+timeout: 270
 server_config:
     name: daos_server
 pool:

--- a/src/tests/ftest/datamover/dm_serial_large_posix.py
+++ b/src/tests/ftest/datamover/dm_serial_large_posix.py
@@ -80,7 +80,7 @@ class DmSerialLargePosix(DataMoverTestBase):
             DAOS-7432: Verify serializing a large POSIX container.
         :avocado: tags=all,full_regression
         :avocado: tags=hw,large
-        :avocado: tags=datamover,dserialize
+        :avocado: tags=datamover,dserialize,dfuse
         :avocado: tags=dm_serial_large_posix,dm_serial_large_posix_dserialize
         """
         self.run_dm_serial_large_posix("DSERIAL")

--- a/src/tests/ftest/datamover/dm_serial_large_posix.yaml
+++ b/src/tests/ftest/datamover/dm_serial_large_posix.yaml
@@ -51,3 +51,4 @@ ddeserialize:
     np: 16
 dfuse:
   mount_dir: "/tmp/daos_dfuse/"
+  disable_caching: True

--- a/src/tests/ftest/datamover/dm_serial_small.py
+++ b/src/tests/ftest/datamover/dm_serial_small.py
@@ -99,7 +99,7 @@ class DmSerialSmallTest(DataMoverTestBase):
         """
         Test Description:
             DAOS-6875: Verify serializing a small container.
-        :avocado: tags=all,weekly_regression
+        :avocado: tags=all,daily_regression
         :avocado: tags=datamover,dserialize
         :avocado: tags=dm_serial_small,dm_serial_small_dserialize
         """


### PR DESCRIPTION
- Added base class for mpifileutils commands.
- Added generic set_params function for all mfu commands.
- Removed old compatibility support for DcpCommand.

Signed-off-by: Dalton Bohning <daltonx.bohning@intel.com>