### PR TITLE
DAOS-8449 common: more logs when failed targets exceed RF

### DIFF
--- a/src/common/pool_map.c
+++ b/src/common/pool_map.c
@@ -2528,7 +2528,7 @@ pmap_node_check(struct pool_domain *node_dom, struct pmap_fail_stat *fstat)
 		fstat->pf_newfail_nr++;
 	if ((fstat->pf_down_nr > fstat->pf_rf) && (fstat->pf_newfail_nr > 0)) {
 		rc = -DER_RF;
-		D_DEBUG(DB_TRACE, "RF broken, found %d DOWN node, "
+		D_ERROR("RF broken, found %d DOWN node, "
 			"newly fail %d, rf %d, "DF_RC"\n", fstat->pf_down_nr,
 			fstat->pf_newfail_nr, fstat->pf_rf, DP_RC(rc));
 	}
@@ -2606,7 +2606,7 @@ pmap_fail_stat_check(struct pmap_fail_stat *fstat)
 
 fail:
 	if (rc == -DER_RF) {
-		D_DEBUG(DB_TRACE, "RF broken, found %d fail, DOWN %d, newly "
+		D_ERROR("RF broken, found %d fail, DOWN %d, newly "
 			"fail %d, max_overlapped %d, rf %d, "DF_RC"\n",
 			fstat->pf_node_nr, fstat->pf_down_nr,
 			fstat->pf_newfail_nr, max_fail_nr,

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -1665,8 +1665,11 @@ obj_capa_check(struct ds_cont_hdl *coh, bool is_write, bool is_agg_migrate)
 		return -DER_NO_PERM;
 	}
 
-	if (!is_agg_migrate && coh->sch_cont && coh->sch_cont->sc_rw_disabled)
+	if (!is_agg_migrate && coh->sch_cont && coh->sch_cont->sc_rw_disabled) {
+		D_ERROR("cont hdl "DF_UUID" exceeds rf\n",
+			DP_UUID(coh->sch_uuid));
 		return -DER_RF;
+	}
 
 	return 0;
 }

--- a/src/tests/ftest/nvme/nvme_pool_exclude.yaml
+++ b/src/tests/ftest/nvme/nvme_pool_exclude.yaml
@@ -31,7 +31,7 @@ server_config:
         scm_class: dcpm
         scm_list: ["/dev/pmem0"]
         scm_mount: /mnt/daos0
-        log_mask: ERR
+        log_mask: DEBUG,MEM=ERR
       1:
         pinned_numa_node: 1
         nr_xs_helpers: 1
@@ -43,7 +43,7 @@ server_config:
         scm_class: dcpm
         scm_list: ["/dev/pmem1"]
         scm_mount: /mnt/daos1
-        log_mask: ERR
+        log_mask: DEBUG,MEM=ERR
 pool:
   mode: 146
   name: daos_server


### PR DESCRIPTION
Only for test.

Test-tag-hw-large: pr,hw,large nvme_pool_exclude

Signed-off-by: Fan Yong <fan.yong@intel.com>