### PR TITLE
DAOS-7204 EC: a few fixes for EC agg

### DIFF
--- a/src/container/srv_target.c
+++ b/src/container/srv_target.c
@@ -2324,10 +2324,16 @@ cont_ec_eph_reduce(void *agg_arg, void *xs_arg)
 
 		c_eph = lookup_insert_cont_ec_eph(&pool->sp_ec_ephs_list,
 						  x_arg->ephs[i].cont_uuid);
-		if (c_eph->ce_eph == 0 ||
-		    (x_arg->ephs[i].eph != 0 &&
-		     x_arg->ephs[i].eph > c_eph->ce_last_eph))
+		if (c_eph->ce_eph == 0) {
 			c_eph->ce_eph = x_arg->ephs[i].eph;
+			continue;
+		}
+		if (x_arg->ephs[i].eph != 0 &&
+		    x_arg->ephs[i].eph > c_eph->ce_last_eph) {
+			if (c_eph->ce_eph <= c_eph->ce_last_eph ||
+			    x_arg->ephs[i].eph < c_eph->ce_eph)
+				c_eph->ce_eph = x_arg->ephs[i].eph;
+		}
 	}
 }
 

--- a/src/object/obj_rpc.h
+++ b/src/object/obj_rpc.h
@@ -360,6 +360,7 @@ CRT_RPC_DECLARE(obj_ec_agg, DAOS_ISEQ_OBJ_EC_AGG, DAOS_OSEQ_OBJ_EC_AGG)
 	((daos_unit_oid_t)	(er_oid)		CRT_VAR)	\
 	((daos_key_t)		(er_dkey)		CRT_VAR)	\
 	((daos_iod_t)		(er_iod)		CRT_VAR)	\
+	((struct dcs_iod_csums)	(er_iod_csums)		CRT_ARRAY)	\
 	((uint64_t)		(er_epoch)		CRT_VAR)	\
 	((uint64_t)		(er_stripenum)		CRT_VAR)	\
 	((crt_bulk_t)		(er_bulk)		CRT_VAR)	\

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -1910,6 +1910,7 @@ ds_obj_ec_rep_handler(crt_rpc_t *rpc)
 	struct obj_ec_rep_out	*oero = crt_reply_get(rpc);
 	daos_key_t		*dkey;
 	daos_iod_t		*iod;
+	struct dcs_iod_csums	*iod_csums;
 	struct bio_desc		*biod;
 	daos_recx_t		 recx = { 0 };
 	daos_epoch_range_t	 epoch_range = { 0 };
@@ -1936,8 +1937,9 @@ ds_obj_ec_rep_handler(crt_rpc_t *rpc)
 	D_ASSERT(ioc.ioc_coc != NULL);
 	dkey = (daos_key_t *)&oer->er_dkey;
 	iod = (daos_iod_t *)&oer->er_iod;
+	iod_csums = oer->er_iod_csums.ca_arrays;
 	rc = vos_update_begin(ioc.ioc_coc->sc_hdl, oer->er_oid,
-			      oer->er_epoch, 0, dkey, 1, iod, NULL,
+			      oer->er_epoch, 0, dkey, 1, iod, iod_csums,
 			      NULL, 0, &ioh, NULL);
 	if (rc) {
 		D_ERROR(DF_UOID" Update begin failed: "DF_RC"\n",

--- a/src/tests/suite/daos_aggregate_ec.c
+++ b/src/tests/suite/daos_aggregate_ec.c
@@ -251,7 +251,7 @@ ec_setup_single_recx_data(struct ec_agg_test_ctx *ctx, unsigned int mode,
 	ctx->fetch_iom.iom_nr = 1;
 	ctx->fetch_iom.iom_nr_out = 0;
 
-	/** Setup Fetch IOD*/
+	/** Setup Fetch IOD */
 	ctx->fetch_iod.iod_name = ctx->update_iod.iod_name;
 	ctx->fetch_iod.iod_size = ctx->update_iod.iod_size;
 	ctx->fetch_iod.iod_recxs = ctx->update_iod.iod_recxs;
@@ -799,7 +799,9 @@ test_all_ec_agg(void **statep)
 	test_half_stripe(&ctx);
 	test_partial_stripe(&ctx);
 	test_range_punch(&ctx);
-	sleep(40);
+	print_message("sleep 45 seconds for aggregation ...\n");
+	sleep(45);
+	print_message("verification after aggregation\n");
 	verify_1p(&ctx, DAOS_OC_EC_K2P1_L32K, 2);
 	verify_2p(&ctx, DAOS_OC_EC_K2P2_L32K);
 	verify_1p(&ctx, DAOS_OC_EC_K4P1_L32K, 4);

--- a/src/tests/suite/daos_aggregate_ec.c
+++ b/src/tests/suite/daos_aggregate_ec.c
@@ -792,8 +792,13 @@ cleanup_ec_agg_tests(struct ec_agg_test_ctx *ctx)
 static void
 test_all_ec_agg(void **statep)
 {
+	test_arg_t		*arg = *statep;
 	struct ec_agg_test_ctx	 ctx = { 0 };
 
+	if (!test_runable(arg, 5))
+		return;
+
+	daos_pool_set_prop(arg->pool.pool_uuid, "reclaim", "time");
 	setup_ec_agg_tests(statep, &ctx);
 	test_filled_stripe(&ctx);
 	test_half_stripe(&ctx);

--- a/src/vos/vos_aggregate.c
+++ b/src/vos/vos_aggregate.c
@@ -239,6 +239,8 @@ vos_agg_obj(daos_handle_t ih, vos_iter_entry_t *entry,
 	D_ASSERT(agg_param != NULL);
 	if (daos_unit_oid_compare(agg_param->ap_oid, entry->ie_oid)) {
 		if (need_aggregate(agg_param, entry)) {
+			D_DEBUG(DB_EPC, "oid:"DF_UOID" vos agg starting\n",
+				DP_UOID(entry->ie_oid));
 			agg_param->ap_oid = entry->ie_oid;
 			reset_agg_pos(VOS_ITER_DKEY, agg_param);
 			reset_agg_pos(VOS_ITER_AKEY, agg_param);

--- a/src/vos/vos_io.c
+++ b/src/vos/vos_io.c
@@ -2575,8 +2575,9 @@ vos_obj_array_remove(daos_handle_t coh, daos_unit_oid_t oid,
 
 	rc = vos_update_end(ioh, 0 /* don't care */, (daos_key_t *)dkey, rc,
 			    NULL, NULL);
-	D_DEBUG(DB_IO, DF_UOID" remove "DF_RECX" "DF_RC"\n",
-		DP_UOID(oid), DP_RECX(*recx), DP_RC(rc));
+	D_DEBUG(DB_IO, DF_UOID" remove "DF_RECX" epr_hi "DF_X64", epr_lo "
+		DF_X64", "DF_RC"\n", DP_UOID(oid), DP_RECX(*recx), epr->epr_hi,
+		epr->epr_lo, DP_RC(rc));
 	return rc;
 }
 


### PR DESCRIPTION
1. agg_reset_pos() after yield during vos_iterate().
2. fix a bug in cont_ec_eph_reduce() that possibly cause issue for
   agg epoch boundary, and then cause vos agg before ec agg.
3. fix a issue in daos_aggregate_ec.c, sleep 40 second cannot ensure
   agg happens, enlarge to 45 S.
4. A few other changes for logs.

Signed-off-by: Xuezhao Liu <xuezhao.liu@intel.com>