### PR TITLE
DAOS-8123 test: Implemented positional parameter support and fixed qu…

### DIFF
--- a/src/tests/ftest/pool/query_attribute.py
+++ b/src/tests/ftest/pool/query_attribute.py
@@ -5,7 +5,6 @@
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
 from apricot import TestWithServers
-from daos_utils import DaosCommand
 
 
 class QueryAttributeTest(TestWithServers):
@@ -38,27 +37,41 @@ class QueryAttributeTest(TestWithServers):
         Use Cases:
             Test query, set-attr, list-attr, and get-attr commands.
 
-        :avocado: tags=all,pool,tiny,full_regression,pool_query_attr
+        :avocado: tags=all,full_regression
+        :avocado: tags=small
+        :avocado: tags=pool,pool_query_attr
         """
+        errors = []
+        daos_cmd = self.get_daos_command()
+
         # 1. Test pool query.
-        # Use the same format as pool query.
-        expected_size = "1000000000"
-        expected = self.get_dmg_command().pool_create(scm_size=expected_size)
-        daos_cmd = DaosCommand(self.bin)
+        expected_size = self.params.get("scm_size", "/run/pool/*")
+        self.add_pool()
+
         # Call daos pool query, obtain pool UUID and SCM size, and compare
         # against those used when creating the pool.
-        kwargs = {"pool": expected["uuid"]}
-        query_result = daos_cmd.get_output("pool_query", **kwargs)
-        actual_uuid = query_result[0][0]
-        actual_size = query_result[2][4]
-        self.assertEqual(actual_uuid, expected["uuid"])
-        self.assertEqual(actual_size, expected_size)
+        query_result = daos_cmd.pool_query(pool=self.pool.uuid)
+        actual_uuid = query_result["response"]["uuid"]
+        actual_size = query_result["response"]["tier_stats"][0]["total"]
+
+        expected_uuid = self.pool.uuid.lower()
+        if expected_uuid != actual_uuid:
+            msg = "Unexpected UUID from daos pool query! Expected = {}; " +\
+                "Actual = {}".format(expected_uuid, actual_uuid)
+            errors.append(msg)
+
+        if expected_size != actual_size:
+            msg = "Unexpected Total Storage Tier 0 size from daos pool " +\
+                "query! Expected = {}; Actual = {}".format(
+                    expected_size, actual_size)
+            errors.append(msg)
 
         # 2. Test pool set-attr, get-attr, and list-attrs.
         expected_attrs = []
-        expected_attrs_dict = {}
+        actual_attrs = []
         sample_attrs = []
         sample_vals = []
+
         # Create 5 attributes.
         for i in range(5):
             sample_attr = "attr" + str(i)
@@ -66,20 +79,32 @@ class QueryAttributeTest(TestWithServers):
             sample_attrs.append(sample_attr)
             sample_vals.append(sample_val)
             daos_cmd.pool_set_attr(
-                pool=actual_uuid, attr=sample_attr, value=sample_val)
+                pool=self.pool.uuid, attr=sample_attr, value=sample_val)
             expected_attrs.append(sample_attr)
-            expected_attrs_dict[sample_attr] = sample_val
+
         # List the attribute names and compare against those set.
-        kwargs = {"pool": actual_uuid}
-        actual_attrs = daos_cmd.get_output("pool_list_attrs", **kwargs)
+        attrs = daos_cmd.pool_list_attrs(pool=self.pool.uuid)
+        for attr in attrs["response"]:
+            actual_attrs.append(attr["name"])
+
         actual_attrs.sort()
         expected_attrs.sort()
-        self.assertEqual(actual_attrs, expected_attrs)
+
+        if actual_attrs != expected_attrs:
+            msg = "Unexpected attribute names! Expected = {}; " +\
+                "Actual = {}".format(expected_attrs, actual_attrs)
+            errors.append(msg)
+
         # Get each attribute's value and compare against those set.
         for i in range(5):
-            kwargs = {
-                "pool": actual_uuid,
-                "attr": sample_attrs[i],
-            }
-            actual_val = daos_cmd.get_output("pool_get_attr", **kwargs)[0]
-            self.assertEqual(sample_vals[i], actual_val)
+            output = daos_cmd.pool_get_attr(
+                pool=self.pool.uuid, attr=sample_attrs[i])
+            actual_val = output["response"]["value"]
+            if sample_vals[i] != actual_val:
+                msg = "Unexpected attribute value! Expected = {}; " +\
+                    "Actual = {}".format(sample_vals[i], actual_val)
+                errors.append(msg)
+
+        if errors:
+            self.fail("\n----- Errors detected! -----\n{}".format(
+                "\n".join(errors)))

--- a/src/tests/ftest/pool/query_attribute.py
+++ b/src/tests/ftest/pool/query_attribute.py
@@ -56,8 +56,8 @@ class QueryAttributeTest(TestWithServers):
 
         expected_uuid = self.pool.uuid.lower()
         if expected_uuid != actual_uuid:
-            msg = "Unexpected UUID from daos pool query! Expected = {}; " +\
-                "Actual = {}".format(expected_uuid, actual_uuid)
+            msg = "Unexpected UUID from daos pool query! " +\
+                "Expected = {}; Actual = {}".format(expected_uuid, actual_uuid)
             errors.append(msg)
 
         if expected_size != actual_size:
@@ -91,8 +91,9 @@ class QueryAttributeTest(TestWithServers):
         expected_attrs.sort()
 
         if actual_attrs != expected_attrs:
-            msg = "Unexpected attribute names! Expected = {}; " +\
-                "Actual = {}".format(expected_attrs, actual_attrs)
+            msg = "Unexpected attribute names! " +\
+                "Expected = {}; Actual = {}".format(
+                    expected_attrs, actual_attrs)
             errors.append(msg)
 
         # Get each attribute's value and compare against those set.
@@ -101,8 +102,9 @@ class QueryAttributeTest(TestWithServers):
                 pool=self.pool.uuid, attr=sample_attrs[i])
             actual_val = output["response"]["value"]
             if sample_vals[i] != actual_val:
-                msg = "Unexpected attribute value! Expected = {}; " +\
-                    "Actual = {}".format(sample_vals[i], actual_val)
+                msg = "Unexpected attribute value! " +\
+                    "Expected = {}; Actual = {}".format(
+                        sample_vals[i], actual_val)
                 errors.append(msg)
 
         if errors:

--- a/src/tests/ftest/pool/query_attribute.yaml
+++ b/src/tests/ftest/pool/query_attribute.yaml
@@ -6,3 +6,6 @@ server_config:
   name: daos_server
   servers:
     targets: 8
+pool:
+  scm_size: 1000000000
+  control_method: dmg

--- a/src/tests/ftest/util/command_utils.py
+++ b/src/tests/ftest/util/command_utils.py
@@ -373,8 +373,7 @@ class ExecutableCommand(CommandWithParameters):
 class CommandWithSubCommand(ExecutableCommand):
     """A class for a command with a sub command."""
 
-    def __init__(self, namespace, command, path="", subprocess=False,
-                 with_json=False):
+    def __init__(self, namespace, command, path="", subprocess=False):
         """Create a CommandWithSubCommand object.
 
         Args:
