### PR TITLE
DAOS-8633 object: Resolve coverity and code style issues. (#6824)

### DIFF
--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -216,8 +216,7 @@ obj_layout_free(struct dc_object *obj)
 	obj->cob_shards_nr = 0;
 	D_SPIN_UNLOCK(&obj->cob_spin);
 
-	if (layout != NULL)
-		D_FREE(layout);
+	D_FREE(layout);
 }
 
 static void
@@ -228,8 +227,7 @@ obj_free(struct d_hlink *hlink)
 	obj = container_of(hlink, struct dc_object, cob_hlink);
 	D_ASSERT(daos_hhash_link_empty(&obj->cob_hlink));
 	obj_layout_free(obj);
-	if (obj->cob_time_fetch_leader != NULL)
-		D_FREE(obj->cob_time_fetch_leader);
+	D_FREE(obj->cob_time_fetch_leader);
 	D_SPIN_DESTROY(&obj->cob_spin);
 	D_RWLOCK_DESTROY(&obj->cob_lock);
 	D_FREE(obj);
@@ -356,8 +354,7 @@ obj_layout_create(struct dc_object *obj, bool refresh)
 
 	if (obj->cob_grp_size > 1 && srv_io_mode == DIM_DTX_FULL_ENABLED &&
 	    old < obj->cob_grp_nr) {
-		if (obj->cob_time_fetch_leader != NULL)
-			D_FREE(obj->cob_time_fetch_leader);
+		D_FREE(obj->cob_time_fetch_leader);
 
 		D_ALLOC_ARRAY(obj->cob_time_fetch_leader, obj->cob_grp_nr);
 		if (obj->cob_time_fetch_leader == NULL)
@@ -449,8 +446,7 @@ obj_auxi_free_failed_tgt_list(struct obj_auxi_args *obj_auxi)
 		return;
 
 	D_FREE(obj_auxi->failed_tgt_list->tl_tgts);
-	D_FREE_PTR(obj_auxi->failed_tgt_list);
-	obj_auxi->failed_tgt_list = NULL;
+	D_FREE(obj_auxi->failed_tgt_list);
 }
 
 static int
@@ -1326,7 +1322,6 @@ dc_obj_redun_check(struct dc_object *obj, daos_handle_t coh)
 	int			 cont_rf;	/* cont redun_fac */
 	int			 cont_tf;	/* cont #tolerate failures */
 	int			 rc;
-
 
 	cont_rf = dc_cont_hdl2redunfac(coh);
 	if (cont_rf < 0) {
@@ -3048,9 +3043,8 @@ merge_recx(d_list_t *head, uint64_t offset, uint64_t size, daos_epoch_t eph)
 			inserted = true;
 			if (recx != new_recx) {
 				d_list_del(&recx->recx_list);
-				D_FREE_PTR(recx);
+				D_FREE(recx);
 			}
-
 		}
 		prev = recx;
 	}
@@ -3296,7 +3290,6 @@ obj_shard_list_key_cb(struct shard_auxi_args *shard_auxi,
 			D_FREE(key);
 		if (rc)
 			return rc;
-
 	}
 
 	return 0;
@@ -3695,7 +3688,7 @@ out:
 		d_list_for_each_entry_safe(key, tmp, &iter_arg.merge_list,
 					   key_list) {
 			d_list_del(&key->key_list);
-			D_FREE_PTR(key);
+			D_FREE(key);
 		}
 	} else if (obj_auxi->opc == DAOS_OBJ_RECX_RPC_ENUMERATE) {
 		struct obj_auxi_list_recx *recx;
@@ -3704,7 +3697,7 @@ out:
 		d_list_for_each_entry_safe(recx, tmp, &iter_arg.merge_list,
 					   recx_list) {
 			d_list_del(&recx->recx_list);
-			D_FREE_PTR(recx);
+			D_FREE(recx);
 		}
 	}
 
@@ -3828,7 +3821,8 @@ obj_comp_cb(tse_task_t *task, void *data)
 
 		idx = obj_auxi->req_tgts.ort_shard_tgts->st_shard /
 			obj_get_grp_size(obj);
-		daos_gettime_coarse(&obj->cob_time_fetch_leader[idx]);
+		rc = daos_gettime_coarse(&obj->cob_time_fetch_leader[idx]);
+		D_ASSERT(rc == 0);
 	}
 
 	/* Check if the pool map needs to refresh */
