### PR TITLE
DAOS-9072 test: move romio test to hw small 

### DIFF
--- a/src/tests/ftest/mpiio/romio.py
+++ b/src/tests/ftest/mpiio/romio.py
@@ -20,7 +20,7 @@ class Romio(MpiioTests):
         Run Romio test provided in mpich package
         Testing various I/O functions provided in romio test suite
         :avocado: tags=all,pr,daily_regression
-        :avocado: tags=small
+        :avocado: tags=hw,small
         :avocado: tags=mpiio,mpich,romio
         """
         # setting romio parameters

--- a/src/tests/ftest/mpiio/romio.yaml
+++ b/src/tests/ftest/mpiio/romio.yaml
@@ -8,10 +8,24 @@ timeout: 150
 # romio test suite directory in CI nodes when available.
 server_config:
     name: daos_server
+    servers:
+        bdev_class: nvme
+        bdev_list: ["0000:81:00.0","0000:da:00.0"]
+        scm_class: dcpm
+        scm_list: ["/dev/pmem0"]
+    transport_config:
+        allow_insecure: True
+agent_config:
+    transport_config:
+        allow_insecure: True
+dmg:
+    transport_config:
+        allow_insecure: True
 pool:
     mode: 146
     name: daos_server
-    scm_size: 1000000000
+    scm_size: 30000000000
+    nvme_size: 40000000000
     svcn: 1
     control_method: dmg
 container:

--- a/src/tests/ftest/mpiio/romio.yaml
+++ b/src/tests/ftest/mpiio/romio.yaml
@@ -10,7 +10,7 @@ server_config:
     name: daos_server
     servers:
         bdev_class: nvme
-        bdev_list: ["0000:81:00.0","0000:da:00.0"]
+        bdev_list: ["aaaa:aa:aa.a","bbbb:bb:bb.b"]
         scm_class: dcpm
         scm_list: ["/dev/pmem0"]
 pool:

--- a/src/tests/ftest/mpiio/romio.yaml
+++ b/src/tests/ftest/mpiio/romio.yaml
@@ -13,14 +13,6 @@ server_config:
         bdev_list: ["0000:81:00.0","0000:da:00.0"]
         scm_class: dcpm
         scm_list: ["/dev/pmem0"]
-    transport_config:
-        allow_insecure: True
-agent_config:
-    transport_config:
-        allow_insecure: True
-dmg:
-    transport_config:
-        allow_insecure: True
 pool:
     mode: 146
     name: daos_server

--- a/src/tests/ftest/mpiio/romio.yaml
+++ b/src/tests/ftest/mpiio/romio.yaml
@@ -16,8 +16,8 @@ server_config:
 pool:
     mode: 146
     name: daos_server
-    scm_size: 30000000000
-    nvme_size: 40000000000
+    scm_size: 30G
+    nvme_size: 40G
     svcn: 1
     control_method: dmg
 container:


### PR DESCRIPTION
it seems that some VMs are running slower on async collective tests
that can potentially create background threads and use collective
MPI functions.

Quick-Functional: true
Test-tag: romio
Test-repeat: 10

Signed-off-by: Mohamad Chaarawi <mohamad.chaarawi@intel.com>