### PR TITLE
DAOS-9033 swim: Avoid busy loop in SWIM progress

### DIFF
--- a/src/cart/crt_context.c
+++ b/src/cart/crt_context.c
@@ -922,7 +922,7 @@ crt_context_timeout_check(struct crt_context *crt_ctx)
 	struct crt_rpc_priv		*rpc_priv;
 	struct d_binheap_node		*bh_node;
 	d_list_t			 timeout_list;
-	uint64_t			 ts_now;
+	uint64_t			 hlc = crt_hlc_get();
 
 	D_ASSERT(crt_ctx != NULL);
 
@@ -931,6 +931,7 @@ crt_context_timeout_check(struct crt_context *crt_ctx)
 		struct crt_swim_membs	*csm = &gp->gp_membs_swim;
 		swim_id_t		 self_id = swim_self_get(csm->csm_ctx);
 
+		crt_swim_csm_lock(csm);
 		if (crt_ctx->cc_last_unpack_hlc > csm->csm_last_unpack_hlc)
 			csm->csm_last_unpack_hlc = crt_ctx->cc_last_unpack_hlc;
 
@@ -942,9 +943,7 @@ crt_context_timeout_check(struct crt_context *crt_ctx)
 		 * the already suspected members will not be expired.
 		 */
 		if (self_id != SWIM_ID_INVALID && csm->csm_alive_count > 2) {
-			uint64_t hlc1 = csm->csm_last_unpack_hlc;
-			uint64_t hlc2 = crt_hlc_get();
-			uint64_t delay = crt_hlc2msec(hlc2 - hlc1);
+			uint64_t delay = crt_hlc2msec(hlc - min(hlc, csm->csm_last_unpack_hlc));
 			uint64_t max_delay = swim_suspect_timeout_get() * 2 / 3;
 
 			if (delay > max_delay) {
@@ -954,22 +953,21 @@ crt_context_timeout_check(struct crt_context *crt_ctx)
 					delay / 1000, delay % 1000,
 					max_delay / 1000, max_delay % 1000);
 				swim_net_glitch_update(csm->csm_ctx, self_id, delay);
-				csm->csm_last_unpack_hlc = hlc2;
+				csm->csm_last_unpack_hlc = hlc;
 			}
 		}
+		crt_swim_csm_unlock(csm);
 	}
 
 	D_INIT_LIST_HEAD(&timeout_list);
-	ts_now = d_timeus_secdiff(0);
 
 	D_MUTEX_LOCK(&crt_ctx->cc_mutex);
 	while (1) {
 		bh_node = d_binheap_root(&crt_ctx->cc_bh_timeout);
 		if (bh_node == NULL)
 			break;
-		rpc_priv = container_of(bh_node, struct crt_rpc_priv,
-					crp_timeout_bp_node);
-		if (rpc_priv->crp_timeout_ts > ts_now)
+		rpc_priv = container_of(bh_node, struct crt_rpc_priv, crp_timeout_bp_node);
+		if (rpc_priv->crp_expire_hlc > hlc)
 			break;
 
 		/* +1 to prevent it from being released in timeout_untrack */
@@ -1071,7 +1069,6 @@ crt_context_req_track(struct crt_rpc_priv *rpc_priv)
 	/* add the RPC req to crt_ep_inflight */
 	D_MUTEX_LOCK(&epi->epi_mutex);
 	D_ASSERT(epi->epi_req_num >= epi->epi_reply_num);
-	crt_set_timeout(rpc_priv);
 	rpc_priv->crp_epi = epi;
 	RPC_ADDREF(rpc_priv);
 
@@ -1091,6 +1088,7 @@ crt_context_req_track(struct crt_rpc_priv *rpc_priv)
 		rpc_priv->crp_state = RPC_STATE_QUEUED;
 		rc = CRT_REQ_TRACK_IN_WAITQ;
 	} else {
+		crt_set_timeout(rpc_priv);
 		D_MUTEX_LOCK(&crt_ctx->cc_mutex);
 		rc = crt_req_timeout_track(rpc_priv);
 		D_MUTEX_UNLOCK(&crt_ctx->cc_mutex);
@@ -1729,7 +1727,7 @@ crt_req_force_timeout(struct crt_rpc_priv *rpc_priv)
 	 */
 	D_MUTEX_LOCK(&crt_ctx->cc_mutex);
 	crt_req_timeout_untrack(rpc_priv);
-	rpc_priv->crp_timeout_ts = 0;
+	rpc_priv->crp_expire_hlc = 0;
 	crt_req_timeout_track(rpc_priv);
 	D_MUTEX_UNLOCK(&crt_ctx->cc_mutex);
 }

