### PR TITLE
DAOS-8190 dfuse: Add checking for new fuse flags.

### DIFF
--- a/src/client/dfuse/dfuse_fuseops.c
+++ b/src/client/dfuse/dfuse_fuseops.c
@@ -39,8 +39,18 @@ dfuse_show_flags(void *handle, unsigned int in)
 	SHOW_FLAG(handle, in, FUSE_CAP_POSIX_ACL);
 	SHOW_FLAG(handle, in, FUSE_CAP_HANDLE_KILLPRIV);
 
+#ifdef FUSE_CAP_CACHE_SYMLINKS
+	SHOW_FLAG(handle, in, FUSE_CAP_CACHE_SYMLINKS);
+#endif
+#ifdef FUSE_CAP_NO_OPENDIR_SUPPORT
+	SHOW_FLAG(handle, in, FUSE_CAP_NO_OPENDIR_SUPPORT);
+#endif
+#ifdef FUSE_CAP_EXPLICIT_INVAL_DATA
+	SHOW_FLAG(handle, in, FUSE_CAP_EXPLICIT_INVAL_DATA);
+#endif
+
 	if (in)
-		DFUSE_TRA_ERROR(handle, "Unknown flags %#x", in);
+		DFUSE_TRA_WARNING(handle, "Unknown flags %#x", in);
 }
 
 /* Called on filesystem init.  It has the ability to both observe configuration


### PR DESCRIPTION
Check for FUSE_CAP_CACHE_SYMLINKS, FUSE_CAP_NO_OPENDIR_SUPPORT and
FUSE_CAP_EXPLICIT_INVAL_DATA in the want flags so we can log
if the kernel supports them.

Downgrade the message for unknown flags from a error to a warning.

There is no code change here, dfuse simply logs the features that
libfuse is offering, the issue is that a newer kernel and libfuse
had set some feature bits that dfuse was not aware of, this change
simply logs the feature bits by name on startup.

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>
