### PR TITLE
DAOS-8697 vos: Aggregation can cache too many removal records

### DIFF
--- a/src/common/lru.c
+++ b/src/common/lru.c
@@ -239,6 +239,7 @@ daos_lru_ref_hold(struct daos_lru_cache *lcache, void *key,
 	link = d_hash_rec_find(&lcache->dlc_htable, key, key_size);
 	if (link != NULL) {
 		llink = link2llink(link);
+		D_ASSERT(llink->ll_evicted == 0);
 		/* remove busy item from LRU */
 		if (!d_list_empty(&llink->ll_qlink))
 			d_list_del_init(&llink->ll_qlink);

--- a/src/include/daos_srv/evtree.h
+++ b/src/include/daos_srv/evtree.h
@@ -410,6 +410,7 @@ evt_vis2dbg(int flag)
 
 	switch (flag & flags) {
 	default:
+		printf("flag = %x\n", flag);
 		D_ASSERT(0);
 	case 0:
 		break;
@@ -669,6 +670,8 @@ enum {
 	EVT_ITER_FOR_DISCARD	= (1 << 7),
 	/** Skip visible data (Only valid with EVT_ITER_VISIBLE) */
 	EVT_ITER_SKIP_DATA	= (1 << 8),
+	/** Only process removals */
+	EVT_ITER_REMOVALS	= (1 << 9),
 };
 
 D_CASSERT((int)EVT_VISIBLE == (int)EVT_ITER_VISIBLE);

--- a/src/vos/evtree.c
+++ b/src/vos/evtree.c
@@ -774,6 +774,9 @@ process_ext:
 			set_visibility(this_ent, EVT_COVERED);
 			evt_ent_addr_update(tcx, temp_ent,
 					    evt_extent_width(this_ext));
+			temp = cur_update;
+			cur_update = cur_update->next;
+			d_list_del(temp);
 			/** Leave marking it covered until processed */
 			cur_update = evt_insert_sorted(temp_ent,
 						    to_process,
@@ -791,10 +794,12 @@ process_ext:
 
 static int
 evt_find_visible(struct evt_context *tcx, const struct evt_filter *filter,
-		 struct evt_entry_array *ent_array, int *num_visible)
+		 struct evt_entry_array *ent_array, int *num_visible,
+		 bool removals_only)
 {
 	struct evt_extent	*this_ext;
 	struct evt_extent	*next_ext;
+	struct evt_list_entry	*le;
 	struct evt_entry	*this_ent;
 	struct evt_entry	*next_ent;
 	struct evt_entry	*temp_ent;
@@ -841,6 +846,18 @@ evt_find_visible(struct evt_context *tcx, const struct evt_filter *filter,
 
 	if (d_list_empty(&covered))
 		return 0;
+
+	if (removals_only) {
+		/** We just want to see records not covered by a removal.  At this point,
+		 *  every record remaining in the list satisfies this condition so mark them all
+		 *  visible for sorting.
+		 */
+		d_list_for_each_entry(le, &covered, le_link) {
+			this_ent = &le->le_ent;
+			evt_mark_visible(this_ent, false, num_visible);
+		}
+		return 0;
+	}
 
 	/* Now uncover entries */
 	current = covered.next;
@@ -983,8 +1000,8 @@ evt_ent_array_sort(struct evt_context *tcx, struct evt_entry_array *ent_array,
 		      evt_ent_list_cmp);
 
 		/* Now separate entries into covered and visible */
-		rc = evt_find_visible(tcx, filter, ent_array, &num_visible);
-
+		rc = evt_find_visible(tcx, filter, ent_array, &num_visible,
+				      (flags & EVT_ITER_REMOVALS) != 0);
 		if (rc != 0) {
 			if (rc == -DER_AGAIN)
 				continue; /* List reallocated, start over */
@@ -1000,7 +1017,7 @@ re_sort:
 		total = ent_array->ea_ent_nr;
 		compar = evt_ent_list_cmp;
 	} else {
-		D_ASSERT(flags & EVT_VISIBLE);
+		D_ASSERT(flags & (EVT_ITER_VISIBLE | EVT_ITER_REMOVALS));
 		compar = evt_ent_list_cmp_visible;
 		total = num_visible;
 	}
@@ -2525,9 +2542,6 @@ evt_ent_array_fill(struct evt_context *tcx, enum evt_find_opc find_opc,
 				 * properly.
 				 */
 				if (range_overlap != RT_OVERLAP_SAME) {
-					if (rect->rc_minor_epc ==
-					    EVT_MINOR_EPC_MAX)
-						break; /* Need to adjust it */
 					D_ERROR("Same epoch partial "
 						"overwrite not supported:"
 						DF_RECT" overlaps with "DF_RECT
@@ -2665,8 +2679,9 @@ evt_find(daos_handle_t toh, const struct evt_filter *filter,
 
 	rc = evt_ent_array_fill(tcx, EVT_FIND_ALL, DAOS_INTENT_DEFAULT,
 				filter, &rect, ent_array);
+
 	if (rc == 0)
-		rc = evt_ent_array_sort(tcx, ent_array, filter, EVT_VISIBLE);
+		rc = evt_ent_array_sort(tcx, ent_array, filter, EVT_ITER_VISIBLE);
 
 	return rc;
 }
@@ -3637,26 +3652,19 @@ evt_remove_all(daos_handle_t toh, const struct evt_extent *ext,
 	if (rc != 0)
 		goto done;
 
+	rc = evt_ent_array_sort(tcx, ent_array, &filter, EVT_ITER_REMOVALS);
+	if (rc != 0)
+		goto done;
+
 	rc = evt_tx_begin(tcx);
 	if (rc != 0)
 		goto done;
 
 	evt_ent_array_for_each(ent, ent_array) {
-		if (ent->en_minor_epc == EVT_MINOR_EPC_MAX)
-			continue; /* Skip existing removal records */
-		entry.ei_rect.rc_ex = ent->en_ext;
+		D_ASSERT(ent->en_minor_epc != EVT_MINOR_EPC_MAX);
+		entry.ei_rect.rc_ex = ent->en_sel_ext;
 		entry.ei_bound = entry.ei_rect.rc_epc = ent->en_epoch;
 		entry.ei_rect.rc_minor_epc = EVT_MINOR_EPC_MAX;
-
-		/** One could make the case for removal for intact extents here but it has the
-		 *  potential for messing with aggregation's implicit assumption that it is the
-		 *  remover of extents.  If the extent is only partially covered, we do need to
-		 *  adjust the bounds before inserting the removal record.
-		 */
-		if (ent->en_ext.ex_lo < ext->ex_lo)
-			entry.ei_rect.rc_ex.ex_lo = ext->ex_lo;
-		if (ent->en_ext.ex_hi > ext->ex_hi)
-			entry.ei_rect.rc_ex.ex_hi = ext->ex_hi;
 
 		D_DEBUG(DB_IO, "Insert removal record "DF_RECT"\n", DP_RECT(&entry.ei_rect));
 		BIO_ADDR_SET_HOLE(&entry.ei_addr);

--- a/src/vos/tests/vts_aggregate.c
+++ b/src/vos/tests/vts_aggregate.c
@@ -2716,6 +2716,56 @@ aggregate_32(void **state)
 	cleanup();
 }
 
+static void
+aggregate_33(void **state)
+{
+	struct io_test_args	*arg = *state;
+	struct agg_tst_dataset	 ds = { 0 };
+	daos_recx_t		 recx_arr[10];
+	daos_epoch_t		 punch_epochs[] = {2, 4, 6, 8, 10, 12};
+	int			 iod_size = 1024, end_idx;
+
+	end_idx = (VOS_MW_FLUSH_THRESH + iod_size - 1) / iod_size;
+	assert_true(end_idx > 5);
+
+	/* Insert a record */
+	recx_arr[0].rx_idx = 0;
+	recx_arr[0].rx_nr = 2;
+	recx_arr[1].rx_idx = 0;
+	recx_arr[1].rx_nr = 2;
+	recx_arr[2].rx_idx = 2;
+	recx_arr[2].rx_nr = 2;
+	recx_arr[3].rx_idx = 1;
+	recx_arr[3].rx_nr = 2;
+	recx_arr[4].rx_idx = 4;
+	recx_arr[4].rx_nr = 2;
+	recx_arr[5].rx_idx = 4;
+	recx_arr[5].rx_nr = 2;
+	recx_arr[6].rx_idx = 6;
+	recx_arr[6].rx_nr = 2;
+	recx_arr[7].rx_idx = 6;
+	recx_arr[7].rx_nr = 2;
+	recx_arr[8].rx_idx = 12;
+	recx_arr[8].rx_nr = 20;
+	recx_arr[9].rx_idx = 12;
+	recx_arr[9].rx_nr = 2;
+
+	ds.td_type = DAOS_IOD_ARRAY;
+	ds.td_iod_size = iod_size;
+	ds.td_recx_nr = ARRAY_SIZE(recx_arr);
+	ds.td_recx = &recx_arr[0];
+	ds.td_expected_recs = 2;
+	ds.td_upd_epr.epr_lo = 1;
+	ds.td_upd_epr.epr_hi = ARRAY_SIZE(recx_arr);
+	ds.td_agg_epr.epr_lo = 0;
+	ds.td_agg_epr.epr_hi = ARRAY_SIZE(recx_arr) + 1;
+	ds.td_discard = false;
+	ds.td_delete = true;
+
+	aggregate_basic(arg, &ds, ARRAY_SIZE(punch_epochs), &punch_epochs[0]);
+	cleanup();
+}
+
 static int
 agg_tst_teardown(void **state)
 {
@@ -2762,6 +2812,26 @@ static const struct CMUnitTest discard_tests[] = {
 };
 
 static const struct CMUnitTest aggregate_tests[] = {
+	{ "VOS424: Aggregate extents not fully covered by delete record",
+	  aggregate_24, NULL, agg_tst_teardown },
+	{ "VOS425: Aggregate delete of end of merge window",
+	  aggregate_25, NULL, agg_tst_teardown },
+	{ "VOS426: Consecutive removed extents",
+	  aggregate_26, NULL, agg_tst_teardown },
+	{ "VOS427: Consecutive removed extents, no logical extents",
+	  aggregate_27, NULL, agg_tst_teardown },
+	{ "VOS428: Logical extent followed by consecutive removed extents",
+	  aggregate_28, NULL, agg_tst_teardown },
+	{ "VOS429: Logical extent followed by disjoint removed extents",
+	  aggregate_29, NULL, agg_tst_teardown },
+	{ "VOS430: Removal stress test",
+	  aggregate_30, NULL, agg_tst_teardown },
+	{ "VOS431: Removal spans windows, flush with no physical records",
+	  aggregate_31, NULL, agg_tst_teardown },
+	{ "VOS432: Overlapping removals",
+	  aggregate_32, NULL, agg_tst_teardown },
+	{ "VOS433: Many small removals",
+	  aggregate_33, NULL, agg_tst_teardown },
 	{ "VOS401: Aggregate SV with confined epr",
 	  aggregate_1, NULL, agg_tst_teardown },
 	{ "VOS402: Aggregate SV with punch records",
@@ -2808,24 +2878,6 @@ static const struct CMUnitTest aggregate_tests[] = {
 	  aggregate_22, NULL, agg_tst_teardown },
 	{ "VOS423: Aggregate deleted records spanning window end",
 	  aggregate_23, NULL, agg_tst_teardown },
-	{ "VOS424: Aggregate extents not fully covered by delete record",
-	  aggregate_24, NULL, agg_tst_teardown },
-	{ "VOS425: Aggregate delete of end of merge window",
-	  aggregate_25, NULL, agg_tst_teardown },
-	{ "VOS426: Consecutive removed extents",
-	  aggregate_26, NULL, agg_tst_teardown },
-	{ "VOS427: Consecutive removed extents, no logical extents",
-	  aggregate_27, NULL, agg_tst_teardown },
-	{ "VOS428: Logical extent followed by consecutive removed extents",
-	  aggregate_28, NULL, agg_tst_teardown },
-	{ "VOS429: Logical extent followed by disjoint removed extents",
-	  aggregate_29, NULL, agg_tst_teardown },
-	{ "VOS430: Removal stress test",
-	  aggregate_30, NULL, agg_tst_teardown },
-	{ "VOS431: Removal spans windows, flush with no physical records",
-	  aggregate_31, NULL, agg_tst_teardown },
-	{ "VOS432: Overlapping removals",
-	  aggregate_32, NULL, agg_tst_teardown },
 };
 
 int

--- a/src/vos/vos_aggregate.c
+++ b/src/vos/vos_aggregate.c
@@ -63,10 +63,16 @@ struct agg_phy_ent {
 /* Removal record */
 struct agg_rmv_ent {
 	d_list_t		re_link;
+	/** list link for physical records */
+	d_list_t		re_phy_link;
 	/* In tree rectangle */
 	struct evt_rect		re_rect;
 	/** Real entries, if any, contained in a logical rectangle */
 	d_list_t		re_contained;
+	int			re_aggregate:1, /* Aggregate of one or more records */
+				re_child:1;	/* Contained in aggregate record */
+	/** Refcount of physical records that reference this removal */
+	int			re_phy_count;
 };
 
 /* EV tree logical entry */
@@ -127,6 +133,8 @@ struct agg_merge_window {
 	unsigned int			 mw_phy_cnt;
 	/** Possibly deleted physical entries */
 	d_list_t			 mw_rmv_ents;
+	/** In order list of physical removal records */
+	d_list_t			 mw_phy_rmv_ents;
 	unsigned int			 mw_rmv_cnt;
 	/* Visible logical entries in merge window */
 	struct agg_lgc_ent		*mw_lgc_ents;
@@ -544,16 +552,81 @@ allocate_rmv_ent(const struct evt_extent *ext, daos_epoch_t epoch, uint16_t mino
 	return rm_ent;
 }
 
-static struct agg_rmv_ent *
+static inline void
+recx2ext(const daos_recx_t *recx, struct evt_extent *ext)
+{
+	D_ASSERT(recx->rx_nr > 0);
+	ext->ex_lo = recx->rx_idx;
+	ext->ex_hi = recx->rx_idx + recx->rx_nr - 1;
+}
+
+static inline int
+delete_evt_entry(struct vos_obj_iter *oiter, const vos_iter_entry_t *entry,
+		 const char *desc)
+{
+	struct evt_rect	rect;
+	int		rc;
+
+	recx2ext(&entry->ie_orig_recx, &rect.rc_ex);
+	rect.rc_epc = entry->ie_epoch;
+	rect.rc_minor_epc = entry->ie_minor_epc;
+
+	rc = evt_delete(oiter->it_hdl, &rect, NULL);
+	if (rc)
+		D_ERROR("Delete %s EV entry "DF_RECT" error: "DF_RC"\n",
+			desc, DP_RECT(&rect), DP_RC(rc));
+	return rc;
+}
+
+static int
+delete_removal(struct agg_merge_window *mw, struct vos_obj_iter *oiter, struct agg_rmv_ent *rm_ent)
+{
+	int			 rc = 0;
+
+	D_ASSERT(d_list_empty(&rm_ent->re_contained));
+	D_DEBUG(DB_EPC, "Removing physical removal record: "DF_RECT"\n", DP_RECT(&rm_ent->re_rect));
+	rc = evt_delete(oiter->it_hdl, &rm_ent->re_rect, NULL);
+	if (rc) {
+		D_ERROR("Remove "DF_RECT" error: "DF_RC"\n", DP_RECT(&rm_ent->re_rect), DP_RC(rc));
+		return rc;
+	}
+
+	d_list_del(&rm_ent->re_phy_link);
+	d_list_del(&rm_ent->re_link);
+	if (!rm_ent->re_child) {
+		D_ASSERT(mw->mw_rmv_cnt > 0);
+		mw->mw_rmv_cnt--;
+	}
+	D_FREE(rm_ent);
+
+	return 0;
+}
+
+static int
 enqueue_rmv_ent(struct agg_merge_window *mw, const struct evt_extent *ext,
-		const vos_iter_entry_t *entry)
+		const vos_iter_entry_t *entry, struct vos_obj_iter *oiter)
 {
 	struct agg_rmv_ent	*rm_ent, *rm_ent2, *rm_ent3;
 	d_list_t		*list = &mw->mw_rmv_ents;
+	int			 rc;
+
+	/** Remove any past removal records that have no remaining physical references */
+	d_list_for_each_entry_safe(rm_ent, rm_ent2, &mw->mw_phy_rmv_ents, re_phy_link) {
+		if (rm_ent->re_phy_count != 0)
+			continue;
+
+		if (rm_ent->re_rect.rc_ex.ex_hi >= ext->ex_lo)
+			continue;
+
+		rc = delete_removal(mw, oiter, rm_ent);
+
+		if (rc != 0)
+			return rc;
+	}
 
 	rm_ent = allocate_rmv_ent(ext, entry->ie_epoch, entry->ie_minor_epc);
 	if (rm_ent == NULL)
-		return NULL;
+		return -DER_NOMEM;
 
 	d_list_for_each_entry_reverse(rm_ent2, &mw->mw_rmv_ents, re_link) {
 		if (rm_ent->re_rect.rc_epc != rm_ent2->re_rect.rc_epc)
@@ -565,28 +638,40 @@ enqueue_rmv_ent(struct agg_merge_window *mw, const struct evt_extent *ext,
 		D_DEBUG(DB_EPC, "Removal record "DF_RECT" is contiguous with "DF_RECT"\n",
 			DP_RECT(&rm_ent->re_rect), DP_RECT(&rm_ent2->re_rect));
 
-		if (d_list_empty(&rm_ent2->re_contained)) {
+		if (!rm_ent2->re_aggregate) {
+			D_ASSERT(d_list_empty(&rm_ent2->re_contained));
 			/* Duplicate the entry */
 			rm_ent3 = allocate_rmv_ent(&rm_ent2->re_rect.rc_ex, rm_ent2->re_rect.rc_epc,
 						   rm_ent2->re_rect.rc_minor_epc);
 			if (rm_ent3 == NULL) {
 				D_FREE(rm_ent);
-				return NULL;
+				return -DER_NOMEM;
 			}
 			D_DEBUG(DB_EPC, "Removal record "DF_RECT" duplicated\n",
 				DP_RECT(&rm_ent2->re_rect));
-			d_list_add_tail(&rm_ent3->re_link, &rm_ent2->re_contained);
+			/** Replace the existing entry in the list with the duplicate */
+			d_list_add(&rm_ent3->re_link, &rm_ent2->re_link);
+			d_list_del(&rm_ent2->re_link);
+			/** Add existing entry to duplicate contained list */
+			d_list_add_tail(&rm_ent2->re_link, &rm_ent3->re_contained);
+			/** Subsequent modification should be on the duplicate */
+			rm_ent3->re_aggregate = 1;
+			rm_ent2->re_child = 1;
+			rm_ent2 = rm_ent3;
 		}
 
 		rm_ent2->re_rect.rc_ex.ex_hi = ext->ex_hi;
 		list = &rm_ent2->re_contained;
+		rm_ent->re_child = 1;
 		goto enqueue;
 	}
 	mw->mw_rmv_cnt++;
 enqueue:
 	d_list_add_tail(&rm_ent->re_link, list);
+	/** Keep a list of just the physical records */
+	d_list_add_tail(&rm_ent->re_phy_link, &mw->mw_phy_rmv_ents);
 
-	return rm_ent;
+	return 0;
 }
 
 static inline bool
@@ -1248,23 +1333,28 @@ process_removals(struct agg_merge_window *mw, struct vos_obj_iter *oiter, d_list
 {
 	struct agg_rmv_ent	*rm_ent, *rm_tmp;
 	struct evt_rect		 rect;
-	int			 rc;
+	int			 rc = 0;
 
 	d_list_for_each_entry_safe(rm_ent, rm_tmp, head, re_link) {
 		rect = rm_ent->re_rect;
 
-		if (!last && rect.rc_ex.ex_hi > mw->mw_ext.ex_hi)
+		if (!last && (rm_ent->re_phy_count != 0 || rect.rc_ex.ex_hi > mw->mw_ext.ex_hi))
 			continue;
 
-		if (d_list_empty(&rm_ent->re_contained)) {
+		if (!rm_ent->re_aggregate) {
+			D_ASSERT(d_list_empty(&rm_ent->re_contained));
 			D_DEBUG(DB_EPC, "Removing physical removal record: "DF_RECT"\n",
 				DP_RECT(&rm_ent->re_rect));
 			rc = evt_delete(oiter->it_hdl, &rect, NULL);
-		} else {
+			d_list_del(&rm_ent->re_phy_link);
+		} else if (!d_list_empty(&rm_ent->re_contained)) {
 			D_ASSERT(top);
 			D_DEBUG(DB_EPC, "Removing logical removal record: "DF_RECT"\n",
 				DP_RECT(&rm_ent->re_rect));
 			rc = process_removals(mw, oiter, &rm_ent->re_contained, last, false);
+
+			if (!d_list_empty(&rm_ent->re_contained))
+				continue;
 		}
 		if (rc) {
 			D_ERROR("Remove "DF_RECT" error: "DF_RC"\n",
@@ -1273,14 +1363,34 @@ process_removals(struct agg_merge_window *mw, struct vos_obj_iter *oiter, d_list
 		}
 
 		d_list_del(&rm_ent->re_link);
-		D_FREE(rm_ent);
 		if (top) {
 			D_ASSERT(mw->mw_rmv_cnt > 0);
 			mw->mw_rmv_cnt--;
 		}
+		D_FREE(rm_ent);
 	}
 
 	return 0;
+}
+
+static void
+unmark_removals(struct agg_merge_window *mw, const struct agg_phy_ent *phy_ent)
+{
+	struct agg_rmv_ent	*rmv_ent;
+
+	d_list_for_each_entry_reverse(rmv_ent, &mw->mw_phy_rmv_ents, re_phy_link) {
+		if (rmv_ent->re_rect.rc_epc != phy_ent->pe_rect.rc_epc)
+			continue;
+
+		if (rmv_ent->re_rect.rc_ex.ex_hi < phy_ent->pe_rect.rc_ex.ex_lo)
+			break;
+
+		if (rmv_ent->re_rect.rc_ex.ex_lo > phy_ent->pe_rect.rc_ex.ex_hi)
+			continue;
+
+		D_ASSERT(rmv_ent->re_phy_count > 0);
+		rmv_ent->re_phy_count--;
+	}
 }
 
 static int
@@ -1346,7 +1456,8 @@ insert_segments(daos_handle_t ih, struct agg_merge_window *mw,
 		if (phy_ent->pe_off != 0)
 			rect.rc_ex.ex_lo += phy_ent->pe_off;
 
-		D_ASSERT(rect.rc_ex.ex_lo <= rect.rc_ex.ex_hi);
+		D_ASSERTF(rect.rc_ex.ex_lo <= rect.rc_ex.ex_hi, "phy_ent "DF_RECT" off="DF_X64"\n",
+			  DP_RECT(&phy_ent->pe_rect), phy_ent->pe_off);
 		D_ASSERT(phy_ent->pe_remove || rect.rc_ex.ex_lo <= mw->mw_ext.ex_hi);
 
 		/*
@@ -1372,6 +1483,7 @@ insert_segments(daos_handle_t ih, struct agg_merge_window *mw,
 		if (rect.rc_ex.ex_hi <= mw->mw_ext.ex_hi ||
 		    phy_ent->pe_remove) {
 			d_list_del(&phy_ent->pe_link);
+			unmark_removals(mw, phy_ent);
 			D_FREE(phy_ent);
 			D_ASSERT(mw->mw_phy_cnt > 0);
 			mw->mw_phy_cnt--;
@@ -1458,6 +1570,7 @@ clear_merge_window(struct agg_merge_window *mw)
 	mw->mw_lgc_cnt = 0;
 	d_list_for_each_entry_safe(phy_ent, tmp, &mw->mw_phy_ents, pe_link) {
 		d_list_del(&phy_ent->pe_link);
+		unmark_removals(mw, phy_ent);
 		D_FREE(phy_ent);
 	}
 	mw->mw_phy_cnt = 0;
@@ -1476,8 +1589,10 @@ free_removal_records(struct agg_merge_window *mw, d_list_t *head, bool top)
 		}
 		D_FREE(rm_ent);
 	}
-	if (top)
+	if (top) {
 		mw->mw_rmv_cnt = 0;
+		D_INIT_LIST_HEAD(&mw->mw_phy_rmv_ents);
+	}
 }
 
 static bool
@@ -1693,14 +1808,6 @@ enqueue_lgc_ent(struct agg_merge_window *mw, struct evt_extent *lgc_ext,
 	return 0;
 }
 
-static inline void
-recx2ext(daos_recx_t *recx, struct evt_extent *ext)
-{
-	D_ASSERT(recx->rx_nr > 0);
-	ext->ex_lo = recx->rx_idx;
-	ext->ex_hi = recx->rx_idx + recx->rx_nr - 1;
-}
-
 static void
 close_merge_window(struct agg_merge_window *mw, int rc)
 {
@@ -1767,22 +1874,32 @@ lookup_phy_ent(struct agg_merge_window *mw, const struct evt_extent *phy_ext,
 	return NULL;
 }
 
-static inline int
-delete_evt_entry(struct vos_obj_iter *oiter, vos_iter_entry_t *entry,
-		 unsigned int *acts, const char *desc)
+static void
+mark_removals(struct agg_merge_window *mw, struct agg_phy_ent *phy_ent,
+	      const struct evt_extent *lgc_ext)
 {
-	struct evt_rect	rect;
-	int		rc;
+	struct agg_rmv_ent	*rmv_ent;
 
-	recx2ext(&entry->ie_orig_recx, &rect.rc_ex);
-	rect.rc_epc = entry->ie_epoch;
-	rect.rc_minor_epc = entry->ie_minor_epc;
+	if (d_list_empty(&mw->mw_phy_rmv_ents))
+		return;
 
-	rc = evt_delete(oiter->it_hdl, &rect, NULL);
-	if (rc)
-		D_ERROR("Delete %s EV entry "DF_RECT" error: "DF_RC"\n",
-			desc, DP_RECT(&rect), DP_RC(rc));
-	return rc;
+	/* This is not a real entry but it doesn't matter.   It will be used to calculate
+	 * where to continue if the physical record has been processed before to ensure
+	 * we never refcount the same record more than once.
+	 */
+	rmv_ent = d_list_entry(&mw->mw_phy_rmv_ents, struct agg_rmv_ent, re_phy_link);
+
+	d_list_for_each_entry_continue(rmv_ent, &mw->mw_phy_rmv_ents, re_phy_link) {
+		if (rmv_ent->re_rect.rc_epc != phy_ent->pe_rect.rc_epc)
+			continue;
+
+		if (rmv_ent->re_rect.rc_ex.ex_hi < lgc_ext->ex_lo)
+			continue;
+
+		/** We should be processing extents in order so this should mean there is overlap */
+		D_ASSERT(rmv_ent->re_rect.rc_ex.ex_lo <= lgc_ext->ex_lo);
+		rmv_ent->re_phy_count++;
+	}
 }
 
 static int
@@ -1813,7 +1930,7 @@ join_merge_window(daos_handle_t ih, struct agg_merge_window *mw,
 		D_DEBUG(DB_EPC, "Delete aborted EV entry "DF_EXT"@"DF_X64"\n",
 			DP_EXT(&phy_ext), entry->ie_epoch);
 
-		rc = delete_evt_entry(oiter, entry, acts, "aborted");
+		rc = delete_evt_entry(oiter, entry, "aborted");
 		if (rc)
 			return rc;
 		/** We just need an alternative error code.  Use -DER_TX_RESTART
@@ -1850,19 +1967,16 @@ join_merge_window(daos_handle_t ih, struct agg_merge_window *mw,
 			  DP_EXT(&lgc_ext), DP_EXT(&phy_ext));
 		D_ASSERT(entry->ie_vis_flags & VOS_VIS_FLAG_COVERED);
 
-		rc = delete_evt_entry(oiter, entry, acts, "covered");
+		rc = delete_evt_entry(oiter, entry, "covered");
 		if (rc)
 			return rc;
 		goto out;
 	}
 
 	if (remove) {
-		struct agg_rmv_ent	*rm_ent;
-
 		/* Enqueue removal record */
-		rm_ent = enqueue_rmv_ent(mw, &phy_ext, entry);
-		if (rm_ent == NULL) {
-			rc = -DER_NOMEM;
+		rc = enqueue_rmv_ent(mw, &phy_ext, entry, oiter);
+		if (rc != 0) {
 			D_ERROR("Enqueue rm_ent win:"DF_EXT", ent:"DF_EXT" "
 				"error: "DF_RC"\n", DP_EXT(&mw->mw_ext),
 				DP_EXT(&phy_ext), DP_RC(rc));
@@ -1919,6 +2033,8 @@ join_merge_window(daos_handle_t ih, struct agg_merge_window *mw,
 	} else {
 		/* Fully covered physical entry must have been deleted */
 		D_ASSERT(partial);
+		/* refcount any removal records covering this extent */
+		mark_removals(mw, phy_ent, &lgc_ext);
 	}
 out:
 	/* Flush & close window on last entry */
@@ -1995,7 +2111,7 @@ vos_agg_ev(daos_handle_t ih, vos_iter_entry_t *entry,
 		 * logical entry
 		 */
 		if (phy_ext.ex_lo == lgc_ext.ex_lo)
-			rc = delete_evt_entry(oiter, entry, acts, "discarded");
+			rc = delete_evt_entry(oiter, entry, "discarded");
 
 		/*
 		 * Sorted iteration doesn't support tree empty check, so we
@@ -2014,10 +2130,10 @@ vos_agg_ev(daos_handle_t ih, vos_iter_entry_t *entry,
 
 	/* Aggregation */
 	D_DEBUG(DB_EPC, "oid:"DF_UOID", lgc_ext:"DF_EXT", "
-		"phy_ext:"DF_EXT", epoch:"DF_X64".%d, flags: %x\n",
+		"phy_ext:"DF_EXT", epoch:"DF_X64".%d, flags: %x(%c)\n",
 		DP_UOID(agg_param->ap_oid), DP_EXT(&lgc_ext),
 		DP_EXT(&phy_ext), entry->ie_epoch, entry->ie_minor_epc,
-		entry->ie_vis_flags);
+		entry->ie_vis_flags, evt_vis2dbg(entry->ie_vis_flags));
 
 	rc = set_window_size(mw, entry->ie_rsize);
 	if (rc)
@@ -2356,6 +2472,7 @@ merge_window_init(struct agg_merge_window *mw, void (*func)(void *))
 
 	memset(mw, 0, sizeof(*mw));
 	D_INIT_LIST_HEAD(&mw->mw_phy_ents);
+	D_INIT_LIST_HEAD(&mw->mw_phy_rmv_ents);
 	D_INIT_LIST_HEAD(&mw->mw_rmv_ents);
 	D_INIT_LIST_HEAD(&io->ic_nvme_exts);
 	io->ic_csum_recalc_func = func;


### PR DESCRIPTION
If the EC range has many contiguous small updates, it can result
in huge numbers of removal records being cached by aggregation
in a single merge window. This change does the following

1. Modifies evt_remove_all to first remove extents already covered
   by removal records before marking new ones.  This fixes some bugs
   where one can get overlapping extents at the same epoch.  This
   leverages a new mode of evt_ent_array_sort that reuses the existing
   code to mark removed records as covered.
2. Adds physical reference count on removal records and deletes them
   as soon as possible, particularly ones that cause the physical
   extent to be deleted immediately.
3. Fixes various minor bugs

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>