### PR TITLE
DAOS-7879 sched: use sched_ult_attr_deep_stack for obj update

### DIFF
--- a/src/engine/sched.c
+++ b/src/engine/sched.c
@@ -13,6 +13,8 @@
 #include <daos_srv/vos.h>
 #include "srv_internal.h"
 
+ABT_thread_attr sched_ult_attr_deep_stack = ABT_THREAD_ATTR_NULL;
+
 struct sched_req_info {
 	d_list_t		sri_req_list;
 	/* Total request count in 'sri_req_list' */
@@ -554,11 +556,14 @@ static inline int
 req_kickoff_internal(struct dss_xstream *dx, struct sched_req_attr *attr,
 		     void (*func)(void *), void *arg)
 {
+	ABT_thread_attr		abt_attr = ABT_THREAD_ATTR_NULL;
+
 	D_ASSERT(attr && func && arg);
 	D_ASSERT(attr->sra_type < SCHED_REQ_MAX);
+	if (attr->sra_type == SCHED_REQ_UPDATE)
+		abt_attr = sched_ult_attr_deep_stack;
 
-	return sched_create_thread(dx, func, arg, ABT_THREAD_ATTR_NULL, NULL,
-				   0);
+	return sched_create_thread(dx, func, arg, abt_attr, NULL, 0);
 }
 
 static int

--- a/src/engine/srv.c
+++ b/src/engine/srv.c
@@ -1152,6 +1152,9 @@ dss_srv_fini(bool force)
 			D_FREE(xstream_data.xd_xs_ptrs);
 		D_DEBUG(DB_TRACE, "Finalized everything\n");
 	}
+
+	if (sched_ult_attr_deep_stack != ABT_THREAD_ATTR_NULL)
+		ABT_thread_attr_free(&sched_ult_attr_deep_stack);
 	return 0;
 }
 
@@ -1232,6 +1235,20 @@ dss_srv_init(void)
 	if (rc != 0)
 		D_GOTO(failed, rc);
 	xstream_data.xd_init_step = XD_INIT_DRPC;
+
+	/* init the global ABT_thread_attr */
+	rc = ABT_thread_attr_create(&sched_ult_attr_deep_stack);
+	if (rc != ABT_SUCCESS) {
+		D_ERROR("Create ABT thread attr failed. %d\n", rc);
+		D_GOTO(failed, rc = dss_abterr2der(rc));
+	}
+
+	rc = ABT_thread_attr_set_stacksize(sched_ult_attr_deep_stack,
+					   DSS_DEEP_STACK_SZ);
+	if (rc != ABT_SUCCESS) {
+		D_ERROR("Set ABT stack size failed. %d\n", rc);
+		D_GOTO(failed, rc = dss_abterr2der(rc));
+	}
 
 	return 0;
 failed:

--- a/src/engine/srv_internal.h
+++ b/src/engine/srv_internal.h
@@ -185,6 +185,7 @@ extern unsigned int sched_stats_intvl;
 extern unsigned int sched_relax_intvl;
 extern unsigned int sched_relax_mode;
 extern unsigned int sched_unit_runtime_max;
+extern ABT_thread_attr sched_ult_attr_deep_stack;
 
 void dss_sched_fini(struct dss_xstream *dx);
 int dss_sched_init(struct dss_xstream *dx);


### PR DESCRIPTION
Hit ABT stack overflow in obj update handling, create global
sched_ult_attr_deep_stack and use it for obj update, to avoid
use deep stack for all RPCs.

Signed-off-by: Xuezhao Liu <xuezhao.liu@intel.com>