### PR TITLE
DAOS-8264 dfuse: Return correct error value from read/write.

### DIFF
--- a/src/client/dfuse/ops/read.c
+++ b/src/client/dfuse/ops/read.c
@@ -24,8 +24,7 @@ dfuse_cb_read_complete(struct dfuse_event *ev)
 
 		DFUSE_REPLY_BUF(ev, ev->de_req, ev->de_iov.iov_buf, ev->de_len);
 	} else {
-		DFUSE_REPLY_ERR_RAW(ev, ev->de_req,
-				    daos_der2errno(ev->de_ev.ev_error));
+		DFUSE_REPLY_ERR_RAW(ev, ev->de_req, ev->de_ev.ev_error);
 	}
 	D_FREE(ev->de_iov.iov_buf);
 }

--- a/src/client/dfuse/ops/write.c
+++ b/src/client/dfuse/ops/write.c
@@ -13,8 +13,7 @@ dfuse_cb_write_complete(struct dfuse_event *ev)
 	if (ev->de_ev.ev_error == 0)
 		DFUSE_REPLY_WRITE(ev, ev->de_req, ev->de_len);
 	else
-		DFUSE_REPLY_ERR_RAW(ev, ev->de_req,
-				    daos_der2errno(ev->de_ev.ev_error));
+		DFUSE_REPLY_ERR_RAW(ev, ev->de_req, ev->de_ev.ev_error);
 	D_FREE(ev->de_iov.iov_buf);
 }
 


### PR DESCRIPTION
If a operation is accepted but then fails the dfs already returns
a system error number so do not attempt to convert it again.

With this change ENOSPACE is correctly reported, instead of EIO

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>
