### PR TITLE
DAOS-8424 dfuse: fix to update parent inode num for rename

### DIFF
--- a/src/client/dfuse/ops/rename.c
+++ b/src/client/dfuse/ops/rename.c
@@ -48,7 +48,7 @@ dfuse_oid_moved(struct dfuse_projection_info *fs_handle, daos_obj_id_t *oid,
 	}
 
 	/* Update the inode entry data */
-	ie->ie_parent = newparent->ie_parent;
+	ie->ie_parent = newparent->ie_stat.st_ino;
 	strncpy(ie->ie_name, newname, NAME_MAX);
 
 	/* Set the new parent and name */


### PR DESCRIPTION
We intent to udpate parent inode num with new parent inode number.
but it was updated as parent's parent inode number.

Fixes: dc7a4f24f7e ("DAOS-6540 dfuse: Detect clobbered files and update kernel accordingly")
Signed-off-by: Wang Shilong <shilong.wang@intel.com>