### PR TITLE
DAOS-8834 test: Fix skipped drpc_client_tests

### DIFF
--- a/src/common/tests/drpc_tests.c
+++ b/src/common/tests/drpc_tests.c
@@ -145,8 +145,7 @@ test_drpc_close_closing_socket_fails(void **state)
 	int		expected_fd = 123;
 	struct drpc	*ctx = new_drpc_with_fd(expected_fd);
 
-	close_return = -1;
-	errno = ENOMEM;
+	close_return = -ENOMEM;
 
 	/* error is logged but ignored */
 	assert_rc_equal(drpc_close(ctx), 0);
@@ -207,8 +206,7 @@ test_drpc_call_fails_if_sendmsg_fails(void **state)
 	Drpc__Response	*resp = NULL;
 	Drpc__Call	*call = new_drpc_call();
 
-	sendmsg_return = -1;
-	errno = EINVAL; /* translates to -DER_INVAL */
+	sendmsg_return = -EINVAL; /* translates to -DER_INVAL */
 
 	assert_rc_equal(drpc_call(ctx, 0, call, &resp), -DER_INVAL);
 	assert_null(resp);
@@ -317,8 +315,7 @@ test_drpc_call_with_sync_flag_fails_on_recvmsg_fail(void **state)
 	Drpc__Response	*resp = NULL;
 	Drpc__Call	*call = new_drpc_call();
 
-	recvmsg_return = -1;
-	errno = EINVAL;
+	recvmsg_return = -EINVAL;
 
 	assert_rc_equal(drpc_call(ctx, R_SYNC, call, &resp), -DER_INVAL);
 	assert_null(resp);
@@ -535,8 +532,7 @@ assert_drpc_recv_call_fails_with_recvmsg_errno(int recvmsg_errno,
 	mock_valid_drpc_call_in_recvmsg();
 
 	recvmsg_call_count = 0;
-	recvmsg_return = -1;
-	errno = recvmsg_errno;
+	recvmsg_return = -recvmsg_errno;
 
 	assert_rc_equal(drpc_recv_call(ctx, &call), expected_retval);
 
@@ -650,8 +646,7 @@ test_drpc_send_response_sendmsg_fails(void **state)
 	struct drpc	*ctx = new_drpc_with_fd(122);
 	Drpc__Response	*resp = new_drpc_response();
 
-	sendmsg_return = -1;
-	errno = ENOMEM;
+	sendmsg_return = -ENOMEM;
 
 	assert_rc_equal(drpc_send_response(ctx, resp), -DER_NOMEM);
 

--- a/src/common/tests/test_mocks.c
+++ b/src/common/tests/test_mocks.c
@@ -231,6 +231,10 @@ sendmsg(int sockfd, const struct msghdr *msg, int flags)
 		sendmsg_msg_iov_len = msg->msg_iov[0].iov_len;
 	}
 	sendmsg_flags = flags;
+	if (sendmsg_return < 0) {
+		errno = -sendmsg_return;
+		return -1;
+	}
 	return sendmsg_return;
 }
 

--- a/src/common/tests/test_mocks.c
+++ b/src/common/tests/test_mocks.c
@@ -193,6 +193,10 @@ close(int fd)
 {
 	close_fd = fd;
 	close_call_count++;
+	if (close_return < 0) {
+		errno = -close_return;
+		return -1;
+	}
 	return close_return;
 }
 
@@ -277,6 +281,10 @@ recvmsg(int sockfd, struct msghdr *msg, int flags)
 		recvmsg_msg_iov_len = msg->msg_iov[0].iov_len;
 	}
 	recvmsg_flags = flags;
+	if (recvmsg_return < 0) {
+		errno = -recvmsg_return;
+		return -1;
+	}
 	return recvmsg_return;
 }
 
@@ -321,6 +329,10 @@ poll(struct pollfd *fds, nfds_t nfds, int timeout)
 	}
 	poll_nfds = nfds;
 	poll_timeout = timeout;
+	if (poll_return < 0) {
+		errno = -poll_return;
+		return -1;
+	}
 	return poll_return;
 }
 

--- a/src/engine/tests/drpc_client_tests.c
+++ b/src/engine/tests/drpc_client_tests.c
@@ -137,16 +137,9 @@ test_drpc_call_connect_fails(void **state)
 	Drpc__Response	*resp;
 	int		 rc;
 
-	/*
-	 * errno is not set for the dss_drpc_thread; connect_return = -1 also
-	 * isn't working.
-	 */
-	skip();
-
 	assert_rc_equal(drpc_init(), 0);
 
-	connect_return = -1;
-	errno = EACCES;
+	connect_return = -EACCES;
 
 	rc = dss_drpc_call(DRPC_MODULE_SRV, DRPC_METHOD_SRV_NOTIFY_READY,
 			   NULL /* req */, 0 /* req_size */, 0 /* flags */,
@@ -165,13 +158,9 @@ test_drpc_call_sendmsg_fails(void **state)
 	Drpc__Response	*resp;
 	int		 rc;
 
-	/* See test_drpc_call_connect_fails. */
-	skip();
-
 	assert_rc_equal(drpc_init(), 0);
 
-	sendmsg_return = -1;
-	errno = EACCES;
+	sendmsg_return = -EACCES;
 
 	rc = dss_drpc_call(DRPC_MODULE_SRV, DRPC_METHOD_SRV_NOTIFY_READY,
 			   NULL /* req */, 0 /* req_size */, 0 /* flags */,

--- a/src/engine/tests/drpc_progress_tests.c
+++ b/src/engine/tests/drpc_progress_tests.c
@@ -352,8 +352,7 @@ test_drpc_progress_poll_failed(void **state)
 	struct drpc_progress_context ctx;
 
 	init_drpc_progress_context(&ctx, new_drpc_with_fd(15));
-	poll_return = -1;
-	errno = ENOMEM;
+	poll_return = -ENOMEM;
 
 	assert_rc_equal(drpc_progress(&ctx, 20), -DER_NOMEM);
 
@@ -492,8 +491,7 @@ test_drpc_progress_session_cleanup_if_recv_fails(void **state)
 
 	poll_revents_return[num_sessions] = POLLIN; /* listener */
 
-	recvmsg_return = -1;
-	errno = ENOMEM;
+	recvmsg_return = -ENOMEM;
 
 	/* the error was handled by closing the sessions */
 	assert_rc_equal(drpc_progress(&ctx, 1), DER_SUCCESS);
@@ -529,8 +527,7 @@ test_drpc_progress_session_fails_if_no_data(void **state)
 
 	poll_revents_return[num_sessions] = POLLIN; /* listener */
 
-	recvmsg_return = -1;
-	errno = EAGAIN; /* No data to fetch */
+	recvmsg_return = -EAGAIN; /* No data to fetch */
 
 	/* Pass up the error this time - we didn't do anything with it */
 	assert_rc_equal(drpc_progress(&ctx, 1), -DER_AGAIN);


### PR DESCRIPTION
- Fixed the skipped unit tests that hadn't been updated to return
  a correct errno.
- Unskipped the tests.

Signed-off-by: Kris Jacque <kristin.jacque@intel.com>