### PR TITLE
DAOS-8022 bio: avoid unnecessary page offset

### DIFF
--- a/src/bio/bio_bulk.c
+++ b/src/bio/bio_bulk.c
@@ -558,13 +558,7 @@ bulk_map_one(struct bio_desc *biod, struct bio_iov *biov, void *data)
 		if (rc)
 			return rc;
 	}
-
-	off = bio_iov2raw_off(biov);
-	end = bio_iov2raw_off(biov) + bio_iov2raw_len(biov);
-	pg_cnt = ((end + BIO_DMA_PAGE_SZ - 1) >> BIO_DMA_PAGE_SHIFT) -
-			(off >> BIO_DMA_PAGE_SHIFT);
-	D_ASSERT(pg_cnt > 0);
-	pg_off = off & ((uint64_t)BIO_DMA_PAGE_SZ - 1);
+	dma_biov2pg(biov, &off, &end, &pg_cnt, &pg_off);
 
 	if (bypass_bulk_cache(biod, biov, pg_cnt)) {
 		rc = dma_map_one(biod, biov, NULL);


### PR DESCRIPTION
When mapping DMA buffer to SCM, it's not necessary to shift start
offset within DMA page according to the SCM offset, that could save
one DMA page when the SCM offset isn't page size aligned.

Signed-off-by: Niu Yawei <yawei.niu@intel.com>