### PR TITLE
DAOS-8122 EC: zero reasb_req.orr_iom_tgt_nr before retry

### DIFF
--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -3736,6 +3736,7 @@ obj_comp_cb(tse_task_t *task, void *data)
 		obj_auxi->ec_in_recov = 0;
 		obj_auxi->reasb_req.orr_recov = 0;
 		obj_auxi->reasb_req.orr_recov_snap = 0;
+		obj_auxi->reasb_req.orr_iom_tgt_nr = 0;
 		obj_ec_fail_info_free(&obj_auxi->reasb_req);
 		D_DEBUG(DB_IO, DF_OID" EC fetch again.\n",
 			DP_OID(obj->cob_md.omd_id));

--- a/src/object/cli_shard.c
+++ b/src/object/cli_shard.c
@@ -166,7 +166,9 @@ dc_rw_cb_iod_sgl_copy(daos_iod_t *iod, d_sg_list_t *sgl, daos_iod_t *cp_iod,
 	cp_sgl->sg_nr_out = cp_sgl->sg_nr;
 	for (i = 0; i < cp_sgl->sg_nr; i++)
 		cp_sgl->sg_iovs[i] = sgl->sg_iovs[sgl_idx.iov_idx + i];
-	D_ASSERT(sgl_idx.iov_offset < cp_sgl->sg_iovs[0].iov_len);
+	D_ASSERTF(sgl_idx.iov_offset < cp_sgl->sg_iovs[0].iov_len,
+		  "iov_offset "DF_U64", iov_len "DF_U64"\n",
+		  sgl_idx.iov_offset, cp_sgl->sg_iovs[0].iov_len);
 	cp_sgl->sg_iovs[0].iov_buf += sgl_idx.iov_offset;
 	cp_sgl->sg_iovs[0].iov_len -= sgl_idx.iov_offset;
 	cp_sgl->sg_iovs[0].iov_buf_len = cp_sgl->sg_iovs[0].iov_len;
@@ -411,7 +413,8 @@ iom_recx_merge(daos_iom_t *dst, daos_recx_t *recx, bool iom_realloc)
 		}
 	}
 
