### PR TITLE
DAOS-7948 tools: Produce coredump on crash of daos tool

### DIFF
--- a/src/control/cmd/daos/main.go
+++ b/src/control/cmd/daos/main.go
@@ -12,6 +12,7 @@ import (
 	"io"
 	"os"
 	"path"
+	"runtime/debug"
 
 	"github.com/jessevdk/go-flags"
 	"github.com/pkg/errors"
@@ -201,6 +202,10 @@ or query/manage an object inside a container.`
 		exitWithError(log, err)
 	}
 	defer debugFini()
+
+	// Set the traceback level such that a crash results in
+	// a coredump (when ulimit -c is set appropriately).
+	debug.SetTraceback("crash")
 
 	_, err = p.ParseArgs(args)
 	if opts.JSON && wroteJSON.IsFalse() {

--- a/src/utils/daos_hdlr.c
+++ b/src/utils/daos_hdlr.c
@@ -705,7 +705,7 @@ cont_check_hdlr(struct cmd_args_s *ap)
 
 	begin = time(NULL);
 
-	D_PRINT("check container "DF_UUIDF" stated at: %s\n",
+	fprintf(ap->outstream, "check container "DF_UUIDF" started at: %s\n",
 		DP_UUID(ap->c_uuid), ctime(&begin));
 
 	while (!daos_anchor_is_eof(&anchor)) {


### PR DESCRIPTION
When a segfault occurs in the C side of the code, the
normal Go stacktrace isn't very helpful for troubleshooting.
This commit will change the crash behavior to produce a core
file when ulimit -c is set appropriately.