### PR TITLE
DAOS-7721 rdb: Limit AE sizes

### DIFF
--- a/doc/admin/env_variables.md
+++ b/doc/admin/env_variables.md
@@ -35,6 +35,9 @@ Environment variables in this section only apply to the server side.
 |----------------------|-----------|
 |RDB\_ELECTION\_TIMEOUT|Raft election timeout used by RDBs in milliseconds. INTEGER. Default to 7000 ms.|
 |RDB\_REQUEST\_TIMEOUT |Raft request timeout used by RDBs in milliseconds. INTEGER. Default to 3000 ms.|
+|RDB\_COMPACT\_THRESHOLD|Raft log compaction threshold in applied entries. INTEGER. Default to 256 entries.|
+|RDB\_AE\_MAX\_ENTRIES |Maximum number of entries in a Raft AppendEntries request. INTEGER. Default to 32.|
+|RDB\_AE\_MAX\_SIZE    |Maximum total size in bytes of all entries in a Raft AppendEntries request. INTEGER. Default to 1 MB.|
 |DAOS\_REBUILD         |Determines whether to start rebuilds when excluding targets. BOOL2. Default to true.|
 |DAOS\_MD\_CAP         |Size of a metadata pmem pool/file in MBs. INTEGER. Default to 128 MB.|
 |DAOS\_START\_POOL\_SVC|Determines whether to start existing pool services when starting a daos\_server. BOOL. Default to true.|

--- a/src/rdb/rdb_internal.h
+++ b/src/rdb/rdb_internal.h
@@ -80,6 +80,8 @@ struct rdb {
 	ABT_thread		d_callbackd;
 	ABT_thread		d_recvd;
 	ABT_thread		d_compactd;
+	size_t			d_ae_max_size;
+	unsigned int		d_ae_max_entries;
 };
 
 /* thresholds of free space for a leader to avoid appending new log entries

--- a/src/rdb/rdb_raft.c
+++ b/src/rdb/rdb_raft.c
@@ -2372,7 +2372,7 @@ rdb_raft_get_request_timeout(void)
 }
 
 static uint64_t
-rdb_raft_get_compact_thres()
+rdb_raft_get_compact_thres(void)
 {
 	char	       *name = "RDB_COMPACT_THRESHOLD";
 	unsigned int	default_value = 256;
@@ -2387,7 +2387,7 @@ rdb_raft_get_compact_thres()
 }
 
 static unsigned int
-rdb_raft_get_ae_max_entries()
+rdb_raft_get_ae_max_entries(void)
 {
 	char	       *name = "RDB_AE_MAX_ENTRIES";
 	unsigned int	default_value = 32;


### PR DESCRIPTION
It was observed that RDB leaders sometimes send AE requests with
thousands of entries. These AE requests may take considerable efforts
from the followers to process. Because the processing does not yield to
the Argobots scheduler, it may starve other ULTs (e.g., dss_srv_handler)
on the same xstream for too long. This patch limits each AE request by
both a maximum number of entries and a maximum aggregated entry data
size.

Also:

  - Fix -DER_IO_INVALs from vos_ioc_create when installing snapshot
    chunks. It appears that rdb_raft_exec_unpack_io may be called with
    an empty io, whose ui_iods_top field equals -1. This patch follows
    other dss_enum_unpack_io callbacks to skip such ios.

  - Return -DER_MISC from rdb_raft_cb_recv_installsnapshot_resp when a
    chunk is not successfully installed. There will be a raft patch to
    make INSTALLSNAPSHOTs be sent promptly. Returning an error avoids
    retrying too eagerly.

Signed-off-by: Li Wei <wei.g.li@intel.com>