### PR TITLE
mjmac/DAOS 8873 el8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,31 +62,31 @@ jobs:
       with:
         submodules: true
     - name: Prepare base image in Docker
-      run: docker build . -f utils/docker/Dockerfile.centos.8
+      run: docker build . -f utils/docker/Dockerfile.centos.fedora
                           --build-arg DAOS_DEPS_BUILD=no
     - name: Build dependencies in Docker
-      run: docker build . -f utils/docker/Dockerfile.centos.8
+      run: docker build . -f utils/docker/Dockerfile.centos.fedora
                           --build-arg DEPS_JOBS=8 --build-arg DAOS_BUILD=no
                           --build-arg BASE_DISTRO=fedora:34
     - name: Build DAOS in Docker image
-      run: docker build . -f utils/docker/Dockerfile.centos.8
+      run: docker build . -f utils/docker/Dockerfile.centos.fedora
                           --build-arg COMPILER=${{ matrix.compiler }}
                           --build-arg DEPS_JOBS=8 --build-arg DAOS_JAVA_BUILD=no
                           --build-arg BASE_DISTRO=fedora:34
 #    - name: Build DAOS Java client in Docker image
-#      run: docker build . -f utils/docker/Dockerfile.centos.8
+#      run: docker build . -f utils/docker/Dockerfile.centos.fedora
 #                          --build-arg COMPILER=${{ matrix.compiler }}
 #                          --build-arg DEPS_JOBS=8
 #                          --build-arg BASE_DISTRO=fedora:34
     - name: Build debug in docker
-      run: docker build . --file utils/docker/Dockerfile.centos.8
+      run: docker build . --file utils/docker/Dockerfile.centos.fedora
                           --build-arg DAOS_JAVA_BUILD=no
                           --build-arg DEPS_JOBS=8
                           --build-arg DAOS_BUILD_TYPE=debug
                           --build-arg COMPILER=${{ matrix.compiler }}
                           --build-arg BASE_DISTRO=fedora:34
     - name: Build devel in docker
-      run: docker build . --file utils/docker/Dockerfile.centos.8
+      run: docker build . --file utils/docker/Dockerfile.centos.fedora
                           --build-arg DAOS_JAVA_BUILD=no
                           --build-arg DEPS_JOBS=8
                           --build-arg DAOS_BUILD_TYPE=dev

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,31 +62,31 @@ jobs:
       with:
         submodules: true
     - name: Prepare base image in Docker
-      run: docker build . -f utils/docker/Dockerfile.centos.fedora
+      run: docker build . -f utils/docker/Dockerfile.fedora
                           --build-arg DAOS_DEPS_BUILD=no
     - name: Build dependencies in Docker
-      run: docker build . -f utils/docker/Dockerfile.centos.fedora
+      run: docker build . -f utils/docker/Dockerfile.fedora
                           --build-arg DEPS_JOBS=8 --build-arg DAOS_BUILD=no
                           --build-arg BASE_DISTRO=fedora:34
     - name: Build DAOS in Docker image
-      run: docker build . -f utils/docker/Dockerfile.centos.fedora
+      run: docker build . -f utils/docker/Dockerfile.fedora
                           --build-arg COMPILER=${{ matrix.compiler }}
                           --build-arg DEPS_JOBS=8 --build-arg DAOS_JAVA_BUILD=no
                           --build-arg BASE_DISTRO=fedora:34
 #    - name: Build DAOS Java client in Docker image
-#      run: docker build . -f utils/docker/Dockerfile.centos.fedora
+#      run: docker build . -f utils/docker/Dockerfile.fedora
 #                          --build-arg COMPILER=${{ matrix.compiler }}
 #                          --build-arg DEPS_JOBS=8
 #                          --build-arg BASE_DISTRO=fedora:34
     - name: Build debug in docker
-      run: docker build . --file utils/docker/Dockerfile.centos.fedora
+      run: docker build . --file utils/docker/Dockerfile.fedora
                           --build-arg DAOS_JAVA_BUILD=no
                           --build-arg DEPS_JOBS=8
                           --build-arg DAOS_BUILD_TYPE=debug
                           --build-arg COMPILER=${{ matrix.compiler }}
                           --build-arg BASE_DISTRO=fedora:34
     - name: Build devel in docker
-      run: docker build . --file utils/docker/Dockerfile.centos.fedora
+      run: docker build . --file utils/docker/Dockerfile.fedora
                           --build-arg DAOS_JAVA_BUILD=no
                           --build-arg DEPS_JOBS=8
                           --build-arg DAOS_BUILD_TYPE=dev

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -659,7 +659,6 @@ pipeline {
                         label params.CI_UNIT_VM1_LABEL
                     }
                     steps {
-                        sh label: 'Get RPM list'
                         unitTest timeout_time: 60,
                                  inst_repos: prRepos(),
                                  inst_rpms: unitPackages()

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -475,21 +475,21 @@ pipeline {
                         }
                     }
                 }
