### PR TITLE
DAOS-8103 cont: add new container types

### DIFF
--- a/src/client/dfs/duns.c
+++ b/src/client/dfs/duns.c
@@ -204,7 +204,7 @@ duns_resolve_lustre_path(const char *path, struct duns_attr_t *attr)
 	}
 
 	daos_parse_ctype(t, &attr->da_type);
-	if (attr->da_type == DAOS_PROP_CO_LAYOUT_UNKOWN) {
+	if (attr->da_type == DAOS_PROP_CO_LAYOUT_UNKNOWN) {
 		D_ERROR("Invalid DAOS LMV format: Container layout cannot be"
 			" unknown\n");
 		return EINVAL;
@@ -565,7 +565,7 @@ duns_parse_attr(char *str, daos_size_t len, struct duns_attr_t *attr)
 		D_GOTO(err, rc = EINVAL);
 	}
 	daos_parse_ctype(t, &attr->da_type);
-	if (attr->da_type == DAOS_PROP_CO_LAYOUT_UNKOWN) {
+	if (attr->da_type == DAOS_PROP_CO_LAYOUT_UNKNOWN) {
 		D_ERROR("Invalid DAOS xattr format: Container layout cannot be unknown\n");
 		D_GOTO(err, rc = EINVAL);
 	}
@@ -796,20 +796,7 @@ duns_create_path(daos_handle_t poh, const char *path, struct duns_attr_t *attrp)
 		return rc;
 	}
 
-	if (attrp->da_type == DAOS_PROP_CO_LAYOUT_HDF5) {
-		/** create a new file if HDF5 container */
-		int fd;
-
-		fd = open(path, O_CREAT | O_EXCL, S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH);
-		if (fd == -1) {
-			rc = errno;
-
-			D_ERROR("Failed to create file %s: %s\n", path,
-				strerror(rc));
-			return rc;
-		}
-		close(fd);
-	} else if (attrp->da_type == DAOS_PROP_CO_LAYOUT_POSIX) {
+	if (attrp->da_type == DAOS_PROP_CO_LAYOUT_POSIX) {
 		struct statfs   fs;
 		char            *dir, *dirp;
 		mode_t		mode = S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH;
@@ -851,6 +838,19 @@ duns_create_path(daos_handle_t poh, const char *path, struct duns_attr_t *attrp)
 			D_ERROR("Failed to create dir %s: %s\n", path, strerror(rc));
 			return rc;
 		}
+	} else if (attrp->da_type != DAOS_PROP_CO_LAYOUT_UNKNOWN) {
+		/** create a new file for other container types */
+		int fd;
+
+		fd = open(path, O_CREAT | O_EXCL, S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH);
+		if (fd == -1) {
+			rc = errno;
+
+			D_ERROR("Failed to create file %s: %s\n", path,
+				strerror(rc));
+			return rc;
+		}
+		close(fd);
 	} else {
 		D_ERROR("Invalid container layout.\n");
 		return EINVAL;
@@ -919,10 +919,10 @@ duns_create_path(daos_handle_t poh, const char *path, struct duns_attr_t *attrp)
 
 	return rc;
 err_link:
-	if (attrp->da_type == DAOS_PROP_CO_LAYOUT_HDF5)
-		unlink(path);
-	else if (attrp->da_type == DAOS_PROP_CO_LAYOUT_POSIX)
+	if (attrp->da_type == DAOS_PROP_CO_LAYOUT_POSIX)
 		rmdir(path);
+	else if (attrp->da_type != DAOS_PROP_CO_LAYOUT_UNKNOWN)
+		unlink(path);
 	return rc;
 }
 
@@ -947,21 +947,7 @@ duns_destroy_path(daos_handle_t poh, const char *path)
 		return daos_der2errno(rc);
 	}
 
