### PR TITLE
DAOS-623 mpiio: change mpiio tests to use direct UNS access

### DIFF
--- a/src/tests/ftest/aggregation/basic.yaml
+++ b/src/tests/ftest/aggregation/basic.yaml
@@ -32,7 +32,7 @@ ior:
     client_processes:
         np_12:
             np: 12
-    test_file: daos:testFile
+    test_file: daos:/testFile
     repetitions: 1
     dfs_destroy: False
     iorflags:

--- a/src/tests/ftest/aggregation/io_small.yaml
+++ b/src/tests/ftest/aggregation/io_small.yaml
@@ -32,7 +32,7 @@ ior:
     client_processes:
         np_12:
             np: 12
-    test_file: daos:testFile
+    test_file: daos:/testFile
     repetitions: 1
     dfs_destroy: False
     iorflags:

--- a/src/tests/ftest/aggregation/throttling.yaml
+++ b/src/tests/ftest/aggregation/throttling.yaml
@@ -32,7 +32,7 @@ ior:
     client_processes:
         np_12:
             np: 12
-    test_file: daos:testFile
+    test_file: daos:/testFile
     repetitions: 1
     dfs_destroy: False
     iorflags:

--- a/src/tests/ftest/dfuse/caching_check.yaml
+++ b/src/tests/ftest/dfuse/caching_check.yaml
@@ -25,7 +25,7 @@ ior:
     client_processes:
         np_16:
             np: 16
-    test_file: daos:testFile
+    test_file: testFile
     repetitions: 1
     api: POSIX
     dfs_destroy: False

--- a/src/tests/ftest/ior/hard.yaml
+++ b/src/tests/ftest/ior/hard.yaml
@@ -52,7 +52,7 @@ ior:
   ior_api:
     daos:
       api: DFS
-  test_file: daos:testFile
+  test_file: /testFile
   repetitions: 1
   transfer_size: '47008'
   block_size: '47008'

--- a/src/tests/ftest/ior/intercept_basic.yaml
+++ b/src/tests/ftest/ior/intercept_basic.yaml
@@ -27,7 +27,7 @@ ior:
     client_processes:
         np_16:
             np: 16
-    test_file: daos:testFile
+    test_file: testFile
     repetitions: 1
 # Remove the below line once DAOS-3143 is resolved
     dfs_destroy: False

--- a/src/tests/ftest/ior/intercept_messages.yaml
+++ b/src/tests/ftest/ior/intercept_messages.yaml
@@ -25,7 +25,7 @@ ior:
     client_processes:
       np_16:
         np: 16
-    test_file: daos:testFile
+    test_file: testFile
     repetitions: 1
     iorflags:
       flags: "-v -w -r"

--- a/src/tests/ftest/ior/intercept_multi_client.yaml
+++ b/src/tests/ftest/ior/intercept_multi_client.yaml
@@ -28,7 +28,7 @@ container:
 ior:
     client_processes:
       np: 16
-    test_file: daos:testFile
+    test_file: testFile
     repetitions: 1
 # Remove the below line once DAOS-3143 is resolved
     dfs_destroy: False

--- a/src/tests/ftest/ior/intercept_verify_data_integrity.yaml
+++ b/src/tests/ftest/ior/intercept_verify_data_integrity.yaml
@@ -39,7 +39,7 @@ ior:
     client_processes:
         np_24:
             np: 24
-    test_file: daos:testFile
+    test_file: testFile
     repetitions: 1
 # Remove the below line once DAOS-3143 is resolved
     dfs_destroy: False

--- a/src/tests/ftest/ior/large.yaml
+++ b/src/tests/ftest/ior/large.yaml
@@ -68,7 +68,7 @@ ior:
       api: MPIIO
     posix:
       api: POSIX
-  test_file: daos:testFile
+  test_file: daos:/testFile
   repetitions: 3
   transfersize_blocksize: !mux
     1K:

--- a/src/tests/ftest/ior/small.py
+++ b/src/tests/ftest/ior/small.py
@@ -34,7 +34,7 @@ class IorSmall(IorTestBase):
 
         :avocado: tags=all,pr,daily_regression
         :avocado: tags=hw,large
