### PR TITLE
DAOS-4495 telemetry: Add d_tm_list_subdirs()

### DIFF
--- a/src/gurt/telemetry.c
+++ b/src/gurt/telemetry.c
@@ -3096,6 +3096,109 @@ d_tm_get_version(void)
 	return D_TM_VERSION;
 }
 
+static int
+list_children(struct d_tm_context *ctx, struct d_tm_nodeList_t **head,
+	      struct d_tm_node_t *node, int d_tm_type,
+	      int cur_depth, const int max_depth, int skip_root)
+{
+	int			 rc = DER_SUCCESS;
+	int			 skip_add = skip_root && (cur_depth == 0);
+	struct d_tm_shmem_hdr	*shmem;
+
+	cur_depth++;
+	if (max_depth > 0 && cur_depth > max_depth)
+		return DER_SUCCESS;
+
+	if ((ctx == NULL) || (head == NULL) || (node == NULL)) {
+		rc = -DER_INVAL;
+		goto out;
+	}
+
+	if (node->dtn_type == D_TM_LINK) {
+		node = d_tm_follow_link(ctx, node);
+		if (node == NULL)
+			D_GOTO(out, rc = 0);
+	}
+
+	if (!skip_add && d_tm_type & node->dtn_type) {
+		rc = d_tm_list_add_node(node, head);
+		if (rc != DER_SUCCESS)
+			goto out;
+	}
+
+	if (node->dtn_child == NULL)
+		goto out;
+
+	shmem = get_shmem_for_key(ctx, node->dtn_shmem_key);
+	if (shmem == NULL)
+		D_GOTO(out, rc = -DER_SHMEM_PERMS);
+
+	node = conv_ptr(shmem, node->dtn_child);
+	if (node == NULL) {
+		rc = -DER_INVAL;
+		goto out;
+	}
+
+	while (node != NULL) {
+		rc = list_children(ctx, head, node, d_tm_type,
+				   cur_depth, max_depth, 0);
+		if (rc != DER_SUCCESS)
+			goto out;
+		node = conv_ptr(shmem, node->dtn_sibling);
+	}
+
+out:
+	return rc;
+
+}
+
+/**
+ * Perform a recursive listing from the given \a node for all subdirectories
+ * to a maximum depth of \a max_depth.
+ *
+ * \param[in]		ctx		Telemetry context
+ * \param[in,out]	head		Pointer to a nodelist
+ * \param[in]		node		The recursive listing starts
+ *					from this node.
+ * \param[in,out]	num_dirs	Optional pointer to storage for the
+ *					number of directories found.
+ * \param[in]		max_depth	The maximum depth of the listing, including
+ *					the root node.
+ *
+ * \return		DER_SUCCESS		Success
+ *			-DER_NOMEM		Out of global heap
+ *			-DER_INVAL		Invalid pointer for \a head or
+ *						\a node
+ */
+int
+d_tm_list_subdirs(struct d_tm_context *ctx, struct d_tm_nodeList_t **head,
+		  struct d_tm_node_t *node, uint64_t *num_dirs, int max_depth)
+{
+	int			 rc = DER_SUCCESS;
+	uint64_t		 dir_count = 0;
+	struct d_tm_nodeList_t	*cur_head = NULL;
+
+	rc = list_children(ctx, head, node, D_TM_DIRECTORY, 0, max_depth, 1);
+	if (rc != DER_SUCCESS)
+		return rc;
+
+	cur_head = *head;
+	while (cur_head != NULL && cur_head->dtnl_node != NULL) {
+		if (cur_head->dtnl_node->dtn_type == D_TM_DIRECTORY)
+			dir_count++;
+
+		if (cur_head->dtnl_next == NULL)
+			break;
+
+		cur_head = cur_head->dtnl_next;
+	}
+
+	if (num_dirs != NULL)
+		*num_dirs = dir_count;
+
+	return DER_SUCCESS;
+}
+
 /**
  * Perform a recursive directory listing from the given \a node for the items
  * described by the \a d_tm_type bitmask.  A result is added to the list if it
@@ -3121,48 +3224,7 @@ int
 d_tm_list(struct d_tm_context *ctx, struct d_tm_nodeList_t **head,
 	  struct d_tm_node_t *node, int d_tm_type)
 {
-	int			 rc = DER_SUCCESS;
-	struct d_tm_shmem_hdr	*shmem;
-
-	if ((ctx == NULL) || (head == NULL) || (node == NULL)) {
-		rc = -DER_INVAL;
-		goto out;
-	}
-
-	if (node->dtn_type == D_TM_LINK) {
-		node = d_tm_follow_link(ctx, node);
-		if (node == NULL)
-			D_GOTO(out, rc = 0);
-	}
-
-	if (d_tm_type & node->dtn_type) {
-		rc = d_tm_list_add_node(node, head);
-		if (rc != DER_SUCCESS)
-			goto out;
-	}
-
-	if (node->dtn_child == NULL)
-		goto out;
-
-	shmem = get_shmem_for_key(ctx, node->dtn_shmem_key);
-	if (shmem == NULL)
-		D_GOTO(out, rc = -DER_SHMEM_PERMS);
-
-	node = conv_ptr(shmem, node->dtn_child);
-	if (node == NULL) {
-		rc = -DER_INVAL;
-		goto out;
-	}
-
-	while (node != NULL) {
-		rc = d_tm_list(ctx, head, node, d_tm_type);
-		if (rc != DER_SUCCESS)
-			goto out;
-		node = conv_ptr(shmem, node->dtn_sibling);
-	}
-
-out:
-	return rc;
+	return list_children(ctx, head, node, d_tm_type, 0, 0, 0);
 }
 
 /**

--- a/src/gurt/telemetry.c
+++ b/src/gurt/telemetry.c
@@ -3162,8 +3162,8 @@ out:
  *					from this node.
  * \param[in,out]	num_dirs	Optional pointer to storage for the
  *					number of directories found.
- * \param[in]		max_depth	The maximum depth of the listing, including
- *					the root node.
+ * \param[in]		max_depth	The maximum depth below the root of
+ *					the listing.
  *
  * \return		DER_SUCCESS		Success
  *			-DER_NOMEM		Out of global heap
@@ -3178,7 +3178,8 @@ d_tm_list_subdirs(struct d_tm_context *ctx, struct d_tm_nodeList_t **head,
 	uint64_t		 dir_count = 0;
 	struct d_tm_nodeList_t	*cur_head = NULL;
 
-	rc = list_children(ctx, head, node, D_TM_DIRECTORY, 0, max_depth, 1);
+	/** add +1 to max_depth to account for the root node */
+	rc = list_children(ctx, head, node, D_TM_DIRECTORY, 0, max_depth+1, 1);
 	if (rc != DER_SUCCESS)
 		return rc;
 
