### PR TITLE
DAOS-8112 test: Fix conflict in telemetry unit tests

### DIFF
--- a/src/control/lib/telemetry/promexp/collector_test.go
+++ b/src/control/lib/telemetry/promexp/collector_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 func TestPromexp_NewEngineSource(t *testing.T) {
-	testIdx := uint32(telemetry.NextTestID())
+	testIdx := uint32(telemetry.NextTestID(telemetry.PromexpIDBase))
 	telemetry.InitTestMetricsProducer(t, int(testIdx), 1024)
 	defer telemetry.CleanupTestMetricsProducer(t)
 
@@ -69,7 +69,7 @@ func TestPromexp_NewEngineSource(t *testing.T) {
 }
 
 func TestPromExp_EngineSource_IsEnabled(t *testing.T) {
-	testIdx := uint32(telemetry.NextTestID())
+	testIdx := uint32(telemetry.NextTestID(telemetry.PromexpIDBase))
 	telemetry.InitTestMetricsProducer(t, int(testIdx), 1024)
 	defer telemetry.CleanupTestMetricsProducer(t)
 
@@ -127,7 +127,7 @@ func allTestMetrics(t *testing.T) telemetry.TestMetricsMap {
 }
 
 func TestPromExp_EngineSource_Collect(t *testing.T) {
-	testIdx := uint32(telemetry.NextTestID())
+	testIdx := uint32(telemetry.NextTestID(telemetry.PromexpIDBase))
 	testRank := uint32(123)
 	telemetry.InitTestMetricsProducer(t, int(testIdx), 2048)
 	defer telemetry.CleanupTestMetricsProducer(t)
@@ -293,7 +293,7 @@ func TestPromExp_Collector_Collect(t *testing.T) {
 	log, buf := logging.NewTestLogger(t.Name())
 	defer common.ShowBufferOnFailure(t, buf)
 
-	testIdx := uint32(telemetry.NextTestID())
+	testIdx := uint32(telemetry.NextTestID(telemetry.PromexpIDBase))
 	testRank := uint32(123)
 	telemetry.InitTestMetricsProducer(t, int(testIdx), 4096)
 	defer telemetry.CleanupTestMetricsProducer(t)

--- a/src/control/lib/telemetry/test_helpers.go
+++ b/src/control/lib/telemetry/test_helpers.go
@@ -38,18 +38,28 @@ add_metric(struct d_tm_node_t **node, int metric_type, char *sh_desc,
 */
 import "C"
 
-var nextID int = 20
+var nextID int
 var nextIDMutex sync.Mutex
+
+const (
+	telemetryIDBase = 100
+	PromexpIDBase   = 200
+)
 
 // NextTestID gets the next available ID for a shmem segment. This helps avoid
 // conflicts amongst tests running concurrently.
-func NextTestID() int {
+// Different packages should use different bases.
+func NextTestID(base ...int) int {
 	nextIDMutex.Lock()
 	defer nextIDMutex.Unlock()
 
+	idBase := telemetryIDBase
+	if len(base) > 0 {
+		idBase = base[0]
+	}
 	id := nextID
 	nextID++
-	return id
+	return idBase + id
 }
 
 type (


### PR DESCRIPTION
- Ensure different Go package test suites don't choose the same
  shmem IDs when they might run concurrently.

Signed-off-by: Kris Jacque <kristin.jacque@intel.com>