### PR TITLE
DAOS-8601 obj: fix a tse race in retry (incorrect backup)

### DIFF
--- a/src/common/tse_internal.h
+++ b/src/common/tse_internal.h
@@ -55,7 +55,10 @@ struct tse_task_private {
 					 dtp_completing:1,
 					/* task is in running state */
 					 dtp_running:1,
-					 dtp_dep_cnt:29;
+					/* task function body is executing */
+					 dtp_executing:1,
+					 dtp_exec_exclude:1,
+					 dtp_dep_cnt:27;
 	/* refcount of the task */
 	uint32_t			 dtp_refcnt;
 	/**

--- a/src/include/daos/tse.h
+++ b/src/include/daos/tse.h
@@ -355,6 +355,9 @@ tse_task_addref(tse_task_t *task);
 void
 tse_task_decref(tse_task_t *task);
 
+void
+tse_task_set_exec_exclude(tse_task_t *task);
+
 /**
  * Add a newly created task to a list. It returns error if the task is already
  * running or completed.

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -1615,6 +1615,7 @@ obj_retry_cb(tse_task_t *task, struct dc_object *obj,
 
 	if (obj_auxi->io_retry) {
 		/* Let's reset task result before retry */
+		tse_task_set_exec_exclude(task); /* lxz */
 		rc = dc_task_resched(task);
 		if (rc != 0) {
 			D_ERROR("Failed to re-init task (%p)\n", task);


### PR DESCRIPTION
In obj_retry_cb(), in original code -
1st step dc_task_resched() the IO task, and then
2nd step dc_task_depend() register the IO task depend on pool map
    refresh task.

That is incorrect in multi-threads executing (for example dfuse fio
test). Because once IO task re-inited, it possibly be scheduled/executed
by another thread B (at the time without dep task), but the pool map
refresh thread may be executed on thread A and after pool task's finish
it possibly incorrect completes IO task (due to its dep task finished -
tse_task_post_process(pool_task) -> tse_task_complete_callback(io_task))
while the IO task still WIP at thread B. That possibly cause kinds of
crash (dfuse) or mem-corruption.

This patch changed some tse code and IO retry handling.
Incorrect fix, replaced by PR6931
backup for future's reference.

Signed-off-by: Xuezhao Liu <xuezhao.liu@intel.com>