### PR TITLE
DAOS-8219 tools: Fix permissions in daos tool

### DIFF
--- a/src/control/cmd/daos/acl.go
+++ b/src/control/cmd/daos/acl.go
@@ -117,7 +117,7 @@ func (cmd *containerOverwriteACLCmd) Execute(args []string) error {
 	}
 	defer deallocCmdArgs()
 
-	cleanup, err := cmd.resolveAndConnect(ap)
+	cleanup, err := cmd.resolveAndConnect(C.DAOS_COO_RW, ap)
 	if err != nil {
 		return err
 	}
@@ -154,7 +154,7 @@ func (cmd *containerUpdateACLCmd) Execute(args []string) error {
 	}
 	defer deallocCmdArgs()
 
-	cleanup, err := cmd.resolveAndConnect(ap)
+	cleanup, err := cmd.resolveAndConnect(C.DAOS_COO_RW, ap)
 	if err != nil {
 		return err
 	}
@@ -192,7 +192,7 @@ func (cmd *containerDeleteACLCmd) Execute(args []string) error {
 	}
 	defer deallocCmdArgs()
 
-	cleanup, err := cmd.resolveAndConnect(ap)
+	cleanup, err := cmd.resolveAndConnect(C.DAOS_COO_RW, ap)
 	if err != nil {
 		return err
 	}
