### PR TITLE
DAOS-9061 obj: fix daos_oclass_names_list()

### DIFF
--- a/src/include/daos_obj_class.h
+++ b/src/include/daos_obj_class.h
@@ -618,9 +618,9 @@ daos_oclass_name2id(const char *name);
  * \param[in]	size	length in bytes of str buffer.
  * \param[out]	str	buffer to get all registered oclass names
  *
- * \return		>= 0 on success and required length of str, -1 if error.
+ * \return		>= 0 on success and required length of str, < 0 if error.
  */
-size_t
+ssize_t
 daos_oclass_names_list(size_t size, char *str);
 
 /**

--- a/src/object/obj_class.c
+++ b/src/object/obj_class.c
@@ -77,14 +77,14 @@ daos_oclass_name2id(const char *name)
 }
 
 /** Return the list of registered oclass names */
-size_t
+ssize_t
 daos_oclass_names_list(size_t size, char *str)
 {
 	struct daos_obj_class   *oc;
-	size_t len = 0;
+	ssize_t len = 0;
 
 	if (size <= 0 || str == NULL)
-		return -1;
+		return -DER_INVAL;
 
 	*str = '\0';
 	for (oc = &daos_obj_classes[0]; oc->oc_id != OC_UNKNOWN; oc++) {
@@ -92,6 +92,8 @@ daos_oclass_names_list(size_t size, char *str)
 		if (len < size) {
 			strcat(str, oc->oc_name);
 			strcat(str, ", ");
+		} else {
+			return -DER_OVERFLOW;
 		}
 	}
 	return len;

--- a/src/placement/tests/place_obj_common.c
+++ b/src/placement/tests/place_obj_common.c
@@ -762,7 +762,7 @@ get_object_classes(daos_oclass_id_t **oclass_id_pp)
 	char *oclass_names;
 	char oclass[64];
 	daos_oclass_id_t *oclass_id;
-	uint32_t length = 0;
+	ssize_t length = 0;
 	uint32_t num_oclass = 0;
 	uint32_t oclass_str_index = 0;
 	uint32_t i, oclass_index;
@@ -772,6 +772,8 @@ get_object_classes(daos_oclass_id_t **oclass_id_pp)
 		return -1;
 
 	length = daos_oclass_names_list(str_size, oclass_names);
+	if (length < 0)
+		return length;
 
 	for (i = 0; i < length; ++i) {
 		if (oclass_names[i] == ',')


### PR DESCRIPTION
Addressed following issues:

1. return value could be negative in error, but we define it as
size_t, fix to use ssize_t instead.

2. if allocated buf is not enough to hold all names, length is
still increased, this means wrong length might be returned, return
error in this case to caller.

3. check function return value properly.

Signed-off-by: Wang Shilong <shilong.wang@intel.com>