### PR TITLE
DAOS-8639 test: Improve dfuse crash handling in test

### DIFF
--- a/src/tests/ftest/util/dfuse_utils.py
+++ b/src/tests/ftest/util/dfuse_utils.py
@@ -124,8 +124,8 @@ class Dfuse(DfuseCommand):
                 else:
                     command = "cat /proc/mounts | grep dfuse"
                     retcodes = pcmd([host], command, expect_rc=None)
-                    for ret_code, nodes in list(retcodes.items()):
-                        for node in nodes:
+                    for ret_code, host_names in list(retcodes.items()):
+                        for node in host_names:
                             if ret_code == 0:
                                 check_mounted.add(node)
                             else:

--- a/src/tests/ftest/util/dfuse_utils.py
+++ b/src/tests/ftest/util/dfuse_utils.py
@@ -122,7 +122,14 @@ class Dfuse(DfuseCommand):
                 if retcode == 0:
                     check_mounted.add(host)
                 else:
-                    state["nodirectory"].add(host)
+                    command = "cat /proc/mounts | grep dfuse"
+                    retcodes = pcmd([host], command, expect_rc=None)
+                    for retcode, hosts in list(retcodes.items()):
+                        for host in hosts:
+                            if retcode == 0:
+                                check_mounted.add(host)
+                            else:
+                                state["nodirectory"].add(host)
 
         if check_mounted:
             # Detect which hosts with mount point directories have it mounted as

--- a/src/tests/ftest/util/dfuse_utils.py
+++ b/src/tests/ftest/util/dfuse_utils.py
@@ -124,12 +124,12 @@ class Dfuse(DfuseCommand):
                 else:
                     command = "cat /proc/mounts | grep dfuse"
                     retcodes = pcmd([host], command, expect_rc=None)
-                    for retcode, hosts in list(retcodes.items()):
-                        for host in hosts:
-                            if retcode == 0:
-                                check_mounted.add(host)
+                    for ret_code, nodes in list(retcodes.items()):
+                        for node in nodes:
+                            if ret_code == 0:
+                                check_mounted.add(node)
                             else:
-                                state["nodirectory"].add(host)
+                                state["nodirectory"].add(node)
 
         if check_mounted:
             # Detect which hosts with mount point directories have it mounted as


### PR DESCRIPTION
Improve dfuse cleanup in case of crash on client.
Adding conditon when there is no fuse process running
and dfuse is still mounted.

Signed-off-by: Saurabh Tandan <saurabh.tandan@intel.com>