### PR TITLE
DAOS-8055 utils: Separate daos_perf and vos_perf

### DIFF
--- a/src/tests/SConscript
+++ b/src/tests/SConscript
@@ -9,13 +9,13 @@ def scons():
     if not prereqs.test_requested():
         return
 
-    libs = ['daos', 'daos_common_pmem', 'gurt', 'm', 'cart', 'uuid', 'cmocka',
-            'daos_tests']
+    libs_client = ['daos', 'daos_common', 'gurt', 'm', 'cart', 'uuid', 'cmocka', 'daos_tests']
+    libs_server = ['daos', 'daos_common_pmem', 'gurt', 'm', 'cart', 'uuid', 'cmocka', 'daos_tests']
 
     denv = base_env.Clone()
 
     if not GetOption('help') and not GetOption('clean'):
-        mpi = daos_build.configure_mpi(denv, libs)
+        mpi = daos_build.configure_mpi(denv, libs_client)
         if mpi is None:
             print("\nSkipping compilation for tests that need MPI")
             print("Install and load mpich or openmpi\n")
@@ -27,37 +27,38 @@ def scons():
     denv.Append(CPPPATH=[Dir('suite').srcnode()])
     prereqs.require(denv, 'argobots', 'hwloc', 'protobufc', 'pmdk', 'isal')
 
-    daos_build.program(denv, 'simple_array', 'simple_array.c', LIBS=libs)
-    daos_build.program(denv, 'simple_obj', 'simple_obj.c', LIBS=libs)
-    libs += ['pthread', 'dts']
+    daos_build.program(denv, 'simple_array', 'simple_array.c', LIBS=libs_client)
+    daos_build.program(denv, 'simple_obj', 'simple_obj.c', LIBS=libs_client)
+    libs_client += ['pthread', 'dts']
+    libs_server += ['pthread', 'dts']
 
     daos_racer = daos_build.program(denv, 'daos_racer',
                                     ['daos_racer.c'],
-                                    LIBS=libs)
+                                    LIBS=libs_client)
     denv.Install('$PREFIX/bin/', daos_racer)
 
     perf_common = denv.StaticObject(['perf_common.c'])
 
     daos_perf = daos_build.program(denv, 'daos_perf',
                                    ['daos_perf.c', perf_common],
-                                   LIBS = libs)
+                                   LIBS=libs_client)
     denv.Install('$PREFIX/bin/', daos_perf)
 
-    libs += ['vos', 'bio', 'abt']
+    libs_server += ['vos', 'bio', 'abt']
     vos_engine = denv.StaticObject(['vos_engine.c'])
 
     vos_perf = daos_build.program(denv, 'vos_perf',
                                   ['vos_perf.c', perf_common, vos_engine],
-                                  LIBS = libs)
+                                  LIBS=libs_server)
     denv.Install('$PREFIX/bin/', vos_perf)
 
     Import('mpi_cmd_parser')
     obj_ctl = daos_build.program(denv, 'obj_ctl',
                                  ['obj_ctl.c', mpi_cmd_parser, vos_engine],
-                                 LIBS=libs)
+                                 LIBS=libs_server)
     denv.Install('$PREFIX/bin/', obj_ctl)
 
-    jobtest = daos_build.program(denv, 'jobtest', ['jobtest.c'], LIBS=libs)
+    jobtest = daos_build.program(denv, 'jobtest', ['jobtest.c'], LIBS=libs_client)
     denv.Install('$PREFIX/bin/', jobtest)
 
     # tests


### PR DESCRIPTION
Simple change to ensure client apps don't depend on server libraries (e.g. libdaos_common_pmem.so)

Signed-off-by: Niu Yawei <yawei.niu@intel.com>
Co-authored-by: Jeff Olivier <jeffrey.v.olivier@intel.com>