### PR TITLE
DAOS-8621 test: restart daos agents with daos server restart

### DIFF
--- a/src/tests/ftest/server/daos_server_restart.py
+++ b/src/tests/ftest/server/daos_server_restart.py
@@ -37,6 +37,10 @@ class DaosServerTest(TestWithServers):
         self.server_managers[0].dmg.storage_format(reformat)
         self.log.info("=Restart daos_server, detect_engine_start().")
         self.server_managers[0].detect_engine_start()
+        self.log.info("=Restart daos_agent, stop")
+        self.stop_agents()
+        self.log.info("=Restart daos_agent, start")
+        self.start_agent_managers()
 
     @fail_on(ServerFailed)
     @fail_on(CommandFailure)

--- a/src/tests/ftest/server/daos_server_restart.yaml
+++ b/src/tests/ftest/server/daos_server_restart.yaml
@@ -12,6 +12,10 @@ hosts:
 
 timeout: 360
 
+setup:
+  start_agents_once: False
+  start_servers_once: False
+
 server_config:
   name: daos_server
 


### PR DESCRIPTION
the agent's cached rank->uri map can get out of sync with the servers
if the agent is not restarted when the servers are.

Test-tag-hw-large: pr,hw,large,server_reformat DAOS_5610
Signed-off-by: Wang Shilong <shilong.wang@intel.com>