### PR TITLE
Feature Branch PR for testing (do not land)

### DIFF
--- a/doc/overview/data_integrity.md
+++ b/doc/overview/data_integrity.md
@@ -385,7 +385,7 @@ obj_iter_scrub(coh, epr, csummer, pool_uuid, event_handlers, entry, type)
   includes a CORRUPTED bit.
 - The vos update api already accepts a flag, so a CORRUPTED flag is added and
   handled during an update so that, if set, the bio address will be updated to
-  be corrupted.
+  be corrupted. (Documented in src/vos/README.md)
 - On fetch, if a value is already marked corrupted, return -DER_CSUM
 
 ### Object Layer

--- a/src/common/tests_lib.c
+++ b/src/common/tests_lib.c
@@ -205,6 +205,7 @@ v_dts_sgl_init_with_strings_repeat(d_sg_list_t *sgl, uint32_t repeat,
 
 		arg = va_arg(valist, char *);
 	}
+	sgl->sg_nr_out = count;
 }
 
 void
@@ -226,4 +227,13 @@ dts_sgl_init_with_strings_repeat(d_sg_list_t *sgl, uint32_t repeat,
 	va_start(valist, d);
 	v_dts_sgl_init_with_strings_repeat(sgl, repeat, count, d, valist);
 	va_end(valist);
+}
+
+void
+dts_sgl_alloc_single_iov(d_sg_list_t *sgl, daos_size_t size)
+{
+	d_sgl_init(sgl, 1);
+	D_ALLOC(sgl->sg_iovs[0].iov_buf, size);
+	D_ASSERT(sgl->sg_iovs[0].iov_buf != NULL);
+	sgl->sg_iovs[0].iov_buf_len = size;
 }

--- a/src/include/daos/tests_lib.h
+++ b/src/include/daos/tests_lib.h
@@ -131,6 +131,9 @@ void
 dts_sgl_init_with_strings_repeat(d_sg_list_t *sgl, uint32_t repeat,
 				 uint32_t count, char *d, ...);
 
+void
+dts_sgl_alloc_single_iov(d_sg_list_t *sgl, daos_size_t size);
+
 #define DTS_CFG_MAX 256
 __attribute__ ((__format__(__printf__, 2, 3)))
 static inline void

--- a/src/include/daos_srv/bio.h
+++ b/src/include/daos_srv/bio.h
@@ -17,16 +17,18 @@
 #include <daos_srv/control.h>
 #include <abt.h>
 
-#define BIO_ADDR_IS_HOLE(addr) ((addr)->ba_flags == BIO_FLAG_HOLE)
+#define BIO_ADDR_IS_HOLE(addr) ((addr)->ba_flags & BIO_FLAG_HOLE)
 #define BIO_ADDR_SET_HOLE(addr) ((addr)->ba_flags |= BIO_FLAG_HOLE)
-#define BIO_ADDR_SET_NOT_HOLE(addr) ((addr)->ba_flags &= ~(BIO_FLAG_HOLE))
-#define BIO_ADDR_IS_DEDUP(addr) ((addr)->ba_flags == BIO_FLAG_DEDUP)
+#define BIO_ADDR_CLEAR_HOLE(addr) ((addr)->ba_flags &= ~(BIO_FLAG_HOLE))
+#define BIO_ADDR_IS_DEDUP(addr) ((addr)->ba_flags & BIO_FLAG_DEDUP)
 #define BIO_ADDR_SET_DEDUP(addr) ((addr)->ba_flags |= BIO_FLAG_DEDUP)
-#define BIO_ADDR_SET_NOT_DEDUP(addr) ((addr)->ba_flags &= ~(BIO_FLAG_DEDUP))
+#define BIO_ADDR_CLEAR_DEDUP(addr) ((addr)->ba_flags &= ~(BIO_FLAG_DEDUP))
 #define BIO_ADDR_IS_DEDUP_BUF(addr) ((addr)->ba_flags == BIO_FLAG_DEDUP_BUF)
 #define BIO_ADDR_SET_DEDUP_BUF(addr) ((addr)->ba_flags |= BIO_FLAG_DEDUP_BUF)
 #define BIO_ADDR_SET_NOT_DEDUP_BUF(addr)	\
 			((addr)->ba_flags &= ~(BIO_FLAG_DEDUP_BUF))
