### PR TITLE
DAOS-7826 migrate: Using correct shard offset during migrate

### DIFF
--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -566,8 +566,11 @@ obj_set_reply_sizes(crt_rpc_t *rpc, daos_iod_t *iods, int iod_nr)
 			return -DER_NOMEM;
 	}
 
-	for (i = 0; i < orw->orw_iod_array.oia_iod_nr; i++)
+	for (i = 0; i < orw->orw_iod_array.oia_iod_nr; i++) {
 		sizes[i] = iods[i].iod_size;
+		D_DEBUG(DB_IO, DF_UOID" %d:"DF_U64"\n", DP_UOID(orw->orw_oid),
+			i, iods[i].iod_size);
+	}
 
 out:
 	if (sizes == NULL)

--- a/src/tests/suite/daos_rebuild_common.c
+++ b/src/tests/suite/daos_rebuild_common.c
@@ -921,6 +921,25 @@ get_rank_by_oid_shard(test_arg_t *arg, daos_obj_id_t oid,
 	return rank;
 }
 
+uint32_t
+get_tgt_idx_by_oid_shard(test_arg_t *arg, daos_obj_id_t oid,
+			 uint32_t shard)
+{
+	struct daos_obj_layout	*layout;
+	uint32_t		grp_idx;
+	uint32_t		idx;
+	uint32_t		tgt_idx;
+
+	daos_obj_layout_get(arg->coh, oid, &layout);
+	grp_idx = shard / layout->ol_shards[0]->os_replica_nr;
+	idx = shard % layout->ol_shards[0]->os_replica_nr;
+	tgt_idx = layout->ol_shards[grp_idx]->os_shard_loc[idx].sd_tgt_idx;
+
+	print_message("idx %u grp %u tgt_idx %d\n", idx, grp_idx, tgt_idx);
+	daos_obj_layout_free(layout);
+	return tgt_idx;
+}
+
 int
 ec_data_nr_get(daos_obj_id_t oid)
 {

--- a/src/tests/suite/daos_test.h
+++ b/src/tests/suite/daos_test.h
@@ -414,6 +414,8 @@ get_killing_rank_by_oid(test_arg_t *arg, daos_obj_id_t oid, int data,
 
 d_rank_t
 get_rank_by_oid_shard(test_arg_t *arg, daos_obj_id_t oid, uint32_t shard);
+uint32_t
+get_tgt_idx_by_oid_shard(test_arg_t *arg, daos_obj_id_t oid, uint32_t shard);
 
 int run_daos_sub_tests(char *test_name, const struct CMUnitTest *tests,
 		       int tests_size, int *sub_tests, int sub_tests_size,

--- a/src/vos/vos_io.c
+++ b/src/vos/vos_io.c
@@ -1139,8 +1139,17 @@ fetch_value:
 			}
 		}
 
-		if (vos_dtx_hit_inprogress())
+		if (vos_dtx_hit_inprogress()) {
+			D_DEBUG(DB_IO, "inprogress %d: idx %lu, nr %lu rsize "
+				DF_U64"\n", i,
+				(unsigned long)iod->iod_recxs[i].rx_idx,
+				(unsigned long)iod->iod_recxs[i].rx_nr, rsize);
 			continue;
+		}
+
+		D_DEBUG(DB_IO, "read IOD at %d: idx %lu, nr %lu rsize "
+			DF_U64"\n", i, (unsigned long)iod->iod_recxs[i].rx_idx,
+			(unsigned long)iod->iod_recxs[i].rx_nr, rsize);
 
 		/*
 		 * Empty tree or all holes, DAOS array API relies on zero


### PR DESCRIPTION
1. Use correct shard offset inside migrate_enum_unpack_cb()
especially for multiple group object.

2. Add test to verify multiple group ec object rebuild.

Signed-off-by: Di Wang <di.wang@intel.com>