### PR TITLE
DAOS-8197 test: pool_op_retry specify PS leader for faults

### DIFF
--- a/src/mgmt/srv.c
+++ b/src/mgmt/srv.c
@@ -181,6 +181,9 @@ ds_mgmt_params_set_hdlr(crt_rpc_t *rpc)
 
 	ps_in = crt_req_get(rpc);
 	D_ASSERT(ps_in != NULL);
+	D_DEBUG(DB_MGMT, "ps_rank=%u, key_id=0x%x, value=0x%"PRIx64", extra=0x%"PRIx64"\n",
+		ps_in->ps_rank, ps_in->ps_key_id, ps_in->ps_value, ps_in->ps_value_extra);
+
 	if (ps_in->ps_rank != -1) {
 		/* Only set local parameter */
 		rc = dss_parameters_set(ps_in->ps_key_id, ps_in->ps_value);

--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -2132,8 +2132,11 @@ ds_pool_connect_handler(crt_rpc_t *rpc)
 
 	rc = pool_connect_iv_dist(svc, in->pci_op.pi_hdl, in->pci_flags,
 				  sec_capas, &in->pci_cred);
-	if (rc == 0 && DAOS_FAIL_CHECK(DAOS_POOL_CONNECT_FAIL_CORPC))
+	if (rc == 0 && DAOS_FAIL_CHECK(DAOS_POOL_CONNECT_FAIL_CORPC)) {
+		D_DEBUG(DF_DSMS, DF_UUID": fault injected: DAOS_POOL_CONNECT_FAIL_CORPC\n",
+			DP_UUID(in->pci_op.pi_uuid));
 		rc = -DER_TIMEDOUT;
+	}
 	if (rc != 0) {
 		D_ERROR(DF_UUID": failed to connect to targets: "DF_RC"\n",
 			DP_UUID(in->pci_op.pi_uuid), DP_RC(rc));
@@ -2204,8 +2207,11 @@ pool_disconnect_bcast(crt_context_t ctx, struct pool_svc *svc,
 	in->tdi_hdls.ca_arrays = pool_hdls;
 	in->tdi_hdls.ca_count = n_pool_hdls;
 	rc = dss_rpc_send(rpc);
-	if (rc == 0 && DAOS_FAIL_CHECK(DAOS_POOL_DISCONNECT_FAIL_CORPC))
+	if (rc == 0 && DAOS_FAIL_CHECK(DAOS_POOL_DISCONNECT_FAIL_CORPC)) {
+		D_DEBUG(DF_DSMS, DF_UUID": fault injected: DAOS_POOL_DISCONNECT_FAIL_CORPC\n",
+			DP_UUID(svc->ps_uuid));
 		rc = -DER_TIMEDOUT;
+	}
 	if (rc != 0)
 		D_GOTO(out_rpc, rc);
 
@@ -2359,8 +2365,11 @@ pool_space_query_bcast(crt_context_t ctx, struct pool_svc *svc, uuid_t pool_hdl,
 	uuid_copy(in->tqi_op.pi_uuid, svc->ps_uuid);
 	uuid_copy(in->tqi_op.pi_hdl, pool_hdl);
 	rc = dss_rpc_send(rpc);
-	if (rc == 0 && DAOS_FAIL_CHECK(DAOS_POOL_QUERY_FAIL_CORPC))
+	if (rc == 0 && DAOS_FAIL_CHECK(DAOS_POOL_QUERY_FAIL_CORPC)) {
+		D_DEBUG(DF_DSMS, DF_UUID": fault injected: DAOS_POOL_QUERY_FAIL_CORPC\n",
+			DP_UUID(svc->ps_uuid));
 		rc = -DER_TIMEDOUT;
+	}
 	if (rc != 0)
 		goto out_rpc;
 

--- a/src/tests/suite/daos_pool.c
+++ b/src/tests/suite/daos_pool.c
@@ -616,10 +616,10 @@ pool_op_retry(void **state)
 	if (arg->myrank != 0)
 		return;
 
-	print_message("setting DAOS_POOL_CONNECT_FAIL_CORPC ... ");
-	rc = daos_debug_set_params(arg->group, 0, DMG_KEY_FAIL_LOC,
-				  DAOS_POOL_CONNECT_FAIL_CORPC | DAOS_FAIL_ONCE,
-				  0, NULL);
+	print_message("setting on leader %u DAOS_POOL_CONNECT_FAIL_CORPC ... ",
+		arg->pool.pool_info.pi_leader);
+	rc = daos_debug_set_params(arg->group, arg->pool.pool_info.pi_leader, DMG_KEY_FAIL_LOC,
+				   DAOS_POOL_CONNECT_FAIL_CORPC | DAOS_FAIL_ONCE, 0, NULL);
 	assert_rc_equal(rc, 0);
 	print_message("success\n");
 
@@ -633,10 +633,9 @@ pool_op_retry(void **state)
 	assert_int_equal(info.pi_ndisabled, 0);
 	print_message("success\n");
 
-	print_message("setting DAOS_POOL_QUERY_FAIL_CORPC ... ");
-	rc = daos_debug_set_params(arg->group, 0, DMG_KEY_FAIL_LOC,
-				  DAOS_POOL_QUERY_FAIL_CORPC | DAOS_FAIL_ONCE,
-				  0, NULL);
+	print_message("setting on leader %u DAOS_POOL_QUERY_FAIL_CORPC ... ", info.pi_leader);
+	rc = daos_debug_set_params(arg->group, info.pi_leader, DMG_KEY_FAIL_LOC,
+				   DAOS_POOL_QUERY_FAIL_CORPC | DAOS_FAIL_ONCE, 0, NULL);
 	assert_rc_equal(rc, 0);
 	print_message("success\n");
 
@@ -648,10 +647,9 @@ pool_op_retry(void **state)
 	assert_int_equal(info.pi_ndisabled, 0);
 	print_message("success\n");
 
-	print_message("setting DAOS_POOL_DISCONNECT_FAIL_CORPC ... ");
-	rc = daos_debug_set_params(arg->group, 0, DMG_KEY_FAIL_LOC,
-				  DAOS_POOL_DISCONNECT_FAIL_CORPC |
-				  DAOS_FAIL_ONCE, 0, NULL);
+	print_message("setting on leader %u DAOS_POOL_DISCONNECT_FAIL_CORPC ... ", info.pi_leader);
+	rc = daos_debug_set_params(arg->group, info.pi_leader, DMG_KEY_FAIL_LOC,
+				  DAOS_POOL_DISCONNECT_FAIL_CORPC | DAOS_FAIL_ONCE, 0, NULL);
 	assert_rc_equal(rc, 0);
 	print_message("success\n");
 


### PR DESCRIPTION
Before this change daos_test -p pool_op_retry() test attempted to
inject pool connect/disconnect/query corpc faults on the daos_engine
side by invoking daos_debug_set_params() with a rank=0 input argument.
The rank 0 engine very often is not the pool service (PS) leader,
so the fault value in rank 0 had no actual fault injection effect
on the subsequent pool operations handled by another (PS leader) rank.
i.e., the operations succeeded, the test seemed to pass, but it did not
actually exercise rpc retry behavior due to an (injected) timeout.

With this change, the test function is changed to specify the PS leader
rank in daos_debug_set_params(). Also, the engine mgmt code is updated
to emit debug log messages to confirm fault injection is engaged.

Signed-off-by: Kenneth Cain <kenneth.c.cain@intel.com>