### PR TITLE
DAOS-7815 test: Increase timeout for pool_destroy_rebuild.py

### DIFF
--- a/src/tests/ftest/rebuild/pool_destroy_rebuild.yaml
+++ b/src/tests/ftest/rebuild/pool_destroy_rebuild.yaml
@@ -6,7 +6,7 @@ hosts:
     - server-B
   test_clients:
     - client-C
-timeout: 180
+timeout: 630
 server_config:
   engines_per_host: 2
   name: daos_server

--- a/src/tests/ftest/rebuild/pool_destroy_rebuild.yaml
+++ b/src/tests/ftest/rebuild/pool_destroy_rebuild.yaml
@@ -6,7 +6,7 @@ hosts:
     - server-B
   test_clients:
     - client-C
-timeout: 630
+timeout: 240
 server_config:
   engines_per_host: 2
   name: daos_server

--- a/src/tests/ftest/rebuild/pool_destroy_rebuild.yaml
+++ b/src/tests/ftest/rebuild/pool_destroy_rebuild.yaml
@@ -6,7 +6,7 @@ hosts:
     - server-B
   test_clients:
     - client-C
-timeout: 240
+timeout: 360
 server_config:
   engines_per_host: 2
   name: daos_server


### PR DESCRIPTION
Increase timeout for pool_destroy_rebuild.py

Quick-Functional: true
Test-tag: pooldestroywithio

Signed-off-by: Saurabh Tandan <saurabh.tandan@intel.com>