### PR TITLE
DAOS-7905 vos: control DTX committed blob size when start engine

### DIFF
--- a/src/vos/vos_internal.h
+++ b/src/vos/vos_internal.h
@@ -72,6 +72,10 @@ D_CASSERT(VOS_MINOR_EPC_MAX == EVT_MINOR_EPC_MAX);
 #define DTX_BTREE_ORDER	23	/* Order for DTX tree */
 #define VEA_TREE_ODR		20	/* Order of a VEA tree */
 
+#define DTX_BLOB_ORDER_MAX	20
+#define DTX_BLOB_ORDER_MIN	14
+#define DTX_BLOB_ORDER_DEF	17
+
 extern struct dss_module_key vos_module_key;
 
 #define VOS_POOL_HHASH_BITS 10 /* Up to 1024 pools */

--- a/src/vos/vos_layout.h
+++ b/src/vos/vos_layout.h
@@ -233,7 +233,8 @@ struct vos_cont_df {
 	uuid_t				cd_id;
 	uint64_t			cd_nobjs;
 	uint32_t			cd_ts_idx;
-	uint32_t			cd_pad;
+	/** To calculate committed DTX blob size: size = 1 << order. */
+	uint32_t			cd_dtx_cmt_blob_order;
 	daos_size_t			cd_used;
 	daos_epoch_t			cd_hae;
 	struct btr_root			cd_obj_root;


### PR DESCRIPTION
Allow to control DTX committed blob size for new created container
via set the environment variable DTX_CMT_BLOB_ORDER on server when
start DAOS engine. The valid value range is [14, 20], the default
value is 17.

size = 1 << order, that may be helpful for performance tuning.

Signed-off-by: Fan Yong <fan.yong@intel.com>