### PR TITLE
DAOS-8401 vos: Defer deletion of removal records

### DIFF
--- a/src/vos/tests/vts_aggregate.c
+++ b/src/vos/tests/vts_aggregate.c
@@ -2532,6 +2532,58 @@ aggregate_31(void **state)
 	cleanup();
 }
 
+static void
+aggregate_32(void **state)
+{
+	struct io_test_args	*arg = *state;
+	struct agg_tst_dataset	 ds = { 0 };
+	daos_recx_t		 recx_arr[11];
+	daos_epoch_t		 punch_epochs[] = {3, 4, 6, 7, 9, 10, 11};
+	int			 iod_size = 1024, end_idx;
+
+	end_idx = (VOS_MW_FLUSH_THRESH + iod_size - 1) / iod_size;
+	assert_true(end_idx > 5);
+
+	/* Insert a record */
+	recx_arr[0].rx_idx = 0;
+	recx_arr[0].rx_nr = end_idx * 2;
+	recx_arr[1].rx_idx = 0;
+	recx_arr[1].rx_nr = end_idx + 2;
+	recx_arr[2].rx_idx = end_idx;
+	recx_arr[2].rx_nr = end_idx;
+	recx_arr[3].rx_idx = 0;
+	recx_arr[3].rx_nr = end_idx + 2;
+	recx_arr[4].rx_idx = 0;
+	recx_arr[4].rx_nr = end_idx * 2;
+	recx_arr[5].rx_idx = 2;
+	recx_arr[5].rx_nr = end_idx;
+	recx_arr[6].rx_idx = 0;
+	recx_arr[6].rx_nr = end_idx * 2;
+	recx_arr[7].rx_idx = 0;
+	recx_arr[7].rx_nr = end_idx * 2;
+	recx_arr[8].rx_idx = 2;
+	recx_arr[8].rx_nr = end_idx;
+	recx_arr[9].rx_idx = 0;
+	recx_arr[9].rx_nr = 3;
+	recx_arr[10].rx_idx = end_idx - 1;
+	recx_arr[10].rx_nr = end_idx + 1;
+
+	ds.td_type = DAOS_IOD_ARRAY;
+	ds.td_iod_size = iod_size;
+	ds.td_recx_nr = ARRAY_SIZE(recx_arr);
+	ds.td_recx = &recx_arr[0];
+	ds.td_expected_recs = 0;
+	ds.td_upd_epr.epr_lo = 1;
+	ds.td_upd_epr.epr_hi = ARRAY_SIZE(recx_arr);
+	ds.td_agg_epr.epr_lo = 0;
+	ds.td_agg_epr.epr_hi = ARRAY_SIZE(recx_arr) + 1;
+	ds.td_discard = false;
+	ds.td_delete = true;
+
+	aggregate_basic(arg, &ds, ARRAY_SIZE(punch_epochs), &punch_epochs[0]);
+	cleanup();
+}
+
 static int
 agg_tst_teardown(void **state)
 {
@@ -2636,6 +2688,8 @@ static const struct CMUnitTest aggregate_tests[] = {
 	  aggregate_30, NULL, agg_tst_teardown },
 	{ "VOS431: Removal spans windows, flush with no physical records",
 	  aggregate_31, NULL, agg_tst_teardown },
+	{ "VOS432: Overlapping removals",
+	  aggregate_32, NULL, agg_tst_teardown },
 };
 
 int


### PR DESCRIPTION
Similar to #6443, we should also defer removal of
removal records to aggregation.   Add insertion records
instead.  There was a bug in removal of overlapped records
anyway so this also fixes that.

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>