### PR TITLE
DAOS-8635 common: Fix Coverity issues

### DIFF
--- a/src/common/pool_map.c
+++ b/src/common/pool_map.c
@@ -1435,12 +1435,14 @@ add_domains_to_pool_buf(struct pool_map *map, struct pool_buf *map_buf,
 		map_comp.co_type = PO_COMP_TP_NODE;
 		map_comp.co_status = new_status;
 		map_comp.co_index = i + num_comps;
+		map_comp.co_padding = 0;
 		map_comp.co_id = node.fdn_val.dom->fd_id;
 		map_comp.co_rank = 0;
 		map_comp.co_ver = map_version;
 		map_comp.co_fseq = 1;
+		map_comp.co_out_ver = map_version;
+		map_comp.co_flags = 0;
 		map_comp.co_nr = node.fdn_val.dom->fd_children_nr;
-		map_comp.co_padding = 0;
 
 		if (map != NULL) {
 			struct pool_domain	*current;

--- a/src/common/prop.c
+++ b/src/common/prop.c
@@ -879,6 +879,7 @@ parse_entry(char *str, struct daos_prop_entry *entry)
 	int	rc = 0;
 
 	/** get prop_name */
+	D_ASSERT(str != NULL);
 	name = strtok_r(str, ":", &end_token);
 	if (name == NULL)
 		return -DER_INVAL;

--- a/src/utils/daos_autotest.c
+++ b/src/utils/daos_autotest.c
@@ -246,6 +246,7 @@ ccreate(void)
 
 	cuuid2 = "autotest_cont_rf1";
 	rc = daos_cont_create_with_label(poh, cuuid2, prop, NULL, NULL);
+	daos_prop_free(prop);
 	if (rc)
 		D_GOTO(fail, rc);
 
@@ -258,6 +259,7 @@ ccreate(void)
 
 	cuuid3 = "autotest_cont_rf2";
 	rc = daos_cont_create_with_label(poh, cuuid3, prop2, NULL, NULL);
+	daos_prop_free(prop2);
 	if (rc)
 		D_GOTO(fail, rc);
 


### PR DESCRIPTION
  - 329164: Uninitialized map_comp fields in add_domains_to_pool_buf
  - 338605: Potential null pointer dereference in parse_entry
  - 338516: Resource leaks

Signed-off-by: Li Wei <wei.g.li@intel.com>