-                stage('Build on CentOS 7 Bullseye') {
+                stage('Build on CentOS 8 Bullseye') {
                     when {
                         beforeAgent true
                         expression { ! skipStage() }
                     }
                     agent {
                         dockerfile {
-                            filename 'utils/docker/Dockerfile.centos.7'
+                            filename 'utils/docker/Dockerfile.centos.8'
                             label 'docker_runner'
                             additionalBuildArgs dockerBuildArgs(repo_type: 'stable',
                                                                 qb: quickBuild()) +
-                                " -t ${sanitized_JOB_NAME}-centos7 " +
+                                " -t ${sanitized_JOB_NAME}-centos8 " +
                                 ' --build-arg BULLSEYE=' + env.BULLSEYE +
                                 ' --build-arg QUICKBUILD_DEPS="' +
-                                quickBuildDeps('centos7') + '"' +
+                                quickBuildDeps('centos8') + '"' +
                                 ' --build-arg REPOS="' + prRepos() + '"'
                         }
                     }
@@ -502,9 +502,9 @@ pipeline {
                     post {
                         unsuccessful {
                             sh """if [ -f config.log ]; then
-                                      mv config.log config.log-centos7-covc
+                                      mv config.log config.log-centos8-covc
                                   fi"""
-                            archiveArtifacts artifacts: 'config.log-centos7-covc',
+                            archiveArtifacts artifacts: 'config.log-centos8-covc',
                                              allowEmptyArchive: true
                         }
                     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -650,7 +650,7 @@ pipeline {
                 expression { ! skipStage() }
             }
             parallel {
-                stage('Unit Test') {
+                stage('Unit Test on CentOS 8') {
                     when {
                       beforeAgent true
                       expression { ! skipStage() }
@@ -669,7 +669,7 @@ pipeline {
                         }
                     }
                 }
-                stage('NLT') {
+                stage('NLT on CentOS 8') {
                     when {
                       beforeAgent true
                       expression { ! skipStage() }
@@ -701,7 +701,7 @@ pipeline {
                         }
                     }
                 }
-                stage('Unit Test Bullseye') {
+                stage('Unit Test Bullseye on CentOS 8') {
                     when {
                       beforeAgent true
                       expression { ! skipStage() }
@@ -727,7 +727,7 @@ pipeline {
                         }
                     }
                 } // stage('Unit test Bullseye')
-                stage('Unit Test with memcheck') {
+                stage('Unit Test with memcheck on CentOS 8') {
                     when {
                       beforeAgent true
                       expression { ! skipStage() }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -660,6 +660,7 @@ pipeline {
                     }
                     steps {
                         unitTest timeout_time: 60,
+                                 target: 'el8.4',
                                  inst_repos: prRepos(),
                                  inst_rpms: unitPackages()
                     }
@@ -679,6 +680,7 @@ pipeline {
                     }
                     steps {
                         unitTest timeout_time: 60,
+                                 target: 'el8.4',
                                  inst_repos: prRepos(),
                                  test_script: 'ci/unit/test_nlt.sh',
                                  inst_rpms: unitPackages()
@@ -711,6 +713,7 @@ pipeline {
                     }
                     steps {
                         unitTest timeout_time: 60,
+                                 target: 'el8.4',
                                  ignore_failure: true,
                                  inst_repos: prRepos(),
                                  inst_rpms: unitPackages()
@@ -737,6 +740,7 @@ pipeline {
                     }
                     steps {
                         unitTest timeout_time: 30,
+                                 target: 'el8.4',
                                  ignore_failure: true,
                                  inst_repos: prRepos(),
                                  inst_rpms: unitPackages()

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,7 +12,7 @@
 
 // To use a test branch (i.e. PR) until it lands to master
 // I.e. for testing library changes
-//@Library(value="pipeline-lib@your_branch") _
+@Library(value="pipeline-lib@bmurrell/run-units-tests-with-quickbuild") _
 
 // For master, this is just some wildly high number
 next_version = "1000"
@@ -442,20 +442,20 @@ pipeline {
                         }
                     }
                 }
-                stage('Build on CentOS 7') {
+                stage('Build on CentOS 8') {
                     when {
                         beforeAgent true
                         expression { ! skipStage() }
                     }
                     agent {
                         dockerfile {
-                            filename 'utils/docker/Dockerfile.centos.7'
+                            filename 'utils/docker/Dockerfile.centos.8'
                             label 'docker_runner'
                             additionalBuildArgs dockerBuildArgs(repo_type: 'stable',
                                                                 qb: quickBuild()) +
-                                                " -t ${sanitized_JOB_NAME}-centos7 " +
+                                                " -t ${sanitized_JOB_NAME}-centos8 " +
                                                 ' --build-arg QUICKBUILD_DEPS="' +
-                                                quickBuildDeps('centos7') + '"' +
+                                                quickBuildDeps('centos8') + '"' +
                                                 ' --build-arg REPOS="' + prRepos() + '"'
                         }
                     }
@@ -468,9 +468,9 @@ pipeline {
                     post {
                         unsuccessful {
                             sh """if [ -f config.log ]; then
-                                      mv config.log config.log-centos7-gcc
+                                      mv config.log config.log-centos8-gcc
                                   fi"""
-                            archiveArtifacts artifacts: 'config.log-centos7-gcc',
+                            archiveArtifacts artifacts: 'config.log-centos8-gcc',
                                              allowEmptyArchive: true
                         }
                     }
@@ -757,20 +757,20 @@ pipeline {
                 expression { ! skipStage() }
             }
             parallel {
-                stage('Coverity on CentOS 7') {
+                stage('Coverity on CentOS 8') {
                     when {
                         beforeAgent true
                         expression { ! skipStage() }
                     }
                     agent {
                         dockerfile {
-                            filename 'utils/docker/Dockerfile.centos.7'
+                            filename 'utils/docker/Dockerfile.centos.8'
                             label 'docker_runner'
                             additionalBuildArgs dockerBuildArgs(repo_type: 'stable',
                                                                 qb: true) +
-                                                " -t ${sanitized_JOB_NAME}-centos7 " +
+                                                " -t ${sanitized_JOB_NAME}-centos8 " +
                                                 ' --build-arg QUICKBUILD_DEPS="' +
-                                                quickBuildDeps('centos7', true) + '"' +
+                                                quickBuildDeps('centos8', true) + '"' +
                                                 ' --build-arg REPOS="' + prRepos() + '"'
                         }
                     }
@@ -787,7 +787,7 @@ pipeline {
                             coverityPost condition: 'unsuccessful'
                         }
                     }
-                } // stage('Coverity on CentOS 7')
+                } // stage('Coverity on CentOS 8')
                 stage('Functional on CentOS 7') {
                     when {
                         beforeAgent true
@@ -1116,21 +1116,21 @@ pipeline {
                     }
                     agent {
                         dockerfile {
-                            filename 'utils/docker/Dockerfile.centos.7'
+                            filename 'utils/docker/Dockerfile.centos.8'
                             label 'docker_runner'
                             additionalBuildArgs dockerBuildArgs(repo_type: 'stable',
                                                                 qb: quickBuild()) +
-                                " -t ${sanitized_JOB_NAME}-centos7 " +
+                                " -t ${sanitized_JOB_NAME}-centos8 " +
                                 ' --build-arg BULLSEYE=' + env.BULLSEYE +
                                 ' --build-arg QUICKBUILD_DEPS="' +
-                                quickBuildDeps('centos7') + '"' +
+                                quickBuildDeps('centos8') + '"' +
                                 ' --build-arg REPOS="' + prRepos() + '"'
                         }
                     }
                     steps {
                         // The coverage_healthy is primarily set here
                         // while the code coverage feature is being implemented.
-                        cloverReportPublish coverage_stashes: ['centos7-covc-unit-cov'],
+                        cloverReportPublish coverage_stashes: ['centos8-covc-unit-cov'],
                                             coverage_healthy: [methodCoverage: 0,
                                                                conditionalCoverage: 0,
                                                                statementCoverage: 0],
@@ -1142,8 +1142,8 @@ pipeline {
     } // stages
     post {
         always {
-            valgrindReportPublish valgrind_stashes: ['centos7-gcc-nlt-memcheck',
-                                                     'centos7-gcc-unit-memcheck']
+            valgrindReportPublish valgrind_stashes: ['centos8-gcc-nlt-memcheck',
+                                                     'centos8-gcc-unit-memcheck']
         }
         unsuccessful {
             notifyBrokenBranch branches: target_branch

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -461,6 +461,7 @@ pipeline {
                     }
                     steps {
                         sconsBuild parallel_build: parallelBuild(),
+                                   target: 'el8.4',
                                    stash_files: 'ci/test_files_to_stash.txt',
                                    scons_exe: 'scons-3',
                                    scons_args: sconsFaultsArgs()

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -509,21 +509,21 @@ pipeline {
                         }
                     }
                 }
-                stage('Build on CentOS 7 debug') {
+                stage('Build on CentOS 8 debug') {
                     when {
                         beforeAgent true
                         expression { ! skipStage() }
                     }
                     agent {
                         dockerfile {
-                            filename 'utils/docker/Dockerfile.centos.7'
+                            filename 'utils/docker/Dockerfile.centos.8'
                             label 'docker_runner'
                             additionalBuildArgs dockerBuildArgs(repo_type: 'stable',
                                                                 qb: quickBuild(),
                                                                 deps_build: true) +
-                                                " -t ${sanitized_JOB_NAME}-centos7 " +
+                                                " -t ${sanitized_JOB_NAME}-centos8 " +
                                                 ' --build-arg QUICKBUILD_DEPS="' +
-                                                quickBuildDeps('centos7') + '"' +
+                                                quickBuildDeps('centos8') + '"' +
                                                 ' --build-arg REPOS="' + prRepos() + '"'
                         }
                     }
@@ -536,28 +536,28 @@ pipeline {
                     post {
                         unsuccessful {
                             sh """if [ -f config.log ]; then
-                                      mv config.log config.log-centos7-gcc-debug
+                                      mv config.log config.log-centos8-gcc-debug
                                   fi"""
-                            archiveArtifacts artifacts: 'config.log-centos7-gcc-debug',
+                            archiveArtifacts artifacts: 'config.log-centos8-gcc-debug',
                                              allowEmptyArchive: true
                         }
                     }
                 }
-                stage('Build on CentOS 7 release') {
+                stage('Build on CentOS 8 release') {
                     when {
                         beforeAgent true
                         expression { ! skipStage() }
                     }
                     agent {
                         dockerfile {
-                            filename 'utils/docker/Dockerfile.centos.7'
+                            filename 'utils/docker/Dockerfile.centos.8'
                             label 'docker_runner'
                             additionalBuildArgs dockerBuildArgs(repo_type: 'stable',
                                                                 qb: quickBuild(),
                                                                 deps_build: true) +
-                                                " -t ${sanitized_JOB_NAME}-centos7 " +
+                                                " -t ${sanitized_JOB_NAME}-centos8 " +
                                                 ' --build-arg QUICKBUILD_DEPS="' +
-                                                quickBuildDeps('centos7') + '"' +
+                                                quickBuildDeps('centos8') + '"' +
                                                 ' --build-arg REPOS="' + prRepos() + '"'
                             args '--tmpfs /mnt/daos_0'
                         }
@@ -571,28 +571,28 @@ pipeline {
                     post {
                         unsuccessful {
                             sh """if [ -f config.log ]; then
-                                      mv config.log config.log-centos7-gcc-release
+                                      mv config.log config.log-centos8-gcc-release
                                   fi"""
-                            archiveArtifacts artifacts: 'config.log-centos7-gcc-release',
+                            archiveArtifacts artifacts: 'config.log-centos8-gcc-release',
                                              allowEmptyArchive: true
                         }
                     }
                 }
-                stage('Build on CentOS 7 with Clang debug') {
+                stage('Build on CentOS 8 with Clang debug') {
                     when {
                         beforeAgent true
                         expression { ! skipStage() }
                     }
                     agent {
                         dockerfile {
-                            filename 'utils/docker/Dockerfile.centos.7'
+                            filename 'utils/docker/Dockerfile.centos.8'
                             label 'docker_runner'
                             additionalBuildArgs dockerBuildArgs(repo_type: 'stable',
                                                                 qb: quickBuild(),
                                                                 deps_build: true) +
-                                                " -t ${sanitized_JOB_NAME}-centos7 " +
+                                                " -t ${sanitized_JOB_NAME}-centos8 " +
                                                 ' --build-arg QUICKBUILD_DEPS="' +
-                                                quickBuildDeps('centos7') + '"' +
+                                                quickBuildDeps('centos8') + '"' +
                                                 ' --build-arg REPOS="' + prRepos() + '"'
                         }
                     }
@@ -605,9 +605,9 @@ pipeline {
                     post {
                         unsuccessful {
                             sh """if [ -f config.log ]; then
-                                      mv config.log config.log-centos7-clang-debug
+                                      mv config.log config.log-centos8-clang-debug
                                   fi"""
-                            archiveArtifacts artifacts: 'config.log-centos7-clang-debug',
+                            archiveArtifacts artifacts: 'config.log-centos8-clang-debug',
                                              allowEmptyArchive: true
                         }
                     }
@@ -659,6 +659,7 @@ pipeline {
                         label params.CI_UNIT_VM1_LABEL
                     }
                     steps {
+                        sh label: 'Get RPM list'
                         unitTest timeout_time: 60,
                                  inst_repos: prRepos(),
                                  inst_rpms: unitPackages()
@@ -688,7 +689,7 @@ pipeline {
                             unitTestPost artifacts: ['nlt_logs/*'],
                                          testResults: 'nlt-junit.xml',
                                          always_script: 'ci/unit/test_nlt_post.sh',
-                                         valgrind_stash: 'centos7-gcc-nlt-memcheck'
+                                         valgrind_stash: 'centos8-gcc-nlt-memcheck'
                             recordIssues enabledForFailure: true,
                                          failOnError: false,
                                          ignoreFailedBuilds: false,
@@ -745,7 +746,7 @@ pipeline {
                         always {
                             unitTestPost artifacts: ['unit_test_memcheck_logs.tar.gz',
                                                      'unit_test_memcheck_logs/*.log'],
-                                         valgrind_stash: 'centos7-gcc-unit-memcheck'
+                                         valgrind_stash: 'centos8-gcc-unit-memcheck'
                         }
                     }
                 } // stage('Unit Test with memcheck')
@@ -909,7 +910,7 @@ pipeline {
                                 target: 'el8.3',
                                 daos_pkg_version: daosPackagesVersion("centos8", next_version)
                    }
-                } // stage('Test CentOS 7 RPMs')
+                } // stage('Test CentOS 8.3.2011 RPMs') {
                 stage('Test Leap 15 RPMs') {
                     when {
                         beforeAgent true
@@ -979,14 +980,14 @@ pipeline {
                         }
                     }
                 } // stage('Scan Leap 15 RPMs')
-                stage('Fault injection testing') {
+                stage('Fault injection testing on CentOS 8') {
                     when {
                         beforeAgent true
                         expression { ! skipStage() }
                     }
                     agent {
                         dockerfile {
-                            filename 'utils/docker/Dockerfile.centos.7'
+                            filename 'utils/docker/Dockerfile.centos.8'
                             label 'docker_runner'
                             additionalBuildArgs dockerBuildArgs(repo_type: 'stable',
                                                                 deps_build: true)
@@ -998,7 +999,7 @@ pipeline {
                                    scons_exe: 'scons-3',
                                    scons_args: "PREFIX=/opt/daos TARGET_TYPE=release BUILD_TYPE=debug",
                                    build_deps: "no"
-                        sh (script:"""./utils/docker_nlt.sh --class-name centos7.fault-injection fi""",
+                        sh (script:"""./utils/docker_nlt.sh --class-name centos8.fault-injection fi""",
                             label: 'Fault injection testing using NLT')
                     }
                     post {
@@ -1018,7 +1019,7 @@ pipeline {
                                                         name: 'Fault injection leaks',
                                                         id: 'NLT_client')]
                             junit testResults: 'nlt-junit.xml'
-                            archiveArtifacts artifacts: 'nlt_logs/centos7.fault-injection/'
+                            archiveArtifacts artifacts: 'nlt_logs/centos8.fault-injection/'
                         }
                     }
                 } // stage('Fault inection testing')

--- a/ci/rpm/build_unsuccessful.sh
+++ b/ci/rpm/build_unsuccessful.sh
@@ -26,6 +26,11 @@ if [ -d /var/cache/pbuilder/ ]; then
 fi
 
 mockroot="/var/lib/mock/${CHROOT_NAME}"
+
+sudo dnf --installroot $mockroot/root/ repolist || true
+ls -l $mockroot/root/etc/yum.conf || true
+cat $mockroot/root/etc/yum.conf || true
+
 cat "$mockroot"/result/{root,build}.log 2>/dev/null || true
 
 if srpms="$(ls _topdir/SRPMS/*)"; then

--- a/ci/unit/required_packages.sh
+++ b/ci/unit/required_packages.sh
@@ -11,7 +11,6 @@ if [[ "$distro" = *7 ]]; then
 elif [[ "$distro" = *8 ]]; then
     OPENMPI_VER=""
     PY_MINOR_VER=""
-    COMPAT_HWLOC=compat-hwloc1
 fi
 pkgs="gotestsum openmpi$OPENMPI_VER                \
       hwloc-devel argobots                         \
@@ -25,7 +24,7 @@ pkgs="gotestsum openmpi$OPENMPI_VER                \
       python3$PY_MINOR_VER-junit_xml               \
       python3$PY_MINOR_VER-tabulate numactl        \
       libyaml-devel                                \
-      valgrind-devel patchelf $COMPAT_HWLOC"
+      valgrind-devel patchelf
 
 if $quick_build; then
     read -r mercury_version < "$distro"-required-mercury-rpm-version

--- a/ci/unit/required_packages.sh
+++ b/ci/unit/required_packages.sh
@@ -11,6 +11,7 @@ if [[ "$distro" = *7 ]]; then
 elif [[ "$distro" = *8 ]]; then
     OPENMPI_VER=""
     PY_MINOR_VER=""
+    COMPAT_HWLOC=compat_hwloc1
 fi
 pkgs="gotestsum openmpi$OPENMPI_VER                \
       hwloc-devel argobots                         \
@@ -24,7 +25,7 @@ pkgs="gotestsum openmpi$OPENMPI_VER                \
       python3$PY_MINOR_VER-junit_xml               \
       python3$PY_MINOR_VER-tabulate numactl        \
       libyaml-devel                                \
-      valgrind-devel patchelf"
+      valgrind-devel patchelf $COMPAT_HWLOC"
 
 if $quick_build; then
     read -r mercury_version < "$distro"-required-mercury-rpm-version

--- a/ci/unit/required_packages.sh
+++ b/ci/unit/required_packages.sh
@@ -24,7 +24,7 @@ pkgs="gotestsum openmpi$OPENMPI_VER                \
       python3$PY_MINOR_VER-junit_xml               \
       python3$PY_MINOR_VER-tabulate numactl        \
       libyaml-devel                                \
-      valgrind-devel patchelf
+      valgrind-devel patchelf"
 
 if $quick_build; then
     read -r mercury_version < "$distro"-required-mercury-rpm-version

--- a/ci/unit/required_packages.sh
+++ b/ci/unit/required_packages.sh
@@ -11,7 +11,7 @@ if [[ "$distro" = *7 ]]; then
 elif [[ "$distro" = *8 ]]; then
     OPENMPI_VER=""
     PY_MINOR_VER=""
-    COMPAT_HWLOC=compat_hwloc1
+    COMPAT_HWLOC=compat-hwloc1
 fi
 pkgs="gotestsum openmpi$OPENMPI_VER                \
       hwloc-devel argobots                         \

--- a/ci/unit/test_main_node.sh
+++ b/ci/unit/test_main_node.sh
@@ -5,6 +5,8 @@
 
 set -uex
 
+rpm -qa
+
 sudo bash -c 'echo 1 > /proc/sys/kernel/sysrq'
 if grep /mnt/daos\  /proc/mounts; then
     sudo umount /mnt/daos

--- a/src/control/lib/netdetect/netdetect_test.go
+++ b/src/control/lib/netdetect/netdetect_test.go
@@ -206,77 +206,17 @@ func TestValidateNetworkConfig(t *testing.T) {
 	}
 }
 
-// ValidateNUMAConfigNonNumaAware verifies that the numa detection successfully executes without error
-// with a topology that has no NUMA devices in it.
-func TestValidateNUMAConfigNonNumaAware(t *testing.T) {
-	for name, tc := range map[string]struct {
-		device   string
-		topology string
-	}{
-		"no NUMA nodes in topology - has devices": {
-			device:   "fake device",
-			topology: "testdata/no-numa-nodes.xml",
-		},
-		"no NUMA nodes in topology with eth0 device": {
-			device:   "eth0",
-			topology: "testdata/no-numa-nodes.xml",
-		},
-		"no NUMA nodes in topology with ib1 device": {
-			device:   "ib1",
-			topology: "testdata/no-numa-nodes.xml",
-		},
-		"no NUMA nodes no devices in topology with fake device": {
-			device:   "fake device",
-			topology: "testdata/no-numa-no-devices.xml",
-		},
-		"no NUMA nodes no devices in topology with eth0 device": {
-			device:   "eth0",
-			topology: "testdata/no-numa-no-devices.xml",
-		},
-		"no NUMA nodes no devices in topology with fake device with ib1 device": {
-			device:   "ib1",
-			topology: "testdata/no-numa-no-devices.xml",
-		},
-	} {
-		t.Run(name, func(t *testing.T) {
-			_, err := os.Stat(tc.topology)
-			AssertEqual(t, err, nil, "unable to load xmlTopology")
-			os.Setenv("HWLOC_XMLFILE", tc.topology)
-			defer os.Unsetenv("HWLOC_XMLFILE")
-
-			netCtx, err := Init(context.Background())
-			defer CleanUp(netCtx)
-			AssertEqual(t, err, nil, "Failed to initialize NetDetectContext")
-			AssertEqual(t, HasNUMA(netCtx), false, "Unexpected detection of NUMA nodes in provided topology")
-
-			err = ValidateNUMAConfig(netCtx, tc.device, 0)
-			AssertEqual(t, err, nil, "Error on ValidateNUMAConfig")
-		})
-	}
-}
-
 // TestNumaAware verifies that the numa detection successfully executes without error
 // with a standard topology and one without any OS devices in it
 func TestNumaAware(t *testing.T) {
 	for name, tc := range map[string]struct {
-		result   bool
 		topology string
 	}{
 		"no devices in topology": {
-			result:   true,
 			topology: "testdata/gcp_topology.xml",
 		},
 		"devices in topology": {
-			result:   true,
 			topology: "testdata/boro-84.xml",
-		},
-		"devices in topology no NUMA nodes": {
-			result:   false,
-			topology: "testdata/no-numa-nodes.xml",
-		},
-		"no devices in topology no NUMA nodes": {
-			result:   false,
-			topology: "testdata/no-numa-no-devices.xml",
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
@@ -289,11 +229,7 @@ func TestNumaAware(t *testing.T) {
 			defer CleanUp(netCtx)
 			AssertEqual(t, err, nil, "Failed to initialize NetDetectContext")
 
-			if tc.result {
-				AssertEqual(t, HasNUMA(netCtx), tc.result, "Unable to detect NUMA on provided topology")
-			} else {
-				AssertEqual(t, HasNUMA(netCtx), tc.result, "Detected NUMA on non-numa topology")
-			}
+			AssertTrue(t, HasNUMA(netCtx), "Unable to detect NUMA on provided topology")
 		})
 	}
 }
@@ -336,16 +272,8 @@ func TestGetAffinityForDeviceEdgeCases(t *testing.T) {
 			device:   "lo",
 			topology: "testdata/no-numa-nodes.xml",
 		},
-		"non-numa topology, with OS devices, no network devices, unknown input device": {
-			device:   "bar",
-			topology: "testdata/no-numa-nodes.xml",
-		},
 		"non-numa topology, with no OS devices, known input device": {
 			device:   "lo",
-			topology: "testdata/no-numa-no-devices.xml",
-		},
-		"non-numa topology, with no OS devices, unknown input device": {
-			device:   "bazz",
 			topology: "testdata/no-numa-no-devices.xml",
 		},
 	} {

--- a/src/rdb/raft_tests/raft_tests.py
+++ b/src/rdb/raft_tests/raft_tests.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 # Copyright (c) 2018-2021 Intel Corporation
 #
 # SPDX-License-Identifier: BSD-2-Clause-Patent

--- a/utils/docker/Dockerfile.centos.8
+++ b/utils/docker/Dockerfile.centos.8
@@ -1,13 +1,12 @@
 # Copyright (C) 2018-2021 Intel Corporation
 # All rights reserved.
 #
-# 'recipe' for Docker to build an image of centOS 8 based
+# 'recipe' for Docker to build an image of CentOS 8 based
 # environment for building the DAOS project.
 #
 
 # Pull base image
-ARG BASE_DISTRO=centos:8
-FROM $BASE_DISTRO
+FROM centos:8
 LABEL maintainer="daos@daos.groups.io"
 
 # Intermittent cache-bust.  Used to reduce load on the actual CACHEBUST later.
@@ -18,40 +17,56 @@ ARG CB0
 # The Docker image starts out with the DISTRO provided GPG keys
 # on the disk, but not installed.  These must be installed before
 # adding any repo that needs GPG keys but does not provide meta
-# data for installing those keys.  Then the epel-release
-# package must be installed and the GPG key it provides must be
-# installed.
+# data for installing those keys.  Then the epel-release package
+# must be installed from the extras repository and the GPG key it
+# provides must be installed.
 ARG REPO_URL
 ARG REPO_DISTRO
-RUN if [ -n "$REPO_DISTRO" ]; then                              \
-      rpm --import /etc/pki/rpm-gpg/*;                          \
-      MY_REPO="${REPO_URL}${REPO_DISTRO}/";                     \
-      MY_NAME="${MY_REPO#*//}";                                 \
-      MY_NAME="${MY_NAME//\//_}";                               \
-      echo -e "[${MY_NAME}]\n\
+RUN if [ -n "$REPO_DISTRO" ]; then                               \
+      rpm --import /etc/pki/rpm-gpg/*;                           \
+      for repo in centos-8.4-{base,extras,powertools}; do        \
+          MY_REPO="${REPO_URL}repository/$repo-x86_64-proxy";    \
+          MY_NAME="${MY_REPO#*//}";                              \
+          MY_NAME="${MY_NAME//\//_}";                            \
+          echo -e "[${MY_NAME}]\n\
 name=created from ${MY_REPO}\n\
 baseurl=${MY_REPO}\n\
 enabled=1\n\
 repo_gpgcheck=0\n\
-gpgcheck=1\n" >> /etc/yum.repos.d/local-centos-group.repo;      \
-      dnf -y install --disablerepo extras --disablerepo baseos  \
-          epel-release-8-8.el8 dnf-plugins-core dnf-utils;      \
-      rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-8;         \
-      dnf config-manager --assumeyes --quiet --disable          \
-          baseos powertools epel epel-modular extras;           \
-      sed "s/^mirrorlist_expire=0*/mirrorlist_expire=99999999/" \
-          -i /etc/dnf/dnf.conf;                                 \
-      dnf -y upgrade epel-release;                              \
-    else                                                        \
-      dnf -y install epel-release dnf-plugins-core &&           \
-      dnf config-manager --assumeyes --set-enabled powertools;  \
-    fi;                                                         \
+gpgcheck=1\n" >> /etc/yum.repos.d/local-centos-$repo.repo;       \
+      done;                                                      \
+      dnf -y --disablerepo=baseos,powertools,extras              \
+          install dnf-plugins-core dnf-utils;                    \
+      dnf config-manager --assumeyes --quiet --disable           \
+          baseos powertools extras;                              \
+      dnf -y install epel-release;                               \
+      rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-8;          \
+      dnf config-manager --assumeyes --quiet --disable           \
+          epel epel-modular;                                     \
+      for repo in epel-el-8; do                                  \
+          MY_REPO="${REPO_URL}repository/$repo-x86_64-proxy";    \
+          MY_NAME="${MY_REPO#*//}";                              \
+          MY_NAME="${MY_NAME//\//_}";                            \
+          echo -e "[${MY_NAME}]\n\
+name=created from ${MY_REPO}\n\
+baseurl=${MY_REPO}\n\
+enabled=1\n\
+repo_gpgcheck=0\n\
+gpgcheck=1\n" >> /etc/yum.repos.d/local-centos-$repo.repo;       \
+      done;                                                      \
+      sed "s/^mirrorlist_expire=0*/mirrorlist_expire=99999999/"  \
+          -i /etc/dnf/dnf.conf;                                  \
+      dnf -y upgrade epel-release;                               \
+    else                                                         \
+      dnf -y install epel-release dnf-plugins-core &&            \
+      dnf config-manager --assumeyes --set-enabled powertools;   \
+    fi;                                                          \
     dnf clean all
 
 # Currently the appstream REPO can not be part of a repo group
 ARG REPO_APSTREAM
 RUN if [ -n "$REPO_APPSTREAM" ]; then                           \
-      rpm --import /etc/pki/rpm-gpg/*;                          \
+      echo rpm --import /etc/pki/rpm-gpg/*;                          \
       MY_REPO="${REPO_URL}${REPO_APPSTREAM}/";                  \
       MY_NAME="${MY_REPO#*//}";                                 \
       MY_NAME="${MY_NAME//\//_}";                               \
@@ -68,16 +83,17 @@ gpgcheck=1\n" >> /etc/yum.repos.d/local-centos-appstream.repo;  \
 # If a local DAOS repository is supplied, then we should use it
 # This is mainly for quickbuilds
 ARG REPO_DAOS
-RUN if [ -n "$REPO_DAOS" ]; then                                \
-      MY_REPO="${REPO_URL}${REPO_DAOS}/";                       \
-      MY_NAME="${MY_REPO#*//}";                                 \
-      MY_NAME="${MY_NAME//\//_}";                               \
+RUN if [ -n "$REPO_DAOS" ]; then                                  \
+      REPO_DAOS="repository/daos-stack-el-8-x86_64-stable-local"; \
+      MY_REPO="${REPO_URL}${REPO_DAOS}/";                         \
+      MY_NAME="${MY_REPO#*//}";                                   \
+      MY_NAME="${MY_NAME//\//_}";                                 \
       echo -e "[${MY_NAME}]\n\
 name=created from ${MY_REPO}\n\
 baseurl=${MY_REPO}\n\
 enabled=1\n\
 repo_gpgcheck=0\n\
-gpgcheck=0\n" >> /etc/yum.repos.d/local-daos-group.repo;        \
+gpgcheck=0\n" >> /etc/yum.repos.d/local-daos-group.repo;          \
     fi
 
 ARG JENKINS_URL
@@ -95,7 +111,7 @@ RUN for repo in $REPOS; do                                                \
         fi;                                                               \
         echo -e "[$repo:$branch:$build_number]\n\
 name=$repo:$branch:$build_number\n\
-baseurl=${JENKINS_URL}job/daos-stack/job/$repo/job/$branch/$build_number/artifact/artifacts/centos7/\n\
+baseurl=${JENKINS_URL}job/daos-stack/job/$repo/job/$branch/$build_number/artifact/artifacts/centos8/\n\
 enabled=1\n\
 gpgcheck=False\n" >> /etc/yum.repos.d/$repo:$branch:$build_number.repo;   \
         cat /etc/yum.repos.d/$repo:$branch:$build_number.repo; \

--- a/utils/docker/Dockerfile.fedora
+++ b/utils/docker/Dockerfile.fedora
@@ -1,12 +1,12 @@
 # Copyright (C) 2018-2021 Intel Corporation
 # All rights reserved.
 #
-# 'recipe' for Docker to build an image of CentOS 7 based
+# 'recipe' for Docker to build an image of Fedora based
 # environment for building the DAOS project.
 #
 
 # Pull base image
-FROM centos:centos7
+FROM fedora:34
 LABEL maintainer="daos@daos.groups.io"
 
 # Intermittent cache-bust.  Used to reduce load on the actual CACHEBUST later.
@@ -17,9 +17,9 @@ ARG CB0
 # The Docker image starts out with the DISTRO provided GPG keys
 # on the disk, but not installed.  These must be installed before
 # adding any repo that needs GPG keys but does not provide meta
-# data for installing those keys.  Then the epel-release package
-# version from the extras repository must be installed and the
-# GPG key it provides must be installed.
+# data for installing those keys.  Then the epel-release
+# package must be installed and the GPG key it provides must be
+# installed.
 ARG REPO_URL
 ARG REPO_DISTRO
 RUN if [ -n "$REPO_DISTRO" ]; then                              \
@@ -33,19 +33,36 @@ baseurl=${MY_REPO}\n\
 enabled=1\n\
 repo_gpgcheck=0\n\
 gpgcheck=1\n" >> /etc/yum.repos.d/local-centos-group.repo;      \
+      dnf -y install --disablerepo extras --disablerepo baseos  \
+          epel-release-8-8.el8 dnf-plugins-core dnf-utils;      \
+      rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-8;         \
+      dnf config-manager --assumeyes --quiet --disable          \
+          baseos powertools epel epel-modular extras;           \
       sed "s/^mirrorlist_expire=0*/mirrorlist_expire=99999999/" \
-          -i /etc/yum.conf;                                     \
-      yum -y install --disablerepo=base,extras,updates          \
-             dnf dnf-plugins-core epel-release-7-11;            \
-      rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-7;         \
-      dnf config-manager --assumeyes --quiet                    \
-          --disable base epel extras updates;                   \
+          -i /etc/dnf/dnf.conf;                                 \
+      dnf -y upgrade epel-release;                              \
     else                                                        \
-      yum -y install dnf dnf-plugins-core epel-release-7-11;    \
+      dnf -y install epel-release dnf-plugins-core &&           \
+      dnf config-manager --assumeyes --set-enabled powertools;  \
     fi;                                                         \
-    dnf -y upgrade epel-release;                                \
-    yum clean all;                                              \
     dnf clean all
+
+# Currently the appstream REPO can not be part of a repo group
+ARG REPO_APSTREAM
+RUN if [ -n "$REPO_APPSTREAM" ]; then                           \
+      rpm --import /etc/pki/rpm-gpg/*;                          \
+      MY_REPO="${REPO_URL}${REPO_APPSTREAM}/";                  \
+      MY_NAME="${MY_REPO#*//}";                                 \
+      MY_NAME="${MY_NAME//\//_}";                               \
+      echo -e "[${MY_NAME}]\n\
+name=created from ${MY_REPO}\n\
+baseurl=${MY_REPO}\n\
+enabled=1\n\
+repo_gpgcheck=1\n\
+gpgcheck=1\n" >> /etc/yum.repos.d/local-centos-appstream.repo;  \
+      dnf config-manager --assumeyes --quiet --disable          \
+          appstream;                                            \
+    fi
 
 # If a local DAOS repository is supplied, then we should use it
 # This is mainly for quickbuilds
@@ -59,7 +76,6 @@ name=created from ${MY_REPO}\n\
 baseurl=${MY_REPO}\n\
 enabled=1\n\
 repo_gpgcheck=0\n\
-exclude=fuse-3* fuse-devel-3* fuse-libs-3* fuse-debuginfo-3* ompi*\n\
 gpgcheck=0\n" >> /etc/yum.repos.d/local-daos-group.repo;        \
     fi
 
@@ -78,7 +94,7 @@ RUN for repo in $REPOS; do                                                \
         fi;                                                               \
         echo -e "[$repo:$branch:$build_number]\n\
 name=$repo:$branch:$build_number\n\
-baseurl=${JENKINS_URL}job/daos-stack/job/$repo/job/$branch/$build_number/artifact/artifacts/centos7/\n\
+baseurl=${JENKINS_URL}job/daos-stack/job/$repo/job/$branch/$build_number/artifact/artifacts/fedora/\n\
 enabled=1\n\
 gpgcheck=False\n" >> /etc/yum.repos.d/$repo:$branch:$build_number.repo;   \
         cat /etc/yum.repos.d/$repo:$branch:$build_number.repo; \
@@ -93,28 +109,27 @@ gpgcheck=False\n" >> /etc/yum.repos.d/$repo:$branch:$build_number.repo;   \
 # libatomic should be in this list, but can not for now due to CI
 # post provisioning issue.
 # *** Keep these in as much alphbetical order as possible ***
-RUN dnf -y install deltarpm && \
-    dnf -y upgrade && \
+RUN dnf -y upgrade && \
     dnf -y install \
-        boost-python36-devel \
+        boost-python3-devel \
         clang-analyzer \
         cmake \
         CUnit-devel \
         e2fsprogs \
         file \
         flex \
-        fuse3-devel \
         fuse3 \
+        fuse3-devel \
         gcc \
         gcc-c++ \
         git \
+        glibc-langpack-en \
         golang \
         graphviz \
         hwloc-devel \
         ipmctl \
         java-1.8.0-openjdk \
         json-c-devel \
-        lcov \
         libaio-devel \
         libcmocka-devel \
         libevent-devel \
@@ -134,20 +149,19 @@ RUN dnf -y install deltarpm && \
         ninja-build \
         numactl \
         numactl-devel \
-        openmpi3-devel \
+        openmpi-devel \
         openssl-devel \
         patch \
         patchelf \
         pciutils \
+        python3-devel \
+        python3-distro \
+        python3-junit_xml \
         python3-pip \
-        python36-defusedxml \
-        python36-devel \
-        python36-distro \
-        python36-junit_xml \
-        python36-tabulate \
-        python36-pyxattr \
-        python36-PyYAML \
-        python36-scons \
+        python3-pyxattr \
+        python3-tabulate \
+        python3-scons \
+        python3-yaml \
         sg3_utils \
         sudo \
         valgrind-devel \

--- a/utils/docker/Dockerfile.leap.15
+++ b/utils/docker/Dockerfile.leap.15
@@ -22,17 +22,17 @@ ARG REPO_URL
 ARG REPO_DISTRO
 RUN if [ -n "${REPO_DISTRO}" ]; then                                           \
       rm -f /etc/zypp/repos.d/*.repo &&                                        \
+      for repo in opensuse-15.3-{update-oss-x86_64-provo-mirror-proxy,update-non-oss-x86_64-proxy,oss-x86_64-proxy,non-oss-x86_64-proxy} ; do        \
       zypper --non-interactive addrepo --gpgcheck-allow-unsigned-repo          \
-            ${REPO_URL}${REPO_DISTRO}/ daos-stack-distro-group-repo &&         \
-      zypper --non-interactive modifyrepo --gpgcheck-allow-unsigned-repo       \
-             daos-stack-distro-group-repo &&                                   \
+            ${REPO_URL}$repo/ &&         \
       zypper clean --all;                                                      \
     fi
 
 # If a local DAOS repository is supplied, then we should use it
 # This is mainly for quickbuilds
 ARG REPO_DAOS
-RUN if [ -n "$REPO_DAOS" ]; then                                \
+RUN if [ -n "$REPO_DAOS" ]; then                                               \
+      REPO_DAOS="repository/daos-stack-opensuse-15-x86_64-stable-local";       \
       zypper --non-interactive addrepo --gpgcheck-allow-unsigned-repo          \
              ${REPO_URL}${REPO_DAOS} daos-stack-daos-group-repo &&             \
       zypper --non-interactive modifyrepo --no-gpgcheck                        \

--- a/utils/docker/Dockerfile.leap.15
+++ b/utils/docker/Dockerfile.leap.15
@@ -24,7 +24,7 @@ RUN if [ -n "${REPO_DISTRO}" ]; then                                            
       rm -f /etc/zypp/repos.d/*.repo &&                                                                                                      \
       for repo in opensuse-15.3-{update-oss-x86_64-provo-mirror-proxy,update-non-oss-x86_64-proxy,oss-x86_64-proxy,non-oss-x86_64-proxy}; do \
           zypper --non-interactive addrepo --gpgcheck-allow-unsigned-repo                                                                    \
-                ${REPO_URL}$repo/                                                                                                            \
+                ${REPO_URL}$repo/;                                                                                                           \
       done;                                                                                                                                  \
       zypper clean --all;                                                                                                                    \
     fi

--- a/utils/docker/Dockerfile.leap.15
+++ b/utils/docker/Dockerfile.leap.15
@@ -20,13 +20,13 @@ ARG CB0
 # data for installing those keys.
 ARG REPO_URL
 ARG REPO_DISTRO
-RUN if [ -n "${REPO_DISTRO}" ]; then                                                                                                          \
-      rm -f /etc/zypp/repos.d/*.repo &&                                                                                                       \
-      for repo in opensuse-15.3-{update-oss-x86_64-provo-mirror-proxy,update-non-oss-x86_64-proxy,oss-x86_64-proxy,non-oss-x86_64-proxy} ; do \
-          zypper --non-interactive addrepo --gpgcheck-allow-unsigned-repo                                                                     \
-                ${REPO_URL}$repo/ &&                                                                                                          \
-      done;                                                                                                                                   \
-      zypper clean --all;                                                                                                                     \
+RUN if [ -n "${REPO_DISTRO}" ]; then                                                                                                         \
+      rm -f /etc/zypp/repos.d/*.repo &&                                                                                                      \
+      for repo in opensuse-15.3-{update-oss-x86_64-provo-mirror-proxy,update-non-oss-x86_64-proxy,oss-x86_64-proxy,non-oss-x86_64-proxy}; do \
+          zypper --non-interactive addrepo --gpgcheck-allow-unsigned-repo                                                                    \
+                ${REPO_URL}$repo/                                                                                                            \
+      done;                                                                                                                                  \
+      zypper clean --all;                                                                                                                    \
     fi
 
 # If a local DAOS repository is supplied, then we should use it

--- a/utils/docker/Dockerfile.leap.15
+++ b/utils/docker/Dockerfile.leap.15
@@ -23,7 +23,7 @@ ARG REPO_DISTRO
 RUN if [ -n "${REPO_DISTRO}" ]; then                                                                                                         \
       rm -f /etc/zypp/repos.d/*.repo &&                                                                                                      \
       for repo in opensuse-15.3-{update-oss-x86_64-provo-mirror-proxy,update-non-oss-x86_64-proxy,oss-x86_64-proxy,non-oss-x86_64-proxy}; do \
-          zypper --non-interactive addrepo --gpgcheck-allow-unsigned-repo                                                                    \
+          zypper --non-interactive addrepo --gpgcheck-allow-unsigned-repo $repo                                                              \
                 ${REPO_URL}$repo/;                                                                                                           \
       done;                                                                                                                                  \
       zypper clean --all;                                                                                                                    \
@@ -33,7 +33,7 @@ RUN if [ -n "${REPO_DISTRO}" ]; then                                            
 # This is mainly for quickbuilds
 ARG REPO_DAOS
 RUN if [ -n "$REPO_DAOS" ]; then                                         \
-      REPO_DAOS="repository/daos-stack-opensuse-15-x86_64-stable-local"; \
+      REPO_DAOS="repository/daos-stack-leap-15-x86_64-stable-local";     \
       zypper --non-interactive addrepo --gpgcheck-allow-unsigned-repo    \
              ${REPO_URL}${REPO_DAOS} daos-stack-daos-group-repo &&       \
       zypper --non-interactive modifyrepo --no-gpgcheck                  \

--- a/utils/docker/Dockerfile.leap.15
+++ b/utils/docker/Dockerfile.leap.15
@@ -20,27 +20,28 @@ ARG CB0
 # data for installing those keys.
 ARG REPO_URL
 ARG REPO_DISTRO
-RUN if [ -n "${REPO_DISTRO}" ]; then                                           \
-      rm -f /etc/zypp/repos.d/*.repo &&                                        \
-      for repo in opensuse-15.3-{update-oss-x86_64-provo-mirror-proxy,update-non-oss-x86_64-proxy,oss-x86_64-proxy,non-oss-x86_64-proxy} ; do        \
-      zypper --non-interactive addrepo --gpgcheck-allow-unsigned-repo          \
-            ${REPO_URL}$repo/ &&         \
-      zypper clean --all;                                                      \
+RUN if [ -n "${REPO_DISTRO}" ]; then                                                                                                          \
+      rm -f /etc/zypp/repos.d/*.repo &&                                                                                                       \
+      for repo in opensuse-15.3-{update-oss-x86_64-provo-mirror-proxy,update-non-oss-x86_64-proxy,oss-x86_64-proxy,non-oss-x86_64-proxy} ; do \
+          zypper --non-interactive addrepo --gpgcheck-allow-unsigned-repo                                                                     \
+                ${REPO_URL}$repo/ &&                                                                                                          \
+      done;                                                                                                                                   \
+      zypper clean --all;                                                                                                                     \
     fi
 
 # If a local DAOS repository is supplied, then we should use it
 # This is mainly for quickbuilds
 ARG REPO_DAOS
-RUN if [ -n "$REPO_DAOS" ]; then                                               \
-      REPO_DAOS="repository/daos-stack-opensuse-15-x86_64-stable-local";       \
-      zypper --non-interactive addrepo --gpgcheck-allow-unsigned-repo          \
-             ${REPO_URL}${REPO_DAOS} daos-stack-daos-group-repo &&             \
-      zypper --non-interactive modifyrepo --no-gpgcheck                        \
-             daos-stack-daos-group-repo &&                                     \
-      zypper addlock --repo daos-stack-daos-group-repo                         \
-             'fuse<3' 'libfuse-devel<3' 'fuse-libs<3'                          \
-             'fuse-debuginfo<3' 'ompi' &&                                      \
-      zypper clean --all;                                                      \
+RUN if [ -n "$REPO_DAOS" ]; then                                         \
+      REPO_DAOS="repository/daos-stack-opensuse-15-x86_64-stable-local"; \
+      zypper --non-interactive addrepo --gpgcheck-allow-unsigned-repo    \
+             ${REPO_URL}${REPO_DAOS} daos-stack-daos-group-repo &&       \
+      zypper --non-interactive modifyrepo --no-gpgcheck                  \
+             daos-stack-daos-group-repo &&                               \
+      zypper addlock --repo daos-stack-daos-group-repo                   \
+             'fuse<3' 'libfuse-devel<3' 'fuse-libs<3'                    \
+             'fuse-debuginfo<3' 'ompi' &&                                \
+      zypper clean --all;                                                \
     fi
 # Allow packages to change vendors
 RUN echo "solver.allowVendorChange = true" >> /etc/zypp/zypp.conf

--- a/utils/docker/Dockerfile.leap.15
+++ b/utils/docker/Dockerfile.leap.15
@@ -23,8 +23,7 @@ ARG REPO_DISTRO
 RUN if [ -n "${REPO_DISTRO}" ]; then                                                                                                         \
       rm -f /etc/zypp/repos.d/*.repo &&                                                                                                      \
       for repo in opensuse-15.3-{update-oss-x86_64-provo-mirror-proxy,update-non-oss-x86_64-proxy,oss-x86_64-proxy,non-oss-x86_64-proxy}; do \
-          zypper --non-interactive addrepo --gpgcheck-allow-unsigned-repo $repo                                                              \
-                ${REPO_URL}$repo/;                                                                                                           \
+          zypper --non-interactive addrepo --gpgcheck-allow-unsigned-repo ${REPO_URL}$repo/ $repo;                                           \
       done;                                                                                                                                  \
       zypper clean --all;                                                                                                                    \
     fi

--- a/utils/docker/Dockerfile.leap.15
+++ b/utils/docker/Dockerfile.leap.15
@@ -23,7 +23,7 @@ ARG REPO_DISTRO
 RUN if [ -n "${REPO_DISTRO}" ]; then                                                                                                         \
       rm -f /etc/zypp/repos.d/*.repo &&                                                                                                      \
       for repo in opensuse-15.3-{update-oss-x86_64-provo-mirror-proxy,update-non-oss-x86_64-proxy,oss-x86_64-proxy,non-oss-x86_64-proxy}; do \
-          zypper --non-interactive addrepo --gpgcheck-allow-unsigned-repo ${REPO_URL}$repo/ $repo;                                           \
+          zypper --non-interactive addrepo --gpgcheck-allow-unsigned-repo ${REPO_URL}repository/$repo/ $repo;                                \
       done;                                                                                                                                  \
       zypper clean --all;                                                                                                                    \
     fi

--- a/utils/rpms/packaging/Makefile_packaging.mk
+++ b/utils/rpms/packaging/Makefile_packaging.mk
@@ -301,14 +301,33 @@ ifeq ($(ID_LIKE),debian)
 # $(DISTRO_BASE)_LOCAL_REPOS is a list separated by | because you cannot pass lists
 # of values with spaces as environment variables
 $(DISTRO_BASE)_LOCAL_REPOS := [trusted=yes]
+else
+$(DISTRO_BASE)_LOCAL_REPOS := $(REPOSITORY_URL)$(DAOS_STACK_$(DISTRO_BASE)_LOCAL_REPO)|
+DISTRO_REPOS = disabled # any non-empty value here works and is not used beyond testing if the value is empty or not
 endif
+ifeq ($(DISTRO_BASE), EL_8)
+# hack to use 8.3 non-group repos on EL_8
+$(DISTRO_BASE)_LOCAL_REPOS := $($(DISTRO_BASE)_LOCAL_REPOS)$(REPOSITORY_URL)repository/centos-8.3-base-x86_64-proxy|$(REPOSITORY_URL)repository/centos-8.3-extras-x86_64-proxy|$(REPOSITORY_URL)repository/centos-8.3-powertools-x86_64-proxy|$(REPOSITORY_URL)repository/epel-el-8-x86_64-proxy
+else
+ifeq ($(DISTRO_BASE), EL_7)
+# hack to use 7.9 non-group repos on EL_7
+$(DISTRO_BASE)_LOCAL_REPOS := $($(DISTRO_BASE)_LOCAL_REPOS)$(REPOSITORY_URL)repository/centos-7.9-base-x86_64-proxy|$(REPOSITORY_URL)repository/centos-7.9-extras-x86_64-proxy|$(REPOSITORY_URL)repository/centos-7.9-updates-x86_64-proxy|$(REPOSITORY_URL)repository/epel-el-7-x86_64-proxy
+else
+ifeq ($(DISTRO_BASE), LEAP_15)
+# hack to use 15.2 non-group repos on LEAP_15
+$(DISTRO_BASE)_LOCAL_REPOS := $($(DISTRO_BASE)_LOCAL_REPOS)$(REPOSITORY_URL)repository/opensuse-15.2-update-oss-x86_64-provo-mirror-proxy|$(REPOSITORY_URL)repository/opensuse-15.2-update-non-oss-x86_64-proxy|$(REPOSITORY_URL)repository/opensuse-15.2-oss-x86_64-proxy|$(REPOSITORY_URL)repository/opensuse-15.2-non-oss-x86_64-proxy
+else
 $(DISTRO_BASE)_LOCAL_REPOS := $($(DISTRO_BASE)_LOCAL_REPOS) $(REPOSITORY_URL)$(DAOS_STACK_$(DISTRO_BASE)_$(DAOS_REPO_TYPE)_REPO)/
 endif
-$(DISTRO_BASE)_LOCAL_REPOS := $($(DISTRO_BASE)_LOCAL_REPOS)|
-ifneq ($(DAOS_STACK_$(DISTRO_BASE)_DOCKER_$(DAOS_REPO_TYPE)_REPO),)
-DISTRO_REPOS = $(DAOS_STACK_$(DISTRO_BASE)_DOCKER_$(DAOS_REPO_TYPE)_REPO)
-$(DISTRO_BASE)_LOCAL_REPOS := $($(DISTRO_BASE)_LOCAL_REPOS)$(REPOSITORY_URL)$(DAOS_STACK_$(DISTRO_BASE)_DOCKER_$(DAOS_REPO_TYPE)_REPO)/|
 endif
+endif
+endif
+$(DISTRO_BASE)_LOCAL_REPOS := $($(DISTRO_BASE)_LOCAL_REPOS)|
+# group repos are not working in Nexus so we hack in the group members directly above
+#ifneq ($(DAOS_STACK_$(DISTRO_BASE)_DOCKER_$(DAOS_REPO_TYPE)_REPO),)
+#DISTRO_REPOS = $(DAOS_STACK_$(DISTRO_BASE)_DOCKER_$(DAOS_REPO_TYPE)_REPO)
+#$(DISTRO_BASE)_LOCAL_REPOS := $($(DISTRO_BASE)_LOCAL_REPOS)$(REPOSITORY_URL)$(DAOS_STACK_$(DISTRO_BASE)_DOCKER_$(DAOS_REPO_TYPE)_REPO)/|
+#endif
 ifneq ($(DAOS_STACK_$(DISTRO_BASE)_APPSTREAM_REPO),)
 $(DISTRO_BASE)_LOCAL_REPOS := $($(DISTRO_BASE)_LOCAL_REPOS)$(REPOSITORY_URL)$(DAOS_STACK_$(DISTRO_BASE)_APPSTREAM_REPO)|
 endif


### PR DESCRIPTION
- DAOS-623 ci: Stop using group repos for RPM builds
- CORCI-1081 ci: Move default EL7 testing to EL8
- Fix Fedora dockerfile name
- Fix pragmas
- Run Bullseye also
- Fix leap15 dockerfile
- Fix Leap dockerfile again
- One last try to get it right
- Fix stable-local repo name
- Fix order
- Need the repository/ subdir
- Use python3 for raft tests
- Build Bullseye on EL8
- Add Doc-only: pragma
- Remove Doc-only: true
- More CentOS 7 -> 8
- Need compat-hwloc1 on 8.3
- Remoeve half-baked sh call
- Run all build stages
- s/_/-/
- Don't need compat-hwloc1
- Replace removed "
- Set the same target for the build
- DAOS-8873 control: Fix hwloc tests on el8
