### PR TITLE
DAOS-6654 debug: debug patch

### DIFF
--- a/src/bio/bio_buffer.c
+++ b/src/bio/bio_buffer.c
@@ -1063,6 +1063,10 @@ bio_iod_prep(struct bio_desc *biod, unsigned int type, void *bulk_ctxt,
 	}
 retry:
 	rc = iterate_biov(biod, arg ? bulk_map_one : dma_map_one, arg);
+	if (biod->bd_bulk_cnt > 10) {
+		D_WARN("IOD(%p) type:%d used many bulk hdls. %u/%u\n",
+		       biod, biod->bd_type, biod->bd_bulk_max, biod->bd_bulk_cnt);
+	}
 	if (rc) {
 		/*
 		 * To avoid deadlock, held buffers need be released


### PR DESCRIPTION
Print bulk count (when bulk count > 10) used by RPC.

Signed-off-by: Niu Yawei <yawei.niu@intel.com>