### PR TITLE
DAOS-8888 misc: Fix ULT leaks

### DIFF
--- a/src/container/srv_container.c
+++ b/src/container/srv_container.c
@@ -1384,6 +1384,9 @@ cont_agg_eph_leader_ult(void *arg)
 	struct cont_ec_agg	*tmp;
 	int			rc = 0;
 
+	if (svc->cs_ec_leader_ephs_req == NULL)
+		goto out;
+
 	while (!dss_ult_exiting(svc->cs_ec_leader_ephs_req)) {
 		d_rank_list_t		fail_ranks = { 0 };
 
@@ -1457,6 +1460,7 @@ yield:
 		sched_req_sleep(svc->cs_ec_leader_ephs_req, EC_AGG_EPH_INTV);
 	}
 
+out:
 	D_DEBUG(DF_DSMS, DF_UUID": stop eph ult: rc %d\n",
 		DP_UUID(svc->cs_pool_uuid), rc);
 
@@ -1465,7 +1469,6 @@ yield:
 		D_FREE(ec_agg->ea_server_ephs);
 		D_FREE(ec_agg);
 	}
-
 }
 
 static int
@@ -1494,7 +1497,7 @@ cont_svc_ec_agg_leader_start(struct cont_svc *svc)
 	if (svc->cs_ec_leader_ephs_req == NULL) {
 		D_ERROR(DF_UUID"Failed to get req for ec eph query ULT\n",
 			DP_UUID(svc->cs_pool_uuid));
-		ABT_thread_join(ec_eph_leader_ult);
+		ABT_thread_free(&ec_eph_leader_ult);
 		return -DER_NOMEM;
 	}
 

--- a/src/container/srv_target.c
+++ b/src/container/srv_target.c
@@ -471,7 +471,7 @@ cont_start_agg_ult(struct ds_cont_child *cont, void (*func)(void *),
 		D_CRIT(DF_CONT"[%d]: Failed to get req for aggregation ULT\n",
 		       DP_CONT(cont->sc_pool->spc_uuid, cont->sc_uuid),
 		       dmi->dmi_tgt_id);
-		ABT_thread_join(agg_ult);
+		ABT_thread_free(&agg_ult);
 		return -DER_NOMEM;
 	}
 
@@ -2457,6 +2457,10 @@ ds_cont_tgt_ec_eph_query_ult(void *data)
 
 	D_DEBUG(DB_MD, DF_UUID" start tgt ec query eph ULT\n",
 		DP_UUID(pool->sp_uuid));
+
+	if (pool->sp_ec_ephs_req == NULL)
+		goto out;
+
 	while (!dss_ult_exiting(pool->sp_ec_ephs_req)) {
 		struct dss_coll_ops	coll_ops = { 0 };
 		struct dss_coll_args	coll_args = { 0 };
@@ -2509,6 +2513,7 @@ yield:
 		sched_req_sleep(pool->sp_ec_ephs_req, EC_TGT_AGG_INTV);
 	}
 
+out:
 	D_DEBUG(DB_MD, DF_UUID" stop tgt ec aggregation\n",
 		DP_UUID(pool->sp_uuid));
 

