### PR TITLE
DAOS-8313 control: Minimize scope of cleanup on pool create

### DIFF
--- a/src/control/lib/control/pool.go
+++ b/src/control/lib/control/pool.go
@@ -186,7 +186,7 @@ func (r *poolRequest) canRetry(reqErr error, try uint) bool {
 		switch e {
 		// These pool errors can be retried.
 		case drpc.DaosTimedOut, drpc.DaosGroupVersionMismatch,
-			drpc.DaosTryAgain, drpc.DaosOutOfGroup:
+			drpc.DaosTryAgain, drpc.DaosOutOfGroup, drpc.DaosUnreachable:
 			return true
 		default:
 			return false

--- a/src/control/server/mgmt_pool.go
+++ b/src/control/server/mgmt_pool.go
@@ -232,7 +232,7 @@ func (svc *mgmtSvc) PoolCreate(ctx context.Context, req *mgmtpb.PoolCreateReq) (
 		resp.Status = int32(drpc.DaosAlready)
 		if ps.State == system.PoolServiceStateCreating {
 			resp.Status = int32(drpc.DaosTryAgain)
-			return resp, svc.checkPools(ctx)
+			return resp, svc.checkPools(ctx, ps)
 		}
 		return resp, nil
 	}
@@ -434,17 +434,17 @@ func (svc *mgmtSvc) PoolCreate(ctx context.Context, req *mgmtpb.PoolCreateReq) (
 // checkPools iterates over the list of pools in the system to check
 // for any that are in an unexpected state. Pools not in the Ready
 // state will be cleaned up and removed from the system.
-//
-// NB: Care should be taken to avoid calling this when it could race
-// with a PoolCreate request.
-func (svc *mgmtSvc) checkPools(ctx context.Context) error {
+func (svc *mgmtSvc) checkPools(ctx context.Context, psList ...*system.PoolService) error {
 	if err := svc.sysdb.CheckLeader(); err != nil {
 		return err
 	}
 
-	psList, err := svc.sysdb.PoolServiceList(true)
-	if err != nil {
-		return err
+	var err error
+	if len(psList) == 0 {
+		psList, err = svc.sysdb.PoolServiceList(true)
+		if err != nil {
+			return errors.Wrap(err, "failed to fetch pool service list")
+		}
 	}
 
 	svc.log.Debugf("checking %d pools", len(psList))

--- a/src/control/system/raft.go
+++ b/src/control/system/raft.go
@@ -292,6 +292,7 @@ func (db *Database) submitPoolUpdate(op raftOp, ps *PoolService) error {
 	if err != nil {
 		return err
 	}
+	db.log.Debugf("pool %s updated @ %s", ps.PoolUUID, ps.LastUpdate)
 	return db.submitRaftUpdate(data)
 }
 

--- a/src/tests/ftest/util/dmg_utils.py
+++ b/src/tests/ftest/util/dmg_utils.py
@@ -9,20 +9,11 @@
 from grp import getgrgid
 from pwd import getpwuid
 import re
-import time
 
 from command_utils_base import CommandFailure
 from dmg_utils_base import DmgCommandBase
 from general_utils import get_numeric_list
 from dmg_utils_params import DmgYamlParameters, DmgTransportCredentials
-
-RETRYABLE_POOL_CREATE_ERRORS = [
-    -1006,  # -DER_UNREACH: Can happen after ranks are killed but before
-            #               SWIM has noticed and excluded them.
-    -1019,  # -DER_OOG: Can happen after restart.
-]
-POOL_RETRY_INTERVAL = 1     # seconds
-
 
 class DmgJsonCommandFailure(CommandFailure):
     """Exception raised when a dmg --json command fails."""
@@ -455,17 +446,6 @@ class DmgCommand(DmgCommandBase):
                                        json_err=True, **kwargs)
         if output["error"] is not None:
             self.log.error(output["error"])
-            if output["status"] in RETRYABLE_POOL_CREATE_ERRORS:
-                time.sleep(POOL_RETRY_INTERVAL)
-                return self.pool_create(scm_size, uid=uid, gid=gid,
-                                        nvme_size=nvme_size,
-                                        target_list=target_list,
-                                        svcn=svcn,
-                                        acl_file=acl_file,
-                                        size=size,
-                                        tier_ratio=tier_ratio,
-                                        properties=properties,
-                                        label=label)
             if self.exit_status_exception:
                 raise DmgJsonCommandFailure(output["error"])
 


### PR DESCRIPTION
When a pool is found to already be in the Creating state
on a retried create, trigger the cleanup code for that single
pool.

Also adds -DER_UNREACH to the set of retryable pool errors,
as testing shows that these can still be encountered after
a server has been killed but hasn't been excluded yet.
Removes some redundant retry code from the test harness.