### PR TITLE
DAOS-7782 objects: various fixes about EC object size query

### DIFF
--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -5288,7 +5288,8 @@ dc_obj_query_key(tse_task_t *api_task)
 			 * retry because some potential 'prepared' DTX.
 			 */
 			shard = obj_grp_leader_get(obj, i, map_ver);
-			if (shard < 0) {
+			if (shard < 0 ||
+			    unlikely(DAOS_FAIL_CHECK(DAOS_OBJ_SKIP_PARITY))) {
 				if (!is_ec_obj) {
 					rc = shard;
 					D_ERROR(DF_OID" no valid shard, rc "

--- a/src/object/cli_shard.c
+++ b/src/object/cli_shard.c
@@ -1793,7 +1793,8 @@ struct obj_query_key_cb_args {
 
 static void
 obj_shard_query_recx_post(struct obj_query_key_cb_args *cb_args, uint32_t shard,
-			  struct obj_query_key_out *okqo, bool get_max)
+			  struct obj_query_key_out *okqo, bool get_max,
+			  bool changed)
 {
 	daos_recx_t		*reply_recx = &okqo->okqo_recx;
 	daos_recx_t		*result_recx = cb_args->recx;
@@ -1828,6 +1829,8 @@ re_check:
 		tmp_recx->rx_idx = rx_idx;
 		tmp_recx->rx_nr = stripe_rec_nr *
 				     (reply_recx->rx_nr / cell_rec_nr);
+		D_DEBUG(DB_IO, "shard %d get recx "DF_U64" "DF_U64"\n",
+			shard, tmp_recx->rx_idx, tmp_recx->rx_nr);
 	} else {
 		/* data ext from data shard needs to convert to daos ext,
 		 * replica ext from parity shard needs not to convert.
@@ -1849,6 +1852,8 @@ re_check:
 							       stripe_rec_nr,
 							       cell_rec_nr,
 							       tgt_idx);
+			D_DEBUG(DB_IO, "shard %d get recx "DF_U64" "DF_U64"\n",
+				shard, tmp_recx->rx_idx, tmp_recx->rx_nr);
 		}
 	}
 	if (!parity_checked && !from_data_tgt) {
@@ -1864,15 +1869,21 @@ re_check:
 	end[0] = DAOS_RECX_END(recx[0]);
 	end[1] = DAOS_RECX_END(recx[1]);
 	if (get_max) {
-		if (end[0] > end[1])
-			*result_recx = recx[0];
-		else
-			*result_recx = recx[1];
+		if (end[0] > end[1]) {
+			if (DAOS_RECX_END(*result_recx) < end[0] || changed)
+				*result_recx = recx[0];
+		} else {
+			if (DAOS_RECX_END(*result_recx) < end[1] || changed)
+				*result_recx = recx[1];
+		}
 	} else {
-		if (end[0] < end[1])
-			*result_recx = recx[0];
-		else
-			*result_recx = recx[1];
+		if (end[0] < end[1]) {
+			if (DAOS_RECX_END(*result_recx) > end[0] || changed)
+				*result_recx = recx[0];
+		} else {
+			if (DAOS_RECX_END(*result_recx) > end[0] || changed)
+				*result_recx = recx[1];
+		}
 	}
 }
 
@@ -1957,6 +1968,8 @@ obj_shard_query_key_cb(tse_task_t *task, void *data)
 			changed = true;
 		} else if (flags & DAOS_GET_MAX) {
 			if (*val > *cur) {
+				D_DEBUG(DB_IO, "dkey update "DF_U64"->"
+					DF_U64"\n", *cur, *val);
 				*cur = *val;
 				/** set to change akey and recx */
 				changed = true;
@@ -1965,7 +1978,7 @@ obj_shard_query_key_cb(tse_task_t *task, void *data)
 				 * replica obj, for EC obj need to check again
 				 * as it possibly from different data shards.
 				 */
-				if (!is_ec_obj)
+				if (!is_ec_obj || *val < *cur)
 					check = false;
 			}
 		} else if (flags & DAOS_GET_MIN) {
@@ -2000,10 +2013,8 @@ obj_shard_query_key_cb(tse_task_t *task, void *data)
 		if (!first && !changed)
 			D_ASSERT(is_ec_obj);
 
-		if (changed)
-			obj_shard_query_recx_post(cb_args,
-						  okqi->okqi_oid.id_shard,
-						  okqo, get_max);
+		obj_shard_query_recx_post(cb_args, okqi->okqi_oid.id_shard,
+					  okqo, get_max, changed);
 	}
 	D_RWLOCK_UNLOCK(&cb_args->obj->cob_lock);
 

--- a/src/tests/suite/daos_degrade_ec.c
+++ b/src/tests/suite/daos_degrade_ec.c
@@ -169,12 +169,6 @@ degrade_full_partial_fail_2data(void **state)
 {
 	int shards[2];
 
-	/*
-	 * Skipping test because of DAOS-6755, which seems to be related to EC
-	 * aggregation
-	 */
-	skip();
-
 	shards[0] = 0;
 	shards[1] = 3;
 	degrade_ec_internal(state, shards, 2, FULL_PARTIAL_UPDATE);
@@ -383,6 +377,7 @@ degrade_multi_conts_agg(void **state)
 			goto out;
 		}
 
+		daos_pool_set_prop(args[i]->pool.pool_uuid, "reclaim", "time");
 		args[i]->index = arg->index;
 		assert_int_equal(args[i]->pool.slave, 1);
 		/* XXX to temporarily workaround DAOS-7350, we need better
@@ -407,8 +402,8 @@ degrade_multi_conts_agg(void **state)
 	}
 
 	/* sleep a while to make aggregation triggered */
-	print_message("sleep about 25 second to wait aggregation ...\n");
-	sleep(25);
+	print_message("sleep about 5 seconds to wait aggregation ...\n");
+	trigger_and_wait_ec_aggreation(arg, oids, CONT_PER_POOL);
 
 	for (i = 0; i < shards_nr; i++)
 		fail_ranks[i] = get_rank_by_oid_shard(args[0], oids[0],

--- a/src/tests/suite/daos_obj_ec.c
+++ b/src/tests/suite/daos_obj_ec.c
@@ -12,6 +12,7 @@
 #define D_LOGFAC	DD_FAC(tests)
 
 #include "daos_iotest.h"
+#include "dfs_test.h"
 #include <daos/pool.h>
 #include <daos/mgmt.h>
 #include <daos/container.h>
@@ -284,15 +285,19 @@ ec_rec_list_punch(void **state)
 	ioreq_fini(&req);
 }
 
-static void
-trigger_and_wait_ec_aggreation(test_arg_t *arg, daos_obj_id_t oid)
+void
+trigger_and_wait_ec_aggreation(test_arg_t *arg, daos_obj_id_t *oids,
+			       int oids_nr)
 {
 	d_rank_t  ec_agg_rank;
+	int i;
 
-	get_killing_rank_by_oid(arg, oid, 0, 1, &ec_agg_rank, NULL);
-	daos_debug_set_params(arg->group, ec_agg_rank, DMG_KEY_FAIL_LOC,
-			      DAOS_FORCE_EC_AGG | DAOS_FAIL_ALWAYS,
-			      0, NULL);
+	for (i = 0; i < oids_nr; i++) {
+		get_killing_rank_by_oid(arg, oids[i], 0, 1, &ec_agg_rank, NULL);
+		daos_debug_set_params(arg->group, ec_agg_rank, DMG_KEY_FAIL_LOC,
+				      DAOS_FORCE_EC_AGG | DAOS_FAIL_ALWAYS,
+				      0, NULL);
+	}
 
 	print_message("wait for 5 seconds for EC aggregation.\n");
 	sleep(5);
@@ -355,7 +360,7 @@ ec_partial_update_agg(void **state)
 			     data, EC_CELL_SIZE, &req);
 	}
 
-	trigger_and_wait_ec_aggreation(arg, oid);
+	trigger_and_wait_ec_aggreation(arg, &oid, 1);
 
 	for (i = 0; i < 10; i++) {
 		daos_off_t offset = i * EC_CELL_SIZE;
@@ -402,7 +407,7 @@ ec_cross_cell_partial_update_agg(void **state)
 			     data, update_size, &req);
 	}
 
-	trigger_and_wait_ec_aggreation(arg, oid);
+	trigger_and_wait_ec_aggreation(arg, &oid, 1);
 
 	for (i = 0; i < 20; i++) {
 		char		c = 'a' + i;
@@ -470,7 +475,7 @@ ec_full_partial_update_agg(void **state)
 			     buffer, partial_update_size, &req);
 	}
 
