### PR TITLE
DAOS-8082 container: remove IV stuff for container destroy

### DIFF
--- a/src/container/container_iv.c
+++ b/src/container/container_iv.c
@@ -1010,23 +1010,61 @@ cont_iv_capability_update(void *ns, uuid_t cont_hdl_uuid, uuid_t cont_uuid,
 	return rc;
 }
 
-int
-cont_iv_capability_invalidate(void *ns, uuid_t cont_hdl_uuid, int mode)
+static int
+cont_iv_invalidate(void *ns, uint32_t class_id, uuid_t cont_uuid, int mode)
 {
 	struct ds_iv_key	key = { 0 };
 	struct cont_iv_key	*civ_key;
 	int			rc;
 
+	key.class_id = class_id;
 	civ_key = key2priv(&key);
-	uuid_copy(civ_key->cont_uuid, cont_hdl_uuid);
-	civ_key->class_id = IV_CONT_CAPA;
+	uuid_copy(civ_key->cont_uuid, cont_uuid);
+	civ_key->class_id = class_id;
+	civ_key->entry_size = 0;
 
-	key.class_id = IV_CONT_CAPA;
-	rc = ds_iv_invalidate(ns, &key, 0, mode, 0, false /* retry */);
+	rc = ds_iv_invalidate(ns, &key, 0, mode, 0, false);
 	if (rc)
-		D_ERROR("iv invalidate failed "DF_RC"\n", DP_RC(rc));
+		D_ERROR(DF_UUID" iv invalidate failed "DF_RC"\n",
+			DP_UUID(cont_uuid), DP_RC(rc));
 
 	return rc;
+}
+
+int
+cont_iv_entry_delete(void *ns, uuid_t pool_uuid, uuid_t cont_uuid)
+{
+	int rc;
+
+	/* delete all entries for this container */
+	rc = oid_iv_invalidate(ns, pool_uuid, cont_uuid);
+	if (rc != 0)
+		D_DEBUG(DB_MD, "delete snap "DF_UUID"\n", DP_UUID(cont_uuid));
+
+	/* delete all entries for this container */
+	rc = cont_iv_invalidate(ns, IV_CONT_SNAP, cont_uuid, CRT_IV_SYNC_NONE);
+	if (rc != 0)
+		D_DEBUG(DB_MD, "delete snap "DF_UUID"\n", DP_UUID(cont_uuid));
+
+	rc = cont_iv_invalidate(ns, IV_CONT_PROP, cont_uuid, CRT_IV_SYNC_NONE);
+	if (rc != 0)
+		D_DEBUG(DB_MD, "delete prop "DF_UUID"\n", DP_UUID(cont_uuid));
+
+	rc = cont_iv_invalidate(ns, IV_CONT_AGG_EPOCH_REPORT, cont_uuid, CRT_IV_SYNC_NONE);
+	if (rc != 0)
+		D_DEBUG(DB_MD, "delete agg epoch report "DF_UUID"\n", DP_UUID(cont_uuid));
+
+	rc = cont_iv_invalidate(ns, IV_CONT_AGG_EPOCH_BOUNDRY, cont_uuid, CRT_IV_SYNC_NONE);
+	if (rc != 0)
+		D_DEBUG(DB_MD, "delete agg epoch boundary "DF_UUID"\n", DP_UUID(cont_uuid));
+
+	return 0;
+}
+
+int
+cont_iv_capability_invalidate(void *ns, uuid_t cont_hdl_uuid, int mode)
+{
+	return cont_iv_invalidate(ns, IV_CONT_CAPA, cont_hdl_uuid, mode);
 }
 
 static int

--- a/src/container/srv_container.c
+++ b/src/container/srv_container.c
@@ -1099,6 +1099,9 @@ out:
 	return rc;
 }
 
+static void
+cont_ec_agg_delete(struct cont_svc *svc, uuid_t cont_uuid);
+
 static int
 cont_destroy(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl,
 	     struct cont *cont, crt_rpc_t *rpc)
