### PR TITLE
DAOS-8782 pool: Remove meta files

### DIFF
--- a/src/common/pool_map.c
+++ b/src/common/pool_map.c
@@ -1381,15 +1381,6 @@ pool_map_merge(struct pool_map *map, uint32_t version,
 }
 
 static int
-uuid_compare_cb(const void *a, const void *b)
-{
-	uuid_t *ua = (uuid_t *)a;
-	uuid_t *ub = (uuid_t *)b;
-
-	return uuid_compare(*ua, *ub);
-}
-
-static int
 add_domains_to_pool_buf(struct pool_map *map, struct pool_buf *map_buf,
 			int map_version,
 			int ndomains, const uint32_t *domains)
@@ -1467,16 +1458,13 @@ add_domains_to_pool_buf(struct pool_map *map, struct pool_buf *map_buf,
 }
 
 int
-gen_pool_buf(struct pool_map *map, struct pool_buf **map_buf_out,
-		int map_version, int ndomains, int nnodes, int ntargets,
-		const uint32_t *domains, uuid_t target_uuids[],
-		const d_rank_list_t *target_addrs, uuid_t **uuids_out,
-		uint32_t dss_tgt_nr)
+gen_pool_buf(struct pool_map *map, struct pool_buf **map_buf_out, int map_version, int ndomains,
+	     int nnodes, int ntargets, const uint32_t *domains, const d_rank_list_t *ranks,
+	     uint32_t dss_tgt_nr)
 {
 	struct pool_component	map_comp;
 	struct pool_buf		*map_buf;
 	struct pool_domain	*found_dom;
-	uuid_t			*uuids = NULL;
 	uint32_t		num_comps;
 	uint8_t			new_status;
 	bool			updated;
@@ -1496,17 +1484,9 @@ gen_pool_buf(struct pool_map *map, struct pool_buf **map_buf_out,
 	D_ASSERT(num_domain_comps > 0);
 	num_domain_comps--; /* remove the root domain - allocated separately */
 
-	/* Prepare the pool map attribute buffers. */
 	map_buf = pool_buf_alloc(num_domain_comps + nnodes + ntargets);
 	if (map_buf == NULL)
 		D_GOTO(out_map_buf, rc = -DER_NOMEM);
-
-	/* Make a sorted target UUID array to determine target IDs. */
-	D_ALLOC_ARRAY_NZ(uuids, nnodes);
-	if (uuids == NULL)
-		D_GOTO(out_map_buf, rc = -DER_NOMEM);
-	memcpy(uuids, target_uuids, sizeof(uuid_t) * nnodes);
-	qsort(uuids, nnodes, sizeof(uuid_t), uuid_compare_cb);
 
 	rc = add_domains_to_pool_buf(map, map_buf, map_version, ndomains,
 				     domains);
@@ -1524,12 +1504,8 @@ gen_pool_buf(struct pool_map *map, struct pool_buf **map_buf_out,
 
 	/* fill nodes */
 	for (i = 0; i < nnodes; i++) {
-		uuid_t *p = bsearch(target_uuids[i], uuids, nnodes,
-				    sizeof(uuid_t), uuid_compare_cb);
-
 		if (map) {
-			found_dom = pool_map_find_node_by_rank(map,
-					target_addrs->rl_ranks[i]);
+			found_dom = pool_map_find_node_by_rank(map, ranks->rl_ranks[i]);
 			if (found_dom)
 				continue;
 		}
@@ -1539,8 +1515,8 @@ gen_pool_buf(struct pool_map *map, struct pool_buf **map_buf_out,
 		map_comp.co_status = new_status;
 		map_comp.co_index = i + num_comps;
 		map_comp.co_padding = 0;
-		map_comp.co_id = (p - uuids) + num_comps;
-		map_comp.co_rank = target_addrs->rl_ranks[i];
+		map_comp.co_id = ranks->rl_ranks[i];
+		map_comp.co_rank = ranks->rl_ranks[i];
 		map_comp.co_ver = map_version;
 		map_comp.co_in_ver = map_version;
 		map_comp.co_fseq = 1;
@@ -1573,7 +1549,7 @@ gen_pool_buf(struct pool_map *map, struct pool_buf **map_buf_out,
 			map_comp.co_index = j;
 			map_comp.co_padding = 0;
 			map_comp.co_id = (i * dss_tgt_nr + j) + num_comps;
-			map_comp.co_rank = target_addrs->rl_ranks[i];
+			map_comp.co_rank = ranks->rl_ranks[i];
 			map_comp.co_ver = map_version;
 			map_comp.co_in_ver = map_version;
 			map_comp.co_fseq = 1;
@@ -1585,17 +1561,12 @@ gen_pool_buf(struct pool_map *map, struct pool_buf **map_buf_out,
 				D_GOTO(out_map_buf, rc);
 		}
 	}
-	if (uuids_out)
-		*uuids_out = uuids;
-	else
-		D_FREE(uuids);
 
 	*map_buf_out = map_buf;
 	return 0;
 
 out_map_buf:
 	pool_buf_free(map_buf);
-	D_FREE(uuids);
 	return rc;
 }
 

--- a/src/include/daos/pool_map.h
+++ b/src/include/daos/pool_map.h
@@ -220,11 +220,9 @@ void pool_buf_free(struct pool_buf *buf);
 int  pool_buf_extract(struct pool_map *map, struct pool_buf **buf_pp);
 int  pool_buf_attach(struct pool_buf *buf, struct pool_component *comps,
 		     unsigned int comp_nr);
-int gen_pool_buf(struct pool_map *map, struct pool_buf **map_buf_out,
-		int map_version, int ndomains, int nnodes, int ntargets,
-		const uint32_t *domains, uuid_t target_uuids[],
-		const d_rank_list_t *target_addrs, uuid_t **uuids_out,
-		uint32_t dss_tgt_nr);
+int gen_pool_buf(struct pool_map *map, struct pool_buf **map_buf_out, int map_version, int ndomains,
+		 int nnodes, int ntargets, const uint32_t *domains, const d_rank_list_t *ranks,
+		 uint32_t dss_tgt_nr);
 
 int pool_map_comp_cnt(struct pool_map *map);
 

--- a/src/include/daos_srv/pool.h
+++ b/src/include/daos_srv/pool.h
@@ -150,27 +150,17 @@ int ds_pool_tgt_add_in(uuid_t pool_uuid, struct pool_target_id_list *list);
 int ds_pool_tgt_map_update(struct ds_pool *pool, struct pool_buf *buf,
 			   unsigned int map_version);
 
-/*
- * TODO: Make the following internal functions of ds_pool after merging in
- * mgmt.
- */
-
-int ds_pool_create(const uuid_t pool_uuid, const char *path,
-		   uuid_t target_uuid);
 int ds_pool_start(uuid_t uuid);
 void ds_pool_stop(uuid_t uuid);
-int ds_pool_extend(uuid_t pool_uuid, int ntargets, uuid_t target_uuids[],
-		   const d_rank_list_t *rank_list, int ndomains,
+int ds_pool_extend(uuid_t pool_uuid, int ntargets, const d_rank_list_t *rank_list, int ndomains,
 		   const uint32_t *domains, d_rank_list_t *svc_ranks);
 int ds_pool_target_update_state(uuid_t pool_uuid, d_rank_list_t *ranks,
 				struct pool_target_addr_list *target_list,
 				pool_comp_state_t state);
 
-int ds_pool_svc_create(const uuid_t pool_uuid, int ntargets,
-		       uuid_t target_uuids[], const char *group,
-		       const d_rank_list_t *target_addrs, int ndomains,
-		       const uint32_t *domains, daos_prop_t *prop,
-		       d_rank_list_t *svc_addrs);
+int ds_pool_svc_create(const uuid_t pool_uuid, int ntargets, const char *group,
+		       const d_rank_list_t *target_addrs, int ndomains, const uint32_t *domains,
+		       daos_prop_t *prop, d_rank_list_t *svc_addrs);
 int ds_pool_svc_destroy(const uuid_t pool_uuid, d_rank_list_t *svc_ranks);
 
 int ds_pool_svc_get_prop(uuid_t pool_uuid, d_rank_list_t *ranks,

--- a/src/mgmt/rpc.h
+++ b/src/mgmt/rpc.h
@@ -150,7 +150,6 @@ CRT_RPC_DECLARE(mgmt_pool_find, DAOS_ISEQ_MGMT_POOL_FIND,
 	((daos_size_t)		(tc_nvme_size)		CRT_VAR)
 
 #define DAOS_OSEQ_MGMT_TGT_CREATE /* output fields */		   \
-	((uuid_t)		(tc_tgt_uuids)		CRT_ARRAY) \
 	((d_rank_t)		(tc_ranks)		CRT_ARRAY) \
 	((int32_t)		(tc_rc)			CRT_VAR)
 

--- a/src/mgmt/srv_target.c
+++ b/src/mgmt/srv_target.c
@@ -545,7 +545,6 @@ ds_mgmt_tgt_create_post_reply(crt_rpc_t *rpc, void *priv)
 	struct mgmt_tgt_create_out	*tc_out;
 
 	tc_out = crt_reply_get(rpc);
-	D_FREE(tc_out->tc_tgt_uuids.ca_arrays);
 	D_FREE(tc_out->tc_ranks.ca_arrays);
 
 	return 0;
@@ -557,67 +556,48 @@ ds_mgmt_tgt_create_aggregator(crt_rpc_t *source, crt_rpc_t *result,
 {
 	struct mgmt_tgt_create_out	*tc_out;
 	struct mgmt_tgt_create_out	*ret_out;
-	uuid_t				*tc_uuids;
 	d_rank_t			*tc_ranks;
-	unsigned int			tc_uuids_nr;
-	uuid_t				*ret_uuids;
+	unsigned int			tc_ranks_nr;
 	d_rank_t			*ret_ranks;
-	unsigned int			ret_uuids_nr;
-	uuid_t				*new_uuids;
+	unsigned int			ret_ranks_nr;
 	d_rank_t			*new_ranks;
-	unsigned int			new_uuids_nr;
+	unsigned int			new_ranks_nr;
 	int				i;
 
 	tc_out = crt_reply_get(source);
-	tc_uuids_nr = tc_out->tc_tgt_uuids.ca_count;
-	tc_uuids = tc_out->tc_tgt_uuids.ca_arrays;
 	tc_ranks = tc_out->tc_ranks.ca_arrays;
+	tc_ranks_nr = tc_out->tc_ranks.ca_count;
 
 	ret_out = crt_reply_get(result);
-	ret_uuids_nr = ret_out->tc_tgt_uuids.ca_count;
-	ret_uuids = ret_out->tc_tgt_uuids.ca_arrays;
 	ret_ranks = ret_out->tc_ranks.ca_arrays;
+	ret_ranks_nr = ret_out->tc_ranks.ca_count;
 
 	if (tc_out->tc_rc != 0)
 		ret_out->tc_rc = tc_out->tc_rc;
-	if (tc_uuids_nr == 0)
+	if (tc_ranks_nr == 0)
 		return 0;
 
-	new_uuids_nr = ret_uuids_nr + tc_uuids_nr;
+	new_ranks_nr = ret_ranks_nr + tc_ranks_nr;
 
-	/* Append tc_uuids to ret_uuids */
-	D_ALLOC_ARRAY(new_uuids, new_uuids_nr);
-	if (new_uuids == NULL)
+	D_ALLOC_ARRAY(new_ranks, new_ranks_nr);
+	if (new_ranks == NULL)
 		return -DER_NOMEM;
 
-	D_ALLOC_ARRAY(new_ranks, new_uuids_nr);
-	if (new_ranks == NULL) {
-		D_FREE(new_uuids);
-		return -DER_NOMEM;
-	}
-
-	for (i = 0; i < new_uuids_nr; i++) {
-		if (i < ret_uuids_nr) {
-			uuid_copy(new_uuids[i], ret_uuids[i]);
+	for (i = 0; i < new_ranks_nr; i++) {
+		if (i < ret_ranks_nr)
 			new_ranks[i] = ret_ranks[i];
-		} else {
-			uuid_copy(new_uuids[i], tc_uuids[i - ret_uuids_nr]);
-			new_ranks[i] = tc_ranks[i - ret_uuids_nr];
-		}
+		else
+			new_ranks[i] = tc_ranks[i - ret_ranks_nr];
 	}
 
-	D_FREE(ret_uuids);
 	D_FREE(ret_ranks);
 
-	ret_out->tc_tgt_uuids.ca_arrays = new_uuids;
-	ret_out->tc_tgt_uuids.ca_count = new_uuids_nr;
 	ret_out->tc_ranks.ca_arrays = new_ranks;
-	ret_out->tc_ranks.ca_count = new_uuids_nr;
+	ret_out->tc_ranks.ca_count = new_ranks_nr;
 	return 0;
 }
 
 struct tgt_create_args {
-	uuid_t			 tca_tgt_uuid;
 	char			*tca_newborn;
 	char			*tca_path;
 	struct ds_pooltgts_rec	*tca_ptrec;
@@ -642,8 +622,6 @@ tgt_create_preallocate(void *arg)
 	rc = access(tca->tca_path, F_OK);
 	if (rc >= 0) {
 		/** target already exists, let's reuse it for idempotence */
-		/** TODO: fetch tgt uuid from existing DSM pool */
-		uuid_generate(tca->tca_tgt_uuid);
 
 		/**
 		 * flush again in case the previous one in tgt_create()
@@ -679,14 +657,6 @@ tgt_create_preallocate(void *arg)
 					     1 << 24), dss_tgt_nr);
 		if (rc)
 			goto out;
-
-		/** initialize DAOS-M target and fetch uuid */
-		rc = ds_pool_create(tca->tca_ptrec->dptr_uuid, tca->tca_newborn,
-				    tca->tca_tgt_uuid);
-		if (rc) {
-			D_ERROR("ds_pool_create failed: "DF_RC"\n", DP_RC(rc));
-			goto out;
-		}
 	} else {
 		rc = daos_errno2der(errno);
 	}
@@ -707,7 +677,6 @@ ds_mgmt_hdlr_tgt_create(crt_rpc_t *tc_req)
 	struct mgmt_tgt_create_out	*tc_out;
 	struct tgt_create_args		 tca = {0};
 	d_rank_t			*rank = NULL;
-	uuid_t				*tmp_tgt_uuid = NULL;
 	pthread_t			 thread;
 	bool				 canceled_thread = false;
 	int				 rc = 0;
@@ -823,14 +792,6 @@ ds_mgmt_hdlr_tgt_create(crt_rpc_t *tc_req)
 		(void)dir_fsync(tca.tca_path);
 	}
 
-	D_ALLOC_PTR(tmp_tgt_uuid);
-	if (tmp_tgt_uuid == NULL)
-		D_GOTO(out, rc = -DER_NOMEM);
-
-	uuid_copy(*tmp_tgt_uuid, tca.tca_tgt_uuid);
-	tc_out->tc_tgt_uuids.ca_arrays = tmp_tgt_uuid;
-	tc_out->tc_tgt_uuids.ca_count  = 1;
-
 	D_ALLOC_PTR(rank);
 	if (rank == NULL)
 		D_GOTO(out, rc = -DER_NOMEM);
@@ -868,10 +829,8 @@ out_rec:
 out_reply:
 	tc_out->tc_rc = rc;
 	rc = crt_reply_send(tc_req);
-	if (rc) {
+	if (rc)
 		D_FREE(rank);
-		D_FREE(tmp_tgt_uuid);
-	}
 }
 
 static void *

--- a/src/placement/tests/jump_map_place_obj.c
+++ b/src/placement/tests/jump_map_place_obj.c
@@ -430,10 +430,8 @@ jtc_pool_map_extend(struct jm_test_ctx *ctx, uint32_t domain_count,
 
 	map_version = pool_map_get_version(ctx->po_map) + 1;
 
-	rc = gen_pool_buf(ctx->po_map, &map_buf, map_version,
-			  domain_tree_len,
-			  node_count, ntargets, domain_tree, target_uuids,
-			  &rank_list, NULL, target_count);
+	rc = gen_pool_buf(ctx->po_map, &map_buf, map_version, domain_tree_len, node_count,
+			  ntargets, domain_tree, &rank_list, target_count);
 	D_FREE(domain_tree);
 	assert_success(rc);
 

--- a/src/placement/tests/place_obj_common.c
+++ b/src/placement/tests/place_obj_common.c
@@ -797,12 +797,9 @@ get_object_classes(daos_oclass_id_t **oclass_id_pp)
 }
 
 int
-extend_test_pool_map(struct pool_map *map,
-		     uint32_t nnodes, uuid_t target_uuids[],
-		     d_rank_list_t *rank_list, uint32_t ndomains,
-		     uint32_t *domains, bool *updated_p,
-		     uint32_t *map_version_p,
-		     uint32_t dss_tgt_nr)
+extend_test_pool_map(struct pool_map *map, uint32_t nnodes, d_rank_list_t *rank_list,
+		     uint32_t ndomains, uint32_t *domains, bool *updated_p,
+		     uint32_t *map_version_p, uint32_t dss_tgt_nr)
 {
 	struct pool_buf	*map_buf = NULL;
 	uint32_t	map_version;
@@ -813,9 +810,8 @@ extend_test_pool_map(struct pool_map *map,
 
 	map_version = pool_map_get_version(map) + 1;
 
-	rc = gen_pool_buf(map, &map_buf, map_version, ndomains, nnodes,
-			  ntargets, domains, target_uuids, rank_list, NULL,
-			dss_tgt_nr);
+	rc = gen_pool_buf(map, &map_buf, map_version, ndomains, nnodes, ntargets, domains,
+			  rank_list, dss_tgt_nr);
 	assert_success(rc);
 
 	D_ASSERT(map_buf != NULL);

--- a/src/placement/tests/place_obj_common.h
+++ b/src/placement/tests/place_obj_common.h
@@ -122,8 +122,7 @@ int
 get_object_classes(daos_oclass_id_t **oclass_id_pp);
 
 int
-extend_test_pool_map(struct pool_map *map, uint32_t nnodes,
-		     uuid_t target_uuids[], d_rank_list_t *rank_list,
+extend_test_pool_map(struct pool_map *map, uint32_t nnodes, d_rank_list_t *rank_list,
 		     uint32_t ndomains, uint32_t *domains, bool *updated_p,
 		     uint32_t *map_version_p, uint32_t dss_tgt_nr);
 

--- a/src/pool/README.md
+++ b/src/pool/README.md
@@ -24,7 +24,7 @@ The top-level KVS stores the pool map, security attributes such as the UID, GID 
 
 #### Pool / Pool Service Creation
 
-Pool creation is driven entirely by the Management Service since it requires special privileges for steps related to allocation of storage and querying of fault domains. After formatting all the targets, the Target component calls `ds_pool_create` of the Pool Module on each target, which simply generates a new UUID for the current target and stores it in the `DSM_META_FILE`. At this point the management module passes the control to the pool module by calling the`ds_pool_svc_create`, which initializes service replication on the selected subset of nodes for the combined Pool and Container Service. The Pool module now sends a `POOL_CREATE` request to the service leader which creates the service database; the list of targets and their fault domains are then converted into the initial version of the pool map and stored in the pool service, along with other initial pool metadata.
+Pool creation is driven entirely by the Management Service since it requires special privileges for steps related to allocation of storage and querying of fault domains. After formatting all the targets, the management module passes the control to the pool module by calling the`ds_pool_svc_create`, which initializes service replication on the selected subset of nodes for the combined Pool and Container Service. The Pool module now sends a `POOL_CREATE` request to the service leader which creates the service database; the list of targets and their fault domains are then converted into the initial version of the pool map and stored in the pool service, along with other initial pool metadata.
 
 <a id="9.3.2"></a>
 

--- a/src/pool/rpc.h
+++ b/src/pool/rpc.h
@@ -157,7 +157,6 @@ CRT_RPC_DECLARE(pool_op, DAOS_ISEQ_POOL_OP, DAOS_OSEQ_POOL_OP)
 
 #define DAOS_ISEQ_POOL_CREATE	/* input fields */		 \
 	((struct pool_op_in)	(pri_op)		CRT_VAR) \
-	((uuid_t)		(pri_tgt_uuids)		CRT_ARRAY) \
 	((d_rank_list_t)	(pri_tgt_ranks)		CRT_PTR) \
 	((daos_prop_t)		(pri_prop)		CRT_PTR) \
 	((uint32_t)		(pri_ndomains)		CRT_VAR) \
@@ -283,7 +282,6 @@ CRT_RPC_DECLARE(pool_replicas_remove, DAOS_ISEQ_POOL_MEMBERSHIP,
 
 #define DAOS_ISEQ_POOL_EXTEND /* input fields */		 \
 	((struct pool_op_in)	(pei_op)		CRT_VAR) \
-	((uuid_t)		(pei_tgt_uuids)		CRT_ARRAY) \
 	((d_rank_list_t)	(pei_tgt_ranks)		CRT_PTR) \
 	((uint32_t)		(pei_ntgts)		CRT_VAR) \
 	((uint32_t)		(pei_ndomains)		CRT_VAR) \

--- a/src/pool/srv_layout.c
+++ b/src/pool/srv_layout.c
@@ -17,7 +17,6 @@
 RDB_STRING_KEY(ds_pool_prop_, version);
 RDB_STRING_KEY(ds_pool_prop_, map_version);
 RDB_STRING_KEY(ds_pool_prop_, map_buffer);
-RDB_STRING_KEY(ds_pool_prop_, map_uuids);
 RDB_STRING_KEY(ds_pool_prop_, label);
 RDB_STRING_KEY(ds_pool_prop_, acl);
 RDB_STRING_KEY(ds_pool_prop_, space_rb);
@@ -27,11 +26,8 @@ RDB_STRING_KEY(ds_pool_prop_, owner);
 RDB_STRING_KEY(ds_pool_prop_, owner_group);
 RDB_STRING_KEY(ds_pool_prop_, connectable);
 RDB_STRING_KEY(ds_pool_prop_, nhandles);
-/** pool handle KVS */
 RDB_STRING_KEY(ds_pool_prop_, handles);
 RDB_STRING_KEY(ds_pool_prop_, ec_cell_sz);
-
-/** user attributed KVS */
 RDB_STRING_KEY(ds_pool_attr_, user);
 
 /** default properties, should cover all optional pool properties */

--- a/src/pool/srv_layout.h
+++ b/src/pool/srv_layout.h
@@ -44,7 +44,6 @@
 extern d_iov_t ds_pool_prop_version;		/* uint32_t */
 extern d_iov_t ds_pool_prop_map_version;	/* uint32_t */
 extern d_iov_t ds_pool_prop_map_buffer;		/* pool_buf */
-extern d_iov_t ds_pool_prop_map_uuids;		/* uuid_t[] (unused now) */
 extern d_iov_t ds_pool_prop_label;		/* string */
 extern d_iov_t ds_pool_prop_acl;		/* daos_acl */
 extern d_iov_t ds_pool_prop_space_rb;		/* uint64_t */


### PR DESCRIPTION
The "meta" file in each pool's directory store the "target UUID" of the
engine in this pool. The file and the UUID were originally introduced
for engine ranks that could change across system restarts. Since ranks
are now persistent, these files and UUIDs are no longer required.
Moreover, the UUIDs are also stored in the pool RDB, but they do not
include any UUIDs corresponding to engines added to the pool after the
pool is created. Hence, this patch removes these UUIDs and "meta" files
to simplify the persistent state as well as to avoid confusions:

  - Determine node component's IDs in a pool map using ranks instead of
    "target UUIDs".
  - Remove "target UUIDs" in pool RDBs.
  - Remove "target UUIDs" in some pool RPCs.
  - Remove "meta" files.

Signed-off-by: Li Wei <wei.g.li@intel.com>