### PR TITLE
DAOS-5692 tools: Don't reset props->dpp_nr

### DIFF
--- a/src/control/cmd/daos/property.go
+++ b/src/control/cmd/daos/property.go
@@ -817,7 +817,6 @@ func (f *PropertiesFlag) Cleanup() {
 		return
 	}
 
-	f.props.dpp_nr = C.DAOS_PROP_ENTRIES_MAX_NR
 	C.daos_prop_free(f.props)
 }
 

--- a/src/control/cmd/daos/util.go
+++ b/src/control/cmd/daos/util.go
@@ -190,7 +190,6 @@ func freeCmdArgs(ap *C.struct_cmd_args_s) {
 	C.free_daos_alloc(unsafe.Pointer(ap.dfs_path))
 
 	if ap.props != nil {
-		ap.props.dpp_nr = C.DAOS_PROP_ENTRIES_MAX_NR
 		C.daos_prop_free(ap.props)
 	}
 }


### PR DESCRIPTION
Mistaken holdover from older logic. Don't reset the
number of prop entries before freeing. Fixes an
intermittent segfault in the new daos utility.