### PR TITLE
DAOS-8939 rebuild: Overlap update for EC 2P object (#7167)

### DIFF
--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -1984,7 +1984,11 @@ obj_iod_sgl_valid(daos_obj_id_t oid, unsigned int nr, daos_iod_t *iods,
 			if (!size_fetch &&
 			    !obj_recx_valid(iods[i].iod_nr, iods[i].iod_recxs,
 					    update)) {
-				D_ERROR("IOD_ARRAY should have valid recxs\n");
+				D_ERROR("Invalid recxs update %s\n", update ? "yes" : "no");
+				for (j = 0; j < iods[i].iod_nr; j++)
+					D_ERROR("%d: "DF_RECX"\n", j,
+						DP_RECX(iods[i].iod_recxs[j]));
+
 				return -DER_INVAL;
 			}
 			if (iods[i].iod_size == DAOS_REC_ANY)

--- a/src/object/srv_obj_migrate.c
+++ b/src/object/srv_obj_migrate.c
@@ -1623,8 +1623,7 @@ migrate_one_ult(void *arg)
 	while (tls->mpt_inflight_size + data_size >=
 	       tls->mpt_inflight_max_size && tls->mpt_inflight_max_size != 0
 	       && !tls->mpt_fini) {
-		D_DEBUG(DB_REBUILD, "mrone %p wait "DF_U64"/"DF_U64"\n",
-			mrone, tls->mpt_inflight_size,
+		D_INFO("mrone %p wait "DF_U64"/"DF_U64"\n", mrone, tls->mpt_inflight_size,
 			tls->mpt_inflight_max_size);
 		ABT_mutex_lock(tls->mpt_inflight_mutex);
 		ABT_cond_wait(tls->mpt_inflight_cond, tls->mpt_inflight_mutex);
@@ -1708,7 +1707,7 @@ migrate_merge_iod_recx(daos_iod_t *dst_iod, daos_epoch_t **p_dst_ephs, daos_recx
 		if (recxs == NULL)
 			D_GOTO(out, rc = -DER_NOMEM);
 
-		if (dst_ephs != NULL) {
+		if (p_dst_ephs != NULL) {
 			D_ALLOC_ARRAY(dst_ephs, nr_recxs);
 			if (dst_ephs == NULL) {
 				D_FREE(recxs);
@@ -1748,12 +1747,12 @@ out:
 	return rc;
 }
 
+/* Merge new_iod/new_recx/new_ephs into iods which assume @iods has enough space. */
 static int
 migrate_insert_recxs_sgl(daos_iod_t *iods, daos_epoch_t **iods_ephs, uint32_t *iods_num,
 			 daos_iod_t *new_iod, daos_recx_t *new_recxs, daos_epoch_t *new_ephs,
 			 int new_recxs_nr, d_sg_list_t *sgls, d_sg_list_t *new_sgl)
 {
-	daos_iod_t *dst_iod;
 	int	   rc = 0;
 	int	   i;
 
@@ -1762,82 +1761,54 @@ migrate_insert_recxs_sgl(daos_iod_t *iods, daos_epoch_t **iods_ephs, uint32_t *i
 			break;
 	}
 
-	/* None duplicate iods, let's create new one */
-	if (i == *iods_num) {
-		rc = daos_iod_copy(&iods[i], new_iod);
+	/* This IOD already exists, let's check if iod_size and type matched */
+	if (iods[i].iod_type != DAOS_IOD_NONE &&
+	    (iods[i].iod_size != new_iod->iod_size ||
+	     iods[i].iod_type != new_iod->iod_type ||
+	     iods[i].iod_type == DAOS_IOD_SINGLE)) {
+		D_ERROR(DF_KEY" dst_iod size "DF_U64" != "DF_U64
+			" dst_iod type %d != %d\n",
+			DP_KEY(&new_iod->iod_name), iods[i].iod_size,
+			new_iod->iod_size, iods[i].iod_type,
+			new_iod->iod_type);
+		D_GOTO(out, rc = -DER_INVAL);
+	}
+
+	/* Insert new IOD */
+	if (iods[i].iod_type == DAOS_IOD_NONE) {
+		D_ASSERT(i == *iods_num);
+		rc = daos_iov_copy(&iods[i].iod_name, &new_iod->iod_name);
 		if (rc)
-			return rc;
+			D_GOTO(out, rc);
+		iods[i].iod_type = new_iod->iod_type;
+		iods[i].iod_size = new_iod->iod_size;
 
 		if (new_sgl) {
 			rc = daos_sgl_alloc_copy_data(&sgls[i], new_sgl);
 			if (rc)
-				return rc;
+				D_GOTO(out, rc);
 		}
+		(*iods_num)++;
+	}
 
-		if (new_iod->iod_type == DAOS_IOD_SINGLE) {
-			iods[i].iod_recxs = NULL;
-			if (iods_ephs != NULL) {
-				D_ALLOC_ARRAY(iods_ephs[i], 1);
-				if (iods_ephs[i] == NULL)
-					return -DER_NOMEM;
-				iods_ephs[i][0] = new_ephs[0];
-				iods[i].iod_nr = new_recxs_nr;
-			}
-		} else {
-			int j;
-
-			D_ALLOC_ARRAY(iods[i].iod_recxs, new_recxs_nr);
-			if (iods[i].iod_recxs == NULL)
-				return -DER_NOMEM;
-
-			if (iods_ephs != NULL) {
-				D_ALLOC_ARRAY(iods_ephs[i], new_recxs_nr);
-				if (iods_ephs[i] == NULL) {
-					D_FREE(iods[i].iod_recxs);
-					iods[i].iod_recxs = NULL;
-					return -DER_NOMEM;
-				}
-			}
-
-			for (j = 0; j < new_recxs_nr; j++) {
-				iods[i].iod_recxs[j] = new_recxs[j];
-				if (iods_ephs != NULL)
-					iods_ephs[i][j] = new_ephs[j];
-			}
+	if (new_iod->iod_type == DAOS_IOD_SINGLE) {
+		iods[i].iod_recxs = NULL;
+		if (iods_ephs != NULL) {
+			D_ALLOC_ARRAY(iods_ephs[i], 1);
+			if (iods_ephs[i] == NULL)
+				D_GOTO(out, rc = -DER_NOMEM);
+			iods_ephs[i][0] = new_ephs[0];
 			iods[i].iod_nr = new_recxs_nr;
 		}
-		D_DEBUG(DB_REBUILD, "add new akey "DF_KEY" at %d\n",
-			DP_KEY(&new_iod->iod_name), i);
-		(*iods_num)++;
-		return rc;
+	} else {
+		rc = migrate_merge_iod_recx(&iods[i], iods_ephs ? &iods_ephs[i] : NULL,
+					    new_recxs, new_ephs, new_recxs_nr);
 	}
 
-	/* Try to merge the iods to the existent IOD */
-	dst_iod = &iods[i];
-	if (dst_iod->iod_size != new_iod->iod_size ||
-	    dst_iod->iod_type != new_iod->iod_type) {
-		D_ERROR(DF_KEY" dst_iod size "DF_U64" != "DF_U64
-			" dst_iod type %d != %d\n",
-			DP_KEY(&new_iod->iod_name), dst_iod->iod_size,
-			new_iod->iod_size, dst_iod->iod_type,
-			new_iod->iod_type);
-		D_GOTO(out, rc);
-	}
-
-	rc = migrate_merge_iod_recx(dst_iod, iods_ephs ? &iods_ephs[i] : NULL, new_recxs,
-				    new_ephs, new_recxs_nr);
-	if (rc)
-		D_GOTO(out, rc);
-
-	if (new_sgl) {
-		rc = daos_sgl_merge(&sgls[i], new_sgl);
-		if (rc)
-			D_GOTO(out, rc);
-	}
-
-	D_DEBUG(DB_REBUILD, "Merge akey "DF_KEY" to %d\n",
-		DP_KEY(&new_iod->iod_name), i);
 out:
+	D_DEBUG(DB_REBUILD, "Merge akey "DF_KEY" at %d: %d\n",
+		DP_KEY(&new_iod->iod_name), i, rc);
+
 	return rc;
 }
 

--- a/src/tests/ftest/daos_test/suite.yaml
+++ b/src/tests/ftest/daos_test/suite.yaml
@@ -137,19 +137,7 @@ daos_tests:
     test_daos_degraded_ec_0to6: DAOS_Degraded_EC_0to6
     test_daos_degraded_ec_8to23: DAOS_Degraded_EC_8to23
     test_daos_dedup: DAOS_Dedup
-    test_daos_capability: DAOS_Capability
-    test_daos_epoch_recovery: DAOS_Epoch_Recovery
-    test_daos_md_replication: DAOS_MD_Replication
-    test_daos_rebuild_simple: DAOS_Rebuild_Simple
-    test_daos_drain_simple: DAOS_Drain_Simple
     test_daos_extend_simple: DAOS_Extend_Simple
-    test_daos_oid_allocator: DAOS_OID_Allocator
-    test_daos_checksum: DAOS_Checksum
-    test_daos_rebuild_ec: DAOS_Rebuild_EC
-    test_daos_aggregate_ec: DAOS_Aggregate_EC
-    test_daos_degraded_ec_0to6: DAOS_Degraded_EC_0to6
-    test_daos_degraded_ec_8to23: DAOS_Degraded_EC_8to23
-    test_daos_dedup: DAOS_Dedup
   daos_test:
     test_daos_degraded_mode: d
     test_daos_management: m
@@ -182,6 +170,7 @@ daos_tests:
     test_daos_degraded_ec_0to6: -u subtests="0-6" --csum_type=crc64
     test_daos_degraded_ec_8to23: -u subtests="8-23" --csum_type=crc64
     test_daos_ec_io: -l"EC_4P2G1"
+    test_daos_rebuild_ec: -s5
   scalable_endpoint:
     test_daos_degraded_mode: True
   stopped_ranks:

--- a/src/tests/suite/daos_rebuild_ec.c
+++ b/src/tests/suite/daos_rebuild_ec.c
@@ -297,12 +297,6 @@ rebuild_ec_setup(void  **state, int number)
 }
 
 static int
-rebuild_ec_4nodes_setup(void **state)
-{
-	return rebuild_ec_setup(state, 4);
-}
-
-static int
 rebuild_ec_8nodes_setup(void **state)
 {
 	return rebuild_ec_setup(state, 8);
@@ -952,27 +946,72 @@ rebuild_ec_snapshot_parity_shard(void **state)
 	rebuild_ec_snapshot(state, OC_EC_4P2G1, 5);
 }
 
+static void
+rebuild_ec_parity_overwrite(void **state)
+{
+	test_arg_t	*arg = *state;
+	daos_obj_id_t	oid;
+	struct ioreq	req;
+	char		*data;
+	daos_recx_t	recx;
+	d_rank_t	rank = 0;
+	int		i;
+	int		stripe_size = 2 * CELL_SIZE;
+
+	if (!test_runable(arg, 8))
+		return;
+
+	oid = daos_test_oid_gen(arg->coh, OC_EC_2P2G1, 0, 0, arg->myrank);
+	ioreq_init(&req, arg->coh, oid, DAOS_IOD_ARRAY, arg);
+	data = (char *)malloc(stripe_size);
+	make_buffer(data, 'a', stripe_size);
+
+	for (i = 0; i < 5; i++) {
+		recx.rx_idx = i * stripe_size;	/* full stripe */
+		recx.rx_nr = stripe_size;
+		insert_recxs("d_key", "a_key", 1, DAOS_TX_NONE, &recx, 1,
+			     data, stripe_size, &req);
+
+		recx.rx_idx = i * stripe_size + 1000;
+		recx.rx_nr = 1000;
+		insert_recxs("d_key", "a_key", 1, DAOS_TX_NONE, &recx, 1,
+			     data, 1000, &req);
+
+		recx.rx_idx = i * stripe_size + CELL_SIZE + 1000;
+		recx.rx_nr = 1000;
+		insert_recxs("d_key", "a_key", 1, DAOS_TX_NONE, &recx, 1,
+			     data, 1000, &req);
+	}
+
+	rank = get_rank_by_oid_shard(arg, oid, 2);
+	rebuild_single_pool_rank(arg, rank, false);
+
+	ioreq_fini(&req);
+
+	free(data);
+}
+
 /** create a new pool/container for each test */
 static const struct CMUnitTest rebuild_tests[] = {
 	{"REBUILD0: rebuild partial update with data tgt fail",
-	 rebuild_partial_fail_data, rebuild_ec_4nodes_setup, test_teardown},
+	 rebuild_partial_fail_data, rebuild_ec_8nodes_setup, test_teardown},
 	{"REBUILD1: rebuild partial update with parity tgt fail",
-	 rebuild_partial_fail_parity, rebuild_ec_4nodes_setup, test_teardown},
+	 rebuild_partial_fail_parity, rebuild_ec_8nodes_setup, test_teardown},
 	{"REBUILD2: rebuild full stripe update with data tgt fail",
-	 rebuild_full_fail_data, rebuild_ec_4nodes_setup, test_teardown},
+	 rebuild_full_fail_data, rebuild_ec_8nodes_setup, test_teardown},
 	{"REBUILD3: rebuild full stripe update with parity tgt fail",
-	 rebuild_full_fail_parity, rebuild_ec_4nodes_setup, test_teardown},
+	 rebuild_full_fail_parity, rebuild_ec_8nodes_setup, test_teardown},
 	{"REBUILD4: rebuild full then partial update with data tgt fail",
-	 rebuild_full_partial_fail_data, rebuild_ec_4nodes_setup,
+	 rebuild_full_partial_fail_data, rebuild_ec_8nodes_setup,
 	 test_teardown},
 	{"REBUILD5: rebuild full then partial update with parity tgt fail",
-	 rebuild_full_partial_fail_parity, rebuild_ec_4nodes_setup,
+	 rebuild_full_partial_fail_parity, rebuild_ec_8nodes_setup,
 	 test_teardown},
 	{"REBUILD6: rebuild partial then full update with data tgt fail",
-	 rebuild_partial_full_fail_data, rebuild_ec_4nodes_setup,
+	 rebuild_partial_full_fail_data, rebuild_ec_8nodes_setup,
 	 test_teardown},
 	{"REBUILD7: rebuild partial then full update with parity tgt fail",
-	 rebuild_partial_full_fail_parity, rebuild_ec_4nodes_setup,
+	 rebuild_partial_full_fail_parity, rebuild_ec_8nodes_setup,
 	 test_teardown},
 	{"REBUILD8: rebuild2p partial update with data tgt fail ",
 	 rebuild2p_partial_fail_data, rebuild_ec_8nodes_setup, test_teardown},
@@ -1071,6 +1110,9 @@ static const struct CMUnitTest rebuild_tests[] = {
 	 test_teardown},
 	{"REBUILD41: rebuild EC snapshot with parity shard",
 	 rebuild_ec_snapshot_parity_shard, rebuild_ec_8nodes_setup,
+	 test_teardown},
+	{"REBUILD42: rebuild parity over write",
+	 rebuild_ec_parity_overwrite, rebuild_ec_8nodes_setup,
 	 test_teardown},
 };
 


### PR DESCRIPTION
Since migrate will convert both parity and replicate
extent into DAOS offset, so let's merge them to remove
the overlap area, which might exist if parity shards are
not being aggregated yet.

Add test cases to verify it.

Set service replica as 5 for daos_replica_ec test to make
sure PS service is always avaible after exclude ranks.

Signed-off-by: Di Wang <di.wang@intel.com>