### PR TITLE
DAOS-8606 metrics: Fix dmg metrics collection after engine restart

### DIFF
--- a/src/control/lib/telemetry/promexp/collector_test.go
+++ b/src/control/lib/telemetry/promexp/collector_test.go
@@ -235,7 +235,11 @@ func TestPromExp_NewCollector(t *testing.T) {
 		expResult *Collector
 	}{
 		"no sources": {
-			expErr: errors.New("must have > 0 sources"),
+			expResult: &Collector{
+				summary: &prometheus.SummaryVec{
+					MetricVec: &prometheus.MetricVec{},
+				},
+			},
 		},
 		"defaults": {
 			sources: testSrc,
@@ -281,8 +285,10 @@ func TestPromExp_NewCollector(t *testing.T) {
 				cmpopts.IgnoreUnexported(regexp.Regexp{}),
 				cmp.AllowUnexported(Collector{}),
 				cmp.FilterPath(func(p cmp.Path) bool {
-					// Ignore the logger
-					return strings.HasSuffix(p.String(), "log")
+					// Ignore a few specific fields
+					return (strings.HasSuffix(p.String(), "log") ||
+						strings.HasSuffix(p.String(), "sourceMutex") ||
+						strings.HasSuffix(p.String(), "cleanupSource"))
 				}, cmp.Ignore()),
 			}
 			if diff := cmp.Diff(tc.expResult, result, cmpOpts...); diff != "" {
@@ -591,6 +597,187 @@ func TestPromExp_extractLabels(t *testing.T) {
 					t.Fatalf("key %q was not expected", key)
 				}
 				common.AssertEqual(t, expVal, val, "incorrect value")
+			}
+		})
+	}
+}
+
+func TestPromExp_Collector_AddSource(t *testing.T) {
+	testSrc := func() []*EngineSource {
+		return []*EngineSource{
+			{Index: 1},
+			{Index: 2},
+			{Index: 3},
+		}
+	}
+
+	for name, tc := range map[string]struct {
+		startSrc   []*EngineSource
+		es         *EngineSource
+		fn         func()
+		expSrc     []*EngineSource
+		expAddedFn bool
+	}{
+		"nil EngineSource": {
+			startSrc: testSrc(),
+			fn:       func() {},
+			expSrc:   testSrc(),
+		},
+		"nil func": {
+			es:     &EngineSource{},
+			expSrc: []*EngineSource{{}},
+		},
+		"add to empty": {
+			es:         &EngineSource{},
+			fn:         func() {},
+			expSrc:     []*EngineSource{{}},
+			expAddedFn: true,
+		},
+		"add to existing list": {
+			startSrc:   testSrc(),
+			es:         &EngineSource{},
+			fn:         func() {},
+			expSrc:     append(testSrc(), &EngineSource{}),
+			expAddedFn: true,
+		},
+		"add as duplicate": {
+			startSrc:   testSrc(),
+			es:         testSrc()[1],
+			fn:         func() {},
+			expSrc:     testSrc(),
+			expAddedFn: true,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			log, buf := logging.NewTestLogger(t.Name())
+			defer common.ShowBufferOnFailure(t, buf)
+
+			collector, err := NewCollector(log, nil, tc.startSrc...)
+			if err != nil {
+				t.Fatalf("failed to set up collector: %s", err)
+			}
+			collector.AddSource(tc.es, tc.fn)
+
+			// Ordering changes are possible, so we can't directly compare the structs
+			common.AssertEqual(t, len(tc.expSrc), len(collector.sources), "")
+			for _, exp := range tc.expSrc {
+				found := false
+				for _, actual := range collector.sources {
+					if actual.Index == exp.Index {
+						found = true
+						break
+					}
+				}
+
+				if !found {
+					t.Errorf("expected EngineSource %d not found", exp.Index)
+				}
+			}
+
+			var found bool
+			if tc.es != nil {
+				_, found = collector.cleanupSource[tc.es.Index]
+			}
+			common.AssertEqual(t, tc.expAddedFn, found, "")
+		})
+	}
+}
+
+func TestPromExp_Collector_RemoveSource(t *testing.T) {
+	badCleanup := func() {
+		t.Fatal("wrong cleanup function called")
+	}
+
+	var goodCleanupCalled int
+	goodCleanup := func() {
+		goodCleanupCalled++
+	}
+
+	for name, tc := range map[string]struct {
+		startSrc         []*EngineSource
+		startCleanup     map[uint32]func()
+		idx              uint32
+		expSrc           []*EngineSource
+		expCleanupKeys   []uint32
+		expCleanupCalled int
+	}{
+		"not found": {
+			startSrc: []*EngineSource{
+				{Index: 1},
+			},
+			startCleanup: map[uint32]func(){
+				1: badCleanup,
+			},
+			idx: 42,
+			expSrc: []*EngineSource{
+				{Index: 1},
+			},
+			expCleanupKeys: []uint32{1},
+		},
+		"success": {
+			startSrc: []*EngineSource{
+				{Index: 1},
+				{Index: 2},
+				{Index: 3},
+			},
+			startCleanup: map[uint32]func(){
+				1: badCleanup,
+				2: goodCleanup,
+				3: badCleanup,
+			},
+			idx: 2,
+			expSrc: []*EngineSource{
+				{Index: 1},
+				{Index: 3},
+			},
+			expCleanupKeys:   []uint32{1, 3},
+			expCleanupCalled: 1,
+		},
+		"remove engine with no cleanup": {
+			startSrc: []*EngineSource{
+				{Index: 1},
+				{Index: 2},
+				{Index: 3},
+			},
+			startCleanup: map[uint32]func(){
+				1: badCleanup,
+				3: badCleanup,
+			},
+			idx: 2,
+			expSrc: []*EngineSource{
+				{Index: 1},
+				{Index: 3},
+			},
+			expCleanupKeys: []uint32{1, 3},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			log, buf := logging.NewTestLogger(t.Name())
+			defer common.ShowBufferOnFailure(t, buf)
+
+			collector, err := NewCollector(log, nil, tc.startSrc...)
+			if err != nil {
+				t.Fatalf("failed to set up collector: %s", err)
+			}
+
+			collector.cleanupSource = tc.startCleanup
+			goodCleanupCalled = 0
+
+			collector.RemoveSource(tc.idx)
+
+			if diff := cmp.Diff(tc.expSrc, collector.sources, cmpopts.IgnoreUnexported(EngineSource{})); diff != "" {
+				t.Fatalf("(-want, +got)\n%s", diff)
+			}
+
+			common.AssertEqual(t, tc.expCleanupCalled, goodCleanupCalled, "")
+
+			common.AssertEqual(t, len(tc.expCleanupKeys), len(collector.cleanupSource), "")
+			for _, key := range tc.expCleanupKeys {
+				fn, found := collector.cleanupSource[key]
+				common.AssertTrue(t, found, fmt.Sprintf("expected to find %d in cleanup map", key))
+				if fn == nil {
+					t.Fatal("cleanup function was nil")
+				}
 			}
 		})
 	}

