### PR TITLE
DAOS-9056 dfuse: Remove pool write requirement from dfuse.

### DIFF
--- a/src/client/dfuse/dfuse_cont.c
+++ b/src/client/dfuse/dfuse_cont.c
@@ -10,9 +10,8 @@
 #include "daos_api.h"
 
 /* Lookup a container within a pool */
-static void
-dfuse_cont_helper(fuse_req_t req, struct dfuse_inode_entry *parent,
-		  const char *name, bool create)
+void
+dfuse_cont_lookup(fuse_req_t req, struct dfuse_inode_entry *parent, const char *name)
 {
 	struct dfuse_projection_info	*fs_handle = fuse_req_userdata(req);
 	struct dfuse_inode_entry	*ie = NULL;
@@ -40,30 +39,7 @@ dfuse_cont_helper(fuse_req_t req, struct dfuse_inode_entry *parent,
 		return;
 	}
 
-	DFUSE_TRA_DEBUG(parent, "Lookup of "DF_UUID" create %d",
-			DP_UUID(cont), create);
-
-	if (create) {
-		D_ALLOC_PTR(dfc);
-		if (!dfc)
-			D_GOTO(err, rc = ENOMEM);
-
-		DFUSE_TRA_UP(dfc, dfp, "dfc");
-
-		rc = dfs_cont_create(dfp->dfp_poh, cont, NULL,
-				     &dfc->dfs_coh, &dfc->dfs_ns);
-		if (rc) {
-			DFUSE_TRA_ERROR(dfc,
-					"dfs_cont_create() failed: (%d)",
-					rc);
-			D_FREE(dfc);
-			D_GOTO(err, rc);
-		}
-
-		uuid_copy(dfc->dfs_cont, cont);
-		if (fs_handle->dpi_info->di_caching)
-			dfuse_set_default_cont_cache_values(dfc);
-	}
+	DFUSE_TRA_DEBUG(parent, "Lookup of "DF_UUID, DP_UUID(cont));
 
 	rc = dfuse_cont_open(fs_handle, dfp, &cont, &dfc);
 	if (rc)
@@ -140,22 +116,4 @@ err:
 	} else {
 		DFUSE_REPLY_ERR_RAW(parent, req, rc);
 	}
-}
-
-void
-dfuse_cont_lookup(fuse_req_t req, struct dfuse_inode_entry *parent,
-		  const char *name)
-{
-	dfuse_cont_helper(req, parent, name, false);
-}
-
-void
-dfuse_cont_mknod(fuse_req_t req, struct dfuse_inode_entry *parent,
-		 const char *name, mode_t mode)
-{
-	if (!S_ISDIR(mode)) {
-		DFUSE_REPLY_ERR_RAW(parent, req, ENOTSUP);
-		return;
-	}
-	dfuse_cont_helper(req, parent, name, true);
 }

