### PR TITLE
DAOS-8882 control: Wait for ready engine before GroupUpdate

### DIFF
--- a/src/control/server/server.go
+++ b/src/control/server/server.go
@@ -332,7 +332,25 @@ func (srv *server) registerEvents() {
 			srv.mgmtSvc.startJoinLoop(ctx)
 			registerLeaderSubscriptions(srv)
 			srv.log.Debugf("requesting sync GroupUpdate after leader change")
-			srv.mgmtSvc.reqGroupUpdate(ctx, true)
+			go func() {
+				for {
+					select {
+					case <-ctx.Done():
+						return
+					default:
+						// Wait for at least one engine to be ready to service the
+						// GroupUpdate request.
+						for _, ei := range srv.harness.Instances() {
+							if ei.IsReady() {
+								srv.mgmtSvc.reqGroupUpdate(ctx, true)
+								return
+							}
+						}
+						srv.log.Debugf("no engines ready for GroupUpdate; waiting %s", groupUpdateInterval)
+						time.Sleep(groupUpdateInterval)
+					}
+				}
+			}()
 			return nil
 		},
 		func(ctx context.Context) error {


### PR DESCRIPTION
Upon gaining leadership state, the MS needs to request a GroupUpdate
in order to ensure that all ranks have the latest group map. The
request should not happen until at least one rank is ready to receive
the request, in order to avoid spurious error messages.

Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com>
