### PR TITLE
DAOS-8108 rebuild: fix a case in obj_ec_recov_need_try_again

### DIFF
--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -1642,6 +1642,8 @@ obj_ec_recov_cb(tse_task_t *task, struct dc_object *obj,
 		extra_flags = DIOF_EC_RECOV;
 		if (recov_task->ert_snapshot)
 			extra_flags |= DIOF_EC_RECOV_SNAP;
+		if ((obj_auxi->flags & ORF_FOR_MIGRATION) != 0)
+			extra_flags |= DIOF_FOR_MIGRATION;
 		rc = dc_obj_fetch_task_create(args->oh, th, 0, args->dkey, 1,
 					      extra_flags,
 					      &recov_task->ert_iod,

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -1251,6 +1251,7 @@ obj_ec_recov_need_try_again(struct obj_rw_in *orw, struct obj_io_context *ioc)
 	 * that flag was only set when (snapshot_epoch < sc_ec_agg_eph_boundry).
 	 */
 	if ((orw->orw_flags & ORF_EC_RECOV_SNAP) == 0 &&
+	    (orw->orw_flags & ORF_FOR_MIGRATION) == 0 &&
 	    orw->orw_epoch < ioc->ioc_coc->sc_ec_agg_eph_boundry)
 		return true;
 


### PR DESCRIPTION
For rebuild, as the aggregation will not cross the rebuild epoch, so
in obj_ec_recov_need_try_again() need to bypass the rebuild case.

Signed-off-by: Xuezhao Liu <xuezhao.liu@intel.com>