### PR TITLE
DAOS-8409 test: Catch and ignore some exceptions with log parser

### DIFF
--- a/src/tests/ftest/cart/util/cart_logparse.py
+++ b/src/tests/ftest/cart/util/cart_logparse.py
@@ -563,7 +563,7 @@ class LogIter():
 
         index = 0
         for line in self._fd:
-            fields = line.split()
+            fields = line.split(None, 8)
             index += 1
             l_pid = None
             if len(fields) < 6 or len(fields[0]) != 17 or fields[0][2] != '/':
@@ -588,7 +588,7 @@ class LogIter():
         index = 0
         position = 0
         for line in self._fd:
-            fields = line.split()
+            fields = line.split(None, 8)
             index += 1
             l_pid = None
             if len(fields) < 6 or len(fields[0]) != 17:
@@ -669,7 +669,7 @@ class LogIter():
             line = self._fd.readline()
             if not line:
                 raise StopIteration
-            fields = line.split()
+            fields = line.split(None, 8)
             if len(fields) < 6 or len(fields[0]) != 17 or fields[0][2] != '/':
                 return LogRaw(line)
             return LogLine(line)

--- a/src/tests/ftest/cart/util/cart_logparse.py
+++ b/src/tests/ftest/cart/util/cart_logparse.py
@@ -187,13 +187,13 @@ class LogLine():
             try:
                 (filename, _) = self._fields[0].split(':')
                 return filename
-            except ValueError:
+            except (IndexError, ValueError):
                 pass
         elif attr == 'lineno':
             try:
                 (_, lineno) = self._fields[0].split(':')
                 return int(lineno)
-            except ValueError:
+            except (IndexError, ValueError):
                 pass
         raise AttributeError
 
@@ -563,7 +563,7 @@ class LogIter():
 
         index = 0
         for line in self._fd:
-            fields = line.split(' ', 8)
+            fields = line.split()
             index += 1
             l_pid = None
             if len(fields) < 6 or len(fields[0]) != 17 or fields[0][2] != '/':
@@ -588,7 +588,7 @@ class LogIter():
         index = 0
         position = 0
         for line in self._fd:
-            fields = line.split(' ', 8)
+            fields = line.split()
             index += 1
             l_pid = None
             if len(fields) < 6 or len(fields[0]) != 17:
@@ -669,7 +669,7 @@ class LogIter():
             line = self._fd.readline()
             if not line:
                 raise StopIteration
-            fields = line.split(' ', 8)
+            fields = line.split()
             if len(fields) < 6 or len(fields[0]) != 17 or fields[0][2] != '/':
                 return LogRaw(line)
             return LogLine(line)


### PR DESCRIPTION
* filename and line number fields can be malformated
* use split(None, 8) rather than split(' ', 8) for the checks.  The latter
  will include whitespace entries.   For instance,

  line = "a b  c" would get ['a', 'b', '', 'c'] whereas split()
  yields ['a', 'b', 'c'].  This means the bounds check doesn't
  prevent calls to LogLine in some cases because LogLine does
  split() which is the same as split(None)

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>