### PR TITLE
DAOS-7878 vos: Forward compatible durable format change

### DIFF
--- a/src/include/daos_srv/vos_types.h
+++ b/src/include/daos_srv/vos_types.h
@@ -328,8 +328,10 @@ enum {
 	VOS_IT_CLEANUP_DTX	= (1 << 7),
 	/** Cleanup stale DTX entry. */
 	VOS_IT_FOR_DISCARD	= (1 << 8),
+	/** Entry is not committed */
+	VOS_IT_UNCOMMITTED	= (1 << 9),
 	/** Mask for all flags */
-	VOS_IT_MASK		= (1 << 9) - 1,
+	VOS_IT_MASK		= (1 << 10) - 1,
 };
 
 /**

--- a/src/vos/vos_internal.h
+++ b/src/vos/vos_internal.h
@@ -787,6 +787,7 @@ struct vos_iterator {
 				 it_for_discard:1,
 				 it_for_migration:1,
 				 it_cleanup_stale_dtx:1,
+				 it_show_uncommitted:1,
 				 it_ignore_uncommitted:1;
 };
 
@@ -980,7 +981,7 @@ key_tree_release(daos_handle_t toh, bool is_array);
 int
 key_tree_punch(struct vos_object *obj, daos_handle_t toh, daos_epoch_t epoch,
 	       daos_epoch_t bound, d_iov_t *key_iov, d_iov_t *val_iov,
-	       uint64_t flags, struct vos_ts_set *ts_set,
+	       uint64_t flags, struct vos_ts_set *ts_set, umem_off_t *known_key,
 	       struct vos_ilog_info *parent, struct vos_ilog_info *info);
 int
 key_tree_delete(struct vos_object *obj, daos_handle_t toh, d_iov_t *key_iov);
@@ -1116,15 +1117,16 @@ D_CASSERT((VOS_IT_KEY_TREE & VOS_IT_MASK) == 0);
  *  \param toh[IN]			Open key tree handle
  *  \param type[IN]			Iterator type (VOS_ITER_AKEY/DKEY only)
  *  \param epr[IN]			Valid epoch range for iteration
- *  \param ignore_inprogress[IN]	Fail if there are uncommitted entries
+ *  \param show_uncommitted[IN]		Return uncommitted entries marked as instead of failing
  *  \param cb[IN]			Callback for key
  *  \param arg[IN]			argument to pass to callback
  *  \param dth[IN]			dtx handle
+ *  \param anchor[IN]			Option anchor from where to start iterator
  */
 int
 vos_iterate_key(struct vos_object *obj, daos_handle_t toh, vos_iter_type_t type,
-		const daos_epoch_range_t *epr, bool ignore_inprogress,
-		vos_iter_cb_t cb, void *arg, struct dtx_handle *dth);
+		const daos_epoch_range_t *epr, bool show_uncommitted,
+		vos_iter_cb_t cb, void *arg, struct dtx_handle *dth, daos_anchor_t *anchor);
 
 /** Start epoch of vos */
 extern daos_epoch_t	vos_start_epoch;

