### PR TITLE
DAOS-8037 vos: Fix a few bugs with removal aggregation

### DIFF
--- a/src/vos/tests/vts_aggregate.c
+++ b/src/vos/tests/vts_aggregate.c
@@ -2267,6 +2267,133 @@ aggregate_26(void **state)
 	cleanup();
 }
 
+static void
+aggregate_27(void **state)
+{
+	struct io_test_args	*arg = *state;
+	struct agg_tst_dataset	 ds = { 0 };
+	daos_recx_t		 recx_arr[5];
+	daos_epoch_t		 punch_epochs[] = {2, 3, 4, 5};
+	int			 iod_size = 1024, end_idx;
+
+	end_idx = (VOS_MW_FLUSH_THRESH + iod_size - 1) / iod_size;
+	assert_true(end_idx > 5);
+
+	/* Insert a record */
+	recx_arr[0].rx_idx = 0;
+	recx_arr[0].rx_nr = end_idx * 4;
+	recx_arr[1].rx_idx = 0;
+	recx_arr[1].rx_nr = end_idx;
+	recx_arr[2].rx_idx = end_idx;
+	recx_arr[2].rx_nr = end_idx;
+	recx_arr[3].rx_idx = end_idx * 2;
+	recx_arr[3].rx_nr = end_idx;
+	recx_arr[4].rx_idx = end_idx * 3;
+	recx_arr[4].rx_nr = end_idx;
+
+	ds.td_type = DAOS_IOD_ARRAY;
+	ds.td_iod_size = iod_size;
+	ds.td_recx_nr = ARRAY_SIZE(recx_arr);
+	ds.td_recx = &recx_arr[0];
+	ds.td_expected_recs = 0;
+	ds.td_upd_epr.epr_lo = 1;
+	ds.td_upd_epr.epr_hi = ARRAY_SIZE(recx_arr);
+	ds.td_agg_epr.epr_lo = 0;
+	ds.td_agg_epr.epr_hi = ARRAY_SIZE(recx_arr) + 1;
+	ds.td_discard = false;
+	ds.td_delete = true;
+
+	VERBOSE_MSG("Consecutive removed extents, no logical extents\n");
+	aggregate_basic(arg, &ds, ARRAY_SIZE(punch_epochs), &punch_epochs[0]);
+	cleanup();
+}
+
+static void
+aggregate_28(void **state)
+{
+	struct io_test_args	*arg = *state;
+	struct agg_tst_dataset	 ds = { 0 };
+	daos_recx_t		 recx_arr[6];
+	daos_epoch_t		 punch_epochs[] = {3, 4, 5, 6};
+	int			 iod_size = 1024, end_idx;
+
+	end_idx = (VOS_MW_FLUSH_THRESH + iod_size - 1) / iod_size;
+	assert_true(end_idx > 5);
+
+	/* Insert a record */
+	recx_arr[0].rx_idx = 0;
+	recx_arr[0].rx_nr = end_idx;
+	recx_arr[1].rx_idx = end_idx;
+	recx_arr[1].rx_nr = end_idx * 4;
+	recx_arr[2].rx_idx = end_idx;
+	recx_arr[2].rx_nr = end_idx;
+	recx_arr[3].rx_idx = end_idx * 2;
+	recx_arr[3].rx_nr = end_idx;
+	recx_arr[4].rx_idx = end_idx * 3;
+	recx_arr[4].rx_nr = end_idx;
+	recx_arr[5].rx_idx = end_idx * 4;
+	recx_arr[5].rx_nr = end_idx;
+
+	ds.td_type = DAOS_IOD_ARRAY;
+	ds.td_iod_size = iod_size;
+	ds.td_recx_nr = ARRAY_SIZE(recx_arr);
+	ds.td_recx = &recx_arr[0];
+	ds.td_expected_recs = 1;
+	ds.td_upd_epr.epr_lo = 1;
+	ds.td_upd_epr.epr_hi = ARRAY_SIZE(recx_arr);
+	ds.td_agg_epr.epr_lo = 0;
+	ds.td_agg_epr.epr_hi = ARRAY_SIZE(recx_arr) + 1;
+	ds.td_discard = false;
+	ds.td_delete = true;
+
+	VERBOSE_MSG("Logical extent followed by consecutive removed extents\n");
+	aggregate_basic(arg, &ds, ARRAY_SIZE(punch_epochs), &punch_epochs[0]);
+	cleanup();
+}
+
+static void
+aggregate_29(void **state)
+{
+	struct io_test_args	*arg = *state;
+	struct agg_tst_dataset	 ds = { 0 };
+	daos_recx_t		 recx_arr[6];
+	daos_epoch_t		 punch_epochs[] = {3, 4, 5, 6};
+	int			 iod_size = 1024, end_idx;
+
+	end_idx = (VOS_MW_FLUSH_THRESH + iod_size - 1) / iod_size;
+	assert_true(end_idx > 5);
+
+	/* Insert a record */
+	recx_arr[0].rx_idx = 0;
+	recx_arr[0].rx_nr = 1;
+	recx_arr[1].rx_idx = end_idx;
+	recx_arr[1].rx_nr = end_idx * 4;
+	recx_arr[2].rx_idx = end_idx;
+	recx_arr[2].rx_nr = end_idx;
+	recx_arr[3].rx_idx = end_idx * 2;
+	recx_arr[3].rx_nr = end_idx;
+	recx_arr[4].rx_idx = end_idx * 3;
+	recx_arr[4].rx_nr = end_idx;
+	recx_arr[5].rx_idx = end_idx * 4;
+	recx_arr[5].rx_nr = end_idx;
+
+	ds.td_type = DAOS_IOD_ARRAY;
+	ds.td_iod_size = iod_size;
+	ds.td_recx_nr = ARRAY_SIZE(recx_arr);
+	ds.td_recx = &recx_arr[0];
+	ds.td_expected_recs = 1;
+	ds.td_upd_epr.epr_lo = 1;
+	ds.td_upd_epr.epr_hi = ARRAY_SIZE(recx_arr);
+	ds.td_agg_epr.epr_lo = 0;
+	ds.td_agg_epr.epr_hi = ARRAY_SIZE(recx_arr) + 1;
+	ds.td_discard = false;
+	ds.td_delete = true;
+
+	VERBOSE_MSG("Logical extent followed by disjoint removed extents\n");
+	aggregate_basic(arg, &ds, ARRAY_SIZE(punch_epochs), &punch_epochs[0]);
+	cleanup();
+}
+
 static int
 agg_tst_teardown(void **state)
 {
@@ -2361,6 +2488,12 @@ static const struct CMUnitTest aggregate_tests[] = {
 	  aggregate_25, NULL, agg_tst_teardown },
 	{ "VOS426: Consecutive removed extents",
 	  aggregate_26, NULL, agg_tst_teardown },
+	{ "VOS427: Consecutive removed extents, no logical extents",
+	  aggregate_27, NULL, agg_tst_teardown },
+	{ "VOS428: Logical extent followed by consecutive removed extents",
+	  aggregate_28, NULL, agg_tst_teardown },
+	{ "VOS429: Logical extent followed by disjoint removed extents",
+	  aggregate_29, NULL, agg_tst_teardown },
 };
 
 int

