### PR TITLE
DAOS-623 build: Fix c++ compilation with pool/cont routines

### DIFF
--- a/src/client/api/SConscript
+++ b/src/client/api/SConscript
@@ -1,6 +1,9 @@
 """Build DAOS client"""
 import daos_build
 
+LIBDAOS_SRC = ['agent.c', 'array.c', 'container.c', 'event.c', 'init.c', 'job.c', 'kv.c', 'mgmt.c',
+               'object.c', 'pool.c', 'rpc.c', 'task.c', 'tx.c']
+
 def scons():
     """Execute build"""
     Import('env', 'base_env', 'API_VERSION', 'prereqs')
@@ -9,7 +12,8 @@ def scons():
     base_env.AppendUnique(LIBPATH=[Dir('.')])
     denv = env.Clone()
     prereqs.require(denv, 'protobufc')
-    libdaos_tgts = denv.SharedObject(Glob('*.c'))
+    libdaos_tgts = denv.SharedObject(LIBDAOS_SRC)
+    _compile_check = denv.Object(["compile_check_cpp.cpp", "compile_check.c"])
 
     Import('dc_pool_tgts', 'dc_co_tgts', 'dc_obj_tgts', 'dc_placement_tgts')
     Import('dc_mgmt_tgts', 'dc_array_tgts', 'dc_kv_tgts', 'dc_security_tgts')

--- a/src/client/api/compile_check.c
+++ b/src/client/api/compile_check.c
@@ -1,0 +1,54 @@
+/*
+ * (C) Copyright 2021 Intel Corporation.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause-Patent
+ */
+
+#include <gurt/debug.h>
+#include <daos.h>
+
+#define check_string_non_literal(var, expect)						\
+	D_CASSERT(d_is_string_non_literal(var) == expect)
+
+#define check_string_literal(var, expect)						\
+	D_CASSERT(d_is_string_literal(var) == expect)
+
+int main(int argc, char **argv)
+{
+	uuid_t	uuid = {0};
+	daos_handle_t	coh;
+	daos_handle_t	poh = {0};
+	char *charp = NULL;
+	const char *ccharp = "hello";
+	char	arr[10] = {0};
+	const char	carr[10] = {0};
+
+	/** Check the macros */
+	check_string_non_literal(charp, true);
+	check_string_non_literal(ccharp, true);
+	check_string_non_literal(uuid, false);
+	check_string_non_literal(arr, true);
+	check_string_non_literal(carr, true);
+	check_string_literal("Hello", true);
+	check_string_literal(charp, false);
+	check_string_literal(ccharp, false);
+	check_string_literal(uuid, false);
+	check_string_literal(arr, false);
+	check_string_literal(carr, false);
+
+	/* Test compilation with real APIs */
+	D_ASSERT(daos_pool_connect(uuid, NULL, 0, &poh, NULL, NULL) == 0);
+	D_ASSERT(daos_pool_connect(arr, NULL, 0, &poh, NULL, NULL) == 0);
+	D_ASSERT(daos_pool_connect(ccharp, NULL, 0, &poh, NULL, NULL) == 0);
+	D_ASSERT(daos_pool_connect(charp, NULL, 0, &poh, NULL, NULL) == 0);
+	D_ASSERT(daos_cont_open(poh, uuid, 0, &coh, NULL, NULL) == 0);
+	D_ASSERT(daos_cont_open(poh, arr, 0, &coh, NULL, NULL) == 0);
+	D_ASSERT(daos_cont_open(poh, ccharp, 0, &coh, NULL, NULL) == 0);
+	D_ASSERT(daos_cont_open(poh, charp, 0, &coh, NULL, NULL) == 0);
+	D_ASSERT(daos_cont_destroy(poh, uuid, 0, NULL) == 0);
+	D_ASSERT(daos_cont_destroy(poh, arr, 0, NULL) == 0);
+	D_ASSERT(daos_cont_destroy(poh, ccharp, 0, NULL) == 0);
+	D_ASSERT(daos_cont_destroy(poh, charp, 0, NULL) == 0);
+
+	return 0;
+}

--- a/src/client/api/compile_check_cpp.cpp
+++ b/src/client/api/compile_check_cpp.cpp
@@ -1,0 +1,7 @@
+/*
+ * (C) Copyright 2021 Intel Corporation.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause-Patent
+ */
+
+#include "compile_check.c"

