### PR TITLE
DAOS-8350 test: Fix getting pool list from JSON

### DIFF
--- a/src/tests/ftest/server/daos_server_restart.py
+++ b/src/tests/ftest/server/daos_server_restart.py
@@ -52,7 +52,7 @@ class DaosServerTest(TestWithServers):
 
     def get_pool_list(self):
         """Get the pool list contents."""
-        pool_list = sorted(self.get_dmg_command().pool_list())
+        pool_list = sorted(self.get_dmg_command().pool_list()["response"]["pools"])
         self.log.info("get_pool-list: %s", pool_list)
         return pool_list
 


### PR DESCRIPTION
The test wasn't comparing against the actual pool list in the
response.

Feature: server_restart,server_reformat

Signed-off-by: Kris Jacque <kristin.jacque@intel.com>