### PR TITLE
DAOS-8870 migrate: missing FOR_MIGRATE flag for obj enumeration (#7241)

### DIFF
--- a/src/object/srv_obj_migrate.c
+++ b/src/object/srv_obj_migrate.c
@@ -2471,7 +2471,8 @@ retry:
 			if (rc != -DER_INPROGRESS) {
 				daos_anchor_set_flags(&dkey_anchor,
 						      DIOF_WITH_SPEC_EPOCH |
-						      DIOF_TO_SPEC_GROUP);
+						      DIOF_TO_SPEC_GROUP |
+						      DIOF_FOR_MIGRATION);
 				D_DEBUG(DB_REBUILD, "retry to non leader "
 					DF_UOID": "DF_RC"\n",
 					DP_UOID(arg->oid), DP_RC(rc));


### PR DESCRIPTION
Missing FOR_MIGRATE flag for object migrate retry.

Signed-off-by: Di Wang <di.wang@intel.com>