### PR TITLE
DAOS-8105 test: Updated control/dmg_pool_query_test.py to use tier_stats

### DIFF
--- a/src/tests/ftest/control/dmg_pool_query_test.py
+++ b/src/tests/ftest/control/dmg_pool_query_test.py
@@ -127,10 +127,8 @@ class DmgPoolQueryTest(ControlTestBase, IorTestBase):
 
         for uuid in uuids:
             # Verify pool query status
-            self.pool.set_query_data()
-            error = None
-            if "error" in self.pool.query_data:
-                error = self.pool.query_data["error"]
+            data = self.dmg.pool_query(uuid)
+            error = data["error"] if "error" in data else None
 
             self.log.info("")
             self.log.info("==>  Using test UUID:                   %s", uuid[0])

--- a/src/tests/ftest/control/dmg_pool_query_test.py
+++ b/src/tests/ftest/control/dmg_pool_query_test.py
@@ -8,7 +8,6 @@ from copy import deepcopy
 
 from ior_test_base import IorTestBase
 from control_test_base import ControlTestBase
-from avocado.core.exceptions import TestFail
 
 
 class DmgPoolQueryTest(ControlTestBase, IorTestBase):
@@ -122,6 +121,9 @@ class DmgPoolQueryTest(ControlTestBase, IorTestBase):
 
         # Add a pass case to verify test is working
         uuids.append([self.pool.uuid, "PASS"])
+
+        # Disable raising an exception if the dmg command fails
+        self.dmg.exit_status_exception = False
 
         for uuid in uuids:
             # Verify pool query status

--- a/src/tests/ftest/control/dmg_pool_query_test.py
+++ b/src/tests/ftest/control/dmg_pool_query_test.py
@@ -127,7 +127,7 @@ class DmgPoolQueryTest(ControlTestBase, IorTestBase):
             msg = "Call dmg pool query {} that's expected to {}".format(
                 uuid[0], uuid[1])
             self.log.info(msg)
-            self.pool.uuid = uuid[0]
+            self.pool.pool.set_uuid_str(uuid[0])
 
             try:
                 # Call dmg pool query.
@@ -143,7 +143,7 @@ class DmgPoolQueryTest(ControlTestBase, IorTestBase):
                     errors_list.append(msg)
 
         # Restore the original UUID.
-        self.pool.uuid = uuids[-1][0]
+        self.pool.pool.set_uuid_str(uuids[-1][0])
 
         # Report errors and fail test if needed.
         if errors_list:

--- a/src/tests/ftest/control/dmg_pool_query_test.py
+++ b/src/tests/ftest/control/dmg_pool_query_test.py
@@ -124,26 +124,23 @@ class DmgPoolQueryTest(ControlTestBase, IorTestBase):
         uuids.append([self.pool.uuid, "PASS"])
 
         for uuid in uuids:
-            msg = "Call dmg pool query {} that's expected to {}".format(
-                uuid[0], uuid[1])
-            self.log.info(msg)
-            self.pool.pool.set_uuid_str(uuid[0])
+            # Verify pool query status
+            data = self.dmg.pool_query(uuid[0])
+            error = data["error"] if "error" in data else None
 
-            try:
-                # Call dmg pool query.
-                self.pool.set_query_data()
-                if uuid[1] == "FAIL":
-                    msg = "Query expected to fail, but worked! {}".format(
-                        uuid[0])
-                    errors_list.append(msg)
-            except TestFail:
-                if uuid[1] == "PASS":
-                    msg = "Query expected to work, but failed! {}".format(
-                        uuid[0])
-                    errors_list.append(msg)
+            self.log.info("")
+            self.log.info("==>  Using test UUID:                   %s", uuid[0])
+            self.log.info("==>  Pool query command is expected to: %s", uuid[1])
+            self.log.info("==>  Error from dmp pool query:         %s", error)
+            self.log.info("")
 
-        # Restore the original UUID.
-        self.pool.pool.set_uuid_str(uuids[-1][0])
+            if uuid[1] == "FAIL" and error is None:
+                errors_list.append("==>   Test expected to fail:" + uuid[0])
+            elif uuid[1] == "PASS" and error is not None:
+                errors_list.append("==>   Test expected to pass:" + uuid[0])
+
+        # Enable exceptions again for dmg.
+        self.dmg.exit_status_exception = True
 
         # Report errors and fail test if needed.
         if errors_list:

--- a/src/tests/ftest/control/dmg_pool_query_test.py
+++ b/src/tests/ftest/control/dmg_pool_query_test.py
@@ -74,12 +74,16 @@ class DmgPoolQueryTest(ControlTestBase, IorTestBase):
                 "disabled_targets", path="/run/exp_vals/*"),
             "version": self.params.get("version", path="/run/exp_vals/*"),
             "leader": self.params.get("leader", path="/run/exp_vals/*"),
-            "scm": {
-                "total": self.params.get("total", path="/run/exp_vals/scm/*")
-            },
-            "nvme": {
-                "total": self.params.get("total", path="/run/exp_vals/nvme/*")
-            },
+            "tier_stats": [
+                {
+                    "total": self.params.get(
+                        "total", path="/run/exp_vals/scm/*")
+                },
+                {
+                    "total": self.params.get(
+                        "total", path="/run/exp_vals/nvme/*")
+                }
+            ],
             "rebuild": {
                 "status": self.params.get(
                     "rebuild_status", path="/run/exp_vals/rebuild/*"),
@@ -124,7 +128,9 @@ class DmgPoolQueryTest(ControlTestBase, IorTestBase):
         for uuid in uuids:
             # Verify pool query status
             self.pool.set_query_data()
-            error = self.pool.query_data["error"] if "error" in data else None
+            error = None
+            if "error" in self.pool.query_data:
+                error = self.pool.query_data["error"]
 
             self.log.info("")
             self.log.info("==>  Using test UUID:                   %s", uuid[0])


### PR DESCRIPTION
dmg pool query JSON output format was updated to use tier_stats instead of
scm/nvme.

Also call TestPool.set_query_data() instead of using dmg_command.

Quick-build: true
Skip-unit-tests: true
Test-tag: pool_query_basic pool_query_inputs pool_query_write
Signed-off-by: Makito Kano <makito.kano@intel.com>