### PR TITLE
DAOS-8609 migrate: do not need migrate punched object

### DIFF
--- a/src/include/daos_srv/daos_engine.h
+++ b/src/include/daos_srv/daos_engine.h
@@ -868,7 +868,8 @@ int
 ds_object_migrate(struct ds_pool *pool, uuid_t pool_hdl_uuid, uuid_t cont_uuid,
 		  uuid_t cont_hdl_uuid, int tgt_id, uint32_t version,
 		  uint64_t max_eph, daos_unit_oid_t *oids, daos_epoch_t *ephs,
-		  unsigned int *shards, int cnt, int clear_conts);
+		  daos_epoch_t *punched_ephs, unsigned int *shards, int cnt,
+		  int clear_conts);
 void
 ds_migrate_fini_one(uuid_t pool_uuid, uint32_t ver);
 

--- a/src/object/obj_rpc.h
+++ b/src/object/obj_rpc.h
@@ -31,7 +31,7 @@
  * These are for daos_rpc::dr_opc and DAOS_RPC_OPCODE(opc, ...) rather than
  * crt_req_create(..., opc, ...). See daos_rpc.h.
  */
-#define DAOS_OBJ_VERSION 5
+#define DAOS_OBJ_VERSION 6
 /* LIST of internal RPCS in form of:
  * OPCODE, flags, FMT, handler, corpc_hdlr and name
  */
@@ -323,6 +323,7 @@ CRT_RPC_DECLARE(obj_sync, DAOS_ISEQ_OBJ_SYNC, DAOS_OSEQ_OBJ_SYNC)
 	((uint32_t)		(om_tgt_idx)		CRT_VAR)	\
 	((daos_unit_oid_t)	(om_oids)		CRT_ARRAY)	\
 	((uint64_t)		(om_ephs)		CRT_ARRAY)	\
+	((uint64_t)		(om_punched_ephs)	CRT_ARRAY)	\
 	((uint32_t)		(om_shards)		CRT_ARRAY)	\
 	((int32_t)		(om_del_local_obj)	CRT_VAR)
 

--- a/src/object/srv_obj_migrate.c
+++ b/src/object/srv_obj_migrate.c
@@ -110,6 +110,7 @@ struct iter_obj_arg {
 	uuid_t			cont_uuid;
 	daos_unit_oid_t		oid;
 	daos_epoch_t		epoch;
+	daos_epoch_t		punched_epoch;
 	unsigned int		shard;
 	unsigned int		tgt_idx;
 	uint64_t		*snaps;
@@ -2234,7 +2235,7 @@ migrate_enum_unpack_cb(struct dss_enum_unpack_io *io, void *data)
 	return rc;
 }
 
-static int
+static void
 migrate_obj_punch_one(void *data)
 {
 	struct migrate_pool_tls *tls;
@@ -2248,23 +2249,23 @@ migrate_obj_punch_one(void *data)
 		       DP_UUID(arg->pool_uuid));
 		D_GOTO(put, rc = 0);
 	}
