### PR TITLE
DAOS-7589 test: Update pool_list() in dmg_utils.py and affected tests

### DIFF
--- a/src/tests/ftest/control/dmg_system_reformat.py
+++ b/src/tests/ftest/control/dmg_system_reformat.py
@@ -77,7 +77,7 @@ class DmgSystemReformatTest(PoolTestBase):
         self.server_managers[-1].detect_engine_start(host_qty=2)
 
         # Check that we have cleared storage by checking pool list
-        if self.get_dmg_command().pool_list():
+        if self.get_dmg_command().pool_list()["response"]["pools"]:
             self.fail("Detected pools in storage after reformat: {}".format(
                 self.get_dmg_command().result.stdout_text))
 
@@ -85,5 +85,6 @@ class DmgSystemReformatTest(PoolTestBase):
         self.add_pool_qty(1)
 
         # Lastly, verify that last created pool is in the list
-        pool_info = self.get_dmg_command().pool_list()
-        self.assertEqual(list(pool_info)[0], self.pool[-1].uuid)
+        output = self.get_dmg_command().pool_list()
+        actual_uuid = output["response"]["pools"][0]["uuid"]
+        self.assertEqual(actual_uuid, self.pool[-1].uuid)

--- a/src/tests/ftest/control/ms_resilience.py
+++ b/src/tests/ftest/control/ms_resilience.py
@@ -40,8 +40,14 @@ class ManagementServiceResilience(TestWithServers):
 
         Returns:
             Pool entry, if found, or None.
+
         """
-        for pool_uuid in self.get_dmg_command().pool_list(no_query=True):
+        output = self.get_dmg_command().pool_list(no_query=True)
+        uuids = []
+        for pool in output["response"]["pools"]:
+            uuids.append(pool["uuid"])
+
+        for pool_uuid in uuids:
             if pool_uuid.lower() == search_uuid.lower():
                 return pool_uuid
         return None
@@ -66,6 +72,7 @@ class ManagementServiceResilience(TestWithServers):
 
         Returns:
             str: hostname of the MS leader, or None
+
         """
         sys_leader_info = self.get_dmg_command().system_leader_query()
         l_addr = sys_leader_info["response"]["CurrentLeader"]
@@ -239,8 +246,9 @@ class ManagementServiceResilience(TestWithServers):
         Test Description:
             Test N=1 management service is accessible after 1 instance is removed.
 
-        :avocado: tags=all,pr,daily_regression,control,ms_resilience
-        :avocado: tags=ms_retained_quorum_N_1
+        :avocado: tags=all,pr,daily_regression
+        :avocado: tags=vm
+        :avocado: tags=control,ms_resilience,ms_retained_quorum_N_1
         """
         # Run test cases
         self.verify_retained_quorum(1)
@@ -252,8 +260,9 @@ class ManagementServiceResilience(TestWithServers):
         Test Description:
             Test N=2 management service is accessible after 2 instances are removed.
 
-        :avocado: tags=all,pr,daily_regression,control,ms_resilience
-        :avocado: tags=ms_retained_quorum_N_2
+        :avocado: tags=all,pr,daily_regression
+        :avocado: tags=vm
+        :avocado: tags=control,ms_resilience,ms_retained_quorum_N_2
         """
         # Run test cases
         self.verify_retained_quorum(2)
@@ -267,8 +276,9 @@ class ManagementServiceResilience(TestWithServers):
             lost (degraded mode), and then test that quorum can be regained for
             full functionality.
 
-        :avocado: tags=all,pr,daily_regression,control,ms_resilience
-        :avocado: tags=ms_regained_quorum_N_1
+        :avocado: tags=all,pr,daily_regression
+        :avocado: tags=vm
+        :avocado: tags=control,ms_resilience,ms_regained_quorum_N_1
         """
         # Run test case
         self.verify_regained_quorum(1)
@@ -282,8 +292,9 @@ class ManagementServiceResilience(TestWithServers):
             lost (degraded mode), and then test that quorum can be regained for
             full functionality.
 
-        :avocado: tags=all,pr,daily_regression,control,ms_resilience
-        :avocado: tags=ms_regained_quorum_N_2
+        :avocado: tags=all,pr,daily_regression
+        :avocado: tags=vm
+        :avocado: tags=control,ms_resilience,ms_regained_quorum_N_2
         """
         # Run test case
         self.verify_regained_quorum(2)

--- a/src/tests/ftest/pool/create_capacity_test.py
+++ b/src/tests/ftest/pool/create_capacity_test.py
@@ -58,8 +58,13 @@ class PoolCreateTests(PoolTestBase):
             "DAOS not ready to accept requests with in 2 minutes")
 
         self.dmg.timeout = 360
+
         # Verify all the pools exists after the restart
-        detected_pools = [uuid.lower() for uuid in self.dmg.pool_list(no_query=True)]
+        output = self.dmg.pool_list(no_query=True)
+        detected_pools = []
+        for pool in output["response"]["pools"]:
+            detected_pools.append(pool["uuid"].lower())
+
         missing_pools = []
         for pool in self.pool:
             pool_uuid = pool.uuid.lower()

--- a/src/tests/ftest/pool/dynamic_server_pool.py
+++ b/src/tests/ftest/pool/dynamic_server_pool.py
@@ -42,7 +42,12 @@ class DynamicServerPool(TestWithServers):
         """Call dmg pool list to get the list of UUIDs and verify against the
         expected UUIDs.
         """
