### PR TITLE
DAOS-8325 prop: new API for creating a property with entries+values

### DIFF
--- a/src/common/prop.c
+++ b/src/common/prop.c
@@ -873,7 +873,9 @@ daos_prop_entry_cmp_acl(struct daos_prop_entry *entry1,
 static int
 parse_entry(char *str, struct daos_prop_entry *entry)
 {
-	char	*name, *val, *end_token;
+	char	*name;
+	char	*val;
+	char	*end_token;
 	int	rc = 0;
 
 	/** get prop_name */
@@ -881,20 +883,20 @@ parse_entry(char *str, struct daos_prop_entry *entry)
 	/** get prop value */
 	val = strtok_r(NULL, ";", &end_token);
 
-	if (strcmp(name, "label") == 0) {
+	if (strcmp(name, DAOS_PROP_ENTRY_LABEL) == 0) {
 		entry->dpe_type = DAOS_PROP_CO_LABEL;
-		rc = daos_prop_entry_set_str(entry, val, strlen(val));
-	} else if (strcmp(name, "cksum") == 0) {
+		rc = daos_prop_entry_set_str(entry, val, DAOS_PROP_LABEL_MAX_LEN);
+	} else if (strcmp(name, DAOS_PROP_ENTRY_CKSUM) == 0) {
 		entry->dpe_type = DAOS_PROP_CO_CSUM;
 		rc = daos_str2csumcontprop(val);
 		if (rc < 0)
 			return rc;
 		entry->dpe_val = rc;
 		rc = 0;
-	} else if (strcmp(name, "cksum_size") == 0) {
+	} else if (strcmp(name, DAOS_PROP_ENTRY_CKSUM_SIZE) == 0) {
 		entry->dpe_type = DAOS_PROP_CO_CSUM_CHUNK_SIZE;
 		entry->dpe_val = strtoull(val, NULL, 0);
-	} else if (strcmp(name, "srv_cksum") == 0) {
+	} else if (strcmp(name, DAOS_PROP_ENTRY_SRV_CKSUM) == 0) {
 		entry->dpe_type = DAOS_PROP_CO_CSUM_SERVER_VERIFY;
 		if (strcmp(val, "on") == 0)
 			entry->dpe_val = DAOS_PROP_CO_CSUM_SV_ON;
@@ -902,7 +904,7 @@ parse_entry(char *str, struct daos_prop_entry *entry)
 			entry->dpe_val = DAOS_PROP_CO_CSUM_SV_OFF;
 		else
 			rc = -DER_INVAL;
-	} else if (strcmp(name, "dedup") == 0) {
+	} else if (strcmp(name, DAOS_PROP_ENTRY_DEDUP) == 0) {
 		entry->dpe_type = DAOS_PROP_CO_DEDUP;
 		if (strcmp(val, "off") == 0)
 			entry->dpe_val = DAOS_PROP_CO_DEDUP_OFF;
@@ -912,24 +914,24 @@ parse_entry(char *str, struct daos_prop_entry *entry)
 			entry->dpe_val = DAOS_PROP_CO_DEDUP_HASH;
 		else
 			rc = -DER_INVAL;
-	} else if (strcmp(name, "dedup_threshold") == 0) {
+	} else if (strcmp(name, DAOS_PROP_ENTRY_DEDUP_THRESHOLD) == 0) {
 		entry->dpe_type = DAOS_PROP_CO_DEDUP_THRESHOLD;
 		entry->dpe_val = strtoull(val, NULL, 0);
-	} else if (strcmp(name, "compression") == 0) {
+	} else if (strcmp(name, DAOS_PROP_ENTRY_COMPRESS) == 0) {
 		entry->dpe_type = DAOS_PROP_CO_COMPRESS;
 		rc = daos_str2compresscontprop(val);
 		if (rc < 0)
 			return rc;
 		entry->dpe_val = rc;
 		rc = 0;
-	} else if (strcmp(name, "encryption") == 0) {
+	} else if (strcmp(name, DAOS_PROP_ENTRY_ENCRYPT) == 0) {
 		entry->dpe_type = DAOS_PROP_CO_ENCRYPT;
 		rc = daos_str2encryptcontprop(val);
 		if (rc < 0)
 			return rc;
 		entry->dpe_val = rc;
 		rc = 0;
-	} else if (strcmp(name, "rf") == 0) {
+	} else if (strcmp(name, DAOS_PROP_ENTRY_REDUN_FAC) == 0) {
 		entry->dpe_type = DAOS_PROP_CO_REDUN_FAC;
 		if (!strcmp(val, "0"))
 			entry->dpe_val = DAOS_PROP_CO_REDUN_RF0;
@@ -945,13 +947,17 @@ parse_entry(char *str, struct daos_prop_entry *entry)
 			D_ERROR("presently supported redundancy factors (rf) are [0-4]\n");
 			rc = -DER_INVAL;
 		}
-	} else if (strcmp(name, "ec_cell") == 0) {
+	} else if (strcmp(name, DAOS_PROP_ENTRY_EC_CELL_SZ) == 0) {
 		entry->dpe_type = DAOS_PROP_CO_EC_CELL_SZ;
 		entry->dpe_val = strtoull(val, NULL, 0);
-	} else if (strcmp(name, "layout_type") == 0 || strcmp(name, "layout_version") == 0 ||
-		   strcmp(name, "rf_lvl") == 0 || strcmp(name, "max_snapshot") == 0 ||
-		   strcmp(name, "alloc_oid") == 0 || strcmp(name, "owner") == 0 ||
-		   strcmp(name, "group") == 0) {
+	} else if (strcmp(name, DAOS_PROP_ENTRY_LAYOUT_TYPE) == 0 ||
+		   strcmp(name, DAOS_PROP_ENTRY_LAYOUT_VER) == 0 ||
+		   strcmp(name, DAOS_PROP_ENTRY_REDUN_LVL) == 0 ||
+		   strcmp(name, DAOS_PROP_ENTRY_SNAPSHOT_MAX) == 0 ||
+		   strcmp(name, DAOS_PROP_ENTRY_ALLOCED_OID) == 0 ||
+		   strcmp(name, DAOS_PROP_ENTRY_STATUS) == 0 ||
+		   strcmp(name, DAOS_PROP_ENTRY_OWNER) == 0 ||
+		   strcmp(name, DAOS_PROP_ENTRY_GROUP) == 0) {
 		D_ERROR("Property %s is read only\n", name);
 		rc = -DER_INVAL;
 	} else {
@@ -963,10 +969,12 @@ parse_entry(char *str, struct daos_prop_entry *entry)
 }
 
 int
-daos_prop_alloc_and_set(const char *str, daos_size_t len, daos_prop_t **_prop)
+daos_prop_from_str(const char *str, daos_size_t len, daos_prop_t **_prop)
 {
 	daos_prop_t	*prop = NULL;
-	char		*save_prop = NULL, *t, *local;
+	char		*save_prop = NULL;
+	char		*t;
+	char		*local;
 	uint32_t	n;
 	int		rc = 0;
 

--- a/src/common/tests/prop_tests.c
+++ b/src/common/tests/prop_tests.c
@@ -252,6 +252,67 @@ test_daos_prop_merge_add_and_update(void **state)
 	daos_prop_free(exp_result);
 }
 
+static void
+test_daos_prop_alloc_and_set(void **state)
+{
+	/** Valid prop entries & values */
+	char		*LABEL		= "label:hello";
+	char		*CSUM		= "cksum:crc64";
+	char		*CSUM_SIZE	= "cksum_size:1048576";
+	char		*DEDUP		= "dedup:hash";
+	char		*DEDUP_TH	= "dedup_threshold:8192";
+	char		*COMP		= "compression:lz4";
+	char		*ENC		= "encryption:aes-xts128";
+	char		*RF		= "rf:2";
+	char		*EC_CELL	= "ec_cell:2021";
+
+	/** Valid prop entries, wrong values */
+	char		*CSUM_INV	= "cksum:crc2000";
+	char            *RF_INV		= "rf:64";
+
+	/** Read only props, that should not be parsed */
+	char		*OID		= "alloc_oid:25";
+	char		*LAYOUT		= "layout_type:posix";
+
+	/** Invalid prop entries */
+	char		*PROP_INV	= "hello:world";
+
+	char		buf[1024] = {0};
+	daos_prop_t	*prop;
+	int		rc;
+
+	rc = daos_prop_alloc_and_set(NULL, sizeof(buf), &prop);
+	assert_int_equal(rc, -DER_INVAL);
+	rc = daos_prop_alloc_and_set(buf, sizeof(buf), NULL);
+	assert_int_equal(rc, -DER_INVAL);
+	rc = daos_prop_alloc_and_set(buf, 0, &prop);
+	assert_int_equal(rc, -DER_INVAL);
+
+	/** Buffer containing read only entries should fail */
+	sprintf(buf, "%s;%s;%s", CSUM, OID, LAYOUT);
+	rc = daos_prop_alloc_and_set(buf, sizeof(buf), &prop);
+	assert_int_equal(rc, -DER_INVAL);
+
+	/** Buffer containing invalid entries should fail */
+	sprintf(buf, "%s;%s;%s", CSUM, LABEL, PROP_INV);
+	rc = daos_prop_alloc_and_set(buf, sizeof(buf), &prop);
+	assert_int_equal(rc, -DER_INVAL);
+
+	/** Buffer containing invalid values should fail */
+	sprintf(buf, "%s;%s", CSUM_INV, RF);
+	rc = daos_prop_alloc_and_set(buf, sizeof(buf), &prop);
+	assert_int_equal(rc, -DER_INVAL);
+	sprintf(buf, "%s;%s", CSUM, RF_INV);
+	rc = daos_prop_alloc_and_set(buf, sizeof(buf), &prop);
+	assert_int_equal(rc, -DER_INVAL);
+
+	sprintf(buf, "%s;%s;%s;%s;%s;%s;%s;%s;%s",
+		LABEL, CSUM, CSUM_SIZE, DEDUP, DEDUP_TH, COMP, ENC, RF, EC_CELL);
+	rc = daos_prop_alloc_and_set(buf, sizeof(buf), &prop);
+	assert_int_equal(rc, 0);
+	daos_prop_free(prop);
+}
+
 int
 main(void)
 {
@@ -262,6 +323,7 @@ main(void)
 		cmocka_unit_test(test_daos_prop_merge_total_update),
 		cmocka_unit_test(test_daos_prop_merge_subset_update),
 		cmocka_unit_test(test_daos_prop_merge_add_and_update),
+		cmocka_unit_test(test_daos_prop_alloc_and_set),
 	};
 
 	return cmocka_run_group_tests_name("common_prop", tests, NULL, NULL);

--- a/src/common/tests/prop_tests.c
+++ b/src/common/tests/prop_tests.c
@@ -187,8 +187,7 @@ test_daos_prop_merge_subset_update(void **state)
 	/* Expecting only one prop to be overwritten */
 	exp_result = daos_prop_dup(prop1, false /* pool */, true /* input */);
 	entry = daos_prop_entry_get(exp_result, prop2->dpp_entries[0].dpe_type);
-	assert_int_equal(daos_prop_entry_copy(&prop2->dpp_entries[0], entry),
-			 0);
+	assert_int_equal(daos_prop_entry_copy(&prop2->dpp_entries[0], entry), 0);
 
 	expect_merge_result(prop1, prop2, exp_result);
 
@@ -253,7 +252,7 @@ test_daos_prop_merge_add_and_update(void **state)
 }
 
 static void
-test_daos_prop_alloc_and_set(void **state)
+test_daos_prop_from_str(void **state)
 {
 	/** Valid prop entries & values */
 	char		*LABEL		= "label:hello";
@@ -277,39 +276,72 @@ test_daos_prop_alloc_and_set(void **state)
 	/** Invalid prop entries */
 	char		*PROP_INV	= "hello:world";
 
-	char		buf[1024] = {0};
-	daos_prop_t	*prop;
-	int		rc;
+	char			buf[1024] = {0};
+	daos_prop_t		*prop;
+	struct daos_prop_entry  *entry;
+	int			rc;
 
-	rc = daos_prop_alloc_and_set(NULL, sizeof(buf), &prop);
+	rc = daos_prop_from_str(NULL, sizeof(buf), &prop);
 	assert_int_equal(rc, -DER_INVAL);
-	rc = daos_prop_alloc_and_set(buf, sizeof(buf), NULL);
+	rc = daos_prop_from_str(buf, sizeof(buf), NULL);
 	assert_int_equal(rc, -DER_INVAL);
-	rc = daos_prop_alloc_and_set(buf, 0, &prop);
+	rc = daos_prop_from_str(buf, 0, &prop);
 	assert_int_equal(rc, -DER_INVAL);
 
 	/** Buffer containing read only entries should fail */
-	sprintf(buf, "%s;%s;%s", CSUM, OID, LAYOUT);
-	rc = daos_prop_alloc_and_set(buf, sizeof(buf), &prop);
+	sprintf(buf, "%s;%s", CSUM, OID);
+	rc = daos_prop_from_str(buf, sizeof(buf), &prop);
+	assert_int_equal(rc, -DER_INVAL);
+	sprintf(buf, "%s;%s", CSUM, LAYOUT);
+	rc = daos_prop_from_str(buf, sizeof(buf), &prop);
 	assert_int_equal(rc, -DER_INVAL);
 
 	/** Buffer containing invalid entries should fail */
 	sprintf(buf, "%s;%s;%s", CSUM, LABEL, PROP_INV);
-	rc = daos_prop_alloc_and_set(buf, sizeof(buf), &prop);
+	rc = daos_prop_from_str(buf, sizeof(buf), &prop);
 	assert_int_equal(rc, -DER_INVAL);
 
 	/** Buffer containing invalid values should fail */
 	sprintf(buf, "%s;%s", CSUM_INV, RF);
-	rc = daos_prop_alloc_and_set(buf, sizeof(buf), &prop);
+	rc = daos_prop_from_str(buf, sizeof(buf), &prop);
 	assert_int_equal(rc, -DER_INVAL);
 	sprintf(buf, "%s;%s", CSUM, RF_INV);
-	rc = daos_prop_alloc_and_set(buf, sizeof(buf), &prop);
+	rc = daos_prop_from_str(buf, sizeof(buf), &prop);
 	assert_int_equal(rc, -DER_INVAL);
 
 	sprintf(buf, "%s;%s;%s;%s;%s;%s;%s;%s;%s",
 		LABEL, CSUM, CSUM_SIZE, DEDUP, DEDUP_TH, COMP, ENC, RF, EC_CELL);
-	rc = daos_prop_alloc_and_set(buf, sizeof(buf), &prop);
+	rc = daos_prop_from_str(buf, sizeof(buf), &prop);
 	assert_int_equal(rc, 0);
+
+	/** verify entry values */
+	entry = daos_prop_entry_get(prop, DAOS_PROP_CO_LABEL);
+	assert_string_equal(entry->dpe_str, "hello");
+
+	entry = daos_prop_entry_get(prop, DAOS_PROP_CO_CSUM);
+	assert_int_equal(entry->dpe_val, DAOS_PROP_CO_CSUM_CRC64);
+
+	entry = daos_prop_entry_get(prop, DAOS_PROP_CO_CSUM_CHUNK_SIZE);
+	assert_int_equal(entry->dpe_val, 1048576);
+
+	entry = daos_prop_entry_get(prop, DAOS_PROP_CO_DEDUP);
+	assert_int_equal(entry->dpe_val, DAOS_PROP_CO_DEDUP_HASH);
+
+	entry = daos_prop_entry_get(prop, DAOS_PROP_CO_DEDUP_THRESHOLD);
+	assert_int_equal(entry->dpe_val, 8192);
+
+	entry = daos_prop_entry_get(prop, DAOS_PROP_CO_COMPRESS);
+	assert_int_equal(entry->dpe_val, DAOS_PROP_CO_COMPRESS_LZ4);
+
+	entry = daos_prop_entry_get(prop, DAOS_PROP_CO_ENCRYPT);
+	assert_int_equal(entry->dpe_val, DAOS_PROP_CO_ENCRYPT_AES_XTS128);
+
+	entry = daos_prop_entry_get(prop, DAOS_PROP_CO_REDUN_FAC);
+	assert_int_equal(entry->dpe_val, DAOS_PROP_CO_REDUN_RF2);
+
+	entry = daos_prop_entry_get(prop, DAOS_PROP_CO_EC_CELL_SZ);
+	assert_int_equal(entry->dpe_val, 2021);
+
 	daos_prop_free(prop);
 }
 
@@ -323,7 +355,7 @@ main(void)
 		cmocka_unit_test(test_daos_prop_merge_total_update),
 		cmocka_unit_test(test_daos_prop_merge_subset_update),
 		cmocka_unit_test(test_daos_prop_merge_add_and_update),
-		cmocka_unit_test(test_daos_prop_alloc_and_set),
+		cmocka_unit_test(test_daos_prop_from_str),
 	};
 
 	return cmocka_run_group_tests_name("common_prop", tests, NULL, NULL);

