### PR TITLE
DAOS-7487 test: Extend autotest with more smoke capabilities

### DIFF
--- a/src/include/daos_errno.h
+++ b/src/include/daos_errno.h
@@ -259,7 +259,10 @@ extern "C" {
 	       Fetch again)						\
 	/** Hit uncertain DTX, may need to try with other replica. */	\
 	ACTION(DER_TX_UNCERTAIN,	(DER_ERR_DAOS_BASE + 33),	\
-	       TX status is uncertaion)
+	       TX status is uncertaion)					\
+	/** Communicatin issue with agent. */				\
+	ACTION(DER_AGENT_COMM,		(DER_ERR_DAOS_BASE + 34),	\
+               Agent communication error)
 
 /** Defines the gurt error codes */
 #define D_FOREACH_ERR_RANGE(ACTION)	\

--- a/src/include/daos_errno.h
+++ b/src/include/daos_errno.h
@@ -262,7 +262,7 @@ extern "C" {
 	       TX status is uncertaion)					\
 	/** Communicatin issue with agent. */				\
 	ACTION(DER_AGENT_COMM,		(DER_ERR_DAOS_BASE + 34),	\
-               Agent communication error)
+		Agent communication error)
 
 /** Defines the gurt error codes */
 #define D_FOREACH_ERR_RANGE(ACTION)	\

--- a/src/mgmt/cli_mgmt.c
+++ b/src/mgmt/cli_mgmt.c
@@ -231,8 +231,10 @@ get_attach_info(const char *name, bool all_ranks, struct dc_mgmt_sys_info *info,
 	rc = drpc_connect(dc_agent_sockpath, &ctx);
 	if (rc != -DER_SUCCESS) {
 		D_ERROR("failed to connect to %s " DF_RC "\n",
-			dc_agent_sockpath, DP_RC(-DER_AGENT_COMM));
-		D_GOTO(out, rc = -DER_AGENT_COMM);
+			dc_agent_sockpath, DP_RC(rc));
+		if (rc == -DER_NONEXIST)
+			rc = -DER_AGENT_COMM;
+		D_GOTO(out, rc);
 	}
 
 	/* Prepare the GetAttachInfo request. */

--- a/src/mgmt/cli_mgmt.c
+++ b/src/mgmt/cli_mgmt.c
@@ -231,8 +231,8 @@ get_attach_info(const char *name, bool all_ranks, struct dc_mgmt_sys_info *info,
 	rc = drpc_connect(dc_agent_sockpath, &ctx);
 	if (rc != -DER_SUCCESS) {
 		D_ERROR("failed to connect to %s " DF_RC "\n",
-			dc_agent_sockpath, DP_RC(rc));
-		D_GOTO(out, 0);
+			dc_agent_sockpath, DP_RC(-DER_AGENT_COMM));
+		D_GOTO(out, rc = -DER_AGENT_COMM);
 	}
 
 	/* Prepare the GetAttachInfo request. */
