### PR TITLE
DAOS-8685: run create tests with logging, CentOS7 HW

### DIFF
--- a/src/tests/ftest/pool/create.yaml
+++ b/src/tests/ftest/pool/create.yaml
@@ -16,6 +16,7 @@ timeouts:
   test_create_no_space_loop: 2160
 server_config:
   name: daos_server
+  control_log_mask: DEBUG
   servers:
     0:
       bdev_class: nvme
@@ -23,6 +24,10 @@ server_config:
       scm_class: dcpm
       scm_list: ["/dev/pmem0"]
       scm_mount: /mnt/daos0
+      log_mask: DEBUG,MEM=ERR,SWIM=ERR
+      env_vars:
+        - DD_MASK=all
+        - DD_SUBSYS=all
 pool_1:
   name: daos_server
   control_method: dmg


### PR DESCRIPTION
Quick-Functional: true
Skip-coverity-test: true
Skip-func-test-vm: true
Skip-func-hw-test-small: true
Skip-func-hw-test-medium: true
Skip-func-hw-test-large: false
Skip-scan-centos-rpms: true
Skip-scan-leap15-rpms: true
Skip-test-centos-rpms: true
Test-tag: create_no_space create_no_space_loop

Signed-off-by: Kenneth Cain <kenneth.c.cain@intel.com>