### PR TITLE
DAOS-8832 IV: missing iv_ns_put

### DIFF
--- a/src/engine/server_iv.c
+++ b/src/engine/server_iv.c
@@ -195,6 +195,7 @@ iv_ns_lookup_by_ivns(crt_iv_namespace_t ivns, struct ds_iv_ns **p_ns)
 		if (ns->iv_stop) {
 			D_DEBUG(DB_MD, DF_UUID" stopping\n",
 				DP_UUID(ns->iv_pool_uuid));
+			*p_ns = ns;
 			return -DER_SHUTDOWN;
 		}
 		ds_iv_ns_get(ns);
@@ -627,8 +628,11 @@ ivc_on_put(crt_iv_namespace_t ivns, d_sg_list_t *iv_value, void *priv)
 	int			 rc;
 
 	rc = iv_ns_lookup_by_ivns(ivns, &ns);
-	if (rc != 0)
+	if (rc != 0) {
+		if (ns != NULL)
+			ds_iv_ns_put(ns); /* balance ivc_on_get */
 		return rc;
+	}
 	D_ASSERT(ns != NULL);
 
 	D_ASSERT(priv_entry != NULL);


### PR DESCRIPTION
Even though iv_ns_lookup is failed due to IV stop,
iv_ns_put is still needed to balance the get in
ivc_on_get().

Signed-off-by: Di Wang <di.wang@intel.com>