### PR TITLE
DAOS-8904-test: Enable object/create_many_dkeys.py

### DIFF
--- a/src/tests/ftest/object/create_many_dkeys.py
+++ b/src/tests/ftest/object/create_many_dkeys.py
@@ -89,8 +89,10 @@ class CreateManyDkeys(TestWithServers):
         Test Description: Test many of dkeys in same object.
         Use Cases: 1. large key counts
                    2. space reclamation after destroy
-        :avocado: tags=all,full,small,object,many_dkeys
 
+        :avocado: tags=all,full_regression
+        :avocado: tags=small
+        :avocado: tags=object,many_dkeys
         """
         self.prepare_pool()
         no_of_dkeys = self.params.get("number_of_dkeys", '/run/dkeys/')


### PR DESCRIPTION
Description: Correct avocado tags with daily test full_regression
modified:   create_many_dkeys.py
Test-tag: pr many_dkeys
Signed-off-by: Ding Ho ding-hwa.ho@intel.com