### PR TITLE
DAOS-8445 tests: not set EC cell size on container for racer

### DIFF
--- a/src/tests/daos_racer.c
+++ b/src/tests/daos_racer.c
@@ -473,7 +473,6 @@ main(int argc, char **argv)
 	d_rank_t	svc_rank  = 0;	/* pool service rank */
 	unsigned	duration = 60; /* seconds */
 	double		expire = 0;
-	daos_prop_t	*prop;
 	int		idx;
 	struct racer_sub_tests	sub_tests[TEST_SIZE] = { 0 };
 	int		rc;
@@ -559,12 +558,6 @@ main(int argc, char **argv)
 	rc = dts_ctx_init(&ts_ctx, NULL);
 	if (rc)
 		D_GOTO(out, rc);
-
-	prop = daos_prop_alloc(1);
-	prop->dpp_entries[0].dpe_type = DAOS_PROP_CO_EC_CELL_SZ;
-	prop->dpp_entries[0].dpe_val = 1024;
-	daos_cont_set_prop(ts_ctx.tsc_coh, prop, NULL);
-	daos_prop_free(prop);
 
 	sub_tests_init(sub_tests, 0xFFFF);
 	expire = dts_time_now() + duration;


### PR DESCRIPTION
It is unnecessary to explicitly set container's EC cell size
as 1M for racer test. Because:

If the user specifies the container to be used for racer test,
then we have no way to change an existing container's EC cell
size. Or

If the user does not specify the test container, then the new
created (by racer) container will inherit such property from
the pool which is 1M by default.

Signed-off-by: Fan Yong <fan.yong@intel.com>