### PR TITLE
Revert "DAOS-7605: network/cart_self_test has incorrect bash cmd"

### DIFF
--- a/src/tests/ftest/util/command_utils.py
+++ b/src/tests/ftest/util/command_utils.py
@@ -1086,7 +1086,7 @@ class SubprocessManager():
             command = "systemctl is-active {}".format(
                 self.manager.job.service_name)
         else:
-            command = "pgrep {}".format(self.manager.job.command)
+            command = "prep {}".format(self.manager.job.command)
         results = run_pcmd(self._hosts, command, 30)
         for result in results:
             for node in result["hosts"]:


### PR DESCRIPTION
Reverts daos-stack/daos#5740