### PR TITLE
DAOS-8832 pool: Add more INFO to pool stop process

### DIFF
--- a/src/container/srv_target.c
+++ b/src/container/srv_target.c
@@ -2482,6 +2482,9 @@ ds_cont_tgt_ec_eph_query_ult(void *data)
 
 		d_list_for_each_entry_safe(ec_eph, tmp, &pool->sp_ec_ephs_list,
 					   ce_list) {
+			if (dss_ult_exiting(pool->sp_ec_ephs_req))
+				break;
+
 			if (ec_eph->ce_destroy) {
 				cont_ec_eph_destroy(ec_eph);
 				continue;
@@ -2509,8 +2512,7 @@ yield:
 		sched_req_sleep(pool->sp_ec_ephs_req, EC_TGT_AGG_INTV);
 	}
 
-	D_DEBUG(DB_MD, DF_UUID" stop tgt ec aggregation\n",
-		DP_UUID(pool->sp_uuid));
+	D_INFO(DF_UUID" stop tgt ec aggregation\n", DP_UUID(pool->sp_uuid));
 
 	d_list_for_each_entry_safe(ec_eph, tmp, &pool->sp_ec_ephs_list,
 				   ce_list)

--- a/src/engine/server_iv.c
+++ b/src/engine/server_iv.c
@@ -858,6 +858,8 @@ ds_iv_ns_stop(struct ds_iv_ns *ns)
 		d_list_del(&entry->iv_link);
 		iv_entry_free(entry);
 	}
+
+	D_INFO(DF_UUID" ns stopped\n", DP_UUID(ns->iv_pool_uuid));
 }
 
 unsigned int

--- a/src/pool/srv_target.c
+++ b/src/pool/srv_target.c
@@ -613,13 +613,16 @@ ds_pool_tgt_ec_eph_query_abort(struct ds_pool *pool)
 	sched_req_wait(pool->sp_ec_ephs_req, true);
 	sched_req_put(pool->sp_ec_ephs_req);
 	pool->sp_ec_ephs_req = NULL;
+	D_INFO(DF_UUID": EC query ULT stopped\n", DP_UUID(pool->sp_uuid));
 }
 
 static void
 pool_fetch_hdls_ult_abort(struct ds_pool *pool)
 {
-	if (!pool->sp_fetch_hdls)
+	if (!pool->sp_fetch_hdls) {
+		D_INFO(DF_UUID": fetch hdls ULT aborted\n", DP_UUID(pool->sp_uuid));
 		return;
+	}
 
 	ABT_mutex_lock(pool->sp_mutex);
 	ABT_cond_signal(pool->sp_fetch_hdls_cond);
@@ -628,6 +631,7 @@ pool_fetch_hdls_ult_abort(struct ds_pool *pool)
 	ABT_mutex_lock(pool->sp_mutex);
 	ABT_cond_wait(pool->sp_fetch_hdls_done_cond, pool->sp_mutex);
 	ABT_mutex_unlock(pool->sp_mutex);
+	D_INFO(DF_UUID": fetch hdls ULT aborted\n", DP_UUID(pool->sp_uuid));
 }
 
 /*
@@ -728,6 +732,7 @@ ds_pool_stop(uuid_t uuid)
 	ds_migrate_abort(pool->sp_uuid, -1);
 	ds_pool_put(pool); /* held by ds_pool_start */
 	ds_pool_put(pool);
+	D_INFO(DF_UUID": pool service is aborted\n", DP_UUID(uuid));
 }
 
 /* ds_pool_hdl ****************************************************************/


### PR DESCRIPTION
Add more INFO to each phase of pool stop process.

Check pool stop aggressively in ds_cont_tgt_ec_eph_query_ult(),
so to exit the ULT quickly if the pool service is stopped.

Signed-off-by: Di Wang <di.wang@intel.com>