### PR TITLE
DAOS-[7987, 7991, 7994] test: Coverity fixes

### DIFF
--- a/src/common/tests/lru.c
+++ b/src/common/tests/lru.c
@@ -104,7 +104,7 @@ int
 main(int argc, char **argv)
 {
 	int			rc, num_keys, i, j;
-	uint64_t		*keys;
+	uint64_t		*keys = NULL;
 	struct daos_llink	*link_ret[3] = {NULL};
 	struct daos_lru_cache	*tcache = NULL;
 	int			csize;
@@ -126,6 +126,12 @@ main(int argc, char **argv)
 				   &tcache);
 	if (rc)
 		D_ASSERTF(0, "Error in creating lru cache\n");
+
+	if (num_keys < 0 || num_keys > INT_MAX) {
+		rc = -DER_INVAL;
+		D_ERROR("Invalid number of keys\n");
+		D_GOTO(exit, rc);
+	}
 
 	D_ALLOC_ARRAY(keys, (num_keys + 2));
 	if (keys == NULL)

--- a/src/common/tests/lru.c
+++ b/src/common/tests/lru.c
@@ -121,24 +121,25 @@ main(int argc, char **argv)
 	csize = strtol(argv[1], (char **)NULL, 10);
 	num_keys = strtol(argv[2], (char **)NULL, 10);
 
+	if (csize < 0 || csize > INT_MAX) {
+		rc = -DER_INVAL;
+		D_ERROR("Invalid cell size\n");
+		D_GOTO(exit, rc);
+	}
+
 	rc = daos_lru_cache_create(csize, D_HASH_FT_RWLOCK,
 				   &uint_ref_llink_ops,
 				   &tcache);
 	if (rc)
 		D_ASSERTF(0, "Error in creating lru cache\n");
 
-	/* make sure these could fit into int variable, since
+	/* make sure csize and num_keys can
+	 * fit into int variable, since
 	 * they used to be cast to int values
 	 */
 	if (num_keys < 0 || num_keys > INT_MAX) {
 		rc = -DER_INVAL;
 		D_ERROR("Invalid number of keys\n");
-		D_GOTO(exit, rc);
-	}
-
-	if (csize < 0 || csize > INT_MAX) {
-		rc = -DER_INVAL;
-		D_ERROR("Invalid cell size\n");
 		D_GOTO(exit, rc);
 	}
 

