### PR TITLE
DAOS-8108 object: fix EC object punch size issue

### DIFF
--- a/src/include/daos_srv/evtree.h
+++ b/src/include/daos_srv/evtree.h
@@ -650,6 +650,8 @@ enum {
 	EVT_ITER_FOR_PURGE	= (1 << 5),
 	/** The iterator is for data migration scan */
 	EVT_ITER_FOR_MIGRATION	= (1 << 6),
+	/** Skip visible data (Only valid with EVT_ITER_VISIBLE) */
+	EVT_ITER_SKIP_DATA	= (1 << 7),
 };
 
 D_CASSERT((int)EVT_VISIBLE == (int)EVT_ITER_VISIBLE);

--- a/src/include/daos_srv/vos.h
+++ b/src/include/daos_srv/vos.h
@@ -1026,6 +1026,10 @@ vos_iterate(vos_iter_param_t *param, vos_iter_type_t type, bool recursive,
  * \param[out]	recx	max or min offset in dkey/akey, and the size of the
  *			extent at the offset. If there are no visible array
  *			records, the size in the recx returned will be 0.
+ * \param[in]	cell_size cell size for EC object, used to calculated the replicated
+ *                      space address on parity shard.
+ * \param[in]	stripe_size stripe size for EC object, used to calculated the replicated
+ *                      space address on parity shard.
  * \param[in]	dth	Pointer to the DTX handle.
  *
  * \return
@@ -1037,7 +1041,8 @@ vos_iterate(vos_iter_param_t *param, vos_iter_type_t type, bool recursive,
 int
 vos_obj_query_key(daos_handle_t coh, daos_unit_oid_t oid, uint32_t flags,
 		  daos_epoch_t epoch, daos_key_t *dkey, daos_key_t *akey,
-		  daos_recx_t *recx, struct dtx_handle *dth);
+		  daos_recx_t *recx, unsigned int cell_size, uint64_t stripe_size,
+		  struct dtx_handle *dth);
 
 /** Return constants that can be used to estimate the metadata overhead
  *  in persistent memory on-disk format.

--- a/src/object/cli_shard.c
+++ b/src/object/cli_shard.c
@@ -1882,6 +1882,8 @@ obj_shard_query_recx_post(struct obj_query_key_cb_args *cb_args, uint32_t shard,
 	tmp_recx = &recx[0];
 re_check:
 	if (reply_recx->rx_idx & PARITY_INDICATOR) {
+		daos_recx_t *punched_recx = &okqo->okqo_recx_punched;
+
 		D_ASSERT(!from_data_tgt);
 		rx_idx = (reply_recx->rx_idx & (~PARITY_INDICATOR));
 		D_ASSERTF(rx_idx % cell_rec_nr == 0, "rx_idx "DF_X64
@@ -1895,6 +1897,24 @@ re_check:
 		tmp_recx->rx_idx = rx_idx;
 		tmp_recx->rx_nr = stripe_rec_nr *
 				     (reply_recx->rx_nr / cell_rec_nr);
+
+		if (DAOS_RECX_END(*punched_recx) > 0) {
+			D_DEBUG(DB_IO, "shard %d punched extent "DF_U64" "DF_U64"\n",
+				shard, punched_recx->rx_idx, punched_recx->rx_nr);
+			D_ASSERT(DAOS_RECX_END(*punched_recx) >= tmp_recx->rx_idx);
+			if (DAOS_RECX_END(*punched_recx) < DAOS_RECX_END(*tmp_recx)) {
+				uint64_t end = DAOS_RECX_END(*tmp_recx);
+
+				tmp_recx->rx_idx = DAOS_RECX_END(*punched_recx);
+				tmp_recx->rx_nr = end - tmp_recx->rx_idx;
+			} else if (punched_recx->rx_idx > tmp_recx->rx_idx) {
+				tmp_recx->rx_nr = min(punched_recx->rx_idx,
+						      DAOS_RECX_END(*tmp_recx)) - tmp_recx->rx_idx;
+			} else {
+				tmp_recx->rx_nr = 0;
+				tmp_recx->rx_idx = 0;
+			}
+		}
 		D_DEBUG(DB_IO, "shard %d get recx "DF_U64" "DF_U64"\n",
 			shard, tmp_recx->rx_idx, tmp_recx->rx_nr);
 	} else {

--- a/src/object/obj_rpc.h
+++ b/src/object/obj_rpc.h
@@ -36,7 +36,7 @@
  * These are for daos_rpc::dr_opc and DAOS_RPC_OPCODE(opc, ...) rather than
  * crt_req_create(..., opc, ...). See daos_rpc.h.
  */
-#define DAOS_OBJ_VERSION 4
+#define DAOS_OBJ_VERSION 5
 /* LIST of internal RPCS in form of:
  * OPCODE, flags, FMT, handler, corpc_hdlr and name
  */
@@ -291,10 +291,12 @@ CRT_RPC_DECLARE(obj_punch, DAOS_ISEQ_OBJ_PUNCH, DAOS_OSEQ_OBJ_PUNCH)
 	((uint32_t)		(okqo_pad32_1)		CRT_VAR) \
 	((daos_key_t)		(okqo_dkey)		CRT_VAR) \
 	((daos_key_t)		(okqo_akey)		CRT_VAR) \
-	/* recx for normal data space */			 \
+	/* recx for visible extent */				\
 	((daos_recx_t)		(okqo_recx)		CRT_VAR) \
-	/* recx for EC parity space */				 \
-	((daos_recx_t)		(okqo_recx_parity)	CRT_VAR)
+	/* recx for EC parity space */				\
+	((daos_recx_t)		(okqo_recx_parity)	CRT_VAR) \
+	/* recx for punched EC extents */			\
+	((daos_recx_t)		(okqo_recx_punched)	CRT_VAR)
 
 CRT_RPC_DECLARE(obj_query_key, DAOS_ISEQ_OBJ_QUERY_KEY, DAOS_OSEQ_OBJ_QUERY_KEY)
 

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -3551,7 +3551,9 @@ ds_obj_query_key_handler(crt_rpc_t *rpc)
 	struct dtx_handle		 dth = {0};
 	struct dtx_epoch		 epoch = {0};
 	uint32_t			 query_flags;
-	daos_recx_t			 ec_recx[2] = {0};
+	unsigned int			 cell_size = 0;
+	uint64_t			 stripe_size = 0;
+	daos_recx_t			 ec_recx[3] = {0};
 	daos_recx_t			*query_recx;
 	int				 retry = 0;
 	int				 rc;
@@ -3600,16 +3602,20 @@ again:
 	    (okqi->okqi_api_flags & DAOS_GET_RECX)) {
 		query_flags |= VOS_GET_RECX_EC;
 		query_recx = ec_recx;
+		cell_size = obj_ec_cell_rec_nr(&ioc.ioc_oca);
+		stripe_size = obj_ec_stripe_rec_nr(&ioc.ioc_oca);
 	} else {
 		query_recx = &okqo->okqo_recx;
 	}
 
 re_query:
 	rc = vos_obj_query_key(ioc.ioc_vos_coh, okqi->okqi_oid, query_flags,
-			       okqi->okqi_epoch, dkey, akey, query_recx, &dth);
+			       okqi->okqi_epoch, dkey, akey, query_recx,
+			       cell_size, stripe_size, &dth);
 	if (rc == 0 && (query_flags & VOS_GET_RECX_EC)) {
 		okqo->okqo_recx = ec_recx[0];
 		okqo->okqo_recx_parity = ec_recx[1];
+		okqo->okqo_recx_punched = ec_recx[2];
 	} else if (obj_dtx_need_refresh(&dth, rc)) {
 		rc = dtx_refresh(&dth, ioc.ioc_coc);
 		if (rc == -DER_AGAIN)

--- a/src/tests/daos_perf.c
+++ b/src/tests/daos_perf.c
@@ -821,7 +821,7 @@ objects_query(struct pf_param *param)
 		rc = vos_obj_query_key(ts_ctx.tsc_coh, ts_uoids[i],
 				       DAOS_GET_MAX | DAOS_GET_DKEY |
 				       DAOS_GET_RECX, epoch, &dkey_iov,
-				       &akey_iov, &recx, NULL);
+				       &akey_iov, &recx, 0, 0, NULL);
 		if (rc != 0 && rc != -DER_NONEXIST)
 			break;
 		if (param->pa_verbose) {

--- a/src/vos/tests/vts_array.c
+++ b/src/vos/tests/vts_array.c
@@ -413,7 +413,7 @@ vts_array_get_size(daos_handle_t aoh, daos_epoch_t epoch, daos_size_t *size)
 	rc = vos_obj_query_key(array->va_coh, array->va_oid,
 			       DAOS_GET_DKEY | DAOS_GET_RECX | DAOS_GET_MAX,
 			       epoch, &dkey, &array->va_iod.iod_name,
-			       &recx, NULL);
+			       &recx, 0, 0, NULL);
 
 	if (rc == -DER_NONEXIST) {
 		*size = 0;

--- a/src/vos/tests/vts_io.c
+++ b/src/vos/tests/vts_io.c
@@ -2128,7 +2128,7 @@ io_query_key(void **state)
 			rc = vos_obj_query_key(arg->ctx.tc_co_hdl, oid,
 					       DAOS_GET_MAX | DAOS_GET_RECX,
 					       epoch + 3, &dkey, &akey,
-					       &recx_read, NULL);
+					       &recx_read, 0, 0, NULL);
 			assert_rc_equal(rc, 0);
 			assert_int_equal(recx_read.rx_idx, 0);
 			assert_int_equal(recx_read.rx_nr, 1);
