### PR TITLE
DAOS-5857 test: Update the expected IL performance in IOR test. (#7001)

### DIFF
--- a/src/tests/ftest/ior/intercept_basic.py
+++ b/src/tests/ftest/ior/intercept_basic.py
@@ -47,11 +47,11 @@ class IorIntercept(IorTestBase):
         apis = self.params.get("ior_api", '/run/ior/iorflags/ssf/*')
         for api in apis:
             self.ior_cmd.api.update(api)
-            out = self.run_ior_with_pool(fail_on_warning=False)
+            out = self.run_ior_with_pool(fail_on_warning=True)
             without_intercept = IorCommand.get_ior_metrics(out)
             if api == "POSIX":
                 intercept = os.path.join(self.prefix, 'lib64', 'libioil.so')
-                out = self.run_ior_with_pool(intercept, fail_on_warning=False)
+                out = self.run_ior_with_pool(intercept, fail_on_warning=True)
                 with_intercept = IorCommand.get_ior_metrics(out)
                 max_mib = int(IorMetrics.Max_MiB)
                 min_mib = int(IorMetrics.Min_MiB)
@@ -72,7 +72,10 @@ class IorIntercept(IorTestBase):
                 # Verifying read performance
                 self.assertTrue(float(with_intercept[1][max_mib]) >
                                 read_x * float(without_intercept[1][max_mib]))
-                self.assertTrue(float(with_intercept[1][min_mib]) >
-                                read_x * float(without_intercept[1][min_mib]))
+                # DAOS-5857 There's a lot of volatility in this result, so disable it to reduce
+                # testing noise.  This test runs IOR with multiple iterations so it should only
+                # affect min results, mean and max results should be more resilient.
+                #self.assertTrue(float(with_intercept[1][min_mib]) >
+                #                read_x * float(without_intercept[1][min_mib]))
                 self.assertTrue(float(with_intercept[1][mean_mib]) >
                                 read_x * float(without_intercept[1][mean_mib]))

--- a/src/tests/ftest/ior/intercept_basic.yaml
+++ b/src/tests/ftest/ior/intercept_basic.yaml
@@ -27,26 +27,24 @@ ior:
     client_processes:
         np_16:
             np: 16
-    test_file: daos:testFile
-    repetitions: 1
-# Remove the below line once DAOS-3143 is resolved
-    dfs_destroy: False
+    test_file: testFile
+    repetitions: 5
     iorflags:
         ssf:
-          flags: "-v -D 300 -w -r"
+          flags: "-v -D 600 -w -r"
           ior_api:
             - DFS
             - POSIX
           transfersize_blocksize:
             1M:
               transfer_size: '1M'
-              block_size: '8G'
+              block_size: '2G'
               # Expected performance improvement
               # of write and read for the specific
               # transfer/block size when using
               # interception library.
-              write_x: 3
-              read_x: 2
+              write_x: 1.5
+              read_x: 1.5
           objectclass:
             oclass_SX:
               dfs_oclass: "SX"


### PR DESCRIPTION
Change the IOR intercept pass to be less susceptible to network issues.
Adjust the data size and stonewall time so that stonewall is not happening, meaning consistent
data sizes are used for comparison.
Fail the test if stonewalling does happen.
Run for 5 rather than one IOR iteration
Only perform the performance comparison on mean and max values, not min to prevent
slow network issue from failing the test, for the test to fail all iterations need to be slow.

This should allow the test to detect actual regressions, but not fail on intermittent issues
which often happen in CI due to the shared nature of the resource.

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>
Skip-func-hw-test: true
Skip-func-test: true
Quick-Functional: true
Test-tag: dfuse
Adding file src/tests/ftest/ior/intercept_basic.py
Adding file src/tests/ftest/ior/intercept_basic.yaml
