### PR TITLE
DAOS-7797 control: Display JSON metric type as a string

### DIFF
--- a/src/control/lib/control/telemetry.go
+++ b/src/control/lib/control/telemetry.go
@@ -70,23 +70,30 @@ const (
 	MetricTypeGauge
 	MetricTypeSummary
 	MetricTypeHistogram
+
+	metricTypeUnknownStr   = "Unknown"
+	metricTypeGenericStr   = "Generic"
+	metricTypeCounterStr   = "Counter"
+	metricTypeGaugeStr     = "Gauge"
+	metricTypeSummaryStr   = "Summary"
+	metricTypeHistogramStr = "Histogram"
 )
 
 func (t MetricType) String() string {
 	switch t {
 	case MetricTypeGeneric:
-		return "Generic"
+		return metricTypeGenericStr
 	case MetricTypeCounter:
-		return "Counter"
+		return metricTypeCounterStr
 	case MetricTypeGauge:
-		return "Gauge"
+		return metricTypeGaugeStr
 	case MetricTypeSummary:
-		return "Summary"
+		return metricTypeSummaryStr
 	case MetricTypeHistogram:
-		return "Histogram"
+		return metricTypeHistogramStr
 	}
 
-	return "Unknown"
+	return metricTypeUnknownStr
 }
 
 func metricTypeFromPrometheus(pType pclient.MetricType) MetricType {
@@ -103,6 +110,23 @@ func metricTypeFromPrometheus(pType pclient.MetricType) MetricType {
 		return MetricTypeGeneric
 	}
 
+	return MetricTypeUnknown
+}
+
+func metricTypeFromString(typeStr string) MetricType {
+	// normalize the strings for comparison
+	switch strings.ToLower(typeStr) {
+	case strings.ToLower(metricTypeCounterStr):
+		return MetricTypeCounter
+	case strings.ToLower(metricTypeGaugeStr):
+		return MetricTypeGauge
+	case strings.ToLower(metricTypeSummaryStr):
+		return MetricTypeSummary
+	case strings.ToLower(metricTypeHistogramStr):
+		return MetricTypeHistogram
+	case strings.ToLower(metricTypeGenericStr):
+		return MetricTypeGeneric
+	}
 	return MetricTypeUnknown
 }
 
@@ -157,10 +181,10 @@ type (
 )
 
 // IsMetric identifies SimpleMetric as a Metric.
-func (_ *SimpleMetric) IsMetric() {}
+func (*SimpleMetric) IsMetric() {}
 
 // IsMetric identifies SummaryMetric as a Metric.
