### PR TITLE
DAOS-7479 container: query return number of snapshots

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -34,7 +34,7 @@ def get_version():
         return version_file.read().rstrip()
 
 API_VERSION_MAJOR = "1"
-API_VERSION_MINOR = "4"
+API_VERSION_MINOR = "5"
 API_VERSION_FIX = "0"
 API_VERSION = "{}.{}.{}".format(API_VERSION_MAJOR, API_VERSION_MINOR,
                                 API_VERSION_FIX)

--- a/src/client/pydaos/raw/daos_cref.py
+++ b/src/client/pydaos/raw/daos_cref.py
@@ -140,8 +140,7 @@ class ContInfo(ctypes.Structure):
                 ("ci_lsnapshots", ctypes.c_uint64),
                 ("ci_redun_fac", ctypes.c_uint32),
                 ("ci_nsnapshots", ctypes.c_uint32),
-                ("ci_snapshots", ctypes.POINTER(ctypes.c_uint64)),
-                ("ci_hae", ctypes.c_uint64)]
+                ("ci_pad", ctypes.c_uint64 * 2)]
 
 
 class DaosEvent(ctypes.Structure):

--- a/src/container/cli.c
+++ b/src/container/cli.c
@@ -770,9 +770,8 @@ cont_open_complete(tse_task_t *task, void *data)
 	uuid_copy(arg->coa_info->ci_uuid, cont->dc_uuid);
 	arg->coa_info->ci_redun_fac = cont->dc_props.dcp_redun_fac;
 
+	arg->coa_info->ci_nsnapshots = out->coo_snap_count;
 	/* TODO */
-	arg->coa_info->ci_nsnapshots = 0;
-	arg->coa_info->ci_snapshots = NULL;
 	arg->coa_info->ci_lsnapshot = 0;
 
 out:
@@ -1157,12 +1156,10 @@ cont_query_complete(tse_task_t *task, void *data)
 
 	uuid_copy(arg->cqa_info->ci_uuid, cont->dc_uuid);
 
-	arg->cqa_info->ci_hae = out->cqo_hae;
 	arg->cqa_info->ci_redun_fac = cont->dc_props.dcp_redun_fac;
 
+	arg->cqa_info->ci_nsnapshots = out->cqo_snap_count;
 	/* TODO */
-	arg->cqa_info->ci_nsnapshots = 0;
-	arg->cqa_info->ci_snapshots = NULL;
 	arg->cqa_info->ci_lsnapshot = 0;
 
 out:
@@ -1302,8 +1299,6 @@ dc_cont_query(tse_task_t *task)
 	uuid_copy(in->cqi_op.ci_uuid, cont->dc_uuid);
 	uuid_copy(in->cqi_op.ci_hdl, cont->dc_cont_hdl);
 	in->cqi_bits = cont_query_bits(args->prop);
-	if (args->info != NULL)
-		in->cqi_bits |= DAOS_CO_QUERY_TGT;
 
 	arg.cqa_pool = pool;
 	arg.cqa_cont = cont;
@@ -2949,6 +2944,9 @@ dc_cont_list_snap(tse_task_t *task)
 			.sg_nr	   = 1,
 			.sg_iovs   = &iov
 		};
