### PR TITLE
DAOS-7921 control: Add positional pool argument to dmg

### DIFF
--- a/src/control/cmd/dmg/pool_test.go
+++ b/src/control/cmd/dmg/pool_test.go
@@ -608,10 +608,33 @@ func TestPoolCommands(t *testing.T) {
 			nil,
 		},
 		{
+			"Query pool with positional UUID",
+			"pool query 12345678-1234-1234-1234-1234567890ab",
+			strings.Join([]string{
+				printRequest(t, &control.PoolQueryReq{
+					UUID: "12345678-1234-1234-1234-1234567890ab",
+				}),
+			}, " "),
+			nil,
+		},
+		{
+			"Query pool with positional label",
+			"pool query test-label",
+			strings.Join([]string{
+				printRequest(t, &control.PoolResolveIDReq{
+					HumanID: "test-label",
+				}),
+				printRequest(t, &control.PoolQueryReq{
+					UUID: defaultPoolUUID,
+				}),
+			}, " "),
+			nil,
+		},
+		{
 			"Query pool with empty ID",
 			"pool query --pool \"\"",
 			"",
-			fmt.Errorf("pool ID"),
+			fmt.Errorf("invalid label"),
 		},
 		{
 			"Nonexistent subcommand",

--- a/src/control/lib/ui/flags.go
+++ b/src/control/lib/ui/flags.go
@@ -1,0 +1,87 @@
+//
+// (C) Copyright 2021 Intel Corporation.
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+
+package ui
+
+import (
+	"github.com/google/uuid"
+	"github.com/jessevdk/go-flags"
+	"github.com/pkg/errors"
+)
+
+var (
+	_ flags.Unmarshaler = &LabelOrUUIDFlag{}
+)
+
+// LabelOrUUIDFlag is used to hold a pool or container ID supplied
+// via command-line-argument.
+type LabelOrUUIDFlag struct {
+	UUID         uuid.UUID
+	Label        string
+	validLabelfn func(string) bool
+}
+
+// Empty returns true if neither UUID or Label were set.
+func (f LabelOrUUIDFlag) Empty() bool {
+	return !f.HasLabel() && !f.HasUUID()
+}
+
+// HasLabel returns true if Label is a nonempty string.
+func (f LabelOrUUIDFlag) HasLabel() bool {
+	return f.Label != ""
+}
+
+// HasUUID returns true if UUID is a nonzero value.
+func (f LabelOrUUIDFlag) HasUUID() bool {
+	return f.UUID != uuid.Nil
+}
+
+func (f LabelOrUUIDFlag) String() string {
+	switch {
+	case f.HasLabel():
+		return f.Label
+	case f.HasUUID():
+		return f.UUID.String()
+	default:
+		return "<no label or uuid set>"
+	}
+}
+
+func (f LabelOrUUIDFlag) validLabel(l string) bool {
+	if f.validLabelfn == nil {
+		return l != ""
+	}
+
+	return f.validLabelfn(l)
+}
+
+// SetLabelValidator allows a custom label validation function
+// to be supplied. By default, all non-empty strings are valid labels.
+func (f *LabelOrUUIDFlag) SetLabelValidator(fn func(string) bool) {
+	f.validLabelfn = fn
+}
+
+// SetLabel validates the supplied label and sets it if valid.
+func (f *LabelOrUUIDFlag) SetLabel(l string) error {
+	if !f.validLabel(l) {
+		return errors.Errorf("invalid label %q", l)
+	}
+
+	f.Label = l
+	return nil
+}
+
+// UnmarshalFlag implements the go-flags.Unmarshaler
+// interface.
+func (f *LabelOrUUIDFlag) UnmarshalFlag(fv string) error {
+	uuid, err := uuid.Parse(fv)
+	if err == nil {
+		f.UUID = uuid
+		return nil
+	}
+
+	return f.SetLabel(fv)
+}

--- a/src/control/lib/ui/flags_test.go
+++ b/src/control/lib/ui/flags_test.go
@@ -1,0 +1,127 @@
+//
+// (C) Copyright 2021 Intel Corporation.
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+
+package ui_test
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/google/uuid"
+
+	"github.com/daos-stack/daos/src/control/common"
+	"github.com/daos-stack/daos/src/control/lib/ui"
+)
+
+type customID struct {
+	ui.LabelOrUUIDFlag
+	fn func(string) bool
+}
+
+func (f *customID) UnmarshalFlag(fv string) error {
+	f.SetLabelValidator(f.fn)
+	return f.SetLabel(fv)
+}
+
+func TestFlags_LabelOrUUIDFlag_customLabelValidation(t *testing.T) {
+	for name, tc := range map[string]struct {
+		arg    string
+		fn     func(string) bool
+		expErr error
+	}{
+		"everything's ok": {
+			fn: func(_ string) bool { return true },
+		},
+		"no a's allowed": {
+			arg: "a-ok",
+			fn: func(l string) bool {
+				return !strings.Contains(l, "a")
+			},
+			expErr: errors.New("invalid label"),
+		},
+		"default disallows empty": {
+			expErr: errors.New("invalid label"),
+		},
+		"default allows non-empty": {
+			arg: "not empty",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			f := customID{fn: tc.fn}
+			gotErr := f.UnmarshalFlag(tc.arg)
+
+			common.CmpErr(t, tc.expErr, gotErr)
+		})
+	}
+}
+
+func TestFlags_LabelOrUUIDFlag(t *testing.T) {
+	for name, tc := range map[string]struct {
+		arg       string
+		expFlag   *ui.LabelOrUUIDFlag
+		isEmpty   bool
+		hasUUID   bool
+		hasLabel  bool
+		expString string
+		expErr    error
+	}{
+		"valid UUID": {
+			arg: "13167ad2-4479-4b88-9d45-13181c152974",
+			expFlag: &ui.LabelOrUUIDFlag{
+				UUID: uuid.MustParse("13167ad2-4479-4b88-9d45-13181c152974"),
+			},
+			hasUUID:   true,
+			expString: "13167ad2-4479-4b88-9d45-13181c152974",
+		},
+		// This seems kind of dodgy... A malformed UUID will be interpreted as
+		// a label. The problem is that it gets tricky to reliably determine when
+		// something is "UUID-ish" enough to call it a malformed UUID instead of
+		// treating it as a label.
+		"invalid UUID": {
+			arg: "13167ad2-4479-4b88-9d45-13181c15297",
+			expFlag: &ui.LabelOrUUIDFlag{
+				Label: "13167ad2-4479-4b88-9d45-13181c15297",
+			},
+			hasLabel:  true,
+			expString: "13167ad2-4479-4b88-9d45-13181c15297",
+		},
+		"valid label": {
+			arg: "this-is-a-good-label",
+			expFlag: &ui.LabelOrUUIDFlag{
+				Label: "this-is-a-good-label",
+			},
+			hasLabel:  true,
+			expString: "this-is-a-good-label",
+		},
+		"unset": {
+			expErr: errors.New("invalid label"),
+		},
+		// NB: Real label validation will be done via a DAOS API call,
+		// in order to centralize the logic across implementations. By
+		// default, this type just cares that the label is not empty.
+	} {
+		t.Run(name, func(t *testing.T) {
+			f := ui.LabelOrUUIDFlag{}
+			gotErr := f.UnmarshalFlag(tc.arg)
+			common.CmpErr(t, tc.expErr, gotErr)
+			if tc.expErr != nil {
+				return
+			}
+
+			common.AssertEqual(t, tc.isEmpty, f.Empty(), "unexpected Empty()")
+			common.AssertEqual(t, tc.hasUUID, f.HasUUID(), "unexpected HasUUID()")
+			common.AssertEqual(t, tc.hasLabel, f.HasLabel(), "unexpected HasLabel()")
+			common.AssertEqual(t, tc.expString, f.String(), "unexpected String()")
+
+			if diff := cmp.Diff(tc.expFlag, &f, cmpopts.IgnoreUnexported(ui.LabelOrUUIDFlag{})); diff != "" {
+				t.Fatalf("unexpected flag value: (-want, +got)\n%s\n", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
For dmg commands that require a pool id, the --pool flag
is now optional and deprecated in favor of placing the
pool id as the last argument.

e.g.
  $ dmg pool query my-awesome-pool
  $ dmg pool query e3e6fc92-72c8-4c4c-96d0-7e9e4149ab2a