### PR TITLE
DAOS-5898 EC: merge adjacent segments in EC sgl reassemble

### DIFF
--- a/src/object/cli_ec.c
+++ b/src/object/cli_ec.c
@@ -205,7 +205,17 @@ obj_ec_seg_pack(struct obj_ec_seg_sorter *sorter, d_sg_list_t *sgl)
 		D_ASSERT(tgt_head->esh_first != OBJ_EC_SEG_NIL);
 		seg = &sorter->ess_segs[tgt_head->esh_first];
 		do {
-			sgl->sg_iovs[idx++] = seg->oes_iov;
+			if ((idx > 0) &&
+			    ((sgl->sg_iovs[idx - 1].iov_buf +
+			      sgl->sg_iovs[idx - 1].iov_len) ==
+			     seg->oes_iov.iov_buf)) {
+				sgl->sg_iovs[idx - 1].iov_len +=
+					seg->oes_iov.iov_len;
+				sgl->sg_iovs[idx - 1].iov_buf_len =
+					sgl->sg_iovs[idx - 1].iov_len;
+			} else {
+				sgl->sg_iovs[idx++] = seg->oes_iov;
+			}
 			if (seg->oes_next == OBJ_EC_SEG_NIL)
 				break;
 			seg = &sorter->ess_segs[seg->oes_next];
@@ -1845,7 +1855,7 @@ obj_ec_recov_add(struct obj_reasb_req *reasb_req,
 	if (recx_lists == NULL || nr == 0)
 		return 0;
 
-	D_SPIN_LOCK(&reasb_req->orr_spin);
+	D_MUTEX_LOCK(&reasb_req->orr_mutex);
 	recov_lists = reasb_req->orr_fail->efi_recx_lists;
 	if (recov_lists == NULL) {
 		D_ALLOC_ARRAY(recov_lists, nr);
@@ -1869,7 +1879,7 @@ obj_ec_recov_add(struct obj_reasb_req *reasb_req,
 		}
 	}
 	daos_recx_ep_list_set(recov_lists, nr, 0, false);
-	D_SPIN_UNLOCK(&reasb_req->orr_spin);
+	D_MUTEX_UNLOCK(&reasb_req->orr_mutex);
 	return 0;
 }
 
@@ -1893,7 +1903,7 @@ obj_ec_parity_check(struct obj_reasb_req *reasb_req,
 	if (recx_lists == NULL || nr == 0)
 		return 0;
 
-	D_SPIN_LOCK(&reasb_req->orr_spin);
+	D_MUTEX_LOCK(&reasb_req->orr_mutex);
 	parity_lists = reasb_req->orr_fail->efi_parity_lists;
 	if (parity_lists == NULL) {
 		reasb_req->orr_fail->efi_parity_lists =
@@ -1915,7 +1925,7 @@ obj_ec_parity_check(struct obj_reasb_req *reasb_req,
 	}
 
 out:
-	D_SPIN_UNLOCK(&reasb_req->orr_spin);
+	D_MUTEX_UNLOCK(&reasb_req->orr_mutex);
 	return rc;
 }
 

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -24,7 +24,7 @@
 #define CLI_OBJ_IO_PARMS	8
 #define NIL_BITMAP		(NULL)
 
-#define OBJ_TGT_INLINE_NR	(12)
+#define OBJ_TGT_INLINE_NR	(11)
 struct obj_req_tgts {
 	/* to save memory allocation if #targets <= OBJ_TGT_INLINE_NR */
 	struct daos_shard_tgt	 ort_tgts_inline[OBJ_TGT_INLINE_NR];
@@ -780,7 +780,7 @@ obj_reasb_req_init(struct obj_reasb_req *reasb_req, daos_iod_t *iods,
 
 	D_ASSERT((uintptr_t)(tmp_ptr - size_tgt_nr) <=
 		 (uintptr_t)(buf + buf_size));
-	D_SPIN_INIT(&reasb_req->orr_spin, PTHREAD_PROCESS_PRIVATE);
+	D_MUTEX_INIT(&reasb_req->orr_mutex, NULL);
 
 	return 0;
 }
@@ -804,7 +804,7 @@ obj_reasb_req_fini(struct obj_reasb_req *reasb_req, uint32_t iod_nr)
 		obj_ec_tgt_oiod_fini(reasb_req->tgt_oiods);
 		reasb_req->tgt_oiods = NULL;
 	}
-	D_SPIN_DESTROY(&reasb_req->orr_spin);
+	D_MUTEX_DESTROY(&reasb_req->orr_mutex);
 	obj_ec_fail_info_free(reasb_req);
 	D_FREE(reasb_req->orr_iods);
 }

--- a/src/object/obj_internal.h
+++ b/src/object/obj_internal.h
@@ -140,7 +140,7 @@ struct obj_reasb_req {
 	uint32_t			 orr_iom_nr;
 	struct daos_oclass_attr		*orr_oca;
 	struct obj_ec_codec		*orr_codec;
-	pthread_spinlock_t		 orr_spin;
+	pthread_mutex_t			 orr_mutex;
 	/* target bitmap, one bit for each target (from first data cell to last
 	 * parity cell.
 	 */


### PR DESCRIPTION
Refine obj_ec_seg_pack() to merge segments when possible, that is
helpful to reduce #segments in bulk handle for one-full-stripe IO.

Change reasb_req's spinlock to mutex as some cases may allocate memory
when holding the lock.

Signed-off-by: Xuezhao Liu <xuezhao.liu@intel.com>