### PR TITLE
DAOS-8633 object: Resolve coverity and code style issues.

### DIFF
--- a/src/object/obj_verify.c
+++ b/src/object/obj_verify.c
@@ -650,6 +650,7 @@ dc_obj_verify_ec_cb(struct dss_enum_unpack_io *io, void *arg)
 	int				idx = 0;
 	int				rc;
 
+	D_ASSERT(obj != NULL);
 	D_DEBUG(DB_TRACE, "compare "DF_KEY" nr %d shard "DF_U64"\n", DP_KEY(&io->ui_dkey),
 		nr, shard);
 	if (nr == 0)
@@ -736,11 +737,9 @@ dc_obj_verify_ec_cb(struct dss_enum_unpack_io *io, void *arg)
 	}
 out:
 	for (i = 0; i < idx; i++) {
-		if (iovs[i].iov_buf)
-			D_FREE(iovs[i].iov_buf);
+		D_FREE(iovs[i].iov_buf);
 
-		if (iovs_verify[i].iov_buf)
-			D_FREE(iovs_verify[i].iov_buf);
+		D_FREE(iovs_verify[i].iov_buf);
 	}
 
 	return rc;

--- a/src/object/srv_ec_aggregate.c
+++ b/src/object/srv_ec_aggregate.c
@@ -303,7 +303,7 @@ agg_clear_extents(struct ec_agg_entry *entry)
 
 		d_list_del(&extent->ae_link);
 		entry->ae_cur_stripe.as_extent_cnt--;
-		D_FREE_PTR(extent);
+		D_FREE(extent);
 	}
 
 	entry->ae_cur_stripe.as_offset = 0U;
@@ -432,7 +432,6 @@ agg_prep_sgl(struct ec_agg_entry *entry)
 out:
 	d_sgl_fini(&entry->ae_sgl, true);
 	return rc;
-
 }
 
 /* Determines if an extent overlaps a cell.
@@ -589,10 +588,8 @@ agg_fetch_odata_cells(struct ec_agg_entry *entry, uint8_t *bit_map,
 		D_ERROR("dsc_obj_fetch failed: "DF_RC"\n", DP_RC(rc));
 
 out:
-	if (recxs)
-		D_FREE(recxs);
-	if (sgl.sg_iovs)
-		D_FREE(sgl.sg_iovs);
+	D_FREE(recxs);
+	D_FREE(sgl.sg_iovs);
 	return rc;
 }
 
@@ -704,7 +701,6 @@ ev_out:
 	ABT_eventual_free(&stripe_ud.asu_eventual);
 out:
 	return rc;
-
 }
 
 /* Driver function for full_stripe encode. Fetches the data and then invokes
@@ -908,10 +904,8 @@ agg_fetch_local_extents(struct ec_agg_entry *entry, uint8_t *bit_map,
 		D_ERROR("vos_obj_fetch failed: "DF_RC"\n", DP_RC(rc));
 
 out:
-	if (recxs != NULL)
-		D_FREE(recxs);
-	if (sgl.sg_iovs != NULL)
-		D_FREE(sgl.sg_iovs);
+	D_FREE(recxs);
+	D_FREE(sgl.sg_iovs);
 	return rc;
 }
 
@@ -1134,7 +1128,6 @@ agg_process_partial_stripe_ult(void *arg)
 
 out:
 	ABT_eventual_set(stripe_ud->asu_eventual, (void *)&rc, sizeof(rc));
-
 }
 
 /* Driver function for partial stripe update. Fetches the data and then invokes
@@ -1476,8 +1469,7 @@ agg_peer_update(struct ec_agg_entry *entry, bool write_parity)
 ev_out:
 	ABT_eventual_free(&stripe_ud.asu_eventual);
 out:
-	if (targets)
-		D_FREE(targets);
+	D_FREE(targets);
 	return rc;
 }
 
@@ -1500,7 +1492,7 @@ agg_process_holes_ult(void *arg)
 	crt_bulk_t		 bulk_hdl = NULL;
 	uint32_t		 len = ec_age2cs(entry);
 	uint64_t		 cell_b = ec_age2cs_b(entry);
-	uint32_t		 k = ec_age2k(entry);
+	uint64_t		 k = ec_age2k(entry);
 	uint32_t		 p = ec_age2p(entry);
 	uint64_t		 ss = entry->ae_cur_stripe.as_stripenum *
 					k * len;
@@ -1700,8 +1692,7 @@ fetch_again:
 	}
 
 out:
-	if (targets)
-		D_FREE(targets);
+	D_FREE(targets);
 	if (rpc)
 		crt_req_decref(rpc);
 	if (bulk_hdl)
@@ -1791,8 +1782,7 @@ ev_out:
 out:
 	D_FREE(stripe_ud.asu_recxs);
 	daos_csummer_free_ic(stripe_ud.asu_csummer, &stripe_ud.asu_iod_csums);
-	if (stripe_ud.asu_csum_iov.iov_buf)
-		D_FREE(stripe_ud.asu_csum_iov.iov_buf);
+	D_FREE(stripe_ud.asu_csum_iov.iov_buf);
 	daos_csummer_destroy(&stripe_ud.asu_csummer);
 	return rc;
 }

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -717,8 +717,7 @@ obj_echo_rw(crt_rpc_t *rpc, daos_iod_t *split_iods, uint64_t *split_offs)
 
 		/* Check each vector */
 		if (p_sgl->sg_iovs[i].iov_buf_len < size) {
-			if (p_sgl->sg_iovs[i].iov_buf != NULL)
-				D_FREE(p_sgl->sg_iovs[i].iov_buf);
+			D_FREE(p_sgl->sg_iovs[i].iov_buf);
 
 			D_ALLOC(p_sgl->sg_iovs[i].iov_buf, size);
 			/* obj_tls_fini() will free these buffer */
@@ -1542,7 +1541,6 @@ obj_local_rw_internal(crt_rpc_t *rpc, struct obj_io_context *ioc,
 				D_ERROR(DF_UOID" fetch verify failed: %d.\n",
 					DP_UOID(orw->orw_oid), rc);
 				goto post;
-
 			}
 		}
 	}
