### PR TITLE
DAOS-8598 swim: don't ignore indirect DEAD after network outage

### DIFF
--- a/src/cart/crt_swim.h
+++ b/src/cart/crt_swim.h
@@ -14,6 +14,8 @@
 #include "cart/swim.h"
 #include "swim/swim_internal.h"
 
+#define CRT_SWIM_NGLITCHES_TRESHOLD	10
+#define CRT_SWIM_NMESSAGES_TRESHOLD	1000
 #define CRT_SWIM_FLUSH_ATTEMPTS		100
 #define CRT_SWIM_PROGRESS_TIMEOUT	0	/* minimal progressing time */
 #define CRT_DEFAULT_PROGRESS_CTX_IDX	0
@@ -29,8 +31,10 @@ struct crt_swim_membs {
 	D_CIRCLEQ_HEAD(, crt_swim_target) csm_head;
 	struct crt_swim_target		*csm_target;
 	struct swim_context		*csm_ctx;
-	int				 csm_crt_ctx_idx;
 	uint64_t			 csm_incarnation;
+	int				 csm_crt_ctx_idx;
+	int				 csm_nglitches;
+	int				 csm_nmessages;
 };
 
 static inline void

--- a/src/cart/swim/swim_internal.h
+++ b/src/cart/swim/swim_internal.h
@@ -105,6 +105,8 @@ struct swim_context {
 	uint64_t		 sc_deadline;
 
 	uint64_t		 sc_piggyback_tx_max;
+
+	unsigned int		 sc_glitch:1;
 };
 
 static inline int


### PR DESCRIPTION
After network outage all members switches into INAVTIVE state
with following bringing them up to date by direct responses.
If node is DEAD it don't send reply back and doesn't switches
from INACTIVE state any more. This patch fix this and introduce
more logic for accommodation to network glitches by controlling
the frequency of glitches happens.