### PR TITLE
DAOS-8685 pool: run create tests with logging, CentOS7 HW

### DIFF
--- a/ci/functional/required_packages.sh
+++ b/ci/functional/required_packages.sh
@@ -32,7 +32,10 @@ elif [[ $distro = el* ]] || [[ $distro = centos* ]] ||
           hdf5-vol-daos-mpich-tests    \
           MACSio-mpich                 \
           MACSio-$openmpi              \
-          mpifileutils-mpich"
+          mpifileutils-mpich           \
+          numactl                      \
+          sysstat                      \
+          hwloc"
 else
     echo "I don't know which packages should be installed for distro"
          "\"$distro\""

--- a/src/engine/srv.c
+++ b/src/engine/srv.c
@@ -322,6 +322,12 @@ dss_srv_handler(void *arg)
 	struct dss_module_info		*dmi;
 	int				 rc;
 	bool				 signal_caller = true;
+	unsigned int			 i;
+
+	hwloc_bitmap_foreach_begin(i, dx->dx_cpuset) {
+		D_INFO("XS id %d : %s : cpuset index %u is set for cpubind and membind",
+		       dx->dx_xs_id, dx->dx_name, i);
+	} hwloc_bitmap_foreach_end();
 
 	/**
 	 * Set cpu affinity
@@ -339,7 +345,7 @@ dss_srv_handler(void *arg)
 	rc = hwloc_set_membind(dss_topo, dx->dx_cpuset, HWLOC_MEMBIND_BIND,
 			       HWLOC_MEMBIND_THREAD);
 	if (rc)
-		D_DEBUG(DB_TRACE, "failed to set memory affinity: %d\n", errno);
+		D_WARN("failed to set memory affinity: %d\n", errno);
 
 	/* initialize xstream-local storage */
 	dtc = dss_tls_init(DAOS_SERVER_TAG, dx->dx_xs_id, dx->dx_tgt_id);
