### PR TITLE
DAOS-8502 Test: Enabled offline rebuild tests.

### DIFF
--- a/src/tests/ftest/erasurecode/ec_offline_rebuild.yaml
+++ b/src/tests/ftest/erasurecode/ec_offline_rebuild.yaml
@@ -72,8 +72,7 @@ ior:
   chunk_block_transfer_sizes:
    # [ChunkSize, BlocksSize, TransferSize]
    - [32M, 128M, 8M]       # Full Striped
-   # Remove this line when DAOS-8502 defect is resolved.
-   #- [32M, 16M, 2K]       # Partial Striped
+   - [32M, 16M, 2K]        # Partial Striped
   objectclass:
    dfs_oclass_list:
     #- [EC_Object_Class, Minimum number of servers]

--- a/src/tests/ftest/erasurecode/ec_offline_rebuild.yaml
+++ b/src/tests/ftest/erasurecode/ec_offline_rebuild.yaml
@@ -22,7 +22,7 @@ hosts:
   test_clients:
     - client-A
     - client-B
-timeout: 2500
+timeout: 600
 server_config:
   engines_per_host: 2
   name: daos_server


### PR DESCRIPTION
The latest master has fixed the original issue so adding
back the ec_offline_rebuild with partial IO.

Quick-Functional: true
Skip-func-hw-test-small: true
Skip-func-hw-test-medium: true
Test-tag-hw-large: pr ec_offline_rebuild_array

Signed-off-by: Samir Raval <samir.raval@intel.com>