### PR TITLE
DAOS-8026 cart: avoid a rpc being completed multi-times

### DIFF
--- a/src/cart/crt_hg.c
+++ b/src/cart/crt_hg.c
@@ -1030,6 +1030,11 @@ crt_hg_req_send_cb(const struct hg_cb_info *hg_cbinfo)
 
 	rpc_pub = &rpc_priv->crp_pub;
 
+	if (crt_rpc_completed(rpc_priv)) {
+		RPC_ERROR(rpc_priv, "already completed, possibly due to duplicated completions.\n");
+		return rc;
+	}
+
 	RPC_TRACE(DB_TRACE, rpc_priv, "entered, hg_cbinfo->ret %d.\n",
 		  hg_cbinfo->ret);
 	switch (hg_cbinfo->ret) {

--- a/src/cart/crt_rpc.c
+++ b/src/cart/crt_rpc.c
@@ -1583,6 +1583,7 @@ crt_rpc_priv_init(struct crt_rpc_priv *rpc_priv, crt_context_t crt_ctx,
 	D_INIT_LIST_HEAD(&rpc_priv->crp_parent_link);
 	rpc_priv->crp_complete_cb = NULL;
 	rpc_priv->crp_arg = NULL;
+	rpc_priv->crp_completed = 0;
 	if (!srv_flag) {
 		/* avoid checksum warning */
 		crt_common_hdr_init(rpc_priv, opc);

--- a/src/cart/crt_rpc.h
+++ b/src/cart/crt_rpc.h
@@ -174,7 +174,9 @@ struct crt_rpc_priv {
 				/* 1 if RPC is successfully put on the wire */
 				crp_on_wire:1,
 				/* 1 if RPC fails HLC epsilon check */
-				crp_fail_hlc:1;
+				crp_fail_hlc:1,
+				/* RPC completed flag */
+				crp_completed:1;
 	uint32_t		crp_refcount;
 	struct crt_opc_info	*crp_opc_info;
 	/* corpc info, only valid when (crp_coll == 1) */
@@ -662,6 +664,8 @@ crt_set_timeout(struct crt_rpc_priv *rpc_priv)
 
 /* Convert opcode to string. Only returns string for internal RPCs */
 char *crt_opc_to_str(crt_opcode_t opc);
+
+bool crt_rpc_completed(struct crt_rpc_priv *rpc_priv);
 
 /* crt_corpc.c */
 int crt_corpc_req_hdlr(struct crt_rpc_priv *rpc_priv);


### PR DESCRIPTION
In previous testing ever observed duplicated completion event that may
cause RPC be completed multi-times, a few related code in mercury
removed. So this patch add a few extra checking at cart level to avoid
that case.

Signed-off-by: Xuezhao Liu <xuezhao.liu@intel.com>