--- a/src/cart/crt_hg.c
+++ b/src/cart/crt_hg.c
@@ -1284,6 +1284,17 @@ crt_hg_reply_send(struct crt_rpc_priv *rpc_priv)
 
 	D_ASSERT(rpc_priv != NULL);
 
+	if (D_LOG_ENABLED(DB_NET)) {
+		uint64_t hlc = crt_hlc_get();
+
+		if (hlc > rpc_priv->crp_create_hlc) {
+			uint64_t delay = crt_hlc2msec(hlc - rpc_priv->crp_create_hlc);
+
+			if (delay > 500)
+				RPC_TRACE(DB_NET, rpc_priv, "RPC reply took %lu ms.\n", delay);
+		}
+	}
+
 	RPC_ADDREF(rpc_priv);
 	hg_ret = HG_Respond(rpc_priv->crp_hg_hdl, crt_hg_reply_send_cb,
 			    rpc_priv, &rpc_priv->crp_pub.cr_output);

--- a/src/cart/crt_rpc.c
+++ b/src/cart/crt_rpc.c
@@ -1245,6 +1245,17 @@ crt_req_send_immediately(struct crt_rpc_priv *rpc_priv)
 	}
 	D_ASSERT(rpc_priv->crp_hg_hdl != NULL);
 
+	if (D_LOG_ENABLED(DB_NET)) {
+		uint64_t hlc = crt_hlc_get();
+
+		if (hlc > rpc_priv->crp_create_hlc) {
+			uint64_t delay = crt_hlc2msec(hlc - rpc_priv->crp_create_hlc);
+
+			if (delay > 20)
+				RPC_TRACE(DB_NET, rpc_priv, "RPC send took %lu ms.\n", delay);
+		}
+	}
+
 	/* set state ahead to avoid race with completion cb */
 	rpc_priv->crp_state = RPC_STATE_REQ_SENT;
 	rc = crt_hg_req_send(rpc_priv);
