### PR TITLE
DAOS-8931 vea: don't do 'plug' in GC

### DIFF
--- a/src/vos/vos_gc.c
+++ b/src/vos/vos_gc.c
@@ -1095,11 +1095,6 @@ vos_gc_pool(daos_handle_t poh, int credits, bool (*yield_func)(void *arg),
 		return 0; /* nothing to reclaim for this pool */
 
 	tls->vtl_gc_running++;
-	/*
-	 * Pause flushing free extents in VEA aging buffer, otherwise,
-	 * there'll be way more fragments to be processed.
-	 */
-	vos_pool_ctl(poh, VOS_PO_CTL_VEA_PLUG);
 
 	while (1) {
 		int	creds = GC_CREDS_PRIV;
@@ -1126,9 +1121,6 @@ vos_gc_pool(daos_handle_t poh, int credits, bool (*yield_func)(void *arg),
 			break;
 		}
 	}
-
-	/* Unplug and make the freed extents available immediately. */
-	vos_pool_ctl(poh, VOS_PO_CTL_VEA_UNPLUG);
 
 	if (total != 0) /* did something */
 		D_DEBUG(DB_TRACE, "GC consumed %d credits\n", total);


### PR DESCRIPTION
The intention of 'plug' in GC is to reduce fragmentations, it stops
VEA flush temporarily, so that more free extents could be merged in
aging tree and being added to free tree batchly.

However, test shows the 'plug' operation could cause container &
pool destroy timeout when pool is fragmented. Also, test shows that
removing the 'plug' operation can actually improve space reclaiming
speed, and fragmentation issues are not worsen.

Signed-off-by: Niu Yawei <yawei.niu@intel.com>