### PR TITLE
DAOS-6530 test: tag test_find_perf as manual (#7015)

### DIFF
--- a/src/tests/ftest/dfuse/find.py
+++ b/src/tests/ftest/dfuse/find.py
@@ -53,7 +53,7 @@ class Cmd(DfuseTestBase):
             The test will fail if DAOS performance is lower than the
             challenger performance.
 
-        :avocado: tags=all,full_regression
+        :avocado: tags=all,manual
         :avocado: tags=hw,medium,ib2
         :avocado: tags=daosio,dfuse
         :avocado: tags=findcmd_perf


### PR DESCRIPTION
test_find_perf expects a Lustre mount which is not available in CI.
replace full_regression with manual, since the test should just be ran
manually.

Signed-off-by: Dalton Bohning <dalton.bohning@intel.com>