### PR TITLE
DAOS-8330 tools: Fix JSON output for daos fs attr cmds

### DIFF
--- a/src/control/cmd/daos/filesystem.go
+++ b/src/control/cmd/daos/filesystem.go
@@ -210,11 +210,11 @@ func (cmd *fsGetAttrCmd) Execute(_ []string) error {
 	C.daos_oclass_id2name(attrs.doi_oclass_id, &oclassName[0])
 
 	if cmd.jsonOutputEnabled() {
-		jsonAttrs := &struct{
-			ObjClass string `json:"oclass"`
+		jsonAttrs := &struct {
+			ObjClass  string `json:"oclass"`
 			ChunkSize uint64 `json:"chunk_size"`
 		}{
-			ObjClass: C.GoString(&oclassName[0]),
+			ObjClass:  C.GoString(&oclassName[0]),
 			ChunkSize: uint64(attrs.doi_chunk_size),
 		}
 		return cmd.outputJSON(jsonAttrs, nil)

--- a/src/control/cmd/daos/filesystem.go
+++ b/src/control/cmd/daos/filesystem.go
@@ -13,7 +13,6 @@ import "C"
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/pkg/errors"
 )
@@ -28,12 +27,12 @@ func dfsError(rc C.int) error {
 }
 
 type fsCmd struct {
-	Copy           fsCopyCmd `command:"copy" description:"copy to and from a POSIX filesystem"`
-	SetAttr        fsAttrCmd `command:"set-attr" description:"set fs attributes"`
-	GetAttr        fsAttrCmd `command:"get-attr" description:"get fs attributes"`
-	ResetAttr      fsAttrCmd `command:"reset-attr" description:"reset fs attributes"`
-	ResetChunkSize fsAttrCmd `command:"reset-chunk-size" description:"reset fs chunk size"`
-	ResetObjClass  fsAttrCmd `command:"reset-oclass" description:"reset fs obj class"`
+	Copy           fsCopyCmd           `command:"copy" description:"copy to and from a POSIX filesystem"`
+	SetAttr        fsSetAttrCmd        `command:"set-attr" description:"set fs attributes"`
+	GetAttr        fsGetAttrCmd        `command:"get-attr" description:"get fs attributes"`
+	ResetAttr      fsResetAttrCmd      `command:"reset-attr" description:"reset fs attributes"`
+	ResetChunkSize fsResetChunkSizeCmd `command:"reset-chunk-size" description:"reset fs chunk size"`
+	ResetObjClass  fsResetOclassCmd    `command:"reset-oclass" description:"reset fs obj class"`
 }
 
 type fsCopyCmd struct {
@@ -69,62 +68,62 @@ func (cmd *fsCopyCmd) Execute(_ []string) error {
 type fsAttrCmd struct {
 	existingContainerCmd
 
-	ChunkSize   ChunkSizeFlag `long:"chunk-size" short:"z" description:"container chunk size"`
-	ObjectClass ObjClassFlag  `long:"oclass" short:"o" description:"default object class"`
-	DfsPath     string        `long:"dfs-path" short:"H" description:"DFS path relative to root of container, when using pool and container instead of --path and the UNS"`
-	DfsPrefix   string        `long:"dfs-prefix" short:"I" description:"Optional prefix path to the root of the DFS container when using pool and container"`
+	DfsPath   string `long:"dfs-path" short:"H" description:"DFS path relative to root of container, when using pool and container instead of --path and the UNS"`
+	DfsPrefix string `long:"dfs-prefix" short:"I" description:"Optional prefix path to the root of the DFS container when using pool and container"`
 }
 
-func (cmd *fsAttrCmd) Execute(_ []string) error {
+func setupFSAttrCmd(cmd *fsAttrCmd) (*C.struct_cmd_args_s, func(), error) {
 	ap, deallocCmdArgs, err := allocCmdArgs(cmd.log)
 	if err != nil {
-		return err
+		return nil, nil, err
 	}
-	defer deallocCmdArgs()
 
 	if cmd.DfsPath != "" {
 		if cmd.Path != "" {
-			return errors.New("Cannot use both --dfs-path and --path")
+			deallocCmdArgs()
+			return nil, nil, errors.New("Cannot use both --dfs-path and --path")
 		}
 		ap.dfs_path = C.CString(cmd.DfsPath)
 	}
 	if cmd.DfsPrefix != "" {
 		if cmd.Path != "" {
-			return errors.New("Cannot use both --dfs-prefix and --path")
+			deallocCmdArgs()
+			return nil, nil, errors.New("Cannot use both --dfs-prefix and --path")
 		}
 		ap.dfs_prefix = C.CString(cmd.DfsPrefix)
 	}
 
-	flags := C.uint(C.DAOS_COO_RW)
-	op := os.Args[2]
+	return ap, deallocCmdArgs, nil
+}
+
+func fsOpString(op uint32) string {
 	switch op {
-	case "set-attr":
-		ap.fs_op = C.FS_SET_ATTR
-		if cmd.ObjectClass.Set {
-			ap.oclass = cmd.ObjectClass.Class
-		}
-		if cmd.ChunkSize.Set {
-			ap.chunk_size = cmd.ChunkSize.Size
-		}
-	case "get-attr":
-		ap.fs_op = C.FS_GET_ATTR
-		flags = C.DAOS_COO_RO
-	case "reset-attr":
-		ap.fs_op = C.FS_RESET_ATTR
-	case "reset-chunk-size":
-		ap.fs_op = C.FS_RESET_CHUNK_SIZE
-		if !cmd.ChunkSize.Set {
-			return errors.New("--chunk-size not set")
-		}
-		ap.chunk_size = cmd.ChunkSize.Size
-	case "reset-oclass":
-		ap.fs_op = C.FS_RESET_OCLASS
-		if !cmd.ObjectClass.Set {
-			return errors.New("--oclass not set")
-		}
-		ap.oclass = cmd.ObjectClass.Class
-	default:
-		return errors.Errorf("unknown fs op %q", op)
+	case C.FS_SET_ATTR:
+		return "set-attr"
+	case C.FS_RESET_ATTR:
+		return "reset-attr"
+	case C.FS_RESET_CHUNK_SIZE:
+		return "reset-chunk-size"
+	case C.FS_RESET_OCLASS:
+		return "reset-oclass"
+	case C.FS_GET_ATTR:
+		return "get-attr"
+	}
+	return "unknown operation"
+}
+
+func fsModifyAttr(cmd *fsAttrCmd, op uint32, updateAP func(*C.struct_cmd_args_s)) error {
+	ap, deallocCmdArgs, err := setupFSAttrCmd(cmd)
+	if err != nil {
+		return err
+	}
+	defer deallocCmdArgs()
+
+	flags := C.uint(C.DAOS_COO_RW)
+
+	ap.fs_op = op
+	if updateAP != nil {
+		updateAP(ap)
 	}
 
 	cleanup, err := cmd.resolveAndConnect(flags, ap)
@@ -134,8 +133,95 @@ func (cmd *fsAttrCmd) Execute(_ []string) error {
 	defer cleanup()
 
 	if err := dfsError(C.fs_dfs_hdlr(ap)); err != nil {
-		return errors.Wrapf(err, "%s failed", op)
+		return errors.Wrapf(err, "%s failed", fsOpString(op))
 	}
+
+	return nil
+}
+
+type fsSetAttrCmd struct {
+	fsAttrCmd
+
+	ChunkSize   ChunkSizeFlag `long:"chunk-size" short:"z" description:"container chunk size"`
+	ObjectClass ObjClassFlag  `long:"oclass" short:"o" description:"default object class"`
+}
+
+func (cmd *fsSetAttrCmd) Execute(_ []string) error {
+	return fsModifyAttr(&cmd.fsAttrCmd, C.FS_SET_ATTR, func(ap *C.struct_cmd_args_s) {
+		if cmd.ObjectClass.Set {
+			ap.oclass = cmd.ObjectClass.Class
+		}
+		if cmd.ChunkSize.Set {
+			ap.chunk_size = cmd.ChunkSize.Size
+		}
+	})
+}
+
+type fsResetAttrCmd struct {
+	fsAttrCmd
+}
+
+func (cmd *fsResetAttrCmd) Execute(_ []string) error {
+	return fsModifyAttr(&cmd.fsAttrCmd, C.FS_RESET_ATTR, nil)
+}
+
+type fsResetChunkSizeCmd struct {
+	fsAttrCmd
+}
+
+func (cmd *fsResetChunkSizeCmd) Execute(_ []string) error {
+	return fsModifyAttr(&cmd.fsAttrCmd, C.FS_RESET_CHUNK_SIZE, nil)
+}
+
+type fsResetOclassCmd struct {
+	fsAttrCmd
+}
+
+func (cmd *fsResetOclassCmd) Execute(_ []string) error {
+	return fsModifyAttr(&cmd.fsAttrCmd, C.FS_RESET_OCLASS, nil)
+}
+
+type fsGetAttrCmd struct {
+	fsAttrCmd
+}
+
+func (cmd *fsGetAttrCmd) Execute(_ []string) error {
+	ap, deallocCmdArgs, err := setupFSAttrCmd(&cmd.fsAttrCmd)
+	if err != nil {
+		return err
+	}
+	defer deallocCmdArgs()
+
+	ap.fs_op = C.FS_GET_ATTR
+	flags := C.uint(C.DAOS_COO_RO)
+
+	cleanup, err := cmd.resolveAndConnect(flags, ap)
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+
+	var attrs C.dfs_obj_info_t
+	if err := dfsError(C.fs_dfs_get_attr_hdlr(ap, &attrs)); err != nil {
+		return errors.Wrapf(err, "%s failed", fsOpString((ap.fs_op)))
+	}
+
+	var oclassName [16]C.char
+	C.daos_oclass_id2name(attrs.doi_oclass_id, &oclassName[0])
+
+	if cmd.jsonOutputEnabled() {
+		jsonAttrs := &struct{
+			ObjClass string `json:"oclass"`
+			ChunkSize uint64 `json:"chunk_size"`
+		}{
+			ObjClass: C.GoString(&oclassName[0]),
+			ChunkSize: uint64(attrs.doi_chunk_size),
+		}
+		return cmd.outputJSON(jsonAttrs, nil)
+	}
+
+	cmd.log.Infof("Object Class = %s", C.GoString(&oclassName[0]))
+	cmd.log.Infof("Object Chunk Size = %d", attrs.doi_chunk_size)
 
 	return nil
 }

--- a/src/include/daos_fs.h
+++ b/src/include/daos_fs.h
@@ -21,6 +21,7 @@ extern "C" {
 #endif
 
 #include <dirent.h>
+#include <sys/stat.h>
 
 /** Maximum Name length */
 #define DFS_MAX_NAME		NAME_MAX

--- a/src/utils/daos_dfs_hdlr.c
+++ b/src/utils/daos_dfs_hdlr.c
@@ -34,10 +34,7 @@ fs_dfs_hdlr(struct cmd_args_s *ap)
 	char            *dir_name = NULL;
 	int		rc, rc2;
 
-	if (ap->fs_op == FS_GET_ATTR)
-		flags = O_RDONLY;
-	else
-		flags = O_RDWR;
+	flags = O_RDWR;
 
 	rc = dfs_mount(ap->pool, ap->cont, flags, &dfs);
 	if (rc) {
@@ -53,29 +50,6 @@ fs_dfs_hdlr(struct cmd_args_s *ap)
 	}
 
 	switch (ap->fs_op) {
-	case FS_GET_ATTR:
-	{
-		dfs_obj_info_t	info;
-		char		oclass_name[16];
-
-		rc = dfs_lookup(dfs, ap->dfs_path, flags, &obj, NULL, NULL);
-		if (rc) {
-			fprintf(ap->errstream, "failed to lookup %s (%s)\n",
-				ap->dfs_path, strerror(rc));
-			D_GOTO(out_umount, rc);
-		}
-
-		rc = dfs_obj_get_info(dfs, obj, &info);
-		if (rc) {
-			fprintf(ap->errstream, "failed to get obj info (%s)\n", strerror(rc));
-			D_GOTO(out_release, rc);
-		}
-
-		daos_oclass_id2name(info.doi_oclass_id, oclass_name);
-		fprintf(ap->outstream, "Object Class = %s\n", oclass_name);
-		fprintf(ap->outstream, "Object Chunk Size = %zu\n", info.doi_chunk_size);
-		break;
-	}
 	case FS_RESET_ATTR:
 	case FS_RESET_CHUNK_SIZE:
 	case FS_RESET_OCLASS:
@@ -166,8 +140,6 @@ out_release:
 	rc2 = dfs_release(obj);
 	if (rc2 != 0)
 		fprintf(ap->errstream, "failed to release dfs obj\n");
-	if (rc == 0)
-		rc = rc2;
 out_names:
 	D_FREE(name);
 	D_FREE(dir_name);
@@ -175,7 +147,55 @@ out_umount:
 	rc2 = dfs_umount(dfs);
 	if (rc2 != 0)
 		fprintf(ap->errstream, "failed to umount DFS container\n");
-	if (rc == 0)
-		rc = rc2;
+	return rc;
+}
+
+int
+fs_dfs_get_attr_hdlr(struct cmd_args_s *ap, dfs_obj_info_t *attrs)
+{
+	int		 flags = O_RDONLY;
+	int		 rc;
+	int		 rc2;
+	dfs_t		*dfs;
+	dfs_obj_t	*obj;
+
+	D_ASSERT(ap != NULL);
+	D_ASSERT(attrs != NULL);
+
+	rc = dfs_mount(ap->pool, ap->cont, flags, &dfs);
+	if (rc) {
+		fprintf(ap->errstream, "failed to mount container %s: %s (%d)\n",
+			ap->cont_str, strerror(rc), rc);
+		return rc;
+	}
+
+	if (ap->dfs_prefix) {
+		rc = dfs_set_prefix(dfs, ap->dfs_prefix);
+		if (rc)
+			D_GOTO(out_umount, rc);
+	}
+
+	rc = dfs_lookup(dfs, ap->dfs_path, flags, &obj, NULL, NULL);
+	if (rc) {
+		fprintf(ap->errstream, "failed to lookup %s (%s)\n",
+			ap->dfs_path, strerror(rc));
+		D_GOTO(out_umount, rc);
+	}
+
+	rc = dfs_obj_get_info(dfs, obj, attrs);
+	if (rc) {
+		fprintf(ap->errstream, "failed to get obj info (%s)\n",
+			strerror(rc));
+		D_GOTO(out_release, rc);
+	}
+
+out_release:
+	rc2 = dfs_release(obj);
+	if (rc2 != 0)
+		fprintf(ap->errstream, "failed to release dfs obj\n");
+out_umount:
+	rc2 = dfs_umount(dfs);
+	if (rc2 != 0)
+		fprintf(ap->errstream, "failed to umount DFS container\n");
 	return rc;
 }

--- a/src/utils/daos_hdlr.h
+++ b/src/utils/daos_hdlr.h
@@ -7,6 +7,8 @@
 #ifndef __DAOS_HDLR_H__
 #define __DAOS_HDLR_H__
 
+#include <daos_fs.h>
+
 enum fs_op {
 	FS_COPY,
 	FS_SET_ATTR,
@@ -193,6 +195,7 @@ int pool_autotest_hdlr(struct cmd_args_s *ap);
 /* filesystem operations */
 int fs_copy_hdlr(struct cmd_args_s *ap);
 int fs_dfs_hdlr(struct cmd_args_s *ap);
+int fs_dfs_get_attr_hdlr(struct cmd_args_s *ap, dfs_obj_info_t *attrs);
 int parse_filename_dfs(const char *path, char **_obj_name, char **_cont_name);
 
 /* Container operations */


### PR DESCRIPTION
- Use separate command objects instead of relying on argument
  order. The options (like --json) may be placed earlier in
  the command string, e.g. "daos fs --json get-attr ..."
- Add a new handler for daos fs get-attr to return the contents
  of dfs_obj_info_t. The tool decides on the formatting.

Signed-off-by: Kris Jacque <kristin.jacque@intel.com>