### PR TITLE
DAOS-8491 vos: Fix non-EC SINGLE gsizes

### DIFF
--- a/src/include/daos_srv/vos.h
+++ b/src/include/daos_srv/vos.h
@@ -520,7 +520,10 @@ vos_obj_fetch_ex(daos_handle_t coh, daos_unit_oid_t oid, daos_epoch_t epoch,
  * \param flags	[IN]	Update flags
  * \param dkey	[IN]	Distribution key.
  * \param iod_nr [IN]	Number of I/O descriptors in \a iods.
- * \param iods [IN]	Array of I/O descriptors.
+ * \param iods	[IN]	Array of I/O descriptors. If \a flags includes
+ *			VOS_OF_EC, then the iod_recxs field of every single
+ *			value iod in \a iods must contain the "gsize" instead
+ *			of a memory address.
  * \param iods_csums [IN]
  *			Array of iod_csums (1 for each iod). Will be NULL
  *			if csums are disabled.
@@ -555,7 +558,10 @@ vos_obj_update(daos_handle_t coh, daos_unit_oid_t oid, daos_epoch_t epoch,
  * \param flags	[IN]	Update flags
  * \param dkey	[IN]	Distribution key.
  * \param iod_nr [IN]	Number of I/O descriptors in \a iods.
- * \param iods [IN]	Array of I/O descriptors.
+ * \param iods	[IN]	Array of I/O descriptors. If \a flags includes
+ *			VOS_OF_EC, then the iod_recxs field of every single
+ *			value iod in \a iods must contain the "gsize" instead
+ *			of a memory address.
  * \param iods_csums [IN]
  *			Array of iod_csums (1 for each iod). Will be NULL
  *			if csums are disabled.
@@ -716,6 +722,10 @@ vos_fetch_end(daos_handle_t ioh, daos_size_t *size, int err);
  * \param dkey	[IN]	Distribution key.
  * \param iod_nr	[IN]	Number of I/O descriptors in \a iods.
  * \param iods	[IN]	Array of I/O descriptors.
+ * \param iods	[IN]	Array of I/O descriptors. If \a flags includes
+ *			VOS_OF_EC, then the iod_recxs field of every single
+ *			value iod in \a iods must contain the "gsize" instead
+ *			of a memory address.
  * \param iods_csums [IN]
  *			Array of iod_csums (1 for each iod). Will be NULL
  *			if csums are disabled.

--- a/src/include/daos_srv/vos_types.h
+++ b/src/include/daos_srv/vos_types.h
@@ -252,7 +252,9 @@ enum {
 	/** Dedup update with memcmp verify mode */
 	VOS_OF_DEDUP_VERIFY		= (1 << 17),
 	/** Ignore fetch only used by shadow fetch to ignore the evt fetch */
-	VOS_OF_SKIP_FETCH	= (1 << 18),
+	VOS_OF_SKIP_FETCH		= (1 << 18),
+	/** Operation on EC object (currently only applies to update) */
+	VOS_OF_EC			= (1 << 19),
 };
 
 /** Mask for any conditionals passed to to the fetch */

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -1341,6 +1341,9 @@ obj_local_rw_internal(crt_rpc_t *rpc, struct obj_io_context *ioc,
 				cond_flags |= VOS_OF_DEDUP_VERIFY;
 		}
 
+		if (orw->orw_flags & ORF_EC)
+			cond_flags |= VOS_OF_EC;
+
 		rc = vos_update_begin(ioc->ioc_vos_coh, orw->orw_oid,
 			      orw->orw_epoch, cond_flags, dkey,
 			      orw->orw_nr, iods, iod_csums,
@@ -3940,6 +3943,8 @@ ds_cpd_handle_one(crt_rpc_t *rpc, struct daos_cpd_sub_head *dcsh,
 			if (ioc->ioc_coc->sc_props.dcp_dedup_verify)
 				update_flags |= VOS_OF_DEDUP_VERIFY;
 		}
+		if (dcu->dcu_flags & ORF_EC)
+			update_flags |= VOS_OF_EC;
 
 		rc = vos_update_begin(ioc->ioc_vos_coh,
 				dcsr->dcsr_oid, dcsh->dcsh_epoch.oe_value,

--- a/src/object/srv_obj_migrate.c
+++ b/src/object/srv_obj_migrate.c
@@ -1006,6 +1006,7 @@ migrate_fetch_update_single(struct migrate_one *mrone, daos_handle_t oh,
 	struct daos_csummer	*csummer = NULL;
 	d_iov_t			 tmp_csum_iov;
 	struct dcs_iod_csums	*iod_csums = NULL;
+	uint64_t		 update_flags = 0;
 
 	D_ASSERT(mrone->mo_iod_num <= DSS_ENUM_UNPACK_MAX_IODS);
 	for (i = 0; i < mrone->mo_iod_num; i++) {
@@ -1136,9 +1137,13 @@ migrate_fetch_update_single(struct migrate_one *mrone, daos_handle_t oh,
 		D_ERROR("unable to allocate iod csums: "DF_RC"\n", DP_RC(rc));
 		goto out;
 	}
+
+	if (daos_oclass_is_ec(&mrone->mo_oca))
+		update_flags |= VOS_OF_EC;
+
 	rc = vos_obj_update(ds_cont->sc_hdl, mrone->mo_oid,
 			    mrone->mo_min_epoch, mrone->mo_version,
-			    0, &mrone->mo_dkey, mrone->mo_iod_num,
+			    update_flags, &mrone->mo_dkey, mrone->mo_iod_num,
 			    mrone->mo_iods, iod_csums, sgls);
 out:
 	for (i = 0; i < mrone->mo_iod_num; i++) {

--- a/src/vos/tests/vts_io.c
+++ b/src/vos/tests/vts_io.c
@@ -771,6 +771,10 @@ io_update_and_fetch_dkey(struct io_test_args *arg, daos_epoch_t update_epoch,
 		goto exit;
 
 	/* Verify */
+	if (arg->ta_flags & TF_REC_EXT)
+		assert_int_equal(iod.iod_size, UPDATE_REC_SIZE);
+	else
+		assert_int_equal(iod.iod_size, UPDATE_BUF_SIZE);
 	assert_memory_equal(update_buf, fetch_buf, UPDATE_BUF_SIZE);
 
 exit:

--- a/src/vos/vos_io.c
+++ b/src/vos/vos_io.c
@@ -75,7 +75,8 @@ struct vos_io_context {
 				 ic_read_ts_only:1,
 				 ic_check_existence:1,
 				 ic_remove:1,
-				 ic_skip_fetch:1;
+				 ic_skip_fetch:1,
+				 ic_ec:1; /**< see VOS_OF_EC */
 	/**
 	 * Input shadow recx lists, one for each iod. Now only used for degraded
 	 * mode EC obj fetch handling.
@@ -659,8 +660,8 @@ vos_ioc_create(daos_handle_t coh, daos_unit_oid_t oid, bool read_only,
 		ioc->ic_read_ts_only = ioc->ic_check_existence = 1;
 	else if (vos_flags & VOS_OF_FETCH_SET_TS_ONLY)
 		ioc->ic_read_ts_only = 1;
-	ioc->ic_remove =
-		((vos_flags & VOS_OF_REMOVE) != 0);
+	ioc->ic_remove = ((vos_flags & VOS_OF_REMOVE) != 0);
+	ioc->ic_ec = ((vos_flags & VOS_OF_EC) != 0);
 	ioc->ic_umoffs_cnt = ioc->ic_umoffs_at = 0;
 	ioc->iod_csums = iod_csums;
 	vos_ilog_fetch_init(&ioc->ic_dkey_info);
@@ -1743,10 +1744,12 @@ akey_update(struct vos_io_context *ioc, uint32_t pm_ver, daos_handle_t ak_toh,
 	}
 
 	if (iod->iod_type == DAOS_IOD_SINGLE) {
-		uint64_t	gsize;
+		uint64_t	gsize = iod->iod_size;
 
-		gsize = (iod->iod_recxs == NULL) ? iod->iod_size :
-						   (uintptr_t)iod->iod_recxs;
+		/* See obj_singv_ec_rw_filter. */
+		if (ioc->ic_ec && iod->iod_recxs != NULL)
+			gsize = (uintptr_t)iod->iod_recxs;
+
 		rc = akey_update_single(toh, pm_ver, iod->iod_size, gsize, ioc,
 					minor_epc);
 		if (rc)


### PR DESCRIPTION
See

  https://daosio.atlassian.net/browse/DAOS-8491?focusedCommentId=85686

for a description of the problem. In short, if vos_update_begin/end are
used to update a SINGLE value with an iod whose iod_recxs points to a
daos_recx_t object, then the ir_gsize of this value will become the
memory address of the daos_recx_t object. When this SINGLE value is
fetched later, the output iod_size will contain an incorrect size---the
aforementioned memory address! With dss_enum_unpack, the problem affects
at least rdb use cases.

To make the VOS API safer in this regard, this patch changes akey_update
to treat iod_recxs as "gsize" only if the object is an EC object. Also:

  - Add an iod_size verification to vts_io.c. This verification fails
    without the rest of this patch.

  - Add comments mentioning the existing EC iod_recxs hack to VOS update
    APIs.

Signed-off-by: Li Wei <wei.g.li@intel.com>