### PR TITLE
DAOS-8398 test: Fix permission for daos_engine to write coverage

### DIFF
--- a/src/tests/ftest/scripts/setup_nodes.sh
+++ b/src/tests/ftest/scripts/setup_nodes.sh
@@ -72,6 +72,7 @@ fi
 rm -f /tmp/test.cov
 if [ -f /usr/lib/daos/TESTING/ftest/test.cov ]; then
     cp /usr/lib/daos/TESTING/ftest/test.cov /tmp
+    chmod 777 /tmp/test.cov
 fi
 
 # make sure to set up for daos_agent. The test harness will take care of

--- a/src/tests/ftest/util/agent_utils.py
+++ b/src/tests/ftest/util/agent_utils.py
@@ -195,6 +195,7 @@ class DaosAgentManager(SubprocessManager):
             "D_LOG_MASK": "DEBUG,RPC=ERR",
             "DD_MASK": "mgmt,io,md,epc,rebuild",
             "D_LOG_FILE_APPEND_PID": "1"
+            "COVFILE": "/tmp/test.cov"
         }
         self.manager.assign_environment_default(EnvironmentVariables(env_vars))
         self.attachinfo = None

--- a/src/tests/ftest/util/agent_utils.py
+++ b/src/tests/ftest/util/agent_utils.py
@@ -194,7 +194,7 @@ class DaosAgentManager(SubprocessManager):
         env_vars = {
             "D_LOG_MASK": "DEBUG,RPC=ERR",
             "DD_MASK": "mgmt,io,md,epc,rebuild",
-            "D_LOG_FILE_APPEND_PID": "1"
+            "D_LOG_FILE_APPEND_PID": "1",
             "COVFILE": "/tmp/test.cov"
         }
         self.manager.assign_environment_default(EnvironmentVariables(env_vars))

--- a/src/tests/ftest/util/agent_utils.py
+++ b/src/tests/ftest/util/agent_utils.py
@@ -195,7 +195,7 @@ class DaosAgentManager(SubprocessManager):
             "D_LOG_MASK": "DEBUG,RPC=ERR",
             "DD_MASK": "mgmt,io,md,epc,rebuild",
             "D_LOG_FILE_APPEND_PID": "1",
-            "COVFILE": "/tmp/test.cov"
+            "COVFILE": "/tmp/test.cov",
         }
         self.manager.assign_environment_default(EnvironmentVariables(env_vars))
         self.attachinfo = None

--- a/src/tests/ftest/util/server_utils_params.py
+++ b/src/tests/ftest/util/server_utils_params.py
@@ -372,6 +372,7 @@ class DaosServerYamlParameters(YamlParameters):
                 "DAOS_MD_CAP=1024",
                 "DD_MASK=mgmt,io,md,epc,rebuild",
                 "D_LOG_FILE_APPEND_PID=1"
+                "COVFILE=/tmp/test.cov"
             ]
             if default_provider == "ofi+sockets":
                 default_env_vars.extend([

--- a/src/tests/ftest/util/server_utils_params.py
+++ b/src/tests/ftest/util/server_utils_params.py
@@ -371,7 +371,7 @@ class DaosServerYamlParameters(YamlParameters):
                 "ABT_MAX_NUM_XSTREAMS=100",
                 "DAOS_MD_CAP=1024",
                 "DD_MASK=mgmt,io,md,epc,rebuild",
-                "D_LOG_FILE_APPEND_PID=1"
+                "D_LOG_FILE_APPEND_PID=1",
                 "COVFILE=/tmp/test.cov"
             ]
             if default_provider == "ofi+sockets":


### PR DESCRIPTION
Fix permission for daos_engine to write to test.cov
Set COVFILE for daos agent and daos server