### PR TITLE
DAOS-8165 placement: set dom_occupied bits in get_object_layout

### DIFF
--- a/src/placement/jump_map.c
+++ b/src/placement/jump_map.c
@@ -349,7 +349,6 @@ retry:
 			range_set = isset_range(tgts_used, start_tgt, end_tgt);
 			if (range_set) {
 				/* Used up all targets in this domain */
-				setbit(dom_occupied, curr_dom - root_pos);
 				D_ASSERT(top != -1);
 				curr_dom = dom_stack[top--]; /* try parent */
 				continue;
@@ -374,6 +373,14 @@ retry:
 
 			setbit(tgts_used, dom_id);
 			setbit(dom_cur_grp_used, curr_dom - root_pos);
+			range_set = isset_range(tgts_used, start_tgt, end_tgt);
+			if (range_set) {
+				/* Used up all targets in this domain */
+				D_DEBUG(DB_PL, "dom %d used up\n",
+					(int)(curr_dom - root_pos));
+				setbit(dom_occupied, curr_dom - root_pos);
+			}
+
 			/* Found target (which may be available or not) */
 			found_target = 1;
 		} else {
@@ -398,6 +405,8 @@ retry:
 					return;
 				}
 				setbit(dom_occupied, curr_dom - root_pos);
+				D_DEBUG(DB_PL, "used up dom %d\n",
+					(int)(curr_dom - root_pos));
 				setbit(dom_cur_grp_used, curr_dom - root_pos);
 				curr_dom = dom_stack[top--];
 				continue;

--- a/src/placement/tests/jump_map_place_obj.c
+++ b/src/placement/tests/jump_map_place_obj.c
@@ -1855,6 +1855,33 @@ same_group_shards_not_in_same_domain(void **state)
 	assert_true(miss_cnt < 2);
 }
 
+static void
+large_shards_over_limited_targets(void **state)
+{
+	struct jm_test_ctx	ctx;
+	int i;
+
+	D_DEBUG(DB_TRACE, "shards over limit\n");
+	jtc_init_with_layout(&ctx, 4, 1, 8, OC_RP_2G8, g_verbose);
+	for (i = 0; i < 8; i++) {
+		jtc_set_status_on_target(&ctx, DOWN, i);
+		jtc_scan(&ctx);
+		jtc_set_status_on_target(&ctx, DOWNOUT, i);
+	}
+
+	assert_success(jtc_create_layout(&ctx));
+
+	for (i = 24; i < 32; i++) {
+		jtc_set_status_on_target(&ctx, DOWN, i);
+		jtc_scan(&ctx);
+		jtc_set_status_on_target(&ctx, DOWNOUT, i);
+	}
+
+	assert_success(jtc_create_layout(&ctx));
+
+	jtc_fini(&ctx);
+}
+
 /*
  * ------------------------------------------------
  * End Test Cases
@@ -1937,6 +1964,8 @@ static const struct CMUnitTest tests[] = {
 	  unbalanced_config),
 	T("shards in the same group not in the same domain",
 	  same_group_shards_not_in_same_domain),
+	T("large shards over limited targets",
+	  large_shards_over_limited_targets),
 };
 
 int


### PR DESCRIPTION
Set dom_occupied bits correctly once the all targets have been
used during layout generation, otherwise get_target might be in
endless lop even if there are still targets left.

Add tests to verify this.

Signed-off-by: Di Wang <di.wang@intel.com>