### PR TITLE
DAOS-8433 object: reduce stack usage for enumeration

### DIFF
--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -2775,7 +2775,6 @@ obj_local_enum(struct obj_io_context *ioc, crt_rpc_t *rpc,
 	       daos_epoch_t *e_out)
 {
 	vos_iter_param_t	param = { 0 };
-	struct vos_iter_anchors	saved_anchors;
 	struct dss_enum_arg	saved_arg;
 	struct obj_key_enum_in	*oei = crt_req_get(rpc);
 	uint32_t		flags = 0;
@@ -2836,7 +2835,7 @@ obj_local_enum(struct obj_io_context *ioc, crt_rpc_t *rpc,
 		/* object iteration for rebuild or consistency verification. */
 		D_ASSERT(opc == DAOS_OBJ_RPC_ENUMERATE);
 		type = VOS_ITER_DKEY;
-		if (daos_anchor_get_flags(&anchors->ia_dkey) &
+		if (daos_anchor_get_flags(&anchors[0].ia_dkey) &
 		      DIOF_WITH_SPEC_EPOCH) {
 			/* For obj verification case. */
 			param.ip_flags |= VOS_IT_RECX_VISIBLE;
@@ -2861,7 +2860,7 @@ obj_local_enum(struct obj_io_context *ioc, crt_rpc_t *rpc,
 	 * 'type' to indicate the anchor is on SV tree or EV tree.
 	 */
 	if (type == VOS_ITER_SINGLE)
-		anchors->ia_sv = anchors->ia_ev;
+		anchors[0].ia_sv = anchors[0].ia_ev;
 	else if (oei->oei_oid.id_shard % 3 == 1 &&
 		 DAOS_FAIL_CHECK(DAOS_VC_LOST_REPLICA))
 		D_GOTO(failed, rc = -DER_NONEXIST);
@@ -2877,7 +2876,7 @@ obj_local_enum(struct obj_io_context *ioc, crt_rpc_t *rpc,
 		goto failed;
 	}
 
-	saved_anchors = *anchors;
+	anchors[1] = anchors[0];
 	saved_arg = *enum_arg;
 
 	if (oei->oei_flags & ORF_FOR_MIGRATION)
@@ -2892,12 +2891,12 @@ obj_local_enum(struct obj_io_context *ioc, crt_rpc_t *rpc,
 		goto failed;
 
 re_pack:
-	rc = dss_enum_pack(&param, type, recursive, anchors, enum_arg,
+	rc = dss_enum_pack(&param, type, recursive, &anchors[0], enum_arg,
 			   vos_iterate, &dth);
 	if (obj_dtx_need_refresh(&dth, rc)) {
 		rc = dtx_refresh(&dth, ioc->ioc_coc);
 		if (rc == -DER_AGAIN) {
-			*anchors = saved_anchors;
+			anchors[0] = anchors[1];
 			obj_restore_enum_args(rpc, enum_arg, &saved_arg);
 
 			goto re_pack;
@@ -2926,7 +2925,7 @@ re_pack:
 		rc = rc_tmp;
 
 	if (type == VOS_ITER_SINGLE)
-		anchors->ia_ev = anchors->ia_sv;
+		anchors[0].ia_ev = anchors[0].ia_sv;
 
 	D_DEBUG(DB_IO, ""DF_UOID" iterate "DF_X64"-"DF_X64" type %d tag %d"
 		" rc %d\n", DP_UOID(oei->oei_oid), param.ip_epr.epr_lo,
@@ -2997,7 +2996,7 @@ void
 ds_obj_enum_handler(crt_rpc_t *rpc)
 {
 	struct dss_enum_arg	enum_arg = { 0 };
-	struct vos_iter_anchors	anchors = { 0 };
+	struct vos_iter_anchors	*anchors = NULL;
 	struct obj_key_enum_in	*oei;
 	struct obj_key_enum_out	*oeo;
 	struct obj_io_context	ioc;
@@ -3023,9 +3022,13 @@ ds_obj_enum_handler(crt_rpc_t *rpc)
 		dss_get_module_info()->dmi_xs_id,
 		oei->oei_map_ver, ioc.ioc_map_ver);
 
-	anchors.ia_dkey = oei->oei_dkey_anchor;
-	anchors.ia_akey = oei->oei_akey_anchor;
-	anchors.ia_ev = oei->oei_anchor;
+	D_ALLOC_ARRAY(anchors, 2);
+	if (anchors == NULL)
+		D_GOTO(out, rc = -DER_NOMEM);
+
+	anchors[0].ia_dkey = oei->oei_dkey_anchor;
+	anchors[0].ia_akey = oei->oei_akey_anchor;
+	anchors[0].ia_ev = oei->oei_anchor;
 
 	/* TODO: Transfer the inline_thres from enumerate RPC */
 	enum_arg.inline_thres = 32;
@@ -3069,16 +3072,16 @@ ds_obj_enum_handler(crt_rpc_t *rpc)
 	/* keep trying until the key_buffer is fully filled or reaching the
 	 * end of the stream.
 	 */
-	rc = obj_local_enum(&ioc, rpc, &anchors, &enum_arg, &epoch);
+	rc = obj_local_enum(&ioc, rpc, anchors, &enum_arg, &epoch);
 	if (rc == 1) /* If the buffer is full, exit and reset failure. */
 		rc = 0;
 
 	if (rc)
 		D_GOTO(out, rc);
 
-	oeo->oeo_dkey_anchor = anchors.ia_dkey;
-	oeo->oeo_akey_anchor = anchors.ia_akey;
-	oeo->oeo_anchor = anchors.ia_ev;
+	oeo->oeo_dkey_anchor = anchors[0].ia_dkey;
+	oeo->oeo_akey_anchor = anchors[0].ia_akey;
+	oeo->oeo_anchor = anchors[0].ia_ev;
 
 	if (enum_arg.eprs)
 		oeo->oeo_eprs.ca_count = enum_arg.eprs_len;
@@ -3105,6 +3108,7 @@ out:
 	}
 	obj_enum_complete(rpc, rc, ioc.ioc_map_ver, epoch);
 	obj_ioc_end(&ioc, rc);
+	D_FREE(anchors);
 }
 
 static void


### PR DESCRIPTION
master-commit: e8f70a152ecdb4ea7efba7c17e7762f07812acb5

On server side, for enumeration handler, dynamically allocate "anchors"
variable on heap instead of allocating it on stack. That can save about
1.4KB stack space.

Signed-off-by: Fan Yong <fan.yong@intel.com>