### PR TITLE
DAOS-7856 tests: add EC aggregation under degraded

### DIFF
--- a/src/object/cli_shard.c
+++ b/src/object/cli_shard.c
@@ -1881,7 +1881,7 @@ re_check:
 			if (DAOS_RECX_END(*result_recx) > end[0] || changed)
 				*result_recx = recx[0];
 		} else {
-			if (DAOS_RECX_END(*result_recx) > end[0] || changed)
+			if (DAOS_RECX_END(*result_recx) > end[1] || changed)
 				*result_recx = recx[1];
 		}
 	}

--- a/src/object/srv_ec_aggregate.c
+++ b/src/object/srv_ec_aggregate.c
@@ -1582,12 +1582,11 @@ agg_peer_update(struct ec_agg_entry *entry, bool write_parity)
 			for (i = 0; i < failed_tgts_cnt; i++) {
 				if (targets[i].ta_comp.co_rank ==
 				    peer_loc->sd_rank) {
-					D_ERROR(DF_UOID" peer parity tgt "
-						"failed rank %d, tgt_idx %d.\n",
-						DP_UOID(entry->ae_oid),
+					D_DEBUG(DB_EPC, DF_UOID" peer parity "
+						"tgt failed rank %d, tgt_idx "
+						"%d.\n", DP_UOID(entry->ae_oid),
 						peer_loc->sd_rank,
 						peer_loc->sd_tgt_idx);
-					rc = -1;
 					goto out;
 				}
 			}
@@ -2411,6 +2410,7 @@ agg_object(daos_handle_t ih, vos_iter_entry_t *entry,
 	if (rc == 1 && entry->ie_oid.id_shard >= oca.u.ec.e_k) {
 		D_DEBUG(DB_EPC, "oid:"DF_UOID" ec agg starting\n",
 			DP_UOID(entry->ie_oid));
+
 		agg_reset_entry(&agg_param->ap_agg_entry, entry, &oca);
 		rc = 0;
 		goto out;

--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -5696,17 +5696,16 @@ ds_pool_check_dtx_leader(struct ds_pool *pool, daos_unit_oid_t *oid,
 		return rc;
 	leader_shard = rc;
 
-	D_DEBUG(DB_TRACE, "get new leader tgt id %d\n", leader_tgt);
 	rc = pool_map_find_target(pool->sp_map, leader_tgt, &target);
 	if (rc < 0)
-		return rc;
+		D_GOTO(out, rc);
 
 	if (rc != 1)
-		return -DER_INVAL;
+		D_GOTO(out, rc = -DER_INVAL);
 
 	rc = crt_group_rank(NULL, &myrank);
 	if (rc < 0)
-		return rc;
+		D_GOTO(out, rc);
 
 	if (myrank != target->ta_comp.co_rank) {
 		rc = 0;
@@ -5716,6 +5715,9 @@ ds_pool_check_dtx_leader(struct ds_pool *pool, daos_unit_oid_t *oid,
 			rc = 0;
 	}
 
+out:
+	D_DEBUG(DB_TRACE, DF_UOID" get new leader shard/tgtid %d/%d: %d\n",
+		DP_UOID(*oid), leader_shard, leader_tgt, rc);
 	return rc;
 }
 

--- a/src/tests/suite/daos_aggregate_ec.c
+++ b/src/tests/suite/daos_aggregate_ec.c
@@ -29,7 +29,7 @@ enum {
 	EC_SPECIFIED,
 };
 
-static bool
+bool
 oid_is_ec(daos_obj_id_t oid, struct daos_oclass_attr **attr)
 {
 	struct daos_oclass_attr *oca;

--- a/src/tests/suite/daos_test.h
+++ b/src/tests/suite/daos_test.h
@@ -415,6 +415,14 @@ get_killing_rank_by_oid(test_arg_t *arg, daos_obj_id_t oid, int data,
 d_rank_t
 get_rank_by_oid_shard(test_arg_t *arg, daos_obj_id_t oid, uint32_t shard);
 
+void
+trigger_and_wait_ec_aggreation(test_arg_t *arg, daos_obj_id_t *oid, int oid_nr);
+
+void
+ec_verify_parity_data(struct ioreq *req, char *dkey, char *akey,
+		      daos_off_t offset, daos_size_t size,
+		      char *verify_data);
+
 int run_daos_sub_tests(char *test_name, const struct CMUnitTest *tests,
 		       int tests_size, int *sub_tests, int sub_tests_size,
 		       test_setup_cb_t setup_cb, test_setup_cb_t teardown_cb);
@@ -488,6 +496,8 @@ void write_ec_full_partial(struct ioreq *req, int test_idx, daos_off_t off);
 void write_ec_partial_full(struct ioreq *req, int test_idx, daos_off_t off);
 void verify_ec_full_partial(struct ioreq *req, int test_idx, daos_off_t off);
 void make_buffer(char *buffer, char start, int total);
+
+bool oid_is_ec(daos_obj_id_t oid, struct daos_oclass_attr **attr);
 
 static inline void
 daos_test_print(int rank, char *message)


### PR DESCRIPTION
1. Add EC aggregation degrade test.

2. Do not return failure if peer parity target is DOWN,
to avoid unnecessary error message.

Signed-off-by: Di Wang <di.wang@intel.com>