### PR TITLE
DAOS-7984 ilog: fix a bug in vos_ilog_update_check

### DIFF
--- a/src/vos/vos_ilog.c
+++ b/src/vos/vos_ilog.c
@@ -321,7 +321,8 @@ vos_ilog_check_(struct vos_ilog_info *info, const daos_epoch_range_t *epr_in,
 static inline int
 vos_ilog_update_check(struct vos_ilog_info *info, const daos_epoch_range_t *epr)
 {
-	if (info->ii_create <= info->ii_prior_any_punch.pr_epc)
+	if (info->ii_prior_any_punch.pr_epc != 0 &&
+	    info->ii_create <= info->ii_prior_any_punch.pr_epc)
 		return -DER_NONEXIST;
 
 	return 0;


### PR DESCRIPTION
For some cases the ii_create and ii_prior_any_punch.pr_epc are both
zero, that should not return DER_NONEXIST in that case.

Signed-off-by: Xuezhao Liu <xuezhao.liu@intel.com>