### PR TITLE
DAOS-7996 objects: use st_shard_id for remote punch

### DIFF
--- a/src/object/srv_obj_remote.c
+++ b/src/object/srv_obj_remote.c
@@ -244,7 +244,7 @@ ds_obj_remote_punch(struct dtx_leader_handle *dlh, void *data, int idx,
 	opi_parent = crt_req_get(parent_req);
 	opi = crt_req_get(req);
 	*opi = *opi_parent;
-	opi->opi_oid.id_shard = shard_tgt->st_shard;
+	opi->opi_oid.id_shard = shard_tgt->st_shard_id;
 	uuid_copy(opi->opi_co_hdl, opi_parent->opi_co_hdl);
 	uuid_copy(opi->opi_co_uuid, opi_parent->opi_co_uuid);
 	opi->opi_shard_tgts.ca_count = opi_parent->opi_shard_tgts.ca_count;

--- a/src/tests/suite/daos_rebuild_common.c
+++ b/src/tests/suite/daos_rebuild_common.c
@@ -172,6 +172,12 @@ rebuild_single_pool_rank(test_arg_t *arg, d_rank_t failed_rank, bool kill)
 }
 
 void
+reintegrate_single_pool_rank_no_disconnect(test_arg_t *arg, d_rank_t failed_rank)
+{
+	rebuild_targets(&arg, 1, &failed_rank, NULL, 1, false, RB_OP_TYPE_REINT);
+}
+
+void
 rebuild_pools_ranks(test_arg_t **args, int args_cnt, d_rank_t *failed_ranks,
 		    int ranks_nr, bool kill)
 {

--- a/src/tests/suite/daos_test.h
+++ b/src/tests/suite/daos_test.h
@@ -437,6 +437,7 @@ void dfs_ec_rebuild_io(void **state, int *shards, int shards_nr);
 void rebuild_single_pool_target(test_arg_t *arg, d_rank_t failed_rank,
 				int failed_tgt, bool kill);
 void rebuild_single_pool_rank(test_arg_t *arg, d_rank_t failed_rank, bool kill);
+void reintegrate_single_pool_rank_no_disconnect(test_arg_t *arg, d_rank_t failed_rank);
 void rebuild_pools_ranks(test_arg_t **args, int args_cnt,
 		d_rank_t *failed_ranks, int ranks_nr, bool kill);
 


### PR DESCRIPTION
Remote punch should use st_shard_id instead of st_shard,
because st_shard is the shard index, and st_shard_id is
the real ID for shard.

Add dfs punch open/create test.

Signed-off-by: Di Wang <di.wang@intel.com>