### PR TITLE
DAOS-7767 container: update cs_uuids KVS in set-prop

### DIFF
--- a/src/tests/suite/daos_container.c
+++ b/src/tests/suite/daos_container.c
@@ -302,7 +302,10 @@ co_properties(void **state)
 	test_arg_t		*arg = NULL;
 	char			*label = "test_cont_properties";
 	char			*label2 = "test_cont_prop_label2";
+	char			*label2_v2 = "test_cont_prop_label2_version2";
 	uuid_t			 cuuid2;
+	daos_handle_t		 coh2;
+	uuid_t			 cuuid3;
 	uint64_t		 snapshot_max = 128;
 	daos_prop_t		*prop;
 	daos_prop_t		*prop_query;
@@ -412,13 +415,15 @@ co_properties(void **state)
 				     0, NULL);
 
 		/* Create container: different UUID, same label - fail */
-		print_message("Checking create: different UUID same label\n");
+		print_message("Checking create: different UUID same label "
+			      "(will fail)\n");
 		uuid_generate(cuuid2);
 		rc = daos_cont_create(arg->pool.poh, cuuid2, prop, NULL);
 		assert_rc_equal(rc, -DER_INVAL);
 
 		/* Create container: same UUID, different label - fail */
-		print_message("Checking create: same UUID, different label\n");
+		print_message("Checking create: same UUID, different label "
+			      "(will fail)\n");
 		free(prop->dpp_entries[0].dpe_str);
 		prop->dpp_entries[0].dpe_str = strdup(label2);
 		rc = daos_cont_create(arg->pool.poh, arg->co_uuid, prop, NULL);
@@ -437,11 +442,57 @@ co_properties(void **state)
 		/* Create container: same UUID, different label - fail
 		 * uuid matches first container, label matches second container
 		 */
-		print_message("Checking create: same UUID, different label\n");
+		print_message("Checking create: same UUID, different label "
+			      "(will fail)\n");
 		rc = daos_cont_create(arg->pool.poh, arg->co_uuid, prop, NULL);
 		assert_rc_equal(rc, -DER_INVAL);
 
+		/* destroy the second container (will re-create it next) */
+		rc = daos_cont_destroy(arg->pool.poh, cuuid2, 0 /* force */,
+				       NULL);
+		assert_rc_equal(rc, 0);
+
+		/* Create container 2 without label, set-label label2,
+		 * Create container 3 with label2  - fail.
+		 */
+		print_message("Checking set-prop and create label conflict "
+			      "(will fail)\n");
+		print_message("step1: create C2 no label\n");
+		rc = daos_cont_create(arg->pool.poh, cuuid2, NULL, NULL);
+		assert_rc_equal(rc, 0);
+		rc = daos_cont_open(arg->pool.poh, cuuid2, DAOS_COO_RW, &coh2,
+				    NULL, NULL);
+		assert_rc_equal(rc, 0);
+		print_message("step2: C2 set-prop label: %s\n",
+			      prop->dpp_entries[0].dpe_str);
+		rc = daos_cont_set_prop(coh2, prop, NULL);
+		assert_rc_equal(rc, 0);
+		uuid_generate(cuuid3);
+		print_message("step3: create C3 with label: %s (will fail)\n",
+			      prop->dpp_entries[0].dpe_str);
+		rc = daos_cont_create(arg->pool.poh, cuuid3, prop, NULL);
+		assert_rc_equal(rc, -DER_INVAL);
+
+		/* Container 2 set-prop label2_v2,
+		 * container 1 set-prop label2 - pass
+		 */
+		print_message("Checking label rename and reuse\n");
+		free(prop->dpp_entries[0].dpe_str);
+		prop->dpp_entries[0].dpe_str = strdup(label2_v2);
+		print_message("step: C2 set-prop change FROM %s TO %s\n",
+			      label2, label2_v2);
+		rc = daos_cont_set_prop(coh2, prop, NULL);
+		assert_rc_equal(rc, 0);
+		free(prop->dpp_entries[0].dpe_str);
+		prop->dpp_entries[0].dpe_str = strdup(label2);
+		print_message("step: C1 set-prop change FROM %s TO %s\n",
+			      label, label2);
+		rc = daos_cont_set_prop(arg->coh, prop, NULL);
+		assert_rc_equal(rc, 0);
+
 		/* destroy the second container */
+		rc = daos_cont_close(coh2, NULL);
+		assert_rc_equal(rc, 0);
 		rc = daos_cont_destroy(arg->pool.poh, cuuid2, 0 /* force */,
 				       NULL);
 		assert_rc_equal(rc, 0);


### PR DESCRIPTION
Before this change, the label -> container UUID "cs_uuids" KVS
was maintained (records inserted or deleted) during container
create and destroy. Container set-prop was not accounted for.
With this change, the KVS is updated appropriately under different
set-prop scenarios (set an initial non-default label string,
rename from existing label string to another, etc.).
Also, the daos_test container properties test is updated to
exercise create/set-prop label scenarios.

Test-tag: pr daily_regression

Signed-off-by: Kenneth Cain <kenneth.c.cain@intel.com>