### PR TITLE
DAOS-8950 test: Reduce # of children in GetAttachInfo test

### DIFF
--- a/src/control/cmd/daos_agent/agent_test.go
+++ b/src/control/cmd/daos_agent/agent_test.go
@@ -167,7 +167,7 @@ func TestAgent_MultiProcess_AttachInfoCache(t *testing.T) {
 	// GetAttachInfo RPC invocation.
 	os.Setenv(drpcDirEnvVar, tmpDir)
 	os.Setenv(childModeEnvVar, childModeGetAttachInfo)
-	maxIter := 128
+	maxIter := 32
 	for i := 0; i < maxIter; i++ {
 		go func(rc chan *mgmtpb.GetAttachInfoResp, ec chan error) {
 			pr, err := pbin.ExecReq(context.Background(), log, os.Args[0], &pbin.Request{})


### PR DESCRIPTION
With 128 child processes, the test was failing intermittently
with broken pipe errors, most likely due to hitting an open
file handle limit.

Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com>
