### PR TITLE
DAOS-8167 object: forget set iod_nr to 1 during parity update

### DIFF
--- a/src/object/srv_obj_migrate.c
+++ b/src/object/srv_obj_migrate.c
@@ -858,7 +858,7 @@ migrate_update_parity(struct migrate_one *mrone, daos_epoch_t parity_eph,
 
 		tmp_sgl.sg_iovs = &tmp_iov;
 		iod->iod_recxs = &tmp_recx;
-
+		iod->iod_nr = 1;
 		rc = daos_csummer_csum_init_with_packed(&csummer, csum_iov);
 		if (rc != 0) {
 			D_ERROR("Error initializing csummer");
@@ -959,7 +959,6 @@ migrate_fetch_update_parity(struct migrate_one *mrone, daos_handle_t oh,
 				continue;
 			}
 
-			tmp_iod.iod_nr = 1;
 			rc = migrate_update_parity(mrone, parity_eph, ds_cont, ptr, offset,
 						   size, &tmp_iod, p_bufs, &tmp_csum_iov_fetch);
 			if (rc)


### PR DESCRIPTION
Missing setting up iod_nr as 1 during parity rebuild in some
cases.

Signed-off-by: Di Wang <di.wang@intel.com>