@@ -832,6 +838,8 @@ dss_start_xs_id(int xs_id)
 	D_DEBUG(DB_TRACE, "start xs_id called for %d.  ", xs_id);
 	/* if we are NUMA aware, use the NUMA information */
 	if (numa_obj) {
+		D_INFO("xs_id %d : Using NUMA-aware core allocation\n", xs_id);
+
 		idx = hwloc_bitmap_first(core_allocation_bitmap);
 		if (idx == -1) {
 			D_ERROR("No core available for XS: %d", xs_id);
@@ -853,10 +861,10 @@ dss_start_xs_id(int xs_id)
 		}
 
 		hwloc_bitmap_asprintf(&cpuset, obj->cpuset);
-		D_DEBUG(DB_TRACE, "Using CPU set %s\n", cpuset);
+		D_INFO("xs_id %d : Using CPU set %s\n", xs_id, cpuset);
 		free(cpuset);
 	} else {
-		D_DEBUG(DB_TRACE, "Using non-NUMA aware core allocation\n");
+		D_INFO("xs id %d : Using non-NUMA aware core allocation\n", xs_id);
 		/*
 		 * All system XS will use the first core, but
 		 * the SWIM XS will use separate core if enough cores

--- a/src/engine/ult.c
+++ b/src/engine/ult.c
@@ -206,10 +206,15 @@ next:
 			stream->st_rc = rc;
 			rc = ABT_future_set(future, (void *)stream);
 			D_ASSERTF(rc == ABT_SUCCESS, "%d\n", rc);
+		} else {
+			D_INFO("created %s for tgt %d, xs_id %d, xs_nr=%d\n",
+			       create_ult ? "thread" : "task", tid, dx->dx_xs_id, xs_nr);
 		}
 	}
 
+	D_INFO("waiting for tasks with ABT_future_wait()\n");
 	ABT_future_wait(future);
+	D_INFO("done waiting for tasks\n");
 
 	rc = aggregator.at_rc;
 

--- a/src/tests/ftest/pool/create.py
+++ b/src/tests/ftest/pool/create.py
@@ -5,6 +5,7 @@
 SPDX-License-Identifier: BSD-2-Clause-Patent
 """
 from pool_test_base import PoolTestBase
+from general_utils import run_pcmd
 
 
 class PoolCreateTests(PoolTestBase):
@@ -66,6 +67,9 @@ class PoolCreateTests(PoolTestBase):
         :avocado: tags=pool
         :avocado: tags=pool_create_tests,create_no_space
         """
+        # quick hack, let's see what hwloc-ls shows on each server node
+        run_pcmd(self.server_managers[0].hosts, "hwloc-ls")
+
         # Define three pools to create:
         #   - one pool using 90% of the available capacity of one server
         #   - one pool using 90% of the available capacity of all servers
@@ -119,6 +123,10 @@ class PoolCreateTests(PoolTestBase):
         :avocado: tags=pool
         :avocado: tags=pool_create_tests,create_no_space_loop
         """
+
+        # quick hack, let's see what hwloc-ls shows on each server node
+        run_pcmd(self.server_managers[0].hosts, "hwloc-ls")
+
         # Define three pools to create:
         #   - one pool using 90% of the available capacity of one server
         #   - one pool using 90% of the available capacity of all servers

--- a/src/tests/ftest/pool/create.yaml
+++ b/src/tests/ftest/pool/create.yaml
@@ -14,15 +14,26 @@ timeouts:
   test_create_max_pool: 300
   test_create_no_space: 300
   test_create_no_space_loop: 2160
+#numactl hack
+#setup:
+#  server_manager_class: Orterun
 server_config:
   name: daos_server
+  control_log_mask: DEBUG
   servers:
     0:
+      pinned_numa_node: 0
       bdev_class: nvme
       bdev_list: ["aaaa:aa:aa.a", "bbbb:bb:bb.b"]
       scm_class: dcpm
       scm_list: ["/dev/pmem0"]
       scm_mount: /mnt/daos0
+      log_mask: DEBUG,MEM=ERR,SWIM=ERR
+      env_vars:
+        # DD_MASK all except mem
+        - DD_MASK=any,trace,net,io,md,pl,mgmt,epc,df,rebuild,sec,csum,dsms,any
+        # - DAOS_SCHED_WATCHDOG_ALL=1
+        # - DAOS_SCHED_RELAX_MODE=disabled
 pool_1:
   name: daos_server
   control_method: dmg

--- a/src/tests/ftest/util/server_utils_base.py
+++ b/src/tests/ftest/util/server_utils_base.py
@@ -177,6 +177,19 @@ class DaosServerCommand(YamlCommand):
             engine_values = self.yaml.get_engine_values(name)
         return engine_values
 
+    #numactl hack
+    #def __str__(self):
+    #
+    #    """Return the command with all of its defined parameters as a string.
+    #
+    #    Returns:
+    #
+    #        str: the command with all the defined parameters
+    #
+    #    """
+    #
+    #    return " ".join(["numactl --cpunodebind=1", super().__str__()])
+
     class NetworkSubCommand(CommandWithSubCommand):
         """Defines an object for the daos_server network sub command."""
 

--- a/src/vos/vos_pool.c
+++ b/src/vos/vos_pool.c
@@ -306,6 +306,9 @@ vos_pool_create(const char *path, uuid_t uuid, daos_size_t scm_sz,
 		return daos_errno2der(errno);
 	}
 
+	D_DEBUG(DB_MGMT, "Pool Path: %s, SCM size: "DF_U64", UUID: "DF_UUID
+		", call vos_pmemobj_create()\n", path, scm_sz, DP_UUID(uuid));
+
 	ph = vos_pmemobj_create(path, POBJ_LAYOUT_NAME(vos_pool_layout), scm_sz,
 				0600);
 	if (!ph) {
@@ -314,6 +317,9 @@ vos_pool_create(const char *path, uuid_t uuid, daos_size_t scm_sz,
 			scm_sz, pmemobj_errormsg());
 		return daos_errno2der(rc);
 	}
+
+	D_DEBUG(DB_MGMT, "Pool Path: %s, UUID: "DF_UUID", call pmemobj_ctl_set()\n",
+		path, DP_UUID(uuid));
 
 	rc = pmemobj_ctl_set(ph, "stats.enabled", &enabled);
 	if (rc) {
@@ -405,6 +411,8 @@ end:
 	blob_hdr.bbh_hdr_sz = VOS_BLOB_HDR_BLKS;
 	uuid_copy(blob_hdr.bbh_pool, uuid);
 
+	D_DEBUG(DB_MGMT, "xs:%p pool:"DF_UUID", call vea_format()\n", xs_ctxt, DP_UUID(uuid));
+
 	/* Format SPDK blob*/
 	rc = vea_format(&umem, vos_txd_get(), &pool_df->pd_vea_df, VOS_BLK_SZ,
 			VOS_BLOB_HDR_BLKS, nvme_sz, vos_blob_format_cb,
@@ -417,6 +425,8 @@ end:
 		goto close;
 	}
 
+	D_DEBUG(DB_MGMT, "xs:%p pool:"DF_UUID", done vea_format()\n", xs_ctxt, DP_UUID(uuid));
+
 open:
 	/* If the caller does not want a VOS pool handle, we're done. */
 	if (poh == NULL)
@@ -425,6 +435,8 @@ open:
 	/* Create a VOS pool handle using ph. */
 	rc = pool_open(ph, pool_df, uuid, flags, NULL, poh);
 	ph = NULL;
+
+	D_DEBUG(DB_MGMT, "xs:%p pool:"DF_UUID", done pool_open()\n", xs_ctxt, DP_UUID(uuid));
 
 close:
 	/* Close this local handle, if it hasn't been consumed nor already


### PR DESCRIPTION
- a change to create.yaml to add server and engine debug logs.
- Plus a change to run pidstat at 1 second intervals on server nodes
  to keep an eye on CPU core allocation, usage, and context switches
  for all daos_server and daos_engine threads.
- Plus a change in dss_srv_handler() to print hwloc_cpuset_t dx_cpuset
  and warn rather than trace debug log if hwloc_set_membind() fails.
- And some logging of dss_thread_collective intended to see timing
  of task creation for each target-specific xs
- And capture hwloc-ls output on each server node.
- Intent to run pool/create.py with most recent vea performance
  improvements.

Quick-Functional: true
Skip-coverity-test: true
Skip-func-test-vm: true
Skip-func-hw-test-small: true
Skip-func-hw-test-medium: true
Skip-func-hw-test-large: false
Skip-scan-centos-rpms: true
Skip-scan-leap15-rpms: true
Skip-test-centos-rpms: true
Skip-test-centos-8.3-rpms: true
Skip-test-leap-15-rpms: true
Test-tag: create_no_space create_no_space_loop

Signed-off-by: Kenneth Cain <kenneth.c.cain@intel.com>