### PR TITLE
DAOS-6049 csum: Improve sleeping of scrubber

### DIFF
--- a/src/include/daos_srv/vos.h
+++ b/src/include/daos_srv/vos.h
@@ -1209,15 +1209,16 @@ enum scrub_status {
 #define M_CSUM_CORRUPTION "corruption/current"
 #define M_CSUM_TOTAL_CORRUPTION "corruption/total"
 #define M_STARTED "scrubber_started"
+#define M_ENDED "scrubber_finished"
 #define M_LAST_DURATION "last_duration"
 
 #define m_inc_counter(m) d_tm_inc_counter((m), 1)
 #define m_reset_counter(m) d_tm_set_counter((m), 0)
 
 struct scrub_ctx_metrics {
-	struct d_tm_node_t *scm_pool_ult_start;
 	struct d_tm_node_t *scm_pool_ult_wait_time;
 	struct d_tm_node_t *scm_start;
+	struct d_tm_node_t *scm_end;
 	struct d_tm_node_t *scm_last_duration;
 	struct d_tm_node_t *scm_csum_calcs;
 	struct d_tm_node_t *scm_total_csum_calcs;

--- a/src/pool/srv_pool_scrub_ult.c
+++ b/src/pool/srv_pool_scrub_ult.c
@@ -101,21 +101,19 @@ cont_is_stopping_cb(void *cont)
 static void
 sc_add_pool_metrics(struct scrub_ctx *ctx)
 {
-	d_tm_add_metric(&ctx->sc_metrics.scm_pool_ult_start, D_TM_TIMESTAMP,
-			"Timestamp when the Scrubber ULT started on the "
-			"pool target",
-			NULL,  DF_POOL_DIR"/ult_start", DP_POOL_DIR(ctx));
-	d_tm_add_metric(&ctx->sc_metrics.scm_pool_ult_wait_time, D_TM_GAUGE,
-			"How long waiting between checksum calculations", "ms",
-			DF_POOL_DIR"/wait_gauge", DP_POOL_DIR(ctx));
-	d_tm_add_metric(&ctx->sc_metrics.scm_last_duration,
-			D_TM_DURATION,
-			"How long the previous scrub took", "ms",
-			DF_POOL_DIR"/"M_LAST_DURATION, DP_POOL_DIR(ctx));
 	d_tm_add_metric(&ctx->sc_metrics.scm_start,
 			D_TM_TIMESTAMP,
 			"When the current scrubbing started", NULL,
 			DF_POOL_DIR"/"M_STARTED, DP_POOL_DIR(ctx));
+	d_tm_add_metric(&ctx->sc_metrics.scm_end, D_TM_TIMESTAMP, "", "",
+			DF_POOL_DIR"/"M_ENDED, DP_POOL_DIR(ctx));
+	d_tm_add_metric(&ctx->sc_metrics.scm_pool_ult_wait_time, D_TM_GAUGE,
+			"How long waiting between checksum calculations", "ms",
+			DF_POOL_DIR"/sleep", DP_POOL_DIR(ctx));
+	d_tm_add_metric(&ctx->sc_metrics.scm_last_duration,
+			D_TM_DURATION,
+			"How long the previous scrub took", "ms",
+			DF_POOL_DIR"/"M_LAST_DURATION, DP_POOL_DIR(ctx));
 	d_tm_add_metric(&ctx->sc_metrics.scm_csum_calcs,
 			D_TM_COUNTER, "Number of checksums calculated for "
 				      "current scan",
@@ -176,7 +174,6 @@ scrubbing_ult(void *arg)
 	ctx.sc_dmi =  dss_get_module_info();
 
 	sc_add_pool_metrics(&ctx);
-	d_tm_record_timestamp(ctx.sc_metrics.scm_pool_ult_start);
 	while (!dss_ult_exiting(child->spc_scrubbing_req)) {
 		vos_scrub_pool(&ctx);
 	}

--- a/src/pool/srv_pool_scrub_ult.c
+++ b/src/pool/srv_pool_scrub_ult.c
@@ -108,34 +108,34 @@ sc_add_pool_metrics(struct scrub_ctx *ctx)
 	d_tm_add_metric(&ctx->sc_metrics.scm_pool_ult_wait_time, D_TM_GAUGE,
 			"How long waiting between checksum calculations", "ms",
 			DF_POOL_DIR"/wait_gauge", DP_POOL_DIR(ctx));
-	d_tm_add_metric(&ctx->sc_metrics.scm_pool_metrics.sm_last_duration,
+	d_tm_add_metric(&ctx->sc_metrics.scm_last_duration,
 			D_TM_DURATION,
 			"How long the previous scrub took", "ms",
 			DF_POOL_DIR"/"M_LAST_DURATION, DP_POOL_DIR(ctx));
-	d_tm_add_metric(&ctx->sc_metrics.scm_pool_metrics.sm_start,
+	d_tm_add_metric(&ctx->sc_metrics.scm_start,
 			D_TM_TIMESTAMP,
 			"When the current scrubbing started", NULL,
 			DF_POOL_DIR"/"M_STARTED, DP_POOL_DIR(ctx));
-	d_tm_add_metric(&ctx->sc_metrics.scm_pool_metrics.sm_csum_calcs,
+	d_tm_add_metric(&ctx->sc_metrics.scm_csum_calcs,
 			D_TM_COUNTER, "Number of checksums calculated for "
 				      "current scan",
 			NULL,
 			DF_POOL_DIR"/"M_CSUM_COUNTER, DP_POOL_DIR(ctx));
-	d_tm_add_metric(&ctx->sc_metrics.scm_pool_metrics.sm_last_csum_calcs,
+	d_tm_add_metric(&ctx->sc_metrics.scm_last_csum_calcs,
 			D_TM_COUNTER, "Number of checksums calculated in last "
 				      "scan", NULL,
 			DF_POOL_DIR"/"M_CSUM_PREV_COUNTER,
 			DP_POOL_DIR(ctx));
-	d_tm_add_metric(&ctx->sc_metrics.scm_pool_metrics.sm_total_csum_calcs,
+	d_tm_add_metric(&ctx->sc_metrics.scm_total_csum_calcs,
 			D_TM_COUNTER, "Total number of checksums calculated",
 			NULL,
 			DF_POOL_DIR"/"M_CSUM_TOTAL_COUNTER, DP_POOL_DIR(ctx));
-	d_tm_add_metric(&ctx->sc_metrics.scm_pool_metrics.sm_corruption,
+	d_tm_add_metric(&ctx->sc_metrics.scm_corruption,
 			D_TM_COUNTER, "Number of silent data corruption "
 				      "detected during current scan",
 			NULL,
 			DF_POOL_DIR"/"M_CSUM_CORRUPTION, DP_POOL_DIR(ctx));
-	d_tm_add_metric(&ctx->sc_metrics.scm_pool_metrics.sm_total_corruption,
+	d_tm_add_metric(&ctx->sc_metrics.scm_total_corruption,
 			D_TM_COUNTER, "Total number of silent data corruption "
 				      "detected",
 			NULL,
@@ -152,9 +152,7 @@ scrubbing_ult(void *arg)
 	struct dss_module_info	*dmi = dss_get_module_info();
 	uuid_t			 pool_uuid;
 	daos_handle_t		 poh;
-	int			 schedule;
 	int			 tgt_id;
-	int			 rc;
 
 	poh = child->spc_hdl;
 	uuid_copy(pool_uuid, child->spc_uuid);
@@ -180,20 +178,7 @@ scrubbing_ult(void *arg)
 	sc_add_pool_metrics(&ctx);
 	d_tm_record_timestamp(ctx.sc_metrics.scm_pool_ult_start);
 	while (!dss_ult_exiting(child->spc_scrubbing_req)) {
-		schedule = sc_schedule(&ctx);
-		if (schedule != DAOS_SCRUB_SCHED_OFF) {
-			rc = vos_scrub_pool(&ctx);
-			if (rc != DER_SUCCESS) {
-				D_ERROR("Scrubbing failed. "DF_RC"\n",
-					DP_RC(rc));
-				/* wait a minute before trying again */
-				sched_req_sleep(child->spc_scrubbing_req,
-						60 * 1000);
-			}
-		}
-		if (dss_ult_exiting(child->spc_scrubbing_req))
-			break;
-		sc_scrub_sched_control(&ctx);
+		vos_scrub_pool(&ctx);
 	}
 }
 

--- a/src/vos/tests/pool_scrubbing_tests.c
+++ b/src/vos/tests/pool_scrubbing_tests.c
@@ -586,8 +586,13 @@ test_yield_deletes_extent(void *arg)
 		       2, false);
 
 	rc = vos_aggregate(ctx->tsc_coh, &epr, NULL, NULL, NULL, true);
-
 	assert_success(rc);
+	/*
+	 * not totally sure why this is needed, but maybe to wait for
+	 * aggregation to finish? But without it, extent_deleted_by_aggregation
+	 * test fails with last assert_success. Is a checksum failure.
+	 */
+	sleep(1);
 
 	return 0;
 }
@@ -611,7 +616,6 @@ extent_deleted_by_aggregation(void **state)
 	/* Second (inserted by test_yield_deletes_extent) should now exist */
 	assert_success(sts_ctx_fetch(ctx, 1, TEST_IOD_ARRAY_1, "dkey",
 				     "akey", 2));
-
 }
 
 static int

--- a/src/vos/tests/scrubbing_sched_tests.c
+++ b/src/vos/tests/scrubbing_sched_tests.c
@@ -87,6 +87,9 @@ ms_between_periods_tests(void **state)
 
 	/* What should wait be if duration isn't set and periods are not set */
 	assert_ms_eq(0, 0, 0, 0, 0);
+
+	/* periods is larger than duration in seconds */
+	assert_ms_eq(908, 10, 11, 0, 1);
 }
 
 static uint32_t test_sleep_fn_call_count;

--- a/src/vos/tests/scrubbing_sched_tests.c
+++ b/src/vos/tests/scrubbing_sched_tests.c
@@ -17,80 +17,76 @@
 #include <fcntl.h>
 #include <daos/tests_lib.h>
 
-static void
-off_always_returns_0(void **state)
-{
-	struct timespec  start_time;
-
-	d_gettime(&start_time);
-
-	assert_int_equal(0, vos_scrub_wait_between_msec(DAOS_SCRUB_SCHED_OFF,
-							start_time, 0, 0));
-	assert_int_equal(0, vos_scrub_wait_between_msec(DAOS_SCRUB_SCHED_OFF,
-							start_time, 100, 100));
-
-}
+#define assert_ms_eq(exp, duration, periods, curr, elapsed_ns) do {  \
+	struct timespec start;                                       \
+	struct timespec elapsed;                                     \
+	d_gettime(&start); elapsed = start;                          \
+	d_timeinc(&elapsed, elapsed_ns);                             \
+	assert_int_equal(exp,                                        \
+		get_ms_between_periods(start, elapsed, duration,     \
+		periods, curr));                                     \
+	} while (false)
 
 static void
-wait_always_returns_0(void **state)
+ms_between_periods_tests(void **state)
 {
-	struct timespec  start_time;
+#define ONE_SECOND_NS (1e+9)
+#define HALF_SECOND_NS (5e+8)
 
-	d_gettime(&start_time);
-
-	assert_int_equal(0,
-			 vos_scrub_wait_between_msec(DAOS_SCRUB_SCHED_RUN_WAIT,
-						     start_time, 0, 0));
-	assert_int_equal(0,
-			 vos_scrub_wait_between_msec(DAOS_SCRUB_SCHED_RUN_WAIT,
-						     start_time, 100, 100));
-}
-
-#define assert_continuous(expected, st, csum_count, freq) \
-	assert_int_equal(expected, \
-		vos_scrub_wait_between_msec(DAOS_SCRUB_SCHED_CONTINUOUS, \
-				st, csum_count, freq))
-static void
-continuous_start_now_calcs_ms(void **state)
-{
-	struct timespec  st;
-
-	d_gettime(&st);
-	/* basic math for these is:
-	 * ```freq_sec * 1000 (convert to ms) / last csum count```
-	 * Plug in different numbers for freq and last csum count to see
-	 * expected values. Make freq big and last csum count small, vice versa,
-	 * how are really large values handled ...
-	 *
-	 * All these tests have a start time of now.
+	/*
+	 * ---------------------------------------------------------
+	 * assert_ms_eq takes the following values in this order:
+	 * Expected, duration, periods, current period, elapsed ns
+	 * ---------------------------------------------------------
 	 */
-	assert_continuous(1000, st, 10, 10);
-	assert_continuous(500, st, 10, 5);
-	assert_continuous(1, st, 10000, 10);
-	assert_continuous(0, st, 10001, 10); /* can't sleep less than 1 ms */
-	assert_continuous(2419200, st, 250, 3600 * 24 * 7); /* 7 days */
-	assert_continuous(2419200, st, 250, 3600 * 24 * 7); /* 7 days */
-	/* infinite (almost) */
-	assert_continuous(UINT64_MAX / 100, st, 100, UINT64_MAX);
-}
 
-static void
-continuous_start_10_sec_ago_calcs_ms(void **state)
-{
-	struct timespec  st;
-
-	d_gettime(&st);
-	st.tv_sec -= 10;
-
-	/* ten seconds have passed an freq is 10 seconds, so should not wait
-	 * any longer in between checksums
+	/*
+	 * First period, no time has elapsed, total of 10 periods in 10 seconds.
+	 * Should be 1 second.
 	 */
-	assert_continuous(0, st, 10, 10);
-	assert_continuous(500, st, 10, 15); /* 5 seconds left */
+	assert_ms_eq(1000, 10, 10, 0, 0);
 
-	st.tv_sec -= 10000;
-	/* Should have finished a long time ago */
-	assert_continuous(0, st, 10, 15);
+	/*
+	 * With 10 periods and 10 second duration, then each period should
+	 * take 1 second.
+	 * if half a second has elapsed already for the first period, then only
+	 * need to wait another half second
+	 */
+	assert_ms_eq(500, 10, 10, 0, HALF_SECOND_NS);
+
+
+	/*
+	 * With 10 periods and 10 second duration, then each period should
+	 * take 1 second.
+	 * if one second (or more) has elapsed already for the first period,
+	 * then shouldn't wait at all
+	 */
+	assert_ms_eq(0, 10, 10, 0, ONE_SECOND_NS);
+	assert_ms_eq(0, 10, 10, 0, ONE_SECOND_NS + HALF_SECOND_NS);
+
+	/*
+	 * With 10 periods and 10 second duration, then each period should
+	 * take 1 second.
+	 * if one and a half second has elapsed and in the second period,
+	 * then should wait half a second
+	 */
+	assert_ms_eq(500, 10, 10, 1, ONE_SECOND_NS + HALF_SECOND_NS);
+
+	/*
+	 * Multiple tests with 5 periods into a 10 second duration
+	 */
+	assert_ms_eq(2000, 10, 5, 0, 0);
+	assert_ms_eq(1750, 10, 5, 0, HALF_SECOND_NS / 2);
+	assert_ms_eq(3750, 10, 5, 1, HALF_SECOND_NS / 2);
+
+	/* No time has elapsed, but already done with all periods, plus
+	 * some. Should wait full 10 seconds now, but not more
+	 */
+	assert_ms_eq(10000, 10, 5, 6, 0);
+	assert_ms_eq(10000, 10, 5, 100, 0);
+
+	/* What should wait be if duration isn't set and periods are not set */
+	assert_ms_eq(0, 0, 0, 0, 0);
 }
 
 static uint32_t test_sleep_fn_call_count;
@@ -174,9 +170,16 @@ free_ctx(struct scrub_ctx *ctx)
 	D_FREE(ctx->sc_pool);
 }
 
-void run_sched_control(struct scrub_ctx *ctx)
+static void
+run_yield_or_sleep_while_running(struct scrub_ctx *ctx)
 {
-	sc_scrub_sched_control(ctx);
+	sc_yield_sleep_while_running(ctx);
+}
+
+static void
+run_yield_or_sleep(struct scrub_ctx *ctx)
+{
+	sc_yield_or_sleep(ctx);
 }
 
 static void
@@ -193,13 +196,13 @@ when_sched_run_wait_credits_are_consumed__should_yield(void **state)
 		.tst_scrub_cred = orig_credits
 	});
 
-	run_sched_control(&ctx);
+	run_yield_or_sleep_while_running(&ctx);
 	/* don't yield until all credits are consumed */
 	assert_int_equal(1, ctx.sc_credits_left);
 	assert_int_equal(0, test_yield_fn_call_count);
 
 	/* credits are consumed */
-	run_sched_control(&ctx);
+	run_yield_or_sleep_while_running(&ctx);
 	/* yielded and reset credits */
 	assert_int_equal(1, test_yield_fn_call_count);
 	assert_int_equal(orig_credits, ctx.sc_credits_left);
@@ -227,13 +230,13 @@ each_schedule__credits_are_consumed_and_wrap(void **state)
 			.tst_already_run_sec = 0,
 		});
 
-		run_sched_control(&ctx);
+		run_yield_or_sleep_while_running(&ctx);
 		assert_int_equal(2, ctx.sc_credits_left);
 
-		run_sched_control(&ctx);
+		run_yield_or_sleep_while_running(&ctx);
 		assert_int_equal(1, ctx.sc_credits_left);
 
-		run_sched_control(&ctx);
+		run_yield_or_sleep_while_running(&ctx);
 		assert_int_equal(3, ctx.sc_credits_left);
 
 		free_ctx(&ctx);
@@ -254,23 +257,20 @@ when_sched_continuous_credits_1__sleeps_and_yield_appropriately(void **state)
 		.tst_scrub_freq_sec = 10,
 		});
 
