### PR TITLE
DAOS-8616 spdk: Performance degradation after repeated format PR-repos:spdk@PR-27

### DIFF
--- a/utils/build.config
+++ b/utils/build.config
@@ -14,5 +14,5 @@ PSM2 = PSM2_11.2.78
 PROTOBUFC = v1.3.3
 
 [patch_versions]
-spdk=https://github.com/spdk/spdk/commit/690783a3ae82ebe58c00d643520a66103d66d540.diff,https://github.com/spdk/spdk/commit/65425be69a0882ac283fb489aa151d7df06c52ad.diff
+spdk=https://github.com/spdk/spdk/commit/690783a3ae82ebe58c00d643520a66103d66d540.diff,https://github.com/spdk/spdk/commit/65425be69a0882ac283fb489aa151d7df06c52ad.diff,https://raw.githubusercontent.com/daos-stack/spdk/master/0003-blob-chunk-clear-operations-in-IU-aligned-chunks.patch
 pmdk=https://raw.githubusercontent.com/daos-stack/pmdk/master/DAOS_8273.patch


### PR DESCRIPTION
Currently, doing multiple cycle of "format; create pool/container; run fio" demonstrates a lot of variability in the results when using NVMe SSD. Adding a blkdiscard call just before the format seemed to be a temporary fix to the issue.

Apply patch from Jim Harris (SPDK) to align clear operation chunks on a physical block boundary. UINT32_MAX is not an aligned to IU size when the SSD has 512B logical format, resulting in the unmap operation being ignored by the SSD.

Signed-off-by: Sydney Vanda sydney.m.vanda@intel.com