### PR TITLE
DAOS-8103 vos: increment ic_io_size for single value

### DIFF
--- a/src/vos/vos_io.c
+++ b/src/vos/vos_io.c
@@ -888,6 +888,7 @@ akey_fetch_single(daos_handle_t toh, const daos_epoch_range_t *epr,
 		goto out;
 
 	*rsize = rbund.rb_gsize;
+	ioc->ic_io_size += rbund.rb_gsize;
 out:
 	return rc;
 }
@@ -1613,6 +1614,8 @@ akey_update_single(daos_handle_t toh, uint32_t pm_ver, daos_size_t rsize,
 	rc = dbtree_update(toh, &kiov, &riov);
 	if (rc != 0)
 		D_ERROR("Failed to update subtree: "DF_RC"\n", DP_RC(rc));
+
+	ioc->ic_io_size += rsize;
 
 	return rc;
 }

--- a/src/vos/vos_io.c
+++ b/src/vos/vos_io.c
@@ -888,7 +888,7 @@ akey_fetch_single(daos_handle_t toh, const daos_epoch_range_t *epr,
 		goto out;
 
 	*rsize = rbund.rb_gsize;
-	ioc->ic_io_size += rbund.rb_gsize;
+	ioc->ic_io_size += rbund.rb_rsize;
 out:
 	return rc;
 }


### PR DESCRIPTION
ioc->ic_io_size is used by telemetry to maintain how much data
was fetched/updated from the engine. It is currently increased
for array value. This patch also covers single value.

Signed-off-by: Johann Lombardi <johann.lombardi@intel.com>