### PR TITLE
DAOS-8082 obj: fix an assertion in obj_ec_recov_tgt_recx_nrs

### DIFF
--- a/src/include/daos_errno.h
+++ b/src/include/daos_errno.h
@@ -266,6 +266,9 @@ extern "C" {
 	/** ID mismatch */						\
 	ACTION(DER_ID_MISMATCH,		(DER_ERR_DAOS_BASE + 35),	\
 	       ID mismatch)						\
+	/** Retry with other target, an internal error code used in EC deg-fetch. */ \
+	ACTION(DER_TGT_RETRY,		(DER_ERR_DAOS_BASE + 36),	\
+		Retry with other target)				\
 
 /** Defines the gurt error codes */
 #define D_FOREACH_ERR_RANGE(ACTION)	\

--- a/src/object/cli_ec.c
+++ b/src/object/cli_ec.c
@@ -272,15 +272,23 @@ obj_ec_seg_pack(struct obj_ec_seg_sorter *sorter, d_sg_list_t *sgl)
 		}							       \
 	} while (0)
 
-static void
+static int
 obj_ec_recov_tgt_recx_nrs(struct obj_reasb_req *reasb_req,
 			  uint32_t *tgt_recx_nrs)
 {
 	struct obj_ec_fail_info	*fail_info = reasb_req->orr_fail;
 	struct daos_oclass_attr	*oca = reasb_req->orr_oca;
 	uint32_t		 tgt, tgt_nr;
+	int			 rc = 0;
 
 	D_ASSERT(fail_info != NULL);
+	if (fail_info->efi_ntgts > obj_ec_parity_tgt_nr(oca)) {
+		rc = -DER_DATA_LOSS;
+		D_ERROR(DF_OID" efi_ntgts %d > parity_tgt_nr %d, "DF_RC"\n",
+			DP_OID(reasb_req->orr_oid), fail_info->efi_ntgts,
+			obj_ec_parity_tgt_nr(oca), DP_RC(rc));
+		goto out;
+	}
 	for (tgt = 0, tgt_nr = 0; tgt < obj_ec_tgt_nr(oca); tgt++) {
 		if (obj_ec_tgt_in_err(fail_info->efi_tgt_list,
 				      fail_info->efi_ntgts, tgt))
@@ -292,6 +300,9 @@ obj_ec_recov_tgt_recx_nrs(struct obj_reasb_req *reasb_req,
 	}
 	D_ASSERTF(tgt_nr == obj_ec_data_tgt_nr(oca), "%d != %d",
 		  tgt_nr, obj_ec_data_tgt_nr(oca));
+
+out:
+	return rc;
 }
 
 /** scan the iod to find the full_stripe recxs and some help info */
@@ -313,7 +324,7 @@ obj_ec_recx_scan(daos_iod_t *iod, d_sg_list_t *sgl,
 	bool				 parity_seg_counted = false;
 	bool				 frag_seg_counted = false;
 	bool				 punch;
-	int				 i, j, idx, rc;
+	int				 i, j, idx, rc = 0;
 
 	if (reasb_req->orr_size_fetched)
 		return 0;
@@ -353,10 +364,11 @@ obj_ec_recx_scan(daos_iod_t *iod, d_sg_list_t *sgl,
 			ec_all_tgt_recx_nrs(oca, tgt_recx_nrs, j);
 		} else {
 			if (reasb_req->orr_recov)
-				obj_ec_recov_tgt_recx_nrs(reasb_req,
-							  tgt_recx_nrs);
+				rc = obj_ec_recov_tgt_recx_nrs(reasb_req, tgt_recx_nrs);
 			else
 				ec_data_tgt_recx_nrs(oca, tgt_recx_nrs, j);
+			if (rc)
+				goto out;
 			continue;
 		}
 
@@ -1466,8 +1478,15 @@ obj_ec_singv_req_reasb(daos_obj_id_t oid, daos_iod_t *iod, d_sg_list_t *sgl,
 				singv_parity = true;
 		} else {
 			if (reasb_req->orr_recov) {
-				struct obj_ec_fail_info	*fail_info =
-							 reasb_req->orr_fail;
+				struct obj_ec_fail_info	*fail_info = reasb_req->orr_fail;
+
+				if (fail_info->efi_ntgts > obj_ec_parity_tgt_nr(oca)) {
+					rc = -DER_DATA_LOSS;
+					D_ERROR(DF_OID" efi_ntgts %d > parity_tgt_nr %d, "DF_RC"\n",
+						DP_OID(reasb_req->orr_oid), fail_info->efi_ntgts,
+						obj_ec_parity_tgt_nr(oca), DP_RC(rc));
+					goto out;
+				}
 
 				tgt_nr = 0;
 				for (idx = 0; idx < obj_ec_tgt_nr(oca); idx++) {


### PR DESCRIPTION
Refine shard tasks' error code handling, add a new error code
DER_TGT_RETRY as previous DER_BAD_TARGET possibly conflict with
cart's failure case.
Change obj_ec_recov_tgt_recx_nrs() a little bit to avoid assertion.

Signed-off-by: Xuezhao Liu <xuezhao.liu@intel.com>