### PR TITLE
DAOS-8307 build: -Werror for go build

### DIFF
--- a/site_scons/prereq_tools/base.py
+++ b/site_scons/prereq_tools/base.py
@@ -827,6 +827,7 @@ class PreReqComponent():
             else:
                 warning_flag = '-Werror'
             self.__env.AppendUnique(CCFLAGS=warning_flag)
+            self.__env.AppendENVPath("CGO_CFLAGS", warning_flag, sep=" ")
 
         env = self.__env.Clone()
         config = Configure(env)

--- a/src/control/cmd/daos/util.h
+++ b/src/control/cmd/daos/util.h
@@ -8,6 +8,9 @@
 #define __CMD_DAOS_UTIL_H__
 
 #define D_LOGFAC	DD_FAC(client)
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
 
 #include <stdio.h>
 #include <stdlib.h>


### PR DESCRIPTION
A new C warning in the daos utility doesn't fail the build.  This sets
the -Werror flag in CGO_CFLAGS to fix that.

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>