### PR TITLE
DAOS-8304 control: system.Join() retry improvements

### DIFF
--- a/src/control/lib/control/faults.go
+++ b/src/control/lib/control/faults.go
@@ -38,7 +38,24 @@ var (
 	)
 )
 
-func IsConnectionError(err error) bool {
+// IsRetryableConnErr indicates whether the error is a connection error that
+// can be retried.
+func IsRetryableConnErr(err error) bool {
+	if !IsConnErr(err) {
+		return false
+	}
+
+	f, ok := errors.Cause(err).(*fault.Fault)
+	if !ok {
+		return false
+	}
+
+	return f.Code == code.ClientConnectionRefused ||
+		f.Code == code.ClientConnectionClosed
+}
+
+// IsConnErr indicates whether the error is a connection error.
+func IsConnErr(err error) bool {
 	f, ok := errors.Cause(err).(*fault.Fault)
 	if !ok {
 		return false

--- a/src/control/lib/control/response.go
+++ b/src/control/lib/control/response.go
@@ -204,7 +204,7 @@ func (ur *UnaryResponse) getMSResponse() (proto.Message, error) {
 func convertMSResponse(ur *UnaryResponse, out interface{}) error {
 	msResp, err := ur.getMSResponse()
 	if err != nil {
-		if IsConnectionError(err) {
+		if IsConnErr(err) {
 			return errMSConnectionFailure
 		}
 		return err

--- a/src/control/lib/control/system_test.go
+++ b/src/control/lib/control/system_test.go
@@ -9,6 +9,7 @@ package control
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -1282,6 +1283,100 @@ func TestControl_SystemErase(t *testing.T) {
 			})
 
 			gotResp, gotErr := SystemErase(context.TODO(), mi, tc.req)
+			common.CmpErr(t, tc.expErr, gotErr)
+			if tc.expErr != nil {
+				return
+			}
+
+			if diff := cmp.Diff(tc.expResp, gotResp, defResCmpOpts()...); diff != "" {
+				t.Fatalf("unexpected response (-want, +got):\n%s\n", diff)
+			}
+		})
+	}
+}
+
+func TestControl_SystemJoin_RetryableErrors(t *testing.T) {
+	for name, testErr := range map[string]error{
+		"system not formatted": system.ErrUninitialized,
+		"system unavailable":   system.ErrRaftUnavail,
+		"connection closed":    FaultConnectionClosed(""),
+		"connection refused":   FaultConnectionRefused(""),
+	} {
+		t.Run(name, func(t *testing.T) {
+			log, buf := logging.NewTestLogger(name)
+			defer common.ShowBufferOnFailure(t, buf)
+
+			client := NewMockInvoker(log, &MockInvokerConfig{
+				UnaryResponseSet: []*UnaryResponse{
+					MockMSResponse("", testErr, nil),
+					MockMSResponse("", nil, &mgmtpb.JoinResp{Rank: 42}),
+				},
+			})
+
+			gotResp, gotErr := SystemJoin(context.TODO(), client, &SystemJoinReq{})
+			if gotErr != nil {
+				t.Fatalf("unexpected error: %v", gotErr)
+			}
+
+			expResp := &SystemJoinResp{Rank: 42}
+			if diff := cmp.Diff(expResp, gotResp, defResCmpOpts()...); diff != "" {
+				t.Fatalf("unexpected response (-want, +got):\n%s\n", diff)
+			}
+		})
+	}
+}
+
+func TestControl_SystemJoin_Timeouts(t *testing.T) {
+	for name, tc := range map[string]struct {
+		outerTimeout time.Duration
+		mic          *MockInvokerConfig
+		expResp      *SystemJoinResp
+		expErr       error
+	}{
+		"outer context is canceled": {
+			outerTimeout: 1 * time.Nanosecond,
+			expErr:       context.DeadlineExceeded,
+		},
+		"inner context is canceled": {
+			mic: &MockInvokerConfig{
+				UnaryResponseSet: []*UnaryResponse{
+					{
+						fromMS: true,
+						Responses: []*HostResponse{
+							{
+								Error: FaultConnectionClosed(""),
+							},
+							{
+								Error: FaultConnectionRefused(""),
+							},
+							{
+								Error: context.DeadlineExceeded,
+							},
+						},
+					},
+					MockMSResponse("", nil, &mgmtpb.JoinResp{Rank: 42}),
+				},
+				UnaryResponseDelays: [][]time.Duration{
+					{},
+					{0, 0, SystemJoinRetryTimeout + time.Millisecond},
+				},
+			},
+			expResp: &SystemJoinResp{Rank: 42},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			log, buf := logging.NewTestLogger(name)
+			defer common.ShowBufferOnFailure(t, buf)
+
+			ctx := context.Background()
+			if tc.outerTimeout > 0 {
+				var cancel context.CancelFunc
+				ctx, cancel = context.WithTimeout(ctx, tc.outerTimeout)
+				defer cancel()
+			}
+
+			client := NewMockInvoker(log, tc.mic)
+			gotResp, gotErr := SystemJoin(ctx, client, &SystemJoinReq{})
 			common.CmpErr(t, tc.expErr, gotErr)
 			if tc.expErr != nil {
 				return

--- a/src/control/server/mgmt_system.go
+++ b/src/control/server/mgmt_system.go
@@ -846,7 +846,7 @@ func (svc *mgmtSvc) SystemErase(ctx context.Context, pbReq *mgmtpb.SystemEraseRe
 		peerReq.AddHost(peer.String())
 
 		if _, err := control.SystemErase(ctx, svc.rpcClient, peerReq); err != nil {
-			if control.IsConnectionError(err) {
+			if control.IsRetryableConnErr(err) {
 				continue
 			}
 			return nil, err

--- a/src/control/system/errors.go
+++ b/src/control/system/errors.go
@@ -23,6 +23,12 @@ var (
 	ErrUninitialized = errors.New("system is uninitialized (storage format required?)")
 )
 
+// IsNotReady is a convenience function for checking if an error
+// indicates that the system is not ready to serve requests.
+func IsNotReady(err error) bool {
+	return IsUninitialized(err) || IsUnavailable(err)
+}
+
 // IsUnavailable returns a boolean indicating whether or not the
 // supplied error corresponds to some unavailability state.
 func IsUnavailable(err error) bool {


### PR DESCRIPTION
Add more granularity to retryable connection errors and
make retrying the inner join timeout more explicit. Also
adds the "not formatted" error to the set of retryable
Join errors, to handle races between server storage formats.