### PR TITLE
DAOS-7212 pool: pool query from MS, mind retryable RPC errors

### DIFF
--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -586,6 +586,28 @@ select_svc_ranks(int nreplicas, const d_rank_list_t *target_addrs,
 	return 0;
 }
 
+/* TODO: replace all rsvc_complete_rpc() calls in this file with pool_rsvc_complete_rpc() */
+
+/*
+ * Returns:
+ *
+ *   RSVC_CLIENT_RECHOOSE	Instructs caller to retry RPC starting from rsvc_client_choose()
+ *   RSVC_CLIENT_PROCEED	OK; proceed to process the reply
+ */
+static int
+pool_rsvc_client_complete_rpc(struct rsvc_client *client, const crt_endpoint_t *ep,
+			      int rc_crt, struct pool_op_out *out)
+{
+	int rc;
+
+	rc = rsvc_client_complete_rpc(client, ep, rc_crt, out->po_rc, &out->po_hint);
+	if (rc == RSVC_CLIENT_RECHOOSE ||
+	    (rc == RSVC_CLIENT_PROCEED && daos_rpc_retryable_rc(out->po_rc))) {
+		return RSVC_CLIENT_RECHOOSE;
+	}
+	return RSVC_CLIENT_PROCEED;
+}
+
 /**
  * Create a (combined) pool(/container) service. This method shall be called on
  * a single storage node in the pool. "target_uuids" shall be an array of the
@@ -3064,9 +3086,7 @@ realloc:
 	out = crt_reply_get(rpc);
 	D_ASSERT(out != NULL);
 
-	rc = rsvc_client_complete_rpc(&client, &ep, rc,
-				      out->pqo_op.po_rc,
-				      &out->pqo_op.po_hint);
+	rc = pool_rsvc_client_complete_rpc(&client, &ep, rc, &out->pqo_op);
 	if (rc == RSVC_CLIENT_RECHOOSE) {
 		map_bulk_destroy(in->pqi_map_bulk, map_buf);
 		crt_req_decref(rpc);

--- a/src/tests/ftest/erasurecode/ec_offline_rebuild.py
+++ b/src/tests/ftest/erasurecode/ec_offline_rebuild.py
@@ -5,7 +5,6 @@
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
 from ec_utils import ErasureCodeIor
-from apricot import skipForTicket
 
 class EcodOfflineRebuild(ErasureCodeIor):
     # pylint: disable=too-many-ancestors
@@ -15,7 +14,6 @@ class EcodOfflineRebuild(ErasureCodeIor):
     :avocado: recursive
     """
 
-    @skipForTicket("DAOS-7212")
     def test_ec_offline_rebuild(self):
         """Jira ID: DAOS-5894.
 

--- a/src/tests/ftest/erasurecode/ec_offline_rebuild_single.py
+++ b/src/tests/ftest/erasurecode/ec_offline_rebuild_single.py
@@ -5,7 +5,6 @@
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
 from ec_utils import ErasureCodeSingle
-from apricot import skipForTicket
 
 class EcodOfflineRebuildSingle(ErasureCodeSingle):
     # pylint: disable=too-many-ancestors
@@ -15,7 +14,6 @@ class EcodOfflineRebuildSingle(ErasureCodeSingle):
     :avocado: recursive
     """
 
-    @skipForTicket("DAOS-7212")
     def test_ec_offline_rebuild_single(self):
         """Jira ID: DAOS-7314.
 


### PR DESCRIPTION
Before this change, stopping the PS leader rank and then issuing
dmg pool query temporarily surfaces -DER_UNREACH to the user.
However, daos pool query internally retries the PS RPCs and seamlessly
(after a raft election delay) returns the pool query result. With dmg,
an MS engine is the cart RPC initiator, whereas with daos, libdaos is
the initiator. The code is similar, but only the libdaos code checks
for and handles "retryable" RPC errors.

With this change, the engine initiator code for POOL_QUERY RPCs checks
for and handles retryable errors (fixing the dmg pool query use case).
This patch is meant to be a precise change to solve a particular issue.
However, a follow-on patch may expand use of retryable error checks for
all MS engine-initiated PS RPCs.

The erasurecode/ec_offline_rebuild and ec_offline_rebuild_single tests
are re-enabled with this change.

Finally, a future change may modify the ftest infrastructure code
to use the daos utility (rather than dmg) to issue pool queries for
detecting rebuild completion.

Test-tag-vm: pr pool_svc
Test-tag-hw-small: pr
Test-tag-hw-medium: pr
Test-tag-hw-large: pr ec_offline_rebuild

Signed-off-by: Kenneth Cain <kenneth.c.cain@intel.com>