### PR TITLE
DAOS-8425 vos: Check evtree for orphaned data

### DIFF
--- a/src/include/daos_srv/evtree.h
+++ b/src/include/daos_srv/evtree.h
@@ -255,8 +255,23 @@ static inline int
 evt_is_empty(struct evt_root *root)
 {
 	D_ASSERT(root != NULL);
+
 	return root->tr_depth == 0;
 }
+
+/** Return true if the tree has any data.   Removal records are
+ *  not considered data.  This is needed for assurance that
+ *  aggregation is not removing any orphaned data.
+ *
+ *  \param root[in]	Tree root
+ *  \param uma[in]	Memory attributes
+ *
+ *  \return		1 if it has data
+ *			0 if it is is empty or has only has removal records
+ *			negative error code on error
+ */
+int
+evt_has_data(struct evt_root *root, struct umem_attr *uma);
 
 enum evt_feats {
 	/** rectangles are Sorted by their Start Offset */

--- a/src/vos/evtree.c
+++ b/src/vos/evtree.c
@@ -2772,9 +2772,11 @@ evt_has_data(struct evt_root *root, struct umem_attr *uma)
 	rc = 0; /* Assume there is no data */
 	evt_ent_array_for_each(ent, tcx->tc_iter.it_entries) {
 		if (ent->en_minor_epc != EVT_MINOR_EPC_MAX) {
+			D_DEBUG(DB_IO, "Found "DF_ENT", stopping search\n", DP_ENT(ent));
 			rc = 1;
 			break;
 		}
+		D_DEBUG(DB_IO, "Ignoring "DF_ENT"\n", DP_ENT(ent));
 	}
 out:
 	evt_tcx_decref(tcx); /* -1 for tcx_create */


### PR DESCRIPTION
We can have orphaned removal records even if there is no
orphaned data.   Augment the check for an empty tree
to only fail if there there is actual data and the tree
isn't just removal entries.  This case can happen if
the EC aggregation inserts removals while aggregation
is processessing the tree.

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>