### PR TITLE
DAOS-8053 pool: cleanup lingering pools

### DIFF
--- a/src/include/daos_srv/vos.h
+++ b/src/include/daos_srv/vos.h
@@ -256,13 +256,13 @@ vos_pool_create(const char *path, uuid_t uuid, daos_size_t scm_sz,
  * Kill a VOS pool before destroy
  * It deletes SPDK blob of this pool and detaches it from VOS GC
  *
- * \param uuid	[IN]	Pool UUID
- * \param force [IN]	Delete blob even if it has open refcount
+ * \param uuid		[IN]	Pool UUID
+ * \param from_cleanup	[IN]	From leftover pool cleanup
  *
  * \return		Zero on success, negative value if error
  */
 int
-vos_pool_kill(uuid_t uuid, bool force);
+vos_pool_kill(uuid_t uuid, bool from_cleanup);
 
 /**
  * Destroy a Versioned Object Storage Pool (VOSP)

--- a/src/include/daos_srv/vos.h
+++ b/src/include/daos_srv/vos.h
@@ -257,12 +257,11 @@ vos_pool_create(const char *path, uuid_t uuid, daos_size_t scm_sz,
  * It deletes SPDK blob of this pool and detaches it from VOS GC
  *
  * \param uuid		[IN]	Pool UUID
- * \param from_cleanup	[IN]	From leftover pool cleanup
  *
  * \return		Zero on success, negative value if error
  */
 int
-vos_pool_kill(uuid_t uuid, bool from_cleanup);
+vos_pool_kill(uuid_t uuid);
 
 /**
  * Destroy a Versioned Object Storage Pool (VOSP)

--- a/src/mgmt/srv_target.c
+++ b/src/mgmt/srv_target.c
@@ -70,6 +70,42 @@ static d_hash_table_ops_t pooltgts_hops = {
 	.hop_key_cmp		= pooltgts_cmp_keys,
 };
 
+static int
+path_gen(const uuid_t pool_uuid, const char *dir, const char *fname, int *idx,
+	 char **fpath)
+{
+	int	 size;
+	int	 off;
+
+	/** *fpath = dir + "/" + pool_uuid + "/" + fname + idx */
+
+	/** DAOS_UUID_STR_SIZE includes the trailing '\0' */
+	size = strlen(dir) + 1 /* "/" */ + DAOS_UUID_STR_SIZE;
+	if (fname != NULL || idx != NULL)
+		size += 1 /* "/" */;
+	if (fname)
+		size += strlen(fname);
+	if (idx)
+		size += snprintf(NULL, 0, "%d", *idx);
+
+	D_ALLOC(*fpath, size);
+	if (*fpath == NULL)
+		return -DER_NOMEM;
+
+	off = sprintf(*fpath, "%s", dir);
+	off += sprintf(*fpath + off, "/");
+	uuid_unparse_lower(pool_uuid, *fpath + off);
+	off += DAOS_UUID_STR_SIZE - 1;
+	if (fname != NULL || idx != NULL)
+		off += sprintf(*fpath + off, "/");
+	if (fname)
+		off += sprintf(*fpath + off, "%s", fname);
+	if (idx)
+		sprintf(*fpath + off, "%d", *idx);
+
+	return 0;
+}
+
 static inline int
 dir_fsync(const char *path)
 {
@@ -123,17 +159,18 @@ subtree_destroy(const char *path)
 	return rc;
 }
 
-int
+struct tgt_destroy_args {
+	struct d_uuid		 tda_id;
+	char			*tda_path;
+	int			 tda_rc;
+};
+
+static inline int
 tgt_kill_pool(void *args)
 {
-	struct d_uuid	*id = args;
+	struct tgt_destroy_args	*tda = args;
 
-	/* XXX: there are a few test cases that leak pool close
-	 * before destroying pool, we have to force the kill to pass
-	 * those tests, but we should try to disable "force" and
-	 * fix those issues in the future.
-	 */
-	return vos_pool_kill(id->uuid, true);
+	return vos_pool_kill(tda->tda_id.uuid, tda->tda_rc != 0);
 }
 
 /**
@@ -147,16 +184,16 @@ tgt_kill_pool(void *args)
  * \param[in]	cb	callback called for each pool
  * \param[in]	arg	argument passed to each \a cb call
  */
