### PR TITLE
DAOS-7754 test: reduce large pool SCM size in basic_snapshot

### DIFF
--- a/src/tests/ftest/container/basic_snapshot.yaml
+++ b/src/tests/ftest/container/basic_snapshot.yaml
@@ -14,8 +14,8 @@ pool:
     scm_size_mux: !mux
         size1gb:
             scm_size: 1073741824
-        size8gb:
-            scm_size: 8489934592
+        size7gb:
+            scm_size: 7516192768
 object_class: !mux
     OC_S1:
         obj_class: OC_S1


### PR DESCRIPTION
Before this change, in virtual machine (VM)-based testing of the
container basic snapshot tests, those tests with the "8gb" scm_size
were failing due to the Linux oom-killer terminating the daos_engine
process. Currently 12GB of memory is provisoned for the VMs, and recent
changes to the engine implementation consume more memory, likely
putting too much pressure on the VM.

With this change, the "8gb" SCM size test cases are changed to instead
allocate 7GiB of SCM for the pool.

Skip-checkpatch: true
Skip-python-bandit: true
Quick-build: true
Parallel-build: true
Skip-unit-tests: true
Skip-coverity-test: true
Skip-func-hw-test: true
Test-tag-vm: basicsnap
Skip-scan-centos-rpms: true
Skip-test-centos-rpms: true

Signed-off-by: Kenneth Cain <kenneth.c.cain@intel.com>