### PR TITLE
DAOS-7769 Test: Daos container attribute test failures

### DIFF
--- a/src/tests/ftest/container/attribute.py
+++ b/src/tests/ftest/container/attribute.py
@@ -122,7 +122,9 @@ class ContainerAttributeTest(TestWithServers):
 
         Test description: Test large randomly created container attribute.
 
-        :avocado: tags=container,attribute,large_conattribute
+        :avocado: tags=all,full_regression
+        :avocado: tags=container,attribute
+        :avocado: tags=large_conattribute
         :avocado: tags=container_attribute
         """
         self.add_pool()
@@ -153,7 +155,9 @@ class ContainerAttributeTest(TestWithServers):
     def test_container_attribute(self):
         """
         Test basic container attribute tests.
-        :avocado: tags=all,tiny,full_regression,container,sync_conattribute
+        :avocado: tags=all,tiny,full_regression
+        :avocado: tags=container,attribute
+        :avocado: tags=sync_conattribute
         :avocado: tags=container_attribute
         """
         self.add_pool()
@@ -217,7 +221,9 @@ class ContainerAttributeTest(TestWithServers):
         """
         Test basic container attribute tests.
 
-        :avocado: tags=all,small,full_regression,container,async_conattribute
+        :avocado: tags=all,small,full_regression
+        :avocado: tags=container,attribute
+        :avocado: tags=async_conattribute
         :avocado: tags=container_attribute
         """
         global GLOB_SIGNAL


### PR DESCRIPTION
    Getting values of non-existent attributes in a container
    return and empty value, not a failure.

    Test now reflect the behaviour, explicity check for
    negative scenarios.

Signed-off-by: Omar Ocampo <omar.ocampo.coronado@intel.com>
Features: container_attribute