### PR TITLE
DAOS-8029 object: add EC object check to daos_obj_verify

### DIFF
--- a/src/include/daos/common.h
+++ b/src/include/daos/common.h
@@ -305,6 +305,7 @@ int daos_sgls_copy_all(d_sg_list_t *dst, int dst_nr, d_sg_list_t *src,
 int daos_sgl_copy_data_out(d_sg_list_t *dst, d_sg_list_t *src);
 int daos_sgl_copy_data(d_sg_list_t *dst, d_sg_list_t *src);
 int daos_sgl_alloc_copy_data(d_sg_list_t *dst, d_sg_list_t *src);
+int daos_sgls_alloc(d_sg_list_t *dst, d_sg_list_t *src, int nr);
 int daos_sgl_merge(d_sg_list_t *dst, d_sg_list_t *src);
 daos_size_t daos_sgl_data_len(d_sg_list_t *sgl);
 daos_size_t daos_sgl_buf_size(d_sg_list_t *sgl);

--- a/src/object/cli_shard.c
+++ b/src/object/cli_shard.c
@@ -1595,10 +1595,14 @@ dc_enumerate_cb(tse_task_t *task, void *arg)
 		       oeo->oeo_recxs.ca_count);
 	}
 
-	if (enum_args->eaa_sgl && oeo->oeo_sgl.sg_nr > 0) {
-		rc = daos_sgl_copy_data_out(enum_args->eaa_sgl, &oeo->oeo_sgl);
-		if (rc)
-			D_GOTO(out, rc);
+	if (enum_args->eaa_sgl) {
+		if (oeo->oeo_sgl.sg_nr > 0) {
+			rc = daos_sgl_copy_data_out(enum_args->eaa_sgl, &oeo->oeo_sgl);
+			if (rc)
+				D_GOTO(out, rc);
+		} else {
+			dc_sgl_out_set(enum_args->eaa_sgl, oeo->oeo_size);
+		}
 	}
 
 	/* Update dkey hash and tag */

--- a/src/object/obj_enum.c
+++ b/src/object/obj_enum.c
@@ -273,7 +273,7 @@ fill_key(daos_handle_t ih, vos_iter_entry_t *key_ent, struct dss_enum_arg *arg,
 		arg->kds[arg->kds_len].kd_val_type = OBJ_ITER_OBJ_PUNCH_EPOCH;
 		arg->kds_len++;
 
-		D_ASSERT(iov->iov_len + pi_size < iov->iov_buf_len);
+		D_ASSERT(iov->iov_len + pi_size <= iov->iov_buf_len);
 		memcpy(iov->iov_buf + iov->iov_len, &key_ent->ie_obj_punch,
 		       pi_size);
 
@@ -303,7 +303,7 @@ fill_key(daos_handle_t ih, vos_iter_entry_t *key_ent, struct dss_enum_arg *arg,
 						OBJ_ITER_DKEY_EPOCH;
 		arg->kds_len++;
 
-		D_ASSERT(iov->iov_len + pi_size < iov->iov_buf_len);
+		D_ASSERT(iov->iov_len + pi_size <= iov->iov_buf_len);
 		memcpy(iov->iov_buf + iov->iov_len, &key_ent->ie_punch,
 		       pi_size);
 
@@ -585,7 +585,7 @@ fill_rec(daos_handle_t ih, vos_iter_entry_t *key_ent, struct dss_enum_arg *arg,
 	arg->kds[arg->kds_len].kd_key_len += sizeof(*rec);
 
 	/* Append the recx record to iovs. */
-	D_ASSERT(iovs[arg->sgl_idx].iov_len + sizeof(*rec) <
+	D_ASSERT(iovs[arg->sgl_idx].iov_len + sizeof(*rec) <=
 		 iovs[arg->sgl_idx].iov_buf_len);
 	rec = iovs[arg->sgl_idx].iov_buf + iovs[arg->sgl_idx].iov_len;
 	rec->rec_recx = key_ent->ie_recx;

--- a/src/object/obj_internal.h
+++ b/src/object/obj_internal.h
@@ -455,6 +455,7 @@ struct dc_obj_verify_args {
 	char				*list_buf;
 	char				*fetch_buf;
 	char				 inline_buf[DOVA_BUF_LEN];
+	uint32_t			 current_shard;
 	struct dc_obj_verify_cursor	 cursor;
 };
 

--- a/src/object/srv_obj_migrate.c
+++ b/src/object/srv_obj_migrate.c
@@ -2298,8 +2298,12 @@ retry:
 			break;
 		}
 
-		if (num == 0)
+		/* Each object enumeration RPC will at least one OID */
+		if (num < 2) {
+			D_DEBUG(DB_REBUILD, "enumeration buffer %u empty"
+				DF_UOID"\n", num, DP_UOID(arg->oid));
 			break;
+		}
 
 		rc = dss_enum_unpack(arg->oid, kds, num, &sgl, &csum,
 				     migrate_enum_unpack_cb, &unpack_arg);

--- a/src/tests/suite/daos_rebuild_ec.c
+++ b/src/tests/suite/daos_rebuild_ec.c
@@ -30,6 +30,7 @@ rebuild_ec_internal(void **state, uint16_t oclass, int kill_data_nr,
 	d_rank_t		kill_ranks[4] = { -1 };
 	int			kill_ranks_num = 0;
 	d_rank_t		extra_kill_ranks[4] = { -1 };
+	int			rc;
 
 	if (oclass == OC_EC_2P1G1 && !test_runable(arg, 4))
 		return;
@@ -65,15 +66,10 @@ rebuild_ec_internal(void **state, uint16_t oclass, int kill_data_nr,
 		rebuild_pools_ranks(&arg, 1, &extra_kill_ranks[2], 2, false);
 	}
 
-	if (write_type == PARTIAL_UPDATE)
-		verify_ec_partial(&req, arg->index, 0);
-	else if (write_type == FULL_UPDATE)
-		verify_ec_full(&req, arg->index, 0);
-	else if (write_type == FULL_PARTIAL_UPDATE)
-		verify_ec_full_partial(&req, arg->index, 0);
-	else if (write_type == PARTIAL_FULL_UPDATE)
-		verify_ec_full(&req, arg->index, 0);
 	ioreq_fini(&req);
+
+	rc = daos_obj_verify(arg->coh, oid, DAOS_EPOCH_MAX);
+	assert_int_equal(rc, 0);
 
 	reintegrate_pools_ranks(&arg, 1, kill_ranks, kill_ranks_num);
 	if (oclass == OC_EC_2P1G1)
@@ -81,17 +77,8 @@ rebuild_ec_internal(void **state, uint16_t oclass, int kill_data_nr,
 	else /* oclass OC_EC_4P2G1 */
 		reintegrate_pools_ranks(&arg, 1, &extra_kill_ranks[2], 2);
 
-	ioreq_init(&req, arg->coh, oid, DAOS_IOD_ARRAY, arg);
-	if (write_type == PARTIAL_UPDATE)
-		verify_ec_partial(&req, arg->index, 0);
-	else if (write_type == FULL_UPDATE)
-		verify_ec_full(&req, arg->index, 0);
-	else if (write_type == FULL_PARTIAL_UPDATE)
-		verify_ec_full_partial(&req, arg->index, 0);
-	else if (write_type == PARTIAL_FULL_UPDATE)
-		verify_ec_full(&req, arg->index, 0);
-
-	ioreq_fini(&req);
+	rc = daos_obj_verify(arg->coh, oid, DAOS_EPOCH_MAX);
+	assert_int_equal(rc, 0);
 }
 
 #define CELL_SIZE	1048576


### PR DESCRIPTION
1. Add EC object check to daos_obj_verify.

2. Update object enumeration sgl buffer size for bulk transfer.

3. Do not need prepare the shard sgl buffer for spec shard object
enumeration, since there is only one shard, which can use the input
sgl directly.

4. Since object enumeration will always return oid, so let's use
num < 2 to see if the enumeration buffer is empty.

Signed-off-by: Di Wang <di.wang@intel.com>