### PR TITLE
DAOS-8400 documentation:ERR- 2001 when trying to destroy filled pool

### DIFF
--- a/docs/admin/pool_operations.md
+++ b/docs/admin/pool_operations.md
@@ -163,6 +163,9 @@ set aside depends on the size of the target and may take up 2+ GB.
 Therefore, Out of space conditions may occur even while pool query may not
 show min approaching zero.
 
+!!! caution
+    When space reserving is disabled for tiny pools, it may not function if the pool is filled up, since destroy/punch also requires additional space in a versioned storage.
+
 The example below shows a rebuild in progress and NVMe space allocated.
 
 ```bash


### PR DESCRIPTION
Added caution in document to reflect the error in the ticket as discussed in TB6 triage meeting.

Skip-build: true
Skip-test: true

Signed-off-by: craig <craig.durfey@intel.com>