@@ -501,8 +501,8 @@ dc_mgmt_notify_exit(void)
 	rc = drpc_connect(dc_agent_sockpath, &ctx);
 	if (rc != -DER_SUCCESS) {
 		D_ERROR("failed to connect to %s " DF_RC "\n",
-			dc_agent_sockpath, DP_RC(rc));
-		D_GOTO(out, 0);
+			dc_agent_sockpath, DP_RC(-DER_AGENT_COMM));
+		D_GOTO(out, rc = -DER_AGENT_COMM);
 	}
 
 	rc = drpc_call_create(ctx, DRPC_MODULE_MGMT,

--- a/src/mgmt/cli_mgmt.c
+++ b/src/mgmt/cli_mgmt.c
@@ -503,8 +503,10 @@ dc_mgmt_notify_exit(void)
 	rc = drpc_connect(dc_agent_sockpath, &ctx);
 	if (rc != -DER_SUCCESS) {
 		D_ERROR("failed to connect to %s " DF_RC "\n",
-			dc_agent_sockpath, DP_RC(-DER_AGENT_COMM));
-		D_GOTO(out, rc = -DER_AGENT_COMM);
+			dc_agent_sockpath, DP_RC(rc));
+		if (rc == -DER_NONEXIST)
+			rc = -DER_AGENT_COMM;
+		D_GOTO(out, rc);
 	}
 
 	rc = drpc_call_create(ctx, DRPC_MODULE_MGMT,

--- a/src/utils/daos_autotest.c
+++ b/src/utils/daos_autotest.c
@@ -961,15 +961,18 @@ static struct step steps[] = {
 	{ 20,	"Inserting 1M 128B values",		kv_insert128,	96 },
 	{ 21,	"Reading 128B values back",		kv_read128,	96 },
 	/** { 22,	"Listing keys",				kv_list,	96 },
-	{ 23,	"Punching object",			kv_punch,	96 }, */
+	* { 23,	"Punching object",			kv_punch,	96 },
+	*/
 	{ 24,	"Inserting 1M 4KB values",		kv_insert4k,	96 },
 	{ 25,	"Reading 4KB values back",		kv_read4k,	96 },
 	/** { 26,	"Listing keys",				kv_list,	96 },
-	{ 27,	"Punching object",			kv_punch,	96 }, */
+	* { 27,	"Punching object",			kv_punch,	96 },
+	*/
 	{ 28,	"Inserting 100K 1MB values",		kv_insert1m,	96 },
 	{ 29,	"Reading 1MB values back",		kv_read1m,	96 },
 	/** { 30,	"Listing keys",				kv_list,	96 },
-	{ 31,	"Punching object",			kv_punch,	96 }, */
+	* { 31,	"Punching object",			kv_punch,	96 },
+	*/
 
 	/** Test aux containers */
 	{ 40,	"Inserting into aux cont",		kv_insertaux,	96 },

--- a/src/utils/daos_autotest.c
+++ b/src/utils/daos_autotest.c
@@ -19,7 +19,6 @@
 #include <daos/common.h>
 
 #include "daos_hdlr.h"
-#include <fcntl.h>
 
 /** Input arguments passed to daos utility */
 struct cmd_args_s *autotest_ap;
@@ -961,16 +960,16 @@ static struct step steps[] = {
 	/** KV tests */
 	{ 20,	"Inserting 1M 128B values",		kv_insert128,	96 },
 	{ 21,	"Reading 128B values back",		kv_read128,	96 },
-	//{ 22,	"Listing keys",				kv_list,	96 },
-	//{ 23,	"Punching object",			kv_punch,	96 },
+	/** { 22,	"Listing keys",				kv_list,	96 },
+	{ 23,	"Punching object",			kv_punch,	96 }, */
 	{ 24,	"Inserting 1M 4KB values",		kv_insert4k,	96 },
 	{ 25,	"Reading 4KB values back",		kv_read4k,	96 },
-	//{ 26,	"Listing keys",				kv_list,	96 },
-	//{ 27,	"Punching object",			kv_punch,	96 },
+	/** { 26,	"Listing keys",				kv_list,	96 },
+	{ 27,	"Punching object",			kv_punch,	96 }, */
 	{ 28,	"Inserting 100K 1MB values",		kv_insert1m,	96 },
 	{ 29,	"Reading 1MB values back",		kv_read1m,	96 },
-	//{ 30,	"Listing keys",				kv_list,	96 },
-	//{ 31,	"Punching object",			kv_punch,	96 },
+	/** { 30,	"Listing keys",				kv_list,	96 },
+	{ 31,	"Punching object",			kv_punch,	96 }, */
 
 	/** Test aux containers */
 	{ 40,	"Inserting into aux cont",		kv_insertaux,	96 },

--- a/src/utils/daos_autotest.c
+++ b/src/utils/daos_autotest.c
@@ -32,20 +32,24 @@ clock_t	start;
 clock_t	end;
 
 /** generated container UUID */
-uuid_t		cuuid;
+const char	*cuuid;
 
-/** generate container UUID for aux cont */
-uuid_t		cuuid2;
-uuid_t		cuuid3;
+/** generated label for aux containers */
+const char	*cuuid2;
+const char	*cuuid3;
 
 /** initial object ID */
 uint64_t	oid_hi = 1;
 daos_obj_id_t	oid = { .hi = 1, .lo = 1 }; /** object ID */
+daos_obj_id_t	oid2 = { .hi = 1, .lo = 1 }; /** object ID */
+daos_obj_id_t	oid3 = { .hi = 1, .lo = 1 }; /** object ID */
 
 /** pool handle */
 daos_handle_t	poh = DAOS_HDL_INVAL;
 /** container handle */
 daos_handle_t	coh = DAOS_HDL_INVAL;
+daos_handle_t	coh2 = DAOS_HDL_INVAL;
+daos_handle_t	coh3 = DAOS_HDL_INVAL;
 
 /** force cleanup */
 int force;
@@ -55,6 +59,20 @@ new_oid(void)
 {
 	oid.hi = ++oid_hi;
 	oid.lo = 1;
+}
+
+static inline void
+new_oid2(void)
+{
+	oid2.hi = ++oid_hi;
+	oid2.lo = 1;
+}
+
+static inline void
+new_oid3(void)
+{
+	oid3.hi = ++oid_hi;
+	oid3.lo = 1;
 }
 
 static inline float
@@ -119,32 +137,6 @@ step_init(void)
 }
 
 static int
-attachinfo(void)
-{
-	char	*command = "sudo daos_agent dump-attachinfo";
-	FILE	*fp = popen(command, "r");
-	char	*line = NULL;
-	size_t	len = 0;
-	size_t	read;
-	int	rc;
-
-	if (fp == NULL)
-		return -DER_INVAL;
-
-	while ((read = getline(&line, &len, fp)) != -1) {
-		continue;
-	}
-
-	rc = pclose(fp);
-	if (rc) {
-		step_fail("Are daos_server and daos_agent running?");
-		return -1;
-	}
-	step_success("");
-	return rc;
-}
-
-static int
 init(void)
 {
 	int rc;
@@ -181,12 +173,10 @@ ccreate(void)
 	int rc;
 
 	/** Create container */
-	uuid_generate(cuuid);
-	rc = daos_cont_create(poh, cuuid, NULL, NULL);
-	if (rc) {
-		step_fail(d_errdesc(rc));
-		return -1;
-	}
+	cuuid = "autotest_cont_def";
+	rc = daos_cont_create_with_label(poh, cuuid, NULL, NULL, NULL);
+	if (rc)
+		D_GOTO(fail, rc);
 
 	/** Create container with RF=1 */
 	daos_prop_t	*prop;
@@ -195,13 +185,10 @@ ccreate(void)
 	prop->dpp_entries[0].dpe_type = DAOS_PROP_CO_REDUN_FAC;
 	prop->dpp_entries[0].dpe_val = DAOS_PROP_CO_REDUN_RF1;
 
-	uuid_generate(cuuid2);
-
-	rc = daos_cont_create(poh, cuuid2, prop, NULL);
-	if (rc) {
-		step_fail(d_errdesc(rc));
-		return -1;
-	}
+	cuuid2 = "autotest_cont_rf1";
+	rc = daos_cont_create_with_label(poh, cuuid2, prop, NULL, NULL);
+	if (rc)
+		D_GOTO(fail, rc);
 
 	/** Create container with RF=2 */
 	daos_prop_t	*prop2;
@@ -210,16 +197,17 @@ ccreate(void)
 	prop2->dpp_entries[0].dpe_type = DAOS_PROP_CO_REDUN_FAC;
 	prop2->dpp_entries[0].dpe_val = DAOS_PROP_CO_REDUN_RF2;
 
-	uuid_generate(cuuid3);
+	cuuid3 = "autotest_cont_rf2";
+	rc = daos_cont_create_with_label(poh, cuuid3, prop2, NULL, NULL);
+	if (rc)
+		D_GOTO(fail, rc);
 
-	rc = daos_cont_create(poh, cuuid3, prop2, NULL);
-	if (rc) {
-		step_fail(d_errdesc(rc));
-		return -1;
-	}
-
-	step_success("uuid = "DF_UUIDF, DP_UUID(cuuid));
+	step_success("");
 	return 0;
+
+fail:
+	step_fail(d_errdesc(rc));
+	return -1;
 }
 
 static int
@@ -229,13 +217,23 @@ copen(void)
 
 	/** Open container */
 	rc = daos_cont_open(poh, cuuid, DAOS_COO_RW, &coh, NULL, NULL);
-	if (rc) {
-		step_fail(d_errdesc(rc));
-		return -1;
-	}
+	if (rc)
+		D_GOTO(fail, rc);
+
+	rc = daos_cont_open(poh, cuuid2, DAOS_COO_RW, &coh2, NULL, NULL);
+	if (rc)
+		D_GOTO(fail, rc);
+
+	rc = daos_cont_open(poh, cuuid3, DAOS_COO_RW, &coh3, NULL, NULL);
+	if (rc)
+		D_GOTO(fail, rc);
 
 	step_success("");
 	return 0;
+
+fail:
+	step_fail(d_errdesc(rc));
+	return -1;
 }
 
 static int
@@ -583,7 +581,7 @@ kv_read128(void)
 	rc = daos_kv_close(oh, NULL);
 
 	if (get_rc) {
-		step_fail("failed to insert: %s", d_errdesc(get_rc));
+		step_fail("failed to read: %s", d_errdesc(get_rc));
 		return -1;
 	}
 
@@ -682,7 +680,7 @@ kv_read4k(void)
 	rc = daos_kv_close(oh, NULL);
 
 	if (get_rc) {
-		step_fail("failed to insert: %s", d_errdesc(get_rc));
+		step_fail("failed to read: %s", d_errdesc(get_rc));
 		return -1;
 	}
 
@@ -759,43 +757,159 @@ kv_read1m(void)
 }
 
 static int
