### PR TITLE
DAOS-8400-test enable fullpoolcontcreate test

### DIFF
--- a/src/tests/ftest/container/full_pool_container_create.py
+++ b/src/tests/ftest/container/full_pool_container_create.py
@@ -15,9 +15,6 @@ class FullPoolContainerCreate(TestWithServers):
     :avocado: recursive
     """
 
-    # Cancel test for small pool size due to DAOS-8400
-    CANCEL_FOR_TICKET = [["DAOS-8400", "size", 134217728]]
-
     def test_no_space_cont_create(self):
         """JIRA ID: DAOS-1169 DAOS-7374
 


### PR DESCRIPTION
DAOS-8400-test enable fullpoolcontcreate test
Test-tag: pr fullpoolcontcreate
Signed-off-by: Ding Ho ding-hwa.ho@intel.com