### PR TITLE
DAOS-9024 control: Increase SystemStop timeout to 60s

### DIFF
--- a/src/control/lib/control/rpc.go
+++ b/src/control/lib/control/rpc.go
@@ -260,6 +260,8 @@ func (c *Client) InvokeUnaryRPCAsync(parent context.Context, req UnaryRequest) (
 		ctx, cancel := setDeadlineIfUnset(parent, req)
 		defer cancel()
 
+		// Record the start time of this attempt.
+		reqStartTime := time.Now()
 		var wg sync.WaitGroup
 		for _, host := range hosts {
 			wg.Add(1)
@@ -271,6 +273,9 @@ func (c *Client) InvokeUnaryRPCAsync(parent context.Context, req UnaryRequest) (
 					conn, err = grpc.DialContext(ctx, hostAddr, opts...)
 					if err == nil {
 						msg, err = req.getRPC()(ctx, conn)
+						if err == nil {
+							c.Debugf("%T/%s/%s", req, hostAddr, time.Since(reqStartTime))
+						}
 						conn.Close()
 					}
 				}
@@ -312,6 +317,9 @@ func invokeUnaryRPC(parentCtx context.Context, log debugLogger, c UnaryInvoker, 
 	reqCtx, cancel := setDeadlineIfUnset(parentCtx, req)
 	defer cancel()
 
+	// Record the start time of the request (all attempts).
+	reqStartTime := time.Now()
+
 	// For non-MS requests, just keep things simple. Fan-out, fan-in,
 	// no retries possible.
 	if !req.isMSRequest() {
@@ -324,6 +332,7 @@ func invokeUnaryRPC(parentCtx context.Context, log debugLogger, c UnaryInvoker, 
 		if err := gatherResponses(reqCtx, respChan, ur); err != nil {
 			return nil, wrapReqTimeout(req, err)
 		}
+		c.Debugf("%T/%s", req, time.Since(reqStartTime))
 		return ur, nil
 	}
 
@@ -476,6 +485,7 @@ func invokeUnaryRPC(parentCtx context.Context, log debugLogger, c UnaryInvoker, 
 			}
 
 			// Otherwise, we're finished trying.
+			c.Debugf("%T/%s", req, time.Since(reqStartTime))
 			return ur, nil
 		}
 

--- a/src/control/lib/control/system.go
+++ b/src/control/lib/control/system.go
@@ -38,6 +38,8 @@ const (
 	// SystemJoinRetryTimeout defines the amount of time a retry attempt can take. It
 	// should be set low in order to ensure that individual join attempts retry quickly.
 	SystemJoinRetryTimeout = 10 * time.Second
+	// SystemStopTimeout defines the amount of time a system stop attempt can take.
+	SystemStopTimeout = 1 * time.Minute
 )
 
 var (
@@ -396,6 +398,7 @@ func SystemStop(ctx context.Context, rpcClient UnaryInvoker, req *SystemStopReq)
 	req.setRPC(func(ctx context.Context, conn *grpc.ClientConn) (proto.Message, error) {
 		return mgmtpb.NewMgmtSvcClient(conn).SystemStop(ctx, pbReq)
 	})
+	req.SetTimeout(SystemStopTimeout)
 	rpcClient.Debugf("DAOS system stop request: %+v", req)
 
 	ur, err := rpcClient.InvokeUnaryRPC(ctx, req)


### PR DESCRIPTION
Double the timeout to see if it has any effect on test failures
due to RPC timeout. Testing the theory that graceful rank stops
may sometimes legitimately take longer than 30s.

Test-tag: pr cascading

Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com>
