### PR TITLE
DAOS-8517 vos: Fix a missing PMDK setting

### DIFF
--- a/src/vos/vos_common.c
+++ b/src/vos/vos_common.c
@@ -440,6 +440,12 @@ vos_mod_init(void)
 	if (vos_start_epoch == DAOS_EPOCH_MAX)
 		vos_start_epoch = crt_hlc_get();
 
+	rc = vos_pool_settings_init();
+	if (rc != 0) {
+		D_ERROR("VOS pool setting initialization error\n");
+		return rc;
+	}
+
 	rc = vos_cont_tab_register();
 	if (rc) {
 		D_ERROR("VOS CI btree initialization error\n");
@@ -575,12 +581,6 @@ vos_self_init(const char *db_path)
 	if (self_mode.self_ref) {
 		self_mode.self_ref++;
 		D_GOTO(out, rc);
-	}
-
-	rc = vos_pool_settings_init();
-	if (rc != 0) {
-		D_MUTEX_UNLOCK(&self_mode.self_lock);
-		return rc;
 	}
 
 	rc = ABT_init(0, NULL);


### PR DESCRIPTION
vos_pool_settings_init is not called in the daos_engine use case,
causing the following error when creating many DAOS pools (see
DAOS-6505):

  vos  ERR  src/vos/vos_pool.c:281 vos_pool_create() Failed to create
    pool /dev/shm/NEWBORNS/d90bf88f-bbbe-43f7-910d-4a5030e93b39/vos-0,
    size=0: pool initialization failed
  mgmt ERR  src/mgmt/srv_target.c:470 tgt_vos_create_one() d90bf88f:
    failed to init vos pool
    /dev/shm/NEWBORNS/d90bf88f-bbbe-43f7-910d-4a5030e93b39/vos-0: -1013
  ... [retries]

This patch moves the call from vos_self_init to vos_mod_init, so that
both the daos_engine case and the standalone case will be covered.

Signed-off-by: Li Wei <wei.g.li@intel.com>