### PR TITLE
DAOS-8561 sched: sched_exec_time()

### DIFF
--- a/src/engine/sched.c
+++ b/src/engine/sched.c
@@ -63,6 +63,7 @@ unsigned int	sched_stats_intvl;
 unsigned int	sched_relax_intvl = SCHED_RELAX_INTVL_DEFAULT;
 unsigned int	sched_relax_mode;
 unsigned int	sched_unit_runtime_max = 32; /* ms */
+bool		sched_watchdog_all;
 
 enum {
 	/* All requests for various pools are processed in FIFO */
@@ -1595,39 +1596,60 @@ sched_start_cycle(struct sched_data *data, ABT_pool *pools)
 	}
 }
 
-struct sched_unit {
-	uint64_t	 su_start;
-	void		*su_func_addr;
-};
-
 static inline bool
 watchdog_enabled(struct dss_xstream *dx)
 {
-	/* Enable watchdog for sys xstream only */
-	return sched_unit_runtime_max != 0 && dx->dx_xs_id == 0;
+	if (sched_unit_runtime_max == 0)
+		return false;
+
+	return dx->dx_xs_id == 0 || (sched_watchdog_all && dx->dx_main_xs);
+}
+
+int
+sched_exec_time(uint64_t *msecs, const char *ult_name)
+{
+	struct dss_xstream	*dx = dss_current_xstream();
+	struct sched_info	*info = &dx->dx_sched_info;
+	uint64_t		 cur;
+
+	if (!watchdog_enabled(dx))
+		return -DER_NOSYS;
+
+	cur = daos_getmtime_coarse();
+	if (cur < info->si_ult_start) {
+		D_WARN("cur:"DF_U64" < start:"DF_U64"\n", cur, info->si_ult_start);
+		*msecs = 0;
+		return 0;
+	}
+
+	*msecs = cur - info->si_ult_start;
+	if (*msecs > sched_unit_runtime_max && ult_name != NULL)
+		D_WARN("ULT:%s executed "DF_U64" msecs\n", ult_name, *msecs);
+	return 0;
+
 }
 
 static void
-sched_watchdog_prep(struct dss_xstream *dx, ABT_unit unit,
-		    struct sched_unit *su)
+sched_watchdog_prep(struct dss_xstream *dx, ABT_unit unit)
 {
-	ABT_thread	thread;
-	void		(*thread_func)(void *);
-	int		rc;
+	struct sched_info	*info = &dx->dx_sched_info;
+	ABT_thread		 thread;
+	void			 (*thread_func)(void *);
+	int			 rc;
 
 	if (!watchdog_enabled(dx))
 		return;
 
-	su->su_start = daos_getmtime_coarse();
+	info->si_ult_start = daos_getmtime_coarse();
 	rc = ABT_unit_get_thread(unit, &thread);
 	D_ASSERT(rc == ABT_SUCCESS);
 	rc = ABT_thread_get_thread_func(thread, &thread_func);
 	D_ASSERT(rc == ABT_SUCCESS);
-	su->su_func_addr = thread_func;
+	info->si_ult_func = thread_func;
 }
 
 static void
-sched_watchdog_post(struct dss_xstream *dx, struct sched_unit *su)
+sched_watchdog_post(struct dss_xstream *dx)
 {
 	struct sched_info	*info = &dx->dx_sched_info;
 	uint64_t		 cur;
@@ -1641,13 +1663,13 @@ sched_watchdog_post(struct dss_xstream *dx, struct sched_unit *su)
 		return;
 
 	cur = daos_getmtime_coarse();
-	if (cur < su->su_start) {
+	if (cur < info->si_ult_start) {
 		D_WARN("Backwards time, cur:"DF_U64", start:"DF_U64"\n",
-		       cur, su->su_start);
+		       cur, info->si_ult_start);
 		return;
 	}
 
-	elapsed = cur - su->su_start;
+	elapsed = cur - info->si_ult_start;
 	if (elapsed <= sched_unit_runtime_max)
 		return;
 
@@ -1656,16 +1678,16 @@ sched_watchdog_post(struct dss_xstream *dx, struct sched_unit *su)
 		  "cur:"DF_U64" < watchdog_ts:"DF_U64"\n",
 		  cur, info->si_stats.ss_watchdog_ts);
 
