### PR TITLE
DAOS-8038 daos: remove semicolon in container create

### DIFF
--- a/src/utils/daos_hdlr.c
+++ b/src/utils/daos_hdlr.c
@@ -3001,7 +3001,7 @@ dm_connect(struct cmd_args_s *ap,
 				D_GOTO(err_dst_root, rc);
 			}
 			fprintf(ap->outstream,
-				"Successfully created container: "
+				"Successfully created container "
 				""DF_UUIDF"\n", DP_UUID(ca->dst_c_uuid));
 		} else if (rc != 0) {
 			fprintf(ap->errstream, "failed to open container: "


### PR DESCRIPTION
There is a semicolon in the container create message
in dm_connect which is part of the fs copy code. This
semicolon in the message causes the dm_dst_create tests
for fs copy to fail, because the functional tests parse
the output and do not expect a semicolon.

Signed-off-by: Danielle Sikich <danielle.sikich@intel.com>