### PR TITLE
DAOS-4410 mgmt: validate group-id while pool evicting

### DIFF
--- a/src/mgmt/srv_pool.c
+++ b/src/mgmt/srv_pool.c
@@ -394,8 +394,16 @@ ds_mgmt_evict_pool(uuid_t pool_uuid, d_rank_list_t *svc_ranks,
 		   uuid_t *handles, size_t n_handles, const char *group)
 {
 	int		 rc;
+	crt_group_t	*crt_group;
 
 	D_DEBUG(DB_MGMT, "evict pool "DF_UUID"\n", DP_UUID(pool_uuid));
+
+	crt_group = crt_group_lookup((char *)group);
+	if (crt_group == NULL) {
+		D_ERROR("Invalid group name %s\n", group);
+		rc = -DER_NONEXIST;
+		goto out;
+	}
 
 	/* Evict active pool connections if they exist*/
 	rc = ds_pool_svc_check_evict(pool_uuid, svc_ranks, handles, n_handles,


### PR DESCRIPTION
Providing a wrong or nonexistent group-id as part of pool
evict request produces the same behavior. This patch adds
a group-id check as part of the pool evict request.

Signed-off-by: Jonathan Martinez Montes <jonathan.martinez.montes@intel.com>