### PR TITLE
DAOS-8108 EC: refine parity list handling in EC data recovery

### DIFF
--- a/src/include/daos/object.h
+++ b/src/include/daos/object.h
@@ -711,9 +711,8 @@ daos_recx_ep_list_dump(struct daos_recx_ep_list *lists, unsigned int nr)
 			list->re_snapshot);
 		for (j = 0; j < list->re_nr; j++) {
 			recx_ep = &list->re_items[j];
-			D_ERROR("[["DF_X64","DF_X64"], "DF_X64"]  ",
-				recx_ep->re_recx.rx_idx, recx_ep->re_recx.rx_nr,
-				recx_ep->re_ep);
+			D_ERROR("[type %d, ["DF_X64","DF_X64"], "DF_X64"]  ", recx_ep->re_type,
+				recx_ep->re_recx.rx_idx, recx_ep->re_recx.rx_nr, recx_ep->re_ep);
 		}
 		D_ERROR("\n");
 	}

--- a/src/object/cli_ec.c
+++ b/src/object/cli_ec.c
@@ -1915,13 +1915,17 @@ obj_ec_parity_check(struct obj_reasb_req *reasb_req,
 		goto out;
 	}
 
-	if (!obj_ec_parity_lists_match(parity_lists, recx_lists, nr) ||
-	    DAOS_FAIL_CHECK(DAOS_FAIL_PARITY_EPOCH_DIFF)) {
+	if (unlikely(DAOS_FAIL_CHECK(DAOS_FAIL_PARITY_EPOCH_DIFF))) {
 		rc = -DER_FETCH_AGAIN;
-		D_ERROR("got different parity lists, "DF_RC"\n", DP_RC(rc));
-		daos_recx_ep_list_dump(parity_lists, nr);
-		daos_recx_ep_list_dump(recx_lists, nr);
-		goto out;
+		D_ERROR("simulate parity list mismatch, "DF_RC"\n", DP_RC(rc));
+	} else {
+		rc = obj_ec_parity_lists_match(parity_lists, recx_lists, nr);
+		if (rc) {
+			D_ERROR("got different parity lists, "DF_RC"\n", DP_RC(rc));
+			daos_recx_ep_list_dump(parity_lists, nr);
+			daos_recx_ep_list_dump(recx_lists, nr);
+			goto out;
+		}
 	}
 
 out:


### PR DESCRIPTION
Refine parity list processing, and refine the test case.

Signed-off-by: Xuezhao Liu <xuezhao.liu@intel.com>