### PR TITLE
DAOS-8082 vos: More conservative allocation of DTX LIDs

### DIFF
--- a/src/vos/vos_internal.h
+++ b/src/vos/vos_internal.h
@@ -81,9 +81,9 @@ extern struct dss_module_key vos_module_key;
 #define VOS_BLK_SZ		(1UL << VOS_BLK_SHIFT) /* bytes */
 #define VOS_BLOB_HDR_BLKS	1	/* block */
 
-/** Up to 1 million lid entries split into 16 expansion slots */
+/** Up to 1 million lid entries split into 2048 expansion slots */
 #define DTX_ARRAY_LEN		(1 << 20) /* Total array slots for DTX lid */
-#define DTX_ARRAY_NR		(1 << 4)  /* Number of expansion arrays */
+#define DTX_ARRAY_NR		(1 << 11)  /* Number of expansion arrays */
 
 enum {
 	/** Used for marking an in-tree record committed */


### PR DESCRIPTION
The local id table for DTX allocates blocks of entries using the
lru array.  It always keeps one of these around.  The current
size is way too large for a per-container allocation and uses
18MB even if the dtx active table is empty.  This will cut it
down to a about 256KB for an empty table (for the array itself
and 1 free subarray).

This amounts to 1 extra malloc per 512 DTX entries so should be
lost in noise.  It still may be a bit heavy for 10K containers
but it's a lot less total memory than before.   We probably need
to look into a mechanism to free the last subarray for unused
containers.   The reason we currently don't is to avoid cases
where we allocate and free on every I/O.

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>