### PR TITLE
DAOS-8823 dfuse: Use correct permissions bits in readdir. (#6992)

### DIFF
--- a/src/client/dfuse/ops/readdir.c
+++ b/src/client/dfuse/ops/readdir.c
@@ -346,14 +346,14 @@ dfuse_cb_readdir(fuse_req_t req, struct dfuse_obj_hdl *oh,
 			if (plus)
 				rc = dfs_lookupx(oh->doh_dfs, oh->doh_obj,
 						 dre->dre_name,
-						 O_RDONLY | O_NOFOLLOW, &obj,
+						 O_RDWR | O_NOFOLLOW, &obj,
 						 &stbuf.st_mode, &stbuf,
 						 1, &duns_xattr_name,
 						 (void **)&outp, &attr_len);
 			else
 				rc = dfs_lookup_rel(oh->doh_dfs, oh->doh_obj,
 						    dre->dre_name,
-						    O_RDONLY | O_NOFOLLOW,
+						    O_RDWR | O_NOFOLLOW,
 						    &obj, &stbuf.st_mode, NULL);
 			if (rc == ENOENT) {
 				DFUSE_TRA_DEBUG(oh, "File does not exist");


### PR DESCRIPTION
Correct a bug in readdir where dfs handles were being
opened read only.  If the handle was not already in the
hash table then the readdir one would be added, leading
to an inability to modify the file afterwards.  To reproduce
it was necessairy to create a file, restart dfuse then
access the file through readdir rather than lookup/stat
at which point subsequent setattr calls would fail.

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>