### PR TITLE
DAOS-8298 dfuse: Return a valid duns xattr for all container roots.

### DIFF
--- a/src/cart/utils/memcheck-cart.supp
+++ b/src/cart/utils/memcheck-cart.supp
@@ -199,6 +199,11 @@
 }
 {
    <insert_a_suppression_name_here>
+   Memcheck:Addr2
+   fun:runtime.memmove
+}
+{
+   <insert_a_suppression_name_here>
    Memcheck:Addr16
    fun:runtime.memmove
 }
@@ -241,6 +246,16 @@
    <insert_a_suppression_name_here>
    Memcheck:Cond
    fun:runtime.deductSweepCredit
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Addr1
+   fun:*protobuf*
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Addr8
+   fun:*protobuf*
 }
 {
    <insert_a_suppression_name_here>

--- a/src/client/dfs/duns.c
+++ b/src/client/dfs/duns.c
@@ -30,8 +30,6 @@
 #include "daos_fs.h"
 #include "daos_uns.h"
 
-#define DUNS_XATTR_FMT		"DAOS.%s://%36s/%36s"
-
 #ifndef FUSE_SUPER_MAGIC
 #define FUSE_SUPER_MAGIC	0x65735546
 #endif
@@ -712,27 +710,6 @@ err:
 	return rc;
 }
 #endif
-
-int
-duns_create_attr(char *type, uuid_t pool, uuid_t cont, char **_value, daos_size_t *_out_size)
-{
-	char *value;
-	char pool_str[37];
-	char cont_str[37];
-
-	uuid_unparse(pool, pool_str);
-	uuid_unparse(cont, cont_str);
-
-	D_ASPRINTF(value, DUNS_XATTR_FMT, type, pool_str, cont_str);
-	if (value == NULL)
-		return ENOMEM;
-
-	*_out_size = strnlen(value, DUNS_MAX_XATTR_LEN);
-
-	*_value = value;
-
-	return 0;
-}
 
 int
 duns_create_path(daos_handle_t poh, const char *path, struct duns_attr_t *attrp)

