### PR TITLE
DAOS-6322 test: Enable control/dmg_system_reformat.py

### DIFF
--- a/src/tests/ftest/control/dmg_system_reformat.py
+++ b/src/tests/ftest/control/dmg_system_reformat.py
@@ -19,7 +19,6 @@ class DmgSystemReformatTest(PoolTestBase):
     :avocado: recursive
     """
 
-    @skipForTicket("DAOS-6004")
     def test_dmg_system_reformat(self):
         """
         JIRA ID: DAOS-5415


### PR DESCRIPTION
Enable control/dmg_system_reformat.py

Skip-unit-tests: true
Test-tag: dmg_system_reformat
Signed-off-by: Makito Kano <makito.kano@intel.com>