### PR TITLE
DAOS-8099 test: Basic test (enable csum scrubber)

### DIFF
--- a/src/tests/ftest/osa/osa_offline_drain.yaml
+++ b/src/tests/ftest/osa/osa_offline_drain.yaml
@@ -49,6 +49,7 @@ pool:
     nvme_size: 108000000000
     svcn: 4
     control_method: dmg
+    properties: scrub:continuous
 container:
     type: POSIX
     control_method: daos

--- a/src/tests/ftest/osa/osa_offline_extend.yaml
+++ b/src/tests/ftest/osa/osa_offline_extend.yaml
@@ -50,6 +50,7 @@ pool:
   nvme_size: 54000000000
   svcn: 4
   control_method: dmg
+  properties: scrub:run_wait
 container:
   type: POSIX
   control_method: daos

--- a/src/tests/ftest/osa/osa_offline_reintegration.yaml
+++ b/src/tests/ftest/osa/osa_offline_reintegration.yaml
@@ -57,6 +57,7 @@ pool:
   control_method: dmg
   rebuild_timeout: 120
   pool_query_timeout: 30
+  properties: scrub:continuous,scrub-freq:1,scrub-cred:10
 container:
   type: POSIX
   control_method: daos


### PR DESCRIPTION
Test-tag-hw-medium: pr,hw,medium,ib2 daily_regression
Test-tag-hw-large: pr,hw,large daily_regression

Summary:
- Enable csum scrubber under OSA tests.

Signed-off-by: rpadma2 <ravindran.padmanabhan@intel.com>