-func (_ *SummaryMetric) IsMetric() {}
+func (*SummaryMetric) IsMetric() {}
 
 // UnmarshalJSON unmarshals a SummaryMetric from JSON.
 func (m *SummaryMetric) UnmarshalJSON(data []byte) error {
@@ -168,38 +192,21 @@ func (m *SummaryMetric) UnmarshalJSON(data []byte) error {
 		return errors.New("nil SummaryMetric")
 	}
 
-	type Alias SummaryMetric
-	aux := &struct {
-		StrQuantiles map[string]string `json:"quantiles"`
-		*Alias
-	}{
-		Alias: (*Alias)(m),
+	if m.Quantiles == nil {
+		m.Quantiles = make(QuantileMap)
 	}
+
+	type Alias SummaryMetric
+	aux := (*Alias)(m)
 	if err := json.Unmarshal(data, &aux); err != nil {
 		return err
-	}
-
-	// Translate from strings to floats
-	m.Quantiles = make(QuantileMap)
-	for key, val := range aux.StrQuantiles {
-		floatKey, err := strconv.ParseFloat(key, 64)
-		if err != nil {
-			return errors.Wrapf(err, "key %q can't be converted to float", key)
-		}
-
-		floatVal, err := strconv.ParseFloat(val, 64)
-		if err != nil {
-			return errors.Wrapf(err, "value %q can't be converted to float", val)
-		}
-
-		m.Quantiles[floatKey] = floatVal
 	}
 
 	return nil
 }
 
 // IsMetric identifies HistogramMetric as a Metric.
-func (_ *HistogramMetric) IsMetric() {}
+func (*HistogramMetric) IsMetric() {}
 
 // Keys gets the sorted list of label keys.
 func (m LabelMap) Keys() []string {
@@ -234,6 +241,118 @@ func (m QuantileMap) MarshalJSON() ([]byte, error) {
 	}
 
 	return json.Marshal(&strMap)
+}
+
+// UnmarshalJSON unmarshals the QuantileMap from JSON.
+func (m QuantileMap) UnmarshalJSON(data []byte) error {
+	if m == nil {
+		return errors.New("QuantileMap is nil")
+	}
+
+	fromJSON := make(map[string]string)
+
+	if err := json.Unmarshal(data, &fromJSON); err != nil {
+		return nil
+	}
+
+	for key, val := range fromJSON {
+		floatKey, err := strconv.ParseFloat(key, 64)
+		if err != nil {
+			return errors.Wrapf(err, "QuantileMap key %q", key)
+		}
+
+		floatVal, err := strconv.ParseFloat(val, 64)
+		if err != nil {
+			return errors.Wrapf(err, "QuantileMap value %q for key %q", val, key)
+		}
+
+		m[floatKey] = floatVal
+	}
+	return nil
+}
+
+// MarshalJSON marshals the MetricSet to JSON.
+func (ms *MetricSet) MarshalJSON() ([]byte, error) {
+	type toJSON MetricSet
+	return json.Marshal(&struct {
+		Type string `json:"type"`
+		*toJSON
+	}{
+		Type:   strings.ToLower(ms.Type.String()),
+		toJSON: (*toJSON)(ms),
+	})
+}
+
+// jsonMetric serves as a universal metric representation for unmarshaling from
+// JSON. It covers all possible fields of Metric types.
+type jsonMetric struct {
+	Labels      LabelMap        `json:"labels"`
+	Value       float64         `json:"value"`
+	SampleCount uint64          `json:"sample_count"`
+	SampleSum   float64         `json:"sample_sum"`
+	Quantiles   QuantileMap     `json:"quantiles"`
+	Buckets     []*MetricBucket `json:"buckets"`
+}
+
+// UnmarshalJSON unmarshals a Metric into the jsonMetric type.
+func (jm *jsonMetric) UnmarshalJSON(data []byte) error {
+	if jm == nil {
+		return errors.New("nil jsonMetric")
+	}
+
+	if jm.Quantiles == nil {
+		jm.Quantiles = make(QuantileMap)
+	}
+
+	type Alias jsonMetric
+	aux := (*Alias)(jm)
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// UnmarshalJSON unmarshals the MetricSet from JSON.
+func (ms *MetricSet) UnmarshalJSON(data []byte) error {
+	if ms == nil {
+		return errors.New("nil MetricSet")
+	}
+
+	type fromJSON MetricSet
+	from := &struct {
+		Type    string        `json:"type"`
+		Metrics []*jsonMetric `json:"metrics"`
+		*fromJSON
+	}{
+		fromJSON: (*fromJSON)(ms),
+	}
+	if err := json.Unmarshal(data, from); err != nil {
+		return err
+	}
+
+	ms.Type = metricTypeFromString(from.Type)
+	for _, m := range from.Metrics {
+		switch ms.Type {
+		case MetricTypeSummary:
+			ms.Metrics = append(ms.Metrics, &SummaryMetric{
+				Labels:      m.Labels,
+				SampleCount: m.SampleCount,
+				SampleSum:   m.SampleSum,
+				Quantiles:   m.Quantiles,
+			})
+		case MetricTypeHistogram:
+			ms.Metrics = append(ms.Metrics, &HistogramMetric{
+				Labels:      m.Labels,
+				SampleCount: m.SampleCount,
+				SampleSum:   m.SampleSum,
+				Buckets:     m.Buckets,
+			})
+		default:
+			ms.Metrics = append(ms.Metrics, newSimpleMetric(m.Labels, m.Value))
+		}
+	}
+	return nil
 }
 
 type (

--- a/src/control/lib/control/telemetry_test.go
+++ b/src/control/lib/control/telemetry_test.go
@@ -14,6 +14,7 @@ import (
 	"net/url"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
@@ -642,6 +643,162 @@ func TestControl_Metric_JSON(t *testing.T) {
 			expResult := tc.metric
 			if tc.metric == nil {
 				expResult = &SimpleMetric{}
+			}
+
+			if diff := cmp.Diff(expResult, unmarshaled); diff != "" {
+				t.Fatalf("unmarshaled different from original (-want, +got):\n%s\n", diff)
+			}
+		})
+	}
+}
+
+func TestControl_metricTypeFromString(t *testing.T) {
+	for name, tc := range map[string]struct {
+		input   string
+		expType MetricType
+	}{
+		"empty": {
+			expType: MetricTypeUnknown,
+		},
+		"counter": {
+			input:   "counter",
+			expType: MetricTypeCounter,
+		},
+		"gauge": {
+			input:   "gauge",
+			expType: MetricTypeGauge,
+		},
+		"summary": {
+			input:   "summary",
+			expType: MetricTypeSummary,
+		},
+		"histogram": {
+			input:   "histogram",
+			expType: MetricTypeHistogram,
+		},
+		"generic": {
+			input:   "generic",
+			expType: MetricTypeGeneric,
+		},
+		"invalid": {
+			input:   "some garbage text",
+			expType: MetricTypeUnknown,
+		},
+		"weird capitalization": {
+			input:   "CoUnTeR",
+			expType: MetricTypeCounter,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			gotType := metricTypeFromString(tc.input)
+
+			common.AssertEqual(t, tc.expType, gotType, "")
+		})
+	}
+}
+
+func TestControl_MetricSet_JSON(t *testing.T) {
+	for name, tc := range map[string]struct {
+		set *MetricSet
+	}{
+		"nil": {},
+		"generic type": {
+			set: &MetricSet{
+				Name:        "timespan",
+				Description: "It's been a while",
+				Type:        MetricTypeGeneric,
+				Metrics: []Metric{
+					newSimpleMetric(map[string]string{
+						"units": "nanoseconds",
+					}, float64(time.Second)),
+				},
+			},
+		},
+		"counter type": {
+			set: &MetricSet{
+				Name:        "one_ring",
+				Description: "Precious...",
+				Type:        MetricTypeCounter,
+				Metrics: []Metric{
+					newSimpleMetric(map[string]string{
+						"owner": "frodo",
+					}, 1),
+				},
+			},
+		},
+		"gauge type": {
+			set: &MetricSet{
+				Name:        "funny_hats",
+				Description: "Hilarious headgear in inventory",
+				Type:        MetricTypeGauge,
+				Metrics: []Metric{
+					newSimpleMetric(map[string]string{
+						"type": "tophat",
+					}, 1),
+					newSimpleMetric(map[string]string{
+						"type": "cowboy",
+					}, 6),
+					newSimpleMetric(map[string]string{
+						"type": "jester",
+					}, 0),
+				},
+			},
+		},
+		"summary type": {
+			set: &MetricSet{
+				Name:        "alpha",
+				Description: "The first letter! Everybody's favorite!",
+				Type:        MetricTypeSummary,
+				Metrics: []Metric{
+					&SummaryMetric{
+						Labels:      map[string]string{"beta": "b"},
+						SampleCount: 3,
+						SampleSum:   42,
+						Quantiles:   map[float64]float64{0.5: 2.2},
+					},
+				},
+			},
+		},
+		"histogram type": {
+			set: &MetricSet{
+				Name:        "my_histogram",
+				Description: "This is a histogram",
+				Type:        MetricTypeHistogram,
+				Metrics: []Metric{
+					&HistogramMetric{
+						Labels:      map[string]string{"owner": "me"},
+						SampleCount: 1024,
+						SampleSum:   12344,
+						Buckets: []*MetricBucket{
+							{
+								CumulativeCount: 789,
+								UpperBound:      500,
+							},
+							{
+								CumulativeCount: 456,
+								UpperBound:      1000,
+							},
+						},
+					},
+				},
+			},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			marshaled, err := json.Marshal(tc.set)
+			if err != nil {
+				t.Fatalf("expected to marshal, got %q", err)
+			}
+
+			unmarshaled := new(MetricSet)
+			err = json.Unmarshal(marshaled, unmarshaled)
+			if err != nil {
+				t.Fatalf("expected to unmarshal, got %q", err)
+			}
+
+			expResult := tc.set
+			if tc.set == nil {
+				expResult = &MetricSet{}
 			}
 
 			if diff := cmp.Diff(expResult, unmarshaled); diff != "" {


### PR DESCRIPTION
- Translate the metric type to and from human-friendly string
  values in JSON.
- Improve JSON marshaling and unmarshaling for some related
  structures.

Signed-off-by: Kris Jacque <kristin.jacque@intel.com>