### PR TITLE
DAOS-8867 pmdk: Explicitly require 1.11.0-3 (#7042)

### DIFF
--- a/ci/parse_ci_envs.sh
+++ b/ci/parse_ci_envs.sh
@@ -16,7 +16,7 @@ if [ -n "${STAGE_NAME:?}" ]; then
       : "${TARGET:=centos8}"
       ;;
     *Leap\ 15*|*leap15*|*opensuse15*|*sles15*)
-      : "${CHROOT_NAME:=opensuse-leap-15.3-x86_64}"
+      : "${CHROOT_NAME:=opensuse-leap-15.2-x86_64}"
       : "${TARGET:=leap15}"
       ;;
     *Ubuntu\ 20.04*|*ubuntu2004*)

--- a/utils/rpms/daos.spec
+++ b/utils/rpms/daos.spec
@@ -14,7 +14,7 @@
 
 Name:          daos
 Version:       1.3.106
-Release:       2%{?relval}%{?dist}
+Release:       3%{?relval}%{?dist}
 Summary:       DAOS Storage Engine
 
 License:       BSD-2-Clause-Patent
@@ -158,10 +158,12 @@ Requires: ndctl
 # needed to set PMem configuration goals in BIOS through control-plane
 %if (0%{?suse_version} >= 1500)
 Requires: ipmctl >= 02.00.00.3733
-Requires: libpmemobj1 >= 1.11
+# When 1.11.2 is released, we can change this to >= 1.11.2
+Requires: libpmemobj1 = 1.11.0-3suse1500
 %else
 Requires: ipmctl > 02.00.00.3816
-Requires: libpmemobj >= 1.11
+# When 1.11.2 is released, we can change this to >= 1.11.2
+Requires: libpmemobj = 1.11.0-3%{?dist}
 %endif
 Requires: mercury = %{mercury_version}
 Requires(post): /sbin/ldconfig
@@ -481,6 +483,9 @@ getent passwd daos_agent >/dev/null || useradd -s /sbin/nologin -r -g daos_agent
 %{_libdir}/libdaos_serialize.so
 
 %changelog
+* Wed Oct 20 2021 Jeff Olivier <jeffrey.v.olivier@intel.com> 2.1.106-3
+- Explicitly require 1.11.0-3 of PMDK
+
 * Mon Oct 13 2021 David Quigley <david.quigley@intel.com> 1.3.106-2
 - Add defusedxml as a required dependency for the test package.
 


### PR DESCRIPTION
We need to ensure that users update their pmdk package to
a patched version.  Until 1.11.2 is released, our only option
is to require the exact version we build

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>