### PR TITLE
DAOS-8672 dtx: trace the newest DTX that is aggregated

### DIFF
--- a/src/dtx/dtx_common.c
+++ b/src/dtx/dtx_common.c
@@ -403,8 +403,8 @@ dtx_aggregation_pool(struct dtx_batched_pool_args *dbpa)
 	    dtx_agg_thd_age_lo)
 		return;
 
-	/* No single pool exceeds DTX thresholds, but the whole pool does,
-	 * we choose the victim container to do the DTX aggregation.
+	/* No single container exceeds DTX thresholds, but the whole pool does,
+	 * then we choose the victim container to do the DTX aggregation.
 	 */
 
 	dbca = dbpa->dbpa_victim;
@@ -1579,7 +1579,6 @@ int
 dtx_handle_resend(daos_handle_t coh,  struct dtx_id *dti,
 		  daos_epoch_t *epoch, uint32_t *pm_ver)
 {
-	uint64_t	age;
 	int		rc;
 
 	if (daos_is_zero_dti(dti))
@@ -1604,16 +1603,23 @@ dtx_handle_resend(daos_handle_t coh,  struct dtx_id *dti,
 		return -DER_ALREADY;
 	case DTX_ST_CORRUPTED:
 		return -DER_DATA_LOSS;
-	case -DER_NONEXIST:
-		age = dtx_hlc_age2sec(dti->dti_hlc);
-		if (age > dtx_agg_thd_age_lo ||
+	case -DER_NONEXIST: {
+		struct dtx_stat		stat = { 0 };
+
+		/* dtx_id::dti_hlc is client side time stamp. If it is older than the time
+		 * of the most new DTX entry that has been aggregated, then it may has been
+		 * removed by DTX aggregation. Under such case, return -DER_EP_OLD.
+		 */
+		vos_dtx_stat(coh, &stat, DSF_SKIP_BAD);
+		if (dti->dti_hlc <= stat.dtx_newest_aggregated ||
 		    DAOS_FAIL_CHECK(DAOS_DTX_LONG_TIME_RESEND)) {
-			D_ERROR("Not sure about whether the old RPC "DF_DTI
-				" is resent or not. Age="DF_U64" s.\n",
-				DP_DTI(dti), age);
+			D_ERROR("Not sure about whether the old RPC "
+				DF_DTI" is resent or not: %lu/%lu\n",
+				DP_DTI(dti), dti->dti_hlc, stat.dtx_newest_aggregated);
 			rc = -DER_EP_OLD;
 		}
 		return rc;
+	}
 	default:
 		return rc >= 0 ? -DER_INVAL : rc;
 	}

--- a/src/dtx/dtx_internal.h
+++ b/src/dtx/dtx_internal.h
@@ -88,9 +88,9 @@ extern uint32_t dtx_agg_thd_cnt_up;
 extern uint32_t dtx_agg_thd_cnt_lo;
 
 /* The age unit is second. */
-#define DTX_AGG_THD_AGE_MAX	700
-#define DTX_AGG_THD_AGE_MIN	140
-#define DTX_AGG_THD_AGE_DEF	210
+#define DTX_AGG_THD_AGE_MAX	1830
+#define DTX_AGG_THD_AGE_MIN	210
+#define DTX_AGG_THD_AGE_DEF	630
 
 /* The time threshold for triggerring DTX aggregation. If the oldest
  * DTX in the DTX table exceeds such threshold, it will trigger DTX

--- a/src/dtx/dtx_srv.c
+++ b/src/dtx/dtx_srv.c
@@ -257,14 +257,23 @@ dtx_handler(crt_rpc_t *rpc)
 			    (*ptr == -DER_NONEXIST && cont->sc_dtx_reindex))
 				*ptr = -DER_INPROGRESS;
 
-			/* dtx_id::dti_hlc is client side time stamp. Usually, it is older than
-			 * the time of the DTX being handled on the leader. If it is older than
-			 * the time of next to be aggregated DTX entry, then it may has been
-			 * removed by DTX aggregation. Under such case, return -DER_TX_UNCERTAIN.
-			 */
-			if (*ptr == -DER_NONEXIST &&
-			    dtx_hlc_age2sec(dtis->dti_hlc) > dtx_agg_thd_age_lo)
-				*ptr = -DER_TX_UNCERTAIN;
+			if (*ptr == -DER_NONEXIST) {
+				struct dtx_stat		stat = { 0 };
+
+				/* dtx_id::dti_hlc is client side time stamp. If it is
+				 * older than the time of the most new DTX entry that
+				 * has been aggregated, then it may has been removed by
+				 * DTX aggregation. Under such case, return -DER_TX_UNCERTAIN.
+				 */
+				vos_dtx_stat(cont->sc_hdl, &stat, DSF_SKIP_BAD);
+				if (dtis->dti_hlc <= stat.dtx_newest_aggregated) {
+					D_WARN("Not sure about whether the old DTX "
+					       DF_DTI" is committed or not: %lu/%lu\n",
+					       DP_DTI(dtis), dtis->dti_hlc,
+					       stat.dtx_newest_aggregated);
+					*ptr = -DER_TX_UNCERTAIN;
+				}
+			}
 
 			if (mbs[i] != NULL)
 				rc1++;
@@ -376,7 +385,7 @@ dtx_init(void)
 		dtx_agg_thd_age_up = DTX_AGG_THD_AGE_DEF;
 	}
 
-	dtx_agg_thd_age_lo = dtx_agg_thd_age_up * 6 / 7;
+	dtx_agg_thd_age_lo = dtx_agg_thd_age_up - 30;
 
 	D_INFO("Set DTX aggregation time threshold as %d (seconds)\n",
 	       dtx_agg_thd_age_up);

--- a/src/include/daos_srv/dtx_srv.h
+++ b/src/include/daos_srv/dtx_srv.h
@@ -170,6 +170,8 @@ struct dtx_stat {
 	uint32_t	dtx_cont_cmt_count;
 	/* pool-based committed DTX entries count. */
 	uint32_t	dtx_pool_cmt_count;
+	/* The epoch for the most new DTX entry that is aggregated. */
+	uint64_t	dtx_newest_aggregated;
 };
 
 enum dtx_flags {

--- a/src/vos/vos_dtx.c
+++ b/src/vos/vos_dtx.c
@@ -2267,6 +2267,7 @@ vos_dtx_aggregate(daos_handle_t coh)
 	struct umem_instance		*umm;
 	struct vos_dtx_blob_df		*dbd;
 	struct vos_dtx_blob_df		*tmp;
+	uint64_t			 epoch;
 	umem_off_t			 dbd_off;
 	int				 rc;
 	int				 i;
@@ -2277,6 +2278,7 @@ vos_dtx_aggregate(daos_handle_t coh)
 	cont_df = cont->vc_cont_df;
 	dbd_off = cont_df->cd_dtx_committed_head;
 	umm = vos_cont2umm(cont);
+	epoch = cont_df->cd_newest_aggregated;
 
 	dbd = umem_off2ptr(umm, dbd_off);
 	if (dbd == NULL || dbd->dbd_count == 0)
@@ -2297,6 +2299,8 @@ vos_dtx_aggregate(daos_handle_t coh)
 		d_iov_t				 kiov;
 
 		dce_df = &dbd->dbd_committed_data[i];
+		if (epoch < dce_df->dce_epoch)
+			epoch = dce_df->dce_epoch;
 		d_iov_set(&kiov, &dce_df->dce_xid, sizeof(dce_df->dce_xid));
 		rc = dbtree_delete(cont->vc_dtx_committed_hdl, BTR_PROBE_EQ,
 				   &kiov, NULL);
@@ -2306,6 +2310,18 @@ vos_dtx_aggregate(daos_handle_t coh)
 				UMOFF_P(dbd_off), DP_RC(rc));
 			goto out;
 		}
