### PR TITLE
DAOS-8229 test: Use no_query=True in PoolCreateCapacity

### DIFF
--- a/src/tests/ftest/pool/create_capacity_test.py
+++ b/src/tests/ftest/pool/create_capacity_test.py
@@ -59,7 +59,7 @@ class PoolCreateTests(PoolTestBase):
 
         self.dmg.timeout = 360
         # Verify all the pools exists after the restart
-        detected_pools = [uuid.lower() for uuid in self.dmg.pool_list()]
+        detected_pools = [uuid.lower() for uuid in self.dmg.pool_list(no_query=True)]
         missing_pools = []
         for pool in self.pool:
             pool_uuid = pool.uuid.lower()


### PR DESCRIPTION
Don't query the pools while listing them, to avoid intermittent
test timeouts.