### PR TITLE
DAOS-8406 vos: fix assert in prepare_segments()

### DIFF
--- a/src/vos/vos_aggregate.c
+++ b/src/vos/vos_aggregate.c
@@ -780,7 +780,7 @@ process_physical:
 		io->ic_seg_cnt++;
 		D_ASSERT(io->ic_seg_cnt <= io->ic_seg_max);
 	}
-	if (mw->mw_csum_support) {
+	if (mw->mw_csum_support && io->ic_seg_cnt > 0) {
 		D_ASSERT(first != NULL);
 		cs_len = first->pe_csum_info.cs_len;
 		cs_type = first->pe_csum_info.cs_type;


### PR DESCRIPTION
Only prepare csum buffer when there are segments to be prepared,
otherwise, the assert of 'first != NULL' will be triggered when
current merge window has removal records only.

Signed-off-by: Niu Yawei <yawei.niu@intel.com>