### PR TITLE
CART-89 self_test: Do not overwrite the error

### DIFF
--- a/src/utils/self_test/self_test.c
+++ b/src/utils/self_test/self_test.c
@@ -984,8 +984,10 @@ cleanup:
 	/* Tell the progress thread to abort and exit */
 	g_shutdown_flag = 1;
 
-	if (pthread_join(tid, NULL))
+	if (pthread_join(tid, NULL)) {
 		D_ERROR("Could not join progress thread");
+		ret = -1;
+	}
 
 cleanup_nothread:
 	if (latencies_bulk_hdl != NULL) {

--- a/src/utils/self_test/self_test.c
+++ b/src/utils/self_test/self_test.c
@@ -984,8 +984,7 @@ cleanup:
 	/* Tell the progress thread to abort and exit */
 	g_shutdown_flag = 1;
 
-	ret = pthread_join(tid, NULL);
-	if (ret)
+	if (pthread_join(tid, NULL))
 		D_ERROR("Could not join progress thread");
 
 cleanup_nothread:


### PR DESCRIPTION
- If self test fails we do not want to overwrite the error. This
way outside script will be able to test for $? to see whether test
passed or failed

Signed-off-by: Alexander Oganezov <alexander.a.oganezov@intel.com>