### PR TITLE
DAOS-8953-test2: Increate timeout for nvme and ior test failed due to timeout

### DIFF
--- a/src/tests/ftest/ior/hard.yaml
+++ b/src/tests/ftest/ior/hard.yaml
@@ -9,7 +9,7 @@ hosts:
     - client-A
     - client-B
     - client-C
-timeout: 1000
+timeout: 1200
 server_config:
   engines_per_host: 2
   name: daos_server

--- a/src/tests/ftest/nvme/io_verification.yaml
+++ b/src/tests/ftest/nvme/io_verification.yaml
@@ -9,7 +9,7 @@ hosts:
    - boro-G
  test_clients:
    - boro-H
-timeout: 4000
+timeout: 5200
 server_config:
  name: daos_server
  servers:

--- a/src/tests/ftest/nvme/object.yaml
+++ b/src/tests/ftest/nvme/object.yaml
@@ -13,7 +13,7 @@ hosts:
   - boro-H
 timeouts:
   test_nvme_object_single_pool: 270
-  test_nvme_object_multiple_pools: 16000
+  test_nvme_object_multiple_pools: 18000
 server_config:
   name: daos_server
   servers:


### PR DESCRIPTION
Description: Increase timeout for nvme and ior failed testcases on weekly CI.

Test-tag: pr nvme_object_multiple_pools nvme_io_verification ior_hard
Signed-off-by: Ding Ho ding-hwa.ho@intel.com