### PR TITLE
DAOS-8103 pydaos: several improvements

### DIFF
--- a/src/client/pydaos/SConscript
+++ b/src/client/pydaos/SConscript
@@ -10,12 +10,10 @@ def build_shim_module(env, lib_prefix):
         return
 
     new_env = env.Clone()
-    extra_flags = ""
     version = "{}.{}".format(
         sys.version_info.major, sys.version_info.minor)
     if sys.version_info.major == 3:
         tgt_name = 'pydaos_shim'
-        extra_flags = " -D__USE_PYTHON3__==1"
         new_env.ParseConfig("pkg-config --cflags --libs python3")
     else:
         raise Exception("Unsupported python version %s" % version)
@@ -30,8 +28,7 @@ def build_shim_module(env, lib_prefix):
 
     obj = new_env.SharedObject(tgt_name, 'pydaos_shim.c',
                                SHLINKFLAGS=[],
-                               SHLIBPREFIX="",
-                               CPPFLAGS=extra_flags)
+                               SHLIBPREFIX="")
     base = daos_build.library(new_env, target=tgt_name, source=[obj],
                               install_off="../../../..",
                               SHLINK='gcc -pthread -shared',

--- a/src/client/pydaos/pydaos_shim.c
+++ b/src/client/pydaos/pydaos_shim.c
@@ -3,13 +3,12 @@
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
-#ifdef __USE_PYTHON3__
+
 /* Those are gone from python3, replaced with new functions */
 #define PyInt_FromLong		PyLong_FromLong
 #define PyString_FromString	PyUnicode_FromString
 #define PyString_FromStringAndSize PyUnicode_FromStringAndSize
 #define PyString_AsString	PyBytes_AsString
-#endif
 
 #include <Python.h>
 
@@ -26,6 +25,14 @@
 #include <daos_uns.h>
 
 #define PY_SHIM_MAGIC_NUMBER 0x7A89
+#define MAX_OID_HI ((1UL << 32) - 1)
+
+struct open_handle {
+	daos_handle_t	poh;   /** pool handle */
+	daos_handle_t	coh;   /** container handle */
+	daos_obj_id_t	root;  /** OID of root kv */
+	daos_obj_id_t	alloc; /** last allocated objid */
+};
 
 static int
 __is_magic_valid(int input)
@@ -115,12 +122,16 @@ __shim_handle__err_to_str(PyObject *self, PyObject *args)
  */
 
 static PyObject *
-cont_open(int ret, uuid_t puuid, uuid_t cuuid, int flags)
+cont_open(int ret, char *pool, char *cont, int flags)
 {
-	PyObject	*return_list;
-	daos_handle_t	 coh = {0};
-	daos_handle_t	 poh = {0};
-	int		 rc;
+	PyObject			*return_list;
+	struct open_handle		*hdl = NULL;
+	daos_handle_t			coh = {0};
+	daos_handle_t			poh = {0};
+	daos_prop_t			*prop = NULL;
+	struct daos_prop_entry		*entry;
+	struct daos_prop_co_roots	*roots;
+	int				rc;
 
 	if (ret != DER_SUCCESS) {
 		rc = ret;
@@ -128,21 +139,77 @@ cont_open(int ret, uuid_t puuid, uuid_t cuuid, int flags)
 	}
 
 	/** Connect to pool */
-	rc = daos_pool_connect(puuid, "daos_server", DAOS_PC_RW, &poh,
+	rc = daos_pool_connect(pool, NULL, DAOS_PC_RW, &poh,
 			       NULL, NULL);
 	if (rc)
 		goto out;
 
 	/** Open container */
-	rc = daos_cont_open(poh, cuuid, DAOS_COO_RW, &coh, NULL, NULL);
+	rc = daos_cont_open(poh, cont, DAOS_COO_RW, &coh, NULL, NULL);
 	if (rc)
-		daos_pool_disconnect(poh, NULL);
+		goto out;
+
+	/** Retrieve container properties via cont_query() */
+	prop = daos_prop_alloc(0);
+	if (prop == NULL) {
+		rc = -ENOMEM;
+		goto out;
+	}
+
+	rc = daos_cont_query(coh, NULL, prop, NULL);
+	if (rc)
+		goto out;
+
+	/** Verify that this is a python container */
+	entry = daos_prop_entry_get(prop, DAOS_PROP_CO_LAYOUT_TYPE);
+	if (entry == NULL || entry->dpe_val != DAOS_PROP_CO_LAYOUT_PYTHON) {
+		D_ERROR("Container is not a python container\n");
+		rc = -DER_INVAL;
+		goto out;
+	}
+
+	/** Fetch root object ID */
+	entry = daos_prop_entry_get(prop, DAOS_PROP_CO_ROOTS);
+	if (entry == NULL) {
+		D_ERROR("Invalid entry in properties for root object ID\n");
+		rc = -DER_INVAL;
+		goto out;
+	}
+	roots = (struct daos_prop_co_roots *)entry->dpe_val_ptr;
+	if (roots->cr_oids[0].hi == 0 && roots->cr_oids[0].lo == 0) {
+		D_ERROR("Invalid root object ID in properties\n");
+		rc = -DER_INVAL;
+		goto out;
+	}
+
+	/** Track container open handle and associated attributes */
+	D_ALLOC_PTR(hdl);
+	if (hdl == NULL) {
+		D_ERROR("failed to allocate internal handle to open container\n");
+		rc = -DER_NOMEM;
+		goto out;
+	}
+	hdl->poh	= poh;
+	hdl->coh	= coh;
+	hdl->root	= roots->cr_oids[0];
+	/** Use flatkv option for root kv */
+	hdl->root.hi	|= (uint64_t)DAOS_OF_KV_FLAT << OID_FMT_FEAT_SHIFT;
+	hdl->alloc.lo	= 0;
+	hdl->alloc.hi	= MAX_OID_HI;
 out:
+	if (prop)
+		daos_prop_free(prop);
+	if (rc) {
+		if (daos_handle_is_valid(coh))
+			daos_cont_close(coh, NULL);
+		if (daos_handle_is_valid(poh))
+			daos_pool_disconnect(poh, NULL);
+	}
+
 	/* Populate return list */
-	return_list = PyList_New(3);
+	return_list = PyList_New(2);
 	PyList_SetItem(return_list, 0, PyInt_FromLong(rc));
-	PyList_SetItem(return_list, 1, PyLong_FromLong(poh.cookie));
-	PyList_SetItem(return_list, 2, PyLong_FromLong(coh.cookie));
+	PyList_SetItem(return_list, 1, PyLong_FromVoidPtr(hdl));
 
 	return return_list;
 }
@@ -150,23 +217,14 @@ out:
 static PyObject *
 __shim_handle__cont_open(PyObject *self, PyObject *args)
 {
-	const char	*puuid_str;
-	const char	*cuuid_str;
-	uuid_t		 puuid;
-	uuid_t		 cuuid;
-	int		 flags;
-	int		 rc;
+	char	*pool;
+	char	*cont;
+	int	 flags;
 
 	/** Parse arguments, flags not used for now */
-	RETURN_NULL_IF_FAILED_TO_PARSE(args, "ssi", &puuid_str, &cuuid_str,
-				       &flags);
-	rc = uuid_parse(puuid_str, puuid);
-	if (rc)
-		goto out;
+	RETURN_NULL_IF_FAILED_TO_PARSE(args, "ssi", &pool, &cont, &flags);
 
-	rc = uuid_parse(cuuid_str, cuuid);
-out:
-	return cont_open(rc, puuid, cuuid, flags);
+	return cont_open(0, pool, cont, flags);
 }
 
 static PyObject *
@@ -181,29 +239,41 @@ __shim_handle__cont_open_by_path(PyObject *self, PyObject *args)
 	RETURN_NULL_IF_FAILED_TO_PARSE(args, "si", &path, &flags);
 
 	rc = duns_resolve_path(path, &attr);
+	if (rc)
+		goto out;
 
-	return cont_open(rc, attr.da_puuid, attr.da_cuuid, flags);
+	if (attr.da_type != DAOS_PROP_CO_LAYOUT_PYTHON)
+		rc = -DER_INVAL;
+out:
+	/**
+	 * XXX attr.da_pool/cont_label to be replaced by attr.da_pool/cont
+	 * once PR 6333 is landed
+	 */
+	return cont_open(rc, attr.da_pool_label, attr.da_cont_label, flags);
 }
 
 static PyObject *
 __shim_handle__cont_close(PyObject *self, PyObject *args)
 {
-	daos_handle_t	 poh;
-	daos_handle_t	 coh;
-	int		 rc;
-	int		 ret;
+	struct open_handle	*hdl;
+	int			rc;
+	int			ret;
 
 	/** Parse arguments */
-	RETURN_NULL_IF_FAILED_TO_PARSE(args, "LL", &poh.cookie, &coh.cookie);
+	RETURN_NULL_IF_FAILED_TO_PARSE(args, "K", &hdl);
 
 	/** Close container */
-	rc = daos_cont_close(coh, NULL);
+	rc = daos_cont_close(hdl->coh, NULL);
 
 	/** Disconnect from pool */
-	ret = daos_pool_disconnect(poh, NULL);
+	ret = daos_pool_disconnect(hdl->poh, NULL);
 
 	if (rc == 0)
 		rc = ret;
+
+	/** if everything went well, free up the handle */
+	if (rc == 0)
+		D_FREE(hdl);
 
 	return PyInt_FromLong(rc);
 }
@@ -353,23 +423,16 @@ static PyObject *
 __shim_handle__obj_idroot(PyObject *self, PyObject *args)
 {
 	PyObject		*return_list;
-	daos_oclass_id_t	 cid;
-	daos_handle_t		 coh;
-	int			 cid_in;
-	daos_obj_id_t		 oid;
+	struct open_handle	*hdl;
 
 	/* Parse arguments */
-	RETURN_NULL_IF_FAILED_TO_PARSE(args, "Li", &coh.cookie, &cid_in);
-	cid = (uint16_t) cid_in;
-	oid.hi = 0;
-	oid.lo = 0;
+	RETURN_NULL_IF_FAILED_TO_PARSE(args, "K", &hdl);
 
-	daos_obj_generate_oid(coh, &oid, DAOS_OF_KV_FLAT, cid, 0, 0);
-
+	/** Return root object ID fetched from properties at open time */
 	return_list = PyList_New(3);
 	PyList_SetItem(return_list, 0, PyInt_FromLong(DER_SUCCESS));
-	PyList_SetItem(return_list, 1, PyLong_FromLong(oid.hi));
-	PyList_SetItem(return_list, 2, PyLong_FromLong(oid.lo));
+	PyList_SetItem(return_list, 1, PyLong_FromLong(hdl->root.hi));
+	PyList_SetItem(return_list, 2, PyLong_FromLong(hdl->root.lo));
 
 	return return_list;
 }
@@ -378,24 +441,39 @@ static PyObject *
 __shim_handle__obj_idgen(PyObject *self, PyObject *args)
 {
 	PyObject		*return_list;
-	daos_handle_t		 coh;
+	struct open_handle	*hdl;
 	daos_oclass_id_t	 cid;
 	int			 cid_in;
 	daos_obj_id_t		 oid;
+	int			 rc = DER_SUCCESS;
 
 	/* Parse arguments */
-	RETURN_NULL_IF_FAILED_TO_PARSE(args, "Li", &coh.cookie, &cid_in);
+	RETURN_NULL_IF_FAILED_TO_PARSE(args, "Ki", &hdl, &cid_in);
 	cid = (uint16_t) cid_in;
 
-	/** XXX: OID should be generated via daos_cont_alloc_oids() */
-	srand(time(0));
-	oid.lo = rand();
-	oid.hi = 0;
+	/** If we ran out of local OIDs, alloc one from the container */
+	if (hdl->alloc.hi >= MAX_OID_HI) {
+		rc = daos_cont_alloc_oids(hdl->coh, 1, &hdl->alloc.lo, NULL);
+		if (rc) {
+			D_ERROR("daos_cont_alloc_oids() Failed (%d)\n", rc);
+			goto out;
+		}
+		if (hdl->alloc.lo == 0)
+			/** reserve the first 100 object IDs */
+			hdl->alloc.hi = 100;
+		else
+			hdl->alloc.hi = 0;
+	}
 
-	daos_obj_generate_oid(coh, &oid, DAOS_OF_KV_FLAT, cid, 0, 0);
+	/** set oid and lo, bump the current hi value */
+	oid.lo = hdl->alloc.lo;
+	oid.hi = hdl->alloc.hi++;
 
+	/** generate the actual object ID */
+	rc = daos_obj_generate_oid(hdl->coh, &oid, DAOS_OF_KV_FLAT, cid, 0, 0);
+out:
 	return_list = PyList_New(3);
-	PyList_SetItem(return_list, 0, PyInt_FromLong(DER_SUCCESS));
+	PyList_SetItem(return_list, 0, PyInt_FromLong(rc));
 	PyList_SetItem(return_list, 1, PyLong_FromLong(oid.hi));
 	PyList_SetItem(return_list, 2, PyLong_FromLong(oid.lo));
 
@@ -405,19 +483,19 @@ __shim_handle__obj_idgen(PyObject *self, PyObject *args)
 static PyObject *
 __shim_handle__kv_open(PyObject *self, PyObject *args)
 {
-	PyObject	*return_list;
-	daos_handle_t	 coh;
-	daos_handle_t	 oh;
-	daos_obj_id_t	 oid;
-	int		 flags;
-	int		 rc;
+	PyObject		*return_list;
+	struct open_handle	*hdl;
+	daos_handle_t		oh;
+	daos_obj_id_t		oid;
+	int			flags;
+	int			rc;
 
 	/** Parse arguments */
-	RETURN_NULL_IF_FAILED_TO_PARSE(args, "LLLi", &coh.cookie, &oid.hi,
+	RETURN_NULL_IF_FAILED_TO_PARSE(args, "KLLi", &hdl, &oid.hi,
 				       &oid.lo, &flags);
 
 	/** Open object */
-	rc = daos_kv_open(coh, oid, DAOS_OO_RW, &oh, NULL);
+	rc = daos_kv_open(hdl->coh, oid, DAOS_OO_RW, &oh, NULL);
 
 	/* Populate return list */
 	return_list = PyList_New(2);
@@ -586,12 +664,10 @@ rewait:
 
 		/** submit get request */
 		op->key_obj = key;
-#ifdef __USE_PYTHON3__
+
 		if (PyUnicode_Check(key)) {
 			op->key = (char *)PyUnicode_AsUTF8(key);
-		} else
-#endif
-		{
+		} else {
 			op->key = PyString_AsString(key);
 		}
 		if (!op->key)
@@ -686,7 +762,7 @@ __shim_handle__kv_put(PyObject *self, PyObject *args)
 
 	/* Parse arguments */
 	RETURN_NULL_IF_FAILED_TO_PARSE(args, "LO!", &oh.cookie,
-				&PyDict_Type, &daos_dict);
+				       &PyDict_Type, &daos_dict);
 
 	rc = daos_eq_create(&eq);
 	if (rc)
@@ -728,13 +804,11 @@ __shim_handle__kv_put(PyObject *self, PyObject *args)
 		/** XXX: Interpret all values as strings for now */
 		if (value == Py_None) {
 			size = 0;
-#ifdef __USE_PYTHON3__
 		} else if (PyUnicode_Check(value)) {
 			Py_ssize_t pysize = 0;
 
 			buf = (char *)PyUnicode_AsUTF8AndSize(value, &pysize);
 			size = pysize;
-#endif
 		} else {
 			Py_ssize_t pysize = 0;
 
@@ -745,12 +819,9 @@ __shim_handle__kv_put(PyObject *self, PyObject *args)
 			size = pysize;
 		}
 
-#ifdef __USE_PYTHON3__
 		if (PyUnicode_Check(key)) {
 			key_str = (char *)PyUnicode_AsUTF8(key);
-		} else
-#endif
-		{
+		} else {
 			key_str = PyString_AsString(key);
 		}
 		if (!key_str)

--- a/src/container/cli.c
+++ b/src/container/cli.c
@@ -17,6 +17,7 @@
 #include <daos/event.h>
 #include <daos/mgmt.h>
 #include <daos/pool.h>
+#include <daos/object.h>
 #include <daos/rsvc.h>
 #include <daos_types.h>
 #include "cli_internal.h"
@@ -76,9 +77,9 @@ cont_rsvc_client_complete_rpc(struct dc_pool *pool, const crt_endpoint_t *ep,
 }
 
 struct cont_args {
-	struct dc_pool		*pool;
-	crt_rpc_t		*rpc;
-	daos_prop_t		*prop;
+	struct dc_pool			*pool;
+	crt_rpc_t			*rpc;
+	daos_prop_t			*prop;
 };
 
 static int
@@ -134,19 +135,22 @@ daos_prop_has_entry(daos_prop_t *prop, uint32_t entry_type)
 /*
  * If no owner/group prop was supplied, translates euid/egid to user and group
  * names, and adds them as owners to a new copy of the daos_prop_t passed in.
+ * Allocate root objid if not specified by the caller.
  * The newly allocated prop is expected to be freed by the cont create callback.
  */
 static int
-dup_with_default_ownership_props(daos_prop_t **prop_out, daos_prop_t *prop_in)
+dup_cont_create_props(daos_handle_t poh, daos_prop_t **prop_out,
+		      daos_prop_t *prop_in)
 {
-	char	       *owner = NULL;
-	char	       *owner_grp = NULL;
-	daos_prop_t    *final_prop = NULL;
-	uint32_t	idx = 0;
-	uint32_t	entries;
-	int		rc = 0;
-	uid_t		uid = geteuid();
-	gid_t		gid = getegid();
+	char				*owner = NULL;
+	char				*owner_grp = NULL;
+	struct daos_prop_co_roots	*roots = NULL;
+	daos_prop_t			*final_prop = NULL;
+	uint32_t			idx = 0;
+	uint32_t			entries;
+	int				rc = 0;
+	uid_t				uid = geteuid();
+	gid_t				gid = getegid();
 
 	entries = (prop_in == NULL) ? 0 : prop_in->dpp_nr;
 
@@ -166,6 +170,40 @@ dup_with_default_ownership_props(daos_prop_t **prop_out, daos_prop_t *prop_in)
 			D_ERROR("Failed to parse gid "DF_RC"\n", DP_RC(rc));
 			D_GOTO(err_out, rc);
 		}
+
+		entries++;
+	}
+
+	if (!daos_prop_has_entry(prop_in, DAOS_PROP_CO_ROOTS)) {
+		uint64_t rf;
+
+		/**
+		 * If user did not provide his own root object, let's generate
+		 * it here. Worst case is that it is not used by the middleware.
+		 */
+
+		D_ALLOC_PTR(roots);
+		if (roots == NULL) {
+			D_ERROR("Failed to allocate structure for root objid\n");
+			D_GOTO(err_out, rc = -DER_NOMEM);
+		}
+
+		/** allocate objid according to the redundancy factor */
+		roots->cr_oids[0].lo = 0;
+		roots->cr_oids[0].hi = 0;
+		rf = daos_cont_prop2redunfac(prop_in);
+		rc = daos_obj_generate_oid_by_rf(poh, rf, &roots->cr_oids[0], 0,
+						 0, 0, 0);
+		if (rc) {
+			D_ERROR("Failed to generate root OID "DF_RC"\n",
+				DP_RC(rc));
+			D_GOTO(err_out, rc);
+		}
+
+		/** only one root oid is needed in the common case */
+		roots->cr_oids[1] = DAOS_OBJ_NIL;
+		roots->cr_oids[2] = DAOS_OBJ_NIL;
+		roots->cr_oids[3] = DAOS_OBJ_NIL;
 
 		entries++;
 	}
@@ -198,6 +236,14 @@ dup_with_default_ownership_props(daos_prop_t **prop_out, daos_prop_t *prop_in)
 			owner_grp = NULL; /* prop is responsible for it now */
 			idx++;
 		}
+
+		if (roots != NULL) {
+			final_prop->dpp_entries[idx].dpe_type =
+				DAOS_PROP_CO_ROOTS;
+			final_prop->dpp_entries[idx].dpe_val_ptr = roots;
+			roots = NULL; /* prop is responsible for it now */
+			idx++;
+		}
 	}
 
 	*prop_out = final_prop;