@@ -1603,6 +1614,7 @@ crt_rpc_priv_init(struct crt_rpc_priv *rpc_priv, crt_context_t crt_ctx,
 	crt_rpc_inout_buff_init(rpc_priv);
 
 	rpc_priv->crp_timeout_sec = ctx->cc_timeout_sec;
+	rpc_priv->crp_create_hlc = crt_hlc_get();
 
 exit:
 	return rc;
@@ -1626,6 +1638,17 @@ crt_handle_rpc(void *arg)
 	rpc_priv = container_of(rpc_pub, struct crt_rpc_priv, crp_pub);
 	D_ASSERT(rpc_priv->crp_opc_info != NULL);
 	D_ASSERT(rpc_priv->crp_opc_info->coi_rpc_cb != NULL);
+
+	if (D_LOG_ENABLED(DB_NET)) {
+		uint64_t hlc = crt_hlc_get();
+
+		if (hlc > rpc_priv->crp_create_hlc) {
+			uint64_t delay = crt_hlc2msec(hlc - rpc_priv->crp_create_hlc);
+
+			if (delay > 20)
+				RPC_TRACE(DB_NET, rpc_priv, "RPC schedule took %lu ms.\n", delay);
+		}
+	}
 
 	/*
 	 * for user initiated corpc if it delivered to itself, in user's RPC
@@ -1700,7 +1723,8 @@ crt_rpc_common_hdlr(struct crt_rpc_priv *rpc_priv)
 	if (!rpc_priv->crp_opc_info->coi_no_reply)
 		rpc_priv->crp_reply_pending = 1;
 
-	if (crt_rpc_cb_customized(crt_ctx, &rpc_priv->crp_pub)) {
+	if (crt_rpc_cb_customized(crt_ctx, &rpc_priv->crp_pub) &&
+	    !crt_opc_is_swim(rpc_priv->crp_req_hdr.cch_opc)) {
 		rc = crt_ctx->cc_rpc_cb((crt_context_t)crt_ctx,
 					&rpc_priv->crp_pub,
 					crt_handle_rpc,
@@ -1761,7 +1785,7 @@ timeout_bp_node_cmp(struct d_binheap_node *a, struct d_binheap_node *b)
 	rpc_priv_a = container_of(a, struct crt_rpc_priv, crp_timeout_bp_node);
 	rpc_priv_b = container_of(b, struct crt_rpc_priv, crp_timeout_bp_node);
 
-	return rpc_priv_a->crp_timeout_ts < rpc_priv_b->crp_timeout_ts;
+	return rpc_priv_a->crp_expire_hlc < rpc_priv_b->crp_expire_hlc;
 }
 
 struct d_binheap_ops crt_timeout_bh_ops = {

--- a/src/cart/crt_rpc.h
+++ b/src/cart/crt_rpc.h
@@ -131,8 +131,9 @@ struct crt_rpc_priv {
 	struct d_binheap_node	crp_timeout_bp_node;
 	/* the timeout in seconds set by user */
 	uint32_t		crp_timeout_sec;
-	/* time stamp to be timeout, the key of timeout binheap */
-	uint64_t		crp_timeout_ts;
+	/* HLC time stamp to be timeout, the key of timeout binheap */
+	uint64_t		crp_expire_hlc;
+	uint64_t		crp_create_hlc;
 	crt_cb_t		crp_complete_cb;
 	void			*crp_arg; /* argument for crp_complete_cb */
 	struct crt_ep_inflight	*crp_epi; /* point back to inflight ep */
@@ -646,20 +647,17 @@ crt_req_timedout(struct crt_rpc_priv *rpc_priv)
 	       !rpc_priv->crp_in_binheap;
 }
 
-static inline uint64_t
+static inline void
 crt_set_timeout(struct crt_rpc_priv *rpc_priv)
 {
-	uint64_t	sec_diff;
+	uint64_t hlc = crt_hlc_get();
 
 	D_ASSERT(rpc_priv != NULL);
 
 	if (rpc_priv->crp_timeout_sec == 0)
 		rpc_priv->crp_timeout_sec = crt_gdata.cg_timeout;
 
-	sec_diff = d_timeus_secdiff(rpc_priv->crp_timeout_sec);
-	rpc_priv->crp_timeout_ts = sec_diff;
-
-	return sec_diff;
+	rpc_priv->crp_expire_hlc = hlc + crt_sec2hlc(rpc_priv->crp_timeout_sec);
 }
 
 /* Convert opcode to string. Only returns string for internal RPCs */

--- a/src/cart/crt_swim.c
+++ b/src/cart/crt_swim.c
@@ -756,10 +756,16 @@ static int64_t crt_swim_progress_cb(crt_context_t crt_ctx, int64_t timeout, void
 			D_ERROR("SWIM shutdown\n");
 		swim_self_set(ctx, SWIM_ID_INVALID);
 	} else if (rc == -DER_TIMEDOUT || rc == -DER_CANCELED) {
-		uint64_t now = swim_now_ms();
+		/*
+		 * Change only for very long timeout to avoid confusing of DAOS scheduler.
+		 * NB: !!! Mercury only supports milli-second timeout !!!
+		 */
+		if (timeout > 1000) {
+			uint64_t hlc = crt_hlc_get();
 
-		if (now < ctx->sc_next_event)
-			timeout = ctx->sc_next_event - now;
+			if (hlc < ctx->sc_next_event)
+				timeout = crt_hlc2msec(ctx->sc_next_event - hlc);
+		}
 	} else if (rc) {
 		D_ERROR("swim_progress(): "DF_RC"\n", DP_RC(rc));
 	}
@@ -1069,7 +1075,7 @@ void crt_swim_accommodate(void)
 		else if (average > max_timeout)
 			average = max_timeout;
 
