### PR TITLE
DAOS-8409 test: Use D_LOG_FILE_APPEND_PID for core tests

### DIFF
--- a/src/tests/ftest/daos_test/daos_core_test-nvme_recovery.yaml
+++ b/src/tests/ftest/daos_test/daos_core_test-nvme_recovery.yaml
@@ -27,6 +27,8 @@ server_config:
       scm_class: dcpm
       scm_list: ["/dev/pmem0"]
       scm_mount: /mnt/daos0
+      env_vars:
+        - D_LOG_FILE_APPEND_PID=1
     1:
       pinned_numa_node: 1
       nr_xs_helpers: 1
@@ -39,6 +41,8 @@ server_config:
       scm_class: dcpm
       scm_list: ["/dev/pmem1"]
       scm_mount: /mnt/daos1
+      env_vars:
+        - D_LOG_FILE_APPEND_PID=1
   transport_config:
     allow_insecure: True
 agent_config:

--- a/src/tests/ftest/daos_test/daos_core_test-rebuild.yaml
+++ b/src/tests/ftest/daos_test/daos_core_test-rebuild.yaml
@@ -32,6 +32,7 @@ server_config:
       log_mask: DEBUG,MEM=ERR
       env_vars:
         - DD_MASK=mgmt,io,md,epc,dsms,rebuild
+        - D_LOG_FILE_APPEND_PID=1
     1:
       pinned_numa_node: 1
       nr_xs_helpers: 1
@@ -47,6 +48,7 @@ server_config:
       log_mask: DEBUG,MEM=ERR
       env_vars:
         - DD_MASK=mgmt,io,md,epc,dsms,rebuild
+        - D_LOG_FILE_APPEND_PID=1
   transport_config:
     allow_insecure: False
 agent_config:

--- a/src/tests/ftest/daos_test/daos_core_test.yaml
+++ b/src/tests/ftest/daos_test/daos_core_test.yaml
@@ -57,6 +57,7 @@ server_config:
       log_mask: DEBUG,MEM=ERR
       env_vars:
         - DD_MASK=mgmt,io,md,epc,rebuild
+        - D_LOG_FILE_APPEND_PID=1
     1:
       pinned_numa_node: 1
       nr_xs_helpers: 1
@@ -71,6 +72,7 @@ server_config:
       log_mask: DEBUG,MEM=ERR
       env_vars:
         - DD_MASK=mgmt,io,md,epc,rebuild
+        - D_LOG_FILE_APPEND_PID=1
   transport_config:
     allow_insecure: True
 agent_config:

--- a/src/tests/ftest/daos_test/daos_core_test_dfs.yaml
+++ b/src/tests/ftest/daos_test/daos_core_test_dfs.yaml
@@ -31,6 +31,8 @@ server_config:
       scm_class: dcpm
       scm_list: ["/dev/pmem0"]
       scm_mount: /mnt/daos0
+      env_vars:
+        - D_LOG_FILE_APPEND_PID=1
     1:
       pinned_numa_node: 1
       nr_xs_helpers: 1
@@ -40,6 +42,8 @@ server_config:
       scm_class: dcpm
       scm_list: ["/dev/pmem1"]
       scm_mount: /mnt/daos1
+      env_vars:
+        - D_LOG_FILE_APPEND_PID=1
   transport_config:
     allow_insecure: True
 agent_config:


### PR DESCRIPTION
To avoid situations where a restarted server is writing to same
log file, always use the flag to append the pid to the log
name.

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>