### PR TITLE
DAOS-7879 EC: refine EC degraded fetch with aggregation

### DIFF
--- a/src/container/srv_target.c
+++ b/src/container/srv_target.c
@@ -2518,7 +2518,7 @@ cont_rw_capa_set(void *data)
 
 	cont_child->sc_rw_disabled = arg->csa_rw_disable;
 	if (dss_get_module_info()->dmi_tgt_id == 0)
-		D_ERROR(DF_CONT" read/write permission %s.\n",
+		D_DEBUG(DB_IO, DF_CONT" read/write permission %s.\n",
 			DP_CONT(arg->csa_pool_uuid, arg->csa_cont_uuid),
 			cont_child->sc_rw_disabled ? "disabled" : "enabled");
 

--- a/src/include/daos/common.h
+++ b/src/include/daos/common.h
@@ -700,6 +700,15 @@ enum {
  * fetch.
  */
 #define DAOS_FAIL_SHARD_FETCH		(DAOS_FAIL_UNIT_TEST_GROUP_LOC | 0x27)
+/**
+ * This fault simulates the EC aggregation boundary (agg_eph_boundry) moved
+ * ahead, in that case need to redo the degraded fetch.
+ */
+#define DAOS_FAIL_AGG_BOUNDRY_MOVED	(DAOS_FAIL_UNIT_TEST_GROUP_LOC | 0x28)
+/**
+ * This fault simulates the EC parity epoch difference in EC data recovery.
+ */
+#define DAOS_FAIL_PARITY_EPOCH_DIFF	(DAOS_FAIL_UNIT_TEST_GROUP_LOC | 0x29)
 
 #define DAOS_DTX_COMMIT_SYNC		(DAOS_FAIL_UNIT_TEST_GROUP_LOC | 0x30)
 #define DAOS_DTX_LEADER_ERROR		(DAOS_FAIL_UNIT_TEST_GROUP_LOC | 0x31)

--- a/src/include/daos_errno.h
+++ b/src/include/daos_errno.h
@@ -253,7 +253,10 @@ extern "C" {
 	       Shards overlap)						\
 	/** #failures exceed RF(Redundancy Factor), data possibly lost */ \
 	ACTION(DER_RF,			(DER_ERR_DAOS_BASE + 31),	\
-	       Failures exceed RF)
+	       Failures exceed RF)					\
+	/** Re-fetch again, an internal error code used in EC deg-fetch */ \
+	ACTION(DER_FETCH_AGAIN,		(DER_ERR_DAOS_BASE + 32),	\
+	       Fetch again)
 
 /** Defines the gurt error codes */
 #define D_FOREACH_ERR_RANGE(ACTION)	\

--- a/src/object/cli_ec.c
+++ b/src/object/cli_ec.c
@@ -1845,6 +1845,7 @@ obj_ec_recov_add(struct obj_reasb_req *reasb_req,
 	if (recx_lists == NULL || nr == 0)
 		return 0;
 
+	D_SPIN_LOCK(&reasb_req->orr_spin);
 	recov_lists = reasb_req->orr_fail->efi_recx_lists;
 	if (recov_lists == NULL) {
 		D_ALLOC_ARRAY(recov_lists, nr);
@@ -1859,6 +1860,7 @@ obj_ec_recov_add(struct obj_reasb_req *reasb_req,
 	for (i = 0; i < nr; i++) {
 		dst_list = &recov_lists[i];
 		src_list = &recx_lists[i];
+		dst_list->re_snapshot = src_list->re_snapshot;
 		D_ASSERT(daos_recx_ep_list_ep_valid(src_list));
 		for (j = 0; j < src_list->re_nr; j++) {
 			rc = daos_recx_ep_add(dst_list, &src_list->re_items[j]);
@@ -1866,8 +1868,55 @@ obj_ec_recov_add(struct obj_reasb_req *reasb_req,
 				return rc;
 		}
 	}
-	daos_recx_ep_list_set_ep_valid(recov_lists, nr);
+	daos_recx_ep_list_set(recov_lists, nr, 0, false);
+	D_SPIN_UNLOCK(&reasb_req->orr_spin);
 	return 0;
+}
+
+/**
+ * In EC data recovery, need to check if different parity shards' parity exts'
+ * epochs are match. To deal with the race condition between EC aggregation and
+ * degraded fetch. In EC aggregation, for some cases need to generate new
+ * parity exts, those new parity exts will be written to different remote parity
+ * shards asynchronously, so possibly that in EC data recovery can get the
+ * parity on some parity shards but cannot on other parity shard. Here check
+ * different parity shards replied parity ext are match (with same epoch), if
+ * mismatch then need to redo the degraded fetch from beginning.
+ */
+int
+obj_ec_parity_check(struct obj_reasb_req *reasb_req,
+		    struct daos_recx_ep_list *recx_lists, unsigned int nr)
+{
+	struct daos_recx_ep_list	*parity_lists;
+	int				 rc = 0;
+
+	if (recx_lists == NULL || nr == 0)
+		return 0;
+
+	D_SPIN_LOCK(&reasb_req->orr_spin);
+	parity_lists = reasb_req->orr_fail->efi_parity_lists;
+	if (parity_lists == NULL) {
+		reasb_req->orr_fail->efi_parity_lists =
+			daos_recx_ep_lists_dup(recx_lists, nr);
+		reasb_req->orr_fail->efi_parity_list_nr = nr;
+		parity_lists = reasb_req->orr_fail->efi_parity_lists;
+		if (parity_lists == NULL)
+			rc = -DER_NOMEM;
+		goto out;
+	}
+
+	if (!obj_ec_parity_lists_match(parity_lists, recx_lists, nr) ||
+	    DAOS_FAIL_CHECK(DAOS_FAIL_PARITY_EPOCH_DIFF)) {
+		rc = -DER_FETCH_AGAIN;
+		D_ERROR("got different parity lists, "DF_RC"\n", DP_RC(rc));
+		daos_recx_ep_list_dump(parity_lists, nr);
+		daos_recx_ep_list_dump(recx_lists, nr);
+		goto out;
+	}
+
+out:
+	D_SPIN_UNLOCK(&reasb_req->orr_spin);
+	return rc;
 }
 
 static void
@@ -1890,6 +1939,7 @@ obj_ec_fail_info_get(struct obj_reasb_req *reasb_req, bool create, uint16_t nr)
 	if (fail_info == NULL)
 		return NULL;
 	reasb_req->orr_fail = fail_info;
+	reasb_req->orr_fail_alloc = 1;
 
 	D_ALLOC_ARRAY(fail_info->efi_tgt_list, nr);
 	if (fail_info->efi_tgt_list == NULL)
@@ -1914,6 +1964,10 @@ obj_ec_fail_info_reset(struct obj_reasb_req *reasb_req)
 		return;
 	for (i = 0; i < fail_info->efi_nrecx_lists; i++)
 		recx_lists[i].re_nr = 0;
+	daos_recx_ep_list_free(fail_info->efi_parity_lists,
+			       fail_info->efi_parity_list_nr);
+	fail_info->efi_parity_lists = NULL;
+	fail_info->efi_parity_list_nr = 0;
 }
 
 static bool
@@ -2103,6 +2157,7 @@ obj_ec_stripe_list_init(struct obj_reasb_req *reasb_req)
 		recx_list = &recx_lists[i];
 		D_ASSERTF(recx_list->re_ep_valid, "recx_list %p", recx_list);
 		stripe_list->re_ep_valid = 1;
+		stripe_list->re_snapshot = recx_list->re_snapshot;
 		iod = &iods[i];
 		if (iod->iod_type == DAOS_IOD_SINGLE) {
 			if (recx_list->re_nr == 0)
@@ -2263,18 +2318,20 @@ obj_ec_recov_task_init(struct obj_reasb_req *reasb_req, daos_obj_id_t oid,
 		sgl = &fail_info->efi_stripe_sgls[i];
 		buf_off = 0;
 		for (j = 0; j < recx_nr; j++) {
-			if (reasb_req->orr_singv_only)
+			D_ASSERT(tidx < fail_info->efi_recov_ntasks);
+			rtask = &fail_info->efi_recov_tasks[tidx++];
+			if (reasb_req->orr_singv_only) {
 				recx_ep = NULL;
-			else
+			} else {
 				recx_ep =  &stripe_list->re_items[j];
+				rtask->ert_snapshot = stripe_list->re_snapshot;
+			}
 			if (iod->iod_type == DAOS_IOD_SINGLE) {
 				stripe_nr = 1;
 			} else {
 				stripe_nr = recx_ep->re_recx.rx_nr /
 					    stripe_rec_nr;
 			}
-			D_ASSERT(tidx < fail_info->efi_recov_ntasks);
-			rtask = &fail_info->efi_recov_tasks[tidx++];
 			rtask->ert_oiod = iod;
 			rtask->ert_iod.iod_name = iod->iod_name;
 			rtask->ert_iod.iod_type = iod->iod_type;
@@ -2309,7 +2366,7 @@ obj_ec_fail_info_free(struct obj_reasb_req *reasb_req)
 {
 	struct obj_ec_fail_info *fail_info = reasb_req->orr_fail;
 
-	if (fail_info == NULL || reasb_req->orr_recov == 1)
+	if (fail_info == NULL || reasb_req->orr_fail_alloc == 0)
 		return;
 
 	obj_ec_recov_task_fini(reasb_req);
@@ -2318,9 +2375,12 @@ obj_ec_fail_info_free(struct obj_reasb_req *reasb_req)
 			       fail_info->efi_nrecx_lists);
 	daos_recx_ep_list_free(fail_info->efi_stripe_lists,
 			       fail_info->efi_nrecx_lists);
+	daos_recx_ep_list_free(fail_info->efi_parity_lists,
+			       fail_info->efi_parity_list_nr);
 	D_FREE(fail_info->efi_tgt_list);
 	D_FREE(fail_info);
 	reasb_req->orr_fail = NULL;
+	reasb_req->orr_fail_alloc = 0;
 }
 
 int

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -1607,7 +1607,7 @@ obj_ec_recov_cb(tse_task_t *task, struct dc_object *obj,
 	daos_handle_t			 coh = obj->cob_coh;
 	daos_handle_t			 th = DAOS_HDL_INVAL;
 	d_list_t			 task_list;
-	uint32_t			 i;
+	uint32_t			 extra_flags, i;
 	int				 rc;
 
 	rc = obj_ec_recov_prep(&obj_auxi->reasb_req, obj->cob_md.omd_id,
@@ -1639,8 +1639,11 @@ obj_ec_recov_cb(tse_task_t *task, struct dc_object *obj,
 		recov_task->ert_th = th;
 		D_DEBUG(DB_REBUILD, DF_C_OID_DKEY" Fetching to recover\n",
 			DP_C_OID_DKEY(obj->cob_md.omd_id, args->dkey));
+		extra_flags = DIOF_EC_RECOV;
+		if (recov_task->ert_snapshot)
+			extra_flags |= DIOF_EC_RECOV_SNAP;
 		rc = dc_obj_fetch_task_create(args->oh, th, 0, args->dkey, 1,
-					      DIOF_EC_RECOV,
+					      extra_flags,
 					      &recov_task->ert_iod,
 					      &recov_task->ert_sgl, NULL,
 					      fail_info, csum_iov,
@@ -3720,6 +3723,18 @@ obj_comp_cb(tse_task_t *task, void *data)
 		if (!obj_auxi->spec_shard && !obj_auxi->spec_group &&
 		    task->dt_result == -DER_INPROGRESS)
 			obj_auxi->to_leader = 1;
+	} else if (obj_auxi->ec_wait_recov &&
+		   task->dt_result == -DER_FETCH_AGAIN) {
+		obj_auxi->new_shard_tasks = 1;
+		obj_auxi->io_retry = 1;
+		pm_stale = 1;
+		obj_auxi->ec_wait_recov = 0;
+		obj_auxi->ec_in_recov = 0;
+		obj_auxi->reasb_req.orr_recov = 0;
+		obj_auxi->reasb_req.orr_recov_snap = 0;
+		obj_ec_fail_info_free(&obj_auxi->reasb_req);
+		D_DEBUG(DB_IO, DF_OID" EC fetch again.\n",
+			DP_OID(obj->cob_md.omd_id));
 	}
 
 	if (!obj_auxi->io_retry && task->dt_result == 0 &&
@@ -4207,6 +4222,8 @@ dc_obj_fetch_task(tse_task_t *task)
 		obj_auxi->ec_in_recov = 1;
 		obj_auxi->reasb_req.orr_fail = args->extra_arg;
 		obj_auxi->reasb_req.orr_recov = 1;
+		if ((args->extra_flags & DIOF_EC_RECOV_SNAP) != 0)
+			obj_auxi->reasb_req.orr_recov_snap = 1;
 	}
 	if (obj_auxi->ec_wait_recov)
 		goto out_task;

--- a/src/object/cli_shard.c
+++ b/src/object/cli_shard.c
@@ -837,13 +837,25 @@ dc_rw_cb(tse_task_t *task, void *arg)
 			D_GOTO(out, rc = -DER_PROTO);
 		}
 
-		if (is_ec_obj) {
+		if (is_ec_obj && !reasb_req->orr_recov) {
 			rc = obj_ec_recov_add(reasb_req,
 					      orwo->orw_rels.ca_arrays,
 					      orwo->orw_rels.ca_count);
 			if (rc) {
-				D_ERROR("fail to add recov list for "DF_UOID
-					",rc %d.\n", DP_UOID(orw->orw_oid), rc);
+				D_ERROR(DF_UOID" obj_ec_recov_add failed, "
+					DF_RC".\n", DP_UOID(orw->orw_oid),
+					DP_RC(rc));
+				goto out;
+			}
+		} else if (is_ec_obj && reasb_req->orr_recov &&
+			   orwo->orw_rels.ca_arrays != NULL) {
+			rc = obj_ec_parity_check(reasb_req,
+						 orwo->orw_rels.ca_arrays,
+						 orwo->orw_rels.ca_count);
+			if (rc) {
+				D_ERROR(DF_UOID" obj_ec_parity_check failed, "
+					DF_RC".\n", DP_UOID(orw->orw_oid),
+					DP_RC(rc));
 				goto out;
 			}
 		}
@@ -927,6 +939,7 @@ dc_rw_cb(tse_task_t *task, void *arg)
 			daos_iom_t			*reply_maps;
 			struct daos_recx_ep_list	*recov_list;
 
+			D_ASSERT(reasb_req == NULL || !reasb_req->orr_recov);
 			/** Should have 1 map per iod */
 			D_ASSERT(orwo->orw_maps.ca_count == orw->orw_nr);
 			for (i = 0; i < orw->orw_nr; i++) {
@@ -1130,10 +1143,14 @@ dc_obj_shard_rw(struct dc_obj_shard *shard, enum obj_rpc_opc opc,
 	rw_args.shard_args = args;
 	/* remember the sgl to copyout the data inline for fetch */
 	rw_args.rwaa_sgls = (opc == DAOS_OBJ_RPC_FETCH) ? sgls : NULL;
-	if (args->reasb_req && args->reasb_req->orr_recov)
+	if (args->reasb_req && args->reasb_req->orr_recov) {
 		rw_args.maps = NULL;
-	else
+		orw->orw_flags |= ORF_EC_RECOV;
+		if (args->reasb_req->orr_recov_snap)
+			orw->orw_flags |= ORF_EC_RECOV_SNAP;
+	} else {
 		rw_args.maps = args->api_args->ioms;
+	}
 	if (opc == DAOS_OBJ_RPC_FETCH) {
 		if (args->iod_csums != NULL) {
 			orw->orw_flags |= (ORF_CREATE_MAP |

--- a/src/object/obj_ec.h
+++ b/src/object/obj_ec.h
@@ -225,7 +225,8 @@ struct obj_ec_recov_task {
 	daos_iod_t		*ert_oiod;
 	d_sg_list_t		ert_sgl;
 	daos_epoch_t		ert_epoch;
-	daos_handle_t		ert_th; /* read-only tx handle */
+	daos_handle_t		ert_th;		/* read-only tx handle */
+	uint32_t		ert_snapshot:1;	/* For snapshot flag */
 };
 
 /** EC obj IO failure information */
@@ -241,6 +242,8 @@ struct obj_ec_fail_info {
 	struct obj_ec_recov_codec	*efi_recov_codec;
 	/* to be recovered full-stripe list */
 	struct daos_recx_ep_list	*efi_stripe_lists;
+	/* parity recx list (to compare parity ext/epoch when data recovery) */
+	struct daos_recx_ep_list	*efi_parity_lists;
 	/* The buffer for all the full-stripes in efi_stripe_lists.
 	 * One iov for each recx_ep (with 1 or more stripes), for each stripe
 	 * it contains ((k + p) * cell_byte_size) memory.
@@ -251,6 +254,7 @@ struct obj_ec_fail_info {
 	 */
 	struct obj_ec_recov_task	*efi_recov_tasks;
 	uint32_t			 efi_recov_ntasks;
+	uint32_t			 efi_parity_list_nr;
 };
 
 struct obj_reasb_req;
@@ -645,6 +649,32 @@ obj_id2ec_codec(daos_obj_id_t id)
 	return obj_ec_codec_get(daos_obj_id2class(id));
 }
 
+static inline bool
+obj_ec_parity_lists_match(struct daos_recx_ep_list *lists_1,
+			  struct daos_recx_ep_list *lists_2,
+			  unsigned int nr)
+{
+	struct daos_recx_ep_list	*list_1, *list_2;
+	unsigned int			 i, j;
+
+	for (i = 0; i < nr; i++) {
+		list_1 = &lists_1[i];
+		list_2 = &lists_2[i];
+		if (list_1->re_nr != list_2->re_nr ||
+		    list_1->re_ep_valid != list_2->re_ep_valid)
+			return false;
+		if (list_1->re_nr == 0)
+			continue;
+		for (j = 0; j < list_1->re_nr; j++) {
+			if (list_1->re_items[j].re_ep !=
+			    list_2->re_items[j].re_ep)
+				return false;
+		}
+	}
+
+	return true;
+}
+
 /* cli_ec.c */
 int obj_ec_req_reasb(daos_iod_t *iods, d_sg_list_t *sgls, daos_obj_id_t oid,
 		     struct daos_oclass_attr *oca,
@@ -662,6 +692,8 @@ void obj_ec_fetch_set_sgl(struct obj_reasb_req *reasb_req, uint32_t iod_nr);
 void obj_ec_update_iod_size(struct obj_reasb_req *reasb_req, uint32_t iod_nr);
 int obj_ec_recov_add(struct obj_reasb_req *reasb_req,
 		     struct daos_recx_ep_list *recx_lists, unsigned int nr);
+int obj_ec_parity_check(struct obj_reasb_req *reasb_req,
+			struct daos_recx_ep_list *recx_lists, unsigned int nr);
 struct obj_ec_fail_info *obj_ec_fail_info_get(struct obj_reasb_req *reasb_req,
 					      bool create, uint16_t p);
 void obj_ec_fail_info_reset(struct obj_reasb_req *reasb_req);

--- a/src/object/obj_internal.h
+++ b/src/object/obj_internal.h
@@ -154,6 +154,8 @@ struct obj_reasb_req {
 	uint32_t			 orr_iod_nr;
 	/* for data recovery flag */
 	uint32_t			 orr_recov:1,
+	/* for snapshot data recovery flag */
+					 orr_recov_snap:1,
 	/* for iod_size fetching flag */
 					 orr_size_fetch:1,
 	/* for iod_size fetched flag */
@@ -165,7 +167,9 @@ struct obj_reasb_req {
 	/* the flag of IOM re-allocable (used for EC IOM merge) */
 					 orr_iom_realloc:1,
 	/* iod_size is set by IO reply */
-					 orr_size_set:1;
+					 orr_size_set:1,
+	/* orr_fail allocated flag, recovery task's orr_fail is inherited */
+					 orr_fail_alloc:1;
 };
 
 static inline void
@@ -614,7 +618,8 @@ struct obj_io_context {
 	uint64_t		 ioc_io_size;
 	uint32_t		 ioc_began:1,
 				 ioc_free_sgls:1,
-				 ioc_lost_reply:1;
+				 ioc_lost_reply:1,
+				 ioc_fetch_snap:1;
 };
 
 struct ds_obj_exec_arg {
@@ -822,6 +827,38 @@ obj_dtx_need_refresh(struct dtx_handle *dth, int rc)
 	return rc == -DER_INPROGRESS && dth->dth_share_tbd_count > 0;
 }
 
+static inline void
+daos_recx_ep_list_set(struct daos_recx_ep_list *lists, unsigned int nr,
+		      daos_epoch_t epoch, bool snapshot)
+{
+	struct daos_recx_ep_list	*list;
+	struct daos_recx_ep		*recx_ep;
+	unsigned int			 i, j;
+
+	for (i = 0; i < nr; i++) {
+		list = &lists[i];
+		list->re_ep_valid = 1;
+		if (epoch == 0)
+			continue;
+		if (snapshot)
+			list->re_snapshot = 1;
+		for (j = 0; j < list->re_nr; j++) {
+			recx_ep = &list->re_items[j];
+			if (snapshot)
+				recx_ep->re_ep = epoch;
+			else
+				recx_ep->re_ep = max(recx_ep->re_ep, epoch);
+		}
+	}
+}
+
+static inline bool
+daos_recx_ep_list_ep_valid(struct daos_recx_ep_list *list)
+{
+	return (list->re_ep_valid == 1);
+}
+
+/** Query the highest and lowest recx in the recx_ep_list */
 int  obj_class_init(void);
 void obj_class_fini(void);
 int  obj_utils_init(void);

--- a/src/object/obj_rpc.c
+++ b/src/object/obj_rpc.c
@@ -327,6 +327,9 @@ crt_proc_struct_daos_recx_ep_list(crt_proc_t proc, crt_proc_op_t proc_op,
 	if (unlikely(rc))
 		return rc;
 
+	rc = crt_proc_bool(proc, proc_op, &list->re_snapshot);
+	if (unlikely(rc))
+		return rc;
 	rc = crt_proc_bool(proc, proc_op, &list->re_ep_valid);
 	if (unlikely(rc))
 		return rc;

--- a/src/object/obj_rpc.h
+++ b/src/object/obj_rpc.h
@@ -162,6 +162,10 @@ enum obj_rpc_flags {
 	ORF_DTX_REFRESH		= (1 << 15),
 	/* for EC aggregate (to bypass read perm check related with RF) */
 	ORF_FOR_EC_AGG		= (1 << 16),
+	/* for EC data recovery */
+	ORF_EC_RECOV		= (1 << 17),
+	/* EC data recovery from snapshot */
+	ORF_EC_RECOV_SNAP	= (1 << 18),
 };
 
 /* common for update/fetch */

--- a/src/object/srv_ec_aggregate.c
+++ b/src/object/srv_ec_aggregate.c
@@ -258,13 +258,11 @@ agg_carry_over(struct ec_agg_entry *entry, struct ec_agg_extent *agg_extent)
 
 	if (end_stripe > start_stripe) {
 		D_ASSERTF(end_stripe - start_stripe == 1,
-			  "IDX="DF_U64", SS="DF_U64", ES="DF_U64
+			  DF_UOID ", recx "DF_RECX" SS="DF_U64", ES="DF_U64
 			  ", EC_OCA(k=%d, p=%d, cs=%d)\n",
-			  agg_extent->ae_recx.rx_idx,
-			  start_stripe, end_stripe,
-			  entry->ae_oca.u.ec.e_k,
-			  entry->ae_oca.u.ec.e_p,
-			  entry->ae_oca.u.ec.e_len);
+			  DP_UOID(entry->ae_oid), DP_RECX(agg_extent->ae_recx),
+			  start_stripe, end_stripe, entry->ae_oca.u.ec.e_k,
+			  entry->ae_oca.u.ec.e_p, entry->ae_oca.u.ec.e_len);
 
 		tail_size = DAOS_RECX_END(agg_extent->ae_recx) -
 			    end_stripe * stripe_size;
@@ -1809,6 +1807,11 @@ agg_process_stripe(struct ec_agg_param *agg_param, struct ec_agg_entry *entry)
 	 * parity ext epoch if exist.
 	 */
 	iter_param.ip_hdl		= DAOS_HDL_INVAL;
+	/* set epr_lo as zero to pass-through possibly existed snapshot
+	 * between agg_param->ap_epr.epr_lo and .epr_hi.
+	 */
+	iter_param.ip_epr.epr_lo	= 0;
+	iter_param.ip_epr.epr_hi	= agg_param->ap_epr.epr_hi;
 	iter_param.ip_ih		= entry->ae_thdl;
 	iter_param.ip_flags		= VOS_IT_RECX_VISIBLE |
 					  VOS_IT_SKIP_REMOVED;

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -1237,6 +1237,26 @@ daos_iod_recx_dup(daos_iod_t *iods, uint32_t iod_nr, daos_iod_t **iods_dup_ptr)
 	return 0;
 }
 
+static bool
+obj_ec_recov_need_try_again(struct obj_rw_in *orw, struct obj_io_context *ioc)
+{
+	D_ASSERT(orw->orw_flags & ORF_EC_RECOV);
+
+	if (DAOS_FAIL_CHECK(DAOS_FAIL_AGG_BOUNDRY_MOVED))
+		return true;
+
+	/* agg_eph_boundry advanced, possibly cause epoch of EC data recovery
+	 * cannot get corresponding parity/data exts, need to retry the degraded
+	 * fetch from beginning. For ORF_EC_RECOV_SNAP case, need not retry as
+	 * that flag was only set when (snapshot_epoch < sc_ec_agg_eph_boundry).
+	 */
+	if ((orw->orw_flags & ORF_EC_RECOV_SNAP) == 0 &&
+	    orw->orw_epoch < ioc->ioc_coc->sc_ec_agg_eph_boundry)
+		return true;
+
+	return false;
+}
+
 static int
 obj_local_rw_internal(crt_rpc_t *rpc, struct obj_io_context *ioc,
 		      daos_iod_t *split_iods, struct dcs_iod_csums *split_csums,
@@ -1260,6 +1280,8 @@ obj_local_rw_internal(crt_rpc_t *rpc, struct obj_io_context *ioc,
 	uint64_t			*offs;
 	uint64_t			 cond_flags;
 	daos_iod_t			*iods_dup = NULL; /* for EC deg fetch */
+	bool				 get_parity_list = false;
+	struct daos_recx_ep_list	*parity_list = NULL;
 	int				err, rc = 0;
 
 	create_map = orw->orw_flags & ORF_CREATE_MAP;
@@ -1331,6 +1353,8 @@ obj_local_rw_internal(crt_rpc_t *rpc, struct obj_io_context *ioc,
 	} else {
 		uint32_t			 fetch_flags = 0;
 		bool				 ec_deg_fetch;
+		bool				 ec_recov;
+		bool				 is_parity_shard;
 		struct daos_recx_ep_list	*shadows = NULL;
 
 		bulk_op = CRT_BULK_PUT;
@@ -1343,6 +1367,28 @@ obj_local_rw_internal(crt_rpc_t *rpc, struct obj_io_context *ioc,
 		}
 
 		ec_deg_fetch = orw->orw_flags & ORF_EC_DEGRADED;
+		ec_recov = orw->orw_flags & ORF_EC_RECOV;
+		D_ASSERTF(ec_recov == false || ec_deg_fetch == false,
+			  "ec_recov %d, ec_deg_fetch %d.\n",
+			  ec_recov, ec_deg_fetch);
+		is_parity_shard = orw->orw_oid.id_shard >=
+				  obj_ec_data_tgt_nr(&ioc->ioc_oca);
+		get_parity_list = ec_recov && is_parity_shard &&
+				  ((orw->orw_flags & ORF_EC_RECOV_SNAP) == 0);
+		if (get_parity_list) {
+			D_ASSERT(!ec_deg_fetch);
+			fetch_flags |= VOS_OF_FETCH_RECX_LIST;
+		}
+		if (unlikely(ec_recov &&
+			     obj_ec_recov_need_try_again(orw, ioc))) {
+			rc = -DER_FETCH_AGAIN;
+			D_DEBUG(DB_IO, DF_UOID" "DF_X64"<"DF_X64
+				" ec_recov needs redo, "DF_RC".\n",
+				DP_UOID(orw->orw_oid), orw->orw_epoch,
+				ioc->ioc_coc->sc_ec_agg_eph_boundry,
+				DP_RC(rc));
+			goto out;
+		}
 		if (ec_deg_fetch && !spec_fetch) {
 			if (orwo->orw_rels.ca_arrays != NULL) {
 				/* Re-entry case */
@@ -1390,6 +1436,14 @@ obj_local_rw_internal(crt_rpc_t *rpc, struct obj_io_context *ioc,
 			goto out;
 		}
 
+		if (get_parity_list) {
+			parity_list = vos_ioh2recx_list(ioh);
+			if (parity_list != NULL) {
+				orwo->orw_rels.ca_arrays = parity_list;
+				orwo->orw_rels.ca_count = orw->orw_nr;
+			}
+		}
+
 		rc = obj_set_reply_sizes(rpc, iods, orw->orw_nr);
 		if (rc != 0)
 			goto out;
@@ -1406,7 +1460,10 @@ obj_local_rw_internal(crt_rpc_t *rpc, struct obj_io_context *ioc,
 			if (rc)
 				goto out;
 		}
-		recov_lists = vos_ioh2recx_list(ioh);
+		if (ec_deg_fetch) {
+			D_ASSERT(!get_parity_list);
+			recov_lists = vos_ioh2recx_list(ioh);
+		}
 		rc = obj_singv_ec_rw_filter(orw->orw_oid, &ioc->ioc_oca,
 					    iods, offs, orw->orw_epoch,
 					    orw->orw_flags,
@@ -1419,8 +1476,25 @@ obj_local_rw_internal(crt_rpc_t *rpc, struct obj_io_context *ioc,
 			goto out;
 		}
 		if (recov_lists != NULL) {
-			daos_recx_ep_list_set_ep_valid(recov_lists,
-						       orw->orw_nr);
+			daos_epoch_t	vos_agg_epoch;
+			daos_epoch_t	recov_epoch = 0;
+			bool		recov_snap = false;
+
+			/* If fetch from snapshot, and snapshot epoch lower than
+			 * vos agg epoch boundary, recovery from snapshot epoch.
+			 * Or, will recovery from max{parity_epoch, vos_epoch_
+			 * boundary}.
+			 */
+			vos_agg_epoch = ioc->ioc_coc->sc_ec_agg_eph_boundry;
+			if (ioc->ioc_fetch_snap &&
+			    orw->orw_epoch < vos_agg_epoch) {
+				recov_epoch = orw->orw_epoch;
+				recov_snap =  true;
+			} else {
+				recov_epoch = vos_agg_epoch;
+			}
+			daos_recx_ep_list_set(recov_lists, orw->orw_nr,
+					      recov_epoch, recov_snap);
 			orwo->orw_rels.ca_arrays = recov_lists;
 			orwo->orw_rels.ca_count = orw->orw_nr;
 		}
@@ -2354,6 +2428,10 @@ ds_obj_rw_handler(crt_rpc_t *rpc)
 		dss_get_module_info()->dmi_tgt_id,
 		dss_get_module_info()->dmi_xs_id, orw->orw_epoch,
 		orw->orw_map_ver, ioc.ioc_map_ver, DP_DTI(&orw->orw_dti));
+
+	if (obj_rpc_is_fetch(rpc) && !(orw->orw_flags & ORF_EC_RECOV) &&
+	    (orw->orw_epoch != 0 && orw->orw_epoch != DAOS_EPOCH_MAX))
+		ioc.ioc_fetch_snap = 1;
 
 	rc = process_epoch(&orw->orw_epoch, &orw->orw_epoch_first,
 			   &orw->orw_flags);

--- a/src/tests/ftest/daos_test/daos_core_test.yaml
+++ b/src/tests/ftest/daos_test/daos_core_test.yaml
@@ -31,6 +31,7 @@ timeouts:
     test_daos_oid_allocator: 320
     test_daos_checksum: 500
     test_daos_rebuild_ec: 1800
+    test_daos_aggregate_ec: 200
     test_daos_degraded_ec_0to6: 900
     test_daos_degraded_ec_8to23: 950
     test_daos_dedup: 220

--- a/src/tests/suite/daos_aggregate_ec.c
+++ b/src/tests/suite/daos_aggregate_ec.c
@@ -786,6 +786,10 @@ setup_ec_agg_tests(void **statep, struct ec_agg_test_ctx *ctx)
 static void
 cleanup_ec_agg_tests(struct ec_agg_test_ctx *ctx)
 {
+	if (ctx->update_iod.iod_name.iov_buf)
+		D_FREE(ctx->update_iod.iod_name.iov_buf);
+	if (ctx->dkey.iov_buf)
+		D_FREE(ctx->dkey.iov_buf);
 	ec_cleanup_cont(ctx);
 }
 
@@ -814,6 +818,135 @@ test_all_ec_agg(void **statep)
 	cleanup_ec_agg_tests(&ctx);
 }
 
+static void
+fetch_snap_with_agg(void **statep)
+{
+	test_arg_t		*arg = *statep;
+	struct ec_agg_test_ctx	 ctx = { 0 };
+	struct daos_oclass_attr	*oca;
+	uint32_t		 cs, ss;
+	daos_epoch_t		 snap_epoch;
+	d_iov_t			 dkey;
+	d_sg_list_t		 sgl;
+	d_iov_t			 sg_iov;
+	daos_iod_t		 iod;
+	daos_recx_t		 recx;
+	char			 *wbuf1;
+	char			 *wbuf2;
+	char			 *rbuf;
+	daos_handle_t		 th;
+	uint16_t		 fail_shard = 1;
+	uint64_t		 fail_val;
+	bool			 snap_higher = false;
+	int			 rc;
+
+	if (!test_runable(arg, 4))
+		skip();
+
+	FAULT_INJECTION_REQUIRED();
+
+	daos_pool_set_prop(arg->pool.pool_uuid, "reclaim", "time");
+	setup_ec_agg_tests(statep, &ctx);
+	dts_ec_agg_oc = DAOS_OC_EC_K2P2_L32K;
+	ec_setup_cont_obj(&ctx, dts_ec_agg_oc);
+	assert_int_equal(oid_is_ec(ctx.oid, &oca), true);
+	assert_int_equal(oca->u.ec.e_k, 2);
+	assert_int_equal(oca->u.ec.e_k, 2);
+	cs = oca->u.ec.e_len;
+	ss = cs * oca->u.ec.e_k;
+	wbuf1 = calloc(ss, 1);
+	wbuf2 = calloc(ss, 1);
+	rbuf = calloc(ss, 1);
+	memset(wbuf1, 'a', ss);
+	memset(wbuf2, 'b', ss);
+	memset(rbuf, 0, ss);
+
+	d_iov_set(&dkey, "dkey", strlen("dkey"));
+	d_iov_set(&iod.iod_name, "akey", strlen("akey"));
+
+	d_iov_set(&sg_iov, wbuf1, ss);
+	sgl.sg_nr = 1;
+	sgl.sg_nr_out = 0;
+	sgl.sg_iovs = &sg_iov;
+	iod.iod_nr	= 1;
+	iod.iod_size	= 1;
+	recx.rx_idx	= 0;
+	recx.rx_nr	= ss;
+	iod.iod_recxs	= &recx;
+	iod.iod_type	= DAOS_IOD_ARRAY;
+
+re_test:
+	/* write @low_epoch */
+	rc = daos_obj_update(ctx.oh, DAOS_TX_NONE, 0, &dkey, 1, &iod, &sgl,
+			     NULL);
+	assert_rc_equal(rc, 0);
+	/* create snapshot */
+	if (!snap_higher) {
+		print_message("test fetch_snapshot < vos_agg_boundary\n");
+		rc = daos_cont_create_snap(ctx.coh, &snap_epoch, NULL, NULL);
+		assert_rc_equal(rc, 0);
+	}
+	/* overwrite @high_epoch */
+	d_iov_set(&sg_iov, wbuf2, ss);
+	rc = daos_obj_update(ctx.oh, DAOS_TX_NONE, 0, &dkey, 1, &iod, &sgl,
+			     NULL);
+	assert_rc_equal(rc, 0);
+
+	/* wait aggregation */
+	daos_debug_set_params(arg->group, -1, DMG_KEY_FAIL_LOC,
+			      DAOS_FORCE_EC_AGG | DAOS_FAIL_ALWAYS,
+			      0, NULL);
+	print_message("wait for 25 seconds for VOS aggregation.\n");
+	sleep(25);
+
+	if (snap_higher) {
+		print_message("test fetch_snapshot > vos_agg_boundary\n");
+		rc = daos_cont_create_snap(ctx.coh, &snap_epoch, NULL, NULL);
+		assert_rc_equal(rc, 0);
+		daos_debug_set_params(arg->group, -1, DMG_KEY_FAIL_LOC,
+				      DAOS_FAIL_AGG_BOUNDRY_MOVED |
+				      DAOS_FAIL_ONCE, 0, NULL);
+	}
+
+	/* degraded fetch from snapshot, compare fetched data with
+	 * buffer written @low_epoch
+	 */
+	rc = daos_tx_open_snap(ctx.coh, snap_epoch, &th, NULL);
+	assert_rc_equal(rc, 0);
+
+	fail_val = daos_shard_fail_value(&fail_shard, 1);
+	daos_fail_loc_set(DAOS_FAIL_SHARD_FETCH | DAOS_FAIL_ONCE);
+	daos_fail_value_set(fail_val);
+	d_iov_set(&sg_iov, rbuf, ss);
+	rc = daos_obj_fetch(ctx.oh, th, 0, &dkey, 1, &iod, &sgl,
+			    NULL, NULL);
+	assert_rc_equal(rc, 0);
+	if (!snap_higher)
+		assert_memory_equal(rbuf, wbuf1, ss);
+	else
+		assert_memory_equal(rbuf, wbuf2, ss);
+
+	rc = daos_tx_close(th, NULL);
+	assert_rc_equal(rc, 0);
+
+	daos_debug_set_params(arg->group, -1, DMG_KEY_FAIL_LOC,
+			      0, 0, NULL);
+	daos_fail_loc_set(0);
+	daos_fail_value_set(0);
+
+	if (!snap_higher) {
+		snap_higher = true;
+		goto re_test;
+	}
+
+	free(wbuf1);
+	free(wbuf2);
+	free(rbuf);
+	rc = daos_obj_close(ctx.oh, NULL);
+	assert_rc_equal(rc, 0);
+	cleanup_ec_agg_tests(&ctx);
+}
+
 #define NUM_SERVERS 5
 static int
 ec_setup(void **statep)
@@ -825,6 +958,8 @@ ec_setup(void **statep)
 static const struct CMUnitTest ec_agg_tests[] = {
 	{"DAOS_ECAG00: test EC aggregation", test_all_ec_agg,
 	  incremental_fill, test_case_teardown},
+	{"DAOS_ECAG01: test fetch snapshot lower than vos agg boundary",
+	  fetch_snap_with_agg, async_disable, test_case_teardown},
 };
 
 int run_daos_aggregation_ec_test(int rank, int size, int *sub_tests,
@@ -832,14 +967,18 @@ int run_daos_aggregation_ec_test(int rank, int size, int *sub_tests,
 {
 	int rc = 0;
 
-	if (rank != 0) {
-		MPI_Barrier(MPI_COMM_WORLD);
-		return rc;
+	MPI_Barrier(MPI_COMM_WORLD);
+	if (sub_tests_size == 0) {
+		sub_tests_size = ARRAY_SIZE(ec_agg_tests);
+		sub_tests = NULL;
 	}
-	rc = cmocka_run_group_tests_name("DAOS_EC_Aggregation",
-					 ec_agg_tests, ec_setup, test_teardown);
+	if (rank != 0)
+		goto out;
+	rc += run_daos_sub_tests("DAOS_EC_Aggregation", ec_agg_tests,
+				 ARRAY_SIZE(ec_agg_tests), sub_tests,
+				 sub_tests_size, ec_setup, test_teardown);
 
+out:
 	MPI_Barrier(MPI_COMM_WORLD);
 	return rc;
 }
-


### PR DESCRIPTION
    As the aggregation runs asynchronously on different nodes, main race
    conditions between aggregation and EC degraded fetch -
    1. VOS may merge adjacent exts (now merge to lower epoch)
    2. VOS may delete lower epoch ext when it is fully covered by higher
       epoch ext.
    3. EC aggregation updates new parity exts asynchronously to different
       parity nodes
    
    That async operation possibly cause the degraded fetch's data-recovery
    handling - shadow epoch corresponding parity/data ext possibly not
    readable and then cause silent data corruption in recovery.
    
    This patch refine the handling of EC degraded fetch -
    1. for step 1 in EC degraded fetch
       if fetch from snapshot and  “snapshot_epoch < vos_agg_eph_boundary”
          parity server replies snapshot_epoch as recovery epoch,
          Client will carry (ORF_EC_RECOV_SNAP | ORF_EC_RECOV) for data
          recovery
       else
          parity server replies max {parity_ext_epoch, vos_agg_eph_boundary}
          as recovery_epoch.
    2. for step 2 in EC degraded fetch
       For some cases, need to internally restart the deg fetch from beginning -
       Server-side check -
       If no ORF_EC_RECOV_SNAP and current vos_agg_eph_boundary > recovery_epoch;
       Client-side check -
       If replied parity_epoch mismatch from different parity shards.
    
    Fix a bug in agg_process_stripe() that did not set correct epoch range
    when checking parity ext.
    
    Signed-off-by: Xuezhao Liu <xuezhao.liu@intel.com>