-		if (average != ping_timeout) {
+		if ((average >> 5) != (ping_timeout >> 5)) {
 			D_INFO("change PING timeout from %lu ms to %lu ms\n",
 			       ping_timeout, average);
 			swim_ping_timeout_set(average);

--- a/src/cart/crt_swim.c
+++ b/src/cart/crt_swim.c
@@ -1075,6 +1075,10 @@ void crt_swim_accommodate(void)
 		else if (average > max_timeout)
 			average = max_timeout;
 
+		/*
+		 * (x >> 5) is just (x / 32) but a way faster.
+		 * This should avoid changes for small deltas.
+		 */
 		if ((average >> 5) != (ping_timeout >> 5)) {
 			D_INFO("change PING timeout from %lu ms to %lu ms\n",
 			       ping_timeout, average);

--- a/src/cart/swim/swim.c
+++ b/src/cart/swim/swim.c
@@ -1055,8 +1055,8 @@ done_item:
 				D_GOTO(out, rc);
 			}
 			send_updates = false;
-		} else if ((hlc + 100) < ctx->sc_next_event) {
-			break;
+		} else if ((hlc + crt_msec2hlc(100)) < ctx->sc_next_event) {
+			break; /* break loop if need to wait more than 100 ms. */
 		}
 	}
 	rc = (hlc > end) ? -DER_TIMEDOUT : -DER_CANCELED;

