### PR TITLE
DAOS-7721 container: Yield when evicting handles

### DIFF
--- a/src/container/srv_container.c
+++ b/src/container/srv_container.c
@@ -975,6 +975,9 @@ struct recs_buf {
 	int				rb_nrecs;
 };
 
+/* Number of recs per yield when growing a recs_buf. See close_iter_cb. */
+#define RECS_BUF_RECS_PER_YIELD 128
+
 static int
 recs_buf_init(struct recs_buf *buf)
 {
@@ -1024,11 +1027,17 @@ recs_buf_grow(struct recs_buf *buf)
 	return 0;
 }
 
+struct find_hdls_by_cont_arg {
+	struct rdb_tx	       *fha_tx;
+	struct recs_buf		fha_buf;
+};
+
 static int
-find_hdls_by_cont_cb(daos_handle_t ih, d_iov_t *key, d_iov_t *val, void *arg)
+find_hdls_by_cont_cb(daos_handle_t ih, d_iov_t *key, d_iov_t *val, void *varg)
 {
-	struct recs_buf	       *buf = arg;
-	int			rc;
+	struct find_hdls_by_cont_arg   *arg = varg;
+	struct recs_buf		       *buf = &arg->fha_buf;
+	int				rc;
 
 	if (key->iov_len != sizeof(uuid_t) || val->iov_len != sizeof(char)) {
 		D_ERROR("invalid key/value size: key="DF_U64" value="DF_U64"\n",
@@ -1043,6 +1052,15 @@ find_hdls_by_cont_cb(daos_handle_t ih, d_iov_t *key, d_iov_t *val, void *arg)
 	uuid_copy(buf->rb_recs[buf->rb_nrecs].tcr_hdl, key->iov_buf);
 	buf->rb_recs[buf->rb_nrecs].tcr_hce = 0 /* unused */;
 	buf->rb_nrecs++;
+
+	if (buf->rb_nrecs % RECS_BUF_RECS_PER_YIELD == 0) {
+		ABT_thread_yield();
+		rc = rdb_tx_revalidate(arg->fha_tx);
+		if (rc != 0) {
+			D_WARN("revalidate RDB TX: "DF_RC"\n", DP_RC(rc));
+			return rc;
+		}
+	}
 	return 0;
 }
 
@@ -1053,19 +1071,20 @@ static int cont_close_hdls(struct cont_svc *svc,
 static int
 evict_hdls(struct rdb_tx *tx, struct cont *cont, bool force, crt_context_t ctx)
 {
-	struct recs_buf	buf;
-	int		rc;
+	struct find_hdls_by_cont_arg	arg;
+	int				rc;
 
-	rc = recs_buf_init(&buf);
+	arg.fha_tx = tx;
+	rc = recs_buf_init(&arg.fha_buf);
 	if (rc != 0)
 		return rc;
 
 	rc = rdb_tx_iterate(tx, &cont->c_hdls, false /* !backward */,
-			    find_hdls_by_cont_cb, &buf);
+			    find_hdls_by_cont_cb, &arg);
 	if (rc != 0)
 		goto out;
 
-	if (buf.rb_nrecs == 0)
+	if (arg.fha_buf.rb_nrecs == 0)
 		goto out;
 
 	if (!force) {
@@ -1073,10 +1092,10 @@ evict_hdls(struct rdb_tx *tx, struct cont *cont, bool force, crt_context_t ctx)
 		goto out;
 	}
 
-	rc = cont_close_hdls(cont->c_svc, buf.rb_recs, buf.rb_nrecs, ctx);
+	rc = cont_close_hdls(cont->c_svc, arg.fha_buf.rb_recs, arg.fha_buf.rb_nrecs, ctx);
 
 out:
-	recs_buf_fini(&buf);
+	recs_buf_fini(&arg.fha_buf);
 	return rc;
 }
 
@@ -1751,10 +1770,6 @@ cont_open(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl, struct cont *cont,
 	chdl.ch_flags = in->coi_flags;
 	chdl.ch_sec_capas = sec_capas;
 
-	rc = ds_cont_epoch_init_hdl(tx, cont, in->coi_op.ci_hdl, &chdl);
-	if (rc != 0)
-		D_GOTO(out, rc);
-
 	rc = rdb_tx_update(tx, &cont->c_svc->cs_hdls, &key, &value);
 	if (rc != 0)
 		D_GOTO(out, rc);
@@ -1861,10 +1876,6 @@ cont_close_one_hdl(struct rdb_tx *tx, struct cont_svc *svc,
 	if (rc != 0)
 		return rc;
 
-	rc = ds_cont_epoch_fini_hdl(tx, cont, ctx, &chdl);
-	if (rc != 0)
-		goto out;
-
 	rc = rdb_tx_delete(tx, &cont->c_hdls, &key);
 	if (rc != 0)
 		goto out;
@@ -1881,8 +1892,9 @@ static int
 cont_close_hdls(struct cont_svc *svc, struct cont_tgt_close_rec *recs,
 		int nrecs, crt_context_t ctx)
 {
-	int	i;
-	int	rc;
+	struct rdb_tx	tx;
+	int		i;
+	int		rc;
 
 	D_ASSERTF(nrecs > 0, "%d\n", nrecs);
 	D_DEBUG(DF_DSMS, DF_CONT": closing %d recs: recs[0].hdl="DF_UUID
@@ -1893,34 +1905,38 @@ cont_close_hdls(struct cont_svc *svc, struct cont_tgt_close_rec *recs,
 	if (rc != 0)
 		D_GOTO(out, rc);
 
-	/*
-	 * Use one TX per handle to avoid calling ds_cont_epoch_fini_hdl() more
-	 * than once in a TX, in which case we would be attempting to query
-	 * uncommitted updates. This could be optimized by adding container
-	 * UUIDs into recs[i] and sorting recs[] by container UUIDs. Then we
-	 * could maintain a list of deleted LREs and a list of deleted LHEs for
-	 * each container while looping, and use the lists to update the GHCE
-	 * once for each container. This approach enables us to commit only
-	 * once (or when a TX becomes too big).
-	 */
-	for (i = 0; i < nrecs; i++) {
-		struct rdb_tx tx;
+	rc = rdb_tx_begin(svc->cs_rsvc->s_db, svc->cs_rsvc->s_term, &tx);
+	if (rc != 0)
+		goto out;
 
-		rc = rdb_tx_begin(svc->cs_rsvc->s_db, svc->cs_rsvc->s_term,
-				  &tx);
-		if (rc != 0)
-			break;
+	for (i = 0; i < nrecs; i++) {
 		rc = cont_close_one_hdl(&tx, svc, ctx, recs[i].tcr_hdl);
-		if (rc != 0) {
-			rdb_tx_end(&tx);
-			break;
-		}
-		rc = rdb_tx_commit(&tx);
-		rdb_tx_end(&tx);
 		if (rc != 0)
-			break;
+			goto out_tx;
+
+		/*
+		 * Yield frequently, in order to cope with the slow
+		 * vos_obj_punch operations invoked by rdb_tx_commit for
+		 * deleting the handles. (If there is no other RDB replica, the
+		 * TX operations will not yield, and this loop would occupy the
+		 * xstream for too long.)
+		 */
+		if ((i + 1) % 32 == 0) {
+			rc = rdb_tx_commit(&tx);
+			if (rc != 0)
+				goto out_tx;
+			rdb_tx_end(&tx);
+			ABT_thread_yield();
+			rc = rdb_tx_begin(svc->cs_rsvc->s_db, svc->cs_rsvc->s_term, &tx);
+			if (rc != 0)
+				goto out;
+		}
 	}
 
+	rc = rdb_tx_commit(&tx);
+
+out_tx:
+	rdb_tx_end(&tx);
 out:
 	D_DEBUG(DF_DSMS, DF_CONT": leaving: %d\n",
 		DP_CONT(svc->cs_pool_uuid, NULL), rc);
@@ -3040,6 +3056,7 @@ cont_attr_list(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl,
 }
 
 struct close_iter_arg {
+	struct rdb_tx  *cia_tx;
 	struct recs_buf	cia_buf;
 	uuid_t	       *cia_pool_hdls;
 	int		cia_n_pool_hdls;
@@ -3085,6 +3102,15 @@ close_iter_cb(daos_handle_t ih, d_iov_t *key, d_iov_t *val, void *varg)
 	uuid_copy(buf->rb_recs[buf->rb_nrecs].tcr_hdl, key->iov_buf);
 	buf->rb_recs[buf->rb_nrecs].tcr_hce = hdl->ch_hce;
 	buf->rb_nrecs++;
+
+	if (buf->rb_nrecs % RECS_BUF_RECS_PER_YIELD == 0) {
+		ABT_thread_yield();
+		rc = rdb_tx_revalidate(arg->cia_tx);
+		if (rc != 0) {
+			D_WARN("revalidate RDB TX: "DF_RC"\n", DP_RC(rc));
+			return rc;
+		}
+	}
 	return 0;
 }
 
@@ -3117,6 +3143,7 @@ ds_cont_close_by_pool_hdls(uuid_t pool_uuid, uuid_t *pool_hdls, int n_pool_hdls,
 
 	ABT_rwlock_wrlock(svc->cs_lock);
 
+	arg.cia_tx = &tx;
 	rc = recs_buf_init(&arg.cia_buf);
 	if (rc != 0)
 		goto out_lock;

--- a/src/container/srv_epoch.c
+++ b/src/container/srv_epoch.c
@@ -93,20 +93,6 @@ read_snap_list(struct rdb_tx *tx, struct cont *cont, daos_epoch_t **buf, int *co
 }
 
 int
-ds_cont_epoch_init_hdl(struct rdb_tx *tx, struct cont *cont, uuid_t c_hdl,
-		       struct container_hdl *hdl)
-{
-	return 0;
-}
-
-int
-ds_cont_epoch_fini_hdl(struct rdb_tx *tx, struct cont *cont,
-		       crt_context_t ctx, struct container_hdl *hdl)
-{
-	return 0;
-}
-
-int
 ds_cont_epoch_aggregate(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl,
 			struct cont *cont, struct container_hdl *hdl,
 			crt_rpc_t *rpc)

--- a/src/container/srv_internal.h
+++ b/src/container/srv_internal.h
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
 /**
- * ds_cont: Client Server Internal Declarations
+ * ds_cont: Container Server Internal Declarations
  */
 
 #ifndef __CONTAINER_SRV_INTERNAL_H__
@@ -55,11 +55,6 @@ dsm_tls_get()
 }
 
 extern bool ec_agg_disabled;
-/*
- * Container service
- *
- * Identified by a number unique within the pool.
- */
 
 struct ec_eph {
 	d_rank_t	rank;
@@ -75,6 +70,11 @@ struct cont_ec_agg {
 	d_list_t		ea_list;
 };
 
+/*
+ * Container service
+ *
+ * Identified by a number unique within the pool.
+ */
 struct cont_svc {
 	uuid_t			cs_pool_uuid;
 	uint64_t		cs_id;
@@ -87,7 +87,7 @@ struct cont_svc {
 	struct ds_pool	       *cs_pool;
 
 	/* Manage the EC aggregation epoch */
-	struct sched_request	*cs_ec_leader_ephs_req;
+	struct sched_request   *cs_ec_leader_ephs_req;
 	d_list_t		cs_ec_agg_list; /* link cont_ec_agg */
 };
 
@@ -170,9 +170,7 @@ struct cont_iv_key {
 	uint32_t	entry_size;
 };
 
-/*
- * srv_container.c
- */
+/* srv_container.c */
 void ds_cont_op_handler(crt_rpc_t *rpc);
 void ds_cont_set_prop_handler(crt_rpc_t *rpc);
 int ds_cont_bcast_create(crt_context_t ctx, struct cont_svc *svc,
@@ -196,19 +194,10 @@ int ds_cont_acl_delete(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl,
 		       crt_rpc_t *rpc);
 int ds_cont_get_prop(uuid_t pool_uuid, uuid_t cont_uuid,
 		     daos_prop_t **prop_out);
-
 int ds_cont_leader_update_agg_eph(uuid_t pool_uuid, uuid_t cont_uuid,
 				  d_rank_t rank, daos_epoch_t eph);
-/*
- * srv_epoch.c
- */
-int ds_cont_epoch_init_hdl(struct rdb_tx *tx, struct cont *cont,
-			   uuid_t c_hdl, struct container_hdl *hdl);
-int ds_cont_epoch_fini_hdl(struct rdb_tx *tx, struct cont *cont,
-			   crt_context_t ctx, struct container_hdl *hdl);
-int ds_cont_epoch_query(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl,
-			struct cont *cont, struct container_hdl *hdl,
-			crt_rpc_t *rpc);
+
+/* srv_epoch.c */
 int ds_cont_snap_create(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl,
 			struct cont *cont, struct container_hdl *hdl,
 			crt_rpc_t *rpc);
@@ -225,9 +214,7 @@ int ds_cont_get_snapshots(uuid_t pool_uuid, uuid_t cont_uuid, daos_epoch_t **sna
 			  int *snap_count);
 void ds_cont_update_snap_iv(struct cont_svc *svc, uuid_t cont_uuid);
 
-/**
- * srv_target.c
- */
+/* srv_target.c */
 int ds_cont_tgt_destroy(uuid_t pool_uuid, uuid_t cont_uuid);
 void ds_cont_tgt_destroy_handler(crt_rpc_t *rpc);
 int ds_cont_tgt_destroy_aggregator(crt_rpc_t *source, crt_rpc_t *result,
@@ -249,7 +236,6 @@ void ds_cont_child_cache_destroy(struct daos_lru_cache *cache);
 int ds_cont_hdl_hash_create(struct d_hash_table *hash);
 void ds_cont_hdl_hash_destroy(struct d_hash_table *hash);
 void ds_cont_oid_alloc_handler(crt_rpc_t *rpc);
-
 int ds_cont_tgt_open(uuid_t pool_uuid, uuid_t cont_hdl_uuid,
 		     uuid_t cont_uuid, uint64_t flags, uint64_t sec_capas,
 		     uint32_t status_pm_ver);
@@ -261,9 +247,8 @@ int ds_cont_tgt_refresh_agg_eph(uuid_t pool_uuid, uuid_t cont_uuid,
 				daos_epoch_t eph);
 int ds_cont_status_pm_ver_update(uuid_t pool_uuid, uuid_t cont_uuid,
 				 uint32_t pm_ver);
-/**
- * oid_iv.c
- */
+
+/* oid_iv.c */
 int ds_oid_iv_init(void);
 int ds_oid_iv_fini(void);
 int oid_iv_reserve(void *ns, uuid_t poh_uuid, uuid_t co_uuid, uuid_t coh_uuid,
@@ -283,15 +268,14 @@ int cont_iv_prop_update(void *ns, uuid_t cont_uuid, daos_prop_t *prop);
 int cont_iv_snapshots_refresh(void *ns, uuid_t cont_uuid);
 int cont_iv_snapshots_update(void *ns, uuid_t cont_uuid,
 			     uint64_t *snapshots, int snap_count);
-
-int cont_child_gather_oids(struct ds_cont_child *cont, uuid_t coh_uuid,
-			   daos_epoch_t epoch);
-
 int cont_iv_ec_agg_eph_update(void *ns, uuid_t cont_uuid, daos_epoch_t eph);
 int cont_iv_ec_agg_eph_refresh(void *ns, uuid_t cont_uuid, daos_epoch_t eph);
 
-/** srv_metrics.c*/
+/* srv_metrics.c*/
 void *ds_cont_metrics_alloc(const char *path, int tgt_id);
 void ds_cont_metrics_free(void *data);
+
+int cont_child_gather_oids(struct ds_cont_child *cont, uuid_t coh_uuid,
+			   daos_epoch_t epoch);
 
 #endif /* __CONTAINER_SRV_INTERNAL_H__ */

--- a/src/include/daos_srv/rdb.h
+++ b/src/include/daos_srv/rdb.h
@@ -249,6 +249,10 @@ enum rdb_probe_opc {
  *   - if rc == 0, rdb_tx_iterate() continues;
  *   - if rc == 1, rdb_tx_iterate() stops and returns 0;
  *   - otherwise, rdb_tx_iterate() stops and returns rc.
+ *
+ * If a callback yields (e.g., via ABT_thread_yield), it must call
+ * rdb_tx_revalidate after the yield and return the return value of
+ * rdb_tx_revalidate.
  */
 typedef int (*rdb_iterate_cb_t)(daos_handle_t ih, d_iov_t *key,
 				d_iov_t *val, void *arg);
@@ -261,5 +265,6 @@ int rdb_tx_fetch(struct rdb_tx *tx, const rdb_path_t *kvs,
 		 d_iov_t *key_out, d_iov_t *value);
 int rdb_tx_iterate(struct rdb_tx *tx, const rdb_path_t *kvs, bool backward,
 		   rdb_iterate_cb_t cb, void *arg);
+int rdb_tx_revalidate(struct rdb_tx *tx);
 
 #endif /* DAOS_SRV_RDB_H */


### PR DESCRIPTION
It was observed that when evicting 10,000 container handles,
cont_close_hdls could occupy the xstream for more than 10 s, if there is
only one RDB replica. This patch adds ABT_thread_yield calls to the
ds_cont_close_by_pool_hdls procedure.

  - Yield when iterating cont->c_hdls and svc->cs_hdls. This requires
    the addition of a new rdb API, rdb_tx_revalidate.

  - Yield when closing handles. This reason behind the one-TX-per-handle
    approach no longer exists. So a batch of handles will be closed in
    one TX, with the size of the batch limited by both TX size and
    xstream occupation considerations.

  - Remove ds_cont_epoch_{init,fini}_hdl. These are no longer necessary.
      - Clean up srv_internal.h a bit.

Signed-off-by: Li Wei <wei.g.li@intel.com>