### PR TITLE
DAOS-8672 dtx: trace the newest DTX that is aggregated

### DIFF
--- a/src/dtx/dtx_internal.h
+++ b/src/dtx/dtx_internal.h
@@ -88,9 +88,9 @@ extern uint32_t dtx_agg_thd_cnt_up;
 extern uint32_t dtx_agg_thd_cnt_lo;
 
 /* The age unit is second. */
-#define DTX_AGG_THD_AGE_MAX	700
-#define DTX_AGG_THD_AGE_MIN	140
-#define DTX_AGG_THD_AGE_DEF	210
+#define DTX_AGG_THD_AGE_MAX	1830
+#define DTX_AGG_THD_AGE_MIN	210
+#define DTX_AGG_THD_AGE_DEF	630
 
 /* The time threshold for triggerring DTX aggregation. If the oldest
  * DTX in the DTX table exceeds such threshold, it will trigger DTX

--- a/src/include/daos_srv/dtx_srv.h
+++ b/src/include/daos_srv/dtx_srv.h
@@ -170,6 +170,8 @@ struct dtx_stat {
 	uint32_t	dtx_cont_cmt_count;
 	/* pool-based committed DTX entries count. */
 	uint32_t	dtx_pool_cmt_count;
+	/* The epoch for the most new DTX entry that is aggregated. */
+	uint64_t	dtx_newest_aggregated;
 };
 
 enum dtx_flags {

--- a/src/vos/vos_layout.h
+++ b/src/vos/vos_layout.h
@@ -88,7 +88,7 @@ enum vos_gc_type {
 #define POOL_DF_MAGIC				0x5ca1ab1e
 
 /** Lowest supported durable format version */
-#define POOL_DF_VER_1				20
+#define POOL_DF_VER_1				21
 /** Current durable format version */
 #define POOL_DF_VERSION				POOL_DF_VER_1
 
@@ -253,6 +253,8 @@ struct vos_cont_df {
 	struct vea_hint_df		cd_hint_df[VOS_IOS_CNT];
 	/** GC bins for object/dkey...Don't need GC_CONT entry */
 	struct vos_gc_bin_df		cd_gc_bins[GC_CONT];
+	/* The epoch for the most new DTX entry that is aggregated. */
+	uint64_t			cd_newest_aggregated;
 };
 
 /* Assume cd_dtx_active_tail is just after cd_dtx_active_head. */


### PR DESCRIPTION
Record the epoch for the newest DXT entry that is aggregated by the
DTX aggregation. Such epoch will be used when check resent RPC and
DTX refresh: if we cannot find the DTX with the give transaction ID
and if the DTX timestamp is newer than such newset aggregated epoch,
then it is impossible that it has been removed by DTX aggregation.
    
The patch also increases the default value for DTX aggreagtion age
threshold. Then if there is no DRAM pressure on server, the committed
DTX entries can be kept for more long time. That is helpful for resend
logic to know whether related DTX has even been committed. But if there
is DRAM pressure on the server, then DTX aggregation will be triggered
via the count threshold.
    
Signed-off-by: Fan Yong <fan.yong@intel.com>