### PR TITLE
DAOS-8916 client: Fix potential OFI interface/domain mismatch (#7183)

### DIFF
--- a/src/mgmt/cli_mgmt.c
+++ b/src/mgmt/cli_mgmt.c
@@ -380,22 +380,29 @@ int dc_mgmt_net_cfg(const char *name)
 	}
 
 	ofi_interface = getenv("OFI_INTERFACE");
+	ofi_domain = getenv("OFI_DOMAIN");
 	if (!ofi_interface) {
 		rc = setenv("OFI_INTERFACE", info.interface, 1);
 		if (rc != 0)
 			D_GOTO(cleanup, rc = d_errno2der(errno));
-	} else {
-		D_INFO("Using client provided OFI_INTERFACE: %s\n",
-			ofi_interface);
-	}
 
-	ofi_domain = getenv("OFI_DOMAIN");
-	if (!ofi_domain) {
+		/*
+		 * If we use the agent as the source, client env shouldn't be allowed to override
+		 * the domain. Otherwise we could get a mismatch between interface and domain.
+		 */
+		if (ofi_domain)
+			D_WARN("Ignoring OFI_DOMAIN '%s' because OFI_INTERFACE is not set; using "
+			       "automatic configuration instead\n", ofi_domain);
+
 		rc = setenv("OFI_DOMAIN", info.domain, 1);
 		if (rc != 0)
 			D_GOTO(cleanup, rc = d_errno2der(errno));
 	} else {
-		D_INFO("Using client provided OFI_DOMAIN: %s\n", ofi_domain);
+		D_INFO("Using client provided OFI_INTERFACE: %s\n", ofi_interface);
+
+		/* If the client env didn't provide a domain, we can assume we don't need one. */
+		if (ofi_domain)
+			D_INFO("Using client provided OFI_DOMAIN: %s\n", ofi_domain);
 	}
 
 	D_DEBUG(DB_MGMT,

--- a/src/tests/ftest/util/server_utils_params.py
+++ b/src/tests/ftest/util/server_utils_params.py
@@ -335,7 +335,7 @@ class DaosServerYamlParameters(YamlParameters):
             super().__init__(namespace)
 
             # Use environment variables to get default parameters
-            default_interface = os.environ.get("OFI_INTERFACE", "eth0")
+            default_interface = os.environ.get("DAOS_TEST_FABRIC_IFACE", "eth0")
             default_port = int(os.environ.get("OFI_PORT", 31416))
             default_share_addr = int(os.environ.get("CRT_CTX_SHARE_ADDR", 0))
             default_provider = os.environ.get("CRT_PHY_ADDR_STR", "ofi+sockets")


### PR DESCRIPTION
The network interface and domain must be acquired from the same
source, either the agent automatic config, or the OFI_INTERFACE
and OFI_DOMAIN environment variables.

Replace the use of OFI_INTERFACE to provide a default fabric_iface value
to the server config with a new DAOS_TEST_FABRIC_IFACE environment
variable.  Launch.py will still use any existing OFI_INTERFACE value but
will no longer set the env.  In CI this will allow the launch node to
run without OFI_INTERFACE beign set.

Co-authored-by: Phillip Henderson <phillip.henderson@intel.com>
Signed-off-by: Kris Jacque <kristin.jacque@intel.com>