### PR TITLE
DAOS-8982 dfuse: Reject attempts to set posix ACLs via xattr. (#7205)

### DIFF
--- a/src/client/dfuse/ops/setxattr.c
+++ b/src/client/dfuse/ops/setxattr.c
@@ -9,6 +9,9 @@
 
 #include "daos_uns.h"
 
+#define ACL_ACCESS	"system.posix_acl_access"
+#define ACL_DEFAULT	"system.posix_acl_default"
+
 void
 dfuse_cb_setxattr(fuse_req_t req, struct dfuse_inode_entry *inode,
 		  const char *name, const char *value, size_t size,
@@ -20,7 +23,7 @@ dfuse_cb_setxattr(fuse_req_t req, struct dfuse_inode_entry *inode,
 	DFUSE_TRA_DEBUG(inode, "Attribute '%s'", name);
 
 	if (strncmp(name, DUNS_XATTR_NAME, sizeof(DUNS_XATTR_NAME)) == 0) {
-		struct duns_attr_t	dattr = {};
+		struct duns_attr_t dattr = {};
 
 		if (inode->ie_root) {
 			DFUSE_TRA_WARNING(inode, "Attempt to set duns attr on container root");
@@ -35,8 +38,13 @@ dfuse_cb_setxattr(fuse_req_t req, struct dfuse_inode_entry *inode,
 		duns_attr = true;
 	}
 
-	rc = dfs_setxattr(inode->ie_dfs->dfs_ns, inode->ie_obj, name, value,
-			  size, flags);
+	if (strncmp(name, ACL_ACCESS, sizeof(ACL_ACCESS)) == 0)
+		D_GOTO(err, rc = ENOTSUP);
+
+	if (strncmp(name, ACL_DEFAULT, sizeof(ACL_DEFAULT)) == 0)
+		D_GOTO(err, rc = ENOTSUP);
+
+	rc = dfs_setxattr(inode->ie_dfs->dfs_ns, inode->ie_obj, name, value, size, flags);
 	if (rc == 0) {
 		/* Optionally remove the dentry to force a new lookup on access.
 		 * If the xattr is to set a UNS entry point, and dentry_dir


### PR DESCRIPTION
Reject rather than accept posix ACL updates.  If these are
accepted the kernel expects them to control future access
to the file, and neither dfuse nor dfs implmenents this so
we should reject any attempt to set these.

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>