### PR TITLE
DAOS-7932 pool: Avoid timeouts during map updates

### DIFF
--- a/src/include/daos_srv/rsvc.h
+++ b/src/include/daos_srv/rsvc.h
@@ -144,9 +144,11 @@ int ds_rsvc_add_replicas_s(struct ds_rsvc *svc, d_rank_list_t *ranks,
 int ds_rsvc_add_replicas(enum ds_rsvc_class_id class, d_iov_t *id,
 			 d_rank_list_t *ranks, size_t size,
 			 struct rsvc_hint *hint);
-int ds_rsvc_remove_replicas_s(struct ds_rsvc *svc, d_rank_list_t *ranks);
+int ds_rsvc_remove_replicas_s(struct ds_rsvc *svc, d_rank_list_t *ranks,
+			      bool stop);
 int ds_rsvc_remove_replicas(enum ds_rsvc_class_id class, d_iov_t *id,
-			    d_rank_list_t *ranks, struct rsvc_hint *hint);
+			    d_rank_list_t *ranks, bool stop,
+			    struct rsvc_hint *hint);
 int ds_rsvc_lookup(enum ds_rsvc_class_id class, d_iov_t *id,
 		   struct ds_rsvc **svc);
 int ds_rsvc_lookup_leader(enum ds_rsvc_class_id class, d_iov_t *id,

--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -4006,7 +4006,7 @@ replace_failed_replicas(struct pool_svc *svc, struct pool_map *map)
 	if (replacement.rl_nr > 0)
 		ds_rsvc_add_replicas_s(&svc->ps_rsvc, &replacement,
 				       ds_rsvc_get_md_cap());
-	ds_rsvc_remove_replicas_s(&svc->ps_rsvc, &failed);
+	ds_rsvc_remove_replicas_s(&svc->ps_rsvc, &failed, false /* stop */);
 	/** `replacement.rl_ranks` is not allocated and shouldn't be freed **/
 	D_FREE(failed.rl_ranks);
 
@@ -5632,7 +5632,7 @@ ds_pool_replicas_update_handler(crt_rpc_t *rpc)
 
 	case POOL_REPLICAS_REMOVE:
 		rc = ds_rsvc_remove_replicas(DS_RSVC_CLASS_POOL, &id, ranks,
-					     &out->pmo_hint);
+					     true /* stop */, &out->pmo_hint);
 		break;
 
 	default:

--- a/src/rdb/tests/rdb_test.c
+++ b/src/rdb/tests/rdb_test.c
@@ -874,7 +874,7 @@ rdbt_replicas_remove_handler(crt_rpc_t *rpc)
 		goto out;
 
 	rc = ds_rsvc_remove_replicas(DS_RSVC_CLASS_TEST, &test_svc_id, ranks,
-				     &out->rtmo_hint);
+				     true /* stop */, &out->rtmo_hint);
 	out->rtmo_failed = ranks;
 
 out:

--- a/src/rsvc/srv.c
+++ b/src/rsvc/srv.c
@@ -1062,7 +1062,7 @@ ds_rsvc_add_replicas(enum ds_rsvc_class_id class, d_iov_t *id,
 }
 
 int
-ds_rsvc_remove_replicas_s(struct ds_rsvc *svc, d_rank_list_t *ranks)
+ds_rsvc_remove_replicas_s(struct ds_rsvc *svc, d_rank_list_t *ranks, bool stop)
 {
 	d_rank_list_t	*stop_ranks;
 	int		 rc;
@@ -1074,7 +1074,7 @@ ds_rsvc_remove_replicas_s(struct ds_rsvc *svc, d_rank_list_t *ranks)
 
 	/* filter out failed ranks */
 	daos_rank_list_filter(ranks, stop_ranks, true /* exclude */);
-	if (stop_ranks->rl_nr > 0)
+	if (stop_ranks->rl_nr > 0 && stop)
 		ds_rsvc_dist_stop(svc->s_class, &svc->s_id, stop_ranks,
 				  NULL, true /* destroy */);
 	d_rank_list_free(stop_ranks);
@@ -1083,7 +1083,7 @@ ds_rsvc_remove_replicas_s(struct ds_rsvc *svc, d_rank_list_t *ranks)
 
 int
 ds_rsvc_remove_replicas(enum ds_rsvc_class_id class, d_iov_t *id,
-			d_rank_list_t *ranks, struct rsvc_hint *hint)
+			d_rank_list_t *ranks, bool stop, struct rsvc_hint *hint)
 {
 	struct ds_rsvc	*svc;
 	int		 rc;
@@ -1091,7 +1091,7 @@ ds_rsvc_remove_replicas(enum ds_rsvc_class_id class, d_iov_t *id,
 	rc = ds_rsvc_lookup_leader(class, id, &svc, hint);
 	if (rc != 0)
 		return rc;
-	rc = ds_rsvc_remove_replicas_s(svc, ranks);
+	rc = ds_rsvc_remove_replicas_s(svc, ranks, stop);
 	ds_rsvc_set_hint(svc, hint);
 	put_leader(svc);
 	return rc;


### PR DESCRIPTION
When a PS replica is being excluded (due to SWIM events), the attempt to
stop it usually fails after a lengthy RPC timeout. This is a quick and
dirty fix to remove this timeout, allowing rebuild jobs to be queued and
completed faster.

Signed-off-by: Li Wei <wei.g.li@intel.com>