### PR TITLE
DAOS-7818 bio: tolerate chunk allocation failures

### DIFF
--- a/src/bio/bio_buffer.c
+++ b/src/bio/bio_buffer.c
@@ -466,8 +466,8 @@ chunk_get_idle(struct bio_dma_buffer *bdb, struct bio_dma_chunk **chk_ptr)
 		/* Try grow buffer first */
 		if (bdb->bdb_tot_cnt < bio_chk_cnt_max) {
 			rc = dma_buffer_grow(bdb, 1);
-			if (rc != 0)
-				return rc;
+			if (rc == 0)
+				goto done;
 		}
 
 		/* Try to reclaim an unused chunk from bulk groups */
@@ -475,7 +475,7 @@ chunk_get_idle(struct bio_dma_buffer *bdb, struct bio_dma_chunk **chk_ptr)
 		if (rc)
 			return rc;
 	}
-
+done:
 	D_ASSERT(!d_list_empty(&bdb->bdb_idle_list));
 	chk = d_list_entry(bdb->bdb_idle_list.next, struct bio_dma_chunk,
 			   bdc_link);

--- a/src/bio/bio_bulk.c
+++ b/src/bio/bio_bulk.c
@@ -372,8 +372,8 @@ bulk_grp_grow(struct bio_dma_buffer *bdb, struct bio_bulk_group *bbg,
 	/* Grow DMA buffer when not reaching DMA upper bound */
 	if (bdb->bdb_tot_cnt < bio_chk_cnt_max) {
 		rc = dma_buffer_grow(bdb, 1);
-		if (rc != 0)
-			return rc;
+		if (rc == 0)
+			goto populate;
 	}
 
 	/* Try to evict an unused chunk from other bulk group */

--- a/src/bio/bio_internal.h
+++ b/src/bio/bio_internal.h
@@ -471,9 +471,9 @@ dump_dma_info(struct bio_dma_buffer *bdb)
 	struct bio_bulk_group	*bbg;
 	int			 i, bulk_grps = 0, bulk_chunks = 0;
 
-	D_EMIT("chunk_size:%u, tot_chunk:%u, active_iods:%u, used:%u,%u,%u\n",
-		bio_chk_sz, bdb->bdb_tot_cnt, bdb->bdb_active_iods,
-		bdb->bdb_used_cnt[BIO_CHK_TYPE_IO],
+	D_EMIT("chk_size:%u, tot_chk:%u/%u, active_iods:%u, used:%u,%u,%u\n",
+		bio_chk_sz, bdb->bdb_tot_cnt, bio_chk_cnt_max,
+		bdb->bdb_active_iods, bdb->bdb_used_cnt[BIO_CHK_TYPE_IO],
 		bdb->bdb_used_cnt[BIO_CHK_TYPE_LOCAL],
 		bdb->bdb_used_cnt[BIO_CHK_TYPE_REBUILD]);
 


### PR DESCRIPTION
Rebuild test shows that we may still hit DMA chunk allocation failure
(before reaching DMA buffer upper bound) even after using conservative
small upper bound. Such allocation failure could be caused by too
fragmented physical memory (or unexpected overhead from the DPDK
allocator).

- Revert the conservative small upper bound change;
- Tolerate chunk allocation failure by treating it in the same way of
  handling reaching DMA upper bound case;
- Fix a defect that could return -DER_AGAIN even buffer grow succeed;

Signed-off-by: Niu Yawei <yawei.niu@intel.com>