-	run_sched_control(&ctx);
+	run_yield_or_sleep_while_running(&ctx);
 	assert_int_equal(1, test_sleep_fn_call_count);
-	assert_int_equal(1000, test_sleep_fn_msec);
 
 	/* simulate 1 second passing and 1 csum calculated */
 	ctx.sc_pool_start_scrub.tv_sec--;
 	ctx.sc_pool_csum_calcs++;
-	run_sched_control(&ctx);
+	run_yield_or_sleep_while_running(&ctx);
 	assert_int_equal(2, test_sleep_fn_call_count);
-	assert_int_equal(1000, test_sleep_fn_msec);
 
 	/* simulate 1 second passing and 1 csum calculated */
 	ctx.sc_pool_start_scrub.tv_sec--;
 	ctx.sc_pool_csum_calcs++;
-	run_sched_control(&ctx);
+	run_yield_or_sleep_while_running(&ctx);
 	assert_int_equal(3, test_sleep_fn_call_count);
-	assert_int_equal(1000, test_sleep_fn_msec);
 
 	/*
 	 * simulate 1 minute passing and still going (even though have
@@ -278,7 +278,7 @@ when_sched_continuous_credits_1__sleeps_and_yield_appropriately(void **state)
 	 */
 	ctx.sc_pool_start_scrub.tv_sec -= 60;
 	ctx.sc_pool_csum_calcs += 100;