--- a/src/client/dfuse/dfuse_core.c
+++ b/src/client/dfuse/dfuse_core.c
@@ -398,9 +398,8 @@ d_hash_table_ops_t cont_hops = {
  * Return code is a system errno.
  */
 int
-dfuse_pool_connect_by_label(struct dfuse_projection_info *fs_handle,
-			const char *label,
-			struct dfuse_pool **_dfp)
+dfuse_pool_connect_by_label(struct dfuse_projection_info *fs_handle, const char *label,
+			    struct dfuse_pool **_dfp)
 {
 	struct dfuse_pool	*dfp;
 	daos_pool_info_t        p_info = {};
@@ -415,17 +414,13 @@ dfuse_pool_connect_by_label(struct dfuse_projection_info *fs_handle,
 
 	DFUSE_TRA_UP(dfp, fs_handle, "dfp");
 
-	rc = daos_pool_connect(label, fs_handle->dpi_info->di_group,
-			       DAOS_PC_RW, &dfp->dfp_poh, &p_info, NULL);
+	rc = daos_pool_connect(label, fs_handle->dpi_info->di_group, DAOS_PC_RO, &dfp->dfp_poh,
+			       &p_info, NULL);
 	if (rc) {
 		if (rc == -DER_NO_PERM)
-			DFUSE_TRA_INFO(dfp,
-				"daos_pool_connect() failed, "
-				DF_RC, DP_RC(rc));
+			DFUSE_TRA_INFO(dfp, "daos_pool_connect() failed, " DF_RC, DP_RC(rc));
 		else
-			DFUSE_TRA_ERROR(dfp,
-					"daos_pool_connect() failed, "
-					DF_RC, DP_RC(rc));
+			DFUSE_TRA_ERROR(dfp, "daos_pool_connect() failed, " DF_RC, DP_RC(rc));
 		D_GOTO(err_free, rc = daos_der2errno(rc));
 	}
 
@@ -479,8 +474,7 @@ dfuse_pool_connect(struct dfuse_projection_info *fs_handle, uuid_t *pool,
 	d_list_t		*rlink;
 	int			rc;
 
-	rlink = d_hash_rec_find(&fs_handle->dpi_pool_table,
-				pool, sizeof(*pool));
+	rlink = d_hash_rec_find(&fs_handle->dpi_pool_table, pool, sizeof(*pool));
 	if (rlink) {
 		*_dfp = container_of(rlink, struct dfuse_pool, dfp_entry);
 		return 0;
@@ -494,27 +488,21 @@ dfuse_pool_connect(struct dfuse_projection_info *fs_handle, uuid_t *pool,
 
 	DFUSE_TRA_UP(dfp, fs_handle, "dfp");
 
-	DFUSE_TRA_DEBUG(dfp, "New pool "DF_UUIDF,
-			DP_UUID(pool));
+	DFUSE_TRA_DEBUG(dfp, "New pool "DF_UUIDF, DP_UUID(pool));
 
 	if (uuid_is_null(*pool) == 0) {
 		char uuid_str[37];
 
 		uuid_copy(dfp->dfp_pool, *pool);
 		uuid_unparse(dfp->dfp_pool, uuid_str);
-		rc = daos_pool_connect(uuid_str,
-				       fs_handle->dpi_info->di_group,
-				       DAOS_PC_RW,
+		rc = daos_pool_connect(uuid_str, fs_handle->dpi_info->di_group, DAOS_PC_RO,
 				       &dfp->dfp_poh, NULL, NULL);
 		if (rc) {
 			if (rc == -DER_NO_PERM)
-				DFUSE_TRA_INFO(dfp,
-					       "daos_pool_connect() failed, "
-					       DF_RC, DP_RC(rc));
+				DFUSE_TRA_INFO(dfp, "daos_pool_connect() failed, "DF_RC, DP_RC(rc));
 			else
-				DFUSE_TRA_ERROR(dfp,
-						"daos_pool_connect() failed, "
-						DF_RC, DP_RC(rc));
+				DFUSE_TRA_ERROR(dfp, "daos_pool_connect() failed, "DF_RC,
+						DP_RC(rc));
 			D_GOTO(err_free, rc = daos_der2errno(rc));
 		}
 	}

--- a/src/client/dfuse/dfuse_fuseops.c
+++ b/src/client/dfuse/dfuse_fuseops.c
@@ -676,7 +676,6 @@ struct dfuse_inode_ops dfuse_dfs_ops = {
 
 struct dfuse_inode_ops dfuse_cont_ops = {
 	.lookup		= dfuse_cont_lookup,
-	.mknod		= dfuse_cont_mknod,
 	.statfs		= dfuse_cb_statfs,
 };
 

--- a/src/client/dfuse/il/int_posix.c
+++ b/src/client/dfuse/il/int_posix.c
@@ -938,8 +938,6 @@ dfuse_open(const char *pathname, int flags, ...)
 			    * for va_arg routine
 			    */
 
-	pthread_once(&init_links_flag, init_links);
-
 	if (flags & O_CREAT) {
 		va_list ap;
 

--- a/src/client/dfuse/il/int_posix.c
+++ b/src/client/dfuse/il/int_posix.c
@@ -659,7 +659,8 @@ ioil_open_cont_handles(int fd, struct dfuse_il_reply *il_reply, struct ioil_cont
 	}
 
 	uuid_unparse(il_reply->fir_cont, uuid_str);
-	rc = daos_cont_open(pool->iop_poh, uuid_str, DAOS_COO_RW, &cont->ioc_coh, NULL, NULL);
+	rc = daos_cont_open(pool->iop_poh, uuid_str, DAOS_COO_RW,
+			    &cont->ioc_coh, NULL, NULL);
 	if (rc)
 		return false;
 

--- a/src/client/dfuse/il/int_posix.c
+++ b/src/client/dfuse/il/int_posix.c
@@ -938,6 +938,8 @@ dfuse_open(const char *pathname, int flags, ...)
 			    * for va_arg routine
 			    */
 
+	pthread_once(&init_links_flag, init_links);
+
 	if (flags & O_CREAT) {
 		va_list ap;
 

--- a/src/client/dfuse/il/int_posix.c
+++ b/src/client/dfuse/il/int_posix.c
@@ -645,8 +645,7 @@ ioil_fetch_cont_handles(int fd, struct ioil_cont *cont)
 }
 
 static bool
-ioil_open_cont_handles(int fd, struct dfuse_il_reply *il_reply,
-		       struct ioil_cont *cont)
+ioil_open_cont_handles(int fd, struct dfuse_il_reply *il_reply, struct ioil_cont *cont)
 {
 	int			rc;
 	struct ioil_pool       *pool = cont->ioc_pool;
@@ -654,20 +653,17 @@ ioil_open_cont_handles(int fd, struct dfuse_il_reply *il_reply,
 
 	if (daos_handle_is_inval(pool->iop_poh)) {
 		uuid_unparse(il_reply->fir_pool, uuid_str);
-		rc = daos_pool_connect(uuid_str, NULL,
-				       DAOS_PC_RW, &pool->iop_poh, NULL, NULL);
+		rc = daos_pool_connect(uuid_str, NULL, DAOS_PC_RO, &pool->iop_poh, NULL, NULL);
 		if (rc)
 			return false;
 	}
 
 	uuid_unparse(il_reply->fir_cont, uuid_str);
-	rc = daos_cont_open(pool->iop_poh, uuid_str, DAOS_COO_RW,
-			    &cont->ioc_coh, NULL, NULL);
+	rc = daos_cont_open(pool->iop_poh, uuid_str, DAOS_COO_RW, &cont->ioc_coh, NULL, NULL);
 	if (rc)
 		return false;
 
-	rc = dfs_mount(pool->iop_poh, cont->ioc_coh, O_RDWR,
-		       &cont->ioc_dfs);
+	rc = dfs_mount(pool->iop_poh, cont->ioc_coh, O_RDWR, &cont->ioc_dfs);
 	if (rc)
 		return false;
 

--- a/utils/node_local_test.py
+++ b/utils/node_local_test.py
@@ -867,20 +867,21 @@ def il_cmd(dfuse, cmd, check_read=True, check_write=True, check_fstat=True):
     """
     my_env = get_base_env()
     prefix = 'dnt_dfuse_il_{}_'.format(get_inc_id())
-    log_file = tempfile.NamedTemporaryFile(prefix=prefix, suffix='.log', delete=False)
-    my_env['D_LOG_FILE'] = log_file.name
+    with tempfile.NamedTemporaryFile(prefix=prefix, suffix='.log', delete=False) as log_file:
+        log_name = log_file.name
+    my_env['D_LOG_FILE'] = log_name
     my_env['LD_PRELOAD'] = os.path.join(dfuse.conf['PREFIX'], 'lib64', 'libioil.so')
     my_env['DAOS_AGENT_DRPC_DIR'] = dfuse._daos.agent_dir
     my_env['D_IL_REPORT'] = '2'
     ret = subprocess.run(cmd, env=my_env, check=False)
-    print('Logged il to {}'.format(log_file.name))
+    print('Logged il to {}'.format(log_name))
     print(ret)
 
     if dfuse.caching:
         check_fstat = False
 
     try:
-        log_test(dfuse.conf, log_file.name, check_read=check_read, check_write=check_write,
+        log_test(dfuse.conf, log_name, check_read=check_read, check_write=check_write,
                  check_fstat=check_fstat)
         assert ret.returncode == 0
     except NLTestNoFunction as error:

--- a/utils/node_local_test.py
+++ b/utils/node_local_test.py
@@ -1259,11 +1259,13 @@ def _create_cont(conf, pool=None, cont=None, ctype=None, label=None, path=None, 
     if label:
         cmd.extend(['--properties',
                     'label:{}'.format(label)])
-    if ctype:
-        cmd.extend(['--type', ctype])
 
     if path:
         cmd.extend(['--path', path])
+        ctype = 'POSIX'
+
+    if ctype:
+        cmd.extend(['--type', ctype])
 
     if cont:
         cmd.extend(['--cont', cont])
@@ -1505,7 +1507,7 @@ class posix_tests():
             assert rc.returncode == 0, rc
 
         child_path = os.path.join(self.dfuse.dir, 'new_cont')
-        new_cont = create_cont(self.conf, self.pool.uuid, path=child_path, ctype="POSIX")
+        new_cont = create_cont(self.conf, self.pool.uuid, path=child_path)
         print(new_cont)
         _check_cmd(child_path)
         _check_cmd(self.dfuse.dir)
@@ -1698,6 +1700,51 @@ class posix_tests():
         assert rc.returncode == 0
 
     @needs_dfuse
+    def test_il(self):
+        """Run a basic interception library test"""
+
+        create_and_read_via_il(self.dfuse, self.dfuse.dir)
+
+        sub_cont_dir = os.path.join(self.dfuse.dir, 'child')
+        create_cont(self.conf, path=sub_cont_dir)
+
+        # Create a file natively.
+        f = os.path.join(self.dfuse.dir, 'file')
+        with open(f, 'w') as fd:
+            fd.write('Hello')
+        # Copy it across containers.
+        ret = il_cmd(self.dfuse, ['cp', f, sub_cont_dir])
+        assert ret.returncode == 0
+
+        # Copy it within the container.
+        child_dir = os.path.join(self.dfuse.dir, 'new_dir')
+        os.mkdir(child_dir)
+        il_cmd(self.dfuse, ['cp', f, child_dir])
+        assert ret.returncode == 0
+
+        # Copy something into a container
+        ret = il_cmd(self.dfuse, ['cp', '/bin/bash', sub_cont_dir], check_read=False)
+        assert ret.returncode == 0
+        # Read it from within a container
+        # TODO:                              # pylint: disable=W0511
+        # change this to something else, md5sum uses fread which isn't
+        # intercepted.
+        ret = il_cmd(self.dfuse,
+                     ['md5sum', os.path.join(sub_cont_dir, 'bash')],
+                     check_read=False, check_write=False, check_fstat=False)
+        assert ret.returncode == 0
+        ret = il_cmd(self.dfuse, ['dd',
+                             'if={}'.format(os.path.join(sub_cont_dir, 'bash')),
+                             'of={}'.format(os.path.join(sub_cont_dir, 'bash_copy')),
+                             'iflag=direct',
+                             'oflag=direct',
+                             'bs=128k'],
+                     check_fstat=False)
+
+        print(ret)
+        assert ret.returncode == 0
+
+    @needs_dfuse
     def test_xattr(self):
         """Perform basic tests with extended attributes"""
 
@@ -1770,7 +1817,7 @@ class posix_tests():
     def test_uns_create(self):
         """Simple test to create a container using a path in dfuse"""
         path = os.path.join(self.dfuse.dir, 'mycont')
-        create_cont(self.conf, path=path, ctype="POSIX")
+        create_cont(self.conf, path=path)
         stbuf = os.stat(path)
         print(stbuf)
         assert stbuf.st_ino < 100
@@ -1954,7 +2001,7 @@ class posix_tests():
         tmp_dir = tempfile.mkdtemp()
 
         cont_path = os.path.join(tmp_dir, 'my-cont')
-        create_cont(self.conf, self.pool.uuid, ctype="POSIX", path=cont_path)
+        create_cont(self.conf, self.pool.uuid, path=cont_path)
 
         dfuse = DFuse(self.server,
                       self.conf,
@@ -1989,11 +2036,7 @@ class posix_tests():
         uns_path = os.path.join(dfuse.dir, 'ep0')
         uns_container = str(uuid.uuid4())
         print('Inserting entry point')
-        create_cont(conf,
-                    pool=pool,
-                    cont=uns_container,
-                    path=uns_path,
-                    ctype="POSIX")
+        create_cont(conf, pool=pool, cont=uns_container, path=uns_path)
         print(os.stat(uns_path))
         print(os.listdir(dfuse.dir))
 
@@ -2022,11 +2065,7 @@ class posix_tests():
 
         # Make a link within the new container.
         print('Inserting entry point')
-        create_cont(conf,
-                    pool=pool,
-                    cont=uns_container,
-                    path=uns_path,
-                    ctype="POSIX")
+        create_cont(conf, pool=pool, cont=uns_container, path=uns_path)
 
         # List the root container again.
         print(os.listdir(os.path.join(dfuse.dir, pool, container)))
@@ -2104,11 +2143,7 @@ class posix_tests():
         uns_path = os.path.join(dfuse.dir, 'ep1')
         uns_container = str(uuid.uuid4())
         print('Inserting entry point')
-        create_cont(conf,
-                    pool=pool,
-                    cont=uns_container,
-                    path=uns_path,
-                    ctype="POSIX")
+        create_cont(conf, pool=pool, cont=uns_container, path=uns_path)
 
         print(os.stat(uns_path))
         print(os.listdir(dfuse.dir))
@@ -2645,7 +2680,7 @@ def run_duns_overlay_test(server, conf):
 
     uns_dir = os.path.join(parent_dir.name, 'uns_ep')
 
-    create_cont(conf, pool=pool, path=uns_dir, ctype="POSIX")
+    create_cont(conf, pool=pool, path=uns_dir)
 
     dfuse = DFuse(server, conf, mount_path=uns_dir, caching=False)
 
@@ -2671,7 +2706,6 @@ def run_dfuse(server, conf):
     except OSError:
         umount(dfuse.dir)
         raise
-    container = str(uuid.uuid4())
     dfuse.start(v_hint='no_pool')
     print(os.statvfs(dfuse.dir))
     subprocess.run(['df', '-h'], check=True) # nosec
@@ -2683,27 +2717,26 @@ def run_dfuse(server, conf):
     pool_stat = os.stat(os.path.join(dfuse.dir, pool))
     print('stat for {}'.format(pool))
     print(pool_stat)
+    container = create_cont(server.conf, pool, ctype="POSIX")
     cdir = os.path.join(dfuse.dir, pool, container)
-    os.mkdir(cdir)
     #create_and_read_via_il(dfuse, cdir)
     fatal_errors.add_result(dfuse.stop())
 
-    container2 = str(uuid.uuid4())
     dfuse = DFuse(server, conf, pool=pool, caching=False)
     pre_stat = os.stat(dfuse.dir)
     dfuse.start(v_hint='pool_only')
     print('Running dfuse with pool only')
     stat_and_check(dfuse, pre_stat)
     check_no_file(dfuse)
+    container2 = create_cont(server.conf, pool, ctype="POSIX")
     cpath = os.path.join(dfuse.dir, container2)
-    os.mkdir(cpath)
+    print(os.listdir(cpath))
     cdir = os.path.join(dfuse.dir, container)
     create_and_read_via_il(dfuse, cdir)
 
     fatal_errors.add_result(dfuse.stop())
 
-    dfuse = DFuse(server, conf, pool=pool, container=container,
-                  caching=False)
+    dfuse = DFuse(server, conf, pool=pool, container=container, caching=False)
     dfuse.cores = 2
     pre_stat = os.stat(dfuse.dir)
     dfuse.start(v_hint='pool_and_cont')
@@ -2722,73 +2755,6 @@ def run_dfuse(server, conf):
     else:
         print('Reached the end, no errors')
     return fatal_errors.errors
-
-def run_il_test(server, conf):
-    """Run a basic interception library test"""
-
-    pool = server.get_test_pool()
-
-    # TODO:                       # pylint: disable=W0511
-    # Implement a test which copies across two pools.
-
-    dfuse = DFuse(server, conf, caching=False)
-    dfuse.start()
-
-    dirs = []
-
-    for _ in range(2):
-        # Use a unique ID for each container to avoid DAOS-5109
-        container = str(uuid.uuid4())
-
-        d = os.path.join(dfuse.dir, pool, container)
-        try:
-            print('Making directory {}'.format(d))
-            os.mkdir(d)
-        except FileExistsError:
-            pass
-        dirs.append(d)
-
-    # Create a file natively.
-    f = os.path.join(dirs[0], 'file')
-    fd = open(f, 'w')
-    fd.write('Hello')
-    fd.close()
-    # Copy it across containers.
-    ret = il_cmd(dfuse, ['cp', f, dirs[-1]])
-    assert ret.returncode == 0
-
-    # Copy it within the container.
-    child_dir = os.path.join(dirs[0], 'new_dir')
-    os.mkdir(child_dir)
-    il_cmd(dfuse, ['cp', f, child_dir])
-    assert ret.returncode == 0
-
-    # Copy something into a container
-    ret = il_cmd(dfuse, ['cp', '/bin/bash', dirs[-1]], check_read=False)
-    assert ret.returncode == 0
-    # Read it from within a container
-    # TODO:                              # pylint: disable=W0511
-    # change this to something else, md5sum uses fread which isn't
-    # intercepted.
-    ret = il_cmd(dfuse,
-                 ['md5sum', os.path.join(dirs[-1], 'bash')],
-                 check_read=False, check_write=False, check_fstat=False)
-    assert ret.returncode == 0
-    ret = il_cmd(dfuse, ['dd',
-                         'if={}'.format(os.path.join(dirs[-1], 'bash')),
-                         'of={}'.format(os.path.join(dirs[-1], 'bash_copy')),
-                         'iflag=direct',
-                         'oflag=direct',
-                         'bs=128k'],
-                 check_fstat=False)
-
-    print(ret)
-    assert ret.returncode == 0
-
-    for my_dir in dirs:
-        create_and_read_via_il(dfuse, my_dir)
-
-    dfuse.stop()
 
 def run_in_fg(server, conf):
     """Run dfuse in the foreground.
@@ -3509,23 +3475,18 @@ def test_alloc_fail_cat(server, conf):
     """
 
     pool = server.get_test_pool()
+    container = create_cont(conf, pool, ctype='POSIX', label='fault_inject')
 
-    dfuse = DFuse(server, conf, pool=pool)
+    dfuse = DFuse(server, conf, pool=pool, container=container)
     dfuse.use_valgrind = False
     dfuse.start()
 
-    container = str(uuid.uuid4())
+    target_file = os.path.join(dfuse.dir, 'test_file')
 
-    os.mkdir(os.path.join(dfuse.dir, container))
-    target_file = os.path.join(dfuse.dir, container, 'test_file')
+    with open(target_file, 'w') as fd:
+        fd.write('Hello there')
 
-    fd = open(target_file, 'w')
-    fd.write('Hello there')
-    fd.close()
-
-    cmd = ['cat', target_file]
-
-    test_cmd = AllocFailTest(conf, 'il-cat', cmd)
+    test_cmd = AllocFailTest(conf, 'il-cat', ['cat', target_file])
     test_cmd.use_il = True
     test_cmd.check_stderr = False
     test_cmd.wf = conf.wf
@@ -3639,8 +3600,6 @@ def run(wf, args):
         try:
             if args.mode == 'launch':
                 run_in_fg(server, conf)
-            elif args.mode == 'il':
-                fatal_errors.add_result(run_il_test(server, conf))
             elif args.mode == 'kv':
                 test_pydaos_kv(server, conf)
             elif args.mode == 'overlay':
@@ -3650,7 +3609,6 @@ def run(wf, args):
             elif args.mode == 'all':
                 fi_test_dfuse = True
                 fatal_errors.add_result(run_posix_tests(server, conf))
-                fatal_errors.add_result(run_il_test(server, conf))
                 fatal_errors.add_result(run_dfuse(server, conf))
                 fatal_errors.add_result(run_duns_overlay_test(server, conf))
                 test_pydaos_kv(server, conf)
@@ -3661,7 +3619,6 @@ def run(wf, args):
                 fatal_errors.add_result(run_posix_tests(server, conf, args.test))
             else:
                 fatal_errors.add_result(run_posix_tests(server, conf))
-                fatal_errors.add_result(run_il_test(server, conf))
                 fatal_errors.add_result(run_dfuse(server, conf))
                 fatal_errors.add_result(set_server_fi(server))
         finally:

--- a/utils/node_local_test.py
+++ b/utils/node_local_test.py
@@ -867,28 +867,24 @@ def il_cmd(dfuse, cmd, check_read=True, check_write=True, check_fstat=True):
     """
     my_env = get_base_env()
     prefix = 'dnt_dfuse_il_{}_'.format(get_inc_id())
-    log_file = tempfile.NamedTemporaryFile(prefix=prefix,
-                                           suffix='.log',
-                                           delete=False)
+    log_file = tempfile.NamedTemporaryFile(prefix=prefix, suffix='.log', delete=False)
     my_env['D_LOG_FILE'] = log_file.name
-    my_env['LD_PRELOAD'] = os.path.join(dfuse.conf['PREFIX'],
-                                        'lib64', 'libioil.so')
+    my_env['LD_PRELOAD'] = os.path.join(dfuse.conf['PREFIX'], 'lib64', 'libioil.so')
     my_env['DAOS_AGENT_DRPC_DIR'] = dfuse._daos.agent_dir
     my_env['D_IL_REPORT'] = '2'
     ret = subprocess.run(cmd, env=my_env, check=False)
     print('Logged il to {}'.format(log_file.name))
     print(ret)
 
+    if dfuse.caching:
+        check_fstat = False
+
     try:
-        log_test(dfuse.conf,
-                 log_file.name,
-                 check_read=check_read,
-                 check_write=check_write,
+        log_test(dfuse.conf, log_file.name, check_read=check_read, check_write=check_write,
                  check_fstat=check_fstat)
         assert ret.returncode == 0
     except NLTestNoFunction as error:
-        print("ERROR: command '{}' did not log via {}".format(' '.join(cmd),
-                                                              error.function))
+        print("ERROR: command '{}' did not log via {}".format(' '.join(cmd), error.function))
         ret.returncode = 1
 
     return ret
@@ -1729,19 +1725,16 @@ class posix_tests():
         # TODO:                              # pylint: disable=W0511
         # change this to something else, md5sum uses fread which isn't
         # intercepted.
-        ret = il_cmd(self.dfuse,
-                     ['md5sum', os.path.join(sub_cont_dir, 'bash')],
+        ret = il_cmd(self.dfuse, ['md5sum', os.path.join(sub_cont_dir, 'bash')],
                      check_read=False, check_write=False, check_fstat=False)
         assert ret.returncode == 0
         ret = il_cmd(self.dfuse, ['dd',
-                             'if={}'.format(os.path.join(sub_cont_dir, 'bash')),
-                             'of={}'.format(os.path.join(sub_cont_dir, 'bash_copy')),
-                             'iflag=direct',
-                             'oflag=direct',
-                             'bs=128k'],
+                                  'if={}'.format(os.path.join(sub_cont_dir, 'bash')),
+                                  'of={}'.format(os.path.join(sub_cont_dir, 'bash_copy')),
+                                  'iflag=direct',
+                                  'oflag=direct',
+                                  'bs=128k'],
                      check_fstat=False)
-
-        print(ret)
         assert ret.returncode == 0
 
     @needs_dfuse


### PR DESCRIPTION
Remove the abilty to create a container in dfuse, and therefore
drop having to have write permissions on pools at all.

Remove, or upate and cleanup tests which used this feature.

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>
