### PR TITLE
DAOS-8437 pool: fix rdb ref leak in pool extend

### DIFF
--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -4523,7 +4523,7 @@ pool_extend_map(struct rdb_tx *tx, struct pool_svc *svc,
 	if (rc != 0) {
 		D_DEBUG(DB_MD, DF_UUID": failed to commit: "DF_RC"\n",
 			DP_UUID(svc->ps_uuid), DP_RC(rc));
-			D_GOTO(out_map, rc);
+		D_GOTO(out_map, rc);
 	}
 
 	updated = true;
@@ -4548,7 +4548,6 @@ out_map:
 		else
 			*map_version_p = pool_map_get_version(map);
 	}
-	rdb_tx_end(tx);
 
 out_map_buf:
 	if (map_buf != NULL)
@@ -4612,6 +4611,7 @@ pool_extend_internal(uuid_t pool_uuid, struct rsvc_hint *hint,
 
 out_lock:
 	ABT_rwlock_unlock(svc->ps_lock);
+	rdb_tx_end(&tx);
 
 out_svc:
 	pool_target_id_list_free(&tgts);

--- a/src/rdb/rdb.c
+++ b/src/rdb/rdb.c
@@ -474,6 +474,7 @@ rdb_stop(struct rdb *db)
 	ABT_cond_free(&db->d_ref_cv);
 	ABT_mutex_free(&db->d_raft_mutex);
 	ABT_mutex_free(&db->d_mutex);
+	D_DEBUG(DB_MD, DF_DB": stopped db %p\n", DP_DB(db), db);
 	D_FREE(db);
 }
 


### PR DESCRIPTION
Before this change, test osa/osa_dmg_negative_test.py
(tag dmg_negative_test_extend) when issuing dmg pool extend commands
that refer to existing pool ranks (e.g., 1, 2, or 3), goes through
a code path in the pool service that leaks a reference on struct rdb.
The pool_extend_internal() function calls rdb_tx_begin() incrementing
the reference, but the pool_extend_map() function it calls invokes
rdb_tx_end() that would decrement the reference. In this scenario,
the rdb_tx_end() call is missed in the error handling path. At the end
of the test pool destroy fails since the RSVC_STOP broadcast does not
get a reply from the pool service leader (it is waiting on references
that will never be released).

This change promotes the rdb_tx_end() call up to pool_extend_internal()
so that the db reference is released in successful and error scenarios.

Test-tag-hw-medium: pr daily_regression,osa_extend dmg_negative_test_extend
Test-tag-hw-large: pr daily_regression,osa_extend

Signed-off-by: Kenneth Cain <kenneth.c.cain@intel.com>