### PR TITLE
DAOS-8127 dfs: Check and retry dfs_release()

### DIFF
--- a/src/client/dfs/dfs.c
+++ b/src/client/dfs/dfs.c
@@ -2952,7 +2952,6 @@ dfs_open_stat(dfs_t *dfs, dfs_obj_t *parent, const char *name, mode_t mode,
 	daos_size_t		file_size = 0;
 	int			rc;
 
-
 	if (dfs == NULL || !dfs->mounted)
 		return EINVAL;
 	if ((dfs->amode != O_RDWR) && (flags & O_CREAT))
@@ -3289,8 +3288,8 @@ dfs_release(dfs_obj_t *obj)
 
 	if (rc)
 		D_ERROR("daos_obj_close() failed, "DF_RC"\n", DP_RC(rc));
-
-	D_FREE(obj);
+	else
+		D_FREE(obj);
 	return daos_der2errno(rc);
 }
 

--- a/src/client/dfuse/il/int_posix.c
+++ b/src/client/dfuse/il/int_posix.c
@@ -150,12 +150,15 @@ ioil_shrink(struct ioil_cont *cont)
 static void
 entry_array_close(void *arg) {
 	struct fd_entry *entry = arg;
+	int rc;
 
 	DFUSE_LOG_DEBUG("entry %p closing array fd_count %d",
 			entry, entry->fd_cont->ioc_open_count);
 
 	DFUSE_TRA_DOWN(entry->fd_dfsoh);
-	dfs_release(entry->fd_dfsoh);
+	rc = dfs_release(entry->fd_dfsoh);
+	if (rc == ENOMEM)
+		dfs_release(entry->fd_dfsoh);
 
 	entry->fd_cont->ioc_open_count -= 1;
 


### PR DESCRIPTION
Retry dfs_release on failure if the failure type is ENOMEM.

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>
