### PR TITLE
DAOS-8049 Test: Fix nvme_fragmentation and nvme_fault test.

### DIFF
--- a/src/tests/ftest/nvme/nvme_fault.py
+++ b/src/tests/ftest/nvme/nvme_fault.py
@@ -8,6 +8,7 @@ import os
 from nvme_utils import ServerFillUp
 from dmg_utils import DmgCommand
 from command_utils_base import CommandFailure
+from apricot import skipForTicket
 
 class NvmeFault(ServerFillUp):
     # pylint: disable=too-many-ancestors
@@ -34,6 +35,7 @@ class NvmeFault(ServerFillUp):
         #Set to True to generate the NVMe fault during IO
         self.set_faulty_device = True
 
+    @skipForTicket("DAOS-8080")
     def test_nvme_fault(self):
         """Jira ID: DAOS-4722.
 

--- a/src/tests/ftest/nvme/nvme_fault.yaml
+++ b/src/tests/ftest/nvme/nvme_fault.yaml
@@ -50,7 +50,7 @@ pool:
 container:
     type: POSIX
     control_method: daos
-    oclass: "RP_2G1"
+    properties: rf:1
 ior:
   api: "DFS"
   client_processes:

--- a/src/tests/ftest/nvme/nvme_fragmentation.py
+++ b/src/tests/ftest/nvme/nvme_fragmentation.py
@@ -10,6 +10,7 @@ import os
 import threading
 import uuid
 from itertools import product
+import queue
 
 from apricot import TestWithServers
 from write_host_file import write_host_file
@@ -19,11 +20,11 @@ from daos_utils import DaosCommand
 from command_utils_base import CommandFailure
 from job_manager_utils import Mpirun
 from mpio_utils import MpioUtils
-import queue
 
 
 class NvmeFragmentation(TestWithServers):
     # pylint: disable=too-many-ancestors
+    # pylint: disable=too-many-instance-attributes
     """NVMe drive fragmentation test cases.
 
     Test class Description:
@@ -85,15 +86,10 @@ class NvmeFragmentation(TestWithServers):
             ior_cmd.block_size.update(test[1])
             ior_cmd.flags.update(flags)
 
-            container_info["{}{}{}"
-                           .format(oclass,
-                                   api,
-                                   test[0])] = str(uuid.uuid4())
-
             # Define the job manager for the IOR command
             self.job_manager = Mpirun(ior_cmd, mpitype="mpich")
-            key = "{}{}{}".format(oclass, api, test[0])
-            self.job_manager.job.dfs_cont.update(container_info[key])
+            cont_uuid = str(uuid.uuid4())
+            self.job_manager.job.dfs_cont.update(cont_uuid)
             env = ior_cmd.get_default_env(str(self.job_manager))
             self.job_manager.assign_hosts(
                 self.hostlist_clients, self.workdir, None)
@@ -103,6 +99,10 @@ class NvmeFragmentation(TestWithServers):
             # run IOR Command
             try:
                 self.job_manager.run()
+                container_info["{}{}{}"
+                               .format(oclass,
+                                       api,
+                                       test[0])] = cont_uuid
             except CommandFailure as _error:
                 results.put("FAIL")
 

--- a/src/tests/ftest/nvme/nvme_health.py
+++ b/src/tests/ftest/nvme/nvme_health.py
@@ -11,6 +11,7 @@ from nvme_utils import ServerFillUp, get_device_ids
 from test_utils_pool import TestPool
 from dmg_utils import DmgCommand
 from command_utils_base import CommandFailure
+from apricot import skipForTicket
 
 class NvmeHealth(ServerFillUp):
     # pylint: disable=too-many-ancestors
@@ -18,6 +19,7 @@ class NvmeHealth(ServerFillUp):
     Test Class Description: To validate NVMe health test cases
     :avocado: recursive
     """
+    @skipForTicket("DAOS-8080")
     def test_monitor_for_large_pools(self):
         """Jira ID: DAOS-4722.
 


### PR DESCRIPTION
- Adding container RF property to nvme_fault.py tests.
- Updated container UUID in to python dictionary after IOR writes
  and create the container

Test-tag-hw-medium: pr,hw,medium nvme_fragmentation nvme_fault

Signed-off-by: Samir Raval <samir.raval@intel.com>