### PR TITLE
DAOS-7321 Test: Add test case to verify container EC cell size property.

### DIFF
--- a/src/tests/ftest/erasurecode/ec_cell_size_property.py
+++ b/src/tests/ftest/erasurecode/ec_cell_size_property.py
@@ -7,7 +7,6 @@
 from itertools import product
 
 from ior_test_base import IorTestBase
-from daos_utils import DaosCommand
 from general_utils import human_to_bytes
 from apricot import skipForTicket
 

--- a/src/tests/ftest/erasurecode/ec_cell_size_property.py
+++ b/src/tests/ftest/erasurecode/ec_cell_size_property.py
@@ -9,6 +9,7 @@ from itertools import product
 from ior_test_base import IorTestBase
 from daos_utils import DaosCommand
 from general_utils import human_to_bytes
+from apricot import skipForTicket
 
 class EcodCellSizeProperty(IorTestBase):
     # pylint: disable=too-many-ancestors
@@ -49,6 +50,8 @@ class EcodCellSizeProperty(IorTestBase):
         cont_cell_size = (human_to_bytes(cell_size.replace(" ", "")))
         self.assertEqual(expected_size, cont_cell_size)
 
+
+    @skipForTicket("DAOS-8051")
     def test_ec_pool_property(self):
         """Jira ID: DAOS-7321.
 

--- a/src/tests/ftest/erasurecode/ec_cell_size_property.py
+++ b/src/tests/ftest/erasurecode/ec_cell_size_property.py
@@ -27,7 +27,7 @@ class EcodCellSizeProperty(IorTestBase):
         Args:
             expected_size (int): expected container cell size
         """
-        daos_cmd = self.get_daos_command()      
+        daos_cmd = self.get_daos_command()
         cont_prop = daos_cmd.container_get_prop(self.pool.uuid,
                                                 self.container.uuid)
         cont_prop_stdout = cont_prop.stdout_text

--- a/src/tests/ftest/erasurecode/ec_cell_size_property.py
+++ b/src/tests/ftest/erasurecode/ec_cell_size_property.py
@@ -21,18 +21,6 @@ class EcodCellSizeProperty(IorTestBase):
 
     :avocado: recursive
     """
-    def __init__(self, *args, **kwargs):
-        """Initialize a EcodCellSizeProperty object."""
-        super().__init__(*args, **kwargs)
-        self.daos_cmd = None
-
-    def setUp(self):
-        """Set up test case."""
-        super().setUp()
-
-        # initialize daos command
-        self.daos_cmd = DaosCommand(self.bin)
-
     def verify_cont_ec_cell_size(self, expected_size):
         """
         Verify the container EC cell size property.
