### PR TITLE
DAOS-7758 test: set rf to be 1 for offline drain test

### DIFF
--- a/src/tests/ftest/osa/osa_offline_drain.yaml
+++ b/src/tests/ftest/osa/osa_offline_drain.yaml
@@ -53,7 +53,7 @@ container:
     type: POSIX
     control_method: daos
     oclass: RP_2G1
-    properties: cksum:crc64,cksum_size:16384,srv_cksum:on
+    properties: cksum:crc64,cksum_size:16384,srv_cksum:on,rf:1
 dkeys:
   single:
     no_of_dkeys:


### PR DESCRIPTION
Creating objects with oclass RP_2G1 implies rf:1, which
was expected failure if container was created with rf:2.

Test-tag-hw-medium: pr,hw,medium,ib2,offline_drain
Signed-off-by: Wang Shilong <wshilong@ddn.com>