### PR TITLE
DAOS-7313 Test: Add EC Failure test cases with Aggregation.

### DIFF
--- a/src/tests/ftest/erasurecode/ec_offline_rebuild_aggregation.py
+++ b/src/tests/ftest/erasurecode/ec_offline_rebuild_aggregation.py
@@ -1,0 +1,134 @@
+#!/usr/bin/python
+'''
+  (C) Copyright 2020-2021 Intel Corporation.
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+'''
+from ec_utils import ErasureCodeIor, check_aggregation_status
+
+class EcodAggregationOffRebuild(ErasureCodeIor):
+    # pylint: disable=too-many-ancestors
+    """
+    Test Class Description: To validate Erasure code object for offline rebuild
+                        with different Aggregation mode for Partial strip data.
+    :avocado: recursive
+    """
+    def test_ec_offline_rebuild_agg_disabled(self):
+        """Jira ID: DAOS-7313.
+
+        Test Description: Test Erasure code object aggregation disabled mode
+                          with IOR.
+        Use Case: Create the pool, disabled aggregation, run IOR with supported
+                  EC object type with partial strip.
+                  Verify that Aggregation should not triggered.
+                  Verify the IOR read data at the end.
+                  Kill single server and wait for rebuild.
+                  Read and verify all the data.
+                  Kill second server and wait for rebuild.
+                  Read and verify data with +2 Parity with no data corruption.
+
+        :avocado: tags=all,full_regression
+        :avocado: tags=hw,large,ib2
+        :avocado: tags=ec,aggregation,ec_array,ec_aggregation
+        :avocado: tags=ec_offline_rebuild_agg_disabled
+        """
+        # Disable the aggregation
+        self.pool.set_property("reclaim", "disabled")
+        self.pool.connect()
+        print("pool_percentage Before = {} ".format(
+            self.pool.pool_percentage_used()))
+
+        # Write the IOR data set with given all the EC object type
+        self.ior_write_dataset()
+
+        # Verify if Aggregation is getting started
+        if any(check_aggregation_status(self.pool).values()) is True:
+            self.fail("Aggregation should not happens...")
+
+        # Read IOR data and verify content
+        self.ior_read_dataset()
+
+        # Kill the last server rank
+        self.server_managers[0].stop_ranks([self.server_count - 1], self.d_log,
+                                           force=True)
+
+        # Wait for rebuild to complete
+        self.pool.wait_for_rebuild(False)
+
+        # Read IOR data and verify for different EC object data still OK
+        # written before killing the single server
+        self.ior_read_dataset()
+
+        # Kill the another server rank
+        self.server_managers[0].stop_ranks([self.server_count - 2], self.d_log,
+                                           force=True)
+
+        # Wait for rebuild to complete
+        self.pool.wait_for_rebuild(False)
+
+        # Read IOR data and verify for different EC object and different sizes
+        # written before killing the second server.
+        # Only +2 (Parity) data will be intact so read and verify only +2 IOR
+        # data set
+        self.ior_read_dataset(parity=2)
+
+    def test_ec_offline_rebuild_agg_default(self):
+        """Jira ID: DAOS-7313.
+
+        Test Description: Test Erasure code object aggregation enabled(default)
+                          mode with IOR.
+        Use Case: Create the pool, run IOR with supported
+                  EC object type classes. Verify the Aggregation gets
+                  triggered and space is getting reclaimed.
+                  Verify the IOR read data at the end.
+        Use Case: Create the pool, disabled aggregation, run IOR with supported
+                  EC object type with partial strip.
+                  Verify the Aggregation gets triggered and space is getting
+                  reclaimed. Verify the IOR read data at the end.
+                  Kill single server and wait for rebuild.
+                  Read and verify all the data.
+                  Kill second server and wait for rebuild.
+                  Read and verify data with +2 Parity with no data corruption.
+
+        :avocado: tags=all,full_regression
+        :avocado: tags=hw,large,ib2
+        :avocado: tags=ec,aggregation,ec_array,ec_aggregation
+        :avocado: tags=ec_offline_rebuild_agg_default
+        """
+        self.pool.connect()
+        print("pool_percentage Before = {} ".format(
+            self.pool.pool_percentage_used()))
+
+        # Write the IOR data set with given all the EC object type
+        self.ior_write_dataset()
+
+        # Verify if Aggregation is getting started
+        if not any(check_aggregation_status(self.pool).values()):
+            self.fail("Aggregation failed to start..")
+
+        # Read IOR data and verify content
+        self.ior_read_dataset()
+
+        # Kill the last server rank
+        self.server_managers[0].stop_ranks([self.server_count - 1], self.d_log,
+                                           force=True)
+
+        # Wait for rebuild to complete
+        self.pool.wait_for_rebuild(False)
+
+        # Read IOR data and verify for different EC object data still OK
+        # written before killing the single server
+        self.ior_read_dataset()
+
+        # Kill the another server rank
+        self.server_managers[0].stop_ranks([self.server_count - 2], self.d_log,
+                                           force=True)
+
+        # Wait for rebuild to complete
+        self.pool.wait_for_rebuild(False)
+
+        # Read IOR data and verify for different EC object and different sizes
+        # written before killing the second server.
+        # Only +2 (Parity) data will be intact so read and verify only +2 IOR
+        # data set
+        self.ior_read_dataset(parity=2)

