### PR TITLE
DAOS-8297 test: Use TestPool and label for tests that use DmgCommand …

### DIFF
--- a/src/tests/ftest/container/list_containers.yaml
+++ b/src/tests/ftest/container/list_containers.yaml
@@ -4,3 +4,6 @@ hosts:
 timeout: 140
 server_config:
   name: daos_server
+pool:
+  control_method: dmg
+  size: 150MB

--- a/src/tests/ftest/pool/multi_server_create_delete_test.yaml
+++ b/src/tests/ftest/pool/multi_server_create_delete_test.yaml
@@ -1,11 +1,15 @@
-# change host names to your reserved nodes, the
-# required quantity is indicated by the placeholders
 hosts:
   test_servers:
     - server-A
     - server-B
+
 server_config:
   name: daos_server
+
+pool:
+  control_method: dmg
+  size: 1GB
+
 tests:
   users: !mux
     validuser:
@@ -20,6 +24,7 @@ tests:
       user:
         - nfsnobody
         - PASS
+
   groups: !mux
     validgroup:
       group:
@@ -33,15 +38,7 @@ tests:
       group:
         - nfsnobody
         - PASS
-  systemnames: !mux
-    validsystemname:
-      systemname:
-        - daos_server
-        - PASS
-    badsetname:
-      systemname:
-        - complete_rubbish
-        - FAIL
+
   tgtlist: !mux
     firsttgt:
       tgt:

--- a/src/tests/ftest/server/daos_server_restart.py
+++ b/src/tests/ftest/server/daos_server_restart.py
@@ -4,8 +4,6 @@
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
-
-
 from avocado import fail_on
 from apricot import TestWithServers
 from daos_utils import DaosCommand
@@ -21,7 +19,6 @@ class DaosServerTest(TestWithServers):
 
     :avocado: recursive
     """
-
     @fail_on(ServerFailed)
     @fail_on(CommandFailure)
     def restart_daos_server(self, reformat=True):
@@ -79,13 +76,12 @@ class DaosServerTest(TestWithServers):
         num_of_pool = self.params.get("num_of_pool", "/run/server/*/", 3)
         container_per_pool = self.params.get(
             "container_per_pool", "/run/server/*/", 2)
+
         for _ in range(num_of_pool):
-            dmg = self.get_dmg_command()
-            result = dmg.pool_create(scm_size)
-            uuid = result['uuid']
+            self.pool.append(self.get_pool(connect=False))
             daos_cmd = DaosCommand(self.bin)
             for _ in range(container_per_pool):
-                result = daos_cmd.container_create(pool=uuid)
+                result = daos_cmd.container_create(pool=self.pool[-1].uuid)
                 self.log.info("container create status: %s", result)
 
     def test_daos_server_reformat(self):
@@ -101,9 +97,12 @@ class DaosServerTest(TestWithServers):
         (5)Verify after DAOS server restarted, it should appear as an empty
            fresh installation.
 
-        :avocado: tags=all,daily_regression,hw,large,server_test
-        :avocado: tags=server_reformat,DAOS_5610
+        :avocado: tags=all,daily_regression
+        :avocado: tags=hw,large
+        :avocado: tags=server_test,server_reformat,DAOS_5610
         """
+        self.pool = []
+
         self.log.info("(1)Verify daos server pool list after started.")
         self.verify_pool_list()
         self.log.info("(2)Restart server without pool created and verify.")
@@ -132,9 +131,12 @@ class DaosServerTest(TestWithServers):
         (5)Use the cmd line to perform a controlled shutdown when the
            daos cluster is incomplete (i.e. 1 of the 2 servers is down).
 
-        :avocado: tags=all,daily_regression,hw,large,server_test
-        :avocado: tags=server_restart,DAOS_5610
+        :avocado: tags=all,daily_regression
+        :avocado: tags=hw,large
+        :avocado: tags=server_test,server_restart,DAOS_5610
         """
+        self.pool = []
+
         self.log.info(
             "(1)Shutdown and restart the daos engine "
             "from a quiescent state.")

--- a/src/tests/ftest/server/daos_server_restart.py
+++ b/src/tests/ftest/server/daos_server_restart.py
@@ -26,7 +26,6 @@ class DaosServerTest(TestWithServers):
 
         Args:
             reformat (bool): always reformat storage, could be destructive.
-
         """
         self.log.info("=Restart daos_server, server stop().")
         self.server_managers[0].stop()
@@ -47,7 +46,6 @@ class DaosServerTest(TestWithServers):
         Args:
             force (bool): Force to stop the daos engine.
             Defaults to True.
-
         """
         self.server_managers[0].dmg.system_stop(force)
         self.server_managers[0].dmg.system_start()
@@ -114,6 +112,8 @@ class DaosServerTest(TestWithServers):
         self.restart_daos_server()
         self.log.info("(5)Verify after server restarted.")
         self.verify_pool_list()
+
+        self.pool = None
 
     def test_engine_restart(self):
         """JIRA ID: DAOS-3593.

--- a/src/tests/ftest/server/daos_server_restart.yaml
+++ b/src/tests/ftest/server/daos_server_restart.yaml
@@ -22,4 +22,4 @@ server:
 
 pool:
   control_method: dmg
-  size: 138000000
+  size: 1GB

--- a/src/tests/ftest/server/daos_server_restart.yaml
+++ b/src/tests/ftest/server/daos_server_restart.yaml
@@ -1,5 +1,3 @@
-# change host names to your reserved nodes, the
-# required quantity is indicated by the placeholders
 hosts:
   test_servers:
     - server-A
@@ -11,10 +9,17 @@ hosts:
   test_clients:
     - server-G
     - server-H
+
 timeout: 360
+
 server_config:
   name: daos_server
+
 server:
   scm_size: 138000000
   num_of_pool: 3
   container_per_pool: 2
+
+pool:
+  control_method: dmg
+  size: 138000000


### PR DESCRIPTION
…directly

Updated the tests to use TestPool and label instead of
directly calling the dmg command.

Skip-unit-tests: true
Test-tag: list_containers multiserver_create_delete server_reformat server_restart
Signed-off-by: Makito Kano <makito.kano@intel.com>