### PR TITLE
DAOS-8256 tests: Adding new argument to launch.py

### DIFF
--- a/src/tests/ftest/launch.py
+++ b/src/tests/ftest/launch.py
@@ -2070,6 +2070,14 @@ def main():
         action="store_true",
         help="modify the test yaml files but do not run the tests")
     parser.add_argument(
+        "-mo", "--mode",
+        choices=['normal', 'manual'],
+        default='normal',
+        help="provide the mode of test to be run under. Default is normal, "
+             "in which the final return code of launch.py is still zero if "
+             "any of the tests failed. 'manual' is where the return code is "
+             "non-zero if any of the tests as part of launch.py failed.")
+    parser.add_argument(
         "-n", "--nvme",
         action="store",
         help="comma-separated list of NVMe device PCI addresses to use as "
@@ -2198,6 +2206,8 @@ def main():
     else:
         if status & 1 == 1:
             print("Detected one or more avocado test failures!")
+            if args.mode == 'manual':
+                ret_code = 1
         if status & 8 == 8:
             print("Detected one or more interrupted avocado jobs!")
         if status & 2 == 2:


### PR DESCRIPTION
Adding new argument '--mode' to launch.py with default
set to 'normal' which will exhibit current behaviour.
But it can accept another value 'manual' where the return
code will be non-zero incase of a failure.

Signed-off-by: Saurabh Tandan <saurabh.tandan@intel.com>