### PR TITLE
DAOS-8357 test: Adding pool metric verification test

### DIFF
--- a/src/tests/ftest/SConscript
+++ b/src/tests/ftest/SConscript
@@ -16,7 +16,8 @@ def scons():
             'mdtest', 'network', 'nvme',
             'object', 'osa', 'pool', 'rebuild', 'security',
             'server', 'soak', 'unittest', 'erasurecode',
-            'datamover', 'scripts', 'dbench', 'harness']
+            'datamover', 'scripts', 'dbench', 'harness',
+            'telemetry']
 
     for sub_dir in dirs:
         env.Install(os.path.join(ftest_install_dir, sub_dir),

--- a/src/tests/ftest/telemetry/telemetry_pool_metrics.py
+++ b/src/tests/ftest/telemetry/telemetry_pool_metrics.py
@@ -132,7 +132,7 @@ class TelemetryPoolMetrics(IorTestBase, TestWithTelemetry):
             and for RF=2 (with RP_2GX) sum should be double the size of
             workload for write but same for read.
         :avocado: tags=all,daily_regression
-        :avocado: tags=hw,small
+        :avocado: tags=hw,medium,ib2
         :avocado: tags=telemetry
         :avocado: tags=telemetry_pool_metrics
 

--- a/src/tests/ftest/telemetry/telemetry_pool_metrics.py
+++ b/src/tests/ftest/telemetry/telemetry_pool_metrics.py
@@ -132,7 +132,7 @@ class TelemetryPoolMetrics(IorTestBase, TestWithTelemetry):
             and for RF=2 (with RP_2GX) sum should be double the size of
             workload for write but same for read.
         :avocado: tags=all,daily_regression
-        :avocado: tags=hw,medium,ib2
+        :avocado: tags=vm
         :avocado: tags=telemetry
         :avocado: tags=telemetry_pool_metrics
 

--- a/src/tests/ftest/telemetry/telemetry_pool_metrics.py
+++ b/src/tests/ftest/telemetry/telemetry_pool_metrics.py
@@ -1,0 +1,173 @@
+#!/usr/bin/python
+"""
+  (C) Copyright 2018-2021 Intel Corporation.
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+"""
+import re
+
+from avocado.core.exceptions import TestFail
+from ior_test_base import IorTestBase
+from telemetry_test_base import TestWithTelemetry
+
+
+class TelemetryPoolMetrics(IorTestBase, TestWithTelemetry):
+    # pylint: disable=too-many-ancestors
+    # pylint: disable=too-many-nested-blocks
+    """Test telemetry pool basic metrics.
+
+    :avocado: recursive
+    """
+
+    def check_range(self, expected_value, actual_value, threshold_percent):
+        """Check if actual value is within expected
+           range of expected value
+        Args:
+          expected_value: Provide expected value to be checked against
+          actual_value: Provide the actual value to be checked
+          threshold_percent: Threshold percentage for acceptable range
+
+        Return:
+          bool: Returns boolean value depending of the check. Returns
+                True if the value is within range, else False.
+
+        """
+        # Calculate the lower and upper bound values
+        upper_bound = (expected_value +
+                       (threshold_percent / 100 * expected_value))
+        lower_bound = (expected_value -
+                       (threshold_percent / 100 * expected_value))
+        self.log.debug("Lower Bound: %s", lower_bound)
+        self.log.debug("Actual Value: %s", actual_value)
+        self.log.debug("Upper Bound: %s", upper_bound)
+        # Check if the actual value is within range
+        if lower_bound <= actual_value <= upper_bound:
+            return True
+
+        return False
+
+    def verify_pool_metrics(self, pool_metrics_list, metrics_data,
+                            expected_values):
+        """ Verify telemetry pool metrics from metrics_data.
+
+        Args:
+            pool_metrics_list (list): list of telemetry pool metrics.
+            metrics_data (dict): a dictionary of host keys linked to a
+                                 list of pool metric names. Contains
+                                 data before and after read/write.
+            expected_values (list): List of expected values for different
+                                    pool metrics.
+
+        """
+        # initializing method params
+        total = []
+        final_value = []
+        # collecting data to be verified
+        for name in sorted(pool_metrics_list):
+            self.log.debug("  --telemetry metric: %s", name)
+            for key in sorted(metrics_data):
+                m_data = metrics_data[key]
+                total.append(0)
+                total[key] = 0
+                for host in sorted(m_data[name]):
+                    for rank in sorted(m_data[name][host]):
+                        for target in sorted(m_data[name][host][rank]):
+                            value = m_data[name][host][rank][target]
+                            # collecting total value for all targets
+                            total[key] = total[key] + value
+            # subtracting the total value after read/write from total value
+            # before read/write
+            final_value.append(total[1] - total[0])
+            # performing verification now
+            if "xferred" in name:
+                # check if oclass has any replication and get the replication
+                # numeric value, else use 1.
+                if True in [char.isdigit() for char in
+                            self.ior_cmd.dfs_oclass.value]:
+                    replication = re.search(
+                        r'\d+', self.ior_cmd.dfs_oclass.value).group()
+                else:
+                    replication = 1
+                # multiply the written amount by replication number
+                # to get total expected written amount for only
+                # write operation.
+                if "update" in name:
+                    total_amount_written = (self.ior_cmd.block_size.value *
+                                            int(replication))
+                else:
+                    total_amount_written = self.ior_cmd.block_size.value
+                # get difference between actual written value and expected
+                # written value
+                final_value[-1] = final_value[-1] - total_amount_written
+                # perform check
+                if final_value[-1] > expected_values[1]:
+                    self.fail("Aggregated Value for {} of all the targets "
+                              "is greater than expected value of {}"
+                              .format(final_value[-1], expected_values[1]))
+            else:
+                if not self.check_range(expected_values[0],
+                                        final_value[-1],
+                                        self.threshold_percent):
+                    self.fail("Aggregated Value for {} of all the targets "
+                              "is out of expected {} percent range"
+                              .format(final_value[-1], self.threshold_percent))
+
+    def test_telmetry_pool_metrics(self):
+        """JIRA ID: DAOS-8357
+
+            Create files of 500M and 1M with transfer size 1M to verify the
+            DAOS engine IO telemetry basic metrics infrastructure.
+        Steps:
+            Create Pool
+            Create Container
+            Generate deterministic workload. Usinf ior to write 512M
+            of data with 1M chunk size and 1M transfer size.
+            Use telemtry command to get values of 4 paramters
+            "engine_pool_ops_fetch", "engine_pool_ops_update",
+            "engine_pool_xferred_fetch", "engine_pool_xferred_update"
+            for all targets.
+            Verify the sum of all parameter metrics matches the the workload.
+            Do this with RF=0 and RF2(but RP_2GX).
+            For RF=0 the sum should be exactly equal to the expected workload
+            and for RF=2 (with RP_2GX) sum should be double the size of
+            workload for write but same for read.
+        :avocado: tags=all,daily_regression
+        :avocado: tags=vm
+        :avocado: tags=telemetry
+        :avocado: tags=telemetry_pool_metrics
+
+        """
+        # test parameters
+        self.threshold_percent = self.params.get("threshold_percent",
+                                                 "/run/telemetry_metrics/*")
+        metric_list = ["engine_pool_ops_fetch",
+                       "engine_pool_ops_update",
+                       "engine_pool_xferred_fetch",
+                       "engine_pool_xferred_update"]
+        metrics_data = {}
+        # create pool and container
+        idx = 0
+        self.add_pool(connect=False)
+        self.pool.set_property("reclaim", "disabled")
+        self.add_container(pool=self.pool)
+        # collect first set of pool metric data before read/write
+        metrics_data[idx] = self.telemetry.get_pool_metrics(metric_list)
+        idx += 1
+
+        # Run ior command.
+        try:
+            self.update_ior_cmd_with_pool(False)
+            self.ior_cmd.dfs_oclass.update(self.container.oclass.value)
+            self.run_ior_with_pool(
+                timeout=200, create_pool=False, create_cont=False)
+        except TestFail:
+            self.log.info("#ior command failed!")
+        # collect second set of pool metric data after read/write
+        metrics_data[idx] = self.telemetry.get_pool_metrics(metric_list)
+        # collect data for expected values
+        expected_total_objects = (self.ior_cmd.block_size.value /
+                                  self.ior_cmd.dfs_chunk.value) + 1
+        check_values = [expected_total_objects, self.ior_cmd.dfs_chunk.value]
+        # perform verification check
+        self.verify_pool_metrics(metric_list, metrics_data, check_values)
+        self.log.info("------Test passed------")

--- a/src/tests/ftest/telemetry/telemetry_pool_metrics.py
+++ b/src/tests/ftest/telemetry/telemetry_pool_metrics.py
@@ -101,7 +101,7 @@ class TelemetryPoolMetrics(IorTestBase, TestWithTelemetry):
                 # write operation.
                 if "update" in name:
                     expected_total_amount_written = (self.ior_cmd.block_size.value *
-                                            int(replication))
+                                                     int(replication))
                 else:
                     expected_total_amount_written = self.ior_cmd.block_size.value
                 # get difference between actual written value and expected

