### PR TITLE
DAOS-8583 EC: allow EC degraded update

### DIFF
--- a/src/include/daos/common.h
+++ b/src/include/daos/common.h
@@ -740,6 +740,7 @@ enum {
  * This fault simulates the EC parity epoch difference in EC data recovery.
  */
 #define DAOS_FAIL_PARITY_EPOCH_DIFF	(DAOS_FAIL_UNIT_TEST_GROUP_LOC | 0x29)
+#define DAOS_FAIL_SHARD_NONEXIST	(DAOS_FAIL_UNIT_TEST_GROUP_LOC | 0x2a)
 
 #define DAOS_DTX_COMMIT_SYNC		(DAOS_FAIL_UNIT_TEST_GROUP_LOC | 0x30)
 #define DAOS_DTX_LEADER_ERROR		(DAOS_FAIL_UNIT_TEST_GROUP_LOC | 0x31)

--- a/src/object/cli_ec.c
+++ b/src/object/cli_ec.c
@@ -2779,6 +2779,8 @@ obj_ec_tgt_oiod_init(struct obj_io_desc *r_oiods, uint32_t iod_nr,
 		for (j = 0; j < r_oiod->oiod_nr; j++) {
 			r_siod = &r_oiod->oiod_siods[j];
 			tgt = r_siod->siod_tgt_idx;
+			if (isclr(tgt_bitmap, tgt))
+				continue;
 			tgt_oiod = obj_ec_tgt_oiod_get(tgt_oiods, tgt_nr, tgt);
 			D_ASSERT(tgt_oiod && tgt_oiod->oto_tgt_idx == tgt);
 			tgt_oiod->oto_offs[i] = r_siod->siod_off;

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -951,6 +951,8 @@ shard_open:
 			} else {
 				if (obj_auxi->opc == DAOS_OBJ_RPC_FETCH)
 					ec_degrade = true;
+				else
+					shard_tgt->st_rank = DAOS_TGT_IGNORE;
 			}
 		} else {
 			D_ERROR(DF_OID" obj_shard_open %u, rc "DF_RC".\n",
@@ -1099,6 +1101,8 @@ obj_shards_2_fwtgts(struct dc_object *obj, uint32_t map_ver, uint8_t *bit_map,
 	req_tgts->ort_grp_size = (shard_nr == shard_cnt) ? grp_size : shard_nr;
 	for (i = 0; i < grp_nr; i++) {
 		struct daos_shard_tgt	*head;
+		struct daos_oclass_attr	*oca;
+		uint32_t		 fail_nr;
 
 		shard_idx = start_shard + i * grp_size;
 		head = tgt = req_tgts->ort_shard_tgts + i * grp_size;
@@ -1125,14 +1129,27 @@ obj_shards_2_fwtgts(struct dc_object *obj, uint32_t map_ver, uint8_t *bit_map,
 				continue;
 		}
 
-		for (j = 0; j < grp_size; j++, shard_idx++) {
+		for (j = 0, fail_nr = 0; j < grp_size; j++, shard_idx++) {
 			if (shard_idx == leader_shard ||
 			    (bit_map != NIL_BITMAP && isclr(bit_map, j)))
 				continue;
 			rc = obj_shard_tgts_query(obj, map_ver, shard_idx,
 						  shard_idx - start_shard,
 						  tgt++, obj_auxi);
-			if (rc != 0)
+			if (unlikely(DAOS_FAIL_CHECK(DAOS_FAIL_SHARD_NONEXIST)))
+				rc = -DER_NONEXIST;
+			if (rc == -DER_NONEXIST && obj_auxi->is_ec_obj) {
+				fail_nr++;
+				rc = 0;
+				oca = obj_get_oca(obj);
+				if (fail_nr > obj_ec_parity_tgt_nr(oca)) {
+					rc = -DER_IO;
+					D_ERROR(DF_OID" #failed_shard %d, exceed %d, "DF_RC"\n",
+						DP_OID(obj->cob_md.omd_id), fail_nr,
+						obj_ec_parity_tgt_nr(oca), DP_RC(rc));
+					return rc;
+				}
+			} else if (rc != 0)
 				return rc;
 
 			if (req_tgts->ort_srv_disp) {
@@ -4474,6 +4491,10 @@ dc_obj_update(tse_task_t *task, struct dtx_epoch *epoch, uint32_t map_ver,
 			goto out_task;
 		}
 
+		if (obj_auxi->is_ec_obj && obj_auxi->req_reasbed) {
+			args->iods = obj_auxi->reasb_req.orr_uiods;
+			args->sgls = obj_auxi->reasb_req.orr_usgls;
+		}
 		/* For OSA case, 2 or more shards locate on the same
 		 * VOS target. We will handle such case via internal
 		 * transaction.

--- a/src/object/obj_tx.c
+++ b/src/object/obj_tx.c
@@ -1182,6 +1182,7 @@ dc_tx_classify_common(struct dc_tx *tx, struct daos_cpd_sub_req *dcsr,
 
 		rc = obj_shard_open(obj, idx, tx->tx_pm_ver, &shard);
 		if (rc == -DER_NONEXIST) {
+			rc = 0;
 			if (daos_oclass_is_ec(oca) && !all) {
 				if (idx >= start + obj->cob_grp_size -
 							oca->u.ec.e_p)

--- a/src/object/srv_ec.c
+++ b/src/object/srv_ec.c
@@ -82,6 +82,10 @@ obj_ec_rw_req_split(daos_unit_oid_t oid, struct obj_iod_array *iod_array,
 	D_ASSERT((oiods[0].oiod_flags & OBJ_SIOD_SINGV) ||
 		 oiods[0].oiod_nr >= 2);
 
+	if (oca == NULL)
+		oca = daos_oclass_attr_find(oid.id_pub, NULL);
+	D_ASSERT(oca != NULL);
+
 	if (tgt_map != NULL)
 		tgt_max_idx = 0;
 	else
@@ -137,10 +141,11 @@ obj_ec_rw_req_split(daos_unit_oid_t oid, struct obj_iod_array *iod_array,
 		 */
 		if (!obj_ec_is_valid_tgt(tgt_map, map_size, leader_id, &leader))
 			leader = tgt_max_idx;
+		else
+			leader = leader % obj_ec_tgt_nr(oca);
 	} else {
 		D_ASSERT(leader_id == PO_COMP_ID_ALL);
 
-		D_ASSERT(oca != NULL);
 		leader = oid.id_shard % obj_ec_tgt_nr(oca);
 		setbit(tgt_bit_map, leader);
 		count++;

--- a/src/tests/suite/daos_degrade_ec.c
+++ b/src/tests/suite/daos_degrade_ec.c
@@ -565,6 +565,39 @@ degrade_ec_agg(void **state)
 	free(verify_data);
 }
 
+static void
+degrade_ec_update(void **state)
+{
+	test_arg_t	*arg = *state;
+	struct ioreq	req;
+	daos_obj_id_t	oid;
+	int		i;
+	char		*data;
+#define TEST_EC_STRIPE_SIZE	(1 * 1014 * 1024 * 2)
+
+	if (!test_runable(arg, 6))
+		return;
+
+	data = (char *)malloc(TEST_EC_STRIPE_SIZE);
+	assert_true(data != NULL);
+	oid = daos_test_oid_gen(arg->coh, OC_EC_2P2GX, 0, 0, arg->myrank);
+
+	arg->fail_loc = DAOS_FAIL_SHARD_NONEXIST | DAOS_FAIL_ONCE;
+	ioreq_init(&req, arg->coh, oid, DAOS_IOD_ARRAY, arg);
+	for (i = 0; i < 4; i++) {
+		daos_recx_t recx;
+
+		req.iod_type = DAOS_IOD_ARRAY;
+		recx.rx_nr = TEST_EC_STRIPE_SIZE;
+		recx.rx_idx = i * TEST_EC_STRIPE_SIZE;
+		memset(data, 'a' + i, TEST_EC_STRIPE_SIZE);
+		insert_recxs("d_key", "a_key", 1, DAOS_TX_NONE, &recx, 1,
+			     data, TEST_EC_STRIPE_SIZE, &req);
+	}
+
+	free(data);
+}
+
 /** create a new pool/container for each test */
 static const struct CMUnitTest degrade_tests[] = {
 	{"DEGRADE0: degrade partial update with data tgt fail",
@@ -638,6 +671,8 @@ static const struct CMUnitTest degrade_tests[] = {
 	 degrade_ec_partial_update_agg, degrade_sub_setup, test_teardown},
 	{"DEGRADE25: degrade ec aggregation",
 	 degrade_ec_agg, degrade_sub_setup, test_teardown},
+	{"DEGRADE26: degrade ec update",
+	 degrade_ec_update, degrade_sub_setup, test_teardown},
 };
 
 int


### PR DESCRIPTION
When #fail_shard < #parity, should allow obj update success, rather than
fail it.
Fixed several bugs related with dc_tx_convert()/obj_ec_rw_req_split()
and obj_ec_tgt_oiod_init() that may affect details in co-located
layout and EC handling.

Signed-off-by: Xuezhao Liu <xuezhao.liu@intel.com>