### PR TITLE
DAOS-5165 tests: Enable functional hw large tests over verbs (#6626)

### DIFF
--- a/src/tests/ftest/launch.py
+++ b/src/tests/ftest/launch.py
@@ -160,59 +160,13 @@ def set_test_environment(args):
 
     if not args.list:
         # Get the default interface to use if OFI_INTERFACE is not set
-        interface = os.environ.get("OFI_INTERFACE")
-        if interface is None:
-            # Find all the /sys/class/net interfaces on the launch node
-            # (excluding lo)
-            print("Detecting network devices - OFI_INTERFACE not set")
-            available_interfaces = {}
-            net_path = os.path.join(os.path.sep, "sys", "class", "net")
-            net_list = [dev for dev in os.listdir(net_path) if dev != "lo"]
-            for device in sorted(net_list):
-                if device == "bonding_masters":
-                    continue
-                # Get the interface state - only include active (up) interfaces
-                device_operstate = os.path.join(net_path, device, "operstate")
-                with open(device_operstate, "r") as file_handle:
-                    state = file_handle.read().strip()
-                # Only include interfaces that are up
-                if state.lower() == "up":
-                    # Get the interface speed - used to select the fastest
-                    # available
-                    device_speed = os.path.join(net_path, device, "speed")
-                    with open(device_speed, "r") as file_handle:
-                        try:
-                            speed = int(file_handle.read().strip())
-                            # KVM/Qemu/libvirt returns an EINVAL
-                        except IOError as ioerror:
-                            if ioerror.errno == errno.EINVAL:
-                                speed = 1000
-                            else:
-                                raise
-                    print(
-                        "  - {0:<5} (speed: {1:>6} state: {2})".format(
-                            device, speed, state))
-                    # Only include the first active interface for each speed -
-                    # first is determined by an alphabetic sort: ib0 will be
-                    # checked before ib1
-                    if speed not in available_interfaces:
-                        available_interfaces[speed] = device
-            print("Available interfaces: {}".format(available_interfaces))
-            try:
-                # Select the fastest active interface available by sorting
-                # the speed
-                interface = \
-                    available_interfaces[sorted(available_interfaces)[-1]]
-            except IndexError:
-                print(
-                    "Error obtaining a default interface from: {}".format(
-                        os.listdir(net_path)))
-                sys.exit(1)
-        print("Using {} as the default interface".format(interface))
+        set_interface_environment()
 
-        # Update env definitions
+        # Get the default provider if CRT_PHY_ADDR_STR is not set
+        set_provider_environment(os.environ["OFI_INTERFACE"], args)
+
+        # Update other env definitions
         os.environ["CRT_CTX_SHARE_ADDR"] = "0"
-        os.environ["OFI_INTERFACE"] = os.environ.get("OFI_INTERFACE", interface)
 
         # Set the default location for daos log files written during testing
         # if not already defined.
@@ -235,6 +189,117 @@ def set_test_environment(args):
         print("ENVIRONMENT VARIABLES")
         for key in sorted(os.environ):
             print("  {}: {}".format(key, os.environ[key]))
+
+
+def set_interface_environment():
+    """Set up the interface environment variables.
+
+    Use the existing OFI_INTERFACE setting if already defined, otherwise
+    select the fastest, active interface on this host.
+    """
+    # Get the default interface to use if OFI_INTERFACE is not set
+    interface = os.environ.get("OFI_INTERFACE")
+    if interface is None:
+        # Find all the /sys/class/net interfaces on the launch node
+        # (excluding lo)
+        print("Detecting network devices - OFI_INTERFACE not set")
+        available_interfaces = {}
+        net_path = os.path.join(os.path.sep, "sys", "class", "net")
+        net_list = [dev for dev in os.listdir(net_path) if dev != "lo"]
+        for device in sorted(net_list):
+            if device == "bonding_masters":
+                continue
+            # Get the interface state - only include active (up) interfaces
+            device_operstate = os.path.join(net_path, device, "operstate")
+            with open(device_operstate, "r") as file_handle:
+                state = file_handle.read().strip()
+            # Only include interfaces that are up
+            if state.lower() == "up":
+                # Get the interface speed - used to select the fastest
+                # available
+                device_speed = os.path.join(net_path, device, "speed")
+                with open(device_speed, "r") as file_handle:
+                    try:
+                        speed = int(file_handle.read().strip())
+                        # KVM/Qemu/libvirt returns an EINVAL
+                    except IOError as ioerror:
+                        if ioerror.errno == errno.EINVAL:
+                            speed = 1000
+                        else:
+                            raise
+                print(
+                    "  - {0:<5} (speed: {1:>6} state: {2})".format(
+                        device, speed, state))
+                # Only include the first active interface for each speed -
+                # first is determined by an alphabetic sort: ib0 will be
+                # checked before ib1
+                if speed not in available_interfaces:
+                    available_interfaces[speed] = device
+        print("Available interfaces: {}".format(available_interfaces))
+        try:
+            # Select the fastest active interface available by sorting
+            # the speed
+            interface = \
+                available_interfaces[sorted(available_interfaces)[-1]]
+        except IndexError:
+            print(
+                "Error obtaining a default interface from: {}".format(
+                    os.listdir(net_path)))
+            sys.exit(1)
+
+    # Update env definitions
+    print("Using {} as the default interface".format(interface))
+    os.environ["CRT_CTX_SHARE_ADDR"] = "0"
+    os.environ["OFI_INTERFACE"] = os.environ.get("OFI_INTERFACE", interface)
+
+
+def set_provider_environment(interface, args):
+    """Set up the provider environment variables.
+
+    Use the existing CRT_PHY_ADDR_STR setting if already defined, otherwise
+    select the appropriate provider based upon the interface driver.
+
+    Args:
+        interface (str): the current interface being used.
+    """
+    # Temporary code to only enable verbs in certain stages
+    tags = [name for tag in args.tags for name in tag.split(",")]
+
+    # Use the detected provider if one is not set
+    name = "CRT_PHY_ADDR_STR"
+    detected_provider = "ofi+sockets"
+    if os.environ.get(name) is None:
+        # Confirm the interface is a Mellanox device - verbs did not work with OPA devices.
+        command = "sudo mst status -v"
+        task = get_remote_output(list(args.test_servers), command)
+        if check_remote_output(task, command):
+            # Detect the provider for the specified interface
+            print("Detecting provider for {} - {} not set".format(interface, name))
+            command = "fi_info -d {} -l | grep -v 'version:'".format(interface)
+            task = get_remote_output(list(args.test_servers), command)
+            if check_remote_output(task, command):
+                # Verify each server host has the same interface driver
+                output_data = list(task.iter_buffers())
+                if len(output_data) > 1:
+                    print("ERROR: Non-homogeneous drivers detected.")
+                    sys.exit(1)
+                # Select the provider - currently use verbs or sockets
+                for line in output_data[0][0]:
+                    provider = line.decode("utf-8").replace(":", "")
+                    # Temporary code to only enable verbs on HW Large stages
+                    if "verbs" in provider and "hw" in tags and "large" in tags:
+                        detected_provider = "ofi+verbs;ofi_rxm"
+                        break
+                    if "sockets" in provider:
+                        detected_provider = "ofi+sockets"
+                        break
+        else:
+            print("No Infiniband devices found - using sockets")
+        print("  Found {} provider for {}".format(detected_provider, interface))
+
+    # Update env definitions
+    os.environ[name] = detected_provider
+    print("Using {}={}".format(name, os.environ[name]))
 
 
 def set_python_environment():
@@ -779,6 +844,7 @@ def get_vmd_replacement(args):
 
     return ",".join(devices), vmd_include_flag
 
+
 def get_vmd_address_backed_nvme(host_list, value):
     """Find valid VMD address which has backing NVMe.
 
@@ -814,6 +880,7 @@ def get_vmd_address_backed_nvme(host_list, value):
             value.remove(device)
 
     return value
+
 
 def find_pci_address(value):
     """Find PCI addresses in the specified string.

--- a/src/tests/ftest/scripts/main.sh
+++ b/src/tests/ftest/scripts/main.sh
@@ -56,7 +56,8 @@ else
     cd "$DAOS_BASE"
 fi
 
-export CRT_PHY_ADDR_STR=ofi+sockets
+# Disable CRT_PHY_ADDR_STR to allow launch.py to set it
+unset CRT_PHY_ADDR_STR
 
 # Disable OFI_INTERFACE to allow launch.py to pick the fastest interface
 unset OFI_INTERFACE

--- a/src/tests/ftest/scripts/setup_nodes.sh
+++ b/src/tests/ftest/scripts/setup_nodes.sh
@@ -97,6 +97,13 @@ EOF
     mount \"$DAOS_BASE\"
 fi"
 
+# For verbs enable servers in dual-nic setups to talk to each other; no adverse effect for sockets
+sudo sysctl -w net.ipv4.conf.all.accept_local=1
+sudo sysctl -w net.ipv4.conf.all.arp_ignore=2
+sudo sysctl -w net.ipv4.conf.all.rp_filter=2
+find /sys/class/net/ -maxdepth 1 -name 'ib*' -print0 | xargs -t -I {} --null basename {} | \
+    xargs -t -I {} sudo sysctl -w net.ipv4.conf.{}.rp_filter=2
+
 if ! $TEST_RPMS; then
     # set up symlinks to spdk scripts (none of this would be
     # necessary if we were testing from RPMs) in order to

--- a/src/tests/ftest/util/server_utils_params.py
+++ b/src/tests/ftest/util/server_utils_params.py
@@ -134,7 +134,6 @@ class DaosServerYamlParameters(YamlParameters):
 
         self.fault_path = BasicParameter(None)
 
-
     def get_params(self, test):
         """Get values for all of the command params from the yaml file.
 
@@ -149,10 +148,10 @@ class DaosServerYamlParameters(YamlParameters):
         # Create the requested number of single server parameters
         if isinstance(self.engines_per_host.value, int):
             self.engine_params = [
-                self.PerEngineYamlParameters(index)
+                self.PerEngineYamlParameters(index, self.provider.value)
                 for index in range(self.engines_per_host.value)]
         else:
-            self.engine_params = [self.PerEngineYamlParameters()]
+            self.engine_params = [self.PerEngineYamlParameters(None, self.provider.value)]
 
         for engine_params in self.engine_params:
             engine_params.get_params(test)
@@ -322,7 +321,20 @@ class DaosServerYamlParameters(YamlParameters):
     class PerEngineYamlParameters(YamlParameters):
         """Defines the configuration yaml parameters for a single server."""
 
-        def __init__(self, index=None):
+        # Engine environment variables that are required by provider type.
+        REQUIRED_ENV_VARS = {
+            "common": [
+                "D_LOG_FILE_APPEND_PID=1",
+                "COVFILE=/tmp/test.cov"],
+            "ofi+sockets": [
+                "FI_SOCKETS_MAX_CONN_RETRY=5",
+                "FI_SOCKETS_CONN_TIMEOUT=2000",
+                "CRT_SWIM_RPC_TIMEOUT=10"],
+            "ofi_rxm": [
+                "FI_OFI_RXM_USE_SRX=1"],
+        }
+
+        def __init__(self, index=None, provider=None):
             """Create a SingleServerConfig object.
 
             Args:
@@ -333,12 +345,15 @@ class DaosServerYamlParameters(YamlParameters):
             if isinstance(index, int):
                 namespace = "/run/server_config/servers/{}/*".format(index)
             super().__init__(namespace)
+            if provider is not None:
+                self._provider = provider
+            else:
+                self._provider = os.environ.get("CRT_PHY_ADDR_STR", "ofi+sockets")
 
             # Use environment variables to get default parameters
             default_interface = os.environ.get("OFI_INTERFACE", "eth0")
             default_port = int(os.environ.get("OFI_PORT", 31416))
             default_share_addr = int(os.environ.get("CRT_CTX_SHARE_ADDR", 0))
-            default_provider = os.environ.get("CRT_PHY_ADDR_STR", "ofi+sockets")
 
             # All log files should be placed in the same directory on each host
             # to enable easy log file archiving by launch.py
@@ -365,21 +380,17 @@ class DaosServerYamlParameters(YamlParameters):
             self.log_mask = BasicParameter(None, "INFO")
             self.log_file = LogParameter(log_dir, None, "daos_server.log")
 
-            # Set extra environment variables for sockets provider
+            # Set default environment variables
             default_env_vars = [
                 "ABT_ENV_MAX_NUM_XSTREAMS=100",
                 "ABT_MAX_NUM_XSTREAMS=100",
                 "DAOS_MD_CAP=1024",
                 "DD_MASK=mgmt,io,md,epc,rebuild",
-                "D_LOG_FILE_APPEND_PID=1",
-                "COVFILE=/tmp/test.cov"
             ]
-            if default_provider == "ofi+sockets":
-                default_env_vars.extend([
-                    "FI_SOCKETS_MAX_CONN_RETRY=5",
-                    "FI_SOCKETS_CONN_TIMEOUT=2000",
-                    "CRT_SWIM_RPC_TIMEOUT=10"
-                ])
+            default_env_vars.extend(self.REQUIRED_ENV_VARS["common"])
+            for name in self._provider.split(";"):
+                if name in self.REQUIRED_ENV_VARS:
+                    default_env_vars.extend(self.REQUIRED_ENV_VARS[name])
             self.env_vars = BasicParameter(None, default_env_vars)
 
             # global CRT_CTX_SHARE_ADDR shared with client
@@ -453,11 +464,32 @@ class DaosServerYamlParameters(YamlParameters):
                 self.log.debug("Ignoring the scm_size when scm_class is 'dcpm'")
                 self.scm_size.update(None, "scm_size")
 
-            # Include fault injection settings if configured
-            if test.fault_injection.fault_file:
-                fault_setting = "D_FI_CONFIG={}".format(test.fault_injection.fault_file)
-                if fault_setting not in self.env_vars.value:
-                    self.env_vars.update(fault_setting, "env_vars", True)
+            # Define any required env vars
+            required_env_vars = {}
+            for env in self.REQUIRED_ENV_VARS["common"]:
+                required_env_vars[env.split("=", maxsplit=1)[0]] = env.split("=", maxsplit=1)[1]
+            for name in self._provider.split(";"):
+                if name in self.REQUIRED_ENV_VARS:
+                    required_env_vars.update({
+                        env.split("=", maxsplit=1)[0]: env.split("=", maxsplit=1)[1]
+                        for env in self.REQUIRED_ENV_VARS[name]})
+
+            # Enable fault injection if configured
+            if test.fault_injection.fault_file is not None:
+                self.log.debug("Enabling fault injection")
+                required_env_vars["D_FI_CONFIG"] = test.fault_injection.fault_file
+
+            # Update the env vars with any missing or different required setting
+            update = False
+            env_var_dict = {env.split("=")[0]: env.split("=")[1] for env in self.env_vars.value}
+            for key in sorted(required_env_vars):
+                if key not in env_var_dict or env_var_dict[key] != required_env_vars[key]:
+                    env_var_dict[key] = required_env_vars[key]
+                    update = True
+            if update:
+                self.log.debug("Assigning required env_vars")
+                new_env_vars = ["=".join([key, str(value)]) for key, value in env_var_dict.items()]
+                self.env_vars.update(new_env_vars, "env_var")
 
         @property
         def using_nvme(self):

--- a/src/tests/ftest/util/telemetry_utils.py
+++ b/src/tests/ftest/util/telemetry_utils.py
@@ -5,6 +5,7 @@
 SPDX-License-Identifier: BSD-2-Clause-Patent
 """
 from logging import getLogger
+import re
 from ClusterShell.NodeSet import NodeSet
 
 
@@ -328,9 +329,9 @@ class TelemetryUtils():
         ENGINE_IO_OPS_TGT_UPDATE_ACTIVE_METRICS +\
         ENGINE_IO_OPS_UPDATE_ACTIVE_METRICS
     ENGINE_NET_METRICS = [
-        "engine_net_ofi_sockets_failed_addr",
-        "engine_net_ofi_sockets_req_timeout",
-        "engine_net_ofi_sockets_uri_lookup_timeout",
+        "engine_net_<provider>_failed_addr",
+        "engine_net_<provider>_req_timeout",
+        "engine_net_<provider>_uri_lookup_timeout",
         "engine_net_uri_lookup_other",
         "engine_net_uri_lookup_self"]
     ENGINE_RANK_METRICS = [
@@ -452,7 +453,6 @@ class TelemetryUtils():
         """
         all_metrics_names = list(self.ENGINE_EVENT_METRICS)
         all_metrics_names.extend(self.ENGINE_IO_METRICS)
-        all_metrics_names.extend(self.ENGINE_NET_METRICS)
         all_metrics_names.extend(self.ENGINE_RANK_METRICS)
         all_metrics_names.extend(self.GO_METRICS)
         all_metrics_names.extend(self.PROCESS_METRICS)
@@ -460,14 +460,20 @@ class TelemetryUtils():
             all_metrics_names.extend(self.ENGINE_POOL_METRICS)
             all_metrics_names.extend(self.ENGINE_CONTAINER_METRICS)
 
+        # Add engine network metrics for the configured provider
+        try:
+            provider = re.sub("[+;]", "_", server.manager.job.get_config_value("provider"))
+        except TypeError:
+            provider = "ofi_sockets"
+        net_metrics = [name.replace("<provider>", provider) for name in self.ENGINE_NET_METRICS]
+        all_metrics_names.extend(net_metrics)
+
         # Add NVMe metrics for any NVMe devices configured for this server
         for nvme_list in server.manager.job.get_engine_values("bdev_list"):
             for nvme in nvme_list if nvme_list is not None else []:
                 # Replace the '<id>' placeholder with the actual NVMe ID
                 nvme_id = nvme.replace(":", "_").replace(".", "_")
-                nvme_metrics = [
-                    name.replace("<id>", nvme_id)
-                    for name in self.ENGINE_NVME_METRICS]
+                nvme_metrics = [name.replace("<id>", nvme_id) for name in self.ENGINE_NVME_METRICS]
                 all_metrics_names.extend(nvme_metrics)
 
         return all_metrics_names


### PR DESCRIPTION
Adding support into launch.py to set the provider based upon the
selected interface driver by setting environment variables.  Any
existing environment variable definitions are honored to support
overriding the automatic/default setting.

Test-tag: pr daily_regression

Signed-off-by: Phillip Henderson <phillip.henderson@intel.com>