### PR TITLE
DAOS-8167 EC: various fixes for EC

### DIFF
--- a/src/object/cli_shard.c
+++ b/src/object/cli_shard.c
@@ -1143,10 +1143,10 @@ dc_obj_shard_rw(struct dc_obj_shard *shard, enum obj_rpc_opc opc,
 	orw->orw_iod_array.oia_offs = args->offs;
 
 	D_DEBUG(DB_IO, "rpc %p opc %d "DF_UOID" "DF_KEY" rank %d tag %d eph "
-		DF_U64", DTI = "DF_DTI" ver %u\n", req, opc,
+		DF_U64", DTI = "DF_DTI" start shard %u ver %u\n", req, opc,
 		DP_UOID(shard->do_id), DP_KEY(dkey), tgt_ep.ep_rank,
 		tgt_ep.ep_tag, auxi->epoch.oe_value, DP_DTI(&orw->orw_dti),
-		orw->orw_map_ver);
+		orw->orw_start_shard, orw->orw_map_ver);
 
 	if (args->bulks != NULL) {
 		orw->orw_sgls.ca_count = 0;

--- a/src/object/obj_ec.h
+++ b/src/object/obj_ec.h
@@ -718,7 +718,7 @@ struct obj_rw_in;
 int obj_ec_rw_req_split(daos_unit_oid_t oid, struct obj_iod_array *iod_array,
 			uint32_t iod_nr, uint32_t start_shard,
 			uint32_t max_shard, uint32_t leader_id,
-			void *tgt_map, uint32_t map_size,
+			void *tgt_map, uint32_t map_size, struct daos_oclass_attr *oca,
 			uint32_t tgt_nr, struct daos_shard_tgt *tgts,
 			struct obj_ec_split_req **split_req);
 void obj_ec_split_req_fini(struct obj_ec_split_req *req);

--- a/src/object/srv_ec.c
+++ b/src/object/srv_ec.c
@@ -47,7 +47,8 @@ int
 obj_ec_rw_req_split(daos_unit_oid_t oid, struct obj_iod_array *iod_array,
 		    uint32_t iod_nr, uint32_t start_shard, uint32_t max_shard,
 		    uint32_t leader_id, void *tgt_map, uint32_t map_size,
-		    uint32_t tgt_nr, struct daos_shard_tgt *tgts,
+		    struct daos_oclass_attr *oca, uint32_t tgt_nr,
+		    struct daos_shard_tgt *tgts,
 		    struct obj_ec_split_req **split_req)
 {
 	daos_iod_t		*iod;
@@ -117,6 +118,7 @@ obj_ec_rw_req_split(daos_unit_oid_t oid, struct obj_iod_array *iod_array,
 			if (tgt_max_idx < tgt_idx)
 				tgt_max_idx = tgt_idx;
 		} else {
+			D_ASSERT(tgts[i].st_shard >= start_shard);
 			tgt_idx = tgts[i].st_shard - start_shard;
 			D_ASSERT(tgt_idx <= tgt_max_idx);
 		}
@@ -138,7 +140,8 @@ obj_ec_rw_req_split(daos_unit_oid_t oid, struct obj_iod_array *iod_array,
 	} else {
 		D_ASSERT(leader_id == PO_COMP_ID_ALL);
 
-		leader = oid.id_shard - start_shard;
+		D_ASSERT(oca != NULL);
+		leader = oid.id_shard % obj_ec_tgt_nr(oca);
 		setbit(tgt_bit_map, leader);
 		count++;
 	}

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -845,8 +845,7 @@ csum_verify_keys(struct daos_csummer *csummer, daos_key_t *dkey,
 		rc = daos_csummer_verify_key(csummer, dkey, dkey_csum);
 		if (rc != 0) {
 			D_ERROR("daos_csummer_verify_key error for dkey: "
-					DF_RC"\n",
-				DP_RC(rc));
+				DF_RC"\n", DP_RC(rc));
 			return rc;
 		}
 	}
@@ -2551,7 +2550,8 @@ again2:
 		rc = obj_ec_rw_req_split(orw->orw_oid, &orw->orw_iod_array,
 					 orw->orw_nr, orw->orw_start_shard,
 					 orw->orw_tgt_max, PO_COMP_ID_ALL,
-					 NULL, 0, orw->orw_shard_tgts.ca_count,
+					 NULL, 0, &ioc.ioc_oca,
+					 orw->orw_shard_tgts.ca_count,
 					 orw->orw_shard_tgts.ca_arrays,
 					 &split_req);
 		if (rc != 0) {
@@ -4354,7 +4354,7 @@ ds_obj_dtx_leader_prep_handle(struct daos_cpd_sub_head *dcsh,
 					 dcsr->dcsr_nr, dcu->dcu_start_shard, 0,
 					 ddt->ddt_id,
 					 dcu->dcu_ec_tgts, dcsr->dcsr_ec_tgt_nr,
-					 tgt_cnt, tgts, &dcu->dcu_ec_split_req);
+					 NULL, tgt_cnt, tgts, &dcu->dcu_ec_split_req);
 		if (rc != 0) {
 			D_ERROR("obj_ec_rw_req_split failed for obj "
 				DF_UOID", DTX "DF_DTI": "DF_RC"\n",

--- a/src/placement/pl_map.c
+++ b/src/placement/pl_map.c
@@ -622,7 +622,9 @@ pl_select_leader(daos_obj_id_t oid, uint32_t grp_idx, uint32_t grp_size,
 	if (oc_attr->ca_resil != DAOS_RES_REPL) {
 		int tgt_nr = oc_attr->u.ec.e_k + oc_attr->u.ec.e_p;
 		int fail_cnt = 0;
-		int idx = grp_idx * tgt_nr + tgt_nr - 1;
+		int idx = grp_idx * grp_size + tgt_nr - 1;
+		bool parity_rebuilding = false;
+		int leader_shard_idx;
 
 		/* For EC object, elect last shard in the group (must to be
 		 * a parity node) as leader.
@@ -631,8 +633,19 @@ pl_select_leader(daos_obj_id_t oid, uint32_t grp_idx, uint32_t grp_size,
 		while (shard->po_rebuilding || shard->po_shard == -1 ||
 		       shard->po_target == -1) {
 			idx--;
-			if (++fail_cnt >= oc_attr->u.ec.e_p)
-				return -DER_IO;
+			if (shard->po_rebuilding)
+				parity_rebuilding = true;
+
+			if (++fail_cnt >= oc_attr->u.ec.e_p) {
+				/* If parity is rebuilding, let's return DER_STALE,
+				 * so object I/O might refresh the pool map and layout
+				 * until parity rebuilt finish.
+				 */
+				if (parity_rebuilding)
+					return -DER_STALE;
+				else
+					return -DER_IO;
+			}
 			shard = pl_get_shard(data, idx);
 		}
 
@@ -643,7 +656,12 @@ pl_select_leader(daos_obj_id_t oid, uint32_t grp_idx, uint32_t grp_size,
 			*tgt_id = shard->po_target;
 		}
 
-		return shard->po_shard == -1 ? -DER_IO : shard->po_shard;
+		if (shard->po_shard == -1)
+			return -DER_IO;
+
+		leader_shard_idx = (shard->po_shard / tgt_nr) * grp_size +
+				    shard->po_shard % tgt_nr;
+		return leader_shard_idx;
 	}
 
 	replicas = oc_attr->u.rp.r_num;


### PR DESCRIPTION
1. reset start_shard for retry task as well, because
the layout might change during reintegration after
layout refresh.

2. If the parity is rebuilding, let's return ESTALE to
retry and wait until parity rebuilding finished.

3. checksum might need be calculated for retry IO, if
the failure happened before the initial checksum  init.

4. A few st_shard fixes for ec split req process on the
leader.

Signed-off-by: Di Wang <di.wang@intel.com>