### PR TITLE
DAOS-7878 vos: Address punch propagation performance

### DIFF
--- a/src/include/daos/btree.h
+++ b/src/include/daos/btree.h
@@ -553,6 +553,7 @@ enum {
 	BTR_ITER_EMBEDDED	= (1 << 0),
 };
 
+int dbtree_key2anchor(daos_handle_t toh, d_iov_t *key, daos_anchor_t *anchor);
 int dbtree_iter_prepare(daos_handle_t toh, unsigned int options,
 			daos_handle_t *ih);
 int dbtree_iter_finish(daos_handle_t ih);

--- a/src/include/daos_srv/vos_types.h
+++ b/src/include/daos_srv/vos_types.h
@@ -328,8 +328,10 @@ enum {
 	VOS_IT_CLEANUP_DTX	= (1 << 7),
 	/** Cleanup stale DTX entry. */
 	VOS_IT_FOR_DISCARD	= (1 << 8),
+	/** Entry is not committed */
+	VOS_IT_UNCOMMITTED	= (1 << 9),
 	/** Mask for all flags */
-	VOS_IT_MASK		= (1 << 9) - 1,
+	VOS_IT_MASK		= (1 << 10) - 1,
 };
 
 /**

--- a/src/vos/tests/vts_mvcc.c
+++ b/src/vos/tests/vts_mvcc.c
@@ -1093,17 +1093,6 @@ struct conflicting_rw_excluded_case {
 };
 
 static struct conflicting_rw_excluded_case conflicting_rw_excluded_cases[] = {
-	/** Used to disable specific tests as necessary */
-	/** These specific tests can be enabled when DAOS-4698 is fixed
-	 *  and the line in vos_obj.c that references this ticket is
-	 *  uncommented.
-	 */
-	{false,	"punchd_dne",	"cod",	"puncho_one",	"co",	0, false},
-	{false,	"punchd_dne",	"cod",	"puncho_one",	"co",	1, false},
-	{false,	"puncha_ane",	"coda",	"puncho_one",	"co",	0, false},
-	{false,	"puncha_ane",	"coda",	"puncho_one",	"co",	1, false},
-	{false, "puncha_ane",   "coda", "puncho_one",   "co",   0, true},
-	{false, "punchd_dne",   "cod",  "puncho_one",   "co",   0, true},
 };
 
 static int64_t

--- a/src/vos/vos_internal.h
+++ b/src/vos/vos_internal.h
@@ -809,6 +809,7 @@ struct vos_iterator {
 				 it_for_discard:1,
 				 it_for_migration:1,
 				 it_cleanup_stale_dtx:1,
+				 it_show_uncommitted:1,
 				 it_ignore_uncommitted:1;
 };
 
@@ -1002,7 +1003,7 @@ key_tree_release(daos_handle_t toh, bool is_array);
 int
 key_tree_punch(struct vos_object *obj, daos_handle_t toh, daos_epoch_t epoch,
 	       daos_epoch_t bound, d_iov_t *key_iov, d_iov_t *val_iov,
-	       uint64_t flags, struct vos_ts_set *ts_set,
+	       uint64_t flags, struct vos_ts_set *ts_set, umem_off_t *known_key,
 	       struct vos_ilog_info *parent, struct vos_ilog_info *info);
 int
 key_tree_delete(struct vos_object *obj, daos_handle_t toh, d_iov_t *key_iov);
@@ -1138,15 +1139,16 @@ D_CASSERT((VOS_IT_KEY_TREE & VOS_IT_MASK) == 0);
  *  \param toh[IN]			Open key tree handle
  *  \param type[IN]			Iterator type (VOS_ITER_AKEY/DKEY only)
  *  \param epr[IN]			Valid epoch range for iteration
- *  \param ignore_inprogress[IN]	Fail if there are uncommitted entries
+ *  \param show_uncommitted[IN]		Return uncommitted entries marked as instead of failing
  *  \param cb[IN]			Callback for key
  *  \param arg[IN]			argument to pass to callback
  *  \param dth[IN]			dtx handle
+ *  \param anchor[IN]			Option anchor from where to start iterator
  */
 int
 vos_iterate_key(struct vos_object *obj, daos_handle_t toh, vos_iter_type_t type,
-		const daos_epoch_range_t *epr, bool ignore_inprogress,
-		vos_iter_cb_t cb, void *arg, struct dtx_handle *dth);
+		const daos_epoch_range_t *epr, bool show_uncommitted,
+		vos_iter_cb_t cb, void *arg, struct dtx_handle *dth, daos_anchor_t *anchor);
 
 /** Start epoch of vos */
 extern daos_epoch_t	vos_start_epoch;

