### PR TITLE
DAOS-7910 tools: Handle empty ACL in daos cont get-acl

### DIFF
--- a/src/control/cmd/daos/acl.go
+++ b/src/control/cmd/daos/acl.go
@@ -44,7 +44,7 @@ func getAclStrings(e *C.struct_daos_prop_entry) (out []string) {
 	var acesNr C.size_t
 
 	rc := C.daos_acl_to_strs(acl, &aces, &acesNr)
-	if err := daosError(rc); err != nil {
+	if err := daosError(rc); err != nil || aces == nil {
 		return
 	}
 	defer C.free_strings(aces, acesNr)
@@ -123,7 +123,7 @@ func (cmd *containerOverwriteACLCmd) Execute(args []string) error {
 
 	cleanup, err := cmd.resolveAndConnect(ap)
 	if err != nil {
-		return nil
+		return err
 	}
 	defer cleanup()
 
@@ -160,7 +160,7 @@ func (cmd *containerUpdateACLCmd) Execute(args []string) error {
 
 	cleanup, err := cmd.resolveAndConnect(ap)
 	if err != nil {
-		return nil
+		return err
 	}
 	defer cleanup()
 
@@ -198,7 +198,7 @@ func (cmd *containerDeleteACLCmd) Execute(args []string) error {
 
 	cleanup, err := cmd.resolveAndConnect(ap)
 	if err != nil {
-		return nil
+		return err
 	}
 	defer cleanup()
 
@@ -300,7 +300,7 @@ func (cmd *containerSetOwnerCmd) Execute(args []string) error {
 
 	cleanup, err := cmd.resolveAndConnect(ap)
 	if err != nil {
-		return nil
+		return err
 	}
 	defer cleanup()
 


### PR DESCRIPTION
Add a missing check for an empty ACL in the get-acl case.

Also fixes some error handling in the acl commands when a
pool/container was not specified.

Test-tags: pr container_acl