### PR TITLE
DAOS-7874 build: Add SPDK patch for ICX VMD driver update

### DIFF
--- a/utils/build.config
+++ b/utils/build.config
@@ -14,4 +14,4 @@ PSM2 = PSM2_11.2.78
 PROTOBUFC = v1.3.3
 
 [patch_versions]
-spdk=https://github.com/spdk/spdk/commit/690783a3ae82ebe58c00d643520a66103d66d540.diff
+spdk=https://github.com/spdk/spdk/commit/690783a3ae82ebe58c00d643520a66103d66d540.diff,https://github.com/spdk/spdk/commit/65425be69a0882ac283fb489aa151d7df06c52ad.diff


### PR DESCRIPTION
There are a few silicon changes with VMD for the IceLake platform found
when testing on a Coyote Pass system. First off, the bus numbering is
different (half of bus numbers now available), new BUS RESTRICTION VMD
registers, and the PCIe device ID has also been updated to 0x28c0.

Patch has been landed to SPDK, as that is where the code for unbinding
the VMD devices and finding the backing NVMe SSDs can be found. Apply
this patch in the meantime until the next SPDK version update. This will allow
VMD to be used on all Icelake systems, where currently functionality is broken.

SPDK PR: https://review.spdk.io/gerrit/c/spdk/spdk/+/8331

Signed-off-by: Sydney Vanda <sydney.m.vanda@intel.com>