### PR TITLE
DAOS-7968 vos: Reduce stack usage

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -30,7 +30,6 @@ DESIRED_FLAGS = ['-Wno-gnu-designator',
                  '-Wno-missing-braces',
                  '-Wno-ignored-attributes',
                  '-Wno-gnu-zero-variadic-macro-arguments',
-                 '-fstack-usage',
                  '-Wno-tautological-constant-out-of-range-compare',
                  '-Wno-unused-command-line-argument',
                  '-Wframe-larger-than=4096']

--- a/SConstruct
+++ b/SConstruct
@@ -30,6 +30,7 @@ DESIRED_FLAGS = ['-Wno-gnu-designator',
                  '-Wno-missing-braces',
                  '-Wno-ignored-attributes',
                  '-Wno-gnu-zero-variadic-macro-arguments',
+                 '-fstack-usage',
                  '-Wno-tautological-constant-out-of-range-compare',
                  '-Wno-unused-command-line-argument',
                  '-Wframe-larger-than=4096']

--- a/src/common/btree.c
+++ b/src/common/btree.c
@@ -1336,8 +1336,6 @@ btr_probe(struct btr_context *tcx, dbtree_probe_opc_t probe_opc,
 	bool			 next_level;
 	struct btr_node		*nd;
 	struct btr_check_alb	 alb;
-	struct btr_trace	 traces[BTR_TRACE_MAX];
-	struct btr_trace	*trace = NULL;
 	umem_off_t		 nd_off;
 
 	if (!btr_probe_valid(probe_opc)) {
@@ -1525,13 +1523,7 @@ again:
 				saved = at + 1;
 		}
 
-		/* backup the probe trace because probe_next will change it */
-		if (trace == NULL)
-			memcpy(traces, tcx->tc_trace,
-			       sizeof(*trace) * tcx->tc_depth);
-
 		if (btr_probe_next(tcx)) {
-			trace = traces;
 			cmp = BTR_CMP_UNKNOWN;
 			break;
 		}

--- a/src/include/daos_srv/evtree.h
+++ b/src/include/daos_srv/evtree.h
@@ -375,9 +375,6 @@ struct evt_entry_array_sm {
 	struct evt_entry_array_sm	 name##_alloc;			\
 	struct evt_entry_array		*name
 
-#define EVT_ENT_ARRAY_PTR_INIT(basename)	\
-	(basename) = &(basename##_alloc).ea_data
-
 D_CASSERT(offsetof(struct evt_entry_array_lg, ea_embedded) ==
 	  offsetof(struct evt_entry_array, ea_embedded_ents));
 D_CASSERT(offsetof(struct evt_entry_array_sm, ea_embedded) ==

--- a/src/include/daos_srv/evtree.h
+++ b/src/include/daos_srv/evtree.h
@@ -338,8 +338,9 @@ struct evt_list_entry {
 
 #define EVT_EMBEDDED_NR 16
 /**
- * list head of \a evt_entry, it contains a few embedded entries to support
- * lightweight allocation of entries.
+ * list head of \a evt_entry.  Do not use directly.  Instead, allocate
+ * on the stack using the EVT_ENT_ARRAY_*_PTR macros below.  This
+ * will allocate some embedded entries to reduce some allocations.
  */
 struct evt_entry_array {
 	/** Array of allocated entries */
@@ -353,8 +354,34 @@ struct evt_entry_array {
 	/** Number of bytes per index */
 	uint32_t			 ea_inob;
 	/* Small array of embedded entries */
-	struct evt_list_entry		 ea_embedded_ents[EVT_EMBEDDED_NR];
+	struct evt_list_entry		 ea_embedded_ents[0];
 };
+
+struct evt_entry_array_lg {
+	struct evt_entry_array		 ea_data;
+	struct evt_list_entry		 ea_embedded[EVT_EMBEDDED_NR];
+};
+
+struct evt_entry_array_sm {
+	struct evt_entry_array		 ea_data;
+	struct evt_list_entry		 ea_embedded[1];
+};
+
+#define EVT_ENT_ARRAY_LG_PTR(name)					\
+	struct evt_entry_array_lg	 name##_alloc;			\
+	struct evt_entry_array		*name
+
+#define EVT_ENT_ARRAY_SM_PTR(name)					\
+	struct evt_entry_array_sm	 name##_alloc;			\
+	struct evt_entry_array		*name
+
+#define EVT_ENT_ARRAY_PTR_INIT(basename)	\
+	(basename) = &(basename##_alloc).ea_data
+
+D_CASSERT(offsetof(struct evt_entry_array_lg, ea_embedded) ==
+	  offsetof(struct evt_entry_array, ea_embedded_ents));
+D_CASSERT(offsetof(struct evt_entry_array_sm, ea_embedded) ==
+	  offsetof(struct evt_entry_array, ea_embedded_ents));
 
 static inline char
 evt_debug_print_visibility(const struct evt_entry *ent)
@@ -421,8 +448,17 @@ evt_entry_selected_offset(const struct evt_entry *entry)
 
 #define evt_ent_array_empty(ea)		(ea->ea_ent_nr == 0)
 
-void evt_ent_array_init(struct evt_entry_array *ent_array);
-void evt_ent_array_fini(struct evt_entry_array *ent_array);
+/** Passing max of 0 tells evtree functions to calculate the maximum size */
+#define evt_ent_array_init(basename, max)							\
+	do {											\
+		(basename) = &basename##_alloc.ea_data;						\
+		evt_ent_array_init_(basename, ARRAY_SIZE(basename##_alloc.ea_embedded), max);	\
+	} while (0)
+void evt_ent_array_init_(struct evt_entry_array *ent_array, int embedded_nr,
+			int max);
+#define evt_ent_array_fini(basename)	\
+	evt_ent_array_fini_(basename, ARRAY_SIZE(basename##_alloc.ea_embedded))
+void evt_ent_array_fini_(struct evt_entry_array *ent_array, int embedded);
 
 struct evt_context;
 

--- a/src/vos/evt_iter.c
+++ b/src/vos/evt_iter.c
@@ -120,7 +120,7 @@ evt_iter_probe_find(struct evt_iterator *iter, const struct evt_rect *rect)
 	int			 mid;
 	int			 cmp = 0;
 
-	enta = &iter->it_entries;
+	enta = iter->it_entries;
 	start = 0;
 	end = enta->ea_ent_nr - 1;
 
@@ -231,12 +231,12 @@ evt_iter_move(struct evt_context *tcx, struct evt_iterator *iter)
 			iter->it_index +=
 				iter->it_forward ? 1 : -1;
 			if (iter->it_index < 0 ||
-			    iter->it_index == iter->it_entries.ea_ent_nr) {
+			    iter->it_index == iter->it_entries->ea_ent_nr) {
 				iter->it_state = EVT_ITER_FINI;
 				D_GOTO(out, rc = -DER_NONEXIST);
 			}
 
-			entry = evt_ent_array_get(&iter->it_entries,
+			entry = evt_ent_array_get(iter->it_entries,
 						  iter->it_index);
 			if (entry->en_avail_rc < 0)
 				return entry->en_avail_rc;
@@ -297,7 +297,7 @@ evt_iter_skip_holes(struct evt_context *tcx, struct evt_iterator *iter)
 	struct evt_entry	*entry;
 
 	if (iter->it_options & (EVT_ITER_SKIP_HOLES | EVT_ITER_SKIP_REMOVED)) {
-		enta = &iter->it_entries;
+		enta = iter->it_entries;
 		entry = evt_ent_array_get(enta, iter->it_index);
 
 		if (should_skip(entry, iter))
@@ -328,7 +328,7 @@ evt_iter_probe_sorted(struct evt_context *tcx, struct evt_iterator *iter,
 	rtmp.rc_ex.ex_hi = iter->it_filter.fr_ex.ex_hi;
 	rtmp.rc_epc = DAOS_EPOCH_MAX;
 
-	enta = &iter->it_entries;
+	enta = iter->it_entries;
 	intent = evt_iter_intent(iter);
 	rc = evt_ent_array_fill(tcx, EVT_FIND_ALL, intent, &iter->it_filter,
 				&rtmp, enta);
@@ -395,7 +395,7 @@ evt_iter_probe(daos_handle_t ih, enum evt_iter_opc opc,
 	if (iter->it_state < EVT_ITER_INIT)
 		D_GOTO(out, rc = -DER_NO_HDL);
 
-	enta = &iter->it_entries;
+	enta = iter->it_entries;
 	ent_array_reset(tcx, enta);
 
 	if (evt_iter_is_sorted(iter))
@@ -594,7 +594,7 @@ evt_iter_fetch(daos_handle_t ih, unsigned int *inob, struct evt_entry *entry,
 		D_GOTO(out, rc);
 
 	if (evt_iter_is_sorted(iter)) {
-		*entry = *evt_ent_array_get(&iter->it_entries, iter->it_index);
+		*entry = *evt_ent_array_get(iter->it_entries, iter->it_index);
 		evt_ent2rect(&rect, entry);
 		goto set_anchor;
 	}

--- a/src/vos/evt_priv.h
+++ b/src/vos/evt_priv.h
@@ -40,7 +40,7 @@ struct evt_iterator {
 	/** index */
 	int				it_index;
 	/** For sorted iterators */
-	struct evt_entry_array		it_entries;
+	EVT_ENT_ARRAY_LG_PTR(it_entries);
 };
 
 #define EVT_TRACE_MAX                   32
@@ -256,7 +256,7 @@ evt_tcx_decref(struct evt_context *tcx)
 	if (tcx->tc_ref == 0) {
 		tcx->tc_magic = EVT_HDL_DEAD;
 		/* Free any memory allocated by embedded iterator */
-		evt_ent_array_fini(&tcx->tc_iter.it_entries);
+		evt_ent_array_fini(tcx->tc_iter.it_entries);
 		D_FREE(tcx);
 	}
 }

--- a/src/vos/evtree.c
+++ b/src/vos/evtree.c
@@ -274,15 +274,6 @@ evt_weight_diff(struct evt_weight *wt1, struct evt_weight *wt2,
 	wt_diff->wt_minor = wt1->wt_minor - wt2->wt_minor;
 }
 
-/** Internal function for initializing an array.   Using 0 for max
- *  ultimately cause it to be set to maximum size needed by
- *  evt_find_visible.
- */
-static inline void
-evt_ent_array_init_internal(struct evt_entry_array *ent_array, int max)
-{
-}
-
 /** Initialize an entry list */
 void
 evt_ent_array_init_(struct evt_entry_array *ent_array, int embedded, int max)
@@ -1923,7 +1914,7 @@ evt_large_hole_insert(daos_handle_t toh, const struct evt_entry_in *entry)
 	struct evt_entry	*ent;
 	struct evt_entry_in	 hole;
 	struct evt_filter	 filter = {0};
-	EVT_ENT_ARRAY_LG_PTR(ent_array);
+	EVT_ENT_ARRAY_SM_PTR(ent_array);
 	int			 rc = 0;
 
 	filter.fr_epr.epr_hi = entry->ei_bound;

--- a/src/vos/evtree.c
+++ b/src/vos/evtree.c
@@ -281,24 +281,23 @@ evt_weight_diff(struct evt_weight *wt1, struct evt_weight *wt2,
 static inline void
 evt_ent_array_init_internal(struct evt_entry_array *ent_array, int max)
 {
-	memset(ent_array, 0, sizeof(*ent_array));
-	ent_array->ea_ents = ent_array->ea_embedded_ents;
-	ent_array->ea_size = EVT_EMBEDDED_NR;
-	ent_array->ea_max = max;
 }
 
 /** Initialize an entry list */
 void
-evt_ent_array_init(struct evt_entry_array *ent_array)
+evt_ent_array_init_(struct evt_entry_array *ent_array, int embedded, int max)
 {
-	evt_ent_array_init_internal(ent_array, 0);
+	memset(ent_array, 0, sizeof(*ent_array));
+	ent_array->ea_ents = &ent_array->ea_embedded_ents[0];
+	ent_array->ea_size = embedded;
+	ent_array->ea_max = max;
 }
 
 /** Finalize an entry list */
 void
-evt_ent_array_fini(struct evt_entry_array *ent_array)
+evt_ent_array_fini_(struct evt_entry_array *ent_array, int embedded)
 {
-	if (ent_array->ea_size > EVT_EMBEDDED_NR)
+	if (ent_array->ea_size > embedded)
 		D_FREE(ent_array->ea_ents);
 
 	ent_array->ea_size = ent_array->ea_ent_nr = 0;
@@ -1029,7 +1028,7 @@ evt_tcx_create(struct evt_root *root, uint64_t feats, unsigned int order,
 	/* Initialize the embedded iterator entry array.  This is a minor
 	 * optimization if the iterator is used more than once
 	 */
-	evt_ent_array_init(&tcx->tc_iter.it_entries);
+	evt_ent_array_init(tcx->tc_iter.it_entries, 0);
 	evt_tcx_set_dep(tcx, depth);
 	*tcx_pp = tcx;
 	return 0;
@@ -1924,19 +1923,19 @@ evt_large_hole_insert(daos_handle_t toh, const struct evt_entry_in *entry)
 	struct evt_entry	*ent;
 	struct evt_entry_in	 hole;
 	struct evt_filter	 filter = {0};
-	struct evt_entry_array	 ent_array;
+	EVT_ENT_ARRAY_LG_PTR(ent_array);
 	int			 rc = 0;
 
 	filter.fr_epr.epr_hi = entry->ei_bound;
 	filter.fr_epoch = entry->ei_rect.rc_epc;
 	filter.fr_ex = entry->ei_rect.rc_ex;
 
-	evt_ent_array_init(&ent_array);
-	rc = evt_find(toh, &filter, &ent_array);
+	evt_ent_array_init(ent_array, 0);
+	rc = evt_find(toh, &filter, ent_array);
 	if (rc != 0)
 		goto done;
 
-	evt_ent_array_for_each(ent, &ent_array) {
+	evt_ent_array_for_each(ent, ent_array) {
 		if (bio_addr_is_hole(&ent->en_addr))
 			continue; /* Skip holes */
 		/** Insert a hole to cover the record */
@@ -1947,7 +1946,7 @@ evt_large_hole_insert(daos_handle_t toh, const struct evt_entry_in *entry)
 			break;
 	}
 done:
-	evt_ent_array_fini(&ent_array);
+	evt_ent_array_fini(ent_array);
 
 	return rc;
 }
@@ -1962,7 +1961,7 @@ evt_insert(daos_handle_t toh, const struct evt_entry_in *entry,
 	   uint8_t **csum_bufp)
 {
 	struct evt_context	*tcx;
-	struct evt_entry_array	 ent_array;
+	EVT_ENT_ARRAY_SM_PTR(ent_array);
 	struct evt_filter	 filter;
 	int			 rc;
 
@@ -1993,7 +1992,7 @@ evt_insert(daos_handle_t toh, const struct evt_entry_in *entry,
 		return -DER_NO_PERM;
 	}
 
-	evt_ent_array_init_internal(&ent_array, 1);
+	evt_ent_array_init(ent_array, 1);
 
 	filter.fr_ex = entry->ei_rect.rc_ex;
 	filter.fr_epr.epr_lo = entry->ei_rect.rc_epc;
@@ -2003,7 +2002,7 @@ evt_insert(daos_handle_t toh, const struct evt_entry_in *entry,
 	filter.fr_punch_minor_epc = 0;
 	/* Phase-1: Check for overwrite and uncertainty */
 	rc = evt_ent_array_fill(tcx, EVT_FIND_OVERWRITE, DAOS_INTENT_UPDATE,
-				&filter, &entry->ei_rect, &ent_array);
+				&filter, &entry->ei_rect, ent_array);
 	if (rc != 0)
 		return rc;
 
@@ -2023,8 +2022,8 @@ evt_insert(daos_handle_t toh, const struct evt_entry_in *entry,
 	}
 
 
-	D_ASSERT(ent_array.ea_ent_nr <= 1);
-	if (ent_array.ea_ent_nr == 1) {
+	D_ASSERT(ent_array->ea_ent_nr <= 1);
+	if (ent_array->ea_ent_nr == 1) {
 		/*
 		 * NB: This is part of the current hack to keep "supporting"
 		 * overwrite for same epoch, full overwrite.
@@ -2038,7 +2037,7 @@ evt_insert(daos_handle_t toh, const struct evt_entry_in *entry,
 	/* Phase-2: Inserting */
 	rc = evt_insert_entry(tcx, entry, csum_bufp);
 
-	/* No need for evt_ent_array_fill as there will be no allocations
+	/* No need for evt_ent_array_fini as there will be no allocations
 	 * with 1 entry in the list
 	 */
 out:
@@ -2446,7 +2445,7 @@ out:
 		rc = evt_data_loss_check(&data_loss_list, ent_array);
 
 	if (rc != 0)
-		evt_ent_array_fini(ent_array);
+		ent_array->ea_ent_nr = 0;
 
 	while ((edli = d_list_pop_entry(&data_loss_list,
 					struct evt_data_loss_item,
@@ -2483,7 +2482,6 @@ evt_find(daos_handle_t toh, const struct evt_filter *filter,
 	if (tcx == NULL)
 		return -DER_NO_HDL;
 
-	evt_ent_array_init(ent_array);
 	rect.rc_ex = filter->fr_ex;
 	rect.rc_epc = filter->fr_epoch;
 	rect.rc_minor_epc = EVT_MINOR_EPC_MAX;
@@ -2492,8 +2490,7 @@ evt_find(daos_handle_t toh, const struct evt_filter *filter,
 				filter, &rect, ent_array);
 	if (rc == 0)
 		rc = evt_ent_array_sort(tcx, ent_array, filter, EVT_VISIBLE);
-	if (rc != 0)
-		evt_ent_array_fini(ent_array);
+
 	return rc;
 }
 
@@ -3335,28 +3332,28 @@ int
 evt_delete_internal(struct evt_context *tcx, const struct evt_rect *rect,
 		    struct evt_entry *ent, bool in_tx)
 {
-	struct evt_entry_array	 ent_array;
+	EVT_ENT_ARRAY_SM_PTR(ent_array);
 	struct evt_filter	 filter = {0};
 	int			 rc;
 
 	/* NB: This function presently only supports exact match on extent. */
-	evt_ent_array_init_internal(&ent_array, 1);
+	evt_ent_array_init(ent_array, 1);
 
 	filter.fr_ex = rect->rc_ex;
 	filter.fr_epr.epr_lo = rect->rc_epc;
 	filter.fr_epr.epr_hi = rect->rc_epc;
 	filter.fr_epoch = rect->rc_epc;
 	rc = evt_ent_array_fill(tcx, EVT_FIND_SAME, DAOS_INTENT_PURGE,
-				&filter, rect, &ent_array);
+				&filter, rect, ent_array);
 	if (rc != 0)
 		return rc;
 
-	if (ent_array.ea_ent_nr == 0)
+	if (ent_array->ea_ent_nr == 0)
 		return -DER_ENOENT;
 
-	D_ASSERT(ent_array.ea_ent_nr == 1);
+	D_ASSERT(ent_array->ea_ent_nr == 1);
 	if (ent != NULL)
-		*ent = *evt_ent_array_get(&ent_array, 0);
+		*ent = *evt_ent_array_get(ent_array, 0);
 
 	if (!in_tx) {
 		rc = evt_tx_begin(tcx);
@@ -3373,7 +3370,7 @@ evt_delete_internal(struct evt_context *tcx, const struct evt_rect *rect,
 	if (rc == -DER_NONEXIST)
 		rc = 0;
 
-	/* No need for evt_ent_array_fill as there will be no allocations
+	/* No need for evt_ent_array_fini as there will be no allocations
 	 * with 1 entry in the list
 	 */
 	return in_tx ? rc : evt_tx_end(tcx, rc);

--- a/src/vos/tests/evt_ctl.c
+++ b/src/vos/tests/evt_ctl.c
@@ -470,7 +470,7 @@ ts_find_rect(void)
 	struct evt_filter	 filter = {0};
 	bio_addr_t		 addr;
 	struct evt_rect		 rect;
-	struct evt_entry_array	 ent_array;
+	EVT_ENT_ARRAY_LG_PTR(ent_array);
 	int			 rc;
 	bool			 should_pass;
 	char			*arg;
@@ -489,12 +489,12 @@ ts_find_rect(void)
 	filter.fr_epr.epr_hi = rect.rc_epc;
 	filter.fr_epoch = filter.fr_epr.epr_hi;
 	filter.fr_ex = rect.rc_ex;
-	evt_ent_array_init(&ent_array);
-	rc = evt_find(ts_toh, &filter, &ent_array);
+	evt_ent_array_init(ent_array, 0);
+	rc = evt_find(ts_toh, &filter, ent_array);
 	if (rc != 0)
 		D_FATAL("Add rect failed "DF_RC"\n", DP_RC(rc));
 
-	evt_ent_array_for_each(ent, &ent_array) {
+	evt_ent_array_for_each(ent, ent_array) {
 		bool punched;
 		addr = ent->en_addr;
 
@@ -507,7 +507,7 @@ ts_find_rect(void)
 								 addr.ba_off));
 	}
 
-	evt_ent_array_fini(&ent_array);
+	evt_ent_array_fini(ent_array);
 }
 
 static void
@@ -1368,7 +1368,7 @@ test_evt_find_internal(void **state)
 	struct evt_entry_in	 entry = {0};
 	struct evt_entry	 *ent;
 	struct evt_filter	 filter = {0};
-	struct evt_entry_array	 ent_array;
+	EVT_ENT_ARRAY_LG_PTR(ent_array);
 	bio_addr_t		 addr;
 	int			 rc;
 	int			 epoch;
@@ -1430,11 +1430,11 @@ test_evt_find_internal(void **state)
 		filter.fr_ex.ex_hi = epoch + 9;
 		filter.fr_epr.epr_hi = epoch;
 		filter.fr_epoch = filter.fr_epr.epr_hi;
-		evt_ent_array_init(&ent_array);
-		rc = evt_find(toh, &filter, &ent_array);
+		evt_ent_array_init(ent_array, 1);
+		rc = evt_find(toh, &filter, ent_array);
 		if (rc != 0)
 			D_FATAL("Find rect failed "DF_RC"\n", DP_RC(rc));
-		evt_ent_array_for_each(ent, &ent_array) {
+		evt_ent_array_for_each(ent, ent_array) {
 			bool punched;
 			static char buf[10];
 
@@ -1479,7 +1479,7 @@ test_evt_find_internal(void **state)
 		assert_int_equal(rc, 0);
 		rc = utest_sync_mem_status(arg->ta_utx);
 		assert_int_equal(rc, 0);
-		evt_ent_array_fini(&ent_array);
+		evt_ent_array_fini(ent_array);
 	}
 	rc = utest_check_mem_initial_status(arg->ta_utx);
 	assert_int_equal(rc, 0);
@@ -1624,7 +1624,7 @@ test_evt_various_data_size_internal(void **state)
 					D_256M_SIZE};
 	uint64_t		data_size;
 	char                     *data;
-	struct evt_entry_array	 ent_array;
+	EVT_ENT_ARRAY_LG_PTR(ent_array);
 	struct evt_entry	 *ent;
 	bio_addr_t		 addr;
 	struct evt_filter	 filter = {0};
@@ -1676,16 +1676,16 @@ test_evt_various_data_size_internal(void **state)
 			rc = utest_sync_mem_status(arg->ta_utx);
 			assert_int_equal(rc, 0);
 			if (epoch == 1) {
-				evt_ent_array_init(&ent_array);
+				evt_ent_array_init(ent_array, 0);
 				filter.fr_ex.ex_lo = epoch;
 				filter.fr_ex.ex_hi = epoch + data_size - 1;
 				filter.fr_epr.epr_hi = epoch;
 				filter.fr_epoch = filter.fr_epr.epr_hi;
-				rc = evt_find(toh, &filter, &ent_array);
+				rc = evt_find(toh, &filter, ent_array);
 				if (rc != 0)
 					D_FATAL("Find rect failed "DF_RC"\n",
 						DP_RC(rc));
-				evt_ent_array_for_each(ent, &ent_array) {
+				evt_ent_array_for_each(ent, ent_array) {
 					static char *actual;
 
 					D_ALLOC(actual, data_size);
@@ -1703,7 +1703,7 @@ test_evt_various_data_size_internal(void **state)
 					}
 					D_FREE(actual);
 				}
-				evt_ent_array_fini(&ent_array);
+				evt_ent_array_fini(ent_array);
 			}
 			/* Delete a record*/
 			if (epoch % 10 == 0) {

--- a/src/vos/vos_aggregate.c
+++ b/src/vos/vos_aggregate.c
@@ -2087,15 +2087,19 @@ merge_window_init(struct agg_merge_window *mw, void (*func)(void *))
 	io->ic_csum_recalc_func = func;
 }
 
+struct agg_data {
+	vos_iter_param_t	ad_iter_param;
+	struct vos_agg_param	ad_agg_param;
+	struct vos_iter_anchors	ad_anchors;
+};
+
 int
 vos_aggregate(daos_handle_t coh, daos_epoch_range_t *epr,
 	      void (*csum_func)(void *),
 	      bool (*yield_func)(void *arg), void *yield_arg, bool full_scan)
 {
 	struct vos_container	*cont = vos_hdl2cont(coh);
-	vos_iter_param_t	 iter_param = { 0 };
-	struct vos_agg_param	 agg_param = { 0 };
-	struct vos_iter_anchors	 anchors = { 0 };
+	struct agg_data		*ad;
 	int			 rc;
 
 	D_ASSERT(epr != NULL);
@@ -2103,45 +2107,49 @@ vos_aggregate(daos_handle_t coh, daos_epoch_range_t *epr,
 		  "epr_lo:"DF_U64", epr_hi:"DF_U64"\n",
 		  epr->epr_lo, epr->epr_hi);
 
+	D_ALLOC_PTR(ad);
+	if (ad == NULL)
+		return -DER_NOMEM;
+
 	rc = aggregate_enter(cont, false, epr);
 	if (rc)
-		return rc;
+		goto free_agg_data;
 
 	/* Set iteration parameters */
-	iter_param.ip_hdl = coh;
-	iter_param.ip_epr = *epr;
+	ad->ad_iter_param.ip_hdl = coh;
+	ad->ad_iter_param.ip_epr = *epr;
 	/*
 	 * Iterate in epoch reserve order for SV tree, so that we can know for
 	 * sure the first returned recx in SV tree has highest epoch and can't
 	 * be aggregated.
 	 */
-	iter_param.ip_epc_expr = VOS_IT_EPC_RR;
+	ad->ad_iter_param.ip_epc_expr = VOS_IT_EPC_RR;
 	/* EV tree iterator returns all sorted logical rectangles */
-	iter_param.ip_flags = VOS_IT_PUNCHED | VOS_IT_RECX_VISIBLE |
+	ad->ad_iter_param.ip_flags = VOS_IT_PUNCHED | VOS_IT_RECX_VISIBLE |
 		VOS_IT_RECX_COVERED;
 
 	/* Set aggregation parameters */
-	agg_param.ap_umm = &cont->vc_pool->vp_umm;
-	agg_param.ap_coh = coh;
-	agg_param.ap_credits_max = VOS_AGG_CREDITS_MAX;
-	agg_param.ap_credits = 0;
-	agg_param.ap_discard = false;
-	agg_param.ap_yield_func = yield_func;
-	agg_param.ap_yield_arg = yield_arg;
-	merge_window_init(&agg_param.ap_window, csum_func);
+	ad->ad_agg_param.ap_umm = &cont->vc_pool->vp_umm;
+	ad->ad_agg_param.ap_coh = coh;
+	ad->ad_agg_param.ap_credits_max = VOS_AGG_CREDITS_MAX;
+	ad->ad_agg_param.ap_credits = 0;
+	ad->ad_agg_param.ap_discard = false;
+	ad->ad_agg_param.ap_yield_func = yield_func;
+	ad->ad_agg_param.ap_yield_arg = yield_arg;
+	merge_window_init(&ad->ad_agg_param.ap_window, csum_func);
 	/* A full scan caused by snapshot deletion */
-	agg_param.ap_full_scan = full_scan;
+	ad->ad_agg_param.ap_full_scan = full_scan;
 
-	iter_param.ip_flags |= VOS_IT_FOR_PURGE;
-	rc = vos_iterate(&iter_param, VOS_ITER_OBJ, true, &anchors,
+	ad->ad_iter_param.ip_flags |= VOS_IT_FOR_PURGE;
+	rc = vos_iterate(&ad->ad_iter_param, VOS_ITER_OBJ, true, &ad->ad_anchors,
 			 vos_aggregate_pre_cb, vos_aggregate_post_cb,
-			 &agg_param, NULL);
+			 &ad->ad_agg_param, NULL);
 	if (rc != 0) {
-		close_merge_window(&agg_param.ap_window, rc);
+		close_merge_window(&ad->ad_agg_param.ap_window, rc);
 		goto exit;
-	} else if (agg_param.ap_csum_err) {
+	} else if (ad->ad_agg_param.ap_csum_err) {
 		rc = -DER_CSUM;	/* Inform caller the csum error */
-		close_merge_window(&agg_param.ap_window, rc);
+		close_merge_window(&ad->ad_agg_param.ap_window, rc);
 		/* HAE needs be updated for csum error case */
 	}
 
@@ -2154,11 +2162,14 @@ vos_aggregate(daos_handle_t coh, daos_epoch_range_t *epr,
 exit:
 	aggregate_exit(cont, false);
 
-	if (agg_param.ap_window.mw_csum_support)
-		D_FREE(agg_param.ap_window.mw_io_ctxt.ic_csum_buf);
+	if (ad->ad_agg_param.ap_window.mw_csum_support)
+		D_FREE(ad->ad_agg_param.ap_window.mw_io_ctxt.ic_csum_buf);
 
-	if (merge_window_status(&agg_param.ap_window) != MW_CLOSED)
+	if (merge_window_status(&ad->ad_agg_param.ap_window) != MW_CLOSED)
 		D_ASSERTF(false, "Merge window resource leaked.\n");
+
+free_agg_data:
+	D_FREE(ad);
 
 	return rc;
 }
@@ -2168,9 +2179,7 @@ vos_discard(daos_handle_t coh, daos_epoch_range_t *epr,
 	    bool (*yield_func)(void *arg), void *yield_arg)
 {
 	struct vos_container	*cont = vos_hdl2cont(coh);
-	vos_iter_param_t	 iter_param = { 0 };
-	struct vos_agg_param	 agg_param = { 0 };
-	struct vos_iter_anchors	 anchors = { 0 };
+	struct agg_data		*ad;
 	int			 rc;
 
 	D_ASSERT(epr != NULL);
@@ -2178,40 +2187,48 @@ vos_discard(daos_handle_t coh, daos_epoch_range_t *epr,
 		  "epr_lo:"DF_U64", epr_hi:"DF_U64"\n",
 		  epr->epr_lo, epr->epr_hi);
 
+	D_ALLOC_PTR(ad);
+	if (ad == NULL)
+		return -DER_NOMEM;
+
 	rc = aggregate_enter(cont, true, epr);
 	if (rc != 0)
-		return rc;
+		goto free_agg_data;
 
 	D_DEBUG(DB_EPC, "Discard epr "DF_U64"-"DF_U64"\n",
 		epr->epr_lo, epr->epr_hi);
 
 	/* Set iteration parameters */
-	iter_param.ip_hdl = coh;
-	iter_param.ip_epr = *epr;
+	ad->ad_iter_param.ip_hdl = coh;
+	ad->ad_iter_param.ip_epr = *epr;
 	if (epr->epr_lo == epr->epr_hi)
-		iter_param.ip_epc_expr = VOS_IT_EPC_EQ;
+		ad->ad_iter_param.ip_epc_expr = VOS_IT_EPC_EQ;
 	else if (epr->epr_hi != DAOS_EPOCH_MAX)
-		iter_param.ip_epc_expr = VOS_IT_EPC_RR;
+		ad->ad_iter_param.ip_epc_expr = VOS_IT_EPC_RR;
 	else
-		iter_param.ip_epc_expr = VOS_IT_EPC_GE;
+		ad->ad_iter_param.ip_epc_expr = VOS_IT_EPC_GE;
 	/* EV tree iterator returns all sorted logical rectangles */
-	iter_param.ip_flags = VOS_IT_PUNCHED | VOS_IT_RECX_VISIBLE |
+	ad->ad_iter_param.ip_flags = VOS_IT_PUNCHED | VOS_IT_RECX_VISIBLE |
 		VOS_IT_RECX_COVERED;
 
 	/* Set aggregation parameters */
-	agg_param.ap_umm = &cont->vc_pool->vp_umm;
-	agg_param.ap_coh = coh;
-	agg_param.ap_credits_max = VOS_AGG_CREDITS_MAX;
-	agg_param.ap_credits = 0;
-	agg_param.ap_discard = true;
-	agg_param.ap_yield_func = yield_func;
-	agg_param.ap_yield_arg = yield_arg;
+	ad->ad_agg_param.ap_umm = &cont->vc_pool->vp_umm;
+	ad->ad_agg_param.ap_coh = coh;
+	ad->ad_agg_param.ap_credits_max = VOS_AGG_CREDITS_MAX;
+	ad->ad_agg_param.ap_credits = 0;
+	ad->ad_agg_param.ap_discard = true;
+	ad->ad_agg_param.ap_yield_func = yield_func;
+	ad->ad_agg_param.ap_yield_arg = yield_arg;
 
-	iter_param.ip_flags |= VOS_IT_FOR_PURGE;
-	rc = vos_iterate(&iter_param, VOS_ITER_OBJ, true, &anchors,
+	ad->ad_iter_param.ip_flags |= VOS_IT_FOR_PURGE;
+	rc = vos_iterate(&ad->ad_iter_param, VOS_ITER_OBJ, true, &ad->ad_anchors,
 			 vos_aggregate_pre_cb, vos_aggregate_post_cb,
-			 &agg_param, NULL);
+			 &ad->ad_agg_param, NULL);
 
 	aggregate_exit(cont, true);
+
+free_agg_data:
+	D_FREE(ad);
+
 	return rc;
 }

--- a/src/vos/vos_io.c
+++ b/src/vos/vos_io.c
@@ -955,7 +955,7 @@ akey_fetch_recx(daos_handle_t toh, const daos_epoch_range_t *epr,
 	/* At present, this is not exposed in interface but passing it toggles
 	 * sorting and clipping of rectangles
 	 */
-	struct evt_entry_array	 ent_array = { 0 };
+	EVT_ENT_ARRAY_LG_PTR(ent_array);
 	struct evt_filter	 filter;
 	struct bio_iov		 biov = {0};
 	daos_size_t		 holes; /* hole width */
@@ -964,6 +964,7 @@ akey_fetch_recx(daos_handle_t toh, const daos_epoch_range_t *epr,
 	daos_off_t		 end;
 	bool			 csum_enabled = false;
 	bool			 with_shadow = (shadow_ep != DAOS_EPOCH_MAX);
+	uint32_t		 inob;
 	int			 rc;
 
 	index = recx->rx_idx;
@@ -978,14 +979,15 @@ akey_fetch_recx(daos_handle_t toh, const daos_epoch_range_t *epr,
 	filter.fr_punch_minor_epc =
 		ioc->ic_akey_info.ii_prior_punch.pr_minor_epc;
 
-	evt_ent_array_init(&ent_array);
-	rc = evt_find(toh, &filter, &ent_array);
+	evt_ent_array_init(ent_array, 0);
+	rc = evt_find(toh, &filter, ent_array);
 	if (rc != 0 || vos_dtx_hit_inprogress())
 		D_GOTO(failed, rc = (rc == 0 ? -DER_INPROGRESS : rc));
 
 	holes = 0;
 	rsize = 0;
-	evt_ent_array_for_each(ent, &ent_array) {
+	inob = ent_array->ea_inob;
+	evt_ent_array_for_each(ent, ent_array) {
 		daos_off_t	 lo = ent->en_sel_ext.ex_lo;
 		daos_off_t	 hi = ent->en_sel_ext.ex_hi;
 		daos_size_t	 nr;
@@ -1012,12 +1014,12 @@ akey_fetch_recx(daos_handle_t toh, const daos_epoch_range_t *epr,
 		if (holes != 0) {
 			if (with_shadow) {
 				rc = save_recx(ioc, lo - holes, holes,
-					       shadow_ep, ent_array.ea_inob,
+					       shadow_ep, inob,
 					       DRT_SHADOW);
 				if (rc != 0)
 					goto failed;
 			}
-			biov_set_hole(&biov, holes * ent_array.ea_inob);
+			biov_set_hole(&biov, holes * inob);
 			/* skip the hole */
 			rc = iod_fetch(ioc, &biov);
 			if (rc != 0)
@@ -1026,17 +1028,17 @@ akey_fetch_recx(daos_handle_t toh, const daos_epoch_range_t *epr,
 		}
 
 		if (rsize == 0)
-			rsize = ent_array.ea_inob;
-		D_ASSERT(rsize == ent_array.ea_inob);
+			rsize = inob;
+		D_ASSERT(rsize == inob);
 
 		if (ioc->ic_save_recx) {
 			rc = save_recx(ioc, lo, nr, ent->en_epoch,
-				       ent_array.ea_inob, DRT_NORMAL);
+				       inob, DRT_NORMAL);
 			if (rc != 0)
 				goto failed;
 		}
-		bio_iov_set(&biov, ent->en_addr, nr * ent_array.ea_inob);
-		ioc->ic_io_size += nr * ent_array.ea_inob;
+		bio_iov_set(&biov, ent->en_addr, nr * inob);
+		ioc->ic_io_size += nr * inob;
 		if (ci_is_valid(&ent->en_csum)) {
 			rc = save_csum(ioc, &ent->en_csum, ent, rsize);
 			if (rc != 0)
@@ -1064,11 +1066,11 @@ akey_fetch_recx(daos_handle_t toh, const daos_epoch_range_t *epr,
 	if (holes != 0) { /* trailing holes */
 		if (with_shadow) {
 			rc = save_recx(ioc, end - holes, holes, shadow_ep,
-				       ent_array.ea_inob, DRT_SHADOW);
+				       inob, DRT_SHADOW);
 			if (rc != 0)
 				goto failed;
 		}
-		biov_set_hole(&biov, holes * ent_array.ea_inob);
+		biov_set_hole(&biov, holes * inob);
 		rc = iod_fetch(ioc, &biov);
 		if (rc != 0)
 			goto failed;
@@ -1076,7 +1078,7 @@ akey_fetch_recx(daos_handle_t toh, const daos_epoch_range_t *epr,
 	if (rsize_p && *rsize_p == 0)
 		*rsize_p = rsize;
 failed:
-	evt_ent_array_fini(&ent_array);
+	evt_ent_array_fini(ent_array);
 	return rc;
 }
 

--- a/src/vos/vos_io.c
+++ b/src/vos/vos_io.c
@@ -21,6 +21,7 @@
 
 /** I/O context */
 struct vos_io_context {
+	EVT_ENT_ARRAY_LG_PTR(ic_ent_array);
 	/** The epoch bound including uncertainty */
 	daos_epoch_t		 ic_bound;
 	daos_epoch_range_t	 ic_epr;
@@ -955,7 +956,6 @@ akey_fetch_recx(daos_handle_t toh, const daos_epoch_range_t *epr,
 	/* At present, this is not exposed in interface but passing it toggles
 	 * sorting and clipping of rectangles
 	 */
-	EVT_ENT_ARRAY_LG_PTR(ent_array);
 	struct evt_filter	 filter;
 	struct bio_iov		 biov = {0};
 	daos_size_t		 holes; /* hole width */
@@ -979,15 +979,15 @@ akey_fetch_recx(daos_handle_t toh, const daos_epoch_range_t *epr,
 	filter.fr_punch_minor_epc =
 		ioc->ic_akey_info.ii_prior_punch.pr_minor_epc;
 
-	evt_ent_array_init(ent_array, 0);
-	rc = evt_find(toh, &filter, ent_array);
+	evt_ent_array_init(ioc->ic_ent_array, 0);
+	rc = evt_find(toh, &filter, ioc->ic_ent_array);
 	if (rc != 0 || vos_dtx_hit_inprogress())
 		D_GOTO(failed, rc = (rc == 0 ? -DER_INPROGRESS : rc));
 
 	holes = 0;
 	rsize = 0;
-	inob = ent_array->ea_inob;
-	evt_ent_array_for_each(ent, ent_array) {
+	inob = ioc->ic_ent_array->ea_inob;
+	evt_ent_array_for_each(ent, ioc->ic_ent_array) {
 		daos_off_t	 lo = ent->en_sel_ext.ex_lo;
 		daos_off_t	 hi = ent->en_sel_ext.ex_hi;
 		daos_size_t	 nr;
@@ -1078,7 +1078,7 @@ akey_fetch_recx(daos_handle_t toh, const daos_epoch_range_t *epr,
 	if (rsize_p && *rsize_p == 0)
 		*rsize_p = rsize;
 failed:
-	evt_ent_array_fini(ent_array);
+	evt_ent_array_fini(ioc->ic_ent_array);
 	return rc;
 }
 

--- a/src/vos/vos_iterator.c
+++ b/src/vos/vos_iterator.c
@@ -800,8 +800,13 @@ vos_iterate_key(struct vos_object *obj, daos_handle_t toh, vos_iter_type_t type,
 		const daos_epoch_range_t *epr, bool ignore_inprogress,
 		vos_iter_cb_t cb, void *arg, struct dtx_handle *dth)
 {
+	struct vos_iter_anchors	*anchors = NULL;
 	vos_iter_param_t	 param = {0};
-	struct vos_iter_anchors	 anchors = {0};
+	int			 rc;
+
+	D_ALLOC_PTR(anchors);
+	if (anchors == NULL)
+		return -DER_NOMEM;
 
 	D_ASSERT(type == VOS_ITER_DKEY || type == VOS_ITER_AKEY);
 	D_ASSERT(daos_handle_is_valid(toh));
@@ -812,9 +817,12 @@ vos_iterate_key(struct vos_object *obj, daos_handle_t toh, vos_iter_type_t type,
 	param.ip_flags = VOS_IT_KEY_TREE;
 	param.ip_dkey.iov_buf = obj;
 
+	rc = vos_iterate_internal(&param, type, false, ignore_inprogress,
+				  anchors, cb, NULL, arg, dth);
 
-	return vos_iterate_internal(&param, type, false, ignore_inprogress,
-				    &anchors, cb, NULL, arg, dth);
+	D_FREE(anchors);
+
+	return rc;
 }
 
 /**

--- a/src/vos/vos_obj.c
+++ b/src/vos/vos_obj.c
@@ -824,7 +824,7 @@ key_iter_match_probe(struct vos_obj_iter *oiter)
 	int	rc;
 
 	while (1) {
-		vos_iter_entry_t	entry;
+		static __thread vos_iter_entry_t	entry;
 
 		rc = key_iter_match(oiter, &entry);
 		switch (rc) {

--- a/src/vos/vos_obj.c
+++ b/src/vos/vos_obj.c
@@ -130,6 +130,12 @@ vos_propagate_check(struct vos_object *obj, daos_handle_t toh,
 	return rc;
 }
 
+struct key_ilog_info {
+	struct vos_ilog_info	ki_obj;
+	struct vos_ilog_info	ki_dkey;
+	struct vos_ilog_info	ki_akey;
+};
+
 /**
  * @} vos_tree_helper
  */
@@ -141,24 +147,26 @@ key_punch(struct vos_object *obj, daos_epoch_t epoch, daos_epoch_t bound,
 	struct vos_krec_df	*krec;
 	struct vos_rec_bundle	 rbund;
 	struct dcs_csum_info	 csum;
-	struct vos_ilog_info	 obj_info = {0};
-	struct vos_ilog_info	 dkey_info = {0};
-	struct vos_ilog_info	 akey_info = {0};
+	struct key_ilog_info	*info;
 	daos_epoch_range_t	 epr = {0, epoch};
 	d_iov_t			 riov;
 	daos_handle_t		 toh = DAOS_HDL_INVAL;
 	int			 i;
 	int			 rc;
 
-	vos_ilog_fetch_init(&obj_info);
-	vos_ilog_fetch_init(&dkey_info);
-	vos_ilog_fetch_init(&akey_info);
+	D_ALLOC_PTR(info);
+	if (info == NULL)
+		return -DER_NOMEM;
+
+	vos_ilog_fetch_init(&info->ki_obj);
+	vos_ilog_fetch_init(&info->ki_dkey);
+	vos_ilog_fetch_init(&info->ki_akey);
 	rc = obj_tree_init(obj);
 	if (rc)
 		D_GOTO(out, rc);
 
 	rc = vos_ilog_punch(obj->obj_cont, &obj->obj_df->vo_ilog, &epr, bound,
-			    NULL, &obj_info, ts_set, false, false);
+			    NULL, &info->ki_obj, ts_set, false, false);
 	if (rc)
 		D_GOTO(out, rc);
 
@@ -181,7 +189,7 @@ key_punch(struct vos_object *obj, daos_epoch_t epoch, daos_epoch_t bound,
 	}
 
 	rc = vos_ilog_punch(obj->obj_cont, &krec->kr_ilog, &epr, bound,
-			    &obj_info, &dkey_info, ts_set, false,
+			    &info->ki_obj, &info->ki_dkey, ts_set, false,
 			    false);
 	if (rc)
 		D_GOTO(out, rc);
@@ -195,8 +203,8 @@ key_punch(struct vos_object *obj, daos_epoch_t epoch, daos_epoch_t bound,
 	for (i = 0; i < akey_nr; i++) {
 		rbund.rb_iov = &akeys[i];
 		rc = key_tree_punch(obj, toh, epoch, bound, &akeys[i], &riov,
-				    flags, ts_set, &dkey_info,
-				    &akey_info);
+				    flags, ts_set, &info->ki_dkey,
+				    &info->ki_akey);
 		if (rc != 0) {
 			VOS_TX_LOG_FAIL(rc, "Failed to punch akey: rc="
 					DF_RC"\n", DP_RC(rc));
@@ -219,7 +227,7 @@ punch_dkey:
 	rbund.rb_tclass	= VOS_BTR_DKEY;
 
 	rc = key_tree_punch(obj, obj->obj_toh, epoch, bound, dkey, &riov,
-			    flags, ts_set, &obj_info, &dkey_info);
+			    flags, ts_set, &info->ki_obj, &info->ki_dkey);
 	if (rc != 0)
 		D_GOTO(out, rc);
 
@@ -229,12 +237,14 @@ punch_dkey:
 					 &epr, VOS_ITER_DKEY);
 	}
  out:
-	vos_ilog_fetch_finish(&obj_info);
-	vos_ilog_fetch_finish(&dkey_info);
-	vos_ilog_fetch_finish(&akey_info);
+	vos_ilog_fetch_finish(&info->ki_obj);
+	vos_ilog_fetch_finish(&info->ki_dkey);
+	vos_ilog_fetch_finish(&info->ki_akey);
 
 	if (daos_handle_is_valid(toh))
 		key_tree_release(toh, 0);
+
+	D_FREE(info);
 
 	return rc;
 }
@@ -245,13 +255,16 @@ obj_punch(daos_handle_t coh, struct vos_object *obj, daos_epoch_t epoch,
 {
 	struct daos_lru_cache	*occ  = vos_obj_cache_current();
 	struct vos_container	*cont;
-	struct vos_ilog_info	 info;
+	struct vos_ilog_info	*info;
 	int			 rc;
 
-	vos_ilog_fetch_init(&info);
+	D_ALLOC_PTR(info);
+	if (info == NULL)
+		return -DER_NOMEM;
+	vos_ilog_fetch_init(info);
 	cont = vos_hdl2cont(coh);
 	rc = vos_oi_punch(cont, obj->obj_id, epoch, bound, flags, obj->obj_df,
-			  &info, ts_set);
+			  info, ts_set);
 	if (rc)
 		D_GOTO(failed, rc);
 
@@ -260,7 +273,8 @@ obj_punch(daos_handle_t coh, struct vos_object *obj, daos_epoch_t epoch,
 	 */
 	vos_obj_evict(occ, obj);
 failed:
-	vos_ilog_fetch_finish(&info);
+	vos_ilog_fetch_finish(info);
+	D_FREE(info);
 	return rc;
 }
 


### PR DESCRIPTION
Move larger data structures to heap since ABT stacks are small

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>