### PR TITLE
DAOS-7174 prop: don't use regex to check label

### DIFF
--- a/src/common/prop.c
+++ b/src/common/prop.c
@@ -8,7 +8,6 @@
  * not belong to other parts.
  */
 #define D_LOGFAC	DD_FAC(common)
-#include <regex.h>
 
 #include <daos/common.h>
 #include <daos/dtx.h>
@@ -163,86 +162,37 @@ err:
 }
 
 static bool
-daos_prop_str_format_valid(const char *str, const char *regex)
-{
-	regex_t		regx;
-	int		rc;
-
-	/* All callers to this internal function shall provide non-NULL args */
-	D_ASSERT(str != NULL);
-	D_ASSERT(regex != NULL);
-
-	rc = regcomp(&regx, regex, REG_EXTENDED);
-	D_ASSERT(rc == 0);
-
-	rc = regexec(&regx, str, 0, NULL, 0);
-	regfree(&regx);
-	if (rc != 0) /* REG_NOMATCH */
-		return false;
-	return true;
-}
-
-static bool
-daos_prop_str_valid(const char *str, const char *prop_name,
-		    size_t max_len, const char *fmt_regex,
-		    bool do_log)
+str_valid(const char *str, const char *prop_name, size_t max_len)
 {
 	size_t len;
 
-	if (str == NULL) {
-		if (do_log)
-			D_ERROR("invalid NULL %s\n", prop_name);
+	if (unlikely(str == NULL)) {
+		D_ERROR("invalid NULL %s\n", prop_name);
 		return false;
 	}
 	/* Detect if it's longer than max_len */
 	len = strnlen(str, max_len + 1);
 	if (len == 0 || len > max_len) {
-		if (do_log)
-			D_ERROR("invalid %s len=%lu, max=%lu\n",
-				prop_name, len, max_len);
+		D_ERROR("invalid %s len=%lu, max=%lu\n", prop_name, len,
+			max_len);
 		return false;
 	}
 
-	if (fmt_regex) {
-		if (!daos_prop_str_format_valid(str, fmt_regex)) {
-			if (do_log)
-				D_ERROR("invalid %s prop \"%s\": does not "
-					"match regex: \"%s\"\n", prop_name,
-					str, fmt_regex);
-			return false;
-		}
-	}
 	return true;
-}
-
-
-bool
-daos_label_is_valid(const char *label) {
-	return daos_prop_str_valid(label, "label", DAOS_PROP_LABEL_MAX_LEN,
-				   DAOS_STANDALONE_LABEL_REGEX, false);
 }
 
 static bool
 daos_prop_owner_valid(d_string_t owner)
 {
 	/* Max length passed in doesn't include the null terminator */
-	return daos_prop_str_valid(owner, "owner",
-				   DAOS_ACL_MAX_PRINCIPAL_LEN, NULL, true);
+	return str_valid(owner, "owner", DAOS_ACL_MAX_PRINCIPAL_LEN);
 }
 
 static bool
 daos_prop_owner_group_valid(d_string_t owner)
 {
 	/* Max length passed in doesn't include the null terminator */
-	return daos_prop_str_valid(owner, "owner-group",
-				   DAOS_ACL_MAX_PRINCIPAL_LEN, NULL, true);
-}
-
-static bool
-daos_prop_label_valid(d_string_t label)
-{
-	return daos_prop_str_valid(label, "label", DAOS_PROP_LABEL_MAX_LEN,
-				   DAOS_STANDALONE_LABEL_REGEX, true);
+	return str_valid(owner, "owner-group", DAOS_ACL_MAX_PRINCIPAL_LEN);
 }
 
 /**
@@ -304,9 +254,12 @@ daos_prop_valid(daos_prop_t *prop, bool pool, bool input)
 		/* pool properties */
 		case DAOS_PROP_PO_LABEL:
 		case DAOS_PROP_CO_LABEL:
-			if (!daos_prop_label_valid(
-				prop->dpp_entries[i].dpe_str))
+			if (!daos_label_is_valid(
+						prop->dpp_entries[i].dpe_str)) {
+				D_ERROR("invalid label \"%s\"\n",
+					prop->dpp_entries[i].dpe_str);
 				return false;
+			}
 			break;
 		case DAOS_PROP_PO_ACL:
 		case DAOS_PROP_CO_ACL:

--- a/src/include/daos_prop.h
+++ b/src/include/daos_prop.h
@@ -14,6 +14,7 @@
 extern "C" {
 #endif
 
+#include <ctype.h>
 #include <daos_types.h>
 
 /**
@@ -346,14 +347,48 @@ struct daos_prop_entry {
 
 /** Allowed max number of property entries in daos_prop_t */
 #define DAOS_PROP_ENTRIES_MAX_NR	(128)
+
 /** max length for pool/container label - NB: POOL_LIST_CONT RPC wire format */
 #define DAOS_PROP_LABEL_MAX_LEN		(127)
-/* DAOS labels (pool/container properties) must consist only of alphanumeric
- * characters, colon ':', period '.' or underscore '_', and must be of length
- * 1 - DAOS_PROP_LABEL_MAX_LEN.
+
+/**
+ * Check if DAOS (pool or container property) label string is valid.
+ * DAOS labels must consist only of alphanumeric characters, colon ':',
+ * period '.' or underscore '_', and must be of length
+ * [1 - DAOS_PROP_LABEL_MAX_LEN].
+ *
+ * \param[in]	label	Label string
+ *
+ * \return		true		Label meets length/format requirements
+ *			false		Label is not valid length or format
  */
-#define DAOS_LABEL_REGEX "([a-zA-Z0-9._:]{1,127})"
-#define DAOS_STANDALONE_LABEL_REGEX "^"DAOS_LABEL_REGEX"$"
+static inline bool
+daos_label_is_valid(const char *label)
+{
+	size_t	len;
+	int	i;
+
+	/** Label cannot be NULL */
+	if (label == NULL)
+		return false;
+
+	/** Check the length */
+	len = strnlen(label, DAOS_PROP_LABEL_MAX_LEN + 1);
+	if (len == 0 || len > DAOS_PROP_LABEL_MAX_LEN)
+		return false;
+
+	/** Verify that it contains only alphanumeric characters or :._ */
+	for (i = 0; i < len; i++) {
+		char c = label[i];
+
+		if (isalnum(c) || c == '.' || c == '_' || c == ':')
+			continue;
+
+		return false;
+	}
+
+	return true;
+}
 
 /** daos properties, for pool or container */
 typedef struct {
@@ -444,19 +479,6 @@ daos_prop_entry_cmp_acl(struct daos_prop_entry *entry1,
 int
 daos_prop_entry_dup_co_roots(struct daos_prop_entry *dst,
 			     struct daos_prop_entry *src);
-
-/**
- * Check if DAOS (pool or container property) label string is valid
- * (string length <= DAOS_PROP_LABEL_MAX_LEN, and conforms to
- *  allowed characters defined by DAOS_LABEL_REGEX).
- *
- * \param[in]	label	Label string
- *
- * \return		true		Label meets length/format requirements
- *			false		Label is not valid length or format
- */
-bool
-daos_label_is_valid(const char *label);
 
 #if defined(__cplusplus)
 }


### PR DESCRIPTION
regex seems to be stack hungry. Since the label pattern is pretty simple,
verify it w/o using regex to avoid stack overflow on the server side.

Signed-off-by: Johann Lombardi <johann.lombardi@intel.com>