### PR TITLE
DAOS-7988 style: fix coverity warning

### DIFF
--- a/src/include/daos_prop.h
+++ b/src/include/daos_prop.h
@@ -71,6 +71,9 @@ enum daos_pool_props {
 	DAOS_PROP_PO_MAX,
 };
 
+#define DAOS_PROP_PO_EC_CELL_SZ_MIN	(1UL << 10)
+#define DAOS_PROP_PO_EC_CELL_SZ_MAX	(1UL << 30)
+
 /**
  * Number of pool property types
  */

--- a/src/placement/tests/place_obj_common.c
+++ b/src/placement/tests/place_obj_common.c
@@ -818,11 +818,11 @@ extend_test_pool_map(struct pool_map *map,
 			dss_tgt_nr);
 	assert_success(rc);
 
+	D_ASSERT(map_buf != NULL);
 	/* Extend the current pool map */
 	rc = pool_map_extend(map, map_version, map_buf);
 	if (rc != 0) {
-		if (map_buf != NULL)
-			pool_buf_free(map_buf);
+		pool_buf_free(map_buf);
 	}
 
 	assert_success(rc);

--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -414,6 +414,17 @@ pool_prop_write(struct rdb_tx *tx, const rdb_path_t *kvs, daos_prop_t *prop,
 					   &value);
 			break;
 		case DAOS_PROP_PO_EC_CELL_SZ:
+			if (entry->dpe_val < DAOS_PROP_PO_EC_CELL_SZ_MIN ||
+			    entry->dpe_val > DAOS_PROP_PO_EC_CELL_SZ_MAX) {
+				D_ERROR("DAOS_PROP_PO_EC_CELL_SZ property value"
+					" "DF_U64" should within rage of "
+					"["DF_U64", "DF_U64"].\n",
+					entry->dpe_val,
+					DAOS_PROP_PO_EC_CELL_SZ_MIN,
+					DAOS_PROP_PO_EC_CELL_SZ_MAX);
+				rc = -DER_INVAL;
+				break;
+			}
 			d_iov_set(&value, &entry->dpe_val,
 				     sizeof(entry->dpe_val));
 			rc = rdb_tx_update(tx, kvs, &ds_pool_prop_ec_cell_sz,

--- a/src/tests/jobtest.c
+++ b/src/tests/jobtest.c
@@ -49,11 +49,13 @@ void cleanup_handles(uuid_t *pool_uuids, int num_pools,
 				char		hdl_str[64];
 
 				pool = dc_hdl2pool(pool_handles[i][j]);
-				uuid_unparse_lower(pool->dp_pool, pool_str);
-				uuid_unparse_lower(pool->dp_pool, hdl_str);
-				printf("disconnect handle %s from pool %s "
-					"failed\n", hdl_str, pool_str);
-				dc_pool_put(pool);
+				if (pool) {
+					uuid_unparse_lower(pool->dp_pool, pool_str);
+					uuid_unparse_lower(pool->dp_pool, hdl_str);
+					printf("disconnect handle %s from pool %s "
+						"failed\n", hdl_str, pool_str);
+					dc_pool_put(pool);
+				}
 			}
 		}
 		free(pool_handles[i]);


### PR DESCRIPTION
Fix two coverity warning
And add cell size parameter checking (within 1K - 1G) for pool property.

Signed-off-by: Xuezhao Liu <xuezhao.liu@intel.com>