### PR TITLE
DAOS-8314 pool: Fix map_known_stale assertion failures

### DIFF
--- a/src/pool/cli.c
+++ b/src/pool/cli.c
@@ -223,15 +223,16 @@ choose:
 
 /* Assume dp_map_lock is locked before calling this function */
 int
-dc_pool_map_update(struct dc_pool *pool, struct pool_map *map,
-		   unsigned int map_version, bool connect)
+dc_pool_map_update(struct dc_pool *pool, struct pool_map *map, bool connect)
 {
-	int rc;
+	unsigned int	map_version;
+	int		rc;
 
 	D_ASSERT(map != NULL);
+	map_version = pool_map_get_version(map);
+
 	if (pool->dp_map == NULL) {
-		rc = pl_map_update(pool->dp_pool, map, connect,
-				DEFAULT_PL_TYPE);
+		rc = pl_map_update(pool->dp_pool, map, connect, DEFAULT_PL_TYPE);
 		if (rc != 0)
 			D_GOTO(out, rc);
 
@@ -292,7 +293,7 @@ process_query_reply(struct dc_pool *pool, struct pool_buf *map_buf,
 	}
 
 	D_RWLOCK_WRLOCK(&pool->dp_map_lock);
-	rc = dc_pool_map_update(pool, map, map_version, connect);
+	rc = dc_pool_map_update(pool, map, connect);
 	if (rc)
 		D_GOTO(out_unlock, rc);
 
@@ -950,6 +951,7 @@ dc_pool_g2l(struct dc_pool_glob *pool_glob, size_t len, daos_handle_t *poh)
 {
 	struct dc_pool		*pool;
 	struct pool_buf		*map_buf;
+	struct pool_map		*map = NULL;
 	void			*p;
 	int			 rc = 0;
 
@@ -981,16 +983,14 @@ dc_pool_g2l(struct dc_pool_glob *pool_glob, size_t len, daos_handle_t *poh)
 	if (rc < 0)
 		goto out;
 
-	rc = pool_map_create(map_buf, pool_glob->dpg_map_version,
-			     &pool->dp_map);
+	rc = pool_map_create(map_buf, pool_glob->dpg_map_version, &map);
 	if (rc != 0) {
 		D_ERROR("failed to create local pool map: "DF_RC"\n",
 			DP_RC(rc));
 		D_GOTO(out, rc);
 	}
 
-	rc = pl_map_update(pool->dp_pool, pool->dp_map, true,
-			DEFAULT_PL_TYPE);
+	rc = dc_pool_map_update(pool, map, true /* connect */);
 	if (rc != 0)
 		D_GOTO(out, rc);
 
@@ -1005,6 +1005,8 @@ dc_pool_g2l(struct dc_pool_glob *pool_glob, size_t len, daos_handle_t *poh)
 out:
 	if (rc != 0)
 		D_ERROR("failed, rc: "DF_RC"\n", DP_RC(rc));
+	if (map != NULL)
+		pool_map_decref(map);
 	if (pool != NULL)
 		dc_pool_put(pool);
 	return rc;
@@ -1611,7 +1613,8 @@ map_refresh_cb(tse_task_t *task, void *varg)
 		goto out;
 	}
 
-	rc = dc_pool_map_update(pool, map, out->tmo_op.po_map_version, false /* connect */);
+	rc = dc_pool_map_update(pool, map, false /* connect */);
+	pool_map_decref(map);
 
 out:
 	destroy_map_refresh_rpc(cb_arg->mrc_rpc, cb_arg->mrc_map_buf);

--- a/src/pool/cli_internal.h
+++ b/src/pool/cli_internal.h
@@ -21,7 +21,6 @@ void dc_pool_hdl_link(struct dc_pool *pool);
 void dc_pool_hdl_unlink(struct dc_pool *pool);
 struct dc_pool *dc_pool_alloc(unsigned int nr);
 
-int dc_pool_map_update(struct dc_pool *pool, struct pool_map *map,
-		       unsigned int map_version, bool connect);
+int dc_pool_map_update(struct dc_pool *pool, struct pool_map *map, bool connect);
 
 #endif /* __POOL_CLIENT_INTERNAL_H__ */

--- a/src/pool/srv_cli.c
+++ b/src/pool/srv_cli.c
@@ -71,7 +71,7 @@ dsc_pool_open(uuid_t pool_uuid, uuid_t poh_uuid, unsigned int flags,
 		D_GOTO(out, rc);
 
 	D_DEBUG(DB_TRACE, "before update "DF_UUIDF"\n", DP_UUID(pool_uuid));
-	rc = dc_pool_map_update(pool, map, pool_map_get_version(map), true);
+	rc = dc_pool_map_update(pool, map, true);
 	if (rc)
 		D_GOTO(out, rc);
 


### PR DESCRIPTION
The following assertaion failure was observed:

    pool EMRG src/pool/cli.c:1409 map_known_stale() Assertion
    'pool->dp_map_version_known >= cached' failed: 1 >= 9

It implies that in some case(s), we update the cached pool map but not
the known pool map version. Going through all places that modify dp_map
reveals dc_pool_g2l as the only case. This patch changes dc_pool_g2l to
use dc_pool_map_update instead, so that dp_map_version_known will be
updated properly.

Also:

  - Fix a pool_map leak in map_refresh_cb.
  - Remove the redundant map_version parameter from dc_pool_map_update.

Signed-off-by: Li Wei <wei.g.li@intel.com>