### PR TITLE
DAOS-8374 Test: Fix regression in test.

### DIFF
--- a/src/tests/ftest/erasurecode/ec_aggregation.yaml
+++ b/src/tests/ftest/erasurecode/ec_aggregation.yaml
@@ -67,7 +67,7 @@ ior:
    - [32MB, 16MB, 128]
    - [32MB, 1GB, 1M]
   objectclass:
-   dfs_oclass:
+   dfs_oclass_list:
     #[EC_Object_Class, Minimum number of servers]
     - ["EC_2P1G1", 4]
     - ["EC_4P1G1", 6]

--- a/src/tests/ftest/erasurecode/ec_offline_rebuild.yaml
+++ b/src/tests/ftest/erasurecode/ec_offline_rebuild.yaml
@@ -74,7 +74,7 @@ ior:
    - [32M, 128M, 8M]       #Full Striped
    #- [32M, 128M, 2K]       #Patrtial Striped
   objectclass:
-   dfs_oclass:
+   dfs_oclass_list:
     #- [EC_Object_Class, Minimum number of servers]
     - ["EC_2P1G1", 6]
     - ["EC_4P1G1", 8]

--- a/src/tests/ftest/erasurecode/ec_offline_rebuild_single.yaml
+++ b/src/tests/ftest/erasurecode/ec_offline_rebuild_single.yaml
@@ -65,7 +65,7 @@ container:
       # [object_qty, record_qty, dkey, akey, data_size]
       - [1, 1, 1, 1, 4194304]
 objectclass:
-    dfs_oclass:
+    dfs_oclass_list:
       #- [EC_Object_Class, Minimum number of servers]
       - ["OC_EC_2P1G1", 6]
       - ["OC_EC_2P2G1", 6]

--- a/src/tests/ftest/erasurecode/ec_online_rebuild.yaml
+++ b/src/tests/ftest/erasurecode/ec_online_rebuild.yaml
@@ -74,7 +74,7 @@ ior:
    - [32M, 4G, 8M]       #Full Striped
    #- [32M, 128M, 2K]       #Patrtial Striped
   objectclass:
-   dfs_oclass:
+   dfs_oclass_list:
     #- [EC_Object_Class, Minimum number of servers]
     - ["EC_2P2G1", 6]
     - ["EC_4P2G1", 8]

--- a/src/tests/ftest/erasurecode/ec_online_rebuild_single.yaml
+++ b/src/tests/ftest/erasurecode/ec_online_rebuild_single.yaml
@@ -65,7 +65,7 @@ container:
       # [object_qty, record_qty, dkey, akey, data_size]
       - [1, 1, 1, 1, 4194304]
 objectclass:
-    dfs_oclass:
+    dfs_oclass_list:
       #- [EC_Object_Class, Minimum number of servers]
       - ["OC_EC_2P2G1", 6]
       - ["OC_EC_4P2G1", 8]

--- a/src/tests/ftest/erasurecode/ec_rebuild_disabled.yaml
+++ b/src/tests/ftest/erasurecode/ec_rebuild_disabled.yaml
@@ -73,7 +73,7 @@ ior:
    - [32M, 128M, 8M]       #Full Striped
    #- [32M, 128M, 2K]       #Patrtial Striped
   objectclass:
-   dfs_oclass:
+   dfs_oclass_list:
     #- [EC_Object_Class, Minimum number of servers]
     - ["EC_2P1G1", 4]
     - ["EC_4P1G1", 6]

--- a/src/tests/ftest/erasurecode/ec_rebuild_disabled_single.yaml
+++ b/src/tests/ftest/erasurecode/ec_rebuild_disabled_single.yaml
@@ -60,7 +60,7 @@ container:
       # [object_qty, record_qty, dkey, akey, data_size]
       - [1, 1, 1, 1, 4194304]
 objectclass:
-    dfs_oclass:
+    dfs_oclass_list:
       #- [EC_Object_Class, Minimum number of servers]
       - ["OC_EC_2P1G1", 4]
       - ["OC_EC_2P2G1", 4]

--- a/src/tests/ftest/util/ec_utils.py
+++ b/src/tests/ftest/util/ec_utils.py
@@ -90,7 +90,7 @@ class ErasureCodeIor(ServerFillUp):
         # Create the Pool
         self.create_pool_max_size()
         self.update_ior_cmd_with_pool()
-        self.obj_class = self.params.get("dfs_oclass",
+        self.obj_class = self.params.get("dfs_oclass_list",
                                          '/run/ior/objectclass/*')
         self.ior_chu_trs_blk_size = self.params.get(
             "chunk_block_transfer_sizes", '/run/ior/*')
@@ -215,7 +215,7 @@ class ErasureCodeSingle(TestWithServers):
         engine_count = self.server_managers[0].get_config_value(
             "engines_per_host")
         self.server_count = len(self.hostlist_servers) * engine_count
-        self.obj_class = self.params.get("dfs_oclass",
+        self.obj_class = self.params.get("dfs_oclass_list",
                                          '/run/objectclass/*')
         self.singledata_set = self.params.get("single_data_set",
                                               '/run/container/*')


### PR DESCRIPTION
During TB5 testing, there are few test failed when try to
create the container.This test has the dfs_oclass as list with
server numbers.
So changing the default obj_class name in yaml file.

Quick-Functional: true
Test-tag-hw-small: pr ec
Test-tag-hw-medium: pr ec
Test-tag-hw-large: pr ec

Signed-off-by: Samir Raval <samir.raval@intel.com>