### PR TITLE
DAOS-7479 container: open, query return most recent snapshot

### DIFF
--- a/src/container/cli.c
+++ b/src/container/cli.c
@@ -771,8 +771,7 @@ cont_open_complete(tse_task_t *task, void *data)
 	arg->coa_info->ci_redun_fac = cont->dc_props.dcp_redun_fac;
 
 	arg->coa_info->ci_nsnapshots = out->coo_snap_count;
-	/* TODO */
-	arg->coa_info->ci_lsnapshot = 0;
+	arg->coa_info->ci_lsnapshot = out->coo_lsnapshot;
 
 out:
 	crt_req_decref(arg->rpc);
@@ -1159,8 +1158,7 @@ cont_query_complete(tse_task_t *task, void *data)
 	arg->cqa_info->ci_redun_fac = cont->dc_props.dcp_redun_fac;
 
 	arg->cqa_info->ci_nsnapshots = out->cqo_snap_count;
-	/* TODO */
-	arg->cqa_info->ci_lsnapshot = 0;
+	arg->cqa_info->ci_lsnapshot = out->cqo_lsnapshot;
 
 out:
 	crt_req_decref(arg->rpc);

--- a/src/container/rpc.h
+++ b/src/container/rpc.h
@@ -24,7 +24,7 @@
  * These are for daos_rpc::dr_opc and DAOS_RPC_OPCODE(opc, ...) rather than
  * crt_req_create(..., opc, ...). See src/include/daos/rpc.h.
  */
-#define DAOS_CONT_VERSION 5
+#define DAOS_CONT_VERSION 6
 /* LIST of internal RPCS in form of:
  * OPCODE, flags, FMT, handler, corpc_hdlr,
  */
