### PR TITLE
DAOS-8773 dtx: restart distributed transaction if pool map refreshed

### DIFF
--- a/src/object/obj_tx.c
+++ b/src/object/obj_tx.c
@@ -1775,6 +1775,10 @@ dc_tx_commit_trigger(tse_task_t *task, struct dc_tx *tx, daos_tx_commit_t *args)
 	crt_endpoint_t			 tgt_ep;
 	int				 rc;
 
+	if (tx->tx_pm_ver != 0 && tx->tx_pm_ver != dc_pool_get_version(tx->tx_pool) &&
+	    (tx->tx_retry || tx->tx_read_cnt > 0))
+		D_GOTO(out, rc = -DER_TX_RESTART);
+
 	if (!tx->tx_retry) {
 		rc = dc_tx_commit_prepare(tx, task);
 		if (rc != 0) {


### PR DESCRIPTION
master-commit: baa1904525a47426d29f7856e41ecf685f66f6ee

On the client, when prepare CPD RPC for the distributed transaction,
we need to check whether the pool map is freshed after the transaction
started or not. If yes, we need to restart the transaction, because the
layout for the touched objects may have been changed and related time
stamps for the distributed transaction may be lost on related servers.

Signed-off-by: Fan Yong <fan.yong@intel.com>