### PR TITLE
DAOS-8777 telemetry: Improve Prometheus exporter performance (#6987)

### DIFF
--- a/src/control/lib/telemetry/promexp/collector.go
+++ b/src/control/lib/telemetry/promexp/collector.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+	"sync"
 	"unicode"
 
 	"github.com/pkg/errors"
@@ -36,14 +37,50 @@ type (
 	}
 
 	EngineSource struct {
-		ctx     context.Context
-		Index   uint32
-		Rank    uint32
-		enabled atm.Bool
+		ctx      context.Context
+		Index    uint32
+		Rank     uint32
+		enabled  atm.Bool
+		tmSchema *telemetry.Schema
+		rmSchema rankMetricSchema
 	}
 
-	labelMap map[string]string
+	rankMetricSchema struct {
+		mu          sync.Mutex
+		rankMetrics map[string]*rankMetric
+		seen        map[string]struct{}
+	}
 )
+
+func (s *rankMetricSchema) Prune() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	for id := range s.rankMetrics {
+		if _, found := s.seen[id]; !found {
+			delete(s.rankMetrics, id)
+		}
+	}
+	s.seen = make(map[string]struct{})
+}
+
+func (s *rankMetricSchema) add(log logging.Logger, rank uint32, metric telemetry.Metric) (rm *rankMetric) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	id := metric.FullPath()
+	s.seen[id] = struct{}{}
+
+	var found bool
+	if rm, found = s.rankMetrics[id]; !found {
+		rm = newRankMetric(log, rank, metric)
+		s.rankMetrics[id] = rm
+	} else {
+		rm.resetVecs()
+	}
+
+	return
+}
 
 func NewEngineSource(parent context.Context, idx uint32, rank uint32) (*EngineSource, func(), error) {
 	ctx, err := telemetry.Init(parent, idx)
@@ -56,10 +93,15 @@ func NewEngineSource(parent context.Context, idx uint32, rank uint32) (*EngineSo
 	}
 
 	return &EngineSource{
-		ctx:     ctx,
-		Index:   idx,
-		Rank:    rank,
-		enabled: atm.NewBool(true),
+		ctx:      ctx,
+		Index:    idx,
+		Rank:     rank,
+		enabled:  atm.NewBool(true),
+		tmSchema: telemetry.NewSchema(),
+		rmSchema: rankMetricSchema{
+			rankMetrics: make(map[string]*rankMetric),
+			seen:        make(map[string]struct{}),
+		},
 	}, cleanupFn, nil
 }
 
@@ -99,6 +141,16 @@ func NewCollector(log logging.Logger, opts *CollectorOpts, sources ...*EngineSou
 	}
 
 	return c, nil
