### PR TITLE
DAOS-8047 agent: Allow user-defined fabric interfaces

### DIFF
--- a/src/control/cmd/daos_agent/config_test.go
+++ b/src/control/cmd/daos_agent/config_test.go
@@ -1,0 +1,152 @@
+//
+// (C) Copyright 2021 Intel Corporation.
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+
+package main
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/pkg/errors"
+
+	"github.com/daos-stack/daos/src/control/common"
+	"github.com/daos-stack/daos/src/control/security"
+)
+
+func TestAgent_LoadConfig(t *testing.T) {
+	dir, cleanup := common.CreateTestDir(t)
+	defer cleanup()
+
+	junkFile := common.CreateTestFile(t, dir, "One ring to rule them all\n")
+	emptyFile := common.CreateTestFile(t, dir, "")
+
+	withoutOptCfg := common.CreateTestFile(t, dir, `
+name: shire
+access_points: ["one:10001", "two:10001"]
+port: 4242
+runtime_dir: /tmp/runtime
+log_file: /home/frodo/logfile
+transport_config:
+  allow_insecure: true
+`)
+
+	fabricCfg := common.CreateTestFile(t, dir, `
+name: shire
+access_points: ["one:10001", "two:10001"]
+port: 4242
+runtime_dir: /tmp/runtime
+log_file: /home/frodo/logfile
+transport_config:
+  allow_insecure: true
+fabric_ifaces:
+-
+  numa_node: 0
+  devices:
+  -
+     iface: ib0
+     domain: mlx5_0
+  -
+     iface: ib1
+     domain: mlx5_1
+-
+  numa_node: 1
+  devices:
+  -
+     iface: ib2
+     domain: mlx5_2
+  -
+     iface: ib3
+     domain: mlx5_3
+`)
+
+	for name, tc := range map[string]struct {
+		path      string
+		expResult *Config
+		expErr    error
+	}{
+		"empty path": {
+			expErr: errors.New("no path"),
+		},
+		"bad path": {
+			path:   "/not/real/path",
+			expErr: errors.New("no such file"),
+		},
+		"not a config file": {
+			path:   junkFile,
+			expErr: errors.New("yaml: unmarshal error"),
+		},
+		"empty config file": {
+			path:      emptyFile,
+			expResult: DefaultConfig(),
+		},
+		"without optional items": {
+			path: withoutOptCfg,
+			expResult: &Config{
+				SystemName:   "shire",
+				AccessPoints: []string{"one:10001", "two:10001"},
+				ControlPort:  4242,
+				RuntimeDir:   "/tmp/runtime",
+				LogFile:      "/home/frodo/logfile",
+				TransportConfig: &security.TransportConfig{
+					AllowInsecure:     true,
+					CertificateConfig: DefaultConfig().TransportConfig.CertificateConfig,
+				},
+			},
+		},
+		"manual fabric config": {
+			path: fabricCfg,
+			expResult: &Config{
+				SystemName:   "shire",
+				AccessPoints: []string{"one:10001", "two:10001"},
+				ControlPort:  4242,
+				RuntimeDir:   "/tmp/runtime",
+				LogFile:      "/home/frodo/logfile",
+				TransportConfig: &security.TransportConfig{
+					AllowInsecure:     true,
+					CertificateConfig: DefaultConfig().TransportConfig.CertificateConfig,
+				},
+				FabricInterfaces: []*NUMAFabricConfig{
+					{
+						NUMANode: 0,
+						Interfaces: []*FabricInterfaceConfig{
+							{
+								Interface: "ib0",
+								Domain:    "mlx5_0",
+							},
+							{
+								Interface: "ib1",
+								Domain:    "mlx5_1",
+							},
+						},
+					},
+					{
+						NUMANode: 1,
+						Interfaces: []*FabricInterfaceConfig{
+							{
+								Interface: "ib2",
+								Domain:    "mlx5_2",
+							},
+							{
+								Interface: "ib3",
+								Domain:    "mlx5_3",
+							},
+						},
+					},
+				},
+			},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			result, err := LoadConfig(tc.path)
+
+			common.CmpErr(t, tc.expErr, err)
+			if diff := cmp.Diff(tc.expResult, result, cmpopts.IgnoreUnexported(security.CertificateConfig{})); diff != "" {
+				t.Fatalf("(want-, got+):\n%s", diff)
+			}
+		})
+	}
+}

