### PR TITLE
DAOS-7970 test: Fixed Coverity issues in test and compress_timing

### DIFF
--- a/src/common/tests/compress_timing.c
+++ b/src/common/tests/compress_timing.c
@@ -327,6 +327,7 @@ run_timings(struct compress_ft *fts[],
 	size_t	nsec;
 	int	rc;
 	FILE	*fp;
+	long int lifile_size;
 	size_t	file_sz, total_sz;
 	int	offset;
 	float	mbs, compr_ratio;
@@ -343,7 +344,9 @@ run_timings(struct compress_ft *fts[],
 		return -1;
 	}
 	fseek(fp, 0L, SEEK_END);
-	file_sz = ftell(fp);
+	lifile_size = ftell(fp);
+	D_ASSERT(lifile_size >= 0);
+	file_sz = lifile_size;
 	fseek(fp, 0L, SEEK_SET);
 
 	D_ALLOC(f_buf, file_sz);
@@ -465,6 +468,7 @@ run_timings(struct compress_ft *fts[],
 					 * Compress ratio - less is better
 					 *  = (compressed size / origin size)
 					 */
+					D_ASSERT(total_sz != 0);
 					compr_ratio = (float)rc / total_sz;
 					printf("\t%s:      \t%s\t%s\t"
 						"%.1f MB/s\t%.2f%%\n",

--- a/src/tests/suite/daos_aggregate_ec.c
+++ b/src/tests/suite/daos_aggregate_ec.c
@@ -368,7 +368,7 @@ verify_1p(struct ec_agg_test_ctx *ctx, daos_oclass_id_t ec_agg_oc,
 	for (j = 0; j < NUM_KEYS; j++)
 		for (i = 0; i < NUM_STRIPES; i++) {
 			ec_setup_single_recx_data(ctx, EC_SPECIFIED,
-						  i * (k * len), k * len, j,
+						  i * ((daos_size_t)k * len), k * len, j,
 						  false, false, 0);
 			ctx->fetch_iom.iom_flags = DAOS_IOMF_DETAIL;
 			rc = dc_obj_fetch_task_create(ctx->oh, DAOS_TX_NONE, 0,
@@ -648,7 +648,7 @@ test_range_punch(struct ec_agg_test_ctx *ctx)
 	for (j = 0; j < NUM_KEYS; j++)
 		for (i = 0; i < NUM_STRIPES; i++) {
 			ec_setup_punch_recx_data(ctx, EC_SPECIFIED,
-						 i * len * k, len, j, 0);
+						 i * len * (daos_size_t)k, len, j, 0);
 			rc = daos_obj_update(ctx->oh, DAOS_TX_NONE, 0,
 					     &ctx->dkey, 1, &ctx->update_iod,
 					     &ctx->update_sgl, NULL);
@@ -690,7 +690,7 @@ verify_rp1p(struct ec_agg_test_ctx *ctx, daos_oclass_id_t ec_agg_oc,
 	for (j = 0; j < NUM_KEYS; j++)
 		for (i = 0; i < NUM_STRIPES; i++) {
 			ec_setup_single_recx_data(ctx, EC_SPECIFIED,
-						  i * len * k + len,
+						  i * len * (daos_size_t)k + len,
 						  len,
 						  j, true, false, 0);
 			memset(&ctx->fetch_iom, 0, sizeof(daos_iom_t));


### PR DESCRIPTION
This PR addresses Coverity issues pertaining to integer overflow, potential divide by zero and a
negative return assigned to unsigned int.

Issues: 316292, 331104, 331105
```
Unintentional integer overflow (OVERFLOW_BEFORE_WIDEN)
overflow_before_widen: Potentially overflowing expression k * len with type unsigned int (32 bits, unsigned) is evaluated using 32-bit arithmetic, and then used in a context that expects an expression of type daos_size_t (64 bits, unsigned).
```

Issue: 329169
```
Division or modulo by float zero (DIVIDE_BY_ZERO)
80. divide_by_zero: In expression (float)rc / total_sz, division by expression total_sz which may be zero has undefined behavior.
```

Issue: 329170
```
Improper use of negative value (NEGATIVE_RETURNS)
4. negative_returns: file_sz is passed to a parameter that cannot be negative.
```

Signed-off-by: Christopher Hoffman <christopherx.hoffman@intel.com>