### PR TITLE
DAOS-8565 control: Allow positional label for pool create

### DIFF
--- a/src/control/cmd/dmg/command_test.go
+++ b/src/control/cmd/dmg/command_test.go
@@ -189,7 +189,6 @@ func runCmdTests(t *testing.T, cmdTests []cmdTest) {
 				testExpectedError(t, st.expectedErr, err)
 				return
 			}
-
 			if diff := cmp.Diff(st.expectedCalls, strings.Join(conn.called, " ")); diff != "" {
 				t.Fatalf("unexpected function calls (-want, +got):\n%s\n", diff)
 			}

--- a/src/control/cmd/dmg/pool.go
+++ b/src/control/cmd/dmg/pool.go
@@ -48,18 +48,22 @@ type PoolCreateCmd struct {
 	cfgCmd
 	ctlInvokerCmd
 	jsonOutputCmd
-	GroupName  string           `short:"g" long:"group" description:"DAOS pool to be owned by given group, format name@domain"`
-	UserName   string           `short:"u" long:"user" description:"DAOS pool to be owned by given user, format name@domain"`
-	PoolLabel  string           `short:"p" long:"label" description:"Unique label for pool"`
-	Properties PoolSetPropsFlag `short:"P" long:"properties" description:"Pool properties to be set"`
-	ACLFile    string           `short:"a" long:"acl-file" description:"Access Control List file path for DAOS pool"`
-	Size       string           `short:"z" long:"size" description:"Total size of DAOS pool (auto)"`
-	TierRatio  string           `short:"t" long:"tier-ratio" default:"6,94" description:"Percentage of storage tiers for pool storage (auto)"`
-	NumRanks   uint32           `short:"k" long:"nranks" description:"Number of ranks to use (auto)"`
-	NumSvcReps uint32           `short:"v" long:"nsvc" description:"Number of pool service replicas"`
-	ScmSize    string           `short:"s" long:"scm-size" description:"Per-server SCM allocation for DAOS pool (manual)"`
-	NVMeSize   string           `short:"n" long:"nvme-size" description:"Per-server NVMe allocation for DAOS pool (manual)"`
-	RankList   string           `short:"r" long:"ranks" description:"Storage server unique identifiers (ranks) for DAOS pool"`
+	GroupName     string           `short:"g" long:"group" description:"DAOS pool to be owned by given group, format name@domain"`
+	UserName      string           `short:"u" long:"user" description:"DAOS pool to be owned by given user, format name@domain"`
+	PoolLabelFlag string           `short:"p" long:"label" description:"Unique label for pool (deprecated, use positional argument)"`
+	Properties    PoolSetPropsFlag `short:"P" long:"properties" description:"Pool properties to be set"`
+	ACLFile       string           `short:"a" long:"acl-file" description:"Access Control List file path for DAOS pool"`
+	Size          string           `short:"z" long:"size" description:"Total size of DAOS pool (auto)"`
+	TierRatio     string           `short:"t" long:"tier-ratio" default:"6,94" description:"Percentage of storage tiers for pool storage (auto)"`
+	NumRanks      uint32           `short:"k" long:"nranks" description:"Number of ranks to use (auto)"`
+	NumSvcReps    uint32           `short:"v" long:"nsvc" description:"Number of pool service replicas"`
+	ScmSize       string           `short:"s" long:"scm-size" description:"Per-server SCM allocation for DAOS pool (manual)"`
+	NVMeSize      string           `short:"n" long:"nvme-size" description:"Per-server NVMe allocation for DAOS pool (manual)"`
+	RankList      string           `short:"r" long:"ranks" description:"Storage server unique identifiers (ranks) for DAOS pool"`
+
+	Args struct {
+		PoolLabel string `positional-arg-name:"<pool label>"`
+	} `positional-args:"yes"`
 }
 
 // Execute is run when PoolCreateCmd subcommand is activated
@@ -71,13 +75,17 @@ func (cmd *PoolCreateCmd) Execute(args []string) error {
 		return errors.New("either --size or --scm-size must be supplied")
 	}
 
