### PR TITLE
DAOS-8182 pool: allow to set ec_cell_sz prop after creation

### DIFF
--- a/src/include/daos_prop.h
+++ b/src/include/daos_prop.h
@@ -194,7 +194,7 @@ enum daos_cont_props {
 	DAOS_PROP_CO_STATUS,
 	/** OID value to start allocation from */
 	DAOS_PROP_CO_ALLOCED_OID,
-	/** EC cell size, it can overwrite DAOS_PROP_EC_CELL_SZ of pool */
+	/** EC cell size, it can overwrite DAOS_PROP_CO_EC_CELL_SZ of pool */
 	DAOS_PROP_CO_EC_CELL_SZ,
 	DAOS_PROP_CO_MAX,
 };

--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -360,14 +360,6 @@ pool_prop_write(struct rdb_tx *tx, const rdb_path_t *kvs, daos_prop_t *prop,
 
 	for (i = 0; i < prop->dpp_nr; i++) {
 		entry = &prop->dpp_entries[i];
-		if (!create &&
-		    (entry->dpe_type == DAOS_PROP_PO_EC_CELL_SZ)) {
-			D_ERROR("Can't change immutable property=%d\n",
-				entry->dpe_type);
-			rc = -DER_NO_PERM;
-			break;
-		}
-
 		switch (entry->dpe_type) {
 		case DAOS_PROP_PO_LABEL:
 			if (entry->dpe_str == NULL ||


### PR DESCRIPTION
Allow to set ec_cell_sz property after creation

Signed-off-by: Xuezhao Liu <xuezhao.liu@intel.com>