### PR TITLE
DAOS-7927 control: Clean up control config handling

### DIFF
--- a/src/control/cmd/dmg/main.go
+++ b/src/control/cmd/dmg/main.go
@@ -236,9 +236,10 @@ and access control settings, along with system wide operations.`
 
 		ctlCfg, err := control.LoadConfig(opts.ConfigPath)
 		if err != nil {
-			if opts.ConfigPath != "" {
-				return errors.WithMessage(err, "failed to load control configuration")
+			if errors.Cause(err) != control.ErrNoConfigFile {
+				return errors.Wrap(err, "failed to load control configuration")
 			}
+			// Use the default config if no config file was found.
 			ctlCfg = control.DefaultConfig()
 		}
 		if ctlCfg.Path != "" {

--- a/src/control/lib/control/config.go
+++ b/src/control/lib/control/config.go
@@ -74,9 +74,17 @@ func LoadConfig(cfgPath string) (*Config, error) {
 		}
 	}
 
+	// If we still don't have a config file, return an error.
+	if cfgPath == "" {
+		return nil, ErrNoConfigFile
+	}
+
 	data, err := ioutil.ReadFile(cfgPath)
 	if err != nil {
 		return nil, err
+	}
+	if len(data) == 0 {
+		return nil, fmt.Errorf("empty config file: %s", cfgPath)
 	}
 
 	cfg := DefaultConfig()

--- a/src/control/lib/control/errors.go
+++ b/src/control/lib/control/errors.go
@@ -1,0 +1,15 @@
+//
+// (C) Copyright 2020-2021 Intel Corporation.
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+
+package control
+
+import "github.com/pkg/errors"
+
+var (
+	// ErrNoConfigFile indicates that no configuration file was able
+	// to be located.
+	ErrNoConfigFile = errors.New("no configuration file found")
+)


### PR DESCRIPTION
When reading/parsing a config file results in an error,
don't mask it by using the default config.