### PR TITLE
DAOS-8226 vos: Fix some issues with removal aggregation

### DIFF
--- a/src/vos/evtree.c
+++ b/src/vos/evtree.c
@@ -3598,6 +3598,8 @@ evt_remove_all(daos_handle_t toh, const struct evt_extent *ext,
 		goto done;
 
 	evt_ent_array_for_each(ent, ent_array) {
+		if (ent->en_minor_epc == EVT_MINOR_EPC_MAX)
+			continue; /* Skip existing removal records */
 		entry.ei_rect.rc_ex = ent->en_ext;
 		entry.ei_bound = entry.ei_rect.rc_epc = ent->en_epoch;
 		entry.ei_rect.rc_minor_epc = ent->en_minor_epc;

--- a/src/vos/tests/vts_aggregate.c
+++ b/src/vos/tests/vts_aggregate.c
@@ -76,8 +76,8 @@ update_value(struct io_test_args *arg, daos_unit_oid_t oid, daos_epoch_t epoch,
 			arg->ta_flags |= TF_ZERO_COPY;
 	}
 
-	rc = io_test_obj_update(arg, epoch, flags, &dkey_iov, &iod, &sgl, NULL,
-				true);
+	rc = io_test_obj_update(arg, epoch, flags, &dkey_iov, &iod, &sgl, NULL, true);
+
 	assert_rc_equal(rc, 0);
 
 	d_sgl_fini(&sgl, false);
@@ -354,8 +354,8 @@ generate_akeys(struct io_test_args *arg, daos_unit_oid_t oid, int nr)
 }
 
 static void
-aggregate_basic(struct io_test_args *arg, struct agg_tst_dataset *ds,
-		int punch_nr, daos_epoch_t punch_epoch[])
+aggregate_basic_lb(struct io_test_args *arg, struct agg_tst_dataset *ds, int punch_nr,
+		   daos_epoch_t punch_epoch[], daos_epoch_t punch_bound[])
 {
 	daos_unit_oid_t		 oid;
 	char			 dkey[UPDATE_DKEY_SIZE] = { 0 };
@@ -390,6 +390,7 @@ aggregate_basic(struct io_test_args *arg, struct agg_tst_dataset *ds,
 	for (epoch = epr_u->epr_lo; epoch <= epr_u->epr_hi; epoch++) {
 		if (punch_idx < punch_nr && punch_epoch[punch_idx] == epoch) {
 			arg->ta_flags |= punch_or_delete;
+			arg->epr_lo = punch_bound == NULL ? 0 : punch_bound[punch_idx];
 			punch_idx++;
 		} else if (punch_nr < 0 && (rand() % 2) &&
 			   epoch != epr_u->epr_lo) {
@@ -431,6 +432,13 @@ aggregate_basic(struct io_test_args *arg, struct agg_tst_dataset *ds,
 		 */
 		D_FREE(ds->td_expected_view);
 	}
+}
+
+static void
+aggregate_basic(struct io_test_args *arg, struct agg_tst_dataset *ds,
+		int punch_nr, daos_epoch_t punch_epoch[])
+{
+	aggregate_basic_lb(arg, ds, punch_nr, punch_epoch, NULL);
 }
 
 static inline int
@@ -2394,6 +2402,92 @@ aggregate_29(void **state)
 	cleanup();
 }
 
+#define MAX_OPS 100
+#define MAX_REMOVE 25
+static void
+removal_stress_case(struct io_test_args *arg, int recx_nr, daos_recx_t *recx_arr, int remove_nr,
+		    daos_epoch_t *remove_epochs, daos_epoch_t *remove_bounds)
+{
+	struct agg_tst_dataset	 ds = { 0 };
+	int			 iod_size = 1024, end_idx;
+	int			 i;
+	int			 remove = 0;
+
+	D_ASSERT(recx_nr > remove_nr && (recx_nr % remove_nr) == 0);
+	D_ASSERT(recx_nr <= MAX_OPS);
+	D_ASSERT(remove_nr <= MAX_REMOVE);
+	end_idx = (VOS_MW_FLUSH_THRESH + iod_size - 1) / iod_size;
+	assert_true(end_idx > 5);
+
+	for (i = 0; i < recx_nr; i++) {
+		recx_arr[i].rx_idx = MAX(0, (i % 7) * end_idx - i);
+		recx_arr[i].rx_nr = end_idx + end_idx * (i % 2);
+		if ((i + 1) % (recx_nr / remove_nr) == 0) {
+			remove_epochs[remove] = i + 1;
+			remove_bounds[remove] = MAX(0, (i + 1) - 23);
+			VERBOSE_MSG("delete "DF_U64" records at "DF_X64"@"DF_X64"-"DF_X64"\n",
+				    recx_arr[i].rx_nr, recx_arr[i].rx_idx, remove_bounds[remove],
+			       remove_epochs[remove]);
+			remove++;
+		} else {
+			VERBOSE_MSG("update "DF_U64" records at "DF_X64"@%x\n", recx_arr[i].rx_nr,
+				    recx_arr[i].rx_idx, i + 1);
+		}
+		fflush(stdout);
+	}
+
+	ds.td_type = DAOS_IOD_ARRAY;
+	ds.td_iod_size = iod_size;
+	ds.td_recx_nr = recx_nr;
+	ds.td_recx = &recx_arr[0];
+	ds.td_expected_recs = -1;
+	ds.td_upd_epr.epr_lo = 1;
+	ds.td_upd_epr.epr_hi = recx_nr;
+	ds.td_agg_epr.epr_lo = 0;
+	ds.td_agg_epr.epr_hi = recx_nr + 1;
+	ds.td_discard = false;
+	ds.td_delete = true;
+
+	VERBOSE_MSG("Stress test recx_nr=%d, remove_nr=%d\n", recx_nr, remove_nr);
+	aggregate_basic_lb(arg, &ds, remove_nr, &remove_epochs[0], &remove_bounds[0]);
+}
+
+static void
+aggregate_30(void **state)
+{
+	struct io_test_args	*arg = *state;
+	daos_recx_t		*recx_arr;
+	daos_epoch_t		*remove_epochs;
+	daos_epoch_t		*remove_bounds;
+
+	D_ALLOC_ARRAY(recx_arr, MAX_OPS);
+	assert_non_null(recx_arr);
+	D_ALLOC_ARRAY(remove_epochs, MAX_REMOVE);
+	assert_non_null(remove_epochs);
+	D_ALLOC_ARRAY(remove_bounds, MAX_REMOVE);
+	assert_non_null(remove_bounds);
+
+	removal_stress_case(arg, 10, recx_arr, 2, remove_epochs, remove_bounds);
+	removal_stress_case(arg, 14, recx_arr, 7, remove_epochs, remove_bounds);
+	removal_stress_case(arg, 20, recx_arr, 4, remove_epochs, remove_bounds);
+	if (!DAOS_ON_VALGRIND) {
+		removal_stress_case(arg, 24, recx_arr, 6, remove_epochs, remove_bounds);
+		removal_stress_case(arg, 30, recx_arr, 3, remove_epochs, remove_bounds);
+		removal_stress_case(arg, 40, recx_arr, 4, remove_epochs, remove_bounds);
+		removal_stress_case(arg, 50, recx_arr, 5, remove_epochs, remove_bounds);
+		removal_stress_case(arg, 60, recx_arr, 15, remove_epochs, remove_bounds);
+		removal_stress_case(arg, 75, recx_arr, 25, remove_epochs, remove_bounds);
+		removal_stress_case(arg, 80, recx_arr, 8, remove_epochs, remove_bounds);
+		removal_stress_case(arg, 100, recx_arr, 10, remove_epochs, remove_bounds);
+	}
+
+	D_FREE(recx_arr);
+	D_FREE(remove_epochs);
+	D_FREE(remove_bounds);
+
+	cleanup();
+}
+
 static int
 agg_tst_teardown(void **state)
 {
@@ -2494,6 +2588,8 @@ static const struct CMUnitTest aggregate_tests[] = {
 	  aggregate_28, NULL, agg_tst_teardown },
 	{ "VOS429: Logical extent followed by disjoint removed extents",
 	  aggregate_29, NULL, agg_tst_teardown },
+	{ "VOS430: Removal stress test",
+	  aggregate_30, NULL, agg_tst_teardown },
 };
 
 int

--- a/src/vos/tests/vts_io.c
+++ b/src/vos/tests/vts_io.c
@@ -547,7 +547,7 @@ io_test_obj_update(struct io_test_args *arg, daos_epoch_t epoch, uint64_t flags,
 	struct dcs_iod_csums	*iod_csums = NULL;
 	struct daos_csummer	*csummer = NULL;
 	d_iov_t			*srv_iov;
-	daos_epoch_range_t	 epr = {0, epoch};
+	daos_epoch_range_t	 epr = {arg->epr_lo, epoch};
 	daos_handle_t		 ioh;
 	int			 rc = 0;
 

--- a/src/vos/tests/vts_io.h
+++ b/src/vos/tests/vts_io.h
@@ -66,6 +66,7 @@ struct io_test_args {
 	uuid_t			 addn_co_uuid;
 	daos_handle_t		 addn_co;
 	/* testing flags, see vts_test_flags */
+	daos_epoch_t		 epr_lo;
 	unsigned long		 ta_flags;
 	const char		*dkey;
 	const char		*akey;

--- a/src/vos/vos_aggregate.c
+++ b/src/vos/vos_aggregate.c
@@ -603,6 +603,25 @@ enqueue:
 	return rm_ent;
 }
 
+static inline bool
+phy_ent_is_removed(struct agg_merge_window *mw, const struct evt_extent *phy_ext,
+		   daos_epoch_t epoch)
+{
+	struct agg_rmv_ent	*rm_ent;
+
+	d_list_for_each_entry(rm_ent, &mw->mw_rmv_ents,
+			      re_link) {
+		struct evt_rect	*rm_rect = &rm_ent->re_rect;
+
+		if (rm_rect->rc_epc == epoch &&
+		    rm_rect->rc_ex.ex_lo <= phy_ext->ex_hi &&
+		    rm_rect->rc_ex.ex_hi >= phy_ext->ex_hi)
+			return true;
+	}
+
+	return false;
+}
+
 static int
 prepare_segments(struct agg_merge_window *mw)
 {
@@ -700,8 +719,6 @@ prepare_segments(struct agg_merge_window *mw)
 process_physical:
 	/* Generate truncated segments according to physical entries */
 	d_list_for_each_entry_safe(phy_ent, temp, &mw->mw_phy_ents, pe_link) {
-		struct agg_rmv_ent	*rm_ent;
-
 		if (first == NULL)
 			first = phy_ent; /* Save the first one */
 
@@ -717,30 +734,15 @@ process_physical:
 		D_ASSERT(ext.ex_lo <= ext.ex_hi);
 		phy_ent->pe_remove = false;
 		if (ext.ex_hi > mw->mw_ext.ex_hi) {
-			/** If a record is covered by a removal record and is
-			 *  contained in the current merge window, it will be
-			 *  removed by aggregation algorithm.  If it extends
-			 *  into next window, and the tail is fully covered
-			 *  by a removal entry, we need to mark the record for
-			 *  removal.
-			 */
-			d_list_for_each_entry(rm_ent, &mw->mw_rmv_ents,
-					      re_link) {
-				struct evt_rect	*rect = &rm_ent->re_rect;
-
-				if (rect->rc_epc != phy_ent->pe_rect.rc_epc ||
-				    rect->rc_ex.ex_lo > ext.ex_hi ||
-				    rect->rc_ex.ex_lo > ext.ex_hi)
-					continue;
-
-				if (rect->rc_ex.ex_hi >= ext.ex_hi) {
-					/** The extent is fully covered after
-					 *  the current merge window, so
-					 *  mark for removal
-					 */
-					phy_ent->pe_remove = true;
-					break;
-				}
+			if (phy_ent_is_removed(mw, &ext, phy_ent->pe_rect.rc_epc)) {
+				/** If a record is covered by a removal record and is
+				 *  contained in the current merge window, it will be
+				 *  removed by aggregation algorithm.  If it extends
+				 *  into next window, and the tail is fully covered
+				 *  by a removal entry, we need to mark the record for
+				 *  removal.
+				 */
+				phy_ent->pe_remove = true;
 			}
 		}
 
@@ -1906,7 +1908,11 @@ join_merge_window(daos_handle_t ih, struct agg_merge_window *mw,
 	/* Lookup physical entry, enqueue if it doesn't exist */
 	phy_ent = lookup_phy_ent(mw, &phy_ext, entry);
 	if (phy_ent == NULL) {
-		D_ASSERT(phy_ext.ex_lo == lgc_ext.ex_lo);
+		if (phy_ext.ex_lo != lgc_ext.ex_lo) {
+			/** Tail of a physical entry that was already removed */
+			D_ASSERT(!visible);
+			goto out;
+		}
 
 		phy_ent = enqueue_phy_ent(mw, &phy_ext, entry,
 					  &entry->ie_biov.bi_addr,


### PR DESCRIPTION
1. vos_obj_array_remove should skip existing entries removals
   rather than removing them
2. A logical extent may refer to a physical extent that is already
   removed because it's fully covered in the current window.
   Ignore such and assert they are not visible rather than asserting
   that the case can't happen.
3. Add a test that helped uncover these issues

Features: aggregation rebuild ec

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>