@@ -40,8 +28,9 @@ class EcodCellSizeProperty(IorTestBase):
         Args:
             expected_size (int): expected container cell size
         """
-        cont_prop = self.daos_cmd.container_get_prop(self.pool.uuid,
-                                                     self.container.uuid)
+        daos_cmd = self.get_daos_command()      
+        cont_prop = daos_cmd.container_get_prop(self.pool.uuid,
+                                                self.container.uuid)
         cont_prop_stdout = cont_prop.stdout_text
         prop_list = cont_prop_stdout.split('\n')[1:]
         cont_index = [i for i, word in enumerate(prop_list)
@@ -49,7 +38,6 @@ class EcodCellSizeProperty(IorTestBase):
         cell_size = (prop_list[cont_index].split('EC Cell Size')[1].strip())
         cont_cell_size = (human_to_bytes(cell_size.replace(" ", "")))
         self.assertEqual(expected_size, cont_cell_size)
-
 
     @skipForTicket("DAOS-8051")
     def test_ec_pool_property(self):
@@ -89,7 +77,7 @@ class EcodCellSizeProperty(IorTestBase):
         for tx_size, cont_cell in product(ior_transfer_size,
                                           cont_cell_size):
             # Initial container
-            self.add_container(self.pool)
+            self.add_container(self.pool, create=False)
 
             # Use the default pool property for container and do not update
             if cont_cell != pool_prop_expected:

--- a/src/tests/ftest/erasurecode/ec_cell_size_property.py
+++ b/src/tests/ftest/erasurecode/ec_cell_size_property.py
@@ -1,0 +1,112 @@
+#!/usr/bin/python
+'''
+  (C) Copyright 2020-2021 Intel Corporation.
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+'''
+from itertools import product
+
+from ior_test_base import IorTestBase
+from daos_utils import DaosCommand
+from general_utils import human_to_bytes
+
+class EcodCellSizeProperty(IorTestBase):
+    # pylint: disable=too-many-ancestors
+    # pylint: disable=too-few-public-methods
+    """EC IOR class to run tests with different container cell size.
+
+    Test Class Description: To validate Erasure code object works with
+                            different EC cell sizes property.
+
+    :avocado: recursive
+    """
+    def __init__(self, *args, **kwargs):
+        """Initialize a EcodCellSizeProperty object."""
+        super().__init__(*args, **kwargs)
+        self.daos_cmd = None
+
+    def setUp(self):
+        """Set up test case."""
+        super().setUp()
+
+        # initialize daos command
+        self.daos_cmd = DaosCommand(self.bin)
+
+    def verify_cont_ec_cell_size(self, expected_size):
+        """
+        Verify the container EC cell size property.
+
+        Args:
+            expected_size (int): expected container cell size
+        """
+        cont_prop = self.daos_cmd.container_get_prop(self.pool.uuid,
+                                                     self.container.uuid)
+        cont_prop_stdout = cont_prop.stdout_text
+        prop_list = cont_prop_stdout.split('\n')[1:]
+        cont_index = [i for i, word in enumerate(prop_list)
+                      if word.startswith('EC Cell Size')][0]
+        cell_size = (prop_list[cont_index].split('EC Cell Size')[1].strip())
+        cont_cell_size = (human_to_bytes(cell_size.replace(" ", "")))
+        self.assertEqual(expected_size, cont_cell_size)
+
+    def test_ec_pool_property(self):
+        """Jira ID: DAOS-7321.
+
+        Test Description:
+            Verify container cell sized is picked from container property
+            and not the pool default cell size.
+
+        Use Case:
+            Create the Pool with different EC cell size
+            Create the container and verify the ec_cell_sz is same for both
+                pool and container.
+            Create the container with different EC cell size
+            Verify the ec_cell_sz is updated for the container.
+            Run IOR with data verification.
+            Verify the cont ec_cell_sz property after IOR.
+
+        :avocado: tags=all,full_regression
+        :avocado: tags=hw,large,ib2
+        :avocado: tags=ec,ec_ior
+        :avocado: tags=ec_cell_property
+        """
+        ior_transfer_size = self.params.get("ior_transfer_size",
+                                            '/run/ior/iorflags/*')
+        cont_cell_size = self.params.get("cont_cell_size",
+                                         '/run/container/*')
+        # Create the pool
+        self.add_pool()
+
+        # Verify pool EC cell size
+        pool_prop_expected = int(self.pool.properties.value.split(":")[1])
+        self.assertEqual(pool_prop_expected,
+                         self.pool.get_property("ec_cell_sz"))
+
+        # Run IOR for different Transfer size and container cell size.
+        for tx_size, cont_cell in product(ior_transfer_size,
+                                          cont_cell_size):
+            # Initial container
+            self.add_container(self.pool)
+
+            # Use the default pool property for container and do not update
+            if cont_cell != pool_prop_expected:
+                self.container.properties.update("ec_cell:{}"
+                                                 .format(cont_cell))
+
+            # Create the container and open handle
+            self.container.create()
+            self.container.open()
+
+            # Verify container EC cell size property
+            self.verify_cont_ec_cell_size(cont_cell)
+
+            # Update IOR Command and Run
+            self.update_ior_cmd_with_pool(create_cont=False)
+            self.ior_cmd.transfer_size.update(tx_size)
+            self.run_ior_with_pool(create_pool=False, create_cont=False)
+
+            # Verify container EC cell size property after IOR
+            self.verify_cont_ec_cell_size(cont_cell)
+
+            # Destroy the container.
+            self.container.destroy()

--- a/src/tests/ftest/erasurecode/ec_cell_size_property.yaml
+++ b/src/tests/ftest/erasurecode/ec_cell_size_property.yaml
@@ -1,0 +1,74 @@
+hosts:
+  test_servers:
+    - server-A
+    - server-B
+    - server-C
+    - server-D
+    - server-E
+  test_clients:
+    - server-F
+    - server-G
+    - server-H
+timeout: 900
+server_config:
+  engines_per_host: 2
+  name: daos_server
+  servers:
+    0:
+      pinned_numa_node: 0
+      nr_xs_helpers: 1
+      fabric_iface: ib0
+      fabric_iface_port: 31317
+      log_file: daos_server0.log
+      bdev_class: nvme
+      bdev_list: ["aaaa:aa:aa.a"]
+      scm_class: dcpm
+      scm_list: ["/dev/pmem0"]
+      scm_mount: /mnt/daos0
+      log_mask: ERR
+    1:
+      pinned_numa_node: 1
+      nr_xs_helpers: 1
+      fabric_iface: ib1
+      fabric_iface_port: 31417
+      log_file: daos_server1.log
+      bdev_class: nvme
+      bdev_list: ["bbbb:bb:bb.b"]
+      scm_class: dcpm
+      scm_list: ["/dev/pmem1"]
+      scm_mount: /mnt/daos1
+      log_mask: ERR
+pool:
+    name: daos_server
+    control_method: dmg
+    scm_size: 25%
+    nvme_size: 93%
+    cell_size: !mux
+      cell_size_4K:
+        properties: ec_cell_sz:4096
+      cell_size_64K:
+        properties: ec_cell_sz:65536
+      cell_size_111K:
+        properties: ec_cell_sz:131072
+container:
+    type: POSIX
+    control_method: daos
+    cont_cell_size:
+      - 4096
+      - 65536
+      - 131072
+      - 1048576
+ior:
+  api: "DFS"
+  client_processes:
+    np: 48
+  dfs_destroy: False
+  iorflags:
+      flags: "-w -W -r -R -G 1 -vv"
+  test_file: /testFile
+  repetitions: 1
+  ior_transfer_size:
+    - 8M
+    - 4K
+  block_size: 64M
+  dfs_oclass: "EC_8P2GX"

--- a/src/tests/ftest/util/dmg_utils.py
+++ b/src/tests/ftest/util/dmg_utils.py
@@ -692,6 +692,24 @@ class DmgCommand(DmgCommandBase):
         return self._get_result(
             ("pool", "set-prop"), pool=pool, name=name, value=value)
 
+    def pool_get_prop(self, pool, name):
+        """Get the Property for a given pool.
+
+        Args:
+            pool (str): Pool for which to get the property.
+            name (str): Get the Property value based on name.
+
+        Returns:
+            CmdResult: Object that contains exit status, stdout, and other
+                information.
+
+        Raises:
+            CommandFailure: if the dmg pool get-prop command fails.
+
+        """
+        return self._get_json_result(
+            ("pool", "get-prop {} {}".format(pool, name)))
+
     def pool_exclude(self, pool, rank, tgt_idx=None):
         """Exclude a daos_server from the pool.
 

