### PR TITLE
DAOS-8599 test: Fix pool/destroy_tests.py

### DIFF
--- a/src/tests/ftest/pool/destroy_tests.py
+++ b/src/tests/ftest/pool/destroy_tests.py
@@ -6,10 +6,8 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 """
 import os
 
-from server_utils import ServerFailed
 from apricot import TestWithServers
 from avocado.core.exceptions import TestFail
-from test_utils_base import CallbackHandler
 from general_utils import get_default_config_file
 from dmg_utils import get_dmg_command
 

--- a/src/tests/ftest/pool/destroy_tests.py
+++ b/src/tests/ftest/pool/destroy_tests.py
@@ -257,6 +257,7 @@ class DestroyTests(TestWithServers):
         valid_uuid = self.pool.uuid
         invalid_uuid = "81ef94d7-a59d-4a5e-935b-abfbd12f2105"
         self.pool.uuid = invalid_uuid
+        self.pool.use_label = False
 
         # Attempt to destroy the pool with an invalid UUID
         self.validate_pool_destroy(
@@ -268,6 +269,7 @@ class DestroyTests(TestWithServers):
         # Restore the valid uuid to allow tearDown() to pass
         self.log.info("Restoring the pool's valid uuid: %s", valid_uuid)
         self.pool.uuid = valid_uuid
+        self.pool.use_label = True
 
     def test_destroy_invalid_group(self):
         """Test destroying a pool with invalid server group.


### PR DESCRIPTION
In test_destroy_invalid_uuid, we need to set

self.pool.use_label = False

so that the test uses invalid UUID instead of the label.

Skip-unit-tests: true
Test-tag: destroy_invalid_uuid
Signed-off-by: Makito Kano <makito.kano@intel.com>