### PR TITLE
DAOS-8916 client: Fix potential OFI interface/domain mismatch

### DIFF
--- a/src/mgmt/cli_mgmt.c
+++ b/src/mgmt/cli_mgmt.c
@@ -391,8 +391,8 @@ int dc_mgmt_net_cfg(const char *name)
 		 * the domain. Otherwise we could get a mismatch between interface and domain.
 		 */
 		if (ofi_domain)
-			D_WARN("Using agent for network config. Ignoring client provided "
-			       "OFI_DOMAIN: %s\n", ofi_domain);
+			D_WARN("Ignoring OFI_DOMAIN '%s' because OFI_INTERFACE is not set; using "
+			       "automatic configuration instead\n", ofi_domain);
 
 		rc = setenv("OFI_DOMAIN", info.domain, 1);
 		if (rc != 0)

--- a/src/mgmt/cli_mgmt.c
+++ b/src/mgmt/cli_mgmt.c
@@ -379,23 +379,32 @@ int dc_mgmt_net_cfg(const char *name)
 			crt_timeout);
 	}
 
+	/*
+	 * If the client is using env vars for OFI_INTERFACE/OFI_DOMAIN, they must provide both.
+	 * Otherwise they could end up with a mismatched domain and interface by overriding only
+	 * one of the values returned by the daos_agent.
+	 */
 	ofi_interface = getenv("OFI_INTERFACE");
-	if (!ofi_interface) {
+	ofi_domain = getenv("OFI_DOMAIN");
+	if (!ofi_interface && !ofi_domain) {
 		rc = setenv("OFI_INTERFACE", info.interface, 1);
 		if (rc != 0)
 			D_GOTO(cleanup, rc = d_errno2der(errno));
-	} else {
-		D_INFO("Using client provided OFI_INTERFACE: %s\n",
-			ofi_interface);
-	}
 
-	ofi_domain = getenv("OFI_DOMAIN");
-	if (!ofi_domain) {
 		rc = setenv("OFI_DOMAIN", info.domain, 1);
 		if (rc != 0)
 			D_GOTO(cleanup, rc = d_errno2der(errno));
-	} else {
+	} else if (ofi_interface && ofi_domain) {
+		D_INFO("Using client provided OFI_INTERFACE: %s\n", ofi_interface);
 		D_INFO("Using client provided OFI_DOMAIN: %s\n", ofi_domain);
+	} else {
+		if (ofi_interface) {
+			D_ERROR("OFI_INTERFACE (%s) provided via env without OFI_DOMAIN\n",
+				ofi_interface);
+		} else {
+			D_ERROR("OFI_DOMAIN (%s) provided without OFI_INTERFACE\n", ofi_domain);
+		}
+		D_GOTO(cleanup, rc = -DER_INVAL);
 	}
 
 	D_DEBUG(DB_MGMT,

--- a/src/tests/ftest/launch.py
+++ b/src/tests/ftest/launch.py
@@ -159,11 +159,11 @@ def set_test_environment(args):
     path = os.environ.get("PATH")
 
     if not args.list:
-        # Get the default interface to use if OFI_INTERFACE is not set
+        # Get the default interface (use OFI_INTERFACE if set) to set DAOS_TEST_FABRIC_IFACE
         set_interface_environment()
 
         # Get the default provider if CRT_PHY_ADDR_STR is not set
-        set_provider_environment(os.environ["OFI_INTERFACE"], args)
+        set_provider_environment(os.environ["DAOS_TEST_FABRIC_IFACE"], args)
 
         # Update other env definitions
         os.environ["CRT_CTX_SHARE_ADDR"] = "0"
@@ -194,8 +194,8 @@ def set_test_environment(args):
 def set_interface_environment():
     """Set up the interface environment variables.
 
-    Use the existing OFI_INTERFACE setting if already defined, otherwise
-    select the fastest, active interface on this host.
+    Use the existing OFI_INTERFACE setting if already defined, otherwise select the fastest, active
+    interface on this host.  Use this value to define DAOS_TEST_FABRIC_IFACE.
     """
     # Get the default interface to use if OFI_INTERFACE is not set
     interface = os.environ.get("OFI_INTERFACE")
@@ -248,9 +248,9 @@ def set_interface_environment():
             sys.exit(1)
 
     # Update env definitions
-    print("Using {} as the default interface".format(interface))
+    print("Using {} as the default interface (DAOS_TEST_FABRIC_IFACE)".format(interface))
     os.environ["CRT_CTX_SHARE_ADDR"] = "0"
-    os.environ["OFI_INTERFACE"] = os.environ.get("OFI_INTERFACE", interface)
+    os.environ["DAOS_TEST_FABRIC_IFACE"] = interface
 
 
 def set_provider_environment(interface, args):

--- a/src/tests/ftest/network/zero_config.py
+++ b/src/tests/ftest/network/zero_config.py
@@ -157,9 +157,9 @@ class ZeroConfigTest(TestWithServers):
         daos_racer = DaosRacerCommand(self.bin, clients[0], dmg)
         daos_racer.get_params(self)
 
-        # Update env_name list to add OFI_INTERFACE and OFI_DOMAIN if needed.
+        # Update env_name list to add OFI_INTERFACE if needed.
         if env:
-            daos_racer.update_env_names(["OFI_INTERFACE", "OFI_DOMAIN"])
+            daos_racer.update_env_names(["OFI_INTERFACE"])
 
         # Setup the environment and logfile
         log_file = "daos_racer_{}_{}.log".format(exp_iface, env)

--- a/src/tests/ftest/network/zero_config.py
+++ b/src/tests/ftest/network/zero_config.py
@@ -157,9 +157,9 @@ class ZeroConfigTest(TestWithServers):
         daos_racer = DaosRacerCommand(self.bin, clients[0], dmg)
         daos_racer.get_params(self)
 
-        # Update env_name list to add OFI_INTERFACE if needed.
+        # Update env_name list to add OFI_INTERFACE and OFI_DOMAIN if needed.
         if env:
-            daos_racer.update_env_names(["OFI_INTERFACE"])
+            daos_racer.update_env_names(["OFI_INTERFACE", "OFI_DOMAIN"])
 
         # Setup the environment and logfile
         log_file = "daos_racer_{}_{}.log".format(exp_iface, env)

--- a/src/tests/ftest/util/server_utils_params.py
+++ b/src/tests/ftest/util/server_utils_params.py
@@ -351,7 +351,7 @@ class DaosServerYamlParameters(YamlParameters):
                 self._provider = os.environ.get("CRT_PHY_ADDR_STR", "ofi+sockets")
 
             # Use environment variables to get default parameters
-            default_interface = os.environ.get("OFI_INTERFACE", "eth0")
+            default_interface = os.environ.get("DAOS_TEST_FABRIC_IFACE", "eth0")
             default_port = int(os.environ.get("OFI_PORT", 31416))
             default_share_addr = int(os.environ.get("CRT_CTX_SHARE_ADDR", 0))
 


### PR DESCRIPTION
The network interface and domain must be acquired from the same
source, either the agent automatic config, or the OFI_INTERFACE
and OFI_DOMAIN environment variables.

Signed-off-by: Kris Jacque <kristin.jacque@intel.com>