### PR TITLE
DAOS-8850 agent: Improve iface detection for verbs (#7144)

### DIFF
--- a/src/control/cmd/daos_agent/infocache.go
+++ b/src/control/cmd/daos_agent/infocache.go
@@ -170,7 +170,7 @@ func (c *localFabricCache) setCache(nf *NUMAFabric) {
 }
 
 // GetDevices fetches an appropriate fabric device from the cache.
-func (c *localFabricCache) GetDevice(numaNode int, netDevClass uint32) (*FabricInterface, error) {
+func (c *localFabricCache) GetDevice(numaNode int, netDevClass uint32, provider string) (*FabricInterface, error) {
 	if c == nil {
 		return nil, NotCachedErr
 	}
@@ -181,5 +181,5 @@ func (c *localFabricCache) GetDevice(numaNode int, netDevClass uint32) (*FabricI
 	if !c.IsCached() {
 		return nil, NotCachedErr
 	}
-	return c.localNUMAFabric.GetDevice(numaNode, netDevClass)
+	return c.localNUMAFabric.GetDevice(numaNode, netDevClass, provider)
 }

--- a/src/control/cmd/daos_agent/mgmt_rpc.go
+++ b/src/control/cmd/daos_agent/mgmt_rpc.go
@@ -7,9 +7,7 @@
 package main
 
 import (
-	"fmt"
 	"net"
-	"strings"
 
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
@@ -137,7 +135,7 @@ func (mod *mgmtModule) getAttachInfo(ctx context.Context, numaNode int, sys stri
 		return nil, err
 	}
 
-	fabricIF, err := mod.getFabricInterface(ctx, numaNode, resp.ClientNetHint.NetDevClass)
+	fabricIF, err := mod.getFabricInterface(ctx, numaNode, resp.ClientNetHint.NetDevClass, resp.ClientNetHint.Provider)
 	if err != nil {
 		mod.log.Errorf("failed to fetch fabric interface of type %s: %s",
 			netdetect.DevClassName(resp.ClientNetHint.NetDevClass), err.Error())
@@ -146,12 +144,7 @@ func (mod *mgmtModule) getAttachInfo(ctx context.Context, numaNode int, sys stri
 
 	resp.ClientNetHint.Interface = fabricIF.Name
 	resp.ClientNetHint.Domain = fabricIF.Name
-	if strings.HasPrefix(resp.ClientNetHint.Provider, verbsProvider) {
-		if fabricIF.Domain == "" {
-			mod.log.Errorf("domain is required for verbs provider, none found on interface %s", fabricIF.Name)
-			return nil, fmt.Errorf("no domain on interface %s", fabricIF.Name)
-		}
-
+	if fabricIF.Domain != "" {
 		resp.ClientNetHint.Domain = fabricIF.Domain
 		mod.log.Debugf("OFI_DOMAIN for %s has been detected as: %s",
 			resp.ClientNetHint.Interface, resp.ClientNetHint.Domain)
@@ -187,9 +180,9 @@ func (mod *mgmtModule) getAttachInfoRemote(ctx context.Context, numaNode int, sy
 	return pbResp, nil
 }
 
-func (mod *mgmtModule) getFabricInterface(ctx context.Context, numaNode int, netDevClass uint32) (*FabricInterface, error) {
+func (mod *mgmtModule) getFabricInterface(ctx context.Context, numaNode int, netDevClass uint32, provider string) (*FabricInterface, error) {
 	if mod.fabricInfo.IsCached() {
-		return mod.fabricInfo.GetDevice(numaNode, netDevClass)
+		return mod.fabricInfo.GetDevice(numaNode, netDevClass, provider)
 	}
 
 	netCtx, err := netdetect.Init(ctx)
@@ -205,7 +198,7 @@ func (mod *mgmtModule) getFabricInterface(ctx context.Context, numaNode int, net
 
 	mod.fabricInfo.CacheScan(netCtx, result)
 
-	return mod.fabricInfo.GetDevice(numaNode, netDevClass)
+	return mod.fabricInfo.GetDevice(numaNode, netDevClass, provider)
 }
 
 func (mod *mgmtModule) handleNotifyPoolConnect(ctx context.Context, reqb []byte, pid int32) error {


### PR DESCRIPTION
Move interface domain-checking logic into the fabric cache to
avoid returning an interface without a domain when a verbs
provider is used.

Signed-off-by: Kris Jacque <kristin.jacque@intel.com>