### PR TITLE
DAOS-7446 daos: add fi test to fs copy

### DIFF
--- a/src/client/dfs/dfs_sys.c
+++ b/src/client/dfs/dfs_sys.c
@@ -213,7 +213,7 @@ hash_lookup(dfs_sys_t *dfs_sys, struct sys_path *sys_path)
 	hdl->name_len = sys_path->dir_name_len;
 	D_STRNDUP(hdl->name, sys_path->dir_name, sys_path->dir_name_len);
 	if (hdl->name == NULL)
-		D_GOTO(free_hdl, ENOMEM);
+		D_GOTO(free_hdl, rc = ENOMEM);
 
 	/* Start with 2 so we have exactly 1 reference left
 	 * when dfs_sys_umount is called.

--- a/src/utils/daos.c
+++ b/src/utils/daos.c
@@ -1045,6 +1045,7 @@ fs_op_hdlr(struct cmd_args_s *ap)
 			D_GOTO(out, rc = RC_PRINT_HELP);
 		} else {
 			rc = fs_copy_hdlr(ap);
+			D_GOTO(out, rc);
 		}
 		break;
 	case FS_SET_ATTR:

--- a/utils/node_local_test.py
+++ b/utils/node_local_test.py
@@ -3417,8 +3417,8 @@ def run(wf, args):
         server = DaosServer(conf, test_class='no-debug')
         server.start()
         if fi_test:
-#            fatal_errors.add_result(test_alloc_fail_copy(server, conf,
-#                                                         wf_client))
+            fatal_errors.add_result(test_alloc_fail_copy(server, conf,
+                                                         wf_client))
             fatal_errors.add_result(test_alloc_fail_cat(server,
                                                         conf, wf_client))
             fatal_errors.add_result(test_alloc_fail(server, conf))


### PR DESCRIPTION
Add fault injection testing to fs copy and use dfs_sys API

    * turn on fi test for fs copy
    * fix return code errors in fault injection tests
    * use macros to print all error codes with standard format
    * fix when error code  was not being properly set
    * return DAOS error codes from higher level functions
    * use dfs_sys API to replace old dfs wrappers

Signed-off-by: Danielle Sikich <danielle.sikich@intel.com>