### PR TITLE
DAOS-7492 dfuse: Improve error reporting on dfuse error.

### DIFF
--- a/src/cart/crt_init.c
+++ b/src/cart/crt_init.c
@@ -94,7 +94,7 @@ prov_data_init(struct crt_prov_gdata *prov_data, int provider,
 	prov_data->cpg_contig_ports = true;
 	prov_data->cpg_ctx_max_num = max_ctx_num;
 
-	D_INIT_LIST_HEAD(&(prov_data->cpg_ctx_list));
+	D_INIT_LIST_HEAD(&prov_data->cpg_ctx_list);
 }
 
 /* first step init - for initializing crt_gdata */
@@ -192,7 +192,6 @@ static int data_init(int server, crt_init_options_t *opt)
 	}
 	crt_gdata.cg_credit_ep_ctx = credits;
 	D_ASSERT(crt_gdata.cg_credit_ep_ctx <= CRT_MAX_CREDITS_PER_EP_CTX);
-
 
 	/** Enable statistics only for the server side and if requested */
 	if (opt && opt->cio_use_sensors && server) {
@@ -584,7 +583,7 @@ crt_finalize(void)
 		crt_self_test_fini();
 
 		/* TODO: Needs to happen for every initialized provider */
-		prov_data = &(crt_gdata.cg_prov_gdata[crt_gdata.cg_init_prov]);
+		prov_data = &crt_gdata.cg_prov_gdata[crt_gdata.cg_init_prov];
 
 		if (prov_data->cpg_ctx_num > 0) {
 			D_ASSERT(!crt_context_empty(crt_gdata.cg_init_prov,
@@ -593,7 +592,7 @@ crt_finalize(void)
 				prov_data->cpg_ctx_num);
 			crt_gdata.cg_refcount++;
 			D_RWLOCK_UNLOCK(&crt_gdata.cg_rwlock);
-			D_GOTO(out, rc = -DER_NO_PERM);
+			D_GOTO(out, rc = -DER_BUSY);
 		} else {
 			D_ASSERT(crt_context_empty(crt_gdata.cg_init_prov,
 				 CRT_LOCKED));
@@ -644,11 +643,10 @@ direct_out:
 	if (rc == 0)
 		d_log_fini(); /* d_log_fini is reference counted */
 	else
-		D_ERROR("failed, rc: %d.\n", rc);
+		D_ERROR("failed, rc: "DF_RC"\n", DP_RC(rc));
 
 	return rc;
 }
-
 
 static inline na_bool_t is_integer_str(char *str)
 {

--- a/src/client/dfuse/dfuse_core.c
+++ b/src/client/dfuse/dfuse_core.c
@@ -991,7 +991,8 @@ dfuse_start(struct dfuse_projection_info *fs_handle,
 err_ie_remove:
 	d_hash_rec_delete_at(&fs_handle->dpi_iet, &ie->ie_htl);
 err:
-	DFUSE_TRA_ERROR(fs_handle, "Failed to start dfuse, rc: %d", rc);
+	DFUSE_TRA_ERROR(fs_handle,
+			"Failed to start dfuse, rc: "DF_RC, DP_RC(rc));
 	D_FREE(fuse_ops);
 	D_FREE(ie);
 	return rc;

--- a/src/client/dfuse/dfuse_main.c
+++ b/src/client/dfuse/dfuse_main.c
@@ -168,7 +168,8 @@ ll_loop_fn(struct dfuse_info *dfuse_info)
 		ret = fuse_session_loop(dfuse_info->di_session);
 	if (ret != 0)
 		DFUSE_TRA_ERROR(dfuse_info,
-				"Fuse loop exited with return code: %d", ret);
+				"Fuse loop exited with return code: %d %s",
+				ret, strerror(ret));
 
 	return ret;
 }


### PR DESCRIPTION
Return -DER_BUSY rather than -DER_NO_PERM from cart_fini is busy
Use DF_RC and strerror to improve messages printed.

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>
