### PR TITLE
DAOS-8430 bio: Fix consecutive reserving

### DIFF
--- a/src/bio/bio_buffer.c
+++ b/src/bio/bio_buffer.c
@@ -583,6 +583,66 @@ direct_scm_access(struct bio_desc *biod, struct bio_iov *biov)
 	return false;
 }
 
+static bool
+iod_expand_region(struct bio_iov *biov, struct bio_rsrvd_region *last_rg,
+		  uint64_t off, uint64_t end, unsigned int pg_cnt, unsigned int pg_off)
+{
+	uint64_t		cur_pg, prev_pg_start, prev_pg_end;
+	unsigned int		chk_pg_idx;
+	struct bio_dma_chunk	*chk = last_rg->brr_chk;
+	bool			forward = true;
+
+	chk_pg_idx = last_rg->brr_pg_idx;
+	D_ASSERT(chk_pg_idx < bio_chk_sz);
+
+	prev_pg_start = last_rg->brr_off >> BIO_DMA_PAGE_SHIFT;
+	prev_pg_end = last_rg->brr_end >> BIO_DMA_PAGE_SHIFT;
+	cur_pg = off >> BIO_DMA_PAGE_SHIFT;
+	D_ASSERT(prev_pg_start <= prev_pg_end);
+
+	/* Only merge NVMe regions */
+	if (bio_iov2media(biov) == DAOS_MEDIA_SCM ||
+	    bio_iov2media(biov) != last_rg->brr_media)
+		return false;
+
+	/* Not consecutive with prev rg */
+	if (cur_pg != prev_pg_end)
+		return false;
+
+	if (last_rg->brr_off < off) {		/* Forward merge */
+		if (last_rg->brr_end <= off) {
+			chk_pg_idx += (prev_pg_end - prev_pg_start);
+			goto reserve;
+		}
+		/* Overlapping */
+	} else if (last_rg->brr_off > off) {	/* Backward merge */
+		if (end <= last_rg->brr_off) {
+			/* Two regions must be covered by same page */
+			D_ASSERT(pg_cnt == 1 && prev_pg_end == prev_pg_start);
+			forward = false;
+			goto reserve;
+		}
+		/* Overlapping */
+	}
+
+	D_DEBUG(DB_IO, "overlapping IOVs: ["DF_U64", "DF_U64"), ["DF_U64", "DF_U64")\n",
+		last_rg->brr_off, last_rg->brr_end, off, end);
+	return false;
+reserve:
+	bio_iov_set_raw_buf(biov, chunk_reserve(chk, chk_pg_idx, pg_cnt, pg_off));
+	if (bio_iov2raw_buf(biov) == NULL)
+		return false;
+
+	if (forward)
+		last_rg->brr_end = end;
+	else
+		last_rg->brr_off = off;
+
+	D_DEBUG(DB_TRACE, "%s consecutive reserve %p.\n",
+		forward ? "Forward" : "Backward", bio_iov2raw_buf(biov));
+	return true;
+}
+
 /* Convert offset of @biov into memory pointer */
 int
 dma_map_one(struct bio_desc *biod, struct bio_iov *biov, void *arg)
@@ -645,36 +705,16 @@ dma_map_one(struct bio_desc *biod, struct bio_iov *biov, void *arg)
 	last_rg = iod_last_region(biod);
 
 	/* First, try consecutive reserve from the last reserved region */
-	if (last_rg && bio_iov2media(biov) != DAOS_MEDIA_SCM &&
-	    bio_iov2media(biov) == last_rg->brr_media) {
-		uint64_t cur_pg, prev_pg_start, prev_pg_end;
-
+	if (last_rg) {
 		D_DEBUG(DB_TRACE, "Last region %p:%d ["DF_U64","DF_U64")\n",
 			last_rg->brr_chk, last_rg->brr_pg_idx,
 			last_rg->brr_off, last_rg->brr_end);
 
 		chk = last_rg->brr_chk;
 		D_ASSERT(biod->bd_chk_type == chk->bdc_type);
-		chk_pg_idx = last_rg->brr_pg_idx;
-		D_ASSERT(chk_pg_idx < bio_chk_sz);
 
-		prev_pg_start = last_rg->brr_off >> BIO_DMA_PAGE_SHIFT;
-		prev_pg_end = last_rg->brr_end >> BIO_DMA_PAGE_SHIFT;
-		cur_pg = off >> BIO_DMA_PAGE_SHIFT;
-		D_ASSERT(prev_pg_start <= prev_pg_end);
-
-		/* Consecutive in page */
-		if (cur_pg == prev_pg_end) {
-			chk_pg_idx += (prev_pg_end - prev_pg_start);
-			bio_iov_set_raw_buf(biov,
-				chunk_reserve(chk, chk_pg_idx, pg_cnt, pg_off));
-			if (bio_iov2raw_buf(biov) != NULL) {
-				D_DEBUG(DB_TRACE, "Consecutive reserve %p.\n",
-					bio_iov2raw_buf(biov));
-				last_rg->brr_end = end;
-				return 0;
-			}
-		}
+		if (iod_expand_region(biov, last_rg, off, end, pg_cnt, pg_off))
+			return 0;
 	}
 
 	/* Try to reserve from the last DMA chunk in io descriptor */


### PR DESCRIPTION
When mapping DMA buffer to NVMe IOVs, we always check if current IOV
is contiguous with previous mapped IOV, if they are congiguous
(current IOV starts from the same blob page where the previous IOV
ended), we just expand the existing reserved region to avoid issuing
two blob I/Os against the same blob page.

There is a defect in current "consecutive reserve" which overlooked
a case: current IOV and previous IOV are both small IOV within same
blob page, and current IOV is ahead of previous IOV, for example:
current IOV is [100, 200), previous IOV is [300, 400).

Signed-off-by: Niu Yawei <yawei.niu@intel.com>