### PR TITLE
DAOS-8984 test: Add a timeout to the RPMs test

### DIFF
--- a/ci/rpm/test_daos_node.sh
+++ b/ci/rpm/test_daos_node.sh
@@ -95,7 +95,7 @@ if ! module load $OPENMPI; then
     module list
     exit 1
 fi
-coproc daos_server --debug start -t 1 --recreate-superblocks
+coproc daos_server --debug start -t 1 --recreate-superblocks 2>&1
 trap 'set -x; kill -INT $COPROC_PID' EXIT
 line=""
 while [[ "$line" != *started\ on\ rank\ 0* ]]; do
@@ -106,4 +106,15 @@ echo "Server started!"
 daos_agent --debug &
 AGENT_PID=$!
 trap 'set -x; kill -INT $AGENT_PID $COPROC_PID' EXIT
-OFI_INTERFACE=eth0 daos_test -m
+if ! OFI_INTERFACE=eth0 timeout -k 30 300 daos_test -m; then
+    rc=${PIPESTATUS[0]}
+    if [ "$rc" = "124" ]; then
+        echo "daos_test -m was killed after running for 5 minutes"
+    else
+        echo "daos_test -m failed, exiting with $rc"
+    fi
+    echo "daos_server stdout and stderr since rank 0 started:"
+    cat <&"${COPROC[0]}"
+    exit "$rc"
+fi
+exit 0


### PR DESCRIPTION
Ensure that if daos_test -m hangs, the test does not hang indefinitely.

Try to get daos_server output if daos_test -m hangs or otherwise exits
!0.