--- a/src/dtx/dtx_common.c
+++ b/src/dtx/dtx_common.c
@@ -49,7 +49,10 @@ struct dtx_batched_cont_args {
 	struct dtx_batched_pool_args	*dbca_pool;
 	int				 dbca_refs;
 	uint32_t			 dbca_reg_gen;
-	uint32_t			 dbca_deregister:1;
+	uint32_t			 dbca_deregister:1,
+					 dbca_cleanup_done:1,
+					 dbca_commit_done:1,
+					 dbca_agg_done:1;
 };
 
 struct dtx_cleanup_stale_cb_args {
@@ -106,24 +109,47 @@ dtx_free_dbca(struct dtx_batched_cont_args *dbca)
 
 	D_ASSERT(d_list_empty(&dbca->dbca_sys_link));
 
-	if (dbca->dbca_cleanup_req != NULL)
-		sched_req_wait(dbca->dbca_cleanup_req, true);
+	if (dbca->dbca_cleanup_req != NULL) {
+		if (!dbca->dbca_cleanup_done)
+			sched_req_wait(dbca->dbca_cleanup_req, true);
+		/* dtx_batched_commit might put it while we were waiting. */
+		if (dbca->dbca_cleanup_req != NULL) {
+			D_ASSERT(dbca->dbca_cleanup_done);
+			sched_req_put(dbca->dbca_cleanup_req);
+			dbca->dbca_cleanup_req = NULL;
+			dbca->dbca_cleanup_done = 0;
+		}
+	}
 
-	if (dbca->dbca_commit_req != NULL)
-		sched_req_wait(dbca->dbca_commit_req, true);
+	if (dbca->dbca_commit_req != NULL) {
+		if (!dbca->dbca_commit_done)
+			sched_req_wait(dbca->dbca_commit_req, true);
+		/* dtx_batched_commit might put it while we were waiting. */
+		if (dbca->dbca_commit_req != NULL) {
+			D_ASSERT(dbca->dbca_commit_done);
+			sched_req_put(dbca->dbca_commit_req);
+			dbca->dbca_commit_req = NULL;
+			dbca->dbca_commit_done = 0;
+		}
+	}
 
-	if (dbca->dbca_agg_req != NULL)
-		sched_req_wait(dbca->dbca_agg_req, true);
+	if (dbca->dbca_agg_req != NULL) {
+		if (!dbca->dbca_agg_done)
+			sched_req_wait(dbca->dbca_agg_req, true);
+		/* Just to be safe... */
+		if (dbca->dbca_agg_req != NULL) {
+			D_ASSERT(dbca->dbca_agg_done);
+			sched_req_put(dbca->dbca_agg_req);
+			dbca->dbca_agg_req = NULL;
+			dbca->dbca_agg_done = 0;
+		}
+	}
 
 	/* dtx_batched_commit() ULT may hold the last reference on the dbca. */
 	while (dbca->dbca_refs > 0) {
 		D_DEBUG(DB_TRACE, "Sleep 10 mseconds for batched commit ULT\n");
 		dss_sleep(10);
 	}
-
-	D_ASSERT(dbca->dbca_cleanup_req == NULL);
-	D_ASSERT(dbca->dbca_commit_req == NULL);
-	D_ASSERT(dbca->dbca_agg_req == NULL);
 
 	if (d_list_empty(&dbpa->dbpa_cont_list)) {
 		d_list_del(&dbpa->dbpa_sys_link);
@@ -261,8 +287,7 @@ dtx_cleanup_stale(void *arg)
 				       dsp_link)) != NULL)
 		D_FREE(dsp);
 
-	sched_req_put(dbca->dbca_cleanup_req);
-	dbca->dbca_cleanup_req = NULL;
+	dbca->dbca_cleanup_done = 1;
 
 out:
 	dtx_put_dbca(dbca);
@@ -305,8 +330,7 @@ dtx_aggregate(void *arg)
 			break;
 	}
 
-	sched_req_put(dbca->dbca_agg_req);
-	dbca->dbca_agg_req = NULL;
+	dbca->dbca_agg_done = 1;
 
 out:
 	dtx_put_dbca(dbca);
@@ -329,6 +353,12 @@ dtx_aggregation_pool(struct dtx_batched_pool_args *dbpa)
 		dbca = d_list_entry(dbpa->dbpa_cont_list.next,
 				    struct dtx_batched_cont_args,
 				    dbca_pool_link);
+
+		if (dbca->dbca_agg_req != NULL && dbca->dbca_agg_done) {
+			sched_req_put(dbca->dbca_agg_req);
+			dbca->dbca_agg_req = NULL;
+			dbca->dbca_agg_done = 0;
+		}
 
 		/* Finish this cycle scan. */
 		if (dbca->dbca_agg_gen == dtx_agg_gen)
