### PR TITLE
DAOS-8074 ctrl: Update storage prepare script env var to PCI_ALLOWED

### DIFF
--- a/src/control/common/storage/commands.go
+++ b/src/control/common/storage/commands.go
@@ -21,7 +21,7 @@ const MsgStoragePrepareWarn = "Memory allocation goals for SCM will be changed a
 	"and subsequent reboot maybe required.\n"
 
 type StoragePrepareNvmeCmd struct {
-	PCIAllowList string `short:"w" long:"pci-whitelist" description:"Whitespace separated list of PCI devices (by address) to be unbound from Kernel driver and used with SPDK (default is all PCI devices)."`
+	PCIAllowList string `short:"w" long:"pci-allowlist" description:"Whitespace separated list of PCI devices (by address) to be unbound from Kernel driver and used with SPDK (default is all PCI devices)."`
 	NrHugepages  int    `short:"p" long:"hugepages" description:"Number of hugepages to allocate (in MB) for use by SPDK (default 1024)"`
 	TargetUser   string `short:"u" long:"target-user" description:"User that will own hugepage mountpoint directory and vfio groups."`
 }

--- a/src/control/lib/spdk/src/nvme_control.c
+++ b/src/control/lib/spdk/src/nvme_control.c
@@ -427,8 +427,8 @@ nvme_fwupdate(char *ctrlr_pci_addr, char *path, unsigned int slot)
 }
 
 static int
