### PR TITLE
DAOS-8051-test: Enable erasurecode/ed_cell_size_property after bug fixed

### DIFF
--- a/src/tests/ftest/erasurecode/cell_size_property.py
+++ b/src/tests/ftest/erasurecode/cell_size_property.py
@@ -8,7 +8,6 @@ from itertools import product
 
 from ior_test_base import IorTestBase
 from general_utils import human_to_bytes
-from apricot import skipForTicket
 
 class EcodCellSizeProperty(IorTestBase):
     # pylint: disable=too-many-ancestors
@@ -38,7 +37,6 @@ class EcodCellSizeProperty(IorTestBase):
         cont_cell_size = (human_to_bytes(cell_size.replace(" ", "")))
         self.assertEqual(expected_size, cont_cell_size)
 
-    @skipForTicket("DAOS-8051")
     def test_ec_pool_property(self):
         """Jira ID: DAOS-7321.
 


### PR DESCRIPTION
DAOS-8051-test: Enable erasurecode/ed_cell_size_property after bug fixed.

Test-tag: pr ec_cell_property
Signed-off-by: Ding Ho ding-hwa.ho@intel.com