### PR TITLE
DAOS-8011 bio: use larger subsystem fini timeout

### DIFF
--- a/src/bio/bio_xstream.c
+++ b/src/bio/bio_xstream.c
@@ -1197,7 +1197,7 @@ bio_xsctxt_free(struct bio_xs_context *ctxt)
 			 * temporary workaround.
 			 */
 			rc = xs_poll_completion(ctxt, &cp_arg.cca_inflights,
-						3000 /*ms*/);
+						9000 /*ms*/);
 			D_CDEBUG(rc == 0, DB_MGMT, DLOG_ERR,
 				 "SPDK subsystems finalized. "DF_RC"\n",
 				 DP_RC(rc));


### PR DESCRIPTION
SPDK subsystem fini usually will take 4 ~ 5 seconds after upgrading,
so we bump the timeout value from 3 seconds to 9 seconds.

Signed-off-by: Niu Yawei <yawei.niu@intel.com>