### PR TITLE
DAOS-623 build: Fix c++ compilation with pool/cont routines

### DIFF
--- a/src/client/api/SConscript
+++ b/src/client/api/SConscript
@@ -1,6 +1,9 @@
 """Build DAOS client"""
 import daos_build
 
+LIBDAOS_SRC = ['agent.c', 'array.c', 'container.c', 'event.c', 'init.c', 'job.c', 'kv.c', 'mgmt.c',
+               'object.c', 'pool.c', 'rpc.c', 'task.c', 'tx.c']
+
 def scons():
     """Execute build"""
     Import('env', 'base_env', 'API_VERSION', 'prereqs')
@@ -9,7 +12,8 @@ def scons():
     base_env.AppendUnique(LIBPATH=[Dir('.')])
     denv = env.Clone()
     prereqs.require(denv, 'protobufc')
-    libdaos_tgts = denv.SharedObject(Glob('*.c'))
+    libdaos_tgts = denv.SharedObject(LIBDAOS_SRC)
+    _compile_check = denv.Object(["compile_check_cpp.cpp", "compile_check.c"])
 
     Import('dc_pool_tgts', 'dc_co_tgts', 'dc_obj_tgts', 'dc_placement_tgts')
     Import('dc_mgmt_tgts', 'dc_array_tgts', 'dc_kv_tgts', 'dc_security_tgts')

