### PR TITLE
DAOS-8615 test: adjust dfuse_caching_check comparison (#6792)

### DIFF
--- a/src/tests/ftest/dfuse/caching_check.py
+++ b/src/tests/ftest/dfuse/caching_check.py
@@ -7,7 +7,8 @@
 
 from ior_test_base import IorTestBase
 from ior_utils import IorCommand, IorMetrics
-from general_utils import pcmd
+from general_utils import pcmd, percent_change
+
 
 class CachingCheck(IorTestBase):
     # pylint: disable=too-many-ancestors
@@ -25,17 +26,13 @@ class CachingCheck(IorTestBase):
             Purpose of this test is to check if dfuse caching is working.
         Use case:
             Write using ior over dfuse with caching disabled.
-            Perform ior read to get base read performance.
-            Run ior read to get second read performance with caching disabled.
-            Compare first and second read performance numbers and they should
-            be similar.
+            Perform ior read twice to get base read performance.
             Unmount dfuse and mount it again with caching enabled.
             Perform ior read after fresh mount to get read performance.
-            Run ior again to get second read performance numbers with caching
-            enabled.
-            Compare first and second read performance numbers after dfuse
-            refresh and the second read should be multiple folds higher than
-            the first one.
+            Run ior again to get second read performance numbers with caching enabled.
+            Compared cached read performance numbers after refresh to the baseline
+            read performance and confirm cached read performance is multiple folds
+            higher than with caching disabled.
 
         :avocado: tags=all,full_regression
         :avocado: tags=hw,small
@@ -55,22 +52,15 @@ class CachingCheck(IorTestBase):
         # update ior flag to read
         self.ior_cmd.flags.update(flags[1])
         # run ior to read and store the read performance
+        base_read_arr = []
         out = self.run_ior_with_pool(fail_on_warning=False, stop_dfuse=False)
-        base_read = IorCommand.get_ior_metrics(out)
+        base_read_arr.append(IorCommand.get_ior_metrics(out))
         # run ior again to read with caching disabled and store performance
         out = self.run_ior_with_pool(fail_on_warning=False, stop_dfuse=False)
-        without_caching = IorCommand.get_ior_metrics(out)
+        base_read_arr.append(IorCommand.get_ior_metrics(out))
+
+        # the index of max_mib
         max_mib = int(IorMetrics.Max_MiB)
-        # Compare read performance with caching disabled
-        # it should be similar to last read
-        lower_bound = (float(base_read[0][max_mib]) -
-                       (float(base_read[0][max_mib]) * read_x[0]))
-        upper_bound = (float(base_read[0][max_mib]) +
-                       (float(base_read[0][max_mib]) * read_x[0]))
-        # verify read performance is similar to last read and within
-        # the range of 1% up or down the first read performance
-        self.assertTrue(lower_bound <= float(without_caching[0][max_mib])
-                        <= upper_bound)
 
         # unmount dfuse and mount again with caching enabled
         pcmd(self.hostlist_clients,
@@ -79,11 +69,13 @@ class CachingCheck(IorTestBase):
         self.dfuse.run()
         # run ior to obtain first read performance after mount
         out = self.run_ior_with_pool(fail_on_warning=False, stop_dfuse=False)
-        base_read = IorCommand.get_ior_metrics(out)
+        base_read_arr.append(IorCommand.get_ior_metrics(out))
         # run ior again to obtain second read performance with caching enabled
         # second read should be multiple times greater than first read
         out = self.run_ior_with_pool(fail_on_warning=False)
         with_caching = IorCommand.get_ior_metrics(out)
-        # verifying read performance
-        self.assertTrue(float(with_caching[0][max_mib]) >
-                        read_x[1] * float(base_read[0][max_mib]))
+        # verify cached read performance is multiple times greater than without caching
+        for base_read in base_read_arr:
+            actual_change = percent_change(base_read[0][max_mib], with_caching[0][max_mib])
+            self.log.info('assert actual_change > min_change: %f > %f', actual_change, read_x)
+            self.assertTrue(actual_change > read_x)

--- a/src/tests/ftest/dfuse/caching_check.yaml
+++ b/src/tests/ftest/dfuse/caching_check.yaml
@@ -32,9 +32,7 @@ ior:
     transfer_size: '1M'
     block_size: '64M'
     dfs_oclass: "SX"
-    read_x:
-      - .01    # 1%
-      - 10     # 1000%
+    read_x: 10 # 1000%
     iorflags:
       - "-v -w -k"
       - "-v -r -k"

--- a/src/tests/ftest/util/general_utils.py
+++ b/src/tests/ftest/util/general_utils.py
@@ -1265,3 +1265,19 @@ def report_errors(test, errors):
         test.fail(error_msg)
 
     test.log.info("No errors detected.")
+
+
+def percent_change(val1, val2):
+    """Calculate percent change between two values as a decimal.
+
+    Args:
+        val1 (float): first value.
+        val2 (float): second value.
+
+    Returns:
+        float: decimal percent change.
+
+    """
+    if val1 and val2:
+        return (float(val2) - float(val1)) / float(val1)
+    return 0.0


### PR DESCRIPTION
Quick-functional: true
Test-tag: dfusecachingcheck

This test was intermittently failing the 1% threshold check
between baseline read performance. Since sockets is not reliable enough
for performance tests, and since the goal is just to verify that
dfuse yields better performance with caching enabled:

- Remove threshold check for two baseline reads
- Just compare performance with caching to performance without
- Add percent_change function
- Log actual and expected percent change before assertion

Signed-off-by: Dalton Bohning <dalton.bohning@intel.com>