### PR TITLE
DAOS-8685 pool: run create tests with logging, CentOS8 HW

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,7 +12,7 @@
 
 // To use a test branch (i.e. PR) until it lands to master
 // I.e. for testing library changes
-//@Library(value="pipeline-lib@your_branch") _
+@Library(value="pipeline-lib@bmurrell/run-prs-on-el8-hw") _
 
 // For master, this is just some wildly high number
 next_version = "1000"
@@ -1054,7 +1054,7 @@ pipeline {
                     }
                     steps {
                         functionalTest inst_repos: daosRepos(),
-                                       inst_rpms: functionalPackages(1, next_version),
+                                       inst_rpms: functionalPackages("centos8", 1, next_version),
                                        test_function: 'runTestFunctionalV2'
                     }
                     post {
@@ -1075,7 +1075,7 @@ pipeline {
                     steps {
                         functionalTest target: hwDistroTarget(),
                                        inst_repos: daosRepos(),
-                                       inst_rpms: functionalPackages(1, next_version),
+                                       inst_rpms: functionalPackages("centos8", 1, next_version),
                                        test_function: 'runTestFunctionalV2'
                    }
                     post {
@@ -1096,7 +1096,7 @@ pipeline {
                     steps {
                         functionalTest target: hwDistroTarget(),
                                        inst_repos: daosRepos(),
-                                       inst_rpms: functionalPackages(1, next_version),
+                                       inst_rpms: functionalPackages("centos8", 1, next_version),
                                        test_function: 'runTestFunctionalV2'
                     }
                     post {

--- a/ci/provisioning/post_provision_config_common.sh
+++ b/ci/provisioning/post_provision_config_common.sh
@@ -55,7 +55,7 @@ retry_cmd() {
         fi
         # Command failed, retry
         rc=${PIPESTATUS[0]}
-        (( attempt++ ))
+        (( attempt++ )) || true
         if [ "$attempt" -gt 0 ]; then
             sleep "${RETRY_DELAY_SECONDS:-$DAOS_STACK_RETRY_DELAY_SECONDS}"
         fi
@@ -84,7 +84,7 @@ timeout_cmd() {
         rc=${PIPESTATUS[0]}
         if [ "$rc" = "124" ]; then
             # Command timed out, try again
-            (( attempt++ ))
+            (( attempt++ )) || true
             continue
         fi
         # Command failed for something other than timeout

--- a/ci/provisioning/post_provision_config_nodes_EL_7.sh
+++ b/ci/provisioning/post_provision_config_nodes_EL_7.sh
@@ -46,6 +46,7 @@ EOF
 
     # Mellanox OFED hack
     if ls -d /usr/mpi/gcc/openmpi-*; then
+        mkdir -p /etc/modulefiles/mpi/
         cat <<EOF > /etc/modulefiles/mpi/mlnx_openmpi-x86_64
 #%Module 1.0
 #

--- a/ci/provisioning/post_provision_config_nodes_EL_8.sh
+++ b/ci/provisioning/post_provision_config_nodes_EL_8.sh
@@ -6,7 +6,7 @@ LSB_RELEASE=redhat-lsb-core
 EXCLUDE_UPGRADE=dpdk,fuse,mercury,daos,daos-\*
 
 bootstrap_dnf() {
-    :
+    dnf -y erase openmpi opensm-libs
 }
 
 group_repo_post() {
@@ -15,22 +15,9 @@ group_repo_post() {
 }
 
 distro_custom() {
-    # force install of avocado 69.x
-    dnf -y erase avocado{,-common}                                              \
-                 python2-avocado{,-plugins-{output-html,varianter-yaml-to-mux}} \
-                 python3-pyyaml
-    pip3 install "avocado-framework<70.0"
-    pip3 install "avocado-framework-plugin-result-html<70.0"
-    pip3 install "avocado-framework-plugin-varianter-yaml-to-mux<70.0"
-    pip3 install clustershell
-
-    if ! rpm -q nfs-utils; then
-        retry_cmd 360 dnf -y install nfs-utils
-    fi
-
-    # CORCI-1096
-    dnf -y install esmtp
-    sed -e 's/^\(hostname *= *\)[^ ].*$/\1 mail.wolf.hpdd.intel.com:25/' < /usr/share/doc/esmtp/sample.esmtprc > /etc/esmtprc
+    # install avocado
+    dnf -y install python3-avocado{,-plugins-{output-html,varianter-yaml-to-mux}} \
+                   clustershell
 
     dnf config-manager --disable powertools
 
@@ -94,10 +81,13 @@ post_provision_config_nodes() {
     retry_cmd 360 dnf -y install $LSB_RELEASE
 
     # shellcheck disable=SC2086
-    if [ -n "$INST_RPMS" ] && ! retry_cmd 360 dnf -y install $INST_RPMS; then
-        rc=${PIPESTATUS[0]}
-        dump_repos
-        exit "$rc"
+    if [ -n "$INST_RPMS" ]; then
+        if ! retry_cmd 360 dnf -y install $INST_RPMS; then
+            rc=${PIPESTATUS[0]}
+            dump_repos
+            #sleep 600
+            exit "$rc"
+        fi
     fi
 
     distro_custom
@@ -112,6 +102,8 @@ post_provision_config_nodes() {
         cat /etc/do-release
     fi
     cat /etc/os-release
+
+    rpm -qa | sort
 
     exit 0
 }

--- a/site_scons/env_modules.py
+++ b/site_scons/env_modules.py
@@ -25,8 +25,8 @@ import sys
 import errno
 import distro
 import subprocess #nosec
+import shutil
 from subprocess import PIPE, Popen #nosec
-from SCons.Script import WhereIs
 
 class _env_module(): # pylint: disable=invalid-name
     """Class for utilizing Modules component to load environment modules"""
@@ -120,7 +120,7 @@ class _env_module(): # pylint: disable=invalid-name
         for to_load in load:
             self._module_func('load', to_load)
             print("Looking for %s" % to_load)
-            if WhereIs('mpirun'):
+            if shutil.which('mpirun'):
                 print("Loaded %s" % to_load)
                 return True
         return False
@@ -146,7 +146,7 @@ class _env_module(): # pylint: disable=invalid-name
         if not self._module_load(mpi):
             print("No %s found\n" % mpi)
             return False
-        exe_path = WhereIs('mpirun')
+        exe_path = shutil.which('mpirun')
         if not exe_path:
             print("No mpirun found in path. Could not configure %s\n" % mpi)
             return False
@@ -166,7 +166,7 @@ def load_mpi(mpi):
     # On Ubuntu, MPI stacks use alternatives and need root to change their
     # pointer, so just verify that the desired MPI is loaded
     if distro.id() == "ubuntu":
-        updatealternatives = WhereIs('update-alternatives')
+        updatealternatives = shutil.which('update-alternatives')
         if not updatealternatives:
             print("No update-alternatives found in path.")
             return False

--- a/src/tests/ftest/harness/basic.py
+++ b/src/tests/ftest/harness/basic.py
@@ -27,7 +27,7 @@ class HarnessBasicTest(Test):
 
         :avocado: tags=all
         :avocado: tags=hw,large,medium,ib2,small
-        :avocado: tags=harness,harness_basic_test,test_always_passes_hw
+        :avocado: tags=harness,harness_basic_test,test_always_passes,test_always_passes_hw
         :avocado: tags=always_passes
         """
         self.test_always_passes()

--- a/src/tests/ftest/pool/create.yaml
+++ b/src/tests/ftest/pool/create.yaml
@@ -16,6 +16,7 @@ timeouts:
   test_create_no_space_loop: 2160
 server_config:
   name: daos_server
+  control_log_mask: DEBUG
   servers:
     0:
       bdev_class: nvme
@@ -23,6 +24,11 @@ server_config:
       scm_class: dcpm
       scm_list: ["/dev/pmem0"]
       scm_mount: /mnt/daos0
+      log_mask: DEBUG,MEM=ERR,SWIM=ERR
+      env_vars:
+        - DD_MASK=all
+        - DD_SUBSYS=all
+        - DAOS_SCHED_RELAX_MODE=disabled
 pool_1:
   name: daos_server
   control_method: dmg

--- a/src/tests/ftest/scripts/setup_nodes.sh
+++ b/src/tests/ftest/scripts/setup_nodes.sh
@@ -43,7 +43,7 @@ if [ \"\$(ulimit -c)\" != \"unlimited\" ]; then
     echo \"*  soft  core  unlimited\" >> /etc/security/limits.conf
 fi
 echo \"/var/tmp/core.%e.%t.%p\" > /proc/sys/kernel/core_pattern"
-rm -f /var/tmp/core.*
+sudo rm -f /var/tmp/core.*
 if [ "${HOSTNAME%%.*}" != "$FIRST_NODE" ]; then
     if grep /mnt/daos\  /proc/mounts; then
         sudo umount /mnt/daos

--- a/src/tests/ftest/server/cpu_usage.yaml
+++ b/src/tests/ftest/server/cpu_usage.yaml
@@ -7,9 +7,8 @@ timeout: 130
 server_config:
   nr_hugepages: 8192
   servers:
-    # 16 targets and 16 nr_xs_helpers are the requirements.
-    targets: 16
-    nr_xs_helpers: 16
+    targets: 8
+    nr_xs_helpers: 8
     bdev_class: nvme
     bdev_list: ["0000:00:00.0"]
     scm_class: dcpm

--- a/src/tests/ftest/server/metadata.yaml
+++ b/src/tests/ftest/server/metadata.yaml
@@ -29,7 +29,7 @@ server_config:
       scm_list: ["/dev/pmem0"]
       # common items below (same in server 0 and server 1)
       scm_class: dcpm
-      nr_xs_helpers: 16
+      nr_xs_helpers: 8
       log_mask: DEBUG,MEM=ERR
       env_vars:
         - DAOS_MD_CAP=128
@@ -45,7 +45,7 @@ server_config:
       scm_list: ["/dev/pmem1"]
       # common items below (same in server 0 and server 1)
       scm_class: dcpm
-      nr_xs_helpers: 16
+      nr_xs_helpers: 8
       log_mask: DEBUG,MEM=ERR
       env_vars:
         - DAOS_MD_CAP=128

--- a/src/tests/ftest/util/general_utils.py
+++ b/src/tests/ftest/util/general_utils.py
@@ -406,17 +406,34 @@ def run_pcmd(hosts, command, verbose=True, timeout=None, expect_rc=0):
         for item in results
         if expect_rc is not None and item["exit_status"] != expect_rc]
     if verbose or bad_exit_status:
-        log.info("Command: %s", command)
-        log.info("Results:")
-        for result in results:
-            log.info(
-                "  %s: exit_status=%s, interrupted=%s:",
-                result["hosts"], result["exit_status"], result["interrupted"])
-            for line in result["stdout"]:
-                log.info("    %s", line)
+        log.info(colate_results(command, results))
 
     return results
 
+
+def colate_results(command, results):
+    """Colate the output of run_pcmd.
+
+    Args:
+        command (str): command used to obtain the data on each server
+        results (list): list: a list of dictionaries with each entry
+                        containing output, exit status, and interrupted
+                        status common to each group of hosts (see run_pcmd()'s
+                        return for details)
+    Returns:
+        str: a string colating run_pcmd()'s results
+
+    """
+    res = ""
+    res += "Command: %s\n" % command
+    res += "Results:\n"
+    for result in results:
+        res += "  %s: exit_status=%s, interrupted=%s:" % (
+               result["hosts"], result["exit_status"], result["interrupted"])
+        for line in result["stdout"]:
+            res += "    %s\n" % line
+
+    return res
 
 def get_host_data(hosts, command, text, error, timeout=None):
     """Get the data requested for each host using the specified command.

--- a/src/tests/ftest/util/server_utils_params.py
+++ b/src/tests/ftest/util/server_utils_params.py
@@ -358,7 +358,7 @@ class DaosServerYamlParameters(YamlParameters):
             #           - CRT_CTX_NUM=8
             self.targets = BasicParameter(None, 8)
             self.first_core = BasicParameter(None, 0)
-            self.nr_xs_helpers = BasicParameter(None, 16)
+            self.nr_xs_helpers = BasicParameter(None, 8)
             self.fabric_iface = BasicParameter(None, default_interface)
             self.fabric_iface_port = BasicParameter(None, default_port)
             self.pinned_numa_node = BasicParameter(None)

--- a/utils/rpms/daos.spec
+++ b/utils/rpms/daos.spec
@@ -14,7 +14,7 @@
 
 Name:          daos
 Version:       2.1.100
-Release:       2%{?relval}%{?dist}
+Release:       3%{?relval}%{?dist}
 Summary:       DAOS Storage Engine
 
 License:       BSD-2-Clause-Patent
@@ -228,6 +228,18 @@ Requires: libpsm_infinipath1
 %description tests
 This is the package needed to run the DAOS test suite
 
+
+%package tests-openmpi
+Summary: The DAOS test suite - tools which need openmpi
+#This is a bit messy and needs some cleanup.  In theory,
+#we should have client tests and server tests in separate
+#packages but some binaries need libraries from both at
+#present.
+Requires: %{name}-tests%{?_isa} = %{version}-%{release}
+
+%description tests-openmpi
+This is the package needed to run the DAOS test suite openmpi tools
+
 %package devel
 Summary: The DAOS development libraries and headers
 Requires: %{name}-client%{?_isa} = %{version}-%{release}
@@ -429,7 +441,6 @@ getent passwd daos_agent >/dev/null || useradd -s /sbin/nologin -r -g daos_agent
 %dir %{_prefix}/lib/daos
 %{_prefix}/lib/daos/TESTING
 %{_bindir}/hello_drpc
-%{_bindir}/jobtest
 %{_libdir}/libdaos_tests.so
 %{_bindir}/jump_pl_map
 %{_bindir}/ring_pl_map
@@ -437,18 +448,9 @@ getent passwd daos_agent >/dev/null || useradd -s /sbin/nologin -r -g daos_agent
 %{_bindir}/smd_ut
 %{_bindir}/vea_ut
 %{_bindir}/vea_stress
-%{_bindir}/daos_perf
-%{_bindir}/vos_perf
-%{_bindir}/daos_racer
 %{_bindir}/evt_ctl
 %{_bindir}/io_conf
 %{_bindir}/rdbt
-%{_bindir}/obj_ctl
-%{_bindir}/daos_gen_io_conf
-%{_bindir}/daos_run_io_conf
-%{_bindir}/crt_launch
-%{_bindir}/daos_test
-%{_bindir}/dfs_test
 %{_bindir}/common_test
 %{_bindir}/acl_dump_test
 %{_bindir}/agent_tests
@@ -464,6 +466,18 @@ getent passwd daos_agent >/dev/null || useradd -s /sbin/nologin -r -g daos_agent
 # For avocado tests
 %{_prefix}/lib/daos/.build_vars.json
 %{_prefix}/lib/daos/.build_vars.sh
+
+%files tests-openmpi
+%{_bindir}/crt_launch
+%{_bindir}/daos_gen_io_conf
+%{_bindir}/daos_perf
+%{_bindir}/daos_racer
+%{_bindir}/daos_run_io_conf
+%{_bindir}/daos_test
+%{_bindir}/dfs_test
+%{_bindir}/jobtest
+%{_bindir}/obj_ctl
+%{_bindir}/vos_perf
 %{_libdir}/libdts.so
 
 %files devel
@@ -481,6 +495,9 @@ getent passwd daos_agent >/dev/null || useradd -s /sbin/nologin -r -g daos_agent
 %{_libdir}/libdaos_serialize.so
 
 %changelog
+* Fri Oct 15 2021 Brian J. Murrell <brian.murrell@intel.com> 2.1.100-3
+- Create new daos-tests-openmpi subpackage
+
 * Mon Oct 13 2021 David Quigley <david.quigley@intel.com> 2.1.100-2
 - Add defusedxml as a required dependency for the test package.
 


### PR DESCRIPTION
This is PR-6741 contents, rebased on 19 October 2021 master.
- Plus a change to create.yaml to add server and engine debug logs.
- Plus a change to server_utils_params.py so that if nr_xs_helpers
  is not specified in engine configuration, it is set to 8 threads.
  This attempts to avoid oversubscribing a CPU's physical cores with
  the daos_engine xstreams(threads).
  (e.g., 18 cores: 8 tgt threads, 8 helpers, swim, system)
  (rather than: 8 tgt threads, _16_ helpers, swim, system)
- Plus a change to pool/create.yaml, DAOS_SCHED_RELAX_MODE=disabled

Quick-Functional: true
Skip-coverity-test: true
Skip-func-test-vm: true
Skip-func-hw-test-small: true
Skip-func-hw-test-medium: true
Skip-func-hw-test-large: false
Func-hw-test-distro: el8.4
Skip-scan-centos-rpms: true
Skip-scan-leap15-rpms: true
Skip-test-centos-rpms: true
Skip-test-centos-8.3-rpms: true
Skip-test-leap-15-rpms: true
Allow-unstable-test: true
Skip-PR-comments: true
Test-tag: create_no_space create_no_space_loop

Signed-off-by: Kenneth Cain <kenneth.c.cain@intel.com>