### PR TITLE
DAOS-8927 vos: Lock memory for VOS pools (#7153)

### DIFF
--- a/src/cart/README.env
+++ b/src/cart/README.env
@@ -134,8 +134,8 @@ This file lists the environment variables used in CaRT.
    Specifies the fault injection configuration file. If this variable is not set
    or set to empty, fault injection is disabled.
 
- . CRT_DISABLE_MEM_PIN
-   Disables server-side memory pinning for CART-890 workaround
+ . CRT_ENABLE_MEM_PIN
+   Enables memory pinning for CART-890 workaround
 
  . CRT_MRC_ENABLE
    When not set automatically disables MR caching via FI_MR_CACHE_MAX_COUNT=0

--- a/src/cart/crt_init.c
+++ b/src/cart/crt_init.c
@@ -109,7 +109,7 @@ static int data_init(int server, crt_init_options_t *opt)
 	uint32_t	timeout;
 	uint32_t	credits;
 	uint32_t	fi_univ_size = 0;
-	uint32_t	mem_pin_disable = 0;
+	uint32_t	mem_pin_enable = 0;
 	uint32_t	mrc_enable = 0;
 	uint64_t	start_rpcid;
 	int		rc = 0;
@@ -143,8 +143,8 @@ static int data_init(int server, crt_init_options_t *opt)
 
 	/* Apply CART-890 workaround for server side only */
 	if (server) {
-		d_getenv_int("CRT_DISABLE_MEM_PIN", &mem_pin_disable);
-		if (mem_pin_disable == 0)
+		d_getenv_int("CRT_ENABLE_MEM_PIN", &mem_pin_enable);
+		if (mem_pin_enable == 1)
 			mem_pin_workaround();
 	}
 

--- a/src/include/gurt/common.h
+++ b/src/include/gurt/common.h
@@ -446,7 +446,7 @@ void d_free_string(struct d_string_buffer_t *buf);
 # define offsetof(typ, memb)	((long)((char *)&(((typ *)0)->memb)))
 #endif
 
-#define D_ALIGNUP(x, a) (((x) + (a - 1)) & ~(a - 1))
+#define D_ALIGNUP(x, a) (((x) + ((a) - 1)) & ~((a) - 1))
 
 #ifndef ARRAY_SIZE
 #define ARRAY_SIZE(arr) (sizeof(arr) / sizeof((arr)[0]))

--- a/src/mgmt/srv_target.c
+++ b/src/mgmt/srv_target.c
@@ -504,6 +504,8 @@ tgt_vos_preallocate(uuid_t uuid, daos_size_t scm_size, int tgt_nr)
 			break;
 		}
 
+		/** Align to 4K or locking the region based on the size will fail */
+		scm_size = D_ALIGNUP(scm_size, 1ULL << 12);
 		/**
 		 * Pre-allocate blocks for vos files in order to provide
 		 * consistent performance and avoid entering into the backend

--- a/src/vos/vos_internal.h
+++ b/src/vos/vos_internal.h
@@ -145,6 +145,8 @@ struct vos_pool {
 	struct umem_attr	vp_uma;
 	/** memory class instance of the pool */
 	struct umem_instance	vp_umm;
+	/** Size of pool file */
+	uint64_t		vp_size;
 	/** btr handle for the container table */
 	daos_handle_t		vp_cont_th;
 	/** GC statistics of this pool */

--- a/src/vos/vos_pool.c
+++ b/src/vos/vos_pool.c
@@ -20,6 +20,8 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <sys/mman.h>
+#include <sys/time.h>
+#include <sys/resource.h>
 #include <vos_layout.h>
 #include <vos_internal.h>
 #include <errno.h>
@@ -140,6 +142,15 @@ pool_hop_free(struct d_ulink *hlink)
 	if (daos_handle_is_valid(pool->vp_cont_th))
 		dbtree_close(pool->vp_cont_th);
 
