### PR TITLE
DAOS-7777 dfs: dfs_punch() should not set size if offset > file size

### DIFF
--- a/src/client/dfs/dfs.c
+++ b/src/client/dfs/dfs.c
@@ -3919,15 +3919,9 @@ dfs_punch(dfs_t *dfs, dfs_obj_t *obj, daos_off_t offset, daos_size_t len)
 	if (rc)
 		return daos_der2errno(rc);
 
-	/** nothing to do if offset is the same as the file size */
-	if (size == offset)
+	/** nothing to do if offset is larger or equal to the file size */
+	if (size <= offset)
 		return 0;
-
-	/** if file is smaller than the offset, extend the file */
-	if (size < offset) {
-		rc = daos_array_set_size(obj->oh, DAOS_TX_NONE, offset, NULL);
-		return daos_der2errno(rc);
-	}
 
 	/** if fsize is between the range to punch, just truncate to offset */
 	if (offset < size && size <= offset + len) {
@@ -3939,7 +3933,7 @@ dfs_punch(dfs_t *dfs, dfs_obj_t *obj, daos_off_t offset, daos_size_t len)
 
 	/** Punch offset -> len */
 	iod.arr_nr = 1;
-	rg.rg_len = offset + len;
+	rg.rg_len = len;
 	rg.rg_idx = offset;
 	iod.arr_rgs = &rg;
 

--- a/src/client/dfs/dfs.c
+++ b/src/client/dfs/dfs.c
@@ -3898,6 +3898,7 @@ dfs_punch(dfs_t *dfs, dfs_obj_t *obj, daos_off_t offset, daos_size_t len)
 	daos_size_t		size;
 	daos_array_iod_t	iod;
 	daos_range_t		rg;
+	daos_off_t		hi;
 	int			rc;
 
 	if (dfs == NULL || !dfs->mounted)
@@ -3923,13 +3924,18 @@ dfs_punch(dfs_t *dfs, dfs_obj_t *obj, daos_off_t offset, daos_size_t len)
 	if (size <= offset)
 		return 0;
 
+	if ((offset + len) < offset)
+		hi = DFS_MAX_FSIZE;
+	else
+		hi = offset + len;
+
 	/** if fsize is between the range to punch, just truncate to offset */
-	if (offset < size && size <= offset + len) {
+	if (offset < size && size <= hi) {
 		rc = daos_array_set_size(obj->oh, DAOS_TX_NONE, offset, NULL);
 		return daos_der2errno(rc);
 	}
 
-	D_ASSERT(size > offset + len);
+	D_ASSERT(size > hi);
 
 	/** Punch offset -> len */
 	iod.arr_nr = 1;

--- a/src/include/daos_fs.h
+++ b/src/include/daos_fs.h
@@ -392,9 +392,8 @@ dfs_get_size(dfs_t *dfs, dfs_obj_t *obj, daos_size_t *size);
 
 /**
  * Punch a hole in the file starting at offset to len. If len is set to
- * DFS_MAX_FSIZE, this will be a truncate operation to punch all bytes in the
- * file above offset. If the file size is smaller than offset, the file is
- * extended to offset and len is ignored.
+ * DFS_MAX_FSIZE, this will be equivalent to a truncate operation to shrink or
+ * extend the file to \a offset bytes depending on the file size.
  *
  * \param[in]	dfs	Pointer to the mounted file system.
  * \param[in]	obj	Opened file object.

--- a/src/tests/suite/dfs_par_test.c
+++ b/src/tests/suite/dfs_par_test.c
@@ -248,7 +248,7 @@ dfs_test_short_read_internal(void **state, daos_oclass_id_t cid,
 	/** truncate the buffer to a large size, read should return all */
 	MPI_Barrier(MPI_COMM_WORLD);
 	if (arg->myrank == 0) {
-		rc = dfs_punch(dfs_mt, obj, 1048576 * 2, 0);
+		rc = dfs_punch(dfs_mt, obj, 1048576 * 2, DFS_MAX_FSIZE);
 		assert_int_equal(rc, 0);
 	}
 	MPI_Barrier(MPI_COMM_WORLD);

--- a/src/tests/suite/dfs_unit_test.c
+++ b/src/tests/suite/dfs_unit_test.c
@@ -392,6 +392,7 @@ dfs_test_file_gen(const char *name, daos_size_t chunk_size,
 	daos_size_t	buf_size = 128 * 1024;
 	daos_size_t	io_size;
 	daos_size_t	size = 0;
+	struct stat	stbuf;
 	int		rc = 0;
 
 	D_ALLOC(buf, buf_size);
@@ -405,6 +406,25 @@ dfs_test_file_gen(const char *name, daos_size_t chunk_size,
 	rc = dfs_open(dfs_mt, NULL, name, S_IFREG | S_IWUSR | S_IRUSR,
 		      O_RDWR | O_CREAT, OC_S1, chunk_size, NULL, &obj);
 	assert_int_equal(rc, 0);
+
+	rc = dfs_punch(dfs_mt, obj, 10, DFS_MAX_FSIZE);
+	assert_int_equal(rc, 0);
+	rc = dfs_ostat(dfs_mt, obj, &stbuf);
+	assert_int_equal(rc, 0);
+	assert_int_equal(stbuf.st_size, 10);
+
+	/** test for overflow */
+	rc = dfs_punch(dfs_mt, obj, 9, DFS_MAX_FSIZE-1);
+	assert_int_equal(rc, 0);
+	rc = dfs_ostat(dfs_mt, obj, &stbuf);
+	assert_int_equal(rc, 0);
+	assert_int_equal(stbuf.st_size, 9);
+
+	rc = dfs_punch(dfs_mt, obj, 0, DFS_MAX_FSIZE);
+	assert_int_equal(rc, 0);
+	rc = dfs_ostat(dfs_mt, obj, &stbuf);
+	assert_int_equal(rc, 0);
+	assert_int_equal(stbuf.st_size, 0);
 
 	while (size < file_size) {
 		io_size = file_size - size;


### PR DESCRIPTION
- also fix typo in punch to just punch len bytes

Signed-off-by: Mohamad Chaarawi <mohamad.chaarawi@intel.com>