### PR TITLE
CART-89 sep: Remove sep variants from most cart tests

### DIFF
--- a/src/tests/ftest/cart/corpc/cart_corpc_one_node.yaml
+++ b/src/tests/ftest/cart/corpc/cart_corpc_one_node.yaml
@@ -14,9 +14,6 @@ env_CRT_PHY_ADDR_STR: !mux
   ofi_sockets:
     CRT_PHY_ADDR_STR: "ofi+sockets"
 env_CRT_CTX_SHARE_ADDR: !mux
-  sep:
-    env: sep
-    CRT_CTX_SHARE_ADDR: "1"
   no_sep:
     env: no_sep
     CRT_CTX_SHARE_ADDR: "0"

--- a/src/tests/ftest/cart/corpc/cart_corpc_two_node.yaml
+++ b/src/tests/ftest/cart/corpc/cart_corpc_two_node.yaml
@@ -12,9 +12,6 @@ env_CRT_PHY_ADDR_STR: !mux
   ofi_sockets:
     CRT_PHY_ADDR_STR: "ofi+sockets"
 env_CRT_CTX_SHARE_ADDR: !mux
-  sep:
-    env: sep
-    CRT_CTX_SHARE_ADDR: "1"
   no_sep:
     env: no_sep
     CRT_CTX_SHARE_ADDR: "0"

--- a/src/tests/ftest/cart/ghost_rank_rpc/cart_ghost_rank_prc_one_node.yaml
+++ b/src/tests/ftest/cart/ghost_rank_rpc/cart_ghost_rank_prc_one_node.yaml
@@ -12,9 +12,6 @@ env_CRT_PHY_ADDR_STR: !mux
   ofi_sockets:
     CRT_PHY_ADDR_STR: "ofi+sockets"
 env_CRT_CTX_SHARE_ADDR: !mux
-  sep:
-    env: sep
-    CRT_CTX_SHARE_ADDR: "1"
   no_sep:
     env: no_sep
     CRT_CTX_SHARE_ADDR: "0"

--- a/src/tests/ftest/cart/iv/cart_iv_one_node.yaml
+++ b/src/tests/ftest/cart/iv/cart_iv_one_node.yaml
@@ -11,9 +11,6 @@ ENV:
     - test_clients_CRT_CTX_NUM: "2"
     - CRT_TEST_CONT: "1"
 env_CRT_CTX_SHARE_ADDR: !mux
-  sep:
-    env: sep
-    CRT_CTX_SHARE_ADDR: "1"
   no_sep:
     env: no_sep
     CRT_CTX_SHARE_ADDR: "0"

--- a/src/tests/ftest/cart/iv/cart_iv_two_node.yaml
+++ b/src/tests/ftest/cart/iv/cart_iv_two_node.yaml
@@ -14,9 +14,6 @@ env_CRT_PHY_ADDR_STR: !mux
   ofi_sockets:
     CRT_PHY_ADDR_STR: "ofi+sockets"
 env_CRT_CTX_SHARE_ADDR: !mux
-  sep:
-    env: sep
-    CRT_CTX_SHARE_ADDR: "1"
   no_sep:
     env: no_sep
     CRT_CTX_SHARE_ADDR: "0"

--- a/src/tests/ftest/cart/rpc/cart_rpc_one_node.yaml
+++ b/src/tests/ftest/cart/rpc/cart_rpc_one_node.yaml
@@ -12,9 +12,6 @@ ENV:
     - test_servers_CRT_CTX_NUM: "16"
     - test_clients_CRT_CTX_NUM: "16"
 env_CRT_CTX_SHARE_ADDR: !mux
-  sep:
-    env: sep
-    CRT_CTX_SHARE_ADDR: "1"
   no_sep:
     env: no_sep
     CRT_CTX_SHARE_ADDR: "0"

--- a/src/tests/ftest/cart/rpc/cart_rpc_two_node.yaml
+++ b/src/tests/ftest/cart/rpc/cart_rpc_two_node.yaml
@@ -13,9 +13,6 @@ env_CRT_PHY_ADDR_STR: !mux
   ofi_sockets:
     CRT_PHY_ADDR_STR: "ofi+sockets"
 env_CRT_CTX_SHARE_ADDR: !mux
-  sep:
-    env: sep
-    CRT_CTX_SHARE_ADDR: "1"
   no_sep:
     env: no_sep
     CRT_CTX_SHARE_ADDR: "0"

--- a/src/tests/ftest/cart/selftest/cart_selftest_three_node.yaml
+++ b/src/tests/ftest/cart/selftest/cart_selftest_three_node.yaml
@@ -13,9 +13,6 @@ env_CRT_PHY_ADDR_STR: !mux
   ofi_sockets:
     CRT_PHY_ADDR_STR: "ofi+sockets"
 env_CRT_CTX_SHARE_ADDR: !mux
-  sep:
-    env: sep
-    CRT_CTX_SHARE_ADDR: "1"
   no_sep:
     env: no_sep
     CRT_CTX_SHARE_ADDR: "0"


### PR DESCRIPTION
- SEP is currently not supported by TCP or verbs, making most of
SEP testing on sockets not that useful while doubling test time on cart

Signed-off-by: Alexander Oganezov <alexander.a.oganezov@intel.com>