+}
+
+type labelMap map[string]string
+
+func (lm labelMap) keys() (keys []string) {
+	for label := range lm {
+		keys = append(keys, label)
+	}
+
+	return
 }
 
 func sanitizeMetricName(in string) string {
@@ -185,26 +237,26 @@ func (es *EngineSource) Collect(log logging.Logger, ch chan<- *rankMetric) {
 		log.Error("nil engine source")
 		return
 	}
+	if !es.IsEnabled() {
+		return
+	}
 	if ch == nil {
 		log.Error("nil channel")
 		return
 	}
 	metrics := make(chan telemetry.Metric)
 	go func() {
-		if err := telemetry.CollectMetrics(es.ctx, metrics); err != nil {
+		if err := telemetry.CollectMetrics(es.ctx, es.tmSchema, metrics); err != nil {
 			log.Errorf("failed to collect metrics for engine rank %d: %s", es.Rank, err)
 			return
 		}
+		es.tmSchema.Prune()
 	}()
 
 	for metric := range metrics {
-		if es.IsEnabled() {
-			ch <- &rankMetric{
-				rank:   es.Rank,
-				metric: metric,
-			}
-		}
+		ch <- es.rmSchema.add(log, es.Rank, metric)
 	}
+	es.rmSchema.Prune()
 }
 
 // IsEnabled checks if the engine source is enabled.
@@ -222,9 +274,108 @@ func (es *EngineSource) Disable() {
 	es.enabled.SetFalse()
 }
 
+type gvMap map[string]*prometheus.GaugeVec
+
+func (m gvMap) add(name, help string, labels labelMap) {
+	if _, found := m[name]; !found {
+		gv := prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name: name,
+			Help: help,
+		}, labels.keys())
+		m[name] = gv
+	}
+}
+
+func (m gvMap) set(name string, value float64, labels labelMap) error {
+	gv, found := m[name]
+	if !found {
+		return errors.Errorf("gauge vector %s not found", name)
+	}
+	gv.With(prometheus.Labels(labels)).Set(value)
+
+	return nil
+}
+
+type cvMap map[string]*prometheus.CounterVec
+
+func (m cvMap) add(name, help string, labels labelMap) {
+	if _, found := m[name]; !found {
+		cv := prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: name,
+			Help: help,
+		}, labels.keys())
+		m[name] = cv
+	}
+}
+
+func (m cvMap) set(name string, value float64, labels labelMap) error {
+	cv, found := m[name]
+	if !found {
+		return errors.Errorf("counter vector %s not found", name)
+	}
+	cv.With(prometheus.Labels(labels)).Add(value)
+
+	return nil
+}
+
 type rankMetric struct {
-	rank   uint32
-	metric telemetry.Metric
+	rank     uint32
+	metric   telemetry.Metric
+	baseName string
+	labels   labelMap
+	gvm      gvMap
+	cvm      cvMap
+}
+
+func (rm *rankMetric) collect(ch chan<- prometheus.Metric) {
+	for _, gv := range rm.gvm {
+		gv.Collect(ch)
+	}
+	for _, cv := range rm.cvm {
+		cv.Collect(ch)
+	}
+}
+
+func (rm *rankMetric) resetVecs() {
+	for _, gv := range rm.gvm {
+		gv.Reset()
+	}
+	for _, cv := range rm.cvm {
+		cv.Reset()
+	}
+}
+
+func newRankMetric(log logging.Logger, rank uint32, m telemetry.Metric) *rankMetric {
+	rm := &rankMetric{
+		metric: m,
+		rank:   rank,
+		gvm:    make(gvMap),
+		cvm:    make(cvMap),
+	}
+
+	var name string
+	rm.labels, name = extractLabels(m.FullPath())
+	rm.labels["rank"] = fmt.Sprintf("%d", rm.rank)
+
+	rm.baseName = strings.Join([]string{"engine", name}, "_")
+	desc := m.Desc()
+
+	switch rm.metric.Type() {
+	case telemetry.MetricTypeGauge, telemetry.MetricTypeTimestamp,
+		telemetry.MetricTypeSnapshot:
+		rm.gvm.add(rm.baseName, desc, rm.labels)
+	case telemetry.MetricTypeStatsGauge, telemetry.MetricTypeDuration:
+		rm.gvm.add(rm.baseName, desc, rm.labels)
+		for _, ms := range getMetricStats(rm.baseName, rm.metric) {
+			rm.gvm.add(ms.name, ms.desc, rm.labels)
+		}
+	case telemetry.MetricTypeCounter:
+		rm.cvm.add(rm.baseName, desc, rm.labels)
+	default:
+		log.Errorf("[%s]: metric type %d not supported", name, rm.metric.Type())
+	}
+
+	return rm
 }
 
 func (c *Collector) isIgnored(name string) bool {
@@ -237,55 +388,13 @@ func (c *Collector) isIgnored(name string) bool {
 	return false
 }
 
-func (lm labelMap) keys() (keys []string) {
-	for label := range lm {
-		keys = append(keys, label)
-	}
-
-	return
-}
-
-type gvMap map[string]*prometheus.GaugeVec
-
-func (m gvMap) add(name, help string, value float64, labels labelMap) {
-	var gv *prometheus.GaugeVec
-	var found bool
-
-	gv, found = m[name]
-	if !found {
-		gv = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-			Name: name,
-			Help: help,
-		}, labels.keys())
-		m[name] = gv
-	}
-	gv.With(prometheus.Labels(labels)).Set(value)
-}
-
-type cvMap map[string]*prometheus.CounterVec
-
-func (m cvMap) add(name, help string, value float64, labels labelMap) {
-	var cv *prometheus.CounterVec
-	var found bool
-
-	cv, found = m[name]
-	if !found {
-		cv = prometheus.NewCounterVec(prometheus.CounterOpts{
-			Name: name,
-			Help: help,
-		}, labels.keys())
-		m[name] = cv
-	}
-	cv.With(prometheus.Labels(labels)).Add(value)
-}
-
 type metricStat struct {
 	name  string
 	desc  string
 	value float64
 }
 
