### PR TITLE
DAOS-8919 engine: debug shutdown, minimal instrumentation

### DIFF
--- a/src/cart/crt_context.c
+++ b/src/cart/crt_context.c
@@ -444,9 +444,9 @@ crt_ctx_epi_abort(d_list_t *rlink, void *arg)
 				   crp_epi_link) {
 		D_ASSERT(epi->epi_req_wait_num > 0);
 		if (msg_logged == false) {
-			D_DEBUG(DB_NET, "destroy context (idx %d, rank %d, "
-				"req_wait_num "DF_U64").\n", ctx->cc_idx,
-				epi->epi_ep.ep_rank, epi->epi_req_wait_num);
+			D_INFO("destroy context (idx %d, rank %d, "
+			       "req_wait_num "DF_U64").\n", ctx->cc_idx,
+			       epi->epi_ep.ep_rank, epi->epi_req_wait_num);
 			msg_logged = true;
 		}
 		/* Just remove from wait_q, decrease the wait_num and destroy
@@ -463,7 +463,7 @@ crt_ctx_epi_abort(d_list_t *rlink, void *arg)
 				   crp_epi_link) {
 		D_ASSERT(epi->epi_req_num > epi->epi_reply_num);
 		if (msg_logged == false) {
-			D_DEBUG(DB_NET,
+			D_INFO(
 				"destroy context (idx %d, rank %d, "
 				"epi_req_num "DF_U64", epi_reply_num "
 				""DF_U64", inflight "DF_U64").\n",
@@ -475,7 +475,7 @@ crt_ctx_epi_abort(d_list_t *rlink, void *arg)
 
 		rc = crt_req_abort(&rpc_priv->crp_pub);
 		if (rc != 0) {
-			D_DEBUG(DB_NET,
+			D_INFO(
 				"crt_req_abort(opc: %#x) failed, rc: %d.\n",
 				rpc_priv->crp_pub.cr_opc, rc);
 			rc = 0;
@@ -483,6 +483,7 @@ crt_ctx_epi_abort(d_list_t *rlink, void *arg)
 		}
 	}
 
+	D_INFO("start wait for aborted RPCs\n");
 	ts_start = d_timeus_secdiff(0);
 	while (wait != 0) {
 		/* make sure all above aborting finished */
@@ -507,6 +508,7 @@ crt_ctx_epi_abort(d_list_t *rlink, void *arg)
 			}
 		}
 	}
+	D_INFO("end wait for aborted RPCs\n");
 
 out:
 	D_MUTEX_UNLOCK(&epi->epi_mutex);

--- a/src/cart/crt_hg.c
+++ b/src/cart/crt_hg.c
@@ -1220,14 +1220,19 @@ crt_hg_reply_send(struct crt_rpc_priv *rpc_priv)
 
 	D_ASSERT(rpc_priv != NULL);
 
-	if (D_LOG_ENABLED(DB_NET)) {
+	if (1 || (D_LOG_ENABLED(DB_NET))) {
 		uint64_t hlc = crt_hlc_get();
 
 		if (hlc > rpc_priv->crp_create_hlc) {
 			uint64_t delay = crt_hlc2msec(hlc - rpc_priv->crp_create_hlc);
 
-			if (delay > 500)
-				RPC_TRACE(DB_NET, rpc_priv, "RPC reply took %lu ms.\n", delay);
+			if (delay > 500) {
+				D_INFO("[opc=%#x rpcid=%#lx rank:tag=%d:%d] RPC reply took "
+				       "%lu ms.\n", rpc_priv->crp_pub.cr_opc,
+				       rpc_priv->crp_req_hdr.cch_rpcid,
+				       rpc_priv->crp_pub.cr_ep.ep_rank,
+				       rpc_priv->crp_pub.cr_ep.ep_tag, delay);
+			}
 		}
 	}
 

--- a/src/cart/crt_rpc.c
+++ b/src/cart/crt_rpc.c
@@ -1245,14 +1245,19 @@ crt_req_send_immediately(struct crt_rpc_priv *rpc_priv)
 	}
 	D_ASSERT(rpc_priv->crp_hg_hdl != NULL);
 
-	if (D_LOG_ENABLED(DB_NET)) {
+	if (1 || (D_LOG_ENABLED(DB_NET))) {
 		uint64_t hlc = crt_hlc_get();
 
 		if (hlc > rpc_priv->crp_create_hlc) {
 			uint64_t delay = crt_hlc2msec(hlc - rpc_priv->crp_create_hlc);
 
-			if (delay > 20)
-				RPC_TRACE(DB_NET, rpc_priv, "RPC send took %lu ms.\n", delay);
+			if (delay > 20) {
+				D_INFO("[opc=%#x rpcid=%#lx rank:tag=%d:%d] RPC send took "
+				       "%lu ms.\n", rpc_priv->crp_pub.cr_opc,
+				       rpc_priv->crp_req_hdr.cch_rpcid,
+				       rpc_priv->crp_pub.cr_ep.ep_rank,
+				       rpc_priv->crp_pub.cr_ep.ep_tag, delay);
+			}
 		}
 	}
 
@@ -1639,14 +1644,19 @@ crt_handle_rpc(void *arg)
 	D_ASSERT(rpc_priv->crp_opc_info != NULL);
 	D_ASSERT(rpc_priv->crp_opc_info->coi_rpc_cb != NULL);
 
-	if (D_LOG_ENABLED(DB_NET)) {
+	if (1 || (D_LOG_ENABLED(DB_NET))) {
 		uint64_t hlc = crt_hlc_get();
 
 		if (hlc > rpc_priv->crp_create_hlc) {
 			uint64_t delay = crt_hlc2msec(hlc - rpc_priv->crp_create_hlc);
 
-			if (delay > 20)
-				RPC_TRACE(DB_NET, rpc_priv, "RPC schedule took %lu ms.\n", delay);
+			if (delay > 20) {
+				D_INFO("[opc=%#x rpcid=%#lx rank:tag=%d:%d] RPC schedule took "
+				       "%lu ms.\n", rpc_priv->crp_pub.cr_opc,
+				       rpc_priv->crp_req_hdr.cch_rpcid,
+				       rpc_priv->crp_pub.cr_ep.ep_rank,
+				       rpc_priv->crp_pub.cr_ep.ep_tag, delay);
+			}
 		}
 	}
 

--- a/src/gurt/dlog.c
+++ b/src/gurt/dlog.c
@@ -657,6 +657,8 @@ void d_vlog(int flags, const char *fmt, va_list ap)
 	if (flush)
 		last_flush = tv.tv_sec;
 
+	/* kccain hack - having some issues with D_LOG_FLUSH=DEBUG */
+	flush = true;
 	rc = d_log_write(b, tlen, flush);
 	if (rc < 0)
 		errno = save_errno;


### PR DESCRIPTION
Quick-Functional: true
Skip-coverity-test: true
Skip-func-test-vm: false
Skip-func-hw-test-small: true
Skip-func-hw-test-medium: true
Skip-func-hw-test-large: true
Skip-scan-centos-rpms: true
Skip-scan-leap15-rpms: true
Skip-test-centos-rpms: true
Skip-test-centos-8.3-rpms: true
Skip-test-leap-15-rpms: true
Allow-unstable-test: true
Skip-PR-comments: true
Test-tag: test_pool_svc
Test-repeat: 25

Signed-off-by: Kenneth Cain <kenneth.c.cain@intel.com>