### PR TITLE
DAOS-9017 dfuse: Add checking for fetching handles for non-files.

### DIFF
--- a/src/client/dfuse/il/int_posix.c
+++ b/src/client/dfuse/il/int_posix.c
@@ -792,7 +792,9 @@ get_file:
 
 	/* Now open the file object to allow read/write */
 	rc = fetch_dfs_obj_handle(fd, entry);
-	if (rc)
+	if (rc == EISDIR)
+		D_GOTO(err, rc);
+	else if (rc)
 		D_GOTO(shrink, rc);
 
 	rc = vector_set(&fd_table, fd, entry);

--- a/src/client/dfuse/ops/ioctl.c
+++ b/src/client/dfuse/ops/ioctl.c
@@ -308,6 +308,9 @@ void dfuse_cb_ioctl(fuse_req_t req, fuse_ino_t ino, unsigned int cmd, void *arg,
 	 * need the correct container handle to be able to use them.
 	 */
 	if (cmd == DFUSE_IOCTL_IL_DSIZE) {
+		if (S_ISDIR(oh->doh_ie->ie_stat.st_mode))
+			D_GOTO(out_err, rc = EISDIR);
+
 		if (out_bufsz < sizeof(struct dfuse_hsd_reply))
 			D_GOTO(out_err, rc = EIO);
 		handle_dsize_ioctl(oh, req);


### PR DESCRIPTION
If a non-file is opened by the IL then we currently get an error
in dfuse from the ioctl, and a error-path is taken in the IL
that will cause it to disconnect from the container.

After this patch we take the following behaviour:
When a directory is opened the container/pool are opened and
dfs is mounted, however when it comes to opening the dfs object
the ioctl code in dfuse will return with E_ISDIR rather than
EINVAL and the IL itself will spot this and not attempt to
release resources - so it will keep dfs mounted for any future
access.

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>
