### PR TITLE
DAOS-8700: test with fabric_iface: ib1

### DIFF
--- a/src/tests/ftest/daos_vol/h5_suite.py
+++ b/src/tests/ftest/daos_vol/h5_suite.py
@@ -5,7 +5,7 @@
 SPDX-License-Identifier: BSD-2-Clause-Patent
 """
 from vol_test_base import VolTestBase
-from general_utils import get_job_manager_class
+from general_utils import get_job_manager_class, run_pcmd
 
 
 class DaosVol(VolTestBase):
@@ -38,6 +38,17 @@ class DaosVol(VolTestBase):
         :avocado: tags=hdf5,vol,volunit,volmpich
         :avocado: tags=DAOS_5610
         """
+
+
+        # quick hack, let's see what ib0 and ib1 interfaces & link status look like
+        run_pcmd(self.server_managers[0].hosts + self.hostlist_clients, "dmesg|egrep 'ib0.*becomes ready|ib1.*becomes ready'")
+        run_pcmd(self.server_managers[0].hosts + self.hostlist_clients, "/usr/sbin/ip link show ib0")
+        run_pcmd(self.server_managers[0].hosts + self.hostlist_clients, "/usr/sbin/ip link show ib1")
+        run_pcmd(self.server_managers[0].hosts + self.hostlist_clients, "dmesg|egrep 'ib0.*becomes ready|ib1.*becomes ready'")
+        run_pcmd(self.server_managers[0].hosts + self.hostlist_clients, "/sbin/ifconfig ib0")
+        run_pcmd(self.server_managers[0].hosts + self.hostlist_clients, "/sbin/ifconfig ib1")
+        run_pcmd(self.server_managers[0].hosts + self.hostlist_clients, "dmesg|egrep 'ib0.*becomes ready|ib1.*becomes ready'")
+
         self.job_manager = get_job_manager_class("Mpirun", None, False, "mpich")
         self.set_job_manager_timeout()
         self.run_test(

--- a/src/tests/ftest/daos_vol/h5_suite.yaml
+++ b/src/tests/ftest/daos_vol/h5_suite.yaml
@@ -8,6 +8,8 @@ job_manager_timeout: 900
 server_config:
     name: daos_server
     servers:
+        pinned_numa_node: 1
+        fabric_iface: ib1
         bdev_class: nvme
         bdev_list: ["0000:81:00.0","0000:da:00.0"]
         scm_class: dcpm
@@ -24,21 +26,21 @@ container:
 dfuse:
   mount_dir: "/tmp/daos_dfuse"
 daos_vol_tests:  !mux
-    test1:
-        testname: h5_partest_t_shapesame
-        client_processes: 6
+    #test1:
+    #    testname: h5_partest_t_shapesame
+    #    client_processes: 6
     test2:
         testname: h5vl_test_parallel
         client_processes: 6
     test3:
         testname: h5vl_test
         client_processes: 1
-    test4:
-        testname: h5_test_testhdf5
-        client_processes: 1
-    test5:
-        testname: h5_partest_testphdf5
-        client_processes: 6
+    #test4:
+    #    testname: h5_test_testhdf5
+    #    client_processes: 1
+    #test5:
+    #    testname: h5_partest_testphdf5
+    #    client_processes: 6
     test6:
         testname: h5daos_test_map
         client_processes: 1
@@ -48,6 +50,6 @@ daos_vol_tests:  !mux
     test8:
         testname: h5daos_test_oclass
         client_processes: 1
-    test9:
-        testname: h5daos_test_metadata_parallel -U -u
-        client_processes: 6
+    #test9:
+    #    testname: h5daos_test_metadata_parallel -U -u
+    #    client_processes: 6


### PR DESCRIPTION
Test PR to run on hw small cluster with ib1 not ib0 default interface.

Quick-Functional: true
Skip-coverity-test: true
Skip-scan-centos-rpms: true
Skip-scan-leap15-rpms: true
Skip-test-centos-rpms: true
Skip-test-centos-8.3-rpms: true
Skip-test-leap-15-rpms: true
Test-tag: volmpich
Test-repeat: 10

Signed-off-by: Kenneth Cain <kenneth.c.cain@intel.com>