### PR TITLE
DAOS-8303 control: return error if provider validate failed

### DIFF
--- a/src/control/lib/netdetect/netdetect.go
+++ b/src/control/lib/netdetect/netdetect.go
@@ -913,6 +913,7 @@ func ValidateProviderStub(ctx context.Context, device string, provider string) e
 	err := ValidateProviderConfig(ctx, device, provider)
 	if err != nil {
 		log.Debugf("ValidateProviderConfig (device: %s, provider %s) returned error: %v", device, provider, err)
+		return err
 	}
 	return nil
 }


### PR DESCRIPTION
daos_server could still start with a invalid provider,
problem is if validation failed, error should be returned
to caller.

Signed-off-by: Wang Shilong <shilong.wang@intel.com>