### PR TITLE
DAOS-2513 firmware: Fix NVMe firmware query/update

### DIFF
--- a/src/control/server/storage/bdev/backend.go
+++ b/src/control/server/storage/bdev/backend.go
@@ -462,31 +462,6 @@ func (sb *spdkBackend) UpdateFirmware(pciAddr string, path string, slot int32) e
 		return FaultBadPCIAddr("")
 	}
 
-	restoreOutput, err := sb.binding.init(sb.log, &spdk.EnvOptions{
-		DisableVMD: sb.IsVMDDisabled(),
-	})
-	if err != nil {
-		return err
-	}
-	defer restoreOutput()
-
-	cs, err := sb.binding.Discover(sb.log)
-	if err != nil {
-		return errors.Wrap(err, "failed to discover nvme")
-	}
-
-	var found bool
-	for _, c := range cs {
-		if c.PciAddr == pciAddr {
-			found = true
-			break
-		}
-	}
-
-	if !found {
-		return FaultPCIAddrNotFound(pciAddr)
-	}
-
 	if err := sb.binding.Update(sb.log, pciAddr, path, slot); err != nil {
 		return err
 	}

--- a/src/control/server/storage/bdev/backend_test.go
+++ b/src/control/server/storage/bdev/backend_test.go
@@ -377,37 +377,19 @@ func TestBackend_Update(t *testing.T) {
 		mnc     spdk.MockNvmeCfg
 		expErr  error
 	}{
-		"init failed": {
-			pciAddr: controllers[0].PciAddr,
-			mec: spdk.MockEnvCfg{
-				InitErr: errors.New("spdk init says no"),
-			},
-			mnc: spdk.MockNvmeCfg{
-				DiscoverCtrlrs: controllers,
-			},
-			expErr: errors.New("spdk init says no"),
-		},
-		"not found": {
-			pciAddr: "NotReal",
-			mnc: spdk.MockNvmeCfg{
-				DiscoverCtrlrs: controllers,
-			},
-			expErr: FaultPCIAddrNotFound("NotReal"),
+		"no PCI addr": {
+			expErr: FaultBadPCIAddr(""),
 		},
 		"binding update fail": {
 			pciAddr: controllers[0].PciAddr,
 			mnc: spdk.MockNvmeCfg{
-				DiscoverCtrlrs: controllers,
-				UpdateErr:      errors.New("spdk says no"),
+				UpdateErr: errors.New("spdk says no"),
 			},
 			expErr: errors.New("spdk says no"),
 		},
 		"binding update success": {
 			pciAddr: controllers[0].PciAddr,
-			mnc: spdk.MockNvmeCfg{
-				DiscoverCtrlrs: controllers,
-			},
-			expErr: nil,
+			expErr:  nil,
 		},
 	} {
 		t.Run(name, func(t *testing.T) {

--- a/src/control/server/storage/bdev/firmware.go
+++ b/src/control/server/storage/bdev/firmware.go
@@ -111,7 +111,7 @@ func (p *Provider) getRequestedControllers(requestedPCIAddrs []string, modelID s
 }
 
 func (p *Provider) getRequestedControllersByAddr(requestedPCIAddrs []string, ignoreMissing bool) (storage.NvmeControllers, error) {
-	resp, err := p.backend.Scan(ScanRequest{})
+	resp, err := p.Scan(ScanRequest{})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Due to some changes further up the stack, firmware query and
update were trying to initialize the SPDK library twice. Since
we're already doing a storage scan for both, it's possible to
simplify the backend/bindings.

Signed-off-by: Kris Jacque <kristin.jacque@intel.com>