### PR TITLE
DAOS-8715 pydaos: Updated documentation in source file

### DIFF
--- a/src/client/pydaos/pydaos_core.py
+++ b/src/client/pydaos/pydaos_core.py
@@ -42,12 +42,12 @@ class DCont():
 
     Attributes
     ----------
-    path : string
-        Path for container representation in unified namespace
     pool : string
         Pool label or UUID string
     cont : string
         Container label or UUID string
+    path : string
+        Path for container representation in unified namespace
 
     Methods
     -------


### PR DESCRIPTION
Documentation in pydaos_core.py was confusing for
DCont constructor.

Skip-build: true
Skip-test: true

Signed-off-by: Eduardo Berrocal <eduardo.berrocal@intel.com>