### PR TITLE
DAOS-3672 tests: Adding the pool/management.py test

### DIFF
--- a/src/tests/ftest/pool/management.py
+++ b/src/tests/ftest/pool/management.py
@@ -1,0 +1,77 @@
+#!/usr/bin/python3
+"""
+(C) Copyright 2021 Intel Corporation.
+
+SPDX-License-Identifier: BSD-2-Clause-Patent
+"""
+from apricot import TestWithServers
+from ior_utils import Ior
+
+
+class TestPoolManagement(TestWithServers):
+    """[summary]."""
+
+    def setUp(self):
+        """Set up each test case."""
+        super().setUp()
+        self.daos = self.get_daos_command()
+        self.pool = []
+        self.container = []
+
+    def verify_pool(self, pool_namespaces):
+        """[summary]
+
+        Args:
+            pool_namespaces ([type]): [description]
+        """
+        for namespace in pool_namespaces:
+            # Create a new pool
+            self.pool.append(self.get_pool(namespace=namespace, connect=False))
+
+            # Create a container for each new pool
+            self.container.append(self.get_container(self.pool[-1]))
+
+            # Run dmg/daos pool query
+            self.pool[-1].query(self.daos)
+
+            # Verify the pool sizes
+
+    def test_pool_management(self):
+        """JIRA DAOS-3672.
+
+        Test Description:
+            Verify pool space usage via cmd line tool.
+
+        :avocado: tags=all,daily_regression
+        :avocado: tags=vm,small
+        :avocado: tags=pool,management
+        :avocado: tags=test_pool_management
+        """
+        self.job_manager.assign_hosts(
+            self.hostlist_clients, self.workdir, self.hostfile_clients_slots)
+
+        # Create and verify a single pool on a single server
+        self.verify_pool(["/run/pool_0_0/*"])
+
+        # Use IOR to fill containers to varying degrees of fullness, verify storage listing
+        ior = Ior(
+            self.job_manager, self.server_managers[0].group, self.pool[0], namespace="/run/ior_0/*")
+        ior.get_params(self)
+        ior.run(self.server_managers[0], self.client_log)
+
+        # Create and verify multiple pools on a single server
+        self.verify_pool(["/run/pool_1_{}/*".format(num) for num in range(3)])
+
+        # Fill containers to varying degrees of fullness, verify storage listing for all pools
+
+        # Create and verify a single pool that spans many servers
+        self.verify_pool(["/run/pool_2_0/*"])
+
+        # Use IOR to fill containers to varying degrees of fullness, verify storage listing
+
+        # Create and verify multiple pools that span many servers
+        self.verify_pool(["/run/pool_3_{}/*".format(num) for num in range(2)])
+
+        # Use IOR to fill containers to varying degrees of fullness, verify storage listing
+
+        # Fail one of the servers for a pool spanning many servers. Verify the storage listing.

--- a/src/tests/ftest/pool/management.yaml
+++ b/src/tests/ftest/pool/management.yaml
@@ -1,0 +1,72 @@
+hosts:
+  test_servers:
+    - server-A
+    - server-B
+    - server-C
+    - server-D
+  test_clients:
+    - client-E
+    - client-F
+    - client-G
+    - client-H
+timeout: 200
+server_config:
+  name: daos_server
+  servers:
+    bdev_class: nvme
+    bdev_list: ["0000:81:00.0","0000:da:00.0"]
+    scm_class: dcpm
+    scm_list: ["/dev/pmem0"]
+job_manager_class_name: Orterun
+pool_0_0:
+  control_method: dmg
+  name: daos_server
+  scm_size: 1T
+  nvme_size: 1T
+  target_list: [0]
+pool_1_0:
+  control_method: dmg
+  name: daos_server
+  scm_size: 800G
+  nvme_size: 800G
+  target_list: [1]
+pool_1_1:
+  control_method: dmg
+  name: daos_server
+  scm_size: 100G
+  nvme_size: 100G
+  target_list: [1]
+pool_1_2:
+  control_method: dmg
+  name: daos_server
+  scm_size: 300G
+  nvme_size: 300G
+  target_list: [1]
+pool_2_0:
+  control_method: dmg
+  name: daos_server
+  scm_size: 150G
+  nvme_size: 150G
+  target_list: [2, 3]
+pool_3_0:
+  control_method: dmg
+  name: daos_server
+  scm_size: 50G
+  nvme_size: 50G
+  target_list: [0, 1, 2, 3]
+pool_3_1:
+  control_method: dmg
+  name: daos_server
+  scm_size: 60G
+  nvme_size: 60G
+  target_list: [0, 1, 2, 3]
+container:
+  control_method: daos
+  type: POSIX
+ior_0:
+  api: DFS
+  transfer_size: '1M'
+  block_size: '8G'
+  flags: "-v -w -W -r -R -k"
+  repetitions: 1
+  dfs_destroy: False

