### PR TITLE
CART-89 msg: Fix error message

### DIFF
--- a/src/tests/ftest/util/test_utils_pool.py
+++ b/src/tests/ftest/util/test_utils_pool.py
@@ -848,8 +848,8 @@ class TestPool(TestDaosApiBase):
                                     "timeout can be adjusted via the "
                                     "'pool/pool_query_timeout' test yaml "
                                     "parameter.".format(
-                                        self.identifier,
-                                        self.pool_query_timeout.value)) \
+                                        self.pool_query_timeout.value,
+                                        self.identifier)) \
                                             from error
                         else:
                             raise CommandFailure(error) from error


### PR DESCRIPTION
- Fix error message which printed timeout and label in wrong order

Signed-off-by: Alexander Oganezov <alexander.a.oganezov@intel.com>