+#define BIO_ADDR_IS_CORRUPTED(addr) ((addr)->ba_flags & BIO_FLAG_CORRUPTED)
+#define BIO_ADDR_SET_CORRUPTED(addr) ((addr)->ba_flags |= BIO_FLAG_CORRUPTED)
 
 /* Can support up to 16 flags for a BIO address */
 enum BIO_FLAG {
@@ -36,6 +38,7 @@ enum BIO_FLAG {
 	BIO_FLAG_DEDUP = (1 << 1),
 	/* The address is a buffer for dedup verify */
 	BIO_FLAG_DEDUP_BUF = (1 << 2),
+	BIO_FLAG_CORRUPTED = (1 << 3),
 };
 
 typedef struct {
@@ -132,7 +135,7 @@ static inline void
 bio_addr_set_hole(bio_addr_t *addr, uint16_t hole)
 {
 	if (hole == 0)
-		BIO_ADDR_SET_NOT_HOLE(addr);
+		BIO_ADDR_CLEAR_HOLE(addr);
 	else
 		BIO_ADDR_SET_HOLE(addr);
 }

--- a/src/include/daos_srv/evtree.h
+++ b/src/include/daos_srv/evtree.h
@@ -691,6 +691,13 @@ int evt_iter_empty(daos_handle_t ih);
 int evt_iter_delete(daos_handle_t ih, struct evt_entry *ent);
 
 /**
+ * Mark the record at the current cursor as being corrupt.
+ *
+ * \param ih		[IN]	Iterator open handle.
+ */
+int evt_iter_corrupt(daos_handle_t ih);
+
+/**
  * Fetch the extent and its data address from the current iterator position.
  *
  * \param ih	[IN]	Iterator open handle.

--- a/src/include/daos_srv/vos.h
+++ b/src/include/daos_srv/vos.h
@@ -900,9 +900,10 @@ vos_iter_copy(daos_handle_t ih, vos_iter_entry_t *entry,
 	      d_iov_t *iov_out);
 
 /**
- * Delete the current data entry of the iterator
+ * Process the operation for the current cursor.
  *
- * \param ih	[IN]	Iterator handle
+ * \param ih	[IN]	Iterator open handle.
+ * \param op	[IN]	op code to process. See vos_iter_proc_op
  * \param args	[IN/OUT]
  *			Optional, Provide additional hints while
  *			deletion to handle special cases.
@@ -912,10 +913,9 @@ vos_iter_copy(daos_handle_t ih, vos_iter_entry_t *entry,
  * \return		Zero on Success
  *			-DER_NONEXIST if cursor does
  *			not exist. negative value if error
- *
  */
 int
-vos_iter_delete(daos_handle_t ih, void *args);
+vos_iter_process(daos_handle_t ih, vos_iter_proc_op op, void *args);
 
 /**
  * If the iterator has any element. The condition provided to vos_iter_prepare

--- a/src/include/daos_srv/vos_types.h
+++ b/src/include/daos_srv/vos_types.h
@@ -210,6 +210,12 @@ typedef enum {
 	VOS_IT_EPC_EQ,
 } vos_it_epc_expr_t;
 
+typedef enum {
+	VOS_ITER_PROC_OP_UNKNOWN = 0,
+	VOS_ITER_PROC_OP_DELETE = 1,
+	VOS_ITER_PROC_OP_MARK_CORRUPT = 2,
+} vos_iter_proc_op;
+
 enum {
 	/** Conditional Op: Punch key if it exists, fail otherwise */
 	VOS_OF_COND_PUNCH		= DAOS_COND_PUNCH,

--- a/src/vos/README.md
+++ b/src/vos/README.md
@@ -696,45 +696,70 @@ A special aggregation ULT processes aggregation, frequently yielding to avoid bl
 
 ## VOS Checksum Management
 
-VOS is responsible for storing checksums during an object update and retrieve checksums on an object fetch.
-Checksums will be stored with other VOS metadata in storage class memory.  For Single Value types, a single checksum is stored.
+VOS is responsible for storing checksums during an object update and retrieve
+checksums on an object fetch. Checksums will be stored with other VOS metadata
+in storage class memory. For Single Value types, a single checksum is stored.
 For Array Value types, multiple checksums can be stored based on the chunk size.
 
-The **Chunk Size** is defined as the maximum number of bytes of data that a checksum is derived from.
-While extents are defined in terms of records, the chunk size is defined in terms of bytes.
-When calculating the number of checksums needed for an extent, the number of records and the record size is needed.
-Checksums should typically be derived from Chunk Size bytes, however,
-if the extent is smaller than Chunk Size or an extent is not "Chunk Aligned," then a checksum might be derived from bytes smaller than Chunk Size.
+The **Chunk Size** is defined as the maximum number of bytes of data that a
+checksum is derived from. While extents are defined in terms of records, the
+chunk size is defined in terms of bytes. When calculating the number of
+checksums needed for an extent, the number of records and the record size is
+needed. Checksums should typically be derived from Chunk Size bytes, however, if
+the extent is smaller than Chunk Size or an extent is not "Chunk Aligned," then
+a checksum might be derived from bytes smaller than Chunk Size.
 
-The **Chunk Alignment** will have an absolute offset, not an I/O offset. So even if an extent is exactly, or less than, Chunk Size bytes long, it may have more than one Chunk if it crosses the alignment barrier.
+The **Chunk Alignment** will have an absolute offset, not an I/O offset. So even
+if an extent is exactly, or less than, Chunk Size bytes long, it may have more
+than one Chunk if it crosses the alignment barrier.
 
 ### Configuration
-Checksums will be configured for a container when a container is created. Checksum specific properties can be included in the daos_cont_create API.
-This configuration has not been fully implemented yet, but properties might include checksum type, chunk size, and server side verification.
+Checksums will be configured for a container when a container is created.
+Checksum specific properties can be included in the daos_cont_create API. This
+configuration has not been fully implemented yet, but properties might include
+checksum type, chunk size, and server side verification.
 
 ### Storage
-Checksums will be stored in a record(vos_irec_df) or extent(evt_desc) structure for Single Value types and Array Value types respectfully.
-Because the checksum can be of variable size, depending on the type of checksum configured, the checksum itself will be appended to the end of the structure.
-The size needed for checksums is included while allocating memory for the persistent structures on SCM (vos_reserve_single/vos_reserve_recx).
+Checksums will be stored in a record(vos_irec_df) or extent(evt_desc) structure
+for Single Value types and Array Value types respectfully. Because the checksum
+can be of variable size, depending on the type of checksum configured, the
+checksum itself will be appended to the end of the structure. The size needed
+for checksums is included while allocating memory for the persistent structures
+on SCM (vos_reserve_single/vos_reserve_recx).
 
-The following diagram illustrates the overall VOS layout and where checksums will be stored. Note that the checksum type isn't actually stored in vos_cont_df yet.
+The following diagram illustrates the overall VOS layout and where checksums
+will be stored. Note that the checksum type isn't actually stored in vos_cont_df
+yet.
 
 ![../../doc/graph/Fig_021.png](../../doc/graph/Fig_021.png "How checksum fits into the VOS Layout")
 
 
 ### Checksum VOS Flow (vos_obj_update/vos_obj_fetch)
 
-On update, the checksum(s) are part of the I/O Descriptor.
-Then, in akey_update_single/akey_update_recx, the checksum buffer pointer is included in the internal structures used for tree updates (vos_rec_bundle for SV and evt_entry_in for EV). As already mentioned, the size of the persistent structure allocated includes the size of the checksum(s). Finally, while storing the record (svt_rec_store) or extent (evt_insert), the checksum(s) are copied to the end of the persistent structure.
+On update, the checksum(s) are part of the I/O Descriptor. Then, in
+akey_update_single/akey_update_recx, the checksum buffer pointer is included in
+the internal structures used for tree updates (vos_rec_bundle for SV and
+evt_entry_in for EV). As already mentioned, the size of the persistent structure
+allocated includes the size of the checksum(s). Finally, while storing the
+record (svt_rec_store) or extent (evt_insert), the checksum(s) are copied to the
+end of the persistent structure.
 
 On a fetch, the update flow is essentially reversed.
 
 For reference, key junction points in the flows are:
-
  - SV Update: 	vos_update_end 	-> akey_update_single 	-> svt_rec_store
  - Sv Fetch: 	vos_fetch_begin -> akey_fetch_single 	-> svt_rec_load
  - EV Update: 	vos_update_end 	-> akey_update_recx 	-> evt_insert
  - EV Fetch: 	vos_fetch_begin -> akey_fetch_recx 	-> evt_fill_entry
+
+### Marking data as corrupted
+When data is discovered as being corrupted, the bio_addr will be marked with a
+corrupted flag to prevent subsequent verifications on data that is already known
+to be corrupted. Because the checksum scrubber will be iterating the vos
+objects, the vos_iter API is used to mark objects as corrupt. The
+vos_iter_process() will take the iter handle that the corruptions was discovered
+on and will call into the btree/evtree to update the durable format structure
+that contains the bio_addr.
 
 <a id="80"></a>
 

--- a/src/vos/evt_iter.c
+++ b/src/vos/evt_iter.c
@@ -566,6 +566,47 @@ out:
 
 D_CASSERT(sizeof(((daos_anchor_t *)0)->da_buf) >= sizeof(struct evt_rect));
 
+int
+evt_iter_corrupt(daos_handle_t ih)
+{
+	struct evt_iterator	*iter;
+	struct evt_context	*tcx;
+	struct evt_trace	*trace;
+	struct evt_desc		*desc;
+	int			 rc;
+
+	tcx = evt_hdl2tcx(ih);
+	if (tcx == NULL)
+		return -DER_NO_HDL;
+
+	iter = &tcx->tc_iter;
+	rc = evt_iter_is_ready(iter);
+	if (rc != 0)
+		return rc;
+
+	trace = &tcx->tc_trace[tcx->tc_depth - 1];
+	desc = evt_node_desc_at(tcx, evt_off2node(tcx, trace->tr_node),
+				trace->tr_at);
+	rc = evt_tx_begin(tcx);
+	if (rc != DER_SUCCESS)
+		return rc;
+
+	rc = umem_tx_add(&tcx->tc_umm,
+			 trace->tr_node + offsetof(struct evt_desc, dc_ex_addr),
+			 sizeof(*desc) - offsetof(struct evt_desc, dc_ex_addr));
+	if (rc != 0) {
+		D_ERROR("umem_tx_add failed: "DF_RC"\n", DP_RC(rc));
+		rc = evt_tx_end(tcx, rc);
+		return rc;
+	}
+
+	D_DEBUG(DB_IO, "Setting record bio_addr flag to corrupted\n");
+	BIO_ADDR_SET_CORRUPTED(&desc->dc_ex_addr);
+	rc = evt_tx_end(tcx, rc);
+
+	return rc;
+}
+
 /**
  * Fetch the extent and its data address from the current iterator position.
  * See daos_srv/evtree.h for the details.
@@ -602,9 +643,8 @@ evt_iter_fetch(daos_handle_t ih, unsigned int *inob, struct evt_entry *entry,
 	node = evt_off2node(tcx, trace->tr_node);
 	evt_node_rect_read_at(tcx, node, trace->tr_at, &rect);
 
-	if (entry)
-		evt_entry_fill(tcx, node, trace->tr_at, NULL,
-			       evt_iter_intent(iter), entry);
+	evt_entry_fill(tcx, node, trace->tr_at, NULL,
+		       evt_iter_intent(iter), entry);
 
 	/* There is no visibility flag for unsorted entries but go ahead and
 	 * set it EVT_COVERED if user has specified a punch epoch in the filter

--- a/src/vos/tests/evt_ctl.c
+++ b/src/vos/tests/evt_ctl.c
@@ -298,7 +298,7 @@ bio_alloc_init(struct utest_context *utx, bio_addr_t *addr, const void *src,
 		BIO_ADDR_SET_HOLE(addr);
 		return 0;
 	} else {
-		BIO_ADDR_SET_NOT_HOLE(addr);
+		BIO_ADDR_CLEAR_HOLE(addr);
 	}
 	rc = utest_alloc(utx, &umoff, size, init_mem, src);
 

--- a/src/vos/tests/vts_checksum.c
+++ b/src/vos/tests/vts_checksum.c
@@ -26,7 +26,7 @@ struct extent_key {
  */
 void
 extent_key_from_test_args(struct extent_key *k,
-			       struct io_test_args *args)
+			  struct io_test_args *args)
 {
 	/* Set up dkey and akey */
 	dts_key_gen(&k->dkey_buf[0], args->dkey_size, args->dkey);
@@ -405,6 +405,127 @@ update_fetch_csum_for_array_10(void **state)
 	});
 }
 
