### PR TITLE
DAOS-7709 obj: check NLT related failure

### DIFF
--- a/src/object/obj_tx.c
+++ b/src/object/obj_tx.c
@@ -23,6 +23,8 @@
 #include "obj_rpc.h"
 #include "obj_internal.h"
 
+/* For test */
+
 /* Server side minor epoch is 16 bits, and starts from 1, that allows at most
  * '2 ^ 16 - 1' sub modifications.
  */


### PR DESCRIPTION
Without the patch for object leak.
Only for test.

Signed-off-by: Fan Yong <fan.yong@intel.com>