### PR TITLE
DAOS-8273 vos: No need to call pmemobj_tx_errno

### DIFF
--- a/src/common/mem.c
+++ b/src/common/mem.c
@@ -377,14 +377,6 @@ static umem_ops_t	pmem_ops = {
 int
 umem_tx_errno(int err)
 {
-	if (err == 0)
-		err = pmemobj_tx_errno();
-
-	if (err == 0) {
-		D_ERROR("Transaction aborted for unknown reason\n");
-		return -DER_MISC;
-	}
-
 	if (err < 0) {
 		if (err < -DER_ERR_GURT_BASE)
 			return err; /* aborted by DAOS */


### PR DESCRIPTION
This is dead code because umem_tx_errno is always called with non-zero
argument.  Secondly, pmdk APIs return the errno value.

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>