### PR TITLE
DAOS-7174 pool: take a generic string in pool_connect

### DIFF
--- a/src/client/api/pool.c
+++ b/src/client/api/pool.c
@@ -11,14 +11,18 @@
 #include "client_internal.h"
 #include "task_internal.h"
 
+/** Disable backward compat code */
+#undef daos_pool_connect
+
+/** Kept for backward ABI compatibility, but not advertised via header file */
 int
-daos_pool_connect(const uuid_t uuid, const char *grp,
-		  unsigned int flags,
+daos_pool_connect(const char *pool, const char *grp, unsigned int flags,
 		  daos_handle_t *poh, daos_pool_info_t *info, daos_event_t *ev)
 {
 	daos_pool_connect_t	*args;
 	tse_task_t		*task;
-	int			 rc;
+	const unsigned char	*uuid = (const unsigned char *) pool;
+	int			rc;
 
 	DAOS_API_ARG_ASSERT(*args, POOL_CONNECT);
 	if (!daos_uuid_valid(uuid))
@@ -29,46 +33,41 @@ daos_pool_connect(const uuid_t uuid, const char *grp,
 		return rc;
 
 	args = dc_task_get_args(task);
-	args->grp		= grp;
-	args->flags		= flags;
-	args->poh		= poh;
-	args->info		= info;
+	args->grp	= grp;
+	args->flags	= flags;
+	args->poh	= poh;
+	args->info	= info;
+	/** use deprecated field for backward compatibility */
 	uuid_copy((unsigned char *)args->uuid, uuid);
-	args->label		= NULL;
+	args->pool	= NULL;
 
 	return dc_task_schedule(task, true);
 }
 
+/**
+ * Real latest & greatest implementation of pool connect.
+ * Used by anyone including the daos_pool.h header file.
+ */
 int
-daos_pool_connect_by_label(const char *label, const char *grp,
-			   unsigned int flags, daos_handle_t *poh,
-			   daos_pool_info_t *info, daos_event_t *ev)
+daos_pool_connect2(const char *pool, const char *sys, unsigned int flags,
+		   daos_handle_t *poh, daos_pool_info_t *info, daos_event_t *ev)
 {
 	daos_pool_connect_t	*args;
 	tse_task_t		*task;
-	size_t			 label_len = 0;
 	int			 rc;
 
 	DAOS_API_ARG_ASSERT(*args, POOL_CONNECT);
-	if (label)
-		label_len = strnlen(label, DAOS_PROP_LABEL_MAX_LEN+1);
-	if (!label || (label_len == 0) ||
-	    (label_len > DAOS_PROP_LABEL_MAX_LEN)) {
-		D_ERROR("invalid label parameter\n");
-		return -DER_INVAL;
-	}
 
-	rc = dc_task_create(dc_pool_connect_lbl, NULL, ev, &task);
+	rc = dc_task_create(dc_pool_connect, NULL, ev, &task);
 	if (rc)
 		return rc;
-
 	args = dc_task_get_args(task);
-	args->grp		= grp;
-	args->flags		= flags;
-	args->poh		= poh;
-	args->info		= info;
+	args->pool	= pool;
+	args->grp	= sys;
+	args->flags	= flags;
+	args->poh	= poh;
+	args->info	= info;
 	uuid_clear(args->uuid);
-	args->label		= label;
 
 	return dc_task_schedule(task, true);
 }

--- a/src/client/dfuse/dfuse_core.c
+++ b/src/client/dfuse/dfuse_core.c
@@ -407,10 +407,8 @@ dfuse_pool_connect_by_label(struct dfuse_projection_info *fs_handle,
 
 	DFUSE_TRA_UP(dfp, fs_handle, "dfp");
 
-	rc = daos_pool_connect_by_label(label,
-				       fs_handle->dpi_info->di_group,
-				       DAOS_PC_RW,
-				       &dfp->dfp_poh, &p_info, NULL);
+	rc = daos_pool_connect(label, fs_handle->dpi_info->di_group,
+			       DAOS_PC_RW, &dfp->dfp_poh, &p_info, NULL);
 	if (rc) {
 		if (rc == -DER_NO_PERM)
 			DFUSE_TRA_INFO(dfp,

--- a/src/control/cmd/daos/pool.go
+++ b/src/control/cmd/daos/pool.go
@@ -80,7 +80,7 @@ func (cmd *poolBaseCmd) connectPool() error {
 
 		cmd.log.Debugf("connecting to pool: %s", cmd.PoolID().Label)
 		rc = C.daos_pool_connect(cLabel, cSysName, C.DAOS_PC_RW,
-					 &cmd.cPoolHandle, &poolInfo, nil)
+			&cmd.cPoolHandle, &poolInfo, nil)
 		if rc == 0 {
 			var err error
 			cmd.poolUUID, err = uuidFromC(poolInfo.pi_uuid)
@@ -94,8 +94,8 @@ func (cmd *poolBaseCmd) connectPool() error {
 		cmd.log.Debugf("connecting to pool: %s", cmd.poolUUID)
 		cUUIDstr := C.CString(cmd.poolUUID.String())
 		defer freeString(cUUIDstr)
-		rc = C.daos_pool_connect(cUUIDstr, cSysName,
-			C.DAOS_PC_RW, &cmd.cPoolHandle, nil, nil)
+		rc = C.daos_pool_connect(cUUIDstr, cSysName, C.DAOS_PC_RW,
+			&cmd.cPoolHandle, nil, nil)
 	default:
 		return errors.New("no pool UUID or label supplied")
 	}

--- a/src/control/cmd/daos/pool.go
+++ b/src/control/cmd/daos/pool.go
@@ -79,8 +79,8 @@ func (cmd *poolBaseCmd) connectPool() error {
 		defer freeString(cLabel)
 
 		cmd.log.Debugf("connecting to pool: %s", cmd.PoolID().Label)
-		rc = C.daos_pool_connect_by_label(cLabel, cSysName,
-			C.DAOS_PC_RW, &cmd.cPoolHandle, &poolInfo, nil)
+		rc = C.daos_pool_connect(cLabel, cSysName, C.DAOS_PC_RW,
+					 &cmd.cPoolHandle, &poolInfo, nil)
 		if rc == 0 {
 			var err error
 			cmd.poolUUID, err = uuidFromC(poolInfo.pi_uuid)
@@ -92,7 +92,9 @@ func (cmd *poolBaseCmd) connectPool() error {
 	case cmd.PoolID().HasUUID():
 		cmd.poolUUID = cmd.PoolID().UUID
 		cmd.log.Debugf("connecting to pool: %s", cmd.poolUUID)
-		rc = C.daos_pool_connect(cmd.poolUUIDPtr(), cSysName,
+		cUUIDstr := C.CString(cmd.poolUUID.String())
+		defer freeString(cUUIDstr)
+		rc = C.daos_pool_connect(cUUIDstr, cSysName,
 			C.DAOS_PC_RW, &cmd.cPoolHandle, nil, nil)
 	default:
 		return errors.New("no pool UUID or label supplied")

--- a/src/include/daos/pool.h
+++ b/src/include/daos/pool.h
@@ -88,7 +88,6 @@ void dc_pool_put(struct dc_pool *pool);
 int dc_pool_local2global(daos_handle_t poh, d_iov_t *glob);
 int dc_pool_global2local(d_iov_t glob, daos_handle_t *poh);
 int dc_pool_connect(tse_task_t *task);
-int dc_pool_connect_lbl(tse_task_t *task);
 int dc_pool_disconnect(tse_task_t *task);
 int dc_pool_query(tse_task_t *task);
 int dc_pool_query_target(tse_task_t *task);

--- a/src/include/daos/tests_lib.h
+++ b/src/include/daos/tests_lib.h
@@ -187,8 +187,7 @@ int dmg_pool_list(const char *dmg_config_file, const char *group,
 
 /**
  * Create a pool spanning \a tgts in \a grp. Upon successful completion, report
- * back the pool UUID in \a uuid and the pool service rank(s) in \a svc, which
- * are required by daos_pool_connect() to establish a pool connection.
+ * back the pool UUID in \a uuid and the pool service rank(s) in \a svc.
  *
  * Targets are assumed to share the same \a size.
  *

--- a/src/include/daos_api.h
+++ b/src/include/daos_api.h
@@ -33,8 +33,7 @@ enum {
 
 /**
  * Generate a rank list from a string with a separator argument. This is a
- * convenience function to generate the rank list required by
- * daos_pool_connect().
+ * convenience function to generate the rank list.
  *
  * \param[in]	str	string with the rank list
  * \param[in]	sep	separator of the ranks in \a str.

--- a/src/include/daos_pool.h
+++ b/src/include/daos_pool.h
@@ -422,7 +422,7 @@ daos_pool_connect2(const char *pool, const char *sys, unsigned int flags,
 		   daos_handle_t *poh, daos_pool_info_t *info, daos_event_t *ev);
 
 /**
- * For backward compatility, support old API where a const uuid_t was used
+ * For backward compatibility, support old API where a const uuid_t was used
  * instead of a string to identify the pool.
  */
 #define daos_pool_connect(po, ...)					\

--- a/src/include/daos_pool.h
+++ b/src/include/daos_pool.h
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
 /**
- * DAOS stoarge pool types and functions
+ * DAOS storage pool types and functions
  */
 #ifndef __DAOS_POOL_H__
 #define __DAOS_POOL_H__
@@ -164,12 +164,13 @@ struct daos_pool_cont_info {
 };
 
 /**
- * Connect to the DAOS pool identified by UUID \a uuid. Upon a successful
- * completion, \a poh returns the pool handle, and \a info returns the latest
- * pool information.
+ * Connect to the DAOS pool identified by its label or UUID string.
+ * Upon a successful completion, \a poh returns the pool handle, and \a info
+ * returns the latest pool information.
  *
- * \param[in]	uuid	UUID to identify a pool.
- * \param[in]	grp	Process set name of the DAOS servers managing the pool
+ * \param[in]	pool	label or UUID string to identify a pool.
+ * \param[in]	sys	DAOS system name to use for the pool connect.
+ *			Pass NULL to connect to the default system.
  * \param[in]	flags	Connect mode represented by the DAOS_PC_ bits.
  * \param[out]	poh	Returned open handle.
  * \param[in,out]
@@ -187,38 +188,8 @@ struct daos_pool_cont_info {
  *			-DER_NONEXIST	Pool is nonexistent
  */
 int
-daos_pool_connect(const uuid_t uuid, const char *grp,
-		  unsigned int flags,
+daos_pool_connect(const char *pool, const char *sys, unsigned int flags,
 		  daos_handle_t *poh, daos_pool_info_t *info, daos_event_t *ev);
-
-/**
- * Connect to the DAOS pool identified by \a label. Upon a successful
- * completion, \a poh returns the pool handle, and \a info returns the latest
- * pool information.
- *
- * \param[in]	label	label string to identify a pool.
- * \param[in]	grp	Process set name of the DAOS servers managing the pool
- * \param[in]	flags	Connect mode represented by the DAOS_PC_ bits.
- * \param[out]	poh	Returned open handle.
- * \param[in,out]
- *		info	Optional, returned pool information,
- *			see daos_pool_info_bit.
- * \param[in]	ev	Completion event, it is optional and can be NULL.
- *			The function will run in blocking mode if \a ev is NULL.
- *
- * \return		These values will be returned by \a ev::ev_error in
- *			non-blocking mode:
- *			0		Success
- *			-DER_INVAL	Invalid parameter
- *			-DER_UNREACH	Network is unreachable
- *			-DER_NO_PERM	Permission denied
- *			-DER_NONEXIST	Pool is nonexistent
- */
-int
-daos_pool_connect_by_label(const char *label, const char *grp,
-			   unsigned int flags,
-			   daos_handle_t *poh, daos_pool_info_t *info,
-			   daos_event_t *ev);
 
 /**
  * Disconnect from the DAOS pool. It should revoke all the container open
@@ -440,6 +411,36 @@ daos_pool_del_attr(daos_handle_t poh, int n, char const *const names[],
 int
 daos_pool_list_cont(daos_handle_t poh, daos_size_t *ncont,
 		    struct daos_pool_cont_info *cbuf, daos_event_t *ev);
+
+/**
+ * Backward compatibility code.
+ * Please don't use directly
+ */
+
+int
+daos_pool_connect2(const char *pool, const char *sys, unsigned int flags,
+		   daos_handle_t *poh, daos_pool_info_t *info, daos_event_t *ev);
+
+/**
+ * For backward compatility, support old API where a const uuid_t was used
+ * instead of a string to identify the pool.
+ */
+#define daos_pool_connect(po, ...)					\
+	({								\
+		int _ret;						\
+		char _str[37];						\
+		const char *__str;					\
+		if (__builtin_types_compatible_p(typeof(po), char *) ||	\
+		    __builtin_types_compatible_p(typeof(po),		\
+						 const char *)) {	\
+			__str = (const char *)po;			\
+		} else {						\
+			uuid_unparse((unsigned char *)po, _str);	\
+			__str = _str;					\
+		}							\
+		_ret = daos_pool_connect2(__str, __VA_ARGS__);		\
+		_ret;							\
+	})
 
 #if defined(__cplusplus)
 }

--- a/src/include/daos_task.h
+++ b/src/include/daos_task.h
@@ -186,7 +186,7 @@ typedef struct {
 	daos_handle_t		*poh;
 	/** Optional, returned pool information. */
 	daos_pool_info_t	*info;
-	/** Pool's label or UUID string to connect to, API v1.2.2 */
+	/** Pool's label or UUID string to connect to, API v1.3.0 */
 	const char		*pool;
 } daos_pool_connect_t;
 

--- a/src/include/daos_task.h
+++ b/src/include/daos_task.h
@@ -36,7 +36,7 @@ typedef enum {
 	DAOS_OPC_MGMT_GET_BS_STATE,
 
 	/** Pool APIs */
-	DAOS_OPC_POOL_CONNECT,
+	DAOS_OPC_POOL_CONNECT = 5,
 	DAOS_OPC_POOL_DISCONNECT,
 	DAOS_OPC_POOL_EXCLUDE,
 	DAOS_OPC_POOL_EXCLUDE_OUT,
@@ -51,7 +51,7 @@ typedef enum {
 	DAOS_OPC_POOL_LIST_CONT,
 
 	/** Container APIs */
-	DAOS_OPC_CONT_CREATE,
+	DAOS_OPC_CONT_CREATE = 18,
 	DAOS_OPC_CONT_OPEN,
 	DAOS_OPC_CONT_CLOSE,
 	DAOS_OPC_CONT_DESTROY,
@@ -72,7 +72,7 @@ typedef enum {
 	DAOS_OPC_CONT_DESTROY_SNAP,
 
 	/** Transaction APIs */
-	DAOS_OPC_TX_OPEN,
+	DAOS_OPC_TX_OPEN = 37,
 	DAOS_OPC_TX_COMMIT,
 	DAOS_OPC_TX_ABORT,
 	DAOS_OPC_TX_OPEN_SNAP,
@@ -80,7 +80,7 @@ typedef enum {
 	DAOS_OPC_TX_RESTART,
 
 	/** Object APIs */
-	DAOS_OPC_OBJ_REGISTER_CLASS,
+	DAOS_OPC_OBJ_REGISTER_CLASS = 43,
 	DAOS_OPC_OBJ_QUERY_CLASS,
 	DAOS_OPC_OBJ_LIST_CLASS,
 	DAOS_OPC_OBJ_OPEN,
@@ -99,7 +99,7 @@ typedef enum {
 	DAOS_OPC_OBJ_LIST_OBJ,
 
 	/** Array APIs */
-	DAOS_OPC_ARRAY_CREATE,
+	DAOS_OPC_ARRAY_CREATE = 60,
 	DAOS_OPC_ARRAY_OPEN,
 	DAOS_OPC_ARRAY_CLOSE,
 	DAOS_OPC_ARRAY_DESTROY,
@@ -110,7 +110,7 @@ typedef enum {
 	DAOS_OPC_ARRAY_SET_SIZE,
 
 	/** KV APIs */
-	DAOS_OPC_KV_OPEN,
+	DAOS_OPC_KV_OPEN = 69,
 	DAOS_OPC_KV_CLOSE,
 	DAOS_OPC_KV_DESTROY,
 	DAOS_OPC_KV_GET,
@@ -173,7 +173,10 @@ typedef struct {
 
 /** pool connect by UUID args */
 typedef struct {
-	/** UUID of the pool. */
+	/**
+	 * Deprecated, please pass the Pool label or UUID string via the pool
+	 * arg at the end of this structure
+	 */
 	uuid_t			 uuid;
 	/** Process set name of the DAOS servers managing the pool. */
 	const char		*grp;
@@ -183,8 +186,8 @@ typedef struct {
 	daos_handle_t		*poh;
 	/** Optional, returned pool information. */
 	daos_pool_info_t	*info;
-	/** Pool label, API v1.2.2 (placed at end for ABI compatibility) */
-	const char		*label;
+	/** Pool's label or UUID string to connect to, API v1.2.2 */
+	const char		*pool;
 } daos_pool_connect_t;
 
 /** pool disconnect args */

--- a/src/tests/suite/daos_test_common.c
+++ b/src/tests/suite/daos_test_common.c
@@ -156,11 +156,11 @@ test_setup_pool_connect(void **state, struct test_pool *pool)
 		if (arg->pool_label) {
 			print_message("setup: connecting to pool by label %s\n",
 				      arg->pool_label);
-			rc = daos_pool_connect_by_label(arg->pool_label,
-							arg->group, flags,
-							&arg->pool.poh,
-							&arg->pool.pool_info,
-							NULL);
+			rc = daos_pool_connect(arg->pool_label,
+					       arg->group, flags,
+					       &arg->pool.poh,
+					       &arg->pool.pool_info,
+					       NULL);
 		} else {
 			print_message("setup: connecting to pool "DF_UUID"\n",
 				      DP_UUID(arg->pool.pool_uuid));

--- a/src/utils/daos.c
+++ b/src/utils/daos.c
@@ -1118,10 +1118,10 @@ fs_op_hdlr(struct cmd_args_s *ap)
 		}
 
 		if (ap->pool_label) {
-			rc = daos_pool_connect_by_label(ap->pool_label,
-							ap->sysname,
-							DAOS_PC_RW, &ap->pool,
-							NULL, NULL);
+			rc = daos_pool_connect(ap->pool_label,
+					       ap->sysname,
+					       DAOS_PC_RW, &ap->pool,
+					       NULL, NULL);
 			if (rc != 0) {
 				fprintf(stderr,
 					"failed to connect to pool "
@@ -1286,9 +1286,9 @@ cont_op_hdlr(struct cmd_args_s *ap)
 	}
 
 	if (ap->pool_label) {
-		rc = daos_pool_connect_by_label(ap->pool_label, ap->sysname,
-						DAOS_PC_RW, &ap->pool,
-						NULL, NULL);
+		rc = daos_pool_connect(ap->pool_label, ap->sysname,
+				       DAOS_PC_RW, &ap->pool,
+				       NULL, NULL);
 		if (rc != 0) {
 			fprintf(stderr, "failed to connect to "
 				"pool %s: %s (%d)\n",


### PR DESCRIPTION
Change daos_pool_connect() to take a string an a input parameter
that can be interpreted as either a label or a UUID string.
Backward API compatibility is supported via a
macro that will automatically convert a uuid_t (old API) to
a UUID string. We could eventually remove the macro in 2.2 or
beyond.
Backward ABI compatibility is supported by keeping around
the daos_pool_connect() symbol, but not advertising it via the
header files. We could eventually remove this symbol in 2.2.

Signed-off-by: Johann Lombardi <johann.lombardi@intel.com>