### PR TITLE
DAOS-8304 control: Fix control RPC timeout handling

### DIFF
--- a/src/control/fault/code/codes.go
+++ b/src/control/fault/code/codes.go
@@ -104,6 +104,7 @@ const (
 	ClientConnectionRefused
 	ClientConnectionClosed
 	ClientFormatRunningSystem
+	ClientRpcTimeout
 )
 
 // server fault codes

--- a/src/control/lib/control/faults.go
+++ b/src/control/lib/control/faults.go
@@ -105,6 +105,18 @@ func FaultConnectionClosed(srvAddr string) *fault.Fault {
 	)
 }
 
+func FaultRpcTimeout(req deadliner) *fault.Fault {
+	timeout := req.getTimeout()
+	if timeout == 0 {
+		timeout = defaultRequestTimeout
+	}
+	return clientFault(
+		code.ClientRpcTimeout,
+		fmt.Sprintf("the %T request timed out after %s", req, timeout),
+		"retry the request or check server logs for more information",
+	)
+}
+
 func clientFault(code code.Code, desc, res string) *fault.Fault {
 	return &fault.Fault{
 		Domain:      "client",

--- a/src/control/lib/control/request.go
+++ b/src/control/lib/control/request.go
@@ -59,6 +59,7 @@ type (
 	deadliner interface {
 		SetTimeout(time.Duration)
 		getDeadline() time.Time
+		getTimeout() time.Duration
 	}
 
 	// UnaryRequest defines an interface to be implemented by
@@ -78,6 +79,7 @@ var (
 // request is an embeddable struct to provide basic functionality
 // common to all request types.
 type request struct {
+	timeout  time.Duration
 	deadline time.Time
 	Sys      string // DAOS system name
 	HostList []string
@@ -127,6 +129,7 @@ func (r *request) AddHost(hostAddr string) {
 // SetTimeout sets a deadline by which the request must have
 // completed. It is calculated from the supplied time.Duration.
 func (r *request) SetTimeout(timeout time.Duration) {
+	r.timeout = timeout
 	r.deadline = time.Now().Add(timeout)
 }
 
@@ -134,6 +137,14 @@ func (r *request) SetTimeout(timeout time.Duration) {
 // Callers should check the returned time.Time for the zero value.
 func (r *request) getDeadline() time.Time {
 	return r.deadline
+}
+
+// getTimeout returns the timeout set for the request, if any.
+// The primary use case for this method is to provide information
+// about the timeout in the event that the request's deadline
+// is exceeded.
+func (r *request) getTimeout() time.Duration {
+	return r.timeout
 }
 
 // isMSRequest implements part of the targetChooser interface,
@@ -194,6 +205,10 @@ type retryableRequest struct {
 	retryTestFn func(error, uint) bool
 	// retryFun defines a function that will run on every retry iteration.
 	retryFn func(context.Context, uint) error
+}
+
+func (r *retryableRequest) setRetryTimeout(timeout time.Duration) {
+	r.retryTimeout = timeout
 }
 
 func (r *retryableRequest) getRetryTimeout() time.Duration {

--- a/src/control/lib/control/rpc.go
+++ b/src/control/lib/control/rpc.go
@@ -337,9 +337,36 @@ func invokeUnaryRPC(parentCtx context.Context, log debugLogger, c UnaryInvoker, 
 	startHostList := make([]string, len(req.getHostList()))
 	copy(startHostList, req.getHostList())
 
+	isTimeout := func(err error) bool {
+		if err == nil {
+			return false
+		}
+
+		// Get the wrapped error.
+		cause := errors.Cause(err)
+		switch {
+		case cause == context.DeadlineExceeded,
+			status.Code(cause) == codes.DeadlineExceeded:
+			return true
+		default:
+			return false
+		}
+	}
+
 	isHardFailure := func(err error, reqCtx context.Context) bool {
 		if err == nil {
 			return false
+		}
+
+		// Get the wrapped error.
+		cause := errors.Cause(err)
+
+		// If the context error is from the parent request context,
+		// then it's a hard failure. Otherwise, it may be a soft failure
+		// that can be retried.
+		if cause == reqCtx.Err() {
+			log.Debugf("outer context failed: %v", err)
+			return true
 		}
 
 		// This helper checks for errors returned during the process of
@@ -347,22 +374,16 @@ func invokeUnaryRPC(parentCtx context.Context, log debugLogger, c UnaryInvoker, 
 		// errors). As such, the set of errors that can cause the entire
 		// request to fail without a retry should be pretty small.
 
-		switch errors.Cause(err) {
-		// These may be retryable.
-		case context.DeadlineExceeded, context.Canceled:
+		switch {
+		case isTimeout(cause):
+			// The outer context hasn't timed out or been canceled, so
+			// this is a soft failure that can be retried.
+			return false
 		default:
-			// Check to see if the error contains a gRPC status code.
-			code := status.Code(errors.Cause(err))
-			if code != codes.Canceled && code != codes.DeadlineExceeded {
-				// If the error is not a context error, it's a hard failure.
-				return true
-			}
+			// If the error is not an inner timeout, it's a hard failure.
+			log.Debugf("non-retryable error: %v", err)
+			return true
 		}
-
-		// If the context error is from the parent request context,
-		// then it's a hard failure. Otherwise, it's a soft failure
-		// and can be retried.
-		return errors.Cause(err) == reqCtx.Err()
 	}
 
 	// MS requests are a little more complicated. The general idea here is that
@@ -381,12 +402,18 @@ func invokeUnaryRPC(parentCtx context.Context, log debugLogger, c UnaryInvoker, 
 		}
 		respChan, err := c.InvokeUnaryRPCAsync(tryCtx, req)
 		if isHardFailure(err, reqCtx) {
+			if isTimeout(err) {
+				return nil, FaultRpcTimeout(req)
+			}
 			return nil, err
 		}
 
 		ur := &UnaryResponse{fromMS: true}
 		err = gatherResponses(tryCtx, respChan, ur)
 		if isHardFailure(err, reqCtx) {
+			if isTimeout(err) {
+				return nil, FaultRpcTimeout(req)
+			}
 			return nil, err
 		}
 
@@ -428,12 +455,10 @@ func invokeUnaryRPC(parentCtx context.Context, log debugLogger, c UnaryInvoker, 
 				req.SetHostList(e.Replicas)
 			}
 		default:
-			// If the inner context has timed out, we should retry the
-			// request as long as the outer context hasn't been canceled.
-			if err != nil && errors.Cause(err) == tryCtx.Err() {
-				if reqCtx.Err() == nil {
-					break
-				}
+			// As long as the outer context hasn't timed out, we
+			// should always retry an inner timeout.
+			if reqCtx.Err() == nil && isTimeout(err) {
+				break
 			}
 
 			// In the case that the request specifies that the error
@@ -461,6 +486,9 @@ func invokeUnaryRPC(parentCtx context.Context, log debugLogger, c UnaryInvoker, 
 		log.Debugf("MS request error: %v; retrying after %s", err, backoff)
 		select {
 		case <-reqCtx.Done():
+			if isTimeout(reqCtx.Err()) {
+				return nil, FaultRpcTimeout(req)
+			}
 			return nil, reqCtx.Err()
 		case <-time.After(backoff):
 		}

--- a/src/control/lib/control/rpc_test.go
+++ b/src/control/lib/control/rpc_test.go
@@ -35,6 +35,7 @@ type testRequest struct {
 	toMS     bool
 	HostList []string
 	Deadline time.Time
+	Timeout  time.Duration
 	Sys      string
 }
 
@@ -51,11 +52,16 @@ func (tr *testRequest) getHostList() []string {
 }
 
 func (tr *testRequest) SetTimeout(to time.Duration) {
+	tr.Timeout = to
 	tr.Deadline = time.Now().Add(to)
 }
 
 func (tr *testRequest) getDeadline() time.Time {
 	return tr.Deadline
+}
+
+func (tr *testRequest) getTimeout() time.Duration {
+	return tr.Timeout
 }
 
 func (tr *testRequest) SetSystem(sys string) {
@@ -398,7 +404,7 @@ func TestControl_InvokeUnaryRPC(t *testing.T) {
 					return nil, errNotLeaderNoLeader
 				},
 			},
-			expErr: context.DeadlineExceeded,
+			expErr: FaultRpcTimeout(new(testRequest)),
 		},
 		"request to non-replicas eventually discovers at least one replica": {
 			req: &testRequest{


### PR DESCRIPTION
Rewrites some of the timeout handling logic to be
clearer and plugs a gap where a retryable timeout
returned from the complex MS response could leak
back to the RPC caller.

Also adds a structured error for request timeout to
better convey what the problem is to the user (no more
mysterious "context deadline exceeded" errors).