### PR TITLE
DAOS-8685 pool,swim: force swim and system xs on same core

### DIFF
--- a/src/cart/crt_context.c
+++ b/src/cart/crt_context.c
@@ -274,8 +274,8 @@ crt_context_provider_create(crt_context_t *crt_ctx, int provider)
 
 	if (crt_is_service() &&
 	    crt_gdata.cg_auto_swim_disable == 0 &&
-	    ctx->cc_idx == crt_gdata.cg_swim_crt_idx) {
-		rc = crt_swim_init(crt_gdata.cg_swim_crt_idx);
+	    ctx->cc_idx == CRT_DEFAULT_PROGRESS_CTX_IDX) {
+		rc = crt_swim_init(CRT_DEFAULT_PROGRESS_CTX_IDX);
 		if (rc) {
 			D_ERROR("crt_swim_init() failed rc: %d.\n", rc);
 			crt_context_destroy(ctx, true);
@@ -1352,23 +1352,23 @@ crt_context_empty(int provider, int locked)
 	return rc;
 }
 
-static int64_t
-crt_exec_progress_cb(struct crt_context *ctx, int64_t timeout)
+static void
+crt_exec_progress_cb(struct crt_context *ctx)
 {
 	struct crt_prog_cb_priv	*cbs_prog;
 	crt_progress_cb		 cb_func;
 	void			*cb_args;
-	size_t			 cbs_size, i;
-	int			 ctx_idx;
-	int			 rc;
+	size_t i, cbs_size;
+	int ctx_idx;
+	int rc;
 
 	if (unlikely(crt_plugin_gdata.cpg_inited == 0 || ctx == NULL))
-		return timeout;
+		return;
 
 	rc = crt_context_idx(ctx, &ctx_idx);
 	if (unlikely(rc)) {
 		D_ERROR("crt_context_idx() failed, rc: %d.\n", rc);
-		return timeout;
+		return;
 	}
 
 	cbs_size = crt_plugin_gdata.cpg_prog_size[ctx_idx];
@@ -1379,10 +1379,8 @@ crt_exec_progress_cb(struct crt_context *ctx, int64_t timeout)
 		cb_args = cbs_prog[i].cpcp_args;
 		/* check for and execute progress callbacks here */
 		if (cb_func != NULL)
-			timeout = cb_func(ctx, timeout, cb_args);
+			cb_func(ctx, cb_args);
 	}
-
-	return timeout;
 }
 
 int
