### PR TITLE
DAOS-8901 pool: Randomize distribution of pool svc ranks

### DIFF
--- a/src/gurt/misc.c
+++ b/src/gurt/misc.c
@@ -308,6 +308,23 @@ d_rank_list_sort(d_rank_list_t *rank_list)
 	      sizeof(d_rank_t), rank_compare);
 }
 
+void
+d_rank_list_shuffle(d_rank_list_t *rank_list)
+{
+	uint32_t	i, j;
+	d_rank_t	tmp;
+
+	if (rank_list == NULL)
+		return;
+
+	for (i = 0; i < rank_list->rl_nr; i++) {
+		j = rand() % rank_list->rl_nr;
+		tmp = rank_list->rl_ranks[i];
+		rank_list->rl_ranks[i] = rank_list->rl_ranks[j];
+		rank_list->rl_ranks[j] = tmp;
+	}
+}
+
 /**
  * Must be previously sorted or not modified at all in order to guarantee
  * consistent indexes.

--- a/src/include/daos/common.h
+++ b/src/include/daos/common.h
@@ -613,6 +613,7 @@ daos_crt_network_error(int err)
 #define daos_rank_list_filter		d_rank_list_filter
 #define daos_rank_list_alloc		d_rank_list_alloc
 #define daos_rank_list_copy		d_rank_list_copy
+#define daos_rank_list_shuffle		d_rank_list_shuffle
 #define daos_rank_list_sort		d_rank_list_sort
 #define daos_rank_list_find		d_rank_list_find
 #define daos_rank_list_identical	d_rank_list_identical

--- a/src/include/gurt/common.h
+++ b/src/include/gurt/common.h
@@ -396,6 +396,7 @@ d_rank_list_t *d_rank_list_alloc(uint32_t size);
 d_rank_list_t *d_rank_list_realloc(d_rank_list_t *ptr, uint32_t size);
 void d_rank_list_free(d_rank_list_t *rank_list);
 int d_rank_list_copy(d_rank_list_t *dst, d_rank_list_t *src);
+void d_rank_list_shuffle(d_rank_list_t *rank_list);
 void d_rank_list_sort(d_rank_list_t *rank_list);
 bool d_rank_list_find(d_rank_list_t *rank_list, d_rank_t rank, int *idx);
 int d_rank_list_del(d_rank_list_t *rank_list, d_rank_t rank);


### PR DESCRIPTION
Instead of always starting with rank 1, use a shuffled list
of target ranks to choose the pool service ranks. This will
help to avoid "hot spots" caused by putting all of the
pool service instances on the same ranks.

Test-tag: pr daily_regression full_regression pool

Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com>
