### PR TITLE
DAOS-7781 Test: Enable test_daos_admin_format to use bdev devices within test

### DIFF
--- a/src/tests/ftest/control/daos_admin_privileged.py
+++ b/src/tests/ftest/control/daos_admin_privileged.py
@@ -31,7 +31,9 @@ class DaosAdminPrivTest(TestWithServers):
             Test daos_admin functionality to perform format privileged
             operations while daos_server is run as normal user.
 
-        :avocado: tags=all,pr,daily_regression,hw,small,daos_admin,basic
+        :avocado: tags=all,pr,daily_regression
+        :avocado: tags=hw,small
+        :avocado: tags=daos_admin,basic
         """
         # Verify that daos_admin has the correct permissions
         self.log.info("Checking daos_admin binary permissions")

--- a/src/tests/ftest/control/daos_admin_privileged.yaml
+++ b/src/tests/ftest/control/daos_admin_privileged.yaml
@@ -15,9 +15,8 @@ server_config:
   name: daos_server
   port: 10001
   servers:
-    # Uncomment once DAOS-4287 has been closed.
-    # bdev_class: nvme
-    # bdev_list: ["aaaa:aa:aa.a","bbbb:bb:bb.b"]
+    bdev_class: nvme
+    bdev_list: ["aaaa:aa:aa.a","bbbb:bb:bb.b"]
     scm_class: dcpm
     scm_list: ["/dev/pmem0"]
   transport_config:


### PR DESCRIPTION
    Removed yaml file comments to enable server to use
    bdev devices.
    Re-formatted the avocado tags.

Signed-off-by: Omar Ocampo <omar.ocampo.coronado@intel.com>
Test-tag-hw-small: pr daos_admin