### PR TITLE
DAOS-8889 rebuild: reclaim for extend

### DIFF
--- a/src/rebuild/scan.c
+++ b/src/rebuild/scan.c
@@ -303,7 +303,7 @@ rebuild_object_insert(struct rebuild_tgt_pool_tracker *rpt,
 		 * reclaim is not being scheduled in the previous failure reintegration,
 		 * so let's ignore duplicate shards(DER_EXIST) in this case.
 		 */
-		if (rpt->rt_rebuild_op == RB_OP_REINT) {
+		if (rpt->rt_rebuild_op == RB_OP_REINT || rpt->rt_rebuild_op == RB_OP_EXTEND) {
 			D_DEBUG(DB_REBUILD, DF_UUID" found duplicate "DF_UOID" %d\n",
 				DP_UUID(co_uuid), DP_UOID(oid), tgt_id);
 			rc = 0;
@@ -513,6 +513,12 @@ rebuild_obj_scan_cb(daos_handle_t ch, vos_iter_entry_t *ent,
 	}
 
 	oc_attr = daos_oclass_attr_find(oid.id_pub, NULL);
+	if (oc_attr == NULL) {
+		D_INFO(DF_UUID" skip invalid "DF_UOID"\n", DP_UUID(rpt->rt_pool_uuid),
+		       DP_UOID(oid));
+		D_GOTO(out, rc = 0);
+	}
+
 	grp_size = daos_oclass_grp_size(oc_attr);
 
 	dc_obj_fetch_md(oid.id_pub, &md);

--- a/src/rebuild/srv.c
+++ b/src/rebuild/srv.c
@@ -629,7 +629,7 @@ rebuild_leader_status_check(struct ds_pool *pool, uint32_t map_ver, uint32_t op,
 			 rs->rs_size, rs->rs_done, rs->rs_errno,
 			 rs->rs_fail_rank, rs->rs_seconds);
 
-		D_DEBUG(DB_REBUILD, "%s", sbuf);
+		D_INFO("%s", sbuf);
 		if (rs->rs_done || rebuild_gst.rg_abort || rgt->rgt_abort) {
 			D_PRINT("%s", sbuf);
 			break;
@@ -1320,7 +1320,7 @@ iv_stop:
 try_reschedule:
 	if (rgt == NULL || !is_rebuild_global_done(rgt) ||
 	    rgt->rgt_status.rs_errno != 0 ||
-	    task->dst_rebuild_op == RB_OP_REINT) {
+	    task->dst_rebuild_op == RB_OP_REINT || task->dst_rebuild_op == RB_OP_EXTEND) {
 		daos_rebuild_opc_t opc = task->dst_rebuild_op;
 		int ret;
 
@@ -1335,7 +1335,7 @@ try_reschedule:
 		/* If reintegrate succeeds, schedule reclaim */
 		if (rgt && is_rebuild_global_done(rgt) &&
 		    rgt->rgt_status.rs_errno == 0 &&
-		    opc == RB_OP_REINT)
+		    (opc == RB_OP_REINT || opc == RB_OP_EXTEND))
 			opc = RB_OP_RECLAIM;
 
 		ret = ds_rebuild_schedule(pool, task->dst_map_ver,
@@ -2004,7 +2004,7 @@ rebuild_tgt_status_check_ult(void *arg)
 			}
 		}
 
-		D_DEBUG(DB_REBUILD, "ver %d obj "DF_U64" rec "DF_U64" size "
+		D_INFO("ver %d obj "DF_U64" rec "DF_U64" size "
 			DF_U64" scan done %d pull done %d scan gl done %d"
 			" gl done %d status %d\n",
 			rpt->rt_rebuild_ver, iv.riv_obj_count,


### PR DESCRIPTION
Similar as reintegration, reclaim should be scheduled after extend
as well.

Change a few important DB_REBUILD log to D_INFO.

During rebuild scan, let's skip invalid objects.

Signed-off-by: Di Wang <di.wang@intel.com>