### PR TITLE
DAOS-8060 bio: bypass health monitor setup

### DIFF
--- a/src/bio/bio_internal.h
+++ b/src/bio/bio_internal.h
@@ -502,6 +502,7 @@ struct bio_bdev *lookup_dev_by_id(uuid_t dev_id);
 void setup_bio_bdev(void *arg);
 void destroy_bio_bdev(struct bio_bdev *d_bdev);
 void replace_bio_bdev(struct bio_bdev *old_dev, struct bio_bdev *new_dev);
+bool bypass_health_collect(void);
 
 /* bio_buffer.c */
 void dma_buffer_destroy(struct bio_dma_buffer *buf);
@@ -581,7 +582,7 @@ dump_dma_info(struct bio_dma_buffer *bdb)
 /* bio_monitor.c */
 int bio_init_health_monitoring(struct bio_blobstore *bb, char *bdev_name);
 void bio_fini_health_monitoring(struct bio_blobstore *bb);
-void bio_bs_monitor(struct bio_xs_context *ctxt, uint64_t now, bool bypass);
+void bio_bs_monitor(struct bio_xs_context *ctxt, uint64_t now);
 void bio_media_error(void *msg_arg);
 void bio_export_health_stats(struct bio_blobstore *bb, char *bdev_name);
 void bio_export_vendor_health_stats(struct bio_blobstore *bb, char *bdev_name);

--- a/src/bio/bio_monitor.c
+++ b/src/bio/bio_monitor.c
@@ -728,7 +728,7 @@ collect_raw_health_data(struct bio_xs_context *ctxt)
 }
 
 void
-bio_bs_monitor(struct bio_xs_context *ctxt, uint64_t now, bool bypass)
+bio_bs_monitor(struct bio_xs_context *ctxt, uint64_t now)
 {
 	struct bio_dev_health	*dev_health;
 	struct bio_blobstore	*bbs;
@@ -761,7 +761,7 @@ bio_bs_monitor(struct bio_xs_context *ctxt, uint64_t now, bool bypass)
 		D_ERROR("State transition on target %d failed. %d\n",
 			ctxt->bxc_tgt_id, rc);
 
-	if (!bypass)
+	if (!bypass_health_collect())
 		collect_raw_health_data(ctxt);
 }
 
@@ -819,6 +819,9 @@ bio_init_health_monitoring(struct bio_blobstore *bb, char *bdev_name)
 
 	D_ASSERT(bb != NULL);
 	D_ASSERT(bdev_name != NULL);
+
+	if (bypass_health_collect())
+		return 0;
 
 	hp_sz = sizeof(struct spdk_nvme_health_information_page);
 	bb->bb_dev_health.bdh_health_buf = spdk_dma_zmalloc(hp_sz, 0, NULL);

--- a/src/engine/srv.c
+++ b/src/engine/srv.c
@@ -267,7 +267,7 @@ dss_nvme_poll_ult(void *args)
 
 	D_ASSERT(dx->dx_main_xs);
 	while (!dss_xstream_exiting(dx)) {
-		bio_nvme_poll(dmi->dmi_nvme_ctxt, dss_nvme_bypass_health_check);
+		bio_nvme_poll(dmi->dmi_nvme_ctxt);
 		ABT_thread_yield();
 	}
 }
@@ -1210,7 +1210,8 @@ dss_srv_init(void)
 	xstream_data.xd_init_step = XD_INIT_SYS_DB;
 
 	rc = bio_nvme_init(dss_nvme_conf, dss_nvme_shm_id, dss_nvme_mem_size,
-			   dss_nvme_hugepage_size, dss_tgt_nr, vos_db_get());
+			   dss_nvme_hugepage_size, dss_tgt_nr, vos_db_get(),
+			   dss_nvme_bypass_health_check);
 	if (rc != 0)
 		D_GOTO(failed, rc);
 	xstream_data.xd_init_step = XD_INIT_NVME;

--- a/src/include/daos_srv/bio.h
+++ b/src/include/daos_srv/bio.h
@@ -405,11 +405,13 @@ void bio_register_bulk_ops(int (*bulk_create)(void *ctxt, d_sg_list_t *sgl,
  * \param[IN] hugepage_size	Configured hugepage size on system
  * \paran[IN] tgt_nr		Number of targets
  * \param[IN] db		persistent database to store SMD data
+ * \param[IN] bypass		Set to bypass health data collection
  *
  * \return		Zero on success, negative value on error
  */
 int bio_nvme_init(const char *nvme_conf, int shm_id, int mem_size,
-		  int hugepage_size, int tgt_nr, struct sys_db *db);
+		  int hugepage_size, int tgt_nr, struct sys_db *db,
+		  bool bypass);
 
 /**
  * Global NVMe finilization.
@@ -461,13 +463,12 @@ void bio_xsctxt_free(struct bio_xs_context *ctxt);
  * NVMe poller to poll NVMe I/O completions.
  *
  * \param[IN] ctxt	Per-xstream NVMe context
- * \param[IN] bypass	Set to bypass the health check
  *
  * \return		0: If no work was done
  *			1: If work was done
  *			-1: If thread has exited
  */
-int bio_nvme_poll(struct bio_xs_context *ctxt,  bool bypass);
+int bio_nvme_poll(struct bio_xs_context *ctxt);
 
 /*
  * Create per VOS instance blob.

--- a/src/vos/vos_common.c
+++ b/src/vos/vos_common.c
@@ -520,7 +520,7 @@ vos_self_nvme_init()
 
 	rc = bio_nvme_init(VOS_NVME_CONF, VOS_NVME_SHM_ID, VOS_NVME_MEM_SIZE,
 			   VOS_NVME_HUGEPAGE_SIZE, VOS_NVME_NR_TARGET,
-			   vos_db_get());
+			   vos_db_get(), true);
 	if (rc)
 		return rc;
 


### PR DESCRIPTION
Bypass health monitor setup when dss_nvme_bypass_check is set.

Signed-off-by: Niu Yawei <yawei.niu@intel.com>