### PR TITLE
DAOS-7813 Build: Fix el8 appstream mirror use

### DIFF
--- a/ci/provisioning/post_provision_config.sh
+++ b/ci/provisioning/post_provision_config.sh
@@ -14,6 +14,7 @@ EOF
 
 DSL_REPO_var="DAOS_STACK_${DISTRO}_LOCAL_REPO"
 DSG_REPO_var="DAOS_STACK_${DISTRO}_GROUP_REPO"
+DSA_REPO_var="DAOS_STACK_${DISTRO}_APPSTREAM_REPO"
 
 clush -B -l root -w "$NODESTRING" -c ci_key* --dest=/tmp/
 
@@ -27,6 +28,7 @@ time clush -B -S -l root -w "$NODESTRING" \
            JENKINS_URL=\"$JENKINS_URL\"
            DAOS_STACK_LOCAL_REPO=\"${!DSL_REPO_var}\"
            DAOS_STACK_GROUP_REPO=\"${!DSG_REPO_var:-}\"
+           DAOS_STACK_EL_8_APPSTREAM_REPO=\"${!DSA_REPO_var:-}\"
            DISTRO=\"$DISTRO\"
            $(cat ci/provisioning/post_provision_config_nodes_"${DISTRO}".sh)
            $(cat ci/provisioning/post_provision_config_nodes.sh)"

--- a/ci/provisioning/post_provision_config_nodes_EL_8.sh
+++ b/ci/provisioning/post_provision_config_nodes_EL_8.sh
@@ -55,7 +55,7 @@ post_provision_config_nodes() {
     # so disable the upstream epel-modular repo
     : "${DAOS_STACK_EL_8_APPSTREAM_REPO:-}"
     if [ -n "${DAOS_STACK_EL_8_APPSTREAM_REPO}" ]; then
-        dnf config-manager --disable epel-modular appstream
+        dnf config-manager --disable epel-modular appstream powertools
     fi
     time dnf repolist
 

--- a/ci/provisioning/post_provision_config_nodes_EL_8.sh
+++ b/ci/provisioning/post_provision_config_nodes_EL_8.sh
@@ -53,6 +53,7 @@ post_provision_config_nodes() {
     # workaround until new snapshot images are produced
     # Assume if APPSTREAM is locally proxied so is epel-modular
     # so disable the upstream epel-modular repo
+    : "${DAOS_STACK_EL_8_APPSTREAM_REPO:-}"
     if [ -n "${DAOS_STACK_EL_8_APPSTREAM_REPO}" ]; then
         dnf config-manager --disable epel-modular appstream
     fi


### PR DESCRIPTION
Fix the test for using the CentOS 8 Appstream Mirror.

Skip-func-stage-centos8: false

Signed-off-by: John E Malmberg <john.e.malmberg@intel.com>