### PR TITLE
(WIP) DAOS-8075 ctrl: Update storage prepare script for VMD unbind/reset

### DIFF
--- a/src/control/cmd/daos_server/storage.go
+++ b/src/control/cmd/daos_server/storage.go
@@ -64,12 +64,18 @@ func (cmd *storagePrepareCmd) Execute(args []string) error {
 			cmd.TargetUser = runningUser.Username
 		}
 
+		disablevmd := true
+		if cmd.EnableVMD {
+			disablevmd = false
+		}
+
 		// Prepare NVMe access through SPDK
 		if _, err := cmd.scs.NvmePrepare(storage.BdevPrepareRequest{
 			HugePageCount: cmd.NrHugepages,
 			TargetUser:    cmd.TargetUser,
 			PCIAllowlist:  cmd.PCIAllowList,
 			ResetOnly:     cmd.Reset,
+			DisableVMD:    disablevmd,
 		}); err != nil {
 			scanErrors = append(scanErrors, err)
 		}

--- a/src/control/common/storage/commands.go
+++ b/src/control/common/storage/commands.go
@@ -24,6 +24,7 @@ type StoragePrepareNvmeCmd struct {
 	PCIAllowList string `short:"w" long:"pci-allowlist" description:"Whitespace separated list of PCI devices (by address) to be unbound from Kernel driver and used with SPDK (default is all PCI devices)."`
 	NrHugepages  int    `short:"p" long:"hugepages" description:"Number of hugepages to allocate (in MB) for use by SPDK (default 1024)"`
 	TargetUser   string `short:"u" long:"target-user" description:"User that will own hugepage mountpoint directory and vfio groups."`
+	EnableVMD    bool   `long:"enable-vmd" description:"Enable VMD devices to be unbound (default is disabled)."`
 }
 
 type StoragePrepareScmCmd struct{}

--- a/src/control/server/storage/bdev/mocks.go
+++ b/src/control/server/storage/bdev/mocks.go
@@ -15,6 +15,7 @@ import (
 type (
 	MockBackendConfig struct {
 		PrepareResetErr error
+		PrepareVMDResetErr error
 		PrepareResp     *storage.BdevPrepareResponse
 		PrepareErr      error
 		FormatRes       *storage.BdevFormatResponse
@@ -85,6 +86,10 @@ func (mb *MockBackend) Format(req storage.BdevFormatRequest) (*storage.BdevForma
 
 func (mb *MockBackend) PrepareReset() error {
 	return mb.cfg.PrepareResetErr
+}
+
+func (mb *MockBackend) PrepareVMDReset(_ storage.BdevPrepareRequest) error {
+	return mb.cfg.PrepareVMDResetErr
 }
 
 func (mb *MockBackend) Prepare(_ storage.BdevPrepareRequest) (*storage.BdevPrepareResponse, error) {


### PR DESCRIPTION
*** VMD reset currently not working ***

Currently the daos_server storage prepare script does not account
for VMD devices. Add a --endable-vmd flag to set DisableVMD: false
(and disable VMD by default w/o the flag). Enable --pci-allowlist
to be passed to reset subcommand (VMD devices require the PCI_ALLOWED
env to be set in thte SPDK setup script in order to be unbound).

Unbind VMD device(s):
$ daos_server storage prepare -w 0000:5d:05.5 -n --enable-vmd
Rebind/Reset VMD device(s):
$ daos_server storage prepare -w 0000:5d:05.5 -n --enable-vmd --reset

Signed-off-by: Sydney Vanda <sydney.m.vanda@intel.com>