### PR TITLE
DAOS-8580 tests: Disabling daos_vol openmpi tests (#7029)

### DIFF
--- a/src/tests/ftest/daos_vol/h5_suite.py
+++ b/src/tests/ftest/daos_vol/h5_suite.py
@@ -7,6 +7,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 from vol_test_base import VolTestBase
 from general_utils import get_job_manager_class
 
+
 class DaosVol(VolTestBase):
     # pylint: disable=too-many-ancestors,too-few-public-methods
     """Runs HDF5 test suites with daos vol connector.
@@ -41,33 +42,3 @@ class DaosVol(VolTestBase):
         self.set_job_manager_timeout()
         self.run_test(
             "/usr/lib64/mpich/lib", "/usr/lib64/hdf5_vol_daos/mpich/tests")
-
-    def test_daos_vol_openmpi(self):
-        """Jira ID: DAOS-3656.
-
-        Test Description:
-            Run HDF5 testphdf5 and t_shapesame provided in HDF5 package with
-            daos vol connector. Testing various I/O functions provided in HDF5
-            test suite such as:
-              h5_test_testhdf5
-              h5vl_test
-              h5_partest_t_bigio
-              h5_partest_testphdf5
-              h5vl_test_parallel
-              h5_partest_t_shapesame
-              h5daos_test_map
-              h5daos_test_map_parallel
-              h5daos_test_oclass
-              h5daos_test_metadata_parallel
-
-        :avocado: tags=all,daily_regression
-        :avocado: tags=hw,small
-        :avocado: tags=hdf5,vol,volunit,volopenmpi
-        :avocado: tags=DAOS_5610
-        """
-        self.job_manager = get_job_manager_class(
-            "Orterun", None, False, "openmpi")
-        self.set_job_manager_timeout()
-        self.run_test(
-            "/usr/lib64/openmpi3/lib",
-            "/usr/lib64/hdf5_vol_daos/openmpi3/tests")

--- a/src/tests/ftest/util/vol_test_base.py
+++ b/src/tests/ftest/util/vol_test_base.py
@@ -42,7 +42,7 @@ class VolTestBase(DfuseTestBase):
         # Assign the test to run
         self.job_manager.job = ExecutableCommand(
             namespace=None, command=testname, path=test_repo,
-            check_results=["FAILED"])
+            check_results=["FAILED", "stderr"])
 
         env = EnvironmentVariables()
         env["DAOS_POOL"] = "{}".format(self.pool.uuid)


### PR DESCRIPTION
Reducing repeated daos_vol tests run with both mpich and openmpi by
removing the openmpi test cases.

Signed-off-by: Phillip Henderson <phillip.henderson@intel.com>