### PR TITLE
CART-89 fix: CID 332947 fix - set tag to 0

### DIFF
--- a/src/pool/cli.c
+++ b/src/pool/cli.c
@@ -1481,6 +1481,7 @@ create_map_refresh_rpc(struct dc_pool *pool, unsigned int map_version,
 
 	ep.ep_grp = group;
 	ep.ep_rank = rank;
+	ep.ep_tag = 0;
 
 	rc = pool_req_create(ctx, &ep, POOL_TGT_QUERY_MAP, &c);
 	if (rc != 0) {


### PR DESCRIPTION
- Set tag to 0 when issuing RPC request for TGT_QUERY_MAP

Signed-off-by: Alexander Oganezov <alexander.a.oganezov@intel.com>