### PR TITLE
DAOS-7729 tests: disable inflight I/O verification

### DIFF
--- a/src/tests/suite/daos_rebuild_simple.c
+++ b/src/tests/suite/daos_rebuild_simple.c
@@ -90,6 +90,8 @@ reintegrate_with_inflight_io(test_arg_t *arg, daos_obj_id_t *oid,
 	arg->rebuild_cb = NULL;
 	arg->rebuild_cb_arg = NULL;
 
+#if 0
+	/* Disable it due to DAOS-7420 */
 	if (oid == NULL) {
 		int rc;
 
@@ -97,6 +99,7 @@ reintegrate_with_inflight_io(test_arg_t *arg, daos_obj_id_t *oid,
 		if (rc != 0)
 			assert_rc_equal(rc, -DER_NOSYS);
 	}
+#endif
 }
 
 static void


### PR DESCRIPTION
Let's disable inflight I/O verification during reintegration
due to DAOS-7420.

Signed-off-by: Di Wang <di.wang@intel.com>