-        :avocado: tags=daosio,checksum,mpich,dfuse,DAOS_5610
+        :avocado: tags=daosio,mpiio,checksum,mpich,dfuse,DAOS_5610
         :avocado: tags=iorsmall
         """
         results = []

--- a/src/tests/ftest/ior/small.yaml
+++ b/src/tests/ftest/ior/small.yaml
@@ -40,7 +40,7 @@ ior:
     client_processes:
         np_16:
             np: 16
-    test_file: daos:testFile
+    test_file: daos:/testFile
     repetitions: 2
     dfs_destroy: False
     iorflags:

--- a/src/tests/ftest/mpiio/hdf5.py
+++ b/src/tests/ftest/mpiio/hdf5.py
@@ -64,7 +64,7 @@ class Hdf5(MpiioTests):
 
         :avocado: tags=all,daily_regression
         :avocado: tags=hw,small
-        :avocado: tags=mpio,llnlmpi4pyhdf5,hdf5,hdf5testsuite
+        :avocado: tags=mpiio,mpich,llnlmpi4pyhdf5,hdf5,hdf5testsuite
         """
         test_repo = self.params.get("hdf5", '/run/test_repo/')
         self.run_test(test_repo, "hdf5")

--- a/src/tests/ftest/nvme/enospace.yaml
+++ b/src/tests/ftest/nvme/enospace.yaml
@@ -59,7 +59,7 @@ ior:
   iorflags:
       flags: "-w -F -k -G 1"
       read_flags: "-r -R -F -k -G 1"
-  test_file: daos:testFile
+  test_file: /testFile
   repetitions: 1
   transfersize_blocksize:
     2K:

--- a/src/tests/ftest/rebuild/with_ior.py
+++ b/src/tests/ftest/rebuild/with_ior.py
@@ -40,8 +40,8 @@ class RbldWithIOR(IorTestBase):
         # ior parameters
         iorflags_write = self.params.get("F", '/run/ior/iorflags/write/')
         iorflags_read = self.params.get("F", '/run/ior/iorflags/read/')
-        file1 = "daos:testFile1"
-        file2 = "daos:testFile2"
+        file1 = "daos:/testFile1"
+        file2 = "daos:/testFile2"
 
         # create pool
         self.create_pool()

--- a/src/tests/ftest/soak/faults.yaml
+++ b/src/tests/ftest/soak/faults.yaml
@@ -129,7 +129,7 @@ ior_faults:
         - POSIX
         - HDF5
         - HDF5-VOL
-    test_file: daos:testFile
+    test_file: daos:/testFile
     flags: -v -w -W -r -R
     block_size:
         - '64M'

--- a/src/tests/ftest/soak/harassers.yaml
+++ b/src/tests/ftest/soak/harassers.yaml
@@ -144,7 +144,7 @@ ior_harasser:
         - MPIIO
         - POSIX
         - HDF5
-    test_file: daos:testFile
+    test_file: daos:/testFile
     flags: -v -w -W -r -R -F -k
     block_size:
         - '64M'

--- a/src/tests/ftest/soak/smoke.yaml
+++ b/src/tests/ftest/soak/smoke.yaml
@@ -112,7 +112,7 @@ ior_smoke:
         - POSIX
         - HDF5
         - HDF5-VOL
-    test_file: daos:testFile
+    test_file: daos:/testFile
     flags: -v -w -W -r -R -k -F
     block_size:
         - '64M'

--- a/src/tests/ftest/soak/stress_2h.yaml
+++ b/src/tests/ftest/soak/stress_2h.yaml
@@ -101,7 +101,7 @@ ior_stress:
     api:
         - DFS
         - MPIIO
-    test_file: daos:testFile
+    test_file: daos:/testFile
     flags: -v -w -W -r -R
     block_size:
         - '1G'

--- a/src/tests/ftest/soak/stress_48h.yaml
+++ b/src/tests/ftest/soak/stress_48h.yaml
@@ -129,7 +129,7 @@ ior_stress:
         - POSIX
         - HDF5
         - HDF5-VOL
