### PR TITLE
DAOS-7785 cart: Fix double free in IV code following failure of bulk create.

### DIFF
--- a/src/cart/crt_iv.c
+++ b/src/cart/crt_iv.c
@@ -2354,7 +2354,7 @@ exit:
 		
 		update_comp_cb(ivns_internal, class_id, iv_key, NULL, iv_value,
 			       update_rc, cb_arg);
-		if (delay_completion == false && rc == 0)
+		if (rc == 0)
 			iv_ops->ivo_on_put(ivns_internal, NULL, user_priv);
 	}
 

--- a/src/cart/crt_iv.c
+++ b/src/cart/crt_iv.c
@@ -2366,7 +2366,7 @@ exit:
 			D_FREE(iv_sync_cb->isc_iv_key.iov_buf);
 			D_FREE(iv_sync_cb);
 		}
-}
+	}
 	return rc;
 }
 
@@ -2584,9 +2584,9 @@ handle_ivupdate_response(const struct crt_cb_info *cb_info)
 						iv_info->uci_user_priv);
 			if (iv_info->uci_sync_type.ivs_comp_cb)
 				iv_info->uci_sync_type.ivs_comp_cb(iv_info->
-				                               uci_sync_type.
-							       ivs_comp_cb_arg,
-							       rc);
+								   uci_sync_type.
+								   ivs_comp_cb_arg,
+								   rc);
 		}
 	}
 

--- a/src/cart/crt_iv.c
+++ b/src/cart/crt_iv.c
@@ -2351,7 +2351,7 @@ exit:
 	if (delay_completion == false || rc != 0) {
 		if (rc != 0)
 			update_rc = rc;
-		
+
 		update_comp_cb(ivns_internal, class_id, iv_key, NULL, iv_value,
 			       update_rc, cb_arg);
 		if (rc == 0)

--- a/src/cart/crt_iv.c
+++ b/src/cart/crt_iv.c
@@ -2354,9 +2354,6 @@ exit:
 
 		update_comp_cb(ivns_internal, class_id, iv_key, NULL, iv_value,
 			       update_rc, cb_arg);
-
-		/* on_get() done in crt_iv_update_internal */
-		iv_ops->ivo_on_put(ivns_internal, NULL, user_priv);
 	}
 
 	if (rc != 0) {
@@ -2369,9 +2366,7 @@ exit:
 			D_FREE(iv_sync_cb->isc_iv_key.iov_buf);
 			D_FREE(iv_sync_cb);
 		}
-		if (sync_type->ivs_comp_cb)
-			sync_type->ivs_comp_cb(sync_type->ivs_comp_cb_arg, rc);
-	}
+}
 	return rc;
 }
 
@@ -2583,10 +2578,16 @@ handle_ivupdate_response(const struct crt_cb_info *cb_info)
 					  iv_info->uci_cb_arg,
 					  iv_info->uci_user_priv,
 					  rc);
-		if (rc != 0)
+		if (rc != 0) {
 			rc = iv_ops->ivo_on_put(iv_info->uci_ivns_internal,
 						tmp_iv_value,
 						iv_info->uci_user_priv);
+			if (iv_info->uci_sync_type.ivs_comp_cb)
+				iv_info->uci_sync_type.ivs_comp_cb(iv_info->
+				                               uci_sync_type.
+							       ivs_comp_cb_arg,
+							       rc);
+		}
 	}
 
 	if (iv_info->uci_bulk_hdl != CRT_BULK_NULL)

--- a/src/cart/crt_iv.c
+++ b/src/cart/crt_iv.c
@@ -2351,11 +2351,11 @@ exit:
 	if (delay_completion == false || rc != 0) {
 		if (rc != 0)
 			update_rc = rc;
-
+		
 		update_comp_cb(ivns_internal, class_id, iv_key, NULL, iv_value,
 			       update_rc, cb_arg);
-	} else if (delay_completion == false) {
-		iv_ops->ivo_on_put(ivns_internal, NULL, user_priv);
+		if (delay_completion == false && rc == 0)
+			iv_ops->ivo_on_put(ivns_internal, NULL, user_priv);
 	}
 
 	if (rc != 0) {

--- a/src/cart/crt_iv.c
+++ b/src/cart/crt_iv.c
@@ -2354,6 +2354,8 @@ exit:
 
 		update_comp_cb(ivns_internal, class_id, iv_key, NULL, iv_value,
 			       update_rc, cb_arg);
+	} else if (delay_completion == false) {
+		iv_ops->ivo_on_put(ivns_internal, NULL, user_priv);
 	}
 
 	if (rc != 0) {


### PR DESCRIPTION
The IV code has been restructured to eliminate redundant calls to ivc_on_put, which was leading to pointers being freed twice.

Signed-off-by: Joseph Moore <joseph.moore@intel.com>