### PR TITLE
DAOS-7069 dtx: properly abort DTX entry when DTX refresh

### DIFF
--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -4201,20 +4201,19 @@ again:
 	}
 
 	rc = ds_cpd_handle_one(rpc, dcsh, dcde, dcsrs, ioc, dth);
-	if (!dth->dth_pinned) {
-		int	rc1;
-
-		/* There will be CPU yield during DTX refresh. We need
-		 * to pin current DTX before refreshing other DTX(es),
-		 * that will avoid race with the resent RPC during the
+	if (obj_dtx_need_refresh(dth, rc)) {
+		/* There will be CPU yield during DTX refresh. We need to pin current DTX before
+		 * refreshing other DTX(es), that will avoid race with the resent RPC during the
 		 * DTX refresh.
 		 */
-		rc1 = vos_dtx_pin(dth, false);
-		if (rc1 != 0)
-			return -DER_INPROGRESS;
-	}
+		if (!dth->dth_pinned) {
+			int	rc1;
 
-	if (obj_dtx_need_refresh(dth, rc)) {
+			rc1 = vos_dtx_pin(dth, false);
+			if (rc1 != 0)
+				return -DER_INPROGRESS;
+		}
+
 		rc = dtx_refresh(dth, ioc->ioc_coc);
 		if (rc == -DER_AGAIN)
 			goto again;


### PR DESCRIPTION
master-commit: 34f072cf20da32f3b9baf492837881542ea45e16

When non-leader refresh some DTX staus with the leader, it may
get the result -DER_NONEXIST. There are two cases for that:

1) The leader has aborted related DTX but the non-leader missed
   or failed to executed the DTX abort RPC.

2) Such DTX entry has been committed, but the non-leader missed
   or failed to executed the DTX commit RPC. Then it is removed
   by DTX aggregation on the leader.

If we are not sure which case it is, then we will have to keep
related of DTX entry instead of aborting it. Otherwise, we may
break leader's local modification or commit.

The patch also contains other fixes to allow cleanup 'prepared'
DTX entry.

Signed-off-by: Fan Yong <fan.yong@intel.com>