### PR TITLE
DAOS-7420 vos: Add object specific mode to vos_discard

### DIFF
--- a/src/include/daos_srv/vos.h
+++ b/src/include/daos_srv/vos.h
@@ -433,6 +433,7 @@ vos_aggregate(daos_handle_t coh, daos_epoch_range_t *epr,
  * the caller.
  *
  * \param coh		[IN]	Container open handle
+ * \param oid		[IN]	Optional oid to limit scan
  * \param epr		[IN]	The epoch range to discard
  *				keys to discard
  * \param yield_func	[IN]	Pointer to customized yield function
@@ -441,7 +442,7 @@ vos_aggregate(daos_handle_t coh, daos_epoch_range_t *epr,
  * \return			Zero on success, negative value if error
  */
 int
-vos_discard(daos_handle_t coh, daos_epoch_range_t *epr,
+vos_discard(daos_handle_t coh, const daos_unit_oid_t *oid, daos_epoch_range_t *epr,
 	    bool (*yield_func)(void *arg), void *yield_arg);
 
 /**

--- a/src/object/srv_obj_migrate.c
+++ b/src/object/srv_obj_migrate.c
@@ -2406,6 +2406,7 @@ destroy_existing_obj(struct migrate_pool_tls *tls, unsigned int tgt_idx,
 		     daos_unit_oid_t *oid, uuid_t cont_uuid)
 {
 	struct ds_cont_child *cont;
+	daos_epoch_range_t   epr;
 	int rc;
 
 	rc = ds_cont_child_open_create(tls->mpt_pool_uuid, cont_uuid, &cont);
@@ -2422,7 +2423,9 @@ destroy_existing_obj(struct migrate_pool_tls *tls, unsigned int tgt_idx,
 		return rc;
 	}
 
-	rc = vos_obj_delete(cont->sc_hdl, *oid);
+	epr.epr_hi = tls->mpt_max_eph;
+	epr.epr_lo = 0;
+	rc = vos_discard(cont->sc_hdl, oid, &epr, NULL, NULL);
 	if (rc != 0) {
 		D_ERROR("Migrate failed to destroy object prior to "
 			"reintegration: pool/object "DF_UUID"/"DF_UOID

--- a/src/rdb/rdb_util.c
+++ b/src/rdb/rdb_util.c
@@ -529,7 +529,7 @@ rdb_vos_discard(daos_handle_t cont, daos_epoch_t low, daos_epoch_t high)
 	range.epr_lo = low;
 	range.epr_hi = high;
 
-	return vos_discard(cont, &range, NULL, NULL);
+	return vos_discard(cont, NULL, &range, NULL, NULL);
 }
 
 int

--- a/src/tests/suite/daos_rebuild_simple.c
+++ b/src/tests/suite/daos_rebuild_simple.c
@@ -69,16 +69,15 @@ reintegrate_with_inflight_io(test_arg_t *arg, daos_obj_id_t *oid,
 {
 	daos_obj_id_t inflight_oid;
 
-#if 0
 	/* Disable it due to DAOS-7420 */
 	if (oid != NULL) {
 		inflight_oid = *oid;
 	} else {
-#endif
-	inflight_oid = daos_test_oid_gen(arg->coh,
-					 DAOS_OC_R3S_SPEC_RANK, 0,
-					 0, arg->myrank);
-	inflight_oid = dts_oid_set_rank(inflight_oid, rank);
+		inflight_oid = daos_test_oid_gen(arg->coh,
+						 DAOS_OC_R3S_SPEC_RANK, 0,
+						 0, arg->myrank);
+		inflight_oid = dts_oid_set_rank(inflight_oid, rank);
+	}
 
 	arg->rebuild_cb = reintegrate_inflight_io;
 	arg->rebuild_cb_arg = &inflight_oid;
@@ -91,7 +90,6 @@ reintegrate_with_inflight_io(test_arg_t *arg, daos_obj_id_t *oid,
 	arg->rebuild_cb = NULL;
 	arg->rebuild_cb_arg = NULL;
 
-#if 0
 	/* Disable it due to DAOS-7420 */
 	if (oid == NULL) {
 		int rc;
@@ -100,7 +98,6 @@ reintegrate_with_inflight_io(test_arg_t *arg, daos_obj_id_t *oid,
 		if (rc != 0)
 			assert_rc_equal(rc, -DER_NOSYS);
 	}
-#endif
 }
 
 static void

--- a/src/vos/evt_iter.c
+++ b/src/vos/evt_iter.c
@@ -373,7 +373,6 @@ int
 evt_iter_probe(daos_handle_t ih, enum evt_iter_opc opc,
 	       const struct evt_rect *rect, const daos_anchor_t *anchor)
 {
-	struct vos_iterator	*oiter = vos_hdl2iter(ih);
 	struct evt_iterator	*iter;
 	struct evt_context	*tcx;
 	struct evt_entry_array	*enta;
@@ -400,6 +399,12 @@ evt_iter_probe(daos_handle_t ih, enum evt_iter_opc opc,
 	switch (opc) {
 	default:
 		D_GOTO(out, rc = -DER_NOSYS);
+	case EVT_ITER_FIND:
+		/** There is really no reliable usage of EVT_ITER_FIND with unsorted iterator.
+		 *  Always start over rather than starting from where we left off.  The issue
+		 *  is the evtree is unsorted so starting from an anchor is no guarantee we
+		 *  will visit every entry.
+		 */
 	case EVT_ITER_FIRST:
 		fopc = EVT_FIND_FIRST;
 		/* An extent that covers everything */
@@ -408,22 +413,9 @@ evt_iter_probe(daos_handle_t ih, enum evt_iter_opc opc,
 		rtmp.rc_epc = DAOS_EPOCH_MAX;
 		rtmp.rc_minor_epc = EVT_MINOR_EPC_MAX;
 		break;
-
-	case EVT_ITER_FIND:
-		if (!rect && !anchor)
-			D_GOTO(out, rc = -DER_INVAL);
-
-		/* Requires the exactly same extent, we require user to
-		 * start over if anything changed (clipped, aggregated).
-		 */
-		fopc = EVT_FIND_SAME;
-		if (rect == NULL)
-			rect = (struct evt_rect *)&anchor->da_buf[0];
-
-		rtmp = *rect;
 	}
 
-	rc = evt_ent_array_fill(tcx, fopc, vos_iter_intent(oiter),
+	rc = evt_ent_array_fill(tcx, fopc, evt_iter_intent(iter),
 				&iter->it_filter, &rtmp, enta);
 	if (rc != 0)
 		D_GOTO(out, rc);

--- a/src/vos/evt_priv.h
+++ b/src/vos/evt_priv.h
@@ -510,13 +510,13 @@ evt_node_desc_at(struct evt_context *tcx, struct evt_node *node,
 static inline bool
 evt_entry_punched(const struct evt_entry *ent, const struct evt_filter *filter)
 {
-	struct vos_punch_record	punch;
+	struct ilog_time_rec	punch;
 
 	if (filter == NULL)
 		return false;
 
-	punch.pr_epc = filter->fr_punch_epc;
-	punch.pr_minor_epc = filter->fr_punch_minor_epc;
+	punch.tr_epc = filter->fr_punch_epc;
+	punch.tr_minor_epc = filter->fr_punch_minor_epc;
 
 	return vos_epc_punched(ent->en_epoch, ent->en_minor_epc, &punch);
 }

--- a/src/vos/evtree.c
+++ b/src/vos/evtree.c
@@ -2494,8 +2494,11 @@ evt_ent_array_fill(struct evt_context *tcx, enum evt_find_opc find_opc,
 			rc = evt_desc_log_status(tcx, rtmp.rc_epc, desc,
 						 intent);
 			/* Skip the unavailable record. */
-			if (rc == ALB_UNAVAILABLE)
+			if (rc == ALB_UNAVAILABLE) {
+				D_DEBUG(DB_TRACE, "Skipping unavailable record "DF_RECT"\n",
+					DP_RECT(&rtmp));
 				continue;
+			}
 
 			/* early check */
 			switch (find_opc) {

--- a/src/vos/ilog.c
+++ b/src/vos/ilog.c
@@ -884,8 +884,6 @@ ilog_modify(daos_handle_t loh, const struct ilog_id *id_in,
 		return -DER_INVAL;
 	}
 
-	D_ASSERT(!lctx->ic_in_txn);
-
 	root = lctx->ic_root;
 
 	version = ilog_mag2ver(root->lr_magic);
@@ -1275,6 +1273,8 @@ struct agg_arg {
 	int32_t				 aa_prev;
 	int32_t				 aa_prior_punch;
 	daos_epoch_t			 aa_punched;
+	daos_epoch_t			 aa_max;
+	bool				 aa_max_is_punch;
 	bool				 aa_discard;
 	uint16_t			 aa_punched_minor;
 };
@@ -1404,6 +1404,37 @@ done:
 	return rc;
 }
 
+static inline void
+set_update_max_entry(struct agg_arg *agg_arg, const struct ilog_entry *entry)
+{
+	if (entry->ie_id.id_epoch <= agg_arg->aa_max)
+		return;
+
+	if (ilog_is_punch(entry)) {
+		/** Last entry is a punch, if it holds, we will not need to
+		 *  insert any ilog
+		 */
+		agg_arg->aa_max_is_punch = true;
+	} else {
+		agg_arg->aa_max_is_punch = false;
+	}
+
+	agg_arg->aa_max = entry->ie_id.id_epoch;
+}
+
+static inline void
+set_update_max(struct agg_arg *agg_arg, const struct ilog_entries *entries, int32_t idx)
+{
+	struct ilog_entry	entry;
+
+	if (idx < 0)
+		return;
+
+	ilog_cache_entry(entries, &entry, idx);
+
+	set_update_max_entry(agg_arg, &entry);
+}
+
 static int
 collapse_tree(struct ilog_context *lctx, struct ilog_array_cache *cache, struct ilog_priv *priv,
 	      int removed)
@@ -1479,7 +1510,7 @@ int
 ilog_aggregate(struct umem_instance *umm, struct ilog_df *ilog,
 	       const struct ilog_desc_cbs *cbs, const daos_epoch_range_t *epr,
 	       bool discard, daos_epoch_t punched_major, uint16_t punched_minor,
-	       struct ilog_entries *entries)
+	       struct ilog_entries *entries, const struct ilog_time_rec *update)
 {
 	struct ilog_priv	*priv = ilog_ent2priv(entries);
 	struct ilog_context	*lctx;
@@ -1492,11 +1523,13 @@ ilog_aggregate(struct umem_instance *umm, struct ilog_df *ilog,
 	int			 removed = 0;
 
 	D_ASSERT(epr != NULL);
-	D_ASSERT(punched_major <= epr->epr_hi);
-
 	D_DEBUG(DB_TRACE, "%s incarnation log: epr: "DF_X64"-"DF_X64" punched="
 		DF_X64".%d\n", discard ? "Discard" : "Aggregate", epr->epr_lo,
 		epr->epr_hi, punched_major, punched_minor);
+
+	D_ASSERT(punched_major <= epr->epr_hi);
+
+	lctx = &priv->ip_lctx;
 
 	/* This can potentially be optimized but using ilog_fetch gets some code
 	 * reuse.
@@ -1507,8 +1540,6 @@ ilog_aggregate(struct umem_instance *umm, struct ilog_df *ilog,
 		/* Log is empty */
 		return 1;
 	}
-
-	lctx = &priv->ip_lctx;
 
 	root = lctx->ic_root;
 
@@ -1524,6 +1555,11 @@ ilog_aggregate(struct umem_instance *umm, struct ilog_df *ilog,
 			return -DER_NOMEM;
 	}
 
+	agg_arg.aa_max = 0;
+	/** If the max is a punch, nothing to do.  This is true if we don't find any
+	 *  updates so set the default to true
+	 */
+	agg_arg.aa_max_is_punch = true;
 	agg_arg.aa_epr = epr;
 	agg_arg.aa_prev = -1;
 	agg_arg.aa_prior_punch = -1;
@@ -1543,11 +1579,13 @@ ilog_aggregate(struct umem_instance *umm, struct ilog_df *ilog,
 			agg_arg.aa_prev = entry.ie_idx;
 			break;
 		case AGG_RC_REMOVE_PREV:
+			set_update_max(&agg_arg, entries, agg_arg.aa_prev);
 			priv->ip_removals[agg_arg.aa_prev] = true;
 			removed++;
 			agg_arg.aa_prev = agg_arg.aa_prior_punch;
 			/* Fall through */
 		case AGG_RC_REMOVE:
+			set_update_max_entry(&agg_arg, &entry);
 			priv->ip_removals[entry.ie_idx] = true;
 			removed++;
 			break;
@@ -1563,13 +1601,29 @@ ilog_aggregate(struct umem_instance *umm, struct ilog_df *ilog,
 collapse:
 	rc = collapse_tree(lctx, &cache, priv, removed);
 
+	if (rc == 0 && update != NULL && update->tr_epc != 0 && !agg_arg.aa_max_is_punch) {
+		daos_epoch_range_t	range	= {update->tr_epc, update->tr_epc};
+		struct ilog_id		id = {
+			.id_tx_id = 0,
+			.id_epoch = update->tr_epc,
+			.id_update_minor_eph = update->tr_minor_epc,
+			.id_punch_minor_eph = 0,
+		};
+		D_DEBUG(DB_TRACE, "INSERT ILOG ENTRY FOR update = "DF_X64"\n", update->tr_epc);
+
+		/* Were moved a creation entry, so need to add the new one */
+		lctx->ic_cbs.dc_log_add_cb = NULL;
+		rc = ilog_modify(ilog_lctx2hdl(lctx), &id, &range, ILOG_OP_UPDATE);
+		if (rc != 0)
+			goto done;
+	}
 	empty = ilog_empty(root);
 done:
 	rc = ilog_tx_end(lctx, rc);
 	D_DEBUG(DB_TRACE, "%s in incarnation log epr:"DF_X64"-"DF_X64
-		" status: "DF_RC", removed %d entries\n",
+		" status: "DF_RC", removed %d entries, %s\n",
 		discard ? "Discard" : "Aggregation", epr->epr_lo,
-		epr->epr_hi, DP_RC(rc), removed);
+		epr->epr_hi, DP_RC(rc), removed, empty ? "empty" : "not empty");
 	if (rc)
 		return rc;
 

--- a/src/vos/ilog.h
+++ b/src/vos/ilog.h
@@ -33,6 +33,16 @@ struct  ilog_df {
 	char	id_pad[24];
 };
 
+#define DF_TREC DF_X64".%d"
+#define DP_TREC(trec) (trec)->tr_epc, (trec)->tr_minor_epc
+
+struct ilog_time_rec {
+	/** Major epoch of update/punch */
+	daos_epoch_t	tr_epc;
+	/** Minor epoch of update/punch */
+	uint16_t	tr_minor_epc;
+};
+
 struct umem_instance;
 
 enum ilog_status {
@@ -197,6 +207,8 @@ struct ilog_entries {
  *  \param	punch_major[in]	Max minor epoch punch of parent incarnation log
  *  \param	entries[in]	Used for efficiency since aggregation is used
  *				by vos_iterator
+ *  \param	update[in]	Optional, indicates next update after the range
+ *				in case the ilog would otherwise be left empty
  *
  *  \return	0		success
  *		1		success but indicates log is empty
@@ -206,7 +218,7 @@ int
 ilog_aggregate(struct umem_instance *umm, struct ilog_df *root,
 	       const struct ilog_desc_cbs *cbs, const daos_epoch_range_t *epr,
 	       bool discard, daos_epoch_t punch_major, uint16_t punch_minor,
-	       struct ilog_entries *entries);
+	       struct ilog_entries *entries, const struct ilog_time_rec *update);
 
 /** Initialize an ilog_entries struct for fetch
  *

--- a/src/vos/tests/vts_aggregate.c
+++ b/src/vos/tests/vts_aggregate.c
@@ -421,7 +421,7 @@ aggregate_basic_lb(struct io_test_args *arg, struct agg_tst_dataset *ds, int pun
 		    "Discard" : "Aggregate", epr_a->epr_lo, epr_a->epr_hi);
 
 	if (ds->td_discard)
-		rc = vos_discard(arg->ctx.tc_co_hdl, epr_a, NULL, NULL);
+		rc = vos_discard(arg->ctx.tc_co_hdl, NULL, epr_a, NULL, NULL);
 	else
 		rc = vos_aggregate(arg->ctx.tc_co_hdl, epr_a,
 				   ds_csum_agg_recalc, NULL, NULL, false);
@@ -607,7 +607,7 @@ aggregate_multi(struct io_test_args *arg, struct agg_tst_dataset *ds_sample)
 		    "Discard" : "Aggregate");
 
 	if (ds_sample->td_discard)
-		rc = vos_discard(arg->ctx.tc_co_hdl, epr_a, NULL, NULL);
+		rc = vos_discard(arg->ctx.tc_co_hdl, NULL, epr_a, NULL, NULL);
 	else
 		rc = vos_aggregate(arg->ctx.tc_co_hdl, epr_a, NULL, NULL, NULL,
 				   false);
@@ -1100,7 +1100,7 @@ do_punch(struct io_test_args *arg, int type, daos_unit_oid_t oid,
 
 #define NUM_INTERNAL 200
 static void
-agg_punches_test_helper(void **state, int record_type, int type, bool discard,
+agg_punches_test_helper(void **state, bool one, int record_type, int type, bool discard,
 			int first, int last)
 {
 	struct io_test_args	*arg = *state;
@@ -1159,7 +1159,7 @@ agg_punches_test_helper(void **state, int record_type, int type, bool discard,
 
 	for (i = 0; i < 2; i++) {
 		if (discard)
-			rc = vos_discard(arg->ctx.tc_co_hdl, &epr, NULL, NULL);
+			rc = vos_discard(arg->ctx.tc_co_hdl, one ? &oid : NULL, &epr, NULL, NULL);
 		else
 			rc = vos_aggregate(arg->ctx.tc_co_hdl, &epr, NULL,
 					   NULL, NULL, false);
@@ -1230,7 +1230,7 @@ agg_punches_test_helper(void **state, int record_type, int type, bool discard,
 
 /** Do a punch aggregation test */
 static void
-agg_punches_test(void **state, int record_type, bool discard)
+agg_punches_test(void **state, bool one, int record_type, bool discard)
 {
 	int	first, last, type;
 	int	lstart;
@@ -1241,7 +1241,7 @@ agg_punches_test(void **state, int record_type, bool discard)
 		for (last = lstart; last <= AGG_UPDATE; last++) {
 			for (type = AGG_OBJ_TYPE; type <= AGG_AKEY_TYPE;
 			     type++) {
-				agg_punches_test_helper(state, record_type,
+				agg_punches_test_helper(state, one, record_type,
 							type, discard, first,
 							last);
 			}
@@ -1251,14 +1251,28 @@ agg_punches_test(void **state, int record_type, bool discard)
 static void
 discard_14(void **state)
 {
-	agg_punches_test(state, DAOS_IOD_SINGLE, true);
+	agg_punches_test(state, false, DAOS_IOD_SINGLE, true);
 	cleanup();
 }
 
 static void
 discard_15(void **state)
 {
-	agg_punches_test(state, DAOS_IOD_ARRAY, true);
+	agg_punches_test(state, false, DAOS_IOD_ARRAY, true);
+	cleanup();
+}
+
+static void
+discard_16(void **state)
+{
+	agg_punches_test(state, true, DAOS_IOD_ARRAY, true);
+	cleanup();
+}
+
+static void
+discard_17(void **state)
+{
+	agg_punches_test(state, true, DAOS_IOD_ARRAY, true);
 	cleanup();
 }
 
@@ -1895,14 +1909,14 @@ aggregate_14(void **state)
 static void
 aggregate_15(void **state)
 {
-	agg_punches_test(state, DAOS_IOD_SINGLE, false);
+	agg_punches_test(state, false, DAOS_IOD_SINGLE, false);
 	cleanup();
 }
 
 static void
 aggregate_16(void **state)
 {
-	agg_punches_test(state, DAOS_IOD_ARRAY, false);
+	agg_punches_test(state, false, DAOS_IOD_ARRAY, false);
 	cleanup();
 }
 
@@ -2503,6 +2517,8 @@ agg_tst_teardown(void **state)
 }
 
 static const struct CMUnitTest discard_tests[] = {
+	{ "VOS458: Discard EV with confined epr",
+	  discard_8, NULL, agg_tst_teardown },
 	{ "VOS451: Discard SV with specified epoch",
 	  discard_1, NULL, agg_tst_teardown },
 	{ "VOS452: Discard SV with confined epr",
@@ -2517,8 +2533,6 @@ static const struct CMUnitTest discard_tests[] = {
 	  discard_6, NULL, agg_tst_teardown },
 	{ "VOS457: Discard EV with specified epoch",
 	  discard_7, NULL, agg_tst_teardown },
-	{ "VOS458: Discard EV with confined epr",
-	  discard_8, NULL, agg_tst_teardown },
 	{ "VOS459: Discard EV with epr [0, DAOS_EPOCH_MAX]",
 	  discard_9, NULL, agg_tst_teardown },
 	{ "VOS460: Discard EV with punch records",
@@ -2533,6 +2547,10 @@ static const struct CMUnitTest discard_tests[] = {
 	  discard_14, NULL, agg_tst_teardown },
 	{ "VOS465: Discard object/key punches array",
 	  discard_15, NULL, agg_tst_teardown },
+	{ "VOS466: Discard single object sv",
+	  discard_16, NULL, agg_tst_teardown },
+	{ "VOS467: Discard single object array",
+	  discard_17, NULL, agg_tst_teardown },
 };
 
 static const struct CMUnitTest aggregate_tests[] = {

--- a/src/vos/vos_aggregate.c
+++ b/src/vos/vos_aggregate.c
@@ -142,6 +142,10 @@ struct vos_agg_param {
 	uint32_t		ap_credits;	/* # of tight loops */
 	daos_handle_t		ap_coh;		/* container handle */
 	daos_unit_oid_t		ap_oid;		/* current object ID */
+	struct ilog_time_rec	ap_dkey_min;	/* min update to dkey */
+	struct ilog_time_rec	ap_akey_min;	/* min update to dkey */
+	struct ilog_time_rec	ap_value_min;	/* min update to dkey */
+	daos_epoch_t		ap_discard_hi;	/* Actual high epoch */
 	daos_key_t		ap_dkey;	/* current dkey */
 	daos_key_t		ap_akey;	/* current akey */
 	unsigned int		ap_discard:1,
@@ -158,6 +162,34 @@ struct vos_agg_param {
 	bool			 ap_skip_dkey;
 	bool			 ap_skip_obj;
 };
+
+static inline void
+set_update_min_epc(struct ilog_time_rec *trec, daos_epoch_t epoch, uint16_t minor_epc)
+{
+	if (trec->tr_epc == 0) {
+		trec->tr_epc = epoch;
+		trec->tr_minor_epc = minor_epc;
+		return;
+	}
+
+	if (trec->tr_epc < epoch)
+		return;
+
+	if (trec->tr_epc > epoch) {
+		trec->tr_epc = epoch;
+		trec->tr_minor_epc = minor_epc;
+		return;
+	}
+
+	if (trec->tr_minor_epc > minor_epc)
+		trec->tr_minor_epc = minor_epc;
+}
+
+static inline void
+set_update_min(const vos_iter_entry_t *entry, struct ilog_time_rec *trec)
+{
+	set_update_min_epc(trec, entry->ie_epoch, entry->ie_minor_epc);
+}
 
 static inline void
 mark_yield(bio_addr_t *addr, unsigned int *acts)
@@ -213,13 +245,22 @@ reset_agg_pos(vos_iter_type_t type, struct vos_agg_param *agg_param)
 {
 	switch (type) {
 	case VOS_ITER_OBJ:
+		D_DEBUG(DB_TRACE, "Reset object\n");
 		memset(&agg_param->ap_oid, 0, sizeof(agg_param->ap_oid));
+		agg_param->ap_dkey_min.tr_epc = 0;
+		agg_param->ap_dkey_min.tr_minor_epc = 0;
 		break;
 	case VOS_ITER_DKEY:
+		D_DEBUG(DB_TRACE, "Reset dkey\n");
 		memset(&agg_param->ap_dkey, 0, sizeof(agg_param->ap_dkey));
+		agg_param->ap_akey_min.tr_epc = 0;
+		agg_param->ap_akey_min.tr_minor_epc = 0;
 		break;
 	case VOS_ITER_AKEY:
+		D_DEBUG(DB_TRACE, "Reset akey\n");
 		memset(&agg_param->ap_akey, 0, sizeof(agg_param->ap_akey));
+		agg_param->ap_value_min.tr_epc = 0;
+		agg_param->ap_value_min.tr_minor_epc = 0;
 		break;
 	default:
 		break;
@@ -427,8 +468,18 @@ vos_agg_sv(daos_handle_t ih, vos_iter_entry_t *entry,
 	D_ASSERT(entry->ie_epoch != 0);
 
 	/* Discard */
-	if (agg_param->ap_discard)
+	if (agg_param->ap_discard) {
+		D_DEBUG(DB_TRACE, "Checking discarded entry "DF_X64" against "DF_X64"\n",
+			entry->ie_epoch, agg_param->ap_discard_hi);
+		if (entry->ie_epoch > agg_param->ap_discard_hi) {
+			/** Entry is outside of discard range */
+			set_update_min(entry, &agg_param->ap_dkey_min);
+			set_update_min(entry, &agg_param->ap_akey_min);
+			set_update_min(entry, &agg_param->ap_value_min);
+			return 0;
+		}
 		goto delete;
+	}
 
 	/* If entry is covered, the key or object is punched */
 	if (entry->ie_vis_flags & VOS_VIS_FLAG_COVERED)
@@ -2008,19 +2059,20 @@ vos_agg_ev(daos_handle_t ih, vos_iter_entry_t *entry,
 
 	/* Discard */
 	if (agg_param->ap_discard) {
-		struct vos_obj_iter	*oiter = vos_hdl2oiter(ih);
+		if (entry->ie_epoch > agg_param->ap_discard_hi) {
+			/** Entry is outside of discard range */
+			set_update_min(entry, &agg_param->ap_dkey_min);
+			set_update_min(entry, &agg_param->ap_akey_min);
+			set_update_min(entry, &agg_param->ap_value_min);
+			return 0;
+		}
 
-		/*
-		 * Delete the physical entry when iterating to the first
-		 * logical entry
-		 */
-		if (phy_ext.ex_lo == lgc_ext.ex_lo)
-			rc = delete_evt_entry(oiter, entry, acts, "discarded");
+		D_DEBUG(DB_TRACE, DF_EXT"@"DF_X64".%d is being discarded\n", DP_EXT(&lgc_ext),
+			entry->ie_epoch, entry->ie_minor_epc);
+		/** Discard iterates unsorted entries.   It may visit entries more than once */
+		D_ASSERT(phy_ext.ex_lo == lgc_ext.ex_lo);
+		rc = vos_iter_delete(ih, NULL);
 
-		/*
-		 * Sorted iteration doesn't support tree empty check, so we
-		 * always inform vos_iterate() to check if subtree is empty.
-		 */
 		if (entry->ie_vis_flags & VOS_VIS_FLAG_LAST) {
 			/* Trigger re-probe in akey iteration */
 			*acts |= VOS_ITER_CB_YIELD;
@@ -2172,6 +2224,7 @@ vos_aggregate_post_cb(daos_handle_t ih, vos_iter_entry_t *entry,
 {
 	struct vos_agg_param	*agg_param = cb_arg;
 	struct vos_container	*cont;
+	struct ilog_time_rec	*min = &agg_param->ap_value_min;
 	int			 rc = 0;
 
 	cont = vos_hdl2cont(param->ip_hdl);
@@ -2185,19 +2238,20 @@ vos_aggregate_post_cb(daos_handle_t ih, vos_iter_entry_t *entry,
 			agg_param->ap_skip_obj = false;
 			break;
 		}
-		rc = oi_iter_aggregate(ih, agg_param->ap_discard);
+		rc = oi_iter_aggregate(ih, agg_param->ap_discard_hi, &agg_param->ap_dkey_min);
 		break;
 	case VOS_ITER_DKEY:
 		if (agg_param->ap_skip_dkey) {
 			agg_param->ap_skip_dkey = false;
 			break;
 		}
+		min = &agg_param->ap_akey_min;
 	case VOS_ITER_AKEY:
 		if (agg_param->ap_skip_akey) {
 			agg_param->ap_skip_akey = false;
 			break;
 		}
-		rc = vos_obj_iter_aggregate(ih, agg_param->ap_discard);
+		rc = vos_obj_iter_aggregate(ih, agg_param->ap_discard_hi, min);
 		break;
 	case VOS_ITER_SINGLE:
 		return 0;
@@ -2406,12 +2460,45 @@ free_agg_data:
 	return rc;
 }
 
+static int
+vos_obj_discard(daos_handle_t coh, const daos_unit_oid_t *oid, daos_epoch_range_t *epr,
+		struct vos_agg_param *ap, const struct ilog_time_rec *update)
+{
+	struct vos_object	*obj;
+	struct vos_obj_df	*obj_df;
+	bool			 delete = false;
+	int			 rc;
+
+	rc = vos_obj_hold(vos_obj_cache_current(), vos_hdl2cont(coh), *oid, epr,
+			  epr->epr_hi, 0, DAOS_INTENT_PURGE, &obj, NULL);
+	if (rc != 0)
+		return rc;
+
+	D_DEBUG(DB_TRACE, "discard object, update="DF_TREC"\n", DP_TREC(update));
+	obj_df = obj->obj_df;
+	rc = vos_ilog_aggregate(coh, &obj_df->vo_ilog, epr, true, NULL, &obj->obj_ilog_info,
+				update);
+	if (rc == 1) {
+		/** The log is empty, object can be removed */
+		D_ASSERT(dbtree_is_empty_inplace(&obj_df->vo_tree));
+		delete = true;
+		rc = 0;
+	}
+	vos_obj_release(vos_obj_cache_current(), obj, rc != 0);
+
+	if (delete)
+		rc = vos_obj_delete_internal(coh, *oid, false);
+
+	return rc;
+}
+
 int
-vos_discard(daos_handle_t coh, daos_epoch_range_t *epr,
+vos_discard(daos_handle_t coh, const daos_unit_oid_t *oid, daos_epoch_range_t *epr,
 	    bool (*yield_func)(void *arg), void *yield_arg)
 {
 	struct vos_container	*cont = vos_hdl2cont(coh);
 	struct agg_data		*ad;
+	int			 type = VOS_ITER_OBJ;
 	int			 rc;
 
 	D_ASSERT(epr != NULL);
@@ -2427,20 +2514,22 @@ vos_discard(daos_handle_t coh, daos_epoch_range_t *epr,
 	if (rc != 0)
 		goto free_agg_data;
 
-	D_DEBUG(DB_EPC, "Discard epr "DF_U64"-"DF_U64"\n",
-		epr->epr_lo, epr->epr_hi);
+	if (oid != NULL) {
+		D_DEBUG(DB_EPC, "Discard "DF_UOID" epr "DF_X64"-"DF_X64"\n", DP_UOID(*oid),
+			epr->epr_lo, epr->epr_hi);
+	} else {
+		D_DEBUG(DB_EPC, "Discard epr "DF_X64"-"DF_X64"\n", epr->epr_lo, epr->epr_hi);
 
+	}
+retry:
 	/* Set iteration parameters */
 	ad->ad_iter_param.ip_hdl = coh;
-	ad->ad_iter_param.ip_epr = *epr;
-	if (epr->epr_lo == epr->epr_hi)
-		ad->ad_iter_param.ip_epc_expr = VOS_IT_EPC_EQ;
-	else if (epr->epr_hi != DAOS_EPOCH_MAX)
-		ad->ad_iter_param.ip_epc_expr = VOS_IT_EPC_RR;
-	else
-		ad->ad_iter_param.ip_epc_expr = VOS_IT_EPC_GE;
+	/** Return every single value above epr_lo */
+	ad->ad_iter_param.ip_epr.epr_lo = epr->epr_lo;
+	ad->ad_iter_param.ip_epr.epr_hi = DAOS_EPOCH_MAX;
+	ad->ad_iter_param.ip_epc_expr = VOS_IT_EPC_GE;
 	/* EV tree iterator returns all sorted logical rectangles */
-	ad->ad_iter_param.ip_flags = VOS_IT_PUNCHED | VOS_IT_RECX_COVERED;
+	ad->ad_iter_param.ip_flags = VOS_IT_PUNCHED | VOS_IT_FOR_PURGE;
 
 	/* Set aggregation parameters */
 	ad->ad_agg_param.ap_umm = &cont->vc_pool->vp_umm;
@@ -2448,14 +2537,29 @@ vos_discard(daos_handle_t coh, daos_epoch_range_t *epr,
 	ad->ad_agg_param.ap_credits_max = VOS_AGG_CREDITS_MAX;
 	ad->ad_agg_param.ap_credits = 0;
 	ad->ad_agg_param.ap_discard = true;
+	ad->ad_agg_param.ap_discard_hi = epr->epr_hi;
 	ad->ad_agg_param.ap_yield_func = yield_func;
 	ad->ad_agg_param.ap_yield_arg = yield_arg;
 
-	ad->ad_iter_param.ip_flags |= VOS_IT_FOR_PURGE;
-	rc = vos_iterate(&ad->ad_iter_param, VOS_ITER_OBJ, true, &ad->ad_anchors,
+	if (oid != NULL) {
+		type = VOS_ITER_DKEY;
+		ad->ad_iter_param.ip_oid = *oid;
+	}
+
+	rc = vos_iterate(&ad->ad_iter_param, type, true, &ad->ad_anchors,
 			 vos_aggregate_pre_cb, vos_aggregate_post_cb,
 			 &ad->ad_agg_param, NULL);
 
+	if (oid != NULL) {
+		if (rc == -DER_INPROGRESS) {
+			/** Yield so progress can be made, then try again */
+			memset(ad, 0, sizeof(*ad));
+			bio_yield();
+			goto retry;
+		}
+		rc = vos_obj_discard(coh, oid, epr, &ad->ad_agg_param,
+				     &ad->ad_agg_param.ap_dkey_min);
+	}
 	aggregate_exit(cont, true);
 
 free_agg_data:

--- a/src/vos/vos_io.c
+++ b/src/vos/vos_io.c
@@ -976,9 +976,9 @@ akey_fetch_recx(daos_handle_t toh, const daos_epoch_range_t *epr,
 	filter.fr_epoch = epr->epr_hi;
 	filter.fr_epr.epr_lo = epr->epr_lo;
 	filter.fr_epr.epr_hi = ioc->ic_bound;
-	filter.fr_punch_epc = ioc->ic_akey_info.ii_prior_punch.pr_epc;
+	filter.fr_punch_epc = ioc->ic_akey_info.ii_prior_punch.tr_epc;
 	filter.fr_punch_minor_epc =
-		ioc->ic_akey_info.ii_prior_punch.pr_minor_epc;
+		ioc->ic_akey_info.ii_prior_punch.tr_minor_epc;
 
 	evt_ent_array_init(ioc->ic_ent_array, 0);
 	rc = evt_find(toh, &filter, ioc->ic_ent_array);
@@ -1126,8 +1126,8 @@ key_ilog_check(struct vos_io_context *ioc, struct vos_krec_df *krec,
 	rc = vos_ilog_check(info, &epr, epr_out, true);
 out:
 	D_DEBUG(DB_TRACE, "ilog check returned "DF_RC" epr_in="DF_X64"-"DF_X64
-		" punch="DF_PUNCH" epr_out="DF_X64"-"DF_X64"\n", DP_RC(rc),
-		epr.epr_lo, epr.epr_hi, DP_PUNCH(&info->ii_prior_punch),
+		" punch="DF_TREC" epr_out="DF_X64"-"DF_X64"\n", DP_RC(rc),
+		epr.epr_lo, epr.epr_hi, DP_TREC(&info->ii_prior_punch),
 		epr_out ? epr_out->epr_lo : 0,
 		epr_out ? epr_out->epr_hi : 0);
 	return rc;
@@ -2378,8 +2378,9 @@ vos_update_begin(daos_handle_t coh, daos_unit_oid_t oid, daos_epoch_t epoch,
 		return -DER_IO;
 
 	D_DEBUG(DB_TRACE, "Prepare IOC for "DF_UOID", iod_nr %d, epc "DF_X64
-		", flags="DF_X64"\n", DP_UOID(oid), iod_nr,
-		dtx_is_valid_handle(dth) ? dth->dth_epoch :  epoch, flags);
+		", flags="DF_X64"%s\n", DP_UOID(oid), iod_nr,
+		dtx_is_valid_handle(dth) ? dth->dth_epoch :  epoch, flags,
+		dtx_is_valid_handle(dth) ? " in DTX" : "");
 
 	rc = vos_check_akeys(iod_nr, iods);
 	if (rc != 0) {

--- a/src/vos/vos_obj.h
+++ b/src/vos/vos_obj.h
@@ -203,9 +203,12 @@ vos_oi_punch(struct vos_container *cont, daos_unit_oid_t oid,
 	     struct vos_obj_df *obj, struct vos_ilog_info *info,
 	     struct vos_ts_set *ts_set);
 
+/** delete object */
+int
+vos_obj_delete_internal(daos_handle_t coh, daos_unit_oid_t oid, bool gc);
 
 /** delete an object from OI table */
 int
-vos_oi_delete(struct vos_container *cont, daos_unit_oid_t oid);
+vos_oi_delete(struct vos_container *cont, daos_unit_oid_t oid, bool gc);
 
 #endif

--- a/src/vos/vos_obj_index.c
+++ b/src/vos/vos_obj_index.c
@@ -314,7 +314,7 @@ vos_oi_punch(struct vos_container *cont, daos_unit_oid_t oid,
  * one incarnation for each object.
  */
 int
-vos_oi_delete(struct vos_container *cont, daos_unit_oid_t oid)
+vos_oi_delete(struct vos_container *cont, daos_unit_oid_t oid, bool gc)
 {
 	d_iov_t		key_iov;
 	int		rc = 0;
@@ -323,7 +323,7 @@ vos_oi_delete(struct vos_container *cont, daos_unit_oid_t oid)
 
 	d_iov_set(&key_iov, &oid, sizeof(oid));
 
-	rc = dbtree_delete(cont->vc_btr_hdl, BTR_PROBE_EQ, &key_iov, cont);
+	rc = dbtree_delete(cont->vc_btr_hdl, BTR_PROBE_EQ, &key_iov, gc ? cont : NULL);
 	if (rc == -DER_NONEXIST)
 		return 0;
 
@@ -647,10 +647,11 @@ exit:
 }
 
 int
-oi_iter_aggregate(daos_handle_t ih, bool discard)
+oi_iter_aggregate(daos_handle_t ih, daos_epoch_t discard, const struct ilog_time_rec *update)
 {
 	struct vos_iterator	*iter = vos_hdl2iter(ih);
 	struct vos_oi_iter	*oiter = iter2oiter(iter);
+	daos_epoch_range_t	 epr;
 	struct vos_obj_df	*obj;
 	daos_unit_oid_t		 oid;
 	d_iov_t			 rec_iov;
@@ -669,13 +670,15 @@ oi_iter_aggregate(daos_handle_t ih, bool discard)
 	obj = (struct vos_obj_df *)rec_iov.iov_buf;
 	oid = obj->vo_id;
 
+	epr.epr_lo = oiter->oit_epr.epr_lo;
+	epr.epr_hi = discard == 0 ? oiter->oit_epr.epr_hi : discard;
+
 	rc = umem_tx_begin(vos_cont2umm(oiter->oit_cont), NULL);
 	if (rc != 0)
 		goto exit;
 
 	rc = vos_ilog_aggregate(vos_cont2hdl(oiter->oit_cont), &obj->vo_ilog,
-				&oiter->oit_epr, discard, NULL,
-				&oiter->oit_ilog_info);
+				&epr, discard != 0, NULL, &oiter->oit_ilog_info, update);
 	if (rc == 1) {
 		/* Incarnation log is empty, delete the object */
 		D_DEBUG(DB_IO, "Removing object "DF_UOID" from tree\n",

--- a/src/vos/vos_query.c
+++ b/src/vos/vos_query.c
@@ -24,7 +24,7 @@ struct open_query {
 	struct vos_ts_set	*qt_ts_set;
 	daos_epoch_t		 qt_bound;
 	daos_epoch_range_t	 qt_epr;
-	struct vos_punch_record	 qt_punch;
+	struct ilog_time_rec	 qt_punch;
 	struct vos_ilog_info	 qt_info;
 	struct btr_root		*qt_dkey_root;
 	daos_handle_t		 qt_dkey_toh;
@@ -78,7 +78,7 @@ find_key(struct open_query *query, daos_handle_t toh, daos_key_t *key,
 	d_iov_t			 riov;
 	struct dcs_csum_info	 csum;
 	daos_epoch_range_t	 epr = query->qt_epr;
-	struct vos_punch_record	 punch = query->qt_punch;
+	struct ilog_time_rec	 punch = query->qt_punch;
 	int			 rc = 0;
 	int			 fini_rc;
 	int			 opc;
@@ -176,8 +176,8 @@ _query_recx(struct open_query *query, daos_recx_t *recx, struct evt_extent *filt
 		opc |= EVT_ITER_REVERSE;
 
 	filter.fr_ex = *filter_extent;
-	filter.fr_punch_epc = query->qt_punch.pr_epc;
-	filter.fr_punch_minor_epc = query->qt_punch.pr_minor_epc;
+	filter.fr_punch_epc = query->qt_punch.tr_epc;
+	filter.fr_punch_minor_epc = query->qt_punch.tr_minor_epc;
 	filter.fr_epr.epr_hi = query->qt_bound;
 	filter.fr_epr.epr_lo = query->qt_epr.epr_lo;
 	filter.fr_epoch = query->qt_epr.epr_hi;
@@ -453,7 +453,7 @@ vos_obj_query_key(daos_handle_t coh, daos_unit_oid_t oid, uint32_t flags,
 	struct open_query	*query;
 	daos_epoch_t		 bound;
 	daos_epoch_range_t	 dkey_epr;
-	struct vos_punch_record	 dkey_punch;
+	struct ilog_time_rec	 dkey_punch;
 	daos_ofeat_t		 obj_feats;
 	daos_epoch_range_t	 obj_epr = {0};
 	struct vos_ts_set	 akey_save = {0};


### PR DESCRIPTION
* Use unsorted iterator for discard
* Modify evt_iter_probe so it always resets probe to start
  since probe is unreliable for seeing everything.
* Track high discard epoch and force updates to add ilog
  entries above that.
* Modify purge so it sees all ilog entries
* Trace all updates on discard to track lowest update after
  discard epoch

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>