@@ -384,7 +383,6 @@ class CommandWithSubCommand(ExecutableCommand):
                 Defaults to "".
             subprocess (bool, optional): whether the command is run as a
                 subprocess. Defaults to False.
-            with_json (bool, optional): whether to use JSON.
         """
         super().__init__(namespace, command, path)
 
@@ -423,6 +421,8 @@ class CommandWithSubCommand(ExecutableCommand):
         #   interrupted     - whether the command completed within timeout
         #   pid             - command's pid
         self.result = None
+
+        self.json = None
 
     def get_param_names(self):
         """Get a sorted list of the names of the BasicParameter attributes.

--- a/src/tests/ftest/util/command_utils_base.py
+++ b/src/tests/ftest/util/command_utils_base.py
@@ -663,3 +663,65 @@ class EnvironmentVariables(dict):
         if export_str:
             export_str = "".join([export_str, separator])
         return export_str
+
+class PositionalParameter(BasicParameter):
+
+    def __init__(self, position, default=None):
+        """Create a PositionalParameter  object.
+
+        Args:
+            position (int): argument position/order
+            default (object, optional): default value for the param. Defaults to
+                None.
+        """
+        super().__init__(default, default)
+        self._position = position
+
+    @property
+    def position(self):
+        return self._position
+
+    def __lt__(self, other):
+        return self.position < other.position
+
+    def __gt__(self, other):
+        return self.position > other.position
+
+    def __eq__(self, other):
+        return self.position == other.position
+
+    def __hash__(self):
+        """Returns self.position as the hash of the class.
+
+        This is used in CommandWithPositionalParameters.get_attribute_names()
+        where we use this object as the key for a dictionary.
+        """
+        return self.position
+
+class CommandWithPositionalParameters(CommandWithParameters):
+
+    def get_attribute_names(self, attr_type=None):
+        """Get a sorted list of the names of the attr_type attributes.
+
+        The list has the ordered positional parameters first, then
+        non-positional parameters.
+
+        Args:
+            attr_type(object, optional): A single object type or tuple of
+                object types used to filter class attributes by their type.
+                Defaults to None.
+
+        Returns:
+            list: a list of class attribute names used to define parameters
+
+        """
+        positional = {}
+        non_positional = []
+        for name in sorted(list(self.__dict__)):
+            attr = getattr(self, name)
+            if isinstance(attr, attr_type):
+                if hasattr(attr, "position"):
+                    positional[attr] = name
+                else:
+                    non_positional.append(name)
+        return [positional[key] for key in sorted(positional)] + non_positional

