### PR TITLE
Daos-7149-test: enable rebuild/io_conf_run.py after skipForTicket resolved

### DIFF
--- a/src/tests/ftest/rebuild/io_conf_run.py
+++ b/src/tests/ftest/rebuild/io_conf_run.py
@@ -5,7 +5,6 @@
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
 from daos_io_conf import IoConfTestBase
-from apricot import skipForTicket
 
 class RbldRunIoConf(IoConfTestBase):
     """Test daos_run_io_conf.
@@ -14,7 +13,6 @@ class RbldRunIoConf(IoConfTestBase):
     """
     # pylint: disable=too-many-ancestors
 
-    @skipForTicket("DAOS-7136")
     def test_daos_run_io_conf(self):
         """Jira ID: DAOS-3150.
 
@@ -30,6 +28,8 @@ class RbldRunIoConf(IoConfTestBase):
         Use Cases:
             Verify rebuild with data verification.
 
-        :avocado: tags=all,full_regression,hw,large,rebuild,iorebuild
+        :avocado: tags=all,full_regression
+        :avocado: tags=hw,large
+        :avocado: tags=rebuild,iorebuild
         """
         self.execute_io_conf_run_test()


### PR DESCRIPTION
Daos-7149-test: enable rebuild/io_conf_run.py after skipForTicket resolved

modified: rebuild/io_conf_run.py
Test-tag: iorebuild
Signed-off-by: Ding Ho ding-hwa.ho@intel.com