### PR TITLE
DAOS-8641 dtx: avoid noisy error log message

### DIFF
--- a/src/dtx/dtx_rpc.c
+++ b/src/dtx/dtx_rpc.c
@@ -960,10 +960,16 @@ again:
 						      pool->sp_map_version,
 						      &tgt);
 			if (rc < 0) {
-				D_ERROR("Failed to find DTX leader for "
-					DF_DTI", ver %d: "DF_RC"\n",
-					DP_DTI(&dsp->dsp_xid),
-					pool->sp_map_version, DP_RC(rc));
+				/* Currently, for EC object, if parity node is
+				 * in rebuilding, we will get -DER_STALE, that
+				 * is not fatal, the caller or related request
+				 * sponsor can retry sometime later.
+				 */
+				D_CDEBUG(rc == -DER_STALE, DB_TRACE, DLOG_WARN,
+					 "Failed to find DTX leader for "
+					 DF_DTI", ver %d: "DF_RC"\n",
+					 DP_DTI(&dsp->dsp_xid),
+					 pool->sp_map_version, DP_RC(rc));
 
 				if (failout)
 					goto out;


### PR DESCRIPTION
During rebuild, DTX refresh may hits -DER_STALE when
locate the leader for non-rebuilt EC object. That is
not fatal and will cause related request sponsor to
repeatedly retry until rebuild done or hit some other
failure. Such repeatedly retry may generate huge of
log message as to the server out of space. Since it
is not fatal, convert it from "ERROR" to "TARCE" in
the log.

Signed-off-by: Fan Yong <fan.yong@intel.com>