### PR TITLE
DAOS-7795 Test: Fix EC IOR smoke tests.

### DIFF
--- a/src/tests/ftest/erasurecode/ec_ior_smoke.yaml
+++ b/src/tests/ftest/erasurecode/ec_ior_smoke.yaml
@@ -52,7 +52,7 @@ ior:
     np: 48
   dfs_destroy: False
   iorflags:
-      flags: "-w -W -r -R -k -G 1 -vv"
+      flags: "-w -W -r -R -G 1 -vv"
   test_file: /testFile
   repetitions: 1
   transfersize_blocksize: !mux


### PR DESCRIPTION
Now we have some servers in CI which has lower NVMe ~350G capacity.
Removing the -k option to see if that free some space after each IOR run.

Signed-off-by: Samir Raval <samir.raval@intel.com>