### PR TITLE
DAOS-6833 utils: Require daos-raft-devel = x.y.z

### DIFF
--- a/utils/rpms/daos.spec
+++ b/utils/rpms/daos.spec
@@ -84,7 +84,7 @@ BuildRequires: libisa-l_crypto-devel
 BuildRequires: libisal-devel
 BuildRequires: libisal_crypto-devel
 %endif
-BuildRequires: daos-raft-devel >= 0.7.3
+BuildRequires: daos-raft-devel = 0.7.3
 BuildRequires: openssl-devel
 BuildRequires: libevent-devel
 BuildRequires: libyaml-devel


### PR DESCRIPTION
7ec7f6c changed the build requirement for daos-raft-devel from

    = 0.7.3

to

    >= 0.7.3

making it difficult to make raft API changes without temporarily
endanger daos master builds. This PR changes the requirement back to

    = 0.7.3

for we will bump the minor version when making API changes.

Signed-off-by: Li Wei <wei.g.li@intel.com>