### PR TITLE
DAOS-8693 dtx: simplify DTX retry logic

### DIFF
--- a/src/dtx/dtx_common.c
+++ b/src/dtx/dtx_common.c
@@ -720,7 +720,6 @@ dtx_handle_reinit(struct dtx_handle *dth)
 	dth->dth_active = 0;
 	dth->dth_touched_leader_oid = 0;
 	dth->dth_local_tx_started = 0;
-	dth->dth_local_retry = 0;
 	dth->dth_cos_done = 0;
 
 	dth->dth_op_seq = 0;
@@ -770,7 +769,6 @@ dtx_handle_init(struct dtx_id *dti, daos_handle_t coh, struct dtx_epoch *epoch,
 	dth->dth_active = 0;
 	dth->dth_touched_leader_oid = 0;
 	dth->dth_local_tx_started = 0;
-	dth->dth_local_retry = 0;
 	dth->dth_dist = dist ? 1 : 0;
 	dth->dth_for_migration = migration ? 1 : 0;
 	dth->dth_ignore_uncommitted = ignore_uncommitted ? 1 : 0;

--- a/src/include/daos_srv/dtx_srv.h
+++ b/src/include/daos_srv/dtx_srv.h
@@ -73,8 +73,6 @@ struct dtx_handle {
 					 dth_touched_leader_oid:1,
 					 /* Local TX is started. */
 					 dth_local_tx_started:1,
-					 /* Retry with this server. */
-					 dth_local_retry:1,
 					 /* The DTX share lists are inited. */
 					 dth_shares_inited:1,
 					 /* Distributed transaction. */

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -2501,7 +2501,6 @@ ds_obj_rw_handler(crt_rpc_t *rpc)
 
 	if (obj_rpc_is_fetch(rpc)) {
 		struct dtx_handle dth = {0};
-		int		  retry = 0;
 
 		if (orw->orw_flags & ORF_CSUM_REPORT) {
 			obj_log_csum_err();
@@ -2520,7 +2519,6 @@ ds_obj_rw_handler(crt_rpc_t *rpc)
 		if (orw->orw_flags & ORF_DTX_REFRESH)
 			dtx_flags |= DTX_FORCE_REFRESH;
 
-re_fetch:
 		rc = dtx_begin(ioc.ioc_vos_coh, &orw->orw_dti, &epoch, 0,
 			       orw->orw_map_ver, &orw->orw_oid,
 			       NULL, 0, dtx_flags, NULL, &dth);
@@ -2529,24 +2527,6 @@ re_fetch:
 
 		rc = obj_local_rw(rpc, &ioc, NULL, NULL, NULL, &dth, false);
 		rc = dtx_end(&dth, ioc.ioc_coc, rc);
-
-		if (rc == -DER_INPROGRESS && dth.dth_local_retry) {
-			if (++retry > 5)
-				D_GOTO(out, rc = -DER_TX_BUSY);
-
-			/* XXX: Currently, we commit the distributed transaction
-			 *	synchronously. Normally it will be very quickly.
-			 *	So let's yield then retry. If related
-			 *	distributed transaction is still not committed
-			 *	after several cycles, replies '-DER_TX_BUSY' to
-			 *	the client.
-			 */
-			D_DEBUG(DB_IO, "Hit non-commit DTX when fetch "
-				DF_UOID" (%d)\n", DP_UOID(orw->orw_oid), retry);
-			ABT_thread_yield();
-
-			goto re_fetch;
-		}
 
 		D_GOTO(out, rc);
 	}
@@ -2798,7 +2778,6 @@ obj_local_enum(struct obj_io_context *ioc, crt_rpc_t *rpc,
 	struct dss_enum_arg	saved_arg;
 	struct obj_key_enum_in	*oei = crt_req_get(rpc);
 	uint32_t		flags = 0;
-	int			retry = 0;
 	int			opc = opc_get(rpc->cr_opc);
 	int			type;
 	int			rc;
@@ -2905,7 +2884,6 @@ obj_local_enum(struct obj_io_context *ioc, crt_rpc_t *rpc,
 	if (oei->oei_flags & ORF_DTX_REFRESH)
 		flags |= DTX_FORCE_REFRESH;
 
-again:
 	rc = dtx_begin(ioc->ioc_vos_coh, &oei->oei_dti, &epoch, 0,
 		       oei->oei_map_ver, &oei->oei_oid, NULL, 0, flags,
 		       NULL, &dth);
@@ -2946,27 +2924,6 @@ re_pack:
 	if (rc_tmp != 0)
 		rc = rc_tmp;
 
-	if (rc == -DER_INPROGRESS && dth.dth_local_retry) {
-		if (++retry > 5)
-			D_GOTO(out, rc = -DER_TX_BUSY);
-
-		/* XXX: Currently, we commit the distributed transaction
-		 *	synchronously. Normally it will be very quickly.
-		 *	So let's yield then retry. If related distributed
-		 *	transaction is still not committed after several
-		 *	cycles, replies '-DER_TX_BUSY' to the client.
-		 */
-		D_DEBUG(DB_IO, "Hit non-commit DTX when enum "
-			DF_UOID" (%d)\n", DP_UOID(oei->oei_oid), retry);
-		ABT_thread_yield();
-
-		*anchors = saved_anchors;
-		obj_restore_enum_args(rpc, enum_arg, &saved_arg);
-
-		goto again;
-	}
-
-out:
 	if (type == VOS_ITER_SINGLE)
 		anchors->ia_ev = anchors->ia_sv;
 
@@ -3632,7 +3589,6 @@ ds_obj_query_key_handler(crt_rpc_t *rpc)
 	uint64_t			 stripe_size = 0;
 	daos_recx_t			 ec_recx[3] = {0};
 	daos_recx_t			*query_recx;
-	int				 retry = 0;
 	int				 rc;
 
 	okqi = crt_req_get(rpc);
@@ -3647,14 +3603,13 @@ ds_obj_query_key_handler(crt_rpc_t *rpc)
 			   okqi->okqi_co_uuid, opc_get(rpc->cr_opc),
 			   okqi->okqi_flags, &ioc);
 	if (rc)
-		D_GOTO(out, rc);
+		D_GOTO(failed, rc);
 
 	rc = process_epoch(&okqi->okqi_epoch, &okqi->okqi_epoch_first,
 			   &okqi->okqi_flags);
 	if (rc == PE_OK_LOCAL)
 		okqi->okqi_flags &= ~ORF_EPOCH_UNCERTAIN;
 
-again:
 	dkey = &okqi->okqi_dkey;
 	akey = &okqi->okqi_akey;
 	d_iov_set(&okqo->okqo_akey, NULL, 0);
@@ -3672,7 +3627,7 @@ again:
 		       okqi->okqi_map_ver, &okqi->okqi_oid, NULL, 0, 0, NULL,
 		       &dth);
 	if (rc != 0)
-		goto out;
+		goto failed;
 
 	query_flags = okqi->okqi_api_flags;
 	if ((okqi->okqi_flags & ORF_EC) &&
@@ -3700,24 +3655,6 @@ re_query:
 	}
 
 	rc = dtx_end(&dth, ioc.ioc_coc, rc);
-
-out:
-	if (rc == -DER_INPROGRESS && dth.dth_local_retry) {
-		if (++retry > 5)
-			D_GOTO(failed, rc = -DER_TX_BUSY);
-
-		/* XXX: Currently, we commit the distributed transaction
-		 *	synchronously. Normally it will be very quickly.
-		 *	So let's yield then retry. If related distributed
-		 *	transaction is still not committed after several
-		 *	cycles, then replies '-DER_TX_BUSY' to the client.
-		 */
-		D_DEBUG(DB_IO, "Hit non-commit DTX when query "
-			DF_UOID" (%d)\n", DP_UOID(okqi->okqi_oid), retry);
-		ABT_thread_yield();
-
-		goto again;
-	}
 
 failed:
 	obj_reply_set_status(rpc, rc);

--- a/src/vos/tests/vts_dtx.c
+++ b/src/vos/tests/vts_dtx.c
@@ -59,7 +59,6 @@ vts_dtx_begin(const daos_unit_oid_t *oid, daos_handle_t coh, daos_epoch_t epoch,
 	dth->dth_resent = 0;
 	dth->dth_touched_leader_oid = 0;
 	dth->dth_local_tx_started = 0;
-	dth->dth_local_retry = 0;
 	dth->dth_solo = 0;
 	dth->dth_modify_shared = 0;
 	dth->dth_active = 0;

--- a/src/vos/vos_dtx.c
+++ b/src/vos/vos_dtx.c
@@ -138,25 +138,9 @@ dtx_inprogress(struct vos_dtx_act_ent *dae, struct dtx_handle *dth,
 		goto out;
 	}
 
-	/* For the DTX with 'DTE_BLOCK' flag, we will sych commit them. But
-	 * before it is committed, if someone wants to read related data on
-	 * non-leader, we can make related IO handle to retry locally, that
-	 * will not cause too much overhead unless the DTX hit some trouble
-	 * (such as client or server failure) that may cause current reader
-	 * to be blocked until such DTX has been handled by the new leader.
-	 */
-
-	if (!dth->dth_force_refresh && dth->dth_ver <= DAE_VER(dae)) {
-		if (DAE_FLAGS(dae) & DTE_BLOCK &&
-		    dth->dth_modification_cnt == 0) {
-			if (dth->dth_share_tbd_count == 0)
-				dth->dth_local_retry = 1;
-			goto out;
-		}
-
-		if (DAE_MBS_FLAGS(dae) & DMF_SRDG_REP && dth->dth_dist == 0)
-			goto out;
-	}
+	if (!dth->dth_force_refresh && !dth->dth_dist &&
+	    dth->dth_ver <= DAE_VER(dae) && DAE_MBS_FLAGS(dae) & DMF_SRDG_REP)
+		goto out;
 
 	s_try = true;
 
@@ -208,8 +192,7 @@ out:
 		hit_again ? "Repeat" : "First", DP_DTI(&DAE_XID(dae)), pos,
 		dth, dth != NULL && dth->dth_force_refresh ? "yes" : "no",
 		dth != NULL && dth->dth_dist ? "yes" : "no", DAE_LID(dae),
-		DAE_FLAGS(dae), DAE_MBS_FLAGS(dae), s_try ? "server" :
-		(dth != NULL && dth->dth_local_retry) ? "local" : "client");
+		DAE_FLAGS(dae), DAE_MBS_FLAGS(dae), s_try ? "server" : "client");
 
 	return -DER_INPROGRESS;
 }


### PR DESCRIPTION
Originally, for read style RPC, if hit sync mode non-committed DTX,
we can make the RPC handler (ULT) to re-schedule locally instead of
asking the client to resend the RPC. It is expected that such sync
mode DTX will be committed soon. But it is not guaranteed. If such
sync mode DTX is still not committed after several cycles of local
re-schedule, we will have to make the client to resent the RPC (to
the leader if possible). So this 'optimization' cannot replace the
client retry logic. On the other hand, current test results cannot
prove sich 'optimization' is worth for the relative complex servre
retry logic. Let's remove server local retry to simplify the logic.

Signed-off-by: Fan Yong <fan.yong@intel.com>