### PR TITLE
DAOS-8618 tests: Re-enable cart_ctl add_log_msg line

### DIFF
--- a/src/cart/utils/crt_utils.c
+++ b/src/cart/utils/crt_utils.c
@@ -189,14 +189,23 @@ crtu_sync_timedwait(struct wfr_status *wfrs, int sec, int line_number)
 	int		rc;
 
 	rc = clock_gettime(CLOCK_REALTIME, &deadline);
-	D_ASSERTF(rc == 0, "clock_gettime() failed at line %d rc: %d\n",
-		  line_number, rc);
+	if (opts.assert_on_error) {
+		D_ASSERTF(rc == 0, "clock_gettime() failed at line %d "
+			  "rc: %d\n",
+			  line_number, rc);
+	} else {
+		wfrs->rc = rc;
+	}
 
 	deadline.tv_sec += sec;
 
 	rc = sem_timedwait(&wfrs->sem, &deadline);
-	D_ASSERTF(rc == 0, "Sync timed out at line %d rc: %d\n",
-		  line_number, rc);
+	if (opts.assert_on_error) {
+		D_ASSERTF(rc == 0, "Sync timed out at line %d rc: %d\n",
+			  line_number, rc);
+	} else {
+		wfrs->rc = rc;
+	}
 }
 
 int
@@ -410,6 +419,11 @@ crtu_dc_mgmt_net_cfg_setenv(const char *name)
 				&crt_net_cfg_resp);
 	if (opts.assert_on_error)
 		D_ASSERTF(rc == 0, "dc_get_attach_info() failed, rc=%d\n", rc);
+
+	if (rc != 0) {
+		D_ERROR("dc_get_attach_info() failed, rc=%d\n", rc);
+		D_GOTO(cleanup, rc = d_errno2der(errno));
+	}
 
 	/* These two are always set */
 	rc = setenv("CRT_PHY_ADDR_STR", crt_net_cfg_info.provider, 1);

--- a/src/tests/ftest/network/zero_config.py
+++ b/src/tests/ftest/network/zero_config.py
@@ -241,7 +241,6 @@ class ZeroConfigTest(TestWithServers):
                 "access_points": self.access_points}
         }
         self.start_agents(agent_groups)
-        self.write_string_to_logfile('"Test.name: ' + str(self) + '"')
         self.log.info("-" * 100)
 
         # Verify

--- a/src/tests/ftest/osa/dmg_negative_test.yaml
+++ b/src/tests/ftest/osa/dmg_negative_test.yaml
@@ -12,6 +12,7 @@ extra_servers:
   test_servers:
     - server-C
 timeout: 1000
+skip_add_log_msg: True
 server_config:
   name: daos_server
   engines_per_host: 2

--- a/src/tests/ftest/osa/offline_drain.yaml
+++ b/src/tests/ftest/osa/offline_drain.yaml
@@ -10,6 +10,7 @@ hosts:
 timeout: 1800
 setup:
   start_servers_once: False
+skip_add_log_msg: True
 server_config:
   name: daos_server
   engines_per_host: 2

--- a/src/tests/ftest/osa/offline_extend.yaml
+++ b/src/tests/ftest/osa/offline_extend.yaml
@@ -11,6 +11,7 @@ extra_servers:
 timeout: 1100
 setup:
   start_servers_once: False
+skip_add_log_msg: True
 server_config:
   name: daos_server
   engines_per_host: 2

--- a/src/tests/ftest/osa/offline_parallel_test.yaml
+++ b/src/tests/ftest/osa/offline_parallel_test.yaml
@@ -12,6 +12,7 @@ extra_servers:
 timeout: 700
 setup:
   start_servers_once: False
+skip_add_log_msg: True
 server_config:
   name: daos_server
   engines_per_host: 2

--- a/src/tests/ftest/osa/offline_reintegration.yaml
+++ b/src/tests/ftest/osa/offline_reintegration.yaml
@@ -10,6 +10,7 @@ timeouts:
   test_osa_offline_reintegrate_with_less_pool_space: 1300
 setup:
   start_servers_once: False
+skip_add_log_msg: True
 server_config:
   name: daos_server
   engines_per_host: 2

--- a/src/tests/ftest/osa/online_drain.yaml
+++ b/src/tests/ftest/osa/online_drain.yaml
@@ -11,6 +11,7 @@ timeout: 1000
 job_manager_timeout: 300
 setup:
   start_servers_once: False
+skip_add_log_msg: True
 server_config:
   name: daos_server
   engines_per_host: 2

--- a/src/tests/ftest/osa/online_extend.yaml
+++ b/src/tests/ftest/osa/online_extend.yaml
@@ -15,6 +15,7 @@ timeout: 1000
 job_manager_timeout: 330
 setup:
   start_servers_once: False
+skip_add_log_msg: True
 server_config:
   name: daos_server
   engines_per_host: 2

--- a/src/tests/ftest/osa/online_parallel_test.yaml
+++ b/src/tests/ftest/osa/online_parallel_test.yaml
@@ -7,6 +7,7 @@ hosts:
     - client-D
 timeout: 1110
 job_manager_timeout: 400
+skip_add_log_msg: True
 server_config:
   name: daos_server
   engines_per_host: 2

--- a/src/tests/ftest/osa/online_reintegration.yaml
+++ b/src/tests/ftest/osa/online_reintegration.yaml
@@ -9,6 +9,7 @@ timeout: 1110
 job_manager_timeout: 300
 setup:
   start_servers_once: False
+skip_add_log_msg: True
 server_config:
   name: daos_server
   engines_per_host: 2

--- a/src/tests/ftest/util/apricot/apricot/test.py
+++ b/src/tests/ftest/util/apricot/apricot/test.py
@@ -676,8 +676,11 @@ class TestWithServers(TestWithoutServers):
         if self.setup_start_agents:
             self.start_agents(force=force_agent_start)
 
+        self.skip_add_log_msg = self.params.get("skip_add_log_msg", "/run/*", False)
+
         # If there's no server started, then there's no server log to write to.
-        if self.setup_start_servers:
+        if (self.setup_start_servers and self.setup_start_agents and
+            not self.skip_add_log_msg):
             # Write an ID string to the log file for cross-referencing logs
             # with test ID
             id_str = '"Test.name: ' + str(self) + '"'
@@ -732,7 +735,7 @@ class TestWithServers(TestWithoutServers):
 
             for manager in self.agent_managers:
                 cart_ctl.group_name.value = manager.get_config_value("name")
-                # cart_ctl.run()
+                cart_ctl.run()
         else:
             self.log.info(
                 "Unable to write message to the server log: %d servers groups "


### PR DESCRIPTION
[Old PR](https://github.com/daos-stack/daos/pull/6812/files): emallovx_DAOS-8618_zero_config__cart_ctl__free_unpacked
New PR: emallovx_DAOS-8618_zero_config__cart_ctl__free_unpacked-2

Allow-unstable: true

Signed-off-by: Ethan Mallove <ethanx.a.mallove@intel.com>