### PR TITLE
DAOS-8184 test: Use UUID to call some dmg pool commands

### DIFF
--- a/src/tests/ftest/container/snapshot_aggregation.py
+++ b/src/tests/ftest/container/snapshot_aggregation.py
@@ -105,7 +105,10 @@ class SnapshotAggregation(IorTestBase):
             "NVMe free pool space was not reduced by the overwrite")
 
         # Enable the aggregation
+        # Test UUID.
+        self.pool.use_label = False
         self.pool.set_property("reclaim", "time")
+        self.pool.use_label = True
 
         # Delete the snapshot.
         daos.container_destroy_snap(

--- a/src/tests/ftest/pool/bad_evict.py
+++ b/src/tests/ftest/pool/bad_evict.py
@@ -4,11 +4,9 @@
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
-import traceback
 import ctypes
 
 from apricot import TestWithServers
-from command_utils import CommandFailure
 
 
 class BadEvictTest(TestWithServers):

--- a/src/tests/ftest/pool/bad_evict.py
+++ b/src/tests/ftest/pool/bad_evict.py
@@ -50,39 +50,38 @@ class BadEvictTest(TestWithServers):
 
         saveduuid = None
 
-        try:
-            # initialize a python pool object then create the underlying
-            # daos storage
-            self.add_pool(connect=False)
+        self.add_pool(connect=False)
+        original_test_pool_uuid = self.pool.uuid
 
-            # trash the UUID value in various ways
-            if excludeuuid is None:
-                saveduuid = (ctypes.c_ubyte * 16)(0)
-                for item in range(0, len(saveduuid)):
-                    saveduuid[item] = self.pool.pool.uuid[item]
-                self.pool.pool.uuid[0:] = \
-                    [0 for item in range(0, len(self.pool.pool.uuid))]
-            elif excludeuuid == 'JUNK':
-                saveduuid = (ctypes.c_ubyte * 16)(0)
-                for item in range(0, len(saveduuid)):
-                    saveduuid[item] = self.pool.pool.uuid[item]
-                self.pool.pool.uuid[4] = 244
+        # Make dmg call and poolevict() not fail.
+        self.pool.dmg.exit_status_exception = False
 
-            # evict the pool
-            self.get_dmg_command().pool_evict(self.pool.pool.get_uuid_str())
+        # trash the UUID value in various ways
+        if excludeuuid is None:
+            saveduuid = (ctypes.c_ubyte * 16)(0)
+            for item in range(0, len(saveduuid)):
+                saveduuid[item] = self.pool.pool.uuid[item]
+            self.pool.pool.uuid[0:] = \
+                [0 for item in range(0, len(self.pool.pool.uuid))]
+        elif excludeuuid == 'JUNK':
+            saveduuid = (ctypes.c_ubyte * 16)(0)
+            for item in range(0, len(saveduuid)):
+                saveduuid[item] = self.pool.pool.uuid[item]
+            self.pool.pool.uuid[4] = 244
 
-            if expected_result in ['FAIL']:
-                self.fail("Test was expected to fail but it passed.\n")
+        self.pool.uuid = self.pool.pool.get_uuid_str()
 
-        except CommandFailure as excep:
-            self.log.error(str(excep))
-            self.log.error(traceback.format_exc())
-            if expected_result in ['PASS']:
-                self.fail("Test was expected to pass but it failed.\n")
-        finally:
-            if self.pool is not None:
-                # if the test trashed some pool parameter, put it back the
-                # way it was
-                if saveduuid is not None:
-                    self.pool.pool.uuid = saveduuid
-                self.pool.destroy()
+        self.pool.use_label = False
+        self.pool.evict()
+        self.pool.use_label = True
+
+        exit_status = self.pool.dmg.result.exit_status
+        if exit_status == 0 and expected_result in ['FAIL']:
+            self.fail("Test was expected to fail but it passed.\n")
+        elif exit_status != 0 and expected_result in ['PASS']:
+            self.fail("Test was expected to pass but it failed.\n")
+
+        # if the test trashed some pool parameter, put it back the way it was
+        if saveduuid is not None:
+            self.pool.pool.uuid = saveduuid
+            self.pool.uuid = original_test_pool_uuid

--- a/src/tests/ftest/pool/bad_evict.py
+++ b/src/tests/ftest/pool/bad_evict.py
@@ -59,14 +59,14 @@ class BadEvictTest(TestWithServers):
         # trash the UUID value in various ways
         if excludeuuid is None:
             saveduuid = (ctypes.c_ubyte * 16)(0)
-            for item in range(0, len(saveduuid)):
-                saveduuid[item] = self.pool.pool.uuid[item]
+            for index, _ in enumerate(saveduuid):
+                saveduuid[index] = self.pool.pool.uuid[index]
             self.pool.pool.uuid[0:] = \
                 [0 for item in range(0, len(self.pool.pool.uuid))]
         elif excludeuuid == 'JUNK':
             saveduuid = (ctypes.c_ubyte * 16)(0)
-            for item in range(0, len(saveduuid)):
-                saveduuid[item] = self.pool.pool.uuid[item]
+            for index, _ in enumerate(saveduuid):
+                saveduuid[index] = self.pool.pool.uuid[index]
             self.pool.pool.uuid[4] = 244
 
         self.pool.uuid = self.pool.pool.get_uuid_str()

--- a/src/tests/ftest/pool/bad_evict.py
+++ b/src/tests/ftest/pool/bad_evict.py
@@ -51,9 +51,6 @@ class BadEvictTest(TestWithServers):
         self.add_pool(connect=False)
         original_test_pool_uuid = self.pool.uuid
 
-        # Make dmg call and poolevict() not fail.
-        self.pool.dmg.exit_status_exception = False
-
         # trash the UUID value in various ways
         if excludeuuid is None:
             saveduuid = (ctypes.c_ubyte * 16)(0)
@@ -69,9 +66,14 @@ class BadEvictTest(TestWithServers):
 
         self.pool.uuid = self.pool.pool.get_uuid_str()
 
-        self.pool.use_label = False
-        self.pool.evict()
-        self.pool.use_label = True
+        try:
+            # Make dmg call and poolevict() not fail.
+            self.pool.dmg.exit_status_exception = False
+            self.pool.use_label = False
+            self.pool.evict()
+        finally:
+            self.pool.use_label = True
+            self.pool.dmg.exit_status_exception = True
 
         exit_status = self.pool.dmg.result.exit_status
         if exit_status == 0 and expected_result in ['FAIL']:

--- a/src/tests/ftest/pool/evict_test.py
+++ b/src/tests/ftest/pool/evict_test.py
@@ -157,9 +157,10 @@ class EvictTests(TestWithServers):
         The handle is removed.
         The test verifies that the other two pools were not affected
         by the evict
+
         :avocado: tags=all,pr,daily_regression,full_regression
         :avocado: tags=small
-        :avocado: tags=pool,pool_evict
+        :avocado: tags=pool,pool_evict,pool_evict_basic
         :avocado: tags=DAOS_5610
         """
         # Do not use self.pool. It will cause -1002 error when disconnecting.
@@ -194,16 +195,11 @@ class EvictTests(TestWithServers):
             container[count].create()
             container[count].write_objects(target_list[-1])
 
-        try:
-            self.log.info(
-                "Attempting to evict clients from pool with UUID: %s",
-                pool[-1].uuid)
-            # Evict the last pool in the list
-            pool[-1].dmg.pool_evict(pool=pool[-1].pool.get_uuid_str())
-        except CommandFailure as result:
-            self.fail(
-                "Detected exception while evicting a client {}".format(
-                    str(result)))
+        pool[-1].dmg.exit_status_exception = False
+        pool[-1].evict()
+        if pool.dmg.result.exit_status != 0:
+            self.fail("Pool evict failed!")
+        pool[-1].dmg.exit_status_exception = True
 
         for count in range(len(tlist)):
             # Commented out due to DAOS-3836.

--- a/src/tests/ftest/pool/evict_test.py
+++ b/src/tests/ftest/pool/evict_test.py
@@ -8,7 +8,6 @@ import uuid
 
 from apricot import TestWithServers
 from pydaos.raw import DaosApiError, c_uuid_to_str
-from command_utils_base import CommandFailure
 from test_utils_container import TestContainer
 
 

--- a/src/tests/ftest/pool/evict_test.py
+++ b/src/tests/ftest/pool/evict_test.py
@@ -197,7 +197,7 @@ class EvictTests(TestWithServers):
 
         pool[-1].dmg.exit_status_exception = False
         pool[-1].evict()
-        if pool.dmg.result.exit_status != 0:
+        if pool[-1].dmg.result.exit_status != 0:
             self.fail("Pool evict failed!")
         pool[-1].dmg.exit_status_exception = True
 

--- a/src/tests/ftest/pool/evict_test.py
+++ b/src/tests/ftest/pool/evict_test.py
@@ -194,11 +194,14 @@ class EvictTests(TestWithServers):
             container[count].create()
             container[count].write_objects(target_list[-1])
 
-        pool[-1].dmg.exit_status_exception = False
-        pool[-1].evict()
+        try:
+            pool[-1].dmg.exit_status_exception = False
+            pool[-1].evict()
+        finally:
+            pool[-1].dmg.exit_status_exception = True
+
         if pool[-1].dmg.result.exit_status != 0:
             self.fail("Pool evict failed!")
-        pool[-1].dmg.exit_status_exception = True
 
         for count in range(len(tlist)):
             # Commented out due to DAOS-3836.

--- a/src/tests/ftest/pool/pool_svc.py
+++ b/src/tests/ftest/pool/pool_svc.py
@@ -29,7 +29,11 @@ class PoolSvc(TestWithServers):
             int: current pool leader rank
 
         """
+        # Test UUID.
+        self.pool.use_label = False
         self.pool.set_query_data()
+        self.pool.use_label = True
+
         try:
             current_leader = int(self.pool.query_data["response"]["leader"])
         except KeyError as error:


### PR DESCRIPTION
Add some UUID test coverage for dmg pool commands.
Updated the tests to use TestPool instead of directly calling dmg.

Skip-unit-tests: true
Test-tag: snapshot_aggregation test_pool_svc bad_evict pool_evict_basic
Signed-off-by: Makito Kano <makito.kano@intel.com>