--- a/src/include/daos_cont.h
+++ b/src/include/daos_cont.h
@@ -680,9 +680,7 @@ daos_cont_open2(daos_handle_t poh, const char *cont, unsigned int flags,
 		int _ret;						\
 		char _str[37];						\
 		const char *__str;					\
-		if (__builtin_types_compatible_p(typeof(co), char *) ||	\
-		    __builtin_types_compatible_p(typeof(co),		\
-						 const char *)) {	\
+		if (d_is_string(co)) {					\
 			__str = (const char *)(co);			\
 		} else {						\
 			uuid_unparse((unsigned char *)(co), _str);	\
@@ -701,9 +699,7 @@ daos_cont_destroy2(daos_handle_t poh, const char *cont, int force,
 		int _ret;						\
 		char _str[37];						\
 		const char *__str;					\
-		if (__builtin_types_compatible_p(typeof(co), char *) ||	\
-		    __builtin_types_compatible_p(typeof(co),		\
-						 const char *)) {	\
+		if (d_is_string(co)) {					\
 			__str = (const char *)(co);			\
 		} else {						\
 			uuid_unparse((unsigned char *)(co), _str);	\

--- a/src/include/daos_pool.h
+++ b/src/include/daos_pool.h
@@ -430,9 +430,7 @@ daos_pool_connect2(const char *pool, const char *sys, unsigned int flags,
 		int _ret;						\
 		char _str[37];						\
 		const char *__str;					\
-		if (__builtin_types_compatible_p(typeof(po), char *) ||	\
-		    __builtin_types_compatible_p(typeof(po),		\
-						 const char *)) {	\
+		if (d_is_string(po)) {					\
 			__str = (const char *)(po);			\
 		} else {						\
 			uuid_unparse((unsigned char *)(po), _str);	\

--- a/src/include/daos_prop.h
+++ b/src/include/daos_prop.h
@@ -373,7 +373,7 @@ struct daos_prop_entry {
 static inline bool
 daos_label_is_valid(const char *label)
 {
-	size_t	len;
+	int	len;
 	int	i;
 
 	/** Label cannot be NULL */

--- a/src/include/daos_types.h
+++ b/src/include/daos_types.h
@@ -10,10 +10,6 @@
 #ifndef DAOS_TYPES_H
 #define DAOS_TYPES_H
 
-#if defined(__cplusplus)
-extern "C" {
-#endif
-
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>
@@ -25,6 +21,10 @@ extern "C" {
 #include <cart/types.h>
 
 #include <daos_errno.h>
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
 
 /** Maximum length (excluding the '\0') of a DAOS system name */
 #define DAOS_SYS_NAME_MAX 15

--- a/src/include/gurt/common.h
+++ b/src/include/gurt/common.h
@@ -134,8 +134,8 @@ char *d_realpath(const char *path, char *resolved_path);
 
 #define D_STRNDUP_S(ptr, s)						\
 	do {								\
-		_Static_assert(sizeof(s) != sizeof(void *) ||		\
-			__builtin_types_compatible_p(typeof(s), typeof("1234567")), \
+		D_CASSERT(sizeof(s) != sizeof(void *) ||		\
+			 __builtin_types_compatible_p(typeof(s), typeof("1234567")), \
 	"D_STRNDUP_S cannot be used with this type");			\
 		(ptr) = d_strndup(s, sizeof(s));			\
 		D_CHECK_ALLOC(strndup, true, ptr, #ptr,			\

--- a/src/include/gurt/debug.h
+++ b/src/include/gurt/debug.h
@@ -304,6 +304,9 @@ do {									\
 	assert(cond);							\
 } while (0)
 
+#ifdef __cplusplus
+#define _Static_assert static_assert
+#endif
 #define D_CASSERT(cond, ...)						\
 	_Static_assert(cond, #cond ": " __VA_ARGS__)
 

--- a/src/include/gurt/types.h
+++ b/src/include/gurt/types.h
@@ -52,13 +52,20 @@ extern "C" {
 #define D_HAS_WARNING(gcc_version, warning) ((gcc_version) <= __GNUC__)
 #endif /* defined(__has_warning) */
 
+#if D_HAS_WARNING(5, "-Wsizeof-array-argument")
+#define DISABLE_SIZEOF_ARRAY_ARGUMENT	\
+	_Pragma("GCC diagnostic ignored \"-Wsizeof-array-argument\"")
+#else
+#define DISABLE_SIZEOF_ARRAY_ARGUMENT (void)0
+#endif
+
 /* Macro for checking if a variable is one of various string types */
 #define d_is_string(var)							\
 	({									\
 		bool __result = false;						\
 										\
 		_Pragma("GCC diagnostic push");					\
-		_Pragma("GCC diagnostic ignored \"-Wsizeof-array-argument\"");	\
+		DISABLE_SIZEOF_ARRAY_ARGUMENT;					\
 		__result = d_is_string_non_literal(var) ||			\
 			   d_is_string_literal(var);				\
 		_Pragma("GCC diagnostic pop");					\


### PR DESCRIPTION
A recent patch (PR #6138) broke C++ compilation.  This restores
it and adds a compiler test to check it.

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>