### PR TITLE
DAOS-9055 control: Default to clean engine shutdown

### DIFF
--- a/src/control/server/engine/exec.go
+++ b/src/control/server/engine/exec.go
@@ -44,7 +44,7 @@ func (r *Runner) run(ctx context.Context, args, env []string, errOut chan<- erro
 		return errors.Wrapf(err, "can't start %s", engineBin)
 	}
 
-	cmd := exec.CommandContext(ctx, binPath, args...)
+	cmd := exec.Command(binPath, args...)
 	cmd.Stdout = &cmdLogger{
 		logFn:  r.log.Info,
 		prefix: fmt.Sprintf("%s:%d", engineBin, r.Config.Index),
@@ -76,11 +76,25 @@ func (r *Runner) run(ctx context.Context, args, env []string, errOut chan<- erro
 	}
 	r.cmd = cmd
 
+	waitDone := make(chan struct{})
 	go func() {
 		r.running.SetTrue()
 		defer r.running.SetFalse()
 
 		errOut <- errors.Wrapf(common.GetExitStatus(cmd.Wait()), "%s exited", binPath)
+
+		close(waitDone)
+	}()
+
+	go func() {
+		select {
+		case <-ctx.Done():
+			r.log.Infof("%s:%d context canceled; shutting down", engineBin, r.Config.Index)
+			if err := r.cmd.Process.Signal(syscall.SIGTERM); err != nil {
+				r.log.Errorf("%s:%d failed to kill process: %s", engineBin, r.Config.Index, err)
+			}
+		case <-waitDone:
+		}
 	}()
 
 	return nil


### PR DESCRIPTION
Currently, when the control plane process is terminated, the
engines are forcibly terminated right away. Instead, we should
give the engines a chance to shut down cleanly first.

Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com>
