### PR TITLE
DAOS-8047 agent: Fix fabric cache init from config

### DIFF
--- a/src/control/cmd/daos_agent/fabric.go
+++ b/src/control/cmd/daos_agent/fabric.go
@@ -31,6 +31,14 @@ type FabricInterface struct {
 	NetDevClass uint32
 }
 
+func (f *FabricInterface) String() string {
+	var dom string
+	if f.Domain != "" {
+		dom = "/" + f.Domain
+	}
+	return fmt.Sprintf("%s%s (%s)", f.Name, dom, netdetect.DevClassName(f.NetDevClass))
+}
+
 // DefaultFabricInterface is the one used if no devices are found on the system.
 var DefaultFabricInterface = &FabricInterface{
 	Name:   "lo",

--- a/src/control/cmd/daos_agent/infocache.go
+++ b/src/control/cmd/daos_agent/infocache.go
@@ -177,6 +177,7 @@ func (c *localFabricCache) setCache(nf *NUMAFabric) {
 	c.localNUMAFabric = nf
 
 	c.initialized.SetTrue()
+	c.log.Debugf("cached:\n%+v", c.localNUMAFabric.numaMap)
 }
 
 // GetDevices fetches an appropriate fabric device from the cache.

--- a/src/control/cmd/daos_agent/start.go
+++ b/src/control/cmd/daos_agent/start.go
@@ -83,7 +83,7 @@ func (cmd *startCmd) Execute(_ []string) error {
 		sys:        cmd.cfg.SystemName,
 		ctlInvoker: cmd.ctlInvoker,
 		attachInfo: newAttachInfoCache(cmd.log, aicEnabled),
-		fabricInfo: newLocalFabricCache(cmd.log, ficEnabled),
+		fabricInfo: fabricCache,
 		numaAware:  numaAware,
 		netCtx:     netCtx,
 		monitor:    procmon,


### PR DESCRIPTION
- Fix the initialization of the fabric cache from the config file.
- Improve debug logging.

Signed-off-by: Kris Jacque <kristin.jacque@intel.com>