### PR TITLE
DAOS-8225 test: Use TestPool in dmg_pool_evict.py

### DIFF
--- a/src/tests/ftest/control/dmg_pool_evict.py
+++ b/src/tests/ftest/control/dmg_pool_evict.py
@@ -43,7 +43,7 @@ class DmgPoolEvictTest(TestWithServers):
             self.container.append(self.get_container(self.pool[-1]))
 
         # Call dmg pool evict on the second pool.
-        self.get_dmg_command().pool_evict(pool=self.pool[1].uuid)
+        self.pool[-1].evict()
 
         daos_cmd = self.get_daos_command()
 


### PR DESCRIPTION
Use TestPool object instead of DmgCommand to call evict.

Skip-unit-tests: true
Test-tag: dmg_pool_evict
Signed-off-by: Makito Kano <makito.kano@intel.com>