@@ -2137,7 +2137,7 @@ io_query_key(void **state)
 			rc = vos_obj_query_key(arg->ctx.tc_co_hdl, oid,
 					       DAOS_GET_MAX | DAOS_GET_RECX,
 					       epoch + 2, &dkey, &akey,
-					       &recx_read, NULL);
+					       &recx_read, 0, 0, NULL);
 			assert_rc_equal(rc, 0);
 			assert_int_equal(recx_read.rx_idx, 2);
 			assert_int_equal(recx_read.rx_nr, 1);
@@ -2146,7 +2146,7 @@ io_query_key(void **state)
 					       DAOS_GET_DKEY | DAOS_GET_AKEY |
 					       DAOS_GET_MAX | DAOS_GET_RECX,
 					       epoch + 3, &dkey_read,
-					       &akey_read, &recx_read, NULL);
+					       &akey_read, &recx_read, 0, 0, NULL);
 			assert_rc_equal(rc, 0);
 			assert_int_equal(recx_read.rx_idx, 0);
 			assert_int_equal(recx_read.rx_nr, 1);
@@ -2160,7 +2160,7 @@ io_query_key(void **state)
 					       DAOS_GET_DKEY | DAOS_GET_AKEY |
 					       DAOS_GET_MAX | DAOS_GET_RECX,
 					       epoch + 2, &dkey_read,
