### PR TITLE
DAOS-8255 control: Add -DER_UNREACH to retryable pool errors

### DIFF
--- a/src/control/lib/control/pool.go
+++ b/src/control/lib/control/pool.go
@@ -185,7 +185,7 @@ func (r *poolRequest) canRetry(reqErr error, try uint) bool {
 		switch e {
 		// These pool errors can be retried.
 		case drpc.DaosTimedOut, drpc.DaosGroupVersionMismatch,
-			drpc.DaosTryAgain, drpc.DaosOutOfGroup:
+			drpc.DaosTryAgain, drpc.DaosOutOfGroup, drpc.DaosUnreachable:
 			return true
 		default:
 			return false

--- a/src/control/system/raft.go
+++ b/src/control/system/raft.go
@@ -292,6 +292,7 @@ func (db *Database) submitPoolUpdate(op raftOp, ps *PoolService) error {
 	if err != nil {
 		return err
 	}
+	db.log.Debugf("pool %s updated @ %s", ps.PoolUUID, ps.LastUpdate)
 	return db.submitRaftUpdate(data)
 }
 

--- a/src/tests/ftest/util/dmg_utils.py
+++ b/src/tests/ftest/util/dmg_utils.py
@@ -16,13 +16,6 @@ from dmg_utils_base import DmgCommandBase
 from general_utils import get_numeric_list
 from dmg_utils_params import DmgYamlParameters, DmgTransportCredentials
 
-RETRYABLE_POOL_CREATE_ERRORS = [
-    -1006, # -DER_UNREACH: Can happen after ranks are killed but before
-           #               SWIM has noticed and excluded them.
-    -1019, # -DER_OOG: Can happen after restart.
-]
-POOL_RETRY_INTERVAL = 1 # seconds
-
 class DmgJsonCommandFailure(CommandFailure):
     """Exception raised when a dmg --json command fails."""
 
@@ -450,17 +443,6 @@ class DmgCommand(DmgCommandBase):
                                        json_err=True, **kwargs)
         if output["error"] is not None:
             self.log.error(output["error"])
-            if output["status"] in RETRYABLE_POOL_CREATE_ERRORS:
-                time.sleep(POOL_RETRY_INTERVAL)
-                return self.pool_create(scm_size, uid=uid, gid=gid,
-                                        nvme_size=nvme_size,
-                                        target_list=target_list,
-                                        svcn=svcn,
-                                        acl_file=acl_file,
-                                        size=size,
-                                        tier_ratio=tier_ratio,
-                                        properties=properties,
-                                        label=label)
             if self.exit_status_exception:
                 raise DmgJsonCommandFailure(output["error"])
 


### PR DESCRIPTION
In some cases, a pool operation may encounter a temporary
-DER_UNREACH failure when a node is down but hasn't been
marked dead by SWIM yet.

Also removes some redundant retry logic from test code, and
modifies the `checkPools()` helper to accept an optional list of
pools to check instead of looking at all pools in the system.