### PR TITLE
DAOS-8108 vea: allow interleaved reserve calls

### DIFF
--- a/src/vea/tests/vea_ut.c
+++ b/src/vea/tests/vea_ut.c
@@ -1026,6 +1026,7 @@ ut_interleaved_ops(void **state)
 	 * 6. reserve A, reserve B, publish B, cancel A
 	 * 7. reserve A, reserve B, cancel A, cancel B
 	 * 8. reserve A, reserve B, cancel B, cancel A
+	 * 9. reserve A, reserve B, reserve C, publish B, publish A & C
 	 **/
 	block_count = 2;
 	r_list_a = &args.vua_resrvd_list[0];
@@ -1128,6 +1129,24 @@ ut_interleaved_ops(void **state)
 	assert_int_equal(rc, 0);
 	rc = vea_cancel(args.vua_vsi, h_ctxt, r_list_a);
 	assert_int_equal(rc, 0);
+
+	/* Case 9 */
+	block_count = 2;
+	/* Reserve A */
+	rc = vea_reserve(args.vua_vsi, block_count, h_ctxt, r_list_a);
+	assert_rc_equal(rc, 0);
+	/* Reserve B */
+	rc = vea_reserve(args.vua_vsi, block_count, h_ctxt, r_list_b);
+	assert_rc_equal(rc, 0);
+	/* Reserve C */
+	rc = vea_reserve(args.vua_vsi, block_count, h_ctxt, r_list_a);
+	assert_rc_equal(rc, 0);
+	/* Publish B */
+	rc = vea_tx_publish(args.vua_vsi, h_ctxt, r_list_b);
+	assert_rc_equal(rc, 0);
+	/* Publish A & C */
+	rc = vea_tx_publish(args.vua_vsi, h_ctxt, r_list_a);
+	assert_rc_equal(rc, 0);
 
 	rc = umem_tx_commit(&args.vua_umm);
 	assert_int_equal(rc, 0);

--- a/src/vea/vea_api.c
+++ b/src/vea/vea_api.c
@@ -373,6 +373,7 @@ process_resrvd_list(struct vea_space_info *vsi, struct vea_hint_context *hint,
 	uint64_t		 seq_max = 0, seq_min = 0;
 	uint64_t		 off_c = 0, off_p = 0;
 	uint64_t		 cur_time;
+	unsigned int		 seq_cnt = 0;
 	int			 rc = 0;
 
 	if (d_list_empty(resrvd_list))
@@ -398,6 +399,7 @@ process_resrvd_list(struct vea_space_info *vsi, struct vea_hint_context *hint,
 			D_ASSERT(seq_min < resrvd->vre_hint_seq);
 		}
 
+		seq_cnt++;
 		seq_max = resrvd->vre_hint_seq;
 		off_p = resrvd->vre_blk_off + resrvd->vre_blk_cnt;
 
@@ -427,8 +429,8 @@ process_resrvd_list(struct vea_space_info *vsi, struct vea_hint_context *hint,
 	}
 
 	rc = publish ? hint_tx_publish(vsi->vsi_umem, hint, off_p, seq_min,
-				       seq_max) :
-		       hint_cancel(hint, off_c, seq_min, seq_max);
+				       seq_max, seq_cnt) :
+		       hint_cancel(hint, off_c, seq_min, seq_max, seq_cnt);
 error:
 	d_list_for_each_entry_safe(resrvd, tmp, resrvd_list, vre_link) {
 		d_list_del_init(&resrvd->vre_link);

--- a/src/vea/vea_internal.h
+++ b/src/vea/vea_internal.h
@@ -175,8 +175,9 @@ void migrate_free_exts(struct vea_space_info *vsi, bool add_tx_cb);
 void hint_get(struct vea_hint_context *hint, uint64_t *off);
 void hint_update(struct vea_hint_context *hint, uint64_t off, uint64_t *seq);
 int hint_cancel(struct vea_hint_context *hint, uint64_t off, uint64_t seq_min,
-		uint64_t seq_max);
+		uint64_t seq_max, unsigned int seq_cnt);
 int hint_tx_publish(struct umem_instance *umm, struct vea_hint_context *hint,
-		    uint64_t off, uint64_t seq_min, uint64_t seq_max);
+		    uint64_t off, uint64_t seq_min, uint64_t seq_max,
+		    unsigned int seq_cnt);
 
 #endif /* __VEA_INTERNAL_H__ */


### PR DESCRIPTION
vea_reserve() may yield when free extents unmap triggered internally,
so the following interleaved reserve calls could happen:

ULT A reserve 1 then yield, ULT B reserve 2 & publish 2, ULT A
continue to reserve 3 and publish 1 & 3.

This patch adjusted hit publish/cancel functions to tolerate above
interleaved reserve calls.

Signed-off-by: Niu Yawei <yawei.niu@intel.com>