### PR TITLE
DAOS-8961 obj: fix a bug in EC degraded update (#7212)

### DIFF
--- a/src/include/daos/common.h
+++ b/src/include/daos/common.h
@@ -727,10 +727,10 @@ enum {
 /** This fault simulates corruption on disk. Must be set on server side. */
 #define DAOS_CSUM_CORRUPT_DISK		(DAOS_FAIL_UNIT_TEST_GROUP_LOC | 0x26)
 /**
- * This fault simulates shard fetch failure. Can be used to test EC degraded
- * fetch.
+ * This fault simulates shard open failure. Can be used to test EC degraded
+ * update/fetch.
  */
-#define DAOS_FAIL_SHARD_FETCH		(DAOS_FAIL_UNIT_TEST_GROUP_LOC | 0x27)
+#define DAOS_FAIL_SHARD_OPEN		(DAOS_FAIL_UNIT_TEST_GROUP_LOC | 0x27)
 /**
  * This fault simulates the EC aggregation boundary (agg_eph_boundry) moved
  * ahead, in that case need to redo the degraded fetch.

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -934,9 +934,8 @@ obj_shard_tgts_query(struct dc_object *obj, uint32_t map_ver, uint32_t shard,
 	}
 shard_open:
 	rc = obj_shard_open(obj, shard, map_ver, &obj_shard);
-	if (obj_auxi->opc == DAOS_OBJ_RPC_FETCH &&
-	    DAOS_FAIL_CHECK(DAOS_FAIL_SHARD_FETCH) &&
-	    daos_shard_in_fail_value(shard + 1)) {
+	if (unlikely(DAOS_FAIL_CHECK(DAOS_FAIL_SHARD_OPEN) &&
+		     daos_shard_in_fail_value(shard + 1))) {
 		rc = -DER_NONEXIST;
 		D_ERROR("obj_shard_open failed on shard %d, "DF_RC"\n",
 			shard, DP_RC(rc));
@@ -1171,7 +1170,8 @@ obj_shards_2_fwtgts(struct dc_object *obj, uint32_t map_ver, uint8_t *bit_map,
 					 * OSA case, will handle it via internal
 					 * transaction.
 					 */
-					if (tmp->st_tgt_id != last->st_tgt_id)
+					if (tmp->st_rank == DAOS_TGT_IGNORE ||
+					    tmp->st_tgt_id != last->st_tgt_id)
 						continue;
 
 					D_DEBUG(DB_IO, "Modify obj "DF_OID

--- a/src/object/srv_ec.c
+++ b/src/object/srv_ec.c
@@ -122,6 +122,8 @@ obj_ec_rw_req_split(daos_unit_oid_t oid, struct obj_iod_array *iod_array,
 			if (tgt_max_idx < tgt_idx)
 				tgt_max_idx = tgt_idx;
 		} else {
+			if (tgts[i].st_rank == DAOS_TGT_IGNORE)
+				continue;
 			D_ASSERT(tgts[i].st_shard >= start_shard);
 			tgt_idx = tgts[i].st_shard - start_shard;
 			D_ASSERT(tgt_idx <= tgt_max_idx);

--- a/src/tests/suite/daos_aggregate_ec.c
+++ b/src/tests/suite/daos_aggregate_ec.c
@@ -918,7 +918,7 @@ re_test:
 	assert_rc_equal(rc, 0);
 
 	fail_val = daos_shard_fail_value(&fail_shard, 1);
-	daos_fail_loc_set(DAOS_FAIL_SHARD_FETCH | DAOS_FAIL_ONCE);
+	daos_fail_loc_set(DAOS_FAIL_SHARD_OPEN | DAOS_FAIL_ONCE);
 	daos_fail_value_set(fail_val);
 	d_iov_set(&sg_iov, rbuf, ss);
 	rc = daos_obj_fetch(ctx.oh, th, 0, &dkey, 1, &iod, &sgl,

--- a/src/tests/suite/daos_epoch_io.c
+++ b/src/tests/suite/daos_epoch_io.c
@@ -1260,8 +1260,7 @@ cmd_line_parse(test_arg_t *arg, const char *cmd_line,
 					      shard[i]);
 			}
 			fail_val = daos_shard_fail_value(shard, argc - 2);
-			arg->fail_loc = DAOS_FAIL_SHARD_FETCH |
-					DAOS_FAIL_ALWAYS;
+			arg->fail_loc = DAOS_FAIL_SHARD_OPEN | DAOS_FAIL_ALWAYS;
 			arg->fail_value = fail_val;
 		} else if (strcmp(argv[1], "clear") == 0) {
 			arg->fail_loc = 0;

--- a/src/tests/suite/daos_iotest.h
+++ b/src/tests/suite/daos_iotest.h
@@ -95,6 +95,11 @@ insert_recxs(const char *dkey, const char *akey, daos_size_t iod_size,
 	     daos_size_t data_size, struct ioreq *req);
 
 void
+inset_recxs_dkey_uint64(uint64_t *dkey, const char *akey, daos_size_t iod_size,
+	     daos_handle_t th, daos_recx_t *recxs, int nr, void *data,
+	     daos_size_t data_size, struct ioreq *req);
+
+void
 lookup(const char *dkey, int nr, const char **akey, uint64_t *idx,
 	daos_size_t *iod_size, void **val, daos_size_t *data_size,
 	daos_handle_t th, struct ioreq *req, bool empty);

--- a/src/tests/suite/daos_obj.c
+++ b/src/tests/suite/daos_obj.c
@@ -325,6 +325,31 @@ insert_recxs(const char *dkey, const char *akey, daos_size_t iod_size,
 }
 
 void
+inset_recxs_dkey_uint64(uint64_t *dkey, const char *akey, daos_size_t iod_size,
+	     daos_handle_t th, daos_recx_t *recxs, int nr, void *data,
+	     daos_size_t data_size, struct ioreq *req)
+{
+	assert_in_range(nr, 1, IOREQ_IOD_NR);
+
+	/* dkey */
+	d_iov_set(&req->dkey, (void *)dkey, sizeof(uint64_t));
+
+	/* akey */
+	ioreq_io_akey_set(req, &akey, 1);
+
+	/* set sgl */
+	if (data != NULL)
+		ioreq_sgl_simple_set(req, &data, &data_size, 1);
+
+	/* iod, recxs */
+	ioreq_iod_recxs_set(req, 0, iod_size, recxs, nr);
+
+	insert_internal_nowait(&req->dkey, 1, req->sgl, req->iod, th, req, 0);
+
+	insert_wait(req);
+}
+
+void
 punch_obj(daos_handle_t th, struct ioreq *req)
 {
 	int rc;

--- a/src/tests/suite/daos_rebuild_ec.c
+++ b/src/tests/suite/daos_rebuild_ec.c
@@ -206,7 +206,7 @@ rebuild_ec_multi_stripes(void **state)
 	fail_shards[0] = 2;
 	fail_shards[1] = 1;
 	daos_fail_value_set(daos_shard_fail_value(fail_shards, 2));
-	daos_fail_loc_set(DAOS_FAIL_SHARD_FETCH | DAOS_FAIL_ALWAYS);
+	daos_fail_loc_set(DAOS_FAIL_SHARD_OPEN | DAOS_FAIL_ALWAYS);
 	for (i = 0; i < TEST_STRIPE_NR; i++) {
 		start = i * 4 * CELL_SIZE;
 		recxs[i * 2].rx_idx = start;


### PR DESCRIPTION
The problem is in detailed handing in EC degraded update.
1) fix an assertion in obj_ec_rw_req_split()
   Assertion 'tgts[i].st_shard >= start_shard' failed
2) small refine in obj_shards_2_fwtgts()
3) add test case to reproduce/verify the problem.

Signed-off-by: Xuezhao Liu <xuezhao.liu@intel.com>