### PR TITLE
DAOS-8293 dfs: dfs_sys should not set size = -1

### DIFF
--- a/src/client/dfs/dfs_sys.c
+++ b/src/client/dfs/dfs_sys.c
@@ -815,10 +815,8 @@ dfs_sys_listxattr(dfs_sys_t *dfs_sys, const char *path, char *list,
 
 listxattr:
 	rc = dfs_listxattr(dfs_sys->dfs, obj, list, &got_size);
-	if (rc != 0) {
-		*size = -1;
+	if (rc != 0)
 		D_GOTO(out_free_obj, rc);
-	}
 
 	if (*size < got_size)
 		rc = ERANGE;
@@ -871,10 +869,8 @@ dfs_sys_getxattr(dfs_sys_t *dfs_sys, const char *path, const char *name,
 
 getxattr:
 	rc = dfs_getxattr(dfs_sys->dfs, obj, name, value, &got_size);
-	if (rc != 0) {
-		*size = -1;
+	if (rc != 0)
 		D_GOTO(out_free_obj, rc);
-	}
 
 	if (*size < got_size)
 		rc = ERANGE;
@@ -1012,8 +1008,6 @@ dfs_sys_readlink(dfs_sys_t *dfs_sys, const char *path, char *buf,
 	}
 
 	rc = dfs_get_symlink_value(obj, buf, size);
-	if (rc != 0)
-		*size = -1;
 
 	dfs_release(obj);
 
@@ -1143,7 +1137,6 @@ int
 dfs_sys_read(dfs_sys_t *dfs_sys, dfs_obj_t *obj, void *buf, daos_off_t off,
 	     daos_size_t *size, daos_event_t *ev)
 {
-	int		rc;
 	d_iov_t		iov;
 	d_sg_list_t	sgl;
 
@@ -1159,18 +1152,13 @@ dfs_sys_read(dfs_sys_t *dfs_sys, dfs_obj_t *obj, void *buf, daos_off_t off,
 	sgl.sg_iovs = &iov;
 	sgl.sg_nr_out = 1;
 
-	rc = dfs_read(dfs_sys->dfs, obj, &sgl, off, size, ev);
-	if (rc != 0)
-		*size = -1;
-
-	return rc;
+	return dfs_read(dfs_sys->dfs, obj, &sgl, off, size, ev);
 }
 
 int
 dfs_sys_write(dfs_sys_t *dfs_sys, dfs_obj_t *obj, const void *buf,
 	      daos_off_t off, daos_size_t *size, daos_event_t *ev)
 {
-	int		rc;
 	d_iov_t		iov;
 	d_sg_list_t	sgl;
 
@@ -1186,11 +1174,7 @@ dfs_sys_write(dfs_sys_t *dfs_sys, dfs_obj_t *obj, const void *buf,
 	sgl.sg_iovs = &iov;
 	sgl.sg_nr_out = 1;
 
-	rc = dfs_write(dfs_sys->dfs, obj, &sgl, off, ev);
-	if (rc != 0)
-		*size = -1;
-
-	return rc;
+	return dfs_write(dfs_sys->dfs, obj, &sgl, off, ev);
 }
 
 int

--- a/src/include/daos_fs_sys.h
+++ b/src/include/daos_fs_sys.h
@@ -8,11 +8,9 @@
  *
  * DAOS File System "Sys" API
  *
- * The DFS Sys API provides a simplified layer directly on top
- * of the DFS API that is more similar to the equivalent
- * POSIX libraries. While the DFS Sys API stands on its own,
- * the DFS API can be used directly by getting the DFS Object
- * with dfs_sys2base().
+ * The DFS Sys API provides a simplified layer directly on top of the DFS API that is more
+ * similar to the equivalent POSIX libraries. While the DFS Sys API stands on its own,
+ * the DFS API can be used directly by getting the DFS Object with dfs_sys2base().
  */
 
 #ifndef __DAOS_FS_SYS_H__
@@ -27,15 +25,15 @@ extern "C" {
 #include <daos.h>
 #include <daos_fs.h>
 
-#define DFS_SYS_NO_CACHE 1
-#define DFS_SYS_NO_LOCK 2
+/** Mount flags for dfs_sys_mount. By default, mount with caching and locking turned on. */
+#define DFS_SYS_NO_CACHE 1 /** Turn off directory caching */
+#define DFS_SYS_NO_LOCK 2  /** Turn off locking. Useful for single-threaded applications. */
 
 /** struct holding attributes for the dfs_sys calls */
 typedef struct dfs_sys dfs_sys_t;
 
 /**
- * Mount a file system with dfs_mount and optionally
- * initialize a cache.
+ * Mount a file system with dfs_mount and optionally initialize a cache.
  *
  * \param[in]	poh	Pool connection handle.
  * \param[in]	coh	Container open handle.
@@ -84,8 +82,7 @@ dfs_sys_local2global(dfs_sys_t *dfs_sys, d_iov_t *glob);
  *			of serialized DFS Sys handle.
  * \param[in]	sflags	Sys flags (DFS_SYS_NO_CACHE or DFS_SYS_NO_LOCK).
  *			This is not inherited from the DFS Sys handle.
- * \param[in]	glob	Global (shared) representation of a collective handle
- *			to be extracted.
+ * \param[in]	glob	Global (shared) representation of a collective handle to be extracted.
  * \param[out]	dfs_sys	Returned dfs_sys mount.
  */
 int
@@ -223,7 +220,6 @@ dfs_sys_mknod(dfs_sys_t *dfs_sys, const char *path, mode_t mode,
  *			[out]: Names placed after each other (null terminated).
  * \param[in,out]
  *		size	[in]: Size of list. [out]: Actual size of list.
- *			On error, this is set to -1.
  * \param[in]	flags	(O_NOFOLLOW)
  *
  * \return		0 on success, errno code on failure.
@@ -243,7 +239,6 @@ dfs_sys_listxattr(dfs_sys_t *dfs_sys, const char *path, char *list,
  * \param[out]	value	Buffer to place value of xattr.
  * \param[in,out]
  *		size	[in]: Size of buffer value. [out]: Actual size of xattr.
- *			On error, this is set to -1.
  * \param[in]	flags	(O_NOFOLLOW)
  *
  * \return		0 on success, errno code on failure.
@@ -300,8 +295,7 @@ dfs_sys_removexattr(dfs_sys_t *dfs_sys, const char *path, const char *name,
  *		buf	[in]: Allocated buffer for value.
  *			[out]: Symlink value.
  * \param[in,out]
- *		size	[in]: Size of buffer passed in. [out]: Actual size of
- *			      value. On error, this is set to -1.
+ *		size	[in]: Size of buffer passed in. [out]: Actual size of value.
  *
  * \return		0 on success, errno code on failure.
  */
@@ -366,8 +360,7 @@ dfs_sys_close(dfs_obj_t *obj);
  *			[out]: Actual data read.
  * \param[in]	off	Offset into the file to read from.
  * \param[in,out]
- *		size	[in]: Size of buffer passed in. [out]: Actual size of
- *			      data read. On error, this is set to -1.
+ *		size	[in]: Size of buffer passed in. [out]: Actual size of data read.
  * \param[in]	ev	Completion event, it is optional and can be NULL.
  *			Function will run in blocking mode if \a ev is NULL.
  *
@@ -385,8 +378,7 @@ dfs_sys_read(dfs_sys_t *dfs_sys, dfs_obj_t *obj, void *buf, daos_off_t off,
  * \param[in]	buf	Data to write.
  * \param[in]	off	Offset into the file to write to.
  * \param[in,out]
- *		size	[in]: Size of buffer passed in. [out]: Actual size of
- *			      data written. On error, this is set to -1.
+ *		size	[in]: Size of buffer passed in. [out]: Actual size of data written.
  * \param[in]	ev	Completion event, it is optional and can be NULL.
  *			Function will run in blocking mode if \a ev is NULL.
  *

--- a/src/include/daos_fs_sys.h
+++ b/src/include/daos_fs_sys.h
@@ -26,8 +26,8 @@ extern "C" {
 #include <daos_fs.h>
 
 /** Mount flags for dfs_sys_mount. By default, mount with caching and locking turned on. */
-#define DFS_SYS_NO_CACHE 1 /** Turn off directory caching */
-#define DFS_SYS_NO_LOCK 2  /** Turn off locking. Useful for single-threaded applications. */
+#define DFS_SYS_NO_CACHE 1 /**< Turn off directory caching */
+#define DFS_SYS_NO_LOCK 2  /**< Turn off locking. Useful for single-threaded applications. */
 
 /** struct holding attributes for the dfs_sys calls */
 typedef struct dfs_sys dfs_sys_t;

--- a/src/tests/ftest/datamover/dm_large_dir.yaml
+++ b/src/tests/ftest/datamover/dm_large_dir.yaml
@@ -21,8 +21,8 @@ server_config:
 pool:
   mode: 146
   name: daos_server
-  scm_size: 42000000000       # 42G
-  nvme_size: 700000000000     # 700G
+  scm_size: 95%
+  nvme_size: 90%
   svcn: 1
   control_method: dmg
 container:

--- a/src/tests/ftest/datamover/dm_large_file.yaml
+++ b/src/tests/ftest/datamover/dm_large_file.yaml
@@ -21,8 +21,8 @@ server_config:
 pool:
   mode: 146
   name: daos_server
-  scm_size: 42000000000       # 42G
-  nvme_size: 700000000000     # 700G
+  scm_size: 95%
+  nvme_size: 90%
   svcn: 1
   control_method: dmg
 container:

--- a/src/tests/suite/dfs_sys_unit_test.c
+++ b/src/tests/suite/dfs_sys_unit_test.c
@@ -375,7 +375,6 @@ dfs_sys_test_readlink(void **state)
 	/** readlink on non-symlink */
 	rc = dfs_sys_readlink(dfs_sys_mt, file1, buf, &buf_size);
 	assert_int_equal(rc, EINVAL);
-	assert_int_equal(buf_size, -1);
 
 	/** readlink with NULL buffer */
 	rc = dfs_sys_readlink(dfs_sys_mt, sym1, buf, &buf_size);
@@ -508,13 +507,11 @@ dfs_sys_test_read_write(void **state)
 	got_size = buf_size;
 	rc = dfs_sys_write(dfs_sys_mt, obj, write_buf, 0, &got_size, NULL);
 	assert_int_equal(rc, EINVAL);
-	assert_int_equal(got_size, -1);
 
 	/** Try to read a dir*/
 	got_size = buf_size;
 	rc = dfs_sys_read(dfs_sys_mt, obj, read_buf, 0, &got_size, NULL);
 	assert_int_equal(rc, EINVAL);
-	assert_int_equal(got_size, -1);
 
 	/** Try to punch a dir */
 	rc = dfs_sys_punch(dfs_sys_mt, dir1, 0, buf_size);


### PR DESCRIPTION
Test-tag: pr fs_copy dcp

Don't set size = -1 for daos_size_t types, since it is unsigned.
The rc is set appropriately anyway, so this is redundant.

Signed-off-by: Dalton Bohning <daltonx.bohning@intel.com>