### PR TITLE
DAOS-8870 dtx: some DTX enhancement for EC object

### DIFF
--- a/src/dtx/dtx_resync.c
+++ b/src/dtx/dtx_resync.c
@@ -147,20 +147,44 @@ dtx_is_leader(struct ds_pool *pool, struct dtx_resync_args *dra,
 	      struct dtx_resync_entry *dre)
 {
 	struct dtx_memberships	*mbs = dre->dre_dte.dte_mbs;
+	struct pool_target	*target;
+	d_rank_t		 myrank;
+	int			 leader_tgt;
 	int			 rc;
 
 	/* Old leader is still alive, then current server is not the leader. */
 	if (mbs->dm_flags & DMF_CONTAIN_LEADER) {
 		rc = dtx_target_alive(pool, mbs->dm_tgts[0].ddt_id);
-		if (rc != 0)
-			return rc > 0 ? 0 : rc;
+		if (rc < 0)
+			goto out;
+		if (rc > 0)
+			return 0;
 	}
 
-	/* XXX: need more work when we support to elect DTX leader from
-	 *	data shard for EC object in the future.
-	 */
-	return ds_pool_check_dtx_leader(pool, &dre->dre_oid,
-					pool->sp_map_version, false);
+	rc = ds_pool_elect_dtx_leader(pool, &dre->dre_oid, mbs, pool->sp_map_version, &leader_tgt);
+	if (rc < 0)
+		goto out;
+
+	rc = pool_map_find_target(pool->sp_map, leader_tgt, &target);
+	if (rc < 0)
+		D_GOTO(out, rc);
+
+	if (rc != 1)
+		D_GOTO(out, rc = -DER_INVAL);
+
+	rc = crt_group_rank(NULL, &myrank);
+	if (rc < 0)
+		D_GOTO(out, rc);
+
+	if (myrank != target->ta_comp.co_rank ||
+	    dss_get_module_info()->dmi_tgt_id != target->ta_comp.co_index)
+		return 0;
+
+	return 1;
+
+out:
+	D_WARN(DF_UOID" failed to get new leader: "DF_RC"\n", DP_UOID(dre->dre_oid), DP_RC(rc));
+	return rc;
 }
 
 static int

--- a/src/include/daos/dtx.h
+++ b/src/include/daos/dtx.h
@@ -40,6 +40,16 @@ enum dtx_mbs_flags {
 	 * is not stored inside MBS as optimization.
 	 */
 	DMF_CONTAIN_LEADER		= (1 << 1),
+	/* The dtx_memberships::dm_tgts is sorted against target ID. */
+	DMF_SORTED_TGT_ID		= (1 << 2),
+	/* The dtx_memberships::dm_tgts is sorted against shard index.
+	 * For most of cases, shard index matches the shard ID. But during
+	 * shard migration, there may be some temporary shards in related
+	 * object layout. Under such case, related shard ID is not unique
+	 * in the object layout, but the shard index is unique. So we use
+	 * shard index to sort the dtx_memberships::dm_tgts.
+	 */
+	DMF_SORTED_SAD_IDX		= (1 << 3),
 };
 
 /**
@@ -48,8 +58,12 @@ enum dtx_mbs_flags {
 struct dtx_daos_target {
 	/* Globally target ID, corresponding to pool_component::co_id. */
 	uint32_t			ddt_id;
-	/* See dtx_target_flags. */
-	uint32_t			ddt_flags;
+	union {
+		/* For distributed transaction, see dtx_target_flags. */
+		uint32_t		ddt_flags;
+		/* For standalong modification. */
+		uint32_t		ddt_shard;
+	};
 };
 
 /**

--- a/src/include/daos/object.h
+++ b/src/include/daos/object.h
@@ -124,7 +124,7 @@ enum daos_io_mode {
 typedef struct {
 	/** Public section, high level object ID */
 	daos_obj_id_t		id_pub;