-is_addr_in_whitelist(char *pci_addr, const struct spdk_pci_addr *whitelist,
-		     int num_whitelist_devices)
+is_addr_in_allowlist(char *pci_addr, const struct spdk_pci_addr *allowlist,
+		     int num_allowlist_devices)
 {
 	int			i;
 	struct spdk_pci_addr    tmp;
@@ -438,8 +438,8 @@ is_addr_in_whitelist(char *pci_addr, const struct spdk_pci_addr *whitelist,
 		return -EINVAL;
 	}
 
-	for (i = 0; i < num_whitelist_devices; i++) {
-		if (spdk_pci_addr_compare(&tmp, &whitelist[i]) == 0) {
+	for (i = 0; i < num_allowlist_devices; i++) {
+		if (spdk_pci_addr_compare(&tmp, &allowlist[i]) == 0) {
 			return 1;
 		}
 	}
@@ -447,7 +447,7 @@ is_addr_in_whitelist(char *pci_addr, const struct spdk_pci_addr *whitelist,
 	return 0;
 }
 
-/** Add PCI address to spdk_env_opts whitelist, ignoring any duplicates. */
+/** Add PCI address to spdk_env_opts allowlist, ignoring any duplicates. */
 static int
 opts_add_pci_addr(struct spdk_env_opts *opts, struct spdk_pci_addr **list,
 		  char *traddr)
@@ -456,7 +456,7 @@ opts_add_pci_addr(struct spdk_env_opts *opts, struct spdk_pci_addr **list,
 	size_t			count = opts->num_pci_addr;
 	struct spdk_pci_addr   *tmp = *list;
 
-	rc = is_addr_in_whitelist(traddr, *list, count);
+	rc = is_addr_in_allowlist(traddr, *list, count);
 	if (rc < 0)
 		return rc;
 	if (rc == 1)

--- a/src/control/server/ctl_storage_rpc.go
+++ b/src/control/server/ctl_storage_rpc.go
@@ -363,7 +363,7 @@ func (c *ControlService) StorageFormat(ctx context.Context, req *ctlpb.StorageFo
 	// Block until all instances have formatted NVMe to avoid
 	// VFIO device or resource busy when starting I/O Engines
 	// because devices have already been claimed during format.
-	// TODO: supply whitelist of instance.Devs to init() on format.
+	// TODO: supply allowlist of instance.Devs to init() on format.
 	for _, srv := range instances {
 		if instanceErrored[srv.Index()] {
 			c.log.Errorf(msgFormatErr, srv.Index())

--- a/src/control/server/init/setup_spdk.sh
+++ b/src/control/server/init/setup_spdk.sh
@@ -76,8 +76,8 @@ if [[ $1 == reset ]]; then
 	PATH=/sbin:$PATH "$scriptpath" reset
 else
 	# avoid shadowing by prefixing input envars
-	PCI_WHITELIST="$_PCI_WHITELIST" \
-	PCI_BLACKLIST="$_PCI_BLACKLIST" \
+	PCI_ALLOWED="$_PCI_ALLOWED" \
+	PCI_BLOCKED="$_PCI_BLOCKED" \
 	NRHUGE="$_NRHUGE" \
 	TARGET_USER="$_TARGET_USER" \
 	DRIVER_OVERRIDE="$_DRIVER_OVERRIDE" \

--- a/src/control/server/storage/bdev/backend.go
+++ b/src/control/server/storage/bdev/backend.go
@@ -314,7 +314,7 @@ func detectVMD() ([]string, error) {
 	vmdCount := bytes.Count(cmdOut.Bytes(), []byte("0000:"))
 	if vmdCount == 0 {
 		// sometimes the output may not include "0000:" prefix
-		// usually when muliple devices are in the PCI_WHITELIST
+		// usually when muliple devices are in PCI_ALLOWED
 		vmdCount = bytes.Count(cmdOut.Bytes(), []byte("Volume"))
 		if vmdCount == 0 {
 			vmdCount = bytes.Count(cmdOut.Bytes(), []byte("201d"))
@@ -399,7 +399,7 @@ func (sb *spdkBackend) vmdPrep(req storage.BdevPrepareRequest) (bool, error) {
 
 	vmdReq := req
 	// If VMD devices are going to be used, then need to run a separate
-	// bdev prepare (SPDK setup) with the VMD address as the PCI_WHITELIST
+	// bdev prepare (SPDK setup) with the VMD address as the PCI_ALLOWED
 	//
 	// TODO: ignore devices not in include list
 	vmdReq.PCIAllowlist = strings.Join(vmdDevs, " ")

--- a/src/control/server/storage/bdev/runner.go
+++ b/src/control/server/storage/bdev/runner.go
@@ -23,8 +23,8 @@ const (
 	defaultNrHugepages = 4096
 	nrHugepagesEnv     = "_NRHUGE"
 	targetUserEnv      = "_TARGET_USER"
-	pciAllowListEnv    = "_PCI_WHITELIST"
-	pciBlockListEnv    = "_PCI_BLACKLIST"
+	pciAllowListEnv    = "_PCI_ALLOWED"
+	pciBlockListEnv    = "_PCI_BLOCKED"
 	driverOverrideEnv  = "_DRIVER_OVERRIDE"
 	vfioDisabledDriver = "uio_pci_generic"
 )
@@ -103,7 +103,7 @@ func (s *spdkSetupScript) Reset() error {
 // (that don't have active mountpoints) from generic kernel driver to be
 // used with SPDK. Either all PCI devices will be unbound by default if wlist
 // parameter is not set, otherwise PCI devices can be specified by passing in a
-// whitelist of PCI addresses.
+// allowlist of PCI addresses.
 //
 // NOTE: will make the controller disappear from /dev until reset() called.
 func (s *spdkSetupScript) Prepare(req storage.BdevPrepareRequest) error {

--- a/src/tests/ftest/util/server_utils_base.py
+++ b/src/tests/ftest/util/server_utils_base.py
@@ -271,7 +271,7 @@ class DaosServerCommand(YamlCommand):
                     "/run/daos_server/storage/prepare/*", "prepare")
 
                 # daos_server storage prepare command options:
-                #   --pci-whitelist=    Whitespace separated list of PCI
+                #   --pci-allowlist=    Whitespace separated list of PCI
                 #                       devices (by address) to be unbound from
                 #                       Kernel driver and used with SPDK
                 #                       (default is all PCI devices).
@@ -287,7 +287,7 @@ class DaosServerCommand(YamlCommand):
                 #                       kernel modules.
                 #   --force             Perform format without prompting for
                 #                       confirmation
-                self.pci_whitelist = FormattedParameter("--pci-whitelist={}")
+                self.pci_allowlist = FormattedParameter("--pci-allowlist={}")
                 self.hugepages = FormattedParameter("--hugepages={}")
                 self.target_user = FormattedParameter("--target-user={}")
                 self.nvme_only = FormattedParameter("--nvme-only", False)


### PR DESCRIPTION
Server yaml variable bdev_include is not working after recent SPDK upgrade.
SPDK setup script now uses environment variables PCI_ALLOWED and PCI_BLOCKED
and had deprecated use of PCI_WHITELIST and PCI_BLACKLIST.

Signed-off-by: Sydney Vanda <sydney.m.vanda@intel.com>