### PR TITLE
DAOS-7946 test: Increased autotest NVMe size to 224G.

### DIFF
--- a/src/tests/ftest/container/autotest.yaml
+++ b/src/tests/ftest/container/autotest.yaml
@@ -13,5 +13,5 @@ server_config:
 pool:
   mode: 146
   scm_size: 16G
-  nvme_size: 128G
+  nvme_size: 192G
   control_method: dmg

--- a/src/tests/ftest/container/autotest.yaml
+++ b/src/tests/ftest/container/autotest.yaml
@@ -13,5 +13,5 @@ server_config:
 pool:
   mode: 146
   scm_size: 16G
-  nvme_size: 192G
+  nvme_size: 224G
   control_method: dmg


### PR DESCRIPTION
Due to space pressure issues while running autotest, the test was taking too long to complete.
* Increased autotest NVMe size to 224G.

Signed-off-by: Christopher Hoffman <christopherx.hoffman@intel.com>