### PR TITLE
DAOS-7306 test: Remove rank abort all from crtu_drain_queue

### DIFF
--- a/src/cart/crt_utils.c
+++ b/src/cart/crt_utils.c
@@ -56,8 +56,6 @@ crtu_drain_queue(crt_context_t ctx)
 	int	rc;
 	int	i;
 
-	crt_rank_abort_all(NULL);
-
 	/* TODO: Need better mechanism for tests to drain all queues */
 	for (i = 0; i < 1000; i++)
 		crt_progress(ctx, 1000);


### PR DESCRIPTION
- Remove crt_rank_abort_all() from crtu_drain_queue helper
function. This causes corpc tests to run much slower, especially on
valgrind runs, as servers start cancelling rpc parts of corpc as
servers are shutting down.

Signed-off-by: Alexander Oganezov <alexander.a.oganezov@intel.com>