### PR TITLE
DAOS-8428 Failed to list file having comma character in name

### DIFF
--- a/src/client/java/daos-java/src/main/java/io/daos/dfs/DaosFile.java
+++ b/src/client/java/daos-java/src/main/java/io/daos/dfs/DaosFile.java
@@ -285,7 +285,7 @@ public class DaosFile {
     //no limit to max returned entries for now
     String children = client.dfsReadDir(dfsPtr, objId, -1);
     return (children == null || (children = children.trim()).length() == 0) ?
-            new String[]{} : children.split(",");
+            new String[]{} : children.split("//");
   }
 
   /**

--- a/src/client/java/daos-java/src/main/native/io_daos_dfs_DaosFsClient.c
+++ b/src/client/java/daos-java/src/main/native/io_daos_dfs_DaosFsClient.c
@@ -1048,8 +1048,8 @@ Java_io_daos_dfs_DaosFsClient_dfsReadDir(JNIEnv *env, jobject client,
 		int i;
 
 		for (i = 0; i < nr; i++) {
-			/* exactly 1 for each file because ',' and \0 */
-			acc += strlen(entries[i].d_name) + 1;
+			/* exactly 1 for each file because of separator // and \0 */
+			acc += strlen(entries[i].d_name) + 2;
 			if (acc >= size) {
 				size += READ_DIR_INITIAL_BUFFER_SIZE;
 				buffer = realloc(buffer, size);
@@ -1064,7 +1064,7 @@ Java_io_daos_dfs_DaosFsClient_dfsReadDir(JNIEnv *env, jobject client,
 					break;
 				}
 			}
-			if (buffer[0]) strcat(buffer, ",");
+			if (buffer[0]) strcat(buffer, "//");
 			strcat(buffer, entries[i].d_name);
 		}
 	}

--- a/src/client/java/hadoop-daos/src/test/java/io/daos/fs/hadoop/HadoopCmdIT.java
+++ b/src/client/java/hadoop-daos/src/test/java/io/daos/fs/hadoop/HadoopCmdIT.java
@@ -66,17 +66,42 @@ public class HadoopCmdIT {
   }
 
   @Test
-  public void testMkdir() throws Exception {
+  public void testMkdirSpecialLongPath() throws Exception {
     String filePath = DaosFSFactory.DAOS_URI +"/zjf/job_1581472776049_0003-1581473346405-" +
         "root-autogen%2D7.1%2DSNAPSHOT%2Djar%2Dwith%2Ddependencies.jar-" +
         "1581473454525-16-1-SUCCEEDED-default-1581473439146.jhist_tmp";
     String[] argv = new String[]{"-rm", "-r", filePath};
-    int res = run(argv);
+    run(argv);
 
     String[] argv2 = new String[]{"-mkdir", "-p", filePath};
-    res = run(argv2);
+    int res = run(argv2);
     Assert.assertTrue(res == 0);
 
+    res = run(argv);
+    Assert.assertTrue(res == 0);
+  }
+
+  @Test
+  public void testMkdirSpecialEqualAndComma() throws Exception {
+    String filePath = DaosFSFactory.DAOS_URI +"/zjf/useDecimal=true,xyz=1";
+    String filePath2 = DaosFSFactory.DAOS_URI +"/zjf/normal";
+    String[] argv = new String[]{"-rm", "-r", filePath};
+    run(argv);
+
+    String[] argv0 = new String[]{"-rm", "-r", filePath2};
+    run(argv0);
+
+    String[] argv2 = new String[]{"-mkdir", "-p", filePath};
+    int res = run(argv2);
+    Assert.assertTrue(res == 0);
+
+    String[] argv20 = new String[]{"-mkdir", "-p", filePath2};
+    res = run(argv20);
+    Assert.assertTrue(res == 0);
+
+    String[] argv3 = new String[]{"-ls", DaosFSFactory.DAOS_URI +"/zjf"};
+    res = run(argv3);
+    Assert.assertTrue(res == 0);
     res = run(argv);
     Assert.assertTrue(res == 0);
   }


### PR DESCRIPTION
fixed issue by using "//" as separator instead of ',' to separate file names in one string buffer return to JVM from JNI.

Signed-off-by: jiafu zhang <jiafu.zhang@intel.com>