### PR TITLE
DAOS-8591 test, container: enable default label in daos_test

### DIFF
--- a/src/tests/suite/daos_test_common.c
+++ b/src/tests/suite/daos_test_common.c
@@ -211,18 +211,15 @@ test_setup_cont_create(void **state, daos_prop_t *co_prop)
 	int rc = 0;
 
 	if (arg->myrank == 0) {
-#if 0
 		/** use daos_test label if none is provided */
 		if (!co_prop || daos_prop_entry_get(co_prop, DAOS_PROP_CO_LABEL) == NULL) {
 			print_message("setup: creating container with label \"daos_test\"\n");
 			rc = daos_cont_create_with_label(arg->pool.poh, "daos_test", co_prop,
 							 &arg->co_uuid, NULL);
-		else {
-#endif
+		} else {
 			print_message("setup: creating container\n");
-
 			rc = daos_cont_create(arg->pool.poh, &arg->co_uuid, co_prop, NULL);
-		//}
+		}
 
 		if (rc) {
 			print_message("daos_cont_create failed, rc: %d\n", rc);
@@ -242,6 +239,7 @@ test_setup_cont_create(void **state, daos_prop_t *co_prop)
 			uuid_unparse(arg->co_uuid, arg->co_str);
 		}
 	}
+
 	return rc;
 }
 

--- a/src/vos/vos_obj.c
+++ b/src/vos/vos_obj.c
@@ -324,7 +324,7 @@ vos_obj_punch(daos_handle_t coh, daos_unit_oid_t oid, daos_epoch_t epoch,
 		bound = epoch;
 	}
 
-	D_DEBUG(DB_IO, "Punch "DF_UOID", epoch "DF_U64"\n",
+	D_DEBUG(DB_IO, "Punch "DF_UOID", epoch "DF_X64"\n",
 		DP_UOID(oid), epr.epr_hi);
 
 	vos_dth_set(dth);


### PR DESCRIPTION
Use default label for containers in daos_test when a label isn't
passed via the properties.

Also with this change, modify container service code that renames
a container (via set prop) so that in the cs_uuids KVS the new label
akey insert is done before punching the old label akey. When there is
a single entry in cs_uuids, this approach avoids a momentary empty KVS
in the same epoch that would cause vos punch propagation (on the dkey).
And avoids vos returning -DER_NO_PERM due to punch and update.

Change vos_obj_punch() logging to print epoch in hex, aligning it
with other vos logging.

Co-authored-by: Johann Lombardi <johann.lombardi@intel.com>
Signed-off-by: Kenneth Cain <kenneth.c.cain@intel.com>