### PR TITLE
DAOS-8907 Test: Force kill fuse in case of test timeout.

### DIFF
--- a/src/tests/ftest/erasurecode/rebuild_fio.yaml
+++ b/src/tests/ftest/erasurecode/rebuild_fio.yaml
@@ -21,7 +21,7 @@ hosts:
         - server-F
   test_clients:
     - client-A
-timeout: 3000
+timeout: 1500
 setup:
   start_agents_once: False
   start_servers_once: False
@@ -40,6 +40,7 @@ server_config:
       scm_class: dcpm
       scm_list: ["/dev/pmem0"]
       scm_mount: /mnt/daos0
+      log_mask: ERR
     1:
       pinned_numa_node: 1
       nr_xs_helpers: 1
@@ -51,6 +52,7 @@ server_config:
       scm_class: dcpm
       scm_list: ["/dev/pmem1"]
       scm_mount: /mnt/daos1
+      log_mask: ERR
 pool:
   mode: 146
   name: daos_server

--- a/src/tests/ftest/util/ec_utils.py
+++ b/src/tests/ftest/util/ec_utils.py
@@ -17,7 +17,7 @@ from mdtest_test_base import MdtestBase
 from fio_test_base import FioBase
 from pydaos.raw import DaosApiError
 from command_utils_base import CommandFailure
-from general_utils import DaosTestError
+from general_utils import DaosTestError, run_pcmd
 
 
 def get_data_parity_number(log, oclass):
@@ -467,6 +467,21 @@ class ErasureCodeFio(FioBase):
         # Create Pool
         self.add_pool()
         self.out_queue = queue.Queue()
+
+    def stop_job_managers(self):
+        """Cleanup dfuse in case of test failure."""
+        error_list = []
+        dfuse_cleanup_cmd = ["pkill dfuse --signal KILL",
+                             "fusermount3 -uz {}".format(self.dfuse.mount_dir.value)]
+
+        for cmd in dfuse_cleanup_cmd:
+            results = run_pcmd(self.hostlist_clients, cmd)
+            for result in results:
+                if result["exit_status"] != 0:
+                    error_list.append("Errors detected during cleanup cmd %s on node %s",
+                                      cmd, str(result["hosts"]))
+                    error_list.extend(super().stop_job_managers())
+        return error_list
 
     def write_single_fio_dataset(self, results):
         """Run Fio Benchmark.


### PR DESCRIPTION
The test is getting Timeout because of rebuild hung DAOS-8870. But test
does not get cleanup and has leftover fuse mount point.
So adding test cleanup procedure to kill the fuse and unmount the partition.

Test-tag-hw-large: pr ec_online_rebuild_fio ec_offline_rebuild_fio

Signed-off-by: Samir Raval <samir.raval@intel.com>