### PR TITLE
DAOS-8657 Failed to list attributes from more than one container in Java

### DIFF
--- a/src/client/java/daos-java/src/main/java/io/daos/DaosContainer.java
+++ b/src/client/java/daos-java/src/main/java/io/daos/DaosContainer.java
@@ -187,13 +187,13 @@ public class DaosContainer extends Shareable implements Closeable {
     Set<String> nameSet = new HashSet<>();
     boolean truncated = true;
     while (truncated) {
-      ByteBuf buffer = BufferAllocator.objBufWithNativeOrder(totalSize + 4);
+      ByteBuf buffer = BufferAllocator.objBufWithNativeOrder(totalSize + 8);
       try {
-        buffer.writeInt(totalSize);
+        buffer.writeLong(totalSize);
         buffer.writerIndex(buffer.capacity());
         DaosClient.daosListContAttrs(contPtr, buffer.memoryAddress());
         buffer.readerIndex(0);
-        int actualSize = buffer.readInt();
+        long actualSize = buffer.readLong();
         if (actualSize <= totalSize) {
           parseNameBuffer(buffer, actualSize, nameSet);
           truncated = false;
@@ -209,7 +209,7 @@ public class DaosContainer extends Shareable implements Closeable {
     return nameSet;
   }
 
-  private void parseNameBuffer(ByteBuf buffer, int actualSize, Set<String> nameSet)
+  private void parseNameBuffer(ByteBuf buffer, long actualSize, Set<String> nameSet)
       throws UnsupportedEncodingException {
     byte terminator = '\0';
     int count = 0;

--- a/src/client/java/daos-java/src/main/java/io/daos/obj/IOSimpleDDAsync.java
+++ b/src/client/java/daos-java/src/main/java/io/daos/obj/IOSimpleDDAsync.java
@@ -147,6 +147,10 @@ public class IOSimpleDDAsync extends IODataDescBase implements DaosEventQueue.At
     return retCode == RET_CODE_SUCCEEDED;
   }
 
+  public int getReturnCode() {
+    return retCode;
+  }
+
   @Override
   public IODataDesc duplicate() {
     throw new UnsupportedOperationException("duplicate is not supported");

--- a/src/client/java/daos-java/src/main/native/io_daos_DaosClient.c
+++ b/src/client/java/daos-java/src/main/native/io_daos_DaosClient.c
@@ -174,18 +174,18 @@ Java_io_daos_DaosClient_daosListContAttrs(JNIEnv *env,
 {
 	daos_handle_t coh;
 	char *buffer = (char *)address;
-	int buffer_size;
+	size_t buffer_size;
 	int rc;
 
-	memcpy(&buffer_size, buffer, 4);
-	buffer += 4;
+	memcpy(&buffer_size, buffer, 8);
+	buffer += 8;
 	memcpy(&coh, &contHandle, sizeof(coh));
 	rc = daos_cont_list_attr(coh, buffer, &buffer_size, NULL);
 	if (rc) {
 		throw_base(env, "Failed to list attributes from container", rc, 0, 0);
 	} else {
-		buffer -= 4;
-		memcpy(buffer, &buffer_size, 4);
+		buffer -= 8;
+		memcpy(buffer, &buffer_size, 8);
 	}
 }
 


### PR DESCRIPTION
It's ok to list attributes from one container in Java. But failed when more than one container. 

The cause is the buffer size parameter in list_cont_attribute is type of 4-byte int whilst it should be 8-byte size_t.

Signed-off-by: jiafu zhang <jiafu.zhang@intel.com>