### PR TITLE
DAOS-8855 agent: Fix lo network device detection

### DIFF
--- a/src/control/cmd/daos_agent/fabric.go
+++ b/src/control/cmd/daos_agent/fabric.go
@@ -29,6 +29,7 @@ type FabricInterface struct {
 	Name        string
 	Domain      string
 	NetDevClass uint32
+	Providers   []string
 }
 
 func (f *FabricInterface) String() string {
@@ -39,10 +40,20 @@ func (f *FabricInterface) String() string {
 	return fmt.Sprintf("%s%s (%s)", f.Name, dom, netdetect.DevClassName(f.NetDevClass))
 }
 
-// DefaultFabricInterface is the one used if no devices are found on the system.
-var DefaultFabricInterface = &FabricInterface{
-	Name:   "lo",
-	Domain: "lo",
+// AddProvider adds a provider to the FabricInterface.
+func (f *FabricInterface) AddProvider(provider string) {
+	if f == nil || provider == "" {
+		return
+	}
+
+	for _, p := range f.Providers {
+		// Avoid adding duplicates
+		if p == provider {
+			return
+		}
+	}
+
+	f.Providers = append(f.Providers, provider)
 }
 
 // FabricDevClassManual is a wildcard netDevClass that indicates the device was
@@ -125,17 +136,12 @@ func (n *NUMAFabric) GetDevice(numaNode int, netDevClass uint32) (*FabricInterfa
 	n.mutex.Lock()
 	defer n.mutex.Unlock()
 
-	if n.getNumNUMANodes() == 0 {
-		n.log.Infof("No fabric interfaces found, using default interface %q", DefaultFabricInterface.Name)
-		return DefaultFabricInterface, nil
-	}
-
 	fi, err := n.getDeviceFromNUMA(numaNode, netDevClass)
 	if err == nil {
 		return fi, nil
 	}
 
-	fi, err = n.findOnRemoteNUMA(netDevClass)
+	fi, err = n.findOnAnyNUMA(netDevClass)
 	if err != nil {
 		return nil, err
 	}
@@ -143,6 +149,22 @@ func (n *NUMAFabric) GetDevice(numaNode int, netDevClass uint32) (*FabricInterfa
 	fiCopy := new(FabricInterface)
 	*fiCopy = *fi
 	return fiCopy, nil
+}
+
+// Find finds a specific fabric device by name.
+func (n *NUMAFabric) Find(name string) (*FabricInterface, error) {
+	if n == nil {
+		return nil, errors.New("nil NUMAFabric")
+	}
+
+	for _, devs := range n.numaMap {
+		for _, fi := range devs {
+			if fi.Name == name {
+				return fi, nil
+			}
+		}
+	}
+	return nil, fmt.Errorf("fabric interface %q not found", name)
 }
 
 func (n *NUMAFabric) getDeviceFromNUMA(numaNode int, netDevClass uint32) (*FabricInterface, error) {
@@ -201,7 +223,7 @@ func (n *NUMAFabric) getNextDevice(numaNode int) *FabricInterface {
 	return n.numaMap[numaNode][idx]
 }
 
-func (n *NUMAFabric) findOnRemoteNUMA(netDevClass uint32) (*FabricInterface, error) {
+func (n *NUMAFabric) findOnAnyNUMA(netDevClass uint32) (*FabricInterface, error) {
 	numNodes := n.getNumNUMANodes()
 	for i := 0; i < numNodes; i++ {
 		numa := (n.defaultNumaNode + i) % numNodes
@@ -255,13 +277,15 @@ func NUMAFabricFromScan(ctx context.Context, log logging.Logger, scan []*netdete
 	fabric := newNUMAFabric(log)
 
 	for _, fs := range scan {
-		if fs.DeviceName == "lo" {
+		if curIF, err := fabric.Find(fs.DeviceName); err == nil {
+			curIF.AddProvider(fs.Provider)
 			continue
 		}
 
 		newIF := &FabricInterface{
 			Name:        fs.DeviceName,
 			NetDevClass: fs.NetDevClass,
+			Providers:   []string{fs.Provider},
 		}
 
 		if getDevAlias != nil {

--- a/src/control/cmd/daos_agent/fabric_test.go
+++ b/src/control/cmd/daos_agent/fabric_test.go
@@ -19,6 +19,76 @@ import (
 	"github.com/daos-stack/daos/src/control/logging"
 )
 
+func TestAgent_FabricInterface_AddProvider(t *testing.T) {
+	for name, tc := range map[string]struct {
+		fi       *FabricInterface
+		provider string
+		expFI    *FabricInterface
+	}{
+		"nil": {
+			provider: "ofi+sockets",
+		},
+		"empty": {
+			fi: &FabricInterface{
+				Name:        "test",
+				NetDevClass: netdetect.Ether,
+			},
+			provider: "p1",
+			expFI: &FabricInterface{
+				Name:        "test",
+				NetDevClass: netdetect.Ether,
+				Providers:   []string{"p1"},
+			},
+		},
+		"add": {
+			fi: &FabricInterface{
+				Name:        "test",
+				NetDevClass: netdetect.Ether,
+				Providers:   []string{"p1", "p2"},
+			},
+			provider: "p3",
+			expFI: &FabricInterface{
+				Name:        "test",
+				NetDevClass: netdetect.Ether,
+				Providers:   []string{"p1", "p2", "p3"},
+			},
+		},
+		"empty provider string": {
+			fi: &FabricInterface{
+				Name:        "test",
+				NetDevClass: netdetect.Ether,
+				Providers:   []string{"p1", "p2"},
+			},
+			expFI: &FabricInterface{
+				Name:        "test",
+				NetDevClass: netdetect.Ether,
+				Providers:   []string{"p1", "p2"},
+			},
+		},
+		"duplicate provider string": {
+			fi: &FabricInterface{
+				Name:        "test",
+				NetDevClass: netdetect.Ether,
+				Providers:   []string{"p1", "p2"},
+			},
+			provider: "p1",
+			expFI: &FabricInterface{
+				Name:        "test",
+				NetDevClass: netdetect.Ether,
+				Providers:   []string{"p1", "p2"},
+			},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			tc.fi.AddProvider(tc.provider)
+
+			if diff := cmp.Diff(tc.expFI, tc.fi); diff != "" {
+				t.Fatalf("-want, +got:\n%s", diff)
+			}
+		})
+	}
+}
+
 func TestAgent_NewNUMAFabric(t *testing.T) {
 	log, buf := logging.NewTestLogger(t.Name())
 	defer common.ShowBufferOnFailure(t, buf)
@@ -179,8 +249,9 @@ func TestAgent_NUMAFabric_GetDevice(t *testing.T) {
 			expErr: errors.New("nil NUMAFabric"),
 		},
 		"empty": {
-			nf:         newNUMAFabric(nil),
-			expResults: []*FabricInterface{DefaultFabricInterface},
+			nf:          newNUMAFabric(nil),
+			netDevClass: netdetect.Loopback,
+			expErr:      errors.New("no suitable fabric interface"),
 		},
 		"type not found": {
 			nf: &NUMAFabric{
@@ -431,6 +502,76 @@ func TestAgent_NUMAFabric_GetDevice(t *testing.T) {
 	}
 }
 
+func TestAgent_NUMAFabric_Find(t *testing.T) {
+	for name, tc := range map[string]struct {
+		nf        *NUMAFabric
+		name      string
+		expResult *FabricInterface
+		expErr    error
+	}{
+		"nil": {
+			name:   "eth0",
+			expErr: errors.New("nil"),
+		},
+		"not found": {
+			nf: &NUMAFabric{
+				numaMap: map[int][]*FabricInterface{
+					0: {
+						{
+							Name:        "t1",
+							NetDevClass: netdetect.Ether,
+						},
+						{
+							Name:        "t2",
+							NetDevClass: netdetect.Ether,
+						},
+						{
+							Name:        "t3",
+							NetDevClass: netdetect.Ether,
+						},
+					},
+				},
+			},
+			name:   "t4",
+			expErr: errors.New("not found"),
+		},
+		"found": {
+			nf: &NUMAFabric{
+				numaMap: map[int][]*FabricInterface{
+					0: {
+						{
+							Name:        "t1",
+							NetDevClass: netdetect.Ether,
+						},
+						{
+							Name:        "t2",
+							NetDevClass: netdetect.Ether,
+						},
+						{
+							Name:        "t3",
+							NetDevClass: netdetect.Ether,
+						},
+					},
+				},
+			},
+			name: "t2",
+			expResult: &FabricInterface{
+				Name:        "t2",
+				NetDevClass: netdetect.Ether,
+			},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			result, err := tc.nf.Find(tc.name)
+
+			common.CmpErr(t, tc.expErr, err)
+			if diff := cmp.Diff(tc.expResult, result); diff != "" {
+				t.Fatalf("-want, +got:\n%s", diff)
+			}
+		})
+	}
+}
+
 func TestAgent_NUMAFabricFromScan(t *testing.T) {
 	for name, tc := range map[string]struct {
 		input               []*netdetect.FabricScan
@@ -442,7 +583,7 @@ func TestAgent_NUMAFabricFromScan(t *testing.T) {
 			expResult:           map[int][]*FabricInterface{},
 			possibleDefaultNUMA: []int{0},
 		},
-		"skip lo": {
+		"include lo": {
 			input: []*netdetect.FabricScan{
 				{
 					Provider:    "ofi+sockets",
@@ -451,9 +592,10 @@ func TestAgent_NUMAFabricFromScan(t *testing.T) {
 					NetDevClass: netdetect.Ether,
 				},
 				{
-					Provider:   "ofi+sockets",
-					DeviceName: "lo",
-					NUMANode:   1,
+					Provider:    "ofi+sockets",
+					DeviceName:  "lo",
+					NUMANode:    1,
+					NetDevClass: netdetect.Loopback,
 				},
 			},
 			expResult: map[int][]*FabricInterface{
@@ -461,6 +603,12 @@ func TestAgent_NUMAFabricFromScan(t *testing.T) {
 					{
 						Name:        "test0",
 						NetDevClass: netdetect.Ether,
+						Providers:   []string{"ofi+sockets"},
+					},
+					{
+						Name:        "lo",
+						NetDevClass: netdetect.Loopback,
+						Providers:   []string{"ofi+sockets"},
 					},
 				},
 			},
@@ -492,16 +640,19 @@ func TestAgent_NUMAFabricFromScan(t *testing.T) {
 					{
 						Name:        "test1",
 						NetDevClass: netdetect.Infiniband,
+						Providers:   []string{"ofi+verbs"},
 					},
 					{
 						Name:        "test2",
 						NetDevClass: netdetect.Ether,
+						Providers:   []string{"ofi+sockets"},
 					},
 				},
 				1: {
 					{
 						Name:        "test0",
 						NetDevClass: netdetect.Ether,
+						Providers:   []string{"ofi+sockets"},
 					},
 				},
 			},
@@ -537,11 +688,13 @@ func TestAgent_NUMAFabricFromScan(t *testing.T) {
 						Name:        "test1",
 						NetDevClass: netdetect.Infiniband,
 						Domain:      "test1_alias",
+						Providers:   []string{"ofi+verbs"},
 					},
 					{
 						Name:        "test2",
 						NetDevClass: netdetect.Ether,
 						Domain:      "test2_alias",
+						Providers:   []string{"ofi+sockets"},
 					},
 				},
 				2: {
@@ -549,10 +702,50 @@ func TestAgent_NUMAFabricFromScan(t *testing.T) {
 						Name:        "test0",
 						NetDevClass: netdetect.Ether,
 						Domain:      "test0_alias",
+						Providers:   []string{"ofi+sockets"},
 					},
 				},
 			},
 			possibleDefaultNUMA: []int{1, 2},
+		},
+		"multiple providers per device": {
+			input: []*netdetect.FabricScan{
+				{
+					Provider:    "ofi+sockets",
+					DeviceName:  "test0",
+					NUMANode:    1,
+					NetDevClass: netdetect.Ether,
+				},
+				{
+					Provider:    "ofi+verbs",
+					DeviceName:  "test1",
+					NUMANode:    0,
+					NetDevClass: netdetect.Infiniband,
+				},
+				{
+					Provider:    "ofi+sockets",
+					DeviceName:  "test1",
+					NUMANode:    0,
+					NetDevClass: netdetect.Infiniband,
+				},
+			},
+			expResult: map[int][]*FabricInterface{
+				0: {
+					{
+						Name:        "test1",
+						NetDevClass: netdetect.Infiniband,
+						Providers:   []string{"ofi+verbs", "ofi+sockets"},
+					},
+				},
+				1: {
+					{
+						Name:        "test0",
+						NetDevClass: netdetect.Ether,
+						Providers:   []string{"ofi+sockets"},
+					},
+				},
+			},
+			possibleDefaultNUMA: []int{0, 1},
 		},
 	} {
 		t.Run(name, func(t *testing.T) {

--- a/src/control/cmd/daos_agent/infocache_test.go
+++ b/src/control/cmd/daos_agent/infocache_test.go
@@ -216,9 +216,10 @@ func TestAgent_localFabricCache_CacheScan(t *testing.T) {
 					NetDevClass: netdetect.Ether,
 				},
 				{
-					Provider:   "ofi+sockets",
-					DeviceName: "lo",
-					NUMANode:   1,
+					Provider:    "ofi+sockets",
+					DeviceName:  "lo",
+					NUMANode:    1,
+					NetDevClass: netdetect.Loopback,
 				},
 				{
 					Provider:    "ofi+verbs",
@@ -240,16 +241,24 @@ func TestAgent_localFabricCache_CacheScan(t *testing.T) {
 						{
 							Name:        "test1",
 							NetDevClass: netdetect.Infiniband,
+							Providers:   []string{"ofi+verbs"},
 						},
 						{
 							Name:        "test2",
 							NetDevClass: netdetect.Ether,
+							Providers:   []string{"ofi+sockets"},
 						},
 					},
 					1: {
 						{
 							Name:        "test0",
 							NetDevClass: netdetect.Ether,
+							Providers:   []string{"ofi+sockets"},
+						},
+						{
+							Name:        "lo",
+							NetDevClass: netdetect.Loopback,
+							Providers:   []string{"ofi+sockets"},
 						},
 					},
 				},
@@ -290,11 +299,13 @@ func TestAgent_localFabricCache_CacheScan(t *testing.T) {
 							Name:        "test1",
 							NetDevClass: netdetect.Infiniband,
 							Domain:      "test1_alias",
+							Providers:   []string{"ofi+verbs"},
 						},
 						{
 							Name:        "test2",
 							NetDevClass: netdetect.Ether,
 							Domain:      "test2_alias",
+							Providers:   []string{"ofi+sockets"},
 						},
 					},
 					2: {
@@ -302,6 +313,7 @@ func TestAgent_localFabricCache_CacheScan(t *testing.T) {
 							Name:        "test0",
 							NetDevClass: netdetect.Ether,
 							Domain:      "test0_alias",
+							Providers:   []string{"ofi+sockets"},
 						},
 					},
 				},

--- a/src/control/lib/netdetect/netdetect.go
+++ b/src/control/lib/netdetect/netdetect.go
@@ -141,6 +141,7 @@ const (
 	IEEE1394   = 24
 	Eui64      = 27
 	Infiniband = 32
+	Loopback   = 772
 )
 
 // DeviceAffinity describes the essential details of a device and its NUMA affinity
@@ -1303,6 +1304,8 @@ func DevClassName(class uint32) string {
 		return "EUI64"
 	case Infiniband:
 		return "INFINIBAND"
+	case Loopback:
+		return "LOOPBACK"
 	default:
 		return "UNKNOWN"
 	}

--- a/utils/nlt_server.yaml
+++ b/utils/nlt_server.yaml
@@ -8,7 +8,7 @@ engines:
 -
   targets: 4
   nr_xs_helpers: 2
-  fabric_iface: eth0
+  fabric_iface: lo
   fabric_iface_port: 31416
   env_vars:
   - DAOS_MD_CAP=1024


### PR DESCRIPTION
  - Remove exceptions for loopback interface in network detection
    in daos_agent. Loopback is now treated like any other network
    interface.
  - Recognize loopback type in netdetect.
  - Update NLT config to test over loopback.

Co-authored-by: Ashley Pittman <ashley.m.pittman@intel.com>
Signed-off-by: Kris Jacque <kristin.jacque@intel.com>