### PR TITLE
DAOS-8007 Test: Fix VMD test identification.

### DIFF
--- a/src/tests/ftest/launch.py
+++ b/src/tests/ftest/launch.py
@@ -784,7 +784,7 @@ def get_vmd_address_backed_nvme(host_list, value):
               devices.
 
     """
-    command = "ls -l /sys/block/ | grep nvme | cut -d\' \' -f11"
+    command = "ls -l /sys/block/ | grep nvme | cut -d\'>\' -f2 | cut -d'/' -f4"
 
     task = get_remote_output(host_list, command)
 


### PR DESCRIPTION
There is an issue to detect the proper backing NVMe device for VMD.
Current cut options does not work on some cases so updated the cut
option to avoide that issue and work on each case.

PR will be tested on VMD enabled HW so no other testing needed in
ci.

Signed-off-by: Samir Raval <samir.raval@intel.com>