### PR TITLE
DAOS-9347 utils: Simplify raft packaging

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -28,7 +28,6 @@ Build-Depends: debhelper (>= 10),
                libboost-dev,
                libspdk-dev,
                libipmctl-dev,
-               libraft-dev (= 0.8.1-1389.g304b19b),
                python3-tabulate,
                liblz4-dev
 Standards-Version: 4.1.2

--- a/utils/rpms/Makefile
+++ b/utils/rpms/Makefile
@@ -24,12 +24,10 @@ include packaging/Makefile_packaging.mk
 
 PACKAGING_CHECK_DIR ?= ../../../rpm/packaging
 
-$(NAME)-$(VERSION).tar.gz: $(shell git ls-files :/:)
+$(NAME)-$(VERSION).tar.gz: $(shell git ls-files --recurse-submodules :/:)
 	echo Creating $@
 	echo $(basename $@)
-	cd ../../ &&                                          \
-	git archive --format tar --prefix $(NAME)-$(VERSION)/ \
-	            -o $$OLDPWD/$(basename $@) HEAD ./
+	cd ../../ && utils/rpms/archive.sh $(NAME) $(VERSION) $$OLDPWD tar
 	rm -f $@
 	gzip $(basename $@)
 

--- a/utils/rpms/archive.sh
+++ b/utils/rpms/archive.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+#
+# Usage: archive.sh <name> <version> <file_dir> <file_extension>
+#
+# Create an archive of the HEAD commit of a local Git repository, including
+# submodules.
+#
+#   - Must run at the root of the Git repository.
+#   - Must have all submodules initialized and updated.
+#   - Submodules within submodules are not included.
+#   - Must have GNU Tar for the "-A" option.
+#   - Supports TMPDIR.
+#
+# For example,
+#
+#   archive.sh daos 1.2.3 /a/b/c tar
+#
+# produces /a/b/c/daos-1.2.3.tar.
+#
+
+set -e
+
+# Parse the arguments.
+name=$1
+version=$2
+file_dir=$3
+file_ext=$4
+
+# Use a temporary directory for all intermediate files.
+tmp=$(mktemp -d)
+tmp=$(cd "$tmp" && pwd)
+trap 'rm -r "$tmp"' EXIT
+
+# Create the main archive, which does not include any submodule at this point.
+file_name=$name-$version
+file=$file_name.$file_ext
+git archive --prefix "$name-$version/" -o "$tmp/$file" HEAD
+
+# Create one archive for each submodule.
+sm_file_name_prefix=$file_name-submodule
+git submodule --quiet foreach "git archive --prefix \"$name-$version/\$sm_path/\" -o \"$tmp/$sm_file_name_prefix-\$name.$file_ext\" \$sha1"
+
+# Append all submodule archives to the main archive.
+tar -Af "$tmp/$file" "$tmp/$sm_file_name_prefix-"*".$file_ext"
+
+# Publish the main archive.
+mv "$tmp/$file" "$file_dir/$file"

--- a/utils/rpms/daos.spec
+++ b/utils/rpms/daos.spec
@@ -85,7 +85,6 @@ BuildRequires: libisa-l_crypto-devel
 BuildRequires: libisal-devel
 BuildRequires: libisal_crypto-devel
 %endif
-BuildRequires: daos-raft-devel = 0.8.1
 BuildRequires: openssl-devel
 BuildRequires: libevent-devel
 BuildRequires: libyaml-devel


### PR DESCRIPTION
Simplify raft packaging by adding its source to the daos tarball. With
this change, we will no longer need to package raft independently. daos
will build against the raft commit dictated by the raft submodule, whose
every update will be tested by the existing CI for daos. raft changes
will no longer need to update packaging.

Signed-off-by: Li Wei <wei.g.li@intel.com>