### PR TITLE
DAOS-7973 sched: tolerate backwards time

### DIFF
--- a/src/bio/bio_xstream.c
+++ b/src/bio/bio_xstream.c
@@ -373,8 +373,7 @@ xs_poll_completion(struct bio_xs_context *ctxt, unsigned int *inflights,
 		if (timeout != 0) {
 			cur_time = daos_getmtime_coarse();
 
-			D_ASSERT(cur_time >= start_time);
-			if (cur_time - start_time > timeout)
+			if (cur_time > (start_time + timeout))
 				return -DER_TIMEDOUT;
 		}
 	}

--- a/src/engine/sched.c
+++ b/src/engine/sched.c
@@ -1113,7 +1113,11 @@ wakeup_all(struct dss_xstream *dx)
 
 	/* Update current ts stored in sched_info */
 	cur_ts = daos_getmtime_coarse();
-	D_ASSERT(cur_ts >= info->si_cur_ts);
+	if (cur_ts < info->si_cur_ts) {
+		D_WARN("Backwards time: cur_ts:"DF_U64", si_cur_ts:"DF_U64"\n",
+		       cur_ts, info->si_cur_ts);
+		cur_ts = info->si_cur_ts;
+	}
 	info->si_stats.ss_tot_time += (cur_ts - info->si_cur_ts);
 	info->si_cur_ts = cur_ts;
 
@@ -1198,6 +1202,15 @@ sched_cond_wait(ABT_cond cond, ABT_mutex mutex)
 	ABT_cond_wait(cond, mutex);
 	D_ASSERT(info->si_wait_cnt > 0);
 	info->si_wait_cnt -= 1;
+}
+
+uint64_t
+sched_cur_msec(void)
+{
+	struct dss_xstream	*dx = dss_current_xstream();
+	struct sched_info	*info = &dx->dx_sched_info;
+
+	return info->si_cur_ts;
 }
 
 /*
@@ -1615,14 +1628,21 @@ sched_watchdog_post(struct dss_xstream *dx, struct sched_unit *su)
 		return;
 
 	cur = daos_getmtime_coarse();
-	D_ASSERT(cur >= su->su_start);
-	elapsed = cur - su->su_start;
+	if (cur < su->su_start) {
+		D_WARN("Backwards time, cur:"DF_U64", start:"DF_U64"\n",
+		       cur, su->su_start);
+		return;
+	}
 
+	elapsed = cur - su->su_start;
 	if (elapsed <= sched_unit_runtime_max)
 		return;
 
 	/* Throttle printing a bit */
-	D_ASSERT(cur >= info->si_stats.ss_watchdog_ts);
+	D_ASSERTF(cur >= info->si_stats.ss_watchdog_ts,
+		  "cur:"DF_U64" < watchdog_ts:"DF_U64"\n",
+		  cur, info->si_stats.ss_watchdog_ts);
+
 	if (info->si_stats.ss_last_unit == su->su_func_addr &&
 	    (cur - info->si_stats.ss_watchdog_ts) <= 2000)
 		return;

--- a/src/engine/srv.c
+++ b/src/engine/srv.c
@@ -191,7 +191,7 @@ dss_rpc_cntr_enter(enum dss_rpc_cntr_id id)
 {
 	struct dss_rpc_cntr *cntr = dss_rpc_cntr_get(id);
 
-	daos_gettime_coarse(&cntr->rc_active_time);
+	cntr->rc_active_time = sched_cur_msec();
 	cntr->rc_active++;
 	cntr->rc_total++;
 
@@ -795,11 +795,11 @@ bool
 dss_xstream_is_busy(void)
 {
 	struct dss_rpc_cntr	*cntr = dss_rpc_cntr_get(DSS_RC_OBJ);
-	uint64_t		 cur_sec = 0;
+	uint64_t		 cur_msec;
 
-	daos_gettime_coarse(&cur_sec);
+	cur_msec = sched_cur_msec();
 	/* No IO requests for more than 5 seconds */
-	return cur_sec < (cntr->rc_active_time + 5);
+	return cur_msec < (cntr->rc_active_time + 5000);
 }
 
 static int

--- a/src/include/daos/common.h
+++ b/src/include/daos/common.h
@@ -232,7 +232,7 @@ daos_get_ntime(void)
 	struct timespec	tv;
 
 	d_gettime(&tv);
-	return (tv.tv_sec * NSEC_PER_SEC + tv.tv_nsec); /* nano seconds */
+	return ((uint64_t)tv.tv_sec * NSEC_PER_SEC + tv.tv_nsec);
 }
 
 static inline uint64_t
@@ -241,7 +241,7 @@ daos_getntime_coarse(void)
 	struct timespec	tv;
 
 	clock_gettime(CLOCK_MONOTONIC_COARSE, &tv);
-	return (tv.tv_sec * NSEC_PER_SEC + tv.tv_nsec); /* nano seconds */
+	return ((uint64_t)tv.tv_sec * NSEC_PER_SEC + tv.tv_nsec);
 }
 
 static inline uint64_t
@@ -263,7 +263,10 @@ daos_wallclock_secs(void)
 static inline uint64_t
 daos_getmtime_coarse(void)
 {
-	return daos_getntime_coarse() / NSEC_PER_MSEC;
+	struct timespec tv;
+
+	clock_gettime(CLOCK_MONOTONIC_COARSE, &tv);
+	return ((uint64_t)tv.tv_sec * 1000 + tv.tv_nsec / NSEC_PER_MSEC);
 }
 
 static inline uint64_t

--- a/src/include/daos_srv/daos_engine.h
+++ b/src/include/daos_srv/daos_engine.h
@@ -360,6 +360,11 @@ int sched_req_space_check(struct sched_request *req);
  */
 void sched_cond_wait(ABT_cond cond, ABT_mutex mutex);
 
+/**
+ * Get current monotonic time in milli-seconds.
+ */
+uint64_t sched_cur_msec(void);
+
 static inline bool
 dss_ult_exiting(struct sched_request *req)
 {
@@ -612,7 +617,7 @@ enum dss_rpc_cntr_id {
 /** RPC counter */
 struct dss_rpc_cntr {
 	/**
-	 * starting wall-clock time, it can be used to calculate average
+	 * starting monotonic time, it can be used to calculate average
 	 * workload.
 	 */
 	uint64_t		rc_stime;

--- a/src/vos/vos_io.c
+++ b/src/vos/vos_io.c
@@ -2228,10 +2228,8 @@ vos_update_end(daos_handle_t ioh, uint32_t pm_ver, daos_key_t *dkey, int err,
 	struct vos_dtx_cmt_ent	**dces = NULL;
 	struct vos_io_context	*ioc = vos_ioh2ioc(ioh);
 	struct umem_instance	*umem;
-	uint64_t		 time = 0;
 	bool			 tx_started = false;
 
-	VOS_TIME_START(time, VOS_UPDATE_END);
 	D_ASSERT(ioc->ic_update);
 	vos_dedup_verify_fini(ioh);
 
@@ -2329,7 +2327,6 @@ abort:
 	if (err != 0)
 		update_cancel(ioc);
 
-	VOS_TIME_END(time, VOS_UPDATE_END);
 	vos_space_unhold(vos_cont2pool(ioc->ic_cont), &ioc->ic_space_held[0]);
 
 	if (size != NULL && err == 0)


### PR DESCRIPTION
clock_gettime() is supposed to return monotonic time when
monotonic is specified, however, backwards time was observed
on rare instances.

This patch adjusted scheduler code to tolerate backwards
time, and two unnecessary gettime calls are removed.

Signed-off-by: Niu Yawei <yawei.niu@intel.com>