@@ -237,7 +237,7 @@ type containerGetACLCmd struct {
 }
 
 func (cmd *containerGetACLCmd) Execute(args []string) error {
-	cleanup, err := cmd.resolveAndConnect(nil)
+	cleanup, err := cmd.resolveAndConnect(C.DAOS_COO_RO, nil)
 	if err != nil {
 		return err
 	}
@@ -294,7 +294,7 @@ func (cmd *containerSetOwnerCmd) Execute(args []string) error {
 	}
 	defer deallocCmdArgs()
 
-	cleanup, err := cmd.resolveAndConnect(ap)
+	cleanup, err := cmd.resolveAndConnect(C.DAOS_COO_RW, ap)
 	if err != nil {
 		return err
 	}

--- a/src/control/cmd/daos/container.go
+++ b/src/control/cmd/daos/container.go
@@ -796,7 +796,7 @@ func (cmd *containerCheckCmd) Execute(_ []string) error {
 	}
 	defer deallocCmdArgs()
 
-	cleanup, err := cmd.resolveAndConnect(C.DAOS_COO_RO, ap)
+	cleanup, err := cmd.resolveAndConnect(C.DAOS_COO_RW, ap)
 	if err != nil {
 		return err
 	}

--- a/src/control/cmd/daos/filesystem.go
+++ b/src/control/cmd/daos/filesystem.go
@@ -80,6 +80,7 @@ func (cmd *fsAttrCmd) Execute(_ []string) error {
 	}
 	defer deallocCmdArgs()
 
+	flags := C.uint(C.DAOS_COO_RW)
 	op := os.Args[2]
 	switch op {
 	case "set-attr":
@@ -92,6 +93,7 @@ func (cmd *fsAttrCmd) Execute(_ []string) error {
 		}
 	case "get-attr":
 		ap.fs_op = C.FS_GET_ATTR
+		flags = C.DAOS_COO_RO
 	case "reset-attr":
 		ap.fs_op = C.FS_RESET_ATTR
 	case "reset-chunk-size":
@@ -110,7 +112,7 @@ func (cmd *fsAttrCmd) Execute(_ []string) error {
 		return errors.Errorf("unknown fs op %q", op)
 	}
 
-	cleanup, err := cmd.resolveAndConnect(ap)
+	cleanup, err := cmd.resolveAndConnect(flags, ap)
 	if err != nil {
 		return err
 	}

--- a/src/control/cmd/daos/object.go
+++ b/src/control/cmd/daos/object.go
@@ -62,7 +62,7 @@ func (cmd *objQueryCmd) Execute(_ []string) error {
 	}
 	defer deallocCmdArgs()
 
-	cleanup, err := cmd.resolveAndConnect(ap)
+	cleanup, err := cmd.resolveAndConnect(C.DAOS_COO_RO, ap)
 	if err != nil {
 		return err
 	}

--- a/src/control/cmd/daos/pool.go
+++ b/src/control/cmd/daos/pool.go
@@ -61,7 +61,7 @@ func (cmd *poolBaseCmd) PoolID() PoolID {
 	return cmd.Args.Pool
 }
 
-func (cmd *poolBaseCmd) connectPool() error {
+func (cmd *poolBaseCmd) connectPool(flags C.uint) error {
 	sysName := cmd.SysName
 	if sysName == "" {
 		sysName = build.DefaultSystemName
@@ -77,7 +77,7 @@ func (cmd *poolBaseCmd) connectPool() error {
 		defer freeString(cLabel)
 
 		cmd.log.Debugf("connecting to pool: %s", cmd.PoolID().Label)
-		rc = C.daos_pool_connect2(cLabel, cSysName, C.DAOS_PC_RW,
+		rc = C.daos_pool_connect2(cLabel, cSysName, flags,
 			&cmd.cPoolHandle, &poolInfo, nil)
 		if rc == 0 {
 			var err error
@@ -92,7 +92,7 @@ func (cmd *poolBaseCmd) connectPool() error {
 		cmd.log.Debugf("connecting to pool: %s", cmd.poolUUID)
 		cUUIDstr := C.CString(cmd.poolUUID.String())
 		defer freeString(cUUIDstr)
-		rc = C.daos_pool_connect2(cUUIDstr, cSysName, C.DAOS_PC_RW,
+		rc = C.daos_pool_connect2(cUUIDstr, cSysName, flags,
 			&cmd.cPoolHandle, nil, nil)
 	default:
 		return errors.New("no pool UUID or label supplied")
@@ -116,8 +116,8 @@ func (cmd *poolBaseCmd) disconnectPool() {
 	}
 }
 
-func (cmd *poolBaseCmd) resolveAndConnect(ap *C.struct_cmd_args_s) (func(), error) {
-	if err := cmd.connectPool(); err != nil {
+func (cmd *poolBaseCmd) resolveAndConnect(flags C.uint, ap *C.struct_cmd_args_s) (func(), error) {
+	if err := cmd.connectPool(flags); err != nil {
 		return nil, errors.Wrapf(err,
 			"failed to connect to pool %s", cmd.PoolID())
 	}
@@ -227,7 +227,7 @@ const (
 )
 
 func (cmd *poolQueryCmd) Execute(_ []string) error {
-	cleanup, err := cmd.resolveAndConnect(nil)
+	cleanup, err := cmd.resolveAndConnect(C.DAOS_PC_RO, nil)
 	if err != nil {
 		return err
 	}
@@ -268,7 +268,7 @@ type poolListAttrsCmd struct {
 }
 
 func (cmd *poolListAttrsCmd) Execute(_ []string) error {
-	cleanup, err := cmd.resolveAndConnect(nil)
+	cleanup, err := cmd.resolveAndConnect(C.DAOS_PC_RO, nil)
 	if err != nil {
 		return err
 	}
@@ -302,7 +302,7 @@ type poolGetAttrCmd struct {
 }
 
 func (cmd *poolGetAttrCmd) Execute(_ []string) error {
-	cleanup, err := cmd.resolveAndConnect(nil)
+	cleanup, err := cmd.resolveAndConnect(C.DAOS_PC_RO, nil)
 	if err != nil {
 		return err
 	}
@@ -338,7 +338,7 @@ type poolSetAttrCmd struct {
 }
 
 func (cmd *poolSetAttrCmd) Execute(_ []string) error {
-	cleanup, err := cmd.resolveAndConnect(nil)
+	cleanup, err := cmd.resolveAndConnect(C.DAOS_PC_RW, nil)
 	if err != nil {
 		return err
 	}
@@ -365,7 +365,7 @@ type poolDelAttrCmd struct {
 }
 
 func (cmd *poolDelAttrCmd) Execute(_ []string) error {
-	cleanup, err := cmd.resolveAndConnect(nil)
+	cleanup, err := cmd.resolveAndConnect(C.DAOS_PC_RW, nil)
 	if err != nil {
 		return err
 	}
@@ -391,7 +391,7 @@ func (cmd *poolAutoTestCmd) Execute(_ []string) error {
 	}
 	defer deallocCmdArgs()
 
-	cleanup, err := cmd.resolveAndConnect(nil)
+	cleanup, err := cmd.resolveAndConnect(C.DAOS_PC_RW, nil)
 	if err != nil {
 		return err
 	}

--- a/src/control/cmd/daos/snapshot.go
+++ b/src/control/cmd/daos/snapshot.go
@@ -29,7 +29,7 @@ func (cmd *containerSnapshotCreateCmd) Execute(args []string) error {
 	}
 	defer deallocCmdArgs()
 
-	cleanup, err := cmd.resolveAndConnect(ap)
+	cleanup, err := cmd.resolveAndConnect(C.DAOS_COO_RW, ap)
 	if err != nil {
 		return err
 	}
@@ -66,7 +66,7 @@ func (cmd *containerSnapshotDestroyCmd) Execute(args []string) error {
 	}
 	defer deallocCmdArgs()
 
-	cleanup, err := cmd.resolveAndConnect(nil)
+	cleanup, err := cmd.resolveAndConnect(C.DAOS_COO_RW, nil)
 	if err != nil {
 		return err
 	}
@@ -100,7 +100,7 @@ func (cmd *containerSnapshotListCmd) Execute(args []string) error {
 	}
 	defer deallocCmdArgs()
 
-	cleanup, err := cmd.resolveAndConnect(ap)
+	cleanup, err := cmd.resolveAndConnect(C.DAOS_COO_RO, ap)
 	if err != nil {
 		return err
 	}
@@ -130,7 +130,7 @@ func (cmd *containerSnapshotRollbackCmd) Execute(args []string) error {
 	}
 	defer deallocCmdArgs()
 
-	cleanup, err := cmd.resolveAndConnect(ap)
+	cleanup, err := cmd.resolveAndConnect(C.DAOS_COO_RW, ap)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Request only the level of permissions necessary for the task, to
avoid pool/container connect failures for users with RO access.

Feature: pool,container,snap,dfuse,security

Signed-off-by: Kris Jacque <kristin.jacque@intel.com>