### PR TITLE
DAOS-8445 tests: run daos_racer with multiple client ranks

### DIFF
--- a/src/tests/ftest/daos_racer/daos_racer.py
+++ b/src/tests/ftest/daos_racer/daos_racer.py
@@ -34,8 +34,9 @@ class DaosRacerTest(TestWithServers):
         dmg = self.get_dmg_command()
         self.assertGreater(
             len(self.hostlist_clients), 0,
-            "This test requires one client: {}".format(self.hostlist_clients))
-        daos_racer = DaosRacerCommand(self.bin, self.hostlist_clients[0], dmg)
+            "This test requires two clients: {}".format(self.hostlist_clients))
+        daos_racer = DaosRacerCommand(
+            self.bin, self.hostlist_clients[0],self.hostlist_clients[1], dmg)
         daos_racer.get_params(self)
         daos_racer.set_environment(
             daos_racer.get_environment(self.server_managers[0]))

--- a/src/tests/ftest/daos_racer/daos_racer.yaml
+++ b/src/tests/ftest/daos_racer/daos_racer.yaml
@@ -6,8 +6,8 @@ hosts:
     - server-D
     - server-E
     - server-F
-    - server-G
   test_clients:
+    - client-G
     - client-H
 timeout: 10800
 server_config:

--- a/src/tests/ftest/daos_racer/daos_racer_simple.py
+++ b/src/tests/ftest/daos_racer/daos_racer_simple.py
@@ -36,8 +36,9 @@ class DaosRacerTest(TestWithServers):
         dmg = self.get_dmg_command()
         self.assertGreater(
             len(self.hostlist_clients), 0,
-            "This test requires one client: {}".format(self.hostlist_clients))
-        daos_racer = DaosRacerCommand(self.bin, self.hostlist_clients[0], dmg)
+            "This test requires two clients: {}".format(self.hostlist_clients))
+        daos_racer = DaosRacerCommand(
+            self.bin, self.hostlist_clients[0],self.hostlist_clients[1], dmg)
         daos_racer.get_params(self)
         daos_racer.set_environment(
             daos_racer.get_environment(self.server_managers[0]))

--- a/src/tests/ftest/daos_racer/daos_racer_simple.yaml
+++ b/src/tests/ftest/daos_racer/daos_racer_simple.yaml
@@ -6,8 +6,8 @@ hosts:
     - server-D
     - server-E
     - server-F
-    - server-G
   test_clients:
+    - client-G
     - client-H
 timeout: 1800
 server_config:


### PR DESCRIPTION
That will help to generate more race conditions.

Signed-off-by: Fan Yong <fan.yong@intel.com>