@@ -3186,9 +3187,6 @@ d_tm_list_subdirs(struct d_tm_context *ctx, struct d_tm_nodeList_t **head,
 	while (cur_head != NULL && cur_head->dtnl_node != NULL) {
 		if (cur_head->dtnl_node->dtn_type == D_TM_DIRECTORY)
 			dir_count++;
-
-		if (cur_head->dtnl_next == NULL)
-			break;
 
 		cur_head = cur_head->dtnl_next;
 	}

--- a/src/gurt/telemetry.c
+++ b/src/gurt/telemetry.c
@@ -3171,24 +3171,24 @@ out:
  *						\a node
  */
 int
-d_tm_list_subdirs(struct d_tm_context *ctx, struct d_tm_nodeList_t **head,
+d_tm_list_subdirs(struct d_tm_context *ctx, struct d_tm_nodeList_t **list,
 		  struct d_tm_node_t *node, uint64_t *num_dirs, int max_depth)
 {
 	int			 rc = DER_SUCCESS;
 	uint64_t		 dir_count = 0;
-	struct d_tm_nodeList_t	*cur_head = NULL;
+	struct d_tm_nodeList_t	*head = NULL;
 
 	/** add +1 to max_depth to account for the root node */
-	rc = list_children(ctx, head, node, D_TM_DIRECTORY, 0, max_depth+1, 1);
+	rc = list_children(ctx, list, node, D_TM_DIRECTORY, 0, max_depth+1, 1);
 	if (rc != DER_SUCCESS)
 		return rc;
 
-	cur_head = *head;
-	while (cur_head != NULL && cur_head->dtnl_node != NULL) {
-		if (cur_head->dtnl_node->dtn_type == D_TM_DIRECTORY)
+	head = *list;
+	while (head != NULL && head->dtnl_node != NULL) {
+		if (head->dtnl_node->dtn_type == D_TM_DIRECTORY)
 			dir_count++;
 
-		cur_head = cur_head->dtnl_next;
+		head = head->dtnl_next;
 	}
 
 	if (num_dirs != NULL)

--- a/src/gurt/telemetry.c
+++ b/src/gurt/telemetry.c
@@ -3171,24 +3171,24 @@ out:
  *						\a node
  */
 int
-d_tm_list_subdirs(struct d_tm_context *ctx, struct d_tm_nodeList_t **list,
+d_tm_list_subdirs(struct d_tm_context *ctx, struct d_tm_nodeList_t **head,
 		  struct d_tm_node_t *node, uint64_t *num_dirs, int max_depth)
 {
 	int			 rc = DER_SUCCESS;
 	uint64_t		 dir_count = 0;
-	struct d_tm_nodeList_t	*head = NULL;
+	struct d_tm_nodeList_t	*cur = NULL;
 
 	/** add +1 to max_depth to account for the root node */
-	rc = list_children(ctx, list, node, D_TM_DIRECTORY, 0, max_depth+1, 1);
+	rc = list_children(ctx, head, node, D_TM_DIRECTORY, 0, max_depth+1, 1);
 	if (rc != DER_SUCCESS)
 		return rc;
 
-	head = *list;
-	while (head != NULL && head->dtnl_node != NULL) {
-		if (head->dtnl_node->dtn_type == D_TM_DIRECTORY)
+	cur = *head;
+	while (cur != NULL && cur->dtnl_node != NULL) {
+		if (cur->dtnl_node->dtn_type == D_TM_DIRECTORY)
 			dir_count++;
 
-		head = head->dtnl_next;
+		cur = cur->dtnl_next;
 	}
 
 	if (num_dirs != NULL)

--- a/src/gurt/tests/test_gurt_telem_producer.c
+++ b/src/gurt/tests/test_gurt_telem_producer.c
@@ -1061,6 +1061,54 @@ test_list_ephemeral(void **state)
 }
 
 static void
+test_list_subdirs(void **state)
+{
+	char			*root_dir = "gurt/tests/subdir_root";
+	char			*subdir_name;
+	char			 new_path[D_TM_MAX_NAME_LEN];
+	struct d_tm_node_t	*dir_node;
+	struct d_tm_nodeList_t	*list = NULL;
+	uint64_t		 num_subdirs = 0;
+	int			 expected_subdirs = 0;
+	int			 i, rc;
+
+	static const char * const subdirs[] = {
+		"sub0",
+		"sub1",
+		"sub2",
+		"sub3",
+		NULL,
+	};
+
+	for (i = 0; subdirs[i] != NULL; i++) {
+		snprintf(new_path, sizeof(new_path), "%s/%s", root_dir, subdirs[i]);
+		rc = d_tm_add_ephemeral_dir(&dir_node, 1024, new_path);
+		assert_rc_equal(rc, DER_SUCCESS);
+		expected_subdirs++;
+	}
+
+	/* add another dir at a deeper level -- shouldn't be included */
+	snprintf(new_path, sizeof(new_path), "%s/%s/deeper", root_dir, subdirs[0]);
+	rc = d_tm_add_ephemeral_dir(&dir_node, 1024, new_path);
+	assert_rc_equal(rc, DER_SUCCESS);
+
+	/* collect a list from the ephemeral metrics' parent directory */
+	dir_node = d_tm_find_metric(cli_ctx, root_dir);
+	assert_non_null(dir_node);
+
+	rc = d_tm_list_subdirs(cli_ctx, &list, dir_node, &num_subdirs, 1);
+	assert_rc_equal(rc, DER_SUCCESS);
+	assert_int_equal(num_subdirs, expected_subdirs);
+
+	for (i = 0; list && i < num_subdirs; i++) {
+		subdir_name = d_tm_get_name(cli_ctx, list->dtnl_node);
+
+		assert_string_equal(subdir_name, subdirs[i]);
+		list = list->dtnl_next;
+	}
+}
+
+static void
 test_follow_link(void **state)
 {
 	struct d_tm_node_t	*node;
@@ -1269,6 +1317,7 @@ main(int argc, char **argv)
 		cmocka_unit_test(test_gc_ctx),
 		/* Run after the tests that populate the metrics */
 		cmocka_unit_test(test_list_ephemeral),
+		cmocka_unit_test(test_list_subdirs),
 		cmocka_unit_test(test_follow_link),
 		cmocka_unit_test(test_find_metric),
 		cmocka_unit_test(test_verify_object_count),

--- a/src/gurt/tests/test_gurt_telem_producer.c
+++ b/src/gurt/tests/test_gurt_telem_producer.c
@@ -1068,6 +1068,7 @@ test_list_subdirs(void **state)
 	char			 new_path[D_TM_MAX_NAME_LEN];
 	struct d_tm_node_t	*dir_node;
 	struct d_tm_nodeList_t	*list = NULL;
+	struct d_tm_nodeList_t	*head = NULL;
 	uint64_t		 num_subdirs = 0;
 	int			 expected_subdirs = 0;
 	int			 i, rc;
@@ -1100,12 +1101,14 @@ test_list_subdirs(void **state)
 	assert_rc_equal(rc, DER_SUCCESS);
 	assert_int_equal(num_subdirs, expected_subdirs);
 
-	for (i = 0; list && i < num_subdirs; i++) {
-		subdir_name = d_tm_get_name(cli_ctx, list->dtnl_node);
+	for (head = list, i = 0; head && i < num_subdirs; i++) {
+		subdir_name = d_tm_get_name(cli_ctx, head->dtnl_node);
 
 		assert_string_equal(subdir_name, subdirs[i]);
-		list = list->dtnl_next;
+		head = head->dtnl_next;
 	}
+
+	d_tm_list_free(list);
 }
 
 static void

--- a/src/gurt/tests/test_gurt_telem_producer.c
+++ b/src/gurt/tests/test_gurt_telem_producer.c
@@ -1067,8 +1067,8 @@ test_list_subdirs(void **state)
 	char			*subdir_name;
 	char			 new_path[D_TM_MAX_NAME_LEN];
 	struct d_tm_node_t	*dir_node;
-	struct d_tm_nodeList_t	*list = NULL;
 	struct d_tm_nodeList_t	*head = NULL;
+	struct d_tm_nodeList_t	*cur = NULL;
 	uint64_t		 num_subdirs = 0;
 	int			 expected_subdirs = 0;
 	int			 i, rc;
@@ -1097,18 +1097,18 @@ test_list_subdirs(void **state)
 	dir_node = d_tm_find_metric(cli_ctx, root_dir);
 	assert_non_null(dir_node);
 
-	rc = d_tm_list_subdirs(cli_ctx, &list, dir_node, &num_subdirs, 1);
+	rc = d_tm_list_subdirs(cli_ctx, &head, dir_node, &num_subdirs, 1);
 	assert_rc_equal(rc, DER_SUCCESS);
 	assert_int_equal(num_subdirs, expected_subdirs);
 
-	for (head = list, i = 0; head && i < num_subdirs; i++) {
-		subdir_name = d_tm_get_name(cli_ctx, head->dtnl_node);
+	for (cur = head, i = 0; cur && i < num_subdirs; i++) {
+		subdir_name = d_tm_get_name(cli_ctx, cur->dtnl_node);
 
 		assert_string_equal(subdir_name, subdirs[i]);
-		head = head->dtnl_next;
+		cur = cur->dtnl_next;
 	}
 
-	d_tm_list_free(list);
+	d_tm_list_free(head);
 }
 
 static void

--- a/src/include/gurt/telemetry_consumer.h
+++ b/src/include/gurt/telemetry_consumer.h
@@ -46,6 +46,9 @@ uint64_t d_tm_count_metrics(struct d_tm_context *ctx, struct d_tm_node_t *node,
 			    int d_tm_type);
 int d_tm_list(struct d_tm_context *ctx, struct d_tm_nodeList_t **head,
 	      struct d_tm_node_t *node, int d_tm_type);
+int d_tm_list_subdirs(struct d_tm_context *ctx, struct d_tm_nodeList_t **head,
+		      struct d_tm_node_t *node, uint64_t *node_count,
+		      int max_depth);
 void d_tm_print_my_children(struct d_tm_context *ctx, struct d_tm_node_t *node,
 			    int level, int filter, char *path, int format,
 			    int opt_fields, FILE *stream);


### PR DESCRIPTION
Adds a new method for getting the subdirectories of
a node, up to an optional max depth.