-int
-ds_mgmt_tgt_pool_iterate(int (*cb)(uuid_t uuid, void *arg), void *arg)
+static int
+common_pool_iterate(const char *path, int (*cb)(uuid_t uuid, void *arg), void *arg)
 {
 	DIR    *storage;
 	int	rc;
 	int	rc_tmp;
 
-	storage = opendir(dss_storage_path);
+	storage = opendir(path);
 	if (storage == NULL) {
-		D_ERROR("failed to open %s: %d\n", dss_storage_path, errno);
+		D_ERROR("failed to open %s: %d\n", path, errno);
 		return daos_errno2der(errno);
 	}
 
@@ -170,7 +207,7 @@ ds_mgmt_tgt_pool_iterate(int (*cb)(uuid_t uuid, void *arg), void *arg)
 		if (entry == NULL) {
 			if (errno != 0) {
 				D_ERROR("failed to read %s: %d\n",
-					dss_storage_path, errno);
+					path, errno);
 				rc = daos_errno2der(errno);
 			}
 			break;
@@ -191,99 +228,110 @@ ds_mgmt_tgt_pool_iterate(int (*cb)(uuid_t uuid, void *arg), void *arg)
 
 	rc_tmp = closedir(storage);
 	if (rc_tmp != 0) {
-		D_ERROR("failed to close %s: %d\n", dss_storage_path, errno);
+		D_ERROR("failed to close %s: %d\n", path, errno);
 		rc_tmp = daos_errno2der(errno);
 	}
 
 	return rc == 0 ? rc_tmp : rc;
 }
 
-/**
- * Iterate pools left in the newborns path that have targets on this node
- * The function \a cb will be called with the UUID of each pool. When \a cb
- * returns an rc,
- *
- *   - if rc == 0, the iteration continues;
- *   - otherwise, the iteration stops and returns rc.
- *
- * \param[in]	cb	callback called for each pool
- * \param[in]	arg	argument passed to each \a cb call
- */
+int
+ds_mgmt_tgt_pool_iterate(int (*cb)(uuid_t uuid, void *arg), void *arg)
+{
+	return common_pool_iterate(dss_storage_path, cb, arg);
+}
+
 static int
 newborn_pool_iterate(int (*cb)(uuid_t uuid, void *arg), void *arg)
 {
-	DIR    *storage;
-	int	rc;
-	int	rc_tmp;
-
-	storage = opendir(newborns_path);
-	if (storage == NULL) {
-		D_ERROR("failed to open %s: %d\n", newborns_path, errno);
-		return daos_errno2der(errno);
-	}
-
-	for (;;) {
-		struct dirent  *entry;
-		uuid_t		uuid;
-
-		rc = 0;
-		errno = 0;
-		entry = readdir(storage);
-		if (entry == NULL) {
-			if (errno != 0) {
-				D_ERROR("failed to read %s: %d\n",
-					newborns_path, errno);
-				rc = daos_errno2der(errno);
-			}
-			break;
-		}
-
-		/* A pool directory must have a valid UUID as its name. */
-		rc = uuid_parse(entry->d_name, uuid);
-		if (rc != 0)
-			continue;
-
-		rc = cb(uuid, arg);
-		if (rc != 0) {
-			break;
-		}
-	}
-
-	rc_tmp = closedir(storage);
-	if (rc_tmp != 0) {
-		D_ERROR("failed to close %s: %d\n", newborns_path, errno);
-		rc_tmp = daos_errno2der(errno);
-	}
-
-	return rc == 0 ? rc_tmp : rc;
+	return common_pool_iterate(newborns_path, cb, arg);
 }
 
-/* During init, remove leftover SPDK resources from pools not fully created */
 static int
