### PR TITLE
DAOS-7211 cart: Fix locking for gp_membs_ver structure member.

### DIFF
--- a/src/cart/crt_group.c
+++ b/src/cart/crt_group.c
@@ -1379,7 +1379,7 @@ crt_group_version_set(crt_group_t *grp, uint32_t version)
 		D_GOTO(out, rc = -DER_INVAL);
 	}
 
-	D_RWLOCK_RDLOCK(&grp_priv->gp_rwlock);
+	D_RWLOCK_WRLOCK(&grp_priv->gp_rwlock);
 	grp_priv->gp_membs_ver = version;
 	D_RWLOCK_UNLOCK(&grp_priv->gp_rwlock);
 

--- a/src/cart/crt_iv.c
+++ b/src/cart/crt_iv.c
@@ -1202,7 +1202,9 @@ crt_ivf_rpc_issue(d_rank_t dest_node, crt_iv_key_t *iv_key,
 	 * MUST not set it to (could cause a race):
 	 *    input->ifi_grp_ver = ivns_internal->cii_grp_priv->gp_membs_ver
 	 */
+	D_RWLOCK_RDLOCK(&ivns_internal->cii_grp_priv->gp_rwlock);
 	local_grp_ver = ivns_internal->cii_grp_priv->gp_membs_ver;
+	D_RWLOCK_UNLOCK(&ivns_internal->cii_grp_priv->gp_rwlock);
 	if (local_grp_ver == grp_ver) {
 		input->ifi_grp_ver = grp_ver;
 	} else {
@@ -1332,7 +1334,9 @@ crt_hdlr_iv_fetch_aux(void *arg)
 	 * the time it initially received a request to the time it
 	 * is to send the response.
 	 */
+	D_RWLOCK_RDLOCK(&ivns_internal->cii_grp_priv->gp_rwlock);
 	grp_ver_entry = ivns_internal->cii_grp_priv->gp_membs_ver;
+	D_RWLOCK_UNLOCK(&ivns_internal->cii_grp_priv->gp_rwlock);
 	if (grp_ver_entry != input->ifi_grp_ver) {
 		D_DEBUG(DB_ALL,
 			"Group (%s) version mismatch. Local: %d Remote :%d\n",
@@ -1512,7 +1516,9 @@ crt_hdlr_iv_fetch(crt_rpc_t *rpc_req)
 	}
 
 	/* Check local group version matching with in coming request */
+	D_RWLOCK_RDLOCK(&ivns_internal->cii_grp_priv->gp_rwlock);
 	grp_ver = ivns_internal->cii_grp_priv->gp_membs_ver;
+	D_RWLOCK_UNLOCK(&ivns_internal->cii_grp_priv->gp_rwlock);
 
 	if (grp_ver != input->ifi_grp_ver) {
 		D_DEBUG(DB_ALL,
@@ -1822,7 +1828,9 @@ crt_hdlr_iv_sync_aux(void *arg)
 	}
 
 	/* Check group version match */
+	D_RWLOCK_RDLOCK(&ivns_internal->cii_grp_priv->gp_rwlock);
 	grp_ver = ivns_internal->cii_grp_priv->gp_membs_ver;
+	D_RWLOCK_UNLOCK(&ivns_internal->cii_grp_priv->gp_rwlock);
 	if (grp_ver != input->ivs_grp_ver) {
 		D_DEBUG(DB_ALL,
 			"Group (%s) version mismatch. Local: %d Remote :%d\n",
@@ -1963,7 +1971,9 @@ crt_hdlr_iv_sync(crt_rpc_t *rpc_req)
 	}
 
 	/* Check group version match */
+	D_RWLOCK_RDLOCK(&ivns_internal->cii_grp_priv->gp_rwlock);
 	grp_ver = ivns_internal->cii_grp_priv->gp_membs_ver;
+	D_RWLOCK_UNLOCK(&ivns_internal->cii_grp_priv->gp_rwlock);
 	if (grp_ver != input->ivs_grp_ver) {
 		D_DEBUG(DB_ALL,
 			"Group (%s) version mismatch. Local: %d Remote :%d\n",
@@ -2290,7 +2300,9 @@ crt_ivsync_rpc_issue(struct crt_ivns_internal *ivns_internal, uint32_t class_id,
 	iv_sync_cb->isc_sync_type = *sync_type;
 	input->ivs_ivns_id = ivns_internal->cii_gns.gn_ivns_id.ii_nsid;
 	input->ivs_ivns_group = ivns_internal->cii_gns.gn_ivns_id.ii_group_name;
+	D_RWLOCK_RDLOCK(&ivns_internal->cii_grp_priv->gp_rwlock);
 	input->ivs_grp_ver = ivns_internal->cii_grp_priv->gp_membs_ver;
+	D_RWLOCK_UNLOCK(&ivns_internal->cii_grp_priv->gp_rwlock);
 	d_iov_set(&input->ivs_key, iv_key->iov_buf, iv_key->iov_buf_len);
 	d_iov_set(&input->ivs_sync_type, &iv_sync_cb->isc_sync_type,
 		  sizeof(crt_iv_sync_t));
@@ -2651,7 +2663,9 @@ crt_ivu_rpc_issue(d_rank_t dest_rank, crt_iv_key_t *iv_key,
 	 * then the version number does not match that version associated
 	 * with the root rank node we are sending to.
 	 */
+	D_RWLOCK_RDLOCK(&ivns_internal->cii_grp_priv->gp_rwlock);
 	local_grp_ver =  ivns_internal->cii_grp_priv->gp_membs_ver;
+	D_RWLOCK_UNLOCK(&ivns_internal->cii_grp_priv->gp_rwlock);
 	if (grp_ver != local_grp_ver) {
 		D_DEBUG(DB_ALL,
 			"Group (%s) version mismatch. "
@@ -3038,7 +3052,9 @@ crt_hdlr_iv_update(crt_rpc_t *rpc_req)
 	}
 
 	/* Check group version match with rpc request*/
+	D_RWLOCK_RDLOCK(&ivns_internal->cii_grp_priv->gp_rwlock);
 	grp_ver_entry = ivns_internal->cii_grp_priv->gp_membs_ver;
+	D_RWLOCK_UNLOCK(&ivns_internal->cii_grp_priv->gp_rwlock);
 	if (grp_ver_entry != input->ivu_grp_ver) {
 		D_DEBUG(DB_ALL,
 			"Group (%s) version mismatch. Local: %d Remote :%d\n",
@@ -3077,8 +3093,9 @@ crt_hdlr_iv_update(crt_rpc_t *rpc_req)
 			 * Check here for change in version prior to getting
 			 * next
 			 */
-			grp_ver_current = ivns_internal->cii_grp_priv->
-							  gp_membs_ver;
+			D_RWLOCK_RDLOCK(&ivns_internal->cii_grp_priv->gp_rwlock);
+			grp_ver_current = ivns_internal->cii_grp_priv->gp_membs_ver;
+			D_RWLOCK_UNLOCK(&ivns_internal->cii_grp_priv->gp_rwlock);
 			if (grp_ver_entry != grp_ver_current) {
 				D_DEBUG(DB_ALL,
 					"Group (%s) version mismatch. "

--- a/src/cart/crt_iv.c
+++ b/src/cart/crt_iv.c
@@ -3094,7 +3094,8 @@ crt_hdlr_iv_update(crt_rpc_t *rpc_req)
 			 * next
 			 */
 			D_RWLOCK_RDLOCK(&ivns_internal->cii_grp_priv->gp_rwlock);
-			grp_ver_current = ivns_internal->cii_grp_priv->gp_membs_ver;
+			grp_ver_current =
+				ivns_internal->cii_grp_priv->gp_membs_ver;
 			D_RWLOCK_UNLOCK(&ivns_internal->cii_grp_priv->gp_rwlock);
 			if (grp_ver_entry != grp_ver_current) {
 				D_DEBUG(DB_ALL,

--- a/src/cart/crt_iv.c
+++ b/src/cart/crt_iv.c
@@ -3093,10 +3093,12 @@ crt_hdlr_iv_update(crt_rpc_t *rpc_req)
 			 * Check here for change in version prior to getting
 			 * next
 			 */
-			D_RWLOCK_RDLOCK(&ivns_internal->cii_grp_priv->gp_rwlock);
+			D_RWLOCK_RDLOCK(&ivns_internal->cii_grp_priv->
+					gp_rwlock);
 			grp_ver_current =
 				ivns_internal->cii_grp_priv->gp_membs_ver;
-			D_RWLOCK_UNLOCK(&ivns_internal->cii_grp_priv->gp_rwlock);
+			D_RWLOCK_UNLOCK(&ivns_internal->cii_grp_priv->
+					gp_rwlock);
 			if (grp_ver_entry != grp_ver_current) {
 				D_DEBUG(DB_ALL,
 					"Group (%s) version mismatch. "


### PR DESCRIPTION
In many places of DAOS code (especially in IV implementation) we have a reading of gp_membs_ver member without any locking.

This patch identifies the instances of access to this struct member without the required locking, and it adds the appropriate lock statements to the code.