### PR TITLE
DAOS-8330 tools: Fix JSON output for fs attr cmds

### DIFF
--- a/src/control/cmd/daos/filesystem.go
+++ b/src/control/cmd/daos/filesystem.go
@@ -12,8 +12,7 @@ package main
 import "C"
 
 import (
-	"fmt"
-	"os"
+	"syscall"
 
 	"github.com/pkg/errors"
 )
@@ -23,17 +22,16 @@ func dfsError(rc C.int) error {
 		return nil
 	}
 
-	strErr := C.strerror(rc)
-	return errors.New(fmt.Sprintf("errno %d (%s)", rc, C.GoString(strErr)))
+	return syscall.Errno(rc)
 }
 
 type fsCmd struct {
-	Copy           fsCopyCmd `command:"copy" description:"copy to and from a POSIX filesystem"`
-	SetAttr        fsAttrCmd `command:"set-attr" description:"set fs attributes"`
-	GetAttr        fsAttrCmd `command:"get-attr" description:"get fs attributes"`
-	ResetAttr      fsAttrCmd `command:"reset-attr" description:"reset fs attributes"`
-	ResetChunkSize fsAttrCmd `command:"reset-chunk-size" description:"reset fs chunk size"`
-	ResetObjClass  fsAttrCmd `command:"reset-oclass" description:"reset fs obj class"`
+	Copy           fsCopyCmd           `command:"copy" description:"copy to and from a POSIX filesystem"`
+	SetAttr        fsSetAttrCmd        `command:"set-attr" description:"set fs attributes"`
+	GetAttr        fsGetAttrCmd        `command:"get-attr" description:"get fs attributes"`
+	ResetAttr      fsResetAttrCmd      `command:"reset-attr" description:"reset fs attributes"`
+	ResetChunkSize fsResetChunkSizeCmd `command:"reset-chunk-size" description:"reset fs chunk size"`
+	ResetObjClass  fsResetOclassCmd    `command:"reset-oclass" description:"reset fs obj class"`
 }
 
 type fsCopyCmd struct {
@@ -69,73 +67,217 @@ func (cmd *fsCopyCmd) Execute(_ []string) error {
 type fsAttrCmd struct {
 	existingContainerCmd
 
-	ChunkSize   ChunkSizeFlag `long:"chunk-size" short:"z" description:"container chunk size"`
-	ObjectClass ObjClassFlag  `long:"oclass" short:"o" description:"default object class"`
-	DfsPath     string        `long:"dfs-path" short:"H" description:"DFS path relative to root of container, when using pool and container instead of --path and the UNS"`
-	DfsPrefix   string        `long:"dfs-prefix" short:"I" description:"Optional prefix path to the root of the DFS container when using pool and container"`
+	DfsPath   string `long:"dfs-path" short:"H" description:"DFS path relative to root of container, when using pool and container instead of --path and the UNS"`
+	DfsPrefix string `long:"dfs-prefix" short:"I" description:"Optional prefix path to the root of the DFS container when using pool and container"`
 }
 
-func (cmd *fsAttrCmd) Execute(_ []string) error {
-	ap, deallocCmdArgs, err := allocCmdArgs(cmd.log)
-	if err != nil {
-		return err
-	}
-	defer deallocCmdArgs()
-
+func parseDFSParamsToAP(cmd *fsAttrCmd, ap *C.struct_cmd_args_s) error {
 	if cmd.DfsPath != "" {
 		if cmd.Path != "" {
-			return errors.New("Cannot use both --dfs-path and --path")
+			return errors.New("cannot use both --dfs-path and --path")
 		}
 		ap.dfs_path = C.CString(cmd.DfsPath)
 	}
 	if cmd.DfsPrefix != "" {
 		if cmd.Path != "" {
-			return errors.New("Cannot use both --dfs-prefix and --path")
+			return errors.New("cannot use both --dfs-prefix and --path")
 		}
 		ap.dfs_prefix = C.CString(cmd.DfsPrefix)
 	}
+	return nil
+}
 
-	flags := C.uint(C.DAOS_COO_RW)
-	op := os.Args[2]
-	switch op {
-	case "set-attr":
-		ap.fs_op = C.FS_SET_ATTR
-		if cmd.ObjectClass.Set {
-			ap.oclass = cmd.ObjectClass.Class
+func setupFSAttrCmd(cmd *fsAttrCmd, flags C.uint, op uint32) (*C.struct_cmd_args_s, *C.dfs_t, func(), error) {
+	var err error
+	cleanupFuncs := []func(){}
+	runAll := func(funcs []func()) {
+		for _, f := range funcs {
+			f()
 		}
-		if cmd.ChunkSize.Set {
-			ap.chunk_size = cmd.ChunkSize.Size
+	}
+	defer func() {
+		if err != nil {
+			runAll(cleanupFuncs)
 		}
-	case "get-attr":
-		ap.fs_op = C.FS_GET_ATTR
-		flags = C.DAOS_COO_RO
-	case "reset-attr":
-		ap.fs_op = C.FS_RESET_ATTR
-	case "reset-chunk-size":
-		ap.fs_op = C.FS_RESET_CHUNK_SIZE
-		if !cmd.ChunkSize.Set {
-			return errors.New("--chunk-size not set")
-		}
-		ap.chunk_size = cmd.ChunkSize.Size
-	case "reset-oclass":
-		ap.fs_op = C.FS_RESET_OCLASS
-		if !cmd.ObjectClass.Set {
-			return errors.New("--oclass not set")
-		}
-		ap.oclass = cmd.ObjectClass.Class
-	default:
-		return errors.Errorf("unknown fs op %q", op)
+	}()
+
+	ap, deallocCmdArgs, err := allocCmdArgs(cmd.log)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	cleanupFuncs = append(cleanupFuncs, deallocCmdArgs)
+
+	if err := parseDFSParamsToAP(cmd, ap); err != nil {
+		return nil, nil, nil, err
 	}
 
+	ap.fs_op = op
+
 	cleanup, err := cmd.resolveAndConnect(flags, ap)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	cleanupFuncs = append(cleanupFuncs, cleanup)
+
+	fsFlags := C.O_RDWR
+	if flags == C.DAOS_COO_RO {
+		fsFlags = C.O_RDONLY
+	}
+
+	dfs, unmount, err := mountDFS(ap, C.int(fsFlags))
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	cleanupFuncs = append(cleanupFuncs, unmount)
+
+	return ap, dfs, func() {
+		runAll(cleanupFuncs)
+	}, nil
+}
+
+type fsGetAttrCmd struct {
+	fsAttrCmd
+}
+
+func (cmd *fsGetAttrCmd) Execute(_ []string) error {
+	ap, dfs, cleanup, err := setupFSAttrCmd(&cmd.fsAttrCmd, C.DAOS_COO_RO, C.FS_GET_ATTR)
 	if err != nil {
 		return err
 	}
 	defer cleanup()
 
-	if err := dfsError(C.fs_dfs_hdlr(ap)); err != nil {
-		return errors.Wrapf(err, "%s failed", op)
+	obj, releaseObj, err := lookupDFSObj(ap.dfs_path, dfs, C.O_RDONLY)
+	if err != nil {
+		return err
+	}
+	defer releaseObj()
+
+	objInfo, err := getDFSObjInfo(ap, dfs, obj)
+	if err != nil {
+		return err
+	}
+
+	if cmd.jsonOutputEnabled() {
+		return cmd.outputJSON(objInfo, nil)
+	}
+
+	cmd.log.Infof("Object Class = %s\n", objInfo.ObjClass)
+	cmd.log.Infof("Object Chunk Size = %d\n", objInfo.ChunkSize)
+
+	return nil
+}
+
+type fsSetAttrCmd struct {
+	fsAttrCmd
+	ChunkSize   ChunkSizeFlag `long:"chunk-size" short:"z" description:"container chunk size"`
+	ObjectClass ObjClassFlag  `long:"oclass" short:"o" description:"default object class"`
+}
+
+func (cmd *fsSetAttrCmd) Execute(_ []string) error {
+	ap, dfs, cleanup, err := setupFSAttrCmd(&cmd.fsAttrCmd, C.DAOS_COO_RW, C.FS_SET_ATTR)
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+
+	obj, releaseObj, err := lookupDFSObj(ap.dfs_path, dfs, C.O_RDWR)
+	if errors.Is(err, syscall.ENOENT) {
+		if cmd.ChunkSize.Set {
+			ap.chunk_size = cmd.ChunkSize.Size
+		}
+		if cmd.ObjectClass.Set {
+			ap.oclass = cmd.ObjectClass.Class
+		}
+		_, releaseObj, err = createDFSObj(ap, dfs)
+		if err != nil {
+			return err
+		}
+		releaseObj()
+		return nil
+	} else if err != nil {
+		return err
+	}
+	defer releaseObj()
+
+	if cmd.ChunkSize.Set {
+		if err := fsSetChunkSize(dfs, obj, uint64(cmd.ChunkSize.Size)); err != nil {
+			return err
+		}
+	}
+
+	if cmd.ObjectClass.Set {
+		if err := fsSetObjClass(dfs, obj, uint16(cmd.ObjectClass.Class)); err != nil {
+			return err
+		}
 	}
 
 	return nil
+}
+
+type fsResetAttrCmd struct {
+	fsAttrCmd
+}
+
+func (cmd *fsResetAttrCmd) Execute(_ []string) error {
+	return fsResetAttr(&cmd.fsAttrCmd, C.FS_RESET_ATTR)
+}
+
+func fsResetAttr(cmd *fsAttrCmd, op uint32) error {
+	ap, dfs, cleanup, err := setupFSAttrCmd(cmd, C.DAOS_COO_RW, op)
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+
+	obj, releaseObj, err := lookupDFSObj(ap.dfs_path, dfs, C.O_RDWR)
+	if err != nil {
+		return err
+	}
+	defer releaseObj()
+
+	if op == C.FS_RESET_ATTR || op == C.FS_RESET_CHUNK_SIZE {
+		if err := fsSetChunkSize(dfs, obj, 0); err != nil {
+			return err
+		}
+	}
+
+	if op == C.FS_RESET_ATTR || op == C.FS_RESET_OCLASS {
+		if err := fsSetObjClass(dfs, obj, 0); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func fsSetChunkSize(dfs *C.dfs_t, obj *C.dfs_obj_t, size uint64) error {
+	rc := C.dfs_obj_set_chunk_size(dfs, obj, 0, C.ulong(size))
+	if rc != 0 {
+		return errors.Wrap(dfsError(rc), "failed to set chunk size")
+	}
+	return nil
+}
+
+func fsSetObjClass(dfs *C.dfs_t, obj *C.dfs_obj_t, objClass uint16) error {
+	rc := C.dfs_obj_set_oclass(dfs, obj, 0, C.ushort(objClass))
+	if rc != 0 {
+		return errors.Wrap(dfsError(rc), "failed to set object class")
+	}
+	return nil
+}
+
+type fsResetChunkSizeCmd struct {
+	fsAttrCmd
+}
+
+func (cmd *fsResetChunkSizeCmd) Execute(_ []string) error {
+	return fsResetAttr(&cmd.fsAttrCmd, C.FS_RESET_CHUNK_SIZE)
+}
+
+type fsResetOclassCmd struct {
+	fsAttrCmd
+}
+
+func (cmd *fsResetOclassCmd) Execute(_ []string) error {
+	return fsResetAttr(&cmd.fsAttrCmd, C.FS_RESET_OCLASS)
 }

--- a/src/control/cmd/daos/util.go
+++ b/src/control/cmd/daos/util.go
@@ -282,7 +282,7 @@ func mountDFS(ap *C.struct_cmd_args_s, flags C.int) (*C.dfs_t, func(), error) {
 		rc = C.dfs_set_prefix(dfs, ap.dfs_prefix)
 		if rc != 0 {
 			unmountDFS(dfs)
-			return nil, nil, errors.Wrapf(dfsError(rc), "failed to set DFS prefix %s", 
+			return nil, nil, errors.Wrapf(dfsError(rc), "failed to set DFS prefix %s",
 				C.GoString(ap.dfs_prefix))
 		}
 

--- a/src/tests/ftest/util/daos_utils_base.py
+++ b/src/tests/ftest/util/daos_utils_base.py
@@ -548,3 +548,54 @@ class DaosCommandBase(CommandWithSubCommand):
                 #   --src=<type>:<pool/cont | path>
                 #   supported types are daos, posix
                 self.dst = FormattedParameter("--dst={}")
+
+        class GetAttrSubCommand(CommonFilesystemSubCommand):
+            """Defines an object for the daos filesystem get-attr command."""
+
+            def __init__(self):
+                """Create a daos filesystem get-attr command object."""
+                super().__init__("get-attr")
+                self.dfs_path = FormattedParameter("--dfs-path={}")
+                self.dfs_prefix = FormattedParameter("--dfs-prefix={}")
+
+        class SetAttrSubCommand(CommonFilesystemSubCommand):
+            """Defines an object for the daos filesystem set-attr command."""
+
+            def __init__(self):
+                """Create a daos filesystem set-attr command object."""
+                super().__init__("set-attr")
+                self.dfs_path = FormattedParameter("--dfs-path={}")
+                self.dfs_prefix = FormattedParameter("--dfs-prefix={}")
+                self.oclass = FormattedParameter("--oclass={}")
+                self.chunk_size = FormattedParameter("--chunk-size={}")
+
+        class ResetAttrSubCommand(CommonFilesystemSubCommand):
+            """Defines an object for the daos filesystem reset-attr command."""
+
+            def __init__(self):
+                """Create a daos filesystem reset-attr command object."""
+                super().__init__("reset-attr")
+                self.dfs_path = FormattedParameter("--dfs-path={}")
+                self.dfs_prefix = FormattedParameter("--dfs-prefix={}")
+
+        class ResetOclassSubCommand(CommonFilesystemSubCommand):
+            """
+            Defines an object for the daos filesystem reset-oclass command.
+            """
+
+            def __init__(self):
+                """Create a daos filesystem reset-oclass command object."""
+                super().__init__("reset-oclass")
+                self.dfs_path = FormattedParameter("--dfs-path={}")
+                self.dfs_prefix = FormattedParameter("--dfs-prefix={}")
+
+        class ResetChunkSizeSubCommand(CommonFilesystemSubCommand):
+            """
+            Defines an object for the daos filesystem reset-chunk-size command.
+            """
+
+            def __init__(self):
+                """Create a daos filesystem reset-chunk-size command object."""
+                super().__init__("reset-chunk-size")
+                self.dfs_path = FormattedParameter("--dfs-path={}")
+                self.dfs_prefix = FormattedParameter("--dfs-prefix={}")


### PR DESCRIPTION
- Refactor the daos fs subcommands into Go to allow them to return
  JSON output and more informative errors.

Signed-off-by: Kris Jacque <kristin.jacque@intel.com>