### PR TITLE
CORCI-1133 test: Use the ior-hpc package for test

### DIFF
--- a/ci/functional/required_packages.sh
+++ b/ci/functional/required_packages.sh
@@ -21,17 +21,17 @@ elif [[ $distro = el* ]] || [[ $distro = centos* ]] ||
         openmpi="openmpi3"
     fi
 
-    pkgs="$prefix ndctl                \
-          fio patchutils ior           \
-          romio-tests                  \
-          testmpio                     \
-          python$pyver-mpi4py-tests    \
-          hdf5-mpich-tests             \
-          hdf5-$openmpi-tests          \
-          hdf5-vol-daos-$openmpi-tests \
-          hdf5-vol-daos-mpich-tests    \
-          MACSio-mpich                 \
-          MACSio-$openmpi              \
+    pkgs="$prefix ndctl fio patchutils   \
+          ior-hpc-daos-${client_ver}     \
+          romio-tests-daos-${client_ver} \
+          testmpio                       \
+          python$pyver-mpi4py-tests      \
+          hdf5-mpich-tests               \
+          hdf5-$openmpi-tests            \
+          hdf5-vol-daos-$openmpi-tests   \
+          hdf5-vol-daos-mpich-tests      \
+          MACSio-mpich                   \
+          MACSio-$openmpi                \
           mpifileutils-mpich"
 else
     echo "I don't know which packages should be installed for distro"


### PR DESCRIPTION
Rather than the ior package, as we wtill want to build from upstream
master rather than building from upstream releases.