### PR TITLE
DAOS-7918 EC: add EC object to racer test

### DIFF
--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -1791,8 +1791,11 @@ obj_recx_valid(unsigned int nr, daos_recx_t *recxs, bool update)
 
 	if (nr == 0 || recxs == NULL)
 		return false;
-	if (nr == 1)
+	if (nr == 1) {
+		if (recxs[0].rx_nr == 0)
+			return false;
 		return true;
+	}
 
 	switch (nr) {
 	case 2:
@@ -1820,6 +1823,10 @@ obj_recx_valid(unsigned int nr, daos_recx_t *recxs, bool update)
 
 		overlapped = false;
 		for (idx = 0; idx < nr; idx++) {
+			if (recxs[idx].rx_nr == 0) {
+				overlapped = true;
+				break;
+			}
 			d_iov_set(&key, &recxs[idx], sizeof(daos_recx_t));
 			rc = dbtree_update(bth, &key, NULL);
 			if (rc != 0) {

--- a/src/tests/daos_racer.c
+++ b/src/tests/daos_racer.c
@@ -36,7 +36,7 @@ enum {
 };
 
 #define MAX_ROUND	10
-#define MAX_REC_SIZE	(4 * 1024)	/* MAX REC */
+#define MAX_REC_SIZE	(8 * 1024)	/* MAX REC */
 #define MAX_KEY_SIZE	32
 #define MAX_KEY_CNT	10
 
@@ -46,6 +46,9 @@ enum {
 	RP_2G2,
 	RP_3G1,
 	RP_3G2,
+	EC_4P1G1,
+	EC_4P2G2,
+	EC_4P2GX,
 	OBJ_CNT
 };
 
@@ -79,6 +82,12 @@ oclass_get(unsigned int random)
 		return OC_RP_3G1;
 	case RP_3G2:
 		return OC_RP_3G2;
+	case EC_4P1G1:
+		return OC_EC_4P1G1;
+	case EC_4P2G2:
+		return OC_EC_4P2G1;
+	case EC_4P2GX:
+		return OC_EC_4P2GX;
 	default:
 		assert(0);
 	}
@@ -456,6 +465,7 @@ main(int argc, char **argv)
 	d_rank_t	svc_rank  = 0;	/* pool service rank */
 	unsigned	duration = 60; /* seconds */
 	double		expire = 0;
+	daos_prop_t	*prop;
 	int		idx;
 	struct racer_sub_tests	sub_tests[TEST_SIZE] = { 0 };
 	int		rc;
@@ -541,6 +551,12 @@ main(int argc, char **argv)
 	rc = dts_ctx_init(&ts_ctx);
 	if (rc)
 		D_GOTO(out, rc);
+
+	prop = daos_prop_alloc(1);
+	prop->dpp_entries[0].dpe_type = DAOS_PROP_CO_EC_CELL_SZ;
+	prop->dpp_entries[0].dpe_val = 1024;
+	daos_cont_set_prop(ts_ctx.tsc_coh, prop, NULL);
+	daos_prop_free(prop);
 
 	sub_tests_init(sub_tests, 0xFFFF);
 	expire = dts_time_now() + duration;


### PR DESCRIPTION
1. Add EC object to racer test.
2. Do not allow rx_nr == 0 recx for Array update, which
might cause some trouble for EC object update.

Signed-off-by: Di Wang <di.wang@intel.com>