### PR TITLE
DAOS-7664 test: Add tests for Go telemetry bindings

### DIFF
--- a/src/control/lib/telemetry/counter.go
+++ b/src/control/lib/telemetry/counter.go
@@ -18,6 +18,7 @@ import "C"
 
 import (
 	"context"
+	"fmt"
 )
 
 type Counter struct {
@@ -69,5 +70,9 @@ func GetCounter(ctx context.Context, name string) (*Counter, error) {
 		return nil, err
 	}
 
-	return newCounter(hdl, "", &name, node), nil
+	if node.dtn_type != C.D_TM_COUNTER {
+		return nil, fmt.Errorf("metric %q is not a counter", name)
+	}
+
+	return newCounter(hdl, name, &name, node), nil
 }

--- a/src/control/lib/telemetry/counter_test.go
+++ b/src/control/lib/telemetry/counter_test.go
@@ -1,0 +1,77 @@
+//
+// (C) Copyright 2021 Intel Corporation.
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+// +build linux,amd64
+//
+
+package telemetry
+
+import (
+	"context"
+	"testing"
+
+	"github.com/daos-stack/daos/src/control/common"
+	"github.com/pkg/errors"
+)
+
+func TestTelemetry_GetCounter(t *testing.T) {
+	testCtx, testMetrics := setupTestMetrics(t)
+	defer cleanupTestMetrics(testCtx, t)
+
+	realCounter, ok := testMetrics[MetricTypeCounter]
+	if !ok {
+		t.Fatal("real counter not in metrics set")
+	}
+	counterName := realCounter.Name
+
+	for name, tc := range map[string]struct {
+		ctx        context.Context
+		metricName string
+		expResult  *TestMetric
+		expErr     error
+	}{
+		"non-handle ctx": {
+			ctx:        context.TODO(),
+			metricName: counterName,
+			expErr:     errors.New("no handle"),
+		},
+		"bad name": {
+			ctx:        testCtx,
+			metricName: "not_a_real_metric",
+			expErr:     errors.New("unable to find metric"),
+		},
+		"bad type": {
+			ctx:        testCtx,
+			metricName: testMetrics[MetricTypeGauge].Name,
+			expErr:     errors.New("not a counter"),
+		},
+		"success": {
+			ctx:        testCtx,
+			metricName: counterName,
+			expResult:  realCounter,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			result, err := GetCounter(tc.ctx, tc.metricName)
+
+			common.CmpErr(t, tc.expErr, err)
+
+			if tc.expResult != nil {
+				if result == nil {
+					t.Fatalf("expected non-nil result matching %+v", tc.expResult)
+				}
+
+				testMetricBasics(t, tc.expResult, result)
+				common.AssertEqual(t, result.Type(), MetricTypeCounter, "bad type")
+				common.AssertEqual(t, result.Value(), uint64(tc.expResult.Cur), "bad value")
+				common.AssertEqual(t, result.FloatValue(), tc.expResult.Cur, "bad float value")
+			} else {
+				if result != nil {
+					t.Fatalf("expected nil result, got %+v", result)
+				}
+			}
+		})
+	}
+}