--- a/src/tests/ftest/util/dfuse_utils.py
+++ b/src/tests/ftest/util/dfuse_utils.py
@@ -79,19 +79,30 @@ class DfuseCommand(ExecutableCommand):
 class Dfuse(DfuseCommand):
     """Class defining an object of type DfuseCommand."""
 
-    def __init__(self, hosts, tmp):
+    def __init__(self, hosts, tmp=None):
         """Create a dfuse object."""
         super().__init__("/run/dfuse/*", "dfuse")
 
         # set params
         self.hosts = hosts
-        self.tmp = tmp
+        self.tmp = tmp      
         self.running_hosts = NodeSet()
+        self._started = False
 
     def __del__(self):
         """Destruct the object."""
         if self.running_hosts:
             self.log.error('Dfuse object deleted without shutting down')
+
+    @property
+    def started(self):
+        """Get whether or not dfuse has been started.
+
+        Returns:
+            bool: whether or not dfuse has been started
+
+        """
+        return self._started
 
     def check_mount_state(self, nodes=None):
         """Check the dfuse mount point mounted state on the hosts.
@@ -331,6 +342,43 @@ class Dfuse(DfuseCommand):
                 raise CommandFailure("dfuse not running")
         return status
 
+    def start(self, server_manager, log_file, pool=None, container=None):
+        """Start dfuse in a test.
+
+        Be sure to call Dfuse.get_params(test) before this method.
+
+        Args:
+            server_manager (DaosServerManager): server manager object to use to
+                obtain the ofi and cart environmental variable settings from the
+                server yaml file
+            log_file (str): name of the log file to combine with the
+                DAOS_TEST_LOG_DIR path with which to assign D_LOG_FILE
+            pool (TestPool, optional): pool to use with Dfuse. Defaults to None.
+            container (TestContainer, optional): container to use with Dfuse.
+                Defaults to None.
+
+        Raises:
+            CommandFailure: if there was a failure starting dfuse.
+
+        """
+        # Update dfuse params
+        if pool:
+            self.set_dfuse_params(pool)
+        if container:
+            self.set_dfuse_cont_param(container)
+        self.set_dfuse_exports(server_manager, log_file)
+
+        try:
+            # Start dfuse
+            self.run()
+
+            # Mark dfuse as successfully started
+            self._started = True
+
+        except CommandFailure as error:
+            raise CommandFailure(
+                "Dfuse command failed on {}".format(self.hosts)) from error
+
     def stop(self):
         """Stop dfuse.
 
@@ -399,3 +447,6 @@ class Dfuse(DfuseCommand):
 
         else:
             self.log.info("No hosts running dfuse - nothing to stop")
+
+        # Mark dfuse as successfully stopped
+        self._started = False

--- a/src/tests/ftest/util/ior_utils.py
+++ b/src/tests/ftest/util/ior_utils.py
@@ -5,15 +5,16 @@
 SPDX-License-Identifier: BSD-2-Clause-Patent
 """
 
-
+import os
 import re
 import uuid
 import time
 from enum import IntEnum
 
-from command_utils_base import CommandFailure, FormattedParameter
+from command_utils_base import CommandFailure, FormattedParameter, BasicParameter
 from command_utils import ExecutableCommand
-from general_utils import get_subprocess_stdout
+from dfuse_utils import Dfuse
+from general_utils import get_subprocess_stdout, get_random_string
 
 
 class IorCommand(ExecutableCommand):
@@ -34,9 +35,15 @@ class IorCommand(ExecutableCommand):
         >>> mpirun.run()
     """
 
-    def __init__(self):
-        """Create an IorCommand object."""
-        super().__init__("/run/ior/*", "ior")
+    def __init__(self, namespace=None):
+        """Create an IorCommand object.
+
+        Args:
+            namespace (str, optional): yaml namespace (path to parameters). Defaults to None.
+        """
+        if namespace is None:
+            namespace = "/run/ior/*"
+        super().__init__(namespace, "ior")
 
         # Flags
         self.flags = FormattedParameter("{}")
