### PR TITLE
DAOS-7894 agent: Refactor GetAttachInfo cache

### DIFF
--- a/src/control/cmd/daos_agent/fabric.go
+++ b/src/control/cmd/daos_agent/fabric.go
@@ -1,0 +1,206 @@
+//
+// (C) Copyright 2021 Intel Corporation.
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/daos-stack/daos/src/control/lib/netdetect"
+	"github.com/daos-stack/daos/src/control/logging"
+	"github.com/pkg/errors"
+)
+
+// FabricNotFoundErr is the error returned when no appropriate fabric interface
+// was found.
+func FabricNotFoundErr(netDevClass uint32) error {
+	return fmt.Errorf("no suitable fabric interface found of type %q", netdetect.DevClassName(netDevClass))
+}
+
+// FabricInterface represents a generic fabric interface.
+type FabricInterface struct {
+	Name        string `yaml:"name"`
+	Domain      string `yaml:"domain"`
+	NetDevClass uint32 `yaml:"net_dev_class"`
+}
+
+// DefaultFabricInterface is the one used if no devices are found on the system.
+var DefaultFabricInterface = &FabricInterface{
+	Name:   "lo",
+	Domain: "lo",
+}
+
+// NUMAFabric represents a set of fabric interfaces organized by NUMA node.
+type NUMAFabric struct {
+	log logging.Logger
+
+	numaMap map[int][]*FabricInterface
+
+	// current device idx to use on each NUMA node
+	currentNumaDevIdx map[int]int
+	defaultNumaNode   int
+}
+
+// Add adds a fabric interface to a specific NUMA node.
+func (n *NUMAFabric) Add(numaNode int, fi *FabricInterface) error {
+	if n == nil {
+		return errors.New("nil NUMAFabric")
+	}
+	n.numaMap[numaNode] = append(n.numaMap[numaNode], fi)
+	return nil
+}
+
+// NumDevices gets the number of devices on a given NUMA node.
+func (n *NUMAFabric) NumDevices(numaNode int) int {
+	if n == nil {
+		return 0
+	}
+	if devs, exist := n.numaMap[numaNode]; exist {
+		return len(devs)
+	}
+	return 0
+}
+
+// NumNUMANodes gets the number of NUMA nodes.
+func (n *NUMAFabric) NumNUMANodes() int {
+	if n == nil {
+		return 0
+	}
+	return len(n.numaMap)
+}
+
+// GetDevice selects the next available interface device on the requested NUMA node.
+func (n *NUMAFabric) GetDevice(numaNode int, netDevClass uint32) (*FabricInterface, error) {
+	if n == nil {
+		return nil, errors.New("nil NUMAFabric")
+	}
+
+	if n.NumNUMANodes() == 0 {
+		n.log.Infof("No fabric interfaces found, using default interface %q", DefaultFabricInterface.Name)
+		return DefaultFabricInterface, nil
+	}
+
+	fi, err := n.getDeviceFromNUMA(numaNode, netDevClass)
+	if err == nil {
+		return fi, nil
+	}
+
+	fi, err = n.findOnRemoteNUMA(netDevClass)
+	if err != nil {
+		return nil, err
+	}
+
+	return fi, nil
+}
+
+func (n *NUMAFabric) getDeviceFromNUMA(numaNode int, netDevClass uint32) (*FabricInterface, error) {
+	for checked := 0; checked < n.NumDevices(numaNode); checked++ {
+		fabricIF, err := n.getNextDevice(numaNode)
+		if err != nil {
+			return nil, err
+		}
+
+		if fabricIF.NetDevClass != netDevClass {
+			n.log.Debugf("Excluding device: %s, network device class: %s from attachInfoCache. Does not match network device class: %s",
+				fabricIF.Name, netdetect.DevClassName(fabricIF.NetDevClass), netdetect.DevClassName(netDevClass))
+			continue
+		}
+
+		return fabricIF, nil
+	}
+	return nil, FabricNotFoundErr(netDevClass)
+}
+
+func (n *NUMAFabric) getNextDevice(numaNode int) (*FabricInterface, error) {
+	idx, err := n.getNextDevIndex(numaNode)
+	if err != nil {
+		return nil, err
+	}
+	return n.numaMap[numaNode][idx], nil
+}
+
+func (n *NUMAFabric) findOnRemoteNUMA(netDevClass uint32) (*FabricInterface, error) {
+	numNodes := n.NumNUMANodes()
+	for i := 0; i < numNodes; i++ {
+		numa := (n.defaultNumaNode + i) % numNodes
+		fi, err := n.getDeviceFromNUMA(numa, netDevClass)
+		if err == nil {
+			// Start the search on this node next time
+			n.defaultNumaNode = numa
+			n.log.Debugf("Suitable fabric interface %q found on NUMA node %d", fi.Name, numa)
+			return fi, nil
+		}
+	}
+	return nil, FabricNotFoundErr(netDevClass)
+}
+
+// getNextDevIndex is a simple round-robin load balancing scheme
+// for NUMA nodes that have multiple adapters to choose from.
+func (n *NUMAFabric) getNextDevIndex(numaNode int) (int, error) {
+	if n.currentNumaDevIdx == nil {
+		n.currentNumaDevIdx = make(map[int]int)
+	}
+	numDevs := n.NumDevices(numaNode)
+	if numDevs > 0 {
+		deviceIndex := n.currentNumaDevIdx[numaNode]
+		n.currentNumaDevIdx[numaNode] = (deviceIndex + 1) % numDevs
+		return deviceIndex, nil
+	}
+	return 0, fmt.Errorf("no fabric interfaces on NUMA node %d", numaNode)
+}
+
+func newNUMAFabric(log logging.Logger) *NUMAFabric {
+	return &NUMAFabric{
+		log:               log,
+		numaMap:           make(map[int][]*FabricInterface),
+		currentNumaDevIdx: make(map[int]int),
+	}
+}
+
+// NUMAFabricFromScan generates a NUMAFabric from a fabric scan result.
+func NUMAFabricFromScan(ctx context.Context, log logging.Logger, scan []*netdetect.FabricScan,
+	getDevAlias func(ctx context.Context, devName string) (string, error)) *NUMAFabric {
+	fabric := newNUMAFabric(log)
+
+	for _, fs := range scan {
+		if fs.DeviceName == "lo" {
+			continue
+		}
+
+		newIF := &FabricInterface{
+			Name:        fs.DeviceName,
+			NetDevClass: fs.NetDevClass,
+		}
+
+		if getDevAlias != nil {
+			deviceAlias, err := getDevAlias(ctx, newIF.Name)
+			if err != nil {
+				log.Debugf("Non-fatal error: failed to get device alias for %q: %v", newIF.Name, err)
+			} else {
+				newIF.Domain = deviceAlias
+			}
+		}
+
+		numa := int(fs.NUMANode)
+		fabric.Add(numa, newIF)
+
+		log.Debugf("Added device %q, domain %q for NUMA %d, device number %d",
+			newIF.Name, newIF.Domain, numa, fabric.NumDevices(numa)-1)
+	}
+
+	for numa := range fabric.numaMap {
+		fabric.defaultNumaNode = numa
+		log.Debugf("The default NUMA node is: %d", numa)
+		break
+	}
+
+	if fabric.NumNUMANodes() == 0 {
+		log.Info("No network devices detected in fabric scan\n")
+	}
+
+	return fabric
+}

--- a/src/control/cmd/daos_agent/fabric.go
+++ b/src/control/cmd/daos_agent/fabric.go
@@ -10,9 +10,10 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/pkg/errors"
+
 	"github.com/daos-stack/daos/src/control/lib/netdetect"
 	"github.com/daos-stack/daos/src/control/logging"
-	"github.com/pkg/errors"
 )
 
 // FabricNotFoundErr is the error returned when no appropriate fabric interface

