### PR TITLE
DAOS-8516 control: Cleanup pools in Destroying state on create

### DIFF
--- a/src/control/server/mgmt_pool_test.go
+++ b/src/control/server/mgmt_pool_test.go
@@ -97,7 +97,7 @@ func TestServer_MgmtSvc_PoolCreateAlreadyExists(t *testing.T) {
 		"destroying": {
 			state: system.PoolServiceStateDestroying,
 			expResp: &mgmtpb.PoolCreateResp{
-				Status: int32(drpc.DaosAlready),
+				Status: int32(drpc.DaosTryAgain),
 			},
 		},
 	} {


### PR DESCRIPTION
Follow-on from DAOS-8313, which added a cleanup handler to deal
with finding a partially-created or partially-destroyed pool left
over from a previous create request. Adjusts the logic to actually
include pools in the Destroying state.