--- a/src/tests/ftest/telemetry/telemetry_pool_metrics.py
+++ b/src/tests/ftest/telemetry/telemetry_pool_metrics.py
@@ -22,6 +22,8 @@ class TelemetryPoolMetrics(IorTestBase, TestWithTelemetry):
     def __init__(self, *args, **kwargs):
         """Initialize a TelemetryPoolMetrics object."""
         super().__init__(*args, **kwargs)
+        # remove this variable and it's use from the code,
+        # once DAOS-8592 is resolved.
         self.threshold_percent = None
 
     def check_range(self, expected_value, actual_value, threshold_percent):

--- a/src/tests/ftest/telemetry/telemetry_pool_metrics.py
+++ b/src/tests/ftest/telemetry/telemetry_pool_metrics.py
@@ -19,6 +19,11 @@ class TelemetryPoolMetrics(IorTestBase, TestWithTelemetry):
     :avocado: recursive
     """
 
+    def __init__(self, *args, **kwargs):
+        """Initialize a TelemetryPoolMetrics object."""
+        super().__init__(*args, **kwargs)
+        self.threshold_percent = None
+
     def check_range(self, expected_value, actual_value, threshold_percent):
         """Check if actual value is within expected
            range of expected value

--- a/src/tests/ftest/telemetry/telemetry_pool_metrics.py
+++ b/src/tests/ftest/telemetry/telemetry_pool_metrics.py
@@ -132,7 +132,7 @@ class TelemetryPoolMetrics(IorTestBase, TestWithTelemetry):
             and for RF=2 (with RP_2GX) sum should be double the size of
             workload for write but same for read.
         :avocado: tags=all,daily_regression
