### PR TITLE
DAOS-8023 utils: Update raft to fix slow re-elections

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,9 +1,16 @@
+daos (1.3.103-4) unstable; urgency=medium
+  [ Li Wei ]
+  * Update raft to fix slow leader re-elections
+
+ -- Li Wei <wei.g.li@intel.com>  Wed, 14 Jul 2021 14:22:00 +0800
+
 daos (1.3.103-3) unstable; urgency=medium
   [ Maureen Jean ]
   * Add python modules to python3.8 site-packages
 
  -- Maureen Jean <maureen.jean@intel.com>  Tue, 13 Jul 2021 14:50:00 -0400
 
+daos (1.3.103-2) unstable; urgency=medium
   [ Alexander Oganezov ]
   * Update to mercury v2.0.1
 

--- a/debian/control
+++ b/debian/control
@@ -28,7 +28,7 @@ Build-Depends: debhelper (>= 10),
                libboost-dev,
                libspdk-dev,
                libipmctl-dev,
-               libraft-dev (= 0.8.0-1386.g7509891),
+               libraft-dev (= 0.8.0-1387.g3b0f9f0),
                python3-tabulate,
                liblz4-dev
 Standards-Version: 4.1.2

--- a/utils/rpms/daos.spec
+++ b/utils/rpms/daos.spec
@@ -14,7 +14,7 @@
 
 Name:          daos
 Version:       1.3.103
-Release:       3%{?relval}%{?dist}
+Release:       4%{?relval}%{?dist}
 Summary:       DAOS Storage Engine
 
 License:       BSD-2-Clause-Patent
@@ -460,6 +460,9 @@ getent passwd daos_agent >/dev/null || useradd -s /sbin/nologin -r -g daos_agent
 %attr(4750,root,daos_server) %{_bindir}/daos_firmware
 
 %changelog
+* Wed Jul 14 2021 Li Wei <wei.g.li@intel.com> 1.3.103-4
+- Update raft to fix slow leader re-elections
+
 * Tue Jul 13 2021  Maureen Jean <maureen.jean@intel.com> 1.3.103-3
 - Add python modules to python3.6 site-packages
 


### PR DESCRIPTION
Update raft to fix slow leader re-elections introduced by Pre-Vote.

Signed-off-by: Li Wei <wei.g.li@intel.com>