### PR TITLE
DAOS-7673 control: don't create tier from legacy cfg if devlist empty

### DIFF
--- a/src/control/server/config/server.go
+++ b/src/control/server/config/server.go
@@ -449,7 +449,14 @@ func (cfg *Server) Validate(log logging.Logger) (err error) {
 						WithScmRamdiskSize(ec.LegacyStorage.RamdiskSize),
 				)
 			}
-			if ec.LegacyStorage.BdevClass != storage.ClassNone {
+
+			// Do not add bdev tier if cls is none or nvme has no
+			// devices to maintain backward compatible behavior.
+			bc := ec.LegacyStorage.BdevClass
+			switch {
+			case bc == storage.ClassNvme && len(ec.LegacyStorage.BdevConfig.DeviceList) == 0:
+			case bc == storage.ClassNone:
+			default:
 				tierCfgs = append(tierCfgs,
 					storage.NewTierConfig().
 						WithBdevClass(ec.LegacyStorage.BdevClass.String()).


### PR DESCRIPTION
In the case that a legacy config file format (without storage tiers) has
been supplied with class NVMe and an empty device list, avoid creating a
bdev tier when converting from legacy to current storage config
structure. This change reinstates previous behavior.

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>