### PR TITLE
DAOS-8151 control: Fix races in agent info/fabric caches

### DIFF
--- a/src/control/cmd/daos_agent/infocache_test.go
+++ b/src/control/cmd/daos_agent/infocache_test.go
@@ -381,6 +381,7 @@ func TestAgent_localFabricCache_GetDevice(t *testing.T) {
 				},
 			},
 		},
+		numaDevIndexMap: make(map[int]chan int),
 	}
 
 	for name, tc := range map[string]struct {
@@ -416,6 +417,12 @@ func TestAgent_localFabricCache_GetDevice(t *testing.T) {
 				tc.lfc.log = log
 				if tc.lfc.localNUMAFabric != nil {
 					tc.lfc.localNUMAFabric.log = log
+				}
+
+				if tc.lfc.localNUMAFabric != nil {
+					ctx, cancel := context.WithCancel(context.Background())
+					defer cancel()
+					tc.lfc.localNUMAFabric.startDevIdxLoops(ctx)
 				}
 			}
 


### PR DESCRIPTION
* Use per-numa channel to read next dev idx