### PR TITLE
DAOS-8557 ctrl: Skip health query for "NEW" devices

### DIFF
--- a/src/control/server/ctl_smd_rpc.go
+++ b/src/control/server/ctl_smd_rpc.go
@@ -96,6 +96,10 @@ func (svc *ControlService) querySmdDevices(ctx context.Context, req *ctlpb.SmdQu
 		}
 
 		for _, dev := range rResp.Devices {
+			/* Skip health query if the device is in "NEW" state */
+			if dev.State == "NEW" {
+				continue
+			}
 			health, err := srv.GetBioHealth(ctx, &ctlpb.BioHealthReq{
 				DevUuid: dev.Uuid,
 			})


### PR DESCRIPTION
Instead of failing, just skip the device health query for any SSDs
in the “NEW” state. This way the health output of all devices will
be printed with dmg storage query list-devices --health instead of
failing with a single “NEW” device.

Signed-off-by: Sydney Vanda <sydney.m.vanda@intel.com>