### PR TITLE
DAOS-7626 test: decrease workload on dfs multithread test

### DIFF
--- a/src/tests/suite/dfs_unit_test.c
+++ b/src/tests/suite/dfs_unit_test.c
@@ -431,8 +431,8 @@ dfs_test_rm(const char *name)
 	assert_int_equal(rc, 0);
 }
 
-int dfs_test_thread_nr		= 32;
-#define DFS_TEST_MAX_THREAD_NR	(64)
+int dfs_test_thread_nr		= 8;
+#define DFS_TEST_MAX_THREAD_NR	(16)
 pthread_t dfs_test_tid[DFS_TEST_MAX_THREAD_NR];
 
 struct dfs_test_thread_arg {


### PR DESCRIPTION
- use 8 threads instead of 32

Quick-Functional: true
Test-tag: hw,large,pr,daos_core_test_dfs

Signed-off-by: Mohamad Chaarawi <mohamad.chaarawi@intel.com>