### PR TITLE
DAOS-8472 dfuse: Ensure error message is printed on duns errors.

### DIFF
--- a/src/client/dfuse/dfuse_main.c
+++ b/src/client/dfuse/dfuse_main.c
@@ -507,8 +507,12 @@ main(int argc, char **argv)
 	} else if (rc == ENOENT) {
 		printf("Mount point does not exist\n");
 		D_GOTO(out_daos, rc = daos_errno2der(rc));
+	} else if (rc == ENOTCONN) {
+		printf("Stale mount point, run fusermount3 and retry\n");
+		D_GOTO(out_daos, rc = daos_errno2der(rc));
 	} else if (rc != ENODATA && rc != ENOTSUP) {
-		/* Other errors from DUNS, it should have logged them already */
+		/* DUNS may have logged this already but won't have printed anything */
+		printf("Error resolving mount point (%d) %s\n", rc, strerror(rc));
 		D_GOTO(out_daos, rc = daos_errno2der(rc));
 	}
 


### PR DESCRIPTION
Dfuse uses duns to check the mount point exists, and for UNS
entry points, however for many failure modes it was not printing
anything, or logging at ERROR.

Add specific error for ENOTCONN in case of previous failed fuse
mounts, and a generic error for all other cases.

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>
