### PR TITLE
DAOS-8433 engine: use DSS_DEEP_STACK_SZ for some collective ULTs

### DIFF
--- a/src/dtx/dtx_resync.c
+++ b/src/dtx/dtx_resync.c
@@ -688,7 +688,7 @@ dtx_resync_ult(void *data)
 		DP_UUID(arg->pool_uuid), pool->sp_dtx_resync_version,
 		arg->version);
 
-	rc = dss_thread_collective(dtx_resync_one, arg, 0);
+	rc = dss_thread_collective(dtx_resync_one, arg, DSS_ULT_DEEP_STACK);
 	if (rc) {
 		/* If dtx resync fails, then let's still update
 		 * sp_dtx_resync_version, so the rebuild can go ahead,

--- a/src/engine/ult.c
+++ b/src/engine/ult.c
@@ -172,14 +172,37 @@ dss_collective_reduce_internal(struct dss_coll_ops *ops,
 		}
 
 		dx = dss_get_xstream(DSS_MAIN_XS_ID(tid));
-		if (create_ult)
-			rc = sched_create_thread(dx, collective_func, stream,
-						 ABT_THREAD_ATTR_NULL, NULL,
-						 flags);
-		else
+		if (create_ult) {
+			ABT_thread_attr		attr;
+			int			rc1;
+
+			if (flags & DSS_ULT_DEEP_STACK) {
+				rc1 = ABT_thread_attr_create(&attr);
+				if (rc1 != ABT_SUCCESS)
+					D_GOTO(next, rc = dss_abterr2der(rc1));
+
+				rc1 = ABT_thread_attr_set_stacksize(attr, DSS_DEEP_STACK_SZ);
+				D_ASSERT(rc1 == ABT_SUCCESS);
+
+				D_DEBUG(DB_TRACE, "Create collective ult with stacksize %d\n",
+					DSS_DEEP_STACK_SZ);
+
+			} else {
+				attr = ABT_THREAD_ATTR_NULL;
+			}
+
+			rc = sched_create_thread(dx, collective_func, stream, attr, NULL, flags);
+			if (attr != ABT_THREAD_ATTR_NULL) {
+				rc1 = ABT_thread_attr_free(&attr);
+				D_ASSERT(rc1 == ABT_SUCCESS);
+			}
+		} else {
 			rc = sched_create_task(dx, collective_func, stream,
 					       NULL, flags);
+		}
+
 		if (rc != 0) {
+next:
 			stream->st_rc = rc;
 			rc = ABT_future_set(future, (void *)stream);
 			D_ASSERTF(rc == ABT_SUCCESS, "%d\n", rc);
@@ -401,8 +424,7 @@ ult_create_internal(void (*func)(void *), void *arg, int xs_type, int tgt_idx,
 			return dss_abterr2der(rc);
 
 		rc = ABT_thread_attr_set_stacksize(attr, stack_size);
-		if (rc != ABT_SUCCESS)
-			D_GOTO(free, rc = dss_abterr2der(rc));
+		D_ASSERT(rc == ABT_SUCCESS);
 
 		D_DEBUG(DB_TRACE, "Create ult stacksize is %zd\n", stack_size);
 	} else {
@@ -410,22 +432,9 @@ ult_create_internal(void (*func)(void *), void *arg, int xs_type, int tgt_idx,
 	}
 
 	rc = sched_create_thread(dx, func, arg, attr, ult, flags);
-
-free:
 	if (attr != ABT_THREAD_ATTR_NULL) {
 		rc1 = ABT_thread_attr_free(&attr);
-		if (rc1 != ABT_SUCCESS)
-			/* The child ULT has already been created,
-			 * we should not return the error for the
-			 * ABT_thread_attr_free() failure; otherwise,
-			 * the caller will free the parameters ("arg")
-			 * that is being used by the child ULT.
-			 *
-			 * So let's ignore the failure, the worse case
-			 * is that we may leak some DRAM.
-			 */
-			D_ERROR("ABT_thread_attr_free failed: %d\n",
-				dss_abterr2der(rc1));
+		D_ASSERT(rc1 == ABT_SUCCESS);
 	}
 
 	return rc;