--- a/src/tests/ftest/util/command_utils_base.py
+++ b/src/tests/ftest/util/command_utils_base.py
@@ -684,6 +684,9 @@ class PositionalParameter(BasicParameter):
 
     @property
     def position(self):
+        """Position property that defines the position of the parameter.
+
+        """
         return self._position
 
     def __lt__(self, other):

--- a/src/tests/ftest/util/command_utils_base.py
+++ b/src/tests/ftest/util/command_utils_base.py
@@ -665,6 +665,10 @@ class EnvironmentVariables(dict):
         return export_str
 
 class PositionalParameter(BasicParameter):
+    """Parameter that defines position.
+
+    Used to support positional parameters for dmg and daos.
+    """
 
     def __init__(self, position, default=None):
         """Create a PositionalParameter  object.
@@ -673,6 +677,7 @@ class PositionalParameter(BasicParameter):
             position (int): argument position/order
             default (object, optional): default value for the param. Defaults to
                 None.
+
         """
         super().__init__(default, default)
         self._position = position
@@ -695,10 +700,15 @@ class PositionalParameter(BasicParameter):
 
         This is used in CommandWithPositionalParameters.get_attribute_names()
         where we use this object as the key for a dictionary.
+
         """
         return self.position
 
 class CommandWithPositionalParameters(CommandWithParameters):
+    """Command that uses positional parameters.
+
+    Used to support positional parameters for dmg and daos.
+    """
 
     def get_attribute_names(self, attr_type=None):
         """Get a sorted list of the names of the attr_type attributes.

--- a/src/tests/ftest/util/daos_utils_base.py
+++ b/src/tests/ftest/util/daos_utils_base.py
@@ -4,7 +4,8 @@
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
-from command_utils_base import FormattedParameter, CommandWithParameters
+from command_utils_base import FormattedParameter, CommandWithParameters,\
+    CommandWithPositionalParameters, PositionalParameter
 from command_utils import CommandWithSubCommand
 
 
@@ -18,6 +19,8 @@ class DaosCommandBase(CommandWithSubCommand):
             path (str): path to the daos command
         """
         super().__init__("/run/daos/*", "daos", path)
+
+        self.json = FormattedParameter("-j", False)
 
     def get_sub_command_class(self):
         # pylint: disable=redefined-variable-type
@@ -62,8 +65,15 @@ class DaosCommandBase(CommandWithSubCommand):
             else:
                 self.sub_command_class = None
 
-        class CommonPoolSubCommand(CommandWithParameters):
-            """Defines an object for the common daos pool sub-command."""
+        class CommonPoolSubCommand(CommandWithPositionalParameters):
+            """Defines an object for the common daos pool sub-command.
+
+            Use PositionalParameter for positional parameter subcommands. The
+            value passed in defines the position. "pool" comes first, so it gets
+            1. Other subcommands get 2 or later. For example set-attr's attr and
+            value gets 2 and 3 because the order is "daos pool set-attr <attr>
+            <value>".
+            """
 
             def __init__(self, sub_command):
                 """Create a common daos pool sub-command object.