@@ -1148,6 +1151,8 @@ cont_destroy(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl,
 	rc = cont_destroy_bcast(rpc->cr_ctx, cont->c_svc, cont->c_uuid);
 	if (rc != 0)
 		goto out_prop;
+
+	cont_ec_agg_delete(cont->c_svc, cont->c_uuid);
 
 	/* Destroy the handle index KVS. */
 	rc = rdb_tx_destroy_kvs(tx, &cont->c_prop, &ds_cont_prop_handles);
@@ -1260,6 +1265,18 @@ cont_ec_agg_destroy(struct cont_ec_agg *ec_agg)
 	d_list_del(&ec_agg->ea_list);
 	D_FREE(ec_agg->ea_server_ephs);
 	D_FREE(ec_agg);
+}
+
+static void
+cont_ec_agg_delete(struct cont_svc *svc, uuid_t cont_uuid)
+{
+	struct cont_ec_agg	*ec_agg;
+
+	ec_agg = cont_ec_agg_lookup(svc, cont_uuid);
+	if (ec_agg == NULL)
+		return;
+
+	cont_ec_agg_destroy(ec_agg);
 }
 
 /**

--- a/src/container/srv_internal.h
+++ b/src/container/srv_internal.h
@@ -252,6 +252,7 @@ int ds_oid_iv_init(void);
 int ds_oid_iv_fini(void);
 int oid_iv_reserve(void *ns, uuid_t poh_uuid, uuid_t co_uuid, uint64_t num_oids,
 		   d_sg_list_t *value);
+int oid_iv_invalidate(void *ns, uuid_t pool_uuid, uuid_t cont_uuid);
 
 /* container_iv.c */
 int ds_cont_iv_init(void);
@@ -269,6 +270,7 @@ int cont_iv_snapshots_update(void *ns, uuid_t cont_uuid,
 			     uint64_t *snapshots, int snap_count);
 int cont_iv_ec_agg_eph_update(void *ns, uuid_t cont_uuid, daos_epoch_t eph);
 int cont_iv_ec_agg_eph_refresh(void *ns, uuid_t cont_uuid, daos_epoch_t eph);
+int cont_iv_entry_delete(void *ns, uuid_t pool_uuid, uuid_t cont_uuid);
 
 /* srv_metrics.c*/
 void *ds_cont_metrics_alloc(const char *path, int tgt_id);

--- a/src/container/srv_target.c
+++ b/src/container/srv_target.c
@@ -1247,14 +1247,25 @@ cont_delete_ec_agg(uuid_t pool_uuid, uuid_t cont_uuid);
 int
 ds_cont_tgt_destroy(uuid_t pool_uuid, uuid_t cont_uuid)
 {
+	struct ds_pool	*pool;
 	struct cont_tgt_destroy_in in;
 	int rc;
+
+	pool = ds_pool_lookup(pool_uuid);
+	if (pool == NULL) {
+		rc = -DER_NO_HDL;
+		goto out;
+	}
 
 	uuid_copy(in.tdi_pool_uuid, pool_uuid);
 	uuid_copy(in.tdi_uuid, cont_uuid);
 
 	cont_delete_ec_agg(pool_uuid, cont_uuid);
+	cont_iv_entry_delete(pool->sp_iv_ns, pool_uuid, cont_uuid);
+	ds_pool_put(pool);
+
 	rc = dss_thread_collective(cont_child_destroy_one, &in, 0);
+out:
 	return rc;
 }
 

--- a/src/engine/server_iv.c
+++ b/src/engine/server_iv.c
@@ -490,6 +490,10 @@ iv_on_update_internal(crt_iv_namespace_t ivns, crt_iv_key_t *iv_key,
 		key.class_id, key.rank, dss_self_rank(),
 		invalidate ? "no" : "yes");
 output:
+	/* invalidate entry might require to delete entry after refresh */
+	if (entry && entry->iv_to_delete)
+		entry->iv_ref--; /* destroy in ivc_on_put */
+
 	ds_iv_ns_put(ns);
 	return rc;
 }

--- a/src/include/daos_srv/iv.h
+++ b/src/include/daos_srv/iv.h
@@ -93,7 +93,8 @@ struct ds_iv_entry {
 	/* link to the namespace */
 	d_list_t		iv_link;
 	unsigned int		iv_ref;
-	unsigned int		iv_valid:1;
+	unsigned int		iv_valid:1,
+				iv_to_delete:1;
 };
 
 /**


### PR DESCRIPTION
1. Remove IV related stuff during container destroy.

2. Remove EC aggregation container tracker during container destroy.

Signed-off-by: Di Wang <di.wang@intel.com>