### PR TITLE
DAOS-8432 Remove R: hwloc

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -946,6 +946,46 @@ pipeline {
                                 daos_pkg_version: daosPackagesVersion(next_version)
                    }
                 } // stage('Test CentOS 7 RPMs')
+                stage('Test CentOS 8.3.2011 RPMs') {
+                    when {
+                        beforeAgent true
+                        expression { ! skipStage() }
+                    }
+                    agent {
+                        label params.CI_UNIT_VM1_LABEL
+                    }
+                    steps {
+                        testRpm inst_repos: daosRepos(),
+                                target: 'el8.3',
+                                daos_pkg_version: daosPackagesVersion("centos8", next_version)
+                   }
+                } // stage('Test CentOS 7 RPMs')
+                stage('Test CentOS 8 RPMs') {
+                    when {
+                        beforeAgent true
+                        expression { ! skipStage() }
+                    }
+                    agent {
+                        label params.CI_UNIT_VM1_LABEL
+                    }
+                    steps {
+                        testRpm inst_repos: daosRepos(),
+                                daos_pkg_version: daosPackagesVersion(next_version)
+                   }
+                } // stage('Test CentOS 8 RPMs')
+                stage('Test Leap 15 RPMs') {
+                    when {
+                        beforeAgent true
+                        expression { ! skipStage() }
+                    }
+                    agent {
+                        label params.CI_UNIT_VM1_LABEL
+                    }
+                    steps {
+                        testRpm inst_repos: daosRepos(),
+                                daos_pkg_version: daosPackagesVersion(next_version)
+                   }
+                } // stage('Test Leap 15 RPMs')
                 stage('Scan CentOS 7 RPMs') {
                     when {
                         beforeAgent true

--- a/ci/functional/required_packages.sh
+++ b/ci/functional/required_packages.sh
@@ -21,7 +21,7 @@ elif [[ $distro = el* ]] || [[ $distro = centos* ]] ||
         openmpi="openmpi3"
     fi
 
-    pkgs="$prefix hwloc ndctl          \
+    pkgs="$prefix ndctl                \
           fio patchutils ior           \
           romio-tests                  \
           testmpio                     \

--- a/ci/parse_ci_envs.sh
+++ b/ci/parse_ci_envs.sh
@@ -16,7 +16,7 @@ if [ -n "${STAGE_NAME:?}" ]; then
       : "${TARGET:=centos8}"
       ;;
     *Leap\ 15*|*leap15*|*opensuse15*|*sles15*)
-      : "${CHROOT_NAME:=opensuse-leap-15.2-x86_64}"
+      : "${CHROOT_NAME:=opensuse-leap-15.3-x86_64}"
       : "${TARGET:=leap15}"
       ;;
     *Ubuntu\ 20.04*|*ubuntu2004*)

--- a/ci/provisioning/post_provision_config_nodes_EL_8.sh
+++ b/ci/provisioning/post_provision_config_nodes_EL_8.sh
@@ -29,6 +29,7 @@ distro_custom() {
     fi
 
     # CORCI-1096
+    dnf -y install esmtp
     sed -e 's/^\(hostname *= *\)[^ ].*$/\1 mail.wolf.hpdd.intel.com:25/' < /usr/share/doc/esmtp/sample.esmtprc > /etc/esmtprc
 
     dnf config-manager --disable powertools

--- a/ci/rpm/build_success.sh
+++ b/ci/rpm/build_success.sh
@@ -16,6 +16,8 @@ fi
 : "${TARGET:=centos7}"
 
 artdir="${PWD}/artifacts/${TARGET}"
+rm -rf "$artdir"
+mkdir -p "$artdir"
 
 if [ -d /var/cache/pbuilder/ ]; then
     mockroot=/var/cache/pbuilder/

--- a/utils/rpms/daos.spec
+++ b/utils/rpms/daos.spec
@@ -14,7 +14,7 @@
 
 Name:          daos
 Version:       1.3.105
-Release:       1%{?relval}%{?dist}
+Release:       2%{?relval}%{?dist}
 Summary:       DAOS Storage Engine
 
 License:       BSD-2-Clause-Patent
@@ -163,7 +163,6 @@ Requires: libpmemobj1 >= 1.11
 Requires: ipmctl > 02.00.00.3816
 Requires: libpmemobj >= 1.11
 %endif
-Requires: hwloc
 Requires: mercury = %{mercury_version}
 Requires(post): /sbin/ldconfig
 Requires(postun): /sbin/ldconfig
@@ -480,6 +479,9 @@ getent passwd daos_agent >/dev/null || useradd -s /sbin/nologin -r -g daos_agent
 %{_libdir}/libdaos_serialize.so
 
 %changelog
+* Fri Sep 03 2021 Brian J. Murrell <brian.murrell@intel.com> 1.3.105-2
+- Remove R: hwloc; RPM's auto-requires/provides will take care of this
+
 * Tue Aug 24 2021 Jeff Olivier <jeffrey.v.olivier@intel.com> 1.3.105-1
 - Version bump to 1.3.105 for 2.0 test build 5
 

--- a/utils/rpms/packaging/Makefile_packaging.mk
+++ b/utils/rpms/packaging/Makefile_packaging.mk
@@ -10,7 +10,7 @@ SHELL=/bin/bash
 -include Makefile.local
 
 # default to Leap 15 distro for chrootbuild
-CHROOT_NAME ?= opensuse-leap-15.2-x86_64
+CHROOT_NAME ?= opensuse-leap-15.3-x86_64
 include packaging/Makefile_distro_vars.mk
 
 ifeq ($(DEB_NAME),)


### PR DESCRIPTION
It should never have been specified as an explicit Requires: as RPM's
autoprovides/requires will take care of installing the necessary hwloc
library RPM at installation time.

Also Remove hwloc from the required packages for functional testing.

This is all because we are going to ship compat-hwloc1 with DAOS to be
able to use the RPMs that we build on EL 8.3 on EL 8.4 also.