### PR TITLE
DAOS-8934 test: Increase expected logfile size for NLT.

### DIFF
--- a/ci/unit/test_nlt_node.sh
+++ b/ci/unit/test_nlt_node.sh
@@ -20,4 +20,4 @@ cd build
 sudo bash -c ". ./utils/sl/setup_local.sh; ./utils/setup_daos_admin.sh"
 
 # NLT will mount /mnt/daos itself.
-./utils/node_local_test.py --max-log-size 500MiB --dfuse-dir /localhome/jenkins/ all
+./utils/node_local_test.py --max-log-size 550MiB --dfuse-dir /localhome/jenkins/ all


### PR DESCRIPTION
NLT enforces a maximum log-file size to catch cases where
we acidentally increase the logging verbosity, however
as we've added more tests the logs have got bigger so we're
now failing the size check randomly.

Increase the size to 10% so that it's within expected
constraints now, but we still pick up major regressions.

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>