--- a/src/control/cmd/daos/property.go
+++ b/src/control/cmd/daos/property.go
@@ -31,6 +31,7 @@ import (
 #include <daos/compression.h>
 #include <daos/cipher.h>
 #include <daos/object.h>
+#include <daos/cont_props.h>
 */
 import "C"
 
@@ -75,7 +76,7 @@ type propHdlr struct {
 //		bool,			   // if true, property may not be set
 // 	},
 var propHdlrs = propHdlrMap{
-	"label": {
+	C.DAOS_PROP_ENTRY_LABEL: {
 		C.DAOS_PROP_CO_LABEL,
 		"Label",
 		func(_ *propHdlr, e *C.struct_daos_prop_entry, v string) error {
@@ -100,7 +101,7 @@ var propHdlrs = propHdlrMap{
 		},
 		false,
 	},
-	"cksum": {
+	C.DAOS_PROP_ENTRY_CKSUM: {
 		C.DAOS_PROP_CO_CSUM,
 		"Checksum",
 		func(h *propHdlr, e *C.struct_daos_prop_entry, v string) error {
@@ -140,7 +141,7 @@ var propHdlrs = propHdlrMap{
 		},
 		false,
 	},
-	"cksum_size": {
+	C.DAOS_PROP_ENTRY_CKSUM_SIZE: {
 		C.DAOS_PROP_CO_CSUM_CHUNK_SIZE,
 		"Checksum Chunk Size",
 		func(_ *propHdlr, e *C.struct_daos_prop_entry, v string) error {
@@ -156,7 +157,7 @@ var propHdlrs = propHdlrMap{
 		humanSizeStringer,
 		false,
 	},
-	"srv_cksum": {
+	C.DAOS_PROP_ENTRY_SRV_CKSUM: {
 		C.DAOS_PROP_CO_CSUM_SERVER_VERIFY,
 		"Server Checksumming",
 		func(h *propHdlr, e *C.struct_daos_prop_entry, v string) error {
@@ -186,7 +187,7 @@ var propHdlrs = propHdlrMap{
 		},
 		false,
 	},
-	"dedup": {
+	C.DAOS_PROP_ENTRY_DEDUP: {
 		C.DAOS_PROP_CO_DEDUP,
 		"Deduplication",
 		func(h *propHdlr, e *C.struct_daos_prop_entry, v string) error {
@@ -219,7 +220,7 @@ var propHdlrs = propHdlrMap{
 		},
 		false,
 	},
-	"dedup_threshold": {
+	C.DAOS_PROP_ENTRY_DEDUP_THRESHOLD: {
 		C.DAOS_PROP_CO_DEDUP_THRESHOLD,
 		"Dedupe Threshold",
 		func(_ *propHdlr, e *C.struct_daos_prop_entry, v string) error {
@@ -235,7 +236,7 @@ var propHdlrs = propHdlrMap{
 		humanSizeStringer,
 		false,
 	},
-	"compression": {
+	C.DAOS_PROP_ENTRY_COMPRESS: {
 		C.DAOS_PROP_CO_COMPRESS,
 		"Compression",
 		func(h *propHdlr, e *C.struct_daos_prop_entry, v string) error {
@@ -275,7 +276,7 @@ var propHdlrs = propHdlrMap{
 		},
 		false,
 	},
-	"encryption": {
+	C.DAOS_PROP_ENTRY_ENCRYPT: {
 		C.DAOS_PROP_CO_ENCRYPT,
 		"Encryption",
 		func(h *propHdlr, e *C.struct_daos_prop_entry, v string) error {
@@ -315,7 +316,7 @@ var propHdlrs = propHdlrMap{
 		},
 		false,
 	},
-	"rf": {
+	C.DAOS_PROP_ENTRY_REDUN_FAC: {
 		C.DAOS_PROP_CO_REDUN_FAC,
 		"Redundancy Factor",
 		func(h *propHdlr, e *C.struct_daos_prop_entry, v string) error {
@@ -354,7 +355,7 @@ var propHdlrs = propHdlrMap{
 		},
 		false,
 	},
-	"status": {
+	C.DAOS_PROP_ENTRY_STATUS: {
 		C.DAOS_PROP_CO_STATUS,
 		"Health",
 		func(h *propHdlr, e *C.struct_daos_prop_entry, v string) error {
@@ -387,7 +388,7 @@ var propHdlrs = propHdlrMap{
 		},
 		false,
 	},
-	"ec_cell": {
+	C.DAOS_PROP_ENTRY_EC_CELL_SZ: {
 		C.DAOS_PROP_CO_EC_CELL_SZ,
 		"EC Cell Size",
 		func(_ *propHdlr, e *C.struct_daos_prop_entry, v string) error {
@@ -419,7 +420,7 @@ var propHdlrs = propHdlrMap{
 		false,
 	},
 	// Read-only properties here for use by get-property.
-	"layout_type": {
+	C.DAOS_PROP_ENTRY_LAYOUT_TYPE: {
 		C.DAOS_PROP_CO_LAYOUT_TYPE,
 		"Layout Type",
 		nil, nil,
@@ -436,14 +437,14 @@ var propHdlrs = propHdlrMap{
 		},
 		true,
 	},
-	"layout_version": {
+	C.DAOS_PROP_ENTRY_LAYOUT_VER: {
 		C.DAOS_PROP_CO_LAYOUT_VER,
 		"Layout Version",
 		nil, nil,
 		uintStringer,
 		true,
 	},
-	"rf_lvl": {
+	C.DAOS_PROP_ENTRY_REDUN_LVL: {
 		C.DAOS_PROP_CO_REDUN_LVL,
 		"Redundancy Level",
 		nil, nil,
@@ -462,28 +463,28 @@ var propHdlrs = propHdlrMap{
 		},
 		true,
 	},
-	"max_snapshot": {
+	C.DAOS_PROP_ENTRY_SNAPSHOT_MAX: {
 		C.DAOS_PROP_CO_SNAPSHOT_MAX,
 		"Max Snapshot",
 		nil, nil,
 		uintStringer,
 		true,
 	},
-	"alloc_oid": {
+	C.DAOS_PROP_ENTRY_ALLOCED_OID: {
 		C.DAOS_PROP_CO_ALLOCED_OID,
 		"Highest Allocated OID",
 		nil, nil,
 		uintStringer,
 		true,
 	},
-	"owner": {
+	C.DAOS_PROP_ENTRY_OWNER: {
 		C.DAOS_PROP_CO_OWNER,
 		"Owner",
 		nil, nil,
 		strValStringer,
 		true,
 	},
-	"group": {
+	C.DAOS_PROP_ENTRY_GROUP: {
 		C.DAOS_PROP_CO_OWNER_GROUP,
 		"Group",
 		nil, nil,

--- a/src/include/daos/cont_props.h
+++ b/src/include/daos/cont_props.h
@@ -9,6 +9,26 @@
 
 #include <daos_prop.h>
 
+/** DAOS container property entry names used to set properties using the daos tool */
+#define DAOS_PROP_ENTRY_LABEL		"label"
+#define DAOS_PROP_ENTRY_CKSUM		"cksum"
+#define DAOS_PROP_ENTRY_CKSUM_SIZE	"cksum_size"
+#define DAOS_PROP_ENTRY_SRV_CKSUM	"srv_cksum"
+#define DAOS_PROP_ENTRY_DEDUP		"dedup"
+#define DAOS_PROP_ENTRY_DEDUP_THRESHOLD	"dedup_threshold"
+#define DAOS_PROP_ENTRY_COMPRESS	"compression"
+#define DAOS_PROP_ENTRY_ENCRYPT		"encryption"
+#define DAOS_PROP_ENTRY_REDUN_FAC	"rf"
+#define DAOS_PROP_ENTRY_STATUS		"status"
+#define DAOS_PROP_ENTRY_EC_CELL_SZ	"ec_cell"
+#define DAOS_PROP_ENTRY_LAYOUT_TYPE	"layout_type"
+#define DAOS_PROP_ENTRY_LAYOUT_VER	"layout_version"
+#define DAOS_PROP_ENTRY_REDUN_LVL	"rf_lvl"
+#define DAOS_PROP_ENTRY_SNAPSHOT_MAX	"max_snapshot"
+#define DAOS_PROP_ENTRY_ALLOCED_OID	"alloc_oid"
+#define DAOS_PROP_ENTRY_OWNER		"owner"
+#define DAOS_PROP_ENTRY_GROUP		"group"
+
 struct cont_props {
 	uint32_t	 dcp_chunksize;
 	uint32_t	 dcp_dedup_size;

--- a/src/include/daos_prop.h
+++ b/src/include/daos_prop.h
@@ -452,7 +452,7 @@ daos_prop_free(daos_prop_t *prop);
  * \param[out]	prop	Property that is created
  */
 int
-daos_prop_alloc_and_set(const char *str, daos_size_t len, daos_prop_t **prop);
+daos_prop_from_str(const char *str, daos_size_t len, daos_prop_t **prop);
 
 /**
  * Merge a set of new DAOS properties into a set of existing DAOS properties.

--- a/src/include/daos_prop.h
+++ b/src/include/daos_prop.h
@@ -440,6 +440,21 @@ void
 daos_prop_free(daos_prop_t *prop);
 
 /**
+ * Allocate a new property from a string buffer of property entries and values. That buffer has to
+ * be of the format:
+ * prop_entry_name1:value1;prop_entry_name2:value2;prop_entry_name3:value3;
+ * \a prop must be freed with daos_prop_free() to release allocated space.
+ * This supports properties that can be modified on container creation only:
+ * label, cksum, cksum_size, srv_cksum, dedup, dedup_threshold, compression, encryption, rf, ec_cell
+ *
+ * \param[in]	str	Serialized string of property entries and their values
+ * \param[in]	len	Serialized string length
+ * \param[out]	prop	Property that is created
+ */
+int
+daos_prop_alloc_and_set(const char *str, daos_size_t len, daos_prop_t **prop);
+
+/**
  * Merge a set of new DAOS properties into a set of existing DAOS properties.
  *
  * \param[in]	old_prop	Existing set of properties


### PR DESCRIPTION
Add a new property API to allow users to pass in a buffer of prop
entry and value pairs to create a new property that can be used to
create a container. The format of the buffer is:
entry1:val1;entry2:val2;...

Skip-nlt: true
Skip-func-test: true
Skip-func-hw-test: true

Signed-off-by: Mohamad Chaarawi <mohamad.chaarawi@intel.com>