### PR TITLE
DAOS-7446 test: Update the filesystem copy fault injection test.

### DIFF
--- a/src/client/dfs/dfs.c
+++ b/src/client/dfs/dfs.c
@@ -849,8 +849,8 @@ restart:
 					       DAOS_OO_RW, 1, chunk_size,
 					       &file->oh, NULL);
 		if (rc != 0) {
-			D_ERROR("daos_array_open_with_attr() failed (%d)\n",
-				rc);
+			D_ERROR("daos_array_open_with_attr() failed "DF_RC"\n",
+				DP_RC(rc));
 			D_GOTO(out, rc = daos_der2errno(rc));
 		}
 
@@ -1396,7 +1396,7 @@ dfs_cont_create(daos_handle_t poh, uuid_t co_uuid, dfs_attr_t *attr,
 
 	rc = daos_obj_close(super_oh, NULL);
 	if (rc) {
-		D_ERROR("Failed to close SB object\n");
+		D_ERROR("Failed to close SB object "DF_RC"\n", DP_RC(rc));
 		D_GOTO(err_close, rc = daos_der2errno(rc));
 	}
 
@@ -2951,7 +2951,6 @@ dfs_open_stat(dfs_t *dfs, dfs_obj_t *parent, const char *name, mode_t mode,
 	size_t			len;
 	daos_size_t		file_size = 0;
 	int			rc;
-
 
 	if (dfs == NULL || !dfs->mounted)
 		return EINVAL;

--- a/src/client/dfs/dfs.c
+++ b/src/client/dfs/dfs.c
@@ -1194,7 +1194,7 @@ open_sb(daos_handle_t coh, bool create, daos_obj_id_t super_oid,
 		rc = daos_obj_update(*oh, DAOS_TX_NONE, DAOS_COND_DKEY_INSERT,
 				     &dkey, SB_AKEYS, iods, sgls, NULL);
 		if (rc) {
-			D_ERROR("Failed to create DFS superblock (%d)\n", rc);
+			D_ERROR("Failed to create DFS superblock "DF_RC"\n", DP_RC(rc));
 			D_GOTO(err, rc = daos_der2errno(rc));
 		}
 
@@ -1287,10 +1287,8 @@ dfs_cont_create(daos_handle_t poh, uuid_t co_uuid, dfs_attr_t *attr,
 		prop = daos_prop_alloc(attr->da_props->dpp_nr + 2);
 	else
 		prop = daos_prop_alloc(2);
-	if (prop == NULL) {
-		D_ERROR("Failed to allocate container prop.");
+	if (prop == NULL)
 		return ENOMEM;
-	}
 
 	if (attr != NULL && attr->da_props != NULL) {
 		rc = daos_prop_copy(prop, attr->da_props);
@@ -1364,7 +1362,7 @@ dfs_cont_create(daos_handle_t poh, uuid_t co_uuid, dfs_attr_t *attr,
 
 	rc = daos_cont_open(poh, co_uuid, DAOS_COO_RW, &coh, &co_info, NULL);
 	if (rc) {
-		D_ERROR("daos_cont_open() failed (%d)\n", rc);
+		D_ERROR("daos_cont_open() failed "DF_RC"\n", DP_RC(rc));
 		D_GOTO(err_destroy, rc = daos_der2errno(rc));
 	}
 
@@ -1415,7 +1413,7 @@ dfs_cont_create(daos_handle_t poh, uuid_t co_uuid, dfs_attr_t *attr,
 	} else {
 		rc = daos_cont_close(coh, NULL);
 		if (rc) {
-			D_ERROR("daos_cont_close() failed (%d)\n", rc);
+			D_ERROR("daos_cont_close() failed "DF_RC"\n", DP_RC(rc));
 			D_GOTO(err_destroy, rc = daos_der2errno(rc));
 		}
 	}

--- a/src/common/acl_principal.c
+++ b/src/common/acl_principal.c
@@ -122,10 +122,8 @@ static int
 local_name_to_principal_name(const char *local_name, char **name)
 {
 	D_ASPRINTF(*name, "%s@", local_name);
-	if (*name == NULL) {
-		D_ERROR("Failed to allocate string for name\n");
+	if (*name == NULL)
 		return -DER_NOMEM;
-	}
 
 	return 0;
 }

--- a/src/container/cli.c
+++ b/src/container/cli.c
@@ -147,7 +147,7 @@ dup_with_default_ownership_props(daos_prop_t **prop_out, daos_prop_t *prop_in)
 	if (!daos_prop_has_entry(prop_in, DAOS_PROP_CO_OWNER)) {
 		rc = daos_acl_uid_to_principal(uid, &owner);
 		if (rc != 0) {
-			D_ERROR("Invalid uid\n");
+			D_ERROR("Failed to parse uid "DF_RC"\n", DP_RC(rc));
 			D_GOTO(err_out, rc);
 		}
 
@@ -157,7 +157,7 @@ dup_with_default_ownership_props(daos_prop_t **prop_out, daos_prop_t *prop_in)
 	if (!daos_prop_has_entry(prop_in, DAOS_PROP_CO_OWNER_GROUP)) {
 		rc = daos_acl_gid_to_principal(gid, &owner_grp);
 		if (rc != 0) {
-			D_ERROR("Invalid gid\n");
+			D_ERROR("Failed to parse gid "DF_RC"\n", DP_RC(rc));
 			D_GOTO(err_out, rc);
 		}
 
@@ -166,10 +166,8 @@ dup_with_default_ownership_props(daos_prop_t **prop_out, daos_prop_t *prop_in)
 
 	/* We always free this prop in the callback - so need to make a copy */
 	final_prop = daos_prop_alloc(entries);
-	if (final_prop == NULL) {
-		D_ERROR("failed to allocate props");
+	if (final_prop == NULL)
 		D_GOTO(err_out, -DER_NOMEM);
-	}
 
 	if (prop_in != NULL && prop_in->dpp_nr > 0) {
 		rc = daos_prop_copy(final_prop, prop_in);
@@ -816,7 +814,6 @@ err_rpc:
 err:
 	D_DEBUG(DF_DSMC, "failed to open container: "DF_RC"\n", DP_RC(rc));
 	return rc;
-
 }
 
 int

--- a/src/utils/daos_hdlr.c
+++ b/src/utils/daos_hdlr.c
@@ -2069,10 +2069,8 @@ mkdir_dfs(struct cmd_args_s *ap, struct file_dfs *file_dfs, const char *path,
 		D_GOTO(out, rc);
 	}
 	rc = dfs_mkdir(file_dfs->dfs, parent, name, *mode, 0);
-	if (rc != 0) {
-		/* TODO: continue if directory exists, fail otherwise */
+	if (rc != 0)
 		DH_PERROR_SYS(ap, rc, "dfs_mkdir '%s' failed", name);
-	}
 out:
 	if (parent != NULL) {
 		tmp_rc = dfs_release(parent);
@@ -3042,7 +3040,7 @@ dm_disconnect(struct cmd_args_s *ap,
 		if (is_posix_copy) {
 			rc = dfs_umount(src_file_dfs->dfs);
 			if (rc != 0) {
-				fprintf(ap->errstream, "failed to unmount source (%d)\n", rc);
+				DH_PERROR_SYS(ap, rc, "failed to unmount source");
 				D_GOTO(out, rc = daos_der2errno(rc));
 			}
 		}
@@ -3065,7 +3063,7 @@ err_src:
 		if (is_posix_copy) {
 			rc2 = dfs_umount(dst_file_dfs->dfs);
 			if (rc2 != 0) {
-				DH_PERROR_DER(ap, rc2, "failed to unmount destination");
+				DH_PERROR_SYS(ap, rc2, "failed to unmount destination");
 				D_GOTO(out, rc = daos_der2errno(rc2));
 			}
 		}

--- a/src/utils/daos_hdlr.c
+++ b/src/utils/daos_hdlr.c
@@ -2948,7 +2948,8 @@ dm_connect(struct cmd_args_s *ap,
 						     ca->dst_c_uuid,
 						     &attr, NULL, NULL);
 				if (rc != 0) {
-					DH_PERROR_SYS(ap, rc, "failed to create destination container");
+					DH_PERROR_SYS(ap, rc,
+						      "failed to create destination container");
 					D_GOTO(err_dst_root, rc = daos_errno2der(rc));
 				}
 			} else {
@@ -2956,7 +2957,8 @@ dm_connect(struct cmd_args_s *ap,
 						      ca->dst_c_uuid,
 						      props, NULL);
 				if (rc != 0) {
-					DH_PERROR_DER(ap, rc, "failed to create destination container");
+					DH_PERROR_DER(ap, rc,
+						      "failed to create destination container");
 					D_GOTO(err_dst_root, rc);
 				}
 			}

--- a/utils/node_local_test.py
+++ b/utils/node_local_test.py
@@ -3258,9 +3258,11 @@ def run(wf, args):
         server = DaosServer(conf, test_class='no-debug')
         server.start()
         if fi_test:
-            fatal_errors.add_result(test_alloc_fail_copy(server, conf, wf_client))
-#            fatal_errors.add_result(test_alloc_fail_cat(server, conf, wf_client))
-#            fatal_errors.add_result(test_alloc_fail(server, conf))
+#            fatal_errors.add_result(test_alloc_fail_copy(server, conf,
+#                                                         wf_client))
+            fatal_errors.add_result(test_alloc_fail_cat(server,
+                                                        conf, wf_client))
+            fatal_errors.add_result(test_alloc_fail(server, conf))
         if args.perf_check:
             check_readdir_perf(server, conf)
         if server.stop(wf_server) != 0:

--- a/utils/node_local_test.py
+++ b/utils/node_local_test.py
@@ -3085,6 +3085,8 @@ class AllocFailTestRun():
         # Check stderr from a daos command.
         # These should mostly be from the DH_PERROR_SYS or DH_PERROR_DER macros so check for
         # this format.  There may be multiple lines and the two styles may be mixed.
+        # These checks will report an error against the line of code that introduced the "leak"
+        # which may well only have a loose correlation to where the error was reported.
         if self.aft.check_daos_stderr:
             stderr = self.stderr.decode('utf-8').rstrip()
             for line in stderr.splitlines():
@@ -3107,8 +3109,6 @@ class AllocFailTestRun():
                                     "Incorrect stderr '{}'".format(line),
                                     mtype='Invalid error code used')
                     continue
-
-                print('XXX{}XXX'.format(line))
 
                 self.aft.wf.add(self.fi_loc,
                                 'NORMAL',
@@ -3136,7 +3136,7 @@ class AllocFailTestRun():
             self.aft.wf.add(self.fi_loc,
                             'NORMAL',
                             "Incorrect stderr '{}'".format(stderr),
-                            mtype='Out of memory not reported incorrectly via stderr')
+                            mtype='Out of memory not reported correctly via stderr')
 
 class AllocFailTest():
     """Class to describe fault injection command"""

--- a/utils/node_local_test.py
+++ b/utils/node_local_test.py
@@ -3417,11 +3417,11 @@ def run(wf, args):
         server = DaosServer(conf, test_class='no-debug')
         server.start()
         if fi_test:
-            fatal_errors.add_result(test_alloc_fail_copy(server, conf,
-                                                         wf_client))
-#            fatal_errors.add_result(test_alloc_fail_cat(server,
-#                                                        conf, wf_client))
-#            fatal_errors.add_result(test_alloc_fail(server, conf))
+#            fatal_errors.add_result(test_alloc_fail_copy(server, conf,
+#                                                         wf_client))
+            fatal_errors.add_result(test_alloc_fail_cat(server,
+                                                        conf, wf_client))
+            fatal_errors.add_result(test_alloc_fail(server, conf))
         if args.perf_check:
             check_readdir_perf(server, conf)
         if server.stop(wf_server) != 0:


### PR DESCRIPTION
Update the test to create a new container each iteration.  This allows
the test to complete properly, and therefore finds a number of new
issues, both with logging and stdout.  For now the test is still disabled however.
Add strerr checking to the test.

Fix a number of logging/output errors, and create new DH_PERROR_SYS and
DH_PERROR_DER macros in daos_hdlr.c so we can have a consistent output
style.

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>