--- a/src/tests/ftest/util/test_utils_pool.py
+++ b/src/tests/ftest/util/test_utils_pool.py
@@ -8,6 +8,7 @@
 import os
 from time import sleep, time
 import ctypes
+import json
 
 from test_utils_base import TestDaosApiBase
 
@@ -416,6 +417,40 @@ class TestPool(TestDaosApiBase):
                 self.log.error(
                     "Error: Undefined control_method: %s",
                     self.control_method.value)
+
+    @fail_on(CommandFailure)
+    def get_property(self, prop_name):
+        """Get Property.
+
+        It gets property for a given pool uuid using dmg.
+
+        Args:
+            prop_name (str): Name of the pool property.
+
+        Returns:
+            prop_value (str): Return pool property value.
+
+        """
+        prop_value = ""
+        if self.pool:
+            self.log.info("Get-prop for Pool: %s", self.identifier)
+
+            if self.control_method.value == self.USE_DMG and self.dmg:
+                # If specific property are not provided, get all the property
+                self.dmg.pool_get_prop(self.identifier, prop_name)
+                
+                if self.dmg.result.exit_status == 0:
+                    prop_value = json.loads(
+                        self.dmg.result.stdout)['response'][0]['value']
+
+            elif self.control_method.value == self.USE_DMG:
+                self.log.error("Error: Undefined dmg command")
+
+            else:
+                self.log.error(
+                    "Error: Undefined control_method: %s",
+                    self.control_method.value)
+        return prop_value
 
     @fail_on(CommandFailure)
     def evict(self):

--- a/src/tests/ftest/util/test_utils_pool.py
+++ b/src/tests/ftest/util/test_utils_pool.py
@@ -438,7 +438,7 @@ class TestPool(TestDaosApiBase):
             if self.control_method.value == self.USE_DMG and self.dmg:
                 # If specific property are not provided, get all the property
                 self.dmg.pool_get_prop(self.identifier, prop_name)
-                
+
                 if self.dmg.result.exit_status == 0:
                     prop_value = json.loads(
                         self.dmg.result.stdout)['response'][0]['value']


### PR DESCRIPTION
Verify cell size is picked based on container property if it's set.
By default container cell size will be the same as the pool cell size.

Quick-Functional: true
Test-tag: ec_cell_property

Signed-off-by: Samir Raval <samir.raval@intel.com>