### PR TITLE
DAOS-7774 dtx: avoid holding CPU for very long time

### DIFF
--- a/src/dtx/dtx_internal.h
+++ b/src/dtx/dtx_internal.h
@@ -94,6 +94,12 @@ CRT_RPC_DECLARE(dtx, DAOS_ISEQ_DTX, DAOS_OSEQ_DTX);
  */
 #define DTX_CLEANUP_THD_AGE_LO	45
 
+#define DTX_YIELD_MAX		256
+#define DTX_YIELD_MIN		64
+#define DTX_YIELD_DEF		128
+
+extern uint32_t dtx_yield_cycle;
+
 struct dtx_pool_metrics {
 	struct d_tm_node_t	*dpm_total[DTX_PROTO_SRV_RPC_COUNT];
 };

--- a/src/dtx/dtx_rpc.c
+++ b/src/dtx/dtx_rpc.c
@@ -624,6 +624,9 @@ dtx_commit(struct ds_cont_child *cont, struct dtx_entry **dtes,
 	int			 rc;
 	int			 rc1 = 0;
 	int			 rc2 = 0;
+	int			 step = dtx_yield_cycle;
+	int			 cur = 0;
+	int			 i;
 
 	D_INIT_LIST_HEAD(&head);
 	memset(&uma, 0, sizeof(uma));
@@ -652,18 +655,31 @@ dtx_commit(struct ds_cont_child *cont, struct dtx_entry **dtes,
 			D_GOTO(out, rc1 = -DER_NOMEM);
 	}
 
-	rc1 = vos_dtx_commit(cont->sc_hdl, dti, count, rm_cos);
-	if (rc1 >= 0 && rm_cos != NULL) {
-		int	i;
+	while (1) {
+		if (cur + step > count)
+			step = count - cur;
 
-		for (i = 0; i < count; i++) {
-			if (rm_cos[i]) {
+		rc1 = vos_dtx_commit(cont->sc_hdl, &dti[cur], step,
+				     rm_cos != NULL ? rm_cos + cur : NULL);
+		i = cur;
+		cur += step;
+
+		if (rc1 >= 0 && rm_cos != NULL) {
+			for (; i < cur; i++) {
+				if (!rm_cos[i])
+					continue;
+
 				D_ASSERT(!daos_oid_is_null(dcks[i].oid.id_pub));
 
 				dtx_del_cos(cont, &dti[i], &dcks[i].oid,
 					    dcks[i].dkey_hash);
 			}
 		}
+
+		if (cur >= count)
+			break;
+
+		ABT_thread_yield();
 	}
 
 	D_FREE(rm_cos);

--- a/src/dtx/dtx_srv.c
+++ b/src/dtx/dtx_srv.c
@@ -16,7 +16,7 @@
 #include <daos_srv/dtx_srv.h>
 #include "dtx_internal.h"
 
-#define DTX_YIELD_CYCLE		(DTX_THRESHOLD_COUNT >> 3)
+uint32_t dtx_yield_cycle;
 
 static void *
 dtx_tls_init(int xs_id, int tgt_id)
@@ -118,7 +118,7 @@ dtx_handler(crt_rpc_t *rpc)
 	uint32_t		 vers[DTX_REFRESH_MAX] = { 0 };
 	uint32_t		 opc = opc_get(rpc->cr_opc);
 	int			*ptr;
-	int			 count = DTX_YIELD_CYCLE;
+	int			 count = dtx_yield_cycle;
 	int			 i = 0;
 	int			 rc1 = 0;
 	int			 rc;
@@ -134,10 +134,11 @@ dtx_handler(crt_rpc_t *rpc)
 
 	switch (opc) {
 	case DTX_COMMIT:
-		if (DAOS_FAIL_CHECK(DAOS_DTX_MISS_COMMIT))
+		if (DAOS_FAIL_CHECK(DAOS_DTX_MISS_COMMIT) ||
+		    unlikely(din->di_dtx_array.ca_count == 0))
 			break;
 
-		while (i < din->di_dtx_array.ca_count) {
+		while (1) {
 			if (i + count > din->di_dtx_array.ca_count)
 				count = din->di_dtx_array.ca_count - i;
 
@@ -147,6 +148,10 @@ dtx_handler(crt_rpc_t *rpc)
 				rc = rc1;
 
 			i += count;
+			if (i >= din->di_dtx_array.ca_count)
+				break;
+
+			ABT_thread_yield();
 		}
 		break;
 	case DTX_ABORT:
@@ -286,7 +291,25 @@ out:
 static int
 dtx_init(void)
 {
-	int	rc;
+	const char	*str;
+	int		 rc;
+
+	str = getenv("DTX_YIELD_CYCLE");
+	if (str != NULL) {
+		dtx_yield_cycle = atoi(str);
+		if (dtx_yield_cycle < DTX_YIELD_MIN ||
+		    dtx_yield_cycle > DTX_YIELD_MAX) {
+			D_WARN("Invalid DTX yield cycle %d, the valid range is "
+			       "[%d, %d], use the default value %d\n",
+			       dtx_yield_cycle, DTX_YIELD_MIN, DTX_YIELD_MAX,
+			       DTX_YIELD_DEF);
+			dtx_yield_cycle = DTX_YIELD_DEF;
+		}
+	} else {
+		dtx_yield_cycle = DTX_YIELD_DEF;
+	}
+
+	D_INFO("Set DTX yield cycle as %d (entries)\n", dtx_yield_cycle);
 
 	rc = dbtree_class_register(DBTREE_CLASS_DTX_CF,
 				   BTR_FEAT_UINT_KEY | BTR_FEAT_DYNAMIC_ROOT,


### PR DESCRIPTION
Some batched DTX operations, such as DTX batched commit may
hold CPU for very long time, that may cause performance ware.
The patch controls CPU yield cycle for DTX batched operations
via the environment variable "DTX_YIELD_CYCLE" on server when
start DAOS engine. The valid value range is [64, 256], the
default value is 128.

Signed-off-by: Fan Yong <fan.yong@intel.com>