-	trigger_and_wait_ec_aggreation(arg, oid);
+	trigger_and_wait_ec_aggreation(arg, &oid, 1);
 
 	ec_verify_parity_data(&req, "d_key", "a_key", (daos_size_t)0,
 			      full_update_size, verify_data);
@@ -532,13 +537,136 @@ ec_partial_full_update_agg(void **state)
 	insert_recxs("d_key", "a_key", 1, DAOS_TX_NONE, &recx, 1,
 		     data, full_update_size, &req);
 
-	trigger_and_wait_ec_aggreation(arg, oid);
+	trigger_and_wait_ec_aggreation(arg, &oid, 1);
 
 	ec_verify_parity_data(&req, "d_key", "a_key", (daos_size_t)0,
 			      full_update_size, verify_data);
 
 	free(data);
 	free(verify_data);
+}
+
+void
+dfs_ec_check_size_internal(void **state, unsigned fail_loc)
+{
+	dfs_t		*dfs_mt;
+	daos_handle_t	co_hdl;
+	test_arg_t	*arg = *state;
+	d_sg_list_t	sgl;
+	d_iov_t		iov;
+	dfs_obj_t	*obj;
+	daos_size_t	buf_size = 10 * 1024;
+	daos_size_t	chunk_size = 32 * 1024 * 4;
+	uuid_t		co_uuid;
+	char		filename[32];
+	struct stat	st;
+	char		*buf;
+	int		i;
+	daos_obj_id_t	oid;
+	int		rc;
+
+	uuid_generate(co_uuid);
+	rc = dfs_cont_create(arg->pool.poh, co_uuid, NULL, &co_hdl, &dfs_mt);
+	assert_int_equal(rc, 0);
+	printf("Created DFS Container "DF_UUIDF"\n", DP_UUID(co_uuid));
+
+	D_ALLOC(buf, buf_size);
+	assert_true(buf != NULL);
+
+	sprintf(filename, "ec_file");
+	rc = dfs_open(dfs_mt, NULL, filename, S_IFREG | S_IWUSR | S_IRUSR,
+		      O_RDWR | O_CREAT, DAOS_OC_EC_K4P2_L32K, chunk_size,
+		      NULL, &obj);
+	assert_int_equal(rc, 0);
+
+	dfs_obj2id(obj, &oid);
+	d_iov_set(&iov, buf, buf_size);
+	sgl.sg_nr = 1;
+	sgl.sg_nr_out = 1;
+	sgl.sg_iovs = &iov;
+
+	for (i = 0; i < 30; i++) {
+		rc = dfs_write(dfs_mt, obj, &sgl, i * buf_size, NULL);
+		assert_int_equal(rc, 0);
+		daos_fail_loc_set(fail_loc);
+		/* Size query for EC object actually does client dispatch
+		 * if the parity(dtx leader) are gone, so it meet uncommitted
+		 * DTX, size query might give incorrect size, and we do not
+		 * do retry for this case at the moment. So let's do obj_verify
+		 * to do dtx sync to avoid uncommitted DTX for this test case.
+		 */
+		daos_obj_verify(co_hdl, oid, DAOS_EPOCH_MAX);
+		rc = dfs_stat(dfs_mt, NULL, filename, &st);
+		assert_int_equal(rc, 0);
+		assert_int_equal(st.st_size, (i + 1) * buf_size);
+		daos_fail_loc_set(0);
+	}
+
+	daos_fail_loc_set(fail_loc);
+
+	rc = dfs_stat(dfs_mt, NULL, filename, &st);
+	assert_int_equal(rc, 0);
+	assert_int_equal(st.st_size, i * buf_size);
+	for (i = 0; i < 10; i++) {
+		daos_fail_loc_set(0);
+		rc = dfs_punch(dfs_mt, obj, (daos_off_t)(i * buf_size),
+			       (daos_size_t)buf_size);
+		assert_int_equal(rc, 0);
+		daos_fail_loc_set(fail_loc);
+		daos_obj_verify(co_hdl, oid, DAOS_EPOCH_MAX);
+		rc = dfs_stat(dfs_mt, NULL, filename, &st);
+		assert_int_equal(rc, 0);
+		assert_int_equal(st.st_size, 30 * buf_size);
+	}
+
+	for (i = 30; i > 10; i--) {
+		daos_fail_loc_set(0);
+		rc = dfs_punch(dfs_mt, obj, (daos_off_t)((i - 1) * buf_size),
+			       (daos_size_t)buf_size);
+		assert_int_equal(rc, 0);
+		daos_fail_loc_set(fail_loc);
+		daos_obj_verify(co_hdl, oid, DAOS_EPOCH_MAX);
+		rc = dfs_stat(dfs_mt, NULL, filename, &st);
+		assert_int_equal(rc, 0);
+		assert_int_equal(st.st_size, (i - 1) * buf_size);
+	}
+
+	rc = dfs_stat(dfs_mt, NULL, filename, &st);
+	assert_int_equal(rc, 0);
+	/**
+	 * NB: the last dfs_punch will set the file size to 10 * buf_size,
+	 * instead of 0
+	 **/
+	assert_int_equal(st.st_size, 10 * buf_size);
+
+	rc = dfs_stat(dfs_mt, NULL, filename, &st);
+	daos_fail_loc_set(0);
+
+	rc = dfs_release(obj);
+	assert_int_equal(rc, 0);
+
+	D_FREE(buf);
+	rc = dfs_umount(dfs_mt);
+	assert_int_equal(rc, 0);
+
+	rc = daos_cont_close(co_hdl, NULL);
+	assert_rc_equal(rc, 0);
+
+	rc = daos_cont_destroy(arg->pool.poh, co_uuid, 1, NULL);
+	assert_rc_equal(rc, 0);
+}
+
+static void
+dfs_ec_check_size(void **state)
+{
+	dfs_ec_check_size_internal(state, 0);
+}
+
+static void
+dfs_ec_check_size_nonparity(void **state)
+{
+	dfs_ec_check_size_internal(state, DAOS_OBJ_SKIP_PARITY |
+					  DAOS_FAIL_ALWAYS);
 }
 
 static int
