### PR TITLE
DAOS-8325 prop: check that name and vals from prop string are not NULL

### DIFF
--- a/src/common/prop.c
+++ b/src/common/prop.c
@@ -875,13 +875,17 @@ parse_entry(char *str, struct daos_prop_entry *entry)
 {
 	char	*name;
 	char	*val;
-	char	*end_token;
+	char	*end_token = NULL;
 	int	rc = 0;
 
 	/** get prop_name */
 	name = strtok_r(str, ":", &end_token);
+	if (name == NULL)
+		return -DER_INVAL;
 	/** get prop value */
 	val = strtok_r(NULL, ";", &end_token);
+	if (val == NULL)
+		return -DER_INVAL;
 
 	if (strcmp(name, DAOS_PROP_ENTRY_LABEL) == 0) {
 		entry->dpe_type = DAOS_PROP_CO_LABEL;

--- a/src/common/tests/prop_tests.c
+++ b/src/common/tests/prop_tests.c
@@ -274,7 +274,10 @@ test_daos_prop_from_str(void **state)
 	char		*LAYOUT		= "layout_type:posix";
 
 	/** Invalid prop entries */
-	char		*PROP_INV	= "hello:world";
+	char		*PROP_INV1	= "hello:world";
+	char		*PROP_INV2	= "helloworld";
+	char		*PROP_INV3	= ":helloworld";
+	char		*PROP_INV4	= "helloworld:";
 
 	char			buf[1024] = {0};
 	daos_prop_t		*prop;
@@ -297,7 +300,16 @@ test_daos_prop_from_str(void **state)
 	assert_int_equal(rc, -DER_INVAL);
 
 	/** Buffer containing invalid entries should fail */
-	sprintf(buf, "%s;%s;%s", CSUM, LABEL, PROP_INV);
+	sprintf(buf, "%s;%s;%s", CSUM, LABEL, PROP_INV1);
+	rc = daos_prop_from_str(buf, sizeof(buf), &prop);
+	assert_int_equal(rc, -DER_INVAL);
+	sprintf(buf, "%s;%s;%s", CSUM, LABEL, PROP_INV2);
+	rc = daos_prop_from_str(buf, sizeof(buf), &prop);
+	assert_int_equal(rc, -DER_INVAL);
+	sprintf(buf, "%s;%s;%s", CSUM, LABEL, PROP_INV3);
+	rc = daos_prop_from_str(buf, sizeof(buf), &prop);
+	assert_int_equal(rc, -DER_INVAL);
+	sprintf(buf, "%s;%s;%s", CSUM, LABEL, PROP_INV4);
 	rc = daos_prop_from_str(buf, sizeof(buf), &prop);
 	assert_int_equal(rc, -DER_INVAL);
 


### PR DESCRIPTION
- fixes a coverity warning
- add a test

Skip-nlt: true
Skip-func-test: true
Skip-func-hw-test: true
Signed-off-by: Mohamad Chaarawi <mohamad.chaarawi@intel.com>