### PR TITLE
DAOS-6827 daos: add preserve_props option to fs copy

### DIFF
--- a/src/control/cmd/daos/filesystem.go
+++ b/src/control/cmd/daos/filesystem.go
@@ -41,6 +41,7 @@ type fsCopyCmd struct {
 
 	Source string `long:"src" short:"s" description:"copy source" required:"1"`
 	Dest   string `long:"dst" short:"d" description:"copy destination" required:"1"`
+	Preserve   string `long:"preserve-props" short:"m" description:"preserve container properties, requires HDF5 library" required:"0"`
 }
 
 func (cmd *fsCopyCmd) Execute(_ []string) error {
@@ -54,6 +55,10 @@ func (cmd *fsCopyCmd) Execute(_ []string) error {
 	defer freeString(ap.src)
 	ap.dst = C.CString(cmd.Dest)
 	defer freeString(ap.dst)
+	if cmd.Preserve != "" {
+		ap.preserve_props = C.CString(cmd.Preserve)
+		defer freeString(ap.preserve_props)
+	}
 
 	ap.fs_op = C.FS_COPY
 	rc := C.fs_copy_hdlr(ap)

--- a/src/tests/ftest/datamover/dm_posix_preserve_props.py
+++ b/src/tests/ftest/datamover/dm_posix_preserve_props.py
@@ -1,0 +1,240 @@
+#!/usr/bin/python
+'''
+  (C) Copyright 2020-2021 Intel Corporation.
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+'''
+from data_mover_test_base import DataMoverTestBase
+from os.path import join
+from pydaos.raw import DaosApiError
+import avocado
+
+class DmvrPreserveProps(DataMoverTestBase):
+    # pylint: disable=too-many-ancestors
+    """Data Mover validation for --preserve-props option only for DFS copies.
+    Test Class Description:
+        Tests the following cases:
+            1. DAOS -> POSIX: Write container properties to an hdf5 file, and write
+	       to destination posix path.
+	    2. POSIX -> DAOS: Read container properties from an hdf5 file, and
+	       write to destination container.
+
+    :avocado: recursive
+    """
+
+    def setUp(self):
+        """Set up each test case."""
+        # Start the servers and agents
+        super().setUp()
+
+        # Get the parameters
+        self.ior_flags = self.params.get(
+            "ior_flags", "/run/ior/*")
+        self.test_file = self.ior_cmd.test_file.value
+
+        # For dataset_gen and dataset_verify
+        self.obj_list = []
+
+    def run_dm_preserve_props(self, tool, cont_type, api):
+        """
+        Test Description:
+            Tests Data Mover container property preservation for DFS copies to and from POSIX.
+        Use Cases:
+            Create pool1.
+            Create a container, and write data to it.
+            Create POSIX path.
+            Copy cont1 to new posix path using --preserve-props and write container props to
+            hdf5 file.
+            Copy from posix path to cont2 and read properties from hdf5 file with --preserve-props.
+        """
+        # Set the tool to use
+        self.set_tool(tool)
+
+        # Set the api to use
+        self.set_api(api)
+
+        # Create 1 pool
+        pool1 = self.create_pool()
+        pool1.connect(2)
+
+	# set the path to read and write container properties
+        self.preserve_props_path = self.tmp + "/cont_props.h5"
+
+        # Create a source cont
+        cont1 = self.create_cont(pool1, cont_type=cont_type)
+
+        # Create source data
+        self.write_cont(cont1)
+
+        # Create a posix source path
+        posix_path = join(self.new_posix_test_path(), self.test_file)
+
+        # move data from DAOS to POSIX path and record container properties in hdf5 file
+        self.run_datamover(
+            self.test_id + " cont1 to posix",
+            "DAOS", "/", pool1, cont1,
+            "POSIX", posix_path, None, None)
+
+        # move data from POSIX path to DAOS and read container properties in hdf5 file to cont2
+        result = self.run_datamover(
+            self.test_id + " posix to cont2 (empty cont)",
+            "POSIX", posix_path + "/" + self.test_file, None, None,
+            "DAOS", "/", pool1, None)
+
+        cont2_uuid = self.parse_create_cont_uuid(result.stdout_text)
+        cont2 = self.get_cont(pool1, cont2_uuid)
+        cont2.type.update(cont1.type.value, "type")
+        self.verify_cont(cont2, api, False)
+
+        pool1.disconnect()
+
+    def write_cont(self, cont):
+        """Write the test data using either ior or the obj API.
+
+        Args:
+            cont (TestContainer): the container to write to.
+
+        Returns:
+            list: string list of properties from daos command.
+
+        """
+        if cont.type.value == "POSIX":
+            self.run_ior_with_params(
+                "DAOS", "/" + self.test_file,
+                cont.pool, cont, flags=self.ior_flags[0])
+        else:
+            self.obj_list = self.dataset_gen(cont, 1, 1, 1, 0, [1024], [])
+
+        # Write the user attributes
+        cont.open()
+        attrs = self.get_cont_usr_attr()
+        cont.container.set_attr(attrs)
+        cont.close()
+
+        # Return existing cont properties
+        return self.get_cont_prop(cont)
+
+    def verify_cont(self, cont, api, check_attr_prop=True, prop_list=None):
+        """Read-verify test data using either ior or the obj API.
+
+        Args:
+            cont (TestContainer): the container to verify.
+            check_attr_prop (bool, optional): whether to verify user
+                attributes and cont properties. Defaults to False.
+            prop_list (list, optional): list of properties from get_cont_prop.
+                Required when check_attr_prop is True.
+
+        """
+        # It's important to check the properties first, since when ior
+        # mounts DFS the alloc'ed OID might be incremented.
+        if check_attr_prop:
+            cont.open()
+            self.verify_cont_prop(cont, prop_list, api)
+            self.verify_usr_attr(cont)
+            cont.close()
+
+        if cont.type.value == "POSIX":
+            # Verify POSIX containers copied with the DFS and Object APIs
+            self.run_ior_with_params(
+                "DAOS", "/" + self.test_file,
+                cont.pool, cont, flags=self.ior_flags[1])
+        else:
+            # Verify non-POSIX containers copied with the Object API
+            self.dataset_verify(self.obj_list, cont, 1, 1, 1, 0, [1024], [])
+
+    def get_cont_prop(self, cont):
+        """Get all container properties with daos command.
+
+        Args:
+            cont (TestContainer): the container to get props of.
+
+        Returns:
+            list: string list of properties and values from daos command.
+
+        """
+        prop_result = self.daos_cmd.container_get_prop(
+            cont.pool.uuid, cont.uuid)
+        prop_text = prop_result.stdout_text
+        prop_list = prop_text.split('\n')[1:]
+        return prop_list
+
+    def verify_cont_prop(self, cont, prop_list, api):
+        """Verify container properties against an input list.
+        Expects the container to be open.
+
+        Args:
+            cont (TestContainer): the container to verify.
+            prop_list (list): list of properties from get_cont_prop.
+
+        """
+        actual_list = self.get_cont_prop(cont)
+
+        # Make sure sizes match
+        if len(prop_list) != len(actual_list):
+            self.log.info("Expected\n%s\nbut got\n%s\n",
+                          prop_list, actual_list)
+            self.fail("Container property verification failed.")
+
+        # Make sure each property matches
+        for prop_idx, prop in enumerate(prop_list):
+            # This one is not set
+            if api == "DFS" and "OID" in prop_list[prop_idx]:
+                continue
+            if prop != actual_list[prop_idx]:
+                self.log.info("Expected\n%s\nbut got\n%s\n",
+                              prop_list, actual_list)
+                self.fail("Container property verification failed.")
+
+        self.log.info("Verified %d container properties:\n%s",
+                      len(actual_list), actual_list)
+
+    @staticmethod
+    def get_cont_usr_attr():
+        """Generate some user attributes"""
+        attrs = {}
+        attrs["attr1".encode("utf-8")] = "value 1".encode("utf-8")
+        attrs["attr2".encode("utf-8")] = "value 2".encode("utf-8")
+        return attrs
+
+    def verify_usr_attr(self, cont):
+        """Verify user attributes. Expects the container to be open.
+
+        Args:
+            cont (TestContainer): the container to verify.
+
+        """
+        attrs = self.get_cont_usr_attr()
+        actual_attrs = cont.container.get_attr(list(attrs.keys()))
+
+        # Make sure the sizes match
+        if len(attrs.keys()) != len(actual_attrs.keys()):
+            self.log.info("Expected\n%s\nbut got\n%s\n",
+                          attrs.items(), actual_attrs.items())
+            self.fail("Container user attributes verification failed.")
+
+        # Make sure each attr matches
+        for attr, val in attrs.items():
+            if attr not in actual_attrs:
+                self.log.info("Expected\n%s\nbut got\n%s\n",
+                              attrs.items(), actual_attrs.items())
+                self.fail("Container user attributes verification failed.")
+            if val != actual_attrs[attr]:
+                self.log.info("Expected\n%s\nbut got\n%s\n",
+                              attrs.items(), actual_attrs.items())
+                self.fail("Container user attributes verification failed.")
+        self.log.info("Verified %d user attributes:\n%s",
+                      len(attrs.keys()), attrs.items())
+
+    @avocado.fail_on(DaosApiError)
+    def test_dm_preserve_props_fs_copy_posix_dfs(self):
+        """
+        Test Description:
+            Verifies destination container creation
+            when API is unknown, including
+            container properties and user attributes.
+
+        :avocado: tags=all,full_regression
+        :avocado: tags=datamover,fs_copy
+        :avocado: tags=dm_preserve_props,dm_preserve_props_fs_copy_posix_dfs
+        """
+        self.run_dm_preserve_props("FS_COPY", "POSIX", "DFS")

--- a/src/tests/ftest/datamover/dm_posix_preserve_props.yaml
+++ b/src/tests/ftest/datamover/dm_posix_preserve_props.yaml
@@ -1,0 +1,28 @@
+hosts:
+    test_servers:
+        - server-A
+    test_clients:
+        - server-B
+timeout: 120
+server_config:
+    name: daos_server
+pool:
+    mode: 146
+    name: daos_server
+    scm_size: 1G
+    control_method: dmg
+container:
+    type: POSIX
+    control_method: daos
+    properties:
+        - compression:lz4
+ior:
+    client_processes:
+        np: 1
+    test_file: testFile
+    ior_flags:
+        - "-v -w -k" # write
+        - "-v -r -R" # read-verify
+    block_size: '1K'
+    transfer_size: '1K'
+    signature: 5

--- a/src/tests/ftest/util/daos_utils.py
+++ b/src/tests/ftest/util/daos_utils.py
@@ -636,7 +636,7 @@ class DaosCommand(DaosCommandBase):
 
         return data
 
-    def filesystem_copy(self, src, dst):
+    def filesystem_copy(self, src, dst, preserve_props=None):
         """Copy a POSIX container or path to another POSIX container or path.
 
         Args:
@@ -644,6 +644,7 @@ class DaosCommand(DaosCommandBase):
                 daos:<pool>/<cont>/<path> or posix:<path>
             dst (str): The destination, formatted as
                 daos:<pool>/<cont>/<path> or posix:<path>
+            preserve_props (str): The filename to read or write container properties
 
         Returns:
             CmdResult: Object that contains exit status, stdout, and other
@@ -654,4 +655,4 @@ class DaosCommand(DaosCommandBase):
 
         """
         return self._get_result(
-            ("filesystem", "copy"), src=src, dst=dst)
+            ("filesystem", "copy"), src=src, dst=dst, preserve_props=preserve_props)

--- a/src/tests/ftest/util/daos_utils_base.py
+++ b/src/tests/ftest/util/daos_utils_base.py
@@ -548,3 +548,5 @@ class DaosCommandBase(CommandWithSubCommand):
                 #   --src=<type>:<pool/cont | path>
                 #   supported types are daos, posix
                 self.dst = FormattedParameter("--dst={}")
+		# filename to write and read container properties
+                self.preserve_props = FormattedParameter("--preserve-props={}")

--- a/src/tests/ftest/util/data_mover_test_base.py
+++ b/src/tests/ftest/util/data_mover_test_base.py
@@ -84,6 +84,9 @@ class DataMoverTestBase(IorTestBase, MdtestBase):
         # Temp directory for serialize/deserialize
         self.serial_tmp_dir = self.tmp
 
+	# path to read and write container properties to/from hdf5 file
+        self.preserve_props_path = None
+
         # List of test paths to create and remove
         self.posix_test_paths = []
 
@@ -770,6 +773,10 @@ class DataMoverTestBase(IorTestBase, MdtestBase):
 
         # First, initialize a new fs copy command
         self.fs_copy_cmd = FsCopy(self.daos_cmd, self.log)
+
+	# set preserve-props path if it was used in test case
+        if self.preserve_props_path:
+            self.fs_copy_cmd.set_fs_copy_params(preserve_props=self.preserve_props_path)
 
         # Set the source params
         if src_type == "POSIX":

--- a/src/tests/ftest/util/data_mover_utils.py
+++ b/src/tests/ftest/util/data_mover_utils.py
@@ -287,10 +287,11 @@ class FsCopy():
         """
         self.src = None
         self.dst = None
+        self.preserve_props = None
         self.daos_cmd = daos_cmd
         self.log = log
 
-    def set_fs_copy_params(self, src=None, dst=None):
+    def set_fs_copy_params(self, src=None, dst=None, preserve_props=None):
         """Set the daos fs copy params.
 
         Args:
@@ -304,6 +305,8 @@ class FsCopy():
             self.src = src
         if dst:
             self.dst = dst
+        if preserve_props:
+            self.preserve_props = preserve_props
 
     def run(self):
         # pylint: disable=arguments-differ
@@ -319,7 +322,8 @@ class FsCopy():
         """
         self.log.info("Starting daos filesystem copy")
 
-        return self.daos_cmd.filesystem_copy(src=self.src, dst=self.dst)
+        return self.daos_cmd.filesystem_copy(src=self.src, dst=self.dst,
+	    preserve_props=self.preserve_props)
 
 class ContClone():
     """Class defining an object of type ContClone.

--- a/src/utils/SConscript
+++ b/src/utils/SConscript
@@ -8,7 +8,7 @@ def scons():
     if not prereqs.client_requested():
         return
 
-    libs = ['daos', 'daos_common', 'uuid', 'dfs', 'duns', 'gurt', 'cart']
+    libs = ['daos', 'daos_common', 'uuid', 'dfs', 'duns', 'gurt', 'cart', 'dl']
 
     daos_build.add_build_rpath(env)
     daos_build.add_build_rpath(base_env)

--- a/src/utils/daos.c
+++ b/src/utils/daos.c
@@ -586,6 +586,7 @@ args_free(struct cmd_args_s *ap)
 	D_FREE(ap->dfs_prefix);
 	D_FREE(ap->src);
 	D_FREE(ap->dst);
+	D_FREE(ap->preserve_props);
 	D_FREE(ap->snapname_str);
 	D_FREE(ap->epcrange_str);
 
@@ -606,35 +607,36 @@ common_op_parse_hdlr(int argc, char *argv[], struct cmd_args_s *ap)
 	/* Note: will rely on getopt_long() substring matching for shorter
 	 * option variants. Specifically --sys= for --sys-name=
 	 */
-	struct option		options[] = {
-		{"sys-name",	required_argument,	NULL,	'G'},
-		{"pool",	required_argument,	NULL,	'p'},
-		{"cont",	required_argument,	NULL,	'c'},
-		{"attr",	required_argument,	NULL,	'a'},
-		{"value",	required_argument,	NULL,	'v'},
-		{"path",	required_argument,	NULL,	'd'},
-		{"src",		required_argument,	NULL,	'S'},
-		{"dst",		required_argument,	NULL,	'D'},
-		{"type",	required_argument,	NULL,	't'},
-		{"mode",	required_argument,	NULL,	'M'},
-		{"oclass",	required_argument,	NULL,	'o'},
-		{"chunk-size",	required_argument,	NULL,	'z'},
-		{"dfs-prefix",	required_argument,	NULL,	'I'},
-		{"dfs-path",	required_argument,	NULL,	'H'},
-		{"snap",	required_argument,	NULL,	's'},
-		{"epc",		required_argument,	NULL,	'e'},
-		{"epcrange",	required_argument,	NULL,	'r'},
-		{"oid",		required_argument,	NULL,	'i'},
-		{"force",	no_argument,		NULL,	'f'},
-		{"properties",	required_argument,	NULL,	DAOS_PROPERTIES_OPTION},
-		{"outfile",	required_argument,	NULL,	'O'},
-		{"verbose",	no_argument,		NULL,	'V'},
-		{"acl-file",	required_argument,	NULL,	'A'},
-		{"entry",	required_argument,	NULL,	'E'},
-		{"user",	required_argument,	NULL,	'u'},
-		{"group",	required_argument,	NULL,	'g'},
-		{"principal",	required_argument,	NULL,	'P'},
-		{NULL,		0,			NULL,	0}
+	struct option			options[] = {
+		{"sys-name",		required_argument,	NULL,	'G'},
+		{"pool",		required_argument,	NULL,	'p'},
+		{"cont",		required_argument,	NULL,	'c'},
+		{"attr",		required_argument,	NULL,	'a'},
+		{"value",		required_argument,	NULL,	'v'},
+		{"path",		required_argument,	NULL,	'd'},
+		{"src",			required_argument,	NULL,	'S'},
+		{"dst",			required_argument,	NULL,	'D'},
+		{"preserve-props",	required_argument,	NULL,	'm'},
+		{"type",		required_argument,	NULL,	't'},
+		{"mode",		required_argument,	NULL,	'M'},
+		{"oclass",		required_argument,	NULL,	'o'},
+		{"chunk-size",		required_argument,	NULL,	'z'},
+		{"dfs-prefix",		required_argument,	NULL,	'I'},
+		{"dfs-path",		required_argument,	NULL,	'H'},
+		{"snap",		required_argument,	NULL,	's'},
+		{"epc",			required_argument,	NULL,	'e'},
+		{"epcrange",		required_argument,	NULL,	'r'},
+		{"oid",			required_argument,	NULL,	'i'},
+		{"force",		no_argument,		NULL,	'f'},
+		{"properties",		required_argument,	NULL,	DAOS_PROPERTIES_OPTION},
+		{"outfile",		required_argument,	NULL,	'O'},
+		{"verbose",		no_argument,		NULL,	'V'},
+		{"acl-file",		required_argument,	NULL,	'A'},
+		{"entry",		required_argument,	NULL,	'E'},
+		{"user",		required_argument,	NULL,	'u'},
+		{"group",		required_argument,	NULL,	'g'},
+		{"principal",		required_argument,	NULL,	'P'},
+		{NULL,			0,			NULL,	0}
 	};
 	bool			posix_mode_set = false;
 	int			rc;
@@ -772,6 +774,11 @@ common_op_parse_hdlr(int argc, char *argv[], struct cmd_args_s *ap)
 		case 'H':
 			D_STRNDUP(ap->dfs_path, optarg, strlen(optarg));
 			if (ap->dfs_path == NULL)
+				D_GOTO(out_free, rc = RC_NO_HELP);
+			break;
+		case 'm':
+			D_STRNDUP(ap->preserve_props, optarg, strlen(optarg));
+			if (ap->preserve_props == NULL)
 				D_GOTO(out_free, rc = RC_NO_HELP);
 			break;
 		case 't':
@@ -1484,6 +1491,7 @@ do { \
 	" filesystem copy options (copy):\n" \
 	"	--src=daos://<pool/cont> | <path>\n" \
 	"	--dst=daos://<pool/cont> | <path>\n" \
+	"	--preserve-props=<filename>\n" \
 	"	\t type is daos, only specified if pool/cont used\n"); \
 	fprintf(stream, "\n"); \
 } while (0)

--- a/src/utils/daos_hdlr.h
+++ b/src/utils/daos_hdlr.h
@@ -89,6 +89,7 @@ struct cmd_args_s {
 	char			*path;		/* --path cont namespace */
 	char			*src;		/* --src path for fs copy */
 	char			*dst;		/* --dst path for fs copy */
+	char			*preserve_props; /* --path to metadata file */
 	daos_cont_layout_t	type;		/* --type cont type */
 	daos_oclass_id_t	oclass;		/* --oclass object class */
 	uint32_t		mode;		/* --posix consistency mode */
@@ -189,6 +190,14 @@ int pool_autotest_hdlr(struct cmd_args_s *ap);
 /* TODO: implement these pool op functions
  * int pool_stat_hdlr(struct cmd_args_s *ap);
  */
+
+/* general datamover operations */
+void dm_cont_free_usr_attrs(int n, char ***_names, void ***_buffers, size_t **_sizes);
+int dm_cont_get_usr_attrs(struct cmd_args_s *ap, daos_handle_t coh, int *_n, char ***_names,
+			  void ***_buffers, size_t **_sizes);
+int dm_cont_get_all_props(struct cmd_args_s *ap, daos_handle_t coh, daos_prop_t **_props,
+			  bool get_oid, bool get_label, bool get_roots);
+int dm_copy_usr_attrs(struct cmd_args_s *ap, daos_handle_t src_coh, daos_handle_t dst_coh);
 
 /* filesystem operations */
 int fs_copy_hdlr(struct cmd_args_s *ap);


### PR DESCRIPTION
	* add an option to preserve container properties
	  to filesystem copy tool
	* add check for container status before copying
	* add serialization support for DAOS_PROP_CO_ROOTS
	  and DAOS_PROP_CO_EC_CELL_SZ
	* add functional tests for the preserve props option

The preserve properties option within filesystem copy can be
used when moving data from DAOS->POSIX and then POSIX->DAOS.
If moving data from DAOS->POSIX the container properties would
be written to an hdf5 file, and then when moving data back
to DAOS the path to the file can be provided so that the newly
created DAOS container will read and use the preserved DAOS
container properties within the hdf5 file.

Signed-off-by: Danielle Sikich <danielle.sikich@intel.com>