### PR TITLE
DAOS-8473 tools: Fail on unexpected positional arguments

### DIFF
--- a/src/control/cmd/daos/container.go
+++ b/src/control/cmd/daos/container.go
@@ -201,18 +201,6 @@ type containerCreateCmd struct {
 	User        string               `long:"user" short:"u" description:"user who will own the container (username@[domain])"`
 	Group       string               `long:"group" short:"g" description:"group who will own the container (group@[domain])"`
 	ContFlag    ContainerID          `long:"cont" short:"c" description:"container UUID (optional)"`
-	Args        struct {
-		Container ContainerID `positional-arg-name:"<container UUID (optional)>"`
-	} `positional-args:"yes"`
-}
-
-func (cmd *containerCreateCmd) getUserUUID() uuid.UUID {
-	for _, id := range []ContainerID{cmd.Args.Container, cmd.ContFlag} {
-		if id.HasUUID() {
-			return id.UUID
-		}
-	}
-	return uuid.Nil
 }
 
 func (cmd *containerCreateCmd) Execute(_ []string) (err error) {
@@ -222,8 +210,8 @@ func (cmd *containerCreateCmd) Execute(_ []string) (err error) {
 	}
 	defer deallocCmdArgs()
 
-	if cu := cmd.getUserUUID(); cu != uuid.Nil {
-		cmd.contUUID = cu
+	if cmd.ContFlag.HasUUID() {
+		cmd.contUUID = cmd.ContFlag.UUID
 		if err := copyUUID(&ap.c_uuid, cmd.contUUID); err != nil {
 			return err
 		}

--- a/src/control/cmd/daos/main.go
+++ b/src/control/cmd/daos/main.go
@@ -186,6 +186,12 @@ or query/manage an object inside a container.`
 			defer fini()
 		}
 
+		if argsCmd, ok := cmd.(common.ArgsHandler); ok {
+			if err := argsCmd.CheckArgs(args); err != nil {
+				return err
+			}
+		}
+
 		if err := cmd.Execute(args); err != nil {
 			return err
 		}

--- a/src/control/cmd/daos/util.go
+++ b/src/control/cmd/daos/util.go
@@ -17,6 +17,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/daos-stack/daos/src/control/build"
+	"github.com/daos-stack/daos/src/control/common"
 	"github.com/daos-stack/daos/src/control/drpc"
 	"github.com/daos-stack/daos/src/control/logging"
 )
@@ -223,6 +224,7 @@ type daosCaller interface {
 }
 
 type daosCmd struct {
+	common.NoArgsCmd
 	jsonOutputCmd
 	logCmd
 }

--- a/src/control/cmd/dmg/main.go
+++ b/src/control/cmd/dmg/main.go
@@ -127,6 +127,9 @@ type cmdLogger interface {
 }
 
 type logCmd struct {
+	common.NoArgsCmd // Hack: Since everything embeds this type,
+	// just embed the args handler in here. We should probably
+	// create a new baseCmd type to cut down on boilerplate.
 	log *logging.LeveledLogger
 }
 
@@ -271,6 +274,12 @@ and access control settings, along with system wide operations.`
 
 		if cfgCmd, ok := cmd.(cmdConfigSetter); ok {
 			cfgCmd.setConfig(ctlCfg)
+		}
+
+		if argsCmd, ok := cmd.(common.ArgsHandler); ok {
+			if err := argsCmd.CheckArgs(args); err != nil {
+				return err
+			}
 		}
 
 		if err := cmd.Execute(args); err != nil {

--- a/src/control/cmd/dmg/pool_test.go
+++ b/src/control/cmd/dmg/pool_test.go
@@ -89,6 +89,12 @@ func TestPoolCommands(t *testing.T) {
 
 	runCmdTests(t, []cmdTest{
 		{
+			"Pool create with extra argument",
+			fmt.Sprintf("pool create --size %s foo bar", testSizeStr),
+			"",
+			errors.New("unexpected"),
+		},
+		{
 			"Create pool with label prop and flag",
 			fmt.Sprintf("pool create --label foo --size %s --properties label:foo", testSizeStr),
 			"",

--- a/src/control/common/cmd_utils.go
+++ b/src/control/common/cmd_utils.go
@@ -9,6 +9,9 @@ package common
 import (
 	"io"
 	"os"
+	"strings"
+
+	"github.com/pkg/errors"
 )
 
 // ManPageWriter defines an interface to be implemented
@@ -40,4 +43,24 @@ func (cmd *ManCmd) Execute(_ []string) error {
 
 	cmd.writeFn(output)
 	return nil
+}
+
+type ArgsHandler interface {
+	CheckArgs([]string) error
+	HandleArgs([]string) error
+}
+
+// NoArgsCmd defines an embeddable struct that can be used to
+// implement a command that does not take any arguments.
+type NoArgsCmd struct{}
+
+func (cmd *NoArgsCmd) CheckArgs(args []string) error {
+	if len(args) != 0 {
+		return errors.Errorf("unexpected arguments: %s", strings.Join(args, " "))
+	}
+	return nil
+}
+
+func (cmd *NoArgsCmd) HandleArgs(args []string) error {
+	return errors.New("this command does not accept additional arguments")
 }


### PR DESCRIPTION
When the user has specified more positional arguments than
are expected for the command, don't silently swallow them.