### PR TITLE
CART-89 rpc: bump bulk threshold

### DIFF
--- a/src/common/misc.c
+++ b/src/common/misc.c
@@ -658,9 +658,9 @@ daos_crt_init_opt_get(bool server, int ctx_nr)
 	daos_crt_init_opt.cio_use_sensors = server;
 
 	/** configure cart for maximum bulk threshold */
-	daos_crt_init_opt.cio_use_expected_size = true;
+	daos_crt_init_opt.cio_use_expected_size = 1;
 	daos_crt_init_opt.cio_max_expected_size = DAOS_RPC_SIZE;
-	daos_crt_init_opt.cio_use_unexpected_size = true;
+	daos_crt_init_opt.cio_use_unexpected_size = 1;
 	daos_crt_init_opt.cio_max_unexpected_size = DAOS_RPC_SIZE;
 
 	/** Scalable EndPoint-related settings */

--- a/src/common/misc.c
+++ b/src/common/misc.c
@@ -657,6 +657,12 @@ daos_crt_init_opt_get(bool server, int ctx_nr)
 	/** enable statistics on the server side */
 	daos_crt_init_opt.cio_use_sensors = server;
 
+	/** configure cart for maximum bulk threshold */
+	daos_crt_init_opt.cio_use_expected_size = true;
+	daos_crt_init_opt.cio_max_expected_size = DAOS_RPC_SIZE;
+	daos_crt_init_opt.cio_use_unexpected_size = true;
+	daos_crt_init_opt.cio_max_unexpected_size = DAOS_RPC_SIZE;
+
 	/** Scalable EndPoint-related settings */
 	d_getenv_bool("CRT_CTX_SHARE_ADDR", &sep);
 	if (!sep)

--- a/src/include/daos/common.h
+++ b/src/include/daos/common.h
@@ -856,8 +856,8 @@ daos_recx_merge(daos_recx_t *src, daos_recx_t *dst)
 #define DAOS_NVME_SHMID_NONE	-1
 #define DAOS_NVME_MEM_PRIMARY	0
 
