### PR TITLE
DAOS-8926 test: 2.0 Address flaky Rebuild/basic.py test failures.

### DIFF
--- a/src/tests/ftest/rebuild/basic.py
+++ b/src/tests/ftest/rebuild/basic.py
@@ -94,9 +94,8 @@ class RbldBasic(TestWithServers):
             else:
                 self.pool[index].exclude(ranks=[rank])
 
-        # Wait for recovery to start
-        for index in range(pool_quantity):
-            self.pool[index].wait_for_rebuild(True)
+        # Wait for recovery to start for first pool.
+        self.pool[0].wait_for_rebuild(True)
 
         # Wait for recovery to complete
         for index in range(pool_quantity):


### PR DESCRIPTION
Skip-func-test-el7: false
Skip-func-test-leap15: false
Test-tag: test_simple_rebuild test_multipool_rebuild
Test-repeat: 1

Check whether rebuild started on first pool alone wait_for_rebuild(True). Since the test uses small data the rebuild can be completed on other pools while we iterate all pools. Just check the start on the first pool and see whether rebuild completed on other pools later with wait_for_rebuild(False) call.

Signed-off-by: rpadma2 <ravindran.padmanabhan@intel.com>