### PR TITLE
DAOS-7878 vos: Implement punch propagation optimization

### DIFF
--- a/src/vos/tests/vts_mvcc.c
+++ b/src/vos/tests/vts_mvcc.c
@@ -1093,17 +1093,6 @@ struct conflicting_rw_excluded_case {
 };
 
 static struct conflicting_rw_excluded_case conflicting_rw_excluded_cases[] = {
-	/** Used to disable specific tests as necessary */
-	/** These specific tests can be enabled when DAOS-4698 is fixed
-	 *  and the line in vos_obj.c that references this ticket is
-	 *  uncommented.
-	 */
-	{false,	"punchd_dne",	"cod",	"puncho_one",	"co",	0, false},
-	{false,	"punchd_dne",	"cod",	"puncho_one",	"co",	1, false},
-	{false,	"puncha_ane",	"coda",	"puncho_one",	"co",	0, false},
-	{false,	"puncha_ane",	"coda",	"puncho_one",	"co",	1, false},
-	{false, "puncha_ane",   "coda", "puncho_one",   "co",   0, true},
-	{false, "punchd_dne",   "cod",  "puncho_one",   "co",   0, true},
 };
 
 static int64_t

--- a/src/vos/vos_tree.c
+++ b/src/vos/vos_tree.c
@@ -1113,13 +1113,14 @@ key_tree_punch(struct vos_object *obj, daos_handle_t toh, daos_epoch_t epoch,
 {
 	struct vos_rec_bundle	*rbund = iov2rec_bundle(val_iov);
 	struct vos_krec_df	*krec;
+	d_iov_t			 kiov = {0};
 	struct ilog_df		*ilog = NULL;
 	daos_epoch_range_t	 epr = {0, epoch};
 	bool			 mark = false;
 	int			 rc;
 	int			 lrc;
 
-	rc = dbtree_fetch(toh, BTR_PROBE_EQ, DAOS_INTENT_UPDATE, key_iov, NULL,
+	rc = dbtree_fetch(toh, BTR_PROBE_EQ, DAOS_INTENT_UPDATE, key_iov, &kiov,
 			  val_iov);
 
 	if (rc == 0 || rc == -DER_NONEXIST) {
@@ -1177,11 +1178,9 @@ key_tree_punch(struct vos_object *obj, daos_handle_t toh, daos_epoch_t epoch,
 	if (rc != 0)
 		goto done;
 
-	if (*known_key != UMOFF_NULL) {
-		/** For forward compatibility, just reset the known key if it's set since
-		 *  this version doesn't use it.
-		 */
-		rc = umem_tx_add_ptr(vos_obj2umm(obj), &known_key, sizeof(*known_key));
+	if (*known_key == umem_ptr2off(vos_obj2umm(obj), kiov.iov_buf)) {
+		/** Set the value to UMOFF_NULL so punch propagation will run full check */
+		rc = umem_tx_add_ptr(vos_obj2umm(obj), known_key, sizeof(*known_key));
 		if (rc)
 			D_GOTO(done, rc);
 		*known_key = UMOFF_NULL;


### PR DESCRIPTION
Enable punch propagation to object level and associated mvcc tests
Enable propagation optimization that saves the umem offset of the last
key known to exist so we can skip iterating if the key hasn't been punched.
This has potentially make punch propagation significantly cheaper so
it can be enabled a the object level, potentially making the object
emptiness check faster too.

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>