### PR TITLE
DAOS-8315 test: Adjusted pool list output in daos_server_restart.py 

### DIFF
--- a/src/tests/ftest/server/daos_server_restart.py
+++ b/src/tests/ftest/server/daos_server_restart.py
@@ -57,14 +57,18 @@ class DaosServerTest(TestWithServers):
             list: List of UUIDs.
 
         """
+        pool_list = []
         output = self.get_dmg_command().pool_list()
 
-        pool_list = []
-        for pool in output["response"]["pools"]:
-            pool_list.append(pool["uuid"])
+        pools = output["response"]["pools"]
+        if pools:
+            for pool in pools:
+                pool_list.append(pool["uuid"])
+
+        pool_list.sort()
         self.log.info("get_pool-list: %s", pool_list)
 
-        return pool_list.sort()
+        return pool_list
 
     def verify_pool_list(self, expected_pool_list=None):
         """Verify the pool list.

--- a/src/tests/ftest/server/daos_server_restart.py
+++ b/src/tests/ftest/server/daos_server_restart.py
@@ -66,13 +66,16 @@ class DaosServerTest(TestWithServers):
 
         return pool_list.sort()
 
-    def verify_pool_list(self, expected_pool_list=[]):
+    def verify_pool_list(self, expected_pool_list=None):
         """Verify the pool list.
 
         Args:
             expected_pool_list (list, optional): Expected list of UUIDs.
-                Defaults to an empty list.
+                Defaults to None.
         """
+        if expected_pool_list is None:
+            expected_pool_list = []
+
         pool_list = self.get_pool_list()
         self.log.info(
             "\n===Current pool-list:  %s\n===Expected pool-list: %s\n",

--- a/src/tests/ftest/server/daos_server_restart.py
+++ b/src/tests/ftest/server/daos_server_restart.py
@@ -109,7 +109,7 @@ class DaosServerTest(TestWithServers):
            fresh installation.
 
         :avocado: tags=all,daily_regression
-        :avocado: tags=hw,large
+        :avocado: tags=vm
         :avocado: tags=server_test,server_reformat,DAOS_5610
         """
         self.pool = []
@@ -145,7 +145,7 @@ class DaosServerTest(TestWithServers):
            daos cluster is incomplete (i.e. 1 of the 2 servers is down).
 
         :avocado: tags=all,daily_regression
-        :avocado: tags=hw,large
+        :avocado: tags=vm
         :avocado: tags=server_test,server_restart,DAOS_5610
         """
         self.pool = []

--- a/src/tests/ftest/server/daos_server_restart.py
+++ b/src/tests/ftest/server/daos_server_restart.py
@@ -51,15 +51,28 @@ class DaosServerTest(TestWithServers):
         self.server_managers[0].dmg.system_start()
 
     def get_pool_list(self):
-        """Get the pool list contents."""
-        pool_list = sorted(self.get_dmg_command().pool_list())
-        self.log.info("get_pool-list: %s", pool_list)
-        return pool_list
+        """Get the sorted pool UUID list.
 
-    def verify_pool_list(self, expected_pool_list=None):
-        """Verify the pool list."""
-        if expected_pool_list is None:
-            expected_pool_list = []
+        Returns:
+            list: List of UUIDs.
+
+        """
+        output = self.get_dmg_command().pool_list()
+
+        pool_list = []
+        for pool in output["response"]["pools"]:
+            pool_list.append(pool["uuid"])
+        self.log.info("get_pool-list: %s", pool_list)
+
+        return pool_list.sort()
+
+    def verify_pool_list(self, expected_pool_list=[]):
+        """Verify the pool list.
+
+        Args:
+            expected_pool_list (list, optional): Expected list of UUIDs.
+                Defaults to an empty list.
+        """
         pool_list = self.get_pool_list()
         self.log.info(
             "\n===Current pool-list:  %s\n===Expected pool-list: %s\n",

--- a/src/tests/ftest/server/daos_server_restart.py
+++ b/src/tests/ftest/server/daos_server_restart.py
@@ -90,7 +90,6 @@ class DaosServerTest(TestWithServers):
 
     def create_pool_and_container(self):
         """Create pool and container."""
-        scm_size = self.params.get("scm_size", "/run/server/*/", 138000000)
         num_of_pool = self.params.get("num_of_pool", "/run/server/*/", 3)
         container_per_pool = self.params.get(
             "container_per_pool", "/run/server/*/", 2)


### PR DESCRIPTION
pool_list() now returns the raw JSON. Adjust the test to
obtain the UUIDs and compare.

Skip-unit-tests: true
Test-tag: server_reformat server_restart
Signed-off-by: Makito Kano <makito.kano@intel.com>