### PR TITLE
DAOS-7069 dtx: properly abort DTX entry when DTX refresh

### DIFF
--- a/src/dtx/dtx_srv.c
+++ b/src/dtx/dtx_srv.c
@@ -240,7 +240,7 @@ dtx_handler(crt_rpc_t *rpc)
 		if (DAOS_FAIL_CHECK(DAOS_DTX_UNCERTAIN)) {
 			for (i = 0; i < count; i++) {
 				ptr = (int *)dout->do_sub_rets.ca_arrays + i;
-				*ptr = -DER_NONEXIST;
+				*ptr = -DER_TX_UNCERTAIN;
 			}
 
 			D_GOTO(out, rc = 0);
@@ -256,6 +256,21 @@ dtx_handler(crt_rpc_t *rpc)
 			     cont->sc_dtx_resyncing) ||
 			    (*ptr == -DER_NONEXIST && cont->sc_dtx_reindex))
 				*ptr = -DER_INPROGRESS;
+
+			if (*ptr == -DER_NONEXIST) {
+				struct dtx_stat		stat = { 0 };
+
+				/* dtx_id::dti_hlc is client side time stamp. Usually, it is
+				 * older than the time of the DTX being handled on the leader.
+				 * If it is older than the time of next to be aggregated DTX
+				 * entry, then it may has been removed by DTX aggregation.
+				 * Under such case, return -DER_TX_UNCERTAIN to non-leader.
+				 */
+				vos_dtx_stat(cont->sc_hdl, &stat, DSF_SKIP_BAD);
+				if (dtis->dti_hlc < stat.dtx_first_cmt_blob_time_up)
+					*ptr = -DER_TX_UNCERTAIN;
+			}
+
 			if (mbs[i] != NULL)
 				rc1++;
 		}

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -4201,20 +4201,19 @@ again:
 	}
 
 	rc = ds_cpd_handle_one(rpc, dcsh, dcde, dcsrs, ioc, dth);
-	if (!dth->dth_pinned) {
-		int	rc1;
-
-		/* There will be CPU yield during DTX refresh. We need
-		 * to pin current DTX before refreshing other DTX(es),
-		 * that will avoid race with the resent RPC during the
+	if (obj_dtx_need_refresh(dth, rc)) {
+		/* There will be CPU yield during DTX refresh. We need to pin current DTX before
+		 * refreshing other DTX(es), that will avoid race with the resent RPC during the
 		 * DTX refresh.
 		 */
-		rc1 = vos_dtx_pin(dth, false);
-		if (rc1 != 0)
-			return -DER_INPROGRESS;
-	}
+		if (!dth->dth_pinned) {
+			int	rc1;
 
-	if (obj_dtx_need_refresh(dth, rc)) {
+			rc1 = vos_dtx_pin(dth, false);
+			if (rc1 != 0)
+				return -DER_INPROGRESS;
+		}
+
 		rc = dtx_refresh(dth, ioc->ioc_coc);
 		if (rc == -DER_AGAIN)
 			goto again;

--- a/src/vos/vos_dtx.c
+++ b/src/vos/vos_dtx.c
@@ -2122,6 +2122,7 @@ vos_dtx_post_handle(struct vos_container *cont,
 
 			if (abort) {
 				daes[i]->dae_aborted = 1;
+				daes[i]->dae_prepared = 0;
 				dtx_act_ent_cleanup(cont, daes[i], NULL, true);
 			} else {
 				daes[i]->dae_committed = 1;
@@ -2701,14 +2702,18 @@ vos_dtx_cleanup_internal(struct dtx_handle *dth)
 				D_ERROR("Fail to remove DTX entry "DF_DTI":"
 					DF_RC"\n",
 					DP_DTI(&dth->dth_xid), DP_RC(rc));
+			else
+				rc = 0;
 
 			dae = dth->dth_ent;
-			if (dae != NULL)
+			if (dae != NULL) {
 				dae->dae_aborted = 1;
+				dae->dae_prepared = 0;
+			}
 		} else {
 			dae = (struct vos_dtx_act_ent *)riov.iov_buf;
-			/* Cannot cleanup 'prepared' or 'committed' DTX entry. */
-			if (dae->dae_prepared || dae->dae_committed)
+			/* Cannot cleanup 'committed' DTX entry. */
+			if (dae->dae_committable || dae->dae_committed)
 				goto out;
 
 			rc = dbtree_delete(cont->vc_dtx_active_hdl, BTR_PROBE_BYPASS, &kiov, &dae);


### PR DESCRIPTION
When non-leader refresh some DTX staus with the leader, it may
get the result -DER_NONEXIST. There are two cases for that:

1) The leader has aborted related DTX but the non-leader missed
   or failed to executed the DTX abort RPC.

2) Such DTX entry has been committed, but the non-leader missed
   or failed to executed the DTX commit RPC. Then it is removed
   by DTX aggregation on the leader.

If we are not sure which case it is, then we will have to keep
related of DTX entry instead of aborting it. Otherwise, we may
break leader's local modification or commit.

The patch also contains other fixes to allow cleanup 'prepared'
DTX entry.

Signed-off-by: Fan Yong <fan.yong@intel.com>