### PR TITLE
DAOS-6319 Test: AssertionError: Pool creation took longer than 3 seconds

### DIFF
--- a/src/tests/ftest/pool/create_capacity_test.py
+++ b/src/tests/ftest/pool/create_capacity_test.py
@@ -39,7 +39,7 @@ class PoolCreateTests(PoolTestBase):
         quantity = self.params.get("quantity", "/run/pool/*", 1)
         ratio = 0.6 / quantity
         self.pool = self.get_pool_list(quantity, ratio, ratio, 1)
-        self.check_pool_creation(3)
+        self.check_pool_creation(10)
 
         # Verify DAOS can be restarted in less than 2 minutes
         try:


### PR DESCRIPTION
    Increased pool creation timeout from 3 to 10 seconds.

Test-tag-hw-large: pr,hw,large create_performance
Signed-off-by: Omar Ocampo <omar.ocampo.coronado@intel.com>