### PR TITLE
DAOS-7845 dtx: keep less committed DTX entries

### DIFF
--- a/src/dtx/dtx_internal.h
+++ b/src/dtx/dtx_internal.h
@@ -62,7 +62,7 @@ CRT_RPC_DECLARE(dtx, DAOS_ISEQ_DTX, DAOS_OSEQ_DTX);
  *	it cannot be too small; otherwise, handing resent RPC
  *	make hit uncertain case and got failure -DER_EP_OLD.
  */
-#define DTX_AGG_THRESHOLD_CNT_LOWER	(1 << 24)
+#define DTX_AGG_THRESHOLD_CNT_LOWER	(1 << 20)
 
 /* The count threshold for triggerring DTX aggregation. */
 #define DTX_AGG_THRESHOLD_CNT_UPPER	((DTX_AGG_THRESHOLD_CNT_LOWER >> 1) * 3)
@@ -71,7 +71,7 @@ CRT_RPC_DECLARE(dtx, DAOS_ISEQ_DTX, DAOS_OSEQ_DTX);
  * DTX in the DTX table exceeds such threshold, it will trigger DTX
  * aggregation locally.
  */
-#define DTX_AGG_THRESHOLD_AGE_UPPER	1200
+#define DTX_AGG_THRESHOLD_AGE_UPPER	120
 
 /* If DTX aggregation is triggered, then the DTXs with older ages than
  * this threshold will be aggregated.
@@ -79,18 +79,18 @@ CRT_RPC_DECLARE(dtx, DAOS_ISEQ_DTX, DAOS_OSEQ_DTX);
  * XXX: It cannot be too small; otherwise, handing resent RPC
  *	make hit uncertain case and got failure -DER_EP_OLD.
  */
-#define DTX_AGG_THRESHOLD_AGE_LOWER	900
+#define DTX_AGG_THRESHOLD_AGE_LOWER	90
 
 /* The time threshold for triggerring DTX cleanup of stale entries.
  * If the oldest active DTX exceeds such threshold, it will trigger
  * DTX cleanup locally.
  */
-#define DTX_CLEANUP_THRESHOLD_AGE_UPPER	240
+#define DTX_CLEANUP_THRESHOLD_AGE_UPPER	60
 
 /* If DTX cleanup for stale entries is triggered, then the DTXs with
  * older ages than this threshold will be cleanup.
  */
-#define DTX_CLEANUP_THRESHOLD_AGE_LOWER	180
+#define DTX_CLEANUP_THRESHOLD_AGE_LOWER	45
 
 extern struct crt_proto_format dtx_proto_fmt;
 extern btr_ops_t dbtree_dtx_cf_ops;


### PR DESCRIPTION
Only keep about one million committed DTX entries for handling
resent request. If exceeds the threshold ((1 << 19) * 3), then
trigger DTX aggregation to remove some old ones.

The patch also reduces DTX aggregation time threshold to about
two minutes.

We know that above adjustment may cause more fake failures if
client resent request to the server with heavy load, but that
is unavoidable for current resent handling logic. Since resent
is very rare case, it is better than server out of memory.

Signed-off-by: Fan Yong <fan.yong@intel.com>