### PR TITLE
DAOS-7672 tools: Find pool UUID by path with daos cont create (#6915)

### DIFF
--- a/src/control/cmd/daos/container.go
+++ b/src/control/cmd/daos/container.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 	"unsafe"
 
@@ -215,6 +216,25 @@ func (cmd *containerCreateCmd) Execute(_ []string) (err error) {
 		if err := copyUUID(&ap.c_uuid, cmd.contUUID); err != nil {
 			return err
 		}
+	}
+
+	if cmd.PoolID().Empty() {
+		if cmd.Path == "" {
+			return errors.New("no pool ID or dfs path supplied")
+		}
+
+		ap.path = C.CString(cmd.Path)
+		rc := C.resolve_duns_pool(ap)
+		freeString(ap.path)
+		if err := daosError(rc); err != nil {
+			return errors.Wrapf(err, "failed to resolve pool id from %q; use --pool <id>", filepath.Dir(cmd.Path))
+		}
+
+		pu, err := uuidFromC(ap.p_uuid)
+		if err != nil {
+			return err
+		}
+		cmd.poolBaseCmd.Args.Pool.UUID = pu
 	}
 
 	disconnectPool, err := cmd.connectPool(C.DAOS_PC_RW, ap)

--- a/src/control/cmd/daos/util.c
+++ b/src/control/cmd/daos/util.c
@@ -3,6 +3,8 @@
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
+#include <libgen.h>
+
 #include "util.h"
 
 static int
@@ -13,7 +15,7 @@ call_dfuse_ioctl(char *path, struct dfuse_il_reply *reply)
 
 	fd = open(path, O_RDONLY | O_DIRECTORY | O_NOFOLLOW);
 	if (fd < 0)
-		return ENOENT;
+		return errno;
 
 	errno = 0;
 	rc = ioctl(fd, DFUSE_IOCTL_IL, reply);
@@ -96,4 +98,37 @@ out:
 	D_FREE(dir_name);
 	D_FREE(name);
 	return daos_errno2der(rc);
+}
+
+int
+resolve_duns_pool(struct cmd_args_s *ap)
+{
+	int			 rc = 0;
+	char			*path = NULL;
+	char			*dir = NULL;
+	struct dfuse_il_reply	 il_reply = {0};
+
+	if (ap->path == NULL)
+		return -DER_INVAL;
+
+	D_ASPRINTF(path, "%s", ap->path);
+	if (path == NULL)
+		return -DER_NOMEM;
+	dir = dirname(path);
+
+	rc = call_dfuse_ioctl(dir, &il_reply);
+	D_FREE(path);
+
+	switch (rc) {
+	case 0:
+		break;
+	case ENOTTY: /* can happen if the path is not in a dfuse mount */
+		return -DER_INVAL;
+	default:
+		return daos_errno2der(rc);
+	}
+
+	uuid_copy(ap->p_uuid, il_reply.fir_pool);
+
+	return 0;
 }

--- a/src/control/cmd/daos/util.h
+++ b/src/control/cmd/daos/util.h
@@ -33,6 +33,7 @@
 #include "daos_hdlr.h"
 
 int resolve_duns_path(struct cmd_args_s *ap);
+int resolve_duns_pool(struct cmd_args_s *ap);
 
 /* cgo is unable to work directly with preprocessor macros
  * so we have to provide these glue helpers.

--- a/utils/node_local_test.py
+++ b/utils/node_local_test.py
@@ -1248,12 +1248,14 @@ def run_daos_cmd(conf,
         rc.json = json.loads(rc.stdout.decode('utf-8'))
     return rc
 
-def _create_cont(conf, pool, cont=None, ctype=None, label=None, path=None, valgrind=False):
+def _create_cont(conf, pool=None, cont=None, ctype=None, label=None, path=None, valgrind=False):
     """Helper function for create_cont"""
 
     cmd = ['container',
-           'create',
-           pool]
+           'create']
+
+    if pool:
+        cmd.append(pool)
 
     if label:
         cmd.extend(['--properties',
@@ -1272,7 +1274,7 @@ def _create_cont(conf, pool, cont=None, ctype=None, label=None, path=None, valgr
     print(rc.json)
     return rc
 
-def create_cont(conf, pool, cont=None, ctype=None, label=None, path=None, valgrind=False):
+def create_cont(conf, pool=None, cont=None, ctype=None, label=None, path=None, valgrind=False):
     """Create a container and return the uuid"""
 
     rc = _create_cont(conf, pool, cont, ctype, label, path, valgrind)
@@ -1286,7 +1288,7 @@ def create_cont(conf, pool, cont=None, ctype=None, label=None, path=None, valgri
             destroy_container(conf, pool, label)
             rc = _create_cont(conf, pool, cont, ctype, label, path, valgrind)
 
-    assert rc.returncode == 0, "rc {} != 0".format(rc.returncode)
+    assert rc.returncode == 0, rc
     return rc.json['response']['container_uuid']
 
 def destroy_container(conf, pool, container, valgrind=True):
@@ -1748,7 +1750,7 @@ class posix_tests():
     def test_uns_create(self):
         """Simple test to create a container using a path in dfuse"""
         path = os.path.join(self.dfuse.dir, 'mycont')
-        create_cont(self.conf, pool=self.pool.uuid, path=path, ctype="POSIX")
+        create_cont(self.conf, path=path, ctype="POSIX")
         stbuf = os.stat(path)
         print(stbuf)
         assert stbuf.st_ino < 100


### PR DESCRIPTION
When the --path parameter has been set to a valid DFS path,
look up the pool UUID so that the user does not need to
supply it.

Co-authored-by: Ashley Pittman <ashley.m.pittman@intel.com>