### PR TITLE
DAOS-8082 vos: Maintain a pool of dtx LID allocation arrays

### DIFF
--- a/src/include/gurt/slab.h
+++ b/src/include/gurt/slab.h
@@ -15,16 +15,17 @@
 struct d_slab_reg {
 	/* Perform any one-time setup or assigning constants.
 	 */
-	void	(*sr_init)(void *, void *);
+	void	(*sr_init)(void *, void *, void *);
 
 	/* Prepare an object for use by freeing any old data
 	 * and allocating new data.
 	 * Returns true on success.
 	 */
-	bool	(*sr_reset)(void *);
+	bool	(*sr_reset)(void *, void *);
 
 	/* Called once at teardown */
-	void	(*sr_release)(void *);
+	void	(*sr_release)(void *, void *);
+	void	*sr_type_arg;
 	char	*sr_name;
 	int	sr_size;
 	int	sr_offset;
@@ -41,7 +42,7 @@ struct d_slab_reg {
  * however once max_desc is reached no more descriptors will be created.
  */
 
-#define POOL_TYPE_INIT(itype, imember) .sr_size = sizeof(struct itype),	\
+#define SLAB_TYPE_INIT(itype, imember) .sr_size = sizeof(struct itype),	\
 		.sr_offset = offsetof(struct itype, imember),		\
 		.sr_name = #itype,
 
@@ -98,8 +99,10 @@ struct d_slab_type *
 d_slab_register(struct d_slab *, struct d_slab_reg *);
 
 /* Allocate a data structure in performant way */
-void *
-d_slab_acquire(struct d_slab_type *);
+#define d_slab_acquire(type, retptr)	\
+	d_slab_acquire_(type, ((void **)retptr))
+int
+d_slab_acquire_(struct d_slab_type *, void **retptr);
 
 /* Release a data structure in a performant way */
 void

--- a/src/vos/vos_aggregate.c
+++ b/src/vos/vos_aggregate.c
@@ -2269,6 +2269,9 @@ enum {
 static int
 aggregate_enter(struct vos_container *cont, int agg_mode, daos_epoch_range_t *epr)
 {
+	/** Take opportunity to restock unused LID tables */
+	vos_slab_restock();
+
 	switch (agg_mode) {
 	default:
 		D_ASSERT(0);

--- a/src/vos/vos_container.c
+++ b/src/vos/vos_container.c
@@ -182,8 +182,7 @@ cont_free_internal(struct vos_container *cont)
 	if (daos_handle_is_valid(cont->vc_dtx_committed_hdl))
 		dbtree_destroy(cont->vc_dtx_committed_hdl, NULL);
 
-	if (cont->vc_dtx_array)
-		lrua_array_free(cont->vc_dtx_array);
+	vos_dtx_array_release(cont);
 
 	D_ASSERT(d_list_empty(&cont->vc_dtx_act_list));
 
@@ -383,16 +382,6 @@ vos_cont_open(daos_handle_t poh, uuid_t co_uuid, daos_handle_t *coh)
 
 	memset(&uma, 0, sizeof(uma));
 	uma.uma_id = UMEM_CLASS_VMEM;
-
-	rc = lrua_array_alloc(&cont->vc_dtx_array, DTX_ARRAY_LEN, DTX_ARRAY_NR,
-			      sizeof(struct vos_dtx_act_ent),
-			      LRU_FLAG_REUSE_UNIQUE,
-			      NULL, NULL);
-	if (rc != 0) {
-		D_ERROR("Failed to create DTX active array: rc = "DF_RC"\n",
-			DP_RC(rc));
-		D_GOTO(exit, rc);
-	}
 
 	rc = dbtree_create_inplace_ex(VOS_BTR_DTX_ACT_TABLE, 0,
 				      DTX_BTREE_ORDER, &uma,

--- a/src/vos/vos_dtx.c
+++ b/src/vos/vos_dtx.c
@@ -44,6 +44,7 @@ enum {
 		D_DEBUG(DB_TRACE, "Evicting lid "DF_DTI": lid=%d\n",	\
 			DP_DTI(&DAE_XID(dae)), DAE_LID(dae));		\
 		d_list_del_init(&dae->dae_link);			\
+		D_ASSERT(cont->vc_dtx_array != NULL);			\
 		lrua_evictx(cont->vc_dtx_array,				\
 			    DAE_LID(dae) - DTX_LID_RESERVED,		\
 			    DAE_EPOCH(dae));				\
@@ -962,6 +963,14 @@ vos_dtx_alloc(struct vos_dtx_blob_df *dbd, struct dtx_handle *dth)
 	cont = vos_hdl2cont(dth->dth_coh);
 	D_ASSERT(cont != NULL);
 
+	rc = vos_dtx_array_acquire(cont);
+	if (rc != 0) {
+		D_ERROR("Failed to re-create DTX active array: "DF_RC"\n",
+			DP_RC(rc));
+		return rc;
+	}
+	D_ASSERT(cont->vc_dtx_array != NULL);
+
 	rc = lrua_allocx(cont->vc_dtx_array, &idx, dth->dth_epoch, &dae);
 	if (rc != 0) {
 		/* The array is full, need to commit some transactions first */
@@ -1119,8 +1128,12 @@ vos_dtx_check_availability(daos_handle_t coh, uint32_t entry,
 	cont = vos_hdl2cont(coh);
 	D_ASSERT(cont != NULL);
 
-	found = lrua_lookupx(cont->vc_dtx_array, entry - DTX_LID_RESERVED,
-			     epoch, &dae);
+	if (cont->vc_dtx_array) {
+		found = lrua_lookupx(cont->vc_dtx_array, entry - DTX_LID_RESERVED,
+				     epoch, &dae);
+	} else {
+		found = false;
+	}
 
 	/* The DTX owner can always see the DTX. */
 	if (found && dtx_is_valid_handle(dth) && dae == dth->dth_ent)
@@ -1512,8 +1525,12 @@ vos_dtx_deregister_record(struct umem_instance *umm, daos_handle_t coh,
 	if (cont == NULL)
 		return;
 
-	found = lrua_lookupx(cont->vc_dtx_array, entry - DTX_LID_RESERVED,
-			     epoch, &dae);
+	if (cont->vc_dtx_array) {
+		found = lrua_lookupx(cont->vc_dtx_array, entry - DTX_LID_RESERVED,
+				     epoch, &dae);
+	} else {
+		found = false;
+	}
 	if (!found) {
 		D_WARN("Could not find active DTX record for lid=%d, epoch="
 		       DF_U64"\n", entry, epoch);
@@ -2022,6 +2039,10 @@ vos_dtx_post_handle(struct vos_container *cont,
 			DAE_FLAGS(daes[i]) &= ~(DTE_CORRUPTED | DTE_ORPHAN);
 		}
 	}
+
+	if (d_list_empty(&cont->vc_dtx_act_list))
+		vos_dtx_array_release(cont);
+
 }
 
 int
@@ -2233,8 +2254,11 @@ vos_dtx_aggregate(daos_handle_t coh)
 	if (dbd == NULL || dbd->dbd_count == 0)
 		return 0;
 
-	/* Take the opportunity to free some memory if we can */
-	lrua_array_aggregate(cont->vc_dtx_array);
+	/** Take the opportunity to free some memory if we can */
+	if (cont->vc_dtx_array != NULL) {
+		lrua_array_aggregate(cont->vc_dtx_array);
+		vos_slab_reclaim();
+	}
 
 	rc = umem_tx_begin(umm, NULL);
 	if (rc != 0) {
@@ -2482,6 +2506,15 @@ vos_dtx_act_reindex(struct vos_container *cont)
 					" is invalid\n", dae_df->dae_lid);
 				D_GOTO(out, rc = -DER_IO);
 			}
+
+			rc = vos_dtx_array_acquire(cont);
+			if (rc != 0) {
+				D_ERROR("Failed create DTX active array: "DF_RC"\n",
+					DP_RC(rc));
+				goto out;
+			}
+			D_ASSERT(cont->vc_dtx_array != NULL);
+
 			rc = lrua_allocx_inplace(cont->vc_dtx_array,
 					 dae_df->dae_lid - DTX_LID_RESERVED,
 					 dae_df->dae_epoch, &dae);
@@ -2899,22 +2932,11 @@ vos_dtx_cache_reset(daos_handle_t coh)
 			       DP_RC(rc));
 	}
 
-	if (cont->vc_dtx_array)
-		lrua_array_free(cont->vc_dtx_array);
+	vos_dtx_array_release(cont);
 
 	cont->vc_dtx_active_hdl = DAOS_HDL_INVAL;
 	cont->vc_dtx_committed_hdl = DAOS_HDL_INVAL;
 	cont->vc_dtx_committed_count = 0;
-
-	rc = lrua_array_alloc(&cont->vc_dtx_array, DTX_ARRAY_LEN, DTX_ARRAY_NR,
-			      sizeof(struct vos_dtx_act_ent),
-			      LRU_FLAG_REUSE_UNIQUE,
-			      NULL, NULL);
-	if (rc != 0) {
-		D_ERROR("Failed to re-create DTX active array: "DF_RC"\n",
-			DP_RC(rc));
-		goto out;
-	}
 
 	memset(&uma, 0, sizeof(uma));
 	uma.uma_id = UMEM_CLASS_VMEM;

--- a/src/vos/vos_tls.h
+++ b/src/vos/vos_tls.h
@@ -21,8 +21,10 @@
 #include <daos_srv/dtx_srv.h>
 #include <gurt/telemetry_common.h>
 #include <gurt/telemetry_producer.h>
+#include <gurt/slab.h>
 
 /* Forward declarations */
+struct lru_ref_type;
 struct vos_ts_table;
 struct dtx_handle;
 
@@ -62,7 +64,11 @@ struct vos_tls {
 		uint64_t		 vtl_hash;
 		bool			 vtl_hash_set;
 	};
-	struct d_tm_node_t		 *vtl_committed;
+	struct d_tm_node_t		*vtl_committed;
+	/** Per thread slab manager */
+	struct d_slab			 vtl_slab;
+	/** Slab for active dtx LID generator */
+	struct lru_ref_type		*vtl_lid_type;
 };
 
 struct bio_xs_context *vos_xsctxt_get(void);
@@ -188,5 +194,11 @@ vos_sched_seq(void)
 	return sched_cur_seq();
 }
 #endif
+
+static inline struct lru_ref_type *
+vos_dtx_type_get(void)
+{
+	return vos_tls_get()->vtl_lid_type;
+}
 
 #endif /* __VOS_TLS_H__ */


### PR DESCRIPTION
Utilize the old IOF code to keep a pool of usable LRU tables
that can be used for containers when they have active DTX and
returned when not in use to avoid growing memory too much.

There are some improvements that we can likely make here at some
point.

1. Renewal may have potential optimization to avoid free/alloc and
perhaps only walk through a list of in-use slabs
2. If we have a good place to invoke d_slab_restock, we can avoid
doing allocations on the critical path.  For now, acquire will
do the allocation.

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>