### PR TITLE
DAOS-7930 dtx: reduce the size of committed DTX entry

### DIFF
--- a/src/dtx/dtx_internal.h
+++ b/src/dtx/dtx_internal.h
@@ -103,7 +103,7 @@ void dtx_batched_commit(void *arg);
 /* dtx_cos.c */
 int dtx_fetch_committable(struct ds_cont_child *cont, uint32_t max_cnt,
 			  daos_unit_oid_t *oid, daos_epoch_t epoch,
-			  struct dtx_entry ***dtes);
+			  struct dtx_entry ***dtes, struct dtx_cos_key **dcks);
 int dtx_add_cos(struct ds_cont_child *cont, struct dtx_entry *dte,
 		daos_unit_oid_t *oid, uint64_t dkey_hash,
 		daos_epoch_t epoch, uint32_t flags);
@@ -113,7 +113,7 @@ uint64_t dtx_cos_oldest(struct ds_cont_child *cont);
 
 /* dtx_rpc.c */
 int dtx_commit(struct ds_cont_child *cont, struct dtx_entry **dtes,
-	       int count, bool drop_cos);
+	       struct dtx_cos_key *dcks, int count);
 int dtx_check(struct ds_cont_child *cont, struct dtx_entry *dte,
 	      daos_epoch_t epoch);
 

--- a/src/dtx/dtx_resync.c
+++ b/src/dtx/dtx_resync.c
@@ -22,6 +22,7 @@ struct dtx_resync_entry {
 	d_list_t		dre_link;
 	daos_epoch_t		dre_epoch;
 	daos_unit_oid_t		dre_oid;
+	uint64_t		dre_dkey_hash;
 	struct dtx_entry	dre_dte;
 };
 
