### PR TITLE
DAOS-7926 control: Add system.ErrUninitialized

### DIFF
--- a/src/control/lib/control/storage.go
+++ b/src/control/lib/control/storage.go
@@ -341,7 +341,8 @@ func checkFormatReq(ctx context.Context, rpcClient UnaryInvoker, req *StorageFor
 		// We expect a system unavailable error when the MS is
 		// not running, so it's safe to swallow these errors. Any
 		// other error should be returned.
-		if !(system.IsUnavailable(err) || err == errMSConnectionFailure) {
+		if !(system.IsUnavailable(err) || system.IsUninitialized(err) ||
+			err == errMSConnectionFailure) {
 			return err
 		}
 

--- a/src/control/lib/control/storage_test.go
+++ b/src/control/lib/control/storage_test.go
@@ -776,6 +776,12 @@ func TestControl_checkFormatReq(t *testing.T) {
 			},
 			expErr: FaultFormatRunningSystem,
 		},
+		"system unformatted": {
+			reqHosts: reqHosts("replica"),
+			responses: []*UnaryResponse{
+				MockMSResponse("replica", system.ErrUninitialized, nil),
+			},
+		},
 		"system query fails": {
 			reqHosts: reqHosts("replica"),
 			responses: []*UnaryResponse{

--- a/src/control/system/database_test.go
+++ b/src/control/system/database_test.go
@@ -141,9 +141,9 @@ func TestSystem_Database_Cancel(t *testing.T) {
 		return nil
 	})
 
-	waitForLeadership(ctx, t, db, true, 10*time.Second)
+	waitForLeadership(ctx, t, db, true, 15*time.Second)
 	dbCancel()
-	waitForLeadership(ctx, t, db, false, 10*time.Second)
+	waitForLeadership(ctx, t, db, false, 15*time.Second)
 
 	if atomic.LoadUint32(&onGainedCalled) != 1 {
 		t.Fatal("OnLeadershipGained callbacks didn't execute")

--- a/src/control/system/errors.go
+++ b/src/control/system/errors.go
@@ -20,6 +20,7 @@ import (
 var (
 	ErrEmptyGroupMap = errors.New("empty group map (all ranks excluded?)")
 	ErrRaftUnavail   = errors.New("raft service unavailable (not started yet?)")
+	ErrUninitialized = errors.New("system is uninitialized (storage format required?)")
 )
 
 // IsUnavailable returns a boolean indicating whether or not the
@@ -38,6 +39,15 @@ func IsEmptyGroupMap(err error) bool {
 		return false
 	}
 	return strings.Contains(errors.Cause(err).Error(), ErrEmptyGroupMap.Error())
+}
+
+// IsUninitialized returns a boolean indicating whether or not the
+// supplied error corresponds to an uninitialized system.
+func IsUninitialized(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(errors.Cause(err).Error(), ErrUninitialized.Error())
 }
 
 // ErrNotReplica indicates that a request was made to a control plane

--- a/src/control/system/mocks.go
+++ b/src/control/system/mocks.go
@@ -149,6 +149,7 @@ func MockDatabaseWithAddr(t *testing.T, log logging.Logger, addr *net.TCPAddr) *
 	db.raft.setSvc(newMockRaftService(&mockRaftServiceConfig{
 		State: raft.Leader,
 	}, (*fsm)(db)))
+	db.initialized.SetTrue()
 
 	return db
 }


### PR DESCRIPTION
This new error will be returned in response to system RPCs
received before the database has started (e.g. when a storage
format is required).