### PR TITLE
DAOS-8210 container, cart: fix set error code in cli.c and crt_context.c

### DIFF
--- a/src/cart/crt_context.c
+++ b/src/cart/crt_context.c
@@ -196,7 +196,7 @@ crt_context_provider_create(crt_context_t *crt_ctx, int provider)
 	    cur_ctx_num >= max_ctx_num) {
 		D_ERROR("Number of active contexts (%d) reached limit (%d).\n",
 			cur_ctx_num, max_ctx_num);
-		D_GOTO(out, -DER_AGAIN);
+		D_GOTO(out, rc = -DER_AGAIN);
 	}
 
 	D_ALLOC_PTR(ctx);

--- a/src/container/cli.c
+++ b/src/container/cli.c
@@ -173,7 +173,7 @@ dup_with_default_ownership_props(daos_prop_t **prop_out, daos_prop_t *prop_in)
 	/* We always free this prop in the callback - so need to make a copy */
 	final_prop = daos_prop_alloc(entries);
 	if (final_prop == NULL)
-		D_GOTO(err_out, -DER_NOMEM);
+		D_GOTO(err_out, rc = -DER_NOMEM);
 
 	if (prop_in != NULL && prop_in->dpp_nr > 0) {
 		rc = daos_prop_copy(final_prop, prop_in);


### PR DESCRIPTION
fix setting error code in container/cli.c and cart/crt_context.c

The return code is not being set when out of memory error occurs. This was
revealed in fault injection testing for filesystem copy which calls
dfs_cont_create, which then calls daos_cont_create...which eventually calls this
function and returns the incorrect error code. This is causing the filesystem
copy fault injection tests to report DER_INVAL value when it should be returning
DER_NOMEM.

There was also another bug here:
src/cart/crt_context.c: D_GOTO(out, -DER_AGAIN);
Where the return code was not being set. 

Signed-off-by: Danielle Sikich <danielle.sikich@intel.com>