### PR TITLE
DAOS-8151 agent: Fix data races

### DIFF
--- a/src/control/cmd/daos_agent/infocache.go
+++ b/src/control/cmd/daos_agent/infocache.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 
 	"github.com/pkg/errors"
+	"google.golang.org/protobuf/proto"
 
 	mgmtpb "github.com/daos-stack/daos/src/control/common/proto/mgmt"
 	"github.com/daos-stack/daos/src/control/lib/atm"
@@ -97,7 +98,8 @@ func (c *attachInfoCache) GetAttachInfoResp() (*mgmtpb.GetAttachInfoResp, error)
 		return nil, NotCachedErr
 	}
 
-	return c.attachInfo, nil
+	aiCopy := proto.Clone(c.attachInfo)
+	return aiCopy.(*mgmtpb.GetAttachInfoResp), nil
 }
 
 func newLocalFabricCache(log logging.Logger, enabled bool) *localFabricCache {


### PR DESCRIPTION
- Protect NUMAFabric structure internals with a lock.
- Return copies of data from caches instead of references.
- Improve testing of round robin interface choice.
- Remove duplicate testing and unreachable code.

Signed-off-by: Kris Jacque <kristin.jacque@intel.com>