### PR TITLE
DAOS-7420 vos: Add object specific mode to vos_discard

### DIFF
--- a/src/include/daos_srv/vos.h
+++ b/src/include/daos_srv/vos.h
@@ -417,6 +417,7 @@ vos_aggregate(daos_handle_t coh, daos_epoch_range_t *epr,
  * the caller.
  *
  * \param coh		[IN]	Container open handle
+ * \param oid		[IN]	Optional oid to limit scan
  * \param epr		[IN]	The epoch range to discard
  *				keys to discard
  * \param yield_func	[IN]	Pointer to customized yield function
@@ -425,7 +426,7 @@ vos_aggregate(daos_handle_t coh, daos_epoch_range_t *epr,
  * \return			Zero on success, negative value if error
  */
 int
-vos_discard(daos_handle_t coh, daos_epoch_range_t *epr,
+vos_discard(daos_handle_t coh, const daos_unit_oid_t *oid, daos_epoch_range_t *epr,
 	    bool (*yield_func)(void *arg), void *yield_arg);
 
 /**

--- a/src/rdb/rdb_util.c
+++ b/src/rdb/rdb_util.c
@@ -529,7 +529,7 @@ rdb_vos_discard(daos_handle_t cont, daos_epoch_t low, daos_epoch_t high)
 	range.epr_lo = low;
 	range.epr_hi = high;
 
-	return vos_discard(cont, &range, NULL, NULL);
+	return vos_discard(cont, NULL, &range, NULL, NULL);
 }
 
 int

--- a/src/vos/evt_priv.h
+++ b/src/vos/evt_priv.h
@@ -510,13 +510,13 @@ evt_node_desc_at(struct evt_context *tcx, struct evt_node *node,
 static inline bool
 evt_entry_punched(const struct evt_entry *ent, const struct evt_filter *filter)
 {
-	struct vos_punch_record	punch;
+	struct ilog_time_rec	punch;
 
 	if (filter == NULL)
 		return false;
 
-	punch.pr_epc = filter->fr_punch_epc;
-	punch.pr_minor_epc = filter->fr_punch_minor_epc;
+	punch.tr_epc = filter->fr_punch_epc;
+	punch.tr_minor_epc = filter->fr_punch_minor_epc;
 
 	return vos_epc_punched(ent->en_epoch, ent->en_minor_epc, &punch);
 }

--- a/src/vos/ilog.h
+++ b/src/vos/ilog.h
@@ -33,6 +33,16 @@ struct  ilog_df {
 	char	id_pad[24];
 };
 
+#define DF_TREC DF_X64".%d"
+#define DP_TREC(trec) (trec)->tr_epc, (trec)->tr_minor_epc
+
+struct ilog_time_rec {
+	/** Major epoch of update/punch */
+	daos_epoch_t	tr_epc;
+	/** Minor epoch of update/punch */
+	uint16_t	tr_minor_epc;
+};
+
 struct umem_instance;
 
 enum ilog_status {
@@ -194,6 +204,8 @@ struct ilog_entries {
  *  \param	punch_major[in]	Max minor epoch punch of parent incarnation log
  *  \param	entries[in]	Used for efficiency since aggregation is used
  *				by vos_iterator
+ *  \param	update[in]	Optional, indicates next update after the range
+ *				in case the ilog would otherwise be left empty
  *
  *  \return	0		success
  *		1		success but indicates log is empty
@@ -203,7 +215,7 @@ int
 ilog_aggregate(struct umem_instance *umm, struct ilog_df *root,
 	       const struct ilog_desc_cbs *cbs, const daos_epoch_range_t *epr,
 	       bool discard, daos_epoch_t punch_major, uint16_t punch_minor,
-	       struct ilog_entries *entries);
+	       struct ilog_entries *entries, const struct ilog_time_rec *update);
 
 /** Initialize an ilog_entries struct for fetch
  *

--- a/src/vos/tests/vts_aggregate.c
+++ b/src/vos/tests/vts_aggregate.c
@@ -411,7 +411,7 @@ aggregate_basic(struct io_test_args *arg, struct agg_tst_dataset *ds,
 		    "Discard" : "Aggregate", epr_a->epr_lo, epr_a->epr_hi);
 
 	if (ds->td_discard)
-		rc = vos_discard(arg->ctx.tc_co_hdl, epr_a, NULL, NULL);
+		rc = vos_discard(arg->ctx.tc_co_hdl, NULL, epr_a, NULL, NULL);
 	else
 		rc = vos_aggregate(arg->ctx.tc_co_hdl, epr_a,
 				   ds_csum_agg_recalc, NULL, NULL, false);
@@ -589,7 +589,7 @@ aggregate_multi(struct io_test_args *arg, struct agg_tst_dataset *ds_sample)
 		    "Discard" : "Aggregate");
 
 	if (ds_sample->td_discard)
-		rc = vos_discard(arg->ctx.tc_co_hdl, epr_a, NULL, NULL);
+		rc = vos_discard(arg->ctx.tc_co_hdl, NULL, epr_a, NULL, NULL);
 	else
 		rc = vos_aggregate(arg->ctx.tc_co_hdl, epr_a, NULL, NULL, NULL,
 				   false);
@@ -1082,7 +1082,7 @@ do_punch(struct io_test_args *arg, int type, daos_unit_oid_t oid,
 
 #define NUM_INTERNAL 200
 static void
-agg_punches_test_helper(void **state, int record_type, int type, bool discard,
+agg_punches_test_helper(void **state, bool one, int record_type, int type, bool discard,
 			int first, int last)
 {
 	struct io_test_args	*arg = *state;
@@ -1141,7 +1141,7 @@ agg_punches_test_helper(void **state, int record_type, int type, bool discard,
 
 	for (i = 0; i < 2; i++) {
 		if (discard)
-			rc = vos_discard(arg->ctx.tc_co_hdl, &epr, NULL, NULL);
+			rc = vos_discard(arg->ctx.tc_co_hdl, one ? &oid : NULL, &epr, NULL, NULL);
 		else
 			rc = vos_aggregate(arg->ctx.tc_co_hdl, &epr, NULL,
 					   NULL, NULL, false);
@@ -1212,7 +1212,7 @@ agg_punches_test_helper(void **state, int record_type, int type, bool discard,
 
 /** Do a punch aggregation test */
 static void
-agg_punches_test(void **state, int record_type, bool discard)
+agg_punches_test(void **state, bool one, int record_type, bool discard)
 {
 	int	first, last, type;
 	int	lstart;
@@ -1223,7 +1223,7 @@ agg_punches_test(void **state, int record_type, bool discard)
 		for (last = lstart; last <= AGG_UPDATE; last++) {
 			for (type = AGG_OBJ_TYPE; type <= AGG_AKEY_TYPE;
 			     type++) {
-				agg_punches_test_helper(state, record_type,
+				agg_punches_test_helper(state, one, record_type,
 							type, discard, first,
 							last);
 			}
@@ -1233,14 +1233,28 @@ agg_punches_test(void **state, int record_type, bool discard)
 static void
 discard_14(void **state)
 {
-	agg_punches_test(state, DAOS_IOD_SINGLE, true);
+	agg_punches_test(state, false, DAOS_IOD_SINGLE, true);
 	cleanup();
 }
 
 static void
 discard_15(void **state)
 {
-	agg_punches_test(state, DAOS_IOD_ARRAY, true);
+	agg_punches_test(state, false, DAOS_IOD_ARRAY, true);
+	cleanup();
+}
+
+static void
+discard_16(void **state)
+{
+	agg_punches_test(state, true, DAOS_IOD_ARRAY, true);
+	cleanup();
+}
+
+static void
+discard_17(void **state)
+{
+	agg_punches_test(state, true, DAOS_IOD_ARRAY, true);
 	cleanup();
 }
 
@@ -1877,14 +1891,14 @@ aggregate_14(void **state)
 static void
 aggregate_15(void **state)
 {
-	agg_punches_test(state, DAOS_IOD_SINGLE, false);
+	agg_punches_test(state, false, DAOS_IOD_SINGLE, false);
 	cleanup();
 }
 
 static void
 aggregate_16(void **state)
 {
-	agg_punches_test(state, DAOS_IOD_ARRAY, false);
+	agg_punches_test(state, false, DAOS_IOD_ARRAY, false);
 	cleanup();
 }
 
@@ -2118,6 +2132,10 @@ static const struct CMUnitTest discard_tests[] = {
 	  discard_14, NULL, agg_tst_teardown },
 	{ "VOS465: Discard object/key punches array",
 	  discard_15, NULL, agg_tst_teardown },
+	{ "VOS466: Discard single object sv",
+	  discard_16, NULL, agg_tst_teardown },
+	{ "VOS466: Discard single object array",
+	  discard_17, NULL, agg_tst_teardown },
 };
 
 static const struct CMUnitTest aggregate_tests[] = {

--- a/src/vos/vos_ilog.h
+++ b/src/vos/vos_ilog.h
@@ -33,16 +33,6 @@ enum {
 
 struct vos_container;
 
-#define DF_PUNCH DF_X64".%d"
-#define DP_PUNCH(punch) (punch)->pr_epc, (punch)->pr_minor_epc
-
-struct vos_punch_record {
-	/** Major epoch of punch */
-	daos_epoch_t	pr_epc;
-	/** Minor epoch of punch */
-	uint16_t	pr_minor_epc;
-};
-
 struct vos_ilog_info {
 	struct ilog_entries	 ii_entries;
 	/** Visible uncommitted epoch */
@@ -50,9 +40,9 @@ struct vos_ilog_info {
 	/** If non-zero, earliest creation timestamp in current incarnation. */
 	daos_epoch_t		 ii_create;
 	/** If non-zero, prior committed punch */
-	struct vos_punch_record	 ii_prior_punch;
+	struct ilog_time_rec	 ii_prior_punch;
 	/** If non-zero, prior committed or uncommitted punch */
-	struct vos_punch_record	 ii_prior_any_punch;
+	struct ilog_time_rec	 ii_prior_any_punch;
 	/** If non-zero, subsequent committed punch.  Minor epoch not used for
 	 *  subsequent punch as it does not need replay if it's intermediate
 	 */
@@ -104,7 +94,7 @@ vos_ilog_fetch_finish(struct vos_ilog_info *info);
 int
 vos_ilog_fetch_(struct umem_instance *umm, daos_handle_t coh, uint32_t intent,
 		struct ilog_df *ilog, daos_epoch_t epoch, daos_epoch_t bound,
-		const struct vos_punch_record *punched,
+		const struct ilog_time_rec *punched,
 		const struct vos_ilog_info *parent, struct vos_ilog_info *info);
 
 /**
@@ -190,6 +180,8 @@ vos_ilog_desc_cbs_init(struct ilog_desc_cbs *cbs, daos_handle_t coh);
  * \param	discard[IN]	Discard all entries in range
  * \param	punched[IN]	Highest epoch where parent is punched
  * \param	info[IN]	Incarnation log info
+ * \param	update[IN]	Optional lowest update after the
+ *				epoch range.
  *
  * \return	0		Success
  *		1		Indicates log is empty
@@ -199,8 +191,9 @@ vos_ilog_desc_cbs_init(struct ilog_desc_cbs *cbs, daos_handle_t coh);
 int
 vos_ilog_aggregate(daos_handle_t coh, struct ilog_df *ilog,
 		   const daos_epoch_range_t *epr, bool discard,
-		   const struct vos_punch_record *parent_punch,
-		   struct vos_ilog_info *info);
+		   const struct ilog_time_rec *parent_punch,
+		   struct vos_ilog_info *info,
+		   const struct ilog_time_rec *update);
 
 /* #define ILOG_TRACE */
 #ifdef ILOG_TRACE
@@ -223,10 +216,10 @@ vos_ilog_aggregate(daos_handle_t coh, struct ilog_df *ilog,
 	__rc = vos_ilog_fetch_(umm, coh, intent, ilog, epoch, bound,	\
 			       punched,	parent, info);			\
 	D_DEBUG(DB_TRACE, "vos_ilog_fetch: returned "DF_RC" create="	\
-		DF_X64" pp="DF_PUNCH" pap="DF_PUNCH" np="DF_X64	\
+		DF_X64" pp="DF_TREC" pap="DF_TREC" np="DF_X64	\
 		" %s\n", DP_RC(__rc), (info)->ii_create,		\
-		DP_PUNCH(&(info)->ii_prior_punch),			\
-		DP_PUNCH(&(info)->ii_prior_any_punch),			\
+		DP_TREC(&(info)->ii_prior_punch),			\
+		DP_TREC(&(info)->ii_prior_any_punch),			\
 		(info)->ii_next_punch,					\
 		(info)->ii_empty ? "is empty" : "");			\
 	__rc;								\
@@ -245,9 +238,9 @@ vos_ilog_aggregate(daos_handle_t coh, struct ilog_df *ilog,
 	__rc = vos_ilog_update_(cont, ilog, epr, bound, parent, info,	\
 				cond, ts_set);				\
 	D_DEBUG(DB_TRACE, "vos_ilog_update: returned "DF_RC" create="	\
-		DF_X64" pap="DF_X64".%d\n", DP_RC(__rc),		\
+		DF_X64" pap="DF_TREC"\n", DP_RC(__rc),			\
 		(info)->ii_create,					\
-		DP_PUNCH(&(info)->ii_prior_any_punch));			\
+		DP_TREC(&(info)->ii_prior_any_punch));			\
 	__rc;								\
 })
 

--- a/src/vos/vos_io.c
+++ b/src/vos/vos_io.c
@@ -975,9 +975,9 @@ akey_fetch_recx(daos_handle_t toh, const daos_epoch_range_t *epr,
 	filter.fr_epoch = epr->epr_hi;
 	filter.fr_epr.epr_lo = epr->epr_lo;
 	filter.fr_epr.epr_hi = ioc->ic_bound;
-	filter.fr_punch_epc = ioc->ic_akey_info.ii_prior_punch.pr_epc;
+	filter.fr_punch_epc = ioc->ic_akey_info.ii_prior_punch.tr_epc;
 	filter.fr_punch_minor_epc =
-		ioc->ic_akey_info.ii_prior_punch.pr_minor_epc;
+		ioc->ic_akey_info.ii_prior_punch.tr_minor_epc;
 
 	evt_ent_array_init(ioc->ic_ent_array, 0);
 	rc = evt_find(toh, &filter, ioc->ic_ent_array);
@@ -1125,8 +1125,8 @@ key_ilog_check(struct vos_io_context *ioc, struct vos_krec_df *krec,
 	rc = vos_ilog_check(info, &epr, epr_out, true);
 out:
 	D_DEBUG(DB_TRACE, "ilog check returned "DF_RC" epr_in="DF_X64"-"DF_X64
-		" punch="DF_PUNCH" epr_out="DF_X64"-"DF_X64"\n", DP_RC(rc),
-		epr.epr_lo, epr.epr_hi, DP_PUNCH(&info->ii_prior_punch),
+		" punch="DF_TREC" epr_out="DF_X64"-"DF_X64"\n", DP_RC(rc),
+		epr.epr_lo, epr.epr_hi, DP_TREC(&info->ii_prior_punch),
 		epr_out ? epr_out->epr_lo : 0,
 		epr_out ? epr_out->epr_hi : 0);
 	return rc;

--- a/src/vos/vos_obj.c
+++ b/src/vos/vos_obj.c
@@ -443,7 +443,7 @@ reset:
 }
 
 int
-vos_obj_delete(daos_handle_t coh, daos_unit_oid_t oid)
+vos_obj_delete_internal(daos_handle_t coh, daos_unit_oid_t oid, bool gc)
 {
 	struct daos_lru_cache	*occ  = vos_obj_cache_current();
 	struct vos_container	*cont = vos_hdl2cont(coh);
@@ -466,7 +466,7 @@ vos_obj_delete(daos_handle_t coh, daos_unit_oid_t oid)
 	if (rc)
 		goto out;
 
-	rc = vos_oi_delete(cont, obj->obj_id);
+	rc = vos_oi_delete(cont, obj->obj_id, gc);
 	if (rc)
 		D_ERROR("Failed to delete object: %s\n", d_errstr(rc));
 
@@ -476,6 +476,12 @@ vos_obj_delete(daos_handle_t coh, daos_unit_oid_t oid)
 out:
 	vos_obj_release(occ, obj, true);
 	return rc;
+}
+
+int
+vos_obj_delete(daos_handle_t coh, daos_unit_oid_t oid)
+{
+	return vos_obj_delete_internal(coh, oid, true);
 }
 
 /* Delete a key in its parent tree.
@@ -579,7 +585,7 @@ out:
 static int
 key_ilog_prepare(struct vos_obj_iter *oiter, daos_handle_t toh, int key_type,
 		 daos_key_t *key, int flags, daos_handle_t *sub_toh,
-		 daos_epoch_range_t *epr, struct vos_punch_record *punched,
+		 daos_epoch_range_t *epr, struct ilog_time_rec *punched,
 		 struct vos_ilog_info *info, struct vos_ts_set *ts_set)
 {
 	struct vos_krec_df	*krec = NULL;
@@ -603,7 +609,7 @@ key_ilog_prepare(struct vos_obj_iter *oiter, daos_handle_t toh, int key_type,
 	if (rc != 0)
 		goto fail;
 
-	if (punched && vos_epc_punched(punched->pr_epc, punched->pr_minor_epc,
+	if (punched && vos_epc_punched(punched->tr_epc, punched->tr_minor_epc,
 				       &info->ii_prior_punch))
 		*punched = info->ii_prior_punch;
 
@@ -723,8 +729,8 @@ key_iter_fetch_root(struct vos_obj_iter *oiter, vos_iter_type_t type,
 	if (rc != 0)
 		return rc;
 
-	if (vos_epc_punched(info->ii_punched.pr_epc,
-			    info->ii_punched.pr_minor_epc,
+	if (vos_epc_punched(info->ii_punched.tr_epc,
+			    info->ii_punched.tr_minor_epc,
 			    &oiter->it_ilog_info.ii_prior_punch))
 		info->ii_punched = oiter->it_ilog_info.ii_prior_punch;
 
@@ -1280,8 +1286,8 @@ recx_iter_prepare(struct vos_obj_iter *oiter, daos_key_t *dkey,
 	filter.fr_epr.epr_lo = oiter->it_epr.epr_lo;
 	filter.fr_epr.epr_hi = oiter->it_iter.it_bound;
 	filter.fr_epoch = oiter->it_epr.epr_hi;
-	filter.fr_punch_epc = oiter->it_punched.pr_epc;
-	filter.fr_punch_minor_epc = oiter->it_punched.pr_minor_epc;
+	filter.fr_punch_epc = oiter->it_punched.tr_epc;
+	filter.fr_punch_minor_epc = oiter->it_punched.tr_minor_epc;
 	options = recx_get_flags(oiter);
 	rc = evt_iter_prepare(rx_toh, options, &filter,
 			      &oiter->it_hdl);
@@ -1647,8 +1653,8 @@ vos_obj_iter_nested_prep(vos_iter_type_t type, struct vos_iter_info *info,
 		filter.fr_epr.epr_lo = oiter->it_epr.epr_lo;
 		filter.fr_epr.epr_hi = oiter->it_iter.it_bound;
 		filter.fr_epoch = oiter->it_epr.epr_hi;
-		filter.fr_punch_epc = oiter->it_punched.pr_epc;
-		filter.fr_punch_minor_epc = oiter->it_punched.pr_minor_epc;
+		filter.fr_punch_epc = oiter->it_punched.tr_epc;
+		filter.fr_punch_minor_epc = oiter->it_punched.tr_minor_epc;
 		options = recx_get_flags(oiter);
 		rc = evt_iter_prepare(toh, options, &filter, &oiter->it_hdl);
 		break;
@@ -1819,8 +1825,10 @@ exit:
 }
 
 int
-vos_obj_iter_aggregate(daos_handle_t ih, bool discard)
+vos_obj_iter_aggregate(daos_handle_t ih, bool discard, daos_epoch_t hi,
+		       const struct ilog_time_rec *update)
 {
+	daos_epoch_range_t	 epr;
 	struct vos_iterator	*iter = vos_hdl2iter(ih);
 	struct vos_obj_iter	*oiter = vos_iter2oiter(iter);
 	struct umem_instance	*umm;
@@ -1849,9 +1857,13 @@ vos_obj_iter_aggregate(daos_handle_t ih, bool discard)
 	if (rc != 0)
 		goto exit;
 
+	epr.epr_hi = hi;
+	epr.epr_lo = oiter->it_epr.epr_lo;
+
 	rc = vos_ilog_aggregate(vos_cont2hdl(obj->obj_cont), &krec->kr_ilog,
-				&oiter->it_epr, discard,
-				&oiter->it_punched, &oiter->it_ilog_info);
+				&epr, discard,
+				&oiter->it_punched, &oiter->it_ilog_info,
+				update);
 
 	if (rc == 1) {
 		/* Incarnation log is empty so delete the key */

--- a/src/vos/vos_obj.h
+++ b/src/vos/vos_obj.h
@@ -207,9 +207,12 @@ vos_oi_punch(struct vos_container *cont, daos_unit_oid_t oid,
 	     struct vos_obj_df *obj, struct vos_ilog_info *info,
 	     struct vos_ts_set *ts_set);
 
+/** delete object */
+int
+vos_obj_delete_internal(daos_handle_t coh, daos_unit_oid_t oid, bool gc);
 
 /** delete an object from OI table */
 int
-vos_oi_delete(struct vos_container *cont, daos_unit_oid_t oid);
+vos_oi_delete(struct vos_container *cont, daos_unit_oid_t oid, bool gc);
 
 #endif

--- a/src/vos/vos_query.c
+++ b/src/vos/vos_query.c
@@ -24,7 +24,7 @@ struct open_query {
 	struct vos_ts_set	*qt_ts_set;
 	daos_epoch_t		 qt_bound;
 	daos_epoch_range_t	 qt_epr;
-	struct vos_punch_record	 qt_punch;
+	struct ilog_time_rec	 qt_punch;
 	struct vos_ilog_info	 qt_info;
 	struct btr_root		*qt_dkey_root;
 	daos_handle_t		 qt_dkey_toh;
@@ -76,7 +76,7 @@ find_key(struct open_query *query, daos_handle_t toh, daos_key_t *key,
 	d_iov_t			 riov;
 	struct dcs_csum_info	 csum;
 	daos_epoch_range_t	 epr = query->qt_epr;
-	struct vos_punch_record	 punch = query->qt_punch;
+	struct ilog_time_rec	 punch = query->qt_punch;
 	int			 rc = 0;
 	int			 fini_rc;
 	int			 opc;
@@ -180,8 +180,8 @@ query_recx(struct open_query *query, daos_recx_t *recx)
 		filter.fr_ex.ex_hi = DAOS_EC_PARITY_BIT - 1;
 	else
 		filter.fr_ex.ex_hi = ~(uint64_t)0;
-	filter.fr_punch_epc = query->qt_punch.pr_epc;
-	filter.fr_punch_minor_epc = query->qt_punch.pr_minor_epc;
+	filter.fr_punch_epc = query->qt_punch.tr_epc;
+	filter.fr_punch_minor_epc = query->qt_punch.tr_minor_epc;
 	filter.fr_epr.epr_hi = query->qt_bound;
 	filter.fr_epr.epr_lo = query->qt_epr.epr_lo;
 	filter.fr_epoch = query->qt_epr.epr_hi;
@@ -322,7 +322,7 @@ vos_obj_query_key(daos_handle_t coh, daos_unit_oid_t oid, uint32_t flags,
 	struct open_query	*query;
 	daos_epoch_t		 bound;
 	daos_epoch_range_t	 dkey_epr;
-	struct vos_punch_record	 dkey_punch;
+	struct ilog_time_rec	 dkey_punch;
 	daos_ofeat_t		 obj_feats;
 	daos_epoch_range_t	 obj_epr = {0};
 	struct vos_ts_set	 akey_save = {0};


### PR DESCRIPTION
Also, fix vos_discard so that it leaves subsequent commits
visible.   This is done by scanning to DAOS_EPOCH_MAX
and then tracking whether the subsequent updates may
have bypassed adding an ilog entry due to an existing
creation entry.   If that entry is discarded, we need
to update the ilog accordingly to ensure we don't have
orphaned entries.

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>