### PR TITLE
DAOS-8559 vos: Disable range discard on ilog

### DIFF
--- a/src/vos/vos_obj.c
+++ b/src/vos/vos_obj.c
@@ -1843,7 +1843,7 @@ vos_obj_iter_aggregate(daos_handle_t ih, bool range_discard)
 		goto exit;
 
 	rc = vos_ilog_aggregate(vos_cont2hdl(obj->obj_cont), &krec->kr_ilog,
-				&oiter->it_epr, iter->it_for_discard, range_discard,
+				&oiter->it_epr, iter->it_for_discard, false,
 				&oiter->it_punched, &oiter->it_ilog_info);
 
 	if (rc == 1) {

--- a/src/vos/vos_obj_index.c
+++ b/src/vos/vos_obj_index.c
@@ -676,7 +676,7 @@ oi_iter_aggregate(daos_handle_t ih, bool range_discard)
 		goto exit;
 
 	rc = vos_ilog_aggregate(vos_cont2hdl(oiter->oit_cont), &obj->vo_ilog,
-				&oiter->oit_epr, iter->it_for_discard, range_discard, NULL,
+				&oiter->oit_epr, iter->it_for_discard, false, NULL,
 				&oiter->oit_ilog_info);
 	if (rc == 1) {
 		/* Incarnation log is empty, delete the object */


### PR DESCRIPTION
Just discard the ilog entries in the range instead.

Not doing so can leave data that is punched but the punches
may have been aggregated and can't be reintegrated.  Also,
supporting inflight I/O with discard is possibly impossible.

The issue with in-flight I/O in such cases is supporting
conditional operations when you have potentially stale
I/Os at earlier epochs.

So, we are punting and just reverting to full discard of the
ilog and assuming no I/O can happen on the such objects
after restart but before discard has completed.

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>