### PR TITLE
DAOS-8984 test: Add a timeout to the RPMs test

### DIFF
--- a/ci/rpm/test_daos_node.sh
+++ b/ci/rpm/test_daos_node.sh
@@ -95,7 +95,6 @@ if ! module load $OPENMPI; then
     module list
     exit 1
 fi
-server_start=$SECONDS
 coproc daos_server --debug start -t 1 --recreate-superblocks 2>&1
 trap 'set -x; kill -INT $COPROC_PID' EXIT
 line=""


### PR DESCRIPTION
Ensure that if daos_test -m hangs, the test does not hang indefinitely.

Try to get daos_server output if daos_test -m hangs or otherwise exits
!0.