### PR TITLE
DAOS-8413 Prepend container UUID/label to file paths listed via hadoop-daos

### DIFF
--- a/src/client/java/hadoop-daos/src/main/java/io/daos/fs/hadoop/Constants.java
+++ b/src/client/java/hadoop-daos/src/main/java/io/daos/fs/hadoop/Constants.java
@@ -61,4 +61,7 @@ public final class Constants {
   public static final int MINIMUM_DAOS_BLOCK_SIZE = 16 * 1024 * 1024;
   public static final int MAXIMUM_DAOS_BLOCK_SIZE = Integer.MAX_VALUE;
 
+  public static final String DAOS_WITH_UNS_PREFIX = "fs.daos.with-uns-prefix";
+  public static final boolean DEFAULT_DAOS_WITH_UNS_PREFIX = true;
+
 }

--- a/src/client/java/hadoop-daos/src/test/java/io/daos/fs/hadoop/DaosFSFactory.java
+++ b/src/client/java/hadoop-daos/src/test/java/io/daos/fs/hadoop/DaosFSFactory.java
@@ -40,6 +40,7 @@ public class DaosFSFactory {
     conf.set(Constants.DAOS_POOL_ID, pooluuid);
     conf.set(Constants.DAOS_CONTAINER_ID, contuuid);
     conf.set(Constants.DAOS_IO_ASYNC, String.valueOf(async));
+    conf.setBoolean(Constants.DAOS_WITH_UNS_PREFIX, false);
   }
 
   public synchronized static FileSystem getFS() throws IOException {

--- a/src/client/java/hadoop-daos/src/test/java/io/daos/fs/hadoop/DaosFileSystemIT.java
+++ b/src/client/java/hadoop-daos/src/test/java/io/daos/fs/hadoop/DaosFileSystemIT.java
@@ -243,7 +243,9 @@ public class DaosFileSystemIT {
       String uri = "daos://" + io.daos.Constants.UNS_ID_PREFIX + unsId.getAndIncrement();
       String uriStr = uri + path;
       Path uriPath = new Path(uriStr);
-      FileSystem fs = uriPath.getFileSystem(new Configuration());
+      Configuration conf = new Configuration();
+      conf.setBoolean(Constants.DAOS_WITH_UNS_PREFIX, false);
+      FileSystem fs = uriPath.getFileSystem(conf);
       Assert.assertNotNull(fs);
       Assert.assertEquals(originPath, ((DaosFileSystem) fs).getUnsPrefix());
       fs.mkdirs(uriPath);
@@ -273,7 +275,9 @@ public class DaosFileSystemIT {
       String uri = "daos://" + io.daos.Constants.UNS_ID_PREFIX + unsId.getAndIncrement();
       String uriStr = uri + path;
       Path uriPath = new Path(uriStr);
-      FileSystem fs = uriPath.getFileSystem(new Configuration());
+      Configuration conf = new Configuration();
+      conf.setBoolean(Constants.DAOS_WITH_UNS_PREFIX, false);
+      FileSystem fs = uriPath.getFileSystem(conf);
       Assert.assertNotNull(fs);
       Assert.assertEquals(originPath, ((DaosFileSystem) fs).getUnsPrefix());
 

--- a/src/client/java/hadoop-daos/src/test/java/io/daos/fs/hadoop/DaosFileSystemTest.java
+++ b/src/client/java/hadoop-daos/src/test/java/io/daos/fs/hadoop/DaosFileSystemTest.java
@@ -90,7 +90,7 @@ public class DaosFileSystemTest {
     PowerMockito.mockStatic(DaosUns.class);
     when(DaosUns.getAccessInfo(any(URI.class))).thenReturn(info);
     fs.initialize(URI.create("daos://123/123/abc"), cfg);
-    Assert.assertEquals("daos://123/user/" + System.getProperty("user.name"),
+    Assert.assertEquals("daos://123/123/user/" + System.getProperty("user.name"),
         fs.getWorkingDirectory().toString());
     verify(client, times(1))
         .mkdir("/user/" + System.getProperty("user.name"), true);

--- a/src/client/java/hadoop-daos/src/test/java/io/daos/fs/hadoop/DaosFsConfigTest.java
+++ b/src/client/java/hadoop-daos/src/test/java/io/daos/fs/hadoop/DaosFsConfigTest.java
@@ -25,7 +25,7 @@ public class DaosFsConfigTest {
   @Test
   public void testFsConfigNamesSize() throws Exception {
     DaosFsConfig cf = DaosFsConfig.getInstance();
-    Assert.assertEquals(11, cf.getFsConfigNames().size());
+    Assert.assertEquals(12, cf.getFsConfigNames().size());
   }
 
   @Test
@@ -38,7 +38,7 @@ public class DaosFsConfigTest {
   @Test
   public void testConfigItemExistence() throws Exception {
     for (String name : DaosFsConfig.getInstance().getFsConfigNames()) {
-      Assert.assertTrue(help.contains(name));
+      Assert.assertTrue(Constants.DAOS_WITH_UNS_PREFIX.equals(name) || help.contains(name));
     }
   }
 


### PR DESCRIPTION
From Hadoop point of view, container UUID/label should not be prepended to file path. Hadoop has lots of UT to verify that. But from DAOS URI, we need container UUID/label. Otherwise, we cannot connect to DAOS. For example, DAOS requires "daos://pool-label/cont-label/root/abc" compared to "daos://pool-label/root/abc" required by Hadoop unit test after being listed from the "root" folder.

To make DAOS URI work, we need to prepend container UUID/label and customize Hadoop defined unit test to bypass the verification.

Signed-off-by: jiafu zhang <jiafu.zhang@intel.com>