-	D_DEBUG(DB_REBUILD, "tls %p "DF_UUID" version %d punch "DF_UOID"\n",
-		tls, DP_UUID(tls->mpt_pool_uuid), arg->version,
+	D_DEBUG(DB_REBUILD, "tls %p "DF_UUID" version %d punch "DF_U64" "DF_UOID"\n",
+		tls, DP_UUID(tls->mpt_pool_uuid), arg->version, arg->punched_epoch,
 		DP_UOID(arg->oid));
 	rc = ds_cont_child_lookup(tls->mpt_pool_uuid, arg->cont_uuid, &cont);
 	D_ASSERT(rc == 0);
 
-	rc = vos_obj_punch(cont->sc_hdl, arg->oid, arg->epoch,
+	D_ASSERT(arg->punched_epoch != 0);
+	rc = vos_obj_punch(cont->sc_hdl, arg->oid, arg->punched_epoch,
 			   tls->mpt_version, VOS_OF_REPLAY_PC,
 			   NULL, 0, NULL, NULL);
 	ds_cont_child_put(cont);
-	if (rc)
-		D_ERROR(DF_UOID" migrate punch failed: "DF_RC"\n",
-			DP_UOID(arg->oid), DP_RC(rc));
 put:
 	if (tls)
 		migrate_pool_tls_put(tls);
-	return rc;
+	if (rc)
+		D_ERROR(DF_UOID" migrate punch failed: "DF_RC"\n",
+			DP_UOID(arg->oid), DP_RC(rc));
 }
 
 static int
@@ -2596,7 +2597,8 @@ ds_migrate_abort(uuid_t pool_uuid, unsigned int version)
 static int
 migrate_obj_punch(struct iter_obj_arg *arg)
 {
-	return dss_task_collective(migrate_obj_punch_one, arg, 0);
+	return dss_ult_create(migrate_obj_punch_one, arg, DSS_XS_VOS,
+			      arg->tgt_idx, MIGRATE_STACK_SIZE, NULL);
 }
 
 /* Destroys an object prior to migration. Called exactly once per object ID per
@@ -2663,7 +2665,7 @@ migrate_obj_ult(void *data)
 	struct migrate_pool_tls	*tls = NULL;
 	daos_epoch_range_t	 epr;
 	int			 i;
-	int			 rc;
+	int			 rc = 0;
 
 	tls = migrate_pool_tls_lookup(arg->pool_uuid, arg->version);
 	if (tls == NULL || tls->mpt_fini) {
@@ -2689,12 +2691,6 @@ migrate_obj_ult(void *data)
 		}
 	}
 
-	if (arg->epoch != DAOS_EPOCH_MAX) {
-		rc = migrate_obj_punch(arg);
-		if (rc)
-			D_GOTO(free, rc);
-	}
-
 	for (i = 0; i < arg->snap_cnt; i++) {
 		epr.epr_lo = i > 0 ? arg->snaps[i-1] + 1 : 0;
 		epr.epr_hi = arg->snaps[i];
@@ -2703,11 +2699,24 @@ migrate_obj_ult(void *data)
 			D_GOTO(free, rc);
 	}
 
+	if (arg->snap_cnt > 0 && arg->punched_epoch != 0) {
+		rc = migrate_obj_punch(arg);
+		if (rc)
+			D_GOTO(free, rc);
+	}
+
 	epr.epr_lo = arg->snaps ? arg->snaps[arg->snap_cnt - 1] + 1 : 0;
 	D_ASSERT(tls->mpt_max_eph != 0);
 	epr.epr_hi = tls->mpt_max_eph;
-	rc = migrate_one_epoch_object(&epr, tls, arg);
-
+	if (arg->epoch > 0) {
+		rc = migrate_one_epoch_object(&epr, tls, arg);
+	} else {
+		/* The obj has been punched for this range */
+		D_DEBUG(DB_REBUILD, "punched obj "DF_UOID" epoch"
+			" "DF_U64"/"DF_U64"/"DF_U64"\n", DP_UOID(arg->oid),
+			arg->epoch, arg->punched_epoch, epr.epr_hi);
+		arg->epoch = DAOS_EPOCH_MAX;
+	}
 free:
 	if (arg->epoch == DAOS_EPOCH_MAX)
 		tls->mpt_obj_count++;
@@ -2750,14 +2759,15 @@ free_notls:
 
 struct migrate_obj_val {
 	daos_epoch_t	epoch;
+	daos_epoch_t	punched_epoch;
 	uint32_t	shard;
 	uint32_t	tgt_idx;
 };
 
 /* This is still running on the main migration ULT */
 static int
