### PR TITLE
DAOS-8029 objects: some fixes for large key migration

### DIFF
--- a/src/include/daos_srv/daos_engine.h
+++ b/src/include/daos_srv/daos_engine.h
@@ -710,10 +710,6 @@ typedef int (*iter_copy_data_cb_t)(daos_handle_t ih,
 				   vos_iter_entry_t *it_entry,
 				   d_iov_t *iov_out);
 struct dss_enum_arg {
-	bool			fill_recxs;	/* type == S||R */
-	bool			chk_key2big;
-	bool			need_punch;	/* need to pack punch epoch */
-	bool			obj_punched;    /* object punch is packed   */
 	daos_epoch_range_t     *eprs;
 	struct daos_csummer    *csummer;
 	int			eprs_cap;
@@ -740,6 +736,11 @@ struct dss_enum_arg {
 	int			rnum;		/* records num (type == S||R) */
 	daos_size_t		rsize;		/* record size (type == S||R) */
 	daos_unit_oid_t		oid;		/* for unpack */
+	uint32_t		fill_recxs:1,	/* type == S||R */
+				chk_key2big:1,
+				need_punch:1,	/* need to pack punch epoch */
+				obj_punched:1,	/* object punch is packed   */
+				size_query:1;	/* Only query size */
 };
 
 struct dtx_handle;

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -4655,7 +4655,7 @@ obj_ec_list_get_shard(struct obj_auxi_args *obj_auxi, unsigned int map_ver,
 	oca = obj_get_oca(obj);
 	obj_ec_get_parity_shards(obj, grp_idx, obj_ec_parity_tgt_nr(oca),
 				 obj_ec_data_tgt_nr(oca), parities);
-	if (unlikely(!DAOS_FAIL_CHECK(DAOS_OBJ_SKIP_PARITY))) {
+	if (likely(!DAOS_FAIL_CHECK(DAOS_OBJ_SKIP_PARITY))) {
 		if (obj_auxi->to_leader) {
 			/* proper way to choose leader ? XXX */
 			shard = parities[0];
@@ -4672,14 +4672,14 @@ obj_ec_list_get_shard(struct obj_auxi_args *obj_auxi, unsigned int map_ver,
 			if (obj->cob_shards->do_shards[shard].do_rebuilding)
 				continue;
 
-			if (obj->cob_shards->do_shards[shard].do_target_id !=
-									-1)
+			if (obj->cob_shards->do_shards[shard].do_target_id != -1)
 				break;
 		}
 
-		D_DEBUG(DB_IO, "choose parity shard %d\n", shard);
-		if (i < p_size)
+		if (i < p_size) {
+			D_DEBUG(DB_IO, "choose parity shard %d\n", shard);
 			D_GOTO(out, shard);
+		}
 	}
 
 	D_DEBUG(DB_IO, "let's choose from the data shard 0 for "DF_OID"\n",

--- a/src/object/obj_enum.c
+++ b/src/object/obj_enum.c
@@ -103,6 +103,14 @@ fill_oid(daos_unit_oid_t oid, struct dss_enum_arg *arg)
 {
 	d_iov_t *iov;
 
+	if (arg->size_query) {
+		arg->kds_len++;
+		arg->kds[0].kd_key_len += sizeof(oid);
+		if (arg->kds_len >= arg->kds_cap)
+			return 1;
+		return 0;
+	}
+
 	/* Check if sgl or kds is full */
 	if (is_sgl_full(arg, sizeof(oid)) || arg->kds_len >= arg->kds_cap)
 		return 1;
@@ -247,6 +255,14 @@ fill_key(daos_handle_t ih, vos_iter_entry_t *key_ent, struct dss_enum_arg *arg,
 	if (type == OBJ_ITER_DKEY && arg->need_punch &&
 	    key_ent->ie_obj_punch != 0 && !arg->obj_punched)
 		kds_cap--;                  /* extra kds for obj punch eph */
+
+	if (arg->size_query) {
+		arg->kds_len++;
+		arg->kds[0].kd_key_len += total_size;
+		if (arg->kds_len >= kds_cap)
+			return 1;
+		return 0;
+	}
 
 	if (is_sgl_full(arg, total_size) || arg->kds_len >= kds_cap) {
 		/* NB: if it is rebuild object iteration, let's
@@ -565,6 +581,14 @@ fill_rec(daos_handle_t ih, vos_iter_entry_t *key_ent, struct dss_enum_arg *arg,
 		D_ASSERT(arg->kds_len > 0);
 		arg->kds_len--;
 		bump_kds_len = true;
+	}
+
+	if (arg->size_query) {
+		arg->kds_len++;
+		arg->kds[0].kd_key_len += size;
+		if (arg->kds_len >= arg->kds_cap)
+			return 1;
+		return 0;
 	}
 
 	if (is_sgl_full(arg, size) || arg->kds_len >= arg->kds_cap) {

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -2803,8 +2803,8 @@ obj_local_enum(struct obj_io_context *ioc, crt_rpc_t *rpc,
 			param.ip_epc_expr = VOS_IT_EPC_RE;
 		}
 		recursive = true;
-		enum_arg->chk_key2big = true;
-		enum_arg->need_punch = true;
+		enum_arg->chk_key2big = 1;
+		enum_arg->need_punch = 1;
 		enum_arg->copy_data_cb = vos_iter_copy;
 		fill_oid(oei->oei_oid, enum_arg);
 	}
@@ -2861,6 +2861,22 @@ re_pack:
 
 			goto re_pack;
 		}
+	}
+
+	if ((rc == -DER_KEY2BIG) && opc == DAOS_OBJ_RPC_ENUMERATE &&
+	    enum_arg->kds_len < 4) {
+		/* let's query the total size for one update (oid/dkey/akey/rec)
+		 * to make sure the migration/enumeration can go ahead.
+		 */
+		enum_arg->size_query = 1;
+		enum_arg->kds_len = 0;
+		enum_arg->kds[0].kd_key_len = 0;
+		enum_arg->kds_cap = 4;
+		goto re_pack;
+	} else if (enum_arg->size_query) {
+		D_DEBUG(DB_IO, DF_UOID "query size by kds %d total %zd\n",
+			DP_UOID(oei->oei_oid), enum_arg->kds_len, enum_arg->kds[0].kd_key_len);
+		rc = -DER_KEY2BIG;
 	}
 
 	/* dss_enum_pack may return 1. */


### PR DESCRIPTION
Return the enough size for object enumeration for KEY2BIG
case, otherwise migration might be in the endless enumeraion
retry.

Add test case for big key rebuild to verify this.

Signed-off-by: Di Wang <di.wang@intel.com>