### PR TITLE
DAOS-7914 cont: refine DAOS_PROP_CO_STATUS setting

### DIFF
--- a/src/container/srv_container.c
+++ b/src/container/srv_container.c
@@ -2588,7 +2588,7 @@ set_prop_co_status_pre_process(struct ds_pool *pool, struct cont *cont,
 	daos_prop_val_2_co_status(entry->dpe_val, &co_status);
 	D_ASSERT(co_status.dcs_status == DAOS_PROP_CO_HEALTHY ||
 		 co_status.dcs_status == DAOS_PROP_CO_UNCLEAN);
-	clear_stat = (co_status.dcs_flags == DAOS_PROP_CO_CLEAR);
+	clear_stat = (co_status.dcs_status == DAOS_PROP_CO_HEALTHY);
 	co_status.dcs_pm_ver = ds_pool_get_version(pool);
 	co_status.dcs_flags = 0;
 	entry->dpe_val = daos_prop_co_status_2_val(&co_status);

--- a/src/tests/ftest/util/rebuild_test_base.py
+++ b/src/tests/ftest/util/rebuild_test_base.py
@@ -6,7 +6,7 @@
 """
 from apricot import TestWithServers
 from command_utils_base import ObjectWithParameters, BasicParameter
-
+from daos_utils import DaosCommand
 
 class RebuildTestParams(ObjectWithParameters):
     # pylint: disable=too-few-public-methods
@@ -33,6 +33,7 @@ class RebuildTestBase(TestWithServers):
         self.server_count = 0
         self.info_checks = None
         self.rebuild_checks = None
+        self.daos_cmd = None
 
     def setUp(self):
         """Set up each test case."""
@@ -160,6 +161,7 @@ class RebuildTestBase(TestWithServers):
         """
         # Get the test params
         self.setup_test_pool()
+        self.daos_cmd = DaosCommand(self.bin)
         if create_container:
             self.setup_test_container()
 
@@ -180,6 +182,13 @@ class RebuildTestBase(TestWithServers):
 
         # Confirm rebuild completes
         self.pool.wait_for_rebuild(False, 1)
+
+        # clear container status for the RF issue
+        self.daos_cmd.container_set_prop(
+                      pool=self.pool.uuid,
+                      cont=self.container.uuid,
+                      prop="status",
+                      value="healthy")
 
         # Refresh local pool and container
         self.pool.check_pool_info()


### PR DESCRIPTION
When set DAOS_PROP_CO_STATUS container prop, set the clear_stat flag
when user set it as DAOS_PROP_CO_HEALTHY, rather than check whether or
not user passed DAOS_PROP_CO_CLEAR flag or not.

Test-tag-vm: pr rebuild
Test-tag-hw-small: pr rebuild
Test-tag-hw-medium: pr rebuild
Test-tag-hw-large: pr rebuild

Signed-off-by: Xuezhao Liu <xuezhao.liu@intel.com>