--- a/src/vos/vos_layout.h
+++ b/src/vos/vos_layout.h
@@ -88,7 +88,7 @@ enum vos_gc_type {
 #define POOL_DF_MAGIC				0x5ca1ab1e
 
 /** Lowest supported durable format version */
-#define POOL_DF_VER_1				21
+#define POOL_DF_VER_1				22
 /** Current durable format version */
 #define POOL_DF_VERSION				POOL_DF_VER_1
 
@@ -295,8 +295,12 @@ struct vos_krec_df {
 	/** Incarnation log for key */
 	struct ilog_df			kr_ilog;
 	union {
-		/** btree root under the key */
-		struct btr_root			kr_btr;
+		struct {
+			/** btree root under the key */
+			struct btr_root			kr_btr;
+			/** Offset of known existing akey */
+			umem_off_t			kr_known_akey;
+		};
 		/** evtree root, which is only used by akey */
 		struct evt_root			kr_evt;
 	};
@@ -343,8 +347,10 @@ struct vos_obj_df {
 	daos_unit_oid_t			vo_id;
 	/** The latest sync epoch */
 	daos_epoch_t			vo_sync;
-	/** Attributes of object.  See vos_oi_attr */
-	uint64_t			vo_oi_attr;
+	/** Offset of known existing dkey */
+	umem_off_t			vo_known_dkey;
+	/** Attributes for future use */
+	uint64_t			vo_attr;
 	/** Incarnation log for the object */
 	struct ilog_df			vo_ilog;
 	/** VOS dkey btree root */

--- a/src/vos/vos_obj.c
+++ b/src/vos/vos_obj.c
@@ -24,55 +24,114 @@ D_CASSERT((uint32_t)VOS_VIS_FLAG_VISIBLE == (uint32_t)EVT_VISIBLE);
 D_CASSERT((uint32_t)VOS_VIS_FLAG_PARTIAL == (uint32_t)EVT_PARTIAL);
 D_CASSERT((uint32_t)VOS_VIS_FLAG_LAST == (uint32_t)EVT_LAST);
 
+struct vos_key_info {
+	umem_off_t		*ki_known_key;
+	struct vos_object	*ki_obj;
+	bool			 ki_non_empty;
+	bool			 ki_has_uncommitted;
+	const void		*ki_first;
+	daos_handle_t		 ki_toh;
+};
+
 /** This callback is invoked only if the tree is not empty */
 static int
 empty_tree_check(daos_handle_t ih, vos_iter_entry_t *entry,
 		 vos_iter_type_t type, vos_iter_param_t *param, void *cb_arg,
 		 unsigned int *acts)
 {
-	bool	*empty = cb_arg;
+	struct vos_rec_bundle	 rbund = {0};
+	d_iov_t			 val_iov;
+	struct umem_instance	*umm;
+	struct vos_key_info	*kinfo = cb_arg;
+	int			 rc;
 
-	*empty = false;
+	if (kinfo->ki_first == entry->ie_key.iov_buf)
+		return 1; /** We've seen this one before */
+
+	/** Save the first thing we see so we can stop iteration early
+	 *  if we see it again on 2nd pass.
+	 */
+	if (kinfo->ki_first == NULL)
+		kinfo->ki_first = entry->ie_key.iov_buf;
+
+	if (entry->ie_vis_flags == VOS_IT_UNCOMMITTED) {
+		kinfo->ki_has_uncommitted = true;
+		return 0;
+	}
+
+	d_iov_set(&val_iov, &rbund, sizeof(rbund));
+	rc = dbtree_fetch(kinfo->ki_toh, BTR_PROBE_EQ, DAOS_INTENT_UPDATE, &entry->ie_key, NULL,
+			  &val_iov);
+	if (rc != 0)
+		return rc;
+
+	kinfo->ki_non_empty = true;
+	umm = vos_obj2umm(kinfo->ki_obj);
+	rc = umem_tx_add_ptr(umm, kinfo->ki_known_key, sizeof(*(kinfo->ki_known_key)));
+	if (rc != 0)
+		return rc;
+
+	*(kinfo->ki_known_key) = umem_ptr2off(umm, rbund.rb_krec);
 
 	return 1; /* Return positive number to break iteration */
 }
 
 static int
-tree_is_empty(struct vos_object *obj, daos_handle_t toh,
+tree_is_empty(struct vos_object *obj, umem_off_t *known_key, daos_handle_t toh,
 	      const daos_epoch_range_t *epr, vos_iter_type_t type)
 {
+	daos_anchor_t		 anchor = {0};
 	struct dtx_handle	*dth = vos_dth_get();
-	bool			 empty = true;
+	d_iov_t			 key;
+	struct vos_key_info	 kinfo = {0};
+	struct vos_krec_df	*krec;
 	int			 rc;
 
-	/** First ignore any uncommitted entries because they only matter
-	 *  when there are no committed entries
-	 */
-	rc = vos_iterate_key(obj, toh, type, epr, true, empty_tree_check,
-			     &empty, dth);
-
-	if (rc < 0)
-		return rc;
-
-	if (!empty)
+	if (*known_key != UMOFF_NULL && (*known_key & 0x1) == 0)
 		return 0;
 
-	/** Ok, there are no committed entries.  We need to run the iterator
-	 *  on more time to ensure there are no uncommitted entries.  If there
-	 *  are, this will return -DER_INPROGRESS.
-	 */
-	rc = vos_iterate_key(obj, toh, type, epr, false, empty_tree_check,
-			     &empty, dth);
+	kinfo.ki_toh = toh;
+	kinfo.ki_obj = obj;
+	kinfo.ki_known_key = known_key;
+
+	if (*known_key == UMOFF_NULL)
+		goto tail;
+
+	krec = umem_off2ptr(vos_obj2umm(obj), (*known_key & ~(1ULL)));
+	d_iov_set(&key, vos_krec2key(krec), krec->kr_size);
+	dbtree_key2anchor(toh, &key, &anchor);
+
+	rc = vos_iterate_key(obj, toh, type, epr, true, empty_tree_check,
+			     &kinfo, dth, &anchor);
 
 	if (rc < 0)
 		return rc;
+
+	if (kinfo.ki_non_empty)
+		return 0;
+
+	/** Start from beginning one more time.  It will iterate until it
+	 *  sees the first thing it saw
+	 */
+tail:
+	rc = vos_iterate_key(obj, toh, type, epr, true, empty_tree_check,
+			     &kinfo, dth, NULL);
+
+	if (rc < 0)
+		return rc;
+
+	if (kinfo.ki_non_empty)
+		return 0;
+
+	if (kinfo.ki_has_uncommitted)
+		return -DER_INPROGRESS;
 
 	/** The tree is empty */
 	return 1;
 }
 
 static int
-vos_propagate_check(struct vos_object *obj, daos_handle_t toh,
+vos_propagate_check(struct vos_object *obj, umem_off_t *known_key, daos_handle_t toh,
 		    struct vos_ts_set *ts_set, const daos_epoch_range_t *epr,
 		    vos_iter_type_t type)
 {
@@ -93,10 +152,7 @@ vos_propagate_check(struct vos_object *obj, daos_handle_t toh,
 		read_flag = VOS_TS_READ_OBJ;
 		write_flag = VOS_TS_WRITE_OBJ;
 		tree_name = "DKEY";
-		/** DAOS-4698.  Don't do emptiness check on dkey or propagate
-		 *  to object until this rebuild bug is fixed.
-		 */
-		return 0;
+		break;
 	case VOS_ITER_AKEY:
 		read_flag = VOS_TS_READ_DKEY;
 		write_flag = VOS_TS_WRITE_DKEY;
@@ -111,7 +167,7 @@ vos_propagate_check(struct vos_object *obj, daos_handle_t toh,
 	 */
 	vos_ts_set_append_cflags(ts_set, read_flag);
 
-	rc = tree_is_empty(obj, toh, epr, type);
+	rc = tree_is_empty(obj, known_key, toh, epr, type);
 	if (rc > 0) {
 		/** tree is now empty, set the flags so we can punch
 		 *  the parent
@@ -203,7 +259,7 @@ key_punch(struct vos_object *obj, daos_epoch_t epoch, daos_epoch_t bound,
 	for (i = 0; i < akey_nr; i++) {
 		rbund.rb_iov = &akeys[i];
 		rc = key_tree_punch(obj, toh, epoch, bound, &akeys[i], &riov,
-				    flags, ts_set, &info->ki_dkey,
+				    flags, ts_set, &krec->kr_known_akey, &info->ki_dkey,
 				    &info->ki_akey);
 		if (rc != 0) {
 			VOS_TX_LOG_FAIL(rc, "Failed to punch akey: rc="
@@ -214,7 +270,7 @@ key_punch(struct vos_object *obj, daos_epoch_t epoch, daos_epoch_t bound,
 
 	if (rc == 0 && (flags & VOS_OF_REPLAY_PC) == 0) {
 		/** Check if we need to propagate the punch */
-		rc = vos_propagate_check(obj, toh, ts_set, &epr,
+		rc = vos_propagate_check(obj, &krec->kr_known_akey, toh, ts_set, &epr,
 					 VOS_ITER_AKEY);
 	}
 
@@ -227,13 +283,14 @@ punch_dkey:
 	rbund.rb_tclass	= VOS_BTR_DKEY;
 
 	rc = key_tree_punch(obj, obj->obj_toh, epoch, bound, dkey, &riov,
-			    flags, ts_set, &info->ki_obj, &info->ki_dkey);
+			    flags, ts_set, &obj->obj_df->vo_known_dkey, &info->ki_obj,
+			    &info->ki_dkey);
 	if (rc != 0)
 		D_GOTO(out, rc);
 
 	if (rc == 0 && (flags & VOS_OF_REPLAY_PC) == 0) {
 		/** Check if we need to propagate to object */
-		rc = vos_propagate_check(obj, obj->obj_toh, ts_set,
+		rc = vos_propagate_check(obj, &obj->obj_df->vo_known_dkey, obj->obj_toh, ts_set,
 					 &epr, VOS_ITER_DKEY);
 	}
  out:
@@ -679,17 +736,22 @@ key_iter_fetch(struct vos_obj_iter *oiter, vos_iter_entry_t *ent,
 				 check_existence, NULL);
 	if (rc == -DER_NONEXIST)
 		return IT_OPC_NEXT;
-	if (rc != 0)
-		return rc;
+	if (rc != 0) {
+		if (!oiter->it_iter.it_show_uncommitted || rc != -DER_INPROGRESS)
+			return rc;
+		/** Mark the entry as uncommitted but return it to the iterator */
+		ent->ie_vis_flags = VOS_IT_UNCOMMITTED;
+	} else {
+		ent->ie_vis_flags = VOS_VIS_FLAG_VISIBLE;
+		if (oiter->it_ilog_info.ii_create == 0) {
+			/* The key has no visible subtrees so mark it covered */
+			ent->ie_vis_flags = VOS_VIS_FLAG_COVERED;
+		}
+	}
 
 	ent->ie_epoch = epr.epr_hi;
 	ent->ie_punch = oiter->it_ilog_info.ii_next_punch;
 	ent->ie_obj_punch = oiter->it_obj->obj_ilog_info.ii_next_punch;
-	ent->ie_vis_flags = VOS_VIS_FLAG_VISIBLE;
-	if (oiter->it_ilog_info.ii_create == 0) {
-		/* The key has no visible subtrees so mark it covered */
-		ent->ie_vis_flags = VOS_VIS_FLAG_COVERED;
-	}
 	vos_ilog_last_update(&krec->kr_ilog, ts_type, &ent->ie_last_update);
 
 	return 0;

--- a/src/vos/vos_tree.c
+++ b/src/vos/vos_tree.c
@@ -1109,7 +1109,7 @@ key_tree_release(daos_handle_t toh, bool is_array)
 int
 key_tree_punch(struct vos_object *obj, daos_handle_t toh, daos_epoch_t epoch,
 	       daos_epoch_t bound, d_iov_t *key_iov, d_iov_t *val_iov,
-	       uint64_t flags, struct vos_ts_set *ts_set,
+	       uint64_t flags, struct vos_ts_set *ts_set, umem_off_t *known_key,
 	       struct vos_ilog_info *parent, struct vos_ilog_info *info)
 {
 	struct vos_rec_bundle	*rbund = iov2rec_bundle(val_iov);
@@ -1175,6 +1175,16 @@ key_tree_punch(struct vos_object *obj, daos_handle_t toh, daos_epoch_t epoch,
 			    info, ts_set, true,
 			    (flags & VOS_OF_REPLAY_PC) != 0);
 
+	if (rc != 0)
+		goto done;
+
+	if (*known_key == umem_ptr2off(vos_obj2umm(obj), krec)) {
+		/** Set the value to UMOFF_NULL so punch propagation will run full check */
+		rc = umem_tx_add_ptr(vos_obj2umm(obj), known_key, sizeof(*known_key));
+		if (rc)
+			D_GOTO(done, rc);
+		*known_key |= 0x1;
+	}
 done:
 	VOS_TX_LOG_FAIL(rc, "Failed to punch key: "DF_RC"\n", DP_RC(rc));
 


### PR DESCRIPTION
DO NOT LAND...this is not a cherry-pick from reviewed master branch patch

* Rather than potentially iterating all keys twice during punch
propagation, iterate once and track whether we've seen
entries or uncommitted data.
* Use existing, unused space in the object and dkey durable format
to save offset of last key known to exist so we can skip scan.  This can
significantly speed up punch propagation in the common case by limiting
full scan to the occasional instance where the saved key is punched.
for punch propagation if the key hasn't been punched.
* Enable punch propagation to object level and associated mvcc tests

In vos_perf tests, I got the following results for punch of 100K dkeys
With this patch:                                0.7 seconds
with master branch:                             0.6 seconds
master branch with propagation to object level: 118 seconds

Seems like a good tradeoff.  It should improve delete performance of
directories containing many objects as in the ticket.

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>