### PR TITLE
DAOS-8446 test: Update ms_resilience.py to wait for dead hosts (#7272)

### DIFF
--- a/src/control/server/config/server.go
+++ b/src/control/server/config/server.go
@@ -641,7 +641,7 @@ func (cfg *Server) CheckFabric(ctx context.Context) (uint32, error) {
 	for index, engine := range cfg.Engines {
 		ndc, err := cfg.GetDeviceClassFn(engine.Fabric.Interface)
 		if err != nil {
-			return 0, err
+			return 0, errors.Wrapf(err, "unable to detect device class for %q", engine.Fabric.Interface)
 		}
 		if index == 0 {
 			netDevClass = ndc

--- a/src/control/server/server.go
+++ b/src/control/server/server.go
@@ -41,7 +41,11 @@ func processConfig(log *logging.LeveledLogger, cfg *config.Server) (*system.Faul
 	}
 
 	lookupNetIF := func(name string) (netInterface, error) {
-		return net.InterfaceByName(name)
+		iface, err := net.InterfaceByName(name)
+		if err != nil {
+			return nil, errors.Wrapf(err, "unable to retrieve interface %q", name)
+		}
+		return iface, nil
 	}
 	for _, ec := range cfg.Engines {
 		if err := checkFabricInterface(ec.Fabric.Interface, lookupNetIF); err != nil {

--- a/src/tests/ftest/control/ms_resilience.py
+++ b/src/tests/ftest/control/ms_resilience.py
@@ -10,6 +10,21 @@ import random
 import socket
 import time
 
+def get_hostname(host_addr):
+    """Get the hostname of a host.
+
+    Args:
+        host_addr (str): address to resolve into hostname.
+
+    Returns:
+        str: hostname of the host.
+
+    """
+    if not host_addr:
+        return None
+
+    fqdn, _, _ = socket.gethostbyaddr(host_addr.split(":")[0])
+    return fqdn.split(".")[0]
 
 class ManagementServiceResilience(TestWithServers):
     """Test Class Description:
@@ -76,13 +91,7 @@ class ManagementServiceResilience(TestWithServers):
         sys_leader_info = self.get_dmg_command().system_leader_query()
         l_addr = sys_leader_info["response"]["CurrentLeader"]
 
-        if not l_addr:
-            return None
-
-        l_hostname, _, _ = socket.gethostbyaddr(l_addr.split(":")[0])
-        l_hostname = l_hostname.split(".")[0]
-
-        return l_hostname
+        return get_hostname(l_addr)
 
     def verify_leader(self, replicas):
         """Verify the leader of the MS is in the replicas.
@@ -95,15 +104,13 @@ class ManagementServiceResilience(TestWithServers):
             str: address of the MS leader.
 
         """
-        l_hostname = None
+        l_hostname = self.get_leader()
         start = time.time()
-        while not l_hostname and (time.time() - start) < self.L_QUERY_TIMER:
-            l_hostname = self.get_leader()
-            # Check that the new leader is in the access list
-            if l_hostname not in replicas:
-                self.log.error("Selected leader <%s> is not within the replicas"
-                               " provided to servers", l_hostname)
+        while l_hostname not in replicas and (time.time() - start) < self.L_QUERY_TIMER:
+            self.log.info("Current leader: <%s>; "
+                            "waiting for new leader to step up", l_hostname)
             time.sleep(1)
+            l_hostname = self.get_leader()
 
         elapsed = time.time() - start
         if not l_hostname:
@@ -111,6 +118,45 @@ class ManagementServiceResilience(TestWithServers):
 
         self.log.info("*** found leader (%s) after %.2fs", l_hostname, elapsed)
         return l_hostname
+
+    def verify_dead(self, kill_list):
+        """Verify that the expected list of killed servers are marked dead.
+
+        Args:
+            kill_list (list): list of hostnames of servers to verify are dead.
+
+        Returns:
+            None
+
+        """
+        hostnames = {}
+
+        while True:
+            time.sleep(1)
+            dead_list = []
+            members = self.get_dmg_command().system_query()["response"]["members"]
+            for member in members:
+                if member["addr"] not in hostnames:
+                    hostname = get_hostname(member["addr"])
+                    if hostname is None:
+                        self.fail("Unable to resolve {} to hostname".format(member["addr"]))
+                    hostnames[member["addr"]] = hostname
+
+                if member["state"] == "excluded":
+                    dead_list.append(hostnames[member["addr"]])
+
+            if len(dead_list) != len(kill_list):
+                self.log.info("*** waiting for %d dead servers to be marked dead",
+                                len(kill_list))
+                continue
+
+            for hostname in kill_list:
+                if hostname not in dead_list:
+                    self.log.error("Server %s not found in dead_list", hostname)
+                    self.fail("Found more dead servers than expected!")
+
+            self.log.info("*** detected %d dead servers", len(dead_list))
+            return
 
     def launch_servers(self, resilience_num):
         """Setup and start the daos_servers.
@@ -189,8 +235,9 @@ class ManagementServiceResilience(TestWithServers):
         self.verify_leader(survivors)
         self.get_dmg_command().hostlist = self.hostlist_servers
 
-        # Dump the current system state.
-        self.get_dmg_command().system_query()
+        # Wait until SWIM has marked the replicas as dead in order to
+        # avoid long timeouts and other issues.
+        self.verify_dead(kill_list)
 
         # Finally, verify that quorum has been retained by performing
         # write operations.


### PR DESCRIPTION
Wait for the killed ranks to be marked as excluded in the membership
before proceeding to pool operations. This will avoid RPC delays
and timeouts due to unreachable ranks.

Also improves a couple of error messages for the case when the
config has an unknown interface.

Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com>