### PR TITLE
DAOS-8025 control,bio: disable dpdk telemetry

### DIFF
--- a/src/bio/bio_xstream.c
+++ b/src/bio/bio_xstream.c
@@ -83,6 +83,7 @@ bio_spdk_env_init(void)
 
 	spdk_env_opts_init(&opts);
 	opts.name = "daos";
+
 	/*
 	 * TODO: Set opts.mem_size to nvme_glb.bd_mem_size
 	 * Currently we can't guarantee clean shutdown (no hugepages leaked).
@@ -90,11 +91,19 @@ bio_spdk_env_init(void)
 	 * and DPDK will fail to initialize.
 	 */
 
-	if (nvme_glb.bd_shm_id != DAOS_NVME_SHMID_NONE)
+	if (nvme_glb.bd_shm_id == DAOS_NVME_SHMID_NONE)
 		opts.shm_id = nvme_glb.bd_shm_id;
 
-	/* quiet DPDK logging by setting level to ERROR */
-	opts.env_context = "--log-level=lib.eal:4";
+	/*
+	 * TODO: Find a way to set multiple overrides, currently only single
+	 * option can be overridden with opts.env_context.
+	 */
+
+	/*
+	 * Quiet DPDK logging by setting level to ERROR
+	 *  opts.env_context = "--log-level=lib.eal:4";
+	 */
+	opts.env_context = "--no-telemetry";
 
 	rc = spdk_env_init(&opts);
 	if (rc != 0) {

--- a/src/bio/bio_xstream.c
+++ b/src/bio/bio_xstream.c
@@ -91,7 +91,7 @@ bio_spdk_env_init(void)
 	 * and DPDK will fail to initialize.
 	 */
 
-	if (nvme_glb.bd_shm_id == DAOS_NVME_SHMID_NONE)
+	if (nvme_glb.bd_shm_id != DAOS_NVME_SHMID_NONE)
 		opts.shm_id = nvme_glb.bd_shm_id;
 
 	/*

--- a/src/control/lib/spdk/spdk.go
+++ b/src/control/lib/spdk/spdk.go
@@ -143,7 +143,9 @@ func (e *EnvImpl) InitSPDKEnv(log logging.Logger, opts *EnvOptions) error {
 		C.setArrayString(cAllowList, C.CString(s), C.int(i))
 	}
 
-	envCtx := C.CString("--log-level=lib.eal:4")
+	// TODO: find a way of passing multiple dpdk commandline opts
+	// envCtx := C.CString("--log-level=lib.eal:4")
+	envCtx := C.CString("--no-telemetry")
 	defer C.free(unsafe.Pointer(envCtx))
 
 	retPtr := C.daos_spdk_init(0, envCtx, C.ulong(len(opts.PciAllowList)),

--- a/src/control/lib/spdk/src/nvme_control.c
+++ b/src/control/lib/spdk/src/nvme_control.c
@@ -475,7 +475,6 @@ daos_spdk_init(int mem_sz, char *env_ctx, size_t nr_pcil, char **pcil)
 		opts.num_pci_addr = nr_pcil;
 	}
 	opts.name = "daos_admin";
-	opts.shm_id = getpid();
 
 	rc = spdk_env_init(&opts);
 	if (rc < 0) {


### PR DESCRIPTION
DPDK exposes telemetry through a temporary socket file.
To avoid telemetry socket file conflicts between runs with different
users, disable DPDK telemetry by passing option override when
initializing SPDK environment. DAOS doesn't use DPDK telemetry.

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>