### PR TITLE
DAOS-8449 tests: misc fixes for nvme_pool_exclude (2)

### DIFF
--- a/src/client/api/object.c
+++ b/src/client/api/object.c
@@ -260,6 +260,8 @@ daos_obj_verify(daos_handle_t coh, daos_obj_id_t oid, daos_epoch_t epoch)
 		rc = dc_task_schedule(task, true);
 		if (rc == 0)
 			rc = dc_obj_verify(oh, epochs_p, epoch_nr);
+		if (rc == -DER_NONEXIST)
+			rc = 0;
 	}
 
 	D_FREE(epochs_p);

--- a/src/common/pool_map.c
+++ b/src/common/pool_map.c
@@ -2456,6 +2456,8 @@ pmap_fail_node_add_tgt(struct pmap_fail_stat *fstat,
 	}
 	if (comp->co_fseq > fstat->pf_last_ver)
 		fnode->pf_new_fail = 1;
+	else
+		fnode->pf_new_fail = 0;
 
 	for (i = 0; i < fnode->pf_ver_nr; i++) {
 		tmp = &fnode->pf_vers[i];
@@ -2529,7 +2531,7 @@ pmap_node_check(struct pool_domain *node_dom, struct pmap_fail_stat *fstat)
 		fstat->pf_newfail_nr++;
 	if ((fstat->pf_down_nr > fstat->pf_rf) && (fstat->pf_newfail_nr > 0)) {
 		rc = -DER_RF;
-		D_DEBUG(DB_TRACE, "RF broken, found %d DOWN node, "
+		D_ERROR("RF broken, found %d DOWN node, "
 			"newly fail %d, rf %d, "DF_RC"\n", fstat->pf_down_nr,
 			fstat->pf_newfail_nr, fstat->pf_rf, DP_RC(rc));
 	}
@@ -2607,7 +2609,7 @@ pmap_fail_stat_check(struct pmap_fail_stat *fstat)
 
 fail:
 	if (rc == -DER_RF) {
-		D_DEBUG(DB_TRACE, "RF broken, found %d fail, DOWN %d, newly "
+		D_ERROR("RF broken, found %d fail, DOWN %d, newly "
 			"fail %d, max_overlapped %d, rf %d, "DF_RC"\n",
 			fstat->pf_node_nr, fstat->pf_down_nr,
 			fstat->pf_newfail_nr, max_fail_nr,

--- a/src/dtx/dtx_resync.c
+++ b/src/dtx/dtx_resync.c
@@ -433,6 +433,9 @@ out:
 		/* Drain old committable DTX to help subsequent rebuild. */
 		err = dtx_obj_sync(cont, NULL, dra->epoch);
 
+	if (err == -DER_NONEXIST)
+		err = 0;
+
 	return err;
 }
 

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -1680,8 +1680,11 @@ obj_capa_check(struct ds_cont_hdl *coh, bool is_write, bool is_agg_migrate)
 		return -DER_NO_PERM;
 	}
 
-	if (!is_agg_migrate && coh->sch_cont && coh->sch_cont->sc_rw_disabled)
+	if (!is_agg_migrate && coh->sch_cont && coh->sch_cont->sc_rw_disabled) {
+		D_ERROR("cont hdl "DF_UUID" exceeds rf\n",
+			DP_UUID(coh->sch_uuid));
 		return -DER_RF;
+	}
 
 	return 0;
 }

--- a/src/tests/ftest/nvme/nvme_pool_exclude.py
+++ b/src/tests/ftest/nvme/nvme_pool_exclude.py
@@ -52,13 +52,7 @@ class NvmePoolExclude(OSAUtils):
         # Create a pool
         label_generator = LabelGenerator()
         pool = {}
-        target_list = []
 
-        # Exclude target : random two targets (target idx : 0-7)
-        n = random.randint(0, 6)
-        target_list.append(n)
-        target_list.append(n+1)
-        t_string = "{},{}".format(target_list[0], target_list[1])
         if oclass is None:
             oclass = self.ior_cmd.dfs_oclass.value
 
@@ -95,11 +89,12 @@ class NvmePoolExclude(OSAUtils):
 
                 index = random.randint(1, len(rank_list))
                 rank = rank_list.pop(index-1)
-                self.log.info("Removing rank %d", rank)
+                tgt_exclude = random.randint(1, 6)
+                self.log.info("Removing rank %d, target %d", rank, tgt_exclude)
 
                 self.log.info("Pool Version at the beginning %s", pver_begin)
                 output = self.dmg_command.pool_exclude(self.pool.uuid,
-                                                       rank, t_string)
+                                                       rank, tgt_exclude)
                 self.print_and_assert_on_rebuild_failure(output)
 
                 pver_exclude = self.get_pool_version()

--- a/src/tests/ftest/nvme/nvme_pool_exclude.yaml
+++ b/src/tests/ftest/nvme/nvme_pool_exclude.yaml
@@ -56,8 +56,8 @@ pool:
 container:
     type: POSIX
     control_method: daos
-    properties: cksum:crc16,cksum_size:16384,srv_cksum:on,rf:1
-    oclass: RP_2G8
+    properties: cksum:crc16,cksum_size:16384,srv_cksum:on,rf:2
+    oclass: RP_3G5
 ior:
   client_processes:
     np: 48
@@ -68,8 +68,8 @@ ior:
     write_flags: "-w -F -k -G 1"
     read_flags: "-F -r -R -k -G 1"
     api: DFS
-    dfs_oclass: RP_2G8
-    dfs_dir_oclass: RP_2G8
+    dfs_oclass: RP_3G5
+    dfs_dir_oclass: RP_3G5
     ior_test_sequence:
     #   - [scm_size, nvme_size, transfersize, blocksize]
     #    The values are set to be in the multiples of 10.
@@ -79,11 +79,10 @@ ior:
         - [50000000000, 300000000000, 1000000000, 8000000000]  #[1G, 8G]
 test_obj_class:
   oclass:
-    - RP_3G6
+    - RP_3G5
     - RP_4G1
-    - S1
 loop_test:
-  iterations: 3
+  iterations: 2
 aggregation:
   test_with_aggregation: True
 rebuild:


### PR DESCRIPTION
Mainly contain two fixes:

1. The RF property should be enough for two targets failure
   (excluded) in nvme_pool_exclude test. Otherwise, the IOR
   will get DER_RF(2031) during the test.

2. There is CPU yield during DTX resync. That is normal that
   someone may has punched the object during the interval of
   resync the DTX enteries (that are related with the object)
   and marking the object as re-synced.

3. Trying to verify a non-exist object is not fatal failure.

Test-tag-hw-large: pr,hw,large nvme_pool_exclude

Signed-off-by: Fan Yong <fan.yong@intel.com>