### PR TITLE
DAOS-7671 api: more heap copies of attrs names and values

### DIFF
--- a/src/container/cli.c
+++ b/src/container/cli.c
@@ -2430,7 +2430,7 @@ attr_check_input(int n, char const *const names[], void const *const values[],
 }
 
 static int
-free_name(tse_task_t *task, void *args)
+free_heap_copy(tse_task_t *task, void *args)
 {
 	char *name = *(char **)args;
 
@@ -2478,13 +2478,12 @@ dc_cont_get_attr(tse_task_t *task)
 	D_ALLOC_ARRAY(new_names, args->n);
 	if (!new_names)
 		D_GOTO(out, rc = -DER_NOMEM);
-	rc = tse_task_register_comp_cb(task, free_name, &new_names,
+	rc = tse_task_register_comp_cb(task, free_heap_copy, &new_names,
 				       sizeof(char *));
 	if (rc) {
 		D_FREE(new_names);
 		D_GOTO(out, rc);
 	}
-
 	for (i = 0 ; i < args->n ; i++) {
 		uint64_t len;
 
@@ -2493,8 +2492,8 @@ dc_cont_get_attr(tse_task_t *task)
 		D_STRNDUP(new_names[i], args->names[i], len);
 		if (new_names[i] == NULL)
 			D_GOTO(out, rc = -DER_NOMEM);
-		rc = tse_task_register_comp_cb(task, free_name, &new_names[i],
-					       sizeof(char *));
+		rc = tse_task_register_comp_cb(task, free_heap_copy,
+					       &new_names[i], sizeof(char *));
 		if (rc) {
 			D_FREE(new_names[i]);
 			D_GOTO(out, rc);
@@ -2535,6 +2534,7 @@ dc_cont_set_attr(tse_task_t *task)
 	struct cont_req_arg	 cb_args;
 	int			 i, rc;
 	char			**new_names = NULL;
+	void			**new_values = NULL;
 
 	args = dc_task_get_args(task);
 	D_ASSERTF(args != NULL, "Task Argument OPC does not match DC OPC\n");
@@ -2560,31 +2560,55 @@ dc_cont_set_attr(tse_task_t *task)
 	/* no easy way to determine if a name storage address is likely
 	 * to cause an EFAULT during memory registration, so duplicate
 	 * name in heap
-	 * XXX may need to do the same for values ??
 	 */
 	D_ALLOC_ARRAY(new_names, args->n);
 	if (!new_names)
 		D_GOTO(out, rc = -DER_NOMEM);
-	rc = tse_task_register_comp_cb(task, free_name, &new_names,
+	rc = tse_task_register_comp_cb(task, free_heap_copy, &new_names,
 				       sizeof(char *));
 	if (rc) {
 		D_FREE(new_names);
 		D_GOTO(out, rc);
 	}
-
 	for (i = 0 ; i < args->n ; i++) {
 		D_STRNDUP(new_names[i], args->names[i], DAOS_ATTR_NAME_MAX);
 		if (new_names[i] == NULL)
 			D_GOTO(out, rc = -DER_NOMEM);
-		rc = tse_task_register_comp_cb(task, free_name, &new_names[i],
-					       sizeof(char *));
+		rc = tse_task_register_comp_cb(task, free_heap_copy,
+					       &new_names[i], sizeof(char *));
 		if (rc) {
 			D_FREE(new_names[i]);
 			D_GOTO(out, rc);
 		}
 	}
 
-	rc = attr_bulk_create(args->n, new_names, (void **)args->values,
+	/* no easy way to determine if a value storage address is likely
+	 * to cause an EFAULT during memory registration, so duplicate
+	 * value in heap
+	 */
+	D_ALLOC_ARRAY(new_values, args->n);
+	if (!new_values)
+		D_GOTO(out, rc = -DER_NOMEM);
+	rc = tse_task_register_comp_cb(task, free_heap_copy, &new_values,
+				       sizeof(char *));
+	if (rc) {
+		D_FREE(new_values);
+		D_GOTO(out, rc);
+	}
+	for (i = 0 ; i < args->n ; i++) {
+		D_ALLOC(new_values[i], args->sizes[i]);
+		if (new_values[i] == NULL)
+			D_GOTO(out, rc = -DER_NOMEM);
+		memcpy(new_values[i], args->values[i], args->sizes[i]);
+		rc = tse_task_register_comp_cb(task, free_heap_copy,
+					       &new_values[i], sizeof(char *));
+		if (rc) {
+			D_FREE(new_values[i]);
+			D_GOTO(out, rc);
+		}
+	}
+
+	rc = attr_bulk_create(args->n, new_names, new_values,
 			      (size_t *)args->sizes, daos_task2ctx(task),
 			      CRT_BULK_RO, &in->casi_bulk);
 	if (rc != 0) {
@@ -2616,7 +2640,8 @@ dc_cont_del_attr(tse_task_t *task)
 	daos_cont_set_attr_t	*args;
 	struct cont_attr_del_in	*in;
 	struct cont_req_arg	 cb_args;
-	int			 rc;
+	int			 i, rc;
+	char			**new_names;
 
 	args = dc_task_get_args(task);
 	D_ASSERTF(args != NULL, "Task Argument OPC does not match DC OPC\n");
@@ -2637,7 +2662,33 @@ dc_cont_del_attr(tse_task_t *task)
 
 	in = crt_req_get(cb_args.cra_rpc);
 	in->cadi_count = args->n;
-	rc = attr_bulk_create(args->n, (char **)args->names, NULL, NULL,
+
+	/* no easy way to determine if a name storage address is likely
+	 * to cause an EFAULT during memory registration, so duplicate
+	 * name in heap
+	 */
+	D_ALLOC_ARRAY(new_names, args->n);
+	if (!new_names)
+		D_GOTO(out, rc = -DER_NOMEM);
+	rc = tse_task_register_comp_cb(task, free_heap_copy, &new_names,
+				       sizeof(char *));
+	if (rc) {
+		D_FREE(new_names);
+		D_GOTO(out, rc);
+	}
+	for (i = 0 ; i < args->n ; i++) {
+		D_STRNDUP(new_names[i], args->names[i], DAOS_ATTR_NAME_MAX);
+		if (new_names[i] == NULL)
+			D_GOTO(out, rc = -DER_NOMEM);
+		rc = tse_task_register_comp_cb(task, free_heap_copy,
+					       &new_names[i], sizeof(char *));
+		if (rc) {
+			D_FREE(new_names[i]);
+			D_GOTO(out, rc);
+		}
+	}
+
+	rc = attr_bulk_create(args->n, new_names, NULL, NULL,
 			      daos_task2ctx(task), CRT_BULK_RO, &in->cadi_bulk);
 	if (rc != 0) {
 		cont_req_cleanup(CLEANUP_RPC, &cb_args);

--- a/src/pool/cli.c
+++ b/src/pool/cli.c
@@ -1999,7 +1999,7 @@ attr_check_input(int n, char const *const names[], void const *const values[],
 }
 
 static int
-free_name(tse_task_t *task, void *args)
+free_heap_copy(tse_task_t *task, void *args)
 {
 	char *name = *(char **)args;
 
@@ -2046,13 +2046,12 @@ dc_pool_get_attr(tse_task_t *task)
 	D_ALLOC_ARRAY(new_names, args->n);
 	if (!new_names)
 		D_GOTO(out, rc = -DER_NOMEM);
-	rc = tse_task_register_comp_cb(task, free_name, &new_names,
+	rc = tse_task_register_comp_cb(task, free_heap_copy, &new_names,
 				       sizeof(char *));
 	if (rc) {
 		D_FREE(new_names);
 		D_GOTO(out, rc);
 	}
-
 	for (i = 0 ; i < args->n ; i++) {
 		uint64_t len;
 
@@ -2061,8 +2060,8 @@ dc_pool_get_attr(tse_task_t *task)
 		D_STRNDUP(new_names[i], args->names[i], len);
 		if (new_names[i] == NULL)
 			D_GOTO(out, rc = -DER_NOMEM);
-		rc = tse_task_register_comp_cb(task, free_name, &new_names[i],
-					       sizeof(char *));
+		rc = tse_task_register_comp_cb(task, free_heap_copy,
+					       &new_names[i], sizeof(char *));
 		if (rc) {
 			D_FREE(new_names[i]);
 			D_GOTO(out, rc);
@@ -2102,6 +2101,7 @@ dc_pool_set_attr(tse_task_t *task)
 	struct pool_req_arg	 cb_args;
 	int			 i, rc;
 	char			**new_names = NULL;
+	void			**new_values = NULL;
 
 	args = dc_task_get_args(task);
 	D_ASSERTF(args != NULL, "Task Argument OPC does not match DC OPC\n");
@@ -2126,33 +2126,57 @@ dc_pool_set_attr(tse_task_t *task)
 	/* no easy way to determine if a name storage address is likely
 	 * to cause an EFAULT during memory registration, so duplicate
 	 * name in heap
-	 * XXX may need to do the same for values ??
 	 */
 	D_ALLOC_ARRAY(new_names, args->n);
 	if (!new_names)
 		D_GOTO(out, rc = -DER_NOMEM);
-	rc = tse_task_register_comp_cb(task, free_name, &new_names,
+	rc = tse_task_register_comp_cb(task, free_heap_copy, &new_names,
 				       sizeof(char *));
 	if (rc) {
 		D_FREE(new_names);
 		D_GOTO(out, rc);
 	}
-
 	for (i = 0 ; i < args->n ; i++) {
 		D_STRNDUP(new_names[i], args->names[i], DAOS_ATTR_NAME_MAX);
 		if (new_names[i] == NULL)
 			D_GOTO(out, rc = -DER_NOMEM);
-		rc = tse_task_register_comp_cb(task, free_name, &new_names[i],
-					       sizeof(char *));
+		rc = tse_task_register_comp_cb(task, free_heap_copy,
+					       &new_names[i], sizeof(char *));
 		if (rc) {
 			D_FREE(new_names[i]);
 			D_GOTO(out, rc);
 		}
 	}
 
-	rc = attr_bulk_create(args->n, new_names, (void **)args->values,
+	/* no easy way to determine if a value storage address is likely
+	 * to cause an EFAULT during memory registration, so duplicate
+	 * value in heap
+	 */
+	D_ALLOC_ARRAY(new_values, args->n);
+	if (!new_values)
+		D_GOTO(out, rc = -DER_NOMEM);
+	rc = tse_task_register_comp_cb(task, free_heap_copy, &new_values,
+				       sizeof(char *));
+	if (rc) {
+		D_FREE(new_values);
+		D_GOTO(out, rc);
+	}
+	for (i = 0 ; i < args->n ; i++) {
+		D_ALLOC(new_values[i], args->sizes[i]);
+		if (new_values[i] == NULL)
+			D_GOTO(out, rc = -DER_NOMEM);
+		memcpy(new_values[i], args->values[i], args->sizes[i]);
+		rc = tse_task_register_comp_cb(task, free_heap_copy,
+					       &new_values[i], sizeof(void *));
+		if (rc) {
+			D_FREE(new_values[i]);
+			D_GOTO(out, rc);
+		}
+	}
+
+	rc = attr_bulk_create(args->n, new_names, new_values,
 			      (size_t *)args->sizes, daos_task2ctx(task),
-			       CRT_BULK_RO, &in->pasi_bulk);
+			      CRT_BULK_RO, &in->pasi_bulk);
 	if (rc != 0) {
 		pool_req_cleanup(CLEANUP_RPC, &cb_args);
 		D_GOTO(out, rc);
@@ -2181,7 +2205,8 @@ dc_pool_del_attr(tse_task_t *task)
 	daos_pool_del_attr_t	*args;
 	struct pool_attr_del_in	*in;
 	struct pool_req_arg	 cb_args;
-	int			 rc;
+	int			 i, rc;
+	char			**new_names;
 
 	args = dc_task_get_args(task);
 	D_ASSERTF(args != NULL, "Task Argument OPC does not match DC OPC\n");
@@ -2201,7 +2226,33 @@ dc_pool_del_attr(tse_task_t *task)
 
 	in = crt_req_get(cb_args.pra_rpc);
 	in->padi_count = args->n;
-	rc = attr_bulk_create(args->n, (char **)args->names, NULL, NULL,
+
+	/* no easy way to determine if a name storage address is likely
+	 * to cause an EFAULT during memory registration, so duplicate
+	 * name in heap
+	 */
+	D_ALLOC_ARRAY(new_names, args->n);
+	if (!new_names)
+		D_GOTO(out, rc = -DER_NOMEM);
+	rc = tse_task_register_comp_cb(task, free_heap_copy, &new_names,
+				       sizeof(char *));
+	if (rc) {
+		D_FREE(new_names);
+		D_GOTO(out, rc);
+	}
+	for (i = 0 ; i < args->n ; i++) {
+		D_STRNDUP(new_names[i], args->names[i], DAOS_ATTR_NAME_MAX);
+		if (new_names[i] == NULL)
+			D_GOTO(out, rc = -DER_NOMEM);
+		rc = tse_task_register_comp_cb(task, free_heap_copy,
+					       &new_names[i], sizeof(char *));
+		if (rc) {
+			D_FREE(new_names[i]);
+			D_GOTO(out, rc);
+		}
+	}
+
+	rc = attr_bulk_create(args->n, new_names, NULL, NULL,
 			      daos_task2ctx(task), CRT_BULK_RO, &in->padi_bulk);
 	if (rc != 0) {
 		pool_req_cleanup(CLEANUP_RPC, &cb_args);


### PR DESCRIPTION
To prevent more EFAULT cases during RDRAM registration on client
side, also copy to heap, attr values for set-attr and attr names
for del-attr.

Change-Id: Ic9e56f9efe5585ec1dcfeaaf4121a50e1ff3ba8d
Signed-off-by: Bruno Faccini <bruno.faccini@intel.com>