### PR TITLE
DAOS-8894 objects: return EIO for inflight reintegrate IO (#7120)

### DIFF
--- a/src/include/daos/placement.h
+++ b/src/include/daos/placement.h
@@ -61,7 +61,8 @@ struct pl_obj_shard {
 	uint32_t	po_shard;	/* shard index */
 	uint32_t	po_target;	/* target id */
 	uint32_t	po_fseq;	/* The latest failure sequence */
-	uint32_t	po_rebuilding:1; /* rebuilding status */
+	uint32_t	po_rebuilding:1, /* rebuilding status */
+			po_reintegrating:1; /* reintegrating status */
 };
 
 struct pl_obj_layout {

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -948,6 +948,12 @@ shard_open:
 			ec_degrade = true;
 			obj_shard_close(obj_shard);
 		}
+		if (obj_auxi->opc == DAOS_OBJ_RPC_UPDATE && obj_shard->do_reintegrating) {
+			D_ERROR(DF_OID" shard is being reintegrated: %d\n",
+				DP_OID(obj->cob_md.omd_id), -DER_IO);
+			obj_shard_close(obj_shard);
+			D_GOTO(out, rc = -DER_IO);
+		}
 	} else {
 		if (rc == -DER_NONEXIST) {
 			if (!obj_auxi->is_ec_obj) {

--- a/src/object/obj_internal.h
+++ b/src/object/obj_internal.h
@@ -66,6 +66,7 @@ struct dc_obj_shard {
 #define do_target_id	do_pl_shard.po_target
 #define do_fseq		do_pl_shard.po_fseq
 #define do_rebuilding	do_pl_shard.po_rebuilding
+#define do_reintegrating do_pl_shard.po_reintegrating
 
 /** client object layout */
 struct dc_obj_layout {

--- a/src/placement/pl_map_common.c
+++ b/src/placement/pl_map_common.c
@@ -465,6 +465,9 @@ pl_map_extend(struct pl_obj_layout *layout, d_list_t *extended_list)
 		new_shards[grp_idx].po_target = f_shard->fs_tgt_id;
 		if (f_shard->fs_status != PO_COMP_ST_DRAIN)
 			new_shards[grp_idx].po_rebuilding = 1;
+
+		if (f_shard->fs_status == PO_COMP_ST_UP)
+			new_shards[grp_idx].po_reintegrating = 1;
 	}
 
 	layout->ol_grp_size += max_fail_grp;


### PR DESCRIPTION
Since we do not allow inflight I/O for reintegrating shard,
so let's return EIO for such update until online reintegration
is supported.

Signed-off-by: Di Wang <di.wang@intel.com>