-cleanup_newborn_pool(uuid_t uuid, void *arg)
+zombie_pool_iterate(int (*cb)(uuid_t uuid, void *arg), void *arg)
 {
-	int		rc;
-	struct d_uuid	id;
+	return common_pool_iterate(zombies_path, cb, arg);
+}
+
+struct dead_pool {
+	d_list_t	dp_link;
+	uuid_t		dp_uuid;
+};
+
+/* Remove leftover SPDK resources from pools not fully created/destroyed */
+static int
+cleanup_leftover_cb(uuid_t uuid, void *arg)
+{
+	struct tgt_destroy_args	 tda = { };
+	d_list_t		*dead_list = arg;
+	struct dead_pool	*dp;
+	int			 rc;
 
 	/* destroy blobIDs */
-	D_DEBUG(DB_MGMT, "Clear SPDK blobs for NEWBORN pool "DF_UUID"\n",
-		DP_UUID(uuid));
-	uuid_copy(id.uuid, uuid);
-	rc = dss_thread_collective(tgt_kill_pool, &id, 0);
+	D_DEBUG(DB_MGMT, "Clear SPDK blobs for pool "DF_UUID"\n", DP_UUID(uuid));
+	uuid_copy(tda.tda_id.uuid, uuid);
+	tda.tda_rc = 1;	/* indicates leftover pool cleanup */
+	rc = dss_thread_collective(tgt_kill_pool, &tda, 0);
 	if (rc != 0) {
-		if (rc > 0)
-			D_ERROR("%d xstreams failed tgt_kill_pool()\n", rc);
-		else
-			D_ERROR("tgt_kill_pool, rc: "DF_RC"\n", DP_RC(rc));
+		D_ERROR("tgt_kill_pool, rc: "DF_RC"\n", DP_RC(rc));
+		return rc;
 	}
 
+	D_ALLOC_PTR(dp);
+	if (dp == NULL)
+		return -DER_NOMEM;
+
+	uuid_copy(dp->dp_uuid, uuid);
+	d_list_add(&dp->dp_link, dead_list);
 	return rc;
 }
 
-static int
-cleanup_newborn_pools(void)
+static void
+cleanup_dead_list(d_list_t *dead_list, const char *path)
 {
-	return newborn_pool_iterate(cleanup_newborn_pool, NULL);
+	struct dead_pool	*dp, *tmp;
+	char			*dead_dir;
+	int			 rc;
+
+	d_list_for_each_entry_safe(dp, tmp, dead_list, dp_link) {
+		rc = path_gen(dp->dp_uuid, path, NULL, NULL, &dead_dir);
+
+		d_list_del_init(&dp->dp_link);
+		D_FREE(dp);
+		if (rc) {
+			D_ERROR("failed to gen path\n");
+			continue;
+		}
+
+		D_INFO("Cleanup leftover pool: %s\n", dead_dir);
+		(void)subtree_destroy(dead_dir);
+		(void)rmdir(dead_dir);
+		D_FREE(dead_dir);
+	}
+}
+
+static void
+cleanup_leftover_pools(bool zombie_only)
+{
+	d_list_t	dead_list;
+	int		rc;
+
+	D_INIT_LIST_HEAD(&dead_list);
+
+	rc = zombie_pool_iterate(cleanup_leftover_cb, &dead_list);
+	if (rc)
+		D_ERROR("failed to delete SPDK blobs for ZOMBIES pools: "
+			"%d, will try again\n", rc);
+	cleanup_dead_list(&dead_list, zombies_path);
+
+	if (zombie_only)
+		return;
+
+	rc = newborn_pool_iterate(cleanup_leftover_cb, &dead_list);
+	if (rc)
+		D_ERROR("failed to delete SPDK blobs for NEWBORNS pools: "
+			"%d, will try again\n", rc);
+	cleanup_dead_list(&dead_list, newborns_path);
 }
 
 int
