### PR TITLE
DAOS-7717 test: enable test_pool_large_attributes in CI

### DIFF
--- a/src/tests/ftest/pool/attribute.py
+++ b/src/tests/ftest/pool/attribute.py
@@ -106,6 +106,7 @@ class PoolAttributeTest(TestWithServers):
 
         Test description: Test large randomly created pool attribute.
 
+        :avocado: tags=all,daily_regression
         :avocado: tags=regression,pool,pool_attr,attribute,large_poolattribute
         """
         self.add_pool()


### PR DESCRIPTION
test_pool_large_attributes is not running in CI, enable
extra daily_regreesion and all tags like test_pool_attributes
did.

Test-tag: pr large_poolattribute
Signed-off-by: Wang Shilong <shilong.wang@intel.com>