-	run_sched_control(&ctx);
+	run_yield_or_sleep_while_running(&ctx);
 	assert_int_equal(3, test_sleep_fn_call_count);
 	assert_int_equal(1, test_yield_fn_call_count);
 
@@ -299,7 +299,7 @@ when_sched_continuous_have_run_half_freq__should_sleep(void **state)
 		.tst_scrub_status = SCRUB_STATUS_NOT_RUNNING
 		});
 
-	run_sched_control(&ctx);
+	run_yield_or_sleep(&ctx);
 	/*
 	 * Should sleep 5 seconds because half way through the 10
 	 * second frequency
@@ -322,30 +322,11 @@ when_sched_continuous_past_freq__should_yield(void **state)
 		.tst_scrub_status = SCRUB_STATUS_NOT_RUNNING
 		});
 
-	run_sched_control(&ctx);
+	run_yield_or_sleep(&ctx);
 
 	assert_int_equal(0, test_sleep_fn_msec);
 	assert_int_equal(0, test_sleep_fn_call_count);
 	assert_int_equal(1, test_yield_fn_call_count);
-
-	free_ctx(&ctx);
-}
-
-/* By default, the ULT should sleep 5 seconds if the schedule is off before
- * checking again.
- */
-static void
-when_sched_off__should_sleep_5_sec(void **state)
-{
-	struct scrub_ctx	ctx = {0};
-
-	INIT_CTX_FOR_TESTS(&ctx, {
-		.tst_scrub_sched = DAOS_SCRUB_SCHED_OFF,
-		.tst_scrub_status = SCRUB_STATUS_NOT_RUNNING
-		});
-
-	run_sched_control(&ctx);
-	assert_int_equal(1000 * 5, test_sleep_fn_msec);
 
 	free_ctx(&ctx);
 }