-	if (dattr.da_type == DAOS_PROP_CO_LAYOUT_HDF5) {
-#ifdef LUSTRE_INCLUDE
-		if (dattr.da_on_lustre)
-			rc = (*unlink_foreign)((char *)path);
-		else
-#endif
-			rc = unlink(path);
-		if (rc) {
-			int err = errno;
-
-			D_ERROR("Failed to unlink %sfile %s: %s\n",
-				dattr.da_on_lustre ? "Lustre " : " ", path, strerror(errno));
-			return err;
-		}
-	} else if (dattr.da_type == DAOS_PROP_CO_LAYOUT_POSIX) {
+	if (dattr.da_type == DAOS_PROP_CO_LAYOUT_POSIX) {
 #ifdef LUSTRE_INCLUDE
 		if (dattr.da_on_lustre)
 			rc = (*unlink_foreign)((char *)path);
@@ -972,6 +958,20 @@ duns_destroy_path(daos_handle_t poh, const char *path)
 			int err = errno;
 
 			D_ERROR("Failed to remove %sdir %s: %s\n",
+				dattr.da_on_lustre ? "Lustre " : " ", path, strerror(errno));
+			return err;
+		}
+	} else if (dattr.da_type != DAOS_PROP_CO_LAYOUT_UNKNOWN) {
+#ifdef LUSTRE_INCLUDE
+		if (dattr.da_on_lustre)
+			rc = (*unlink_foreign)((char *)path);
+		else
+#endif
+			rc = unlink(path);
+		if (rc) {
+			int err = errno;
+
+			D_ERROR("Failed to unlink %sfile %s: %s\n",
 				dattr.da_on_lustre ? "Lustre " : " ", path, strerror(errno));
 			return err;
 		}

--- a/src/client/java/daos-java/src/main/java/io/daos/dfs/uns/PropType.java
+++ b/src/client/java/daos-java/src/main/java/io/daos/dfs/uns/PropType.java
@@ -132,8 +132,8 @@ public enum PropType
   /**
    * <pre>
    * *
-   * Layout type: unknown, POSIX, MPI-IO, HDF5, Apache Arrow, ...
-   * default value = DAOS_PROP_CO_LAYOUT_UNKOWN
+   * Layout type: unknown, POSIX, HDF5, Python, ...
+   * default value = DAOS_PROP_CO_LAYOUT_UNKNOWN
    * </pre>
    *
    * <code>DAOS_PROP_CO_LAYOUT_TYPE = 4098;</code>
@@ -382,7 +382,7 @@ public enum PropType
    * <pre>
    * *
    * Layout type: unknown, POSIX, MPI-IO, HDF5, Apache Arrow, ...
-   * default value = DAOS_PROP_CO_LAYOUT_UNKOWN
+   * default value = DAOS_PROP_CO_LAYOUT_UNKNOWN
    * </pre>
    *
    * <code>DAOS_PROP_CO_LAYOUT_TYPE = 4098;</code>

--- a/src/client/java/daos-java/src/main/native/include/DunsAttribute.pb-c.h
+++ b/src/client/java/daos-java/src/main/native/include/DunsAttribute.pb-c.h
@@ -98,7 +98,7 @@ typedef enum _Uns__PropType {
   /*
    **
    * Layout type: unknown, POSIX, MPI-IO, HDF5, Apache Arrow, ...
-   * default value = DAOS_PROP_CO_LAYOUT_UNKOWN
+   * default value = DAOS_PROP_CO_LAYOUT_UNKNOWN
    */
   UNS__PROP_TYPE__DAOS_PROP_CO_LAYOUT_TYPE = 4098,
   /*

--- a/src/client/java/daos-java/src/main/resources/DunsAttribute.proto
+++ b/src/client/java/daos-java/src/main/resources/DunsAttribute.proto
@@ -63,7 +63,7 @@ enum PropType {
   DAOS_PROP_CO_LABEL = 0x1001;
   /**
    * Layout type: unknown, POSIX, MPI-IO, HDF5, Apache Arrow, ...
-   * default value = DAOS_PROP_CO_LAYOUT_UNKOWN
+   * default value = DAOS_PROP_CO_LAYOUT_UNKNOWN
    */
   DAOS_PROP_CO_LAYOUT_TYPE = 0x1002;
   /**

--- a/src/client/pydaos/raw/daos_api.py
+++ b/src/client/pydaos/raw/daos_api.py
@@ -1282,7 +1282,7 @@ class DaosContainer():
             else:
                 # TODO: This should ideally fail.
                 self.cont_prop.dpp_entries[idx].dpe_val = ctypes.c_uint64(
-                    DaosContPropEnum.DAOS_PROP_CO_LAYOUT_UNKOWN.value)
+                    DaosContPropEnum.DAOS_PROP_CO_LAYOUT_UNKNOWN.value)
             idx = idx + 1
         # If checksum flag is enabled.
         if self.cont_input_values.enable_chksum is True:

--- a/src/common/prop.c
+++ b/src/common/prop.c
@@ -324,9 +324,7 @@ daos_prop_valid(daos_prop_t *prop, bool pool, bool input)
 			break;
 		case DAOS_PROP_CO_LAYOUT_TYPE:
 			val = prop->dpp_entries[i].dpe_val;
-			if (val != DAOS_PROP_CO_LAYOUT_UNKOWN &&
-			    val != DAOS_PROP_CO_LAYOUT_POSIX &&
-			    val != DAOS_PROP_CO_LAYOUT_HDF5) {
+			if (val >= DAOS_PROP_CO_LAYOUT_MAX) {
 				D_ERROR("invalid layout type "DF_U64".\n", val);
 				return false;
 			}

--- a/src/container/srv_layout.c
+++ b/src/container/srv_layout.c
@@ -57,7 +57,7 @@ struct daos_prop_entry cont_prop_entries_default[CONT_PROP_NUM] = {
 		.dpe_str	= "container_label_not_set",
 	}, {
 		.dpe_type	= DAOS_PROP_CO_LAYOUT_TYPE,
-		.dpe_val	= DAOS_PROP_CO_LAYOUT_UNKOWN,
+		.dpe_val	= DAOS_PROP_CO_LAYOUT_UNKNOWN,
 	}, {
 		.dpe_type	= DAOS_PROP_CO_LAYOUT_VER,
 		.dpe_val	= 1,

--- a/src/include/daos/common.h
+++ b/src/include/daos/common.h
@@ -869,8 +869,22 @@ daos_parse_ctype(const char *string, daos_cont_layout_t *type)
 		*type = DAOS_PROP_CO_LAYOUT_HDF5;
 	else if (strcasecmp(string, "POSIX") == 0)
 		*type = DAOS_PROP_CO_LAYOUT_POSIX;
+	else if (strcasecmp(string, "PYTHON") == 0)
+		*type = DAOS_PROP_CO_LAYOUT_PYTHON;
+	else if (strcasecmp(string, "DATABASE") == 0 ||
+		 strcasecmp(string, "DB") == 0)
+		*type = DAOS_PROP_CO_LAYOUT_DATABASE;
+	else if (strcasecmp(string, "ROOT") == 0 ||
+		 strcasecmp(string, "RNTuple") == 0)
+		*type = DAOS_PROP_CO_LAYOUT_ROOT;
+	else if (strcasecmp(string, "SEISMIC") == 0 ||
+		 strcasecmp(string, "DSG") == 0)
+		*type = DAOS_PROP_CO_LAYOUT_SEISMIC;
+	else if (strcasecmp(string, "METEO") == 0 ||
+		 strcasecmp(string, "FDB") == 0)
+		*type = DAOS_PROP_CO_LAYOUT_METEO;
 	else
-		*type = DAOS_PROP_CO_LAYOUT_UNKOWN;
+		*type = DAOS_PROP_CO_LAYOUT_UNKNOWN;
 }
 
 static inline void
@@ -882,6 +896,21 @@ daos_unparse_ctype(daos_cont_layout_t ctype, char *string)
 		break;
 	case DAOS_PROP_CO_LAYOUT_HDF5:
 		strcpy(string, "HDF5");
+		break;
+	case DAOS_PROP_CO_LAYOUT_PYTHON:
+		strcpy(string, "PYTHON");
+		break;
+	case DAOS_PROP_CO_LAYOUT_DATABASE:
+		strcpy(string, "DATABASE");
+		break;
+	case DAOS_PROP_CO_LAYOUT_ROOT:
+		strcpy(string, "ROOT");
+		break;
+	case DAOS_PROP_CO_LAYOUT_SEISMIC:
+		strcpy(string, "SEISMIC");
+		break;
+	case DAOS_PROP_CO_LAYOUT_METEO:
+		strcpy(string, "METEO");
 		break;
 	default:
 		strcpy(string, "unknown");

--- a/src/include/daos/common.h
+++ b/src/include/daos/common.h
@@ -871,6 +871,8 @@ daos_parse_ctype(const char *string, daos_cont_layout_t *type)
 		*type = DAOS_PROP_CO_LAYOUT_POSIX;
 	else if (strcasecmp(string, "PYTHON") == 0)
 		*type = DAOS_PROP_CO_LAYOUT_PYTHON;
+	else if (strcasecmp(string, "SPARK") == 0)
+		*type = DAOS_PROP_CO_LAYOUT_SPARK;
 	else if (strcasecmp(string, "DATABASE") == 0 ||
 		 strcasecmp(string, "DB") == 0)
 		*type = DAOS_PROP_CO_LAYOUT_DATABASE;
@@ -899,6 +901,9 @@ daos_unparse_ctype(daos_cont_layout_t ctype, char *string)
 		break;
 	case DAOS_PROP_CO_LAYOUT_PYTHON:
 		strcpy(string, "PYTHON");
+		break;
+	case DAOS_PROP_CO_LAYOUT_SPARK:
+		strcpy(string, "SPARK");
 		break;
 	case DAOS_PROP_CO_LAYOUT_DATABASE:
 		strcpy(string, "DATABASE");

--- a/src/include/daos_prop.h
+++ b/src/include/daos_prop.h
@@ -218,6 +218,7 @@ enum {
 	DAOS_PROP_CO_LAYOUT_POSIX,	/** DFS/dfuse/MPI-IO */
 	DAOS_PROP_CO_LAYOUT_HDF5,	/** HDF5 DAOS VOL connector */
 	DAOS_PROP_CO_LAYOUT_PYTHON,	/** PyDAOS */
+	DAOS_PROP_CO_LAYOUT_SPARK,	/** Specific layout for Spark shuffle */
 	DAOS_PROP_CO_LAYOUT_DATABASE,	/** SQL Database */
 	DAOS_PROP_CO_LAYOUT_ROOT,	/** ROOT/RNTuple format */
 	DAOS_PROP_CO_LAYOUT_SEISMIC,	/** Seismic Graph, aka SEGY */

--- a/src/include/daos_prop.h
+++ b/src/include/daos_prop.h
@@ -101,8 +101,8 @@ enum daos_cont_props {
 	 */
 	DAOS_PROP_CO_LABEL,
 	/**
-	 * Layout type: unknown, POSIX, MPI-IO, HDF5, Apache Arrow, ...
-	 * default value = DAOS_PROP_CO_LAYOUT_UNKOWN
+	 * Layout type: unknown, POSIX, HDF5, Python, Database, Parquet, ...
+	 * default value = DAOS_PROP_CO_LAYOUT_UNKNOWN
 	 */
 	DAOS_PROP_CO_LAYOUT_TYPE,
 	/**
@@ -213,9 +213,16 @@ typedef uint16_t daos_cont_layout_t;
 
 /** container layout type */
 enum {
-	DAOS_PROP_CO_LAYOUT_UNKOWN,
-	DAOS_PROP_CO_LAYOUT_POSIX,
-	DAOS_PROP_CO_LAYOUT_HDF5,
+	DAOS_PROP_CO_LAYOUT_UNKNOWN,
+	DAOS_PROP_CO_LAYOUT_UNKOWN = DAOS_PROP_CO_LAYOUT_UNKNOWN,
+	DAOS_PROP_CO_LAYOUT_POSIX,	/** DFS/dfuse/MPI-IO */
+	DAOS_PROP_CO_LAYOUT_HDF5,	/** HDF5 DAOS VOL connector */
+	DAOS_PROP_CO_LAYOUT_PYTHON,	/** PyDAOS */
+	DAOS_PROP_CO_LAYOUT_DATABASE,	/** SQL Database */
+	DAOS_PROP_CO_LAYOUT_ROOT,	/** ROOT/RNTuple format */
+	DAOS_PROP_CO_LAYOUT_SEISMIC,	/** Seismic Graph, aka SEGY */
+	DAOS_PROP_CO_LAYOUT_METEO,	/** Meteorology, aka Field Data Base */
+	DAOS_PROP_CO_LAYOUT_MAX
 };
 
 /** container checksum type */

--- a/src/utils/daos_hdlr.c
+++ b/src/utils/daos_hdlr.c
@@ -2776,7 +2776,7 @@ set_dm_args_default(struct dm_args *dm)
 	dm->dst_coh = DAOS_HDL_INVAL;
 	dm->cont_prop_oid = DAOS_PROP_CO_ALLOCED_OID;
 	dm->cont_prop_layout = DAOS_PROP_CO_LAYOUT_TYPE;
-	dm->cont_layout = DAOS_PROP_CO_LAYOUT_UNKOWN;
+	dm->cont_layout = DAOS_PROP_CO_LAYOUT_UNKNOWN;
 	dm->cont_oid = 0;
 }
 

--- a/src/utils/daos_hdlr.h
+++ b/src/utils/daos_hdlr.h
@@ -146,7 +146,7 @@ struct cmd_args_s {
 
 #define ARGS_VERIFY_PATH_CREATE(ap, label, rcexpr)			\
 	do {								\
-		if (((ap)->type == DAOS_PROP_CO_LAYOUT_UNKOWN)) {	\
+		if (((ap)->type == DAOS_PROP_CO_LAYOUT_UNKNOWN)) {	\
 			fprintf(stderr, "create by --path : must also "	\
 					"specify --type\n");		\
 			D_GOTO(label, (rcexpr));			\
@@ -155,7 +155,7 @@ struct cmd_args_s {
 
 #define ARGS_VERIFY_PATH_NON_CREATE(ap, label, rcexpr)			\
 	do {								\
-		if (((ap)->type != DAOS_PROP_CO_LAYOUT_UNKOWN) ||	\
+		if (((ap)->type != DAOS_PROP_CO_LAYOUT_UNKNOWN) ||	\
 		    ((ap)->oclass != OC_UNKNOWN)	||		\
 		    ((ap)->chunk_size != 0)) {				\
 			fprintf(stderr, "query by --path : do not "	\


### PR DESCRIPTION
Add container types for new I/O middleware developped over DAOS.
Fix typo in DAOS_PROP_CO_LAYOUT_UNK(N)OWN.

Signed-off-by: Johann Lombardi <johann.lombardi@intel.com>