### PR TITLE
DAOS-7361 bio: fix to use realtime for nvme poll

### DIFF
--- a/src/bio/bio_monitor.c
+++ b/src/bio/bio_monitor.c
@@ -595,7 +595,7 @@ get_spdk_health_info_completion(struct spdk_bdev_io *bdev_io, bool success,
 	D_ASSERT(bdev != NULL);
 
 	/* Store device health info in in-memory health state log. */
-	dev_health->bdh_health_state.timestamp = dev_health->bdh_stat_age;
+	dev_health->bdh_health_state.timestamp = daos_wallclock_secs();
 	populate_health_stats(dev_health);
 
 	/* Prep NVMe command to get SPDK Intel NVMe SSD Smart Attributes */

--- a/src/include/daos/common.h
+++ b/src/include/daos/common.h
@@ -245,6 +245,22 @@ daos_getntime_coarse(void)
 }
 
 static inline uint64_t
+daos_wallclock_secs(void)
+{
+	struct timespec         now;
+	int                     rc;
+
+	rc = clock_gettime(CLOCK_REALTIME, &now);
+	if (rc) {
+		D_ERROR("clock_gettime failed, rc: %d, errno %d(%s).\n",
+			rc, errno, strerror(errno));
+		return 0;
+	}
+
+	return now.tv_sec;
+}
+
+static inline uint64_t
 daos_getmtime_coarse(void)
 {
 	return daos_getntime_coarse() / NSEC_PER_MSEC;


### PR DESCRIPTION
Currently we used CLOCK_MONOTONIC to get time for nvme poll,
this could have problem since we need export polling timestamps
for 'dmg storage scan --nvme-health'.

Another problem is control plane interpret timestamp
as seconds, fix it.

Signed-off-by: Wang Shilong <shilong.wang@intel.com>