### PR TITLE
DAOS-8602-test: container/snapshot RC -1005 when snapshot destroy the 2nd snapshot by daos_api

### DIFF
--- a/src/tests/ftest/container/snapshot.py
+++ b/src/tests/ftest/container/snapshot.py
@@ -313,6 +313,8 @@ class Snapshot(TestWithServers):
                    ==>Repeat step(1) to step(4) for multiple snapshot tests.
                 (5)Verify the snapshots data.
                 (6)Destroy the snapshot individually.
+                   ==>Loop step(5) and step(6) to perform multiple snapshots
+                   data verification and snapshot destroy test.
                 (7)Check if still able to Open the destroyed snapshot and
                    Verify the snapshot removed from the snapshot list.
         Use Cases: Require 1 client and 1 server to run snapshot test.
@@ -425,6 +427,9 @@ class Snapshot(TestWithServers):
                           "still available", num_transactions)
 
         # (5)Verify the snapshots data
+        #    Step(5) and (6), test loop to perform multiple snapshots data
+        #    verification and snapshot destroy.
+        #    Use current_ss for the individual snapshot object.
         for ss_number in range(snapshot_loop-1, 0, -1):
             ind = ss_number - 1
             self.log.info("=(5.%s)Verify the snapshot number %s:"

--- a/src/tests/ftest/container/snapshot.py
+++ b/src/tests/ftest/container/snapshot.py
@@ -486,4 +486,3 @@ class Snapshot(TestWithServers):
         except Exception as error:
             self.fail("##(7)Error when calling the snapshot list: {}"
                       .format(str(error)))
-

--- a/src/tests/ftest/container/snapshot.py
+++ b/src/tests/ftest/container/snapshot.py
@@ -315,7 +315,6 @@ class Snapshot(TestWithServers):
                 (6)Destroy the snapshot individually.
                 (7)Check if still able to Open the destroyed snapshot and
                    Verify the snapshot removed from the snapshot list.
-                (8)Destroy the container snapshot.
         Use Cases: Require 1 client and 1 server to run snapshot test.
                    1 pool and 1 container is used, num_of_snapshot defined
                    in the snapshot.yaml will be performed and verified.
@@ -426,8 +425,8 @@ class Snapshot(TestWithServers):
                           "still available", num_transactions)
 
         # (5)Verify the snapshots data
-        for ind, _ in enumerate(test_data):
-            ss_number = ind + 1
+        for ss_number in range(snapshot_loop-1, 0, -1):
+            ind = ss_number - 1
             self.log.info("=(5.%s)Verify the snapshot number %s:"
                           , ss_number, ss_number)
             self.display_snapshot_test_data(test_data, ss_number)
@@ -438,7 +437,7 @@ class Snapshot(TestWithServers):
             datasize = len(tst_data) + 1
             try:
                 obj.open()
-                snap_handle5 = snapshot.open(coh, current_ss.epoch)
+                snap_handle5 = current_ss.open(coh, current_ss.epoch)
                 thedata5 = self.container.read_an_obj(
                     datasize, dkey, akey, obj, txn=snap_handle5.value)
                 obj.close()
@@ -454,14 +453,14 @@ class Snapshot(TestWithServers):
 
         # (6)Destroy the individual snapshot
             self.log.info("=(6.%s)Destroy the snapshot epoch: %s",
-                          ss_number, snapshot.epoch)
+                          ss_number, current_ss.epoch)
             try:
-                snapshot.destroy(coh, snapshot.epoch)
+                current_ss.destroy(coh, current_ss.epoch)
                 self.log.info(
                     "  ==snapshot.epoch %s successfully destroyed",
-                    snapshot.epoch)
+                    current_ss.epoch)
             except Exception as error:
-                self.fail("##(6)Error on snapshot.destroy: {}"
+                self.fail("##(6)Error on current_ss.destroy: {}"
                           .format(str(error)))
 
         # (7)Check if still able to Open the destroyed snapshot and
@@ -488,11 +487,3 @@ class Snapshot(TestWithServers):
             self.fail("##(7)Error when calling the snapshot list: {}"
                       .format(str(error)))
 
-        # (8)Destroy the snapshot on the container
-        try:
-            snapshot.destroy(coh)
-            self.log.info("=(8)Container snapshot destroyed successfully.")
-        except Exception as error:
-            self.fail("##(8)Error on snapshot.destroy. {}"
-                      .format(str(error)))
-        self.log.info("===DAOS container Multiple snapshots test passed.")


### PR DESCRIPTION
DAOS-8602-test: container/snapshot RC -1005 when snapshot destroy the 2nd snapshot by daos_api
modified: container/snapshot.py
Summary: Script updates with current_snapshot object in destroying snapshot loop for destroying multiple snapshots, and removed the redundant step (8).

Test-tag: pr snapshots
Co-Author: Kenneth Cain kenneth.c.cain@intel.com
Signed-off-by: Ding Ho ding-hwa.ho@intel.com