### PR TITLE
DAOS-8529 test: Allow dfuse tests to be able to run from local host

### DIFF
--- a/src/tests/ftest/io/dfuse_bash_cmd.yaml
+++ b/src/tests/ftest/io/dfuse_bash_cmd.yaml
@@ -1,8 +1,6 @@
 hosts:
   test_servers:
     - server-A
-  test_clients:
-    - client-B
 timeout: 900
 server_config:
   name: daos_server

--- a/src/tests/ftest/util/dfuse_test_base.py
+++ b/src/tests/ftest/util/dfuse_test_base.py
@@ -28,8 +28,7 @@ class DfuseTestBase(TestWithServers):
         super().setUp()
         # using localhost as client if client list is empty
         if self.hostlist_clients is None:
-            self.hostlist_clients = agu.include_local_host(
-                self.hostlist_clients)
+            self.hostlist_clients = agu.include_local_host(None)
 
     def stop_job_managers(self):
         """Stop the test job manager followed by dfuse.

--- a/src/tests/ftest/util/dfuse_test_base.py
+++ b/src/tests/ftest/util/dfuse_test_base.py
@@ -4,6 +4,7 @@
 
 SPDX-License-Identifier: BSD-2-Clause-Patent
 """
+import agent_utils as agu
 from ClusterShell.NodeSet import NodeSet
 
 from apricot import TestWithServers
@@ -12,7 +13,7 @@ from dfuse_utils import Dfuse
 
 
 class DfuseTestBase(TestWithServers):
-    """Runs HDF5 vol test suites.
+    """Runs Dfuse test suites.
 
     :avocado: recursive
     """
@@ -21,6 +22,14 @@ class DfuseTestBase(TestWithServers):
         """Initialize a TestWithServers object."""
         super().__init__(*args, **kwargs)
         self.dfuse = None
+
+    def setUp(self):
+        """Setup Test Case"""
+        super().setUp()
+        # using localhost as client if client list is empty
+        if self.hostlist_clients is None:
+            self.hostlist_clients = agu.include_local_host(
+                self.hostlist_clients)
 
     def stop_job_managers(self):
         """Stop the test job manager followed by dfuse.


### PR DESCRIPTION
Changes made to dfuse_test_base.py to allow dfuse tests to be
able to run from local host if needed.
Also modifying io/dfuse_bash_cmd.py to run from local host
instead of remote client.

Test-tag-hw-small: pr bashcmd

Signed-off-by: Saurabh Tandan <saurabh.tandan@intel.com>