@@ -578,6 +706,10 @@ static const struct CMUnitTest ec_tests[] = {
 	 ec_full_partial_update_agg, async_disable, test_case_teardown},
 	{"EC6: ec partial and full update then aggregation",
 	 ec_partial_full_update_agg, async_disable, test_case_teardown},
+	{"EC7: ec file size check on parity",
+	 dfs_ec_check_size, async_disable, test_case_teardown},
+	{"EC8: ec file size check on non-parity",
+	 dfs_ec_check_size_nonparity, async_disable, test_case_teardown},
 };
 
 int

--- a/src/tests/suite/daos_test.h
+++ b/src/tests/suite/daos_test.h
@@ -470,6 +470,8 @@ int wait_and_verify_blobstore_state(uuid_t bs_uuid, char *expected_state,
 int wait_and_verify_pool_tgt_state(daos_handle_t poh, int tgtidx, int rank,
 				   char *expected_state);
 void save_group_state(void **state);
+void trigger_and_wait_ec_aggreation(test_arg_t *arg, daos_obj_id_t *oids,
+				    int oids_nr);
 
 enum op_type {
 	PARTIAL_UPDATE	=	1,


### PR DESCRIPTION
1. Fix a typo of punch size in dfs_punch().

2. In obj_shard_query_key_cb(), it should all shards for EC object
size calculation.

3. Add few test cases for EC object size query.

Signed-off-by: Di Wang <di.wang@intel.com>