### PR TITLE
DAOS-8680 test: fix rebuild/io_conf_run

### DIFF
--- a/src/tests/ftest/rebuild/io_conf_run.yaml
+++ b/src/tests/ftest/rebuild/io_conf_run.yaml
@@ -8,7 +8,7 @@ hosts:
     - server-F
     - server-G
     - server-H
-timeout: 3600
+timeout: 900
 server_config:
   name: daos_server
   servers:
@@ -30,16 +30,16 @@ gen_io_conf:
       targets: "8"
   no_of_dkeys:
     large_no_dkeys:
-      dkeys: "5"
+      dkeys: "2"
   no_of_akeys:
     large_no_akeys:
-      akeys: "5"
+      akeys: "2"
   record:
     large_record_no:
       record_size: "50"
   no_of_objects:
     large_no_objects:
-      obj_num: "10"
+      obj_num: "3"
   object_class: !mux
     replica2_group1:
       obj_class: "RP_2G1"

--- a/src/tests/suite/daos_epoch_io.c
+++ b/src/tests/suite/daos_epoch_io.c
@@ -364,6 +364,8 @@ daos_test_cb_exclude(test_arg_t *arg, struct test_op_record *op,
 				    arg->dmg_config,
 				    op->ae_arg.ua_rank, op->ae_arg.ua_tgt);
 	}
+
+	daos_cont_status_clear(arg->coh, NULL);
 	return 0;
 }
 
@@ -403,7 +405,7 @@ static int
 test_cb_noop(test_arg_t *arg, struct test_op_record *op,
 	     char **rbuf, daos_size_t *rbuf_size)
 {
-	return -DER_NOSYS;
+	return 0;
 }
 
 struct test_op_dict op_dict[] = {
@@ -1475,6 +1477,8 @@ io_conf_run(test_arg_t *arg, const char *io_conf)
 		return daos_errno2der(errno);
 	}
 
+	int line_nr = 0;
+
 	do {
 		size_t	cmd_size;
 
@@ -1497,6 +1501,7 @@ io_conf_run(test_arg_t *arg, const char *io_conf)
 
 		if (op != NULL) {
 			op->snap_epoch = &sn_epoch[op->tx];
+			print_message("will run cmd_line %s, line_nr %d\n", cmd_line, ++line_nr);
 			rc = cmd_line_run(arg, op);
 			if (rc) {
 				print_message("run cmd_line %s failed, "


### PR DESCRIPTION
1) fixed DER_RF error in IO after excluding server rank
2) fixed testing failures, PUNCH_ARRAY is not well supported in
   the test tool now so disable it
3) reduce the #objs/#dkeys/#akeys to save testing time.

Skip-func-test-el7: false
Skip-func-test-el8: false
Skip-func-test-leap15: false
Test-tag: pr iorebuild

Signed-off-by: Xuezhao Liu <xuezhao.liu@intel.com>