### PR TITLE
DAOS-8835 vos: not clean non-exist DXT entry

### DIFF
--- a/src/vos/vos_dtx.c
+++ b/src/vos/vos_dtx.c
@@ -2697,14 +2697,17 @@ vos_dtx_cleanup_internal(struct dtx_handle *dth)
 		}
 
 		if (rc != 0) {
-			if (rc != -DER_NONEXIST)
+			if (rc != -DER_NONEXIST) {
 				D_ERROR("Fail to remove DTX entry "DF_DTI":"
 					DF_RC"\n",
 					DP_DTI(&dth->dth_xid), DP_RC(rc));
 
-			dae = dth->dth_ent;
-			if (dae != NULL)
-				dae->dae_aborted = 1;
+				dae = dth->dth_ent;
+				if (dae != NULL)
+					dae->dae_aborted = 1;
+			} else {
+				rc = 0;
+			}
 		} else {
 			dae = (struct vos_dtx_act_ent *)riov.iov_buf;
 			/* Cannot cleanup 'prepared' or 'committed' DTX entry. */


### PR DESCRIPTION
master-commit: dd6edd4f3ac17c67607c35a4949fad08da958c81

The DTX entry may has been aborted during current ULT waiting
for some event, such as bulk data transfer. Then when current
ULT try to cleanup the DTX entry for some reason, it needs to
check whether related DTX entry is still in the active table
or not, if not then skip the cleanup.

Signed-off-by: Fan Yong <fan.yong@intel.com>