### PR TITLE
DAOS-7863 test: Handle list_pools response with no pools

### DIFF
--- a/src/tests/ftest/util/dmg_utils.py
+++ b/src/tests/ftest/util/dmg_utils.py
@@ -628,7 +628,7 @@ class DmgCommand(DmgCommandBase):
         output = self._get_json_result(("pool", "list"))
 
         data = {}
-        if output["response"] is None:
+        if output["response"] is None or output["response"]["pools"] is None:
             return data
 
         for pool in output["response"]["pools"]:


### PR DESCRIPTION
When there are no pools in the system, the pools field is
null, not an empty array. Just return early in this case.