### PR TITLE
DAOS-8161 Test: Update the default VMD option for server yaml file.

### DIFF
--- a/src/tests/ftest/launch.py
+++ b/src/tests/ftest/launch.py
@@ -819,11 +819,11 @@ def replace_yaml_file(yaml_file, args, yaml_dir, vmd_flag=False):
         str: the test yaml file; None if the yaml file contains placeholders
             w/o replacements
         env_vars (dict): Returns environment variable dictionary. Presently,
-            returns DAOS_DISABLE_VMD: "False" or "True" dictionary.
+            returns DAOS_ENABLE_VMD: "False" or "True" dictionary.
 
     """
     replacements = {}
-    env_vars = {"DAOS_DISABLE_VMD": "True"}
+    env_vars = {"DAOS_ENABLE_VMD": "False"}
 
     if args.test_servers or args.nvme:
         # Find the test yaml keys and values that match the replaceable fields
@@ -877,9 +877,9 @@ def replace_yaml_file(yaml_file, args, yaml_dir, vmd_flag=False):
                         value_format.format(item)
                         for item in find_pci_address(yaml_find[key])]
                     # if VMD pci address in present under nvme_data,
-                    # set DAOS_DISABLE_VMD to False
+                    # set DAOS_ENABLE_VMD to True
                     if vmd_flag is True:
-                        env_vars["DAOS_DISABLE_VMD"] = "False"
+                        env_vars["DAOS_ENABLE_VMD"] = "True"
 
                 # Add the next user-specified value as a replacement for key
                 for value in values_to_replace:

--- a/src/tests/ftest/util/server_utils_params.py
+++ b/src/tests/ftest/util/server_utils_params.py
@@ -113,9 +113,9 @@ class DaosServerYamlParameters(YamlParameters):
         self.control_log_file = LogParameter(log_dir, None, "daos_control.log")
         self.helper_log_file = LogParameter(log_dir, None, "daos_admin.log")
         self.telemetry_port = BasicParameter(None, 9191)
-        default_disable_vmd_val = os.environ.get("DAOS_DISABLE_VMD", "True")
-        default_disable_vmd = ast.literal_eval(default_disable_vmd_val)
-        self.disable_vmd = BasicParameter(None, default_disable_vmd)
+        default_enable_vmd_val = os.environ.get("DAOS_ENABLE_VMD", "False")
+        default_enable_vmd = ast.literal_eval(default_enable_vmd_val)
+        self.enable_vmd = BasicParameter(None, default_enable_vmd)
 
         # Used to drop privileges before starting data plane
         # (if started as root to perform hardware provisioning)


### PR DESCRIPTION
VMD option in server.yaml file has been changed in PR#6339.
Changing the test code to adopt the same and use
enable_vmd = True instead of disabled_vmd = False.

Signed-off-by: Samir Raval <samir.raval@intel.com>