### PR TITLE
DAOS-8027 vos: skip blob deletion properly

### DIFF
--- a/src/vos/vos_pool.c
+++ b/src/vos/vos_pool.c
@@ -449,7 +449,7 @@ vos_pool_kill(uuid_t uuid, bool force)
 	D_DEBUG(DB_MGMT, "No open handles, OK to delete\n");
 
 	/* NVMe device is configured */
-	if (bio_nvme_configured()) {
+	if (bio_nvme_configured() && xs_ctxt) {
 		D_DEBUG(DB_MGMT, "Deleting blob for xs:%p pool:"DF_UUID"\n",
 			xs_ctxt, DP_UUID(uuid));
 		rc = bio_blob_delete(uuid, xs_ctxt);


### PR DESCRIPTION
When VOS finalize in standalone mode (daos_perf, vos unit tests, etc.),
sysdb will try to delete blob if NVMe is enabled (/etc/daos_nvme.conf
is existing when VOS running in standalone mode), however, sysdb
actually doesn't have blob and bio_xs_context has already torndown
at this moment, so assert on "xs_ctxt != NULL" will be triggered in
bio_blob_delete().

Signed-off-by: Niu Yawei <yawei.niu@intel.com>