### PR TITLE
DAOS-7160 Test: Updating the core API function based on recent modification.

### DIFF
--- a/src/tests/ftest/osa/offline_drain.py
+++ b/src/tests/ftest/osa/offline_drain.py
@@ -74,7 +74,7 @@ class OSAOfflineDrain(OSAUtils, ServerFillUp):
                     self.ior_cmd.dfs_dir_oclass.update(oclass)
                     self.ior_default_flags = self.ior_w_flags
                     self.log.info(self.pool.pool_percentage_used())
-                    self.start_ior_load(storage='NVMe', percent=pool_fillup)
+                    self.start_ior_load(storage='NVMe', operation="Auto_Write", percent=pool_fillup)
                     self.log.info(self.pool.pool_percentage_used())
                 else:
                     self.run_ior_thread("Write", oclass, test_seq)
@@ -133,7 +133,7 @@ class OSAOfflineDrain(OSAUtils, ServerFillUp):
             pool[val].display_pool_daos_space(display_string)
             if data:
                 if pool_fillup > 0:
-                    self.start_ior_load(storage='NVMe', operation='Read', percent=pool_fillup)
+                    self.start_ior_load(storage='NVMe', operation='Auto_Read', percent=pool_fillup)
                 else:
                     self.run_ior_thread("Read", oclass, test_seq)
                     self.run_mdtest_thread(oclass)

--- a/src/tests/ftest/osa/offline_reintegration.py
+++ b/src/tests/ftest/osa/offline_reintegration.py
@@ -80,7 +80,7 @@ class OSAOfflineReintegration(OSAUtils, ServerFillUp):
                     self.ior_default_flags = self.ior_w_flags
                     self.ior_cmd.repetitions.update(self.ior_test_repetitions)
                     self.log.info(self.pool.pool_percentage_used())
-                    self.start_ior_load(storage='NVMe', percent=pool_fillup)
+                    self.start_ior_load(storage='NVMe', operation="Auto_Write", percent=pool_fillup)
                     self.log.info(self.pool.pool_percentage_used())
                 else:
                     self.run_ior_thread("Write", oclass, test_seq)
@@ -180,7 +180,7 @@ class OSAOfflineReintegration(OSAUtils, ServerFillUp):
             self.pool = pool[val]
             if data:
                 if pool_fillup > 0:
-                    self.start_ior_load(storage='NVMe', operation='Read', percent=pool_fillup)
+                    self.start_ior_load(storage='NVMe', operation='Auto_Read', percent=pool_fillup)
                 else:
                     self.run_ior_thread("Read", oclass, test_seq)
                     self.run_mdtest_thread(oclass)


### PR DESCRIPTION
start_ior_load() API was modified to accommodate a few changes, part of that operation needs to be passed as an argument for auto-filled.

Test-tag-hw-medium: pr,hw,medium,ib2 offline_drain offline_drain_full offline_reintegration_daily offline_reintegration_full

Signed-off-by: Samir Raval <samir.raval@intel.com>