### PR TITLE
DAOS-7905 dtx: not rebalance leaf nodes for committed DTX table

### DIFF
--- a/src/common/btree.c
+++ b/src/common/btree.c
@@ -2244,6 +2244,17 @@ btr_node_del_leaf(struct btr_context *tcx,
 		if (rc != 0)
 			return rc;
 
+		if (tcx->tc_feats & BTR_FEAT_SKIP_LEAF_REBAL) {
+			struct btr_node	*nd;
+
+			nd = btr_off2ptr(tcx, cur_tr->tr_node);
+			/* Current leaf node become empty,
+			 * will be removed from parent node.
+			 */
+			if (nd->tn_keyn == 0)
+				return 0;
+		}
+
 		return 1;
 	}
 
@@ -2563,12 +2574,12 @@ btr_node_del_rec(struct btr_context *tcx, struct btr_trace *par_tr,
 		is_leaf ? "record" : "child", is_leaf ? "leaf" : "non-leaf",
 		cur_nd->tn_keyn);
 
-	if (cur_nd->tn_keyn > 1) {
+	if (cur_nd->tn_keyn > 1 ||
+	    (is_leaf && tcx->tc_feats & BTR_FEAT_SKIP_LEAF_REBAL)) {
 		/* OK to delete record without doing any extra work */
 		D_DEBUG(DB_TRACE, "Straight away deletion, no rebalance.\n");
 		sib_off	= BTR_NODE_NULL;
-		sib_on_right	= false; /* whatever... */
-
+		sib_on_right = false; /* whatever... */
 	} else { /* needs to rebalance or merge nodes */
 		D_DEBUG(DB_TRACE, "Parent trace at=%d, key_nr=%d\n",
 			par_tr->tr_at, par_nd->tn_keyn);
@@ -3834,6 +3845,9 @@ btr_class_init(umem_off_t root_off, struct btr_root *root,
 
 	if (tc->tc_feats & BTR_FEAT_DYNAMIC_ROOT)
 		*tree_feats |= BTR_FEAT_DYNAMIC_ROOT;
+
+	if (tc->tc_feats & BTR_FEAT_SKIP_LEAF_REBAL)
+		*tree_feats |= BTR_FEAT_SKIP_LEAF_REBAL;
 
 	if ((*tree_feats & tc->tc_feats) != *tree_feats) {
 		D_ERROR("Unsupported features "DF_X64"/"DF_X64"\n",

--- a/src/include/daos/btree.h
+++ b/src/include/daos/btree.h
@@ -482,6 +482,8 @@ enum btr_feats {
 	 *  tree class
 	 */
 	BTR_FEAT_DYNAMIC_ROOT		= (1 << 2),
+	/** Skip rebalance leaf when delete some record from the leaf. */
+	BTR_FEAT_SKIP_LEAF_REBAL	= (1 << 3),
 };
 
 /**

--- a/src/vos/vos_dtx.c
+++ b/src/vos/vos_dtx.c
@@ -491,7 +491,8 @@ vos_dtx_table_register(void)
 		return rc;
 	}
 
-	rc = dbtree_class_register(VOS_BTR_DTX_CMT_TABLE, 0,
+	rc = dbtree_class_register(VOS_BTR_DTX_CMT_TABLE,
+				   BTR_FEAT_SKIP_LEAF_REBAL,
 				   &dtx_committed_btr_ops);
 	if (rc != 0)
 		D_ERROR("Failed to register DTX committed dbtree: %d\n", rc);

--- a/src/vos/vos_pool.c
+++ b/src/vos/vos_pool.c
@@ -700,9 +700,9 @@ pool_open(PMEMobjpool *ph, struct vos_pool_df *pool_df, uuid_t uuid,
 	memset(&vma, 0, sizeof(vma));
 	vma.uma_id = UMEM_CLASS_VMEM;
 
-	rc = dbtree_create_inplace_ex(VOS_BTR_DTX_CMT_TABLE, 0,
-				      DTX_BTREE_ORDER, &vma,
-				      &pool->vp_dtx_committed_btr,
+	rc = dbtree_create_inplace_ex(VOS_BTR_DTX_CMT_TABLE,
+				      BTR_FEAT_SKIP_LEAF_REBAL, DTX_BTREE_ORDER,
+				      &vma, &pool->vp_dtx_committed_btr,
 				      DAOS_HDL_INVAL, pool,
 				      &pool->vp_dtx_committed_hdl);
 	if (rc != 0) {


### PR DESCRIPTION
The committed DTX table is organized as a btree. Normally, during
DTX aggregation, some DTX entries will be removed from such btree.
When some leaf node becomes empty, it will trigger btree rebalance
that will cause some records movement from its sibling leaf nodes.
Such rebalance is good for some potential subsequent btree search.
But for DTX aggregation, we can do some optimization:

For each time DTX aggregation run, it will remove a lot of entries
from the committed DTX table. These entries will be removed one by
one via single transaction. When some leaf node is empty, a record
from sibling leaf node will be moved to current empty node, but it
is quite possible that such record will be the next to be removed.
Then the movement caused by leaf nodes rebalance will cause a lot
of unnecessary overhead. On the other hand, searching in committed
DTX table is mainly for handling resent RPC and DTX refresh, it is
expected that these searching will happen relatively rare. So even
if without btree leaf nodes rebalance, it will not much affect the
whole system efficiency.

Signed-off-by: Fan Yong <fan.yong@intel.com>