### PR TITLE
DAOS-5692 tools: Use fflush() on stream cleanup

### DIFF
--- a/src/control/cmd/daos/util.go
+++ b/src/control/cmd/daos/util.go
@@ -171,8 +171,8 @@ func createWriteStream(prefix string, printLn func(line string)) (*C.FILE, func(
 	}(prefix)
 
 	return stream, func() {
+		C.fflush(stream)
 		C.fclose(stream)
-		C.sync()
 	}, nil
 }
 


### PR DESCRIPTION
When cleaning up the handler output stream, call fflush()
on the stream before closing it.
