### PR TITLE
DAOS-8685 pool: run create tests with logging, CentOS8 HW

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,7 +12,7 @@
 
 // To use a test branch (i.e. PR) until it lands to master
 // I.e. for testing library changes
-//@Library(value="pipeline-lib@your_branch") _
+@Library(value="pipeline-lib@bmurrell/run-prs-on-el8-hw") _
 
 // For master, this is just some wildly high number
 next_version = "1000"
@@ -1054,7 +1054,7 @@ pipeline {
                     }
                     steps {
                         functionalTest inst_repos: daosRepos(),
-                                       inst_rpms: functionalPackages(1, next_version),
+                                       inst_rpms: functionalPackages("centos8", 1, next_version),
                                        test_function: 'runTestFunctionalV2'
                     }
                     post {
@@ -1075,7 +1075,7 @@ pipeline {
                     steps {
                         functionalTest target: hwDistroTarget(),
                                        inst_repos: daosRepos(),
-                                       inst_rpms: functionalPackages(1, next_version),
+                                       inst_rpms: functionalPackages("centos8", 1, next_version),
                                        test_function: 'runTestFunctionalV2'
                    }
                     post {
@@ -1096,7 +1096,7 @@ pipeline {
                     steps {
                         functionalTest target: hwDistroTarget(),
                                        inst_repos: daosRepos(),
-                                       inst_rpms: functionalPackages(1, next_version),
+                                       inst_rpms: functionalPackages("centos8", 1, next_version),
                                        test_function: 'runTestFunctionalV2'
                     }
                     post {

--- a/ci/functional/required_packages.sh
+++ b/ci/functional/required_packages.sh
@@ -32,7 +32,10 @@ elif [[ $distro = el* ]] || [[ $distro = centos* ]] ||
           hdf5-vol-daos-mpich-tests    \
           MACSio-mpich                 \
           MACSio-$openmpi              \
-          mpifileutils-mpich"
+          mpifileutils-mpich           \
+          numactl                      \
+          sysstat                      \
+          hwloc"
 else
     echo "I don't know which packages should be installed for distro"
          "\"$distro\""

--- a/ci/provisioning/post_provision_config_common.sh
+++ b/ci/provisioning/post_provision_config_common.sh
@@ -55,7 +55,7 @@ retry_cmd() {
         fi
         # Command failed, retry
         rc=${PIPESTATUS[0]}
-        (( attempt++ ))
+        (( attempt++ )) || true
         if [ "$attempt" -gt 0 ]; then
             sleep "${RETRY_DELAY_SECONDS:-$DAOS_STACK_RETRY_DELAY_SECONDS}"
         fi
@@ -84,7 +84,7 @@ timeout_cmd() {
         rc=${PIPESTATUS[0]}
         if [ "$rc" = "124" ]; then
             # Command timed out, try again
-            (( attempt++ ))
+            (( attempt++ )) || true
             continue
         fi
         # Command failed for something other than timeout

--- a/ci/provisioning/post_provision_config_nodes_EL_7.sh
+++ b/ci/provisioning/post_provision_config_nodes_EL_7.sh
@@ -46,6 +46,7 @@ EOF
 
     # Mellanox OFED hack
     if ls -d /usr/mpi/gcc/openmpi-*; then
+        mkdir -p /etc/modulefiles/mpi/
         cat <<EOF > /etc/modulefiles/mpi/mlnx_openmpi-x86_64
 #%Module 1.0
 #

--- a/ci/provisioning/post_provision_config_nodes_EL_8.sh
+++ b/ci/provisioning/post_provision_config_nodes_EL_8.sh
@@ -6,7 +6,7 @@ LSB_RELEASE=redhat-lsb-core
 EXCLUDE_UPGRADE=dpdk,fuse,mercury,daos,daos-\*
 
 bootstrap_dnf() {
-    :
+    dnf -y erase openmpi opensm-libs
 }
 
 group_repo_post() {
@@ -15,22 +15,9 @@ group_repo_post() {
 }
 
 distro_custom() {
-    # force install of avocado 69.x
-    dnf -y erase avocado{,-common}                                              \
-                 python2-avocado{,-plugins-{output-html,varianter-yaml-to-mux}} \
-                 python3-pyyaml
-    pip3 install "avocado-framework<70.0"
-    pip3 install "avocado-framework-plugin-result-html<70.0"
-    pip3 install "avocado-framework-plugin-varianter-yaml-to-mux<70.0"
-    pip3 install clustershell
-
-    if ! rpm -q nfs-utils; then
-        retry_cmd 360 dnf -y install nfs-utils
-    fi
-
-    # CORCI-1096
-    dnf -y install esmtp
-    sed -e 's/^\(hostname *= *\)[^ ].*$/\1 mail.wolf.hpdd.intel.com:25/' < /usr/share/doc/esmtp/sample.esmtprc > /etc/esmtprc
+    # install avocado
+    dnf -y install python3-avocado{,-plugins-{output-html,varianter-yaml-to-mux}} \
+                   clustershell
 
     dnf config-manager --disable powertools
 
@@ -94,10 +81,13 @@ post_provision_config_nodes() {
     retry_cmd 360 dnf -y install $LSB_RELEASE
 
     # shellcheck disable=SC2086
-    if [ -n "$INST_RPMS" ] && ! retry_cmd 360 dnf -y install $INST_RPMS; then
-        rc=${PIPESTATUS[0]}
-        dump_repos
-        exit "$rc"
+    if [ -n "$INST_RPMS" ]; then
+        if ! retry_cmd 360 dnf -y install $INST_RPMS; then
+            rc=${PIPESTATUS[0]}
+            dump_repos
+            #sleep 600
+            exit "$rc"
+        fi
     fi
 
     distro_custom
@@ -112,6 +102,8 @@ post_provision_config_nodes() {
         cat /etc/do-release
     fi
     cat /etc/os-release
+
+    rpm -qa | sort
 
     exit 0
 }

--- a/site_scons/env_modules.py
+++ b/site_scons/env_modules.py
@@ -25,8 +25,8 @@ import sys
 import errno
 import distro
 import subprocess #nosec
+import shutil
 from subprocess import PIPE, Popen #nosec
-from SCons.Script import WhereIs
 
 class _env_module(): # pylint: disable=invalid-name
     """Class for utilizing Modules component to load environment modules"""
@@ -120,7 +120,7 @@ class _env_module(): # pylint: disable=invalid-name
         for to_load in load:
             self._module_func('load', to_load)
             print("Looking for %s" % to_load)
-            if WhereIs('mpirun'):
+            if shutil.which('mpirun'):
                 print("Loaded %s" % to_load)
                 return True
         return False
@@ -146,7 +146,7 @@ class _env_module(): # pylint: disable=invalid-name
         if not self._module_load(mpi):
             print("No %s found\n" % mpi)
             return False
-        exe_path = WhereIs('mpirun')
+        exe_path = shutil.which('mpirun')
         if not exe_path:
             print("No mpirun found in path. Could not configure %s\n" % mpi)
             return False
@@ -166,7 +166,7 @@ def load_mpi(mpi):
     # On Ubuntu, MPI stacks use alternatives and need root to change their
     # pointer, so just verify that the desired MPI is loaded
     if distro.id() == "ubuntu":
-        updatealternatives = WhereIs('update-alternatives')
+        updatealternatives = shutil.which('update-alternatives')
         if not updatealternatives:
             print("No update-alternatives found in path.")
             return False

--- a/src/engine/srv.c
+++ b/src/engine/srv.c
@@ -322,6 +322,12 @@ dss_srv_handler(void *arg)
 	struct dss_module_info		*dmi;
 	int				 rc;
 	bool				 signal_caller = true;
+	unsigned int			 i;
+
+	hwloc_bitmap_foreach_begin(i, dx->dx_cpuset) {
+		D_INFO("XS id %d : %s : cpuset index %u is set for cpubind and membind",
+		       dx->dx_xs_id, dx->dx_name, i);
+	} hwloc_bitmap_foreach_end();
 
 	/**
 	 * Set cpu affinity
@@ -339,7 +345,7 @@ dss_srv_handler(void *arg)
 	rc = hwloc_set_membind(dss_topo, dx->dx_cpuset, HWLOC_MEMBIND_BIND,
 			       HWLOC_MEMBIND_THREAD);
 	if (rc)
-		D_DEBUG(DB_TRACE, "failed to set memory affinity: %d\n", errno);
+		D_WARN("failed to set memory affinity: %d\n", errno);
 
 	/* initialize xstream-local storage */
 	dtc = dss_tls_init(DAOS_SERVER_TAG, dx->dx_xs_id, dx->dx_tgt_id);
@@ -832,6 +838,8 @@ dss_start_xs_id(int xs_id)
 	D_DEBUG(DB_TRACE, "start xs_id called for %d.  ", xs_id);
 	/* if we are NUMA aware, use the NUMA information */
 	if (numa_obj) {
+		D_INFO("xs_id %d : Using NUMA-aware core allocation\n", xs_id);
+
 		idx = hwloc_bitmap_first(core_allocation_bitmap);
 		if (idx == -1) {
 			D_ERROR("No core available for XS: %d", xs_id);
@@ -853,10 +861,10 @@ dss_start_xs_id(int xs_id)
 		}
 
 		hwloc_bitmap_asprintf(&cpuset, obj->cpuset);
-		D_DEBUG(DB_TRACE, "Using CPU set %s\n", cpuset);
+		D_INFO("xs_id %d : Using CPU set %s\n", xs_id, cpuset);
 		free(cpuset);
 	} else {
-		D_DEBUG(DB_TRACE, "Using non-NUMA aware core allocation\n");
+		D_INFO("xs id %d : Using non-NUMA aware core allocation\n", xs_id);
 		/*
 		 * All system XS will use the first core, but
 		 * the SWIM XS will use separate core if enough cores

--- a/src/tests/ftest/harness/basic.py
+++ b/src/tests/ftest/harness/basic.py
@@ -27,7 +27,7 @@ class HarnessBasicTest(Test):
 
         :avocado: tags=all
         :avocado: tags=hw,large,medium,ib2,small
-        :avocado: tags=harness,harness_basic_test,test_always_passes_hw
+        :avocado: tags=harness,harness_basic_test,test_always_passes,test_always_passes_hw
         :avocado: tags=always_passes
         """
         self.test_always_passes()

--- a/src/tests/ftest/pool/create.py
+++ b/src/tests/ftest/pool/create.py
@@ -5,6 +5,7 @@
 SPDX-License-Identifier: BSD-2-Clause-Patent
 """
 from pool_test_base import PoolTestBase
+from general_utils import run_pcmd
 
 
 class PoolCreateTests(PoolTestBase):
@@ -66,6 +67,9 @@ class PoolCreateTests(PoolTestBase):
         :avocado: tags=pool
         :avocado: tags=pool_create_tests,create_no_space
         """
+        # quick hack, let's see what hwloc-ls shows on each server node
+        run_pcmd(self.server_managers[0].hosts, "hwloc-ls")
+
         # Define three pools to create:
         #   - one pool using 90% of the available capacity of one server
         #   - one pool using 90% of the available capacity of all servers
@@ -119,6 +123,10 @@ class PoolCreateTests(PoolTestBase):
         :avocado: tags=pool
         :avocado: tags=pool_create_tests,create_no_space_loop
         """
+
+        # quick hack, let's see what hwloc-ls shows on each server node
+        run_pcmd(self.server_managers[0].hosts, "hwloc-ls")
+
         # Define three pools to create:
         #   - one pool using 90% of the available capacity of one server
         #   - one pool using 90% of the available capacity of all servers

--- a/src/tests/ftest/pool/create.yaml
+++ b/src/tests/ftest/pool/create.yaml
@@ -14,15 +14,26 @@ timeouts:
   test_create_max_pool: 300
   test_create_no_space: 300
   test_create_no_space_loop: 2160
+#numactl hack
+#setup:
+#  server_manager_class: Orterun
 server_config:
   name: daos_server
+  control_log_mask: DEBUG
   servers:
     0:
+      pinned_numa_node: 0
       bdev_class: nvme
       bdev_list: ["aaaa:aa:aa.a", "bbbb:bb:bb.b"]
       scm_class: dcpm
       scm_list: ["/dev/pmem0"]
       scm_mount: /mnt/daos0
+      log_mask: DEBUG,MEM=ERR,SWIM=ERR
+      env_vars:
+        # DD_MASK all except mem
+        - DD_MASK=any,trace,net,io,md,pl,mgmt,epc,df,rebuild,sec,csum,dsms,any
+        - DAOS_SCHED_WATCHDOG_ALL=1
+        # - DAOS_SCHED_RELAX_MODE=disabled
 pool_1:
   name: daos_server
   control_method: dmg

--- a/src/tests/ftest/scripts/setup_nodes.sh
+++ b/src/tests/ftest/scripts/setup_nodes.sh
@@ -43,7 +43,7 @@ if [ \"\$(ulimit -c)\" != \"unlimited\" ]; then
     echo \"*  soft  core  unlimited\" >> /etc/security/limits.conf
 fi
 echo \"/var/tmp/core.%e.%t.%p\" > /proc/sys/kernel/core_pattern"
-rm -f /var/tmp/core.*
+sudo rm -f /var/tmp/core.*
 if [ "${HOSTNAME%%.*}" != "$FIRST_NODE" ]; then
     if grep /mnt/daos\  /proc/mounts; then
         sudo umount /mnt/daos

--- a/src/tests/ftest/util/general_utils.py
+++ b/src/tests/ftest/util/general_utils.py
@@ -406,17 +406,34 @@ def run_pcmd(hosts, command, verbose=True, timeout=None, expect_rc=0):
         for item in results
         if expect_rc is not None and item["exit_status"] != expect_rc]
     if verbose or bad_exit_status:
-        log.info("Command: %s", command)
-        log.info("Results:")
-        for result in results:
-            log.info(
-                "  %s: exit_status=%s, interrupted=%s:",
-                result["hosts"], result["exit_status"], result["interrupted"])
-            for line in result["stdout"]:
-                log.info("    %s", line)
+        log.info(colate_results(command, results))
 
     return results
 
+
+def colate_results(command, results):
+    """Colate the output of run_pcmd.
+
+    Args:
+        command (str): command used to obtain the data on each server
+        results (list): list: a list of dictionaries with each entry
+                        containing output, exit status, and interrupted
+                        status common to each group of hosts (see run_pcmd()'s
+                        return for details)
+    Returns:
+        str: a string colating run_pcmd()'s results
+
+    """
+    res = ""
+    res += "Command: %s\n" % command
+    res += "Results:\n"
+    for result in results:
+        res += "  %s: exit_status=%s, interrupted=%s:" % (
+               result["hosts"], result["exit_status"], result["interrupted"])
+        for line in result["stdout"]:
+            res += "    %s\n" % line
+
+    return res
 
 def get_host_data(hosts, command, text, error, timeout=None):
     """Get the data requested for each host using the specified command.

--- a/src/tests/ftest/util/server_utils.py
+++ b/src/tests/ftest/util/server_utils.py
@@ -14,7 +14,7 @@ import yaml
 from avocado import fail_on
 
 from command_utils_base import CommandFailure, CommonConfig
-from command_utils import SubprocessManager
+from command_utils import SubprocessManager, ExecutableCommand
 from general_utils import pcmd, get_log_file, human_to_bytes, bytes_to_human, \
     convert_list, get_default_config_file, distribute_files, DaosTestError, \
     stop_processes, get_display_size, run_pcmd
@@ -24,7 +24,6 @@ from server_utils_base import \
 from server_utils_params import \
     DaosServerTransportCredentials, DaosServerYamlParameters
 from ClusterShell.NodeSet import NodeSet
-
 
 def get_server_command(group, cert_dir, bin_dir, config_file, config_temp=None):
     """Get the daos_server command object to manage.
@@ -91,6 +90,8 @@ class DaosServerManager(SubprocessManager):
                 manage the YamlCommand defined through the "job" attribute.
                 Defaults to "Orterun".
         """
+        self.pidstatstartcmd = None
+        self.pidstatstopcmd = None
         self.group = group
         server_command = get_server_command(
             group, svr_cert_dir, bin_dir, svr_config_file, svr_config_temp)
@@ -483,6 +484,14 @@ class DaosServerManager(SubprocessManager):
         # Wait for all the engines to start
         self.detect_engine_start()
 
+        # Start pidstat in the background to monitor context switches of daos_server, daos_engine
+        startcmd = "clush -w {} 'pidstat -C daos_ -tw 1 > {} 2>&1'".format(
+            ",".join(self.hosts), get_log_file("daos_pidstat.log"))
+        stopcmd = "clush -w {} 'pkill pidstat'".format(",".join(self.hosts))
+        self.pidstatstartcmd = ExecutableCommand("pidstat", startcmd, subprocess=True)
+        self.pidstatstartcmd.run()
+        self.pidstatstopcmd = ExecutableCommand("pkill_pidstat", stopcmd, subprocess=False)
+
         return True
 
     def stop(self):
@@ -500,6 +509,13 @@ class DaosServerManager(SubprocessManager):
             messages.append(
                 "Error stopping the {} subprocess: {}".format(
                     self.manager.command, error))
+        finally:
+            if self.pidstatstartcmd is not None:
+                try:
+                    self.pidstatstartcmd.stop()
+                    self.pidstatstopcmd.run()
+                except CommandFailure as error:
+                    messages.append("Error stopping pidstat: {}".format(error))
 
         # Kill any leftover processes that may not have been stopped correctly
         self.manager.kill()

--- a/src/tests/ftest/util/server_utils_base.py
+++ b/src/tests/ftest/util/server_utils_base.py
@@ -177,6 +177,19 @@ class DaosServerCommand(YamlCommand):
             engine_values = self.yaml.get_engine_values(name)
         return engine_values
 
+    #numactl hack
+    #def __str__(self):
+    #
+    #    """Return the command with all of its defined parameters as a string.
+    #
+    #    Returns:
+    #
+    #        str: the command with all the defined parameters
+    #
+    #    """
+    #
+    #    return " ".join(["numactl --cpunodebind=1", super().__str__()])
+
     class NetworkSubCommand(CommandWithSubCommand):
         """Defines an object for the daos_server network sub command."""
 

--- a/src/vos/vos_pool.c
+++ b/src/vos/vos_pool.c
@@ -295,6 +295,9 @@ vos_pool_create(const char *path, uuid_t uuid, daos_size_t scm_sz,
 		return daos_errno2der(errno);
 	}
 
+	D_DEBUG(DB_MGMT, "Pool Path: %s, SCM size: "DF_U64", UUID: "DF_UUID
+		", call vos_pmemobj_create()\n", path, scm_sz, DP_UUID(uuid));
+
 	ph = vos_pmemobj_create(path, POBJ_LAYOUT_NAME(vos_pool_layout), scm_sz,
 				0600);
 	if (!ph) {
@@ -303,6 +306,9 @@ vos_pool_create(const char *path, uuid_t uuid, daos_size_t scm_sz,
 			scm_sz, pmemobj_errormsg());
 		return daos_errno2der(rc);
 	}
+
+	D_DEBUG(DB_MGMT, "Pool Path: %s, UUID: "DF_UUID", call pmemobj_ctl_set()\n",
+		path, DP_UUID(uuid));
 
 	rc = pmemobj_ctl_set(ph, "stats.enabled", &enabled);
 	if (rc) {
@@ -394,6 +400,8 @@ end:
 	blob_hdr.bbh_hdr_sz = VOS_BLOB_HDR_BLKS;
 	uuid_copy(blob_hdr.bbh_pool, uuid);
 
+	D_DEBUG(DB_MGMT, "xs:%p pool:"DF_UUID", call vea_format()\n", xs_ctxt, DP_UUID(uuid));
+
 	/* Format SPDK blob*/
 	rc = vea_format(&umem, vos_txd_get(), &pool_df->pd_vea_df, VOS_BLK_SZ,
 			VOS_BLOB_HDR_BLKS, nvme_sz, vos_blob_format_cb,
@@ -406,6 +414,8 @@ end:
 		goto close;
 	}
 
+	D_DEBUG(DB_MGMT, "xs:%p pool:"DF_UUID", done vea_format()\n", xs_ctxt, DP_UUID(uuid));
+
 open:
 	/* If the caller does not want a VOS pool handle, we're done. */
 	if (poh == NULL)
@@ -414,6 +424,8 @@ open:
 	/* Create a VOS pool handle using ph. */
 	rc = pool_open(ph, pool_df, uuid, flags, poh);
 	ph = NULL;
+
+	D_DEBUG(DB_MGMT, "xs:%p pool:"DF_UUID", done pool_open()\n", xs_ctxt, DP_UUID(uuid));
 
 close:
 	/* Close this local handle, if it hasn't been consumed nor already

--- a/utils/rpms/daos.spec
+++ b/utils/rpms/daos.spec
@@ -14,7 +14,7 @@
 
 Name:          daos
 Version:       2.1.100
-Release:       2%{?relval}%{?dist}
+Release:       3%{?relval}%{?dist}
 Summary:       DAOS Storage Engine
 
 License:       BSD-2-Clause-Patent
@@ -228,6 +228,18 @@ Requires: libpsm_infinipath1
 %description tests
 This is the package needed to run the DAOS test suite
 
+
+%package tests-openmpi
+Summary: The DAOS test suite - tools which need openmpi
+#This is a bit messy and needs some cleanup.  In theory,
+#we should have client tests and server tests in separate
+#packages but some binaries need libraries from both at
+#present.
+Requires: %{name}-tests%{?_isa} = %{version}-%{release}
+
+%description tests-openmpi
+This is the package needed to run the DAOS test suite openmpi tools
+
 %package devel
 Summary: The DAOS development libraries and headers
 Requires: %{name}-client%{?_isa} = %{version}-%{release}
@@ -429,7 +441,6 @@ getent passwd daos_agent >/dev/null || useradd -s /sbin/nologin -r -g daos_agent
 %dir %{_prefix}/lib/daos
 %{_prefix}/lib/daos/TESTING
 %{_bindir}/hello_drpc
-%{_bindir}/jobtest
 %{_libdir}/libdaos_tests.so
 %{_bindir}/jump_pl_map
 %{_bindir}/ring_pl_map
@@ -437,18 +448,9 @@ getent passwd daos_agent >/dev/null || useradd -s /sbin/nologin -r -g daos_agent
 %{_bindir}/smd_ut
 %{_bindir}/vea_ut
 %{_bindir}/vea_stress
-%{_bindir}/daos_perf
-%{_bindir}/vos_perf
-%{_bindir}/daos_racer
 %{_bindir}/evt_ctl
 %{_bindir}/io_conf
 %{_bindir}/rdbt
-%{_bindir}/obj_ctl
-%{_bindir}/daos_gen_io_conf
-%{_bindir}/daos_run_io_conf
-%{_bindir}/crt_launch
-%{_bindir}/daos_test
-%{_bindir}/dfs_test
 %{_bindir}/common_test
 %{_bindir}/acl_dump_test
 %{_bindir}/agent_tests
@@ -464,6 +466,18 @@ getent passwd daos_agent >/dev/null || useradd -s /sbin/nologin -r -g daos_agent
 # For avocado tests
 %{_prefix}/lib/daos/.build_vars.json
 %{_prefix}/lib/daos/.build_vars.sh
+
+%files tests-openmpi
+%{_bindir}/crt_launch
+%{_bindir}/daos_gen_io_conf
+%{_bindir}/daos_perf
+%{_bindir}/daos_racer
+%{_bindir}/daos_run_io_conf
+%{_bindir}/daos_test
+%{_bindir}/dfs_test
+%{_bindir}/jobtest
+%{_bindir}/obj_ctl
+%{_bindir}/vos_perf
 %{_libdir}/libdts.so
 
 %files devel
@@ -481,6 +495,9 @@ getent passwd daos_agent >/dev/null || useradd -s /sbin/nologin -r -g daos_agent
 %{_libdir}/libdaos_serialize.so
 
 %changelog
+* Fri Oct 15 2021 Brian J. Murrell <brian.murrell@intel.com> 2.1.100-3
+- Create new daos-tests-openmpi subpackage
+
 * Mon Oct 13 2021 David Quigley <david.quigley@intel.com> 2.1.100-2
 - Add defusedxml as a required dependency for the test package.
 


### PR DESCRIPTION
This is PR-6741 contents, rebased on 22 October 2021 master.
- Plus a change to create.yaml to add server and engine debug logs.
  and to set DAOS_SCHED_WATCHDOG_ALL=1
- Plus a change to run pidstat at 1 second intervals on server nodes
  to keep an eye on voluntary and non-voluntary context switches
  for all daos_server and daos_engine threads.
- back out change to run daos_server and threads on NUMA node 1 while
  keeping daos_engine and its threads on NUMA node 0.
- Plus a change in dss_srv_handler() to print hwloc_cpuset_t dx_cpuset
  and warn rather than trace debug log if hwloc_set_membind() fails.
- And some logging of dss_thread_collective intended to see timing
  of task creation for each target-specific xs
- And an attempt to capture hwloc-ls output on each server node.
- Intent to run pool/create.py with most recent vea performance
  improvements.

Quick-Functional: true
Skip-coverity-test: true
Skip-func-test-vm: true
Skip-func-hw-test-small: true
Skip-func-hw-test-medium: true
Skip-func-hw-test-large: false
Func-hw-test-distro: el8.4
Skip-scan-centos-rpms: true
Skip-scan-leap15-rpms: true
Skip-test-centos-rpms: true
Skip-test-centos-8.3-rpms: true
Skip-test-leap-15-rpms: true
Allow-unstable-test: true
Skip-PR-comments: true
Test-tag: create_no_space create_no_space_loop

Signed-off-by: Kenneth Cain <kenneth.c.cain@intel.com>