### PR TITLE
DAOS-8108 EC: fix a bug in obj_ec_parity_check

### DIFF
--- a/src/object/cli_ec.c
+++ b/src/object/cli_ec.c
@@ -1904,12 +1904,12 @@ obj_ec_parity_check(struct obj_reasb_req *reasb_req,
 		return 0;
 
 	D_MUTEX_LOCK(&reasb_req->orr_mutex);
-	parity_lists = reasb_req->orr_fail->efi_parity_lists;
+	parity_lists = reasb_req->orr_parity_lists;
 	if (parity_lists == NULL) {
-		reasb_req->orr_fail->efi_parity_lists =
+		reasb_req->orr_parity_lists =
 			daos_recx_ep_lists_dup(recx_lists, nr);
-		reasb_req->orr_fail->efi_parity_list_nr = nr;
-		parity_lists = reasb_req->orr_fail->efi_parity_lists;
+		reasb_req->orr_parity_list_nr = nr;
+		parity_lists = reasb_req->orr_parity_lists;
 		if (parity_lists == NULL)
 			rc = -DER_NOMEM;
 		goto out;
@@ -1978,10 +1978,10 @@ obj_ec_fail_info_reset(struct obj_reasb_req *reasb_req)
 	fail_info->efi_recx_lists = NULL;
 	fail_info->efi_stripe_lists = NULL;
 	fail_info->efi_nrecx_lists = 0;
-	daos_recx_ep_list_free(fail_info->efi_parity_lists,
-			       fail_info->efi_parity_list_nr);
-	fail_info->efi_parity_lists = NULL;
-	fail_info->efi_parity_list_nr = 0;
+	daos_recx_ep_list_free(reasb_req->orr_parity_lists,
+			       reasb_req->orr_parity_list_nr);
+	reasb_req->orr_parity_lists = NULL;
+	reasb_req->orr_parity_list_nr = 0;
 }
 
 static bool
@@ -2390,12 +2390,14 @@ obj_ec_fail_info_free(struct obj_reasb_req *reasb_req)
 			       fail_info->efi_nrecx_lists);
 	daos_recx_ep_list_free(fail_info->efi_stripe_lists,
 			       fail_info->efi_nrecx_lists);
-	daos_recx_ep_list_free(fail_info->efi_parity_lists,
-			       fail_info->efi_parity_list_nr);
+	daos_recx_ep_list_free(reasb_req->orr_parity_lists,
+			       reasb_req->orr_parity_list_nr);
 	D_FREE(fail_info->efi_tgt_list);
 	D_FREE(fail_info);
 	reasb_req->orr_fail = NULL;
 	reasb_req->orr_fail_alloc = 0;
+	reasb_req->orr_parity_lists = NULL;
+	reasb_req->orr_parity_list_nr = 0;
 }
 
 int

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -24,7 +24,7 @@
 #define CLI_OBJ_IO_PARMS	8
 #define NIL_BITMAP		(NULL)
 
