### PR TITLE
DAOS-7812 cart: Suppress a Coverity complain

### DIFF
--- a/src/cart/crt_swim.c
+++ b/src/cart/crt_swim.c
@@ -767,8 +767,12 @@ int crt_swim_init(int crt_ctx_idx)
 	 * Because daos needs to call crt_self_incarnation_get before it calls
 	 * crt_rank_self_set, we choose the self incarnation here instead of in
 	 * crt_swim_rank_add.
+	 *
+	 * The locking is to suppress Coverity complains.
 	 */
+	crt_swim_csm_lock(csm);
 	csm->csm_incarnation = crt_hlc_get();
+	crt_swim_csm_unlock(csm);
 	csm->csm_ctx = swim_init(SWIM_ID_INVALID, &crt_swim_ops, NULL);
 	if (csm->csm_ctx == NULL) {
 		D_ERROR("swim_init() failed for self=%u, crt_ctx_idx=%d\n",


### PR DESCRIPTION
Suppressing the following Coverity complain:

   CID 332960:  Concurrent data access violations  (MISSING_LOCK)
   Accessing "csm->csm_incarnation" without holding lock
   "crt_swim_membs.csm_lock". Elsewhere,
   "crt_swim_membs.csm_incarnation" is accessed with
   "crt_swim_membs.csm_lock" held 1 out of 2 times (1 of
   these accesses strongly imply that it is necessary).

Signed-off-by: Li Wei <wei.g.li@intel.com>