### PR TITLE
DAOS-8825 pool: stop gc ULT when all ops ULTs are gone

### DIFF
--- a/src/pool/srv_target.c
+++ b/src/pool/srv_target.c
@@ -276,6 +276,7 @@ pool_child_delete_one(void *uuid)
 
 	d_list_del_init(&child->spc_list);
 	ds_cont_child_stop_all(child);
+	ds_stop_scrubbing_ult(child);
 	ds_pool_child_put(child); /* -1 for the list */
 
 	ds_pool_child_put(child); /* -1 for lookup */
@@ -286,8 +287,7 @@ pool_child_delete_one(void *uuid)
 
 	ABT_eventual_free(&child->spc_ref_eventual);
 
-	/* only stop scrubbing and gc ULTs when all ops ULTs are done */
-	ds_stop_scrubbing_ult(child);
+	/* only stop gc ULT when all ops ULTs are done */
 	stop_gc_ult(child);
 
 	/* ds_pool_child must be freed here to keep

--- a/src/pool/srv_target.c
+++ b/src/pool/srv_target.c
@@ -263,8 +263,6 @@ pool_child_delete_one(void *uuid)
 
 	d_list_del_init(&child->spc_list);
 	ds_cont_child_stop_all(child);
-	stop_gc_ult(child);
-	ds_stop_scrubbing_ult(child);
 	ds_pool_child_put(child); /* -1 for the list */
 
 	ds_pool_child_put(child); /* -1 for lookup */
@@ -274,6 +272,11 @@ pool_child_delete_one(void *uuid)
 	 * since the ds_pool_child references ds_pool by 'spc_pool' without
 	 * holding ds_pool refcount.
 	 */
+
+	/* only stop scrubbing and gc ULTs when all ops ULTs are done */
+	ds_stop_scrubbing_ult(child);
+	stop_gc_ult(child);
+
 	return 0;
 }
 


### PR DESCRIPTION
Do not stop gc ULT thread before all workers ULTs running
on ds_pool_child have completed, because some of them, like
container_aggregate, can be late and need to schedule gc ULT.
This patch is a follow-on to DAOS-8546/PR-6079, where it is
ensured to wait for all late workers ULTs to be done prior
terminating ds_pool_child.

Change-Id: I7def5c933ca78de3818b3cd7e8bf9d9b708b31d0
Signed-off-by: Bruno Faccini <bruno.faccini@intel.com>