### PR TITLE
DAOS-8542 object: missing bulk free in obj_comp_cb

### DIFF
--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -3788,11 +3788,12 @@ obj_comp_cb(tse_task_t *task, void *data)
 		 * are some other cases we need to retry the RPC with current
 		 * shard, such as -DER_TIMEDOUT or daos_crt_network_error().
 		 */
-		/* It needs to retry for INPROGRESS and TX_BUSY anyway */
-		if (!obj_auxi->no_retry &&
-		    (!obj_auxi->spec_shard || task->dt_result == -DER_INPROGRESS ||
-					      task->dt_result == -DER_TX_BUSY))
-			obj_auxi->io_retry = 1;
+		obj_auxi->io_retry = 1;
+		if (obj_auxi->no_retry ||
+		    (obj_auxi->spec_shard && (task->dt_result == -DER_INPROGRESS ||
+		     task->dt_result == -DER_TX_BUSY || task->dt_result == -DER_EXCLUDED ||
+		     task->dt_result == -DER_CSUM)))
+			obj_auxi->io_retry = 0;
 
 		if (task->dt_result == -DER_CSUM ||
 		    task->dt_result == -DER_TX_UNCERTAIN) {
@@ -3844,7 +3845,7 @@ obj_comp_cb(tse_task_t *task, void *data)
 		rc = obj_retry_cb(task, obj, obj_auxi, pm_stale, obj_auxi->map_ver_reply);
 		if (rc) {
 			D_ERROR(DF_OID "retry io failed: %d\n", DP_OID(obj->cob_md.omd_id), rc);
-			obj_bulk_fini(obj_auxi);
+			D_ASSERT(obj_auxi->io_retry == 0);
 		}
 	}
 

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -3788,11 +3788,10 @@ obj_comp_cb(tse_task_t *task, void *data)
 		 * are some other cases we need to retry the RPC with current
 		 * shard, such as -DER_TIMEDOUT or daos_crt_network_error().
 		 */
-
-		if ((!obj_auxi->spec_shard && !obj_auxi->spec_group &&
-		     !obj_auxi->no_retry) ||
-		    (task->dt_result != -DER_INPROGRESS &&
-		     task->dt_result != -DER_TX_BUSY))
+		/* It needs to retry for INPROGRESS and TX_BUSY anyway */
+		if (!obj_auxi->no_retry &&
+		    (!obj_auxi->spec_shard || task->dt_result == -DER_INPROGRESS ||
+					      task->dt_result == -DER_TX_BUSY))
 			obj_auxi->io_retry = 1;
 
 		if (task->dt_result == -DER_CSUM ||
@@ -3841,9 +3840,13 @@ obj_comp_cb(tse_task_t *task, void *data)
 	    DAOS_FAIL_CHECK(DAOS_DTX_NO_RETRY))
 		obj_auxi->io_retry = 0;
 
-	if (!obj_auxi->no_retry && (pm_stale || obj_auxi->io_retry))
-		obj_retry_cb(task, obj, obj_auxi, pm_stale,
-			     obj_auxi->map_ver_reply);
+	if (!obj_auxi->no_retry && (pm_stale || obj_auxi->io_retry)) {
+		rc = obj_retry_cb(task, obj, obj_auxi, pm_stale, obj_auxi->map_ver_reply);
+		if (rc) {
+			D_ERROR(DF_OID "retry io failed: %d\n", DP_OID(obj->cob_md.omd_id), rc);
+			obj_bulk_fini(obj_auxi);
+		}
+	}
 
 	if (!obj_auxi->io_retry) {
 		struct obj_ec_fail_info	*fail_info;
@@ -3984,6 +3987,7 @@ obj_comp_cb(tse_task_t *task, void *data)
 			memset(obj_auxi, 0, sizeof(*obj_auxi));
 		}
 	} else {
+		D_ASSERT(!obj_auxi->no_retry);
 		if (!obj_auxi->ec_in_recov)
 			obj_ec_fail_info_reset(&obj_auxi->reasb_req);
 	}


### PR DESCRIPTION
If no_retry is set for the task, which is usually used by migration
task, then it should not check io_retry, otherwse both io_retry and
no_retry will be set, and retry_cb will not be scheduled, so bulks
will not freed, but its buffer allocated by DAOS will be freed, so
later if the data arrive, it will cause segfaults.

Missing bulk free if retry_cb() failed.

Signed-off-by: Di Wang <di.wang@intel.com>