### PR TITLE
DAOS-7125 test: autotest skip and time limit

### DIFF
--- a/src/control/cmd/daos/pool.go
+++ b/src/control/cmd/daos/pool.go
@@ -393,6 +393,9 @@ func (cmd *poolDelAttrCmd) Execute(_ []string) error {
 
 type poolAutoTestCmd struct {
 	poolBaseCmd
+
+	SkipBig       C.bool `long:"skip-big" short:"S" description:"skip big tests"`
+	DeadlineLimit C.int  `long:"deadline-limit" short:"D" description:"deadline limit for test (seconds)"`
 }
 
 func (cmd *poolAutoTestCmd) Execute(_ []string) error {
@@ -419,6 +422,10 @@ func (cmd *poolAutoTestCmd) Execute(_ []string) error {
 	if err != nil {
 		return err
 	}
+
+	ap.skip_big = C.bool(cmd.SkipBig)
+
+	ap.deadline_limit = C.int(cmd.DeadlineLimit)
 
 	rc := C.pool_autotest_hdlr(ap)
 	if err := daosError(rc); err != nil {

--- a/src/utils/daos_hdlr.h
+++ b/src/utils/daos_hdlr.h
@@ -110,6 +110,10 @@ struct cmd_args_s {
 	char			*dfs_prefix;	/* --dfs-prefix name */
 	char			*dfs_path;	/* --dfs-path file/dir */
 
+	/* autotest related */
+	bool			skip_big;	/* skip big tests */
+	int			deadline_limit;	/* deadline limit for tests */
+
 	FILE			*ostream;	/* help_hdlr() stream */
 	char			*outfile;	/* --outfile path */
 	char			*aclfile;	/* --acl-file path */


### PR DESCRIPTION
The following capabilities were added to autotest:
	-"S" option skip big test (steps 28, 29)
	-Added time limit for tests
		"D" option to specify limit in seconds

Signed-off-by: Christopher Hoffman <christopherx.hoffman@intel.com>