### PR TITLE
DAOS-7741 control: Remove single-letter command aliases

### DIFF
--- a/src/control/cmd/daos_server/storage.go
+++ b/src/control/cmd/daos_server/storage.go
@@ -24,7 +24,7 @@ import (
 )
 
 type storageCmd struct {
-	Prepare storagePrepareCmd `command:"prepare" alias:"p" description:"Prepare SCM and NVMe storage attached to remote servers."`
+	Prepare storagePrepareCmd `command:"prepare" description:"Prepare SCM and NVMe storage attached to remote servers."`
 	Scan    storageScanCmd    `command:"scan" description:"Scan SCM and NVMe storage attached to local server"`
 }
 

--- a/src/control/cmd/dmg/auto.go
+++ b/src/control/cmd/dmg/auto.go
@@ -20,7 +20,7 @@ import (
 
 // configCmd is the struct representing the top-level config subcommand.
 type configCmd struct {
-	Generate configGenCmd `command:"generate" alias:"g" description:"Generate DAOS server configuration file based on discoverable hardware devices"`
+	Generate configGenCmd `command:"generate" alias:"gen" description:"Generate DAOS server configuration file based on discoverable hardware devices"`
 }
 
 type configGenCmd struct {

--- a/src/control/cmd/dmg/firmware.go
+++ b/src/control/cmd/dmg/firmware.go
@@ -17,13 +17,13 @@ import (
 
 // firmwareOption defines a DMG option that enables firmware management in DAOS.
 type firmwareOption struct {
-	Firmware firmwareCmd `command:"firmware" alias:"fw" hidden:"true" description:"Manage the storage device firmware"`
+	Firmware firmwareCmd `command:"firmware" hidden:"true" description:"Manage the storage device firmware"`
 }
 
 // firmwareCmd defines the firmware management subcommands.
 type firmwareCmd struct {
-	Query  firmwareQueryCmd  `command:"query" alias:"q" description:"Query device firmware versions and status on DAOS storage nodes"`
-	Update firmwareUpdateCmd `command:"update" alias:"u" description:"Update the device firmware on DAOS storage nodes"`
+	Query  firmwareQueryCmd  `command:"query" description:"Query device firmware versions and status on DAOS storage nodes"`
+	Update firmwareUpdateCmd `command:"update" description:"Update the device firmware on DAOS storage nodes"`
 }
 
 // firmwareQueryCmd is used to query the storage device firmware on a set of DAOS hosts.

--- a/src/control/cmd/dmg/pool.go
+++ b/src/control/cmd/dmg/pool.go
@@ -25,21 +25,21 @@ import (
 
 // PoolCmd is the struct representing the top-level pool subcommand.
 type PoolCmd struct {
-	Create       PoolCreateCmd       `command:"create" alias:"c" description:"Create a DAOS pool"`
-	Destroy      PoolDestroyCmd      `command:"destroy" alias:"d" description:"Destroy a DAOS pool"`
-	Evict        PoolEvictCmd        `command:"evict" alias:"ev" description:"Evict all pool connections to a DAOS pool"`
+	Create       PoolCreateCmd       `command:"create" description:"Create a DAOS pool"`
+	Destroy      PoolDestroyCmd      `command:"destroy" description:"Destroy a DAOS pool"`
+	Evict        PoolEvictCmd        `command:"evict" description:"Evict all pool connections to a DAOS pool"`
 	List         PoolListCmd         `command:"list" alias:"ls" description:"List DAOS pools"`
-	Extend       PoolExtendCmd       `command:"extend" alias:"ext" description:"Extend a DAOS pool to include new ranks."`
-	Exclude      PoolExcludeCmd      `command:"exclude" alias:"e" description:"Exclude targets from a rank"`
-	Drain        PoolDrainCmd        `command:"drain" alias:"d" description:"Drain targets from a rank"`
-	Reintegrate  PoolReintegrateCmd  `command:"reintegrate" alias:"r" description:"Reintegrate targets for a rank"`
-	Query        PoolQueryCmd        `command:"query" alias:"q" description:"Query a DAOS pool"`
-	GetACL       PoolGetACLCmd       `command:"get-acl" alias:"ga" description:"Get a DAOS pool's Access Control List"`
-	OverwriteACL PoolOverwriteACLCmd `command:"overwrite-acl" alias:"oa" description:"Overwrite a DAOS pool's Access Control List"`
-	UpdateACL    PoolUpdateACLCmd    `command:"update-acl" alias:"ua" description:"Update entries in a DAOS pool's Access Control List"`
-	DeleteACL    PoolDeleteACLCmd    `command:"delete-acl" alias:"da" description:"Delete an entry from a DAOS pool's Access Control List"`
-	SetProp      PoolSetPropCmd      `command:"set-prop" alias:"sp" description:"Set pool property"`
-	GetProp      PoolGetPropCmd      `command:"get-prop" alias:"gp" description:"Get pool properties"`
+	Extend       PoolExtendCmd       `command:"extend" description:"Extend a DAOS pool to include new ranks."`
+	Exclude      PoolExcludeCmd      `command:"exclude" description:"Exclude targets from a rank"`
+	Drain        PoolDrainCmd        `command:"drain" description:"Drain targets from a rank"`
+	Reintegrate  PoolReintegrateCmd  `command:"reintegrate" alias:"reint" description:"Reintegrate targets for a rank"`
+	Query        PoolQueryCmd        `command:"query" description:"Query a DAOS pool"`
+	GetACL       PoolGetACLCmd       `command:"get-acl" description:"Get a DAOS pool's Access Control List"`
+	OverwriteACL PoolOverwriteACLCmd `command:"overwrite-acl" description:"Overwrite a DAOS pool's Access Control List"`
+	UpdateACL    PoolUpdateACLCmd    `command:"update-acl" description:"Update entries in a DAOS pool's Access Control List"`
+	DeleteACL    PoolDeleteACLCmd    `command:"delete-acl" description:"Delete an entry from a DAOS pool's Access Control List"`
+	SetProp      PoolSetPropCmd      `command:"set-prop" description:"Set pool property"`
+	GetProp      PoolGetPropCmd      `command:"get-prop" description:"Get pool properties"`
 }
 
 // PoolCreateCmd is the struct representing the command to create a DAOS pool.

--- a/src/control/cmd/dmg/storage.go
+++ b/src/control/cmd/dmg/storage.go
@@ -19,12 +19,12 @@ import (
 
 // storageCmd is the struct representing the top-level storage subcommand.
 type storageCmd struct {
-	Scan     storageScanCmd     `command:"scan" alias:"s" description:"Scan SCM and NVMe storage attached to remote servers."`
-	Format   storageFormatCmd   `command:"format" alias:"f" description:"Format SCM and NVMe storage attached to remote servers."`
-	Query    storageQueryCmd    `command:"query" alias:"q" description:"Query storage commands, including raw NVMe SSD device health stats and internal blobstore health info."`
-	Set      setFaultyCmd       `command:"set" alias:"s" description:"Manually set the device state."`
-	Replace  storageReplaceCmd  `command:"replace" alias:"r" description:"Replace a storage device that has been hot-removed with a new device."`
-	Identify storageIdentifyCmd `command:"identify" alias:"i" description:"Blink the status LED on a given VMD device for visual SSD identification."`
+	Scan     storageScanCmd     `command:"scan" description:"Scan SCM and NVMe storage attached to remote servers."`
+	Format   storageFormatCmd   `command:"format" description:"Format SCM and NVMe storage attached to remote servers."`
+	Query    storageQueryCmd    `command:"query" description:"Query storage commands, including raw NVMe SSD device health stats and internal blobstore health info."`
+	Set      setFaultyCmd       `command:"set" description:"Manually set the device state."`
+	Replace  storageReplaceCmd  `command:"replace" description:"Replace a storage device that has been hot-removed with a new device."`
+	Identify storageIdentifyCmd `command:"identify" description:"Blink the status LED on a given VMD device for visual SSD identification."`
 }
 
 // storageScanCmd is the struct representing the scan storage subcommand.
@@ -155,7 +155,7 @@ func (cmd *storageFormatCmd) printFormatResp(resp *control.StorageFormatResp) er
 
 // setFaultyCmd is the struct representing the set storage subcommand
 type setFaultyCmd struct {
-	NVMe nvmeSetFaultyCmd `command:"nvme-faulty" alias:"n" description:"Manually set the device state of an NVMe SSD to FAULTY."`
+	NVMe nvmeSetFaultyCmd `command:"nvme-faulty" description:"Manually set the device state of an NVMe SSD to FAULTY."`
 }
 
 // nvmeSetFaultyCmd is the struct representing the set-faulty storage subcommand
@@ -187,7 +187,7 @@ func (cmd *nvmeSetFaultyCmd) Execute(_ []string) error {
 
 // storageReplaceCmd is the struct representing the replace storage subcommand
 type storageReplaceCmd struct {
-	NVMe nvmeReplaceCmd `command:"nvme" alias:"n" description:"Replace an evicted/FAULTY NVMe SSD with another device."`
+	NVMe nvmeReplaceCmd `command:"nvme" description:"Replace an evicted/FAULTY NVMe SSD with another device."`
 }
 
 // nvmeReplaceCmd is the struct representing the replace nvme storage subcommand
@@ -220,7 +220,7 @@ func (cmd *nvmeReplaceCmd) Execute(_ []string) error {
 
 // storageIdentifyCmd is the struct representing the identify storage subcommand.
 type storageIdentifyCmd struct {
-	VMD vmdIdentifyCmd `command:"vmd" alias:"n" description:"Quickly blink the status LED on a VMD NVMe SSD for device identification. Duration of LED event can be configured by setting the VMD_LED_PERIOD environment variable, otherwise default is 60 seconds."`
+	VMD vmdIdentifyCmd `command:"vmd" description:"Quickly blink the status LED on a VMD NVMe SSD for device identification. Duration of LED event can be configured by setting the VMD_LED_PERIOD environment variable, otherwise default is 60 seconds."`
 }
 
 // vmdIdentifyCmd is the struct representing the identify vmd storage subcommand.

--- a/src/control/cmd/dmg/storage_query.go
+++ b/src/control/cmd/dmg/storage_query.go
@@ -60,11 +60,11 @@ func (cmd *smdQueryCmd) makeRequest(ctx context.Context, req *control.SmdQueryRe
 
 // storageQueryCmd is the struct representing the storage query subcommand
 type storageQueryCmd struct {
-	TargetHealth tgtHealthQueryCmd   `command:"target-health" alias:"t" description:"Query the target health"`
-	DeviceHealth devHealthQueryCmd   `command:"device-health" alias:"d" description:"Query the device health"`
-	ListPools    listPoolsQueryCmd   `command:"list-pools" alias:"p" description:"List pools on the server"`
-	ListDevices  listDevicesQueryCmd `command:"list-devices" alias:"d" description:"List storage devices on the server"`
-	Usage        usageQueryCmd       `command:"usage" alias:"u" description:"Show SCM & NVMe storage space utilization per storage server"`
+	TargetHealth tgtHealthQueryCmd   `command:"target-health" description:"Query the target health"`
+	DeviceHealth devHealthQueryCmd   `command:"device-health" description:"Query the device health"`
+	ListPools    listPoolsQueryCmd   `command:"list-pools" description:"List pools on the server"`
+	ListDevices  listDevicesQueryCmd `command:"list-devices" description:"List storage devices on the server"`
+	Usage        usageQueryCmd       `command:"usage" description:"Show SCM & NVMe storage space utilization per storage server"`
 }
 
 type devHealthQueryCmd struct {

--- a/src/control/cmd/dmg/system.go
+++ b/src/control/cmd/dmg/system.go
@@ -20,12 +20,12 @@ import (
 
 // SystemCmd is the struct representing the top-level system subcommand.
 type SystemCmd struct {
-	LeaderQuery leaderQueryCmd `command:"leader-query" alias:"l" description:"Query for current Management Service leader"`
-	Query       systemQueryCmd `command:"query" alias:"q" description:"Query DAOS system status"`
-	Stop        systemStopCmd  `command:"stop" alias:"s" description:"Perform controlled shutdown of DAOS system"`
-	Start       systemStartCmd `command:"start" alias:"r" description:"Perform start of stopped DAOS system"`
-	Erase       systemEraseCmd `command:"erase" alias:"e" description:"Erase system metadata prior to reformat"`
-	ListPools   PoolListCmd    `command:"list-pools" alias:"p" description:"List all pools in the DAOS system"`
+	LeaderQuery leaderQueryCmd `command:"leader-query" description:"Query for current Management Service leader"`
+	Query       systemQueryCmd `command:"query" description:"Query DAOS system status"`
+	Stop        systemStopCmd  `command:"stop" description:"Perform controlled shutdown of DAOS system"`
+	Start       systemStartCmd `command:"start" description:"Perform start of stopped DAOS system"`
+	Erase       systemEraseCmd `command:"erase" description:"Erase system metadata prior to reformat"`
+	ListPools   PoolListCmd    `command:"list-pools" description:"List all pools in the DAOS system"`
 }
 
 type leaderQueryCmd struct {


### PR DESCRIPTION
These aliases were not intuitive and were inconsistenly defined.
With tab-completion, the commands shouldn't need any aliases, but
some of the more obvious ones were left in case they are useful.