### PR TITLE
DAOS-623 build: Fix merge conflict

### DIFF
--- a/src/dtx/dtx_rpc.c
+++ b/src/dtx/dtx_rpc.c
@@ -177,7 +177,7 @@ dtx_req_cb(const struct crt_cb_info *cb_info)
 			D_GOTO(out, rc = -DER_DATA_LOSS);
 		case -DER_NONEXIST:
 			if (dtx_hlc_age2sec(dsp->dsp_epoch) >
-			    DTX_AGG_THRESHOLD_AGE_LOWER ||
+			    DTX_AGG_THD_AGE_LO ||
 			    DAOS_FAIL_CHECK(DAOS_DTX_UNCERTAIN)) {
 
 				/* Related DTX entry on leader does not exist.


### PR DESCRIPTION
DTX_AGG_THRESHOLD_AGE_LOWER was renamed to DTX_AGG_THD_AGE_LO
and old version was used in a recent patch while both landed
at the same time.

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>