-migrate_one_object(daos_unit_oid_t oid, daos_epoch_t eph, unsigned int shard,
-		   unsigned int tgt_idx, void *data)
+migrate_one_object(daos_unit_oid_t oid, daos_epoch_t eph, daos_epoch_t punched_eph,
+		   unsigned int shard, unsigned int tgt_idx, void *data)
 {
 	struct iter_cont_arg	*cont_arg = data;
 	struct iter_obj_arg	*obj_arg;
@@ -2777,6 +2787,7 @@ migrate_one_object(daos_unit_oid_t oid, daos_epoch_t eph, unsigned int shard,
 	obj_arg->oid = oid;
 	obj_arg->epoch = eph;
 	obj_arg->shard = shard;
+	obj_arg->punched_epoch = punched_eph;
 	obj_arg->tgt_idx = tgt_idx;
 	uuid_copy(obj_arg->pool_uuid, cont_arg->pool_tls->mpt_pool_uuid);
 	uuid_copy(obj_arg->cont_uuid, cont_arg->cont_uuid);
@@ -2842,13 +2853,13 @@ free:
 #define DEFAULT_YIELD_FREQ	128
 
 static int
-migrate_obj_iter_cb(daos_handle_t ih, d_iov_t *key_iov, d_iov_t *val_iov,
-		    void *data)
+migrate_obj_iter_cb(daos_handle_t ih, d_iov_t *key_iov, d_iov_t *val_iov, void *data)
 {
 	struct iter_cont_arg		*arg = data;
 	daos_unit_oid_t			*oid = key_iov->iov_buf;
 	struct migrate_obj_val		*obj_val = val_iov->iov_buf;
 	daos_epoch_t			epoch = obj_val->epoch;
+	daos_epoch_t			punched_epoch = obj_val->punched_epoch;
 	unsigned int			tgt_idx = obj_val->tgt_idx;
 	unsigned int			shard = obj_val->shard;
 	int				rc;
@@ -2860,7 +2871,7 @@ migrate_obj_iter_cb(daos_handle_t ih, d_iov_t *key_iov, d_iov_t *val_iov,
 		" eph "DF_U64" start\n", DP_UUID(arg->cont_uuid), DP_UOID(*oid),
 		ih.cookie, epoch);
 
-	rc = migrate_one_object(*oid, epoch, shard, tgt_idx, arg);
+	rc = migrate_one_object(*oid, epoch, punched_epoch, shard, tgt_idx, arg);
 	if (rc != 0) {
 		D_ERROR("obj "DF_UOID" migration failed: "DF_RC"\n",
 			DP_UOID(*oid), DP_RC(rc));
@@ -3088,7 +3099,8 @@ migrate_del_object_tree(struct migrate_pool_tls *tls)
 static int
 migrate_try_obj_insert(struct migrate_pool_tls *tls, uuid_t co_uuid,
 		       daos_unit_oid_t oid, daos_epoch_t epoch,
-		       unsigned int shard, unsigned int tgt_idx)
+		       daos_epoch_t punched_epoch, unsigned int shard,
+		       unsigned int tgt_idx)
 {
 	struct migrate_obj_val	val;
 	daos_handle_t		toh = tls->mpt_root_hdl;
@@ -3100,11 +3112,12 @@ migrate_try_obj_insert(struct migrate_pool_tls *tls, uuid_t co_uuid,
 	D_ASSERT(daos_handle_is_valid(migrated_toh));
 
 	val.epoch = epoch;
+	val.punched_epoch = punched_epoch;
 	val.shard = shard;
 	val.tgt_idx = tgt_idx;
-	D_DEBUG(DB_REBUILD, "Insert migrate "DF_UUID"/"DF_UOID" "DF_U64
-		"/%d/%d\n", DP_UUID(co_uuid), DP_UOID(oid), epoch, shard,
-		tgt_idx);
+	D_DEBUG(DB_REBUILD, "Insert migrate "DF_UUID"/"DF_UOID" "DF_U64"/"DF_U64
+		"/%d/%d\n", DP_UUID(co_uuid), DP_UOID(oid), epoch, punched_epoch,
+		shard, tgt_idx);
 
 	d_iov_set(&val_iov, &val, sizeof(struct migrate_obj_val));
 	rc = obj_tree_lookup(toh, co_uuid, oid, &val_iov);
@@ -3138,6 +3151,7 @@ ds_obj_migrate_handler(crt_rpc_t *rpc)
 	daos_unit_oid_t		*oids;
 	unsigned int		oids_count;
 	daos_epoch_t		*ephs;
+	daos_epoch_t		*punched_ephs;
 	unsigned int		ephs_count;
 	uint32_t		*shards;
 	unsigned int		shards_count;
@@ -3153,6 +3167,7 @@ ds_obj_migrate_handler(crt_rpc_t *rpc)
 	oids = migrate_in->om_oids.ca_arrays;
 	oids_count = migrate_in->om_oids.ca_count;
 	ephs = migrate_in->om_ephs.ca_arrays;
+	punched_ephs = migrate_in->om_punched_ephs.ca_arrays;
 	ephs_count = migrate_in->om_ephs.ca_count;
 	shards = migrate_in->om_shards.ca_arrays;
 	shards_count = migrate_in->om_shards.ca_count;
@@ -3204,7 +3219,8 @@ ds_obj_migrate_handler(crt_rpc_t *rpc)
 	for (i = 0; i < oids_count; i++) {
 		/* firstly insert/check rebuilt tree */
 		rc = migrate_try_obj_insert(pool_tls, co_uuid, oids[i], ephs[i],
-					    shards[i], migrate_in->om_tgt_idx);
+					    punched_ephs[i], shards[i],
+					    migrate_in->om_tgt_idx);
 		if (rc == -DER_EXIST) {
 			D_DEBUG(DB_TRACE, DF_UOID"/"DF_UUID"exists.\n",
 				DP_UOID(oids[i]), DP_UUID(co_uuid));
@@ -3351,6 +3367,7 @@ out:
  * param max_eph [in]		maxim epoch of the migration.
  * param oids [in]		array of the objects to be migrated.
  * param ephs [in]		epoch of the objects.
+ * param punched_ephs [in]	punched_epoch of objects.
  * param shards [in]		it can be NULL, otherwise it indicates
  *				the source shard of the migration, so it
  *				is only used for replicate objects.
@@ -3363,8 +3380,8 @@ int
 ds_object_migrate(struct ds_pool *pool, uuid_t pool_hdl_uuid,
 		  uuid_t cont_hdl_uuid, uuid_t cont_uuid, int tgt_id,
 		  uint32_t version, uint64_t max_eph, daos_unit_oid_t *oids,
-		  daos_epoch_t *ephs, unsigned int *shards, int cnt,
-		  int del_local_objs)
+		  daos_epoch_t *ephs, daos_epoch_t *punched_ephs,
+		  unsigned int *shards, int cnt, int del_local_objs)
 {
 	struct obj_migrate_in	*migrate_in = NULL;
 	struct obj_migrate_out	*migrate_out = NULL;
@@ -3421,6 +3438,8 @@ ds_object_migrate(struct ds_pool *pool, uuid_t pool_hdl_uuid,
 	migrate_in->om_oids.ca_count = cnt;
 	migrate_in->om_ephs.ca_arrays = ephs;
 	migrate_in->om_ephs.ca_count = cnt;
+	migrate_in->om_punched_ephs.ca_arrays = punched_ephs;
+	migrate_in->om_punched_ephs.ca_count = cnt;
 
 	if (shards) {
 		migrate_in->om_shards.ca_arrays = shards;

--- a/src/vos/ilog.c
+++ b/src/vos/ilog.c
@@ -915,6 +915,8 @@ ilog_modify(daos_handle_t loh, const struct ilog_id *id_in,
 		tmp.lr_magic = ilog_ver_inc(lctx);
 		tmp.lr_ts_idx = root->lr_ts_idx;
 		tmp.lr_id = *id_in;
+		D_ASSERTF(id_in->id_epoch != 0, "epoch "DF_U64" opc %d\n",
+			  id_in->id_epoch, opc);
 		rc = ilog_ptr_set(lctx, root, &tmp);
 		if (rc != 0)
 			goto done;


### PR DESCRIPTION
During migration, send punched epoch to migrating target,
so to avoid migrating the punched objects for some cases.

Signed-off-by: Di Wang <di.wang@intel.com>