### PR TITLE
DAOS-8300 vos: maintain epoch for committed DTX entry

### DIFF
--- a/src/vos/vos_internal.h
+++ b/src/vos/vos_internal.h
@@ -314,6 +314,7 @@ struct vos_dtx_cmt_ent {
 
 #define DCE_XID(dce)		((dce)->dce_base.dce_xid)
 #define DCE_EPOCH(dce)		((dce)->dce_base.dce_epoch)
+#define DCE_HANDLE_TIME(dce)	((dce)->dce_base.dce_handle_time)
 
 extern int vos_evt_feats;
 

--- a/src/vos/vos_layout.h
+++ b/src/vos/vos_layout.h
@@ -88,7 +88,7 @@ enum vos_gc_type {
 #define POOL_DF_MAGIC				0x5ca1ab1e
 
 /** Lowest supported durable format version */
-#define POOL_DF_VER_1				19
+#define POOL_DF_VER_1				20
 /** Current durable format version */
 #define POOL_DF_VERSION				POOL_DF_VER_1
 
@@ -147,6 +147,8 @@ struct vos_dtx_cmt_ent_df {
 	struct dtx_id			dce_xid;
 	/** The epoch# for the DTX. */
 	daos_epoch_t			dce_epoch;
+	/** The time of the DTX being handled on the server. */
+	daos_epoch_t			dce_handle_time;
 };
 
 /** Active DTX entry on-disk layout in both SCM and DRAM. */


### PR DESCRIPTION
It is mainly used for handling resent distributed transaction
CPD RPC that requires the server to reply the client with the
committable/committed transaction epoch.

This patch enlarges the committed DTX entry size with 8 bytes.

Signed-off-by: Fan Yong <fan.yong@intel.com>