### PR TITLE
DAOS-8072 object: buffer boundary check when enumerate object

### DIFF
--- a/src/object/obj_enum.c
+++ b/src/object/obj_enum.c
@@ -585,8 +585,13 @@ fill_rec(daos_handle_t ih, vos_iter_entry_t *key_ent, struct dss_enum_arg *arg,
 	arg->kds[arg->kds_len].kd_key_len += sizeof(*rec);
 
 	/* Append the recx record to iovs. */
-	D_ASSERT(iovs[arg->sgl_idx].iov_len + sizeof(*rec) <
-		 iovs[arg->sgl_idx].iov_buf_len);
+	D_ASSERTF(iovs[arg->sgl_idx].iov_len + sizeof(*rec) <=
+		  iovs[arg->sgl_idx].iov_buf_len,
+		  "Buffer overflow: idx %d, data len %ld, buf len %ld, "
+		  "rec size %ld, type %d\n",
+		  arg->sgl_idx, iovs[arg->sgl_idx].iov_len,
+		  iovs[arg->sgl_idx].iov_buf_len, sizeof(*rec), type);
+
 	rec = iovs[arg->sgl_idx].iov_buf + iovs[arg->sgl_idx].iov_len;
 	rec->rec_recx = key_ent->ie_recx;
 	rec->rec_size = iod_size;


### PR DESCRIPTION
It is a valid case that the new appended record exactly matches
the buffer, unnecessary to be smaller than the buffer boundary.

Signed-off-by: Fan Yong <fan.yong@intel.com>