### PR TITLE
DAOS-7990: Fix Coverity Integer Issues in Engine Code

### DIFF
--- a/src/common/pool_map.c
+++ b/src/common/pool_map.c
@@ -1440,6 +1440,7 @@ add_domains_to_pool_buf(struct pool_map *map, struct pool_buf *map_buf,
 		map_comp.co_ver = map_version;
 		map_comp.co_fseq = 1;
 		map_comp.co_nr = node.fdn_val.dom->fd_children_nr;
+		map_comp.co_padding = 0;
 
 		if (map != NULL) {
 			struct pool_domain	*current;

--- a/src/object/srv_ec_aggregate.c
+++ b/src/object/srv_ec_aggregate.c
@@ -983,7 +983,7 @@ agg_diff_preprocess(struct ec_agg_entry *entry, unsigned char *diff,
 	uint64_t		 hole_off, hole_end;
 
 	ss = k * len * entry->ae_cur_stripe.as_stripenum;
-	cell_start = cell_idx * len;
+	cell_start = (uint64_t)cell_idx * len;
 	cell_end = cell_start + len;
 	hole_off = 0;
 	d_list_for_each_entry(extent, &entry->ae_cur_stripe.as_dextents,
@@ -1522,7 +1522,7 @@ agg_process_holes_ult(void *arg)
 		}
 		last_ext_end = agg_extent->ae_recx.rx_idx +
 			agg_extent->ae_recx.rx_nr - ss;
-		if (last_ext_end >= k * len)
+		if (last_ext_end >= (uint64_t)k * len)
 			break;
 	}
 


### PR DESCRIPTION
Fix various issues found by coverity having to do with uninitialized integers
and integer overflow.

CID: 331437, 331452, 329164

Signed-off-by: David Quigley <david.quigley@intel.com>