### PR TITLE
DAOS-9059 obj: Check function pointer for NULL

### DIFF
--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -4334,7 +4334,8 @@ obj_obj_dtx_leader(struct dtx_leader_handle *dlh, void *arg, int idx,
 			if (dcde->dcde_write_cnt != 0) {
 				rc = obj_capa_check(ioc->ioc_coh, true, false);
 				if (rc != 0) {
-					comp_cb(dlh, idx, rc);
+					if (comp_cb != NULL)
+						comp_cb(dlh, idx, rc);
 
 					return rc;
 				}


### PR DESCRIPTION
The comp_cb function pointer wasn't being checked for NULL. This
caused a crash in a case where a user tried to delete a file in
a container for which they did not have write permissions.

Signed-off-by: Kris Jacque <kristin.jacque@intel.com>