### PR TITLE
DAOS-8353 rebuild: a few fixes for overwrite EC rebuild

### DIFF
--- a/src/include/daos/object.h
+++ b/src/include/daos/object.h
@@ -519,6 +519,8 @@ enum daos_io_flags {
 	DIOF_FOR_EC_AGG		= 0x80,
 	/* The operation is for EC snapshot recovering */
 	DIOF_EC_RECOV_SNAP	= 0x100,
+	/* Only recover from parity */
+	DIOF_EC_RECOV_FROM_PARITY = 0x200,
 };
 
 /**

--- a/src/include/daos_srv/daos_engine.h
+++ b/src/include/daos_srv/daos_engine.h
@@ -786,7 +786,7 @@ struct dss_enum_unpack_io {
 	/* punched epochs per akey */
 	daos_epoch_t		*ui_akey_punch_ephs;
 	daos_epoch_t		*ui_rec_punch_ephs;
-	daos_epoch_t		*ui_rec_min_ephs;
+	daos_epoch_t		**ui_recx_ephs;
 	int			 ui_iods_cap;
 	int			 ui_iods_top;
 	int			*ui_recxs_caps;

--- a/src/include/daos_srv/vos_types.h
+++ b/src/include/daos_srv/vos_types.h
@@ -251,6 +251,8 @@ enum {
 	VOS_OF_DEDUP			= (1 << 16),
 	/** Dedup update with memcmp verify mode */
 	VOS_OF_DEDUP_VERIFY		= (1 << 17),
+	/** Ignore fetch only used by shadow fetch to ignore the evt fetch */
+	VOS_OF_SKIP_FETCH	= (1 << 18),
 };
 
 /** Mask for any conditionals passed to to the fetch */