-					       &akey_read, &recx_read, NULL);
+					       &akey_read, &recx_read, 0, 0, NULL);
 			assert_rc_equal(rc, 0);
 			assert_int_equal(recx_read.rx_idx, 2);
 			assert_int_equal(recx_read.rx_nr, 1);
@@ -2172,7 +2172,7 @@ io_query_key(void **state)
 			rc = vos_obj_query_key(arg->ctx.tc_co_hdl, oid,
 					       DAOS_GET_MIN | DAOS_GET_RECX,
 					       epoch + 3, &dkey, &akey,
-					       &recx_read, NULL);
+					       &recx_read, 0, 0, NULL);
 			assert_rc_equal(rc, 0);
 			assert_int_equal(recx_read.rx_idx, 0);
 			assert_int_equal(recx_read.rx_nr, 1);
@@ -2181,7 +2181,7 @@ io_query_key(void **state)
 			rc = vos_obj_query_key(arg->ctx.tc_co_hdl, oid,
 					       DAOS_GET_MIN | DAOS_GET_RECX,
 					       epoch + 2, &dkey, &akey,
-					       &recx_read, NULL);
+					       &recx_read, 0, 0, NULL);
 			assert_rc_equal(rc, 0);
 			assert_int_equal(recx_read.rx_idx, 0);
 			assert_int_equal(recx_read.rx_nr, 1);
@@ -2190,7 +2190,7 @@ io_query_key(void **state)
 					       DAOS_GET_DKEY | DAOS_GET_AKEY |
 					       DAOS_GET_MIN | DAOS_GET_RECX,
 					       epoch + 3, &dkey_read,
