### PR TITLE
DAOS-8559 vos: Ensure aggregation not running with obj discard

### DIFF
--- a/src/include/daos/dtx.h
+++ b/src/include/daos/dtx.h
@@ -183,6 +183,7 @@ enum daos_ops_intent {
 	DAOS_INTENT_CHECK		= 5, /* check aborted or not */
 	DAOS_INTENT_KILL		= 6, /* delete object/key */
 	DAOS_INTENT_IGNORE_NONCOMMITTED	= 7, /* ignore non-committed DTX. */
+	DAOS_INTENT_DISCARD		= 8, /* discard data */
 };
 
 /**

--- a/src/include/daos_srv/evtree.h
+++ b/src/include/daos_srv/evtree.h
@@ -665,8 +665,10 @@ enum {
 	EVT_ITER_FOR_PURGE	= (1 << 5),
 	/** The iterator is for data migration scan */
 	EVT_ITER_FOR_MIGRATION	= (1 << 6),
+	/** The iterator is for data discard */
+	EVT_ITER_FOR_DISCARD	= (1 << 7),
 	/** Skip visible data (Only valid with EVT_ITER_VISIBLE) */
-	EVT_ITER_SKIP_DATA	= (1 << 7),
+	EVT_ITER_SKIP_DATA	= (1 << 8),
 };
 
 D_CASSERT((int)EVT_VISIBLE == (int)EVT_ITER_VISIBLE);

--- a/src/include/daos_srv/vos_types.h
+++ b/src/include/daos_srv/vos_types.h
@@ -326,8 +326,10 @@ enum {
 	VOS_IT_PUNCHED		= (1 << 6),
 	/** Cleanup stale DTX entry. */
 	VOS_IT_CLEANUP_DTX	= (1 << 7),
+	/** Cleanup stale DTX entry. */
+	VOS_IT_FOR_DISCARD	= (1 << 8),
 	/** Mask for all flags */
-	VOS_IT_MASK		= (1 << 8) - 1,
+	VOS_IT_MASK		= (1 << 9) - 1,
 };
 
 /**

--- a/src/vos/evt_iter.c
+++ b/src/vos/evt_iter.c
@@ -192,6 +192,8 @@ evt_iter_intent(struct evt_iterator *iter)
 {
 	if (iter->it_options & EVT_ITER_FOR_PURGE)
 		return DAOS_INTENT_PURGE;
+	if (iter->it_options & EVT_ITER_FOR_DISCARD)
+		return DAOS_INTENT_DISCARD;
 	if (iter->it_options & EVT_ITER_FOR_MIGRATION)
 		return DAOS_INTENT_MIGRATION;
 	return DAOS_INTENT_DEFAULT;

--- a/src/vos/ilog.h
+++ b/src/vos/ilog.h
@@ -193,6 +193,8 @@ struct ilog_entries {
  *				that are provably not needed.  If discard is
  *				set, it will remove everything in the epoch
  *				range.
+ *  \param	inprogress[in]	If discarding, leave committed entries alone.
+ *				Remove only uncommitted entries.
  *  \param	punch_major[in]	Max major epoch punch of parent incarnation log
  *  \param	punch_major[in]	Max minor epoch punch of parent incarnation log
  *  \param	entries[in]	Used for efficiency since aggregation is used
@@ -205,7 +207,7 @@ struct ilog_entries {
 int
 ilog_aggregate(struct umem_instance *umm, struct ilog_df *root,
 	       const struct ilog_desc_cbs *cbs, const daos_epoch_range_t *epr,
-	       bool discard, daos_epoch_t punch_major, uint16_t punch_minor,
+	       bool discard, bool inprogress, daos_epoch_t punch_major, uint16_t punch_minor,
 	       struct ilog_entries *entries);
 
 /** Initialize an ilog_entries struct for fetch

--- a/src/vos/tests/vts_ilog.c
+++ b/src/vos/tests/vts_ilog.c
@@ -868,7 +868,7 @@ ilog_test_aggregate(void **state)
 	commit_all();
 	epr.epr_lo = 2;
 	epr.epr_hi = 4;
-	rc = ilog_aggregate(umm, ilog, &ilog_callbacks, &epr, false, 0, 0,
+	rc = ilog_aggregate(umm, ilog, &ilog_callbacks, &epr, false, false, 0, 0,
 			    &ilents);
 	LOG_FAIL(rc, 0, "Failed to aggregate ilog\n");
 	version_cache_fetch(&version_cache, loh, true);
@@ -892,7 +892,7 @@ ilog_test_aggregate(void **state)
 
 	epr.epr_lo = 0;
 	epr.epr_hi = 6;
-	rc = ilog_aggregate(umm, ilog, &ilog_callbacks, &epr, false, 0, 0,
+	rc = ilog_aggregate(umm, ilog, &ilog_callbacks, &epr, false, false, 0, 0,
 			    &ilents);
 	LOG_FAIL(rc, 0, "Failed to aggregate ilog\n");
 	version_cache_fetch(&version_cache, loh, true);
@@ -907,7 +907,7 @@ ilog_test_aggregate(void **state)
 	version_cache_fetch(&version_cache, loh, true);
 	commit_all();
 	epr.epr_hi = 7;
-	rc = ilog_aggregate(umm, ilog, &ilog_callbacks, &epr, false, 0, 0,
+	rc = ilog_aggregate(umm, ilog, &ilog_callbacks, &epr, false, false, 0, 0,
 			    &ilents);
 	/* 1 means empty */
 	LOG_FAIL(rc, 1, "Failed to aggregate log entry\n");
