### PR TITLE
DAOS-623 test: Fix IO test name to include object class

### DIFF
--- a/src/tests/ftest/daos_test/daos_core_test.yaml
+++ b/src/tests/ftest/daos_test/daos_core_test.yaml
@@ -90,8 +90,8 @@ daos_tests:
     test_daos_distributed_tx: DAOS_Distributed_TX
     test_daos_verify_consistency: DAOS_Verify_Consistency
     test_daos_io: DAOS_IO
-    test_daos_ec_io: DAOS_EC_IO
-    test_daos_ec_obj: DAOS_EC_OBJ
+    test_daos_ec_io: DAOS_IO_EC_4P2G1
+    test_daos_ec_obj: DAOS_EC
     test_daos_object_array: DAOS_Object_Array
     test_daos_array: DAOS_Array
     test_daos_kv: DAOS_KV

--- a/src/tests/suite/daos_obj.c
+++ b/src/tests/suite/daos_obj.c
@@ -4667,7 +4667,7 @@ int
 run_daos_io_test(int rank, int size, int *sub_tests, int sub_tests_size)
 {
 	int rc = 0;
-	char oclass[16];
+	char oclass[16] = {0};
 	char buf[32];
 
 	MPI_Barrier(MPI_COMM_WORLD);
@@ -4676,8 +4676,11 @@ run_daos_io_test(int rank, int size, int *sub_tests, int sub_tests_size)
 		sub_tests = NULL;
 	}
 
-	daos_oclass_id2name(dt_obj_class, oclass);
-	snprintf(buf, sizeof(buf), "DAOS_IO_%s", oclass);
+	if (dt_obj_class != OC_UNKNOWN) {
+		oclass[0] = '_';
+		daos_oclass_id2name(dt_obj_class, &oclass[1]);
+	}
+	snprintf(buf, sizeof(buf), "DAOS_IO%s", oclass);
 	buf[sizeof(buf) - 1] = 0;
 
 	rc = run_daos_sub_tests(buf, io_tests,

--- a/src/tests/suite/daos_obj.c
+++ b/src/tests/suite/daos_obj.c
@@ -4667,6 +4667,8 @@ int
 run_daos_io_test(int rank, int size, int *sub_tests, int sub_tests_size)
 {
 	int rc = 0;
+	char oclass[16];
+	char buf[32];
 
 	MPI_Barrier(MPI_COMM_WORLD);
 	if (sub_tests_size == 0) {
@@ -4674,7 +4676,11 @@ run_daos_io_test(int rank, int size, int *sub_tests, int sub_tests_size)
 		sub_tests = NULL;
 	}
 
-	rc = run_daos_sub_tests("DAOS_IO", io_tests,
+	daos_oclass_id2name(dt_obj_class, oclass);
+	snprintf(buf, sizeof(buf), "DAOS_IO_%s", oclass);
+	buf[sizeof(buf) - 1] = 0;
+
+	rc = run_daos_sub_tests(buf, io_tests,
 				ARRAY_SIZE(io_tests), sub_tests, sub_tests_size,
 				obj_setup, test_teardown);
 


### PR DESCRIPTION
Otherwise, it is confusing since we run the tests with
different object classes

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>