### PR TITLE
DAOS-8707 control: Fix agent AttachInfo cache (#7055)

### DIFF
--- a/src/control/cmd/daos_agent/agent_test.go
+++ b/src/control/cmd/daos_agent/agent_test.go
@@ -1,0 +1,205 @@
+//
+// (C) Copyright 2021 Intel Corporation.
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/pkg/errors"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/testing/protocmp"
+
+	"github.com/daos-stack/daos/src/control/common"
+	mgmtpb "github.com/daos-stack/daos/src/control/common/proto/mgmt"
+	"github.com/daos-stack/daos/src/control/drpc"
+	"github.com/daos-stack/daos/src/control/lib/control"
+	"github.com/daos-stack/daos/src/control/lib/netdetect"
+	"github.com/daos-stack/daos/src/control/logging"
+	"github.com/daos-stack/daos/src/control/pbin"
+)
+
+const (
+	childModeEnvVar        = "GO_TESTING_CHILD_MODE"
+	childModeGetAttachInfo = "MODE_GET_ATTACH_INFO"
+	drpcDirEnvVar          = "DAOS_AGENT_DRPC_DIR"
+)
+
+func childErrExit(err error) {
+	if err == nil {
+		err = errors.New("unknown error")
+	}
+	fmt.Fprintf(os.Stderr, "CHILD ERROR: %s\n", err)
+	os.Exit(1)
+}
+
+func getAttachInfo() error {
+	sockPath := os.Getenv(drpcDirEnvVar) + "/" + agentSockName
+	drpcClient := drpc.NewClientConnection(sockPath)
+	if err := drpcClient.Connect(); err != nil {
+		return err
+	}
+	defer drpcClient.Close()
+
+	req := &mgmtpb.GetAttachInfoReq{}
+
+	var bodyBytes []byte
+	var err error
+	bodyBytes, err = proto.Marshal(req)
+	if err != nil {
+		return err
+	}
+
+	method := drpc.MethodGetAttachInfo
+	call := &drpc.Call{
+		Module: method.Module().ID(),
+		Method: method.ID(),
+		Body:   bodyBytes,
+	}
+
+	dresp, err := drpcClient.SendMsg(call)
+	if err != nil {
+		return err
+	}
+
+	attachInfo := new(mgmtpb.GetAttachInfoResp)
+	if err = proto.Unmarshal(dresp.Body, attachInfo); err != nil {
+		return err
+	}
+
+	payload, err := json.Marshal(attachInfo)
+	if err != nil {
+		return err
+	}
+
+	res := pbin.Response{
+		Payload: payload,
+	}
+
+	conn := pbin.NewStdioConn("child", "parent", os.Stdin, os.Stdout)
+
+	writeBuf, err := json.Marshal(&res)
+	if err != nil {
+		return err
+	}
+
+	if _, err = conn.Write(writeBuf); err != nil {
+		return err
+	}
+
+	if err = conn.CloseWrite(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func TestMain(m *testing.M) {
+	mode := os.Getenv(childModeEnvVar)
+	switch mode {
+	case "":
+		// default; run the test binary
+		os.Exit(m.Run())
+	case childModeGetAttachInfo:
+		if err := getAttachInfo(); err != nil {
+			childErrExit(err)
+		}
+	default:
+		childErrExit(errors.Errorf("Unknown child mode: %q", mode))
+	}
+}
+
+func TestAgent_MultiProcess_AttachInfoCache(t *testing.T) {
+	log, buf := logging.NewTestLogger(t.Name())
+	defer common.ShowBufferOnFailure(t, buf)
+
+	tmpDir, cleanup := common.CreateTestDir(t)
+	defer cleanup()
+
+	srvResp := &mgmtpb.GetAttachInfoResp{
+		ClientNetHint: &mgmtpb.ClientNetHint{
+			Provider:    "tcp+sockets",
+			NetDevClass: netdetect.Ether,
+		},
+	}
+
+	agentCfg := DefaultConfig()
+	agentCfg.RuntimeDir = tmpDir
+	client := control.NewMockInvoker(log, &control.MockInvokerConfig{
+		UnaryResponse: control.MockMSResponse("localhost", nil, srvResp),
+	})
+	testAgentStart := &startCmd{
+		logCmd: logCmd{
+			log: log,
+		},
+		configCmd: configCmd{
+			cfg: agentCfg,
+		},
+		ctlInvokerCmd: ctlInvokerCmd{
+			ctlInvoker: client,
+		},
+	}
+
+	// Start the "agent" in a goroutine. Unfortunately, we can't block
+	// on waiting for it to be ready without rewriting things a lot, but
+	// sleeping for a second should be fine.
+	go func() {
+		err := testAgentStart.Execute([]string{})
+		if err != nil {
+			t.Log(err)
+		}
+	}()
+	time.Sleep(1 * time.Second)
+
+	errCh := make(chan error)
+	respCh := make(chan *mgmtpb.GetAttachInfoResp)
+
+	// Now, start a bunch of child processes to hammer away at the agent. The goal
+	// is to verify that the cache should be initialized with the result of a single
+	// GetAttachInfo RPC invocation.
+	os.Setenv(drpcDirEnvVar, tmpDir)
+	os.Setenv(childModeEnvVar, childModeGetAttachInfo)
+	maxIter := 128
+	for i := 0; i < maxIter; i++ {
+		go func(rc chan *mgmtpb.GetAttachInfoResp, ec chan error) {
+			pr, err := pbin.ExecReq(context.Background(), log, os.Args[0], &pbin.Request{})
+			if err != nil {
+				ec <- err
+				return
+			}
+
+			gr := new(mgmtpb.GetAttachInfoResp)
+			if err = json.Unmarshal(pr.Payload, gr); err != nil {
+				ec <- err
+				return
+			}
+			rc <- gr
+		}(respCh, errCh)
+	}
+
+	// We don't really care about the interface chosen for this test; the main
+	// thing we want to verify is that the responses look valid and that the
+	// cache is working correctly (i.e. only 1 invocation of the RPC).
+	cmpOpts := append(common.DefaultCmpOpts(),
+		protocmp.IgnoreFields(&mgmtpb.ClientNetHint{}, "domain", "interface"))
+	for i := 0; i < maxIter; i++ {
+		select {
+		case err := <-errCh:
+			t.Fatal(err)
+		case resp := <-respCh:
+			if diff := cmp.Diff(resp, srvResp, cmpOpts...); diff != "" {
+				t.Errorf("Unexpected resp (-want +got):\n%s", diff)
+			}
+		}
+	}
+
+	common.AssertEqual(t, client.GetInvokeCount(), 1, "unexpected number of GetAttachInfo RPC invocations")
+}

--- a/src/control/cmd/daos_agent/agent_test.go
+++ b/src/control/cmd/daos_agent/agent_test.go
@@ -167,7 +167,7 @@ func TestAgent_MultiProcess_AttachInfoCache(t *testing.T) {
 	// GetAttachInfo RPC invocation.
 	os.Setenv(drpcDirEnvVar, tmpDir)
 	os.Setenv(childModeEnvVar, childModeGetAttachInfo)
-	maxIter := 128
+	maxIter := 32
 	for i := 0; i < maxIter; i++ {
 		go func(rc chan *mgmtpb.GetAttachInfoResp, ec chan error) {
 			pr, err := pbin.ExecReq(context.Background(), log, os.Args[0], &pbin.Request{})

--- a/src/control/cmd/daos_agent/infocache.go
+++ b/src/control/cmd/daos_agent/infocache.go
@@ -37,7 +37,7 @@ func newAttachInfoCache(log logging.Logger, enabled bool) *attachInfoCache {
 }
 
 type attachInfoCache struct {
-	mutex sync.RWMutex
+	mutex sync.Mutex
 
 	log         logging.Logger
 	enabled     atm.Bool
@@ -47,59 +47,48 @@ type attachInfoCache struct {
 	attachInfo *mgmtpb.GetAttachInfoResp
 }
 
-// IsEnabled reports whether the cache is enabled.
-func (c *attachInfoCache) IsEnabled() bool {
-	if c == nil {
-		return false
-	}
-
-	return c.enabled.IsTrue()
-}
-
-// IsCached reports whether there is data in the cache.
-func (c *attachInfoCache) IsCached() bool {
-	if c == nil {
-		return false
-	}
+func (c *attachInfoCache) isCached() bool {
 	return c.initialized.IsTrue()
 }
 
-// Cache preserves the results of a GetAttachInfo remote call.
-func (c *attachInfoCache) Cache(ctx context.Context, resp *mgmtpb.GetAttachInfoResp) {
-	if c == nil {
-		return
-	}
-
-	c.mutex.Lock()
-	defer c.mutex.Unlock()
-
-	if !c.IsEnabled() {
-		return
-	}
-
-	if resp == nil {
-		return
-	}
-
-	c.attachInfo = resp
-	c.initialized.SetTrue()
+func (c *attachInfoCache) isEnabled() bool {
+	return c.enabled.IsTrue()
 }
 
-// GetAttachInfoResp fetches the cached GetAttachInfoResp.
-func (c *attachInfoCache) GetAttachInfoResp() (*mgmtpb.GetAttachInfoResp, error) {
-	if c == nil {
-		return nil, NotCachedErr
-	}
-
-	c.mutex.RLock()
-	defer c.mutex.RUnlock()
-
-	if !c.IsCached() {
+func (c *attachInfoCache) getAttachInfoResp() (*mgmtpb.GetAttachInfoResp, error) {
+	if !c.isCached() {
 		return nil, NotCachedErr
 	}
 
 	aiCopy := proto.Clone(c.attachInfo)
 	return aiCopy.(*mgmtpb.GetAttachInfoResp), nil
+}
+
+type getAttachInfoFn func(ctx context.Context, numaNode int, sys string) (*mgmtpb.GetAttachInfoResp, error)
+
+// Get is responsible for returning a GetAttachInfo response, either from the cache or from
+// the remote server if the cache is disabled.
+func (c *attachInfoCache) Get(ctx context.Context, numaNode int, sys string, getRemote getAttachInfoFn) (*mgmtpb.GetAttachInfoResp, error) {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	if c.isEnabled() && c.isCached() {
+		return c.getAttachInfoResp()
+	}
+
+	attachInfo, err := getRemote(ctx, numaNode, sys)
+	if err != nil {
+		return nil, err
+	}
+
+	if !c.isEnabled() {
+		return attachInfo, nil
+	}
+
+	c.attachInfo = attachInfo
+	c.initialized.SetTrue()
+
+	return c.getAttachInfoResp()
 }
 
 func newLocalFabricCache(log logging.Logger, enabled bool) *localFabricCache {

--- a/src/control/cmd/daos_agent/infocache_test.go
+++ b/src/control/cmd/daos_agent/infocache_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/pkg/errors"
 
 	"github.com/daos-stack/daos/src/control/common"
 	mgmtpb "github.com/daos-stack/daos/src/control/common/proto/mgmt"
@@ -41,83 +42,85 @@ func TestAgent_newAttachInfoCache(t *testing.T) {
 			}
 
 			common.AssertEqual(t, log, cache.log, "")
-			common.AssertEqual(t, tc.enabled, cache.IsEnabled(), "IsEnabled()")
-			common.AssertFalse(t, cache.IsCached(), "default state is uncached")
+			common.AssertEqual(t, tc.enabled, cache.isEnabled(), "isEnabled()")
+			common.AssertFalse(t, cache.isCached(), "default state is uncached")
 		})
 	}
 }
 
-func TestAgent_attachInfoCache_Cache(t *testing.T) {
+func TestAgent_attachInfoCache_Get(t *testing.T) {
+	srvResp := &mgmtpb.GetAttachInfoResp{
+		Status: -1000,
+		RankUris: []*mgmtpb.GetAttachInfoResp_RankUri{
+			{Rank: 1, Uri: "firsturi"},
+			{Rank: 2, Uri: "nexturi"},
+		},
+	}
+
 	for name, tc := range map[string]struct {
 		aic       *attachInfoCache
-		input     *mgmtpb.GetAttachInfoResp
+		cache     *mgmtpb.GetAttachInfoResp
 		expCached bool
+		expRemote bool
+		remoteErr bool
+		expErr    error
 	}{
-		"nil cache": {},
 		"not enabled": {
-			aic: &attachInfoCache{},
+			aic:       &attachInfoCache{},
+			expRemote: true,
 		},
-		"nil input": {
-			aic: &attachInfoCache{enabled: atm.NewBool(true)},
-		},
-		"success": {
-			aic: &attachInfoCache{enabled: atm.NewBool(true)},
-			input: &mgmtpb.GetAttachInfoResp{
-				Status: -1000,
-				RankUris: []*mgmtpb.GetAttachInfoResp_RankUri{
-					{Rank: 1, Uri: "firsturi"},
-					{Rank: 2, Uri: "nexturi"},
-				},
-			},
+		"not cached": {
+			aic:       &attachInfoCache{enabled: atm.NewBool(true)},
+			expRemote: true,
 			expCached: true,
+		},
+		"cached": {
+			aic:       &attachInfoCache{enabled: atm.NewBool(true)},
+			cache:     srvResp,
+			expCached: true,
+		},
+		"remote fails": {
+			aic:       &attachInfoCache{enabled: atm.NewBool(true)},
+			expRemote: true,
+			remoteErr: true,
+			expErr:    errors.New("no soup for you"),
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			tc.aic.Cache(context.TODO(), tc.input)
-
-			common.AssertEqual(t, tc.expCached, tc.aic.IsCached(), "IsCached()")
+			if tc.cache != nil {
+				tc.aic.attachInfo = tc.cache
+				tc.aic.initialized.SetTrue()
+			}
 
 			if tc.aic == nil {
 				return
 			}
 
-			cachedResp, err := tc.aic.GetAttachInfoResp()
-			if tc.expCached {
-				if diff := cmp.Diff(tc.input, cachedResp, common.DefaultCmpOpts()...); diff != "" {
-					t.Fatalf("-want, +got:\n%s", diff)
+			numaNode := 42
+			sysName := "snekSezSyss"
+			remoteInvoked := atm.NewBool(false)
+			getFn := func(_ context.Context, node int, name string) (*mgmtpb.GetAttachInfoResp, error) {
+				common.AssertEqual(t, numaNode, node, "node was not supplied")
+				common.AssertEqual(t, sysName, name, "name was not supplied")
+
+				remoteInvoked.SetTrue()
+				if tc.remoteErr {
+					return nil, tc.expErr
 				}
-				if err != nil {
-					t.Fatalf("expected no error, got: %s", err.Error())
-				}
-			} else {
-				common.CmpErr(t, NotCachedErr, err)
-				if cachedResp != nil {
-					t.Fatalf("expected nothing cached, got: %+v", cachedResp)
-				}
+				return srvResp, nil
 			}
 
-		})
-	}
-}
+			cachedResp, gotErr := tc.aic.Get(context.Background(), numaNode, sysName, getFn)
+			common.CmpErr(t, tc.expErr, gotErr)
+			if tc.expErr != nil {
+				return
+			}
+			if diff := cmp.Diff(srvResp, cachedResp, common.DefaultCmpOpts()...); diff != "" {
+				t.Fatalf("-want, +got:\n%s", diff)
+			}
 
-func TestAgent_attachInfoCache_IsEnabled(t *testing.T) {
-	for name, tc := range map[string]struct {
-		aic        *attachInfoCache
-		expEnabled bool
-	}{
-		"nil": {},
-		"not enabled": {
-			aic: &attachInfoCache{},
-		},
-		"enabled": {
-			aic:        &attachInfoCache{enabled: atm.NewBool(true)},
-			expEnabled: true,
-		},
-	} {
-		t.Run(name, func(t *testing.T) {
-			enabled := tc.aic.IsEnabled()
-
-			common.AssertEqual(t, tc.expEnabled, enabled, "IsEnabled()")
+			common.AssertEqual(t, tc.expCached, tc.aic.isCached(), "cache state")
+			common.AssertEqual(t, tc.expRemote, remoteInvoked.Load(), "remote invoked")
 		})
 	}
 }

--- a/src/control/cmd/daos_agent/mgmt_rpc.go
+++ b/src/control/cmd/daos_agent/mgmt_rpc.go
@@ -161,21 +161,7 @@ func (mod *mgmtModule) getAttachInfo(ctx context.Context, numaNode int, sys stri
 }
 
 func (mod *mgmtModule) getAttachInfoResp(ctx context.Context, numaNode int, sys string) (*mgmtpb.GetAttachInfoResp, error) {
-	if mod.attachInfo.IsCached() {
-		return mod.attachInfo.GetAttachInfoResp()
-	}
-
-	resp, err := mod.getAttachInfoRemote(ctx, numaNode, sys)
-	if err != nil {
-		return nil, err
-	}
-
-	if mod.attachInfo.IsEnabled() {
-		mod.attachInfo.Cache(ctx, resp)
-		return mod.attachInfo.GetAttachInfoResp()
-	}
-
-	return resp, nil
+	return mod.attachInfo.Get(ctx, numaNode, sys, mod.getAttachInfoRemote)
 }
 
 func (mod *mgmtModule) getAttachInfoRemote(ctx context.Context, numaNode int, sys string) (*mgmtpb.GetAttachInfoResp, error) {
@@ -216,6 +202,7 @@ func (mod *mgmtModule) getFabricInterface(ctx context.Context, numaNode int, net
 	if err != nil {
 		return nil, err
 	}
+
 	mod.fabricInfo.CacheScan(netCtx, result)
 
 	return mod.fabricInfo.GetDevice(numaNode, netDevClass)

--- a/src/control/lib/control/mocks.go
+++ b/src/control/lib/control/mocks.go
@@ -75,6 +75,12 @@ func MockMSResponse(hostAddr string, hostErr error, hostMsg proto.Message) *Unar
 	}
 }
 
+func (mi *MockInvoker) GetInvokeCount() int {
+	mi.invokeCountMutex.RLock()
+	defer mi.invokeCountMutex.RUnlock()
+	return mi.invokeCount
+}
+
 func (mi *MockInvoker) Debug(msg string) {
 	mi.log.Debug(msg)
 }


### PR DESCRIPTION
Eliminate racy initialization of the AttachInfo cache that
can occur when multiple client applications all start at
the same time.

Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com>