### PR TITLE
DAOS-8063 rpc: Avoid double completion of failed RPC

### DIFF
--- a/src/cart/crt_rpc.c
+++ b/src/cart/crt_rpc.c
@@ -1216,6 +1216,9 @@ finish_rpc:
 	if (rc != 0) {
 		crt_context_req_untrack(rpc_priv);
 		crt_rpc_complete(rpc_priv, rc);
+
+		/* Do not propagate error further as we've completed the rpc */
+		rc = DER_SUCCESS;
 	}
 
 out:


### PR DESCRIPTION
- Avoid double completion of failed RPC if the failure happens during
hg address lookup phase.

Previously the error was handled already when HG_Reset() fails
in the lookup code (completion invoked), but it was also being propagated
to the caller, which also attempts to handle it (invoking completion again).
That caused rpc reference count to go below 0, cauisng the crash.

Signed-off-by: Alexander Oganezov <alexander.a.oganezov@intel.com>