### PR TITLE
DAOS-8630 control: Fix static analysis issues

### DIFF
--- a/src/control/cmd/dmg/pool.go
+++ b/src/control/cmd/dmg/pool.go
@@ -171,7 +171,10 @@ func (cmd *PoolCreateCmd) Execute(args []string) error {
 		req.TotalBytes = 0
 		req.TierRatio = nil
 
-		scmRatio := float64(ScmBytes) / float64(NvmeBytes)
+		scmRatio := 1.0
+		if NvmeBytes > 0 {
+			scmRatio = float64(ScmBytes) / float64(NvmeBytes)
+		}
 
 		if scmRatio < storage.MinScmToNVMeRatio {
 			cmd.log.Infof("SCM:NVMe ratio is less than %0.2f %%, DAOS "+

--- a/src/control/cmd/dmg/pretty/pool.go
+++ b/src/control/cmd/dmg/pretty/pool.go
@@ -75,8 +75,10 @@ func PrintPoolCreateResponse(pcr *control.PoolCreateResp, out io.Writer, opts ..
 	}
 
 	tierRatio := make([]float64, len(pcr.TierBytes))
-	for tierIdx, tierBytes := range pcr.TierBytes {
-		tierRatio[tierIdx] = float64(tierBytes) / float64(totalSize)
+	if totalSize != 0 {
+		for tierIdx, tierBytes := range pcr.TierBytes {
+			tierRatio[tierIdx] = float64(tierBytes) / float64(totalSize)
+		}
 	}
 
 	if len(pcr.TgtRanks) == 0 {
@@ -97,6 +99,7 @@ func PrintPoolCreateResponse(pcr *control.PoolCreateResp, out io.Writer, opts ..
 			title += ","
 			tierName = "NVMe"
 		}
+
 		title += fmt.Sprintf("%0.2f%%", tierRatio*100)
 		fmtName := fmt.Sprintf("Storage tier %d (%s)", tierIdx, tierName)
 		fmtArgs = append(fmtArgs, txtfmt.TableRow{fmtName: fmt.Sprintf("%s (%s / rank)", humanize.Bytes(pcr.TierBytes[tierIdx]*numRanks), humanize.Bytes(pcr.TierBytes[tierIdx]))})

--- a/src/control/lib/control/pool_property.go
+++ b/src/control/lib/control/pool_property.go
@@ -68,7 +68,7 @@ func PoolProperties() PoolPropertyMap {
 					if err != nil {
 						return nil, rbErr
 					}
-					if rsPct < 0 || rsPct > 100 {
+					if rsPct > 100 {
 						return nil, rbErr
 					}
 					return &PoolPropertyValue{rsPct}, nil

--- a/src/control/server/storage/bdev/backend_vmd.go
+++ b/src/control/server/storage/bdev/backend_vmd.go
@@ -229,14 +229,18 @@ func getVMDPrepReq(log logging.Logger, req *storage.BdevPrepareRequest, vmdDetec
 
 	vmdReq := vmdProcessFilters(req, vmdPCIAddrs)
 
-	if req.PCIAllowList != "" && vmdReq.PCIAllowList == "" {
-		log.Debugf("vmd prep: %v devices not allowed", vmdPCIAddrs)
-		return nil, nil
+	// No addrs left after filtering
+	if vmdReq.PCIAllowList == "" {
+		if req.PCIAllowList != "" {
+			log.Debugf("vmd prep: %v devices not allowed", vmdPCIAddrs)
+			return nil, nil
+		}
+		if req.PCIBlockList != "" {
+			log.Debugf("vmd prep: %v devices blocked", vmdPCIAddrs)
+			return nil, nil
+		}
 	}
-	if req.PCIBlockList != "" && vmdReq.PCIAllowList == "" {
-		log.Debugf("vmd prep: %v devices blocked", vmdPCIAddrs)
-		return nil, nil
-	}
+
 	log.Debugf("volume management devices selected: %v", vmdReq.PCIAllowList)
 
 	return &vmdReq, nil


### PR DESCRIPTION
- Avoid dividing by zero. (332706, 332705)
- Remove check for uint < 0. (332670)
- Clarify logic that caused a false positive in Coverity, so the intent
  is clearer to readers. (333475)

Signed-off-by: Kris Jacque <kristin.jacque@intel.com>