### PR TITLE
DAOS-8001 tools: Snapshot destroy fails due to null handle

### DIFF
--- a/src/control/cmd/daos/snapshot.go
+++ b/src/control/cmd/daos/snapshot.go
@@ -101,7 +101,7 @@ func (cmd *containerSnapshotDestroyCmd) Execute(args []string) error {
 		return errors.New("must specify one of snapshot name or epoch or epoch range")
 	}
 
-	cleanup, err := cmd.resolveAndConnect(C.DAOS_COO_RW, nil)
+	cleanup, err := cmd.resolveAndConnect(C.DAOS_COO_RW, ap)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This was fixed in #6356 but accidentally reverted while
resolving a merge conflict.

Test-tag: pr snapshot_aggregation