### PR TITLE
DAOS-7849 build: Remove psm2 from the default build

### DIFF
--- a/doc/admin/deployment.md
+++ b/doc/admin/deployment.md
@@ -686,6 +686,14 @@ engines:
 <end>
 ```
 
+There are a few optional providers that are not built by default. For detailed
+information, please refer to the [DAOS build documentation][6].
+
+>**_NOTE_**
+>
+>The support of the optional providers is not guarantee and can be removed
+>without further notification.
+
 ### Network Scan and Configuration
 
 The `daos_server` supports the `network scan` function to display the network
@@ -1099,3 +1107,5 @@ each storage node.
 [^4]: https://github.com/daos-stack/daos/tree/master/src/control/README.md
 
 [^5]: https://github.com/pmem/ndctl/issues/130
+
+[6]: <../dev/development.md#building-optional-components> (Building DAOS for Development)

--- a/doc/dev/development.md
+++ b/doc/dev/development.md
@@ -95,6 +95,42 @@ Note that such targets need to be specified each time you build as the default
 is equivalent to specifying `client server test` on the command line.  The
 `test` target is, at present, dependent on `client` and `server` as well.
 
+### Building Optional Components
+
+There are a few optional components that can be included into the DAOS build.
+For instance, to include the `psm2` provider. Run the following `scons`
+command:
+
+```bash
+$ scons PREFIX=${daos_prefix_path}
+      INCLUDE=psm2
+      install
+      --build-deps=yes
+      --config=force
+```
+
+Refer to the built-in `scons` help command to get a full list of all the
+optional components under the `INCLUDE` optional parameter.
+
+```bash
+$ scons -h
+scons: Reading SConscript files ...
+
+INCLUDE: Optional components to build
+    (all|none|comma-separated list of names)
+    allowed names: psm2 psm3
+    default: none
+    actual:
+```
+
+The version of the components can be changed by editing the
+[utils/build.config][1] file.
+
+>**_NOTE_**
+>
+>The support of the optional components is not guarantee and can be removed
+>without further notification.
+
 ## Go dependencies
 
 Developers contributing Go code may need to change the external dependencies
@@ -217,3 +253,5 @@ $ git status
 
 After verifying that the generated C/Go files are correct, add and commit them
 as you would any other file.
+
+[1]: <../../utils/build.config> (build.config)

--- a/doc/overview/use_cases.md
+++ b/doc/overview/use_cases.md
@@ -128,7 +128,7 @@ individual tasks, but not committed, are automatically rolled back.
 In the previous <a href="6a">figure</a>, we have two examples of 
 producer/consumer. The down-sample job consumes raw timesteps generated 
 by the simulation job and produces sampled timesteps analyzed by the 
-post-process job. The DAOS stack provides specific mechanisms for 
+post-process job. The DAOS stack provides specific mechanisms for
 producer/consumer workflow which even allows the consumer to dumps the 
 result of its analysis into the same container as the producer.
 

--- a/site_scons/components/__init__.py
+++ b/site_scons/components/__init__.py
@@ -66,12 +66,13 @@ class installed_comps():
         self.not_installed.append(name)
         return False
 
-def exclude(reqs, name, use_value, exclude_value):
-    """Return True if in exclude list"""
-    if set([name, 'all']).intersection(set(reqs.exclude)):
-        print("Excluding %s from build" % name)
-        return exclude_value
-    return use_value
+def include(reqs, name, use_value, exclude_value):
+    """Return True if in include list"""
+    if set([name, 'all']).intersection(set(reqs.include)):
+        print("Including %s optional component from build" % name)
+        return use_value
+    print("Excluding %s optional component from build" % name)
+    return exclude_value
 
 def inst(reqs, name):
     """Return True if name is in list of installed packages"""
@@ -135,18 +136,21 @@ def define_mercury(reqs):
                           '--disable-psm3 ' +
                           '--without-gdrcopy ' +
                           OFI_DEBUG +
-                          exclude(reqs, 'psm2',
+                          include(reqs, 'psm2',
                                   '--enable-psm2' +
                                   check(reqs, 'psm2',
                                         "=$PSM2_PREFIX "
                                         'LDFLAGS="-Wl,--enable-new-dtags ' +
                                         '-Wl,-rpath=$PSM2_PREFIX/lib64" ',
                                         ''),
-                                  ''),
+                                  '--disable-psm2 ') +
+                          include(reqs, 'psm3',
+                                  '--enable-psm3 ',
+                                  '--disable-psm3 '),
                           'make $JOBS_OPT',
                           'make install'],
                 libs=['fabric'],
-                requires=exclude(reqs, 'psm2', ['psm2'], []),
+                requires=include(reqs, 'psm2', ['psm2'], []),
                 config_cb=ofi_config,
                 headers=['rdma/fabric.h'],
                 package='libfabric-devel' if inst(reqs, 'ofi') else None,

--- a/site_scons/prereq_tools/base.py
+++ b/site_scons/prereq_tools/base.py
@@ -681,8 +681,8 @@ class PreReqComponent():
         self.__opts.Add('USE_INSTALLED',
                         'Comma separated list of preinstalled dependencies',
                         'none')
-        self.add_opts(ListVariable('EXCLUDE', "Components to skip building",
-                                   'none', ['psm2']))
+        self.add_opts(ListVariable('INCLUDE', "Optional components to build",
+                                   'none', ['psm2', 'psm3']))
         self.add_opts(('MPI_PKG',
                        'Specifies name of pkg-config to load for MPI', None))
         self.add_opts(BoolVariable('FIRMWARE_MGMT',
@@ -705,7 +705,7 @@ class PreReqComponent():
             self.configs.read(config_file)
 
         self.installed = env.subst("$USE_INSTALLED").split(",")
-        self.exclude = env.subst("$EXCLUDE").split(",")
+        self.include = env.subst("$INCLUDE").split(" ")
         self._build_targets = []
 
     def init_build_targets(self, build_dir):

--- a/src/cart/crt_init.c
+++ b/src/cart/crt_init.c
@@ -464,7 +464,9 @@ do_init:
 			}
 		}
 
+		/* Print notice that "ofi+psm2" will be deprecated*/
 		if (prov == CRT_NA_OFI_PSM2) {
+			D_WARN("\"ofi+psm2\" will be deprecated soon.\n");
 			setenv("FI_PSM2_NAME_SERVER", "1", true);
 			D_DEBUG(DB_ALL, "Setting FI_PSM2_NAME_SERVER to 1\n");
 		}


### PR DESCRIPTION
This patch removes the psm2 and psm3 providers from the default DAOS build. The
providers can be enabled on demand by using the `INCLUDE` option.
For instance, to enable the psm2 provider:

`scons --build-deps=yes --config=force BUILD_TYPE=release INCLUDE=psm2 install`

The list of all the optional components can be retrieved by running the scons
help command.

`scons -h`

¯\_(ツ)_/¯

Signed-off-by: Galen Erso <rogue.developer@outlook.com>