### PR TITLE
DAOS-0000 DTX: reduce batch commit threshold

### DIFF
--- a/src/include/daos/dtx.h
+++ b/src/include/daos/dtx.h
@@ -15,7 +15,7 @@
  * threshould with considering RPC limitation, PMDK transaction, and
  * CPU schedule efficiency, and so on.
  */
-#define DTX_THRESHOLD_COUNT		(1 << 9)
+#define DTX_THRESHOLD_COUNT		(1 << 6)
 
 /* The time (in second) threshold for batched DTX commit. */
 #define DTX_COMMIT_THRESHOLD_AGE	10


### PR DESCRIPTION
Decrease it from  512 to 64

only for test

Signed-off-by: Liang Zhen <liang.zhen@intel.com>