### PR TITLE
DAOS-8628 dfuse: Resolve issues identified by coverity

### DIFF
--- a/src/client/dfs/dfs.c
+++ b/src/client/dfs/dfs.c
@@ -1451,11 +1451,11 @@ err_prop:
 int
 dfs_cont_create(daos_handle_t poh, uuid_t *cuuid, dfs_attr_t *attr, daos_handle_t *coh, dfs_t **dfs)
 {
-	const unsigned char     *uuid = (const unsigned char *) cuuid;
+	const unsigned char     *uuid = (const unsigned char *)cuuid;
 	uuid_t			co_uuid;
 
 	if (!daos_uuid_valid(uuid))
-		return -DER_INVAL;
+		return EINVAL;
 
 	uuid_copy(co_uuid, uuid);
 	return dfs_cont_create_int(poh, cuuid, true, co_uuid, attr, coh, dfs);

--- a/src/client/dfuse/dfuse_cont.c
+++ b/src/client/dfuse/dfuse_cont.c
@@ -117,7 +117,6 @@ dfuse_cont_helper(fuse_req_t req, struct dfuse_inode_entry *parent,
 
 	ie->ie_parent = parent->ie_stat.st_ino;
 	strncpy(ie->ie_name, name, NAME_MAX);
-	ie->ie_name[NAME_MAX] = '\0';
 
 	atomic_store_relaxed(&ie->ie_ref, 1);
 	ie->ie_dfs = dfc;

--- a/src/client/dfuse/dfuse_core.c
+++ b/src/client/dfuse/dfuse_core.c
@@ -977,7 +977,7 @@ dfuse_fs_init(struct dfuse_info *dfuse_info,
 
 	rc = sem_init(&fs_handle->dpi_sem, 0, 0);
 	if (rc != 0)
-		D_GOTO(err_eq, 0);
+		D_GOTO(err_eq, rc = daos_errno2der(errno));
 
 	fs_handle->dpi_shutdown = false;
 	*_fsh = fs_handle;

--- a/src/client/dfuse/dfuse_pool.c
+++ b/src/client/dfuse/dfuse_pool.c
@@ -90,7 +90,6 @@ dfuse_pool_lookup(fuse_req_t req, struct dfuse_inode_entry *parent,
 
 	ie->ie_parent = parent->ie_stat.st_ino;
 	strncpy(ie->ie_name, name, NAME_MAX);
-	ie->ie_name[NAME_MAX] = '\0';
 
 	atomic_store_relaxed(&ie->ie_ref, 1);
 	ie->ie_dfs = dfc;

--- a/src/client/dfuse/dfuse_thread.c
+++ b/src/client/dfuse/dfuse_thread.c
@@ -128,10 +128,10 @@ dfuse_loop(struct dfuse_info *dfuse_info)
 
 	rc = sem_init(&dtm->tm_finish, 0, 0);
 	if (rc != 0)
-		D_GOTO(out, rc);
+		D_GOTO(out, errno);
 	rc = D_MUTEX_INIT(&dtm->tm_lock, NULL);
 	if (rc != 0)
-		D_GOTO(out_sem, rc);
+		D_GOTO(out_sem, daos_der2errno(rc));
 
 	D_MUTEX_LOCK(&dtm->tm_lock);
 	for (i = 0 ; i < dfuse_info->di_thread_count ; i++) {

--- a/src/client/dfuse/ops/create.c
+++ b/src/client/dfuse/ops/create.c
@@ -101,7 +101,6 @@ dfuse_cb_create(fuse_req_t req, struct dfuse_inode_entry *parent,
 	fi_out.fh = (uint64_t)oh;
 
 	strncpy(ie->ie_name, name, NAME_MAX);
-	ie->ie_name[NAME_MAX] = '\0';
 	ie->ie_parent = parent->ie_stat.st_ino;
 	ie->ie_truncated = false;
 	atomic_store_relaxed(&ie->ie_ref, 1);

--- a/src/client/dfuse/ops/lookup.c
+++ b/src/client/dfuse/ops/lookup.c
@@ -112,7 +112,7 @@ dfuse_reply_entry(struct dfuse_projection_info *fs_handle,
 			wipe_name[NAME_MAX] = '\0';
 
 			inode->ie_parent = ie->ie_parent;
-			strncpy(inode->ie_name, ie->ie_name, NAME_MAX);
+			strncpy(inode->ie_name, ie->ie_name, NAME_MAX + 1);
 		}
 		atomic_fetch_sub_relaxed(&ie->ie_ref, 1);
 		dfuse_ie_close(fs_handle, ie);

--- a/src/client/dfuse/ops/lookup.c
+++ b/src/client/dfuse/ops/lookup.c
@@ -100,7 +100,7 @@ dfuse_reply_entry(struct dfuse_projection_info *fs_handle,
 		if (ie->ie_stat.st_ino == ie->ie_dfs->dfs_ino) {
 			DFUSE_TRA_DEBUG(inode, "Not updating parent");
 		} else if ((inode->ie_parent != ie->ie_parent) ||
-			(strncmp(inode->ie_name, ie->ie_name, NAME_MAX + 1) != 0)) {
+			(strncmp(inode->ie_name, ie->ie_name, NAME_MAX) != 0)) {
 			DFUSE_TRA_DEBUG(inode, "File has moved from '%s to '%s'",
 					inode->ie_name, ie->ie_name);
 
@@ -108,10 +108,11 @@ dfuse_reply_entry(struct dfuse_projection_info *fs_handle,
 
 			/* Save the old name so that we can invalidate it in later */
 			wipe_parent = inode->ie_parent;
-			strncpy(wipe_name, inode->ie_name, NAME_MAX + 1);
+			strncpy(wipe_name, inode->ie_name, NAME_MAX);
+			wipe_name[NAME_MAX] = '\0';
 
 			inode->ie_parent = ie->ie_parent;
-			strncpy(inode->ie_name, ie->ie_name, NAME_MAX + 1);
+			strncpy(inode->ie_name, ie->ie_name, NAME_MAX);
 		}
 		atomic_fetch_sub_relaxed(&ie->ie_ref, 1);
 		dfuse_ie_close(fs_handle, ie);
@@ -249,7 +250,6 @@ dfuse_cb_lookup(fuse_req_t req, struct dfuse_inode_entry *parent,
 	DFUSE_TRA_DEBUG(ie, "Attr len is %zi", attr_len);
 
 	strncpy(ie->ie_name, name, NAME_MAX);
-	ie->ie_name[NAME_MAX] = '\0';
 	atomic_store_relaxed(&ie->ie_ref, 1);
 
 	dfs_obj2id(ie->ie_obj, &ie->ie_oid);

--- a/src/client/dfuse/ops/mknod.c
+++ b/src/client/dfuse/ops/mknod.c
@@ -33,7 +33,6 @@ dfuse_cb_mknod(fuse_req_t req, struct dfuse_inode_entry *parent,
 		D_GOTO(err, rc);
 
 	strncpy(ie->ie_name, name, NAME_MAX);
-	ie->ie_name[NAME_MAX] = '\0';
 	ie->ie_parent = parent->ie_stat.st_ino;
 	ie->ie_dfs = parent->ie_dfs;
 	ie->ie_truncated = false;

--- a/src/client/dfuse/ops/readdir.c
+++ b/src/client/dfuse/ops/readdir.c
@@ -134,7 +134,7 @@ create_entry(struct dfuse_projection_info *fs_handle,
 	entry->generation = 1;
 	entry->ino = entry->attr.st_ino;
 
-	strncpy(ie->ie_name, name, NAME_MAX);
+	strncpy(ie->ie_name, name, NAME_MAX + 1);
 	atomic_store_relaxed(&ie->ie_ref, 1);
 
 	DFUSE_TRA_DEBUG(ie, "Inserting inode %#lx mode 0%o",
@@ -175,7 +175,7 @@ create_entry(struct dfuse_projection_info *fs_handle,
 						rc);
 		}
 		inode->ie_parent = ie->ie_parent;
-		strncpy(inode->ie_name, ie->ie_name, NAME_MAX);
+		strncpy(inode->ie_name, ie->ie_name, NAME_MAX + 1);
 
 		atomic_fetch_sub_relaxed(&ie->ie_ref, 1);
 		dfuse_ie_close(fs_handle, ie);

--- a/src/client/dfuse/ops/readdir.c
+++ b/src/client/dfuse/ops/readdir.c
@@ -135,7 +135,6 @@ create_entry(struct dfuse_projection_info *fs_handle,
 	entry->ino = entry->attr.st_ino;
 
 	strncpy(ie->ie_name, name, NAME_MAX);
-	ie->ie_name[NAME_MAX] = '\0';
 	atomic_store_relaxed(&ie->ie_ref, 1);
 
 	DFUSE_TRA_DEBUG(ie, "Inserting inode %#lx mode 0%o",
@@ -176,7 +175,7 @@ create_entry(struct dfuse_projection_info *fs_handle,
 						rc);
 		}
 		inode->ie_parent = ie->ie_parent;
-		strncpy(inode->ie_name, ie->ie_name, NAME_MAX + 1);
+		strncpy(inode->ie_name, ie->ie_name, NAME_MAX);
 
 		atomic_fetch_sub_relaxed(&ie->ie_ref, 1);
 		dfuse_ie_close(fs_handle, ie);

--- a/src/client/dfuse/ops/readdir.c
+++ b/src/client/dfuse/ops/readdir.c
@@ -134,7 +134,8 @@ create_entry(struct dfuse_projection_info *fs_handle,
 	entry->generation = 1;
 	entry->ino = entry->attr.st_ino;
 
-	strncpy(ie->ie_name, name, NAME_MAX + 1);
+	strncpy(ie->ie_name, name, NAME_MAX);
+	ie->ie_name[NAME_MAX] = '\0';
 	atomic_store_relaxed(&ie->ie_ref, 1);
 
 	DFUSE_TRA_DEBUG(ie, "Inserting inode %#lx mode 0%o",

--- a/src/client/dfuse/ops/rename.c
+++ b/src/client/dfuse/ops/rename.c
@@ -36,7 +36,7 @@ dfuse_oid_moved(struct dfuse_projection_info *fs_handle, daos_obj_id_t *oid,
 
 	/* If the move is not from where we thought the file was then invalidate the old entry */
 	if ((ie->ie_parent != parent->ie_stat.st_ino) ||
-		(strncmp(ie->ie_name, name, NAME_MAX + 1) != 0)) {
+		(strncmp(ie->ie_name, name, NAME_MAX) != 0)) {
 		DFUSE_TRA_DEBUG(ie, "Invalidating old name");
 
 		rc = fuse_lowlevel_notify_inval_entry(fs_handle->dpi_info->di_session,

--- a/src/client/dfuse/ops/symlink.c
+++ b/src/client/dfuse/ops/symlink.c
@@ -31,7 +31,6 @@ dfuse_cb_symlink(fuse_req_t req, const char *link,
 	DFUSE_TRA_INFO(ie, "obj is %p", ie->ie_obj);
 
 	strncpy(ie->ie_name, name, NAME_MAX);
-	ie->ie_name[NAME_MAX] = '\0';
 	ie->ie_parent = parent->ie_stat.st_ino;
 	ie->ie_dfs = parent->ie_dfs;
 	atomic_store_relaxed(&ie->ie_ref, 1);

--- a/src/client/dfuse/ops/unlink.c
+++ b/src/client/dfuse/ops/unlink.c
@@ -54,7 +54,7 @@ dfuse_oid_unlinked(struct dfuse_projection_info *fs_handle, fuse_req_t req, daos
 	 * for cases where the kernel knows which file it deleted.
 	 */
 	if ((ie->ie_parent != parent->ie_stat.st_ino) ||
-		(strncmp(ie->ie_name, name, NAME_MAX + 1) != 0)) {
+		(strncmp(ie->ie_name, name, NAME_MAX) != 0)) {
 		DFUSE_TRA_DEBUG(ie, "Telling kernel to forget %#lx.'%s'",
 				ie->ie_parent, ie->ie_name);
 


### PR DESCRIPTION
Correctly handle errors from sem_init()
dfs_cont_create() needs to return system error code.
Correctly terminate strings after copy.

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>
