### PR TITLE
DAOS-7479 container: query optionally retreive snapshots

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -34,7 +34,7 @@ def get_version():
         return version_file.read().rstrip()
 
 API_VERSION_MAJOR = "1"
-API_VERSION_MINOR = "4"
+API_VERSION_MINOR = "5"
 API_VERSION_FIX = "0"
 API_VERSION = "{}.{}.{}".format(API_VERSION_MAJOR, API_VERSION_MINOR,
                                 API_VERSION_FIX)

--- a/src/container/rpc.h
+++ b/src/container/rpc.h
@@ -24,7 +24,7 @@
  * These are for daos_rpc::dr_opc and DAOS_RPC_OPCODE(opc, ...) rather than
  * crt_req_create(..., opc, ...). See src/include/daos/rpc.h.
  */
-#define DAOS_CONT_VERSION 4
+#define DAOS_CONT_VERSION 5
 /* LIST of internal RPCS in form of:
  * OPCODE, flags, FMT, handler, corpc_hdlr,
  */
@@ -171,6 +171,7 @@ CRT_RPC_DECLARE(cont_destroy, DAOS_ISEQ_CONT_DESTROY, DAOS_OSEQ_CONT_DESTROY)
 CRT_RPC_DECLARE(cont_destroy_bylabel, DAOS_ISEQ_CONT_DESTROY_BYLABEL,
 		DAOS_OSEQ_CONT_DESTROY)
 
+/* TODO: snapshots bulk handle (input) and count (output)*/
 #define DAOS_ISEQ_CONT_OPEN	/* input fields */		 \
 	((struct cont_op_in)	(coi_op)		CRT_VAR) \
 	((uint64_t)		(coi_flags)		CRT_VAR) \
@@ -241,13 +242,18 @@ CRT_RPC_DECLARE(cont_close, DAOS_ISEQ_CONT_CLOSE, DAOS_OSEQ_CONT_CLOSE)
 
 #define DAOS_ISEQ_CONT_QUERY	/* input fields */		 \
 	((struct cont_op_in)	(cqi_op)		CRT_VAR) \
-	((uint64_t)		(cqi_bits)		CRT_VAR)
+	((uint64_t)		(cqi_bits)		CRT_VAR) \
+	((crt_bulk_t)		(cqi_bulk)		CRT_VAR)
+
+
 
 /** Add more items to query when needed */
 #define DAOS_OSEQ_CONT_QUERY	/* output fields */		 \
 	((struct cont_op_out)	(cqo_op)		CRT_VAR) \
 	((daos_epoch_t)		(cqo_hae)		CRT_VAR) \
-	((daos_prop_t)		(cqo_prop)		CRT_PTR)
+	((daos_prop_t)		(cqo_prop)		CRT_PTR) \
+	((uint32_t)		(cqo_snap_count)	CRT_VAR) \
+	((uint32_t)		(cqo_pad)		CRT_VAR)
 
 CRT_RPC_DECLARE(cont_query, DAOS_ISEQ_CONT_QUERY, DAOS_OSEQ_CONT_QUERY)
 

--- a/src/container/srv_internal.h
+++ b/src/container/srv_internal.h
@@ -221,11 +221,13 @@ int ds_cont_snap_list(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl,
 int ds_cont_snap_destroy(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl,
 			 struct cont *cont, struct container_hdl *hdl,
 			 crt_rpc_t *rpc);
-int
-ds_cont_get_snapshots(uuid_t pool_uuid, uuid_t cont_uuid,
-		      daos_epoch_t **snapshots, int *snap_count);
-void
-ds_cont_update_snap_iv(struct cont_svc *svc, uuid_t cont_uuid);
+int ds_cont_read_snap_list(struct rdb_tx *tx, struct cont *cont, daos_epoch_t **buf, int *count);
+int ds_cont_xfer_snap_list(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl, struct cont *cont,
+			   struct container_hdl *hdl, crt_rpc_t *rpc, crt_bulk_t *bulk,
+			   int *snap_countp);
+int ds_cont_get_snapshots(uuid_t pool_uuid, uuid_t cont_uuid, daos_epoch_t **snapshots,
+			  int *snap_count);
+void ds_cont_update_snap_iv(struct cont_svc *svc, uuid_t cont_uuid);
 
 /**
  * srv_target.c

--- a/src/include/daos_cont.h
+++ b/src/include/daos_cont.h
@@ -53,6 +53,8 @@ typedef struct {
 	daos_epoch_t	       *ci_snapshots;
 	/** The minimal "Highest aggregated epoch" among all targets */
 	daos_epoch_t		ci_hae;
+	/* snapshot names */
+	char		      **ci_snapshot_names;
 	/* TODO: add more members, e.g., size, # objects, uid, gid... */
 } daos_cont_info_t;
 


### PR DESCRIPTION
For daos_cont_query(), if daos_cont_info_t.ci_snapshots is not NULL
fetch and return to the caller the number of, and list of snapshot
epochs created for the container.

Container CaRT RPC version update from 4 to 5 to reflect the addition
of a bulk handle (input) and snapshot count (output) in CONT_QUERY.

API version update to v1.5.0 with addition of daos_cont_info_t struct
ci_snapshot_names member.

Go-based daos utility code changes to allocate ci_snapshots if invoked
with the --verbose command-line option. And to retry the CONT_QUERY
RPC in the event that the snapshots storage is insufficient to store
the full list of container snapshots.

daos_test snapshot test additions to exercise query for snapshots,
alongside the existing list_snaps API.

Future changes will be required
- container open API similarly allows retrieval of snapshots
- for query, open, and list_snapshot, retrieve snapshot names
- engine container metadata format (+ version update): snapshot names

Signed-off-by: Kenneth Cain <kenneth.c.cain@intel.com>