### PR TITLE
DAOS-8563 test: reduce parameter of daos_perf/large.py (#6852)

### DIFF
--- a/src/tests/ftest/daos_perf/large.yaml
+++ b/src/tests/ftest/daos_perf/large.yaml
@@ -11,12 +11,12 @@ hosts:
     - client-H
 # some run can take long to run, but needs to be verified
 # by running consecutively for accurate time.
-timeout: 9600
+timeout: 3600
 job_manager_class_name: Orterun
 job_manager_mpi_type: openmpi
-job_manager_timeout: 9000
+job_manager_timeout: 3600
 pool:
-    size: 3TB
+    size: 1TB
     control_method: dmg
 container:
     type: POSIX
@@ -33,6 +33,6 @@ daos_perf:
   processes: 64
   test_type: daos
   akey_use_array: False
-  dkeys: 4k
-  akeys: 1k
+  dkeys: 256
+  akeys: 128
   object_class: EC2P1


### PR DESCRIPTION
The original parameter will drive test of -
“-a 1k -d 4k -c EC2P1 -R "U;p F;p V O;p" -T daos”
the data size will be
64 * 1K * 4K * 16 * 3MB (full-stripe with parity) = 12288 GB  = 12.3TB.

The data size is too large, this patch reduce
ts_dkey_p_obj = 256, and ts_akey_p_dkey = 128.

Quick-build: true
Skip-unit-tests: true
Skip-nlt: true
Skip-unit-test: true
Skip-func-test-vm: true
Skip-func-hw-test-small: true
Skip-func-hw-test-medium: true
Test-tag: daosperflarge

Signed-off-by: Xuezhao Liu <xuezhao.liu@intel.com>