### PR TITLE
DAOS-7675 vos: Avoid unnecessary object cache eviction

### DIFF
--- a/src/vos/ilog.c
+++ b/src/vos/ilog.c
@@ -1067,6 +1067,23 @@ ilog_fetch_init(struct ilog_entries *entries)
 	entries->ie_statuses = &priv->ip_embedded[0];
 }
 
+void
+ilog_fetch_move(struct ilog_entries *dest, struct ilog_entries *src)
+{
+	struct ilog_priv	*priv_dest = ilog_ent2priv(dest);
+	struct ilog_priv	*priv_src = ilog_ent2priv(src);
+
+	D_ASSERT(dest != NULL);
+	D_ASSERT(src != NULL);
+
+	/** We've already copied everything, just fix up any pointers here */
+	if (src->ie_statuses == &priv_src->ip_embedded[0])
+		dest->ie_statuses = &priv_dest->ip_embedded[0];
+
+	priv_src->ip_alloc_size = 0;
+	priv_src->ip_removals = NULL;
+}
+
 static void
 ilog_status_refresh(struct ilog_context *lctx, uint32_t intent,
 		    struct ilog_entries *entries)

--- a/src/vos/ilog.h
+++ b/src/vos/ilog.h
@@ -215,6 +215,15 @@ ilog_aggregate(struct umem_instance *umm, struct ilog_df *root,
 void
 ilog_fetch_init(struct ilog_entries *entries);
 
+/** Assuming src has already been copied to dest, just fix up internal pointers
+ *  and reset src
+ *
+ *  \param	dest[in]	Destination entries
+ *  \param	src[in]		Source entries
+ */
+void
+ilog_fetch_move(struct ilog_entries *dest, struct ilog_entries *src);
+
 /** Fetch the entire incarnation log.  This function will refresh only when
  * the underlying log or the intent has changed.  If the struct is shared
  * between multiple ULT's fetch should be done after every yield.

--- a/src/vos/vos_ilog.c
+++ b/src/vos/vos_ilog.c
@@ -543,6 +543,13 @@ vos_ilog_fetch_init(struct vos_ilog_info *info)
 	ilog_fetch_init(&info->ii_entries);
 }
 
+void
+vos_ilog_fetch_move(struct vos_ilog_info *dest, struct vos_ilog_info *src)
+{
+	memcpy(dest, src, sizeof(*dest));
+	ilog_fetch_move(&dest->ii_entries, &src->ii_entries);
+}
+
 /** Finalize incarnation log information */
 void
 vos_ilog_fetch_finish(struct vos_ilog_info *info)

--- a/src/vos/vos_ilog.h
+++ b/src/vos/vos_ilog.h
@@ -74,6 +74,10 @@ vos_ilog_init(void);
 void
 vos_ilog_fetch_init(struct vos_ilog_info *info);
 
+/** Move ilog information from src to dest, clearing src */
+void
+vos_ilog_fetch_move(struct vos_ilog_info *dest, struct vos_ilog_info *src);
+
 /** Finalize incarnation log information */
 void
 vos_ilog_fetch_finish(struct vos_ilog_info *info);

--- a/src/vos/vos_obj.h
+++ b/src/vos/vos_obj.h
@@ -41,18 +41,14 @@ struct vos_object {
 	daos_handle_t			obj_toh;
 	/** btree iterator handle */
 	daos_handle_t			obj_ih;
-	/** epoch when the object(cache) is initialized */
-	daos_epoch_t			obj_epoch;
 	/** The latest sync epoch */
 	daos_epoch_t			obj_sync_epoch;
-	/** cached vos_obj_df::vo_incarnation, for revalidation. */
-	uint32_t			obj_incarnation;
-	/** nobody should access this object */
-	bool				obj_zombie;
 	/** Persistent memory address of the object */
 	struct vos_obj_df		*obj_df;
 	/** backref to container */
 	struct vos_container		*obj_cont;
+	/** nobody should access this object */
+	bool				obj_zombie;
 };
 
 enum {

--- a/src/vos/vos_obj_cache.c
+++ b/src/vos/vos_obj_cache.c
@@ -38,6 +38,19 @@ struct obj_lru_key {
 	daos_unit_oid_t		 olk_oid;
 };
 
+static inline void
+init_object(struct vos_object *obj, daos_unit_oid_t oid, struct vos_container *cont)
+{
+	/**
+	 * Saving a copy of oid to avoid looking up in vos_obj_df, which
+	 * is a direct pointer to pmem data structure
+	 */
+	obj->obj_id	= oid;
+	obj->obj_cont	= cont;
+	vos_cont_addref(cont);
+	vos_ilog_fetch_init(&obj->obj_ilog_info);
+}
+
 static int
 obj_lop_alloc(void *key, unsigned int ksize, void *args,
 	      struct daos_llink **llink_p)
@@ -59,14 +72,8 @@ obj_lop_alloc(void *key, unsigned int ksize, void *args,
 	D_ALLOC_PTR(obj);
 	if (!obj)
 		D_GOTO(failed, rc = -DER_NOMEM);
-	/**
-	 * Saving a copy of oid to avoid looking up in vos_obj_df, which
-	 * is a direct pointer to pmem data structure
-	 */
-	obj->obj_id	= lkey->olk_oid;
-	obj->obj_cont	= cont;
-	vos_cont_addref(cont);
-	vos_ilog_fetch_init(&obj->obj_ilog_info);
+
+	init_object(obj, lkey->olk_oid, cont);
 
 	*llink_p = &obj->obj_llink;
 	rc = 0;
@@ -102,6 +109,16 @@ obj_lop_rec_hash(struct daos_llink *llink)
 	return d_hash_string_u32((const char *)&lkey, sizeof(lkey));
 }
 
+static inline void
+clean_object(struct vos_object *obj)
+{
+	vos_ilog_fetch_finish(&obj->obj_ilog_info);
+	if (obj->obj_cont != NULL)
+		vos_cont_decref(obj->obj_cont);
+
+	obj_tree_fini(obj);
+}
+
 static void
 obj_lop_free(struct daos_llink *llink)
 {
@@ -110,11 +127,7 @@ obj_lop_free(struct daos_llink *llink)
 	D_DEBUG(DB_TRACE, "lru free callback for vos_obj_cache\n");
 
 	obj = container_of(llink, struct vos_object, obj_llink);
-	vos_ilog_fetch_finish(&obj->obj_ilog_info);
-	if (obj->obj_cont != NULL)
-		vos_cont_decref(obj->obj_cont);
-
-	obj_tree_fini(obj);
+	clean_object(obj);
 	D_FREE(obj);
 }
 
@@ -185,9 +198,17 @@ vos_obj_cache_current(void)
 	return vos_obj_cache_get();
 }
 
+static __thread struct vos_object	 obj_local = {0};
+
 void
 vos_obj_release(struct daos_lru_cache *occ, struct vos_object *obj, bool evict)
 {
+
+	if (obj == &obj_local) {
+		clean_object(obj);
+		memset(obj, 0, sizeof(*obj));
+		return;
+	}
 
 	D_ASSERT((occ != NULL) && (obj != NULL));
 
@@ -195,6 +216,41 @@ vos_obj_release(struct daos_lru_cache *occ, struct vos_object *obj, bool evict)
 		daos_lru_ref_evict(occ, &obj->obj_llink);
 
 	daos_lru_ref_release(occ, &obj->obj_llink);
+}
+
+/** Move local object to the lru cache */
+static inline int
+cache_object(struct daos_lru_cache *occ)
+{
+	struct vos_object	*obj_new;
+	struct daos_llink	*lret;
+	struct obj_lru_key	 lkey;
+	int			 rc;
+
+	D_ASSERT(obj_local.obj_cont != NULL);
+
+	lkey.olk_cont = obj_local.obj_cont;
+	lkey.olk_oid = obj_local.obj_id;
+
+	rc = daos_lru_ref_hold(occ, &lkey, sizeof(lkey), obj_local.obj_cont, &lret);
+	if (rc != 0)
+		return rc; /* Can't cache new object */
+
+	/** Object is in cache */
+	obj_new = container_of(lret, struct vos_object, obj_llink);
+	/* This object should not be cached */
+	D_ASSERT(obj_new->obj_df == NULL);
+
+	vos_ilog_fetch_move(&obj_new->obj_ilog_info, &obj_local.obj_ilog_info);
+	obj_new->obj_toh = obj_local.obj_toh;
+	obj_new->obj_ih = obj_local.obj_ih;
+	obj_new->obj_sync_epoch = obj_local.obj_sync_epoch;
+	obj_new->obj_df = obj_local.obj_df;
+	obj_new->obj_zombie = obj_local.obj_zombie;
+	clean_object(&obj_local);
+	memset(&obj_local, 0, sizeof(obj_local));
+
+	return 0;
 }
 
 int
@@ -232,16 +288,36 @@ vos_obj_hold(struct daos_lru_cache *occ, struct vos_container *cont,
 	lkey.olk_cont = cont;
 	lkey.olk_oid = oid;
 
-	rc = daos_lru_ref_hold(occ, &lkey, sizeof(lkey), cont, &lret);
-	if (rc)
+try_hold:
+	/** Pass NULL as the create_args the first time.   We don't want to
+	 *  evict an entry until we need to do so.
+	 */
+	rc = daos_lru_ref_hold(occ, &lkey, sizeof(lkey), NULL, &lret);
+	if (rc == -DER_NONEXIST) {
+		/** Object isn't in cache, use a threadprivate variable for the checks */
+		if (obj_local.obj_cont != NULL) {
+			/** Threadprivate variable is in used, first move it to cache */
+			rc = cache_object(occ);
+			if (rc != 0)
+				goto failed_2;
+			goto try_hold;
+		}
+		obj = &obj_local;
+		init_object(obj, oid, cont);
+	} else if (rc != 0) {
 		D_GOTO(failed_2, rc);
-
-	obj = container_of(lret, struct vos_object, obj_llink);
+	} else {
+		/** Object is in cache */
+		obj = container_of(lret, struct vos_object, obj_llink);
+	}
 
 	if (obj->obj_zombie)
 		D_GOTO(failed, rc = -DER_AGAIN);
 
 	if (intent == DAOS_INTENT_KILL) {
+		if (obj == &obj_local)
+			goto out; /* Ok to delete, not referenced */
+
 		if (vos_obj_refcount(obj) > 2)
 			D_GOTO(failed, rc = -DER_BUSY);
 
@@ -368,6 +444,9 @@ out:
 		D_GOTO(failed, rc = -DER_TX_RESTART);
 	}
 
+	if (obj == &obj_local) {
+	}
+
 	*obj_p = obj;
 
 	return 0;
@@ -381,6 +460,11 @@ failed_2:
 void
 vos_obj_evict(struct daos_lru_cache *occ, struct vos_object *obj)
 {
+	if (obj == &obj_local) {
+		/** prevent new holders */
+		obj_local.obj_zombie = true;
+		return;
+	}
 	daos_lru_ref_evict(occ, &obj->obj_llink);
 }
 
@@ -399,6 +483,13 @@ vos_obj_evict_by_oid(struct daos_lru_cache *occ, struct vos_container *cont,
 	if (rc == 0) {
 		daos_lru_ref_evict(occ, lret);
 		daos_lru_ref_release(occ, lret);
+	}
+
+	if (rc == -DER_NONEXIST && obj_local.obj_cont == cont &&
+	    memcmp(&obj_local.obj_id.id_pub, &oid.id_pub, sizeof(oid.id_pub)) == 0) {
+		/** prevent new holders */
+		obj_local.obj_zombie = true;
+		rc = 0;
 	}
 
 	return rc == -DER_NONEXIST ? 0 : rc;


### PR DESCRIPTION
For fetch of non-existent objects or other operations that will
fail vos_obj_hold, we can use a threadprivate object to
cache the state, thus avoiding any eviction until we know
the object needs to be cached.

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>