@@ -4211,7 +4205,6 @@ obj_csum_update(struct dc_object *obj, daos_obj_update_t *args,
 	if (csummer_copy == NULL)
 		return -DER_NOMEM;
 
-
 	/** Calc 'd' key checksum */
 	rc = daos_csummer_calc_key(csummer_copy, args->dkey, &dkey_csum);
 	if (rc != 0) {
@@ -4236,7 +4229,7 @@ obj_csum_update(struct dc_object *obj, daos_obj_update_t *args,
 	 * checksum - simulates corruption over network
 	 */
 	if (DAOS_FAIL_CHECK(DAOS_CSUM_CORRUPT_UPDATE_DKEY))
-		((char *) args->dkey->iov_buf)[0]++;
+		((char *)args->dkey->iov_buf)[0]++;
 	if (DAOS_FAIL_CHECK(DAOS_CSUM_CORRUPT_UPDATE_AKEY))
 		((char *)iod_csums[0].ic_akey.cs_csum)[0]++;
 	if (DAOS_FAIL_CHECK(DAOS_CSUM_CORRUPT_UPDATE))
@@ -5238,7 +5231,6 @@ obj_punch_common(tse_task_t *task, enum obj_rpc_opc opc, daos_obj_punch_t *args)
 		goto comp; /* invalid parameters */
 
 	if (daos_handle_is_valid(args->th)) {
-
 		/* add the operation to DTX and complete immediately */
 		rc = dc_tx_attach(args->th, obj, opc, task);
 		goto comp;

--- a/src/object/obj_verify.c
+++ b/src/object/obj_verify.c
@@ -650,6 +650,7 @@ dc_obj_verify_ec_cb(struct dss_enum_unpack_io *io, void *arg)
 	int				idx = 0;
 	int				rc;
 
+	D_ASSERT(obj != NULL);
 	D_DEBUG(DB_TRACE, "compare "DF_KEY" nr %d shard "DF_U64"\n", DP_KEY(&io->ui_dkey),
 		nr, shard);
 	if (nr == 0)
@@ -736,11 +737,9 @@ dc_obj_verify_ec_cb(struct dss_enum_unpack_io *io, void *arg)
 	}
 out:
 	for (i = 0; i < idx; i++) {
-		if (iovs[i].iov_buf)
-			D_FREE(iovs[i].iov_buf);
+		D_FREE(iovs[i].iov_buf);
 
-		if (iovs_verify[i].iov_buf)
-			D_FREE(iovs_verify[i].iov_buf);
+		D_FREE(iovs_verify[i].iov_buf);
 	}
 
 	return rc;

--- a/src/object/srv_ec_aggregate.c
+++ b/src/object/srv_ec_aggregate.c
@@ -304,7 +304,7 @@ agg_clear_extents(struct ec_agg_entry *entry)
 
 		d_list_del(&extent->ae_link);
 		entry->ae_cur_stripe.as_extent_cnt--;
-		D_FREE_PTR(extent);
+		D_FREE(extent);
 	}
 
 	entry->ae_cur_stripe.as_offset = 0U;
@@ -433,7 +433,6 @@ agg_prep_sgl(struct ec_agg_entry *entry)
 out:
 	d_sgl_fini(&entry->ae_sgl, true);
 	return rc;
-
 }
 
 /* Determines if an extent overlaps a cell.
@@ -590,10 +589,8 @@ agg_fetch_odata_cells(struct ec_agg_entry *entry, uint8_t *bit_map,
 		D_ERROR("dsc_obj_fetch failed: "DF_RC"\n", DP_RC(rc));
 
 out:
-	if (recxs)
-		D_FREE(recxs);
-	if (sgl.sg_iovs)
-		D_FREE(sgl.sg_iovs);
+	D_FREE(recxs);
+	D_FREE(sgl.sg_iovs);
 	return rc;
 }
 
@@ -702,7 +699,6 @@ ev_out:
 	ABT_eventual_free(&stripe_ud.asu_eventual);
 out:
 	return rc;
-
 }
 
 /* Driver function for full_stripe encode. Fetches the data and then invokes
@@ -906,10 +902,8 @@ agg_fetch_local_extents(struct ec_agg_entry *entry, uint8_t *bit_map,
 		D_ERROR("vos_obj_fetch failed: "DF_RC"\n", DP_RC(rc));
 
 out:
-	if (recxs != NULL)
-		D_FREE(recxs);
-	if (sgl.sg_iovs != NULL)
-		D_FREE(sgl.sg_iovs);
+	D_FREE(recxs);
+	D_FREE(sgl.sg_iovs);
 	return rc;
 }
 
@@ -1132,7 +1126,6 @@ agg_process_partial_stripe_ult(void *arg)
 
 out:
 	ABT_eventual_set(stripe_ud->asu_eventual, (void *)&rc, sizeof(rc));
-
 }
 
 /* Driver function for partial stripe update. Fetches the data and then invokes
@@ -1470,8 +1463,7 @@ agg_peer_update(struct ec_agg_entry *entry, bool write_parity)
 ev_out:
 	ABT_eventual_free(&stripe_ud.asu_eventual);
 out:
-	if (targets)
-		D_FREE(targets);
+	D_FREE(targets);
 	return rc;
 }
 
@@ -1494,7 +1486,7 @@ agg_process_holes_ult(void *arg)
 	crt_bulk_t		 bulk_hdl = NULL;
 	uint32_t		 len = ec_age2cs(entry);
 	uint64_t		 cell_b = ec_age2cs_b(entry);
-	uint32_t		 k = ec_age2k(entry);
+	uint64_t		 k = ec_age2k(entry);
 	uint32_t		 p = ec_age2p(entry);
 	uint64_t		 ss = entry->ae_cur_stripe.as_stripenum *
 					k * len;
@@ -1694,8 +1686,7 @@ fetch_again:
 	}
 
 out:
-	if (targets)
-		D_FREE(targets);
+	D_FREE(targets);
 	if (rpc)
 		crt_req_decref(rpc);
 	if (bulk_hdl)
@@ -1784,8 +1775,7 @@ ev_out:
 out:
 	D_FREE(stripe_ud.asu_recxs);
 	daos_csummer_free_ic(stripe_ud.asu_csummer, &stripe_ud.asu_iod_csums);
-	if (stripe_ud.asu_csum_iov.iov_buf)
-		D_FREE(stripe_ud.asu_csum_iov.iov_buf);
+	D_FREE(stripe_ud.asu_csum_iov.iov_buf);
 	daos_csummer_destroy(&stripe_ud.asu_csummer);
 	return rc;
 }

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -729,8 +729,7 @@ obj_echo_rw(crt_rpc_t *rpc, daos_iod_t *split_iods, uint64_t *split_offs)
 
 		/* Check each vector */
 		if (p_sgl->sg_iovs[i].iov_buf_len < size) {
-			if (p_sgl->sg_iovs[i].iov_buf != NULL)
-				D_FREE(p_sgl->sg_iovs[i].iov_buf);
+			D_FREE(p_sgl->sg_iovs[i].iov_buf);
 
 			D_ALLOC(p_sgl->sg_iovs[i].iov_buf, size);
 			/* obj_tls_fini() will free these buffer */
@@ -1555,7 +1554,6 @@ obj_local_rw_internal(crt_rpc_t *rpc, struct obj_io_context *ioc,
 				D_ERROR(DF_UOID" fetch verify failed: %d.\n",
 					DP_UOID(orw->orw_oid), rc);
 				goto post;
-
 			}
 		}
 	}
