### PR TITLE
DAOS-8433 engine: increase ULT stack size

### DIFF
--- a/src/include/daos_srv/daos_engine.h
+++ b/src/include/daos_srv/daos_engine.h
@@ -490,6 +490,7 @@ struct dss_module {
  * Stack size used for ULTs with deep stack
  */
 #define DSS_DEEP_STACK_SZ	65536
+#define DSS_DEFAULT_STACK_SZ	(DSS_DEEP_STACK_SZ >> 1)
 
 enum dss_xs_type {
 	/** current xstream */


### PR DESCRIPTION
Increase ABT ULT stack size from 16KB (by default) to 32KB for
DAOS usage. That is helpful to avoid ULT stack overflow during
server reintegration.

Signed-off-by: Fan Yong <fan.yong@intel.com>