### PR TITLE
DAOS-8685 pool: run create tests with logging, CentOS 8 HW

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,7 +12,7 @@
 
 // To use a test branch (i.e. PR) until it lands to master
 // I.e. for testing library changes
-//@Library(value="pipeline-lib@your_branch") _
+@Library(value="pipeline-lib@bmurrell/run-prs-on-el8-hw") _
 
 // For master, this is just some wildly high number
 next_version = "1000"
@@ -1054,7 +1054,7 @@ pipeline {
                     }
                     steps {
                         functionalTest inst_repos: daosRepos(),
-                                       inst_rpms: functionalPackages(1, next_version),
+                                       inst_rpms: functionalPackages("centos8", 1, next_version),
                                        test_function: 'runTestFunctionalV2'
                     }
                     post {
@@ -1075,7 +1075,7 @@ pipeline {
                     steps {
                         functionalTest target: hwDistroTarget(),
                                        inst_repos: daosRepos(),
-                                       inst_rpms: functionalPackages(1, next_version),
+                                       inst_rpms: functionalPackages("centos8", 1, next_version),
                                        test_function: 'runTestFunctionalV2'
                    }
                     post {
@@ -1096,7 +1096,7 @@ pipeline {
                     steps {
                         functionalTest target: hwDistroTarget(),
                                        inst_repos: daosRepos(),
-                                       inst_rpms: functionalPackages(1, next_version),
+                                       inst_rpms: functionalPackages("centos8", 1, next_version),
                                        test_function: 'runTestFunctionalV2'
                     }
                     post {

--- a/ci/functional/required_packages.sh
+++ b/ci/functional/required_packages.sh
@@ -32,7 +32,10 @@ elif [[ $distro = el* ]] || [[ $distro = centos* ]] ||
           hdf5-vol-daos-mpich-tests    \
           MACSio-mpich                 \
           MACSio-$openmpi              \
-          mpifileutils-mpich"
+          mpifileutils-mpich           \
+          numactl                      \
+          sysstat                      \
+          hwloc"
 else
     echo "I don't know which packages should be installed for distro"
          "\"$distro\""

--- a/ci/provisioning/post_provision_config_common.sh
+++ b/ci/provisioning/post_provision_config_common.sh
@@ -55,7 +55,7 @@ retry_cmd() {
         fi
         # Command failed, retry
         rc=${PIPESTATUS[0]}
-        (( attempt++ ))
+        (( attempt++ )) || true
         if [ "$attempt" -gt 0 ]; then
             sleep "${RETRY_DELAY_SECONDS:-$DAOS_STACK_RETRY_DELAY_SECONDS}"
         fi
@@ -84,7 +84,7 @@ timeout_cmd() {
         rc=${PIPESTATUS[0]}
         if [ "$rc" = "124" ]; then
             # Command timed out, try again
-            (( attempt++ ))
+            (( attempt++ )) || true
             continue
         fi
         # Command failed for something other than timeout

--- a/ci/provisioning/post_provision_config_nodes_EL_7.sh
+++ b/ci/provisioning/post_provision_config_nodes_EL_7.sh
@@ -46,6 +46,7 @@ EOF
 
     # Mellanox OFED hack
     if ls -d /usr/mpi/gcc/openmpi-*; then
+        mkdir -p /etc/modulefiles/mpi/
         cat <<EOF > /etc/modulefiles/mpi/mlnx_openmpi-x86_64
 #%Module 1.0
 #

--- a/ci/provisioning/post_provision_config_nodes_EL_8.sh
+++ b/ci/provisioning/post_provision_config_nodes_EL_8.sh
@@ -6,7 +6,7 @@ LSB_RELEASE=redhat-lsb-core
 EXCLUDE_UPGRADE=dpdk,fuse,mercury,daos,daos-\*
 
 bootstrap_dnf() {
-    :
+    dnf -y erase openmpi opensm-libs
 }
 
 group_repo_post() {
@@ -15,22 +15,9 @@ group_repo_post() {
 }
 
 distro_custom() {
-    # force install of avocado 69.x
-    dnf -y erase avocado{,-common}                                              \
-                 python2-avocado{,-plugins-{output-html,varianter-yaml-to-mux}} \
-                 python3-pyyaml
-    pip3 install "avocado-framework<70.0"
-    pip3 install "avocado-framework-plugin-result-html<70.0"
-    pip3 install "avocado-framework-plugin-varianter-yaml-to-mux<70.0"
-    pip3 install clustershell
-
-    if ! rpm -q nfs-utils; then
-        retry_cmd 360 dnf -y install nfs-utils
-    fi
-
-    # CORCI-1096
-    dnf -y install esmtp
-    sed -e 's/^\(hostname *= *\)[^ ].*$/\1 mail.wolf.hpdd.intel.com:25/' < /usr/share/doc/esmtp/sample.esmtprc > /etc/esmtprc
+    # install avocado
+    dnf -y install python3-avocado{,-plugins-{output-html,varianter-yaml-to-mux}} \
+                   clustershell
 
     dnf config-manager --disable powertools
 
@@ -94,10 +81,13 @@ post_provision_config_nodes() {
     retry_cmd 360 dnf -y install $LSB_RELEASE
 
     # shellcheck disable=SC2086
-    if [ -n "$INST_RPMS" ] && ! retry_cmd 360 dnf -y install $INST_RPMS; then
-        rc=${PIPESTATUS[0]}
-        dump_repos
-        exit "$rc"
+    if [ -n "$INST_RPMS" ]; then
+        if ! retry_cmd 360 dnf -y install $INST_RPMS; then
+            rc=${PIPESTATUS[0]}
+            dump_repos
+            #sleep 600
+            exit "$rc"
+        fi
     fi
 
     distro_custom
@@ -112,6 +102,8 @@ post_provision_config_nodes() {
         cat /etc/do-release
     fi
     cat /etc/os-release
+
+    rpm -qa | sort
 
     exit 0
 }

--- a/site_scons/env_modules.py
+++ b/site_scons/env_modules.py
@@ -25,8 +25,8 @@ import sys
 import errno
 import distro
 import subprocess #nosec
+import shutil
 from subprocess import PIPE, Popen #nosec
-from SCons.Script import WhereIs
 
 class _env_module(): # pylint: disable=invalid-name
     """Class for utilizing Modules component to load environment modules"""
@@ -120,7 +120,7 @@ class _env_module(): # pylint: disable=invalid-name
         for to_load in load:
             self._module_func('load', to_load)
             print("Looking for %s" % to_load)
-            if WhereIs('mpirun'):
+            if shutil.which('mpirun'):
                 print("Loaded %s" % to_load)
                 return True
         return False
@@ -146,7 +146,7 @@ class _env_module(): # pylint: disable=invalid-name
         if not self._module_load(mpi):
             print("No %s found\n" % mpi)
             return False
-        exe_path = WhereIs('mpirun')
+        exe_path = shutil.which('mpirun')
         if not exe_path:
             print("No mpirun found in path. Could not configure %s\n" % mpi)
             return False
@@ -166,7 +166,7 @@ def load_mpi(mpi):
     # On Ubuntu, MPI stacks use alternatives and need root to change their
     # pointer, so just verify that the desired MPI is loaded
     if distro.id() == "ubuntu":
-        updatealternatives = WhereIs('update-alternatives')
+        updatealternatives = shutil.which('update-alternatives')
         if not updatealternatives:
             print("No update-alternatives found in path.")
             return False

--- a/src/cart/crt_init.c
+++ b/src/cart/crt_init.c
@@ -75,7 +75,8 @@ mem_pin_workaround(void)
 			       errno, strerror(errno));
 
 	} else {
-		D_INFO("mlockall() skipped\n");
+		D_INFO("mlockall() skipped, rlim_cur=%lu, rlim_max=%lu\n",
+		       rlim.rlim_cur, rlim.rlim_max);
 	}
 
 	D_DEBUG(DB_ALL, "Memory pinning workaround enabled\n");

--- a/src/engine/srv.c
+++ b/src/engine/srv.c
@@ -322,6 +322,12 @@ dss_srv_handler(void *arg)
 	struct dss_module_info		*dmi;
 	int				 rc;
 	bool				 signal_caller = true;
+	unsigned int			 i;
+
+	hwloc_bitmap_foreach_begin(i, dx->dx_cpuset) {
+		D_INFO("XS id %d : %s : cpuset index %u is set for cpubind and membind",
+		       dx->dx_xs_id, dx->dx_name, i);
+	} hwloc_bitmap_foreach_end();
 
 	/**
 	 * Set cpu affinity
@@ -339,7 +345,7 @@ dss_srv_handler(void *arg)
 	rc = hwloc_set_membind(dss_topo, dx->dx_cpuset, HWLOC_MEMBIND_BIND,
 			       HWLOC_MEMBIND_THREAD);
 	if (rc)
-		D_DEBUG(DB_TRACE, "failed to set memory affinity: %d\n", errno);
+		D_WARN("failed to set memory affinity: %d\n", errno);
 
 	/* initialize xstream-local storage */
 	dtc = dss_tls_init(DAOS_SERVER_TAG, dx->dx_xs_id, dx->dx_tgt_id);
@@ -832,6 +838,8 @@ dss_start_xs_id(int xs_id)
 	D_DEBUG(DB_TRACE, "start xs_id called for %d.  ", xs_id);
 	/* if we are NUMA aware, use the NUMA information */
 	if (numa_obj) {
+		D_INFO("xs_id %d : Using NUMA-aware core allocation\n", xs_id);
+
 		idx = hwloc_bitmap_first(core_allocation_bitmap);
 		if (idx == -1) {
 			D_ERROR("No core available for XS: %d", xs_id);
@@ -853,10 +861,10 @@ dss_start_xs_id(int xs_id)
 		}
 
 		hwloc_bitmap_asprintf(&cpuset, obj->cpuset);
-		D_DEBUG(DB_TRACE, "Using CPU set %s\n", cpuset);
+		D_INFO("xs_id %d : Using CPU set %s\n", xs_id, cpuset);
 		free(cpuset);
 	} else {
-		D_DEBUG(DB_TRACE, "Using non-NUMA aware core allocation\n");
+		D_INFO("xs id %d : Using non-NUMA aware core allocation\n", xs_id);
 		/*
 		 * All system XS will use the first core, but
 		 * the SWIM XS will use separate core if enough cores

--- a/src/engine/ult.c
+++ b/src/engine/ult.c
@@ -206,10 +206,15 @@ next:
 			stream->st_rc = rc;
 			rc = ABT_future_set(future, (void *)stream);
 			D_ASSERTF(rc == ABT_SUCCESS, "%d\n", rc);
+		} else {
+			D_INFO("created %s for tgt %d, xs_id %d, xs_nr=%d\n",
+			       create_ult ? "thread" : "task", tid, dx->dx_xs_id, xs_nr);
 		}
 	}
 
+	D_INFO("waiting for tasks with ABT_future_wait()\n");
 	ABT_future_wait(future);
+	D_INFO("done waiting for tasks\n");
 
 	rc = aggregator.at_rc;
 

--- a/src/include/gurt/common.h
+++ b/src/include/gurt/common.h
@@ -446,7 +446,7 @@ void d_free_string(struct d_string_buffer_t *buf);
 # define offsetof(typ, memb)	((long)((char *)&(((typ *)0)->memb)))
 #endif
 
-#define D_ALIGNUP(x, a) (((x) + (a - 1)) & ~(a - 1))
+#define D_ALIGNUP(x, a) (((x) + ((a) - 1)) & ~((a) - 1))
 
 #ifndef ARRAY_SIZE
 #define ARRAY_SIZE(arr) (sizeof(arr) / sizeof((arr)[0]))

--- a/src/mgmt/srv_target.c
+++ b/src/mgmt/srv_target.c
@@ -504,6 +504,8 @@ tgt_vos_preallocate(uuid_t uuid, daos_size_t scm_size, int tgt_nr)
 			break;
 		}
 
+		/** Align to 4K or locking the region based on the size will fail */
+		scm_size = D_ALIGNUP(scm_size, 1ULL << 12);
 		/**
 		 * Pre-allocate blocks for vos files in order to provide
 		 * consistent performance and avoid entering into the backend

--- a/src/tests/ftest/harness/basic.py
+++ b/src/tests/ftest/harness/basic.py
@@ -27,7 +27,7 @@ class HarnessBasicTest(Test):
 
         :avocado: tags=all
         :avocado: tags=hw,large,medium,ib2,small
-        :avocado: tags=harness,harness_basic_test,test_always_passes_hw
+        :avocado: tags=harness,harness_basic_test,test_always_passes,test_always_passes_hw
         :avocado: tags=always_passes
         """
         self.test_always_passes()

--- a/src/tests/ftest/pool/create.py
+++ b/src/tests/ftest/pool/create.py
@@ -5,6 +5,7 @@
 SPDX-License-Identifier: BSD-2-Clause-Patent
 """
 from pool_test_base import PoolTestBase
+from general_utils import run_pcmd
 
 
 class PoolCreateTests(PoolTestBase):
@@ -66,6 +67,9 @@ class PoolCreateTests(PoolTestBase):
         :avocado: tags=pool
         :avocado: tags=pool_create_tests,create_no_space
         """
+        # quick hack, let's see what hwloc-ls shows on each server node
+        run_pcmd(self.server_managers[0].hosts, "hwloc-ls")
+
         # Define three pools to create:
         #   - one pool using 90% of the available capacity of one server
         #   - one pool using 90% of the available capacity of all servers
@@ -119,6 +123,10 @@ class PoolCreateTests(PoolTestBase):
         :avocado: tags=pool
         :avocado: tags=pool_create_tests,create_no_space_loop
         """
+
+        # quick hack, let's see what hwloc-ls shows on each server node
+        run_pcmd(self.server_managers[0].hosts, "hwloc-ls")
+
         # Define three pools to create:
         #   - one pool using 90% of the available capacity of one server
         #   - one pool using 90% of the available capacity of all servers

--- a/src/tests/ftest/pool/create.yaml
+++ b/src/tests/ftest/pool/create.yaml
@@ -14,15 +14,27 @@ timeouts:
   test_create_max_pool: 300
   test_create_no_space: 300
   test_create_no_space_loop: 2160
+#numactl hack
+#setup:
+#  server_manager_class: Orterun
 server_config:
   name: daos_server
+  control_log_mask: DEBUG
   servers:
     0:
+      pinned_numa_node: 0
       bdev_class: nvme
       bdev_list: ["aaaa:aa:aa.a", "bbbb:bb:bb.b"]
       scm_class: dcpm
       scm_list: ["/dev/pmem0"]
       scm_mount: /mnt/daos0
+      log_mask: DEBUG,MEM=ERR,SWIM=ERR
+      env_vars:
+        # DD_MASK all except mem
+        - DD_MASK=any,trace,net,io,md,pl,mgmt,epc,df,rebuild,sec,csum,dsms,any
+        # - CRT_ENABLE_MEM_PIN=1
+        # - DAOS_SCHED_WATCHDOG_ALL=1
+        # - DAOS_SCHED_RELAX_MODE=disabled
 pool_1:
   name: daos_server
   control_method: dmg

--- a/src/tests/ftest/scripts/setup_nodes.sh
+++ b/src/tests/ftest/scripts/setup_nodes.sh
@@ -43,7 +43,7 @@ if [ \"\$(ulimit -c)\" != \"unlimited\" ]; then
     echo \"*  soft  core  unlimited\" >> /etc/security/limits.conf
 fi
 echo \"/var/tmp/core.%e.%t.%p\" > /proc/sys/kernel/core_pattern"
-rm -f /var/tmp/core.*
+sudo rm -f /var/tmp/core.*
 if [ "${HOSTNAME%%.*}" != "$FIRST_NODE" ]; then
     if grep /mnt/daos\  /proc/mounts; then
         sudo umount /mnt/daos

--- a/src/tests/ftest/util/general_utils.py
+++ b/src/tests/ftest/util/general_utils.py
@@ -406,17 +406,34 @@ def run_pcmd(hosts, command, verbose=True, timeout=None, expect_rc=0):
         for item in results
         if expect_rc is not None and item["exit_status"] != expect_rc]
     if verbose or bad_exit_status:
-        log.info("Command: %s", command)
-        log.info("Results:")
-        for result in results:
-            log.info(
-                "  %s: exit_status=%s, interrupted=%s:",
-                result["hosts"], result["exit_status"], result["interrupted"])
-            for line in result["stdout"]:
-                log.info("    %s", line)
+        log.info(colate_results(command, results))
 
     return results
 
+
+def colate_results(command, results):
+    """Colate the output of run_pcmd.
+
+    Args:
+        command (str): command used to obtain the data on each server
+        results (list): list: a list of dictionaries with each entry
+                        containing output, exit status, and interrupted
+                        status common to each group of hosts (see run_pcmd()'s
+                        return for details)
+    Returns:
+        str: a string colating run_pcmd()'s results
+
+    """
+    res = ""
+    res += "Command: %s\n" % command
+    res += "Results:\n"
+    for result in results:
+        res += "  %s: exit_status=%s, interrupted=%s:" % (
+               result["hosts"], result["exit_status"], result["interrupted"])
+        for line in result["stdout"]:
+            res += "    %s\n" % line
+
+    return res
 
 def get_host_data(hosts, command, text, error, timeout=None):
     """Get the data requested for each host using the specified command.

--- a/src/tests/ftest/util/server_utils_base.py
+++ b/src/tests/ftest/util/server_utils_base.py
@@ -177,6 +177,19 @@ class DaosServerCommand(YamlCommand):
             engine_values = self.yaml.get_engine_values(name)
         return engine_values
 
+    #numactl hack
+    #def __str__(self):
+    #
+    #    """Return the command with all of its defined parameters as a string.
+    #
+    #    Returns:
+    #
+    #        str: the command with all the defined parameters
+    #
+    #    """
+    #
+    #    return " ".join(["numactl --cpunodebind=1", super().__str__()])
+
     class NetworkSubCommand(CommandWithSubCommand):
         """Defines an object for the daos_server network sub command."""
 

--- a/src/vos/vos_pool.c
+++ b/src/vos/vos_pool.c
@@ -306,6 +306,9 @@ vos_pool_create(const char *path, uuid_t uuid, daos_size_t scm_sz,
 		return daos_errno2der(errno);
 	}
 
+	D_DEBUG(DB_MGMT, "Pool Path: %s, SCM size: "DF_U64", UUID: "DF_UUID
+		", call vos_pmemobj_create()\n", path, scm_sz, DP_UUID(uuid));
+
 	ph = vos_pmemobj_create(path, POBJ_LAYOUT_NAME(vos_pool_layout), scm_sz,
 				0600);
 	if (!ph) {
@@ -314,6 +317,9 @@ vos_pool_create(const char *path, uuid_t uuid, daos_size_t scm_sz,
 			scm_sz, pmemobj_errormsg());
 		return daos_errno2der(rc);
 	}
+
+	D_DEBUG(DB_MGMT, "Pool Path: %s, UUID: "DF_UUID", call pmemobj_ctl_set()\n",
+		path, DP_UUID(uuid));
 
 	rc = pmemobj_ctl_set(ph, "stats.enabled", &enabled);
 	if (rc) {
@@ -405,6 +411,8 @@ end:
 	blob_hdr.bbh_hdr_sz = VOS_BLOB_HDR_BLKS;
 	uuid_copy(blob_hdr.bbh_pool, uuid);
 
+	D_DEBUG(DB_MGMT, "xs:%p pool:"DF_UUID", call vea_format()\n", xs_ctxt, DP_UUID(uuid));
+
 	/* Format SPDK blob*/
 	rc = vea_format(&umem, vos_txd_get(), &pool_df->pd_vea_df, VOS_BLK_SZ,
 			VOS_BLOB_HDR_BLKS, nvme_sz, vos_blob_format_cb,
@@ -417,6 +425,8 @@ end:
 		goto close;
 	}
 
+	D_DEBUG(DB_MGMT, "xs:%p pool:"DF_UUID", done vea_format()\n", xs_ctxt, DP_UUID(uuid));
+
 open:
 	/* If the caller does not want a VOS pool handle, we're done. */
 	if (poh == NULL)
@@ -425,6 +435,8 @@ open:
 	/* Create a VOS pool handle using ph. */
 	rc = pool_open(ph, pool_df, uuid, flags, NULL, poh);
 	ph = NULL;
+
+	D_DEBUG(DB_MGMT, "xs:%p pool:"DF_UUID", done pool_open()\n", xs_ctxt, DP_UUID(uuid));
 
 close:
 	/* Close this local handle, if it hasn't been consumed nor already
@@ -639,6 +651,23 @@ enum {
 	LM_FLAG_ENABLED
 };
 
+#define LINE_SIZE 256
+static void
+log_proc_self_maps(void)
+{
+	FILE		*maps = fopen("/proc/self/maps", "r");
+	char		 buf[LINE_SIZE];
+
+	if (maps == NULL) {
+		D_WARN("Could not open /proc/self/maps, errno=%d (%s)\n", errno, strerror(errno));
+		return;
+	}
+
+	while (fgets(buf, LINE_SIZE, maps) != NULL) {
+		D_WARN("%s", buf);
+	}
+}
+
 static void
 lock_pool_memory(struct vos_pool *pool)
 {
@@ -655,7 +684,8 @@ lock_pool_memory(struct vos_pool *pool)
 		}
 
 		if (rlim.rlim_cur != RLIM_INFINITY || rlim.rlim_max != RLIM_INFINITY) {
-			D_WARN("Infinite rlimit not detected, not locking VOS pool memory\n");
+			D_WARN("Infinite rlimit not detected (cur=%lu, max=%lu), not locking "
+			       "VOS pool memory\n", rlim.rlim_cur, rlim.rlim_max);
 			lock_mem = LM_FLAG_DISABLED;
 			return;
 		}
@@ -668,8 +698,10 @@ lock_pool_memory(struct vos_pool *pool)
 
 	rc = mlock((void *)pool->vp_umm.umm_base, pool->vp_pool_df->pd_scm_sz);
 	if (rc != 0) {
-		D_WARN("Could not lock memory for VOS pool at "DF_X64"; errno=%d (%s)\n",
-		       pool->vp_umm.umm_base, errno, strerror(errno));
+		D_WARN("Could not lock memory for VOS pool "DF_U64" bytes at "DF_X64
+		       "; errno=%d (%s)\n", pool->vp_pool_df->pd_scm_sz, pool->vp_umm.umm_base,
+		       errno, strerror(errno));
+		log_proc_self_maps();
 		return;
 	}
 

--- a/utils/rpms/daos.spec
+++ b/utils/rpms/daos.spec
@@ -254,6 +254,18 @@ Requires: %{name}-server-tests%{?_isa} = %{version}-%{release}
 %description server-tests-openmpi
 This is the package needed to run the DAOS server test suite openmpi tools
 
+
+%package tests-openmpi
+Summary: The DAOS test suite - tools which need openmpi
+#This is a bit messy and needs some cleanup.  In theory,
+#we should have client tests and server tests in separate
+#packages but some binaries need libraries from both at
+#present.
+Requires: %{name}-tests%{?_isa} = %{version}-%{release}
+
+%description tests-openmpi
+This is the package needed to run the DAOS test suite openmpi tools
+
 %package devel
 Summary: The DAOS development libraries and headers
 Requires: %{name}-client%{?_isa} = %{version}-%{release}


### PR DESCRIPTION
This is PR-6741 contents, rebased on 03 November 2021 master.

- Plus a change to create.yaml to add server and engine debug logs.
- Plus a change to lock_pool_memory() to log more information on
  mlock() failure, or when finding insufficient locked memory
  limits in the environment for the engine process.
- Plus a change to run pidstat at 1 second intervals on server nodes
  to keep an eye on CPU core allocation, usage, and context switches
  for all daos_server and daos_engine threads.
- Plus a change in dss_srv_handler() to print hwloc_cpuset_t dx_cpuset
  and warn rather than trace debug log if hwloc_set_membind() fails.
- And some logging of dss_thread_collective intended to see timing
  of task creation for each target-specific xs
- And capture hwloc-ls output on each server node.
- Intent to run pool/create.py with most recent vea performance
  improvements.

Quick-Functional: true
Skip-coverity-test: true
Skip-func-test-vm: true
Skip-func-hw-test-small: true
Skip-func-hw-test-medium: true
Skip-func-hw-test-large: false
Func-hw-test-distro: el8.4
Skip-scan-centos-rpms: true
Skip-scan-leap15-rpms: true
Skip-test-centos-rpms: true
Skip-test-centos-8.3-rpms: true
Skip-test-leap-15-rpms: true
Allow-unstable-test: true
Skip-PR-comments: true
Test-tag: create_no_space create_no_space_loop

Signed-off-by: Kenneth Cain <kenneth.c.cain@intel.com>