### PR TITLE
DAOS-8198 control: Protect rand.Source with lock

### DIFF
--- a/src/control/lib/control/rpc.go
+++ b/src/control/lib/control/rpc.go
@@ -34,8 +34,33 @@ const (
 	maxMSCandidates    = 5
 )
 
+type (
+	safeRandSource struct {
+		sync.Mutex
+		src rand.Source
+	}
+)
+
+func (srs *safeRandSource) Int63() int64 {
+	srs.Lock()
+	defer srs.Unlock()
+	return srs.src.Int63()
+}
+
+func (srs *safeRandSource) Seed(seed int64) {
+	srs.Lock()
+	defer srs.Unlock()
+	srs.src.Seed(seed)
+}
+
+func newSafeRandSource(seed int64) *safeRandSource {
+	return &safeRandSource{
+		src: rand.NewSource(seed),
+	}
+}
+
 var (
-	msCandidateRandSource = rand.NewSource(time.Now().UnixNano())
+	msCandidateRandSource = newSafeRandSource(time.Now().UnixNano())
 )
 
 type (

--- a/src/control/lib/control/rpc_test.go
+++ b/src/control/lib/control/rpc_test.go
@@ -9,7 +9,6 @@ package control
 import (
 	"context"
 	"fmt"
-	"math/rand"
 	"os"
 	"runtime"
 	"sort"
@@ -219,7 +218,7 @@ func TestControl_InvokeUnaryRPCAsync(t *testing.T) {
 
 func TestControl_InvokeUnaryRPC(t *testing.T) {
 	// make the rand deterministic for testing
-	msCandidateRandSource = rand.NewSource(1)
+	msCandidateRandSource = newSafeRandSource(1)
 
 	clientCfg := DefaultConfig()
 	clientCfg.TransportConfig.AllowInsecure = true


### PR DESCRIPTION
The default rand source is thread-safe, but sources
created with rand.NewSource() are not. Wrap the
MS candidate chooser source with a mutex to avoid
race warnings.