### PR TITLE
DAOS-8204 test: Add a test for "container list". (#6325)

### DIFF
--- a/src/container/srv_container.c
+++ b/src/container/srv_container.c
@@ -40,8 +40,8 @@ cont_prop_read(struct rdb_tx *tx, struct cont *cont, uint64_t bits,
  * if there are more failures for that domain type then allowed restrict
  * container opening.
  *
- * \param pmap  [in]    The pool map referenced by the container.
- * \param props [in]    The container properties, used to get redundancy factor
+ * \param[in] pmap      The pool map referenced by the container.
+ * \param[in] props     The container properties, used to get redundancy factor
  *                      and level.
  *
  * \return	0 if the container meets the requirements, negative error code
@@ -3289,14 +3289,17 @@ enum_cont_cb(daos_handle_t ih, d_iov_t *key, d_iov_t *val, void *varg)
 		return rc;
 	}
 	rc = cont_prop_read(ap->tx, cont, DAOS_CO_QUERY_PROP_LABEL, &prop);
+	cont_put(cont);
 	if (rc != 0) {
 		D_ERROR(DF_CONT": cont_prop_read() failed, "DF_RC"\n",
 			DP_CONT(ap->pool_uuid, cont_uuid), DP_RC(rc));
+		return rc;
 	}
 	strncpy(cinfo->pci_label, prop->dpp_entries[0].dpe_str,
 		DAOS_PROP_LABEL_MAX_LEN);
 	cinfo->pci_label[DAOS_PROP_LABEL_MAX_LEN] = '\0';
 
+	daos_prop_free(prop);
 	return 0;
 }
 

--- a/src/control/cmd/daos/container.go
+++ b/src/control/cmd/daos/container.go
@@ -491,6 +491,8 @@ func listContainers(hdl C.daos_handle_t) ([]*ContainerID, error) {
 		out[i].Label = C.GoString(&dpciSlice[i].pci_label[0])
 	}
 
+	C.free(unsafe.Pointer(cConts))
+
 	return out, nil
 }
 

--- a/src/control/cmd/daos/util.c
+++ b/src/control/cmd/daos/util.c
@@ -3,6 +3,11 @@
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
+
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
 #include <libgen.h>
 
 #include "util.h"

--- a/utils/node_local_test.py
+++ b/utils/node_local_test.py
@@ -1402,6 +1402,12 @@ class posix_tests():
         """Mark a test method as failed"""
         raise NLTestFail
 
+    def test_cont_list(self):
+        """Test daos container list"""
+
+        rc = run_daos_cmd(self.conf, ['container', 'list', self.pool.id()])
+        assert rc.returncode == 0, rc
+
     def test_cache(self):
         """Test with caching enabled"""
 


### PR DESCRIPTION
* Run this under NLT so that server memory leaks can be detected.
* Resolve memory leaks.

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>