### PR TITLE
DAOS-7893 Systemd: StartLimitIntervalSec in incorrect section in service file

### DIFF
--- a/utils/rpms/daos.spec
+++ b/utils/rpms/daos.spec
@@ -472,7 +472,7 @@ getent passwd daos_agent >/dev/null || useradd -s /sbin/nologin -r -g daos_agent
 %{_libdir}/libdaos_serialize.so
 
 %changelog
-* Tue Aug 03 2021 Christopher Hoffman <christopherx.hoffman@intel.com> 1.3.103-6
+* Tue Aug 03 2021 Christopher Hoffman <christopherx.hoffman@intel.com> 1.3.104-2
 - Update conditional statement to include checking for distributions to
   determine which unit files to use for daos-server and daos-agent
 

--- a/utils/rpms/daos.spec
+++ b/utils/rpms/daos.spec
@@ -14,7 +14,7 @@
 
 Name:          daos
 Version:       1.3.104
-Release:       3%{?relval}%{?dist}
+Release:       4%{?relval}%{?dist}
 Summary:       DAOS Storage Engine
 
 License:       BSD-2-Clause-Patent
@@ -472,7 +472,7 @@ getent passwd daos_agent >/dev/null || useradd -s /sbin/nologin -r -g daos_agent
 %{_libdir}/libdaos_serialize.so
 
 %changelog
-* Tue Aug 03 2021 Christopher Hoffman <christopherx.hoffman@intel.com> 1.3.104-2
+* Thu Aug 05 2021 Christopher Hoffman <christopherx.hoffman@intel.com> 1.3.104-4
 - Update conditional statement to include checking for distributions to
   determine which unit files to use for daos-server and daos-agent
 

--- a/utils/rpms/daos.spec
+++ b/utils/rpms/daos.spec
@@ -472,9 +472,8 @@ getent passwd daos_agent >/dev/null || useradd -s /sbin/nologin -r -g daos_agent
 %{_libdir}/libdaos_serialize.so
 
 %changelog
-* Wed Jul 28 2021 Christopher Hoffman <christopherx.hoffman@intel.com> 1.3.103-6
+* Tue Aug 03 2021 Christopher Hoffman <christopherx.hoffman@intel.com> 1.3.103-6
 - Update conditional statement to include checking for distributions to
-  Cleaned up whitespace
   determine which unit files to use for daos-server and daos-agent
 
 * Wed Aug 04 2021 Kris Jacque <kristin.jacque@intel.com> 1.3.104-3

--- a/utils/rpms/daos.spec
+++ b/utils/rpms/daos.spec
@@ -305,7 +305,7 @@ mkdir -p %{buildroot}/%{_unitdir}
 %if (0%{?rhel} == 7)
 install -m 644 utils/systemd/%{server_svc_name}.pre230 %{buildroot}/%{_unitdir}/%{server_svc_name}
 install -m 644 utils/systemd/%{agent_svc_name}.pre230 %{buildroot}/%{_unitdir}/%{agent_svc_name}
-%else
+%else if (0%{?rhel} == 8 or  %{?suse_version} == 1500)
 install -m 644 utils/systemd/%{server_svc_name} %{buildroot}/%{_unitdir}
 install -m 644 utils/systemd/%{agent_svc_name} %{buildroot}/%{_unitdir}
 %endif
@@ -472,6 +472,10 @@ getent passwd daos_agent >/dev/null || useradd -s /sbin/nologin -r -g daos_agent
 %{_libdir}/libdaos_serialize.so
 
 %changelog
+* Thu July 22 2021 Christopher Hoffman <christopherx.hoffman@intel.com> 1.3.103-4
+- Update conditional statement to include checking for rhel 8 and leap 15 to
+  determine which unit files to use for daos-server and daos-agent
+
 * Wed Aug 04 2021 Kris Jacque <kristin.jacque@intel.com> 1.3.104-3
 - Move daos_metrics tool from tests package to server package
 

--- a/utils/rpms/daos.spec
+++ b/utils/rpms/daos.spec
@@ -472,7 +472,7 @@ getent passwd daos_agent >/dev/null || useradd -s /sbin/nologin -r -g daos_agent
 %{_libdir}/libdaos_serialize.so
 
 %changelog
-* Thu July 22 2021 Christopher Hoffman <christopherx.hoffman@intel.com> 1.3.103-4
+* Thu Jul 22 2021 Christopher Hoffman <christopherx.hoffman@intel.com> 1.3.103-5
 - Update conditional statement to include checking for rhel 8 and leap 15 to
   determine which unit files to use for daos-server and daos-agent
 

--- a/utils/rpms/daos.spec
+++ b/utils/rpms/daos.spec
@@ -472,8 +472,9 @@ getent passwd daos_agent >/dev/null || useradd -s /sbin/nologin -r -g daos_agent
 %{_libdir}/libdaos_serialize.so
 
 %changelog
-* Thu Jul 22 2021 Christopher Hoffman <christopherx.hoffman@intel.com> 1.3.103-5
-- Update conditional statement to include checking for rhel 8 and leap 15 to
+* Wed Jul 28 2021 Christopher Hoffman <christopherx.hoffman@intel.com> 1.3.103-6
+- Update conditional statement to include checking for distributions to
+  Cleaned up whitespace
   determine which unit files to use for daos-server and daos-agent
 
 * Wed Aug 04 2021 Kris Jacque <kristin.jacque@intel.com> 1.3.104-3

--- a/utils/systemd/daos_agent.service
+++ b/utils/systemd/daos_agent.service
@@ -1,5 +1,6 @@
 [Unit]
 Description=DAOS Agent
+StartLimitIntervalSec=60
 Wants=network-online.target
 After=network-online.target
 
@@ -16,7 +17,6 @@ Restart=always
 RestartSec=10
 LimitMEMLOCK=infinity
 LimitCORE=infinity
-StartLimitIntervalSec=60
 StartLimitBurst=5
 
 [Install]

--- a/utils/systemd/daos_server.service
+++ b/utils/systemd/daos_server.service
@@ -1,5 +1,6 @@
 [Unit]
 Description=DAOS Server
+StartLimitIntervalSec=60
 Wants=network-online.target
 After=network-online.target
 
@@ -17,7 +18,6 @@ RestartSec=10
 LimitMEMLOCK=infinity
 LimitCORE=infinity
 LimitNOFILE=infinity
-StartLimitIntervalSec=60
 StartLimitBurst=5
 
 [Install]


### PR DESCRIPTION
The option 'StartLimitIntervalSec' is to be in Unit section and not Service section.
See: https://www.freedesktop.org/software/systemd/man/systemd.unit.html

-Moved 'StartLimitIntervalSec' from Service section to Unit section

Signed-off-by: Christopher Hoffman <christopherx.hoffman@intel.com>