### PR TITLE
DAOS-7440 build: Fix rpath in binary builds

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -1,11 +1,20 @@
 """Build DAOS"""
 import os
+import sys
 import platform
 import subprocess
 import time
 import errno
 import SCons.Warnings
 from SCons.Script import BUILD_TARGETS
+
+if sys.version_info.major < 3:
+    print(""""Python 2.7 is no longer supported in the DAOS build.
+Install python3 version of SCons.   On some platforms this package does not
+install the scons binary so your command may need to use scons-3 instead of
+scons or you will need to create an alias or script by the same name to
+wrap scons-3.""")
+    Exit(1)
 
 SCons.Warnings.warningAsException()
 

--- a/src/control/SConscript
+++ b/src/control/SConscript
@@ -207,6 +207,7 @@ def scons():
 
     denv.AppendUnique(LINKFLAGS=["-Wl,--no-as-needed"])
     prereqs.require(senv, 'pmdk', 'spdk', 'ofi', 'hwloc')
+    daos_build.add_rpaths(denv, "..", True, True)
 
     cgolibdirs = senv.subst("-L$BUILD_DIR/src/control/lib/spdk "
                             "-L$BUILD_DIR/src/gurt "

--- a/utils/docker_nlt.sh
+++ b/utils/docker_nlt.sh
@@ -10,7 +10,4 @@ set -e
 
 ./utils/setup_daos_admin.sh
 
-# Needed for Ubuntu
-export LD_LIBRARY_PATH=/opt/daos/prereq/release/spdk/lib/
-
 ./utils/node_local_test.py --no-root --memcheck no --server-debug WARN "$@"

--- a/utils/run_in_ga.sh
+++ b/utils/run_in_ga.sh
@@ -54,7 +54,5 @@ echo ::group::Setting up daos_admin
 echo ::endgroup::
 
 echo ::group::Container copy test
-# DAOS-7440
-export LD_LIBRARY_PATH=/opt/daos/prereq/release/spdk/lib/
 ./utils/node_local_test.py --no-root --test cont_copy
 echo ::endgroup::


### PR DESCRIPTION
Also, add a python 2.7 check to the main SConstruct

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>