### PR TITLE
DAOS-8183 engine: Correctly size label buffers

### DIFF
--- a/src/container/srv_container.c
+++ b/src/container/srv_container.c
@@ -393,7 +393,7 @@ cont_existence_check(struct rdb_tx *tx, struct cont_svc *svc,
 	/* Label provided in request - search for it in cs_uuids KVS
 	 * and perform additional sanity checks.
 	 */
-	d_iov_set(&key, clabel, strnlen(clabel, DAOS_PROP_LABEL_MAX_LEN + 1));
+	d_iov_set(&key, clabel, strnlen(clabel, DAOS_PROP_MAX_LABEL_BUF_LEN));
 	d_iov_set(&val, match_cuuid, sizeof(uuid_t));
 	rc = rdb_tx_lookup(tx, &svc->cs_uuids, &key, &val);
 	if (rc != -DER_NONEXIST) {
@@ -837,7 +837,7 @@ cont_create(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl,
 		/* If we have come this far (see existence check), there must
 		 * not be an entry with this label in cs_uuids. Just update.
 		 */
-		d_iov_set(&key, lbl, strnlen(lbl, DAOS_PROP_LABEL_MAX_LEN + 1));
+		d_iov_set(&key, lbl, strnlen(lbl, DAOS_PROP_MAX_LABEL_BUF_LEN));
 		d_iov_set(&value, in->cci_op.ci_uuid, sizeof(uuid_t));
 		rc = rdb_tx_update(tx, &svc->cs_uuids, &key, &value);
 		if (rc != 0) {
@@ -1142,7 +1142,7 @@ cont_destroy(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl,
 	lbl_ent = daos_prop_entry_get(prop, DAOS_PROP_CO_LABEL);
 	if (lbl_ent) {
 		d_iov_set(&key, lbl_ent->dpe_str,
-			  strnlen(lbl_ent->dpe_str, DAOS_PROP_LABEL_MAX_LEN + 1));
+			  strnlen(lbl_ent->dpe_str, DAOS_PROP_MAX_LABEL_BUF_LEN));
 		d_iov_set(&val, NULL, 0);
 		rc = rdb_tx_lookup(tx, &cont->c_svc->cs_uuids, &key, &val);
 		if (rc != -DER_NONEXIST) {
@@ -1553,7 +1553,7 @@ cont_lookup_bylabel(struct rdb_tx *tx, const struct cont_svc *svc,
 	d_iov_t		val;
 	int		rc;
 
-	label_len = strnlen(label, DAOS_PROP_LABEL_MAX_LEN + 1);
+	label_len = strnlen(label, DAOS_PROP_MAX_LABEL_BUF_LEN);
 	if (!label || (label_len == 0) || (label_len > DAOS_PROP_LABEL_MAX_LEN))
 		return -DER_INVAL;
 
@@ -2655,7 +2655,7 @@ check_set_prop_label(struct rdb_tx *tx, struct ds_pool *pool, struct cont *cont,
 		return 0;
 
 	/* Remove old label from cs_uuids KVS, if applicable */
-	d_iov_set(&key, old_lbl, strnlen(old_lbl, DAOS_PROP_LABEL_MAX_LEN + 1));
+	d_iov_set(&key, old_lbl, strnlen(old_lbl, DAOS_PROP_MAX_LABEL_BUF_LEN));
 	d_iov_set(&val, match_cuuid, sizeof(uuid_t));
 	rc = rdb_tx_lookup(tx, &cont->c_svc->cs_uuids, &key, &val);
 	if (rc != -DER_NONEXIST) {
@@ -2676,7 +2676,7 @@ check_set_prop_label(struct rdb_tx *tx, struct ds_pool *pool, struct cont *cont,
 	}
 
 	/* Insert new label into cs_uuids KVS, fail if already in use */
-	d_iov_set(&key, in_lbl, strnlen(in_lbl, DAOS_PROP_LABEL_MAX_LEN + 1));
+	d_iov_set(&key, in_lbl, strnlen(in_lbl, DAOS_PROP_MAX_LABEL_BUF_LEN));
 	d_iov_set(&val, match_cuuid, sizeof(uuid_t));
 	rc = rdb_tx_lookup(tx, &cont->c_svc->cs_uuids, &key, &val);
 	if (rc != -DER_NONEXIST) {

--- a/src/container/srv_internal.h
+++ b/src/container/srv_internal.h
@@ -122,7 +122,7 @@ struct cont_iv_capa {
 
 /* flattened container properties */
 struct cont_iv_prop {
-	char		cip_label[DAOS_PROP_LABEL_MAX_LEN];
+	char		cip_label[DAOS_PROP_MAX_LABEL_BUF_LEN];
 	char		cip_owner[DAOS_ACL_MAX_PRINCIPAL_BUF_LEN];
 	char		cip_owner_grp[DAOS_ACL_MAX_PRINCIPAL_BUF_LEN];
 	uint64_t	cip_layout_type;

--- a/src/include/daos_prop.h
+++ b/src/include/daos_prop.h
@@ -358,6 +358,8 @@ struct daos_prop_entry {
 
 /** max length for pool/container label - NB: POOL_LIST_CONT RPC wire format */
 #define DAOS_PROP_LABEL_MAX_LEN		(127)
+/** DAOS_PROP_LABEL_MAX_LEN including NULL terminator */
+#define DAOS_PROP_MAX_LABEL_BUF_LEN	(DAOS_PROP_LABEL_MAX_LEN + 1)
 
 /**
  * Check if DAOS (pool or container property) label string is valid.

--- a/src/pool/srv_internal.h
+++ b/src/pool/srv_internal.h
@@ -51,7 +51,7 @@ struct pool_iv_map {
 
 /* The structure to serialize the prop for IV */
 struct pool_iv_prop {
-	char		pip_label[DAOS_PROP_LABEL_MAX_LEN];
+	char		pip_label[DAOS_PROP_MAX_LABEL_BUF_LEN];
 	char		pip_owner[DAOS_ACL_MAX_PRINCIPAL_BUF_LEN];
 	char		pip_owner_grp[DAOS_ACL_MAX_PRINCIPAL_BUF_LEN];
 	uint64_t	pip_space_rb;

--- a/src/tests/ftest/pool/label.py
+++ b/src/tests/ftest/pool/label.py
@@ -6,7 +6,7 @@
 """
 import string
 
-from apricot import TestWithServers, skipForTicket
+from apricot import TestWithServers
 from avocado.core.exceptions import TestFail
 from general_utils import report_errors, get_random_string
 from command_utils_base import CommandFailure
@@ -99,14 +99,12 @@ class Label(TestWithServers):
 
         return errors
 
-    @skipForTicket("DAOS-8183")
     def test_valid_labels(self):
         """Test ID: DAOS-7942
 
         Test Description: Create and destroy pool with the following labels.
         * Random alpha numeric string of length 126.
         * Random alpha numeric string of length 127.
-        * Random alpha numeric string of length 128.
         * Random upper case string of length 50.
         * Random lower case string of length 50.
         * Random number string of length 50.
@@ -120,7 +118,6 @@ class Label(TestWithServers):
         labels = [
             get_random_string(126),
             get_random_string(127),
-            get_random_string(128),
             get_random_string(length=50, include=string.ascii_uppercase),
             get_random_string(length=50, include=string.ascii_lowercase),
             get_random_string(length=50, include=string.digits)
@@ -137,7 +134,7 @@ class Label(TestWithServers):
 
         Test Description: Create pool with following invalid labels.
         * UUID format string: 23ab123e-5296-4f95-be14-641de40b4d5a
-        * Long label - 129 random chars.
+        * Long label - 128 random chars.
 
         :avocado: tags=all,full_regression
         :avocado: tags=small
@@ -147,7 +144,7 @@ class Label(TestWithServers):
         errors = []
         label_outs = [
             ("23ab123e-5296-4f95-be14-641de40b4d5a", "invalid label"),
-            (get_random_string(129), "value too long")
+            (get_random_string(128), "invalid label")
         ]
 
         for label_out in label_outs:


### PR DESCRIPTION
Add a new #define (DAOS_PROP_MAX_LABEL_BUF_LEN) to indicate
the max size of a buffer that can hold a label plus a trailing
NULL to terminate the string. Fixes a crash found with label
boundary testing.

Re-enables testing for invalid pool labels (DAOS-8205).