### PR TITLE
DAOS-7502 doc: Update Security Model doc

### DIFF
--- a/doc/overview/security.md
+++ b/doc/overview/security.md
@@ -77,6 +77,9 @@ permissions for specific actions.
 The permissions of a handle last for the duration of its existence, similar to
 an open file descriptor in a POSIX system. A handle cannot currently be revoked.
 
+A DAOS ACL is composed of zero or more Access Control Entries (ACEs). The ACEs
+are the [rules](https://daos-stack.github.io/overview/security/#enforcement)
+used to grant or deny privileges to a user who requests access to a resource.
 
 #### Access Control Entries
 

--- a/doc/overview/security.md
+++ b/doc/overview/security.md
@@ -39,13 +39,13 @@ The DAOS management components communicate over the network using the
 
 Each trusted DAOS component (`daos_server`, `daos_agent`, and the `dmg`
 administrative tool) is authenticated by means of a certificate generated for
-that component by system administrator. All of the component certificates must
-be generated with the same root certificate and distributed to the appropriate
-DAOS nodes, as described in the
+that component by the system administrator. All of the component certificates
+must be generated with the same root certificate and distributed to the
+appropriate DAOS nodes, as described in the
 [DAOS Administration Guide](https://daos-stack.github.io/admin/deployment/#certificate-configuration).
 
 DAOS components identify one another over the DAOS management network via
-mutually-authenticated TLS over gRPC using their respective component
+gRPC over mutually-authenticated TLS using their respective component
 certificates. DAOS verifies the certificate chain, as well as the Common Name
 (CN) in the certificate, to authenticate the component's identity.
 

--- a/doc/overview/security.md
+++ b/doc/overview/security.md
@@ -22,21 +22,32 @@ accessing client resources or the DAOS management network.
 
 ### Client Library
 
-The client library `libdaos` is an untrusted component. The `daos` user-level 
-command that uses the client library is also an untrusted component. 
+The client library `libdaos` is an untrusted component. The `daos` user-level
+command that uses the client library is also an untrusted component.
 A trusted process, the DAOS agent (`daos_agent`),
 runs on each client node and authenticates the user processes.
 
 The DAOS security model is designed to support different authentication methods
-for client processes. Currently, we support AUTH_SYS authentication only.
+for client processes. Currently, we support only the AUTH_SYS authentication
+flavor, as defined for NFS in
+[RFC 2623](https://datatracker.ietf.org/doc/html/rfc2623#section-2.2.1).
 
 ### DAOS Management Network
 
-Each trusted DAOS component (`daos_server`, `daos_agent`, 
-and the `dmg` administrative tool) is
-authenticated by means of a certificate generated for that component. These
-components identify one another over the DAOS management network via
-mutually-authenticated TLS.
+The DAOS management components communicate over the network using the
+[gRPC protocol](https://grpc.io/).
+
+Each trusted DAOS component (`daos_server`, `daos_agent`, and the `dmg`
+administrative tool) is authenticated by means of a certificate generated for
+that component by system administrator. All of the component certificates must
+be generated with the same root certificate and distributed to the appropriate
+DAOS nodes, as described in the
+[DAOS Administration Guide](https://daos-stack.github.io/admin/deployment/#certificate-configuration).
+
+DAOS components identify one another over the DAOS management network via
+mutually-authenticated TLS over gRPC using their respective component
+certificates. DAOS verifies the certificate chain, as well as the Common Name
+(CN) in the certificate, to authenticate the component's identity.
 
 ## Authorization
 
@@ -60,7 +71,7 @@ and adapted for the unique needs of a distributed system.
 
 The client may request read-only or read-write access to the resource. If the
 resource ACL doesn't grant them the requested access level, they won't
-be able to connect. While connected, their handle to that resource grants 
+be able to connect. While connected, their handle to that resource grants
 permissions for specific actions.
 
 The permissions of a handle last for the duration of its existence, similar to
@@ -69,8 +80,8 @@ an open file descriptor in a POSIX system. A handle cannot currently be revoked.
 
 #### Access Control Entries
 
-In the input and output of DAOS tools, an Access Control Entry (ACE) is defined 
-using a colon-separated string with the following format: 
+In the input and output of DAOS tools, an Access Control Entry (ACE) is defined
+using a colon-separated string with the following format:
 `TYPE:FLAGS:PRINCIPAL:PERMISSIONS`
 
 The contents of all the fields are case-sensitive.
@@ -103,7 +114,7 @@ also have the `G` (group) flag.
 ##### Permissions
 
 The permissions in a resource's ACE permit a certain type of user access to
-the resource. The order of the permission "bits" (characters) within the 
+the resource. The order of the permission "bits" (characters) within the
 `PERMISSIONS` field of the ACE is not significant.
 
 | Permission	| Pool Meaning		| Container Meaning				|
@@ -143,7 +154,7 @@ It is _not_ possible to deny access to a specific group in this way, due to
 * `A::daos_user@:rw`
     * Allow the UNIX user named `daos_user` to have read-write access.
 * `A:G:project_users@:tc`
-    * Allow anyone in the UNIX group `project_users` to access a pool's 
+    * Allow anyone in the UNIX group `project_users` to access a pool's
       contents and create containers.
 * `A::OWNER@:rwdtTaAo`
     * Allow the UNIX user who owns the container to have full control.


### PR DESCRIPTION
- Clarify how mutually-authenticated TLS is performed in
  the management network.
- Link to NFS standard document where AUTH_SYS authentication
  is defined.

Doc-only: true

Signed-off-by: Kris Jacque <kristin.jacque@intel.com>