### PR TITLE
DAOS-8904-test_rel_2.0: Fix and enable object/create_many_dkeys.py

### DIFF
--- a/src/tests/ftest/object/create_many_dkeys.py
+++ b/src/tests/ftest/object/create_many_dkeys.py
@@ -63,14 +63,14 @@ class CreateManyDkeys(TestWithServers):
             val = ioreq.single_fetch(c_dkey,
                                      c_akey,
                                      len(the_data)+1)
-
-            if the_data != (repr(val.value)[1:-1]):
+            exp_value = val.value.decode("utf-8")
+            if the_data != exp_value:
                 self.fail("ERROR: Data mismatch for dkey = {0}, akey={1}, "
                           "Expected Value={2} and Received Value={3}\n"
                           .format("dkey {0}".format(key),
                                   "akey {0}".format(key),
                                   the_data,
-                                  repr(val.value)[1:-1]))
+                                  exp_value))
 
             if key > last_key:
                 print("veried: {}".format(key))
@@ -89,8 +89,11 @@ class CreateManyDkeys(TestWithServers):
         Test Description: Test many of dkeys in same object.
         Use Cases: 1. large key counts
                    2. space reclamation after destroy
-        :avocado: tags=all,full,small,object,many_dkeys
 
+        :avocado: tags=all,full_regression
+        :avocado: tags=small
+        :avocado: tags=object
+        :avocado: tags=many_dkeys
         """
         self.prepare_pool()
         no_of_dkeys = self.params.get("number_of_dkeys", '/run/dkeys/')

--- a/src/tests/ftest/object/create_many_dkeys.yaml
+++ b/src/tests/ftest/object/create_many_dkeys.yaml
@@ -4,13 +4,13 @@ hosts:
   test_servers:
     - server-A
     - server-B
-timeout: 8000
+timeout: 3000
 server_config:
   name: daos_server
 pool:
   mode: 511
   name: daos_server
-  scm_size: 2000000000
+  scm_size: 8000000000
   control_method: dmg
 dkeys:
   number_of_dkeys: 1000000

--- a/src/tests/ftest/object/create_many_dkeys.yaml
+++ b/src/tests/ftest/object/create_many_dkeys.yaml
@@ -10,7 +10,7 @@ server_config:
 pool:
   mode: 511
   name: daos_server
-  scm_size: 8G
+  scm_size: 8000000000
   control_method: dmg
 dkeys:
   number_of_dkeys: 1000000

--- a/src/tests/ftest/object/create_many_dkeys.yaml
+++ b/src/tests/ftest/object/create_many_dkeys.yaml
@@ -10,7 +10,7 @@ server_config:
 pool:
   mode: 511
   name: daos_server
-  scm_size: 8000000000
+  scm_size: 8G
   control_method: dmg
 dkeys:
   number_of_dkeys: 1000000


### PR DESCRIPTION
Description: Cherrypick for release_2.0, fix script failure due to output of unicode and
             -1007 not enough space with 10k dkeys.
modified: create_many_dkeys.py
modified: create_many_dkeys.yaml
Test-tag: many_dkeys
Signed-off-by: Ding Ho ding-hwa.ho@intel.com