@@ -2195,6 +2193,7 @@ ds_obj_tgt_update_handler(crt_rpc_t *rpc)
 
 	if (DAOS_FAIL_CHECK(DAOS_VC_DIFF_DKEY)) {
 		unsigned char	*buf = dkey->iov_buf;
+
 		buf[0] += orw->orw_oid.id_shard + 1;
 		orw->orw_dkey_hash = obj_dkey2hash(orw->orw_oid.id_pub, dkey);
 	}
@@ -2312,7 +2311,7 @@ obj_tgt_update(struct dtx_leader_handle *dlh, void *arg, int idx,
 			D_GOTO(comp, rc = -DER_IO);
 
 		/* No need re-exec local update */
-		if (dlh != NULL && dlh->dlh_handle.dth_prepared)
+		if (dlh->dlh_handle.dth_prepared)
 			goto comp;
 
 		/* XXX: For non-solo DTX, leader and non-leader will make each
@@ -2986,7 +2985,6 @@ obj_enum_reply_bulk(crt_rpc_t *rpc)
 			       DAOS_HDL_INVAL, sgls, idx, NULL);
 	if (oei->oei_kds_bulk) {
 		D_FREE(oeo->oeo_kds.ca_arrays);
-		oeo->oeo_kds.ca_arrays = NULL;
 		oeo->oeo_kds.ca_count = 0;
 	}
 
@@ -3359,7 +3357,7 @@ obj_tgt_punch(struct dtx_leader_handle *dlh, void *arg, int idx,
 		if (DAOS_FAIL_CHECK(DAOS_DTX_LEADER_ERROR))
 			D_GOTO(comp, rc = -DER_IO);
 
-		if (dlh != NULL && dlh->dlh_handle.dth_prepared)
+		if (dlh->dlh_handle.dth_prepared)
 			goto comp;
 
 		rc = obj_local_punch(opi, opc_get(rpc->cr_opc), exec_arg->ioc,
@@ -4162,7 +4160,6 @@ out:
 				if (biods[i] != NULL)
 					bio_iod_post(biods[i]);
 			}
-
 		}
 
 		if (iohs != NULL) {


### PR DESCRIPTION
338866 and 332771.  Use assert to check for error state
331452 Promote a stack variable to 64 bit.
332885 and 332887.  Assume that dlh cannot be NULL.

Apply a number of automatic checkpatch corrections, and replace
the use of D_FREE_PTR with D_FREE

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>
