### PR TITLE
DAOS-8431 test: increase number of hugepages for cpu_usage test

### DIFF
--- a/src/tests/ftest/server/cpu_usage.yaml
+++ b/src/tests/ftest/server/cpu_usage.yaml
@@ -5,6 +5,7 @@ hosts:
     - client-A
 timeout: 130
 server_config:
+  nr_hugepages: 8192
   servers:
     # 16 targets and 16 nr_xs_helpers are the requirements.
     targets: 16


### PR DESCRIPTION
The server config has NVMe enabled and 16 targets, 4096 hugepages
configured. BIO internally requires at least 1GB hugepages per target,
so the hugepages needs be configured as 8192 or larger.

Test-tag: pr cpu_usage

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>