### PR TITLE
DAOS-8474 container: fix potential leak in cont_snap_notify_one()

### DIFF
--- a/src/container/srv_target.c
+++ b/src/container/srv_target.c
@@ -2004,10 +2004,11 @@ cont_snap_notify_one(void *vin)
 		rc = cont_child_gather_oids(cont, args->coh_uuid,
 					    args->snap_epoch);
 		if (rc)
-			return rc;
+			goto out_cont;
 	}
 
 	cont->sc_aggregation_max = crt_hlc_get();
+out_cont:
 	ds_cont_child_put(cont);
 	return rc;
 }


### PR DESCRIPTION
if cont_child_gather_oids() failed, it returned directly without
releasing extra container reference count.

Signed-off-by: Wang Shilong <shilong.wang@intel.com>