### PR TITLE
DAOS-8527 control: Return ErrRaftUnavail on empty membership

### DIFF
--- a/src/control/server/mgmt_system.go
+++ b/src/control/server/mgmt_system.go
@@ -585,6 +585,12 @@ func (svc *mgmtSvc) SystemQuery(ctx context.Context, req *mgmtpb.SystemQueryReq)
 		Absenthosts: missHosts.String(),
 	}
 	if hitRanks.Count() == 0 {
+		// If the membership is empty, this replica is likely waiting
+		// for logs from peers, so we should indicate to the client
+		// that it should try a different replica.
+		if req.Ranks == "" && req.Hosts == "" {
+			return nil, system.ErrRaftUnavail
+		}
 		return resp, nil
 	}
 


### PR DESCRIPTION
In rare circumstances after a MS replica comes back online,
it may temporarily appear to have an empty membership. In
this case, just return ErrRaftUnavail to indicate to the
client that it should try a different replica.