### PR TITLE
DAOS-8145 rebuild: check rebuild property for rebuild regenerate

### DIFF
--- a/src/include/daos_srv/rebuild.h
+++ b/src/include/daos_srv/rebuild.h
@@ -40,7 +40,7 @@ int ds_rebuild_schedule(struct ds_pool *pool, uint32_t map_ver,
 			daos_rebuild_opc_t rebuild_op, uint64_t delay_sec);
 int ds_rebuild_query(uuid_t pool_uuid,
 		     struct daos_rebuild_status *status);
-int ds_rebuild_regenerate_task(struct ds_pool *pool);
+int ds_rebuild_regenerate_task(struct ds_pool *pool, daos_prop_t *prop);
 void ds_rebuild_leader_stop_all(void);
 void ds_rebuild_leader_stop(const uuid_t pool_uuid, unsigned int version);
 void ds_rebuild_abort(uuid_t pool_uuid, unsigned int version);

--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -1292,7 +1292,7 @@ pool_svc_step_up_cb(struct ds_rsvc *rsvc)
 		DP_UUID(svc->ps_uuid), DP_UUID(pool_hdl_uuid),
 		DP_UUID(cont_hdl_uuid));
 
-	rc = ds_rebuild_regenerate_task(svc->ps_pool);
+	rc = ds_rebuild_regenerate_task(svc->ps_pool, prop);
 	if (rc != 0)
 		goto out;
 

--- a/src/rebuild/srv.c
+++ b/src/rebuild/srv.c
@@ -1726,19 +1726,27 @@ regenerate_task_of_type(struct ds_pool *pool, pool_comp_state_t match_states,
 
 /* Regenerate the rebuild tasks when changing the leader. */
 int
-ds_rebuild_regenerate_task(struct ds_pool *pool)
+ds_rebuild_regenerate_task(struct ds_pool *pool, daos_prop_t *prop)
 {
-	int rc;
+	struct daos_prop_entry	*entry;
+	int			rc = 0;
 
 	rebuild_gst.rg_abort = 0;
 
-	rc = regenerate_task_of_type(pool, PO_COMP_ST_DOWN, RB_OP_FAIL);
-	if (rc != 0)
-		return rc;
+	entry = daos_prop_entry_get(prop, DAOS_PROP_PO_SELF_HEAL);
+	D_ASSERT(entry != NULL);
+	if (entry->dpe_val & DAOS_SELF_HEAL_AUTO_REBUILD) {
+		rc = regenerate_task_of_type(pool, PO_COMP_ST_DOWN, RB_OP_FAIL);
+		if (rc != 0)
+			return rc;
 
-	rc = regenerate_task_of_type(pool, PO_COMP_ST_DRAIN, RB_OP_DRAIN);
-	if (rc != 0)
-		return rc;
+		rc = regenerate_task_of_type(pool, PO_COMP_ST_DRAIN, RB_OP_DRAIN);
+		if (rc != 0)
+			return rc;
+	} else {
+		D_DEBUG(DB_REBUILD, DF_UUID" self healing is disabled\n",
+			DP_UUID(pool->sp_uuid));
+	}
 
 	rc = regenerate_task_of_type(pool, PO_COMP_ST_UP, RB_OP_REINT);
 	if (rc != 0)


### PR DESCRIPTION
Check if the pool auto-healing property is set before regenerate
the rebuild task.

Signed-off-by: Di Wang <di.wang@intel.com>