-        actual_uuids = sorted(self.get_dmg_command().pool_list())
+        actual_uuids = []
+        output = self.get_dmg_command().pool_list()
+        for pool in output["response"]["pools"]:
+            actual_uuids.append(pool["uuid"])
+        actual_uuids.sort()
+
         self.expected_uuids.sort()
         self.assertEqual(self.expected_uuids, actual_uuids)
 
@@ -98,7 +103,9 @@ class DynamicServerPool(TestWithServers):
 
         Test Description: See class description.
 
-        :avocado: tags=all,medium,control,full_regression,dynamic_server_pool
+        :avocado: tags=all,full_regression
+        :avocado: tags=vm
+        :avocado: tags=control,dynamic_server_pool
         """
         # Create a pool on rank0.
         self.create_pool_with_ranks(ranks=[0], tl_update=True)

--- a/src/tests/ftest/util/dmg_utils.py
+++ b/src/tests/ftest/util/dmg_utils.py
@@ -618,58 +618,57 @@ class DmgCommand(DmgCommandBase):
         return self._get_result(
             ("pool", "delete-acl"), pool=pool, principal=principal)
 
-    def pool_list(self, no_query=False):
+    def pool_list(self, no_query=False, verbose=False):
         """List pools.
 
         Args:
             no_query (bool, optional): If True, do not query for pool stats.
+            verbose (bool, optional): If True, use verbose mode.
 
         Raises:
             CommandFailure: if the dmg pool pool list command fails.
 
         Returns:
-            dict: a dictionary of pool UUID keys and svc replica values
+            dict: JSON output dictionary
 
         """
-        # Sample JSON Output:
+        # Sample verbose JSON Output:
         # {
-        #    "response": {
-        #        "status": 0,
-        #        "pools": [
-        #        {
-        #            "uuid": "3dd3f313-6e37-4890-9e64-93a34d04e9f5",
-        #            "label": "foobar",
-        #            "svc_reps": [
-        #            0
-        #            ]
-        #        },
-        #        {
-        #            "uuid": "6871d543-9a12-4530-b704-d937197c131c",
-        #            "label": "foobaz",
-        #            "svc_reps": [
-        #            0
-        #            ]
-        #        },
-        #        {
-        #            "uuid": "aa503e26-e974-4634-ac5a-738ee00f0c39",
-        #            "svc_reps": [
-        #            0
-        #            ]
-        #        }
-        #        ]
-        #    },
-        #    "error": null,
-        #    "status": 0
+        #     "response": {
+        #         "status": 0,
+        #         "pools": [
+        #         {
+        #             "uuid": "517217db-47c4-4bb9-aae5-e38ca7b3dafc",
+        #             "label": "mkp1",
+        #             "svc_reps": [
+        #             0
+        #             ],
+        #             "targets_total": 8,
+        #             "targets_disabled": 0,
+        #             "query_error_msg": "",
+        #             "query_status_msg": "",
+        #             "usage": [
+        #             {
+        #                 "tier_name": "SCM",
+        #                 "size": 3000000000,
+        #                 "free": 2995801112,
+        #                 "imbalance": 0
+        #             },
+        #             {
+        #                 "tier_name": "NVME",
+        #                 "size": 47000000000,
+        #                 "free": 26263322624,
+        #                 "imbalance": 36
+        #             }
+        #             ]
+        #         }
+        #         ]
+        #     },
+        #     "error": null,
+        #     "status": 0
         # }
-        output = self._get_json_result(("pool", "list"), no_query=no_query)
-
-        data = {}
-        if output["response"] is None or output["response"]["pools"] is None:
-            return data
-
-        for pool in output["response"]["pools"]:
-            data[pool["uuid"]] = pool["svc_reps"]
-        return data
+        return self._get_json_result(
+            ("pool", "list"), no_query=no_query, verbose=verbose)
 
     def pool_set_prop(self, pool, name, value):
         """Set property for a given Pool.

--- a/src/tests/ftest/util/dmg_utils_base.py
+++ b/src/tests/ftest/util/dmg_utils_base.py
@@ -303,7 +303,7 @@ class DmgCommandBase(YamlCommand):
                 """Create a dmg pool list command object."""
                 super().__init__("/run/dmg/pool/list/*", "list")
                 self.no_query = FormattedParameter("--no-query", False)
-                self.no_query = FormattedParameter("--verbose", False)
+                self.verbose = FormattedParameter("--verbose", False)
 
         class OverwriteAclSubCommand(CommandWithParameters):
             """Defines an object for the dmg pool overwrite-acl command."""

--- a/src/tests/ftest/util/dmg_utils_base.py
+++ b/src/tests/ftest/util/dmg_utils_base.py
@@ -303,6 +303,7 @@ class DmgCommandBase(YamlCommand):
                 """Create a dmg pool list command object."""
                 super().__init__("/run/dmg/pool/list/*", "list")
                 self.no_query = FormattedParameter("--no-query", False)
+                self.no_query = FormattedParameter("--verbose", False)
 
         class OverwriteAclSubCommand(CommandWithParameters):
             """Defines an object for the dmg pool overwrite-acl command."""


### PR DESCRIPTION
Use JSON for dmg pool list.
Fixed affected tests.

Skip-unit-tests: true
Test-tag: pr list_pools dynamic_server_pool
Signed-off-by: Makito Kano <makito.kano@intel.com>