### PR TITLE
DAOS-7796 test: Resolve a conflict in NLT internal APIs.

### DIFF
--- a/utils/node_local_test.py
+++ b/utils/node_local_test.py
@@ -1377,7 +1377,7 @@ class posix_tests():
         dfuse0 = DFuse(self.server,
                        self.conf,
                        caching=True,
-                       pool=self.pool,
+                       pool=self.pool.uuid,
                        container=self.container)
         dfuse0.start(v_hint='two_0')
 
@@ -1386,7 +1386,7 @@ class posix_tests():
                        caching=True,
                        path=os.path.join(self.conf.dfuse_parent_dir,
                                          'dfuse_mount_1'),
-                       pool=self.pool,
+                       pool=self.pool.uuid,
                        container=self.container)
         dfuse1.start(v_hint='two_1')
 


### PR DESCRIPTION
There was a conflict between two landings using and changing
an internal API within NLT.  Update the new code to use the
new API.

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>
