### PR TITLE
DAOS-8282 control: ListPools() should only include Ready pools

### DIFF
--- a/src/control/server/mgmt_pool.go
+++ b/src/control/server/mgmt_pool.go
@@ -442,7 +442,7 @@ func (svc *mgmtSvc) checkPools(ctx context.Context) error {
 		return err
 	}
 
-	psList, err := svc.sysdb.PoolServiceList()
+	psList, err := svc.sysdb.PoolServiceList(true)
 	if err != nil {
 		return err
 	}
@@ -943,7 +943,7 @@ func (svc *mgmtSvc) ListPools(ctx context.Context, req *mgmtpb.ListPoolsReq) (*m
 	}
 	svc.log.Debugf("MgmtSvc.ListPools dispatch, req:%+v\n", req)
 
-	psList, err := svc.sysdb.PoolServiceList()
+	psList, err := svc.sysdb.PoolServiceList(false)
 	if err != nil {
 		return nil, err
 	}

--- a/src/control/system/database.go
+++ b/src/control/system/database.go
@@ -809,8 +809,9 @@ func copyPoolService(in *PoolService) *PoolService {
 }
 
 // PoolServiceList returns a list of pool services registered
-// with the system.
-func (db *Database) PoolServiceList() ([]*PoolService, error) {
+// with the system. If the all parameter is not true, only
+// pool services in the "Ready" state are returned.
+func (db *Database) PoolServiceList(all bool) ([]*PoolService, error) {
 	if err := db.CheckReplica(); err != nil {
 		return nil, err
 	}
@@ -820,11 +821,12 @@ func (db *Database) PoolServiceList() ([]*PoolService, error) {
 	// NB: This is expensive! We make a copy of the
 	// pool services to ensure that they can't be changed
 	// elsewhere.
-	dbCopy := make([]*PoolService, len(db.data.Pools.Uuids))
-	copyIdx := 0
+	dbCopy := make([]*PoolService, 0, len(db.data.Pools.Uuids))
 	for _, ps := range db.data.Pools.Uuids {
-		dbCopy[copyIdx] = copyPoolService(ps)
-		copyIdx++
+		if ps.State != PoolServiceStateReady && !all {
+			continue
+		}
+		dbCopy = append(dbCopy, copyPoolService(ps))
 	}
 	return dbCopy, nil
 }

--- a/src/control/system/database_test.go
+++ b/src/control/system/database_test.go
@@ -706,12 +706,83 @@ func TestSystem_Database_OnEvent(t *testing.T) {
 
 			<-ctx.Done()
 
-			poolSvcs, err := db.PoolServiceList()
+			poolSvcs, err := db.PoolServiceList(false)
 			if err != nil {
 				t.Fatal(err)
 			}
 
 			cmpOpts := []cmp.Option{
+				cmpopts.IgnoreUnexported(PoolService{}),
+				cmpopts.EquateApproxTime(time.Second),
+			}
+			if diff := cmp.Diff(tc.expPoolSvcs, poolSvcs, cmpOpts...); diff != "" {
+				t.Errorf("unexpected pool service replicas (-want, +got):\n%s\n", diff)
+			}
+		})
+	}
+}
+
+func TestSystemDatabase_PoolServiceList(t *testing.T) {
+	ready := &PoolService{
+		PoolUUID:   uuid.New(),
+		PoolLabel:  "pool0001",
+		State:      PoolServiceStateReady,
+		Replicas:   []Rank{1, 2, 3, 4, 5},
+		LastUpdate: time.Now(),
+	}
+	creating := &PoolService{
+		PoolUUID:   uuid.New(),
+		PoolLabel:  "pool0002",
+		State:      PoolServiceStateCreating,
+		Replicas:   []Rank{1, 2, 3, 4, 5},
+		LastUpdate: time.Now(),
+	}
+	destroying := &PoolService{
+		PoolUUID:   uuid.New(),
+		PoolLabel:  "pool0003",
+		State:      PoolServiceStateDestroying,
+		Replicas:   []Rank{1, 2, 3, 4, 5},
+		LastUpdate: time.Now(),
+	}
+
+	for name, tc := range map[string]struct {
+		poolSvcs    []*PoolService
+		all         bool
+		expPoolSvcs []*PoolService
+	}{
+		"empty": {
+			expPoolSvcs: []*PoolService{},
+		},
+		"all: false": {
+			poolSvcs:    []*PoolService{creating, ready, destroying},
+			expPoolSvcs: []*PoolService{ready},
+		},
+		"all: true": {
+			poolSvcs:    []*PoolService{creating, ready, destroying},
+			all:         true,
+			expPoolSvcs: []*PoolService{creating, ready, destroying},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			log, buf := logging.NewTestLogger(t.Name())
+			defer common.ShowBufferOnFailure(t, buf)
+
+			db := MockDatabase(t, log)
+			for _, ps := range tc.poolSvcs {
+				if err := db.AddPoolService(ps); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			poolSvcs, err := db.PoolServiceList(tc.all)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			cmpOpts := []cmp.Option{
+				cmpopts.SortSlices(func(x, y *PoolService) bool {
+					return x.PoolLabel < y.PoolLabel
+				}),
 				cmpopts.IgnoreUnexported(PoolService{}),
 				cmpopts.EquateApproxTime(time.Second),
 			}


### PR DESCRIPTION
The user-visible list should only include pools that are
ready to be used.