### PR TITLE
DAOS-8211 test: Fix conflict in VMD configuration

### DIFF
--- a/src/tests/ftest/launch.py
+++ b/src/tests/ftest/launch.py
@@ -574,9 +574,9 @@ def get_test_files(test_list, args, yaml_dir, vmd_flag=False):
     test_files = [{"py": test, "yaml": None, "env": {}} for test in test_list]
     for test_file in test_files:
         base, _ = os.path.splitext(test_file["py"])
-        yanl_file, env_vars = replace_yaml_file(
+        yaml_file, env_vars = replace_yaml_file(
             "{}.yaml".format(base), args, yaml_dir, vmd_flag)
-        test_file["yaml"] = yanl_file
+        test_file["yaml"] = yaml_file
         test_file["env"] = env_vars
 
     return test_files
@@ -819,11 +819,11 @@ def replace_yaml_file(yaml_file, args, yaml_dir, vmd_flag=False):
         str: the test yaml file; None if the yaml file contains placeholders
             w/o replacements
         env_vars (dict): Returns environment variable dictionary. Presently,
-            returns DAOS_DISABLE_VMD: "False" or "True" dictionary.
+            returns DAOS_ENABLE_VMD: "False" or "True" dictionary.
 
     """
     replacements = {}
-    env_vars = {"DAOS_DISABLE_VMD": "True"}
+    env_vars = {"DAOS_ENABLE_VMD": "False"}
 
     if args.test_servers or args.nvme:
         # Find the test yaml keys and values that match the replaceable fields
@@ -877,9 +877,9 @@ def replace_yaml_file(yaml_file, args, yaml_dir, vmd_flag=False):
                         value_format.format(item)
                         for item in find_pci_address(yaml_find[key])]
                     # if VMD pci address in present under nvme_data,
-                    # set DAOS_DISABLE_VMD to False
+                    # set DAOS_ENABLE_VMD to True
                     if vmd_flag is True:
-                        env_vars["DAOS_DISABLE_VMD"] = "False"
+                        env_vars["DAOS_ENABLE_VMD"] = "True"
 
                 # Add the next user-specified value as a replacement for key
                 for value in values_to_replace:

--- a/src/tests/ftest/util/server_utils_params.py
+++ b/src/tests/ftest/util/server_utils_params.py
@@ -113,9 +113,9 @@ class DaosServerYamlParameters(YamlParameters):
         self.control_log_file = LogParameter(log_dir, None, "daos_control.log")
         self.helper_log_file = LogParameter(log_dir, None, "daos_admin.log")
         self.telemetry_port = BasicParameter(None, 9191)
-        default_disable_vmd_val = os.environ.get("DAOS_DISABLE_VMD", "True")
-        default_disable_vmd = ast.literal_eval(default_disable_vmd_val)
-        self.disable_vmd = BasicParameter(None, default_disable_vmd)
+        default_enable_vmd_val = os.environ.get("DAOS_ENABLE_VMD", "False")
+        default_enable_vmd = ast.literal_eval(default_enable_vmd_val)
+        self.enable_vmd = BasicParameter(None, default_enable_vmd)
 
         # Used to drop privileges before starting data plane
         # (if started as root to perform hardware provisioning)


### PR DESCRIPTION
Since VMD is now disabled by default, the test code
needs to be updated to reflect the inverted logic.