--- a/src/vos/vos_aggregate.c
+++ b/src/vos/vos_aggregate.c
@@ -576,6 +576,9 @@ enqueue_rmv_ent(struct agg_merge_window *mw, const struct evt_extent *ext,
 		if ((ext->ex_lo) != rm_ent2->re_rect.rc_ex.ex_hi + 1)
 			continue;
 
+		D_DEBUG(DB_EPC, "Removal record "DF_RECT" is contiguous with "DF_RECT"\n",
+			DP_RECT(&rm_ent->re_rect), DP_RECT(&rm_ent2->re_rect));
+
 		if (d_list_empty(&rm_ent2->re_contained)) {
 			/* Duplicate the entry */
 			rm_ent3 = allocate_rmv_ent(&rm_ent2->re_rect.rc_ex, rm_ent2->re_rect.rc_epc,
@@ -584,6 +587,8 @@ enqueue_rmv_ent(struct agg_merge_window *mw, const struct evt_extent *ext,
 				D_FREE(rm_ent);
 				return NULL;
 			}
+			D_DEBUG(DB_EPC, "Removal record "DF_RECT" duplicated\n",
+				DP_RECT(&rm_ent2->re_rect));
 			d_list_add_tail(&rm_ent3->re_link, &rm_ent2->re_contained);
 		}
 
@@ -621,8 +626,12 @@ prepare_segments(struct agg_merge_window *mw)
 	 * segments (at most mw_lgc_cnt) and truncated segments (at most
 	 * mw_phy_cnt).
 	 */
-	D_ASSERT(mw->mw_lgc_cnt > 0);
+	D_ASSERT(mw->mw_lgc_cnt > 0 || mw->mw_rmv_cnt > 0);
 	D_ASSERT(mw->mw_phy_cnt > 0);
+	io->ic_seg_cnt = 0;
+	if (mw->mw_lgc_cnt == 0)
+		goto process_physical;
+
 	seg_max = MAX((mw->mw_lgc_cnt + mw->mw_phy_cnt), 200);
 	if (io->ic_seg_max < seg_max) {
 		D_REALLOC_ARRAY_NZ(lgc_seg, io->ic_segs, seg_max);
@@ -633,7 +642,6 @@ prepare_segments(struct agg_merge_window *mw)
 		io->ic_seg_max = seg_max;
 	}
 	memset(io->ic_segs, 0, io->ic_seg_max * sizeof(*lgc_seg));
-	io->ic_seg_cnt = 0;
 
 	/* Generate coalesced segments according to visible logical entries */
 	for (i = 0; i < mw->mw_lgc_cnt; i++) {
@@ -685,14 +693,15 @@ prepare_segments(struct agg_merge_window *mw)
 		ent_in->ei_rect.rc_minor_epc = VOS_SUB_OP_MAX;
 	}
 
+	io->ic_seg_cnt++;
+	D_ASSERT(io->ic_seg_cnt < io->ic_seg_max);
+
+process_physical:
 	if (mw->mw_csum_support) {
 		cs_len = phy_ent->pe_csum_info.cs_len;
 		cs_type = phy_ent->pe_csum_info.cs_type;
 		chunksize = phy_ent->pe_csum_info.cs_chunksize;
 	}
-
-	io->ic_seg_cnt++;
-	D_ASSERT(io->ic_seg_cnt < io->ic_seg_max);
 
 	/* Generate truncated segments according to physical entries */
 	d_list_for_each_entry_safe(phy_ent, temp, &mw->mw_phy_ents, pe_link) {
@@ -708,8 +717,6 @@ prepare_segments(struct agg_merge_window *mw)
 			ext.ex_lo += phy_ent->pe_off;
 
 		D_ASSERT(ext.ex_lo <= ext.ex_hi);
-		D_ASSERT(ext.ex_lo <= mw->mw_ext.ex_hi);
-
 		phy_ent->pe_remove = false;
 		if (ext.ex_hi > mw->mw_ext.ex_hi) {
 			/** If a record is covered by a removal record and is
@@ -748,6 +755,7 @@ prepare_segments(struct agg_merge_window *mw)
 		    phy_ent->pe_remove)
 			continue;
 
+		D_ASSERT(ext.ex_lo <= mw->mw_ext.ex_hi);
 		D_ASSERT(ext.ex_hi >= mw->mw_ext.ex_lo);
 
 		lgc_seg->ls_phy_ent = phy_ent;
@@ -1198,6 +1206,11 @@ fill_segments(daos_handle_t ih, struct agg_merge_window *mw,
 	unsigned int		 i, scm_max;
 	int			 rc = 0;
 
+	if (io->ic_seg_cnt == 0) {
+		/** No logical extents to handle (only removals) */
+		return 0;
+	}
+
 	scm_max = MAX(io->ic_seg_cnt, 200);
 	if (io->ic_rsrvd_scm == NULL ||
 	    io->ic_rsrvd_scm->rs_actv_cnt < scm_max) {
@@ -1342,14 +1355,14 @@ insert_segments(daos_handle_t ih, struct agg_merge_window *mw,
 			rect.rc_ex.ex_lo += phy_ent->pe_off;
 
 		D_ASSERT(rect.rc_ex.ex_lo <= rect.rc_ex.ex_hi);
-		D_ASSERT(rect.rc_ex.ex_lo <= mw->mw_ext.ex_hi);
+		D_ASSERT(phy_ent->pe_remove || rect.rc_ex.ex_lo <= mw->mw_ext.ex_hi);
 
 		/*
 		 * The physical entry spans window end, but is fully covered
 		 * in current window, keep it intact.
 		 */
-		if (rect.rc_ex.ex_hi > mw->mw_ext.ex_hi &&
-						!phy_ent->pe_trunc_head) {
+		if (!phy_ent->pe_remove && rect.rc_ex.ex_hi > mw->mw_ext.ex_hi &&
+		    !phy_ent->pe_trunc_head) {
 			leftovers++;
 			continue;
 		}
@@ -1372,6 +1385,7 @@ insert_segments(daos_handle_t ih, struct agg_merge_window *mw,
 			mw->mw_phy_cnt--;
 			continue;
 		}
+
 		/* Update extent start of truncated physical entry */
 		rect.rc_ex.ex_lo = mw->mw_ext.ex_hi + 1;
 		phy_ent->pe_off = rect.rc_ex.ex_lo -


### PR DESCRIPTION
Corner cases triggered assertion failures with vos aggregation

Need to handle the following cases

1. All entries are removed by aggregation (no logical extents)
2. Removals are after logical extents

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>