### PR TITLE
DAOS-8868 test: Fix control test on Go < 1.15

### DIFF
--- a/src/control/lib/control/rpc_test.go
+++ b/src/control/lib/control/rpc_test.go
@@ -193,7 +193,13 @@ func TestControl_InvokeUnaryRPCAsync(t *testing.T) {
 				}
 			}
 
-			testDeadline, ok := t.Deadline()
+			deadliner, ok := (interface{})(t).(interface{ Deadline() (time.Time, bool) })
+			if !ok {
+				t.Log("go version < 1.15; skipping stragglers check")
+				return
+			}
+
+			testDeadline, ok := deadliner.Deadline()
 			if !ok {
 				panic("no deadline")
 			}


### PR DESCRIPTION
Add a runtime check to disable advanced testing features
when run on older versions of Go.