### PR TITLE
DAOS-8767 pydaos: fix for direct uns access with pydaos

### DIFF
--- a/src/client/pydaos/pydaos_shim.c
+++ b/src/client/pydaos/pydaos_shim.c
@@ -278,8 +278,6 @@ __shim_handle__cont_open_by_path(PyObject *self, PyObject *args)
 	if (rc)
 		goto out;
 
-	if (attr.da_type != DAOS_PROP_CO_LAYOUT_PYTHON)
-		rc = -DER_INVAL;
 out:
 	obj = cont_open(rc, attr.da_pool, attr.da_cont, flags);
 	duns_destroy_attr(&attr);


### PR DESCRIPTION
remove check for cont type after duns_resolve_path() as it's not set
if using direct path (daos://pool/cont). The type is already checked
in cont_open later by fetching the layout property, so that check
was redundant anyway.

Signed-off-by: Mohamad Chaarawi <mohamad.chaarawi@intel.com>