### PR TITLE
DAOS-8689 test: daos_racer with multiple client ranks

### DIFF
--- a/src/tests/ftest/daos_racer/parallel.py
+++ b/src/tests/ftest/daos_racer/parallel.py
@@ -1,0 +1,57 @@
+#!/usr/bin/python3
+"""
+(C) Copyright 2021 Intel Corporation.
+
+SPDX-License-Identifier: BSD-2-Clause-Patent
+"""
+
+from apricot import TestWithServers
+from command_utils import CommandFailure
+from daos_racer_utils import DaosRacerCommand
+
+
+class DaosRacerTest(TestWithServers):
+    """Test cases that utilize the daos_racer tool.
+
+    :avocado: recursive
+    """
+
+    def test_parallel(self):
+        """JIRA-8445: multi-client daos_racer/consistency checker test.
+
+        Test Description:
+            The daos_racer test tool generates a bunch of simultaneous,
+            conflicting I/O requests. After it is run it will verify that all
+            the replicas of a given object are consistent.
+
+            Run daos_racer for 5-10 minutes or so on 3-way replicated object
+            data (at least 6 servers) and verify the object replicas.
+
+        Use Cases:
+            Running simultaneous, conflicting I/O requests.
+
+        :avocado: tags=all,full_regression
+        :avocado: tags=hw,large
+        :avocado: tags=io,daosracer,daos_racer_parallel
+        """
+        # Create the dmg command
+        daos_racer = DaosRacerCommand(self.bin, self.hostlist_clients[0], self.get_dmg_command())
+        daos_racer.get_params(self)
+
+        # Create the orterun command
+        self.job_manager.assign_hosts(self.hostlist_clients, self.workdir, None)
+        self.job_manager.assign_processes(len(self.hostlist_clients))
+        self.job_manager.assign_environment(daos_racer.get_environment(self.server_managers[0]))
+        self.job_manager.job = daos_racer
+        self.job_manager.check_results_list = ["<stderr>"]
+        self.log.info("Multi-process command: %s", str(self.job_manager))
+
+        # Run the daos_perf command and check for errors
+        try:
+            self.job_manager.run()
+
+        except CommandFailure as error:
+            self.log.error("DAOS Racer Failed: %s", str(error))
+            self.fail("Test was expected to pass but it failed.\n")
+
+        self.log.info("Test passed!")

--- a/src/tests/ftest/daos_racer/parallel.yaml
+++ b/src/tests/ftest/daos_racer/parallel.yaml
@@ -1,0 +1,50 @@
+hosts:
+  test_servers:
+    - server-A
+    - server-B
+    - server-C
+    - server-D
+  test_clients:
+    - client-E
+    - client-F
+    - client-G
+    - client-H
+timeout: 150
+server_config:
+  engines_per_host: 2
+  name: daos_server
+  servers:
+    0:
+      pinned_numa_node: 0
+      nr_xs_helpers: 1
+      fabric_iface: ib0
+      fabric_iface_port: 31317
+      log_file: daos_server0.log
+      log_mask: DEBUG,MEM=ERR
+      env_vars:
+        - DD_MASK=io,trace,rebuild
+      bdev_class: nvme
+      bdev_list: ["aaaa:aa:aa.a"]
+      scm_class: dcpm
+      scm_list: ["/dev/pmem0"]
+      scm_mount: /mnt/daos0
+    1:
+      pinned_numa_node: 1
+      nr_xs_helpers: 1
+      fabric_iface: ib1
+      fabric_iface_port: 31417
+      log_file: daos_server1.log
+      log_mask: DEBUG,MEM=ERR
+      env_vars:
+        - DD_MASK=io,trace,rebuild
+      bdev_class: nvme
+      bdev_list: ["bbbb:bb:bb.b"]
+      scm_class: dcpm
+      scm_list: ["/dev/pmem1"]
+      scm_mount: /mnt/daos1
+job_manager_class_name: Orterun
+job_manager_mpi_type: openmpi
+job_manager_timeout: 630
+daos_racer:
+  runtime: 600
+  clush_timeout: 900


### PR DESCRIPTION
Adding a daos_racer test case to generate more race conditions by
running multiple daos_racer commands simultaneously.

Quick-functional: true
Test-tag: daos_racer_multi

Signed-off-by: Phillip Henderson <phillip.henderson@intel.com>
Signed-off-by: Fan Yong <fan.yong@intel.com>