### PR TITLE
CART-89 limits: Expose expected/unexpected message size limits

### DIFF
--- a/src/cart/crt_hg.c
+++ b/src/cart/crt_hg.c
@@ -590,6 +590,12 @@ crt_hg_class_init(int provider, int idx, hg_class_t **ret_hg_class)
 	else
 		init_info.na_init_info.max_contexts = 1;
 
+	if (prov_data->cpg_max_exp_size > 0)
+		init_info.na_init_info.max_expected_size =  prov_data->cpg_max_exp_size;
+
+	if (prov_data->cpg_max_unexp_size > 0)
+		init_info.na_init_info.max_unexpected_size = prov_data->cpg_max_unexp_size;
+
 	init_info.request_post_incr = 0;
 	hg_class = HG_Init_opt(info_string, crt_is_service(), &init_info);
 	if (hg_class == NULL) {

--- a/src/cart/crt_init.c
+++ b/src/cart/crt_init.c
@@ -439,8 +439,8 @@ do_init:
 			max_num_ctx = ctx_num;
 		}
 
-		int32_t max_expect_size = -1;
-		int32_t max_unexpect_size = -1;
+		uint32_t max_expect_size = 0;
+		uint32_t max_unexpect_size = 0;
 
 		if (opt && opt->cio_use_expected_size)
 			max_expect_size = opt->cio_max_expected_size;

--- a/src/cart/crt_init.c
+++ b/src/cart/crt_init.c
@@ -85,7 +85,8 @@ exit:
 
 static void
 prov_data_init(struct crt_prov_gdata *prov_data, int provider,
-		bool sep_mode, int max_ctx_num)
+	       bool sep_mode, int max_ctx_num,
+	       int max_exp_size, int max_unexp_size)
 {
 	prov_data->cpg_inited = true;
 	prov_data->cpg_provider = provider;
@@ -93,6 +94,11 @@ prov_data_init(struct crt_prov_gdata *prov_data, int provider,
 	prov_data->cpg_sep_mode = sep_mode;
 	prov_data->cpg_contig_ports = true;
 	prov_data->cpg_ctx_max_num = max_ctx_num;
+	prov_data->cpg_max_exp_size = max_exp_size;
+	prov_data->cpg_max_unexp_size = max_unexp_size;
+
+	D_DEBUG(DB_ALL, "Provider (%d), sep_mode (%d), sizes (%d/%d)\n",
+		provider, sep_mode, max_exp_size, max_unexp_size);
 
 	D_INIT_LIST_HEAD(&prov_data->cpg_ctx_list);
 }
@@ -425,8 +431,7 @@ do_init:
 			share_addr = false;
 			ctx_num = 0;
 
-			d_getenv_bool("CRT_CTX_SHARE_ADDR",
-				      &share_addr);
+			d_getenv_bool("CRT_CTX_SHARE_ADDR", &share_addr);
 			if (share_addr)
 				set_sep = true;
 
@@ -434,8 +439,18 @@ do_init:
 			max_num_ctx = ctx_num;
 		}
 