@@ -1416,9 +1414,23 @@ crt_progress_cond(crt_context_t crt_ctx, int64_t timeout,
 	ctx = crt_ctx;
 
 	/** Progress with callback and non-null timeout */
-	if (timeout > 0) {
+	if (timeout < 0) {
+		/**
+		 * For infinite timeout, use a mercury timeout of 1 ms to avoid
+		 * being blocked indefinitely if another thread has called
+		 * crt_hg_progress() behind our back
+		 */
+		hg_timeout = 1000;
+	} else if (timeout == 0) {
+		hg_timeout = 0;
+	} else { /** timeout > 0 */
 		now = d_timeus_secdiff(0);
 		end = now + timeout;
+		/** similarly, probe more frequently if timeout is large */
+		if (timeout > 1000 * 1000)
+			hg_timeout = 1000 * 1000;
+		else
+			hg_timeout = timeout;
 	}
 
 	/**
@@ -1434,24 +1446,7 @@ crt_progress_cond(crt_context_t crt_ctx, int64_t timeout,
 	/** loop until callback returns non-null value */
 	while ((rc = cond_cb(arg)) == 0) {
 		crt_context_timeout_check(ctx);
-		timeout = crt_exec_progress_cb(ctx, timeout);
-
-		if (timeout < 0) {
-			/**
-			 * For infinite timeout, use a mercury timeout of 1 ms to avoid
-			 * being blocked indefinitely if another thread has called
-			 * crt_hg_progress() behind our back
-			 */
-			hg_timeout = 1000;
-		} else if (timeout == 0) {
-			hg_timeout = 0;
-		} else { /** timeout > 0 */
-			/** similarly, probe more frequently if timeout is large */
-			if (timeout > 1000 * 1000)
-				hg_timeout = 1000 * 1000;
-			else
-				hg_timeout = timeout;
-		}
+		crt_exec_progress_cb(ctx);
 
 		rc = crt_hg_progress(&ctx->cc_hg_ctx, hg_timeout);
 		if (unlikely(rc && rc != -DER_TIMEDOUT)) {
@@ -1471,6 +1466,12 @@ crt_progress_cond(crt_context_t crt_ctx, int64_t timeout,
 				break;
 			return -DER_TIMEDOUT;
 		}
+
+		/** adjust timeout */
+		if (end - now > 1000 * 1000)
+			hg_timeout = 1000 * 1000;
+		else
+			hg_timeout = end - now;
 	}
 
 	if (rc > 0)
@@ -1506,7 +1507,7 @@ crt_progress(crt_context_t crt_ctx, int64_t timeout)
 	 * progress
 	 */
 	crt_context_timeout_check(ctx);
-	timeout = crt_exec_progress_cb(ctx, timeout);
+	crt_exec_progress_cb(ctx);
 
 	if (timeout != 0 && (rc == 0 || rc == -DER_TIMEDOUT)) {
 		/** call progress once again with the real timeout */

--- a/src/cart/crt_init.c
+++ b/src/cart/crt_init.c
@@ -163,10 +163,6 @@ static int data_init(int server, crt_init_options_t *opt)
 	D_DEBUG(DB_ALL, "set the global timeout value as %d second.\n",
 		crt_gdata.cg_timeout);
 
-	crt_gdata.cg_swim_crt_idx = CRT_DEFAULT_PROGRESS_CTX_IDX;
-
-	D_DEBUG(DB_ALL, "SWIM context idx=%d\n", crt_gdata.cg_swim_crt_idx);
-
 	/* Override defaults and environment if option is set */
 	if (opt && opt->cio_use_credits) {
 		credits = opt->cio_ep_credits;
@@ -542,6 +538,7 @@ do_init:
 		D_ASSERT(crt_gdata.cg_opc_map != NULL);
 
 		crt_gdata.cg_inited = 1;
+
 	} else {
 		if (crt_gdata.cg_server == false && server == true) {
 			D_ERROR("CRT initialized as client, cannot set as "

--- a/src/cart/crt_internal_types.h
+++ b/src/cart/crt_internal_types.h
@@ -71,9 +71,6 @@ struct crt_gdata {
 	/** global timeout value (second) for all RPCs */
 	uint32_t		cg_timeout;
 
-	/** global swim index for all servers */
-	int32_t			cg_swim_crt_idx;
-
 	/** credits limitation for #inflight RPCs per target EP CTX */
 	uint32_t		cg_credit_ep_ctx;
 

--- a/src/cart/crt_swim.c
+++ b/src/cart/crt_swim.c
@@ -710,7 +710,7 @@ static void crt_swim_new_incarnation(struct swim_context *ctx,
 	state->sms_incarnation = incarnation;
 }
 
-static int64_t crt_swim_progress_cb(crt_context_t crt_ctx, int64_t timeout, void *arg)
+static void crt_swim_progress_cb(crt_context_t crt_ctx, void *arg)
 {
 	struct crt_grp_priv	*grp_priv = crt_gdata.cg_grp->gg_primary_grp;
 	struct crt_swim_membs	*csm = &grp_priv->gp_membs_swim;
@@ -719,7 +719,7 @@ static int64_t crt_swim_progress_cb(crt_context_t crt_ctx, int64_t timeout, void
 	int			 rc;
 
 	if (self_id == SWIM_ID_INVALID)
-		return timeout;
+		return;
 
 	if (crt_swim_fail_hlc && crt_hlc_get() >= crt_swim_fail_hlc) {
 		crt_swim_should_fail = true;
@@ -727,22 +727,14 @@ static int64_t crt_swim_progress_cb(crt_context_t crt_ctx, int64_t timeout, void
 		D_EMIT("SWIM id=%lu should fail\n", crt_swim_fail_id);
 	}
 
-	rc = swim_progress(ctx, timeout);
+	rc = swim_progress(ctx, CRT_SWIM_PROGRESS_TIMEOUT);
 	if (rc == -DER_SHUTDOWN) {
 		if (grp_priv->gp_size > 1)
 			D_ERROR("SWIM shutdown\n");
 		swim_self_set(ctx, SWIM_ID_INVALID);
-	} else if (rc == -DER_TIMEDOUT || rc == -DER_CANCELED) {
-		uint64_t now = swim_now_ms();
-
-		if (now < ctx->sc_next_event)
-			timeout = ctx->sc_next_event - now;
-		D_DEBUG(DB_TRACE, "adjust the timeout=%li\n", timeout);
-	} else if (rc) {
+	} else if (rc && rc != -DER_TIMEDOUT) {
 		D_ERROR("swim_progress(): "DF_RC"\n", DP_RC(rc));
 	}
-
-	return timeout;
 }
 
 void crt_swim_fini(void)

--- a/src/cart/crt_swim.h
+++ b/src/cart/crt_swim.h
@@ -17,7 +17,8 @@
 #define CRT_SWIM_NGLITCHES_TRESHOLD	10
 #define CRT_SWIM_NMESSAGES_TRESHOLD	1000
 #define CRT_SWIM_FLUSH_ATTEMPTS		100
-#define CRT_DEFAULT_PROGRESS_CTX_IDX	1
+#define CRT_SWIM_PROGRESS_TIMEOUT	0	/* minimal progressing time */
+#define CRT_DEFAULT_PROGRESS_CTX_IDX	0
 
 struct crt_swim_target {
 	d_circleq_entry(crt_swim_target) cst_link;

--- a/src/cart/swim/swim.c
+++ b/src/cart/swim/swim.c
@@ -485,9 +485,6 @@ swim_member_update_suspected(struct swim_context *ctx, uint64_t now,
 						 id_state.sms_incarnation);
 				D_FREE(item);
 			}
-		} else {
-			if (item->u.si_deadline < ctx->sc_next_event)
-				ctx->sc_next_event = item->u.si_deadline;
 		}
 next_item:
 		item = next;
@@ -532,9 +529,6 @@ swim_ipings_update(struct swim_context *ctx, uint64_t now,
 		if (now > item->u.si_deadline) {
 			TAILQ_REMOVE(&ctx->sc_ipings, item, si_link);
 			TAILQ_INSERT_TAIL(&targets, item, si_link);
-		} else {
-			if (item->u.si_deadline < ctx->sc_next_event)
-				ctx->sc_next_event = item->u.si_deadline;
 		}
 		item = next;
 	}
@@ -834,7 +828,6 @@ swim_progress(struct swim_context *ctx, int64_t timeout)
 	now = swim_now_ms();
 	if (timeout > 0)
 		end = now + timeout;
-	ctx->sc_next_event = now + swim_period_get() / 3;
 
 	if (now > ctx->sc_expect_progress_time &&
 	    0  != ctx->sc_expect_progress_time) {
@@ -901,12 +894,7 @@ swim_progress(struct swim_context *ctx, int64_t timeout)
 				ctx->sc_next_tick_time = now
 							 + swim_period_get();
 				ctx->sc_deadline = now + delay;
-				if (ctx->sc_deadline < ctx->sc_next_event)
-					ctx->sc_next_event = ctx->sc_deadline;
 				ctx_state = SCS_PINGED;
-			} else {
-				if (ctx->sc_next_tick_time < ctx->sc_next_event)
-					ctx->sc_next_event = ctx->sc_next_tick_time;
 			}
 			break;
 		case SCS_PINGED:
@@ -929,10 +917,6 @@ swim_progress(struct swim_context *ctx, int64_t timeout)
 					 */
 					ctx_state = SCS_SELECT;
 				}
-				ctx->sc_next_event = now;
-			} else {
-				if (ctx->sc_deadline < ctx->sc_next_event)
-					ctx->sc_next_event = ctx->sc_deadline;
 			}
 			break;
 		case SCS_TIMEDOUT:
@@ -984,8 +968,6 @@ swim_progress(struct swim_context *ctx, int64_t timeout)
 				D_GOTO(out, rc = -DER_SHUTDOWN);
 			}
 
-			if (ctx->sc_next_tick_time < ctx->sc_next_event)
-				ctx->sc_next_event = ctx->sc_next_tick_time;
 			ctx_state = SCS_BEGIN;
 			break;
 		}
@@ -1002,8 +984,6 @@ swim_progress(struct swim_context *ctx, int64_t timeout)
 				D_GOTO(out, rc);
 			}
 			send_updates = false;
-		} else if (now + 100 < ctx->sc_next_event) {
-			break;
 		}
 	}
 	rc = (now > end) ? -DER_TIMEDOUT : -DER_CANCELED;

--- a/src/cart/swim/swim_internal.h
+++ b/src/cart/swim/swim_internal.h
@@ -102,7 +102,6 @@ struct swim_context {
 	uint64_t		 sc_expect_progress_time;
 	uint64_t		 sc_last_success_time;
 	uint64_t		 sc_next_tick_time;
-	uint64_t		 sc_next_event;
 	uint64_t		 sc_deadline;
 
 	uint64_t		 sc_piggyback_tx_max;

--- a/src/cart/utils/crt_utils.c
+++ b/src/cart/utils/crt_utils.c
@@ -141,7 +141,7 @@ crtu_progress_fn(void *data)
 		crt_progress(*p_ctx, 1000);
 
 	if (opts.is_swim_enabled && idx == 0)
-		crt_swim_disable_all();
+		crt_swim_fini();
 
 	rc = crtu_drain_queue(*p_ctx);
 	D_ASSERTF(rc == 0, "crtu_drain_queue() failed with rc=%d\n", rc);
@@ -673,11 +673,6 @@ crtu_srv_start_basic(char *srv_group_name, crt_context_t *crt_ctx,
 			  "pthread_create() failed; rc=%d\n",
 			  rc);
 
-	if (opts.is_swim_enabled) {
-		rc = crt_swim_init(0);
-		D_ASSERTF(rc == 0, "crt_swim_init() failed; rc=%d\n", rc);
-	}
-
 	grp_cfg_file = getenv("CRT_L_GRP_CFG");
 
 	rc = crt_rank_uri_get(*grp, my_rank, 0, &my_uri);
@@ -695,6 +690,11 @@ crtu_srv_start_basic(char *srv_group_name, crt_context_t *crt_ctx,
 			  rc);
 
 	D_FREE(my_uri);
+
+	if (opts.is_swim_enabled) {
+		rc = crt_swim_init(0);
+		D_ASSERTF(rc == 0, "crt_swim_init() failed; rc=%d\n", rc);
+	}
 
 	rc = crt_group_size(NULL, grp_size);
 	D_ASSERTF(rc == 0, "crt_group_size() failed; rc=%d\n", rc);

--- a/src/engine/init.c
+++ b/src/engine/init.c
@@ -576,9 +576,9 @@ server_id_cb(uint32_t *tid, uint64_t *uid)
 static int
 server_init(int argc, char *argv[])
 {
-	uint64_t		bound;
-	unsigned int		ctx_nr;
-	int			rc;
+	uint64_t		 bound;
+	unsigned int		 ctx_nr;
+	int			 rc;
 	struct engine_metrics	*metrics;
 
 	/*

--- a/src/engine/sched.c
+++ b/src/engine/sched.c
@@ -1626,6 +1626,7 @@ sched_exec_time(uint64_t *msecs, const char *ult_name)
 	if (*msecs > sched_unit_runtime_max && ult_name != NULL)
 		D_WARN("ULT:%s executed "DF_U64" msecs\n", ult_name, *msecs);
 	return 0;
+
 }
 
 static void

--- a/src/engine/srv.c
+++ b/src/engine/srv.c
@@ -385,33 +385,26 @@ dss_srv_handler(void *arg)
 		dx->dx_ctx_id = dmi->dmi_ctx_id;
 		/** verify CART assigned the ctx_id ascendantly start from 0 */
 		if (dx->dx_xs_id < dss_sys_xs_nr) {
-			/*
-			 * xs_id: 0 => SYS  XS: ctx_id: 0
-			 * xs_id: 1 => SWIM XS: ctx_id: 1
-			 * xs_id: 2 => DRPC XS: no ctx_id
-			 */
-			D_ASSERTF(dx->dx_ctx_id == dx->dx_xs_id,
-				  "incorrect ctx_id %d for xs_id %d\n",
-				  dx->dx_ctx_id, dx->dx_xs_id);
+			D_ASSERT(dx->dx_ctx_id == dx->dx_xs_id);
 		} else {
 			if (dx->dx_main_xs) {
 				D_ASSERTF(dx->dx_ctx_id ==
-					  (dx->dx_tgt_id + dss_sys_xs_nr - DRPC_XS_NR),
-					  "incorrect ctx_id %d for xs_id %d tgt_id %d\n",
-					  dx->dx_ctx_id, dx->dx_xs_id, dx->dx_tgt_id);
+					  dx->dx_tgt_id + dss_sys_xs_nr -
+					  DRPC_XS_NR,
+					  "incorrect ctx_id %d for xs_id %d\n",
+					  dx->dx_ctx_id, dx->dx_xs_id);
 			} else {
 				if (dss_helper_pool)
-					D_ASSERTF(dx->dx_ctx_id == (dx->dx_xs_id - DRPC_XS_NR),
-						  "incorrect ctx_id %d for xs_id %d tgt_id %d\n",
-						  dx->dx_ctx_id, dx->dx_xs_id, dx->dx_tgt_id);
+					D_ASSERTF(dx->dx_ctx_id ==
+						  (dx->dx_xs_id - DRPC_XS_NR),
+					"incorrect ctx_id %d for xs_id %d\n",
+					dx->dx_ctx_id, dx->dx_xs_id);
 				else
 					D_ASSERTF(dx->dx_ctx_id ==
-						  (dx->dx_tgt_id + dss_sys_xs_nr - DRPC_XS_NR +
-						   dss_tgt_nr),
-						  "incorrect ctx_id %d for xs_id %d "
-						  "tgt_id %d tgt_nr %d\n",
-						  dx->dx_ctx_id, dx->dx_xs_id,
-						  dx->dx_tgt_id, dss_tgt_nr);
+						(dss_sys_xs_nr + dss_tgt_nr +
+						 dx->dx_tgt_id - DRPC_XS_NR),
+					"incorrect ctx_id %d for xs_id %d\n",
+					dx->dx_ctx_id, dx->dx_xs_id);
 			}
 		}
 	}
@@ -609,38 +602,27 @@ dss_start_one_xstream(hwloc_cpuset_t cpus, int xs_id)
 	 * as it is only for EC/checksum/compress offloading.
 	 */
 	if (dss_helper_pool) {
-		comm =  (xs_id == 0) || /* DSS_XS_SYS */
-			(xs_id == 1) || /* DSS_XS_SWIM */
-			(xs_id >= dss_sys_xs_nr &&
-			 xs_id < (dss_sys_xs_nr + 2 * dss_tgt_nr));
+		comm = (xs_id == 0) || (xs_id >= dss_sys_xs_nr &&
+				xs_id < (dss_sys_xs_nr + 2 * dss_tgt_nr));
 	} else {
 		int	helper_per_tgt;
 
 		helper_per_tgt = dss_tgt_offload_xs_nr / dss_tgt_nr;
-		D_ASSERT(helper_per_tgt == 0 ||
-			 helper_per_tgt == 1 ||
+		D_ASSERT(helper_per_tgt == 0 || helper_per_tgt == 1 ||
 			 helper_per_tgt == 2);
-
-		if ((xs_id >= dss_sys_xs_nr) &&
-		    (xs_id < (dss_sys_xs_nr + dss_tgt_nr + dss_tgt_offload_xs_nr)))
-			xs_offset = (xs_id - dss_sys_xs_nr) % (helper_per_tgt + 1);
-		else
-			xs_offset = -1;
-
-		comm =  (xs_id == 0) ||		/* DSS_XS_SYS */
-			(xs_id == 1) ||		/* DSS_XS_SWIM */
-			(xs_offset == 0) ||	/* main XS */
-			(xs_offset == 1);	/* first offload XS */
+		xs_offset = xs_id < dss_sys_xs_nr ? -1 :
+				(((xs_id) - dss_sys_xs_nr) %
+				 (helper_per_tgt + 1));
+		comm = (xs_id == 0) || xs_offset == 0 || xs_offset == 1;
 	}
-
 	dx->dx_xs_id	= xs_id;
 	dx->dx_ctx_id	= -1;
 	dx->dx_comm	= comm;
 	if (dss_helper_pool) {
-		dx->dx_main_xs	= (xs_id >= dss_sys_xs_nr) &&
-				  (xs_id < (dss_sys_xs_nr + dss_tgt_nr));
+		dx->dx_main_xs	= xs_id >= dss_sys_xs_nr &&
+				  xs_id < (dss_sys_xs_nr + dss_tgt_nr);
 	} else {
-		dx->dx_main_xs	= (xs_id >= dss_sys_xs_nr) && (xs_offset == 0);
+		dx->dx_main_xs	= xs_id >= dss_sys_xs_nr && xs_offset == 0;
 	}
 	dx->dx_dsc_started = false;
 
@@ -839,11 +821,8 @@ dss_start_xs_id(int xs_id)
 		}
 		D_DEBUG(DB_TRACE,
 			"Choosing next available core index %d.", idx);
-		/*
-		 * All system XS will reuse the first XS' core, but
-		 * the SWIM and DRPC XS will use separate core if enough cores
-		 */
-		if (xs_id > 1 || (xs_id == 0 && dss_core_nr > dss_tgt_nr))
+		/* the 2nd system XS (drpc XS) will reuse the first XS' core */
+		if (xs_id != 0)
 			hwloc_bitmap_clr(core_allocation_bitmap, idx);
 
 		obj = hwloc_get_obj_by_depth(dss_topo, dss_core_depth, idx);
@@ -858,15 +837,13 @@ dss_start_xs_id(int xs_id)
 	} else {
 		D_DEBUG(DB_TRACE, "Using non-NUMA aware core allocation\n");
 		/*
-		 * All system XS will use the first core, but
-		 * the SWIM XS will use separate core if enough cores
-		 */
-		if (xs_id > 2)
-			xs_core_offset = xs_id - ((dss_core_nr > dss_tgt_nr) ? 1 : 2);
-		else if (xs_id == 1)
-			xs_core_offset = (dss_core_nr > dss_tgt_nr) ? 1 : 0;
-		else
+		* System XS all use the first core
+		*/
+		if (xs_id < dss_sys_xs_nr)
 			xs_core_offset = 0;
+		else
+			xs_core_offset = xs_id - (dss_sys_xs_nr - DRPC_XS_NR);
+
 		obj = hwloc_get_obj_by_depth(dss_topo, dss_core_depth,
 					     (xs_core_offset + dss_core_offset)
 					     % dss_core_nr);
@@ -959,28 +936,28 @@ dss_xstreams_init(void)
 	}
 
 	/* start offload XS if any */