+	if (pool->vp_size != 0) {
+		rc = munlock((void *)pool->vp_umm.umm_base, pool->vp_size);
+		if (rc != 0)
+			D_WARN("Failed to unlock pool memory at "DF_X64": errno=%d (%s)\n",
+			       pool->vp_umm.umm_base, errno, strerror(errno));
+		else
+			D_DEBUG(DB_MGMT, "Unlocked VOS pool memory: "DF_U64" bytes at "DF_X64"\n",
+				pool->vp_size, pool->vp_umm.umm_base);
+	}
 	if (pool->vp_uma.uma_pool)
 		vos_pmemobj_close(pool->vp_uma.uma_pool);
 
@@ -619,6 +630,55 @@ vos_register_slabs(struct umem_attr *uma)
 	return 0;
 }
 
+enum {
+	/** Memory locking flag not initialized */
+	LM_FLAG_UNINIT,
+	/** Memory locking disabled */
+	LM_FLAG_DISABLED,
+	/** Memory locking enabled */
+	LM_FLAG_ENABLED
+};
+
+static void
+lock_pool_memory(struct vos_pool *pool)
+{
+	static		 int lock_mem = LM_FLAG_UNINIT;
+	struct rlimit	 rlim;
+	int		 rc;
+
+	if (lock_mem == LM_FLAG_UNINIT) {
+		rc = getrlimit(RLIMIT_MEMLOCK, &rlim);
+		if (rc != 0) {
+			D_WARN("getrlimit() failed; errno=%d (%s)\n", errno, strerror(errno));
+			lock_mem = LM_FLAG_DISABLED;
+			return;
+		}
+
+		if (rlim.rlim_cur != RLIM_INFINITY || rlim.rlim_max != RLIM_INFINITY) {
+			D_WARN("Infinite rlimit not detected, not locking VOS pool memory\n");
+			lock_mem = LM_FLAG_DISABLED;
+			return;
+		}
+
+		lock_mem = LM_FLAG_ENABLED;
+	}
+
+	if (lock_mem == LM_FLAG_DISABLED)
+		return;
+
+	rc = mlock((void *)pool->vp_umm.umm_base, pool->vp_pool_df->pd_scm_sz);
+	if (rc != 0) {
+		D_WARN("Could not lock memory for VOS pool at "DF_X64"; errno=%d (%s)\n",
+		       pool->vp_umm.umm_base, errno, strerror(errno));
+		return;
+	}
+
+	/* Only save the size if the locking was successful */
+	pool->vp_size = pool->vp_pool_df->pd_scm_sz;
+	D_DEBUG(DB_MGMT, "Locking VOS pool in memory "DF_U64" bytes at "DF_X64"\n", pool->vp_size,
+		pool->vp_umm.umm_base);
+}
+
 /*
  * If successful, this function consumes ph, and closes it upon any error.
  * So the caller shall not close ph in any case.
@@ -714,6 +774,7 @@ pool_open(PMEMobjpool *ph, struct vos_pool_df *pool_df, uuid_t uuid,
 	vos_space_sys_init(pool);
 	/* Ensure GC is triggered after server restart */
 	gc_add_pool(pool);
+	lock_pool_memory(pool);
 	D_DEBUG(DB_MGMT, "Opened pool %p\n", pool);
 	return 0;
 failed:

--- a/src/vos/vos_pool.c
+++ b/src/vos/vos_pool.c
@@ -668,8 +668,9 @@ lock_pool_memory(struct vos_pool *pool)
 
 	rc = mlock((void *)pool->vp_umm.umm_base, pool->vp_pool_df->pd_scm_sz);
 	if (rc != 0) {
-		D_WARN("Could not lock memory for VOS pool at "DF_X64"; errno=%d (%s)\n",
-		       pool->vp_umm.umm_base, errno, strerror(errno));
+		D_WARN("Could not lock memory for VOS pool "DF_U64" bytes at "DF_X64
+		       "; errno=%d (%s)\n", pool->vp_pool_df->pd_scm_sz, pool->vp_umm.umm_base,
+		       errno, strerror(errno));
 		return;
 	}
 


### PR DESCRIPTION
Change CART envirable to turn on memory pinning globally
with it off by default.   Instead, lock each vos pool individually.

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>

