### PR TITLE
DAOS-8300 dtx: control dtx aggregation threshold when start engine

### DIFF
--- a/src/dtx/dtx_common.c
+++ b/src/dtx/dtx_common.c
@@ -19,6 +19,10 @@
 
 uint64_t dtx_agg_gen;
 struct dtx_batched_cont_args;
+uint32_t dtx_agg_thd_cnt_up;
+uint32_t dtx_agg_thd_cnt_lo;
+uint32_t dtx_agg_thd_age_up;
+uint32_t dtx_agg_thd_age_lo;
 
 struct dtx_batched_pool_args {
 	/* Link to dss_module_info::dmi_dtx_batched_pool_list. */
@@ -291,9 +295,9 @@ dtx_aggregate(void *arg)
 
 		if (stat.dtx_cont_cmt_count == 0 ||
 		    stat.dtx_first_cmt_blob_time_lo == 0 ||
-		    (stat.dtx_cont_cmt_count <= DTX_AGG_THD_CNT_LO &&
+		    (stat.dtx_cont_cmt_count <= dtx_agg_thd_cnt_lo &&
 		     dtx_hlc_age2sec(stat.dtx_first_cmt_blob_time_lo) <=
-		     DTX_AGG_THD_AGE_LO))
+		     dtx_agg_thd_age_lo))
 			break;
 	}
 
@@ -346,11 +350,11 @@ dtx_aggregation_pool(struct dtx_batched_pool_args *dbpa)
 		    stat.dtx_first_cmt_blob_time_lo == 0)
 			continue;
 
-		if (stat.dtx_cont_cmt_count >= DTX_AGG_THD_CNT_UP ||
-		    ((stat.dtx_cont_cmt_count > DTX_AGG_THD_CNT_LO ||
-		      stat.dtx_pool_cmt_count >= DTX_AGG_THD_CNT_UP) &&
+		if (stat.dtx_cont_cmt_count >= dtx_agg_thd_cnt_up ||
+		    ((stat.dtx_cont_cmt_count > dtx_agg_thd_cnt_lo ||
+		      stat.dtx_pool_cmt_count >= dtx_agg_thd_cnt_up) &&
 		     (dtx_hlc_age2sec(stat.dtx_first_cmt_blob_time_lo) >=
-		      DTX_AGG_THD_AGE_UP))) {
+		      dtx_agg_thd_age_up))) {
 			dtx_get_dbca(dbca);
 			rc = dss_ult_create(dtx_aggregate, dbca,
 					    DSS_XS_SELF, 0, 0, &child);
@@ -393,10 +397,10 @@ dtx_aggregation_pool(struct dtx_batched_pool_args *dbpa)
 	}
 
 	if (dbpa->dbpa_aggregating || dbpa->dbpa_victim == NULL ||
-	    dbpa->dbpa_stat.dtx_pool_cmt_count <= DTX_AGG_THD_CNT_LO ||
+	    dbpa->dbpa_stat.dtx_pool_cmt_count <= dtx_agg_thd_cnt_lo ||
 	    dbpa->dbpa_stat.dtx_first_cmt_blob_time_lo == 0 ||
 	    dtx_hlc_age2sec(dbpa->dbpa_stat.dtx_first_cmt_blob_time_lo) <=
-	    DTX_AGG_THD_AGE_LO)
+	    dtx_agg_thd_age_lo)
 		return;
 
 	/* No single pool exceeds DTX thresholds, but the whole pool does,
@@ -490,7 +494,7 @@ dtx_batched_commit_one(void *arg)
 
 		dtx_stat(cont, &stat);
 
-		if (stat.dtx_pool_cmt_count >= DTX_AGG_THD_CNT_UP &&
+		if (stat.dtx_pool_cmt_count >= dtx_agg_thd_cnt_up &&
 		    !dbca->dbca_pool->dbpa_aggregating)
 			sched_req_wakeup(dmi->dmi_dtx_agg_req);
 
@@ -1604,7 +1608,7 @@ dtx_handle_resend(daos_handle_t coh,  struct dtx_id *dti,
 		return -DER_DATA_LOSS;
 	case -DER_NONEXIST:
 		age = dtx_hlc_age2sec(dti->dti_hlc);
-		if (age > DTX_AGG_THD_AGE_LO ||
+		if (age > dtx_agg_thd_age_lo ||
 		    DAOS_FAIL_CHECK(DAOS_DTX_LONG_TIME_RESEND)) {
 			D_ERROR("Not sure about whether the old RPC "DF_DTI
 				" is resent or not. Age="DF_U64" s.\n",

--- a/src/dtx/dtx_internal.h
+++ b/src/dtx/dtx_internal.h
@@ -55,34 +55,6 @@ enum dtx_operation {
 
 CRT_RPC_DECLARE(dtx, DAOS_ISEQ_DTX, DAOS_OSEQ_DTX);
 
-/* The age unit is second. */
-
-/* If the DTX entries are not more than this count threshold,
- * then no need DTX aggregation.
- *
- * XXX: This threshold should consider the real SCM size. But
- *	it cannot be too small; otherwise, handing resent RPC
- *	make hit uncertain case and got failure -DER_EP_OLD.
- */
-#define DTX_AGG_THD_CNT_LO	((1 << 19) * 6)
-
-/* The count threshold for triggerring DTX aggregation. */
-#define DTX_AGG_THD_CNT_UP	((1 << 19) * 7)
-
-/* The time threshold for triggerring DTX aggregation. If the oldest
- * DTX in the DTX table exceeds such threshold, it will trigger DTX
- * aggregation locally.
- */
-#define DTX_AGG_THD_AGE_UP	210
-
-/* If DTX aggregation is triggered, then the DTXs with older ages than
- * this threshold will be aggregated.
- *
- * XXX: It cannot be too small; otherwise, handing resent RPC
- *	make hit uncertain case and got failure -DER_EP_OLD.
- */
-#define DTX_AGG_THD_AGE_LO	180
-
 /* The time threshold for triggerring DTX cleanup of stale entries.
  * If the oldest active DTX exceeds such threshold, it will trigger
  * DTX cleanup locally.
@@ -93,6 +65,47 @@ CRT_RPC_DECLARE(dtx, DAOS_ISEQ_DTX, DAOS_OSEQ_DTX);
  * older ages than this threshold will be cleanup.
  */
 #define DTX_CLEANUP_THD_AGE_LO	45