@@ -2234,6 +2232,7 @@ ds_obj_tgt_update_handler(crt_rpc_t *rpc)
 
 	if (DAOS_FAIL_CHECK(DAOS_VC_DIFF_DKEY)) {
 		unsigned char	*buf = dkey->iov_buf;
+
 		buf[0] += orw->orw_oid.id_shard + 1;
 		orw->orw_dkey_hash = obj_dkey2hash(orw->orw_oid.id_pub, dkey);
 	}
@@ -2351,7 +2350,7 @@ obj_tgt_update(struct dtx_leader_handle *dlh, void *arg, int idx,
 			D_GOTO(comp, rc = -DER_IO);
 
 		/* No need re-exec local update */
-		if (dlh != NULL && dlh->dlh_handle.dth_prepared)
+		if (dlh->dlh_handle.dth_prepared)
 			goto comp;
 
 		/* XXX: For non-solo DTX, leader and non-leader will make each
@@ -2982,7 +2981,6 @@ obj_enum_reply_bulk(crt_rpc_t *rpc)
 			       DAOS_HDL_INVAL, sgls, idx, NULL);
 	if (oei->oei_kds_bulk) {
 		D_FREE(oeo->oeo_kds.ca_arrays);
-		oeo->oeo_kds.ca_arrays = NULL;
 		oeo->oeo_kds.ca_count = 0;
 	}
 
@@ -3355,7 +3353,7 @@ obj_tgt_punch(struct dtx_leader_handle *dlh, void *arg, int idx,
 		if (DAOS_FAIL_CHECK(DAOS_DTX_LEADER_ERROR))
 			D_GOTO(comp, rc = -DER_IO);
 
-		if (dlh != NULL && dlh->dlh_handle.dth_prepared)
+		if (dlh->dlh_handle.dth_prepared)
 			goto comp;
 
 		rc = obj_local_punch(opi, opc_get(rpc->cr_opc), exec_arg->ioc,
@@ -4161,7 +4159,6 @@ out:
 				if (biods[i] != NULL)
 					bio_iod_post(biods[i]);
 			}
-
 		}
 
 		if (iohs != NULL) {


### PR DESCRIPTION
338866 and 332771.  Use assert to check for error state
331452 Promote a stack variable to 64 bit.
332885 and 332887.  Assume that dlh cannot be NULL.

Apply a number of automatic checkpatch corrections, and replace
the use of D_FREE_PTR with D_FREE

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>