### PR TITLE
DAOS-7976: Fix Coverity Null Pointer Deference Issues in Engine

### DIFF
--- a/src/common/checksum.c
+++ b/src/common/checksum.c
@@ -926,14 +926,16 @@ daos_csummer_verify_iod(struct daos_csummer *obj, daos_iod_t *iod,
 	int			 rc;
 	bool			 match;
 
-	if (!daos_csummer_initialized(obj) || obj->dcs_skip_data_verify ||
-	    iod->iod_size == 0)
+	if (!daos_csummer_initialized(obj) || obj->dcs_skip_data_verify)
 		return 0;
 
 	if (iod == NULL || sgl == NULL || iod_csum == NULL) {
 		D_ERROR("Invalid params\n");
 		return -DER_INVAL;
 	}
+
+	if (iod->iod_size == 0)
+		return 0;
 
 	rc = daos_csummer_calc_iods(obj, sgl, iod, map, 1, 0, singv_lo,
 				    singv_idx, &new_iod_csums);

--- a/src/object/srv_obj_migrate.c
+++ b/src/object/srv_obj_migrate.c
@@ -287,6 +287,8 @@ obj_tree_insert(daos_handle_t toh, uuid_t co_uuid, daos_unit_oid_t oid,
 void
 migrate_pool_tls_destroy(struct migrate_pool_tls *tls)
 {
+	if (!tls)
+		return;
 	D_DEBUG(DB_REBUILD, "TLS destroy for "DF_UUID" ver %d\n",
 		DP_UUID(tls->mpt_pool_uuid), tls->mpt_version);
 	if (tls->mpt_pool)
@@ -310,12 +312,16 @@ migrate_pool_tls_destroy(struct migrate_pool_tls *tls)
 void
 migrate_pool_tls_get(struct migrate_pool_tls *tls)
 {
+	if (!tls)
+		return;
 	tls->mpt_refcount++;
 }
 
 void
 migrate_pool_tls_put(struct migrate_pool_tls *tls)
 {
+	if (!tls)
+		return;
 	tls->mpt_refcount--;
 	if (tls->mpt_fini && tls->mpt_refcount == 1)
 		ABT_eventual_set(tls->mpt_done_eventual, NULL, 0);
@@ -2645,7 +2651,7 @@ migrate_obj_ult(void *data)
 	if (tls == NULL || tls->mpt_fini) {
 		D_WARN("some one abort the rebuild "DF_UUID"\n",
 		       DP_UUID(arg->pool_uuid));
-		D_GOTO(free, rc = 0);
+		D_GOTO(free_notls, rc = 0);
 	}
 
 	if (tls->mpt_del_local_objs) {
@@ -2718,6 +2724,7 @@ free:
 		DP_UUID(tls->mpt_pool_uuid), tls->mpt_version,
 		DP_UOID(arg->oid), arg->shard, tls->mpt_obj_executed_ult,
 		DP_RC(rc));
+free_notls:
 	D_FREE(arg->snaps);
 	D_FREE(arg);
 	migrate_pool_tls_put(tls);

--- a/src/vos/vos_dtx.c
+++ b/src/vos/vos_dtx.c
@@ -297,7 +297,9 @@ dtx_act_ent_free(struct btr_instance *tins, struct btr_record *rec,
 
 	dae = umem_off2ptr(&tins->ti_umm, rec->rec_off);
 	rec->rec_off = UMOFF_NULL;
-	d_list_del_init(&dae->dae_link);
+
+	if (dae != NULL)
+		d_list_del_init(&dae->dae_link);
 
 	if (args != NULL) {
 		/* Return the record addreass (offset in DRAM).


### PR DESCRIPTION
Coverity identified issues in the engine code where a null pointer is
dereference either before or after a check for NULL is done.

CID: 331131, 331444, 331453

Signed-off-by: David Quigley <david.quigley@intel.com>