### PR TITLE
DAOS-7905 dtx: lazy rebalance leaf nodes for committed DTX table

### DIFF
--- a/src/include/daos/btree.h
+++ b/src/include/daos/btree.h
@@ -63,10 +63,24 @@ struct btr_node {
 	uint32_t			tn_pad_32;
 	/** generation, reserved for COW */
 	uint64_t			tn_gen;
-	/** the first child, it is unused on leaf node */
-	umem_off_t			tn_child;
+	union {
+		/** the first child, it is unused on leaf node */
+		umem_off_t		tn_child;
+		/** Pointer to the next leaf node in DRAM. */
+		void			*tn_next;
+	};
 	/** records in this node */
 	struct btr_record		tn_recs[0];
+};
+
+/**
+ * Trace the leaf nodes that may need to be lazy rebalanced.
+ */
+struct btr_leaf_rebal {
+	struct btr_node			*blr_head;
+	struct btr_node			*blr_tail;
+	void				*blr_args;
+	uint32_t			 blr_lazy_rebal:1;
 };
 
 enum {
@@ -482,6 +496,8 @@ enum btr_feats {
 	 *  tree class
 	 */
 	BTR_FEAT_DYNAMIC_ROOT		= (1 << 2),
+	/** Lazy leaf node rebalance when delete some record from the leaf. */
+	BTR_FEAT_LAZY_LEAF_REBAL	= (1 << 3),
 };
 
 /**
@@ -537,6 +553,7 @@ int  dbtree_delete(daos_handle_t toh, dbtree_probe_opc_t opc,
 		   d_iov_t *key, void *args);
 int  dbtree_query(daos_handle_t toh, struct btr_attr *attr,
 		  struct btr_stat *stat);
+int  dbtree_lazy_leaf_rebal(daos_handle_t toh, struct btr_node *nd);
 int  dbtree_is_empty(daos_handle_t toh);
 struct umem_instance *btr_hdl2umm(daos_handle_t toh);
 


### PR DESCRIPTION
The committed DTX table is organized as a btree. Normally, during
DTX aggregation, some DTX entries will be removed from such btree.
Currently, when remove a record from the leaf node, those records
after the removed one will be moved forward to fill the slot. And
when the leaf node becomes empty, it will trigger btree rebalance
that will cause some records movement from its sibling leaf nodes.
Such movement and rebalance are good for some potential subsequent
btree search. But for DTX aggregation, we can do some optimization:

For each time DTX aggregation run, it will remove a lot of entries
from the committed DTX table. These entries will be removed one by
one (via single transaction). Above mentioned records movement and
rebalance may be unnecessary, it is quite possible that the record
to be moved (or rebalanced) after current removed one will also be
removed in subsequnt DTX aggregation within the same transaction.
So if we delay related btree records movement and rebalance until
the DTX aggregation for current transaction are all done, then we
may avoid a lot of unnecessary overhead.

Signed-off-by: Fan Yong <fan.yong@intel.com>