### PR TITLE
DAOS-8030 hadoop: Update Hadoop from 3.3.0 to 3.3.1

### DIFF
--- a/src/client/java/hadoop-daos/pom.xml
+++ b/src/client/java/hadoop-daos/pom.xml
@@ -15,7 +15,7 @@
   <packaging>jar</packaging>
 
   <properties>
-    <hadoop.version>3.3.0</hadoop.version>
+    <hadoop.version>3.3.1</hadoop.version>
     <native.build.path>${project.basedir}/build</native.build.path>
     <daos.install.path>${project.basedir}/install</daos.install.path>
   </properties>


### PR DESCRIPTION
Upgrade the version of Hadoop to remove some known CVEs.

Signed-off-by: David Quigley <david.quigley@intel.com>