### PR TITLE
DAOS-8433 engine: use 64KB for the ULT with deep stack

### DIFF
--- a/src/container/srv_target.c
+++ b/src/container/srv_target.c
@@ -1572,7 +1572,7 @@ ds_cont_local_open(uuid_t pool_uuid, uuid_t cont_hdl_uuid, uuid_t cont_uuid,
 		ddra->pool = ds_pool_child_get(hdl->sch_cont->sc_pool);
 		uuid_copy(ddra->co_uuid, cont_uuid);
 		rc = dss_ult_create(ds_dtx_resync, ddra, DSS_XS_SELF,
-				    0, 0, NULL);
+				    0, DSS_DEEP_STACK_SZ, NULL);
 		if (rc != 0) {
 			ds_pool_child_put(hdl->sch_cont->sc_pool);
 			D_FREE(ddra);

--- a/src/dtx/dtx_resync.c
+++ b/src/dtx/dtx_resync.c
@@ -688,7 +688,7 @@ dtx_resync_ult(void *data)
 		DP_UUID(arg->pool_uuid), pool->sp_dtx_resync_version,
 		arg->version);
 
-	rc = dss_thread_collective(dtx_resync_one, arg, 0);
+	rc = dss_thread_collective(dtx_resync_one, arg, DSS_ULT_DEEP_STACK);
 	if (rc) {
 		/* If dtx resync fails, then let's still update
 		 * sp_dtx_resync_version, so the rebuild can go ahead,

--- a/src/include/daos_srv/daos_engine.h
+++ b/src/include/daos_srv/daos_engine.h
@@ -513,6 +513,8 @@ int dss_parameters_set(unsigned int key_id, uint64_t value);
 enum dss_ult_flags {
 	/* Periodically created ULTs */
 	DSS_ULT_FL_PERIODIC	= (1 << 0),
+	/* Use DSS_DEEP_STACK_SZ for new created ULT */
+	DSS_ULT_DEEP_STACK	= (1 << 1),
 };
 
 int dss_ult_create(void (*func)(void *), void *arg, int xs_type, int tgt_id,

--- a/src/object/srv_ec_aggregate.c
+++ b/src/object/srv_ec_aggregate.c
@@ -1226,7 +1226,7 @@ agg_process_partial_stripe(struct ec_agg_entry *entry)
 	}
 	tid = dss_get_module_info()->dmi_tgt_id;
 	rc = dss_ult_create(agg_process_partial_stripe_ult, &stripe_ud,
-			    DSS_XS_IOFW, tid, 0, NULL);
+			    DSS_XS_IOFW, tid, DSS_DEEP_STACK_SZ, NULL);
 	if (rc)
 		goto ev_out;
 	rc = ABT_eventual_wait(stripe_ud.asu_eventual, (void **)&status);
@@ -1455,7 +1455,7 @@ agg_peer_update(struct ec_agg_entry *entry, bool write_parity)
 	}
 	tid = dss_get_module_info()->dmi_tgt_id;
 	rc = dss_ult_create(agg_peer_update_ult, &stripe_ud,
-			    DSS_XS_IOFW, tid, 0, NULL);
+			    DSS_XS_IOFW, tid, DSS_DEEP_STACK_SZ, NULL);
 	if (rc)
 		goto ev_out;
 	rc = ABT_eventual_wait(stripe_ud.asu_eventual, (void **)&status);
@@ -1739,7 +1739,7 @@ agg_process_holes(struct ec_agg_entry *entry)
 	}
 	tid = dss_get_module_info()->dmi_tgt_id;
 	rc = dss_ult_create(agg_process_holes_ult, &stripe_ud,
-			    DSS_XS_IOFW, tid, 0, NULL);
+			    DSS_XS_IOFW, tid, DSS_DEEP_STACK_SZ, NULL);
 	if (rc)
 		goto ev_out;
 	rc = ABT_eventual_wait(stripe_ud.asu_eventual, (void **)&status);


### PR DESCRIPTION
It will be helpful to avoid stack overflow for related ULT,
mainly include:

1. DTX resync related ULTs.

2. The ULT created for DSS_XS_IOFW. We have ever found that
   some ULT (created for DSS_XS_IOFW) overflow with default
   stack size (16 KB). Although we are not sure all of them
   will be, to be safe, use deep stack size (64 KB) for the
   ULT created for DSS_XS_IOFW that may use deep stack.

Signed-off-by: Fan Yong <fan.yong@intel.com>