@@ -206,6 +252,7 @@ dup_with_default_ownership_props(daos_prop_t **prop_out, daos_prop_t *prop_in)
 
 err_out:
 	daos_prop_free(final_prop);
+	D_FREE(roots);
 	D_FREE(owner);
 	D_FREE(owner_grp);
 	return rc;
@@ -220,7 +267,7 @@ dc_cont_create(tse_task_t *task)
 	struct dc_pool	       *pool;
 	crt_endpoint_t		ep;
 	crt_rpc_t	       *rpc;
-	struct cont_args	arg;
+	struct cont_args	arg = {0, };
 	int			rc;
 	daos_prop_t	       *rpc_prop = NULL;
 
@@ -241,7 +288,8 @@ dc_cont_create(tse_task_t *task)
 	if (pool == NULL)
 		D_GOTO(err_task, rc = -DER_NO_HDL);
 
-	rc = dup_with_default_ownership_props(&rpc_prop, args->prop);
+	/** duplicate properties and add extra ones (e.g. ownership) */
+	rc = dup_cont_create_props(args->poh, &rpc_prop, args->prop);
 	if (rc != 0)
 		D_GOTO(err_pool, rc);
 

--- a/src/control/cmd/daos/container.go
+++ b/src/control/cmd/daos/container.go
@@ -181,7 +181,7 @@ func (cmd *containerBaseCmd) connectPool(ap *C.struct_cmd_args_s) (func(), error
 type containerCreateCmd struct {
 	containerBaseCmd
 
-	Type        string               `long:"type" short:"t" description:"container type" choice:"POSIX" choice:"HDF5"`
+	Type        string               `long:"type" short:"t" description:"container type"`
 	Path        string               `long:"path" short:"d" description:"container namespace path"`
 	ChunkSize   ChunkSizeFlag        `long:"chunk-size" short:"z" description:"container chunk size"`
 	ObjectClass ObjClassFlag         `long:"oclass" short:"o" description:"default object class"`
@@ -258,10 +258,14 @@ func (cmd *containerCreateCmd) Execute(_ []string) (err error) {
 		ap.props = cmd.Properties.props
 	}
 
+	// convert the container type string to a DAOS_PROP_CO_LAYOUT_* value
+	cType := C.CString(cmd.Type)
+	defer freeString(cType)
+	C.daos_parse_ctype(cType, &ap._type)
+
 	switch cmd.Type {
 	case "POSIX":
-		ap._type = C.DAOS_PROP_CO_LAYOUT_POSIX
-
+		// POSIX containers have extra attributes
 		if cmd.ChunkSize.Set {
 			ap.chunk_size = cmd.ChunkSize.Size
 		}
@@ -271,8 +275,6 @@ func (cmd *containerCreateCmd) Execute(_ []string) (err error) {
 		if cmd.Mode.Set {
 			ap.mode = cmd.Mode.Mode
 		}
-	case "HDF5":
-		ap._type = C.DAOS_PROP_CO_LAYOUT_HDF5
 	}
 
 	var rc C.int

--- a/src/include/daos/common.h
+++ b/src/include/daos/common.h
@@ -859,7 +859,6 @@ daos_prop_t *daos_prop_dup(daos_prop_t *prop, bool pool, bool input);
 int daos_prop_copy(daos_prop_t *prop_req, daos_prop_t *prop_reply);
 void daos_prop_fini(daos_prop_t *prop);
 
-struct daos_prop_entry *daos_prop_entry_get(daos_prop_t *prop, uint32_t type);
 int daos_prop_entry_copy(struct daos_prop_entry *entry,
 			 struct daos_prop_entry *entry_dup);
 daos_recx_t *daos_recx_alloc(uint32_t nr);

--- a/src/include/daos_prop.h
+++ b/src/include/daos_prop.h
@@ -446,6 +446,16 @@ daos_prop_t *
 daos_prop_merge(daos_prop_t *old_prop, daos_prop_t *new_prop);
 
 /**
+ * Search and return a property entry of type \a type in the property list
+ * \a prop
+ * Return NULL if not found.
+ *
+ * \param[in]		prop		Property list
+ * \param[in]		type		Type of property to look for
+ */
+struct daos_prop_entry *daos_prop_entry_get(daos_prop_t *prop, uint32_t type);
+
+/**
  * Duplicate a generic pointer value from one DAOS prop entry to another.
  * Convenience function.
  *

--- a/src/utils/daos_hdlr.c
+++ b/src/utils/daos_hdlr.c
@@ -1497,6 +1497,9 @@ get_num_prop_entries_to_add(struct cmd_args_s *ap)
 		nr++;
 	if (ap->group)
 		nr++;
+	if (ap->type != DAOS_PROP_CO_LAYOUT_POSIX &&
+	    ap->type != DAOS_PROP_CO_LAYOUT_UNKNOWN)
+		nr++;
 
 	return nr;
 }
@@ -1546,7 +1549,7 @@ get_first_empty_prop_entry(struct cmd_args_s *ap,
 }
 
 static int
-update_props_for_access_control(struct cmd_args_s *ap)
+update_props_for_create(struct cmd_args_s *ap)
 {
 	int			rc = 0;
 	struct daos_acl		*acl = NULL;
@@ -1615,6 +1618,14 @@ update_props_for_access_control(struct cmd_args_s *ap)
 		entry++;
 	}
 
+	if (ap->type != DAOS_PROP_CO_LAYOUT_POSIX &&
+	    ap->type != DAOS_PROP_CO_LAYOUT_UNKNOWN) {
+		entry->dpe_type = DAOS_PROP_CO_LAYOUT_TYPE;
+		entry->dpe_val = ap->type;
+
+		entry++;
+	}
+
 	return 0;
 }
 
@@ -1655,7 +1666,7 @@ cont_create_hdlr(struct cmd_args_s *ap)
 {
 	int rc;
 
-	rc = update_props_for_access_control(ap);
+	rc = update_props_for_create(ap);
 	if (rc != 0)
 		return rc;
 
@@ -1705,7 +1716,7 @@ cont_create_uns_hdlr(struct cmd_args_s *ap)
 	 */
 	ARGS_VERIFY_PATH_CREATE(ap, err_rc, rc = RC_PRINT_HELP);
 
-	rc = update_props_for_access_control(ap);
+	rc = update_props_for_create(ap);
 	if (rc != 0)
 		return rc;
 

--- a/utils/node_local_test.py
+++ b/utils/node_local_test.py
@@ -1213,7 +1213,7 @@ def run_daos_cmd(conf,
         rc.json = json.loads(rc.stdout.decode('utf-8'))
     return rc
 
-def _create_cont(conf, pool, cont=None, posix=False, label=None, path=None, valgrind=False):
+def _create_cont(conf, pool, cont=None, ctype=None, label=None, path=None, valgrind=False):
     """Helper function for create_cont"""
 
     cmd = ['container',
@@ -1223,8 +1223,8 @@ def _create_cont(conf, pool, cont=None, posix=False, label=None, path=None, valg
     if label:
         cmd.extend(['--properties',
                     'label:{}'.format(label)])
-    if posix:
-        cmd.extend(['--type', 'POSIX'])
+    if ctype:
+        cmd.extend(['--type', ctype])
 
     if path:
         cmd.extend(['--path', path])
@@ -1237,15 +1237,15 @@ def _create_cont(conf, pool, cont=None, posix=False, label=None, path=None, valg
     print(rc.json)
     return rc
 
-def create_cont(conf, pool, cont=None, posix=False, label=None, path=None, valgrind=False):
+def create_cont(conf, pool, cont=None, ctype=None, label=None, path=None, valgrind=False):
     """Create a container and return the uuid"""
 
-    rc = _create_cont(conf, pool, cont, posix, label, path, valgrind)
+    rc = _create_cont(conf, pool, cont, ctype, label, path, valgrind)
 
     if rc.returncode == 1 and \
        rc.json['error'] == 'failed to create container: DER_EXIST(-1004): Entity already exists':
         destroy_container(conf, pool, label)
-        rc = _create_cont(conf, pool, cont, posix, label, path, valgrind)
+        rc = _create_cont(conf, pool, cont, ctype, label, path, valgrind)
 
     assert rc.returncode == 0, "rc {} != 0".format(rc.returncode)
     return rc.json['response']['container_uuid']
@@ -1364,7 +1364,7 @@ class posix_tests():
     def test_cache(self):
         """Test with caching enabled"""
 
-        container = create_cont(self.conf, self.pool.id(), posix=True, label='Cache')
+        container = create_cont(self.conf, self.pool.id(), ctype="POSIX", label='Cache')
         run_daos_cmd(self.conf,
                      ['container', 'query',
                       self.pool.id(), container],
@@ -1669,7 +1669,7 @@ class posix_tests():
     def test_uns_create(self):
         """Simple test to create a container using a path in dfuse"""
         path = os.path.join(self.dfuse.dir, 'mycont')
-        create_cont(self.conf, pool=self.pool.uuid, path=path, posix=True)
+        create_cont(self.conf, pool=self.pool.uuid, path=path, ctype="POSIX")
         stbuf = os.stat(path)
         print(stbuf)
         assert stbuf.st_ino < 100
@@ -1826,7 +1826,7 @@ class posix_tests():
         tmp_dir = tempfile.mkdtemp()
 
         cont_path = os.path.join(tmp_dir, 'my-cont')
-        create_cont(self.conf, self.pool.uuid, posix=True, path=cont_path)
+        create_cont(self.conf, self.pool.uuid, ctype="POSIX", path=cont_path)
 
         dfuse = DFuse(self.server,
                       self.conf,
@@ -1865,7 +1865,7 @@ class posix_tests():
                     pool=pool,
                     cont=uns_container,
                     path=uns_path,
-                    posix=True)
+                    ctype="POSIX")
         print(os.stat(uns_path))
         print(os.listdir(dfuse.dir))
 
@@ -1898,7 +1898,7 @@ class posix_tests():
                     pool=pool,
                     cont=uns_container,
                     path=uns_path,
-                    posix=True)
+                    ctype="POSIX")
 
         # List the root container again.
         print(os.listdir(os.path.join(dfuse.dir, pool, container)))
@@ -1980,7 +1980,7 @@ class posix_tests():
                     pool=pool,
                     cont=uns_container,
                     path=uns_path,
-                    posix=True)
+                    ctype="POSIX")
 
         print(os.stat(uns_path))
         print(os.listdir(dfuse.dir))
@@ -2137,7 +2137,7 @@ def run_posix_tests(server, conf, test=None):
                 # should not reduce coverage.
                 pt.container = create_cont(conf,
                                            pool.id(),
-                                           posix=True,
+                                           ctype="POSIX",
                                            valgrind=False,
                                            label=fn)
                 pt.container_label = fn
@@ -2496,7 +2496,7 @@ def run_duns_overlay_test(server, conf):
 
     uns_dir = os.path.join(parent_dir.name, 'uns_ep')
 
-    create_cont(conf, pool=pool, path=uns_dir, posix=True)
+    create_cont(conf, pool=pool, path=uns_dir, ctype="POSIX")
 
     dfuse = DFuse(server, conf, mount_path=uns_dir, caching=False)
 
@@ -2652,7 +2652,7 @@ def run_in_fg(server, conf):
     dfuse = DFuse(server, conf, pool=pool)
     dfuse.start()
 
-    container = create_cont(conf, pool, posix=True)
+    container = create_cont(conf, pool, ctype="POSIX")
 
     run_daos_cmd(conf,
                  ['container', 'set-attr',
@@ -2872,7 +2872,7 @@ def test_pydaos_kv(server, conf):
 
     pool = server.get_test_pool()
 
-    c_uuid = create_cont(conf, pool)
+    c_uuid = create_cont(conf, pool, ctype="PYTHON")
 
     container = daos.Cont(pool, c_uuid)
 


### PR DESCRIPTION
Implement the following changes to pydaos:
- Remove ifdef for python2 support.
- Add support for pool and container label.
- Use oid in the roots property to boostrap the
  container and find the rootkv.
- Use container oid allocator instead of srand()
  to generate object ID.
- Track container and pool handles in the shim layer
  as well as the current allocated id. The pydaos
  frontend is only returned an opaq pointer.

In addition, the following changes were made:
- change daos_cont_create() to allocate a root oid by
  default if none is passed by the caller.
- modify the daos utility to accept all container types
- adjust nlt to accomodate the changes mentioned above.

Signed-off-by: Johann Lombardi <johann.lombardi@intel.com>