### PR TITLE
DAOS-8821 object: Fix epoch typo in migrate_insert_recxs_sgl

### DIFF
--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -3015,7 +3015,8 @@ merge_recx(d_list_t *head, uint64_t offset, uint64_t size, daos_epoch_t eph)
 		daos_off_t recx_end = recx->recx.rx_idx + recx->recx.rx_nr;
 		daos_epoch_t recx_eph = recx->recx_eph;
 
-		D_DEBUG(DB_TRACE, "current "DF_U64"/"DF_U64"\n", recx_start, recx_end);
+		D_DEBUG(DB_TRACE, "current "DF_U64"/"DF_U64" "DF_X64"\n",
+			recx_start, recx_end, recx_eph);
 		if (end < recx_start) {
 			if (!inserted) {
 				rc = merge_recx_insert(prev == NULL ?

--- a/src/object/srv_obj_migrate.c
+++ b/src/object/srv_obj_migrate.c
@@ -1649,7 +1649,7 @@ migrate_merge_iod_recx(daos_iod_t *dst_iod, daos_epoch_t **p_dst_ephs, daos_recx
 	dst_ephs = p_dst_ephs ? *p_dst_ephs : NULL;
 	D_INIT_LIST_HEAD(&merge_list);
 	for (i = 0; i < new_recxs_nr; i++) {
-		D_DEBUG(DB_REBUILD, "src merge "DF_U64"/"DF_U64" eph "DF_U64"\n",
+		D_DEBUG(DB_REBUILD, "src merge "DF_U64"/"DF_U64" eph "DF_X64"\n",
 			new_recxs[i].rx_idx, new_recxs[i].rx_nr, new_ephs ? new_ephs[i] : 0);
 		rc = merge_recx(&merge_list, new_recxs[i].rx_idx,
 				new_recxs[i].rx_nr, new_ephs ? new_ephs[i] : 0);
@@ -1660,8 +1660,8 @@ migrate_merge_iod_recx(daos_iod_t *dst_iod, daos_epoch_t **p_dst_ephs, daos_recx
 	D_ASSERT(dst_iod != NULL);
 	recxs = dst_iod->iod_recxs;
 	for (i = 0; i < dst_iod->iod_nr; i++) {
-		D_DEBUG(DB_REBUILD, "dst merge "DF_U64"/"DF_U64" eph "DF_U64"\n",
-			recxs[i].rx_idx, recxs[i].rx_nr, dst_ephs ? dst_ephs[i] : 0);
+		D_DEBUG(DB_REBUILD, "dst merge "DF_U64"/"DF_U64" %p eph "DF_X64"\n",
+			recxs[i].rx_idx, recxs[i].rx_nr, dst_ephs, dst_ephs ? dst_ephs[i] : 0);
 		rc = merge_recx(&merge_list, recxs[i].rx_idx, recxs[i].rx_nr,
 				dst_ephs ? dst_ephs[i] : 0);
 		if (rc)
@@ -1688,25 +1688,23 @@ migrate_merge_iod_recx(daos_iod_t *dst_iod, daos_epoch_t **p_dst_ephs, daos_recx
 	}
 
 	i = 0;
-	d_list_for_each_entry_safe(recx, tmp, &merge_list, recx_list) {
+	d_list_for_each_entry(recx, &merge_list, recx_list) {
 		recxs[i] = recx->recx;
 		if (dst_ephs)
 			dst_ephs[i] = recx->recx_eph;
 		i++;
-		D_DEBUG(DB_REBUILD, "merge recx "DF_U64"/"DF_U64"\n",
-			recx->recx.rx_idx, recx->recx.rx_nr);
-		d_list_del(&recx->recx_list);
-		D_FREE(recx);
+		D_DEBUG(DB_REBUILD, "%d merge recx "DF_U64"/"DF_U64" %p "DF_X64"\n",
+			i - 1, recx->recx.rx_idx, recx->recx.rx_nr, dst_ephs,
+			recx->recx_eph);
 	}
 
 	if (dst_iod->iod_recxs != recxs)
 		D_FREE(dst_iod->iod_recxs);
 
-	if (p_dst_ephs && dst_ephs != *p_dst_ephs)
+	if (p_dst_ephs && dst_ephs != *p_dst_ephs) {
 		D_FREE(*p_dst_ephs);
-
-	if (p_dst_ephs)
 		*p_dst_ephs = dst_ephs;
+	}
 
 	dst_iod->iod_recxs = recxs;
 	dst_iod->iod_nr = i;
@@ -1794,7 +1792,8 @@ migrate_insert_recxs_sgl(daos_iod_t *iods, daos_epoch_t **iods_ephs, uint32_t *i
 		D_GOTO(out, rc);
 	}
 
-	rc = migrate_merge_iod_recx(dst_iod, iods_ephs, new_recxs, new_ephs, new_recxs_nr);
+	rc = migrate_merge_iod_recx(dst_iod, iods_ephs ? &iods_ephs[i] : NULL, new_recxs,
+				    new_ephs, new_recxs_nr);
 	if (rc)
 		D_GOTO(out, rc);
 


### PR DESCRIPTION
Fix epoch typo in migrate_insert_recxs_sgl, which might cause
incorrect epoch for parity migration and make data invisible
in some cases.

Add a few useful information to debug log.

Signed-off-by: Di Wang <di.wang@intel.com>