### PR TITLE
DAOS-8008 control,bio: set spdk stderr mask in admin and engine

### DIFF
--- a/src/bio/SConscript
+++ b/src/bio/SConscript
@@ -24,7 +24,7 @@ def scons():
     denv.AppendUnique(OBJPREFIX='b_')
 
     # SPDK related libs
-    libs = ['spdk_env_dpdk', 'spdk_thread', 'spdk_bdev', 'rte_mempool']
+    libs = ['spdk_log', 'spdk_env_dpdk', 'spdk_thread', 'spdk_bdev', 'rte_mempool']
     libs += ['rte_mempool_ring', 'rte_bus_pci', 'rte_pci', 'rte_ring']
     libs += ['rte_mbuf', 'rte_eal', 'rte_kvargs', 'spdk_bdev_aio']
     libs += ['spdk_bdev_nvme', 'spdk_blob', 'spdk_nvme', 'spdk_util']

--- a/src/bio/bio_xstream.c
+++ b/src/bio/bio_xstream.c
@@ -10,6 +10,7 @@
 #include <fcntl.h>
 #include <uuid/uuid.h>
 #include <abt.h>
+#include <spdk/log.h>
 #include <spdk/env.h>
 #include <spdk/init.h>
 #include <spdk/nvme.h>
@@ -79,6 +80,9 @@ bio_spdk_env_init(void)
 	int			 rc;
 
 	D_ASSERT(nvme_glb.bd_nvme_conf != NULL);
+
+	// Only print error and more severe to stderr.
+	spdk_log_set_print_level(SPDK_LOG_ERROR);
 
 	spdk_env_opts_init(&opts);
 	opts.name = "daos";

--- a/src/bio/bio_xstream.c
+++ b/src/bio/bio_xstream.c
@@ -81,7 +81,7 @@ bio_spdk_env_init(void)
 
 	D_ASSERT(nvme_glb.bd_nvme_conf != NULL);
 
-	// Only print error and more severe to stderr.
+	/* Only print error and more severe to stderr. */
 	spdk_log_set_print_level(SPDK_LOG_ERROR);
 
 	spdk_env_opts_init(&opts);

--- a/src/control/lib/spdk/SConscript
+++ b/src/control/lib/spdk/SConscript
@@ -18,7 +18,7 @@ def scons():
     senv.AppendUnique(OBJPREFIX='s_')
 
     # Explicitly link RTE & SPDK libs for CGO access
-    libs = ['spdk_env_dpdk', 'spdk_nvme', 'spdk_vmd', 'rte_mempool']
+    libs = ['spdk_log', 'spdk_env_dpdk', 'spdk_nvme', 'spdk_vmd', 'rte_mempool']
     libs += ['rte_mempool_ring', 'rte_bus_pci', 'nvme_control']
 
     # Other libs

--- a/src/control/lib/spdk/spdk.go
+++ b/src/control/lib/spdk/spdk.go
@@ -13,13 +13,14 @@ package spdk
 /*
 #cgo CFLAGS: -I .
 #cgo LDFLAGS: -L . -lnvme_control
-#cgo LDFLAGS: -lspdk_env_dpdk -lspdk_nvme -lspdk_vmd -lrte_mempool
+#cgo LDFLAGS: -lspdk_log -lspdk_env_dpdk -lspdk_nvme -lspdk_vmd -lrte_mempool
 #cgo LDFLAGS: -lrte_mempool_ring -lrte_bus_pci
 
 #include "stdlib.h"
 #include "daos_srv/control.h"
 #include "spdk/stdinc.h"
 #include "spdk/string.h"
+#include "spdk/log.h"
 #include "spdk/env.h"
 #include "spdk/nvme.h"
 #include "spdk/vmd.h"
@@ -129,6 +130,9 @@ func revertBackingToVmd(log logging.Logger, pciAddrs []string) ([]string, error)
 // The library must be initialized first.
 func (e *EnvImpl) InitSPDKEnv(log logging.Logger, opts *EnvOptions) error {
 	log.Debugf("spdk init go opts: %+v", opts)
+
+	// Only print error and more severe to stderr.
+	C.spdk_log_set_print_level(C.SPDK_LOG_ERROR)
 
 	if err := opts.sanitizeAllowList(log); err != nil {
 		return errors.Wrap(err, "sanitizing PCI include list")


### PR DESCRIPTION
Avoid printing non-error level SPDK messages to stderr which results in
confusing log output.

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>