### PR TITLE
DAOS-8913 rebuild: send stable epoch to other servers multiple times …

### DIFF
--- a/src/rebuild/rebuild_internal.h
+++ b/src/rebuild/rebuild_internal.h
@@ -130,7 +130,6 @@ struct rebuild_global_pool_tracker {
 	uint32_t	rgt_refcount;
 
 	unsigned int	rgt_abort:1,
-			rgt_notify_stable_epoch:1,
 			rgt_init_scan:1;
 };
 

--- a/src/rebuild/scan.c
+++ b/src/rebuild/scan.c
@@ -795,7 +795,7 @@ out:
 	if (tls->rebuild_pool_status == 0 && rc != 0)
 		tls->rebuild_pool_status = rc;
 
-	D_DEBUG(DB_TRACE, DF_UUID" iterate pool done: "DF_RC"\n",
+	D_DEBUG(DB_REBUILD, DF_UUID" iterate pool done: "DF_RC"\n",
 		DP_UUID(rpt->rt_pool_uuid), DP_RC(rc));
 	return rc;
 }

--- a/src/rebuild/srv.c
+++ b/src/rebuild/srv.c
@@ -569,11 +569,7 @@ rebuild_leader_status_check(struct ds_pool *pool, uint32_t map_ver, uint32_t op,
 				" %u->%u.\n", DP_UUID(pool->sp_uuid), myrank,
 				pool->sp_iv_ns->iv_master_rank);
 
-		if (!rgt->rgt_abort &&
-		    myrank == pool->sp_iv_ns->iv_master_rank &&
-		    ((!is_rebuild_global_pull_done(rgt) &&
-		      is_rebuild_global_scan_done(rgt)) ||
-		      !rgt->rgt_notify_stable_epoch)) {
+		if (!rgt->rgt_abort && myrank == pool->sp_iv_ns->iv_master_rank) {
 			struct rebuild_iv iv = { 0 };
 
 			D_ASSERT(rgt->rgt_stable_epoch != 0);
@@ -592,17 +588,9 @@ rebuild_leader_status_check(struct ds_pool *pool, uint32_t map_ver, uint32_t op,
 			rc = rebuild_iv_update(pool->sp_iv_ns,
 					       &iv, CRT_IV_SHORTCUT_NONE,
 					       CRT_IV_SYNC_LAZY, false);
-			if (rc) {
+			if (rc)
 				D_WARN("master %u iv update failed: %d\n",
 				       pool->sp_iv_ns->iv_master_rank, rc);
-			} else {
-				/* Each server uses IV to notify the leader
-				 * its rebuild stable epoch, then the leader
-				 * will choose the largest epoch as the global
-				 * stable epoch to rebuild.
-				 */
-				rgt->rgt_notify_stable_epoch = 1;
-			}
 		}
 
 		/* query the current rebuild status */


### PR DESCRIPTION
…(#7351)

Let's keep send stable epoch to other servers to make sure
all servers get stable epoch, otherwise rebuild scan might
be stucked.

Signed-off-by: Di Wang <di.wang@intel.com>