### PR TITLE
DAOS-8637 coverity: Fix coverity issues reported on VOS

### DIFF
--- a/src/vos/ilog.c
+++ b/src/vos/ilog.c
@@ -1240,8 +1240,6 @@ ilog_fetch(struct umem_instance *umm, struct ilog_df *root_df,
 		if (status != -DER_INPROGRESS && status < 0)
 			D_GOTO(fail, rc = status);
 		set_entry(entries, i, status);
-		if (rc != 0)
-			goto fail;
 	}
 
 out:

--- a/src/vos/vos_obj.c
+++ b/src/vos/vos_obj.c
@@ -473,6 +473,7 @@ vos_obj_delete(daos_handle_t coh, daos_unit_oid_t oid)
 
 	rc = umem_tx_end(umm, rc);
 
+out:
 	vos_obj_release(occ, obj, true);
 	return rc;
 }

--- a/src/vos/vos_obj.c
+++ b/src/vos/vos_obj.c
@@ -472,9 +472,7 @@ vos_obj_delete(daos_handle_t coh, daos_unit_oid_t oid)
 		D_ERROR("Failed to delete object: %s\n", d_errstr(rc));
 
 	rc = umem_tx_end(umm, rc);
-	if (rc)
-		goto out;
-out:
+
 	vos_obj_release(occ, obj, true);
 	return rc;
 }


### PR DESCRIPTION
332770 - rc check is never true in ilog.c
329605 - goto has no effect in vos_obj.c

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>