### PR TITLE
DAOS-8320 tool: destroy hdlr should return -der instead of errno

### DIFF
--- a/src/utils/daos_hdlr.c
+++ b/src/utils/daos_hdlr.c
@@ -1806,7 +1806,7 @@ cont_destroy_hdlr(struct cmd_args_s *ap)
 				ap->path, strerror(rc));
 		else
 			fprintf(ap->outstream, "Successfully destroyed path %s\n", ap->path);
-		return rc;
+		return daos_errno2der(rc);
 	}
 
 	rc = daos_cont_destroy(ap->pool, ap->cont_str, ap->force, NULL);


### PR DESCRIPTION
Signed-off-by: Mohamad Chaarawi <mohamad.chaarawi@intel.com>