### PR TITLE
DAOS-8303 control: return error if daos_server validation failed

### DIFF
--- a/src/control/server/config/server.go
+++ b/src/control/server/config/server.go
@@ -312,8 +312,8 @@ func DefaultServer() *Server {
 		Hyperthreads:       false,
 		Path:               defaultConfigPath,
 		ControlLogMask:     ControlLogLevel(logging.LogLevelInfo),
-		validateProviderFn: netdetect.ValidateProviderStub,
-		validateNUMAFn:     netdetect.ValidateNUMAStub,
+		validateProviderFn: netdetect.ValidateProviderConfig,
+		validateNUMAFn:     netdetect.ValidateNUMAConfig,
 		GetDeviceClassFn:   netdetect.GetDeviceClass,
 		EnableVMD:          false, // disabled by default
 	}


### PR DESCRIPTION
See comments from code:
"
ValidateProviderStub are used for most unit testing to replace
ValidateProviderConfig because the network configuration validation
depends upon physical hardware resources and configuration on the target machine
that are either not known or static in the test environment
"

However, daos_server should fail and return error if provider validation
failed in real usage, fix to use ValidatexxxConfig functions instead.

Signed-off-by: Wang Shilong <shilong.wang@intel.com>