### PR TITLE
DAOS-8735 dtx: simplify DTX abort interface

### DIFF
--- a/src/dtx/dtx_common.c
+++ b/src/dtx/dtx_common.c
@@ -1316,8 +1316,7 @@ abort:
 	if (unpin || (result < 0 && result != -DER_AGAIN && !dth->dth_solo)) {
 		/* Drop partial modification for distributed transaction. */
 		vos_dtx_cleanup(dth);
-		dte = &dth->dth_dte;
-		dtx_abort(cont, dth->dth_epoch, &dte, 1);
+		dtx_abort(cont, &dth->dth_dte, dth->dth_epoch);
 		aborted = true;
 	}
 

--- a/src/dtx/dtx_resync.c
+++ b/src/dtx/dtx_resync.c
@@ -269,7 +269,7 @@ dtx_status_handle_one(struct ds_cont_child *cont, struct dtx_entry *dte,
 			 *	Then we mark the TX as corrupted via special
 			 *	dtx_abort() with 0 @epoch.
 			 */
-			rc = dtx_abort(cont, 0, &dte, 1);
+			rc = dtx_abort(cont, dte, 0);
 			if (rc < 0 && err != NULL)
 				*err = rc;
 
@@ -312,7 +312,7 @@ dtx_status_handle_one(struct ds_cont_child *cont, struct dtx_entry *dte,
 		 * some other DTX(s). To avoid complex rollback logic, let's
 		 * abort the DTXs one by one, not batched.
 		 */
-		rc = dtx_abort(cont, epoch, &dte, 1);
+		rc = dtx_abort(cont, dte, epoch);
 
 		D_DEBUG(DB_TRACE,
 			"As the new leader for TX "DF_DTI", abort it: "
@@ -356,7 +356,7 @@ dtx_status_handle(struct dtx_resync_args *dra)
 	if (drh->drh_count == 0)
 		goto out;
 
-	ABT_rwlock_wrlock(pool->sp_lock);
+	ABT_rwlock_rdlock(pool->sp_lock);
 	tgt_cnt = pool_map_target_nr(pool->sp_map);
 	ABT_rwlock_unlock(pool->sp_lock);
 	D_ASSERT(tgt_cnt != 0);

--- a/src/dtx/dtx_rpc.c
+++ b/src/dtx/dtx_rpc.c
@@ -180,8 +180,7 @@ dtx_req_cb(const struct crt_cb_info *cb_info)
 			 * been aborted or committed (then removed by DTX aggregation). Then mark it
 			 * as 'orphan' that will be handled via some special DAOS tools in future.
 			 */
-			rc1 = vos_dtx_set_flags(dra->dra_cont->sc_hdl, &dsp->dsp_xid,
-						1, DTE_ORPHAN);
+			rc1 = vos_dtx_set_flags(dra->dra_cont->sc_hdl, &dsp->dsp_xid, DTE_ORPHAN);
 			D_ERROR("Hit uncertain leaked DTX "DF_DTI", mark it as orphan: "DF_RC"\n",
 				DP_DTI(&dsp->dsp_xid), DP_RC(rc1));
 			D_FREE(dsp);
@@ -194,8 +193,7 @@ dtx_req_cb(const struct crt_cb_info *cb_info)
 			/* The leader does not have related DTX info, we may miss related DTX abort
 			 * request, let's abort it locally.
 			 */
-			rc1 = vos_dtx_abort(dra->dra_cont->sc_hdl, DAOS_EPOCH_MAX,
-					    &dsp->dsp_xid, 1);
+			rc1 = vos_dtx_abort(dra->dra_cont->sc_hdl, &dsp->dsp_xid, DAOS_EPOCH_MAX);
 			if (rc1 < 0 && rc1 != -DER_NONEXIST && dra->dra_abt_list != NULL)
 				d_list_add_tail(&dsp->dsp_link, dra->dra_abt_list);
 			else
@@ -483,8 +481,8 @@ btr_ops_t dbtree_dtx_cf_ops = {
 #define DTX_CF_BTREE_ORDER	20
 
 static int
-dtx_dti_classify_one(struct ds_pool *pool, daos_handle_t tree, d_list_t *head,
-		     int *length, struct dtx_entry *dte, int count)
+dtx_classify_one(struct ds_pool *pool, daos_handle_t tree, d_list_t *head,
+		 int *length, struct dtx_entry *dte, int count)
 {
 	struct dtx_memberships		*mbs = dte->dte_mbs;
 	struct dtx_cf_rec_bundle	 dcrb;
@@ -495,28 +493,27 @@ dtx_dti_classify_one(struct ds_pool *pool, daos_handle_t tree, d_list_t *head,
 	if (mbs->dm_tgt_cnt == 0)
 		return -DER_INVAL;
 
-	dcrb.dcrb_count = count;
-	dcrb.dcrb_dti = &dte->dte_xid;
-	dcrb.dcrb_head = head;
-	dcrb.dcrb_length = length;
+	if (daos_handle_is_valid(tree)) {
+		dcrb.dcrb_count = count;
+		dcrb.dcrb_dti = &dte->dte_xid;
+		dcrb.dcrb_head = head;
+		dcrb.dcrb_length = length;
+	}
 
 	crt_group_rank(NULL, &myrank);
 	for (i = 0; i < mbs->dm_tgt_cnt && rc >= 0; i++) {
 		struct pool_target	*target;
-		d_iov_t			 kiov;
-		d_iov_t			 riov;
 
 		ABT_rwlock_rdlock(pool->sp_lock);
 		rc = pool_map_find_target(pool->sp_map,
 					  mbs->dm_tgts[i].ddt_id, &target);
+		ABT_rwlock_unlock(pool->sp_lock);
 		if (rc != 1) {
 			D_WARN("Cannot find target %u at %d/%d, flags %x\n",
 			       mbs->dm_tgts[i].ddt_id, i, mbs->dm_tgt_cnt,
 			       mbs->dm_flags);
-			ABT_rwlock_unlock(pool->sp_lock);
 			return -DER_UNINIT;
 		}
-		ABT_rwlock_unlock(pool->sp_lock);
 
 		/* Skip the target that (re-)joined the system after the DTX. */
 		if (target->ta_comp.co_ver > dte->dte_ver)
@@ -533,13 +530,30 @@ dtx_dti_classify_one(struct ds_pool *pool, daos_handle_t tree, d_list_t *head,
 		    target->ta_comp.co_index)
 			continue;
 
-		dcrb.dcrb_rank = target->ta_comp.co_rank;
-		dcrb.dcrb_tag = target->ta_comp.co_index;
+		if (daos_handle_is_valid(tree)) {
+			d_iov_t			 kiov;
+			d_iov_t			 riov;
 
-		d_iov_set(&riov, &dcrb, sizeof(dcrb));
-		d_iov_set(&kiov, &dcrb.dcrb_key, sizeof(dcrb.dcrb_key));
-		rc = dbtree_upsert(tree, BTR_PROBE_EQ, DAOS_INTENT_UPDATE,
-				   &kiov, &riov);
+			dcrb.dcrb_rank = target->ta_comp.co_rank;
+			dcrb.dcrb_tag = target->ta_comp.co_index;
+
+			d_iov_set(&riov, &dcrb, sizeof(dcrb));
+			d_iov_set(&kiov, &dcrb.dcrb_key, sizeof(dcrb.dcrb_key));
+			rc = dbtree_upsert(tree, BTR_PROBE_EQ, DAOS_INTENT_UPDATE, &kiov, &riov);
+		} else {
+			struct dtx_req_rec	*drr;
+
+			D_ALLOC_PTR(drr);
+			if (drr == NULL)
+				return -DER_NOMEM;
+
+			drr->drr_rank = target->ta_comp.co_rank;
+			drr->drr_tag = target->ta_comp.co_index;
+			drr->drr_count = 1;
+			drr->drr_dti = &dte->dte_xid;
+			d_list_add_tail(&drr->drr_link, head);
+			(*length)++;
+		}
 	}
 
 	return rc > 0 ? 0 : rc;
@@ -555,8 +569,7 @@ dtx_dti_classify(struct ds_pool *pool, daos_handle_t tree,
 	int	i;
 
 	for (i = 0; i < count; i++) {
-		rc = dtx_dti_classify_one(pool, tree, head, &length,
-					  dtes[i], count);
+		rc = dtx_classify_one(pool, tree, head, &length, dtes[i], count);
 		if (rc < 0)
 			break;
 
@@ -584,8 +597,13 @@ dtx_commit_internal(struct ds_cont_child *cont, d_list_t *head,
 		    struct dtx_entry **dtes, int count)
 {
 	struct umem_attr	 uma = { 0 };
+	struct ds_pool		*pool;
 	int			 length;
 	int			 rc;
+
+	D_ASSERT(cont->sc_pool != NULL);
+	pool = cont->sc_pool->spc_pool;
+	D_ASSERT(pool != NULL);
 
 	uma.uma_id = UMEM_CLASS_VMEM;
 	rc = dbtree_create_inplace(DBTREE_CLASS_DTX_CF, 0, DTX_CF_BTREE_ORDER,
@@ -593,8 +611,7 @@ dtx_commit_internal(struct ds_cont_child *cont, d_list_t *head,
 	if (rc != 0)
 		return rc;
 
-	length = dtx_dti_classify(cont->sc_pool->spc_pool, *tree_hdl,
-				  head, dtis, dtes, count);
+	length = dtx_dti_classify(pool, *tree_hdl, head, dtis, dtes, count);
 	if (length < 0)
 		return length;
 
@@ -603,8 +620,7 @@ dtx_commit_internal(struct ds_cont_child *cont, d_list_t *head,
 
 	D_ASSERT(length > 0);
 
-	return dtx_req_list_send(dra, DTX_COMMIT, head, length,
-				 cont->sc_pool->spc_pool->sp_uuid,
+	return dtx_req_list_send(dra, DTX_COMMIT, head, length, pool->sp_uuid,
 				 cont->sc_uuid, 0, NULL, NULL, NULL, NULL);
 }
 
@@ -647,6 +663,8 @@ dtx_commit(struct ds_cont_child *cont, struct dtx_entry **dtes,
 	d_list_t		 head;
 	ABT_thread		 child = ABT_THREAD_NULL;
 	struct dtx_commit_args	*cmt_arg = NULL;
+	struct dtx_id		 dti;
+	bool			 cos;
 	int			 rc;
 	int			 rc1 = 0;
 	int			 rc2 = 0;
@@ -657,9 +675,13 @@ dtx_commit(struct ds_cont_child *cont, struct dtx_entry **dtes,
 	dra.dra_future = ABT_FUTURE_NULL;
 	D_INIT_LIST_HEAD(&head);
 
-	D_ALLOC_ARRAY(dtis, count);
-	if (dtis == NULL)
-		D_GOTO(out, rc = -DER_NOMEM);
+	if (count > 1) {
+		D_ALLOC_ARRAY(dtis, count);
+		if (dtis == NULL)
+			D_GOTO(out, rc = -DER_NOMEM);
+	} else {
+		dtis = &dti;
+	}
 
 	if (helper) {
 		D_ALLOC_PTR(cmt_arg);
@@ -692,9 +714,13 @@ dtx_commit(struct ds_cont_child *cont, struct dtx_entry **dtes,
 	}
 
 	if (dcks != NULL) {
-		D_ALLOC_ARRAY(rm_cos, count);
-		if (rm_cos == NULL)
-			D_GOTO(out, rc1 = -DER_NOMEM);
+		if (count > 1) {
+			D_ALLOC_ARRAY(rm_cos, count);
+			if (rm_cos == NULL)
+				D_GOTO(out, rc1 = -DER_NOMEM);
+		} else {
+			rm_cos = &cos;
+		}
 	}
 
 	rc1 = vos_dtx_commit(cont->sc_hdl, dtis, count, rm_cos);
@@ -709,7 +735,8 @@ dtx_commit(struct ds_cont_child *cont, struct dtx_entry **dtes,
 		}
 	}
 
-	D_FREE(rm_cos);
+	if (rm_cos != &cos)
+		D_FREE(rm_cos);
 
 out:
 	/* -DER_NONEXIST may be caused by race or repeated commit, ignore it. */
@@ -729,14 +756,14 @@ out:
 		 "Commit DTXs "DF_DTI", count %d: rc %d %d %d\n",
 		 DP_DTI(&dtes[0]->dte_xid), count, rc, rc1, rc2);
 
-	D_FREE(dtis);
+	if (dtis != &dti)
+		D_FREE(dtis);
 
 	if (daos_handle_is_valid(tree_hdl))
 		dbtree_destroy(tree_hdl, NULL);
 
 	while ((drr = d_list_pop_entry(&head, struct dtx_req_rec,
 				       drr_link)) != NULL) {
-		D_FREE(drr->drr_cb_args);
 		D_FREE(drr->drr_dti);
 		D_FREE(drr);
 	}
@@ -745,50 +772,35 @@ out:
 }
 
 int
-dtx_abort(struct ds_cont_child *cont, daos_epoch_t epoch,
-	  struct dtx_entry **dtes, int count)
+dtx_abort(struct ds_cont_child *cont, struct dtx_entry *dte, daos_epoch_t epoch)
 {
-	struct dtx_req_args	 dra;
 	struct dtx_req_rec	*drr;
-	struct ds_pool		*pool = cont->sc_pool->spc_pool;
-	struct dtx_id		*dtis = NULL;
-	struct umem_attr	 uma = { 0 };
-	struct btr_root		 tree_root = { 0 };
-	daos_handle_t		 tree_hdl = DAOS_HDL_INVAL;
+	struct ds_pool		*pool;
 	d_list_t		 head;
-	int			 length;
+	int			 length = 0;
 	int			 rc;
 
-	D_ASSERT(count >= 1);
+	D_ASSERT(cont->sc_pool != NULL);
+	pool = cont->sc_pool->spc_pool;
+	D_ASSERT(pool != NULL);
 
-	dra.dra_future = ABT_FUTURE_NULL;
 	D_INIT_LIST_HEAD(&head);
-
-	D_ALLOC_ARRAY(dtis, count);
-	if (dtis == NULL)
-		D_GOTO(out, rc = -DER_NOMEM);
-
-	uma.uma_id = UMEM_CLASS_VMEM;
-	rc = dbtree_create_inplace(DBTREE_CLASS_DTX_CF, 0, DTX_CF_BTREE_ORDER,
-				   &uma, &tree_root, &tree_hdl);
-	if (rc != 0)
+	rc = dtx_classify_one(pool, DAOS_HDL_INVAL, &head, &length, dte, 1);
+	if (rc < 0)
 		goto out;
-
-	length = dtx_dti_classify(pool, tree_hdl, &head, dtis, dtes, count);
-	if (length < 0)
-		D_GOTO(out, rc = length);
 
 	/* Local abort firstly. */
 	if (epoch != 0)
-		rc = vos_dtx_abort(cont->sc_hdl, epoch, dtis, count);
+		rc = vos_dtx_abort(cont->sc_hdl, &dte->dte_xid, epoch);
 	else
-		rc = vos_dtx_set_flags(cont->sc_hdl, dtis, count,
-				       DTE_CORRUPTED);
+		rc = vos_dtx_set_flags(cont->sc_hdl, &dte->dte_xid, DTE_CORRUPTED);
 
 	if (rc > 0 || rc == -DER_NONEXIST)
 		rc = 0;
 
 	if (rc == 0 && !d_list_empty(&head)) {
+		struct dtx_req_args	dra;
+
 		rc = dtx_req_list_send(&dra, DTX_ABORT, &head, length,
 				       pool->sp_uuid, cont->sc_uuid, epoch,
 				       NULL, NULL, NULL, NULL);
@@ -801,21 +813,11 @@ dtx_abort(struct ds_cont_child *cont, daos_epoch_t epoch,
 	}
 
 out:
-	D_CDEBUG(rc != 0, DLOG_ERR, DB_IO,
-		 "Abort DTXs "DF_DTI", count %d: rc %d\n",
-		 DP_DTI(&dtes[0]->dte_xid), count, rc);
+	D_CDEBUG(rc != 0, DLOG_ERR, DB_IO, "Abort DTXs "DF_DTI": rc "DF_RC"\n",
+		 DP_DTI(&dte->dte_xid), DP_RC(rc));
 
-	D_FREE(dtis);
-
-	if (daos_handle_is_valid(tree_hdl))
-		dbtree_destroy(tree_hdl, NULL);
-
-	while ((drr = d_list_pop_entry(&head, struct dtx_req_rec,
-				       drr_link)) != NULL) {
-		D_FREE(drr->drr_cb_args);
-		D_FREE(drr->drr_dti);
-		D_FREE(drr);
-	}
+	while ((drr = d_list_pop_entry(&head, struct dtx_req_rec, drr_link)) != NULL)
+		D_FREE_PTR(drr);
 
 	return rc < 0 ? rc : 0;
 }
@@ -824,78 +826,32 @@ int
 dtx_check(struct ds_cont_child *cont, struct dtx_entry *dte, daos_epoch_t epoch)
 {
 	struct dtx_req_args	 dra;
-	struct dtx_memberships	*mbs = dte->dte_mbs;
-	struct ds_pool		*pool = cont->sc_pool->spc_pool;
+	struct ds_pool		*pool;
 	struct dtx_req_rec	*drr;
-	struct dtx_req_rec	*next;
 	d_list_t		 head;
-	d_rank_t		 myrank;
 	int			 length = 0;
 	int			 rc = 0;
-	int			 i;
 
-	if (mbs->dm_tgt_cnt == 0)
-		return -DER_INVAL;
+	D_ASSERT(cont->sc_pool != NULL);
+	pool = cont->sc_pool->spc_pool;
+	D_ASSERT(pool != NULL);
 
 	/* If no other target, then current target is the unique
 	 * one that can be committed if it is 'prepared'.
 	 */
-	if (mbs->dm_tgt_cnt == 1)
+	if (dte->dte_mbs->dm_tgt_cnt == 1)
 		return DTX_ST_PREPARED;
 
 	D_INIT_LIST_HEAD(&head);
-	crt_group_rank(NULL, &myrank);
-	for (i = 0; i < mbs->dm_tgt_cnt; i++) {
-		struct pool_target	*target;
-
-		ABT_rwlock_rdlock(pool->sp_lock);
-		rc = pool_map_find_target(pool->sp_map,
-					  mbs->dm_tgts[i].ddt_id, &target);
-		if (rc != 1) {
-			D_WARN("Cannot find target %u at %d/%d, flags %x\n",
-			       mbs->dm_tgts[i].ddt_id, i, mbs->dm_tgt_cnt,
-			       mbs->dm_flags);
-			ABT_rwlock_unlock(pool->sp_lock);
-			D_GOTO(out, rc = -DER_UNINIT);
-		}
-		ABT_rwlock_unlock(pool->sp_lock);
-
-		/* Skip the target that (re-)joined the system after the DTX. */
-		if (target->ta_comp.co_ver > dte->dte_ver)
-			continue;
-
-		/* Skip non-healthy one. */
-		if (target->ta_comp.co_status != PO_COMP_ST_UP &&
-		    target->ta_comp.co_status != PO_COMP_ST_UPIN)
-			continue;
-
-		/* skip myself. */
-		if (myrank == target->ta_comp.co_rank &&
-		    dss_get_module_info()->dmi_tgt_id ==
-		    target->ta_comp.co_index)
-			continue;
-
-		D_ALLOC_PTR(drr);
-		if (drr == NULL) {
-			rc = -DER_NOMEM;
-			goto out;
-		}
-
-		drr->drr_rank = target->ta_comp.co_rank;
-		drr->drr_tag = target->ta_comp.co_index;
-		drr->drr_count = 1;
-		drr->drr_dti = &dte->dte_xid;
-		d_list_add_tail(&drr->drr_link, &head);
-		length++;
-	}
+	rc = dtx_classify_one(pool, DAOS_HDL_INVAL, &head, &length, dte, 1);
+	if (rc < 0)
+		goto out;
 
 	/* If no other available targets, then current target is the
 	 * unique valid one, it can be committed if it is also 'prepared'.
 	 */
-	if (d_list_empty(&head)) {
-		rc = DTX_ST_PREPARED;
-		goto out;
-	}
+	if (d_list_empty(&head))
+		D_GOTO(out, rc = DTX_ST_PREPARED);
 
 	rc = dtx_req_list_send(&dra, DTX_CHECK, &head, length, pool->sp_uuid,
 			       cont->sc_uuid, epoch, NULL, NULL, NULL, NULL);
@@ -903,10 +859,8 @@ dtx_check(struct ds_cont_child *cont, struct dtx_entry *dte, daos_epoch_t epoch)
 		rc = dtx_req_wait(&dra);
 
 out:
-	d_list_for_each_entry_safe(drr, next, &head, drr_link) {
-		d_list_del(&drr->drr_link);
+	while ((drr = d_list_pop_entry(&head, struct dtx_req_rec, drr_link)) != NULL)
 		D_FREE_PTR(drr);
-	}
 
 	return rc;
 }

--- a/src/include/daos_srv/dtx_srv.h
+++ b/src/include/daos_srv/dtx_srv.h
@@ -233,8 +233,8 @@ void dtx_batched_commit_deregister(struct ds_cont_child *cont);
 int dtx_obj_sync(struct ds_cont_child *cont, daos_unit_oid_t *oid,
 		 daos_epoch_t epoch);
 
-int dtx_abort(struct ds_cont_child *cont, daos_epoch_t epoch,
-	      struct dtx_entry **dtes, int count);
+int dtx_abort(struct ds_cont_child *cont, struct dtx_entry *dte, daos_epoch_t epoch);
+
 int dtx_refresh(struct dtx_handle *dth, struct ds_cont_child *cont);
 
 /**

--- a/src/include/daos_srv/vos.h
+++ b/src/include/daos_srv/vos.h
@@ -108,31 +108,25 @@ vos_dtx_commit(daos_handle_t coh, struct dtx_id *dtis, int count,
  * Abort the specified DTXs.
  *
  * \param coh	[IN]	Container open handle.
+ * \param dti	[IN]	The DTX identifiers to be aborted.
  * \param epoch	[IN]	The max epoch for the DTX to be aborted.
- * \param dtis	[IN]	The array for DTX identifiers to be aborted.
- * \param count [IN]	The count of DTXs to be aborted.
  *
- * \return		Negative value if error.
- * \return		Others are for the count of aborted DTXs.
+ * \return		Zero on success, negative value if error.
  */
 int
-vos_dtx_abort(daos_handle_t coh, daos_epoch_t epoch, struct dtx_id *dtis,
-	      int count);
+vos_dtx_abort(daos_handle_t coh, struct dtx_id *dti, daos_epoch_t epoch);
 
 /**
  * Set flags on the active DTXs.
  *
  * \param coh	[IN]	Container open handle.
- * \param dtis	[IN]	The array for DTX identifiers to be handled.
- * \param count [IN]	The count of DTXs to be handled.
+ * \param dti	[IN]	The DTX identifiers to be handled.
  * \param flags [IN]	The flags for the DTXs.
  *
- * \return		Negative value if error.
- * \return		Others are for the count of handled DTXs.
+ * \return		Zero on success, negative value if error.
  */
 int
-vos_dtx_set_flags(daos_handle_t coh, struct dtx_id *dtis, int count,
-		  uint32_t flags);
+vos_dtx_set_flags(daos_handle_t coh, struct dtx_id *dti, uint32_t flags);
 
 /**
  * Aggregate the committed DTXs.

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -2261,8 +2261,7 @@ ds_obj_tgt_update_handler(crt_rpc_t *rpc)
 			/* Abort it by force with MAX epoch to guarantee
 			 * that it can be aborted.
 			 */
-			rc = vos_dtx_abort(ioc.ioc_vos_coh, DAOS_EPOCH_MAX,
-					   &orw->orw_dti, 1);
+			rc = vos_dtx_abort(ioc.ioc_vos_coh, &orw->orw_dti, DAOS_EPOCH_MAX);
 
 		if (rc < 0 && rc != -DER_NONEXIST)
 			D_GOTO(out, rc);
@@ -2692,15 +2691,13 @@ again2:
 out:
 	if (rc != 0 && need_abort) {
 		struct dtx_entry	 dte;
-		struct dtx_entry	*pdte;
 		int			 rc1;
 
 		dte.dte_xid = orw->orw_dti;
 		dte.dte_ver = version;
 		dte.dte_refs = 1;
 		dte.dte_mbs = mbs;
-		pdte = &dte;
-		rc1 = dtx_abort(ioc.ioc_coc, orw->orw_epoch, &pdte, 1);
+		rc1 = dtx_abort(ioc.ioc_coc, &dte, orw->orw_epoch);
 		if (rc1 != 0 && rc1 != -DER_NONEXIST)
 			D_WARN("Failed to abort DTX "DF_DTI": "DF_RC"\n",
 			       DP_DTI(&orw->orw_dti), DP_RC(rc1));
@@ -3240,8 +3237,7 @@ ds_obj_tgt_punch_handler(crt_rpc_t *rpc)
 			/* Abort it by force with MAX epoch to guarantee
 			 * that it can be aborted.
 			 */
-			rc = vos_dtx_abort(ioc.ioc_vos_coh, DAOS_EPOCH_MAX,
-					   &opi->opi_dti, 1);
+			rc = vos_dtx_abort(ioc.ioc_vos_coh, &opi->opi_dti, DAOS_EPOCH_MAX);
 
 		if (rc < 0 && rc != -DER_NONEXIST)
 			D_GOTO(out, rc);
@@ -3556,15 +3552,13 @@ again2:
 out:
 	if (rc != 0 && need_abort) {
 		struct dtx_entry	 dte;
-		struct dtx_entry	*pdte;
 		int			 rc1;
 
 		dte.dte_xid = opi->opi_dti;
 		dte.dte_ver = version;
 		dte.dte_refs = 1;
 		dte.dte_mbs = mbs;
-		pdte = &dte;
-		rc1 = dtx_abort(ioc.ioc_coc, opi->opi_epoch, &pdte, 1);
+		rc1 = dtx_abort(ioc.ioc_coc, &dte, opi->opi_epoch);
 		if (rc1 != 0 && rc1 != -DER_NONEXIST)
 			D_WARN("Failed to abort DTX "DF_DTI": "DF_RC"\n",
 			       DP_DTI(&opi->opi_dti), DP_RC(rc1));
@@ -4276,8 +4270,7 @@ ds_obj_dtx_follower(crt_rpc_t *rpc, struct obj_io_context *ioc)
 		/* For resent RPC, abort it firstly if exist but with different
 		 * (old) epoch, then re-execute with new epoch.
 		 */
-		rc = vos_dtx_abort(ioc->ioc_vos_coh, DAOS_EPOCH_MAX,
-				   &dcsh->dcsh_xid, 1);
+		rc = vos_dtx_abort(ioc->ioc_vos_coh, &dcsh->dcsh_xid, DAOS_EPOCH_MAX);
 
 		if (rc < 0 && rc != -DER_NONEXIST)
 			D_GOTO(out, rc);
@@ -4596,16 +4589,13 @@ out:
 
 	if (rc != 0 && need_abort) {
 		struct dtx_entry	 dte;
-		struct dtx_entry	*pdte;
 		int			 rc1;
 
 		dte.dte_xid = dcsh->dcsh_xid;
 		dte.dte_ver = oci->oci_map_ver;
 		dte.dte_refs = 1;
 		dte.dte_mbs = dcsh->dcsh_mbs;
-		pdte = &dte;
-		rc1 = dtx_abort(dca->dca_ioc->ioc_coc,
-				dcsh->dcsh_epoch.oe_value, &pdte, 1);
+		rc1 = dtx_abort(dca->dca_ioc->ioc_coc, &dte, dcsh->dcsh_epoch.oe_value);
 		if (rc1 != 0 && rc1 != -DER_NONEXIST)
 			D_WARN("Failed to abort DTX "DF_DTI": "DF_RC"\n",
 			       DP_DTI(&dcsh->dcsh_xid), DP_RC(rc1));

--- a/src/vos/tests/vts_dtx.c
+++ b/src/vos/tests/vts_dtx.c
@@ -354,8 +354,8 @@ vts_dtx_abort_visibility(struct io_test_args *args, bool ext, bool punch_obj)
 	vts_dtx_end(dth);
 
 	/* Aborted the update DTX. */
-	rc = vos_dtx_abort(args->ctx.tc_co_hdl, epoch, &xid, 1);
-	assert_rc_equal(rc, 1);
+	rc = vos_dtx_abort(args->ctx.tc_co_hdl, &xid, epoch);
+	assert_rc_equal(rc, 0);
 
 	memset(fetch_buf, 0, UPDATE_BUF_SIZE);
 	d_iov_set(&val_iov, fetch_buf, UPDATE_BUF_SIZE);
@@ -386,8 +386,8 @@ vts_dtx_abort_visibility(struct io_test_args *args, bool ext, bool punch_obj)
 	vts_dtx_end(dth);
 
 	/* Aborted the punch DTX. */
-	rc = vos_dtx_abort(args->ctx.tc_co_hdl, epoch, &xid, 1);
-	assert_rc_equal(rc, 1);
+	rc = vos_dtx_abort(args->ctx.tc_co_hdl, &xid, epoch);
+	assert_rc_equal(rc, 0);
 
 	memset(fetch_buf, 0, UPDATE_BUF_SIZE);
 	d_iov_set(&val_iov, fetch_buf, UPDATE_BUF_SIZE);
@@ -484,8 +484,8 @@ dtx_14(void **state)
 	assert_memory_equal(update_buf, fetch_buf, UPDATE_BUF_SIZE);
 
 	/* Committed DTX cannot be aborted. */
-	rc = vos_dtx_abort(args->ctx.tc_co_hdl, epoch, &xid, 1);
-	assert_int_not_equal(rc, 1);
+	rc = vos_dtx_abort(args->ctx.tc_co_hdl, &xid, epoch);
+	assert_int_not_equal(rc, 0);
 
 	memset(fetch_buf, 0, UPDATE_BUF_SIZE);
 	d_iov_set(&val_iov, fetch_buf, UPDATE_BUF_SIZE);
@@ -546,12 +546,12 @@ dtx_15(void **state)
 	vts_dtx_end(dth);
 
 	/* Aborted the update DTX. */
-	rc = vos_dtx_abort(args->ctx.tc_co_hdl, epoch, &xid, 1);
-	assert_rc_equal(rc, 1);
+	rc = vos_dtx_abort(args->ctx.tc_co_hdl, &xid, epoch);
+	assert_rc_equal(rc, 0);
 
 	/* Double aborted the DTX is harmless. */
-	rc = vos_dtx_abort(args->ctx.tc_co_hdl, epoch, &xid, 1);
-	assert_int_not_equal(rc, 1);
+	rc = vos_dtx_abort(args->ctx.tc_co_hdl, &xid, epoch);
+	assert_int_not_equal(rc, 0);
 
 	memset(fetch_buf, 0, UPDATE_BUF_SIZE);
 	d_iov_set(&val_iov, fetch_buf, UPDATE_BUF_SIZE);

--- a/src/vos/tests/vts_mvcc.c
+++ b/src/vos/tests/vts_mvcc.c
@@ -1556,8 +1556,7 @@ out:
 			rc = vos_dtx_commit(arg->ctx.tc_co_hdl,
 					    &wtx->th_saved_xid, 1, NULL);
 		else
-			rc = vos_dtx_abort(arg->ctx.tc_co_hdl, DAOS_EPOCH_MAX,
-					   &wtx->th_saved_xid, 1);
+			rc = vos_dtx_abort(arg->ctx.tc_co_hdl, &wtx->th_saved_xid, DAOS_EPOCH_MAX);
 		assert(rc >= 0 || rc == -DER_NONEXIST);
 	}
 
@@ -1566,8 +1565,7 @@ out:
 			rc = vos_dtx_commit(arg->ctx.tc_co_hdl,
 					    &atx->th_saved_xid, 1, NULL);
 		else
-			rc = vos_dtx_abort(arg->ctx.tc_co_hdl, DAOS_EPOCH_MAX,
-					   &atx->th_saved_xid, 1);
+			rc = vos_dtx_abort(arg->ctx.tc_co_hdl, &atx->th_saved_xid, DAOS_EPOCH_MAX);
 		assert(rc >= 0 || rc == -DER_NONEXIST);
 	}
 

--- a/src/vos/vos_dtx.c
+++ b/src/vos/vos_dtx.c
@@ -879,62 +879,6 @@ out:
 	return rc;
 }
 
-static int
-vos_dtx_abort_one(struct vos_container *cont, daos_epoch_t epoch,
-		  struct dtx_id *dti, struct vos_dtx_act_ent **dae_p,
-		  bool *fatal)
-{
-	struct vos_dtx_act_ent	*dae;
-	d_iov_t			 riov;
-	d_iov_t			 kiov;
-	int			 rc;
-
-	d_iov_set(&kiov, dti, sizeof(*dti));
-	d_iov_set(&riov, NULL, 0);
-	rc = dbtree_lookup(cont->vc_dtx_active_hdl, &kiov, &riov);
-	if (rc != 0)
-		goto out;
-
-	dae = riov.iov_buf;
-	if (dae->dae_committable || dae->dae_committed) {
-		D_ERROR("NOT allow to abort a committed DTX "DF_DTI"\n",
-			DP_DTI(dti));
-		D_GOTO(out, rc = -DER_NONEXIST);
-	}
-
-	/* It has been aborted before, but failed to be removed
-	 * from the active table, just remove it again.
-	 */
-	if (dae->dae_aborted) {
-		rc = dbtree_delete(cont->vc_dtx_active_hdl,
-				   BTR_PROBE_BYPASS, &kiov, &dae);
-		if (rc == 0) {
-			dtx_act_ent_cleanup(cont, dae, NULL, true);
-			dtx_evict_lid(cont, dae);
-		}
-
-		goto out;
-	}
-
-	if (DAE_EPOCH(dae) > epoch)
-		D_GOTO(out, rc = -DER_NONEXIST);
-
-	rc = dtx_rec_release(cont, dae, true);
-	if (rc != 0) {
-		*fatal = true;
-		goto out;
-	}
-
-	D_ASSERT(dae_p != NULL);
-	*dae_p = dae;
-
-out:
-	D_DEBUG(DB_IO, "Abort the DTX "DF_DTI": rc = "DF_RC"\n",
-		DP_DTI(dti), DP_RC(rc));
-
-	return rc;
-}
-
 static inline const char *
 vos_dtx_flags2name(uint32_t flags)
 {
@@ -948,53 +892,6 @@ vos_dtx_flags2name(uint32_t flags)
 	}
 
 	return NULL;
-}
-
-static int
-vos_dtx_set_flags_one(struct vos_container *cont, struct dtx_id *dti,
-		      uint32_t flags, bool *fatal)
-{
-	struct umem_instance		*umm = vos_cont2umm(cont);
-	struct vos_dtx_act_ent		*dae;
-	struct vos_dtx_act_ent_df	*dae_df;
-	d_iov_t				 riov;
-	d_iov_t				 kiov;
-	int				 rc;
-
-	/* Only allow set single flags. */
-	if (flags != DTE_CORRUPTED && flags != DTE_ORPHAN) {
-		D_ERROR("Try to set unrecognized flags %x on DTX "
-			DF_DTI"\n", flags, DP_DTI(dti));
-		return -DER_INVAL;
-	}
-
-	d_iov_set(&kiov, dti, sizeof(*dti));
-	d_iov_set(&riov, NULL, 0);
-	rc = dbtree_lookup(cont->vc_dtx_active_hdl, &kiov, &riov);
-	if (rc != 0)
-		goto out;
-
-	dae = (struct vos_dtx_act_ent *)riov.iov_buf;
-
-	if (dae->dae_committable || dae->dae_committed || dae->dae_aborted)
-		D_GOTO(out, rc = -DER_NONEXIST);
-
-	dae_df = umem_off2ptr(umm, dae->dae_df_off);
-	D_ASSERT(dae_df != NULL);
-
-	rc = umem_tx_add_ptr(umm, &dae_df->dae_flags,
-			     sizeof(dae_df->dae_flags));
-	if (rc == 0) {
-		dae_df->dae_flags |= flags;
-		DAE_FLAGS(dae) |= flags;
-	}
-
-out:
-	D_CDEBUG(rc != 0, DLOG_ERR, DLOG_WARN,
-		 "Mark the DTX entry "DF_DTI" as %s: "DF_RC"\n",
-		 DP_DTI(dti), vos_dtx_flags2name(flags), DP_RC(rc));
-
-	return rc;
 }
 
 static bool
@@ -2138,19 +2035,26 @@ vos_dtx_commit(daos_handle_t coh, struct dtx_id *dtis, int count, bool *rm_cos)
 {
 	struct vos_dtx_act_ent	**daes = NULL;
 	struct vos_dtx_cmt_ent	**dces = NULL;
+	struct vos_dtx_act_ent	 *dae = NULL;
+	struct vos_dtx_cmt_ent	 *dce = NULL;
 	struct vos_container	 *cont;
 	int			  committed = 0;
 	int			  rc = 0;
 
 	D_ASSERT(count > 0);
 
-	D_ALLOC_ARRAY(daes, count);
-	if (daes == NULL)
-		D_GOTO(out, rc = -DER_NOMEM);
+	if (count > 1) {
+		D_ALLOC_ARRAY(daes, count);
+		if (daes == NULL)
+			D_GOTO(out, rc = -DER_NOMEM);
 
-	D_ALLOC_ARRAY(dces, count);
-	if (dces == NULL)
-		D_GOTO(out, rc = -DER_NOMEM);
+		D_ALLOC_ARRAY(dces, count);
+		if (dces == NULL)
+			D_GOTO(out, rc = -DER_NOMEM);
+	} else {
+		daes = &dae;
+		dces = &dce;
+	}
 
 	cont = vos_hdl2cont(coh);
 	D_ASSERT(cont != NULL);
@@ -2171,92 +2075,119 @@ vos_dtx_commit(daos_handle_t coh, struct dtx_id *dtis, int count, bool *rm_cos)
 	}
 
 out:
-	D_FREE(daes);
-	D_FREE(dces);
+	if (daes != &dae)
+		D_FREE(daes);
+	if (dces != &dce)
+		D_FREE(dces);
 
 	return rc < 0 ? rc : committed;
 }
 
 int
-vos_dtx_abort(daos_handle_t coh, daos_epoch_t epoch, struct dtx_id *dtis,
-	      int count)
+vos_dtx_abort(daos_handle_t coh, struct dtx_id *dti, daos_epoch_t epoch)
 {
-	struct vos_dtx_act_ent	**daes = NULL;
-	struct vos_container	 *cont;
-	int			  aborted = 0;
-	int			  rc;
-	int			  i;
-	bool			  fatal = false;
-
-	D_ASSERT(count > 0);
-
-	D_ALLOC_ARRAY(daes, count);
-	if (daes == NULL)
-		return -DER_NOMEM;
+	struct vos_container	*cont;
+	struct umem_instance	*umm;
+	struct vos_dtx_act_ent	*dae = NULL;
+	d_iov_t			 riov;
+	d_iov_t			 kiov;
+	int			 rc;
 
 	cont = vos_hdl2cont(coh);
 	D_ASSERT(cont != NULL);
 
-	/* Abort multiple DTXs via single PMDK transaction. */
-	rc = umem_tx_begin(vos_cont2umm(cont), NULL);
-	if (rc == 0) {
-		for (i = 0; i < count; i++) {
-			rc = vos_dtx_abort_one(cont, epoch, &dtis[i], &daes[i],
-					       &fatal);
-			if (fatal) {
-				aborted = rc;
-				break;
-			}
+	d_iov_set(&kiov, dti, sizeof(*dti));
+	d_iov_set(&riov, NULL, 0);
+	rc = dbtree_lookup(cont->vc_dtx_active_hdl, &kiov, &riov);
+	if (rc != 0)
+		goto out;
 
-			if (rc == 0 && daes[i] != NULL)
-				aborted++;
-		}
-
-		rc = umem_tx_end(vos_cont2umm(cont), aborted > 0 ? 0 : rc);
-		if (rc == 0)
-			vos_dtx_post_handle(cont, daes, NULL, count,
-					    true, false);
+	dae = riov.iov_buf;
+	if (dae->dae_committable || dae->dae_committed) {
+		D_ERROR("NOT allow to abort a committed DTX "DF_DTI"\n", DP_DTI(dti));
+		D_GOTO(out, rc = -DER_NONEXIST);
 	}
 
-	D_FREE(daes);
+	/* It has been aborted before, but failed to be removed from the active table
+	 * at that time, then need to be removed again via vos_dtx_post_handle().
+	 */
+	if (dae->dae_aborted)
+		D_GOTO(out, rc = -DER_ALREADY);
 
-	return rc < 0 ? rc : aborted;
+	if (DAE_EPOCH(dae) > epoch)
+		D_GOTO(out, rc = -DER_NONEXIST);
+
+	umm = vos_cont2umm(cont);
+	rc = umem_tx_begin(umm, NULL);
+	if (rc == 0) {
+		rc = dtx_rec_release(cont, dae, true);
+		rc = umem_tx_end(umm, rc);
+	}
+
+out:
+	D_DEBUG(DB_IO, "Abort the DTX "DF_DTI": "DF_RC"\n", DP_DTI(dti), DP_RC(rc));
+
+	if (rc == -DER_ALREADY)
+		rc = 0;
+	if (rc == 0)
+		vos_dtx_post_handle(cont, &dae, NULL, 1, true, false);
+
+	return rc;
 }
 
 int
-vos_dtx_set_flags(daos_handle_t coh, struct dtx_id *dtis, int count,
-		  uint32_t flags)
+vos_dtx_set_flags(daos_handle_t coh, struct dtx_id *dti, uint32_t flags)
 {
-	struct vos_container	*cont;
-	int			 set = 0;
-	int			 rc;
-	int			 i;
-	bool			 fatal = false;
-
-	D_ASSERT(count > 0);
+	struct vos_container		*cont;
+	struct umem_instance		*umm;
+	struct vos_dtx_act_ent		*dae;
+	struct vos_dtx_act_ent_df	*dae_df;
+	d_iov_t				 riov;
+	d_iov_t				 kiov;
+	int				 rc;
 
 	cont = vos_hdl2cont(coh);
 	D_ASSERT(cont != NULL);
 
-	/* Set multiple DTXs via single PMDK transaction. */
-	rc = umem_tx_begin(vos_cont2umm(cont), NULL);
-	if (rc == 0) {
-		for (i = 0; i < count; i++) {
-			rc = vos_dtx_set_flags_one(cont, &dtis[i],
-						   flags, &fatal);
-			if (fatal) {
-				set = rc;
-				break;
-			}
-
-			if (rc == 0)
-				set++;
-		}
-
-		rc = umem_tx_end(vos_cont2umm(cont), set > 0 ? 0 : rc);
+	/* Only allow set single flags. */
+	if (flags != DTE_CORRUPTED && flags != DTE_ORPHAN) {
+		D_ERROR("Try to set unrecognized flags %x on DTX "
+			DF_DTI"\n", flags, DP_DTI(dti));
+		D_GOTO(out, rc = -DER_INVAL);
 	}
 
-	return rc < 0 ? rc : set;
+	d_iov_set(&kiov, dti, sizeof(*dti));
+	d_iov_set(&riov, NULL, 0);
+	rc = dbtree_lookup(cont->vc_dtx_active_hdl, &kiov, &riov);
+	if (rc != 0)
+		goto out;
+
+	dae = (struct vos_dtx_act_ent *)riov.iov_buf;
+	if (dae->dae_committable || dae->dae_committed || dae->dae_aborted)
+		D_GOTO(out, rc = -DER_NONEXIST);
+
+	umm = vos_cont2umm(cont);
+	dae_df = umem_off2ptr(umm, dae->dae_df_off);
+	D_ASSERT(dae_df != NULL);
+
+	rc = umem_tx_begin(umm, NULL);
+	if (rc != 0)
+		goto out;
+
+	rc = umem_tx_add_ptr(umm, &dae_df->dae_flags, sizeof(dae_df->dae_flags));
+	if (rc == 0)
+		dae_df->dae_flags |= flags;
+
+	rc = umem_tx_end(umm, rc);
+	if (rc == 0)
+		DAE_FLAGS(dae) |= flags;
+
+out:
+	D_CDEBUG(rc != 0, DLOG_ERR, DLOG_WARN,
+		 "Mark the DTX entry "DF_DTI" as %s: "DF_RC"\n",
+		 DP_DTI(dti), vos_dtx_flags2name(flags), DP_RC(rc));
+
+	return rc;
 }
 
 int


### PR DESCRIPTION
master-commit: f37bbbfd66484a02ba3ad991b4c2869e8b92f475

Currently, we do not have the usage of aborting multiple DTX entries
via signle API or RPC. Then we can simplify related VOS APIs to drop
useless parameters. The patch also avoids some small pieces of DRAM
allocation for DTX commit/abort.

On the other hand, the patch also adds some check for pool related
data strucutre to avoid access invalid DRAM when prepare DTX RPCs.

Another fixes: use read lock when access pool map for DTX refresh.

Signed-off-by: Fan Yong <fan.yong@intel.com>