### PR TITLE
DAOS-8733: add object classes for 15 targets/engine

### DIFF
--- a/src/include/daos_obj_class.h
+++ b/src/include/daos_obj_class.h
@@ -165,6 +165,13 @@ enum {
 	OC_S6K,
 	OC_S8K,
 	OC_SX,
+	OC_S15,
+	OC_S30,
+	OC_S60,
+	OC_S90,
+	OC_S120,
+	OC_S150,
+	OC_S180,
 
 	/**
 	 * Replicated object with explicit layout


### PR DESCRIPTION
add OC_S15, OC_S30, OC_S60, ... OC_S180 for engines with 5x NVMe

Signed-off-by: Michael Hennecke <michael.hennecke@intel.com>