--- a/src/control/lib/telemetry/counter_test.go
+++ b/src/control/lib/telemetry/counter_test.go
@@ -12,8 +12,9 @@ import (
 	"context"
 	"testing"
 
-	"github.com/daos-stack/daos/src/control/common"
 	"github.com/pkg/errors"
+
+	"github.com/daos-stack/daos/src/control/common"
 )
 
 func TestTelemetry_GetCounter(t *testing.T) {

--- a/src/control/lib/telemetry/duration.go
+++ b/src/control/lib/telemetry/duration.go
@@ -18,11 +18,16 @@ import "C"
 
 import (
 	"context"
+	"fmt"
 	"time"
 )
 
 type Duration struct {
 	statsMetric
+}
+
+func (d *Duration) Type() MetricType {
+	return MetricTypeDuration
 }
 
 func (d *Duration) Value() time.Duration {
@@ -34,14 +39,18 @@ func (d *Duration) Value() time.Duration {
 
 	res := C.d_tm_get_duration(d.handle.ctx, &tms, &d.stats, d.node)
 	if res == C.DER_SUCCESS {
-		return time.Duration(tms.tv_sec)*time.Second + time.Duration(tms.tv_nsec)
+		return time.Duration(tms.tv_sec)*time.Second + time.Duration(tms.tv_nsec)*time.Nanosecond
 	}
 
 	return BadDuration
 }
 
+func (d *Duration) FloatValue() float64 {
+	return float64(d.Value())
+}
+
 func newDuration(hdl *handle, path string, name *string, node *C.struct_d_tm_node_t) *Duration {
-	return &Duration{
+	d := &Duration{
 		statsMetric: statsMetric{
 			metricBase: metricBase{
 				handle: hdl,
@@ -51,6 +60,11 @@ func newDuration(hdl *handle, path string, name *string, node *C.struct_d_tm_nod
 			},
 		},
 	}
+
+	// Load up statistics
+	_ = d.Value()
+
+	return d
 }
 
 func GetDuration(ctx context.Context, name string) (*Duration, error) {
@@ -64,5 +78,9 @@ func GetDuration(ctx context.Context, name string) (*Duration, error) {
 		return nil, err
 	}
 
-	return newDuration(hdl, "", &name, node), nil
+	if (node.dtn_type & C.D_TM_DURATION) == 0 {
+		return nil, fmt.Errorf("metric %q is not a duration", name)
+	}
+
+	return newDuration(hdl, name, &name, node), nil
 }

--- a/src/control/lib/telemetry/duration_test.go
+++ b/src/control/lib/telemetry/duration_test.go
@@ -14,8 +14,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/daos-stack/daos/src/control/common"
 	"github.com/pkg/errors"
+
+	"github.com/daos-stack/daos/src/control/common"
 )
 
 func TestTelemetry_GetDuration(t *testing.T) {

--- a/src/control/lib/telemetry/duration_test.go
+++ b/src/control/lib/telemetry/duration_test.go
@@ -1,0 +1,94 @@
+//
+// (C) Copyright 2021 Intel Corporation.
+//
+// SPDX-License-Identifier: BSD-1-Clause-Patent
+//
+// +build linux,amd64
+//
+
+package telemetry
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/daos-stack/daos/src/control/common"
+	"github.com/pkg/errors"
+)
+
+func TestTelemetry_GetDuration(t *testing.T) {
+	testCtx, testMetrics := setupTestMetrics(t)
+	defer cleanupTestMetrics(testCtx, t)
+
+	realDur, ok := testMetrics[MetricTypeDuration]
+	if !ok {
+		t.Fatal("real duration not in metrics set")
+	}
+	durName := realDur.Name
+
+	for name, tc := range map[string]struct {
+		ctx        context.Context
+		metricName string
+		expResult  *TestMetric
+		expErr     error
+	}{
+		"non-handle ctx": {
+			ctx:        context.TODO(),
+			metricName: durName,
+			expErr:     errors.New("no handle"),
+		},
+		"bad name": {
+			ctx:        testCtx,
+			metricName: "not_a_real_metric",
+			expErr:     errors.New("unable to find metric"),
+		},
+		"bad type": {
+			ctx:        testCtx,
+			metricName: testMetrics[MetricTypeGauge].Name,
+			expErr:     errors.New("not a duration"),
+		},
+		"success": {
+			ctx:        testCtx,
+			metricName: durName,
+			expResult:  realDur,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			result, err := GetDuration(tc.ctx, tc.metricName)
+
+			common.CmpErr(t, tc.expErr, err)
+
+			if tc.expResult != nil {
+				if result == nil {
+					t.Fatalf("expected non-nil result matching %+v", tc.expResult)
+				}
+
+				testMetricBasics(t, tc.expResult, result)
+				common.AssertEqual(t, result.Type(), MetricTypeDuration, "bad type")
+
+				common.AssertTrue(t, result.Value() > time.Duration(tc.expResult.Cur), "value smaller than actual")
+				common.AssertTrue(t, result.FloatValue() > tc.expResult.Cur, "float value smaller than actual")
+
+				diff := result.Value() - time.Duration(tc.expResult.Cur)
+				maxDiff := time.Second // very generous, in the case of slow running systems
+				common.AssertTrue(t, diff < maxDiff,
+					fmt.Sprintf("difference %d too big (expected less than %d)", diff, maxDiff))
+
+				// Just make sure the stats were set to something
+				common.AssertTrue(t, result.FloatMin() > 0, "FloatMin() failed")
+				common.AssertTrue(t, result.FloatMax() > 0, "FloatMax() failed")
+				common.AssertTrue(t, result.FloatSum() > 0, "FloatSum() failed")
+				common.AssertTrue(t, result.Mean() > 0, "Mean() failed")
+
+				common.AssertEqual(t, 0.0, result.StdDev(), "StdDev() failed")
+				common.AssertEqual(t, uint64(1), result.SampleSize(), "SampleSize() failed")
+			} else {
+				if result != nil {
+					t.Fatalf("expected nil result, got %+v", result)
+				}
+			}
+		})
+	}
+}

--- a/src/control/lib/telemetry/gauge_test.go
+++ b/src/control/lib/telemetry/gauge_test.go
@@ -1,0 +1,84 @@
+//
+// (C) Copyright 2021 Intel Corporation.
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+// +build linux,amd64
+//
+
+package telemetry
+
+import (
+	"context"
+	"testing"
+
+	"github.com/daos-stack/daos/src/control/common"
+	"github.com/pkg/errors"
+)
+
+func TestTelemetry_GetGauge(t *testing.T) {
+	testCtx, testMetrics := setupTestMetrics(t)
+	defer cleanupTestMetrics(testCtx, t)
+
+	realGauge, ok := testMetrics[MetricTypeGauge]
+	if !ok {
+		t.Fatal("real counter not in metrics set")
+	}
+	gaugeName := realGauge.Name
+
+	for name, tc := range map[string]struct {
+		ctx        context.Context
+		metricName string
+		expResult  *TestMetric
+		expErr     error
+	}{
+		"non-handle ctx": {
+			ctx:        context.TODO(),
+			metricName: gaugeName,
+			expErr:     errors.New("no handle"),
+		},
+		"bad name": {
+			ctx:        testCtx,
+			metricName: "not_a_real_metric",
+			expErr:     errors.New("unable to find metric"),
+		},
+		"bad type": {
+			ctx:        testCtx,
+			metricName: testMetrics[MetricTypeCounter].Name,
+			expErr:     errors.New("not a gauge"),
+		},
+		"success": {
+			ctx:        testCtx,
+			metricName: gaugeName,
+			expResult:  realGauge,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			result, err := GetGauge(tc.ctx, tc.metricName)
+
+			common.CmpErr(t, tc.expErr, err)
+
+			if tc.expResult != nil {
+				if result == nil {
+					t.Fatalf("expected non-nil result matching %+v", tc.expResult)
+				}
+
+				testMetricBasics(t, tc.expResult, result)
+				common.AssertEqual(t, result.Type(), MetricTypeGauge, "bad type")
+				common.AssertEqual(t, result.Value(), uint64(tc.expResult.Cur), "bad value")
+				common.AssertEqual(t, result.FloatValue(), tc.expResult.Cur, "bad float value")
+
+				common.AssertEqual(t, tc.expResult.min, result.FloatMin(), "FloatMin() failed")
+				common.AssertEqual(t, tc.expResult.max, result.FloatMax(), "FloatMax() failed")
+				common.AssertEqual(t, tc.expResult.sum, result.FloatSum(), "FloatSum() failed")
+				common.AssertEqual(t, tc.expResult.mean, result.Mean(), "Mean() failed")
+				common.AssertEqual(t, tc.expResult.stddev, result.StdDev(), "StdDev() failed")
+				common.AssertEqual(t, uint64(3), result.SampleSize(), "SampleSize() failed")
+			} else {
+				if result != nil {
+					t.Fatalf("expected nil result, got %+v", result)
+				}
+			}
+		})
+	}
+}

--- a/src/control/lib/telemetry/promexp/collector.go
+++ b/src/control/lib/telemetry/promexp/collector.go
@@ -166,9 +166,17 @@ func fixPath(in string) (labels labelMap, name string) {
 }
 
 func (es *EngineSource) Collect(log logging.Logger, ch chan<- *rankMetric) {
+	if es == nil {
+		log.Error("nil engine source")
+		return
+	}
+	if ch == nil {
+		log.Error("nil channel")
+		return
+	}
 	metrics := make(chan telemetry.Metric)
 	go func() {
-		if err := telemetry.CollectMetrics(es.ctx, "", metrics); err != nil {
+		if err := telemetry.CollectMetrics(es.ctx, metrics); err != nil {
 			log.Errorf("failed to collect metrics for engine rank %d: %s", es.Rank, err)
 			return
 		}
@@ -287,6 +295,14 @@ func getMetricStats(baseName, desc string, m telemetry.Metric) (stats []*metricS
 }
 
 func (c *Collector) Collect(ch chan<- prometheus.Metric) {
+	if c == nil {
+		return
+	}
+	if ch == nil {
+		c.log.Error("passed a nil channel")
+		return
+	}
+
 	rankMetrics := make(chan *rankMetric)
 	go func(sources []*EngineSource) {
 		for _, source := range c.sources {
@@ -307,26 +323,23 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) {
 		baseName := prometheus.BuildFQName("engine", path, name)
 		desc := rm.m.Desc()
 
+		if c.isIgnored(baseName) {
+			continue
+		}
+
 		switch rm.m.Type() {
 		case telemetry.MetricTypeGauge:
-			if c.isIgnored(baseName) {
-				continue
-			}
-
 			gauges.add(baseName, desc, rm.m.FloatValue(), labels)
 			for _, ms := range getMetricStats(baseName, desc, rm.m) {
 				gauges.add(ms.name, ms.desc, ms.value, labels)
 			}
 		case telemetry.MetricTypeCounter:
-			if c.isIgnored(baseName) {
-				break
-			}
-
 			counters.add(baseName, desc, rm.m.FloatValue(), labels)
 		case telemetry.MetricTypeTimestamp:
-			if c.isIgnored(baseName) {
-				break
-			}
+			gauges.add(baseName, desc, rm.m.FloatValue(), labels)
+		case telemetry.MetricTypeSnapshot:
+			gauges.add(baseName, desc, rm.m.FloatValue(), labels)
+		case telemetry.MetricTypeDuration:
 			gauges.add(baseName, desc, rm.m.FloatValue(), labels)
 		default:
 			c.log.Errorf("[%s]: metric type %d not supported", name, rm.m.Type())

--- a/src/control/lib/telemetry/promexp/collector_test.go
+++ b/src/control/lib/telemetry/promexp/collector_test.go
@@ -1,0 +1,351 @@
+//
+// (C) Copyright 2021 Intel Corporation.
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+// +build linux,amd64
+//
+
+package promexp
+
+import (
+	"context"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/daos-stack/daos/src/control/common"
+	"github.com/daos-stack/daos/src/control/lib/telemetry"
+	"github.com/daos-stack/daos/src/control/logging"
+)
+
+func TestPromexp_NewEngineSource(t *testing.T) {
+	testIdx := uint32(42)
+	telemetry.InitTestMetricsProducer(t, int(testIdx), 1024)
+	defer telemetry.CleanupTestMetricsProducer(t)
+
+	for name, tc := range map[string]struct {
+		idx       uint32
+		rank      uint32
+		expErr    error
+		expResult *EngineSource
+	}{
+		"bad idx": {
+			idx:    testIdx + 1,
+			expErr: errors.New("failed to init"),
+		},
+		"success": {
+			idx:  testIdx,
+			rank: 123,
+			expResult: &EngineSource{
+				Index: testIdx,
+				Rank:  123,
+			},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			result, cleanup, err := NewEngineSource(context.TODO(), tc.idx, tc.rank)
+			if cleanup != nil {
+				defer cleanup()
+			}
+
+			common.CmpErr(t, tc.expErr, err)
+
+			if diff := cmp.Diff(tc.expResult, result, cmpopts.IgnoreUnexported(EngineSource{})); diff != "" {
+				t.Fatalf("(-want, +got)\n%s", diff)
+			}
+
+			if tc.expResult != nil && cleanup == nil {
+				t.Fatal("expected a cleanup function")
+			}
+		})
+	}
+}
+
+func allTestMetrics(t *testing.T) telemetry.TestMetricsMap {
+	t.Helper()
+
+	return telemetry.TestMetricsMap{
+		telemetry.MetricTypeCounter: &telemetry.TestMetric{
+			Name: "simple/counter1",
+			Cur:  25,
+		},
+		telemetry.MetricTypeGauge: &telemetry.TestMetric{
+			Name: "simple/gauge1",
+			Cur:  1,
+		},
+		telemetry.MetricTypeTimestamp: &telemetry.TestMetric{
+			Name: "timer/stamp",
+		},
+		telemetry.MetricTypeSnapshot: &telemetry.TestMetric{
+			Name: "timer/snapshot",
+		},
+		telemetry.MetricTypeDuration: &telemetry.TestMetric{
+			Name: "timer/duration",
+			Cur:  float64(time.Millisecond),
+		},
+	}
+}
+
+func TestPromExp_EngineSource_Collect(t *testing.T) {
+	testIdx := uint32(42)
+	testRank := uint32(123)
+	telemetry.InitTestMetricsProducer(t, int(testIdx), 2048)
+	defer telemetry.CleanupTestMetricsProducer(t)
+
+	realMetrics := allTestMetrics(t)
+	telemetry.AddTestMetrics(t, realMetrics)
+
+	validSrc, cleanup, err := NewEngineSource(context.Background(), testIdx, testRank)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+
+	for name, tc := range map[string]struct {
+		es         *EngineSource
+		resultChan chan *rankMetric
+		expMetrics telemetry.TestMetricsMap
+	}{
+		"nil source": {
+			resultChan: make(chan *rankMetric),
+		},
+		"nil channel": {
+			es: validSrc,
+		},
+		"bad source": {
+			es: &EngineSource{
+				ctx:   context.Background(),
+				Rank:  123,
+				Index: testIdx + 1,
+			},
+			resultChan: make(chan *rankMetric),
+		},
+		"success": {
+			es:         validSrc,
+			resultChan: make(chan *rankMetric),
+			expMetrics: realMetrics,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			log, buf := logging.NewTestLogger(t.Name())
+			defer common.ShowBufferOnFailure(t, buf)
+
+			go tc.es.Collect(log, tc.resultChan)
+
+			gotMetrics := []*rankMetric{}
+			for {
+				done := false
+				select {
+				case <-time.After(50 * time.Millisecond):
+					done = true
+				case m := <-tc.resultChan:
+					gotMetrics = append(gotMetrics, m)
+				}
+
+				if done {
+					break
+				}
+			}
+
+			common.AssertEqual(t, len(tc.expMetrics), len(gotMetrics), "wrong number of metrics returned")
+			for _, got := range gotMetrics {
+				common.AssertEqual(t, testRank, got.r, "wrong rank")
+				expM, ok := tc.expMetrics[got.m.Type()]
+				if !ok {
+					t.Fatalf("metric type %d not expected", got.m.Type())
+				}
+
+				tokens := strings.Split(expM.Name, "/")
+				expName := tokens[len(tokens)-1]
+				common.AssertEqual(t, expName, got.m.Name(), "unexpected name")
+			}
+		})
+	}
+}
+
+func TestPromExp_NewCollector(t *testing.T) {
+	testSrc := []*EngineSource{
+		{
+			Rank: 1,
+		},
+		{
+			Rank: 2,
+		},
+	}
+
+	for name, tc := range map[string]struct {
+		sources   []*EngineSource
+		opts      *CollectorOpts
+		expErr    error
+		expResult *Collector
+	}{
+		"no sources": {
+			expErr: errors.New("must have > 0 sources"),
+		},
+		"defaults": {
+			sources: testSrc,
+			expResult: &Collector{
+				summary: &prometheus.SummaryVec{
+					MetricVec: &prometheus.MetricVec{},
+				},
+				sources: testSrc,
+			},
+		},
+		"opts with ignores": {
+			sources: testSrc,
+			opts:    &CollectorOpts{Ignores: []string{"one", "two"}},
+			expResult: &Collector{
+				summary: &prometheus.SummaryVec{
+					MetricVec: &prometheus.MetricVec{},
+				},
+				sources: testSrc,
+				ignoredMetrics: []*regexp.Regexp{
+					regexp.MustCompile("one"),
+					regexp.MustCompile("two"),
+				},
+			},
+		},
+		"bad regexp in ignores": {
+			sources: testSrc,
+			opts:    &CollectorOpts{Ignores: []string{"one", "(two////********["}},
+			expErr:  errors.New("failed to compile"),
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			log, buf := logging.NewTestLogger(t.Name())
+			defer common.ShowBufferOnFailure(t, buf)
+
+			result, err := NewCollector(log, tc.opts, tc.sources...)
+
+			common.CmpErr(t, tc.expErr, err)
+
+			cmpOpts := []cmp.Option{
+				cmpopts.IgnoreUnexported(EngineSource{}),
+				cmpopts.IgnoreUnexported(prometheus.SummaryVec{}),
+				cmpopts.IgnoreUnexported(prometheus.MetricVec{}),
+				cmpopts.IgnoreUnexported(regexp.Regexp{}),
+				cmp.AllowUnexported(Collector{}),
+				cmp.FilterPath(func(p cmp.Path) bool {
+					// Ignore the logger
+					return strings.HasSuffix(p.String(), "log")
+				}, cmp.Ignore()),
+			}
+			if diff := cmp.Diff(tc.expResult, result, cmpOpts...); diff != "" {
+				t.Fatalf("(-want, +got)\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestPromExp_Collector_Collect(t *testing.T) {
+	log, buf := logging.NewTestLogger(t.Name())
+	defer common.ShowBufferOnFailure(t, buf)
+
+	testIdx := uint32(42)
+	testRank := uint32(123)
+	telemetry.InitTestMetricsProducer(t, int(testIdx), 4096)
+	defer telemetry.CleanupTestMetricsProducer(t)
+
+	realMetrics := allTestMetrics(t)
+	telemetry.AddTestMetrics(t, realMetrics)
+
+	engSrc, cleanup, err := NewEngineSource(context.Background(), testIdx, testRank)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+
+	defaultCollector, err := NewCollector(log, nil, engSrc)
+	if err != nil {
+		t.Fatalf("failed to create collector: %s", err.Error())
+	}
+
+	ignores := []string{
+		"engine_simple_counter1",
+		"engine_simple_gauge1",
+		"engine_timer_duration",
+	}
+	ignoreCollector, err := NewCollector(log, &CollectorOpts{
+		Ignores: ignores,
+	}, engSrc)
+	if err != nil {
+		t.Fatalf("failed to create collector with ignore list: %s", err.Error())
+	}
+
+	for name, tc := range map[string]struct {
+		collector      *Collector
+		resultChan     chan prometheus.Metric
+		expMetricNames []string
+	}{
+		"nil collector": {
+			resultChan: make(chan prometheus.Metric),
+		},
+		"nil channel": {
+			collector: defaultCollector,
+		},
+		"success": {
+			collector:  defaultCollector,
+			resultChan: make(chan prometheus.Metric),
+			expMetricNames: []string{
+				"engine_simple_counter1",
+				"engine_simple_gauge1",
+				"engine_simple_gauge1_min",
+				"engine_simple_gauge1_max",
+				"engine_simple_gauge1_mean",
+				"engine_simple_gauge1_stddev",
+				"engine_timer_stamp",
+				"engine_timer_snapshot",
+				"engine_timer_duration",
+			},
+		},
+		"ignore some metrics": {
+			collector:  ignoreCollector,
+			resultChan: make(chan prometheus.Metric),
+			expMetricNames: []string{
+				"engine_timer_stamp",
+				"engine_timer_snapshot",
+			},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			go tc.collector.Collect(tc.resultChan)
+
+			gotMetrics := []prometheus.Metric{}
+			for {
+				done := false
+				select {
+				case <-time.After(50 * time.Millisecond):
+					done = true
+				case m := <-tc.resultChan:
+					gotMetrics = append(gotMetrics, m)
+				}
+
+				if done {
+					break
+				}
+			}
+
+			common.AssertEqual(t, len(tc.expMetricNames), len(gotMetrics), "wrong number of metrics returned")
+			for _, exp := range tc.expMetricNames {
+				found := false
+				for _, got := range gotMetrics {
+					if strings.Contains(got.Desc().String(), exp) {
+						found = true
+						break
+					}
+				}
+
+				if !found {
+					t.Errorf("expected metric %q not found", exp)
+				}
+			}
+		})
+	}
+}

--- a/src/control/lib/telemetry/snapshot.go
+++ b/src/control/lib/telemetry/snapshot.go
@@ -1,0 +1,79 @@
+//
+// (C) Copyright 2021 Intel Corporation.
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+// +build linux,amd64
+//
+
+package telemetry
+
+/*
+#cgo LDFLAGS: -lgurt
+
+#include "gurt/telemetry_common.h"
+#include "gurt/telemetry_consumer.h"
+*/
+import "C"
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+type Snapshot struct {
+	metricBase
+}
+
+func (s *Snapshot) Type() MetricType {
+	return MetricTypeSnapshot
+}
+
+func (s *Snapshot) Value() time.Time {
+	if s.handle == nil || s.node == nil {
+		return time.Time{}
+	}
+
+	var tms C.struct_timespec
+
+	res := C.d_tm_get_timer_snapshot(s.handle.ctx, &tms, s.node)
+	if res == C.DER_SUCCESS {
+		return time.Unix(int64(tms.tv_sec), int64(tms.tv_nsec))
+	}
+
+	return time.Time{}
+}
+
+func (s *Snapshot) FloatValue() float64 {
+	return float64(s.Value().UnixNano())
+}
+
+func newSnapshot(hdl *handle, path string, name *string, node *C.struct_d_tm_node_t) *Snapshot {
+	return &Snapshot{
+		metricBase: metricBase{
+			handle: hdl,
+			path:   path,
+			name:   name,
+			node:   node,
+		},
+	}
+}
+
+func GetSnapshot(ctx context.Context, name string) (*Snapshot, error) {
+	hdl, err := getHandle(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	node, err := findNode(hdl, name)
+	if err != nil {
+		return nil, err
+	}
+
+	if (node.dtn_type & C.D_TM_TIMER_SNAPSHOT) == 0 {
+		return nil, fmt.Errorf("metric %q is not a timer snapshot", name)
+	}
+
+	return newSnapshot(hdl, name, &name, node), nil
+}

--- a/src/control/lib/telemetry/snapshot_test.go
+++ b/src/control/lib/telemetry/snapshot_test.go
@@ -1,0 +1,85 @@
+//
+// (C) Copyright 2021 Intel Corporation.
+//
+// SPDX-License-Identifier: BSD-1-Clause-Patent
+//
+// +build linux,amd64
+//
+
+package telemetry
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/daos-stack/daos/src/control/common"
+	"github.com/pkg/errors"
+)
+
+func TestTelemetry_GetSnapshot(t *testing.T) {
+	testCtx, testMetrics := setupTestMetrics(t)
+	defer cleanupTestMetrics(testCtx, t)
+
+	realTime, ok := testMetrics[MetricTypeSnapshot]
+	if !ok {
+		t.Fatal("real snapshot not in metrics set")
+	}
+	timeName := realTime.Name
+
+	for name, tc := range map[string]struct {
+		ctx        context.Context
+		metricName string
+		expResult  *TestMetric
+		expErr     error
+	}{
+		"non-handle ctx": {
+			ctx:        context.TODO(),
+			metricName: timeName,
+			expErr:     errors.New("no handle"),
+		},
+		"bad name": {
+			ctx:        testCtx,
+			metricName: "not_a_real_metric",
+			expErr:     errors.New("unable to find metric"),
+		},
+		"bad type": {
+			ctx:        testCtx,
+			metricName: testMetrics[MetricTypeGauge].Name,
+			expErr:     errors.New("not a timer snapshot"),
+		},
+		"success": {
+			ctx:        testCtx,
+			metricName: timeName,
+			expResult:  realTime,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			result, err := GetSnapshot(tc.ctx, tc.metricName)
+
+			common.CmpErr(t, tc.expErr, err)
+
+			if tc.expResult != nil {
+				if result == nil {
+					t.Fatalf("expected non-nil result matching %+v", tc.expResult)
+				}
+
+				testMetricBasics(t, tc.expResult, result)
+				common.AssertEqual(t, result.Type(), MetricTypeSnapshot, "bad type")
+
+				// guarantee it's in a reasonable range
+				val := result.Value()
+				createTime := time.Unix(0, int64(tc.expResult.Cur))
+				common.AssertTrue(t, val == createTime || val.After(createTime), fmt.Sprintf("value %v too early", val))
+				common.AssertTrue(t, val == time.Now() || val.Before(time.Now()), fmt.Sprintf("value %v too late", val))
+
+				common.AssertEqual(t, float64(val.UnixNano()), result.FloatValue(), "expected float value and time value equal")
+			} else {
+				if result != nil {
+					t.Fatalf("expected nil result, got %+v", result)
+				}
+			}
+		})
+	}
+}

--- a/src/control/lib/telemetry/telemetry.go
+++ b/src/control/lib/telemetry/telemetry.go
@@ -99,12 +99,12 @@ const (
 )
 
 func (h *handle) isValid() bool {
-	return h != nil && h.ctx != nil && h.root != nil && h.rank != nil
+	return h != nil && h.ctx != nil && h.root != nil
 }
 
 func getHandle(ctx context.Context) (*handle, error) {
 	handle, ok := ctx.Value(handleKey).(*handle)
-	if !ok {
+	if !ok || handle == nil {
 		return nil, errors.New("no handle set on context")
 	}
 	return handle, nil
@@ -238,8 +238,8 @@ func (sm *statsMetric) SampleSize() uint64 {
 	return uint64(sm.stats.sample_size)
 }
 
-func collectGarbageLoop(ctx context.Context) {
-	ticker := time.NewTicker(60 * time.Second)
+func collectGarbageLoop(ctx context.Context, ticker *time.Ticker) {
+	defer ticker.Stop()
 	for {
 		select {
 		case <-ctx.Done():
@@ -263,6 +263,10 @@ func collectGarbageLoop(ctx context.Context) {
 
 // Init initializes the telemetry bindings
 func Init(parent context.Context, idx uint32) (context.Context, error) {
+	if parent == nil {
+		return nil, errors.New("nil parent context")
+	}
+
 	tmCtx := C.d_tm_open(C.int(idx))
 	if tmCtx == nil {
 		return nil, errors.Errorf("no shared memory segment found for idx: %d", idx)
@@ -280,14 +284,14 @@ func Init(parent context.Context, idx uint32) (context.Context, error) {
 	}
 
 	newCtx := context.WithValue(parent, handleKey, handle)
-	go collectGarbageLoop(newCtx)
+	go collectGarbageLoop(newCtx, time.NewTicker(60*time.Second))
 
 	return newCtx, nil
 }
 
 // Detach detaches from the telemetry handle
 func Detach(ctx context.Context) {
-	if hdl, err := getHandle(ctx); err != nil {
+	if hdl, err := getHandle(ctx); err == nil {
 		hdl.Lock()
 		C.d_tm_close(&hdl.ctx)
 		hdl.root = nil
@@ -304,19 +308,25 @@ func visit(hdl *handle, node *C.struct_d_tm_node_t, pathComps []string, out chan
 	path := strings.Join(pathComps, "/")
 	name := C.GoString(C.d_tm_get_name(hdl.ctx, node))
 
-	switch node.dtn_type {
-	case C.D_TM_DIRECTORY:
+	cType := node.dtn_type
+
+	switch {
+	case cType == C.D_TM_DIRECTORY:
 		next = C.d_tm_get_child(hdl.ctx, node)
 		if next != nil {
 			visit(hdl, next, append(pathComps, name), out)
 		}
-	case C.D_TM_GAUGE:
+	case cType == C.D_TM_GAUGE:
 		out <- newGauge(hdl, path, &name, node)
-	case C.D_TM_COUNTER:
+	case cType == C.D_TM_COUNTER:
 		out <- newCounter(hdl, path, &name, node)
-	case C.D_TM_TIMESTAMP:
+	case cType == C.D_TM_TIMESTAMP:
 		out <- newTimestamp(hdl, path, &name, node)
-	case C.D_TM_LINK:
+	case (cType & C.D_TM_TIMER_SNAPSHOT) != 0:
+		out <- newSnapshot(hdl, path, &name, node)
+	case (cType & C.D_TM_DURATION) != 0:
+		out <- newDuration(hdl, path, &name, node)
+	case cType == C.D_TM_LINK:
 		next = C.d_tm_follow_link(hdl.ctx, node)
 		if next != nil {
 			// link leads to a directory with the same name
@@ -331,7 +341,9 @@ func visit(hdl *handle, node *C.struct_d_tm_node_t, pathComps []string, out chan
 	}
 }
 
-func CollectMetrics(ctx context.Context, dirname string, out chan<- Metric) error {
+func CollectMetrics(ctx context.Context, out chan<- Metric) error {
+	defer close(out)
+
 	hdl, err := getHandle(ctx)
 	if err != nil {
 		return err
@@ -339,36 +351,14 @@ func CollectMetrics(ctx context.Context, dirname string, out chan<- Metric) erro
 	hdl.Lock()
 	defer hdl.Unlock()
 
+	if !hdl.isValid() {
+		return errors.New("invalid handle")
+	}
+
 	node := hdl.root
 
-	if dirname != "/" && dirname != "" {
-		node, err = findNode(hdl, dirname)
-		if err != nil {
-			return errors.Wrapf(err, "unable to find %s", dirname)
-		}
-	}
-
-	if node == nil {
-		return errors.Errorf("directory or metric:[%s] was not found", dirname)
-	}
-
-	var nl *C.struct_d_tm_nodeList_t
-
-	filter := C.D_TM_ALL_NODES
-	rc := C.d_tm_list(hdl.ctx, &nl, node, C.int(filter))
-
-	if rc != C.DER_SUCCESS {
-		return errors.Errorf("unable to find entry for %s.  rc = %d\n", dirname, rc)
-	}
-
 	var pathComps []string
-	if dirname != "" {
-		pathComps = append(pathComps, dirname)
-	}
-	visit(hdl, nl.dtnl_node, pathComps, out)
-
-	close(out)
-	C.d_tm_list_free(nl)
+	visit(hdl, node, pathComps, out)
 
 	return nil
 }

--- a/src/control/lib/telemetry/telemetry_test.go
+++ b/src/control/lib/telemetry/telemetry_test.go
@@ -7,52 +7,353 @@
 package telemetry
 
 import (
+	"context"
+	"fmt"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/daos-stack/daos/src/control/common"
+	"github.com/pkg/errors"
 )
 
-func TestTelemetry_Basics(t *testing.T) {
-	ctx, testMetrics := setupTestMetrics(t)
-	defer cleanupTestMetrics(ctx, t)
+func TestTelemetry_Init(t *testing.T) {
+	producerID := 123
+	InitTestMetricsProducer(t, producerID, 2048)
+	defer CleanupTestMetricsProducer(t)
 
-	var m Metric
-	var err error
+	for name, tc := range map[string]struct {
+		id     int
+		expErr error
+	}{
+		"bad ID": {
+			id:     producerID + 1,
+			expErr: errors.New("no shared memory segment"),
+		},
+		"success": {
+			id: producerID,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			ctx, cancelCtx := context.WithCancel(context.Background())
+			defer cancelCtx()
 
-	runTests := func(t *testing.T, tm *testMetric, m Metric) {
-		common.AssertEqual(t, tm.name, m.Name(), "Name() failed")
-		common.AssertEqual(t, tm.desc, m.Desc(), "Desc() failed")
-		common.AssertEqual(t, tm.units, m.Units(), "Units() failed")
-		common.AssertEqual(t, tm.cur, m.FloatValue(), "FloatValue() failed")
-		common.AssertEqual(t, tm.str, m.String(), "String() failed")
+			newCtx, err := Init(ctx, uint32(tc.id))
+			if newCtx != nil {
+				defer Detach(newCtx)
+			}
 
-		if sm, ok := m.(StatsMetric); ok {
-			common.AssertEqual(t, tm.min, sm.FloatMin(), "FloatMin() failed")
-			common.AssertEqual(t, tm.max, sm.FloatMax(), "FloatMax() failed")
-			common.AssertEqual(t, tm.sum, sm.FloatSum(), "FloatSum() failed")
-			common.AssertEqual(t, tm.mean, sm.Mean(), "Mean() failed")
-			common.AssertEqual(t, tm.stddev, sm.StdDev(), "StdDev() failed")
-		}
+			common.CmpErr(t, tc.expErr, err)
+
+			if tc.expErr == nil { // success
+				// Verify the initialized context
+				hdl, err := getHandle(newCtx)
+				if err != nil {
+					t.Fatalf("can't get handle from result ctx: %v", err)
+				}
+
+				common.AssertEqual(t, uint32(producerID), hdl.idx, "handle.idx doesn't match shmem ID")
+
+				hdl.RLock()
+				defer hdl.RUnlock()
+				common.AssertTrue(t, hdl.isValid(), "handle is not valid")
+			}
+		})
+	}
+}
+
+func TestTelemetry_Detach(t *testing.T) {
+	producerID := 123
+	InitTestMetricsProducer(t, producerID, 2048)
+	defer CleanupTestMetricsProducer(t)
+
+	// Invalid context
+	Detach(context.Background())
+
+	// success
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	newCtx, err := Init(ctx, uint32(producerID))
+	if err != nil {
+		t.Fatalf("Init failed: %v", err)
+	}
+	Detach(newCtx)
+
+	hdl, err := getHandle(newCtx)
+	if err != nil {
+		t.Fatalf("can't get handle from result ctx: %v", err)
 	}
 
-	for mt, tm := range testMetrics {
-		switch mt {
-		case MetricTypeGauge:
-			m, err = GetGauge(ctx, tm.name)
-			if err != nil {
-				t.Fatal(err)
+	hdl.RLock()
+	common.AssertFalse(t, hdl.isValid(), "handle should be invalidated")
+	hdl.RUnlock()
+
+	// previously invalidated handle/context
+	Detach(newCtx)
+	hdl.RLock()
+	common.AssertFalse(t, hdl.isValid(), "handle should still be invalid")
+	hdl.RUnlock()
+}
+
+func TestTelemetry_GetAPIVersion(t *testing.T) {
+	ver := GetAPIVersion()
+
+	common.AssertEqual(t, ver, 1, "wrong API version")
+}
+
+func initCtxReal(t *testing.T, id uint32) context.Context {
+	t.Helper()
+
+	ctx, err := Init(context.Background(), id)
+	if err != nil {
+		t.Fatalf("Init failed: %v", err)
+	}
+
+	return ctx
+}
+
+func teardownCtxReal(_ *testing.T, ctx context.Context) {
+	Detach(ctx)
+}
+
+func TestTelemetry_GetRank(t *testing.T) {
+	producerID := 42
+
+	rankHdl := &handle{
+		rank: new(uint32),
+	}
+	*rankHdl.rank = 6
+
+	for name, tc := range map[string]struct {
+		metrics     TestMetricsMap
+		setupCtx    func(t *testing.T, id uint32) context.Context
+		teardownCtx func(t *testing.T, ctx context.Context)
+		expResult   uint32
+		expErr      error
+	}{
+		"nil handle": {
+			setupCtx: func(_ *testing.T, _ uint32) context.Context {
+				return context.WithValue(context.Background(), handleKey, nil)
+			},
+			teardownCtx: func(_ *testing.T, _ context.Context) {},
+			expErr:      errors.New("no handle"),
+		},
+		"handle has rank": {
+			setupCtx: func(_ *testing.T, _ uint32) context.Context {
+				return context.WithValue(context.Background(), handleKey, rankHdl)
+			},
+			teardownCtx: func(_ *testing.T, _ context.Context) {},
+			expResult:   *rankHdl.rank,
+		},
+		"no rank metric": {
+			expErr: errors.New("unable to find metric named \"/rank\""),
+		},
+		"fetched rank metric": {
+			metrics: TestMetricsMap{
+				MetricTypeGauge: {
+					Name: "rank",
+					Cur:  4,
+				},
+			},
+			expResult: 4,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			InitTestMetricsProducer(t, producerID, 2048)
+			defer CleanupTestMetricsProducer(t)
+
+			if tc.metrics != nil {
+				AddTestMetrics(t, tc.metrics)
 			}
 
-			runTests(t, tm, m)
-		case MetricTypeCounter:
-			m, err = GetCounter(ctx, tm.name)
-			if err != nil {
-				t.Fatal(err)
+			if tc.setupCtx == nil {
+				tc.setupCtx = initCtxReal
+			}
+			if tc.teardownCtx == nil {
+				tc.teardownCtx = teardownCtxReal
 			}
 
-			runTests(t, tm, m)
-		default:
-			t.Fatalf("%d not tested", mt)
-		}
+			ctx := tc.setupCtx(t, uint32(producerID))
+			defer tc.teardownCtx(t, ctx)
+
+			result, err := GetRank(ctx)
+
+			common.CmpErr(t, tc.expErr, err)
+			common.AssertEqual(t, tc.expResult, result, "rank result")
+		})
+	}
+}
+
+func TestTelemetry_CollectMetrics(t *testing.T) {
+	producerID := 777
+
+	testMetrics := TestMetricsMap{
+		MetricTypeCounter: &TestMetric{
+			Name: "collect_test/my_counter",
+			Cur:  12,
+		},
+		MetricTypeGauge: &TestMetric{
+			Name: "collect_test/my_gauge",
+			Cur:  2020,
+		},
+		MetricTypeTimestamp: &TestMetric{
+			Name: "ts",
+		},
+		MetricTypeSnapshot: &TestMetric{
+			Name: "snapshot",
+		},
+		MetricTypeDuration: &TestMetric{
+			Name: "dur",
+			Cur:  float64(time.Millisecond),
+		},
+	}
+
+	for name, tc := range map[string]struct {
+		metrics     TestMetricsMap
+		setupCtx    func(t *testing.T, id uint32) context.Context
+		teardownCtx func(t *testing.T, ctx context.Context)
+		expMetrics  TestMetricsMap
+		expErr      error
+	}{
+		"no handle": {
+			setupCtx: func(_ *testing.T, _ uint32) context.Context {
+				return context.Background()
+			},
+			teardownCtx: func(_ *testing.T, _ context.Context) {},
+			expErr:      errors.New("no handle"),
+		},
+		"nil invalid handle": {
+			setupCtx: func(t *testing.T, id uint32) context.Context {
+				t.Helper()
+
+				ctx := initCtxReal(t, id)
+
+				// clear the root node in the real handle
+				hdl, err := getHandle(ctx)
+				if err != nil {
+					t.Fatalf("failed to get handle: %v", err)
+				}
+				hdl.Lock()
+				defer hdl.Unlock()
+				hdl.root = nil
+
+				return ctx
+			},
+			expErr: errors.New("invalid handle"),
+		},
+		"no metrics": {
+			expMetrics: TestMetricsMap{},
+		},
+		"success": {
+			metrics:    testMetrics,
+			expMetrics: testMetrics,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			InitTestMetricsProducer(t, producerID, 2048)
+			defer CleanupTestMetricsProducer(t)
+
+			if tc.metrics != nil {
+				AddTestMetrics(t, tc.metrics)
+			}
+
+			if tc.setupCtx == nil {
+				tc.setupCtx = initCtxReal
+			}
+			if tc.teardownCtx == nil {
+				tc.teardownCtx = teardownCtxReal
+			}
+
+			ctx := tc.setupCtx(t, uint32(producerID))
+			defer tc.teardownCtx(t, ctx)
+
+			ch := make(chan Metric)
+
+			// poll in parallel to avoid blocking the channel
+			gotMetrics := make([]Metric, 0)
+			var wg sync.WaitGroup
+			wg.Add(1)
+			go func() {
+				for metric := range ch {
+					gotMetrics = append(gotMetrics, metric)
+				}
+				wg.Done()
+			}()
+
+			err := CollectMetrics(ctx, ch)
+
+			common.CmpErr(t, tc.expErr, err)
+
+			wg.Wait()
+			common.AssertEqual(t, len(tc.expMetrics), len(gotMetrics), "got wrong number of metrics")
+
+			for _, exp := range tc.expMetrics {
+				expPath := fmt.Sprintf("ID: %d/%s", producerID, exp.Name)
+
+				found := false
+				for _, m := range gotMetrics {
+					fullPath := fmt.Sprintf("%s/%s", m.Path(), m.Name())
+					if fullPath == expPath {
+						found = true
+						break
+					}
+				}
+
+				if !found {
+					t.Errorf("expected Metric %q not found", expPath)
+				}
+			}
+		})
+	}
+}
+
+func TestTelemetry_garbageCollection(t *testing.T) {
+	validCtx, _ := setupTestMetrics(t)
+	defer cleanupTestMetrics(validCtx, t)
+
+	invalidCtx := context.WithValue(context.Background(), handleKey, &handle{})
+	testTimeout := 5 * time.Second
+	loopInterval := time.Millisecond
+
+	for name, tc := range map[string]struct {
+		ctx         context.Context
+		cancelAfter time.Duration
+	}{
+		"no handle": {
+			ctx: context.Background(),
+		},
+		"handle invalid": {
+			ctx: invalidCtx,
+		},
+		"canceled": {
+			ctx:         validCtx,
+			cancelAfter: time.Microsecond,
+		},
+		"at least one run": {
+			ctx:         validCtx,
+			cancelAfter: loopInterval * 3,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(tc.ctx, testTimeout)
+			if tc.cancelAfter != 0 {
+				go func(cancelFunc context.CancelFunc, after time.Duration) {
+					time.Sleep(after)
+					cancelFunc()
+				}(cancel, tc.cancelAfter)
+			}
+
+			start := time.Now()
+			collectGarbageLoop(ctx, time.NewTicker(loopInterval))
+			end := time.Now()
+
+			cancel()
+
+			elapsed := end.Sub(start)
+			if elapsed >= testTimeout {
+				t.Fatalf("expected immediate return, took %v", elapsed)
+			}
+		})
 	}
 }

--- a/src/control/lib/telemetry/test_helpers.go
+++ b/src/control/lib/telemetry/test_helpers.go
@@ -10,7 +10,11 @@ package telemetry
 
 import (
 	"context"
+	"regexp"
 	"testing"
+	"time"
+
+	"github.com/daos-stack/daos/src/control/common"
 )
 
 /*
@@ -33,40 +37,94 @@ add_metric(struct d_tm_node_t **node, int metric_type, char *sh_desc,
 import "C"
 
 type (
-	testMetric struct {
-		name   string
+	TestMetric struct {
+		Name   string
 		desc   string
 		units  string
 		min    float64
 		max    float64
-		cur    float64
+		Cur    float64 // value - may be exact or approximate
 		sum    float64
 		mean   float64
 		stddev float64
-		str    string
+		str    string // string of regex to compare String() against
 		node   *C.struct_d_tm_node_t
 	}
-	testMetricsMap map[MetricType]*testMetric
+	TestMetricsMap map[MetricType]*TestMetric
 )
 
-func setupTestMetrics(t *testing.T) (context.Context, testMetricsMap) {
-	rc := C.d_tm_init(42, 8192, 0)
+func InitTestMetricsProducer(t *testing.T, id int, size uint64) {
+	t.Helper()
+
+	rc := C.d_tm_init(C.int(id), C.ulong(size), C.D_TM_SERVER_PROCESS)
 	if rc != 0 {
 		t.Fatalf("failed to init telemetry: %d", rc)
 	}
+}
 
-	ctx, err := Init(context.Background(), 42)
+func AddTestMetrics(t *testing.T, testMetrics TestMetricsMap) {
+	t.Helper()
+
+	for mt, tm := range testMetrics {
+		switch mt {
+		case MetricTypeGauge:
+			rc := C.add_metric(&tm.node, C.D_TM_GAUGE, C.CString(tm.desc), C.CString(tm.units), C.CString(tm.Name))
+			if rc != 0 {
+				t.Fatalf("failed to add %s: %d", tm.Name, rc)
+			}
+			for _, val := range []float64{tm.min, tm.max, tm.Cur} {
+				C.d_tm_set_gauge(tm.node, C.uint64_t(val))
+			}
+		case MetricTypeCounter:
+			rc := C.add_metric(&tm.node, C.D_TM_COUNTER, C.CString(tm.desc), C.CString(tm.units), C.CString(tm.Name))
+			if rc != 0 {
+				t.Fatalf("failed to add %s: %d", tm.Name, rc)
+			}
+			C.d_tm_inc_counter(tm.node, C.ulong(tm.Cur))
+		case MetricTypeDuration:
+			rc := C.add_metric(&tm.node, C.D_TM_DURATION|C.D_TM_CLOCK_REALTIME, C.CString(tm.desc), C.CString(tm.units), C.CString(tm.Name))
+			if rc != 0 {
+				t.Fatalf("failed to add %s: %d", tm.Name, rc)
+			}
+			C.d_tm_mark_duration_start(tm.node, C.D_TM_CLOCK_REALTIME)
+			time.Sleep(time.Duration(tm.Cur))
+			C.d_tm_mark_duration_end(tm.node)
+		case MetricTypeTimestamp:
+			rc := C.add_metric(&tm.node, C.D_TM_TIMESTAMP, C.CString(tm.desc), C.CString(tm.units), C.CString(tm.Name))
+			if rc != 0 {
+				t.Fatalf("failed to add %s: %d", tm.Name, rc)
+			}
+			C.d_tm_record_timestamp(tm.node)
+		case MetricTypeSnapshot:
+			rc := C.add_metric(&tm.node, C.D_TM_TIMER_SNAPSHOT|C.D_TM_CLOCK_REALTIME, C.CString(tm.desc), C.CString(tm.units), C.CString(tm.Name))
+			if rc != 0 {
+				t.Fatalf("failed to add %s: %d", tm.Name, rc)
+			}
+			C.d_tm_take_timer_snapshot(tm.node, C.D_TM_CLOCK_REALTIME)
+		default:
+			t.Fatalf("metric type %d not supported", mt)
+		}
+	}
+}
+
+func setupTestMetrics(t *testing.T) (context.Context, TestMetricsMap) {
+	t.Helper()
+
+	id := 42
+	InitTestMetricsProducer(t, id, 4096)
+
+	ctx, err := Init(context.Background(), uint32(id))
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	testMetrics := testMetricsMap{
+	testMetrics := TestMetricsMap{
 		MetricTypeGauge: {
-			name:   "test_gauge",
+			Name:   "test_gauge",
 			desc:   "some gauge",
 			units:  "rpc/s",
 			min:    1,
-			cur:    42,
+			Cur:    42,
 			max:    64,
 			sum:    107,
 			mean:   35.666666666666664,
@@ -74,39 +132,59 @@ func setupTestMetrics(t *testing.T) (context.Context, testMetricsMap) {
 			str:    "test_gauge: 42 rpc/s, min: 1, max: 64, mean: 35.666667, sample size: 3, std dev: 31.973948",
 		},
 		MetricTypeCounter: {
-			name:  "test_counter",
+			Name:  "test_counter",
 			desc:  "some counter",
 			units: "KB",
-			cur:   1,
+			Cur:   1,
 			str:   "test_counter: 1 KB",
+		},
+		MetricTypeDuration: {
+			Name:  "test_duration",
+			desc:  "some duration",
+			units: "us", // TODO: fix at library level, should be ns
+			Cur:   float64(10 * time.Millisecond),
+			str:   `test_duration: [0-9]+ us, min: [0-9]+, max: [0-9]+, mean: [0-9]+\.[0-9]+, sample size: [0-9]+`,
+		},
+		MetricTypeTimestamp: {
+			Name: "test_timestamp",
+			desc: "some timestamp",
+			Cur:  float64(time.Now().Unix()),
+			str:  `test_timestamp: [[:alpha:]]{3,} [[:alpha:]]{3,} +[0-9]{1,2} [0-9]{2}:[0-9]{2}:[0-9]{2} [0-9]{4}`,
+		},
+		MetricTypeSnapshot: {
+			Name:  "test_snapshot",
+			desc:  "some snapshot",
+			units: "us", // TODO: fix at library level, should be ns
+			Cur:   float64(time.Now().UnixNano()),
+			str:   `test_snapshot: [0-9]+ us`,
 		},
 	}
 
-	for mt, tm := range testMetrics {
-		switch mt {
-		case MetricTypeGauge:
-			rc = C.add_metric(&tm.node, C.D_TM_GAUGE, C.CString(tm.desc), C.CString(tm.units), C.CString(tm.name))
-			if rc != 0 {
-				t.Fatalf("failed to add %s: %d", tm.name, rc)
-			}
-			for _, val := range []float64{tm.min, tm.max, tm.cur} {
-				C.d_tm_set_gauge(tm.node, C.uint64_t(val))
-			}
-		case MetricTypeCounter:
-			rc = C.add_metric(&tm.node, C.D_TM_COUNTER, C.CString(tm.desc), C.CString(tm.units), C.CString(tm.name))
-			if rc != 0 {
-				t.Fatalf("failed to add %s: %d", tm.name, rc)
-			}
-			C.d_tm_inc_counter(tm.node, 1)
-		default:
-			t.Fatalf("metric type %d not supported", mt)
-		}
-	}
+	AddTestMetrics(t, testMetrics)
 
 	return ctx, testMetrics
 }
 
 func cleanupTestMetrics(ctx context.Context, t *testing.T) {
 	Detach(ctx)
+	CleanupTestMetricsProducer(t)
+}
+
+func CleanupTestMetricsProducer(t *testing.T) {
 	C.d_tm_fini()
+}
+
+func testMetricBasics(t *testing.T, tm *TestMetric, m Metric) {
+	t.Helper()
+
+	common.AssertEqual(t, tm.Name, m.Name(), "Name() failed")
+	common.AssertEqual(t, tm.Name, m.Path(), "Path() failed")
+	common.AssertEqual(t, tm.desc, m.Desc(), "Desc() failed")
+	common.AssertEqual(t, tm.units, m.Units(), "Units() failed")
+
+	strRE, err := regexp.Compile(tm.str)
+	if err != nil {
+		t.Fatalf("invalid regex %q", tm.str)
+	}
+	common.AssertTrue(t, strRE.Match([]byte(m.String())), "String() failed")
 }

--- a/src/control/lib/telemetry/timestamp.go
+++ b/src/control/lib/telemetry/timestamp.go
@@ -18,6 +18,7 @@ import "C"
 
 import (
 	"context"
+	"fmt"
 	"time"
 )
 
@@ -69,5 +70,9 @@ func GetTimestamp(ctx context.Context, name string) (*Timestamp, error) {
 		return nil, err
 	}
 
-	return newTimestamp(hdl, "", &name, node), nil
+	if node.dtn_type != C.D_TM_TIMESTAMP {
+		return nil, fmt.Errorf("metric %q is not a timestamp", name)
+	}
+
+	return newTimestamp(hdl, name, &name, node), nil
 }

--- a/src/control/lib/telemetry/timestamp_test.go
+++ b/src/control/lib/telemetry/timestamp_test.go
@@ -1,0 +1,85 @@
+//
+// (C) Copyright 2021 Intel Corporation.
+//
+// SPDX-License-Identifier: BSD-1-Clause-Patent
+//
+// +build linux,amd64
+//
+
+package telemetry
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/daos-stack/daos/src/control/common"
+	"github.com/pkg/errors"
+)
+
+func TestTelemetry_GetTimestamp(t *testing.T) {
+	testCtx, testMetrics := setupTestMetrics(t)
+	defer cleanupTestMetrics(testCtx, t)
+
+	realTime, ok := testMetrics[MetricTypeTimestamp]
+	if !ok {
+		t.Fatal("real timestamp not in metrics set")
+	}
+	timeName := realTime.Name
+
+	for name, tc := range map[string]struct {
+		ctx        context.Context
+		metricName string
+		expResult  *TestMetric
+		expErr     error
+	}{
+		"non-handle ctx": {
+			ctx:        context.TODO(),
+			metricName: timeName,
+			expErr:     errors.New("no handle"),
+		},
+		"bad name": {
+			ctx:        testCtx,
+			metricName: "not_a_real_metric",
+			expErr:     errors.New("unable to find metric"),
+		},
+		"bad type": {
+			ctx:        testCtx,
+			metricName: testMetrics[MetricTypeGauge].Name,
+			expErr:     errors.New("not a timestamp"),
+		},
+		"success": {
+			ctx:        testCtx,
+			metricName: timeName,
+			expResult:  realTime,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			result, err := GetTimestamp(tc.ctx, tc.metricName)
+
+			common.CmpErr(t, tc.expErr, err)
+
+			if tc.expResult != nil {
+				if result == nil {
+					t.Fatalf("expected non-nil result matching %+v", tc.expResult)
+				}
+
+				testMetricBasics(t, tc.expResult, result)
+				common.AssertEqual(t, result.Type(), MetricTypeTimestamp, "bad type")
+
+				// guarantee it's in a reasonable range
+				val := result.Value()
+				createTime := time.Unix(int64(tc.expResult.Cur), 0)
+				common.AssertTrue(t, val == createTime || val.After(createTime), fmt.Sprintf("value %v too early", val))
+				common.AssertTrue(t, val == time.Now() || val.Before(time.Now()), fmt.Sprintf("value %v too late", val))
+
+				common.AssertEqual(t, float64(val.Unix()), result.FloatValue(), "expected float value and time value equal")
+			} else {
+				if result != nil {
+					t.Fatalf("expected nil result, got %+v", result)
+				}
+			}
+		})
+	}
+}

--- a/src/gurt/telemetry.c
+++ b/src/gurt/telemetry.c
@@ -3098,7 +3098,7 @@ d_tm_list(struct d_tm_context *ctx, struct d_tm_nodeList_t **head,
 	int			 rc = DER_SUCCESS;
 	struct d_tm_shmem_hdr	*shmem;
 
-	if ((head == NULL) || (node == NULL)) {
+	if ((ctx == NULL) || (head == NULL) || (node == NULL)) {
 		rc = -DER_INVAL;
 		goto out;
 	}


### PR DESCRIPTION
- Add unit tests for metric types, collector, and Prometheus
  exporter.
- Fix bugs and add missing timestamp, snapshot, and duration
  functionality in the collector/exporter.

Signed-off-by: Kris Jacque <kristin.jacque@intel.com>