### PR TITLE
DAOS-7351 control: Fix RAS timestamps

### DIFF
--- a/src/control/common/time_utils.go
+++ b/src/control/common/time_utils.go
@@ -8,14 +8,18 @@ package common
 
 import (
 	"math/rand"
+	"strings"
 	"time"
 )
 
 const (
 	// Use ISO8601 format for timestamps as it's
 	// widely supported by parsers (e.g. javascript, etc).
-	iso8601NoMicro = "2006-01-02T15:04:05Z0700"
-	iso8601        = "2006-01-02T15:04:05.000000Z0700"
+	//
+	// NB: ISO8601 is very similar to RFC3339 format; the
+	// primary difference is that the UTC zone is represented
+	// as -00:00 instead of Z.
+	iso8601 = "2006-01-02T15:04:05.000-07:00"
 
 	defaultJitter = 500 * time.Millisecond
 )
@@ -26,16 +30,19 @@ func FormatTime(t time.Time) string {
 	return t.Format(iso8601)
 }
 
-// FormatTimeNoMicro returns ISO8601 formatted representation of timestamp with
-// second resolution.
-func FormatTimeNoMicro(t time.Time) string {
-	return t.Format(iso8601NoMicro)
-}
-
-// ParseTime returns time.Time object from ISO8601 formatted timestamp with
-// microsecond resolution.
+// ParseTime returns a time.Time object from ISO8601 or RFC3339
+// timestamp strings.
 func ParseTime(ts string) (time.Time, error) {
-	return time.Parse(iso8601, ts)
+	if t, err := time.Parse(time.RFC3339Nano, ts); err == nil {
+		return t, nil
+	}
+
+	// The strftime() offset doesn't include a colon. If the normal
+	// format string doesn't work, try this one.
+	idx := strings.LastIndex(time.RFC3339Nano, ":")
+	fmtRunes := []rune(time.RFC3339Nano)
+	fmtStr := string(append(fmtRunes[0:idx], fmtRunes[idx+1:]...))
+	return time.Parse(fmtStr, ts)
 }
 
 // ExpBackoffWithJitter is like ExpBackoff but allows for a custom