@@ -259,7 +266,7 @@ class IorCommand(ExecutableCommand):
         """
         ior_metric_summary = "Summary of all tests:"
         messages = cmdresult.stdout_text.splitlines()
-        # Get the index whre the summary starts and add one to
+        # Get the index where the summary starts and add one to
         # get to the header.
         idx = messages.index(ior_metric_summary)
         # idx + 1 is header.
@@ -381,3 +388,254 @@ class IorMetrics(IntEnum):
     aggs_MiB = 24
     API = 25
     RefNum = 26
+
+
+class Ior(IorCommand):
+    """Run ior in parallel on multiple hosts using a JobManager class.
+
+    Steps:
+        1) Define a TestPool object and optionally a TestContainer object
+        2) Define a JobManager object, e.g. Mpirun or Orterun, and call its assign_hosts() method to
+           assign which hosts will run ior (also creates the hostfile)
+        3) Initialize an Ior object with the JobManager, TestPool, and TestContainer objects
+        4) Call Ior.get_params(Test)
+        5) Call Ior.run()
+
+    For running ior on multiple pools, multiple Ior objects can be created.
+
+    For running ior threads the Ior.run() method can be used with the ThreadManager class.
+    """
+
+    def __init__(self, job_manager, group, pool, container=None, namespace=None):
+        """Create an Ior object.
+
+        Args:
+            job_manager (JobManager): object to manage running the ior job
+            group (str): DAOS server group name
+            pool (TestPool): DAOS pool to test.
+            container (TestContainer, optional): DAOS container to test. Defaults to None.
+            namespace (str, optional): yaml namespace (path to parameters). Defaults to None.
+        """
+        super().__init__(namespace)
+        self.job_manager = job_manager
+        self.dfuse = Dfuse(self.job_manager.hosts)
+        self.group = group
+        self.pool = pool
+        self.container = container
+
+        self._display = BasicParameter(None, True, yaml_key="display")
+        self._display_space = BasicParameter(None, True, yaml_key="display_space")
+        self._plugin_path = BasicParameter(None, yaml_key="plugin_path")
+        self._intercept = BasicParameter(None, yaml_key="intercept")
+        self._fail_on_warning = BasicParameter(None, False, yaml_key="fail_on_warning")
+
+    @property
+    def display(self):
+        """Get the option to display updated paramters."""
+        return self._display.value
+
+    @display.setter
+    def display(self, value):
+        """Set the option to display updated paramters."""
+        if isinstance(value, bool):
+            self.update_value(self._display, value, "display")
+
+    @property
+    def display_space(self):
+        """Get the option to display pool space before and after running ior."""
+        return self._display_space.value
+
+    @display_space.setter
+    def display_space(self, value):
+        """Set the option to display pool space before and after running ior."""
+        if isinstance(value, bool):
+            self.update_value(self._display_space, value, "display_space")
+
+    @property
+    def plugin_path(self):
+        """Get the plugin path option."""
+        return self._plugin_path.value
+
+    @plugin_path.setter
+    def plugin_path(self, value):
+        """Set the plugin path option."""
+        self.update_value(self._plugin_path, value, "plugin_path")
+
+    @property
+    def intercept(self):
+        """Get the intercept library option."""
+        return self._intercept.value
+
+    @intercept.setter
+    def intercept(self, value):
+        """Set the intercept library option."""
+        self.update_value(self._intercept, value, "intercept")
+
+    @property
+    def fail_on_warning(self):
+        """Get the option to fail the ior command if warnings are found in the output."""
+        return self._fail_on_warning.value
+
+    @fail_on_warning.setter
+    def fail_on_warning(self, value):
+        """Set the option to fail the ior command if warnings are found in the output."""
+        if isinstance(value, bool):
+            self.update_value(self._fail_on_warning, value, "fail_on_warning")
+
+    def update_value(self, parameter, value, name):
+        """Update a BasicParameter object's value and optionally log the update.
+
+        Args:
+            attribute (BasicParameter): object whose value is being updated
+            value (object): the updated value to set
+            name (str): the name of the object being updated
+        """
+        parameter.update(value, name if self.display.value else None)
+
+    def get_str_param_names(self):
+        """Get a sorted list of the names of the command attributes.
+
+        Returns:
+            list: a list of class attribute names used to define parameters for the command.
+
+        """
+        # Get only the parameter names that apply to the actual ior command string
+        return self.get_attribute_names(FormattedParameter)
+
+    def get_params(self, test):
+        """Get values for the IOR command parameters from the test yaml file.
+
+        Args:
+            test (Test): avocado Test object
+        """
+        super().get_params(test)
+        self.dfuse.get_params(test)
+        self.set_daos_params(self.group, self.pool, self._get_container_uuid(), self.display)
+
+        # Ensure a test file is set
+        if self.test_file.value is None:
+            self.update_value(self.test_file, "daos:testFile", "test_file")
+
+    def display_pool_space(self):
+        """Display the space information for the pool.
+
+        If the TestPool object has a DmgCommand object assigned, also display
+        the free pool space per target.
+        """
+        if self.pool and self.display_space:
+            self.pool.display_pool_daos_space()
+            if self.pool.dmg:
+                self.pool.set_query_data()
+
+    def _get_container_uuid(self):
+        """Get the container UUID.
+
+        Returns:
+            str: the container UUID if defined; otherwise None
+
+        """
+        uuid = None
+        if self.container:
+            uuid = self.container.uuid
+        return uuid
+
+    def _setup_test_file(self, server_manager, log_file, test_file_suffix=None):
+        """Configure the ior testfile argument.
+
+        This method will also start dfuse if required and it is not already started.
+
+        Args:
+            server_manager (DaosServerManager): server manager for the running servers
+            log_file (str): log file to use when assigning D_LOG_FILE
+            test_file_suffix (str, optional): suffix to add to the end of the test file name.
+                Defaults to None.
+        """
+        if self.api.value == "POSIX" or self.plugin_path:
+            if self.plugin_path:
+                # Add a substring in case of HDF5-VOL
+                new_mount_dir = os.path.join(self.dfuse.mount_dir.value, get_random_string(5))
+                self.update_value(self.dfuse.mount_dir, new_mount_dir, "dfuse.mount_dir")
+            if not self.dfuse.started:
+                # Start dfuse
+                self.dfuse.start(server_manager, log_file, self.pool, self.container)
+            self.update_value(
+                self.test_file, os.path.join(self.dfuse.mount_dir.value, "testfile"), "test_file")
+        elif self.api.value == "DFS":
+            self.update_value(self.test_file, os.path.join("/", "testfile"), "test_file")
+
+        # Add the suffix if specified
+        if test_file_suffix is not None:
+            self.update_value(
+                self.test_file, "".join([self.test_file.value, test_file_suffix]), "test_file")
+
+    def _setup_environment(self, env, log_file):
+        """Set up the environment variables for the ior command.
+
+        Args:
+            env (EnvironmentVariables): existing environment variable definitions to extend; can be
+                None.
+            log_file (str): value to use with D_LOG_FILE if env is None; required if env is None.
+        """
+        if not env:
+            env = self.get_default_env(str(self.job_manager), log_file)
+        if self.intercept is not None:
+            env["LD_PRELOAD"] = self.intercept
+            env["D_LOG_MASK"] = "INFO"
+            if env.get("D_IL_REPORT", None) is None:
+                env["D_IL_REPORT"] = "1"
+        if self.plugin_path is not None:
+            env["HDF5_VOL_CONNECTOR"] = "daos"
+            env["HDF5_PLUGIN_PATH"] = str(self.plugin_path)
+            self.job_manager.working_dir.value = self.dfuse.mount_dir.value
+        self.job_manager.assign_environment(env)
+
+    def run(self, server_manager, log_file, processes=None, test_file_suffix=None, env=None):
+        """Run ior via the job manager.
+
+        Note: to use a timeout set self.job_manager.timeout prior to calling this method.
+
+        Args:
+            server_manager (DaosServerManager): server manager for the running servers
+            log_file (str): log file to use when assigning D_LOG_FILE
+            processes (int, optional): number of host processes. Defaults to None which will use the
+                length of the JobManager.hosts list.
+            test_file_suffix (str, optional): suffix to add to the end of the test file name.
+                Defaults to None.
+            env (EnvironmentVariables, optional): predefined environment variables to be used when
+                running ior. Defaults to None.
+
+        Returns:
+            CmdResult: an avocado.utils.process CmdResult object containing the
+                result of the command execution.  A CmdResult object has the
+                following properties:
+                    command         - command string
+                    exit_status     - exit_status of the command
+                    stdout          - the stdout
+                    stdout_text     - decoded stdout
+                    stderr          - the stderr
+                    stderr_text     - decoded stderr
+                    duration        - command execution time
+                    interrupted     - whether the command completed within timeout
+                    pid             - command's pid
+
+        """
+        if processes is None:
+            processes = len(self.job_manager.hosts)
+        self.job_manager.assign_processes(processes)
+        self._setup_test_file(server_manager, log_file, test_file_suffix)
+        self._setup_environment(env, log_file)
+
+        if self.fail_on_warning:
+            self.check_results_list.append("WARNING")
+        self.job_manager.job = self
+
+        try:
+            self.display_pool_space()
+            result = self.job_manager.run()
+
+        finally:
+            self.display_pool_space()
+            if self.stop_dfuse:
+                self.dfuse.stop()
+
+        return result


### PR DESCRIPTION
The pool/management.py test creates multiple pools of various sizes
across different numbers of ranks and verifies the pool space allocation
is accurate before and after writing data to each pool.

Quick-functional: true
Test-tag: test_pool_management dmg,nvme_scan,basic

Signed-off-by: Phillip Henderson <phillip.henderson@intel.com>