### PR TITLE
DAOS-8449 object: object may be removed during DTX sync

### DIFF
--- a/src/client/api/object.c
+++ b/src/client/api/object.c
@@ -260,6 +260,8 @@ daos_obj_verify(daos_handle_t coh, daos_obj_id_t oid, daos_epoch_t epoch)
 		rc = dc_task_schedule(task, true);
 		if (rc == 0)
 			rc = dc_obj_verify(oh, epochs_p, epoch_nr);
+		if (rc == -DER_NONEXIST)
+			rc = 0;
 	}
 
 	D_FREE(epochs_p);

--- a/src/dtx/dtx_resync.c
+++ b/src/dtx/dtx_resync.c
@@ -433,6 +433,9 @@ out:
 		/* Drain old committable DTX to help subsequent rebuild. */
 		err = dtx_obj_sync(cont, NULL, dra->epoch);
 
+	if (err == -DER_NONEXIST)
+		err = 0;
+
 	return err;
 }
 


### PR DESCRIPTION
There is CPU yield during DTX resync. Then it is normal that
someone may has removed/punched the object during the interval
of resync the DTX enteries that are related with the object and
marking the object as re-synced.

On the other hand, try to verify an object that does not exists
is not fatal failure.

Signed-off-by: Fan Yong <fan.yong@intel.com>