### PR TITLE
DAOS-8261 metrics: Let daos_metrics print stats gauges

### DIFF
--- a/src/utils/daos_metrics/daos_metrics.c
+++ b/src/utils/daos_metrics/daos_metrics.c
@@ -119,7 +119,7 @@ main(int argc, char **argv)
 			filter |= D_TM_TIMER_SNAPSHOT;
 			break;
 		case 'g':
-			filter |= D_TM_GAUGE;
+			filter |= D_TM_GAUGE | D_TM_STATS_GAUGE;
 			break;
 		case 'i':
 			num_iter = atoi(optarg);
@@ -146,7 +146,7 @@ main(int argc, char **argv)
 
 	if (filter == 0)
 		filter = D_TM_COUNTER | D_TM_DURATION | D_TM_TIMESTAMP |
-			 D_TM_TIMER_SNAPSHOT | D_TM_GAUGE;
+			 D_TM_TIMER_SNAPSHOT | D_TM_GAUGE | D_TM_STATS_GAUGE;
 
 	ctx = d_tm_open(srv_idx);
 	if (!ctx)


### PR DESCRIPTION
The tool wasn't updated to fetch stats gauges when the new type
was added.

Signed-off-by: Kris Jacque <kristin.jacque@intel.com>