### PR TITLE
DAOS-8967 test: Disable daos_agent.TestAgent_MultiProcess_AttachInfoCache

### DIFF
--- a/src/control/cmd/daos_agent/agent_test.go
+++ b/src/control/cmd/daos_agent/agent_test.go
@@ -118,6 +118,7 @@ func TestMain(m *testing.M) {
 }
 
 func TestAgent_MultiProcess_AttachInfoCache(t *testing.T) {
+	t.Skip("DAOS-8967")
 	log, buf := logging.NewTestLogger(t.Name())
 	defer common.ShowBufferOnFailure(t, buf)
 


### PR DESCRIPTION
It's causing intermittent failures in CI and affecting PRs.

Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com>
