### PR TITLE
DAOS-8601 obj: fix a tse race in IO retry handling

### DIFF
--- a/src/container/cli.c
+++ b/src/container/cli.c
@@ -1748,13 +1748,13 @@ cont_oid_alloc_complete(tse_task_t *task, void *data)
 		if (rc != 0)
 			D_GOTO(out, rc);
 
-		rc = dc_task_resched(task);
+		rc = dc_task_depend(task, 1, &ptask);
 		if (rc != 0) {
 			dc_pool_abandon_map_refresh_task(ptask);
 			D_GOTO(out, rc);
 		}
 
-		rc = dc_task_depend(task, 1, &ptask);
+		rc = dc_task_resched(task);
 		if (rc != 0) {
 			dc_pool_abandon_map_refresh_task(ptask);
 			D_GOTO(out, rc);

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -1614,13 +1614,6 @@ obj_retry_cb(tse_task_t *task, struct dc_object *obj,
 	}
 
 	if (obj_auxi->io_retry) {
-		/* Let's reset task result before retry */
-		rc = dc_task_resched(task);
-		if (rc != 0) {
-			D_ERROR("Failed to re-init task (%p)\n", task);
-			D_GOTO(err, rc);
-		}
-
 		if (pool_task != NULL) {
 			rc = dc_task_depend(task, 1, &pool_task);
 			if (rc != 0) {
@@ -1628,6 +1621,12 @@ obj_retry_cb(tse_task_t *task, struct dc_object *obj,
 					 "query task (%p)\n", pool_task);
 				D_GOTO(err, rc);
 			}
+		}
+
+		rc = dc_task_resched(task);
+		if (rc != 0) {
+			D_ERROR("Failed to re-init task (%p)\n", task);
+			D_GOTO(err, rc);
 		}
 	} else if (obj_auxi->spec_shard || obj_auxi->spec_group) {
 		/* If the RPC sponsor specifies shard or group, we will NOT


### PR DESCRIPTION
In obj_retry_cb(), in original code -
1st step dc_task_resched() the IO task, and then
2nd step dc_task_depend() register the IO task depend on pool map
    refresh task.

That is incorrect in multi-threads executing (for example dfuse fio
test). Because once IO task re-inited, it possibly be scheduled/executed
by another thread B (at the time without dep task), but the pool map
refresh thread may be executed on thread A and after pool task's finish
it possibly incorrect completes IO task (due to its dep task finished -
tse_task_post_process(pool_task) -> tse_task_complete_callback(io_task))
while the IO task still WIP at thread B. That possibly cause kinds of
crash (dfuse) or mem-corruption.

This patch fixes it by convert the order or the 2 steps.
Fixed a similar case in cont_oid_alloc_complete().

Signed-off-by: Xuezhao Liu <xuezhao.liu@intel.com>