### PR TITLE
DAOS-8610 test: Fix pool fault injection test (#6846)

### DIFF
--- a/src/tests/ftest/fault_injection/pool.py
+++ b/src/tests/ftest/fault_injection/pool.py
@@ -72,13 +72,12 @@ class PoolServicesFaultInjection(TestWithServers):
         self.pool.exclude([server_to_exclude])
         self.look_missed_request(self.pool.dmg.result.stderr)
 
-        self.pool.wait_for_rebuild(True)
-        self.look_missed_request(self.pool.dmg.result.stderr)
         self.pool.wait_for_rebuild(False)
         self.look_missed_request(self.pool.dmg.result.stderr)
+
         self.pool.reintegrate(str(server_to_exclude))
-        self.pool.wait_for_rebuild(True)
         self.look_missed_request(self.pool.dmg.result.stderr)
+
         self.pool.wait_for_rebuild(False)
         self.look_missed_request(self.pool.dmg.result.stderr)
 
@@ -86,11 +85,13 @@ class PoolServicesFaultInjection(TestWithServers):
         """Destroy container and pool
         Look for missed request on each executed command
         """
-        self.container.destroy()
-        self.look_missed_request(
-            self.container.daos.result.stderr)
-        self.pool.destroy(force=1)
-        self.look_missed_request(self.pool.dmg.result.stderr)
+        if self.container:
+            self.container.destroy()
+            self.look_missed_request(
+                self.container.daos.result.stderr)
+        if self.pool:
+            self.pool.destroy(force=1)
+            self.look_missed_request(self.pool.dmg.result.stderr)
 
     def test_pool_services(self):
         """ Test the following pool commands:
@@ -119,7 +120,6 @@ class PoolServicesFaultInjection(TestWithServers):
         dmg_command = self.get_dmg_command()
         pool_namespace = self.params.get("pool", "/run/*")
         number_pools = self.params.get("number_pools", "/run/*")
-
         for _ in range(number_pools):
             try:
                 # Create pool

--- a/src/tests/ftest/fault_injection/pool.yaml
+++ b/src/tests/ftest/fault_injection/pool.yaml
@@ -4,10 +4,9 @@ hosts:
     - server-B
     - server-C
     - server-D
-    - server-E
   test_clients:
     - client-H
-timeout: 600
+timeout: 1200
 server_config:
   name: daos_server
   servers:
@@ -17,6 +16,8 @@ pool:
   control_method: dmg
   size: 12G
   nranks: 4
+  rebuild_timeout: 120
+  pool_query_timeout: 60
 container:
   object_qty: 100
   record_qty: 100
@@ -37,13 +38,3 @@ faults:
       - DAOS_CONT_DESTROY_FAIL_CORPC
       - DAOS_CONT_CLOSE_FAIL_CORPC
       - DAOS_CONT_QUERY_FAIL_CORPC
-      - DAOS_CONT_OPEN_FAIL
-      - DAOS_REBUILD_DROP_SCAN
-      - DAOS_REBUILD_NO_HDL
-      - DAOS_REBUILD_DROP_OBJ
-      - DAOS_REBUILD_UPDATE_FAIL
-      - DAOS_REBUILD_STALE_POOL
-      - DAOS_REBUILD_TGT_IV_UPDATE_FAIL
-      - DAOS_REBUILD_TGT_START_FAIL
-      - DAOS_REBUILD_TGT_SEND_OBJS_FAIL
-      - DAOS_REBUILD_TGT_NOSPACE


### PR DESCRIPTION
The test should detect failures when creating/destroying pools and containers.
The test was previously failing because it was not detecting the injected faults.

Features: test_pool_services

Signed-off-by: Maureen Jean <maureen.jean@intel.com>