### PR TITLE
DAOS-8246 nlt: Change core affinity settings in NLT.

### DIFF
--- a/utils/nlt_server.yaml
+++ b/utils/nlt_server.yaml
@@ -1,14 +1,12 @@
 name: daos_server
 port: 10001
 provider: ofi+sockets
-socket_dir: /tmp/dnt_sockets
 nr_hugepages: 4096
 control_log_mask: DEBUG
 access_points: ['localhost:10001']
 engines:
 -
-  targets: 2
-  first_core: 0
+  targets: 4
   nr_xs_helpers: 2
   fabric_iface: eth0
   fabric_iface_port: 31416

--- a/utils/node_local_test.py
+++ b/utils/node_local_test.py
@@ -579,7 +579,7 @@ class DaosServer():
         if self.dfuse_cores:
             first_core = self.dfuse_cores
         else:
-            first_core = 24
+            first_core = 0
         server_port_count = int(server_env['FI_UNIVERSE_SIZE'])
         for idx in range(self.engines):
             engine = copy.deepcopy(ref_engine)

--- a/utils/node_local_test.py
+++ b/utils/node_local_test.py
@@ -443,6 +443,14 @@ class DaosServer():
         self._io_server_dir = None
         self.test_pool = None
 
+        # Detect the number of cores for dfuse and do something sensible, if there are
+        # more than 32 on the node then use 12, otherwise use the whole node.
+        num_cores = len(os.sched_getaffinity(0))
+        if num_cores > 32:
+            self.dfuse_cores = 12
+        else:
+            self.dfuse_cores = None
+
     def __del__(self):
         if self._agent:
             self._stop_agent()
@@ -558,6 +566,8 @@ class DaosServer():
             scyaml['engines'][0]['log_mask'] = self.conf.args.server_debug
         scyaml['control_log_file'] = self.control_log.name
 
+        scyaml['socket_dir'] = self.agent_dir
+
         for (key, value) in server_env.items():
             scyaml['engines'][0]['env_vars'].append('{}={}'.format(key, value))
 
@@ -565,11 +575,16 @@ class DaosServer():
         ref_engine['storage'][0]['scm_size'] = int(
             ref_engine['storage'][0]['scm_size'] / self.engines)
         scyaml['engines'] = []
+        # Leave some cores for dfuse, and start the daos server after these.
+        if self.dfuse_cores:
+            first_core = self.dfuse_cores
+        else:
+            first_core = 24
         server_port_count = int(server_env['FI_UNIVERSE_SIZE'])
         for idx in range(self.engines):
             engine = copy.deepcopy(ref_engine)
             engine['log_file'] = self.server_logs[idx].name
-            engine['first_core'] = ref_engine['targets'] * idx
+            engine['first_core'] = first_core + (ref_engine['targets'] * idx)
             engine['fabric_iface_port'] += server_port_count * idx
             engine['storage'][0]['scm_mount'] = '{}_{}'.format(
                 ref_engine['storage'][0]['scm_mount'], idx)
@@ -581,8 +596,7 @@ class DaosServer():
         self._yaml_file.write(yaml.dump(scyaml, encoding='utf-8'))
         self._yaml_file.flush()
 
-        cmd = [daos_server, '--config={}'.format(self._yaml_file.name),
-               'start', '-t', '4', '--insecure', '-d', self.agent_dir]
+        cmd = [daos_server, '--config={}'.format(self._yaml_file.name), 'start', '--insecure']
 
         if self.conf.args.no_root:
             cmd.append('--recreate-superblocks')
@@ -947,13 +961,7 @@ class DFuse():
         self.uns_path = uns_path
         self.container = container
         self.conf = conf
-        # Detect the number of cores and do something sensible, if there are
-        # more than 32 on the node then use 12, otherwise use the whole node.
-        num_cores = len(os.sched_getaffinity(0))
-        if num_cores > 32:
-            self.cores = 12
-        else:
-            self.cores = None
+        self.cores = daos.dfuse_cores
         self._daos = daos
         self.caching = caching
         self.use_valgrind = True


### PR DESCRIPTION
Avoid binding multiple processes to the same core in NLT.
Both daos_enging and dfuse were selecting cores to use, and
the algorithms they used overlapped.  Add logic to NLT to
ensure they bind to different cores.

Tidy up daos_server args, and put settings in config file
where possible.

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>