--- a/src/control/cmd/daos_agent/fabric_test.go
+++ b/src/control/cmd/daos_agent/fabric_test.go
@@ -1,0 +1,588 @@
+//
+// (C) Copyright 2021 Intel Corporation.
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/pkg/errors"
+
+	"github.com/daos-stack/daos/src/control/common"
+	"github.com/daos-stack/daos/src/control/lib/netdetect"
+	"github.com/daos-stack/daos/src/control/logging"
+)
+
+func TestAgent_NewNUMAFabric(t *testing.T) {
+	log, buf := logging.NewTestLogger(t.Name())
+	defer common.ShowBufferOnFailure(t, buf)
+
+	result := newNUMAFabric(log)
+
+	if result == nil {
+		t.Fatal("result was nil")
+	}
+
+	if result.numaMap == nil {
+		t.Fatal("map was nil")
+	}
+}
+
+func TestAgent_NUMAFabric_NumNUMANodes(t *testing.T) {
+	for name, tc := range map[string]struct {
+		nf        *NUMAFabric
+		expResult int
+	}{
+		"nil": {},
+		"empty struct": {
+			nf: &NUMAFabric{},
+		},
+		"multiple nodes": {
+			nf: &NUMAFabric{
+				numaMap: map[int][]*FabricInterface{
+					0:  {},
+					1:  {},
+					3:  {},
+					10: {},
+				},
+			},
+			expResult: 4,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			log, buf := logging.NewTestLogger(t.Name())
+			defer common.ShowBufferOnFailure(t, buf)
+			if tc.nf != nil {
+				tc.nf.log = log
+			}
+
+			common.AssertEqual(t, tc.expResult, tc.nf.NumNUMANodes(), "")
+		})
+	}
+}
+
+func TestAgent_NUMAFabric_NumDevices(t *testing.T) {
+	for name, tc := range map[string]struct {
+		nf        *NUMAFabric
+		node      int
+		expResult int
+	}{
+		"nil": {},
+		"empty": {
+			nf:   &NUMAFabric{},
+			node: 5,
+		},
+		"multiple devices on node": {
+			nf: &NUMAFabric{
+				numaMap: map[int][]*FabricInterface{
+					3: {&FabricInterface{}, &FabricInterface{}},
+				},
+			},
+			node:      3,
+			expResult: 2,
+		},
+		"multiple nodes": {
+			nf: &NUMAFabric{
+				numaMap: map[int][]*FabricInterface{
+					0:  {&FabricInterface{}, &FabricInterface{}, &FabricInterface{}},
+					1:  {&FabricInterface{}},
+					3:  {&FabricInterface{}},
+					10: {&FabricInterface{}},
+				},
+			},
+			node:      0,
+			expResult: 3,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			log, buf := logging.NewTestLogger(t.Name())
+			defer common.ShowBufferOnFailure(t, buf)
+			if tc.nf != nil {
+				tc.nf.log = log
+			}
+
+			common.AssertEqual(t, tc.expResult, tc.nf.NumDevices(tc.node), "")
+		})
+	}
+}
+
+func TestAgent_NUMAFabric_Add(t *testing.T) {
+	for name, tc := range map[string]struct {
+		nf        *NUMAFabric
+		input     *FabricInterface
+		node      int
+		expErr    error
+		expResult map[int][]*FabricInterface
+	}{
+		"nil": {
+			expErr: errors.New("nil NUMAFabric"),
+		},
+		"empty": {
+			nf:    newNUMAFabric(nil),
+			input: &FabricInterface{Name: "test1"},
+			node:  2,
+			expResult: map[int][]*FabricInterface{
+				2: {{Name: "test1"}},
+			},
+		},
+		"non-empty": {
+			nf: &NUMAFabric{
+				numaMap: map[int][]*FabricInterface{
+					2: {{Name: "t1"}},
+					3: {{Name: "t2"}, {Name: "t3"}},
+				},
+			},
+			input: &FabricInterface{Name: "test1"},
+			node:  2,
+			expResult: map[int][]*FabricInterface{
+				2: {{Name: "t1"}, {Name: "test1"}},
+				3: {{Name: "t2"}, {Name: "t3"}},
+			},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			log, buf := logging.NewTestLogger(t.Name())
+			defer common.ShowBufferOnFailure(t, buf)
+			if tc.nf != nil {
+				tc.nf.log = log
+			}
+
+			err := tc.nf.Add(tc.node, tc.input)
+
+			common.CmpErr(t, tc.expErr, err)
+
+			if tc.nf == nil {
+				return
+			}
+			if diff := cmp.Diff(tc.expResult, tc.nf.numaMap); diff != "" {
+				t.Fatalf("-want, +got:\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestAgent_NUMAFabric_GetDevice(t *testing.T) {
+	for name, tc := range map[string]struct {
+		nf          *NUMAFabric
+		node        int
+		netDevClass uint32
+		expErr      error
+		expResult   *FabricInterface
+	}{
+		"nil": {
+			expErr: errors.New("nil NUMAFabric"),
+		},
+		"empty": {
+			nf:        newNUMAFabric(nil),
+			expResult: DefaultFabricInterface,
+		},
+		"type not found": {
+			nf: &NUMAFabric{
+				numaMap: map[int][]*FabricInterface{
+					0: {
+						{
+							Name:        "t1",
+							NetDevClass: netdetect.Ether,
+						},
+						{
+							Name:        "t2",
+							NetDevClass: netdetect.Ether,
+						},
+						{
+							Name:        "t3",
+							NetDevClass: netdetect.Ether,
+						},
+					},
+				},
+			},
+			node:        0,
+			netDevClass: netdetect.Infiniband,
+			expErr:      errors.New("no suitable fabric interface"),
+		},
+		"choose first device": {
+			nf: &NUMAFabric{
+				numaMap: map[int][]*FabricInterface{
+					0: {
+						{
+							Name:        "t1",
+							NetDevClass: netdetect.Infiniband,
+						},
+					},
+				},
+			},
+			node:        0,
+			netDevClass: netdetect.Infiniband,
+			expResult: &FabricInterface{
+				Name:        "t1",
+				NetDevClass: netdetect.Infiniband,
+			},
+		},
+		"choose later device": {
+			nf: &NUMAFabric{
+				numaMap: map[int][]*FabricInterface{
+					0: {
+						{
+							Name:        "t1",
+							NetDevClass: netdetect.Ether,
+						},
+						{
+							Name:        "t2",
+							NetDevClass: netdetect.Infiniband,
+						},
+					},
+				},
+			},
+			node:        0,
+			netDevClass: netdetect.Infiniband,
+			expResult: &FabricInterface{
+				Name:        "t2",
+				NetDevClass: netdetect.Infiniband,
+			},
+		},
+		"nothing on NUMA node": {
+			nf: &NUMAFabric{
+				numaMap: map[int][]*FabricInterface{
+					0: {
+						{
+							Name:        "t1",
+							NetDevClass: netdetect.Infiniband,
+						},
+					},
+					1: {},
+				},
+			},
+			node:        1,
+			netDevClass: netdetect.Infiniband,
+			expResult: &FabricInterface{
+				Name:        "t1",
+				NetDevClass: netdetect.Infiniband,
+			},
+		},
+		"type not found on NUMA node": {
+			nf: &NUMAFabric{
+				numaMap: map[int][]*FabricInterface{
+					0: {
+						{
+							Name:        "t1",
+							NetDevClass: netdetect.Infiniband,
+						},
+					},
+					1: {
+						{
+							Name:        "t2",
+							NetDevClass: netdetect.Ether,
+						},
+					},
+				},
+			},
+			node:        1,
+			netDevClass: netdetect.Infiniband,
+			expResult: &FabricInterface{
+				Name:        "t1",
+				NetDevClass: netdetect.Infiniband,
+			},
+		},
+		"load balancing": {
+			nf: &NUMAFabric{
+				numaMap: map[int][]*FabricInterface{
+					0: {
+						{
+							Name:        "t1",
+							NetDevClass: netdetect.Ether,
+						},
+						{
+							Name:        "t2",
+							NetDevClass: netdetect.Ether,
+						},
+						{
+							Name:        "t3",
+							NetDevClass: netdetect.Ether,
+						},
+					},
+				},
+				currentNumaDevIdx: map[int]int{
+					0: 1,
+				},
+			},
+			node:        0,
+			netDevClass: netdetect.Ether,
+			expResult: &FabricInterface{
+				Name:        "t2",
+				NetDevClass: netdetect.Ether,
+			},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			log, buf := logging.NewTestLogger(t.Name())
+			defer common.ShowBufferOnFailure(t, buf)
+			if tc.nf != nil {
+				tc.nf.log = log
+			}
+
+			result, err := tc.nf.GetDevice(tc.node, tc.netDevClass)
+
+			common.CmpErr(t, tc.expErr, err)
+			if diff := cmp.Diff(tc.expResult, result); diff != "" {
+				t.Fatalf("-want, +got:\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestAgent_NUMAFabric_getNextDevice(t *testing.T) {
+	for name, tc := range map[string]struct {
+		nf         *NUMAFabric
+		node       int
+		expErr     error
+		expResult  *FabricInterface
+		expNodeIdx int
+	}{
+		"empty node": {
+			nf: &NUMAFabric{
+				numaMap: map[int][]*FabricInterface{
+					0: {},
+				},
+			},
+			node:   0,
+			expErr: errors.New("no fabric interfaces"),
+		},
+		"single item": {
+			nf: &NUMAFabric{
+				numaMap: map[int][]*FabricInterface{
+					0: {
+						{
+							Name:        "t1",
+							NetDevClass: netdetect.Ether,
+						},
+					},
+				},
+				currentNumaDevIdx: map[int]int{
+					0: 0,
+				},
+			},
+			expResult: &FabricInterface{
+				Name:        "t1",
+				NetDevClass: netdetect.Ether,
+			},
+		},
+		"multi item": {
+			nf: &NUMAFabric{
+				numaMap: map[int][]*FabricInterface{
+					0: {
+						{
+							Name:        "t1",
+							NetDevClass: netdetect.Ether,
+						},
+						{
+							Name:        "t2",
+							NetDevClass: netdetect.Ether,
+						},
+						{
+							Name:        "t3",
+							NetDevClass: netdetect.Ether,
+						},
+					},
+				},
+				currentNumaDevIdx: map[int]int{
+					0: 0,
+				},
+			},
+			expResult: &FabricInterface{
+				Name:        "t1",
+				NetDevClass: netdetect.Ether,
+			},
+			expNodeIdx: 1,
+		},
+		"round robin": {
+			nf: &NUMAFabric{
+				numaMap: map[int][]*FabricInterface{
+					0: {
+						{
+							Name:        "t1",
+							NetDevClass: netdetect.Ether,
+						},
+						{
+							Name:        "t2",
+							NetDevClass: netdetect.Ether,
+						},
+						{
+							Name:        "t3",
+							NetDevClass: netdetect.Ether,
+						},
+					},
+				},
+				currentNumaDevIdx: map[int]int{
+					0: 2,
+				},
+			},
+			expResult: &FabricInterface{
+				Name:        "t3",
+				NetDevClass: netdetect.Ether,
+			},
+			expNodeIdx: 0,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			result, err := tc.nf.getNextDevice(tc.node)
+
+			common.AssertEqual(t, tc.expNodeIdx, tc.nf.currentNumaDevIdx[tc.node], "")
+			common.CmpErr(t, tc.expErr, err)
+			if diff := cmp.Diff(tc.expResult, result); diff != "" {
+				t.Fatalf("-want, +got:\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestAgent_NUMAFabricFromScan(t *testing.T) {
+	for name, tc := range map[string]struct {
+		input               []*netdetect.FabricScan
+		getDevAlias         func(ctx context.Context, devName string) (string, error)
+		expResult           map[int][]*FabricInterface
+		possibleDefaultNUMA []int
+	}{
+		"no devices in scan": {
+			expResult:           map[int][]*FabricInterface{},
+			possibleDefaultNUMA: []int{0},
+		},
+		"skip lo": {
+			input: []*netdetect.FabricScan{
+				{
+					Provider:    "ofi+sockets",
+					DeviceName:  "test0",
+					NUMANode:    1,
+					NetDevClass: netdetect.Ether,
+				},
+				{
+					Provider:   "ofi+sockets",
+					DeviceName: "lo",
+					NUMANode:   1,
+				},
+			},
+			expResult: map[int][]*FabricInterface{
+				1: {
+					{
+						Name:        "test0",
+						NetDevClass: netdetect.Ether,
+					},
+				},
+			},
+			possibleDefaultNUMA: []int{1},
+		},
+		"multiple devices": {
+			input: []*netdetect.FabricScan{
+				{
+					Provider:    "ofi+sockets",
+					DeviceName:  "test0",
+					NUMANode:    1,
+					NetDevClass: netdetect.Ether,
+				},
+				{
+					Provider:    "ofi+verbs",
+					DeviceName:  "test1",
+					NUMANode:    0,
+					NetDevClass: netdetect.Infiniband,
+				},
+				{
+					Provider:    "ofi+sockets",
+					DeviceName:  "test2",
+					NUMANode:    0,
+					NetDevClass: netdetect.Ether,
+				},
+			},
+			expResult: map[int][]*FabricInterface{
+				0: {
+					{
+						Name:        "test1",
+						NetDevClass: netdetect.Infiniband,
+					},
+					{
+						Name:        "test2",
+						NetDevClass: netdetect.Ether,
+					},
+				},
+				1: {
+					{
+						Name:        "test0",
+						NetDevClass: netdetect.Ether,
+					},
+				},
+			},
+			possibleDefaultNUMA: []int{0, 1},
+		},
+		"with device alias": {
+			getDevAlias: func(_ context.Context, dev string) (string, error) {
+				return dev + "_alias", nil
+			},
+			input: []*netdetect.FabricScan{
+				{
+					Provider:    "ofi+sockets",
+					DeviceName:  "test0",
+					NUMANode:    2,
+					NetDevClass: netdetect.Ether,
+				},
+				{
+					Provider:    "ofi+verbs",
+					DeviceName:  "test1",
+					NUMANode:    1,
+					NetDevClass: netdetect.Infiniband,
+				},
+				{
+					Provider:    "ofi+sockets",
+					DeviceName:  "test2",
+					NUMANode:    1,
+					NetDevClass: netdetect.Ether,
+				},
+			},
+			expResult: map[int][]*FabricInterface{
+				1: {
+					{
+						Name:        "test1",
+						NetDevClass: netdetect.Infiniband,
+						Domain:      "test1_alias",
+					},
+					{
+						Name:        "test2",
+						NetDevClass: netdetect.Ether,
+						Domain:      "test2_alias",
+					},
+				},
+				2: {
+					{
+						Name:        "test0",
+						NetDevClass: netdetect.Ether,
+						Domain:      "test0_alias",
+					},
+				},
+			},
+			possibleDefaultNUMA: []int{1, 2},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			log, buf := logging.NewTestLogger(t.Name())
+			defer common.ShowBufferOnFailure(t, buf)
+
+			result := NUMAFabricFromScan(context.TODO(), log, tc.input, tc.getDevAlias)
+
+			if diff := cmp.Diff(tc.expResult, result.numaMap); diff != "" {
+				t.Fatalf("-want, +got:\n%s", diff)
+			}
+
+			defaultNumaOK := false
+			for _, numa := range tc.possibleDefaultNUMA {
+				if numa == result.defaultNumaNode {
+					defaultNumaOK = true
+				}
+			}
+
+			if !defaultNumaOK {
+				t.Fatalf("default NUMA node %d (expected in list: %+v)", result.defaultNumaNode, tc.possibleDefaultNUMA)
+			}
+		})
+	}
+}

--- a/src/control/cmd/daos_agent/infocache.go
+++ b/src/control/cmd/daos_agent/infocache.go
@@ -8,14 +8,11 @@ package main
 
 import (
 	"context"
-	"strings"
 	"sync"
 
 	"github.com/pkg/errors"
-	"google.golang.org/protobuf/proto"
 
 	mgmtpb "github.com/daos-stack/daos/src/control/common/proto/mgmt"
-	"github.com/daos-stack/daos/src/control/drpc"
 	"github.com/daos-stack/daos/src/control/lib/atm"
 	"github.com/daos-stack/daos/src/control/lib/netdetect"
 	"github.com/daos-stack/daos/src/control/logging"
@@ -28,189 +25,114 @@ const (
 	defaultDomain        = "lo"
 )
 
+func newAttachInfoCache(log logging.Logger, enabled bool) *attachInfoCache {
+	return &attachInfoCache{
+		log:     log,
+		enabled: atm.NewBool(enabled),
+	}
+}
+
 type attachInfoCache struct {
-	log logging.Logger
-	// is caching enabled?
-	enabled atm.Bool
-	// is the cache initialized?
+	mutex sync.Mutex
+
+	log         logging.Logger
+	enabled     atm.Bool
 	initialized atm.Bool
-	// maps NUMA affinity and device index to a response
-	numaDeviceMarshResp map[int]map[int][]byte
-	// maps NUMA affinity to a device index
-	currentNumaDevIdx map[int]int
-	mutex             sync.Mutex
-	// specifies what NUMA node to use when there are no devices
-	// associated with the client NUMA node
-	defaultNumaNode int
+
+	// cached response from remote server
+	AttachInfo *mgmtpb.GetAttachInfoResp
 }
 
-// loadBalance is a simple round-robin load balancing scheme
-// to assign network interface adapters to clients
-// on the same NUMA node that have multiple adapters
-// to choose from.  Returns the index of the device to use.
-func (aic *attachInfoCache) loadBalance(numaNode int) int {
-	aic.mutex.Lock()
-	deviceIndex := invalidIndex
-	numDevs := len(aic.numaDeviceMarshResp[numaNode])
-	if numDevs > 0 {
-		deviceIndex = aic.currentNumaDevIdx[numaNode]
-		aic.currentNumaDevIdx[numaNode] = (deviceIndex + 1) % numDevs
+// IsEnabled reports whether the cache is enabled.
+func (c *attachInfoCache) IsEnabled() bool {
+	if c == nil {
+		return false
 	}
-	aic.mutex.Unlock()
-	return deviceIndex
+
+	return c.enabled.IsTrue()
 }
 
-// selectRemote is called when no local network adapters
-// was detected on the local NUMA node and we need to pick
-// one attached to a remote NUMA node. Some balancing is
-// still required here to avoid overloading a specific interface
-func (aic *attachInfoCache) selectRemote() (int, int) {
-	aic.mutex.Lock()
-	defer aic.mutex.Unlock()
-
-	deviceIndex := invalidIndex
-	// restart from previous NUMA node
-	numaNode := aic.defaultNumaNode
-
-	if len(aic.numaDeviceMarshResp) == 0 {
-		aic.log.Infof("No network device available")
-		return numaNode, deviceIndex
+// IsCached reports whether there is data in the cache.
+func (c *attachInfoCache) IsCached() bool {
+	if c == nil {
+		return false
 	}
-
-	for i := 1; i <= len(aic.numaDeviceMarshResp); i++ {
-		node := (numaNode + i) % len(aic.numaDeviceMarshResp)
-		numDevs := len(aic.numaDeviceMarshResp[node])
-		if numDevs > 0 {
-			numaNode = node
-			deviceIndex = aic.currentNumaDevIdx[numaNode]
-			aic.currentNumaDevIdx[numaNode] = (deviceIndex + 1) % numDevs
-			break
-		}
-	}
-
-	// update the default with the one we finally picked
-	aic.defaultNumaNode = numaNode
-
-	return numaNode, deviceIndex
+	return c.enabled.IsTrue() && c.initialized.IsTrue()
 }
 
-func (aic *attachInfoCache) getResponse(numaNode int) ([]byte, error) {
-	deviceIndex := aic.loadBalance(numaNode)
-	// If there is no response available for the client's actual NUMA node,
-	// use the default NUMA node
-	if deviceIndex == invalidIndex {
-		var numaSel int
-
-		numaSel, deviceIndex = aic.selectRemote()
-		if deviceIndex == invalidIndex {
-			return nil, errors.Errorf("No fallback network device found")
-		}
-		aic.log.Infof("No network devices bound to client NUMA node %d.  Using response from NUMA %d", numaNode, numaSel)
-		numaNode = numaSel
+// Cache preserves the results of a GetAttachInfo remote call.
+func (c *attachInfoCache) Cache(ctx context.Context, resp *mgmtpb.GetAttachInfoResp) error {
+	if c == nil {
+		return errors.New("nil attachInfoCache")
 	}
 
-	aic.mutex.Lock()
-	defer aic.mutex.Unlock()
-	numaDeviceMarshResp, ok := aic.numaDeviceMarshResp[numaNode][deviceIndex]
-	if !ok {
-		return nil, errors.Errorf("GetAttachInfo entry for numaNode %d device index %d did not exist", numaNode, deviceIndex)
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	if !c.IsEnabled() {
+		return errors.New("cache is not enabled")
 	}
 
-	aic.log.Debugf("Retrieved response for NUMA %d with device index %d\n", numaNode, deviceIndex)
-	return numaDeviceMarshResp, nil
-}
-
-func (aic *attachInfoCache) isCached() bool {
-	return aic.enabled.IsTrue() && aic.initialized.IsTrue()
-}
-
-// initResponseCache generates a unique dRPC response corresponding to each device specified
-// in the scanResults.  The responses are differentiated based on the network device NUMA affinity.
-func (aic *attachInfoCache) initResponseCache(ctx context.Context, resp *mgmtpb.GetAttachInfoResp, scanResults []*netdetect.FabricScan) error {
-	aic.mutex.Lock()
-	defer aic.mutex.Unlock()
-
-	// Make a new map each time the cache is initialized
-	aic.numaDeviceMarshResp = make(map[int]map[int][]byte)
-
-	// Make a new map just once.
-	// Preserve any previous device index map in order to maintain ability to load balance
-	if len(aic.currentNumaDevIdx) == 0 {
-		aic.currentNumaDevIdx = make(map[int]int)
+	if resp == nil {
+		return errors.New("nil input")
 	}
 
-	var haveDefaultNuma bool
+	c.AttachInfo = resp
 
-	hint := resp.ClientNetHint
-	if hint == nil {
-		return errors.New("no client networking hint in response")
-	}
-	for _, fs := range scanResults {
-		if fs.DeviceName == "lo" {
-			continue
-		}
-
-		if fs.NetDevClass != hint.NetDevClass {
-			aic.log.Debugf("Excluding device: %s, network device class: %s from attachInfoCache.  Does not match server network device class: %s\n",
-				fs.DeviceName, netdetect.DevClassName(fs.NetDevClass), netdetect.DevClassName(hint.NetDevClass))
-			continue
-		}
-
-		hint.Interface = fs.DeviceName
-		// by default, the domain is the deviceName
-		hint.Domain = fs.DeviceName
-		if strings.HasPrefix(hint.Provider, verbsProvider) {
-			deviceAlias, err := netdetect.GetDeviceAlias(ctx, hint.Interface)
-			if err != nil {
-				aic.log.Debugf("non-fatal error: %v. unable to determine OFI_DOMAIN for %s", err, hint.Interface)
-			} else {
-				hint.Domain = deviceAlias
-				aic.log.Debugf("OFI_DOMAIN has been detected as: %s", hint.Domain)
-			}
-		}
-
-		numa := int(fs.NUMANode)
-
-		numaDeviceMarshResp, err := proto.Marshal(resp)
-		if err != nil {
-			return drpc.MarshalingFailure()
-		}
-
-		if _, ok := aic.numaDeviceMarshResp[numa]; !ok {
-			aic.numaDeviceMarshResp[numa] = make(map[int][]byte)
-		}
-		aic.numaDeviceMarshResp[numa][len(aic.numaDeviceMarshResp[numa])] = numaDeviceMarshResp
-
-		// Any client bound to a NUMA node that has no network devices associated with it will
-		// get a response from this defaultNumaNode.
-		// This response offers a valid network device at degraded performance for those clients
-		// that need it.
-		if !haveDefaultNuma {
-			aic.defaultNumaNode = numa
-			haveDefaultNuma = true
-			aic.log.Debugf("The default NUMA node is: %d", aic.defaultNumaNode)
-		}
-
-		aic.log.Debugf("Added device %s, domain %s for NUMA %d, device number %d\n", hint.Interface, hint.Domain, numa, len(aic.numaDeviceMarshResp[numa])-1)
-	}
-
-	// If there were no network devices found, then add a default response to the default NUMA node entry
-	if _, ok := aic.numaDeviceMarshResp[aic.defaultNumaNode]; !ok {
-		aic.log.Info("No network devices detected in fabric scan; default AttachInfo response may be incorrect\n")
-		aic.numaDeviceMarshResp[aic.defaultNumaNode] = make(map[int][]byte)
-		hint.Interface = defaultNetworkDevice
-		hint.Domain = defaultDomain
-		numaDeviceMarshResp, err := proto.Marshal(resp)
-		if err != nil {
-			return drpc.MarshalingFailure()
-		}
-		aic.numaDeviceMarshResp[aic.defaultNumaNode][0] = numaDeviceMarshResp
-	}
-
-	// If caching is enabled, the cache is now 'initialized'
-	if aic.enabled.IsTrue() {
-		aic.initialized.SetTrue()
-	}
-
+	c.initialized.SetTrue()
 	return nil
+}
+
+func newLocalFabricCache(log logging.Logger) *localFabricCache {
+	return &localFabricCache{
+		log:             log,
+		localNUMAFabric: newNUMAFabric(log),
+	}
+}
+
+type localFabricCache struct {
+	sync.Mutex // Caller should lock and unlock around cache operations
+
+	log         logging.Logger
+	initialized atm.Bool
+	// cached fabric interfaces organized by NUMA affinity
+	localNUMAFabric *NUMAFabric
+
+	getDevAlias func(ctx context.Context, devName string) (string, error)
+}
+
+// IsCached reports whether there is data in the cache.
+func (c *localFabricCache) IsCached() bool {
+	if c == nil {
+		return false
+	}
+
+	return c.initialized.IsTrue()
+}
+
+// Cache caches the results of a fabric scan locally.
+func (c *localFabricCache) Cache(ctx context.Context, scan []*netdetect.FabricScan) error {
+	if c == nil {
+		return errors.New("nil localFabricCache")
+	}
+
+	if c.getDevAlias == nil {
+		c.getDevAlias = netdetect.GetDeviceAlias
+	}
+
+	c.localNUMAFabric = NUMAFabricFromScan(ctx, c.log, scan, c.getDevAlias)
+
+	c.initialized.SetTrue()
+	return nil
+}
+
+// GetDevices fetches an appropriate fabric device from the cache.
+func (c *localFabricCache) GetDevice(numaNode int, netDevClass uint32) (*FabricInterface, error) {
+	if c == nil {
+		return nil, errors.New("nil localFabricCache")
+	}
+	if !c.IsCached() {
+		return nil, errors.New("not cached")
+	}
+	return c.localNUMAFabric.GetDevice(numaNode, netDevClass)
 }

--- a/src/control/cmd/daos_agent/infocache_test.go
+++ b/src/control/cmd/daos_agent/infocache_test.go
@@ -8,14 +8,10 @@ package main
 
 import (
 	"context"
-	"fmt"
-	"math/rand"
-	"strings"
-	"sync"
 	"testing"
-	"time"
 
-	"google.golang.org/protobuf/proto"
+	"github.com/google/go-cmp/cmp"
+	"github.com/pkg/errors"
 
 	"github.com/daos-stack/daos/src/control/common"
 	mgmtpb "github.com/daos-stack/daos/src/control/common/proto/mgmt"
@@ -24,467 +20,365 @@ import (
 	"github.com/daos-stack/daos/src/control/logging"
 )
 
-const maxConcurrent = 100
-
-type netdetectCleanup func(context.Context)
-
-func initCache(t *testing.T, scanResults []*netdetect.FabricScan, aiCache *attachInfoCache) (context.Context, netdetectCleanup) {
-	netCtx, err := netdetect.Init(context.Background())
-	if err != nil {
-		t.Fatalf("failed to init netdetect context: %v", err)
-	}
-	resp := &mgmtpb.GetAttachInfoResp{
-		ClientNetHint: &mgmtpb.ClientNetHint{},
-	}
-	err = aiCache.initResponseCache(netCtx, resp, scanResults)
-	if err != nil {
-		t.Fatalf("initResponseCache error: %v", err)
-	}
-	return netCtx, netdetect.CleanUp
-}
-
-func TestInfoCacheInitNoScanResults(t *testing.T) {
-	log, buf := logging.NewTestLogger(t.Name())
-	defer common.ShowBufferOnFailure(t, buf)
-	enabled := atm.NewBool(true)
-	scanResults := []*netdetect.FabricScan{}
-	aiCache := attachInfoCache{log: log, enabled: enabled}
-
-	netCtx, cleanupFn := initCache(t, scanResults, &aiCache)
-	defer cleanupFn(netCtx)
-
-	common.AssertTrue(t, aiCache.isCached() == true, "initResponseCache failed to initialized")
-
+func TestAgent_newAttachInfoCache(t *testing.T) {
 	for name, tc := range map[string]struct {
-		numaNode   int
-		deviceName string
+		enabled bool
 	}{
-		"info cache response for numa 0": {
-			numaNode:   0,
-			deviceName: "eth0",
+		"enabled": {
+			enabled: true,
 		},
-		"info cache response for numa 1": {
-			numaNode:   1,
-			deviceName: "eth1",
-		},
-		"info cache response for numa 2": {
-			numaNode:   2,
-			deviceName: "eth2",
+		"disabled": {
+			enabled: false,
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			var res []byte
-			var err error
-			if aiCache.isCached() {
-				res, err = aiCache.getResponse(tc.numaNode)
-				common.AssertEqual(t, err, nil, "getResponse error")
+			log, buf := logging.NewTestLogger(t.Name())
+			defer common.ShowBufferOnFailure(t, buf)
+
+			cache := newAttachInfoCache(log, tc.enabled)
+
+			if cache == nil {
+				t.Fatal("expected non-nil cache")
 			}
-			resp := &mgmtpb.GetAttachInfoResp{}
-			if err = proto.Unmarshal(res, resp); err != nil {
-				t.Errorf("Expected error on proto.Unmarshal, got %+v", err)
+
+			common.AssertEqual(t, log, cache.log, "")
+			common.AssertEqual(t, tc.enabled, cache.IsEnabled(), "IsEnabled()")
+			common.AssertFalse(t, cache.IsCached(), "default state is uncached")
+			if cache.AttachInfo != nil {
+				t.Fatalf("initial data should be nil, got %+v", cache.AttachInfo)
 			}
-			hint := resp.GetClientNetHint()
-			common.AssertTrue(t, hint.GetInterface() == defaultNetworkDevice, fmt.Sprintf("Expected default interface: %s, got %s", defaultNetworkDevice, hint.GetInterface()))
-			common.AssertTrue(t, hint.GetDomain() == defaultDomain, fmt.Sprintf("Expected default domain: %s, got %s", defaultDomain, hint.GetDomain()))
 		})
 	}
 }
 
-func TestInfoCacheInit(t *testing.T) {
-	log, buf := logging.NewTestLogger(t.Name())
-	defer common.ShowBufferOnFailure(t, buf)
-	enabled := atm.NewBool(true)
-	scanResults := []*netdetect.FabricScan{
-		{Provider: "ofi+sockets", DeviceName: "eth0_node0", NUMANode: 0},
-		{Provider: "ofi+sockets", DeviceName: "eth1_node0", NUMANode: 0},
-		{Provider: "ofi+sockets", DeviceName: "eth2_node0", NUMANode: 0},
-		{Provider: "ofi+sockets", DeviceName: "eth3_node0", NUMANode: 0},
-		{Provider: "ofi+sockets", DeviceName: "eth0_node1", NUMANode: 1},
-		{Provider: "ofi+sockets", DeviceName: "eth1_node1", NUMANode: 1},
-		{Provider: "ofi+sockets", DeviceName: "eth0_node2", NUMANode: 2},
-		{Provider: "ofi+sockets", DeviceName: "eth1_node2", NUMANode: 2},
-		{Provider: "ofi+sockets", DeviceName: "eth2_node2", NUMANode: 2},
-		{Provider: "ofi+sockets", DeviceName: "eth3_node2", NUMANode: 2}}
-
-	aiCache := attachInfoCache{log: log, enabled: enabled}
-
-	netCtx, cleanupFn := initCache(t, scanResults, &aiCache)
-	defer cleanupFn(netCtx)
-
+func TestAgent_attachInfoCache_Cache(t *testing.T) {
 	for name, tc := range map[string]struct {
-		numaNode int
-		numDevs  int
+		aic       *attachInfoCache
+		input     *mgmtpb.GetAttachInfoResp
+		expErr    error
+		expCached bool
 	}{
-		"info cache response for numa 0": {
-			numaNode: 0,
-			numDevs:  4,
+		"nil cache": {
+			expErr: errors.New("nil attachInfoCache"),
 		},
-		"info cache response for numa 1": {
-			numaNode: 1,
-			numDevs:  2,
+		"not enabled": {
+			aic:    &attachInfoCache{},
+			expErr: errors.New("not enabled"),
 		},
-		"info cache response for numa 2": {
-			numaNode: 2,
-			numDevs:  4,
+		"nil input": {
+			aic:    &attachInfoCache{enabled: atm.NewBool(true)},
+			expErr: errors.New("nil input"),
 		},
-	} {
-		t.Run(name, func(t *testing.T) {
-
-			numDevs := len(aiCache.numaDeviceMarshResp[tc.numaNode])
-			common.AssertEqual(t, numDevs, tc.numDevs,
-				fmt.Sprintf("initResponseCache error - expected %d cached responses, got %d", tc.numDevs, numDevs))
-		})
-	}
-}
-
-func TestInfoCacheInitWithDeviceFiltering(t *testing.T) {
-	log, buf := logging.NewTestLogger(t.Name())
-	defer common.ShowBufferOnFailure(t, buf)
-	enabled := atm.NewBool(true)
-
-	scanResults := []*netdetect.FabricScan{
-		{Provider: "ofi+sockets", DeviceName: "eth0_node0", NUMANode: 0, NetDevClass: netdetect.Ether},
-		{Provider: "ofi+sockets", DeviceName: "eth1_node0", NUMANode: 0, NetDevClass: netdetect.Ether},
-		{Provider: "ofi+sockets", DeviceName: "eth2_node0", NUMANode: 0, NetDevClass: netdetect.Ether},
-		{Provider: "ofi+sockets", DeviceName: "ib0_node0", NUMANode: 0, NetDevClass: netdetect.Infiniband},
-		{Provider: "ofi+sockets", DeviceName: "eth0_node1", NUMANode: 1, NetDevClass: netdetect.Ether},
-		{Provider: "ofi+sockets", DeviceName: "ib1_node1", NUMANode: 1, NetDevClass: netdetect.Infiniband},
-		{Provider: "ofi+sockets", DeviceName: "eth0_node2", NUMANode: 2, NetDevClass: netdetect.Ether},
-		{Provider: "ofi+sockets", DeviceName: "eth1_node2", NUMANode: 2, NetDevClass: netdetect.Ether},
-		{Provider: "ofi+sockets", DeviceName: "eth2_node2", NUMANode: 2, NetDevClass: netdetect.Ether},
-		{Provider: "ofi+sockets", DeviceName: "eth3_node2", NUMANode: 2, NetDevClass: netdetect.Ether}}
-
-	aiCache := attachInfoCache{log: log, enabled: enabled}
-
-	netCtx, cleanupFn := initCache(t, scanResults, &aiCache)
-	defer cleanupFn(netCtx)
-
-	for name, tc := range map[string]struct {
-		numaNode          int
-		numDevs           int
-		serverNetDevClass uint32
-	}{
-		"info cache device with filtering for Ethernet with numa 0": {
-			numaNode:          0,
-			numDevs:           3,
-			serverNetDevClass: netdetect.Ether,
-		},
-		"info cache device with filtering for Ethernet with numa 1": {
-			numaNode:          1,
-			numDevs:           1,
-			serverNetDevClass: netdetect.Ether,
-		},
-		"info cache device with filtering for Ethernet with numa 2": {
-			numaNode:          2,
-			numDevs:           4,
-			serverNetDevClass: netdetect.Ether,
-		},
-		"info cache device with filtering for Infiniband with numa 0": {
-			numaNode:          0,
-			numDevs:           1,
-			serverNetDevClass: netdetect.Infiniband,
-		},
-		"info cache device with filtering for Infiniband with numa 1": {
-			numaNode:          1,
-			numDevs:           1,
-			serverNetDevClass: netdetect.Infiniband,
-		},
-		"info cache device with filtering for Infiniband with numa 2": {
-			numaNode:          2,
-			numDevs:           0,
-			serverNetDevClass: netdetect.Infiniband,
-		},
-	} {
-		t.Run(name, func(t *testing.T) {
-			resp := &mgmtpb.GetAttachInfoResp{
-				ClientNetHint: &mgmtpb.ClientNetHint{
-					NetDevClass: tc.serverNetDevClass,
+		"success": {
+			aic: &attachInfoCache{enabled: atm.NewBool(true)},
+			input: &mgmtpb.GetAttachInfoResp{
+				Status: -1000,
+				RankUris: []*mgmtpb.GetAttachInfoResp_RankUri{
+					{Rank: 1, Uri: "firsturi"},
+					{Rank: 2, Uri: "nexturi"},
 				},
-			}
-			err := aiCache.initResponseCache(netCtx, resp, scanResults)
-			common.AssertEqual(t, err, nil, "initResponseCache error")
+			},
+			expCached: true,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			err := tc.aic.Cache(context.TODO(), tc.input)
 
-			numDevs := len(aiCache.numaDeviceMarshResp[tc.numaNode])
-			common.AssertEqual(t, numDevs, tc.numDevs,
-				fmt.Sprintf("initResponseCache error - expected %d cached responses, got %d", tc.numDevs, numDevs))
+			common.CmpErr(t, tc.expErr, err)
+			common.AssertEqual(t, tc.expCached, tc.aic.IsCached(), "IsCached()")
+
+			if tc.aic == nil {
+				return
+			}
+
+			if diff := cmp.Diff(tc.input, tc.aic.AttachInfo, common.DefaultCmpOpts()...); diff != "" {
+				t.Fatalf("-want, +got:\n%s", diff)
+			}
 		})
 	}
 }
 
-// TestInfoCacheGetResponse reads an entry from the cache for the specified NUMA node
-// and verifies that it got the exact response that was expected.
-func TestInfoCacheGetResponse(t *testing.T) {
-	log, buf := logging.NewTestLogger(t.Name())
-	defer common.ShowBufferOnFailure(t, buf)
-	enabled := atm.NewBool(true)
-	scanResults := []*netdetect.FabricScan{
-		{Provider: "ofi+sockets", DeviceName: "eth0", NUMANode: 0},
-		{Provider: "ofi+sockets", DeviceName: "eth1", NUMANode: 1},
-		{Provider: "ofi+sockets", DeviceName: "eth2", NUMANode: 2}}
-
-	aiCache := attachInfoCache{log: log, enabled: enabled}
-
-	netCtx, cleanupFn := initCache(t, scanResults, &aiCache)
-	defer cleanupFn(netCtx)
-
-	devList := func(devs ...string) []string {
-		return devs
-	}
-
+func TestAgent_attachInfoCache_IsEnabled(t *testing.T) {
 	for name, tc := range map[string]struct {
-		numaNode       int
-		allowedDevices []string
+		aic        *attachInfoCache
+		expEnabled bool
 	}{
-		"info cache response for numa 0": {
-			numaNode:       0,
-			allowedDevices: devList("eth0"),
+		"nil": {},
+		"not enabled": {
+			aic: &attachInfoCache{},
 		},
-		"info cache response for numa 1": {
-			numaNode:       1,
-			allowedDevices: devList("eth1"),
-		},
-		"info cache response for numa 2": {
-			numaNode:       2,
-			allowedDevices: devList("eth2"),
-		},
-		"info cache response one for numa 3 with no devices": {
-			numaNode:       3,
-			allowedDevices: devList("eth0", "eth1", "eth2"),
-		},
-		"info cache response two for numa 3 with no devices": {
-			numaNode:       3,
-			allowedDevices: devList("eth0", "eth1", "eth2"),
-		},
-		"info cache response three for numa 3 with no devices": {
-			numaNode:       3,
-			allowedDevices: devList("eth0", "eth1", "eth2"),
+		"enabled": {
+			aic:        &attachInfoCache{enabled: atm.NewBool(true)},
+			expEnabled: true,
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			res, err := aiCache.getResponse(tc.numaNode)
-			common.AssertEqual(t, err, nil, "getResponse error")
+			enabled := tc.aic.IsEnabled()
 
-			resp := &mgmtpb.GetAttachInfoResp{}
-			if err = proto.Unmarshal(res, resp); err != nil {
-				t.Errorf("Expected error on proto.Unmarshal, got %+v", err)
+			common.AssertEqual(t, tc.expEnabled, enabled, "IsEnabled()")
+		})
+	}
+}
+
+func TestAgent_newLocalFabricCache(t *testing.T) {
+	log, buf := logging.NewTestLogger(t.Name())
+	defer common.ShowBufferOnFailure(t, buf)
+
+	cache := newLocalFabricCache(log)
+
+	if cache == nil {
+		t.Fatal("expected non-nil cache")
+	}
+
+	common.AssertEqual(t, log, cache.log, "")
+	common.AssertFalse(t, cache.IsCached(), "default state is uncached")
+}
+
+func newTestFabricCache(t *testing.T, log logging.Logger, cacheMap *NUMAFabric) *localFabricCache {
+	t.Helper()
+
+	cache := newLocalFabricCache(log)
+	if cache == nil {
+		t.Fatalf("nil cache")
+	}
+	cache.localNUMAFabric = cacheMap
+	cache.initialized.SetTrue()
+
+	return cache
+}
+
+func TestAgent_localFabricCache_Cache(t *testing.T) {
+	for name, tc := range map[string]struct {
+		lfc       *localFabricCache
+		input     []*netdetect.FabricScan
+		expErr    error
+		expCached bool
+		expResult *NUMAFabric
+	}{
+		"nil": {
+			expErr: errors.New("nil localFabricCache"),
+		},
+		"no devices in scan": {
+			lfc:       &localFabricCache{},
+			expCached: true,
+			expResult: &NUMAFabric{
+				numaMap: map[int][]*FabricInterface{},
+			},
+		},
+		"successfully cached": {
+			lfc: &localFabricCache{},
+			input: []*netdetect.FabricScan{
+				{
+					Provider:    "ofi+sockets",
+					DeviceName:  "test0",
+					NUMANode:    1,
+					NetDevClass: netdetect.Ether,
+				},
+				{
+					Provider:   "ofi+sockets",
+					DeviceName: "lo",
+					NUMANode:   1,
+				},
+				{
+					Provider:    "ofi+verbs",
+					DeviceName:  "test1",
+					NUMANode:    0,
+					NetDevClass: netdetect.Infiniband,
+				},
+				{
+					Provider:    "ofi+sockets",
+					DeviceName:  "test2",
+					NUMANode:    0,
+					NetDevClass: netdetect.Ether,
+				},
+			},
+			expCached: true,
+			expResult: &NUMAFabric{
+				numaMap: map[int][]*FabricInterface{
+					0: {
+						{
+							Name:        "test1",
+							NetDevClass: netdetect.Infiniband,
+						},
+						{
+							Name:        "test2",
+							NetDevClass: netdetect.Ether,
+						},
+					},
+					1: {
+						{
+							Name:        "test0",
+							NetDevClass: netdetect.Ether,
+						},
+					},
+				},
+			},
+		},
+		"with device alias": {
+			lfc: &localFabricCache{
+				getDevAlias: func(_ context.Context, dev string) (string, error) {
+					return dev + "_alias", nil
+				},
+			},
+			input: []*netdetect.FabricScan{
+				{
+					Provider:    "ofi+sockets",
+					DeviceName:  "test0",
+					NUMANode:    2,
+					NetDevClass: netdetect.Ether,
+				},
+				{
+					Provider:    "ofi+verbs",
+					DeviceName:  "test1",
+					NUMANode:    1,
+					NetDevClass: netdetect.Infiniband,
+				},
+				{
+					Provider:    "ofi+sockets",
+					DeviceName:  "test2",
+					NUMANode:    1,
+					NetDevClass: netdetect.Ether,
+				},
+			},
+			expCached: true,
+			expResult: &NUMAFabric{
+				numaMap: map[int][]*FabricInterface{
+					1: {
+						{
+							Name:        "test1",
+							NetDevClass: netdetect.Infiniband,
+							Domain:      "test1_alias",
+						},
+						{
+							Name:        "test2",
+							NetDevClass: netdetect.Ether,
+							Domain:      "test2_alias",
+						},
+					},
+					2: {
+						{
+							Name:        "test0",
+							NetDevClass: netdetect.Ether,
+							Domain:      "test0_alias",
+						},
+					},
+				},
+			},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			log, buf := logging.NewTestLogger(t.Name())
+			defer common.ShowBufferOnFailure(t, buf)
+
+			if tc.lfc != nil {
+				tc.lfc.log = log
 			}
-			hint := resp.GetClientNetHint()
 
-			for _, dev := range tc.allowedDevices {
-				if hint.GetInterface() == dev {
-					return
+			err := tc.lfc.Cache(context.TODO(), tc.input)
+
+			common.CmpErr(t, tc.expErr, err)
+			common.AssertEqual(t, tc.expCached, tc.lfc.IsCached(), "IsCached()")
+
+			if tc.lfc == nil {
+				return
+			}
+
+			if diff := cmp.Diff(tc.expResult.numaMap, tc.lfc.localNUMAFabric.numaMap); diff != "" {
+				t.Fatalf("-want, +got:\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestAgent_localFabricCache_GetDevice(t *testing.T) {
+	populatedCache := &NUMAFabric{
+		numaMap: map[int][]*FabricInterface{
+			0: {
+				{
+					Name:        "test1",
+					NetDevClass: netdetect.Infiniband,
+					Domain:      "test1_alias",
+				},
+				{
+					Name:        "test2",
+					NetDevClass: netdetect.Ether,
+					Domain:      "test2_alias",
+				},
+			},
+			1: {
+				{
+					Name:        "test3",
+					NetDevClass: netdetect.Infiniband,
+					Domain:      "test3_alias",
+				},
+				{
+					Name:        "test4",
+					NetDevClass: netdetect.Infiniband,
+					Domain:      "test4_alias",
+				},
+				{
+					Name:        "test5",
+					NetDevClass: netdetect.Ether,
+					Domain:      "test5_alias",
+				},
+			},
+			2: {
+				{
+					Name:        "test6",
+					NetDevClass: netdetect.Ether,
+					Domain:      "test6_alias",
+				},
+				{
+					Name:        "test7",
+					NetDevClass: netdetect.Ether,
+					Domain:      "test7_alias",
+				},
+			},
+		},
+	}
+
+	for name, tc := range map[string]struct {
+		lfc         *localFabricCache
+		numaNode    int
+		netDevClass uint32
+		expDevice   *FabricInterface
+		expErr      error
+	}{
+		"nil cache": {
+			expErr: errors.New("nil localFabricCache"),
+		},
+		"nothing cached": {
+			lfc:    &localFabricCache{},
+			expErr: errors.New("not cached"),
+		},
+		"success": {
+			lfc:         newTestFabricCache(t, nil, populatedCache),
+			numaNode:    1,
+			netDevClass: netdetect.Ether,
+			expDevice: &FabricInterface{
+				Name:        "test5",
+				NetDevClass: netdetect.Ether,
+				Domain:      "test5_alias",
+			},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			log, buf := logging.NewTestLogger(t.Name())
+			defer common.ShowBufferOnFailure(t, buf)
+
+			if tc.lfc != nil {
+				tc.lfc.log = log
+				if tc.lfc.localNUMAFabric != nil {
+					tc.lfc.localNUMAFabric.log = log
 				}
 			}
-			t.Fatalf("response device %s was not in list of allowed devices (%+v)", hint.GetInterface(), tc.allowedDevices)
-		})
-	}
-}
 
-// TestInfoCacheDefaultNumaNode reads an entry from the cache for the specified NUMA node
-// and verifies the default response does not depend specifically on NUMA 0.
-func TestInfoCacheDefaultNumaNode(t *testing.T) {
-	log, buf := logging.NewTestLogger(t.Name())
-	defer common.ShowBufferOnFailure(t, buf)
-	enabled := atm.NewBool(true)
-	scanResults := []*netdetect.FabricScan{
-		{Provider: "ofi+sockets", DeviceName: "eth1", NUMANode: 1},
-		{Provider: "ofi+sockets", DeviceName: "eth2", NUMANode: 2}}
+			dev, err := tc.lfc.GetDevice(tc.numaNode, tc.netDevClass)
 
-	aiCache := attachInfoCache{log: log, enabled: enabled}
-
-	netCtx, cleanupFn := initCache(t, scanResults, &aiCache)
-	defer cleanupFn(netCtx)
-
-	for name, tc := range map[string]struct {
-		numaNode   int
-		deviceName string
-	}{
-		"info cache response for numa 0 with no devices": {
-			numaNode:   0,
-			deviceName: "eth1",
-		},
-		"info cache response for numa 1": {
-			numaNode:   1,
-			deviceName: "eth1",
-		},
-		"info cache response for numa 2": {
-			numaNode:   2,
-			deviceName: "eth2",
-		},
-		"info cache response for numa 3 with no devices": {
-			numaNode:   3,
-			deviceName: "eth1",
-		},
-	} {
-		t.Run(name, func(t *testing.T) {
-			res, err := aiCache.getResponse(tc.numaNode)
-			common.AssertEqual(t, err, nil, "getResponse error")
-
-			resp := &mgmtpb.GetAttachInfoResp{}
-			if err = proto.Unmarshal(res, resp); err != nil {
-				t.Errorf("Expected error on proto.Unmarshal, got %+v", err)
+			common.CmpErr(t, tc.expErr, err)
+			if diff := cmp.Diff(tc.expDevice, dev); diff != "" {
+				t.Fatalf("-want, +got:\n%s", diff)
 			}
-			hint := resp.GetClientNetHint()
-			common.AssertTrue(t, hint.GetInterface() == tc.deviceName, fmt.Sprintf("Expected: %s, got %s", tc.deviceName, hint.GetInterface()))
 		})
 	}
-}
-
-// TestInfoCacheLoadBalancer verifies that the load balancer provided the desired response.
-// This test initializes the info cache with multiple devices per NUMA node and a predictable
-// set of data for the cache.  The load balancer is expected to assign each cached response
-// per NUMA node in linear order.
-func TestInfoCacheLoadBalancer(t *testing.T) {
-	log, buf := logging.NewTestLogger(t.Name())
-	defer common.ShowBufferOnFailure(t, buf)
-	enabled := atm.NewBool(true)
-	scanResults := []*netdetect.FabricScan{
-		{Provider: "ofi+sockets", DeviceName: "eth0_node0", NUMANode: 0},
-		{Provider: "ofi+sockets", DeviceName: "eth1_node0", NUMANode: 0},
-		{Provider: "ofi+sockets", DeviceName: "eth2_node0", NUMANode: 0},
-		{Provider: "ofi+sockets", DeviceName: "eth3_node0", NUMANode: 0},
-		{Provider: "ofi+sockets", DeviceName: "eth0_node1", NUMANode: 1},
-		{Provider: "ofi+sockets", DeviceName: "eth1_node1", NUMANode: 1},
-		{Provider: "ofi+sockets", DeviceName: "eth1_node2", NUMANode: 1},
-		{Provider: "ofi+sockets", DeviceName: "eth0_node2", NUMANode: 2},
-		{Provider: "ofi+sockets", DeviceName: "eth1_node2", NUMANode: 2},
-		{Provider: "ofi+sockets", DeviceName: "eth0_node3", NUMANode: 3},
-		{Provider: "ofi+sockets", DeviceName: "eth0_node7", NUMANode: 7},
-		{Provider: "ofi+sockets", DeviceName: "eth1_node7", NUMANode: 7},
-		{Provider: "ofi+sockets", DeviceName: "eth2_node7", NUMANode: 7},
-		{Provider: "ofi+sockets", DeviceName: "eth3_node7", NUMANode: 7},
-		{Provider: "ofi+sockets", DeviceName: "eth4_node7", NUMANode: 7},
-	}
-
-	aiCache := attachInfoCache{log: log, enabled: enabled}
-
-	netCtx, cleanupFn := initCache(t, scanResults, &aiCache)
-	defer cleanupFn(netCtx)
-
-	var results map[int][]byte
-	var response map[int]*mgmtpb.GetAttachInfoResp
-	results = make(map[int][]byte)
-	response = make(map[int]*mgmtpb.GetAttachInfoResp)
-
-	for name, tc := range map[string]struct {
-		numaNode   int
-		numDevices int
-		deviceName string
-		neighbor   string
-	}{
-		"load balancer infocache entry numa 0 with 4 devices": {
-			numaNode:   0,
-			numDevices: 4,
-			deviceName: "eth0_node0",
-			neighbor:   "eth1_node0",
-		},
-		"load balancer infocache entry numa 1 with 3 devices": {
-			numaNode:   1,
-			numDevices: 3,
-			deviceName: "eth0_node1",
-			neighbor:   "eth1_node1",
-		},
-		"load balancer infocache entry numa 2 with 2 devices": {
-			numaNode:   2,
-			numDevices: 2,
-			deviceName: "eth0_node2",
-			neighbor:   "eth1_node2",
-		},
-		"load balancer infocache entry numa 3 with 1 device": {
-			numaNode:   3,
-			numDevices: 1,
-			deviceName: "eth0_node3",
-			neighbor:   "eth0_node3",
-		},
-		// This entry shows that numa nodes entries need not be contiguous
-		"load balancer infocache entry numa 7 with 5 devices": {
-			numaNode:   7,
-			numDevices: 5,
-			deviceName: "eth0_node7",
-			neighbor:   "eth1_node7",
-		},
-	} {
-		t.Run(name, func(t *testing.T) {
-			for i := 0; i < tc.numDevices+2; i++ {
-				var err error
-				results[i], err = aiCache.getResponse(tc.numaNode)
-				common.AssertEqual(t, err, nil, "getResponse error")
-				response[i] = &mgmtpb.GetAttachInfoResp{}
-				if err = proto.Unmarshal(results[i], response[i]); err != nil {
-					t.Errorf("Expected error on proto.Unmarshal, got %+v", err)
-				}
-			}
-
-			// verifies that the load balancer rolled back to the beginning of the list
-			common.AssertTrue(t, response[0].GetClientNetHint().GetInterface() == response[tc.numDevices].GetClientNetHint().GetInterface(),
-				fmt.Sprintf("expected: %s, got %s", response[0].GetClientNetHint().GetInterface(), response[tc.numDevices].GetClientNetHint().GetInterface()))
-
-			// verifies that the device name is exactly the one expected
-			common.AssertTrue(t, response[0].GetClientNetHint().GetInterface() == tc.deviceName,
-				fmt.Sprintf("expected: %s, got %s", tc.deviceName, response[0].GetClientNetHint().GetInterface()))
-
-			// verifies that the neighbor response is what was expected
-			common.AssertTrue(t, response[tc.numDevices+1].GetClientNetHint().GetInterface() == tc.neighbor,
-				fmt.Sprintf("expected: %s, got %s", tc.neighbor, response[tc.numDevices+1].GetClientNetHint().GetInterface()))
-		})
-	}
-}
-
-// getResponse is called as a concurrent routine to access the info cache.
-// The cache contains responses with interface names specific to each NUMA node.
-// Aside from actually generating a failure due to a race condition, the response
-// data is checked to make sure it contains a device known to be associated with the
-// given numa node.
-func getResponse(t *testing.T, aiCache *attachInfoCache, numaNode int, wg *sync.WaitGroup) {
-	defer wg.Done()
-	res, err := aiCache.getResponse(numaNode)
-	common.AssertEqual(t, err, nil, "TestInfoCacheConcurrentAccess getResponse error")
-
-	resp := &mgmtpb.GetAttachInfoResp{}
-	if err = proto.Unmarshal(res, resp); err != nil {
-		t.Errorf("Expected error on proto.Unmarshal, got %+v", err)
-	}
-
-	deviceName := fmt.Sprintf("_node%d", numaNode)
-	hint := resp.GetClientNetHint()
-	if !strings.HasSuffix(hint.GetInterface(), deviceName) {
-		t.Errorf("TestInfoCacheConcurrentAccess response mismatch.  Devicename: %s, does not have suffix: %s", hint.GetInterface(), deviceName)
-	}
-}
-
-// TestInfoCacheConcurrentAccess launches maxConcurrent go routines
-// that concurrently access the info cache.  This test verifies that there are
-// no race conditions accessing the shared cache.
-func TestInfoCacheConcurrentAccess(t *testing.T) {
-	log, buf := logging.NewTestLogger(t.Name())
-	defer common.ShowBufferOnFailure(t, buf)
-	enabled := atm.NewBool(true)
-	scanResults := []*netdetect.FabricScan{
-		{Provider: "ofi+sockets", DeviceName: "eth0_node0", NUMANode: 0, Priority: 0},
-		{Provider: "ofi+sockets", DeviceName: "eth1_node0", NUMANode: 0, Priority: 1},
-		{Provider: "ofi+sockets", DeviceName: "eth2_node0", NUMANode: 0, Priority: 2},
-		{Provider: "ofi+sockets", DeviceName: "eth3_node0", NUMANode: 0, Priority: 3},
-		{Provider: "ofi+sockets", DeviceName: "eth0_node1", NUMANode: 1, Priority: 0},
-		{Provider: "ofi+sockets", DeviceName: "eth1_node1", NUMANode: 1, Priority: 1},
-		{Provider: "ofi+sockets", DeviceName: "eth0_node2", NUMANode: 2, Priority: 0},
-		{Provider: "ofi+sockets", DeviceName: "eth1_node2", NUMANode: 2, Priority: 1},
-		{Provider: "ofi+sockets", DeviceName: "eth2_node2", NUMANode: 2, Priority: 2},
-		{Provider: "ofi+sockets", DeviceName: "eth3_node2", NUMANode: 2, Priority: 3}}
-
-	aiCache := attachInfoCache{log: log, enabled: enabled}
-
-	netCtx, cleanupFn := initCache(t, scanResults, &aiCache)
-	defer cleanupFn(netCtx)
-
-	var wg sync.WaitGroup
-	maxNumaNodes := 3
-	rand.Seed(time.Now().UnixNano())
-	for i := 0; i < maxConcurrent; i++ {
-		wg.Add(1)
-		go func(n int) {
-			time.Sleep(time.Duration(rand.Intn(100)) * time.Microsecond)
-			getResponse(t, &aiCache, n, &wg)
-		}(i % maxNumaNodes)
-	}
-	wg.Wait()
 }

--- a/src/control/cmd/daos_agent/mgmt_rpc.go
+++ b/src/control/cmd/daos_agent/mgmt_rpc.go
@@ -8,6 +8,7 @@ package main
 
 import (
 	"net"
+	"strings"
 	"sync"
 
 	"github.com/pkg/errors"
@@ -27,14 +28,15 @@ import (
 // Management Service proxy, handling dRPCs sent by libdaos by forwarding them
 // to MS.
 type mgmtModule struct {
-	log        logging.Logger
-	sys        string
-	ctlInvoker control.Invoker
-	aiCache    *attachInfoCache
-	numaAware  bool
-	netCtx     context.Context
-	mutex      sync.Mutex
-	monitor    *procMon
+	log         logging.Logger
+	sys         string
+	ctlInvoker  control.Invoker
+	cacheMutex  sync.Mutex
+	aiCache     *attachInfoCache
+	fabricCache *localFabricCache
+	numaAware   bool
+	netCtx      context.Context
+	monitor     *procMon
 }
 
 func (mod *mgmtModule) HandleCall(session *drpc.Session, method drpc.Method, req []byte) ([]byte, error) {
@@ -69,8 +71,6 @@ func (mod *mgmtModule) HandleCall(session *drpc.Session, method drpc.Method, req
 		// call the disconnect handler and return success.
 		mod.handleNotifyExit(ctx, cred.Pid)
 		return nil, nil
-	default:
-		return nil, drpc.UnknownMethodFailure()
 	}
 
 	return nil, drpc.UnknownMethodFailure()
@@ -121,64 +121,105 @@ func (mod *mgmtModule) handleGetAttachInfo(ctx context.Context, reqb []byte, pid
 		}
 	}
 
-	// synchronize access to mod.aiCache.* resources used below
-	mod.mutex.Lock()
-	defer mod.mutex.Unlock()
-
-	if mod.aiCache.isCached() {
-		if !mod.numaAware {
-			numaNode = mod.aiCache.defaultNumaNode
-		}
-		return mod.aiCache.getResponse(numaNode)
+	resp, err := mod.getAttachInfo(ctx, numaNode, pbReq.Sys)
+	if err != nil {
+		return nil, err
 	}
 
+	mod.log.Debugf("GetAttachInfoResp: %+v", resp)
+
+	return proto.Marshal(resp)
+}
+
+func (mod *mgmtModule) getAttachInfo(ctx context.Context, numaNode int, sys string) (*mgmtpb.GetAttachInfoResp, error) {
+	var resp *mgmtpb.GetAttachInfoResp
+	var err error
+	if mod.aiCache.IsEnabled() {
+		resp, err = mod.getAttachInfoCached(ctx, numaNode, sys)
+	} else {
+		resp, err = mod.getAttachInfoRemote(ctx, numaNode, sys)
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	fabricIF, err := mod.getFabricInterface(ctx, numaNode, resp.ClientNetHint.NetDevClass)
+	if err != nil {
+		return nil, err
+	}
+
+	resp.ClientNetHint.Interface = fabricIF.Name
+	resp.ClientNetHint.Domain = fabricIF.Name
+	if strings.HasPrefix(resp.ClientNetHint.Provider, verbsProvider) {
+		resp.ClientNetHint.Domain = fabricIF.Domain
+		mod.log.Debugf("OFI_DOMAIN for %s has been detected as: %s",
+			resp.ClientNetHint.Interface, resp.ClientNetHint.Domain)
+	}
+
+	return resp, nil
+}
+
+func (mod *mgmtModule) getAttachInfoCached(ctx context.Context, numaNode int, sys string) (*mgmtpb.GetAttachInfoResp, error) {
+	mod.cacheMutex.Lock()
+	defer mod.cacheMutex.Unlock()
+
+	if mod.aiCache.IsCached() {
+		return mod.aiCache.AttachInfo, nil
+	}
+
+	resp, err := mod.getAttachInfoRemote(ctx, numaNode, sys)
+	if err != nil {
+		return nil, err
+	}
+
+	mod.aiCache.Cache(ctx, resp)
+	return resp, nil
+}
+
+func (mod *mgmtModule) getAttachInfoRemote(ctx context.Context, numaNode int, sys string) (*mgmtpb.GetAttachInfoResp, error) {
 	// Ask the MS for _all_ info, regardless of pbReq.AllRanks, so that the
 	// cache can serve future "pbReq.AllRanks == true" requests.
 	req := new(control.GetAttachInfoReq)
-	req.SetSystem(pbReq.GetSys())
+	req.SetSystem(sys)
 	req.AllRanks = true
 	resp, err := control.GetAttachInfo(ctx, mod.ctlInvoker, req)
 	if err != nil {
-		return nil, errors.Wrapf(err, "GetAttachInfo %+v", pbReq)
+		return nil, errors.Wrapf(err, "GetAttachInfo %+v", req)
 	}
 
 	if resp.ClientNetHint.Provider == "" {
 		return nil, errors.New("GetAttachInfo response contained no provider")
 	}
 
-	// Scan the local fabric to determine what devices are available that match our provider
-	scanResults, err := netdetect.ScanFabric(mod.netCtx, resp.ClientNetHint.Provider)
-	if err != nil {
-		return nil, err
-	}
-
-	mod.log.Debugf("GetAttachInfo resp from MS: %+v", resp)
-
 	pbResp := new(mgmtpb.GetAttachInfoResp)
 	if err := convert.Types(resp, pbResp); err != nil {
 		return nil, errors.Wrap(err, "Failed to convert GetAttachInfo response")
 	}
 
-	err = mod.aiCache.initResponseCache(mod.netCtx, pbResp, scanResults)
+	return pbResp, nil
+}
+
+func (mod *mgmtModule) getFabricInterface(ctx context.Context, numaNode int, netDevClass uint32) (*FabricInterface, error) {
+	mod.cacheMutex.Lock()
+	defer mod.cacheMutex.Unlock()
+	if mod.fabricCache.IsCached() {
+		return mod.fabricCache.GetDevice(numaNode, netDevClass)
+	}
+
+	netCtx, err := netdetect.Init(ctx)
 	if err != nil {
 		return nil, err
 	}
+	defer netdetect.CleanUp(netCtx)
 
-	if !mod.numaAware {
-		numaNode = mod.aiCache.defaultNumaNode
-	}
-
-	cacheResp, err := mod.aiCache.getResponse(numaNode)
+	result, err := netdetect.ScanFabric(netCtx, "")
 	if err != nil {
 		return nil, err
 	}
+	mod.fabricCache.Cache(ctx, result)
 
-	// If pbReq.AllRanks == false, we shouldn't return the rank URIs.
-	// Implementing that may require changing the cache to either hold
-	// unmarshalled responses (more computation work for daos_agent) or
-	// two variants of marshalled responses.
-
-	return cacheResp, err
+	return mod.fabricCache.GetDevice(numaNode, netDevClass)
 }
 
 func (mod *mgmtModule) handleNotifyPoolConnect(ctx context.Context, reqb []byte, pid int32) error {


### PR DESCRIPTION
Split the agent cache into two separate caches: one for the remote
GetAttachInfo response, and one for the fabric interface topology
on the machine. The remote cache may still be disabled using the
environment variable. The local fabric cache may also be disabled
via a new environment variable.

Signed-off-by: Kris Jacque <kristin.jacque@intel.com>