+kv_insertaux(void)
+{
+	daos_handle_t	oh = DAOS_HDL_INVAL; /** object handle */
+	int		put_rc;
+	int		rc;
+
+	new_oid2();
+	daos_obj_generate_oid(coh2, &oid2, DAOS_OF_KV_FLAT, 0, 0, 0);
+
+	rc = daos_kv_open(coh2, oid2, DAOS_OO_RW, &oh, NULL);
+	if (rc)
+		D_GOTO(fail_open, rc);
+
+	put_rc = kv_put(oh, 128, 1000000);
+	rc = daos_kv_close(oh, NULL);
+
+	if (put_rc)
+		D_GOTO(fail_insert, put_rc);
+
+	if (rc)
+		D_GOTO(fail_close, rc);
+
+	oh = DAOS_HDL_INVAL;
+	new_oid3();
+	daos_obj_generate_oid(coh3, &oid3, DAOS_OF_KV_FLAT, 0, 0, 0);
+
+	rc = daos_kv_open(coh3, oid3, DAOS_OO_RW, &oh, NULL);
+	if (rc)
+		D_GOTO(fail_open, rc);
+
+	put_rc = kv_put(oh, 128, 1000000);
+	rc = daos_kv_close(oh, NULL);
+
+	if (put_rc)
+		D_GOTO(fail_insert, put_rc);
+
+	if (rc)
+		D_GOTO(fail_close, rc);
+
+	step_success("");
+	return 0;
+
+fail_open:
+	step_fail("failed to open object: %s", d_errdesc(rc));
+	return -1;
+
+fail_insert:
+	step_fail("failed to insert: %s", d_errdesc(put_rc));
+	return -1;
+
+fail_close:
+	step_fail("failed to close object: %s", d_errdesc(rc));
+	return -1;
+}
+
+static int
+kv_readaux(void)
+{
+	daos_handle_t	oh = DAOS_HDL_INVAL; /** object handle */
+	int		get_rc;
+	int		rc;
+
+	rc = daos_kv_open(coh2, oid2, DAOS_OO_RW, &oh, NULL);
+	if (rc)
+		D_GOTO(fail_open, rc);
+
+	get_rc = kv_get(oh, 128, 1000000);
+	rc = daos_kv_close(oh, NULL);
+
+	if (get_rc)
+		D_GOTO(fail_read, get_rc);
+
+	if (rc)
+		D_GOTO(fail_close, rc);
+
+	oh = DAOS_HDL_INVAL;
+	rc = daos_kv_open(coh3, oid3, DAOS_OO_RW, &oh, NULL);
+	if (rc)
+		D_GOTO(fail_open, rc);
+
+	get_rc = kv_get(oh, 128, 1000000);
+	rc = daos_kv_close(oh, NULL);
+
+	if (get_rc)
+		D_GOTO(fail_read, get_rc);
+
+	if (rc)
+		D_GOTO(fail_close, rc);
+
+	step_success("");
+	return 0;
+
+fail_open:
+	step_fail("failed to open object: %s", d_errdesc(rc));
+	return -1;
+
+fail_read:
+	step_fail("failed to read: %s", d_errdesc(get_rc));
+	return -1;
+
+fail_close:
+	step_fail("failed to close object: %s", d_errdesc(rc));
+	return -1;
+}
+
+static int
 cclose(void)
 {
 	int rc;
 
 	rc = daos_cont_close(coh, NULL);
-	if (rc) {
-		step_fail(d_errdesc(rc));
-		return -1;
-	}
+	if (rc)
+		D_GOTO(fail, rc);
+
+	rc = daos_cont_close(coh2, NULL);
+	if (rc)
+		D_GOTO(fail, rc);
+
+	rc = daos_cont_close(coh3, NULL);
+	if (rc)
+		D_GOTO(fail, rc);
+
 	step_success("");
 	return 0;
+
+fail:
+	step_fail(d_errdesc(rc));
+	return -1;
 }
 
 static int
 cdestroy(void)
 {
 	int rc;
+
 	rc = daos_cont_destroy(poh, cuuid, force, NULL);
-	if (rc) {
-		step_fail(d_errdesc(rc));
-		return -1;
-	}
+	if (rc)
+		D_GOTO(fail, rc);
 
 	rc = daos_cont_destroy(poh, cuuid2, force, NULL);
-	if (rc) {
-		step_fail(d_errdesc(rc));
-		return -1;
-	}
+	if (rc)
+		D_GOTO(fail, rc);
 
 	rc = daos_cont_destroy(poh, cuuid3, force, NULL);
-	if (rc) {
-		step_fail(d_errdesc(rc));
-		return -1;
-	}
+	if (rc)
+		D_GOTO(fail, rc);
 
 	step_success("");
 	return 0;
+
+fail:
+	step_fail(d_errdesc(rc));
+	return -1;
 }
 
 static int
