### PR TITLE
DAOS-8930 vea: various frag flushing fixes (#7171)

### DIFF
--- a/src/include/daos_srv/vea.h
+++ b/src/include/daos_srv/vea.h
@@ -301,11 +301,14 @@ int vea_query(struct vea_space_info *vsi, struct vea_attr *attr,
 	      struct vea_stat *stat);
 
 /**
- * Pause or resume flushing the free extents in aging buffer
+ * Flushing the free frags in aging buffer
  *
  * \param vsi       [IN]	In-memory compound index
- * \param plug      [IN]	Plug or unplug
+ * \param force     [IN]	Force flush all frags no matter if they are expired
+ *
+ * \return			0:	Nothing to be flushed;
+ *				1:	Some Frags need be flushed;
  */
-void vea_flush(struct vea_space_info *vsi, bool plug);
+int vea_flush(struct vea_space_info *vsi, bool force);
 
 #endif /* __VEA_API_H__ */

--- a/src/include/daos_srv/vos.h
+++ b/src/include/daos_srv/vos.h
@@ -1091,14 +1091,6 @@ vos_pool_get_scm_cutoff(void);
 enum vos_pool_opc {
 	/** Reset pool GC statistics */
 	VOS_PO_CTL_RESET_GC,
-	/**
-	 * Pause flushing the free extents in aging buffer. This is usually
-	 * called before container destroy where huge amount of extents could
-	 * be freed in a short period of time.
-	 */
-	VOS_PO_CTL_VEA_PLUG,
-	/** Pairing with PLUG, usually called after container destroy done. */
-	VOS_PO_CTL_VEA_UNPLUG,
 };
 
 /**

--- a/src/pool/srv_target.c
+++ b/src/pool/srv_target.c
@@ -104,7 +104,10 @@ gc_ult(void *arg)
 			break;
 
 		/* It'll be woke up by container destroy or aggregation */
-		sched_req_sleep(child->spc_gc_req, 10ULL * 1000);
+		if (rc > 0)
+			sched_req_yield(child->spc_gc_req);
+		else
+			sched_req_sleep(child->spc_gc_req, 10UL * 1000);
 	}
 
 out:

--- a/src/vea/tests/vea_ut.c
+++ b/src/vea/tests/vea_ut.c
@@ -361,7 +361,7 @@ ut_free(void **state)
 	vea_dump(args->vua_vsi, false);
 
 	/* call vea_flush to trigger free extents migration */
-	vea_flush(args->vua_vsi, false);
+	vea_flush(args->vua_vsi, true);
 
 	r_list = &args->vua_alloc_list;
 	d_list_for_each_entry(ext, r_list, vre_link) {

--- a/src/vea/vea_free.c
+++ b/src/vea/vea_free.c
@@ -392,6 +392,8 @@ struct vea_unmap_extent {
 	d_list_t		vue_link;
 };
 
+#define MAX_FLUSH_FRAGS	2000
+
 void
 migrate_end_cb(void *data, bool noop)
 {
@@ -401,7 +403,7 @@ migrate_end_cb(void *data, bool noop)
 	struct vea_unmap_extent	*vue, *tmp_vue;
 	d_list_t		 unmap_list;
 	uint64_t		 cur_time = 0;
-	int			 rc;
+	int			 rc, frags = 0;
 
 	if (noop)
 		return;
@@ -429,6 +431,8 @@ migrate_end_cb(void *data, bool noop)
 
 		/* Remove entry from aggregate LRU list */
 		d_list_del_init(&entry->ve_link);
+		frags++;
+
 		/*
 		 * Remove entry from aggregate tree, entry will be freed on
 		 * deletion.
@@ -466,6 +470,8 @@ migrate_end_cb(void *data, bool noop)
 				break;
 			}
 		}
+		if (frags >= MAX_FLUSH_FRAGS)
+			break;
 	}
 
 	/* Update aggregation time before yield */

--- a/src/vos/vos_gc.c
+++ b/src/vos/vos_gc.c
@@ -1088,18 +1088,17 @@ vos_gc_pool(daos_handle_t poh, int credits, bool (*yield_func)(void *arg),
 {
 	struct vos_pool	*pool = vos_hdl2pool(poh);
 	struct vos_tls	*tls  = vos_tls_get();
-	int		 rc, total = 0;
+	int		 rc = 0, total = 0;
 
 	D_ASSERT(daos_handle_is_valid(poh));
-	if (!gc_have_pool(pool))
-		return 0; /* nothing to reclaim for this pool */
+
+	if (!gc_have_pool(pool)) {
+		if (pool->vp_vea_info != NULL)
+			rc = vea_flush(pool->vp_vea_info, true);
+		return rc;
+	}
 
 	tls->vtl_gc_running++;
-	/*
-	 * Pause flushing free extents in VEA aging buffer, otherwise,
-	 * there'll be way more fragments to be processed.
-	 */
-	vos_pool_ctl(poh, VOS_PO_CTL_VEA_PLUG);
 
 	while (1) {
 		int	creds = GC_CREDS_PRIV;
@@ -1122,13 +1121,12 @@ vos_gc_pool(daos_handle_t poh, int credits, bool (*yield_func)(void *arg),
 
 		if (vos_gc_yield(yield_func, yield_arg)) {
 			D_DEBUG(DB_TRACE, "GC pool run aborted\n");
-			rc = 1;
 			break;
 		}
 	}
 
-	/* Unplug and make the freed extents available immediately. */
-	vos_pool_ctl(poh, VOS_PO_CTL_VEA_UNPLUG);
+	if (pool->vp_vea_info != NULL)
+		rc = vea_flush(pool->vp_vea_info, false);
 
 	if (total != 0) /* did something */
 		D_DEBUG(DB_TRACE, "GC consumed %d credits\n", total);

--- a/src/vos/vos_pool.c
+++ b/src/vos/vos_pool.c
@@ -983,14 +983,6 @@ vos_pool_ctl(daos_handle_t poh, enum vos_pool_opc opc)
 	case VOS_PO_CTL_RESET_GC:
 		memset(&pool->vp_gc_stat, 0, sizeof(pool->vp_gc_stat));
 		break;
-	case VOS_PO_CTL_VEA_PLUG:
-		if (pool->vp_vea_info != NULL)
-			vea_flush(pool->vp_vea_info, true);
-		break;
-	case VOS_PO_CTL_VEA_UNPLUG:
-		if (pool->vp_vea_info != NULL)
-			vea_flush(pool->vp_vea_info, false);
-		break;
 	}
 
 	return 0;


### PR DESCRIPTION
- Get rid of VEA 'plug' operation. The 'plug' operation was introduced
  for improving space reclaiming speed on container destroy, however,
  it could result in too many frags stays in aging buffer for too long
  time.

- Explicitly call vea_flush() in GC ULT, and don't sleep if there are
  frags to be flushed.

- Add back flush triggering on reserve, otherwise, too many aging
  frags could be accumulated in aging buffer.

- Restrict the number of frags on each flush to avoid hogging CPU for
  too long.

Signed-off-by: Niu Yawei <yawei.niu@intel.com>