### PR TITLE
DAOS-8449 tests: adjust RF property for nvme pool test

### DIFF
--- a/src/common/pool_map.c
+++ b/src/common/pool_map.c
@@ -2455,6 +2455,8 @@ pmap_fail_node_add_tgt(struct pmap_fail_stat *fstat,
 	}
 	if (comp->co_fseq > fstat->pf_last_ver)
 		fnode->pf_new_fail = 1;
+	else
+		fnode->pf_new_fail = 0;
 
 	for (i = 0; i < fnode->pf_ver_nr; i++) {
 		tmp = &fnode->pf_vers[i];
@@ -2528,7 +2530,7 @@ pmap_node_check(struct pool_domain *node_dom, struct pmap_fail_stat *fstat)
 		fstat->pf_newfail_nr++;
 	if ((fstat->pf_down_nr > fstat->pf_rf) && (fstat->pf_newfail_nr > 0)) {
 		rc = -DER_RF;
-		D_DEBUG(DB_TRACE, "RF broken, found %d DOWN node, "
+		D_ERROR("RF broken, found %d DOWN node, "
 			"newly fail %d, rf %d, "DF_RC"\n", fstat->pf_down_nr,
 			fstat->pf_newfail_nr, fstat->pf_rf, DP_RC(rc));
 	}
@@ -2606,7 +2608,7 @@ pmap_fail_stat_check(struct pmap_fail_stat *fstat)
 
 fail:
 	if (rc == -DER_RF) {
-		D_DEBUG(DB_TRACE, "RF broken, found %d fail, DOWN %d, newly "
+		D_ERROR("RF broken, found %d fail, DOWN %d, newly "
 			"fail %d, max_overlapped %d, rf %d, "DF_RC"\n",
 			fstat->pf_node_nr, fstat->pf_down_nr,
 			fstat->pf_newfail_nr, max_fail_nr,

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -1665,8 +1665,11 @@ obj_capa_check(struct ds_cont_hdl *coh, bool is_write, bool is_agg_migrate)
 		return -DER_NO_PERM;
 	}
 
-	if (!is_agg_migrate && coh->sch_cont && coh->sch_cont->sc_rw_disabled)
+	if (!is_agg_migrate && coh->sch_cont && coh->sch_cont->sc_rw_disabled) {
+		D_ERROR("cont hdl "DF_UUID" exceeds rf\n",
+			DP_UUID(coh->sch_uuid));
 		return -DER_RF;
+	}
 
 	return 0;
 }

--- a/src/tests/ftest/nvme/nvme_pool_exclude.py
+++ b/src/tests/ftest/nvme/nvme_pool_exclude.py
@@ -52,13 +52,7 @@ class NvmePoolExclude(OSAUtils):
         # Create a pool
         label_generator = LabelGenerator()
         pool = {}
-        target_list = []
 
-        # Exclude target : random two targets (target idx : 0-7)
-        n = random.randint(0, 6)
-        target_list.append(n)
-        target_list.append(n+1)
-        t_string = "{},{}".format(target_list[0], target_list[1])
         if oclass is None:
             oclass = self.ior_cmd.dfs_oclass.value
 
@@ -95,11 +89,12 @@ class NvmePoolExclude(OSAUtils):
 
                 index = random.randint(1, len(rank_list))
                 rank = rank_list.pop(index-1)
-                self.log.info("Removing rank %d", rank)
+                tgt_exclude = random.randint(1, 6)
+                self.log.info("Removing rank %d, target %d", rank, tgt_exclude)
 
                 self.log.info("Pool Version at the beginning %s", pver_begin)
                 output = self.dmg_command.pool_exclude(self.pool.uuid,
-                                                       rank, t_string)
+                                                       rank, tgt_exclude)
                 self.print_and_assert_on_rebuild_failure(output)
 
                 pver_exclude = self.get_pool_version()

--- a/src/tests/ftest/nvme/nvme_pool_exclude.yaml
+++ b/src/tests/ftest/nvme/nvme_pool_exclude.yaml
@@ -31,7 +31,7 @@ server_config:
         scm_class: dcpm
         scm_list: ["/dev/pmem0"]
         scm_mount: /mnt/daos0
-        log_mask: ERR
+        log_mask: DEBUG,MEM=ERR
       1:
         pinned_numa_node: 1
         nr_xs_helpers: 1
@@ -43,7 +43,7 @@ server_config:
         scm_class: dcpm
         scm_list: ["/dev/pmem1"]
         scm_mount: /mnt/daos1
-        log_mask: ERR
+        log_mask: DEBUG,MEM=ERR
 pool:
   mode: 146
   name: daos_server
@@ -56,8 +56,8 @@ pool:
 container:
     type: POSIX
     control_method: daos
-    properties: cksum:crc16,cksum_size:16384,srv_cksum:on,rf:1
-    oclass: RP_2G8
+    properties: cksum:crc16,cksum_size:16384,srv_cksum:on,rf:2
+    oclass: RP_3G5
 ior:
   client_processes:
     np: 48
@@ -68,8 +68,8 @@ ior:
     write_flags: "-w -F -k -G 1"
     read_flags: "-F -r -R -k -G 1"
     api: DFS
-    dfs_oclass: RP_2G8
-    dfs_dir_oclass: RP_2G8
+    dfs_oclass: RP_3G5
+    dfs_dir_oclass: RP_3G5
     ior_test_sequence:
     #   - [scm_size, nvme_size, transfersize, blocksize]
     #    The values are set to be in the multiples of 10.
@@ -79,11 +79,10 @@ ior:
         - [50000000000, 300000000000, 1000000000, 8000000000]  #[1G, 8G]
 test_obj_class:
   oclass:
-    - RP_3G6
+    - RP_3G5
     - RP_4G1
-    - S1
 loop_test:
-  iterations: 3
+  iterations: 2
 aggregation:
   test_with_aggregation: True
 rebuild:


### PR DESCRIPTION
The RF property should be enough for two targets failure in
nvme_pool_exclude test. Otherwise, IOR will get DER_RF(2031)
during the test.

More logs when exceeds container RF property.

Test-tag-hw-large: pr,hw,large nvme_pool_exclude