### PR TITLE
DAOS-8082 EC: cleanup yield in EC aggregation

### DIFF
--- a/src/object/srv_ec_aggregate.c
+++ b/src/object/srv_ec_aggregate.c
@@ -127,7 +127,6 @@ struct ec_agg_param {
 	uint32_t		 ap_credits_max; /* # of tight loops to yield */
 	uint32_t		 ap_credits;     /* # of tight loops          */
 	uint32_t		 ap_initialized:1, /* initialized flag */
-				 ap_yielded:1,	   /* yielded */
 				 ap_obj_skipped:1; /* skipped obj during aggregation */
 };
 
@@ -672,7 +671,6 @@ static int
 agg_encode_full_stripe(struct ec_agg_entry *entry)
 {
 	struct ec_agg_stripe_ud		stripe_ud = { 0 };
-	struct ec_agg_param		*agg_param;
 	int				*status;
 	int				tid, rc = 0;
 
@@ -688,8 +686,6 @@ agg_encode_full_stripe(struct ec_agg_entry *entry)
 	if (rc)
 		goto ev_out;
 
-	agg_param = container_of(entry, struct ec_agg_param, ap_agg_entry);
-	agg_param->ap_yielded = 1;
 	rc = ABT_eventual_wait(stripe_ud.asu_eventual, (void **)&status);
 	if (rc != ABT_SUCCESS) {
 		rc = dss_abterr2der(rc);
@@ -1144,7 +1140,6 @@ static int
 agg_process_partial_stripe(struct ec_agg_entry *entry)
 {
 	struct ec_agg_stripe_ud	 stripe_ud = { 0 };
-	struct ec_agg_param	*agg_param;
 	struct ec_agg_extent	*extent;
 	int			*status;
 	uint8_t			*bit_map = NULL;
@@ -1234,8 +1229,6 @@ agg_process_partial_stripe(struct ec_agg_entry *entry)
 			    DSS_XS_IOFW, tid, 0, NULL);
 	if (rc)
 		goto ev_out;
-	agg_param = container_of(entry, struct ec_agg_param, ap_agg_entry);
-	agg_param->ap_yielded = 1;
 	rc = ABT_eventual_wait(stripe_ud.asu_eventual, (void **)&status);
 	if (rc != ABT_SUCCESS) {
 		rc = dss_abterr2der(rc);
@@ -1465,7 +1458,6 @@ agg_peer_update(struct ec_agg_entry *entry, bool write_parity)
 			    DSS_XS_IOFW, tid, 0, NULL);
 	if (rc)
 		goto ev_out;
-	agg_param->ap_yielded = 1;
 	rc = ABT_eventual_wait(stripe_ud.asu_eventual, (void **)&status);
 	if (rc != ABT_SUCCESS) {
 		rc = dss_abterr2der(rc);
@@ -1750,7 +1742,6 @@ agg_process_holes(struct ec_agg_entry *entry)
 			    DSS_XS_IOFW, tid, 0, NULL);
 	if (rc)
 		goto ev_out;
-	agg_param->ap_yielded = 1;
 	rc = ABT_eventual_wait(stripe_ud.asu_eventual, (void **)&status);
 	if (rc != ABT_SUCCESS) {
 		rc = dss_abterr2der(rc);
@@ -2040,11 +2031,6 @@ agg_akey_post(daos_handle_t ih, struct ec_agg_param *agg_param,
 		agg_entry->ae_cur_stripe.as_offset	= 0U;
 	}
 
-	if (agg_param->ap_yielded) {
-		*acts |= VOS_ITER_CB_YIELD;
-		agg_param->ap_yielded = 0;
-	}
-
 	return rc;
 }
 
@@ -2290,7 +2276,6 @@ agg_iterate_pre_cb(daos_handle_t ih, vos_iter_entry_t *entry,
 	agg_param->ap_credits++;
 	if (agg_param->ap_credits > agg_param->ap_credits_max) {
 		agg_param->ap_credits = 0;
-		*acts |= VOS_ITER_CB_YIELD;
 		D_DEBUG(DB_EPC, "EC aggregation yield type %d. acts %u\n",
 			type, *acts);
 		if (!(*acts & VOS_ITER_CB_SKIP))
@@ -2393,7 +2378,6 @@ ec_agg_param_init(struct ds_cont_child *cont, struct agg_param *param)
 	agg_param->ap_credits_max	= EC_AGG_ITERATION_MAX;
 	D_INIT_LIST_HEAD(&agg_param->ap_agg_entry.ae_cur_stripe.as_dextents);
 	D_INIT_LIST_HEAD(&agg_param->ap_agg_entry.ae_cur_stripe.as_hoextents);
-	agg_param->ap_yielded = 0;
 
 	rc = ABT_eventual_create(sizeof(*status), &eventual);
 	if (rc != ABT_SUCCESS)


### PR DESCRIPTION
Ad PR6732 (8aca03a3ef) landed, vos_iterate() internally set
VOS_ITER_CB_YIELD when needed, remove related code in EC agg.

Signed-off-by: Xuezhao Liu <xuezhao.liu@intel.com>