### PR TITLE
DAOS-8579 duns: initialize dir on stack

### DIFF
--- a/src/client/dfs/duns.c
+++ b/src/client/dfs/duns.c
@@ -423,7 +423,7 @@ duns_resolve_path(const char *path, struct duns_attr_t *attr)
 	size_t		rel_len = 0;
 	int		rc;
 #ifdef LUSTRE_INCLUDE
-	char *dir;
+	char *dir = NULL;
 #endif
 
 	if (path == NULL || strlen(path) == 0)


### PR DESCRIPTION
When compiling with lustre support, need to initialize
dir variable with NULL on stack, in order` to avoid false
assumption it needs to be freed upon exit of duns_resolve_path().

Change-Id: I59105ad88048853c59407224dfe0ca8c438e5178
Signed-off-by: Bruno Faccini <bruno.faccini@intel.com>