### PR TITLE
DAOS-8008 control: set dpdk log masks to error

### DIFF
--- a/src/bio/bio_xstream.c
+++ b/src/bio/bio_xstream.c
@@ -93,12 +93,7 @@ bio_spdk_env_init(void)
 	if (nvme_glb.bd_shm_id != DAOS_NVME_SHMID_NONE)
 		opts.shm_id = nvme_glb.bd_shm_id;
 
-	/*
-	 * Disable DPDK telemetry to avoid socket file clashes and quiet DPDK
-	 * logging by setting level to ERROR.
-	 */
-	opts.env_context = "--log-level=lib.eal:4 --log-level=lib.user1:4"
-		" --no-telemetry";
+	opts.env_context = (char *)dpdk_cli_override_opts;
 
 	rc = spdk_env_init(&opts);
 	if (rc != 0) {

--- a/src/common/control.c
+++ b/src/common/control.c
@@ -15,8 +15,8 @@
  * logging by setting specific facility masks.
  */
 const char *
-dpdk_cli_override_opts = "--log-level=pmd:1 --log-level=lib.eal:4 "
-			 "--log-level=user1:4 --no-telemetry";
+spdk_cli_override_opts = "--log-level=pmd:3 --no-telemetry "
+			 "--log-level=lib.eal:4";
 
 int
 copy_ascii(char *dst, size_t dst_sz, const void *src, size_t src_sz)

--- a/src/common/control.c
+++ b/src/common/control.c
@@ -15,8 +15,7 @@
  * logging by setting specific facility masks.
  */
 const char *
-dpdk_cli_override_opts = "--log-level=pmd:3 --no-telemetry "
-			 "--log-level=lib.eal:4";
+dpdk_cli_override_opts = "--log-level=pmd:3";
 
 int
 copy_ascii(char *dst, size_t dst_sz, const void *src, size_t src_sz)

--- a/src/common/control.c
+++ b/src/common/control.c
@@ -15,7 +15,8 @@
  * logging by setting specific facility masks.
  */
 const char *
-dpdk_cli_override_opts = "--log-level=pmd:3";
+dpdk_cli_override_opts = "--log-level=pmd:3 --no-telemetry "
+			 "--log-level=lib.eal:4";
 
 int
 copy_ascii(char *dst, size_t dst_sz, const void *src, size_t src_sz)

--- a/src/common/control.c
+++ b/src/common/control.c
@@ -15,8 +15,36 @@
  * logging by setting specific facility masks.
  */
 const char *
-dpdk_cli_override_opts = "--log-level=pmd:3 --no-telemetry "
-			 "--log-level=lib.eal:4";
+dpdk_cli_override_opts = "--log-level=lib.eal:4 "
+			 "--log-level=lib.malloc:4 "
+			 "--log-level=lib.ring:4 "
+			 "--log-level=lib.mempool:4 "
+			 "--log-level=lib.timer:4 "
+			 "--log-level=pmd:4 "
+			 "--log-level=lib.hash:4 "
+			 "--log-level=lib.lpm:4 "
+			 "--log-level=lib.kni:4 "
+			 "--log-level=lib.acl:4 "
+			 "--log-level=lib.power:4 "
+			 "--log-level=lib.meter:4 "
+			 "--log-level=lib.sched:4 "
+			 "--log-level=lib.port:4 "
+			 "--log-level=lib.table:4 "
+			 "--log-level=lib.pipeline:4 "
+			 "--log-level=lib.mbuf:4 "
+			 "--log-level=lib.cryptodev:4 "
+			 "--log-level=lib.efd:4 "
+			 "--log-level=lib.eventdev:4 "
+			 "--log-level=lib.gso:4 "
+			 "--log-level=user1:4 "
+			 "--log-level=user2:4 "
+			 "--log-level=user3:4 "
+			 "--log-level=user4:4 "
+			 "--log-level=user5:4 "
+			 "--log-level=user6:4 "
+			 "--log-level=user7:4 "
+			 "--log-level=user8:4 "
+			 "--no-telemetry";
 
 int
 copy_ascii(char *dst, size_t dst_sz, const void *src, size_t src_sz)

--- a/src/common/control.c
+++ b/src/common/control.c
@@ -15,7 +15,7 @@
  * logging by setting specific facility masks.
  */
 const char *
-dpdk_cli_override_opts = "--log-level=lib.eal:4 --log-level=pmd:3 "
+dpdk_cli_override_opts = "--log-level=pmd:1 --log-level=lib.eal:4 "
 			 "--log-level=user1:4 --no-telemetry";
 
 int

--- a/src/common/control.c
+++ b/src/common/control.c
@@ -15,7 +15,7 @@
  * logging by setting specific facility masks.
  */
 const char *
-spdk_cli_override_opts = "--log-level=pmd:3 --no-telemetry "
+dpdk_cli_override_opts = "--log-level=pmd:3 --no-telemetry "
 			 "--log-level=lib.eal:4";
 
 int

--- a/src/common/control.c
+++ b/src/common/control.c
@@ -10,6 +10,14 @@
 #include <assert.h>
 #include <stdint.h>
 
+/*
+ * Disable DPDK telemetry to avoid socket file clashes and quiet DPDK
+ * logging by setting specific facility masks.
+ */
+const char *
+dpdk_cli_override_opts = "--log-level=lib.eal:4 --log-level=pmd:3 "
+			 "--log-level=user1:4 --no-telemetry";
+
 int
 copy_ascii(char *dst, size_t dst_sz, const void *src, size_t src_sz)
 {

--- a/src/control/lib/spdk/spdk.go
+++ b/src/control/lib/spdk/spdk.go
@@ -143,9 +143,7 @@ func (e *EnvImpl) InitSPDKEnv(log logging.Logger, opts *EnvOptions) error {
 		C.setArrayString(cAllowList, C.CString(s), C.int(i))
 	}
 
-	// Disable DPDK telemetry to avoid socket file clashes and quiet DPDK
-	// logging by setting level to ERROR.
-	envCtx := C.CString("--log-level=lib.eal:4 --log-level=lib.user1:4 --no-telemetry")
+	envCtx := C.dpdk_cli_override_opts
 	defer C.free(unsafe.Pointer(envCtx))
 
 	retPtr := C.daos_spdk_init(0, envCtx, C.ulong(len(opts.PCIAllowList)),

--- a/src/control/lib/spdk/spdk.go
+++ b/src/control/lib/spdk/spdk.go
@@ -45,7 +45,6 @@ import "C"
 
 import (
 	"fmt"
-	"unsafe"
 
 	"github.com/pkg/errors"
 
@@ -144,7 +143,6 @@ func (e *EnvImpl) InitSPDKEnv(log logging.Logger, opts *EnvOptions) error {
 	}
 
 	envCtx := C.dpdk_cli_override_opts
-	defer C.free(unsafe.Pointer(envCtx))
 
 	retPtr := C.daos_spdk_init(0, envCtx, C.ulong(len(opts.PCIAllowList)),
 		cAllowList)

--- a/src/control/lib/spdk/src/nvme_control.c
+++ b/src/control/lib/spdk/src/nvme_control.c
@@ -493,7 +493,7 @@ daos_spdk_init(int mem_sz, char *env_ctx, size_t nr_pcil, char **pcil)
 		opts.env_context = env_ctx;
 	if (nr_pcil > 0) {
 		for (i = 0; i < nr_pcil; i++) {
-			fprintf(stderr, "spdk env adding pci: %s\n", pcil[i]);
+			fprintf(stdout, "spdk env adding pci: %s\n", pcil[i]);
 
 			rc = opts_add_pci_addr(&opts, &opts.pci_allowed,
 					       pcil[i]);

--- a/src/include/daos_srv/control.h
+++ b/src/include/daos_srv/control.h
@@ -15,6 +15,13 @@
 #include <stdbool.h>
 #include <assert.h>
 
+/*
+ * Space separated string of CLI options to pass to DPDK when started during
+ * spdk_env_init(). These options will override the DPDK defaults.
+ */
+extern const char *
+dpdk_cli_override_opts;
+
 enum {
 	/* Device is plugged */
 	NVME_DEV_FL_PLUGGED	= 0x1,


### PR DESCRIPTION
Undesired log messages are being printed to stdout of daos_server. These
messages originate from DPDK which sets some of the facility log masks
to NOTICE and INFO.

This PR sets masks for all DPDK facilities to ERROR in daos_admin and
daos_engine and moves the log level cli args to a common location.

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>