### PR TITLE
DAOS-8694 tests: Removing daos_agent_config.py server_name test cases.

### DIFF
--- a/src/tests/ftest/control/daos_agent_config.yaml
+++ b/src/tests/ftest/control/daos_agent_config.yaml
@@ -131,16 +131,6 @@ agent_config_val: !mux
        - "key"
        - /tmp/does_not_exist.ext
        - "PASS"
-  server_name_junk:
-    config_val:
-       - "server_name"
-       - "! @#$%^&*()_+{}|:<>?-=[];',./"
-       - "FAIL"
-  server_name_list:
-    config_val:
-      - "server_name"
-      - [12345, "ABDCD"]
-      - "FAIL"
   runtime_dir_wrong_path:
     config_val:
       - "runtime_dir"


### PR DESCRIPTION
In the control/daos_agent_config.py test was inadvertently testing the 
transport_config/server_name agent config file setting.  Recent changes
to remove internal (to the control plane) config params from the external
config files now cause this test case to fail.  As a result the test cases for
the 'server_name' have been removed.

Signed-off-by: Phillip Henderson <phillip.henderson@intel.com>