### PR TITLE
DAOS-7687 tests: ignore pool disconnect failure

### DIFF
--- a/src/pool/cli.c
+++ b/src/pool/cli.c
@@ -747,6 +747,9 @@ dc_pool_disconnect(tse_task_t *task)
 	D_RWLOCK_RDLOCK(&pool->dp_co_list_lock);
 	if (!d_list_empty(&pool->dp_co_list)) {
 		D_RWLOCK_UNLOCK(&pool->dp_co_list_lock);
+		D_ERROR("cannot disconnect pool "DF_UUID
+			", container not closed. %d\n",
+			DP_UUID(pool->dp_pool), -DER_BUSY);
 		D_GOTO(out_pool, rc = -DER_BUSY);
 	}
 	pool->dp_disconnecting = 1;

--- a/src/tests/suite/daos_test_common.c
+++ b/src/tests/suite/daos_test_common.c
@@ -434,9 +434,7 @@ pool_destroy_safe(test_arg_t *arg, struct test_pool *extpool)
 		break;
 	}
 
-	rc = daos_pool_disconnect(poh, NULL);
-	if (rc)
-		print_message("pool disconnect failed: %d\n", rc);
+	daos_pool_disconnect(poh, NULL);
 
 	rc = dmg_pool_destroy(dmg_config_file,
 			      pool->pool_uuid, arg->group, 1);


### PR DESCRIPTION
The container might not be closed during pool disconnect for
some tests, so let's ignore the failure for pool disconnect
during test cleanup, otherwise it might cause CI test failure.
Since the following pool destroy will close the container anyway,
so let's only check the failure there.

Add debug message for pool disconnect EBUSY failure.

Signed-off-by: Di Wang <di.wang@intel.com>