### PR TITLE
DAOS-8927 vos: Lock memory for VOS pools

### DIFF
--- a/src/cart/README.env
+++ b/src/cart/README.env
@@ -134,8 +134,8 @@ This file lists the environment variables used in CaRT.
    Specifies the fault injection configuration file. If this variable is not set
    or set to empty, fault injection is disabled.
 
- . CRT_DISABLE_MEM_PIN
-   Disables server-side memory pinning for CART-890 workaround
+ . CRT_ENABLE_MEM_PIN
+   Enables memory pinning for CART-890 workaround
 
  . CRT_MRC_ENABLE
    When not set automatically disables MR caching via FI_MR_CACHE_MAX_COUNT=0

--- a/src/cart/crt_init.c
+++ b/src/cart/crt_init.c
@@ -109,7 +109,7 @@ static int data_init(int server, crt_init_options_t *opt)
 	uint32_t	timeout;
 	uint32_t	credits;
 	uint32_t	fi_univ_size = 0;
-	uint32_t	mem_pin_disable = 0;
+	uint32_t	mem_pin_enable = 0;
 	uint32_t	mrc_enable = 0;
 	uint64_t	start_rpcid;
 	int		rc = 0;
@@ -143,8 +143,8 @@ static int data_init(int server, crt_init_options_t *opt)
 
 	/* Apply CART-890 workaround for server side only */
 	if (server) {
-		d_getenv_int("CRT_DISABLE_MEM_PIN", &mem_pin_disable);
-		if (mem_pin_disable == 0)
+		d_getenv_int("CRT_ENABLE_MEM_PIN", &mem_pin_enable);
+		if (mem_pin_enable == 1)
 			mem_pin_workaround();
 	}
 

--- a/src/vos/vos_internal.h
+++ b/src/vos/vos_internal.h
@@ -145,8 +145,6 @@ struct vos_pool {
 	struct umem_attr	vp_uma;
 	/** memory class instance of the pool */
 	struct umem_instance	vp_umm;
-	/** Base mapped address of pool file */
-	void			*vp_base;
 	/** Size of pool file */
 	uint64_t		vp_size;
 	/** btr handle for the container table */

--- a/src/vos/vos_internal.h
+++ b/src/vos/vos_internal.h
@@ -145,6 +145,10 @@ struct vos_pool {
 	struct umem_attr	vp_uma;
 	/** memory class instance of the pool */
 	struct umem_instance	vp_umm;
+	/** Base mapped address of pool file */
+	void			*vp_base;
+	/** Size of pool file */
+	uint64_t		vp_size;
 	/** btr handle for the container table */
 	daos_handle_t		vp_cont_th;
 	/** GC statistics of this pool */

--- a/src/vos/vos_pool.c
+++ b/src/vos/vos_pool.c
@@ -20,6 +20,8 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <sys/mman.h>
+#include <sys/time.h>
+#include <sys/resource.h>
 #include <vos_layout.h>
 #include <vos_internal.h>
 #include <errno.h>
@@ -140,6 +142,15 @@ pool_hop_free(struct d_ulink *hlink)
 	if (daos_handle_is_valid(pool->vp_cont_th))
 		dbtree_close(pool->vp_cont_th);
 
+	if (pool->vp_base != NULL) {
+		rc = munlock(pool->vp_base, pool->vp_size);
+		if (rc != 0)
+			D_WARN("Failed to unlock pool memory: errno=%d (%s)\n", errno,
+			       strerror(errno));
+		else
+			D_DEBUG(DB_MGMT, "Unlocked VOS pool memory: "DF_U64" bytes at %p\n",
+				pool->vp_size, pool->vp_base);
+	}
 	if (pool->vp_uma.uma_pool)
 		vos_pmemobj_close(pool->vp_uma.uma_pool);
 
@@ -619,6 +630,70 @@ vos_register_slabs(struct umem_attr *uma)
 	return 0;
 }
 
+#define LINE_SIZE 256
+static void
+lock_pool_memory(struct vos_pool *pool)
+{
+	struct rlimit	 rlim;
+	FILE		*maps = fopen("/proc/self/maps", "r");
+	uintptr_t	 addr1, addr2;
+	uintptr_t	 pool_base = (uintptr_t)pool->vp_pool_df;
+	char		*tok, *save;
+	char		 buf[LINE_SIZE];
+	int		 rc;
+
+	if (maps == NULL) {
+		D_WARN("Could not open /proc/self/maps to lock pool memory: errno=%d (%s)\n",
+		       errno, strerror(errno));
+		return;
+	}
+
+	rc = getrlimit(RLIMIT_MEMLOCK, &rlim);
+	if (rc != 0) {
+		D_WARN("getrlimit() failed; errno=%d (%s)\n", errno, strerror(errno));
+		return;
+	}
+
+	if (rlim.rlim_cur != RLIM_INFINITY || rlim.rlim_max != RLIM_INFINITY) {
+		D_WARN("Infinite rlimit not detected, not locking VOS pool memory\n");
+		return;
+	}
+
+	while (fgets(buf, LINE_SIZE, maps) != NULL) {
+		tok = strtok_r(buf, "-", &save);
+
+		if (tok == NULL)
+			continue;
+
+		addr1 = strtoull(tok, NULL, 16);
+
+		tok = strtok_r(NULL, " ", &save);
+
+		if (tok == NULL)
+			continue;
+
+		addr2 = strtoull(tok, NULL, 16);
+
+		if (addr1 > pool_base || addr2 < pool_base)
+			continue; /* Not the right map */
+
+		rc = mlock((void *)addr1, addr2 - addr1);
+		if (rc != 0) {
+			D_WARN("Could not lock memory for VOS pool at %p; errno=%d (%s)\n",
+			       (void *)addr1, errno, strerror(errno));
+			return;
+		}
+
+		/* Only save the size if the locking was successful */
+		pool->vp_base = (void *)addr1;
+		pool->vp_size = addr2 - addr1;
+		D_DEBUG(DB_MGMT, "Locking VOS pool in memory "DF_U64" bytes at %p\n", pool->vp_size,
+			pool->vp_base);
+
+		break;
+	}
+}
+
 /*
  * If successful, this function consumes ph, and closes it upon any error.
  * So the caller shall not close ph in any case.
@@ -714,6 +789,7 @@ pool_open(PMEMobjpool *ph, struct vos_pool_df *pool_df, uuid_t uuid,
 	vos_space_sys_init(pool);
 	/* Ensure GC is triggered after server restart */
 	gc_add_pool(pool);
+	lock_pool_memory(pool);
 	D_DEBUG(DB_MGMT, "Opened pool %p\n", pool);
 	return 0;
 failed:


### PR DESCRIPTION
Change CART envirable to turn on memory pinning globally
with it off by default.   Instead, lock each vos pool
individually.

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>