+	}
+
+	if (epoch != cont_df->cd_newest_aggregated) {
+		rc = umem_tx_add_ptr(umm, &cont_df->cd_newest_aggregated,
+				     sizeof(cont_df->cd_newest_aggregated));
+		if (rc != 0) {
+			D_ERROR("Failed to refresh epoch for DTX aggregation "UMOFF_PF": "DF_RC"\n",
+				UMOFF_P(dbd_off), DP_RC(rc));
+			goto out;
+		}
+
+		cont_df->cd_newest_aggregated = epoch;
 	}
 
 	tmp = umem_off2ptr(umm, dbd->dbd_next);
@@ -2399,6 +2415,7 @@ cmt:
 	stat->dtx_first_cmt_blob_time_up = 0;
 	stat->dtx_first_cmt_blob_time_lo = 0;
 	cont_df = cont->vc_cont_df;
+	stat->dtx_newest_aggregated = cont_df->cd_newest_aggregated;
 
 	if (!umoff_is_null(cont_df->cd_dtx_committed_head)) {
 		struct umem_instance		*umm = vos_cont2umm(cont);

--- a/src/vos/vos_layout.h
+++ b/src/vos/vos_layout.h
@@ -88,7 +88,7 @@ enum vos_gc_type {
 #define POOL_DF_MAGIC				0x5ca1ab1e
 
 /** Lowest supported durable format version */
-#define POOL_DF_VER_1				20
+#define POOL_DF_VER_1				21
 /** Current durable format version */
 #define POOL_DF_VERSION				POOL_DF_VER_1
 
@@ -253,6 +253,8 @@ struct vos_cont_df {
 	struct vea_hint_df		cd_hint_df[VOS_IOS_CNT];
 	/** GC bins for object/dkey...Don't need GC_CONT entry */
 	struct vos_gc_bin_df		cd_gc_bins[GC_CONT];
+	/* The epoch for the most new DTX entry that is aggregated. */
+	uint64_t			cd_newest_aggregated;
 };
 
 /* Assume cd_dtx_active_tail is just after cd_dtx_active_head. */


### PR DESCRIPTION
master-release: 440d04127110efdeeb9278866ed7e4aeef69a279

Record the epoch for the newest DXT entry that is aggregated by the
DTX aggregation. Such epoch will be used when check resent RPC and
DTX refresh: if we cannot find the DTX with the give transaction ID
and if the DTX timestamp is newer than such newset aggregated epoch,
then it is impossible that it has been removed by DTX aggregation.

The patch also increases the default value for DTX aggreagtion age
threshold. Then if there is no DRAM pressure on server, the committed
DTX entries can be kept for more long time. That is helpful for resend
logic to know whether related DTX has even been committed. But if there
is DRAM pressure on the server, then DTX aggregation will be triggered
via the count threshold.

Signed-off-by: Fan Yong <fan.yong@intel.com>