### PR TITLE
DAOS-8231 object: missing % grp_size in object list

### DIFF
--- a/src/include/daos/object.h
+++ b/src/include/daos/object.h
@@ -521,6 +521,8 @@ enum daos_io_flags {
 	DIOF_EC_RECOV_SNAP	= 0x100,
 	/* Only recover from parity */
 	DIOF_EC_RECOV_FROM_PARITY = 0x200,
+	/* Force fetch/list to do degraded enumeration/fetch */
+	DIOF_FOR_FORCE_DEGRADE = 0x400,
 };
 
 /**

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -89,7 +89,8 @@ struct obj_auxi_args {
 					 ec_wait_recov:1,
 					 ec_in_recov:1,
 					 new_shard_tasks:1,
-					 reset_param:1;
+					 reset_param:1,
+					 force_degraded:1;
 	/* request flags. currently only: ORF_RESEND */
 	uint32_t			 flags;
 	uint32_t			 specified_shard;
@@ -724,7 +725,7 @@ obj_shard2tgtid(struct dc_object *obj, uint32_t shard, uint32_t map_ver,
  * iod_csums/iod_eprs array will set as 0/NULL.
  */
 int
-obj_reasb_req_init(struct obj_reasb_req *reasb_req, daos_iod_t *iods,
+obj_reasb_req_init(struct obj_reasb_req *reasb_req, struct dc_object *obj, daos_iod_t *iods,
 		   uint32_t iod_nr, struct daos_oclass_attr *oca)
 {
 	daos_size_t			 size_iod, size_sgl, size_oiod;
@@ -743,9 +744,9 @@ obj_reasb_req_init(struct obj_reasb_req *reasb_req, daos_iod_t *iods,
 	size_recx = roundup(sizeof(struct obj_ec_recx_array) * iod_nr, 8);
 	size_sorter = roundup(sizeof(struct obj_ec_seg_sorter) * iod_nr, 8);
 	size_singv = roundup(sizeof(struct dcs_layout) * iod_nr, 8);
-	size_array = sizeof(daos_size_t) * obj_ec_tgt_nr(oca) * iod_nr;
+	size_array = sizeof(daos_size_t) * obj_get_grp_size(obj) * iod_nr;
 	/* for oer_tgt_recx_nrs/_idxs */
-	size_tgt_nr = roundup(sizeof(uint32_t) * obj_ec_tgt_nr(oca), 8);
+	size_tgt_nr = roundup(sizeof(uint32_t) * obj_get_grp_size(obj), 8);
 	buf_size = size_iod + size_sgl + size_oiod + size_recx + size_sorter +
 		   size_singv + size_array +
 		   size_tgt_nr * iod_nr * 2 + OBJ_TGT_BITMAP_LEN;
@@ -841,7 +842,7 @@ obj_rw_req_reassemb(struct dc_object *obj, daos_obj_rw_t *args,
 
 	if (!obj_auxi->req_reasbed) {
 		obj_auxi->is_ec_obj = 1;
-		rc = obj_reasb_req_init(&obj_auxi->reasb_req, args->iods,
+		rc = obj_reasb_req_init(&obj_auxi->reasb_req, obj, args->iods,
 					args->nr, oca);
 		if (rc) {
 			D_ERROR(DF_OID" obj_reasb_req_init failed %d.\n",
@@ -896,8 +897,7 @@ obj_shard_tgts_query(struct dc_object *obj, uint32_t map_ver, uint32_t shard,
 
 	if (obj_auxi->is_ec_obj &&
 	    (obj_auxi->csum_retry || obj_auxi->tx_uncertain ||
-	     DAOS_FAIL_CHECK(DAOS_OBJ_FORCE_DEGRADE) ||
-	     obj_auxi->flags & ORF_EC_RECOV_FROM_PARITY)) {
+	     obj_auxi->force_degraded || DAOS_FAIL_CHECK(DAOS_OBJ_FORCE_DEGRADE))) {
 		if (obj_auxi->tx_uncertain) {
 			tx_uncertain = true;
 			obj_auxi->tx_uncertain = 0;
@@ -2396,7 +2396,7 @@ obj_req_get_tgts(struct dc_object *obj, int *shard, daos_key_t *dkey,
 			struct daos_oclass_attr	*oca;
 
 			oca = obj_get_oca(obj);
-			if (shard_idx % obj_ec_tgt_nr(oca) <
+			if (shard_idx % obj_get_grp_size(obj) <
 			    obj_ec_data_tgt_nr(oca)) {
 				/* Client dispatch for EC recx enumeration */
 				flags = OBJ_TGT_FLAG_CLI_DISPATCH;
@@ -4300,6 +4300,9 @@ dc_obj_fetch_task(tse_task_t *task)
 	if (args->extra_flags & DIOF_EC_RECOV_FROM_PARITY)
 		obj_auxi->flags |= ORF_EC_RECOV_FROM_PARITY;
 
+	if (args->extra_flags & DIOF_FOR_FORCE_DEGRADE)
+		obj_auxi->force_degraded = 1;
+
 	if (args->extra_flags & DIOF_CHECK_EXISTENCE) {
 		obj_auxi->flags |= ORF_CHECK_EXISTENCE;
 	} else {
@@ -4568,7 +4571,7 @@ obj_shard_list_fini(daos_obj_list_t *obj_args,
 
 /* prepare the object enumeration for each shards */
 static int
-obj_shard_list_prep(daos_obj_list_t *obj_args,
+obj_shard_list_prep(daos_obj_list_t *obj_args, struct dc_object *obj,
 		    struct shard_list_args *shard_arg, int shard_nr,
 		    int opc)
 {
@@ -4582,7 +4585,7 @@ obj_shard_list_prep(daos_obj_list_t *obj_args,
 	}
 
 	shard_arg->la_nr = *obj_args->nr / shard_nr;
-	idx = shard_arg->la_auxi.shard;
+	idx = shard_arg->la_auxi.shard % obj_get_grp_size(obj);
 	if (shard_arg->la_kds == NULL && obj_args->kds != NULL)
 		shard_arg->la_kds = &obj_args->kds[idx * shard_arg->la_nr];
 
@@ -4631,9 +4634,9 @@ shard_list_prep(struct shard_auxi_args *shard_auxi, struct dc_object *obj,
 	shard_arg->la_api_args = obj_args;
 	oca = obj_get_oca(obj);
 	if (obj_auxi->is_ec_obj &&
-	    shard_auxi->shard < obj_ec_data_tgt_nr(oca) &&
+	    (shard_auxi->shard % obj_get_grp_size(obj)) < obj_ec_data_tgt_nr(oca) &&
 	    !obj_auxi->spec_shard) {
-		uint32_t		idx = shard_auxi->shard;
+		uint32_t		idx = shard_auxi->shard % obj_get_grp_size(obj);
 		daos_anchor_t		*sub_anchors;
 		int			shard_nr;
 		int			rc;
@@ -4649,7 +4652,7 @@ shard_list_prep(struct shard_auxi_args *shard_auxi, struct dc_object *obj,
 			return rc;
 		}
 
-		rc = obj_shard_list_prep(obj_args, shard_arg, shard_nr,
+		rc = obj_shard_list_prep(obj_args, obj, shard_arg, shard_nr,
 					 obj_auxi->opc);
 		if (rc) {
 			D_ERROR(DF_OID" shard list %d prep: %d\n",
@@ -4752,7 +4755,7 @@ obj_ec_list_get_shard(struct obj_auxi_args *obj_auxi, unsigned int map_ver,
 		DP_OID(obj->cob_md.omd_id));
 
 	/* Check if all data shard are in good state */
-	first = grp_idx * obj_ec_tgt_nr(oca);
+	first = grp_idx * obj_get_grp_size(obj);
 	for (idx = first; idx < first + obj_ec_data_tgt_nr(oca); idx++) {
 		if (obj->cob_shards->do_shards[idx].do_rebuilding ||
 		    obj->cob_shards->do_shards[idx].do_target_id == -1)
@@ -4904,6 +4907,10 @@ obj_list_common(tse_task_t *task, int opc, daos_obj_list_t *args)
 	if (args->dkey_anchor != NULL &&
 	    daos_anchor_get_flags(args->dkey_anchor) & DIOF_FOR_MIGRATION)
 		obj_auxi->no_retry = 1;
+
+	if (args->dkey_anchor != NULL &&
+	    daos_anchor_get_flags(args->dkey_anchor) & DIOF_FOR_FORCE_DEGRADE)
+		obj_auxi->force_degraded = 1;
 
 	if (obj_is_ec(obj)) {
 		obj_auxi->is_ec_obj = 1;

--- a/src/object/obj_internal.h
+++ b/src/object/obj_internal.h
@@ -506,9 +506,8 @@ int dc_obj_verify_rdg(struct dc_object *obj, struct dc_obj_verify_args *dova,
 bool obj_op_is_ec_fetch(struct obj_auxi_args *obj_auxi);
 int obj_recx_ec2_daos(struct daos_oclass_attr *oca, int shard, daos_recx_t **recxs_p,
 		      daos_epoch_t **recx_ephs_p, unsigned int *nr, bool convert_parity);
-
-int obj_reasb_req_init(struct obj_reasb_req *reasb_req, daos_iod_t *iods,
-		       uint32_t iod_nr, struct daos_oclass_attr *oca);
+int obj_reasb_req_init(struct obj_reasb_req *reasb_req, struct dc_object *obj,
+		       daos_iod_t *iods, uint32_t iod_nr, struct daos_oclass_attr *oca);
 void obj_reasb_req_fini(struct obj_reasb_req *reasb_req, uint32_t iod_nr);
 int obj_bulk_prep(d_sg_list_t *sgls, unsigned int nr, bool bulk_bind,
 		  crt_bulk_perm_t bulk_perm, tse_task_t *task,

--- a/src/object/obj_tx.c
+++ b/src/object/obj_tx.c
@@ -1060,7 +1060,7 @@ dc_tx_classify_update(struct dc_tx *tx, struct daos_cpd_sub_req *dcsr,
 		 * dc_tx_cleanup().
 		 */
 		dcsr->dcsr_reasb = reasb_req;
-		rc = obj_reasb_req_init(dcsr->dcsr_reasb,
+		rc = obj_reasb_req_init(dcsr->dcsr_reasb, obj,
 					dcu->dcu_iod_array.oia_iods,
 					dcsr->dcsr_nr, oca);
 		if (rc != 0)

--- a/src/object/srv_obj_migrate.c
+++ b/src/object/srv_obj_migrate.c
@@ -540,7 +540,21 @@ mrone_obj_fetch(struct migrate_one *mrone, daos_handle_t oh, d_sg_list_t *sgls,
 	if (daos_oclass_grp_size(&mrone->mo_oca) > 1)
 		flags |= DIOF_TO_LEADER;
 
-	rc = dsc_obj_fetch(oh, eph, &mrone->mo_dkey, iod_num, iods, sgls, NULL,
+	if (daos_oclass_is_ec(&mrone->mo_oca) &&
+	    iods[0].iod_type != DAOS_IOD_SINGLE) {
+		unsigned int shard = mrone->mo_oid.id_shard %
+			     daos_oclass_grp_size(&mrone->mo_oca);
+
+		/* For EC data migration, let's force it to do degraded fetch,
+		 * make sure reintegration will not fetch from the original
+		 * shard, which might cause parity corruption.
+		 */
+		if (shard < obj_ec_data_tgt_nr(&mrone->mo_oca))
+			flags |= DIOF_FOR_FORCE_DEGRADE;
+	}
+
+	rc = dsc_obj_fetch(oh, mrone->mo_epoch, &mrone->mo_dkey,
+			   iod_num, iods, sgls, NULL,
 			   flags, NULL, csum_iov_fetch);
 	if (rc != 0)
 		return rc;

--- a/src/pool/srv_target.c
+++ b/src/pool/srv_target.c
@@ -488,7 +488,7 @@ ds_pool_lookup(const uuid_t uuid)
 
 	pool = pool_obj(llink);
 	if (pool->sp_stopping) {
-		D_ERROR(DF_UUID": is in stopping\n", DP_UUID(uuid));
+		D_DEBUG(DB_MD, DF_UUID": is in stopping\n", DP_UUID(uuid));
 		ds_pool_put(pool);
 		return NULL;
 	}

--- a/src/tests/suite/daos_rebuild_ec.c
+++ b/src/tests/suite/daos_rebuild_ec.c
@@ -844,6 +844,37 @@ rebuild_ec_dkey_enumeration(void **state)
 	ioreq_fini(&req);
 }
 
+static void
+rebuild_ec_parity_multi_group(void **state)
+{
+	test_arg_t	*arg = *state;
+	struct ioreq	req;
+	daos_obj_id_t	oid;
+	d_rank_t	rank;
+	int		i;
+
+	if (!test_runable(arg, 8))
+		return;
+
+	oid = daos_test_oid_gen(arg->coh, OC_EC_4P1G8, 0, 0, arg->myrank);
+	ioreq_init(&req, arg->coh, oid, DAOS_IOD_ARRAY, arg);
+	for (i = 0; i < 100; i++) {
+		char dkey[32];
+
+		/* Make dkey on different shards */
+		req.iod_type = DAOS_IOD_ARRAY;
+		sprintf(dkey, "dkey_%d", i);
+		insert_single(dkey, "a_key", 0, "data", strlen("data") + 1,
+			      DAOS_TX_NONE, &req);
+	}
+
+	rank = get_rank_by_oid_shard(arg, oid, 9);
+	rebuild_single_pool_rank(arg, rank, false);
+
+	reintegrate_single_pool_rank(arg, rank);
+	ioreq_fini(&req);
+}
+
 /** create a new pool/container for each test */
 static const struct CMUnitTest rebuild_tests[] = {
 	{"REBUILD0: rebuild partial update with data tgt fail",
@@ -954,6 +985,9 @@ static const struct CMUnitTest rebuild_tests[] = {
 	 test_teardown},
 	{"REBUILD38: rebuild EC multi-stripes @ different epochs",
 	 rebuild_ec_multi_stripes, rebuild_ec_8nodes_setup,
+	 test_teardown},
+	{"REBUILD39: rebuild EC parity with multiple group",
+	 rebuild_ec_parity_multi_group, rebuild_ec_8nodes_setup,
 	 test_teardown},
 };
 

--- a/src/tests/suite/daos_test.h
+++ b/src/tests/suite/daos_test.h
@@ -168,6 +168,7 @@ typedef struct {
 	 */
 	int			(*rebuild_cb)(void *test_arg);
 	void			*rebuild_cb_arg;
+	uint32_t		rebuild_pre_pool_ver;
 	/* The callback is called after pool rebuild, used for validating IO
 	 * after rebuild
 	 */

--- a/src/tests/suite/daos_test_common.c
+++ b/src/tests/suite/daos_test_common.c
@@ -688,18 +688,21 @@ rebuild_pool_wait(test_arg_t *arg)
 	pinfo.pi_bits = DPI_REBUILD_STATUS;
 	rc = test_pool_get_info(arg, &pinfo);
 	rst = &pinfo.pi_rebuild_st;
-	if ((rst->rs_done || rc != 0) && rst->rs_version != 0) {
-		print_message("Rebuild "DF_UUIDF" (ver=%d) is done %d/%d, "
+	if ((rst->rs_done || rc != 0) && rst->rs_version != 0 &&
+	     rst->rs_version != arg->rebuild_pre_pool_ver) {
+		print_message("Rebuild "DF_UUIDF" (ver=%u orig_ver=%u) is done %d/%d, "
 			      "obj="DF_U64", rec="DF_U64".\n",
 			       DP_UUID(arg->pool.pool_uuid), rst->rs_version,
+			       arg->rebuild_pre_pool_ver,
 			       rc, rst->rs_errno, rst->rs_obj_nr,
 			       rst->rs_rec_nr);
 		done = true;
 	} else {
-		print_message("wait for rebuild pool "DF_UUIDF"(ver=%u), "
+		print_message("wait for rebuild pool "DF_UUIDF"(ver=%u orig_ver=%u), "
 			      "to-be-rebuilt obj="DF_U64", already rebuilt obj="
 			      DF_U64", rec="DF_U64"\n",
 			      DP_UUID(arg->pool.pool_uuid), rst->rs_version,
+			      arg->rebuild_pre_pool_ver,
 			      rst->rs_toberb_obj_nr, rst->rs_obj_nr,
 			      rst->rs_rec_nr);
 	}


### PR DESCRIPTION
It should use shard % grp_size to check if it is
data shard or parity shard for EC object.

Add tests to verify it

Signed-off-by: Di Wang <di.wang@intel.com>