### PR TITLE
DAOS-8344 dtx: send DTX batched commit RPC via helper SX

### DIFF
--- a/src/dtx/dtx_common.c
+++ b/src/dtx/dtx_common.c
@@ -483,7 +483,7 @@ dtx_batched_commit_one(void *arg)
 		if (cnt <= 0)
 			break;
 
-		rc = dtx_commit(cont, dtes, dcks, cnt);
+		rc = dtx_commit(cont, dtes, dcks, cnt, true);
 		dtx_free_committable(dtes, dcks, cnt);
 		if (rc != 0)
 			break;
@@ -1234,7 +1234,7 @@ dtx_leader_end(struct dtx_leader_handle *dlh, struct ds_cont_child *cont,
 sync:
 	if (dth->dth_sync) {
 		dte = &dth->dth_dte;
-		rc = dtx_commit(cont, &dte, NULL, 1);
+		rc = dtx_commit(cont, &dte, NULL, 1, false);
 		if (rc != 0) {
 			D_ERROR(DF_UUID": Fail to sync commit DTX "DF_DTI
 				": "DF_RC"\n", DP_UUID(cont->sc_uuid),
@@ -1426,7 +1426,7 @@ dtx_flush_on_deregister(struct dss_module_info *dmi,
 			  (unsigned long)total,
 			  (unsigned long)stat.dtx_committable_count);
 
-		rc = dtx_commit(cont, dtes, dcks, cnt);
+		rc = dtx_commit(cont, dtes, dcks, cnt, true);
 		dtx_free_committable(dtes, dcks, cnt);
 	}
 
@@ -1784,7 +1784,7 @@ dtx_obj_sync(struct ds_cont_child *cont, daos_unit_oid_t *oid,
 			break;
 		}
 
-		rc = dtx_commit(cont, dtes, dcks, cnt);
+		rc = dtx_commit(cont, dtes, dcks, cnt, true);
 		dtx_free_committable(dtes, dcks, cnt);
 		if (rc < 0) {
 			D_ERROR("Fail to commit dtx: "DF_RC"\n", DP_RC(rc));

--- a/src/dtx/dtx_internal.h
+++ b/src/dtx/dtx_internal.h
@@ -135,7 +135,7 @@ uint64_t dtx_cos_oldest(struct ds_cont_child *cont);
 
 /* dtx_rpc.c */
 int dtx_commit(struct ds_cont_child *cont, struct dtx_entry **dtes,
-	       struct dtx_cos_key *dcks, int count);
+	       struct dtx_cos_key *dcks, int count, bool helper);
 int dtx_check(struct ds_cont_child *cont, struct dtx_entry *dte,
 	      daos_epoch_t epoch);
 

--- a/src/dtx/dtx_resync.c
+++ b/src/dtx/dtx_resync.c
@@ -103,7 +103,7 @@ next:
 	}
 
 	if (j > 0) {
-		rc = dtx_commit(cont, dtes, dcks, j);
+		rc = dtx_commit(cont, dtes, dcks, j, true);
 		if (rc < 0)
 			D_ERROR("Failed to commit the DTXs: rc = "DF_RC"\n",
 				DP_RC(rc));

--- a/src/dtx/dtx_rpc.c
+++ b/src/dtx/dtx_rpc.c
@@ -563,34 +563,77 @@ dtx_dti_classify_one(struct ds_pool *pool, daos_handle_t tree, d_list_t *head,
 
 static int
 dtx_dti_classify(struct ds_pool *pool, daos_handle_t tree,
-		 struct dtx_entry **dtes, int count,
-		 d_list_t *head, struct dtx_id **dtis)
+		 d_list_t *head, struct dtx_id *dtis,
+		 struct dtx_entry **dtes, int count)
 {
-	struct dtx_id		*dti = NULL;
-	int			 length = 0;
-	int			 rc = 0;
-	int			 i;
+	int	length = 0;
+	int	rc = 0;
+	int	i;
 
-	D_ALLOC_ARRAY(dti, count);
-	if (dti != NULL) {
-		for (i = 0; i < count; i++) {
-			rc = dtx_dti_classify_one(pool, tree, head, &length,
-						  dtes[i], count);
-			if (rc < 0)
-				break;
+	for (i = 0; i < count; i++) {
+		rc = dtx_dti_classify_one(pool, tree, head, &length,
+					  dtes[i], count);
+		if (rc < 0)
+			break;
 
-			dti[i] = dtes[i]->dte_xid;
-		}
-
-		if (rc >= 0)
-			*dtis = dti;
-		else if (dti != NULL)
-			D_FREE(dti);
-	} else {
-		rc = -DER_NOMEM;
+		if (dtis != NULL)
+			dtis[i] = dtes[i]->dte_xid;
 	}
 
 	return rc < 0 ? rc : length;
+}
+
+struct dtx_commit_args {
+	struct ds_cont_child	 *dca_cont;
+	d_list_t		 *dca_head;
+	struct btr_root		 *dca_tree_root;
+	daos_handle_t		 *dca_tree_hdl;
+	struct dtx_req_args	 *dca_dra;
+	struct dtx_entry	**dca_dtes;
+	int			  dca_count;
+};
+
+static int
+dtx_commit_internal(struct ds_cont_child *cont, d_list_t *head,
+		    struct btr_root *tree_root, daos_handle_t *tree_hdl,
+		    struct dtx_req_args *dra, struct dtx_id *dtis,
+		    struct dtx_entry **dtes, int count)
+{
+	struct umem_attr	 uma = { 0 };
+	int			 length;
+	int			 rc;
+
+	uma.uma_id = UMEM_CLASS_VMEM;
+	rc = dbtree_create_inplace(DBTREE_CLASS_DTX_CF, 0, DTX_CF_BTREE_ORDER,
+				   &uma, tree_root, tree_hdl);
+	if (rc != 0)
+		return rc;
+
+	length = dtx_dti_classify(cont->sc_pool->spc_pool, *tree_hdl,
+				  head, dtis, dtes, count);
+	if (length < 0)
+		return length;
+
+	if (d_list_empty(head))
+		return 0;
+
+	D_ASSERT(length > 0);
+
+	return dtx_req_list_send(dra, DTX_COMMIT, head, length,
+				 cont->sc_pool->spc_pool->sp_uuid,
+				 cont->sc_uuid, 0, NULL, NULL, NULL, NULL);
+}
+
+static void
+dtx_commit_helper(void *arg)
+{
+	struct dtx_commit_args	*dca = arg;
+
+	dtx_commit_internal(dca->dca_cont, dca->dca_head, dca->dca_tree_root,
+			    dca->dca_tree_hdl, dca->dca_dra, NULL,
+			    dca->dca_dtes, dca->dca_count);
+
+	D_FREE(dca);
 }
 
 /**
@@ -609,39 +652,57 @@ dtx_dti_classify(struct ds_pool *pool, daos_handle_t tree,
  */
 int
 dtx_commit(struct ds_cont_child *cont, struct dtx_entry **dtes,
-	   struct dtx_cos_key *dcks, int count)
+	   struct dtx_cos_key *dcks, int count, bool helper)
 {
 	struct dtx_req_args	 dra;
 	struct dtx_req_rec	*drr;
-	struct ds_pool		*pool = cont->sc_pool->spc_pool;
-	struct dtx_id		*dti = NULL;
+	struct dtx_id		*dtis = NULL;
 	bool			*rm_cos = NULL;
-	struct umem_attr	 uma;
 	struct btr_root		 tree_root = { 0 };
 	daos_handle_t		 tree_hdl = DAOS_HDL_INVAL;
 	d_list_t		 head;
-	int			 length;
+	ABT_thread		 child = ABT_THREAD_NULL;
+	struct dtx_commit_args	*cmt_arg = NULL;
 	int			 rc;
 	int			 rc1 = 0;
 	int			 rc2 = 0;
+	int			 i;
 
-	D_INIT_LIST_HEAD(&head);
-	memset(&uma, 0, sizeof(uma));
-	uma.uma_id = UMEM_CLASS_VMEM;
-	rc = dbtree_create_inplace(DBTREE_CLASS_DTX_CF, 0, DTX_CF_BTREE_ORDER,
-				   &uma, &tree_root, &tree_hdl);
-	if (rc != 0)
-		goto out;
-
-	length = dtx_dti_classify(pool, tree_hdl, dtes, count, &head, &dti);
-	if (length < 0)
-		D_GOTO(out, rc = length);
+	D_ASSERT(count >= 1);
 
 	dra.dra_future = ABT_FUTURE_NULL;
-	if (!d_list_empty(&head)) {
-		rc = dtx_req_list_send(&dra, DTX_COMMIT, &head, length,
-				       pool->sp_uuid, cont->sc_uuid, 0,
-				       NULL, NULL, NULL, NULL);
+	D_INIT_LIST_HEAD(&head);
+
+	D_ALLOC_ARRAY(dtis, count);
+	if (dtis == NULL)
+		D_GOTO(out, rc = -DER_NOMEM);
+
+	if (helper) {
+		D_ALLOC_PTR(cmt_arg);
+		if (cmt_arg == NULL)
+			D_GOTO(out, rc = -DER_NOMEM);
+
+		cmt_arg->dca_cont = cont;
+		cmt_arg->dca_head = &head;
+		cmt_arg->dca_tree_root = &tree_root;
+		cmt_arg->dca_tree_hdl = &tree_hdl;
+		cmt_arg->dca_dra = &dra;
+		cmt_arg->dca_dtes = dtes;
+		cmt_arg->dca_count = count;
+
+		rc = dss_ult_create(dtx_commit_helper, cmt_arg, DSS_XS_IOFW,
+				    dss_get_module_info()->dmi_tgt_id,
+				    DSS_DEEP_STACK_SZ, &child);
+		if (rc != 0) {
+			D_FREE(cmt_arg);
+			goto out;
+		}
+
+		for (i = 0; i < count; i++)
+			dtis[i] = dtes[i]->dte_xid;
+	} else {
+		rc = dtx_commit_internal(cont, &head, &tree_root, &tree_hdl,
+					 &dra, dtis, dtes, count);
 		if (rc != 0)
 			goto out;
 	}
@@ -652,15 +713,13 @@ dtx_commit(struct ds_cont_child *cont, struct dtx_entry **dtes,
 			D_GOTO(out, rc1 = -DER_NOMEM);
 	}
 
-	rc1 = vos_dtx_commit(cont->sc_hdl, dti, count, rm_cos);
+	rc1 = vos_dtx_commit(cont->sc_hdl, dtis, count, rm_cos);
 	if (rc1 >= 0 && rm_cos != NULL) {
-		int	i;
-
 		for (i = 0; i < count; i++) {
 			if (rm_cos[i]) {
 				D_ASSERT(!daos_oid_is_null(dcks[i].oid.id_pub));
 
-				dtx_del_cos(cont, &dti[i], &dcks[i].oid,
+				dtx_del_cos(cont, &dtis[i], &dcks[i].oid,
 					    dcks[i].dkey_hash);
 			}
 		}
@@ -668,9 +727,13 @@ dtx_commit(struct ds_cont_child *cont, struct dtx_entry **dtes,
 
 	D_FREE(rm_cos);
 
+out:
 	/* -DER_NONEXIST may be caused by race or repeated commit, ignore it. */
 	if (rc1 == -DER_NONEXIST)
 		rc1 = 0;
+
+	if (child != ABT_THREAD_NULL)
+		ABT_thread_join(child);
 
 	if (dra.dra_future != ABT_FUTURE_NULL) {
 		rc2 = dtx_req_wait(&dra);
@@ -678,12 +741,11 @@ dtx_commit(struct ds_cont_child *cont, struct dtx_entry **dtes,
 			rc2 = 0;
 	}
 
-out:
 	D_CDEBUG(rc < 0 || rc1 < 0 || rc2 < 0, DLOG_ERR, DB_IO,
 		 "Commit DTXs "DF_DTI", count %d: rc %d %d %d\n",
 		 DP_DTI(&dtes[0]->dte_xid), count, rc, rc1, rc2);
 
-	D_FREE(dti);
+	D_FREE(dtis);
 
 	if (daos_handle_is_valid(tree_hdl))
 		dbtree_destroy(tree_hdl, NULL);
@@ -705,33 +767,39 @@ dtx_abort(struct ds_cont_child *cont, daos_epoch_t epoch,
 	struct dtx_req_args	 dra;
 	struct dtx_req_rec	*drr;
 	struct ds_pool		*pool = cont->sc_pool->spc_pool;
-	struct dtx_id		*dti = NULL;
-	struct umem_attr	 uma;
+	struct dtx_id		*dtis = NULL;
+	struct umem_attr	 uma = { 0 };
 	struct btr_root		 tree_root = { 0 };
 	daos_handle_t		 tree_hdl = DAOS_HDL_INVAL;
 	d_list_t		 head;
 	int			 length;
 	int			 rc;
 
+	D_ASSERT(count >= 1);
+
+	dra.dra_future = ABT_FUTURE_NULL;
 	D_INIT_LIST_HEAD(&head);
-	memset(&uma, 0, sizeof(uma));
+
+	D_ALLOC_ARRAY(dtis, count);
+	if (dtis == NULL)
+		D_GOTO(out, rc = -DER_NOMEM);
+
 	uma.uma_id = UMEM_CLASS_VMEM;
 	rc = dbtree_create_inplace(DBTREE_CLASS_DTX_CF, 0, DTX_CF_BTREE_ORDER,
 				   &uma, &tree_root, &tree_hdl);
 	if (rc != 0)
 		goto out;
 
-	length = dtx_dti_classify(pool, tree_hdl, dtes, count, &head, &dti);
+	length = dtx_dti_classify(pool, tree_hdl, &head, dtis, dtes, count);
 	if (length < 0)
 		D_GOTO(out, rc = length);
 
-	D_ASSERT(dti != NULL);
-
 	/* Local abort firstly. */
 	if (epoch != 0)
-		rc = vos_dtx_abort(cont->sc_hdl, epoch, dti, count);
+		rc = vos_dtx_abort(cont->sc_hdl, epoch, dtis, count);
 	else
-		rc = vos_dtx_set_flags(cont->sc_hdl, dti, count, DTE_CORRUPTED);
+		rc = vos_dtx_set_flags(cont->sc_hdl, dtis, count,
+				       DTE_CORRUPTED);
 
 	if (rc > 0 || rc == -DER_NONEXIST)
 		rc = 0;
@@ -753,7 +821,7 @@ out:
 		 "Abort DTXs "DF_DTI", count %d: rc %d\n",
 		 DP_DTI(&dtes[0]->dte_xid), count, rc);
 
-	D_FREE(dti);
+	D_FREE(dtis);
 
 	if (daos_handle_is_valid(tree_hdl))
 		dbtree_destroy(tree_hdl, NULL);
@@ -1029,7 +1097,7 @@ next:
 
 			dck.oid = dsp->dsp_oid;
 			dck.dkey_hash = dsp->dsp_dkey_hash;
-			rc = dtx_commit(cont, &pdte, &dck, 1);
+			rc = dtx_commit(cont, &pdte, &dck, 1, false);
 			if (rc < 0 && rc != -DER_NONEXIST && cmt_list != NULL)
 				d_list_add_tail(&dsp->dsp_link, cmt_list);
 			else

--- a/src/dtx/dtx_srv.c
+++ b/src/dtx/dtx_srv.c
@@ -266,7 +266,7 @@ out:
 		/* Commit the DTX after replied the original refresh request to
 		 * avoid further query the same DTX.
 		 */
-		rc = dtx_commit(cont, pdte, dcks, j);
+		rc = dtx_commit(cont, pdte, dcks, j, false);
 		if (rc < 0)
 			D_WARN("Failed to commit DTX "DF_DTI", count %d: "
 			       DF_RC"\n", DP_DTI(&dtes[0].dte_xid), j,


### PR DESCRIPTION
For the object with multiple shards (such as 16 + 2 EC), the DTX
batched commit operation against hundreds of DTX entries, the RPC
sending to multiple non-leader servers may take some long time. We
can use the helper XS to speedup related process.

Signed-off-by: Fan Yong <fan.yong@intel.com>