### PR TITLE
DAOS-7312 Test: Functional testing for EC auto object class selection

### DIFF
--- a/src/tests/ftest/nvme/nvme_io.yaml
+++ b/src/tests/ftest/nvme/nvme_io.yaml
@@ -29,7 +29,7 @@ ior:
  repetitions: 1
  test_file: /testFile
  object_type:
-  - "SX"
+  - "EC_2P1GX"
   - "S1"
   - "S4"
   - "RP_2GX"


### PR DESCRIPTION
    Replaced SX object for EC

Quick-build: true
Skip-unit-tests: true
Skip-nlt: true
Skip-unit-test: true
Skip-func-test-vm: true
Skip-func-hw-test-small: true
Skip-func-hw-test-medium: true
Test-tag-hw-large: nvme_io

Signed-off-by: Omar Ocampo <omar.ocampo.coronado@intel.com>