--- a/src/client/dfuse/dfuse.h
+++ b/src/client/dfuse/dfuse.h
@@ -530,6 +530,7 @@ struct dfuse_inode_entry {
 	/** file was truncated from 0 to a certain size */
 	bool			ie_truncated;
 
+	/** file is the root of a container */
 	bool			ie_root;
 
 	/** File has been unlinked from daos */

--- a/src/client/dfuse/ops/setxattr.c
+++ b/src/client/dfuse/ops/setxattr.c
@@ -19,8 +19,13 @@ dfuse_cb_setxattr(fuse_req_t req, struct dfuse_inode_entry *inode,
 
 	DFUSE_TRA_DEBUG(inode, "Attribute '%s'", name);
 
-	if (strcmp(name, DUNS_XATTR_NAME) == 0) {
+	if (strncmp(name, DUNS_XATTR_NAME, sizeof(DUNS_XATTR_NAME)) == 0) {
 		struct duns_attr_t	dattr = {};
+
+		if (inode->ie_root) {
+			DFUSE_TRA_WARNING(inode, "Attempt to set duns attr on container root");
+			D_GOTO(err, rc = EINVAL);
+		}
 
 		/* Just check this is valid, but don't do anything with it */
 		rc = duns_parse_attr((char *)value, size, &dattr);

--- a/src/control/cmd/daos/util.c
+++ b/src/control/cmd/daos/util.c
@@ -95,5 +95,5 @@ out:
 	duns_destroy_attr(&dattr);
 	D_FREE(dir_name);
 	D_FREE(name);
-	return rc;
+	return daos_errno2der(rc);
 }

--- a/src/include/daos_uns.h
+++ b/src/include/daos_uns.h
@@ -195,12 +195,15 @@ duns_destroy_path(daos_handle_t poh, const char *path);
 int
 duns_parse_attr(char *str, daos_size_t len, struct duns_attr_t *attr);
 
+int
+duns_create_attr(char *type, uuid_t pool, uuid_t cont, char **_value, daos_size_t *_out_size);
+
 /**
  * Set the system name in the duns struct in case it was obtained in a different way than
  * using duns_resolve_path().
  *
  * \param[in]	attrp	Attr pointer
- * \param[in]   sys	DAOS System name
+ * \param[in]	sys	DAOS System name
  *
  * \return              0 on Success. errno code on failure.
  */

--- a/src/include/daos_uns.h
+++ b/src/include/daos_uns.h
@@ -121,6 +121,8 @@ struct duns_attr_t {
 /** Length of the extended attribute */
 #define DUNS_MAX_XATTR_LEN	170
 
+#define DUNS_XATTR_FMT		"DAOS.%s://%36s/%36s"
+
 /**
  * Create a special directory (POSIX) or file (HDF5) depending on the container type, and create a
  * new DAOS container. The uuid of the container can be either passed in \a attrp->da_cuuid
@@ -194,9 +196,6 @@ duns_destroy_path(daos_handle_t poh, const char *path);
  */
 int
 duns_parse_attr(char *str, daos_size_t len, struct duns_attr_t *attr);
-
-int
-duns_create_attr(char *type, uuid_t pool, uuid_t cont, char **_value, daos_size_t *_out_size);
 
 /**
  * Set the system name in the duns struct in case it was obtained in a different way than

--- a/src/utils/daos_hdlr.c
+++ b/src/utils/daos_hdlr.c
@@ -1667,8 +1667,7 @@ cont_create_hdlr(struct cmd_args_s *ap)
 	}
 
 	if (rc != 0) {
-		fprintf(ap->errstream, "failed to create container: "DF_RC"\n",
-			DP_RC(rc));
+		DH_PERROR_DER(ap, rc, "failed to create container");
 		return rc;
 	}
 
@@ -1687,12 +1686,11 @@ cont_create_uns_hdlr(struct cmd_args_s *ap)
 	struct duns_attr_t	dattr = {0};
 	char			type[10];
 	int			rc;
-	const int		RC_PRINT_HELP = 2;
 
 	/* Required: pool handle, container type, obj class, chunk_size.
 	 * Optional: uuid of pool handle, user-specified container UUID.
 	 */
-	ARGS_VERIFY_PATH_CREATE(ap, err_rc, rc = RC_PRINT_HELP);
+	ARGS_VERIFY_PATH_CREATE(ap, err_rc, rc = -DER_INVAL);
 
 	rc = update_props_for_create(ap);
 	if (rc != 0)
@@ -1707,8 +1705,8 @@ cont_create_uns_hdlr(struct cmd_args_s *ap)
 
 	rc = duns_create_path(ap->pool, ap->path, &dattr);
 	if (rc) {
-		fprintf(ap->errstream, "duns_create_path() error: %s\n", strerror(rc));
-		D_GOTO(err_rc, rc);
+		DH_PERROR_SYS(ap, rc, "duns_create_path() failed");
+		D_GOTO(err_rc, rc = daos_errno2der(rc));
 	}
 
 	snprintf(ap->cont_str, DAOS_PROP_LABEL_MAX_LEN + 1, "%s", dattr.da_cont);
@@ -3331,7 +3329,7 @@ cont_clone_hdlr(struct cmd_args_s *ap)
 	if (dst_str == NULL) {
 		rc = -DER_NOMEM;
 		DH_PERROR_DER(ap, rc, "Unable to allocate memory for destination path");
-		D_GOTO(out, rc = -DER_NOMEM);
+		D_GOTO(out, rc);
 	}
 	rc = dm_parse_path(&dst_cp_type, dst_str, dst_str_len, &ca.dst_p_uuid, &ca.dst_c_uuid);
 	if (rc != 0) {

--- a/utils/node_local_test.py
+++ b/utils/node_local_test.py
@@ -1244,8 +1244,12 @@ def create_cont(conf, pool, cont=None, ctype=None, label=None, path=None, valgri
 
     if rc.returncode == 1 and \
        rc.json['error'] == 'failed to create container: DER_EXIST(-1004): Entity already exists':
-        destroy_container(conf, pool, label)
-        rc = _create_cont(conf, pool, cont, ctype, label, path, valgrind)
+
+        # If a path is set DER_EXIST may refer to the path, not a container so do not attempt to
+        # remove and retry in this case.
+        if path is None:
+            destroy_container(conf, pool, label)
+            rc = _create_cont(conf, pool, cont, ctype, label, path, valgrind)
 
     assert rc.returncode == 0, "rc {} != 0".format(rc.returncode)
     return rc.json['response']['container_uuid']
@@ -1411,6 +1415,31 @@ class posix_tests():
             self.fatal_errors = True
 
         destroy_container(self.conf, self.pool.id(), container)
+
+    @needs_dfuse
+    def test_cont_info(self):
+        """Check that daos container info and fs get-attr works on container roots"""
+
+        def _check_cmd(check_path):
+            rc = run_daos_cmd(self.conf,
+                              ['container', 'query', '--path', check_path],
+                              use_json=True)
+            print(rc)
+            assert rc.returncode == 0, rc
+            # Don't use JSON here because of https://jira.hpdd.intel.com/browse/DAOS-8330
+            rc = run_daos_cmd(self.conf,
+                              ['fs', 'get-attr', '--path', check_path])
+            print(rc)
+            assert rc.returncode == 0, rc
+
+        child_path = os.path.join(self.dfuse.dir, 'new_cont')
+        new_cont = create_cont(self.conf, self.pool.uuid, path=child_path, ctype="POSIX")
+        print(new_cont)
+        _check_cmd(child_path)
+        _check_cmd(self.dfuse.dir)
+
+        # Do not destroy the container at this point as dfuse will be holding a reference to it.
+        # destroy_container(self.conf, self.pool.id(), new_cont)
 
     def test_two_mounts(self):
         """Create two mounts, and check that a file created in one


### PR DESCRIPTION
Rather than have container create sometimes set an xattr on the root
directory when a container is created do not create this xattr, but
rather have dfuse create the xattr on the fly when one is requested.

This allows commands like "daos df get-attr" to work correctly,
regardless of how the container was created.

Add a test for this, and correct some returncodes from the "fs get-attr"
error paths.

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>