+static int
+corrupt_cb(daos_handle_t ih, vos_iter_entry_t *entry,
+	   vos_iter_type_t type, vos_iter_param_t *param,
+	   void *cb_arg, unsigned int *acts)
+{
+	if (type == VOS_ITER_SINGLE || type == VOS_ITER_RECX)
+		assert_success(
+			vos_iter_process(ih, VOS_ITER_PROC_OP_MARK_CORRUPT,
+					 NULL));
+
+	return 0;
+}
+
+static int
+verify_corrupted_cb(daos_handle_t ih, vos_iter_entry_t *entry,
+		    vos_iter_type_t type, vos_iter_param_t *param,
+		    void *cb_arg, unsigned int *acts)
+{
+	if (type == VOS_ITER_SINGLE || type == VOS_ITER_RECX)
+		assert_true(BIO_ADDR_IS_CORRUPTED(&entry->ie_biov.bi_addr));
+
+	return 0;
+}
+
+static void
+setup_iod_data(daos_iod_t *iod, d_sg_list_t *sgl, daos_iod_type_t type)
+{
+	iod->iod_type = type;
+	if (iod->iod_type == DAOS_IOD_ARRAY) {
+		iod->iod_nr = 1;
+		iod->iod_size = 2;
+		D_ALLOC_PTR(iod->iod_recxs);
+		iod->iod_recxs[0].rx_idx = 0;
+		iod->iod_recxs[0].rx_nr = daos_sgl_buf_size(sgl) / 2;
+
+	} else {
+		iod->iod_size = daos_sgl_buf_size(sgl);
+		iod->iod_nr = 1;
+	}
+}
+
+static void
+test_marking_corrupted_with_iod_type(void **state, daos_iod_type_t iod_type)
+{
+	struct extent_key	k = {0};
+	daos_iod_t		iod = {0};
+	d_sg_list_t		sgl = {0};
+	d_sg_list_t		sgl_fetch = {0};
+	int			rc = 0;
+	daos_epoch_t		epoch = 1;
+	uint32_t		i;
+	const uint32_t		akey_len = 32;
+	char			akey[akey_len];
+	vos_iter_param_t	param = {0};
+	struct vos_iter_anchors	anchor = {0};
+
+	/** setup */
+	memset(akey, 0, akey_len);
+	extent_key_from_test_args(&k, *state);
+	dts_sgl_init_with_strings(&sgl, 1, "Going to be corrupted!!");
+	dts_sgl_alloc_single_iov(&sgl_fetch, daos_sgl_buf_size(&sgl));
+
+	d_iov_set(&iod.iod_name, akey, akey_len);
+	setup_iod_data(&iod, &sgl, iod_type);
+
+	for (i = 0; i < 100; i++) {
+		snprintf(akey, 32, "akey-%d", i);
+		assert_success(
+			vos_obj_update(k.container_hdl, k.object_id,
+				       epoch, 0, 0, &k.dkey, 1, &iod,
+				       NULL, &sgl));
+	}
+
+	/* Iterate and mark corrupted each recx/sv */
+
+	param.ip_hdl = k.container_hdl;
+	param.ip_epr.epr_lo = 0;
+	param.ip_epr.epr_hi = DAOS_EPOCH_MAX;
+	param.ip_flags = VOS_IT_RECX_ALL;
+
+	rc = vos_iterate(&param, VOS_ITER_OBJ, true, &anchor,
+			 corrupt_cb, NULL, NULL, NULL);
+	assert_success(rc);
+
+
+	/* Verify that each SV/RECX entry is marked as corrupted, but
+	 * vos_iterate shouldn't fail
+	 */
+	rc = vos_iterate(&param, VOS_ITER_OBJ, true, &anchor,
+			 verify_corrupted_cb, NULL, NULL, NULL);
+	assert_success(rc);
+
+	/*
+	 * With the bio_addr marked as corrupted, obj_fetch should return a
+	 * csum error
+	 */
+	for (i = 0; i < 100; i++) {
+		snprintf(akey, 32, "akey-%d", i);
+		rc = vos_obj_fetch(k.container_hdl, k.object_id, 1, 0,
+				   &k.dkey, 1, &iod, &sgl_fetch);
+		assert_rc_equal(-DER_CSUM, rc);
+	}
+
+	/** clean up */
+	D_FREE(iod.iod_recxs);
+	d_sgl_fini(&sgl, true);
+	d_sgl_fini(&sgl_fetch, true);
+}
+
+static void
+mark_sv_corrupted(void **state)
+{
+	test_marking_corrupted_with_iod_type(state, DAOS_IOD_SINGLE);
+}
+
+static void
+mark_extent_corrupted(void **state)
+{
+	test_marking_corrupted_with_iod_type(state, DAOS_IOD_ARRAY);
+}
+
 /**
  * -------------------------------------
  * Helper function tests
@@ -723,18 +844,18 @@ test_evt_entry_csum_update(void **state)
 			 actual.cs_csum);
 }
 
-int setup(void **state)
+int vts_csum_setup(void **state)
 {
 	return 0;
 }
 
-int teardown(void **state)
+int vts_csum_teardown(void **state)
 {
 	return 0;
 }
 
 #define	VOS(desc, test_fn) \
-	{ "VOS_CSUM" desc, test_fn, setup, teardown}
+	{ "VOS_CSUM" desc, test_fn, vts_csum_setup, vts_csum_teardown}
 
 static const struct CMUnitTest update_fetch_checksums_for_array_types[] = {
 	VOS("01: Single chunk", update_fetch_csum_for_array_1),
@@ -747,10 +868,12 @@ static const struct CMUnitTest update_fetch_checksums_for_array_types[] = {
 	VOS("08: Partial -> more partial", update_fetch_csum_for_array_8),
 	VOS("09: Many sequential extents", update_fetch_csum_for_array_9),
 	VOS("10: Holes", update_fetch_csum_for_array_10),
+	VOS("11: Mark corrupted: Single Value", mark_sv_corrupted),
+	VOS("12: Mark corrupted: Array Value", mark_extent_corrupted),
 };
 
 #define	EVT(desc, test_fn) \
-	{ "EVT_CSUM" desc, test_fn, setup, teardown}
+	{ "EVT_CSUM" desc, test_fn, vts_csum_setup, vts_csum_teardown}
 static const struct CMUnitTest evt_checksums_tests[] = {
 	EVT("01: Some EVT Checksum Helper Functions",
 		evt_csum_helper_functions_tests),

--- a/src/vos/vos_aggregate.c
+++ b/src/vos/vos_aggregate.c
@@ -177,7 +177,7 @@ agg_del_entry(daos_handle_t ih, struct umem_instance *umm,
 
 	mark_yield(&entry->ie_biov.bi_addr, acts);
 
-	rc = vos_iter_delete(ih, NULL);
+	rc = vos_iter_process(ih, VOS_ITER_PROC_OP_DELETE, NULL);
 	if (rc != 0)
 		rc = umem_tx_abort(umm, rc);
 	else
@@ -784,7 +784,7 @@ csum_append_added_segs(struct bio_sglist *bsgl, unsigned int added_segs)
 			bsgl->bs_iovs[add_idx].bi_prefix_len = 0;
 			bsgl->bs_iovs[add_idx].bi_suffix_len = 0;
 			bsgl->bs_iovs[add_idx].bi_buf = NULL;
-			BIO_ADDR_SET_NOT_HOLE(
+			BIO_ADDR_CLEAR_HOLE(
 				&bsgl->bs_iovs[add_idx++].bi_addr);
 		}
 		if (bsgl->bs_iovs[i].bi_suffix_len) {
@@ -801,7 +801,7 @@ csum_append_added_segs(struct bio_sglist *bsgl, unsigned int added_segs)
 			bsgl->bs_iovs[add_idx].bi_prefix_len = 0;
 			bsgl->bs_iovs[add_idx].bi_suffix_len = 0;
 			bsgl->bs_iovs[add_idx].bi_buf = NULL;
-			BIO_ADDR_SET_NOT_HOLE(
+			BIO_ADDR_CLEAR_HOLE(
 				&bsgl->bs_iovs[add_idx++].bi_addr);
 		}
 

--- a/src/vos/vos_container.c
+++ b/src/vos/vos_container.c
@@ -767,7 +767,7 @@ cont_iter_probe(struct vos_iterator *iter, daos_anchor_t *anchor)
 }
 
 static int
-cont_iter_delete(struct vos_iterator *iter, void *args)
+cont_iter_process(struct vos_iterator *iter, vos_iter_proc_op op, void *args)
 {
 	D_ASSERT(iter->it_type == VOS_ITER_COUUID);
 
@@ -780,5 +780,5 @@ struct vos_iter_ops vos_cont_iter_ops = {
 	.iop_probe   = cont_iter_probe,
 	.iop_next    = cont_iter_next,
 	.iop_fetch   = cont_iter_fetch,
-	.iop_delete  = cont_iter_delete,
+	.iop_process  = cont_iter_process,
 };

--- a/src/vos/vos_dtx_iter.c
+++ b/src/vos/vos_dtx_iter.c
@@ -10,6 +10,7 @@
  */
 #define D_LOGFAC	DD_FAC(vos)
 
