### PR TITLE
DAOS-8650 test: increase test_daos_dfs_sys timeout

### DIFF
--- a/src/tests/ftest/daos_test/dfs.py
+++ b/src/tests/ftest/daos_test/dfs.py
@@ -32,7 +32,7 @@ class DaosCoreTestDfs(DaosCoreBase):
 
         :avocado: tags=all,pr,daily_regression
         :avocado: tags=hw,large
-        :avocado: tags=daos_test,dfs_test
+        :avocado: tags=daos_test,dfs_test,dfs
         :avocado: tags=daos_core_test_dfs,test_daos_dfs_unit
         """
         self.daos_test = os.path.join(self.bin, 'dfs_test')
@@ -49,7 +49,7 @@ class DaosCoreTestDfs(DaosCoreBase):
 
         :avocado: tags=all,pr,daily_regression
         :avocado: tags=hw,large
-        :avocado: tags=daos_test,dfs_test
+        :avocado: tags=daos_test,dfs_test,dfs
         :avocado: tags=daos_core_test_dfs,test_daos_dfs_parallel
         """
         self.daos_test = os.path.join(self.bin, 'dfs_test')
@@ -66,7 +66,7 @@ class DaosCoreTestDfs(DaosCoreBase):
 
         :avocado: tags=all,full_regression
         :avocado: tags=hw,large
-        :avocado: tags=daos_test,dfs_test
+        :avocado: tags=daos_test,dfs_test,dfs
         :avocado: tags=daos_core_test_dfs,test_daos_dfs_sys
         """
         self.daos_test = os.path.join(self.bin, 'dfs_test')

--- a/src/tests/ftest/daos_test/dfs.yaml
+++ b/src/tests/ftest/daos_test/dfs.yaml
@@ -15,7 +15,7 @@ timeout: 1000
 timeouts:
   test_daos_dfs_unit: 1000
   test_daos_dfs_parallel: 200
-  test_daos_dfs_sys: 60
+  test_daos_dfs_sys: 90
 pool:
   scm_size: 8G
 server_config:


### PR DESCRIPTION
Quick-Functional: true
Test-tag: daos_test,dfs

- Increase test_daos_dfs_sys timeout to 90
- Tag tests with "dfs"

Signed-off-by: Dalton Bohning <dalton.bohning@intel.com>