### PR TITLE
DAOS-8405 test: Fix Go telemetry timestamp unit test

### DIFF
--- a/src/control/lib/telemetry/timestamp_test.go
+++ b/src/control/lib/telemetry/timestamp_test.go
@@ -71,8 +71,8 @@ func TestTelemetry_GetTimestamp(t *testing.T) {
 				// guarantee it's in a reasonable range
 				val := result.Value()
 				createTime := time.Unix(int64(tc.expResult.Cur), 0)
-				common.AssertTrue(t, val == createTime || val.After(createTime), fmt.Sprintf("value %v too early", val))
-				common.AssertTrue(t, val == time.Now() || val.Before(time.Now()), fmt.Sprintf("value %v too late", val))
+				common.AssertTrue(t, val.Equal(createTime) || val.After(createTime), fmt.Sprintf("value %v too early", val))
+				common.AssertTrue(t, val.Equal(time.Now()) || val.Before(time.Now()), fmt.Sprintf("value %v too late", val))
 
 				common.AssertEqual(t, float64(val.Unix()), result.FloatValue(), "expected float value and time value equal")
 			} else {


### PR DESCRIPTION
Fix the time equality comparison to use .Equal() instead of
"==", as recommended in the time package documentation.

Signed-off-by: Kris Jacque <kristin.jacque@intel.com>