@@ -984,7 +984,7 @@ ilog_test_discard(void **state)
 	commit_all();
 	epr.epr_lo = 2;
 	epr.epr_hi = 4;
-	rc = ilog_aggregate(umm, ilog, &ilog_callbacks, &epr, true, 0, 0,
+	rc = ilog_aggregate(umm, ilog, &ilog_callbacks, &epr, true, false, 0, 0,
 			    &ilents);
 	LOG_FAIL(rc, 0, "Failed to aggregate ilog\n");
 	version_cache_fetch(&version_cache, loh, true);
@@ -1007,7 +1007,7 @@ ilog_test_discard(void **state)
 	commit_all();
 	epr.epr_lo = 0;
 	epr.epr_hi = 6;
-	rc = ilog_aggregate(umm, ilog, &ilog_callbacks, &epr, true, 0, 0,
+	rc = ilog_aggregate(umm, ilog, &ilog_callbacks, &epr, true, false, 0, 0,
 			    &ilents);
 	/* 1 means empty */
 	LOG_FAIL(rc, 1, "Failed to aggregate ilog\n");
@@ -1025,7 +1025,7 @@ ilog_test_discard(void **state)
 	commit_all();
 
 	epr.epr_hi = 7;
-	rc = ilog_aggregate(umm, ilog, &ilog_callbacks, &epr, true, 0, 0,
+	rc = ilog_aggregate(umm, ilog, &ilog_callbacks, &epr, true, false, 0, 0,
 			    &ilents);
 	/* 1 means empty */
 	LOG_FAIL(rc, 1, "Failed to aggregate ilog\n");

--- a/src/vos/vos_aggregate.c
+++ b/src/vos/vos_aggregate.c
@@ -2158,9 +2158,7 @@ vos_aggregate_post_cb(daos_handle_t ih, vos_iter_entry_t *entry,
 			agg_param->ap_skip_obj = false;
 			break;
 		}
-		if (agg_param->ap_discard_obj)
-			return 0;
-		rc = oi_iter_aggregate(ih, agg_param->ap_discard);
+		rc = oi_iter_aggregate(ih, agg_param->ap_discard_obj);
 		break;
 	case VOS_ITER_DKEY:
 		if (agg_param->ap_skip_dkey) {
@@ -2172,9 +2170,7 @@ vos_aggregate_post_cb(daos_handle_t ih, vos_iter_entry_t *entry,
 			agg_param->ap_skip_akey = false;
 			break;
 		}
-		if (agg_param->ap_discard_obj)
-			return 0;
-		rc = vos_obj_iter_aggregate(ih, agg_param->ap_discard);
+		rc = vos_obj_iter_aggregate(ih, agg_param->ap_discard_obj);
 		break;
 	case VOS_ITER_SINGLE:
 		return 0;

--- a/src/vos/vos_aggregate.c
+++ b/src/vos/vos_aggregate.c
@@ -2503,7 +2503,7 @@ vos_discard(daos_handle_t coh, daos_unit_oid_t *oidp, daos_epoch_range_t *epr,
 	ad->ad_agg_param.ap_yield_func = yield_func;
 	ad->ad_agg_param.ap_yield_arg = yield_arg;
 
-	ad->ad_iter_param.ip_flags |= VOS_IT_FOR_PURGE;
+	ad->ad_iter_param.ip_flags |= VOS_IT_FOR_DISCARD;
 	rc = vos_iterate(&ad->ad_iter_param, type, true, &ad->ad_anchors,
 			 vos_aggregate_pre_cb, vos_aggregate_post_cb,
 			 &ad->ad_agg_param, NULL);

--- a/src/vos/vos_aggregate.c
+++ b/src/vos/vos_aggregate.c
@@ -2220,19 +2220,36 @@ vos_aggregate_post_cb(daos_handle_t ih, vos_iter_entry_t *entry,
 	return rc;
 }
 
+enum {
+	AGG_MODE_AGGREGATE,
+	AGG_MODE_DISCARD,
+	AGG_MODE_OBJ_DISCARD,
+};
+
 static int
-aggregate_enter(struct vos_container *cont, bool discard,
+aggregate_enter(struct vos_container *cont, int agg_mode,
 		daos_epoch_range_t *epr)
 {
-	if (discard) {
+	switch (agg_mode) {
+	default:
+		D_ASSERT(0);
+		break;
+	case AGG_MODE_DISCARD:
 		if (cont->vc_in_discard) {
-			D_ERROR(DF_CONT": Already in discard\n",
-				DP_CONT(cont->vc_pool->vp_id, cont->vc_id));
+			D_ERROR(DF_CONT": Already in discard epr["DF_U64", "DF_U64"]\n",
+				DP_CONT(cont->vc_pool->vp_id, cont->vc_id),
+				cont->vc_epr_discard.epr_lo, cont->vc_epr_discard.epr_hi);
 			return -DER_BUSY;
 		}
 
-		if (cont->vc_in_aggregation &&
-		    cont->vc_epr_aggregation.epr_hi >= epr->epr_lo) {
+		if (cont->vc_in_obj_discard) {
+			D_ERROR(DF_CONT": In object discard epr["DF_U64", "DF_U64"]\n",
+				DP_CONT(cont->vc_pool->vp_id, cont->vc_id),
+				cont->vc_epr_discard.epr_lo, cont->vc_epr_discard.epr_hi);
+			return -DER_BUSY;
+		}
+
+		if (cont->vc_in_aggregation && cont->vc_epr_aggregation.epr_hi >= epr->epr_lo) {
 			D_ERROR(DF_CONT": Aggregate epr["DF_U64", "DF_U64"], "
 				"discard epr["DF_U64", "DF_U64"]\n",
 				DP_CONT(cont->vc_pool->vp_id, cont->vc_id),
@@ -2244,10 +2261,19 @@ aggregate_enter(struct vos_container *cont, bool discard,
 
 		cont->vc_in_discard = 1;
 		cont->vc_epr_discard = *epr;
-	} else {
+		break;
+	case AGG_MODE_AGGREGATE:
 		if (cont->vc_in_aggregation) {
-			D_ERROR(DF_CONT": Already in aggregation\n",
-				DP_CONT(cont->vc_pool->vp_id, cont->vc_id));
+			D_ERROR(DF_CONT": Already in aggregation epr["DF_U64", "DF_U64"]\n",
+				DP_CONT(cont->vc_pool->vp_id, cont->vc_id),
+				cont->vc_epr_aggregation.epr_lo, cont->vc_epr_aggregation.epr_hi);
+			return -DER_BUSY;
+		}
+
+		if (cont->vc_in_obj_discard) {
+			D_ERROR(DF_CONT": In object discard epr["DF_U64", "DF_U64"]\n",
+				DP_CONT(cont->vc_pool->vp_id, cont->vc_id),
+				cont->vc_epr_discard.epr_lo, cont->vc_epr_discard.epr_hi);
 			return -DER_BUSY;
 		}
 
@@ -2264,24 +2290,62 @@ aggregate_enter(struct vos_container *cont, bool discard,
 
 		cont->vc_in_aggregation = 1;
 		cont->vc_epr_aggregation = *epr;
+		break;
+	case AGG_MODE_OBJ_DISCARD:
+		if (cont->vc_in_obj_discard) {
+			D_ERROR(DF_CONT": Already in object discard epr["DF_U64", "DF_U64"]\n",
+				DP_CONT(cont->vc_pool->vp_id, cont->vc_id),
+				cont->vc_epr_discard.epr_lo, cont->vc_epr_discard.epr_hi);
+			return -DER_BUSY;
+		}
+
+		if (cont->vc_in_discard) {
+			D_ERROR(DF_CONT": In discard epr["DF_U64", "DF_U64"]\n",
+				DP_CONT(cont->vc_pool->vp_id, cont->vc_id),
+				cont->vc_epr_discard.epr_lo, cont->vc_epr_discard.epr_hi);
+			return -DER_BUSY;
+		}
+
+		if (cont->vc_in_aggregation) {
+			D_ERROR(DF_CONT": In aggregation epr["DF_U64", "DF_U64"]\n",
+				DP_CONT(cont->vc_pool->vp_id, cont->vc_id),
+				cont->vc_epr_aggregation.epr_lo, cont->vc_epr_aggregation.epr_hi);
+			return -DER_BUSY;
+		}
+
+		cont->vc_in_obj_discard = 1;
+		cont->vc_epr_discard = *epr;
+		break;
 	}
 
 	return 0;
 }
 
 static void
-aggregate_exit(struct vos_container *cont, bool discard)
+aggregate_exit(struct vos_container *cont, int agg_mode)
 {
-	if (discard) {
+	switch (agg_mode) {
+	default:
+		D_ASSERT(0);
+		break;
+	case AGG_MODE_DISCARD:
 		D_ASSERT(cont->vc_in_discard);
 		cont->vc_in_discard = 0;
 		cont->vc_epr_discard.epr_lo = 0;
 		cont->vc_epr_discard.epr_hi = 0;
-	} else {
+		break;
+	case AGG_MODE_AGGREGATE:
 		D_ASSERT(cont->vc_in_aggregation);
 		cont->vc_in_aggregation = 0;
 		cont->vc_epr_aggregation.epr_lo = 0;
 		cont->vc_epr_aggregation.epr_hi = 0;
+		break;
+	case AGG_MODE_OBJ_DISCARD:
+		D_ASSERT(cont->vc_in_obj_discard);
+		cont->vc_in_obj_discard = 0;
+		cont->vc_epr_discard.epr_lo = 0;
+		cont->vc_epr_discard.epr_hi = 0;
+		break;
 	}
 }
 
@@ -2321,7 +2385,7 @@ vos_aggregate(daos_handle_t coh, daos_epoch_range_t *epr,
 	if (ad == NULL)
 		return -DER_NOMEM;
 
-	rc = aggregate_enter(cont, false, epr);
+	rc = aggregate_enter(cont, AGG_MODE_AGGREGATE, epr);
 	if (rc)
 		goto free_agg_data;
 
@@ -2369,7 +2433,7 @@ vos_aggregate(daos_handle_t coh, daos_epoch_range_t *epr,
 	if (cont->vc_cont_df->cd_hae < epr->epr_hi)
 		cont->vc_cont_df->cd_hae = epr->epr_hi;
 exit:
-	aggregate_exit(cont, false);
+	aggregate_exit(cont, AGG_MODE_AGGREGATE);
 
 	if (ad->ad_agg_param.ap_window.mw_csum_support)
 		D_FREE(ad->ad_agg_param.ap_window.mw_io_ctxt.ic_csum_buf);
@@ -2391,6 +2455,7 @@ vos_discard(daos_handle_t coh, daos_unit_oid_t *oidp, daos_epoch_range_t *epr,
 	struct agg_data		*ad;
 	int			 type = VOS_ITER_OBJ;
 	int			 rc;
+	int			 mode = oidp == NULL ? AGG_MODE_DISCARD : AGG_MODE_OBJ_DISCARD;
 
 	D_ASSERT(epr != NULL);
 	D_ASSERTF(epr->epr_lo <= epr->epr_hi,
@@ -2401,7 +2466,7 @@ vos_discard(daos_handle_t coh, daos_unit_oid_t *oidp, daos_epoch_range_t *epr,
 	if (ad == NULL)
 		return -DER_NOMEM;
 
-	rc = aggregate_enter(cont, true, epr);
+	rc = aggregate_enter(cont, mode, epr);
 	if (rc != 0)
 		goto free_agg_data;
 
@@ -2443,7 +2508,7 @@ vos_discard(daos_handle_t coh, daos_unit_oid_t *oidp, daos_epoch_range_t *epr,
 			 vos_aggregate_pre_cb, vos_aggregate_post_cb,
 			 &ad->ad_agg_param, NULL);
 
-	aggregate_exit(cont, true);
+	aggregate_exit(cont, mode);
 
 free_agg_data:
 	D_FREE(ad);

--- a/src/vos/vos_aggregate.c
+++ b/src/vos/vos_aggregate.c
@@ -216,6 +216,10 @@ need_aggregate(struct vos_agg_param *agg_param, vos_iter_entry_t *entry)
 		cont->vc_cont_df->cd_hae, entry->ie_last_update,
 		entry->ie_vis_flags);
 
+	/** Don't skip for discard */
+	if (agg_param->ap_discard_obj || agg_param->ap_discard)
+		return true;
+
 	/* Don't skip aggregation for full scan */
 	if (agg_param->ap_full_scan)
 		return true;

--- a/src/vos/vos_aggregate.c
+++ b/src/vos/vos_aggregate.c
@@ -211,14 +211,14 @@ need_aggregate(struct vos_agg_param *agg_param, vos_iter_entry_t *entry)
 {
 	struct vos_container	*cont = vos_hdl2cont(agg_param->ap_coh);
 
+	/** Skip this check for discard */
+	if (agg_param->ap_discard_obj || agg_param->ap_discard)
+		return true;
+
 	D_DEBUG(DB_EPC, "full_scan:%d, hae:"DF_U64", last_update:"DF_U64", "
 		"flags:%u\n", agg_param->ap_full_scan,
 		cont->vc_cont_df->cd_hae, entry->ie_last_update,
 		entry->ie_vis_flags);
-
-	/** Don't skip for discard */
-	if (agg_param->ap_discard_obj || agg_param->ap_discard)
-		return true;
 
 	/* Don't skip aggregation for full scan */
 	if (agg_param->ap_full_scan)

--- a/src/vos/vos_dtx.c
+++ b/src/vos/vos_dtx.c
@@ -1233,8 +1233,8 @@ vos_dtx_check_availability(daos_handle_t coh, uint32_t entry,
 		return ALB_AVAILABLE_CLEAN;
 	}
 
-	/* Committed */
-	if (entry == DTX_LID_COMMITTED)
+	/* Committed -or- being discarded */
+	if (entry == DTX_LID_COMMITTED || intent == DAOS_INTENT_DISCARD)
 		return ALB_AVAILABLE_CLEAN;
 
 	/* Aborted */

--- a/src/vos/vos_ilog.c
+++ b/src/vos/vos_ilog.c
@@ -509,9 +509,8 @@ punch_log:
 }
 
 int
-vos_ilog_aggregate(daos_handle_t coh, struct ilog_df *ilog,
-		   const daos_epoch_range_t *epr,
-		   bool discard, const struct vos_punch_record *parent_punch,
+vos_ilog_aggregate(daos_handle_t coh, struct ilog_df *ilog, const daos_epoch_range_t *epr,
+		   bool discard, bool uncommitted_only, const struct vos_punch_record *parent_punch,
 		   struct vos_ilog_info *info)
 {
 	struct vos_container	*cont = vos_hdl2cont(coh);
@@ -526,7 +525,7 @@ vos_ilog_aggregate(daos_handle_t coh, struct ilog_df *ilog,
 	vos_ilog_desc_cbs_init(&cbs, coh);
 	D_DEBUG(DB_TRACE, "log="DF_X64"\n", umem_ptr2off(umm, ilog));
 
-	rc = ilog_aggregate(umm, ilog, &cbs, epr, discard, punch_rec.pr_epc,
+	rc = ilog_aggregate(umm, ilog, &cbs, epr, discard, uncommitted_only, punch_rec.pr_epc,
 			    punch_rec.pr_minor_epc, &info->ii_entries);
 
 	if (rc != 0)

--- a/src/vos/vos_ilog.h
+++ b/src/vos/vos_ilog.h
@@ -192,6 +192,7 @@ vos_ilog_desc_cbs_init(struct ilog_desc_cbs *cbs, daos_handle_t coh);
  * \param	ilog[IN]	Incarnation log
  * \param	epr[IN]		Aggregation range
  * \param	discard[IN]	Discard all entries in range
+ * \param	inprogress[IN]	Discard only uncommitted entries
  * \param	punched[IN]	Highest epoch where parent is punched
  * \param	info[IN]	Incarnation log info
  *
@@ -201,9 +202,8 @@ vos_ilog_desc_cbs_init(struct ilog_desc_cbs *cbs, daos_handle_t coh);
  *		< 0		Failure
  */
 int
-vos_ilog_aggregate(daos_handle_t coh, struct ilog_df *ilog,
-		   const daos_epoch_range_t *epr, bool discard,
-		   const struct vos_punch_record *parent_punch,
+vos_ilog_aggregate(daos_handle_t coh, struct ilog_df *ilog, const daos_epoch_range_t *epr,
+		   bool discard, bool inprogress, const struct vos_punch_record *parent_punch,
 		   struct vos_ilog_info *info);
 
 /* #define ILOG_TRACE */

--- a/src/vos/vos_internal.h
+++ b/src/vos/vos_internal.h
@@ -1098,8 +1098,8 @@ gc_reserve_space(daos_size_t *rsrvd);
  * Aggregate the creation/punch records in the current entry of the object
  * iterator
  *
- * \param ih[IN]	Iterator handle
- * \param discard[IN]	Discard all entries (within the iterator epoch range)
+ * \param ih[IN]		Iterator handle
+ * \param range_discard[IN]	Discard only uncommitted ilog entries (for reintegration)
  *
  * \return		Zero on Success
  *			1 if a reprobe is needed (entry is removed or not
@@ -1107,14 +1107,14 @@ gc_reserve_space(daos_size_t *rsrvd);
  *			negative value otherwise
  */
 int
-oi_iter_aggregate(daos_handle_t ih, bool discard);
+oi_iter_aggregate(daos_handle_t ih, bool range_discard);
 
 /**
  * Aggregate the creation/punch records in the current entry of the key
  * iterator
  *
- * \param ih[IN]	Iterator handle
- * \param discard[IN]	Discard all entries (within the iterator epoch range)
+ * \param ih[IN]		Iterator handle
+ * \param range_discard[IN]	Discard only uncommitted ilog entries (for reintegration)
  *
  * \return		Zero on Success
  *			1 if a reprobe is needed (entry is removed or not
@@ -1122,7 +1122,7 @@ oi_iter_aggregate(daos_handle_t ih, bool discard);
  *			negative value otherwise
  */
 int
-vos_obj_iter_aggregate(daos_handle_t ih, bool discard);
+vos_obj_iter_aggregate(daos_handle_t ih, bool range_discard);
 
 /** Internal bit for initializing iterator from open tree handle */
 #define VOS_IT_KEY_TREE	(1 << 31)

--- a/src/vos/vos_internal.h
+++ b/src/vos/vos_internal.h
@@ -806,6 +806,7 @@ struct vos_iterator {
 	uint32_t		 it_ref_cnt;
 	uint32_t		 it_from_parent:1,
 				 it_for_purge:1,
+				 it_for_discard:1,
 				 it_for_migration:1,
 				 it_cleanup_stale_dtx:1,
 				 it_ignore_uncommitted:1;
@@ -1061,6 +1062,8 @@ vos_iter_intent(struct vos_iterator *iter)
 {
 	if (iter->it_for_purge)
 		return DAOS_INTENT_PURGE;
+	if (iter->it_for_discard)
+		return DAOS_INTENT_DISCARD;
 	if (iter->it_ignore_uncommitted)
 		return DAOS_INTENT_IGNORE_NONCOMMITTED;
 	if (iter->it_for_migration)

--- a/src/vos/vos_internal.h
+++ b/src/vos/vos_internal.h
@@ -213,6 +213,7 @@ struct vos_container {
 	/* Various flags */
 	unsigned int		vc_in_aggregation:1,
 				vc_in_discard:1,
+				vc_in_obj_discard:1,
 				vc_reindex_cmt_dtx:1;
 	unsigned int		vc_open_count;
 };

--- a/src/vos/vos_obj.c
+++ b/src/vos/vos_obj.c
@@ -1812,7 +1812,7 @@ exit:
 }
 
 int
-vos_obj_iter_aggregate(daos_handle_t ih, bool discard)
+vos_obj_iter_aggregate(daos_handle_t ih, bool range_discard)
 {
 	struct vos_iterator	*iter = vos_hdl2iter(ih);
 	struct vos_obj_iter	*oiter = vos_iter2oiter(iter);
@@ -1844,7 +1844,7 @@ vos_obj_iter_aggregate(daos_handle_t ih, bool discard)
 		goto exit;
 
 	rc = vos_ilog_aggregate(vos_cont2hdl(obj->obj_cont), &krec->kr_ilog,
-				&oiter->it_epr, discard,
+				&oiter->it_epr, iter->it_for_discard, range_discard,
 				&oiter->it_punched, &oiter->it_ilog_info);
 
 	if (rc == 1) {

--- a/src/vos/vos_obj.c
+++ b/src/vos/vos_obj.c
@@ -1597,7 +1597,7 @@ vos_obj_iter_nested_prep(vos_iter_type_t type, struct vos_iter_info *info,
 		oiter->it_obj = obj;
 	if (info->ii_flags & VOS_IT_FOR_PURGE)
 		oiter->it_iter.it_for_purge = 1;
-	if (info->ip_flags & VOS_IT_FOR_DISCARD)
+	if (info->ii_flags & VOS_IT_FOR_DISCARD)
 		oiter->it_iter.it_for_discard = 1;
 	if (info->ii_flags & VOS_IT_FOR_MIGRATION)
 		oiter->it_iter.it_for_migration = 1;

--- a/src/vos/vos_obj.c
+++ b/src/vos/vos_obj.c
@@ -1219,6 +1219,8 @@ recx_get_flags(struct vos_obj_iter *oiter)
 		options |= EVT_ITER_REVERSE;
 	if (oiter->it_flags & VOS_IT_FOR_PURGE)
 		options |= EVT_ITER_FOR_PURGE;
+	if (oiter->it_flags & VOS_IT_FOR_DISCARD)
+		options |= EVT_ITER_FOR_DISCARD;
 	if (oiter->it_flags & VOS_IT_FOR_MIGRATION)
 		options |= EVT_ITER_FOR_MIGRATION;
 	return options;
@@ -1401,6 +1403,8 @@ vos_obj_iter_prep(vos_iter_type_t type, vos_iter_param_t *param,
 	oiter->it_recx = param->ip_recx;
 	if (param->ip_flags & VOS_IT_FOR_PURGE)
 		oiter->it_iter.it_for_purge = 1;
+	if (param->ip_flags & VOS_IT_FOR_DISCARD)
+		oiter->it_iter.it_for_discard = 1;
 	if (param->ip_flags & VOS_IT_FOR_MIGRATION)
 		oiter->it_iter.it_for_migration = 1;
 	if (param->ip_flags == VOS_IT_KEY_TREE) {
@@ -1593,6 +1597,8 @@ vos_obj_iter_nested_prep(vos_iter_type_t type, struct vos_iter_info *info,
 		oiter->it_obj = obj;
 	if (info->ii_flags & VOS_IT_FOR_PURGE)
 		oiter->it_iter.it_for_purge = 1;
+	if (info->ip_flags & VOS_IT_FOR_DISCARD)
+		oiter->it_iter.it_for_discard = 1;
 	if (info->ii_flags & VOS_IT_FOR_MIGRATION)
 		oiter->it_iter.it_for_migration = 1;
 

--- a/src/vos/vos_obj_index.c
+++ b/src/vos/vos_obj_index.c
@@ -470,6 +470,8 @@ oi_iter_prep(vos_iter_type_t type, vos_iter_param_t *param,
 	oiter->oit_flags = param->ip_flags;
 	if (param->ip_flags & VOS_IT_FOR_PURGE)
 		oiter->oit_iter.it_for_purge = 1;
+	if (param->ip_flags & VOS_IT_FOR_DISCARD)
+		oiter->oit_iter.it_for_discard = 1;
 	if (param->ip_flags & VOS_IT_FOR_MIGRATION)
 		oiter->oit_iter.it_for_migration = 1;
 

--- a/src/vos/vos_obj_index.c
+++ b/src/vos/vos_obj_index.c
@@ -649,7 +649,7 @@ exit:
 }
 
 int
-oi_iter_aggregate(daos_handle_t ih, bool discard)
+oi_iter_aggregate(daos_handle_t ih, bool range_discard)
 {
 	struct vos_iterator	*iter = vos_hdl2iter(ih);
 	struct vos_oi_iter	*oiter = iter2oiter(iter);
@@ -676,7 +676,7 @@ oi_iter_aggregate(daos_handle_t ih, bool discard)
 		goto exit;
 
 	rc = vos_ilog_aggregate(vos_cont2hdl(oiter->oit_cont), &obj->vo_ilog,
-				&oiter->oit_epr, discard, NULL,
+				&oiter->oit_epr, iter->it_for_discard, range_discard, NULL,
 				&oiter->oit_ilog_info);
 	if (rc == 1) {
 		/* Incarnation log is empty, delete the object */


### PR DESCRIPTION
* Follow-up patch to prior patch that implemented vos_discard for single
object epoch range.
* Modify discard to actually remove everything, including uncommitted data.  It's used for snapshot rollback so uncommitted data in the range should be removed too.
* For object specific discard, only discard uncommitted entries.
* need_aggregate should always return true for discard

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>