### PR TITLE
DAOS-8332 vos: Allocation based on real merge window size

### DIFF
--- a/src/vos/tests/vts_aggregate.c
+++ b/src/vos/tests/vts_aggregate.c
@@ -224,6 +224,7 @@ struct agg_tst_dataset {
 	bool				 td_delete;
 };
 
+#define PARITY_BIT (1ULL << 63)
 static daos_size_t
 get_view_len(struct agg_tst_dataset *ds, daos_recx_t *recx)
 {
@@ -232,11 +233,14 @@ get_view_len(struct agg_tst_dataset *ds, daos_recx_t *recx)
 	if (ds->td_type == DAOS_IOD_SINGLE) {
 		view_len = ds->td_iod_size;
 	} else {
-		uint64_t	start = UINT64_MAX, end = 0, tmp;
+		uint64_t	start = PARITY_BIT - 1, end = 0, tmp;
 		int		i;
 
 		assert_true(ds->td_recx_nr > 0);
 		for (i = 0; i < ds->td_recx_nr; i++) {
+			if (ds->td_recx[i].rx_idx & PARITY_BIT)
+				continue; /* Ignore "parity" for now */
+
 			if (start > ds->td_recx[i].rx_idx)
 				start = ds->td_recx[i].rx_idx;
 			tmp = ds->td_recx[i].rx_idx + ds->td_recx[i].rx_nr;
@@ -294,7 +298,7 @@ verify_view(struct io_test_args *arg, daos_unit_oid_t oid, char *dkey,
 	daos_epoch_range_t	*epr_a;
 	char			*buf_f;
 	daos_size_t		 view_len;
-	daos_recx_t		 recx;
+	daos_recx_t		 recx = {0};
 	int			 nr;
 
 	VERBOSE_MSG("Verify logical view\n");
@@ -2406,7 +2410,7 @@ aggregate_29(void **state)
 #define MAX_REMOVE 25
 static void
 removal_stress_case(struct io_test_args *arg, int recx_nr, daos_recx_t *recx_arr, int remove_nr,
-		    daos_epoch_t *remove_epochs, daos_epoch_t *remove_bounds)
+		    daos_epoch_t *remove_epochs, daos_epoch_t *remove_bounds, bool add_parity)
 {
 	struct agg_tst_dataset	 ds = { 0 };
 	int			 iod_size = 1024, end_idx;
@@ -2421,6 +2425,8 @@ removal_stress_case(struct io_test_args *arg, int recx_nr, daos_recx_t *recx_arr
 
 	for (i = 0; i < recx_nr; i++) {
 		recx_arr[i].rx_idx = MAX(0, (i % 7) * end_idx - i);
+		if (add_parity && (i & 1) == 0)
+			recx_arr[i].rx_idx |= PARITY_BIT;
 		recx_arr[i].rx_nr = end_idx + end_idx * (i % 2);
 		if ((i + 1) % (recx_nr / remove_nr) == 0) {
 			remove_epochs[remove] = i + 1;
@@ -2467,18 +2473,18 @@ aggregate_30(void **state)
 	D_ALLOC_ARRAY(remove_bounds, MAX_REMOVE);
 	assert_non_null(remove_bounds);
 
-	removal_stress_case(arg, 10, recx_arr, 2, remove_epochs, remove_bounds);
-	removal_stress_case(arg, 14, recx_arr, 7, remove_epochs, remove_bounds);
-	removal_stress_case(arg, 20, recx_arr, 4, remove_epochs, remove_bounds);
+	removal_stress_case(arg, 10, recx_arr, 2, remove_epochs, remove_bounds, false);
+	removal_stress_case(arg, 14, recx_arr, 7, remove_epochs, remove_bounds, false);
+	removal_stress_case(arg, 20, recx_arr, 4, remove_epochs, remove_bounds, true);
 	if (!DAOS_ON_VALGRIND) {
-		removal_stress_case(arg, 24, recx_arr, 6, remove_epochs, remove_bounds);
-		removal_stress_case(arg, 30, recx_arr, 3, remove_epochs, remove_bounds);
-		removal_stress_case(arg, 40, recx_arr, 4, remove_epochs, remove_bounds);
-		removal_stress_case(arg, 50, recx_arr, 5, remove_epochs, remove_bounds);
-		removal_stress_case(arg, 60, recx_arr, 15, remove_epochs, remove_bounds);
-		removal_stress_case(arg, 75, recx_arr, 25, remove_epochs, remove_bounds);
-		removal_stress_case(arg, 80, recx_arr, 8, remove_epochs, remove_bounds);
-		removal_stress_case(arg, 100, recx_arr, 10, remove_epochs, remove_bounds);
+		removal_stress_case(arg, 24, recx_arr, 6, remove_epochs, remove_bounds, false);
+		removal_stress_case(arg, 30, recx_arr, 3, remove_epochs, remove_bounds, false);
+		removal_stress_case(arg, 40, recx_arr, 4, remove_epochs, remove_bounds, false);
+		removal_stress_case(arg, 50, recx_arr, 5, remove_epochs, remove_bounds, false);
+		removal_stress_case(arg, 60, recx_arr, 15, remove_epochs, remove_bounds, true);
+		removal_stress_case(arg, 75, recx_arr, 25, remove_epochs, remove_bounds, false);
+		removal_stress_case(arg, 80, recx_arr, 8, remove_epochs, remove_bounds, false);
+		removal_stress_case(arg, 100, recx_arr, 10, remove_epochs, remove_bounds, true);
 	}
 
 	D_FREE(recx_arr);

--- a/src/vos/vos_aggregate.c
+++ b/src/vos/vos_aggregate.c
@@ -120,6 +120,8 @@ struct agg_merge_window {
 	daos_size_t			 mw_flush_thresh;
 	/* Merge window extent */
 	struct evt_extent		 mw_ext;
+	/** Real merge window upper bound */
+	uint64_t			 mw_alloc_hi;
 	/* Physical entries in merge window */
 	d_list_t			 mw_phy_ents;
 	unsigned int			 mw_phy_cnt;
@@ -841,9 +843,13 @@ reserve_segment(struct vos_object *obj, struct agg_io_context *io,
 static inline daos_size_t
 merge_window_size(struct agg_merge_window *mw)
 {
+	struct evt_extent ext;
 	D_ASSERT(mw->mw_ext.ex_hi >= mw->mw_ext.ex_lo);
+	D_ASSERT(mw->mw_alloc_hi >= mw->mw_ext.ex_lo);
 	D_ASSERT(mw->mw_rsize != 0);
-	return evt_extent_width(&mw->mw_ext) * mw->mw_rsize;
+	ext.ex_hi = mw->mw_alloc_hi;
+	ext.ex_lo = mw->mw_ext.ex_lo;
+	return evt_extent_width(&ext) * mw->mw_rsize;
 }
 
 /* Widen biov entry for read extents to range required to verify checksums. */
@@ -1421,7 +1427,7 @@ insert_segments(daos_handle_t ih, struct agg_merge_window *mw,
 	}
 
 	/* Clear window size */
-	mw->mw_ext.ex_lo = mw->mw_ext.ex_hi = 0;
+	mw->mw_ext.ex_lo = mw->mw_ext.ex_hi = mw->mw_alloc_hi = 0;
 
 	/* Publish NVMe reservations */
 	rc = vos_publish_blocks(obj->obj_cont, &io->ic_nvme_exts, true,
@@ -1467,7 +1473,7 @@ clear_merge_window(struct agg_merge_window *mw)
 {
 	struct agg_phy_ent *phy_ent, *tmp;
 
-	mw->mw_ext.ex_lo = mw->mw_ext.ex_hi = 0;
+	mw->mw_ext.ex_lo = mw->mw_ext.ex_hi = mw->mw_alloc_hi = 0;
 	mw->mw_lgc_cnt = 0;
 	d_list_for_each_entry_safe(phy_ent, tmp, &mw->mw_phy_ents, pe_link) {
 		d_list_del(&phy_ent->pe_link);
@@ -1697,7 +1703,7 @@ enqueue_lgc_ent(struct agg_merge_window *mw, struct evt_extent *lgc_ext,
 	 */
 	if (mw->mw_lgc_cnt == 1)
 		mw->mw_ext.ex_lo = lgc_ext->ex_lo;
-	mw->mw_ext.ex_hi = lgc_ext->ex_hi;
+	mw->mw_ext.ex_hi = mw->mw_alloc_hi = lgc_ext->ex_hi;
 
 	D_DEBUG(DB_EPC, "lgc_ext:"DF_EXT", phy_ext:"DF_RECT", mw:"DF_EXT", "
 		"index:%u\n", DP_EXT(lgc_ext), DP_RECT(&phy_ent->pe_rect),
@@ -1888,10 +1894,8 @@ join_merge_window(daos_handle_t ih, struct agg_merge_window *mw,
 
 	/* Trigger current window flush when reaching threshold */
 	if (visible && trigger_flush(mw, &lgc_ext)) {
-		if (!d_list_empty(&mw->mw_rmv_ents)) {
-			/* The window flush doesn't expect holes caused by removal records */
-			mw->mw_ext.ex_hi = lgc_ext.ex_lo - 1;
-		}
+		/* The window flush doesn't expect holes caused by removal records */
+		mw->mw_ext.ex_hi = lgc_ext.ex_lo - 1;
 		rc = flush_merge_window(ih, mw, false, acts);
 		if (rc) {
 			D_ERROR("Flush window "DF_EXT" error: "DF_RC"\n",
@@ -1904,7 +1908,10 @@ join_merge_window(daos_handle_t ih, struct agg_merge_window *mw,
 	/* Lookup physical entry, enqueue if it doesn't exist */
 	phy_ent = lookup_phy_ent(mw, &phy_ext, entry);
 	if (phy_ent == NULL) {
-		D_ASSERT(phy_ext.ex_lo == lgc_ext.ex_lo);
+		if (phy_ext.ex_lo != lgc_ext.ex_lo) {
+			D_ASSERT(!visible && phy_ent_is_removed(mw, &phy_ext, entry->ie_epoch));
+			goto out;
+		}
 		phy_ent = enqueue_phy_ent(mw, &phy_ext, entry,
 					  &entry->ie_biov.bi_addr,
 					  &entry->ie_csum, entry->ie_ver);


### PR DESCRIPTION
In prior patch, the merge window size was adjusted based on the newly
found visible logical extent.   The buffer size allocated needs to
be based on the actual size of enclosed extents.   Track the allocation
hi value for this purpose.

This bug was exposed in EC aggregation.  Add some testing for
aggregation with parity ranges and fix a couple of remaining issues
this change exposed.   It's still possible to get a new logical extent
that has already been removed so modify the assertion accordingly
to check if it's covered by a removal record.

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>