### PR TITLE
DAOS-8321 test: Fix dmg pool query test

### DIFF
--- a/src/tests/ftest/control/dmg_pool_query_test.py
+++ b/src/tests/ftest/control/dmg_pool_query_test.py
@@ -76,10 +76,12 @@ class DmgPoolQueryTest(ControlTestBase, IorTestBase):
             "leader": self.params.get("leader", path="/run/exp_vals/*"),
             "tier_stats": [
                 {
+                    "media_type": "scm",
                     "total": self.params.get(
                         "total", path="/run/exp_vals/scm/*")
                 },
                 {
+                    "media_type": "nvme",
                     "total": self.params.get(
                         "total", path="/run/exp_vals/nvme/*")
                 }


### PR DESCRIPTION
Added the "media_type" field to the test expectations.

Feature: pool_query

Signed-off-by: Kris Jacque <kristin.jacque@intel.com>