### PR TITLE
DAOS-8652 test: tag tests in ftest/dfuse

### DIFF
--- a/src/tests/ftest/dfuse/posix_stat.py
+++ b/src/tests/ftest/dfuse/posix_stat.py
@@ -33,6 +33,7 @@ class POSIXStatTest(IorTestBase):
 
         :avocado: tags=all,full_regression
         :avocado: tags=small
+        :avocado: tags=dfuse
         :avocado: tags=stat_parameters
         """
         block_sizes = self.params.get("block_sizes", "/run/*")

--- a/src/tests/ftest/dfuse/sparse_file.py
+++ b/src/tests/ftest/dfuse/sparse_file.py
@@ -42,7 +42,10 @@ class SparseFile(IorTestBase):
             Verify, the bytes between 1st byte and 1024th byte are empty.
             Now try to read the file from it's last 512 bytes till EOF.
             This should return EOF, otherwise fail the test.
-        :avocado: tags=all,hw,daosio,small,full_regression,dfusesparsefile
+        :avocado: tags=all,full_regression
+        :avocado: tags=hw,small
+        :avocado: tags=daosio,dfuse
+        :avocado: tags=dfusesparsefile
         """
         # Create a pool, container and start dfuse.
         self.create_pool()


### PR DESCRIPTION
Tag all tests in ftest/dfuse with "dfuse"

Quick-Functional: true
Test-tags: dfuse,dfusesparsefile dfuse,stat_parameters

Signed-off-by: Dalton Bohning <dalton.bohning@intel.com>