### PR TITLE
DAOS-8600 bio: properly check xstream setup state

### DIFF
--- a/src/bio/bio_internal.h
+++ b/src/bio/bio_internal.h
@@ -349,6 +349,7 @@ struct bio_xs_context {
 	struct spdk_io_channel	*bxc_io_channel;
 	struct bio_dma_buffer	*bxc_dma_buf;
 	d_list_t		 bxc_io_ctxts;
+	unsigned int		 bxc_ready:1;	/* xstream setup finished */
 };
 
 /* Per VOS instance I/O context */

--- a/src/bio/bio_recovery.c
+++ b/src/bio/bio_recovery.c
@@ -70,6 +70,7 @@ teardown_xstream(void *arg)
 		return;
 	}
 
+	xs_ctxt->bxc_ready = 0;
 	/* This xstream is torndown */
 	if (xs_ctxt->bxc_io_channel == NULL)
 		return;
@@ -200,7 +201,6 @@ setup_xstream(void *arg)
 {
 	struct bio_xs_context	*xs_ctxt = arg;
 	struct bio_blobstore	*bbs;
-	struct bio_bdev		*d_bdev;
 	struct bio_io_context	*ioc;
 	int			 closed_blobs = 0;
 
@@ -244,10 +244,7 @@ setup_xstream(void *arg)
 			xs_ctxt, closed_blobs);
 		return;
 	}
-
-	d_bdev = bbs->bb_dev;
-	D_ASSERT(d_bdev != NULL);
-	D_ASSERT(d_bdev->bb_name != NULL);
+	xs_ctxt->bxc_ready = 1;
 }
 
 static void
@@ -341,6 +338,10 @@ bs_loaded:
 	D_ASSERT(is_server_started());
 	for (i = 0; i < bbs->bb_ref; i++) {
 		struct bio_xs_context	*xs_ctxt = bbs->bb_xs_ctxts[i];
+
+		/* Setup for the xsteam is done */
+		if (xs_ctxt->bxc_ready)
+			continue;
 
 		D_ASSERT(xs_ctxt->bxc_thread != NULL);
 		spdk_thread_send_msg(xs_ctxt->bxc_thread, setup_xstream,

--- a/src/bio/bio_xstream.c
+++ b/src/bio/bio_xstream.c
@@ -1021,6 +1021,7 @@ init_blobstore_ctxt(struct bio_xs_context *ctxt, int tgt_id)
 	bool			 assigned = false;
 	int			 rc;
 
+	D_ASSERT(!ctxt->bxc_ready);
 	D_ASSERT(ctxt->bxc_blobstore == NULL);
 	D_ASSERT(ctxt->bxc_io_channel == NULL);
 
@@ -1144,6 +1145,7 @@ retry:
 		rc = -DER_NOMEM;
 		goto out;
 	}
+	ctxt->bxc_ready = 1;
 
 out:
 	D_ASSERT(dev_info != NULL);
@@ -1167,6 +1169,7 @@ bio_xsctxt_free(struct bio_xs_context *ctxt)
 	if (ctxt == NULL)
 		return;
 
+	ctxt->bxc_ready = 0;
 	if (ctxt->bxc_io_channel != NULL) {
 		spdk_bs_free_io_channel(ctxt->bxc_io_channel);
 		ctxt->bxc_io_channel = NULL;


### PR DESCRIPTION
On device state transition, BIO used to check the per-xstream io
stats open descriptor to see if the setup procedure is done, however,
this open descriptor was removed by 'commit 639a3d0b76e2 ("DAOS-6526
bio: export SSD smart info via d_tm (#5413)")', and the device state
transition logic wasn't adjusted accordingly.

This patch introduced per-xstream 'bxc_ready' flag to indicate
if the setup procedure for a xstream is finished.

Signed-off-by: Niu Yawei <yawei.niu@intel.com>