-					       &akey_read, &recx_read, NULL);
+					       &akey_read, &recx_read, 0, 0, NULL);
 			assert_rc_equal(rc, 0);
 			assert_int_equal(recx_read.rx_idx, 0);
 			assert_int_equal(recx_read.rx_nr, 1);
@@ -2204,7 +2204,7 @@ io_query_key(void **state)
 					       DAOS_GET_DKEY | DAOS_GET_AKEY |
 					       DAOS_GET_MIN | DAOS_GET_RECX,
 					       epoch + 2, &dkey_read,
-					       &akey_read, &recx_read, NULL);
+					       &akey_read, &recx_read, 0, 0, NULL);
 			assert_rc_equal(rc, 0);
 			assert_int_equal(recx_read.rx_idx, 0);
 			assert_int_equal(recx_read.rx_nr, 1);
@@ -2233,13 +2233,13 @@ io_query_key(void **state)
 
 	rc = vos_obj_query_key(arg->ctx.tc_co_hdl, oid, DAOS_GET_AKEY |
 			       DAOS_GET_MIN, epoch++, &dkey, &akey_read, NULL,
-			       NULL);
+			       0, 0, NULL);
 	assert_rc_equal(rc, 0);
 	assert_int_equal(*(uint64_t *)akey_read.iov_buf, KEY_INC * 2);
 
 	rc = vos_obj_query_key(arg->ctx.tc_co_hdl, oid, DAOS_GET_AKEY |
 			       DAOS_GET_MAX, epoch++, &dkey, &akey_read, NULL,
-			       NULL);
+			       0, 0, NULL);
 	assert_rc_equal(rc, 0);
 	assert_int_equal(*(uint64_t *)akey_read.iov_buf, MAX_INT_KEY - KEY_INC);
 
@@ -2252,12 +2252,12 @@ io_query_key(void **state)
 	}
 	rc = vos_obj_query_key(arg->ctx.tc_co_hdl, oid, DAOS_GET_AKEY |
 			       DAOS_GET_MAX, epoch++, &dkey, &akey_read, NULL,
-			       NULL);
+			       0, 0, NULL);
 	assert_rc_equal(rc, -DER_NONEXIST);
 
 	rc = vos_obj_query_key(arg->ctx.tc_co_hdl, oid, DAOS_GET_AKEY |
 			       DAOS_GET_DKEY | DAOS_GET_MAX, epoch++,
-			       &dkey_read, &akey_read, NULL, NULL);
+			       &dkey_read, &akey_read, NULL, 0, 0, NULL);
 	assert_rc_equal(rc, 0);
 	assert_int_equal(*(uint64_t *)akey_read.iov_buf, MAX_INT_KEY);
 	assert_int_equal(*(uint64_t *)dkey_read.iov_buf, MAX_INT_KEY - KEY_INC);
@@ -2266,7 +2266,7 @@ io_query_key(void **state)
 	rc = vos_obj_query_key(arg->ctx.tc_co_hdl, oid, DAOS_GET_AKEY |
 			       DAOS_GET_DKEY | DAOS_GET_RECX | DAOS_GET_MAX,
 			       epoch++, &dkey_read, &akey_read,
-			       &recx_read, NULL);
+			       &recx_read, 0, 0, NULL);
 	assert_rc_equal(rc, 0);
 	assert_int_equal(*(uint64_t *)akey_read.iov_buf, MAX_INT_KEY - KEY_INC);
 	assert_int_equal(*(uint64_t *)dkey_read.iov_buf, MAX_INT_KEY - KEY_INC);
@@ -2286,7 +2286,7 @@ io_query_key(void **state)
 
 	rc = vos_obj_query_key(arg->ctx.tc_co_hdl, oid, DAOS_GET_DKEY |
 			       DAOS_GET_MIN, epoch++, &dkey_read, NULL, NULL,
-			       NULL);
+			       0, 0, NULL);
 	assert_rc_equal(rc, 0);
 	assert_int_equal(*(uint64_t *)dkey_read.iov_buf, KEY_INC * 2);
 
