### PR TITLE
DAOS-7669 Reduce third-party jar dependencies to avoid potential jar conflict

### DIFF
--- a/doc/user/spark.md
+++ b/doc/user/spark.md
@@ -14,7 +14,7 @@ to access DAOS from Hadoop and Spark.
 
 1. Linux OS
 2. Java 8
-3. Hadoop 3.2 or later
+3. Hadoop 2.7 or later
 4. Spark 3.1 or later
 5. DAOS Readiness
 We assume that the DAOS servers and agents have already been deployed in the

--- a/src/client/java/daos-java/pom.xml
+++ b/src/client/java/daos-java/pom.xml
@@ -34,10 +34,6 @@
       <artifactId>log4j-core</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-lang3</artifactId>
-    </dependency>
-    <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
       <version>3.11.4</version>

--- a/src/client/java/daos-java/src/main/java/io/daos/DaosClient.java
+++ b/src/client/java/daos-java/src/main/java/io/daos/DaosClient.java
@@ -7,7 +7,6 @@
 package io.daos;
 
 import io.daos.dfs.*;
-import org.apache.commons.lang3.ObjectUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -420,7 +419,12 @@ public class DaosClient implements ForceCloseable {
       if (poolId == null) {
         throw new IllegalArgumentException("need pool UUID");
       }
-      DaosClient client = new DaosClient((DaosClientBuilder) ObjectUtils.clone(this));
+      DaosClient client;
+      try {
+        client = new DaosClient(clone());
+      } catch (CloneNotSupportedException ce) {
+        throw new IllegalStateException("clone not supported.", ce);
+      }
       client.init();
       return client;
     }

--- a/src/client/java/daos-java/src/main/java/io/daos/DaosUtils.java
+++ b/src/client/java/daos-java/src/main/java/io/daos/DaosUtils.java
@@ -7,7 +7,6 @@
 package io.daos;
 
 import io.daos.dfs.StatAttributes;
