### PR TITLE
DAOS-8120 control: Add OOG to retryable pool destroy errors

### DIFF
--- a/src/control/lib/control/pool.go
+++ b/src/control/lib/control/pool.go
@@ -302,7 +302,7 @@ func PoolDestroy(ctx context.Context, rpcClient UnaryInvoker, req *PoolDestroyRe
 			switch e {
 			// These destroy errors can be retried.
 			case drpc.DaosTimedOut, drpc.DaosGroupVersionMismatch,
-				drpc.DaosTryAgain:
+				drpc.DaosTryAgain, drpc.DaosOutOfGroup:
 				return true
 			default:
 				return false


### PR DESCRIPTION
Seen occasionally in CI. Add to the set of retryable errors
with the idea that it should resolve eventually. Worst-case,
the destroy command will continue to retry until the request
deadline.