### PR TITLE
CART-89 test: Add 1 second delay on retry to wait for ranks

### DIFF
--- a/src/cart/crt_utils.c
+++ b/src/cart/crt_utils.c
@@ -278,6 +278,9 @@ crtu_wait_for_ranks(crt_context_t ctx, crt_group_t *grp,
 			rc = d_gettime(&t2);
 			D_ASSERTF(rc == 0, "d_gettime() failed; rc=%d\n", rc);
 			time_s = d_time2s(d_timediff(t1, t2));
+
+			if (ws.rc != 0 && time_s < total_timeout)
+				sleep(1);
 		}
 
 		if (ws.rc != 0) {


### PR DESCRIPTION
- When crtu_wait_for_ranks() fails to ping a rank, add 1 second
delay between retries.

Signed-off-by: Alexander Oganezov <alexander.a.oganezov@intel.com>