### PR TITLE
DAOS-8073 control: Tool command parity

### DIFF
--- a/src/control/cmd/daos/main.go
+++ b/src/control/cmd/daos/main.go
@@ -143,7 +143,6 @@ func parseOpts(args []string, opts *cliOptions, log *logging.LeveledLogger) erro
 	p := flags.NewParser(opts, flags.Default)
 	p.Name = "daos"
 	p.ShortDescription = "Command to manage DAOS pool/container/object"
-	p.Usage = "RESOURCE COMMAND [OPTIONS]"
 	p.LongDescription = `daos is a tool that can be used to manage/query pool content,
 create/query/manage/destroy a container inside a pool, copy data
 between a POSIX container and a POSIX filesystem, clone a DAOS container,

--- a/src/control/cmd/dmg/json_test.go
+++ b/src/control/cmd/dmg/json_test.go
@@ -97,7 +97,7 @@ func TestDmg_JsonOutput(t *testing.T) {
 				testArgs = append(testArgs, []string{common.MockUUID(), "--ranks", "0"}...)
 			case "pool exclude", "pool drain", "pool reintegrate":
 				testArgs = append(testArgs, []string{common.MockUUID(), "--rank", "0"}...)
-			case "cont set-owner":
+			case "container set-owner":
 				testArgs = append(testArgs, []string{"--user", "foo", "--pool", common.MockUUID(), "--cont", common.MockUUID()}...)
 			case "telemetry metrics list", "telemetry metrics query":
 				return // These commands query via http directly

--- a/src/control/cmd/dmg/main.go
+++ b/src/control/cmd/dmg/main.go
@@ -157,14 +157,14 @@ type cliOptions struct {
 	JSON           bool          `short:"j" long:"json" description:"Enable JSON output"`
 	JSONLogs       bool          `short:"J" long:"json-logging" description:"Enable JSON-formatted log output"`
 	ConfigPath     string        `short:"o" long:"config-path" description:"Client config file path"`
-	Storage        storageCmd    `command:"storage" alias:"st" description:"Perform tasks related to storage attached to remote servers"`
-	Config         configCmd     `command:"config" alias:"co" description:"Perform tasks related to configuration of hardware remote servers"`
-	System         SystemCmd     `command:"system" alias:"sy" description:"Perform distributed tasks related to DAOS system"`
-	Network        NetCmd        `command:"network" alias:"n" description:"Perform tasks related to network devices attached to remote servers"`
-	Pool           PoolCmd       `command:"pool" alias:"p" description:"Perform tasks related to DAOS pools"`
-	Cont           ContCmd       `command:"cont" alias:"c" description:"Perform tasks related to DAOS containers"`
+	Storage        storageCmd    `command:"storage" alias:"sto" description:"Perform tasks related to storage attached to remote servers"`
+	Config         configCmd     `command:"config" alias:"cfg" description:"Perform tasks related to configuration of hardware remote servers"`
+	System         SystemCmd     `command:"system" alias:"sys" description:"Perform distributed tasks related to DAOS system"`
+	Network        NetCmd        `command:"network" alias:"net" description:"Perform tasks related to network devices attached to remote servers"`
+	Pool           PoolCmd       `command:"pool" description:"Perform tasks related to DAOS pools"`
+	Cont           ContCmd       `command:"container" alias:"cont" description:"Perform tasks related to DAOS containers"`
 	Version        versionCmd    `command:"version" description:"Print dmg version"`
-	Telemetry      telemCmd      `command:"telemetry" description:"Perform telemetry operations"`
+	Telemetry      telemCmd      `command:"telemetry" alias:"telem" description:"Perform telemetry operations"`
 	firmwareOption               // build with tag "firmware" to enable
 	ManPage        common.ManCmd `command:"manpage" hidden:"true"`
 }
@@ -191,7 +191,6 @@ func parseOpts(args []string, opts *cliOptions, invoker control.Invoker, log *lo
 	p := flags.NewParser(opts, flags.Default)
 	p.Name = "dmg"
 	p.ShortDescription = "Administrative tool for managing DAOS clusters"
-	p.Usage = "[OPTIONS] [COMMAND] [SUBCOMMAND]"
 	p.LongDescription = `dmg (DAOS Management) is a tool for connecting to DAOS servers
 for the purpose of issuing administrative commands to the cluster. dmg is
 provided as a means for allowing administrators to securely discover and


### PR DESCRIPTION
Both daos and dmg have commands related to containers, so
both should allow the same container/cont aliases for the
commands.

Also cleans up the generated help text and aliases for other
dmg commands.