### PR TITLE
DAOS-8685 test: configure default nr_xs_helpers: 4

### DIFF
--- a/src/tests/ftest/server/cpu_usage.yaml
+++ b/src/tests/ftest/server/cpu_usage.yaml
@@ -7,9 +7,8 @@ timeout: 130
 server_config:
   nr_hugepages: 8192
   servers:
-    # 16 targets and 16 nr_xs_helpers are the requirements.
-    targets: 16
-    nr_xs_helpers: 16
+    targets: 8
+    nr_xs_helpers: 8
     bdev_class: nvme
     bdev_list: ["0000:00:00.0"]
     scm_class: dcpm

--- a/src/tests/ftest/server/metadata.yaml
+++ b/src/tests/ftest/server/metadata.yaml
@@ -29,7 +29,7 @@ server_config:
       scm_list: ["/dev/pmem0"]
       # common items below (same in server 0 and server 1)
       scm_class: dcpm
-      nr_xs_helpers: 16
+      nr_xs_helpers: 4
       log_mask: DEBUG,MEM=ERR
       env_vars:
         - DAOS_MD_CAP=128
@@ -45,7 +45,7 @@ server_config:
       scm_list: ["/dev/pmem1"]
       # common items below (same in server 0 and server 1)
       scm_class: dcpm
-      nr_xs_helpers: 16
+      nr_xs_helpers: 4
       log_mask: DEBUG,MEM=ERR
       env_vars:
         - DAOS_MD_CAP=128

--- a/src/tests/ftest/util/server_utils_params.py
+++ b/src/tests/ftest/util/server_utils_params.py
@@ -358,7 +358,7 @@ class DaosServerYamlParameters(YamlParameters):
             #           - CRT_CTX_NUM=8
             self.targets = BasicParameter(None, 8)
             self.first_core = BasicParameter(None, 0)
-            self.nr_xs_helpers = BasicParameter(None, 16)
+            self.nr_xs_helpers = BasicParameter(None, 4)
             self.fabric_iface = BasicParameter(None, default_interface)
             self.fabric_iface_port = BasicParameter(None, default_port)
             self.pinned_numa_node = BasicParameter(None)


### PR DESCRIPTION
Cherry-pick PR #7040 master commit b7311ec to release/2.0 branch.

Before this change, if a functional test .yaml file did not specify
nr_xs_helpers, the server_utils_params.py code would set it to 16.
This would result in (along with a default of 8 targets), at least
24 threads (8 target pthreads, 16 helpers) along with the usual
system xstream and swim xstream threads. If run on a (for example)
single CPU of a dual-CPU system with 18 physical cores per CPU,
there is concern for oversubscription and possible CPU scheduling
contention - that may be more pronounced in particular OS / kernel
versions.

With this change, the default setting is 4 helpers, one helper thread
responsible for 2 (of the default 8) targets.

Test-tag: pr daily_regression metadata_fillup metadata_addremove cpu_usage

Signed-off-by: Kenneth Cain <kenneth.c.cain@intel.com>