### PR TITLE
DAOS-8082 object: more leak fixes

### DIFF
--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -180,9 +180,9 @@ open_retry:
 		rc = dc_obj_shard_open(obj, oid, obj->cob_mode, obj_shard);
 		if (rc)
 			D_GOTO(unlock, rc);
-	}
 
-	if (rc == 0) {
+		*shard_ptr = obj_shard;
+	} else {
 		/* hold the object shard */
 		obj_shard_addref(obj_shard);
 		*shard_ptr = obj_shard;
@@ -367,6 +367,7 @@ obj_layout_create(struct dc_object *obj, bool refresh)
 
 		obj_shard = &obj->cob_shards->do_shards[i];
 		obj_shard->do_shard = layout->ol_shards[i].po_shard;
+		obj_shard->do_shard_idx = i;
 		obj_shard->do_target_id = layout->ol_shards[i].po_target;
 		obj_shard->do_fseq = layout->ol_shards[i].po_fseq;
 		obj_shard->do_rebuilding = layout->ol_shards[i].po_rebuilding;
@@ -5610,6 +5611,8 @@ out:
 			if (dova[i].list_buf != dova[i].inline_buf)
 				D_FREE(dova[i].list_buf);
 
+			daos_iov_free(&dova[i].cursor.dkey);
+			daos_iov_free(&dova[i].cursor.iod.iod_name);
 			D_FREE(dova[i].fetch_buf);
 		}
 

--- a/src/object/cli_shard.c
+++ b/src/object/cli_shard.c
@@ -21,7 +21,7 @@ static inline struct dc_obj_layout *
 obj_shard2layout(struct dc_obj_shard *shard)
 {
 	return container_of(shard, struct dc_obj_layout,
-			    do_shards[shard->do_shard]);
+			    do_shards[shard->do_shard_idx]);
 }
 
 void

--- a/src/object/obj_internal.h
+++ b/src/object/obj_internal.h
@@ -50,15 +50,16 @@ extern unsigned int	srv_io_mode;
 struct dc_obj_shard {
 	/** refcount */
 	unsigned int		do_ref;
+	uint32_t		do_target_rank;
 	/** object id */
 	daos_unit_oid_t		do_id;
 	/** container handler of the object */
 	daos_handle_t		do_co_hdl;
-	uint8_t			do_target_idx;	/* target VOS index in node */
-	uint32_t		do_target_rank;
 	struct pl_obj_shard	do_pl_shard;
 	/** point back to object */
 	struct dc_object	*do_obj;
+	uint32_t		do_shard_idx;
+	uint8_t			do_target_idx;	/* target VOS index in node */
 };
 
 #define do_shard	do_pl_shard.po_shard


### PR DESCRIPTION
1. Add do_shard_idx to dc_obj_shard, since do_shard
may not be the offset of shard in cob_shards during
reintegration.

2. dkeys and aksys free are missing in cursor.

Signed-off-by: Di Wang <di.wang@intel.com>