### PR TITLE
DAOS-7833 test: Verify telemetry engine NVMe metrics (#6848)

### DIFF
--- a/src/bio/bio_internal.h
+++ b/src/bio/bio_internal.h
@@ -166,10 +166,6 @@ struct bio_dma_buffer {
 	X(bdh_temp_crit_time, "temp/crit_time",				\
 	  "Amount of time the controller operated above crit temp threshold",  \
 	  "minutes", D_TM_COUNTER)					\
-	X(bdh_percent_used, "reliability/percentage_used",		\
-	  "Estimate of the percentage of NVM subsystem life used based on the "\
-	  "actual usage and the manufacturer's prediction of NVM life",	\
-	  "%", D_TM_COUNTER)						\
 	X(bdh_avail_spare, "reliability/avail_spare",			\
 	  "Percentage of remaining spare capacity available",		\
 	  "%", D_TM_COUNTER)						\

--- a/src/tests/ftest/control/dmg_telemetry_nvme.py
+++ b/src/tests/ftest/control/dmg_telemetry_nvme.py
@@ -5,14 +5,64 @@
 SPDX-License-Identifier: BSD-2-Clause-Patent
 """
 from telemetry_test_base import TestWithTelemetry
+from apricot import TestWithServers
+from telemetry_utils import TelemetryUtils
 
-
-class TestWithTelemetryNvme(TestWithTelemetry):
+class TestWithTelemetryNvme(TestWithTelemetry,TestWithServers):
     # pylint: disable=too-many-ancestors
-    """Test container telemetry metrics.
+    # pylint: disable=too-many-nested-blocks
+    """Test telemetry engine NVMe metrics.
 
     :avocado: recursive
     """
+
+    def display_nvme_test_metrics(self, metrics_data):
+        """ Display NVMe metrics_data.
+
+        Args:
+            metrics_data (dict): a dictionary of host keys linked to a
+                                 list of NVMe metric names.
+        """
+        for key in sorted(metrics_data):
+            self.log.info(
+                    "\n  %12s: %s",
+                    "Initial " if key == 0 else "Test Loop {}".format(key),
+                    metrics_data[key])
+
+    def test_nvme_telemetry_metrics(self):
+        """JIRA ID: DAOS-7833
+
+            Verify the telemetry engine NVMe metrics.
+
+        :avocado: tags=all,pr,daily_regression
+        :avocado: tags=hw,small
+        :avocado: tags=control,telemetry,nvme
+        :avocado: tags=test_nvme_telemetry_metrics
+        """
+        metrics_data = self.telemetry.get_nvme_metrics(self.server_managers[0])
+        self.display_nvme_test_metrics(metrics_data)
+
+        # Get and verify NVMe metrics
+        groups = [
+                "ENGINE_NVME_HEALTH_METRICS",
+                "ENGINE_NVME_CRIT_WARN_METRICS",
+                "ENGINE_NVME_TEMP_METRICS",
+                "ENGINE_NVME_TEMP_TIME_METRICS",
+                "ENGINE_NVME_RELIABILITY_METRICS",
+                "ENGINE_NVME_INTEL_VENDOR_METRICS"]
+
+        for group in groups:
+            yaml_key = "_".join([group.lower().replace("engine_", ""), "valid"])
+            threshold = self.params.get(yaml_key, "/run/*", [None, None])
+            test_metrics = getattr(TelemetryUtils, group)
+            metrics_data = self.telemetry.get_nvme_metrics(self.server_managers[0], test_metrics)
+            desc = " ".join([item.lower() if item != "NVME" else item for item in group.split("_")])
+            self.log.info("Verify %s", desc)
+            status = self.telemetry.verify_metric_value(metrics_data, threshold[0], threshold[1])
+            if not status:
+                self.fail("##Telemetry test NVMe metrics verification failed.")
+
+        self.log.info("------Test passed------")
 
     def test_telemetry_list_nvme(self):
         """JIRA ID: DAOS-7667 / SRS-324.

--- a/src/tests/ftest/control/dmg_telemetry_nvme.yaml
+++ b/src/tests/ftest/control/dmg_telemetry_nvme.yaml
@@ -8,3 +8,8 @@ server_config:
   servers:
     bdev_class: nvme
     bdev_list: ["aaaa:aa:aa.a", "bbbb:bb:bb.b"]
+telemetry_metrics:
+  nvme_crit_warn_metrics_valid: [0, 1]
+  nvme_temp_metrics_valid: [280, 350]
+  nvme_temp_time_metrics_valid: [0, 4294967295]
+  nvme_reliability_metrics_valid: [0, 100]

--- a/src/tests/ftest/util/telemetry_utils.py
+++ b/src/tests/ftest/util/telemetry_utils.py
@@ -372,31 +372,35 @@ class TelemetryUtils():
         "process_start_time_seconds",
         "process_virtual_memory_bytes",
         "process_virtual_memory_max_bytes"]
-    ENGINE_NVME_METRICS = [
-        "engine_nvme_<id>_commands_checksum_mismatch",
-        "engine_nvme_<id>_commands_ctrl_busy_time",
-        "engine_nvme_<id>_commands_data_units_read",
+    ENGINE_NVME_HEALTH_METRICS = [
         "engine_nvme_<id>_commands_data_units_written",
-        "engine_nvme_<id>_commands_host_read_cmds",
+        "engine_nvme_<id>_commands_data_units_read",
         "engine_nvme_<id>_commands_host_write_cmds",
+        "engine_nvme_<id>_commands_host_read_cmds",
         "engine_nvme_<id>_commands_media_errs",
         "engine_nvme_<id>_commands_read_errs",
-        "engine_nvme_<id>_commands_unmap_errs",
         "engine_nvme_<id>_commands_write_errs",
+        "engine_nvme_<id>_commands_unmap_errs",
+        "engine_nvme_<id>_commands_checksum_mismatch",
         "engine_nvme_<id>_power_cycles",
+        "engine_nvme_<id>_commands_ctrl_busy_time",
         "engine_nvme_<id>_power_on_hours",
-        "engine_nvme_<id>_read_only_warn",
-        "engine_nvme_<id>_reliability_avail_spare",
-        "engine_nvme_<id>_reliability_avail_spare_threshold",
-        "engine_nvme_<id>_reliability_avail_spare_warn",
-        "engine_nvme_<id>_reliability_percentage_used",
-        "engine_nvme_<id>_reliability_reliability_warn",
-        "engine_nvme_<id>_temp_crit_time",
-        "engine_nvme_<id>_temp_current",
-        "engine_nvme_<id>_temp_warn",
+        "engine_nvme_<id>_unsafe_shutdowns"]
+    ENGINE_NVME_TEMP_METRICS = [
+        "engine_nvme_<id>_temp_current"]
+    ENGINE_NVME_TEMP_TIME_METRICS = [
         "engine_nvme_<id>_temp_warn_time",
-        "engine_nvme_<id>_unsafe_shutdowns",
-        "engine_nvme_<id>_volatile_mem_warn",
+        "engine_nvme_<id>_temp_crit_time"]
+    ENGINE_NVME_RELIABILITY_METRICS = [
+        "engine_nvme_<id>_reliability_avail_spare",
+        "engine_nvme_<id>_reliability_avail_spare_threshold"]
+    ENGINE_NVME_CRIT_WARN_METRICS = [
+        "engine_nvme_<id>_reliability_avail_spare_warn",
+        "engine_nvme_<id>_reliability_reliability_warn",
+        "engine_nvme_<id>_temp_warn",
+        "engine_nvme_<id>_read_only_warn",
+        "engine_nvme_<id>_volatile_mem_warn"]
+    ENGINE_NVME_INTEL_VENDOR_METRICS = [
         "engine_nvme_<id>_vendor_program_fail_cnt_norm",
         "engine_nvme_<id>_vendor_program_fail_cnt_raw",
         "engine_nvme_<id>_vendor_erase_fail_cnt_norm",
@@ -416,6 +420,12 @@ class TelemetryUtils():
         "engine_nvme_<id>_vendor_pll_lock_loss_cnt",
         "engine_nvme_<id>_vendor_nand_bytes_written",
         "engine_nvme_<id>_vendor_host_bytes_written"]
+    ENGINE_NVME_METRICS = ENGINE_NVME_HEALTH_METRICS +\
+        ENGINE_NVME_TEMP_METRICS +\
+        ENGINE_NVME_TEMP_TIME_METRICS +\
+        ENGINE_NVME_RELIABILITY_METRICS +\
+        ENGINE_NVME_CRIT_WARN_METRICS +\
+        ENGINE_NVME_INTEL_VENDOR_METRICS
 
     def __init__(self, dmg, servers):
         """Create a TelemetryUtils object.
@@ -678,3 +688,96 @@ class TelemetryUtils():
                 else:
                     errors.append("No {} data for {}".format(name, host))
         return errors
+
+    def get_nvme_metrics(self, server, specific_metrics=None):
+        """Get the NVMe telemetry metrics.
+
+        Args:
+            specific_metrics(list): list of specific NVMe metrics
+            server (DaosServerCommand): the server from which to determine what metrics
+                                        will be available
+
+        Returns:
+            dict: dictionary of dictionaries of NVMe metric names and
+                values per server host key
+
+        """
+        data = {}
+        if specific_metrics is None:
+            specific_metrics = self.ENGINE_NVME_METRICS
+
+        # Add NVMe metrics for any NVMe devices configured for this server
+        for nvme_list in server.manager.job.get_engine_values("bdev_list"):
+            for nvme in nvme_list if nvme_list is not None else []:
+                # Replace the '<id>' placeholder with the actual NVMe ID
+                nvme_id = nvme.replace(":", "_").replace(".", "_")
+                specific_metrics = [
+                    name.replace("<id>", nvme_id)
+                    for name in specific_metrics]
+
+        info = self.get_metrics(",".join(specific_metrics))
+        self.log.info("NVMe Telemetry Information")
+        for name in specific_metrics:
+            for index, host in enumerate(info):
+                if name in info[host]:
+                    if index == 0:
+                        self.log.info(
+                            "  %s (%s):",
+                            name, info[host][name]["description"])
+                        self.log.info(
+                            "    %-12s %-4s %s",
+                            "Host", "Rank", "Value")
+                    if name not in data:
+                        data[name] = {}
+                    if host not in data[name]:
+                        data[name][host] = {}
+                    for metric in info[host][name]["metrics"]:
+                        if "labels" in metric:
+                            if "rank" in metric["labels"]:
+                                rank = metric["labels"]["rank"]
+                                if rank not in data[name][host]:
+                                    data[name][host][rank] = {}
+                                data[name][host][rank] = \
+                                    metric["value"]
+                                self.log.info(
+                                    "    %-12s %-4s %s",
+                                    host, rank, metric["value"])
+        return data
+
+    def verify_metric_value(self, metrics_data, min_value=None, max_value=None):
+        """ Verify telemetry metrics from metrics_data.
+
+        Args:
+            metrics_data (dict): a dictionary of host keys linked to a list of metric names.
+            min_value (int): minimum value of test metrics threshold, 0 if not set
+            max_value (int): maximum value of test metrics threshold
+
+            Returns:
+                bool: True if all metrics are verified, False if any metrics are out of the
+                      allowable range or less than 0
+        """
+        self.log.info("Verify threshold of metrics")
+        status = True
+        invalid = ""
+        if min_value is None and max_value is None:
+            # Verify that the metric value is >0 if a range is not provided
+            min_value = 0
+
+        for name in sorted(metrics_data):
+            self.log.info("    --telemetry metric: %s", name)
+            self.log.info("    %-12s %-4s %s", "Host", "Rank", "Value")
+            for host in sorted(metrics_data[name]):
+                for rank in sorted(metrics_data[name][host]):
+                    value = metrics_data[name][host][rank]
+                    invalid = "Metric value in range"
+                    #Verify metrics are within allowable threshold
+                    if min_value is not None and value < min_value:
+                        status = False
+                        invalid = "Metric value is smaller than {}: {}".format(min_value, value)
+                    if max_value is not None and value > max_value:
+                        status = False
+                        invalid = "Metric value is larger than {}: {}".format(max_value, value)
+
+                    self.log.info("    %-12s %-4s %s %s",
+                                  host, rank, value, invalid)
+        return status


### PR DESCRIPTION
Added ftests for engine NVMe metrics verification. NVMe telemetry metrics are split into a few categories and
validated with the appropriate threshold.
Critical warnings 0 or 1
Temperature range 280K - 350K
Temperature time counters 0-4294967295
Reliability metrics 0% - 100%
The remaining NVMe metrics are just validated to be >= 0

Removed the engine_nvme__reliability_percentage_used stat as it was not getting set anywhere.

Signed-off-by: Sydney Vanda <sydney.m.vanda@intel.com>