### PR TITLE
DAOS-8448 Test: Updating the log file to look for disk event messages in control log file instead of server log.

### DIFF
--- a/src/tests/suite/daos_nvme_recovery.c
+++ b/src/tests/suite/daos_nvme_recovery.c
@@ -353,7 +353,7 @@ nvme_test_verify_device_stats(void **state)
 	print_message("server_config_file = %s\n", server_config_file);
 
 	get_log_file(devices[rank_pos].host, server_config_file,
-		     " log_file", log_file);
+		     "control_log_file", log_file);
 	rc = verify_server_log_mask(devices[rank_pos].host,
 				    server_config_file, "DEBUG");
 	if (rc) {


### PR DESCRIPTION
Test-tag-hw-medium: pr daos_core_test_nvme

Signed-off-by: Samir Raval <samir.raval@intel.com>