### PR TITLE
DAOS-8029 tests: add EC object verify to daos racer

### DIFF
--- a/src/tests/daos_racer.c
+++ b/src/tests/daos_racer.c
@@ -85,7 +85,7 @@ oclass_get(unsigned int random)
 	case EC_4P1G1:
 		return OC_EC_4P1G1;
 	case EC_4P2G2:
-		return OC_EC_4P2G1;
+		return OC_EC_4P2G2;
 	case EC_4P2GX:
 		return OC_EC_4P2GX;
 	default:
@@ -435,6 +435,14 @@ racer_valid_oid(daos_obj_id_t oid, daos_pool_info_t *pinfo)
 	case OC_RP_3G2:
 		required_node = 3;
 		required_tgt = 6;
+		break;
+	case OC_EC_4P1G1:
+		required_node = 5;
+		required_tgt = 5;
+		break;
+	case OC_EC_4P2G2:
+		required_node = 6;
+		required_tgt = 12;
 		break;
 	default:
 		return false;


### PR DESCRIPTION
Add EC object verify to daos racer.

Signed-off-by: Di Wang <di.wang@intel.com>