### PR TITLE
CART-963 tests: avoid redefinition of opts

### DIFF
--- a/src/cart/crt_utils.h
+++ b/src/cart/crt_utils.h
@@ -14,17 +14,17 @@
 
 #define DBG_PRINT(x...)							\
 	do {								\
-		struct test_options *opts;				\
-		opts = crtu_get_opts();					\
+		struct test_options *__opts;				\
+		__opts = crtu_get_opts();					\
 		D_INFO(x);						\
-		if (opts->is_server)					\
+		if (__opts->is_server)					\
 			fprintf(stderr, "SRV [rank=%d pid=%d]\t",       \
-			opts->self_rank,				\
-			opts->mypid);					\
+			__opts->self_rank,				\
+			__opts->mypid);					\
 		else							\
 			fprintf(stderr, "CLI [rank=%d pid=%d]\t",       \
-			opts->self_rank,				\
-			opts->mypid);					\
+			__opts->self_rank,				\
+			__opts->mypid);					\
 		fprintf(stderr, x);					\
 	} while (0)
 


### PR DESCRIPTION
In file included from src/cart/crt_utils.c:18:
src/cart/crt_utils.c: In function ‘write_completion_file’:
src/cart/crt_utils.h:17:38: warning: declaration of ‘opts’ shadows a global declaration [-Wshadow]
   17 |                 struct test_options *opts;                              \
      |                                      ^~~~
src/cart/crt_utils.c:117:9: note: in expansion of macro ‘DBG_PRINT’
  117 |         DBG_PRINT("Wrote completion file: %s.\n", completion_file);
      |         ^~~~~~~~~
src/cart/crt_utils.c:21:21: note: shadowed declaration is here
   21 | struct test_options opts = { .is_initialized = false };
      |                     ^~~~

See https://github.com/daos-stack/daos/runs/3088961924#step:5:437

Signed-off-by: Ethan Mallove <ethanx.a.mallove@intel.com>