-    test_file: daos:testFile
+    test_file: daos:/testFile
     flags: -v -w -W -r -R -k
     block_size:
         - '64M'

--- a/src/tests/ftest/telemetry/telemetry_pool_metrics.yaml
+++ b/src/tests/ftest/telemetry/telemetry_pool_metrics.yaml
@@ -32,6 +32,6 @@ ior:
   transfer_size: 1M
   block_size: 536870912
   dfs_destroy: False
-  test_file: daos:testFile
+  test_file: /testFile
 dfuse:
   mount_dir: "/tmp/daos_dfuse"

--- a/src/tests/ftest/util/ior_test_base.py
+++ b/src/tests/ftest/util/ior_test_base.py
@@ -89,7 +89,7 @@ class IorTestBase(DfuseTestBase):
             pool.set_query_data()
 
     def run_ior_with_pool(self, intercept=None, test_file_suffix="",
-                          test_file="daos:testFile", create_pool=True,
+                          test_file="daos:/testFile", create_pool=True,
                           create_cont=True, stop_dfuse=True, plugin_path=None,
                           timeout=None, fail_on_warning=False,
                           mount_dir=None, out_queue=None, env=None):
@@ -105,7 +105,7 @@ class IorTestBase(DfuseTestBase):
             test_file_suffix (str, optional): suffix to add to the end of the
                 test file name. Defaults to "".
             test_file (str, optional): ior test file name. Defaults to
-                "daos:testFile". Is ignored when using POSIX through DFUSE.
+                "daos:/testFile". Is ignored when using POSIX through DFUSE.
             create_pool (bool, optional): If it is true, create pool and
                 container else just run the ior. Defaults to True.
             create_cont (bool, optional): Create new container. Default is True

--- a/src/tests/ftest/util/ior_utils.py
+++ b/src/tests/ftest/util/ior_utils.py
@@ -235,9 +235,8 @@ class IorCommand(ExecutableCommand):
 
         if "mpirun" in manager_cmd or "srun" in manager_cmd:
             if self.dfs_pool.value is not None:
-                env["DAOS_POOL"] = self.dfs_pool.value
-                env["DAOS_CONT"] = self.dfs_cont.value
-                env["DAOS_BYPASS_DUNS"] = "1"
+                env["DAOS_UNS_PREFIX"] = "daos://{}/{}/".format(self.dfs_pool.value,
+                                                                self.dfs_cont.value)
                 if self.dfs_oclass.value is not None:
                     env["IOR_HINT__MPI__romio_daos_obj_class"] = \
                         self.dfs_oclass.value

--- a/src/tests/ftest/util/mpio_utils.py
+++ b/src/tests/ftest/util/mpio_utils.py
@@ -87,9 +87,7 @@ class MpioUtils():
 
         # environment variables only to be set on client node
         env = EnvironmentVariables()
-        env["DAOS_POOL"] = "{}".format(pool_uuid)
-        env["DAOS_CONT"] = "{}".format(cont_uuid)
-        env["DAOS_BYPASS_DUNS"] = "1"
+        env["DAOS_UNS_PREFIX"] = "daos://{}/{}/".format(pool_uuid, cont_uuid)
         mpirun = os.path.join(self.mpichinstall, "bin", "mpirun")
 
         executables = {
@@ -117,10 +115,10 @@ class MpioUtils():
         commands = []
         if test_name == "romio":
             commands.append(
-                "{} -fname=daos:test1 -subset".format(
+                "{} -fname=daos:/test1 -subset".format(
                     executables[test_name][0]))
         elif test_name == "llnl":
-            env["MPIO_USER_PATH"] = "daos:"
+            env["MPIO_USER_PATH"] = "daos:/"
             for exe in executables[test_name]:
                 commands.append(
                     "{} -np {} --hostfile {} {} 1".format(


### PR DESCRIPTION
- old way with bypassing UNS and setting pool and cont env variables
is not production way.
- Also fix how different APIs pass the testfile name:
MPIIO should use daos:/testfile
DFS should use /testfile
POSIX should use /dfuse/path/testfile

Signed-off-by: Mohamad Chaarawi <mohamad.chaarawi@intel.com>