### PR TITLE
DAOS-8103 pool: add proactive pings and delay daos_fini

### DIFF
--- a/src/cart/crt_group.c
+++ b/src/cart/crt_group.c
@@ -10,6 +10,7 @@
 
 #include <sys/types.h>
 #include <sys/stat.h>
+#include <semaphore.h>
 #include "crt_internal.h"
 
 static int crt_group_primary_add_internal(struct crt_grp_priv *grp_priv,

--- a/src/client/api/init.c
+++ b/src/client/api/init.c
@@ -29,8 +29,13 @@
 /** protect against concurrent daos_init/fini calls */
 static pthread_mutex_t	module_lock = PTHREAD_MUTEX_INITIALIZER;
 
+/** daos_init has been called at least once */
+static bool module_initialized;
+/** whether the __daos_fini() destructor has been called already */
+static bool module_destructor_called;
+
 /** refcount on how many times daos_init has been called */
-static int		module_initialized;
+static int module_refcount;
 
 const struct daos_task_api dc_funcs[] = {
 	/** Management */
@@ -133,9 +138,9 @@ daos_init(void)
 	int rc;
 
 	D_MUTEX_LOCK(&module_lock);
-	if (module_initialized > 0) {
+	if (module_initialized) {
 		/** already initialized, report success */
-		module_initialized++;
+		module_refcount++;
 		D_GOTO(unlock, rc = 0);
 	}
 
@@ -198,7 +203,8 @@ daos_init(void)
 	if (rc != 0)
 		D_GOTO(out_co, rc);
 
-	module_initialized++;
+	module_initialized = true;
+	module_refcount++;
 	D_GOTO(unlock, rc = 0);
 
 out_co:
@@ -227,28 +233,16 @@ unlock:
 /**
  * Turn down DAOS client library
  */
-int
-daos_fini(void)
+static int
+daos_cleanup(void)
 {
-	int	rc;
-
-	D_MUTEX_LOCK(&module_lock);
-	if (module_initialized == 0) {
-		/** calling fini without init, report an error */
-		D_GOTO(unlock, rc = -DER_UNINIT);
-	} else if (module_initialized > 1) {
-		/**
-		 * DAOS was initialized multiple times.
-		 * Can happen when using multiple DAOS-aware middleware.
-		 */
-		module_initialized--;
-		D_GOTO(unlock, rc = 0);
-	}
+	int ret = 0;
+	int rc;
 
 	rc = daos_eq_lib_fini();
-	if (rc != 0) {
+	if (rc) {
 		D_ERROR("failed to finalize eq: "DF_RC"\n", DP_RC(rc));
-		D_GOTO(unlock, rc);
+		ret = rc;
 	}
 
 	dc_obj_fini();
@@ -257,9 +251,12 @@ daos_fini(void)
 	dc_mgmt_fini();
 
 	rc = dc_mgmt_notify_exit();
-	if (rc != 0)
+	if (rc) {
 		D_ERROR("failed to disconnect some resources may leak, "
 			DF_RC"\n", DP_RC(rc));
+		if (rc == 0)
+			ret = rc;
+	}
 
 	dc_agent_fini();
 	dc_job_fini();
@@ -267,8 +264,52 @@ daos_fini(void)
 	pl_fini();
 	daos_hhash_fini();
 	daos_debug_fini();
-	module_initialized = 0;
-unlock:
+
+	module_initialized = false;
+
+	return ret;
+}
+
+int
+daos_fini(void)
+{
+	int	rc = 0;
+
+	D_MUTEX_LOCK(&module_lock);
+	if (module_refcount == 0) {
+		/** calling fini without init, report an error */
+		rc = -DER_UNINIT;
+	} else if (module_refcount > 1) {
+		/**
+		 * DAOS was initialized multiple times.
+		 * Can happen when using multiple DAOS-aware middleware.
+		 */
+		module_refcount--;
+	} else if (module_destructor_called) {
+		/** called after the destructor, trigger clean up by myself */
+		rc = daos_cleanup();
+		if (rc == 0)
+			module_refcount--;
+	} else {
+		/**
+		 * Just decrement the refcount, destructor will take care of
+		 * the real cleanup.
+		 */
+		module_refcount--;
+	}
+
 	D_MUTEX_UNLOCK(&module_lock);
+
 	return rc;
+}
+
+static __attribute__((destructor)) void
+__daos_fini(void)
+{
+	D_MUTEX_LOCK(&module_lock);
+	if (module_initialized && module_refcount == 0)
+		/** Trigger real clean up */
+		(void)daos_cleanup();
+	module_destructor_called = true;
+	D_MUTEX_UNLOCK(&module_lock);
 }

--- a/src/pool/cli.c
+++ b/src/pool/cli.c
@@ -21,6 +21,7 @@
 #include <daos/pool.h>
 #include <daos/security.h>
 #include <daos_types.h>
+#include <semaphore.h>
 #include "cli_internal.h"
 #include "rpc.h"
 
@@ -29,6 +30,8 @@ struct rsvc_client_state {
 	struct rsvc_client  scs_client;
 	struct dc_mgmt_sys *scs_sys;
 };
+
+static pthread_mutex_t	warmup_lock = PTHREAD_MUTEX_INITIALIZER;
 
 /**
  * Initialize pool interface
@@ -356,6 +359,109 @@ struct pool_connect_arg {
 	daos_handle_t		*hdlp;
 };
 
+static void
+warmup_cb(const struct crt_cb_info *info) {
+	sem_t   *sem;
+
+	if (info->cci_rc != 0)
+		D_ERROR("Ping failed with rc = %d\n", info->cci_rc);
+
+	sem = (sem_t *)info->cci_arg;
+
+	sem_post(sem);
+}
+
+/*
+ * Pro-actively ping each target in the pool map.
+ * This forces underlying connection to be set up.
+ */
+static void
+warmup(struct dc_pool *pool)
+{
+	static bool		parsed;
+	static bool		enabled = false;
+	crt_context_t		ctx;
+	int			i;
+	int			shift;
+	struct pool_target	*tgts;
+	sem_t			sem;
+	int			nr;
+	int			rc = 0;
+
+	if (parsed && !enabled)
+		/** fast path when disabled */
+		return;
+
+	D_MUTEX_LOCK(&warmup_lock);
+	if (!parsed) {
+		d_getenv_bool("D_POOL_WARMUP", &enabled);
+		parsed = true;
+	}
+	if (!enabled) {
+		D_MUTEX_UNLOCK(&warmup_lock);
+		return;
+	}
+
+	rc = sem_init(&sem, 0, 0);
+	if (rc < 0) {
+		D_ERROR("Failed to initialize semaphore\n");
+		D_MUTEX_UNLOCK(&warmup_lock);
+		return;
+	}
+
+	/** retrieve all targets from the pool map */
+	nr = pool_map_find_target(pool->dp_map, PO_COMP_ID_ALL, &tgts);
+
+	/** Randomize start order to minimize load for large-scale job */
+	shift = rand() + (int)getpid();
+	if (shift < 0)
+		shift = rand();
+
+	D_DEBUG(DB_TRACE, "Pinging %d targets, shifting at %d\n", nr, shift);
+
+	ctx = daos_get_crt_ctx();
+	for (i = 0; i < nr; i++) {
+		crt_endpoint_t		ep;
+		crt_rpc_t		*rpc = NULL;
+		int			idx;
+
+		idx = (i + shift) % nr;
+		ep.ep_grp = pool->dp_sys->sy_group;
+		ep.ep_rank = tgts[idx].ta_comp.co_rank;
+		ep.ep_tag = daos_rpc_tag(DAOS_REQ_TGT,
+					 tgts[idx].ta_comp.co_index);
+
+		rc = pool_req_create(ctx, &ep, POOL_TGT_WARMUP, &rpc);
+		if (rc != 0) {
+			D_ERROR("Failed to allocate req "DF_RC"\n", DP_RC(rc));
+			goto exit;
+		}
+		D_ASSERTF(rc == 0, "crt_req_create failed; rc=%d\n", rc);
+
+		rc = crt_req_send(rpc, warmup_cb, &sem);
+		if (rc != 0) {
+			D_ERROR("Failed to ping rank=%d:%d, "DF_RC"\n",
+				ep.ep_rank, ep.ep_tag, DP_RC(rc));
+			goto exit;
+		}
+
+		while (sem_trywait(&sem) == -1) {
+			rc = crt_progress(ctx, 0);
+			if (rc && rc != -DER_TIMEDOUT) {
+				D_ERROR("failed to progress context, "
+						DF_RC"\n", DP_RC(rc));
+				break;
+			}
+		}
+		rc = 0;
+	}
+	D_DEBUG(DB_TRACE, "Pinging done\n");
+
+exit:
+	(void)sem_destroy(&sem);
+	D_MUTEX_UNLOCK(&warmup_lock);
+}
+
 static int
 pool_connect_cp(tse_task_t *task, void *data)
 {
@@ -425,6 +531,7 @@ pool_connect_cp(tse_task_t *task, void *data)
 		" master\n", DP_UUID(pool->dp_pool), arg->hdlp->cookie,
 		DP_UUID(pool->dp_pool_hdl));
 
+	warmup(pool);
 out:
 	crt_req_decref(arg->rpc);
 	map_bulk_destroy(pci->pci_map_bulk, map_buf);
@@ -1002,6 +1109,7 @@ dc_pool_g2l(struct dc_pool_glob *pool_glob, size_t len, daos_handle_t *poh)
 		" slave\n", DP_UUID(pool->dp_pool), poh->cookie,
 		DP_UUID(pool->dp_pool_hdl));
 
+	warmup(pool);
 out:
 	if (rc != 0)
 		D_ERROR("failed, rc: "DF_RC"\n", DP_RC(rc));

--- a/src/pool/rpc.c
+++ b/src/pool/rpc.c
@@ -116,6 +116,8 @@ CRT_RPC_DEFINE(pool_query_info, DAOS_ISEQ_POOL_QUERY_INFO,
 		DAOS_OSEQ_POOL_QUERY_INFO)
 CRT_RPC_DEFINE(pool_tgt_query_map, DAOS_ISEQ_POOL_TGT_QUERY_MAP,
 		DAOS_OSEQ_POOL_TGT_QUERY_MAP)
+CRT_RPC_DEFINE(pool_tgt_warmup, DAOS_ISEQ_POOL_TGT_WARMUP,
+		DAOS_OSEQ_POOL_TGT_WARMUP)
 
 /* Define for cont_rpcs[] array population below.
  * See POOL_PROTO_*_RPC_LIST macro definition

--- a/src/pool/rpc.h
+++ b/src/pool/rpc.h
@@ -95,7 +95,10 @@
 		ds_pool_list_cont_handler, NULL),			\
 	X(POOL_TGT_QUERY_MAP,						\
 		0, &CQF_pool_tgt_query_map,				\
-		ds_pool_tgt_query_map_handler, NULL)
+		ds_pool_tgt_query_map_handler, NULL),			\
+	X(POOL_TGT_WARMUP,						\
+		0, &CQF_pool_tgt_warmup,				\
+		ds_pool_tgt_warmup_handler, NULL)
 
 #define POOL_PROTO_SRV_RPC_LIST						\
 	X(POOL_TGT_DISCONNECT,						\
@@ -445,6 +448,12 @@ CRT_RPC_DECLARE(pool_ranks_get, DAOS_ISEQ_POOL_RANKS_GET,
 
 CRT_RPC_DECLARE(pool_tgt_query_map, DAOS_ISEQ_POOL_TGT_QUERY_MAP,
 		DAOS_OSEQ_POOL_TGT_QUERY_MAP)
+
+#define DAOS_ISEQ_POOL_TGT_WARMUP
+#define DAOS_OSEQ_POOL_TGT_WARMUP
+
+CRT_RPC_DECLARE(pool_tgt_warmup, DAOS_ISEQ_POOL_TGT_WARMUP,
+		DAOS_OSEQ_POOL_TGT_WARMUP)
 
 static inline int
 pool_req_create(crt_context_t crt_ctx, crt_endpoint_t *tgt_ep, crt_opcode_t opc,

--- a/src/pool/srv_internal.h
+++ b/src/pool/srv_internal.h
@@ -148,6 +148,7 @@ void ds_pool_replicas_update_handler(crt_rpc_t *rpc);
 int ds_pool_tgt_prop_update(struct ds_pool *pool, struct pool_iv_prop *iv_prop);
 int ds_pool_tgt_connect(struct ds_pool *pool, struct pool_iv_conn *pic);
 void ds_pool_tgt_query_map_handler(crt_rpc_t *rpc);
+void ds_pool_tgt_warmup_handler(crt_rpc_t *rpc);
 
 /*
  * srv_util.c

--- a/src/pool/srv_target.c
+++ b/src/pool/srv_target.c
@@ -1404,3 +1404,9 @@ out:
 		DP_UUID(in->tmi_op.pi_uuid), rpc, DP_RC(out->tmo_op.po_rc));
 	crt_reply_send(rpc);
 }
+
+void
+ds_pool_tgt_warmup_handler(crt_rpc_t *rpc)
+{
+	crt_reply_send(rpc);
+}


### PR DESCRIPTION
- add new D_POOL_WARMUP client-side env variable to ping all server
  on pool connect and global2local and thus force all dynamic
  low-level network connection to be set up. This functionality
  is disabled by default and only enabled when D_POOL_WARMUP is
  set.
- refcount daos_init/fini and call real fini in a destructor.

Signed-off-by: Johann Lombardi <johann.lombardi@intel.com>