-        :avocado: tags=vm
+        :avocado: tags=hw,small
         :avocado: tags=telemetry
         :avocado: tags=telemetry_pool_metrics
 

--- a/src/tests/ftest/telemetry/telemetry_pool_metrics.py
+++ b/src/tests/ftest/telemetry/telemetry_pool_metrics.py
@@ -112,7 +112,7 @@ class TelemetryPoolMetrics(IorTestBase, TestWithTelemetry):
                               "is out of expected {} percent range"
                               .format(final_value[-1], self.threshold_percent))
 
-    def test_telmetry_pool_metrics(self):
+    def test_telemetry_pool_metrics(self):
         """JIRA ID: DAOS-8357
 
             Create files of 500M and 1M with transfer size 1M to verify the
@@ -122,7 +122,7 @@ class TelemetryPoolMetrics(IorTestBase, TestWithTelemetry):
             Create Container
             Generate deterministic workload. Usinf ior to write 512M
             of data with 1M chunk size and 1M transfer size.
-            Use telemtry command to get values of 4 paramters
+            Use telemetry command to get values of 4 parameters
             "engine_pool_ops_fetch", "engine_pool_ops_update",
             "engine_pool_xferred_fetch", "engine_pool_xferred_update"
             for all targets.

--- a/src/tests/ftest/telemetry/telemetry_pool_metrics.py
+++ b/src/tests/ftest/telemetry/telemetry_pool_metrics.py
@@ -127,13 +127,13 @@ class TelemetryPoolMetrics(IorTestBase, TestWithTelemetry):
         Steps:
             Create Pool
             Create Container
-            Generate deterministic workload. Usinf ior to write 512M
+            Generate deterministic workload. Using ior to write 512M
             of data with 1M chunk size and 1M transfer size.
             Use telemetry command to get values of 4 parameters
             "engine_pool_ops_fetch", "engine_pool_ops_update",
             "engine_pool_xferred_fetch", "engine_pool_xferred_update"
             for all targets.
-            Verify the sum of all parameter metrics matches the the workload.
+            Verify the sum of all parameter metrics matches the workload.
             Do this with RF=0 and RF2(but RP_2GX).
             For RF=0 the sum should be exactly equal to the expected workload
             and for RF=2 (with RP_2GX) sum should be double the size of

--- a/src/tests/ftest/telemetry/telemetry_pool_metrics.yaml
+++ b/src/tests/ftest/telemetry/telemetry_pool_metrics.yaml
@@ -3,7 +3,7 @@ hosts:
     - server-A
     - server-B
   test_clients:
-    - client-A
+    - client-C
 timeout: 240
 server_config:
   engines_per_host: 2

--- a/src/tests/ftest/telemetry/telemetry_pool_metrics.yaml
+++ b/src/tests/ftest/telemetry/telemetry_pool_metrics.yaml
@@ -2,35 +2,11 @@ hosts:
   test_servers:
     - server-A
     - server-B
+    - server-C
+    - server-D
   test_clients:
-    - client-C
+    - client-E
 timeout: 240
-server_config:
-  engines_per_host: 2
-  name: daos_server
-  servers:
-    0:
-      pinned_numa_node: 0
-      nr_xs_helpers: 1
-      fabric_iface: ib0
-      fabric_iface_port: 31317
-      log_file: daos_server0.log
-      bdev_class: nvme
-      bdev_list: ["0000:83:00.0"]
-      scm_class: dcpm
-      scm_list: ["/dev/pmem0"]
-      scm_mount: /mnt/daos0
-    1:
-      pinned_numa_node: 1
-      nr_xs_helpers: 1
-      fabric_iface: ib1
-      fabric_iface_port: 31417
-      log_file: daos_server1.log
-      bdev_class: nvme
-      bdev_list: ["0000:84:00.0"]
-      scm_class: dcpm
-      scm_list: ["/dev/pmem1"]
-      scm_mount: /mnt/daos1
 pool:
   name: daos_server
   scm_size: 1G

--- a/src/tests/ftest/telemetry/telemetry_pool_metrics.yaml
+++ b/src/tests/ftest/telemetry/telemetry_pool_metrics.yaml
@@ -22,6 +22,8 @@ container:
       properties: rf:2
       oclass: RP_3GX
 telemetry_metrics:
+  # remove this variable and it's use from the code,
+  # DAOS-8592 is resolved.
   threshold_percent: 7 # 7%
 ior:
   api: DFS

--- a/src/tests/ftest/telemetry/telemetry_pool_metrics.yaml
+++ b/src/tests/ftest/telemetry/telemetry_pool_metrics.yaml
@@ -1,0 +1,59 @@
+hosts:
+  test_servers:
+    - server-A
+    - server-B
+  test_clients:
+    - client-A
+timeout: 240
+server_config:
+  engines_per_host: 2
+  name: daos_server
+  servers:
+    0:
+      pinned_numa_node: 0
+      nr_xs_helpers: 1
+      fabric_iface: ib0
+      fabric_iface_port: 31317
+      log_file: daos_server0.log
+      bdev_class: nvme
+      bdev_list: ["0000:83:00.0"]
+      scm_class: dcpm
+      scm_list: ["/dev/pmem0"]
+      scm_mount: /mnt/daos0
+    1:
+      pinned_numa_node: 1
+      nr_xs_helpers: 1
+      fabric_iface: ib1
+      fabric_iface_port: 31417
+      log_file: daos_server1.log
+      bdev_class: nvme
+      bdev_list: ["0000:84:00.0"]
+      scm_class: dcpm
+      scm_list: ["/dev/pmem1"]
+      scm_mount: /mnt/daos1
+pool:
+  name: daos_server
+  scm_size: 1G
+  control_method: dmg
+container:
+  type: POSIX
+  control_method: daos
+  replication: !mux
+    rf0:
+      properties: rf:0
+      oclass: SX
+    rf2:
+      properties: rf:2
+      oclass: RP_3GX
+telemetry_metrics:
+  threshold_percent: 7 # 7%
+ior:
+  api: DFS
+  flags: "-v -w -r -k"
+  max_duration: 10
+  transfer_size: 1M
+  block_size: 536870912
+  dfs_destroy: False
+  test_file: daos:testFile
+dfuse:
+  mount_dir: "/tmp/daos_dfuse"

--- a/src/tests/ftest/util/telemetry_utils.py
+++ b/src/tests/ftest/util/telemetry_utils.py
@@ -575,7 +575,7 @@ class TelemetryUtils():
                                     host, rank, target, metric["value"])
         return data
 
-    def get_metrics_data(self, test_metrics=None):
+    def get_io_metrics(self, test_metrics=None):
         """Get the io telemetry metrics.
 
         Args:

--- a/src/tests/ftest/util/telemetry_utils.py
+++ b/src/tests/ftest/util/telemetry_utils.py
@@ -529,7 +529,53 @@ class TelemetryUtils():
                         data[host][name] = metric["value"]
         return data
 
-    def get_io_metrics(self, test_metrics=None):
+    def get_pool_metrics(self, specific_metrics=None):
+        """Get the pool telemetry metrics.
+
+        Args:
+            specific_metrics(list): list of specific pool metrics
+        Returns:
+            dict: dictionary of dictionaries of pool metric names and
+                values per server host key
+
+        """
+        data = {}
+        if specific_metrics is None:
+            specific_metrics = self.ENGINE_POOL_METRICS
+        info = self.get_metrics(",".join(specific_metrics))
+        self.log.info("Pool Telemetry Information")
+        for name in specific_metrics:
+            for index, host in enumerate(info):
+                if name in info[host]:
+                    if index == 0:
+                        self.log.info(
+                            "  %s (%s):",
+                            name, info[host][name]["description"])
+                        self.log.info(
+                            "    %-12s %-4s %-6s %s",
+                            "Host", "Rank", "Target", "Value")
+                    if name not in data:
+                        data[name] = {}
+                    if host not in data[name]:
+                        data[name][host] = {}
+                    for metric in info[host][name]["metrics"]:
+                        if "labels" in metric:
+                            if ("rank" in metric["labels"]
+                                    and "target" in metric["labels"]):
+                                rank = metric["labels"]["rank"]
+                                target = metric["labels"]["target"]
+                                if rank not in data[name][host]:
+                                    data[name][host][rank] = {}
+                                if target not in data[name][host][rank]:
+                                    data[name][host][rank][target] = {}
+                                data[name][host][rank][target] = \
+                                    metric["value"]
+                                self.log.info(
+                                    "    %-12s %-4s %-6s %s",
+                                    host, rank, target, metric["value"])
+        return data
+
+    def get_metrics_data(self, test_metrics=None):
         """Get the io telemetry metrics.
 
         Args:
@@ -544,11 +590,10 @@ class TelemetryUtils():
         """
         data = {}
         if test_metrics is None:
