### PR TITLE
MPICH3_FIX Build: Quick fix for mpich test fails

### DIFF
--- a/ci/provisioning/post_provision_config_nodes_EL_7.sh
+++ b/ci/provisioning/post_provision_config_nodes_EL_7.sh
@@ -3,7 +3,7 @@
 REPOS_DIR=/etc/yum.repos.d
 DISTRO_NAME=centos7
 LSB_RELEASE=redhat-lsb-core
-EXCLUDE_UPGRADE=fuse,mercury,daos,daos-\*
+EXCLUDE_UPGRADE=fuse,mercury,mpich,daos,daos-\*
 
 timeout_yum() {
     local timeout="$1"


### PR DESCRIPTION
Stop updating mpipch for el7 tests.

Signed-off-by: John E Malmberg <john.e.malmberg@intel.com>