@@ -359,6 +389,7 @@ dtx_aggregation_pool(struct dtx_batched_pool_args *dbpa)
 		      stat.dtx_pool_cmt_count >= dtx_agg_thd_cnt_up) &&
 		     (dtx_hlc_age2sec(stat.dtx_first_cmt_blob_time_lo) >=
 		      dtx_agg_thd_age_up))) {
+			D_ASSERT(!dbca->dbca_agg_done);
 			dtx_get_dbca(dbca);
 			rc = dss_ult_create(dtx_aggregate, dbca,
 					    DSS_XS_SELF, 0, 0, &child);
@@ -374,7 +405,7 @@ dtx_aggregation_pool(struct dtx_batched_pool_args *dbpa)
 			if (dbca->dbca_agg_req == NULL) {
 				D_WARN("Fail to get agg sched req (1) for "
 				       DF_UUID"\n", DP_UUID(cont->sc_uuid));
-				ABT_thread_join(child);
+				ABT_thread_free(&child);
 				continue;
 			}
 
@@ -413,6 +444,7 @@ dtx_aggregation_pool(struct dtx_batched_pool_args *dbpa)
 
 	dbca = dbpa->dbpa_victim;
 	cont = dbca->dbca_cont;
+	D_ASSERT(dbca->dbca_agg_req == NULL && !dbca->dbca_agg_done);
 	dtx_get_dbca(dbca);
 
 	rc = dss_ult_create(dtx_aggregate, dbca, DSS_XS_SELF, 0, 0, &child);
@@ -425,7 +457,7 @@ dtx_aggregation_pool(struct dtx_batched_pool_args *dbpa)
 		if (dbca->dbca_agg_req == NULL) {
 			D_WARN("Fail to get agg sched req (2) for "DF_UUID"\n",
 			       DP_UUID(cont->sc_uuid));
-			ABT_thread_join(child);
+			ABT_thread_free(&child);
 		} else {
 			dbpa->dbpa_aggregating = 1;
 		}
@@ -464,9 +496,6 @@ dtx_aggregation_main(void *arg)
 
 		sched_req_sleep(dmi->dmi_dtx_agg_req, sleep_time);
 	}
-
-	sched_req_put(dmi->dmi_dtx_agg_req);
-	dmi->dmi_dtx_agg_req = NULL;
 }
 
 static void
@@ -520,8 +549,7 @@ dtx_batched_commit_one(void *arg)
 			break;
 	}
 
-	sched_req_put(dbca->dbca_commit_req);
-	dbca->dbca_commit_req = NULL;
+	dbca->dbca_commit_done = 1;
 
 out:
 	dtx_put_dbca(dbca);
@@ -553,7 +581,7 @@ dtx_batched_commit(void *arg)
 	dtx_init_sched_req(NULL, &dmi->dmi_dtx_agg_req, child);
 	if (dmi->dmi_dtx_agg_req == NULL) {
 		D_ERROR("Failed to get DTX aggregation sched request.\n");
-		ABT_thread_join(child);
+		ABT_thread_free(&child);
 		goto out;
 	}
 
@@ -574,10 +602,17 @@ dtx_batched_commit(void *arg)
 		dbca = d_list_entry(dmi->dmi_dtx_batched_cont_list.next,
 				    struct dtx_batched_cont_args,
 				    dbca_sys_link);
+		dtx_get_dbca(dbca);
 		cont = dbca->dbca_cont;
 		d_list_move_tail(&dbca->dbca_sys_link,
 				 &dmi->dmi_dtx_batched_cont_list);
 		dtx_stat(cont, &stat);
+
+		if (dbca->dbca_commit_req != NULL && dbca->dbca_commit_done) {
+			sched_req_put(dbca->dbca_commit_req);
+			dbca->dbca_commit_req = NULL;
+			dbca->dbca_commit_done = 0;
+		}
 
 		if (!cont->sc_closing &&
 		    !dbca->dbca_deregister && dbca->dbca_commit_req == NULL &&
@@ -585,6 +620,7 @@ dtx_batched_commit(void *arg)
 		     (stat.dtx_oldest_committable_time != 0 &&
 		      dtx_hlc_age2sec(stat.dtx_oldest_committable_time) >=
 		      DTX_COMMIT_THRESHOLD_AGE))) {
+			D_ASSERT(!dbca->dbca_commit_done);
 			sleep_time = 0;
 			dtx_get_dbca(dbca);
 			rc = dss_ult_create(dtx_batched_commit_one, dbca,
@@ -601,9 +637,15 @@ dtx_batched_commit(void *arg)
 					D_WARN("Fail to get sched req (1) for "
 					       DF_UUID"\n",
 					       DP_UUID(cont->sc_uuid));
-					ABT_thread_join(child);
+					ABT_thread_free(&child);
 				}
 			}
+		}
+
+		if (dbca->dbca_cleanup_req != NULL && dbca->dbca_cleanup_done) {
+			sched_req_put(dbca->dbca_cleanup_req);
+			dbca->dbca_cleanup_req = NULL;
+			dbca->dbca_cleanup_done = 0;
 		}
 
 		if (!cont->sc_closing &&
@@ -611,6 +653,7 @@ dtx_batched_commit(void *arg)
 		    stat.dtx_oldest_active_time != 0 &&
 		    dtx_hlc_age2sec(stat.dtx_oldest_active_time) >=
 		    DTX_CLEANUP_THD_AGE_UP) {
+			D_ASSERT(!dbca->dbca_cleanup_done);
 			sleep_time = 0;
 			dtx_get_dbca(dbca);
 			rc = dss_ult_create(dtx_cleanup_stale, dbca,
@@ -628,10 +671,12 @@ dtx_batched_commit(void *arg)
 					D_WARN("Fail to get sched req (3) for "
 					       DF_UUID"\n",
 					       DP_UUID(cont->sc_uuid));
-					ABT_thread_join(child);
+					ABT_thread_free(&child);
 				}
 			}
 		}
