### PR TITLE
DAOS-8510 pool,container: reduce rate of client RPC retries

### DIFF
--- a/src/container/cli.c
+++ b/src/container/cli.c
@@ -66,9 +66,17 @@ cont_rsvc_client_complete_rpc(struct dc_pool *pool, const crt_endpoint_t *ep,
 	rc = rsvc_client_complete_rpc(&pool->dp_client, ep, rc_crt, out->co_rc,
 				      &out->co_hint);
 	D_MUTEX_UNLOCK(&pool->dp_client_lock);
+
 	if (rc == RSVC_CLIENT_RECHOOSE ||
 	    (rc == RSVC_CLIENT_PROCEED && daos_rpc_retryable_rc(out->co_rc))) {
-		rc = tse_task_reinit(task);
+		uint64_t delay = 0;
+
+		if (daos_rpc_retryable_rc(out->co_rc) || daos_rpc_retryable_rc(rc_crt)) {
+			D_DEBUG(DF_DSMC, "delay reinit RPC by 1 sec\n");
+			delay = 1e6; /* 1 s */
+		}
+
+		rc = tse_task_reinit_with_delay(task, delay);
 		if (rc != 0)
 			return rc;
 		return RSVC_CLIENT_RECHOOSE;


### PR DESCRIPTION
Before this change, when a libdaos client attempts to contact a
pool/container service that is undergoing a leadership transition
(new raft election due to loss of a replica), upon retryable RPC
errors (e.g., -DER_UNREACH when contacting a lost replica), a retry is
immediately attempted. This results in thousands of ERR messages in the
client's debug log while the election takes place over tens of seconds
of elapsed time. If the logging is not directed to a file, all of this
output this appears at a very high rate in the user's terminal.

With this change, upon a "retryable" RPC errorr (e.g., -DER_UNREACH)
the RPC retry is scheduled with a 1 second delay, to greatly reduce the
amount of associated logging.

Not addressed in this change is a potential need for utilities (e.g.,
the daos command) to finally time out after some lengthy period of
retries that never succeed (e.g., minutes). This scenario can occur if
half or more of the pool/container service replicas are lost on the
server side, and client requests may never get fulfilled as a result.

Signed-off-by: Kenneth Cain <kenneth.c.cain@intel.com>