### PR TITLE
DAOS-8301 props: provide new prop APIs to set str and ptr values.

### DIFF
--- a/src/client/api/container.c
+++ b/src/client/api/container.c
@@ -116,11 +116,10 @@ daos_cont_create_with_label(daos_handle_t poh, const char *label,
 		return -DER_NOMEM;
 	}
 	label_prop->dpp_entries[0].dpe_type = DAOS_PROP_CO_LABEL;
-	D_STRNDUP(label_prop->dpp_entries[0].dpe_str, label, DAOS_PROP_LABEL_MAX_LEN);
-	if (label_prop->dpp_entries[0].dpe_str == NULL) {
-		rc = -DER_NOMEM;
+	rc = daos_prop_entry_set_str(label_prop, DAOS_PROP_CO_LABEL, label,
+				     DAOS_PROP_LABEL_MAX_LEN);
+	if (rc)
 		goto out_prop;
-	}
 
 	if (cont_prop) {
 		merged_props = daos_prop_merge(cont_prop, label_prop);

--- a/src/client/api/container.c
+++ b/src/client/api/container.c
@@ -116,8 +116,7 @@ daos_cont_create_with_label(daos_handle_t poh, const char *label,
 		return -DER_NOMEM;
 	}
 	label_prop->dpp_entries[0].dpe_type = DAOS_PROP_CO_LABEL;
-	rc = daos_prop_entry_set_str(label_prop, DAOS_PROP_CO_LABEL, label,
-				     DAOS_PROP_LABEL_MAX_LEN);
+	rc = daos_prop_entry_set_str(&label_prop->dpp_entries[0], label, DAOS_PROP_LABEL_MAX_LEN);
 	if (rc)
 		goto out_prop;
 

--- a/src/client/dfs/dfs.c
+++ b/src/client/dfs/dfs.c
@@ -1333,7 +1333,7 @@ dfs_cont_create_int(daos_handle_t poh, uuid_t *cuuid, bool uuid_is_set, uuid_t i
 					 0, dattr.da_oclass_id, 0, 0);
 	if (rc) {
 		D_ERROR("Failed to generate SB OID "DF_RC"\n", DP_RC(rc));
-		return daos_der2errno(rc);
+		D_GOTO(err_prop, rc = daos_der2errno(rc));
 	}
 
 	/* select oclass and generate ROOT OID */
@@ -1343,13 +1343,15 @@ dfs_cont_create_int(daos_handle_t poh, uuid_t *cuuid, bool uuid_is_set, uuid_t i
 					 0, dattr.da_oclass_id, 0, 0);
 	if (rc) {
 		D_ERROR("Failed to generate ROOT OID "DF_RC"\n", DP_RC(rc));
-		return daos_der2errno(rc);
+		D_GOTO(err_prop, rc = daos_der2errno(rc));
 	}
 
 	/* store SB & root OIDs as container property */
 	roots.cr_oids[2] = roots.cr_oids[3] = DAOS_OBJ_NIL;
 	prop->dpp_entries[prop->dpp_nr - 2].dpe_type = DAOS_PROP_CO_ROOTS;
-	prop->dpp_entries[prop->dpp_nr - 2].dpe_val_ptr = &roots;
+	rc = daos_prop_entry_set_ptr(prop, DAOS_PROP_CO_ROOTS, &roots, sizeof(roots));
+	if (rc)
+		D_GOTO(err_prop, rc = daos_der2errno(rc));
 
 	prop->dpp_entries[prop->dpp_nr - 1].dpe_type = DAOS_PROP_CO_LAYOUT_TYPE;
 	prop->dpp_entries[prop->dpp_nr - 1].dpe_val = DAOS_PROP_CO_LAYOUT_POSIX;
@@ -1358,12 +1360,6 @@ dfs_cont_create_int(daos_handle_t poh, uuid_t *cuuid, bool uuid_is_set, uuid_t i
 		rc = daos_cont_create(poh, in_uuid, prop, NULL);
 	else
 		rc = daos_cont_create(poh, cuuid, prop, NULL);
-	/* should not be freed by daos_prop_free */
-	prop->dpp_entries[prop->dpp_nr - 2].dpe_val_ptr = NULL;
-	if (rc) {
-		D_ERROR("daos_cont_create() failed "DF_RC"\n", DP_RC(rc));
-		D_GOTO(err_prop, rc = daos_der2errno(rc));
-	}
 
 	rc = daos_cont_open(poh, *cuuid, DAOS_COO_RW, &coh, &co_info, NULL);
 	if (rc) {

--- a/src/client/dfs/dfs.c
+++ b/src/client/dfs/dfs.c
@@ -1349,7 +1349,7 @@ dfs_cont_create_int(daos_handle_t poh, uuid_t *cuuid, bool uuid_is_set, uuid_t i
 	/* store SB & root OIDs as container property */
 	roots.cr_oids[2] = roots.cr_oids[3] = DAOS_OBJ_NIL;
 	prop->dpp_entries[prop->dpp_nr - 2].dpe_type = DAOS_PROP_CO_ROOTS;
-	rc = daos_prop_entry_set_ptr(prop, DAOS_PROP_CO_ROOTS, &roots, sizeof(roots));
+	rc = daos_prop_entry_set_ptr(&prop->dpp_entries[prop->dpp_nr - 2], &roots, sizeof(roots));
 	if (rc)
 		D_GOTO(err_prop, rc = daos_der2errno(rc));
 

--- a/src/client/serialize/daos_serialize.c
+++ b/src/client/serialize/daos_serialize.c
@@ -783,7 +783,7 @@ deserialize_props(daos_handle_t poh, hid_t file_id, daos_prop_t **_prop,
 		}
 
 		prop->dpp_entries[prop_num].dpe_type = DAOS_PROP_CO_OWNER;
-		rc = daos_prop_entry_set_str(prop, DAOS_PROP_CO_OWNER, owner, strlen(owner));
+		rc = daos_prop_entry_set_str(&prop->dpp_entries[prop_num], owner, strlen(owner));
 		if (rc)
 			D_GOTO(out, rc);
 		prop_num++;
@@ -797,7 +797,7 @@ deserialize_props(daos_handle_t poh, hid_t file_id, daos_prop_t **_prop,
 		}
 
 		prop->dpp_entries[prop_num].dpe_type = DAOS_PROP_CO_OWNER_GROUP;
-		rc = daos_prop_entry_set_str(prop, DAOS_PROP_CO_OWNER_GROUP, group, strlen(group));
+		rc = daos_prop_entry_set_str(prop->dpp_entries[prop_num], group, strlen(group));
 		if (rc)
 			D_GOTO(out, rc);
 		prop_num++;
@@ -851,7 +851,7 @@ deserialize_props(daos_handle_t poh, hid_t file_id, daos_prop_t **_prop,
 	/* deserialize_label stays false if property doesn't exist above */
 	if (deserialize_label) {
 		prop->dpp_entries[prop_num].dpe_type = DAOS_PROP_CO_LABEL;
-		rc = daos_prop_entry_set_str(prop, DAOS_PROP_CO_LABEL, label, strlen(label));
+		rc = daos_prop_entry_set_str(&prop->dpp_entries[prop_num], label, strlen(label));
 		if (rc)
 			D_GOTO(out, rc);
 	}

--- a/src/client/serialize/daos_serialize.c
+++ b/src/client/serialize/daos_serialize.c
@@ -797,7 +797,7 @@ deserialize_props(daos_handle_t poh, hid_t file_id, daos_prop_t **_prop,
 		}
 
 		prop->dpp_entries[prop_num].dpe_type = DAOS_PROP_CO_OWNER_GROUP;
-		rc = daos_prop_entry_set_str(prop->dpp_entries[prop_num], group, strlen(group));
+		rc = daos_prop_entry_set_str(&prop->dpp_entries[prop_num], group, strlen(group));
 		if (rc)
 			D_GOTO(out, rc);
 		prop_num++;

--- a/src/client/serialize/daos_serialize.c
+++ b/src/client/serialize/daos_serialize.c
@@ -451,8 +451,7 @@ out:
 }
 
 static int
-deserialize_str(hid_t file_id, struct daos_prop_entry *entry,
-		const char *prop_str)
+deserialize_str(hid_t file_id, char **str, const char *prop_str)
 {
 	hid_t	status = 0;
 	int	rc = 0;
@@ -475,15 +474,15 @@ deserialize_str(hid_t file_id, struct daos_prop_entry *entry,
 		D_ERROR("failed to get size of datatype\n");
 		D_GOTO(out, rc = -DER_MISC);
 	}
-	D_ALLOC(entry->dpe_str, buf_size);
-	if (entry->dpe_str == NULL) {
+
+	D_ALLOC(*str, buf_size);
+	if (*str == NULL)
 		D_GOTO(out, rc = -DER_NOMEM);
-	}
-	status = H5Aread(cont_attr, attr_dtype, entry->dpe_str);
+
+	status = H5Aread(cont_attr, attr_dtype, *str);
 	if (status < 0) {
 		rc = -DER_IO;
-		D_ERROR("failed to read property attribute %s "DF_RC"\n",
-			entry->dpe_str, DP_RC(rc));
+		D_ERROR("failed to read property attribute %s "DF_RC"\n", *str, DP_RC(rc));
 		D_GOTO(out, rc);
 	}
 out:
@@ -619,10 +618,9 @@ deserialize_props(daos_handle_t poh, hid_t file_id, daos_prop_t **_prop,
 	bool			deserialize_label = false;
 	bool			close_cont = true;
 	uint64_t		total_props = 0;
-	daos_prop_t		*label = NULL;
+	char			*label = NULL;
 	daos_prop_t		*prop = NULL;
 	struct daos_prop_entry	*entry;
-	struct daos_prop_entry	*label_entry = NULL;
 	daos_handle_t		coh;
 	daos_cont_info_t	cont_info = {0};
 	int			prop_num = 0;
@@ -633,27 +631,16 @@ deserialize_props(daos_handle_t poh, hid_t file_id, daos_prop_t **_prop,
 	 */
 
 	if (H5Aexists(file_id, "DAOS_PROP_CO_LABEL") > 0) {
-		label = daos_prop_alloc(1);
-		if (label == NULL) {
-			return ENOMEM;
-		}
-		label->dpp_entries[0].dpe_type = DAOS_PROP_CO_LABEL;
-
-		/* read the container label entry to decide if it should be
-		 * added to property list. The container label is required to
-		 * be unique, which is why it is handled differently than the
-		 * other container properties. If the label already exists in
-		 * the pool then this property will be skipped for
-		 * deserialization
+		/* read the container label entry to decide if it should be added to property
+		 * list. The container label is required to be unique, which is why it is handled
+		 * differently than the other container properties. If the label already exists in
+		 * the pool then this property will be skipped for deserialization
 		 */
-		label_entry = &label->dpp_entries[0];
-		rc = deserialize_str(file_id, label_entry,
-				     "DAOS_PROP_CO_LABEL");
+		rc = deserialize_str(file_id, &label, "DAOS_PROP_CO_LABEL");
 		if (rc != 0) {
 			D_GOTO(out, rc);
 		}
-		rc = daos_cont_open(poh, label_entry->dpe_str, DAOS_COO_RW,
-				    &coh, &cont_info, NULL);
+		rc = daos_cont_open(poh, label, DAOS_COO_RW, &coh, &cont_info, NULL);
 		if (rc == -DER_NONEXIST) {
 			/* label doesn't already exist so deserialize */
 			deserialize_label = true;
@@ -661,8 +648,7 @@ deserialize_props(daos_handle_t poh, hid_t file_id, daos_prop_t **_prop,
 		} else if (rc != 0) {
 			D_GOTO(out, rc);
 		}  else {
-			D_PRINT("Container label cannot be set, "
-				"the label already exists in pool\n");
+			D_PRINT("Container label already exists in pool and cannot be set\n");
 		}
 	}
 
@@ -789,24 +775,31 @@ deserialize_props(daos_handle_t poh, hid_t file_id, daos_prop_t **_prop,
 		prop_num++;
 	}
 	if (H5Aexists(file_id, "DAOS_PROP_CO_OWNER") > 0) {
-		type = DAOS_PROP_CO_OWNER;
-		prop->dpp_entries[prop_num].dpe_type = type;
-		entry = &prop->dpp_entries[prop_num];
-		rc = deserialize_str(file_id, entry, "DAOS_PROP_CO_OWNER");
+		char *owner = NULL;
+
+		rc = deserialize_str(file_id, &owner, "DAOS_PROP_CO_OWNER");
 		if (rc != 0) {
 			D_GOTO(out, rc);
 		}
+
+		prop->dpp_entries[prop_num].dpe_type = DAOS_PROP_CO_OWNER;
+		rc = daos_prop_entry_set_str(prop, DAOS_PROP_CO_OWNER, owner, strlen(owner));
+		if (rc)
+			D_GOTO(out, rc);
 		prop_num++;
 	}
 	if (H5Aexists(file_id, "DAOS_PROP_CO_OWNER_GROUP") > 0) {
-		type = DAOS_PROP_CO_OWNER_GROUP;
-		prop->dpp_entries[prop_num].dpe_type = type;
-		entry = &prop->dpp_entries[prop_num];
-		rc = deserialize_str(file_id, entry,
-				     "DAOS_PROP_CO_OWNER_GROUP");
+		char *group = NULL;
+
+		rc = deserialize_str(file_id, &group, "DAOS_PROP_CO_OWNER_GROUP");
 		if (rc != 0) {
 			D_GOTO(out, rc);
 		}
+
+		prop->dpp_entries[prop_num].dpe_type = DAOS_PROP_CO_OWNER_GROUP;
+		rc = daos_prop_entry_set_str(prop, DAOS_PROP_CO_OWNER_GROUP, group, strlen(group));
+		if (rc)
+			D_GOTO(out, rc);
 		prop_num++;
 	}
 	if (H5Aexists(file_id, "DAOS_PROP_CO_DEDUP") > 0) {
@@ -857,17 +850,17 @@ deserialize_props(daos_handle_t poh, hid_t file_id, daos_prop_t **_prop,
 	}
 	/* deserialize_label stays false if property doesn't exist above */
 	if (deserialize_label) {
-		type = DAOS_PROP_CO_LABEL;
-		prop->dpp_entries[prop_num].dpe_type = type;
-		prop->dpp_entries[prop_num].dpe_str =
-						strdup(label_entry->dpe_str);
+		prop->dpp_entries[prop_num].dpe_type = DAOS_PROP_CO_LABEL;
+		rc = daos_prop_entry_set_str(prop, DAOS_PROP_CO_LABEL, label, strlen(label));
+		if (rc)
+			D_GOTO(out, rc);
 	}
 	*_prop = prop;
 out:
 	/* close container after checking if label exists in pool */
 	if (close_cont)
 		daos_cont_close(coh, NULL);
-	daos_prop_free(label);
+	D_FREE(label);
 	return rc;
 }
 

--- a/src/common/prop.c
+++ b/src/common/prop.c
@@ -574,13 +574,22 @@ daos_prop_entry_get(daos_prop_t *prop, uint32_t type)
 }
 
 int
-daos_prop_entry_set_str(daos_prop_t *prop, uint32_t type, const char *str, daos_size_t len)
+daos_prop_set_str(daos_prop_t *prop, uint32_t type, const char *str, daos_size_t len)
 {
 	struct daos_prop_entry	*entry;
 
 	entry = daos_prop_entry_get(prop, type);
 	if (entry == NULL)
 		return -DER_NONEXIST;
+
+	return daos_prop_entry_set_str(entry, str, len);
+}
+
+int
+daos_prop_entry_set_str(struct daos_prop_entry *entry, const char *str, daos_size_t len)
+{
+	if (entry == NULL)
+		return -DER_INVAL;
 
 	if (!daos_prop_has_str(entry)) {
 		D_ERROR("Entry type does not expect a string value\n");
@@ -590,6 +599,9 @@ daos_prop_entry_set_str(daos_prop_t *prop, uint32_t type, const char *str, daos_
 	if (entry->dpe_str != NULL)
 		D_FREE(entry->dpe_str);
 
+	if (str == NULL || len == 0)
+		return 0;
+
 	D_STRNDUP(entry->dpe_str, str, len);
 	if (entry->dpe_str == NULL)
 		return -DER_NOMEM;
@@ -598,13 +610,22 @@ daos_prop_entry_set_str(daos_prop_t *prop, uint32_t type, const char *str, daos_
 }
 
 int
-daos_prop_entry_set_ptr(daos_prop_t *prop, uint32_t type, const void *ptr, daos_size_t size)
+daos_prop_set_ptr(daos_prop_t *prop, uint32_t type, const void *ptr, daos_size_t size)
 {
 	struct daos_prop_entry	*entry;
 
 	entry = daos_prop_entry_get(prop, type);
 	if (entry == NULL)
 		return -DER_NONEXIST;
+
+	return daos_prop_entry_set_ptr(entry, ptr, size);
+}
+
+int
+daos_prop_entry_set_ptr(struct daos_prop_entry *entry, const void *ptr, daos_size_t size)
+{
+	if (entry == NULL)
+		return -DER_INVAL;
 
 	if (!daos_prop_has_ptr(entry)) {
 		D_ERROR("Entry type does not expect a ptr value\n");
@@ -613,6 +634,9 @@ daos_prop_entry_set_ptr(daos_prop_t *prop, uint32_t type, const void *ptr, daos_
 
 	if (entry->dpe_val_ptr != NULL)
 		D_FREE(entry->dpe_val_ptr);
+
+	if (ptr == NULL || size == 0)
+		return 0;
 
 	D_ALLOC(entry->dpe_val_ptr, size);
 	if (entry->dpe_val_ptr == NULL)

--- a/src/common/prop.c
+++ b/src/common/prop.c
@@ -573,6 +573,55 @@ daos_prop_entry_get(daos_prop_t *prop, uint32_t type)
 	return NULL;
 }
 
+int
+daos_prop_entry_set_str(daos_prop_t *prop, uint32_t type, const char *str, daos_size_t len)
+{
+	struct daos_prop_entry	*entry;
+
+	entry = daos_prop_entry_get(prop, type);
+	if (entry == NULL)
+		return -DER_NONEXIST;
+
+	if (!daos_prop_has_str(entry)) {
+		D_ERROR("Entry type does not expect a string value\n");
+		return -DER_INVAL;
+	}
+
+	if (entry->dpe_str != NULL)
+		D_FREE(entry->dpe_str);
+
+	D_STRNDUP(entry->dpe_str, str, len);
+	if (entry->dpe_str == NULL)
+		return -DER_NOMEM;
+
+	return 0;
+}
+
+int
+daos_prop_entry_set_ptr(daos_prop_t *prop, uint32_t type, const void *ptr, daos_size_t size)
+{
+	struct daos_prop_entry	*entry;
+
+	entry = daos_prop_entry_get(prop, type);
+	if (entry == NULL)
+		return -DER_NONEXIST;
+
+	if (!daos_prop_has_ptr(entry)) {
+		D_ERROR("Entry type does not expect a ptr value\n");
+		return -DER_INVAL;
+	}
+
+	if (entry->dpe_val_ptr != NULL)
+		D_FREE(entry->dpe_val_ptr);
+
+	D_ALLOC(entry->dpe_val_ptr, size);
+	if (entry->dpe_val_ptr == NULL)
+		return -DER_NOMEM;
+	memcpy(entry->dpe_val_ptr, ptr, size);
+
+	return 0;
+}
+
 static void
 free_str_prop_entry(daos_prop_t *prop, uint32_t type)
 {

--- a/src/common/prop.c
+++ b/src/common/prop.c
@@ -590,15 +590,12 @@ daos_prop_entry_set_str(struct daos_prop_entry *entry, const char *str, daos_siz
 {
 	if (entry == NULL)
 		return -DER_INVAL;
-
 	if (!daos_prop_has_str(entry)) {
 		D_ERROR("Entry type does not expect a string value\n");
 		return -DER_INVAL;
 	}
-
 	if (entry->dpe_str != NULL)
 		D_FREE(entry->dpe_str);
-
 	if (str == NULL || len == 0)
 		return 0;
 
@@ -626,15 +623,12 @@ daos_prop_entry_set_ptr(struct daos_prop_entry *entry, const void *ptr, daos_siz
 {
 	if (entry == NULL)
 		return -DER_INVAL;
-
 	if (!daos_prop_has_ptr(entry)) {
 		D_ERROR("Entry type does not expect a ptr value\n");
 		return -DER_INVAL;
 	}
-
 	if (entry->dpe_val_ptr != NULL)
 		D_FREE(entry->dpe_val_ptr);
-
 	if (ptr == NULL || size == 0)
 		return 0;
 

--- a/src/control/cmd/daos/property.go
+++ b/src/control/cmd/daos/property.go
@@ -82,6 +82,7 @@ var propHdlrs = propHdlrMap{
 			if !drpc.LabelIsValid(v) {
 				return errors.Errorf("invalid label %q", v)
 			}
+			e.dpe_type = C.DAOS_PROP_CO_LABEL
 			cStr := C.CString(v)
 			C.daos_prop_entry_set_str(e, cStr, C.strlen(cStr))
 			freeString(cStr)

--- a/src/control/cmd/daos/property.go
+++ b/src/control/cmd/daos/property.go
@@ -83,7 +83,7 @@ var propHdlrs = propHdlrMap{
 				return errors.Errorf("invalid label %q", v)
 			}
 			cStr := C.CString(v)
-			C.daos_prop_entry_set_str(e, cStr, C.size_t(len(v)+1))
+			C.daos_prop_entry_set_str(e, cStr, C.strlen(cStr))
 			freeString(cStr)
 			return nil
 		},

--- a/src/control/cmd/daos/property.go
+++ b/src/control/cmd/daos/property.go
@@ -83,7 +83,7 @@ var propHdlrs = propHdlrMap{
 				return errors.Errorf("invalid label %q", v)
 			}
 			cStr := C.CString(v)
-			C.set_dpe_dupe_str(e, cStr, C.size_t(len(v)+1))
+			C.daos_prop_entry_set_str(e, cStr, C.size_t(len(v)+1))
 			freeString(cStr)
 			return nil
 		},

--- a/src/control/cmd/daos/property.h
+++ b/src/control/cmd/daos/property.h
@@ -56,19 +56,6 @@ set_dpe_str(struct daos_prop_entry *dpe, d_string_t str)
 }
 
 static inline void
-set_dpe_dupe_str(struct daos_prop_entry *dpe, d_string_t str, int strlen)
-{
-	if (dpe == NULL || str == NULL || strlen == 0)
-		return;
-
-	/* Use this to keep NLT happy; otherwise it will complain
-	 * about "free of unknown memory" if a string allocated
-	 * by cgo's CString() is used.
-	 */
-	D_STRNDUP(dpe->dpe_str, str, strlen);
-}
-
-static inline void
 set_dpe_val(struct daos_prop_entry *dpe, uint64_t val)
 {
 	if (dpe == NULL)

--- a/src/control/cmd/daos/util.c
+++ b/src/control/cmd/daos/util.c
@@ -68,8 +68,7 @@ resolve_duns_path(struct cmd_args_s *ap)
 
 	/** set pool/cont label or uuid */
 	if (dattr.da_pool_label) {
-		D_STRNDUP(ap->pool_label, dattr.da_pool_label,
-			  DAOS_PROP_LABEL_MAX_LEN);
+		D_STRNDUP(ap->pool_label, dattr.da_pool_label, DAOS_PROP_LABEL_MAX_LEN);
 		if (ap->pool_label == NULL)
 			D_GOTO(out, rc = ENOMEM);
 	} else {
@@ -77,8 +76,7 @@ resolve_duns_path(struct cmd_args_s *ap)
 	}
 
 	if (dattr.da_cont_label) {
-		D_STRNDUP(ap->cont_label, dattr.da_cont_label,
-			  DAOS_PROP_LABEL_MAX_LEN);
+		D_STRNDUP(ap->cont_label, dattr.da_cont_label, DAOS_PROP_LABEL_MAX_LEN);
 		if (ap->cont_label == NULL)
 			D_GOTO(out, rc = ENOMEM);
 	} else {
@@ -87,18 +85,15 @@ resolve_duns_path(struct cmd_args_s *ap)
 
 	if (ap->fs_op != -1) {
 		if (name) {
-			if (dattr.da_rel_path) {
-				asprintf(&ap->dfs_path, "%s/%s",
-					 dattr.da_rel_path, name);
-			} else {
+			if (dattr.da_rel_path)
+				asprintf(&ap->dfs_path, "%s/%s", dattr.da_rel_path, name);
+			else
 				asprintf(&ap->dfs_path, "/%s", name);
-			}
 		} else {
-			if (dattr.da_rel_path) {
+			if (dattr.da_rel_path)
 				ap->dfs_path = strndup(dattr.da_rel_path, PATH_MAX);
-			} else {
+			else
 				ap->dfs_path = strndup("/", 1);
-			}
 		}
 		if (ap->dfs_path == NULL)
 			D_GOTO(out, rc = ENOMEM);

--- a/src/control/cmd/daos/util.h
+++ b/src/control/cmd/daos/util.h
@@ -80,19 +80,6 @@ set_dpe_str(struct daos_prop_entry *dpe, d_string_t str)
 }
 
 static inline void
-set_dpe_dupe_str(struct daos_prop_entry *dpe, d_string_t str, size_t len)
-{
-	if (dpe == NULL || str == NULL || len == 0)
-		return;
-
-	/* Use this to keep NLT happy; otherwise it will complain
-	 * about "free of unknown memory" if a string allocated
-	 * by cgo's CString() is used.
-	 */
-	D_STRNDUP(dpe->dpe_str, str, len);
-}
-
-static inline void
 set_dpe_val(struct daos_prop_entry *dpe, uint64_t val)
 {
 	if (dpe == NULL)

--- a/src/include/daos_prop.h
+++ b/src/include/daos_prop.h
@@ -459,6 +459,36 @@ struct daos_prop_entry *
 daos_prop_entry_get(daos_prop_t *prop, uint32_t type);
 
 /**
+ * Set the string value of a property entry in a property. The property type must expect that it's
+ * entry is of a string type. This duplicates the string internally and the entry string is freed
+ * with daos_free_prop(). The user does not need to keep the string buffer around after this
+ * function is called. If the entry already has a string value set, it frees that and overwrites it
+ * with this new string.
+ *
+ * \param[in]		prop		Property list
+ * \param[in]		type		Type of property to look for
+ * \param[in]		str		String value to set in the prop entry
+ * \param[in]           len		Length of \a str
+ */
+int
+daos_prop_entry_set_str(daos_prop_t *prop, uint32_t type, const char *str, daos_size_t len);
+
+/**
+ * Set the pointer value of a property entry in a property. The property type must expect that it's
+ * entry is of a pointer type. This duplicates the buffer internally and the entry string is freed
+ * with daos_free_prop(). The user does not need to keep the string buffer around after this
+ * function is called. If the entry already has a value set, it frees that and overwrites it with
+ * this new value.
+ *
+ * \param[in]		prop		Property list
+ * \param[in]		type		Type of property to look for
+ * \param[in]		ptr		Pointer to value of entry to set
+ * \param[in]           size		Size of value
+ */
+int
+daos_prop_entry_set_ptr(daos_prop_t *prop, uint32_t type, const void *ptr, daos_size_t size);
+
+/**
  * Duplicate a generic pointer value from one DAOS prop entry to another.
  * Convenience function.
  *

--- a/src/include/daos_prop.h
+++ b/src/include/daos_prop.h
@@ -471,11 +471,22 @@ daos_prop_entry_get(daos_prop_t *prop, uint32_t type);
  * \param[in]           len		Length of \a str
  */
 int
-daos_prop_entry_set_str(daos_prop_t *prop, uint32_t type, const char *str, daos_size_t len);
+daos_prop_set_str(daos_prop_t *prop, uint32_t type, const char *str, daos_size_t len);
+
+/**
+ * Set the entry string value with the provided \a str.
+ * Convenience Function.
+ *
+ * \param[in,out]	entry		Entry where to duplicate the str into.
+ * \param[in]		str		String value to set in the prop entry
+ * \param[in]           len		Length of \a str
+ */
+int
+daos_prop_entry_set_str(struct daos_prop_entry *entry, const char *str, daos_size_t len);
 
 /**
  * Set the pointer value of a property entry in a property. The property type must expect that it's
- * entry is of a pointer type. This duplicates the buffer internally and the entry string is freed
+ * entry is of a pointer type. This duplicates the buffer internally and the entry buffer is freed
  * with daos_free_prop(). The user does not need to keep the string buffer around after this
  * function is called. If the entry already has a value set, it frees that and overwrites it with
  * this new value.
@@ -486,7 +497,18 @@ daos_prop_entry_set_str(daos_prop_t *prop, uint32_t type, const char *str, daos_
  * \param[in]           size		Size of value
  */
 int
-daos_prop_entry_set_ptr(daos_prop_t *prop, uint32_t type, const void *ptr, daos_size_t size);
+daos_prop_set_ptr(daos_prop_t *prop, uint32_t type, const void *ptr, daos_size_t size);
+
+/**
+ * Set the entry pointer value with the provided \a ptr.
+ * Convenience Function.
+ *
+ * \param[in,out]	entry		Entry where to copy the value.
+ * \param[in]		ptr             Pointer to value of entry to set
+ * \param[in]           size            Size of value
+ */
+int
+daos_prop_entry_set_ptr(struct daos_prop_entry *entry, const void *ptr, daos_size_t size);
 
 /**
  * Duplicate a generic pointer value from one DAOS prop entry to another.

--- a/src/tests/suite/daos_container.c
+++ b/src/tests/suite/daos_container.c
@@ -333,11 +333,18 @@ co_properties(void **state)
 	assert_int_equal(rc, 0);
 
 	prop = daos_prop_alloc(2);
+	/** setting the label on entries with no type should fail */
+	rc = daos_prop_entry_set_str(prop, DAOS_PROP_CO_LABEL, label, strlen(label));
+	assert_rc_equal(rc, -DER_NONEXIST);
+
 	prop->dpp_entries[0].dpe_type = DAOS_PROP_CO_LABEL;
-	prop->dpp_entries[0].dpe_str = strdup(label);
+	/** setting the label as a pointer should fail */
+	rc = daos_prop_entry_set_ptr(prop, DAOS_PROP_CO_LABEL, label, strlen(label));
+	assert_rc_equal(rc, -DER_INVAL);
+	rc = daos_prop_entry_set_str(prop, DAOS_PROP_CO_LABEL, label, strlen(label));
+	assert_rc_equal(rc, 0);
 	prop->dpp_entries[1].dpe_type = DAOS_PROP_CO_SNAPSHOT_MAX;
 	prop->dpp_entries[1].dpe_val = snapshot_max;
-	D_STRNDUP(arg->cont_label, label, DAOS_PROP_LABEL_MAX_LEN);
 
 	while (!rc && arg->setup_state != SETUP_CONT_CONNECT)
 		rc = test_setup_next_step((void **)&arg, NULL, NULL, prop);
@@ -436,8 +443,8 @@ co_properties(void **state)
 		/* Create container: same UUID, different label - fail */
 		print_message("Checking create: same UUID, different label "
 			      "(will fail)\n");
-		free(prop->dpp_entries[0].dpe_str);
-		prop->dpp_entries[0].dpe_str = strdup(label2);
+		rc = daos_prop_entry_set_str(prop, DAOS_PROP_CO_LABEL, label2, strlen(label2));
+		assert_rc_equal(rc, 0);
 		rc = daos_cont_create(arg->pool.poh, arg->co_uuid, prop, NULL);
 		assert_rc_equal(rc, -DER_INVAL);
 
@@ -502,14 +509,15 @@ co_properties(void **state)
 		 * container 1 set-prop label2 - pass
 		 */
 		print_message("Checking label rename and reuse\n");
-		free(prop->dpp_entries[0].dpe_str);
-		prop->dpp_entries[0].dpe_str = strdup(label2_v2);
+		rc = daos_prop_entry_set_str(prop, DAOS_PROP_CO_LABEL, label2_v2,
+					     strlen(label2_v2));
+		assert_rc_equal(rc, 0);
 		print_message("step: C3 set-prop change FROM %s TO %s\n",
 			      label2, label2_v2);
 		rc = daos_cont_set_prop(coh3, prop, NULL);
 		assert_rc_equal(rc, 0);
-		free(prop->dpp_entries[0].dpe_str);
-		prop->dpp_entries[0].dpe_str = strdup(label2);
+		rc = daos_prop_entry_set_str(prop, DAOS_PROP_CO_LABEL, label2, strlen(label2));
+		assert_rc_equal(rc, 0);
 		print_message("step: C1 set-prop change FROM %s TO %s\n",
 			      label, label2);
 		rc = daos_cont_set_prop(arg->coh, prop, NULL);

--- a/src/tests/suite/daos_container.c
+++ b/src/tests/suite/daos_container.c
@@ -334,14 +334,14 @@ co_properties(void **state)
 
 	prop = daos_prop_alloc(2);
 	/** setting the label on entries with no type should fail */
-	rc = daos_prop_entry_set_str(prop, DAOS_PROP_CO_LABEL, label, strlen(label));
+	rc = daos_prop_set_str(prop, DAOS_PROP_CO_LABEL, label, strlen(label));
 	assert_rc_equal(rc, -DER_NONEXIST);
 
 	prop->dpp_entries[0].dpe_type = DAOS_PROP_CO_LABEL;
 	/** setting the label as a pointer should fail */
-	rc = daos_prop_entry_set_ptr(prop, DAOS_PROP_CO_LABEL, label, strlen(label));
+	rc = daos_prop_set_ptr(prop, DAOS_PROP_CO_LABEL, label, strlen(label));
 	assert_rc_equal(rc, -DER_INVAL);
-	rc = daos_prop_entry_set_str(prop, DAOS_PROP_CO_LABEL, label, strlen(label));
+	rc = daos_prop_set_str(prop, DAOS_PROP_CO_LABEL, label, strlen(label));
 	assert_rc_equal(rc, 0);
 	prop->dpp_entries[1].dpe_type = DAOS_PROP_CO_SNAPSHOT_MAX;
 	prop->dpp_entries[1].dpe_val = snapshot_max;
@@ -443,7 +443,7 @@ co_properties(void **state)
 		/* Create container: same UUID, different label - fail */
 		print_message("Checking create: same UUID, different label "
 			      "(will fail)\n");
-		rc = daos_prop_entry_set_str(prop, DAOS_PROP_CO_LABEL, label2, strlen(label2));
+		rc = daos_prop_set_str(prop, DAOS_PROP_CO_LABEL, label2, strlen(label2));
 		assert_rc_equal(rc, 0);
 		rc = daos_cont_create(arg->pool.poh, arg->co_uuid, prop, NULL);
 		assert_rc_equal(rc, -DER_INVAL);
@@ -509,14 +509,13 @@ co_properties(void **state)
 		 * container 1 set-prop label2 - pass
 		 */
 		print_message("Checking label rename and reuse\n");
-		rc = daos_prop_entry_set_str(prop, DAOS_PROP_CO_LABEL, label2_v2,
-					     strlen(label2_v2));
+		rc = daos_prop_set_str(prop, DAOS_PROP_CO_LABEL, label2_v2, strlen(label2_v2));
 		assert_rc_equal(rc, 0);
 		print_message("step: C3 set-prop change FROM %s TO %s\n",
 			      label2, label2_v2);
 		rc = daos_cont_set_prop(coh3, prop, NULL);
 		assert_rc_equal(rc, 0);
-		rc = daos_prop_entry_set_str(prop, DAOS_PROP_CO_LABEL, label2, strlen(label2));
+		rc = daos_prop_set_str(prop, DAOS_PROP_CO_LABEL, label2, strlen(label2));
 		assert_rc_equal(rc, 0);
 		print_message("step: C1 set-prop change FROM %s TO %s\n",
 			      label, label2);


### PR DESCRIPTION
The current property API usage only works for the DAOS library since it has the same allocator and free functions. regular users cannot be expected to allocate the str or ptr values for property entries, and then DAOS would free them using daos_prop_free().

This PR adds APIs to set the str and ptr values so they can be freed in daos_prop_free().
this doesn't migrate all internal usage of the props to that new API, but this is not a problem, because internal usage is the same as using this function since those entries are allocated with D_ macros internally.

Signed-off-by: Mohamad Chaarawi <mohamad.chaarawi@intel.com>