-#define OBJ_TGT_INLINE_NR	11
+#define OBJ_TGT_INLINE_NR	10
 #define OBJ_INLINE_BTIMAP	4
 
 struct obj_req_tgts {

--- a/src/object/obj_ec.h
+++ b/src/object/obj_ec.h
@@ -242,8 +242,6 @@ struct obj_ec_fail_info {
 	struct obj_ec_recov_codec	*efi_recov_codec;
 	/* to be recovered full-stripe list */
 	struct daos_recx_ep_list	*efi_stripe_lists;
-	/* parity recx list (to compare parity ext/epoch when data recovery) */
-	struct daos_recx_ep_list	*efi_parity_lists;
 	/* The buffer for all the full-stripes in efi_stripe_lists.
 	 * One iov for each recx_ep (with 1 or more stripes), for each stripe
 	 * it contains ((k + p) * cell_byte_size) memory.
@@ -255,7 +253,6 @@ struct obj_ec_fail_info {
 	 */
 	struct obj_ec_recov_task	*efi_recov_tasks;
 	uint32_t			 efi_recov_ntasks;
-	uint32_t			 efi_parity_list_nr;
 };
 
 struct obj_reasb_req;

--- a/src/object/obj_internal.h
+++ b/src/object/obj_internal.h
@@ -119,6 +119,8 @@ struct dc_object {
  *    it, create oiod/siod to specify each shard/tgt's IO req.
  */
 struct obj_reasb_req {
+	/* object ID */
+	daos_obj_id_t			 orr_oid;
 	/* epoch for IO (now only used for fetch */
 	struct dtx_epoch		 orr_epoch;
 	/* original user input iods/sgls */
@@ -149,8 +151,9 @@ struct obj_reasb_req {
 	struct obj_tgt_oiod		*tgt_oiods;
 	/* IO failure information */
 	struct obj_ec_fail_info		*orr_fail;
-	/* object ID */
-	daos_obj_id_t			 orr_oid;
+	/* parity recx list (to compare parity ext/epoch when data recovery) */
+	struct daos_recx_ep_list	*orr_parity_lists;
+	uint32_t			 orr_parity_list_nr;
 	/* #iods of IO req */
 	uint32_t			 orr_iod_nr;
 	/* for data recovery flag */

--- a/src/tests/suite/daos_rebuild_ec.c
+++ b/src/tests/suite/daos_rebuild_ec.c
@@ -66,6 +66,14 @@ rebuild_ec_internal(void **state, uint16_t oclass, int kill_data_nr,
 		rebuild_pools_ranks(&arg, 1, &extra_kill_ranks[2], 2, false);
 	}
 
+	if (write_type == PARTIAL_UPDATE)
+		verify_ec_partial(&req, arg->index, 0);
+	else if (write_type == FULL_UPDATE)
+		verify_ec_full(&req, arg->index, 0);
+	else if (write_type == FULL_PARTIAL_UPDATE)
+		verify_ec_full_partial(&req, arg->index, 0);
+	else if (write_type == PARTIAL_FULL_UPDATE)
+		verify_ec_full(&req, arg->index, 0);
 	ioreq_fini(&req);
 
 	rc = daos_obj_verify(arg->coh, oid, DAOS_EPOCH_MAX);
@@ -76,6 +84,18 @@ rebuild_ec_internal(void **state, uint16_t oclass, int kill_data_nr,
 		reintegrate_pools_ranks(&arg, 1, &extra_kill_ranks[1], 1);
 	else /* oclass OC_EC_4P2G1 */
 		reintegrate_pools_ranks(&arg, 1, &extra_kill_ranks[2], 2);
+
+	ioreq_init(&req, arg->coh, oid, DAOS_IOD_ARRAY, arg);
+	if (write_type == PARTIAL_UPDATE)
+		verify_ec_partial(&req, arg->index, 0);
+	else if (write_type == FULL_UPDATE)
+		verify_ec_full(&req, arg->index, 0);
+	else if (write_type == FULL_PARTIAL_UPDATE)
+		verify_ec_full_partial(&req, arg->index, 0);
+	else if (write_type == PARTIAL_FULL_UPDATE)
+		verify_ec_full(&req, arg->index, 0);
+
+	ioreq_fini(&req);
 
 	rc = daos_obj_verify(arg->coh, oid, DAOS_EPOCH_MAX);
 	assert_int_equal(rc, 0);
@@ -133,8 +153,67 @@ rebuild_mixed_stripes(void **state)
 		     data, size, &req);
 	assert_memory_equal(data, verify_data, size);
 
+	free(data);
+	free(verify_data);
 	ioreq_fini(&req);
 
+	reintegrate_pools_ranks(&arg, 1, &rank, 1);
+}
+
+static void
+rebuild_ec_multi_stripes(void **state)
+{
+#define TEST_STRIPE_NR	(4)
+	test_arg_t	*arg = *state;
+	daos_obj_id_t	oid;
+	struct ioreq	req;
+	char		*data[TEST_STRIPE_NR];
+	char		*verify_data[TEST_STRIPE_NR];
+	daos_recx_t	recxs[2];
+	d_rank_t	rank = 0;
+	uint64_t	start;
+	int		i, size = 8 * CELL_SIZE;
+
+	if (!test_runable(arg, 7))
+		return;
+
+	oid = daos_test_oid_gen(arg->coh, OC_EC_4P2G1, 0, 0, arg->myrank);
+	ioreq_init(&req, arg->coh, oid, DAOS_IOD_ARRAY, arg);
+
+	for (i = 0; i < TEST_STRIPE_NR; i++) {
+		start = i * 4 * CELL_SIZE * 100;
+		recxs[0].rx_idx = start;
+		recxs[0].rx_nr = 4 * CELL_SIZE;
+		recxs[1].rx_idx = start + 16 * CELL_SIZE;
+		recxs[1].rx_nr = 4 * CELL_SIZE;
+
+		data[i] = (char *)malloc(size);
+		verify_data[i] = (char *)malloc(size);
+		make_buffer(data[i], 'a' + i, size);
+		make_buffer(verify_data[i], 'a' + i, size);
+
+		req.iod_type = DAOS_IOD_ARRAY;
+		insert_recxs("d_key", "a_key", 1, DAOS_TX_NONE, recxs, 2, data[i], size, &req);
+	}
+
+	rank = get_rank_by_oid_shard(arg, oid, 0);
+	rebuild_pools_ranks(&arg, 1, &rank, 1, false);
+
+	for (i = 0; i < TEST_STRIPE_NR; i++) {
+		start = i * 4 * CELL_SIZE * 100;
+		recxs[0].rx_idx = start;
+		recxs[0].rx_nr = 4 * CELL_SIZE;
+		recxs[1].rx_idx = start + 16 * CELL_SIZE;
+		recxs[1].rx_nr = 4 * CELL_SIZE;
+
+		memset(data[i], 0, size);
+		lookup_recxs("d_key", "a_key", 1, DAOS_TX_NONE, recxs, 2, data[i], size, &req);
+		assert_memory_equal(data[i], verify_data[i], size);
+		free(data[i]);
+		free(verify_data[i]);
+	}
+
+	ioreq_fini(&req);
 	reintegrate_pools_ranks(&arg, 1, &rank, 1);
 }
 
@@ -836,6 +915,9 @@ static const struct CMUnitTest rebuild_tests[] = {
 	 test_teardown},
 	{"REBUILD37: rebuild EC dkey enumeration",
 	 rebuild_ec_dkey_enumeration, rebuild_ec_8nodes_setup,
+	 test_teardown},
+	{"REBUILD38: rebuild EC multi-stripes @ different epochs",
+	 rebuild_ec_multi_stripes, rebuild_ec_8nodes_setup,
 	 test_teardown},
 };
 

--- a/src/vos/evtree.c
+++ b/src/vos/evtree.c
@@ -2524,7 +2524,7 @@ evt_ent_array_fill(struct evt_context *tcx, enum evt_find_opc find_opc,
 					if (rect->rc_minor_epc ==
 					    EVT_MINOR_EPC_MAX)
 						break; /* Need to adjust it */
-					D_DEBUG(DB_IO, "Same epoch partial "
+					D_ERROR("Same epoch partial "
 						"overwrite not supported:"
 						DF_RECT" overlaps with "DF_RECT
 						"\n", DP_RECT(rect),

--- a/src/vos/vos_io.c
+++ b/src/vos/vos_io.c
@@ -1692,8 +1692,11 @@ akey_update(struct vos_io_context *ioc, uint32_t pm_ver, daos_handle_t ak_toh,
 	rc = key_tree_prepare(obj, ak_toh, VOS_BTR_AKEY,
 			      &iod->iod_name, flags, DAOS_INTENT_UPDATE,
 			      &krec, &toh, ioc->ic_ts_set);
-	if (rc != 0)
+	if (rc != 0) {
+		D_ERROR("akey "DF_KEY" update, key_tree_prepare failed, "DF_RC"\n",
+			DP_KEY(&iod->iod_name), DP_RC(rc));
 		return rc;
+	}
 
 	if (ioc->ic_ts_set) {
 		uint64_t akey_flags;
@@ -1740,6 +1743,9 @@ akey_update(struct vos_io_context *ioc, uint32_t pm_ver, daos_handle_t ak_toh,
 						   (uintptr_t)iod->iod_recxs;
 		rc = akey_update_single(toh, pm_ver, iod->iod_size, gsize, ioc,
 					minor_epc);
+		if (rc)
+			D_ERROR("akey "DF_KEY" update, akey_update_single failed, "DF_RC"\n",
+				DP_KEY(&iod->iod_name), DP_RC(rc));
 		goto out;
 	} /* else: array */
 
@@ -1760,8 +1766,11 @@ akey_update(struct vos_io_context *ioc, uint32_t pm_ver, daos_handle_t ak_toh,
 		rc = akey_update_recx(toh, pm_ver, &iod->iod_recxs[i],
 				      recx_csum, iod->iod_size, ioc,
 				      minor_epc);
-		if (rc != 0)
+		if (rc != 0) {
+			D_ERROR("akey "DF_KEY" update, akey_update_recx failed, "DF_RC"\n",
+				DP_KEY(&iod->iod_name), DP_RC(rc));
 			goto out;
+		}
 	}
 
 out:

--- a/src/vos/vos_tree.c
+++ b/src/vos/vos_tree.c
@@ -1226,6 +1226,9 @@ obj_tree_init(struct vos_object *obj)
 					    vos_cont2hdl(obj->obj_cont),
 					    vos_obj2pool(obj), &obj->obj_toh);
 	}
+
+	if (rc)
+		D_ERROR("obj_tree_init failed, "DF_RC"\n", DP_RC(rc));
 	return rc;
 }
 


### PR DESCRIPTION
In EC data recovery, it possible need to recover multiple stripes
by different recovery tasks. Those tasks share the same fail_info,
so the parity_lists cannot be inside fail_info to avoid mixing
with different stripe recovery tasks.

Signed-off-by: Xuezhao Liu <xuezhao.liu@intel.com>