### PR TITLE
DAOS-8352 smd: Fix storage device list without NVME

### DIFF
--- a/src/bio/smd/smd_device.c
+++ b/src/bio/smd/smd_device.c
@@ -249,6 +249,10 @@ smd_dev_list(d_list_t *dev_list, int *devs)
 	struct smd_trav_data td;
 	int		     rc;
 
+	/* There is no NVMe, smd will not be initialized */
+	if (!smd_db_ready())
+		return 0;
+
 	td.td_count = 0;
 	D_INIT_LIST_HEAD(&td.td_list);
 


### PR DESCRIPTION
If there is no NVMe storage, the storage query
seg faults trying to list smd devices. fix to check
before calling smd_db_lock() to avoiding segfault.

Signed-off-by: Wang Shilong <shilong.wang@intel.com>