### PR TITLE
DAOS-8604 dfuse: Allow cache times in minutes, hours and days.

### DIFF
--- a/docs/user/filesystem.md
+++ b/docs/user/filesystem.md
@@ -351,7 +351,8 @@ to be set to 0 or off, except dentry-dir-time which defaults to dentry-time
 | dfuse-direct-io-disable | Force use of page cache for this container ("on"/"off")        |
 
 For metadata caching attributes specify the duration that the cache should be
-valid for, specified in seconds, and allowing 'S' or 'M' suffix.
+valid for, specified in seconds or with a 's', 'm', 'h' or 'd' suffix for seconds,
+minutes, hours or days.
 
 dfuse-data-cache should be set to "on", or "off" if set, any other value will
 log an error, and result in the cache being off.  The O\_DIRECT flag for open

--- a/src/client/dfuse/dfuse_core.c
+++ b/src/client/dfuse/dfuse_core.c
@@ -79,9 +79,13 @@ dfuse_parse_time(char *buff, size_t len, unsigned int *_out)
 		return EINVAL;
 
 	if (matched == 2) {
-		if (c == 'm' || c == 'M')
+		if (c == 'd' || c == 'D')
+			out *= 60 * 60 * 24;
+		else if (c == 'h' || c == 'H')
+			out *= 60 * 60;
+		else if (c == 'm' || c == 'M')
 			out *= 60;
-		if (c == 's' || c == 'S')
+		else if (c == 's' || c == 'S')
 			true;
 		else
 			return EINVAL;


### PR DESCRIPTION
Fix a bug where minutes were not accepted, and add support
for hours and days.  Update documentation accordingly.

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>
