### PR TITLE
DAOS-8454 test: Removed test_create_destroy_uuid

### DIFF
--- a/src/tests/ftest/pool/uuid_corner_case.py
+++ b/src/tests/ftest/pool/uuid_corner_case.py
@@ -41,24 +41,3 @@ class UUIDCornerCase(TestWithServers):
 
         # Destroy with UUID.
         self.verify_destroy_uuid()
-
-    def test_create_destroy_uuid(self):
-        """Test ID: JIRA-7943
-
-        Test Description: Create without label, destroy with UUID.
-
-        :avocado: tags=all,full_regression
-        :avocado: tags=small
-        :avocado: tags=pool,uuid_corner_case,create_without_label_destroy_uuid
-        """
-        self.add_pool(create=False)
-
-        # Make the TestPool object to use UUID.
-        self.pool.use_label = False
-        self.pool.label.update(None)
-
-        # Create without a label.
-        self.pool.create()
-
-        # Destroy with UUID.
-        self.verify_destroy_uuid()


### PR DESCRIPTION
Pool label is required at creation time, so the test to create without it is invalid.

Skip-build: true
Skip-test: true
Signed-off-by: Makito Kano <makito.kano@intel.com>