### PR TITLE
DAOS-7312-test4a: Functional testing for EC auto object class selection and move some existing tests to use EC by default

### DIFF
--- a/src/tests/ftest/aggregation/shutdown_restart.py
+++ b/src/tests/ftest/aggregation/shutdown_restart.py
@@ -47,8 +47,8 @@ class IoAggregation(IorTestBase):
             for 4 attempts.
 
         :avocado: tags=all,full_regression
-        :avocado: tags=hw,small
-        :avocado: tags=daosio,io_aggregation,tx
+        :avocado: tags=hw,medium,ib2
+        :avocado: tags=daosio,ioaggregation,tx
         """
         # update ior signature option
         self.ior_cmd.signature.update("123")
@@ -61,9 +61,9 @@ class IoAggregation(IorTestBase):
         # create snapshot
         self.container.create_snap()
 
-        # write to same ior file again
+        # write to same ior file again, expect warning
         self.ior_cmd.signature.update("456")
-        self.run_ior_with_pool(create_cont=False)
+        self.run_ior_with_pool(create_cont=False, fail_on_warning=False)
 
         # capture free space after second ior write
         free_space_before_snap_destroy = self.get_nvme_free_space()

--- a/src/tests/ftest/aggregation/shutdown_restart.yaml
+++ b/src/tests/ftest/aggregation/shutdown_restart.yaml
@@ -1,8 +1,10 @@
 hosts:
   test_servers:
     - server-A
+    - server-B
+    - server-C
   test_clients:
-    - client-B
+    - client-D
 timeout: 600
 server_config:
   name: daos_server
@@ -16,7 +18,7 @@ server_config:
       - FI_SOCKETS_CONN_TIMEOUT=2000
       - DD_MASK=all
     bdev_class: nvme
-    bdev_list: ["0000:81:00.0"]
+    bdev_list: ["aaaa:aa:aa.a","bbbb:bb:bb.b"]
 pool:
   createmode:
     mode_RW:
@@ -24,8 +26,8 @@ pool:
   createset:
     setname: daos_server
   createsize:
-    scm_size: 5000000000
-    nvme_size: 10000000000
+    scm_size: 20%
+    nvme_size: 50%
   createsvc:
     svcn: 1
   control_method: dmg
@@ -45,5 +47,5 @@ ior:
       transfer_size: '4K'
       block_size: '104857600'  # 100M
   objectclass:
-    SX:
-      dfs_oclass: "SX"
+    EC_2P1GX:
+      dfs_oclass: "EC_2P1GX"


### PR DESCRIPTION

Description: Update EC by default for aggregation/shutdown_restart tests.
modified:   shutdown_restart.py
modified:   shutdown_restart.yaml

Test-tag: ioaggregation
Signed-off-by: Ding Ho ding-hwa.ho@intel.com