@@ -2296,7 +2296,7 @@ io_query_key(void **state)
 
 	rc = vos_obj_query_key(arg->ctx.tc_co_hdl, oid, DAOS_GET_DKEY |
 			       DAOS_GET_MAX, 0 /* Ignored epoch */, &dkey_read,
-			       NULL, NULL, dth);
+			       NULL, NULL, 0, 0, dth);
 	assert_rc_equal(rc, 0);
 	assert_int_equal(*(uint64_t *)dkey_read.iov_buf, MAX_INT_KEY - KEY_INC);
 
@@ -2322,7 +2322,7 @@ io_query_key(void **state)
 
 	rc = vos_obj_query_key(arg->ctx.tc_co_hdl, oid, DAOS_GET_DKEY |
 			       DAOS_GET_MAX, epoch++, &dkey_read, NULL, NULL,
-			       NULL);
+			       0, 0, NULL);
 	assert_rc_equal(rc, -DER_NONEXIST);
 }
 
@@ -2369,7 +2369,7 @@ io_query_key_punch_update(void **state)
 	struct io_test_args	*arg = *state;
 	int			rc = 0;
 	daos_epoch_t		epoch = 1;
-	daos_key_t		dkey;
+	daos_key_t		dkey = { 0 };
 	daos_key_t		akey;
 	daos_recx_t		recx_read;
 	daos_unit_oid_t		oid;
@@ -2385,7 +2385,7 @@ io_query_key_punch_update(void **state)
 
 	rc = vos_obj_query_key(arg->ctx.tc_co_hdl, oid,
 			       DAOS_GET_MAX | DAOS_GET_DKEY | DAOS_GET_RECX,
-			       epoch++, &dkey, &akey, &recx_read, NULL);
+			       epoch++, &dkey, &akey, &recx_read, 0, 0, NULL);
 	assert_rc_equal(rc, 0);
 	assert_int_equal(recx_read.rx_idx, 0);
 	assert_int_equal(recx_read.rx_nr, sizeof("Goodbye"));
@@ -2400,7 +2400,7 @@ io_query_key_punch_update(void **state)
 
 	rc = vos_obj_query_key(arg->ctx.tc_co_hdl, oid,
 			       DAOS_GET_MAX | DAOS_GET_DKEY | DAOS_GET_RECX,
-			       epoch++, &dkey, &akey, &recx_read, NULL);
+			       epoch++, &dkey, &akey, &recx_read, 0, 0, NULL);
 	assert_rc_equal(rc, 0);
 	assert_int_equal(recx_read.rx_idx, 0);
 	assert_int_equal(recx_read.rx_nr, sizeof("World"));
@@ -2411,7 +2411,7 @@ io_query_key_punch_update(void **state)
 
 	rc = vos_obj_query_key(arg->ctx.tc_co_hdl, oid,
 			       DAOS_GET_MAX | DAOS_GET_DKEY | DAOS_GET_RECX,
-			       epoch++, &dkey, &akey, &recx_read, NULL);
+			       epoch++, &dkey, &akey, &recx_read, 0, 0, NULL);
 	assert_rc_equal(rc, 0);
 	assert_int_equal(recx_read.rx_nr, sizeof("Hello"));
 	assert_int_equal(recx_read.rx_idx, 0);
@@ -2434,21 +2434,21 @@ io_query_key_negative(void **state)
 			       DAOS_GET_DKEY | DAOS_GET_AKEY |
 			       DAOS_GET_MAX | DAOS_GET_RECX, 4,
 			       &dkey_read, &akey_read,
-			       &recx_read, NULL);
+			       &recx_read, 0, 0, NULL);
 	assert_rc_equal(rc, -DER_NONEXIST);
 
 	rc = vos_obj_query_key(arg->ctx.tc_co_hdl, oid,
 			       DAOS_GET_DKEY | DAOS_GET_AKEY |
 			       DAOS_GET_MIN | DAOS_GET_RECX, 4,
 			       &dkey_read, &akey_read,
-			       &recx_read, NULL);
+			       &recx_read, 0, 0, NULL);
 	assert_rc_equal(rc, -DER_NONEXIST);
 
 	gen_query_tree(arg, oid);
 
 	rc = vos_obj_query_key(arg->ctx.tc_co_hdl, arg->oid,
 			       DAOS_GET_DKEY | DAOS_GET_MAX, 4,
-			       NULL, NULL, NULL, NULL);
+			       NULL, NULL, NULL, 0, 0, NULL);
 	assert_rc_equal(rc, -DER_INVAL);
 }
 

