### PR TITLE
DAOS-8825 pool: stop gc ULT when all ops ULTs are gone (#7021)

### DIFF
--- a/src/pool/srv_target.c
+++ b/src/pool/srv_target.c
@@ -279,7 +279,6 @@ pool_child_delete_one(void *uuid)
 
 	d_list_del_init(&child->spc_list);
 	ds_cont_child_stop_all(child);
-	stop_gc_ult(child);
 	ds_stop_scrubbing_ult(child);
 	ds_pool_child_put(child); /* -1 for the list */
 
@@ -290,6 +289,10 @@ pool_child_delete_one(void *uuid)
 		return dss_abterr2der(rc);
 
 	ABT_eventual_free(&child->spc_ref_eventual);
+
+	/* only stop gc ULT when all ops ULTs are done */
+	stop_gc_ult(child);
+
 	/* ds_pool_child must be freed here to keep
 	 * spc_ref_enventual usage safe
 	 */


### PR DESCRIPTION
Do not stop gc ULT thread before all workers ULTs running
on ds_pool_child have completed, because some of them, like
container_aggregate, can be late and need to schedule gc ULT.
This patch is a follow-on to DAOS-8546/PR-6079, where it is
ensured to wait for all late workers ULTs to be done prior
terminating ds_pool_child.

Since it has no interaction with internal/ops ULTs, to
be stopped, scrubbing ULT do not need to wait for them
to be gone, unlike GC ULT.

Signed-off-by: Bruno Faccini <bruno.faccini@intel.com>