### PR TITLE
DAOS-7858 test: Increase telemetry test timeout

### DIFF
--- a/src/tests/ftest/control/dmg_telemetry_basic.yaml
+++ b/src/tests/ftest/control/dmg_telemetry_basic.yaml
@@ -6,7 +6,7 @@ hosts:
     - client-A
 timeouts:
   test_telemetry_list: 60
-  test_container_telemetry: 130
+  test_container_telemetry: 230
 server_config:
   name: daos_server
   servers:


### PR DESCRIPTION
The container telemetry tests were timing out on CI VMs, while
otherwise executing normally.

Feature: telemetry

Signed-off-by: Kris Jacque <kristin.jacque@intel.com>