@@ -834,41 +948,42 @@ struct step {
 };
 
 static struct step steps[] = {
-	/** Pre-test checks */
-	{ 0,	"Dumping AttachInfo",		attachinfo,	100 },
-
 	/** Set up */
-	{ 1,	"Initializing DAOS",		init,		100 },
-	{ 2,	"Connecting to pool",		pconnect,	99 },
-	{ 3,	"Creating container",		ccreate,	98 },
-	{ 4,	"Opening container",		copen,		97 },
+	{ 0,	"Initializing DAOS",			init,		100 },
+	{ 1,	"Connecting to pool",			pconnect,	99 },
+	{ 2,	"Creating containers",			ccreate,	98 },
+	{ 3,	"Opening container",			copen,		97 },
 
 	/** Layout generation tests */
-	{ 10,	"Generating 1M S1 layouts",	oS1,		96 },
-	{ 11,	"Generating 10K SX layouts",	oSX,		96 },
+	{ 10,	"Generating 1M S1 layouts",		oS1,		96 },
+	{ 11,	"Generating 10K SX layouts",		oSX,		96 },
 
 	/** KV tests */
-	{ 20,	"Inserting 1M 128B values",	kv_insert128,	96 },
-	{ 21,	"Reading 128B values back",	kv_read128,	96 },
-	//{ 22,	"Listing keys",			kv_list,	96 },
-	//{ 23,	"Punching object",		kv_punch,	96 },
-	{ 24,	"Inserting 1M 4KB values",	kv_insert4k,	96 },
-	{ 25,	"Reading 4KB values back",	kv_read4k,	96 },
-	//{ 26,	"Listing keys",			kv_list,	96 },
-	//{ 27,	"Punching object",		kv_punch,	96 },
-	{ 28,	"Inserting 100K 1MB values",	kv_insert1m,	96 },
-	{ 29,	"Reading 1MB values back",	kv_read1m,	96 },
-	//{ 30,	"Listing keys",			kv_list,	96 },
-	//{ 31,	"Punching object",		kv_punch,	96 },
+	{ 20,	"Inserting 1M 128B values",		kv_insert128,	96 },
+	{ 21,	"Reading 128B values back",		kv_read128,	96 },
+	//{ 22,	"Listing keys",				kv_list,	96 },
+	//{ 23,	"Punching object",			kv_punch,	96 },
+	{ 24,	"Inserting 1M 4KB values",		kv_insert4k,	96 },
+	{ 25,	"Reading 4KB values back",		kv_read4k,	96 },
+	//{ 26,	"Listing keys",				kv_list,	96 },
+	//{ 27,	"Punching object",			kv_punch,	96 },
+	{ 28,	"Inserting 100K 1MB values",		kv_insert1m,	96 },
+	{ 29,	"Reading 1MB values back",		kv_read1m,	96 },
+	//{ 30,	"Listing keys",				kv_list,	96 },
+	//{ 31,	"Punching object",			kv_punch,	96 },
+
+	/** Test aux containers */
+	{ 40,	"Inserting into aux cont",		kv_insertaux,	96 },
+	{ 41,	"Reading values back",			kv_readaux,	96 },
 
 	/** Array tests */
 
 	/** Tear down */
-	{ 96,	"Closing container",		cclose,		97 },
-	{ 97,	"Destroying container",		cdestroy,	98 },
-	{ 98,	"Disconnecting from pool",	pdisconnect,	99 },
-	{ 99,	"Tearing down DAOS",		fini,		100 },
-	{ 100,	"",				NULL,		100 }
+	{ 96,	"Closing containers",			cclose,		97 },
+	{ 97,	"Destroying containers",		cdestroy,	98 },
+	{ 98,	"Disconnecting from pool",		pdisconnect,	99 },
+	{ 99,	"Tearing down DAOS",			fini,		100 },
+	{ 100,	"",					NULL,		100 }
 };
 
 int


### PR DESCRIPTION
Extended autotest to include additional functionality:

-better diagnoses, more particularly when the agent isn't running or one
cannot connect to the server (e.g. network issue)
-use the new API to auto-select the object class
-create extra containers with RF=1 and RF=2

Signed-off-by: Christopher Hoffman <christopherx.hoffman@intel.com>