-	if cmd.PoolLabel != "" {
+	if cmd.PoolLabelFlag != "" {
+		cmd.Args.PoolLabel = cmd.PoolLabelFlag
+	}
+
+	if cmd.Args.PoolLabel != "" {
 		for _, prop := range cmd.Properties.ToSet {
 			if prop.Name == "label" {
-				return errors.New("can't use both --label and --properties label:")
+				return errors.New("can't set label property with label argument")
 			}
 		}
-		if err := cmd.Properties.UnmarshalFlag(fmt.Sprintf("label:%s", cmd.PoolLabel)); err != nil {
+		if err := cmd.Properties.UnmarshalFlag(fmt.Sprintf("label:%s", cmd.Args.PoolLabel)); err != nil {
 			return err
 		}
 	}

--- a/src/control/cmd/dmg/pool_test.go
+++ b/src/control/cmd/dmg/pool_test.go
@@ -89,6 +89,75 @@ func TestPoolCommands(t *testing.T) {
 
 	runCmdTests(t, []cmdTest{
 		{
+			"Create pool with label prop and flag",
+			fmt.Sprintf("pool create --label foo --size %s --properties label:foo", testSizeStr),
+			"",
+			errors.New("can't set label property"),
+		},
+		{
+			"Create pool with label prop and argument",
+			fmt.Sprintf("pool create --size %s --properties label:foo foo", testSizeStr),
+			"",
+			errors.New("can't set label property"),
+		},
+		{
+			"Create pool with invalid label",
+			fmt.Sprintf("pool create --size %s alfalfa!", testSizeStr),
+			"",
+			errors.New("invalid label"),
+		},
+		{
+			"Create pool with label argument",
+			fmt.Sprintf("pool create --size %s foo", testSizeStr),
+			strings.Join([]string{
+				printRequest(t, &control.PoolCreateReq{
+					TotalBytes: uint64(testSize),
+					TierRatio:  []float64{0.06, 0.94},
+					User:       eUsr.Username + "@",
+					UserGroup:  eGrp.Name + "@",
+					Ranks:      []system.Rank{},
+					Properties: []*control.PoolProperty{
+						propWithVal("label", "foo"),
+					},
+				}),
+			}, " "),
+			nil,
+		},
+		{
+			"Create pool with label flag",
+			fmt.Sprintf("pool create --size %s --label foo", testSizeStr),
+			strings.Join([]string{
+				printRequest(t, &control.PoolCreateReq{
+					TotalBytes: uint64(testSize),
+					TierRatio:  []float64{0.06, 0.94},
+					User:       eUsr.Username + "@",
+					UserGroup:  eGrp.Name + "@",
+					Ranks:      []system.Rank{},
+					Properties: []*control.PoolProperty{
+						propWithVal("label", "foo"),
+					},
+				}),
+			}, " "),
+			nil,
+		},
+		{
+			"Create pool with label property",
+			fmt.Sprintf("pool create --size %s --properties label:foo", testSizeStr),
+			strings.Join([]string{
+				printRequest(t, &control.PoolCreateReq{
+					TotalBytes: uint64(testSize),
+					TierRatio:  []float64{0.06, 0.94},
+					User:       eUsr.Username + "@",
+					UserGroup:  eGrp.Name + "@",
+					Ranks:      []system.Rank{},
+					Properties: []*control.PoolProperty{
+						propWithVal("label", "foo"),
+					},
+				}),
+			}, " "),
+			nil,
+		},
+		{
 			"Create pool with missing arguments",
 			"pool create",
 			"",

--- a/src/control/common/proto/mgmt/addons.go
+++ b/src/control/common/proto/mgmt/addons.go
@@ -6,6 +6,7 @@
 package mgmt
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -14,6 +15,31 @@ import (
 
 	"github.com/daos-stack/daos/src/control/system"
 )
+
+func (p *PoolProperty) UnmarshalJSON(b []byte) error {
+	type fromJSON PoolProperty
+	from := struct {
+		Value struct {
+			Strval string `json:"strval"`
+			Numval uint64 `json:"numval"`
+		}
+		*fromJSON
+	}{
+		fromJSON: (*fromJSON)(p),
+	}
+
+	if err := json.Unmarshal(b, &from); err != nil {
+		return err
+	}
+
+	if from.Value.Strval != "" {
+		p.SetValueString(from.Value.Strval)
+	} else {
+		p.SetValueNumber(from.Value.Numval)
+	}
+
+	return nil
+}
 
 // SetValueString sets the Value field to a string.
 func (p *PoolProperty) SetValueString(strVal string) {

--- a/src/control/lib/control/pool.go
+++ b/src/control/lib/control/pool.go
@@ -121,6 +121,22 @@ func convertPoolProps(in []*PoolProperty, setProp bool) ([]*mgmtpb.PoolProperty,
 	return out, nil
 }
 
+func (pcr *PoolCreateReq) MarshalJSON() ([]byte, error) {
+	props, err := convertPoolProps(pcr.Properties, true)
+	if err != nil {
+		return nil, err
+	}
+
+	type toJSON PoolCreateReq
+	return json.Marshal(struct {
+		Properties []*mgmtpb.PoolProperty `json:"properties"`
+		*toJSON
+	}{
+		Properties: props,
+		toJSON:     (*toJSON)(pcr),
+	})
+}
+
 // genPoolCreateRequest takes a *PoolCreateRequest and generates a valid protobuf
 // request, filling in any missing fields with reasonable defaults.
 func genPoolCreateRequest(in *PoolCreateReq) (out *mgmtpb.PoolCreateReq, err error) {
@@ -143,11 +159,6 @@ func genPoolCreateRequest(in *PoolCreateReq) (out *mgmtpb.PoolCreateReq, err err
 
 	out = new(mgmtpb.PoolCreateReq)
 	if err = convert.Types(in, out); err != nil {
-		return
-	}
-
-	out.Properties, err = convertPoolProps(in.Properties, true)
-	if err != nil {
 		return
 	}
 


### PR DESCRIPTION
As the label is now a required parameter, it should be
settable as a positional argument. The existing --label
flag is kept but marked as deprecated.