--- a/src/vos/tests/vts_mvcc.c
+++ b/src/vos/tests/vts_mvcc.c
@@ -764,7 +764,7 @@ tx_query(daos_handle_t coh, struct tx_helper *txh, daos_epoch_t epoch,
 	dth = start_tx(coh, oid, epoch, txh);
 
 	rc = vos_obj_query_key(coh, oid, flags, epoch, dkey, akey, recx,
-			       dth);
+			       0, 0, dth);
 
 	stop_tx(coh, txh, rc == 0, false);
 

--- a/src/vos/tests/vts_pm.c
+++ b/src/vos/tests/vts_pm.c
@@ -737,7 +737,7 @@ punch_model_test(void **state)
 
 	rc = vos_obj_query_key(arg->ctx.tc_co_hdl, oid,
 			       DAOS_GET_RECX | DAOS_GET_MAX,
-			       11, &dkey, &akey, &rex, NULL);
+			       11, &dkey, &akey, &rex, 0, 0, NULL);
 	assert_rc_equal(rc, 0);
 	assert_int_equal(rex.rx_idx, 0);
 	assert_int_equal(rex.rx_nr, strlen(latest));

--- a/src/vos/vos_query.c
+++ b/src/vos/vos_query.c
@@ -31,11 +31,13 @@ struct open_query {
 	struct btr_root		*qt_akey_root;
 	daos_handle_t		 qt_akey_toh;
 	struct evt_root		*qt_recx_root;
-	uint32_t		 qt_flags;
 	struct vos_pool		*qt_pool;
 	daos_handle_t		 qt_coh;
 	daos_anchor_t		 qt_dkey_anchor;
 	daos_anchor_t		 qt_akey_anchor;
+	uint64_t		 qt_stripe_size;
+	uint32_t		 qt_flags;
+	unsigned int		 qt_cell_size;
 };
 
 static int
@@ -147,7 +149,8 @@ out:
 }
 
 static int
