### PR TITLE
DAOS-7012 bio: Tolerate inconsistent SMD info

### DIFF
--- a/src/bio/bio_context.c
+++ b/src/bio/bio_context.c
@@ -242,8 +242,8 @@ bio_bs_hold(struct bio_blobstore *bbs)
 	if (bbs->bb_state == BIO_BS_STATE_TEARDOWN ||
 	    bbs->bb_state == BIO_BS_STATE_OUT ||
 	    bbs->bb_state == BIO_BS_STATE_SETUP) {
-		D_ERROR("Blobstore %p is in %d state, reject request.\n",
-			bbs, bbs->bb_state);
+		D_ERROR("Blobstore %p is in %s state, reject request.\n",
+			bbs, bio_state_enum_to_str(bbs->bb_state));
 		rc = -DER_DOS;
 		goto out;
 	}

--- a/src/bio/bio_device.c
+++ b/src/bio/bio_device.c
@@ -41,8 +41,9 @@ revive_dev(struct bio_xs_context *xs_ctxt, struct bio_bdev *d_bdev)
 	/* Set the LED of the VMD device to OFF state */
 	rc = bio_set_led_state(xs_ctxt, d_bdev->bb_uuid, "off", false/*reset*/);
 	if (rc != 0)
-		D_ERROR("Error managing LED on device:"DF_UUID"\n",
-			DP_UUID(d_bdev->bb_uuid));
+		D_CDEBUG(rc == -DER_NOSYS, DB_MGMT, DLOG_ERR,
+			 "Set LED on device:"DF_UUID" failed, "DF_RC"\n",
+			 DP_UUID(d_bdev->bb_uuid), DP_RC(rc));
 
 	return 0;
 }
@@ -734,7 +735,8 @@ skip_led_str:
 
 	if (found) {
 		if (strcmp(spdk_pci_device_get_type(pci_device), "vmd") != 0) {
-			D_ERROR("%s is not a VMD device\n", b_info.bdi_traddr);
+			D_DEBUG(DB_MGMT, "%s is not a VMD device\n",
+				b_info.bdi_traddr);
 			D_GOTO(free_traddr, rc = -DER_NOSYS);
 		}
 	} else {

--- a/src/pool/srv_util.c
+++ b/src/pool/srv_util.c
@@ -367,6 +367,7 @@ static int
 check_pool_targets(uuid_t pool_id, int *tgt_ids, int tgt_cnt, bool reint,
 		   d_rank_t *pl_rank)
 {
+	struct ds_pool_child	*pool_child;
 	struct ds_pool		*pool;
 	struct pool_target	*target = NULL;
 	d_rank_t		 rank = dss_self_rank();
@@ -374,11 +375,24 @@ check_pool_targets(uuid_t pool_id, int *tgt_ids, int tgt_cnt, bool reint,
 	int			 i, nr, rc = 0;
 
 	/* Get pool map to check the target status */
-	pool = ds_pool_lookup(pool_id);
-	if (pool == NULL) {
+	pool_child = ds_pool_child_lookup(pool_id);
+	if (pool_child == NULL) {
 		D_ERROR(DF_UUID": Pool cache not found\n", DP_UUID(pool_id));
-		return -DER_UNINIT;
+		/*
+		 * The SMD pool info could be inconsistent with global pool
+		 * info when pool creation/destroy partially succeed or fail.
+		 * For example: If a pool destroy happened after a blobstore
+		 * is torndown for faulty SSD, the blob and SMD info for the
+		 * affected pool targets will be left behind.
+		 *
+		 * SSD faulty/reint reaction should tolerate such kind of
+		 * inconsistency, otherwise, state transition for the SSD
+		 * won't be able to moving forward.
+		 */
+		return 0;
 	}
+	pool = pool_child->spc_pool;
+	D_ASSERT(pool != NULL);
 
 	nr_downout = nr_down = nr_upin = nr_up = 0;
 	ABT_rwlock_rdlock(pool->sp_lock);
@@ -420,7 +434,7 @@ check_pool_targets(uuid_t pool_id, int *tgt_ids, int tgt_cnt, bool reint,
 	}
 
 	ABT_rwlock_unlock(pool->sp_lock);
-	ds_pool_put(pool);
+	ds_pool_child_put(pool_child);
 
 	if (rc)
 		return rc;


### PR DESCRIPTION
The SMD pool info could be inconsistent with global pool info when
pool creation/destroy partially succeed or fail. For exmaple: If a
pool destroy happened after a blobstore is torndown for faulty SSD,
the blob and SMD info for the affected pool targets will be left
behind after the pool being destroyed.

SSD faulty reaction should tolerate such kind of inconsistency,
otherwise, state transition for the SSD won't be able to moving
forward. (The problem usually happens in testing where we mark
device as faulty, then destroy pool, then revive the device for
other tests).

In the future, we may need to have some kind of repairing
tool/mechanism to fix such inconsistency manually/automatically.

Signed-off-by: Niu Yawei <yawei.niu@intel.com>