-import org.apache.commons.lang3.StringUtils;
 
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -103,10 +102,26 @@ public final class DaosUtils {
    * @return escaped value
    */
   public static String escapeUnsValue(String value) {
-    if (StringUtils.isBlank(value)) {
+    if (isBlankStr(value)) {
       return value;
     }
     value = value.replaceAll(":", "\\\\u003a");
     return value.replaceAll("=", "\\\\u003d");
+  }
+
+  public static String unEscapeUnsValue(String value) {
+    if (isBlankStr(value)) {
+      return value;
+    }
+    value = value.replaceAll("\\\\u003a", ":");
+    return value.replaceAll("\\\\u003d", "=");
+  }
+
+  public static boolean isEmptyStr(String value) {
+    return value == null || value.length() == 0;
+  }
+
+  public static boolean isBlankStr(String value) {
+    return value == null || value.trim().length() == 0;
   }
 }

--- a/src/client/java/daos-java/src/main/java/io/daos/dfs/DaosFsClient.java
+++ b/src/client/java/daos-java/src/main/java/io/daos/dfs/DaosFsClient.java
@@ -13,7 +13,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 import io.daos.*;
-import org.apache.commons.lang3.ObjectUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -1074,7 +1073,12 @@ public final class DaosFsClient extends ShareableClient implements ForceCloseabl
     public DaosFsClient build() throws IOException {
       String poolId = getPoolId();
       String contId = getContId();
-      DaosFsClientBuilder builder = (DaosFsClientBuilder) ObjectUtils.clone(this);
+      DaosFsClientBuilder builder;
+      try {
+        builder = clone();
+      } catch (CloneNotSupportedException e) {
+        throw new IllegalStateException("clone not supported.", e);
+      }
       DaosFsClient fsClient;
       if (!builder.shareFsClient) {
         fsClient = new DaosFsClient(poolId, contId, builder);

--- a/src/client/java/daos-java/src/main/java/io/daos/dfs/DaosUns.java
+++ b/src/client/java/daos-java/src/main/java/io/daos/dfs/DaosUns.java
@@ -17,8 +17,6 @@ import com.google.protobuf.TextFormat;
 import io.daos.*;
 import io.daos.dfs.uns.*;
 
-import org.apache.commons.lang3.ObjectUtils;
-import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -126,7 +124,7 @@ public class DaosUns {
    * {@link DaosIOException}
    */
   public static void setAppInfo(String path, String attrName, String value) throws IOException {
-    if (StringUtils.isBlank(attrName)) {
+    if (DaosUtils.isBlankStr(attrName)) {
       throw new IllegalArgumentException("attribute name cannot be empty");
     }
     if (!attrName.startsWith("user.")) {
@@ -154,7 +152,7 @@ public class DaosUns {
    * {@link DaosIOException}
    */
   public static String getAppInfo(String path, String attrName, int maxValueLen) throws IOException {
-    if (StringUtils.isBlank(attrName)) {
+    if (DaosUtils.isBlankStr(attrName)) {
       throw new IllegalArgumentException("attribute name cannot be empty");
     }
     if (!attrName.startsWith("user.")) {
@@ -476,7 +474,11 @@ public class DaosUns {
         throw new IllegalArgumentException("layout should be posix or HDF5");
       }
       DaosUns duns = new DaosUns();
-      duns.builder = (DaosUnsBuilder) ObjectUtils.clone(this);
+      try {
+        duns.builder = clone();
+      } catch (CloneNotSupportedException e) {
+        throw new IllegalStateException("clone not supported.", e);
+      }
       buildAttribute(duns);
       return duns;
     }
@@ -660,7 +662,7 @@ public class DaosUns {
 
   private static void util() {
     String op = System.getProperty("op");
-    if (StringUtils.isBlank(op)) {
+    if (DaosUtils.isBlankStr(op)) {
       throw new IllegalArgumentException("need operation type.\n" + getUsage());
     }
     switch (op) {
@@ -704,7 +706,7 @@ public class DaosUns {
 
   private static void getPropertyValueType() {
     String type = System.getProperty("prop_type");
-    if (StringUtils.isBlank(type)) {
+    if (DaosUtils.isBlankStr(type)) {
       throw new IllegalArgumentException("need property type.\n" + getUsage());
     }
     log.info("property value type is: " + PropValue.getValueClass(PropType.valueOf(type)));
@@ -723,7 +725,7 @@ public class DaosUns {
 
   private static void escapeAppValue() {
     String input = System.getProperty("input");
-    if (StringUtils.isBlank(input)) {
+    if (DaosUtils.isBlankStr(input)) {
       throw new IllegalArgumentException("need input.\n" + getUsage());
     }
     log.info("escaped value is: " + DaosUtils.escapeUnsValue(input));
@@ -838,10 +840,10 @@ public class DaosUns {
     String serverGrp = System.getProperty("server_group");
     String poolFlags = System.getProperty("pool_flags");
 
-    if (StringUtils.isBlank(path)) {
+    if (DaosUtils.isBlankStr(path)) {
       throw new IllegalArgumentException("need path, -Dpath=");
     }
-    if (StringUtils.isBlank(poolId)) {
+    if (DaosUtils.isBlankStr(poolId)) {
       throw new IllegalArgumentException("need pool UUID, -Dpool_id");
     }
 
@@ -850,13 +852,13 @@ public class DaosUns {
     builder.path(file.getAbsolutePath());
     builder.poolId(poolId);
 
-    if (!StringUtils.isBlank(ranks)) {
+    if (!DaosUtils.isBlankStr(ranks)) {
       builder.ranks(ranks);
     }
-    if (!StringUtils.isBlank(serverGrp)) {
+    if (!DaosUtils.isBlankStr(serverGrp)) {
       builder.serverGroup(serverGrp);
     }
-    if (!StringUtils.isBlank(poolFlags)) {
+    if (!DaosUtils.isBlankStr(poolFlags)) {
       builder.poolFlags(Integer.valueOf(poolFlags));
     }
 
@@ -882,10 +884,10 @@ public class DaosUns {
     String poolFlags = System.getProperty("pool_flags");
     String properties = System.getProperty("properties");
 
-    if (StringUtils.isBlank(path)) {
+    if (DaosUtils.isBlankStr(path)) {
       throw new IllegalArgumentException("need path, -Dpath=");
     }
-    if (StringUtils.isBlank(poolId)) {
+    if (DaosUtils.isBlankStr(poolId)) {
       throw new IllegalArgumentException("need pool UUID, -Dpool_id");
     }
 
@@ -893,31 +895,31 @@ public class DaosUns {
     DaosUns.DaosUnsBuilder builder = new DaosUns.DaosUnsBuilder();
     builder.path(file.getAbsolutePath());
     builder.poolId(poolId);
-    if (!StringUtils.isBlank(contId)) {
+    if (!DaosUtils.isBlankStr(contId)) {
       builder.containerId(contId);
     }
-    if (!StringUtils.isBlank(layout)) {
+    if (!DaosUtils.isBlankStr(layout)) {
       builder.layout(Layout.valueOf(layout));
     }
-    if (!StringUtils.isBlank(objectType)) {
+    if (!DaosUtils.isBlankStr(objectType)) {
       builder.objectType(DaosObjectType.valueOf(objectType));
     }
-    if (!StringUtils.isBlank(chunkSize)) {
+    if (!DaosUtils.isBlankStr(chunkSize)) {
       builder.chunkSize(Long.valueOf(chunkSize));
     }
-    if (!StringUtils.isBlank(onLustre)) {
+    if (!DaosUtils.isBlankStr(onLustre)) {
       builder.onLustre(Boolean.valueOf(onLustre));
     }
-    if (!StringUtils.isBlank(ranks)) {
+    if (!DaosUtils.isBlankStr(ranks)) {
       builder.ranks(ranks);
     }
-    if (!StringUtils.isBlank(serverGrp)) {
+    if (!DaosUtils.isBlankStr(serverGrp)) {
       builder.serverGroup(serverGrp);
     }
-    if (!StringUtils.isBlank(poolFlags)) {
+    if (!DaosUtils.isBlankStr(poolFlags)) {
       builder.poolFlags(Integer.valueOf(poolFlags));
     }
-    if (!StringUtils.isBlank(properties)) {
+    if (!DaosUtils.isBlankStr(properties)) {
       Properties.Builder pb = Properties.newBuilder();
       try {
         TextFormat.getParser().merge(properties, pb);

--- a/src/client/java/daos-java/src/main/java/io/daos/obj/DaosObjClient.java
+++ b/src/client/java/daos-java/src/main/java/io/daos/obj/DaosObjClient.java
@@ -7,7 +7,6 @@
 package io.daos.obj;
 
 import io.daos.*;
-import org.apache.commons.lang3.ObjectUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -420,7 +419,12 @@ public class DaosObjClient extends ShareableClient implements ForceCloseable {
     public DaosObjClient build() throws IOException {
       String poolId = getPoolId();
       String contId = getContId();
-      DaosObjClientBuilder builder = (DaosObjClientBuilder) ObjectUtils.clone(this);
+      DaosObjClientBuilder builder;
+      try {
+        builder = clone();
+      } catch (CloneNotSupportedException e) {
+        throw new IllegalStateException("clone not supported", e);
+      }
       DaosObjClient objClient;
       if (!builder.shareFsClient) {
         objClient = new DaosObjClient(poolId, contId, builder);

--- a/src/client/java/daos-java/src/main/java/io/daos/obj/DaosObject.java
+++ b/src/client/java/daos-java/src/main/java/io/daos/obj/DaosObject.java
@@ -7,13 +7,9 @@
 package io.daos.obj;
 
 import com.google.protobuf.InvalidProtocolBufferException;
-import io.daos.BufferAllocator;
-import io.daos.Constants;
-import io.daos.DaosEventQueue;
-import io.daos.DaosIOException;
+import io.daos.*;
 import io.daos.obj.attr.DaosObjectAttribute;
 import io.netty.buffer.ByteBuf;
-import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -124,7 +120,7 @@ public class DaosObject {
     int bufferLen = 0;
     List<byte[]> keyBytesList = new ArrayList<>(keys.size());
     for (String key : keys) {
-      if (StringUtils.isBlank(key)) {
+      if (DaosUtils.isBlankStr(key)) {
         throw new IllegalArgumentException("one of akey is blank");
       }
       byte bytes[];
@@ -469,7 +465,7 @@ public class DaosObject {
    */
   public List<String> listAkeys(IOKeyDesc desc) throws DaosObjectException {
     checkOpen();
-    if (StringUtils.isBlank(desc.getDkey())) {
+    if (DaosUtils.isBlankStr(desc.getDkey())) {
       throw new DaosObjectException(oid, "dkey is needed when list akeys");
     }
     desc.encode();
@@ -503,10 +499,10 @@ public class DaosObject {
    */
   public int getRecordSize(String dkey, String akey) throws DaosObjectException {
     checkOpen();
-    if (StringUtils.isBlank(dkey)) {
+    if (DaosUtils.isBlankStr(dkey)) {
       throw new IllegalArgumentException("dkey is blank");
     }
-    if (StringUtils.isBlank(akey)) {
+    if (DaosUtils.isBlankStr(akey)) {
       throw new IllegalArgumentException("akey is blank");
     }
     byte dkeyBytes[];

--- a/src/client/java/daos-java/src/main/java/io/daos/obj/IODataDescSync.java
+++ b/src/client/java/daos-java/src/main/java/io/daos/obj/IODataDescSync.java
@@ -8,8 +8,8 @@ package io.daos.obj;
 
 import io.daos.BufferAllocator;
 import io.daos.Constants;
+import io.daos.DaosUtils;
 import io.netty.buffer.ByteBuf;
-import org.apache.commons.lang3.StringUtils;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
@@ -561,7 +561,7 @@ public class IODataDescSync extends IODataDescBase {
      */
     private SyncEntry(String key, long offset, int dataSize)
         throws IOException {
-      if (StringUtils.isBlank(key)) {
+      if (DaosUtils.isBlankStr(key)) {
         throw new IllegalArgumentException("key is blank");
       }
       this.key = key;
@@ -731,7 +731,7 @@ public class IODataDescSync extends IODataDescBase {
     }
 
     private void setKey(String akey, long offset, ByteBuf buf, int fetchDataSize) throws UnsupportedEncodingException {
-      if (StringUtils.isBlank(akey)) {
+      if (DaosUtils.isBlankStr(akey)) {
         throw new IllegalArgumentException("key is blank");
       }
       if (!akey.equals(this.key)) {

--- a/src/client/java/daos-java/src/main/java/io/daos/obj/IOSimpleDDAsync.java
+++ b/src/client/java/daos-java/src/main/java/io/daos/obj/IOSimpleDDAsync.java
@@ -6,12 +6,9 @@
 
 package io.daos.obj;
 
-import io.daos.BufferAllocator;
-import io.daos.Constants;
-import io.daos.DaosEventQueue;
-import io.daos.DaosIOException;
+import io.daos.*;
 import io.netty.buffer.ByteBuf;
-import org.apache.commons.lang3.StringUtils;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -361,7 +358,7 @@ public class IOSimpleDDAsync extends IODataDescBase implements DaosEventQueue.At
      */
     private AsyncEntry(String key, long offset, int dataSize)
         throws IOException {
-      if (StringUtils.isBlank(key)) {
+      if (DaosUtils.isBlankStr(key)) {
         throw new IllegalArgumentException("key is blank");
       }
       this.key = key;

--- a/src/client/java/daos-java/src/test/java/io/daos/DaosClientTest.java
+++ b/src/client/java/daos-java/src/test/java/io/daos/DaosClientTest.java
@@ -1,18 +1,43 @@
 package io.daos;
 
+import io.daos.dfs.DaosFsClient;
+import io.daos.dfs.DaosUns;
+import io.daos.obj.DaosObjClient;
 import org.junit.Assert;
 import org.junit.Test;
+import org.powermock.reflect.Whitebox;
 
 public class DaosClientTest {
 
   @Test
   public void testBuilderClone() throws Exception {
-    DaosClient.DaosClientBuilder builder = new DaosClient.DaosClientBuilder().poolId("pid")
-        .containerId("cid");
+    String pid = "aab99b21-5fba-402d-9ac0-59ce9f34f998";
+    String cid = "70941ff5-44f3-4326-a5ec-b5b237df2f6f";
+    DaosClient.DaosClientBuilder builder = new DaosClient.DaosClientBuilder().poolId(pid)
+        .containerId(cid);
 
     DaosClient.DaosClientBuilder bdCloned = builder.clone();
     Assert.assertNotEquals(builder, bdCloned);
-    Assert.assertEquals(builder.getPoolId(), "pid");
-    Assert.assertEquals(builder.getContId(), "cid");
+    Assert.assertEquals(bdCloned.getPoolId(), pid);
+    Assert.assertEquals(bdCloned.getContId(), cid);
+
+    DaosObjClient.DaosObjClientBuilder bobj = new DaosObjClient.DaosObjClientBuilder().poolId(pid).containerId(cid)
+        .poolFlags(2);
+    DaosObjClient.DaosObjClientBuilder bobjCloned = bobj.clone();
+    Assert.assertEquals(bobjCloned.getPoolId(), pid);
+    Assert.assertEquals(bobjCloned.getContId(), cid);
+    Assert.assertEquals((int)Whitebox.getInternalState(bobjCloned, "poolFlags"), 2);
+
+    DaosFsClient.DaosFsClientBuilder bfs = new DaosFsClient.DaosFsClientBuilder().poolId(pid).containerId(cid)
+        .readOnlyFs(true);
+    DaosFsClient.DaosFsClientBuilder bfsCloned = bfs.clone();
+    Assert.assertEquals(bfsCloned.getPoolId(), pid);
+    Assert.assertEquals(bfsCloned.getContId(), cid);
+    Assert.assertEquals(Whitebox.getInternalState(bfsCloned, "readOnlyFs"), true);
+
+    DaosUns.DaosUnsBuilder buns = new DaosUns.DaosUnsBuilder().poolId(pid).path("/root");
+    DaosUns.DaosUnsBuilder bunsCloned = buns.clone();
+    Assert.assertEquals(Whitebox.getInternalState(bunsCloned, "poolUuid"), pid);
+    Assert.assertEquals(Whitebox.getInternalState(bunsCloned, "path"), "/root");
   }
 }

--- a/src/client/java/daos-java/src/test/java/io/daos/DaosClientTest.java
+++ b/src/client/java/daos-java/src/test/java/io/daos/DaosClientTest.java
@@ -1,0 +1,18 @@
+package io.daos;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class DaosClientTest {
+
+  @Test
+  public void testBuilderClone() throws Exception {
+    DaosClient.DaosClientBuilder builder = new DaosClient.DaosClientBuilder().poolId("pid")
+        .containerId("cid");
+
+    DaosClient.DaosClientBuilder bdCloned = builder.clone();
+    Assert.assertNotEquals(builder, bdCloned);
+    Assert.assertEquals(builder.getPoolId(), "pid");
+    Assert.assertEquals(builder.getContId(), "cid");
+  }
+}

--- a/src/client/java/daos-java/src/test/java/io/daos/DaosUtilsTest.java
+++ b/src/client/java/daos-java/src/test/java/io/daos/DaosUtilsTest.java
@@ -1,6 +1,5 @@
 package io.daos;
 
-import org.apache.commons.lang3.StringEscapeUtils;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -128,6 +127,6 @@ public class DaosUtilsTest {
     String value = "ab:c=:def=";
     String evalue = DaosUtils.escapeUnsValue(value);
     Assert.assertEquals("ab\\u003ac\\u003d\\u003adef\\u003d", evalue);
-    Assert.assertEquals(value, StringEscapeUtils.unescapeJava(evalue));
+    Assert.assertEquals(value, DaosUtils.unEscapeUnsValue(evalue));
   }
 }

--- a/src/client/java/hadoop-daos/src/main/java/io/daos/fs/hadoop/DaosConfigException.java
+++ b/src/client/java/hadoop-daos/src/main/java/io/daos/fs/hadoop/DaosConfigException.java
@@ -1,0 +1,18 @@
+/*
+ * (C) Copyright 2018-2021 Intel Corporation.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause-Patent
+ */
+
+package io.daos.fs.hadoop;
+
+public class DaosConfigException extends RuntimeException {
+
+  public DaosConfigException(String msg) {
+    super(msg);
+  }
+
+  public DaosConfigException(String msg, Throwable e) {
+    super(msg, e);
+  }
+}

--- a/src/client/java/hadoop-daos/src/main/java/io/daos/fs/hadoop/DaosConfigFile.java
+++ b/src/client/java/hadoop-daos/src/main/java/io/daos/fs/hadoop/DaosConfigFile.java
@@ -17,7 +17,7 @@ import java.util.Set;
 
 import javax.xml.parsers.DocumentBuilderFactory;
 
-import org.apache.commons.lang3.StringUtils;
+import io.daos.DaosUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -157,15 +157,15 @@ public class DaosConfigFile {
     setUuid(authority, Constants.DAOS_POOL_UUID, hadoopConfig);
     setUuid(authority, Constants.DAOS_CONTAINER_UUID, hadoopConfig);
     //set other configurations after the UUIDs are set
-    return merge(StringUtils.isEmpty(authority) ? "" : (authority + "."), hadoopConfig, null);
+    return merge(DaosUtils.isEmptyStr(authority) ? "" : (authority + "."), hadoopConfig, null);
   }
 
   private void setUuid(String authority, String configName, Configuration hadoopConfig) {
     String hid = hadoopConfig.get(configName);
-    if (StringUtils.isEmpty(authority)) { // default URI
-      if (StringUtils.isEmpty(hid)) { // make sure UUID is set
+    if (DaosUtils.isEmptyStr(authority)) { // default URI
+      if (DaosUtils.isEmptyStr(hid)) { // make sure UUID is set
         String did = defaultConfig.get(configName);
-        if (StringUtils.isEmpty(did)) {
+        if (DaosUtils.isEmptyStr(did)) {
           throw new IllegalArgumentException(configName + " is neither specified nor default value found.");
         }
         hadoopConfig.set(configName, did);
@@ -173,9 +173,9 @@ public class DaosConfigFile {
       return;
     }
     // non-default
-    if (StringUtils.isEmpty(hid)) { // make sure UUID is set
+    if (DaosUtils.isEmptyStr(hid)) { // make sure UUID is set
       String did = defaultConfig.get(authority + "." + configName) ;
-      if (StringUtils.isEmpty(did)) {
+      if (DaosUtils.isEmptyStr(did)) {
         throw new IllegalArgumentException(configName + " is neither specified nor default value found for authority " +
                 authority);
       }
@@ -200,7 +200,7 @@ public class DaosConfigFile {
       String name = it.next();
       if (excludeProps == null || !excludeProps.contains(name)) {
         if (hadoopConfig.get(name) == null) { //not set by user
-          String value = StringUtils.isEmpty(authority) ? defaultConfig.get(name) :
+          String value = DaosUtils.isEmptyStr(authority) ? defaultConfig.get(name) :
               defaultConfig.get(authority + name, defaultConfig.get(name));
           if (value != null) {
             hadoopConfig.set(name, value);

--- a/src/client/java/hadoop-daos/src/main/java/io/daos/fs/hadoop/DaosConfigFile.java
+++ b/src/client/java/hadoop-daos/src/main/java/io/daos/fs/hadoop/DaosConfigFile.java
@@ -17,7 +17,6 @@ import java.util.Set;
 
 import javax.xml.parsers.DocumentBuilderFactory;
 
-import org.apache.commons.configuration2.ex.ConfigurationException;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.slf4j.Logger;
@@ -80,7 +79,7 @@ public class DaosConfigFile {
         }
       }
       if (targetNode == null) {
-        throw new ConfigurationException("cannot find " + Constants.DAOS_DEFAULT_FS + " node from " + exampleFile);
+        throw new DaosConfigException("cannot find " + Constants.DAOS_DEFAULT_FS + " node from " + exampleFile);
       }
       Element desc = (Element)targetNode.getElementsByTagName("description").item(0);
       daosUriDesc = desc.getTextContent();

--- a/src/client/java/hadoop-daos/src/main/java/io/daos/fs/hadoop/DaosFileSourceAsync.java
+++ b/src/client/java/hadoop-daos/src/main/java/io/daos/fs/hadoop/DaosFileSourceAsync.java
@@ -1,3 +1,9 @@
+/*
+ * (C) Copyright 2018-2021 Intel Corporation.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause-Patent
+ */
+
 package io.daos.fs.hadoop;
 
 import io.daos.DaosEventQueue;

--- a/src/client/java/hadoop-daos/src/main/java/io/daos/fs/hadoop/DaosFileSourceSync.java
+++ b/src/client/java/hadoop-daos/src/main/java/io/daos/fs/hadoop/DaosFileSourceSync.java
@@ -1,3 +1,9 @@
+/*
+ * (C) Copyright 2018-2021 Intel Corporation.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause-Patent
+ */
+
 package io.daos.fs.hadoop;
 
 import io.daos.dfs.DaosFile;

--- a/src/client/java/hadoop-daos/src/main/java/io/daos/fs/hadoop/DaosFileSystem.java
+++ b/src/client/java/hadoop-daos/src/main/java/io/daos/fs/hadoop/DaosFileSystem.java
@@ -19,8 +19,6 @@ import com.google.common.collect.Lists;
 import io.daos.*;
 import io.daos.dfs.*;
 
-import org.apache.commons.lang3.StringEscapeUtils;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.*;
 import org.apache.hadoop.fs.permission.FsPermission;
@@ -259,37 +257,37 @@ public class DaosFileSystem extends FileSystem {
     if (appInfo != null) {
       String[] pairs = appInfo.split(":");
       for (String pair : pairs) {
-        if (StringUtils.isBlank(pair)) {
+        if (DaosUtils.isBlankStr(pair)) {
           continue;
         }
         String[] kv = pair.split("=");
         try {
           switch (kv[0]) {
             case Constants.DAOS_SERVER_GROUP:
-              if (StringUtils.isBlank(conf.get(Constants.DAOS_SERVER_GROUP))) {
-                conf.set(Constants.DAOS_SERVER_GROUP, StringEscapeUtils.unescapeJava(kv[1]));
+              if (DaosUtils.isBlankStr(conf.get(Constants.DAOS_SERVER_GROUP))) {
+                conf.set(Constants.DAOS_SERVER_GROUP, DaosUtils.unEscapeUnsValue(kv[1]));
               }
               break;
             case Constants.DAOS_POOL_UUID:
-              if (StringUtils.isBlank(poolId)) {
-                poolId = StringEscapeUtils.unescapeJava(kv[1]);
+              if (DaosUtils.isBlankStr(poolId)) {
+                poolId = DaosUtils.unEscapeUnsValue(kv[1]);
               } else {
                 LOG.warn("ignoring pool id {} from app info", kv[1]);
               }
               break;
             case Constants.DAOS_POOL_SVC:
-              if (StringUtils.isBlank(conf.get(Constants.DAOS_POOL_SVC))) {
-                conf.set(Constants.DAOS_POOL_SVC, StringEscapeUtils.unescapeJava(kv[1]));
+              if (DaosUtils.isBlankStr(conf.get(Constants.DAOS_POOL_SVC))) {
+                conf.set(Constants.DAOS_POOL_SVC, DaosUtils.unEscapeUnsValue(kv[1]));
               }
               break;
             case Constants.DAOS_POOL_FLAGS:
-              if (StringUtils.isBlank(conf.get(Constants.DAOS_POOL_FLAGS))) {
-                conf.set(Constants.DAOS_POOL_FLAGS, StringEscapeUtils.unescapeJava(kv[1]));
+              if (DaosUtils.isBlankStr(conf.get(Constants.DAOS_POOL_FLAGS))) {
+                conf.set(Constants.DAOS_POOL_FLAGS, DaosUtils.unEscapeUnsValue(kv[1]));
               }
               break;
             case Constants.DAOS_CONTAINER_UUID:
-              if (StringUtils.isBlank(contId)) {
-                contId = StringEscapeUtils.unescapeJava(kv[1]);
+              if (DaosUtils.isBlankStr(contId)) {
+                contId = DaosUtils.unEscapeUnsValue(kv[1]);
               } else {
                 LOG.warn("ignoring container id {} from app info", kv[1]);
               }
@@ -299,7 +297,7 @@ public class DaosFileSystem extends FileSystem {
             case Constants.DAOS_BLOCK_SIZE:
             case Constants.DAOS_CHUNK_SIZE:
             case Constants.DAOS_READ_MINIMUM_SIZE:
-              if (StringUtils.isBlank(conf.get(kv[0]))) {
+              if (DaosUtils.isBlankStr(conf.get(kv[0]))) {
                 conf.setInt(kv[0], Integer.valueOf(kv[1]));
               }
               break;
@@ -374,27 +372,27 @@ public class DaosFileSystem extends FileSystem {
       String svc = conf.get(Constants.DAOS_POOL_SVC);
 
       String poolUuid = conf.get(Constants.DAOS_POOL_UUID);
-      if (StringUtils.isEmpty(poolUuid)) {
+      if (DaosUtils.isEmptyStr(poolUuid)) {
         throw new IllegalArgumentException(Constants.DAOS_POOL_UUID +
                 " is null , need to set " + Constants.DAOS_POOL_UUID);
       }
       String contUuid = conf.get(Constants.DAOS_CONTAINER_UUID);
-      if (StringUtils.isEmpty(contUuid)) {
+      if (DaosUtils.isEmptyStr(contUuid)) {
         throw new IllegalArgumentException(Constants.DAOS_CONTAINER_UUID +
                 " is null, need to set " + Constants.DAOS_CONTAINER_UUID);
       }
 
       if (LOG.isDebugEnabled()) {
         LOG.debug(name + " configs:");
-        if (!StringUtils.isBlank(svrGrp)) {
+        if (!DaosUtils.isBlankStr(svrGrp)) {
           LOG.debug("daos server group: " + svrGrp);
         }
         LOG.debug("pool uuid: " + poolUuid);
-        if (!StringUtils.isBlank(poolFlags)) {
+        if (!DaosUtils.isBlankStr(poolFlags)) {
           LOG.debug("pool flags: " + poolFlags);
         }
         LOG.debug("container uuid: " + contUuid);
-        if (!StringUtils.isBlank(svc)) {
+        if (!DaosUtils.isBlankStr(svc)) {
           LOG.debug("pool svc: " + svc);
         }
         LOG.debug("read buffer size " + readBufferSize);
@@ -407,13 +405,13 @@ public class DaosFileSystem extends FileSystem {
       // daosFSclient build
       DaosFsClient.DaosFsClientBuilder builder = new DaosFsClient.DaosFsClientBuilder().poolId(poolUuid)
               .containerId(contUuid);
-      if (!StringUtils.isBlank(svrGrp)) {
+      if (!DaosUtils.isBlankStr(svrGrp)) {
         builder.serverGroup(svrGrp);
       }
-      if (!StringUtils.isBlank(poolFlags)) {
+      if (!DaosUtils.isBlankStr(poolFlags)) {
         builder.poolFlags(Integer.valueOf(poolFlags));
       }
-      if (!StringUtils.isBlank(svc)) {
+      if (!DaosUtils.isBlankStr(svc)) {
         builder.ranks(svc);
       }
       this.daos = builder.build();

--- a/src/client/java/hadoop-daos/src/test/java/io/daos/fs/hadoop/DaosHadoopTestUtils.java
+++ b/src/client/java/hadoop-daos/src/test/java/io/daos/fs/hadoop/DaosHadoopTestUtils.java
@@ -4,7 +4,7 @@
 
 package io.daos.fs.hadoop;
 
-import org.apache.commons.lang3.StringUtils;
+import io.daos.DaosUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.junit.internal.AssumptionViolatedException;
 
@@ -36,7 +36,7 @@ public class DaosHadoopTestUtils {
     String fsname = conf.getTrimmed(
         DaosHadoopTestUtils.TEST_FS_DAOS_NAME, "daos://192.168.2.1:23456/");
 
-    boolean liveTest = !StringUtils.isEmpty(fsname);
+    boolean liveTest = !DaosUtils.isEmptyStr(fsname);
     URI testURI = null;
     if (liveTest) {
       testURI = URI.create(fsname);

--- a/src/client/java/pom.xml
+++ b/src/client/java/pom.xml
@@ -13,7 +13,6 @@
   <url>http://daos.io</url>
 
   <properties>
-    <commons-lang3.version>3.7</commons-lang3.version>
     <junit.platform.version>1.4.0</junit.platform.version>
     <junit.jupiter.version>5.4.0</junit.jupiter.version>
     <slf4j.version>1.7.25</slf4j.version>
@@ -298,11 +297,6 @@
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-core</artifactId>
         <version>${log4j.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.commons</groupId>
-        <artifactId>commons-lang3</artifactId>
-	<version>${commons-lang3.version}</version>
       </dependency>
       <dependency>
         <groupId>com.google.code.findbugs</groupId>


### PR DESCRIPTION
- removed dependency to apache commons-lang3.jar 

Without this dependency, hadoop-daos can work with combinations of spark-3.0, spark-3.1, hadoop-2.7 and hadoop-3.2 or later.

Signed-off-by: jiafu zhang <jiafu.zhang@intel.com>