### PR TITLE
DAOS-7930 vos: per-pool based committed DTX table

### DIFF
--- a/src/dtx/dtx_internal.h
+++ b/src/dtx/dtx_internal.h
@@ -62,16 +62,16 @@ CRT_RPC_DECLARE(dtx, DAOS_ISEQ_DTX, DAOS_OSEQ_DTX);
  *	it cannot be too small; otherwise, handing resent RPC
  *	make hit uncertain case and got failure -DER_EP_OLD.
  */
-#define DTX_AGG_THRESHOLD_CNT_LOWER	(1 << 20)
+#define DTX_AGG_THRESHOLD_CNT_LOWER	((1 << 19) * 7)
 
 /* The count threshold for triggerring DTX aggregation. */
-#define DTX_AGG_THRESHOLD_CNT_UPPER	((DTX_AGG_THRESHOLD_CNT_LOWER >> 1) * 3)
+#define DTX_AGG_THRESHOLD_CNT_UPPER	((1 << 19) * 6)
 
 /* The time threshold for triggerring DTX aggregation. If the oldest
  * DTX in the DTX table exceeds such threshold, it will trigger DTX
  * aggregation locally.
  */
-#define DTX_AGG_THRESHOLD_AGE_UPPER	120
+#define DTX_AGG_THRESHOLD_AGE_UPPER	210
 
 /* If DTX aggregation is triggered, then the DTXs with older ages than
  * this threshold will be aggregated.
@@ -79,7 +79,7 @@ CRT_RPC_DECLARE(dtx, DAOS_ISEQ_DTX, DAOS_OSEQ_DTX);
  * XXX: It cannot be too small; otherwise, handing resent RPC
  *	make hit uncertain case and got failure -DER_EP_OLD.
  */
-#define DTX_AGG_THRESHOLD_AGE_LOWER	90
+#define DTX_AGG_THRESHOLD_AGE_LOWER	180
 
 /* The time threshold for triggerring DTX cleanup of stale entries.
  * If the oldest active DTX exceeds such threshold, it will trigger

--- a/src/include/daos_srv/dtx_srv.h
+++ b/src/include/daos_srv/dtx_srv.h
@@ -159,11 +159,11 @@ struct dtx_leader_handle {
 };
 
 struct dtx_stat {
-	uint64_t	dtx_committable_count;
-	uint64_t	dtx_oldest_committable_time;
-	uint64_t	dtx_committed_count;
-	uint64_t	dtx_oldest_committed_time;
-	uint64_t	dtx_oldest_active_time;
+	uint64_t	dtx_committable_count; /* container based. */
+	uint64_t	dtx_oldest_committable_time; /* container based. */
+	uint64_t	dtx_committed_count; /* pool based */
+	uint64_t	dtx_oldest_committed_time; /* container based. */
+	uint64_t	dtx_oldest_active_time; /* container based. */
 };
 
 enum dtx_flags {


### PR DESCRIPTION
Currently, the committed DTX table in DRAM in per-container based.
For each committed DTX table, the threshold of DTX aggregation is
about 1^20 entries. If there are multiple (assume 'N') containers
maintained by the same engine, then there maybe at most 1^ 20 * N
committed DTX entries. If "N" is too large, then may cause server
out of memory.

This patch changes the per-container based committed DTX table as
per-pool based. Then the total committed DTX entries in DRAM will
be much reduced for multiple containers case.

The DTX aggregation thresholds are also adjusted:

1. Count threshold: 1^20 => 1^20 * 3
2. Time threshold: 90 sec => 180 sec

Signed-off-by: Fan Yong <fan.yong@intel.com>