### PR TITLE
DAOS-8489 doc: Document manually-defined fabric ifaces

### DIFF
--- a/docs/admin/deployment.md
+++ b/docs/admin/deployment.md
@@ -888,6 +888,39 @@ Refer to the example configuration file (
 [`daos_agent.yml`](https://github.com/daos-stack/daos/blob/master/utils/config/daos_agent.yml)
 ) for latest information and examples.
 
+#### Defining fabric interfaces manually
+
+By default, the DAOS agent automatically detects all fabric interfaces on the
+client node. It selects an appropriate one for DAOS I/O based on the NUMA node
+of the client request and the interface type preferences reported by the DAOS
+management service.
+
+If the DAOS agent does not detect the fabric interfaces correctly, the
+administrator may define them manually in the agent configuration. They must be
+organized by NUMA node. If using the verbs provider, the interface domain is
+also required.
+
+Example:
+```
+fabric_ifaces:
+  - numa_node: 0
+    devices:
+    -
+      - iface: ib0
+      - domain: mlx5_0
+    -
+      - iface: ib1
+      - domain: mlx5_1
+  - numa_node: 1
+    devices:
+    -
+      - iface: ib2
+      - domain: mlx5_2
+    -
+      - iface: ib3
+      - domain: mlx5_3
+```
+
 ### Agent Startup
 
 DAOS Agent is a standalone application to be run on each compute node.

--- a/utils/config/daos_agent.yml
+++ b/utils/config/daos_agent.yml
@@ -47,3 +47,25 @@
 # Full path and name of the DAOS agent logfile.
 # default: /tmp/daos_agent.log
 #log_file: /tmp/daos_agent.log
+
+# Manually define the fabric interfaces and domains to be used by the agent,
+# organized by NUMA node.
+# If not defined, the agent will automatically detect all fabric interfaces and
+# select appropriate ones based on the server preferences.
+#fabric_ifaces:
+#  - numa_node: 0
+#    devices:
+#    -
+#      - iface: ib0
+#      - domain: mlx5_0
+#    -
+#      - iface: ib1
+#      - domain: mlx5_1
+#  - numa_node: 1
+#    devices:
+#    -
+#      - iface: ib2
+#      - domain: mlx5_2
+#    -
+#      - iface: ib3
+#      - domain: mlx5_3


### PR DESCRIPTION
Add documentation about manually defining client fabric interfaces
in the agent config file.

Doc-only: true

Signed-off-by: Kris Jacque <kristin.jacque@intel.com>