### PR TITLE
DAOS-8819 test: fix dfuse mount point check (#6986)

### DIFF
--- a/src/tests/ftest/util/dfuse_utils.py
+++ b/src/tests/ftest/util/dfuse_utils.py
@@ -122,7 +122,7 @@ class Dfuse(DfuseCommand):
                 if retcode == 0:
                     check_mounted.add(host)
                 else:
-                    command = "cat /proc/mounts | grep dfuse"
+                    command = "grep 'dfuse {}' /proc/mounts" .format(self.mount_dir.value)
                     retcodes = pcmd([host], command, expect_rc=None)
                     for ret_code, host_names in list(retcodes.items()):
                         for node in host_names:


### PR DESCRIPTION
Quick-functional: true
Test-tag: dfuse,-findcmd_perf,-iorinterceptbasic,-largefilecount

Instead of a simple:
cat /proc/mounts | grep dfuse
We need to include the directory as well:
cat /proc/mounts | grep dfuse <mount_dir>
Otherwise multiple dfuse mount points are not supported.

Signed-off-by: Dalton Bohning <dalton.bohning@intel.com>