### PR TITLE
DAOS-7774 dtx: yield CPU for every 128 DTX commit

### DIFF
--- a/src/dtx/dtx_internal.h
+++ b/src/dtx/dtx_internal.h
@@ -94,6 +94,8 @@ CRT_RPC_DECLARE(dtx, DAOS_ISEQ_DTX, DAOS_OSEQ_DTX);
  */
 #define DTX_CLEANUP_THD_AGE_LO	45
 
+#define DTX_YIELD_CYCLE		(DTX_THRESHOLD_COUNT << 2)
+
 struct dtx_pool_metrics {
 	struct d_tm_node_t	*dpm_total[DTX_PROTO_SRV_RPC_COUNT];
 };


### PR DESCRIPTION
Avoid to hold CPU too long time that may cause performance ware.
This patch will  check whether it is helpful for the performance.

Signed-off-by: Fan Yong <fan.yong@intel.com>