### PR TITLE
DAOS-8784 tests: Prevent cascading failures in cart tests

### DIFF
--- a/src/tests/ftest/cart/util/cart_utils.py
+++ b/src/tests/ftest/cart/util/cart_utils.py
@@ -34,12 +34,22 @@ class CartTest(TestWithoutServers):
         self.src_dir = os.path.dirname(os.path.dirname(os.path.dirname(
                        os.path.dirname(os.path.dirname(os.path.dirname(
                        os.path.dirname(os.path.abspath(__file__))))))))
+        self.attach_dir = None
 
     def setUp(self):
         """Set up the test case."""
         super().setUp()
         self.set_other_env_vars()
         self.env = self.get_env()
+
+        # clean CRT_ATTACH_INFO_PATH dir of stale attach files
+        files_in_attach = os.listdir(self.attach_dir)
+        filtered = [f for f in files_in_attach if f.endswith(".attach_info_tmp")]
+
+        for f in filtered:
+            to_del = os.path.join(self.attach_dir, f)
+            print("WARN: stale file {} found, deleting...\n".format(to_del))
+            os.remove(to_del)
 
         # Add test binaries and daos binaries to PATH
         test_dirs = {"TESTING": "tests", "install": "bin"}
@@ -208,10 +218,12 @@ class CartTest(TestWithoutServers):
                                          os.getenv('HOME'))
 
         log_path = os.environ['DAOS_TEST_LOG_DIR']
+        log_path = log_path.replace(";", "_")
+
         log_file = os.path.join(log_path, log_dir,
                                 test_name + "_" + \
                                 env_CCSA + "_" + \
-                                env_PHY_ADDR_STR + "_cart.log")
+                                env_PHY_ADDR_STR + "_cart.log").replace(";", "_")
 
         # Default env vars for orterun to None
         log_mask = None
@@ -242,7 +254,7 @@ class CartTest(TestWithoutServers):
                        env_PHY_ADDR_STR + "_" + \
                        "output.orterun_log"
 
-        output_filename_path = os.path.join(log_path, log_dir, log_filename)
+        output_filename_path = os.path.join(log_path, log_dir, log_filename).replace(";", "_")
         env = " --output-filename {!s}".format(output_filename_path)
         env += " -x D_LOG_FILE={!s}".format(log_file)
         env += " -x D_LOG_FILE_APPEND_PID=1"
@@ -269,6 +281,7 @@ class CartTest(TestWithoutServers):
         env += " -x DAOS_TEST_SHARED_DIR={!s}".format(daos_test_shared_dir)
         env += " -x COVFILE=/tmp/test.cov"
 
+        self.attach_dir = daos_test_shared_dir
         self.log_path = log_path
 
         if not os.path.exists(log_path):


### PR DESCRIPTION
- Cleanup attach info dir of stale attach files
- Replace ';' with '_' for all pathnames in order to support verbs and tcp

Skip-func-test-vm-valgrind: false

Signed-off-by: Alexander Oganezov <alexander.a.oganezov@intel.com>