### PR TITLE
DAOS-8873 control: Fix hwloc tests on el8

### DIFF
--- a/src/control/lib/netdetect/netdetect_test.go
+++ b/src/control/lib/netdetect/netdetect_test.go
@@ -210,24 +210,13 @@ func TestValidateNetworkConfig(t *testing.T) {
 // with a standard topology and one without any OS devices in it
 func TestNumaAware(t *testing.T) {
 	for name, tc := range map[string]struct {
-		result   bool
 		topology string
 	}{
 		"no devices in topology": {
-			result:   true,
 			topology: "testdata/gcp_topology.xml",
 		},
 		"devices in topology": {
-			result:   true,
 			topology: "testdata/boro-84.xml",
-		},
-		"devices in topology no NUMA nodes": {
-			result:   false,
-			topology: "testdata/no-numa-nodes.xml",
-		},
-		"no devices in topology no NUMA nodes": {
-			result:   false,
-			topology: "testdata/no-numa-no-devices.xml",
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
@@ -240,9 +229,7 @@ func TestNumaAware(t *testing.T) {
 			defer CleanUp(netCtx)
 			AssertEqual(t, err, nil, "Failed to initialize NetDetectContext")
 
-			if tc.result {
-				AssertEqual(t, HasNUMA(netCtx), tc.result, "Unable to detect NUMA on provided topology")
-			}
+			AssertTrue(t, HasNUMA(netCtx), "Unable to detect NUMA on provided topology")
 		})
 	}
 }


### PR DESCRIPTION
In hwloc 2.0+, a NUMA node is automatically added to the
topology if the synthetic topology did not contain one.

A number of the unit tests were written with the assumption
that a loaded topology could contain 0 NUMA nodes, and are
therefore not valid anymore.

Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com>
