### PR TITLE
DAOS-XXX vos: Invalidate the cached ilog info in iterator when probing

### DIFF
--- a/src/vos/ilog.c
+++ b/src/vos/ilog.c
@@ -1068,6 +1068,15 @@ ilog_fetch_init(struct ilog_entries *entries)
 }
 
 void
+ilog_fetch_invalidate(struct ilog_entries *entries)
+{
+	struct ilog_priv	*priv = ilog_ent2priv(entries);
+
+	/** Make sure we don't happen to get same address on subsequent check */
+	priv->ip_lctx.ic_root = NULL;
+}
+
+void
 ilog_fetch_move(struct ilog_entries *dest, struct ilog_entries *src)
 {
 	struct ilog_priv	*priv_dest = ilog_ent2priv(dest);

--- a/src/vos/ilog.h
+++ b/src/vos/ilog.h
@@ -215,6 +215,13 @@ ilog_aggregate(struct umem_instance *umm, struct ilog_df *root,
 void
 ilog_fetch_init(struct ilog_entries *entries);
 
+/** Invalidate the ilog_entries struct for fetch
+ *
+ *  \param	entries[in]	Allocated structure where entries are stored
+ */
+void
+ilog_fetch_invalidate(struct ilog_entries *entries);
+
 /** Assuming src has already been copied to dest, just fix up internal pointers
  *  and reset src
  *

--- a/src/vos/vos_ilog.c
+++ b/src/vos/vos_ilog.c
@@ -544,6 +544,13 @@ vos_ilog_fetch_init(struct vos_ilog_info *info)
 }
 
 void
+vos_ilog_fetch_invalidate(struct vos_ilog_info *info)
+{
+	ilog_fetch_invalidate(&info->ii_entries);
+}
+
+
+void
 vos_ilog_fetch_move(struct vos_ilog_info *dest, struct vos_ilog_info *src)
 {
 	memcpy(dest, src, sizeof(*dest));

--- a/src/vos/vos_ilog.h
+++ b/src/vos/vos_ilog.h
@@ -74,6 +74,10 @@ vos_ilog_init(void);
 void
 vos_ilog_fetch_init(struct vos_ilog_info *info);
 
+/** Invalidate incarnation log information */
+void
+vos_ilog_fetch_invalidate(struct vos_ilog_info *info);
+
 /** Move ilog information from src to dest, clearing src */
 void
 vos_ilog_fetch_move(struct vos_ilog_info *dest, struct vos_ilog_info *src);

--- a/src/vos/vos_obj.c
+++ b/src/vos/vos_obj.c
@@ -864,6 +864,7 @@ key_iter_probe(struct vos_obj_iter *oiter, daos_anchor_t *anchor)
 	if (rc)
 		D_GOTO(out, rc);
 
+	vos_ilog_fetch_invalidate(&oiter->it_ilog_info);
 	rc = key_iter_match_probe(oiter);
 	if (rc)
 		D_GOTO(out, rc);

--- a/src/vos/vos_obj_index.c
+++ b/src/vos/vos_obj_index.c
@@ -556,6 +556,7 @@ oi_iter_probe(struct vos_iterator *iter, daos_anchor_t *anchor)
 	/* NB: these probe cannot guarantee the returned entry is within
 	 * the condition epoch range.
 	 */
+	vos_ilog_fetch_invalidate(&oiter->oit_ilog_info);
 	rc = oi_iter_match_probe(iter);
  out:
 	return rc;


### PR DESCRIPTION
Avoid any possibility of same address being used for different ilog

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>