-	D_ASSERT(dst->iom_nr_out <= dst->iom_nr);
+	D_ASSERTF(dst->iom_nr_out <= dst->iom_nr,
+		 "iom_nr_out %d, iom_nr %d\n", dst->iom_nr_out, dst->iom_nr);
 	if (iom_realloc && dst->iom_nr_out == dst->iom_nr) {
 		iom_nr = dst->iom_nr + 32;
 		D_REALLOC_ARRAY(tmpr, dst->iom_recxs, dst->iom_nr, iom_nr);
@@ -446,7 +449,8 @@ obj_ec_iom_merge(struct obj_reasb_req *reasb_req, uint32_t shard,
 	bool			 done;
 	int			 rc = 0;
 
-	D_ASSERT(tgt_idx < obj_ec_data_tgt_nr(oca));
+	D_ASSERTF(tgt_idx < obj_ec_data_tgt_nr(oca), "tgt_idx %d, tgt_nr %d\n",
+		  tgt_idx, obj_ec_data_tgt_nr(oca));
 
 	if (recov_list != NULL)
 		daos_recx_ep_list_hilo(recov_list, &recov_hi, &recov_lo);
@@ -516,7 +520,9 @@ obj_ec_iom_merge(struct obj_reasb_req *reasb_req, uint32_t shard,
 
 	/* merge iom_recxs */
 	reasb_req->orr_iom_tgt_nr++;
-	D_ASSERT(reasb_req->orr_iom_tgt_nr <= reasb_req->orr_tgt_nr);
+	D_ASSERTF(reasb_req->orr_iom_tgt_nr <= reasb_req->orr_tgt_nr,
+		  "orr_iom_tgt_nr %d, orr_tgt_nr %d.\n",
+		  reasb_req->orr_iom_tgt_nr, reasb_req->orr_tgt_nr);
 	done = (reasb_req->orr_iom_tgt_nr == reasb_req->orr_tgt_nr);
 	reasb_req->orr_iom_nr += src->iom_nr;
 	for (i = 0; i < src->iom_nr; i++) {
@@ -645,7 +651,7 @@ dc_shard_csum_report(tse_task_t *task, crt_endpoint_t *tgt_ep, crt_rpc_t *rpc)
 	int			 rc;
 
 	opc = opc_get(rpc->cr_opc);
-	D_ASSERT(opc == DAOS_OBJ_RPC_FETCH);
+	D_ASSERTF(opc == DAOS_OBJ_RPC_FETCH, "bad opc 0x%x\n", opc);
 	rc = obj_req_create(daos_task2ctx(task), tgt_ep, opc, &csum_rpc);
 	if (rc) {
 		D_ERROR("Failed to create csum report request, task %p.\n",
@@ -916,8 +922,11 @@ dc_rw_cb(tse_task_t *task, void *arg)
 			 *  obj layer will handle it (obj_ec_fetch_set_sgl).
 			 */
 			if (is_ec_obj) {
-				D_ASSERT(orw->orw_tgt_idx <
-					 obj_ec_tgt_nr(reasb_req->orr_oca));
+				D_ASSERTF(orw->orw_tgt_idx <
+					  obj_ec_tgt_nr(reasb_req->orr_oca),
+					  "orw_tgt_idx %d, obj_ec_tgt_nr %d\n",
+					  orw->orw_tgt_idx,
+					  obj_ec_tgt_nr(reasb_req->orr_oca));
 				size_array = reasb_req->orr_data_sizes +
 					     orw->orw_tgt_idx * orw->orw_nr;
 			}
@@ -948,7 +957,10 @@ dc_rw_cb(tse_task_t *task, void *arg)
 					continue;
 				}
 				data_size = replied_sizes[i];
-				D_ASSERT(data_size <= size_in_iod);
+				D_ASSERTF(data_size <= size_in_iod,
+					  "data_size "DF_U64
+					  ", size_in_iod "DF_U64"\n",
+					  data_size, size_in_iod);
 				dc_sgl_out_set(&sgls[i], data_size);
 			}
 		}
@@ -965,7 +977,9 @@ dc_rw_cb(tse_task_t *task, void *arg)
 
 			D_ASSERT(reasb_req == NULL || !reasb_req->orr_recov);
 			/** Should have 1 map per iod */
-			D_ASSERT(orwo->orw_maps.ca_count == orw->orw_nr);
+			D_ASSERTF(orwo->orw_maps.ca_count == orw->orw_nr,
+				  "ca_count "DF_U64", orw_nr %d\n",
+				  orwo->orw_maps.ca_count, orw->orw_nr);
 			for (i = 0; i < orw->orw_nr; i++) {
 				reply_maps = &orwo->orw_maps.ca_arrays[i];
 				recov_list = orwo->orw_rels.ca_arrays;
@@ -1613,7 +1627,9 @@ dc_enumerate_cb(tse_task_t *task, void *arg)
 		       oeo->oeo_kds.ca_count);
 
 	if (enum_args->eaa_recxs && oeo->oeo_recxs.ca_count > 0) {
-		D_ASSERT(*enum_args->eaa_nr >= oeo->oeo_recxs.ca_count);
+		D_ASSERTF(*enum_args->eaa_nr >= oeo->oeo_recxs.ca_count,
+			  "eaa_nr %d, ca_count "DF_U64"\n",
+			  *enum_args->eaa_nr, oeo->oeo_recxs.ca_count);
 		memcpy(enum_args->eaa_recxs, oeo->oeo_recxs.ca_arrays,
 		       sizeof(*enum_args->eaa_recxs) *
 		       oeo->oeo_recxs.ca_count);
@@ -1867,8 +1883,12 @@ re_check:
 	if (reply_recx->rx_idx & PARITY_INDICATOR) {
 		D_ASSERT(!from_data_tgt);
 		rx_idx = (reply_recx->rx_idx & (~PARITY_INDICATOR));
-		D_ASSERT(rx_idx % cell_rec_nr == 0);
-		D_ASSERT(reply_recx->rx_nr % cell_rec_nr == 0);
+		D_ASSERTF(rx_idx % cell_rec_nr == 0, "rx_idx "DF_X64
+			  ", cell_rec_nr "DF_U64"\n",
+			  rx_idx, cell_rec_nr);
+		D_ASSERTF(reply_recx->rx_nr % cell_rec_nr == 0,
+			  "rx_nr "DF_U64", cell_rec_nr "DF_U64"\n",
+			  reply_recx->rx_nr, cell_rec_nr);
 		rx_idx = obj_ec_idx_vos2daos(rx_idx, stripe_rec_nr, cell_rec_nr,
 					     0);
 		tmp_recx->rx_idx = rx_idx;
@@ -1905,8 +1925,10 @@ re_check:
 		parity_checked = true;
 		tmp_recx = &recx[1];
 		reply_recx = &okqo->okqo_recx_parity;
-		D_ASSERT((reply_recx->rx_idx & PARITY_INDICATOR) ||
-			 reply_recx->rx_nr == 0);
+		D_ASSERTF((reply_recx->rx_idx & PARITY_INDICATOR) ||
+			  reply_recx->rx_nr == 0, "reply_recx "DF_RECX"\n",
+			  DP_RECX(reply_recx[0]));
+
 		if (reply_recx->rx_nr != 0)
 			goto re_check;
 	}


### PR DESCRIPTION
For EC FETCH_AGAIN, need to reset reasb_req.orr_iom_tgt_nr as zero.
And change some D_ASSERT to D_ASSERTF to provide more info.

Signed-off-by: Xuezhao Liu <xuezhao.liu@intel.com>