### PR TITLE
DAOS-9004 test: remove full_regression from daily

### DIFF
--- a/src/tests/ftest/checksum/csum_basic.py
+++ b/src/tests/ftest/checksum/csum_basic.py
@@ -62,7 +62,7 @@ class CsumContainerValidation(TestWithServers):
         Test ID: DAOS-3927
         Test Description: Write Avocado Test to verify single data after
                           pool/container disconnect/reconnect.
-        :avocado: tags=all,full_regression,daily_regression
+        :avocado: tags=all,daily_regression
         :avocado: tags=checksum
         :avocado: tags=basic_checksum_object
         """

--- a/src/tests/ftest/container/autotest.py
+++ b/src/tests/ftest/container/autotest.py
@@ -18,7 +18,7 @@ class ContainerAutotestTest(TestWithServers):
     def test_container_autotest(self):
         """Test container autotest.
 
-        :avocado: tags=all,full_regression,daily_regression
+        :avocado: tags=all,daily_regression
         :avocado: tags=hw,medium,ib2
         :avocado: tags=container,autotest,containerautotest,quick
         """

--- a/src/tests/ftest/pool/evict.py
+++ b/src/tests/ftest/pool/evict.py
@@ -157,7 +157,7 @@ class EvictTests(TestWithServers):
         The test verifies that the other two pools were not affected
         by the evict
 
-        :avocado: tags=all,pr,daily_regression,full_regression
+        :avocado: tags=all,pr,daily_regression
         :avocado: tags=small
         :avocado: tags=pool,pool_evict,pool_evict_basic
         :avocado: tags=DAOS_5610
@@ -251,7 +251,7 @@ class EvictTests(TestWithServers):
         """
         Test evicting a pool using an invalid uuid.
 
-        :avocado: tags=all,pool,pr,daily_regression,full_regression
+        :avocado: tags=all,pool,pr,daily_regression
         :avocado: tags=small
         :avocado: tags=pool_evict,pool_evict_bad_uuid,DAOS_5610
         """


### PR DESCRIPTION
Quick-functional: true
Test-tag: basic_checksum_object containerautotest pool_evict

Remove full_regression tags from tests already tagged with
daily_regression.

Signed-off-by: Dalton Bohning <dalton.bohning@intel.com>