### PR TITLE
DAOS-8779 arrays: use conditional ops for proper create/open

### DIFF
--- a/src/client/array/dc_array.c
+++ b/src/client/array/dc_array.c
@@ -522,6 +522,7 @@ write_md_cb(tse_task_t *task, void *data)
 	update_args->nr		= 1;
 	update_args->iods	= &params->iod;
 	update_args->sgls	= &params->sgl;
+	update_args->flags	= DAOS_COND_DKEY_INSERT | DAOS_COND_AKEY_INSERT;
 
 	rc = tse_task_register_comp_cb(task, free_md_params_cb, &params,
 				       sizeof(params));
@@ -715,6 +716,7 @@ fetch_md_cb(tse_task_t *task, void *data)
 	fetch_args->nr		= 1;
 	fetch_args->iods	= &params->iod;
 	fetch_args->sgls	= &params->sgl;
+	fetch_args->flags	= DAOS_COND_DKEY_FETCH | DAOS_COND_AKEY_FETCH;
 
 	return 0;
 }

--- a/src/tests/suite/daos_array.c
+++ b/src/tests/suite/daos_array.c
@@ -75,7 +75,7 @@ simple_array_mgmt(void **state)
 {
 	test_arg_t	*arg = *state;
 	daos_obj_id_t	oid;
-	daos_handle_t	oh;
+	daos_handle_t	oh, oh2;
 	daos_size_t	cell_size = 0, csize = 0;
 	daos_size_t	size;
 	int		rc;
@@ -99,6 +99,11 @@ simple_array_mgmt(void **state)
 	rc = daos_array_create(arg->coh, oid, DAOS_TX_NONE, 4, chunk_size,
 			       &oh, NULL);
 	assert_rc_equal(rc, 0);
+
+	/** create the same array again, should fail */
+	rc = daos_array_create(arg->coh, oid, DAOS_TX_NONE, 4, chunk_size,
+			       &oh2, NULL);
+	assert_rc_equal(rc, -DER_EXIST);
 
 	rc = daos_array_get_attr(oh, &csize, &cell_size);
 	assert_rc_equal(rc, 0);
@@ -154,11 +159,9 @@ simple_array_mgmt(void **state)
 	rc = daos_array_destroy(oh, DAOS_TX_NONE, NULL);
 	assert_rc_equal(rc, 0);
 
-	daos_handle_t temp_oh;
-
 	rc = daos_array_open(arg->coh, oid, DAOS_TX_NONE, DAOS_OO_RW,
-			     &cell_size, &csize, &temp_oh, NULL);
-	assert_rc_equal(rc, -DER_NO_PERM);
+			     &cell_size, &csize, &oh2, NULL);
+	assert_rc_equal(rc, -DER_NONEXIST);
 
 	rc = daos_array_close(oh, NULL);
 	assert_rc_equal(rc, 0);


### PR DESCRIPTION
- Array create should return DER_EXIST if array exists.
- Array open should return DER_NONEXIST if array does not exist.

Signed-off-by: Mohamad Chaarawi <mohamad.chaarawi@intel.com>