### PR TITLE
DAOS-8631 dfs: fix coverity issue 329522

### DIFF
--- a/src/client/dfs/dfs.c
+++ b/src/client/dfs/dfs.c
@@ -3278,6 +3278,7 @@ dfs_obj_local2global(dfs_t *dfs, dfs_obj_t *obj, d_iov_t *glob)
 	uuid_copy(obj_glob->coh_uuid, coh_uuid);
 	uuid_copy(obj_glob->cont_uuid, cont_uuid);
 	strncpy(obj_glob->name, obj->name, DFS_MAX_NAME + 1);
+	obj_glob->name[DFS_MAX_NAME] = 0;
 	rc = dfs_get_chunk_size(obj, &obj_glob->chunk_size);
 	if (rc)
 		return rc;


### PR DESCRIPTION
strncpy does not NULL terminate in edge case.

Signed-off-by: Mohamad Chaarawi <mohamad.chaarawi@intel.com>