--- a/src/control/common/time_utils_test.go
+++ b/src/control/common/time_utils_test.go
@@ -1,0 +1,120 @@
+//
+// (C) Copyright 2020-2021 Intel Corporation.
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+
+package common_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/daos-stack/daos/src/control/common"
+	"github.com/google/go-cmp/cmp"
+)
+
+func Test_Common_ParseTime(t *testing.T) {
+	zone := func(hours int) *time.Location {
+		return time.FixedZone("", int((time.Duration(hours) * time.Hour).Seconds()))
+	}
+
+	for name, tc := range map[string]struct {
+		in      string
+		expTime time.Time
+		expErr  error
+	}{
+		"iso861 (weird offset)": {
+			in: "2021-06-03T14:29:19.461+01:30",
+			expTime: time.Date(2021, 6, 3, 14, 29, 19, int(461*time.Millisecond),
+				time.FixedZone("", int((90*time.Minute).Seconds()))),
+		},
+		"iso8601 (negative offset)": {
+			in:      "2021-06-03T14:29:19.461-10:00",
+			expTime: time.Date(2021, 6, 3, 14, 29, 19, int(461*time.Millisecond), zone(-10)),
+		},
+		"iso8601 (UTC)": {
+			in:      "2021-06-03T14:29:19.461+00:00",
+			expTime: time.Date(2021, 6, 3, 14, 29, 19, int(461*time.Millisecond), zone(0)),
+		},
+		"iso8601 (positive offset)": {
+			in:      "2021-06-03T14:29:19.461+01:00",
+			expTime: time.Date(2021, 6, 3, 14, 29, 19, int(461*time.Millisecond), zone(1)),
+		},
+		"iso8601 (strftime offset)": {
+			in:      "2021-06-03T13:13:55.040-0400",
+			expTime: time.Date(2021, 6, 3, 13, 13, 55, int(40*time.Millisecond), zone(-4)),
+		},
+		"iso861 (weird strftime offset)": {
+			in: "2021-06-03T14:29:19.461+0430",
+			expTime: time.Date(2021, 6, 3, 14, 29, 19, int(461*time.Millisecond),
+				time.FixedZone("", int((270*time.Minute).Seconds()))),
+		},
+		"rfc3339 (UTC)": {
+			in:      "2021-06-03T14:29:19.461Z",
+			expTime: time.Date(2021, 6, 3, 14, 29, 19, int(461*time.Millisecond), zone(0)),
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			gotTime, gotErr := common.ParseTime(tc.in)
+			common.CmpErr(t, tc.expErr, gotErr)
+			if tc.expErr != nil {
+				return
+			}
+			if !tc.expTime.Equal(gotTime) {
+				t.Fatalf("times are not equal:\n%s\n%s)", gotTime, tc.expTime)
+			}
+		})
+	}
+}
+
+func Test_Common_FormatTime(t *testing.T) {
+	zone := func(hours int) *time.Location {
+		return time.FixedZone("", int((time.Duration(hours) * time.Hour).Seconds()))
+	}
+
+	for name, tc := range map[string]struct {
+		in     time.Time
+		expStr string
+	}{
+		"weird offset": {
+			in: time.Date(2021, 6, 3, 14, 29, 19, int(461*time.Millisecond),
+				time.FixedZone("", int((90*time.Minute).Seconds()))),
+			expStr: "2021-06-03T14:29:19.461+01:30",
+		},
+		"negative offset": {
+			in:     time.Date(2021, 6, 3, 14, 29, 19, int(461*time.Millisecond), zone(-10)),
+			expStr: "2021-06-03T14:29:19.461-10:00",
+		},
+		"UTC": {
+			in:     time.Date(2021, 6, 3, 14, 29, 19, int(461*time.Millisecond), zone(0)),
+			expStr: "2021-06-03T14:29:19.461+00:00",
+		},
+		"positive offset": {
+			in:     time.Date(2021, 6, 3, 14, 29, 19, int(46*time.Millisecond), zone(1)),
+			expStr: "2021-06-03T14:29:19.046+01:00",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			gotStr := common.FormatTime(tc.in)
+			if diff := cmp.Diff(tc.expStr, gotStr); diff != "" {
+				t.Fatalf("unexpected timestamp (-want, +got):\n%s\n", diff)
+			}
+		})
+	}
+
+}
+
+func Test_Common_ParseFormattedTime(t *testing.T) {
+	// Just a quick sanity check to verify that we're producing
+	// timestamps that we can parse.
+
+	formatted := common.FormatTime(time.Now())
+	parsed, err := common.ParseTime(formatted)
+	if err != nil {
+		t.Fatalf("unable to parse formatted time %q", formatted)
+	}
+	if common.FormatTime(parsed) != formatted {
+		t.Fatalf("after parsing, %q != %q", common.FormatTime(parsed), formatted)
+	}
+}

--- a/src/engine/drpc_ras.c
+++ b/src/engine/drpc_ras.c
@@ -51,6 +51,7 @@ init_event(ras_event_t id, char *msg, ras_type_t type, ras_sev_t sev,
 	struct dss_module_info	*dmi = get_module_info();
 	struct timeval		 tv;
 	struct tm		*tm;
+	char			 zone[6]; /* ±0000\0 */
 	int			 rc;
 
 	/* Populate mandatory RAS fields. */
@@ -58,12 +59,18 @@ init_event(ras_event_t id, char *msg, ras_type_t type, ras_sev_t sev,
 	(void)gettimeofday(&tv, 0);
 	tm = localtime(&tv.tv_sec);
 	if (tm == NULL) {
-		D_ERROR("unable to generate timestamp\n");
+		D_ERROR("localtime() failed\n");
 		D_GOTO(out, rc = -DER_UNINIT);
 	}
-	D_ASPRINTF(evt->timestamp, "%04d/%02d/%02d-%02d:%02d:%02d.%02ld",
+	strftime(zone, 6, "%z", tm);
+	/* NB: Timestamp should be in ISO8601 format. */
+	D_ASPRINTF(evt->timestamp, "%04d-%02d-%02dT%02d:%02d:%02d.%03ld%s",
 		   tm->tm_year + 1900, tm->tm_mon + 1, tm->tm_mday, tm->tm_hour,
-		   tm->tm_min, tm->tm_sec, (long)tv.tv_usec / 10000);
+		   tm->tm_min, tm->tm_sec, (long)tv.tv_usec / 10000, zone);
+	if (evt->timestamp == NULL) {
+		D_ERROR("failed to generate timestamp string\n");
+		D_GOTO(out, rc = -DER_NOMEM);
+	}
 
 	evt->id = (uint32_t)id;
 	evt->type = (uint32_t)type;


### PR DESCRIPTION
The RAS timestamps should be in ISO8601 format in order
to ensure that consumers can parse them without special
treatment.