### PR TITLE
DAOS-8497 test: Catch AttributeError when getting source location

### DIFF
--- a/src/tests/ftest/cart/util/cart_logparse.py
+++ b/src/tests/ftest/cart/util/cart_logparse.py
@@ -188,13 +188,13 @@ class LogLine():
                 (filename, _) = self._fields[0].split(':')
                 return filename
             except (IndexError, ValueError):
-                return 'Unknown'
+                pass
         elif attr == 'lineno':
             try:
                 (_, lineno) = self._fields[0].split(':')
                 return int(lineno)
             except (IndexError, ValueError):
-                return 0
+                pass
         raise AttributeError
 
     def get_msg(self):

--- a/src/tests/ftest/cart/util/cart_logparse.py
+++ b/src/tests/ftest/cart/util/cart_logparse.py
@@ -188,13 +188,13 @@ class LogLine():
                 (filename, _) = self._fields[0].split(':')
                 return filename
             except (IndexError, ValueError):
-                pass
+                return 'Unknown'
         elif attr == 'lineno':
             try:
                 (_, lineno) = self._fields[0].split(':')
                 return int(lineno)
             except (IndexError, ValueError):
-                pass
+                return 0
         raise AttributeError
 
     def get_msg(self):

--- a/src/tests/ftest/cart/util/cart_logtest.py
+++ b/src/tests/ftest/cart/util/cart_logtest.py
@@ -250,7 +250,7 @@ class LogTest():
         if self.quiet:
             return
         self.log_count += 1
-        function = getattr(line, 'filename', None)
+        function = getattr(line, 'function', None)
         if function:
             loc = '{}:{}'.format(line.filename, line.lineno)
         else:

--- a/src/tests/ftest/cart/util/cart_logtest.py
+++ b/src/tests/ftest/cart/util/cart_logtest.py
@@ -250,10 +250,9 @@ class LogTest():
         if self.quiet:
             return
         self.log_count += 1
-        function = getattr(line, 'function', None)
-        if function:
+        try:
             loc = '{}:{}'.format(line.filename, line.lineno)
-        else:
+        except AttributeError:
             loc = 'Unknown'
         self.log_locs[loc] += 1
         self.log_fac[line.fac] += 1


### PR DESCRIPTION
In the log that failed, the last line was truncated after
the : so there was no line number.   If there, is a function,
however, there should generally be a line number.

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>