### PR TITLE
DAOS-8333 dfuse: Avoid truncation from causing incorrect reads. (#7027)

### DIFF
--- a/src/client/dfuse/ops/setattr.c
+++ b/src/client/dfuse/ops/setattr.c
@@ -111,8 +111,11 @@ dfuse_cb_setattr(fuse_req_t req, struct dfuse_inode_entry *ie,
 
 	attr->st_ino = ie->ie_stat.st_ino;
 
-	/* Update the size as dfuse knows about it for future use */
-	ie->ie_stat.st_size = attr->st_size;
+	/* Update the size as dfuse knows about it for future use, but only if it was set as part
+	 * of this call.  See DAOS-8333
+	 */
+	if (dfs_flags & DFS_SET_ATTR_SIZE)
+		ie->ie_stat.st_size = attr->st_size;
 
 	DFUSE_REPLY_ATTR(ie, req, attr);
 	return;


### PR DESCRIPTION
Changing timings and add logging to reproduce truncated
read error.

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>