### PR TITLE
DAOS-8890 & 8924 array: combine short read task in IO read list

### DIFF
--- a/src/client/api/event.c
+++ b/src/client/api/event.c
@@ -711,7 +711,7 @@ daos_eq_poll(daos_handle_t eqh, int wait_running, int64_t timeout,
 	struct eq_progress_arg	epa;
 	int			rc;
 
-	if (n_events == 0)
+	if (n_events == 0 || events == NULL)
 		return -DER_INVAL;
 
 	/** look up private eq */

--- a/src/client/array/dc_array.c
+++ b/src/client/array/dc_array.c
@@ -400,7 +400,7 @@ dc_array_g2l(daos_handle_t coh, struct dc_array_glob *array_glob,
 	rc = daos_obj_open(coh, array_glob->oid, array_mode, &array->daos_oh,
 			   NULL);
 	if (rc) {
-		D_ERROR("Failed local object open "DF_RC".\n", DP_RC(rc));
+		D_ERROR("Failed local object open "DF_RC"\n", DP_RC(rc));
 		D_GOTO(out_array, rc);
 	}
 
@@ -463,7 +463,7 @@ dc_array_global2local(daos_handle_t coh, d_iov_t glob, unsigned int mode,
 
 	rc = dc_array_g2l(coh, array_glob, mode, oh);
 	if (rc != 0)
-		D_ERROR("dc_array_g2l failed "DF_RC".\n", DP_RC(rc));
+		D_ERROR("dc_array_g2l failed "DF_RC"\n", DP_RC(rc));
 
 out:
 	return rc;
@@ -679,7 +679,7 @@ err_obj:
 		rc2 = daos_task_create(DAOS_OPC_OBJ_CLOSE, tse_task2sched(task),
 				       0, NULL, &close_task);
 		if (rc2) {
-			D_ERROR("Failed to create task to cleanup obj hdl\n");
+			D_ERROR("Failed to create task to cleanup obj hdl "DF_RC"\n", DP_RC(rc2));
 			return rc;
 		}
 
@@ -1298,7 +1298,7 @@ check_short_read_cb(tse_task_t *task, void *data)
 
 	if (rc != 0) {
 		D_ERROR("Array Read Failed "DF_RC"\n", DP_RC(rc));
-		D_GOTO(err_params, rc);
+		D_GOTO(out, rc);
 	}
 
 	D_ASSERT(params);
@@ -1383,7 +1383,7 @@ next:
 		/** memset all holes to 0 */
 		params->array_size = UINT64_MAX;
 		rc = process_iomap(params, args);
-		D_GOTO(err_params, rc);
+		D_GOTO(out, rc);
 	}
 
 	/** Schedule the get size to properly check for short reads */
@@ -1396,11 +1396,11 @@ next:
 
 	rc = tse_task_register_comp_cb(task, set_short_read_cb, NULL, 0);
 	if (rc)
-		D_GOTO(err_params, rc);
+		D_GOTO(out, rc);
 
 	return rc;
 
-err_params:
+out:
 	D_FREE(params);
 	tse_task_complete(task, rc);
 	return rc;
@@ -1468,8 +1468,7 @@ dc_array_io(daos_handle_t array_oh, daos_handle_t th,
 	 * callback of that task).
 	 */
 	if (op_type == DAOS_OPC_ARRAY_READ && array->byte_array) {
-		rc = daos_task_create(DAOS_OPC_ARRAY_GET_SIZE,
-				      tse_task2sched(task), 0, NULL,
+		rc = daos_task_create(DAOS_OPC_ARRAY_GET_SIZE, tse_task2sched(task), 0, NULL,
 				      &stask);
 		if (rc)
 			D_GOTO(err_task, rc);
@@ -1802,17 +1801,11 @@ dc_array_io(daos_handle_t array_oh, daos_handle_t th,
 				D_GOTO(err_iotask, rc);
 			}
 
-			tse_task_list_sched(&io_task_list, false);
-			rc = tse_task_schedule(stask, false);
-			if (rc != 0) {
-				D_FREE(sparams);
-				D_GOTO(err_iotask, rc);
-			}
+			tse_task_list_add(stask, &io_task_list);
 		}
-	} else {
-		tse_task_list_sched(&io_task_list, false);
 	}
 
+	tse_task_list_sched(&io_task_list, false);
 	array_decref(array);
 	tse_sched_progress(tse_task2sched(task));
 	return 0;
@@ -2041,7 +2034,7 @@ punch_key(daos_handle_t oh, daos_handle_t th, daos_size_t dkey_val,
 	rc = daos_task_create(opc, tse_task2sched(task), 0, NULL, &io_task);
 	if (rc) {
 		D_ERROR("daos_task_create() failed "DF_RC"\n", DP_RC(rc));
-		D_GOTO(err, rc);
+		D_GOTO(free, rc);
 	}
 
 	p_args = daos_task_get_args(io_task);
@@ -2052,7 +2045,7 @@ punch_key(daos_handle_t oh, daos_handle_t th, daos_size_t dkey_val,
 	rc = tse_task_register_comp_cb(io_task, free_io_params_cb, &params,
 				       sizeof(params));
 	if (rc)
-		D_GOTO(err, rc);
+		D_GOTO(free, rc);
 
 	rc = tse_task_register_deps(task, 1, &io_task);
 	if (rc)
@@ -2063,8 +2056,9 @@ punch_key(daos_handle_t oh, daos_handle_t th, daos_size_t dkey_val,
 		D_GOTO(err, rc);
 
 	return rc;
-err:
+free:
 	D_FREE(params);
+err:
 	if (io_task)
 		tse_task_complete(io_task, rc);
 	return rc;
@@ -2441,10 +2435,8 @@ adjust_array_size_cb(tse_task_t *task, void *data)
 		rc = tse_task_register_cbs(task, NULL, NULL, 0,
 					   adjust_array_size_cb, &props,
 					   sizeof(props));
-		if (rc) {
-			tse_task_complete(task, rc);
+		if (rc)
 			return rc;
-		}
 
 		rc = tse_task_reinit(task);
 		if (rc) {

--- a/src/client/dfs/dfs.c
+++ b/src/client/dfs/dfs.c
@@ -665,29 +665,31 @@ entry_stat(dfs_t *dfs, daos_handle_t th, daos_handle_t oh, const char *name,
 		break;
 	case S_IFREG:
 	{
-		daos_handle_t file_oh;
+		if (obj) {
+			rc = daos_array_get_size(obj->oh, th, &size, NULL);
+			if (rc)
+				return daos_der2errno(rc);
+		} else {
+			daos_handle_t file_oh;
 
-		rc = daos_array_open_with_attr(dfs->coh, entry.oid, th,
-					       DAOS_OO_RO, 1, entry.chunk_size ?
-					       entry.chunk_size :
-					       dfs->attr.da_chunk_size,
-					       &file_oh, NULL);
-		if (rc) {
-			D_ERROR("daos_array_open_with_attr() failed (%d)\n",
-				rc);
-			return daos_der2errno(rc);
+			rc = daos_array_open_with_attr(dfs->coh, entry.oid, th, DAOS_OO_RO, 1,
+						       entry.chunk_size ? entry.chunk_size :
+						       dfs->attr.da_chunk_size, &file_oh, NULL);
+			if (rc) {
+				D_ERROR("daos_array_open_with_attr() failed "DF_RC"\n", DP_RC(rc));
+				return daos_der2errno(rc);
+			}
+
+			rc = daos_array_get_size(file_oh, th, &size, NULL);
+			if (rc) {
+				daos_array_close(file_oh, NULL);
+				return daos_der2errno(rc);
+			}
+
+			rc = daos_array_close(file_oh, NULL);
+			if (rc)
+				return daos_der2errno(rc);
 		}
-
-		rc = daos_array_get_size(file_oh, th, &size, NULL);
-		if (rc) {
-			daos_array_close(file_oh, NULL);
-			return daos_der2errno(rc);
-		}
-
-		rc = daos_array_close(file_oh, NULL);
-		if (rc)
-			return daos_der2errno(rc);
-
 		/*
 		 * TODO - this is not accurate since it does not account for
 		 * sparse files or file metadata or xattributes.
@@ -912,7 +914,7 @@ fopen:
 	if (flags & O_TRUNC) {
 		rc = daos_array_set_size(file->oh, th, 0, NULL);
 		if (rc) {
-			D_ERROR("Failed to truncate file (%d)\n", rc);
+			D_ERROR("Failed to truncate file "DF_RC"\n", DP_RC(rc));
 			daos_array_close(file->oh, NULL);
 			D_GOTO(out, rc = daos_der2errno(rc));
 		}
@@ -2909,8 +2911,7 @@ dfs_lookup_rel_int(dfs_t *dfs, dfs_obj_t *parent, const char *name, int flags,
 					       dfs->attr.da_chunk_size,
 					       &obj->oh, NULL);
 		if (rc != 0) {
-			D_ERROR("daos_array_open_with_attr() Failed (%d)\n",
-				rc);
+			D_ERROR("daos_array_open_with_attr() Failed "DF_RC"\n", DP_RC(rc));
 			D_GOTO(err_obj, rc = daos_der2errno(rc));
 		}
 
@@ -2922,8 +2923,7 @@ dfs_lookup_rel_int(dfs_t *dfs, dfs_obj_t *parent, const char *name, int flags,
 						 NULL);
 			if (rc) {
 				daos_array_close(obj->oh, NULL);
-				D_ERROR("daos_array_get_size() Failed (%d)\n",
-					rc);
+				D_ERROR("daos_array_get_size() Failed "DF_RC"\n", DP_RC(rc));
 				D_GOTO(err_obj, rc = daos_der2errno(rc));
 			}
 			stbuf->st_size = size;
@@ -4039,7 +4039,7 @@ dfs_osetattr(dfs_t *dfs, dfs_obj_t *obj, struct stat *stbuf, int flags)
 
 	rc = daos_obj_update(oh, th, DAOS_COND_DKEY_UPDATE, &dkey, 1, &iod, &sgl, NULL);
 	if (rc) {
-		D_ERROR("Failed to update attr (rc = %d)\n", rc);
+		D_ERROR("Failed to update attr "DF_RC"\n", DP_RC(rc));
 		D_GOTO(out_obj, rc = daos_der2errno(rc));
 	}
 
@@ -4620,7 +4620,7 @@ dfs_setxattr(dfs_t *dfs, dfs_obj_t *obj, const char *name,
 	/** Open parent object and insert xattr in the entry of the object */
 	rc = daos_obj_open(dfs->coh, obj->parent_oid, DAOS_OO_RW, &oh, NULL);
 	if (rc)
-		D_GOTO(out, rc = daos_der2errno(rc));
+		D_GOTO(free, rc = daos_der2errno(rc));
 
 	/** set dkey as the entry name */
 	d_iov_set(&dkey, (void *)obj->name, strlen(obj->name));
@@ -4654,8 +4654,9 @@ dfs_setxattr(dfs_t *dfs, dfs_obj_t *obj, const char *name,
 	}
 
 out:
-	D_FREE(xname);
 	daos_obj_close(oh, NULL);
+free:
+	D_FREE(xname);
 	return rc;
 }
 
@@ -4724,7 +4725,7 @@ dfs_getxattr(dfs_t *dfs, dfs_obj_t *obj, const char *name, void *value,
 				    NULL, NULL);
 	}
 	if (rc) {
-		D_ERROR("Failed to fetch xattr %s (%d)\n", name, rc);
+		D_ERROR("Failed to fetch xattr %s "DF_RC"\n", name, DP_RC(rc));
 		D_GOTO(close, rc = daos_der2errno(rc));
 	}
 
@@ -4777,7 +4778,7 @@ dfs_removexattr(dfs_t *dfs, dfs_obj_t *obj, const char *name)
 	/** Open parent object and remove xattr from the entry of the object */
 	rc = daos_obj_open(dfs->coh, obj->parent_oid, DAOS_OO_RW, &oh, NULL);
 	if (rc)
-		D_GOTO(out, rc = daos_der2errno(rc));
+		D_GOTO(free, rc = daos_der2errno(rc));
 
 	/** set dkey as the entry name */
 	d_iov_set(&dkey, (void *)obj->name, strlen(obj->name));
@@ -4793,8 +4794,9 @@ dfs_removexattr(dfs_t *dfs, dfs_obj_t *obj, const char *name)
 	}
 
 out:
-	D_FREE(xname);
 	daos_obj_close(oh, NULL);
+free:
+	D_FREE(xname);
 	return rc;
 }
 

--- a/src/client/dfuse/dfuse_core.c
+++ b/src/client/dfuse/dfuse_core.c
@@ -32,23 +32,17 @@ dfuse_progress_thread(void *arg)
 			if (rc == EINTR)
 				continue;
 
-			DFUSE_TRA_ERROR(fs_handle,
-					"Error from sem_wait: %d", rc);
+			DFUSE_TRA_ERROR(fs_handle, "Error from sem_wait: %d", rc);
 		}
 
 		if (fs_handle->dpi_shutdown)
 			return NULL;
 
-		rc = daos_eq_poll(fs_handle->dpi_eq, 1,
-				  DAOS_EQ_WAIT,
-				1,
-				&dev);
-
+		rc = daos_eq_poll(fs_handle->dpi_eq, 1, DAOS_EQ_WAIT, 1, &dev);
 		if (rc == 1) {
+			daos_event_fini(dev);
 			ev = container_of(dev, struct dfuse_event, de_ev);
-
 			ev->de_complete_cb(ev);
-
 			D_FREE(ev);
 		}
 	}

--- a/src/tests/suite/dfs_par_test.c
+++ b/src/tests/suite/dfs_par_test.c
@@ -124,7 +124,7 @@ test_cond_helper(test_arg_t *arg, int rf)
 
 	d_getenv_bool("DFS_USE_DTX", &use_dtx);
 	if (!use_dtx)
-		return;
+		goto out;
 	if (arg->myrank == 0) {
 		print_message("All ranks rename the same file\n");
 		rc = dfs_open(dfs, NULL, filename,
@@ -170,6 +170,7 @@ test_cond_helper(test_arg_t *arg, int rf)
 		dfs_release(file);
 	}
 
+out:
 	rc = dfs_umount(dfs);
 	assert_int_equal(rc, 0);
 	rc = daos_cont_close(coh, NULL);
@@ -666,8 +667,7 @@ dfs_test_cont_atomic(void **state)
 	if (arg->myrank == 0)
 		print_message("one rank Created POSIX Container dfs_par_test_cont\n");
 
-	rc = daos_cont_open(arg->pool.poh, "dfs_par_test_cont", DAOS_COO_RW,
-			    &coh, &co_info, NULL);
+	rc = daos_cont_open(arg->pool.poh, "dfs_par_test_cont", DAOS_COO_RW, &coh, &co_info, NULL);
 	assert_int_equal(rc, 0);
 
 	rc = dfs_mount(arg->pool.poh, coh, O_RDWR, &dfs);


### PR DESCRIPTION
- just in case the scheduler does not recognize the dependency of the
parent task to the size task, add the size task to be scheduled with
the io tasks and not seperately to take care of possible races.
- fix some possible leaks with FI testing
- call event fini in dfuse
- other minor code format and test fixes.

Signed-off-by: Mohamad Chaarawi <mohamad.chaarawi@intel.com>