### PR TITLE
DAOS-7174 cont: a take string on cont_open/destroy

### DIFF
--- a/src/client/api/container.c
+++ b/src/client/api/container.c
@@ -106,12 +106,17 @@ out_prop:
 	return rc;
 }
 
+/** Disable backward compat code */
+#undef daos_cont_open
+
+/** Kept for backward ABI compatibility, but not advertised via header file */
 int
-daos_cont_open(daos_handle_t poh, const uuid_t uuid, unsigned int flags,
+daos_cont_open(daos_handle_t poh, const char *cont, unsigned int flags,
 	       daos_handle_t *coh, daos_cont_info_t *info, daos_event_t *ev)
 {
 	daos_cont_open_t	*args;
 	tse_task_t		*task;
+	const unsigned char	*uuid = (const unsigned char *) cont;
 	int			 rc;
 
 	DAOS_API_ARG_ASSERT(*args, CONT_OPEN);
@@ -123,43 +128,41 @@ daos_cont_open(daos_handle_t poh, const uuid_t uuid, unsigned int flags,
 		return rc;
 
 	args = dc_task_get_args(task);
-	args->poh		= poh;
-	args->flags		= flags;
-	args->coh		= coh;
-	args->info		= info;
+	args->poh	= poh;
+	args->flags	= flags;
+	args->coh	= coh;
+	args->info	= info;
 	uuid_copy((unsigned char *)args->uuid, uuid);
-	args->label		= NULL;
+	args->cont	= NULL;
 
 	return dc_task_schedule(task, true);
 }
 
+/**
+ * Real latest & greatest implementation of container open.
+ * Used by anyone including the daos_cont.h header file.
+ */
 int
-daos_cont_open_by_label(daos_handle_t poh, const char *label,
-			unsigned int flags, daos_handle_t *coh,
-			daos_cont_info_t *info, daos_event_t *ev)
+daos_cont_open2(daos_handle_t poh, const char *cont, unsigned int flags,
+		daos_handle_t *coh, daos_cont_info_t *info, daos_event_t *ev)
 {
 	daos_cont_open_t	*args;
 	tse_task_t		*task;
-	size_t			 label_len = 0;
 	int			 rc;
 
 	DAOS_API_ARG_ASSERT(*args, CONT_OPEN);
-	if (label)
-		label_len = strnlen(label, DAOS_PROP_LABEL_MAX_LEN+1);
-	if (!label || (label_len == 0) || (label_len > DAOS_PROP_LABEL_MAX_LEN))
-		return -DER_INVAL;
 
-	rc = dc_task_create(dc_cont_open_lbl, NULL, ev, &task);
+	rc = dc_task_create(dc_cont_open, NULL, ev, &task);
 	if (rc)
 		return rc;
 
 	args = dc_task_get_args(task);
-	args->poh		= poh;
-	args->flags		= flags;
-	args->coh		= coh;
-	args->info		= info;
+	args->poh	= poh;
+	args->flags	= flags;
+	args->coh	= coh;
+	args->info	= info;
 	uuid_clear(args->uuid);
-	args->label		= label;
+	args->cont	= cont;
 
 	return dc_task_schedule(task, true);
 }
@@ -183,12 +186,17 @@ daos_cont_close(daos_handle_t coh, daos_event_t *ev)
 	return dc_task_schedule(task, true);
 }
 
+/** Disable backward compat code */
+#undef daos_cont_destroy
+
+/** Kept for backward ABI compatibility, but not advertised via header file */
 int
-daos_cont_destroy(daos_handle_t poh, const uuid_t uuid, int force,
+daos_cont_destroy(daos_handle_t poh, const char *cont, int force,
 		  daos_event_t *ev)
 {
 	daos_cont_destroy_t	*args;
 	tse_task_t		*task;
+	const unsigned char	*uuid = (const unsigned char *) cont;
 	int			 rc;
 
 	DAOS_API_ARG_ASSERT(*args, CONT_DESTROY);
@@ -202,39 +210,38 @@ daos_cont_destroy(daos_handle_t poh, const uuid_t uuid, int force,
 	args = dc_task_get_args(task);
 	args->poh	= poh;
 	args->force	= force;
+	args->cont	= NULL;
 	uuid_copy((unsigned char *)args->uuid, uuid);
 
 	return dc_task_schedule(task, true);
 }
 
+/**
+ * Real latest & greatest implementation of container destroy.
+ * Used by anyone including the daos_cont.h header file.
+ */
 int
-daos_cont_destroy_by_label(daos_handle_t poh, const char *label, int force,
-			   daos_event_t *ev)
+daos_cont_destroy2(daos_handle_t poh, const char *cont, int force,
+		   daos_event_t *ev)
 {
-	size_t			 label_len = 0;
 	daos_cont_destroy_t	*args;
 	tse_task_t		*task;
 	int			 rc;
 
 	DAOS_API_ARG_ASSERT(*args, CONT_DESTROY);
-	if (label)
-		label_len = strnlen(label, DAOS_PROP_LABEL_MAX_LEN+1);
-	if (!label || (label_len == 0) || (label_len > DAOS_PROP_LABEL_MAX_LEN))
-		return -DER_INVAL;
 
-	rc = dc_task_create(dc_cont_destroy_lbl, NULL, ev, &task);
+	rc = dc_task_create(dc_cont_destroy, NULL, ev, &task);
 	if (rc)
 		return rc;
 
 	args = dc_task_get_args(task);
-	args->poh		= poh;
-	args->force		= force;
+	args->poh	= poh;
+	args->force	= force;
 	uuid_clear(args->uuid);
-	args->label		= label;
+	args->cont	= cont;
 
 	return dc_task_schedule(task, true);
 }
-
 
 int
 daos_cont_query(daos_handle_t coh, daos_cont_info_t *info,

--- a/src/client/dfuse/dfuse_core.c
+++ b/src/client/dfuse/dfuse_core.c
@@ -734,8 +734,8 @@ dfuse_cont_open_by_label(struct dfuse_projection_info *fs_handle,
 
 	DFUSE_TRA_UP(dfc, dfp, "dfc");
 
-	rc = daos_cont_open_by_label(dfp->dfp_poh, label, DAOS_COO_RW,
-				     &dfc->dfs_coh, &c_info, NULL);
+	rc = daos_cont_open(dfp->dfp_poh, label, DAOS_COO_RW, &dfc->dfs_coh,
+			    &c_info, NULL);
 	if (rc == -DER_NONEXIST) {
 		DFUSE_TRA_INFO(dfc,
 			"daos_cont_open() failed: "

--- a/src/control/cmd/daos/container.go
+++ b/src/control/cmd/daos/container.go
@@ -87,8 +87,8 @@ func (cmd *containerBaseCmd) openContainer() error {
 		defer freeString(cLabel)
 
 		cmd.log.Debugf("opening container: %s", cmd.contLabel)
-		rc = C.daos_cont_open_by_label(cmd.cPoolHandle, cLabel,
-			openFlags, &cmd.cContHandle, &contInfo, nil)
+		rc = C.daos_cont_open(cmd.cPoolHandle, cLabel, openFlags,
+			&cmd.cContHandle, &contInfo, nil)
 		if rc == 0 {
 			var err error
 			cmd.contUUID, err = uuidFromC(contInfo.ci_uuid)
@@ -99,7 +99,9 @@ func (cmd *containerBaseCmd) openContainer() error {
 		}
 	case cmd.contUUID != uuid.Nil:
 		cmd.log.Debugf("opening container: %s", cmd.contUUID)
-		rc = C.daos_cont_open(cmd.cPoolHandle, cmd.contUUIDPtr(),
+		cUUIDstr := C.CString(cmd.contUUID.String())
+		defer freeString(cUUIDstr)
+		rc = C.daos_cont_open(cmd.cPoolHandle, cUUIDstr,
 			openFlags, &cmd.cContHandle, nil, nil)
 	default:
 		return errors.New("no container UUID or label supplied")
@@ -547,12 +549,14 @@ func (cmd *containerDestroyCmd) Execute(_ []string) error {
 		defer freeString(cPath)
 		rc = C.duns_destroy_path(cmd.cPoolHandle, cPath)
 	case cmd.ContainerID().HasUUID():
-		rc = C.daos_cont_destroy(cmd.cPoolHandle,
-			cmd.contUUIDPtr(), goBool2int(cmd.Force), nil)
+		cUUIDstr := C.CString(cmd.contUUID.String())
+		defer freeString(cUUIDstr)
+		rc = C.daos_cont_destroy(cmd.cPoolHandle, cUUIDstr,
+			goBool2int(cmd.Force), nil)
 	case cmd.ContainerID().Label != "":
 		cLabel := C.CString(cmd.ContainerID().Label)
 		defer freeString(cLabel)
-		rc = C.daos_cont_destroy_by_label(cmd.cPoolHandle,
+		rc = C.daos_cont_destroy(cmd.cPoolHandle,
 			cLabel, goBool2int(cmd.Force), nil)
 	default:
 		return errors.New("no UUID or label or path for container")

--- a/src/include/daos/container.h
+++ b/src/include/daos/container.h
@@ -35,10 +35,8 @@ int dc_cont_global2local(daos_handle_t poh, d_iov_t glob,
 
 int dc_cont_create(tse_task_t *task);
 int dc_cont_open(tse_task_t *task);
-int dc_cont_open_lbl(tse_task_t *task);
 int dc_cont_close(tse_task_t *task);
 int dc_cont_destroy(tse_task_t *task);
-int dc_cont_destroy_lbl(tse_task_t *task);
 int dc_cont_query(tse_task_t *task);
 int dc_cont_set_prop(tse_task_t *task);
 int dc_cont_update_acl(tse_task_t *task);

--- a/src/include/daos_cont.h
+++ b/src/include/daos_cont.h
@@ -168,14 +168,13 @@ daos_cont_create_by_label(daos_handle_t poh, const char *label,
 			  daos_event_t *ev);
 
 /**
- * Open an existing container identified by UUID \a uuid. Upon successful
+ * Open an existing container identified by a label or UUID string. Upon successful
  * completion, \a coh and \a info, both of which shall be allocated by the
  * caller, return the container handle and the latest container information
- * respectively. The resulting container handle has an HCE equal to GHCE, an
- * LHE equal to DAOS_EPOCH_MAX, and an LRE equal to GHCE.
+ * respectively.
  *
  * \param[in]	poh	Pool connection handle.
- * \param[in]	uuid	UUID to identify container.
+ * \param[in]	cont	Label or UUID string to identify the container.
  * \param[in]	flags	Open mode, represented by the DAOS_COO_ bits.
  * \param[out]	coh	Returned open handle.
  * \param[out]	info	Optional, return container information
@@ -192,36 +191,8 @@ daos_cont_create_by_label(daos_handle_t poh, const char *label,
  *			-DER_RF		#failures exceed RF, data possibly lost
  */
 int
-daos_cont_open(daos_handle_t poh, const uuid_t uuid, unsigned int flags,
+daos_cont_open(daos_handle_t poh, const char *cont, unsigned int flags,
 	       daos_handle_t *coh, daos_cont_info_t *info, daos_event_t *ev);
-
-/**
- * Open an existing container identified by label property \a label.
- * Upon successful completion, \a coh and \a info, both of which shall be
- * allocated by the caller, return the container handle and the latest
- * container information respectively.
- *
- * \param[in]	poh	Pool connection handle.
- * \param[in]	label	Label property to identify the container.
- * \param[in]	flags	Open mode, represented by the DAOS_COO_ bits.
- * \param[out]	coh	Returned open handle.
- * \param[out]	info	Optional, return container information
- * \param[in]	ev	Completion event, it is optional and can be NULL.
- *			The function will run in blocking mode if \a ev is NULL.
- *
- * \return		These values will be returned by \a ev::ev_error in
- *			non-blocking mode:
- *			0		Success
- *			-DER_INVAL	Invalid parameter
- *			-DER_UNREACH	Network is unreachable
- *			-DER_NO_PERM	Permission denied
- *			-DER_NONEXIST	Container is nonexistent
- *			-DER_RF		#failures exceed RF, data possibly lost
- */
-int
-daos_cont_open_by_label(daos_handle_t poh, const char *label,
-			unsigned int flags, daos_handle_t *coh,
-			daos_cont_info_t *info, daos_event_t *ev);
 
 /**
  * Close a container handle. Upon successful completion, the container handle's
@@ -242,14 +213,15 @@ int
 daos_cont_close(daos_handle_t coh, daos_event_t *ev);
 
 /**
- * Destroy a container identified by \a uuid, all objects within this
- * container will be destroyed as well.
+ * Destroy a container identified by \a cont, label or UUID string associated
+ * with the container. All objects within this container will be destroyed.
  * If there is at least one container opener, and \a force is set to zero, then
  * the operation completes with DER_BUSY. Otherwise, the container is destroyed
  * when the operation completes.
  *
  * \param[in]	poh	Pool connection handle.
- * \param[in]	uuid	Container UUID.
+ * \param[in]	cont	Label or UUID string to idenfity the container to
+ *			destroy
  * \param[in]	force	Container destroy will return failure if the container
  *			is still busy (outstanding open handles). This parameter
  *			will force the destroy to proceed even if there is an
@@ -266,36 +238,8 @@ daos_cont_close(daos_handle_t coh, daos_event_t *ev);
  *			-DER_BUSY	Pool is busy
  */
 int
-daos_cont_destroy(daos_handle_t poh, const uuid_t uuid, int force,
+daos_cont_destroy(daos_handle_t poh, const char *cont, int force,
 		  daos_event_t *ev);
-
-/**
- * Destroy a container identified by \a label, all objects within this
- * container will be destroyed as well.
- * If there is at least one container opener, and \a force is set to zero, then
- * the operation completes with DER_BUSY. Otherwise, the container is destroyed
- * when the operation completes.
- *
- * \param[in]	poh	Pool connection handle.
- * \param[in]	label	Container label property.
- * \param[in]	force	Container destroy will return failure if the container
- *			is still busy (outstanding open handles). This parameter
- *			will force the destroy to proceed even if there is an
- *			outstanding open handle.
- * \param[in]	ev	Completion event, it is optional and can be NULL.
- *			Function will run in blocking mode if \a ev is NULL.
- *
- * \return		These values will be returned by \a ev::ev_error in
- *			non-blocking mode:
- *			0		Success
- *			-DER_NO_PERM	Permission denied
- *			-DER_UNREACH	Network is unreachable
- *			-DER_NONEXIST	Container is nonexistent
- *			-DER_BUSY	Pool is busy
- */
-int
-daos_cont_destroy_by_label(daos_handle_t poh, const char *label, int force,
-			   daos_event_t *ev);
 
 /**
  * Query container information.
@@ -716,6 +660,57 @@ daos_cont_list_snap(daos_handle_t coh, int *nr, daos_epoch_t *epochs,
 int
 daos_cont_destroy_snap(daos_handle_t coh, daos_epoch_range_t epr,
 		       daos_event_t *ev);
+
+
+/**
+ * Backward compatibility code.
+ * Please don't use direclty
+ */
+
+int
+daos_cont_open2(daos_handle_t poh, const char *cont, unsigned int flags,
+		daos_handle_t *coh, daos_cont_info_t *info, daos_event_t *ev);
+
+ /**
+  * for backward compatility, support old api where a const uuid_t was used
+  * instead of a string to identify the container.
+  */
+#define daos_cont_open(poh, co, ...)					\
+	({								\
+		int _ret;						\
+		char _str[37];						\
+		const char *__str;					\
+		if (__builtin_types_compatible_p(typeof(co), char *) ||	\
+		    __builtin_types_compatible_p(typeof(co),		\
+						 const char *)) {	\
+			__str = (const char *)co;			\
+		} else {						\
+			uuid_unparse((unsigned char *)co, _str);	\
+			__str = _str;					\
+		}							\
+		_ret = daos_cont_open2(poh, __str, __VA_ARGS__);	\
+		_ret;							\
+	})
+
+int
+daos_cont_destroy2(daos_handle_t poh, const char *cont, int force,
+		   daos_event_t *ev);
+#define daos_cont_destroy(poh, co, ...)					\
+	({								\
+		int _ret;						\
+		char _str[37];						\
+		const char *__str;					\
+		if (__builtin_types_compatible_p(typeof(co), char *) ||	\
+		    __builtin_types_compatible_p(typeof(co),		\
+						 const char *)) {	\
+			__str = (const char *)co;			\
+		} else {						\
+			uuid_unparse((unsigned char *)co, _str);	\
+			__str = _str;					\
+		}							\
+		_ret = daos_cont_destroy2(poh, __str, __VA_ARGS__);	\
+		_ret;							\
+	})
 
 #if defined(__cplusplus)
 }

--- a/src/include/daos_cont.h
+++ b/src/include/daos_cont.h
@@ -168,10 +168,10 @@ daos_cont_create_by_label(daos_handle_t poh, const char *label,
 			  daos_event_t *ev);
 
 /**
- * Open an existing container identified by a label or UUID string. Upon successful
- * completion, \a coh and \a info, both of which shall be allocated by the
- * caller, return the container handle and the latest container information
- * respectively.
+ * Open an existing container identified by \a cont, a label or UUID string.
+ * Upon successful completion, \a coh and \a info, both of which shall be
+ * allocated by the caller, return the container handle and the latest
+ * container information respectively.
  *
  * \param[in]	poh	Pool connection handle.
  * \param[in]	cont	Label or UUID string to identify the container.
@@ -213,7 +213,7 @@ int
 daos_cont_close(daos_handle_t coh, daos_event_t *ev);
 
 /**
- * Destroy a container identified by \a cont, label or UUID string associated
+ * Destroy a container identified by \a cont, a label or UUID string associated
  * with the container. All objects within this container will be destroyed.
  * If there is at least one container opener, and \a force is set to zero, then
  * the operation completes with DER_BUSY. Otherwise, the container is destroyed
@@ -683,12 +683,12 @@ daos_cont_open2(daos_handle_t poh, const char *cont, unsigned int flags,
 		if (__builtin_types_compatible_p(typeof(co), char *) ||	\
 		    __builtin_types_compatible_p(typeof(co),		\
 						 const char *)) {	\
-			__str = (const char *)co;			\
+			__str = (const char *)(co);			\
 		} else {						\
-			uuid_unparse((unsigned char *)co, _str);	\
+			uuid_unparse((unsigned char *)(co), _str);	\
 			__str = _str;					\
 		}							\
-		_ret = daos_cont_open2(poh, __str, __VA_ARGS__);	\
+		_ret = daos_cont_open2((poh), __str, __VA_ARGS__);	\
 		_ret;							\
 	})
 
@@ -703,12 +703,12 @@ daos_cont_destroy2(daos_handle_t poh, const char *cont, int force,
 		if (__builtin_types_compatible_p(typeof(co), char *) ||	\
 		    __builtin_types_compatible_p(typeof(co),		\
 						 const char *)) {	\
-			__str = (const char *)co;			\
+			__str = (const char *)(co);			\
 		} else {						\
-			uuid_unparse((unsigned char *)co, _str);	\
+			uuid_unparse((unsigned char *)(co), _str);	\
 			__str = _str;					\
 		}							\
-		_ret = daos_cont_destroy2(poh, __str, __VA_ARGS__);	\
+		_ret = daos_cont_destroy2((poh), __str, __VA_ARGS__);	\
 		_ret;							\
 	})
 

--- a/src/include/daos_cont.h
+++ b/src/include/daos_cont.h
@@ -664,7 +664,7 @@ daos_cont_destroy_snap(daos_handle_t coh, daos_epoch_range_t epr,
 
 /**
  * Backward compatibility code.
- * Please don't use direclty
+ * Please don't use directly
  */
 
 int

--- a/src/include/daos_cont.h
+++ b/src/include/daos_cont.h
@@ -695,6 +695,7 @@ daos_cont_open2(daos_handle_t poh, const char *cont, unsigned int flags,
 int
 daos_cont_destroy2(daos_handle_t poh, const char *cont, int force,
 		   daos_event_t *ev);
+
 #define daos_cont_destroy(poh, co, ...)					\
 	({								\
 		int _ret;						\

--- a/src/include/daos_pool.h
+++ b/src/include/daos_pool.h
@@ -164,7 +164,7 @@ struct daos_pool_cont_info {
 };
 
 /**
- * Connect to the DAOS pool identified by its label or UUID string.
+ * Connect to the DAOS pool identified by \a pool, a label or UUID string.
  * Upon a successful completion, \a poh returns the pool handle, and \a info
  * returns the latest pool information.
  *
@@ -433,9 +433,9 @@ daos_pool_connect2(const char *pool, const char *sys, unsigned int flags,
 		if (__builtin_types_compatible_p(typeof(po), char *) ||	\
 		    __builtin_types_compatible_p(typeof(po),		\
 						 const char *)) {	\
-			__str = (const char *)po;			\
+			__str = (const char *)(po);			\
 		} else {						\
-			uuid_unparse((unsigned char *)po, _str);	\
+			uuid_unparse((unsigned char *)(po), _str);	\
 			__str = _str;					\
 		}							\
 		_ret = daos_pool_connect2(__str, __VA_ARGS__);		\

--- a/src/include/daos_task.h
+++ b/src/include/daos_task.h
@@ -339,7 +339,10 @@ typedef struct {
 typedef struct {
 	/** Pool open handle. */
 	daos_handle_t		poh;
-	/** Container UUID. */
+	/**
+	 * Deprecated, container UUID replaced by UUID string or label via the
+	 * cont arg at the end of this structure.
+	 */
 	uuid_t			uuid;
 	/** Open mode, represented by the DAOS_COO_ bits.*/
 	unsigned int		flags;
@@ -347,8 +350,8 @@ typedef struct {
 	daos_handle_t		*coh;
 	/** Optional, return container information. */
 	daos_cont_info_t	*info;
-	/** Container label, API v1.2.2 (placed at end for ABI compatibility) */
-	const char		*label;
+	/** Container (UUID string or label) to open, API v1.3.0 */
+	const char		*cont;
 } daos_cont_open_t;
 
 /** Container close args */
@@ -361,12 +364,15 @@ typedef struct {
 typedef struct {
 	/** Pool open handle. */
 	daos_handle_t		poh;
-	/** Container UUID. */
+	/**
+	 * Deprecated, container UUID replaced by UUID string or label via the
+	 * cont arg at the end of this structure.
+	 */
 	uuid_t			uuid;
 	/** Force destroy even if there is outstanding open handles. */
 	int			force;
-	/* label, API v1.2.4 (placed at end for ABI compatibility) */
-	const char	       *label;
+	/** Container (UUID string or label) to destroy, API v1.3.0 */
+	const char	       *cont;
 } daos_cont_destroy_t;
 
 /** Container query args */

--- a/src/tests/suite/daos_container.c
+++ b/src/tests/suite/daos_container.c
@@ -453,8 +453,8 @@ co_properties(void **state)
 		assert_rc_equal(rc, 0);
 		print_message("created container C2: %s\n", label2);
 		/* Open by label, and immediately close */
-		rc = daos_cont_open_by_label(arg->pool.poh, label2, DAOS_COO_RW,
-					     &coh2, NULL, NULL);
+		rc = daos_cont_open(arg->pool.poh, label2, DAOS_COO_RW, &coh2,
+				    NULL, NULL);
 		assert_rc_equal(rc, 0);
 		rc = daos_cont_close(coh2, NULL /* ev */);
 		assert_rc_equal(rc, 0);
@@ -469,8 +469,8 @@ co_properties(void **state)
 		assert_rc_equal(rc, -DER_INVAL);
 
 		/* destroy the container C2 (will re-create it next) */
-		rc = daos_cont_destroy_by_label(arg->pool.poh, label2,
-						0 /* force */, NULL /* ev */);
+		rc = daos_cont_destroy(arg->pool.poh, label2, 0 /* force */,
+				       NULL /* ev */);
 		assert_rc_equal(rc, 0);
 		print_message("destroyed container C2: %s\n", label2);
 
@@ -485,8 +485,8 @@ co_properties(void **state)
 		assert_rc_equal(rc, 0);
 		print_message("step1: created container C3: %s : "
 			      "UUID:"DF_UUIDF"\n", foo_label, DP_UUID(cuuid3));
-		rc = daos_cont_open_by_label(arg->pool.poh, foo_label,
-					     DAOS_COO_RW, &coh3, NULL, NULL);
+		rc = daos_cont_open(arg->pool.poh, foo_label, DAOS_COO_RW,
+				    &coh3, NULL, NULL);
 		assert_rc_equal(rc, 0);
 		print_message("step2: C3 set-prop, rename %s -> %s\n",
 			      foo_label, prop->dpp_entries[0].dpe_str);
@@ -518,8 +518,8 @@ co_properties(void **state)
 		/* destroy container C3 */
 		rc = daos_cont_close(coh3, NULL);
 		assert_rc_equal(rc, 0);
-		rc = daos_cont_destroy_by_label(arg->pool.poh, label2_v2,
-						0 /* force */, NULL /* ev */);
+		rc = daos_cont_destroy(arg->pool.poh, label2_v2, 0 /* force */,
+				       NULL /* ev */);
 		assert_rc_equal(rc, 0);
 		print_message("destroyed container C3: %s : "
 			      "UUID:"DF_UUIDF"\n", label2_v2, DP_UUID(cuuid3));

--- a/src/tests/suite/daos_container.c
+++ b/src/tests/suite/daos_container.c
@@ -2048,6 +2048,7 @@ expect_co_get_attr_access(test_arg_t *arg, uint64_t perms, int exp_result)
 	const char	*name = "AttrName";
 	size_t		 val_size = TEST_MAX_ATTR_LEN;
 	char		 value[val_size];
+	void		*valptr = &value;
 
 	cont_prop = get_daos_prop_with_owner_acl_perms(perms,
 						       DAOS_PROP_CO_ACL);
@@ -2061,7 +2062,7 @@ expect_co_get_attr_access(test_arg_t *arg, uint64_t perms, int exp_result)
 	if (arg->myrank == 0) {
 		/* Trivial case - just to see if we have access */
 		rc = daos_cont_get_attr(arg->coh, 1, &name,
-					(void * const*)&value,
+					(void * const*)&valptr,
 					&val_size,
 					NULL);
 

--- a/src/tests/suite/daos_test_common.c
+++ b/src/tests/suite/daos_test_common.c
@@ -239,11 +239,10 @@ test_setup_cont_open(void **state)
 		if (arg->cont_label) {
 			print_message("setup: opening container by label %s\n",
 				      arg->cont_label);
-			rc = daos_cont_open_by_label(arg->pool.poh,
-						     arg->cont_label,
-						     arg->cont_open_flags,
-						     &arg->coh, &arg->co_info,
-						     NULL);
+			rc = daos_cont_open(arg->pool.poh, arg->cont_label,
+					    arg->cont_open_flags,
+					    &arg->coh, &arg->co_info,
+					    NULL);
 		} else {
 			print_message("setup: opening container "DF_UUID"\n",
 				      DP_UUID(arg->co_uuid));

--- a/src/utils/daos.c
+++ b/src/utils/daos.c
@@ -1143,10 +1143,9 @@ fs_op_hdlr(struct cmd_args_s *ap)
 		}
 
 		if (ap->cont_label) {
-			rc = daos_cont_open_by_label(ap->pool, ap->cont_label,
-						     DAOS_COO_RW |
-						     DAOS_COO_FORCE,
-						     &ap->cont, NULL, NULL);
+			rc = daos_cont_open(ap->pool, ap->cont_label,
+					    DAOS_COO_RW | DAOS_COO_FORCE,
+					    &ap->cont, NULL, NULL);
 			fprintf(stderr,
 				"failed to open container %s: %s (%d)\n",
 				ap->cont_label, d_errdesc(rc), rc);
@@ -1330,9 +1329,9 @@ cont_op_hdlr(struct cmd_args_s *ap)
 
 	if (op != CONT_CREATE && op != CONT_DESTROY) {
 		if (ap->cont_label) {
-			rc = daos_cont_open_by_label(ap->pool, ap->cont_label,
-					     DAOS_COO_RW | DAOS_COO_FORCE,
-					     &ap->cont, &cont_info, NULL);
+			rc = daos_cont_open(ap->pool, ap->cont_label,
+					    DAOS_COO_RW | DAOS_COO_FORCE,
+					    &ap->cont, &cont_info, NULL);
 			if (rc != 0) {
 				fprintf(stderr, "failed to open "
 					"container %s: %s (%d)\n",


### PR DESCRIPTION
Change daos_cont_open/destroy() to take a string an a input
parameter that can be interpreted as either a label or a UUID.

Backward API compatibility is supported via a macro that will
automatically convert a uuid_t (old API) to a UUID string.
We could eventually remove the macro in 2.2 or beyond.

Backward ABI compatibility is supported by keeping around
the daos_cont_open/destroy symbols, but not advertising them via
the header files (the macro overrides it). We could also remove this
symbol at some point when all users have recompiled against 2.x
code.

Handle backward compatibility for the task API too.

Remove daos_cont_open/destroy_by_label() operations

Signed-off-by: Johann Lombardi <johann.lombardi@intel.com>