### PR TITLE
DAOS-7773 tests: Fixing checking daos_agent state

### DIFF
--- a/src/tests/ftest/util/command_utils.py
+++ b/src/tests/ftest/util/command_utils.py
@@ -1091,9 +1091,8 @@ class SubprocessManager():
         for result in results:
             for node in result["hosts"]:
                 # expecting single line output from run_pcmd
-                data[ranks[node]] = {
-                    "host": node, "uuid": "-",
-                    "state": result["stdout"][-1]}
+                stdout = result["stdout"][-1] if result["stdout"] else "unknown"
+                data[ranks[node]] = {"host": node, "uuid": "-", "state": stdout}
         return data
 
     def update_expected_states(self, ranks, state):

--- a/src/tests/ftest/util/command_utils.py
+++ b/src/tests/ftest/util/command_utils.py
@@ -1086,7 +1086,7 @@ class SubprocessManager():
             command = "systemctl is-active {}".format(
                 self.manager.job.service_name)
         else:
-            command = "prep {}".format(self.manager.job.command)
+            command = "pgrep {}".format(self.manager.job.command)
         results = run_pcmd(self._hosts, command, 30)
         for result in results:
             for node in result["hosts"]:


### PR DESCRIPTION
When not using systemctl to run the daos_agent the state checking code
ends up using pgrep to determine if the agent is running.  In the case
where the agent is not running, pgrep returns no stdout which causes a
python exception.  This change remedies this problem.

Signed-off-by: Phillip Henderson <phillip.henderson@intel.com>