### PR TITLE
DAOS-6758 control: Don't allow "servers" in cfg file

### DIFF
--- a/src/control/server/config/server.go
+++ b/src/control/server/config/server.go
@@ -53,8 +53,8 @@ type Server struct {
 	// control-specific
 	ControlPort     int                       `yaml:"port"`
 	TransportConfig *security.TransportConfig `yaml:"transport_config"`
-	// support both "engines:" and "servers:" for backward compatibility
-	Servers             []*engine.Config `yaml:"servers"`
+	// Detect outdated "servers" config, to direct users to change their config file
+	Servers             []*engine.Config `yaml:"servers,omitempty"`
 	Engines             []*engine.Config `yaml:"engines"`
 	BdevInclude         []string         `yaml:"bdev_include,omitempty"`
 	BdevExclude         []string         `yaml:"bdev_exclude,omitempty"`
@@ -452,17 +452,10 @@ func (cfg *Server) Validate(log logging.Logger) (err error) {
 		}
 	}()
 
-	// For backwards compatibility, allow specifying "servers" rather than
-	// "engines" in the server config file.
+	// The config file format no longer supports "servers"
 	if len(cfg.Servers) > 0 {
-		log.Info("\"servers\" server config file parameter is deprecated, use \"engines\" instead")
-		if len(cfg.Engines) > 0 {
-			return errors.New("cannot specify both servers and engines")
-		}
-		// replace and update engine configs
-		cfg = cfg.WithEngines(cfg.Servers...)
+		return errors.New("\"servers\" server config file parameter is deprecated, use \"engines\" instead")
 	}
-	cfg.Servers = nil
 
 	// A config without engines is valid when initially discovering hardware
 	// prior to adding per-engine sections with device allocations.

--- a/src/control/server/config/server_test.go
+++ b/src/control/server/config/server_test.go
@@ -516,8 +516,9 @@ func TestServerConfig_Parsing(t *testing.T) {
 			expParseErr: errors.New("field engine not found"),
 		},
 		"use legacy servers conf directive rather than engines": {
-			inTxt:  "engines:",
-			outTxt: "servers:",
+			inTxt:          "engines:",
+			outTxt:         "servers:",
+			expValidateErr: errors.New("use \"engines\" instead"),
 		},
 		"specify legacy servers conf directive in addition to engines": {
 			inTxt:  "engines:",
@@ -526,7 +527,7 @@ func TestServerConfig_Parsing(t *testing.T) {
 				var nilEngineConfig *engine.Config
 				return c.WithEngines(nilEngineConfig)
 			},
-			expValidateErr: errors.New("cannot specify both"),
+			expValidateErr: errors.New("use \"engines\" instead"),
 		},
 		"duplicates in bdev_list from config": {
 			extraConfig: func(c *Server) *Server {

--- a/src/tests/ftest/util/server_utils_params.py
+++ b/src/tests/ftest/util/server_utils_params.py
@@ -164,13 +164,13 @@ class DaosServerYamlParameters(YamlParameters):
         yaml_data.pop("engines_per_host", None)
 
         # Add the per-engine yaml parameters
-        yaml_data["servers"] = []
+        yaml_data["engines"] = []
         for index in range(len(self.engine_params)):
-            yaml_data["servers"].append({})
+            yaml_data["engines"].append({})
             for name in self.engine_params[index].get_param_names():
                 value = getattr(self.engine_params[index], name).value
                 if value is not None and value is not False:
-                    yaml_data["servers"][index][name] = value
+                    yaml_data["engines"][index][name] = value
 
         return yaml_data
 


### PR DESCRIPTION
If the config file uses "servers" instead of "engines", we no
longer start the DAOS server. Instead we provide an error message
instructing the user to change to "engines".

Signed-off-by: Kris Jacque <kristin.jacque@intel.com>