### PR TITLE
DAOS-8776 object: use ds_cont_child_lookup during migration

### DIFF
--- a/src/include/daos_srv/daos_engine.h
+++ b/src/include/daos_srv/daos_engine.h
@@ -871,7 +871,7 @@ ds_object_migrate(struct ds_pool *pool, uuid_t pool_hdl_uuid, uuid_t cont_uuid,
 		  uuid_t cont_hdl_uuid, int tgt_id, uint32_t version,
 		  uint64_t max_eph, daos_unit_oid_t *oids, daos_epoch_t *ephs,
 		  daos_epoch_t *punched_ephs, unsigned int *shards, int cnt,
-		  int clear_conts);
+		  unsigned int migrate_opc);
 void
 ds_migrate_fini_one(uuid_t pool_uuid, uint32_t ver);
 

--- a/src/object/obj_internal.h
+++ b/src/object/obj_internal.h
@@ -249,16 +249,9 @@ struct migrate_pool_tls {
 	ABT_cond		mpt_inflight_cond;
 	ABT_mutex		mpt_inflight_mutex;
 	int			mpt_inflight_max_ult;
+	uint32_t		mpt_opc;
 	/* migrate leader ULT */
 	unsigned int		mpt_ult_running:1,
-	/* Indicates whether objects on the migration destination should be
-	 * removed prior to migrating new data here. This is primarily useful
-	 * for reintegration to ensure that any data that has adequate replica
-	 * data to reconstruct will prefer the remote data over possibly stale
-	 * existing data. Objects that don't have remote replica data will not
-	 * be removed.
-	 */
-				mpt_del_local_objs:1,
 				mpt_fini:1;
 };
 

--- a/src/object/obj_rpc.h
+++ b/src/object/obj_rpc.h
@@ -31,7 +31,7 @@
  * These are for daos_rpc::dr_opc and DAOS_RPC_OPCODE(opc, ...) rather than
  * crt_req_create(..., opc, ...). See daos_rpc.h.
  */
-#define DAOS_OBJ_VERSION 6
+#define DAOS_OBJ_VERSION 7
 /* LIST of internal RPCS in form of:
  * OPCODE, flags, FMT, handler, corpc_hdlr and name
  */
@@ -325,7 +325,7 @@ CRT_RPC_DECLARE(obj_sync, DAOS_ISEQ_OBJ_SYNC, DAOS_OSEQ_OBJ_SYNC)
 	((uint64_t)		(om_ephs)		CRT_ARRAY)	\
 	((uint64_t)		(om_punched_ephs)	CRT_ARRAY)	\
 	((uint32_t)		(om_shards)		CRT_ARRAY)	\
-	((int32_t)		(om_del_local_obj)	CRT_VAR)
+	((uint32_t)		(om_opc)		CRT_VAR)
 
 #define DAOS_OSEQ_OBJ_MIGRATE	/* output fields */		 \
 	((int32_t)		(om_status)		CRT_VAR)

--- a/src/rebuild/scan.c
+++ b/src/rebuild/scan.c
@@ -125,9 +125,7 @@ rebuild_obj_send_cb(struct tree_cache_root *root, struct rebuild_send_arg *arg)
 				       arg->tgt_id, rpt->rt_rebuild_ver,
 				       rpt->rt_stable_epoch, arg->oids,
 				       arg->ephs, arg->punched_ephs, arg->shards,
-				       arg->count,
-				       /* Delete local objects for reint */
-				       rpt->rt_rebuild_op == RB_OP_REINT);
+				       arg->count, rpt->rt_rebuild_op);
 		/* If it does not need retry */
 		if (rc == 0 || (rc != -DER_TIMEDOUT && rc != -DER_GRPVER &&
 		    rc != -DER_AGAIN && !daos_crt_network_error(rc)))


### PR DESCRIPTION
Migration should not use ds_cont_child_open_create(), since
it may actually create the container, instead it should use
ds_cont_child_lookup() to check if the container still exists.

Signed-off-by: Di Wang <di.wang@intel.com>