### PR TITLE
DAOS-6654-test: Unable daos_vol/bigio.py after bug fixed.

### DIFF
--- a/src/tests/ftest/daos_vol/bigio.py
+++ b/src/tests/ftest/daos_vol/bigio.py
@@ -15,11 +15,6 @@ class DaosVol(VolTestBase):
     :avocado: recursive
     """
 
-    # Test variants that should be skipped
-    CANCEL_FOR_TICKET = [
-        ["DAOS-6654", "testname", "h5_partest_t_bigio"],
-    ]
-
     def test_daos_vol_bigio(self):
         """Jira ID: DAOS-3656.
 


### PR DESCRIPTION
DAOS-6654-test: Unable daos_vol/bigio.py after bug fixed.
Test-tag: pr volbigio
Signed-off-by: Ding Ho ding-hwa.ho@intel.com