--- a/src/cart/swim/swim.c
+++ b/src/cart/swim/swim.c
@@ -195,8 +195,7 @@ swim_updates_prepare(struct swim_context *ctx, swim_id_t id, swim_id_t to,
 		if (item->si_id != id &&
 		    item->si_id != self_id &&
 		    item->si_id != to) {
-			rc = ctx->sc_ops->get_member_state(ctx, item->si_id,
-							   &upds[n].smu_state);
+			rc = ctx->sc_ops->get_member_state(ctx, item->si_id, &upds[n].smu_state);
 			if (rc) {
 				if (rc == -DER_NONEXIST) {
 					/* this member was removed already */
@@ -284,8 +283,7 @@ update:
 }
 
 static int
-swim_member_alive(struct swim_context *ctx, swim_id_t from,
-		  swim_id_t id, uint64_t nr)
+swim_member_alive(struct swim_context *ctx, swim_id_t from, swim_id_t id, uint64_t nr)
 {
 	struct swim_member_state	 id_state;
 	struct swim_item		*item;
@@ -337,8 +335,7 @@ out:
 }
 
 static int
-swim_member_dead(struct swim_context *ctx, swim_id_t from,
-		 swim_id_t id, uint64_t nr)
+swim_member_dead(struct swim_context *ctx, swim_id_t from, swim_id_t id, uint64_t nr)
 {
 	struct swim_member_state	 id_state;
 	struct swim_item		*item;
@@ -385,8 +382,7 @@ out:
 }
 
 static int
-swim_member_suspect(struct swim_context *ctx, swim_id_t from,
-		    swim_id_t id, uint64_t nr)
+swim_member_suspect(struct swim_context *ctx, swim_id_t from, swim_id_t id, uint64_t nr)
 {
 	struct swim_member_state	 id_state;
 	struct swim_item		*item;
@@ -427,7 +423,7 @@ search:
 		D_GOTO(out, rc = -DER_NOMEM);
 	item->si_id   = id;
 	item->si_from = from;
-	item->u.si_deadline = swim_now_ms() + swim_suspect_timeout_get();
+	item->u.si_deadline = crt_hlc_get() + crt_msec2hlc(swim_suspect_timeout_get());
 	TAILQ_INSERT_TAIL(&ctx->sc_suspects, item, si_link);
 
 update:
@@ -439,8 +435,7 @@ out:
 }
 
 static int
-swim_member_update_suspected(struct swim_context *ctx, uint64_t now,
-			     uint64_t net_glitch_delay)
+swim_member_update_suspected(struct swim_context *ctx, uint64_t hlc, uint64_t net_glitch_delay)
 {
 	TAILQ_HEAD(, swim_item)		 targets;
 	struct swim_member_state	 id_state;
@@ -456,11 +451,9 @@ swim_member_update_suspected(struct swim_context *ctx, uint64_t now,
 	item = TAILQ_FIRST(&ctx->sc_suspects);
 	while (item != NULL) {
 		next = TAILQ_NEXT(item, si_link);
-		item->u.si_deadline += net_glitch_delay;
-		if (now > item->u.si_deadline) {
-			rc = ctx->sc_ops->get_member_state(ctx,
-							   item->si_id,
-							   &id_state);
+		item->u.si_deadline += crt_msec2hlc(net_glitch_delay);
+		if (hlc > item->u.si_deadline) {
+			rc = ctx->sc_ops->get_member_state(ctx, item->si_id, &id_state);
 			if (rc || (id_state.sms_status != SWIM_MEMBER_SUSPECT)) {
 				/* this member was removed or updated already */
 				TAILQ_REMOVE(&ctx->sc_suspects, item, si_link);
@@ -468,15 +461,14 @@ swim_member_update_suspected(struct swim_context *ctx, uint64_t now,
 				D_GOTO(next_item, rc = 0);
 			}
 
-			SWIM_INFO("%lu: suspect timeout %lu\n",
-				  self_id, item->si_id);
+			SWIM_INFO("%lu: suspect timeout %lu\n", self_id, item->si_id);
 			if (item->si_from != self_id) {
 				/* let's try to confirm from gossip origin */
 				id      = item->si_id;
 				from_id = item->si_from;
 
 				item->si_from = self_id;
-				item->u.si_deadline += swim_ping_timeout_get();
+				item->u.si_deadline += crt_msec2hlc(swim_ping_timeout_get());
 
 				D_ALLOC_PTR(item);
 				if (item == NULL)
@@ -524,8 +516,7 @@ next_item:
 }
 
 static int
-swim_ipings_update(struct swim_context *ctx, uint64_t now,
-		   uint64_t net_glitch_delay)
+swim_ipings_update(struct swim_context *ctx, uint64_t hlc, uint64_t net_glitch_delay)
 {
 	TAILQ_HEAD(, swim_item)		 targets;
 	struct swim_item		*next, *item;
@@ -538,8 +529,8 @@ swim_ipings_update(struct swim_context *ctx, uint64_t now,
 	item = TAILQ_FIRST(&ctx->sc_ipings);
 	while (item != NULL) {
 		next = TAILQ_NEXT(item, si_link);
-		item->u.si_deadline += net_glitch_delay;
-		if (now > item->u.si_deadline) {
+		item->u.si_deadline += crt_msec2hlc(net_glitch_delay);
+		if (hlc > item->u.si_deadline) {
 			TAILQ_REMOVE(&ctx->sc_ipings, item, si_link);
 			TAILQ_INSERT_TAIL(&targets, item, si_link);
 		} else {
@@ -610,8 +601,7 @@ swim_ipings_reply(struct swim_context *ctx, swim_id_t to_id, int ret_rc)
 }
 
 int
-swim_ipings_suspend(struct swim_context *ctx, swim_id_t from_id,
-		    swim_id_t to_id, void *args)
+swim_ipings_suspend(struct swim_context *ctx, swim_id_t from_id, swim_id_t to_id, void *args)
 {
 	struct swim_item	*item;
 	int			 rc = 0;
@@ -631,7 +621,7 @@ swim_ipings_suspend(struct swim_context *ctx, swim_id_t from_id,
 		item->si_id   = to_id;
 		item->si_from = from_id;
 		item->si_args = args;
-		item->u.si_deadline = swim_now_ms() + swim_ping_timeout_get();
+		item->u.si_deadline = crt_hlc_get() + crt_msec2hlc(swim_ping_timeout_get());
 		TAILQ_INSERT_TAIL(&ctx->sc_ipings, item, si_link);
 	} else {
 		rc = -DER_NOMEM;
@@ -752,15 +742,15 @@ swim_init(swim_id_t self_id, struct swim_ops *swim_ops, void *data)
 	/* force to choose next target first */
 	ctx->sc_target = SWIM_ID_INVALID;
 
-	/* delay the first ping until all things will be initialized */
-	ctx->sc_next_tick_time = swim_now_ms() + 3 * SWIM_PROTOCOL_PERIOD_LEN;
-
 	/* set global tunable defaults */
 	swim_prot_period_len = swim_prot_period_len_default();
 	swim_suspect_timeout = swim_suspect_timeout_default();
 	swim_ping_timeout    = swim_ping_timeout_default();
 
 	ctx->sc_default_ping_timeout = swim_ping_timeout;
+
+	/* delay the first ping until all things will be initialized */
+	ctx->sc_next_tick_time = crt_hlc_get() + crt_msec2hlc(3 * swim_prot_period_len);
 
 out:
 	return ctx;
@@ -827,17 +817,17 @@ swim_net_glitch_update(struct swim_context *ctx, swim_id_t id, uint64_t delay)
 	/* update expire time of suspected members */
 	TAILQ_FOREACH(item, &ctx->sc_suspects, si_link) {
 		if (id == self_id || id == item->si_id)
-			item->u.si_deadline += delay;
+			item->u.si_deadline += crt_msec2hlc(delay);
 	}
 	/* update expire time of ipinged members */
 	TAILQ_FOREACH(item, &ctx->sc_ipings, si_link) {
 		if (id == self_id || id == item->si_id)
-			item->u.si_deadline += delay;
+			item->u.si_deadline += crt_msec2hlc(delay);
 	}
 
 	if (id == self_id || id == ctx->sc_target) {
 		if (swim_state_get(ctx) == SCS_PINGED)
-			ctx->sc_deadline += delay;
+			ctx->sc_deadline += crt_msec2hlc(delay);
 	}
 
 	swim_ctx_unlock(ctx);
@@ -854,7 +844,7 @@ swim_progress(struct swim_context *ctx, int64_t timeout)
 	enum swim_context_state	 ctx_state = SCS_TIMEDOUT;
 	struct swim_member_state target_state;
 	struct swim_item	*item;
-	uint64_t		 now, end = 0;
+	uint64_t		 hlc, end = 0;
 	uint64_t		 net_glitch_delay = 0UL;
 	swim_id_t		 target_id, sendto_id;
 	bool			 send_updates = false;
@@ -869,27 +859,27 @@ swim_progress(struct swim_context *ctx, int64_t timeout)
 	if (ctx->sc_self == SWIM_ID_INVALID) /* not initialized yet */
 		D_GOTO(out_err, rc = 0); /* Ignore this update */
 
-	now = swim_now_ms();
+	hlc = crt_hlc_get();
 	if (timeout > 0)
-		end = now + timeout;
-	ctx->sc_next_event = now + swim_period_get() / 3;
+		end = hlc + crt_msec2hlc(timeout);
+	ctx->sc_next_event = hlc + crt_msec2hlc(swim_period_get());
 
-	if (now > ctx->sc_expect_progress_time &&
+	if (hlc > ctx->sc_expect_progress_time &&
 	    0  != ctx->sc_expect_progress_time) {
-		net_glitch_delay = now - ctx->sc_expect_progress_time;
+		net_glitch_delay = crt_hlc2msec(hlc - ctx->sc_expect_progress_time);
 		SWIM_ERROR("The progress callback was not called for too long: "
 			   "%lu ms after expected.\n", net_glitch_delay);
 	}
 
-	for (; now <= end || ctx_state == SCS_TIMEDOUT; now = swim_now_ms()) {
-		rc = swim_member_update_suspected(ctx, now, net_glitch_delay);
+	for (; hlc <= end || ctx_state == SCS_TIMEDOUT; hlc = crt_hlc_get()) {
+		rc = swim_member_update_suspected(ctx, hlc, net_glitch_delay);
 		if (rc) {
 			SWIM_ERROR("swim_member_update_suspected(): "DF_RC"\n",
 				   DP_RC(rc));
 			D_GOTO(out, rc);
 		}
 
-		rc = swim_ipings_update(ctx, now, net_glitch_delay);
+		rc = swim_ipings_update(ctx, hlc, net_glitch_delay);
 		if (rc) {
 			SWIM_ERROR("swim_ipings_update(): "DF_RC"\n",
 				   DP_RC(rc));
@@ -899,8 +889,7 @@ swim_progress(struct swim_context *ctx, int64_t timeout)
 		swim_ctx_lock(ctx);
 		ctx_state = SCS_SELECT;
 		if (ctx->sc_target != SWIM_ID_INVALID) {
-			rc = ctx->sc_ops->get_member_state(ctx, ctx->sc_target,
-							   &target_state);
+			rc = ctx->sc_ops->get_member_state(ctx, ctx->sc_target, &target_state);
 			if (rc) {
 				ctx->sc_target = SWIM_ID_INVALID;
 				if (rc != -DER_NONEXIST) {
@@ -917,7 +906,7 @@ swim_progress(struct swim_context *ctx, int64_t timeout)
 
 		switch (ctx_state) {
 		case SCS_BEGIN:
-			if (now > ctx->sc_next_tick_time) {
+			if (hlc > ctx->sc_next_tick_time) {
 				if (TAILQ_EMPTY(&ctx->sc_subgroup)) {
 					uint64_t delay = target_state.sms_delay * 2;
 					uint64_t ping_timeout = swim_ping_timeout_get();
@@ -936,8 +925,9 @@ swim_progress(struct swim_context *ctx, int64_t timeout)
 						  target_state.sms_incarnation,
 						  target_state.sms_delay, delay);
 
-					ctx->sc_next_tick_time = now + swim_period_get();
-					ctx->sc_deadline = now + delay;
+					ctx->sc_next_tick_time = hlc
+							       + crt_msec2hlc(swim_period_get());
+					ctx->sc_deadline = hlc + crt_msec2hlc(delay);
 					if (ctx->sc_deadline < ctx->sc_next_event)
 						ctx->sc_next_event = ctx->sc_deadline;
 					ctx_state = SCS_PINGED;
@@ -954,8 +944,8 @@ swim_progress(struct swim_context *ctx, int64_t timeout)
 			 * protocol tick ever successfully acked a direct
 			 * ping request
 			 */
-			ctx->sc_deadline += net_glitch_delay;
-			if (now > ctx->sc_deadline) {
+			ctx->sc_deadline += crt_msec2hlc(net_glitch_delay);
+			if (hlc > ctx->sc_deadline) {
 				/* no response from direct ping */
 				if (target_state.sms_status != SWIM_MEMBER_INACTIVE) {
 					/* suspect this member */
@@ -969,7 +959,7 @@ swim_progress(struct swim_context *ctx, int64_t timeout)
 					 */
 					ctx_state = SCS_SELECT;
 				}
-				ctx->sc_next_event = now;
+				ctx->sc_next_event = hlc;
 			} else {
 				if (ctx->sc_deadline < ctx->sc_next_event)
 					ctx->sc_next_event = ctx->sc_deadline;
@@ -1065,13 +1055,13 @@ done_item:
 				D_GOTO(out, rc);
 			}
 			send_updates = false;
-		} else if (now + 100 < ctx->sc_next_event) {
+		} else if ((hlc + 100) < ctx->sc_next_event) {
 			break;
 		}
 	}
-	rc = (now > end) ? -DER_TIMEDOUT : -DER_CANCELED;
+	rc = (hlc > end) ? -DER_TIMEDOUT : -DER_CANCELED;
 out:
-	ctx->sc_expect_progress_time = now + swim_period_get() / 2;
+	ctx->sc_expect_progress_time = hlc + crt_msec2hlc(swim_period_get());
 out_err:
 	return rc;
 }
@@ -1123,12 +1113,10 @@ swim_updates_parse(struct swim_context *ctx, swim_id_t from_id,
 				 * suspected/confirmed in the current
 				 * incarnation
 				 */
-				rc = ctx->sc_ops->get_member_state(ctx, self_id,
-								   &self_state);
+				rc = ctx->sc_ops->get_member_state(ctx, self_id, &self_state);
 				if (rc) {
 					swim_ctx_unlock(ctx);
-					SWIM_ERROR("get_member_state(%lu): "
-						   DF_RC"\n", self_id,
+					SWIM_ERROR("get_member_state(%lu): "DF_RC"\n", self_id,
 						   DP_RC(rc));
 					D_GOTO(out, rc);
 				}
@@ -1140,20 +1128,16 @@ swim_updates_parse(struct swim_context *ctx, swim_id_t from_id,
 				SWIM_ERROR("{%lu %c %lu} self %s received "
 					   "{%lu %c %lu} from %lu\n",
 					   self_id,
-					   SWIM_STATUS_CHARS[
-							 self_state.sms_status],
+					   SWIM_STATUS_CHARS[self_state.sms_status],
 					   self_state.sms_incarnation,
-					   SWIM_STATUS_STR[
-						  upds[i].smu_state.sms_status],
+					   SWIM_STATUS_STR[upds[i].smu_state.sms_status],
 					   self_id,
-					   SWIM_STATUS_CHARS[
-						  upds[i].smu_state.sms_status],
+					   SWIM_STATUS_CHARS[upds[i].smu_state.sms_status],
 					   upds[i].smu_state.sms_incarnation,
 					   from_id);
 
 				ctx->sc_ops->new_incarnation(ctx, self_id, &self_state);
-				rc = swim_updates_notify(ctx, self_id, self_id,
-							 &self_state, 0);
+				rc = swim_updates_notify(ctx, self_id, self_id, &self_state, 0);
 				if (rc) {
 					swim_ctx_unlock(ctx);
 					SWIM_ERROR("swim_updates_notify(): "

--- a/src/cart/swim/swim_internal.h
+++ b/src/cart/swim/swim_internal.h
@@ -19,8 +19,8 @@
 #include <string.h>
 #include <sys/queue.h>
 #include <errno.h>
-#include <time.h>
 
+#include <cart/api.h>
 #include <cart/swim.h>
 #include <gurt/debug.h>
 #include <gurt/common.h>
@@ -131,17 +131,6 @@ swim_ctx_unlock(struct swim_context *ctx)
 		SWIM_ERROR("SWIM_MUTEX_UNLOCK() failed rc=%d\n", rc);
 
 	return rc;
-}
-
-static inline uint64_t
-swim_now_ms(void)
-{
-	struct timespec now;
-	int rc;
-
-	rc = clock_gettime(CLOCK_MONOTONIC, &now);
-
-	return rc ? 0 : now.tv_sec * 1000 + now.tv_nsec / 1000000;
 }
 
 static inline enum swim_context_state

--- a/src/tests/ftest/cart/test_swim_emu.c
+++ b/src/tests/ftest/cart/test_swim_emu.c
@@ -84,7 +84,7 @@ static int test_send_message(struct swim_context *ctx, swim_id_t id,
 		item->np_to    = to;
 		item->np_upds  = upds;
 		item->np_nupds = nupds;
-		item->np_time  = swim_now_ms();
+		item->np_time  = crt_hlc_get();
 
 		D_SPIN_LOCK(&g.lock);
 		TAILQ_INSERT_TAIL(&g.pkts, item, np_link);
@@ -217,7 +217,7 @@ int test_run(void)
 {
 	enum swim_member_status s;
 	struct timespec now;
-	uint64_t time = swim_now_ms();
+	uint64_t time = crt_hlc_get();
 	int i, j, cs, cd, tick, rc = 0;
 
 	sleep(1);
@@ -320,7 +320,7 @@ static void deliver_pkt(struct network_pkt *item)
 	int i, rc = 0;
 
 	max_delay = swim_ping_timeout_get() / 2;
-	rcv_delay = swim_now_ms() - item->np_time;
+	rcv_delay = crt_hlc2msec(crt_hlc_get() - item->np_time);
 
 	for (i = 0; i < item->np_nupds; i++) {
 		id = item->np_upds[i].smu_id;
@@ -470,10 +470,6 @@ int test_fini(void)
 
 	return rc;
 }
-
-#ifdef USE_CART_FOR_DEBUG_LOG
-extern int crt_init_opt(char *grpid, uint32_t flags, void *opt);
-#endif
 
 int test_init(void)
 {


### PR DESCRIPTION
Removed usage of clock_gettime() and use HLC everywhere instead.
Turned off scheduling incoming SWIM RPCs by DAOS customization.
Changed progress timeout only for very long timeout to avoid
confusing of DAOS scheduler.

Add more debug timing traces for RPCs. Now we can see in logs:
 - how long RPC scheduled for processing
 - how long RPC send (it was in queue before send to wire)
 - how long RPC was processed before reply