### PR TITLE
DAOS-623 duns: use strncpy instead of snprintf

### DIFF
--- a/src/client/dfs/duns.c
+++ b/src/client/dfs/duns.c
@@ -220,7 +220,8 @@ duns_resolve_lustre_path(const char *path, struct duns_attr_t *attr)
 		D_ERROR("Invalid DAOS LMV format: pool UUID cannot be parsed\n");
 		return EINVAL;
 	}
-	snprintf(attr->da_pool, DAOS_PROP_LABEL_MAX_LEN + 1,  "%s", t);
+	strncpy(attr->da_pool, t, DAOS_PROP_LABEL_MAX_LEN);
+	attr->da_pool[DAOS_PROP_LABEL_MAX_LEN] = '\0';
 
 	t = strtok_r(NULL, "/", &saveptr);
 	if (t == NULL) {
@@ -234,7 +235,8 @@ duns_resolve_lustre_path(const char *path, struct duns_attr_t *attr)
 		D_ERROR("Invalid DAOS LMV format: container UUID cannot be parsed\n");
 		return EINVAL;
 	}
-	snprintf(attr->da_cont, DAOS_PROP_LABEL_MAX_LEN + 1,  "%s", t);
+	strncpy(attr->da_cont, t, DAOS_PROP_LABEL_MAX_LEN);
+	attr->da_cont[DAOS_PROP_LABEL_MAX_LEN] = '\0';
 
 	/* path is DAOS-foreign and will need to be unlinked using
 	 * unlink_foreign API
@@ -364,7 +366,8 @@ resolve_direct_path(const char *path, struct duns_attr_t *attr, bool no_prefix, 
 		if (!daos_label_is_valid(t))
 			D_GOTO(err, rc = EINVAL);
 	}
-	snprintf(attr->da_pool, DAOS_PROP_LABEL_MAX_LEN + 1,  "%s", t);
+	strncpy(attr->da_pool, t, DAOS_PROP_LABEL_MAX_LEN);
+	attr->da_pool[DAOS_PROP_LABEL_MAX_LEN] = '\0';
 
 	if (pool_only) {
 		D_FREE(dir);
@@ -385,7 +388,8 @@ resolve_direct_path(const char *path, struct duns_attr_t *attr, bool no_prefix, 
 		if (!daos_label_is_valid(t))
 			D_GOTO(err, rc = EINVAL);
 	}
-	snprintf(attr->da_cont, DAOS_PROP_LABEL_MAX_LEN + 1,  "%s", t);
+	strncpy(attr->da_cont, t, DAOS_PROP_LABEL_MAX_LEN);
+	attr->da_cont[DAOS_PROP_LABEL_MAX_LEN] = '\0';
 
 	/** if there is a relative path, parse it out */
 	t = strtok_r(NULL, "", &saveptr);
@@ -576,7 +580,8 @@ duns_parse_attr(char *str, daos_size_t len, struct duns_attr_t *attr)
 		D_ERROR("Invalid DAOS xattr format: pool UUID cannot be parsed\n");
 		D_GOTO(err, rc = EINVAL);
 	}
-	snprintf(attr->da_pool, DAOS_PROP_LABEL_MAX_LEN + 1,  "%s", t);
+	strncpy(attr->da_pool, t, DAOS_PROP_LABEL_MAX_LEN);
+	attr->da_pool[DAOS_PROP_LABEL_MAX_LEN] = '\0';
 
 	t = strtok_r(NULL, "/", &saveptr);
 	if (t == NULL) {
@@ -590,7 +595,8 @@ duns_parse_attr(char *str, daos_size_t len, struct duns_attr_t *attr)
 		D_ERROR("Invalid DAOS xattr format: container UUID cannot be parsed\n");
 		D_GOTO(err, rc = EINVAL);
 	}
-	snprintf(attr->da_cont, DAOS_PROP_LABEL_MAX_LEN + 1,  "%s", t);
+	strncpy(attr->da_cont, t, DAOS_PROP_LABEL_MAX_LEN);
+	attr->da_cont[DAOS_PROP_LABEL_MAX_LEN] = '\0';
 
 	rc = 0;
 err:


### PR DESCRIPTION
Signed-off-by: Mohamad Chaarawi <mohamad.chaarawi@intel.com>