### PR TITLE
DAOS-8003 Test: Enabled NVMe recovery test in Ci.

### DIFF
--- a/src/tests/ftest/daos_test/daos_core_test-nvme_recovery.py
+++ b/src/tests/ftest/daos_test/daos_core_test-nvme_recovery.py
@@ -4,7 +4,6 @@
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
-from apricot import skipForTicket
 from daos_core_base import DaosCoreBase
 
 class DaosCoreTestNvme(DaosCoreBase):
@@ -30,7 +29,6 @@ class DaosCoreTestNvme(DaosCoreBase):
         """
         self.run_subtest()
 
-    @skipForTicket("DAOS-5134")
     def test_daos_nvme_recovery_2(self):
         """Jira ID: DAOS-3846.
 
@@ -47,7 +45,6 @@ class DaosCoreTestNvme(DaosCoreBase):
         """
         self.run_subtest()
 
-    @skipForTicket("DAOS-5134")
     def test_daos_nvme_recovery_3(self):
         """Jira ID: DAOS-3846.
 
@@ -64,7 +61,6 @@ class DaosCoreTestNvme(DaosCoreBase):
         """
         self.run_subtest()
 
-    @skipForTicket("DAOS-5134")
     def test_daos_nvme_recovery_4(self):
         """Jira ID: DAOS-3846.
 
@@ -81,7 +77,6 @@ class DaosCoreTestNvme(DaosCoreBase):
         """
         self.run_subtest()
 
-    @skipForTicket("DAOS-5134")
     def test_daos_nvme_recovery_5(self):
         """Jira ID: DAOS-3760.
 
@@ -98,7 +93,6 @@ class DaosCoreTestNvme(DaosCoreBase):
         """
         self.run_subtest()
 
-    @skipForTicket("DAOS-5134")
     def test_daos_nvme_recovery_6(self):
         """Jira ID: DAOS-7120.
         Test Description:
@@ -111,4 +105,3 @@ class DaosCoreTestNvme(DaosCoreBase):
         :avocado: tags=daos_test,daos_core_test_nvme,test_daos_nvme_recovery_6
         """
         self.run_subtest()
-

--- a/src/tests/ftest/daos_test/daos_core_test-nvme_recovery.yaml
+++ b/src/tests/ftest/daos_test/daos_core_test-nvme_recovery.yaml
@@ -5,6 +5,9 @@ hosts:
     - server-A
     - server-B
 timeout: 600
+#Remove this once DAOS-5134 is resolved
+setup:
+  start_servers_once: False
 pool:
   scm_size: 8G
   nvme_size: 16G


### PR DESCRIPTION
All NVMe recovery test will run in Ci and server will
be reformatted for each test until DAOS-5134 is resolved.

Quick-Functional: true
Test-tag-hw-medium: daos_core_test_nvme

Signed-off-by: Samir Raval <samir.raval@intel.com>