### PR TITLE
DAOS-7978 tests: add snapshot for EC object test

### DIFF
--- a/src/common/fail_loc.c
+++ b/src/common/fail_loc.c
@@ -81,8 +81,11 @@ daos_fail_loc_set(uint64_t fail_loc)
 	else
 		attr_in.fa_id = DAOS_FAIL_GROUP_GET(fail_loc);
 
-	D_ASSERT(attr_in.fa_id > 0);
-	D_ASSERT(attr_in.fa_id < DAOS_FAIL_MAX_GROUP);
+	if (attr_in.fa_id >= DAOS_FAIL_MAX_GROUP) {
+		D_ERROR("invalid fail_loc "DF_X64" fa_id: %u\n", fail_loc,
+			attr_in.fa_id);
+		return;
+	}
 
 	attr_in.fa_probability_x = 1;
 	attr_in.fa_probability_y = 1;

--- a/src/object/obj_rpc.h
+++ b/src/object/obj_rpc.h
@@ -344,10 +344,7 @@ CRT_RPC_DECLARE(obj_migrate, DAOS_ISEQ_OBJ_MIGRATE, DAOS_OSEQ_OBJ_MIGRATE)
 	((daos_epoch_range_t)	(ea_epoch_range)	CRT_VAR)	\
 	((uint64_t)		(ea_stripenum)		CRT_VAR)	\
 	((crt_bulk_t)		(ea_bulk)		CRT_VAR)	\
-	((uint32_t)		(ea_map_ver)		CRT_VAR)	\
-	((uint32_t)		(ea_remove_nr)		CRT_VAR)	\
-	((daos_recx_t)		(ea_remove_recxs)	CRT_ARRAY)	\
-	((daos_epoch_t)		(ea_remove_eps)		CRT_ARRAY)
+	((uint32_t)		(ea_map_ver)		CRT_VAR)
 
 
 #define DAOS_OSEQ_OBJ_EC_AGG	/* output fields */		 \

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -2109,40 +2109,15 @@ ds_obj_ec_agg_handler(crt_rpc_t *rpc)
 			goto out;
 		}
 	}
-	if (oea->ea_remove_nr) {
-		daos_epoch_range_t	epr;
-		uint64_t		stripe_end;
-		int			i;
 
-		stripe_end = (oea->ea_stripenum + 1) * obj_ioc2ec_ss(&ioc);
-		for (i = 0; i < oea->ea_remove_nr; i++) {
-			daos_recx_t *ea_recx;
-
-			ea_recx = &oea->ea_remove_recxs.ca_arrays[i];
-			if (DAOS_RECX_END(*ea_recx) > stripe_end)
-				continue;
-
-			epr.epr_hi = epr.epr_lo =
-				oea->ea_remove_eps.ca_arrays[i];
-			rc = vos_obj_array_remove(ioc.ioc_coc->sc_hdl,
-						  oea->ea_oid, &epr, dkey,
-						  &iod->iod_name, ea_recx);
-			if (rc) {
-				D_ERROR(DF_UOID"array_remove failed: "DF_RC"\n",
-					DP_UOID(oea->ea_oid), DP_RC(rc));
-			}
-		}
-
-	} else {
-		recx.rx_idx = oea->ea_stripenum * obj_ioc2ec_ss(&ioc);
-		recx.rx_nr = obj_ioc2ec_ss(&ioc);
-		rc = vos_obj_array_remove(ioc.ioc_coc->sc_hdl, oea->ea_oid,
-					  &oea->ea_epoch_range, dkey,
-					  &iod->iod_name, &recx);
-		if (rc) {
-			D_ERROR(DF_UOID"array_remove failed: "DF_RC"\n",
-				DP_UOID(oea->ea_oid), DP_RC(rc));
-		}
+	recx.rx_idx = oea->ea_stripenum * obj_ioc2ec_ss(&ioc);
+	recx.rx_nr = obj_ioc2ec_ss(&ioc);
+	rc = vos_obj_array_remove(ioc.ioc_coc->sc_hdl, oea->ea_oid,
+				  &oea->ea_epoch_range, dkey,
+				  &iod->iod_name, &recx);
+	if (rc) {
+		D_ERROR(DF_UOID"array_remove failed: "DF_RC"\n",
+			DP_UOID(oea->ea_oid), DP_RC(rc));
 	}
 out:
 	obj_rw_reply(rpc, rc, 0, &ioc);

--- a/src/tests/suite/daos_test.h
+++ b/src/tests/suite/daos_test.h
@@ -420,7 +420,7 @@ get_tgt_idx_by_oid_shard(test_arg_t *arg, daos_obj_id_t oid, uint32_t shard);
 void
 ec_verify_parity_data(struct ioreq *req, char *dkey, char *akey,
 		      daos_off_t offset, daos_size_t size,
-		      char *verify_data);
+		      char *verify_data, daos_handle_t th);
 
 int run_daos_sub_tests(char *test_name, const struct CMUnitTest *tests,
 		       int tests_size, int *sub_tests, int sub_tests_size,
@@ -477,8 +477,11 @@ int wait_and_verify_blobstore_state(uuid_t bs_uuid, char *expected_state,
 int wait_and_verify_pool_tgt_state(daos_handle_t poh, int tgtidx, int rank,
 				   char *expected_state);
 void save_group_state(void **state);
+
 void trigger_and_wait_ec_aggreation(test_arg_t *arg, daos_obj_id_t *oids,
-				    int oids_nr, uint64_t fail_loc);
+				    int oids_nr, char *dkey, char *akey,
+				    daos_off_t start, daos_size_t size,
+				    uint64_t fail_loc);
 
 enum op_type {
 	PARTIAL_UPDATE	=	1,


### PR DESCRIPTION
1. Add snapshot EC object test.

2. Do not need assert invalid fail_loc, since client
may send any fail_loc to set by server. Just ingore
the bad fail_loc for now.

3. Remove few obsolote and temporary EC aggregation code
after new object remove function support.

4. Add extra replica check on replica.

Signed-off-by: Di Wang <di.wang@intel.com>