@@ -73,7 +83,7 @@ class DaosCommandBase(CommandWithSubCommand):
                 """
                 super().__init__(
                     "/run/daos/pool/{}/*".format(sub_command), sub_command)
-                self.pool = FormattedParameter("--pool={}")
+                self.pool = PositionalParameter(1)
                 self.sys_name = FormattedParameter("--sys-name={}")
                 self.sys = FormattedParameter("--sys={}")
 
@@ -104,6 +114,8 @@ class DaosCommandBase(CommandWithSubCommand):
             def __init__(self):
                 """Create a daos pool list-attr command object."""
                 super().__init__("list-attrs")
+                self.sys_name = FormattedParameter("--sys-name={}")
+                self.verbose = FormattedParameter("--verbose", False)
 
         class GetAttrSubCommand(CommonPoolSubCommand):
             """Defines an object for the daos pool get-attr command."""
@@ -111,7 +123,8 @@ class DaosCommandBase(CommandWithSubCommand):
             def __init__(self):
                 """Create a daos pool get-attr command object."""
                 super().__init__("get-attr")
-                self.attr = FormattedParameter("--attr={}")
+                self.attr = PositionalParameter(2)
+                self.sys_name = FormattedParameter("--sys-name={}")
 
         class SetAttrSubCommand(CommonPoolSubCommand):
             """Defines an object for the daos pool set-attr command."""
@@ -119,8 +132,9 @@ class DaosCommandBase(CommandWithSubCommand):
             def __init__(self):
                 """Create a daos pool set-attr command object."""
                 super().__init__("set-attr")
-                self.attr = FormattedParameter("--attr={}")
-                self.value = FormattedParameter("--value={}")
+                self.attr = PositionalParameter(2)
+                self.value = PositionalParameter(3)
+                self.sys_name = FormattedParameter("--sys-name={}")
 
         class AutotestSubCommand(CommonPoolSubCommand):
             """Defines an object for the daos pool autotest command."""

--- a/src/tests/ftest/util/dmg_utils.py
+++ b/src/tests/ftest/util/dmg_utils.py
@@ -9,7 +9,6 @@
 from grp import getgrgid
 from pwd import getpwuid
 import re
-import json
 
 from dmg_utils_base import DmgCommandBase
 from general_utils import get_numeric_list
@@ -77,19 +76,6 @@ class DmgCommand(DmgCommandBase):
             r"[-]+\s+([a-z0-9-]+)\s+[-]+\s+|Devices\s+|(?:UUID:[a-z0-9-]+\s+"
             r"Targets:\[[0-9 ]+\]\s+Rank:\d+\s+State:(\w+))",
     }
-
-    def _get_json_result(self, sub_command_list=None, **kwargs):
-        """Wrap the base _get_result method to force JSON output."""
-        prev_json_val = self.json.value
-        self.json.update(True)
-        prev_output_check = self.output_check
-        self.output_check = "both"
-        try:
-            self._get_result(sub_command_list, **kwargs)
-        finally:
-            self.json.update(prev_json_val)
-            self.output_check = prev_output_check
-        return json.loads(self.result.stdout)
 
     def network_scan(self, provider=None):
         """Get the result of the dmg network scan command.


### PR DESCRIPTION
…ery_attribute.py

Implemented positional parameter support for daos command.

Fixed and refactored query_attribute.py

Support JSON in daos command. Moved _get_json_result into command_utils.py so
we can maintain it in one place.

Skip-unit-tests: true
Test-tag: pr pool_query_attr
Signed-off-by: Makito Kano <makito.kano@intel.com>