### PR TITLE
DAOS-8628 dfuse: Improve dfuse coverity fixes.

### DIFF
--- a/src/client/dfuse/dfuse_thread.c
+++ b/src/client/dfuse/dfuse_thread.c
@@ -128,7 +128,7 @@ dfuse_loop(struct dfuse_info *dfuse_info)
 
 	rc = sem_init(&dtm->tm_finish, 0, 0);
 	if (rc != 0)
-		D_GOTO(out, errno);
+		D_GOTO(out, rc = errno);
 	rc = D_MUTEX_INIT(&dtm->tm_lock, NULL);
 	if (rc != 0)
 		D_GOTO(out_sem, daos_der2errno(rc));


### PR DESCRIPTION
Actaully set rc to errno rather than just reading it if sem_init
fails.
