### PR TITLE
DAOS-8975 sched: introduce sched_create_ult()

### DIFF
--- a/src/container/srv_container.c
+++ b/src/container/srv_container.c
@@ -1474,33 +1474,22 @@ static int
 cont_svc_ec_agg_leader_start(struct cont_svc *svc)
 {
 	struct sched_req_attr	attr;
-	ABT_thread		ec_eph_leader_ult = ABT_THREAD_NULL;
-	int			rc;
 
 	if (unlikely(ec_agg_disabled))
 		return 0;
 
 	D_INIT_LIST_HEAD(&svc->cs_ec_agg_list);
+	D_ASSERT(svc->cs_ec_leader_ephs_req == NULL);
 
-	rc = dss_ult_create(cont_agg_eph_leader_ult, svc, DSS_XS_SYS,
-			    0, 0, &ec_eph_leader_ult);
-	if (rc) {
-		D_ERROR(DF_UUID" Failed to create aggregation ULT. %d\n",
-			DP_UUID(svc->cs_pool_uuid), rc);
-		return rc;
-	}
-
-	D_ASSERT(ec_eph_leader_ult != ABT_THREAD_NULL);
 	sched_req_attr_init(&attr, SCHED_REQ_GC, &svc->cs_pool_uuid);
-	svc->cs_ec_leader_ephs_req = sched_req_get(&attr, ec_eph_leader_ult);
+	svc->cs_ec_leader_ephs_req = sched_create_ult(&attr, cont_agg_eph_leader_ult, svc, 0);
 	if (svc->cs_ec_leader_ephs_req == NULL) {
-		D_ERROR(DF_UUID"Failed to get req for ec eph query ULT\n",
+		D_ERROR(DF_UUID" Failed to create EC leader eph ULT.\n",
 			DP_UUID(svc->cs_pool_uuid));
-		ABT_thread_free(&ec_eph_leader_ult);
 		return -DER_NOMEM;
 	}
 
-	return rc;
+	return 0;
 }
 
 static void

--- a/src/include/daos_srv/daos_engine.h
+++ b/src/include/daos_srv/daos_engine.h
@@ -388,6 +388,21 @@ uint64_t sched_cur_seq(void);
  */
 int sched_exec_time(uint64_t *msecs, const char *ult_name);
 
+/**
+ * Create an ULT on the caller xstream and return the associated sched_request.
+ * Caller is responsible for freeing the sched_request by sched_req_put().
+ *
+ * \param[in]	attr		sched request attributes
+ * \param[in]	func		ULT function
+ * \param[in]	arg		ULT argument
+ * \param[in]	stack_size	ULT stack size
+ *
+ * \retval			associated shed_request on success, NULL on error.
+ */
+struct sched_request *
+sched_create_ult(struct sched_req_attr *attr, void (*func)(void *), void *arg,
+		 size_t stack_size);
+
 static inline bool
 dss_ult_exiting(struct sched_request *req)
 {

--- a/src/pool/srv_pool_scrub.c
+++ b/src/pool/srv_pool_scrub.c
@@ -271,8 +271,6 @@ ds_start_scrubbing_ult(struct ds_pool_child *child)
 {
 	struct dss_module_info	*dmi = dss_get_module_info();
 	struct sched_req_attr	 attr;
-	ABT_thread		 thread = ABT_THREAD_NULL;
-	int			 rc;
 
 	D_ASSERT(child != NULL);
 	D_ASSERT(child->spc_scrubbing_req == NULL);
@@ -292,22 +290,12 @@ ds_start_scrubbing_ult(struct ds_pool_child *child)
 	/* There will be several levels iteration, such as pool, container, object, and lower,
 	 * and so on. Let's use DSS_DEEP_STACK_SZ to avoid ULT overflow.
 	 */
-	rc = dss_ult_create(scrubbing_ult, child, DSS_XS_SELF, 0, DSS_DEEP_STACK_SZ, &thread);
-	if (rc) {
-		D_ERROR(DF_UUID"[%d]: Failed to create Scrubbing ULT. %d\n",
-			DP_UUID(child->spc_uuid), dmi->dmi_tgt_id, rc);
-		return rc;
-	}
-
-	D_ASSERT(thread != ABT_THREAD_NULL);
-
 	sched_req_attr_init(&attr, SCHED_REQ_SCRUB, &child->spc_uuid);
-	attr.sra_flags = SCHED_REQ_FL_NO_DELAY;
-	child->spc_scrubbing_req = sched_req_get(&attr, thread);
+	child->spc_scrubbing_req = sched_create_ult(&attr, scrubbing_ult, child,
+						    DSS_DEEP_STACK_SZ);
 	if (child->spc_scrubbing_req == NULL) {
-		D_CRIT(DF_UUID"[%d]: Failed to get req for Scrubbing ULT\n",
-		       DP_UUID(child->spc_uuid), dmi->dmi_tgt_id);
-		ABT_thread_free(&thread);
+		D_ERROR(DF_UUID"[%d]: Failed to create Scrubbing ULT.n",
+			DP_UUID(child->spc_uuid), dmi->dmi_tgt_id);
 		return -DER_NOMEM;
 	}
 

--- a/src/pool/srv_target.c
+++ b/src/pool/srv_target.c
@@ -117,27 +117,17 @@ start_gc_ult(struct ds_pool_child *child)
 {
 	struct dss_module_info	*dmi = dss_get_module_info();
 	struct sched_req_attr	 attr;
-	ABT_thread		 gc = ABT_THREAD_NULL;
-	int			 rc;
 
 	D_ASSERT(child != NULL);
 	D_ASSERT(child->spc_gc_req == NULL);
 
-	rc = dss_ult_create(gc_ult, child, DSS_XS_SELF, 0, 0, &gc);
-	if (rc) {
-		D_ERROR(DF_UUID"[%d]: Failed to create GC ULT. %d\n",
-			DP_UUID(child->spc_uuid), dmi->dmi_tgt_id, rc);
-		return rc;
-	}
-
-	D_ASSERT(gc != ABT_THREAD_NULL);
 	sched_req_attr_init(&attr, SCHED_REQ_GC, &child->spc_uuid);
 	attr.sra_flags = SCHED_REQ_FL_NO_DELAY;
-	child->spc_gc_req = sched_req_get(&attr, gc);
+
+	child->spc_gc_req = sched_create_ult(&attr, gc_ult, child, 0);
 	if (child->spc_gc_req == NULL) {
-		D_CRIT(DF_UUID"[%d]: Failed to get req for GC ULT\n",
-		       DP_UUID(child->spc_uuid), dmi->dmi_tgt_id);
-		ABT_thread_free(&gc);
+		D_ERROR(DF_UUID"[%d]: Failed to create GC ULT.\n",
+			DP_UUID(child->spc_uuid), dmi->dmi_tgt_id);
 		return -DER_NOMEM;
 	}
 
@@ -577,31 +567,21 @@ static int
 ds_pool_start_ec_eph_query_ult(struct ds_pool *pool)
 {
 	struct sched_req_attr	attr;
-	ABT_thread		ec_eph_query_ult = ABT_THREAD_NULL;
-	int			rc;
 
 	if (unlikely(ec_agg_disabled))
 		return 0;
 
-	rc = dss_ult_create(tgt_ec_eph_query_ult, pool, DSS_XS_SYS, 0,
-			    DSS_DEEP_STACK_SZ, &ec_eph_query_ult);
-	if (rc != 0) {
-		D_ERROR(DF_UUID": failed create ec eph equery ult: %d\n",
-			DP_UUID(pool->sp_uuid), rc);
-		return rc;
-	}
-
-	D_ASSERT(ec_eph_query_ult != ABT_THREAD_NULL);
+	D_ASSERT(pool->sp_ec_ephs_req == NULL);
 	sched_req_attr_init(&attr, SCHED_REQ_GC, &pool->sp_uuid);
-	pool->sp_ec_ephs_req = sched_req_get(&attr, ec_eph_query_ult);
+	pool->sp_ec_ephs_req = sched_create_ult(&attr, tgt_ec_eph_query_ult, pool,
+						DSS_DEEP_STACK_SZ);
 	if (pool->sp_ec_ephs_req == NULL) {
-		D_ERROR(DF_UUID": Failed to get req for ec eph query ULT\n",
+		D_ERROR(DF_UUID": failed create ec eph equery ult.\n",
 			DP_UUID(pool->sp_uuid));
-		ABT_thread_free(&ec_eph_query_ult);
 		return -DER_NOMEM;
 	}
 
-	return rc;
+	return 0;
 }
 
 static void


### PR DESCRIPTION
Server component used to create an externally tracked ULT in following
code snippet:
{
    dss_create_ult(... , &thread);
    req = sched_req_get(attr, thread);
    if (req == NULL) {
        ABT_thread_free(thread);
        return error;
    }
}

The problem is that when sched_req_get() failed, there will be no way
to inform the 'thread' to abort, so the ABT_thread_free() on error
cleanup path would be blocked forever. (sched_get_req() usually won't
fail because most 'sched_request' are pre-allocated).

This patch introduced sched_create_ult() to solve above issue.

Signed-off-by: Niu Yawei <yawei.niu@intel.com>