@@ -180,6 +180,7 @@ CRT_RPC_DECLARE(cont_destroy_bylabel, DAOS_ISEQ_CONT_DESTROY_BYLABEL,
 #define DAOS_OSEQ_CONT_OPEN	/* output fields */		 \
 	((struct cont_op_out)	(coo_op)		CRT_VAR) \
 	((daos_prop_t)		(coo_prop)		CRT_PTR) \
+	((daos_epoch_t)		(coo_lsnapshot)		CRT_VAR) \
 	((uint32_t)		(coo_snap_count)	CRT_VAR) \
 	((uint32_t)		(coo_pad)		CRT_VAR)
 
@@ -249,6 +250,7 @@ CRT_RPC_DECLARE(cont_close, DAOS_ISEQ_CONT_CLOSE, DAOS_OSEQ_CONT_CLOSE)
 #define DAOS_OSEQ_CONT_QUERY	/* output fields */		 \
 	((struct cont_op_out)	(cqo_op)		CRT_VAR) \
 	((daos_prop_t)		(cqo_prop)		CRT_PTR) \
+	((daos_epoch_t)		(cqo_lsnapshot)		CRT_VAR) \
 	((uint32_t)		(cqo_snap_count)	CRT_VAR) \
 	((uint32_t)		(cqo_pad)		CRT_VAR)
 

--- a/src/container/srv_container.c
+++ b/src/container/srv_container.c
@@ -1792,8 +1792,23 @@ cont_open(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl, struct cont *cont,
 		goto out;
 	}
 	out->coo_snap_count = snap_count;
-	D_DEBUG(DF_DSMS, DF_CONT": got nsnapshots=%u on open\n",
+	D_DEBUG(DF_DSMS, DF_CONT": got nsnapshots=%u\n",
 		DP_CONT(cont->c_svc->cs_pool_uuid, cont->c_uuid), snap_count);
+
+	/* Get latest snapshot */
+	if (snap_count > 0) {
+		d_iov_t		key_out;
+
+		rc = rdb_tx_query_key_max(tx, &cont->c_snaps, &key_out);
+		if (rc != 0) {
+			D_ERROR(DF_CONT": failed to query lsnapshot, "DF_RC"\n",
+				DP_CONT(cont->c_svc->cs_pool_uuid, cont->c_uuid), DP_RC(rc));
+			goto out;
+		}
+		out->coo_lsnapshot = *(uint64_t *)key_out.iov_buf;
+		D_DEBUG(DF_DSMS, DF_CONT": got lsnapshot="DF_X64"\n",
+			DP_CONT(cont->c_svc->cs_pool_uuid, cont->c_uuid), out->coo_lsnapshot);
+	}
 
 out:
 	if (rc == 0) {
@@ -2426,6 +2441,21 @@ cont_query(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl, struct cont *cont,
 		return rc;
 	}
 	out->cqo_snap_count = snap_count;
+
+	/* Get latest snapshot */
+	if (snap_count > 0) {
+		d_iov_t		key_out;
+
+		rc = rdb_tx_query_key_max(tx, &cont->c_snaps, &key_out);
+		if (rc != 0) {
+			D_ERROR(DF_CONT": failed to query lsnapshot, "DF_RC"\n",
+				DP_CONT(cont->c_svc->cs_pool_uuid, cont->c_uuid), DP_RC(rc));
+			goto out;
+		}
+		out->cqo_lsnapshot = *(uint64_t *)key_out.iov_buf;
+		D_DEBUG(DF_DSMS, DF_CONT": got lsnapshot="DF_X64"\n",
+			DP_CONT(cont->c_svc->cs_pool_uuid, cont->c_uuid), out->cqo_lsnapshot);
+	}
 
 	/* need RF to process co_status */
 	if (in->cqi_bits & DAOS_CO_QUERY_PROP_CO_STATUS)

--- a/src/control/cmd/daos/container.go
+++ b/src/control/cmd/daos/container.go
@@ -653,7 +653,7 @@ func printContainerInfo(out io.Writer, ci *containerInfo, verbose bool) error {
 		rows = append(rows, []txtfmt.TableRow{
 			{"Pool UUID": ci.PoolUUID.String()},
 			{"Number of snapshots": fmt.Sprintf("%d", *ci.NumSnapshots)},
-			{"Latest Persistent Snapshot": fmt.Sprintf("%d", *ci.LatestSnapshot)},
+			{"Latest Persistent Snapshot": fmt.Sprintf("%x", *ci.LatestSnapshot)},
 			{"Container redundancy factor": fmt.Sprintf("%d", *ci.RedundancyFactor)},
 		}...)
 

--- a/src/include/daos_srv/rdb.h
+++ b/src/include/daos_srv/rdb.h
@@ -263,6 +263,7 @@ int rdb_tx_lookup(struct rdb_tx *tx, const rdb_path_t *kvs,
 int rdb_tx_fetch(struct rdb_tx *tx, const rdb_path_t *kvs,
 		 enum rdb_probe_opc opc, const d_iov_t *key_in,
 		 d_iov_t *key_out, d_iov_t *value);
+int rdb_tx_query_key_max(struct rdb_tx *tx, const rdb_path_t *kvs, d_iov_t *key);
 int rdb_tx_iterate(struct rdb_tx *tx, const rdb_path_t *kvs, bool backward,
 		   rdb_iterate_cb_t cb, void *arg);
 int rdb_tx_revalidate(struct rdb_tx *tx);

--- a/src/include/daos_srv/vos.h
+++ b/src/include/daos_srv/vos.h
@@ -993,7 +993,7 @@ vos_iterate(vos_iter_param_t *param, vos_iter_type_t type, bool recursive,
  * object. If object does not have an array value, 0 is returned in extent. User
  * has to specify what is being queried (dkey, akey, and/or recx) along with the
  * query type (max or min) in flags. If one of those is not provided the
- * function will fail. If the dkey or akey are not being queried, there value
+ * function will fail. If the dkey or akey are not being queried, their values
  * must be provided by the user.
  *
  * If searching in a particular dkey for the max akey and max offset in that

--- a/src/rdb/rdb_internal.h
+++ b/src/rdb/rdb_internal.h
@@ -316,6 +316,7 @@ int rdb_vos_fetch(daos_handle_t cont, daos_epoch_t epoch, rdb_oid_t oid,
 		  daos_key_t *akey, d_iov_t *value);
 int rdb_vos_fetch_addr(daos_handle_t cont, daos_epoch_t epoch, rdb_oid_t oid,
 		       daos_key_t *akey, d_iov_t *value);
+int rdb_vos_query_key_max(daos_handle_t cont, daos_epoch_t epoch, rdb_oid_t oid, daos_key_t *akey);
 int rdb_vos_iter_fetch(daos_handle_t cont, daos_epoch_t epoch, rdb_oid_t oid,
 		       enum rdb_probe_opc opc, daos_key_t *akey_in,
 		       daos_key_t *akey_out, d_iov_t *value);
@@ -431,6 +432,12 @@ rdb_lc_iter_fetch(daos_handle_t lc, uint64_t index, rdb_oid_t oid,
 		value == NULL ? 0 : value->iov_len);
 	return rdb_vos_iter_fetch(lc, index, oid, opc, akey_in, akey_out,
 				  value);
+}
+
+static inline int
+rdb_lc_query_key_max(daos_handle_t lc, uint64_t index, rdb_oid_t oid, d_iov_t *akey)
+{
+	return rdb_vos_query_key_max(lc, index, oid, akey);
 }
 
 static inline int

--- a/src/rdb/rdb_tx.c
+++ b/src/rdb/rdb_tx.c
@@ -1032,7 +1032,7 @@ rdb_tx_fetch(struct rdb_tx *tx, const rdb_path_t *kvs, enum rdb_probe_opc opc,
  * \retval -DER_NONEXIST	no keys (KVS is empty)
  */
 int
-rdb_tx_query_key_max(struct rdb_tx *tx, const rdb_path_t *kvs, d_iov_t *key)
+rdb_tx_query_key_max(struct rdb_tx *tx, const rdb_path_t *kvs, d_iov_t *key_out)
 {
 	struct rdb     *db = tx->dt_db;
 	struct rdb_kvs *s;
@@ -1041,7 +1041,7 @@ rdb_tx_query_key_max(struct rdb_tx *tx, const rdb_path_t *kvs, d_iov_t *key)
 	rc = rdb_tx_query_pre(tx, kvs, &s);
 	if (rc != 0)
 		return rc;
-	rc = rdb_lc_query_key_max(db->d_lc, db->d_applied, s->de_object, key);
+	rc = rdb_lc_query_key_max(db->d_lc, db->d_applied, s->de_object, key_out);
 	if (rc != 0) {
 		D_ERROR(DF_DB": rdb_lc_query_key_max d_applied="DF_U64", rdb_oid="DF_U64"\n",
 			DP_DB(db), db->d_applied, s->de_object);

--- a/src/rdb/rdb_tx.c
+++ b/src/rdb/rdb_tx.c
@@ -987,9 +987,6 @@ rdb_tx_lookup(struct rdb_tx *tx, const rdb_path_t *kvs, const d_iov_t *key,
 	rc = rdb_lc_lookup(db->d_lc, db->d_applied, s->de_object,
 			   (d_iov_t *)key, value);
 	rdb_tx_query_post(tx, s);
-	if (rc != 0) {
-
-	}
 	return rc;
 }
 
@@ -1027,7 +1024,12 @@ rdb_tx_fetch(struct rdb_tx *tx, const rdb_path_t *kvs, enum rdb_probe_opc opc,
 }
 
 /* Find the largest integer key in \a kvs
+ * \param[in]		tx	transaction
+ * \param[in]		kvs	path to a KVS with an integer key
+ * \param[out]		key_out	output maximum key
  *
+ * \retval -DER_NOTLEADER	not current leader
+ * \retval -DER_NONEXIST	no keys (KVS is empty)
  */
 int
 rdb_tx_query_key_max(struct rdb_tx *tx, const rdb_path_t *kvs, d_iov_t *key)

--- a/src/rdb/rdb_tx.c
+++ b/src/rdb/rdb_tx.c
@@ -987,6 +987,9 @@ rdb_tx_lookup(struct rdb_tx *tx, const rdb_path_t *kvs, const d_iov_t *key,
 	rc = rdb_lc_lookup(db->d_lc, db->d_applied, s->de_object,
 			   (d_iov_t *)key, value);
 	rdb_tx_query_post(tx, s);
+	if (rc != 0) {
+
+	}
 	return rc;
 }
 
@@ -1019,6 +1022,28 @@ rdb_tx_fetch(struct rdb_tx *tx, const rdb_path_t *kvs, enum rdb_probe_opc opc,
 		return rc;
 	rc = rdb_lc_iter_fetch(db->d_lc, db->d_applied, s->de_object, opc,
 			       (d_iov_t *)key_in, key_out, value);
+	rdb_tx_query_post(tx, s);
+	return rc;
+}
+
+/* Find the largest integer key in \a kvs
+ *
+ */
+int
+rdb_tx_query_key_max(struct rdb_tx *tx, const rdb_path_t *kvs, d_iov_t *key)
+{
+	struct rdb     *db = tx->dt_db;
+	struct rdb_kvs *s;
+	int		rc;
+
+	rc = rdb_tx_query_pre(tx, kvs, &s);
+	if (rc != 0)
+		return rc;
+	rc = rdb_lc_query_key_max(db->d_lc, db->d_applied, s->de_object, key);
+	if (rc != 0) {
+		D_ERROR(DF_DB": rdb_lc_query_key_max d_applied="DF_U64", rdb_oid="DF_U64"\n",
+			DP_DB(db), db->d_applied, s->de_object);
+	}
 	rdb_tx_query_post(tx, s);
 	return rc;
 }

--- a/src/rdb/rdb_util.c
+++ b/src/rdb/rdb_util.c
@@ -364,6 +364,24 @@ out:
 }
 
 int
+rdb_vos_query_key_max(daos_handle_t cont, daos_epoch_t epoch, rdb_oid_t oid, daos_key_t *akey)
+{
+	daos_unit_oid_t	uoid;
+	int		rc;
+
+	rdb_oid_to_uoid(oid, &uoid);
+	rc = vos_obj_query_key(cont, uoid, DAOS_GET_AKEY|DAOS_GET_MAX, epoch, &rdb_dkey, akey,
+			       NULL /* recx */, 0 /* cell sz */, 0 /* stripe sz */, NULL /* dth */);
+	if (rc != 0) {
+		D_ERROR("vos_obj_query_key((rdb,vos) oids=("DF_U64",lo="DF_U64", hi="DF_U64"), "
+			"epoch="DF_U64" ...) failed, "DF_RC"\n", oid, uoid.id_pub.lo,
+			uoid.id_pub.hi, epoch, DP_RC(rc));
+	}
+
+	return rc;
+}
+
+int
 rdb_vos_iter_fetch(daos_handle_t cont, daos_epoch_t epoch, rdb_oid_t oid,
 		   enum rdb_probe_opc opc, daos_key_t *akey_in,
 		   daos_key_t *akey_out, d_iov_t *value)

--- a/src/utils/daos_hdlr.c
+++ b/src/utils/daos_hdlr.c
@@ -846,7 +846,7 @@ cont_list_snaps_hdlr(struct cmd_args_s *ap)
 
 	if (ap->snapname_str == NULL && ap->epc == 0) {
 		for (i = 0; i < min(expected_count, snaps_count); i++)
-			D_PRINT(DF_U64" %s\n", epochs[i], names[i]);
+			D_PRINT(DF_X64" %s\n", epochs[i], names[i]);
 	} else {
 		for (i = 0; i < min(expected_count, snaps_count); i++)
 			if (ap->snapname_str != NULL &&
@@ -1754,8 +1754,7 @@ cont_query_hdlr(struct cmd_args_s *ap)
 	printf("Pool UUID:\t%s\n", ap->pool_str);
 	printf("Container UUID:\t"DF_UUIDF"\n", DP_UUID(cont_info.ci_uuid));
 	printf("Number of snapshots: %i\n", (int)cont_info.ci_nsnapshots);
-	printf("Latest Persistent Snapshot: %i\n",
-		(int)cont_info.ci_lsnapshot);
+	printf("Latest Persistent Snapshot: "DF_X64"\n", cont_info.ci_lsnapshot);
 	printf("Container redundancy factor: %d\n", cont_info.ci_redun_fac);
 	daos_unparse_ctype(cont_type, type);
 	printf("Container Type:\t%s\n", type);

--- a/src/vos/vos_query.c
+++ b/src/vos/vos_query.c
@@ -429,12 +429,14 @@ open_and_query_key(struct open_query *query, daos_key_t *key,
 			return rc;
 	}
 
-	if (tree_type == VOS_GET_DKEY)
+	if (tree_type == VOS_GET_DKEY) {
 		query->qt_akey_root = &rbund.rb_krec->kr_btr;
-	else if ((rbund.rb_krec->kr_bmap & KREC_BF_EVT) == 0)
-		return -DER_NONEXIST;
-	else
+	} else if ((rbund.rb_krec->kr_bmap & KREC_BF_EVT) == 0) {
+		if (query->qt_flags & VOS_GET_RECX)
+			return -DER_NONEXIST;
+	} else {
 		query->qt_recx_root = &rbund.rb_krec->kr_evt;
+	}
 
 	return 0;
 }


### PR DESCRIPTION
Get a container's most recent snapshot in daos container open/query.
In the pool/container service, the vos_obj_query_key() function is
invoked through a new function rdb_tx_query_key_max() to get the
largest epoch/snapshot key in the container snapshot rdb KVS.

The vos_obj_query_key() behavior is also updated to allow a single
value akey when the user does not specify VOS_GET_RECX in flags.

Engine logging code prints out the epoch/snapshot values in hexadecimal
format, since the values are HLC with components that are more easily
read this way. Also, the daos utility output for the container query
(ci_lsnapshot) and list-snap commands are updated to print the values
in hex. Finally, the daos_test epoch tests are updated to assert a
correct value in daos_cont_info_t.ci_lsnapshot, returned by the
daos_cont_open() and daos_cont_query() functions.

Co-authored-by: Jeff Olivier <jeffrey.v.olivier@intel.com>
Signed-off-by: Kenneth Cain <kenneth.c.cain@intel.com>