### PR TITLE
DAOS-7756 packages: remove *.so from devel packages

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+daos (1.3.101-3) unstable; urgency=medium
+  [ Johann Lombardi]
+  * Bump version to match the RPM's one
+
+ -- Johann Lombardi <johann.lombardi@intel.com>  Wed, 02 June 2021 08:00:30 -0100
+
 daos (1.3.101-2) unstable; urgency=medium
   [ Jeff Olivier]
   * Remove client and server libs from common package

--- a/debian/changelog
+++ b/debian/changelog
@@ -2,7 +2,7 @@ daos (1.3.101-3) unstable; urgency=medium
   [ Johann Lombardi]
   * Bump version to match the RPM's one
 
- -- Johann Lombardi <johann.lombardi@intel.com>  Wed, 02 June 2021 08:00:30 -0100
+ -- Johann Lombardi <johann.lombardi@intel.com>  Wed, 02 Jun 2021 08:00:30 -0100
 
 daos (1.3.101-2) unstable; urgency=medium
   [ Jeff Olivier]

--- a/utils/rpms/daos.spec
+++ b/utils/rpms/daos.spec
@@ -456,7 +456,6 @@ getent passwd daos_agent >/dev/null || useradd -s /sbin/nologin -r -g daos_agent
 %{_libdir}/libgurt.so
 %{_libdir}/libcart.so
 %{_libdir}/*.a
-%{_libdir}/*.so
 
 %files firmware
 # set daos_firmware to be setuid root in order to perform privileged tasks

--- a/utils/rpms/daos.spec
+++ b/utils/rpms/daos.spec
@@ -462,7 +462,7 @@ getent passwd daos_agent >/dev/null || useradd -s /sbin/nologin -r -g daos_agent
 %attr(4750,root,daos_server) %{_bindir}/daos_firmware
 
 %changelog
-* Wed June 02 2021 Johann Lombardi <johann.lombardi@intel.com> 1.3.101-3
+* Wed Jun 02 2021 Johann Lombardi <johann.lombardi@intel.com> 1.3.101-3
 - Remove libs from devel package
 
 * Thu May 20 2021 Jeff Olivier <jeffrey.v.olivier@intel.com> 1.3.0-101-2

--- a/utils/rpms/daos.spec
+++ b/utils/rpms/daos.spec
@@ -14,7 +14,7 @@
 
 Name:          daos
 Version:       1.3.101
-Release:       2%{?relval}%{?dist}
+Release:       3%{?relval}%{?dist}
 Summary:       DAOS Storage Engine
 
 License:       BSD-2-Clause-Patent
@@ -462,6 +462,9 @@ getent passwd daos_agent >/dev/null || useradd -s /sbin/nologin -r -g daos_agent
 %attr(4750,root,daos_server) %{_bindir}/daos_firmware
 
 %changelog
+* Wed June 02 2021 Johann Lombardi <johann.lombardi@intel.com> 1.3.101-3
+- Remove libs from devel package
+
 * Thu May 20 2021 Jeff Olivier <jeffrey.v.olivier@intel.com> 1.3.0-101-2
 - Remove client libs from common package
 


### PR DESCRIPTION
To avoid packing libdts.so in the devel package.

Signed-off-by: Johann Lombardi <johann.lombardi@intel.com>