-query_recx(struct open_query *query, daos_recx_t *recx)
+_query_recx(struct open_query *query, daos_recx_t *recx, struct evt_extent *filter_extent,
+	    int opc)
 {
 	struct evt_desc_cbs	cbs;
 	struct evt_entry	entry;
@@ -156,11 +159,10 @@ query_recx(struct open_query *query, daos_recx_t *recx)
 	struct evt_filter	filter = {0};
 	int			rc;
 	int			close_rc;
-	int			opc;
 	uint32_t		inob;
-	bool			re_itered = false;
+	uint64_t		start = 0;
+	uint64_t		end = 0;
 	bool			exist = false;
-	bool			for_ec_recx;
 
 	recx->rx_idx = 0;
 	recx->rx_nr = 0;
@@ -170,23 +172,16 @@ query_recx(struct open_query *query, daos_recx_t *recx)
 	if (rc != 0)
 		return rc;
 
-	opc = EVT_ITER_EMBEDDED | EVT_ITER_VISIBLE | EVT_ITER_SKIP_HOLES;
 	if (query->qt_flags & VOS_GET_MAX)
 		opc |= EVT_ITER_REVERSE;
 
-	for_ec_recx = (query->qt_flags & VOS_GET_RECX_EC);
-	filter.fr_ex.ex_lo = 0;
-	if (for_ec_recx)
-		filter.fr_ex.ex_hi = DAOS_EC_PARITY_BIT - 1;
-	else
-		filter.fr_ex.ex_hi = ~(uint64_t)0;
+	filter.fr_ex = *filter_extent;
 	filter.fr_punch_epc = query->qt_punch.pr_epc;
 	filter.fr_punch_minor_epc = query->qt_punch.pr_minor_epc;
 	filter.fr_epr.epr_hi = query->qt_bound;
 	filter.fr_epr.epr_lo = query->qt_epr.epr_lo;
 	filter.fr_epoch = query->qt_epr.epr_hi;
 
-re_iter:
 	rc = evt_iter_prepare(toh, opc, &filter, &ih);
 	if (rc != 0)
 		goto out;
@@ -203,9 +198,46 @@ re_iter:
 	if (rc != 0)
 		goto fini;
 
-	recx->rx_idx = entry.en_sel_ext.ex_lo;
-	recx->rx_nr = entry.en_sel_ext.ex_hi - entry.en_sel_ext.ex_lo + 1;
+	if (opc & EVT_ITER_SKIP_HOLES) {
+		if (entry.en_visibility & EVT_VISIBLE) {
+			recx->rx_idx = entry.en_sel_ext.ex_lo;
+			recx->rx_nr = entry.en_sel_ext.ex_hi - entry.en_sel_ext.ex_lo + 1;
+		} else {
+			rc = -DER_NONEXIST;
+		}
+		D_GOTO(fini, rc);
+	}
+
+	/* The following only supports MAX recx query at the moment */
+	if (!(query->qt_flags & VOS_GET_MAX))
+		D_GOTO(fini, rc = -DER_INVAL);
+
+	/* Check if these extents can be merged */
+	D_ASSERT(bio_addr_is_hole(&entry.en_addr));
+	end = entry.en_sel_ext.ex_hi;
+	start = entry.en_sel_ext.ex_lo;
+	while (1) {
+		rc = evt_iter_next(ih);
+		if (rc)
+			break;
+
+		rc = evt_iter_fetch(ih, &inob, &entry, NULL);
+		if (rc != 0)
+			break;
+
+		D_ASSERT(bio_addr_is_hole(&entry.en_addr));
+		if (entry.en_sel_ext.ex_hi == start - 1)
+			start = entry.en_sel_ext.ex_lo;
+		else
+			break;
+	}
+
+	recx->rx_idx = start;
+	recx->rx_nr = end - start + 1;
+
 fini:
+	D_DEBUG(DB_TRACE, "query recx "DF_U64"/"DF_U64" : "DF_RC"\n", recx->rx_idx,
+		recx->rx_nr, DP_RC(rc));
 	if (rc == 0)
 		exist = true;
 	if (rc == -DER_NONEXIST)
@@ -213,21 +245,119 @@ fini:
 	close_rc = evt_iter_finish(ih);
 	if (rc == 0)
 		rc = close_rc;
-	if (rc == 0 && !re_itered && for_ec_recx) {
-		re_itered = true;
-		filter.fr_ex.ex_lo = DAOS_EC_PARITY_BIT;
-		filter.fr_ex.ex_hi = ~(uint64_t)0;
-		recx++;
-		recx->rx_idx = 0;
-		recx->rx_nr = 0;
-		goto re_iter;
-	}
 out:
 	close_rc = evt_close(toh);
 	if (rc == 0 && !exist)
 		rc = -DER_NONEXIST;
 	if (rc == 0)
 		rc = close_rc;
+
+	return rc;
+}
+
+static int
+query_normal_recx(struct open_query *query, daos_recx_t *recx)
+{
+	struct evt_extent filter_ex;
+	int		  opc;
+
+	memset(recx, 0, sizeof(*recx));
+	/* query visible last recx */
+	opc = EVT_ITER_EMBEDDED | EVT_ITER_VISIBLE | EVT_ITER_SKIP_HOLES;
+	if (query->qt_flags & VOS_GET_MAX)
+		opc |= EVT_ITER_REVERSE;
+
+	filter_ex.ex_lo = 0;
+	filter_ex.ex_hi = ~(uint64_t)0;
+
+	return _query_recx(query, recx, &filter_ex, opc);
+}
+
+static int
+query_ec_normal_recx(struct open_query *query, daos_recx_t *recx,
+		     struct evt_extent *filter_ex, bool skip_hole)
+{
+	struct evt_extent tmp_ex;
+	int		  opc;
+
+	memset(recx, 0, sizeof(*recx));
+	/* query visible last recx */
+	opc = EVT_ITER_EMBEDDED | EVT_ITER_VISIBLE;
+	if (query->qt_flags & VOS_GET_MAX)
+		opc |= EVT_ITER_REVERSE;
+
+	if (skip_hole)
+		opc |= EVT_ITER_SKIP_HOLES;
+	else /* otherwise skip DATA */
+		opc |= EVT_ITER_SKIP_DATA;
+
+	if (filter_ex) {
+		tmp_ex = *filter_ex;
+	} else {
+		tmp_ex.ex_lo = 0;
+		tmp_ex.ex_hi = DAOS_EC_PARITY_BIT - 1;
+	}
+	D_DEBUG(DB_TRACE, "search opc %x ["DF_U64"-"DF_U64"]\n", opc,
+		tmp_ex.ex_lo, tmp_ex.ex_hi);
+	return _query_recx(query, recx, &tmp_ex, opc);
+}
+
+static int
+query_ec_parity_recx(struct open_query *query, daos_recx_t *recx)
+{
+	struct evt_extent filter_ex;
+	int		  opc;
+
+	memset(recx, 0, sizeof(*recx));
+	/* query visible last recx */
+	opc = EVT_ITER_EMBEDDED | EVT_ITER_VISIBLE | EVT_ITER_SKIP_HOLES;
+	if (query->qt_flags & VOS_GET_MAX)
+		opc |= EVT_ITER_REVERSE;
+
+	filter_ex.ex_lo = DAOS_EC_PARITY_BIT;
+	filter_ex.ex_hi = ~(uint64_t)0;
+
+	return _query_recx(query, recx, &filter_ex, opc);
+}
+
+static int
+query_recx(struct open_query *query, daos_recx_t *recxs)
+{
+	struct evt_extent filter_ex;
+	int		  rc;
+
+	if (!(query->qt_flags & VOS_GET_RECX_EC))
+		return query_normal_recx(query, &recxs[0]);
+
+	/* visible recxs */
+	rc = query_ec_normal_recx(query, &recxs[0], NULL, true);
+	if (rc && rc != -DER_NONEXIST)
+		return rc;
+
+	/* visible parity recxs */
+	rc = query_ec_parity_recx(query, &recxs[1]);
+	if (rc) {
+		if (rc == -DER_NONEXIST)
+			rc = 0;
+		return rc;
+	}
+
+	/* possible punched recxs within this parity recx */
+	filter_ex.ex_lo = recxs[1].rx_idx;
+	D_ASSERT((filter_ex.ex_lo & DAOS_EC_PARITY_BIT) != 0);
+	filter_ex.ex_lo &= ~DAOS_EC_PARITY_BIT;
+	D_ASSERT(filter_ex.ex_lo % query->qt_cell_size == 0);
+	filter_ex.ex_hi = (((filter_ex.ex_lo + recxs[1].rx_nr) / query->qt_cell_size) *
+			   query->qt_stripe_size);
+	filter_ex.ex_lo = ((filter_ex.ex_lo / query->qt_cell_size) *
+			   query->qt_stripe_size);
+
+	rc = query_ec_normal_recx(query, &recxs[2], &filter_ex, false);
+	if (rc == -DER_NONEXIST)
+		rc = 0;
+
+	D_DEBUG(DB_TRACE, "get punched recxs "DF_U64"/"DF_U64"\n", recxs[2].rx_idx,
+		recxs[2].rx_nr);
 
 	return rc;
 }
