### PR TITLE
DAOS-8410 tests: Fix network/zero_config.py

### DIFF
--- a/src/tests/ftest/network/zero_config.py
+++ b/src/tests/ftest/network/zero_config.py
@@ -58,11 +58,11 @@ class ZeroConfigTest(TestWithServers):
         results = run_pcmd(self.hostlist_servers, command)
         try:
             if results[0]["exit_status"] == 0:
-                regex = r"\.\d+\s+(mlx\d_\d)\s+net-(ib\d)\s+(\d)"
+                regex = r"(mlx\d_\d)\s+net-(ib\d)\s+(\d)"
                 for match in re.findall(regex, "\n".join(results[0]["stdout"])):
-                    self.dev_info[match[1]]["numa"] = match[2]
+                    self.dev_info[match[1]]["numa"] = int(match[2])
                     self.dev_info[match[1]]["domain"] = match[0]
-        except (IndexError, KeyError) as error:
+        except (IndexError, KeyError, ValueError) as error:
             self.log.error("Error obtaining interfaces: %s", str(error))
             self.fail("Error obtaining interfaces - unexpected error")
 

--- a/src/tests/ftest/network/zero_config.py
+++ b/src/tests/ftest/network/zero_config.py
@@ -54,7 +54,7 @@ class ZeroConfigTest(TestWithServers):
         #   DEVICE_TYPE        MST   PCI       RDMA     NET       NUMA
         #   ConnectX6(rev:0)   NA    86:00.0   mlx5_1   net-ib1   1
         #   ConnectX6(rev:0)   NA    37:00.0   mlx5_0   net-ib0   0
-        command = "mst status -v"
+        command = "sudo mst status -v"
         results = run_pcmd(self.hostlist_servers, command)
         try:
             if results[0]["exit_status"] == 0:

--- a/src/tests/ftest/network/zero_config.py
+++ b/src/tests/ftest/network/zero_config.py
@@ -84,7 +84,7 @@ class ZeroConfigTest(TestWithServers):
         for interface in self.interfaces:
             # Check the port counter for each interface on all of the hosts
             counter_file = os.path.join(
-                os.sep, "sys", "class", "infiniband", self.interfaces[interface]["doamin"], "ports",
+                os.sep, "sys", "class", "infiniband", self.interfaces[interface]["domain"], "ports",
                 "1", "counters", port_counter)
             check_result = check_file_exists(hosts, counter_file)
             if not check_result[0]:

--- a/src/tests/ftest/network/zero_config.py
+++ b/src/tests/ftest/network/zero_config.py
@@ -32,11 +32,8 @@ class ZeroConfigTest(TestWithServers):
         self.dev_info = {}
         self.start_agents_once = False
         self.start_servers_once = False
-
-    def setUp(self):
-        """Set up for zero-config test."""
         self.setup_start_servers = False
-        super().setUp()
+        self.setup_start_agents = False
 
     def get_device_info(self):
         """Get the available device names, their numa nodes, and their domains."""
@@ -210,13 +207,7 @@ class ZeroConfigTest(TestWithServers):
         exp_iface = random.choice(list(self.dev_info.keys()))
 
         # Configure the daos server
