### PR TITLE
DAOS-8492 object: check resent RPC during DTX with CPU yield

### DIFF
--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -116,7 +116,7 @@ obj_rw_complete(crt_rpc_t *rpc, struct obj_io_context *ioc,
 		if (rc != 0) {
 			D_CDEBUG(rc == -DER_REC2BIG || rc == -DER_INPROGRESS ||
 				 rc == -DER_TX_RESTART || rc == -DER_EXIST ||
-				 rc == -DER_NONEXIST,
+				 rc == -DER_NONEXIST || rc == -DER_ALREADY,
 				 DLOG_DBG, DLOG_ERR,
 				 DF_UOID " %s end failed: "DF_RC"\n",
 				 DP_UOID(orwi->orw_oid),
@@ -1279,6 +1279,7 @@ obj_local_rw_internal(crt_rpc_t *rpc, struct obj_io_context *ioc,
 	daos_iod_t			*iods;
 	uint64_t			*offs;
 	uint64_t			 cond_flags;
+	uint64_t			 sched_seq = sched_cur_seq();
 	daos_iod_t			*iods_dup = NULL; /* for EC deg fetch */
 	bool				 get_parity_list = false;
 	struct daos_recx_ep_list	*parity_list = NULL;
@@ -1619,10 +1620,34 @@ post:
 	err = bio_iod_post(biod);
 	rc = rc ? : err;
 out:
+	/* There is CPU yield after DTX start, and the resent RPC may be handled during that.
+	 * Let's check resent again before further process.
+	 */
+	if (rc == 0 && obj_rpc_is_update(rpc) && !dth->dth_pinned && sched_cur_seq() != sched_seq) {
+		daos_epoch_t	epoch = 0;
+		int		rc1;
+
+		rc1 = dtx_handle_resend(ioc->ioc_vos_coh, &orw->orw_dti, &epoch, NULL);
+		switch (rc1) {
+		case 0:
+			orw->orw_epoch = epoch;
+			/* Fall through */
+		case -DER_ALREADY:
+			rc = -DER_ALREADY;
+			break;
+		case -DER_NONEXIST:
+		case -DER_EP_OLD:
+			break;
+		default:
+			rc = rc1;
+			break;
+		}
+	}
+
 	rc = obj_rw_complete(rpc, ioc, ioh, rc, dth);
 	if (iods_dup != NULL)
 		daos_iod_recx_free(iods_dup, orw->orw_nr);
-	return rc;
+	return unlikely(rc == -DER_ALREADY) ? 0 : rc;
 }
 
 static int
@@ -3858,6 +3883,7 @@ ds_cpd_handle_one(crt_rpc_t *rpc, struct daos_cpd_sub_head *dcsh,
 	int				  rc = 0;
 	int				  i;
 	uint64_t			  update_flags;
+	uint64_t			  sched_seq = sched_cur_seq();
 
 	if (dth->dth_flags & DTE_LEADER &&
 	    DAOS_FAIL_CHECK(DAOS_DTX_RESTART))
@@ -4058,49 +4084,71 @@ ds_cpd_handle_one(crt_rpc_t *rpc, struct daos_cpd_sub_head *dcsh,
 		}
 	}
 
-	/* P4: punch and vos_update_end. */
+	/* P4: data verification and copy. */
+	for (i = 0; i < dcde->dcde_write_cnt; i++) {
+		dcsr = &dcsrs[dcri[i].dcri_req_idx];
+		if (dcsr->dcsr_opc != DCSO_UPDATE)
+			continue;
+
+		dcu = &dcsr->dcsr_update;
+		if (dcu->dcu_ec_split_req != NULL) {
+			iods = dcu->dcu_ec_split_req->osr_iods;
+			csums = dcu->dcu_ec_split_req->osr_iod_csums;
+		} else {
+			iods = dcu->dcu_iod_array.oia_iods;
+			csums = dcu->dcu_iod_array.oia_iod_csums;
+		}
+
+		rc = vos_dedup_verify(iohs[i]);
+		if (rc != 0) {
+			D_ERROR("dedup_verify failed for obj "DF_UOID", DTX "DF_DTI": "DF_RC"\n",
+				DP_UOID(dcsr->dcsr_oid), DP_DTI(&dcsh->dcsh_xid), DP_RC(rc));
+			goto out;
+		}
+
+		rc = obj_verify_bio_csum(dcsr->dcsr_oid.id_pub, iods, csums, biods[i],
+					 ioc->ioc_coc->sc_csummer, dcsr->dcsr_nr);
+		if (rc != 0) {
+			if (rc == -DER_CSUM)
+				obj_log_csum_err();
+			goto out;
+		}
+
+		rc = bio_iod_post(biods[i]);
+		biods[i] = NULL;
+		if (rc != 0) {
+			D_ERROR("iod_post failed for obj "DF_UOID", DTX "DF_DTI": "DF_RC"\n",
+				DP_UOID(dcsr->dcsr_oid), DP_DTI(&dcsh->dcsh_xid), DP_RC(rc));
+			goto out;
+		}
+	}
+
+	/* There is CPU yield after DTX start, and the resent RPC may be handled during that.
+	 * Let's check resent again before further process.
+	 */
+	if (rc == 0 && dth->dth_modification_cnt > 0 && !dth->dth_pinned &&
+	    sched_cur_seq() != sched_seq) {
+		daos_epoch_t	epoch = 0;
+		int		rc1;
+
+		rc1 = dtx_handle_resend(ioc->ioc_vos_coh, &dcsh->dcsh_xid, &epoch, NULL);
+		switch (rc1) {
+		case 0:
+		case -DER_ALREADY:
+			D_GOTO(out, rc = -DER_ALREADY);
+		case -DER_NONEXIST:
+		case -DER_EP_OLD:
+			break;
+		default:
+			D_GOTO(out, rc = rc1);
+		}
+	}
+
+	/* P5: punch and vos_update_end. */
 	for (i = 0; i < dcde->dcde_write_cnt; i++) {
 		dcsr = &dcsrs[dcri[i].dcri_req_idx];
 
 		if (dcsr->dcsr_opc == DCSO_UPDATE) {
-			dcu = &dcsr->dcsr_update;
-			if (dcu->dcu_ec_split_req != NULL) {
-				iods = dcu->dcu_ec_split_req->osr_iods;
-				csums = dcu->dcu_ec_split_req->osr_iod_csums;
-			} else {
-				iods = dcu->dcu_iod_array.oia_iods;
-				csums = dcu->dcu_iod_array.oia_iod_csums;
-			}
-
-			rc = vos_dedup_verify(iohs[i]);
-			if (rc != 0) {
-				D_ERROR("dedup_verify failed for obj "
-					DF_UOID", DTX "DF_DTI": "DF_RC"\n",
-					DP_UOID(dcsr->dcsr_oid),
-					DP_DTI(&dcsh->dcsh_xid), DP_RC(rc));
-					goto out;
-			}
-
-			rc = obj_verify_bio_csum(dcsr->dcsr_oid.id_pub,
-						 iods, csums, biods[i],
-						 ioc->ioc_coc->sc_csummer,
-						 dcsr->dcsr_nr);
-			if (rc != 0) {
-				if (rc == -DER_CSUM)
-					obj_log_csum_err();
-				goto out;
-			}
-
-			rc = bio_iod_post(biods[i]);
-			biods[i] = NULL;
-			if (rc != 0) {
-				D_ERROR("iod_post failed for obj "DF_UOID
-					", DTX "DF_DTI": "DF_RC"\n",
-					DP_UOID(dcsr->dcsr_oid),
-					DP_DTI(&dcsh->dcsh_xid), DP_RC(rc));
-				goto out;
-			}
-
 			rc = dtx_sub_init(dth, &dcsr->dcsr_oid,
 					  dcsr->dcsr_dkey_hash);
 			if (rc != 0)
@@ -4182,7 +4230,7 @@ out:
 	D_FREE(biods);
 	D_FREE(bulks);
 
-	return rc;
+	return unlikely(rc == -DER_ALREADY) ? 0 : rc;
 }
 
 static int

--- a/src/vos/vos_dtx.c
+++ b/src/vos/vos_dtx.c
@@ -218,8 +218,6 @@ static void
 dtx_act_ent_cleanup(struct vos_container *cont, struct vos_dtx_act_ent *dae,
 		    struct dtx_handle *dth, bool evict)
 {
-	D_FREE(dae->dae_records);
-
 	if (evict) {
 		daos_unit_oid_t	*oids;
 		int		 count;
@@ -250,6 +248,10 @@ dtx_act_ent_cleanup(struct vos_container *cont, struct vos_dtx_act_ent *dae,
 		D_FREE(dae->dae_oids);
 		dae->dae_oid_cnt = 0;
 	}
+
+	D_FREE(dae->dae_records);
+	dae->dae_rec_cap = 0;
+	DAE_REC_CNT(dae) = 0;
 }
 
 static int
@@ -2682,6 +2684,7 @@ vos_dtx_cleanup_internal(struct dtx_handle *dth)
 	struct vos_container	*cont;
 	struct vos_dtx_act_ent	*dae = NULL;
 	d_iov_t			 kiov;
+	d_iov_t			 riov;
 	int			 rc;
 
 	if (!dtx_is_valid_handle(dth) ||
@@ -2701,8 +2704,15 @@ vos_dtx_cleanup_internal(struct dtx_handle *dth)
 		dtx_act_ent_cleanup(cont, dae, dth, true);
 	} else {
 		d_iov_set(&kiov, &dth->dth_xid, sizeof(dth->dth_xid));
-		rc = dbtree_delete(cont->vc_dtx_active_hdl, BTR_PROBE_EQ, &kiov,
-				   &dae);
+		d_iov_set(&riov, NULL, 0);
+		rc = dbtree_lookup(cont->vc_dtx_active_hdl, &kiov, &riov);
+		if (rc == -DER_NONEXIST) {
+			rc = dbtree_lookup(cont->vc_dtx_committed_hdl, &kiov, &riov);
+			/* Cannot cleanup 'committed' DTX entry. */
+			if (rc == 0)
+				goto out;
+		}
+
 		if (rc != 0) {
 			if (rc != -DER_NONEXIST)
 				D_ERROR("Fail to remove DTX entry "DF_DTI":"
@@ -2712,6 +2722,14 @@ vos_dtx_cleanup_internal(struct dtx_handle *dth)
 			dae = dth->dth_ent;
 			if (dae != NULL)
 				dae->dae_aborted = 1;
+		} else {
+			dae = (struct vos_dtx_act_ent *)riov.iov_buf;
+			/* Cannot cleanup 'prepared' or 'committed' DTX entry. */
+			if (dae->dae_prepared || dae->dae_committed)
+				goto out;
+
+			rc = dbtree_delete(cont->vc_dtx_active_hdl, BTR_PROBE_BYPASS, &kiov, &dae);
+			D_ASSERT(rc == 0);
 		}
 
 		if (dae != NULL) {
@@ -2720,6 +2738,7 @@ vos_dtx_cleanup_internal(struct dtx_handle *dth)
 				dtx_evict_lid(cont, dae);
 		}
 
+out:
 		dth->dth_ent = NULL;
 	}
 }


### PR DESCRIPTION
There are some cases that current ULT may be blocked and yield during
DTX process, such as some NVMe operation (allocation, data copy). And
related RPC may be resent and handled by another ULT. Under such case,
when the blocked ULT is scheduled again, it needs to check resent RPC
to properly handle the case of the DTX for resent RPC being committed
before its original RPC.

Signed-off-by: Fan Yong <fan.yong@intel.com>