### PR TITLE
DAOS-8329 bugfix: Size not reset on each query

### DIFF
--- a/src/cart/crt_group.c
+++ b/src/cart/crt_group.c
@@ -2467,6 +2467,7 @@ crt_rank_self_set(d_rank_t rank)
 	d_list_for_each_entry(ctx, ctx_list, cc_link) {
 		hg_class =  ctx->cc_hg_ctx.chc_hgcla;
 
+		size = CRT_ADDR_STR_MAX_LEN;
 		rc = crt_hg_get_addr(hg_class, uri_addr, &size);
 		if (rc != 0) {
 			D_ERROR("crt_hg_get_addr() failed; rc=%d\n", rc);


### PR DESCRIPTION
- Each time uri is queried the size is not reset. This causes previous
size response to be used for next request.
If URI length changes for next target/endpoint, then it will cause
mercury overflow error.

Signed-off-by: Alexander Oganezov <alexander.a.oganezov@intel.com>