### PR TITLE
DAOS-8048 EC: checksum fixes for EC

### DIFF
--- a/src/object/cli_shard.c
+++ b/src/object/cli_shard.c
@@ -1543,7 +1543,8 @@ dc_enumerate_copy_csum(d_iov_t *dst, const d_iov_t *src)
 			   src->iov_len));
 		dst->iov_len = src->iov_len;
 		if (dst->iov_len > dst->iov_buf_len) {
-			D_DEBUG(DB_CSUM, "Checksum buffer truncated");
+			D_DEBUG(DB_CSUM, "Checksum buffer truncated %d > %d\n",
+				(int)dst->iov_len, (int)dst->iov_buf_len);
 			return -DER_TRUNC;
 		}
 	}

--- a/src/object/obj_enum.c
+++ b/src/object/obj_enum.c
@@ -185,6 +185,7 @@ fill_data_csum(struct dcs_csum_info *src_csum_info, d_iov_t *csum_iov)
 	rc = iov_alloc_for_csum_info(csum_iov, src_csum_info);
 	if (rc != 0)
 		return rc;
+
 	rc = ci_serialize(src_csum_info, csum_iov);
 	/** iov_alloc_for_csum_info should have allocated enough so this
 	 * would be a programmer error and want to know right away
@@ -1490,11 +1491,10 @@ dss_enum_unpack(daos_unit_oid_t oid, daos_key_desc_t *kds, int kds_num,
 			      &unpack_arg);
 	if (rc)
 		D_GOTO(out, rc);
-
+out:
 	if (io.ui_iods_top >= 0)
 		rc = complete_io(&io, cb, cb_arg);
 
-out:
 	D_DEBUG(DB_REBUILD, "process list buf "DF_UOID" rc "DF_RC"\n",
 		DP_UOID(io.ui_oid), DP_RC(rc));
 

--- a/src/object/srv_obj_migrate.c
+++ b/src/object/srv_obj_migrate.c
@@ -579,8 +579,6 @@ mrone_obj_fetch(struct migrate_one *mrone, daos_handle_t oh, d_sg_list_t *sgls,
  * Note: the csum_iov is modified so a shallow copy should be sent instead of
  * the original.
  */
-
-
 static int
 migrate_fetch_update_inline(struct migrate_one *mrone, daos_handle_t oh,
 			    struct ds_cont_child *ds_cont)
