### PR TITLE
DAOS-8873 control: Fix hwloc tests on el8 (#7093)

### DIFF
--- a/src/control/lib/netdetect/netdetect_test.go
+++ b/src/control/lib/netdetect/netdetect_test.go
@@ -206,77 +206,17 @@ func TestValidateNetworkConfig(t *testing.T) {
 	}
 }
 
-// ValidateNUMAConfigNonNumaAware verifies that the numa detection successfully executes without error
-// with a topology that has no NUMA devices in it.
-func TestValidateNUMAConfigNonNumaAware(t *testing.T) {
-	for name, tc := range map[string]struct {
-		device   string
-		topology string
-	}{
-		"no NUMA nodes in topology - has devices": {
-			device:   "fake device",
-			topology: "testdata/no-numa-nodes.xml",
-		},
-		"no NUMA nodes in topology with eth0 device": {
-			device:   "eth0",
-			topology: "testdata/no-numa-nodes.xml",
-		},
-		"no NUMA nodes in topology with ib1 device": {
-			device:   "ib1",
-			topology: "testdata/no-numa-nodes.xml",
-		},
-		"no NUMA nodes no devices in topology with fake device": {
-			device:   "fake device",
-			topology: "testdata/no-numa-no-devices.xml",
-		},
-		"no NUMA nodes no devices in topology with eth0 device": {
-			device:   "eth0",
-			topology: "testdata/no-numa-no-devices.xml",
-		},
-		"no NUMA nodes no devices in topology with fake device with ib1 device": {
-			device:   "ib1",
-			topology: "testdata/no-numa-no-devices.xml",
-		},
-	} {
-		t.Run(name, func(t *testing.T) {
-			_, err := os.Stat(tc.topology)
-			AssertEqual(t, err, nil, "unable to load xmlTopology")
-			os.Setenv("HWLOC_XMLFILE", tc.topology)
-			defer os.Unsetenv("HWLOC_XMLFILE")
-
-			netCtx, err := Init(context.Background())
-			defer CleanUp(netCtx)
-			AssertEqual(t, err, nil, "Failed to initialize NetDetectContext")
-			AssertEqual(t, HasNUMA(netCtx), false, "Unexpected detection of NUMA nodes in provided topology")
-
-			err = ValidateNUMAConfig(netCtx, tc.device, 0)
-			AssertEqual(t, err, nil, "Error on ValidateNUMAConfig")
-		})
-	}
-}
-
 // TestNumaAware verifies that the numa detection successfully executes without error
 // with a standard topology and one without any OS devices in it
 func TestNumaAware(t *testing.T) {
 	for name, tc := range map[string]struct {
-		result   bool
 		topology string
 	}{
 		"no devices in topology": {
-			result:   true,
 			topology: "testdata/gcp_topology.xml",
 		},
 		"devices in topology": {
-			result:   true,
 			topology: "testdata/boro-84.xml",
-		},
-		"devices in topology no NUMA nodes": {
-			result:   false,
-			topology: "testdata/no-numa-nodes.xml",
-		},
-		"no devices in topology no NUMA nodes": {
-			result:   false,
-			topology: "testdata/no-numa-no-devices.xml",
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
@@ -289,11 +229,7 @@ func TestNumaAware(t *testing.T) {
 			defer CleanUp(netCtx)
 			AssertEqual(t, err, nil, "Failed to initialize NetDetectContext")
 
-			if tc.result {
-				AssertEqual(t, HasNUMA(netCtx), tc.result, "Unable to detect NUMA on provided topology")
-			} else {
-				AssertEqual(t, HasNUMA(netCtx), tc.result, "Detected NUMA on non-numa topology")
-			}
+			AssertTrue(t, HasNUMA(netCtx), "Unable to detect NUMA on provided topology")
 		})
 	}
 }
@@ -336,16 +272,8 @@ func TestGetAffinityForDeviceEdgeCases(t *testing.T) {
 			device:   "lo",
 			topology: "testdata/no-numa-nodes.xml",
 		},
-		"non-numa topology, with OS devices, no network devices, unknown input device": {
-			device:   "bar",
-			topology: "testdata/no-numa-nodes.xml",
-		},
 		"non-numa topology, with no OS devices, known input device": {
 			device:   "lo",
-			topology: "testdata/no-numa-no-devices.xml",
-		},
-		"non-numa topology, with no OS devices, unknown input device": {
-			device:   "bazz",
 			topology: "testdata/no-numa-no-devices.xml",
 		},
 	} {


### PR DESCRIPTION
In hwloc 2.0+, a NUMA node is automatically added to the
topology if the synthetic topology did not contain one.

A number of the unit tests were written with the assumption
that a loaded topology could contain 0 NUMA nodes, and are
therefore not valid anymore.

Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com>