--- a/src/tests/ftest/erasurecode/ec_offline_rebuild_aggregation.yaml
+++ b/src/tests/ftest/erasurecode/ec_offline_rebuild_aggregation.yaml
@@ -1,0 +1,72 @@
+hosts:
+  test_servers:
+    - server-A
+    - server-B
+    - server-C
+    - server-D
+    - server-E
+  test_clients:
+    - client-A
+    - client-B
+    - client-C
+timeout: 3000
+setup:
+  start_agents_once: False
+  start_servers_once: False
+server_config:
+  engines_per_host: 2
+  name: daos_server
+  servers:
+    0:
+      pinned_numa_node: 0
+      nr_xs_helpers: 1
+      fabric_iface: ib0
+      fabric_iface_port: 31416
+      log_file: daos_server0.log
+      bdev_class: nvme
+      bdev_list: ["aaaa:aa:aa.a"]
+      scm_class: dcpm
+      scm_list: ["/dev/pmem0"]
+      scm_mount: /mnt/daos0
+    1:
+      pinned_numa_node: 1
+      nr_xs_helpers: 1
+      fabric_iface: ib1
+      fabric_iface_port: 31517
+      log_file: daos_server1.log
+      bdev_class: nvme
+      bdev_list: ["bbbb:bb:bb.b"]
+      scm_class: dcpm
+      scm_list: ["/dev/pmem1"]
+      scm_mount: /mnt/daos1
+pool:
+    mode: 146
+    name: daos_server
+    scm_size: 95%
+    nvme_size: 90%
+    control_method: dmg
+    pool_query_timeout: 30
+container:
+    type: POSIX
+    control_method: daos
+ior:
+  api: "DFS"
+  client_processes:
+   np: 48
+  dfs_destroy: False
+  iorflags:
+   flags: "-w -W -F -k -G 1 -vv"
+   read_flags: "-r -R -F -k -G 1 -vv"
+  test_file: /testFile
+  repetitions: 1
+  chunk_block_transfer_sizes:
+   #[ChunkSize, BlocksSize, TransferSize]
+   - [8MB, 16MB, 128]
+   - [1MB, 8MB, 1M]
+  objectclass:
+   dfs_oclass_list:
+    #[EC_Object_Class, Minimum number of servers]
+    - ["EC_2P1G1", 4]
+    - ["EC_4P1G1", 6]
+    - ["EC_4P2G1", 6]
+    - ["EC_8P2G1", 10]

--- a/src/tests/ftest/erasurecode/ec_rebuild_disabled.py
+++ b/src/tests/ftest/erasurecode/ec_rebuild_disabled.py
@@ -5,7 +5,7 @@
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
 import time
-from ec_utils import ErasureCodeIor
+from ec_utils import ErasureCodeIor, check_aggregation_status
 
 class EcodDisabledRebuild(ErasureCodeIor):
     # pylint: disable=too-many-ancestors
@@ -35,6 +35,10 @@ class EcodDisabledRebuild(ErasureCodeIor):
 
         # Write the IOR data set with given all the EC object type
         self.ior_write_dataset()
+
+        # Verify if Aggregation is getting started
+        if not any(check_aggregation_status(self.pool).values()):
+            self.fail("Aggregation failed to start..")
 
         # Kill the last server rank and wait for 20 seconds, Rebuild is disabled
         # so data should not be rebuild


### PR DESCRIPTION
 - Adding EC test case to do partial strip IO and check if Aggregation
   is getting triggered.Later fail server for an offline rebuild and verify the data.
 - Updated existing test rebuild disabled to check the Aggregation after write.

Quick-Functional: true
Skip-func-hw-test-small: true
Skip-func-hw-test-medium: true
Test-tag-hw-large: pr ec_disabled_rebuild_array ec_offline_rebuild_agg_default ec_offline_rebuild_agg_disabled

Signed-off-by: Samir Raval <samir.raval@intel.com>