### PR TITLE
DAOS-623 test: Add --failfast flag to launch.py

### DIFF
--- a/src/tests/ftest/launch.py
+++ b/src/tests/ftest/launch.py
@@ -887,6 +887,8 @@ def run_tests(test_files, tag_filter, args):
         command_list.append("--show-job-log")
     if tag_filter:
         command_list.extend(tag_filter)
+    if args.failfast:
+        command_list.extend(["--failfast", "on"])
 
     # Run each test
     skip_reason = None
@@ -1034,6 +1036,12 @@ def run_tests(test_files, tag_filter, args):
                 hosts,
                 "/tmp/test.cov*",
                 args)
+
+        # If the test failed and the user requested that testing should
+        # stop after the first failure, then we should break out of the
+        # loop and not re-run the tests.
+        if return_code != 0 and args.failfast:
+            break
 
     return return_code
 
@@ -2045,6 +2053,10 @@ def main():
         action="store_true",
         help="when replacing server/client yaml file placeholders, discard "
              "any placeholders that do not end up with a replacement value")
+    parser.add_argument(
+        "--failfast",
+        action="store_true",
+        help="stop the test suite after the first failure")
     parser.add_argument(
         "-i", "--include_localhost",
         action="store_true",

--- a/src/tests/ftest/util/server_utils.py
+++ b/src/tests/ftest/util/server_utils.py
@@ -624,6 +624,8 @@ class DaosServerManager(SubprocessManager):
             query_data = {"status": 1}
         if query_data["status"] == 0:
             if "response" in query_data and "members" in query_data["response"]:
+                if query_data["response"]["members"] is None:
+                    return data
                 for member in query_data["response"]["members"]:
                     host = member["fault_domain"].split(".")[0].replace("/", "")
                     if host in self._hosts:


### PR DESCRIPTION
If set, appends '--failfast on' to the avocado run
arguments. This will cause avocado to abort the test
run at the first test failure. Also breaks out of the
repeat loop if --repeat was specified.

Fixes a corner case in the system query helper where the
response succeeds but contains a null members array.