### PR TITLE
DAOS-8520 rebuild: re-enable basic.py and with_io.py (#6718)

### DIFF
--- a/src/tests/ftest/rebuild/basic.py
+++ b/src/tests/ftest/rebuild/basic.py
@@ -4,7 +4,7 @@
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
-from apricot import TestWithServers, skipForTicket
+from apricot import TestWithServers
 from daos_utils import DaosCommand
 
 class RbldBasic(TestWithServers):
@@ -144,7 +144,6 @@ class RbldBasic(TestWithServers):
         """
         self.run_rebuild_test(1)
 
-    @skipForTicket("DAOS-7050, DAOS-7134")
     def test_multipool_rebuild(self):
         """JIRA ID: DAOS-XXXX (Rebuild-002).
 

--- a/src/tests/ftest/rebuild/basic.yaml
+++ b/src/tests/ftest/rebuild/basic.yaml
@@ -8,7 +8,7 @@ hosts:
     - server-D
     - server-E
     - server-F
-timeout: 600
+timeout: 900
 server_config:
   name: daos_server
   servers:
@@ -16,7 +16,7 @@ server_config:
 pool:
   mode: 511
   name: daos_server
-  scm_size: 1073741824
+  scm_size: 1G
   control_method: dmg
   pool_query_timeout: 30
 container:

--- a/src/tests/ftest/rebuild/with_io.yaml
+++ b/src/tests/ftest/rebuild/with_io.yaml
@@ -12,7 +12,7 @@ timeout: 5000
 server_config:
   name: daos_server
   servers:
-    targets: 8
+    targets: 2
 pool:
   mode: 511
   name: daos_server
@@ -26,5 +26,5 @@ container:
 testparams:
   ranks:
     rank0:
-      rank: 0
-  object_class: DAOS_OC_R3_RW
+      rank: 4
+  object_class: OC_RP_3G1


### PR DESCRIPTION
Re-enable basic.py and with_io.py which were disabled before.

Features: rebuild
Signed-off-by: Xuezhao Liu <xuezhao.liu@intel.com>