@@ -315,7 +445,8 @@ open_and_query_key(struct open_query *query, daos_key_t *key,
 int
 vos_obj_query_key(daos_handle_t coh, daos_unit_oid_t oid, uint32_t flags,
 		  daos_epoch_t epoch, daos_key_t *dkey, daos_key_t *akey,
-		  daos_recx_t *recx, struct dtx_handle *dth)
+		  daos_recx_t *recx, unsigned int cell_size, uint64_t stripe_size,
+		  struct dtx_handle *dth)
 {
 	struct vos_container	*cont;
 	struct vos_object	*obj = NULL;
@@ -439,6 +570,8 @@ vos_obj_query_key(daos_handle_t coh, daos_unit_oid_t oid, uint32_t flags,
 	query->qt_dkey_root  = &obj->obj_df->vo_tree;
 	query->qt_coh	    = coh;
 	query->qt_pool	    = vos_obj2pool(obj);
+	query->qt_cell_size = cell_size;
+	query->qt_stripe_size = stripe_size;
 
 	/** We may read a dkey/akey that has no valid akey/recx and will need to
 	 *  reset the timestamp cache state to cache the new dkey/akey


### PR DESCRIPTION
When punch EC object, it does not punch anything on
the parity extent, only on replicate extent. so if
size querying goes to the parity shard before EC
aggregation, then it will check the punched extents.

Signed-off-by: Di Wang <di.wang@intel.com>