### PR TITLE
CART-89 uris: Fix uri parsing

### DIFF
--- a/src/cart/utils/crt_utils.c
+++ b/src/cart/utils/crt_utils.c
@@ -316,7 +316,7 @@ crtu_load_group_from_file(const char *grp_cfg_file, crt_context_t ctx,
 	}
 
 	while (1) {
-		rc = fscanf(f, "%8d %32s", &parsed_rank, parsed_addr);
+		rc = fscanf(f, "%8d %254s", &parsed_rank, parsed_addr);
 		if (rc == EOF) {
 			rc = 0;
 			break;


### PR DESCRIPTION
- URI parsing was limiting URIs to 32 characters, causing longer
uris like ofi+tcp;ofi_rxm://addr:port to exceed the limit
- Set limit to 254 instead

Singed-off-by: Alexander Oganezov <alexander.a.oganezov@intel.com>