### PR TITLE
DAOS-8676 control: daos_server storage prepare has duplicate -b option

### DIFF
--- a/src/control/common/storage/commands.go
+++ b/src/control/common/storage/commands.go
@@ -21,8 +21,8 @@ const MsgStoragePrepareWarn = "Memory allocation goals for SCM will be changed a
 	"and subsequent reboot maybe required.\n"
 
 type StoragePrepareNvmeCmd struct {
-	PCIAllowList string `short:"a" long:"pci-allow-list" description:"Whitespace separated list of PCI devices (by address) to be unbound from Kernel driver and used with SPDK (default is all PCI devices)."`
-	PCIBlockList string `short:"b" long:"pci-block-list" description:"Whitespace separated list of PCI devices (by address) to be ignored when unbinding devices from Kernel driver to be used with SPDK (default is no PCI devices)."`
+	PCIAllowList string `long:"pci-allow-list" description:"Whitespace separated list of PCI devices (by address) to be unbound from Kernel driver and used with SPDK (default is all PCI devices)."`
+	PCIBlockList string `long:"pci-block-list" description:"Whitespace separated list of PCI devices (by address) to be ignored when unbinding devices from Kernel driver to be used with SPDK (default is no PCI devices)."`
 	NrHugepages  int    `short:"p" long:"hugepages" description:"Number of hugepages to allocate (in MB) for use by SPDK (default 1024)"`
 	TargetUser   string `short:"u" long:"target-user" description:"User that will own hugepage mountpoint directory and vfio groups."`
 }


### PR DESCRIPTION
"-b" is overloaded with debug and block list options, remove the short
command aliases to avoid the conflict.

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>