### PR TITLE
proposed updates

### DIFF
--- a/src/control/common/pci_utils.go
+++ b/src/control/common/pci_utils.go
@@ -77,6 +77,26 @@ func (pa *PCIAddress) IsVMDBackingAddress() bool {
 	return pa.Domain != "0000"
 }
 
+func (pa *PCIAddress) LessThan(other *PCIAddress) bool {
+	if pa == nil || other == nil {
+		return false
+	}
+
+	if pa.Domain != other.Domain {
+		return hexStr2Int(pa.Domain) < hexStr2Int(other.Domain)
+	}
+
+	if pa.Bus != other.Bus {
+		return hexStr2Int(pa.Bus) < hexStr2Int(other.Bus)
+	}
+
+	if pa.Device != other.Device {
+		return hexStr2Int(pa.Device) < hexStr2Int(other.Device)
+	}
+
+	return hexStr2Int(pa.Function) < hexStr2Int(other.Function)
+}
+
 // NewPCIAddress creates a PCIAddress stuct from input string.
 func NewPCIAddress(addr string) (*PCIAddress, error) {
 	dom, bus, dev, fun, err := parsePCIAddress(addr)
@@ -99,49 +119,48 @@ func NewPCIAddress(addr string) (*PCIAddress, error) {
 	return pa, nil
 }
 
-// PCIAddressList represents a list of PCI addresses.
-type PCIAddressList []*PCIAddress
+// PCIAddressSet represents a unique list of PCI addresses.
+type PCIAddressSet struct {
+	addrMap map[string]*PCIAddress
+}
 
 // Contains returns true if provided address is already in list.
-func (pal *PCIAddressList) Contains(a *PCIAddress) bool {
+func (pal *PCIAddressSet) Contains(a *PCIAddress) bool {
 	if pal == nil {
 		return false
 	}
 
-	for _, addr := range *pal {
-		if addr.Equals(a) {
-			return true
-		}
+	_, found := pal.addrMap[a.String()]
+	return found
+}
+
+func (pal *PCIAddressSet) add(a *PCIAddress) {
+	if pal.addrMap == nil {
+		pal.addrMap = make(map[string]*PCIAddress)
 	}
 
-	return false
+	pal.addrMap[a.String()] = a
 }
 
 // Add adds PCI addresses to slice. Ignores duplicate addresses.
-func (pal *PCIAddressList) Add(addrs ...PCIAddress) {
+func (pal *PCIAddressSet) Add(addrs ...*PCIAddress) error {
 	if pal == nil {
-		return
+		return errors.New("PCIAddressSet is nil")
 	}
 
-	for _, a := range addrs {
-		if !pal.Contains(&a) {
-			*pal = append(*pal, &a)
-		}
+	for _, addr := range addrs {
+		pal.add(addr)
 	}
 
-	sort.Sort(pal)
+	return nil
 }
 
 // AddStrings adds PCI addresses to slice from supplied strings. If any input string is not a valid PCI
 // address then return error and don't add any elements to slice. Ignores duplicateaddresses.
-func (pal *PCIAddressList) AddStrings(addrs ...string) error {
+func (pal *PCIAddressSet) AddStrings(addrs ...string) error {
 	if pal == nil {
-		return errors.New("method call on nil address list")
+		return errors.New("PCIAddressSet is nil")
 	}
-
-	var al []*PCIAddress
-
-	addrs = DedupeStringSlice(addrs)
 
 	for _, addr := range addrs {
 		if addr == "" {
@@ -153,59 +172,52 @@ func (pal *PCIAddressList) AddStrings(addrs ...string) error {
 			return err
 		}
 
-		if !pal.Contains(a) {
-			al = append(al, a)
-		}
+		pal.add(a)
 	}
-	*pal = append(*pal, al...)
-
-	sort.Sort(pal)
 
 	return nil
 }
 
-// Strings returns PCI addresses as slice of strings.
-func (pal *PCIAddressList) Strings() []string {
+func (pal *PCIAddressSet) Addresses() []*PCIAddress {
 	if pal == nil {
 		return nil
 	}
 
-	var addrs []string
+	addrs := make([]*PCIAddress, 0, len(pal.addrMap))
+	for _, addr := range pal.addrMap {
+		addrs = append(addrs, addr)
+	}
+	sort.Slice(addrs, func(i, j int) bool { return addrs[i].LessThan(addrs[j]) })
 
-	for _, addr := range *pal {
-		addrs = append(addrs, addr.String())
+	return addrs
+}
+
+// Strings returns PCI addresses as slice of strings.
+func (pal *PCIAddressSet) Strings() []string {
+	if pal == nil {
+		return nil
 	}
 
-	return sort.StringSlice(addrs)
+	addrs := make([]string, len(pal.addrMap))
+	for i, addr := range pal.Addresses() {
+		addrs[i] = addr.String()
+	}
+
+	return addrs
 }
 
 // Strings returns PCI addresses as string of joined space separated strings.
-func (pal *PCIAddressList) String() string {
-	if pal == nil {
-		return ""
-	}
-
+func (pal *PCIAddressSet) String() string {
 	return strings.Join(pal.Strings(), bdevPciAddrSep)
 }
 
-// Copy returns a copy of the PCIAddressList.
-func (pal *PCIAddressList) Copy() PCIAddressList {
-	if pal == nil {
-		return PCIAddressList{}
-	}
-
-	cpy := make(PCIAddressList, 0, pal.Len())
-
-	return append(cpy, *pal...)
-}
-
 // Len returns length of slice. Required by sort.Interface.
-func (pal *PCIAddressList) Len() int {
+func (pal *PCIAddressSet) Len() int {
 	if pal == nil {
 		return 0
 	}
 
-	return len(*pal)
+	return len(pal.addrMap)
 }
 
 func hexStr2Int(s string) int64 {
@@ -216,115 +228,54 @@ func hexStr2Int(s string) int64 {
 	return i
 }
 
-// Less returns true if elem i is "less" than elem j. Required by sort.Interface.
-func (pal *PCIAddressList) Less(i, j int) bool {
-	if pal == nil {
-		return false
-	}
-
-	al := *pal
-
-	fmv := hexStr2Int(al[i].Domain)
-	smv := hexStr2Int(al[j].Domain)
-
-	if fmv != smv {
-		return fmv < smv
-	}
-
-	fbv := hexStr2Int(al[i].Bus)
-	sbv := hexStr2Int(al[j].Bus)
-
-	if fbv != sbv {
-		return fbv < sbv
-	}
-
-	fdv := hexStr2Int(al[i].Device)
-	sdv := hexStr2Int(al[j].Device)
-
-	if fdv != sdv {
-		return fdv < sdv
-	}
-
-	ffv := hexStr2Int(al[i].Function)
-	sfv := hexStr2Int(al[j].Function)
-
-	return ffv < sfv
-}
-
-// Swap exchanges elements in underlying slice. Required by sort.Interface.
-func (pal *PCIAddressList) Swap(i, j int) {
-	if pal == nil {
-		return
-	}
-
-	al := *pal
-
-	al[i], al[j] = al[j], al[i]
-}
-
-// IsEmpty returns true if length of slice is zero.
-func (pal *PCIAddressList) IsEmpty() bool {
-	return pal == nil || pal.Len() == 0
-}
-
 // Intersect returns elements in 'this' AND input address lists.
-func (pal *PCIAddressList) Intersect(inList *PCIAddressList) *PCIAddressList {
-	if pal == nil || inList == nil {
-		return nil
-	}
-
-	intersection := PCIAddressList{}
+func (pal *PCIAddressSet) Intersect(in *PCIAddressSet) *PCIAddressSet {
+	intersection := &PCIAddressSet{}
 
 	// loop over the smaller set
-	if pal.Len() < inList.Len() {
-		for _, a := range *pal {
-			if inList.Contains(a) {
-				intersection.Add(*a)
+	if pal.Len() < in.Len() {
+		for _, a := range pal.Addresses() {
+			if in.Contains(a) {
+				intersection.Add(a)
 			}
 		}
 
-		return &intersection
+		return intersection
 	}
 
-	for _, a := range *inList {
+	for _, a := range in.Addresses() {
 		if pal.Contains(a) {
-			intersection.Add(*a)
+			intersection.Add(a)
 		}
 	}
 
-	return &intersection
+	return intersection
 }
 
 // Difference returns elements in 'this' list but NOT IN input address list.
-func (pal *PCIAddressList) Difference(inList *PCIAddressList) *PCIAddressList {
-	if pal == nil {
-		return nil
-	}
+func (pal *PCIAddressSet) Difference(in *PCIAddressSet) *PCIAddressSet {
+	difference := &PCIAddressSet{}
 
-	difference := PCIAddressList{}
-
-	for _, a := range *pal {
-		if !inList.Contains(a) {
-			difference.Add(*a)
+	for _, a := range pal.Addresses() {
+		if !in.Contains(a) {
+			difference.Add(a)
 		}
 	}
 
-	return &difference
+	return difference
 }
 
-// NewPCIAddressList takes a variable number of strings and attempts to create an address list.
-func NewPCIAddressList(addrs ...string) (*PCIAddressList, error) {
-	al := &PCIAddressList{}
+// NewPCIAddressSet takes a variable number of strings and attempts to create an address set.
+func NewPCIAddressSet(addrs ...string) (*PCIAddressSet, error) {
+	al := &PCIAddressSet{}
 	if err := al.AddStrings(addrs...); err != nil {
 		return nil, err
 	}
 
-	sort.Sort(al)
-
 	return al, nil
 }
 
-// NewPCIAddressListFromString takes a space-separated string and attempts to create an address list.
-func NewPCIAddressListFromString(addrs string) (*PCIAddressList, error) {
-	return NewPCIAddressList(strings.Split(addrs, bdevPciAddrSep)...)
+// NewPCIAddressSetFromString takes a space-separated string and attempts to create an address set.
+func NewPCIAddressSetFromString(addrs string) (*PCIAddressSet, error) {
+	return NewPCIAddressSet(strings.Split(addrs, bdevPciAddrSep)...)
 }

--- a/src/control/common/pci_utils_test.go
+++ b/src/control/common/pci_utils_test.go
@@ -63,7 +63,7 @@ func TestPCIUtils_NewPCIAddress(t *testing.T) {
 	}
 }
 
-func TestPCIUtils_NewPCIAddressList(t *testing.T) {
+func TestPCIUtils_NewPCIAddressSet(t *testing.T) {
 	for name, tc := range map[string]struct {
 		addrStrs    []string
 		expAddrStr  string
@@ -88,23 +88,23 @@ func TestPCIUtils_NewPCIAddressList(t *testing.T) {
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			addrList, err := NewPCIAddressList(tc.addrStrs...)
+			addrSet, err := NewPCIAddressSet(tc.addrStrs...)
 			CmpErr(t, tc.expErr, err)
 			if tc.expErr != nil {
 				return
 			}
 
-			if diff := cmp.Diff(tc.expAddrStr, addrList.String()); diff != "" {
-				t.Fatalf("unexpected result (-want, +got):\n%s\n", diff)
+			if diff := cmp.Diff(tc.expAddrStr, addrSet.String()); diff != "" {
+				t.Fatalf("unexpected string (-want, +got):\n%s\n", diff)
 			}
-			if diff := cmp.Diff(tc.expAddrStrs, addrList.Strings()); diff != "" {
-				t.Fatalf("unexpected result (-want, +got):\n%s\n", diff)
+			if diff := cmp.Diff(tc.expAddrStrs, addrSet.Strings()); diff != "" {
+				t.Fatalf("unexpected list (-want, +got):\n%s\n", diff)
 			}
 		})
 	}
 }
 
-func TestPCIUtils_PCIAddressList_Intersect(t *testing.T) {
+func TestPCIUtils_PCIAddressSet_Intersect(t *testing.T) {
 	for name, tc := range map[string]struct {
 		addrStrs          []string
 		intersectAddrStrs []string
@@ -124,17 +124,17 @@ func TestPCIUtils_PCIAddressList_Intersect(t *testing.T) {
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			addrList, err := NewPCIAddressList(tc.addrStrs...)
+			addrSet, err := NewPCIAddressSet(tc.addrStrs...)
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			intersectAddrList, err := NewPCIAddressList(tc.intersectAddrStrs...)
+			intersectAddrSet, err := NewPCIAddressSet(tc.intersectAddrStrs...)
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			intersection := addrList.Intersect(intersectAddrList)
+			intersection := addrSet.Intersect(intersectAddrSet)
 
 			if diff := cmp.Diff(tc.expAddrStrs, intersection.Strings()); diff != "" {
 				t.Fatalf("unexpected result (-want, +got):\n%s\n", diff)
@@ -143,7 +143,7 @@ func TestPCIUtils_PCIAddressList_Intersect(t *testing.T) {
 	}
 }
 
-func TestPCIUtils_PCIAddressList_Difference(t *testing.T) {
+func TestPCIUtils_PCIAddressSet_Difference(t *testing.T) {
 	for name, tc := range map[string]struct {
 		addrStrs           []string
 		differenceAddrStrs []string
@@ -163,17 +163,17 @@ func TestPCIUtils_PCIAddressList_Difference(t *testing.T) {
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			addrList, err := NewPCIAddressList(tc.addrStrs...)
+			addrSet, err := NewPCIAddressSet(tc.addrStrs...)
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			differenceAddrList, err := NewPCIAddressList(tc.differenceAddrStrs...)
+			differenceAddrSet, err := NewPCIAddressSet(tc.differenceAddrStrs...)
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			difference := addrList.Difference(differenceAddrList)
+			difference := addrSet.Difference(differenceAddrSet)
 
 			if diff := cmp.Diff(tc.expAddrStrs, difference.Strings()); diff != "" {
 				t.Fatalf("unexpected result (-want, +got):\n%s\n", diff)


### PR DESCRIPTION
      * Rename PCIAddressList -> PCIAddressSet, to better reflect
        the use/capabilities of the type
      * Make PCIAddressSet use a map as the core data structure, for
        automatic deduplication
      * Sort on demand when Addresses() is called
