### PR TITLE
DAOS-7174 doc: Update image sources from doc to docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,4 +11,4 @@ For any questions, please post to our
 Bugs should be reported through our
 [issue tracker](https://jira.hpdd.intel.com/projects/DAOS),
 with a test case to reproduce the issue (when applicable)
-and [debug logs](./doc/debugging.md).
+and [debug logs](./docs/debugging.md).

--- a/README.md
+++ b/README.md
@@ -44,4 +44,4 @@ More information can also be found on the [wiki](http://wiki.daos.io).
 
 For any questions, please post to our [user forum](https://daos.groups.io/g/daos).
 Bugs should be reported through our [issue tracker](http://jira.daos.io)
-with a test case to reproduce the issue (when applicable) and [debug logs](./doc/debugging.md).
+with a test case to reproduce the issue (when applicable) and [debug logs](./docs/debugging.md).

--- a/docs/admin/performance_tuning.md
+++ b/docs/admin/performance_tuning.md
@@ -472,12 +472,12 @@ please refer to the [System Deployment: Agent Startup][6] documentation
 section.
 
 [1]: <https://github.com/daos-stack/daos/tree/master/src/cart> (Collective and RPC Transport)
-[2]: <https://github.com/daos-stack/daos/blob/master/doc/admin/installation.md#distribution-packages> (DAOS distribution packages)
-[3]: <https://github.com/daos-stack/daos/blob/master/doc/admin/installation.md#building-daos--dependencies> (DAOS build documentation)
-[4]: <https://github.com/daos-stack/daos/blob/master/doc/admin/deployment.md#server-startup> (DAOS server startup documentation)
+[2]: <https://github.com/daos-stack/daos/blob/master/docs/admin/installation.md#distribution-packages> (DAOS distribution packages)
+[3]: <https://github.com/daos-stack/daos/blob/master/docs/admin/installation.md#building-daos--dependencies> (DAOS build documentation)
+[4]: <https://github.com/daos-stack/daos/blob/master/docs/admin/deployment.md#server-startup> (DAOS server startup documentation)
 [5]: <https://www.open-mpi.org/faq/?category=running#mpirun-hostfile> (mpirun hostfile)
-[6]: <https://github.com/daos-stack/daos/blob/master/doc/admin/deployment.md#disable-agent-cache-optional> (System Deployment Agent Startup)
+[6]: <https://github.com/daos-stack/daos/blob/master/docs/admin/deployment.md#disable-agent-cache-optional> (System Deployment Agent Startup)
 [7]: <https://daos-stack.github.io/user/posix/#dfuse>
-[8]: <https://github.com/daos-stack/daos/blob/master/doc/user/mpi-io.md>
-[9]: <https://github.com/daos-stack/daos/blob/master/doc/user/hdf5.md>
+[8]: <https://github.com/daos-stack/daos/blob/master/docs/user/mpi-io.md>
+[9]: <https://github.com/daos-stack/daos/blob/master/docs/user/hdf5.md>
 [10]: <https://github.com/hpc/ior/blob/main/README_DAOS>

--- a/docs/admin/performance_tuning.md
+++ b/docs/admin/performance_tuning.md
@@ -471,13 +471,13 @@ restarted to gain visibility to these changes. For additional information,
 please refer to the [System Deployment: Agent Startup][6] documentation
 section.
 
-[1]: <https://github.com/daos-stack/daos/tree/master/src/cart> (Collective and RPC Transport)
-[2]: <https://github.com/daos-stack/daos/blob/master/docs/admin/installation.md#distribution-packages> (DAOS distribution packages)
-[3]: <https://github.com/daos-stack/daos/blob/master/docs/admin/installation.md#building-daos--dependencies> (DAOS build documentation)
-[4]: <https://github.com/daos-stack/daos/blob/master/docs/admin/deployment.md#server-startup> (DAOS server startup documentation)
+[1]: </src/cart> (Collective and RPC Transport)
+[2]: </docs/admin/installation.md#distribution-packages> (DAOS distribution packages)
+[3]: </docs/admin/installation.md#building-daos--dependencies> (DAOS build documentation)
+[4]: </docs/admin/deployment.md#server-startup> (DAOS server startup documentation)
 [5]: <https://www.open-mpi.org/faq/?category=running#mpirun-hostfile> (mpirun hostfile)
-[6]: <https://github.com/daos-stack/daos/blob/master/docs/admin/deployment.md#disable-agent-cache-optional> (System Deployment Agent Startup)
+[6]: </docs/admin/deployment.md#disable-agent-cache-optional> (System Deployment Agent Startup)
 [7]: <https://daos-stack.github.io/user/posix/#dfuse>
-[8]: <https://github.com/daos-stack/daos/blob/master/docs/user/mpi-io.md>
-[9]: <https://github.com/daos-stack/daos/blob/master/docs/user/hdf5.md>
+[8]: </docs/user/mpi-io.md>
+[9]: </docs/user/hdf5.md>
 [10]: <https://github.com/hpc/ior/blob/main/README_DAOS>

--- a/docs/overview/terminology.md
+++ b/docs/overview/terminology.md
@@ -46,4 +46,4 @@
 |[ULT](https://github.com/pmodels/argobots/wiki/User-level-Thread-(ULT))|User Level Thread|
 |UPI|Intel Ultra Path Interconnect|
 |UUID|Universal Unique Identifier|
-|[VOS](/doc/vos/README.md)|Versioning Object Store|
+|[VOS](/docs/vos/README.md)|Versioning Object Store|

--- a/src/README.md
+++ b/src/README.md
@@ -2,8 +2,8 @@
 
 The purpose of this document is to describe the internal code structure and
 major algorithms used by DAOS. It assumes prior knowledge of
-the <a href="/doc/overview/storage.md">DAOS storage model</a>
-and <a href="/doc/overview/terminology.md">acronyms</a>.
+the <a href="/docs/overview/storage.md">DAOS storage model</a>
+and <a href="/docs/overview/terminology.md">acronyms</a>.
 This document contains the following sections:
 
 - <a href="#1">DAOS Components</a>
@@ -34,7 +34,7 @@ a high-performant fabric for data access. In practice, the same network
 can be used for both management and data access. IP over fabric can also
 be used as the management network.
 
-![DAOS SDS Components](/doc/graph/system_architecture.png)
+![DAOS SDS Components](/docs/graph/system_architecture.png)
 
 <a id="11"></a>
 ### DAOS System
@@ -181,7 +181,7 @@ As shown in the diagram below, the DAOS stack is structured as a collection
 of storage services over a client/server architecture.
 Examples of DAOS services are the pool, container, object and rebuild services.
 
-![DAOS Internal Services & Libraries](/doc/graph/services.png)
+![DAOS Internal Services & Libraries](/docs/graph/services.png)
 
 A DAOS service can be spread across the control and data planes and
 communicate internally through dRPC. Most services have client and server
@@ -261,7 +261,7 @@ For further reading on those infrastructure libraries, please see:
 
 The diagram below shows the internal layering of the DAOS services and
 interactions with the different libraries mentioned above.
-![DAOS Internal Layering](/doc/graph/layering.png)
+![DAOS Internal Layering](/docs/graph/layering.png)
 
 Vertical boxes represent DAOS services whereas horizontal ones are for
 infrastructure libraries.

--- a/src/bio/README.md
+++ b/src/bio/README.md
@@ -25,7 +25,7 @@ The DAOS service has two tiers of storage: Storage Class Memory (SCM) for byte-g
 ### Storage Performance Development Kit (SPDK)
 SPDK is an open source C library that when used in a storage application, can provide a significant performance increase of more than 7X over the standard NVMe kernel driver. SPDK's high performance can mainly be attributed to the user space NVMe driver, eliminating all syscalls and enabling zero-copy access from the application. In SPDK, the hardware is polled for completions as opposed to relying on interrupts, lowering both total latency and latency variance. SPDK also offers a block device layer called bdev which sits immediately above the device drivers like in a traditional kernel storage stack. This module offers pluggable module APIs for implementing block devices that interface with different types of block storage devices. This includes driver modules for NVMe, Malloc (ramdisk), Linux AIO, Ceph RBD, and others.
 
-![/doc/graph/Fig_065.png](/doc/graph/Fig_065.png "SPDK Software Stack")
+![/docs/graph/Fig_065.png](/docs/graph/Fig_065.png "SPDK Software Stack")
 
 #### SPDK NVMe Driver
 The NVMe driver is a C library linked to a storage application providing direct, zero-copy data transfer to and from NVMe SSDs. Other benefits of the SPDK NVMe driver are that it is entirely in user space, operates in polled-mode vs. interrupt-dependent, is asynchronous and lock-less.
@@ -64,7 +64,7 @@ BIO internally manages a per-xstream DMA safe buffer for SPDK DMA transfer over 
   - Device Owner Xstream: In the case there is no direct 1:1 mapping of VOS XStream to NVMe SSD, the VOS xstream that first opens the SPDK blobstore will be named the 'Device Owner'. The Device Owner Xstream is responsible for maintaining and updating the blobstore health data, handling device state transitions, and also media error events. All non-owner xstreams will forward events to the device owner.
   - Init Xstream: The first started VOS xstream is termed the 'Init Xstream'. The init xstream is responsible for initializing and finalizing the SPDK bdev, registering the SPDK hotplug poller, handling and periodically checking for new NVMe SSD hot remove and hotplug events, and handling all VMD LED device events.
 
-![/doc/graph/NVME_Threading_Model_Final](/doc/graph/NVME_Threading_Model_Final.PNG "NVMe Threading Model")
+![/docs/graph/NVME_Threading_Model_Final](/docs/graph/NVME_Threading_Model_Final.PNG "NVMe Threading Model")
 
 Above is a diagram of the current NVMe threading model. The 'Device Owner' xstream is responsible for all faulty device and device reintegration callbacks, as well as updating device health data. The 'Init' xstream is responsible for registering the SPDK hotplug poller and maintaining the current device list of SPDK bdevs as well as evicted and unplugged devices. Any device metadata operations or media error events that do not occur on either of these two xstreams will be forwarded to the appropriate xstream using the SPDK event framework for lockless inter-thread communication. All xstreams will periodically poll for I/O statistics (if enabled in server config), but only the device owner xstream will poll for device events, making necessary state transitions, and update device health stats, and the init xstream will poll for any device removal or device hot plug events.
 
@@ -111,14 +111,14 @@ The SSD identification feature is a way to quickly and visually locate a device.
 ### Intel Volume Management Device (VMD)
 Intel VMD is a technology embedded in the processor silicon that aggregates the NVMe PCIe SSDs attached to its root port, acting as an HBA does for SATA and SAS. Currently, PCIe storage lacks a standardized method to blink LEDs and indicated the status of a device. Intel VMD, along with NVMe, provides this support for LED management.
 
-![/doc/graph/Intel_VMD.png](/doc/graph/Intel_VMD.png "Intel VMD Technology")
+![/docs/graph/Intel_VMD.png](/docs/graph/Intel_VMD.png "Intel VMD Technology")
 Intel VMD places a control point in the PCIe root complex of the servers, meaning that NVMe drives can be hot-swapped, and the status LED is always reliable.
 
-![/doc/graph/VMD_Amber_LED.png](/doc/graph/VMD_Amber_LED.png "Status Amber VMD LED")
+![/docs/graph/VMD_Amber_LED.png](/docs/graph/VMD_Amber_LED.png "Status Amber VMD LED")
 The Amber LED (status LED) is what VMD provides. It represents the LED coming from the slot on the backplane. The Green LED is the activity LED.
 
 The status LED on the VMD device has four states: OFF, FAULT, REBUILD, and IDENTIFY. These are communicated by blinking patterns specified in the IBPI standard (SFF-8489).
-![/doc/graph/VMD_LED_states.png](/doc/graph/VMD_LED_states.png "Status LED states")
+![/docs/graph/VMD_LED_states.png](/docs/graph/VMD_LED_states.png "Status LED states")
 
 #### Locate a Health Device
 Upon issuing a device identify command with a specified device ID, an admin now can quickly identify a device in question. The status LED on the VMD device would be set to an IDENTIFY state, represented by a quick, 4Hz blinking amber light. The device would quickly blink by default for 60 seconds and then return to the default OFF state. The LED event duration can be customized by setting the VMD_LED_PERIOD environment variable if a duration other than the default value is desired.
@@ -137,7 +137,7 @@ The device states that are returned from a device query by the admin are depende
   - UNPLUGGED: A device previously used by DAOS is unplugged.
   - NEW: A new device is available for use by DAOS.
 
-![/doc/graph/dmg_device_states.png](/doc/graph/dmg_device_states.png "Device States")
+![/docs/graph/dmg_device_states.png](/docs/graph/dmg_device_states.png "Device States")
 
  Useful admin command to query device states:
    - <a href="#31">dmg storage query list-devices</a> [used to query NVMe SSD device states]

--- a/src/client/api/README.md
+++ b/src/client/api/README.md
@@ -18,7 +18,7 @@ details about the functionality they support except for APIs to support
 non-blocking operations which is discussed here.
 
 The libdaos API is available under [/src/include/daos\_\*](/src/include/) and
-associated man pages under [/doc/man/man3/](/doc/man/man3/).
+associated man pages under [/docs/man/man3/](/docs/man/man3/).
 
 ## Event & Event Queue
 

--- a/src/client/java/README.md
+++ b/src/client/java/README.md
@@ -234,4 +234,4 @@ file, like capacity-scheduler.xml in yarn.
 ## Contacts
 For any questions, please post to our [user forum](https://daos.groups.io/g/daos). Bugs should be reported through our 
 [issue tracker](https://jira.hpdd.intel.com/projects/DAOS) with a test case to reproduce the issue (when applicable) and
- [debug logs](./doc/debugging.md).
+ [debug logs](./docs/debugging.md).

--- a/src/container/README.md
+++ b/src/container/README.md
@@ -7,7 +7,7 @@ A container represents an object address space inside a pool and is identified b
 
 The Container Service (`cont_svc`) stores the metadata for containers and provides an API to query and update the state as well as for managing the life-cycle of a container. Container metadata are organized as a hierarchy of key-value stores (KVS) that is replicated over a number of servers backed by Raft consensus protocol which uses strong leadership; client requests can only be serviced by the service leader while non-leader replicas merely respond with a hint pointing to the current leader for the client to retry. `cont_svc` derives from a generic replicated service module `rsvc` (see: <a href="/src/rsvc/README.md#architecture">Replicated Services: Architecture</a>) whose implementation facilitates the client search for the current leader.
 
-![Container Service Layout](/doc/graph/Fig_070.png "Container Service Layout")
+![Container Service Layout](/docs/graph/Fig_070.png "Container Service Layout")
 
 The top-level KVS `root` has two children:
 
@@ -16,7 +16,7 @@ The top-level KVS `root` has two children:
 
 The container properties KVS is used to store per-container metadata that consists of many mutable and immutable scalar valued properties as well as other KVSs as shown in the figure above.
 
-Users can create, delete and retrieve a list of persistent snapshots, which are essentially epochs that will not be aggregated away. A snapshot remains readable until it is explicitly destroyed. A container can also be rolled back to a particular snapshot. (see: <a href="/doc/overview/storage.md#daos-container">Storage Model: DAOS Container</a> and <a href="/doc/overview/transaction.md#container-snapshot">Transaction Model: Container Snapshot</a>).
+Users can create, delete and retrieve a list of persistent snapshots, which are essentially epochs that will not be aggregated away. A snapshot remains readable until it is explicitly destroyed. A container can also be rolled back to a particular snapshot. (see: <a href="/docs/overview/storage.md#daos-container">Storage Model: DAOS Container</a> and <a href="/docs/overview/transaction.md#container-snapshot">Transaction Model: Container Snapshot</a>).
 
 Users can also define custom attributes for containers which are essentially name-value pairs; with the name being a null-terminated string while the value is an arbitrary sequence of bytes. The Container Service allows clients to retrieve and update multiple attributes at a time as well as to list names of stored attributes.
 
@@ -58,7 +58,7 @@ A container is destroyed when the client sends a `CONT_DESTROY` request to the C
 
 #### Epoch Protocol
 
-The epoch protocol implements the epoch model described in the <a href="/doc/overview/transaction.md">Transaction Model</a>. The Container service manages the epochs of a container; it maintains the definitive epoch state as part of the container metadata, whereas the target services have little knowledge of the global epoch state. Epoch commit, discard, and aggregate procedures are therefore all driven by the container service.
+The epoch protocol implements the epoch model described in the <a href="/docs/overview/transaction.md">Transaction Model</a>. The Container service manages the epochs of a container; it maintains the definitive epoch state as part of the container metadata, whereas the target services have little knowledge of the global epoch state. Epoch commit, discard, and aggregate procedures are therefore all driven by the container service.
 
 On each target, the target service eagerly stores incoming write operations into the matching VOS container. If a container handle discards an epoch, VOS helps discard all write operations associated with that container handle. When a write operation succeeds, it is immediately visible to conflicting operations in equal or higher epochs. A conflicting write operation with the same epoch will be rejected by VOS unless it is associated with the same container handle and has the same content as the one that is already executed.
 

--- a/src/control/security/README.md
+++ b/src/control/security/README.md
@@ -54,7 +54,7 @@ handle additional properties and authentication methods.
 Certificates are used in several locations to provide authentication and
 validation of user identity in a DAOS system.
 For information on how to set up the certificates in a DAOS system, see the
-[Admin Guide](/doc/admin/deployment.md#certificate-configuration).
+[Admin Guide](/docs/admin/deployment.md#certificate-configuration).
 
 ### Certificate Generation
 

--- a/src/control/server/README.md
+++ b/src/control/server/README.md
@@ -160,7 +160,7 @@ is contained within `/src/control/server/ctl_storage*.go` files.
 Storage is required to be formatted before the DAOS data plane can be
 started.
 
-![Storage format diagram](/doc/graph/storage_format_detail.png)
+![Storage format diagram](/docs/graph/storage_format_detail.png)
 
 If storage has not been previously formatted, `daos_server` will halt on
 start-up waiting for storage format to be triggered by issuing the `dmg storage
@@ -198,7 +198,7 @@ server has been formatted.
 
 A view of DAOS' software component architecture:
 
-![Architecture diagram](/doc/graph/system_architecture.png)
+![Architecture diagram](/docs/graph/system_architecture.png)
 
 ## Running
 

--- a/src/object/README.md
+++ b/src/object/README.md
@@ -4,7 +4,7 @@ DAOS object stores user's data, it is identified by object ID which is unique
 within the DAOS container it belongs to. Objects can be distributed across any
 target of the pool for both performance and resilience.
 DAOS object in DAOS storage model is shown in the diagram -
-![/doc/graph/Fig_002.png](/doc/graph/Fig_002.png "object in storage model")
+![/docs/graph/Fig_002.png](/docs/graph/Fig_002.png "object in storage model")
 The object module implements the object I/O stack.
 
 ## KV store, dkey and akey
@@ -114,7 +114,7 @@ The checksum feature attempts to provide end-to-end data integrity. On an update
  the DAOS client calculates checksums for user data and sends with the RPC to
  the DAOS server. The DAOS server returns the checksum with the data on a fetch
  so the DAOS client can verify the integrity of the data. See [End-to-end Data
- Integrity Overiew](../../doc/overview/data_integrity.md) for more information.
+ Integrity Overiew](../../docs/overview/data_integrity.md) for more information.
 
 Checksums are configured at the container level and when a client opens a
  container, the checksum properties will be queried automatically, and, if

--- a/src/placement/JUMP_MAP.md
+++ b/src/placement/JUMP_MAP.md
@@ -53,7 +53,7 @@ This section details the state transitions that the jump map handles as part of 
 
 <a id="state_transitions"></a>
 **Pool component state transition diagram**
-![../../doc/graph/pool_component_state_transition_diagram.png](../../doc/graph/pool_component_state_transition_diagram.png "Pool component state transition diagram")
+![../../docs/graph/pool_component_state_transition_diagram.png](../../docs/graph/pool_component_state_transition_diagram.png "Pool component state transition diagram")
 
 ### Drain
 

--- a/src/placement/README.md
+++ b/src/placement/README.md
@@ -12,7 +12,7 @@ A placement map is essentially an abstracted and permuted pool map; it does not 
 
 **Pool-map and placement maps**
 
-![../../doc/graph/Fig_043.png](../../doc/graph/Fig_043.png "Pool-map and placement maps")
+![../../docs/graph/Fig_043.png](../../docs/graph/Fig_043.png "Pool-map and placement maps")
 
 A placement map does not maintain a copy of status or any characteristics of the corresponding pool map components, but only references pool map components. Each time DAOS computes an object distribution based on a placement map, it also needs to check the corresponding component status and attributes from the pool map. This adds an extra step for indirect memory access, but can significantly reduce cache pollution and memory consumption when there are many placement maps but only one pool map in a DAOS pool.
 

--- a/src/placement/RING_MAP.md
+++ b/src/placement/RING_MAP.md
@@ -15,7 +15,7 @@ This is a concept developed in collaboration with Argonne National Laboratory, s
 <a id="f10.3"></a>
 **Ring Placement Map**
 
-![../../doc/graph/Fig_044.png](../../doc/graph/Fig_044.png "Ring Placement Map")
+![../../docs/graph/Fig_044.png](../../docs/graph/Fig_044.png "Ring Placement Map")
 
 <a id="10.2.3.1"></a>
 ## Fault Tolerance
@@ -34,7 +34,7 @@ To avoid this imbalance, widely distributed striped objects may be placed with "
  <a id="f10.4"></a>
 **Rebuild targets and failure sequence**
 
-![../../doc/graph/Fig_045.png](../../doc/graph/Fig_045.png "Ring Placement Map")
+![../../docs/graph/Fig_045.png](../../docs/graph/Fig_045.png "Ring Placement Map")
 
 Note that after all spare targets in a gap have become rebuild targets, further failures can still be handled by selecting rebuild targets immediately prior to the first member of RDGs affected by failure, albeit at the expense of load balance. This also means that multiple shards of a same object can possibly be stored on the same target. To distinguish these collocated shards from a same object, DSR can construct DSM object ID by appending object shard index to DSR object ID.
 
@@ -57,7 +57,7 @@ When there is no failure, the ring placement map can evenly distribute objects t
 <a id="f10.5"></a>
 **Object distribution on rebuild targets**
 
-![../../doc/graph/Fig_046.png](../../doc/graph/Fig_046.png "Object distribution on rebuild targets")
+![../../docs/graph/Fig_046.png](../../docs/graph/Fig_046.png "Object distribution on rebuild targets")
 
 In the <a href="#f10.5">figure</a> above, if all objects are 3-way replicated, and the layout of each of them is the targets connected by arcs in the same color. When target-4 fails, as each object will choose the prior target as spare target:
 
@@ -84,7 +84,7 @@ As shown in the <a href="#f10.6">figure</a> below, objects placed on the ring sh
 <a id="f10.6"></a>
 **Doubling domains for a ring placement map**
 
-![../../doc/graph/Fig_047.png](../../doc/graph/Fig_047.png "Doubling domains for a ring placement map")
+![../../docs/graph/Fig_047.png](../../docs/graph/Fig_047.png "Doubling domains for a ring placement map")
 
 The shards of objects created before the new domains are added, are no longer contiguous on the ring after doubling to avoid having to move all shards except the first one. This may be achieved by keeping the hash stride between object shards constant. However, this necessitates storing the initial hash stride with the object metadata as described in the next section. Note that the distribution of an object will become increasingly sparse on the placement ring with each extending operation.
 
@@ -98,7 +98,7 @@ To avoid this situation, DAOS doubles the consistent hashing key range. For exam
 <a id="f10.7"></a>
 **Doubling targets within domains**
 
-![../../doc/graph/Fig_048.png](../../doc/graph/Fig_048.png "Doubling targets within domains")
+![../../docs/graph/Fig_048.png](../../docs/graph/Fig_048.png "Doubling targets within domains")
 
 <a id="10.2.4"></a>
 # Multi-Ring Placement Map
@@ -117,7 +117,7 @@ In the example in the <a href="#f10.8">figure</a> below, there are six domains a
 
 <a id="f10.8"></a>
 **Multi-ring placement map**
-![../../doc/graph/Fig_049.png](../../doc/graph/Fig_049.png "Multi-ring placement map")
+![../../docs/graph/Fig_049.png](../../docs/graph/Fig_049.png "Multi-ring placement map")
 
 
 Given a large enough number of rings, each of them is created by a pseudo-random algorithm that selects M domains from the total of N domains, and selects T targets from each domain.

--- a/src/pool/README.md
+++ b/src/pool/README.md
@@ -1,6 +1,6 @@
 # DAOS Pool
 
-A pool is a set of targets spread across different storage nodes over which data and metadata are distributed to achieve horizontal scalability, and replicated or erasure-coded to ensure durability and availability (see: <a href="/doc/overview/storage.md#daos-pool">Storage Model: DAOS Pool</a>).
+A pool is a set of targets spread across different storage nodes over which data and metadata are distributed to achieve horizontal scalability, and replicated or erasure-coded to ensure durability and availability (see: <a href="/docs/overview/storage.md#daos-pool">Storage Model: DAOS Pool</a>).
 
 <a id="9.1"></a>
 
@@ -12,7 +12,7 @@ The Pool Service (`pool_svc`) stores the metadata for pools, and provides an API
 
 #### Metadata Layout
 
-![Pool Service Layout](/doc/graph/Fig_072.png "Pool Service Layout")
+![Pool Service Layout](/docs/graph/Fig_072.png "Pool Service Layout")
 
 The top-level KVS stores the pool map, security attributes such as the UID, GID and mode, information related to space management and self-healing (see: <a href="/src/rebuild/README.md">Rebuild</a>) as well as a second-level KVS containing user-defined attributes (see: <a href="/src/container/README.md#metadata-layout">Container Service: Metadata Layout</a>). In addition, it also stores information on pool connections, represented by a pool handle and identified by a client-generated handle UUID. The terms "pool connection" and "pool handle" may be used interchangeably.
 
@@ -39,6 +39,6 @@ At this point, the Pool Service checks for existing pool handles:
 
 If everything goes well, the pool service sends a collective `POOL_TGT_CONNECT` request to all targets in the pool with the pool handle UUID. The Target Service creates and caches the local pool objects and opens the local VOS pool for access.
 
-A group of peer application processes may share a single pool connection handle (see: <a href="/doc/overview/storage.md#daos-pool">Storage Model: DAOS Pool</a> and <a href="/doc/overview/use_cases.md#storage-management--workflow-integration">Use Cases: Storage Management and Workflow Integration</a>).
+A group of peer application processes may share a single pool connection handle (see: <a href="/docs/overview/storage.md#daos-pool">Storage Model: DAOS Pool</a> and <a href="/docs/overview/use_cases.md#storage-management--workflow-integration">Use Cases: Storage Management and Workflow Integration</a>).
 
 To close a pool connection, a client process calls the `daos_pool_disconnect` method in the client library with the pool handle, triggering a `POOL_DISCONNECT` request to the Pool Service, which sends a collective `POOL_TGT_DISCONNECT` request to all targets in the pool. These steps destroy all state associated with the connection, including all container handles. Other client processes sharing this connection should destroy their copies of the pool handle locally, preferably before the disconnect method is called on behalf of everyone. If a group of client processes terminate prematurely, before having a chance to call the pool disconnect method, their pool connection will eventually be evicted once the pool service learns about the event from the run-time environment.

--- a/src/proto/README.md
+++ b/src/proto/README.md
@@ -4,7 +4,7 @@ The proto directory contains
 [protocol buffer](https://developers.google.com/protocol-buffers) definitions
 for the messaging format used in communication over the gRPC and dRPC channels.
 For information on using protobuf tools for development see
-[here](../../doc/dev/development.md#protobuf-compiler).
+[here](../../docs/dev/development.md#protobuf-compiler).
 
 ## Directory structure
 

--- a/src/rdb/README.md
+++ b/src/rdb/README.md
@@ -14,7 +14,7 @@ The <a href="#f8.1">figure</a> below shows the modules constituting a service re
 <a id="f8.1"></a>
 **Service replication modules**
 
-![../../doc/graph/Fig_041.png](../../doc/graph/Fig_041.png "Service replication modules")
+![../../docs/graph/Fig_041.png](../../docs/graph/Fig_041.png "Service replication modules")
 
 <a id="8.3.2"></a>
 ## RPC Handling

--- a/src/rebuild/README.md
+++ b/src/rebuild/README.md
@@ -52,7 +52,7 @@ held during the rebuild process.
 
 <a id="f10.18"></a>
 **Rebuild Protocol**
-![../../doc/graph/Fig_059.png](../../doc/graph/Fig_059.png "Rebuild Protocol")
+![../../docs/graph/Fig_059.png](../../docs/graph/Fig_059.png "Rebuild Protocol")
 
 The <a href="#f10.18">figure</a> above is an example of this process:
 There are five objects in the cluster: object A is 3-way replicated,
@@ -101,7 +101,7 @@ The following <a href="#f10.20">figure</a> is an example of this protocol.
 
 <a id="f10.20"></a>
 **Multi-failure protocol**
-![../../doc/graph/Fig_061.png](../../doc/graph/Fig_061.png "Multi-failure protocol")
+![../../docs/graph/Fig_061.png](../../docs/graph/Fig_061.png "Multi-failure protocol")
 
 - In this example, object A is 2-way replicated, object B, C and D are 3-way
 replicated.

--- a/src/security/README.md
+++ b/src/security/README.md
@@ -23,13 +23,13 @@ are outlined
 This section covers the implementation details of pool and container access
 control.
 
-See the [security overview](/doc/overview/security.md#access-control-lists) for
+See the [security overview](/docs/overview/security.md#access-control-lists) for
 background on DAOS Access Control Lists.
 
-See the [Admin Guide](/doc/admin/pool_operations.md#access-control-lists)
+See the [Admin Guide](/docs/admin/pool_operations.md#access-control-lists)
 for a higher-level view of pool access control.
 
-See the [User Guide](/doc/user/container.md#access-control-lists)
+See the [User Guide](/docs/user/container.md#access-control-lists)
 for a higher-level view of container access control.
 
 ### Pool Access

--- a/src/vos/README.md
+++ b/src/vos/README.md
@@ -1,7 +1,7 @@
 
 # Versioning Object Store
 
-The Versioning Object Store (VOS) is responsible for providing and maintaining a persistent object store that supports byte-granular access and versioning for a single shard in a <a href="/doc/storage_model.md#DAOS_Pool">DAOS pool</a>.
+The Versioning Object Store (VOS) is responsible for providing and maintaining a persistent object store that supports byte-granular access and versioning for a single shard in a <a href="/docs/storage_model.md#DAOS_Pool">DAOS pool</a>.
 It maintains its metadata in persistent memory and may store data either in persistent memory or on block storage, depending on available storage and performance requirements.
 It must provide this functionality with minimum overhead so that performance can approach the theoretical performance of the underlying hardware as closely as possible, both with respect to latency and bandwidth.
 Its internal data structures, in both persistent and non-persistent memory, must also support the highest levels of concurrency so that throughput scales over the cores of modern processor architectures.
@@ -123,7 +123,7 @@ Note that "punch" of an extent of an array object is logged as zeroed extents, r
 This ensures that the full version history of objects remain accessible.   The DAOS api, however, only allows accessing data at snapshots so VOS aggregation can aggressively remove objects, keys, and values that are no longer accessible at a known snapshot.
 
 <a id="7a"></a>
-![../../doc/graph/Fig_067.png](../../doc/graph/Fig_067.png "VOS Pool storage layout")
+![../../docs/graph/Fig_067.png](../../docs/graph/Fig_067.png "VOS Pool storage layout")
 
 When performing lookup on a single value in an object, the object index is traversed to find the index node with the highest epoch number less than or equal to the requested epoch (near-epoch) that matches the key.
 If a value or negative entry is found, it is returned.
@@ -307,7 +307,7 @@ For explanation purposes, representative keys and values are used in the example
 
 <a id="7d"></a>
 
-![../../doc/graph/Fig_011.png](../../doc/graph/Fig_011.png "Red Black Tree based KV Store with Multi-Key")
+![../../docs/graph/Fig_011.png](../../docs/graph/Fig_011.png "Red Black Tree based KV Store with Multi-Key")
 
 The red-black tree, like any traditional binary tree, organizes the keys lesser than the root to the left subtree and keys greater than the root to the right subtree.
 Value pointers are stored along with the keys in each node.
@@ -368,7 +368,7 @@ In this example, the different lines represent the actual data stored in the res
 
 <b>Example of extents and epochs in a Key Array object</b>
 
-![../../doc/graph/Fig_012.png](../../doc/graph/Fig_012.png "Example of extents and epochs in a byte array object")
+![../../docs/graph/Fig_012.png](../../docs/graph/Fig_012.png "Example of extents and epochs in a byte array object")
 
 In the <a href="7f">above</a> example, there is significant overlap between different extent ranges.
 VOS supports nearest-epoch access, which necessitates reading the latest value for any given extent range.
@@ -405,7 +405,7 @@ TODO: Create a new figure
 <a id="7k"></a>
 <b>Rectangles representing extent_range.epoch_validity arranged in 2-D space for an order-4 EV-Tree using input in the table <a href="#7g">above</a></b>
 
-![../../doc/graph/Fig_016.png](../../doc/graph/Fig_016.png "Rectangles representing extent_range.epoch_validity arranged in 2-D space for an order-4 EV-Tree using input in the table")
+![../../docs/graph/Fig_016.png](../../docs/graph/Fig_016.png "Rectangles representing extent_range.epoch_validity arranged in 2-D space for an order-4 EV-Tree using input in the table")
 
 The figure <a href="7l">below</a> shows the rectangles constructed with splitting and trimming operations of EV-Tree for the example in the previous <a href="#7g">table</a> with an additional write at offset {0 - 100} introduced to consider the case for extensive splitting.
 The figure <a href="#7k">above</a> shows the EV-Tree construction for the same example.
@@ -414,7 +414,7 @@ The figure <a href="#7k">above</a> shows the EV-Tree construction for the same e
 
 <b>Tree (order - 4) for the example in Table 6 3 (pictorial representation shown in the figure <a href="#7g">above</a></b>
 
-![../../doc/graph/Fig_017.png](../../doc/graph/Fig_017.png "Rectangles representing extent_range.epoch_validity arranged in 2-D space for an order-4 EV-Tree using input in the table")
+![../../docs/graph/Fig_017.png](../../docs/graph/Fig_017.png "Rectangles representing extent_range.epoch_validity arranged in 2-D space for an order-4 EV-Tree using input in the table")
 
 Inserts in an EV-Tree locate the appropriate leaf-node to insert, by checking for overlap.
 If multiple bounding boxes overlap, the bounding box with the least enlargement is chosen.
@@ -516,7 +516,7 @@ the corresponding key or object.
 <a id="8a"></a>
 <b>Scenarios illustrating utility of write timestamp cache</b>
 
-![../../doc/graph/uncertainty.png](../../doc/graph/uncertainty.png "Scenarios illustrating utility of write timestamp cache")
+![../../docs/graph/uncertainty.png](../../docs/graph/uncertainty.png "Scenarios illustrating utility of write timestamp cache")
 
 <a id="824"></a>
 ### MVCC Rules
@@ -719,7 +719,7 @@ The size needed for checksums is included while allocating memory for the persis
 
 The following diagram illustrates the overall VOS layout and where checksums will be stored. Note that the checksum type isn't actually stored in vos_cont_df yet.
 
-![../../doc/graph/Fig_021.png](../../doc/graph/Fig_021.png "How checksum fits into the VOS Layout")
+![../../docs/graph/Fig_021.png](../../docs/graph/Fig_021.png "How checksum fits into the VOS Layout")
 
 
 ### Checksum VOS Flow (vos_obj_update/vos_obj_fetch)
@@ -823,7 +823,7 @@ the DTX model.
 
 <b>Modify multiple replicated object under DTX model</b>
 
-![../../doc/graph/Fig_066.png](../../doc/graph/Fig_066.png ">Modify multiple replicated object under DTX model")
+![../../docs/graph/Fig_066.png](../../docs/graph/Fig_066.png ">Modify multiple replicated object under DTX model")
 
 <a id="812"></a>
 


### PR DESCRIPTION
With PR 6565 the doc folder was renamed to docs. Many image sources
and links need to be updated to point to 'docs' instead of 'doc'.

Signed-off-by: Ryon Jensen <ryon.jensen@intel.com>

Doc-only: true

Note : DAOS-7174 doesn't appear to be the correct ticket number for the doc changes, however it is what was used for PR 6565 so using it for now. Can update when correct ticket number is identified.