### PR TITLE
DAOS-7312-test3: Functional testing for EC auto object class selection and move some existing tests to use EC by default

### DIFF
--- a/src/tests/ftest/aggregation/shutdown_restart.py
+++ b/src/tests/ftest/aggregation/shutdown_restart.py
@@ -48,7 +48,7 @@ class IoAggregation(IorTestBase):
 
         :avocado: tags=all,full_regression
         :avocado: tags=hw,small
-        :avocado: tags=daosio,io_aggregation,tx
+        :avocado: tags=daosio,ioaggregation,tx
         """
         # update ior signature option
         self.ior_cmd.signature.update("123")

--- a/src/tests/ftest/aggregation/shutdown_restart.yaml
+++ b/src/tests/ftest/aggregation/shutdown_restart.yaml
@@ -16,7 +16,7 @@ server_config:
       - FI_SOCKETS_CONN_TIMEOUT=2000
       - DD_MASK=all
     bdev_class: nvme
-    bdev_list: ["0000:81:00.0"]
+    bdev_list: ["aaaa:aa:aa.a","bbbb:bb:bb.b"]
 pool:
   createmode:
     mode_RW:
@@ -24,8 +24,8 @@ pool:
   createset:
     setname: daos_server
   createsize:
-    scm_size: 5000000000
-    nvme_size: 10000000000
+    scm_size: 20% 
+    nvme_size: 50% 
   createsvc:
     svcn: 1
   control_method: dmg
@@ -46,4 +46,4 @@ ior:
       block_size: '104857600'  # 100M
   objectclass:
     SX:
-      dfs_oclass: "SX"
+      dfs_oclass: "EC_2P1GX"

--- a/src/tests/ftest/aggregation/shutdown_restart.yaml
+++ b/src/tests/ftest/aggregation/shutdown_restart.yaml
@@ -24,8 +24,8 @@ pool:
   createset:
     setname: daos_server
   createsize:
-    scm_size: 20% 
-    nvme_size: 50% 
+    scm_size: 20%
+    nvme_size: 50%
   createsvc:
     svcn: 1
   control_method: dmg

--- a/src/tests/ftest/aggregation/shutdown_restart.yaml
+++ b/src/tests/ftest/aggregation/shutdown_restart.yaml
@@ -1,8 +1,9 @@
 hosts:
   test_servers:
     - server-A
+    - server-B
   test_clients:
-    - client-B
+    - client-C
 timeout: 600
 server_config:
   name: daos_server
@@ -32,6 +33,7 @@ pool:
 container:
   type: POSIX
   control_method: daos
+  properties: rf:1
 ior:
   api: "DFS"
   client_processes:
@@ -45,5 +47,5 @@ ior:
       transfer_size: '4K'
       block_size: '104857600'  # 100M
   objectclass:
-    SX:
+    EC_2P1GX:
       dfs_oclass: "EC_2P1GX"

--- a/src/tests/ftest/dfuse/caching_check.py
+++ b/src/tests/ftest/dfuse/caching_check.py
@@ -35,7 +35,7 @@ class CachingCheck(IorTestBase):
             higher than with caching disabled.
 
         :avocado: tags=all,full_regression
-        :avocado: tags=hw,small
+        :avocado: tags=hw,medium,ib2
         :avocado: tags=daosio,dfuse
         :avocado: tags=dfusecachingcheck
         """

--- a/src/tests/ftest/dfuse/caching_check.py
+++ b/src/tests/ftest/dfuse/caching_check.py
@@ -35,7 +35,7 @@ class CachingCheck(IorTestBase):
             higher than with caching disabled.
 
         :avocado: tags=all,full_regression
-        :avocado: tags=hw,medium,ib2
+        :avocado: tags=hw,small
         :avocado: tags=daosio,dfuse
         :avocado: tags=dfusecachingcheck
         """

--- a/src/tests/ftest/dfuse/caching_check.yaml
+++ b/src/tests/ftest/dfuse/caching_check.yaml
@@ -9,14 +9,14 @@ server_config:
     servers:
         log_mask: INFO
         bdev_class: nvme
-        bdev_list: ["0000:83:00.0"]
+        bdev_list: ["aaaa:aa:aa.a", "bbbb:bb:bb.b"]
         scm_class: dcpm
         scm_list: ["/dev/pmem0"]
 pool:
     mode: 146 # 146 is RW
     name: daos_server
-    scm_size: 6G
-    nvme_size: 10G
+    scm_size: 20%
+    nvme_size: 40%
     control_method: dmg
 container:
     type: POSIX
@@ -31,7 +31,7 @@ ior:
     dfs_destroy: False
     transfer_size: '1M'
     block_size: '64M'
-    dfs_oclass: "SX"
+    dfs_oclass: "EC_2P1G1"
     read_x: 10 # 1000%
     iorflags:
       - "-v -w -k"

--- a/src/tests/ftest/io/parallel_io.yaml
+++ b/src/tests/ftest/io/parallel_io.yaml
@@ -2,8 +2,9 @@ hosts:
   test_servers:
     - server-A
     - server-B
+    - server-C
   test_clients:
-    - client-C
+    - client-D
 timeout: 600
 server_config:
   name: daos_server
@@ -47,7 +48,7 @@ ior:
     transfer_size: '25M'
     block_size: '26214400'    # 25M
     objectclass:
-        oclass_SX:
-          dfs_oclass: "SX"
+        oclass_EC_2P1GX:
+          dfs_oclass: "EC_2P1GX"
 dfuse:
   mount_dir: "/tmp/daos_dfuse/"


### PR DESCRIPTION
DAOS-7312 tests: Functional testing for EC auto object class selection and move some existing tests to use EC by default.
Description: Update test dfs_oclass: with "EC_2P2GX" after DAOS-7205 auto obj class selection implemented.
This commit for ioaggregation,dfusecachingcheck,parallelio are portion of the test scripts specified in DAOS-7312.

modified:   ../aggregation/shutdown_restart.py
modified:   ../aggregation/shutdown_restart.yaml
modified:   ../dfuse/caching_check.py
modified:   ../dfuse/caching_check.yaml
modified:   parallel_io.yaml

Test-tag-hw-small: pr ioaggregation,dfusecachingcheck
Test-tag-hw-medium: pr parallelio
Signed-off-by: Ding Ho ding-hwa.ho@intel.com