### PR TITLE
DAOS-8280 array: deprecate daos_array_generate_id in favor of new API

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -34,7 +34,7 @@ def get_version():
         return version_file.read().rstrip()
 
 API_VERSION_MAJOR = "1"
-API_VERSION_MINOR = "3"
+API_VERSION_MINOR = "4"
 API_VERSION_FIX = "0"
 API_VERSION = "{}.{}.{}".format(API_VERSION_MAJOR, API_VERSION_MINOR,
                                 API_VERSION_FIX)

--- a/src/include/daos_array.h
+++ b/src/include/daos_array.h
@@ -45,6 +45,7 @@ typedef struct {
 } daos_array_iod_t;
 
 /**
+ * Deprecated - use daos_array_generate_oid()
  * Convenience function to generate a DAOS object ID by encoding the private
  * DAOS bits of the object address space.
  *
@@ -60,9 +61,8 @@ typedef struct {
  *			be stored in the obj (true).
  * \param[in]	args	Reserved.
  */
-static inline int
-daos_array_generate_id(daos_obj_id_t *oid, daos_oclass_id_t cid, bool add_attr,
-		       uint32_t args)
+static inline int  __attribute__ ((deprecated))
+daos_array_generate_id(daos_obj_id_t *oid, daos_oclass_id_t cid, bool add_attr, uint32_t args)
 {
 	static daos_ofeat_t	feat;
 	uint64_t		hdr;
@@ -89,6 +89,42 @@ daos_array_generate_id(daos_obj_id_t *oid, daos_oclass_id_t cid, bool add_attr,
 	oid->hi |= hdr;
 
 	return 0;
+}
+
+/**
+ * Convenience function to generate a DAOS Array object ID by encoding the private DAOS bits of the
+ * object address space.
+ *
+ * \param[in]	coh	Container open handle.
+ * \param[in,out]
+ *		oid	[in]: Object ID with low 96 bits set and unique inside the container.
+ *			[out]: Fully populated DAOS object identifier with the low 96 bits untouched
+ *			and the DAOS private bits (the high 32 bits) encoded.
+ * \param[in]	add_attr
+ *			Indicate whether the user would maintain the array cell and chunk size
+ *			(false), or the metadata should be stored in the obj (true).
+ * \param[in]	cid	Class Identifier. This setting is for advanced users who are knowledgeable
+ *			on the specific oclass being set and what that means for the object in the
+ *			current system and the container it's in. Setting this to 0 (unknown) will
+ *			check if there are any hints specified and use an oclass accordingly. If
+ *			there are no hints specified we use the container properties to select the
+ *			object class.
+ * \param[in]   hints	Optional hints to select oclass with redundancy type and sharding. This will
+ *			be ignored if cid is not OC_UNKNOWN (0).
+ * \param[in]	args	Reserved.
+ */
+static inline int
+daos_array_generate_oid(daos_handle_t coh, daos_obj_id_t *oid, bool add_attr, daos_oclass_id_t cid,
+			daos_oclass_hints_t hints, uint32_t args)
+{
+	static daos_ofeat_t	feat;
+
+	feat = DAOS_OF_DKEY_UINT64 | DAOS_OF_KV_FLAT;
+
+	if (add_attr)
+		feat = feat | DAOS_OF_ARRAY;
+
+	return daos_obj_generate_oid(coh, oid, feat, cid, hints, args);
 }
 
 /**

--- a/src/include/daos_obj.h
+++ b/src/include/daos_obj.h
@@ -312,8 +312,8 @@ typedef struct {
 } daos_key_desc_t;
 
 /**
- * Generate a DAOS object ID by encoding the private DAOS bits of the object
- * address space.
+ * Deprecated - use daos_obj_generate_oid()
+ * Generate a DAOS object ID by encoding the private DAOS bits of the object address space.
  *
  * \param[in,out]
  *		oid	[in]: Object ID with low 96 bits set and unique inside

--- a/src/tests/simple_obj.c
+++ b/src/tests/simple_obj.c
@@ -486,7 +486,7 @@ example_daos_array()
 	 * daos_obj_generate_oid() that adds the required feature flags for an
 	 * array: DAOS_OF_DKEY_UINT64 | DAOS_OF_KV_FLAT | DAOS_OF_ARRAY
 	 */
-	daos_array_generate_id(&oid, OC_SX, true, 0);
+	daos_array_generate_oid(coh, &oid, true, 0, 0, 0);
 
 	/*
 	 * Create the array object with cell size 1 (byte array) and 1m chunk


### PR DESCRIPTION
daos_array_generate_id() still requires the oclass. Deprecate that in
favor of a new convenience API for array oid generation:
daos_array_generate_oid() that makes the oclass optional and uses the
container properties and rf factor if oclass is unknown.

Signed-off-by: Mohamad Chaarawi <mohamad.chaarawi@intel.com>