+		int32_t max_expect_size = -1;
+		int32_t max_unexpect_size = -1;
+
+		if (opt && opt->cio_use_expected_size)
+			max_expect_size = opt->cio_max_expected_size;
+
+		if (opt && opt->cio_use_unexpected_size)
+			max_unexpect_size = opt->cio_max_unexpected_size;
+
 		prov_data_init(&crt_gdata.cg_prov_gdata[prov],
-			       prov, set_sep, max_num_ctx);
+			       prov, set_sep, max_num_ctx,
+			       max_expect_size, max_unexpect_size);
 
 		/* Print notice that "ofi+verbs" is legacy */
 		if (prov == CRT_NA_OFI_VERBS) {

--- a/src/cart/crt_init.c
+++ b/src/cart/crt_init.c
@@ -86,7 +86,7 @@ exit:
 static void
 prov_data_init(struct crt_prov_gdata *prov_data, int provider,
 	       bool sep_mode, int max_ctx_num,
-	       int max_exp_size, int max_unexp_size)
+	       uint32_t max_exp_size, uint32_t max_unexp_size)
 {
 	prov_data->cpg_inited = true;
 	prov_data->cpg_provider = provider;

--- a/src/cart/crt_internal_types.h
+++ b/src/cart/crt_internal_types.h
@@ -49,11 +49,14 @@ struct crt_prov_gdata {
 	/** maximum number of contexts user wants to create */
 	uint32_t		cpg_ctx_max_num;
 
+	/** Hints to mercury/ofi for max expected/unexp sizes */
+	int32_t			cpg_max_exp_size;
+	int32_t			cpg_max_unexp_size;
+
 	/** Set of flags */
 	unsigned int		cpg_sep_mode		: 1,
 				cpg_contig_ports	: 1,
 				cpg_inited		: 1;
-
 };
 
 

--- a/src/cart/crt_internal_types.h
+++ b/src/cart/crt_internal_types.h
@@ -50,8 +50,8 @@ struct crt_prov_gdata {
 	uint32_t		cpg_ctx_max_num;
 
 	/** Hints to mercury/ofi for max expected/unexp sizes */
-	int32_t			cpg_max_exp_size;
-	int32_t			cpg_max_unexp_size;
+	uint32_t		cpg_max_exp_size;
+	uint32_t		cpg_max_unexp_size;
 
 	/** Set of flags */
 	unsigned int		cpg_sep_mode		: 1,

--- a/src/include/cart/types.h
+++ b/src/include/cart/types.h
@@ -69,8 +69,8 @@ typedef struct crt_init_options {
 	 * Hints to mercury/ofi to use for expected/unexpected
 	 * maximum sizes of messages.
 	 */
-	int		cio_max_expected_size;
-	int		cio_max_unexpected_size;
+	uint32_t	cio_max_expected_size;
+	uint32_t	cio_max_unexpected_size;
 } crt_init_options_t;
 
 typedef int		crt_status_t;

--- a/src/include/cart/types.h
+++ b/src/include/cart/types.h
@@ -51,7 +51,11 @@ typedef struct crt_init_options {
 			 */
 			cio_use_credits:1,
 			/** whether or not to enable per-context sensors */
-			cio_use_sensors:1;
+			cio_use_sensors:1,
+
+			/** whether or not to use expected sizes */
+			cio_use_expected_size:1,
+			cio_use_unexpected_size:1;
 	/**
 	 * overrides the value of the environment variable
 	 * CRT_CTX_NUM
@@ -60,6 +64,13 @@ typedef struct crt_init_options {
 
 	/** Used with cio_use_credits to set credit limit */
 	int		cio_ep_credits;
+
+	/**
+	 * Hints to mercury/ofi to use for expected/unexpected
+	 * maximum sizes of messages.
+	 */
+	int		cio_max_expected_size;
+	int		cio_max_unexpected_size;
 } crt_init_options_t;
 
 typedef int		crt_status_t;

--- a/src/tests/ftest/cart/dual_iface_server.c
+++ b/src/tests/ftest/cart/dual_iface_server.c
@@ -325,7 +325,7 @@ server_main(d_rank_t my_rank, const char *str_port, const char *str_interface,
 	syncfs(fd_write);
 
 	/* Give time for both servers to write to local tmp file */
-	sleep(1);
+	sleep(5);
 
 	/* Read each others URIs from the file */
 	memset(other_server_uri, 0x0, MAX_URI);

--- a/src/tests/ftest/cart/dual_iface_server.c
+++ b/src/tests/ftest/cart/dual_iface_server.c
@@ -325,7 +325,7 @@ server_main(d_rank_t my_rank, const char *str_port, const char *str_interface,
 	syncfs(fd_write);
 
 	/* Give time for both servers to write to local tmp file */
-	sleep(5);
+	sleep(1);
 
 	/* Read each others URIs from the file */
 	memset(other_server_uri, 0x0, MAX_URI);


### PR DESCRIPTION
- Expose expected/unexpected message size limits to be settable
optionally via crt_init_opt_t structure

Signed-off-by: Alexander Oganezov <alexander.a.oganezov@intel.com>