### PR TITLE
DAOS-8935 build: fix rmem_{max,default} values applied in specfile

### DIFF
--- a/utils/rpms/daos.spec
+++ b/utils/rpms/daos.spec
@@ -331,8 +331,8 @@ mkdir -p %{buildroot}/%{_sysconfdir}/ld.so.conf.d/
 echo "%{_libdir}/daos_srv" > %{buildroot}/%{_sysconfdir}/ld.so.conf.d/daos.conf
 mkdir -p %{buildroot}/%{_sysconfdir}/sysctl.d/
 cat << EOF > %{buildroot}/%{_sysconfdir}/sysctl.d/%{sysctl_script_name}
-net.core.rmem_max=104857 +
-net.core.rmem_default=104857
+net.core.rmem_max=1048576 +
+net.core.rmem_default=1048576
 EOF
 mkdir -p %{buildroot}/%{_unitdir}
 %if (0%{?rhel} == 7)


### PR DESCRIPTION
Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>