### PR TITLE
DAOS-8609 engine: increase the stack size for dsc_progress

### DIFF
--- a/src/engine/srv_cli.c
+++ b/src/engine/srv_cli.c
@@ -48,13 +48,11 @@ dsc_progress_start(void)
 	if (dx->dx_dsc_started)
 		return 0;
 
-	rc = ABT_thread_create(dx->dx_pools[DSS_POOL_GENERIC], dsc_progress,
-			       dx, ABT_THREAD_ATTR_NULL, NULL);
-	if (rc != ABT_SUCCESS)
-		return dss_abterr2der(rc);
-
-	dx->dx_dsc_started = true;
-	return 0;
+	/* NB: EC recovery will be done inside this ULT, so let's use DEEP stack size */
+	rc = dss_ult_create(dsc_progress, dx, DSS_XS_SELF, 0, DSS_DEEP_STACK_SZ, NULL);
+	if (rc == 0)
+		dx->dx_dsc_started = true;
+	return rc;
 }
 
 static int

--- a/src/pool/srv_target.c
+++ b/src/pool/srv_target.c
@@ -563,7 +563,7 @@ ds_pool_start_ec_eph_query_ult(struct ds_pool *pool)
 		return 0;
 
 	rc = dss_ult_create(tgt_ec_eph_query_ult, pool, DSS_XS_SYS, 0,
-			    131072, &ec_eph_query_ult);
+			    DSS_DEEP_STACK_SZ, &ec_eph_query_ult);
 	if (rc != 0) {
 		D_ERROR(DF_UUID": failed create ec eph equery ult: %d\n",
 			DP_UUID(pool->sp_uuid), rc);


### PR DESCRIPTION
Since EC degraded fetch and recovery might be done inside
dsc_progress ULT, so let's increase the stack size to 64KB.

Use DEEP stack size(64KB) to EC query ULT.
Signed-off-by: Di Wang <di.wang@intel.com>