### PR TITLE
DAOS-8869 memcheck: Add suppression for EL8 (#7127)

### DIFF
--- a/utils/test_memcheck.supp
+++ b/utils/test_memcheck.supp
@@ -167,6 +167,17 @@
    ...
 }
 {
+   libevent
+   Memcheck:Leak
+   match-leak-kinds: all
+   ...
+   fun:?alloc
+   ...
+   obj:*libevent*.so*
+   fun:*event_base_loop
+   ...
+}
+{
    libopen-rte leak
    Memcheck:Leak
    match-leak-kinds: all


### PR DESCRIPTION
Add EL8 version of libevent suppression

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>