-	if (dss_tgt_offload_xs_nr > 0) {
-		if (dss_helper_pool) {
-			for (i = 0; i < dss_tgt_offload_xs_nr; i++) {
-				xs_id = dss_sys_xs_nr + dss_tgt_nr + i;
+	if (dss_tgt_offload_xs_nr == 0)
+		D_GOTO(out, rc);
+	if (dss_helper_pool) {
+		for (i = 0; i < dss_tgt_offload_xs_nr; i++) {
+			xs_id = dss_sys_xs_nr + dss_tgt_nr + i;
+			rc = dss_start_xs_id(xs_id);
+			if (rc)
+				D_GOTO(out, rc);
+		}
+	} else {
+		D_ASSERTF(dss_tgt_offload_xs_nr % dss_tgt_nr == 0,
+			  "bad dss_tgt_offload_xs_nr %d, dss_tgt_nr %d\n",
+			  dss_tgt_offload_xs_nr, dss_tgt_nr);
+		for (i = 0; i < dss_tgt_nr; i++) {
+			int j;
+
+			for (j = 0; j < dss_tgt_offload_xs_nr / dss_tgt_nr;
+			     j++) {
+				xs_id = DSS_MAIN_XS_ID(i) + j + 1;
 				rc = dss_start_xs_id(xs_id);
 				if (rc)
 					D_GOTO(out, rc);
-			}
-		} else {
-			D_ASSERTF(dss_tgt_offload_xs_nr % dss_tgt_nr == 0,
-				  "dss_tgt_offload_xs_nr %d, dss_tgt_nr %d\n",
-				  dss_tgt_offload_xs_nr, dss_tgt_nr);
-			for (i = 0; i < dss_tgt_nr; i++) {
-				int j;
-
-				for (j = 0; j < dss_tgt_offload_xs_nr /
-						dss_tgt_nr; j++) {
-					xs_id = DSS_MAIN_XS_ID(i) + j + 1;
-					rc = dss_start_xs_id(xs_id);
-					if (rc)
-						D_GOTO(out, rc);
-				}
 			}
 		}
 	}

--- a/src/engine/srv_internal.h
+++ b/src/engine/srv_internal.h
@@ -115,7 +115,6 @@ extern unsigned int	dss_tgt_offload_xs_nr;
 extern unsigned int	dss_sys_xs_nr;
 /** Flag of helper XS as a pool */
 extern bool		dss_helper_pool;
-
 /** Shadow dss_get_module_info */
 struct dss_module_info *get_module_info(void);
 
@@ -273,11 +272,10 @@ void ds_iv_fini(void);
 	 (dss_tgt_offload_xs_nr > dss_tgt_nr ? dss_tgt_nr :	\
 	  dss_tgt_offload_xs_nr))
 /** main XS id of (vos) tgt_id */
-#define DSS_MAIN_XS_ID(tgt_id)					\
-	(dss_helper_pool ? ((tgt_id) + dss_sys_xs_nr) :		\
-			   ((tgt_id) * ((dss_tgt_offload_xs_nr /\
+#define DSS_MAIN_XS_ID(tgt_id)						\
+	(dss_helper_pool ? ((tgt_id) + dss_sys_xs_nr) :			\
+			   ((tgt_id) * ((dss_tgt_offload_xs_nr /	\
 			      dss_tgt_nr) + 1) + dss_sys_xs_nr))
-
 
 /**
  * get the VOS target ID of xstream.

--- a/src/engine/ult.c
+++ b/src/engine/ult.c
@@ -310,77 +310,59 @@ sched_ult2xs(int xs_type, int tgt_id)
 	switch (xs_type) {
 	case DSS_XS_SELF:
 		return DSS_XS_SELF;
-	case DSS_XS_SYS:
-		return 0;
-	case DSS_XS_SWIM:
-		return 1;
-	case DSS_XS_DRPC:
-		return 2;
 	case DSS_XS_IOFW:
 		if (!dss_helper_pool) {
 			if (dss_tgt_offload_xs_nr > 0)
 				xs_id = DSS_MAIN_XS_ID(tgt_id) + 1;
 			else
-				xs_id = DSS_MAIN_XS_ID((tgt_id + 1) % dss_tgt_nr);
-			break;
+				xs_id = DSS_MAIN_XS_ID((tgt_id + 1) %
+						       dss_tgt_nr);
+			D_ASSERT(xs_id < DSS_XS_NR_TOTAL &&
+				 xs_id >= dss_sys_xs_nr);
+			return xs_id;
 		}
 
-		/*
-		 * Comment from @liuxuezhao:
-		 *
-		 * This is the case that no helper XS, so for IOFW,
-		 * we either use itself, or use neighbor XS.
-		 *
-		 * Why original code select neighbor XS rather than itself
-		 * is because, when the code is called, I know myself is on
-		 * processing IO request and need IO forwarding, now I am
-		 * processing IO, so likely there is not only one IO (possibly
-		 * more than one IO for specific dkey), I am busy so likely my
-		 * neighbor is not busy (both busy seems only in some special
-		 * multiple dkeys used at same time) can help me do the IO
-		 * forwarding?
-		 *
-		 * But this is just original intention, you guys think it is
-		 * not reasonable? prefer another way that I am processing IO
-		 * and need IO forwarding, OK, just let myself do it ...
-		 *
-		 * Note that we first do IO forwarding and then serve local IO,
-		 * ask neighbor to do IO forwarding seems is helpful to make
-		 * them concurrent, right?
-		 */
 		if (dss_tgt_offload_xs_nr >= dss_tgt_nr)
-			xs_id = dss_sys_xs_nr + dss_tgt_nr + tgt_id;
-		else if (dss_tgt_offload_xs_nr > 0)
-			xs_id = dss_sys_xs_nr + dss_tgt_nr + tgt_id % dss_tgt_offload_xs_nr;
+			return (dss_sys_xs_nr + dss_tgt_nr + tgt_id);
+		if (dss_tgt_offload_xs_nr > 0)
+			return (dss_sys_xs_nr + dss_tgt_nr +
+				tgt_id % dss_tgt_offload_xs_nr);
 		else
-			xs_id = (DSS_MAIN_XS_ID(tgt_id) + 1) % dss_tgt_nr;
-		break;
+			return ((DSS_MAIN_XS_ID(tgt_id) + 1) % dss_tgt_nr +
+				dss_sys_xs_nr);
 	case DSS_XS_OFFLOAD:
 		if (!dss_helper_pool) {
 			if (dss_tgt_offload_xs_nr > 0)
-				xs_id = DSS_MAIN_XS_ID(tgt_id) + dss_tgt_offload_xs_nr / dss_tgt_nr;
+				xs_id = DSS_MAIN_XS_ID(tgt_id) +
+					dss_tgt_offload_xs_nr / dss_tgt_nr;
 			else
-				xs_id = DSS_MAIN_XS_ID((tgt_id + 1) % dss_tgt_nr);
-			break;
+				xs_id = DSS_MAIN_XS_ID((tgt_id + 1) %
+						       dss_tgt_nr);
+			D_ASSERT(xs_id < DSS_XS_NR_TOTAL &&
+				 xs_id >= dss_sys_xs_nr);
+			return xs_id;
 		}
 
 		if (dss_tgt_offload_xs_nr > dss_tgt_nr)
-			xs_id = dss_sys_xs_nr + 2 * dss_tgt_nr +
-				(tgt_id % (dss_tgt_offload_xs_nr - dss_tgt_nr));
-		else if (dss_tgt_offload_xs_nr > 0)
-			xs_id = dss_sys_xs_nr + dss_tgt_nr + tgt_id % dss_tgt_offload_xs_nr;
+			return (dss_sys_xs_nr + 2 * dss_tgt_nr +
+				(tgt_id % (dss_tgt_offload_xs_nr -
+					   dss_tgt_nr)));
+		if (dss_tgt_offload_xs_nr > 0)
+			return (dss_sys_xs_nr + dss_tgt_nr +
+				tgt_id % dss_tgt_offload_xs_nr);
 		else
-			xs_id = (DSS_MAIN_XS_ID(tgt_id) + 1) % dss_tgt_nr;
-		break;
+			return (DSS_MAIN_XS_ID(tgt_id) + 1) % dss_tgt_nr +
+			       dss_sys_xs_nr;
+	case DSS_XS_SYS:
+		return 0;
+	case DSS_XS_DRPC:
+		return 1;
 	case DSS_XS_VOS:
-		xs_id = DSS_MAIN_XS_ID(tgt_id);
-		break;
+		return DSS_MAIN_XS_ID(tgt_id);
 	default:
 		D_ASSERTF(0, "Invalid xstream type %d.\n", xs_type);
 		return -DER_INVAL;
 	}
-	D_ASSERT(xs_id < DSS_XS_NR_TOTAL && xs_id >= dss_sys_xs_nr);
-	return xs_id;
 }
 
 static int

--- a/src/include/cart/api.h
+++ b/src/include/cart/api.h
@@ -1722,8 +1722,8 @@ crt_proc_d_rank_list_t(crt_proc_t proc, crt_proc_op_t proc_op,
 int
 crt_proc_d_iov_t(crt_proc_t proc, crt_proc_op_t proc_op, d_iov_t *data);
 
-typedef int64_t
-(*crt_progress_cb) (crt_context_t ctx, int64_t timeout, void *arg);
+typedef void
+(*crt_progress_cb) (crt_context_t ctx, void *arg);
 
 /**
  * Register a callback function which will be called inside crt_progress()

--- a/src/include/cart/types.h
+++ b/src/include/cart/types.h
@@ -71,8 +71,6 @@ typedef struct crt_init_options {
 	 */
 	uint32_t	cio_max_expected_size;
 	uint32_t	cio_max_unexpected_size;
-			/** swim crt index */
-	int		cio_swim_crt_idx;
 } crt_init_options_t;
 
 typedef int		crt_status_t;

--- a/src/include/daos/rpc.h
+++ b/src/include/daos/rpc.h
@@ -93,7 +93,7 @@ enum daos_rpc_type {
 };
 
 /** DAOS_TGT0_OFFSET is target 0's cart context offset */
-#define DAOS_TGT0_OFFSET		(2)
+#define DAOS_TGT0_OFFSET		(1)
 /** The cart context index of target index */
 #define DAOS_IO_CTX_ID(tgt_idx)		((tgt_idx) + DAOS_TGT0_OFFSET)
 
@@ -113,8 +113,6 @@ daos_rpc_tag(int req_type, int tgt_idx)
 	case DAOS_REQ_IO:
 	case DAOS_REQ_TGT:
 		return DAOS_IO_CTX_ID(tgt_idx);
-	case DAOS_REQ_SWIM:
-		return 1;
 	/* target tag 0 is to handle below requests */
 	case DAOS_REQ_MGMT:
 	case DAOS_REQ_POOL:
@@ -123,6 +121,7 @@ daos_rpc_tag(int req_type, int tgt_idx)
 	case DAOS_REQ_REBUILD:
 	case DAOS_REQ_IV:
 	case DAOS_REQ_BCAST:
+	case DAOS_REQ_SWIM:
 		return 0;
 	default:
 		D_ASSERTF(0, "bad req_type %d.\n", req_type);

--- a/src/include/daos_srv/daos_engine.h
+++ b/src/include/daos_srv/daos_engine.h
@@ -502,10 +502,8 @@ enum dss_xs_type {
 	DSS_XS_OFFLOAD	= 2,
 	/** pool service, RDB, drpc handler */
 	DSS_XS_SYS	= 3,
-	/** SWIM operations */
-	DSS_XS_SWIM	= 4,
 	/** drpc listener */
-	DSS_XS_DRPC	= 5,
+	DSS_XS_DRPC	= 4,
 };
 
 int dss_parameters_set(unsigned int key_id, uint64_t value);

--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -38,27 +38,6 @@
 #include "srv_layout.h"
 #include "srv_pool_map.h"
 
-/* Pool service crt event */
-struct pool_svc_event {
-	d_list_t		psv_link;
-	d_rank_t		psv_rank;
-	uint64_t		psv_incarnation;
-	enum crt_event_source	psv_src;
-	enum crt_event_type	psv_type;
-};
-
-#define DF_PS_EVENT	"rank=%u inc="DF_U64" src=%d type=%d"
-#define DP_PS_EVENT(e)	e->psv_rank, e->psv_incarnation, e->psv_src, e->psv_type
-
-/* Pool service crt-event-handling state */
-struct pool_svc_events {
-	ABT_mutex		pse_mutex;
-	ABT_cond		pse_cv;
-	d_list_t		pse_queue;
-	ABT_thread		pse_handler;
-	bool			pse_stop;
-};
-
 /* Pool service */
 struct pool_svc {
 	struct ds_rsvc		ps_rsvc;
@@ -69,7 +48,6 @@ struct pool_svc {
 	rdb_path_t		ps_handles;	/* pool handle KVS */
 	rdb_path_t		ps_user;	/* pool user attributes KVS */
 	struct ds_pool	       *ps_pool;
-	struct pool_svc_events	ps_events;
 };
 
 static bool pool_disable_exclude = false;
@@ -784,8 +762,6 @@ pool_svc_alloc_cb(d_iov_t *id, struct ds_rsvc **rsvc)
 	d_iov_set(&svc->ps_rsvc.s_id, svc->ps_uuid, sizeof(uuid_t));
 
 	uuid_copy(svc->ps_uuid, id->iov_buf);
-	D_INIT_LIST_HEAD(&svc->ps_events.pse_queue);
-	svc->ps_events.pse_handler = ABT_THREAD_NULL;
 
 	rc = ABT_rwlock_create(&svc->ps_lock);
 	if (rc != ABT_SUCCESS) {
@@ -815,30 +791,14 @@ pool_svc_alloc_cb(d_iov_t *id, struct ds_rsvc **rsvc)
 	if (rc != 0)
 		goto err_user;
 
-	rc = ABT_mutex_create(&svc->ps_events.pse_mutex);
-	if (rc != ABT_SUCCESS) {
-		rc = dss_abterr2der(rc);
-		goto err_user;
-	}
-
-	rc = ABT_cond_create(&svc->ps_events.pse_cv);
-	if (rc != ABT_SUCCESS) {
-		rc = dss_abterr2der(rc);
-		goto err_events_mutex;
-	}
-
 	rc = ds_cont_svc_init(&svc->ps_cont_svc, svc->ps_uuid, 0 /* id */,
 			      &svc->ps_rsvc);
 	if (rc != 0)
-		goto err_events_cv;
+		goto err_user;
 
 	*rsvc = &svc->ps_rsvc;
 	return 0;
 
-err_events_cv:
-	ABT_cond_free(&svc->ps_events.pse_cv);
-err_events_mutex:
-	ABT_mutex_free(&svc->ps_events.pse_mutex);
 err_user:
 	rdb_path_fini(&svc->ps_user);
 err_handles:
@@ -859,6 +819,30 @@ pool_svc_put(struct pool_svc *svc)
 	ds_rsvc_put(&svc->ps_rsvc);
 }
 
+struct ds_pool_exclude_arg {
+	struct pool_svc *svc;
+	d_rank_t	rank;
+};
+
+static int pool_svc_exclude_rank(struct pool_svc *svc, d_rank_t rank);
+static void pool_svc_get_leader(struct pool_svc *svc);
+static void pool_svc_put_leader(struct pool_svc *svc);
+
+static void
+pool_exclude_rank_ult(void *data)
+{
+	struct ds_pool_exclude_arg     *arg = data;
+	int				rc;
+
+	rc = pool_svc_exclude_rank(arg->svc, arg->rank);
+
+	D_DEBUG(DB_MGMT, DF_UUID" exclude rank %u : rc %d\n",
+		DP_UUID(arg->svc->ps_uuid), arg->rank, rc);
+
+	pool_svc_put_leader(arg->svc);
+	D_FREE_PTR(arg);
+}
+
 /* Disable all pools exclusion */
 void
 ds_pool_disable_exclude(void)
@@ -873,210 +857,65 @@ ds_pool_enable_exclude(void)
 }
 
 static int
-queue_event(struct pool_svc *svc, d_rank_t rank, uint64_t incarnation, enum crt_event_source src,
-	    enum crt_event_type type)
+pool_exclude_rank(struct pool_svc *svc, d_rank_t rank)
 {
-	struct pool_svc_events *events = &svc->ps_events;
-	struct pool_svc_event  *event;
+	struct ds_pool_exclude_arg	*ult_arg;
+	int				rc;
 
-	D_ALLOC_PTR(event);
-	if (event == NULL)
-		return -DER_NOMEM;
+	D_ALLOC_PTR(ult_arg);
+	if (ult_arg == NULL)
+		D_GOTO(out, rc = -DER_NOMEM);
 
-	event->psv_rank = rank;
-	event->psv_incarnation = incarnation;
-	event->psv_src = src;
-	event->psv_type = type;
-
-	D_DEBUG(DB_MD, DF_UUID": queuing event: "DF_PS_EVENT"\n", DP_UUID(svc->ps_uuid),
-		DP_PS_EVENT(event));
-
-	ABT_mutex_lock(events->pse_mutex);
-	d_list_add_tail(&event->psv_link, &events->pse_queue);
-	ABT_cond_broadcast(events->pse_cv);
-	ABT_mutex_unlock(events->pse_mutex);
-	return 0;
-}
-
-static void
-discard_events(d_list_t *queue)
-{
-	struct pool_svc_event  *event;
-	struct pool_svc_event  *tmp;
-
-	d_list_for_each_entry_safe(event, tmp, queue, psv_link) {
-		D_DEBUG(DB_MD, "discard event: "DF_PS_EVENT"\n", DP_PS_EVENT(event));
-		d_list_del_init(&event->psv_link);
-		D_FREE(event);
+	pool_svc_get_leader(svc);
+	ult_arg->svc = svc;
+	ult_arg->rank = rank;
+	rc = dss_ult_create(pool_exclude_rank_ult, ult_arg, DSS_XS_SELF,
+			    0, 0, NULL);
+	if (rc) {
+		pool_svc_put_leader(svc);
+		D_FREE_PTR(ult_arg);
 	}
-}
-
-static int pool_svc_exclude_rank(struct pool_svc *svc, d_rank_t rank);
-
-static void
-handle_event(struct pool_svc *svc, struct pool_svc_event *event)
-{
-	daos_prop_t		prop = {0};
-	struct daos_prop_entry *entry;
-	int			rc;
-
-	/* Only used for exclude the rank for the moment */
-	if ((event->psv_src != CRT_EVS_GRPMOD && event->psv_src != CRT_EVS_SWIM) ||
-	    event->psv_type != CRT_EVT_DEAD || pool_disable_exclude) {
-		D_DEBUG(DB_MD, "ignore event: "DF_PS_EVENT" exclude=%d\n", DP_PS_EVENT(event),
-			pool_disable_exclude);
-		goto out;
-	}
-
-	D_DEBUG(DB_MD, DF_UUID": handling event: "DF_PS_EVENT"\n", DP_UUID(svc->ps_uuid),
-		DP_PS_EVENT(event));
-
-	rc = ds_pool_iv_prop_fetch(svc->ps_pool, &prop);
-	if (rc != 0) {
-		D_ERROR(DF_UUID": failed to fetch properties: "DF_RC"\n", DP_UUID(svc->ps_uuid),
-			DP_RC(rc));
-		goto out;
-	}
-
-	entry = daos_prop_entry_get(&prop, DAOS_PROP_PO_SELF_HEAL);
-	D_ASSERT(entry != NULL);
-	if (!(entry->dpe_val & DAOS_SELF_HEAL_AUTO_EXCLUDE)) {
-		D_DEBUG(DB_MD, DF_UUID": self healing is disabled\n", DP_UUID(svc->ps_uuid));
-		goto out_prop;
-	}
-
-	rc = pool_svc_exclude_rank(svc, event->psv_rank);
-	if (rc != 0) {
-		D_ERROR(DF_UUID": failed to exclude rank %u: "DF_RC"\n", DP_UUID(svc->ps_uuid),
-			event->psv_rank, DP_RC(rc));
-		goto out_prop;
-	}
-
-	D_DEBUG(DB_MD, DF_UUID": excluded rank %u\n", DP_UUID(svc->ps_uuid), event->psv_rank);
-out_prop:
-	daos_prop_fini(&prop);
 out:
-	return;
-}
-
-static void
-events_handler(void *arg)
-{
-	struct pool_svc	       *svc = arg;
-	struct pool_svc_events *events = &svc->ps_events;
-
-	D_DEBUG(DB_MD, DF_UUID": starting\n", DP_UUID(svc->ps_uuid));
-
-	for (;;) {
-		struct pool_svc_event  *event;
-		bool			stop;
-
-		ABT_mutex_lock(events->pse_mutex);
-		for (;;) {
-			stop = events->pse_stop;
-			if (stop) {
-				discard_events(&events->pse_queue);
-				break;
-			}
-			if (!d_list_empty(&events->pse_queue)) {
-				event = d_list_entry(events->pse_queue.next, struct pool_svc_event,
-						     psv_link);
-				d_list_del_init(&event->psv_link);
-				break;
-			}
-			ABT_cond_wait(events->pse_cv, events->pse_mutex);
-		}
-		ABT_mutex_unlock(events->pse_mutex);
-		if (stop)
-			break;
-
-		handle_event(svc, event);
-
-		D_FREE(event);
-		ABT_thread_yield();
-	}
-
-	D_DEBUG(DB_MD, DF_UUID": stopping\n", DP_UUID(svc->ps_uuid));
+	if (rc)
+		D_ERROR("exclude ult failed: rc %d\n", rc);
+	return rc;
 }
 
 static void
 ds_pool_crt_event_cb(d_rank_t rank, uint64_t incarnation, enum crt_event_source src,
 		     enum crt_event_type type, void *arg)
 {
-	struct pool_svc	       *svc = arg;
-	int			rc;
+	daos_prop_t		prop = { 0 };
+	struct daos_prop_entry	*entry;
+	struct pool_svc		*svc = arg;
+	int			rc = 0;
 
-	rc = queue_event(svc, rank, incarnation, src, type);
-	if (rc != 0)
-		D_ERROR(DF_UUID": failed to queue event: "DF_PS_EVENT": "DF_RC"\n",
-			DP_UUID(svc->ps_uuid), rank, incarnation, src, type, DP_RC(rc));
-}
-
-static int pool_svc_check_node_status(struct pool_svc *svc);
-
-static int
-init_events(struct pool_svc *svc)
-{
-	struct pool_svc_events *events = &svc->ps_events;
-	int			rc;
-
-	D_ASSERT(d_list_empty(&events->pse_queue));
-	D_ASSERT(events->pse_handler == ABT_THREAD_NULL);
-
-	rc = crt_register_event_cb(ds_pool_crt_event_cb, svc);
-	if (rc != 0) {
-		D_ERROR(DF_UUID": failed to register event callback: "DF_RC"\n",
-			DP_UUID(svc->ps_uuid), DP_RC(rc));
-		goto err;
+	/* Only used for exclude the rank for the moment */
+	if ((src != CRT_EVS_GRPMOD && src != CRT_EVS_SWIM) ||
+	    type != CRT_EVT_DEAD ||
+	    pool_disable_exclude) {
+		D_DEBUG(DB_MGMT, "ignore src/type/exclude %u/%u/%d\n",
+			src, type, pool_disable_exclude);
+		return;
 	}
 
-	/*
-	 * Note that events happened during the status-based recovery may
-	 * appear twice in the event queue: one queued by the event callback,
-	 * and one queued by the recovery.
-	 */
-	rc = pool_svc_check_node_status(svc);
-	if (rc != 0) {
-		D_ERROR(DF_UUID": failed to create event handler: "DF_RC"\n",
-			DP_UUID(svc->ps_uuid), DP_RC(rc));
-		goto err_cb;
+	rc = ds_pool_iv_prop_fetch(svc->ps_pool, &prop);
+	if (rc)
+		D_GOTO(out, rc);
+
+	entry = daos_prop_entry_get(&prop, DAOS_PROP_PO_SELF_HEAL);
+	D_ASSERT(entry != NULL);
+	if (!(entry->dpe_val & DAOS_SELF_HEAL_AUTO_EXCLUDE)) {
+		D_DEBUG(DB_MGMT, "self healing is disabled\n");
+		D_GOTO(out, rc);
 	}
 
-	rc = dss_ult_create(events_handler, svc, DSS_XS_SELF, 0, 0, &events->pse_handler);
-	if (rc != 0) {
-		D_ERROR(DF_UUID": failed to create event handler: "DF_RC"\n",
-			DP_UUID(svc->ps_uuid), DP_RC(rc));
-		goto err_cb;
-	}
-
-	return 0;
-
-err_cb:
-	crt_unregister_event_cb(ds_pool_crt_event_cb, svc);
-	discard_events(&events->pse_queue);
-err:
-	return rc;
-}
-
-static void
-fini_events(struct pool_svc *svc)
-{
-	struct pool_svc_events *events = &svc->ps_events;
-	int			rc;
-
-	D_ASSERT(events->pse_handler != ABT_THREAD_NULL);
-
-	crt_unregister_event_cb(ds_pool_crt_event_cb, svc);
-
-	ABT_mutex_lock(events->pse_mutex);
-	events->pse_stop = true;
-	ABT_cond_broadcast(events->pse_cv);
-	ABT_mutex_unlock(events->pse_mutex);
-
-	rc = ABT_thread_join(events->pse_handler);
-	D_ASSERTF(rc == 0, DF_RC"\n", DP_RC(rc));
-	ABT_thread_free(&events->pse_handler);
-	events->pse_handler = ABT_THREAD_NULL;
+	rc = pool_exclude_rank(svc, rank);
+out:
+	if (rc)
+		D_ERROR("pool "DF_UUID" event %d failed: rc %d\n",
+			DP_UUID(svc->ps_uuid), src, rc);
+	daos_prop_fini(&prop);
 }
 
 static void
@@ -1085,8 +924,6 @@ pool_svc_free_cb(struct ds_rsvc *rsvc)
 	struct pool_svc *svc = pool_svc_obj(rsvc);
 
 	ds_cont_svc_fini(&svc->ps_cont_svc);
-	ABT_cond_free(&svc->ps_events.pse_cv);
-	ABT_mutex_free(&svc->ps_events.pse_mutex);
 	rdb_path_fini(&svc->ps_user);
 	rdb_path_fini(&svc->ps_handles);
 	rdb_path_fini(&svc->ps_root);
@@ -1286,10 +1123,9 @@ pool_svc_check_node_status(struct pool_svc *svc)
 		D_DEBUG(DB_REBUILD, "rank/state %d/%d\n",
 			doms[i].do_comp.co_rank,
 			rc == -DER_NONEXIST ? -1 : state.sms_status);
-		if (rc == -DER_NONEXIST || state.sms_status == SWIM_MEMBER_DEAD) {
-			rc = queue_event(svc, doms[i].do_comp.co_rank, 0 /* incarnation */,
-					 rc == -DER_NONEXIST ? CRT_EVS_GRPMOD : CRT_EVS_SWIM,
-					 CRT_EVT_DEAD);
+		if (rc == -DER_NONEXIST ||
+		    state.sms_status == SWIM_MEMBER_DEAD) {
+			rc = pool_exclude_rank(svc, doms[i].do_comp.co_rank);
 			if (rc) {
 				D_ERROR("failed to exclude rank %u: %d\n",
 					doms[i].do_comp.co_rank, rc);
@@ -1311,7 +1147,7 @@ pool_svc_step_up_cb(struct ds_rsvc *rsvc)
 	uuid_t			cont_hdl_uuid;
 	daos_prop_t	       *prop = NULL;
 	bool			cont_svc_up = false;
-	bool			events_initialized = false;
+	bool			event_cb_registered = false;
 	d_rank_t		rank;
 	int			rc;
 
@@ -1351,16 +1187,20 @@ pool_svc_step_up_cb(struct ds_rsvc *rsvc)
 		goto out;
 	cont_svc_up = true;
 
-	rc = init_events(svc);
-	if (rc != 0)
+	rc = crt_register_event_cb(ds_pool_crt_event_cb, svc);
+	if (rc)
 		goto out;
-	events_initialized = true;
+	event_cb_registered = true;
 
 	rc = ds_pool_iv_prop_update(svc->ps_pool, prop);
 	if (rc) {
 		D_ERROR("ds_pool_iv_prop_update failed %d.\n", rc);
 		D_GOTO(out, rc);
 	}
+
+	rc = pool_svc_check_node_status(svc);
+	if (rc)
+		D_GOTO(out, rc);
 
 	if (!uuid_is_null(svc->ps_pool->sp_srv_cont_hdl)) {
 		uuid_copy(pool_hdl_uuid, svc->ps_pool->sp_srv_pool_hdl);
@@ -1391,8 +1231,8 @@ pool_svc_step_up_cb(struct ds_rsvc *rsvc)
 		DP_UUID(svc->ps_uuid), rank, svc->ps_rsvc.s_term);
 out:
 	if (rc != 0) {
-		if (events_initialized)
-			fini_events(svc);
+		if (event_cb_registered)
+			crt_unregister_event_cb(ds_pool_crt_event_cb, svc);
 		if (cont_svc_up)
 			ds_cont_svc_step_down(svc->ps_cont_svc);
 		if (svc->ps_pool != NULL)
@@ -1412,9 +1252,9 @@ pool_svc_step_down_cb(struct ds_rsvc *rsvc)
 	d_rank_t		rank;
 	int			rc;
 
-	ds_pool_iv_srv_hdl_invalidate(svc->ps_pool);
+	crt_unregister_event_cb(ds_pool_crt_event_cb, svc);
 
-	fini_events(svc);
+	ds_pool_iv_srv_hdl_invalidate(svc->ps_pool);
 	ds_cont_svc_step_down(svc->ps_cont_svc);
 	fini_svc_pool(svc);
 
@@ -1515,6 +1355,12 @@ pool_svc_lookup_leader(uuid_t uuid, struct pool_svc **svcp,
 		return rc;
 	*svcp = pool_svc_obj(rsvc);
 	return 0;
+}
+
+static void
+pool_svc_get_leader(struct pool_svc *svc)
+{
+	ds_rsvc_get_leader(&svc->ps_rsvc);
 }
 
 static void

--- a/src/tests/ftest/cart/dual_iface_server.c
+++ b/src/tests/ftest/cart/dual_iface_server.c
@@ -263,7 +263,8 @@ server_main(d_rank_t my_rank, const char *str_port, const char *str_interface,
 		error_exit();
 	}
 
-	rc = crt_init("server_grp", CRT_FLAG_BIT_SERVER | CRT_FLAG_BIT_AUTO_SWIM_DISABLE);
+	rc = crt_init("server_grp", CRT_FLAG_BIT_SERVER |
+		      CRT_FLAG_BIT_AUTO_SWIM_DISABLE);
 	if (rc != 0) {
 		D_ERROR("crt_init() failed; rc=%d\n", rc);
 		error_exit();

--- a/src/tests/ftest/cart/iv_server.c
+++ b/src/tests/ftest/cart/iv_server.c
@@ -1266,7 +1266,8 @@ int main(int argc, char **argv)
 	/* rank, num_attach_retries, is_server, assert_on_error */
 	crtu_test_init(my_rank, 20, true, true);
 
-	rc = crt_init(IV_GRP_NAME, CRT_FLAG_BIT_SERVER | CRT_FLAG_BIT_AUTO_SWIM_DISABLE);
+	rc = crt_init(IV_GRP_NAME, CRT_FLAG_BIT_SERVER |
+				   CRT_FLAG_BIT_AUTO_SWIM_DISABLE);
 	assert(rc == 0);
 
 	rc = crt_rank_self_set(my_rank);

--- a/src/tests/ftest/cart/no_pmix_corpc_errors.c
+++ b/src/tests/ftest/cart/no_pmix_corpc_errors.c
@@ -249,7 +249,6 @@ int main(int argc, char **argv)
 	crt_group_t		*grp;
 	crt_context_t		crt_ctx[NUM_SERVER_CTX];
 	pthread_t		progress_thread[NUM_SERVER_CTX];
-	struct test_options	*opts = crtu_get_opts();
 	int			i, k;
 	char			*my_uri;
 	char			*env_self_rank;
@@ -275,7 +274,8 @@ int main(int argc, char **argv)
 	assert(rc == 0);
 
 	DBG_PRINT("Server starting up\n");
-	rc = crt_init(NULL, CRT_FLAG_BIT_SERVER | CRT_FLAG_BIT_AUTO_SWIM_DISABLE);
+	rc = crt_init(NULL, CRT_FLAG_BIT_SERVER |
+			CRT_FLAG_BIT_AUTO_SWIM_DISABLE);
 	if (rc != 0) {
 		D_ERROR("crt_init() failed; rc=%d\n", rc);
 		assert(0);
@@ -308,14 +308,6 @@ int main(int argc, char **argv)
 				rpc_callback, NULL, NULL);
 		if (rc != 0) {
 			D_ERROR("register_rpc_task failed; rc=%d\n", rc);
-			assert(0);
-		}
-	}
-
-	if (opts->is_swim_enabled) {
-		rc = crt_swim_init(0);
-		if (rc != 0) {
-			D_ERROR("crt_swim_init() failed; rc=%d\n", rc);
 			assert(0);
 		}
 	}
@@ -408,6 +400,12 @@ int main(int argc, char **argv)
 				 NUM_SERVER_CTX, 10, 100.0);
 	if (rc != 0) {
 		D_ERROR("wait_for_ranks() failed; rc=%d\n", rc);
+		assert(0);
+	}
+
+	rc = crt_swim_init(0);
+	if (rc != 0) {
+		D_ERROR("crt_swim_init() failed; rc=%d\n", rc);
 		assert(0);
 	}
 

--- a/src/tests/ftest/cart/no_pmix_group_test.c
+++ b/src/tests/ftest/cart/no_pmix_group_test.c
@@ -288,7 +288,6 @@ int main(int argc, char **argv)
 	crt_group_t		*grp;
 	crt_context_t		crt_ctx[NUM_SERVER_CTX];
 	pthread_t		progress_thread[NUM_SERVER_CTX];
-	struct test_options	*opts = crtu_get_opts();
 	d_rank_list_t		*mod_ranks;
 	char			*uris[10];
 	d_rank_list_t		*mod_prim_ranks;
@@ -320,7 +319,8 @@ int main(int argc, char **argv)
 	assert(rc == 0);
 
 	DBG_PRINT("Server starting up\n");
-	rc = crt_init(NULL, CRT_FLAG_BIT_SERVER | CRT_FLAG_BIT_AUTO_SWIM_DISABLE);
+	rc = crt_init(NULL, CRT_FLAG_BIT_SERVER |
+			CRT_FLAG_BIT_AUTO_SWIM_DISABLE);
 	if (rc != 0) {
 		D_ERROR("crt_init() failed; rc=%d\n", rc);
 		assert(0);
@@ -356,14 +356,6 @@ int main(int argc, char **argv)
 		assert(rc == 0);
 	}
 
-	if (opts->is_swim_enabled) {
-		rc = crt_swim_init(0);
-		if (rc != 0) {
-			D_ERROR("crt_swim_init() failed; rc=%d\n", rc);
-			assert(0);
-		}
-	}
-
 	grp_cfg_file = getenv("CRT_L_GRP_CFG");
 
 	rc = crt_rank_self_set(my_rank);
@@ -390,6 +382,12 @@ int main(int argc, char **argv)
 	DBG_PRINT("self_rank=%d uri=%s grp_cfg_file=%s\n", my_rank,
 			my_uri, grp_cfg_file);
 	D_FREE(my_uri);
+
+	rc = crt_swim_init(0);
+	if (rc != 0) {
+		D_ERROR("crt_swim_init() failed; rc=%d\n", rc);
+		assert(0);
+	}
 
 	rc = crt_group_size(NULL, &grp_size);
 	if (rc != 0) {

--- a/src/tests/ftest/cart/no_pmix_group_version.c
+++ b/src/tests/ftest/cart/no_pmix_group_version.c
@@ -245,7 +245,6 @@ int main(int argc, char **argv)
 	crt_group_t		*grp;
 	crt_context_t		crt_ctx[NUM_SERVER_CTX];
 	pthread_t		progress_thread[NUM_SERVER_CTX];
-	struct test_options	*opts = crtu_get_opts();
 	int			i;
 	char			*my_uri;
 	char			*env_self_rank;
@@ -271,7 +270,8 @@ int main(int argc, char **argv)
 	assert(rc == 0);
 
 	DBG_PRINT("Server starting up\n");
-	rc = crt_init(NULL, CRT_FLAG_BIT_SERVER | CRT_FLAG_BIT_AUTO_SWIM_DISABLE);
+	rc = crt_init(NULL, CRT_FLAG_BIT_SERVER |
+			CRT_FLAG_BIT_AUTO_SWIM_DISABLE);
 	if (rc != 0) {
 		D_ERROR("crt_init() failed; rc=%d\n", rc);
 		assert(0);
@@ -299,14 +299,6 @@ int main(int argc, char **argv)
 		rc = pthread_create(&progress_thread[i], 0,
 				    crtu_progress_fn, &crt_ctx[i]);
 		assert(rc == 0);
-	}
-
-	if (opts->is_swim_enabled) {
-		rc = crt_swim_init(0);
-		if (rc != 0) {
-			D_ERROR("crt_swim_init() failed; rc=%d\n", rc);
-			assert(0);
-		}
 	}
 
 	grp_cfg_file = getenv("CRT_L_GRP_CFG");
@@ -402,6 +394,12 @@ int main(int argc, char **argv)
 
 	d_rank_list_free(rank_list);
 	rank_list = NULL;
+
+	rc = crt_swim_init(0);
+	if (rc != 0) {
+		D_ERROR("crt_swim_init() failed; rc=%d\n", rc);
+		assert(0);
+	}
 
 	rc = sem_init(&sem, 0, 0);
 	if (rc != 0) {

--- a/src/tests/ftest/cart/no_pmix_launcher_server.c
+++ b/src/tests/ftest/cart/no_pmix_launcher_server.c
@@ -24,7 +24,6 @@ int main(int argc, char **argv)
 	crt_group_t		*grp;
 	crt_context_t		crt_ctx[NUM_SERVER_CTX];
 	pthread_t		progress_thread[NUM_SERVER_CTX];
-	struct test_options	*opts = crtu_get_opts();
 	int			i;
 	char			*my_uri;
 	char			*env_self_rank;
@@ -43,7 +42,8 @@ int main(int argc, char **argv)
 	assert(rc == 0);
 
 	DBG_PRINT("Server starting up\n");
-	rc = crt_init("server_grp", CRT_FLAG_BIT_SERVER | CRT_FLAG_BIT_AUTO_SWIM_DISABLE);
+	rc = crt_init("server_grp", CRT_FLAG_BIT_SERVER |
+				CRT_FLAG_BIT_AUTO_SWIM_DISABLE);
 	if (rc != 0) {
 		D_ERROR("crt_init() failed; rc=%d\n", rc);
 		assert(0);
@@ -75,14 +75,6 @@ int main(int argc, char **argv)
 		assert(0);
 	}
 
-	if (opts->is_swim_enabled) {
-		rc = crt_swim_init(0);
-		if (rc != 0) {
-			D_ERROR("crt_swim_init() failed; rc=%d\n", rc);
-			assert(0);
-		}
-	}
-
 	grp_cfg_file = getenv("CRT_L_GRP_CFG");
 
 	rc = crt_rank_uri_get(grp, my_rank, 0, &my_uri);
@@ -102,6 +94,12 @@ int main(int argc, char **argv)
 	DBG_PRINT("self_rank=%d uri=%s grp_cfg_file=%s\n", my_rank,
 		  my_uri, grp_cfg_file);
 	D_FREE(my_uri);
+
+	rc = crt_swim_init(0);
+	if (rc != 0) {
+		D_ERROR("crt_swim_init() failed; rc=%d\n", rc);
+		assert(0);
+	}
 
 	rc = crt_group_size(NULL, &grp_size);
 	if (rc != 0) {

--- a/src/tests/ftest/cart/rpc_test_srv.c
+++ b/src/tests/ftest/cart/rpc_test_srv.c
@@ -534,7 +534,7 @@ srv_rpc_init(void)
 
 	dbg("---%s--->", __func__);
 
-	rc = crt_init(CRT_DEFAULT_GRPID, CRT_FLAG_BIT_SERVER | CRT_FLAG_BIT_AUTO_SWIM_DISABLE);
+	rc = crt_init(CRT_DEFAULT_GRPID, CRT_FLAG_BIT_SERVER);
 	D_ASSERTF(rc == 0, " crt_init failed %d\n", rc);
 
 	rc = crt_group_config_path_set(rpc_srv.config_path);

--- a/src/tests/ftest/cart/rpc_test_srv2.c
+++ b/src/tests/ftest/cart/rpc_test_srv2.c
@@ -207,8 +207,7 @@ srv_rpc_init(void)
 
 	dbg("---%s--->", __func__);
 
-	rc = crt_init(CRT_RPC_MULTITIER_GRPID, CRT_FLAG_BIT_SERVER |
-					       CRT_FLAG_BIT_AUTO_SWIM_DISABLE);
+	rc = crt_init(CRT_RPC_MULTITIER_GRPID, CRT_FLAG_BIT_SERVER);
 	D_ASSERTF(rc == 0, "crt_init failed %d\n", rc);
 
 	rc = crt_group_config_path_set(rpc_srv.config_path);

--- a/src/tests/ftest/cart/test_corpc_exclusive.c
+++ b/src/tests/ftest/cart/test_corpc_exclusive.c
@@ -112,7 +112,8 @@ int main(void)
 	rc = d_log_init();
 	assert(rc == 0);
 
-	rc = crt_init(NULL, CRT_FLAG_BIT_SERVER | CRT_FLAG_BIT_AUTO_SWIM_DISABLE);
+	rc = crt_init(NULL, CRT_FLAG_BIT_SERVER |
+			CRT_FLAG_BIT_AUTO_SWIM_DISABLE);
 	assert(rc == 0);
 
 	rc = crt_proto_register(&my_proto_fmt_basic_corpc);

--- a/src/tests/ftest/cart/test_corpc_prefwd.c
+++ b/src/tests/ftest/cart/test_corpc_prefwd.c
@@ -134,7 +134,8 @@ int main(void)
 	rc = d_log_init();
 	assert(rc == 0);
 
-	rc = crt_init(NULL, CRT_FLAG_BIT_SERVER | CRT_FLAG_BIT_AUTO_SWIM_DISABLE);
+	rc = crt_init(NULL, CRT_FLAG_BIT_SERVER |
+			CRT_FLAG_BIT_AUTO_SWIM_DISABLE);
 	assert(rc == 0);
 
 	rc = crt_proto_register(&my_proto_fmt_basic_corpc);

--- a/src/tests/ftest/cart/test_hlc_net.c
+++ b/src/tests/ftest/cart/test_hlc_net.c
@@ -218,7 +218,7 @@ static int srv_init(void)
 
 	dbg("---%s--->", __func__);
 
-	rc = crt_init(CRT_DEFAULT_GRPID, CRT_FLAG_BIT_SERVER | CRT_FLAG_BIT_AUTO_SWIM_DISABLE);
+	rc = crt_init(CRT_DEFAULT_GRPID, CRT_FLAG_BIT_SERVER);
 	D_ASSERTF(rc == 0, " crt_init failed %d\n", rc);
 
 	rc = crt_proto_register(&test_proto_fmt);

--- a/src/tests/ftest/cart/test_rpc_error.c
+++ b/src/tests/ftest/cart/test_rpc_error.c
@@ -200,7 +200,7 @@ rpc_err_init(void)
 	rc = d_log_init();
 	assert(rc == 0);
 
-	flag = rpc_err.re_is_service ? (CRT_FLAG_BIT_SERVER | CRT_FLAG_BIT_AUTO_SWIM_DISABLE) : 0;
+	flag = rpc_err.re_is_service ? CRT_FLAG_BIT_SERVER : 0;
 	rc = crt_init(rpc_err.re_local_group_name, flag);
 	D_ASSERTF(rc == 0, "crt_init() failed, rc: %d\n", rc);
 

--- a/src/tests/ftest/cart/test_rpc_to_ghost_rank.c
+++ b/src/tests/ftest/cart/test_rpc_to_ghost_rank.c
@@ -308,7 +308,7 @@ test_init(void)
 	rc = sem_init(&test_g.t_token_to_proceed, 0, 0);
 	D_ASSERTF(rc == 0, "sem_init() failed.\n");
 
-	flag = test_g.t_is_service ? (CRT_FLAG_BIT_SERVER | CRT_FLAG_BIT_AUTO_SWIM_DISABLE) : 0;
+	flag = test_g.t_is_service ? CRT_FLAG_BIT_SERVER : 0;
 	rc = crt_init(test_g.t_local_group_name, flag);
 	D_ASSERTF(rc == 0, "crt_init() failed, rc: %d\n", rc);
 

--- a/src/tests/ftest/cart/test_swim_net.c
+++ b/src/tests/ftest/cart/test_swim_net.c
@@ -275,7 +275,7 @@ static void *srv_progress(void *data)
 	return NULL;
 }
 
-static int64_t swim_progress_cb(crt_context_t ctx, int64_t timeout, void *arg)
+static void swim_progress_cb(crt_context_t ctx, void *arg)
 {
 	struct swim_global_srv *srv = arg;
 	swim_id_t self_id = swim_self_get(srv->swim_ctx);
@@ -293,7 +293,6 @@ static int64_t swim_progress_cb(crt_context_t ctx, int64_t timeout, void *arg)
 		D_ERROR("swim_progress() failed rc=%d\n", rc);
 out:
 	dbg("<---%s---", __func__);
-	return timeout;
 }
 
 static void srv_fini(void)
@@ -340,7 +339,7 @@ static int srv_init(void)
 
 	dbg("---%s--->", __func__);
 
-	rc = crt_init(CRT_DEFAULT_GRPID, CRT_FLAG_BIT_SERVER | CRT_FLAG_BIT_AUTO_SWIM_DISABLE);
+	rc = crt_init(CRT_DEFAULT_GRPID, CRT_FLAG_BIT_SERVER);
 	D_ASSERTF(rc == 0, " crt_init failed %d\n", rc);
 
 	rc = crt_proto_register(&swim_proto_fmt);

--- a/src/tests/ftest/cart/threaded_server.c
+++ b/src/tests/ftest/cart/threaded_server.c
@@ -111,7 +111,7 @@ int main(int argc, char **argv)
 	rc = d_log_init();
 	assert(rc == 0);
 
-	rc = crt_init("manyserver", CRT_FLAG_BIT_SERVER | CRT_FLAG_BIT_AUTO_SWIM_DISABLE);
+	rc = crt_init("manyserver", CRT_FLAG_BIT_SERVER);
 	if (rc != 0) {
 		printf("Could not start server, rc = %d", rc);
 		return -1;

--- a/src/tests/ftest/cart/utest/utest_portnumber.c
+++ b/src/tests/ftest/cart/utest/utest_portnumber.c
@@ -87,7 +87,7 @@ run_test_fork(void **state)
 	/* fork first child process */
 	pid1 = fork();
 	if (pid1 == 0) {
-		rc = crt_init(NULL, CRT_FLAG_BIT_SERVER | CRT_FLAG_BIT_AUTO_SWIM_DISABLE);
+		rc = crt_init(NULL, CRT_FLAG_BIT_SERVER);
 		if (rc != 0) {
 			sem_post(child2_sem);
 			rc = CHILD1_INIT_ERR;
@@ -137,7 +137,7 @@ child1_error1:
 			goto child2_error;
 		}
 
-		rc = crt_init(NULL, CRT_FLAG_BIT_SERVER | CRT_FLAG_BIT_AUTO_SWIM_DISABLE);
+		rc = crt_init(NULL, CRT_FLAG_BIT_SERVER);
 		if (rc != 0) {
 			rc = CHILD2_INIT_ERR;
 			goto child2_error;

--- a/src/tests/ftest/cart/utest/utest_swim.c
+++ b/src/tests/ftest/cart/utest/utest_swim.c
@@ -24,7 +24,8 @@ test_swim(void **state)
 {
 	int rc;
 
-	rc = crt_init(NULL, CRT_FLAG_BIT_SERVER | CRT_FLAG_BIT_AUTO_SWIM_DISABLE);
+	rc = crt_init(NULL, CRT_FLAG_BIT_SERVER |
+			    CRT_FLAG_BIT_AUTO_SWIM_DISABLE);
 	assert_int_equal(rc, 0);
 
 	rc = crt_swim_init(0);

--- a/src/tests/ftest/pool/create.yaml
+++ b/src/tests/ftest/pool/create.yaml
@@ -16,6 +16,7 @@ timeouts:
   test_create_no_space_loop: 2160
 server_config:
   name: daos_server
+  control_log_mask: DEBUG
   servers:
     0:
       bdev_class: nvme
@@ -23,6 +24,10 @@ server_config:
       scm_class: dcpm
       scm_list: ["/dev/pmem0"]
       scm_mount: /mnt/daos0
+      log_mask: DEBUG,MEM=ERR,SWIM=ERR
+      env_vars:
+        - DD_MASK=all
+        - DD_SUBSYS=all
 pool_1:
   name: daos_server
   control_method: dmg

--- a/src/tests/ftest/util/server_utils_params.py
+++ b/src/tests/ftest/util/server_utils_params.py
@@ -358,7 +358,7 @@ class DaosServerYamlParameters(YamlParameters):
             #           - CRT_CTX_NUM=8
             self.targets = BasicParameter(None, 8)
             self.first_core = BasicParameter(None, 0)
-            self.nr_xs_helpers = BasicParameter(None, 16)
+            self.nr_xs_helpers = BasicParameter(None, 4)
             self.fabric_iface = BasicParameter(None, default_interface)
             self.fabric_iface_port = BasicParameter(None, default_port)
             self.pinned_numa_node = BasicParameter(None)

--- a/src/utils/self_test/self_test.c
+++ b/src/utils/self_test/self_test.c
@@ -113,7 +113,7 @@ static int self_test_init(char *dest_name, crt_context_t *crt_ctx,
 
 
 	if (listen)
-		init_flags |= (CRT_FLAG_BIT_SERVER | CRT_FLAG_BIT_AUTO_SWIM_DISABLE);
+		init_flags |= CRT_FLAG_BIT_SERVER;
 	ret = crt_init(CRT_SELF_TEST_GROUP_NAME, init_flags);
 	if (ret != 0) {
 		D_ERROR("crt_init failed; ret = %d\n", ret);


### PR DESCRIPTION
Experimental patch to examine the effects on pool create timing
of placing swim and system xstreams on the same CPU core.

Also, apply a default nr_xs_helpers=4 to, with the above change,
create conditions where
1) swim + system XS are pinned to the same physical core
2) limited number of helper xstreams will (I assume) result in
   pinning those threads to separate physical cores than
   sys/swim xstreams. Whereas the alternative of 16 helpers
   causes some speculation/concern that helpers may a source
   of interference on the core running system/swim xstreams.

Quick-Functional: true
Skip-coverity-test: true
Skip-func-test-vm: true
Skip-func-hw-test-small: true
Skip-func-hw-test-medium: true
Skip-func-hw-test-large: false
Skip-scan-centos-rpms: true
Skip-scan-leap15-rpms: true
Skip-test-centos-rpms: true
Test-tag: create_no_space create_no_space_loop

Signed-off-by: Kenneth Cain <kenneth.c.cain@intel.com>