### PR TITLE
DAOS-8675 vea: Misc fixes (#6962)

### DIFF
--- a/src/engine/sched.c
+++ b/src/engine/sched.c
@@ -653,7 +653,7 @@ check_space_pressure(struct dss_xstream *dx, struct sched_pool_info *spi)
 
 	if (spi->spi_space_pressure != SCHED_SPACE_PRESS_NONE &&
 	    spi->spi_space_pressure != orig_pressure) {
-		D_INFO("XS(%d): pool:"DF_UUID" is under %d presure, "
+		D_INFO("XS(%d): pool:"DF_UUID" is under %d pressure, "
 		       "SCM: tot["DF_U64"], sys["DF_U64"], free["DF_U64"] "
 		       "NVMe: tot["DF_U64"], sys["DF_U64"], free["DF_U64"]\n",
 		       dx->dx_xs_id, DP_UUID(spi->spi_pool_id),

--- a/src/vea/tests/vea_ut.c
+++ b/src/vea/tests/vea_ut.c
@@ -333,7 +333,6 @@ static void
 ut_free(void **state)
 {
 	struct vea_ut_args *args = *state;
-	struct vea_hint_context *h_ctxt;
 	struct vea_resrvd_ext *ext;
 	d_list_t *r_list;
 	uint64_t blk_off;
@@ -361,17 +360,8 @@ ut_free(void **state)
 	print_message("persistent free extents:\n");
 	vea_dump(args->vua_vsi, false);
 
-	/* wait for free extents expire */
-	print_message("wait for %d seconds ...\n", VEA_MIGRATE_INTVL);
-	sleep(VEA_MIGRATE_INTVL);
-	/* call reserve to trigger free extents migration */
-	r_list = &args->vua_resrvd_list[0];
-	h_ctxt = args->vua_hint_ctxt[0];
-	rc = vea_reserve(args->vua_vsi, 1, h_ctxt, r_list);
-	assert_rc_equal(rc, 0);
-
-	rc = vea_cancel(args->vua_vsi, h_ctxt, r_list);
-	assert_int_equal(rc, 0);
+	/* call vea_flush to trigger free extents migration */
+	vea_flush(args->vua_vsi, false);
 
 	r_list = &args->vua_alloc_list;
 	d_list_for_each_entry(ext, r_list, vre_link) {

--- a/src/vea/vea_alloc.c
+++ b/src/vea/vea_alloc.c
@@ -392,9 +392,6 @@ persistent_alloc(struct vea_space_info *vsi, struct vea_free_extent *vfe)
 		if (found_end > vfe_end) {
 			frag.vfe_blk_off = vfe->vfe_blk_off + vfe->vfe_blk_cnt;
 			frag.vfe_blk_cnt = found_end - vfe_end;
-			rc = daos_gettime_coarse(&frag.vfe_age);
-			if (rc)
-				return rc;
 
 			d_iov_set(&key_in, &frag.vfe_blk_off,
 				  sizeof(frag.vfe_blk_off));
@@ -411,9 +408,6 @@ persistent_alloc(struct vea_space_info *vsi, struct vea_free_extent *vfe)
 
 		found->vfe_blk_off = vfe->vfe_blk_off + vfe->vfe_blk_cnt;
 		found->vfe_blk_cnt = found_end - vfe_end;
-		rc = daos_gettime_coarse(&found->vfe_age);
-		if (rc)
-			return rc;
 	} else {
 		/* Remove the original free extent from persistent tree */
 		rc = dbtree_delete(btr_hdl, BTR_PROBE_BYPASS, &key_out, NULL);

--- a/src/vea/vea_api.c
+++ b/src/vea/vea_api.c
@@ -88,7 +88,7 @@ vea_format(struct umem_instance *umem, struct umem_tx_stage_data *txd,
 	 * Extent block count is represented by uint32_t, make sure the
 	 * largest extent won't overflow.
 	 */
-	if (tot_blks >= UINT32_MAX) {
+	if (tot_blks > UINT32_MAX) {
 		D_ERROR("Capacity "DF_U64" is too large.\n", capacity);
 		return -DER_INVAL;
 	}
@@ -308,10 +308,7 @@ vea_reserve(struct vea_space_info *vsi, uint32_t blk_cnt,
 	/* Get hint offset */
 	hint_get(hint, &resrvd->vre_hint_off);
 
-migrate:
-	/* Trigger free extents migration */
-	migrate_free_exts(vsi, false);
-
+retry:
 	/* Reserve from hint offset */
 	rc = reserve_hint(vsi, blk_cnt, resrvd);
 	if (rc != 0)
@@ -339,7 +336,9 @@ migrate:
 	if (rc == -DER_NOSPACE && retry) {
 		vsi->vsi_agg_time = 0; /* force free extents migration */
 		retry = false;
-		goto migrate;
+		/* Trigger free extents migration */
+		migrate_free_exts(vsi, false);
+		goto retry;
 	} else if (rc != 0) {
 		goto error;
 	}


### PR DESCRIPTION
- Fixed vea_format() to support upto 16TB instead of < 16TB capacity.

- Don't store free extent age in persistent heap, otherwise,
  reconstructing LRU list on heap loading could take a very long time.
  It's acceptable to reset LRU list on a fresh new load, and maybe we
  can remove the 'age' field from extent durable format in the future.

- Added '-l' option for vea_stress to measure heap loading time.

- Improved vea_stress to print heap size.

- Improved vea_stress to collect and print performance counters.

- Don't trigger free extent flush on reserve unless the reserve failed
for ENOSPACE on first try. Free extent flush will be triggered on
free which is usually invoked by aggregation or GC.

Signed-off-by: Niu Yawei <yawei.niu@intel.com>