### PR TITLE
DAOS-7136-Test: reable rebuild/io_conf_run.py 20 skipped testcases.

### DIFF
--- a/src/tests/ftest/rebuild/io_conf_run.py
+++ b/src/tests/ftest/rebuild/io_conf_run.py
@@ -5,7 +5,6 @@
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
 from daos_io_conf import IoConfTestBase
-from apricot import skipForTicket
 
 class RbldRunIoConf(IoConfTestBase):
     """Test daos_run_io_conf.
@@ -14,7 +13,6 @@ class RbldRunIoConf(IoConfTestBase):
     """
     # pylint: disable=too-many-ancestors
 
-    @skipForTicket("DAOS-7136")
     def test_daos_run_io_conf(self):
         """Jira ID: DAOS-3150.
 


### PR DESCRIPTION
DAOS-7136-Test: reable rebuild/io_conf_run.py 20 skipped testcases.

Updated: rebuild/io_conf_run.py
Test-tag: pr iorebuild
Signed-off-by: Ding Ho ding-hwa.ho@intel.com
