### PR TITLE
DAOS-5913 telemetry: Install telemetry headers

### DIFF
--- a/src/SConscript
+++ b/src/SConscript
@@ -10,7 +10,8 @@ HEADERS = ['daos.h', 'daos_api.h', 'daos_types.h', 'daos_errno.h', 'daos_kv.h',
 HEADERS_SRV = ['vos.h', 'vos_types.h']
 HEADERS_GURT = ['dlog.h', 'debug.h', 'common.h', 'hash.h', 'list.h',
                 'heap.h', 'fault_inject.h', 'debug_setup.h',
-                'types.h', 'atomic.h', 'slab.h']
+                'types.h', 'atomic.h', 'slab.h',
+                'telemetry_consumer.h', 'telemetry_common.h']
 
 # Keep versioned libs for now to avoid any conflict with 1.0
 CART_VERSION = "4.9.0"

--- a/src/include/gurt/telemetry_consumer.h
+++ b/src/include/gurt/telemetry_consumer.h
@@ -6,6 +6,7 @@
 #ifndef __TELEMETRY_CONSUMER_H__
 #define __TELEMETRY_CONSUMER_H__
 
+#include <gurt/telemetry_common.h>
 
 /* Developer facing client API to read data */
 char *d_tm_get_name(struct d_tm_context *ctx, struct d_tm_node_t *node);


### PR DESCRIPTION
These headers are needed for external projects (e.g. LDMS)
to use the telemetry consumer.