### PR TITLE
DAOS-8729 object: opcode fix here.

### DIFF
--- a/src/object/srv_obj_remote.c
+++ b/src/object/srv_obj_remote.c
@@ -230,7 +230,7 @@ ds_obj_remote_punch(struct dtx_leader_handle *dlh, void *data, int idx,
 
 	if (opc_get(parent_req->cr_opc) == DAOS_OBJ_RPC_PUNCH)
 		opc = DAOS_OBJ_RPC_TGT_PUNCH;
-	else if (opc_get(parent_req->cr_opc) == DAOS_OBJ_RPC_TGT_PUNCH_DKEYS)
+	else if (opc_get(parent_req->cr_opc) == DAOS_OBJ_RPC_PUNCH_DKEYS)
 		opc = DAOS_OBJ_RPC_TGT_PUNCH_DKEYS;
 	else
 		opc = DAOS_OBJ_RPC_TGT_PUNCH_AKEYS;


### PR DESCRIPTION
Fix typo for opcode in ds_obj_remote_punch.

Signed-off-by: Di Wang <di.wang@intel.com>