### PR TITLE
DAOS-8439 common: convert PMDK positive errno to DAOS errno

### DIFF
--- a/src/common/mem.c
+++ b/src/common/mem.c
@@ -86,8 +86,13 @@ pmem_tx_free(struct umem_instance *umm, umem_off_t umoff)
 	if (pmemobj_tx_stage() == TX_STAGE_ONABORT)
 		return 0;
 
-	if (!UMOFF_IS_NULL(umoff))
-		return pmemobj_tx_free(umem_off2id(umm, umoff));
+	if (!UMOFF_IS_NULL(umoff)) {
+		int	rc;
+
+		rc = pmemobj_tx_free(umem_off2id(umm, umoff));
+		return rc ? umem_tx_errno(rc) : 0;
+	}
+
 	return 0;
 }
 
@@ -102,22 +107,31 @@ static int
 pmem_tx_add(struct umem_instance *umm, umem_off_t umoff,
 	    uint64_t offset, size_t size)
 {
-	return pmemobj_tx_add_range(umem_off2id(umm, umoff), offset, size);
+	int	rc;
+
+	rc = pmemobj_tx_add_range(umem_off2id(umm, umoff), offset, size);
+	return rc ? umem_tx_errno(rc) : 0;
 }
 
 static int
 pmem_tx_xadd(struct umem_instance *umm, umem_off_t umoff, uint64_t offset,
 	     size_t size, uint64_t flags)
 {
-	return pmemobj_tx_xadd_range(umem_off2id(umm, umoff), offset, size,
-				     flags);
+	int	rc;
+
+	rc = pmemobj_tx_xadd_range(umem_off2id(umm, umoff), offset, size,
+				   flags);
+	return rc ? umem_tx_errno(rc) : 0;
 }
 
 
 static int
 pmem_tx_add_ptr(struct umem_instance *umm, void *ptr, size_t size)
 {
-	return pmemobj_tx_add_range_direct(ptr, size);
+	int	rc;
+
+	rc = pmemobj_tx_add_range_direct(ptr, size);
+	return rc ? umem_tx_errno(rc) : 0;
 }
 
 static int
@@ -268,14 +282,17 @@ pmem_reserve(struct umem_instance *umm, struct pobj_action *act, size_t size,
 static void
 pmem_cancel(struct umem_instance *umm, struct pobj_action *actv, int actv_cnt)
 {
-	return pmemobj_cancel(umm->umm_pool, actv, actv_cnt);
+	pmemobj_cancel(umm->umm_pool, actv, actv_cnt);
 }
 
 static int
 pmem_tx_publish(struct umem_instance *umm, struct pobj_action *actv,
 		int actv_cnt)
 {
-	return pmemobj_tx_publish(actv, actv_cnt);
+	int	rc;
+
+	rc = pmemobj_tx_publish(actv, actv_cnt);
+	return rc ? umem_tx_errno(rc) : 0;
 }
 
 static int


### PR DESCRIPTION
PMDK logic may return positive errno to DAOS caller, that will
misguide related DAOS logic to regard it as succeed case. This
patch converts the PMDK positive errno to DAOS errno (-DER_XXX)
before returning to DAOS caller.

Signed-off-by: Fan Yong <fan.yong@intel.com>