### PR TITLE
DAOS-7166 dmg: Use hostlist in metrics list/query

### DIFF
--- a/src/control/cmd/dmg/main.go
+++ b/src/control/cmd/dmg/main.go
@@ -256,15 +256,16 @@ and access control settings, along with system wide operations.`
 		invoker.SetConfig(ctlCfg)
 		if ctlCmd, ok := cmd.(ctlInvoker); ok {
 			ctlCmd.setInvoker(invoker)
-			if opts.HostList != "" {
-				if hlCmd, ok := cmd.(hostListSetter); ok {
-					hl := strings.Split(opts.HostList, ",")
-					hlCmd.setHostList(hl)
-					ctlCfg.HostList = hl
-				} else {
-					return errors.Errorf("this command does not accept a hostlist parameter (set it in %s or %s)",
-						control.UserConfigPath(), control.SystemConfigPath())
-				}
+		}
+
+		if opts.HostList != "" {
+			if hlCmd, ok := cmd.(hostListSetter); ok {
+				hl := strings.Split(opts.HostList, ",")
+				hlCmd.setHostList(hl)
+				ctlCfg.HostList = hl
+			} else {
+				return errors.Errorf("this command does not accept a hostlist parameter (set it in %s or %s)",
+					control.UserConfigPath(), control.SystemConfigPath())
 			}
 		}
 

--- a/src/control/cmd/dmg/telemetry.go
+++ b/src/control/cmd/dmg/telemetry.go
@@ -347,15 +347,21 @@ type metricsCmd struct {
 type metricsListCmd struct {
 	logCmd
 	jsonOutputCmd
-	Host string `short:"s" long:"host" default:"localhost" description:"DAOS server host to query"`
+	cfgCmd
+	hostListCmd
 	Port uint32 `short:"p" long:"port" default:"9191" description:"Telemetry port on the host"`
 }
 
 // Execute runs the command to list metrics from the DAOS storage nodes.
 func (cmd *metricsListCmd) Execute(args []string) error {
+	host, err := getMetricsHost(cmd.config, cmd.hostlist)
+	if err != nil {
+		return err
+	}
+
 	req := new(control.MetricsListReq)
 	req.Port = cmd.Port
-	req.Host = cmd.Host
+	req.Host = host
 
 	if !cmd.shouldEmitJSON {
 		cmd.log.Info(getConnectingMsg(req.Host, req.Port))
@@ -379,6 +385,24 @@ func (cmd *metricsListCmd) Execute(args []string) error {
 	return nil
 }
 
+func getMetricsHost(cfg *control.Config, custom []string) (string, error) {
+	var hostlist []string
+	if len(custom) > 0 {
+		hostlist = custom
+	} else {
+		hostlist = cfg.HostList
+	}
+
+	if len(hostlist) == 1 {
+		// discard port if supplied - we use the metrics port
+		parts := strings.Split(hostlist[0], ":")
+
+		return parts[0], nil
+	}
+
+	return "", fmt.Errorf("must pass in exactly 1 host (got %d)", len(hostlist))
+}
+
 func getConnectingMsg(host string, port uint32) string {
 	return fmt.Sprintf("connecting to %s:%d...", host, port)
 }
@@ -387,16 +411,22 @@ func getConnectingMsg(host string, port uint32) string {
 type metricsQueryCmd struct {
 	logCmd
 	jsonOutputCmd
-	Host    string `short:"s" long:"host" default:"localhost" description:"DAOS server host to query"`
+	cfgCmd
+	hostListCmd
 	Port    uint32 `short:"p" long:"port" default:"9191" description:"Telemetry port on the host"`
 	Metrics string `short:"m" long:"metrics" default:"" description:"Comma-separated list of metric names"`
 }
 
 // Execute runs the command to query metrics from the DAOS storage nodes.
 func (cmd *metricsQueryCmd) Execute(args []string) error {
+	host, err := getMetricsHost(cmd.config, cmd.hostlist)
+	if err != nil {
+		return err
+	}
+
 	req := new(control.MetricsQueryReq)
 	req.Port = cmd.Port
-	req.Host = cmd.Host
+	req.Host = host
 	req.MetricNames = common.TokenizeCommaSeparatedString(cmd.Metrics)
 
 	if !cmd.shouldEmitJSON {

--- a/src/control/cmd/dmg/telemetry.go
+++ b/src/control/cmd/dmg/telemetry.go
@@ -347,14 +347,13 @@ type metricsCmd struct {
 type metricsListCmd struct {
 	logCmd
 	jsonOutputCmd
-	cfgCmd
 	hostListCmd
 	Port uint32 `short:"p" long:"port" default:"9191" description:"Telemetry port on the host"`
 }
 
 // Execute runs the command to list metrics from the DAOS storage nodes.
 func (cmd *metricsListCmd) Execute(args []string) error {
-	host, err := getMetricsHost(cmd.config, cmd.hostlist)
+	host, err := getMetricsHost(cmd.hostlist)
 	if err != nil {
 		return err
 	}
@@ -385,12 +384,9 @@ func (cmd *metricsListCmd) Execute(args []string) error {
 	return nil
 }
 
-func getMetricsHost(cfg *control.Config, custom []string) (string, error) {
-	var hostlist []string
-	if len(custom) > 0 {
-		hostlist = custom
-	} else {
-		hostlist = cfg.HostList
+func getMetricsHost(hostlist []string) (string, error) {
+	if len(hostlist) == 0 {
+		return "localhost", nil
 	}
 
 	if len(hostlist) == 1 {
@@ -411,7 +407,6 @@ func getConnectingMsg(host string, port uint32) string {
 type metricsQueryCmd struct {
 	logCmd
 	jsonOutputCmd
-	cfgCmd
 	hostListCmd
 	Port    uint32 `short:"p" long:"port" default:"9191" description:"Telemetry port on the host"`
 	Metrics string `short:"m" long:"metrics" default:"" description:"Comma-separated list of metric names"`
@@ -419,7 +414,7 @@ type metricsQueryCmd struct {
 
 // Execute runs the command to query metrics from the DAOS storage nodes.
 func (cmd *metricsQueryCmd) Execute(args []string) error {
-	host, err := getMetricsHost(cmd.config, cmd.hostlist)
+	host, err := getMetricsHost(cmd.hostlist)
 	if err != nil {
 		return err
 	}

--- a/src/control/cmd/dmg/telemetry_test.go
+++ b/src/control/cmd/dmg/telemetry_test.go
@@ -1,0 +1,79 @@
+//
+// (C) Copyright 2021 Intel Corporation.
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+
+package main
+
+import (
+	"testing"
+
+	"github.com/daos-stack/daos/src/control/common"
+	"github.com/daos-stack/daos/src/control/lib/control"
+	"github.com/pkg/errors"
+)
+
+func TestTelemetryCommands(t *testing.T) {
+	runCmdTests(t, []cmdTest{
+		{
+			"list with too many hosts",
+			"telemetry metrics list -l host1,host2",
+			"",
+			errors.New("exactly 1 host"),
+		},
+		{
+			"query with too many hosts",
+			"telemetry metrics query -l host1,host2",
+			"",
+			errors.New("exactly 1 host"),
+		},
+	})
+}
+
+func TestTelemetry_getMetricsHost(t *testing.T) {
+	for name, tc := range map[string]struct {
+		cfg       *control.Config
+		custom    []string
+		expResult string
+		expErr    error
+	}{
+		"custom list with one host": {
+			custom:    []string{"one"},
+			expResult: "one",
+		},
+		"custom list with too many hosts": {
+			custom: []string{"one", "two"},
+			expErr: errors.New("exactly 1 host"),
+		},
+		"config with one host": {
+			cfg: &control.Config{
+				HostList: []string{"host1"},
+			},
+			expResult: "host1",
+		},
+		"config with too many hosts": {
+			cfg: &control.Config{
+				HostList: []string{"host1", "host2"},
+			},
+			expErr: errors.New("exactly 1 host"),
+		},
+		"config with host and port": {
+			cfg: &control.Config{
+				HostList: []string{"host1:10001"},
+			},
+			expResult: "host1",
+		},
+		"no hosts": {
+			cfg:    &control.Config{},
+			expErr: errors.New("exactly 1 host"),
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			result, err := getMetricsHost(tc.cfg, tc.custom)
+
+			common.CmpErr(t, tc.expErr, err)
+			common.AssertEqual(t, tc.expResult, result, "")
+		})
+	}
+}

--- a/src/control/cmd/dmg/telemetry_test.go
+++ b/src/control/cmd/dmg/telemetry_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 
 	"github.com/daos-stack/daos/src/control/common"
-	"github.com/daos-stack/daos/src/control/lib/control"
 	"github.com/pkg/errors"
 )
 
@@ -33,44 +32,28 @@ func TestTelemetryCommands(t *testing.T) {
 
 func TestTelemetry_getMetricsHost(t *testing.T) {
 	for name, tc := range map[string]struct {
-		cfg       *control.Config
-		custom    []string
+		list      []string
 		expResult string
 		expErr    error
 	}{
-		"custom list with one host": {
-			custom:    []string{"one"},
+		"one host": {
+			list:      []string{"one"},
 			expResult: "one",
 		},
-		"custom list with too many hosts": {
-			custom: []string{"one", "two"},
+		"host with port": {
+			list:      []string{"one:1234"},
+			expResult: "one",
+		},
+		"too many hosts": {
+			list:   []string{"one", "two"},
 			expErr: errors.New("exactly 1 host"),
-		},
-		"config with one host": {
-			cfg: &control.Config{
-				HostList: []string{"host1"},
-			},
-			expResult: "host1",
-		},
-		"config with too many hosts": {
-			cfg: &control.Config{
-				HostList: []string{"host1", "host2"},
-			},
-			expErr: errors.New("exactly 1 host"),
-		},
-		"config with host and port": {
-			cfg: &control.Config{
-				HostList: []string{"host1:10001"},
-			},
-			expResult: "host1",
 		},
 		"no hosts": {
-			cfg:    &control.Config{},
-			expErr: errors.New("exactly 1 host"),
+			expResult: "localhost",
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			result, err := getMetricsHost(tc.cfg, tc.custom)
+			result, err := getMetricsHost(tc.list)
 
 			common.CmpErr(t, tc.expErr, err)
 			common.AssertEqual(t, tc.expResult, result, "")

--- a/src/tests/ftest/util/dmg_utils_base.py
+++ b/src/tests/ftest/util/dmg_utils_base.py
@@ -596,7 +596,7 @@ class DmgCommandBase(YamlCommand):
                     """Create a dmg telemetry metrics list object."""
                     super().__init__(
                         "/run/dmg/telemetry/metrics/list/*", "list")
-                    self.host = FormattedParameter("--host={}", None)
+                    self.host = FormattedParameter("--hostlist={}", None)
                     self.port = FormattedParameter("--port={}", None)
 
             class QuerySubCommand(CommandWithParameters):
@@ -606,6 +606,6 @@ class DmgCommandBase(YamlCommand):
                     """Create a dmg telemetry metrics query object."""
                     super().__init__(
                         "/run/dmg/telemetry/metrics/query/*", "query")
-                    self.host = FormattedParameter("--host={}", None)
+                    self.host = FormattedParameter("--hostlist={}", None)
                     self.port = FormattedParameter("--port={}", None)
                     self.metrics = FormattedParameter("--metrics={}", None)

--- a/src/tests/ftest/util/dmg_utils_base.py
+++ b/src/tests/ftest/util/dmg_utils_base.py
@@ -596,7 +596,7 @@ class DmgCommandBase(YamlCommand):
                     """Create a dmg telemetry metrics list object."""
                     super().__init__(
                         "/run/dmg/telemetry/metrics/list/*", "list")
-                    self.host = FormattedParameter("--hostlist={}", None)
+                    self.host = FormattedParameter("--host-list={}", None)
                     self.port = FormattedParameter("--port={}", None)
 
             class QuerySubCommand(CommandWithParameters):
@@ -606,6 +606,6 @@ class DmgCommandBase(YamlCommand):
                     """Create a dmg telemetry metrics query object."""
                     super().__init__(
                         "/run/dmg/telemetry/metrics/query/*", "query")
-                    self.host = FormattedParameter("--hostlist={}", None)
+                    self.host = FormattedParameter("--host-list={}", None)
                     self.port = FormattedParameter("--port={}", None)
                     self.metrics = FormattedParameter("--metrics={}", None)


### PR DESCRIPTION
The special --host parameter for metrics commands was confusing.
This patch removes the --host parameter and instead uses the same
--host-list used by other dmg commands. The user may still only
query one DAOS server at a time.

Signed-off-by: Kris Jacque <kristin.jacque@intel.com>