### PR TITLE
DAOS-7930 dtx: pool based DTX aggregation threshold

### DIFF
--- a/src/dtx/dtx_common.c
+++ b/src/dtx/dtx_common.c
@@ -17,14 +17,34 @@
 #include <daos_srv/daos_engine.h>
 #include "dtx_internal.h"
 
-struct dtx_batched_commit_args {
-	d_list_t		 dbca_link;
-	int			 dbca_refs;
-	uint32_t		 dbca_deregister:1;
-	struct sched_request	*dbca_cleanup_req;
-	struct sched_request	*dbca_commit_req;
-	struct sched_request	*dbca_agg_req;
-	struct ds_cont_child	*dbca_cont;
+uint64_t dtx_agg_gen;
+struct dtx_batched_cont_args;
+
+struct dtx_batched_pool_args {
+	/* Link to dss_module_info::dmi_dtx_batched_pool_list. */
+	d_list_t			 dbpa_sys_link;
+	/* The list of containers belong to the pool. */
+	d_list_t			 dbpa_cont_list;
+	struct ds_pool_child		*dbpa_pool;
+	/* The container that needs to do DTX aggregation. */
+	struct dtx_batched_cont_args	*dbpa_victim;
+	struct dtx_stat			 dbpa_stat;
+	uint32_t			 dbpa_aggregating:1;
+};
+
+struct dtx_batched_cont_args {
+	/* Link to dss_module_info::dmi_dtx_batched_cont_list. */
+	d_list_t			 dbca_sys_link;
+	/* Link to dtx_batched_pool_args::dbpa_cont_list. */
+	d_list_t			 dbca_pool_link;
+	uint64_t			 dbca_gen;
+	int				 dbca_refs;
+	uint32_t			 dbca_deregister:1;
+	struct sched_request		*dbca_cleanup_req;
+	struct sched_request		*dbca_commit_req;
+	struct sched_request		*dbca_agg_req;
+	struct ds_cont_child		*dbca_cont;
+	struct dtx_batched_pool_args	*dbca_pool;
 };
 
 struct dtx_cleanup_stale_cb_args {
@@ -45,23 +65,24 @@ dtx_free_committable(struct dtx_entry **dtes, struct dtx_cos_key *dcks,
 }
 
 static inline void
-dtx_get_dbca(struct dtx_batched_commit_args *dbca)
+dtx_get_dbca(struct dtx_batched_cont_args *dbca)
 {
 	dbca->dbca_refs++;
 	D_ASSERT(dbca->dbca_refs >= 1);
 }
 
 static inline void
-dtx_put_dbca(struct dtx_batched_commit_args *dbca)
+dtx_put_dbca(struct dtx_batched_cont_args *dbca)
 {
 	D_ASSERT(dbca->dbca_refs >= 1);
 	dbca->dbca_refs--;
 }
 
 static void
-dtx_free_dbca(struct dtx_batched_commit_args *dbca)
+dtx_free_dbca(struct dtx_batched_cont_args *dbca)
 {
-	struct ds_cont_child	*cont = dbca->dbca_cont;
+	struct ds_cont_child		*cont = dbca->dbca_cont;
+	struct dtx_batched_pool_args	*dbpa = dbca->dbca_pool;
 
 	/* Nobody re-opened it during waiting dtx_flush_on_deregister(). */
 	if (cont->sc_closing) {
@@ -78,7 +99,7 @@ dtx_free_dbca(struct dtx_batched_commit_args *dbca)
 	 * reopen will use new dbca, so current dbca needs to be cleanup.
 	 */
 
-	D_ASSERT(d_list_empty(&dbca->dbca_link));
+	D_ASSERT(d_list_empty(&dbca->dbca_sys_link));
 
 	if (dbca->dbca_cleanup_req != NULL)
 		sched_req_wait(dbca->dbca_cleanup_req, true);
@@ -98,6 +119,11 @@ dtx_free_dbca(struct dtx_batched_commit_args *dbca)
 	D_ASSERT(dbca->dbca_cleanup_req == NULL);
 	D_ASSERT(dbca->dbca_commit_req == NULL);
 	D_ASSERT(dbca->dbca_agg_req == NULL);
+
+	if (d_list_empty(&dbpa->dbpa_cont_list)) {
+		d_list_del(&dbpa->dbpa_sys_link);
+		D_FREE(dbpa);
+	}
 
 	D_FREE_PTR(dbca);
 	ds_cont_child_put(cont);
@@ -151,7 +177,7 @@ dtx_cleanup_stale_iter_cb(uuid_t co_uuid, vos_iter_entry_t *ent, void *args)
 
 	/* Stop the iteration if current DTX is not too old. */
 	if (dtx_hlc_age2sec(ent->ie_dtx_start_time) <=
-	    DTX_CLEANUP_THRESHOLD_AGE_LOWER)
+	    DTX_CLEANUP_THD_AGE_LO)
 		return 1;
 
 	D_ALLOC(dsp, sizeof(*dsp) + ent->ie_dtx_mbs_dsize);
@@ -179,12 +205,15 @@ dtx_cleanup_stale_iter_cb(uuid_t co_uuid, vos_iter_entry_t *ent, void *args)
 static void
 dtx_cleanup_stale(void *arg)
 {
-	struct dtx_batched_commit_args		*dbca = arg;
+	struct dtx_batched_cont_args		*dbca = arg;
 	struct ds_cont_child			*cont = dbca->dbca_cont;
 	struct dtx_share_peer			*dsp;
 	struct dtx_cleanup_stale_cb_args	 dcsca;
 	int					 count;
 	int					 rc;
+
+	if (dbca->dbca_cleanup_req == NULL)
+		goto out;
 
 	D_INIT_LIST_HEAD(&dcsca.dcsca_list);
 	dcsca.dcsca_count = 0;
@@ -224,14 +253,19 @@ dtx_cleanup_stale(void *arg)
 
 	sched_req_put(dbca->dbca_cleanup_req);
 	dbca->dbca_cleanup_req = NULL;
+
+out:
 	dtx_put_dbca(dbca);
 }
 
 static void
 dtx_aggregate(void *arg)
 {
-	struct dtx_batched_commit_args	*dbca = arg;
+	struct dtx_batched_cont_args	*dbca = arg;
 	struct ds_cont_child		*cont = dbca->dbca_cont;
+
+	if (dbca->dbca_agg_req == NULL)
+		goto out;
 
 	while (!dss_ult_exiting(dbca->dbca_agg_req)) {
 		struct dtx_stat		stat = { 0 };
@@ -245,28 +279,190 @@ dtx_aggregate(void *arg)
 
 		dtx_stat(cont, &stat);
 
-		if (stat.dtx_committed_count <= DTX_AGG_THRESHOLD_CNT_LOWER)
-			break;
+		/* If current container does not exceeds DTX thresholds,
+		 * but the whole pool still exceeds the thresholds, then
+		 * we need to choose a proper (maybe the same) container
+		 * to do DTX aggregation.
+		 */
 
-		if (stat.dtx_committed_count >= DTX_AGG_THRESHOLD_CNT_UPPER)
-			continue;
-
-		if (stat.dtx_oldest_committed_time == 0 ||
-		    dtx_hlc_age2sec(stat.dtx_oldest_committed_time) <=
-		    DTX_AGG_THRESHOLD_AGE_LOWER)
+		if (stat.dtx_cont_cmt_count == 0 ||
+		    stat.dtx_first_cmt_blob_time_lo == 0 ||
+		    (stat.dtx_cont_cmt_count <= DTX_AGG_THD_CNT_LO &&
+		     dtx_hlc_age2sec(stat.dtx_first_cmt_blob_time_lo) <=
+		     DTX_AGG_THD_AGE_LO))
 			break;
 	}
 
 	sched_req_put(dbca->dbca_agg_req);
 	dbca->dbca_agg_req = NULL;
+
+out:
 	dtx_put_dbca(dbca);
+}
+
+static void
+dtx_aggregation_pool(struct dtx_batched_pool_args *dbpa)
+{
+	ABT_thread			 child;
+	struct dtx_batched_cont_args	*dbca;
+	struct ds_cont_child		*cont;
+	int				 rc;
+
+	while (1) {
+		struct dtx_stat		 stat = { 0 };
+
+		if (d_list_empty(&dbpa->dbpa_cont_list))
+			return;
+
+		dbca = d_list_entry(dbpa->dbpa_cont_list.next,
+				    struct dtx_batched_cont_args,
+				    dbca_pool_link);
+
+		/* Finish this cycle scan. */
+		if (dbca->dbca_gen == dtx_agg_gen)
+			break;
+
+		dbca->dbca_gen = dtx_agg_gen;
+		d_list_move_tail(&dbca->dbca_pool_link, &dbpa->dbpa_cont_list);
+
+		if (dbca->dbca_deregister)
+			continue;
+
+		cont = dbca->dbca_cont;
+		if (cont->sc_closing)
+			continue;
+
+		if (dbca->dbca_agg_req != NULL) {
+			dbpa->dbpa_aggregating = 1;
+			continue;
+		}
+
+		dtx_stat(cont, &stat);
+		if (stat.dtx_cont_cmt_count == 0 ||
+		    stat.dtx_first_cmt_blob_time_lo == 0)
+			continue;
+
+		if (stat.dtx_cont_cmt_count >= DTX_AGG_THD_CNT_UP ||
+		    ((stat.dtx_cont_cmt_count > DTX_AGG_THD_CNT_LO ||
+		      stat.dtx_pool_cmt_count >= DTX_AGG_THD_CNT_UP) &&
+		     (dtx_hlc_age2sec(stat.dtx_first_cmt_blob_time_lo) >=
+		      DTX_AGG_THD_AGE_UP))) {
+			dtx_get_dbca(dbca);
+			rc = dss_ult_create(dtx_aggregate, dbca,
+					    DSS_XS_SELF, 0, 0, &child);
+			if (rc != 0) {
+				D_WARN("Fail to start DTX agg ULT (1) for "
+				       DF_UUID": "DF_RC"\n",
+				       DP_UUID(cont->sc_uuid), DP_RC(rc));
+				dtx_put_dbca(dbca);
+				continue;
+			}
+
+			dtx_init_sched_req(cont, &dbca->dbca_agg_req, child);
+			if (dbca->dbca_agg_req == NULL) {
+				D_WARN("Fail to get agg sched req (1) for "
+				       DF_UUID"\n", DP_UUID(cont->sc_uuid));
+				ABT_thread_join(child);
+				continue;
+			}
+
+			dbpa->dbpa_aggregating = 1;
+			continue;
+		}
+
+		if (dbpa->dbpa_stat.dtx_first_cmt_blob_time_lo == 0 ||
+		    dbpa->dbpa_stat.dtx_first_cmt_blob_time_lo >
+		    stat.dtx_first_cmt_blob_time_lo ||
+		    (dbpa->dbpa_stat.dtx_first_cmt_blob_time_lo ==
+		     stat.dtx_first_cmt_blob_time_lo &&
+		     dbpa->dbpa_stat.dtx_first_cmt_blob_time_up >
+		     stat.dtx_first_cmt_blob_time_up) ||
+		    (dbpa->dbpa_stat.dtx_first_cmt_blob_time_lo ==
+		     stat.dtx_first_cmt_blob_time_lo &&
+		     dbpa->dbpa_stat.dtx_first_cmt_blob_time_up ==
+		     stat.dtx_first_cmt_blob_time_up &&
+		     dbpa->dbpa_stat.dtx_cont_cmt_count <
+		     stat.dtx_cont_cmt_count)) {
+			dbpa->dbpa_stat = stat;
+			dbpa->dbpa_victim = dbca;
+		}
+	}
+
+	if (dbpa->dbpa_aggregating || dbpa->dbpa_victim == NULL ||
+	    dbpa->dbpa_stat.dtx_pool_cmt_count <= DTX_AGG_THD_CNT_LO ||
+	    dbpa->dbpa_stat.dtx_first_cmt_blob_time_lo == 0 ||
+	    dtx_hlc_age2sec(dbpa->dbpa_stat.dtx_first_cmt_blob_time_lo) <=
+	    DTX_AGG_THD_AGE_LO)
+		return;
+
+	/* No single pool exceeds DTX thresholds, but the whole pool does,
+	 * we choose the victim container to do the DTX aggregation.
+	 */
+
+	dbca = dbpa->dbpa_victim;
+	cont = dbca->dbca_cont;
+	dtx_get_dbca(dbca);
+
+	rc = dss_ult_create(dtx_aggregate, dbca, DSS_XS_SELF, 0, 0, &child);
+	if (rc != 0) {
+		D_WARN("Fail to start DTX agg ULT (2) for "DF_UUID": "DF_RC"\n",
+		       DP_UUID(cont->sc_uuid), DP_RC(rc));
+		dtx_put_dbca(dbca);
+	} else {
+		dtx_init_sched_req(cont, &dbca->dbca_agg_req, child);
+		if (dbca->dbca_agg_req == NULL) {
+			D_WARN("Fail to get agg sched req (2) for "DF_UUID"\n",
+			       DP_UUID(cont->sc_uuid));
+			ABT_thread_join(child);
+		} else {
+			dbpa->dbpa_aggregating = 1;
+		}
+	}
+}
+
+static void
+dtx_aggregation_main(void *arg)
+{
+	struct dss_module_info		*dmi = dss_get_module_info();
+	struct dtx_batched_pool_args	*dbpa;
+
+	if (dmi->dmi_dtx_agg_req == NULL)
+		return;
+
+	while (1) {
+		int	sleep_time = 50; /* ms */
+
+		if (!d_list_empty(&dmi->dmi_dtx_batched_pool_list)) {
+			dbpa = d_list_entry(dmi->dmi_dtx_batched_pool_list.next,
+					    struct dtx_batched_pool_args,
+					    dbpa_sys_link);
+			d_list_move_tail(&dbpa->dbpa_sys_link,
+					 &dmi->dmi_dtx_batched_pool_list);
+
+			dtx_agg_gen++;
+			dbpa->dbpa_victim = NULL;
+			dbpa->dbpa_aggregating = 0;
+			dtx_aggregation_pool(dbpa);
+			if (dbpa->dbpa_aggregating)
+				sleep_time = 0;
+		}
+
+		if (dss_xstream_exiting(dmi->dmi_xstream))
+			break;
+
+		sched_req_sleep(dmi->dmi_dtx_agg_req, sleep_time);
+	}
 }
 
 static void
 dtx_batched_commit_one(void *arg)
 {
-	struct dtx_batched_commit_args	*dbca = arg;
+	struct dss_module_info		*dmi = dss_get_module_info();
+	struct dtx_batched_cont_args	*dbca = arg;
 	struct ds_cont_child		*cont = dbca->dbca_cont;
+
+	if (dbca->dbca_commit_req == NULL)
+		goto out;
 
 	while (!dss_ult_exiting(dbca->dbca_commit_req)) {
 		struct dtx_entry	**dtes = NULL;
@@ -287,6 +483,10 @@ dtx_batched_commit_one(void *arg)
 
 		dtx_stat(cont, &stat);
 
+		if (stat.dtx_pool_cmt_count >= DTX_AGG_THD_CNT_UP &&
+		    !dbca->dbca_pool->dbpa_aggregating)
+			sched_req_wakeup(dmi->dmi_dtx_agg_req);
+
 		if ((stat.dtx_committable_count <= DTX_THRESHOLD_COUNT) &&
 		    (stat.dtx_oldest_committable_time == 0 ||
 		     dtx_hlc_age2sec(stat.dtx_oldest_committable_time) <
@@ -296,6 +496,8 @@ dtx_batched_commit_one(void *arg)
 
 	sched_req_put(dbca->dbca_commit_req);
 	dbca->dbca_commit_req = NULL;
+
+out:
 	dtx_put_dbca(dbca);
 }
 
@@ -303,38 +505,52 @@ void
 dtx_batched_commit(void *arg)
 {
 	struct dss_module_info		*dmi = dss_get_module_info();
-	struct dtx_batched_commit_args	*dbca;
-	struct sched_request		*sched_req = NULL;
-	struct dtx_batched_commit_args	*tmp;
+	struct dtx_batched_cont_args	*dbca;
+	struct dtx_batched_cont_args	*tmp;
+	ABT_thread			 child;
+	int				 rc;
 
-	dtx_init_sched_req(NULL, &sched_req, ABT_THREAD_NULL);
-	if (sched_req == NULL) {
-		D_ERROR("Failed to get sched request.\n");
+	dtx_init_sched_req(NULL, &dmi->dmi_dtx_cmt_req, ABT_THREAD_NULL);
+	if (dmi->dmi_dtx_cmt_req == NULL) {
+		D_ERROR("Failed to get DTX batched commit sched request.\n");
 		return;
 	}
 
-	dmi->dmi_dtx_req = sched_req;
+	rc = dss_ult_create(dtx_aggregation_main, NULL,
+			    DSS_XS_SELF, 0, 0, &child);
+	if (rc != 0) {
+		D_ERROR("Fail to start DTX aggregation main ULT: "DF_RC"\n",
+			DP_RC(rc));
+		goto out;
+	}
+
+	dtx_init_sched_req(NULL, &dmi->dmi_dtx_agg_req, child);
+	if (dmi->dmi_dtx_cmt_req == NULL) {
+		D_ERROR("Failed to get DTX aggregation sched request.\n");
+		ABT_thread_join(child);
+		goto out;
+	}
+
 	dmi->dmi_dtx_batched_started = 1;
 
 	while (1) {
 		struct ds_cont_child	*cont;
 		struct dtx_stat		 stat = { 0 };
-		ABT_thread		 child = ABT_THREAD_NULL;
 		int			 sleep_time = 10; /* ms */
-		int			 rc;
 
-		if (d_list_empty(&dmi->dmi_dtx_batched_list))
+		if (d_list_empty(&dmi->dmi_dtx_batched_cont_list))
 			goto check;
 
 		if (DAOS_FAIL_CHECK(DAOS_DTX_NO_BATCHED_CMT) ||
 		    DAOS_FAIL_CHECK(DAOS_DTX_NO_COMMITTABLE))
 			goto check;
 
-		dbca = d_list_entry(dmi->dmi_dtx_batched_list.next,
-				    struct dtx_batched_commit_args, dbca_link);
-		dtx_get_dbca(dbca);
+		dbca = d_list_entry(dmi->dmi_dtx_batched_cont_list.next,
+				    struct dtx_batched_cont_args,
+				    dbca_sys_link);
 		cont = dbca->dbca_cont;
-		d_list_move_tail(&dbca->dbca_link, &dmi->dmi_dtx_batched_list);
+		d_list_move_tail(&dbca->dbca_sys_link,
+				 &dmi->dmi_dtx_batched_cont_list);
 		dtx_stat(cont, &stat);
 
 		if (!cont->sc_closing &&
@@ -365,38 +581,10 @@ dtx_batched_commit(void *arg)
 		}
 
 		if (!cont->sc_closing &&
-		    !dbca->dbca_deregister && dbca->dbca_agg_req == NULL &&
-		    (stat.dtx_committed_count >= DTX_AGG_THRESHOLD_CNT_UPPER ||
-		     (stat.dtx_committed_count > DTX_AGG_THRESHOLD_CNT_LOWER &&
-		      stat.dtx_oldest_committed_time != 0 &&
-		      dtx_hlc_age2sec(stat.dtx_oldest_committed_time) >=
-				DTX_AGG_THRESHOLD_AGE_UPPER))) {
-			sleep_time = 0;
-			dtx_get_dbca(dbca);
-			rc = dss_ult_create(dtx_aggregate, dbca,
-					    DSS_XS_SELF, 0, 0, &child);
-			if (rc != 0) {
-				D_WARN("Fail to start DTX ULT (2) for "
-				       DF_UUID": "DF_RC"\n",
-				       DP_UUID(cont->sc_uuid), DP_RC(rc));
-				dtx_put_dbca(dbca);
-			} else {
-				dtx_init_sched_req(cont, &dbca->dbca_agg_req,
-						   child);
-				if (dbca->dbca_agg_req == NULL) {
-					D_WARN("Fail to get sched req (2) for "
-					       DF_UUID"\n",
-					       DP_UUID(cont->sc_uuid));
-					ABT_thread_join(child);
-				}
-			}
-		}
-
-		if (!cont->sc_closing &&
 		    !dbca->dbca_deregister && dbca->dbca_cleanup_req == NULL &&
 		    stat.dtx_oldest_active_time != 0 &&
 		    dtx_hlc_age2sec(stat.dtx_oldest_active_time) >=
-		    DTX_CLEANUP_THRESHOLD_AGE_UPPER) {
+		    DTX_CLEANUP_THD_AGE_UP) {
 			sleep_time = 0;
 			dtx_get_dbca(dbca);
 			rc = dss_ult_create(dtx_cleanup_stale, dbca,
@@ -419,18 +607,22 @@ dtx_batched_commit(void *arg)
 			}
 		}
 
-		dtx_put_dbca(dbca);
-
 check:
 		if (dss_xstream_exiting(dmi->dmi_xstream))
 			break;
-		sched_req_sleep(sched_req, sleep_time);
-	}
-	dmi->dmi_dtx_req = NULL;
-	sched_req_put(sched_req);
 
-	d_list_for_each_entry_safe(dbca, tmp, &dmi->dmi_dtx_batched_list,
-				   dbca_link)
+		sched_req_sleep(dmi->dmi_dtx_cmt_req, sleep_time);
+	}
+
+	if (dmi->dmi_dtx_agg_req != NULL)
+		sched_req_wait(dmi->dmi_dtx_agg_req, true);
+
+out:
+	sched_req_put(dmi->dmi_dtx_cmt_req);
+	dmi->dmi_dtx_cmt_req = NULL;
+
+	d_list_for_each_entry_safe(dbca, tmp, &dmi->dmi_dtx_batched_cont_list,
+				   dbca_sys_link)
 		dbca->dbca_cont->sc_dtx_cos_shutdown = 1;
 
 	dmi->dmi_dtx_batched_started = 0;
@@ -1023,7 +1215,7 @@ dtx_leader_end(struct dtx_leader_handle *dlh, struct ds_cont_child *cont,
 				struct dss_module_info	*dmi;
 
 				dmi = dss_get_module_info();
-				sched_req_wakeup(dmi->dmi_dtx_req);
+				sched_req_wakeup(dmi->dmi_dtx_cmt_req);
 			}
 		}
 	} else {
@@ -1191,7 +1383,7 @@ dtx_end(struct dtx_handle *dth, struct ds_cont_child *cont, int result)
 
 static void
 dtx_flush_on_deregister(struct dss_module_info *dmi,
-			struct dtx_batched_commit_args *dbca)
+			struct dtx_batched_cont_args *dbca)
 {
 	struct ds_cont_child	*cont = dbca->dbca_cont;
 	struct dtx_stat		 stat = { 0 };
@@ -1238,10 +1430,13 @@ int
 dtx_batched_commit_register(struct ds_cont_child *cont)
 {
 	struct dss_module_info		*dmi = dss_get_module_info();
-	struct dtx_batched_commit_args	*dbca;
-	d_list_t			*head;
+	d_list_t			*pool_head;
+	d_list_t			*cont_head;
+	struct dtx_batched_pool_args	*dbpa;
+	struct dtx_batched_cont_args	*dbca;
 	struct umem_attr		 uma;
 	int				 rc;
+	bool				 new_pool = true;
 
 	/* If batched commit ULT is not enabled, then sync commit DTX. */
 	if (!dmi->dmi_dtx_batched_started) {
@@ -1252,16 +1447,39 @@ dtx_batched_commit_register(struct ds_cont_child *cont)
 	D_ASSERT(cont != NULL);
 	D_ASSERT(cont->sc_open > 0);
 
-	head = &dss_get_module_info()->dmi_dtx_batched_list;
-	d_list_for_each_entry(dbca, head, dbca_link)
-		/* NOT allow one container to register more than once unless
-		 * its former registered instance has already deregistered.
-		 */
-		D_ASSERT(dbca->dbca_cont != cont);
+	pool_head = &dmi->dmi_dtx_batched_pool_list;
+	cont_head = &dmi->dmi_dtx_batched_cont_list;
+
+	d_list_for_each_entry(dbpa, pool_head, dbpa_sys_link) {
+		if (dbpa->dbpa_pool == cont->sc_pool) {
+			/* NOT allow one container to register more than
+			 * once unless its former registered instance has
+			 * already deregistered.
+			 */
+			d_list_for_each_entry(dbca, &dbpa->dbpa_cont_list,
+					      dbca_pool_link)
+				D_ASSERT(dbca->dbca_cont != cont);
+			new_pool = false;
+			break;
+		}
+	}
+
+	if (new_pool) {
+		D_ALLOC_PTR(dbpa);
+		if (dbpa == NULL)
+			return -DER_NOMEM;
+
+		D_INIT_LIST_HEAD(&dbpa->dbpa_sys_link);
+		D_INIT_LIST_HEAD(&dbpa->dbpa_cont_list);
+		dbpa->dbpa_pool = cont->sc_pool;
+	}
 
 	D_ALLOC_PTR(dbca);
-	if (dbca == NULL)
+	if (dbca == NULL) {
+		if (new_pool)
+			D_FREE(dbpa);
 		return -DER_NOMEM;
+	}
 
 	/* Former dtx_batched_commit_deregister is waiting for
 	 * dtx_flush_on_deregister, we reopening the container.
@@ -1281,6 +1499,8 @@ dtx_batched_commit_register(struct ds_cont_child *cont)
 		D_ERROR("Failed to create DTX CoS btree: "DF_RC"\n",
 			DP_RC(rc));
 		D_FREE(dbca);
+		if (new_pool)
+			D_FREE(dbpa);
 		return rc;
 	}
 
@@ -1293,7 +1513,12 @@ add:
 	ds_cont_child_get(cont);
 	dbca->dbca_refs = 0;
 	dbca->dbca_cont = cont;
-	d_list_add_tail(&dbca->dbca_link, head);
+	dbca->dbca_pool = dbpa;
+	dbca->dbca_gen = dtx_agg_gen;
+	d_list_add_tail(&dbca->dbca_sys_link, cont_head);
+	d_list_add_tail(&dbca->dbca_pool_link, &dbpa->dbpa_cont_list);
+	if (new_pool)
+		d_list_add_tail(&dbpa->dbpa_sys_link, pool_head);
 
 out:
 	cont->sc_closing = 0;
@@ -1305,8 +1530,9 @@ out:
 void
 dtx_batched_commit_deregister(struct ds_cont_child *cont)
 {
-	struct dtx_batched_commit_args	*dbca;
-	d_list_t			*head;
+	struct dss_module_info		*dmi = dss_get_module_info();
+	struct dtx_batched_pool_args	*dbpa;
+	struct dtx_batched_cont_args	*dbca;
 
 	D_ASSERT(cont != NULL);
 	D_ASSERT(cont->sc_open == 0);
@@ -1315,18 +1541,25 @@ dtx_batched_commit_deregister(struct ds_cont_child *cont)
 	cont->sc_closing = 1;
 	cont->sc_dtx_cos_shutdown = 1;
 
-	head = &dss_get_module_info()->dmi_dtx_batched_list;
-	d_list_for_each_entry(dbca, head, dbca_link) {
-		if (dbca->dbca_cont == cont) {
-			/* Unlink the dbca firstly, then even if the container
-			 * is reopened during my waiting for current deregister,
-			 * it will not find current dbca.
-			 */
-			d_list_del_init(&dbca->dbca_link);
-			dbca->dbca_deregister = 1;
-			dtx_flush_on_deregister(dss_get_module_info(), dbca);
-			dtx_free_dbca(dbca);
-			return;
+	d_list_for_each_entry(dbpa, &dmi->dmi_dtx_batched_pool_list,
+			      dbpa_sys_link) {
+		if (dbpa->dbpa_pool == cont->sc_pool) {
+			d_list_for_each_entry(dbca, &dbpa->dbpa_cont_list,
+					      dbca_pool_link) {
+				if (dbca->dbca_cont == cont) {
+					/* Unlink the dbca firstly, then even
+					 * if the container is reopened during
+					 * my waiting for current deregister,
+					 * it will not find current dbca.
+					 */
+					d_list_del_init(&dbca->dbca_sys_link);
+					d_list_del_init(&dbca->dbca_pool_link);
+					dbca->dbca_deregister = 1;
+					dtx_flush_on_deregister(dmi, dbca);
+					dtx_free_dbca(dbca);
+					return;
+				}
+			}
 		}
 	}
 }
@@ -1362,7 +1595,7 @@ dtx_handle_resend(daos_handle_t coh,  struct dtx_id *dti,
 		return -DER_DATA_LOSS;
 	case -DER_NONEXIST:
 		age = dtx_hlc_age2sec(dti->dti_hlc);
-		if (age > DTX_AGG_THRESHOLD_AGE_LOWER ||
+		if (age > DTX_AGG_THD_AGE_LO ||
 		    DAOS_FAIL_CHECK(DAOS_DTX_LONG_TIME_RESEND)) {
 			D_ERROR("Not sure about whether the old RPC "DF_DTI
 				" is resent or not. Age="DF_U64" s.\n",

--- a/src/dtx/dtx_internal.h
+++ b/src/dtx/dtx_internal.h
@@ -64,16 +64,16 @@ CRT_RPC_DECLARE(dtx, DAOS_ISEQ_DTX, DAOS_OSEQ_DTX);
  *	it cannot be too small; otherwise, handing resent RPC
  *	make hit uncertain case and got failure -DER_EP_OLD.
  */
-#define DTX_AGG_THRESHOLD_CNT_LOWER	(1 << 20)
+#define DTX_AGG_THD_CNT_LO	((1 << 19) * 6)
 
 /* The count threshold for triggerring DTX aggregation. */
-#define DTX_AGG_THRESHOLD_CNT_UPPER	((DTX_AGG_THRESHOLD_CNT_LOWER >> 1) * 3)
+#define DTX_AGG_THD_CNT_UP	((1 << 19) * 7)
 
 /* The time threshold for triggerring DTX aggregation. If the oldest
  * DTX in the DTX table exceeds such threshold, it will trigger DTX
  * aggregation locally.
  */
-#define DTX_AGG_THRESHOLD_AGE_UPPER	120
+#define DTX_AGG_THD_AGE_UP	210
 
 /* If DTX aggregation is triggered, then the DTXs with older ages than
  * this threshold will be aggregated.
@@ -81,18 +81,18 @@ CRT_RPC_DECLARE(dtx, DAOS_ISEQ_DTX, DAOS_OSEQ_DTX);
  * XXX: It cannot be too small; otherwise, handing resent RPC
  *	make hit uncertain case and got failure -DER_EP_OLD.
  */
-#define DTX_AGG_THRESHOLD_AGE_LOWER	90
+#define DTX_AGG_THD_AGE_LO	180
 
 /* The time threshold for triggerring DTX cleanup of stale entries.
  * If the oldest active DTX exceeds such threshold, it will trigger
  * DTX cleanup locally.
  */
-#define DTX_CLEANUP_THRESHOLD_AGE_UPPER	60
+#define DTX_CLEANUP_THD_AGE_UP	60
 
 /* If DTX cleanup for stale entries is triggered, then the DTXs with
  * older ages than this threshold will be cleanup.
  */
-#define DTX_CLEANUP_THRESHOLD_AGE_LOWER	45
+#define DTX_CLEANUP_THD_AGE_LO	45
 
 struct dtx_pool_metrics {
 	struct d_tm_node_t	*dpm_total[DTX_PROTO_SRV_RPC_COUNT];
@@ -116,6 +116,7 @@ dtx_tls_get(void)
 extern struct crt_proto_format dtx_proto_fmt;
 extern btr_ops_t dbtree_dtx_cf_ops;
 extern btr_ops_t dtx_btr_cos_ops;
+extern uint64_t dtx_agg_gen;
 
 /* dtx_common.c */
 int dtx_handle_reinit(struct dtx_handle *dth);

--- a/src/dtx/dtx_srv.c
+++ b/src/dtx/dtx_srv.c
@@ -294,6 +294,8 @@ dtx_setup(void)
 {
 	int	rc;
 
+	dtx_agg_gen = 1;
+
 	rc = dss_ult_create_all(dtx_batched_commit, NULL, true);
 	if (rc != 0)
 		D_ERROR("Failed to create DTX batched commit ULT: "DF_RC"\n",

--- a/src/engine/srv.c
+++ b/src/engine/srv.c
@@ -353,7 +353,8 @@ dss_srv_handler(void *arg)
 	dmi->dmi_xs_id	= dx->dx_xs_id;
 	dmi->dmi_tgt_id	= dx->dx_tgt_id;
 	dmi->dmi_ctx_id	= -1;
-	D_INIT_LIST_HEAD(&dmi->dmi_dtx_batched_list);
+	D_INIT_LIST_HEAD(&dmi->dmi_dtx_batched_cont_list);
+	D_INIT_LIST_HEAD(&dmi->dmi_dtx_batched_pool_list);
 
 	(void)pthread_setname_np(pthread_self(), dx->dx_name);
 

--- a/src/include/daos_srv/daos_engine.h
+++ b/src/include/daos_srv/daos_engine.h
@@ -197,10 +197,12 @@ struct dss_module_info {
 	/* the cart context id */
 	int			dmi_ctx_id;
 	uint32_t		dmi_dtx_batched_started:1;
-	d_list_t		dmi_dtx_batched_list;
+	d_list_t		dmi_dtx_batched_cont_list;
+	d_list_t		dmi_dtx_batched_pool_list;
 	/* the profile information */
 	struct daos_profile	*dmi_dp;
-	struct sched_request	*dmi_dtx_req;
+	struct sched_request	*dmi_dtx_cmt_req;
+	struct sched_request	*dmi_dtx_agg_req;
 };
 
 extern struct dss_module_key	daos_srv_modkey;

--- a/src/include/daos_srv/dtx_srv.h
+++ b/src/include/daos_srv/dtx_srv.h
@@ -161,9 +161,15 @@ struct dtx_leader_handle {
 struct dtx_stat {
 	uint64_t	dtx_committable_count;
 	uint64_t	dtx_oldest_committable_time;
-	uint64_t	dtx_committed_count;
-	uint64_t	dtx_oldest_committed_time;
 	uint64_t	dtx_oldest_active_time;
+	/* The epoch for the oldest entry in the 1st committed blob. */
+	uint64_t	dtx_first_cmt_blob_time_up;
+	/* The epoch for the newest entry in the 1st committed blob. */
+	uint64_t	dtx_first_cmt_blob_time_lo;
+	/* container-based committed DTX entries count. */
+	uint32_t	dtx_cont_cmt_count;
+	/* pool-based committed DTX entries count. */
+	uint32_t	dtx_pool_cmt_count;
 };
 
 enum dtx_flags {

--- a/src/vos/vos_common.c
+++ b/src/vos/vos_common.c
@@ -245,13 +245,13 @@ vos_tx_begin(struct dtx_handle *dth, struct umem_instance *umm)
 
 int
 vos_tx_end(struct vos_container *cont, struct dtx_handle *dth_in,
-	   struct vos_rsrvd_scm **rsrvd_scmp, d_list_t *nvme_exts, bool started,
-	   int err)
+	   struct vos_rsrvd_scm **rsrvd_scmp, d_list_t *nvme_exts,
+	   bool started, int err)
 {
 	struct dtx_handle	*dth = dth_in;
 	struct dtx_rsrvd_uint	*dru;
+	struct vos_dtx_cmt_ent	*dce = NULL;
 	struct dtx_handle	 tmp = {0};
-	int			 rc = err;
 
 	if (!dtx_is_valid_handle(dth)) {
 		/** Created a dummy dth handle for publishing extents */
@@ -283,25 +283,30 @@ vos_tx_end(struct vos_container *cont, struct dtx_handle *dth_in,
 	dth->dth_local_tx_started = 0;
 
 	if (dtx_is_valid_handle(dth_in) && err == 0)
-		err = vos_dtx_prepared(dth);
+		err = vos_dtx_prepared(dth, &dce);
 
 	if (err == 0)
-		rc = vos_tx_publish(dth, true);
+		err = vos_tx_publish(dth, true);
 
-	rc = umem_tx_end(vos_cont2umm(cont), rc);
+	err = umem_tx_end(vos_cont2umm(cont), err);
 
 cancel:
-	if (rc != 0) {
+	if (err != 0) {
 		/* The transaction aborted or failed to commit. */
 		vos_tx_publish(dth, false);
 		if (dtx_is_valid_handle(dth_in))
 			vos_dtx_cleanup_internal(dth);
 	}
 
-	if (err != 0)
-		return err;
+	if (dce != NULL) {
+		struct vos_dtx_act_ent	*dae = dth_in->dth_ent;
 
-	return rc;
+		vos_dtx_post_handle(cont, &dae, &dce, 1, false,
+				    err != 0 ? true : false);
+		dth_in->dth_ent = NULL;
+	}
+
+	return err;
 }
 
 /**

--- a/src/vos/vos_container.c
+++ b/src/vos/vos_container.c
@@ -185,8 +185,6 @@ cont_free_internal(struct vos_container *cont)
 	if (cont->vc_dtx_array)
 		lrua_array_free(cont->vc_dtx_array);
 
-	D_ASSERT(d_list_empty(&cont->vc_dtx_committed_list));
-	D_ASSERT(d_list_empty(&cont->vc_dtx_committed_tmp_list));
 	D_ASSERT(d_list_empty(&cont->vc_dtx_act_list));
 
 	dbtree_close(cont->vc_btr_hdl);
@@ -370,11 +368,8 @@ vos_cont_open(daos_handle_t poh, uuid_t co_uuid, daos_handle_t *coh)
 	cont->vc_ts_idx = &cont->vc_cont_df->cd_ts_idx;
 	cont->vc_dtx_active_hdl = DAOS_HDL_INVAL;
 	cont->vc_dtx_committed_hdl = DAOS_HDL_INVAL;
-	D_INIT_LIST_HEAD(&cont->vc_dtx_committed_list);
-	D_INIT_LIST_HEAD(&cont->vc_dtx_committed_tmp_list);
 	D_INIT_LIST_HEAD(&cont->vc_dtx_act_list);
 	cont->vc_dtx_committed_count = 0;
-	cont->vc_dtx_committed_tmp_count = 0;
 	gc_check_cont(cont);
 
 	/* Cache this btr object ID in container handle */

--- a/src/vos/vos_dtx.c
+++ b/src/vos/vos_dtx.c
@@ -363,22 +363,14 @@ static int
 dtx_cmt_ent_alloc(struct btr_instance *tins, d_iov_t *key_iov,
 		  d_iov_t *val_iov, struct btr_record *rec)
 {
+	struct vos_tls		*tls = vos_tls_get();
 	struct vos_container	*cont = tins->ti_priv;
 	struct vos_dtx_cmt_ent	*dce = val_iov->iov_buf;
 
 	rec->rec_off = umem_ptr2off(&tins->ti_umm, dce);
-	if (!cont->vc_reindex_cmt_dtx || dce->dce_reindex) {
-		struct vos_tls *tls = vos_tls_get();
-
-		d_list_add_tail(&dce->dce_committed_link,
-				&cont->vc_dtx_committed_list);
-		cont->vc_dtx_committed_count++;
-		d_tm_inc_gauge(tls->vtl_committed, 1);
-	} else {
-		d_list_add_tail(&dce->dce_committed_link,
-				&cont->vc_dtx_committed_tmp_list);
-		cont->vc_dtx_committed_tmp_count++;
-	}
+	cont->vc_dtx_committed_count++;
+	cont->vc_pool->vp_dtx_committed_count++;
+	d_tm_inc_gauge(tls->vtl_committed, 1);
 
 	return 0;
 }
@@ -387,6 +379,7 @@ static int
 dtx_cmt_ent_free(struct btr_instance *tins, struct btr_record *rec,
 		 void *args)
 {
+	struct vos_tls		*tls = vos_tls_get();
 	struct vos_container	*cont = tins->ti_priv;
 	struct vos_dtx_cmt_ent	*dce;
 
@@ -394,16 +387,10 @@ dtx_cmt_ent_free(struct btr_instance *tins, struct btr_record *rec,
 	D_ASSERT(dce != NULL);
 
 	rec->rec_off = UMOFF_NULL;
-	d_list_del(&dce->dce_committed_link);
-	if (!cont->vc_reindex_cmt_dtx || dce->dce_reindex) {
-		struct vos_tls *tls = vos_tls_get();
-
-		cont->vc_dtx_committed_count--;
-		d_tm_dec_gauge(tls->vtl_committed, 1);
-	} else {
-		cont->vc_dtx_committed_tmp_count--;
-	}
+	cont->vc_dtx_committed_count--;
+	cont->vc_pool->vp_dtx_committed_count--;
 	D_FREE_PTR(dce);
+	d_tm_dec_gauge(tls->vtl_committed, 1);
 
 	return 0;
 }
@@ -1638,7 +1625,7 @@ handle_df:
 }
 
 int
-vos_dtx_prepared(struct dtx_handle *dth)
+vos_dtx_prepared(struct dtx_handle *dth, struct vos_dtx_cmt_ent **dce_p)
 {
 	struct vos_dtx_act_ent		*dae;
 	struct vos_container		*cont;
@@ -1659,19 +1646,15 @@ vos_dtx_prepared(struct dtx_handle *dth)
 
 	if (dth->dth_solo) {
 		rc = vos_dtx_commit_internal(cont, &dth->dth_xid, 1,
-					     dth->dth_epoch, NULL, NULL, NULL);
+					     dth->dth_epoch, NULL, NULL, dce_p);
 		dth->dth_active = 0;
-		if (rc >= 0)
+		dth->dth_pinned = 0;
+		if (rc >= 0) {
 			dth->dth_sync = 1;
-
-		if (dae != NULL) {
-			vos_dtx_post_handle(cont, &dae, NULL, 1,
-					    rc < 0 ? true : false);
-			dth->dth_ent = NULL;
-			dth->dth_pinned = 0;
+			rc = 0;
 		}
 
-		return rc > 0 ? 0 : rc;
+		return rc;
 	}
 
 	D_ASSERT(dae != NULL);
@@ -2015,21 +1998,22 @@ out:
 }
 
 void
-vos_dtx_post_handle(struct vos_container *cont, struct vos_dtx_act_ent **daes,
-		    struct vos_dtx_cmt_ent **dces, int count, bool abort)
+vos_dtx_post_handle(struct vos_container *cont,
+		    struct vos_dtx_act_ent **daes,
+		    struct vos_dtx_cmt_ent **dces,
+		    int count, bool abort, bool rollback)
 {
-	int	rc;
-	int	i;
+	d_iov_t		kiov;
+	int		rc;
+	int		i;
 
-	for (i = 0; i < count; i++) {
-		d_iov_t		kiov;
+	if (rollback) {
+		D_ASSERT(!abort);
 
-		if (daes[i] == NULL)
-			continue;
+		if (dces == NULL)
+			return;
 
-		if (dces != NULL) {
-			D_ASSERT(!abort);
-
+		for (i = 0; i < count; i++) {
 			if (dces[i] == NULL)
 				continue;
 
@@ -2043,9 +2027,14 @@ vos_dtx_post_handle(struct vos_container *cont, struct vos_dtx_act_ent **daes,
 				       DP_DTI(&DCE_XID(dces[i])), DP_RC(rc));
 				dces[i]->dce_invalid = 1;
 			}
-
-			continue;
 		}
+
+		return;
+	}
+
+	for (i = 0; i < count; i++) {
+		if (daes[i] == NULL)
+			continue;
 
 		d_iov_set(&kiov, &DAE_XID(daes[i]), sizeof(DAE_XID(daes[i])));
 		rc = dbtree_delete(cont->vc_dtx_active_hdl, BTR_PROBE_EQ,
@@ -2098,14 +2087,16 @@ vos_dtx_commit(daos_handle_t coh, struct dtx_id *dtis, int count, bool *rm_cos)
 	/* Commit multiple DTXs via single PMDK transaction. */
 	rc = umem_tx_begin(vos_cont2umm(cont), NULL);
 	if (rc == 0) {
-		committed = vos_dtx_commit_internal(cont, dtis, count,
-						    0, rm_cos, daes, dces);
+		committed = vos_dtx_commit_internal(cont, dtis, count, 0,
+						    rm_cos, daes, dces);
 		rc = umem_tx_end(vos_cont2umm(cont),
 				 committed > 0 ? 0 : committed);
 		if (rc == 0)
-			vos_dtx_post_handle(cont, daes, NULL, count, false);
+			vos_dtx_post_handle(cont, daes, dces,
+					    count, false, false);
 		else
-			vos_dtx_post_handle(cont, daes, dces, count, false);
+			vos_dtx_post_handle(cont, daes, dces,
+					    count, false, true);
 	}
 
 out:
@@ -2152,7 +2143,8 @@ vos_dtx_abort(daos_handle_t coh, daos_epoch_t epoch, struct dtx_id *dtis,
 
 		rc = umem_tx_end(vos_cont2umm(cont), aborted > 0 ? 0 : rc);
 		if (rc == 0)
-			vos_dtx_post_handle(cont, daes, NULL, count, true);
+			vos_dtx_post_handle(cont, daes, NULL, count,
+					    true, false);
 	}
 
 	D_FREE(daes);
@@ -2256,6 +2248,7 @@ out:
 	if (rc != 0)
 		D_ERROR("Failed to aggregate DTX blob "UMOFF_PF": "
 			DF_RC"\n", UMOFF_P(dbd_off), DP_RC(rc));
+
 	return rc;
 }
 
@@ -2263,11 +2256,10 @@ void
 vos_dtx_stat(daos_handle_t coh, struct dtx_stat *stat, uint32_t flags)
 {
 	struct vos_container	*cont;
+	struct vos_cont_df	*cont_df;
 
 	cont = vos_hdl2cont(coh);
 	D_ASSERT(cont != NULL);
-
-	stat->dtx_committed_count = cont->vc_dtx_committed_count;
 
 	if (d_list_empty(&cont->vc_dtx_act_list)) {
 		stat->dtx_oldest_active_time = 0;
@@ -2294,14 +2286,42 @@ vos_dtx_stat(daos_handle_t coh, struct dtx_stat *stat, uint32_t flags)
 	}
 
 cmt:
-	if (d_list_empty(&cont->vc_dtx_committed_list)) {
-		stat->dtx_oldest_committed_time = 0;
-	} else {
-		struct vos_dtx_cmt_ent	*dce;
+	stat->dtx_cont_cmt_count = cont->vc_dtx_committed_count;
+	stat->dtx_pool_cmt_count = cont->vc_pool->vp_dtx_committed_count;
 
-		dce = d_list_entry(cont->vc_dtx_committed_list.next,
-				   struct vos_dtx_cmt_ent, dce_committed_link);
-		stat->dtx_oldest_committed_time = DCE_EPOCH(dce);
+	stat->dtx_first_cmt_blob_time_up = 0;
+	stat->dtx_first_cmt_blob_time_lo = 0;
+	cont_df = cont->vc_cont_df;
+
+	if (!umoff_is_null(cont_df->cd_dtx_committed_head)) {
+		struct umem_instance		*umm = vos_cont2umm(cont);
+		struct vos_dtx_blob_df		*dbd;
+		struct vos_dtx_cmt_ent_df	*dce;
+		int				 i;
+
+		dbd = umem_off2ptr(umm, cont_df->cd_dtx_committed_head);
+
+		for (i = 0; i < dbd->dbd_count; i++) {
+			dce = &dbd->dbd_committed_data[i];
+
+			if (!daos_is_zero_dti(&dce->dce_xid) &&
+			    dce->dce_epoch != 0) {
+				stat->dtx_first_cmt_blob_time_up =
+							dce->dce_epoch;
+				break;
+			}
+		}
+
+		for (i = dbd->dbd_count - 1; i > 0; i--) {
+			dce = &dbd->dbd_committed_data[i];
+
+			if (!daos_is_zero_dti(&dce->dce_xid) &&
+			    dce->dce_epoch != 0) {
+				stat->dtx_first_cmt_blob_time_lo =
+							dce->dce_epoch;
+				break;
+			}
+		}
 	}
 }
 
@@ -2529,18 +2549,8 @@ vos_dtx_cmt_reindex(daos_handle_t coh, void *hint)
 	*dbd_off = dbd->dbd_next;
 
 out:
-	if (rc > 0) {
-		struct vos_tls *tls = vos_tls_get();
-
-		d_list_splice_init(&cont->vc_dtx_committed_tmp_list,
-				   &cont->vc_dtx_committed_list);
-		cont->vc_dtx_committed_count +=
-				cont->vc_dtx_committed_tmp_count;
-		d_tm_inc_gauge(tls->vtl_committed,
-			       cont->vc_dtx_committed_tmp_count);
-		cont->vc_dtx_committed_tmp_count = 0;
+	if (rc > 0)
 		cont->vc_reindex_cmt_dtx = 0;
-	}
 
 	return rc;
 }
@@ -2628,6 +2638,7 @@ vos_dtx_pin(struct dtx_handle *dth, bool persistent)
 	struct vos_container	*cont;
 	struct umem_instance	*umm = NULL;
 	struct vos_dtx_blob_df	*dbd = NULL;
+	struct vos_dtx_cmt_ent	*dce = NULL;
 	bool			 began = false;
 	int			 rc = 0;
 
@@ -2682,7 +2693,7 @@ vos_dtx_pin(struct dtx_handle *dth, bool persistent)
 	if (rc == 0) {
 		if (persistent) {
 			dth->dth_active = 1;
-			rc = vos_dtx_prepared(dth);
+			rc = vos_dtx_prepared(dth, &dce);
 		} else {
 			dth->dth_pinned = 1;
 		}
@@ -2699,8 +2710,16 @@ out:
 			DP_DTI(&dth->dth_xid), DP_RC(rc));
 	}
 
-	if (began)
+	if (began) {
 		rc = umem_tx_end(umm, rc);
+		if (dce != NULL) {
+			struct vos_dtx_act_ent	*dae = dth->dth_ent;
+
+			vos_dtx_post_handle(cont, &dae, &dce, 1,
+					    false, rc != 0 ? true : false);
+			dth->dth_ent = NULL;
+		}
+	}
 
 	return rc;
 }
@@ -2770,13 +2789,9 @@ vos_dtx_cache_reset(daos_handle_t coh)
 	if (cont->vc_dtx_array)
 		lrua_array_free(cont->vc_dtx_array);
 
-	D_ASSERT(d_list_empty(&cont->vc_dtx_committed_list));
-	D_ASSERT(d_list_empty(&cont->vc_dtx_committed_tmp_list));
-
 	cont->vc_dtx_active_hdl = DAOS_HDL_INVAL;
 	cont->vc_dtx_committed_hdl = DAOS_HDL_INVAL;
 	cont->vc_dtx_committed_count = 0;
-	cont->vc_dtx_committed_tmp_count = 0;
 
 	rc = lrua_array_alloc(&cont->vc_dtx_array, DTX_ARRAY_LEN, DTX_ARRAY_NR,
 			      sizeof(struct vos_dtx_act_ent),

--- a/src/vos/vos_internal.h
+++ b/src/vos/vos_internal.h
@@ -165,6 +165,8 @@ struct vos_pool {
 	daos_size_t		vp_space_held[DAOS_MEDIA_MAX];
 	/** Dedup hash */
 	struct d_hash_table	*vp_dedup_hash;
+	/* The count of committed DTXs for the whole pool. */
+	uint32_t		 vp_dtx_committed_count;
 };
 
 /**
@@ -189,16 +191,10 @@ struct vos_container {
 	struct btr_root		vc_dtx_active_btr;
 	/** The root of the B+ tree for committed DTXs. */
 	struct btr_root		vc_dtx_committed_btr;
-	/* The global list for committed DTXs. */
-	d_list_t		vc_dtx_committed_list;
-	/* The temporary list for committed DTXs during re-index. */
-	d_list_t		vc_dtx_committed_tmp_list;
 	/* The list for active DTXs, roughly ordered in time. */
 	d_list_t		vc_dtx_act_list;
 	/* The count of committed DTXs. */
 	uint32_t		vc_dtx_committed_count;
-	/* The items count in vc_dtx_committed_tmp_list. */
-	uint32_t		vc_dtx_committed_tmp_count;
 	/** Index for timestamp lookup */
 	uint32_t		*vc_ts_idx;
 	/** Direct pointer to the VOS container */
@@ -307,8 +303,6 @@ do {						\
 #define DAE_MBS_OFF(dae)	((dae)->dae_base.dae_mbs_off)
 
 struct vos_dtx_cmt_ent {
-	/* Link into vos_conter::vc_dtx_committed_list */
-	d_list_t			 dce_committed_link;
 	struct vos_dtx_cmt_ent_df	 dce_base;
 
 	uint32_t			 dce_reindex:1,
@@ -493,7 +487,7 @@ vos_dtx_deregister_record(struct umem_instance *umm, daos_handle_t coh,
  * \return		0 on success and negative on failure.
  */
 int
-vos_dtx_prepared(struct dtx_handle *dth);
+vos_dtx_prepared(struct dtx_handle *dth, struct vos_dtx_cmt_ent **dce_p);
 
 int
 vos_dtx_commit_internal(struct vos_container *cont, struct dtx_id *dtis,
@@ -501,8 +495,10 @@ vos_dtx_commit_internal(struct vos_container *cont, struct dtx_id *dtis,
 			struct vos_dtx_act_ent **daes,
 			struct vos_dtx_cmt_ent **dces);
 void
-vos_dtx_post_handle(struct vos_container *cont, struct vos_dtx_act_ent **daes,
-		    struct vos_dtx_cmt_ent **dces, int count, bool abort);
+vos_dtx_post_handle(struct vos_container *cont,
+		    struct vos_dtx_act_ent **daes,
+		    struct vos_dtx_cmt_ent **dces,
+		    int count, bool abort, bool rollback);
 
 /**
  * Establish indexed active DTX table in DRAM.

--- a/src/vos/vos_io.c
+++ b/src/vos/vos_io.c
@@ -2289,15 +2289,16 @@ abort:
 	if (err == 0) {
 		vos_ts_set_upgrade(ioc->ic_ts_set);
 		if (daes != NULL) {
-			vos_dtx_post_handle(ioc->ic_cont, daes, NULL,
-					    dth->dth_dti_cos_count, false);
+			vos_dtx_post_handle(ioc->ic_cont, daes, dces,
+					    dth->dth_dti_cos_count,
+					    false, false);
 			dth->dth_cos_done = 1;
 		}
 		vos_dedup_process(vos_cont2pool(ioc->ic_cont),
 				  &ioc->ic_dedup_entries, false);
 	} else if (daes != NULL) {
 		vos_dtx_post_handle(ioc->ic_cont, daes, dces,
-				    dth->dth_dti_cos_count, false);
+				    dth->dth_dti_cos_count, false, true);
 		dth->dth_cos_done = 0;
 	}
 

--- a/src/vos/vos_obj.c
+++ b/src/vos/vos_obj.c
@@ -417,13 +417,14 @@ reset:
 	if (rc == 0) {
 		vos_ts_set_upgrade(ts_set);
 		if (daes != NULL) {
-			vos_dtx_post_handle(cont, daes, NULL,
-					    dth->dth_dti_cos_count, false);
+			vos_dtx_post_handle(cont, daes, dces,
+					    dth->dth_dti_cos_count,
+					    false, false);
 			dth->dth_cos_done = 1;
 		}
 	} else if (daes != NULL) {
-		vos_dtx_post_handle(cont, daes, dces, dth->dth_dti_cos_count,
-				    false);
+		vos_dtx_post_handle(cont, daes, dces,
+				    dth->dth_dti_cos_count, false, true);
 		dth->dth_cos_done = 1;
 	}
 

--- a/src/vos/vos_pool.c
+++ b/src/vos/vos_pool.c
@@ -696,6 +696,7 @@ pool_open(PMEMobjpool *ph, struct vos_pool_df *pool_df, uuid_t uuid,
 		D_GOTO(failed, rc);
 	}
 
+	pool->vp_dtx_committed_count = 0;
 	pool->vp_pool_df = pool_df;
 	pool->vp_opened = 1;
 	pool->vp_excl = !!(flags & VOS_POF_EXCL);


### PR DESCRIPTION
Currently, the committed DTX table in DRAM in container based. For
the committed DTX table, the count threshold of DTX aggregation is
about 1^20 entries. If there are multiple (assume 'N') containers
maintained by the same engine, then there maybe at most 1^ 20 * N
committed DTX entries. If "N" is too large, then may cause server
out of memory.

This patch changes the container based DTX aggregation threshold
as pool based. Then the total committed DTX entries in DRAM will
be much reduced for multiple containers case.

The DTX aggregation thresholds are also adjusted:

1. Count threshold: 1^20 => 1^20 * 3
2. Time threshold: 90 sec => 180 sec

The in-DRAM committed DTX entry size is reduced to 36 bytes per entry.

Signed-off-by: Fan Yong <fan.yong@intel.com>