### PR TITLE
DAOS-8871 test: Add skipForTicket for the rel2.2 testcases which failed on weekly CI.

### DIFF
--- a/src/tests/ftest/container/full_pool_container_create.py
+++ b/src/tests/ftest/container/full_pool_container_create.py
@@ -5,7 +5,7 @@
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
 import time
-from apricot import TestWithServers
+from apricot import TestWithServers, skipForTicket
 from general_utils import get_random_bytes, DaosTestError
 from test_utils_container import TestContainerData
 
@@ -15,6 +15,7 @@ class FullPoolContainerCreate(TestWithServers):
     :avocado: recursive
     """
 
+    @skipForTicket("DAOS-8400, DAOS-5813")
     def test_no_space_cont_create(self):
         """JIRA ID: DAOS-1169 DAOS-7374
 

--- a/src/tests/ftest/control/daos_snapshot.py
+++ b/src/tests/ftest/control/daos_snapshot.py
@@ -4,7 +4,7 @@
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
-from apricot import TestWithServers
+from apricot import TestWithServers, skipForTicket
 from daos_utils import DaosCommand
 
 
@@ -117,6 +117,7 @@ class DaosSnapshotTest(TestWithServers):
             pool=self.pool.uuid, cont=self.container.uuid)
         self.assertTrue(not epochs)
 
+    @skipForTicket("DAOS-4691")
     def test_epcrange(self):
         """JIRA ID: DAOS-4872
 

--- a/src/tests/ftest/fault_domain/fault_domain.py
+++ b/src/tests/ftest/fault_domain/fault_domain.py
@@ -5,7 +5,7 @@
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
 
-from apricot import TestWithServers
+from apricot import TestWithServers, skipForTicket
 
 
 class FaultDomain(TestWithServers):
@@ -21,6 +21,7 @@ class FaultDomain(TestWithServers):
         self.setup_start_servers = False
         super().setUp()
 
+    @skipForTicket("DAOS-7919")
     def test_pools_in_different_domains(self):
         """This aims to:
             Be able to configure daos servers using different fault domains.

--- a/src/tests/ftest/nvme/enospace.py
+++ b/src/tests/ftest/nvme/enospace.py
@@ -7,6 +7,7 @@
 import time
 import threading
 
+from apricot import skipForTicket
 from nvme_utils import ServerFillUp
 from avocado.core.exceptions import TestFail
 from daos_utils import DaosCommand
@@ -194,6 +195,7 @@ class NvmeEnospace(ServerFillUp):
             if self.out_queue.get() == "FAIL":
                 self.fail("One of the Background IOR job failed")
 
+    @skipForTicket("DAOS-7378")
     def test_enospace_lazy_with_bg(self):
         """Jira ID: DAOS-4756.
 
@@ -217,6 +219,7 @@ class NvmeEnospace(ServerFillUp):
         #Run IOR to fill the pool.
         self.run_enospace_with_bg_job()
 
+    @skipForTicket("DAOS-7378")
     def test_enospace_lazy_with_fg(self):
         """Jira ID: DAOS-4756.
 
@@ -251,6 +254,7 @@ class NvmeEnospace(ServerFillUp):
         #Run last IO
         self.start_ior_load(storage='SCM', percent=1)
 
+    @skipForTicket("DAOS-7378")
     def test_enospace_time_with_bg(self):
         """Jira ID: DAOS-4756.
 
@@ -278,6 +282,7 @@ class NvmeEnospace(ServerFillUp):
         #Run IOR to fill the pool.
         self.run_enospace_with_bg_job()
 
+    @skipForTicket("DAOS-7378")
     def test_enospace_time_with_fg(self):
         """Jira ID: DAOS-4756.
 
@@ -316,6 +321,7 @@ class NvmeEnospace(ServerFillUp):
         #Run last IO
         self.start_ior_load(storage='SCM', percent=1)
 
+    @skipForTicket("DAOS-7378")
     def test_performance_storage_full(self):
         """Jira ID: DAOS-4756.
 
@@ -357,6 +363,7 @@ class NvmeEnospace(ServerFillUp):
                       ' Baseline Read MiB = {} and latest IOR Read MiB = {}'
                       .format(max_mib_baseline, max_mib_latest))
 
+    @skipForTicket("DAOS-7378")
     def test_enospace_no_aggregation(self):
         """Jira ID: DAOS-4756.
 

--- a/src/tests/ftest/nvme/pool_extend.py
+++ b/src/tests/ftest/nvme/pool_extend.py
@@ -7,6 +7,7 @@
 import time
 import threading
 
+from apricot import skipForTicket
 from osa_utils import OSAUtils
 from write_host_file import write_host_file
 from dmg_utils import check_system_query_status
@@ -117,6 +118,7 @@ class NvmePoolExtend(OSAUtils):
             output = self.daos_command.container_check(**kwargs)
             self.log.info(output)
 
+    @skipForTicket("DAOS-7195, DAOS-7955")
     def test_nvme_pool_extend(self):
         """Test ID: DAOS-2086
         Test Description: NVME Pool Extend

--- a/src/tests/ftest/rebuild/container_rf.py
+++ b/src/tests/ftest/rebuild/container_rf.py
@@ -14,6 +14,11 @@ class RbldContRfTest(ContRedundancyFactor):
     :avocado: recursive
     """
 
+    CANCEL_FOR_TICKET = [
+        ["DAOS-8827", "properties", "rf:1", "rank", [3,4,5]],
+        ["DAOS-8827", "properties", "rf:2", "rank", [3]]
+    ]
+
     def __init__(self, *args, **kwargs):
         """Initialize a Rebuild Container RF with ObjClass Write object."""
         super().__init__(*args, **kwargs)


### PR DESCRIPTION
DAOS-8871 test: Add skipForTicket and CANCEL_FOR_TICKET for the rel2.2 testcases which failed on weekly CI.

Description: Following tests will be skipped on rel2.0 weekly CI regression and updated with skipForTicket.
                    After the Jira-tickets (bugs) resolved, to create a Jira and remove the @skipForTicket DAOS-xxxx from
                    the test.py.
modified:   container/full_pool_container_create.py
modified:   control/daos_snapshot.py
modified:   fault_domain/fault_domain.py
modified:   nvme/enospace.py
modified:   nvme/pool_extend.py
modified:   rebuild/container_rf.py

Test-tag: full_regression
Signed-off-by: Ding Ho ding-hwa.ho@intel.com