--- a/src/control/server/telemetry.go
+++ b/src/control/server/telemetry.go
@@ -21,46 +21,10 @@ import (
 	"github.com/daos-stack/daos/src/control/system"
 )
 
-func regPromEngineSources(ctx context.Context, log logging.Logger, engines []Engine) ([]func(), error) {
+func regPromEngineSources(ctx context.Context, log logging.Logger, engines []Engine) error {
 	numEngines := len(engines)
 	if numEngines == 0 {
-		return []func(){}, nil
-	}
-
-	var err error
-	cleanupFns := make([]func(), 0, numEngines)
-	defer func() {
-		if err != nil {
-			for _, cleanup := range cleanupFns {
-				cleanup()
-			}
-		}
-	}()
-
-	sources := make([]*promexp.EngineSource, numEngines)
-	for i := 0; i < numEngines; i++ {
-		er, err := engines[i].GetRank()
-		if err != nil {
-			return nil, errors.Wrapf(err, "failed to get rank for idx %d", i)
-		}
-		es, cleanup, err := promexp.NewEngineSource(ctx, uint32(i), er.Uint32())
-		if err != nil {
-			return nil, errors.Wrapf(err, "failed to create EngineSource for idx %d", i)
-		}
-		sources[i] = es
-		cleanupFns = append(cleanupFns, cleanup)
-
-		engines[i].OnInstanceExit(func(_ context.Context, _ uint32, rank system.Rank, _ error, _ uint64) error {
-			log.Debugf("Disabling metrics collection for rank %s", rank.String())
-			es.Disable()
-			return nil
-		})
-
-		engines[i].OnReady(func(context.Context) error {
-			log.Debugf("Enabling metrics collection for ready engine")
-			es.Enable()
-			return nil
-		})
+		return nil
 	}
 
 	opts := &promexp.CollectorOpts{
@@ -68,18 +32,51 @@ func regPromEngineSources(ctx context.Context, log logging.Logger, engines []Eng
 			`.*_ID_(\d+)_rank`,
 		},
 	}
-	c, err := promexp.NewCollector(log, opts, sources...)
+	c, err := promexp.NewCollector(log, opts)
 	if err != nil {
-		return nil, err
+		return err
 	}
 	prometheus.MustRegister(c)
 
-	return cleanupFns, nil
+	addFn := func(idx uint32, rank system.Rank) func(context.Context) error {
+		return func(context.Context) error {
+			log.Debugf("Setting up metrics collection for engine %d", idx)
+			es, cleanup, err := promexp.NewEngineSource(ctx, idx, rank.Uint32())
+			if err != nil {
+				return errors.Wrapf(err, "failed to create EngineSource for idx %d", idx)
+			}
+			c.AddSource(es, cleanup)
+			return nil
+		}
+	}
+
+	delFn := func(idx uint32) func(context.Context, uint32, system.Rank, error, uint64) error {
+		return func(_ context.Context, _ uint32, rank system.Rank, _ error, _ uint64) error {
+			log.Debugf("Tearing down metrics collection for engine %d (rank %s)", idx, rank.String())
+			c.RemoveSource(idx)
+			return nil
+		}
+	}
+
+	for i := 0; i < numEngines; i++ {
+		er, err := engines[i].GetRank()
+		if err != nil {
+			return errors.Wrapf(err, "failed to get rank for idx %d", i)
+		}
+
+		addEngineSrc := addFn(uint32(i), er)
+		addEngineSrc(ctx)
+
+		// Set up engine to add/remove source on exit/restart
+		engines[i].OnReady(addEngineSrc)
+		engines[i].OnInstanceExit(delFn(uint32(i)))
+	}
+
+	return nil
 }
 
 func startPrometheusExporter(ctx context.Context, log logging.Logger, port int, engines []Engine) (func(), error) {
-	cleanupFns, err := regPromEngineSources(ctx, log, engines)
-	if err != nil {
+	if err := regPromEngineSources(ctx, log, engines); err != nil {
 		return nil, err
 	}
 
@@ -118,10 +115,6 @@ func startPrometheusExporter(ctx context.Context, log logging.Logger, port int, 
 		defer cancel()
 		if err := srv.Shutdown(timedCtx); err != nil {
 			log.Infof("HTTP server didn't shut down within timeout: %s", err.Error())
-		}
-
-		for _, cleanup := range cleanupFns {
-			cleanup()
 		}
 	}, nil
 }


### PR DESCRIPTION
When the engine stops, it marks the telemetry shmem region for
deletion, and recreates it on restart. The control plane was
holding onto a stale reference for the deleted region, while
the restarted engine began updating a new region.

In this patch, the control plane server discards a stopped engine's
telemetry source, and attaches to a new one when the engine comes back
up.

Signed-off-by: Kris Jacque <kristin.jacque@intel.com>