--- a/src/common/tests/lru.c
+++ b/src/common/tests/lru.c
@@ -103,11 +103,11 @@ test_ref_hold(struct daos_lru_cache *cache,
 int
 main(int argc, char **argv)
 {
-	int			rc, num_keys, i, j;
+	int			rc, i, j;
+	long int		num_keys, csize;
 	uint64_t		*keys = NULL;
 	struct daos_llink	*link_ret[3] = {NULL};
 	struct daos_lru_cache	*tcache = NULL;
-	int			csize;
 
 	rc = daos_debug_init(DAOS_LOG_DEFAULT);
 	if (rc != 0)
@@ -118,8 +118,8 @@ main(int argc, char **argv)
 		exit(-1);
 	}
 
-	csize	 = (int)strtol(argv[1], (char **)NULL, 10);
-	num_keys = (int)strtol(argv[2], (char **)NULL, 10);
+	csize = strtol(argv[1], (char **)NULL, 10);
+	num_keys = strtol(argv[2], (char **)NULL, 10);
 
 	rc = daos_lru_cache_create(csize, D_HASH_FT_RWLOCK,
 				   &uint_ref_llink_ops,
@@ -127,9 +127,18 @@ main(int argc, char **argv)
 	if (rc)
 		D_ASSERTF(0, "Error in creating lru cache\n");
 
+	/* make sure these could fit into int variable, since
+	 * they used to be cast to int values
+	 */
 	if (num_keys < 0 || num_keys > INT_MAX) {
 		rc = -DER_INVAL;
 		D_ERROR("Invalid number of keys\n");
+		D_GOTO(exit, rc);
+	}
+
+	if (csize < 0 || csize > INT_MAX) {
+		rc = -DER_INVAL;
+		D_ERROR("Invalid cell size\n");
 		D_GOTO(exit, rc);
 	}
 

--- a/src/tests/ftest/cart/dual_iface_server.c
+++ b/src/tests/ftest/cart/dual_iface_server.c
@@ -329,6 +329,7 @@ server_main(d_rank_t my_rank, const char *str_port, const char *str_interface,
 
 	/* Read each others URIs from the file */
 	memset(other_server_uri, 0x0, MAX_URI);
+	other_server_uri[MAX_URI - 1] = '\0';
 	lseek(fd_read, 0, SEEK_SET);
 	rc = read(fd_read, other_server_uri, MAX_URI);
 	if (rc < 0) {

--- a/src/tests/ftest/cart/dual_iface_server.c
+++ b/src/tests/ftest/cart/dual_iface_server.c
@@ -576,6 +576,7 @@ int main(int argc, char **argv)
 	printf("----------------------------------------\n\n");
 
 	/* Spawn 2 servers, each one reads and writes URIs into diff file */
+	umask(600);
 	fd0 = mkstemp(tmp_file0);
 	fd1 = mkstemp(tmp_file1);
 

--- a/src/tests/ftest/cart/dual_iface_server.c
+++ b/src/tests/ftest/cart/dual_iface_server.c
@@ -576,7 +576,7 @@ int main(int argc, char **argv)
 	printf("----------------------------------------\n\n");
 
 	/* Spawn 2 servers, each one reads and writes URIs into diff file */
-	umask(600);
+	umask(S_IWGRP | S_IWOTH);
 	fd0 = mkstemp(tmp_file0);
 	fd1 = mkstemp(tmp_file1);
 

--- a/src/tests/ftest/cart/test_group_np_common.h
+++ b/src/tests/ftest/cart/test_group_np_common.h
@@ -635,6 +635,7 @@ parse_verify_swim_status_arg(char *source)
 				int exp_status_len = 8;
 				char exp_status[exp_status_len];
 
+				memset(exp_status, 0, exp_status_len);
 				if (exp_status_len >
 				    strlen(cC + groupArray[g].rm_so)) {
 					/* avoid checkpatch warning */

--- a/src/tests/suite/daos_epoch_io.c
+++ b/src/tests/suite/daos_epoch_io.c
@@ -497,7 +497,7 @@ cmd_line_get(FILE *fp, char *line)
 
 	D_ASSERT(line != NULL && fp != NULL);
 	do {
-		if (fgets(line, CMD_LINE_LEN_MAX, fp) == NULL)
+		if (fgets(line, CMD_LINE_LEN_MAX - 1, fp) == NULL)
 			return -DER_ENOENT;
 		for (p = line; isspace(*p); p++)
 			;
@@ -1458,7 +1458,7 @@ io_conf_run(test_arg_t *arg, const char *io_conf)
 {
 	struct test_op_record	*op = NULL;
 	FILE			*fp;
-	char			 cmd_line[CMD_LINE_LEN_MAX] = {};
+	char			 cmd_line[CMD_LINE_LEN_MAX - 1] = {};
 	int			 rc = 0;
 	/*Array for snapshot epoch*/
 	daos_epoch_t		sn_epoch[DTS_MAX_EPOCH_TIMES] = {};
@@ -1478,14 +1478,14 @@ io_conf_run(test_arg_t *arg, const char *io_conf)
 	do {
 		size_t	cmd_size;
 
-		memset(cmd_line, 0, CMD_LINE_LEN_MAX);
+		memset(cmd_line, 0, CMD_LINE_LEN_MAX - 1);
 		if (cmd_line_get(fp, cmd_line) != 0)
 			break;
 
-		cmd_size = strnlen(cmd_line, CMD_LINE_LEN_MAX);
+		cmd_size = strnlen(cmd_line, CMD_LINE_LEN_MAX - 1);
 		if (cmd_size == 0)
 			continue;
-		if (cmd_size >= CMD_LINE_LEN_MAX) {
+		if (cmd_size >= CMD_LINE_LEN_MAX - 1) {
 			print_message("bad cmd_line, exit.\n");
 			break;
 		}


### PR DESCRIPTION
DAOS-7994 test: fix CID 275713
    
    In main: An unscrutinized value from an untrusted source
    used as a loop bound.
    
    Fix for this is to ensure that num_keys has an upper bound
    which is checked and also that a check is in place to make
    sure a negative number is not passed provided.

DAOS-7991 test: fix CID 329700
    
    In main: Using an insecure temporary file creation function
    
    Set umask before creation of temporary files.

DAOS-7987 test: fix CID 329541, 331438, 329382
    
    329541 In cmd_line_parse: The string buffer may
    not have a null terminator if the source string's
    length is equal to the buffer size
    
    Set source buffer to max - 1 to make so there is room
    in destination buffer for null byte.
    
    331438 In server_main: A character buffer that has
    not been null terminated is passed to a function
    expecting a null terminated string
    
    Set null terminator on string.
    
    329382 In parse_verify_swim_status_arg: Reads an
    uninitialized pointer or its target
    
    Initialize the array.