-	/** Private section, object shard index */
+	/** Private section, object shard identifier */
 	uint32_t		id_shard;
 	/** Padding */
 	uint32_t		id_pad_32;

--- a/src/include/daos/placement.h
+++ b/src/include/daos/placement.h
@@ -19,6 +19,8 @@
 /** default placement map when none are specified */
 #define DEFAULT_PL_TYPE PL_TYPE_JUMP_MAP
 
+#define NIL_BITMAP	(NULL)
+
 /** types of placement maps */
 typedef enum {
 	PL_TYPE_UNKNOWN,
@@ -58,7 +60,7 @@ struct pl_target_grp {
 };
 
 struct pl_obj_shard {
-	uint32_t	po_shard;	/* shard index */
+	uint32_t	po_shard;	/* shard identifier */
 	uint32_t	po_target;	/* target id */
 	uint32_t	po_fseq;	/* The latest failure sequence */
 	uint32_t	po_rebuilding:1, /* rebuilding status */
@@ -164,6 +166,7 @@ pl_obj_get_shard(void *data, int idx)
 }
 
 int pl_select_leader(daos_obj_id_t oid, uint32_t shard_idx, uint32_t grp_size,
+		     uint8_t *bit_map, struct dtx_memberships *mbs,
 		     int *tgt_id, pl_get_shard_t pl_get_shard, void *data);
 
 void obj_layout_dump(daos_obj_id_t oid, struct pl_obj_layout *layout);

--- a/src/include/daos_srv/pool.h
+++ b/src/include/daos_srv/pool.h
@@ -212,9 +212,7 @@ int ds_pool_iv_srv_hdl_fetch(struct ds_pool *pool, uuid_t *pool_hdl_uuid,
 int ds_pool_svc_term_get(uuid_t uuid, uint64_t *term);
 
 int ds_pool_elect_dtx_leader(struct ds_pool *pool, daos_unit_oid_t *oid,
-			     uint32_t version, int *tgt_id);
-int ds_pool_check_dtx_leader(struct ds_pool *pool, daos_unit_oid_t *oid,
-			     uint32_t version, bool check_shard);
+			     struct dtx_memberships *mbs, uint32_t version, int *tgt_id);
 
 int
 ds_pool_child_map_refresh_sync(struct ds_pool_child *dpc);

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -22,7 +22,6 @@
 #include "obj_internal.h"
 
 #define CLI_OBJ_IO_PARMS	8
-#define NIL_BITMAP		(NULL)
 
 #define OBJ_TGT_INLINE_NR	10
 #define OBJ_INLINE_BTIMAP	4
@@ -621,16 +620,14 @@ obj_shard_find_replica(struct dc_object *obj, unsigned int target,
 }
 
 static int
-obj_grp_leader_get(struct dc_object *obj, int idx, unsigned int map_ver)
+obj_grp_leader_get(struct dc_object *obj, int idx, unsigned int map_ver, uint8_t *bit_map)
 {
 	int	rc = -DER_STALE;
 
 	D_RWLOCK_RDLOCK(&obj->cob_lock);
 	if (obj->cob_version == map_ver)
-		rc = pl_select_leader(obj->cob_md.omd_id,
-				      idx / obj->cob_grp_size,
-				      obj->cob_grp_size, NULL,
-				      obj_get_shard, obj);
+		rc = pl_select_leader(obj->cob_md.omd_id, idx / obj->cob_grp_size,
+				      obj->cob_grp_size, bit_map, NULL, NULL, obj_get_shard, obj);
 	D_RWLOCK_UNLOCK(&obj->cob_lock);
 
 	return rc;
@@ -698,8 +695,11 @@ obj_dkey2shard(struct dc_object *obj, uint64_t hash, unsigned int map_ver,
 	    time - obj->cob_time_fetch_leader[grp_idx])
 		to_leader = true;
 
-	if (to_leader)
-		return obj_grp_leader_get(obj, idx, map_ver);
+	/* For EC object, read from DTX leader is meaningless, because the leader shard may
+	 * not has the expected data. Let's directly (or still) read from related data shard.
+	 */
+	if (to_leader && !obj_is_ec(obj))
+		return obj_grp_leader_get(obj, idx, map_ver, NIL_BITMAP);
 
 	return obj_grp_valid_shard_get(obj, grp_idx, map_ver, failed_tgt_list);
 }
@@ -1056,6 +1056,8 @@ obj_req_tgts_dump(struct obj_req_tgts *req_tgts)
 #define OBJ_TGT_FLAG_LEADER_ONLY	(1U << 0)
 /* client side dispatch, despite of srv_io_mode setting */
 #define OBJ_TGT_FLAG_CLI_DISPATCH	(1U << 1)
+/* Forward leader information. */
+#define OBJ_TGT_FLAG_FW_LEADER_INFO	(1U << 2)
 
 static int
 obj_shards_2_fwtgts(struct dc_object *obj, uint32_t map_ver, uint8_t *bit_map,
@@ -1118,7 +1120,7 @@ obj_shards_2_fwtgts(struct dc_object *obj, uint32_t map_ver, uint8_t *bit_map,
 		shard_idx = start_shard + i * grp_size;
 		head = tgt = req_tgts->ort_shard_tgts + i * grp_size;
 		if (req_tgts->ort_srv_disp) {
-			rc = obj_grp_leader_get(obj, shard_idx, map_ver);
+			rc = obj_grp_leader_get(obj, shard_idx, map_ver, bit_map);
 			if (rc < 0) {
 				D_ERROR(DF_OID" no valid shard %u, grp size %u "
 					"grp nr %u, shards %u, reps %u, is %s: "
@@ -1189,7 +1191,10 @@ obj_shards_2_fwtgts(struct dc_object *obj, uint32_t map_ver, uint8_t *bit_map,
 		}
 	}
 
-	if (flags == 0 && bit_map == NIL_BITMAP)
+	if (flags & OBJ_TGT_FLAG_FW_LEADER_INFO)
+		obj_auxi->flags |= ORF_CONTAIN_LEADER;
+
+	if ((flags == 0 || flags & OBJ_TGT_FLAG_FW_LEADER_INFO) && bit_map == NIL_BITMAP)
 		D_ASSERT(tgt == req_tgts->ort_shard_tgts + shard_nr);
 
 	return 0;
@@ -2429,6 +2434,7 @@ obj_req_get_tgts(struct dc_object *obj, int *shard, daos_key_t *dkey,
 			D_DEBUG(DB_TRACE, "shard_idx %d shard_cnt %d\n",
 				(int)shard_idx, (int)shard_cnt);
 		}
+		flags = OBJ_TGT_FLAG_FW_LEADER_INFO;
 		break;
 	case DAOS_OBJ_DKEY_RPC_ENUMERATE:
 	case DAOS_OBJ_RPC_ENUMERATE:
@@ -2661,11 +2667,20 @@ shard_io(tse_task_t *task, struct shard_auxi_args *shard_auxi)
 	shard_auxi->flags = shard_auxi->obj_auxi->flags;
 	req_tgts = &shard_auxi->obj_auxi->req_tgts;
 	D_ASSERT(shard_auxi->grp_idx < req_tgts->ort_grp_nr);
-	fw_shard_tgts = req_tgts->ort_srv_disp ?
-			(req_tgts->ort_shard_tgts +
-			 shard_auxi->grp_idx * req_tgts->ort_grp_size + 1) :
-			 NULL;
-	fw_cnt = req_tgts->ort_srv_disp ? (req_tgts->ort_grp_size - 1) : 0;
+
+	if (req_tgts->ort_srv_disp) {
+		fw_shard_tgts = req_tgts->ort_shard_tgts +
+				shard_auxi->grp_idx * req_tgts->ort_grp_size;
+		fw_cnt = req_tgts->ort_grp_size;
+		if (!(obj_auxi->flags & ORF_CONTAIN_LEADER)) {
+			fw_shard_tgts++;
+			fw_cnt--;
+		}
+	} else {
+		fw_shard_tgts = NULL;
+		fw_cnt = 0;
+	}
+
 	rc = shard_auxi->shard_io_cb(obj_shard, obj_auxi->opc, shard_auxi,
 				     fw_shard_tgts, fw_cnt, task);
 	obj_shard_close(obj_shard);
@@ -4972,9 +4987,8 @@ obj_list_get_shard(struct obj_auxi_args *obj_auxi, unsigned int map_ver,
 		shard = obj_ec_list_get_shard(obj_auxi, map_ver, grp_idx, args);
 	} else {
 		if (obj_auxi->to_leader) {
-			shard = obj_grp_leader_get(obj,
-						   grp_idx * obj->cob_grp_size,
-						   map_ver);
+			shard = obj_grp_leader_get(obj, grp_idx * obj->cob_grp_size,
+						   map_ver, NIL_BITMAP);
 		} else {
 			shard = obj_grp_valid_shard_get(obj, grp_idx, map_ver,
 							obj_auxi->failed_tgt_list);
@@ -5515,7 +5529,7 @@ dc_obj_query_key(tse_task_t *api_task)
 		if (!obj_is_ec(obj) || likely(!DAOS_FAIL_CHECK(DAOS_OBJ_SKIP_PARITY))) {
 			int leader;
 
-			leader = obj_grp_leader_get(obj, start_shard, map_ver);
+			leader = obj_grp_leader_get(obj, start_shard, map_ver, NIL_BITMAP);
 			if (leader >= 0) {
 				rc = queue_shard_query_key_task(api_task, obj_auxi, &epoch, leader,
 								map_ver, obj, dkey_hash, &dti,

--- a/src/object/obj_rpc.h
+++ b/src/object/obj_rpc.h
@@ -163,6 +163,8 @@ enum obj_rpc_flags {
 	ORF_EC_RECOV_SNAP	= (1 << 18),
 	/* EC data recovery from parity */
 	ORF_EC_RECOV_FROM_PARITY = (1 << 19),
+	/* The forward targets array contains leader information. */
+	ORF_CONTAIN_LEADER	= (1 << 20),
 };
 
 /* common for update/fetch */

--- a/src/object/obj_tx.c
+++ b/src/object/obj_tx.c
@@ -1165,7 +1165,7 @@ dc_tx_classify_common(struct dc_tx *tx, struct daos_cpd_sub_req *dcsr,
 	if (dcsr->dcsr_opc == DCSO_UPDATE) {
 		dcu = &dcsr->dcsr_update;
 		reasb_req = dcsr->dcsr_reasb;
-		if (dcu->dcu_flags & ORF_EC && reasb_req->tgt_bitmap != NULL) {
+		if (dcu->dcu_flags & ORF_EC && reasb_req->tgt_bitmap != NIL_BITMAP) {
 			D_ALLOC_ARRAY(dcu->dcu_ec_tgts, obj->cob_grp_size);
 			if (dcu->dcu_ec_tgts == NULL)
 				D_GOTO(out, rc = -DER_NOMEM);
@@ -1176,8 +1176,8 @@ dc_tx_classify_common(struct dc_tx *tx, struct daos_cpd_sub_req *dcsr,
 
 	/* Descending order to guarantee that EC parity is handled firstly. */
 	for (idx = start + obj->cob_grp_size - 1; idx >= start; idx--) {
-		if (reasb_req != NULL && reasb_req->tgt_bitmap != NULL &&
-		    !isset(reasb_req->tgt_bitmap, idx - start))
+		if (reasb_req != NULL && reasb_req->tgt_bitmap != NIL_BITMAP &&
+		    isclr(reasb_req->tgt_bitmap, idx - start))
 			continue;
 
 		rc = obj_shard_open(obj, idx, tx->tx_pm_ver, &shard);
@@ -1601,12 +1601,14 @@ dc_tx_commit_prepare(struct dc_tx *tx, tse_task_t *task)
 		D_GOTO(out, rc = -DER_NOMEM);
 
 	mbs = dcsh->dcsh_mbs;
-	mbs->dm_flags = DMF_CONTAIN_LEADER;
+	mbs->dm_flags = DMF_CONTAIN_LEADER | DMF_SORTED_TGT_ID;
 
 	/* For the case of modification(s) within single RDG,
 	 * elect leader as standalone modification case does.
 	 */
 	if (mod_grp_cnt == 1) {
+		uint8_t	*bit_map;
+
 		i = dc_tx_leftmost_req(tx, true);
 		dcsr = &tx->tx_req_cache[i];
 		obj = dcsr->dcsr_obj;
@@ -1616,9 +1618,13 @@ dc_tx_commit_prepare(struct dc_tx *tx, tse_task_t *task)
 		if (grp_idx < 0)
 			D_GOTO(out, rc = grp_idx);
 
-		i = pl_select_leader(obj->cob_md.omd_id, grp_idx,
-				     obj->cob_grp_size, NULL,
-				     obj_get_shard, obj);
+		if (obj_is_ec(obj))
+			bit_map = ((struct obj_reasb_req *)(dcsr->dcsr_reasb))->tgt_bitmap;
+		else
+			bit_map = NIL_BITMAP;
+
+		i = pl_select_leader(obj->cob_md.omd_id, grp_idx, obj->cob_grp_size, bit_map, NULL,
+				     NULL, obj_get_shard, obj);
 		if (i < 0)
 			D_GOTO(out, rc = i);
 

--- a/src/object/srv_ec_aggregate.c
+++ b/src/object/srv_ec_aggregate.c
@@ -2168,6 +2168,52 @@ agg_reset_entry(struct ec_agg_entry *agg_entry, vos_iter_entry_t *entry,
 	agg_entry->ae_cur_stripe.as_offset	= 0U;
 }
 
+static int
+agg_obj_is_leader(struct ds_pool *pool, struct daos_oclass_attr *oca,
+		  daos_unit_oid_t *oid, uint32_t version)
+{
+	struct daos_obj_md	 md = { 0 };
+	struct pl_map		*map;
+	struct pl_obj_layout	*layout = NULL;
+	struct pl_obj_shard	*shard;
+	uint32_t		 start;
+	int			 rc;
+	int			 i;
+
+	/* Only parity shard can be EC-AGG leader. */
+	if (oid->id_shard % daos_oclass_grp_size(oca) < oca->u.ec.e_k)
+		return 0;
+
+	map = pl_map_find(pool->sp_uuid, oid->id_pub);
+	if (map == NULL) {
+		D_ERROR("Failed to find pool map to check leader for "DF_UOID"\n", DP_UOID(*oid));
+		return -DER_INVAL;
+	}
+
+	md.omd_id = oid->id_pub;
+	md.omd_ver = version;
+	rc = pl_obj_place(map, &md, NULL, &layout);
+	if (rc != 0)
+		goto out;
+
+	start = oid->id_shard / daos_oclass_grp_size(oca) * layout->ol_grp_size;
+	for (i = start + oca->u.ec.e_k + oca->u.ec.e_p - 1; i >= start + oca->u.ec.e_k; i--) {
+		shard = pl_obj_get_shard(layout, i);
+		if (shard->po_target != -1 && shard->po_shard != -1 && !shard->po_rebuilding)
+			/* Select the last non-rebuilding parity shard as the EC-AGG leader. */
+			D_GOTO(out, rc = (oid->id_shard == shard->po_shard ? 1 : 0));
+	}
+
+	/* If all parity shards are unavailable, then skip the object via returning -DER_STALE. */
+	rc = -DER_STALE;
+
+out:
+	if (layout != NULL)
+		pl_obj_layout_free(layout);
+	pl_map_decref(map);
+	return rc;
+}
+
 /* Iterator pre-callback for objects. Determines if object is subject
  * to aggregation. Skips objects that are not EC, or are not led by
  * this target.
@@ -2204,8 +2250,8 @@ agg_object(daos_handle_t ih, vos_iter_entry_t *entry,
 		goto out;
 	}
 
-	rc = ds_pool_check_dtx_leader(info->api_pool, &entry->ie_oid,
-				      info->api_pool->sp_map_version, true);
+	rc = agg_obj_is_leader(info->api_pool, &oca, &entry->ie_oid,
+			       info->api_pool->sp_map_version);
 	if (rc == 1 && entry->ie_oid.id_shard >= oca.u.ec.e_k) {
 		D_DEBUG(DB_EPC, "oid:"DF_UOID" ec agg starting\n",
 			DP_UOID(entry->ie_oid));

--- a/src/placement/pl_map.c
+++ b/src/placement/pl_map.c
@@ -592,12 +592,91 @@ pl_map_query(uuid_t po_uuid, struct pl_map_attr *attr)
 	return rc;
 }
 
+static int
+pl_mbs_sort_tgt_ops_cmp_key(void *array, int i, uint64_t key)
+{
+	struct dtx_daos_target	*ddt = (struct dtx_daos_target *)array;
+	uint32_t		 target = (uint32_t)key;
+
+	if (ddt[i].ddt_id > target)
+		return 1;
+	if (ddt[i].ddt_id < target)
+		return -1;
+	return 0;
+}
+
+static daos_sort_ops_t	pl_mbs_sort_tgt_ops = {
+	.so_cmp_key	= pl_mbs_sort_tgt_ops_cmp_key,
+};
+
+static int
+pl_mbs_sort_sad_ops_cmp_key(void *array, int i, uint64_t key)
+{
+	struct dtx_daos_target	*ddt = (struct dtx_daos_target *)array;
+	uint32_t		 shard = (uint32_t)key;
+
+	if (ddt[i].ddt_shard > shard)
+		return 1;
+	if (ddt[i].ddt_shard < shard)
+		return -1;
+	return 0;
+}
+
+static daos_sort_ops_t	pl_mbs_sort_sad_ops = {
+	.so_cmp_key	= pl_mbs_sort_sad_ops_cmp_key,
+};
+
+static bool
+pl_target_in_mbs(struct pl_obj_shard *shard, struct dtx_memberships *mbs)
+{
+	daos_sort_ops_t		*ops;
+	uint64_t		 key;
+
+	/* If the original leader is not in mbs->dm_tgts, then current shard maybe just such one. */
+	if (mbs == NULL || !(mbs->dm_flags & DMF_CONTAIN_LEADER))
+		return true;
+
+	if (mbs->dm_tgts[0].ddt_id == shard->po_target)
+		return true;
+
+	if (mbs->dm_flags & DMF_SORTED_TGT_ID) {
+		key = shard->po_target;
+		ops = &pl_mbs_sort_tgt_ops;
+	} else if (mbs->dm_flags & DMF_SORTED_SAD_IDX) {
+		key = shard->po_shard;
+		ops = &pl_mbs_sort_sad_ops;
+	} else {
+		int	i;
+
+		/* The mbs->dm_tgts is not sorted, that is upgraded from old storage.
+		 * We cannot do binary search for such case, then have to search from
+		 * the beginning one by one.
+		 */
+
+		for (i = 1; i < mbs->dm_tgt_cnt; i++) {
+			if (mbs->dm_tgts[i].ddt_id == shard->po_target)
+				return true;
+
+			break;
+		}
+
+		return false;
+	}
+
+	if (daos_array_find(&mbs->dm_tgts[1], mbs->dm_tgt_cnt - 1, key, ops) < 0)
+		return false;
+
+	return true;
+}
+
 /**
  * Select leader replica for the given object's shard.
  *
  * \param [IN]  oid             The object identifier.
  * \param [IN]  grp_idx         The group index.
  * \param [IN]  grp_size        Group size of obj layout.
+ * \param [IN]  bit_map         Select leader from the shards bit_map, for client IO on EC object.
+ * \param [IN]  mbs             Select leader from the shards array, for server side leader check.
  * \param [OUT] tgt_id          If non-NULL, Require leader target id.
  * \param [IN]  pl_get_shard    The callback function to parse out pl_obj_shard
  *                              from the given @data.
@@ -608,6 +687,7 @@ pl_map_query(uuid_t po_uuid, struct pl_map_attr *attr)
  */
 int
 pl_select_leader(daos_obj_id_t oid, uint32_t grp_idx, uint32_t grp_size,
+		 uint8_t *bit_map, struct dtx_memberships *mbs,
 		 int *tgt_id, pl_get_shard_t pl_get_shard, void *data)
 {
 	struct pl_obj_shard             *shard;
@@ -618,56 +698,65 @@ pl_select_leader(daos_obj_id_t oid, uint32_t grp_idx, uint32_t grp_size,
 	int                              replica_idx;
 	int                              i;
 
+	start = grp_idx * grp_size;
 	oc_attr = daos_oclass_attr_find(oid, NULL, NULL);
-	if (oc_attr->ca_resil != DAOS_RES_REPL) {
+	if (oc_attr->ca_resil == DAOS_RES_EC) {
 		int tgt_nr = oc_attr->u.ec.e_k + oc_attr->u.ec.e_p;
-		int fail_cnt = 0;
-		int idx = grp_idx * grp_size + tgt_nr - 1;
-		bool parity_rebuilding = false;
-		int leader_shard_idx;
 
-		/* For EC object, elect last shard in the group (must to be
-		 * a parity node) as leader.
+		/* For EC object, the leader candidate order is as following:
+		 * 1. The last parity node if healthy, otherwise
+		 * 2. The prior parity to the former one, and the prior if necessary.
+		 * 3. The first healthy one in the given bit_map.
 		 */
-		shard = pl_get_shard(data, idx);
-		while (shard->po_rebuilding || shard->po_shard == -1 ||
-		       shard->po_target == -1) {
-			idx--;
-			if (shard->po_rebuilding)
-				parity_rebuilding = true;
 
-			fail_cnt++;
-			if (fail_cnt > oc_attr->u.ec.e_p) {
-				D_ERROR(DF_OID" fail_cnt %d, exceed e_p %d, "DF_RC"\n",
-					DP_OID(oid), fail_cnt, oc_attr->u.ec.e_p, DP_RC(-DER_IO));
-				return -DER_IO;
-			}
+		for (i = start + tgt_nr - 1; i >= start + oc_attr->u.ec.e_k; i--) {
+			if (bit_map != NIL_BITMAP && isclr(bit_map, i - start))
+				continue;
 
-			shard = pl_get_shard(data, idx);
+			shard = pl_get_shard(data, i);
+			if (shard->po_target == -1 || shard->po_shard == -1 || shard->po_rebuilding)
+				continue;
+
+			if (pl_target_in_mbs(shard, mbs))
+				goto found;
 		}
 
-		if (fail_cnt == oc_attr->u.ec.e_p) {
-			/* If parity is rebuilding, let's return DER_STALE,
-			 * so object I/O might refresh the pool map and layout
-			 * until parity rebuilt finish.
-			 */
-			if (parity_rebuilding)
-				return -DER_STALE;
-			else
-				return -DER_IO;
+		/* If we do not know which data shards participate in the transaction,
+		 * let's return DER_STALE, then object I/O might refresh the pool map
+		 * and layout until parity rebuilt finish.
+		 */
+
+		if (bit_map == NIL_BITMAP && mbs == NULL) {
+			D_WARN(DF_OID" all parity shards %d are in rebuilding, retry later.\n",
+				DP_OID(oid), oc_attr->u.ec.e_p);
+			return -DER_STALE;
 		}
 
-		D_ASSERT(shard->po_target != -1);
-		D_ASSERT(shard->po_shard != -1);
-		D_ASSERT(!shard->po_rebuilding);
+		for (i = start; i < start + oc_attr->u.ec.e_k; i++) {
+			if (bit_map != NIL_BITMAP && isclr(bit_map, i - start))
+				continue;
 
+			shard = pl_get_shard(data, i);
+			if (shard->po_target == -1 || shard->po_shard == -1 || shard->po_rebuilding)
+				break;
+
+			if (pl_target_in_mbs(shard, mbs))
+				goto found;
+		}
+
+		D_ERROR(DF_OID" unhealthy targets exceed the max redundancy, e_p %d\n",
+			DP_OID(oid), oc_attr->u.ec.e_p);
+		return -DER_IO;
+
+found:
 		if (tgt_id != NULL)
 			*tgt_id = shard->po_target;
 
-		leader_shard_idx = (shard->po_shard / tgt_nr) * grp_size +
-				    shard->po_shard % tgt_nr;
-		return leader_shard_idx;
+		return (shard->po_shard / tgt_nr) * grp_size + shard->po_shard % tgt_nr;
 	}
+
+	D_ASSERT(oc_attr->ca_resil == DAOS_RES_REPL);
+	D_ASSERT(bit_map == NIL_BITMAP);
 
 	replicas = oc_attr->u.rp.r_num;
 	if (replicas == DAOS_OBJ_REPL_MAX) {
@@ -706,7 +795,6 @@ pl_select_leader(daos_obj_id_t oid, uint32_t grp_idx, uint32_t grp_size,
 	 *      The one with the lowest f_seq will be elected as the leader
 	 *      to avoid leader switch.
 	 */
-	start = grp_idx * grp_size;
 	replica_idx = (oid.lo + grp_idx) % replicas;
 	for (i = 0, pos = -1; i < replicas;
 	     i++, replica_idx = (replica_idx + 1) % replicas) {
@@ -718,10 +806,11 @@ pl_select_leader(daos_obj_id_t oid, uint32_t grp_idx, uint32_t grp_size,
 		 * case that during reintegration we may have an extended
 		 * layout that with in-adding shards with po_rebuilding set).
 		 */
-		if (shard->po_target == -1 || shard->po_rebuilding)
+		if (shard->po_target == -1 || shard->po_shard == -1 || shard->po_rebuilding ||
+		    !pl_target_in_mbs(shard, mbs))
 			continue;
-		if (pos == -1 ||
-		    pl_get_shard(data, pos)->po_fseq > shard->po_fseq)
+
+		if (pos == -1 || pl_get_shard(data, pos)->po_fseq > shard->po_fseq)
 			pos = off;
 	}
 	if (pos != -1) {


### PR DESCRIPTION
master-commit: 72a1242b6f44d463b0972c237fdc2712778ce8e3

Mainly includes the followoing:

1. When modify EC object, allow related DTX leader to be on data shard
   if all parity shards are unavailable. Such data shard should be one
   of the shard that participates in related modification.

2. Client needs to tell DTX leader logic which shards (via some bitmap)
   will participate in related IO when elect the DTX leader.

3. Server needs to pass dtx_memberships information to DTX leader logic
   for which targets participated in the DTX when DTX resync/refresh.

4. EC aggregation does not need to depend on DTX leader logic. Because
   DTX leader can be on data shard. EC aggregation need its own leader
   to drive the EC aggregation from one of the parity shards globally.

5. Some bug in current DTX RPC prepare logic that may cause the RPC to
   some remote target to be regarded as local operation and then being
   skipped by wrong. The patch fixes related issues.

Signed-off-by: Fan Yong <fan.yong@intel.com>