@@ -319,11 +367,7 @@ ds_mgmt_tgt_setup(void)
 	umask(stored_mode);
 
 	/** remove leftover from previous runs */
-	rc = cleanup_newborn_pools();
-	if (rc)
-		/** only log error, will try again next time */
-		D_ERROR("failed to delete SPDK blobs for NEWBORNS pools: "
-			"%d, will try again\n", rc);
+	cleanup_leftover_pools(false);
 
 	/* create lock/cv and hash table to track outstanding pool creates */
 	D_ALLOC_PTR(pooltgts);
@@ -395,42 +439,6 @@ ds_mgmt_tgt_cleanup(void)
 	D_FREE(pooltgts);
 	D_FREE(zombies_path);
 	D_FREE(newborns_path);
-}
-
-static int
-path_gen(const uuid_t pool_uuid, const char *dir, const char *fname, int *idx,
-	 char **fpath)
-{
-	int	 size;
-	int	 off;
-
-	/** *fpath = dir + "/" + pool_uuid + "/" + fname + idx */
-
-	/** DAOS_UUID_STR_SIZE includes the trailing '\0' */
-	size = strlen(dir) + 1 /* "/" */ + DAOS_UUID_STR_SIZE;
-	if (fname != NULL || idx != NULL)
-		size += 1 /* "/" */;
-	if (fname)
-		size += strlen(fname);
-	if (idx)
-		size += snprintf(NULL, 0, "%d", *idx);
-
-	D_ALLOC(*fpath, size);
-	if (*fpath == NULL)
-		return -DER_NOMEM;
-
-	off = sprintf(*fpath, "%s", dir);
-	off += sprintf(*fpath + off, "/");
-	uuid_unparse_lower(pool_uuid, *fpath + off);
-	off += DAOS_UUID_STR_SIZE - 1;
-	if (fname != NULL || idx != NULL)
-		off += sprintf(*fpath + off, "/");
-	if (fname)
-		off += sprintf(*fpath + off, "%s", fname);
-	if (idx)
-		sprintf(*fpath + off, "%d", *idx);
-
-	return 0;
 }
 
 /**
@@ -714,6 +722,9 @@ ds_mgmt_hdlr_tgt_create(crt_rpc_t *tc_req)
 	tc_out = crt_reply_get(tc_req);
 	D_ASSERT(tc_in != NULL && tc_out != NULL);
 
+	/* cleanup lingering pools to free up space */
+	cleanup_leftover_pools(true);
+
 	/** insert record in dpt_creates_ht hash table (creates in progress) */
 	D_ALLOC_PTR(tca.tca_ptrec);
 	if (tca.tca_ptrec == NULL)
@@ -864,41 +875,43 @@ out_reply:
 	}
 }
 
-struct tgt_destroy_args {
-	struct d_uuid		 tda_id;
-	char			*tda_path;
-	char			*tda_zombie;
-	int			 tda_rc;
-};
-
 static void *
 tgt_destroy_cleanup(void *arg)
 {
 	struct tgt_destroy_args	*tda = arg;
+	char			*zombie;
 	int			 rc;
 
 	/** move target directory to ZOMBIES */
-	rc = path_gen(tda->tda_id.uuid, zombies_path, NULL, NULL,
-		      &tda->tda_zombie);
+	rc = path_gen(tda->tda_id.uuid, zombies_path, NULL, NULL, &zombie);
 	if (rc)
 		goto out;
 
-	rc = rename(tda->tda_path, tda->tda_zombie);
-	if (rc < 0)
+	rc = rename(tda->tda_path, zombie);
+	if (rc < 0) {
+		rc = daos_errno2der(errno);
+		D_ERROR("Failed to rename %s to %s: "DF_RC"\n",
+			tda->tda_path, zombie, DP_RC(rc));
 		goto out;
+	}
 
 	/** make sure the rename is persistent */
-	(void)dir_fsync(tda->tda_zombie);
+	(void)dir_fsync(zombie);
 
 	/**
 	 * once successfully moved to the ZOMBIES directory, the target will
 	 * take care of retrying on failure and thus always report success to
 	 * the caller.
 	 */
-	(void)subtree_destroy(tda->tda_zombie);
-	(void)rmdir(tda->tda_zombie);
+	if (tda->tda_rc == 0) {
+		(void)subtree_destroy(zombie);
+		(void)rmdir(zombie);
+	} else {
+		D_INFO("Defer cleanup for lingering pool:"DF_UUID"\n",
+		       DP_UUID(tda->tda_id.uuid));
+	}
 out:
-	D_FREE(tda->tda_zombie);
+	D_FREE(zombie);
 	tda->tda_rc = rc;
 	return NULL;
 }