--- a/src/control/cmd/daos_agent/fabric.go
+++ b/src/control/cmd/daos_agent/fabric.go
@@ -24,9 +24,9 @@ func FabricNotFoundErr(netDevClass uint32) error {
 
 // FabricInterface represents a generic fabric interface.
 type FabricInterface struct {
-	Name        string `yaml:"name"`
-	Domain      string `yaml:"domain"`
-	NetDevClass uint32 `yaml:"net_dev_class"`
+	Name        string
+	Domain      string
+	NetDevClass uint32
 }
 
 // DefaultFabricInterface is the one used if no devices are found on the system.
@@ -34,6 +34,10 @@ var DefaultFabricInterface = &FabricInterface{
 	Name:   "lo",
 	Domain: "lo",
 }
+
+// FabricDevClassManual is a wildcard netDevClass that indicates the device was
+// supplied by the user.
+const FabricDevClassManual = uint32(1 << 31)
 
 // NUMAFabric represents a set of fabric interfaces organized by NUMA node.
 type NUMAFabric struct {
@@ -105,7 +109,7 @@ func (n *NUMAFabric) getDeviceFromNUMA(numaNode int, netDevClass uint32) (*Fabri
 			return nil, err
 		}
 
-		if fabricIF.NetDevClass != netDevClass {
+		if fabricIF.NetDevClass != netDevClass && fabricIF.NetDevClass != FabricDevClassManual {
 			n.log.Debugf("Excluding device: %s, network device class: %s from attachInfoCache. Does not match network device class: %s",
 				fabricIF.Name, netdetect.DevClassName(fabricIF.NetDevClass), netdetect.DevClassName(netDevClass))
 			continue
@@ -154,6 +158,14 @@ func (n *NUMAFabric) getNextDevIndex(numaNode int) (int, error) {
 	return 0, fmt.Errorf("no fabric interfaces on NUMA node %d", numaNode)
 }
 
+func (n *NUMAFabric) setDefaultNUMANode() {
+	for numa := range n.numaMap {
+		n.defaultNumaNode = numa
+		n.log.Debugf("The default NUMA node is: %d", numa)
+		break
+	}
+}
+
 func newNUMAFabric(log logging.Logger) *NUMAFabric {
 	return &NUMAFabric{
 		log:               log,
@@ -193,15 +205,31 @@ func NUMAFabricFromScan(ctx context.Context, log logging.Logger, scan []*netdete
 			newIF.Name, newIF.Domain, numa, fabric.NumDevices(numa)-1)
 	}
 
-	for numa := range fabric.numaMap {
-		fabric.defaultNumaNode = numa
-		log.Debugf("The default NUMA node is: %d", numa)
-		break
-	}
+	fabric.setDefaultNUMANode()
 
 	if fabric.NumNUMANodes() == 0 {
 		log.Info("No network devices detected in fabric scan\n")
 	}
+
+	return fabric
+}
+
+// NUMAFabricFromConfig generates a NUMAFabric layout based on a config.
+func NUMAFabricFromConfig(log logging.Logger, cfg []*NUMAFabricConfig) *NUMAFabric {
+	fabric := newNUMAFabric(log)
+
+	for _, fc := range cfg {
+		node := fc.NUMANode
+		for _, fi := range fc.Interfaces {
+			fabric.numaMap[node] = append(fabric.numaMap[node],
+				&FabricInterface{
+					Name:        fi.Interface,
+					Domain:      fi.Domain,
+					NetDevClass: FabricDevClassManual,
+				})
+		}
+	}
+	fabric.setDefaultNUMANode()
 
 	return fabric
 }

--- a/src/control/cmd/daos_agent/fabric_test.go
+++ b/src/control/cmd/daos_agent/fabric_test.go
@@ -287,6 +287,30 @@ func TestAgent_NUMAFabric_GetDevice(t *testing.T) {
 				NetDevClass: netdetect.Infiniband,
 			},
 		},
+		"manual FI matches any": {
+			nf: &NUMAFabric{
+				numaMap: map[int][]*FabricInterface{
+					0: {
+						{
+							Name:        "t1",
+							NetDevClass: FabricDevClassManual,
+						},
+					},
+					1: {
+						{
+							Name:        "t2",
+							NetDevClass: FabricDevClassManual,
+						},
+					},
+				},
+			},
+			node:        1,
+			netDevClass: netdetect.Infiniband,
+			expResult: &FabricInterface{
+				Name:        "t2",
+				NetDevClass: FabricDevClassManual,
+			},
+		},
 		"load balancing": {
 			nf: &NUMAFabric{
 				numaMap: map[int][]*FabricInterface{
@@ -568,6 +592,120 @@ func TestAgent_NUMAFabricFromScan(t *testing.T) {
 			defer common.ShowBufferOnFailure(t, buf)
 
 			result := NUMAFabricFromScan(context.TODO(), log, tc.input, tc.getDevAlias)
+
+			if diff := cmp.Diff(tc.expResult, result.numaMap); diff != "" {
+				t.Fatalf("-want, +got:\n%s", diff)
+			}
+
+			defaultNumaOK := false
+			for _, numa := range tc.possibleDefaultNUMA {
+				if numa == result.defaultNumaNode {
+					defaultNumaOK = true
+				}
+			}
+
+			if !defaultNumaOK {
+				t.Fatalf("default NUMA node %d (expected in list: %+v)", result.defaultNumaNode, tc.possibleDefaultNUMA)
+			}
+		})
+	}
+}
+
+func TestAgent_NUMAFabricFromConfig(t *testing.T) {
+	for name, tc := range map[string]struct {
+		input               []*NUMAFabricConfig
+		expResult           map[int][]*FabricInterface
+		possibleDefaultNUMA []int
+	}{
+		"empty input": {
+			expResult:           map[int][]*FabricInterface{},
+			possibleDefaultNUMA: []int{0},
+		},
+		"no devices on NUMA node": {
+			input: []*NUMAFabricConfig{
+				{
+					NUMANode:   1,
+					Interfaces: []*FabricInterfaceConfig{},
+				},
+			},
+			expResult:           map[int][]*FabricInterface{},
+			possibleDefaultNUMA: []int{0},
+		},
+		"single NUMA node": {
+			input: []*NUMAFabricConfig{
+				{
+					NUMANode: 1,
+					Interfaces: []*FabricInterfaceConfig{
+						{
+							Interface: "test0",
+							Domain:    "test0_domain",
+						},
+					},
+				},
+			},
+			expResult: map[int][]*FabricInterface{
+				1: {
+					{
+						Name:        "test0",
+						Domain:      "test0_domain",
+						NetDevClass: FabricDevClassManual,
+					},
+				},
+			},
+			possibleDefaultNUMA: []int{1},
+		},
+		"multiple devices": {
+			input: []*NUMAFabricConfig{
+				{
+					NUMANode: 0,
+					Interfaces: []*FabricInterfaceConfig{
+						{
+							Interface: "test1",
+						},
+						{
+							Interface: "test2",
+							Domain:    "test2_domain",
+						},
+					},
+				},
+				{
+					NUMANode: 1,
+					Interfaces: []*FabricInterfaceConfig{
+						{
+							Interface: "test0",
+							Domain:    "test0_domain",
+						},
+					},
+				},
+			},
+			expResult: map[int][]*FabricInterface{
+				0: {
+					{
+						Name:        "test1",
+						NetDevClass: FabricDevClassManual,
+					},
+					{
+						Name:        "test2",
+						Domain:      "test2_domain",
+						NetDevClass: FabricDevClassManual,
+					},
+				},
+				1: {
+					{
+						Name:        "test0",
+						Domain:      "test0_domain",
+						NetDevClass: FabricDevClassManual,
+					},
+				},
+			},
+			possibleDefaultNUMA: []int{0, 1},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			log, buf := logging.NewTestLogger(t.Name())
+			defer common.ShowBufferOnFailure(t, buf)
+
+			result := NUMAFabricFromConfig(log, tc.input)
 
 			if diff := cmp.Diff(tc.expResult, result.numaMap); diff != "" {
 				t.Fatalf("-want, +got:\n%s", diff)

--- a/src/control/cmd/daos_agent/infocache.go
+++ b/src/control/cmd/daos_agent/infocache.go
@@ -139,7 +139,7 @@ func (c *localFabricCache) IsCached() bool {
 }
 
 // Cache caches the results of a fabric scan locally.
-func (c *localFabricCache) Cache(ctx context.Context, scan []*netdetect.FabricScan) {
+func (c *localFabricCache) CacheScan(ctx context.Context, scan []*netdetect.FabricScan) {
 	if c == nil {
 		return
 	}
@@ -147,15 +147,32 @@ func (c *localFabricCache) Cache(ctx context.Context, scan []*netdetect.FabricSc
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
 
-	if !c.IsEnabled() {
-		return
-	}
-
 	if c.getDevAlias == nil {
 		c.getDevAlias = netdetect.GetDeviceAlias
 	}
 
-	c.localNUMAFabric = NUMAFabricFromScan(ctx, c.log, scan, c.getDevAlias)
+	scanResult := NUMAFabricFromScan(ctx, c.log, scan, c.getDevAlias)
+	c.setCache(scanResult)
+}
+
+// Cache initializes the cache with a specific NUMAFabric.
+func (c *localFabricCache) Cache(ctx context.Context, nf *NUMAFabric) {
+	if c == nil || nf == nil {
+		return
+	}
+
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	c.setCache(nf)
+}
+
+func (c *localFabricCache) setCache(nf *NUMAFabric) {
+	if !c.IsEnabled() {
+		return
+	}
+
+	c.localNUMAFabric = nf
 
 	c.initialized.SetTrue()
 }

--- a/src/control/cmd/daos_agent/mgmt_rpc.go
+++ b/src/control/cmd/daos_agent/mgmt_rpc.go
@@ -132,11 +132,14 @@ func (mod *mgmtModule) handleGetAttachInfo(ctx context.Context, reqb []byte, pid
 func (mod *mgmtModule) getAttachInfo(ctx context.Context, numaNode int, sys string) (*mgmtpb.GetAttachInfoResp, error) {
 	resp, err := mod.getAttachInfoResp(ctx, numaNode, sys)
 	if err != nil {
+		mod.log.Errorf("failed to fetch remote AttachInfo: %s", err.Error())
 		return nil, err
 	}
 
 	fabricIF, err := mod.getFabricInterface(ctx, numaNode, resp.ClientNetHint.NetDevClass)
 	if err != nil {
+		mod.log.Errorf("failed to fetch fabric interface of type %s: %s",
+			netdetect.DevClassName(resp.ClientNetHint.NetDevClass), err.Error())
 		return nil, err
 	}
 

--- a/src/control/cmd/daos_agent/mgmt_rpc.go
+++ b/src/control/cmd/daos_agent/mgmt_rpc.go
@@ -203,7 +203,7 @@ func (mod *mgmtModule) getFabricInterface(ctx context.Context, numaNode int, net
 	if err != nil {
 		return nil, err
 	}
-	mod.fabricInfo.Cache(ctx, result)
+	mod.fabricInfo.CacheScan(ctx, result)
 
 	return mod.fabricInfo.GetDevice(numaNode, netDevClass)
 }

--- a/src/control/cmd/daos_agent/start.go
+++ b/src/control/cmd/daos_agent/start.go
@@ -69,6 +69,14 @@ func (cmd *startCmd) Execute(_ []string) error {
 	procmon := NewProcMon(cmd.log, cmd.ctlInvoker, cmd.cfg.SystemName)
 	procmon.startMonitoring(ctx)
 
+	fabricCache := newLocalFabricCache(cmd.log, ficEnabled)
+	if len(cmd.cfg.FabricInterfaces) > 0 {
+		// Cache is required to use user-defined fabric interfaces
+		fabricCache.enabled.SetTrue()
+		nf := NUMAFabricFromConfig(cmd.log, cmd.cfg.FabricInterfaces)
+		fabricCache.Cache(ctx, nf)
+	}
+
 	drpcServer.RegisterRPCModule(NewSecurityModule(cmd.log, cmd.cfg.TransportConfig))
 	drpcServer.RegisterRPCModule(&mgmtModule{
 		log:        cmd.log,


### PR DESCRIPTION
- Add the optional field "fabric_ifaces" to the DAOS agent config
  file, to allow users to specify the NUMA affinity of fabric
  interfaces. If provided, this is used instead of detecting the
  devices automatically.

Signed-off-by: Kris Jacque <kristin.jacque@intel.com>