--- a/src/vos/vos_layout.h
+++ b/src/vos/vos_layout.h
@@ -88,7 +88,7 @@ enum vos_gc_type {
 #define POOL_DF_MAGIC				0x5ca1ab1e
 
 /** Lowest supported durable format version */
-#define POOL_DF_VER_1				21
+#define POOL_DF_VER_1				22
 /** Current durable format version */
 #define POOL_DF_VERSION				POOL_DF_VER_1
 
@@ -295,8 +295,12 @@ struct vos_krec_df {
 	/** Incarnation log for key */
 	struct ilog_df			kr_ilog;
 	union {
-		/** btree root under the key */
-		struct btr_root			kr_btr;
+		struct {
+			/** btree root under the key */
+			struct btr_root			kr_btr;
+			/** Offset of known existing akey */
+			umem_off_t			kr_known_akey;
+		};
 		/** evtree root, which is only used by akey */
 		struct evt_root			kr_evt;
 	};
@@ -343,8 +347,10 @@ struct vos_obj_df {
 	daos_unit_oid_t			vo_id;
 	/** The latest sync epoch */
 	daos_epoch_t			vo_sync;
-	/** Attributes of object.  See vos_oi_attr */
-	uint64_t			vo_oi_attr;
+	/** Offset of known existing dkey */
+	umem_off_t			vo_known_dkey;
+	/** Attributes for future use */
+	uint64_t			vo_attr;
 	/** Incarnation log for the object */
 	struct ilog_df			vo_ilog;
 	/** VOS dkey btree root */

--- a/src/vos/vos_obj.c
+++ b/src/vos/vos_obj.c
@@ -24,55 +24,55 @@ D_CASSERT((uint32_t)VOS_VIS_FLAG_VISIBLE == (uint32_t)EVT_VISIBLE);
 D_CASSERT((uint32_t)VOS_VIS_FLAG_PARTIAL == (uint32_t)EVT_PARTIAL);
 D_CASSERT((uint32_t)VOS_VIS_FLAG_LAST == (uint32_t)EVT_LAST);
 
+struct vos_key_info {
+	bool			 ki_non_empty;
+	bool			 ki_has_uncommitted;
+};
+
 /** This callback is invoked only if the tree is not empty */
 static int
 empty_tree_check(daos_handle_t ih, vos_iter_entry_t *entry,
 		 vos_iter_type_t type, vos_iter_param_t *param, void *cb_arg,
 		 unsigned int *acts)
 {
-	bool	*empty = cb_arg;
+	struct vos_key_info	*kinfo = cb_arg;
 
-	*empty = false;
+	if (entry->ie_vis_flags == VOS_IT_UNCOMMITTED) {
+		kinfo->ki_has_uncommitted = true;
+		return 0;
+	}
+
+	kinfo->ki_non_empty = true;
 
 	return 1; /* Return positive number to break iteration */
 }
 
 static int
-tree_is_empty(struct vos_object *obj, daos_handle_t toh,
+tree_is_empty(struct vos_object *obj, umem_off_t *known_key, daos_handle_t toh,
 	      const daos_epoch_range_t *epr, vos_iter_type_t type)
 {
 	struct dtx_handle	*dth = vos_dth_get();
-	bool			 empty = true;
+	struct vos_key_info	 kinfo = {0};
 	int			 rc;
 
-	/** First ignore any uncommitted entries because they only matter
-	 *  when there are no committed entries
-	 */
 	rc = vos_iterate_key(obj, toh, type, epr, true, empty_tree_check,
-			     &empty, dth);
+			     &kinfo, dth, NULL);
 
 	if (rc < 0)
 		return rc;
 
-	if (!empty)
+	if (kinfo.ki_non_empty)
 		return 0;
 
-	/** Ok, there are no committed entries.  We need to run the iterator
-	 *  on more time to ensure there are no uncommitted entries.  If there
-	 *  are, this will return -DER_INPROGRESS.
-	 */
-	rc = vos_iterate_key(obj, toh, type, epr, false, empty_tree_check,
-			     &empty, dth);
-
-	if (rc < 0)
-		return rc;
+	if (kinfo.ki_has_uncommitted)
+		return -DER_INPROGRESS;
 
 	/** The tree is empty */
 	return 1;
 }
 
 static int
-vos_propagate_check(struct vos_object *obj, daos_handle_t toh,
+vos_propagate_check(struct vos_object *obj, umem_off_t *known_key, daos_handle_t toh,
 		    struct vos_ts_set *ts_set, const daos_epoch_range_t *epr,
 		    vos_iter_type_t type)
 {
@@ -93,9 +93,7 @@ vos_propagate_check(struct vos_object *obj, daos_handle_t toh,
 		read_flag = VOS_TS_READ_OBJ;
 		write_flag = VOS_TS_WRITE_OBJ;
 		tree_name = "DKEY";
-		/** DAOS-4698.  Don't do emptiness check on dkey or propagate
-		 *  to object until this rebuild bug is fixed.
-		 */
+		/** Skip object punch propagation until performation is addressed */
 		return 0;
 	case VOS_ITER_AKEY:
 		read_flag = VOS_TS_READ_DKEY;
@@ -111,7 +109,7 @@ vos_propagate_check(struct vos_object *obj, daos_handle_t toh,
 	 */
 	vos_ts_set_append_cflags(ts_set, read_flag);
 
-	rc = tree_is_empty(obj, toh, epr, type);
+	rc = tree_is_empty(obj, known_key, toh, epr, type);
 	if (rc > 0) {
 		/** tree is now empty, set the flags so we can punch
 		 *  the parent
@@ -203,7 +201,7 @@ key_punch(struct vos_object *obj, daos_epoch_t epoch, daos_epoch_t bound,
 	for (i = 0; i < akey_nr; i++) {
 		rbund.rb_iov = &akeys[i];
 		rc = key_tree_punch(obj, toh, epoch, bound, &akeys[i], &riov,
-				    flags, ts_set, &info->ki_dkey,
+				    flags, ts_set, &krec->kr_known_akey, &info->ki_dkey,
 				    &info->ki_akey);
 		if (rc != 0) {
 			VOS_TX_LOG_FAIL(rc, "Failed to punch akey: rc="
@@ -214,7 +212,7 @@ key_punch(struct vos_object *obj, daos_epoch_t epoch, daos_epoch_t bound,
 
 	if (rc == 0 && (flags & VOS_OF_REPLAY_PC) == 0) {
 		/** Check if we need to propagate the punch */
-		rc = vos_propagate_check(obj, toh, ts_set, &epr,
+		rc = vos_propagate_check(obj, &krec->kr_known_akey, toh, ts_set, &epr,
 					 VOS_ITER_AKEY);
 	}
 
@@ -227,13 +225,14 @@ punch_dkey:
 	rbund.rb_tclass	= VOS_BTR_DKEY;
 
 	rc = key_tree_punch(obj, obj->obj_toh, epoch, bound, dkey, &riov,
-			    flags, ts_set, &info->ki_obj, &info->ki_dkey);
+			    flags, ts_set, &obj->obj_df->vo_known_dkey, &info->ki_obj,
+			    &info->ki_dkey);
 	if (rc != 0)
 		D_GOTO(out, rc);
 
 	if (rc == 0 && (flags & VOS_OF_REPLAY_PC) == 0) {
 		/** Check if we need to propagate to object */
-		rc = vos_propagate_check(obj, obj->obj_toh, ts_set,
+		rc = vos_propagate_check(obj, &obj->obj_df->vo_known_dkey, obj->obj_toh, ts_set,
 					 &epr, VOS_ITER_DKEY);
 	}
  out:
@@ -679,17 +678,22 @@ key_iter_fetch(struct vos_obj_iter *oiter, vos_iter_entry_t *ent,
 				 check_existence, NULL);
 	if (rc == -DER_NONEXIST)
 		return IT_OPC_NEXT;
-	if (rc != 0)
-		return rc;
+	if (rc != 0) {
+		if (!oiter->it_iter.it_show_uncommitted || rc != -DER_INPROGRESS)
+			return rc;
+		/** Mark the entry as uncommitted but return it to the iterator */
+		ent->ie_vis_flags = VOS_IT_UNCOMMITTED;
+	} else {
+		ent->ie_vis_flags = VOS_VIS_FLAG_VISIBLE;
+		if (oiter->it_ilog_info.ii_create == 0) {
+			/* The key has no visible subtrees so mark it covered */
+			ent->ie_vis_flags = VOS_VIS_FLAG_COVERED;
+		}
+	}
 
 	ent->ie_epoch = epr.epr_hi;
 	ent->ie_punch = oiter->it_ilog_info.ii_next_punch;
 	ent->ie_obj_punch = oiter->it_obj->obj_ilog_info.ii_next_punch;
-	ent->ie_vis_flags = VOS_VIS_FLAG_VISIBLE;
-	if (oiter->it_ilog_info.ii_create == 0) {
-		/* The key has no visible subtrees so mark it covered */
-		ent->ie_vis_flags = VOS_VIS_FLAG_COVERED;
-	}
 	vos_ilog_last_update(&krec->kr_ilog, ts_type, &ent->ie_last_update);
 
 	return 0;

--- a/src/vos/vos_pool.c
+++ b/src/vos/vos_pool.c
@@ -603,7 +603,7 @@ static int
 vos_register_slabs(struct umem_attr *uma)
 {
 	struct pobj_alloc_class_desc	*slab;
-	int				 i, rc;
+	int				 i, rc, j;
 
 	D_ASSERT(uma->uma_pool != NULL);
 	for (i = 0; i < VOS_SLAB_MAX; i++) {
@@ -616,6 +616,16 @@ vos_register_slabs(struct umem_attr *uma)
 			return rc;
 		}
 
+		for (j = 0; j < i; j++) {
+			if (uma->uma_slabs[j].unit_size == slab->unit_size) {
+				/** PMDK will fail to register a new slab of the same size
+				 *  so reuse the class id
+				 */
+				slab->class_id = uma->uma_slabs[j].class_id;
+				goto skip_new_class;
+			}
+		}
+
 		rc = pmemobj_ctl_set(uma->uma_pool, "heap.alloc_class.new.desc",
 				     slab);
 		if (rc) {
@@ -624,6 +634,7 @@ vos_register_slabs(struct umem_attr *uma)
 			rc = umem_tx_errno(rc);
 			return rc;
 		}
+skip_new_class:
 		D_ASSERT(slab->class_id != 0);
 	}
 

--- a/src/vos/vos_pool.c
+++ b/src/vos/vos_pool.c
@@ -622,7 +622,8 @@ vos_register_slabs(struct umem_attr *uma)
 				 *  so reuse the class id
 				 */
 				slab->class_id = uma->uma_slabs[j].class_id;
-				goto skip_new_class;
+				D_ASSERT(slab->class_id != 0);
+				continue;
 			}
 		}
 
@@ -634,7 +635,6 @@ vos_register_slabs(struct umem_attr *uma)
 			rc = umem_tx_errno(rc);
 			return rc;
 		}
-skip_new_class:
 		D_ASSERT(slab->class_id != 0);
 	}
 


### PR DESCRIPTION
For the case where the punch propagation optimization doesn't make
it to 2.0, this is a format change that is forward compatible with
the optimization so that we can add it later, if necessary without
another format change.

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>