-func getMetricStats(baseName, desc string, m telemetry.Metric) (stats []*metricStat) {
+func getMetricStats(baseName string, m telemetry.Metric) (stats []*metricStat) {
 	ms, ok := m.(telemetry.StatsMetric)
 	if !ok {
 		return
@@ -314,7 +423,7 @@ func getMetricStats(baseName, desc string, m telemetry.Metric) (stats []*metricS
 	} {
 		stats = append(stats, &metricStat{
 			name:  baseName + "_" + name,
-			desc:  desc + s.desc,
+			desc:  m.Desc() + s.desc,
 			value: s.fn(),
 		})
 	}
@@ -339,49 +448,37 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) {
 		close(rankMetrics)
 	}(c.sources)
 
-	gauges := make(gvMap)
-	counters := make(cvMap)
-
 	for rm := range rankMetrics {
-		labels, name := extractLabels(rm.metric.FullPath())
-		labels["rank"] = fmt.Sprintf("%d", rm.rank)
-
-		baseName := strings.Join([]string{"engine", name}, "_")
-		desc := rm.metric.Desc()
-
-		if c.isIgnored(baseName) {
+		if c.isIgnored(rm.baseName) {
 			continue
 		}
 
+		var err error
 		switch rm.metric.Type() {
-		case telemetry.MetricTypeGauge:
-			gauges.add(baseName, desc, rm.metric.FloatValue(), labels)
-		case telemetry.MetricTypeStatsGauge:
-			gauges.add(baseName, desc, rm.metric.FloatValue(), labels)
-			for _, ms := range getMetricStats(baseName, desc, rm.metric) {
-				gauges.add(ms.name, ms.desc, ms.value, labels)
+		case telemetry.MetricTypeGauge, telemetry.MetricTypeTimestamp,
+			telemetry.MetricTypeSnapshot:
+			err = rm.gvm.set(rm.baseName, rm.metric.FloatValue(), rm.labels)
+		case telemetry.MetricTypeStatsGauge, telemetry.MetricTypeDuration:
+			if err = rm.gvm.set(rm.baseName, rm.metric.FloatValue(), rm.labels); err != nil {
+				break
+			}
+			for _, ms := range getMetricStats(rm.baseName, rm.metric) {
+				if err = rm.gvm.set(ms.name, ms.value, rm.labels); err != nil {
+					break
+				}
 			}
 		case telemetry.MetricTypeCounter:
-			counters.add(baseName, desc, rm.metric.FloatValue(), labels)
-		case telemetry.MetricTypeTimestamp:
-			gauges.add(baseName, desc, rm.metric.FloatValue(), labels)
-		case telemetry.MetricTypeSnapshot:
-			gauges.add(baseName, desc, rm.metric.FloatValue(), labels)
-		case telemetry.MetricTypeDuration:
-			gauges.add(baseName, desc, rm.metric.FloatValue(), labels)
-			for _, ms := range getMetricStats(baseName, desc, rm.metric) {
-				gauges.add(ms.name, ms.desc, ms.value, labels)
-			}
+			err = rm.cvm.set(rm.baseName, rm.metric.FloatValue(), rm.labels)
 		default:
-			c.log.Errorf("[%s]: metric type %d not supported", name, rm.metric.Type())
+			c.log.Errorf("[%s]: metric type %d not supported", rm.baseName, rm.metric.Type())
 		}
-	}
 
-	for _, gv := range gauges {
-		gv.Collect(ch)
-	}
-	for _, cv := range counters {
-		cv.Collect(ch)
+		if err != nil {
+			c.log.Errorf("[%s]: %s", rm.baseName, err)
+			continue
+		}
+
+		rm.collect(ch)
 	}
 }
 

--- a/src/control/lib/telemetry/telemetry.go
+++ b/src/control/lib/telemetry/telemetry.go
@@ -39,11 +39,15 @@ const (
 	MetricTypeStatsGauge MetricType = C.D_TM_STATS_GAUGE
 	MetricTypeSnapshot   MetricType = C.D_TM_TIMER_SNAPSHOT
 	MetricTypeTimestamp  MetricType = C.D_TM_TIMESTAMP
+	MetricTypeDirectory  MetricType = C.D_TM_DIRECTORY
+	MetricTypeLink       MetricType = C.D_TM_LINK
 
 	BadUintVal  = ^uint64(0)
 	BadFloatVal = float64(BadUintVal)
 	BadIntVal   = int64(BadUintVal >> 1)
 	BadDuration = time.Duration(BadIntVal)
+
+	pathSep = '/'
 )
 
 type (
@@ -165,7 +169,7 @@ func (mb *metricBase) FullPath() string {
 		return "<nil>"
 	}
 
-	return strings.Join([]string{mb.Path(), mb.Name()}, "/")
+	return mb.Path() + string(pathSep) + mb.Name()
 }
 
 func (mb *metricBase) fillMetadata() {
@@ -320,14 +324,94 @@ func Detach(ctx context.Context) {
 	}
 }
 
-func visit(hdl *handle, node *C.struct_d_tm_node_t, pathComps []string, out chan<- Metric) {
+type Schema struct {
+	mu      sync.RWMutex
+	metrics map[string]Metric
+	seen    map[string]struct{}
+}
+
+func (s *Schema) setSeen(id string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.seen[id] = struct{}{}
+}
+
+func (s *Schema) Prune() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for k := range s.metrics {
+		if _, found := s.seen[k]; !found {
+			delete(s.metrics, k)
+		}
+	}
+	s.seen = make(map[string]struct{}) // reset for the next time
+}
+
+func splitId(id string) (string, string) {
+	i := len(id) - 1
+	for i >= 0 && id[i] != pathSep {
+		i--
+	}
+
+	name := id[i+1:]
+	// Trim trailing separator.
+	if id[i] == pathSep {
+		i--
+	}
+
+	return id[:i+1], name
+}
+
+func (s *Schema) Add(hdl *handle, id string, typ C.int, node *C.struct_d_tm_node_t) Metric {
+	s.setSeen(id)
+	s.mu.RLock()
+	if m, found := s.metrics[id]; found {
+		s.mu.RUnlock()
+		return m
+	}
+	s.mu.RUnlock()
+
+	var m Metric
+	path, name := splitId(id)
+	switch {
+	case typ == C.D_TM_GAUGE:
+		m = newGauge(hdl, path, &name, node)
+	case typ == C.D_TM_STATS_GAUGE:
+		m = newStatsGauge(hdl, path, &name, node)
+	case typ == C.D_TM_COUNTER:
+		m = newCounter(hdl, path, &name, node)
+	case typ == C.D_TM_TIMESTAMP:
+		m = newTimestamp(hdl, path, &name, node)
+	case (typ & C.D_TM_TIMER_SNAPSHOT) != 0:
+		m = newSnapshot(hdl, path, &name, node)
+	case (typ & C.D_TM_DURATION) != 0:
+		m = newDuration(hdl, path, &name, node)
+	default:
+		return nil
+	}
+	s.mu.Lock()
+	s.metrics[id] = m
+	s.mu.Unlock()
+
+	return m
+}
+
+func NewSchema() *Schema {
+	return &Schema{
+		metrics: make(map[string]Metric),
+		seen:    make(map[string]struct{}),
+	}
+
+}
+
+func visit(hdl *handle, s *Schema, node *C.struct_d_tm_node_t, pathComps []string, out chan<- Metric) {
 	var next *C.struct_d_tm_node_t
 
 	if node == nil {
 		return
 	}
-	path := strings.Join(pathComps, "/")
 	name := C.GoString(C.d_tm_get_name(hdl.ctx, node))
+	id := strings.Join(append(pathComps, name), string(pathSep))
 
 	cType := node.dtn_type
 
@@ -335,36 +419,28 @@ func visit(hdl *handle, node *C.struct_d_tm_node_t, pathComps []string, out chan
 	case cType == C.D_TM_DIRECTORY:
 		next = C.d_tm_get_child(hdl.ctx, node)
 		if next != nil {
-			visit(hdl, next, append(pathComps, name), out)
+			visit(hdl, s, next, append(pathComps, name), out)
 		}
-	case cType == C.D_TM_GAUGE:
-		out <- newGauge(hdl, path, &name, node)
-	case cType == C.D_TM_STATS_GAUGE:
-		out <- newStatsGauge(hdl, path, &name, node)
-	case cType == C.D_TM_COUNTER:
-		out <- newCounter(hdl, path, &name, node)
-	case cType == C.D_TM_TIMESTAMP:
-		out <- newTimestamp(hdl, path, &name, node)
-	case (cType & C.D_TM_TIMER_SNAPSHOT) != 0:
-		out <- newSnapshot(hdl, path, &name, node)
-	case (cType & C.D_TM_DURATION) != 0:
-		out <- newDuration(hdl, path, &name, node)
 	case cType == C.D_TM_LINK:
 		next = C.d_tm_follow_link(hdl.ctx, node)
 		if next != nil {
 			// link leads to a directory with the same name
-			visit(hdl, next, pathComps, out)
+			visit(hdl, s, next, pathComps, out)
 		}
 	default:
+		m := s.Add(hdl, id, cType, node)
+		if m != nil {
+			out <- m
+		}
 	}
 
 	next = C.d_tm_get_sibling(hdl.ctx, node)
 	if next != nil && next != node {
-		visit(hdl, next, pathComps, out)
+		visit(hdl, s, next, pathComps, out)
 	}
 }
 
-func CollectMetrics(ctx context.Context, out chan<- Metric) error {
+func CollectMetrics(ctx context.Context, s *Schema, out chan<- Metric) error {
 	defer close(out)
 
 	hdl, err := getHandle(ctx)
@@ -379,9 +455,8 @@ func CollectMetrics(ctx context.Context, out chan<- Metric) error {
 	}
 
 	node := hdl.root
-
 	var pathComps []string
-	visit(hdl, node, pathComps, out)
+	visit(hdl, s, node, pathComps, out)
 
 	return nil
 }

--- a/src/control/lib/telemetry/telemetry_test.go
+++ b/src/control/lib/telemetry/telemetry_test.go
@@ -194,6 +194,12 @@ func TestTelemetry_CollectMetrics(t *testing.T) {
 			Name: "collect_test/my_gauge",
 			Cur:  2020,
 		},
+		MetricTypeStatsGauge: &TestMetric{
+			Name: "collect_test/my_stats_gauge",
+			Cur:  4242,
+			min:  10,
+			max:  5000,
+		},
 		MetricTypeTimestamp: &TestMetric{
 			Name: "ts",
 		},
@@ -279,7 +285,8 @@ func TestTelemetry_CollectMetrics(t *testing.T) {
 				wg.Done()
 			}()
 
-			err := CollectMetrics(ctx, ch)
+			s := NewSchema()
+			err := CollectMetrics(ctx, s, ch)
 
 			common.CmpErr(t, tc.expErr, err)
 

--- a/src/control/lib/telemetry/test_helpers.go
+++ b/src/control/lib/telemetry/test_helpers.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/daos-stack/daos/src/control/common"
+	"github.com/daos-stack/daos/src/control/drpc"
 )
 
 /*
@@ -34,6 +35,18 @@ add_metric(struct d_tm_node_t **node, int metric_type, char *sh_desc,
            char *lng_desc, const char *str)
 {
 	return d_tm_add_metric(node, metric_type, sh_desc, lng_desc, str);
+}
+
+static int
+add_eph_dir(struct d_tm_node_t **node, size_t size_bytes, const char *str)
+{
+	return d_tm_add_ephemeral_dir(node, size_bytes, str);
+}
+
+static int
+del_eph_dir(const char *str)
+{
+	return d_tm_del_ephemeral_dir(str);
 }
 */
 import "C"
@@ -107,13 +120,13 @@ func AddTestMetrics(t *testing.T, testMetrics TestMetricsMap) {
 		case MetricTypeGauge:
 			rc := C.add_metric(&tm.node, C.D_TM_GAUGE, C.CString(tm.desc), C.CString(tm.units), C.CString(fullName))
 			if rc != 0 {
-				t.Fatalf("failed to add %s: %d", fullName, rc)
+				t.Fatalf("failed to add %s: %s", fullName, drpc.DaosStatus(rc))
 			}
 			C.d_tm_set_gauge(tm.node, C.uint64_t(tm.Cur))
 		case MetricTypeStatsGauge:
 			rc := C.add_metric(&tm.node, C.D_TM_STATS_GAUGE, C.CString(tm.desc), C.CString(tm.units), C.CString(fullName))
 			if rc != 0 {
-				t.Fatalf("failed to add %s: %d", tm.Name, rc)
+				t.Fatalf("failed to add %s: %s", tm.Name, drpc.DaosStatus(rc))
 			}
 			for _, val := range []float64{tm.min, tm.max, tm.Cur} {
 				C.d_tm_set_gauge(tm.node, C.uint64_t(val))
@@ -121,13 +134,13 @@ func AddTestMetrics(t *testing.T, testMetrics TestMetricsMap) {
 		case MetricTypeCounter:
 			rc := C.add_metric(&tm.node, C.D_TM_COUNTER, C.CString(tm.desc), C.CString(tm.units), C.CString(fullName))
 			if rc != 0 {
-				t.Fatalf("failed to add %s: %d", fullName, rc)
+				t.Fatalf("failed to add %s: %s", fullName, drpc.DaosStatus(rc))
 			}
 			C.d_tm_inc_counter(tm.node, C.ulong(tm.Cur))
 		case MetricTypeDuration:
 			rc := C.add_metric(&tm.node, C.D_TM_DURATION|C.D_TM_CLOCK_REALTIME, C.CString(tm.desc), C.CString(tm.units), C.CString(fullName))
 			if rc != 0 {
-				t.Fatalf("failed to add %s: %d", fullName, rc)
+				t.Fatalf("failed to add %s: %s", fullName, drpc.DaosStatus(rc))
 			}
 			C.d_tm_mark_duration_start(tm.node, C.D_TM_CLOCK_REALTIME)
 			time.Sleep(time.Duration(tm.Cur))
@@ -135,17 +148,43 @@ func AddTestMetrics(t *testing.T, testMetrics TestMetricsMap) {
 		case MetricTypeTimestamp:
 			rc := C.add_metric(&tm.node, C.D_TM_TIMESTAMP, C.CString(tm.desc), C.CString(tm.units), C.CString(fullName))
 			if rc != 0 {
-				t.Fatalf("failed to add %s: %d", fullName, rc)
+				t.Fatalf("failed to add %s: %s", fullName, drpc.DaosStatus(rc))
 			}
 			C.d_tm_record_timestamp(tm.node)
 		case MetricTypeSnapshot:
 			rc := C.add_metric(&tm.node, C.D_TM_TIMER_SNAPSHOT|C.D_TM_CLOCK_REALTIME, C.CString(tm.desc), C.CString(tm.units), C.CString(fullName))
 			if rc != 0 {
-				t.Fatalf("failed to add %s: %d", fullName, rc)
+				t.Fatalf("failed to add %s: %s", fullName, drpc.DaosStatus(rc))
 			}
 			C.d_tm_take_timer_snapshot(tm.node, C.D_TM_CLOCK_REALTIME)
+		case MetricTypeDirectory:
+			rc := C.add_metric(&tm.node, C.D_TM_DIRECTORY, C.CString(tm.desc), C.CString(tm.units), C.CString(fullName))
+			if rc != 0 {
+				t.Fatalf("failed to add %s: %s", fullName, drpc.DaosStatus(rc))
+			}
+		case MetricTypeLink:
+			rc := C.add_eph_dir(&tm.node, 1024, C.CString(fullName))
+			if rc != 0 {
+				t.Fatalf("failed to add %s: %s", fullName, drpc.DaosStatus(rc))
+			}
 		default:
 			t.Fatalf("metric type %d not supported", mt)
+		}
+	}
+}
+
+func RemoveTestMetrics(t *testing.T, testMetrics TestMetricsMap) {
+	t.Helper()
+
+	for mt, tm := range testMetrics {
+		if mt != MetricTypeLink {
+			continue
+		}
+
+		fullName := tm.FullPath()
+		rc := C.del_eph_dir(C.CString(fullName))
+		if rc != 0 {
+			t.Fatalf("failed to remove %s: %s", fullName, drpc.DaosStatus(rc))
 		}
 	}
 }


### PR DESCRIPTION
Add some caching layers to avoid unnecessary work and GC pressure
for each metrics scrape.

Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com>