### PR TITLE
DAOS-9052-test_rel_2.0: Add skipForTicket for the release 2.0 testcas…

### DIFF
--- a/src/tests/ftest/control/daos_snapshot.py
+++ b/src/tests/ftest/control/daos_snapshot.py
@@ -4,7 +4,7 @@
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
-from apricot import TestWithServers
+from apricot import TestWithServers, skipForTicket
 from daos_utils import DaosCommand
 
 
@@ -117,6 +117,7 @@ class DaosSnapshotTest(TestWithServers):
             pool=self.pool.uuid, cont=self.container.uuid)
         self.assertTrue(not epochs)
 
+    @skipForTicket("DAOS-4691")
     def test_epcrange(self):
         """JIRA ID: DAOS-4872
 

--- a/src/tests/ftest/fault_domain/fault_domain.py
+++ b/src/tests/ftest/fault_domain/fault_domain.py
@@ -5,7 +5,7 @@
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
 
-from apricot import TestWithServers
+from apricot import TestWithServers, skipForTicket
 
 
 class FaultDomain(TestWithServers):
@@ -21,6 +21,7 @@ class FaultDomain(TestWithServers):
         self.setup_start_servers = False
         super().setUp()
 
+    @skipForTicket("DAOS-7919")
     def test_pools_in_different_domains(self):
         """This aims to:
             Be able to configure daos servers using different fault domains.

--- a/src/tests/ftest/nvme/enospace.py
+++ b/src/tests/ftest/nvme/enospace.py
@@ -7,6 +7,7 @@
 import time
 import threading
 
+from apricot import skipForTicket
 from nvme_utils import ServerFillUp
 from avocado.core.exceptions import TestFail
 from daos_utils import DaosCommand
@@ -316,6 +317,7 @@ class NvmeEnospace(ServerFillUp):
         #Run last IO
         self.start_ior_load(storage='SCM', percent=1)
 
+    @skipForTicket("DAOS-8896")
     def test_performance_storage_full(self):
         """Jira ID: DAOS-4756.
 

--- a/src/tests/ftest/nvme/pool_extend.py
+++ b/src/tests/ftest/nvme/pool_extend.py
@@ -7,6 +7,7 @@
 import time
 import threading
 
+from apricot import skipForTicket
 from osa_utils import OSAUtils
 from write_host_file import write_host_file
 from dmg_utils import check_system_query_status
@@ -117,6 +118,7 @@ class NvmePoolExtend(OSAUtils):
             output = self.daos_command.container_check(**kwargs)
             self.log.info(output)
 
+    @skipForTicket("DAOS-7195", "DAOS-7955")
     def test_nvme_pool_extend(self):
         """Test ID: DAOS-2086
         Test Description: NVME Pool Extend


### PR DESCRIPTION
…es failed due to release 2.2 tickets

Description: following tests will be skipped on release 2.0
1. /control/daos_snapshot.py:DaosSnapshotTest.test_epcrange  (3 testcases)   daos-4691
2. fault_domain/fault_domain.py:FaultDomain.test_pools_in_different_domains (1 testcase)  daos-7919
3. /nvme/enospace.py:NvmeEnospace.test_performance_storage_ful  (1 testcase)  daos-8896
4. /nvme/pool_extend.py (1 testcase)  daos-7195, daos-7955

Signed-off-by: Ding Ho ding-hwa.ho@intel.com