+#include <daos_srv/vos.h>
 #include "vos_layout.h"
 #include "vos_internal.h"
 
@@ -227,9 +228,11 @@ dtx_iter_fetch(struct vos_iterator *iter, vos_iter_entry_t *it_entry,
 }
 
 static int
-dtx_iter_delete(struct vos_iterator *iter, void *args)
+dtx_iter_process(struct vos_iterator *iter, vos_iter_proc_op op, void *args)
 {
 	D_ASSERT(iter->it_type == VOS_ITER_DTX);
+	if (op != VOS_ITER_PROC_OP_DELETE)
+		return -DER_NOSYS;
 
 	D_WARN("NOT allow to remove DTX entry via iteration!\n");
 
@@ -242,5 +245,5 @@ struct vos_iter_ops vos_dtx_iter_ops = {
 	.iop_probe   =	dtx_iter_probe,
 	.iop_next    =  dtx_iter_next,
 	.iop_fetch   =  dtx_iter_fetch,
-	.iop_delete  =	dtx_iter_delete,
+	.iop_process  =	dtx_iter_process,
 };

--- a/src/vos/vos_internal.h
+++ b/src/vos/vos_internal.h
@@ -884,8 +884,8 @@ struct vos_iter_ops {
 	int	(*iop_copy)(struct vos_iterator *iter,
 			    vos_iter_entry_t *it_entry, d_iov_t *iov_out);
 	/** Delete the record that the cursor points to */
-	int	(*iop_delete)(struct vos_iterator *iter,
-			      void *args);
+	int	(*iop_process)(struct vos_iterator *iter, vos_iter_proc_op op,
+			       void *args);
 	/**
 	 * Optional, the iterator has no element.
 	 *

--- a/src/vos/vos_io.c
+++ b/src/vos/vos_io.c
@@ -27,7 +27,7 @@ struct vos_io_context {
 	daos_unit_oid_t		 ic_oid;
 	struct vos_container	*ic_cont;
 	daos_iod_t		*ic_iods;
-	struct dcs_iod_csums	*iod_csums;
+	struct dcs_iod_csums	*ic_iod_csums;
 	/** reference on the object */
 	struct vos_object	*ic_obj;
 	/** BIO descriptor, has ic_iod_nr SGLs */
@@ -342,8 +342,9 @@ static struct dcs_csum_info *
 vos_ioc2csum(struct vos_io_context *ioc)
 {
 	/** is enabled and has csums (might not for punch) */
-	if (ioc->iod_csums != NULL && ioc->iod_csums[ioc->ic_sgl_at].ic_nr > 0)
-		return ioc->iod_csums[ioc->ic_sgl_at].ic_data;
+	if (ioc->ic_iod_csums != NULL &&
+	    ioc->ic_iod_csums[ioc->ic_sgl_at].ic_nr > 0)
+		return ioc->ic_iod_csums[ioc->ic_sgl_at].ic_data;
 	return NULL;
 }
 
@@ -487,7 +488,7 @@ vos_ioc_create(daos_handle_t coh, daos_unit_oid_t oid, bool read_only,
 	ioc->ic_remove =
 		((vos_flags & VOS_OF_REMOVE) != 0);
 	ioc->ic_umoffs_cnt = ioc->ic_umoffs_at = 0;
-	ioc->iod_csums = iod_csums;
+	ioc->ic_iod_csums = iod_csums;
 	vos_ilog_fetch_init(&ioc->ic_dkey_info);
 	vos_ilog_fetch_init(&ioc->ic_akey_info);
 	D_INIT_LIST_HEAD(&ioc->ic_blk_exts);
@@ -709,6 +710,11 @@ akey_fetch_single(daos_handle_t toh, const daos_epoch_range_t *epr,
 	if (ci_is_valid(&csum_info))
 		save_csum(ioc, &csum_info, NULL, 0);
 
+	if (BIO_ADDR_IS_CORRUPTED(&rbund.rb_biov->bi_addr)) {
+		D_DEBUG(DB_CSUM, "Found corrupted record\n");
+		return -DER_CSUM;
+	}
+
 	rc = iod_fetch(ioc, &biov);
 	if (rc != 0)
 		goto out;
@@ -820,6 +826,13 @@ akey_fetch_recx(daos_handle_t toh, const daos_epoch_range_t *epr,
 		D_ASSERT(hi >= lo);
 		nr = hi - lo + 1;
 
+		if (BIO_ADDR_IS_CORRUPTED(&ent->en_addr)) {
+			D_DEBUG(DB_CSUM, "Found corrupted entity: "DF_ENT"\n",
+				DP_ENT(ent));
+			rc = -DER_CSUM;
+			goto failed;
+		}
+
 		if (lo != index) {
 			D_ASSERTF(lo > index,
 				  DF_U64"/"DF_U64", "DF_EXT", "DF_ENT"\n",
@@ -867,7 +880,7 @@ akey_fetch_recx(daos_handle_t toh, const daos_epoch_range_t *epr,
 		if (ci_is_valid(&ent->en_csum)) {
 			rc = save_csum(ioc, &ent->en_csum, ent, rsize);
 			if (rc != 0)
-				return rc;
+				goto failed;
 			biov_align_lens(&biov, ent, rsize);
 			csum_enabled = true;
 		} else {
@@ -1406,6 +1419,7 @@ akey_update_single(daos_handle_t toh, uint32_t pm_ver, daos_size_t rsize,
 	struct dcs_csum_info	 csum;
 	d_iov_t			 kiov, riov;
 	struct bio_iov		*biov;
+	struct dcs_csum_info	*value_csum;
 	umem_off_t		 umoff;
 	daos_epoch_t		 epoch = ioc->ic_epr.epr_hi;
 	int			 rc;
@@ -1423,18 +1437,18 @@ akey_update_single(daos_handle_t toh, uint32_t pm_ver, daos_size_t rsize,
 
 	tree_rec_bundle2iov(&rbund, &riov);
 
-	struct dcs_csum_info *value_csum = vos_ioc2csum(ioc);
+	value_csum = vos_ioc2csum(ioc);
 
 	if (value_csum != NULL)
 		rbund.rb_csum	= value_csum;
 	else
 		rbund.rb_csum	= &csum;
 
-	rbund.rb_biov	= biov;
-	rbund.rb_rsize	= rsize;
-	rbund.rb_gsize	= gsize;
-	rbund.rb_off	= umoff;
-	rbund.rb_ver	= pm_ver;
+	rbund.rb_biov		= biov;
+	rbund.rb_rsize		= rsize;
+	rbund.rb_gsize		= gsize;
+	rbund.rb_off		= umoff;
+	rbund.rb_ver		= pm_ver;
 
 	rc = dbtree_update(toh, &kiov, &riov);
 	if (rc != 0)
@@ -1473,7 +1487,7 @@ akey_update_recx(daos_handle_t toh, uint32_t pm_ver, daos_recx_t *recx,
 	biov = iod_update_biov(ioc);
 	ent.ei_addr = biov->bi_addr;
 	/* Don't make this flag persistent */
-	BIO_ADDR_SET_NOT_DEDUP(&ent.ei_addr);
+	BIO_ADDR_CLEAR_DEDUP(&ent.ei_addr);
 
 	if (ioc->ic_remove)
 		return evt_remove_all(toh, &ent.ei_rect.rc_ex, &ioc->ic_epr);
@@ -2278,7 +2292,7 @@ vos_set_io_csum(daos_handle_t ioh, struct dcs_iod_csums *csums)
 
 	D_ASSERT(ioc != NULL);
 
-	ioc->iod_csums = csums;
+	ioc->ic_iod_csums = csums;
 }
 
 /*
@@ -2345,7 +2359,7 @@ vos_dedup_dup_bsgl(daos_handle_t ioh, struct bio_sglist *bsgl,
 			return -DER_NOMEM;
 		}
 
-		BIO_ADDR_SET_NOT_DEDUP(&biov_dup->bi_addr);
+		BIO_ADDR_CLEAR_DEDUP(&biov_dup->bi_addr);
 		BIO_ADDR_SET_DEDUP_BUF(&biov_dup->bi_addr);
 		biov_dup->bi_addr.ba_off = UMOFF_NULL;
 	}
@@ -2450,7 +2464,7 @@ vos_dedup_verify(daos_handle_t ioh, struct bio_sglist *bsgls_dup)
 							   oid);
 			biov->bi_buf = umem_off2ptr(vos_ioc2umm(ioc),
 						bio_iov2off(biov));
-			BIO_ADDR_SET_NOT_DEDUP(&biov->bi_addr);
+			BIO_ADDR_CLEAR_DEDUP(&biov->bi_addr);
 
 			pmemobj_memcpy_persist(vos_ioc2umm(ioc)->umm_pool,
 					       biov->bi_buf, biov_dup->bi_buf,

--- a/src/vos/vos_iterator.c
+++ b/src/vos/vos_iterator.c
@@ -427,20 +427,19 @@ vos_iter_copy(daos_handle_t ih, vos_iter_entry_t *it_entry,
 }
 
 int
-vos_iter_delete(daos_handle_t ih, void *args)
+vos_iter_process(daos_handle_t ih, vos_iter_proc_op op, void *args)
 {
-	struct vos_iterator *iter = vos_hdl2iter(ih);
-	int rc;
+	struct vos_iterator	*iter = vos_hdl2iter(ih);
+	int			 rc = 0;
+
+	if (iter->it_ops->iop_process == NULL)
+		return -DER_NOSYS;
 
 	rc = iter_verify_state(iter);
 	if (rc)
 		return rc;
 
-	D_ASSERT(iter->it_ops != NULL);
-	if (iter->it_ops->iop_delete == NULL)
-		return -DER_NOSYS;
-
-	return iter->it_ops->iop_delete(iter, args);
+	return iter->it_ops->iop_process(iter, op, args);
 }
 
 int

--- a/src/vos/vos_obj.c
+++ b/src/vos/vos_obj.c
@@ -1804,6 +1804,60 @@ exit:
 	return rc;
 }
 
+/*
+ * For a single value btree, grab the value of the current iter cursor, and use
+ * the offset to get the durable format (pmem) structure with the bio_addr. Then
+ * set it to corrupt.
+ */
+static int
+sv_iter_corrupt(struct vos_obj_iter *oiter)
+{
+	struct umem_instance	*umm;
+	struct vos_svt_key	 skey = {0};
+	struct vos_rec_bundle	 rbund = {0};
+	struct bio_iov		 biov = {0};
+	daos_anchor_t		 anchor = {0};
+	d_iov_t			 key, val;
+	size_t			 addr_offset;
+	struct vos_irec_df	*irec;
+	int			 rc = 0;
+
+	umm = vos_obj2umm(oiter->it_obj);
+
+	rc = umem_tx_begin(umm, NULL);
+	if (rc != 0)
+		return rc;
+
+	/* Bundle the key and value structures into appropriate iovs */
+	tree_rec_bundle2iov(&rbund, &val);
+	rbund.rb_biov = &biov;
+	d_iov_set(&key, &skey, sizeof(skey));
+
+	/* Fetch the key/value for the current iter cursor */
+	rc = dbtree_iter_fetch(oiter->it_hdl, &key, &val, &anchor);
+	if (rc != 0) {
+		D_ERROR("dbtree_iter_fetch failed: "DF_RC"\n", DP_RC(rc));
+		rc = umem_tx_end(umm, rc);
+		return rc;
+	}
+
+	addr_offset = offsetof(struct vos_irec_df, ir_ex_addr);
+	rc = umem_tx_add(umm, rbund.rb_off + addr_offset,
+			 sizeof(*irec) - addr_offset);
+	if (rc != 0) {
+		D_ERROR("umem_tx_add failed: "DF_RC"\n", DP_RC(rc));
+		rc = umem_tx_end(umm, rc);
+		return rc;
+	}
+
+	D_DEBUG(DB_IO, "Setting record bio_addr flag to corrupted\n");
+	irec = umem_off2ptr(umm, rbund.rb_off);
+	BIO_ADDR_SET_CORRUPTED(&irec->ir_ex_addr);
+
+	rc = umem_tx_end(umm, rc);
+	return rc;
+}
+
 int
 vos_obj_iter_aggregate(daos_handle_t ih, bool discard)
 {
@@ -1875,23 +1929,33 @@ exit:
 }
 
 static int
-vos_obj_iter_delete(struct vos_iterator *iter, void *args)
+vos_obj_iter_process(struct vos_iterator *iter, vos_iter_proc_op op,
+		     void *args)
 {
 	struct vos_obj_iter *oiter = vos_iter2oiter(iter);
 
-	switch (iter->it_type) {
+	switch (op) {
+	case VOS_ITER_PROC_OP_DELETE:
+		switch (iter->it_type) {
+		default:
+			D_ASSERT(0);
+			return -DER_INVAL;
+		case VOS_ITER_DKEY:
+		case VOS_ITER_AKEY:
+		case VOS_ITER_SINGLE:
+			return obj_iter_delete(oiter, args);
+		case VOS_ITER_RECX:
+			return evt_iter_delete(oiter->it_hdl, NULL);
+		}
+	case VOS_ITER_PROC_OP_MARK_CORRUPT:
+		if (iter->it_type == VOS_ITER_SINGLE)
+			return sv_iter_corrupt(oiter);
+		if (iter->it_type == VOS_ITER_RECX)
+			return evt_iter_corrupt(oiter->it_hdl);
 	default:
 		D_ASSERT(0);
-		return -DER_INVAL;
-
-	case VOS_ITER_DKEY:
-	case VOS_ITER_AKEY:
-	case VOS_ITER_SINGLE:
-		return obj_iter_delete(oiter, args);
-
-	case VOS_ITER_RECX:
-		return evt_iter_delete(oiter->it_hdl, NULL);
 	}
+	return 0;
 }
 
 static int
@@ -1924,7 +1988,7 @@ struct vos_iter_ops	vos_obj_iter_ops = {
 	.iop_next		= vos_obj_iter_next,
 	.iop_fetch		= vos_obj_iter_fetch,
 	.iop_copy		= vos_obj_iter_copy,
-	.iop_delete		= vos_obj_iter_delete,
+	.iop_process		= vos_obj_iter_process,
 	.iop_empty		= vos_obj_iter_empty,
 };
 /**

--- a/src/vos/vos_obj_index.c
+++ b/src/vos/vos_obj_index.c
@@ -18,6 +18,7 @@
 #include <vos_internal.h>
 #include <vos_ilog.h>
 #include <vos_obj.h>
+#include <daos_srv/vos.h>
 
 /** iterator for oid */
 struct vos_oi_iter {
@@ -625,12 +626,14 @@ oi_iter_fetch(struct vos_iterator *iter, vos_iter_entry_t *it_entry,
 }
 
 static int
-oi_iter_delete(struct vos_iterator *iter, void *args)
+oi_iter_process(struct vos_iterator *iter, vos_iter_proc_op op, void *args)
 {
 	struct vos_oi_iter	*oiter = iter2oiter(iter);
 	int			rc = 0;
 
 	D_ASSERT(iter->it_type == VOS_ITER_OBJ);
+	if (op != VOS_ITER_PROC_OP_DELETE)
+		return -DER_NOSYS;
 
 	rc = umem_tx_begin(vos_cont2umm(oiter->oit_cont), NULL);
 	if (rc != 0)
@@ -716,7 +719,7 @@ struct vos_iter_ops vos_oi_iter_ops = {
 	.iop_probe		= oi_iter_probe,
 	.iop_next		= oi_iter_next,
 	.iop_fetch		= oi_iter_fetch,
-	.iop_delete		= oi_iter_delete,
+	.iop_process		= oi_iter_process,
 };
 
 /**

--- a/src/vos/vos_tree.c
+++ b/src/vos/vos_tree.c
@@ -516,6 +516,7 @@ svt_rec_load(struct btr_instance *tins, struct btr_record *rec,
 	rbund->rb_gsize	= irec->ir_gsize;
 	rbund->rb_ver	= irec->ir_ver;
 	rbund->rb_dtx_state = vos_dtx_ent_state(irec->ir_dtx);
+	rbund->rb_off = rec->rec_off;
 	return 0;
 }
 
@@ -718,8 +719,7 @@ svt_rec_fetch(struct btr_instance *tins, struct btr_record *rec,
 	if (key_iov != NULL)
 		key = iov2svt_key(key_iov);
 
-	svt_rec_load(tins, rec, key, rbund);
-	return 0;
+	return svt_rec_load(tins, rec, key, rbund);
 }
 
 static int


### PR DESCRIPTION
Add the ability to set a bio address as corrupted using the VOS
iter API. This will be necessary for the checksum scrubber
to be able to mark data as corrupted when silent data
corruption is detected.

- Change the vos_iter_delete api to be more generic with an op code
  parameter. Will have a delete and corrupt op code for now.

Signed-off-by: Ryon Jensen <ryon.jensen@intel.com>