-        self.add_server_manager()
-        self.configure_manager(
-            "server",
-            self.server_managers[0],
-            self.hostlist_servers,
-            self.hostfile_servers_slots,
-            self.access_points)
+        self.setup_servers()
         self.assertTrue(
             self.server_managers[0].set_config_value(
                 "fabric_iface", exp_iface),
@@ -228,7 +219,7 @@ class ZeroConfigTest(TestWithServers):
 
         # Start the daos server and daos agents
         self.start_server_managers()
-        self.start_agent_managers()
+        self.start_agents()
         self.write_string_to_logfile('"Test.name: ' + str(self) + '"')
 
         # Verify

--- a/src/tests/ftest/network/zero_config.py
+++ b/src/tests/ftest/network/zero_config.py
@@ -38,11 +38,12 @@ class ZeroConfigTest(TestWithServers):
     def get_device_info(self):
         """Get the available device names, their numa nodes, and their domains."""
         self.dev_info = {}
-        command = "ls -1 {}".format(os.path.join(os.path.sep, "sys", "class", "net", "ib*"))
+        command = "ls -1 {}".format(os.path.join(os.path.sep, "sys", "class", "net"))
         results = run_pcmd(self.hostlist_servers, command)
         if len(results) != 1:
             self.fail("Error obtaining interfaces - non-homogeneous config")
         try:
+            # Find any ib* device in the listing and initially use default numa and domain values
             for index, interface in enumerate(re.findall(r"ib\d", "\n".join(results[0]["stdout"]))):
                 self.dev_info[interface] = {"numa": index, "domain": "hfi1_{}".format(index)}
         except (IndexError, KeyError) as error:

--- a/src/tests/ftest/network/zero_config.py
+++ b/src/tests/ftest/network/zero_config.py
@@ -90,7 +90,7 @@ class ZeroConfigTest(TestWithServers):
             if not check_result[0]:
                 self.fail("{}: {} not found".format(check_result[1], counter_file))
             all_host_data = get_host_data(
-                hosts, "cat {}".format(counter_file), "port_counter",
+                hosts, "cat {}".format(counter_file), "{} port_counter".format(interface),
                 "Error obtaining {} info".format(port_counter), 20)
             port_info[interface] = {}
             for host_data in all_host_data:
@@ -177,7 +177,7 @@ class ZeroConfigTest(TestWithServers):
         port_info_after = self.get_port_cnt(clients, "port_rcv_data")
 
         self.log.info("Client interface port_rcv_data counters")
-        msg_format = "%16s  %9s  %-9s  %-9s %-9s"
+        msg_format = "%16s  %9s  %9s  %9s  %s"
         self.log.info(msg_format, "Host(s)", "Interface", "Before", "After", "Difference")
         self.log.info(msg_format, "-" * 16, "-" * 9, "-" * 9, "-" * 9, "-" * 9)
         no_traffic = set()
@@ -186,12 +186,12 @@ class ZeroConfigTest(TestWithServers):
                 before = port_info_before[interface][host][1]["port_rcv_data"]
                 try:
                     after = port_info_after[interface][host][1]["port_rcv_data"]
-                    diff = after - before
+                    diff = int(after) - int(before)
                     if diff <= 0:
                         no_traffic.add(interface)
-                except KeyError:
+                except (KeyError, ValueError) as error:
                     after = "Error"
-                    diff = "Unknown"
+                    diff = "Unknown - {}".format(error)
                     no_traffic.add(interface)
                 self.log.info(msg_format, host, interface, before, after, diff)
 

--- a/src/tests/ftest/network/zero_config.py
+++ b/src/tests/ftest/network/zero_config.py
@@ -217,10 +217,18 @@ class ZeroConfigTest(TestWithServers):
                 "pinned_numa_node", self.dev_info[exp_iface]["numa"]),
             "Error updating daos_server 'pinned_numa_node' config opt")
 
-        # Start the daos server and daos agents
+        # Start the daos server
         self.start_server_managers()
-        self.start_agents()
+
+        # Start the daos agents - do not start an agent on the local host
+        agent_groups = {
+            self.server_group: {
+                "hosts": self.hostlist_clients,
+                "access_points": self.access_points}
+        }
+        self.start_agents(agent_groups)
         self.write_string_to_logfile('"Test.name: ' + str(self) + '"')
+        self.log.info("-" * 100)
 
         # Verify
         if not self.verify_client_run(exp_iface, env_state):


### PR DESCRIPTION
Updating the network/zero_config.py test to run on clusters with
Mellanox hardware.

Quick-Functional: true
Test-tag: zero_config

Signed-off-by: Phillip Henderson <phillip.henderson@intel.com>