### PR TITLE
CART-89 shadow: Shadow param to generate error instead of warn

### DIFF
--- a/site_scons/compiler_setup.py
+++ b/site_scons/compiler_setup.py
@@ -73,7 +73,7 @@ def base_setup(env, prereqs=None):
     env.AppendUnique(CPPDEFINES='_GNU_SOURCE')
 
     cenv = env.Clone()
-    cenv.Append(CFLAGS='-Werror')
+    cenv.Append(CFLAGS='-Werror -Wshadow')
     config = Configure(cenv)
     if config.CheckHeader('stdatomic.h'):
         config.Finish()

--- a/site_scons/compiler_setup.py
+++ b/site_scons/compiler_setup.py
@@ -73,7 +73,7 @@ def base_setup(env, prereqs=None):
     env.AppendUnique(CPPDEFINES='_GNU_SOURCE')
 
     cenv = env.Clone()
-    cenv.Append(CFLAGS='-Werror -Wshadow')
+    cenv.Append(CFLAGS='-Werror')
     config = Configure(cenv)
     if config.CheckHeader('stdatomic.h'):
         config.Finish()

--- a/src/include/gurt/debug.h
+++ b/src/include/gurt/debug.h
@@ -63,7 +63,7 @@ extern void (*d_alt_assert)(const int, const char*, const char*, const int);
  * scope.   This enables use of a variable in the macro below and is
  * just good coding practice.
  */
-#pragma GCC diagnostic warning "-Wshadow"
+#pragma GCC diagnostic error "-Wshadow"
 
 /** Internal macro for printing the message using resolved mask */
 #define _D_LOG_NOCHECK(mask, fmt, ...)				\

--- a/src/object/cli_shard.c
+++ b/src/object/cli_shard.c
@@ -1903,10 +1903,10 @@ re_check:
 				shard, punched_recx->rx_idx, punched_recx->rx_nr);
 			D_ASSERT(DAOS_RECX_END(*punched_recx) >= tmp_recx->rx_idx);
 			if (DAOS_RECX_END(*punched_recx) < DAOS_RECX_END(*tmp_recx)) {
-				uint64_t end = DAOS_RECX_END(*tmp_recx);
+				uint64_t r_end = DAOS_RECX_END(*tmp_recx);
 
 				tmp_recx->rx_idx = DAOS_RECX_END(*punched_recx);
-				tmp_recx->rx_nr = end - tmp_recx->rx_idx;
+				tmp_recx->rx_nr = r_end - tmp_recx->rx_idx;
 			} else if (punched_recx->rx_idx > tmp_recx->rx_idx) {
 				tmp_recx->rx_nr = min(punched_recx->rx_idx,
 						      DAOS_RECX_END(*tmp_recx)) - tmp_recx->rx_idx;


### PR DESCRIPTION
- Add -Wshadow as a flag to our build; change gurt header to mark
shadow warnings as errors.

Signed-off-by: Alexander Oganezov <alexander.a.oganezov@intel.com>