-	if (info->si_stats.ss_last_unit == su->su_func_addr &&
+	if (info->si_stats.ss_last_unit == info->si_ult_func &&
 	    (cur - info->si_stats.ss_watchdog_ts) <= 2000)
 		return;
 
-	info->si_stats.ss_last_unit = su->su_func_addr;
+	info->si_stats.ss_last_unit = info->si_ult_func;
 	info->si_stats.ss_watchdog_ts = cur;
 
-	strings = backtrace_symbols(&su->su_func_addr, 1);
+	strings = backtrace_symbols(&info->si_ult_func, 1);
 	D_ERROR("WATCHDOG: XS(%d) Thread %p took %u ms. symbol:%s\n",
-		dx->dx_xs_id, su->su_func_addr, elapsed,
+		dx->dx_xs_id, info->si_ult_func, elapsed,
 		strings != NULL ? strings[0] : NULL);
 
 	free(strings);
@@ -1681,7 +1703,6 @@ sched_run(ABT_sched sched)
 	ABT_pool		 pool;
 	ABT_unit		 unit;
 	uint32_t		 work_count = 0;
-	struct sched_unit	 su = { 0 };
 	int			 ret;
 
 	ABT_sched_get_data(sched, (void **)&data);
@@ -1724,11 +1745,11 @@ sched_run(ABT_sched sched)
 		goto check_event;
 execute:
 		D_ASSERT(pool != ABT_POOL_NULL);
-		sched_watchdog_prep(dx, unit, &su);
+		sched_watchdog_prep(dx, unit);
 
 		ABT_xstream_run_unit(unit, pool);
 
-		sched_watchdog_post(dx, &su);
+		sched_watchdog_post(dx);
 start_cycle:
 		if (cycle->sc_new_cycle) {
 			sched_start_cycle(data, pools);

--- a/src/engine/srv.c
+++ b/src/engine/srv.c
@@ -905,6 +905,7 @@ dss_xstreams_init(void)
 	       sched_relax_mode2str(sched_relax_mode));
 
 	d_getenv_int("DAOS_SCHED_UNIT_RUNTIME_MAX", &sched_unit_runtime_max);
+	d_getenv_bool("DAOS_SCHED_WATCHDOG_ALL", &sched_watchdog_all);
 
 	/* start the execution streams */
 	D_DEBUG(DB_TRACE,

--- a/src/engine/srv_internal.h
+++ b/src/engine/srv_internal.h
@@ -36,6 +36,8 @@ struct sched_stats {
 struct sched_info {
 	uint64_t		 si_cur_ts;	/* Current timestamp (ms) */
 	uint64_t		 si_cur_seq;	/* Current schedule sequence */
+	uint64_t		 si_ult_start;	/* Start time of last executed unit */
+	void			*si_ult_func;	/* Function addr of last executed unit */
 	struct sched_stats	 si_stats;	/* Sched stats */
 	d_list_t		 si_idle_list;	/* All unused requests */
 	d_list_t		 si_sleep_list;	/* All sleeping requests */
@@ -186,6 +188,7 @@ extern unsigned int sched_stats_intvl;
 extern unsigned int sched_relax_intvl;
 extern unsigned int sched_relax_mode;
 extern unsigned int sched_unit_runtime_max;
+extern bool sched_watchdog_all;
 
 void dss_sched_fini(struct dss_xstream *dx);
 int dss_sched_init(struct dss_xstream *dx);

--- a/src/include/daos_srv/daos_engine.h
+++ b/src/include/daos_srv/daos_engine.h
@@ -372,6 +372,17 @@ uint64_t sched_cur_msec(void);
  */
 uint64_t sched_cur_seq(void);
 
+/**
+ * Get current ULT/Task execution time. The execution time is the elapsed
+ * time since current ULT/Task was scheduled last time.
+ *
+ * \param[out]	msecs		executed time in milli-second
+ * \param[in]	ult_name	ULT name (optional)
+ *
+ * \retval			-DER_NOSYS or 0 on success.
+ */
+int sched_exec_time(uint64_t *msecs, const char *ult_name);
+
 static inline bool
 dss_ult_exiting(struct sched_request *req)
 {


### PR DESCRIPTION
sched_exec_time() is to get the elapsed time since the current
ULT/task was scheduled last time. It's introduced for debug purpose,
caller can call this function to tell if current ULT/Task is hogging
CPU for too long.

sched_exec_time() is enabled for sys xstream by default, one can set
"DAOS_SCHED_WATCHDOG_ALL=1" to enable it for VOS xstreams as well.

Signed-off-by: Niu Yawei <yawei.niu@intel.com>