### PR TITLE
DAOS-8870 EC: select parity shard or first data shard as DTX leader

### DIFF
--- a/src/object/srv_ec_aggregate.c
+++ b/src/object/srv_ec_aggregate.c
@@ -2206,7 +2206,7 @@ agg_object(daos_handle_t ih, vos_iter_entry_t *entry,
 
 	rc = ds_pool_check_dtx_leader(info->api_pool, &entry->ie_oid,
 				      info->api_pool->sp_map_version, true);
-	if (rc == 1 && entry->ie_oid.id_shard >= oca.u.ec.e_k) {
+	if (rc == 1 && is_ec_parity_shard(entry->ie_oid.id_shard, &oca)) {
 		D_DEBUG(DB_EPC, "oid:"DF_UOID" ec agg starting\n",
 			DP_UOID(entry->ie_oid));
 

--- a/src/placement/pl_map.c
+++ b/src/placement/pl_map.c
@@ -592,6 +592,12 @@ pl_map_query(uuid_t po_uuid, struct pl_map_attr *attr)
 	return rc;
 }
 
+static bool
+shard_is_down(struct pl_obj_shard *shard)
+{
+	return (shard->po_shard == -1 || shard->po_target == -1);
+}
+
 /**
  * Select leader replica for the given object's shard.
  *
@@ -622,41 +628,38 @@ pl_select_leader(daos_obj_id_t oid, uint32_t grp_idx, uint32_t grp_size,
 	if (oc_attr->ca_resil != DAOS_RES_REPL) {
 		int tgt_nr = oc_attr->u.ec.e_k + oc_attr->u.ec.e_p;
 		int fail_cnt = 0;
-		int idx = grp_idx * grp_size + tgt_nr - 1;
-		bool parity_rebuilding = false;
+		int idx;
 		int leader_shard_idx;
 
-		/* For EC object, elect last shard in the group (must to be
-		 * a parity node) as leader.
+		/*
+		 * For EC obj, select data shard 0 or parity shard as leader. As those shards always
+		 * involved for every modification operation -
+		 * If shard 0 is healthy then select it as leader, or will select one parity shard.
+		 * If #failed_shards exceed #parity_shards, returns EIO.
 		 */
+		idx = grp_idx * grp_size;
 		shard = pl_get_shard(data, idx);
-		while (shard->po_rebuilding || shard->po_shard == -1 ||
-		       shard->po_target == -1) {
-			idx--;
-			if (shard->po_rebuilding)
-				parity_rebuilding = true;
-
+		if (shard->po_rebuilding || shard_is_down(shard)) {
 			fail_cnt++;
-			if (fail_cnt > oc_attr->u.ec.e_p) {
-				D_ERROR(DF_OID" fail_cnt %d, exceed e_p %d, "DF_RC"\n",
-					DP_OID(oid), fail_cnt, oc_attr->u.ec.e_p, DP_RC(-DER_IO));
-				return -DER_IO;
-			}
 
+			idx = grp_idx * grp_size + tgt_nr - 1;
 			shard = pl_get_shard(data, idx);
+			while (shard->po_rebuilding || shard_is_down(shard)) {
+				idx--;
+
+				fail_cnt++;
+				if (fail_cnt > oc_attr->u.ec.e_p) {
+					D_ERROR(DF_OID" fail_cnt %d, exceed e_p %d, "DF_RC"\n",
+						DP_OID(oid), fail_cnt, oc_attr->u.ec.e_p,
+						DP_RC(-DER_IO));
+					return -DER_IO;
+				}
+
+				shard = pl_get_shard(data, idx);
+			}
 		}
 
-		if (fail_cnt == oc_attr->u.ec.e_p) {
-			/* If parity is rebuilding, let's return DER_STALE,
-			 * so object I/O might refresh the pool map and layout
-			 * until parity rebuilt finish.
-			 */
-			if (parity_rebuilding)
-				return -DER_STALE;
-			else
-				return -DER_IO;
-		}
-
+		D_ASSERT(fail_cnt <= oc_attr->u.ec.e_p);
 		D_ASSERT(shard->po_target != -1);
 		D_ASSERT(shard->po_shard != -1);
 		D_ASSERT(!shard->po_rebuilding);


### PR DESCRIPTION
Current problem - if all parity shards are in rebuilding, then cannot
select a valid DTX leader for following update/punch, and the rebuild
possibly endless if the enumerate hit some un-committed record.
    
This patch fix that by change the DTX leader selection that select
parity shard or first data shard as DTX leader.

Signed-off-by: Xuezhao Liu <xuezhao.liu@intel.com>