--- a/src/object/cli_ec.c
+++ b/src/object/cli_ec.c
@@ -2776,13 +2776,14 @@ obj_ec_tgt_oiod_init(struct obj_io_desc *r_oiods, uint32_t iod_nr,
 
 /* Get all of recxs of the specific target from the daos offset */
 int
-obj_recx_ec2_daos(struct daos_oclass_attr *oca, int shard,
-		  daos_recx_t **recxs_p, unsigned int *nr)
+obj_recx_ec2_daos(struct daos_oclass_attr *oca, int shard, daos_recx_t **recxs_p,
+		  daos_epoch_t **recx_ephs_p, unsigned int *nr, bool convert_parity)
 {
 	int		cell_nr = obj_ec_cell_rec_nr(oca);
 	int		stripe_nr = obj_ec_stripe_rec_nr(oca);
 	daos_recx_t	*recxs = *recxs_p;
 	daos_recx_t	*tgt_recxs;
+	daos_epoch_t	*recx_ephs = NULL;
 	int		tgt_idx;
 	unsigned int	total;
 	int		idx;
@@ -2793,7 +2794,7 @@ obj_recx_ec2_daos(struct daos_oclass_attr *oca, int shard,
 
 	tgt_idx = shard % obj_ec_tgt_nr(oca);
 	/* parity shard conversion */
-	if (tgt_idx >= obj_ec_data_tgt_nr(oca)) {
+	if (is_ec_parity_shard(tgt_idx, oca)) {
 		for (i = 0; i < *nr; i++) {
 			daos_off_t offset = recxs[i].rx_idx;
 
@@ -2803,9 +2804,8 @@ obj_recx_ec2_daos(struct daos_oclass_attr *oca, int shard,
 			offset &= ~PARITY_INDICATOR;
 			D_ASSERT(offset % cell_nr == 0);
 			D_ASSERT(recxs[i].rx_nr % cell_nr == 0);
-			recxs[i].rx_idx = obj_ec_idx_parity2daos(offset,
-								 cell_nr,
-								 stripe_nr);
+			offset = obj_ec_idx_parity2daos(offset, cell_nr, stripe_nr);
+			recxs[i].rx_idx = convert_parity ? offset : PARITY_INDICATOR | offset;
 			recxs[i].rx_nr *= obj_ec_data_tgt_nr(oca);
 		}
 		return 0;
@@ -2823,6 +2823,13 @@ obj_recx_ec2_daos(struct daos_oclass_attr *oca, int shard,
 	D_ALLOC_ARRAY(tgt_recxs, total);
 	if (tgt_recxs == NULL)
 		return -DER_NOMEM;
+	if (recx_ephs_p != NULL) {
+		D_ALLOC_ARRAY(recx_ephs, total);
+		if (recx_ephs == NULL) {
+			D_FREE(tgt_recxs);
+			return -DER_NOMEM;
+		}
+	}
 
 	for (i = 0, idx = 0; i < *nr; i++) {
 		daos_off_t offset = recxs[i].rx_idx;
@@ -2839,10 +2846,17 @@ obj_recx_ec2_daos(struct daos_oclass_attr *oca, int shard,
 			D_ASSERT(idx < total);
 			tgt_recxs[idx].rx_idx = daos_off;
 			tgt_recxs[idx].rx_nr = daos_size;
+			if (recx_ephs != NULL)
+				recx_ephs[idx] = (*recx_ephs_p)[i];
 			offset += daos_size;
 			size -= daos_size;
 			idx++;
 		}
+	}
+
+	if (recx_ephs_p) {
+		D_FREE(*recx_ephs_p);
+		*recx_ephs_p = recx_ephs;
 	}
 
 	D_FREE(*recxs_p);
@@ -2853,10 +2867,11 @@ obj_recx_ec2_daos(struct daos_oclass_attr *oca, int shard,
 
 /* Convert DAOS offset to specific data target daos offset */
 int
-obj_recx_ec_daos2shard(struct daos_oclass_attr *oca, int shard,
-		       daos_recx_t **recxs_p, unsigned int *iod_nr)
+obj_recx_ec_daos2shard(struct daos_oclass_attr *oca, int shard, daos_recx_t **recxs_p,
+		       daos_epoch_t **recx_ephs_p, unsigned int *iod_nr)
 {
 	daos_recx_t	*recx = *recxs_p;
+	daos_epoch_t	*new_ephs = NULL;
 	int		nr = *iod_nr;
 	int		cell_nr = obj_ec_cell_rec_nr(oca);
 	int		stripe_nr = obj_ec_stripe_rec_nr(oca);
@@ -2868,7 +2883,7 @@ obj_recx_ec_daos2shard(struct daos_oclass_attr *oca, int shard,
 
 	D_ASSERT(shard_idx < obj_ec_data_tgt_nr(oca));
 	for (i = 0, total = 0; i < nr; i++) {
-		uint64_t offset = recx[i].rx_idx;
+		uint64_t offset = recx[i].rx_idx & ~PARITY_INDICATOR;
 		uint64_t end = offset + recx[i].rx_nr;
 
 		while (offset < end) {
@@ -2886,6 +2901,10 @@ obj_recx_ec_daos2shard(struct daos_oclass_attr *oca, int shard,
 
 	if (total == 0) {
 		D_FREE(*recxs_p);
+		if (recx_ephs_p) {
+			D_FREE(*recx_ephs_p);
+			*recx_ephs_p = NULL;
+		}
 		*iod_nr = 0;
 		return 0;
 	}
@@ -2894,8 +2913,17 @@ obj_recx_ec_daos2shard(struct daos_oclass_attr *oca, int shard,
 	if (tgt_recxs == NULL)
 		return -DER_NOMEM;
 
+	if (recx_ephs_p != NULL) {
+		D_ALLOC_ARRAY(new_ephs, total);
+		if (new_ephs == NULL) {
+			D_FREE(tgt_recxs);
+			return -DER_NOMEM;
+		}
+	}
+
 	for (i = 0, idx = 0; i < nr; i++) {
-		uint64_t offset = recx[i].rx_idx;
+		uint64_t parity_indicator = recx[i].rx_idx & PARITY_INDICATOR;
+		uint64_t offset = recx[i].rx_idx & ~PARITY_INDICATOR;
 		uint64_t end = offset + recx[i].rx_nr;
 
 		while (offset < end) {
@@ -2911,8 +2939,10 @@ obj_recx_ec_daos2shard(struct daos_oclass_attr *oca, int shard,
 			/* Intersect with the shard cell */
 			D_ASSERT(idx < total);
 			tgt_recxs[idx].rx_idx = max(shard_start, offset);
-			tgt_recxs[idx].rx_nr = min(shard_end, end) -
-					       tgt_recxs[idx].rx_idx;
+			tgt_recxs[idx].rx_nr = min(shard_end, end) - tgt_recxs[idx].rx_idx;
+			tgt_recxs[idx].rx_idx |= parity_indicator;
+			if (new_ephs)
+				new_ephs[idx] = (*recx_ephs_p)[i];
 			idx++;
 			offset = roundup(offset + 1, stripe_nr);
 		}
@@ -2920,6 +2950,10 @@ obj_recx_ec_daos2shard(struct daos_oclass_attr *oca, int shard,
 
 	D_FREE(*recxs_p);
 	*recxs_p = tgt_recxs;
+	if (recx_ephs_p != NULL) {
+		D_FREE(*recx_ephs_p);
+		*recx_ephs_p = new_ephs;
+	}
 	*iod_nr = total;
 
 	return 0;

--- a/src/object/cli_shard.c
+++ b/src/object/cli_shard.c
@@ -1187,6 +1187,8 @@ dc_obj_shard_rw(struct dc_obj_shard *shard, enum obj_rpc_opc opc,
 		if (args->reasb_req->orr_recov_snap)
 			orw->orw_flags |= ORF_EC_RECOV_SNAP;
 	} else {
+		if (api_args->extra_flags & DIOF_EC_RECOV_FROM_PARITY)
+			orw->orw_flags |= ORF_EC_RECOV_FROM_PARITY;
 		rw_args.maps = args->api_args->ioms;
 	}
 	if (opc == DAOS_OBJ_RPC_FETCH) {

--- a/src/object/obj_ec.h
+++ b/src/object/obj_ec.h
@@ -304,6 +304,11 @@ struct obj_reasb_req;
 /** Alignment size of sing value local size */
 #define OBJ_EC_SINGV_CELL_ALIGN			(8)
 
+#define is_ec_data_shard(shard, oca)					\
+		((shard % obj_ec_tgt_nr(oca)) < obj_ec_data_tgt_nr(oca))
+#define is_ec_parity_shard(shard, oca)					\
+		((shard % obj_ec_tgt_nr(oca)) >= obj_ec_data_tgt_nr(oca))
+
 /** Local rec size, padding bytes and offset in the global record */
 struct obj_ec_singv_local {
 	uint64_t	esl_off;
@@ -630,10 +635,7 @@ obj_shard_is_ec_parity(daos_unit_oid_t oid, struct daos_oclass_attr *attr)
 	if (!daos_oclass_is_ec(attr))
 		return false;
 
-	if ((oid.id_shard % obj_ec_tgt_nr(attr)) < obj_ec_data_tgt_nr(attr))
-		return false;
-
-	return true;
+	return is_ec_parity_shard(oid.id_shard, attr);
 }
 
 /* obj_class.c */

--- a/src/object/obj_enum.c
+++ b/src/object/obj_enum.c
@@ -807,10 +807,10 @@ unpack_recx_csum(d_iov_t *csum_iov, d_iov_t *csum_iov_out)
 
 /* Parse recxs in <*data, len> and append them to iod and sgl. */
 static int
-unpack_recxs(daos_iod_t *iod, int *recxs_cap, daos_epoch_t *eph,
-	     daos_epoch_t *min_eph, d_sg_list_t *sgl, daos_key_desc_t *kds,
-	     void *data, d_iov_t *csum_iov_in, d_iov_t *csum_iov_out,
-	     unsigned int type)
+unpack_recxs(daos_iod_t *iod, daos_epoch_t **recx_ephs, int *recxs_cap,
+	     daos_epoch_t *eph,  d_sg_list_t *sgl,
+	     daos_key_desc_t *kds, void *data, d_iov_t *csum_iov_in,
+	     d_iov_t *csum_iov_out, unsigned int type)
 {
 	struct obj_enum_rec	*rec = data;
 	int			rc = 0;
@@ -829,6 +829,11 @@ unpack_recxs(daos_iod_t *iod, int *recxs_cap, daos_epoch_t *eph,
 
 		rc = grow_array((void **)&iod->iod_recxs,
 				sizeof(*iod->iod_recxs), *recxs_cap, cap);
+		if (rc != 0)
+			D_GOTO(out, rc);
+
+		rc = grow_array((void **)recx_ephs,
+				sizeof(daos_epoch_t), *recxs_cap, cap);
 		if (rc != 0)
 			D_GOTO(out, rc);
 
@@ -855,9 +860,7 @@ unpack_recxs(daos_iod_t *iod, int *recxs_cap, daos_epoch_t *eph,
 	if (*eph < rec->rec_epr.epr_lo)
 		*eph = rec->rec_epr.epr_lo;
 
-	if (*min_eph == 0 || rec->rec_epr.epr_lo < *min_eph)
-		*min_eph = rec->rec_epr.epr_lo;
-
+	(*recx_ephs)[iod->iod_nr] = rec->rec_epr.epr_lo;
 	iod->iod_recxs[iod->iod_nr] = rec->rec_recx;
 	iod->iod_nr++;
 	iod->iod_size = rec->rec_size;
@@ -904,15 +907,15 @@ out:
  * \param[in]		recxs_caps	recxs capacity array
  * \param[in]		sgls		optional sgl array for inline recxs
  * \param[in]		akey_ephs	akey punched ephs
- * \param[in]		rec_ephs	record punched ephs
+ * \param[in]		punched_ephs	record punched ephs
  * \param[in]		iods_cap	maximal number of elements in \a iods,
  *					\a recxs_caps, \a sgls, and \a ephs
  */
 static void
 dss_enum_unpack_io_init(struct dss_enum_unpack_io *io, daos_unit_oid_t oid,
 			daos_iod_t *iods, int *recxs_caps, d_sg_list_t *sgls,
-			daos_epoch_t *akey_ephs, daos_epoch_t *rec_ephs,
-			daos_epoch_t *rec_min_ephs, int iods_cap)
+			daos_epoch_t *akey_ephs, daos_epoch_t *punched_ephs,
+			daos_epoch_t **recx_ephs, int iods_cap)
 {
 	memset(io, 0, sizeof(*io));
 
@@ -938,16 +941,15 @@ dss_enum_unpack_io_init(struct dss_enum_unpack_io *io, daos_unit_oid_t oid,
 		io->ui_akey_punch_ephs = akey_ephs;
 	}
 
-	if (rec_ephs != NULL) {
-		memset(rec_ephs, 0, sizeof(*rec_ephs) * iods_cap);
-		io->ui_rec_punch_ephs = rec_ephs;
+	if (punched_ephs != NULL) {
+		memset(punched_ephs, 0, sizeof(*punched_ephs) * iods_cap);
+		io->ui_rec_punch_ephs = punched_ephs;
 	}
 
-	if (rec_min_ephs != NULL) {
-		memset(rec_min_ephs, 0, sizeof(*rec_min_ephs) * iods_cap);
-		io->ui_rec_min_ephs = rec_min_ephs;
+	if (recx_ephs != NULL) {
+		memset(recx_ephs, 0, sizeof(*recx_ephs) * iods_cap);
+		io->ui_recx_ephs = recx_ephs;
 	}
-
 }
 
 /**
@@ -965,9 +967,10 @@ dss_enum_unpack_io_clear(struct dss_enum_unpack_io *io)
 			d_sgl_fini(&io->ui_sgls[i], false);
 		daos_iov_free(&io->ui_csum_iov);
 
-
 		daos_iov_free(&io->ui_iods[i].iod_name);
 		D_FREE(io->ui_iods[i].iod_recxs);
+		D_FREE(io->ui_recx_ephs[i]);
+		io->ui_recx_ephs[i] = NULL;
 	}
 	memset(io->ui_iods, 0, sizeof(*io->ui_iods) * io->ui_iods_cap);
 	memset(io->ui_recxs_caps, 0,
@@ -1104,7 +1107,6 @@ next_iod(struct dss_enum_unpack_io *io, dss_enum_unpack_cb_t cb, void *cb_arg,
 		return complete_io_init_iod(io, cb, cb_arg, new_iod_name);
 
 	io->ui_iods_top++;
-	io->ui_rec_min_ephs[io->ui_iods_top] = 0;
 	/* Init the iod_name of the new IOD */
 	if (new_iod_name == NULL && idx != -1)
 		new_iod_name = &io->ui_iods[idx].iod_name;
@@ -1276,9 +1278,8 @@ enum_unpack_recxs(daos_key_desc_t *kds, void *data,
 		io->ui_version = rec->rec_version;
 
 	top = io->ui_iods_top;
-	rc = unpack_recxs(&io->ui_iods[top], &io->ui_recxs_caps[top],
-			  &io->ui_rec_punch_ephs[top],
-			  &io->ui_rec_min_ephs[top],
+	rc = unpack_recxs(&io->ui_iods[top], &io->ui_recx_ephs[top],
+			  &io->ui_recxs_caps[top], &io->ui_rec_punch_ephs[top],
 			  io->ui_sgls == NULL ?  NULL : &io->ui_sgls[top],
 			  kds, ptr, csum_iov, io_csums_iov(io), type);
 free:
@@ -1462,8 +1463,8 @@ dss_enum_unpack(daos_unit_oid_t oid, daos_key_desc_t *kds, int kds_num,
 	int				recxs_caps[DSS_ENUM_UNPACK_MAX_IODS];
 	d_sg_list_t			sgls[DSS_ENUM_UNPACK_MAX_IODS];
 	daos_epoch_t			ephs[DSS_ENUM_UNPACK_MAX_IODS];
-	daos_epoch_t			rec_ephs[DSS_ENUM_UNPACK_MAX_IODS];
-	daos_epoch_t			rec_min_ephs[DSS_ENUM_UNPACK_MAX_IODS];
+	daos_epoch_t			punched_ephs[DSS_ENUM_UNPACK_MAX_IODS];
+	daos_epoch_t			*recx_ephs[DSS_ENUM_UNPACK_MAX_IODS];
 	d_iov_t				csum_iov_in = {0};
 	struct io_unpack_arg		unpack_arg;
 	int				rc = 0;
@@ -1478,7 +1479,7 @@ dss_enum_unpack(daos_unit_oid_t oid, daos_key_desc_t *kds, int kds_num,
 		csum_iov_in = *csum;
 
 	dss_enum_unpack_io_init(&io, oid, iods, recxs_caps, sgls,
-				ephs, rec_ephs, rec_min_ephs,
+				ephs, punched_ephs, recx_ephs,
 				DSS_ENUM_UNPACK_MAX_IODS);
 
 	D_ASSERTF(sgl->sg_nr > 0, "%u\n", sgl->sg_nr);

--- a/src/object/obj_internal.h
+++ b/src/object/obj_internal.h
@@ -375,6 +375,7 @@ struct shard_list_args {
 
 struct obj_auxi_list_recx {
 	daos_recx_t	recx;
+	daos_epoch_t	recx_eph;
 	d_list_t	recx_list;
 };
 
@@ -392,7 +393,7 @@ struct obj_auxi_list_obj_enum {
 };
 
 int
-merge_recx(d_list_t *head, uint64_t offset, uint64_t size);
+merge_recx(d_list_t *head, uint64_t offset, uint64_t size, daos_epoch_t eph);
 
 struct ec_bulk_spec {
 	uint64_t is_skip:	1;
@@ -503,8 +504,9 @@ int dc_obj_shard_sync(struct dc_obj_shard *shard, enum obj_rpc_opc opc,
 int dc_obj_verify_rdg(struct dc_object *obj, struct dc_obj_verify_args *dova,
 		      uint32_t rdg_idx, uint32_t reps, daos_epoch_t epoch);
 bool obj_op_is_ec_fetch(struct obj_auxi_args *obj_auxi);
-int obj_recx_ec2_daos(struct daos_oclass_attr *oca, int shard,
-		      daos_recx_t **recxs_p, unsigned int *nr);
+int obj_recx_ec2_daos(struct daos_oclass_attr *oca, int shard, daos_recx_t **recxs_p,
+		      daos_epoch_t **recx_ephs_p, unsigned int *nr, bool convert_parity);
+
 int obj_reasb_req_init(struct obj_reasb_req *reasb_req, daos_iod_t *iods,
 		       uint32_t iod_nr, struct daos_oclass_attr *oca);
 void obj_reasb_req_fini(struct obj_reasb_req *reasb_req, uint32_t iod_nr);
@@ -523,8 +525,8 @@ bool obj_csum_dedup_candidate(struct cont_props *props, daos_iod_t *iods,
 			      uint32_t iod_nr);
 
 #define obj_shard_close(shard)	dc_obj_shard_close(shard)
-int obj_recx_ec_daos2shard(struct daos_oclass_attr *oca, int shard,
-			   daos_recx_t **recxs_p, unsigned int *iod_nr);
+int obj_recx_ec_daos2shard(struct daos_oclass_attr *oca, int shard, daos_recx_t **recxs_p,
+			   daos_epoch_t **recx_ephs_p, unsigned int *iod_nr);
 int obj_ec_singv_encode_buf(daos_unit_oid_t oid, struct daos_oclass_attr *oca,
 			    daos_iod_t *iod, d_sg_list_t *sgl, d_iov_t *e_iov);
 int obj_ec_singv_split(daos_unit_oid_t oid, struct daos_oclass_attr *oca,

--- a/src/object/obj_rpc.h
+++ b/src/object/obj_rpc.h
@@ -166,6 +166,8 @@ enum obj_rpc_flags {
 	ORF_EC_RECOV		= (1 << 17),
 	/* EC data recovery from snapshot */
 	ORF_EC_RECOV_SNAP	= (1 << 18),
+	/* EC data recovery from parity */
+	ORF_EC_RECOV_FROM_PARITY = (1 << 19),
 };
 
 /* common for update/fetch */

--- a/src/object/obj_verify.c
+++ b/src/object/obj_verify.c
@@ -685,9 +685,8 @@ dc_obj_verify_ec_cb(struct dss_enum_unpack_io *io, void *arg)
 		sgls_verify[idx].sg_nr_out = 1;
 		sgls_verify[idx].sg_iovs = &iovs_verify[idx];
 		if (iod->iod_type == DAOS_IOD_ARRAY) {
-			rc = obj_recx_ec2_daos(obj_get_oca(obj),
-					       io->ui_oid.id_shard,
-					       &iod->iod_recxs, &iod->iod_nr);
+			rc = obj_recx_ec2_daos(obj_get_oca(obj), io->ui_oid.id_shard,
+					       &iod->iod_recxs, NULL, &iod->iod_nr, true);
 			if (rc != 0)
 				D_GOTO(out, rc);
 		}
@@ -727,8 +726,9 @@ dc_obj_verify_ec_cb(struct dss_enum_unpack_io *io, void *arg)
 		if (sgls[i].sg_iovs[0].iov_len != sgls_verify[i].sg_iovs[0].iov_len ||
 		    memcmp(sgls[i].sg_iovs[0].iov_buf, sgls_verify[i].sg_iovs[0].iov_buf,
 			   sgls[i].sg_iovs[0].iov_len)) {
-			D_ERROR(DF_OID" shard %u mismatch\n", DP_OID(obj->cob_md.omd_id),
-				dova->current_shard);
+			D_ERROR(DF_OID"i %d shard %u mismatch\n",
+				DP_OID(obj->cob_md.omd_id), i, dova->current_shard);
+
 			D_GOTO(out, rc = -DER_MISMATCH);
 		}
 		D_DEBUG(DB_TRACE, DF_OID" shard %u match\n", DP_OID(obj->cob_md.omd_id),

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -1425,12 +1425,14 @@ obj_local_rw_internal(crt_rpc_t *rpc, struct obj_io_context *ioc,
 				goto out;
 			}
 			iod_converted = true;
+
+			if (orw->orw_flags & ORF_EC_RECOV_FROM_PARITY)
+				fetch_flags |= VOS_OF_SKIP_FETCH;
 		}
 
 		rc = vos_fetch_begin(ioc->ioc_vos_coh, orw->orw_oid,
 				     orw->orw_epoch, dkey, orw->orw_nr, iods,
-				     cond_flags | fetch_flags, shadows, &ioh,
-				     dth);
+				     cond_flags | fetch_flags, shadows, &ioh, dth);
 		daos_recx_ep_list_free(shadows, orw->orw_nr);
 		if (rc) {
 			D_CDEBUG(rc == -DER_INPROGRESS || rc == -DER_NONEXIST ||
@@ -1465,6 +1467,7 @@ obj_local_rw_internal(crt_rpc_t *rpc, struct obj_io_context *ioc,
 			if (rc)
 				goto out;
 		}
+
 		if (ec_deg_fetch) {
 			D_ASSERT(!get_parity_list);
 			recov_lists = vos_ioh2recx_list(ioh);

--- a/src/object/srv_obj_migrate.c
+++ b/src/object/srv_obj_migrate.c
@@ -43,13 +43,31 @@ struct migrate_one {
 	daos_unit_oid_t		 mo_oid;
 	daos_epoch_t		 mo_obj_punch_eph;
 	daos_epoch_t		 mo_dkey_punch_eph;
-	daos_epoch_t		 mo_epoch;
-	daos_epoch_t		 mo_update_epoch;
+
+	/* minimum epoch from mo_iods & mo_iods_from_parity, used
+	 * as the updated epoch for replication extent rebuild.
+	*/
+	daos_epoch_t             mo_min_epoch;
+	daos_epoch_t             mo_epoch;
+
+	/* Epochs per recx in mo_iods, used for parity extent rebuild. */
+        daos_epoch_t		**mo_iods_update_ephs;
+
+	/* IOD for replicate recxs migration */
 	daos_iod_t		*mo_iods;
-	struct dcs_iod_csums	*mo_iods_csums;
+
+	/* IOD for recxs gotten from parity rebuild. During EC rebuild, it
+	 * will first rebuild mo_iods_from_parity then rebuild mo_iods to
+	 * avoid parity corruption.
+	*/
+	daos_iod_t		*mo_iods_from_parity;
+
 	daos_iod_t		*mo_punch_iods;
+
 	daos_epoch_t		*mo_akey_punch_ephs;
 	daos_epoch_t		 mo_rec_punch_eph;
+
+	struct dcs_iod_csums	*mo_iods_csums;
 	d_sg_list_t		*mo_sgls;
 	struct daos_oclass_attr	 mo_oca;
 	unsigned int		 mo_iod_num;
@@ -59,6 +77,7 @@ struct migrate_one {
 	uint64_t		 mo_size;
 	uint64_t		 mo_version;
 	uint32_t		 mo_pool_tls_version;
+	uint32_t		 mo_iods_num_from_parity;
 	d_list_t		 mo_list;
 	d_iov_t			 mo_csum_iov;
 };
@@ -459,8 +478,8 @@ out:
 }
 
 static void
-mrone_recx_daos_vos_internal(struct migrate_one *mrone,
-			     bool daos2vos, int shard)
+mrone_recx_daos_vos_internal(struct migrate_one *mrone, bool daos2vos, int shard,
+			     daos_iod_t *iods, int iods_num)
 {
 	daos_iod_t *iod;
 	int cell_nr;
@@ -473,8 +492,8 @@ mrone_recx_daos_vos_internal(struct migrate_one *mrone,
 	cell_nr = obj_ec_cell_rec_nr(&mrone->mo_oca);
 	stripe_nr = obj_ec_stripe_rec_nr(&mrone->mo_oca);
 	/* Convert the DAOS to VOS EC offset */
-	for (j = 0; j < mrone->mo_iod_num; j++) {
-		iod = &mrone->mo_iods[j];
+	for (j = 0; j < iods_num; j++) {
+		iod = &iods[j];
 		if (iod->iod_type == DAOS_IOD_SINGLE)
 			continue;
 		for (k = 0; k < iod->iod_nr; k++) {
@@ -498,33 +517,31 @@ mrone_recx_daos_vos_internal(struct migrate_one *mrone,
 }
 
 static void
-mrone_recx_daos2_vos(struct migrate_one *mrone)
+mrone_recx_daos2_vos(struct migrate_one *mrone, daos_iod_t *iods, int iods_num)
 {
-	mrone_recx_daos_vos_internal(mrone, true, -1);
+	mrone_recx_daos_vos_internal(mrone, true, -1, iods, iods_num);
 }
 
 static void
-mrone_recx_vos2_daos(struct migrate_one *mrone, int shard)
+mrone_recx_vos2_daos(struct migrate_one *mrone, int shard, daos_iod_t *iods, int iods_num)
 {
 	shard = shard % obj_ec_tgt_nr(&mrone->mo_oca);
 	D_ASSERT(shard < obj_ec_data_tgt_nr(&mrone->mo_oca));
-	mrone_recx_daos_vos_internal(mrone, false, shard);
+	mrone_recx_daos_vos_internal(mrone, false, shard, iods, iods_num);
 }
 
 static int
 mrone_obj_fetch(struct migrate_one *mrone, daos_handle_t oh, d_sg_list_t *sgls,
+		daos_iod_t *iods, int iod_num, daos_epoch_t eph, uint32_t flags,
 		d_iov_t *csum_iov_fetch)
 {
-	uint32_t		 flags = DIOF_FOR_MIGRATION;
-	int			 rc;
+	int rc;
 
 	if (daos_oclass_grp_size(&mrone->mo_oca) > 1)
 		flags |= DIOF_TO_LEADER;
 
-	rc = dsc_obj_fetch(oh, mrone->mo_epoch, &mrone->mo_dkey,
-			   mrone->mo_iod_num, mrone->mo_iods, sgls, NULL,
+	rc = dsc_obj_fetch(oh, eph, &mrone->mo_dkey, iod_num, iods, sgls, NULL,
 			   flags, NULL, csum_iov_fetch);
-
 	if (rc != 0)
 		return rc;
 
@@ -543,8 +560,7 @@ mrone_obj_fetch(struct migrate_one *mrone, daos_handle_t oh, d_sg_list_t *sgls,
 		csum_iov_fetch->iov_len = 0;
 		csum_iov_fetch->iov_buf = p;
 
-		rc = dsc_obj_fetch(oh, mrone->mo_epoch, &mrone->mo_dkey,
-				   mrone->mo_iod_num, mrone->mo_iods, sgls,
+		rc = dsc_obj_fetch(oh, mrone->mo_epoch, &mrone->mo_dkey, iod_num, iods, sgls,
 				   NULL, flags, NULL, csum_iov_fetch);
 	}
 
@@ -617,7 +633,8 @@ migrate_fetch_update_inline(struct migrate_one *mrone, daos_handle_t oh,
 		if (rc != 0)
 			D_GOTO(out, rc);
 
-		rc = mrone_obj_fetch(mrone, oh, sgls, &csum_iov_fetch);
+		rc = mrone_obj_fetch(mrone, oh, sgls, mrone->mo_iods, mrone->mo_iod_num,
+				     mrone->mo_epoch, DIOF_FOR_MIGRATION, &csum_iov_fetch);
 
 		if (rc) {
 			D_ERROR("mrone_obj_fetch "DF_RC"\n", DP_RC(rc));
@@ -638,7 +655,7 @@ migrate_fetch_update_inline(struct migrate_one *mrone, daos_handle_t oh,
 
 	if (daos_oclass_is_ec(&mrone->mo_oca) &&
 	    !obj_shard_is_ec_parity(mrone->mo_oid, &mrone->mo_oca))
-		mrone_recx_daos2_vos(mrone);
+		mrone_recx_daos2_vos(mrone, mrone->mo_iods, mrone->mo_iod_num);
 
 	rc = daos_csummer_csum_init_with_packed(&csummer, csums_iov);
 	if (rc != 0)
@@ -683,8 +700,7 @@ migrate_fetch_update_inline(struct migrate_one *mrone, daos_handle_t oh,
 			}
 
 			rc = vos_obj_update(ds_cont->sc_hdl, mrone->mo_oid,
-					    mrone->mo_update_epoch,
-					    mrone->mo_version,
+					    mrone->mo_min_epoch, mrone->mo_version,
 					    0, &mrone->mo_dkey, iod_cnt,
 					    &mrone->mo_iods[start], iod_csums,
 					    &sgls[start]);
@@ -723,8 +739,7 @@ migrate_fetch_update_inline(struct migrate_one *mrone, daos_handle_t oh,
 		}
 
 		rc = vos_obj_update(ds_cont->sc_hdl, mrone->mo_oid,
-				    mrone->mo_update_epoch,
-				    mrone->mo_version,
+				    mrone->mo_min_epoch, mrone->mo_version,
 				    0, &mrone->mo_dkey, iod_cnt,
 				    &mrone->mo_iods[start], iod_csums,
 				    &sgls[start]);
@@ -772,7 +787,8 @@ obj_ec_encode_buf(daos_obj_id_t oid, struct daos_oclass_attr *oca,
 }
 
 static int
-migrate_update_parity(struct migrate_one *mrone, struct ds_cont_child *ds_cont,
+migrate_update_parity(struct migrate_one *mrone, daos_epoch_t parity_eph,
+		      struct ds_cont_child *ds_cont,
 		      unsigned char *buffer, daos_off_t offset,
 		      daos_size_t size, daos_iod_t *iod,
 		      unsigned char *p_bufs[], d_iov_t *csum_iov)
@@ -815,7 +831,7 @@ migrate_update_parity(struct migrate_one *mrone, struct ds_cont_child *ds_cont,
 			tmp_recx.rx_nr = cell_nr;
 			d_iov_set(&tmp_iov, p_bufs[shard],
 				  cell_nr * iod->iod_size);
-			D_DEBUG(DB_IO, "parity "DF_U64"/"DF_U64" "DF_U64"\n",
+			D_DEBUG(DB_IO, "parity "DF_X64"/"DF_U64" "DF_U64"\n",
 				tmp_recx.rx_idx, tmp_recx.rx_nr, iod->iod_size);
 		} else {
 			tmp_recx.rx_idx = offset;
@@ -844,10 +860,12 @@ migrate_update_parity(struct migrate_one *mrone, struct ds_cont_child *ds_cont,
 		}
 
 		rc = vos_obj_update(ds_cont->sc_hdl, mrone->mo_oid,
-				    mrone->mo_epoch,
-				    mrone->mo_version,
+				    parity_eph, mrone->mo_version,
 				    0, &mrone->mo_dkey, 1, iod, iod_csums,
 				    &tmp_sgl);
+		if (rc != 0)
+			D_GOTO(out, rc);
+
 		size -= write_nr;
 		offset += write_nr;
 		buffer += write_nr * iod->iod_size;
@@ -895,7 +913,8 @@ migrate_fetch_update_parity(struct migrate_one *mrone, daos_handle_t oh,
 	rc = daos_iov_alloc(&csum_iov_fetch, CSUM_BUF_SIZE, false);
 	if (rc)
 		D_GOTO(out, rc);
-	rc = mrone_obj_fetch(mrone, oh, sgls, &csum_iov_fetch);
+	rc = mrone_obj_fetch(mrone, oh, sgls, mrone->mo_iods, mrone->mo_iod_num,
+			     mrone->mo_epoch, DIOF_FOR_MIGRATION, &csum_iov_fetch);
 	tmp_csum_iov_fetch = csum_iov_fetch;
 	if (rc) {
 		D_ERROR("migrate dkey "DF_KEY" failed: "DF_RC"\n",
@@ -908,10 +927,13 @@ migrate_fetch_update_parity(struct migrate_one *mrone, daos_handle_t oh,
 		int		j;
 		daos_off_t	offset;
 		daos_iod_t	tmp_iod;
+		daos_epoch_t	*iod_ephs = mrone->mo_iods_update_ephs[i];
+		daos_epoch_t	parity_eph;
 
 		iod = &mrone->mo_iods[i];
 		offset = iod->iod_recxs[0].rx_idx;
 		size = iod->iod_recxs[0].rx_nr;
+		parity_eph = iod_ephs[0];
 		tmp_iod = *iod;
 		ptr = iov[i].iov_buf;
 		for (j = 1; j < iod->iod_nr; j++) {
@@ -919,22 +941,23 @@ migrate_fetch_update_parity(struct migrate_one *mrone, daos_handle_t oh,
 
 			if (offset + size == recx->rx_idx) {
 				size += recx->rx_nr;
+				parity_eph = iod_ephs[j];
 				continue;
 			}
 
 			tmp_iod.iod_nr = 1;
-			rc = migrate_update_parity(mrone, ds_cont, ptr, offset,
-						   size, &tmp_iod, p_bufs,
-						   &tmp_csum_iov_fetch);
+			rc = migrate_update_parity(mrone, parity_eph, ds_cont, ptr, offset,
+						   size, &tmp_iod, p_bufs, &tmp_csum_iov_fetch);
 			if (rc)
 				D_GOTO(out, rc);
 			ptr += size * iod->iod_size;
 			offset = recx->rx_idx;
 			size = recx->rx_nr;
+			parity_eph = iod_ephs[j];
 		}
 
 		if (size > 0)
-			rc = migrate_update_parity(mrone, ds_cont, ptr, offset,
+			rc = migrate_update_parity(mrone, parity_eph, ds_cont, ptr, offset,
 						   size, &tmp_iod, p_bufs,
 						   &tmp_csum_iov_fetch);
 	}
@@ -995,7 +1018,8 @@ migrate_fetch_update_single(struct migrate_one *mrone, daos_handle_t oh,
 	if (rc != 0)
 		D_GOTO(out, rc);
 
-	rc = mrone_obj_fetch(mrone, oh, sgls, &csum_iov_fetch);
+	rc = mrone_obj_fetch(mrone, oh, sgls, mrone->mo_iods, mrone->mo_iod_num,
+			     mrone->mo_epoch, DIOF_FOR_MIGRATION, &csum_iov_fetch);
 	if (rc) {
 		D_ERROR("migrate dkey "DF_KEY" failed: "DF_RC"\n",
 			DP_KEY(&mrone->mo_dkey), DP_RC(rc));
@@ -1099,7 +1123,7 @@ migrate_fetch_update_single(struct migrate_one *mrone, daos_handle_t oh,
 		goto out;
 	}
 	rc = vos_obj_update(ds_cont->sc_hdl, mrone->mo_oid,
-			    mrone->mo_update_epoch, mrone->mo_version,
+			    mrone->mo_min_epoch, mrone->mo_version,
 			    0, &mrone->mo_dkey, mrone->mo_iod_num,
 			    mrone->mo_iods, iod_csums, sgls);
 out:
@@ -1122,8 +1146,9 @@ out:
 }
 
 static int
-migrate_fetch_update_bulk(struct migrate_one *mrone, daos_handle_t oh,
-			  struct ds_cont_child *ds_cont)
+__migrate_fetch_update_bulk(struct migrate_one *mrone, daos_handle_t oh,
+			    daos_iod_t *iods, int iod_num, daos_epoch_t update_eph,
+			    uint32_t flags, struct ds_cont_child *ds_cont)
 {
 	d_sg_list_t		 sgls[DSS_ENUM_UNPACK_MAX_IODS];
 	daos_handle_t		 ioh;
@@ -1133,18 +1158,13 @@ migrate_fetch_update_bulk(struct migrate_one *mrone, daos_handle_t oh,
 	struct dcs_iod_csums	*iod_csums = NULL;
 	d_iov_t			 tmp_csum_iov;
 
-
-	if (obj_shard_is_ec_parity(mrone->mo_oid, &mrone->mo_oca))
-		return migrate_fetch_update_parity(mrone, oh, ds_cont);
-
 	if (daos_oclass_is_ec(&mrone->mo_oca))
-		mrone_recx_daos2_vos(mrone);
+		mrone_recx_daos2_vos(mrone, iods, iod_num);
 
-	D_ASSERT(mrone->mo_iod_num <= DSS_ENUM_UNPACK_MAX_IODS);
-	rc = vos_update_begin(ds_cont->sc_hdl, mrone->mo_oid,
-			      mrone->mo_update_epoch, 0, &mrone->mo_dkey,
-			      mrone->mo_iod_num, mrone->mo_iods,
-			      mrone->mo_iods_csums, 0, &ioh, NULL);
+	D_ASSERT(iod_num <= DSS_ENUM_UNPACK_MAX_IODS);
+	rc = vos_update_begin(ds_cont->sc_hdl, mrone->mo_oid, update_eph, 0,
+			      &mrone->mo_dkey, iod_num, iods, mrone->mo_iods_csums,
+			      0, &ioh, NULL);
 	if (rc != 0) {
 		D_ERROR(DF_UOID"preparing update fails: "DF_RC"\n",
 			DP_UOID(mrone->mo_oid), DP_RC(rc));
@@ -1159,7 +1179,7 @@ migrate_fetch_update_bulk(struct migrate_one *mrone, daos_handle_t oh,
 		goto end;
 	}
 
-	for (i = 0; i < mrone->mo_iod_num; i++) {
+	for (i = 0; i < iod_num; i++) {
 		struct bio_sglist	*bsgl;
 
 		bsgl = vos_iod_sgl_at(ioh, i);
@@ -1174,16 +1194,17 @@ migrate_fetch_update_bulk(struct migrate_one *mrone, daos_handle_t oh,
 	D_DEBUG(DB_REBUILD,
 		DF_UOID" mrone %p dkey "DF_KEY" nr %d eph "DF_U64"\n",
 		DP_UOID(mrone->mo_oid), mrone, DP_KEY(&mrone->mo_dkey),
-		mrone->mo_iod_num, mrone->mo_epoch);
+		iod_num, mrone->mo_epoch);
 
 	if (daos_oclass_is_ec(&mrone->mo_oca))
-		mrone_recx_vos2_daos(mrone, mrone->mo_oid.id_shard);
+		mrone_recx_vos2_daos(mrone, mrone->mo_oid.id_shard, iods, iod_num);
 
 	rc = daos_iov_alloc(&csum_iov_fetch, CSUM_BUF_SIZE, false);
 	if (rc != 0)
 		D_GOTO(post, rc);
 
-	rc = mrone_obj_fetch(mrone, oh, sgls, &csum_iov_fetch);
+	rc = mrone_obj_fetch(mrone, oh, sgls, iods, iod_num, mrone->mo_epoch,
+			     flags, &csum_iov_fetch);
 	if (rc) {
 		D_ERROR("migrate dkey "DF_KEY" failed: "DF_RC"\n",
 			DP_KEY(&mrone->mo_dkey), DP_RC(rc));
@@ -1199,20 +1220,16 @@ migrate_fetch_update_bulk(struct migrate_one *mrone, daos_handle_t oh,
 			DF_C_UOID_DKEY" REBUILD: Calculating csums. "
 			"IOD count: %d\n",
 			DP_C_UOID_DKEY(mrone->mo_oid, &mrone->mo_dkey),
-			mrone->mo_iod_num);
-		rc = daos_csummer_calc_iods(csummer, sgls, mrone->mo_iods, NULL,
-					    mrone->mo_iod_num, false, NULL, -1,
+			iod_num);
+		rc = daos_csummer_calc_iods(csummer, sgls, iods, NULL, iod_num, false, NULL, -1,
 					    &iod_csums);
 	} else {
 		D_DEBUG(DB_CSUM,
 			DF_C_UOID_DKEY" REBUILD: Using packed csums\n",
 			DP_C_UOID_DKEY(mrone->mo_oid, &mrone->mo_dkey));
 		tmp_csum_iov = csum_iov_fetch;
-		rc = daos_csummer_alloc_iods_csums_with_packed(csummer,
-							mrone->mo_iods,
-							mrone->mo_iod_num,
-							&tmp_csum_iov,
-							&iod_csums);
+		rc = daos_csummer_alloc_iods_csums_with_packed(csummer, iods, iod_num,
+							       &tmp_csum_iov, &iod_csums);
 		if (rc != 0) {
 			D_ERROR("Failed to alloc iod csums: "DF_RC"\n",
 				DP_RC(rc));
@@ -1226,7 +1243,7 @@ post:
 		d_sgl_fini(&sgls[i], false);
 
 	if (daos_oclass_is_ec(&mrone->mo_oca))
-		mrone_recx_daos2_vos(mrone);
+		mrone_recx_daos2_vos(mrone, iods, iod_num);
 
 	ret = bio_iod_post(vos_ioh2desc(ioh));
 	if (ret) {
@@ -1235,8 +1252,8 @@ post:
 		rc = rc ? : ret;
 	}
 
-	for (i = 0; rc == 0 && i < mrone->mo_iod_num; i++) {
-		if (mrone->mo_iods[i].iod_size == 0) {
+	for (i = 0; rc == 0 && i < iod_num; i++) {
+		if (iods[i].iod_size == 0) {
 			/* zero size iod will cause assertion failure
 			 * in VOS, so let's check here.
 			 * So the object is being destroyed between
@@ -1253,8 +1270,7 @@ post:
 				" eph "DF_U64" "DF_RC"\n",
 				DP_UOID(mrone->mo_oid),
 				mrone, DP_KEY(&mrone->mo_dkey),
-				DP_KEY(&mrone->mo_iods[i].iod_name),
-				mrone->mo_iod_num, i, mrone->mo_epoch,
+				DP_KEY(&iods[i].iod_name), iod_num, i, mrone->mo_epoch,
 				DP_RC(rc));
 			D_GOTO(end, rc);
 		}
@@ -1267,6 +1283,46 @@ end:
 	daos_iov_free(&csum_iov_fetch);
 	if (rc == 0)
 		rc = rc1;
+	return rc;
+}
+
+static int
+migrate_fetch_update_bulk(struct migrate_one *mrone, daos_handle_t oh,
+			  struct ds_cont_child *ds_cont)
+{
+	int rc = 0;
+
+	if (obj_shard_is_ec_parity(mrone->mo_oid, &mrone->mo_oca))
+		return migrate_fetch_update_parity(mrone, oh, ds_cont);
+
+	if (!daos_oclass_is_ec(&mrone->mo_oca))
+		return __migrate_fetch_update_bulk(mrone, oh, mrone->mo_iods,
+						   mrone->mo_iod_num,
+						   mrone->mo_min_epoch,
+						   DIOF_FOR_MIGRATION, ds_cont);
+
+	/* For EC object, if the migration include both extent from parity rebuild
+	 * and extent from replicate rebuild, let rebuild the extent with parity first,
+	 * then extent from replication.
+	 */
+	if (mrone->mo_iods_num_from_parity > 0) {
+		rc = __migrate_fetch_update_bulk(mrone, oh, mrone->mo_iods_from_parity,
+						 mrone->mo_iods_num_from_parity,
+						 mrone->mo_min_epoch,
+						 DIOF_FOR_MIGRATION | DIOF_EC_RECOV_FROM_PARITY,
+						 ds_cont);
+		if (rc > 0)
+			D_GOTO(out, rc);
+	}
+
+	if (mrone->mo_iod_num > 0) {
+		rc = __migrate_fetch_update_bulk(mrone, oh, mrone->mo_iods,
+						 mrone->mo_iod_num, mrone->mo_epoch,
+						 DIOF_FOR_MIGRATION, ds_cont);
+		if (rc > 0)
+			D_GOTO(out, rc);
+	}
+out:
 	return rc;
 }
 
@@ -1445,12 +1501,22 @@ migrate_one_destroy(struct migrate_one *mrone)
 	D_ASSERT(d_list_empty(&mrone->mo_list));
 	daos_iov_free(&mrone->mo_dkey);
 
+	if (mrone->mo_iods_update_ephs) {
+		for (i = 0; i < mrone->mo_iod_alloc_num; i++) {
+			if (mrone->mo_iods_update_ephs[i])
+				D_FREE(mrone->mo_iods_update_ephs[i]);
+		}
+		D_FREE(mrone->mo_iods_update_ephs);
+	}
+
 	if (mrone->mo_iods)
 		daos_iods_free(mrone->mo_iods, mrone->mo_iod_alloc_num, true);
 
+	if (mrone->mo_iods_from_parity)
+		daos_iods_free(mrone->mo_iods_from_parity, mrone->mo_iod_alloc_num, true);
+
 	if (mrone->mo_punch_iods)
-		daos_iods_free(mrone->mo_punch_iods, mrone->mo_iod_alloc_num,
-			       true);
+		daos_iods_free(mrone->mo_punch_iods, mrone->mo_iod_alloc_num, true);
 
 	if (mrone->mo_akey_punch_ephs)
 		D_FREE(mrone->mo_akey_punch_ephs);
@@ -1487,8 +1553,12 @@ migrate_one_ult(void *arg)
 	}
 
 	data_size = daos_iods_len(mrone->mo_iods, mrone->mo_iod_num);
-	D_DEBUG(DB_TRACE, "mrone %p data size is "DF_U64"\n",
-		mrone, data_size);
+	data_size += daos_iods_len(mrone->mo_iods_from_parity,
+				   mrone->mo_iods_num_from_parity);
+
+	D_DEBUG(DB_TRACE, "mrone %p data size is "DF_U64" %d/%d\n",
+		mrone, data_size, mrone->mo_iod_num, mrone->mo_iods_num_from_parity);
+
 	D_ASSERT(data_size != (daos_size_t)-1);
 	D_DEBUG(DB_REBUILD, "mrone %p inflight size "DF_U64" max "DF_U64"\n",
 		mrone, tls->mpt_inflight_size, tls->mpt_inflight_max_size);
@@ -1539,35 +1609,36 @@ out:
 
 /* If src_iod is NULL, it will try to merge the recxs inside dst_iod */
 static int
-migrate_merge_iod_recx(daos_iod_t *dst_iod, daos_iod_t *src_iod)
+migrate_merge_iod_recx(daos_iod_t *dst_iod, daos_epoch_t **p_dst_ephs, daos_recx_t *new_recxs,
+		       daos_epoch_t *new_ephs, int new_recxs_nr)
 {
 	struct obj_auxi_list_recx	*recx;
 	struct obj_auxi_list_recx	*tmp;
+	daos_epoch_t	*dst_ephs;
 	daos_recx_t	*recxs;
 	d_list_t	merge_list;
 	int		nr_recxs = 0;
 	int		i;
 	int		rc = 0;
 
+	dst_ephs = p_dst_ephs ? *p_dst_ephs : NULL;
 	D_INIT_LIST_HEAD(&merge_list);
-	if (src_iod != NULL) {
-		recxs = src_iod->iod_recxs;
-		for (i = 0; i < src_iod->iod_nr; i++) {
-			D_DEBUG(DB_REBUILD, "src merge "DF_U64"/"DF_U64"\n",
-				recxs[i].rx_idx, recxs[i].rx_nr);
-			rc = merge_recx(&merge_list, recxs[i].rx_idx,
-					recxs[i].rx_nr);
-			if (rc)
-				D_GOTO(out, rc);
-		}
+	for (i = 0; i < new_recxs_nr; i++) {
+		D_DEBUG(DB_REBUILD, "src merge "DF_U64"/"DF_U64" eph "DF_U64"\n",
+			new_recxs[i].rx_idx, new_recxs[i].rx_nr, new_ephs ? new_ephs[i] : 0);
+		rc = merge_recx(&merge_list, new_recxs[i].rx_idx,
+				new_recxs[i].rx_nr, new_ephs ? new_ephs[i] : 0);
+		if (rc)
+			D_GOTO(out, rc);
 	}
 
 	D_ASSERT(dst_iod != NULL);
 	recxs = dst_iod->iod_recxs;
 	for (i = 0; i < dst_iod->iod_nr; i++) {
-		D_DEBUG(DB_REBUILD, "dst merge "DF_U64"/"DF_U64"\n",
-			recxs[i].rx_idx, recxs[i].rx_nr);
-		rc = merge_recx(&merge_list, recxs[i].rx_idx, recxs[i].rx_nr);
+		D_DEBUG(DB_REBUILD, "dst merge "DF_U64"/"DF_U64" eph "DF_U64"\n",
+			recxs[i].rx_idx, recxs[i].rx_nr, dst_ephs ? dst_ephs[i] : 0);
+		rc = merge_recx(&merge_list, recxs[i].rx_idx, recxs[i].rx_nr,
+				dst_ephs ? dst_ephs[i] : 0);
 		if (rc)
 			D_GOTO(out, rc);
 	}
@@ -1579,14 +1650,24 @@ migrate_merge_iod_recx(daos_iod_t *dst_iod, daos_iod_t *src_iod)
 		D_ALLOC_ARRAY(recxs, nr_recxs);
 		if (recxs == NULL)
 			D_GOTO(out, rc = -DER_NOMEM);
+
+		if (dst_ephs != NULL) {
+			D_ALLOC_ARRAY(dst_ephs, nr_recxs);
+			if (dst_ephs == NULL) {
+				D_FREE(recxs);
+				D_GOTO(out, rc = -DER_NOMEM);
+			}
+		}
 	} else {
 		recxs = dst_iod->iod_recxs;
 	}
 
 	i = 0;
 	d_list_for_each_entry_safe(recx, tmp, &merge_list, recx_list) {
-		recxs[i++] = recx->recx;
-
+		recxs[i] = recx->recx;
+		if (dst_ephs)
+			dst_ephs[i] = recx->recx_eph;
+		i++;
 		D_DEBUG(DB_REBUILD, "merge recx "DF_U64"/"DF_U64"\n",
 			recx->recx.rx_idx, recx->recx.rx_nr);
 		d_list_del(&recx->recx_list);
@@ -1595,6 +1676,12 @@ migrate_merge_iod_recx(daos_iod_t *dst_iod, daos_iod_t *src_iod)
 
 	if (dst_iod->iod_recxs != recxs)
 		D_FREE(dst_iod->iod_recxs);
+
+	if (p_dst_ephs && dst_ephs != *p_dst_ephs)
+		D_FREE(*p_dst_ephs);
+
+	if (p_dst_ephs)
+		*p_dst_ephs = dst_ephs;
 
 	dst_iod->iod_recxs = recxs;
 	dst_iod->iod_nr = i;
@@ -1607,8 +1694,9 @@ out:
 }
 
 static int
-migrate_iod_sgl_add(daos_iod_t *iods, uint32_t *iods_num, daos_iod_t *new_iod,
-		    d_sg_list_t *sgls, d_sg_list_t *new_sgl)
+migrate_insert_recxs_sgl(daos_iod_t *iods, daos_epoch_t **iods_ephs, uint32_t *iods_num,
+			 daos_iod_t *new_iod, daos_recx_t *new_recxs, daos_epoch_t *new_ephs,
+			 int new_recxs_nr, d_sg_list_t *sgls, d_sg_list_t *new_sgl)
 {
 	daos_iod_t *dst_iod;
 	int	   rc = 0;
@@ -1627,22 +1715,41 @@ migrate_iod_sgl_add(daos_iod_t *iods, uint32_t *iods_num, daos_iod_t *new_iod,
 
 		if (new_sgl) {
 			rc = daos_sgl_alloc_copy_data(&sgls[i], new_sgl);
-			if (rc) {
-				daos_iov_free(&iods[i].iod_name);
+			if (rc)
 				return rc;
-			}
 		}
 
 		if (new_iod->iod_type == DAOS_IOD_SINGLE) {
 			iods[i].iod_recxs = NULL;
+			if (iods_ephs != NULL) {
+				D_ALLOC_ARRAY(iods_ephs[i], 1);
+				if (iods_ephs[i] == NULL)
+					return -DER_NOMEM;
+				iods_ephs[i][0] = new_ephs[0];
+				iods[i].iod_nr = new_recxs_nr;
+			}
 		} else {
-			/**
-			 * recx in iod has been reused, i.e. it will be
-			 * freed with mrone, so let's set iod_recxs in
-			 * iod to be NULL to avoid it is being freed
-			 * with iod afterwards.
-			 */
-			new_iod->iod_recxs = NULL;
+			int j;
+
+			D_ALLOC_ARRAY(iods[i].iod_recxs, new_recxs_nr);
+			if (iods[i].iod_recxs == NULL)
+				return -DER_NOMEM;
+
+			if (iods_ephs != NULL) {
+				D_ALLOC_ARRAY(iods_ephs[i], new_recxs_nr);
+				if (iods_ephs[i] == NULL) {
+					D_FREE(iods[i].iod_recxs);
+					iods[i].iod_recxs = NULL;
+					return -DER_NOMEM;
+				}
+			}
+
+			for (j = 0; j < new_recxs_nr; j++) {
+				iods[i].iod_recxs[j] = new_recxs[j];
+				if (iods_ephs != NULL)
+					iods_ephs[i][j] = new_ephs[j];
+			}
+			iods[i].iod_nr = new_recxs_nr;
 		}
 		D_DEBUG(DB_REBUILD, "add new akey "DF_KEY" at %d\n",
 			DP_KEY(&new_iod->iod_name), i);
@@ -1662,7 +1769,7 @@ migrate_iod_sgl_add(daos_iod_t *iods, uint32_t *iods_num, daos_iod_t *new_iod,
 		D_GOTO(out, rc);
 	}
 
-	rc = migrate_merge_iod_recx(dst_iod, new_iod);
+	rc = migrate_merge_iod_recx(dst_iod, iods_ephs, new_recxs, new_ephs, new_recxs_nr);
 	if (rc)
 		D_GOTO(out, rc);
 
@@ -1679,12 +1786,12 @@ out:
 }
 
 static int
-rw_iod_pack(struct migrate_one *mrone, daos_iod_t *iod, d_sg_list_t *sgl)
+rw_iod_pack(struct migrate_one *mrone, daos_iod_t *iod, daos_epoch_t *ephs, d_sg_list_t *sgl)
 {
 	uint64_t total_size = 0;
 	int	 rec_cnt = 0;
 	int	 i;
-	int	 rc;
+	int	 rc = 0;
 
 	D_ASSERT(iod->iod_size > 0);
 
@@ -1699,30 +1806,87 @@ rw_iod_pack(struct migrate_one *mrone, daos_iod_t *iod, d_sg_list_t *sgl)
 		rec_cnt = 1;
 		total_size = iod->iod_size;
 		D_DEBUG(DB_REBUILD, "single recx "DF_U64"\n", total_size);
+		rc = migrate_insert_recxs_sgl(mrone->mo_iods, mrone->mo_iods_update_ephs,
+					      &mrone->mo_iod_num, iod, &iod->iod_recxs[0],
+					      &ephs[0], 1, mrone->mo_sgls, sgl);
+		if (rc != 0)
+			D_GOTO(out, rc);
 	} else {
+		int parity_nr = 0;
+		int nr = 0;
+		int start = 0;
+
+		/* For EC object, let's separate the parity rebuild and replicate rebuild to
+		 * make sure both extents are being rebuilt individually.
+		 */
 		for (i = 0; i < iod->iod_nr; i++) {
-			D_DEBUG(DB_REBUILD, "new recx "DF_U64"/"DF_U64"\n",
-				iod->iod_recxs[i].rx_idx,
-				iod->iod_recxs[i].rx_nr);
 			rec_cnt += iod->iod_recxs[i].rx_nr;
 			total_size += iod->iod_recxs[i].rx_nr * iod->iod_size;
+			if (iod->iod_recxs[i].rx_idx & PARITY_INDICATOR) {
+				if (nr > 0) {
+					/* Once there are parity extents, let's add replicate */
+					rc = migrate_insert_recxs_sgl(mrone->mo_iods,
+								      mrone->mo_iods_update_ephs,
+								      &mrone->mo_iod_num, iod,
+								      &iod->iod_recxs[start],
+								      &ephs[start], nr,
+								      mrone->mo_sgls, sgl);
+					if (rc)
+						D_GOTO(out, rc);
+					start = i;
+					nr = 0;
+				}
+				parity_nr++;
+				iod->iod_recxs[i].rx_idx = iod->iod_recxs[i].rx_idx &
+							    ~PARITY_INDICATOR;
+			} else {
+				if (parity_nr > 0) {
+					/* Once there are replicate extents, let's add parity */
+					rc = migrate_insert_recxs_sgl(
+								mrone->mo_iods_from_parity, NULL,
+								&mrone->mo_iods_num_from_parity,
+								iod, &iod->iod_recxs[start],
+								&ephs[start], parity_nr,
+								mrone->mo_sgls, sgl);
+					if (rc)
+						D_GOTO(out, rc);
+					start = i;
+					parity_nr = 0;
+				}
+				nr++;
+			}
+			D_DEBUG(DB_REBUILD, "new recx "DF_U64"/"DF_U64"\n",
+				iod->iod_recxs[i].rx_idx, iod->iod_recxs[i].rx_nr);
+		}
+
+		if (parity_nr > 0) {
+			rc = migrate_insert_recxs_sgl(mrone->mo_iods_from_parity, NULL,
+						     &mrone->mo_iods_num_from_parity, iod,
+						     &iod->iod_recxs[start],
+						     &ephs[start], parity_nr,
+						     mrone->mo_sgls, sgl);
+			if (rc)
+				D_GOTO(out, rc);
+		}
+
+		if (nr > 0) {
+			rc = migrate_insert_recxs_sgl(mrone->mo_iods, mrone->mo_iods_update_ephs,
+						      &mrone->mo_iod_num, iod,
+						      &iod->iod_recxs[start], &ephs[start], nr,
+						      mrone->mo_sgls, sgl);
+			if (rc)
+				D_GOTO(out, rc);
 		}
 	}
 
-	rc = migrate_iod_sgl_add(mrone->mo_iods, &mrone->mo_iod_num, iod,
-				 mrone->mo_sgls, sgl);
-	if (rc != 0)
-		D_GOTO(out, rc);
-
+	mrone->mo_rec_num += rec_cnt;
+	mrone->mo_size += total_size;
+out:
 	D_DEBUG(DB_REBUILD,
 		"idx %d akey "DF_KEY" nr %d size "DF_U64" type %d rec %d total "
 		DF_U64"\n", mrone->mo_iod_num - 1, DP_KEY(&iod->iod_name),
 		iod->iod_nr, iod->iod_size, iod->iod_type, rec_cnt, total_size);
 
-	mrone->mo_rec_num += rec_cnt;
-	mrone->mo_size += total_size;
-
-out:
 	return rc;
 }
 
@@ -1740,8 +1904,8 @@ punch_iod_pack(struct migrate_one *mrone, daos_iod_t *iod, daos_epoch_t eph)
 			return -DER_NOMEM;
 	}
 
-	rc = migrate_iod_sgl_add(mrone->mo_punch_iods, &mrone->mo_punch_iod_num,
-				 iod, NULL, NULL);
+	rc = migrate_insert_recxs_sgl(mrone->mo_punch_iods, NULL, &mrone->mo_punch_iod_num,
+				      iod, iod->iod_recxs, NULL, iod->iod_nr, NULL, NULL);
 	if (rc != 0)
 		D_GOTO(out, rc);
 
@@ -1782,7 +1946,10 @@ migrate_one_merge(struct migrate_one *mo, struct dss_enum_unpack_io *io)
 				continue;
 			if (mo->mo_iods[j].iod_type == DAOS_IOD_ARRAY) {
 				rc = migrate_merge_iod_recx(&mo->mo_iods[j],
-							    &io->ui_iods[i]);
+							    &mo->mo_iods_update_ephs[j],
+							    io->ui_iods[i].iod_recxs,
+							    io->ui_recx_ephs[i],
+							    io->ui_iods[i].iod_nr);
 				if (rc)
 					D_GOTO(out, rc);
 
@@ -1808,13 +1975,11 @@ struct enum_unpack_arg {
 	struct daos_oclass_attr	oc_attr;
 	daos_epoch_range_t	epr;
 	d_list_t		merge_list;
-	uint32_t		iterate_parity:1,
-				invalid_inline_sgl:1;
+	uint32_t		iterate_parity:1;
 };
 
 static int
-migrate_one_insert(struct enum_unpack_arg *arg,
-		   struct dss_enum_unpack_io *io, daos_epoch_t epoch)
+migrate_one_insert(struct enum_unpack_arg *arg, struct dss_enum_unpack_io *io)
 {
 	struct iter_obj_arg	*iter_arg = arg->arg;
 	daos_unit_oid_t		oid = io->ui_oid;
@@ -1826,6 +1991,7 @@ migrate_one_insert(struct enum_unpack_arg *arg,
 	daos_epoch_t		*rec_ephs = io->ui_rec_punch_ephs;
 	int			iod_eph_total = io->ui_iods_top + 1;
 	d_sg_list_t		*sgls = io->ui_sgls;
+	daos_epoch_t		min_eph = DAOS_EPOCH_MAX;
 	uint32_t		version = io->ui_version;
 	struct migrate_pool_tls *tls;
 	struct migrate_one	*mrone = NULL;
@@ -1859,8 +2025,17 @@ migrate_one_insert(struct enum_unpack_arg *arg,
 	if (mrone->mo_iods == NULL)
 		D_GOTO(free, rc = -DER_NOMEM);
 
+	D_ALLOC_ARRAY(mrone->mo_iods_update_ephs, iod_eph_total);
+	if (mrone->mo_iods_update_ephs == NULL)
+		D_GOTO(free, rc = -DER_NOMEM);
+
+	if (daos_oclass_is_ec(&arg->oc_attr)) {
+		D_ALLOC_ARRAY(mrone->mo_iods_from_parity, iod_eph_total);
+		if (mrone->mo_iods_from_parity == NULL)
+			D_GOTO(free, rc = -DER_NOMEM);
+	}
+
 	mrone->mo_epoch = arg->epr.epr_hi;
-	mrone->mo_update_epoch = epoch;
 	mrone->mo_obj_punch_eph = obj_punch_eph;
 	mrone->mo_dkey_punch_eph = dkey_punch_eph;
 	D_ALLOC_ARRAY(mrone->mo_akey_punch_ephs, iod_eph_total);
@@ -1878,8 +2053,7 @@ migrate_one_insert(struct enum_unpack_arg *arg,
 	for (i = 0; i < iod_eph_total; i++) {
 		int j;
 
-		if (sgls[i].sg_nr == 0 || sgls[i].sg_iovs == NULL ||
-		    arg->invalid_inline_sgl) {
+		if (sgls[i].sg_nr == 0 || sgls[i].sg_iovs == NULL) {
 			inline_copy = false;
 			break;
 		}
@@ -1895,8 +2069,12 @@ migrate_one_insert(struct enum_unpack_arg *arg,
 		if (!inline_copy)
 			break;
 	}
+
 	for (i = 0; i < iod_eph_total; i++) {
-		/* Pack punched epoch here */
+		daos_epoch_t *iod_ephs;
+		int j;
+
+		iod_ephs = io->ui_recx_ephs[i];
 		mrone->mo_akey_punch_ephs[i] = akey_ephs[i];
 		if (akey_ephs[i] != 0)
 			D_DEBUG(DB_TRACE, "punched %d akey "DF_KEY" "
@@ -1907,32 +2085,35 @@ migrate_one_insert(struct enum_unpack_arg *arg,
 			continue;
 
 		if (iods[i].iod_size == 0) {
+			/* Pack punched epoch here */
 			rc = punch_iod_pack(mrone, &iods[i], rec_ephs[i]);
 			if (rc)
 				D_GOTO(free, rc);
 		} else {
-			rc = rw_iod_pack(mrone, &iods[i],
-					 inline_copy ? &sgls[i] : NULL);
+			for (j = 0; j < iods[i].iod_nr; j++) {
+				if (iod_ephs[j] != 0)
+					min_eph = min(min_eph, iod_ephs[j]);
+			}
+
+			rc = rw_iod_pack(mrone, &iods[i], iod_ephs, inline_copy ? &sgls[i] : NULL);
 			if (rc)
 				D_GOTO(free, rc);
 		}
 	}
 
+	mrone->mo_min_epoch = min_eph;
+	mrone->mo_version = version;
 	rc = daos_iov_copy(&mrone->mo_csum_iov, &io->ui_csum_iov);
 	if (rc != 0)
 		D_GOTO(free, rc);
-
-	mrone->mo_version = version;
-	D_DEBUG(DB_TRACE, "create migrate dkey ult %d\n", iter_arg->tgt_idx);
 
 	rc = daos_iov_copy(&mrone->mo_dkey, dkey);
 	if (rc != 0)
 		D_GOTO(free, rc);
 
-	D_DEBUG(DB_REBUILD, DF_UOID" %p dkey "DF_KEY" migrate on idx %d"
-		" iod_num %d\n", DP_UOID(mrone->mo_oid), mrone,
-		DP_KEY(dkey), iter_arg->tgt_idx,
-		mrone->mo_iod_num);
+	D_DEBUG(DB_REBUILD, DF_UOID" %p dkey "DF_KEY" migrate on idx %d iod_num %d min eph "DF_U64
+		" ver %u\n", DP_UOID(mrone->mo_oid), mrone, DP_KEY(dkey), iter_arg->tgt_idx,
+		mrone->mo_iod_num, mrone->mo_min_epoch, version);
 
 	d_list_add(&mrone->mo_list, &arg->merge_list);
 
@@ -1953,81 +2134,64 @@ migrate_enum_unpack_cb(struct dss_enum_unpack_io *io, void *data)
 	struct enum_unpack_arg	*arg = data;
 	struct migrate_one	*mo;
 	bool			merged = false;
-	daos_epoch_t		epoch = arg->epr.epr_hi;
 	int			rc = 0;
 	int			i;
 
-	if (daos_oclass_is_ec(&arg->oc_attr)) {
-		/* Convert EC object offset to DAOS offset. */
-		for (i = 0; i <= io->ui_iods_top; i++) {
-			daos_iod_t	*iod = &io->ui_iods[i];
-			uint32_t	shard;
+	if (!daos_oclass_is_ec(&arg->oc_attr))
+		return migrate_one_insert(arg, io);
 
-			if (iod->iod_type == DAOS_IOD_SINGLE)
-				continue;
+	/* Convert EC object offset to DAOS offset. */
+	for (i = 0; i <= io->ui_iods_top; i++) {
+		daos_iod_t	*iod = &io->ui_iods[i];
+		daos_epoch_t	**ephs = &io->ui_recx_ephs[i];
+		uint32_t	shard;
 
-			rc = obj_recx_ec2_daos(&arg->oc_attr,
-					       io->ui_oid.id_shard,
-					       &iod->iod_recxs, &iod->iod_nr);
+		if (iod->iod_type == DAOS_IOD_SINGLE)
+			continue;
+
+		shard = arg->arg->shard % obj_ec_tgt_nr(&arg->oc_attr);
+		/* For data shard, convert to single shard offset */
+		if (is_ec_data_shard(shard, &arg->oc_attr)) {
+			rc = obj_recx_ec2_daos(&arg->oc_attr, io->ui_oid.id_shard,
+					       &iod->iod_recxs, ephs, &iod->iod_nr, false);
 			if (rc != 0)
 				return rc;
 
-			/* After convert to DAOS offset, there might be
-			 * some duplicate recxs due to replication/parity
-			 * space. let's remove them.
-			 */
-			rc = migrate_merge_iod_recx(iod, NULL);
+			D_DEBUG(DB_REBUILD, "convert shard %u tgt %d\n", shard,
+				obj_ec_data_tgt_nr(&arg->oc_attr));
+
+			rc = obj_recx_ec_daos2shard(&arg->oc_attr, shard, &iod->iod_recxs,
+						    ephs, &iod->iod_nr);
 			if (rc)
 				return rc;
 
-			shard = arg->arg->shard % obj_ec_tgt_nr(&arg->oc_attr);
-			/* For data shard, convert to single shard offset */
-			if (shard < obj_ec_data_tgt_nr(&arg->oc_attr)) {
-				D_DEBUG(DB_REBUILD, "convert shard %u tgt %d\n",
-					shard,
-					obj_ec_data_tgt_nr(&arg->oc_attr));
-				/* data shard */
-				rc = obj_recx_ec_daos2shard(&arg->oc_attr,
-							    shard,
-							    &iod->iod_recxs,
-							    &iod->iod_nr);
-				if (rc)
-					return rc;
-
-				/* To avoid aligning  inline sgl, so let's set
-				 * invalid_inline_sgl and force re-fetching
-				 * the online data.
-				 */
-				arg->invalid_inline_sgl = 1;
-				/* No data needs to be migrate. */
-				if (iod->iod_nr == 0)
-					continue;
-				/* NB: data epoch can not be larger than
-				 * parity epoch, otherwise it will cause
-				 * issue in degraded fetch, since it will
-				 * use the parity epoch to fetch data
-				 */
-				if (io->ui_rec_min_ephs[i] < epoch)
-					epoch = io->ui_rec_min_ephs[i];
-			}
+			/* No data needs to be migrate. */
+			if (iod->iod_nr == 0)
+				continue;
+		} else {
+			/* parity shard */
+			rc = obj_recx_ec2_daos(&arg->oc_attr, io->ui_oid.id_shard,
+					       &iod->iod_recxs, ephs, &iod->iod_nr, true);
+			if (rc != 0)
+				return rc;
 		}
+	}
 
-		d_list_for_each_entry(mo, &arg->merge_list, mo_list) {
-			if (daos_oid_cmp(mo->mo_oid.id_pub,
-					 io->ui_oid.id_pub) == 0 &&
-			    daos_key_match(&mo->mo_dkey, &io->ui_dkey)) {
-				rc = migrate_one_merge(mo, io);
-				if (rc != 1) {
-					if (rc == 0)
-						merged = true;
-					break;
-				}
+	d_list_for_each_entry(mo, &arg->merge_list, mo_list) {
+		if (daos_oid_cmp(mo->mo_oid.id_pub,
+				 io->ui_oid.id_pub) == 0 &&
+		    daos_key_match(&mo->mo_dkey, &io->ui_dkey)) {
+			rc = migrate_one_merge(mo, io);
+			if (rc != 1) {
+				if (rc == 0)
+					merged = true;
+				break;
 			}
 		}
 	}
 
 	if (!merged)
-		rc = migrate_one_insert(arg, io, epoch);
+		rc = migrate_one_insert(arg, io);
 
 	return rc;
 }
@@ -2205,7 +2369,6 @@ migrate_one_epoch_object(daos_epoch_range_t *epr, struct migrate_pool_tls *tls,
 				      DIOF_TO_LEADER | DIOF_WITH_SPEC_EPOCH |
 				      DIOF_TO_SPEC_GROUP | DIOF_FOR_MIGRATION);
 retry:
-		unpack_arg.invalid_inline_sgl = 0;
 		rc = dsc_obj_list_obj(oh, epr, NULL, NULL, NULL,
 				     &num, kds, &sgl, &anchor,
 				     &dkey_anchor, &akey_anchor, p_csum);

--- a/src/tests/suite/daos_rebuild.c
+++ b/src/tests/suite/daos_rebuild.c
@@ -22,7 +22,6 @@
 #define OBJ_CLS		OC_RP_3G1
 #define OBJ_REPLICAS	3
 #define DEFAULT_FAIL_TGT 0
-#define REBUILD_POOL_SIZE	(4ULL << 30)
 
 /* Destroy the pool for the sub test */
 static void

--- a/src/tests/suite/daos_rebuild_common.c
+++ b/src/tests/suite/daos_rebuild_common.c
@@ -1006,12 +1006,10 @@ get_killing_rank_by_oid(test_arg_t *arg, daos_obj_id_t oid, int data_nr,
 	while (parity_nr-- > 0)
 		ranks[idx++] = get_rank_by_oid_shard(arg, oid, shard--);
 
-	shard = 0;
+	shard = rand() % oca->u.ec.e_k;
 	while (data_nr-- > 0) {
 		ranks[idx++] = get_rank_by_oid_shard(arg, oid, shard);
-		shard = shard + 2;
-		if (shard > oca->u.ec.e_k)
-			break;
+		shard = (shard + 2) % oca->u.ec.e_k;
 	}
 
 	if (ranks_num)
@@ -1065,7 +1063,7 @@ rebuild_small_sub_setup(void **state)
 
 	save_group_state(state);
 	rc = test_setup(state, SETUP_CONT_CONNECT, true,
-			REBUILD_SMALL_POOL_SIZE, 0, NULL);
+			REBUILD_POOL_SIZE, 0, NULL);
 	if (rc)
 		return rc;
 

--- a/src/tests/suite/daos_rebuild_ec.c
+++ b/src/tests/suite/daos_rebuild_ec.c
@@ -59,11 +59,11 @@ rebuild_ec_internal(void **state, uint16_t oclass, int kill_data_nr,
 	 * verify degrade fetch is correct.
 	 */
 	if (oclass == OC_EC_2P1G1) {
-		get_killing_rank_by_oid(arg, oid, 2, 0, extra_kill_ranks, NULL);
-		rebuild_pools_ranks(&arg, 1, &extra_kill_ranks[1], 1, false);
+		get_killing_rank_by_oid(arg, oid, 1, 0, extra_kill_ranks, NULL);
+		rebuild_pools_ranks(&arg, 1, &extra_kill_ranks[0], 1, false);
 	} else { /* oclass OC_EC_4P2G1 */
-		get_killing_rank_by_oid(arg, oid, 4, 0, extra_kill_ranks, NULL);
-		rebuild_pools_ranks(&arg, 1, &extra_kill_ranks[2], 2, false);
+		get_killing_rank_by_oid(arg, oid, 2, 0, extra_kill_ranks, NULL);
+		rebuild_pools_ranks(&arg, 1, &extra_kill_ranks[0], 2, false);
 	}
 
 	if (write_type == PARTIAL_UPDATE)
@@ -262,7 +262,7 @@ rebuild_ec_setup(void  **state, int number)
 
 	save_group_state(state);
 	rc = test_setup(state, SETUP_POOL_CONNECT, true,
-			REBUILD_SMALL_POOL_SIZE, number, NULL);
+			REBUILD_POOL_SIZE, number, NULL);
 	if (rc) {
 		/* Let's skip for this case, since it is possible there
 		 * is not enough ranks here.

--- a/src/tests/suite/daos_test.h
+++ b/src/tests/suite/daos_test.h
@@ -220,6 +220,7 @@ enum {
 
 #define SMALL_POOL_SIZE		(1ULL << 30)	/* 1GB */
 #define DEFAULT_POOL_SIZE	(4ULL << 30)	/* 4GB */
+#define REBUILD_POOL_SIZE	(4ULL << 30)
 
 #define REBUILD_SUBTEST_POOL_SIZE (1ULL << 30)
 #define REBUILD_SMALL_POOL_SIZE (1ULL << 28)


### PR DESCRIPTION
1. Add random rank failed for EC rebuild test.

2. Add DIOF_EC_RECOV_FROM_PARITY and VOS_OF_SKIP_FETCH to
split the partial EC overwrite rebuild into 2 steps.
    1) reconstruct the data from the parity rebuild.
    2) reconstruct the data from replicate data on the pairty.
So the parity will not be corrupted before EC aggregation.

3. Remember recx epoch during migration unpack, so the parity
rebuild will use the maxim epoch from all data shards, to make
sure the right shadow epoch will be chosen during degraded fetch
after rebuild.

4. Remove obsolete invalid_inline_sgl, since EC rebuild will not fetch
inline data anyway.

5. enlarge some rebuild tests pool size to avoid ENOSPACE error.
Signed-off-by: Di Wang <di.wang@intel.com>