### PR TITLE
DAOS-8953-test: 17 recent tests failed due to timeout.

### DIFF
--- a/src/tests/ftest/erasurecode/offline_rebuild.yaml
+++ b/src/tests/ftest/erasurecode/offline_rebuild.yaml
@@ -22,7 +22,7 @@ hosts:
   test_clients:
     - client-A
     - client-B
-timeout: 600
+timeout: 900
 server_config:
   engines_per_host: 2
   name: daos_server

--- a/src/tests/ftest/erasurecode/offline_rebuild.yaml
+++ b/src/tests/ftest/erasurecode/offline_rebuild.yaml
@@ -59,6 +59,7 @@ pool:
 container:
     type: POSIX
     control_method: daos
+    properties: "rf:1"
 ior:
   api: "DFS"
   client_processes:

--- a/src/tests/ftest/erasurecode/offline_rebuild_single.yaml
+++ b/src/tests/ftest/erasurecode/offline_rebuild_single.yaml
@@ -64,6 +64,7 @@ container:
     single_data_set:
       # [object_qty, record_qty, dkey, akey, data_size]
       - [1, 1, 1, 1, 4194304]
+    properties: "rf:1"
 objectclass:
     dfs_oclass_list:
       #- [EC_Object_Class, Minimum number of servers]

--- a/src/tests/ftest/erasurecode/offline_rebuild_single.yaml
+++ b/src/tests/ftest/erasurecode/offline_rebuild_single.yaml
@@ -23,7 +23,7 @@ hosts:
     - client-A
 setup:
   start_servers_once: False
-timeout: 900
+timeout: 1200
 server_config:
   engines_per_host: 2
   name: daos_server

--- a/src/tests/ftest/erasurecode/online_rebuild_single.yaml
+++ b/src/tests/ftest/erasurecode/online_rebuild_single.yaml
@@ -21,7 +21,7 @@ hosts:
         - server-F
   test_clients:
     - client-A
-timeout: 1200
+timeout: 1500
 setup:
   start_servers_once: False
 server_config:

--- a/src/tests/ftest/erasurecode/online_rebuild_single.yaml
+++ b/src/tests/ftest/erasurecode/online_rebuild_single.yaml
@@ -64,6 +64,7 @@ container:
     single_data_set:
       # [object_qty, record_qty, dkey, akey, data_size]
       - [1, 1, 1, 1, 4194304]
+    properties: "rf:1"
 objectclass:
     dfs_oclass_list:
       #- [EC_Object_Class, Minimum number of servers]

--- a/src/tests/ftest/erasurecode/rebuild_disabled.yaml
+++ b/src/tests/ftest/erasurecode/rebuild_disabled.yaml
@@ -20,7 +20,7 @@ hosts:
     - client-A
     - client-B
     - client-C
-timeout: 3500
+timeout: 3900
 server_config:
   engines_per_host: 2
   name: daos_server

--- a/src/tests/ftest/erasurecode/rebuild_disabled.yaml
+++ b/src/tests/ftest/erasurecode/rebuild_disabled.yaml
@@ -58,6 +58,7 @@ pool:
 container:
     type: POSIX
     control_method: daos
+    properties: "rf:1"
 ior:
   api: "DFS"
   client_processes:

--- a/src/tests/ftest/erasurecode/rebuild_disabled_single.yaml
+++ b/src/tests/ftest/erasurecode/rebuild_disabled_single.yaml
@@ -18,7 +18,7 @@ hosts:
         - server-E
   test_clients:
     - client-A
-timeout: 250
+timeout: 600
 server_config:
   engines_per_host: 2
   name: daos_server

--- a/src/tests/ftest/erasurecode/rebuild_disabled_single.yaml
+++ b/src/tests/ftest/erasurecode/rebuild_disabled_single.yaml
@@ -59,6 +59,7 @@ container:
     single_data_set:
       # [object_qty, record_qty, dkey, akey, data_size]
       - [1, 1, 1, 1, 4194304]
+    properties: "rf:1"
 objectclass:
     dfs_oclass_list:
       #- [EC_Object_Class, Minimum number of servers]

--- a/src/tests/ftest/erasurecode/restart.yaml
+++ b/src/tests/ftest/erasurecode/restart.yaml
@@ -9,7 +9,7 @@ hosts:
     - client-A
     - client-B
     - client-C
-timeout: 1500
+timeout: 1800
 setup:
   start_agents_once: False
   start_servers_once: False

--- a/src/tests/ftest/erasurecode/restart.yaml
+++ b/src/tests/ftest/erasurecode/restart.yaml
@@ -52,6 +52,7 @@ pool:
 container:
     type: POSIX
     control_method: daos
+    properties: "rf:1"
 ior:
   api: "DFS"
   client_processes:

--- a/src/tests/ftest/ior/hard.yaml
+++ b/src/tests/ftest/ior/hard.yaml
@@ -9,7 +9,7 @@ hosts:
     - client-A
     - client-B
     - client-C
-timeout: 1000
+timeout: 1200
 server_config:
   engines_per_host: 2
   name: daos_server

--- a/src/tests/ftest/ior/intercept_dfuse_mix.yaml
+++ b/src/tests/ftest/ior/intercept_dfuse_mix.yaml
@@ -6,7 +6,7 @@ hosts:
         - client-B
         - client-C
         - client-D
-timeout: 2400
+timeout: 2700
 server_config:
     name: daos_server
     servers:

--- a/src/tests/ftest/nvme/io_verification.yaml
+++ b/src/tests/ftest/nvme/io_verification.yaml
@@ -9,7 +9,7 @@ hosts:
    - boro-G
  test_clients:
    - boro-H
-timeout: 4000
+timeout: 4600
 server_config:
  name: daos_server
  servers:

--- a/src/tests/ftest/nvme/io_verification.yaml
+++ b/src/tests/ftest/nvme/io_verification.yaml
@@ -9,7 +9,7 @@ hosts:
    - boro-G
  test_clients:
    - boro-H
-timeout: 4600
+timeout: 5200
 server_config:
  name: daos_server
  servers:

--- a/src/tests/ftest/nvme/object.yaml
+++ b/src/tests/ftest/nvme/object.yaml
@@ -13,7 +13,7 @@ hosts:
   - boro-H
 timeouts:
   test_nvme_object_single_pool: 270
-  test_nvme_object_multiple_pools: 16000
+  test_nvme_object_multiple_pools: 18000
 server_config:
   name: daos_server
   servers:

--- a/src/tests/ftest/rebuild/widely_striped.yaml
+++ b/src/tests/ftest/rebuild/widely_striped.yaml
@@ -11,7 +11,7 @@ hosts:
     - server-G
   test_clients:
     - client-H
-timeout: 500
+timeout: 800
 server_config:
   name: daos_server
   servers:


### PR DESCRIPTION
Description: increase test timeout for the following tests.
modified:   erasurecode/offline_rebuild.yaml
modified:   erasurecode/offline_rebuild_single.yaml
modified:   erasurecode/online_rebuild_single.yaml
modified:   erasurecode/rebuild_disabled.yaml
modified:   erasurecode/rebuild_disabled_single.yaml
modified:   erasurecode/restart.yaml
modified:   ior/intercept_dfuse_mix.yaml
modified:   nvme/io_verification.yaml
modified:   rebuild/widely_striped.yaml

Test-tag: pr ec_offline_rebuild ec_online_rebuild ec_disabled_rebuild ec_server_restart ior_intercept_mix daosio widelystriped
Signed-off-by: Ding Ho ding-hwa.ho@intel.com