+
+		dtx_put_dbca(dbca);
 
 check:
 		if (dss_xstream_exiting(dmi->dmi_xstream))
@@ -640,8 +685,11 @@ check:
 		sched_req_sleep(dmi->dmi_dtx_cmt_req, sleep_time);
 	}
 
-	if (dmi->dmi_dtx_agg_req != NULL)
+	if (dmi->dmi_dtx_agg_req != NULL) {
 		sched_req_wait(dmi->dmi_dtx_agg_req, true);
+		sched_req_put(dmi->dmi_dtx_agg_req);
+		dmi->dmi_dtx_agg_req = NULL;
+	}
 
 out:
 	sched_req_put(dmi->dmi_dtx_cmt_req);

--- a/src/dtx/dtx_rpc.c
+++ b/src/dtx/dtx_rpc.c
@@ -717,7 +717,7 @@ out:
 		rc1 = 0;
 
 	if (child != ABT_THREAD_NULL)
-		ABT_thread_join(child);
+		ABT_thread_free(&child);
 
 	if (dra.dra_future != ABT_FUTURE_NULL) {
 		rc2 = dtx_req_wait(&dra);

--- a/src/engine/sched.c
+++ b/src/engine/sched.c
@@ -55,7 +55,9 @@ struct sched_request {
 	uint64_t		 sr_wakeup_time;
 	/* When the request is enqueued, in msecs */
 	uint64_t		 sr_enqueue_ts;
-	unsigned int		 sr_abort:1;
+	unsigned int		 sr_abort:1,
+				 /* sr_ult is sched_request-owned */
+				 sr_owned:1;
 };
 
 bool		sched_prio_disabled;
@@ -503,7 +505,7 @@ cur_pool_info(struct sched_info *info, uuid_t pool_uuid)
 
 static struct sched_request *
 req_get(struct dss_xstream *dx, struct sched_req_attr *attr,
-	void (*func)(void *), void *arg, ABT_thread ult)
+	void (*func)(void *), void *arg, ABT_thread ult, bool owned)
 {
 	struct sched_info	*info = &dx->dx_sched_info;
 	struct sched_pool_info	*spi;
@@ -536,6 +538,7 @@ req_get(struct dss_xstream *dx, struct sched_req_attr *attr,
 	req->sr_arg	= arg;
 	req->sr_ult	= ult;
 	req->sr_abort	= 0;
+	req->sr_owned	= (owned ? 1 : 0);
 	req->sr_pool_info = spi;
 
 	return req;
@@ -968,7 +971,7 @@ sched_req_enqueue(struct dss_xstream *dx, struct sched_req_attr *attr,
 		return req_kickoff_internal(dx, attr, func, arg);
 
 	D_ASSERT(attr->sra_type < SCHED_REQ_MAX);
-	req = req_get(dx, attr, func, arg, ABT_THREAD_NULL);
+	req = req_get(dx, attr, func, arg, ABT_THREAD_NULL, false);
 	if (req == NULL) {
 		D_ERROR("XS(%d): get req failed.\n", dx->dx_xs_id);
 		return -DER_NOMEM;
@@ -1081,13 +1084,16 @@ sched_req_wakeup(struct sched_request *req)
 void
 sched_req_wait(struct sched_request *req, bool abort)
 {
+	int	rc;
+
 	D_ASSERT(req != NULL);
 	if (abort) {
 		req->sr_abort = 1;
 		sched_req_wakeup(req);
 	}
 	D_ASSERT(req->sr_ult != ABT_THREAD_NULL);
-	ABT_thread_join(req->sr_ult);
+	rc = ABT_thread_join(req->sr_ult);
+	D_ASSERTF(rc == ABT_SUCCESS, "ABT_thread_join: %d\n", rc);
 }
 
 inline bool
@@ -1144,6 +1150,7 @@ struct sched_request *
 sched_req_get(struct sched_req_attr *attr, ABT_thread ult)
 {
 	struct dss_xstream	*dx = dss_current_xstream();
+	bool			 owned;
 	struct sched_request	*req;
 	int			 rc;
 
@@ -1153,15 +1160,32 @@ sched_req_get(struct sched_req_attr *attr, ABT_thread ult)
 		ABT_thread	self;
 
 		rc = ABT_thread_self(&self);
-		if (rc) {
-			D_ERROR("Failed to get self thread. "DF_RC"\n",
-				DP_RC(dss_abterr2der(rc)));
+		if (rc != ABT_SUCCESS) {
+			D_ERROR("Failed to get self thread: %d\n", rc);
 			return NULL;
 		}
 		ult = self;
+		owned = false;
+	} else {
+		ABT_bool unnamed;
+
+		/*
+		 * Since Argobots prohibits freeing unnamed ULTs, don't own
+		 * them.
+		 */
+		rc = ABT_thread_is_unnamed(ult, &unnamed);
+		if (rc != ABT_SUCCESS) {
+			D_ERROR("Failed to get thread type: %d\n", rc);
+			return NULL;
+		}
+		if (unnamed == ABT_TRUE) {
+			D_ERROR("Unnamed threads are not supported\n");
+			return NULL;
+		}
+		owned = true;
 	}
 
-	req = req_get(dx, attr, NULL, NULL, ult);
+	req = req_get(dx, attr, NULL, NULL, ult, owned);
 	if (req != NULL && attr->sra_type == SCHED_REQ_GC)
 		req->sr_pool_info->spi_gc_ults++;
 
@@ -1173,9 +1197,17 @@ sched_req_put(struct sched_request *req)
 {
 	struct dss_xstream	*dx = dss_current_xstream();
 	struct sched_info	*info = &dx->dx_sched_info;
+	int			 rc;
 
 	D_ASSERT(req != NULL && req->sr_ult != ABT_THREAD_NULL);
 	D_ASSERT(d_list_empty(&req->sr_link));
+	if (req->sr_owned) {
+		/* We are responsible for freeing a req-owned ULT. */
+		rc = ABT_thread_free(&req->sr_ult);
+		D_ASSERTF(rc == ABT_SUCCESS, "%d\n", rc);
+	} else {
+		req->sr_ult = ABT_THREAD_NULL;
+	}
 	d_list_add_tail(&req->sr_link, &info->si_idle_list);
 
 	if (req->sr_attr.sra_type == SCHED_REQ_GC) {

--- a/src/include/daos_srv/daos_engine.h
+++ b/src/include/daos_srv/daos_engine.h
@@ -276,11 +276,14 @@ sched_req_attr_init(struct sched_req_attr *attr, unsigned int type,
 struct sched_request;	/* Opaque schedule request */
 
 /**
- * Get A sched request.
+ * Get a sched request.
  *
  * \param[in] attr	Sched request attributes.
- * \param[in] ult	ULT attached to the sched request,
- *			self ULT will be used when ult == ABT_THREAD_NULL.
+ * \param[in] ult	ULT attached to the sched request, self ULT will be
+ *			used when ult == ABT_THREAD_NULL. If not
+ *			ABT_THREAD_NULL, ult will be freed by sched_req_put.
+ *			Unnamed ULTs (e.g., from ABT_thread_self) are
+ *			prohibited.
  *
  * \retval		Sched request.
  */
@@ -288,7 +291,8 @@ struct sched_request *
 sched_req_get(struct sched_req_attr *attr, ABT_thread ult);
 
 /**
- * Put A sched request.
+ * Put a sched request. If the associated ULT was passed in by the caller, it
+ * will be freed.
  *
  * \param[in] req	Sched request.
  *
@@ -325,7 +329,8 @@ void sched_req_sleep(struct sched_request *req, uint32_t msec);
 void sched_req_wakeup(struct sched_request *req);
 
 /**
- * Wakeup a sched request attached ULT terminated.
+ * Wakeup a sched request attached ULT terminated. The associated ULT of \a req
+ * must not an unnamed ULT.
  *
  * \param[in] req	Sched request.
  * \param[in] abort	Abort the ULT or not.

--- a/src/pool/srv_pool_scrub.c
+++ b/src/pool/srv_pool_scrub.c
@@ -232,7 +232,8 @@ scrubbing_ult(void *arg)
 	C_TRACE("Scrubbing ULT started for pool: "DF_UUIDF"[%d]\n",
 		DP_UUID(child->spc_uuid), dmi->dmi_tgt_id);
 
-	D_ASSERT(child->spc_scrubbing_req != NULL);
+	if (child->spc_scrubbing_req == NULL)
+		return;
 
 	sc_init(&ctx, child);
 	sleep_sec = between_scrub_sec();
@@ -306,7 +307,7 @@ ds_start_scrubbing_ult(struct ds_pool_child *child)
 	if (child->spc_scrubbing_req == NULL) {
 		D_CRIT(DF_UUID"[%d]: Failed to get req for Scrubbing ULT\n",
 		       DP_UUID(child->spc_uuid), dmi->dmi_tgt_id);
-		ABT_thread_join(thread);
+		ABT_thread_free(&thread);
 		return -DER_NOMEM;
 	}
 

--- a/src/pool/srv_target.c
+++ b/src/pool/srv_target.c
@@ -89,7 +89,9 @@ gc_ult(void *arg)
 	D_DEBUG(DF_DSMS, DF_UUID"[%d]: GC ULT started\n",
 		DP_UUID(child->spc_uuid), dmi->dmi_tgt_id);
 
-	D_ASSERT(child->spc_gc_req != NULL);
+	if (child->spc_gc_req == NULL)
+		goto out;
+
 	while (!dss_ult_exiting(child->spc_gc_req)) {
 		rc = vos_gc_pool(child->spc_hdl, -1, dss_ult_yield,
 				 (void *)child->spc_gc_req);
@@ -105,6 +107,7 @@ gc_ult(void *arg)
 		sched_req_sleep(child->spc_gc_req, 10ULL * 1000);
 	}
 
+out:
 	D_DEBUG(DF_DSMS, DF_UUID"[%d]: GC ULT stopped\n",
 		DP_UUID(child->spc_uuid), dmi->dmi_tgt_id);
 }
@@ -134,7 +137,7 @@ start_gc_ult(struct ds_pool_child *child)
 	if (child->spc_gc_req == NULL) {
 		D_CRIT(DF_UUID"[%d]: Failed to get req for GC ULT\n",
 		       DP_UUID(child->spc_uuid), dmi->dmi_tgt_id);
-		ABT_thread_join(gc);
+		ABT_thread_free(&gc);
 		return -DER_NOMEM;
 	}
 
@@ -594,7 +597,7 @@ ds_pool_start_ec_eph_query_ult(struct ds_pool *pool)
 	if (pool->sp_ec_ephs_req == NULL) {
 		D_ERROR(DF_UUID": Failed to get req for ec eph query ULT\n",
 			DP_UUID(pool->sp_uuid));
-		ABT_thread_join(ec_eph_query_ult);
+		ABT_thread_free(&ec_eph_query_ult);
 		return -DER_NOMEM;
 	}
 

--- a/src/rebuild/scan.c
+++ b/src/rebuild/scan.c
@@ -784,7 +784,7 @@ rebuild_scanner(void *data)
 out:
 	tls->rebuild_pool_scan_done = 1;
 	if (ult_send != ABT_THREAD_NULL)
-		ABT_thread_join(ult_send);
+		ABT_thread_free(&ult_send);
 
 	if (tls->rebuild_pool_status == 0 && rc != 0)
 		tls->rebuild_pool_status = rc;


### PR DESCRIPTION
Argobots dictates the following:

  - A ULT that is not unnamed must be freed explicitly via
    ABT_thread_free. (ABT_thread_join does not do this.)
  - An unnamed ULT cannot be freed explicitly via ABT_thread_free.
  - A ULT cannot free itself.
  - ABT_thread_free implicitly joins the ULT before freeing it.
  - An unnamed ULT cannot be joined via ABT_thread_join.

In several modules, ULTs are only joined but not freed, leading to ULT
leaks. This patch replaces these ABT_thread_join calls with
ABT_thread_free call, which both join as well as free. Also, in some
error paths among those cases, the ULTs may not terminate, leading to
hangs. This patch adopts a check-if-req-is-null-in-the-ULT approach from
other error paths, whose correctness subtly relies on the absence of
yielding between the ULT creation and the ABT_thread_free
call---something that should be replaced with a more robust solution in
the future.

sched_req_put does not free the ULT too. This patch adds an "owned" flag
to sched_req so that sched_req_put can call ABT_thread_free on ULTs that
are req-owned. Some dtx ULTs' sched_req_put calls have to be adjusted a
bit to avoid those ULTs from freeing themselves.

Signed-off-by: Li Wei <wei.g.li@intel.com>