### PR TITLE
DAOS-8685 pool: run create tests with logging, CentOS8 HW

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,7 +12,7 @@
 
 // To use a test branch (i.e. PR) until it lands to master
 // I.e. for testing library changes
-//@Library(value="pipeline-lib@your_branch") _
+@Library(value="pipeline-lib@bmurrell/run-prs-on-el8-hw") _
 
 // For master, this is just some wildly high number
 next_version = "1000"
@@ -1054,7 +1054,7 @@ pipeline {
                     }
                     steps {
                         functionalTest inst_repos: daosRepos(),
-                                       inst_rpms: functionalPackages(1, next_version),
+                                       inst_rpms: functionalPackages("centos8", 1, next_version),
                                        test_function: 'runTestFunctionalV2'
                     }
                     post {
@@ -1075,7 +1075,7 @@ pipeline {
                     steps {
                         functionalTest target: hwDistroTarget(),
                                        inst_repos: daosRepos(),
-                                       inst_rpms: functionalPackages(1, next_version),
+                                       inst_rpms: functionalPackages("centos8", 1, next_version),
                                        test_function: 'runTestFunctionalV2'
                    }
                     post {
@@ -1096,7 +1096,7 @@ pipeline {
                     steps {
                         functionalTest target: hwDistroTarget(),
                                        inst_repos: daosRepos(),
-                                       inst_rpms: functionalPackages(1, next_version),
+                                       inst_rpms: functionalPackages("centos8", 1, next_version),
                                        test_function: 'runTestFunctionalV2'
                     }
                     post {

--- a/ci/functional/required_packages.sh
+++ b/ci/functional/required_packages.sh
@@ -27,11 +27,8 @@ elif [[ $distro = el* ]] || [[ $distro = centos* ]] ||
           testmpio                     \
           python$pyver-mpi4py-tests    \
           hdf5-mpich-tests             \
-          hdf5-$openmpi-tests          \
-          hdf5-vol-daos-$openmpi-tests \
           hdf5-vol-daos-mpich-tests    \
           MACSio-mpich                 \
-          MACSio-$openmpi              \
           mpifileutils-mpich"
 else
     echo "I don't know which packages should be installed for distro"

--- a/ci/provisioning/post_provision_config_nodes_EL_7.sh
+++ b/ci/provisioning/post_provision_config_nodes_EL_7.sh
@@ -46,6 +46,7 @@ EOF
 
     # Mellanox OFED hack
     if ls -d /usr/mpi/gcc/openmpi-*; then
+        mkdir -p /etc/modulefiles/mpi/
         cat <<EOF > /etc/modulefiles/mpi/mlnx_openmpi-x86_64
 #%Module 1.0
 #

--- a/ci/provisioning/post_provision_config_nodes_EL_8.sh
+++ b/ci/provisioning/post_provision_config_nodes_EL_8.sh
@@ -15,22 +15,37 @@ group_repo_post() {
 }
 
 distro_custom() {
-    # force install of avocado 69.x
-    dnf -y erase avocado{,-common}                                              \
-                 python2-avocado{,-plugins-{output-html,varianter-yaml-to-mux}} \
-                 python3-pyyaml
-    pip3 install "avocado-framework<70.0"
-    pip3 install "avocado-framework-plugin-result-html<70.0"
-    pip3 install "avocado-framework-plugin-varianter-yaml-to-mux<70.0"
-    pip3 install clustershell
+    # install avocado
+    dnf -y install python3-avocado{,-plugins-{output-html,varianter-yaml-to-mux}} \
+                   clustershell
 
-    if ! rpm -q nfs-utils; then
-        retry_cmd 360 dnf -y install nfs-utils
+    # Mellanox OFED hack
+    if ls -d /usr/mpi/gcc/openmpi-*; then
+        mkdir -p /etc/modulefiles/mpi/
+        cat <<EOF > /etc/modulefiles/mpi/mlnx_openmpi-x86_64
+#%Module 1.0
+#
+#  OpenMPI module for use with 'environment-modules' package:
+#
+conflict		mpi
+prepend-path 		PATH 		/usr/mpi/gcc/openmpi-4.1.2a/bin
+prepend-path 		LD_LIBRARY_PATH /usr/mpi/gcc/openmpi-4.1.2a/lib64
+prepend-path 		PKG_CONFIG_PATH	/usr/mpi/gcc/openmpi-4.1.2a/lib64/pkgconfig
+prepend-path		PYTHONPATH	/usr/lib64/python2.7/site-packages/openmpi
+prepend-path		MANPATH		/usr/mpi/gcc/openmpi-4.1.2a/share/man
+setenv 			MPI_BIN		/usr/mpi/gcc/openmpi-4.1.2a/bin
+setenv			MPI_SYSCONFIG	/usr/mpi/gcc/openmpi-4.1.2a/etc
+setenv			MPI_FORTRAN_MOD_DIR	/usr/mpi/gcc/openmpi-4.1.2a/lib64
+setenv			MPI_INCLUDE	/usr/mpi/gcc/openmpi-4.1.2a/include
+setenv	 		MPI_LIB		/usr/mpi/gcc/openmpi-4.1.2a/lib64
+setenv			MPI_MAN			/usr/mpi/gcc/openmpi-4.1.2a/share/man
+setenv			MPI_PYTHON_SITEARCH	/usr/lib64/python2.7/site-packages/openmpi
+setenv			MPI_PYTHON2_SITEARCH	/usr/lib64/python2.7/site-packages/openmpi
+setenv			MPI_COMPILER	openmpi-x86_64
+setenv			MPI_SUFFIX	_openmpi
+setenv	 		MPI_HOME	/usr/mpi/gcc/openmpi-4.1.2a
+EOF
     fi
-
-    # CORCI-1096
-    dnf -y install esmtp
-    sed -e 's/^\(hostname *= *\)[^ ].*$/\1 mail.wolf.hpdd.intel.com:25/' < /usr/share/doc/esmtp/sample.esmtprc > /etc/esmtprc
 
     dnf config-manager --disable powertools
 
@@ -94,10 +109,13 @@ post_provision_config_nodes() {
     retry_cmd 360 dnf -y install $LSB_RELEASE
 
     # shellcheck disable=SC2086
-    if [ -n "$INST_RPMS" ] && ! retry_cmd 360 dnf -y install $INST_RPMS; then
-        rc=${PIPESTATUS[0]}
-        dump_repos
-        exit "$rc"
+    if [ -n "$INST_RPMS" ]; then
+        if ! retry_cmd 360 dnf -y install $INST_RPMS; then
+            rc=${PIPESTATUS[0]}
+            dump_repos
+            #sleep 600
+            exit "$rc"
+        fi
     fi
 
     distro_custom
@@ -112,6 +130,8 @@ post_provision_config_nodes() {
         cat /etc/do-release
     fi
     cat /etc/os-release
+
+    rpm -qa | sort
 
     exit 0
 }

--- a/site_scons/env_modules.py
+++ b/site_scons/env_modules.py
@@ -25,8 +25,8 @@ import sys
 import errno
 import distro
 import subprocess
+import shutil
 from subprocess import PIPE, Popen
-from SCons.Script import WhereIs
 
 class _env_module(): # pylint: disable=invalid-name
     """Class for utilizing Modules component to load environment modules"""
@@ -120,7 +120,7 @@ class _env_module(): # pylint: disable=invalid-name
         for to_load in load:
             self._module_func('load', to_load)
             print("Looking for %s" % to_load)
-            if WhereIs('mpirun'):
+            if shutil.which('mpirun'):
                 print("Loaded %s" % to_load)
                 return True
         return False
@@ -146,7 +146,7 @@ class _env_module(): # pylint: disable=invalid-name
         if not self._module_load(mpi):
             print("No %s found\n" % mpi)
             return False
-        exe_path = WhereIs('mpirun')
+        exe_path = shutil.which('mpirun')
         if not exe_path:
             print("No mpirun found in path. Could not configure %s\n" % mpi)
             return False
@@ -166,7 +166,7 @@ def load_mpi(mpi):
     # On Ubuntu, MPI stacks use alternatives and need root to change their
     # pointer, so just verify that the desired MPI is loaded
     if distro.id() == "ubuntu":
-        updatealternatives = WhereIs('update-alternatives')
+        updatealternatives = shutil.which('update-alternatives')
         if not updatealternatives:
             print("No update-alternatives found in path.")
             return False

--- a/src/tests/ftest/harness/basic.py
+++ b/src/tests/ftest/harness/basic.py
@@ -27,7 +27,7 @@ class HarnessBasicTest(Test):
 
         :avocado: tags=all
         :avocado: tags=hw,large,medium,ib2,small
-        :avocado: tags=harness,harness_basic_test,test_always_passes_hw
+        :avocado: tags=harness,harness_basic_test,test_always_passes,test_always_passes_hw
         :avocado: tags=always_passes
         """
         self.test_always_passes()

--- a/src/tests/ftest/pool/create.yaml
+++ b/src/tests/ftest/pool/create.yaml
@@ -16,6 +16,7 @@ timeouts:
   test_create_no_space_loop: 2160
 server_config:
   name: daos_server
+  control_log_mask: DEBUG
   servers:
     0:
       bdev_class: nvme
@@ -23,6 +24,10 @@ server_config:
       scm_class: dcpm
       scm_list: ["/dev/pmem0"]
       scm_mount: /mnt/daos0
+      log_mask: DEBUG,MEM=ERR,SWIM=ERR
+      env_vars:
+        - DD_MASK=all
+        - DD_SUBSYS=all
 pool_1:
   name: daos_server
   control_method: dmg

--- a/src/tests/ftest/util/general_utils.py
+++ b/src/tests/ftest/util/general_utils.py
@@ -406,16 +406,32 @@ def run_pcmd(hosts, command, verbose=True, timeout=None, expect_rc=0):
         for item in results
         if expect_rc is not None and item["exit_status"] != expect_rc]
     if verbose or bad_exit_status:
-        log.info("Command: %s", command)
-        log.info("Results:")
-        for result in results:
-            log.info(
-                "  %s: exit_status=%s, interrupted=%s:",
-                result["hosts"], result["exit_status"], result["interrupted"])
-            for line in result["stdout"]:
-                log.info("    %s", line)
+        log.info(colate_results(command, results))
 
     return results
+
+
+def colate_results(command, results):
+    """Colate the output of run_pcmd.
+
+    Args:
+        command (str): command used to obtain the data on each server
+        results (list): list: a list of dictionaries with each entry
+                        containing output, exit status, and interrupted
+                        status common to each group of hosts (see run_pcmd()'s
+                        return for details)
+    Returns:
+        str: a string colating run_pcmd()'s results
+
+    """
+    res = ""
+    res += "Command: %s\n" % command
+    res += "Results:\n"
+    for result in results:
+        res += "  %s: exit_status=%s, interrupted=%s:" % (
+               result["hosts"], result["exit_status"], result["interrupted"])
+        for line in result["stdout"]:
+            res += "    %s\n" % line
 
 
 def get_host_data(hosts, command, text, error, timeout=None):

--- a/utils/rpms/daos.spec
+++ b/utils/rpms/daos.spec
@@ -14,7 +14,7 @@
 
 Name:          daos
 Version:       1.3.105
-Release:       4%{?relval}%{?dist}
+Release:       5%{?relval}%{?dist}
 Summary:       DAOS Storage Engine
 
 License:       BSD-2-Clause-Patent
@@ -226,6 +226,18 @@ Requires: libpsm_infinipath1
 %description tests
 This is the package needed to run the DAOS test suite
 
+
+%package tests-openmpi
+Summary: The DAOS test suite - tools which need openmpi
+#This is a bit messy and needs some cleanup.  In theory,
+#we should have client tests and server tests in separate
+#packages but some binaries need libraries from both at
+#present.
+Requires: %{name}-tests%{?_isa} = %{version}-%{release}
+
+%description tests-openmpi
+This is the package needed to run the DAOS test suite openmpi tools
+
 %package devel
 Summary: The DAOS development libraries and headers
 Requires: %{name}-client%{?_isa} = %{version}-%{release}
@@ -427,25 +439,15 @@ getent passwd daos_agent >/dev/null || useradd -s /sbin/nologin -r -g daos_agent
 %dir %{_prefix}/lib/daos
 %{_prefix}/lib/daos/TESTING
 %{_bindir}/hello_drpc
-%{_bindir}/jobtest
 %{_libdir}/libdaos_tests.so
 %{_bindir}/jump_pl_map
 %{_bindir}/ring_pl_map
 %{_bindir}/pl_bench
 %{_bindir}/smd_ut
 %{_bindir}/vea_ut
-%{_bindir}/daos_perf
-%{_bindir}/vos_perf
-%{_bindir}/daos_racer
 %{_bindir}/evt_ctl
 %{_bindir}/io_conf
 %{_bindir}/rdbt
-%{_bindir}/obj_ctl
-%{_bindir}/daos_gen_io_conf
-%{_bindir}/daos_run_io_conf
-%{_bindir}/crt_launch
-%{_bindir}/daos_test
-%{_bindir}/dfs_test
 %{_bindir}/common_test
 %{_bindir}/acl_dump_test
 %{_bindir}/agent_tests
@@ -461,6 +463,18 @@ getent passwd daos_agent >/dev/null || useradd -s /sbin/nologin -r -g daos_agent
 # For avocado tests
 %{_prefix}/lib/daos/.build_vars.json
 %{_prefix}/lib/daos/.build_vars.sh
+
+%files tests-openmpi
+%{_bindir}/crt_launch
+%{_bindir}/daos_gen_io_conf
+%{_bindir}/daos_perf
+%{_bindir}/daos_racer
+%{_bindir}/daos_run_io_conf
+%{_bindir}/daos_test
+%{_bindir}/dfs_test
+%{_bindir}/jobtest
+%{_bindir}/obj_ctl
+%{_bindir}/vos_perf
 %{_libdir}/libdts.so
 
 %files devel
@@ -478,6 +492,9 @@ getent passwd daos_agent >/dev/null || useradd -s /sbin/nologin -r -g daos_agent
 %{_libdir}/libdaos_serialize.so
 
 %changelog
+* Tue Oct 12 2021 Brian J. Murrell <brian.murrell@intel.com> 1.3.105-5
+- Create new daos-tests-openmpi subpackage
+
 * Wed Oct 8 2021 Alexander Oganezov <alexander.a.oganezov@intel.com> 1.13.105-4
 - Update OFI to v1.13.2rc1
 


### PR DESCRIPTION
This is PR-6741 contents, plus a change to create.yaml to add
daos_server and daos_engine debug level logging.

Quick-Functional: true
Skip-coverity-test: true
Skip-func-test-vm: true
Skip-func-hw-test-small: true
Skip-func-hw-test-medium: true
Skip-func-hw-test-large: false
Func-hw-test-distro: el8.4
Skip-scan-centos-rpms: true
Skip-scan-leap15-rpms: true
Skip-test-centos-rpms: true
Allow-unstable-test: true
Skip-PR-comments: true
Test-tag: pr create_no_space create_no_space_loop test_daos_dfs_parallel daos_admin

Signed-off-by: Kenneth Cain <kenneth.c.cain@intel.com>