### PR TITLE
DAOS-8216 tests: Remove any pools between tests.

### DIFF
--- a/src/tests/ftest/control/dmg_system_reformat.py
+++ b/src/tests/ftest/control/dmg_system_reformat.py
@@ -77,7 +77,7 @@ class DmgSystemReformatTest(PoolTestBase):
         self.server_managers[-1].detect_engine_start(host_qty=2)
 
         # Check that we have cleared storage by checking pool list
-        if self.get_dmg_command().pool_list():
+        if self.get_dmg_command().get_pool_list_uuids():
             self.fail("Detected pools in storage after reformat: {}".format(
                 self.get_dmg_command().result.stdout_text))
 
@@ -85,5 +85,5 @@ class DmgSystemReformatTest(PoolTestBase):
         self.add_pool_qty(1)
 
         # Lastly, verify that last created pool is in the list
-        pool_info = self.get_dmg_command().pool_list()
-        self.assertEqual(list(pool_info)[0], self.pool[-1].uuid)
+        pool_uuids = self.get_dmg_command().get_pool_list_uuids()
+        self.assertEqual(pool_uuids[0], self.pool[-1].uuid)

--- a/src/tests/ftest/control/ms_resilience.py
+++ b/src/tests/ftest/control/ms_resilience.py
@@ -40,8 +40,10 @@ class ManagementServiceResilience(TestWithServers):
 
         Returns:
             Pool entry, if found, or None.
+
         """
-        for pool_uuid in self.get_dmg_command().pool_list(no_query=True):
+        pool_uuids = self.get_dmg_command().get_pool_list_uuids(no_query=True)
+        for pool_uuid in pool_uuids:
             if pool_uuid.lower() == search_uuid.lower():
                 return pool_uuid
         return None

--- a/src/tests/ftest/pool/create_capacity_test.py
+++ b/src/tests/ftest/pool/create_capacity_test.py
@@ -59,7 +59,8 @@ class PoolCreateTests(PoolTestBase):
 
         self.dmg.timeout = 360
         # Verify all the pools exists after the restart
-        detected_pools = [uuid.lower() for uuid in self.dmg.pool_list(no_query=True)]
+        pool_uuids = self.get_dmg_command().get_pool_list_uuids(no_query=True)
+        detected_pools = [uuid.lower() for uuid in pool_uuids]
         missing_pools = []
         for pool in self.pool:
             pool_uuid = pool.uuid.lower()

--- a/src/tests/ftest/pool/create_capacity_test.yaml
+++ b/src/tests/ftest/pool/create_capacity_test.yaml
@@ -10,7 +10,7 @@ hosts:
   test_clients:
     - client-H
 timeouts:
-  test_create_pool_quantity: 660
+  test_create_pool_quantity: 690
 server_config:
   name: daos_server
   servers:

--- a/src/tests/ftest/pool/dynamic_server_pool.py
+++ b/src/tests/ftest/pool/dynamic_server_pool.py
@@ -42,7 +42,7 @@ class DynamicServerPool(TestWithServers):
         """Call dmg pool list to get the list of UUIDs and verify against the
         expected UUIDs.
         """
-        actual_uuids = sorted(self.get_dmg_command().pool_list())
+        actual_uuids = self.get_dmg_command().get_pool_list_uuids()
         self.expected_uuids.sort()
         self.assertEqual(self.expected_uuids, actual_uuids)
 

--- a/src/tests/ftest/pool/info_tests.yaml
+++ b/src/tests/ftest/pool/info_tests.yaml
@@ -1,7 +1,7 @@
 hosts:
   test_servers:
     - server-A
-timeout: 40
+timeout: 90
 server_config:
   name: daos_server
   servers:

--- a/src/tests/ftest/pool/list_pools.py
+++ b/src/tests/ftest/pool/list_pools.py
@@ -46,7 +46,7 @@ class ListPoolsTest(TestWithServers):
         # information.  The DmgCommand.pool_info() method returns the command
         # output as a dictionary of pool UUID keys with service replica list
         # values.
-        detected_uuids = self.get_dmg_command().pool_list()
+        detected_uuids = self.get_dmg_command().get_pool_list_uuids()
         self.log.info("Expected pool info: %s", str(expected_uuids))
         self.log.info("Detected pool info: %s", str(detected_uuids))
 

--- a/src/tests/ftest/server/daos_server_restart.py
+++ b/src/tests/ftest/server/daos_server_restart.py
@@ -50,17 +50,11 @@ class DaosServerTest(TestWithServers):
         self.server_managers[0].dmg.system_stop(force)
         self.server_managers[0].dmg.system_start()
 
-    def get_pool_list(self):
-        """Get the pool list contents."""
-        pool_list = sorted(self.get_dmg_command().pool_list())
-        self.log.info("get_pool-list: %s", pool_list)
-        return pool_list
-
     def verify_pool_list(self, expected_pool_list=None):
         """Verify the pool list."""
         if expected_pool_list is None:
             expected_pool_list = []
-        pool_list = self.get_pool_list()
+        pool_list = self.get_dmg_command().get_pool_list_uuids()
         self.log.info(
             "\n===Current pool-list:  %s\n===Expected pool-list: %s\n",
             pool_list, expected_pool_list)
@@ -148,7 +142,7 @@ class DaosServerTest(TestWithServers):
             "(2)Shutdown and restart the daos engine with pools "
             "and containers created.")
         self.create_pool_and_container()
-        pool_list = self.get_pool_list()
+        pool_list = self.get_dmg_command().get_pool_list_uuids()
         self.restart_engine()
         self.log.info(
             "(3)Force shutdown and restart the daos engine.")


### PR DESCRIPTION
Allow multiple test methods/variants to run if one fails to cleanup its
pools by removing any pools that exist on any continuously running
servers.

As part of this change the DmgCommand.pool_list() method has been
updated to return the raw json output converted into a dictionary.
Helper methods for parsing out the UUIDs and labels from the json
dictionary output have been added.

Test-tag: dmg_system_reformat ms_resilience pool_create_tests dynamic_server_pool info_test list_pools server_restart

Signed-off-by: Phillip Henderson <phillip.henderson@intel.com>