### PR TITLE
DAOS-8545 dmg: Fix double percent mark in SMART stats output

### DIFF
--- a/docs/admin/administration.md
+++ b/docs/admin/administration.md
@@ -345,22 +345,22 @@ boro-11
         Volatile Memory Backup: OK
       Intel Vendor SMART Attributes:
         Program Fail Count:
-           Normalized(%%):100
+           Normalized:100%
            Raw:0
         Erase Fail Count:
-           Normalized(%%):100
+           Normalized:100%
            Raw:0
         Wear Leveling Count:
-           Normalized(%%):100
+           Normalized:100%
            Min:24
            Max:25
            Avg:24
         End-to-End Error Detection Count:0
         CRC Error Count:0
-        Timed Workload, Media Wear(%%):63
+        Timed Workload, Media Wear:63%
         Timed Workload, Host Reads:65535
         Timed Workload, Timer:65535
-        Thermal Throttle Status(%%):0
+        Thermal Throttle Status:0%
         Thermal Throttle Event Count:0
         Retry Buffer Overflow Counter:0
         PLL Lock Loss Count:0

--- a/docs/admin/deployment.md
+++ b/docs/admin/deployment.md
@@ -502,22 +502,22 @@ PCI:0000:81:00.0 Model:INTEL SSDPED1K750GA  FW:E2010325 Socket:1 Capacity:750 GB
     Volatile Memory Backup: OK
   Intel Vendor SMART Attributes:
     Program Fail Count:
-       Normalized(%%):100
+       Normalized:100%
        Raw:0
     Erase Fail Count:
-       Normalized(%%):100
+       Normalized:100%
        Raw:0
     Wear Leveling Count:
-       Normalized(%%):100
+       Normalized:100%
        Min:0
        Max:9
        Avg:3
     End-to-End Error Detection Count:0
     CRC Error Count:0
-    Timed Workload, Media Wear(%%):63
+    Timed Workload, Media Wear:63%
     Timed Workload, Host Reads:65535
     Timed Workload, Timer:65535
-    Thermal Throttle Status(%%):0
+    Thermal Throttle Status:0%
     Thermal Throttle Event Count:0
     Retry Buffer Overflow Counter:0
     PLL Lock Loss Count:0
@@ -546,22 +546,22 @@ PCI:0000:da:00.0 Model:INTEL SSDPED1K750GA  FW:E2010325 Socket:1 Capacity:750 GB
     Volatile Memory Backup: OK
   Intel Vendor SMART Attributes:
     Program Fail Count:
-       Normalized(%%):100
+       Normalized:100%
        Raw:0
     Erase Fail Count:
-       Normalized(%%):100
+       Normalized:100%
        Raw:0
     Wear Leveling Count:
-       Normalized(%%):100
+       Normalized:100%
        Min:0
        Max:9
        Avg:3
     End-to-End Error Detection Count:0
     CRC Error Count:0
-    Timed Workload, Media Wear(%%):63
+    Timed Workload, Media Wear:63%
     Timed Workload, Host Reads:65535
     Timed Workload, Timer:65535
-    Thermal Throttle Status(%%):0
+    Thermal Throttle Status:0%
     Thermal Throttle Event Count:0
     Retry Buffer Overflow Counter:0
     PLL Lock Loss Count:0
@@ -593,22 +593,22 @@ PCI:0000:81:00.0 Model:INTEL SSDPED1K750GA  FW:E2010435 Socket:1 Capacity:750 GB
     Volatile Memory Backup: OK
   Intel Vendor SMART Attributes:
     Program Fail Count:
-       Normalized(%%):100
+       Normalized:100%
        Raw:0
     Erase Fail Count:
-       Normalized(%%):100
+       Normalized:100%
        Raw:0
     Wear Leveling Count:
-       Normalized(%%):100
+       Normalized:100%
        Min:0
        Max:9
        Avg:3
     End-to-End Error Detection Count:0
     CRC Error Count:0
-    Timed Workload, Media Wear(%%):63
+    Timed Workload, Media Wear:63%
     Timed Workload, Host Reads:65535
     Timed Workload, Timer:65535
-    Thermal Throttle Status(%%):0
+    Thermal Throttle Status:0%
     Thermal Throttle Event Count:0
     Retry Buffer Overflow Counter:0
     PLL Lock Loss Count:0
