### PR TITLE
DAOS-7670 tests: report errors from gc_setup()

### DIFF
--- a/src/vos/tests/vts_gc.c
+++ b/src/vos/tests/vts_gc.c
@@ -555,6 +555,7 @@ static int
 gc_setup(void **state)
 {
 	struct credit_context	*tc = &gc_args.gc_ctx;
+	int rc;
 
 	memset(&gc_stat, 0, sizeof(gc_stat));
 	memset(&gc_args, 0, sizeof(gc_args));
@@ -569,7 +570,8 @@ gc_setup(void **state)
 	uuid_generate(tc->tsc_cont_uuid);
 	vts_pool_fallocate(&tc->tsc_pmem_file);
 
-	dts_ctx_init(&gc_args.gc_ctx);
+	rc = dts_ctx_init(&gc_args.gc_ctx);
+	assert_rc_equal(rc, 0);
 
 	gc_args.gc_array = false;
 	*state = &gc_args;


### PR DESCRIPTION
Errors from dts_ctx_init() are not relayed by gc_setup(), this
allows GC subtests to be wrongly run anyway and thus also
group-teardown routine gc_teardown(), leading to dts_ctx_fini()
to be called, even if it had been already during error-path in
dts_ctx_init(), causing too early extraneous unreferencing and
freeing of self_mode.self_tls with later crash consequences upon
dereferencing for next test-groups running attempts.
Simply relaying these errors from group-setup routine will allow
cmocka to handle this gracefully, by not running associated
sub-tests not group-teardown, and thus keep self_mode in a
consistent state.

Change-Id: Ife0fa364c33c09ef0a3d440a9ccef6866cef6488
Signed-off-by: Bruno Faccini <bruno.faccini@intel.com>