### PR TITLE
DAOS-8732 Support URI Labels in Hadoop Yarn

### DIFF
--- a/src/client/java/daos-java/src/test/java/io/daos/DaosTestBase.java
+++ b/src/client/java/daos-java/src/test/java/io/daos/DaosTestBase.java
@@ -1,13 +1,13 @@
 package io.daos;
 
 public class DaosTestBase {
-  public static final String DEFAULT_POOL_ID = "fa659243-b141-4dc8-8487-13d8fbd54010";
-  public static final String DEFAULT_CONT_ID = "b72e068f-ba04-4546-b05c-2de9d936895e";
+  public static final String DEFAULT_POOL_ID = "bcc5099c-2ae5-4790-85d2-f625aa8d3065";
+  public static final String DEFAULT_CONT_ID = "8c00ed27-1b18-4c92-a95f-17aa672f7fa9";
 
   public static final String DEFAULT_POOL_LABEL = "pool1";
   public static final String DEFAULT_CONT_LABEL = "cont1";
 
-  public static final String DEFAULT_OBJECT_CONT_ID = "70be2f5e-5117-41e5-84b7-dba0c9f3601a";
+  public static final String DEFAULT_OBJECT_CONT_ID = "4a61bbf9-d768-4b8a-80ad-ac1e70452b79";
 
   public static String getPoolId() {
     return System.getProperty("pool_id", DaosTestBase.DEFAULT_POOL_ID);

--- a/src/client/java/hadoop-daos/src/main/java/io/daos/fs/hadoop/DaosAbsFsImpl.java
+++ b/src/client/java/hadoop-daos/src/main/java/io/daos/fs/hadoop/DaosAbsFsImpl.java
@@ -28,13 +28,13 @@ public class DaosAbsFsImpl extends DelegateToFileSystem {
   }
 
   /**
-   * not used in DAOS. Just return 1 as fake port.
+   * not used in DAOS. Just return -1 as fake port.
    *
-   * @return 1
+   * @return -1
    */
   @Override
   public int getUriDefaultPort() {
-    return 1;
+    return -1;
   }
 
   @Override

--- a/src/client/java/hadoop-daos/src/main/java/io/daos/fs/hadoop/DaosFileSystem.java
+++ b/src/client/java/hadoop-daos/src/main/java/io/daos/fs/hadoop/DaosFileSystem.java
@@ -219,7 +219,7 @@ public class DaosFileSystem extends FileSystem {
 
   @Override
   public int getDefaultPort() {
-    return 1;
+    return 0;
   }
 
   private void checkSizeMin(int size, int min, String msg) {

--- a/src/client/java/hadoop-daos/src/test/java/io/daos/fs/hadoop/DaosFSFactory.java
+++ b/src/client/java/hadoop-daos/src/test/java/io/daos/fs/hadoop/DaosFSFactory.java
@@ -15,8 +15,8 @@ import java.io.IOException;
  *
  */
 public class DaosFSFactory {
-  public final static String defaultPoolId = "fa659243-b141-4dc8-8487-13d8fbd54010";
-  public final static String defaultContId = "b72e068f-ba04-4546-b05c-2de9d936895e";
+  public final static String defaultPoolId = "bcc5099c-2ae5-4790-85d2-f625aa8d3065";
+  public final static String defaultContId = "2f02e626-8954-4b5f-8659-8ca8999b9b70";
   public final static String pooluuid = System.getProperty("pool_id", defaultPoolId);
   public final static String contuuid = System.getProperty("cont_id", defaultContId);
   public static final String defaultPoolLabel = "pool1";

--- a/src/client/java/hadoop-daos/src/test/java/io/daos/fs/hadoop/DaosFileSystemIT.java
+++ b/src/client/java/hadoop-daos/src/test/java/io/daos/fs/hadoop/DaosFileSystemIT.java
@@ -230,6 +230,38 @@ public class DaosFileSystemIT {
   }
 
   @Test
+  public void testConnectViaFileContext() throws Exception {
+    File file = Files.createTempDirectory("uns").toFile();
+    try {
+      String path = file.getAbsolutePath();
+      String daosAttr = String.format(io.daos.Constants.DUNS_XATTR_FMT, Layout.POSIX.name(),
+          DaosFSFactory.getPooluuid(), DaosFSFactory.getContuuid());
+      DaosUns.setAppInfo(path, io.daos.Constants.DUNS_XATTR_NAME, daosAttr);
+      String authority = io.daos.Constants.UNS_ID_PREFIX + unsId.getAndIncrement();
+      String uriStr = "daos://" + authority + path;
+      Configuration cfg = new Configuration();
+      cfg.set("fs.defaultFS", uriStr);
+      cfg.set("fs.AbstractFileSystem.daos.impl", "io.daos.fs.hadoop.DaosAbsFsImpl");
+      AbstractFileSystem afs = FileContext.getFileContext(cfg).getDefaultFileSystem();
+      Assert.assertEquals("daos://" + authority + "/", afs.getUri().toString());
+      Assert.assertNotNull(afs);
+    } finally {
+      file.delete();
+    }
+  }
+
+  @Test
+  public void testConnectViaFileContextWithLabels() throws Exception {
+    String uriStr = "daos://" + DaosFSFactory.getPoolLabel() + "/" + DaosFSFactory.getContLabel();
+    Configuration cfg = new Configuration();
+    cfg.set("fs.defaultFS", uriStr);
+    cfg.set("fs.AbstractFileSystem.daos.impl", "io.daos.fs.hadoop.DaosAbsFsImpl");
+    AbstractFileSystem afs = FileContext.getFileContext(cfg).getDefaultFileSystem();
+    Assert.assertEquals("daos://" + DaosFSFactory.getPoolLabel() + "/", afs.getUri().toString());
+    Assert.assertNotNull(afs);
+  }
+
+  @Test
   public void testDirAndListPathFromHybridUnsPath() throws Exception {
     File file = Files.createTempDirectory("uns").toFile();
     try {


### PR DESCRIPTION
Hadoop Yarn uses FileContext and AbstractFileSystem to read/write from FS. They must need a port in URI to access FS. This PR changed default port to "-1" in abstract file system impl and "0" in Daos file system to bypass the limit.

Signed-off-by: jiafu zhang <jiafu.zhang@intel.com>