### PR TITLE
DAOS-8235 agent: Fix data race in GetAttachInfo

### DIFF
--- a/src/control/cmd/daos_agent/mgmt_rpc.go
+++ b/src/control/cmd/daos_agent/mgmt_rpc.go
@@ -171,7 +171,7 @@ func (mod *mgmtModule) getAttachInfoResp(ctx context.Context, numaNode int, sys 
 	}
 
 	mod.attachInfo.Cache(ctx, resp)
-	return resp, nil
+	return mod.attachInfo.GetAttachInfoResp()
 }
 
 func (mod *mgmtModule) getAttachInfoRemote(ctx context.Context, numaNode int, sys string) (*mgmtpb.GetAttachInfoResp, error) {

--- a/src/control/cmd/daos_agent/mgmt_rpc_test.go
+++ b/src/control/cmd/daos_agent/mgmt_rpc_test.go
@@ -1,0 +1,79 @@
+//
+// (C) Copyright 2021 Intel Corporation.
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+
+package main
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/pkg/errors"
+
+	"github.com/daos-stack/daos/src/control/common"
+	mgmtpb "github.com/daos-stack/daos/src/control/common/proto/mgmt"
+	"github.com/daos-stack/daos/src/control/lib/control"
+	"github.com/daos-stack/daos/src/control/lib/netdetect"
+	"github.com/daos-stack/daos/src/control/logging"
+)
+
+func TestAgent_mgmtModule_getAttachInfo_Parallel(t *testing.T) {
+	log, buf := logging.NewTestLogger(t.Name())
+	defer common.ShowBufferOnFailure(t, buf)
+
+	sysName := "dontcare"
+
+	mod := &mgmtModule{
+		log: log,
+		sys: sysName,
+		fabricInfo: newTestFabricCache(t, log, &NUMAFabric{
+			log: log,
+			numaMap: map[int][]*FabricInterface{
+				0: {
+					&FabricInterface{
+						Name:        "test0",
+						Domain:      "",
+						NetDevClass: netdetect.Ether,
+					},
+				},
+			},
+		}),
+		attachInfo: newAttachInfoCache(log, true),
+		ctlInvoker: control.NewMockInvoker(log, &control.MockInvokerConfig{
+			Sys: sysName,
+			UnaryResponse: &control.UnaryResponse{
+				Responses: []*control.HostResponse{
+					{
+						Message: &mgmtpb.GetAttachInfoResp{
+							MsRanks: []uint32{0, 1, 3},
+							ClientNetHint: &mgmtpb.ClientNetHint{
+								Provider:    "ofi+sockets",
+								NetDevClass: netdetect.Ether,
+							},
+						},
+					},
+				},
+			},
+		}),
+	}
+
+	var wg sync.WaitGroup
+
+	numThreads := 20
+	for i := 0; i < numThreads; i++ {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+
+			_, err := mod.getAttachInfo(context.Background(), 0, sysName)
+			if err != nil {
+				panic(errors.Wrapf(err, "thread %d", n))
+			}
+		}(i)
+	}
+
+	wg.Wait()
+}


### PR DESCRIPTION
Also fixed a test-level race in MockUnaryInvoker.

Signed-off-by: Kris Jacque <kristin.jacque@intel.com>