### PR TITLE
DAOS-8826 object: distinguish update resent and retry in metrics

### DIFF
--- a/src/object/obj_internal.h
+++ b/src/object/obj_internal.h
@@ -280,6 +280,8 @@ struct obj_pool_metrics {
 	struct d_tm_node_t	*opm_update_restart;
 	/** Total number of resent update operations (type = counter) */
 	struct d_tm_node_t	*opm_update_resent;
+	/** Total number of retry update operations (type = counter) */
+	struct d_tm_node_t	*opm_update_retry;
 };
 
 struct obj_tls {

--- a/src/object/srv_mod.c
+++ b/src/object/srv_mod.c
@@ -255,6 +255,13 @@ obj_metrics_alloc(const char *path, int tgt_id)
 		D_WARN("Failed to create resent cnt sensor: "DF_RC"\n",
 		       DP_RC(rc));
 
+	/** Total number of retry updates locally, of type counter */
+	rc = d_tm_add_metric(&metrics->opm_update_retry, D_TM_COUNTER,
+			     "total number of retried update RPCs", "updates",
+			     "%s/retry/tgt_%u", path, tgt_id);
+	if (rc)
+		D_WARN("Failed to create retry cnt sensor: "DF_RC"\n", DP_RC(rc));
+
 	/** Total bytes read */
 	rc = d_tm_add_metric(&metrics->opm_fetch_bytes, D_TM_COUNTER,
 			     "total number of bytes fetched/read", "bytes",


### PR DESCRIPTION
Resent is client sponsored RPC with 'ORF_RESEND' flag.
Retry is server self triggered local re-executing related operation.
Distinguishing them will avoid misguiding.

Signed-off-by: Fan Yong <fan.yong@intel.com>