@@ -604,7 +602,12 @@ migrate_fetch_update_inline(struct migrate_one *mrone, daos_handle_t oh,
 		if (mrone->mo_iods[i].iod_size == 0)
 			continue;
 
-		if (mrone->mo_sgls != NULL && mrone->mo_sgls[i].sg_nr > 0) {
+		/* Let's do real fetch for all EC object, since the
+		 * checksum needs to be re-calculated for EC rebuild,
+		 * and we do not have checksum information yet.
+		 */
+		if ((mrone->mo_sgls != NULL && mrone->mo_sgls[i].sg_nr > 0) &&
+		     !daos_oclass_is_ec(&mrone->mo_oca)) {
 			sgls[i] = mrone->mo_sgls[i];
 		} else {
 			sgls[i].sg_nr = 1;
@@ -2152,6 +2155,7 @@ migrate_one_epoch_object(daos_epoch_range_t *epr, struct migrate_pool_tls *tls,
 	daos_size_t		 buf_len;
 	daos_key_desc_t		 kds[KDS_NUM] = {0};
 	d_iov_t			 csum = {0};
+	d_iov_t			 *p_csum;
 	uint8_t			 stack_csum_buf[CSUM_BUF_SIZE] = {0};
 	struct cont_props	 props;
 	struct enum_unpack_arg	 unpack_arg = { 0 };
@@ -2205,7 +2209,13 @@ migrate_one_epoch_object(daos_epoch_range_t *epr, struct migrate_pool_tls *tls,
 		D_GOTO(out_cont, rc);
 	}
 
-	d_iov_set(&csum, stack_csum_buf, CSUM_BUF_SIZE);
+	if (daos_oclass_is_ec(&unpack_arg.oc_attr)) {
+		p_csum = NULL;
+	} else {
+		p_csum = &csum;
+		d_iov_set(&csum, stack_csum_buf, CSUM_BUF_SIZE);
+	}
+
 	while (!tls->mpt_fini) {
 		memset(buf, 0, buf_len);
 		memset(kds, 0, KDS_NUM * sizeof(*kds));
@@ -2217,7 +2227,8 @@ migrate_one_epoch_object(daos_epoch_range_t *epr, struct migrate_pool_tls *tls,
 		sgl.sg_nr_out = 1;
 		sgl.sg_iovs = &iov;
 
-		csum.iov_len = 0;
+		if (p_csum != NULL)
+			p_csum->iov_len = 0;
 
 		num = KDS_NUM;
 		daos_anchor_set_flags(&dkey_anchor,
@@ -2227,7 +2238,7 @@ retry:
 		unpack_arg.invalid_inline_sgl = 0;
 		rc = dsc_obj_list_obj(oh, epr, NULL, NULL, NULL,
 				     &num, kds, &sgl, &anchor,
-				     &dkey_anchor, &akey_anchor, &csum);
+				     &dkey_anchor, &akey_anchor, p_csum);
 
 		if (rc == -DER_KEY2BIG) {
 			D_DEBUG(DB_REBUILD, "migrate obj "DF_UOID" got "
@@ -2242,17 +2253,17 @@ retry:
 				break;
 			}
 			continue;
-		} else if (rc == -DER_TRUNC &&
-			   csum.iov_len > csum.iov_buf_len) {
+		} else if (rc == -DER_TRUNC && p_csum != NULL &&
+			   p_csum->iov_len > p_csum->iov_buf_len) {
 			D_DEBUG(DB_REBUILD, "migrate obj csum buf "
 				"not large enough. Increase and try again");
-			if (csum.iov_buf != stack_csum_buf)
-				D_FREE(csum.iov_buf);
+			if (p_csum->iov_buf != stack_csum_buf)
+				D_FREE(p_csum->iov_buf);
 
-			csum.iov_buf_len = csum.iov_len;
-			csum.iov_len = 0;
-			D_ALLOC(csum.iov_buf, csum.iov_buf_len);
-			if (csum.iov_buf == NULL) {
+			p_csum->iov_buf_len = p_csum->iov_len;
+			p_csum->iov_len = 0;
+			D_ALLOC(p_csum->iov_buf, p_csum->iov_buf_len);
+			if (p_csum->iov_buf == NULL) {
 				rc = -DER_NOMEM;
 				break;
 			}
@@ -2293,8 +2304,8 @@ retry:
 				rc = 0;
 			}
 
-			D_DEBUG(DB_REBUILD, "Can not rebuild "
-				DF_UOID"\n", DP_UOID(arg->oid));
+			D_DEBUG(DB_REBUILD, "Can not rebuild "DF_UOID" "DF_RC"\n",
+				DP_UOID(arg->oid), DP_RC(rc));
 			break;
 		}
 
@@ -2305,7 +2316,7 @@ retry:
 			break;
 		}
 
-		rc = dss_enum_unpack(arg->oid, kds, num, &sgl, &csum,
+		rc = dss_enum_unpack(arg->oid, kds, num, &sgl, p_csum,
 				     migrate_enum_unpack_cb, &unpack_arg);
 		if (rc) {
 			D_ERROR("migrate "DF_UOID" failed: %d\n",

--- a/src/tests/suite/daos_rebuild_common.c
+++ b/src/tests/suite/daos_rebuild_common.c
@@ -615,6 +615,13 @@ write_ec(struct ioreq *req, int index, char *data, daos_off_t off, int size)
 
 	for (i = 0; i < KEY_NR; i++) {
 		req->iod_type = DAOS_IOD_ARRAY;
+
+		sprintf(key, "dkey_small_%d", index);
+		recx.rx_nr = 5;
+		recx.rx_idx = off + i * 10485760;
+		insert_recxs(key, "a_key", 1, DAOS_TX_NONE, &recx, 1,
+			     data, size, req);
+
 		sprintf(key, "dkey_%d", index);
 		recx.rx_nr = size;
 		recx.rx_idx = off + i * 10485760;
@@ -659,8 +666,18 @@ verify_ec(struct ioreq *req, int index, char *verify_data, daos_off_t off,
 		daos_size_t	single_data_size;
 		daos_size_t	iod3_datasize = IOD3_DATA_SIZE * 3;
 		daos_size_t	datasize = size;
+		daos_size_t	small_size = 5;
 
 		req->iod_type = DAOS_IOD_ARRAY;
+
+		sprintf(key, "dkey_small_%d", index);
+		sprintf(key_buf, "a_key");
+		memset(read_data, 0, 5);
+		lookup(key, 1, &akey, &offset, &iod_size,
+		       &read_data, &small_size, DAOS_TX_NONE, req, false);
+		assert_memory_equal(read_data, verify_data, small_size);
+		assert_int_equal(iod_size, 1);
+
 		sprintf(key, "dkey_%d", index);
 		sprintf(key_buf, "a_key");
 		memset(read_data, 0, size);

--- a/src/tests/suite/daos_rebuild_ec.c
+++ b/src/tests/suite/daos_rebuild_ec.c
@@ -142,7 +142,7 @@ static int
 rebuild_ec_setup(void  **state, int number)
 {
 	test_arg_t	*arg;
-	daos_prop_t	*prop = NULL;
+	daos_prop_t	*props = NULL;
 	int		rc;
 
 	save_group_state(state);
@@ -160,12 +160,18 @@ rebuild_ec_setup(void  **state, int number)
 
 	arg = *state;
 	/* sustain 2 failure here */
-	prop = daos_prop_alloc(1);
-	prop->dpp_entries[0].dpe_type = DAOS_PROP_CO_REDUN_FAC;
-	prop->dpp_entries[0].dpe_val = DAOS_PROP_CO_REDUN_RF1;
+	props = daos_prop_alloc(3);
+	props->dpp_entries[0].dpe_type = DAOS_PROP_CO_REDUN_FAC;
+	props->dpp_entries[0].dpe_val = DAOS_PROP_CO_REDUN_RF1;
+	props->dpp_entries[1].dpe_type = DAOS_PROP_CO_CSUM;
+	props->dpp_entries[1].dpe_val = DAOS_PROP_CO_CSUM_CRC32;
+	props->dpp_entries[2].dpe_type = DAOS_PROP_CO_CSUM_SERVER_VERIFY;
+	props->dpp_entries[2].dpe_val = DAOS_PROP_CO_CSUM_SV_ON;
+
 	while (!rc && arg->setup_state != SETUP_CONT_CONNECT)
-		rc = test_setup_next_step((void **)&arg, NULL, NULL, prop);
+		rc = test_setup_next_step((void **)&arg, NULL, NULL, props);
 	assert_int_equal(rc, 0);
+	daos_prop_free(props);
 
 	if (dt_obj_class != DAOS_OC_UNKNOWN)
 		arg->obj_class = dt_obj_class;


### PR DESCRIPTION
Do not need checksum for EC enumeration, since
checksum needs to be re-calculated during EC
rebuild.

Cleanup iod in obj_enum_unpack() in error handling
path.

Enforce checksum for EC rebuild test.

Signed-off-by: Di Wang <di.wang@intel.com>