### PR TITLE
DAOS-7888 vos: avoid aggregating same entry repeatedly

### DIFF
--- a/src/object/srv_ec_aggregate.c
+++ b/src/object/srv_ec_aggregate.c
@@ -2136,7 +2136,8 @@ agg_iterate_post_cb(daos_handle_t ih, vos_iter_entry_t *entry,
 	if (agg_param->ap_credits > agg_param->ap_credits_max) {
 		agg_param->ap_credits = 0;
 		*acts |= VOS_ITER_CB_YIELD;
-		agg_reset_pos(type, agg_entry);
+		if (!(*acts & VOS_ITER_CB_SKIP))
+			agg_reset_pos(type, agg_entry);
 		D_DEBUG(DB_EPC, "EC aggregation yield type %d.\n", type);
 		if (ec_aggregate_yield(agg_param)) {
 			D_DEBUG(DB_EPC, "EC aggregation aborted\n");

--- a/src/tests/ftest/daos_vol/daos_vol.py
+++ b/src/tests/ftest/daos_vol/daos_vol.py
@@ -15,8 +15,6 @@ class DaosVol(VolTestBase):
     :avocado: recursive
     """
 
-    CANCEL_FOR_TICKET = [["DAOS-7888", "testname", "h5_test_testhdf5"]]
-
     def test_daos_vol_mpich(self):
         """Jira ID: DAOS-3656.
 

--- a/src/vos/vos_aggregate.c
+++ b/src/vos/vos_aggregate.c
@@ -1915,6 +1915,9 @@ vos_aggregate_pre_cb(daos_handle_t ih, vos_iter_entry_t *entry,
 
 	if (agg_param->ap_credits > agg_param->ap_credits_max ||
 	    (DAOS_FAIL_CHECK(DAOS_VOS_AGG_RANDOM_YIELD) && (rand() % 2))) {
+		D_DEBUG(DB_EPC, "Credits exhausted, type:%u, acts:%u\n",
+			type, *acts);
+
 		agg_param->ap_credits = 0;
 		*acts |= VOS_ITER_CB_YIELD;
 
@@ -1922,8 +1925,14 @@ vos_aggregate_pre_cb(daos_handle_t ih, vos_iter_entry_t *entry,
 		 * Reset position if we yield while iterating in object, dkey
 		 * or akey level, so that subtree won't be skipped mistakenly,
 		 * see the comment in vos_agg_obj().
+		 *
+		 * If current object/dkey/akey has been marked as processed,
+		 * don't reset the position, otherwise, iterator will reprobe
+		 * the same item and process it again.
 		 */
-		reset_agg_pos(type, agg_param);
+		if (!(*acts & VOS_ITER_CB_SKIP))
+			reset_agg_pos(type, agg_param);
+
 		if (vos_aggregate_yield(agg_param)) {
 			D_DEBUG(DB_EPC, "VOS discard/aggregation aborted\n");
 			return 1;
@@ -1978,7 +1987,7 @@ vos_aggregate_post_cb(daos_handle_t ih, vos_iter_entry_t *entry,
 
 	if (rc == 1) {
 		/* Reprobe flag is set */
-		*acts |= VOS_ITER_CB_YIELD;
+		*acts |= VOS_ITER_CB_DELETE;
 		rc = 0;
 	} else if (rc != 0) {
 		D_ERROR("VOS aggregation failed: %d\n", rc);


### PR DESCRIPTION
There is a situation can cause aggregation processing same item
repeatedly:
1. If aggregation callback yield when iterating in subtrees, it
   will set YIELD flag to inform iterator to re-probe when iterator
   is back to parent tree;
2. Iterator re-probe in parent tree and locate the last processed
   entry, aggregation callback set SKIP flag to inform iterator to
   skip iterating into it's subtrees again;
3. However, aggregation credits happened to be exhausted at this
   point, so aggregation callback also set YIELD flag & reset the
   last processed entry, then yield;
4. Aggregation back from yield and iterator do re-probe to locate
   the last processed entry, then this last processed entry is
   processed again;

This patch fixed the problem by not reseting the last processed entry
when SKIP flag is present. It also changed aggregation post callback
to use DELETE flag instead of YIELD flag when ilog is deleted.

Signed-off-by: Niu Yawei <yawei.niu@intel.com>