### PR TITLE
DAOS-7866 container: return EC cell size on open

### DIFF
--- a/src/container/cli.c
+++ b/src/container/cli.c
@@ -758,7 +758,8 @@ dc_cont_open_internal(tse_task_t *task, struct dc_pool *pool)
 				  DAOS_CO_QUERY_PROP_CSUM_CHUNK |
 				  DAOS_CO_QUERY_PROP_DEDUP |
 				  DAOS_CO_QUERY_PROP_DEDUP_THRESHOLD |
-				  DAOS_CO_QUERY_PROP_REDUN_FAC;
+				  DAOS_CO_QUERY_PROP_REDUN_FAC |
+				  DAOS_CO_QUERY_PROP_EC_CELL_SZ;
 
 	/* open bylabel RPC input */
 	if (args->label) {


### PR DESCRIPTION
Container open should read the EC cell size.

Signed-off-by: Liang Zhen <liang.zhen@intel.com>