### PR TITLE
DAOS-7766 dedup: Fix a typo

### DIFF
--- a/src/vos/vos_io.c
+++ b/src/vos/vos_io.c
@@ -2330,7 +2330,7 @@ vos_dedup_dup_bsgl(daos_handle_t ioh, struct bio_sglist *bsgl,
 
 		D_ASSERT(bio_iov2len(biov) != 0);
 		D_ALLOC(biov_dup->bi_buf, bio_iov2len(biov));
-		if (biov_dup->bi_buf) {
+		if (biov_dup->bi_buf == NULL) {
 			D_ERROR("Failed to alloc "DF_U64" bytes\n",
 				bio_iov2len(biov));
 			return -DER_NOMEM;


### PR DESCRIPTION
Fix a typo in vos_dedup_dup_bsgl().

Signed-off-by: Niu Yawei <yawei.niu@intel.com>