### PR TITLE
DAOS-8725 gurt: Fix crash in D_REALPATH macro. (#7310)

### DIFF
--- a/src/include/gurt/common.h
+++ b/src/include/gurt/common.h
@@ -151,16 +151,29 @@ char *d_realpath(const char *path, char *resolved_path);
 			      (ptr) = NULL);				\
 	} while (0)
 
+/* d_realpath() can fail with genuine errors, in which case we want to keep the errno from
+ * realpath, however if it doesn't fail then we want to preserve the previous errno, in
+ * addition the fault injection code could insert an error in the D_CHECK_ALLOC() macro
+ * so if that happens then we want to set ENOMEM there.
+ * Save the original error on the way in, overwrite it and then if realpath does not change
+ * it then re-instate it.
+ */
 #define D_REALPATH(ptr, path)						\
 	do {								\
-		int _size;						\
-		void *_ptr;						\
+		int _errno = errno;					\
+		errno = 0;						\
 		(ptr) = d_realpath((path), NULL);			\
-		_ptr = (ptr);						\
-		_size = strnlen((ptr), PATH_MAX + 1) + 1 ;		\
-		D_CHECK_ALLOC(realpath, true, ptr, #ptr, _size,	0, #ptr, 0); \
-		if (((ptr) == NULL) && _ptr != NULL)			\
-			errno = ENOMEM;					\
+		if (errno == 0 || errno == ENOMEM) {			\
+			int _size = 0;					\
+			void *_ptr = (ptr);				\
+			if (_ptr)					\
+				_size = strnlen(_ptr, PATH_MAX + 1) + 1 ; \
+			D_CHECK_ALLOC(realpath, true, ptr, #ptr, _size,	0, #ptr, 0); \
+			if (errno == 0 && ((ptr) == NULL) && _ptr != NULL) \
+				errno = ENOMEM;				\
+			else if (errno == 0)				\
+				errno = _errno;				\
+		}							\
 	} while (0)
 
 #define D_ALIGNED_ALLOC(ptr, alignment, size)				\


### PR DESCRIPTION
If the realpath was failing for an error other than ENOMEM then this
was segfaulting, so protect against that and ensure errno is set
correctly for other failure modes.

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>