-/** Size of (un)expected buffers */
-#define DAOS_RPC_SIZE  (49152) /* 48KiB */
+/** Size of (un)expected Mercury buffers */
+#define DAOS_RPC_SIZE  (20480) /* 20KiB */
 /**
  * Threshold for inline vs bulk transfer
  * If the data size is smaller or equal to this limit, it will be transferred

--- a/src/include/daos/common.h
+++ b/src/include/daos/common.h
@@ -856,6 +856,16 @@ daos_recx_merge(daos_recx_t *src, daos_recx_t *dst)
 #define DAOS_NVME_SHMID_NONE	-1
 #define DAOS_NVME_MEM_PRIMARY	0
 
+/** Size of (un)expected buffers */
+#define DAOS_RPC_SIZE  (49152) /* 48KiB */
+/**
+ * Threshold for inline vs bulk transfer
+ * If the data size is smaller or equal to this limit, it will be transferred
+ * inline in the request/reply. Otherwise, a RDMA transfer will be used.
+ * Based on RPC size above and reserve 1KiB for RPC fields and cart/HG headers.
+ */
+#define DAOS_BULK_LIMIT	(DAOS_RPC_SIZE - 1024) /* Reserve 1KiB for headers */
+
 crt_init_options_t *daos_crt_init_opt_get(bool server, int crt_nr);
 
 int crt_proc_struct_dtx_id(crt_proc_t proc, crt_proc_op_t proc_op,

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -1803,7 +1803,7 @@ obj_rw_bulk_prep(struct dc_object *obj, daos_iod_t *iods, d_sg_list_t *sgls,
 	 * if need bulk transferring.
 	 */
 	sgls_size = daos_sgls_packed_size(sgls, nr, NULL);
-	if (sgls_size >= OBJ_BULK_LIMIT || obj_auxi->reasb_req.orr_tgt_nr > 1) {
+	if (sgls_size >= DAOS_BULK_LIMIT || obj_auxi->reasb_req.orr_tgt_nr > 1) {
 		bulk_perm = update ? CRT_BULK_RO : CRT_BULK_RW;
 		rc = obj_bulk_prep(sgls, nr, bulk_bind, bulk_perm, task,
 				   &obj_auxi->bulks);

--- a/src/object/cli_shard.c
+++ b/src/object/cli_shard.c
@@ -1778,7 +1778,7 @@ dc_obj_shard_list(struct dc_obj_shard *obj_shard, enum obj_rpc_opc opc,
 	if (sgl != NULL) {
 		oei->oei_sgl = *sgl;
 		sgl_size = daos_sgls_packed_size(sgl, 1, NULL);
-		if (sgl_size >= OBJ_BULK_LIMIT) {
+		if (sgl_size >= DAOS_BULK_LIMIT) {
 			/* Create bulk */
 			rc = crt_bulk_create(daos_task2ctx(task),
 					     sgl, CRT_BULK_RW,
@@ -1830,7 +1830,7 @@ dc_obj_shard_list(struct dc_obj_shard *obj_shard, enum obj_rpc_opc opc,
 
 out_eaa:
 	crt_req_decref(req);
-	if (sgl != NULL && sgl_size >= OBJ_BULK_LIMIT)
+	if (sgl != NULL && sgl_size >= DAOS_BULK_LIMIT)
 		crt_bulk_free(oei->oei_bulk);
 out_req:
 	crt_req_decref(req);

--- a/src/object/obj_rpc.h
+++ b/src/object/obj_rpc.h
@@ -25,11 +25,6 @@
 
 #include "obj_ec.h"
 
-/* It cannot exceed the mercury unexpected msg size (4KB), reserves half-KB
- * for other RPC fields and cart/HG headers.
- */
-#define OBJ_BULK_LIMIT	(3584) /* (3K + 512) bytes */
-
 /*
  * RPC operation codes
  *

--- a/src/object/obj_tx.c
+++ b/src/object/obj_tx.c
@@ -1532,7 +1532,7 @@ dc_tx_commit_prepare(struct dc_tx *tx, tse_task_t *task)
 			if (rc < 0)
 				goto out;
 
-			if (rc > (OBJ_BULK_LIMIT >> 2)) {
+			if (rc > (DAOS_BULK_LIMIT >> 2)) {
 				rc = tx_bulk_prepare(dcsr, task);
 				if (rc != 0)
 					goto out;

--- a/src/tests/suite/daos_checksum.c
+++ b/src/tests/suite/daos_checksum.c
@@ -454,7 +454,7 @@ test_server_data_corruption(void **state)
 	FAULT_INJECTION_REQUIRED();
 
 	setup_from_test_args(&ctx, *state);
-	setup_cont_obj(&ctx, dts_csum_prop_type, false, 1024*8, oc);
+	setup_cont_obj(&ctx, dts_csum_prop_type, false, 1024*64, oc);
 
 	/**1. Simple server data corruption after RDMA */
 	setup_multiple_extent_data(&ctx);
@@ -2425,7 +2425,7 @@ test_enumerate_object2(void **state)
 	assert_rc_equal(0, rc);
 
 	d_sgl_init(&list_sgl, 1);
-	iov_alloc(&list_sgl.sg_iovs[0], 1024 * 10);
+	iov_alloc(&list_sgl.sg_iovs[0], 1024 * 64);
 	/** Sanity check that no failure still returns success */
 	daos_epoch_range_t epr = {.epr_lo = 0, .epr_hi = DAOS_EPOCH_MAX};
 


### PR DESCRIPTION
Use new functionality exported by Mercury/Cart to initialize
the message size at init time.
Modify DAOS to use inline requests up to 47KiB and keep an
extra 1KiB for headers.

Signed-off-by: Johann Lombardi <johann.lombardi@intel.com>