@@ -912,12 +925,12 @@ tgt_destroy(uuid_t pool_uuid, char *path)
 
 	/* destroy blobIDs first */
 	uuid_copy(tda.tda_id.uuid, pool_uuid);
-	rc = dss_thread_collective(tgt_kill_pool, &tda.tda_id, 0);
-	if (rc)
+	rc = dss_thread_collective(tgt_kill_pool, &tda, 0);
+	if (rc && rc != -DER_BUSY)
 		goto out;
 
 	tda.tda_path   = path;
-	tda.tda_zombie = NULL;
+	tda.tda_rc     = rc;
 	rc = pthread_create(&thread, NULL, tgt_destroy_cleanup, &tda);
 	if (rc) {
 		rc = daos_errno2der(errno);

--- a/src/vos/vos_pool.c
+++ b/src/vos/vos_pool.c
@@ -94,6 +94,25 @@ pool_hlink2ptr(struct d_ulink *hlink)
 }
 
 static void
+vos_delete_blob(uuid_t pool_uuid)
+{
+	struct bio_xs_context	*xs_ctxt = vos_xsctxt_get();
+	int			 rc;
+
+	/* NVMe device isn't configured */
+	if (!bio_nvme_configured() || xs_ctxt == NULL)
+		return;
+
+	D_DEBUG(DB_MGMT, "Deleting blob for xs:%p pool:"DF_UUID"\n",
+		xs_ctxt, DP_UUID(pool_uuid));
+
+	rc = bio_blob_delete(pool_uuid, xs_ctxt);
+	if (rc)
+		D_ERROR("Deleting blob for xs:%p pool="DF_UUID" failed: "DF_RC"\n",
+			xs_ctxt, DP_UUID(pool_uuid), DP_RC(rc));
+}
+
+static void
 pool_hop_free(struct d_ulink *hlink)
 {
 	struct vos_pool	*pool = pool_hlink2ptr(hlink);
@@ -125,6 +144,9 @@ pool_hop_free(struct d_ulink *hlink)
 		vos_pmemobj_close(pool->vp_uma.uma_pool);
 
 	vos_dedup_fini(pool);
+
+	if (pool->vp_dying)
+		vos_delete_blob(pool->vp_id);
 
 	D_FREE(pool);
 }
