### PR TITLE
DAOS-7718 control: Retry certain pool destroy errors

### DIFF
--- a/src/control/lib/control/pool_test.go
+++ b/src/control/lib/control/pool_test.go
@@ -51,6 +51,28 @@ func TestControl_PoolDestroy(t *testing.T) {
 			},
 			expErr: errors.New("invalid UUID"),
 		},
+		"-DER_GRPVER is retried": {
+			req: &PoolDestroyReq{
+				UUID: common.MockUUID(),
+			},
+			mic: &MockInvokerConfig{
+				UnaryResponseSet: []*UnaryResponse{
+					MockMSResponse("host1", drpc.DaosGroupVersionMismatch, nil),
+					MockMSResponse("host1", nil, &mgmtpb.PoolDestroyResp{}),
+				},
+			},
+		},
+		"-DER_AGAIN is retried": {
+			req: &PoolDestroyReq{
+				UUID: common.MockUUID(),
+			},
+			mic: &MockInvokerConfig{
+				UnaryResponseSet: []*UnaryResponse{
+					MockMSResponse("host1", drpc.DaosTryAgain, nil),
+					MockMSResponse("host1", nil, &mgmtpb.PoolDestroyResp{}),
+				},
+			},
+		},
 		"success": {
 			req: &PoolDestroyReq{
 				UUID: common.MockUUID(),
@@ -266,7 +288,7 @@ func TestControl_PoolCreate(t *testing.T) {
 			},
 			expResp: &PoolCreateResp{},
 		},
-		"create -DER_GRPVER is retried": {
+		"-DER_GRPVER is retried": {
 			req: &PoolCreateReq{TotalBytes: 10},
 			mic: &MockInvokerConfig{
 				UnaryResponseSet: []*UnaryResponse{
@@ -276,7 +298,7 @@ func TestControl_PoolCreate(t *testing.T) {
 			},
 			expResp: &PoolCreateResp{},
 		},
-		"create -DER_AGAIN is retried": {
+		"-DER_AGAIN is retried": {
 			req: &PoolCreateReq{TotalBytes: 10},
 			mic: &MockInvokerConfig{
 				UnaryResponseSet: []*UnaryResponse{

--- a/src/control/lib/control/request.go
+++ b/src/control/lib/control/request.go
@@ -10,8 +10,9 @@ import (
 	"context"
 	"time"
 
-	"github.com/daos-stack/daos/src/control/build"
 	"github.com/pkg/errors"
+
+	"github.com/daos-stack/daos/src/control/build"
 )
 
 type (


### PR DESCRIPTION
If a -DER_GRPVER or -DER_AGAIN are encountered on pool
destroy, try the request again.