+
+		/* TODO: iovs for names[] and list_snap bulk create function */
+
 		rc = crt_bulk_create(daos_task2ctx(task), &sgl,
 				     CRT_BULK_RW, &in->sli_bulk);
 		if (rc != 0) {

--- a/src/container/rpc.h
+++ b/src/container/rpc.h
@@ -24,7 +24,7 @@
  * These are for daos_rpc::dr_opc and DAOS_RPC_OPCODE(opc, ...) rather than
  * crt_req_create(..., opc, ...). See src/include/daos/rpc.h.
  */
-#define DAOS_CONT_VERSION 4
+#define DAOS_CONT_VERSION 5
 /* LIST of internal RPCS in form of:
  * OPCODE, flags, FMT, handler, corpc_hdlr,
  */
@@ -179,7 +179,9 @@ CRT_RPC_DECLARE(cont_destroy_bylabel, DAOS_ISEQ_CONT_DESTROY_BYLABEL,
 
 #define DAOS_OSEQ_CONT_OPEN	/* output fields */		 \
 	((struct cont_op_out)	(coo_op)		CRT_VAR) \
-	((daos_prop_t)		(coo_prop)		CRT_PTR)
+	((daos_prop_t)		(coo_prop)		CRT_PTR) \
+	((uint32_t)		(coo_snap_count)	CRT_VAR) \
+	((uint32_t)		(coo_pad)		CRT_VAR)
 
 CRT_RPC_DECLARE(cont_open, DAOS_ISEQ_CONT_OPEN, DAOS_OSEQ_CONT_OPEN)
 
@@ -246,8 +248,9 @@ CRT_RPC_DECLARE(cont_close, DAOS_ISEQ_CONT_CLOSE, DAOS_OSEQ_CONT_CLOSE)
 /** Add more items to query when needed */
 #define DAOS_OSEQ_CONT_QUERY	/* output fields */		 \
 	((struct cont_op_out)	(cqo_op)		CRT_VAR) \
-	((daos_epoch_t)		(cqo_hae)		CRT_VAR) \
-	((daos_prop_t)		(cqo_prop)		CRT_PTR)
+	((daos_prop_t)		(cqo_prop)		CRT_PTR) \
+	((uint32_t)		(cqo_snap_count)	CRT_VAR) \
+	((uint32_t)		(cqo_pad)		CRT_VAR)
 
 CRT_RPC_DECLARE(cont_query, DAOS_ISEQ_CONT_QUERY, DAOS_OSEQ_CONT_QUERY)
 
@@ -346,6 +349,9 @@ struct cont_tgt_close_rec {
 	daos_epoch_t	tcr_hce;
 };
 
+/* TODO: more tgt query information ; and decide if tqo_hae is needed at all
+ * (e.g., CONT_QUERY cqo_hae has been removed).
+ */
 #define DAOS_ISEQ_TGT_QUERY	/* input fields */		 \
 	((uuid_t)		(tqi_pool_uuid)		CRT_VAR) \
 	((uuid_t)		(tqi_cont_uuid)		CRT_VAR)

--- a/src/container/srv_container.c
+++ b/src/container/srv_container.c
@@ -3355,13 +3355,7 @@ cont_op_with_cont(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl,
 		/* Look up the container handle. */
 		d_iov_set(&key, in->ci_hdl, sizeof(uuid_t));
 		d_iov_set(&value, &hdl, sizeof(hdl));
-		D_DEBUG(DF_DSMS, DF_CONT": lookup hdl "DF_UUID", len before=%lu\n",
-			DP_CONT(cont->c_svc->cs_pool_uuid, cont->c_uuid), DP_UUID(in->ci_hdl),
-			sizeof(hdl));
 		rc = rdb_tx_lookup(tx, &cont->c_svc->cs_hdls, &key, &value);
-		D_DEBUG(DF_DSMS, DF_CONT": lookup hdl "DF_UUID", after len=%lu, buf_len=%lu\n",
-			DP_CONT(cont->c_svc->cs_pool_uuid, cont->c_uuid), DP_UUID(in->ci_hdl),
-			value.iov_len, value.iov_buf_len);
 		if (rc != 0) {
 			if (rc == -DER_NONEXIST) {
 				D_ERROR(DF_CONT": rejecting unauthorized "

--- a/src/container/srv_container.c
+++ b/src/container/srv_container.c
@@ -349,6 +349,7 @@ ds_cont_init_metadata(struct rdb_tx *tx, const rdb_path_t *kvs,
 		return rc;
 	}
 
+
 	attr.dsa_class = RDB_KVS_GENERIC;
 	attr.dsa_order = 16;
 	rc = rdb_tx_create_kvs(tx, kvs, &ds_cont_prop_cont_handles, &attr);
@@ -718,6 +719,7 @@ cont_create(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl,
 	struct daos_prop_entry *lbl_ent;
 	struct daos_prop_entry *def_lbl_ent;
 	d_string_t		lbl = NULL;
+	uint32_t		nsnapshots = 0;
 	int			rc;
 
 	D_DEBUG(DF_DSMS, DF_CONT": processing rpc %p\n",
@@ -851,14 +853,19 @@ cont_create(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl,
 	}
 
 	/* Create the snapshot KVS. */
+	d_iov_set(&value, &nsnapshots, sizeof(nsnapshots));
+	rc = rdb_tx_update(tx, &kvs, &ds_cont_prop_nsnapshots, &value);
+	if (rc != 0) {
+		D_ERROR(DF_CONT": failed to update nsnapshots, "DF_RC"\n",
+			DP_CONT(pool_hdl->sph_pool->sp_uuid, in->cci_op.ci_uuid), DP_RC(rc));
+		D_GOTO(out_kvs, rc);
+	}
 	attr.dsa_class = RDB_KVS_INTEGER;
 	attr.dsa_order = 16;
 	rc = rdb_tx_create_kvs(tx, &kvs, &ds_cont_prop_snapshots, &attr);
 	if (rc != 0) {
-		D_ERROR(DF_CONT" failed to create container snapshots KVS: "
-			""DF_RC"\n",
-			DP_CONT(pool_hdl->sph_pool->sp_uuid,
-				in->cci_op.ci_uuid), DP_RC(rc));
+		D_ERROR(DF_CONT" failed to create container snapshots KVS: "DF_RC"\n",
+			DP_CONT(pool_hdl->sph_pool->sp_uuid, in->cci_op.ci_uuid), DP_RC(rc));
 	}
 
 	/* Create the user attribute KVS. */
@@ -1633,6 +1640,7 @@ cont_open(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl, struct cont *cont,
 	bool			cont_hdl_opened = false;
 	uint32_t		stat_pm_ver = 0;
 	uint64_t		sec_capas = 0;
+	uint32_t		snap_count;
 
 	D_DEBUG(DF_DSMS, DF_CONT": processing rpc %p: hdl="DF_UUID" flags="
 		DF_X64"\n",
@@ -1759,6 +1767,18 @@ cont_open(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl, struct cont *cont,
 	rc = rdb_tx_update(tx, &cont->c_hdls, &key, &value);
 	if (rc != 0)
 		goto out;
+
+	/* Get nsnapshots */
+	d_iov_set(&value, &snap_count, sizeof(snap_count));
+	rc = rdb_tx_lookup(tx, &cont->c_prop, &ds_cont_prop_nsnapshots, &value);
+	if (rc != 0) {
+		D_ERROR(DF_CONT": failed to lookup nsnapshots, "DF_RC"\n",
+			DP_CONT(cont->c_svc->cs_pool_uuid, cont->c_uuid), DP_RC(rc));
+		goto out;
+	}
+	out->coo_snap_count = snap_count;
+	D_DEBUG(DF_DSMS, DF_CONT": got nsnapshots=%u on open\n",
+		DP_CONT(cont->c_svc->cs_pool_uuid, cont->c_uuid), snap_count);
 
 out:
 	if (rc == 0) {
@@ -1957,6 +1977,9 @@ out:
 	return rc;
 }
 
+/* TODO: decide if tqo_hae is needed at all; and query for more information.
+ * Currently this does not do much and is not used. Kept for future expansion.
+ */
 static int
 cont_query_bcast(crt_context_t ctx, struct cont *cont, const uuid_t pool_hdl,
 		 const uuid_t cont_hdl, struct cont_query_out *query_out)
@@ -1994,7 +2017,7 @@ cont_query_bcast(crt_context_t ctx, struct cont *cont, const uuid_t pool_hdl,
 			DP_CONT(cont->c_svc->cs_pool_uuid, cont->c_uuid), rc);
 		D_GOTO(out_rpc, rc = -DER_IO);
 	} else {
-		query_out->cqo_hae = out->tqo_hae;
+		/* cqo_hae removed: query_out->cqo_hae = out->tqo_hae; */
 	}
 
 out_rpc:
@@ -2367,6 +2390,8 @@ cont_query(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl, struct cont *cont,
 	struct cont_query_out  *out = crt_reply_get(rpc);
 	daos_prop_t	       *prop = NULL;
 	uint32_t		last_ver = 0;
+	d_iov_t			value;
+	int			snap_count;
 	int			rc = 0;
 
 	D_DEBUG(DF_DSMS, DF_CONT": processing rpc %p: hdl="DF_UUID"\n",
@@ -2376,10 +2401,21 @@ cont_query(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl, struct cont *cont,
 	if (!hdl_has_query_access(hdl, cont, in->cqi_bits))
 		return -DER_NO_PERM;
 
+	/* Get nsnapshots */
+	d_iov_set(&value, &snap_count, sizeof(snap_count));
+	rc = rdb_tx_lookup(tx, &cont->c_prop, &ds_cont_prop_nsnapshots, &value);
+	if (rc != 0) {
+		D_ERROR(DF_CONT": failed to lookup nsnapshots, "DF_RC"\n",
+			DP_CONT(cont->c_svc->cs_pool_uuid, cont->c_uuid), DP_RC(rc));
+		return rc;
+	}
+	out->cqo_snap_count = snap_count;
+
 	/* need RF to process co_status */
 	if (in->cqi_bits & DAOS_CO_QUERY_PROP_CO_STATUS)
 		in->cqi_bits |= DAOS_CO_QUERY_PROP_REDUN_FAC;
 
+	/* Currently DAOS_CO_QUERY_TGT not used; code kept for future expansion. */
 	if (in->cqi_bits & DAOS_CO_QUERY_TGT) {
 		/* need RF if user query cont_info */
 		in->cqi_bits |= DAOS_CO_QUERY_PROP_REDUN_FAC;
@@ -3319,7 +3355,13 @@ cont_op_with_cont(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl,
 		/* Look up the container handle. */
 		d_iov_set(&key, in->ci_hdl, sizeof(uuid_t));
 		d_iov_set(&value, &hdl, sizeof(hdl));
+		D_DEBUG(DF_DSMS, DF_CONT": lookup hdl "DF_UUID", len before=%lu\n",
+			DP_CONT(cont->c_svc->cs_pool_uuid, cont->c_uuid), DP_UUID(in->ci_hdl),
+			sizeof(hdl));
 		rc = rdb_tx_lookup(tx, &cont->c_svc->cs_hdls, &key, &value);
+		D_DEBUG(DF_DSMS, DF_CONT": lookup hdl "DF_UUID", after len=%lu, buf_len=%lu\n",
+			DP_CONT(cont->c_svc->cs_pool_uuid, cont->c_uuid), DP_UUID(in->ci_hdl),
+			value.iov_len, value.iov_buf_len);
 		if (rc != 0) {
 			if (rc == -DER_NONEXIST) {
 				D_ERROR(DF_CONT": rejecting unauthorized "

--- a/src/container/srv_epoch.c
+++ b/src/container/srv_epoch.c
@@ -62,9 +62,9 @@ snap_list_iter_cb(daos_handle_t ih, d_iov_t *key, d_iov_t *val,
 	return 0;
 }
 
+/* Read snapshot epochs from rdb (TODO: add names) */
 static int
-read_snap_list(struct rdb_tx *tx, struct cont *cont,
-	       daos_epoch_t **buf, int *count)
+read_snap_list(struct rdb_tx *tx, struct cont *cont, daos_epoch_t **buf, int *count)
 {
 	struct snap_list_iter_args iter_args;
 	int rc;
@@ -151,6 +151,7 @@ snap_create_bcast(struct rdb_tx *tx, struct cont *cont, uuid_t coh_uuid,
 	char					 zero = 0;
 	d_iov_t					 key;
 	d_iov_t					 value;
+	uint32_t				 nsnapshots;
 	int					 rc;
 
 	rc = ds_cont_bcast_create(ctx, cont->c_svc,
@@ -187,6 +188,22 @@ snap_create_bcast(struct rdb_tx *tx, struct cont *cont, uuid_t coh_uuid,
 			DP_CONT(cont->c_svc->cs_pool_uuid, cont->c_uuid), rc);
 		goto out_rpc;
 	}
+	/* Update number of snapshots */
+	d_iov_set(&value, &nsnapshots, sizeof(nsnapshots));
+	rc = rdb_tx_lookup(tx, &cont->c_prop, &ds_cont_prop_nsnapshots, &value);
+	if (rc != 0) {
+		D_ERROR(DF_CONT": failed to lookup nsnapshots, "DF_RC"\n",
+			DP_CONT(cont->c_svc->cs_pool_uuid, cont->c_uuid), DP_RC(rc));
+		goto out_rpc;
+	}
+	nsnapshots++;
+	rc = rdb_tx_update(tx, &cont->c_prop, &ds_cont_prop_nsnapshots, &value);
+	if (rc != 0) {
+		D_ERROR(DF_CONT": failed to update nsnapshots, "DF_RC"\n",
+			DP_CONT(cont->c_svc->cs_pool_uuid, cont->c_uuid), DP_RC(rc));
+		goto out_rpc;
+	}
+
 	D_DEBUG(DF_DSMS, DF_CONT": created snapshot "DF_U64"\n",
 		DP_CONT(cont->c_svc->cs_pool_uuid, cont->c_uuid), *epoch);
 out_rpc:
@@ -234,6 +251,8 @@ ds_cont_snap_destroy(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl,
 {
 	struct cont_epoch_op_in		*in = crt_req_get(rpc);
 	d_iov_t				 key;
+	d_iov_t				 value;
+	uint32_t			 nsnapshots;
 	int				 rc;
 
 	D_DEBUG(DF_DSMS, DF_CONT": processing rpc %p: epoch="DF_U64"\n",
@@ -248,7 +267,16 @@ ds_cont_snap_destroy(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl,
 		goto out;
 	}
 
+	/* Lookup snapshot, so that nsnapshots-- does not occur if snapshot does not exist */
 	d_iov_set(&key, &in->cei_epoch, sizeof(daos_epoch_t));
+	d_iov_set(&value, NULL, 0);
+	rc = rdb_tx_lookup(tx, &cont->c_snaps, &key, &value);
+	if (rc != 0) {
+		D_ERROR(DF_CONT": failed to lookup snapshot [%lu]: "DF_RC"\n",
+			DP_CONT(cont->c_svc->cs_pool_uuid, cont->c_uuid), in->cei_epoch, DP_RC(rc));
+		goto out;
+	}
+
 	rc = rdb_tx_delete(tx, &cont->c_snaps, &key);
 	if (rc != 0) {
 		D_ERROR(DF_CONT": failed to delete snapshot [%lu]: %d\n",
@@ -256,6 +284,23 @@ ds_cont_snap_destroy(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl,
 			in->cei_epoch, rc);
 		goto out;
 	}
+
+	/* Update number of snapshots */
+	d_iov_set(&value, &nsnapshots, sizeof(nsnapshots));
+	rc = rdb_tx_lookup(tx, &cont->c_prop, &ds_cont_prop_nsnapshots, &value);
+	if (rc != 0) {
+		D_ERROR(DF_CONT": failed to lookup nsnapshots, "DF_RC"\n",
+			DP_CONT(cont->c_svc->cs_pool_uuid, cont->c_uuid), DP_RC(rc));
+		goto out;
+	}
+	nsnapshots--;
+	rc = rdb_tx_update(tx, &cont->c_prop, &ds_cont_prop_nsnapshots, &value);
+	if (rc != 0) {
+		D_ERROR(DF_CONT": failed to update nsnapshots, "DF_RC"\n",
+			DP_CONT(cont->c_svc->cs_pool_uuid, cont->c_uuid), DP_RC(rc));
+		goto out;
+	}
+
 	D_DEBUG(DF_DSMS, DF_CONT": deleted snapshot [%lu]\n",
 		DP_CONT(pool_hdl->sph_pool->sp_uuid, in->cei_op.ci_uuid),
 		in->cei_epoch);
@@ -273,16 +318,106 @@ bulk_cb(const struct crt_bulk_cb_info *cb_info)
 	return 0;
 }
 
+/* Transfer snapshots to client (TODO: add snapshot names) */
+static int
+xfer_snap_list(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl, struct cont *cont,
+	       struct container_hdl *hdl, crt_rpc_t *rpc, crt_bulk_t *bulk, int *snap_countp)
+{
+	int		rc;
+	daos_size_t	bulk_size;
+	int		snap_count;
+	daos_epoch_t   *snapshots = NULL;
+	int		xfer_size;
+
+	/*
+	 * If remote bulk handle does not exist, only aggregate size is sent.
+	 */
+	if (bulk) {
+		rc = crt_bulk_get_len(bulk, &bulk_size);
+		if (rc != 0)
+			goto out;
+		D_DEBUG(DF_DSMS, DF_CONT": bulk_size=%lu\n",
+			DP_CONT(pool_hdl->sph_pool->sp_uuid, cont->c_uuid), bulk_size);
+
+		snap_count = (int)(bulk_size / sizeof(daos_epoch_t));
+	} else {
+		bulk_size = 0;
+		snap_count = 0;
+	}
+	rc = read_snap_list(tx, cont, &snapshots, &snap_count);
+	if (rc != 0)
+		goto out;
+
+	xfer_size = snap_count * sizeof(daos_epoch_t);
+	xfer_size = MIN(xfer_size, bulk_size);
+
+	D_DEBUG(DF_DSMS, DF_CONT": snap_count=%d, bulk_size=%zu, xfer_size=%d\n",
+		DP_CONT(pool_hdl->sph_pool->sp_uuid, cont->c_uuid), snap_count, bulk_size,
+		xfer_size);
+	if (xfer_size > 0) {
+		ABT_eventual		 eventual;
+		int			*status;
+		d_iov_t			 iov = {
+			.iov_buf			= snapshots,
+			.iov_len			= xfer_size,
+			.iov_buf_len			= xfer_size
+		};
+		d_sg_list_t		 sgl = {
+			.sg_nr_out			= 1,
+			.sg_nr				= 1,
+			.sg_iovs			= &iov
+		};
+		struct crt_bulk_desc	 bulk_desc = {
+			.bd_rpc				= rpc,
+			.bd_bulk_op			= CRT_BULK_PUT,
+			.bd_local_off			= 0,
+			.bd_remote_hdl			= bulk,
+			.bd_remote_off			= 0,
+			.bd_len				= xfer_size
+		};
+
+		rc = ABT_eventual_create(sizeof(*status), &eventual);
+		if (rc != ABT_SUCCESS) {
+			rc = dss_abterr2der(rc);
+			goto out_mem;
+		}
+
+		rc = crt_bulk_create(rpc->cr_ctx, &sgl, CRT_BULK_RW, &bulk_desc.bd_local_hdl);
+		if (rc != 0)
+			goto out_eventual;
+		rc = crt_bulk_transfer(&bulk_desc, bulk_cb, &eventual, NULL);
+		if (rc != 0)
+			goto out_bulk;
+		rc = ABT_eventual_wait(eventual, (void **)&status);
+		if (rc != ABT_SUCCESS)
+			rc = dss_abterr2der(rc);
+		else
+			rc = *status;
+		D_DEBUG(DF_DSMS, DF_CONT": done bulk transfer xfer_size=%d, rc=%d\n",
+			DP_CONT(pool_hdl->sph_pool->sp_uuid, cont->c_uuid), xfer_size, rc);
+
+out_bulk:
+		crt_bulk_free(bulk_desc.bd_local_hdl);
+out_eventual:
+		ABT_eventual_free(&eventual);
+	}
+
+out_mem:
+	if (snapshots)
+		D_FREE(snapshots);
+out:
+	if (rc == 0)
+		*snap_countp = snap_count;
+	return rc;
+}
+
 int
 ds_cont_snap_list(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl,
 		  struct cont *cont, struct container_hdl *hdl, crt_rpc_t *rpc)
 {
 	struct cont_snap_list_in	*in		= crt_req_get(rpc);
 	struct cont_snap_list_out	*out		= crt_reply_get(rpc);
-	daos_size_t			 bulk_size;
-	daos_epoch_t			*snapshots;
 	int				 snap_count;
-	int				 xfer_size;
 	int				 rc;
 
 	D_DEBUG(DF_DSMS, DF_CONT": processing rpc %p: hdl="DF_UUID"\n",
@@ -297,77 +432,11 @@ ds_cont_snap_list(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl,
 		goto out;
 	}
 
-	/*
-	 * If remote bulk handle does not exist, only aggregate size is sent.
-	 */
-	if (in->sli_bulk) {
-		rc = crt_bulk_get_len(in->sli_bulk, &bulk_size);
-		if (rc != 0)
-			goto out;
-		D_DEBUG(DF_DSMS, DF_CONT": bulk_size=%lu\n",
-			DP_CONT(pool_hdl->sph_pool->sp_uuid,
-				in->sli_op.ci_uuid), bulk_size);
-		snap_count = (int)(bulk_size / sizeof(daos_epoch_t));
-	} else {
-		bulk_size = 0;
-		snap_count = 0;
-	}
-	rc = read_snap_list(tx, cont, &snapshots, &snap_count);
-	if (rc != 0)
+	rc = xfer_snap_list(tx, pool_hdl, cont, hdl, rpc, in->sli_bulk, &snap_count);
+	if (rc)
 		goto out;
 	out->slo_count = snap_count;
-	xfer_size = snap_count * sizeof(daos_epoch_t);
-	xfer_size = MIN(xfer_size, bulk_size);
 
-	if (xfer_size > 0) {
-		ABT_eventual	 eventual;
-		int		*status;
-		d_iov_t	 iov = {
-			.iov_buf	= snapshots,
-			.iov_len	= xfer_size,
-			.iov_buf_len	= xfer_size
-		};
-		d_sg_list_t	 sgl = {
-			.sg_nr_out = 1,
-			.sg_nr	   = 1,
-			.sg_iovs   = &iov
-		};
-		struct crt_bulk_desc bulk_desc = {
-			.bd_rpc		= rpc,
-			.bd_bulk_op	= CRT_BULK_PUT,
-			.bd_local_off	= 0,
-			.bd_remote_hdl	= in->sli_bulk,
-			.bd_remote_off	= 0,
-			.bd_len		= xfer_size
-		};
-
-		rc = ABT_eventual_create(sizeof(*status), &eventual);
-		if (rc != ABT_SUCCESS) {
-			rc = dss_abterr2der(rc);
-			goto out_mem;
-		}
-
-		rc = crt_bulk_create(rpc->cr_ctx, &sgl, CRT_BULK_RW,
-				     &bulk_desc.bd_local_hdl);
-		if (rc != 0)
-			goto out_eventual;
-		rc = crt_bulk_transfer(&bulk_desc, bulk_cb, &eventual, NULL);
-		if (rc != 0)
-			goto out_bulk;
-		rc = ABT_eventual_wait(eventual, (void **)&status);
-		if (rc != ABT_SUCCESS)
-			rc = dss_abterr2der(rc);
-		else
-			rc = *status;
-
-out_bulk:
-		crt_bulk_free(bulk_desc.bd_local_hdl);
-out_eventual:
-		ABT_eventual_free(&eventual);
-	}
-
-out_mem:
-	D_FREE(snapshots);
 out:
 	return rc;
 }
@@ -394,7 +463,6 @@ ds_cont_get_snapshots(uuid_t pool_uuid, uuid_t cont_uuid,
 	rc = cont_lookup(&tx, svc, cont_uuid, &cont);
 	if (rc != 0)
 		D_GOTO(out_lock, rc);
-
 	rc = read_snap_list(&tx, cont, snapshots, snap_count);
 	cont_put(cont);
 	if (rc != 0)

--- a/src/container/srv_epoch.c
+++ b/src/container/srv_epoch.c
@@ -463,6 +463,7 @@ ds_cont_get_snapshots(uuid_t pool_uuid, uuid_t cont_uuid,
 	rc = cont_lookup(&tx, svc, cont_uuid, &cont);
 	if (rc != 0)
 		D_GOTO(out_lock, rc);
+
 	rc = read_snap_list(&tx, cont, snapshots, snap_count);
 	cont_put(cont);
 	if (rc != 0)

--- a/src/container/srv_internal.h
+++ b/src/container/srv_internal.h
@@ -221,11 +221,9 @@ int ds_cont_snap_list(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl,
 int ds_cont_snap_destroy(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl,
 			 struct cont *cont, struct container_hdl *hdl,
 			 crt_rpc_t *rpc);
-int
-ds_cont_get_snapshots(uuid_t pool_uuid, uuid_t cont_uuid,
-		      daos_epoch_t **snapshots, int *snap_count);
-void
-ds_cont_update_snap_iv(struct cont_svc *svc, uuid_t cont_uuid);
+int ds_cont_get_snapshots(uuid_t pool_uuid, uuid_t cont_uuid, daos_epoch_t **snapshots,
+			  int *snap_count);
+void ds_cont_update_snap_iv(struct cont_svc *svc, uuid_t cont_uuid);
 
 /**
  * srv_target.c

--- a/src/container/srv_layout.c
+++ b/src/container/srv_layout.c
@@ -40,6 +40,7 @@ RDB_STRING_KEY(ds_cont_prop_, owner);
 RDB_STRING_KEY(ds_cont_prop_, owner_group);
 RDB_STRING_KEY(ds_cont_prop_, lres);
 RDB_STRING_KEY(ds_cont_prop_, lhes);
+RDB_STRING_KEY(ds_cont_prop_, nsnapshots);
 RDB_STRING_KEY(ds_cont_prop_, snapshots);
 RDB_STRING_KEY(ds_cont_prop_, co_status);
 RDB_STRING_KEY(ds_cont_attr_, user);

--- a/src/container/srv_layout.h
+++ b/src/container/srv_layout.h
@@ -32,10 +32,10 @@
 #include <daos_types.h>
 
 /* Default layout version */
-#define DS_CONT_MD_VERSION 3
+#define DS_CONT_MD_VERSION 4
 
 /* Lowest compatible layout version */
-#define DS_CONT_MD_VERSION_LOW 2
+#define DS_CONT_MD_VERSION_LOW 4
 
 /*
  * Root KVS (RDB_KVS_GENERIC)
@@ -85,6 +85,7 @@ extern d_iov_t ds_cont_prop_encrypt;		/* uint64_t */
 extern d_iov_t ds_cont_prop_acl;		/* struct daos_acl */
 extern d_iov_t ds_cont_prop_owner;		/* string */
 extern d_iov_t ds_cont_prop_owner_group;	/* string */
+extern d_iov_t ds_cont_prop_nsnapshots;		/* uint32_t */
 extern d_iov_t ds_cont_prop_snapshots;		/* snapshot KVS */
 extern d_iov_t ds_cont_prop_co_status;		/* uint64_t */
 extern d_iov_t ds_cont_attr_user;		/* user attribute KVS */

--- a/src/control/cmd/daos/container.go
+++ b/src/control/cmd/daos/container.go
@@ -27,6 +27,7 @@ import (
 
 /*
 #include "util.h"
+
 */
 import "C"
 
@@ -640,12 +641,6 @@ func (cmd *containerStatCmd) Execute(_ []string) error {
 }
 
 func printContainerInfo(out io.Writer, ci *containerInfo, verbose bool) error {
-	epochs := ci.SnapshotEpochs()
-	epochStrs := make([]string, *ci.NumSnapshots)
-	for i := uint32(0); i < *ci.NumSnapshots; i++ {
-		epochStrs[i] = fmt.Sprintf("%d", epochs[i])
-	}
-
 	rows := []txtfmt.TableRow{
 		{"Container UUID": ci.ContainerUUID.String()},
 	}
@@ -659,9 +654,7 @@ func printContainerInfo(out io.Writer, ci *containerInfo, verbose bool) error {
 			{"Pool UUID": ci.PoolUUID.String()},
 			{"Number of snapshots": fmt.Sprintf("%d", *ci.NumSnapshots)},
 			{"Latest Persistent Snapshot": fmt.Sprintf("%d", *ci.LatestSnapshot)},
-			{"Highest Aggregated Epoch": fmt.Sprintf("%d", *ci.HighestAggregatedEpoch)},
 			{"Container redundancy factor": fmt.Sprintf("%d", *ci.RedundancyFactor)},
-			{"Snapshot Epochs": strings.Join(epochStrs, ",")},
 		}...)
 
 		if ci.ObjectClass != "" {
@@ -676,36 +669,24 @@ func printContainerInfo(out io.Writer, ci *containerInfo, verbose bool) error {
 }
 
 type containerInfo struct {
-	dci                    C.daos_cont_info_t
-	PoolUUID               *uuid.UUID `json:"pool_uuid"`
-	ContainerUUID          *uuid.UUID `json:"container_uuid"`
-	ContainerLabel         string     `json:"container_label,omitempty"`
-	LatestSnapshot         *uint64    `json:"latest_snapshot"`
-	RedundancyFactor       *uint32    `json:"redundancy_factor"`
-	NumSnapshots           *uint32    `json:"num_snapshots"`
-	HighestAggregatedEpoch *uint64    `json:"highest_aggregated_epoch"`
-	Type                   string     `json:"container_type"`
-	ObjectClass            string     `json:"object_class,omitempty"`
-	ChunkSize              uint64     `json:"chunk_size,omitempty"`
-}
-
-func (ci *containerInfo) SnapshotEpochs() []uint64 {
-	if ci.dci.ci_snapshots == nil {
-		return nil
-	}
-
-	// return a Go slice backed by the C array of snapshot epochs
-	return (*[1 << 30]uint64)(unsafe.Pointer(ci.dci.ci_snapshots))[:*ci.NumSnapshots:*ci.NumSnapshots]
+	dci              C.daos_cont_info_t
+	PoolUUID         *uuid.UUID `json:"pool_uuid"`
+	ContainerUUID    *uuid.UUID `json:"container_uuid"`
+	ContainerLabel   string     `json:"container_label,omitempty"`
+	LatestSnapshot   *uint64    `json:"latest_snapshot"`
+	RedundancyFactor *uint32    `json:"redundancy_factor"`
+	NumSnapshots     *uint32    `json:"num_snapshots"`
+	Type             string     `json:"container_type"`
+	ObjectClass      string     `json:"object_class,omitempty"`
+	ChunkSize        uint64     `json:"chunk_size,omitempty"`
 }
 
 func (ci *containerInfo) MarshalJSON() ([]byte, error) {
 	type toJSON containerInfo
 	return json.Marshal(&struct {
-		SnapshotEpochs []uint64 `json:"snapshot_epochs"`
 		*toJSON
 	}{
-		SnapshotEpochs: ci.SnapshotEpochs(),
-		toJSON:         (*toJSON)(ci),
+		toJSON: (*toJSON)(ci),
 	})
 }
 
@@ -719,7 +700,7 @@ func newContainerInfo(poolUUID, contUUID *uuid.UUID) *containerInfo {
 	ci.LatestSnapshot = (*uint64)(&ci.dci.ci_lsnapshot)
 	ci.RedundancyFactor = (*uint32)(&ci.dci.ci_redun_fac)
 	ci.NumSnapshots = (*uint32)(&ci.dci.ci_nsnapshots)
-	ci.HighestAggregatedEpoch = (*uint64)(&ci.dci.ci_hae)
+	*ci.NumSnapshots = 0
 
 	return ci
 }

--- a/src/control/cmd/daos/container.go
+++ b/src/control/cmd/daos/container.go
@@ -700,7 +700,6 @@ func newContainerInfo(poolUUID, contUUID *uuid.UUID) *containerInfo {
 	ci.LatestSnapshot = (*uint64)(&ci.dci.ci_lsnapshot)
 	ci.RedundancyFactor = (*uint32)(&ci.dci.ci_redun_fac)
 	ci.NumSnapshots = (*uint32)(&ci.dci.ci_nsnapshots)
-	*ci.NumSnapshots = 0
 
 	return ci
 }

--- a/src/include/daos_cont.h
+++ b/src/include/daos_cont.h
@@ -49,10 +49,7 @@ typedef struct {
 	uint32_t		ci_redun_fac;
 	/** Number of snapshots */
 	uint32_t		ci_nsnapshots;
-	/** Epochs of returns snapshots */
-	daos_epoch_t	       *ci_snapshots;
-	/** The minimal "Highest aggregated epoch" among all targets */
-	daos_epoch_t		ci_hae;
+	uint64_t		ci_pad[2];
 	/* TODO: add more members, e.g., size, # objects, uid, gid... */
 } daos_cont_info_t;
 
@@ -248,10 +245,6 @@ daos_cont_destroy(daos_handle_t poh, const char *cont, int force, daos_event_t *
  *
  * \param[in]	coh	Container open handle.
  * \param[out]	info	Returned container information.
- *			If \a info::ci_snapshots is not NULL, epochs of
- *			snapshots will be stored in it.
- *			If \a info::ci_snapshots is NULL, number of snapshots
- *			will be returned by \a info::ci_nsnapshots.
  * \param[out]	cont_prop
  *			Optional, returned container properties
  *			If it is NULL, then needs not query the properties.

--- a/src/pool/srv_layout.h
+++ b/src/pool/srv_layout.h
@@ -26,10 +26,10 @@
 #include <daos_types.h>
 
 /* Default layout version */
-#define DS_POOL_MD_VERSION 3
+#define DS_POOL_MD_VERSION 4
 
 /* Lowest compatible layout version */
-#define DS_POOL_MD_VERSION_LOW 2
+#define DS_POOL_MD_VERSION_LOW 4
 
 /*
  * Root KVS (RDB_KVS_GENERIC): pool properties

--- a/src/utils/daos_hdlr.c
+++ b/src/utils/daos_hdlr.c
@@ -1756,12 +1756,9 @@ cont_query_hdlr(struct cmd_args_s *ap)
 	printf("Number of snapshots: %i\n", (int)cont_info.ci_nsnapshots);
 	printf("Latest Persistent Snapshot: %i\n",
 		(int)cont_info.ci_lsnapshot);
-	printf("Highest Aggregated Epoch: "DF_U64"\n", cont_info.ci_hae);
 	printf("Container redundancy factor: %d\n", cont_info.ci_redun_fac);
 	daos_unparse_ctype(cont_type, type);
 	printf("Container Type:\t%s\n", type);
-
-	/* TODO: list snapshot epoch numbers, including ~80 column wrap. */
 
 	if (ap->oid.hi || ap->oid.lo) {
 		printf("Path is within container, oid: " DF_OID "\n",


### PR DESCRIPTION
Return daos_cont_info_t.ci_nsnapshots in container query and open,
instead of always returning the value 0. Also, update the container
CaRT RPC version since a new snapshot count (out) parameter is added
to both CONT_QUERY and CONT_OPEN, and since CONT_QUERY no longer
returns cqo_hae (see daos_cont_info_t change).

The daos_engine (pool and) container metadata layout version is updated
to include a new ds_prop_cont_nsnapshots key / unsigned integer value
in the container properties KVS. The value increments and decrements
appropriately with snapshot create / destroy operations and is more
quickly read (compared to iterating snapshots keys) during container
open and query operations.

The libdaos API version is also updated to v1.5.0 to reflect removal
of ci_hae (highest aggregated epoch) and ci_snapshots (snapshot list)
members of daos_cont_info_t (replaced with padding). Additional pydaos
and control plane code changes are made to remove references.

The daos_test epochs (snapshots) test is updated to verify the number
of snapshots returned by container query and open. And to add
some additional testing of snapshot destroy (decrementing nsnapshots,
and flagging an error when a nonexistent epoch is specified).

Signed-off-by: Kenneth Cain <kenneth.c.cain@intel.com>