### PR TITLE
DAOS-0000 object: ENV to select dkey hash

### DIFF
--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -621,7 +621,11 @@ obj_dkey2grpidx(struct dc_object *obj, uint64_t hash, unsigned int map_ver)
 
 	D_ASSERT(obj->cob_shards_nr >= grp_size);
 
-	grp_idx = d_hash_jump(hash, obj->cob_shards_nr / grp_size);
+	if (cli_dkey_hash == CLI_DK_JUMP)
+		grp_idx = d_hash_jump(hash, obj->cob_shards_nr / grp_size);
+	else
+		grp_idx = hash % (obj->cob_shards_nr / grp_size);
+
 	D_RWLOCK_UNLOCK(&obj->cob_lock);
 
 	return grp_idx;

--- a/src/object/obj_internal.h
+++ b/src/object/obj_internal.h
@@ -104,6 +104,14 @@ struct dc_object {
 	struct dc_obj_layout	*cob_shards;
 };
 
+enum {
+	CLI_DK_UNKNOWN,
+	CLI_DK_NOHASH,
+	CLI_DK_JUMP,
+};
+
+extern int cli_dkey_hash;
+
 /**
  * Reassembled obj request.
  * User input iod/sgl possibly need to be reassembled at client before sending


### PR DESCRIPTION
Add environment variable and allow user to select hash
function on client, this is for debugging.

Signed-off-by: Liang Zhen <liang.zhen@intel.com>