### PR TITLE
DAOS-7623 utils: Update raft to 0.8.1

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+daos (1.3.105-3) unstable; urgency=medium
+  [ Li Wei ]
+  * Update raft to fix InstallSnapshot performance
+
+ -- Li Wei <wei.g.li@intel.com>  Wed, 15 Sep 2021 11:37:00 +0800
+
 daos (1.3.105-1) unstable; urgency=medium
   [ Jeff Olivier ]
   * Version bump to 1.3.105 for 2.0 test build 5

--- a/debian/control
+++ b/debian/control
@@ -28,7 +28,7 @@ Build-Depends: debhelper (>= 10),
                libboost-dev,
                libspdk-dev,
                libipmctl-dev,
-               libraft-dev (= 0.8.0-1387.g3b0f9f0),
+               libraft-dev (= 0.8.1-1389.g304b19b),
                python3-tabulate,
                liblz4-dev
 Standards-Version: 4.1.2

--- a/utils/rpms/daos.spec
+++ b/utils/rpms/daos.spec
@@ -14,7 +14,7 @@
 
 Name:          daos
 Version:       1.3.105
-Release:       2%{?relval}%{?dist}
+Release:       3%{?relval}%{?dist}
 Summary:       DAOS Storage Engine
 
 License:       BSD-2-Clause-Patent
@@ -84,7 +84,7 @@ BuildRequires: libisa-l_crypto-devel
 BuildRequires: libisal-devel
 BuildRequires: libisal_crypto-devel
 %endif
-BuildRequires: daos-raft-devel = 0.8.0
+BuildRequires: daos-raft-devel = 0.8.1
 BuildRequires: openssl-devel
 BuildRequires: libevent-devel
 BuildRequires: libyaml-devel
@@ -479,6 +479,10 @@ getent passwd daos_agent >/dev/null || useradd -s /sbin/nologin -r -g daos_agent
 %{_libdir}/libdaos_serialize.so
 
 %changelog
+* Wed Sep 15 2021 Li Wei <wei.g.li@intel.com> 1.3.105-3
+- Update raft to fix InstallSnapshot performance as well as to avoid some
+  incorrect 0.8.0 RPMs
+
 * Fri Sep 03 2021 Brian J. Murrell <brian.murrell@intel.com> 1.3.105-2
 - Remove R: hwloc; RPM's auto-requires/provides will take care of this
 


### PR DESCRIPTION
Update raft to 0.8.1 to fix InstallSnapshot performance as well as to
avoid some incorrect 0.8.0 RPMs.

Signed-off-by: Li Wei <wei.g.li@intel.com>