### PR TITLE
DAOS-8549 dmg: Fix percent output for media_wear_raw SPDK health stats

### DIFF
--- a/docs/admin/administration.md
+++ b/docs/admin/administration.md
@@ -313,7 +313,10 @@ health data, including NVMe SSD health stats and in-memory I/O error and checksu
 error counters. The server rank and device state are also listed. The device health
 data can either be queried by device UUID (device-health command) or by VOS target ID
 along with the server rank (target-health command). The same device health information
-is displayed with both command options.
+is displayed with both command options. Additionally, vendor-specific SMART stats are
+displayed, currently for Intel devices only. Note: A reasonable timed workload > 60 min
+must be ran for the SMART stats to register (Raw values are 65535). Media wear percentage
+can be calculated by dividing by 1024 to find the percentage of the maximum rated cycles.
 ```bash
 $ dmg -l boro-11 storage query device-health --uuid=5bd91603-d3c7-4fb7-9a71-76bc25690c19
 or
@@ -357,8 +360,8 @@ boro-11
            Avg:24
         End-to-End Error Detection Count:0
         CRC Error Count:0
-        Timed Workload, Media Wear:63%
-        Timed Workload, Host Reads:65535
+        Timed Workload, Media Wear:65535
+        Timed Workload, Host Read/Write Ratio:65535
         Timed Workload, Timer:65535
         Thermal Throttle Status:0%
         Thermal Throttle Event Count:0

--- a/docs/admin/deployment.md
+++ b/docs/admin/deployment.md
@@ -514,8 +514,8 @@ PCI:0000:81:00.0 Model:INTEL SSDPED1K750GA  FW:E2010325 Socket:1 Capacity:750 GB
        Avg:3
     End-to-End Error Detection Count:0
     CRC Error Count:0
-    Timed Workload, Media Wear:63%
-    Timed Workload, Host Reads:65535
+    Timed Workload, Media Wear:65535
+    Timed Workload, Host Read/Write Ratio:65535
     Timed Workload, Timer:65535
     Thermal Throttle Status:0%
     Thermal Throttle Event Count:0
@@ -558,8 +558,8 @@ PCI:0000:da:00.0 Model:INTEL SSDPED1K750GA  FW:E2010325 Socket:1 Capacity:750 GB
        Avg:3
     End-to-End Error Detection Count:0
     CRC Error Count:0
-    Timed Workload, Media Wear:63%
-    Timed Workload, Host Reads:65535
+    Timed Workload, Media Wear:65535
+    Timed Workload, Host Read/Write Ratio:65535
     Timed Workload, Timer:65535
     Thermal Throttle Status:0%
     Thermal Throttle Event Count:0
@@ -605,8 +605,8 @@ PCI:0000:81:00.0 Model:INTEL SSDPED1K750GA  FW:E2010435 Socket:1 Capacity:750 GB
        Avg:3
     End-to-End Error Detection Count:0
     CRC Error Count:0
-    Timed Workload, Media Wear:63%
-    Timed Workload, Host Reads:65535
+    Timed Workload, Media Wear:65535
+    Timed Workload, Host Read/Write Ratio:65535
     Timed Workload, Timer:65535
     Thermal Throttle Status:0%
     Thermal Throttle Event Count:0
@@ -649,8 +649,8 @@ PCI:0000:da:00.0 Model:INTEL SSDPED1K750GA  FW:E2010435 Socket:1 Capacity:750 GB
        Avg:3
     End-to-End Error Detection Count:0
     CRC Error Count:0
-    Timed Workload, Media Wear:63%
-    Timed Workload, Host Reads:65535
+    Timed Workload, Media Wear:65535
+    Timed Workload, Host Read/Write Ratio:65535
     Timed Workload, Timer:65535
     Thermal Throttle Status:0%
     Thermal Throttle Event Count:0

--- a/src/bio/bio_monitor.c
+++ b/src/bio/bio_monitor.c
@@ -369,7 +369,7 @@ populate_intel_smart_stats(struct bio_dev_health *bdh)
 			atb = isp->attributes[i];
 			/* divide raw value by 1024 to derive the percentage */
 			stats->media_wear_raw =
-				extend_to_uint64(atb.raw_value, 6) >> 10;
+					extend_to_uint64(atb.raw_value, 6);
 			d_tm_set_counter(bdh->bdh_media_wear_raw,
 					 stats->media_wear_raw);
 		}

--- a/src/control/cmd/dmg/pretty/storage_nvme.go
+++ b/src/control/cmd/dmg/pretty/storage_nvme.go
@@ -136,9 +136,9 @@ func printNvmeHealth(stat *storage.NvmeHealth, out io.Writer, opts ...PrintConfi
 			uint64(stat.EndtoendErrCntRaw))
 		fmt.Fprintf(iw, "CRC Error Count:%d\n",
 			uint64(stat.CrcErrCntRaw))
-		fmt.Fprintf(iw, "Timed Workload, Media Wear:%d%%\n",
+		fmt.Fprintf(iw, "Timed Workload, Media Wear:%d\n",
 			uint64(stat.MediaWearRaw))
-		fmt.Fprintf(iw, "Timed Workload, Host Reads:%d\n",
+		fmt.Fprintf(iw, "Timed Workload, Host Read/Write Ratio:%d\n",
 			uint64(stat.HostReadsRaw))
 		fmt.Fprintf(iw, "Timed Workload, Timer:%d\n",
 			uint64(stat.WorkloadTimerRaw))

--- a/src/control/cmd/dmg/pretty/storage_nvme_test.go
+++ b/src/control/cmd/dmg/pretty/storage_nvme_test.go
@@ -94,8 +94,8 @@ PCI:%s Model:%s FW:%s Socket:%d Capacity:%s
        Avg:%d
     End-to-End Error Detection Count:%d
     CRC Error Count:%d
-    Timed Workload, Media Wear:%d%s
-    Timed Workload, Host Reads:%d
+    Timed Workload, Media Wear:%d
+    Timed Workload, Host Read/Write Ratio:%d
     Timed Workload, Timer:%d
     Thermal Throttle Status:%d%s
     Thermal Throttle Event Count:%d
@@ -135,8 +135,8 @@ PCI:%s Model:%s FW:%s Socket:%d Capacity:%s
        Avg:%d
     End-to-End Error Detection Count:%d
     CRC Error Count:%d
-    Timed Workload, Media Wear:%d%s
-    Timed Workload, Host Reads:%d
+    Timed Workload, Media Wear:%d
+    Timed Workload, Host Read/Write Ratio:%d
     Timed Workload, Timer:%d
     Thermal Throttle Status:%d%s
     Thermal Throttle Event Count:%d
@@ -159,7 +159,7 @@ PCI:%s Model:%s FW:%s Socket:%d Capacity:%s
 				controllerA.HealthStats.WearLevelingCntNorm, "%", controllerA.HealthStats.WearLevelingCntMin,
 				controllerA.HealthStats.WearLevelingCntMax, controllerA.HealthStats.WearLevelingCntAvg,
 				controllerA.HealthStats.EndtoendErrCntRaw, controllerA.HealthStats.CrcErrCntRaw,
-				controllerA.HealthStats.MediaWearRaw, "%", controllerA.HealthStats.HostReadsRaw,
+				controllerA.HealthStats.MediaWearRaw, controllerA.HealthStats.HostReadsRaw,
 				controllerA.HealthStats.WorkloadTimerRaw,
 				controllerA.HealthStats.ThermalThrottleStatus, "%", controllerA.HealthStats.ThermalThrottleEventCnt,
 				controllerA.HealthStats.RetryBufferOverflowCnt,
@@ -179,7 +179,7 @@ PCI:%s Model:%s FW:%s Socket:%d Capacity:%s
 				controllerB.HealthStats.WearLevelingCntNorm, "%", controllerB.HealthStats.WearLevelingCntMin,
 				controllerB.HealthStats.WearLevelingCntMax, controllerB.HealthStats.WearLevelingCntAvg,
 				controllerB.HealthStats.EndtoendErrCntRaw, controllerB.HealthStats.CrcErrCntRaw,
-				controllerB.HealthStats.MediaWearRaw, "%", controllerB.HealthStats.HostReadsRaw,
+				controllerB.HealthStats.MediaWearRaw, controllerB.HealthStats.HostReadsRaw,
 				controllerB.HealthStats.WorkloadTimerRaw,
 				controllerB.HealthStats.ThermalThrottleStatus, "%", controllerB.HealthStats.ThermalThrottleEventCnt,
 				controllerB.HealthStats.RetryBufferOverflowCnt,
@@ -238,8 +238,8 @@ PCI:%s Model:%s FW:%s Socket:%d Capacity:%s
        Avg:%d
     End-to-End Error Detection Count:%d
     CRC Error Count:%d
-    Timed Workload, Media Wear:%d%s
-    Timed Workload, Host Reads:%d
+    Timed Workload, Media Wear:%d
+    Timed Workload, Host Read/Write Ratio:%d
     Timed Workload, Timer:%d
     Thermal Throttle Status:%d%s
     Thermal Throttle Event Count:%d
@@ -264,7 +264,7 @@ PCI:%s Model:%s FW:%s Socket:%d Capacity:%s
 				controllerAwTS.HealthStats.WearLevelingCntNorm, "%", controllerAwTS.HealthStats.WearLevelingCntMin,
 				controllerAwTS.HealthStats.WearLevelingCntMax, controllerAwTS.HealthStats.WearLevelingCntAvg,
 				controllerAwTS.HealthStats.EndtoendErrCntRaw, controllerAwTS.HealthStats.CrcErrCntRaw,
-				controllerAwTS.HealthStats.MediaWearRaw, "%", controllerAwTS.HealthStats.HostReadsRaw,
+				controllerAwTS.HealthStats.MediaWearRaw, controllerAwTS.HealthStats.HostReadsRaw,
 				controllerAwTS.HealthStats.WorkloadTimerRaw,
 				controllerAwTS.HealthStats.ThermalThrottleStatus, "%", controllerAwTS.HealthStats.ThermalThrottleEventCnt,
 				controllerAwTS.HealthStats.RetryBufferOverflowCnt,

--- a/src/control/cmd/dmg/pretty/storage_test.go
+++ b/src/control/cmd/dmg/pretty/storage_test.go
@@ -1488,8 +1488,8 @@ host1
            Avg:%d
         End-to-End Error Detection Count:%d
         CRC Error Count:%d
-        Timed Workload, Media Wear:%d%s
-        Timed Workload, Host Reads:%d
+        Timed Workload, Media Wear:%d
+        Timed Workload, Host Read/Write Ratio:%d
         Timed Workload, Timer:%d
         Thermal Throttle Status:%d%s
         Thermal Throttle Event Count:%d
@@ -1510,7 +1510,7 @@ host1
 				mockController.HealthStats.WearLevelingCntNorm, "%", mockController.HealthStats.WearLevelingCntMin,
 				mockController.HealthStats.WearLevelingCntMax, mockController.HealthStats.WearLevelingCntAvg,
 				mockController.HealthStats.EndtoendErrCntRaw, mockController.HealthStats.CrcErrCntRaw,
-				mockController.HealthStats.MediaWearRaw, "%", mockController.HealthStats.HostReadsRaw,
+				mockController.HealthStats.MediaWearRaw, mockController.HealthStats.HostReadsRaw,
 				mockController.HealthStats.WorkloadTimerRaw,
 				mockController.HealthStats.ThermalThrottleStatus, "%", mockController.HealthStats.ThermalThrottleEventCnt,
 				mockController.HealthStats.RetryBufferOverflowCnt,

--- a/src/control/lib/spdk/src/nvme_control_common.c
+++ b/src/control/lib/spdk/src/nvme_control_common.c
@@ -360,7 +360,7 @@ populate_dev_health(struct nvme_stats *stats,
 				SPDK_NVME_INTEL_SMART_MEDIA_WEAR) {
 			atb = isp->attributes[i];
 			stats->media_wear_raw =
-				extend_to_uint64(atb.raw_value, 6) >> 10;
+					extend_to_uint64(atb.raw_value, 6);
 		}
 		if (isp->attributes[i].code ==
 				SPDK_NVME_INTEL_SMART_HOST_READ_PERCENTAGE) {


### PR DESCRIPTION
The output for Intel SMART stats for Timed Workout, Media Wear was
falsely reporting a confusing percentage for media wear, instead of the
raw value. The media wear percentage is only meaningful after a
reasonable workload > 60 min is conducted, and the value can then be
converted to a percent.

Timed Workload, Media Wear: 65535 (raw, reset value)
Timed Workload, Media Wear: 41 (after workload test)

Media wear = 41/1024 = 0.04%

Signed-off-by: Sydney Vanda <sydney.m.vanda@intel.com>