### PR TITLE
DAOS-7845 vos: remove useless info from committed DTX entry

### DIFF
--- a/src/vos/vos_dtx.c
+++ b/src/vos/vos_dtx.c
@@ -389,10 +389,6 @@ dtx_cmt_ent_free(struct btr_instance *tins, struct btr_record *rec,
 	dce = umem_off2ptr(&tins->ti_umm, rec->rec_off);
 	D_ASSERT(dce != NULL);
 
-	if (dce->dce_oids != NULL && dce->dce_oids != &dce->dce_oid_inline &&
-	    dce->dce_oids != &DCE_OID(dce))
-		D_FREE(dce->dce_oids);
-
 	rec->rec_off = UMOFF_NULL;
 	d_list_del(&dce->dce_committed_link);
 	if (!cont->vc_reindex_cmt_dtx || dce->dce_reindex)
@@ -788,7 +784,6 @@ vos_dtx_commit_one(struct vos_container *cont, struct dtx_id *dti,
 	struct vos_dtx_cmt_ent		*dce = NULL;
 	d_iov_t				 kiov;
 	d_iov_t				 riov;
-	size_t				 size;
 	int				 rc = 0;
 
 	d_iov_set(&kiov, dti, sizeof(*dti));
@@ -843,6 +838,7 @@ vos_dtx_commit_one(struct vos_container *cont, struct dtx_id *dti,
 			rc = dbtree_delete(cont->vc_dtx_active_hdl,
 					   BTR_PROBE_BYPASS, &kiov, &dae);
 			if (rc == 0)
+				dtx_act_ent_cleanup(cont, dae, NULL, false);
 				dtx_evict_lid(cont, dae);
 
 			goto out;
@@ -857,20 +853,6 @@ vos_dtx_commit_one(struct vos_container *cont, struct dtx_id *dti,
 		memcpy(&dce->dce_base.dce_common, &dae->dae_base.dae_common,
 		       sizeof(dce->dce_base.dce_common));
 		DCE_EPOCH(dce) = dae->dae_start_time;
-		dce->dce_oid_cnt = dae->dae_oid_cnt;
-		if (dce->dce_oid_cnt > 1) {
-			/* Take over OIDs buffer. */
-			dce->dce_oids = dae->dae_oids;
-			dae->dae_oid_cnt = 0;
-			dae->dae_oids = NULL;
-		} else if (dce->dce_oid_cnt == 1) {
-			if (daos_unit_oid_is_null(dae->dae_oid_inline)) {
-				dce->dce_oids = &DCE_OID(dce);
-			} else {
-				dce->dce_oid_inline = dae->dae_oid_inline;
-				dce->dce_oids = &dce->dce_oid_inline;
-			}
-		}
 	} else {
 		struct dtx_handle	*dth = vos_dth_get();
 
@@ -880,37 +862,8 @@ vos_dtx_commit_one(struct vos_container *cont, struct dtx_id *dti,
 		DCE_EPOCH(dce) = crt_hlc_get();
 		DCE_OID(dce) = dth->dth_leader_oid;
 		DCE_DKEY_HASH(dce) = dth->dth_dkey_hash;
-
-		if (dth->dth_oid_array == NULL) {
-			dce->dce_oids = &DCE_OID(dce);
-			dce->dce_oid_cnt = 1;
-			goto insert;
-		}
-
-		if (dth->dth_oid_cnt == 1) {
-			dce->dce_oid_inline = dth->dth_oid_array[0];
-			dce->dce_oids = &dce->dce_oid_inline;
-			dce->dce_oid_cnt = 1;
-			goto insert;
-		}
-
-		D_ASSERT(dth->dth_oid_cnt > 1);
-
-		size = sizeof(daos_unit_oid_t) * dth->dth_oid_cnt;
-		D_ALLOC(dce->dce_oids, size);
-		if (dce->dce_oids == NULL) {
-			/* Not fatal. */
-			D_WARN("No DRAM to store CMT DTX OIDs "
-			       DF_DTI"\n", DP_DTI(dti));
-			dce->dce_oid_cnt = 0;
-			goto insert;
-		}
-
-		memcpy(dce->dce_oids, dth->dth_oid_array, size);
-		dce->dce_oid_cnt = dth->dth_oid_cnt;
 	}
 
-insert:
 	d_iov_set(&riov, dce, sizeof(*dce));
 	rc = dbtree_upsert(cont->vc_dtx_committed_hdl, BTR_PROBE_EQ,
 			   DAOS_INTENT_UPDATE, &kiov, &riov);
@@ -941,13 +894,8 @@ out:
 	D_CDEBUG(rc != 0 && rc != -DER_NONEXIST, DLOG_ERR, DB_IO,
 		 "Commit the DTX "DF_DTI": rc = "DF_RC"\n",
 		 DP_DTI(dti), DP_RC(rc));
-	if (rc != 0 && dce != NULL) {
-		if (dce->dce_oids != NULL &&
-		    dce->dce_oids != &dce->dce_oid_inline &&
-		    dce->dce_oids != &DCE_OID(dce))
-			D_FREE(dce->dce_oids);
+	if (rc != 0)
 		D_FREE(dce);
-	}
 
 	return rc;
 }
@@ -982,6 +930,7 @@ vos_dtx_abort_one(struct vos_container *cont, daos_epoch_t epoch,
 		rc = dbtree_delete(cont->vc_dtx_active_hdl,
 				   BTR_PROBE_BYPASS, &kiov, &dae);
 		if (rc == 0)
+			dtx_act_ent_cleanup(cont, dae, NULL, true);
 			dtx_evict_lid(cont, dae);
 
 		goto out;

--- a/src/vos/vos_internal.h
+++ b/src/vos/vos_internal.h
@@ -312,17 +312,6 @@ struct vos_dtx_cmt_ent {
 	d_list_t			 dce_committed_link;
 	struct vos_dtx_cmt_ent_df	 dce_base;
 
-	/* The single object OID if it is different from 'dce_base::dce_oid'. */
-	daos_unit_oid_t			 dce_oid_inline;
-
-	/* Similar as dae_oids, it points to 'dce_base::dce_oid',
-	 * or 'dce_oid_inline' or new buffer to hold more OIDs.
-	 */
-	daos_unit_oid_t			*dce_oids;
-
-	/* The count objects modified by current DTX. */
-	int				 dce_oid_cnt;
-
 	uint32_t			 dce_reindex:1,
 					 dce_exist:1,
 					 dce_invalid:1;

--- a/src/vos/vos_layout.h
+++ b/src/vos/vos_layout.h
@@ -154,15 +154,6 @@ struct vos_dtx_ent_common {
 
 /** Committed DTX entry on-disk layout in both SCM and DRAM. */
 struct vos_dtx_cmt_ent_df {
-	/**
-	 * For single RDG based DTX, the DTX may be in the CoS cache. Under
-	 * such case, 'dce_common.dec_oid' is part of the key for CoS cache.
-	 *
-	 * For cross RDGs modification, the DTX will not be in CoS cache.
-	 * Under such case, if only single object is modified by this DTX,
-	 * its OID is stored inside 'dce_common.dec_oid'; otherwise, the
-	 * objects' OIDs are stored via 'dce_oid_off'.
-	 */
 	struct vos_dtx_ent_common	dce_common;
 };
 


### PR DESCRIPTION
We store the objects' (being modified via the DTX) IDs in committed
DTX entry for EC aggregation. But EC aggregation logic does not use
such information. Then remove the useless information to reduce the
committed DTX entry size.

Signed-off-by: Fan Yong <fan.yong@intel.com>