### PR TITLE
DOS_8204 test: Add a test for "container list".

### DIFF
--- a/utils/node_local_test.py
+++ b/utils/node_local_test.py
@@ -1361,6 +1361,13 @@ class posix_tests():
         """Mark a test method as failed"""
         raise NLTestFail
 
+    def test_cont_list(self):
+        """Test daos container list"""
+
+        rc = run_daos_cmd(self.conf,
+                          ['container', 'list', self.pool.id()])
+        assert rc.returncode == 0, rc
+
     def test_cache(self):
         """Test with caching enabled"""
 


### PR DESCRIPTION
Run this under NLT so that server memory leaks can be detected.

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>
