### PR TITLE
DAOS-6540 dfuse: Detect clobbered files and update kernel accordingly.

### DIFF
--- a/src/client/dfs/dfs.c
+++ b/src/client/dfs/dfs.c
@@ -3586,6 +3586,7 @@ dfs_update_parent(dfs_obj_t *obj, dfs_obj_t *src_obj, const char *name)
 	return 0;
 }
 
+/* Update a object to a new parent, taking the parent directly */
 void
 dfs_update_parentfd(dfs_obj_t *obj, dfs_obj_t *src_obj, const char *name)
 {
@@ -4184,7 +4185,7 @@ out:
 	return rc;
 }
 
-/* Accepts oid as input or output parameter */
+/* Returns but does not checked moved oid, will check and return oid for clobbered file */
 int
 dfs_moveoi(dfs_t *dfs, dfs_obj_t *parent, char *name, dfs_obj_t *new_parent,
 	   char *new_name, daos_obj_id_t *moid, daos_obj_id_t *oid)
@@ -4199,6 +4200,8 @@ dfs_moveoi(dfs_t *dfs, dfs_obj_t *parent, char *name, dfs_obj_t *new_parent,
 
 	if (dfs == NULL || !dfs->mounted)
 		return EINVAL;
+	if (moid && (moid->lo || moid->hi))
+		return EINVAL;
 	if (dfs->amode != O_RDWR)
 		return EPERM;
 	if (parent == NULL)
@@ -4209,8 +4212,6 @@ dfs_moveoi(dfs_t *dfs, dfs_obj_t *parent, char *name, dfs_obj_t *new_parent,
 		new_parent = &dfs->root;
 	else if (!S_ISDIR(new_parent->mode))
 		return ENOTDIR;
-	if (moid && (moid->lo || moid->hi))
-		return EINVAL;
 
 	rc = check_name(name, &len);
 	if (rc)

--- a/src/client/dfs/dfs_internal.h
+++ b/src/client/dfs/dfs_internal.h
@@ -53,21 +53,17 @@ dfs_lookupx(dfs_t *dfs, dfs_obj_t *parent, const char *name, int flags,
 	    dfs_obj_t **obj, mode_t *mode, struct stat *stbuf, int xnr,
 	    char *xnames[], void *xvals[], daos_size_t *xsizes);
 
-/* oid-in variants of dfs functions, these can be be used to verify the file being clobbered */
-int
-dfs_removeoi(dfs_t *dfs, dfs_obj_t *parent, const char *name, bool force, daos_obj_id_t *oid);
-
 /* moid is moved oid, oid is clobbered file.
  * This isn't yet fully compatible with dfuse because we also want to pass in a flag for if the
  * destination exists.
  */
 int
-dfs_moveoi(dfs_t *dfs, dfs_obj_t *parent, char *name, dfs_obj_t *new_parent, char *new_name,
-	   daos_obj_id_t *moid, daos_obj_id_t *oid);
+dfs_move_internal(dfs_t *dfs, dfs_obj_t *parent, char *name, dfs_obj_t *new_parent, char *new_name,
+		  daos_obj_id_t *moid, daos_obj_id_t *oid);
 
-/* Set the parent, but takes the parent, rather than another file object */
+/* Set the in-memory parent, but takes the parent, rather than another file object */
 void
-dfs_update_parentfd(dfs_obj_t *obj, dfs_obj_t *src_obj, const char *name);
+dfs_update_parentfd(dfs_obj_t *obj, dfs_obj_t *new_parent, const char *name);
 
 /** update chunk size and oclass of obj with the ones from new_obj */
 void

--- a/src/client/dfs/dfs_internal.h
+++ b/src/client/dfs/dfs_internal.h
@@ -53,6 +53,22 @@ dfs_lookupx(dfs_t *dfs, dfs_obj_t *parent, const char *name, int flags,
 	    dfs_obj_t **obj, mode_t *mode, struct stat *stbuf, int xnr,
 	    char *xnames[], void *xvals[], daos_size_t *xsizes);
 
+/* oid-in variants of dfs functions, these can be be used to verify the file being clobbered */
+int
+dfs_removeoi(dfs_t *dfs, dfs_obj_t *parent, const char *name, bool force, daos_obj_id_t *oid);
+
+/* moid is moved oid, oid is clobbered file.
+ * This isn't yet fully compatible with dfuse because we also want to pass in a flag for if the
+ * destination exists.
+ */
+int
+dfs_moveoi(dfs_t *dfs, dfs_obj_t *parent, char *name, dfs_obj_t *new_parent, char *new_name,
+	   daos_obj_id_t *moid, daos_obj_id_t *oid);
+
+/* Set the parent, but takes the parent, rather than another file object */
+void
+dfs_update_parentfd(dfs_obj_t *obj, dfs_obj_t *src_obj, const char *name);
+
 /** update chunk size and oclass of obj with the ones from new_obj */
 void
 dfs_obj_copy_attr(dfs_obj_t *dst_obj, dfs_obj_t *src_obj);

--- a/src/client/dfuse/dfuse.h
+++ b/src/client/dfuse/dfuse.h
@@ -670,7 +670,7 @@ dfuse_reply_entry(struct dfuse_projection_info *fs_handle,
 
 /* Mark object as removed and invalidate any kernel data for it */
 void
-dfuse_oid_unlinked(struct dfuse_projection_info *fs_handle, daos_obj_id_t *oid,
+dfuse_oid_unlinked(struct dfuse_projection_info *fs_handle, fuse_req_t req, daos_obj_id_t *oid,
 		   struct dfuse_inode_entry *parent, const char *name);
 
 /* dfuse_cont.c */

--- a/src/client/dfuse/dfuse.h
+++ b/src/client/dfuse/dfuse.h
@@ -531,6 +531,9 @@ struct dfuse_inode_entry {
 	bool			ie_truncated;
 
 	bool			ie_root;
+
+	/** File has been unlinked from daos */
+	bool			ie_unlinked;
 };
 
 /* Generate the inode to use for this dfs object.  This is generating a single
@@ -664,6 +667,11 @@ dfuse_reply_entry(struct dfuse_projection_info *fs_handle,
 		  struct fuse_file_info *fi_out,
 		  bool is_new,
 		  fuse_req_t req);
+
+/* Mark object as removed and invalidate any kernel data for it */
+void
+dfuse_oid_unlinked(struct dfuse_projection_info *fs_handle, daos_obj_id_t *oid,
+		   struct dfuse_inode_entry *parent, const char *name);
 
 /* dfuse_cont.c */
 void

--- a/src/client/dfuse/dfuse_core.c
+++ b/src/client/dfuse/dfuse_core.c
@@ -193,7 +193,7 @@ ih_free(struct d_hash_table *htable, d_list_t *rlink)
 
 	ie = container_of(rlink, struct dfuse_inode_entry, ie_htl);
 
-	DFUSE_TRA_DEBUG(ie, "parent %lu", ie->ie_parent);
+	DFUSE_TRA_DEBUG(ie, "parent %#lx", ie->ie_parent);
 	dfuse_ie_close(fs_handle, ie);
 }
 

--- a/src/client/dfuse/ops/fgetattr.c
+++ b/src/client/dfuse/ops/fgetattr.c
@@ -13,6 +13,12 @@ dfuse_cb_getattr(fuse_req_t req, struct dfuse_inode_entry *ie)
 	struct stat	stat = {};
 	int		rc;
 
+	if (ie->ie_unlinked) {
+		DFUSE_TRA_DEBUG(ie, "File is unlinked, returning most recent data");
+		DFUSE_REPLY_ATTR(ie, req, &ie->ie_stat);
+		return;
+	}
+
 	rc = dfs_ostat(ie->ie_dfs->dfs_ns, ie->ie_obj, &stat);
 	if (rc != 0)
 		D_GOTO(err, rc);

--- a/src/client/dfuse/ops/rename.c
+++ b/src/client/dfuse/ops/rename.c
@@ -76,8 +76,8 @@ dfuse_cb_rename(fuse_req_t req, struct dfuse_inode_entry *parent,
 	if (!newparent)
 		newparent = parent;
 
-	rc = dfs_moveoi(parent->ie_dfs->dfs_ns, parent->ie_obj, (char *)name,
-			newparent->ie_obj, (char *)newname, &moid, &oid);
+	rc = dfs_move_internal(parent->ie_dfs->dfs_ns, parent->ie_obj, (char *)name,
+			       newparent->ie_obj, (char *)newname, &moid, &oid);
 	if (rc)
 		D_GOTO(out, rc);
 

--- a/src/client/dfuse/ops/rename.c
+++ b/src/client/dfuse/ops/rename.c
@@ -7,12 +7,65 @@
 #include "dfuse_common.h"
 #include "dfuse.h"
 
+/* Handle a file that has been moved.
+ *
+ * Dfuse may not be aware of this file, but if it is find the inode and update it for the new
+ * location.
+ */
+
+static void
+dfuse_oid_moved(struct dfuse_projection_info *fs_handle, daos_obj_id_t *oid,
+		struct dfuse_inode_entry *parent, const char *name,
+		struct dfuse_inode_entry *newparent,
+		const char *newname)
+{
+	struct dfuse_inode_entry	*ie;
+	d_list_t			*rlink;
+	int				rc;
+	ino_t ino;
+
+	dfuse_compute_inode(parent->ie_dfs, oid, &ino);
+
+	DFUSE_TRA_DEBUG(fs_handle, "Renamed file was %#lx", ino);
+
+	rlink = d_hash_rec_find(&fs_handle->dpi_iet, &ino, sizeof(ino));
+	if (!rlink)
+		return;
+
+	ie = container_of(rlink, struct dfuse_inode_entry, ie_htl);
+
+	/* If the move is not from where we thought the file was then invalidate the old entry */
+	if ((ie->ie_parent != parent->ie_stat.st_ino) ||
+		(strncmp(ie->ie_name, name, NAME_MAX + 1) != 0)) {
+		DFUSE_TRA_DEBUG(ie, "Invalidating old name");
+
+		rc = fuse_lowlevel_notify_inval_entry(fs_handle->dpi_info->di_session,
+						      ie->ie_parent,
+						      ie->ie_name, strnlen(ie->ie_name, NAME_MAX));
+
+		if (rc)
+			DFUSE_TRA_ERROR(ie, "inval_entry returned %d: %s", rc, strerror(-rc));
+	}
+
+	/* Update the inode entry data */
+	ie->ie_parent = newparent->ie_parent;
+	strncpy(ie->ie_name, newname, NAME_MAX);
+
+	/* Set the new parent and name */
+	dfs_update_parentfd(ie->ie_obj, newparent->ie_obj, newname);
+
+	/* Drop the ref again */
+	d_hash_rec_decref(&fs_handle->dpi_iet, rlink);
+}
+
 void
 dfuse_cb_rename(fuse_req_t req, struct dfuse_inode_entry *parent,
 		const char *name, struct dfuse_inode_entry *newparent,
 		const char *newname, unsigned int flags)
 {
 	struct dfuse_projection_info	*fs_handle;
+	daos_obj_id_t			moid = {};
+	daos_obj_id_t			oid = {};
 	int				rc;
 
 	fs_handle = fuse_req_userdata(req);
@@ -23,27 +76,23 @@ dfuse_cb_rename(fuse_req_t req, struct dfuse_inode_entry *parent,
 	if (!newparent)
 		newparent = parent;
 
-	rc = dfs_move(parent->ie_dfs->dfs_ns, parent->ie_obj, (char *)name,
-		      newparent->ie_obj, (char *)newname, NULL);
+	rc = dfs_moveoi(parent->ie_dfs->dfs_ns, parent->ie_obj, (char *)name,
+			newparent->ie_obj, (char *)newname, &moid, &oid);
 	if (rc)
 		D_GOTO(out, rc);
 
-	DFUSE_TRA_INFO(parent, "Renamed %s to %s in %p",
+	DFUSE_TRA_INFO(parent, "Renamed '%s' to '%s' in %p",
 		       name, newname, newparent);
+
+	/* update moid */
+	dfuse_oid_moved(fs_handle, &moid, parent, name, newparent, newname);
 
 	DFUSE_REPLY_ZERO(parent, req);
 
-	if (parent->ie_dfs->dfc_dentry_timeout ||
-		parent->ie_dfs->dfc_dentry_dir_timeout ||
-		parent->ie_dfs->dfc_ndentry_timeout) {
-		/* The caller has a reference on newparent */
-		rc = fuse_lowlevel_notify_inval_entry(fs_handle->dpi_info->di_session,
-						      newparent->ie_stat.st_ino,
-						      newname, strnlen(newname, NAME_MAX));
-		if (rc)
-			DFUSE_TRA_ERROR(parent,
-					"inval_entry failed %d", rc);
-	}
+	/* Check if a file was unlinked and see if anything needs updating */
+	if (oid.lo || oid.hi)
+		dfuse_oid_unlinked(fs_handle, &oid, newparent, newname);
+
 	return;
 
 out:

--- a/src/client/dfuse/ops/rename.c
+++ b/src/client/dfuse/ops/rename.c
@@ -81,17 +81,17 @@ dfuse_cb_rename(fuse_req_t req, struct dfuse_inode_entry *parent,
 	if (rc)
 		D_GOTO(out, rc);
 
-	DFUSE_TRA_INFO(parent, "Renamed '%s' to '%s' in %p",
+	DFUSE_TRA_INFO(newparent, "Renamed '%s' to '%s' in %p",
 		       name, newname, newparent);
 
 	/* update moid */
 	dfuse_oid_moved(fs_handle, &moid, parent, name, newparent, newname);
 
-	DFUSE_REPLY_ZERO(parent, req);
-
 	/* Check if a file was unlinked and see if anything needs updating */
 	if (oid.lo || oid.hi)
-		dfuse_oid_unlinked(fs_handle, &oid, newparent, newname);
+		dfuse_oid_unlinked(fs_handle, req, &oid, newparent, newname);
+	else
+		DFUSE_REPLY_ZERO(newparent, req);
 
 	return;
 

--- a/src/client/dfuse/ops/setattr.c
+++ b/src/client/dfuse/ops/setattr.c
@@ -16,6 +16,26 @@ dfuse_cb_setattr(fuse_req_t req, struct dfuse_inode_entry *ie,
 
 	DFUSE_TRA_DEBUG(ie, "flags %#x", to_set);
 
+	if (ie->ie_unlinked) {
+		DFUSE_TRA_DEBUG(ie, "File is unlinked, returning most recent data");
+
+		/* This will happen on close with caching enabled if there are writes through the
+		 * cache so accept these two entries only and reject anything else.  This allows
+		 * the read/write case to work on unlinked files without triggering an error.
+		 */
+		if (to_set & ~(FUSE_SET_ATTR_MTIME | FUSE_SET_ATTR_CTIME))
+			D_GOTO(err, rc = ENOENT);
+
+		if (to_set & FUSE_SET_ATTR_MTIME)
+			ie->ie_stat.st_mtim = attr->st_mtim;
+
+		if (to_set & FUSE_SET_ATTR_CTIME)
+			ie->ie_stat.st_ctim = attr->st_ctim;
+
+		DFUSE_REPLY_ATTR(ie, req, &ie->ie_stat);
+		return;
+	}
+
 	if (to_set & (FUSE_SET_ATTR_UID | FUSE_SET_ATTR_GID)) {
 		DFUSE_TRA_INFO(ie, "File uid/gid support not enabled");
 		D_GOTO(err, rc = ENOTSUP);

--- a/src/client/dfuse/ops/unlink.c
+++ b/src/client/dfuse/ops/unlink.c
@@ -10,9 +10,11 @@
 /* Handle a file that has been unlinked via dfuse.  This means that either a unlink or rename call
  * caused the file to be deleted.
  * Takes the oid of the deleted file, and the parent/name where the delete happened.
+ *
+ * Will always call DFUSE_REPLY_ZERO() after updating local state but before updating kernel.
  */
 void
-dfuse_oid_unlinked(struct dfuse_projection_info *fs_handle, daos_obj_id_t *oid,
+dfuse_oid_unlinked(struct dfuse_projection_info *fs_handle, fuse_req_t req, daos_obj_id_t *oid,
 		   struct dfuse_inode_entry *parent, const char *name)
 {
 	struct dfuse_inode_entry	*ie;
@@ -25,14 +27,18 @@ dfuse_oid_unlinked(struct dfuse_projection_info *fs_handle, daos_obj_id_t *oid,
 	DFUSE_TRA_DEBUG(fs_handle, "Unlinked file was %#lx", ino);
 
 	rlink = d_hash_rec_find(&fs_handle->dpi_iet, &ino, sizeof(ino));
-	if (!rlink)
+	if (!rlink) {
+		DFUSE_REPLY_ZERO(parent, req);
 		return;
+	}
 
 	ie = container_of(rlink, struct dfuse_inode_entry, ie_htl);
 
 	DFUSE_TRA_DEBUG(ie, "Setting inode as deleted");
 
 	ie->ie_unlinked = true;
+
+	DFUSE_REPLY_ZERO(parent, req);
 
 	/* If caching is enabled then invalidate the data and attribute caches */
 	rc = fuse_lowlevel_notify_inval_inode(fs_handle->dpi_info->di_session, ino, 0, 0);
@@ -73,9 +79,8 @@ dfuse_cb_unlink(fuse_req_t req, struct dfuse_inode_entry *parent, const char *na
 		return;
 	}
 
-	DFUSE_REPLY_ZERO(parent, req);
-
 	D_ASSERT(oid.lo || oid.hi);
 
-	dfuse_oid_unlinked(fs_handle, &oid, parent, name);
+	/* TODO: Need to do the first part of this and set ie->ie_unlinked before returning */
+	dfuse_oid_unlinked(fs_handle, req, &oid, parent, name);
 }

--- a/src/client/dfuse/ops/unlink.c
+++ b/src/client/dfuse/ops/unlink.c
@@ -7,16 +7,75 @@
 #include "dfuse_common.h"
 #include "dfuse.h"
 
+/* Handle a file that has been unlinked via dfuse.  This means that either a unlink or rename call
+ * caused the file to be deleted.
+ * Takes the oid of the deleted file, and the parent/name where the delete happened.
+ */
 void
-dfuse_cb_unlink(fuse_req_t req, struct dfuse_inode_entry *parent,
-		const char *name)
+dfuse_oid_unlinked(struct dfuse_projection_info *fs_handle, daos_obj_id_t *oid,
+		   struct dfuse_inode_entry *parent, const char *name)
 {
+	struct dfuse_inode_entry	*ie;
+	d_list_t			*rlink;
 	int				rc;
+	fuse_ino_t			ino;
 
-	rc = dfs_remove(parent->ie_dfs->dfs_ns, parent->ie_obj, name, false,
-			NULL);
-	if (rc == 0)
-		DFUSE_REPLY_ZERO(parent, req);
-	else
+	dfuse_compute_inode(parent->ie_dfs, oid, &ino);
+
+	DFUSE_TRA_DEBUG(fs_handle, "Unlinked file was %#lx", ino);
+
+	rlink = d_hash_rec_find(&fs_handle->dpi_iet, &ino, sizeof(ino));
+	if (!rlink)
+		return;
+
+	ie = container_of(rlink, struct dfuse_inode_entry, ie_htl);
+
+	DFUSE_TRA_DEBUG(ie, "Setting inode as deleted");
+
+	ie->ie_unlinked = true;
+
+	/* If caching is enabled then invalidate the data and attribute caches */
+	rc = fuse_lowlevel_notify_inval_inode(fs_handle->dpi_info->di_session, ino, 0, 0);
+	if (rc)
+		DFUSE_TRA_ERROR(ie, "inval_inode returned %d: %s", rc, strerror(-rc));
+
+	/* If the kernel was aware of this inode at an old location then remove that which should
+	 * trigger a forget call
+	 */
+	if ((ie->ie_parent != parent->ie_stat.st_ino) ||
+		(strncmp(ie->ie_name, name, NAME_MAX + 1) != 0)) {
+		DFUSE_TRA_DEBUG(ie, "Telling kernel to forget %#lx.'%s'",
+				ie->ie_parent, ie->ie_name);
+
+		rc = fuse_lowlevel_notify_inval_entry(fs_handle->dpi_info->di_session,
+						      ie->ie_parent,
+						      ie->ie_name, strnlen(ie->ie_name, NAME_MAX));
+		if (rc)
+			DFUSE_TRA_ERROR(ie, "inval_entry returned %d: %s", rc, strerror(-rc));
+	}
+
+	/* Drop the ref again */
+	d_hash_rec_decref(&fs_handle->dpi_iet, rlink);
+}
+
+void
+dfuse_cb_unlink(fuse_req_t req, struct dfuse_inode_entry *parent, const char *name)
+{
+	struct dfuse_projection_info	*fs_handle;
+	int				rc;
+	daos_obj_id_t			oid = {};
+
+	fs_handle = fuse_req_userdata(req);
+
+	rc = dfs_remove(parent->ie_dfs->dfs_ns, parent->ie_obj, name, false, &oid);
+	if (rc != 0) {
 		DFUSE_REPLY_ERR_RAW(parent, req, rc);
+		return;
+	}
+
+	DFUSE_REPLY_ZERO(parent, req);
+
+	D_ASSERT(oid.lo || oid.hi);
+
+	dfuse_oid_unlinked(fs_handle, &oid, parent, name);
 }

--- a/utils/node_local_test.py
+++ b/utils/node_local_test.py
@@ -1510,12 +1510,7 @@ class posix_tests():
         nfd.close()
         print(os.fstat(ofd.fileno()))
         os.rename(newfile, fname)
-        # This should fail, because the file has been deleted.
-        try:
-            print(os.fstat(ofd.fileno()))
-            self.fail()
-        except FileNotFoundError:
-            print('Failed to fstat() replaced file')
+        print(os.fstat(ofd.fileno()))
         ofd.close()
 
     @needs_dfuse
@@ -1527,12 +1522,7 @@ class posix_tests():
         pre = os.fstat(ofd.fileno())
         print(pre)
         os.rename(fname, newfile)
-        try:
-            post = os.fstat(ofd.fileno())
-            print(post)
-            self.fail()
-        except FileNotFoundError:
-            print('Failed to fstat() renamed file')
+        print(os.fstat(ofd.fileno()))
         os.stat(newfile)
         post = os.fstat(ofd.fileno())
         print(post)
@@ -1546,20 +1536,8 @@ class posix_tests():
         ofd = open(fname, 'w')
         print(os.fstat(ofd.fileno()))
         os.unlink(fname)
-        try:
-            print(os.fstat(ofd.fileno()))
-            self.fail()
-        except FileNotFoundError:
-            print('Failed to fstat() unlinked file')
-        # With wb caching enabled the kernel will do a setattr to set the times
-        # on close, so with caching enabled catch that and ignore it.
-        if self.dfuse.caching:
-            try:
-                ofd.close()
-            except FileNotFoundError:
-                pass
-        else:
-            ofd.close()
+        print(os.fstat(ofd.fileno()))
+        ofd.close()
 
     @needs_dfuse
     def test_symlink_broken(self):

--- a/utils/node_local_test.py
+++ b/utils/node_local_test.py
@@ -946,7 +946,6 @@ class DFuse():
             self.dir = os.path.join(conf.dfuse_parent_dir, 'dfuse_mount')
         self.pool = pool
         self.uns_path = uns_path
-        self.valgrind_file = None
         self.container = container
         self.conf = conf
         # Detect the number of cores and do something sensible, if there are
@@ -1696,6 +1695,151 @@ class posix_tests():
         print(stbuf)
         assert stbuf.st_ino < 100
         print(os.listdir(path))
+
+    @needs_dfuse
+    def test_rename(self):
+        """Test that rename clobbers files correctly
+
+        use rename to delete a file, but where the kernel is aware of a different file.
+        Create a filename to be clobbered and stat it.
+        Create a file to copy over.
+        Start a second dfuse instance and overwrite the original file with a new name.
+        Perform a rename on the first dfuse.
+
+        This should clobber a file, but not the one that the kernel is expecting, although it will
+        do a lookup of the destination filename before the rename.
+
+        Inspection of the logs is required to verify what is happening here which is beyond the
+        scope of this test, however this does execute the code-paths and ensures that all refs
+        are correctly updated.
+
+        """
+
+        # Create all three files in the dfuse instance we're checking.
+        for index in range(3):
+            fd = open(os.path.join(self.dfuse.dir, 'file.{}'.format(index)), 'w')
+            fd.write('test')
+            fd.close()
+
+        # Start another dfuse instance to move the files around without the kernel knowing.
+        dfuse = DFuse(self.server,
+                      self.conf,
+                      pool=self.pool.id(),
+                      container=self.container,
+                      caching=False,
+                      mount_path=os.path.join(self.conf.dfuse_parent_dir, 'dfuse_mount_backend'))
+        dfuse.start(v_hint='rename_other')
+
+        print(os.listdir(self.dfuse.dir))
+        print(os.listdir(dfuse.dir))
+
+        # Rename file 1 to file 2 in the background, this will remove file 2
+        os.rename(os.path.join(dfuse.dir, 'file.1') ,os.path.join(dfuse.dir, 'file.2'))
+
+        # Rename file 0 to file 2 in the test dfuse.  Here the kernel thinks it's clobbering
+        # file 2 but it's really clobbering file 1, although it will stat() file 2 before the
+        # operation so may have the correct data.
+        # Dfuse should return file 1 for the details of what has been deleted.
+        os.rename(os.path.join(self.dfuse.dir, 'file.0') ,os.path.join(self.dfuse.dir, 'file.2'))
+
+        if dfuse.stop():
+            self.fatal_errors = True
+
+        # Finally, perform some more I/O so we can tell from the dfuse logs where the test ends and
+        # dfuse teardown starts.  At this point file 1 and file 2 have been deleted.
+        time.sleep(1)
+        print(os.statvfs(self.dfuse.dir))
+
+    @needs_dfuse
+    def test_complex_unlink(self):
+        """Test that unlink clears file data correctly.
+
+        Create two files, exchange them in the backend then unlink the one.
+
+        The kernel will be unlinking what it thinks is file 1 but it will actually be file 0.
+        """
+
+        fds = []
+
+        # Create both files in the dfuse instance we're checking.  These files are created in
+        # binary mode with buffering off so the writes are sent direct to the kernel.
+        for index in range(2):
+            fd = open(os.path.join(self.dfuse.dir, 'file.{}'.format(index)), 'wb', buffering=0)
+            fd.write(b'test')
+            fds.append(fd)
+
+        # Start another dfuse instance to move the files around without the kernel knowing.
+        dfuse = DFuse(self.server,
+                      self.conf,
+                      pool=self.pool.id(),
+                      container=self.container,
+                      caching=False,
+                      mount_path=os.path.join(self.conf.dfuse_parent_dir, 'dfuse_mount_backend'))
+        dfuse.start(v_hint='unlink')
+
+        print(os.listdir(self.dfuse.dir))
+        print(os.listdir(dfuse.dir))
+
+        # Rename file 0 to file 0 in the background, this will remove file 1
+        os.rename(os.path.join(dfuse.dir, 'file.0') ,os.path.join(dfuse.dir, 'file.1'))
+
+        # Perform the unlink, this will unlink the other file.
+        os.unlink(os.path.join(self.dfuse.dir, 'file.1'))
+
+        if dfuse.stop():
+            self.fatal_errors = True
+
+        # Finally, perform some more I/O so we can tell from the dfuse logs where the test ends and
+        # dfuse teardown starts.  At this point file 1 and file 2 have been deleted.
+        time.sleep(1)
+        print(os.statvfs(self.dfuse.dir))
+
+        for fd in fds:
+            fd.close()
+
+    @needs_dfuse
+    def test_complex_rename(self):
+        """Test for rename semantics, and that rename is correctly updating the dfuse data for
+        the moved rile.
+
+        # Create a file, read/write to it.
+        # Check fstat works.
+        # Rename it from the backend
+        # Check fstat - it should not work.
+        # Rename the file into a new directory, this should allow the kernel to 'find' the file
+        # again and update the name/parent.
+        # check fstat works.
+        """
+
+        fname = os.path.join(self.dfuse.dir, 'file')
+        ofd = open(fname, 'w')
+        print(os.fstat(ofd.fileno()))
+
+        dfuse = DFuse(self.server,
+                      self.conf,
+                      pool=self.pool.id(),
+                      container=self.container,
+                      caching=False,
+                      mount_path=os.path.join(self.conf.dfuse_parent_dir, 'dfuse_mount_backend'))
+        dfuse.start(v_hint='rename')
+
+        os.mkdir(os.path.join(dfuse.dir, 'step_dir'))
+        os.mkdir(os.path.join(dfuse.dir, 'new_dir'))
+        os.rename(os.path.join(dfuse.dir, 'file'), os.path.join(dfuse.dir, 'step_dir', 'file-new'))
+
+        # This should fail, because the file has been deleted.
+        try:
+            print(os.fstat(ofd.fileno()))
+            self.fail()
+        except FileNotFoundError:
+            print('Failed to fstat() replaced file')
+
+        os.rename(os.path.join(self.dfuse.dir, 'step_dir', 'file-new'),
+                  os.path.join(self.dfuse.dir, 'new_dir', 'my-file'))
+
+        print(os.fstat(ofd.fileno()))
+
+        ofd.close()
 
     def test_with_path(self):
         """Test that dfuse starts with path option."""


### PR DESCRIPTION
Use the oid option to dfs when calling move or rename to detect
what if any file has been removed, and check for that file in
the local inode table.
When files have been moved or are observed at a different location
to what dfuse expects then update the kernel to remove the old
dentries which should reduce kernel resources required.
When files are removed then check if the file is known and if so
mark is as removed.
For getattr on removed files return most recent data rather than error.
For setattr on removed files allow setting of times only as this can
happen with cached writes.

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>