### PR TITLE
CORCI-1081 ci: Move default EL7 testing to EL8 

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,7 +12,7 @@
 
 // To use a test branch (i.e. PR) until it lands to master
 // I.e. for testing library changes
-//@Library(value="pipeline-lib@your_branch") _
+@Library(value="pipeline-lib@bmurrell/run-prs-on-el8-hw") _
 
 // For master, this is just some wildly high number
 next_version = "1000"


### PR DESCRIPTION
Support needed for testing with EL8 on hardware clusters.