### PR TITLE
Fix a potential deadlock issue on the lock &ioil_iog.iog_lock

### DIFF
--- a/src/client/dfuse/il/int_posix.c
+++ b/src/client/dfuse/il/int_posix.c
@@ -716,6 +716,7 @@ check_ioctl_on_open(int fd, struct fd_entry *entry, int flags, int status)
 			DFUSE_LOG_DEBUG("daos_init() failed, "DF_RC,
 					DP_RC(rc));
 			ioil_iog.iog_no_daos = true;
+			pthread_mutex_unlock(&ioil_iog.iog_lock);
 			return false;
 		}
 		ioil_iog.iog_daos_init = true;


### PR DESCRIPTION
Fix a potential deadlock issue on the lock &ioil_iog.iog_lock.
The problem here is that the lock ioil_iog.iog_lock will become an unreleased lock if the program returns at line 719. 

Signed-off-by: Yuandao Ryan Cai <ycaibb@gmail.com>