### PR TITLE
DAOS-8221 swim: tolerate to slow network providers

### DIFF
--- a/src/cart/crt_context.c
+++ b/src/cart/crt_context.c
@@ -281,6 +281,20 @@ crt_context_provider_create(crt_context_t *crt_ctx, int provider)
 			crt_context_destroy(ctx, true);
 			D_GOTO(out, rc);
 		}
+
+		if (provider == CRT_NA_OFI_SOCKETS || provider == CRT_NA_OFI_TCP_RXM) {
+			struct crt_grp_priv	*grp_priv = crt_gdata.cg_grp->gg_primary_grp;
+			struct crt_swim_membs	*csm = &grp_priv->gp_membs_swim;
+
+			D_DEBUG(DB_TRACE, "Slow network provider is detected, "
+					  "increase SWIM timeouts by twice.\n");
+
+			swim_suspect_timeout_set(swim_suspect_timeout_get() * 2);
+			swim_ping_timeout_set(swim_ping_timeout_get() * 2);
+			swim_period_set(swim_period_get() * 2);
+			csm->csm_ctx->sc_default_ping_timeout *= 2;
+		}
+
 	}
 
 	*crt_ctx = (crt_context_t)ctx;

--- a/src/cart/crt_swim.h
+++ b/src/cart/crt_swim.h
@@ -59,9 +59,11 @@ crt_swim_rpc_timeout(void)
 	uint32_t timeout_sec;
 
 	/*
-	 * Convert SWIM ping timeout from ms to seconds with rounding up
+	 * Convert SWIM ping timeout from ms to seconds with rounding up.
+	 * Increase it by 2 seconds to avoid early expiration by timeout
+	 * in case of network glitches.
 	 */
-	timeout_sec = 1 + swim_ping_timeout_get() / 1000 /* ms per sec */;
+	timeout_sec = 3 + swim_ping_timeout_get() / 1000 /* ms per sec */;
 
 	return timeout_sec;
 }


### PR DESCRIPTION
Increase SWIM timeouts by twice for slow network providers.
Improve debug messages.