### PR TITLE
DAOS-8254 control: handle lowercase masks in set-logmasks

### DIFF
--- a/src/control/server/engine/utils.go
+++ b/src/control/server/engine/utils.go
@@ -54,7 +54,7 @@ var logMasksValidLevels = []string{
 
 func isValidLevel(level string) bool {
 	for _, l := range logMasksValidLevels {
-		if level == l {
+		if strings.ToUpper(level) == l {
 			return true
 		}
 	}

--- a/src/control/server/engine/utils_test.go
+++ b/src/control/server/engine/utils_test.go
@@ -45,6 +45,10 @@ func TestValidateLogMasks(t *testing.T) {
 			masks:  "mgmt=DEBUG,ERR",
 			expErr: errors.New("want PREFIX=LEVEL"),
 		},
+		"single assignment; single level; lower case levels": {
+			masks:  "mgmt=debug,err",
+			expErr: errors.New("want PREFIX=LEVEL"),
+		},
 		"multiple assignment": {
 			masks: "mgmt=DEBUG,bio=ERR",
 		},

--- a/src/control/server/engine/utils_test.go
+++ b/src/control/server/engine/utils_test.go
@@ -34,29 +34,29 @@ func TestValidateLogMasks(t *testing.T) {
 		"single level; single assignment": {
 			masks: "ERR,mgmt=DEBUG",
 		},
+		"single level; single assignment; mixed caae": {
+			masks: "err,mgmt=debuG",
+		},
 		"single level; single assignment; with space": {
 			masks:  "ERR, mgmt=DEBUG",
 			expErr: errors.New("illegal characters"),
 		},
 		"single level; single assignment; bad level": {
-			masks: "ERR,mgmt=DEBUG",
+			masks:  "ERR,mgmt=DEG",
+			expErr: errors.New("unknown log level"),
 		},
 		"single assignment; single level": {
 			masks:  "mgmt=DEBUG,ERR",
 			expErr: errors.New("want PREFIX=LEVEL"),
 		},
-		"single assignment; single level; lower case levels": {
-			masks:  "mgmt=debug,err",
-			expErr: errors.New("want PREFIX=LEVEL"),
-		},
-		"multiple assignment": {
+		"multiple assignments": {
 			masks: "mgmt=DEBUG,bio=ERR",
 		},
-		"multiple assignment; bad format": {
+		"multiple assignments; bad format": {
 			masks:  "mgmt=DEBUG,bio=ERR=",
 			expErr: errors.New("want PREFIX=LEVEL"),
 		},
-		"multiple assignment; bad chars": {
+		"multiple assignments; bad chars": {
 			masks:  "mgmt=DEBUG,bio!=ERR",
 			expErr: errors.New("illegal characters"),
 		},


### PR DESCRIPTION
Masks such as debug or err should not cause validation failures.

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>