### PR TITLE
DAOS-7479 vos: Allow single value tree for non-recx query

### DIFF
--- a/src/vos/vos_query.c
+++ b/src/vos/vos_query.c
@@ -429,12 +429,15 @@ open_and_query_key(struct open_query *query, daos_key_t *key,
 			return rc;
 	}
 
-	if (tree_type == VOS_GET_DKEY)
+	if (tree_type == VOS_GET_DKEY) {
 		query->qt_akey_root = &rbund.rb_krec->kr_btr;
-	else if ((rbund.rb_krec->kr_bmap & KREC_BF_EVT) == 0)
-		return -DER_NONEXIST;
-	else
+	} else if ((rbund.rb_krec->kr_bmap & KREC_BF_EVT) == 0) {
+		if (query->qt_flags & VOS_GET_RECX)
+			return -DER_NONEXIST;
+		return 0;
+	} else {
 		query->qt_recx_root = &rbund.rb_krec->kr_evt;
+	}
 
 	return 0;
 }


### PR DESCRIPTION
vos_obj_query_key can allow a single value akey when the user
isn't querying the maximum value.

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>