### PR TITLE
DAOS-623 build: Fix the parser of custom build targets

### DIFF
--- a/site_scons/prereq_tools/base.py
+++ b/site_scons/prereq_tools/base.py
@@ -710,18 +710,20 @@ class PreReqComponent():
 
     def init_build_targets(self, build_dir):
         """Setup default build targets"""
+        targets = ['test', 'server', 'client']
         self.__env.Alias('client', build_dir)
         self.__env.Alias('server', build_dir)
         self.__env.Alias('test', build_dir)
         self._build_targets = []
-        BUILD_TARGETS.append(build_dir)
-        if 'client' in BUILD_TARGETS:
-            self._build_targets.extend(['client'])
-        elif 'server' in BUILD_TARGETS:
-            self._build_targets.extend(['server'])
-        else:
-            # either test or default
+        check = any(item in BUILD_TARGETS for item in targets)
+        if not check or 'test' in BUILD_TARGETS:
             self._build_targets.extend(['client', 'server', 'test'])
+        else:
+            if 'client' in BUILD_TARGETS:
+                self._build_targets.extend(['client'])
+            if 'server' in BUILD_TARGETS:
+                self._build_targets.extend(['server'])
+        BUILD_TARGETS.append(build_dir)
 
     def has_source(self, env, *comps, **kw):
         """Check if source exists for a component"""

--- a/site_scons/prereq_tools/base.py
+++ b/site_scons/prereq_tools/base.py
@@ -720,9 +720,9 @@ class PreReqComponent():
             self._build_targets.extend(['client', 'server', 'test'])
         else:
             if 'client' in BUILD_TARGETS:
-                self._build_targets.extend(['client'])
+                self._build_targets.append('client')
             if 'server' in BUILD_TARGETS:
-                self._build_targets.extend(['server'])
+                self._build_targets.append('server')
         BUILD_TARGETS.append(build_dir)
 
     def has_source(self, env, *comps, **kw):

--- a/utils/run_in_ga.sh
+++ b/utils/run_in_ga.sh
@@ -34,7 +34,7 @@ utils/check.sh -n /opt/daos/bin/dmg
 echo ::endgroup::
 
 echo ::group::Test incremental debug build with test target
-$SCONS --jobs 10 test
+$SCONS --jobs 10 test client
 echo ::endgroup::
 
 echo ::group::Config file


### PR DESCRIPTION
Previously, the logic in the function was messed up when multiple
custom targets are used.

For example,
scons test client server

would only build the client.

This fixes the logic in the function so it handles multiple targets
appropriately.

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>