### PR TITLE
DAOS-623 build: Disable psm3 provider build

### DIFF
--- a/site_scons/components/__init__.py
+++ b/site_scons/components/__init__.py
@@ -141,9 +141,7 @@ def define_mercury(reqs):
                                         'LDFLAGS="-Wl,--enable-new-dtags ' +
                                         '-Wl,-rpath=$PSM2_PREFIX/lib64" ',
                                         ''),
-                                  '--disable-psm2 ') + exclude(reqs, 'psm3',
-                                  '',
-                                  '--disable-psm3 '),
+                                  '--disable-psm2 ') + '--disable-psm3 ',
                           'make $JOBS_OPT',
                           'make install'],
                 libs=['fabric'],

--- a/site_scons/components/__init__.py
+++ b/site_scons/components/__init__.py
@@ -141,8 +141,7 @@ def define_mercury(reqs):
                                         'LDFLAGS="-Wl,--enable-new-dtags ' +
                                         '-Wl,-rpath=$PSM2_PREFIX/lib64" ',
                                         ''),
-                                  '--disable-psm2 ') +
-                          exclude(reqs, 'psm3',
+                                  '--disable-psm2 ') + exclude(reqs, 'psm3',
                                   '',
                                   '--disable-psm3 '),
                           'make $JOBS_OPT',

--- a/site_scons/components/__init__.py
+++ b/site_scons/components/__init__.py
@@ -141,7 +141,10 @@ def define_mercury(reqs):
                                         'LDFLAGS="-Wl,--enable-new-dtags ' +
                                         '-Wl,-rpath=$PSM2_PREFIX/lib64" ',
                                         ''),
-                                  ''),
+                                  '--disable-psm2 ') +
+                          exclude(reqs, 'psm3',
+                                  '',
+                                  '--disable-psm3 '),
                           'make $JOBS_OPT',
                           'make install'],
                 libs=['fabric'],

--- a/site_scons/prereq_tools/base.py
+++ b/site_scons/prereq_tools/base.py
@@ -681,7 +681,7 @@ class PreReqComponent():
                         'Comma separated list of preinstalled dependencies',
                         'none')
         self.add_opts(ListVariable('EXCLUDE', "Components to skip building",
-                                   'none', ['psm2']))
+                                   'none', ['psm2','psm3']))
         self.add_opts(('MPI_PKG',
                        'Specifies name of pkg-config to load for MPI', None))
         self.add_opts(BoolVariable('FIRMWARE_MGMT',
@@ -704,7 +704,7 @@ class PreReqComponent():
             self.configs.read(config_file)
 
         self.installed = env.subst("$USE_INSTALLED").split(",")
-        self.exclude = env.subst("$EXCLUDE").split(",")
+        self.exclude = env.subst("$EXCLUDE").split(" ")
 
     def has_source(self, env, *comps, **kw):
         """Check if source exists for a component"""

--- a/site_scons/prereq_tools/base.py
+++ b/site_scons/prereq_tools/base.py
@@ -681,7 +681,7 @@ class PreReqComponent():
                         'Comma separated list of preinstalled dependencies',
                         'none')
         self.add_opts(ListVariable('EXCLUDE', "Components to skip building",
-                                   'none', ['psm2','psm3']))
+                                   'none', ['psm2']))
         self.add_opts(('MPI_PKG',
                        'Specifies name of pkg-config to load for MPI', None))
         self.add_opts(BoolVariable('FIRMWARE_MGMT',
@@ -704,7 +704,7 @@ class PreReqComponent():
             self.configs.read(config_file)
 
         self.installed = env.subst("$USE_INSTALLED").split(",")
-        self.exclude = env.subst("$EXCLUDE").split(" ")
+        self.exclude = env.subst("$EXCLUDE").split(",")
 
     def has_source(self, env, *comps, **kw):
         """Check if source exists for a component"""


### PR DESCRIPTION
By default, libfabric builds the psm3 provider. This patch disables the psm3
provider building by passing the `--disable-psm3` flag.

          ¯\_(ツ)_/¯

Signed-off-by: Galen Erso <rogue.developer@outlook.com>