+
+/* The count threshold (per pool) for triggerring DTX aggregation. */
+#define DTX_AGG_THD_CNT_MAX	(1 << 24)
+#define DTX_AGG_THD_CNT_MIN	(1 << 20)
+#define DTX_AGG_THD_CNT_DEF	((1 << 19) * 7)
+
+/* If the total committed DTX entries count for the pool exceeds
+ * such threshold, it will trigger DTX aggregation locally.
+ *
+ * XXX: It is controlled via the environment "DTX_AGG_THD_CNT".
+ *	This threshold should consider the real SCM size. But
+ *	it cannot be too small; otherwise, handing resent RPC
+ *	make hit uncertain case and got failure -DER_EP_OLD.
+ */
+extern uint32_t dtx_agg_thd_cnt_up;
+
+/* If DTX aggregation is triggered, then current DTX aggregation
+ * will not stop until the committed DTX entries count for the
+ * pool down to such threshold.
+ */
+extern uint32_t dtx_agg_thd_cnt_lo;
+
+/* The age unit is second. */
+#define DTX_AGG_THD_AGE_MAX	700
+#define DTX_AGG_THD_AGE_MIN	140
+#define DTX_AGG_THD_AGE_DEF	210
+
+/* The time threshold for triggerring DTX aggregation. If the oldest
+ * DTX in the DTX table exceeds such threshold, it will trigger DTX
+ * aggregation locally.
+ *
+ * XXX: It is controlled via the environment "DTX_AGG_THD_AGE".
+ *	It cannot be too small; otherwise, handing resent RPC
+ *	make hit uncertain case and got failure -DER_EP_OLD.
+ */
+extern uint32_t dtx_agg_thd_age_up;
+
+/* If DTX aggregation is triggered, then the DTXs with older ages than
+ * this threshold will be aggregated.
+ */
+extern uint32_t dtx_agg_thd_age_lo;
 
 struct dtx_pool_metrics {
 	struct d_tm_node_t	*dpm_batched_degree;

--- a/src/dtx/dtx_rpc.c
+++ b/src/dtx/dtx_rpc.c
@@ -177,7 +177,7 @@ dtx_req_cb(const struct crt_cb_info *cb_info)
 			D_GOTO(out, rc = -DER_DATA_LOSS);
 		case -DER_NONEXIST:
 			if (dtx_hlc_age2sec(dsp->dsp_epoch) >
-			    DTX_AGG_THD_AGE_LO ||
+			    dtx_agg_thd_age_lo ||
 			    DAOS_FAIL_CHECK(DAOS_DTX_UNCERTAIN)) {
 
 				/* Related DTX entry on leader does not exist.

--- a/src/dtx/dtx_srv.c
+++ b/src/dtx/dtx_srv.c
@@ -319,7 +319,50 @@ out:
 static int
 dtx_init(void)
 {
-	int	rc;
+	const char	*str;
+	int		 rc;
+
+	str = getenv("DTX_AGG_THD_CNT");
+	if (str != NULL) {
+		dtx_agg_thd_cnt_up = atoi(str);
+		if (dtx_agg_thd_cnt_up < DTX_AGG_THD_CNT_MIN ||
+		    dtx_agg_thd_cnt_up > DTX_AGG_THD_CNT_MAX) {
+			D_WARN("Invalid DTX aggregation count threshold %d, "
+			       "the valid range is [%d, %d], use the "
+			       "default value %d\n",
+			       dtx_agg_thd_cnt_up, DTX_AGG_THD_CNT_MIN,
+			       DTX_AGG_THD_CNT_MAX, DTX_AGG_THD_CNT_DEF);
+			dtx_agg_thd_cnt_up = DTX_AGG_THD_CNT_DEF;
+		}
+	} else {
+		dtx_agg_thd_cnt_up = DTX_AGG_THD_CNT_DEF;
+	}
+
+	dtx_agg_thd_cnt_lo = dtx_agg_thd_cnt_up * 6 / 7;
+
+	D_INFO("Set DTX aggregation count threshold as %d (entries)\n",
+	       dtx_agg_thd_cnt_up);
+
+	str = getenv("DTX_AGG_THD_AGE");
+	if (str != NULL) {
+		dtx_agg_thd_age_up = atoi(str);
+		if (dtx_agg_thd_age_up < DTX_AGG_THD_AGE_MIN ||
+		    dtx_agg_thd_age_up > DTX_AGG_THD_AGE_MAX) {
+			D_WARN("Invalid DTX aggregation age threshold %d, "
+			       "the valid range is [%d, %d], use the "
+			       "default value %d\n",
+			       dtx_agg_thd_age_up, DTX_AGG_THD_AGE_MIN,
+			       DTX_AGG_THD_AGE_MAX, DTX_AGG_THD_AGE_DEF);
+			dtx_agg_thd_age_up = DTX_AGG_THD_AGE_DEF;
+		}
+	} else {
+		dtx_agg_thd_age_up = DTX_AGG_THD_AGE_DEF;
+	}
+
+	dtx_agg_thd_age_lo = dtx_agg_thd_age_up * 6 / 7;
+
+	D_INFO("Set DTX aggregation time threshold as %d (seconds)\n",
+	       dtx_agg_thd_age_up);
 
 	rc = dbtree_class_register(DBTREE_CLASS_DTX_CF,
 				   BTR_FEAT_UINT_KEY | BTR_FEAT_DYNAMIC_ROOT,


### PR DESCRIPTION
Allow to control DTX aggregation threshold via set the environment
variable "DTX_AGG_THRESHOLD" on server when start DAOS engine. The
valid value range is [2^20, 2^24], the default value is 2^19*7.

It is helpful for performance tuning.

Signed-off-by: Fan Yong <fan.yong@intel.com>