### PR TITLE
DAOS-7487 control: Extend autotest with more smoke capabilities

### DIFF
--- a/src/utils/daos_autotest.c
+++ b/src/utils/daos_autotest.c
@@ -184,7 +184,7 @@ oS1(void)
 	int		rc;
 
 	new_oid();
-	daos_obj_generate_oid(coh, &oid, 0, OC_S1, 0, 0);
+	daos_obj_generate_oid(coh, &oid, 0, 0, 0, 0);
 
 	for (i = 0; i < 1000000; i++) {
 
@@ -213,7 +213,7 @@ oSX(void)
 	int		rc;
 
 	new_oid();
-	daos_obj_generate_oid(coh, &oid, 0, OC_SX, 0, 0);
+	daos_obj_generate_oid(coh, &oid, 0, 0, 0, 0);
 
 	for (i = 0; i < 10000; i++) {
 
@@ -479,7 +479,7 @@ kv_insert128(void)
 	int		rc;
 
 	new_oid();
-	daos_obj_generate_oid(coh, &oid, DAOS_OF_KV_FLAT, OC_SX, 0, 0);
+	daos_obj_generate_oid(coh, &oid, DAOS_OF_KV_FLAT, 0, 0, 0);
 
 	rc = daos_kv_open(coh, oid, DAOS_OO_RW, &oh, NULL);
 	if (rc) {
@@ -578,7 +578,7 @@ kv_insert4k(void)
 	int		rc;
 
 	new_oid();
-	daos_obj_generate_oid(coh, &oid, DAOS_OF_KV_FLAT, OC_SX, 0, 0);
+	daos_obj_generate_oid(coh, &oid, DAOS_OF_KV_FLAT, 0, 0, 0);
 
 	rc = daos_kv_open(coh, oid, DAOS_OO_RO, &oh, NULL);
 	if (rc) {
@@ -641,7 +641,7 @@ kv_insert1m(void)
 	int		rc;
 
 	new_oid();
-	daos_obj_generate_oid(coh, &oid, DAOS_OF_KV_FLAT, OC_SX, 0, 0);
+	daos_obj_generate_oid(coh, &oid, DAOS_OF_KV_FLAT, 0, 0, 0);
 
 	rc = daos_kv_open(coh, oid, DAOS_OO_RW, &oh, NULL);
 	if (rc) {

--- a/src/utils/daos_autotest.c
+++ b/src/utils/daos_autotest.c
@@ -128,6 +128,7 @@ attachinfo(void)
 	size_t 	len = 0;
 	size_t 	read;
 	int	rc;
+	
 	if (fp == NULL)
 		return -DER_INVAL;
 
@@ -194,7 +195,7 @@ ccreate(void)
 	prop->dpp_entries[0].dpe_type = DAOS_PROP_CO_REDUN_FAC;
  	prop->dpp_entries[0].dpe_val = DAOS_PROP_CO_REDUN_RF1;
 
-	uuid_generate(cuuid2);	
+	uuid_generate(cuuid2);
 
 	rc = daos_cont_create(poh, cuuid2, prop, NULL);
 	if (rc) {
@@ -209,8 +210,8 @@ ccreate(void)
 	prop2->dpp_entries[0].dpe_val = DAOS_PROP_CO_REDUN_RF2;
 
 	uuid_generate(cuuid3);
-	
-	rc = daos_cont_create(poh,cuuid3, prop2, NULL);
+
+	rc = daos_cont_create(poh, cuuid3, prop2, NULL);
 	if (rc) {
 		step_fail(d_errdesc(rc));
 		return -1;
@@ -836,7 +837,7 @@ static struct step steps[] = {
 	{ 0,	"Dumping AttachInfo",		attachinfo,	100 },
 
 	/** Set up */
-	{ 1,	"Initializing DAOS",		init ,		100 },
+	{ 1,	"Initializing DAOS",		init,		100 },
 	{ 2,	"Connecting to pool",		pconnect,	99 },
 	{ 3,	"Creating container",		ccreate,	98 },
 	{ 4,	"Opening container",		copen,		97 },

--- a/src/utils/daos_autotest.c
+++ b/src/utils/daos_autotest.c
@@ -206,8 +206,8 @@ ccreate(void)
 
 	/** Create container with RF=2 */
 	daos_prop_t	*prop2;
-	prop2 = daos_prop_alloc(1);
 
+	prop2 = daos_prop_alloc(1);
 	prop2->dpp_entries[0].dpe_type = DAOS_PROP_CO_REDUN_FAC;
 	prop2->dpp_entries[0].dpe_val = DAOS_PROP_CO_REDUN_RF2;
 

--- a/src/utils/daos_autotest.c
+++ b/src/utils/daos_autotest.c
@@ -122,11 +122,12 @@ step_init(void)
 static int
 attachinfo(void)
 {
-	char *command = "sudo daos_agent dump-attachinfo";
- 	FILE *fp = popen(command, "r");
- 	char *line = NULL;
- 	size_t len = 0;
-	size_t read;
+	char 	*command = "sudo daos_agent dump-attachinfo";
+	FILE 	*fp = popen(command, "r");
+	char 	*line = NULL;
+	size_t 	len = 0;
+	size_t 	read;
+	int	rc;
 	if (fp == NULL)
 		return -DER_INVAL;
 
@@ -134,7 +135,6 @@ attachinfo(void)
 		continue;
 	}
 
-	int rc;
 	rc = pclose(fp);
 	if (rc) {
 		step_fail("Are daos_server and daos_agent running?");
@@ -148,7 +148,7 @@ static int
 init(void)
 {
 	int rc;
-	
+
 	rc = daos_init();
 	if (rc) {
 		step_fail(d_errdesc(rc));
@@ -190,13 +190,13 @@ ccreate(void)
 
 	/** Create container with RF=1 */
 	daos_prop_t	*prop;
-        prop = daos_prop_alloc(1);
-        prop->dpp_entries[0].dpe_type = DAOS_PROP_CO_REDUN_FAC;
-        prop->dpp_entries[0].dpe_val = DAOS_PROP_CO_REDUN_RF1;
-	
+	prop = daos_prop_alloc(1);
+	prop->dpp_entries[0].dpe_type = DAOS_PROP_CO_REDUN_FAC;
+ 	prop->dpp_entries[0].dpe_val = DAOS_PROP_CO_REDUN_RF1;
+
 	uuid_generate(cuuid2);	
 
-	rc = daos_cont_create(poh,cuuid2, prop, NULL);
+	rc = daos_cont_create(poh, cuuid2, prop, NULL);
 	if (rc) {
 		step_fail(d_errdesc(rc));
 		return -1;
@@ -204,9 +204,9 @@ ccreate(void)
 
 	/** Create container with RF=2 */
 	daos_prop_t	*prop2;
-        prop2 = daos_prop_alloc(1);
-        prop2->dpp_entries[0].dpe_type = DAOS_PROP_CO_REDUN_FAC;
-        prop2->dpp_entries[0].dpe_val = DAOS_PROP_CO_REDUN_RF2;
+	prop2 = daos_prop_alloc(1);
+	prop2->dpp_entries[0].dpe_type = DAOS_PROP_CO_REDUN_FAC;
+	prop2->dpp_entries[0].dpe_val = DAOS_PROP_CO_REDUN_RF2;
 
 	uuid_generate(cuuid3);
 	
@@ -779,14 +779,13 @@ cdestroy(void)
 		step_fail(d_errdesc(rc));
 		return -1;
 	}
-	
 
 	rc = daos_cont_destroy(poh, cuuid2, force, NULL);
 	if (rc) {
 		step_fail(d_errdesc(rc));
 		return -1;
 	}
-	
+
 	rc = daos_cont_destroy(poh, cuuid3, force, NULL);
 	if (rc) {
 		step_fail(d_errdesc(rc));

--- a/src/utils/daos_autotest.c
+++ b/src/utils/daos_autotest.c
@@ -184,6 +184,31 @@ out:
 }
 
 static int
+attachinfo(void)
+{
+	char *command = "sudo daos_agent dump-attachinfo";
+ 	FILE *fp = popen(command, "r");
+ 	char *line = NULL;
+ 	size_t len = 0;
+	size_t read;
+	if (fp == NULL)
+		return -DER_INVAL;
+
+	while ((read = getline(&line, &len, fp)) != -1) {
+		continue;
+	}
+
+	int rc;
+	rc = pclose(fp);
+	if (rc) {
+		step_fail("Are daos_server and daos_agent running?");
+		return -1;
+	}
+	step_success("");
+	return rc;
+}
+
+static int
 init(void)
 {
 	int rc;
@@ -874,12 +899,13 @@ struct step {
 static struct step steps[] = {
 	/** Pre-test checks */
 	{ 0,	"Checking daos_agent pid",	agent,		100 },
+	{ 1,	"Dumping AttachInfo",		attachinfo,	100 },
 
 	/** Set up */
-	{ 1,	"Initializing DAOS",		init ,		100 },
-	{ 2,	"Connecting to pool",		pconnect,	99 },
-	{ 3,	"Creating container",		ccreate,	98 },
-	{ 4,	"Opening container",		copen,		97 },
+	{ 2,	"Initializing DAOS",		init ,		100 },
+	{ 3,	"Connecting to pool",		pconnect,	99 },
+	{ 4,	"Creating container",		ccreate,	98 },
+	{ 5,	"Opening container",		copen,		97 },
 
 	/** Layout generation tests */
 	{ 10,	"Generating 1M S1 layouts",	oS1,		96 },

--- a/src/utils/daos_autotest.c
+++ b/src/utils/daos_autotest.c
@@ -32,6 +32,11 @@ clock_t	end;
 
 /** generated container UUID */
 uuid_t		cuuid;
+
+/** generate container UUID for aux cont */
+uuid_t		cuuid2;
+uuid_t		cuuid3;
+
 /** initial object ID */
 uint64_t	oid_hi = 1;
 daos_obj_id_t	oid = { .hi = 1, .lo = 1 }; /** object ID */
@@ -151,6 +156,34 @@ ccreate(void)
 	/** Create container */
 	uuid_generate(cuuid);
 	rc = daos_cont_create(poh, cuuid, NULL, NULL);
+	if (rc) {
+		step_fail(d_errdesc(rc));
+		return -1;
+	}
+
+	/** Create container with RF=1 */
+	daos_prop_t	*prop;
+        prop = daos_prop_alloc(1);
+        prop->dpp_entries[0].dpe_type = DAOS_PROP_CO_REDUN_FAC;
+        prop->dpp_entries[0].dpe_val = DAOS_PROP_CO_REDUN_RF1;
+	
+	uuid_generate(cuuid2);	
+
+	rc = daos_cont_create(poh,cuuid2, prop, NULL);
+	if (rc) {
+		step_fail(d_errdesc(rc));
+		return -1;
+	}
+
+	/** Create container with RF=2 */
+	daos_prop_t	*prop2;
+        prop2 = daos_prop_alloc(1);
+        prop2->dpp_entries[0].dpe_type = DAOS_PROP_CO_REDUN_FAC;
+        prop2->dpp_entries[0].dpe_val = DAOS_PROP_CO_REDUN_RF2;
+
+	uuid_generate(cuuid3);
+	
+	rc = daos_cont_create(poh,cuuid3, prop2, NULL);
 	if (rc) {
 		step_fail(d_errdesc(rc));
 		return -1;
@@ -714,12 +747,25 @@ static int
 cdestroy(void)
 {
 	int rc;
-
 	rc = daos_cont_destroy(poh, cuuid, force, NULL);
 	if (rc) {
 		step_fail(d_errdesc(rc));
 		return -1;
 	}
+	
+
+	rc = daos_cont_destroy(poh, cuuid2, force, NULL);
+	if (rc) {
+		step_fail(d_errdesc(rc));
+		return -1;
+	}
+	
+	rc = daos_cont_destroy(poh, cuuid3, force, NULL);
+	if (rc) {
+		step_fail(d_errdesc(rc));
+		return -1;
+	}
+
 	step_success("");
 	return 0;
 }

--- a/src/utils/daos_autotest.c
+++ b/src/utils/daos_autotest.c
@@ -122,13 +122,13 @@ step_init(void)
 static int
 attachinfo(void)
 {
-	char 	*command = "sudo daos_agent dump-attachinfo";
-	FILE 	*fp = popen(command, "r");
-	char 	*line = NULL;
-	size_t 	len = 0;
-	size_t 	read;
+	char	*command = "sudo daos_agent dump-attachinfo";
+	FILE	*fp = popen(command, "r");
+	char	*line = NULL;
+	size_t	len = 0;
+	size_t	read;
 	int	rc;
-	
+
 	if (fp == NULL)
 		return -DER_INVAL;
 
@@ -191,9 +191,10 @@ ccreate(void)
 
 	/** Create container with RF=1 */
 	daos_prop_t	*prop;
+
 	prop = daos_prop_alloc(1);
 	prop->dpp_entries[0].dpe_type = DAOS_PROP_CO_REDUN_FAC;
- 	prop->dpp_entries[0].dpe_val = DAOS_PROP_CO_REDUN_RF1;
+	prop->dpp_entries[0].dpe_val = DAOS_PROP_CO_REDUN_RF1;
 
 	uuid_generate(cuuid2);
 
@@ -206,6 +207,7 @@ ccreate(void)
 	/** Create container with RF=2 */
 	daos_prop_t	*prop2;
 	prop2 = daos_prop_alloc(1);
+
 	prop2->dpp_entries[0].dpe_type = DAOS_PROP_CO_REDUN_FAC;
 	prop2->dpp_entries[0].dpe_val = DAOS_PROP_CO_REDUN_RF2;
 


### PR DESCRIPTION
Extended autotest to include additional functionality:

-better diagnoses, more particularly when the agent isn't running or one cannot connect to the server (e.g. network issue)
-use the new API to auto-select the object class
-create extra containers with RF=1 and RF=2