@@ -54,16 +55,23 @@ dtx_resync_commit(struct ds_cont_child *cont,
 		  struct dtx_resync_head *drh, int count)
 {
 	struct dtx_resync_entry		 *dre;
-	struct dtx_entry		**dte = NULL;
+	struct dtx_entry		**dtes = NULL;
+	struct dtx_cos_key		 *dcks = NULL;
 	int				  rc = 0;
 	int				  i = 0;
 	int				  j = 0;
 
 	D_ASSERT(drh->drh_count >= count);
 
-	D_ALLOC_ARRAY(dte, count);
-	if (dte == NULL)
+	D_ALLOC_ARRAY(dtes, count);
+	if (dtes == NULL)
 		return -DER_NOMEM;
+
+	D_ALLOC_ARRAY(dcks, count);
+	if (dcks == NULL) {
+		D_FREE(dtes);
+		return -DER_NOMEM;
+	}
 
 	for (i = 0; i < count; i++) {
 		dre = d_list_entry(drh->drh_list.next,
@@ -74,7 +82,7 @@ dtx_resync_commit(struct ds_cont_child *cont,
 		 * DTXs. So double check the status before current commit.
 		 */
 		rc = vos_dtx_check(cont->sc_hdl, &dre->dre_xid,
-				   NULL, NULL, NULL, false);
+				   NULL, NULL, NULL, NULL, false);
 
 		/* Skip this DTX since it has been committed or aggregated. */
 		if (rc == DTX_ST_COMMITTED || rc == DTX_ST_COMMITTABLE ||
@@ -85,22 +93,25 @@ dtx_resync_commit(struct ds_cont_child *cont,
 		 * not committed, then commit it (again), that is harmless.
 		 */
 
-		dte[j++] = dtx_entry_get(&dre->dre_dte);
+		dtes[j] = dtx_entry_get(&dre->dre_dte);
+		dcks[j].oid = dre->dre_oid;
+		dcks[j].dkey_hash = dre->dre_dkey_hash;
+		j++;
 
 next:
 		dtx_dre_release(drh, dre);
 	}
 
 	if (j > 0) {
-		rc = dtx_commit(cont, dte, j, true);
+		rc = dtx_commit(cont, dtes, dcks, j);
 		if (rc < 0)
 			D_ERROR("Failed to commit the DTXs: rc = "DF_RC"\n",
 				DP_RC(rc));
 
 		for (i = 0; i < j; i++) {
-			D_ASSERT(dte[i]->dte_refs == 1);
+			D_ASSERT(dtes[i]->dte_refs == 1);
 
-			dre = d_list_entry(dte[i], struct dtx_resync_entry,
+			dre = d_list_entry(dtes[i], struct dtx_resync_entry,
 					   dre_dte);
 			D_FREE(dre);
 		}
@@ -108,7 +119,8 @@ next:
 		rc = 0;
 	}
 
-	D_FREE(dte);
+	D_FREE(dtes);
+	D_FREE(dcks);
 	return rc;
 }
 
@@ -272,7 +284,7 @@ dtx_status_handle_one(struct ds_cont_child *cont, struct dtx_entry *dte,
 		 * DTXs. So double check the status before next action.
 		 */
 		rc = vos_dtx_check(cont->sc_hdl, &dte->dte_xid,
-				   NULL, NULL, NULL, false);
+				   NULL, NULL, NULL, NULL, false);
 
 		/* Skip this DTX that it may has been committed or aborted. */
 		if (rc == DTX_ST_COMMITTED || rc == DTX_ST_COMMITTABLE ||
@@ -480,6 +492,7 @@ dtx_iter_cb(uuid_t co_uuid, vos_iter_entry_t *ent, void *args)
 
 	dre->dre_epoch = ent->ie_epoch;
 	dre->dre_oid = ent->ie_dtx_oid;
+	dre->dre_dkey_hash = ent->ie_dkey_hash;
 
 	dte = &dre->dre_dte;
 	mbs = (struct dtx_memberships *)(dte + 1);

--- a/src/dtx/dtx_rpc.c
+++ b/src/dtx/dtx_rpc.c
@@ -581,13 +581,13 @@ dtx_dti_classify(struct ds_pool *pool, daos_handle_t tree,
  */
 int
 dtx_commit(struct ds_cont_child *cont, struct dtx_entry **dtes,
-	   int count, bool drop_cos)
+	   struct dtx_cos_key *dcks, int count)
 {
 	struct dtx_req_args	 dra;
 	struct dtx_req_rec	*drr;
 	struct ds_pool		*pool = cont->sc_pool->spc_pool;
 	struct dtx_id		*dti = NULL;
-	struct dtx_cos_key	*dcks = NULL;
+	bool			*rm_cos = NULL;
 	struct umem_attr	 uma;
 	struct btr_root		 tree_root = { 0 };
 	daos_handle_t		 tree_hdl = DAOS_HDL_INVAL;
@@ -618,25 +618,27 @@ dtx_commit(struct ds_cont_child *cont, struct dtx_entry **dtes,
 			goto out;
 	}
 
-	if (drop_cos) {
-		D_ALLOC_ARRAY(dcks, count);
-		if (dcks == NULL)
+	if (dcks != NULL) {
+		D_ALLOC_ARRAY(rm_cos, count);
+		if (rm_cos == NULL)
 			D_GOTO(out, rc1 = -DER_NOMEM);
 	}
 
-	rc1 = vos_dtx_commit(cont->sc_hdl, dti, count, dcks);
-
-	if (rc1 >= 0 && drop_cos) {
+	rc1 = vos_dtx_commit(cont->sc_hdl, dti, count, rm_cos);
+	if (rc1 >= 0 && rm_cos != NULL) {
 		int	i;
 
 		for (i = 0; i < count; i++) {
-			if (!daos_oid_is_null(dcks[i].oid.id_pub))
+			if (rm_cos[i]) {
+				D_ASSERT(!daos_oid_is_null(dcks[i].oid.id_pub));
+
 				dtx_del_cos(cont, &dti[i], &dcks[i].oid,
 					    dcks[i].dkey_hash);
+			}
 		}
 	}
 
-	D_FREE(dcks);
+	D_FREE(rm_cos);
 
 	/* -DER_NONEXIST may be caused by race or repeated commit, ignore it. */
 	if (rc1 == -DER_NONEXIST)
@@ -977,7 +979,7 @@ next:
 
 	/* Handle the entries whose leaders are on current server. */
 	d_list_for_each_entry_safe(dsp, tmp, &self, dsp_link) {
-		struct dtx_entry	 dte;
+		struct dtx_entry	dte;
 
 		d_list_del(&dsp->dsp_link);
 
@@ -991,8 +993,11 @@ next:
 		switch (rc) {
 		case DSHR_NEED_COMMIT: {
 			struct dtx_entry	*pdte = &dte;
+			struct dtx_cos_key	 dck;
 
-			rc = dtx_commit(cont, &pdte, 1, true);
+			dck.oid = dsp->dsp_oid;
+			dck.dkey_hash = dsp->dsp_dkey_hash;
+			rc = dtx_commit(cont, &pdte, &dck, 1);
 			if (rc < 0 && rc != -DER_NONEXIST && cmt_list != NULL)
 				d_list_add_tail(&dsp->dsp_link, cmt_list);
 			else

--- a/src/dtx/dtx_srv.c
+++ b/src/dtx/dtx_srv.c
@@ -92,6 +92,7 @@ dtx_handler(crt_rpc_t *rpc)
 	struct ds_cont_child	*cont = NULL;
 	struct dtx_id		*dtis;
 	struct dtx_memberships	*mbs[DTX_REFRESH_MAX] = { 0 };
+	struct dtx_cos_key	 dcks[DTX_REFRESH_MAX] = { 0 };
 	uint32_t		 vers[DTX_REFRESH_MAX] = { 0 };
 	uint32_t		 opc = opc_get(rpc->cr_opc);
 	int			 count = DTX_YIELD_CYCLE;
@@ -148,7 +149,7 @@ dtx_handler(crt_rpc_t *rpc)
 			D_GOTO(out, rc = -DER_PROTO);
 
 		rc = vos_dtx_check(cont->sc_hdl, din->di_dtx_array.ca_arrays,
-				   NULL, NULL, NULL, false);
+				   NULL, NULL, NULL, NULL, false);
 		if (rc == -DER_NONEXIST && cont->sc_dtx_reindex)
 			rc = -DER_INPROGRESS;
 
@@ -172,7 +173,7 @@ dtx_handler(crt_rpc_t *rpc)
 
 			dtis = (struct dtx_id *)din->di_dtx_array.ca_arrays + i;
 			*ptr = vos_dtx_check(cont->sc_hdl, dtis, NULL, &vers[i],
-					     &mbs[i], false);
+					     &mbs[i], &dcks[i], false);
 			/* The DTX status may be changes by DTX resync soon. */
 			if ((*ptr == DTX_ST_PREPARED &&
 			     cont->sc_dtx_resyncing) ||
@@ -218,6 +219,7 @@ out:
 			dtes[j].dte_mbs = mbs[i];
 
 			pdte[j] = &dtes[j];
+			dcks[j] = dcks[i];
 			j++;
 		}
 
@@ -226,7 +228,7 @@ out:
 		/* Commit the DTX after replied the original refresh request to
 		 * avoid further query the same DTX.
 		 */
-		rc = dtx_commit(cont, pdte, j, true);
+		rc = dtx_commit(cont, pdte, dcks, j);
 		if (rc < 0)
 			D_WARN("Failed to commit DTX "DF_DTI", count %d: "
 			       DF_RC"\n", DP_DTI(&dtes[0].dte_xid), j,

--- a/src/include/daos_srv/dtx_srv.h
+++ b/src/include/daos_srv/dtx_srv.h
@@ -21,6 +21,7 @@ struct dtx_share_peer {
 	struct dtx_id		dsp_xid;
 	daos_unit_oid_t		dsp_oid;
 	daos_epoch_t		dsp_epoch;
+	uint64_t		dsp_dkey_hash;
 	struct dtx_memberships	dsp_mbs;
 };
 

--- a/src/include/daos_srv/vos.h
+++ b/src/include/daos_srv/vos.h
@@ -66,7 +66,8 @@ vos_dtx_validation(struct dtx_handle *dth);
  *				 if the DTX exists, then the DTX's epoch will
  *				 be saved in it.
  * \param pm_ver	[OUT]	Hold the DTX's pool map version.
- * \param mbs		[OUT	Pointer to the DTX participants information.]
+ * \param mbs		[OUT]	Pointer to the DTX participants information.
+ * \param dck		[OUT]	Pointer to the key for CoS cache.
  * \param for_resent	[IN]	The check is for check resent or not.
  *
  * \return		DTX_ST_PREPARED	means that the DTX has been 'prepared',
@@ -85,7 +86,8 @@ vos_dtx_validation(struct dtx_handle *dth);
  */
 int
 vos_dtx_check(daos_handle_t coh, struct dtx_id *dti, daos_epoch_t *epoch,
-	      uint32_t *pm_ver, struct dtx_memberships **mbs, bool for_resent);
+	      uint32_t *pm_ver, struct dtx_memberships **mbs,
+	      struct dtx_cos_key *dck, bool for_resent);
 
 /**
  * Commit the specified DTXs.
@@ -93,15 +95,14 @@ vos_dtx_check(daos_handle_t coh, struct dtx_id *dti, daos_epoch_t *epoch,
  * \param coh	[IN]	Container open handle.
  * \param dtis	[IN]	The array for DTX identifiers to be committed.
  * \param count [IN]	The count of DTXs to be committed.
- * \param dcks	[OUT]	The array to hold the OID and dkey hash corresponding to
- *			the committed DTXs array for subsequent CoS handling.
+ * \param rm_cos [OUT]	The array for whether remove entry from CoS cache.
  *
  * \return		Negative value if error.
  * \return		Others are for the count of committed DTXs.
  */
 int
 vos_dtx_commit(daos_handle_t coh, struct dtx_id *dtis, int count,
-	       struct dtx_cos_key *dcks);
+	       bool *rm_cos);
 
 /**
  * Abort the specified DTXs.

--- a/src/include/daos_srv/vos_types.h
+++ b/src/include/daos_srv/vos_types.h
@@ -433,6 +433,8 @@ typedef struct {
 			uint32_t		ie_dtx_mbs_dsize;
 			/* The time when create the DTX entry. */
 			uint64_t		ie_dtx_start_time;
+			/* The hashed dkey if applicable. */
+			uint64_t		ie_dkey_hash;
 			/** DTX participants information. */
 			void			*ie_dtx_mbs;
 		};

--- a/src/vos/tests/vts_dtx.c
+++ b/src/vos/tests/vts_dtx.c
@@ -826,7 +826,7 @@ dtx_18(void **state)
 
 	for (i = 0; i < 10; i++) {
 		rc = vos_dtx_check(args->ctx.tc_co_hdl, &xid[i],
-				   NULL, NULL, NULL, false);
+				   NULL, NULL, NULL, NULL, false);
 		assert_rc_equal(rc, DTX_ST_COMMITTED);
 	}
 
@@ -838,7 +838,7 @@ dtx_18(void **state)
 
 	for (i = 0; i < 10; i++) {
 		rc = vos_dtx_check(args->ctx.tc_co_hdl, &xid[i],
-				   NULL, NULL, NULL, false);
+				   NULL, NULL, NULL, NULL, false);
 		assert_rc_equal(rc, -DER_NONEXIST);
 	}
 

--- a/src/vos/vos_dtx.c
+++ b/src/vos/vos_dtx.c
@@ -180,6 +180,7 @@ dtx_inprogress(struct vos_dtx_act_ent *dae, struct dtx_handle *dth,
 	dsp->dsp_xid = DAE_XID(dae);
 	dsp->dsp_oid = DAE_OID(dae);
 	dsp->dsp_epoch = DAE_EPOCH(dae);
+	dsp->dsp_dkey_hash = DAE_DKEY_HASH(dae);
 
 	mbs = &dsp->dsp_mbs;
 	mbs->dm_tgt_cnt = DAE_TGT_CNT(dae);
@@ -777,8 +778,7 @@ dtx_rec_release(struct vos_container *cont, struct vos_dtx_act_ent *dae,
 static int
 vos_dtx_commit_one(struct vos_container *cont, struct dtx_id *dti,
 		   daos_epoch_t epoch, struct vos_dtx_cmt_ent **dce_p,
-		   struct dtx_cos_key *dck, struct vos_dtx_act_ent **dae_p,
-		   bool *fatal)
+		   struct vos_dtx_act_ent **dae_p, bool *rm_cos, bool *fatal)
 {
 	struct vos_dtx_act_ent		*dae = NULL;
 	struct vos_dtx_cmt_ent		*dce = NULL;
@@ -806,11 +806,7 @@ vos_dtx_commit_one(struct vos_container *cont, struct dtx_id *dti,
 					D_GOTO(out, rc = -DER_NONEXIST);
 				}
 
-				if (dck != NULL) {
-					dck->oid = DCE_OID(dce);
-					dck->dkey_hash = DCE_DKEY_HASH(dce);
-					dce = NULL;
-				}
+				dce = NULL;
 			}
 
 			goto out;
@@ -830,11 +826,6 @@ vos_dtx_commit_one(struct vos_container *cont, struct dtx_id *dti,
 		 * from the active table, just remove it again.
 		 */
 		if (dae->dae_committed) {
-			if (dck != NULL) {
-				dck->oid = DAE_OID(dae);
-				dck->dkey_hash = DAE_DKEY_HASH(dae);
-			}
-
 			rc = dbtree_delete(cont->vc_dtx_active_hdl,
 					   BTR_PROBE_BYPASS, &kiov, &dae);
 			if (rc == 0) {
@@ -851,8 +842,7 @@ vos_dtx_commit_one(struct vos_container *cont, struct dtx_id *dti,
 		D_GOTO(out, rc = -DER_NOMEM);
 
 	if (dae != NULL) {
-		memcpy(&dce->dce_base.dce_common, &dae->dae_base.dae_common,
-		       sizeof(dce->dce_base.dce_common));
+		DCE_XID(dce) = DAE_XID(dae);
 		DCE_EPOCH(dce) = dae->dae_start_time;
 	} else {
 		struct dtx_handle	*dth = vos_dth_get();
@@ -861,8 +851,6 @@ vos_dtx_commit_one(struct vos_container *cont, struct dtx_id *dti,
 
 		DCE_XID(dce) = *dti;
 		DCE_EPOCH(dce) = crt_hlc_get();
-		DCE_OID(dce) = dth->dth_leader_oid;
-		DCE_DKEY_HASH(dce) = dth->dth_dkey_hash;
 	}
 
 	d_iov_set(&riov, dce, sizeof(*dce));
@@ -883,11 +871,6 @@ vos_dtx_commit_one(struct vos_container *cont, struct dtx_id *dti,
 		goto out;
 	}
 
-	if (dck != NULL) {
-		dck->oid = DAE_OID(dae);
-		dck->dkey_hash = DAE_DKEY_HASH(dae);
-	}
-
 	D_ASSERT(dae_p != NULL);
 	*dae_p = dae;
 
@@ -897,6 +880,9 @@ out:
 		 DP_DTI(dti), DP_RC(rc));
 	if (rc != 0)
 		D_FREE(dce);
+
+	if (rm_cos != NULL && (rc == 0 || rc == -DER_NONEXIST))
+		*rm_cos = true;
 
 	return rc;
 }
@@ -1810,7 +1796,8 @@ vos_dtx_pack_mbs(struct umem_instance *umm, struct vos_dtx_act_ent *dae)
 
 int
 vos_dtx_check(daos_handle_t coh, struct dtx_id *dti, daos_epoch_t *epoch,
-	      uint32_t *pm_ver, struct dtx_memberships **mbs, bool for_resent)
+	      uint32_t *pm_ver, struct dtx_memberships **mbs,
+	      struct dtx_cos_key *dck, bool for_resent)
 {
 	struct vos_container	*cont;
 	struct vos_dtx_act_ent	*dae;
@@ -1832,6 +1819,11 @@ vos_dtx_check(daos_handle_t coh, struct dtx_id *dti, daos_epoch_t *epoch,
 
 		if (pm_ver != NULL)
 			*pm_ver = DAE_VER(dae);
+
+		if (dck != NULL) {
+			dck->oid = DAE_OID(dae);
+			dck->dkey_hash = DAE_DKEY_HASH(dae);
+		}
 
 		if (dae->dae_committed)
 			return DTX_ST_COMMITTED;
@@ -1888,7 +1880,7 @@ vos_dtx_check(daos_handle_t coh, struct dtx_id *dti, daos_epoch_t *epoch,
 
 int
 vos_dtx_commit_internal(struct vos_container *cont, struct dtx_id *dtis,
-			int count, daos_epoch_t epoch, struct dtx_cos_key *dcks,
+			int count, daos_epoch_t epoch, bool *rm_cos,
 			struct vos_dtx_act_ent **daes,
 			struct vos_dtx_cmt_ent **dces)
 {
@@ -1926,8 +1918,8 @@ again:
 		struct vos_dtx_cmt_ent	*dce = NULL;
 
 		rc = vos_dtx_commit_one(cont, &dtis[cur], epoch, &dce,
-					dcks != NULL ? &dcks[cur] : NULL,
 					daes != NULL ? &daes[cur] : NULL,
+					rm_cos != NULL ? &rm_cos[cur] : NULL,
 					&fatal);
 		if (dces != NULL)
 			dces[cur] = dce;
@@ -2074,8 +2066,7 @@ vos_dtx_post_handle(struct vos_container *cont, struct vos_dtx_act_ent **daes,
 }
 
 int
-vos_dtx_commit(daos_handle_t coh, struct dtx_id *dtis, int count,
-	       struct dtx_cos_key *dcks)
+vos_dtx_commit(daos_handle_t coh, struct dtx_id *dtis, int count, bool *rm_cos)
 {
 	struct vos_dtx_act_ent	**daes = NULL;
 	struct vos_dtx_cmt_ent	**dces = NULL;
@@ -2100,7 +2091,7 @@ vos_dtx_commit(daos_handle_t coh, struct dtx_id *dtis, int count,
 	rc = umem_tx_begin(vos_cont2umm(cont), NULL);
 	if (rc == 0) {
 		committed = vos_dtx_commit_internal(cont, dtis, count,
-						    0, dcks, daes, dces);
+						    0, rm_cos, daes, dces);
 		rc = umem_tx_end(vos_cont2umm(cont),
 				 committed > 0 ? 0 : committed);
 		if (rc == 0)

--- a/src/vos/vos_dtx_iter.c
+++ b/src/vos/vos_dtx_iter.c
@@ -213,6 +213,7 @@ dtx_iter_fetch(struct vos_iterator *iter, vos_iter_entry_t *it_entry,
 	it_entry->ie_dtx_grp_cnt = DAE_GRP_CNT(dae);
 	it_entry->ie_dtx_mbs_dsize = DAE_MBS_DSIZE(dae);
 	it_entry->ie_dtx_start_time = dae->dae_start_time;
+	it_entry->ie_dkey_hash = DAE_DKEY_HASH(dae);
 	if (DAE_MBS_DSIZE(dae) <= sizeof(DAE_MBS_INLINE(dae)))
 		it_entry->ie_dtx_mbs = DAE_MBS_INLINE(dae);
 	else

--- a/src/vos/vos_internal.h
+++ b/src/vos/vos_internal.h
@@ -320,8 +320,6 @@ struct vos_dtx_cmt_ent {
 
 #define DCE_XID(dce)		((dce)->dce_base.dce_xid)
 #define DCE_EPOCH(dce)		((dce)->dce_base.dce_epoch)
-#define DCE_OID(dce)		((dce)->dce_base.dce_oid)
-#define DCE_DKEY_HASH(dce)	((dce)->dce_base.dce_dkey_hash)
 
 extern int vos_evt_feats;
 
@@ -501,8 +499,7 @@ vos_dtx_prepared(struct dtx_handle *dth);
 
 int
 vos_dtx_commit_internal(struct vos_container *cont, struct dtx_id *dtis,
-			int counti, daos_epoch_t epoch,
-			struct dtx_cos_key *dcks,
+			int count, daos_epoch_t epoch, bool *rm_cos,
 			struct vos_dtx_act_ent **daes,
 			struct vos_dtx_cmt_ent **dces);
 void

--- a/src/vos/vos_layout.h
+++ b/src/vos/vos_layout.h
@@ -88,7 +88,7 @@ enum vos_gc_type {
 #define POOL_DF_MAGIC				0x5ca1ab1e
 
 /** Lowest supported durable format version */
-#define POOL_DF_VER_1				16
+#define POOL_DF_VER_1				17
 /** Current durable format version */
 #define POOL_DF_VERSION				POOL_DF_VER_1
 
@@ -141,30 +141,24 @@ enum vos_dtx_record_types {
 
 #define DTX_INLINE_REC_CNT	4
 
-struct vos_dtx_ent_common {
-	/** The DTX identifier. */
-	struct dtx_id			dec_xid;
-	/** The epoch# for the DTX. */
-	daos_epoch_t			dec_epoch;
-	/** The identifier of the modified object (shard). */
-	daos_unit_oid_t			dec_oid;
-	/** The hashed dkey if applicable. */
-	uint64_t			dec_dkey_hash;
-};
-
 /** Committed DTX entry on-disk layout in both SCM and DRAM. */
 struct vos_dtx_cmt_ent_df {
-	struct vos_dtx_ent_common	dce_common;
+	/** The DTX identifier. */
+	struct dtx_id			dce_xid;
+	/** The epoch# for the DTX. */
+	daos_epoch_t			dce_epoch;
 };
-
-#define dce_xid		dce_common.dec_xid
-#define dce_epoch	dce_common.dec_epoch
-#define dce_oid		dce_common.dec_oid
-#define dce_dkey_hash	dce_common.dec_dkey_hash
 
 /** Active DTX entry on-disk layout in both SCM and DRAM. */
 struct vos_dtx_act_ent_df {
-	struct vos_dtx_ent_common	dae_common;
+	/** The DTX identifier. */
+	struct dtx_id			dae_xid;
+	/** The epoch# for the DTX. */
+	daos_epoch_t			dae_epoch;
+	/** The identifier of the modified object (shard). */
+	daos_unit_oid_t			dae_oid;
+	/** The hashed dkey if applicable. */
+	uint64_t			dae_dkey_hash;
 	/** The allocated local id for the DTX entry */
 	uint32_t			dae_lid;
 	/** DTX flags, see enum dtx_entry_flags. */
@@ -195,11 +189,6 @@ struct vos_dtx_act_ent_df {
 	/** The offset for the dtx mbs if out of inline. */
 	umem_off_t			dae_mbs_off;
 };
-
-#define dae_xid		dae_common.dec_xid
-#define dae_epoch	dae_common.dec_epoch
-#define dae_oid		dae_common.dec_oid
-#define dae_dkey_hash	dae_common.dec_dkey_hash
 
 struct vos_dtx_blob_df {
 	/** Magic number, can be used to distinguish active or committed DTX. */


### PR DESCRIPTION
Drop unnecessary members from both the in-DRAM and in-PMEM
committed DTX entry, that will save 32 bytes per committed
DTX entry. Now the size for committed DTX entry in PMEM is
32 bytes, the in-DRAM size is 52 bytes.

Signed-off-by: Fan Yong <fan.yong@intel.com>