-            info = self.get_metrics(",".join(self.ENGINE_IO_METRICS))
-        else:
-            info = self.get_metrics(",".join(test_metrics))
-        self.log.info("I/O Telemetry Information")
-        for name in self.ENGINE_IO_METRICS:
+            test_metrics = self.ENGINE_IO_METRICS
+        info = self.get_metrics(",".join(test_metrics))
+        self.log.info("Telemetry Information")
+        for name in test_metrics:
             for index, host in enumerate(info):
                 if name in info[host]:
                     if index == 0:
@@ -580,7 +625,7 @@ class TelemetryUtils():
                                     "    %-12s %-4s %-6s %-6s %s",
                                     host, rank, target, size, metric["value"])
                             elif ("rank" in metric["labels"]
-                                    and "target" in metric["labels"]):
+                                  and "target" in metric["labels"]):
                                 rank = metric["labels"]["rank"]
                                 target = metric["labels"]["target"]
                                 if rank not in data[name][host]:


### PR DESCRIPTION
Adding test to verify pool metrics data for
"engine_pool_ops_fetch", "engine_pool_ops_update",
"engine_pool_xferred_fetch", "engine_pool_xferred_update"

Quick-Functional: true
Test-tag: telemetry_pool_metrics
Test-repeat: 5

Signed-off-by: Saurabh Tandan <saurabh.tandan@intel.com>