@@ -637,22 +637,22 @@ PCI:0000:da:00.0 Model:INTEL SSDPED1K750GA  FW:E2010435 Socket:1 Capacity:750 GB
     Volatile Memory Backup: OK
   Intel Vendor SMART Attributes:
     Program Fail Count:
-       Normalized(%%):100
+       Normalized:100%
        Raw:0
     Erase Fail Count:
-       Normalized(%%):100
+       Normalized:100%
        Raw:0
     Wear Leveling Count:
-       Normalized(%%):100
+       Normalized:100%
        Min:0
        Max:9
        Avg:3
     End-to-End Error Detection Count:0
     CRC Error Count:0
-    Timed Workload, Media Wear(%%):63
+    Timed Workload, Media Wear:63%
     Timed Workload, Host Reads:65535
     Timed Workload, Timer:65535
-    Thermal Throttle Status(%%):0
+    Thermal Throttle Status:0%
     Thermal Throttle Event Count:0
     Retry Buffer Overflow Counter:0
     PLL Lock Loss Count:0

--- a/src/control/cmd/dmg/pretty/storage_nvme.go
+++ b/src/control/cmd/dmg/pretty/storage_nvme.go
@@ -114,17 +114,17 @@ func printNvmeHealth(stat *storage.NvmeHealth, out io.Writer, opts ...PrintConfi
 	if stat.ProgFailCntNorm > 0 {
 		fmt.Fprintf(out, "Intel Vendor SMART Attributes:\n")
 		fmt.Fprintf(iw, "Program Fail Count:\n")
-		fmt.Fprintf(iw, "   Normalized(%s):%d\n", "%%",
+		fmt.Fprintf(iw, "   Normalized:%d%%\n",
 			uint8(stat.ProgFailCntNorm))
 		fmt.Fprintf(iw, "   Raw:%d\n",
 			uint64(stat.ProgFailCntRaw))
 		fmt.Fprintf(iw, "Erase Fail Count:\n")
-		fmt.Fprintf(iw, "   Normalized(%s):%d\n", "%%",
+		fmt.Fprintf(iw, "   Normalized:%d%%\n",
 			uint8(stat.EraseFailCntNorm))
 		fmt.Fprintf(iw, "   Raw:%d\n",
 			uint64(stat.EraseFailCntRaw))
 		fmt.Fprintf(iw, "Wear Leveling Count:\n")
-		fmt.Fprintf(iw, "   Normalized(%s):%d\n", "%%",
+		fmt.Fprintf(iw, "   Normalized:%d%%\n",
 			uint8(stat.WearLevelingCntNorm))
 		fmt.Fprintf(iw, "   Min:%d\n",
 			uint16(stat.WearLevelingCntMin))
@@ -136,13 +136,13 @@ func printNvmeHealth(stat *storage.NvmeHealth, out io.Writer, opts ...PrintConfi
 			uint64(stat.EndtoendErrCntRaw))
 		fmt.Fprintf(iw, "CRC Error Count:%d\n",
 			uint64(stat.CrcErrCntRaw))
-		fmt.Fprintf(iw, "Timed Workload, Media Wear(%s):%d\n", "%%",
+		fmt.Fprintf(iw, "Timed Workload, Media Wear:%d%%\n",
 			uint64(stat.MediaWearRaw))
 		fmt.Fprintf(iw, "Timed Workload, Host Reads:%d\n",
 			uint64(stat.HostReadsRaw))
 		fmt.Fprintf(iw, "Timed Workload, Timer:%d\n",
 			uint64(stat.WorkloadTimerRaw))
-		fmt.Fprintf(iw, "Thermal Throttle Status(%s):%d\n", "%%",
+		fmt.Fprintf(iw, "Thermal Throttle Status:%d%%\n",
 			uint8(stat.ThermalThrottleStatus))
 		fmt.Fprintf(iw, "Thermal Throttle Event Count:%d\n",
 			uint64(stat.ThermalThrottleEventCnt))

--- a/src/control/cmd/dmg/pretty/storage_nvme_test.go
+++ b/src/control/cmd/dmg/pretty/storage_nvme_test.go
@@ -82,22 +82,22 @@ PCI:%s Model:%s FW:%s Socket:%d Capacity:%s
     Volatile Memory Backup: WARNING
   Intel Vendor SMART Attributes:
     Program Fail Count:
-       Normalized(%s):%d
+       Normalized:%d%s
        Raw:%d
     Erase Fail Count:
-       Normalized(%s):%d
+       Normalized:%d%s
        Raw:%d
     Wear Leveling Count:
-       Normalized(%s):%d
+       Normalized:%d%s
        Min:%d
        Max:%d
        Avg:%d
     End-to-End Error Detection Count:%d
     CRC Error Count:%d
-    Timed Workload, Media Wear(%s):%d
+    Timed Workload, Media Wear:%d%s
     Timed Workload, Host Reads:%d
     Timed Workload, Timer:%d
-    Thermal Throttle Status(%s):%d
+    Thermal Throttle Status:%d%s
     Thermal Throttle Event Count:%d
     Retry Buffer Overflow Counter:%d
     PLL Lock Loss Count:%d
@@ -123,22 +123,22 @@ PCI:%s Model:%s FW:%s Socket:%d Capacity:%s
     Volatile Memory Backup: WARNING
   Intel Vendor SMART Attributes:
     Program Fail Count:
-       Normalized(%s):%d
+       Normalized:%d%s
        Raw:%d
     Erase Fail Count:
-       Normalized(%s):%d
+       Normalized:%d%s
        Raw:%d
     Wear Leveling Count:
-       Normalized(%s):%d
+       Normalized:%d%s
        Min:%d
        Max:%d
        Avg:%d
     End-to-End Error Detection Count:%d
     CRC Error Count:%d
-    Timed Workload, Media Wear(%s):%d
+    Timed Workload, Media Wear:%d%s
     Timed Workload, Host Reads:%d
     Timed Workload, Timer:%d
-    Thermal Throttle Status(%s):%d
+    Thermal Throttle Status:%d%s
     Thermal Throttle Event Count:%d
     Retry Buffer Overflow Counter:%d
     PLL Lock Loss Count:%d
@@ -154,14 +154,14 @@ PCI:%s Model:%s FW:%s Socket:%d Capacity:%s
 				time.Duration(controllerA.HealthStats.PowerOnHours)*time.Hour,
 				controllerA.HealthStats.UnsafeShutdowns, controllerA.HealthStats.MediaErrors,
 				controllerA.HealthStats.ErrorLogEntries,
-				"%%", controllerA.HealthStats.ProgFailCntNorm, controllerA.HealthStats.ProgFailCntRaw,
-				"%%", controllerA.HealthStats.EraseFailCntNorm, controllerA.HealthStats.EraseFailCntRaw,
-				"%%", controllerA.HealthStats.WearLevelingCntNorm, controllerA.HealthStats.WearLevelingCntMin,
+				controllerA.HealthStats.ProgFailCntNorm, "%", controllerA.HealthStats.ProgFailCntRaw,
+				controllerA.HealthStats.EraseFailCntNorm, "%", controllerA.HealthStats.EraseFailCntRaw,
+				controllerA.HealthStats.WearLevelingCntNorm, "%", controllerA.HealthStats.WearLevelingCntMin,
 				controllerA.HealthStats.WearLevelingCntMax, controllerA.HealthStats.WearLevelingCntAvg,
 				controllerA.HealthStats.EndtoendErrCntRaw, controllerA.HealthStats.CrcErrCntRaw,
-				"%%", controllerA.HealthStats.MediaWearRaw, controllerA.HealthStats.HostReadsRaw,
+				controllerA.HealthStats.MediaWearRaw, "%", controllerA.HealthStats.HostReadsRaw,
 				controllerA.HealthStats.WorkloadTimerRaw,
-				"%%", controllerA.HealthStats.ThermalThrottleStatus, controllerA.HealthStats.ThermalThrottleEventCnt,
+				controllerA.HealthStats.ThermalThrottleStatus, "%", controllerA.HealthStats.ThermalThrottleEventCnt,
 				controllerA.HealthStats.RetryBufferOverflowCnt,
 				controllerA.HealthStats.PllLockLossCnt,
 				controllerA.HealthStats.NandBytesWritten, controllerA.HealthStats.HostBytesWritten,
@@ -174,14 +174,14 @@ PCI:%s Model:%s FW:%s Socket:%d Capacity:%s
 				time.Duration(controllerB.HealthStats.PowerOnHours)*time.Hour,
 				controllerB.HealthStats.UnsafeShutdowns, controllerB.HealthStats.MediaErrors,
 				controllerB.HealthStats.ErrorLogEntries,
-				"%%", controllerB.HealthStats.ProgFailCntNorm, controllerB.HealthStats.ProgFailCntRaw,
-				"%%", controllerB.HealthStats.EraseFailCntNorm, controllerB.HealthStats.EraseFailCntRaw,
-				"%%", controllerB.HealthStats.WearLevelingCntNorm, controllerB.HealthStats.WearLevelingCntMin,
+				controllerB.HealthStats.ProgFailCntNorm, "%", controllerB.HealthStats.ProgFailCntRaw,
+				controllerB.HealthStats.EraseFailCntNorm, "%", controllerB.HealthStats.EraseFailCntRaw,
+				controllerB.HealthStats.WearLevelingCntNorm, "%", controllerB.HealthStats.WearLevelingCntMin,
 				controllerB.HealthStats.WearLevelingCntMax, controllerB.HealthStats.WearLevelingCntAvg,
 				controllerB.HealthStats.EndtoendErrCntRaw, controllerB.HealthStats.CrcErrCntRaw,
-				"%%", controllerB.HealthStats.MediaWearRaw, controllerB.HealthStats.HostReadsRaw,
+				controllerB.HealthStats.MediaWearRaw, "%", controllerB.HealthStats.HostReadsRaw,
 				controllerB.HealthStats.WorkloadTimerRaw,
-				"%%", controllerB.HealthStats.ThermalThrottleStatus, controllerB.HealthStats.ThermalThrottleEventCnt,
+				controllerB.HealthStats.ThermalThrottleStatus, "%", controllerB.HealthStats.ThermalThrottleEventCnt,
 				controllerB.HealthStats.RetryBufferOverflowCnt,
 				controllerB.HealthStats.PllLockLossCnt,
 				controllerB.HealthStats.NandBytesWritten, controllerB.HealthStats.HostBytesWritten,
@@ -226,22 +226,22 @@ PCI:%s Model:%s FW:%s Socket:%d Capacity:%s
     Volatile Memory Backup: WARNING
   Intel Vendor SMART Attributes:
     Program Fail Count:
-       Normalized(%s):%d
+       Normalized:%d%s
        Raw:%d
     Erase Fail Count:
-       Normalized(%s):%d
+       Normalized:%d%s
        Raw:%d
     Wear Leveling Count:
-       Normalized(%s):%d
+       Normalized:%d%s
        Min:%d
        Max:%d
        Avg:%d
     End-to-End Error Detection Count:%d
     CRC Error Count:%d
-    Timed Workload, Media Wear(%s):%d
+    Timed Workload, Media Wear:%d%s
     Timed Workload, Host Reads:%d
     Timed Workload, Timer:%d
-    Thermal Throttle Status(%s):%d
+    Thermal Throttle Status:%d%s
     Thermal Throttle Event Count:%d
     Retry Buffer Overflow Counter:%d
     PLL Lock Loss Count:%d
@@ -259,14 +259,14 @@ PCI:%s Model:%s FW:%s Socket:%d Capacity:%s
 				controllerAwTS.HealthStats.ReadErrors, controllerAwTS.HealthStats.WriteErrors,
 				controllerAwTS.HealthStats.UnmapErrors, controllerAwTS.HealthStats.ChecksumErrors,
 				controllerAwTS.HealthStats.ErrorLogEntries,
-				"%%", controllerAwTS.HealthStats.ProgFailCntNorm, controllerAwTS.HealthStats.ProgFailCntRaw,
-				"%%", controllerAwTS.HealthStats.EraseFailCntNorm, controllerAwTS.HealthStats.EraseFailCntRaw,
-				"%%", controllerAwTS.HealthStats.WearLevelingCntNorm, controllerAwTS.HealthStats.WearLevelingCntMin,
+				controllerAwTS.HealthStats.ProgFailCntNorm, "%", controllerAwTS.HealthStats.ProgFailCntRaw,
+				controllerAwTS.HealthStats.EraseFailCntNorm, "%", controllerAwTS.HealthStats.EraseFailCntRaw,
+				controllerAwTS.HealthStats.WearLevelingCntNorm, "%", controllerAwTS.HealthStats.WearLevelingCntMin,
 				controllerAwTS.HealthStats.WearLevelingCntMax, controllerAwTS.HealthStats.WearLevelingCntAvg,
 				controllerAwTS.HealthStats.EndtoendErrCntRaw, controllerAwTS.HealthStats.CrcErrCntRaw,
-				"%%", controllerAwTS.HealthStats.MediaWearRaw, controllerAwTS.HealthStats.HostReadsRaw,
+				controllerAwTS.HealthStats.MediaWearRaw, "%", controllerAwTS.HealthStats.HostReadsRaw,
 				controllerAwTS.HealthStats.WorkloadTimerRaw,
-				"%%", controllerAwTS.HealthStats.ThermalThrottleStatus, controllerAwTS.HealthStats.ThermalThrottleEventCnt,
+				controllerAwTS.HealthStats.ThermalThrottleStatus, "%", controllerAwTS.HealthStats.ThermalThrottleEventCnt,
 				controllerAwTS.HealthStats.RetryBufferOverflowCnt,
 				controllerAwTS.HealthStats.PllLockLossCnt,
 				controllerAwTS.HealthStats.NandBytesWritten, controllerAwTS.HealthStats.HostBytesWritten,

--- a/src/control/cmd/dmg/pretty/storage_test.go
+++ b/src/control/cmd/dmg/pretty/storage_test.go
@@ -1476,22 +1476,22 @@ host1
         Volatile Memory Backup: WARNING
       Intel Vendor SMART Attributes:
         Program Fail Count:
-           Normalized(%s):%d
+           Normalized:%d%s
            Raw:%d
         Erase Fail Count:
-           Normalized(%s):%d
+           Normalized:%d%s
            Raw:%d
         Wear Leveling Count:
-           Normalized(%s):%d
+           Normalized:%d%s
            Min:%d
            Max:%d
            Avg:%d
         End-to-End Error Detection Count:%d
         CRC Error Count:%d
-        Timed Workload, Media Wear(%s):%d
+        Timed Workload, Media Wear:%d%s
         Timed Workload, Host Reads:%d
         Timed Workload, Timer:%d
-        Thermal Throttle Status(%s):%d
+        Thermal Throttle Status:%d%s
         Thermal Throttle Event Count:%d
         Retry Buffer Overflow Counter:%d
         PLL Lock Loss Count:%d
@@ -1505,14 +1505,14 @@ host1
 				time.Duration(mockController.HealthStats.PowerOnHours)*time.Hour,
 				mockController.HealthStats.UnsafeShutdowns, mockController.HealthStats.MediaErrors,
 				mockController.HealthStats.ErrorLogEntries,
-				"%%", mockController.HealthStats.ProgFailCntNorm, mockController.HealthStats.ProgFailCntRaw,
-				"%%", mockController.HealthStats.EraseFailCntNorm, mockController.HealthStats.EraseFailCntRaw,
-				"%%", mockController.HealthStats.WearLevelingCntNorm, mockController.HealthStats.WearLevelingCntMin,
+				mockController.HealthStats.ProgFailCntNorm, "%", mockController.HealthStats.ProgFailCntRaw,
+				mockController.HealthStats.EraseFailCntNorm, "%", mockController.HealthStats.EraseFailCntRaw,
+				mockController.HealthStats.WearLevelingCntNorm, "%", mockController.HealthStats.WearLevelingCntMin,
 				mockController.HealthStats.WearLevelingCntMax, mockController.HealthStats.WearLevelingCntAvg,
 				mockController.HealthStats.EndtoendErrCntRaw, mockController.HealthStats.CrcErrCntRaw,
-				"%%", mockController.HealthStats.MediaWearRaw, mockController.HealthStats.HostReadsRaw,
+				mockController.HealthStats.MediaWearRaw, "%", mockController.HealthStats.HostReadsRaw,
 				mockController.HealthStats.WorkloadTimerRaw,
-				"%%", mockController.HealthStats.ThermalThrottleStatus, mockController.HealthStats.ThermalThrottleEventCnt,
+				mockController.HealthStats.ThermalThrottleStatus, "%", mockController.HealthStats.ThermalThrottleEventCnt,
 				mockController.HealthStats.RetryBufferOverflowCnt,
 				mockController.HealthStats.PllLockLossCnt,
 				mockController.HealthStats.NandBytesWritten, mockController.HealthStats.HostBytesWritten,


### PR DESCRIPTION
Error in SMART stats output now resolved.

Intel Vendor SMART Attributes:
Program Fail Count:
Normalized(%%):100 --> Normalized:100%

Signed-off-by: Sydney Vanda <sydney.m.vanda@intel.com>