### PR TITLE
DAOS_3836 test DAOS-7337 pool/evict_test reenable.

### DIFF
--- a/src/tests/ftest/pool/evict_test.py
+++ b/src/tests/ftest/pool/evict_test.py
@@ -5,7 +5,7 @@
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
 import uuid
-from apricot import TestWithServers, skipForTicket
+from apricot import TestWithServers
 from pydaos.raw import DaosApiError, c_uuid_to_str
 from command_utils_base import CommandFailure
 from test_utils_pool import TestPool
@@ -133,7 +133,6 @@ class EvictTests(TestWithServers):
                        "evicting a pool with bad param: %s", test_param)
         return False
 
-    @skipForTicket("DAOS-7377")
     def test_evict(self):
         """
         Test evicting a client from a pool.


### PR DESCRIPTION
DAOS_3836 and DAOS-7337 pool/evict_test reenable.

Test-tag: poolevict
Signed-off-by: Ding Ho <ding-hwa.ho@intel.com>