### PR TITLE
Daos 5363 test osa: Triage and investigate 16 functional tests failed on secure-mode

### DIFF
--- a/src/tests/ftest/daos_test/daos_core_test.yaml
+++ b/src/tests/ftest/daos_test/daos_core_test.yaml
@@ -71,13 +71,13 @@ server_config:
       env_vars:
         - DD_MASK=mgmt,io,md,epc,rebuild
   transport_config:
-    allow_insecure: True
+    allow_insecure: False
 agent_config:
   transport_config:
-    allow_insecure: True
+    allow_insecure: False
 dmg:
   transport_config:
-    allow_insecure: True
+    allow_insecure: False
 daos_tests:
   num_clients: 1
   test_name:

--- a/src/tests/ftest/io/fio_small.yaml
+++ b/src/tests/ftest/io/fio_small.yaml
@@ -32,13 +32,13 @@ server_config:
       scm_list: ["/dev/pmem1"]
       scm_mount: /mnt/daos1
   transport_config:
-    allow_insecure: True
+    allow_insecure: False
 agent_config:
   transport_config:
-    allow_insecure: True
+    allow_insecure: False
 dmg:
   transport_config:
-    allow_insecure: True
+    allow_insecure: False
 pool:
   mode: 146
   name: daos_server

--- a/src/tests/ftest/io/hdf5.yaml
+++ b/src/tests/ftest/io/hdf5.yaml
@@ -12,13 +12,13 @@ server_config:
         scm_class: dcpm
         scm_list: ["/dev/pmem0"]
     transport_config:
-        allow_insecure: True
+        allow_insecure: False
 agent_config:
     transport_config:
-        allow_insecure: True
+        allow_insecure: False
 dmg:
     transport_config:
-        allow_insecure: True
+        allow_insecure: False
 pool:
     mode: 146
     name: daos_server

--- a/src/tests/ftest/nvme/nvme_object.yaml
+++ b/src/tests/ftest/nvme/nvme_object.yaml
@@ -22,13 +22,13 @@ server_config:
     scm_class: dcpm
     scm_list: ["/dev/pmem0"]
   transport_config:
-    allow_insecure: True
+    allow_insecure: False
 agent_config:
   transport_config:
-    allow_insecure: True
+    allow_insecure: False
 dmg:
   transport_config:
-    allow_insecure: True
+    allow_insecure: False
 pool:
   createmode:
     mode: 511

--- a/src/tests/ftest/osa/osa_offline_reintegration.yaml
+++ b/src/tests/ftest/osa/osa_offline_reintegration.yaml
@@ -41,13 +41,13 @@ server_config:
       env_vars:
         - DD_MASK=mgmt,md,rebuild
   transport_config:
-    allow_insecure: True
+    allow_insecure: False
 agent_config:
   transport_config:
-    allow_insecure: True
+    allow_insecure: False
 dmg:
   transport_config:
-    allow_insecure: True
+    allow_insecure: False
 pool:
   mode: 146
   name: daos_server


### PR DESCRIPTION
Daos 5363 test osa: Triage and investigate 16 functional tests failed on secure-mode

modified:   daos_core_test.yaml
modified:   ../nvme/nvme_object.yaml
modified:   ../osa/osa_offline_reintegration.yaml
Test-tag: nvme_object,offline_reintegration_multiple_pools,daos_core_test
Signed-off-by: Ding Ho <ding-hwa.ho@intel.com>
