### PR TITLE
DAOS-8080 test: re-enable nvme query and health tests

### DIFF
--- a/src/control/common/proto/types_test.go
+++ b/src/control/common/proto/types_test.go
@@ -123,7 +123,10 @@ func TestProto_ConvertScmModules(t *testing.T) {
 
 func TestProto_ConvertScmMountPoint(t *testing.T) {
 	a := storage.MockScmMountPoint()
-	resA, _ := json.Marshal(a)
+	resA, err := json.Marshal(a)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	var b storage.ScmMountPoint
 	if err := json.Unmarshal(resA, &b); err != nil {

--- a/src/control/server/ctl_storage.go
+++ b/src/control/server/ctl_storage.go
@@ -338,7 +338,7 @@ func mapCtrlrs(ctrlrs storage.NvmeControllers) (map[string]*storage.NvmeControll
 // health statistics and stored server meta-data. If I/O Engines are running
 // then query is issued over dRPC as go-spdk bindings cannot be used to access
 // controller claimed by another process. Only update info for controllers
-// assigned to I/O Engineslled.
+// assigned to I/O Engines.
 func (c *ControlService) scanAssignedBdevs(ctx context.Context, statsReq bool) (*storage.BdevScanResponse, error) {
 	var ctrlrs storage.NvmeControllers
 	instances := c.harness.Instances()

--- a/src/control/server/storage/provider.go
+++ b/src/control/server/storage/provider.go
@@ -395,7 +395,6 @@ func filterScanResp(log logging.Logger, resp *BdevScanResponse, pciFilter ...str
 
 	for _, c := range resp.Controllers {
 		if len(pciFilter) != 0 && !common.Includes(pciFilter, c.PciAddr) {
-			log.Debugf("filter out bdev %s from scan response", c.PciAddr)
 			continue
 		}
 		cn := *c

--- a/src/tests/ftest/nvme/nvme_fault.py
+++ b/src/tests/ftest/nvme/nvme_fault.py
@@ -8,7 +8,6 @@ import os
 from nvme_utils import ServerFillUp
 from dmg_utils import DmgCommand
 from command_utils_base import CommandFailure
-from apricot import skipForTicket
 
 class NvmeFault(ServerFillUp):
     # pylint: disable=too-many-ancestors

--- a/src/tests/ftest/nvme/nvme_fault.py
+++ b/src/tests/ftest/nvme/nvme_fault.py
@@ -35,7 +35,6 @@ class NvmeFault(ServerFillUp):
         #Set to True to generate the NVMe fault during IO
         self.set_faulty_device = True
 
-    @skipForTicket("DAOS-8080")
     def test_nvme_fault(self):
         """Jira ID: DAOS-4722.
 

--- a/src/tests/ftest/nvme/nvme_health.py
+++ b/src/tests/ftest/nvme/nvme_health.py
@@ -10,7 +10,6 @@ import os
 from nvme_utils import ServerFillUp, get_device_ids
 from dmg_utils import DmgCommand
 from command_utils_base import CommandFailure
-from apricot import skipForTicket
 
 class NvmeHealth(ServerFillUp):
     # pylint: disable=too-many-ancestors

--- a/src/tests/ftest/nvme/nvme_health.py
+++ b/src/tests/ftest/nvme/nvme_health.py
@@ -18,7 +18,6 @@ class NvmeHealth(ServerFillUp):
     Test Class Description: To validate NVMe health test cases
     :avocado: recursive
     """
-    @skipForTicket("DAOS-8080")
     def test_monitor_for_large_pools(self):
         """Jira ID: DAOS-4722.
 


### PR DESCRIPTION
Remove test skips and address some small feedback issues.

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>