### PR TITLE
DAOS-8713 pool: fix useless dc_xxx_fini()

### DIFF
--- a/src/container/cli.c
+++ b/src/container/cli.c
@@ -45,7 +45,11 @@ dc_cont_init(void)
 void
 dc_cont_fini(void)
 {
-	daos_rpc_unregister(&cont_proto_fmt);
+	int rc;
+
+	rc = daos_rpc_unregister(&cont_proto_fmt);
+	if (rc != 0)
+		D_ERROR("failed to unregister cont RPCs: "DF_RC"\n", DP_RC(rc));
 }
 
 /*

--- a/src/mgmt/cli_mgmt.c
+++ b/src/mgmt/cli_mgmt.c
@@ -924,7 +924,11 @@ dc_mgmt_init()
 void
 dc_mgmt_fini()
 {
-	daos_rpc_unregister(&mgmt_proto_fmt);
+	int rc;
+
+	rc = daos_rpc_unregister(&mgmt_proto_fmt);
+	if (rc != 0)
+		D_ERROR("failed to unregister mgmt RPCs: "DF_RC"\n", DP_RC(rc));
 }
 
 int dc2_mgmt_svc_rip(tse_task_t *task)

--- a/src/pool/cli.c
+++ b/src/pool/cli.c
@@ -52,7 +52,11 @@ dc_pool_init(void)
 void
 dc_pool_fini(void)
 {
-	daos_rpc_unregister(&pool_proto_fmt);
+	int rc;
+
+	rc = daos_rpc_unregister(&pool_proto_fmt);
+	if (rc != 0)
+		D_ERROR("failed to unregister pool RPCs: "DF_RC"\n", DP_RC(rc));
 }
 
 static void


### PR DESCRIPTION
dc_xxx_fini() ignored return value of rpc module unregister call,
the reason we can do that is because module unregister always returns 0 regardless
so its ok to squelch the error but should be corrected incase that changes in the future.

we'd better keep dc_xxx_fini() since this could avoid potential resource leaks.

Signed-off-by: Wang Shilong <shilong.wang@intel.com>