### PR TITLE
DAOS-8699 container: Use UV class for container btree

### DIFF
--- a/src/container/container_iv.c
+++ b/src/container/container_iv.c
@@ -49,7 +49,7 @@ cont_iv_ent_init(struct ds_iv_key *iv_key, void *data,
 	int		 rc;
 
 	uma.uma_id = UMEM_CLASS_VMEM;
-	rc = dbtree_create(DBTREE_CLASS_NV, 0, 4, &uma, NULL, &root_hdl);
+	rc = dbtree_create(DBTREE_CLASS_UV, 0, 4, &uma, NULL, &root_hdl);
 	if (rc != 0) {
 		D_ERROR("failed to create tree: "DF_RC"\n", DP_RC(rc));
 		return rc;


### PR DESCRIPTION
The key is a uuid, so it's appropriate to use the UV class instead.
The NV class without direct key can have hash conflicts between
two different UUIDs.   This is similar to what we saw previously
with objects in DAOS-6149.   It's likely that the customer is just
using more containers than we're used to seeing.

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>