--- a/src/client/api/SConscript
+++ b/src/client/api/SConscript
@@ -6,7 +6,7 @@ LIBDAOS_SRC = ['agent.c', 'array.c', 'container.c', 'event.c', 'init.c', 'job.c'
 
 def scons():
     """Execute build"""
-    Import('env', 'base_env', 'API_VERSION', 'prereqs')
+    Import('env', 'base_env', 'API_VERSION', 'prereqs', 'common_lib')
 
     env.AppendUnique(LIBPATH=[Dir('.')])
     base_env.AppendUnique(LIBPATH=[Dir('.')])
@@ -20,17 +20,20 @@ def scons():
     Export('libdaos_tgts')
 
     if prereqs.client_requested():
-        libdaos= daos_build.library(denv, 'daos', libdaos_tgts,
+        libdaos= daos_build.library(env, 'daos', libdaos_tgts,
                                      SHLIBVERSION=API_VERSION,
                                      LIBS=['daos_common'])
+        env.Requires(libdaos, common_lib)
         if hasattr(env, 'InstallVersionedLib'):
-            denv.InstallVersionedLib('$PREFIX/lib64/', libdaos,
+            env.InstallVersionedLib('$PREFIX/lib64/', libdaos,
                                     SHLIBVERSION=API_VERSION)
         else:
             env.Install('$PREFIX/lib64/', libdaos)
         check_libs = ['daos', 'gurt', 'uuid']
-        _compile_check = daos_build.test(denv, ["compile_check.c"], LIBS=check_libs)
-        _compile_check_cpp = daos_build.test(denv, ["compile_check_cpp.cpp"], LIBS=check_libs)
+        compile_check = daos_build.test(denv, ["compile_check.c"], LIBS=check_libs)
+        compile_check_cpp = daos_build.test(denv, ["compile_check_cpp.cpp"], LIBS=check_libs)
+        denv.Requires(compile_check, libdaos)
+        denv.Requires(compile_check_cpp, libdaos)
 
 
     if prereqs.test_requested():

--- a/src/client/api/SConscript
+++ b/src/client/api/SConscript
@@ -18,6 +18,7 @@ def scons():
     libdaos_tgts += dc_pool_tgts + dc_co_tgts + dc_placement_tgts + dc_obj_tgts
     libdaos_tgts += dc_mgmt_tgts + dc_array_tgts + dc_kv_tgts + dc_security_tgts
     Export('libdaos_tgts')
+    compile_check = denv.Object(["compile_check.c", "compile_check_cpp.cpp"])
 
     if prereqs.client_requested():
         libdaos= daos_build.library(env, 'daos', libdaos_tgts,
@@ -30,11 +31,6 @@ def scons():
         else:
             env.Install('$PREFIX/lib64/', libdaos)
         check_libs = ['daos', 'gurt', 'uuid']
-        compile_check = daos_build.test(denv, ["compile_check.c"], LIBS=check_libs)
-        compile_check_cpp = daos_build.test(denv, ["compile_check_cpp.cpp"], LIBS=check_libs)
-        denv.Requires(compile_check, libdaos)
-        denv.Requires(compile_check_cpp, libdaos)
-
 
     if prereqs.test_requested():
         SConscript('tests/SConscript', exports='denv')

--- a/src/client/api/SConscript
+++ b/src/client/api/SConscript
@@ -19,10 +19,6 @@ def scons():
     libdaos_tgts += dc_mgmt_tgts + dc_array_tgts + dc_kv_tgts + dc_security_tgts
     Export('libdaos_tgts')
 
-    check_libs = ['daos', 'gurt', 'uuid']
-    _compile_check = daos_build.test(env, ["compile_check.c"], LIBS=check_libs)
-    _compile_check_cpp = daos_build.test(env, ["compile_check_cpp.cpp"], LIBS=check_libs)
-
     if prereqs.client_requested():
         libdaos= daos_build.library(env, 'daos', libdaos_tgts,
                                      SHLIBVERSION=API_VERSION,
@@ -32,6 +28,10 @@ def scons():
                                     SHLIBVERSION=API_VERSION)
         else:
             env.Install('$PREFIX/lib64/', libdaos)
+        check_libs = ['daos', 'gurt', 'uuid']
+        _compile_check = daos_build.test(env, ["compile_check.c"], LIBS=check_libs)
+        _compile_check_cpp = daos_build.test(env, ["compile_check_cpp.cpp"], LIBS=check_libs)
+
 
     if prereqs.test_requested():
         SConscript('tests/SConscript', exports='denv')

--- a/src/client/api/SConscript
+++ b/src/client/api/SConscript
@@ -6,7 +6,7 @@ LIBDAOS_SRC = ['agent.c', 'array.c', 'container.c', 'event.c', 'init.c', 'job.c'
 
 def scons():
     """Execute build"""
-    Import('env', 'base_env', 'API_VERSION', 'prereqs', 'common_lib')
+    Import('env', 'base_env', 'API_VERSION', 'prereqs')
 
     env.AppendUnique(LIBPATH=[Dir('.')])
     base_env.AppendUnique(LIBPATH=[Dir('.')])
@@ -24,13 +24,11 @@ def scons():
         libdaos= daos_build.library(env, 'daos', libdaos_tgts,
                                      SHLIBVERSION=API_VERSION,
                                      LIBS=['daos_common'])
-        env.Requires(libdaos, common_lib)
         if hasattr(env, 'InstallVersionedLib'):
             env.InstallVersionedLib('$PREFIX/lib64/', libdaos,
                                     SHLIBVERSION=API_VERSION)
         else:
             env.Install('$PREFIX/lib64/', libdaos)
-        check_libs = ['daos', 'gurt', 'uuid']
 
     if prereqs.test_requested():
         SConscript('tests/SConscript', exports='denv')

--- a/src/client/api/SConscript
+++ b/src/client/api/SConscript
@@ -20,17 +20,17 @@ def scons():
     Export('libdaos_tgts')
 
     if prereqs.client_requested():
-        libdaos= daos_build.library(env, 'daos', libdaos_tgts,
+        libdaos= daos_build.library(denv, 'daos', libdaos_tgts,
                                      SHLIBVERSION=API_VERSION,
                                      LIBS=['daos_common'])
         if hasattr(env, 'InstallVersionedLib'):
-            env.InstallVersionedLib('$PREFIX/lib64/', libdaos,
+            denv.InstallVersionedLib('$PREFIX/lib64/', libdaos,
                                     SHLIBVERSION=API_VERSION)
         else:
             env.Install('$PREFIX/lib64/', libdaos)
         check_libs = ['daos', 'gurt', 'uuid']
-        _compile_check = daos_build.test(env, ["compile_check.c"], LIBS=check_libs)
-        _compile_check_cpp = daos_build.test(env, ["compile_check_cpp.cpp"], LIBS=check_libs)
+        _compile_check = daos_build.test(denv, ["compile_check.c"], LIBS=check_libs)
+        _compile_check_cpp = daos_build.test(denv, ["compile_check_cpp.cpp"], LIBS=check_libs)
 
 
     if prereqs.test_requested():

--- a/src/client/api/SConscript
+++ b/src/client/api/SConscript
@@ -18,7 +18,7 @@ def scons():
     libdaos_tgts += dc_pool_tgts + dc_co_tgts + dc_placement_tgts + dc_obj_tgts
     libdaos_tgts += dc_mgmt_tgts + dc_array_tgts + dc_kv_tgts + dc_security_tgts
     Export('libdaos_tgts')
-    compile_check = denv.Object(["compile_check.c", "compile_check_cpp.cpp"])
+    _compile_check = denv.Object(["compile_check.c", "compile_check_cpp.cpp"])
 
     if prereqs.client_requested():
         libdaos= daos_build.library(env, 'daos', libdaos_tgts,

--- a/src/client/api/SConscript
+++ b/src/client/api/SConscript
@@ -13,13 +13,15 @@ def scons():
     denv = env.Clone()
     prereqs.require(denv, 'protobufc')
     libdaos_tgts = denv.SharedObject(LIBDAOS_SRC)
-    _compile_check = denv.Object(["compile_check_cpp.cpp", "compile_check.c"])
-
     Import('dc_pool_tgts', 'dc_co_tgts', 'dc_obj_tgts', 'dc_placement_tgts')
     Import('dc_mgmt_tgts', 'dc_array_tgts', 'dc_kv_tgts', 'dc_security_tgts')
     libdaos_tgts += dc_pool_tgts + dc_co_tgts + dc_placement_tgts + dc_obj_tgts
     libdaos_tgts += dc_mgmt_tgts + dc_array_tgts + dc_kv_tgts + dc_security_tgts
     Export('libdaos_tgts')
+
+    check_libs = ['daos', 'gurt', 'uuid']
+    _compile_check = daos_build.test(env, ["compile_check.c"], LIBS=check_libs)
+    _compile_check_cpp = daos_build.test(env, ["compile_check_cpp.cpp"], LIBS=check_libs)
 
     if prereqs.client_requested():
         libdaos= daos_build.library(env, 'daos', libdaos_tgts,

--- a/src/client/api/compile_check.c
+++ b/src/client/api/compile_check.c
@@ -10,6 +10,8 @@
 #if defined(__cplusplus)
 #define check_uuid(var, expect, type) (void)0
 #define check_string(var, expect, type) (void)0
+#define check_uuid_func(...) (void)0
+#define check_const_uuid_func(...) (void)0
 #else
 #define check_uuid(var, expect, type)							\
 	do {										\
@@ -24,6 +26,20 @@
 		       expect ? "string" : "uuid", d_is_string(var) ? "string" : "uuid");	\
 		D_CASSERT(d_is_string(var) == expect);						\
 	} while (0)
+
+static void
+check_uuid_func(uuid_t uuid)
+{
+	check_uuid(uuid, true, uuid_t (in function));
+	check_string(uuid, false, uuid_t (in function));
+}
+
+static void
+check_const_uuid_func(const uuid_t uuid)
+{
+	check_uuid(uuid, true, const uuid_t (in function));
+	check_string(uuid, false, const uuid_t (in function));
+}
 #endif
 
 #define noop
@@ -38,8 +54,7 @@
 	ACTION(const char *, ccharp, noop, NULL, poh, coh, false)	\
 	ACTION(char,         arr,    [10], {0},  poh, coh, false)	\
 	ACTION(const char,   carr,   [10], {0},  poh, coh, false)	\
-	ACTION(char,         arru,   [37], {0},  poh, coh, false)	\
-	ACTION(const char,   carru,  [37], {0},  poh, coh, false)	\
+	ACTION(char,         arrs,   [16], {0},  poh, coh, false)	\
 	ACTION(char,         dyn,    [],   "c",  poh, coh, false)
 
 #define FOREACH_ALL(ACTION, poh, coh)					\
@@ -57,7 +72,7 @@
 	} while (0)
 
 #define RUN_ACTION(type, name, mod, init, poh, coh, expect)			\
-	check_uuid(name, expect, type mod);						\
+	check_uuid(name, expect, type mod);					\
 	RUN_FUNCTION(daos_pool_connect(name, NULL, 0, &poh, NULL, NULL) == 0);	\
 	RUN_FUNCTION(daos_cont_open(poh, name, 0, &coh, NULL, NULL) == 0);	\
 	RUN_FUNCTION(daos_cont_destroy(poh, name, 0, NULL) == 0);		\
@@ -71,6 +86,10 @@ int main(int argc, char **argv)
 	FOREACH_TYPE(DECLARE_ACTION, poh, coh);
 
 	FOREACH_ALL(RUN_ACTION, poh, coh);
+
+	check_uuid_func(uuid);
+	check_const_uuid_func(uuid);
+	check_const_uuid_func(cuuid);
 
 	return 0;
 }

--- a/src/client/api/compile_check.c
+++ b/src/client/api/compile_check.c
@@ -1,0 +1,47 @@
+/*
+ * (C) Copyright 2021 Intel Corporation.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause-Patent
+ */
+
+#include <gurt/debug.h>
+#include <daos.h>
+
+#define check_string_non_literal(var, expect)						\
+	D_CASSERT(d_is_string_non_literal(var) == expect)
+
+#define check_string_literal(var, expect)						\
+	D_CASSERT(d_is_string_literal(var) == expect)
+
+int main(int argc, char **argv)
+{
+	uuid_t	uuid = {0};
+	daos_handle_t	coh;
+	daos_handle_t	poh = {0};
+	char *charp = NULL;
+	const char *ccharp = "hello";
+	char	arr[10] = {0};
+	const char	carr[10] = {0};
+
+	/* Test compilation with real APIs */
+	D_ASSERT(daos_pool_connect(uuid, NULL, 0, &poh, NULL, NULL) == 0);
+	D_ASSERT(daos_pool_connect(arr, NULL, 0, &poh, NULL, NULL) == 0);
+	D_ASSERT(daos_pool_connect(carr, NULL, 0, &poh, NULL, NULL) == 0);
+	D_ASSERT(daos_pool_connect(ccharp, NULL, 0, &poh, NULL, NULL) == 0);
+	D_ASSERT(daos_pool_connect(charp, NULL, 0, &poh, NULL, NULL) == 0);
+	D_ASSERT(daos_pool_connect("Hello", NULL, 0, &poh, NULL, NULL) == 0);
+	D_ASSERT(daos_cont_open(poh, uuid, 0, &coh, NULL, NULL) == 0);
+	D_ASSERT(daos_cont_open(poh, arr, 0, &coh, NULL, NULL) == 0);
+	D_ASSERT(daos_cont_open(poh, carr, 0, &coh, NULL, NULL) == 0);
+	D_ASSERT(daos_cont_open(poh, ccharp, 0, &coh, NULL, NULL) == 0);
+	D_ASSERT(daos_cont_open(poh, charp, 0, &coh, NULL, NULL) == 0);
+	D_ASSERT(daos_cont_open(poh, "Hello", 0, &coh, NULL, NULL) == 0);
+	D_ASSERT(daos_cont_destroy(poh, uuid, 0, NULL) == 0);
+	D_ASSERT(daos_cont_destroy(poh, arr, 0, NULL) == 0);
+	D_ASSERT(daos_cont_destroy(poh, carr, 0, NULL) == 0);
+	D_ASSERT(daos_cont_destroy(poh, ccharp, 0, NULL) == 0);
+	D_ASSERT(daos_cont_destroy(poh, charp, 0, NULL) == 0);
+	D_ASSERT(daos_cont_destroy(poh, "Hello", 0, NULL) == 0);
+
+	return 0;
+}

--- a/src/client/api/compile_check.c
+++ b/src/client/api/compile_check.c
@@ -8,32 +8,60 @@
 #include <daos.h>
 
 #if defined(__cplusplus)
-#define check_uuid(var, expect) (void)0
+#define check_uuid(var, expect, type) (void)0
+#define check_string(var, expect, type) (void)0
 #else
-#define check_uuid(var, expect)			\
-	D_CASSERT(d_is_uuid(var) == expect)
+#define check_uuid(var, expect, type)							\
+	do {										\
+		printf("uuid check:   "#var" of type " #type " should be a %s, is %s\n",\
+		       expect ? "uuid" : "string", d_is_uuid(var) ? "uuid" : "string");	\
+		D_CASSERT(d_is_uuid(var) == expect);					\
+	} while (0)
+
+#define check_string(var, expect, type)								\
+	do {											\
+		printf("string check: "#var" of type " #type " should be a %s, is %s\n",	\
+		       expect ? "string" : "uuid", d_is_string(var) ? "string" : "uuid");	\
+		D_CASSERT(d_is_string(var) == expect);						\
+	} while (0)
 #endif
 
-#define FOREACH_TYPE(ACTION, poh, coh)					\
+#define noop
+
+#define FOREACH_UUID_TYPE(ACTION, poh, coh)				\
 	ACTION(uuid_t,       uuid,   noop, {0},  poh, coh, true)	\
-	ACTION(const uuid_t, cuuid,  noop, {0},  poh, coh, true)	\
+	ACTION(const uuid_t, cuuid,  noop, {0},  poh, coh, true)
+
+#define FOREACH_TYPE(ACTION, poh, coh)					\
+	FOREACH_UUID_TYPE(ACTION, poh, coh)				\
 	ACTION(char *,       charp,  noop, NULL, poh, coh, false)	\
 	ACTION(const char *, ccharp, noop, NULL, poh, coh, false)	\
 	ACTION(char,         arr,    [10], {0},  poh, coh, false)	\
-	ACTION(const char,   carr,   [10], {0},  poh, coh, false)
+	ACTION(const char,   carr,   [10], {0},  poh, coh, false)	\
+	ACTION(char,         arru,   [37], {0},  poh, coh, false)	\
+	ACTION(const char,   carru,  [37], {0},  poh, coh, false)	\
+	ACTION(char,         dyn,    [],   "c",  poh, coh, false)
 
 #define FOREACH_ALL(ACTION, poh, coh)					\
 	FOREACH_TYPE(ACTION, poh, coh)					\
-	ACTION(noop,         "STR",  noop, noop, poh, coh, false)
+	ACTION(literal,      "STR",  noop, noop, poh, coh, false)
 
 #define DECLARE_ACTION(type, name, mod, init, poh, coh, expect)	\
 	type	name mod = init;
 
+#define RUN_FUNCTION(cmd)	\
+	do {			\
+		int	__rc;	\
+		__rc = cmd;	\
+		(void)__rc;	\
+	} while (0)
+
 #define RUN_ACTION(type, name, mod, init, poh, coh, expect)			\
-	check_uuid(name, expect);						\
-	D_ASSERT(daos_pool_connect(name, NULL, 0, &poh, NULL, NULL) == 0);	\
-	D_ASSERT(daos_cont_open(poh, name, 0, &coh, NULL, NULL) == 0);		\
-	D_ASSERT(daos_cont_destroy(poh, name, 0, NULL) == 0);
+	check_uuid(name, expect, type mod);						\
+	RUN_FUNCTION(daos_pool_connect(name, NULL, 0, &poh, NULL, NULL) == 0);	\
+	RUN_FUNCTION(daos_cont_open(poh, name, 0, &coh, NULL, NULL) == 0);	\
+	RUN_FUNCTION(daos_cont_destroy(poh, name, 0, NULL) == 0);		\
+	check_string(name, !(expect), type mod);
 
 int main(int argc, char **argv)
 {
@@ -42,7 +70,7 @@ int main(int argc, char **argv)
 
 	FOREACH_TYPE(DECLARE_ACTION, poh, coh);
 
-	FOREACH_TYPE(RUN_ACTION, poh, coh);
+	FOREACH_ALL(RUN_ACTION, poh, coh);
 
 	return 0;
 }

--- a/src/client/api/compile_check.c
+++ b/src/client/api/compile_check.c
@@ -7,41 +7,42 @@
 #include <gurt/debug.h>
 #include <daos.h>
 
-#define check_string_non_literal(var, expect)						\
-	D_CASSERT(d_is_string_non_literal(var) == expect)
+#if defined(__cplusplus)
+#define check_uuid(var, expect) (void)0
+#else
+#define check_uuid(var, expect)			\
+	D_CASSERT(d_is_uuid(var) == expect)
+#endif
 
-#define check_string_literal(var, expect)						\
-	D_CASSERT(d_is_string_literal(var) == expect)
+#define FOREACH_TYPE(ACTION, poh, coh)					\
+	ACTION(uuid_t,       uuid,   noop, {0},  poh, coh, true)	\
+	ACTION(const uuid_t, cuuid,  noop, {0},  poh, coh, true)	\
+	ACTION(char *,       charp,  noop, NULL, poh, coh, false)	\
+	ACTION(const char *, ccharp, noop, NULL, poh, coh, false)	\
+	ACTION(char,         arr,    [10], {0},  poh, coh, false)	\
+	ACTION(const char,   carr,   [10], {0},  poh, coh, false)
+
+#define FOREACH_ALL(ACTION, poh, coh)					\
+	FOREACH_TYPE(ACTION, poh, coh)					\
+	ACTION(noop,         "STR",  noop, noop, poh, coh, false)
+
+#define DECLARE_ACTION(type, name, mod, init, poh, coh, expect)	\
+	type	name mod = init;
+
+#define RUN_ACTION(type, name, mod, init, poh, coh, expect)			\
+	check_uuid(name, expect);						\
+	D_ASSERT(daos_pool_connect(name, NULL, 0, &poh, NULL, NULL) == 0);	\
+	D_ASSERT(daos_cont_open(poh, name, 0, &coh, NULL, NULL) == 0);		\
+	D_ASSERT(daos_cont_destroy(poh, name, 0, NULL) == 0);
 
 int main(int argc, char **argv)
 {
-	uuid_t	uuid = {0};
 	daos_handle_t	coh;
-	daos_handle_t	poh = {0};
-	char *charp = NULL;
-	const char *ccharp = "hello";
-	char	arr[10] = {0};
-	const char	carr[10] = {0};
+	daos_handle_t	poh;
 
-	/* Test compilation with real APIs */
-	D_ASSERT(daos_pool_connect(uuid, NULL, 0, &poh, NULL, NULL) == 0);
-	D_ASSERT(daos_pool_connect(arr, NULL, 0, &poh, NULL, NULL) == 0);
-	D_ASSERT(daos_pool_connect(carr, NULL, 0, &poh, NULL, NULL) == 0);
-	D_ASSERT(daos_pool_connect(ccharp, NULL, 0, &poh, NULL, NULL) == 0);
-	D_ASSERT(daos_pool_connect(charp, NULL, 0, &poh, NULL, NULL) == 0);
-	D_ASSERT(daos_pool_connect("Hello", NULL, 0, &poh, NULL, NULL) == 0);
-	D_ASSERT(daos_cont_open(poh, uuid, 0, &coh, NULL, NULL) == 0);
-	D_ASSERT(daos_cont_open(poh, arr, 0, &coh, NULL, NULL) == 0);
-	D_ASSERT(daos_cont_open(poh, carr, 0, &coh, NULL, NULL) == 0);
-	D_ASSERT(daos_cont_open(poh, ccharp, 0, &coh, NULL, NULL) == 0);
-	D_ASSERT(daos_cont_open(poh, charp, 0, &coh, NULL, NULL) == 0);
-	D_ASSERT(daos_cont_open(poh, "Hello", 0, &coh, NULL, NULL) == 0);
-	D_ASSERT(daos_cont_destroy(poh, uuid, 0, NULL) == 0);
-	D_ASSERT(daos_cont_destroy(poh, arr, 0, NULL) == 0);
-	D_ASSERT(daos_cont_destroy(poh, carr, 0, NULL) == 0);
-	D_ASSERT(daos_cont_destroy(poh, ccharp, 0, NULL) == 0);
-	D_ASSERT(daos_cont_destroy(poh, charp, 0, NULL) == 0);
-	D_ASSERT(daos_cont_destroy(poh, "Hello", 0, NULL) == 0);
+	FOREACH_TYPE(DECLARE_ACTION, poh, coh);
+
+	FOREACH_TYPE(RUN_ACTION, poh, coh);
 
 	return 0;
 }

--- a/src/client/api/compile_check_cpp.cpp
+++ b/src/client/api/compile_check_cpp.cpp
@@ -1,0 +1,7 @@
+/*
+ * (C) Copyright 2021 Intel Corporation.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause-Patent
+ */
+
+#include "compile_check.c"

--- a/src/common/SConscript
+++ b/src/common/SConscript
@@ -15,15 +15,17 @@ def build_daos_common(env, client, prereqs):
     """ Building non-pmem version for client's common lib"""
     denv = env.Clone()
 
+    common_libs = ['isal', 'isal_crypto', 'cart', 'gurt', 'lz4', 'protobuf-c', 'uuid', 'pthread']
     if client:
         libname = 'libdaos_common'
     else:
+        common_libs.extend(['pmemobj'])
         denv.Append(CPPDEFINES=['-DDAOS_PMEM_BUILD'])
         denv.Append(OBJPREFIX="v_")
         libname = 'libdaos_common_pmem'
         prereqs.require(denv, 'pmdk')
 
-    common = daos_build.library(denv, libname, COMMON_FILES)
+    common = daos_build.library(denv, libname, COMMON_FILES, LIBS=common_libs)
     denv.Install('$PREFIX/lib64/', common)
 
 def build_dts_library(env):

--- a/src/common/SConscript
+++ b/src/common/SConscript
@@ -80,8 +80,7 @@ def scons():
     denv = env.Clone(LIBS=[])
     prereqs.require(denv, 'isal', 'isal_crypto', 'protobufc')
     denv.AppendUnique(LIBS=['cart', 'gurt', 'lz4'])
-    common_lib = build_daos_common(denv, True, prereqs)
-    Export('common_lib')
+    build_daos_common(denv, True, prereqs)
 
     control_tgts = [File('control.c')]
     Export('control_tgts')

--- a/src/common/SConscript
+++ b/src/common/SConscript
@@ -80,7 +80,8 @@ def scons():
     denv = env.Clone(LIBS=[])
     prereqs.require(denv, 'isal', 'isal_crypto', 'protobufc')
     denv.AppendUnique(LIBS=['cart', 'gurt', 'lz4'])
-    build_daos_common(denv, True, prereqs)
+    common_lib = build_daos_common(denv, True, prereqs)
+    Export('common_lib')
 
     control_tgts = [File('control.c')]
     Export('control_tgts')

--- a/src/control/cmd/daos/container.go
+++ b/src/control/cmd/daos/container.go
@@ -87,7 +87,7 @@ func (cmd *containerBaseCmd) openContainer() error {
 		defer freeString(cLabel)
 
 		cmd.log.Debugf("opening container: %s", cmd.contLabel)
-		rc = C.daos_cont_open(cmd.cPoolHandle, cLabel, openFlags,
+		rc = C.daos_cont_open2(cmd.cPoolHandle, cLabel, openFlags,
 			&cmd.cContHandle, &contInfo, nil)
 		if rc == 0 {
 			var err error
@@ -101,7 +101,7 @@ func (cmd *containerBaseCmd) openContainer() error {
 		cmd.log.Debugf("opening container: %s", cmd.contUUID)
 		cUUIDstr := C.CString(cmd.contUUID.String())
 		defer freeString(cUUIDstr)
-		rc = C.daos_cont_open(cmd.cPoolHandle, cUUIDstr,
+		rc = C.daos_cont_open2(cmd.cPoolHandle, cUUIDstr,
 			openFlags, &cmd.cContHandle, nil, nil)
 	default:
 		return errors.New("no container UUID or label supplied")
@@ -551,12 +551,12 @@ func (cmd *containerDestroyCmd) Execute(_ []string) error {
 	case cmd.ContainerID().HasUUID():
 		cUUIDstr := C.CString(cmd.contUUID.String())
 		defer freeString(cUUIDstr)
-		rc = C.daos_cont_destroy(cmd.cPoolHandle, cUUIDstr,
+		rc = C.daos_cont_destroy2(cmd.cPoolHandle, cUUIDstr,
 			goBool2int(cmd.Force), nil)
 	case cmd.ContainerID().Label != "":
 		cLabel := C.CString(cmd.ContainerID().Label)
 		defer freeString(cLabel)
-		rc = C.daos_cont_destroy(cmd.cPoolHandle,
+		rc = C.daos_cont_destroy2(cmd.cPoolHandle,
 			cLabel, goBool2int(cmd.Force), nil)
 	default:
 		return errors.New("no UUID or label or path for container")

--- a/src/control/cmd/daos/pool.go
+++ b/src/control/cmd/daos/pool.go
@@ -77,7 +77,7 @@ func (cmd *poolBaseCmd) connectPool() error {
 		defer freeString(cLabel)
 
 		cmd.log.Debugf("connecting to pool: %s", cmd.PoolID().Label)
-		rc = C.daos_pool_connect(cLabel, cSysName, C.DAOS_PC_RW,
+		rc = C.daos_pool_connect2(cLabel, cSysName, C.DAOS_PC_RW,
 			&cmd.cPoolHandle, &poolInfo, nil)
 		if rc == 0 {
 			var err error
@@ -92,7 +92,7 @@ func (cmd *poolBaseCmd) connectPool() error {
 		cmd.log.Debugf("connecting to pool: %s", cmd.poolUUID)
 		cUUIDstr := C.CString(cmd.poolUUID.String())
 		defer freeString(cUUIDstr)
-		rc = C.daos_pool_connect(cUUIDstr, cSysName, C.DAOS_PC_RW,
+		rc = C.daos_pool_connect2(cUUIDstr, cSysName, C.DAOS_PC_RW,
 			&cmd.cPoolHandle, nil, nil)
 	default:
 		return errors.New("no pool UUID or label supplied")

--- a/src/include/daos_cont.h
+++ b/src/include/daos_cont.h
@@ -167,7 +167,6 @@ daos_cont_create_by_label(daos_handle_t poh, const char *label,
 			  daos_prop_t *cont_prop, uuid_t *uuid,
 			  daos_event_t *ev);
 
-#if DAOS_MACRO
 /**
  * Open an existing container identified by \a cont, a label or UUID string.
  * Upon successful completion, \a coh and \a info, both of which shall be
@@ -194,7 +193,6 @@ daos_cont_create_by_label(daos_handle_t poh, const char *label,
 int
 daos_cont_open(daos_handle_t poh, const char *cont, unsigned int flags, daos_handle_t *coh,
 	       daos_cont_info_t *info, daos_event_t *ev);
-#endif /* DAOS_MACRO */
 
 /**
  * Close a container handle. Upon successful completion, the container handle's
@@ -214,7 +212,6 @@ daos_cont_open(daos_handle_t poh, const char *cont, unsigned int flags, daos_han
 int
 daos_cont_close(daos_handle_t coh, daos_event_t *ev);
 
-#if DAOS_MACRO
 /**
  * Destroy a container identified by \a cont, a label or UUID string associated
  * with the container. All objects within this container will be destroyed.
@@ -242,7 +239,6 @@ daos_cont_close(daos_handle_t coh, daos_event_t *ev);
  */
 int
 daos_cont_destroy(daos_handle_t poh, const char *cont, int force, daos_event_t *ev);
-#endif /* DAOS_MACRO */
 
 /**
  * Query container information.
@@ -681,15 +677,16 @@ daos_cont_destroy2(daos_handle_t poh, const char *cont, int force,
 #if defined(__cplusplus)
 }
 
+#define daos_cont_open daos_cont_open_cpp
 static inline int
-daos_cont_open(daos_handle_t poh, const char *cont, unsigned int flags, daos_handle_t *coh,
-	       daos_cont_info_t *info, daos_event_t *ev)
+daos_cont_open_cpp(daos_handle_t poh, const char *cont, unsigned int flags, daos_handle_t *coh,
+		   daos_cont_info_t *info, daos_event_t *ev)
 {
 	return daos_cont_open2(poh, cont, flags, coh, info, ev);
 }
 
 static inline int
-daos_cont_open(daos_handle_t poh, const uuid_t cont, unsigned int flags, daos_handle_t *coh,
+daos_cont_open_cpp(daos_handle_t poh, const uuid_t cont, unsigned int flags, daos_handle_t *coh,
 	       daos_cont_info_t *info, daos_event_t *ev)
 {
 	char str[37];
@@ -698,14 +695,15 @@ daos_cont_open(daos_handle_t poh, const uuid_t cont, unsigned int flags, daos_ha
 	return daos_cont_open2(poh, str, flags, coh, info, ev);
 }
 
+#define daos_cont_destroy daos_cont_destroy_cpp
 static inline int
-daos_cont_destroy(daos_handle_t poh, const char *cont, int force, daos_event_t *ev)
+daos_cont_destroy_cpp(daos_handle_t poh, const char *cont, int force, daos_event_t *ev)
 {
 	return daos_cont_destroy2(poh, cont, force, ev);
 }
 
 static inline int
-daos_cont_destroy(daos_handle_t poh, const uuid_t cont, int force, daos_event_t *ev)
+daos_cont_destroy_cpp(daos_handle_t poh, const uuid_t cont, int force, daos_event_t *ev)
 {
 	char str[37];
 

--- a/src/include/daos_cont.h
+++ b/src/include/daos_cont.h
@@ -721,12 +721,12 @@ daos_cont_destroy_cpp(daos_handle_t poh, const uuid_t cont, int force, daos_even
 	({								\
 		int _ret;						\
 		char _str[37];						\
-		const char *__str;					\
-		if (d_is_uuid(co)) {					\
+		const char *__str = NULL;				\
+		if (d_is_string(co)) {					\
+			__str = (const char *)(co);			\
+		} else if (d_is_uuid(co)) {				\
 			uuid_unparse((unsigned char *)(co), _str);	\
 			__str = _str;					\
-		} else {						\
-			__str = (const char *)(co);			\
 		}							\
 		_ret = daos_cont_open2((poh), __str, __VA_ARGS__);	\
 		_ret;							\
@@ -740,12 +740,12 @@ daos_cont_destroy_cpp(daos_handle_t poh, const uuid_t cont, int force, daos_even
 	({								\
 		int _ret;						\
 		char _str[37];						\
-		const char *__str;					\
-		if (d_is_uuid(co)) {					\
+		const char *__str = NULL;				\
+		if (d_is_string(co)) {					\
+			__str = (const char *)(co);			\
+		} else if (d_is_uuid(co)) {				\
 			uuid_unparse((unsigned char *)(co), _str);	\
 			__str = _str;					\
-		} else {						\
-			__str = (const char *)(co);			\
 		}							\
 		_ret = daos_cont_destroy2((poh), __str, __VA_ARGS__);	\
 		_ret;							\

--- a/src/include/daos_cont.h
+++ b/src/include/daos_cont.h
@@ -713,7 +713,6 @@ daos_cont_destroy_cpp(daos_handle_t poh, const uuid_t cont, int force, daos_even
 	return daos_cont_destroy2(poh, str, force, ev);
 }
 #else
-
  /**
   * for backward compatility, support old api where a const uuid_t was used
   * instead of a string to identify the container.
@@ -723,9 +722,7 @@ daos_cont_destroy_cpp(daos_handle_t poh, const uuid_t cont, int force, daos_even
 		int _ret;						\
 		char _str[37];						\
 		const char *__str;					\
-		if (__builtin_types_compatible_p(typeof(co), uuid_t) ||	\
-		    __builtin_types_compatible_p(typeof(co),		\
-						 const uuid_t)) {	\
+		if (d_is_uuid(co)) {					\
 			uuid_unparse((unsigned char *)(co), _str);	\
 			__str = _str;					\
 		} else {						\
@@ -744,9 +741,7 @@ daos_cont_destroy_cpp(daos_handle_t poh, const uuid_t cont, int force, daos_even
 		int _ret;						\
 		char _str[37];						\
 		const char *__str;					\
-		if (__builtin_types_compatible_p(typeof(co), uuid_t) ||	\
-		    __builtin_types_compatible_p(typeof(co),		\
-						 const uuid_t)) {	\
+		if (d_is_uuid(co)) {					\
 			uuid_unparse((unsigned char *)(co), _str);	\
 			__str = _str;					\
 		} else {						\
@@ -756,5 +751,5 @@ daos_cont_destroy_cpp(daos_handle_t poh, const uuid_t cont, int force, daos_even
 		_ret;							\
 	})
 
-#endif
+#endif /* __cplusplus */
 #endif /* __DAOS_CONT_H__ */

--- a/src/include/daos_cont.h
+++ b/src/include/daos_cont.h
@@ -660,16 +660,18 @@ int
 daos_cont_destroy_snap(daos_handle_t coh, daos_epoch_range_t epr,
 		       daos_event_t *ev);
 
+/**
+ * Backward compatibility code.
+ * Please don't use directly
+ */
+int
+daos_cont_open2(daos_handle_t poh, const char *cont, unsigned int flags,
+		daos_handle_t *coh, daos_cont_info_t *info, daos_event_t *ev);
 
 /**
  * Backward compatibility code.
  * Please don't use directly
  */
-
-int
-daos_cont_open2(daos_handle_t poh, const char *cont, unsigned int flags,
-		daos_handle_t *coh, daos_cont_info_t *info, daos_event_t *ev);
-
 int
 daos_cont_destroy2(daos_handle_t poh, const char *cont, int force,
 		   daos_event_t *ev);
@@ -733,6 +735,10 @@ daos_cont_destroy_cpp(daos_handle_t poh, const uuid_t cont, int force, daos_even
 		_ret;							\
 	})
 
+ /**
+  * for backward compatility, support old api where a const uuid_t was used
+  * instead of a string to identify the container.
+  */
 #define daos_cont_destroy(poh, co, ...)					\
 	({								\
 		int _ret;						\

--- a/src/include/daos_pool.h
+++ b/src/include/daos_pool.h
@@ -163,7 +163,6 @@ struct daos_pool_cont_info {
 	char		pci_label[DAOS_PROP_LABEL_MAX_LEN+1];
 };
 
-#if DAOS_MACRO
 /**
  * Connect to the DAOS pool identified by \a pool, a label or UUID string.
  * Upon a successful completion, \a poh returns the pool handle, and \a info
@@ -191,7 +190,6 @@ struct daos_pool_cont_info {
 int
 daos_pool_connect(const char *pool, const char *sys, unsigned int flags,
 		  daos_handle_t *poh, daos_pool_info_t *info, daos_event_t *ev);
-#endif /* DAOS_MACRO */
 
 /**
  * Disconnect from the DAOS pool. It should revoke all the container open
@@ -426,16 +424,17 @@ daos_pool_connect2(const char *pool, const char *sys, unsigned int flags,
 
 #if defined(__cplusplus)
 }
+#define daos_pool_connect daos_pool_connect_cpp
 static inline int
-daos_pool_connect(const char *pool, const char *sys, unsigned int flags,
-		  daos_handle_t *poh, daos_pool_info_t *info, daos_event_t *ev)
+daos_pool_connect_cpp(const char *pool, const char *sys, unsigned int flags, daos_handle_t *poh,
+		      daos_pool_info_t *info, daos_event_t *ev)
 {
 	return daos_pool_connect2(pool, sys, flags, poh, info, ev);
 }
 
 static inline int
-daos_pool_connect(const uuid_t pool, const char *sys, unsigned int flags,
-		  daos_handle_t *poh, daos_pool_info_t *info, daos_event_t *ev)
+daos_pool_connect_cpp(const uuid_t pool, const char *sys, unsigned int flags, daos_handle_t *poh,
+		      daos_pool_info_t *info, daos_event_t *ev)
 {
 	char str[37];
 

--- a/src/include/daos_pool.h
+++ b/src/include/daos_pool.h
@@ -449,12 +449,12 @@ daos_pool_connect_cpp(const uuid_t pool, const char *sys, unsigned int flags, da
 	({								\
 		int _ret;						\
 		char _str[37];						\
-		const char *__str;					\
-		if (d_is_uuid(po)) {					\
+		const char *__str = NULL;				\
+		if (d_is_string(po)) {					\
+			__str = (const char *)(po);			\
+		} else if (d_is_uuid(po)) {				\
 			uuid_unparse((unsigned char *)(po), _str);	\
 			__str = _str;					\
-		} else {						\
-			__str = (const char *)(po);			\
 		}							\
 		_ret = daos_pool_connect2(__str, __VA_ARGS__);		\
 		_ret;							\

--- a/src/include/daos_pool.h
+++ b/src/include/daos_pool.h
@@ -450,9 +450,7 @@ daos_pool_connect_cpp(const uuid_t pool, const char *sys, unsigned int flags, da
 		int _ret;						\
 		char _str[37];						\
 		const char *__str;					\
-		if (__builtin_types_compatible_p(typeof(po), uuid_t) ||	\
-		    __builtin_types_compatible_p(typeof(po),		\
-						 const uuid_t)) {	\
+		if (d_is_uuid(po)) {					\
 			uuid_unparse((unsigned char *)(po), _str);	\
 			__str = _str;					\
 		} else {						\

--- a/src/include/daos_pool.h
+++ b/src/include/daos_pool.h
@@ -416,7 +416,6 @@ daos_pool_list_cont(daos_handle_t poh, daos_size_t *ncont,
  * Backward compatibility code.
  * Please don't use directly
  */
-
 int
 daos_pool_connect2(const char *pool, const char *sys, unsigned int flags,
 		   daos_handle_t *poh, daos_pool_info_t *info, daos_event_t *ev);

--- a/src/include/daos_prop.h
+++ b/src/include/daos_prop.h
@@ -373,7 +373,7 @@ struct daos_prop_entry {
 static inline bool
 daos_label_is_valid(const char *label)
 {
-	size_t	len;
+	int	len;
 	int	i;
 
 	/** Label cannot be NULL */

--- a/src/include/gurt/types.h
+++ b/src/include/gurt/types.h
@@ -33,6 +33,10 @@
 
 #if defined(__cplusplus)
 extern "C" {
+#else
+#define d_is_uuid(var)						\
+	(__builtin_types_compatible_p(typeof(var), uuid_t) ||	\
+	 __builtin_types_compatible_p(typeof(var), const uuid_t))
 #endif
 
 #if defined(__has_warning)

--- a/src/include/gurt/types.h
+++ b/src/include/gurt/types.h
@@ -34,9 +34,14 @@
 #if defined(__cplusplus)
 extern "C" {
 #else
-#define d_is_uuid(var)						\
-	(__builtin_types_compatible_p(typeof(var), uuid_t) ||	\
+#define d_is_uuid(var)							\
+	(__builtin_types_compatible_p(typeof(var), uuid_t) ||		\
 	 __builtin_types_compatible_p(typeof(var), const uuid_t))
+#define d_is_string(var)						\
+	(__builtin_types_compatible_p(typeof(var), char *) ||		\
+	 __builtin_types_compatible_p(typeof(var), const char *) ||	\
+	 __builtin_types_compatible_p(typeof(var), const char []) ||	\
+	 __builtin_types_compatible_p(typeof(var), char []))
 #endif
 
 #if defined(__has_warning)

--- a/src/include/gurt/types.h
+++ b/src/include/gurt/types.h
@@ -34,8 +34,10 @@
 #if defined(__cplusplus)
 extern "C" {
 #else
-#define d_is_uuid(var)							\
-	(__builtin_types_compatible_p(typeof(var), uuid_t) ||		\
+#define d_is_uuid(var)								\
+	(__builtin_types_compatible_p(typeof(var), uuid_t) ||			\
+	 __builtin_types_compatible_p(typeof(var), unsigned char *) ||		\
+	 __builtin_types_compatible_p(typeof(var), const unsigned char *) ||	\
 	 __builtin_types_compatible_p(typeof(var), const uuid_t))
 #define d_is_string(var)						\
 	(__builtin_types_compatible_p(typeof(var), char *) ||		\


### PR DESCRIPTION
A recent patch (PR #6138) broke C++ compilation.  This restores
it and adds a compiler test to check it.

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>