@@ -261,8 +283,8 @@ vos_pool_create(const char *path, uuid_t uuid, daos_size_t scm_sz,
 	rc = pool_lookup(&ukey, &pool);
 	if (rc == 0) {
 		D_ASSERT(pool != NULL);
-		D_DEBUG(DB_MGMT, "Found already opened(%d) pool : %p\n",
-			pool->vp_opened, pool);
+		D_ERROR("Found already opened(%d) pool:%p dying(%d)\n",
+			pool->vp_opened, pool, pool->vp_dying);
 		vos_pool_decref(pool);
 		return -DER_EXIST;
 	}
@@ -407,11 +429,10 @@ close:
  * - detach from GC, delete SPDK blob
  */
 int
-vos_pool_kill(uuid_t uuid, bool force)
+vos_pool_kill(uuid_t uuid, bool from_cleanup)
 {
-	struct bio_xs_context	*xs_ctxt = vos_xsctxt_get();
-	struct d_uuid		 ukey;
-	int			 rc;
+	struct d_uuid	ukey;
+	int		rc;
 
 	uuid_copy(ukey.uuid, uuid);
 	while (1) {
@@ -425,7 +446,18 @@ vos_pool_kill(uuid_t uuid, bool force)
 		}
 
 		D_ASSERT(pool != NULL);
-		pool->vp_dying = 1;
+		/*
+		 * When this function is called for leftover pools cleanup,
+		 * a new pool with same UUID could have been created, don't
+		 * touch the new pool in this case.
+		 */
+		if (from_cleanup && !pool->vp_dying) {
+			D_WARN("A new pool with same UUID:"DF_UUID"detected\n",
+			       DP_UUID(uuid));
+			vos_pool_decref(pool);
+			return 0;
+		}
+
 		if (gc_have_pool(pool)) {
 			/* still pinned by GC, un-pin it because there is no
 			 * need to run GC for this pool anymore.
@@ -434,31 +466,16 @@ vos_pool_kill(uuid_t uuid, bool force)
 			vos_pool_decref(pool); /* -1 for lookup */
 			continue;	/* try again */
 		}
+		pool->vp_dying = 1;
 		vos_pool_decref(pool); /* -1 for lookup */
 
-		if (force) {
-			D_ERROR("Open reference exists, force kill\n");
-			/* NB: rebuild might still take refcount vos_pool,
-			 * we don't want to fail destroy or locking space.
-			 */
-			break;
-		}
-		D_ERROR("Open reference exists, cannot kill pool\n");
+		D_ERROR(DF_UUID": Open reference exists, force kill\n", DP_UUID(uuid));
+		/* Blob destroy will be deferred to last vos_pool ref drop */
 		return -DER_BUSY;
 	}
 	D_DEBUG(DB_MGMT, "No open handles, OK to delete\n");
 
-	/* NVMe device is configured */
-	if (bio_nvme_configured() && xs_ctxt) {
-		D_DEBUG(DB_MGMT, "Deleting blob for xs:%p pool:"DF_UUID"\n",
-			xs_ctxt, DP_UUID(uuid));
-		rc = bio_blob_delete(uuid, xs_ctxt);
-		if (rc) {
-			D_ERROR("Destroy blob for pool="DF_UUID" rc=%s\n",
-				DP_UUID(uuid), d_errstr(rc));
-			/* do not return the error, nothing we can do */
-		}
-	}
+	vos_delete_blob(uuid);
 	return 0;
 }
 
@@ -738,6 +755,11 @@ vos_pool_open(const char *path, uuid_t uuid, unsigned int flags,
 		D_ASSERT(pool != NULL);
 		D_DEBUG(DB_MGMT, "Found already opened(%d) pool : %p\n",
 			pool->vp_opened, pool);
+		if (pool->vp_dying) {
+			D_ERROR("Found dying pool : %p\n", pool);
+			vos_pool_decref(pool);
+			return -DER_BUSY;
+		}
 		if ((flags & VOS_POF_EXCL) || pool->vp_excl) {
 			vos_pool_decref(pool);
 			return -DER_BUSY;
@@ -865,8 +887,12 @@ vos_pool_query_space(uuid_t pool_id, struct vos_pool_space *vps)
 
 	uuid_copy(ukey.uuid, pool_id);
 	rc = pool_lookup(&ukey, &pool);
-	if (rc)
+	if (rc) {
 		return rc;
+	} else if (pool->vp_dying) {
+		vos_pool_decref(pool);
+		return -DER_NONEXIST;
+	}
 
 	D_ASSERT(pool != NULL);
 	rc = vos_space_query(pool, vps, false);


### PR DESCRIPTION
On pool target destroy, if vos_pool is still being held by lingering
IO requests, we'd defer the blob destroy and pmemobj file deletion
until the vos_pool is released.

The blob destroy will be deferred till the last vos_pool reference
put, or the next server start. The pmemobj file deletion will be
deferred till the next pool target creation, or next server start.

Signed-off-by: Niu Yawei <yawei.niu@intel.com>