### PR TITLE
DAOS-8009 tests: Fix CONT21

### DIFF
--- a/src/tests/suite/daos_container.c
+++ b/src/tests/suite/daos_container.c
@@ -1968,7 +1968,7 @@ co_owner_implicit_access(void **state)
 	print_message("- Verify set-prop denied\n");
 	tmp_prop = daos_prop_alloc(1);
 	tmp_prop->dpp_entries[0].dpe_type = DAOS_PROP_CO_LABEL;
-	D_STRNDUP_S(tmp_prop->dpp_entries[0].dpe_str, "My Label");
+	D_STRNDUP_S(tmp_prop->dpp_entries[0].dpe_str, "My_Label");
 	rc = daos_cont_set_prop(arg->coh, tmp_prop, NULL);
 	assert_rc_equal(rc, -DER_NO_PERM);
 	daos_prop_free(tmp_prop);


### PR DESCRIPTION
Fix a regression from 01a8c21fa522bf1f08abc3aa24f04c1fc3c3d3fc, which
changed a container label into an invalid value.

Signed-off-by: Li Wei <wei.g.li@intel.com>