### PR TITLE
DAOS-7844 csum: Improve IOD Is Valid Check

### DIFF
--- a/src/include/daos/checksum.h
+++ b/src/include/daos/checksum.h
@@ -539,9 +539,11 @@ static inline bool
 csum_iod_is_supported(daos_iod_t *iod)
 {
 	/**
-	 * iod_size must be greater than 1
+	 * Needs to have something to actually checksum
+	 * iod_size must be greater than 1 and have records if it's an array
 	 */
-	return iod->iod_size > 0;
+	return iod->iod_size > 0 &&
+	       !(iod->iod_type == DAOS_IOD_ARRAY && iod->iod_nr == 0);
 }
 
 /**

--- a/src/vos/vos_io.c
+++ b/src/vos/vos_io.c
@@ -1578,7 +1578,7 @@ akey_update(struct vos_io_context *ioc, uint32_t pm_ver, daos_handle_t ak_toh,
 			continue;
 		}
 
-		if (iod_csums != NULL)
+		if (iod_csums != NULL && csum_iod_is_supported(iod))
 			recx_csum = &iod_csums[i];
 		rc = akey_update_recx(toh, pm_ver, &iod->iod_recxs[i],
 				      recx_csum, iod->iod_size, ioc,


### PR DESCRIPTION
The is valid IOD check should check for number of
recxs for array values. If there are none, then
don't expect a checksum during the verify processes.

Signed-off-by: Ryon Jensen <ryon.jensen@intel.com>