### PR TITLE
DAOS-8910 debug: daos memory counter

### DIFF
--- a/src/bio/bio_buffer.c
+++ b/src/bio/bio_buffer.c
@@ -33,7 +33,7 @@ dma_alloc_chunk(unsigned int cnt)
 	int rc;
 
 	D_ASSERT(bytes > 0);
-	D_ALLOC_PTR(chunk);
+	DM_ALLOC_PTR(M_BIO, chunk);
 	if (chunk == NULL) {
 		D_ERROR("Failed to allocate chunk\n");
 		return NULL;
@@ -119,7 +119,7 @@ dma_buffer_create(unsigned int init_cnt)
 	struct bio_dma_buffer *buf;
 	int rc;
 
-	D_ALLOC_PTR(buf);
+	DM_ALLOC_PTR(M_BIO, buf);
 	if (buf == NULL)
 		return NULL;
 
@@ -181,7 +181,7 @@ bio_iod_alloc(struct bio_io_context *ctxt, unsigned int sgl_cnt,
 	D_ASSERT(ctxt != NULL && ctxt->bic_umem != NULL);
 	D_ASSERT(sgl_cnt != 0);
 
-	D_ALLOC(biod, offsetof(struct bio_desc, bd_sgls[sgl_cnt]));
+	DM_ALLOC(M_BIO, biod, offsetof(struct bio_desc, bd_sgls[sgl_cnt]));
 	if (biod == NULL)
 		return NULL;
 
@@ -505,7 +505,7 @@ iod_add_chunk(struct bio_desc *biod, struct bio_dma_chunk *chk)
 		int size = sizeof(struct bio_dma_chunk *);
 		unsigned new_cnt = cnt + 10;
 
-		D_ALLOC_ARRAY(chunks, new_cnt);
+		DM_ALLOC_ARRAY(M_BIO, chunks, new_cnt);
 		if (chunks == NULL)
 			return -DER_NOMEM;
 
@@ -540,7 +540,7 @@ iod_add_region(struct bio_desc *biod, struct bio_dma_chunk *chk,
 		int size = sizeof(struct bio_rsrvd_region);
 		unsigned new_cnt = cnt + 20;
 
-		D_ALLOC_ARRAY(rgs, new_cnt);
+		DM_ALLOC_ARRAY(M_BIO, rgs, new_cnt);
 		if (rgs == NULL)
 			return -DER_NOMEM;
 
@@ -862,7 +862,7 @@ rw_completion(void *cb_arg, int err)
 
 	/* Report all NVMe IO errors */
 	if (err != 0) {
-		D_ALLOC_PTR(mem);
+		DM_ALLOC_PTR(M_BIO, mem);
 		if (mem == NULL)
 			goto skip_media_error;
 		mem->mem_err_type = (biod->bd_type == BIO_IOD_TYPE_UPDATE) ?

--- a/src/bio/bio_bulk.c
+++ b/src/bio/bio_bulk.c
@@ -326,7 +326,7 @@ bulk_chunk_populate(struct bio_dma_chunk *chk, struct bio_bulk_group *bbg,
 	int			 i, tot_bulks, rc;
 
 	if (chk->bdc_bulks == NULL) {
-		D_ALLOC_ARRAY(chk->bdc_bulks, bio_chk_sz);
+		DM_ALLOC_ARRAY(M_BIO, chk->bdc_bulks, bio_chk_sz);
 		if (chk->bdc_bulks == NULL)
 			return -DER_NOMEM;
 
@@ -572,7 +572,7 @@ bulk_iod_init(struct bio_desc *biod)
 		max_bulks += bsgl->bs_nr_out;
 	}
 
-	D_ALLOC_ARRAY(biod->bd_bulk_hdls, max_bulks);
+	DM_ALLOC_ARRAY(M_BIO, biod->bd_bulk_hdls, max_bulks);
 	if (biod->bd_bulk_hdls == NULL) {
 		D_ERROR("Failed to allocate bulk handle array\n");
 		return -DER_NOMEM;
@@ -744,11 +744,11 @@ bulk_cache_create(struct bio_dma_buffer *bdb)
 	D_ASSERT(bbc->bbc_grps == NULL);
 	D_INIT_LIST_HEAD(&bbc->bbc_grp_lru);
 
-	D_ALLOC_ARRAY(bbc->bbc_grps, BIO_BULK_GRPS_MAX);
+	DM_ALLOC_ARRAY(M_BIO, bbc->bbc_grps, BIO_BULK_GRPS_MAX);
 	if (bbc->bbc_grps == NULL)
 		return -DER_NOMEM;
 
-	D_ALLOC_ARRAY(bbc->bbc_sorted, BIO_BULK_GRPS_MAX);
+	DM_ALLOC_ARRAY(M_BIO, bbc->bbc_sorted, BIO_BULK_GRPS_MAX);
 	if (bbc->bbc_sorted == NULL) {
 		D_FREE(bbc->bbc_grps);
 		bbc->bbc_grps = NULL;

--- a/src/cart/crt_corpc.c
+++ b/src/cart/crt_corpc.c
@@ -25,7 +25,7 @@ crt_corpc_info_init(struct crt_rpc_priv *rpc_priv,
 	D_ASSERT(rpc_priv != NULL);
 	D_ASSERT(grp_priv != NULL);
 
-	D_ALLOC_PTR(co_info);
+	DM_ALLOC_PTR(M_CRT_RPC, co_info);
 	if (co_info == NULL)
 		D_GOTO(out, rc = -DER_NOMEM);
 
@@ -215,7 +215,7 @@ crt_corpc_free_chained_bulk(crt_bulk_t bulk_hdl)
 		D_ERROR("bad zero seg_num.\n");
 		D_GOTO(out, rc = -DER_PROTO);
 	}
-	D_ALLOC_ARRAY(iovs, seg_num);
+	DM_ALLOC_ARRAY(M_CRT, iovs, seg_num);
 	if (iovs == NULL)
 		D_GOTO(out, rc = -DER_NOMEM);
 
@@ -273,7 +273,7 @@ crt_corpc_common_hdlr(struct crt_rpc_priv *rpc_priv)
 			D_GOTO(out, rc);
 		}
 
-		D_ALLOC(bulk_iov.iov_buf, bulk_len);
+		DM_ALLOC(M_CRT_RPC, bulk_iov.iov_buf, bulk_len);
 		if (bulk_iov.iov_buf == NULL)
 			D_GOTO(out, rc = -DER_NOMEM);
 		bulk_iov.iov_buf_len = bulk_len;

--- a/src/cart/crt_group.c
+++ b/src/cart/crt_group.c
@@ -294,7 +294,7 @@ grp_li_uri_set(struct crt_lookup_item *li, int tag, const char *uri)
 	rlink = d_hash_rec_find(&grp_priv->gp_uri_lookup_cache,
 				(void *)&rank, sizeof(rank));
 	if (rlink == NULL) {
-		D_ALLOC_PTR(ui);
+		DM_ALLOC_PTR(M_CRT, ui);
 		if (!ui)
 			D_GOTO(exit, rc = -DER_NOMEM);
 
@@ -434,7 +434,7 @@ crt_grp_lc_create(struct crt_grp_priv *grp_priv)
 		D_GOTO(out, rc = -DER_NO_PERM);
 	}
 
-	D_ALLOC_ARRAY(htables, CRT_SRV_CONTEXT_NUM);
+	DM_ALLOC_ARRAY(M_CRT, htables, CRT_SRV_CONTEXT_NUM);
 	if (htables == NULL)
 		D_GOTO(out, rc = -DER_NOMEM);
 
@@ -562,7 +562,7 @@ grp_lc_uri_insert_internal_locked(struct crt_grp_priv *grp_priv,
 				(void *)&rank, sizeof(rank));
 	if (rlink == NULL) {
 		/* target rank not in cache */
-		D_ALLOC_PTR(li);
+		DM_ALLOC_PTR(M_CRT, li);
 		if (li == NULL)
 			D_GOTO(out, rc = -DER_NOMEM);
 
@@ -993,7 +993,7 @@ crt_grp_priv_create(struct crt_grp_priv **grp_priv_created,
 	D_ASSERT(grp_id != NULL && strlen(grp_id) > 0 &&
 		 strlen(grp_id) < CRT_GROUP_ID_MAX_LEN);
 
-	D_ALLOC_PTR(grp_priv);
+	DM_ALLOC_PTR(M_CRT, grp_priv);
 	if (grp_priv == NULL)
 		D_GOTO(out, rc = -DER_NOMEM);
 
@@ -1652,7 +1652,7 @@ crt_grp_init(crt_group_id_t grpid)
 	D_ASSERT(crt_gdata.cg_grp_inited == 0);
 	D_ASSERT(crt_gdata.cg_grp == NULL);
 
-	D_ALLOC_PTR(grp_gdata);
+	DM_ALLOC_PTR(M_CRT, grp_gdata);
 	if (grp_gdata == NULL)
 		D_GOTO(out, rc = -DER_NOMEM);
 
@@ -2015,7 +2015,7 @@ crt_grp_config_psr_load(struct crt_grp_priv *grp_priv, d_rank_t psr_rank)
 		D_GOTO(out, rc = d_errno2der(errno));
 	}
 
-	D_ALLOC(grpname, CRT_GROUP_ID_MAX_LEN + 1);
+	DM_ALLOC(M_CRT, grpname, CRT_GROUP_ID_MAX_LEN + 1);
 	if (grpname == NULL)
 		D_GOTO(out, rc = -DER_NOMEM);
 
@@ -2048,7 +2048,7 @@ crt_grp_config_psr_load(struct crt_grp_priv *grp_priv, d_rank_t psr_rank)
 		D_GOTO(out, rc = d_errno2der(errno));
 	}
 
-	D_ALLOC(addr_str, CRT_ADDR_STR_MAX_LEN + 1);
+	DM_ALLOC(M_CRT, addr_str, CRT_ADDR_STR_MAX_LEN + 1);
 	if (addr_str == NULL)
 		D_GOTO(out, rc = -DER_NOMEM);
 
@@ -2148,7 +2148,7 @@ crt_register_event_cb(crt_event_cb func, void *args)
 	crt_plugin_gdata.cpg_event_cbs_old = cbs_event;
 	cbs_size += CRT_CALLBACKS_NUM;
 
-	D_ALLOC_ARRAY(cbs_event, cbs_size);
+	DM_ALLOC_ARRAY(M_CRT, cbs_event, cbs_size);
 	if (cbs_event == NULL) {
 		crt_plugin_gdata.cpg_event_cbs_old = NULL;
 		D_GOTO(out_unlock, rc = -DER_NOMEM);
@@ -2262,7 +2262,7 @@ grp_add_free_index(d_list_t *list, int index, bool tail)
 {
 	struct free_index *free_index;
 
-	D_ALLOC_PTR(free_index);
+	DM_ALLOC_PTR(M_CRT, free_index);
 	if (free_index == NULL)
 		return -DER_NOMEM;
 
@@ -2862,7 +2862,7 @@ crt_group_secondary_create(crt_group_id_t grp_name, crt_group_t *primary_grp,
 	}
 
 	/* Record secondary group in the primary group */
-	D_ALLOC_PTR(entry);
+	DM_ALLOC_PTR(M_CRT, entry);
 	if (entry == NULL)
 		D_GOTO(out, rc = -DER_NOMEM);
 
@@ -2956,7 +2956,7 @@ crt_rank_mapping_init(d_rank_t key, d_rank_t value)
 {
 	struct crt_rank_mapping *rm;
 
-	D_ALLOC_PTR(rm);
+	DM_ALLOC_PTR(M_CRT, rm);
 	if (rm == NULL)
 		goto out;
 
@@ -3129,7 +3129,7 @@ crt_group_mod_get(d_rank_list_t *grp_membs, d_rank_list_t *mod_membs,
 	}
 
 	/* Array will have at most 'mod_membs' elements */
-	D_ALLOC_ARRAY(idx_to_add, mod_membs->rl_nr);
+	DM_ALLOC_ARRAY(M_CRT, idx_to_add, mod_membs->rl_nr);
 	if (!idx_to_add) {
 		D_GOTO(cleanup, rc = -DER_NOMEM);
 	}

--- a/src/cart/crt_hg.c
+++ b/src/cart/crt_hg.c
@@ -80,7 +80,7 @@ crt_hg_pool_enable(struct crt_hg_context *hg_ctx, int32_t max_num,
 	D_SPIN_UNLOCK(&hg_pool->chp_lock);
 
 	while (prepost) {
-		D_ALLOC_PTR(hdl);
+		DM_ALLOC_PTR(M_CRT, hdl);
 		if (hdl == NULL) {
 			rc = -DER_NOMEM;
 			break;
@@ -224,7 +224,7 @@ crt_hg_pool_put(struct crt_rpc_priv *rpc_priv)
 	D_ASSERT(rpc_priv->crp_hg_hdl != HG_HANDLE_NULL);
 
 	if (rpc_priv->crp_hdl_reuse == NULL) {
-		D_ALLOC_PTR(hdl);
+		DM_ALLOC_PTR(M_CRT, hdl);
 		if (hdl == NULL)
 			D_GOTO(out, 0);
 		D_INIT_LIST_HEAD(&hdl->chh_link);
@@ -807,7 +807,7 @@ crt_rpc_handler_common(hg_handle_t hg_hdl)
 	}
 	D_ASSERT(opc_info->coi_opc == opc);
 
-	D_ALLOC(rpc_priv, opc_info->coi_rpc_size);
+	DM_ALLOC(M_CRT, rpc_priv, opc_info->coi_rpc_size);
 	if (unlikely(rpc_priv == NULL)) {
 		crt_hg_reply_error_send(&rpc_tmp, -DER_DOS);
 		crt_hg_unpack_cleanup(proc);
@@ -1341,7 +1341,7 @@ crt_hg_bulk_create(struct crt_hg_context *hg_ctx, d_sg_list_t *sgl,
 		buf_sizes = buf_sizes_stack;
 	} else {
 		allocate = true;
-		D_ALLOC_ARRAY(buf_sizes, sgl->sg_nr);
+		DM_ALLOC_ARRAY(M_CRT, buf_sizes, sgl->sg_nr);
 		if (buf_sizes == NULL)
 			D_GOTO(out, rc = -DER_NOMEM);
 	}
@@ -1352,7 +1352,7 @@ crt_hg_bulk_create(struct crt_hg_context *hg_ctx, d_sg_list_t *sgl,
 		buf_ptrs = NULL;
 	} else {
 		if (allocate) {
-			D_ALLOC_ARRAY(buf_ptrs, sgl->sg_nr);
+			DM_ALLOC_ARRAY(M_CRT, buf_ptrs, sgl->sg_nr);
 			if (buf_ptrs == NULL)
 				D_GOTO(out, rc = -DER_NOMEM);
 		} else {
@@ -1433,11 +1433,11 @@ crt_hg_bulk_access(crt_bulk_t bulk_hdl, d_sg_list_t *sgl)
 		buf_sizes = buf_sizes_stack;
 		buf_ptrs = buf_ptrs_stack;
 	} else {
-		D_ALLOC_ARRAY(buf_sizes, bulk_sgnum);
+		DM_ALLOC_ARRAY(M_CRT, buf_sizes, bulk_sgnum);
 		if (buf_sizes == NULL)
 			D_GOTO(out, rc = -DER_NOMEM);
 
-		D_ALLOC_ARRAY(buf_ptrs, bulk_sgnum);
+		DM_ALLOC_ARRAY(M_CRT, buf_ptrs, bulk_sgnum);
 		if (buf_ptrs == NULL) {
 			D_FREE(buf_sizes);
 			D_GOTO(out, rc = -DER_NOMEM);
@@ -1551,10 +1551,10 @@ crt_hg_bulk_transfer(struct crt_bulk_desc *bulk_desc, crt_bulk_cb_t complete_cb,
 	hg_ctx = &ctx->cc_hg_ctx;
 	D_ASSERT(hg_ctx != NULL && hg_ctx->chc_bulkctx != NULL);
 
-	D_ALLOC_PTR(bulk_cbinfo);
+	DM_ALLOC_PTR(M_CRT, bulk_cbinfo);
 	if (bulk_cbinfo == NULL)
 		D_GOTO(out, rc = -DER_NOMEM);
-	D_ALLOC_PTR(bulk_desc_dup);
+	DM_ALLOC_PTR(M_CRT, bulk_desc_dup);
 	if (bulk_desc_dup == NULL) {
 		D_FREE(bulk_cbinfo);
 		D_GOTO(out, rc = -DER_NOMEM);

--- a/src/cart/crt_iv.c
+++ b/src/cart/crt_iv.c
@@ -272,7 +272,7 @@ crt_ivf_key_in_progress_set(struct crt_ivns_internal *ivns,
 	struct ivf_key_in_progress	*entry;
 	int				rc;
 
-	D_ALLOC(entry, offsetof(struct ivf_key_in_progress,
+	DM_ALLOC(M_CRT_IV, entry, offsetof(struct ivf_key_in_progress,
 				payload[0]) + key->iov_buf_len);
 	if (entry == NULL)
 		return NULL;
@@ -336,7 +336,7 @@ crt_ivf_pending_request_add(struct crt_ivns_internal *ivns_internal,
 {
 	struct pending_fetch	*pending_fetch;
 
-	D_ALLOC_PTR(pending_fetch);
+	DM_ALLOC_PTR(M_CRT_IV, pending_fetch);
 	if (pending_fetch == NULL)
 		return -DER_NOMEM;
 
@@ -647,7 +647,7 @@ crt_ivns_internal_create(crt_context_t crt_ctx, struct crt_grp_priv *grp_priv,
 	struct crt_ivns_id		*internal_ivns_id;
 	int				rc;
 
-	D_ALLOC_PTR(ivns_internal);
+	DM_ALLOC_PTR(M_CRT_IV, ivns_internal);
 	if (ivns_internal == NULL)
 		D_GOTO(exit, 0);
 
@@ -666,7 +666,7 @@ crt_ivns_internal_create(crt_context_t crt_ctx, struct crt_grp_priv *grp_priv,
 
 	ivns_internal->cii_ref_count = 1;
 
-	D_ALLOC_ARRAY(ivns_internal->cii_iv_classes, num_class);
+	DM_ALLOC_ARRAY(M_CRT_IV, ivns_internal->cii_iv_classes, num_class);
 	if (ivns_internal->cii_iv_classes == NULL) {
 		D_MUTEX_DESTROY(&ivns_internal->cii_lock);
 		D_SPIN_DESTROY(&ivns_internal->cii_ref_lock);
@@ -997,7 +997,7 @@ crt_ivf_bulk_transfer(struct crt_ivns_internal *ivns_internal,
 	bulk_desc.bd_local_off = 0;
 	bulk_desc.bd_len = size;
 
-	D_ALLOC_PTR(cb_info);
+	DM_ALLOC_PTR(M_CRT_IV, cb_info);
 	if (cb_info == NULL)
 		D_GOTO(cleanup, rc = -DER_NOMEM);
 
@@ -1425,7 +1425,7 @@ crt_hdlr_iv_fetch_aux(void *arg)
 			D_GOTO(send_error, rc = -DER_GRPVER);
 		}
 
-		D_ALLOC_PTR(cb_info);
+		DM_ALLOC_PTR(M_CRT_IV, cb_info);
 		if (cb_info == NULL)
 			D_GOTO(send_error, rc = -DER_NOMEM);
 
@@ -1657,7 +1657,7 @@ crt_iv_fetch(crt_iv_namespace_t ivns, uint32_t class_id,
 	}
 
 	/* Allocate memory pointer for scatter/gather list */
-	D_ALLOC_PTR(iv_value);
+	DM_ALLOC_PTR(M_CRT_IV, iv_value);
 	if (iv_value == NULL)
 		D_GOTO(exit, rc = -DER_NOMEM);
 
@@ -1731,7 +1731,7 @@ crt_iv_fetch(crt_iv_namespace_t ivns, uint32_t class_id,
 
 	IV_DBG(iv_key, "root=%d next_parent=%d\n", root_rank, next_node);
 
-	D_ALLOC_PTR(cb_info);
+	DM_ALLOC_PTR(M_CRT_IV, cb_info);
 	if (cb_info == NULL)
 		D_GOTO(exit, rc = -DER_NOMEM);
 
@@ -1865,7 +1865,7 @@ crt_hdlr_iv_sync_aux(void *arg)
 
 		need_put = true;
 
-		D_ALLOC_ARRAY(tmp_iovs, iv_value.sg_nr);
+		DM_ALLOC_ARRAY(M_CRT_IV, tmp_iovs, iv_value.sg_nr);
 		if (tmp_iovs == NULL) {
 			D_ERROR("Failed to allocate temporary iovs\n");
 			D_GOTO(exit, rc = -DER_NOMEM);
@@ -2053,7 +2053,7 @@ call_pre_sync_cb(struct crt_ivns_internal *ivns_internal,
 	need_put = true;
 
 	if (rpc_req->cr_co_bulk_hdl != CRT_BULK_NULL) {
-		D_ALLOC_ARRAY(tmp_iovs, iv_value.sg_nr);
+		DM_ALLOC_ARRAY(M_CRT_IV, tmp_iovs, iv_value.sg_nr);
 		if (tmp_iovs == NULL) {
 			D_ERROR("Failed to allocate temporary iovs\n");
 			D_GOTO(exit, rc);
@@ -2290,7 +2290,7 @@ crt_ivsync_rpc_issue(struct crt_ivns_internal *ivns_internal, uint32_t class_id,
 	input = crt_req_get(corpc_req);
 	D_ASSERT(input != NULL);
 
-	D_ALLOC_PTR(iv_sync_cb);
+	DM_ALLOC_PTR(M_CRT_IV, iv_sync_cb);
 	if (iv_sync_cb == NULL) {
 		/* Avoid checkpatch warning */
 		D_GOTO(exit, rc = -DER_NOMEM);
@@ -2324,7 +2324,7 @@ crt_ivsync_rpc_issue(struct crt_ivns_internal *ivns_internal, uint32_t class_id,
 		iv_sync_cb->isc_class_id = class_id;
 
 		/* Copy iv_key over as it will get destroyed after this call */
-		D_ALLOC(iv_sync_cb->isc_iv_key.iov_buf, iv_key->iov_buf_len);
+		DM_ALLOC(M_CRT_IV, iv_sync_cb->isc_iv_key.iov_buf, iv_key->iov_buf_len);
 		if (iv_sync_cb->isc_iv_key.iov_buf == NULL) {
 			/* Avoid checkpatch warning */
 			D_GOTO(exit, rc = -DER_NOMEM);
@@ -2750,7 +2750,7 @@ handle_response_cb(const struct crt_cb_info *cb_info)
 		int rc;
 		struct crt_cb_info *info;
 
-		D_ALLOC_PTR(info);
+		DM_ALLOC_PTR(M_CRT_IV, info);
 		if (info == NULL) {
 			D_WARN("allocate fails, do cb directly\n");
 			goto callback;
@@ -2826,7 +2826,7 @@ bulk_update_transfer_done_aux(const struct crt_bulk_cb_info *info)
 
 	sync_type = input->ivu_sync_type.iov_buf;
 
-	D_ALLOC_PTR(update_cb_info);
+	DM_ALLOC_PTR(M_CRT_IV, update_cb_info);
 	if (update_cb_info == NULL)
 		D_GOTO(send_error, rc = -DER_NOMEM);
 
@@ -2969,11 +2969,11 @@ bulk_update_transfer_done(const struct crt_bulk_cb_info *info)
 	}
 
 	if (iv_ops->ivo_pre_update != NULL) {
-		D_ALLOC_PTR(info_dup);
+		DM_ALLOC_PTR(M_CRT_IV, info_dup);
 		if (info_dup == NULL)
 			D_GOTO(send_error, rc = -DER_NOMEM);
 
-		D_ALLOC_PTR(info_dup->bci_bulk_desc);
+		DM_ALLOC_PTR(M_CRT_IV, info_dup->bci_bulk_desc);
 		if (info_dup->bci_bulk_desc == NULL) {
 			D_FREE(info_dup);
 			D_GOTO(send_error, rc = -DER_NOMEM);
@@ -3110,7 +3110,7 @@ crt_hdlr_iv_update(crt_rpc_t *rpc_req)
 				D_GOTO(send_error, rc = -DER_GRPVER);
 			}
 
-			D_ALLOC_PTR(update_cb_info);
+			DM_ALLOC_PTR(M_CRT_IV, update_cb_info);
 			if (update_cb_info == NULL)
 				D_GOTO(send_error, rc = -DER_NOMEM);
 
@@ -3178,7 +3178,7 @@ crt_hdlr_iv_update(crt_rpc_t *rpc_req)
 	bulk_desc.bd_local_off = 0;
 	bulk_desc.bd_len = size;
 
-	D_ALLOC_PTR(cb_info);
+	DM_ALLOC_PTR(M_CRT_IV, cb_info);
 	if (cb_info == NULL) {
 		RPC_PUB_DECREF(bulk_desc.bd_rpc);
 		crt_bulk_free(local_bulk_handle);
@@ -3356,7 +3356,7 @@ crt_iv_update_internal(crt_iv_namespace_t ivns, uint32_t class_id,
 
 		/* comp_cb is only for sync update for now */
 		D_ASSERT(sync_type.ivs_comp_cb == NULL);
-		D_ALLOC_PTR(cb_info);
+		DM_ALLOC_PTR(M_CRT_IV, cb_info);
 		if (cb_info == NULL)
 			D_GOTO(put, rc = -DER_NOMEM);
 

--- a/src/cart/crt_rpc.c
+++ b/src/cart/crt_rpc.c
@@ -435,9 +435,9 @@ crt_rpc_priv_alloc(crt_opcode_t opc, struct crt_rpc_priv **priv_allocated,
 	}
 
 	if (forward)
-		D_ALLOC(rpc_priv, opc_info->coi_input_offset);
+		DM_ALLOC(M_CRT_RPC, rpc_priv, opc_info->coi_input_offset);
 	else
-		D_ALLOC(rpc_priv, opc_info->coi_rpc_size);
+		DM_ALLOC(M_CRT_RPC, rpc_priv, opc_info->coi_rpc_size);
 	if (rpc_priv == NULL)
 		D_GOTO(out, rc = -DER_NOMEM);
 

--- a/src/cart/crt_swim.c
+++ b/src/cart/crt_swim.c
@@ -1092,7 +1092,7 @@ int crt_swim_rank_add(struct crt_grp_priv *grp_priv, d_rank_t rank)
 		D_GOTO(out, rc = -DER_INVAL);
 	}
 
-	D_ALLOC_PTR(cst);
+	DM_ALLOC_PTR(M_CRT, cst);
 	if (cst == NULL)
 		D_GOTO(out, rc = -DER_NOMEM);
 
@@ -1120,7 +1120,7 @@ int crt_swim_rank_add(struct crt_grp_priv *grp_priv, d_rank_t rank)
 
 	if (rank != self) {
 		if (cst == NULL) {
-			D_ALLOC_PTR(cst);
+			DM_ALLOC_PTR(M_CRT, cst);
 			if (cst == NULL)
 				D_GOTO(out_unlock, rc = -DER_NOMEM);
 		}

--- a/src/cart/swim/swim.c
+++ b/src/cart/swim/swim.c
@@ -139,7 +139,7 @@ swim_updates_prepare(struct swim_context *ctx, swim_id_t id, swim_id_t to,
 	if (id != to)
 		nupds++; /* to */
 
-	D_ALLOC_ARRAY(upds, nupds);
+	DM_ALLOC_ARRAY(M_SWIM, upds, nupds);
 	if (upds == NULL)
 		D_GOTO(out, rc = -DER_NOMEM);
 
@@ -272,7 +272,7 @@ swim_updates_notify(struct swim_context *ctx, swim_id_t from, swim_id_t id,
 	/* add this update to recent update list so it will be
 	 * piggybacked on future protocol messages
 	 */
-	D_ALLOC_PTR(item);
+	DM_ALLOC_PTR(M_SWIM, item);
 	if (item != NULL) {
 		item->si_id   = id;
 		item->si_from = from;
@@ -422,7 +422,7 @@ search:
 	}
 
 	/* add to end of suspect list */
-	D_ALLOC_PTR(item);
+	DM_ALLOC_PTR(M_SWIM, item);
 	if (item == NULL)
 		D_GOTO(out, rc = -DER_NOMEM);
 	item->si_id   = id;
@@ -478,7 +478,7 @@ swim_member_update_suspected(struct swim_context *ctx, uint64_t now,
 				item->si_from = self_id;
 				item->u.si_deadline += swim_ping_timeout_get();
 
-				D_ALLOC_PTR(item);
+				DM_ALLOC_PTR(M_SWIM, item);
 				if (item == NULL)
 					D_GOTO(next_item, rc = -DER_NOMEM);
 				item->si_id   = id;
@@ -626,7 +626,7 @@ swim_ipings_suspend(struct swim_context *ctx, swim_id_t from_id,
 		}
 	}
 
-	D_ALLOC_PTR(item);
+	DM_ALLOC_PTR(M_SWIM, item);
 	if (item != NULL) {
 		item->si_id   = to_id;
 		item->si_from = from_id;
@@ -653,7 +653,7 @@ swim_subgroup_init(struct swim_context *ctx)
 		if (id == SWIM_ID_INVALID)
 			D_GOTO(out, rc = 0);
 
-		D_ALLOC_PTR(item);
+		DM_ALLOC_PTR(M_SWIM, item);
 		if (item == NULL)
 			D_GOTO(out, rc = -DER_NOMEM);
 		item->si_from = ctx->sc_target;
@@ -727,7 +727,7 @@ swim_init(swim_id_t self_id, struct swim_ops *swim_ops, void *data)
 	}
 
 	/* allocate structure for storing swim context */
-	D_ALLOC_PTR(ctx);
+	DM_ALLOC_PTR(M_SWIM, ctx);
 	if (ctx == NULL)
 		D_GOTO(out, ctx = NULL);
 

--- a/src/common/misc.c
+++ b/src/common/misc.c
@@ -194,14 +194,14 @@ daos_sgl_merge(d_sg_list_t *dst, d_sg_list_t *src)
 		return 0;
 
 	total = dst->sg_nr + src->sg_nr;
-	D_REALLOC_ARRAY(new_iovs, dst->sg_iovs, dst->sg_nr, total);
+	DM_REALLOC_ARRAY(M_IO_ARG, new_iovs, dst->sg_iovs, dst->sg_nr, total);
 	if (new_iovs == NULL)
 		return -DER_NOMEM;
 
 	for (i = dst->sg_nr; i < total; i++) {
 		int idx = i - dst->sg_nr;
 
-		D_ALLOC_NZ(new_iovs[i].iov_buf, src->sg_iovs[idx].iov_buf_len);
+		DM_ALLOC_NZ(M_IO_ARG, new_iovs[i].iov_buf, src->sg_iovs[idx].iov_buf_len);
 		if (new_iovs[i].iov_buf == NULL)
 			D_GOTO(free, rc = -DER_NOMEM);
 
@@ -274,8 +274,8 @@ daos_sgl_buf_extend(d_sg_list_t *sgl, int idx, size_t new_size)
 	if (sgl->sg_iovs[idx].iov_buf_len >= new_size)
 		return 0;
 
-	D_REALLOC(new_buf, sgl->sg_iovs[idx].iov_buf,
-		  sgl->sg_iovs[idx].iov_buf_len, new_size);
+	DM_REALLOC(M_IO_ARG, new_buf, sgl->sg_iovs[idx].iov_buf,
+		   sgl->sg_iovs[idx].iov_buf_len, new_size);
 	if (new_buf == NULL)
 		return -DER_NOMEM;
 
@@ -414,7 +414,7 @@ daos_iov_copy(d_iov_t *dst, d_iov_t *src)
 	D_ASSERT(src->iov_buf_len > 0);
 	D_ASSERT(dst != NULL);
 
-	D_ALLOC(dst->iov_buf, src->iov_buf_len);
+	DM_ALLOC(M_IO_ARG, dst->iov_buf, src->iov_buf_len);
 	if (dst->iov_buf == NULL)
 		return -DER_NOMEM;
 	dst->iov_buf_len = src->iov_buf_len;
@@ -431,7 +431,7 @@ daos_iov_alloc(d_iov_t *iov, daos_size_t size, bool set_full)
 	D_ASSERT(size > 0);
 
 	memset(iov, 0, sizeof(*iov));
-	D_ALLOC(iov->iov_buf, size);
+	DM_ALLOC(M_IO_ARG, iov->iov_buf, size);
 	if (iov->iov_buf == NULL)
 		return -DER_NOMEM;
 
@@ -734,7 +734,7 @@ daos_recx_alloc(uint32_t nr)
 {
 	daos_recx_t	*recxs;
 
-	D_ALLOC_ARRAY(recxs, nr);
+	DM_ALLOC_ARRAY(M_IO_ARG, recxs, nr);
 	return recxs;
 }
 

--- a/src/common/profile.c
+++ b/src/common/profile.c
@@ -265,7 +265,7 @@ daos_profile_dump(struct daos_profile *dp)
 		unlink(path);
 out:
 	if (path != name)
-		free(path);
+		D_FREE(path);
 }
 
 int

--- a/src/common/prop.c
+++ b/src/common/prop.c
@@ -28,12 +28,12 @@ daos_prop_alloc(uint32_t entries_nr)
 		return NULL;
 	}
 
-	D_ALLOC_PTR(prop);
+	DM_ALLOC_PTR(M_PROP, prop);
 	if (prop == NULL)
 		return NULL;
 
 	if (entries_nr > 0) {
-		D_ALLOC_ARRAY(prop->dpp_entries, entries_nr);
+		DM_ALLOC_ARRAY(M_PROP, prop->dpp_entries, entries_nr);
 		if (prop->dpp_entries == NULL) {
 			D_FREE(prop);
 			return NULL;
@@ -635,7 +635,7 @@ daos_prop_entry_set_ptr(struct daos_prop_entry *entry, const void *ptr, daos_siz
 	if (ptr == NULL || size == 0)
 		return 0;
 
-	D_ALLOC(entry->dpe_val_ptr, size);
+	DM_ALLOC(M_PROP, entry->dpe_val_ptr, size);
 	if (entry->dpe_val_ptr == NULL)
 		return -DER_NOMEM;
 	memcpy(entry->dpe_val_ptr, ptr, size);
@@ -695,7 +695,7 @@ daos_prop_copy(daos_prop_t *prop_req, daos_prop_t *prop_reply)
 	}
 	if (prop_req->dpp_nr == 0) {
 		prop_req->dpp_nr = prop_reply->dpp_nr;
-		D_ALLOC_ARRAY(prop_req->dpp_entries, prop_req->dpp_nr);
+		DM_ALLOC_ARRAY(M_PROP, prop_req->dpp_entries, prop_req->dpp_nr);
 		if (prop_req->dpp_entries == NULL)
 			return -DER_NOMEM;
 		entries_alloc = true;
@@ -800,7 +800,7 @@ daos_prop_entry_dup_co_roots(struct daos_prop_entry *dst,
 			     struct daos_prop_entry *src)
 {
 	if (dst->dpe_val_ptr == NULL) {
-		D_ALLOC(dst->dpe_val_ptr, sizeof(struct daos_prop_co_roots));
+		DM_ALLOC(M_PROP, dst->dpe_val_ptr, sizeof(struct daos_prop_co_roots));
 
 		if (dst->dpe_val_ptr == NULL)
 			return -DER_NOMEM;
@@ -819,7 +819,7 @@ daos_prop_entry_dup_ptr(struct daos_prop_entry *entry_dst,
 	D_ASSERT(entry_src != NULL);
 	D_ASSERT(entry_dst != NULL);
 
-	D_ALLOC(entry_dst->dpe_val_ptr, len);
+	DM_ALLOC(M_PROP, entry_dst->dpe_val_ptr, len);
 	if (entry_dst->dpe_val_ptr == NULL)
 		return -DER_NOMEM;
 

--- a/src/common/tse.c
+++ b/src/common/tse.c
@@ -343,7 +343,7 @@ tse_sched_register_comp_cb(tse_sched_t *sched,
 	struct tse_sched_private	*dsp = tse_sched2priv(sched);
 	struct tse_sched_comp		*dsc;
 
-	D_ALLOC_PTR(dsc);
+	DM_ALLOC_PTR(M_TSE, dsc);
 	if (dsc == NULL)
 		return -DER_NOMEM;
 
@@ -411,7 +411,7 @@ register_cb(tse_task_t *task, bool is_comp, tse_task_cb_t cb,
 		return -DER_NO_PERM;
 	}
 
-	D_ALLOC(dtc, sizeof(*dtc) + arg_size);
+	DM_ALLOC(M_TSE, dtc, sizeof(*dtc) + arg_size);
 	if (dtc == NULL)
 		return -DER_NOMEM;
 
@@ -905,7 +905,7 @@ tse_task_add_dependent(tse_task_t *task, tse_task_t *dep)
 	if (dep_dtp->dtp_completed)
 		return 0;
 
-	D_ALLOC_PTR(tlink);
+	DM_ALLOC_PTR(M_TSE, tlink);
 	if (tlink == NULL)
 		return -DER_NOMEM;
 
@@ -947,7 +947,7 @@ tse_task_create(tse_task_func_t task_func, tse_sched_t *sched, void *priv,
 	struct tse_task_private	 *dtp;
 	tse_task_t		 *task;
 
-	D_ALLOC_PTR(task);
+	DM_ALLOC_PTR(M_TSE, task);
 	if (task == NULL)
 		return -DER_NOMEM;
 

--- a/src/container/container_iv.c
+++ b/src/container/container_iv.c
@@ -62,7 +62,7 @@ cont_iv_ent_init(struct ds_iv_key *iv_key, void *data,
 	if (rc)
 		D_GOTO(out, rc);
 
-	D_ALLOC(entry->iv_value.sg_iovs[0].iov_buf, sizeof(root_hdl));
+	DM_ALLOC(M_IV, entry->iv_value.sg_iovs[0].iov_buf, sizeof(root_hdl));
 	if (entry->iv_value.sg_iovs[0].iov_buf == NULL)
 		D_GOTO(out, rc = -DER_NOMEM);
 
@@ -226,7 +226,7 @@ cont_iv_snap_ent_create(struct ds_iv_entry *entry, struct ds_iv_key *key)
 		D_GOTO(out, rc);
 
 	D_ASSERT(snap_cnt >= 0);
-	D_ALLOC(iv_entry, cont_iv_snap_ent_size(snap_cnt));
+	DM_ALLOC(M_IV, iv_entry, cont_iv_snap_ent_size(snap_cnt));
 	if (iv_entry == NULL)
 		D_GOTO(out, rc = -DER_NOMEM);
 
@@ -358,7 +358,7 @@ cont_iv_prop_ent_create(struct ds_iv_entry *entry, struct ds_iv_key *key)
 		D_GOTO(out, rc);
 
 	entry_size = cont_iv_prop_ent_size(DAOS_ACL_MAX_ACE_LEN);
-	D_ALLOC(iv_entry, entry_size);
+	DM_ALLOC(M_IV, iv_entry, entry_size);
 	if (iv_entry == NULL)
 		D_GOTO(out, rc = -DER_NOMEM);
 
@@ -613,7 +613,7 @@ cont_iv_value_alloc(struct ds_iv_entry *iv_entry, struct ds_iv_key *key,
 	if (rc)
 		return rc;
 
-	D_ALLOC(entry, civ_key->entry_size);
+	DM_ALLOC(M_IV, entry, civ_key->entry_size);
 	if (entry == NULL)
 		D_GOTO(out, rc = -DER_NOMEM);
 
@@ -753,7 +753,7 @@ cont_iv_snapshots_fetch(void *ns, uuid_t cont_uuid, uint64_t **snapshots,
 	uint64_t		snap_cnt = INIT_SNAP_CNT;
 retry:
 	iv_entry_size = cont_iv_snap_ent_size(snap_cnt);
-	D_ALLOC(iv_entry, iv_entry_size);
+	DM_ALLOC(M_IV, iv_entry, iv_entry_size);
 	if (iv_entry == NULL)
 		return -DER_NOMEM;
 
@@ -777,7 +777,7 @@ retry:
 	}
 
 	if (snapshots != NULL) {
-		D_ALLOC(*snapshots,
+		DM_ALLOC(M_IV, *snapshots,
 		      sizeof(iv_entry->iv_snap.snaps[0]) * iv_entry->iv_snap.snap_cnt);
 		if (*snapshots == NULL)
 			D_GOTO(free, rc = -DER_NOMEM);
@@ -805,7 +805,7 @@ cont_iv_snapshots_update(void *ns, uuid_t cont_uuid, uint64_t *snapshots,
 	D_ASSERT(dss_get_module_info()->dmi_xs_id == 0);
 
 	iv_entry_size = cont_iv_snap_ent_size(snap_count);
-	D_ALLOC(iv_entry, iv_entry_size);
+	DM_ALLOC(M_IV, iv_entry, iv_entry_size);
 	if (iv_entry == NULL)
 		return -DER_NOMEM;
 
@@ -1172,7 +1172,7 @@ cont_iv_prop_g2l(struct cont_iv_prop *iv_prop, daos_prop_t *prop)
 			break;
 		case DAOS_PROP_CO_ROOTS:
 			roots = &iv_prop->cip_roots;
-			D_ALLOC(prop_entry->dpe_val_ptr, sizeof(*roots));
+			DM_ALLOC(M_PROP, prop_entry->dpe_val_ptr, sizeof(*roots));
 			if (!prop_entry->dpe_val_ptr)
 				D_GOTO(out, rc = -DER_NOMEM);
 			memcpy(prop_entry->dpe_val_ptr, roots, sizeof(*roots));
@@ -1209,7 +1209,7 @@ cont_iv_prop_update(void *ns, uuid_t cont_uuid, daos_prop_t *prop)
 	D_ASSERT(dss_get_module_info()->dmi_xs_id == 0);
 
 	iv_entry_size = cont_iv_prop_ent_size(DAOS_ACL_MAX_ACE_LEN);
-	D_ALLOC(iv_entry, iv_entry_size);
+	DM_ALLOC(M_IV, iv_entry, iv_entry_size);
 	if (iv_entry == NULL)
 		return -DER_NOMEM;
 
@@ -1248,7 +1248,7 @@ cont_iv_prop_fetch_ult(void *data)
 		D_GOTO(out, rc = -DER_NONEXIST);
 
 	iv_entry_size = cont_iv_prop_ent_size(DAOS_ACL_MAX_ACE_LEN);
-	D_ALLOC(iv_entry, iv_entry_size);
+	DM_ALLOC(M_IV, iv_entry, iv_entry_size);
 	if (iv_entry == NULL)
 		D_GOTO(out, rc = -DER_NOMEM);
 

--- a/src/container/srv_container.c
+++ b/src/container/srv_container.c
@@ -161,7 +161,7 @@ ds_cont_svc_init(struct cont_svc **svcp, const uuid_t pool_uuid, uint64_t id,
 	struct cont_svc	       *svc;
 	int			rc;
 
-	D_ALLOC_PTR(svc);
+	DM_ALLOC_PTR(M_CONT, svc);
 	if (svc == NULL)
 		return -DER_NOMEM;
 	rc = cont_svc_init(svc, pool_uuid, id, rsvc);
@@ -985,7 +985,7 @@ recs_buf_init(struct recs_buf *buf)
 	size_t				tmp_size;
 
 	tmp_size = 4096;
-	D_ALLOC(tmp, tmp_size);
+	DM_ALLOC(M_CONT, tmp, tmp_size);
 	if (tmp == NULL)
 		return -DER_NOMEM;
 
@@ -1015,7 +1015,7 @@ recs_buf_grow(struct recs_buf *buf)
 		size_t				recs_size_tmp;
 
 		recs_size_tmp = buf->rb_recs_size * 2;
-		D_ALLOC(recs_tmp, recs_size_tmp);
+		DM_ALLOC(M_CONT, recs_tmp, recs_size_tmp);
 		if (recs_tmp == NULL)
 			return -DER_NOMEM;
 		memcpy(recs_tmp, buf->rb_recs, buf->rb_recs_size);
@@ -1228,7 +1228,7 @@ cont_ec_agg_alloc(struct cont_svc *cont_svc, uuid_t cont_uuid,
 	int			rc = 0;
 	int			i;
 
-	D_ALLOC_PTR(ec_agg);
+	DM_ALLOC_PTR(M_CONT, ec_agg);
 	if (ec_agg == NULL)
 		return -DER_NOMEM;
 
@@ -1238,7 +1238,7 @@ cont_ec_agg_alloc(struct cont_svc *cont_svc, uuid_t cont_uuid,
 	if (node_nr < 0)
 		D_GOTO(out, rc = node_nr);
 
-	D_ALLOC_ARRAY(ec_agg->ea_server_ephs, node_nr);
+	DM_ALLOC_ARRAY(M_CONT, ec_agg->ea_server_ephs, node_nr);
 	if (ec_agg->ea_server_ephs == NULL)
 		D_GOTO(out, rc = -DER_NOMEM);
 
@@ -1537,7 +1537,7 @@ cont_lookup(struct rdb_tx *tx, const struct cont_svc *svc, const uuid_t uuid,
 	if (rc != 0)
 		D_GOTO(err, rc);
 
-	D_ALLOC_PTR(p);
+	DM_ALLOC_PTR(M_CONT, p);
 	if (p == NULL) {
 		D_ERROR("Failed to allocate container descriptor\n");
 		D_GOTO(err, rc = -DER_NOMEM);
@@ -2248,7 +2248,7 @@ cont_prop_read(struct rdb_tx *tx, struct cont *cont, uint64_t bits,
 			D_GOTO(out, rc);
 		D_ASSERT(idx < nr);
 		prop->dpp_entries[idx].dpe_type = DAOS_PROP_CO_ACL;
-		D_ALLOC(prop->dpp_entries[idx].dpe_val_ptr, value.iov_buf_len);
+		DM_ALLOC(M_PROP, prop->dpp_entries[idx].dpe_val_ptr, value.iov_buf_len);
 		if (prop->dpp_entries[idx].dpe_val_ptr == NULL)
 			D_GOTO(out, rc = -DER_NOMEM);
 		memcpy(prop->dpp_entries[idx].dpe_val_ptr, value.iov_buf,
@@ -2325,7 +2325,7 @@ cont_prop_read(struct rdb_tx *tx, struct cont *cont, uint64_t bits,
 			D_GOTO(out, rc);
 		D_ASSERT(idx < nr);
 		prop->dpp_entries[idx].dpe_type = DAOS_PROP_CO_ROOTS;
-		D_ALLOC(prop->dpp_entries[idx].dpe_val_ptr, value.iov_len);
+		DM_ALLOC(M_PROP, prop->dpp_entries[idx].dpe_val_ptr, value.iov_len);
 		if (prop->dpp_entries[idx].dpe_val_ptr == NULL)
 			D_GOTO(out, rc = -DER_NOMEM);
 
@@ -2535,7 +2535,7 @@ cont_query(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl, struct cont *cont,
 		struct daos_prop_entry	*entry, *iv_entry;
 		int			 i;
 
-		D_ALLOC_PTR(iv_prop);
+		DM_ALLOC_PTR(M_PROP, iv_prop);
 		if (iv_prop == NULL)
 			return -DER_NOMEM;
 
@@ -3270,7 +3270,7 @@ enum_cont_cb(daos_handle_t ih, d_iov_t *key, d_iov_t *val, void *varg)
 		size_t	realloc_elems = (ap->conts_len == 0) ? 1 :
 					ap->conts_len * 2;
 
-		D_REALLOC_ARRAY(ptr, ap->conts, ap->conts_len, realloc_elems);
+		DM_REALLOC_ARRAY(M_CONT, ptr, ap->conts, ap->conts_len, realloc_elems);
 		if (ptr == NULL)
 			return -DER_NOMEM;
 		ap->conts = ptr;

--- a/src/container/srv_epoch.c
+++ b/src/container/srv_epoch.c
@@ -45,9 +45,8 @@ snap_list_iter_cb(daos_handle_t ih, d_iov_t *key, d_iov_t *val,
 			if (i_args->sla_index < i_args->sla_count) {
 				void *ptr;
 
-				D_REALLOC_ARRAY(ptr, i_args->sla_buf,
-						i_args->sla_index,
-						i_args->sla_count);
+				DM_REALLOC_ARRAY(M_CONT, ptr, i_args->sla_buf,
+						 i_args->sla_index, i_args->sla_count);
 				if (ptr == NULL)
 					return -DER_NOMEM;
 				i_args->sla_buf = ptr;

--- a/src/container/srv_target.c
+++ b/src/container/srv_target.c
@@ -311,7 +311,7 @@ cont_child_aggregate(struct ds_cont_child *cont, cont_aggregate_cb_t agg_cb,
 	if (cont->sc_snapshots_nr + 1 < MAX_SNAPSHOT_LOCAL) {
 		snapshots = snapshots_local;
 	} else {
-		D_ALLOC(snapshots, (cont->sc_snapshots_nr + 1) *
+		DM_ALLOC(M_CONT, snapshots, (cont->sc_snapshots_nr + 1) *
 			sizeof(daos_epoch_t));
 		if (snapshots == NULL)
 			return -DER_NOMEM;
@@ -697,7 +697,7 @@ cont_child_alloc_ref(void *co_uuid, unsigned int ksize, void *po_uuid,
 	D_ASSERT(po_uuid != NULL);
 	D_DEBUG(DF_DSMS, DF_CONT": opening\n", DP_CONT(po_uuid, co_uuid));
 
-	D_ALLOC_PTR(cont);
+	DM_ALLOC_PTR(M_CONT, cont);
 	if (cont == NULL)
 		return -DER_NOMEM;
 
@@ -1480,7 +1480,7 @@ ds_cont_local_open(uuid_t pool_uuid, uuid_t cont_hdl_uuid, uuid_t cont_uuid,
 		return rc;
 	}
 
-	D_ALLOC_PTR(hdl);
+	DM_ALLOC_PTR(M_CONT, hdl);
 	if (hdl == NULL)
 		return -DER_NOMEM;
 
@@ -1565,7 +1565,7 @@ ds_cont_local_open(uuid_t pool_uuid, uuid_t cont_hdl_uuid, uuid_t cont_uuid,
 			D_GOTO(err_reindex, rc);
 		}
 
-		D_ALLOC_PTR(ddra);
+		DM_ALLOC_PTR(M_CONT, ddra);
 		if (ddra == NULL)
 			D_GOTO(err_register, rc = -DER_NOMEM);
 
@@ -1843,7 +1843,7 @@ ds_cont_query_stream_alloc(struct dss_stream_arg_type *args,
 {
 	struct xstream_cont_query	*rarg = a_arg;
 
-	D_ALLOC(args->st_arg, sizeof(struct xstream_cont_query));
+	DM_ALLOC(M_CONT, args->st_arg, sizeof(struct xstream_cont_query));
 	if (args->st_arg == NULL)
 		return -DER_NOMEM;
 	memcpy(args->st_arg, rarg, sizeof(struct xstream_cont_query));
@@ -1935,8 +1935,7 @@ cont_snap_update_one(void *vin)
 	} else {
 		uint64_t *snaps;
 
-		D_REALLOC_ARRAY_NZ(snaps, cont->sc_snapshots,
-				   args->snap_count);
+		DM_REALLOC_ARRAY_NZ(M_CONT, snaps, cont->sc_snapshots, args->snap_count);
 		if (snaps == NULL) {
 			rc = -DER_NOMEM;
 			goto out_cont;
@@ -2002,7 +2001,7 @@ ds_cont_tgt_snapshots_refresh(uuid_t pool_uuid, uuid_t cont_uuid)
 	struct cont_snap_args	*args;
 	int			 rc;
 
-	D_ALLOC_PTR(args);
+	DM_ALLOC_PTR(M_CONT, args);
 	if (args == NULL)
 		return -DER_NOMEM;
 	uuid_copy(args->pool_uuid, pool_uuid);
@@ -2304,7 +2303,7 @@ cont_ec_xs_reduce_alloc(struct dss_stream_arg_type *xs, void *agg_arg)
 	struct cont_ec_xs_query_arg *xs_arg;
 	struct ds_pool *pool = agg_arg;
 
-	D_ALLOC_PTR(xs_arg);
+	DM_ALLOC_PTR(M_CONT, xs_arg);
 	if (xs_arg == NULL)
 		return -DER_NOMEM;
 
@@ -2343,7 +2342,7 @@ lookup_insert_cont_ec_eph(d_list_t *ec_list, uuid_t cont_uuid)
 	found = lookup_cont_ec_eph(ec_list, cont_uuid);
 	if (found != NULL)
 		return found;
-	D_ALLOC_PTR(found);
+	DM_ALLOC_PTR(M_CONT, found);
 	if (found == NULL)
 		return NULL;
 
@@ -2401,7 +2400,7 @@ cont_ec_eph_query_one(void *arg)
 	if (total == 0)
 		D_GOTO(out, rc = 0);
 
-	D_ALLOC_ARRAY(ephs, total);
+	DM_ALLOC_ARRAY(M_CONT, ephs, total);
 	if (ephs == NULL)
 		D_GOTO(out, rc = -DER_NOMEM);
 

--- a/src/dtx/dtx_common.c
+++ b/src/dtx/dtx_common.c
@@ -215,7 +215,7 @@ dtx_cleanup_stale_iter_cb(uuid_t co_uuid, vos_iter_entry_t *ent, void *args)
 	    DTX_CLEANUP_THD_AGE_LO)
 		return 1;
 
-	D_ALLOC(dsp, sizeof(*dsp) + ent->ie_dtx_mbs_dsize);
+	DM_ALLOC(M_DTX, dsp, sizeof(*dsp) + ent->ie_dtx_mbs_dsize);
 	if (dsp == NULL)
 		return -DER_NOMEM;
 
@@ -899,7 +899,7 @@ dtx_insert_oid(struct dtx_handle *dth, daos_unit_oid_t *oid, bool touch_leader)
 	if (dth->dth_oid_cnt == dth->dth_oid_cap) {
 		daos_unit_oid_t		*oid_array;
 
-		D_ALLOC_ARRAY(oid_array, dth->dth_oid_cap << 1);
+		DM_ALLOC_ARRAY(M_DTX, oid_array, dth->dth_oid_cap << 1);
 		if (oid_array == NULL)
 			return -DER_NOMEM;
 
@@ -995,7 +995,7 @@ dtx_sub_init(struct dtx_handle *dth, daos_unit_oid_t *oid, uint64_t dkey_hash)
 
 		/* 4 slots by default to hold rename case. */
 		dth->dth_oid_cap = 4;
-		D_ALLOC_ARRAY(dth->dth_oid_array, dth->dth_oid_cap);
+		DM_ALLOC_ARRAY(M_DTX, dth->dth_oid_array, dth->dth_oid_cap);
 		if (dth->dth_oid_array == NULL)
 			D_GOTO(out, rc = -DER_NOMEM);
 
@@ -1254,7 +1254,7 @@ dtx_leader_end(struct dtx_leader_handle *dlh, struct ds_cont_child *cont,
 	D_ASSERT(dth->dth_mbs != NULL);
 
 	size = sizeof(*dte) + sizeof(*mbs) + dth->dth_mbs->dm_data_size;
-	D_ALLOC(dte, size);
+	DM_ALLOC(M_DTX, dte, size);
 	if (dte == NULL) {
 		dth->dth_sync = 1;
 		goto sync;
@@ -1538,7 +1538,7 @@ dtx_batched_commit_register(struct ds_cont_child *cont)
 	}
 
 	if (new_pool) {
-		D_ALLOC_PTR(dbpa);
+		DM_ALLOC_PTR(M_DTX, dbpa);
 		if (dbpa == NULL)
 			return -DER_NOMEM;
 
@@ -1547,7 +1547,7 @@ dtx_batched_commit_register(struct ds_cont_child *cont)
 		dbpa->dbpa_pool = cont->sc_pool;
 	}
 
-	D_ALLOC_PTR(dbca);
+	DM_ALLOC_PTR(M_DTX, dbca);
 	if (dbca == NULL) {
 		if (new_pool)
 			D_FREE(dbpa);
@@ -1794,7 +1794,7 @@ dtx_leader_exec_ops(struct dtx_leader_handle *dlh, dtx_sub_func_t func,
 	if (dlh->dlh_sub_cnt == 0)
 		goto exec;
 
-	D_ALLOC_PTR(ult_arg);
+	DM_ALLOC_PTR(M_DTX, ult_arg);
 	if (ult_arg == NULL)
 		return -DER_NOMEM;
 	ult_arg->func	= func;

--- a/src/dtx/dtx_cos.c
+++ b/src/dtx/dtx_cos.c
@@ -110,7 +110,7 @@ dtx_cos_rec_alloc(struct btr_instance *tins, d_iov_t *key_iov,
 	key = (struct dtx_cos_key *)key_iov->iov_buf;
 	rbund = (struct dtx_cos_rec_bundle *)val_iov->iov_buf;
 
-	D_ALLOC_PTR(dcr);
+	DM_ALLOC_PTR(M_DTX, dcr);
 	if (dcr == NULL)
 		return -DER_NOMEM;
 
@@ -120,7 +120,7 @@ dtx_cos_rec_alloc(struct btr_instance *tins, d_iov_t *key_iov,
 	D_INIT_LIST_HEAD(&dcr->dcr_prio_list);
 	D_INIT_LIST_HEAD(&dcr->dcr_expcmt_list);
 
-	D_ALLOC_PTR(dcrc);
+	DM_ALLOC_PTR(M_DTX, dcrc);
 	if (dcrc == NULL) {
 		D_FREE_PTR(dcr);
 		return -DER_NOMEM;
@@ -227,7 +227,7 @@ dtx_cos_rec_update(struct btr_instance *tins, struct btr_record *rec,
 	dcr = (struct dtx_cos_rec *)umem_off2ptr(&tins->ti_umm, rec->rec_off);
 	rbund = (struct dtx_cos_rec_bundle *)val->iov_buf;
 
-	D_ALLOC_PTR(dcrc);
+	DM_ALLOC_PTR(M_DTX, dcrc);
 	if (dcrc == NULL)
 		return -DER_NOMEM;
 
@@ -281,11 +281,11 @@ dtx_fetch_committable(struct ds_cont_child *cont, uint32_t max_cnt,
 		return 0;
 	}
 
-	D_ALLOC_ARRAY(dte_buf, count);
+	DM_ALLOC_ARRAY(M_DTX, dte_buf, count);
 	if (dte_buf == NULL)
 		return -DER_NOMEM;
 
-	D_ALLOC_ARRAY(dck_buf, count);
+	DM_ALLOC_ARRAY(M_DTX, dck_buf, count);
 	if (dck_buf == NULL) {
 		D_FREE(dte_buf);
 		return -DER_NOMEM;
@@ -356,7 +356,7 @@ dtx_list_cos(struct ds_cont_child *cont, daos_unit_oid_t *oid,
 	else
 		count = dcr->dcr_prio_count;
 
-	D_ALLOC_ARRAY(dti, count);
+	DM_ALLOC_ARRAY(M_DTX, dti, count);
 	if (dti == NULL)
 		return -DER_NOMEM;
 

--- a/src/dtx/dtx_resync.c
+++ b/src/dtx/dtx_resync.c
@@ -63,11 +63,11 @@ dtx_resync_commit(struct ds_cont_child *cont,
 
 	D_ASSERT(drh->drh_count >= count);
 
-	D_ALLOC_ARRAY(dtes, count);
+	DM_ALLOC_ARRAY(M_DTX, dtes, count);
 	if (dtes == NULL)
 		return -DER_NOMEM;
 
-	D_ALLOC_ARRAY(dcks, count);
+	DM_ALLOC_ARRAY(M_DTX, dcks, count);
 	if (dcks == NULL) {
 		D_FREE(dtes);
 		return -DER_NOMEM;
@@ -361,7 +361,7 @@ dtx_status_handle(struct dtx_resync_args *dra)
 	ABT_rwlock_unlock(pool->sp_lock);
 	D_ASSERT(tgt_cnt != 0);
 
-	D_ALLOC_ARRAY(tgt_array, tgt_cnt);
+	DM_ALLOC_ARRAY(M_DTX, tgt_array, tgt_cnt);
 	if (tgt_array == NULL)
 		D_GOTO(out, err = -DER_NOMEM);
 
@@ -493,7 +493,7 @@ dtx_iter_cb(uuid_t co_uuid, vos_iter_entry_t *ent, void *args)
 	D_ASSERT(ent->ie_dtx_tgt_cnt > 0);
 
 	size = sizeof(*dre) + sizeof(*mbs) + ent->ie_dtx_mbs_dsize;
-	D_ALLOC(dre, size);
+	DM_ALLOC(M_DTX, dre, size);
 	if (dre == NULL)
 		return -DER_NOMEM;
 

--- a/src/dtx/dtx_rpc.c
+++ b/src/dtx/dtx_rpc.c
@@ -406,12 +406,12 @@ dtx_cf_rec_alloc(struct btr_instance *tins, d_iov_t *key_iov,
 
 	D_ASSERT(tins->ti_umm.umm_id == UMEM_CLASS_VMEM);
 
-	D_ALLOC_PTR(drr);
+	DM_ALLOC_PTR(M_DTX, drr);
 	if (drr == NULL)
 		return -DER_NOMEM;
 
 	dcrb = val_iov->iov_buf;
-	D_ALLOC_ARRAY(drr->drr_dti, dcrb->dcrb_count);
+	DM_ALLOC_ARRAY(M_DTX, drr->drr_dti, dcrb->dcrb_count);
 	if (drr->drr_dti == NULL) {
 		D_FREE(drr);
 		return -DER_NOMEM;
@@ -657,12 +657,12 @@ dtx_commit(struct ds_cont_child *cont, struct dtx_entry **dtes,
 	dra.dra_future = ABT_FUTURE_NULL;
 	D_INIT_LIST_HEAD(&head);
 
-	D_ALLOC_ARRAY(dtis, count);
+	DM_ALLOC_ARRAY(M_DTX, dtis, count);
 	if (dtis == NULL)
 		D_GOTO(out, rc = -DER_NOMEM);
 
 	if (helper) {
-		D_ALLOC_PTR(cmt_arg);
+		DM_ALLOC_PTR(M_DTX, cmt_arg);
 		if (cmt_arg == NULL)
 			D_GOTO(out, rc = -DER_NOMEM);
 
@@ -692,7 +692,7 @@ dtx_commit(struct ds_cont_child *cont, struct dtx_entry **dtes,
 	}
 
 	if (dcks != NULL) {
-		D_ALLOC_ARRAY(rm_cos, count);
+		DM_ALLOC_ARRAY(M_DTX, rm_cos, count);
 		if (rm_cos == NULL)
 			D_GOTO(out, rc1 = -DER_NOMEM);
 	}
@@ -1023,17 +1023,17 @@ again:
 			}
 		}
 
-		D_ALLOC_PTR(drr);
+		DM_ALLOC_PTR(M_DTX, drr);
 		if (drr == NULL)
 			D_GOTO(out, rc = -DER_NOMEM);
 
-		D_ALLOC_ARRAY(drr->drr_dti, *check_count);
+		DM_ALLOC_ARRAY(M_DTX, drr->drr_dti, *check_count);
 		if (drr->drr_dti == NULL) {
 			D_FREE(drr);
 			D_GOTO(out, rc = -DER_NOMEM);
 		}
 
-		D_ALLOC_ARRAY(drr->drr_cb_args, *check_count);
+		DM_ALLOC_ARRAY(M_DTX, drr->drr_cb_args, *check_count);
 		if (drr->drr_cb_args == NULL) {
 			D_FREE(drr->drr_dti);
 			D_FREE(drr);

--- a/src/dtx/dtx_srv.c
+++ b/src/dtx/dtx_srv.c
@@ -25,7 +25,7 @@ dtx_tls_init(int xs_id, int tgt_id)
 	struct dtx_tls  *tls;
 	int              rc;
 
-	D_ALLOC_PTR(tls);
+	DM_ALLOC_PTR(M_DTX, tls);
 	if (tls == NULL)
 		return NULL;
 
@@ -76,7 +76,7 @@ dtx_metrics_alloc(const char *path, int tgt_id)
 
 	D_ASSERT(tgt_id >= 0);
 
-	D_ALLOC_PTR(metrics);
+	DM_ALLOC_PTR(M_DTX, metrics);
 	if (metrics == NULL)
 		return NULL;
 
@@ -231,7 +231,7 @@ dtx_handler(crt_rpc_t *rpc)
 		if (count > DTX_REFRESH_MAX)
 			D_GOTO(out, rc = -DER_PROTO);
 
-		D_ALLOC(dout->do_sub_rets.ca_arrays, sizeof(int32_t) * count);
+		DM_ALLOC(M_DTX, dout->do_sub_rets.ca_arrays, sizeof(int32_t) * count);
 		if (dout->do_sub_rets.ca_arrays == NULL)
 			D_GOTO(out, rc = -DER_NOMEM);
 

--- a/src/engine/sched.c
+++ b/src/engine/sched.c
@@ -367,7 +367,7 @@ add_purge_list(struct dss_xstream *dx, struct sched_pool_info *spi)
 			return;
 	}
 
-	D_ALLOC_PTR(pi);
+	DM_ALLOC_PTR(M_SCHED, pi);
 	if (pi == NULL) {
 		D_ERROR("XS(%d): Alloc purge item failed.\n", dx->dx_xs_id);
 		return;
@@ -408,7 +408,7 @@ prealloc_requests(struct sched_info *info, int cnt)
 	int			 i;
 
 	for (i = 0; i < cnt; i++) {
-		D_ALLOC_PTR(req);
+		DM_ALLOC_PTR(M_SCHED, req);
 		if (req == NULL) {
 			D_ERROR("Alloc req failed.\n");
 			return -DER_NOMEM;
@@ -480,7 +480,7 @@ cur_pool_info(struct sched_info *info, uuid_t pool_uuid)
 		return spi;
 	}
 
-	D_ALLOC_PTR(spi);
+	DM_ALLOC_PTR(M_SCHED, spi);
 	if (spi == NULL) {
 		D_ERROR("Failed to allocate spi\n");
 		return NULL;
@@ -1306,7 +1306,7 @@ sched_init(ABT_sched sched, ABT_sched_config config)
 	struct sched_data	*data;
 	int			 ret;
 
-	D_ALLOC_PTR(data);
+	DM_ALLOC_PTR(M_SCHED, data);
 	if (data == NULL)
 		return ABT_ERR_MEM;
 

--- a/src/engine/server_iv.c
+++ b/src/engine/server_iv.c
@@ -64,7 +64,7 @@ ds_iv_class_register(unsigned int class_id, struct crt_iv_ops *crt_ops,
 	if (!found) {
 		struct crt_iv_class *new_iv_class;
 
-		D_ALLOC(new_iv_class, (crt_iv_class_nr + 1) *
+		DM_ALLOC(M_IV, new_iv_class, (crt_iv_class_nr + 1) *
 				       sizeof(*new_iv_class));
 		if (new_iv_class == NULL)
 			return -DER_NOMEM;
@@ -83,7 +83,7 @@ ds_iv_class_register(unsigned int class_id, struct crt_iv_ops *crt_ops,
 		crt_iv_class_id = crt_iv_class_nr - 1;
 	}
 
-	D_ALLOC_PTR(class);
+	DM_ALLOC_PTR(M_IV, class);
 	if (class == NULL)
 		return -DER_NOMEM;
 
@@ -297,7 +297,7 @@ iv_entry_alloc(struct ds_iv_ns *ns, struct ds_iv_class *class,
 	struct ds_iv_entry *entry;
 	int			 rc;
 
-	D_ALLOC_PTR(entry);
+	DM_ALLOC_PTR(M_IV, entry);
 	if (entry == NULL)
 		return -DER_NOMEM;
 
@@ -596,7 +596,7 @@ ivc_on_get(crt_iv_namespace_t ivns, crt_iv_key_t *iv_key,
 	if (rc)
 		D_GOTO(out, rc);
 
-	D_ALLOC_PTR(priv_entry);
+	DM_ALLOC_PTR(M_IV, priv_entry);
 	if (priv_entry == NULL) {
 		class->iv_class_ops->ivc_ent_put(entry, priv);
 		D_GOTO(out, rc);
@@ -748,7 +748,7 @@ iv_ns_create_internal(unsigned int ns_id, uuid_t pool_uuid,
 	if (ns)
 		return -DER_EXIST;
 
-	D_ALLOC_PTR(ns);
+	DM_ALLOC_PTR(M_IV, ns);
 	if (ns == NULL)
 		return -DER_NOMEM;
 
@@ -1071,7 +1071,7 @@ retry:
 		struct sync_comp_cb_arg *arg = NULL;
 
 		/* Register asynchronous sync(lazy mode) callback */
-		D_ALLOC_PTR(arg);
+		DM_ALLOC_PTR(M_IV, arg);
 		if (arg == NULL)
 			return -DER_NOMEM;
 

--- a/src/engine/srv.c
+++ b/src/engine/srv.c
@@ -320,6 +320,7 @@ dss_srv_handler(void *arg)
 	struct dss_xstream		*dx = (struct dss_xstream *)arg;
 	struct dss_thread_local_storage	*dtc;
 	struct dss_module_info		*dmi;
+	uint64_t			 then = 0;
 	int				 rc;
 	bool				 signal_caller = true;
 
@@ -491,6 +492,14 @@ dss_srv_handler(void *arg)
 		if (dss_xstream_exiting(dx))
 			break;
 
+		if (dx->dx_xs_id == 0) {
+			uint64_t now = sched_cur_msec();
+
+			if (now > then + DAOS_DM_INTV * 1000) {
+				then = now;
+				dm_mem_dump_log();
+			}
+		}
 		ABT_thread_yield();
 	}
 

--- a/src/gurt/misc.c
+++ b/src/gurt/misc.c
@@ -13,6 +13,462 @@
 #include <math.h>
 #include <gurt/common.h>
 
+#if DAOS_DM_MODE
+
+/** TLS memory allocation counter */
+struct dm_tls_counter {
+	/** already allocated size */
+	int64_t		 mtc_size;
+	/** total number of calls of allocation */
+	int64_t		 mtc_count;
+	/** true if this TLS counter is registered on \a dm_counters */
+	bool		 mtc_registered;
+};
+
+/** thread-local counters */
+static __thread struct dm_tls_counter dm_tls_counters[M_TAG_MAX];
+static pthread_mutex_t	dm_lock = PTHREAD_MUTEX_INITIALIZER;
+
+/** Assuming no more than 128 xstreams */
+#define DM_TLS_MAX	128
+
+/** All the defined counters */
+struct dm_counters {
+	/** counter tag, see \a dm_tag */
+	int			 mc_tag;
+	/** index of the last TLS counter in \a mc_tls_cntrs */
+	int			 mc_last;
+	/** counter string name */
+	char			*mc_name;
+	/** all the registered tls counters */
+	struct dm_tls_counter	*mc_tls_cntrs[DM_TLS_MAX];
+};
+
+static struct dm_counters	dm_counters[] = {
+	{
+		.mc_tag		= M_OTHER,
+		.mc_name	= "other",
+	},
+	{
+		.mc_tag		= M_STR,
+		.mc_name	= "string",
+	},
+	{
+		.mc_tag		= M_RANK,
+		.mc_name	= "rank",
+	},
+	{
+		.mc_tag		= M_CRT,
+		.mc_name	= "cart",
+	},
+	{
+		.mc_tag		= M_CRT_RPC,
+		.mc_name	= "cart_rpc",
+	},
+	{
+		.mc_tag		= M_CRT_IV,
+		.mc_name	= "cart_iv",
+	},
+	{
+		.mc_tag		= M_SWIM,
+		.mc_name	= "swim",
+	},
+	{
+		.mc_tag		= M_CSUM,
+		.mc_name	= "csum",
+	},
+	{
+		.mc_tag		= M_PROP,
+		.mc_name	= "prop",
+	},
+	{
+		.mc_tag		= M_TSE,
+		.mc_name	= "task",
+	},
+	{
+		.mc_tag		= M_PL,
+		.mc_name	= "pl",
+	},
+	{
+		.mc_tag		= M_IV,
+		.mc_name	= "incast",
+	},
+	{
+		.mc_tag		= M_SCHED,
+		.mc_name	= "sched",
+	},
+	{
+		.mc_tag		= M_IO,
+		.mc_name	= "io",
+	},
+	{
+		.mc_tag		= M_IO_ARG,
+		.mc_name	= "io_arg",
+	},
+	{
+		.mc_tag		= M_BIO,
+		.mc_name	= "bio",
+	},
+	{
+		.mc_tag		= M_VEA,
+		.mc_name	= "vea",
+	},
+	{
+		.mc_tag		= M_AGG,
+		.mc_name	= "agg",
+	},
+	{
+		.mc_tag		= M_RECOV,
+		.mc_name	= "recov",
+	},
+	{
+		.mc_tag		= M_EC,
+		.mc_name	= "ec",
+	},
+	{
+		.mc_tag		= M_EC_AGG,
+		.mc_name	= "ec_agg",
+	},
+	{
+		.mc_tag		= M_EC_RECOV,
+		.mc_name	= "ec_recov",
+	},
+	{
+		.mc_tag		= M_POOL,
+		.mc_name	= "pool",
+	},
+	{
+		.mc_tag		= M_CONT,
+		.mc_name	= "cont",
+	},
+	{
+		.mc_tag		= M_OBJ,
+		.mc_name	= "obj",
+	},
+	{
+		.mc_tag		= M_DTX,
+		.mc_name	= "dtx",
+	},
+	{
+		.mc_tag		= M_VOS,
+		.mc_name	= "vos",
+	},
+	{
+		.mc_tag		= M_VOS_TS,
+		.mc_name	= "vos_ts",
+	},
+	{
+		.mc_tag		= M_VOS_LRU,
+		.mc_name	= "vos_lru",
+	},
+	{
+		.mc_tag		= M_VOS_DTX,
+		.mc_name	= "vos_dtx",
+	},
+	{
+		.mc_tag		= M_RDB,
+		.mc_name	= "rdb",
+	},
+	{
+		.mc_tag		= M_TAG_MAX,
+		.mc_name	= NULL,
+	},
+};
+
+/* register thread-local counter to the counter table, so we can
+ * collect the summary, see dm_tag_query().
+ */
+static void
+dm_tls_register(int tag, struct dm_tls_counter *mtc)
+{
+	struct dm_counters	*mc;
+
+	mc = &dm_counters[tag];
+	D_ASSERTF(tag == mc->mc_tag, "Mimatched tag %s: %d/%d\n",
+		  mc->mc_name, mc->mc_tag, tag);
+
+	pthread_mutex_lock(&dm_lock);
+
+	D_ASSERT(mc->mc_last < DM_TLS_MAX);
+	D_ASSERT(mc->mc_tls_cntrs[mc->mc_last] == NULL);
+
+	mc->mc_tls_cntrs[mc->mc_last] = mtc;
+	mc->mc_last++;
+	mtc->mtc_registered = true;
+
+	pthread_mutex_unlock(&dm_lock);
+}
+
+char *
+dm_mem_tag_query(int tag, int64_t *size_p, int64_t *count_p)
+{
+	struct dm_counters  *mc;
+	int64_t		     size;
+	int64_t		     count;
+	int		     i;
+
+	if (tag >= M_TAG_MAX)
+		return NULL;
+
+	/* summarise total memory consumption from thread-local counters */
+	mc = &dm_counters[tag];
+	D_ASSERT(mc->mc_tag == tag);
+
+	pthread_mutex_lock(&dm_lock);
+	for (i = size = count = 0; i < mc->mc_last; i++) {
+		D_ASSERT(mc->mc_tls_cntrs[i]);
+		size += mc->mc_tls_cntrs[i]->mtc_size;
+		count += mc->mc_tls_cntrs[i]->mtc_count;
+	}
+	pthread_mutex_unlock(&dm_lock);
+	if (size_p)
+		*size_p = size;
+	if (count_p)
+		*count_p = count;
+
+	return mc->mc_name;
+}
+
+void
+dm_mem_dump_log(void)
+{
+	char	*name;
+	int64_t	 size;
+	int64_t	 count;
+	int	 i;
+
+	D_DEBUG(DB_MEM, "Memory Consumption Status:\n");
+	for (size = count = i = 0; i < M_TAG_MAX; i++) {
+		int64_t	s, c;
+
+		name = dm_mem_tag_query(i, &s, &c);
+		D_ASSERT(name);
+
+		size += s;
+		count += c;
+		D_DEBUG(DB_MEM, "%-16s: size="DF_U64"(KB) count="DF_U64"\n", name, s >> 10, c);
+	}
+	D_DEBUG(DB_MEM, "ALL : size="DF_U64"(KB) count="DF_U64"\n", size >> 10, count);
+}
+
+static struct dm_header *
+dm_ptr2hdr(void *ptr)
+{
+	return ptr - sizeof(struct dm_header);
+}
+
+static void *
+dm_hdr2ptr(struct dm_header *hdr)
+{
+	return (void *)&hdr->mh_payload[0];
+}
+
+static void
+dm_free(void *ptr)
+{
+	struct dm_tls_counter	*mtc;
+	struct dm_header	*hdr;
+
+	if (!ptr)
+		return;
+
+	hdr = dm_ptr2hdr(ptr);
+	/* NB: counter might belong to a different xstream, so it's not 100% safe w/o lock
+	 * but it's for debugging and hurts nothing except returning inaccurate result.
+	 */
+	mtc = hdr->mh_counter;
+	D_ASSERT(mtc);
+
+	mtc->mtc_size -= hdr->mh_size;
+	mtc->mtc_count--;
+	/* this is the real allocated address */
+	D_ASSERT(hdr->mh_addr);
+	free(hdr->mh_addr);
+}
+
+static void *
+dm_alloc(int tag, int alignment, size_t size)
+{
+	struct dm_tls_counter	*mtc;
+	struct dm_header	*hdr;
+	void			*buf;
+	int			 hdr_size = sizeof(*hdr);
+
+	D_ASSERTF(tag >= M_OTHER && tag < M_TAG_MAX, "tag=%d, alignment=%d, size="DF_U64"\n",
+		  tag, alignment, size);
+
+	mtc = &dm_tls_counters[tag];
+	if (!mtc->mtc_registered) /* register the thread-local counter */
+		dm_tls_register(tag, mtc);
+
+	if (alignment == 0) {
+		buf = malloc(hdr_size + size);
+		if (!buf)
+			return NULL;
+
+		hdr = buf;
+		hdr->mh_alignment = 0;
+	} else {
+		int	nob = alignment;
+
+		while (alignment < hdr_size)
+			alignment += nob;
+
+		buf = aligned_alloc(alignment, alignment + size);
+		if (!buf)
+			return NULL;
+
+		hdr = buf + alignment - hdr_size;
+		hdr->mh_alignment = alignment;
+	}
+
+	hdr->mh_addr	= buf;
+	hdr->mh_tag	= tag;
+	hdr->mh_size	= size;
+	hdr->mh_counter = mtc;
+
+	mtc->mtc_size += size;
+	mtc->mtc_count++;
+	return dm_hdr2ptr(hdr);
+}
+
+void
+d_free(void *ptr)
+{
+	dm_free(ptr);
+}
+
+void *
+d_malloc(int tag, size_t size)
+{
+	return dm_alloc(tag, 0, size);
+}
+
+void *
+d_calloc(int tag, size_t count, size_t eltsize)
+{
+	void   *buf;
+	size_t  rsize = count * eltsize;
+
+	buf = dm_alloc(tag, 0, rsize);
+	memset(buf, 0, rsize);
+	return buf;
+}
+
+void *
+d_realloc(int tag, void *ptr, size_t size)
+{
+	struct dm_header	*hdr;
+	void			*new_ptr;
+	int			 alignment = 0;
+
+	/* trick part is @ptr can be NULL, so we still require @tag as input */
+	if (ptr) {
+		hdr = dm_ptr2hdr(ptr);
+		tag = hdr->mh_tag;
+		alignment = hdr->mh_alignment;
+	} else {
+		hdr = NULL;
+	}
+
+	new_ptr = dm_alloc(tag, alignment, size);
+	if (!new_ptr)
+		return NULL;
+
+	if (ptr) {
+		memcpy(new_ptr, ptr, min(size, hdr->mh_size));
+		dm_free(ptr);
+	}
+	return new_ptr;
+}
+
+char *
+d_strndup(const char *s, size_t n)
+{
+	char	*str;
+
+	str = dm_alloc(M_STR, 0, n + 1);
+	if (!str)
+		return NULL;
+
+	strncpy(str, s, n);
+	return str;
+}
+
+int
+d_asprintf(char **strp, const char *fmt, ...)
+{
+	char	*tmp1;
+	char	*tmp2;
+	va_list	ap;
+	int	rc;
+
+	va_start(ap, fmt);
+	rc = vasprintf(&tmp1, fmt, ap);
+	va_end(ap);
+
+	if (rc < 0)
+		return rc;
+
+	tmp2 = dm_alloc(M_STR, 0, strlen(tmp1) + 1);
+	if (!tmp2) {
+		free(tmp1);
+		return -1;
+	}
+	strncpy(tmp2, tmp1, strlen(tmp1));
+	free(tmp1);
+	*strp = tmp2;
+
+	return rc;
+}
+
+char *
+d_realpath(const char *path, char *resolved_path)
+{
+	char *tmp1;
+	char *tmp2;
+
+	/* NB: realpath is buggy on some platforms, the output string is
+	 * not NULL terminated.
+	 */
+	if (!resolved_path) {
+		tmp1 = d_calloc(M_STR, strlen(path) + 1, 1);
+		if (!tmp1)
+			return NULL;
+	} else {
+		tmp1 = resolved_path;
+		memset(tmp1, 0, strlen(path) + 1);
+	}
+
+	tmp2 = realpath(path, tmp1);
+	if (!tmp2) {
+		D_PRINT("Invalid output %s\n", tmp1);
+		if (tmp1 != resolved_path)
+			dm_free(tmp1);
+		return NULL;
+	}
+	return tmp1;
+}
+
+void *
+d_aligned_alloc(int tag, size_t alignment, size_t size)
+{
+	return dm_alloc(tag, alignment, size);
+}
+
+#else /* DAOS_DM_MODE */
+
+char *
+dm_mem_tag_query(int tag, int64_t *size_p, int64_t *count_p)
+{
+	return NULL;
+}
+
+void
+dm_mem_dump_log(void)
+{
+}
+
 void
 d_free(void *ptr)
 {
@@ -20,19 +476,19 @@ d_free(void *ptr)
 }
 
 void *
-d_calloc(size_t count, size_t eltsize)
+d_calloc(int tag, size_t count, size_t eltsize)
 {
 	return calloc(count, eltsize);
 }
 
 void *
-d_malloc(size_t size)
+d_malloc(int tag, size_t size)
 {
 	return malloc(size);
 }
 
 void *
-d_realloc(void *ptr, size_t size)
+d_realloc(int tag, void *ptr, size_t size)
 {
 	return realloc(ptr, size);
 }
@@ -63,10 +519,12 @@ d_realpath(const char *path, char *resolved_path)
 }
 
 void *
-d_aligned_alloc(size_t alignment, size_t size)
+d_aligned_alloc(int tag, size_t alignment, size_t size)
 {
 	return aligned_alloc(alignment, size);
 }
+
+#endif /* DAOS_DM_MODE */
 
 int
 d_rank_list_dup(d_rank_list_t **dst, const d_rank_list_t *src)
@@ -82,7 +540,7 @@ d_rank_list_dup(d_rank_list_t **dst, const d_rank_list_t *src)
 	if (src == NULL)
 		D_GOTO(out, 0);
 
-	D_ALLOC_PTR(rank_list);
+	DM_ALLOC_PTR(M_RANK, rank_list);
 	if (rank_list == NULL)
 		D_GOTO(out, rc = -DER_NOMEM);
 
@@ -90,7 +548,7 @@ d_rank_list_dup(d_rank_list_t **dst, const d_rank_list_t *src)
 	if (rank_list->rl_nr == 0)
 		D_GOTO(out, 0);
 
-	D_ALLOC_ARRAY(rank_list->rl_ranks, rank_list->rl_nr);
+	DM_ALLOC_ARRAY(M_RANK, rank_list->rl_ranks, rank_list->rl_nr);
 	if (rank_list->rl_ranks == NULL) {
 		D_FREE(rank_list);
 		D_GOTO(out, rc = -DER_NOMEM);
@@ -206,7 +664,7 @@ d_rank_list_alloc(uint32_t size)
 	d_rank_list_t		*rank_list;
 	int			 i;
 
-	D_ALLOC_PTR(rank_list);
+	DM_ALLOC_PTR(M_RANK, rank_list);
 	if (rank_list == NULL)
 		return NULL;
 
@@ -216,7 +674,7 @@ d_rank_list_alloc(uint32_t size)
 		return rank_list;
 	}
 
-	D_ALLOC_ARRAY(rank_list->rl_ranks, size);
+	DM_ALLOC_ARRAY(M_RANK, rank_list->rl_ranks, size);
 	if (rank_list->rl_ranks == NULL) {
 		D_FREE(rank_list);
 		return NULL;
@@ -240,7 +698,7 @@ d_rank_list_realloc(d_rank_list_t *ptr, uint32_t size)
 		d_rank_list_free(ptr);
 		return NULL;
 	}
-	D_REALLOC_ARRAY(new_rl_ranks, ptr->rl_ranks, ptr->rl_nr, size);
+	DM_REALLOC_ARRAY(M_RANK, new_rl_ranks, ptr->rl_ranks, ptr->rl_nr, size);
 	if (new_rl_ranks != NULL) {
 		ptr->rl_ranks = new_rl_ranks;
 		ptr->rl_nr = size;
@@ -481,7 +939,7 @@ d_rank_list_dump(d_rank_list_t *rank_list, d_string_t name, int name_len)
 	for (i = 0; i < rank_list->rl_nr; i++)
 		width += snprintf(NULL, 0, "%d ", rank_list->rl_ranks[i]);
 	width++;
-	D_ALLOC(tmp_str, width);
+	DM_ALLOC(M_STR, tmp_str, width);
 	if (tmp_str == NULL)
 		D_GOTO(out, rc = -DER_NOMEM);
 	for (i = 0; i < rank_list->rl_nr; i++)
@@ -516,7 +974,7 @@ rank_list_to_uint32_array(d_rank_list_t *rl, uint32_t **ints, size_t *len)
 {
 	uint32_t i;
 
-	D_ALLOC_ARRAY(*ints, rl->rl_nr);
+	DM_ALLOC_ARRAY(M_RANK, *ints, rl->rl_nr);
 	if (*ints == NULL)
 		return -DER_NOMEM;
 
@@ -672,7 +1130,7 @@ d_write_string_buffer(struct d_string_buffer_t *buf, const char *format, ...)
 	}
 
 	if (buf->str == NULL) {
-		D_ALLOC(buf->str, size);
+		DM_ALLOC(M_STR, buf->str, size);
 		if (buf->str == NULL) {
 			buf->status = -DER_NOMEM;
 			return -DER_NOMEM;
@@ -699,7 +1157,7 @@ d_write_string_buffer(struct d_string_buffer_t *buf, const char *format, ...)
 		}
 
 		size = buf->buf_size * 2;
-		D_REALLOC(new_buf, buf->str, buf->buf_size, size);
+		DM_REALLOC(M_STR, new_buf, buf->str, buf->buf_size, size);
 		if (new_buf == NULL) {
 			buf->status = -DER_NOMEM;
 			return -DER_NOMEM;

--- a/src/gurt/tests/test_gurt.c
+++ b/src/gurt/tests/test_gurt.c
@@ -239,6 +239,102 @@ void test_d_errdesc(void **state)
 	assert_string_equal(value, "Unknown error code -501001");
 }
 
+static int size_table[] = {
+	8,		16,
+	64,		12,
+	256,		1024,
+	4096,		8192,
+	(1 << 15),	(1 << 20),
+};
+
+struct dm_ptr {
+	int		foo[64];
+};
+
+#define TEST_STR	"/////tmp///"
+
+void test_dm_alloc(void **state)
+{
+	void		**ptrs;
+	int		 i;
+	int		 j;
+	int		 c;
+
+	for (i = 0; i < M_TAG_MAX; i++) {
+		char		*buf;
+		char		*buf2;
+		struct dm_ptr	*ptr;
+
+		for (j = 0; j < ARRAY_SIZE(size_table); j += 2) {
+			DM_ALLOC(i, buf, size_table[j]);
+			assert_non_null(buf);
+			buf[0] = 'a';
+			buf[size_table[j] - 1] = 'b';
+
+			D_REALLOC(buf2, buf, size_table[j], size_table[j + 1]);
+			assert_non_null(buf2);
+			buf2[0] = 'a';
+			buf2[size_table[j + 1] - 1] = 'b';
+			D_FREE(buf2);
+
+			DM_ALIGNED_ALLOC(i, buf, 128, size_table[j]);
+			assert_non_null(buf);
+			buf[0] = 'a';
+			buf[size_table[j] - 1] = 'b';
+
+			D_REALLOC(buf2, buf, size_table[j], size_table[j + 1]);
+			assert_non_null(buf2);
+			buf2[0] = 'a';
+			buf2[size_table[j + 1] - 1] = 'b';
+			D_FREE(buf2);
+
+			DM_ALLOC_PTR(i, ptr);
+			assert_non_null(ptr);
+			ptr->foo[0] = 1;
+			ptr->foo[63] = 2;
+			D_FREE_PTR(ptr);
+
+			DM_ALLOC_ARRAY(i, ptr, 16);
+			assert_non_null(ptr);
+			ptr[0].foo[1] = 1;
+			ptr[0].foo[63] = 2;
+			ptr[15].foo[1] = 1;
+			ptr[15].foo[63] = 2;
+			D_FREE(ptr);
+		}
+
+		D_STRNDUP_S(buf, TEST_STR);
+		assert_non_null(buf);
+		D_FREE(buf);
+
+		D_REALPATH(buf, TEST_STR);
+		assert_non_null(buf);
+		D_FREE(buf);
+
+		D_ASPRINTF(buf, "%s", TEST_STR);
+		assert_non_null(buf);
+		D_FREE(buf);
+	}
+
+	D_ALLOC_ARRAY(ptrs, 4096);
+	assert_non_null(ptrs);
+	for (c = i = 0; i < M_TAG_MAX; i++) {
+		for (j = 0; j < ARRAY_SIZE(size_table); j++) {
+			DM_ALLOC(i, ptrs[c], size_table[j]);
+			c++;
+		}
+	}
+	dm_mem_dump_log();
+	for (c = i = 0; i < M_TAG_MAX; i++) {
+		for (j = 0; j < ARRAY_SIZE(size_table); j++) {
+			D_FREE(ptrs[c]);
+			c++;
+		}
+	}
+	dm_mem_dump_log();
+	D_FREE(ptrs);
+}
+
 static int
 init_tests(void **state)
 {
@@ -265,7 +361,7 @@ static int
 fini_tests(void **state)
 {
 	rmdir(__root);
-	free(__root);
+	D_FREE(__root);
 	d_log_fini();
 
 	return 0;
@@ -2124,6 +2220,7 @@ main(int argc, char **argv)
 		cmocka_unit_test(test_time),
 		cmocka_unit_test(test_d_errstr),
 		cmocka_unit_test(test_d_errdesc),
+		cmocka_unit_test(test_dm_alloc),
 		cmocka_unit_test(test_gurt_list),
 		cmocka_unit_test(test_gurt_hlist),
 		cmocka_unit_test(test_gurt_circular_list),

--- a/src/include/gurt/common.h
+++ b/src/include/gurt/common.h
@@ -65,13 +65,69 @@ extern "C" {
 
 /* memory allocating macros */
 void  d_free(void *);
-void *d_calloc(size_t, size_t);
-void *d_malloc(size_t);
-void *d_realloc(void *, size_t);
+void *d_calloc(int tag, size_t, size_t);
+void *d_malloc(int tag, size_t);
+void *d_realloc(int tag, void *, size_t);
 char *d_strndup(const char *s, size_t n);
 int d_asprintf(char **strp, const char *fmt, ...);
-void *d_aligned_alloc(size_t alignment, size_t size);
+void *d_aligned_alloc(int tag, size_t alignment, size_t size);
 char *d_realpath(const char *path, char *resolved_path);
+
+#define DAOS_DM_MODE	1	/* enable debug-memory mode */
+
+#define DAOS_DM_INTV	5	/* dump memory log every 5 seconds */
+
+/** Allocation tag, please make sure dm_counters are declared in the same order. */
+enum dm_tag {
+	M_OTHER,		/* all the untagged */
+	M_STR,			/* strdup, asprintf... */
+	M_RANK,			/* rank list allocation */
+	M_CRT,			/* default cart tag */
+	M_CRT_RPC,		/* CaRT RPC */
+	M_CRT_IV,		/* IV framework in cart */
+	M_SWIM,			/* SWIM */
+	M_CSUM,			/* checksum */
+	M_PROP,			/* properties */
+	M_TSE,			/* task engine */
+	M_PL,			/* placement */
+	M_IV,			/* DAOS level IV */
+	M_SCHED,		/* ABT scheduler */
+	M_IO,			/* common I/O code */
+	M_IO_ARG,		/* SGL, IOV... */
+	M_BIO,			/* BIO */
+	M_VEA,			/* VEA */
+	M_AGG,			/* common aggregation */
+	M_RECOV,		/* common rebuild */
+	M_EC,			/* common EC */
+	M_EC_AGG,		/* EC aggregation */
+	M_EC_RECOV,		/* EC recovery */
+	M_POOL,			/* Pool, cache or data structures */
+	M_CONT,			/* contaier, cache or data structures */
+	M_OBJ,			/* object, shard, cache... */
+	M_DTX,			/* distributed transaction */
+	M_VOS,			/* common VOS */
+	M_VOS_TS,		/* VOS timestamp cache */
+	M_VOS_LRU,		/* VOS LRU */
+	M_VOS_DTX,		/* DTX in VOS */
+	M_RDB,			/* Raft DB */
+	M_TAG_MAX,		/* the last */
+};
+
+struct dm_tls_counter;
+
+/* 64 bytes header in memory-debugging mode */
+struct dm_header {
+	struct dm_tls_counter	*mh_counter;
+	/** real address of the buffer */
+	void			*mh_addr;
+	int64_t			 mh_size;
+	int32_t			 mh_alignment;
+	int32_t			 mh_tag;
+	uint64_t		 mh_payload[0];
+};
+
+char *dm_mem_tag_query(int tag, int64_t *size_p, int64_t *count_p);
+void  dm_mem_dump_log(void);
 
 #define D_CHECK_ALLOC(func, cond, ptr, name, size, count, cname,	\
 			on_error)					\
@@ -104,16 +160,16 @@ char *d_realpath(const char *path, char *resolved_path);
 				(int)(size));				\
 	} while (0)
 
-#define D_ALLOC_CORE(ptr, size, count)					\
+#define DM_ALLOC_CORE(tag, ptr, size, count)				\
 	do {								\
-		(ptr) = (__typeof__(ptr))d_calloc((count), (size));	\
+		(ptr) = (__typeof__(ptr))d_calloc(tag, (count), (size)); \
 		D_CHECK_ALLOC(calloc, true, ptr, #ptr, size,		\
 			      count, #count, 0);			\
 	} while (0)
 
-#define D_ALLOC_CORE_NZ(ptr, size, count)				\
+#define DM_ALLOC_CORE_NZ(tag, ptr, size, count)				\
 	do {								\
-		(ptr) = (__typeof__(ptr))d_malloc((count) * (size));	\
+		(ptr) = (__typeof__(ptr))d_malloc(tag, (count) * (size)); \
 		D_CHECK_ALLOC(malloc, true, ptr, #ptr, size,		\
 			      count, #count, 0);			\
 	} while (0)
@@ -163,19 +219,22 @@ char *d_realpath(const char *path, char *resolved_path);
 			errno = ENOMEM;					\
 	} while (0)
 
-#define D_ALIGNED_ALLOC(ptr, alignment, size)				\
+#define DM_ALIGNED_ALLOC(tag, ptr, alignment, size)			\
 	do {								\
-		(ptr) = (__typeof__(ptr))d_aligned_alloc(alignment,	\
+		(ptr) = (__typeof__(ptr))d_aligned_alloc(tag, alignment,\
 							 size);		\
 		D_CHECK_ALLOC(aligned_alloc, true, ptr, #ptr,		\
 			      size, 0, #ptr, 0);			\
 	} while (0)
 
+#define D_ALIGNED_ALLOC(ptr, alignment, size)				\
+	DM_ALIGNED_ALLOC(M_OTHER, ptr, alignemnt, size)
+
 /* Requires newptr and oldptr to be different variables.  Otherwise
  * there is no way to tell the difference between successful and
  * failed realloc.
  */
-#define D_REALLOC_COMMON(newptr, oldptr, oldsize, size, cnt)		\
+#define DM_REALLOC_COMMON(tag, newptr, oldptr, oldsize, size, cnt)	\
 	do {								\
 		size_t _esz = (size_t)(size);				\
 		size_t _sz = (size_t)(size) * (cnt);			\
@@ -197,7 +256,7 @@ char *d_realpath(const char *path, char *resolved_path);
 		if (D_SHOULD_FAIL(d_fault_attr_mem))			\
 			(newptr) = NULL;				\
 		else							\
-			(newptr) = d_realloc(optr, _sz);		\
+			(newptr) = d_realloc(tag, optr, _sz);		\
 		if ((newptr) != NULL) {					\
 			if (_cnt <= 1)					\
 				D_DEBUG(DB_MEM,				\
@@ -230,37 +289,53 @@ char *d_realpath(const char *path, char *resolved_path);
 				_esz, _cnt);				\
 	} while (0)
 
+#define DM_REALLOC(tag, newptr, oldptr, oldsize, size)			\
+	DM_REALLOC_COMMON(tag, newptr, oldptr, oldsize, size, 1)
 #define D_REALLOC(newptr, oldptr, oldsize, size)			\
-	D_REALLOC_COMMON(newptr, oldptr, oldsize, size, 1)
+	DM_REALLOC(M_OTHER, newptr, oldptr, oldsize, size)
 
-#define D_REALLOC_ARRAY(newptr, oldptr, oldcount, count)		\
-	D_REALLOC_COMMON(newptr, oldptr,				\
+#define DM_REALLOC_ARRAY(tag, newptr, oldptr, oldcount, count)		\
+	DM_REALLOC_COMMON(tag, newptr, oldptr,				\
 			 (oldcount) * sizeof(*(oldptr)),		\
 					     sizeof(*(oldptr)), count)
+#define D_REALLOC_ARRAY(newptr, oldptr, oldcount, count)		\
+	DM_REALLOC_ARRAY(M_OTHER, newptr, oldptr, oldcount, count)
 
+#define DM_REALLOC_NZ(tag, newptr, oldptr, size)			\
+	DM_REALLOC_COMMON(tag, newptr, oldptr, size, size, 1)
 #define D_REALLOC_NZ(newptr, oldptr, size)				\
-	D_REALLOC_COMMON(newptr, oldptr, size, size, 1)
+	DM_REALLOC_NZ(M_OTHER, newptr, oldptr, size)
 
-#define D_REALLOC_ARRAY_NZ(newptr, oldptr, count)			\
-	D_REALLOC_COMMON(newptr, oldptr,				\
+#define DM_REALLOC_ARRAY_NZ(tag, newptr, oldptr, count)			\
+	DM_REALLOC_COMMON(tag, newptr, oldptr,				\
 			 (count) * sizeof(*(oldptr)),			\
 			 sizeof(*(oldptr)), count)
+#define D_REALLOC_ARRAY_NZ(newptr, oldptr, count)			\
+	DM_REALLOC_ARRAY_NZ(M_OTHER, newptr, oldptr, count)
 
 /** realloc macros that do not clear the new memory */
+#define DM_REALLOC_NZ(tag, newptr, oldptr, size)			\
+	DM_REALLOC_COMMON(tag, newptr, oldptr, size, size, 1)
 #define D_REALLOC_NZ(newptr, oldptr, size)				\
-	D_REALLOC_COMMON(newptr, oldptr, size, size, 1)
+	DM_REALLOC_NZ(M_OTHER, newptr, oldptr, size)
 
-#define D_REALLOC_ARRAY_NZ(newptr, oldptr, count)			\
-	D_REALLOC_COMMON(newptr, oldptr,				\
+#define DM_REALLOC_ARRAY_NZ(tag, newptr, oldptr, count)			\
+	DM_REALLOC_COMMON(tag, newptr, oldptr,				\
 			 (count) * sizeof(*(oldptr)),			\
 			 sizeof(*(oldptr)), count)
+#define D_REALLOC_ARRAY_NZ(newptr, oldptr, count)			\
+	DM_REALLOC_ARRAY_NZ(M_OTHER, newptr, oldptr, count)
 
 /** realloc macros that clear the whole allocation */
+#define DM_REALLOC_Z(tag, newptr, oldptr, size)				\
+	DM_REALLOC_COMMON(tag, newptr, oldptr, 0, size, 1)
 #define D_REALLOC_Z(newptr, oldptr, size)				\
-	D_REALLOC_COMMON(newptr, oldptr, 0, size, 1)
+	DM_REALLOC_Z(M_OTHER, newptr, oldptr, size)
 
+#define DM_REALLOC_ARRAY_Z(tag, newptr, oldptr, count)			\
+	DM_REALLOC_COMMON(tag, newptr, oldptr, 0, sizeof(*(oldptr)), count)
 #define D_REALLOC_ARRAY_Z(newptr, oldptr, count)			\
-	D_REALLOC_COMMON(newptr, oldptr, 0, sizeof(*(oldptr)), count)
+	DM_REALLOC_ARRAY_Z(M_OTHER, newptr, oldptr, count)
 
 #define D_FREE(ptr)							\
 	do {								\
@@ -269,12 +344,24 @@ char *d_realpath(const char *path, char *resolved_path);
 		(ptr) = NULL;						\
 	} while (0)
 
-#define D_ALLOC(ptr, size)	D_ALLOC_CORE(ptr, size, 1)
-#define D_ALLOC_PTR(ptr)	D_ALLOC(ptr, sizeof(*ptr))
-#define D_ALLOC_ARRAY(ptr, count) D_ALLOC_CORE(ptr, sizeof(*ptr), count)
-#define D_ALLOC_NZ(ptr, size)	D_ALLOC_CORE_NZ(ptr, size, 1)
-#define D_ALLOC_PTR_NZ(ptr)	D_ALLOC_NZ(ptr, sizeof(*ptr))
-#define D_ALLOC_ARRAY_NZ(ptr, count) D_ALLOC_CORE_NZ(ptr, sizeof(*ptr), count)
+#define DM_ALLOC(tag, ptr, size)	DM_ALLOC_CORE(tag, ptr, size, 1)
+#define D_ALLOC(ptr, size)		DM_ALLOC(M_OTHER, ptr, size)
+
+#define DM_ALLOC_PTR(tag, ptr)		DM_ALLOC(tag, ptr, sizeof(*ptr))
+#define D_ALLOC_PTR(ptr)		DM_ALLOC_PTR(M_OTHER, ptr)
+
+#define DM_ALLOC_ARRAY(tag, ptr, count)	DM_ALLOC_CORE(tag, ptr, sizeof(*ptr), count)
+#define D_ALLOC_ARRAY(ptr, count)	DM_ALLOC_ARRAY(M_OTHER, ptr, count)
+
+#define DM_ALLOC_NZ(tag, ptr, size)	DM_ALLOC_CORE_NZ(tag, ptr, size, 1)
+#define D_ALLOC_NZ(ptr, size)		DM_ALLOC_NZ(M_OTHER, ptr, size)
+
+#define DM_ALLOC_PTR_NZ(tag, ptr)	DM_ALLOC_NZ(tag, ptr, sizeof(*ptr))
+#define D_ALLOC_PTR_NZ(ptr)		DM_ALLOC_PTR_NZ(M_OTHER, ptr)
+
+#define DM_ALLOC_ARRAY_NZ(tag, ptr, count)	DM_ALLOC_CORE_NZ(tag, ptr, sizeof(*ptr), count)
+#define D_ALLOC_ARRAY_NZ(ptr, count)		DM_ALLOC_ARRAY_NZ(M_OTHER, ptr, count)
+
 #define D_FREE_PTR(ptr)		D_FREE(ptr)
 
 #define D_GOTO(label, rc)			\
@@ -406,7 +493,7 @@ d_sgl_init(d_sg_list_t *sgl, unsigned int nr)
 		return 0;
 	}
 
-	D_ALLOC_ARRAY(sgl->sg_iovs, nr);
+	DM_ALLOC_ARRAY(M_IO_ARG, sgl->sg_iovs, nr);
 
 	return sgl->sg_iovs == NULL ? -DER_NOMEM : 0;
 }

--- a/src/object/cli_ec.c
+++ b/src/object/cli_ec.c
@@ -40,7 +40,7 @@ obj_ec_recxs_init(struct obj_ec_recx_array *recxs, uint32_t recx_nr)
 	if (recx_nr == 0)
 		return 0;
 
-	D_ALLOC_ARRAY(recxs->oer_recxs, recx_nr);
+	DM_ALLOC_ARRAY(M_EC, recxs->oer_recxs, recx_nr);
 	if (recxs->oer_recxs == NULL)
 		return -DER_NOMEM;
 
@@ -83,7 +83,7 @@ obj_ec_pbufs_init(struct obj_ec_recx_array *recxs, uint64_t cell_bytes)
 		return 0;
 
 	parity_len = roundup(recxs->oer_stripe_total * cell_bytes, 8);
-	D_ALLOC(pbuf, parity_len * recxs->oer_p);
+	DM_ALLOC(M_EC, pbuf, parity_len * recxs->oer_p);
 	if (pbuf == NULL)
 		return -DER_NOMEM;
 
@@ -99,7 +99,7 @@ static int
 obj_ec_riod_init(daos_iod_t *riod, uint32_t recx_nr)
 {
 	riod->iod_nr = recx_nr;
-	D_ALLOC_ARRAY(riod->iod_recxs, recx_nr);
+	DM_ALLOC_ARRAY(M_EC, riod->iod_recxs, recx_nr);
 	if (riod->iod_recxs == NULL)
 		return -DER_NOMEM;
 	return 0;
@@ -114,7 +114,7 @@ obj_ec_seg_sorter_init(struct obj_ec_seg_sorter *sorter, uint32_t tgt_nr,
 	int		 i;
 
 	buf_size = sizeof(struct obj_ec_seg_head) * tgt_nr;
-	D_ALLOC(buf, buf_size + sizeof(struct obj_ec_seg) * seg_nr);
+	DM_ALLOC(M_EC, buf, buf_size + sizeof(struct obj_ec_seg) * seg_nr);
 	if (buf == NULL)
 		return -DER_NOMEM;
 
@@ -500,7 +500,7 @@ obj_ec_stripe_encode(daos_iod_t *iod, d_sg_list_t *sgl, uint32_t iov_idx,
 		} else {
 			uint64_t copied = 0;
 
-			D_ALLOC(c_data[c_idx], cell_bytes);
+			DM_ALLOC(M_EC, c_data[c_idx], cell_bytes);
 			if (c_data[c_idx] == NULL)
 				D_GOTO(out, rc = -DER_NOMEM);
 			while (copied < len) {
@@ -1127,7 +1127,7 @@ obj_ec_recx_reasb(daos_iod_t *iod, d_sg_list_t *sgl,
 		if (iov_nr <= EC_INLINE_IOVS) {
 			iovs = iov_inline;
 		} else {
-			D_ALLOC_ARRAY(iovs, iov_nr);
+			DM_ALLOC_ARRAY(M_EC, iovs, iov_nr);
 			if (iovs == NULL)
 				return -DER_NOMEM;
 		}
@@ -1836,7 +1836,7 @@ obj_ec_recov_codec_alloc(struct daos_oclass_attr *oca)
 	list_size = roundup(sizeof(uint32_t) * p, 8);
 	err_size = roundup(sizeof(bool) * (k + p), 8);
 
-	D_ALLOC(buf, struct_size + tbl_size + 3 * matrix_size + idx_size +
+	DM_ALLOC(M_EC_RECOV, buf, struct_size + tbl_size + 3 * matrix_size + idx_size +
 		     list_size + err_size);
 	if (buf == NULL)
 		return NULL;
@@ -1877,7 +1877,7 @@ obj_ec_recov_add(struct obj_reasb_req *reasb_req,
 	D_MUTEX_LOCK(&reasb_req->orr_mutex);
 	recov_lists = reasb_req->orr_fail->efi_recx_lists;
 	if (recov_lists == NULL) {
-		D_ALLOC_ARRAY(recov_lists, nr);
+		DM_ALLOC_ARRAY(M_EC_RECOV, recov_lists, nr);
 		if (recov_lists == NULL)
 			return -DER_NOMEM;
 		reasb_req->orr_fail->efi_recx_lists = recov_lists;
@@ -1968,13 +1968,13 @@ obj_ec_fail_info_get(struct obj_reasb_req *reasb_req, bool create, uint16_t nr)
 		return fail_info;
 
 	D_ASSERT(nr <= OBJ_EC_MAX_M);
-	D_ALLOC_PTR(fail_info);
+	DM_ALLOC_PTR(M_EC_RECOV, fail_info);
 	if (fail_info == NULL)
 		return NULL;
 	reasb_req->orr_fail = fail_info;
 	reasb_req->orr_fail_alloc = 1;
 
-	D_ALLOC_ARRAY(fail_info->efi_tgt_list, nr);
+	DM_ALLOC_ARRAY(M_EC_RECOV, fail_info->efi_tgt_list, nr);
 	if (fail_info->efi_tgt_list == NULL)
 		return NULL;
 
@@ -2185,7 +2185,7 @@ obj_ec_stripe_list_init(struct obj_reasb_req *reasb_req)
 		return 0;
 
 	stripe_rec_nr = obj_ec_stripe_rec_nr(oca);
-	D_ALLOC_ARRAY(stripe_lists, iod_nr);
+	DM_ALLOC_ARRAY(M_EC, stripe_lists, iod_nr);
 	if (stripe_lists == NULL)
 		return -DER_NOMEM;
 
@@ -2274,7 +2274,7 @@ obj_ec_recov_task_init(struct obj_reasb_req *reasb_req, daos_obj_id_t oid,
 	uint32_t			 i, j, tidx = 0;
 	int				 rc = 0;
 
-	D_ALLOC_ARRAY(fail_info->efi_stripe_sgls, iod_nr);
+	DM_ALLOC_ARRAY(M_EC_RECOV, fail_info->efi_stripe_sgls, iod_nr);
 	if (fail_info->efi_stripe_sgls == NULL)
 		D_GOTO(out, rc = -DER_NOMEM);
 	fail_info->efi_stripe_sgls_nr = iod_nr;
@@ -2320,13 +2320,13 @@ obj_ec_recov_task_init(struct obj_reasb_req *reasb_req, daos_obj_id_t oid,
 		rc = d_sgl_init(sgl, 1);
 		if (rc)
 			goto out;
-		D_ALLOC(buf, buf_sz);
+		DM_ALLOC(M_EC_RECOV, buf, buf_sz);
 		if (buf == NULL)
 			D_GOTO(out, rc = -DER_NOMEM);
 		d_iov_set(&sgl->sg_iovs[0], buf, buf_sz);
 	}
 
-	D_ALLOC_ARRAY(fail_info->efi_recov_tasks, recx_ep_nr);
+	DM_ALLOC_ARRAY(M_EC_RECOV, fail_info->efi_recov_tasks, recx_ep_nr);
 	if (fail_info->efi_recov_tasks == NULL)
 		D_GOTO(out, rc = -DER_NOMEM);
 	fail_info->efi_recov_ntasks = recx_ep_nr;
@@ -2723,7 +2723,7 @@ obj_ec_tgt_oiod_init(struct obj_io_desc *r_oiods, uint32_t iod_nr,
 
 	D_ASSERT(tgt_nr > 0 && iod_nr > 0);
 
-	D_ALLOC_ARRAY(tgt_oiods, tgt_nr);
+	DM_ALLOC_ARRAY(M_EC, tgt_oiods, tgt_nr);
 	if (tgt_oiods == NULL)
 		return NULL;
 
@@ -2731,7 +2731,7 @@ obj_ec_tgt_oiod_init(struct obj_io_desc *r_oiods, uint32_t iod_nr,
 	oiod_size = roundup(sizeof(struct obj_io_desc), 8);
 	siod_size = roundup(sizeof(struct obj_shard_iod), 8);
 	item_size = (off_size + oiod_size + siod_size) * iod_nr;
-	D_ALLOC(buf, item_size * tgt_nr);
+	DM_ALLOC(M_EC, buf, item_size * tgt_nr);
 	if (buf == NULL) {
 		D_FREE(tgt_oiods);
 		return NULL;
@@ -2841,11 +2841,11 @@ obj_recx_ec2_daos(struct daos_oclass_attr *oca, int shard, daos_recx_t **recxs_p
 			 cell_nr;
 	}
 
-	D_ALLOC_ARRAY(tgt_recxs, total);
+	DM_ALLOC_ARRAY(M_EC, tgt_recxs, total);
 	if (tgt_recxs == NULL)
 		return -DER_NOMEM;
 	if (recx_ephs_p != NULL) {
-		D_ALLOC_ARRAY(recx_ephs, total);
+		DM_ALLOC_ARRAY(M_EC, recx_ephs, total);
 		if (recx_ephs == NULL) {
 			D_FREE(tgt_recxs);
 			return -DER_NOMEM;
@@ -2930,12 +2930,12 @@ obj_recx_ec_daos2shard(struct daos_oclass_attr *oca, int shard, daos_recx_t **re
 		return 0;
 	}
 
-	D_ALLOC_ARRAY(tgt_recxs, total);
+	DM_ALLOC_ARRAY(M_EC, tgt_recxs, total);
 	if (tgt_recxs == NULL)
 		return -DER_NOMEM;
 
 	if (recx_ephs_p != NULL) {
-		D_ALLOC_ARRAY(new_ephs, total);
+		DM_ALLOC_ARRAY(M_EC, new_ephs, total);
 		if (new_ephs == NULL) {
 			D_FREE(tgt_recxs);
 			return -DER_NOMEM;

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -243,7 +243,7 @@ obj_alloc(void)
 {
 	struct dc_object *obj;
 
-	D_ALLOC_PTR(obj);
+	DM_ALLOC_PTR(M_OBJ, obj);
 	if (obj == NULL)
 		return NULL;
 
@@ -343,7 +343,7 @@ obj_layout_create(struct dc_object *obj, bool refresh)
 	obj->cob_version = layout->ol_ver;
 
 	D_ASSERT(obj->cob_shards == NULL);
-	D_ALLOC(obj->cob_shards, sizeof(struct dc_obj_layout) +
+	DM_ALLOC(M_OBJ, obj->cob_shards, sizeof(struct dc_obj_layout) +
 		sizeof(struct dc_obj_shard) * layout->ol_nr);
 	if (obj->cob_shards == NULL)
 		D_GOTO(out, rc = -DER_NOMEM);
@@ -357,7 +357,7 @@ obj_layout_create(struct dc_object *obj, bool refresh)
 	    old < obj->cob_grp_nr) {
 		D_FREE(obj->cob_time_fetch_leader);
 
-		D_ALLOC_ARRAY(obj->cob_time_fetch_leader, obj->cob_grp_nr);
+		DM_ALLOC_ARRAY(M_OBJ, obj->cob_time_fetch_leader, obj->cob_grp_nr);
 		if (obj->cob_time_fetch_leader == NULL)
 			D_GOTO(out, rc = -DER_NOMEM);
 	}
@@ -413,7 +413,7 @@ obj_auxi_add_failed_tgt(struct obj_auxi_args *obj_auxi, uint32_t tgt)
 	uint32_t			*tgts;
 
 	if (tgt_list == NULL) {
-		D_ALLOC_PTR(tgt_list);
+		DM_ALLOC_PTR(M_RECOV, tgt_list);
 		if (tgt_list == NULL)
 			return -DER_NOMEM;
 		allocated = true;
@@ -424,8 +424,7 @@ obj_auxi_add_failed_tgt(struct obj_auxi_args *obj_auxi, uint32_t tgt)
 		}
 	}
 
-	D_REALLOC_ARRAY(tgts, tgt_list->tl_tgts, tgt_list->tl_nr,
-			tgt_list->tl_nr + 1);
+	DM_REALLOC_ARRAY(M_OBJ, tgts, tgt_list->tl_tgts, tgt_list->tl_nr, tgt_list->tl_nr + 1);
 	if (tgts == NULL) {
 		if (allocated)
 			D_FREE(tgt_list);
@@ -769,7 +768,7 @@ obj_reasb_req_init(struct obj_reasb_req *reasb_req, struct dc_object *obj, daos_
 	buf_size = size_iod + size_sgl + size_oiod + size_recx + size_sorter +
 		   size_singv + size_array + size_tgt_nr * iod_nr * 2 + OBJ_TGT_BITMAP_LEN +
 		   size_size_set;
-	D_ALLOC(buf, buf_size);
+	DM_ALLOC(M_IO, buf, buf_size);
 	if (buf == NULL)
 		return -DER_NOMEM;
 
@@ -1092,7 +1091,7 @@ obj_shards_2_fwtgts(struct dc_object *obj, uint32_t map_ver, uint8_t *bit_map,
 			req_tgts->ort_shard_tgts = NULL;
 		}
 		if (req_tgts->ort_shard_tgts == NULL) {
-			D_ALLOC_ARRAY(req_tgts->ort_shard_tgts, shard_nr);
+			DM_ALLOC_ARRAY(M_IO, req_tgts->ort_shard_tgts, shard_nr);
 			if (req_tgts->ort_shard_tgts == NULL)
 				return -DER_NOMEM;
 		}
@@ -1480,14 +1479,14 @@ daos_obj_layout_alloc(struct daos_obj_layout **layout, uint32_t grp_nr,
 	int rc = 0;
 	int i;
 
-	D_ALLOC(*layout, sizeof(struct daos_obj_layout) +
+	DM_ALLOC(M_OBJ, *layout, sizeof(struct daos_obj_layout) +
 			 grp_nr * sizeof(struct daos_obj_shard *));
 	if (*layout == NULL)
 		return -DER_NOMEM;
 
 	(*layout)->ol_nr = grp_nr;
 	for (i = 0; i < grp_nr; i++) {
-		D_ALLOC((*layout)->ol_shards[i],
+		DM_ALLOC(M_OBJ, (*layout)->ol_shards[i],
 			sizeof(struct daos_obj_shard) +
 			grp_size * sizeof(struct daos_shard_loc));
 		if ((*layout)->ol_shards[i] == NULL)
@@ -1771,7 +1770,7 @@ obj_bulk_prep(d_sg_list_t *sgls, unsigned int nr, bool bulk_bind,
 	int		 rc = 0;
 
 	D_ASSERTF(nr >= 1, "invalid nr %d.\n", nr);
-	D_ALLOC_ARRAY(bulks, nr);
+	DM_ALLOC_ARRAY(M_IO, bulks, nr);
 	if (bulks == NULL)
 		D_GOTO(out, rc = -DER_NOMEM);
 
@@ -2990,7 +2989,7 @@ merge_recx_insert(d_list_t *prev, uint64_t offset, uint64_t size, daos_epoch_t e
 {
 	struct obj_auxi_list_recx *new;
 
-	D_ALLOC_PTR(new);
+	DM_ALLOC_PTR(M_IO, new);
 	if (new == NULL)
 		return -DER_NOMEM;
 
@@ -3219,11 +3218,11 @@ merge_key(d_list_t *head, char *key, int key_size)
 		}
 	}
 
-	D_ALLOC_PTR(key_one);
+	DM_ALLOC_PTR(M_IO, key_one);
 	if (key_one == NULL)
 		return -DER_NOMEM;
 
-	D_ALLOC(key_one->key.iov_buf, key_size);
+	DM_ALLOC(M_IO, key_one->key.iov_buf, key_size);
 	if (key_one->key.iov_buf == NULL) {
 		D_FREE(key_one);
 		return -DER_NOMEM;
@@ -3272,7 +3271,7 @@ obj_shard_list_key_cb(struct shard_auxi_args *shard_auxi,
 		} else {
 			int left = key_size;
 
-			D_ALLOC(key, key_size);
+			DM_ALLOC(M_IO, key, key_size);
 			if (key == NULL)
 				return -DER_NOMEM;
 
@@ -4630,7 +4629,7 @@ shard_anchor_prep(daos_anchor_t *anchor, int nr)
 	int		i;
 
 	D_ASSERT(anchor->da_sub_anchors == 0);
-	D_ALLOC_ARRAY(sub_anchors, nr);
+	DM_ALLOC_ARRAY(M_IO, sub_anchors, nr);
 	if (sub_anchors == NULL)
 		return -DER_NOMEM;
 
@@ -4722,11 +4721,11 @@ obj_shard_list_prep(daos_obj_list_t *obj_args, struct dc_object *obj,
 
 		seg_size = obj_args->sgl->sg_iovs[0].iov_buf_len / shard_nr;
 
-		D_ALLOC_PTR(shard_arg->la_sgl);
+		DM_ALLOC_PTR(M_IO_ARG, shard_arg->la_sgl);
 		if (shard_arg->la_sgl == NULL)
 			D_GOTO(out, rc = -DER_NOMEM);
 
-		D_ALLOC_PTR(shard_iov);
+		DM_ALLOC_PTR(M_IO_ARG, shard_iov);
 		if (shard_iov == NULL)
 			D_GOTO(out, rc = -DER_NOMEM);
 
@@ -5620,7 +5619,7 @@ dc_obj_sync(tse_task_t *task)
 	if (!obj_auxi->io_retry) {
 		daos_epoch_t	*tmp = NULL;
 
-		D_ALLOC_ARRAY(tmp, obj->cob_grp_nr);
+		DM_ALLOC_ARRAY(M_OBJ, tmp, obj->cob_grp_nr);
 		if (tmp == NULL)
 			D_GOTO(out_task, rc = -DER_NOMEM);
 
@@ -5683,7 +5682,7 @@ dc_obj_verify(daos_handle_t oh, daos_epoch_t *epochs, unsigned int nr)
 	D_ASSERTF(obj->cob_grp_nr == nr, "Invalid grp count %u/%u\n",
 		  obj->cob_grp_nr, nr);
 
-	D_ALLOC_ARRAY(dova, reps);
+	DM_ALLOC_ARRAY(M_IO, dova, reps);
 	if (dova == NULL) {
 		D_ERROR(DF_OID" no MEM for verify group, reps %u\n",
 			DP_OID(obj->cob_md.omd_id), reps);

--- a/src/object/cli_shard.c
+++ b/src/object/cli_shard.c
@@ -320,7 +320,7 @@ dc_rw_cb_csum_verify(const struct rw_cb_args *rw_args)
 			if (sgls[i].sg_nr <= IOV_INLINE) {
 				shard_sgl.sg_iovs = iovs_inline;
 			} else {
-				D_ALLOC_ARRAY(iovs_alloc, sgls[i].sg_nr);
+				DM_ALLOC_ARRAY(M_IO_ARG, iovs_alloc, sgls[i].sg_nr);
 				if (iovs_alloc == NULL) {
 					rc = -DER_NOMEM;
 					break;
@@ -417,7 +417,7 @@ iom_recx_merge(daos_iom_t *dst, daos_recx_t *recx, bool iom_realloc)
 		 "iom_nr_out %d, iom_nr %d\n", dst->iom_nr_out, dst->iom_nr);
 	if (iom_realloc && dst->iom_nr_out == dst->iom_nr) {
 		iom_nr = dst->iom_nr + 32;
-		D_REALLOC_ARRAY(tmpr, dst->iom_recxs, dst->iom_nr, iom_nr);
+		DM_REALLOC_ARRAY(M_IO_ARG, tmpr, dst->iom_recxs, dst->iom_nr, iom_nr);
 		if (tmpr == NULL)
 			return -DER_NOMEM;
 		dst->iom_recxs = tmpr;
@@ -509,7 +509,7 @@ obj_ec_iom_merge(struct obj_reasb_req *reasb_req, uint32_t shard,
 	if (dst->iom_recxs == NULL) {
 		iom_nr = src->iom_nr * reasb_req->orr_tgt_nr;
 		iom_nr = roundup(iom_nr, 8);
-		D_ALLOC_ARRAY(dst->iom_recxs, iom_nr);
+		DM_ALLOC_ARRAY(M_IO_ARG, dst->iom_recxs, iom_nr);
 		if (dst->iom_recxs == NULL) {
 			D_MUTEX_UNLOCK(&reasb_req->orr_mutex);
 			return -DER_NOMEM;

--- a/src/object/obj_class.c
+++ b/src/object/obj_class.c
@@ -436,11 +436,11 @@ obj_ec_codec_init()
 		return 0;
 
 	oc_ec_codec_nr = ocnr;
-	D_ALLOC_ARRAY(oc_ec_codecs, ocnr);
+	DM_ALLOC_ARRAY(M_EC, oc_ec_codecs, ocnr);
 	if (oc_ec_codecs == NULL)
 		D_GOTO(failed, rc = -DER_NOMEM);
 
-	D_ALLOC_ARRAY(ecc_array, ocnr);
+	DM_ALLOC_ARRAY(M_EC, ecc_array, ocnr);
 	if (ecc_array == NULL)
 		D_GOTO(failed, rc = -DER_NOMEM);
 
@@ -469,10 +469,10 @@ obj_ec_codec_init()
 		}
 		m = k + p;
 		/* 32B needed for data generated for each input coefficient */
-		D_ALLOC(ec_codec->ec_gftbls, k * p * 32);
+		DM_ALLOC(M_EC, ec_codec->ec_gftbls, k * p * 32);
 		if (ec_codec->ec_gftbls == NULL)
 			D_GOTO(failed, rc = -DER_NOMEM);
-		D_ALLOC(encode_matrix, m * k);
+		DM_ALLOC(M_EC, encode_matrix, m * k);
 		if (encode_matrix == NULL)
 			D_GOTO(failed, rc = -DER_NOMEM);
 		ec_codec->ec_en_matrix = encode_matrix;
@@ -755,17 +755,17 @@ obj_class_init(void)
 	if (oc_ident_array)
 		return 0;
 
-	D_ALLOC_ARRAY(oc_ident_array, OC_NR);
+	DM_ALLOC_ARRAY(M_OBJ, oc_ident_array, OC_NR);
 	if (!oc_ident_array)
 		return -DER_NOMEM;
 
-	D_ALLOC_ARRAY(oc_scale_array, OC_NR);
+	DM_ALLOC_ARRAY(M_OBJ, oc_scale_array, OC_NR);
 	if (!oc_scale_array) {
 		rc = -DER_NOMEM;
 		goto failed;
 	}
 
-	D_ALLOC_ARRAY(oc_resil_array, OC_NR);
+	DM_ALLOC_ARRAY(M_OBJ, oc_resil_array, OC_NR);
 	if (!oc_resil_array) {
 		rc = -DER_NOMEM;
 		goto failed;

--- a/src/object/obj_ec.h
+++ b/src/object/obj_ec.h
@@ -411,7 +411,7 @@ obj_io_desc_init(struct obj_io_desc *oiod, uint32_t tgt_nr, uint32_t flags)
 	}
 #endif
 	if ((flags & OBJ_SIOD_SINGV) == 0) {
-		D_ALLOC_ARRAY(oiod->oiod_siods, tgt_nr);
+		DM_ALLOC_ARRAY(M_EC, oiod->oiod_siods, tgt_nr);
 		if (oiod->oiod_siods == NULL)
 			return -DER_NOMEM;
 	}
@@ -482,7 +482,7 @@ obj_iod_break(daos_iod_t *iod, struct daos_oclass_attr *oca)
 		D_ASSERT(stripe_nr >= 1);
 		if (stripe_nr == 1)
 			continue;
-		D_ALLOC_ARRAY(new_recx, stripe_nr + iod->iod_nr - 1);
+		DM_ALLOC_ARRAY(M_IO_ARG, new_recx, stripe_nr + iod->iod_nr - 1);
 		if (new_recx == NULL)
 			return -DER_NOMEM;
 		for (j = 0; j < i; j++)

--- a/src/object/obj_enum.c
+++ b/src/object/obj_enum.c
@@ -150,7 +150,7 @@ iov_alloc_for_csum_info(d_iov_t *iov, struct dcs_csum_info *csum_info)
 
 	/** Make sure the csum buffer is big enough ... resize if needed */
 	if (iov->iov_buf == NULL) {
-		D_ALLOC(iov->iov_buf, size_needed);
+		DM_ALLOC(M_OBJ, iov->iov_buf, size_needed);
 		if (iov->iov_buf == NULL)
 			return -DER_NOMEM;
 		iov->iov_buf_len = size_needed;
@@ -160,7 +160,7 @@ iov_alloc_for_csum_info(d_iov_t *iov, struct dcs_csum_info *csum_info)
 		size_t	 new_size = max(iov->iov_buf_len * 2,
 					      iov->iov_len + size_needed);
 
-		D_REALLOC(p, iov->iov_buf, iov->iov_buf_len, new_size);
+		DM_REALLOC(M_OBJ, p, iov->iov_buf, iov->iov_buf_len, new_size);
 		if (p == NULL)
 			return -DER_NOMEM;
 		iov->iov_buf = p;
@@ -401,7 +401,7 @@ csummer_alloc_csum_info(struct daos_csummer *csummer,
 	chunksize = daos_csummer_get_rec_chunksize(csummer, rsize);
 	csum_nr = daos_recx_calc_chunks(*recx, rsize, chunksize);
 
-	D_ALLOC(result, sizeof(*result) + csum_len * csum_nr);
+	DM_ALLOC(M_OBJ, result, sizeof(*result) + csum_len * csum_nr);
 	if (result == NULL)
 		return -DER_NOMEM;
 
@@ -486,7 +486,7 @@ csum_copy_inline(int type, vos_iter_entry_t *ent, struct dss_enum_arg *arg,
 			ent->ie_recx.rx_idx -
 			ent->ie_orig_recx.rx_idx;
 
-		D_ALLOC(data_to_verify.iov_buf, orig_data_len);
+		DM_ALLOC(M_OBJ, data_to_verify.iov_buf, orig_data_len);
 		if (data_to_verify.iov_buf == NULL)
 			return -DER_NOMEM;
 
@@ -759,7 +759,7 @@ grow_array(void **arrayp, size_t elem_size, int old_len, int new_len)
 	void *p;
 
 	D_ASSERTF(old_len < new_len, "%d < %d\n", old_len, new_len);
-	D_REALLOC(p, *arrayp, elem_size * old_len, elem_size * new_len);
+	DM_REALLOC(M_OBJ, p, *arrayp, elem_size * old_len, elem_size * new_len);
 	if (p == NULL)
 		return -DER_NOMEM;
 	*arrayp = p;

--- a/src/object/obj_rpc.c
+++ b/src/object/obj_rpc.c
@@ -217,7 +217,7 @@ crt_proc_daos_iod_and_csum(crt_proc_t proc, crt_proc_op_t proc_op,
 
 	if (DECODING(proc_op)) {
 		if (existing_flags & IOD_REC_EXIST) {
-			D_ALLOC_ARRAY(iod->iod_recxs, nr);
+			DM_ALLOC_ARRAY(M_IO_ARG, iod->iod_recxs, nr);
 			if (iod->iod_recxs == NULL)
 				D_GOTO(out, rc = -DER_NOMEM);
 		}
@@ -296,7 +296,7 @@ static int crt_proc_daos_iom_t(crt_proc_t proc, crt_proc_op_t proc_op,
 	if (DECODING(proc_op)) {
 		map->iom_nr = iom_nr;
 		map->iom_nr_out = iom_nr;
-		D_ALLOC_ARRAY(map->iom_recxs, iom_nr);
+		DM_ALLOC_ARRAY(M_IO_ARG, map->iom_recxs, iom_nr);
 		if (map->iom_recxs == NULL)
 			return -DER_NOMEM;
 	}
@@ -338,7 +338,7 @@ crt_proc_struct_daos_recx_ep_list(crt_proc_t proc, crt_proc_op_t proc_op,
 		return 0;
 
 	if (DECODING(proc_op)) {
-		D_ALLOC_ARRAY(list->re_items, list->re_nr);
+		DM_ALLOC_ARRAY(M_IO_ARG, list->re_items, list->re_nr);
 		if (list->re_items == NULL)
 			return -DER_NOMEM;
 		list->re_total = list->re_nr;
@@ -432,7 +432,7 @@ crt_proc_struct_obj_iod_array(crt_proc_t proc, crt_proc_op_t proc_op,
 		if (iod_array->oia_oiod_nr != 0)
 			buf_size += sizeof(struct obj_io_desc) *
 				    iod_array->oia_oiod_nr;
-		D_ALLOC(buf, buf_size);
+		DM_ALLOC(M_IO_ARG, buf, buf_size);
 		if (buf == NULL)
 			return -DER_NOMEM;
 		iod_array->oia_iods = buf;
@@ -516,7 +516,7 @@ crt_proc_d_sg_list_t(crt_proc_t proc, crt_proc_op_t proc_op, d_sg_list_t *p)
 
 	switch (proc_op) {
 	case CRT_PROC_DECODE:
-		D_ALLOC_ARRAY(p->sg_iovs, p->sg_nr);
+		DM_ALLOC_ARRAY(M_IO_ARG, p->sg_iovs, p->sg_nr);
 		if (p->sg_iovs == NULL)
 			return -DER_NOMEM;
 		/* fall through to fill sg_iovs */
@@ -584,7 +584,7 @@ crt_proc_struct_daos_cpd_sub_head(crt_proc_t proc, crt_proc_op_t proc_op,
 	D_ASSERT(size != 0);
 
 	if (DECODING(proc_op)) {
-		D_ALLOC(dcsh->dcsh_mbs, size);
+		DM_ALLOC(M_IO_ARG, dcsh->dcsh_mbs, size);
 		if (dcsh->dcsh_mbs == NULL)
 			return -DER_NOMEM;
 	}
@@ -635,7 +635,7 @@ crt_proc_daos_iod_t(crt_proc_t proc, crt_proc_op_t proc_op, daos_iod_t *iod)
 		return 0;
 
 	if (DECODING(proc_op)) {
-		D_ALLOC_ARRAY(iod->iod_recxs, iod->iod_nr);
+		DM_ALLOC_ARRAY(M_IO_ARG, iod->iod_recxs, iod->iod_nr);
 		if (iod->iod_recxs == NULL)
 			return -DER_NOMEM;
 	}
@@ -706,7 +706,7 @@ crt_proc_struct_daos_cpd_sub_req(crt_proc_t proc, crt_proc_op_t proc_op,
 
 		if (DECODING(proc_op)) {
 			if (dcsr->dcsr_ec_tgt_nr != 0) {
-				D_ALLOC_ARRAY(dcu->dcu_ec_tgts,
+				DM_ALLOC_ARRAY(M_IO_ARG, dcu->dcu_ec_tgts,
 					      dcsr->dcsr_ec_tgt_nr);
 				if (dcu->dcu_ec_tgts == NULL)
 					D_GOTO(out, rc = -DER_NOMEM);
@@ -746,7 +746,7 @@ crt_proc_struct_daos_cpd_sub_req(crt_proc_t proc, crt_proc_op_t proc_op,
 
 		if (dcu->dcu_flags & ORF_CPD_BULK) {
 			if (DECODING(proc_op)) {
-				D_ALLOC_ARRAY(dcu->dcu_bulks, dcsr->dcsr_nr);
+				DM_ALLOC_ARRAY(M_IO_ARG, dcu->dcu_bulks, dcsr->dcsr_nr);
 				if (dcu->dcu_bulks == NULL)
 					D_GOTO(out, rc = -DER_NOMEM);
 			}
@@ -759,7 +759,7 @@ crt_proc_struct_daos_cpd_sub_req(crt_proc_t proc, crt_proc_op_t proc_op,
 			}
 		} else {
 			if (DECODING(proc_op)) {
-				D_ALLOC_ARRAY(dcu->dcu_sgls, dcsr->dcsr_nr);
+				DM_ALLOC_ARRAY(M_IO_ARG, dcu->dcu_sgls, dcsr->dcsr_nr);
 				if (dcu->dcu_sgls == NULL)
 					D_GOTO(out, rc = -DER_NOMEM);
 			}
@@ -783,7 +783,7 @@ crt_proc_struct_daos_cpd_sub_req(crt_proc_t proc, crt_proc_op_t proc_op,
 			D_GOTO(out, rc = 0);
 
 		if (DECODING(proc_op)) {
-			D_ALLOC_ARRAY(dcp->dcp_akeys, dcsr->dcsr_nr);
+			DM_ALLOC_ARRAY(M_IO_ARG, dcp->dcp_akeys, dcsr->dcsr_nr);
 			if (dcp->dcp_akeys == NULL)
 				D_GOTO(out, rc = -DER_NOMEM);
 		}
@@ -804,7 +804,7 @@ crt_proc_struct_daos_cpd_sub_req(crt_proc_t proc, crt_proc_op_t proc_op,
 			D_GOTO(out, rc = 0);
 
 		if (DECODING(proc_op)) {
-			D_ALLOC_ARRAY(dcr->dcr_iods, dcsr->dcsr_nr);
+			DM_ALLOC_ARRAY(M_IO_ARG, dcr->dcr_iods, dcsr->dcsr_nr);
 			if (dcr->dcr_iods == NULL)
 				D_GOTO(out, rc = -DER_NOMEM);
 		}
@@ -869,7 +869,7 @@ crt_proc_struct_daos_cpd_disp_ent(crt_proc_t proc, crt_proc_op_t proc_op,
 		return 0;
 
 	if (DECODING(proc_op)) {
-		D_ALLOC_ARRAY(dcde->dcde_reqs, count);
+		DM_ALLOC_ARRAY(M_IO_ARG, dcde->dcde_reqs, count);
 		if (dcde->dcde_reqs == NULL)
 			return -DER_NOMEM;
 	}
@@ -904,7 +904,7 @@ crt_proc_struct_daos_cpd_sg(crt_proc_t proc, crt_proc_op_t proc_op,
 		struct daos_cpd_sub_head *dcsh;
 
 		if (DECODING(proc_op)) {
-			D_ALLOC_ARRAY(dcsh, dcs->dcs_nr);
+			DM_ALLOC_ARRAY(M_IO_ARG, dcsh, dcs->dcs_nr);
 			if (dcsh == NULL)
 				D_GOTO(out, rc = -DER_NOMEM);
 
@@ -928,7 +928,7 @@ crt_proc_struct_daos_cpd_sg(crt_proc_t proc, crt_proc_op_t proc_op,
 		bool			 with_oid;
 
 		if (DECODING(proc_op)) {
-			D_ALLOC_ARRAY(dcsr, dcs->dcs_nr);
+			DM_ALLOC_ARRAY(M_IO_ARG, dcsr, dcs->dcs_nr);
 			if (dcsr == NULL)
 				D_GOTO(out, rc = -DER_NOMEM);
 
@@ -956,7 +956,7 @@ crt_proc_struct_daos_cpd_sg(crt_proc_t proc, crt_proc_op_t proc_op,
 		struct daos_cpd_disp_ent	*dcde;
 
 		if (DECODING(proc_op)) {
-			D_ALLOC_ARRAY(dcde, dcs->dcs_nr);
+			DM_ALLOC_ARRAY(M_IO_ARG, dcde, dcs->dcs_nr);
 			if (dcde == NULL)
 				D_GOTO(out, rc = -DER_NOMEM);
 
@@ -978,7 +978,7 @@ crt_proc_struct_daos_cpd_sg(crt_proc_t proc, crt_proc_op_t proc_op,
 		struct daos_shard_tgt		*dst;
 
 		if (DECODING(proc_op)) {
-			D_ALLOC_ARRAY(dst, dcs->dcs_nr);
+			DM_ALLOC_ARRAY(M_IO_ARG, dst, dcs->dcs_nr);
 			if (dst == NULL)
 				D_GOTO(out, rc = -DER_NOMEM);
 

--- a/src/object/obj_tx.c
+++ b/src/object/obj_tx.c
@@ -163,7 +163,7 @@ full:
 	else
 		count = (tx->tx_total_slots << 1) - DTX_SUB_WRITE_MAX;
 
-	D_ALLOC_ARRAY(buf, count);
+	DM_ALLOC_ARRAY(M_DTX, buf, count);
 	if (buf == NULL)
 		return -DER_NOMEM;
 
@@ -277,11 +277,11 @@ dc_tx_alloc(daos_handle_t coh, daos_epoch_t epoch, uint64_t flags,
 	ph = dc_cont_hdl2pool_hdl(coh);
 	D_ASSERT(daos_handle_is_valid(ph));
 
-	D_ALLOC_PTR(tx);
+	DM_ALLOC_PTR(M_DTX, tx);
 	if (tx == NULL)
 		return -DER_NOMEM;
 
-	D_ALLOC_ARRAY(tx->tx_req_cache, DTX_SUB_REQ_DEF);
+	DM_ALLOC_ARRAY(M_DTX, tx->tx_req_cache, DTX_SUB_REQ_DEF);
 	if (tx->tx_req_cache == NULL) {
 		D_FREE(tx);
 		return -DER_NOMEM;
@@ -1051,7 +1051,7 @@ dc_tx_classify_update(struct dc_tx *tx, struct daos_cpd_sub_req *dcsr,
 	if (daos_oclass_is_ec(oca)) {
 		struct obj_reasb_req	*reasb_req;
 
-		D_ALLOC_PTR(reasb_req);
+		DM_ALLOC_PTR(M_DTX, reasb_req);
 		if (reasb_req == NULL)
 			return rc = -DER_NOMEM;
 
@@ -1155,7 +1155,7 @@ dc_tx_classify_common(struct dc_tx *tx, struct daos_cpd_sub_req *dcsr,
 
 	oca = obj_get_oca(obj);
 	size = sizeof(*dtr) + sizeof(uint32_t) * obj->cob_grp_size;
-	D_ALLOC(dtr, size);
+	DM_ALLOC(M_DTX, dtr, size);
 	if (dtr == NULL)
 		return -DER_NOMEM;
 
@@ -1166,7 +1166,7 @@ dc_tx_classify_common(struct dc_tx *tx, struct daos_cpd_sub_req *dcsr,
 		dcu = &dcsr->dcsr_update;
 		reasb_req = dcsr->dcsr_reasb;
 		if (dcu->dcu_flags & ORF_EC && reasb_req->tgt_bitmap != NULL) {
-			D_ALLOC_ARRAY(dcu->dcu_ec_tgts, obj->cob_grp_size);
+			DM_ALLOC_ARRAY(M_DTX, dcu->dcu_ec_tgts, obj->cob_grp_size);
 			if (dcu->dcu_ec_tgts == NULL)
 				D_GOTO(out, rc = -DER_NOMEM);
 
@@ -1219,7 +1219,7 @@ dc_tx_classify_common(struct dc_tx *tx, struct daos_cpd_sub_req *dcsr,
 		dtrg = &dtrgs[shard->do_target_id];
 		if (dtrg->dtrg_req_idx == NULL) {
 			/* dtrg->dtrg_req_idx will be released by caller. */
-			D_ALLOC_ARRAY(dtrg->dtrg_req_idx, DTX_SUB_REQ_DEF);
+			DM_ALLOC_ARRAY(M_DTX, dtrg->dtrg_req_idx, DTX_SUB_REQ_DEF);
 			if (dtrg->dtrg_req_idx == NULL) {
 				obj_shard_close(shard);
 				D_GOTO(out, rc = -DER_NOMEM);
@@ -1243,7 +1243,7 @@ dc_tx_classify_common(struct dc_tx *tx, struct daos_cpd_sub_req *dcsr,
 
 		if ((dtrg->dtrg_read_cnt + dtrg->dtrg_write_cnt) >=
 		    dtrg->dtrg_slot_cnt) {
-			D_ALLOC_ARRAY(dcri, dtrg->dtrg_slot_cnt << 1);
+			DM_ALLOC_ARRAY(M_DTX, dcri, dtrg->dtrg_slot_cnt << 1);
 			if (dcri == NULL) {
 				obj_shard_close(shard);
 				D_GOTO(out, rc = -DER_NOMEM);
@@ -1524,7 +1524,7 @@ dc_tx_commit_prepare(struct dc_tx *tx, tse_task_t *task)
 	tgt_cnt = pool_map_target_nr(tx->tx_pool->dp_map);
 	D_ASSERT(tgt_cnt != 0);
 
-	D_ALLOC_ARRAY(dtrgs, tgt_cnt);
+	DM_ALLOC_ARRAY(M_DTX, dtrgs, tgt_cnt);
 	if (dtrgs == NULL)
 		D_GOTO(out, rc = -DER_NOMEM);
 
@@ -1584,19 +1584,19 @@ dc_tx_commit_prepare(struct dc_tx *tx, tse_task_t *task)
 
 	size += sizeof(*ddt) * act_tgt_cnt;
 
-	D_ALLOC_PTR(dcsh);
+	DM_ALLOC_PTR(M_DTX, dcsh);
 	if (dcsh == NULL)
 		D_GOTO(out, rc = -DER_NOMEM);
 
-	D_ALLOC(dcsh->dcsh_mbs, size + sizeof(*dcsh->dcsh_mbs));
+	DM_ALLOC(M_DTX, dcsh->dcsh_mbs, size + sizeof(*dcsh->dcsh_mbs));
 	if (dcsh->dcsh_mbs == NULL)
 		D_GOTO(out, rc = -DER_NOMEM);
 
-	D_ALLOC_ARRAY(dcdes, act_tgt_cnt);
+	DM_ALLOC_ARRAY(M_DTX, dcdes, act_tgt_cnt);
 	if (dcdes == NULL)
 		D_GOTO(out, rc = -DER_NOMEM);
 
-	D_ALLOC_ARRAY(shard_tgts, act_tgt_cnt);
+	DM_ALLOC_ARRAY(M_DTX, shard_tgts, act_tgt_cnt);
 	if (shard_tgts == NULL)
 		D_GOTO(out, rc = -DER_NOMEM);
 
@@ -2219,7 +2219,7 @@ dc_tx_add_update(struct dc_tx *tx, struct dc_object **obj, uint64_t flags,
 	iod_array = &dcu->dcu_iod_array;
 	iod_array->oia_iod_nr = nr;
 
-	D_ALLOC_ARRAY(iod_array->oia_iods, nr);
+	DM_ALLOC_ARRAY(M_DTX, iod_array->oia_iods, nr);
 	if (iod_array->oia_iods == NULL)
 		D_GOTO(fail, rc = -DER_NOMEM);
 
@@ -2236,7 +2236,7 @@ dc_tx_add_update(struct dc_tx *tx, struct dc_object **obj, uint64_t flags,
 		if (iods[i].iod_recxs == NULL)
 			continue;
 
-		D_ALLOC_ARRAY(iod_array->oia_iods[i].iod_recxs,
+		DM_ALLOC_ARRAY(M_DTX, iod_array->oia_iods[i].iod_recxs,
 			      iods[i].iod_nr);
 		if (iod_array->oia_iods[i].iod_recxs == NULL)
 			D_GOTO(fail, rc = -DER_NOMEM);
@@ -2245,7 +2245,7 @@ dc_tx_add_update(struct dc_tx *tx, struct dc_object **obj, uint64_t flags,
 		       sizeof(daos_recx_t) * iods[i].iod_nr);
 	}
 
-	D_ALLOC_ARRAY(dcsr->dcsr_sgls, nr);
+	DM_ALLOC_ARRAY(M_DTX, dcsr->dcsr_sgls, nr);
 	if (dcsr->dcsr_sgls == NULL)
 		D_GOTO(fail, rc = -DER_NOMEM);
 
@@ -2389,7 +2389,7 @@ dc_tx_add_punch_akeys(struct dc_tx *tx, struct dc_object **obj, uint64_t flags,
 		goto fail;
 
 	dcp = &dcsr->dcsr_punch;
-	D_ALLOC_ARRAY(dcp->dcp_akeys, nr);
+	DM_ALLOC_ARRAY(M_DTX, dcp->dcp_akeys, nr);
 	if (dcp->dcp_akeys == NULL)
 		D_GOTO(fail, rc = -DER_NOMEM);
 
@@ -2468,7 +2468,7 @@ dc_tx_add_read(struct dc_tx *tx, struct dc_object **obj, int opc,
 		goto done;
 
 	dcr = &dcsr->dcsr_read;
-	D_ALLOC_ARRAY(dcr->dcr_iods, nr);
+	DM_ALLOC_ARRAY(M_DTX, dcr->dcr_iods, nr);
 	if (dcr->dcr_iods == NULL)
 		D_GOTO(fail, rc = -DER_NOMEM);
 
@@ -2644,7 +2644,7 @@ dc_tx_check_existence_task(enum obj_rpc_opc opc, daos_handle_t oh,
 		D_ASSERT(iods_or_akeys != NULL);
 
 		if (opc != DAOS_OBJ_RPC_UPDATE) {
-			D_ALLOC_ARRAY(iods, nr);
+			DM_ALLOC_ARRAY(M_DTX, iods, nr);
 			if (iods == NULL)
 				D_GOTO(out, rc = -DER_NOMEM);
 

--- a/src/object/rpc_csum.c
+++ b/src/object/rpc_csum.c
@@ -70,7 +70,7 @@ proc_struct_dcs_csum_info_adv(crt_proc_t proc, crt_proc_op_t proc_op,
 	}
 
 	if (DECODING(proc_op)) {
-		D_ALLOC(csum->cs_csum, csum->cs_buf_len);
+		DM_ALLOC(M_CSUM, csum->cs_csum, csum->cs_buf_len);
 		if (csum->cs_csum == NULL)
 			return -DER_NOMEM;
 
@@ -121,7 +121,7 @@ crt_proc_struct_dcs_csum_info(crt_proc_t proc, crt_proc_op_t proc_op,
 			*p_csum = NULL;
 			return 0;
 		}
-		D_ALLOC_PTR(*p_csum);
+		DM_ALLOC_PTR(M_CSUM, *p_csum);
 		if (*p_csum == NULL)
 			return -DER_NOMEM;
 		rc = proc_struct_dcs_csum_info(proc, proc_op, *p_csum);
@@ -183,7 +183,7 @@ crt_proc_struct_dcs_iod_csums_adv(crt_proc_t proc, crt_proc_op_t proc_op,
 
 	if (DECODING(proc_op)) {
 		PROC(uint32_t, &iod_csum->ic_nr);
-		D_ALLOC_ARRAY(iod_csum->ic_data, iod_csum->ic_nr);
+		DM_ALLOC_ARRAY(M_CSUM, iod_csum->ic_data, iod_csum->ic_nr);
 		if (iod_csum->ic_data == NULL)
 			return -DER_NOMEM;
 		for (i = 0; i < iod_csum->ic_nr; i++) {

--- a/src/object/srv_csum.c
+++ b/src/object/srv_csum.c
@@ -265,7 +265,7 @@ cc_verify_resize_if_needed(struct csum_context *ctx)
 		return 0;
 
 	new_size = ctx->cc_to_verify_size * 2;
-	D_ALLOC_ARRAY(to_verify, new_size);
+	DM_ALLOC_ARRAY(M_CSUM, to_verify, new_size);
 	if (to_verify == NULL)
 		return -DER_NOMEM;
 

--- a/src/object/srv_ec.c
+++ b/src/object/srv_ec.c
@@ -98,7 +98,7 @@ obj_ec_rw_req_split(daos_unit_oid_t oid, struct obj_iod_array *iod_array,
 		singv_ci_size = roundup(sizeof(struct dcs_csum_info) * iod_nr,
 					8);
 	}
-	D_ALLOC(buf, req_size + iods_size + csums_size + singv_ci_size);
+	DM_ALLOC(M_EC, buf, req_size + iods_size + csums_size + singv_ci_size);
 	if (buf == NULL)
 		return -DER_NOMEM;
 

--- a/src/object/srv_ec_aggregate.c
+++ b/src/object/srv_ec_aggregate.c
@@ -357,7 +357,7 @@ agg_alloc_buf(d_sg_list_t *sgl, size_t ent_buf_len, unsigned int iov_entry,
 	int	 rc = 0;
 
 	if (align_data) {
-		D_ALIGNED_ALLOC(buf, 32, ent_buf_len);
+		DM_ALIGNED_ALLOC(M_EC_AGG, buf, 32, ent_buf_len);
 		if (buf == NULL) {
 			rc = -DER_NOMEM;
 			goto out;
@@ -365,7 +365,7 @@ agg_alloc_buf(d_sg_list_t *sgl, size_t ent_buf_len, unsigned int iov_entry,
 		D_FREE(sgl->sg_iovs[iov_entry].iov_buf);
 		sgl->sg_iovs[iov_entry].iov_buf = buf;
 	} else {
-		D_REALLOC_NZ(buf, sgl->sg_iovs[iov_entry].iov_buf, ent_buf_len);
+		DM_REALLOC_NZ(M_EC_AGG, buf, sgl->sg_iovs[iov_entry].iov_buf, ent_buf_len);
 		 if (buf == NULL) {
 			rc = -DER_NOMEM;
 			goto out;
@@ -394,7 +394,7 @@ agg_prep_sgl(struct ec_agg_entry *entry)
 	int		 rc = 0;
 
 	if (entry->ae_sgl.sg_nr == 0) {
-		D_ALLOC_ARRAY(entry->ae_sgl.sg_iovs, AGG_IOV_CNT);
+		DM_ALLOC_ARRAY(M_EC_AGG, entry->ae_sgl.sg_iovs, AGG_IOV_CNT);
 		if (entry->ae_sgl.sg_iovs == NULL) {
 			rc = -DER_NOMEM;
 			goto out;
@@ -547,7 +547,7 @@ agg_fetch_odata_cells(struct ec_agg_entry *entry, uint8_t *bit_map,
 	unsigned int		 i, j;
 	int			 rc = 0;
 
-	D_ALLOC_ARRAY(recxs, cell_cnt);
+	DM_ALLOC_ARRAY(M_EC_AGG, recxs, cell_cnt);
 	if (recxs == NULL)
 		return -DER_NOMEM;
 
@@ -566,7 +566,7 @@ agg_fetch_odata_cells(struct ec_agg_entry *entry, uint8_t *bit_map,
 	iod.iod_nr	= cell_cnt;
 	iod.iod_recxs	= recxs;
 
-	D_ALLOC_ARRAY(sgl.sg_iovs, cell_cnt);
+	DM_ALLOC_ARRAY(M_EC_AGG, sgl.sg_iovs, cell_cnt);
 	if (sgl.sg_iovs == NULL) {
 		rc = -DER_NOMEM;
 		goto out;
@@ -846,7 +846,7 @@ agg_fetch_local_extents(struct ec_agg_entry *entry, uint8_t *bit_map,
 	uint32_t		 i, j;
 	int			 rc = 0;
 
-	D_ALLOC_ARRAY(recxs, is_recalc ? cell_cnt : cell_cnt + 1);
+	DM_ALLOC_ARRAY(M_EC_AGG, recxs, is_recalc ? cell_cnt : cell_cnt + 1);
 	if (recxs == NULL) {
 		rc = -DER_NOMEM;
 		goto out;
@@ -871,7 +871,7 @@ agg_fetch_local_extents(struct ec_agg_entry *entry, uint8_t *bit_map,
 		recxs[cell_cnt].rx_nr = len;
 	}
 
-	D_ALLOC_ARRAY(sgl.sg_iovs, cell_cnt + 1);
+	DM_ALLOC_ARRAY(M_EC_AGG, sgl.sg_iovs, cell_cnt + 1);
 	if (sgl.sg_iovs == NULL) {
 		rc = -DER_NOMEM;
 		goto out;
@@ -1570,7 +1570,7 @@ fetch_again:
 			 */
 			void *tmp_ptr;
 
-			D_REALLOC(tmp_ptr, csum_iov_fetch->iov_buf,
+			DM_REALLOC(M_EC_AGG, tmp_ptr, csum_iov_fetch->iov_buf,
 				  csum_iov_fetch->iov_buf_len,
 				  csum_iov_fetch->iov_len);
 			if (tmp_ptr == NULL)
@@ -1706,7 +1706,7 @@ agg_process_holes(struct ec_agg_entry *entry)
 	int			 tid, rc = 0;
 	int			*status;
 
-	D_ALLOC_ARRAY(stripe_ud.asu_recxs,
+	DM_ALLOC_ARRAY(M_EC_AGG, stripe_ud.asu_recxs,
 		      entry->ae_cur_stripe.as_extent_cnt + 1);
 	if (stripe_ud.asu_recxs == NULL) {
 		rc = -DER_NOMEM;
@@ -1904,7 +1904,7 @@ agg_extent_add(struct ec_agg_entry *agg_entry, vos_iter_entry_t *entry,
 	int			rc = 0;
 
 	/* Add the extent to the entry, for the current stripe */
-	D_ALLOC_PTR(extent);
+	DM_ALLOC_PTR(M_EC_AGG, extent);
 	if (extent == NULL)
 		D_GOTO(out, rc = -DER_NOMEM);
 

--- a/src/object/srv_obj_migrate.c
+++ b/src/object/srv_obj_migrate.c
@@ -380,7 +380,7 @@ migrate_pool_tls_create_one(void *data)
 		return 0;
 	}
 
-	D_ALLOC_PTR(pool_tls);
+	DM_ALLOC_PTR(M_RECOV, pool_tls);
 	if (pool_tls == NULL)
 		D_GOTO(out, rc = -DER_NOMEM);
 
@@ -444,7 +444,7 @@ migrate_pool_tls_lookup_create(struct ds_pool *pool, int version,
 	if (tls)
 		return tls;
 
-	D_ALLOC_PTR(prop);
+	DM_ALLOC_PTR(M_RECOV, prop);
 	if (prop == NULL)
 		D_GOTO(out, rc = -DER_NOMEM);
 
@@ -574,7 +574,7 @@ mrone_obj_fetch(struct migrate_one *mrone, daos_handle_t oh, d_sg_list_t *sgls,
 		 */
 		void *p;
 
-		D_REALLOC(p, csum_iov_fetch->iov_buf,
+		DM_REALLOC(M_CSUM, p, csum_iov_fetch->iov_buf,
 			  csum_iov_fetch->iov_buf_len, csum_iov_fetch->iov_len);
 		if (p == NULL)
 			return -DER_NOMEM;
@@ -796,7 +796,7 @@ obj_ec_encode_buf(daos_obj_id_t oid, struct daos_oclass_attr *oca,
 	D_ASSERT(codec != NULL);
 
 	for (i = 0; i < p && p_bufs[i] == NULL; i++) {
-		D_ALLOC(p_bufs[i], cell_bytes);
+		DM_ALLOC(M_EC, p_bufs[i], cell_bytes);
 		if (p_bufs[i] == NULL)
 			return -DER_NOMEM;
 	}
@@ -917,7 +917,7 @@ migrate_fetch_update_parity(struct migrate_one *mrone, daos_handle_t oh,
 	D_ASSERT(mrone->mo_iod_num <= DSS_ENUM_UNPACK_MAX_IODS);
 	for (i = 0; i < mrone->mo_iod_num; i++) {
 		size = daos_iods_len(&mrone->mo_iods[i], 1);
-		D_ALLOC(data, size);
+		DM_ALLOC(M_EC, data, size);
 		if (data == NULL)
 			D_GOTO(out, rc =-DER_NOMEM);
 
@@ -1021,7 +1021,7 @@ migrate_fetch_update_single(struct migrate_one *mrone, daos_handle_t oh,
 
 		size = daos_iods_len(&mrone->mo_iods[i], 1);
 		D_ASSERT(size != -1);
-		D_ALLOC(data, size);
+		DM_ALLOC(M_RECOV, data, size);
 		if (data == NULL)
 			D_GOTO(out, rc =-DER_NOMEM);
 
@@ -1703,12 +1703,12 @@ migrate_merge_iod_recx(daos_iod_t *dst_iod, daos_epoch_t **p_dst_ephs, daos_recx
 		nr_recxs++;
 
 	if (nr_recxs > dst_iod->iod_nr) {
-		D_ALLOC_ARRAY(recxs, nr_recxs);
+		DM_ALLOC_ARRAY(M_RECOV, recxs, nr_recxs);
 		if (recxs == NULL)
 			D_GOTO(out, rc = -DER_NOMEM);
 
 		if (p_dst_ephs != NULL) {
-			D_ALLOC_ARRAY(dst_ephs, nr_recxs);
+			DM_ALLOC_ARRAY(M_RECOV, dst_ephs, nr_recxs);
 			if (dst_ephs == NULL) {
 				D_FREE(recxs);
 				D_GOTO(out, rc = -DER_NOMEM);
@@ -1794,7 +1794,7 @@ migrate_insert_recxs_sgl(daos_iod_t *iods, daos_epoch_t **iods_ephs, uint32_t *i
 	if (new_iod->iod_type == DAOS_IOD_SINGLE) {
 		iods[i].iod_recxs = NULL;
 		if (iods_ephs != NULL) {
-			D_ALLOC_ARRAY(iods_ephs[i], 1);
+			DM_ALLOC_ARRAY(M_RECOV, iods_ephs[i], 1);
 			if (iods_ephs[i] == NULL)
 				D_GOTO(out, rc = -DER_NOMEM);
 			iods_ephs[i][0] = new_ephs[0];
@@ -1824,7 +1824,7 @@ rw_iod_pack(struct migrate_one *mrone, daos_iod_t *iod, daos_epoch_t *ephs, d_sg
 
 	if (sgl && mrone->mo_sgls == NULL) {
 		D_ASSERT(mrone->mo_iod_alloc_num > 0);
-		D_ALLOC_ARRAY(mrone->mo_sgls, mrone->mo_iod_alloc_num);
+		DM_ALLOC_ARRAY(M_RECOV, mrone->mo_sgls, mrone->mo_iod_alloc_num);
 		if (mrone->mo_sgls == NULL)
 			return -DER_NOMEM;
 	}
@@ -1926,7 +1926,7 @@ punch_iod_pack(struct migrate_one *mrone, daos_iod_t *iod, daos_epoch_t eph)
 	D_ASSERT(iod->iod_size == 0);
 
 	if (mrone->mo_punch_iods == NULL) {
-		D_ALLOC_ARRAY(mrone->mo_punch_iods, mrone->mo_iod_alloc_num);
+		DM_ALLOC_ARRAY(M_RECOV, mrone->mo_punch_iods, mrone->mo_iod_alloc_num);
 		if (mrone->mo_punch_iods == NULL)
 			return -DER_NOMEM;
 	}
@@ -2060,21 +2060,21 @@ migrate_one_create(struct enum_unpack_arg *arg, struct dss_enum_unpack_io *io)
 		D_GOTO(put, rc = 0);
 	}
 
-	D_ALLOC_PTR(mrone);
+	DM_ALLOC_PTR(M_RECOV, mrone);
 	if (mrone == NULL)
 		D_GOTO(put, rc = -DER_NOMEM);
 
 	D_INIT_LIST_HEAD(&mrone->mo_list);
-	D_ALLOC_ARRAY(mrone->mo_iods, iod_eph_total);
+	DM_ALLOC_ARRAY(M_RECOV, mrone->mo_iods, iod_eph_total);
 	if (mrone->mo_iods == NULL)
 		D_GOTO(free, rc = -DER_NOMEM);
 
-	D_ALLOC_ARRAY(mrone->mo_iods_update_ephs, iod_eph_total);
+	DM_ALLOC_ARRAY(M_RECOV, mrone->mo_iods_update_ephs, iod_eph_total);
 	if (mrone->mo_iods_update_ephs == NULL)
 		D_GOTO(free, rc = -DER_NOMEM);
 
 	if (daos_oclass_is_ec(&arg->oc_attr)) {
-		D_ALLOC_ARRAY(mrone->mo_iods_from_parity, iod_eph_total);
+		DM_ALLOC_ARRAY(M_RECOV, mrone->mo_iods_from_parity, iod_eph_total);
 		if (mrone->mo_iods_from_parity == NULL)
 			D_GOTO(free, rc = -DER_NOMEM);
 	}
@@ -2082,7 +2082,7 @@ migrate_one_create(struct enum_unpack_arg *arg, struct dss_enum_unpack_io *io)
 	mrone->mo_epoch = arg->epr.epr_hi;
 	mrone->mo_obj_punch_eph = obj_punch_eph;
 	mrone->mo_dkey_punch_eph = dkey_punch_eph;
-	D_ALLOC_ARRAY(mrone->mo_akey_punch_ephs, iod_eph_total);
+	DM_ALLOC_ARRAY(M_RECOV, mrone->mo_akey_punch_ephs, iod_eph_total);
 	if (mrone->mo_akey_punch_ephs == NULL)
 		D_GOTO(free, rc = -DER_NOMEM);
 
@@ -2445,7 +2445,7 @@ retry:
 
 			if (buf != stack_buf)
 				D_FREE(buf);
-			D_ALLOC(buf, buf_len);
+			DM_ALLOC(M_RECOV, buf, buf_len);
 			if (buf == NULL) {
 				rc = -DER_NOMEM;
 				break;
@@ -2460,7 +2460,7 @@ retry:
 
 			p_csum->iov_buf_len = p_csum->iov_len;
 			p_csum->iov_len = 0;
-			D_ALLOC(p_csum->iov_buf, p_csum->iov_buf_len);
+			DM_ALLOC(M_RECOV, p_csum->iov_buf, p_csum->iov_buf_len);
 			if (p_csum->iov_buf == NULL) {
 				rc = -DER_NOMEM;
 				break;
@@ -2811,7 +2811,7 @@ migrate_one_object(daos_unit_oid_t oid, daos_epoch_t eph, daos_epoch_t punched_e
 
 	D_ASSERT(daos_handle_is_valid(toh));
 
-	D_ALLOC_PTR(obj_arg);
+	DM_ALLOC_PTR(M_RECOV, obj_arg);
 	if (obj_arg == NULL)
 		return -DER_NOMEM;
 
@@ -2824,7 +2824,7 @@ migrate_one_object(daos_unit_oid_t oid, daos_epoch_t eph, daos_epoch_t punched_e
 	uuid_copy(obj_arg->cont_uuid, cont_arg->cont_uuid);
 	obj_arg->version = cont_arg->pool_tls->mpt_version;
 	if (cont_arg->snaps) {
-		D_ALLOC(obj_arg->snaps,
+		DM_ALLOC(M_RECOV, obj_arg->snaps,
 			sizeof(*cont_arg->snaps) * cont_arg->snap_cnt);
 		if (obj_arg->snaps == NULL)
 			D_GOTO(free, rc = -DER_NOMEM);

--- a/src/object/srv_obj_remote.c
+++ b/src/object/srv_obj_remote.c
@@ -99,7 +99,7 @@ ds_obj_remote_update(struct dtx_leader_handle *dlh, void *data, int idx,
 		}
 	}
 
-	D_ALLOC_PTR(remote_arg);
+	DM_ALLOC_PTR(M_IO, remote_arg);
 	if (remote_arg == NULL)
 		D_GOTO(out, rc = -DER_NOMEM);
 
@@ -214,7 +214,7 @@ ds_obj_remote_punch(struct dtx_leader_handle *dlh, void *data, int idx,
 	D_ASSERT(idx < dlh->dlh_sub_cnt);
 	sub = &dlh->dlh_subs[idx];
 	shard_tgt = &sub->dss_tgt;
-	D_ALLOC_PTR(remote_arg);
+	DM_ALLOC_PTR(M_IO, remote_arg);
 	if (remote_arg == NULL)
 		D_GOTO(out, rc = -DER_NOMEM);
 
@@ -309,11 +309,11 @@ ds_obj_cpd_clone_reqs(struct dtx_leader_handle *dlh, struct daos_shard_tgt *tgt,
 	int				 i;
 
 	count = dcde_parent->dcde_read_cnt + dcde_parent->dcde_write_cnt;
-	D_ALLOC_ARRAY(dcsr, count);
+	DM_ALLOC_ARRAY(M_IO, dcsr, count);
 	if (dcsr == NULL)
 		D_GOTO(out, rc = -DER_NOMEM);
 
-	D_ALLOC(dcde, sizeof(*dcde) +
+	DM_ALLOC(M_IO, dcde, sizeof(*dcde) +
 		sizeof(struct daos_cpd_req_idx) * count);
 	if (dcde == NULL)
 		D_GOTO(out, rc = -DER_NOMEM);
@@ -412,19 +412,19 @@ ds_obj_cpd_dispatch(struct dtx_leader_handle *dlh, void *arg, int idx,
 	sub = &dlh->dlh_subs[idx];
 	shard_tgt = &sub->dss_tgt;
 
-	D_ALLOC_PTR(head_dcs);
+	DM_ALLOC_PTR(M_IO, head_dcs);
 	if (head_dcs == NULL)
 		D_GOTO(out, rc = -DER_NOMEM);
 
-	D_ALLOC_PTR(dcsr_dcs);
+	DM_ALLOC_PTR(M_IO, dcsr_dcs);
 	if (dcsr_dcs == NULL)
 		D_GOTO(out, rc = -DER_NOMEM);
 
-	D_ALLOC_PTR(dcde_dcs);
+	DM_ALLOC_PTR(M_IO, dcde_dcs);
 	if (dcde_dcs == NULL)
 		D_GOTO(out, rc = -DER_NOMEM);
 
-	D_ALLOC_PTR(remote_arg);
+	DM_ALLOC_PTR(M_IO, remote_arg);
 	if (remote_arg == NULL)
 		D_GOTO(out, rc = -DER_NOMEM);
 

--- a/src/placement/jump_map.c
+++ b/src/placement/jump_map.c
@@ -675,7 +675,7 @@ remap_gpu_alloc_one(d_list_t *remap_list, uint8_t *dom_cur_grp_used)
 {
 	struct dom_grp_used	*dgu;
 
-	D_ALLOC_PTR(dgu);
+	DM_ALLOC_PTR(M_PL, dgu);
 	if (dgu == NULL)
 		return NULL;
 
@@ -758,15 +758,15 @@ get_object_layout(struct pl_jump_map *jmap, struct pl_obj_layout *layout,
 	dom_size = (struct pool_domain *)(root->do_targets) - (root) + 1;
 	dom_array_size = dom_size/NBBY + 1;
 	if (dom_array_size > LOCAL_DOM_ARRAY_SIZE) {
-		D_ALLOC_ARRAY(dom_used, dom_array_size);
-		D_ALLOC_ARRAY(dom_occupied, dom_array_size);
+		DM_ALLOC_ARRAY(M_PL, dom_used, dom_array_size);
+		DM_ALLOC_ARRAY(M_PL, dom_occupied, dom_array_size);
 	} else {
 		dom_used = dom_used_array;
 		dom_occupied = dom_occupied_array;
 	}
 
 	if (root->do_target_nr / NBBY + 1 > LOCAL_TGT_ARRAY_SIZE)
-		D_ALLOC_ARRAY(tgts_used, (root->do_target_nr / NBBY) + 1);
+		DM_ALLOC_ARRAY(M_PL, tgts_used, (root->do_target_nr / NBBY) + 1);
 	else
 		tgts_used = tgts_used_array;
 
@@ -783,7 +783,7 @@ get_object_layout(struct pl_jump_map *jmap, struct pl_obj_layout *layout,
 
 		if (realloc_grp_used) {
 			realloc_grp_used = false;
-			D_ALLOC_ARRAY(dom_cur_grp_used, dom_array_size);
+			DM_ALLOC_ARRAY(M_PL, dom_cur_grp_used, dom_array_size);
 			if (dom_cur_grp_used == NULL)
 				D_GOTO(out, rc = -DER_NOMEM);
 		} else {
@@ -967,7 +967,7 @@ jump_map_create(struct pool_map *poolmap, struct pl_map_init_attr *mia,
 	struct pool_domain      *doms;
 	int                     rc;
 
-	D_ALLOC_PTR(jmap);
+	DM_ALLOC_PTR(M_PL, jmap);
 	if (jmap == NULL)
 		return -DER_NOMEM;
 

--- a/src/placement/pl_map.c
+++ b/src/placement/pl_map.c
@@ -253,7 +253,7 @@ pl_obj_layout_alloc(unsigned int grp_size, unsigned int grp_nr,
 	struct pl_obj_layout *layout;
 	unsigned int shard_nr = grp_size * grp_nr;
 
-	D_ALLOC_PTR(layout);
+	DM_ALLOC_PTR(M_PL, layout);
 	if (layout == NULL)
 		return -DER_NOMEM;
 
@@ -261,7 +261,7 @@ pl_obj_layout_alloc(unsigned int grp_size, unsigned int grp_nr,
 	layout->ol_grp_nr = grp_nr;
 	layout->ol_grp_size = grp_size;
 
-	D_ALLOC_ARRAY(layout->ol_shards, layout->ol_nr);
+	DM_ALLOC_ARRAY(M_PL, layout->ol_shards, layout->ol_nr);
 	if (layout->ol_shards == NULL)
 		goto failed;
 

--- a/src/placement/pl_map_common.c
+++ b/src/placement/pl_map_common.c
@@ -63,7 +63,7 @@ remap_alloc_one(d_list_t *remap_list, unsigned int shard_idx,
 {
 	struct failed_shard *f_new;
 
-	D_ALLOC_PTR(f_new);
+	DM_ALLOC_PTR(M_PL, f_new);
 	if (f_new == NULL)
 		return -DER_NOMEM;
 
@@ -361,10 +361,10 @@ grp_map_extend(uint32_t *grp_map, uint32_t *grp_map_size)
 	int	 i;
 
 	if (*grp_map_size > STACK_TGTS_SIZE)
-		D_REALLOC_ARRAY(new_grp_map, grp_map, *grp_map_size,
-				new_grp_size);
+		DM_REALLOC_ARRAY(M_PL, new_grp_map, grp_map, *grp_map_size,
+				 new_grp_size);
 	else
-		D_ALLOC_ARRAY(new_grp_map, new_grp_size);
+		DM_ALLOC_ARRAY(M_PL, new_grp_map, new_grp_size);
 
 	for (i = *grp_map_size; i < new_grp_size; i++)
 		grp_map[i] = -1;
@@ -403,7 +403,7 @@ pl_map_extend(struct pl_obj_layout *layout, d_list_t *extended_list)
 	if (layout->ol_grp_nr <= STACK_TGTS_SIZE) {
 		grp_count = grp_cnt_array;
 	} else {
-		D_ALLOC_ARRAY(grp_count, layout->ol_grp_nr);
+		DM_ALLOC_ARRAY(M_PL, grp_count, layout->ol_grp_nr);
 		if (grp_count == NULL)
 			D_GOTO(out, rc = -DER_NOMEM);
 	}
@@ -436,7 +436,7 @@ pl_map_extend(struct pl_obj_layout *layout, d_list_t *extended_list)
 
 	new_group_size = layout->ol_grp_size + max_fail_grp;
 	new_shards_nr = new_group_size * layout->ol_grp_nr;
-	D_ALLOC_ARRAY(new_shards, new_shards_nr);
+	DM_ALLOC_ARRAY(M_PL, new_shards, new_shards_nr);
 	if (new_shards == NULL)
 		D_GOTO(out, rc = -DER_NOMEM);
 

--- a/src/pool/srv_iv.c
+++ b/src/pool/srv_iv.c
@@ -54,7 +54,7 @@ pool_iv_value_alloc_internal(struct ds_iv_key *key, d_sg_list_t *sgl)
 	if (rc)
 		return rc;
 
-	D_ALLOC(sgl->sg_iovs[0].iov_buf, buf_size);
+	DM_ALLOC(M_IV, sgl->sg_iovs[0].iov_buf, buf_size);
 	if (sgl->sg_iovs[0].iov_buf == NULL)
 		D_GOTO(free, rc = -DER_NOMEM);
 
@@ -422,7 +422,7 @@ pool_iv_conns_resize(d_sg_list_t *sgl, unsigned int old_size,
 	struct pool_iv_entry *new_ent;
 	struct pool_iv_conns *new_conns;
 
-	D_REALLOC(new_ent, old_ent, old_size, new_size);
+	DM_REALLOC(M_IV, new_ent, old_ent, old_size, new_size);
 	if (new_ent == NULL)
 		return -DER_NOMEM;
 
@@ -581,7 +581,7 @@ pool_iv_map_ent_update(d_sg_list_t *dst_sgl, struct pool_iv_entry *src_iv)
 		uint32_t new_size;
 
 		new_size = pool_iv_map_ent_size(pb_nr);
-		D_REALLOC_NZ(new_buf, dst_sgl->sg_iovs[0].iov_buf, new_size);
+		DM_REALLOC_NZ(M_IV, new_buf, dst_sgl->sg_iovs[0].iov_buf, new_size);
 		if (new_buf == NULL)
 			return -DER_NOMEM;
 
@@ -1018,7 +1018,7 @@ ds_pool_iv_map_update(struct ds_pool *pool, struct pool_buf *buf,
 
 	nr = buf != NULL ? buf->pb_nr : 0;
 	iv_entry_size = pool_iv_map_ent_size(nr);
-	D_ALLOC(iv_entry, iv_entry_size);
+	DM_ALLOC(M_IV, iv_entry, iv_entry_size);
 	if (iv_entry == NULL)
 		return -DER_NOMEM;
 
@@ -1058,7 +1058,7 @@ ds_pool_iv_conn_hdl_update(struct ds_pool *pool, uuid_t hdl_uuid,
 	int			rc;
 
 	iv_entry_size = pool_iv_conn_ent_size(cred->iov_len);
-	D_ALLOC(iv_entry, iv_entry_size);
+	DM_ALLOC(M_IV, iv_entry, iv_entry_size);
 	if (iv_entry == NULL)
 		return -DER_NOMEM;
 
@@ -1364,7 +1364,7 @@ ds_pool_iv_prop_update(struct ds_pool *pool, daos_prop_t *prop)
 
 	iv_entry_size = pool_iv_prop_ent_size(DAOS_ACL_MAX_ACE_LEN,
 					      svc_list->rl_nr);
-	D_ALLOC(iv_entry, iv_entry_size);
+	DM_ALLOC(M_IV, iv_entry, iv_entry_size);
 	if (iv_entry == NULL)
 		D_GOTO(out, rc = -DER_NOMEM);
 
@@ -1455,7 +1455,7 @@ ds_pool_iv_prop_fetch(struct ds_pool *pool, daos_prop_t *prop)
 
 	iv_entry_size = pool_iv_prop_ent_size(DAOS_ACL_MAX_ACE_LEN,
 					      PROP_SVC_LIST_MAX_TMP);
-	D_ALLOC(iv_entry, iv_entry_size);
+	DM_ALLOC(M_IV, iv_entry, iv_entry_size);
 	if (iv_entry == NULL)
 		D_GOTO(out, rc = -DER_NOMEM);
 

--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -149,7 +149,7 @@ read_map_buf(struct rdb_tx *tx, const rdb_path_t *kvs, struct pool_buf **buf,
 	if (rc != 0)
 		return rc;
 	size = pool_buf_size(b->pb_nr);
-	D_ALLOC(*buf, size);
+	DM_ALLOC(M_PROP, *buf, size);
 	if (*buf == NULL)
 		return -DER_NOMEM;
 	memcpy(*buf, b, size);
@@ -655,7 +655,7 @@ pool_svc_name_cb(d_iov_t *id, char **name)
 
 	if (id->iov_len != sizeof(uuid_t))
 		return -DER_INVAL;
-	D_ALLOC(s, DAOS_UUID_STR_SIZE);
+	DM_ALLOC(M_POOL, s, DAOS_UUID_STR_SIZE);
 	if (s == NULL)
 		return -DER_NOMEM;
 	uuid_unparse_lower(id->iov_buf, s);
@@ -689,7 +689,7 @@ pool_svc_alloc_cb(d_iov_t *id, struct ds_rsvc **rsvc)
 		goto err;
 	}
 
-	D_ALLOC_PTR(svc);
+	DM_ALLOC_PTR(M_POOL, svc);
 	if (svc == NULL) {
 		rc = -DER_NOMEM;
 		goto err;
@@ -793,7 +793,7 @@ queue_event(struct pool_svc *svc, d_rank_t rank, uint64_t incarnation, enum crt_
 	struct pool_svc_events *events = &svc->ps_events;
 	struct pool_svc_event  *event;
 
-	D_ALLOC_PTR(event);
+	DM_ALLOC_PTR(M_POOL, event);
 	if (event == NULL)
 		return -DER_NOMEM;
 
@@ -1707,7 +1707,7 @@ pool_prop_read(struct rdb_tx *tx, const struct pool_svc *svc, uint64_t bits,
 			return rc;
 		D_ASSERT(idx < nr);
 		prop->dpp_entries[idx].dpe_type = DAOS_PROP_PO_ACL;
-		D_ALLOC(prop->dpp_entries[idx].dpe_val_ptr, value.iov_buf_len);
+		DM_ALLOC(M_PROP, prop->dpp_entries[idx].dpe_val_ptr, value.iov_buf_len);
 		if (prop->dpp_entries[idx].dpe_val_ptr == NULL)
 			return -DER_NOMEM;
 		memcpy(prop->dpp_entries[idx].dpe_val_ptr, value.iov_buf,
@@ -2512,7 +2512,7 @@ realloc_resp:
 	}
 
 	/* Allocate response buffer */
-	D_ALLOC_ARRAY(resp_cont, resp_ncont);
+	DM_ALLOC_ARRAY(M_PROP, resp_cont, resp_ncont);
 	if (resp_cont == NULL)
 		D_GOTO(out_rpc, rc = -DER_NOMEM);
 
@@ -2726,7 +2726,7 @@ ds_pool_query_handler(crt_rpc_t *rpc)
 		struct daos_prop_entry	*entry, *iv_entry;
 		int			i;
 
-		D_ALLOC_PTR(iv_prop);
+		DM_ALLOC_PTR(M_PROP, iv_prop);
 		if (iv_prop == NULL)
 			D_GOTO(out_lock, rc = -DER_NOMEM);
 
@@ -3804,7 +3804,7 @@ ds_pool_svc_delete_acl(uuid_t pool_uuid, d_rank_list_t *ranks,
 	if (principal_name != NULL) {
 		/* Need to sanitize the incoming string */
 		name_buf_len = DAOS_ACL_MAX_PRINCIPAL_BUF_LEN;
-		D_ALLOC_ARRAY(name_buf, name_buf_len);
+		DM_ALLOC_ARRAY(M_PROP, name_buf, name_buf_len);
 		if (name_buf == NULL)
 			D_GOTO(out, rc = -DER_NOMEM);
 		/* force null terminator in copy */
@@ -4169,7 +4169,7 @@ get_open_handles_cb(daos_handle_t ih, d_iov_t *key, d_iov_t *val, void *varg)
 	if (size_needed > arg->hdls_size) {
 		void *newbuf = NULL;
 
-		D_REALLOC(newbuf, *arg->hdls, arg->hdls_size, size_needed);
+		DM_REALLOC(M_POOL, newbuf, *arg->hdls, arg->hdls_size, size_needed);
 		if (newbuf == NULL)
 			D_GOTO(out_hdl, rc = -DER_NOMEM);
 
@@ -4267,7 +4267,7 @@ ds_pool_get_open_handles(uuid_t pool_uuid, d_iov_t *hdls)
 	 * close enough just reduces the number of reallocations needed during
 	 * iteration
 	 */
-	D_ALLOC(hdls->iov_buf, nhandles * (sizeof(struct pool_iv_conn) + 160));
+	DM_ALLOC(M_PROP, hdls->iov_buf, nhandles * (sizeof(struct pool_iv_conn) + 160));
 	if (hdls->iov_buf == NULL)
 		D_GOTO(out_lock, rc = -DER_NOMEM);
 
@@ -4703,7 +4703,7 @@ evict_iter_cb(daos_handle_t ih, d_iov_t *key, d_iov_t *val, void *varg)
 		size_t	hdl_uuids_size_tmp;
 
 		hdl_uuids_size_tmp = arg->eia_hdl_uuids_size * 2;
-		D_ALLOC(hdl_uuids_tmp, hdl_uuids_size_tmp);
+		DM_ALLOC(M_PROP, hdl_uuids_tmp, hdl_uuids_size_tmp);
 		if (hdl_uuids_tmp == NULL)
 			return -DER_NOMEM;
 		memcpy(hdl_uuids_tmp, arg->eia_hdl_uuids,
@@ -4729,7 +4729,7 @@ find_hdls_to_evict(struct rdb_tx *tx, struct pool_svc *svc, uuid_t **hdl_uuids,
 	int			rc;
 
 	arg.eia_hdl_uuids_size = sizeof(uuid_t) * 4;
-	D_ALLOC(arg.eia_hdl_uuids, arg.eia_hdl_uuids_size);
+	DM_ALLOC(M_PROP, arg.eia_hdl_uuids, arg.eia_hdl_uuids_size);
 	if (arg.eia_hdl_uuids == NULL)
 		return -DER_NOMEM;
 	arg.eia_n_hdl_uuids = 0;
@@ -4767,7 +4767,7 @@ validate_hdls_to_evict(struct rdb_tx *tx, struct pool_svc *svc,
 	}
 
 	/* Assume the entire list is valid */
-	D_ALLOC(valid_list, sizeof(uuid_t) * n_hdl_list);
+	DM_ALLOC(M_PROP, valid_list, sizeof(uuid_t) * n_hdl_list);
 	if (valid_list == NULL)
 		return -DER_NOMEM;
 
@@ -5659,7 +5659,7 @@ ds_pool_child_map_refresh_async(struct ds_pool_child *dpc)
 	struct pool_map_refresh_ult_arg	*arg;
 	int				rc;
 
-	D_ALLOC_PTR(arg);
+	DM_ALLOC_PTR(M_PROP, arg);
 	if (arg == NULL)
 		return -DER_NOMEM;
 	arg->iua_pool_version = dpc->spc_map_version;

--- a/src/pool/srv_target.c
+++ b/src/pool/srv_target.c
@@ -188,7 +188,7 @@ pool_child_add_one(void *varg)
 
 	D_DEBUG(DF_DSMS, DF_UUID": creating\n", DP_UUID(arg->pla_uuid));
 
-	D_ALLOC_PTR(child);
+	DM_ALLOC_PTR(M_POOL, child);
 	if (child == NULL)
 		return -DER_NOMEM;
 
@@ -333,7 +333,7 @@ pool_alloc_ref(void *key, unsigned int ksize, void *varg,
 
 	D_DEBUG(DF_DSMS, DF_UUID": creating\n", DP_UUID(key));
 
-	D_ALLOC_PTR(pool);
+	DM_ALLOC_PTR(M_POOL, pool);
 	if (pool == NULL)
 		D_GOTO(err, rc = -DER_NOMEM);
 
@@ -923,7 +923,7 @@ pool_query_xs_arg_alloc(struct dss_stream_arg_type *xs, void *agg_arg)
 {
 	struct pool_query_xs_arg	*x_arg, *a_arg = agg_arg;
 
-	D_ALLOC_PTR(x_arg);
+	DM_ALLOC_PTR(M_POOL, x_arg);
 	if (x_arg == NULL)
 		return -DER_NOMEM;
 
@@ -1071,7 +1071,7 @@ ds_pool_tgt_connect(struct ds_pool *pool, struct pool_iv_conn *pic)
 		return 0;
 	}
 
-	D_ALLOC_PTR(hdl);
+	DM_ALLOC_PTR(M_POOL, hdl);
 	if (hdl == NULL)
 		D_GOTO(out, rc = -DER_NOMEM);
 
@@ -1294,7 +1294,7 @@ ds_pool_tgt_map_update(struct ds_pool *pool, struct pool_buf *buf,
 		/* Since the map has been updated successfully, so let's
 		 * ignore the dtx resync failure for now.
 		 */
-		D_ALLOC_PTR(arg);
+		DM_ALLOC_PTR(M_POOL, arg);
 		if (arg == NULL)
 			D_GOTO(out, rc);
 

--- a/src/rdb/rdb.c
+++ b/src/rdb/rdb.c
@@ -232,7 +232,7 @@ rdb_start_internal(daos_handle_t pool, daos_handle_t mc, const uuid_t uuid,
 
 	D_ASSERT(cbs->dc_stop != NULL);
 
-	D_ALLOC_PTR(db);
+	DM_ALLOC_PTR(M_RDB, db);
 	if (db == NULL) {
 		D_ERROR(DF_UUID": failed to allocate db object\n",
 			DP_UUID(uuid));

--- a/src/rdb/rdb_kvs.c
+++ b/src/rdb/rdb_kvs.c
@@ -108,7 +108,7 @@ rdb_kvs_alloc_ref(void *key, unsigned int ksize, void *varg,
 		goto err;
 	}
 
-	D_ALLOC(kvs, sizeof(*kvs) + ksize);
+	DM_ALLOC(M_RDB, kvs, sizeof(*kvs) + ksize);
 	if (kvs == NULL) {
 		rc = -DER_NOMEM;
 		goto err;

--- a/src/rdb/rdb_path.c
+++ b/src/rdb/rdb_path.c
@@ -38,7 +38,7 @@ rdb_path_init(rdb_path_t *path)
 	d_iov_t p = {};
 
 	p.iov_buf_len = 128;
-	D_ALLOC(p.iov_buf, p.iov_buf_len);
+	DM_ALLOC(M_RDB, p.iov_buf, p.iov_buf_len);
 	if (p.iov_buf == NULL)
 		return -DER_NOMEM;
 	*path = p;
@@ -72,7 +72,7 @@ rdb_path_clone(const rdb_path_t *path, rdb_path_t *new_path)
 	void *buf;
 
 	rdb_path_assert(path);
-	D_ALLOC(buf, path->iov_buf_len);
+	DM_ALLOC(M_RDB, buf, path->iov_buf_len);
 	if (buf == NULL)
 		return -DER_NOMEM;
 	memcpy(buf, path->iov_buf, path->iov_len);
@@ -111,7 +111,7 @@ rdb_path_push(rdb_path_t *path, const d_iov_t *key)
 				return -DER_OVERFLOW;
 			buf_len = min(buf_len * 2, rdb_iov_max);
 		} while (buf_len < path->iov_len + len);
-		D_ALLOC(buf, buf_len);
+		DM_ALLOC(M_RDB, buf, buf_len);
 		if (buf == NULL)
 			return -DER_NOMEM;
 		memcpy(buf, path->iov_buf, path->iov_len);

--- a/src/rdb/rdb_raft.c
+++ b/src/rdb/rdb_raft.c
@@ -126,7 +126,7 @@ rdb_raft_clone_ae(struct rdb *db, const msg_appendentries_t *ae, msg_appendentri
 	else if (ae_new->n_entries > db->d_ae_max_entries)
 		ae_new->n_entries = db->d_ae_max_entries;
 
-	D_ALLOC_ARRAY(ae_new->entries, ae_new->n_entries);
+	DM_ALLOC_ARRAY(M_RDB, ae_new->entries, ae_new->n_entries);
 	if (ae_new->entries == NULL)
 		return -DER_NOMEM;
 	for (i = 0; i < ae_new->n_entries; i++) {
@@ -148,7 +148,7 @@ rdb_raft_clone_ae(struct rdb *db, const msg_appendentries_t *ae, msg_appendentri
 			break;
 		}
 
-		D_ALLOC(e_new->data.buf, e_new->data.len);
+		DM_ALLOC(M_RDB, e_new->data.buf, e_new->data.len);
 		if (e_new->data.buf == NULL) {
 			rdb_raft_fini_ae(ae_new);
 			return -DER_NOMEM;
@@ -236,7 +236,7 @@ rdb_raft_add_node(struct rdb *db, d_rank_t rank)
 	d_rank_t		 self;
 	int			 rc = 0;
 
-	D_ALLOC_PTR(dnode);
+	DM_ALLOC_PTR(M_RDB, dnode);
 	if (dnode == NULL)
 		D_GOTO(out, rc = -DER_NOMEM);
 	rc = crt_group_rank(NULL, &self);
@@ -465,12 +465,12 @@ rdb_raft_cb_send_installsnapshot(raft_server_t *raft, void *arg,
 	 */
 	kds.iov_buf_len = 4 * 1024;
 	kds.iov_len = 0;
-	D_ALLOC(kds.iov_buf, kds.iov_buf_len);
+	DM_ALLOC(M_RDB, kds.iov_buf, kds.iov_buf_len);
 	if (kds.iov_buf == NULL)
 		goto err_rpc;
 	data.iov_buf_len = 1 * 1024 * 1024;
 	data.iov_len = 0;
-	D_ALLOC(data.iov_buf, data.iov_buf_len);
+	DM_ALLOC(M_RDB, data.iov_buf, data.iov_buf_len);
 	if (data.iov_buf == NULL)
 		goto err_kds;
 
@@ -599,7 +599,7 @@ rdb_raft_recv_is(struct rdb *db, crt_rpc_t *rpc, d_iov_t *kds,
 	rc = crt_bulk_get_len(in->isi_kds, &kds->iov_buf_len);
 	D_ASSERTF(rc == 0, ""DF_RC"\n", DP_RC(rc));
 	kds->iov_len = kds->iov_buf_len;
-	D_ALLOC(kds->iov_buf, kds->iov_buf_len);
+	DM_ALLOC(M_RDB, kds->iov_buf, kds->iov_buf_len);
 	if (kds->iov_buf == NULL) {
 		rc = -DER_NOMEM;
 		goto out;
@@ -607,7 +607,7 @@ rdb_raft_recv_is(struct rdb *db, crt_rpc_t *rpc, d_iov_t *kds,
 	rc = crt_bulk_get_len(in->isi_data, &data->iov_buf_len);
 	D_ASSERTF(rc == 0, ""DF_RC"\n", DP_RC(rc));
 	data->iov_len = data->iov_buf_len;
-	D_ALLOC(data->iov_buf, data->iov_buf_len);
+	DM_ALLOC(M_RDB, data->iov_buf, data->iov_buf_len);
 	if (data->iov_buf == NULL) {
 		rc = -DER_NOMEM;
 		goto out_kds;
@@ -1840,7 +1840,7 @@ rdb_raft_register_result(struct rdb *db, uint64_t index, void *buf)
 	struct rdb_raft_result *result;
 	int			rc;
 
-	D_ALLOC_PTR(result);
+	DM_ALLOC_PTR(M_RDB, result);
 	if (result == NULL)
 		return -DER_NOMEM;
 	result->drr_index = index;

--- a/src/rdb/rdb_rpc.c
+++ b/src/rdb/rdb_rpc.c
@@ -63,7 +63,7 @@ crt_proc_msg_entry_t(crt_proc_t proc, crt_proc_op_t proc_op, msg_entry_t *p)
 		return 0;
 
 	if (DECODING(proc_op)) {
-		D_ALLOC(p->data.buf, p->data.len);
+		DM_ALLOC(M_RDB, p->data.buf, p->data.len);
 		if (p->data.buf == NULL)
 			return -DER_NOMEM;
 	}
@@ -104,7 +104,7 @@ crt_proc_msg_appendentries_t(crt_proc_t proc, crt_proc_op_t proc_op,
 		return 0;
 
 	if (DECODING(proc_op)) {
-		D_ALLOC_ARRAY(p->entries, p->n_entries);
+		DM_ALLOC_ARRAY(M_RDB, p->entries, p->n_entries);
 		if (p->entries == NULL)
 			return -DER_NOMEM;
 	}
@@ -242,7 +242,7 @@ rdb_alloc_raft_rpc(struct rdb *db, crt_rpc_t *rpc)
 {
 	struct rdb_raft_rpc *rrpc;
 
-	D_ALLOC_PTR(rrpc);
+	DM_ALLOC_PTR(M_RDB, rrpc);
 	if (rrpc == NULL)
 		return NULL;
 	D_INIT_LIST_HEAD(&rrpc->drc_entry);

--- a/src/rdb/rdb_tx.c
+++ b/src/rdb/rdb_tx.c
@@ -331,7 +331,7 @@ rdb_tx_append(struct rdb_tx *tx, struct rdb_tx_op *op)
 			else
 				new_size *= 2;
 		} while (len > new_size - tx->dt_entry_len);
-		D_ALLOC(new_buf, new_size);
+		DM_ALLOC(M_RDB, new_buf, new_size);
 		if (new_buf == NULL)
 			return -DER_NOMEM;
 		if (tx->dt_entry_len > 0)

--- a/src/rebuild/rebuild_iv.c
+++ b/src/rebuild/rebuild_iv.c
@@ -35,7 +35,7 @@ rebuild_iv_alloc_internal(d_sg_list_t *sgl)
 	if (rc)
 		return rc;
 
-	D_ALLOC(sgl->sg_iovs[0].iov_buf, sizeof(struct rebuild_iv));
+	DM_ALLOC(M_IV, sgl->sg_iovs[0].iov_buf, sizeof(struct rebuild_iv));
 	if (sgl->sg_iovs[0].iov_buf == NULL)
 		D_GOTO(free, rc = -DER_NOMEM);
 	sgl->sg_iovs[0].iov_buf_len = sizeof(struct rebuild_iv);

--- a/src/rebuild/scan.c
+++ b/src/rebuild/scan.c
@@ -203,19 +203,19 @@ rebuild_objects_send_ult(void *data)
 	tls = rebuild_pool_tls_lookup(rpt->rt_pool_uuid, rpt->rt_rebuild_ver);
 	D_ASSERT(tls != NULL);
 
-	D_ALLOC_ARRAY(oids, REBUILD_SEND_LIMIT);
+	DM_ALLOC_ARRAY(M_RECOV, oids, REBUILD_SEND_LIMIT);
 	if (oids == NULL)
 		D_GOTO(out, rc = -DER_NOMEM);
 
-	D_ALLOC_ARRAY(shards, REBUILD_SEND_LIMIT);
+	DM_ALLOC_ARRAY(M_RECOV, shards, REBUILD_SEND_LIMIT);
 	if (shards == NULL)
 		D_GOTO(out, rc = -DER_NOMEM);
 
-	D_ALLOC_ARRAY(ephs, REBUILD_SEND_LIMIT);
+	DM_ALLOC_ARRAY(M_RECOV, ephs, REBUILD_SEND_LIMIT);
 	if (ephs == NULL)
 		D_GOTO(out, rc = -DER_NOMEM);
 
-	D_ALLOC_ARRAY(punched_ephs, REBUILD_SEND_LIMIT);
+	DM_ALLOC_ARRAY(M_RECOV, punched_ephs, REBUILD_SEND_LIMIT);
 	if (ephs == NULL)
 		D_GOTO(out, rc = -DER_NOMEM);
 
@@ -417,8 +417,8 @@ find_rebuild_shards(unsigned int *tgt_stack_array,
 			D_DEBUG(DB_REBUILD, "Insufficient stack buffer to find "
 					    "rebuild shards, allocating %u\n",
 				max_shards);
-			D_ALLOC_ARRAY(*tgts, max_shards);
-			D_ALLOC_ARRAY(*shards, max_shards);
+			DM_ALLOC_ARRAY(M_RECOV, *tgts, max_shards);
+			DM_ALLOC_ARRAY(M_RECOV, *shards, max_shards);
 			if (*tgts == NULL || *shards == NULL)
 				D_GOTO(out, rc = -DER_NOMEM);
 		}

--- a/src/rebuild/srv.c
+++ b/src/rebuild/srv.c
@@ -77,7 +77,7 @@ rebuild_pool_tls_create(uuid_t pool_uuid, uuid_t poh_uuid, uuid_t coh_uuid,
 	rebuild_pool_tls = rebuild_pool_tls_lookup(pool_uuid, ver);
 	D_ASSERT(rebuild_pool_tls == NULL);
 
-	D_ALLOC_PTR(rebuild_pool_tls);
+	DM_ALLOC_PTR(M_RECOV, rebuild_pool_tls);
 	if (rebuild_pool_tls == NULL)
 		return NULL;
 
@@ -113,7 +113,7 @@ rebuild_tls_init(int xs_id, int tgt_id)
 {
 	struct rebuild_tls *tls;
 
-	D_ALLOC_PTR(tls);
+	DM_ALLOC_PTR(M_RECOV, tls);
 	if (tls == NULL)
 		return NULL;
 
@@ -266,7 +266,7 @@ rebuild_status_completed_update(const uuid_t pool_uuid,
 		return 0;
 	}
 
-	D_ALLOC_PTR(rsc);
+	DM_ALLOC_PTR(M_RECOV, rsc);
 	if (rsc == NULL)
 		return -DER_NOMEM;
 
@@ -676,7 +676,7 @@ rebuild_global_pool_tracker_create(struct ds_pool *pool, uint32_t ver,
 	int i;
 	int rc = 0;
 
-	D_ALLOC_PTR(rgt);
+	DM_ALLOC_PTR(M_RECOV, rgt);
 	if (rgt == NULL)
 		return -DER_NOMEM;
 
@@ -685,7 +685,7 @@ rebuild_global_pool_tracker_create(struct ds_pool *pool, uint32_t ver,
 	if (node_nr < 0)
 		D_GOTO(out, rc = node_nr);
 
-	D_ALLOC_ARRAY(rgt->rgt_servers, node_nr);
+	DM_ALLOC_ARRAY(M_RECOV, rgt->rgt_servers, node_nr);
 	if (rgt->rgt_servers == NULL)
 		D_GOTO(out, rc = -DER_NOMEM);
 
@@ -1612,7 +1612,7 @@ ds_rebuild_schedule(struct ds_pool *pool, uint32_t map_ver,
 		return rc == 1 ? 0 : rc;
 
 	/* No existing task was found - allocate a new one and use it */
-	D_ALLOC_PTR(new_task);
+	DM_ALLOC_PTR(M_RECOV, new_task);
 	if (new_task == NULL)
 		return -DER_NOMEM;
 
@@ -2073,7 +2073,7 @@ rpt_create(struct ds_pool *pool, uint32_t pm_ver, uint64_t leader_term,
 	d_rank_t	rank;
 	int		rc;
 
-	D_ALLOC_PTR(rpt);
+	DM_ALLOC_PTR(M_RECOV, rpt);
 	if (rpt == NULL)
 		return -DER_NOMEM;
 

--- a/src/vea/vea_api.c
+++ b/src/vea/vea_api.c
@@ -216,7 +216,7 @@ vea_load(struct umem_instance *umem, struct umem_tx_stage_data *txd,
 		return -DER_UNINIT;
 	}
 
-	D_ALLOC_PTR(vsi);
+	DM_ALLOC_PTR(M_VEA, vsi);
 	if (vsi == NULL)
 		return -DER_NOMEM;
 
@@ -298,7 +298,7 @@ vea_reserve(struct vea_space_info *vsi, uint32_t blk_cnt,
 	D_ASSERT(vsi != NULL);
 	D_ASSERT(resrvd_list != NULL);
 
-	D_ALLOC_PTR(resrvd);
+	DM_ALLOC_PTR(M_VEA, resrvd);
 	if (resrvd == NULL)
 		return -DER_NOMEM;
 
@@ -524,7 +524,7 @@ vea_free(struct vea_space_info *vsi, uint64_t blk_off, uint32_t blk_cnt)
 	struct free_commit_cb_arg *fca;
 	int rc;
 
-	D_ALLOC_PTR(fca);
+	DM_ALLOC_PTR(M_VEA, fca);
 	if (fca == NULL)
 		return -DER_NOMEM;
 
@@ -599,7 +599,7 @@ vea_hint_load(struct vea_hint_df *phd, struct vea_hint_context **thc)
 	D_ASSERT(thc != NULL);
 	struct vea_hint_context *hint_ctxt;
 
-	D_ALLOC_PTR(hint_ctxt);
+	DM_ALLOC_PTR(M_VEA, hint_ctxt);
 	if (hint_ctxt == NULL)
 		return -DER_NOMEM;
 

--- a/src/vea/vea_free.c
+++ b/src/vea/vea_free.c
@@ -448,7 +448,7 @@ migrate_end_cb(void *data, bool noop)
 		 * this tight loop.
 		 */
 		if (vsi->vsi_unmap_ctxt.vnc_unmap != NULL) {
-			D_ALLOC_PTR(vue);
+			DM_ALLOC_PTR(M_VEA, vue);
 			if (vue == NULL) {
 				rc = -DER_NOMEM;
 				break;

--- a/src/vea/vea_init.c
+++ b/src/vea/vea_init.c
@@ -75,14 +75,14 @@ create_free_class(struct vea_free_class *vfc, struct vea_space_df *md)
 	}
 
 	D_ASSERT(vfc->vfc_lrus == NULL);
-	D_ALLOC_ARRAY(vfc->vfc_lrus, lru_cnt);
+	DM_ALLOC_ARRAY(M_VEA, vfc->vfc_lrus, lru_cnt);
 	if (vfc->vfc_lrus == NULL) {
 		rc = -DER_NOMEM;
 		goto error;
 	}
 
 	D_ASSERT(vfc->vfc_sizes == NULL);
-	D_ALLOC_ARRAY(vfc->vfc_sizes, lru_cnt);
+	DM_ALLOC_ARRAY(M_VEA, vfc->vfc_sizes, lru_cnt);
 	if (vfc->vfc_sizes == NULL) {
 		rc = -DER_NOMEM;
 		goto error;
@@ -99,7 +99,7 @@ create_free_class(struct vea_free_class *vfc, struct vea_space_df *md)
 
 	D_ASSERT(vfc->vfc_cursor == NULL);
 	size = lru_cnt * sizeof(struct vea_entry *);
-	D_ALLOC_ARRAY(vfc->vfc_cursor, size);
+	DM_ALLOC_ARRAY(M_VEA, vfc->vfc_cursor, size);
 	if (vfc->vfc_cursor == NULL) {
 		rc = -DER_NOMEM;
 		goto error;

--- a/src/vos/evtree.c
+++ b/src/vos/evtree.c
@@ -303,7 +303,7 @@ ent_array_resize(struct evt_context *tcx, struct evt_entry_array *ent_array,
 {
 	struct evt_list_entry	*ents;
 
-	D_ALLOC_ARRAY(ents, new_size);
+	DM_ALLOC_ARRAY(M_VOS, ents, new_size);
 	if (ents == NULL)
 		return -DER_NOMEM;
 
@@ -1120,7 +1120,7 @@ evt_tcx_create(struct evt_root *root, uint64_t feats, unsigned int order,
 
 	D_ASSERT(root != NULL);
 
-	D_ALLOC_PTR(tcx);
+	DM_ALLOC_PTR(M_VOS, tcx);
 	if (tcx == NULL)
 		return -DER_NOMEM;
 
@@ -2299,7 +2299,7 @@ evt_data_loss_add(d_list_t *head, struct evt_rect *rect)
 {
 	struct evt_data_loss_item	*edli;
 
-	D_ALLOC_PTR(edli);
+	DM_ALLOC_PTR(M_VOS, edli);
 	if (edli != NULL) {
 		edli->edli_rect = *rect;
 		d_list_add(&edli->edli_link, head);

--- a/src/vos/ilog.c
+++ b/src/vos/ilog.c
@@ -289,7 +289,7 @@ static int
 ilog_ctx_create(struct umem_instance *umm, struct ilog_root *root,
 		const struct ilog_desc_cbs *cbs, struct ilog_context **lctxp)
 {
-	D_ALLOC_PTR(*lctxp);
+	DM_ALLOC_PTR(M_VOS, *lctxp);
 	if (*lctxp == NULL) {
 		D_ERROR("Could not allocate memory for open incarnation log\n");
 		return -DER_NOMEM;
@@ -1167,7 +1167,7 @@ prepare_entries(struct ilog_entries *entries, struct ilog_array_cache *cache)
 	if (cache->ac_nr <= priv->ip_alloc_size)
 		goto done;
 
-	D_ALLOC_ARRAY(statuses, cache->ac_nr);
+	DM_ALLOC_ARRAY(M_VOS, statuses, cache->ac_nr);
 	if (statuses == NULL)
 		return -DER_NOMEM;
 
@@ -1537,7 +1537,7 @@ ilog_aggregate(struct umem_instance *umm, struct ilog_df *ilog,
 	ilog_log2cache(lctx, &cache);
 
 	if (priv->ip_removals == NULL) {
-		D_ALLOC_ARRAY(priv->ip_removals, cache.ac_nr);
+		DM_ALLOC_ARRAY(M_VOS, priv->ip_removals, cache.ac_nr);
 		if (priv->ip_removals == NULL)
 			return -DER_NOMEM;
 	}

--- a/src/vos/lru_array.c
+++ b/src/vos/lru_array.c
@@ -74,7 +74,7 @@ lrua_array_alloc_one(struct lru_array *array, struct lru_sub *sub)
 	uint32_t		 idx;
 
 	rec_size = sizeof(*entry) + array->la_payload_size;
-	D_ALLOC(sub->ls_table, rec_size * nr_ents);
+	DM_ALLOC(M_VOS_LRU, sub->ls_table, rec_size * nr_ents);
 	if (sub->ls_table == NULL)
 		return -DER_NOMEM;
 
@@ -272,7 +272,7 @@ lrua_array_alloc(struct lru_array **arrayp, uint32_t nr_ent, uint32_t nr_arrays,
 
 	*arrayp = NULL;
 
-	D_ALLOC(array, sizeof(*array) +
+	DM_ALLOC(M_VOS_LRU, array, sizeof(*array) +
 		(sizeof(array->la_sub[0]) * nr_arrays));
 	if (array == NULL)
 		return -DER_NOMEM;

--- a/src/vos/vos_aggregate.c
+++ b/src/vos/vos_aggregate.c
@@ -515,7 +515,7 @@ csum_prepare_buf(struct agg_lgc_seg *segs, unsigned int seg_cnt,
 	int		 i;
 
 	if (new_len > cur_len) {
-		D_REALLOC_NZ(buffer, *csum_bufp, new_len);
+		DM_REALLOC_NZ(M_CSUM, buffer, *csum_bufp, new_len);
 		if (buffer == NULL)
 			return -DER_NOMEM;
 	} else
@@ -539,7 +539,7 @@ allocate_rmv_ent(const struct evt_extent *ext, daos_epoch_t epoch, uint16_t mino
 {
 	struct agg_rmv_ent *rm_ent;
 
-	D_ALLOC_PTR(rm_ent);
+	DM_ALLOC_PTR(M_VOS, rm_ent);
 	if (rm_ent == NULL)
 		return NULL;
 
@@ -724,7 +724,7 @@ prepare_segments(struct agg_merge_window *mw)
 
 	seg_max = MAX((mw->mw_lgc_cnt + mw->mw_phy_cnt), 200);
 	if (io->ic_seg_max < seg_max) {
-		D_REALLOC_ARRAY_NZ(lgc_seg, io->ic_segs, seg_max);
+		DM_REALLOC_ARRAY_NZ(M_VOS, lgc_seg, io->ic_segs, seg_max);
 		if (lgc_seg == NULL)
 			return -DER_NOMEM;
 
@@ -961,8 +961,7 @@ csum_append_added_segs(struct bio_sglist *bsgl, unsigned int added_segs)
 	void		*buffer;
 	unsigned int	 i, add_idx = bsgl->bs_nr;
 
-	D_REALLOC_ARRAY(buffer, bsgl->bs_iovs, bsgl->bs_nr,
-			bsgl->bs_nr + added_segs);
+	DM_REALLOC_ARRAY(M_VOS, buffer, bsgl->bs_iovs, bsgl->bs_nr, bsgl->bs_nr + added_segs);
 	if (buffer == NULL)
 		return -DER_NOMEM;
 	bsgl->bs_iovs = buffer;
@@ -1121,8 +1120,8 @@ fill_one_segment(daos_handle_t ih, struct agg_merge_window *mw,
 		void *buffer;
 
 		/* An array of recalc structs (one per output segment). */
-		D_REALLOC_ARRAY(buffer, io->ic_csum_recalcs,
-				io->ic_csum_recalc_cnt, seg_count);
+		DM_REALLOC_ARRAY(M_VOS, buffer, io->ic_csum_recalcs,
+				 io->ic_csum_recalc_cnt, seg_count);
 		if (buffer == NULL)
 			D_GOTO(out, rc = -DER_NOMEM);
 
@@ -1200,8 +1199,7 @@ fill_one_segment(daos_handle_t ih, struct agg_merge_window *mw,
 	if (io->ic_buf_len < buf_max + buf_add) {
 		void *buffer;
 
-		D_REALLOC(buffer, io->ic_buf, io->ic_buf_len,
-			  buf_max + buf_add);
+		DM_REALLOC(M_VOS, buffer, io->ic_buf, io->ic_buf_len, buf_max + buf_add);
 		if (buffer == NULL) {
 			rc = -DER_NOMEM;
 			goto out;
@@ -1297,7 +1295,7 @@ fill_segments(daos_handle_t ih, struct agg_merge_window *mw,
 		size = sizeof(*io->ic_rsrvd_scm) *
 			sizeof(*scm_exts) * scm_max;
 
-		D_REALLOC_Z(rsrvd_scm, io->ic_rsrvd_scm, size);
+		DM_REALLOC_Z(M_VOS, rsrvd_scm, io->ic_rsrvd_scm, size);
 		if (rsrvd_scm == NULL)
 			return -DER_NOMEM;
 
@@ -1715,7 +1713,7 @@ enqueue_phy_ent(struct agg_merge_window *mw, struct evt_extent *phy_ext,
 {
 	struct agg_phy_ent *phy_ent;
 
-	D_ALLOC_PTR(phy_ent);
+	DM_ALLOC_PTR(M_VOS, phy_ent);
 	if (phy_ent == NULL)
 		return NULL;
 
@@ -1776,7 +1774,7 @@ enqueue_lgc_ent(struct agg_merge_window *mw, struct evt_extent *lgc_ext,
 	if (cnt == max) {
 		unsigned int new_max = max ? max * 2 : 10;
 
-		D_REALLOC_ARRAY(lgc_ent, mw->mw_lgc_ents, max, new_max);
+		DM_REALLOC_ARRAY(M_VOS, lgc_ent, mw->mw_lgc_ents, max, new_max);
 		if (lgc_ent == NULL)
 			return -DER_NOMEM;
 
@@ -2489,7 +2487,7 @@ vos_aggregate(daos_handle_t coh, daos_epoch_range_t *epr,
 		  "epr_lo:"DF_U64", epr_hi:"DF_U64"\n",
 		  epr->epr_lo, epr->epr_hi);
 
-	D_ALLOC_PTR(ad);
+	DM_ALLOC_PTR(M_VOS, ad);
 	if (ad == NULL)
 		return -DER_NOMEM;
 
@@ -2570,7 +2568,7 @@ vos_discard(daos_handle_t coh, daos_unit_oid_t *oidp, daos_epoch_range_t *epr,
 		  "epr_lo:"DF_U64", epr_hi:"DF_U64"\n",
 		  epr->epr_lo, epr->epr_hi);
 
-	D_ALLOC_PTR(ad);
+	DM_ALLOC_PTR(M_VOS, ad);
 	if (ad == NULL)
 		return -DER_NOMEM;
 

--- a/src/vos/vos_common.c
+++ b/src/vos/vos_common.c
@@ -366,7 +366,7 @@ vos_tls_init(int xs_id, int tgt_id)
 	struct vos_tls *tls;
 	int		rc;
 
-	D_ALLOC_PTR(tls);
+	DM_ALLOC_PTR(M_VOS, tls);
 	if (tls == NULL)
 		return NULL;
 

--- a/src/vos/vos_container.c
+++ b/src/vos/vos_container.c
@@ -356,7 +356,7 @@ vos_cont_open(daos_handle_t poh, uuid_t co_uuid, daos_handle_t *coh)
 		D_GOTO(exit, rc);
 	}
 
-	D_ALLOC_PTR(cont);
+	DM_ALLOC_PTR(M_VOS, cont);
 	if (!cont) {
 		D_ERROR("Error in allocating container handle\n");
 		D_GOTO(exit, rc = -DER_NOMEM);
@@ -689,7 +689,7 @@ cont_iter_prep(vos_iter_type_t type, vos_iter_param_t *param,
 	if (vpool == NULL)
 		return -DER_INVAL;
 
-	D_ALLOC_PTR(co_iter);
+	DM_ALLOC_PTR(M_VOS, co_iter);
 	if (co_iter == NULL)
 		return -DER_NOMEM;
 

--- a/src/vos/vos_dtx.c
+++ b/src/vos/vos_dtx.c
@@ -153,7 +153,7 @@ dtx_inprogress(struct vos_dtx_act_ent *dae, struct dtx_handle *dth,
 	if (dth->dth_share_tbd_count >= DTX_REFRESH_MAX)
 		goto out;
 
-	D_ALLOC(dsp, sizeof(*dsp) + DAE_MBS_DSIZE(dae));
+	DM_ALLOC(M_VOS_DTX, dsp, sizeof(*dsp) + DAE_MBS_DSIZE(dae));
 	if (dsp == NULL) {
 		D_ERROR("Hit uncommitted DTX "DF_DTI" at %d: lid=%d, "
 			"but fail to alloc DRAM.\n",
@@ -825,7 +825,7 @@ vos_dtx_commit_one(struct vos_container *cont, struct dtx_id *dti,
 		}
 	}
 
-	D_ALLOC_PTR(dce);
+	DM_ALLOC_PTR(M_VOS_DTX, dce);
 	if (dce == NULL)
 		D_GOTO(out, rc = -DER_NOMEM);
 
@@ -1152,7 +1152,7 @@ vos_dtx_append(struct dtx_handle *dth, umem_off_t record, uint32_t type)
 			else
 				count = dae->dae_rec_cap * 2;
 
-			D_ALLOC_ARRAY(rec, count);
+			DM_ALLOC_ARRAY(M_VOS_DTX, rec, count);
 			if (rec == NULL)
 				return -DER_NOMEM;
 
@@ -1745,7 +1745,7 @@ vos_dtx_prepared(struct dtx_handle *dth, struct vos_dtx_cmt_ent **dce_p)
 			dae->dae_oids = &dae->dae_oid_inline;
 		} else {
 			size = sizeof(daos_unit_oid_t) * dth->dth_oid_cnt;
-			D_ALLOC_NZ(dae->dae_oids, size);
+			DM_ALLOC_NZ(M_VOS_DTX, dae->dae_oids, size);
 			if (dae->dae_oids == NULL) {
 				/* Not fatal. */
 				D_WARN("No DRAM to store ACT DTX OIDs "
@@ -1823,7 +1823,7 @@ vos_dtx_pack_mbs(struct umem_instance *umm, struct vos_dtx_act_ent *dae)
 	size_t			 size;
 
 	size = sizeof(*tmp) + DAE_MBS_DSIZE(dae);
-	D_ALLOC(tmp, size);
+	DM_ALLOC(M_VOS_DTX, tmp, size);
 	if (tmp == NULL)
 		return NULL;
 
@@ -2144,11 +2144,11 @@ vos_dtx_commit(daos_handle_t coh, struct dtx_id *dtis, int count, bool *rm_cos)
 
 	D_ASSERT(count > 0);
 
-	D_ALLOC_ARRAY(daes, count);
+	DM_ALLOC_ARRAY(M_VOS_DTX, daes, count);
 	if (daes == NULL)
 		D_GOTO(out, rc = -DER_NOMEM);
 
-	D_ALLOC_ARRAY(dces, count);
+	DM_ALLOC_ARRAY(M_VOS_DTX, dces, count);
 	if (dces == NULL)
 		D_GOTO(out, rc = -DER_NOMEM);
 
@@ -2567,7 +2567,7 @@ vos_dtx_act_reindex(struct vos_container *cont)
 				count = DAE_REC_CNT(dae) - DTX_INLINE_REC_CNT;
 				size = sizeof(*dae->dae_records) * count;
 
-				D_ALLOC(dae->dae_records, size);
+				DM_ALLOC(M_VOS_DTX, dae->dae_records, size);
 				if (dae->dae_records == NULL) {
 					dtx_evict_lid(cont, dae);
 					D_GOTO(out, rc = -DER_NOMEM);
@@ -2641,7 +2641,7 @@ vos_dtx_cmt_reindex(daos_handle_t coh, void *hint)
 			continue;
 		}
 
-		D_ALLOC_PTR(dce);
+		DM_ALLOC_PTR(M_VOS_DTX, dce);
 		if (dce == NULL)
 			D_GOTO(out, rc = -DER_NOMEM);
 
@@ -2883,11 +2883,11 @@ vos_dtx_rsrvd_init(struct dtx_handle *dth)
 		return 0;
 	}
 
-	D_ALLOC_ARRAY(dth->dth_rsrvds, dth->dth_modification_cnt);
+	DM_ALLOC_ARRAY(M_VOS_DTX, dth->dth_rsrvds, dth->dth_modification_cnt);
 	if (dth->dth_rsrvds == NULL)
 		return -DER_NOMEM;
 
-	D_ALLOC_ARRAY(dth->dth_deferred, dth->dth_modification_cnt);
+	DM_ALLOC_ARRAY(M_VOS_DTX, dth->dth_deferred, dth->dth_modification_cnt);
 	if (dth->dth_deferred == NULL) {
 		D_FREE(dth->dth_rsrvds);
 		return -DER_NOMEM;

--- a/src/vos/vos_dtx_iter.c
+++ b/src/vos/vos_dtx_iter.c
@@ -70,7 +70,7 @@ dtx_iter_prep(vos_iter_type_t type, vos_iter_param_t *param,
 	if (cont == NULL)
 		return -DER_INVAL;
 
-	D_ALLOC_PTR(oiter);
+	DM_ALLOC_PTR(M_VOS_DTX, oiter);
 	if (oiter == NULL)
 		return -DER_NOMEM;
 

--- a/src/vos/vos_io.c
+++ b/src/vos/vos_io.c
@@ -267,7 +267,7 @@ vos_dedup_update(struct vos_pool *pool, struct dcs_csum_info *csum,
 	if (vos_dedup_lookup(pool, csum, csum_len, NULL))
 		return;
 
-	D_ALLOC_PTR(entry);
+	DM_ALLOC_PTR(M_VOS, entry);
 	if (entry == NULL) {
 		D_ERROR("Failed to allocate dedup entry\n");
 		return;
@@ -275,7 +275,7 @@ vos_dedup_update(struct vos_pool *pool, struct dcs_csum_info *csum,
 	D_INIT_LIST_HEAD(&entry->de_link);
 
 	D_ASSERT(csum_len != 0);
-	D_ALLOC(entry->de_csum_buf, csum_len);
+	DM_ALLOC(M_VOS, entry->de_csum_buf, csum_len);
 	if (entry->de_csum_buf == NULL) {
 		D_ERROR("Failed to allocate csum buf "DF_U64"\n", csum_len);
 		D_FREE(entry);
@@ -464,7 +464,7 @@ vos_dedup_verify_init(daos_handle_t ioh, void *bulk_ctxt,
 		return 0;
 
 	D_ASSERT(ioc->ic_dedup_bsgls == NULL);
-	D_ALLOC_ARRAY(ioc->ic_dedup_bsgls, ioc->ic_iod_nr);
+	DM_ALLOC_ARRAY(M_VOS, ioc->ic_dedup_bsgls, ioc->ic_iod_nr);
 	if (ioc->ic_dedup_bsgls == NULL)
 		return -DER_NOMEM;
 
@@ -477,7 +477,7 @@ vos_dedup_verify_init(daos_handle_t ioh, void *bulk_ctxt,
 	}
 
 	D_ASSERT(buf_idx > 0);
-	D_ALLOC_ARRAY(ioc->ic_dedup_bufs, buf_idx);
+	DM_ALLOC_ARRAY(M_VOS, ioc->ic_dedup_bufs, buf_idx);
 	if (ioc->ic_dedup_bufs == NULL) {
 		D_FREE(ioc->ic_dedup_bsgls);
 		return -DER_NOMEM;
@@ -562,7 +562,7 @@ vos_ioc_reserve_init(struct vos_io_context *ioc, struct dtx_handle *dth)
 		total_acts += iod->iod_nr;
 	}
 
-	D_ALLOC_ARRAY(ioc->ic_umoffs, total_acts);
+	DM_ALLOC_ARRAY(M_VOS, ioc->ic_umoffs, total_acts);
 	if (ioc->ic_umoffs == NULL)
 		return -DER_NOMEM;
 
@@ -571,7 +571,7 @@ vos_ioc_reserve_init(struct vos_io_context *ioc, struct dtx_handle *dth)
 
 	size = sizeof(*ioc->ic_rsrvd_scm) +
 		sizeof(struct pobj_action) * total_acts;
-	D_ALLOC(ioc->ic_rsrvd_scm, size);
+	DM_ALLOC(M_VOS, ioc->ic_rsrvd_scm, size);
 	if (ioc->ic_rsrvd_scm == NULL)
 		return -DER_NOMEM;
 
@@ -581,7 +581,7 @@ vos_ioc_reserve_init(struct vos_io_context *ioc, struct dtx_handle *dth)
 		return 0;
 
 	/** Reserve enough space for any deferred actions */
-	D_ALLOC(scm, size);
+	DM_ALLOC(M_VOS, scm, size);
 	if (scm == NULL) {
 		D_FREE(ioc->ic_rsrvd_scm);
 		return -DER_NOMEM;
@@ -635,7 +635,7 @@ vos_ioc_create(daos_handle_t coh, daos_unit_oid_t oid, bool read_only,
 		goto error;
 	}
 
-	D_ALLOC_PTR(ioc);
+	DM_ALLOC_PTR(M_VOS, ioc);
 	if (ioc == NULL)
 		return -DER_NOMEM;
 
@@ -717,7 +717,7 @@ vos_ioc_create(daos_handle_t coh, daos_unit_oid_t oid, bool read_only,
 
 	ioc->ic_biov_csums_nr = 1;
 	ioc->ic_biov_csums_at = 0;
-	D_ALLOC_ARRAY(ioc->ic_biov_csums, ioc->ic_biov_csums_nr);
+	DM_ALLOC_ARRAY(M_VOS, ioc->ic_biov_csums, ioc->ic_biov_csums_nr);
 	if (ioc->ic_biov_csums == NULL) {
 		rc = -DER_NOMEM;
 		goto error;
@@ -773,7 +773,7 @@ iod_fetch(struct vos_io_context *ioc, struct bio_iov *biov)
 	if (iov_at == iov_nr - 1) {
 		struct bio_iov *biovs;
 
-		D_REALLOC_ARRAY(biovs, bsgl->bs_iovs, iov_nr, iov_nr * 2);
+		DM_REALLOC_ARRAY(M_VOS, biovs, bsgl->bs_iovs, iov_nr, iov_nr * 2);
 		if (biovs == NULL)
 			return -DER_NOMEM;
 
@@ -797,7 +797,7 @@ bsgl_csums_resize(struct vos_io_context *ioc)
 		struct dcs_csum_info *new_infos;
 		uint32_t	 new_nr = dcb_nr * 2;
 
-		D_REALLOC_ARRAY(new_infos, csums, dcb_nr, new_nr);
+		DM_REALLOC_ARRAY(M_CSUM, new_infos, csums, dcb_nr, new_nr);
 		if (new_infos == NULL)
 			return -DER_NOMEM;
 
@@ -935,7 +935,7 @@ save_recx(struct vos_io_context *ioc, uint64_t rx_idx, uint64_t rx_nr,
 	struct daos_recx_ep		 recx_ep;
 
 	if (ioc->ic_recx_lists == NULL) {
-		D_ALLOC_ARRAY(ioc->ic_recx_lists, ioc->ic_iod_nr);
+		DM_ALLOC_ARRAY(M_VOS, ioc->ic_recx_lists, ioc->ic_iod_nr);
 		if (ioc->ic_recx_lists == NULL)
 			return -DER_NOMEM;
 	}
@@ -2252,11 +2252,11 @@ vos_update_end(daos_handle_t ioh, uint32_t pm_ver, daos_key_t *dkey, int err,
 	/* Commit the CoS DTXs via the IO PMDK transaction. */
 	if (dtx_is_valid_handle(dth) && dth->dth_dti_cos_count > 0 &&
 	    !dth->dth_cos_done) {
-		D_ALLOC_ARRAY(daes, dth->dth_dti_cos_count);
+		DM_ALLOC_ARRAY(M_VOS_DTX, daes, dth->dth_dti_cos_count);
 		if (daes == NULL)
 			D_GOTO(abort, err = -DER_NOMEM);
 
-		D_ALLOC_ARRAY(dces, dth->dth_dti_cos_count);
+		DM_ALLOC_ARRAY(M_VOS_DTX, dces, dth->dth_dti_cos_count);
 		if (dces == NULL)
 			D_GOTO(abort, err = -DER_NOMEM);
 

--- a/src/vos/vos_iterator.c
+++ b/src/vos/vos_iterator.c
@@ -819,7 +819,7 @@ vos_iterate_key(struct vos_object *obj, daos_handle_t toh, vos_iter_type_t type,
 	vos_iter_param_t	 param = {0};
 	int			 rc;
 
-	D_ALLOC_PTR(anchors);
+	DM_ALLOC_PTR(M_VOS, anchors);
 	if (anchors == NULL)
 		return -DER_NOMEM;
 

--- a/src/vos/vos_obj.c
+++ b/src/vos/vos_obj.c
@@ -154,7 +154,7 @@ key_punch(struct vos_object *obj, daos_epoch_t epoch, daos_epoch_t bound,
 	int			 i;
 	int			 rc;
 
-	D_ALLOC_PTR(info);
+	DM_ALLOC_PTR(M_VOS, info);
 	if (info == NULL)
 		return -DER_NOMEM;
 
@@ -258,7 +258,7 @@ obj_punch(daos_handle_t coh, struct vos_object *obj, daos_epoch_t epoch,
 	struct vos_ilog_info	*info;
 	int			 rc;
 
-	D_ALLOC_PTR(info);
+	DM_ALLOC_PTR(M_VOS, info);
 	if (info == NULL)
 		return -DER_NOMEM;
 	vos_ilog_fetch_init(info);
@@ -362,11 +362,11 @@ vos_obj_punch(daos_handle_t coh, daos_unit_oid_t oid, daos_epoch_t epoch,
 	/* Commit the CoS DTXs via the PUNCH PMDK transaction. */
 	if (dtx_is_valid_handle(dth) && dth->dth_dti_cos_count > 0 &&
 	    !dth->dth_cos_done) {
-		D_ALLOC_ARRAY(daes, dth->dth_dti_cos_count);
+		DM_ALLOC_ARRAY(M_VOS_DTX, daes, dth->dth_dti_cos_count);
 		if (daes == NULL)
 			D_GOTO(reset, rc = -DER_NOMEM);
 
-		D_ALLOC_ARRAY(dces, dth->dth_dti_cos_count);
+		DM_ALLOC_ARRAY(M_VOS_DTX, dces, dth->dth_dti_cos_count);
 		if (dces == NULL)
 			D_GOTO(reset, rc = -DER_NOMEM);
 
@@ -1386,7 +1386,7 @@ vos_obj_iter_prep(vos_iter_type_t type, vos_iter_param_t *param,
 	daos_epoch_t		 bound;
 	int			 rc;
 
-	D_ALLOC_PTR(oiter);
+	DM_ALLOC_PTR(M_VOS, oiter);
 	if (oiter == NULL)
 		return -DER_NOMEM;
 
@@ -1580,7 +1580,7 @@ vos_obj_iter_nested_prep(vos_iter_type_t type, struct vos_iter_info *info,
 	int			 rc = 0;
 	uint32_t		 options;
 
-	D_ALLOC_PTR(oiter);
+	DM_ALLOC_PTR(M_VOS, oiter);
 	if (oiter == NULL)
 		return -DER_NOMEM;
 

--- a/src/vos/vos_obj_cache.c
+++ b/src/vos/vos_obj_cache.c
@@ -69,7 +69,7 @@ obj_lop_alloc(void *key, unsigned int ksize, void *args,
 	D_DEBUG(DB_TRACE, "cont="DF_UUID", obj="DF_UOID"\n",
 		DP_UUID(cont->vc_id), DP_UOID(lkey->olk_oid));
 
-	D_ALLOC_PTR(obj);
+	DM_ALLOC_PTR(M_OBJ, obj);
 	if (!obj)
 		D_GOTO(failed, rc = -DER_NOMEM);
 

--- a/src/vos/vos_obj_index.c
+++ b/src/vos/vos_obj_index.c
@@ -449,7 +449,7 @@ oi_iter_prep(vos_iter_type_t type, vos_iter_param_t *param,
 	if (cont == NULL)
 		return -DER_INVAL;
 
-	D_ALLOC_PTR(oiter);
+	DM_ALLOC_PTR(M_VOS, oiter);
 	if (oiter == NULL)
 		return -DER_NOMEM;
 

--- a/src/vos/vos_pool.c
+++ b/src/vos/vos_pool.c
@@ -161,7 +161,7 @@ pool_alloc(uuid_t uuid, struct vos_pool **pool_p)
 {
 	struct vos_pool		*pool;
 
-	D_ALLOC_PTR(pool);
+	DM_ALLOC_PTR(M_VOS, pool);
 	if (pool == NULL)
 		return -DER_NOMEM;
 

--- a/src/vos/vos_query.c
+++ b/src/vos/vos_query.c
@@ -485,7 +485,7 @@ vos_obj_query_key(daos_handle_t coh, daos_unit_oid_t oid, uint32_t flags,
 		return -DER_INVAL;
 	}
 
-	D_ALLOC_PTR(query);
+	DM_ALLOC_PTR(M_VOS, query);
 	if (query == NULL)
 		return -DER_NOMEM;
 

--- a/src/vos/vos_ts.c
+++ b/src/vos/vos_ts.c
@@ -118,12 +118,12 @@ vos_ts_table_alloc(struct vos_ts_table **ts_tablep)
 
 	*ts_tablep = NULL;
 
-	D_ALLOC_PTR(ts_table);
+	DM_ALLOC_PTR(M_VOS_TS, ts_table);
 	if (ts_table == NULL)
 		return -DER_NOMEM;
 
-	D_ALLOC_ARRAY(ts_table->tt_misses,
-		      OBJ_MISS_SIZE + DKEY_MISS_SIZE + AKEY_MISS_SIZE);
+	DM_ALLOC_ARRAY(M_VOS_TS, ts_table->tt_misses,
+		       OBJ_MISS_SIZE + DKEY_MISS_SIZE + AKEY_MISS_SIZE);
 	if (ts_table->tt_misses == NULL) {
 		rc = -DER_NOMEM;
 		goto free_table;
@@ -284,7 +284,7 @@ vos_ts_set_allocate(struct vos_ts_set **ts_set, uint64_t flags,
 	size = VOS_TS_TYPE_AKEY + akey_nr;
 	array_size = size * sizeof((*ts_set)->ts_entries[0]);
 
-	D_ALLOC(*ts_set, sizeof(**ts_set) + array_size);
+	DM_ALLOC(M_VOS_TS, *ts_set, sizeof(**ts_set) + array_size);
 	if (*ts_set == NULL)
 		return -DER_NOMEM;
 


### PR DESCRIPTION
Add memory debug mode to DAOS (It can only be enabled by recompiling).
In this mode, DAOS will allocate extra 64 bytes as header to store
the size and allocation tag, then increase the allocated size in TLS counter.
The allocated size will be decreased from the TLS counter on free.

In addition, each allocation can take a "tag" as parameter:
"M_OBJ", "M_EC", "M_IO", "M_IO", "M_RECOV", "M_CART", ....
developer can find out the amount of memory consumed by each tag and
diagnose potential memory leak in DAOS itself.

Signed-off-by: Liang Zhen <liang.zhen@intel.com>