--- a/src/include/daos_srv/daos_engine.h
+++ b/src/include/daos_srv/daos_engine.h
@@ -513,6 +513,8 @@ int dss_parameters_set(unsigned int key_id, uint64_t value);
 enum dss_ult_flags {
 	/* Periodically created ULTs */
 	DSS_ULT_FL_PERIODIC	= (1 << 0),
+	/* Use DSS_DEEP_STACK_SZ as the stack size */
+	DSS_ULT_DEEP_STACK	= (1 << 1),
 };
 
 int dss_ult_create(void (*func)(void *), void *arg, int xs_type, int tgt_id,

--- a/src/object/srv_ec_aggregate.c
+++ b/src/object/srv_ec_aggregate.c
@@ -2380,7 +2380,7 @@ ec_agg_param_init(struct ds_cont_child *cont, struct agg_param *param)
 
 	arg.param = agg_param;
 	arg.eventual = eventual;
-	rc = dss_ult_periodic(agg_iv_ult, &arg, DSS_XS_SYS, 0, 0, NULL);
+	rc = dss_ult_periodic(agg_iv_ult, &arg, DSS_XS_SYS, 0, DSS_DEEP_STACK_SZ, NULL);
 	if (rc)
 		D_GOTO(free_eventual, rc = dss_abterr2der(rc));
 

--- a/src/object/srv_obj_migrate.c
+++ b/src/object/srv_obj_migrate.c
@@ -3301,7 +3301,7 @@ ds_obj_migrate_handler(crt_rpc_t *rpc)
 		pool_tls->mpt_ult_running = 1;
 		migrate_pool_tls_get(pool_tls);
 		rc = dss_ult_create(migrate_ult, pool_tls, DSS_XS_SELF,
-				    0, 0, NULL);
+				    0, MIGRATE_STACK_SIZE, NULL);
 		if (rc) {
 			pool_tls->mpt_ult_running = 0;
 			migrate_pool_tls_put(pool_tls);

--- a/src/pool/srv_pool_scrub.c
+++ b/src/pool/srv_pool_scrub.c
@@ -288,7 +288,10 @@ ds_start_scrubbing_ult(struct ds_pool_child *child)
 		"xs_id: %d, tgt_id: %d, ctx_id: %d, ",
 		dmi->dmi_xs_id, dmi->dmi_tgt_id, dmi->dmi_ctx_id);
 
-	rc = dss_ult_create(scrubbing_ult, child, DSS_XS_SELF, 0, 0, &thread);
+	/* There will be several levels iteration, such as pool, container, object, and lower,
+	 * and so on. Let's use DSS_DEEP_STACK_SZ to avoid ULT overflow.
+	 */
+	rc = dss_ult_create(scrubbing_ult, child, DSS_XS_SELF, 0, DSS_DEEP_STACK_SZ, &thread);
 	if (rc) {
 		D_ERROR(DF_UUID"[%d]: Failed to create Scrubbing ULT. %d\n",
 			DP_UUID(child->spc_uuid), dmi->dmi_tgt_id, rc);

--- a/src/rebuild/scan.c
+++ b/src/rebuild/scan.c
@@ -813,7 +813,7 @@ rebuild_scan_leader(void *data)
 	while (rpt->rt_pool->sp_dtx_resync_version < rpt->rt_rebuild_ver)
 		ABT_thread_yield();
 
-	rc = dss_thread_collective(rebuild_scanner, rpt, 0);
+	rc = dss_thread_collective(rebuild_scanner, rpt, DSS_ULT_DEEP_STACK);
 	if (rc)
 		D_GOTO(out, rc);
 


### PR DESCRIPTION
master-commit: a2dc8e7417e3f7b76e62892b6c72570b6811eaea

Some ULTs created via dss_collective_reduce() may recursively trigger
vos iteration for kinds of storage level scan, such as the container,
the object, and related callbacks. Use DSS_DEEP_STACK_SZ for such ULT
to avoid stack overflow.

This patch also unifies the stack size for EC aggregation related
ULTs with DSS_DEEP_STACK_SZ, and MIGRATE_STACK_SIZE for migration
related ones.

Signed-off-by: Fan Yong <fan.yong@intel.com>