### PR TITLE
DAOS-8927 vos: Fix vos pool locking to align scm size to a page

### DIFF
--- a/src/include/gurt/common.h
+++ b/src/include/gurt/common.h
@@ -446,7 +446,7 @@ void d_free_string(struct d_string_buffer_t *buf);
 # define offsetof(typ, memb)	((long)((char *)&(((typ *)0)->memb)))
 #endif
 
-#define D_ALIGNUP(x, a) (((x) + (a - 1)) & ~(a - 1))
+#define D_ALIGNUP(x, a) (((x) + ((a) - 1)) & ~((a) - 1))
 
 #ifndef ARRAY_SIZE
 #define ARRAY_SIZE(arr) (sizeof(arr) / sizeof((arr)[0]))

--- a/src/mgmt/srv_target.c
+++ b/src/mgmt/srv_target.c
@@ -504,6 +504,8 @@ tgt_vos_preallocate(uuid_t uuid, daos_size_t scm_size, int tgt_nr)
 			break;
 		}
 
+		/** Align to 4K or locking the region based on the size will fail */
+		scm_size = D_ALIGNUP(scm_size, 1ULL << 12);
 		/**
 		 * Pre-allocate blocks for vos files in order to provide
 		 * consistent performance and avoid entering into the backend

--- a/src/vos/vos_pool.c
+++ b/src/vos/vos_pool.c
@@ -668,8 +668,9 @@ lock_pool_memory(struct vos_pool *pool)
 
 	rc = mlock((void *)pool->vp_umm.umm_base, pool->vp_pool_df->pd_scm_sz);
 	if (rc != 0) {
-		D_WARN("Could not lock memory for VOS pool at "DF_X64"; errno=%d (%s)\n",
-		       pool->vp_umm.umm_base, errno, strerror(errno));
+		D_WARN("Could not lock memory for VOS pool "DF_U64" bytes at "DF_X64
+		       "; errno=%d (%s)\n", pool->vp_pool_df->pd_scm_sz, pool->vp_umm.umm_base,
+		       errno, strerror(errno));
 		return;
 	}
 


### PR DESCRIPTION
mlock will fail if trying to lock memory to a page boundary and
PMDK doesn't even map the whole space if there are leftover bits
on a page.   Just round up the size to the next page boundary.

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>