### PR TITLE
DAOS-8419 daos: open container RW for when list-obj is called

### DIFF
--- a/src/control/cmd/daos/container.go
+++ b/src/control/cmd/daos/container.go
@@ -611,7 +611,7 @@ func (cmd *containerListObjectsCmd) Execute(_ []string) error {
 	}
 	defer deallocCmdArgs()
 
-	cleanup, err := cmd.resolveAndConnect(C.DAOS_COO_RO, ap)
+	cleanup, err := cmd.resolveAndConnect(C.DAOS_COO_RW, ap)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
daos tool currently opens the container read only causing list-obj to fail
since that creates then destroys a snapshot. fix that issue and open
container RW.

Signed-off-by: Mohamad Chaarawi <mohamad.chaarawi@intel.com>