### PR TITLE
DAOS-9030 test: Adjust test to account for rounding (#7374)

### DIFF
--- a/src/tests/ftest/control/dmg_pool_query_test.yaml
+++ b/src/tests/ftest/control/dmg_pool_query_test.yaml
@@ -37,7 +37,7 @@ exp_vals:
   version: 1
   leader: 0
   scm:
-    total: 16000000000
+    total: 16000024576
   nvme:
     total: 32000000000
   rebuild:


### PR DESCRIPTION
Per-target SCM usage is rounded to nearest page boundary.  Account
for this in the query to check the SCM size.

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>