### PR TITLE
DAOS-8230 aggregate: wait 5 seconds if EC aggregates hit rebuild (#6705)

### DIFF
--- a/src/container/srv_target.c
+++ b/src/container/srv_target.c
@@ -368,7 +368,7 @@ cont_child_aggregate(struct ds_cont_child *cont, cont_aggregate_cb_t agg_cb,
 			DP_CONT(cont->sc_pool->spc_uuid, cont->sc_uuid),
 			tgt_id, epoch_range.epr_lo, epoch_range.epr_hi);
 
-		rc = agg_cb(cont, &epoch_range, full_scan, param);
+		rc = agg_cb(cont, &epoch_range, full_scan, param, msecs);
 		if (rc)
 			D_GOTO(free, rc);
 		epoch_range.epr_lo = epoch_range.epr_hi + 1;
@@ -383,7 +383,7 @@ cont_child_aggregate(struct ds_cont_child *cont, cont_aggregate_cb_t agg_cb,
 		DP_CONT(cont->sc_pool->spc_uuid, cont->sc_uuid),
 		tgt_id, epoch_range.epr_lo, epoch_range.epr_hi);
 
-	rc = agg_cb(cont, &epoch_range, full_scan, param);
+	rc = agg_cb(cont, &epoch_range, full_scan, param, msecs);
 out:
 	if (rc == 0 && epoch_min == 0)
 		param->ap_full_scan_hlc = hlc;
@@ -494,7 +494,7 @@ cont_stop_agg_ult(struct ds_cont_child *cont, struct sched_request *req)
 
 static int
 cont_vos_aggregate_cb(struct ds_cont_child *cont, daos_epoch_range_t *epr,
-		      bool full_scan, struct agg_param *param)
+		      bool full_scan, struct agg_param *param, uint64_t *msecs)
 {
 	int rc;
 

--- a/src/include/daos_srv/container.h
+++ b/src/include/daos_srv/container.h
@@ -132,7 +132,7 @@ struct agg_param {
 
 typedef int (*cont_aggregate_cb_t)(struct ds_cont_child *cont,
 				   daos_epoch_range_t *epr, bool full_scan,
-				   struct agg_param *param);
+				   struct agg_param *param, uint64_t *msecs);
 void
 cont_aggregate_interval(struct ds_cont_child *cont, cont_aggregate_cb_t cb,
 			struct agg_param *param);

--- a/src/object/srv_ec_aggregate.c
+++ b/src/object/srv_ec_aggregate.c
@@ -2434,7 +2434,7 @@ out:
  */
 static int
 cont_ec_aggregate_cb(struct ds_cont_child *cont, daos_epoch_range_t *epr,
-		     bool full_scan, struct agg_param *agg_param)
+		     bool full_scan, struct agg_param *agg_param, uint64_t *msec)
 {
 	struct ec_agg_param	 *ec_agg_param = agg_param->ap_data;
 	vos_iter_param_t	 iter_param = { 0 };
@@ -2504,8 +2504,14 @@ again:
 		ec_agg_param->ap_agg_entry.ae_obj_hdl = DAOS_HDL_INVAL;
 	}
 
-	if (ec_agg_param->ap_obj_skipped)
-		D_ERROR("with skipped obj during aggregation.\n");
+	if (ec_agg_param->ap_obj_skipped) {
+		D_DEBUG(DB_EPC, "with skipped obj during aggregation.\n");
+		/* There is rebuild going no, and we can proceed EC aggregate boundary,
+		 * Let's wait for 5 seconds for another EC aggregation.
+		 */
+		if (msec)
+			*msec = 5 * 1000;
+	}
 
 	if (rc == 0 && ec_agg_param->ap_obj_skipped == 0)
 		cont->sc_ec_agg_eph = max(cont->sc_ec_agg_eph, epr->epr_hi);


### PR DESCRIPTION
Let's wait 5 seconds for next aggregate if some objects are in
rebuilding status, since EC aggregate epoch boundary can not proceed
until rebuild finish.

Signed-off-by: Di Wang <di.wang@intel.com>