### PR TITLE
Update dfuse_bash_cmd.py

### DIFF
--- a/src/tests/ftest/io/dfuse_bash_cmd.py
+++ b/src/tests/ftest/io/dfuse_bash_cmd.py
@@ -20,7 +20,7 @@ class BashCmd(DfuseTestBase):
     """
 
     def test_bashcmd(self):
-        """Jira ID: DAOS-3508.
+        """Jira ID: DAOS-3508, DAOS-7860.
 
         Test Description:
             Purpose of this test is to mount different mount points of dfuse
@@ -45,6 +45,7 @@ class BashCmd(DfuseTestBase):
               Rename file
               Verify renamed file exist using list.
               Remove a directory
+              Test Memory Registration Problem with echo/cat
 
         :avocado: tags=all,full_regression
         :avocado: tags=hw,medium,ib2
@@ -92,7 +93,8 @@ class BashCmd(DfuseTestBase):
                                                abs_file_path2),
                             "ls -al {}".format(abs_file_path2),
                             "rm {}".format(abs_file_path2),
-                            "rmdir {}".format(abs_dir_path)]
+                            "rmdir {}".format(abs_dir_path),
+                            "echo 12345 > {0}/test; cat {0}/test".format(mount_dir)]
                 for cmd in commands:
                     try:
                         # execute bash cmds


### PR DESCRIPTION
Add echo/cat test for DAOS-7860. On Leap15 with pmem and verbs provider, if DAOS have Memory Registration Problem will not pass this test. Shouldn't be any problem for Centos and tmpfs.