### PR TITLE
DOAS-7484 build: Use pkgconfig even for built dependencies

### DIFF
--- a/site_scons/components/__init__.py
+++ b/site_scons/components/__init__.py
@@ -187,8 +187,8 @@ def define_mercury(reqs):
                                 '-DOFI_LIBRARY=$OFI_PREFIX/lib/libfabric.so'),
                           'make $JOBS_OPT', 'make install'],
                 libs=['mercury', 'na', 'mercury_util'],
+                pkgconfig='mercury',
                 requires=[atomic, 'boost', 'ofi'] + libs,
-                extra_include_path=[os.path.join('include', 'na')],
                 out_of_src_build=True,
                 package='mercury-devel' if inst(reqs, 'mercury') else None,
                 patch_rpath=['lib'])

--- a/site_scons/prereq_tools/base.py
+++ b/site_scons/prereq_tools/base.py
@@ -1446,6 +1446,12 @@ class _Component():
         path = os.environ.get("PKG_CONFIG_PATH", None)
         if not path is None:
             env["ENV"]["PKG_CONFIG_PATH"] = path
+        if self.component_prefix:
+            for path in ["lib", "lib64"]:
+                config = os.path.join(self.component_prefix, path, "pkgconfig")
+                if not os.path.exists(config):
+                    continue
+                env.AppendENVPath("PKG_CONFIG_PATH", config)
 
         try:
             env.ParseConfig("pkg-config %s %s" % (opts, self.pkgconfig))


### PR DESCRIPTION
Allow the component build to specify a pkgconfig file to configure
libraries for the build.

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>