@@ -364,19 +345,13 @@ static int scrub_test_setup(void **state)
 #define TS(x) { "SCRUB_SCHED_" STR(__COUNTER__) ": " #x, x, scrub_test_setup, \
 		NULL, NULL }
 
-static const struct CMUnitTest wait_between_tests[] = {
-	TS(off_always_returns_0),
-	TS(when_sched_off__should_sleep_5_sec),
-	TS(wait_always_returns_0),
-	TS(continuous_start_now_calcs_ms),
-	TS(continuous_start_10_sec_ago_calcs_ms),
-};
-
 static const struct CMUnitTest scrubbing_sched_tests[] = {
+	TS(ms_between_periods_tests),
 	TS(when_sched_run_wait_credits_are_consumed__should_yield),
 	TS(each_schedule__credits_are_consumed_and_wrap),
 	TS(when_sched_continuous_credits_1__sleeps_and_yield_appropriately),
 	TS(when_sched_continuous_have_run_half_freq__should_sleep),
+	TS(when_sched_continuous_past_freq__should_yield),
 	TS(when_sched_continuous_past_freq__should_yield),
 };
 
@@ -385,10 +360,6 @@ run_scrubbing_sched_tests()
 {
 	int rc = 0;
 
-	rc += cmocka_run_group_tests_name(
-		"Test calculations and logic for how long to wait when credits "
-		"are consumed.",
-		wait_between_tests, NULL, NULL);
 	rc += cmocka_run_group_tests_name(
 		"Test logic for how the schedule is controlled (sleeping vs "
 		"yield) based on schedules, where at in scrubbing process, etc",


### PR DESCRIPTION
This is an enhancement to PR-6410 that was recently landed. It has
some cleanup and fixes some issues when there is only a single item
to scrub. Also,
- Removed extra layer of structs for metrics. Should have done
  this when removed container metrics.
- Moved more of the schedule flow out of the ULT code.

Signed-off-by: Ryon Jensen <ryon.jensen@intel.com>