### PR TITLE
DAOS-8902 tests: Run HW Small tests with the verbs provider (#7110)

### DIFF
--- a/src/tests/ftest/network/zero_config.py
+++ b/src/tests/ftest/network/zero_config.py
@@ -168,6 +168,7 @@ class ZeroConfigTest(TestWithServers):
         racer_env = daos_racer.get_environment(self.server_managers[0], log_file)
         racer_env["FI_LOG_LEVEL"] = "info"
         racer_env["D_LOG_MASK"] = "INFO,object=ERR,placement=ERR"
+        racer_env["OFI_DOMAIN"] = self.interfaces[exp_iface]["domain"]
         daos_racer.set_environment(racer_env)
 
         # Run client


### PR DESCRIPTION
Enable running Functional Hardware Small tests with the verbs provider
when supported.

Signed-off-by: Phillip Henderson <phillip.henderson@intel.com>