### PR TITLE
DAOS-7924 doc: remove references to daos-tests

### DIFF
--- a/docs/QSG/setup.md
+++ b/docs/QSG/setup.md
@@ -1,8 +1,6 @@
 # DAOS Set-Up on CentOS
 
 
-
-
 The following instructions detail how to install, set up and start DAOS servers and clients on two or more nodes.  This document includes
 instructions for CentOS. For setup instructions on OpenSuse, refer to the [OpenSuse setup](../suse_setup/). 
 For more details reference the DAOS administration guide:
@@ -107,14 +105,6 @@ daos-server RPM.
 
 		pdsh -w $ALL_NODES -x $SERVER_NODES 'sudo yum install -y
 		daos-client'
-
-
-
-22. (Optionally) Install the DAOS test RPMs on the client nodes -
-    typically not required
-
-		pdsh -w $ALL_NODES -x $SERVER_NODES 'sudo yum install -y'
-		daos-tests\'
 
 
 ## Hardware Provisioning

--- a/docs/QSG/suse_setup.md
+++ b/docs/QSG/suse_setup.md
@@ -118,12 +118,6 @@ daos-server RPM.
 
 
 
-22. (Optionally) Install the DAOS test RPMs on the client nodes -
-    typically not required
-
-		pdsh -w $ALL_NODES -x $SERVER_NODES 'sudo zypper install -y daos-tests'
-
-
 ## Hardware Provisioning
 
 In this section, PMem (Intel(R) Optane(TM) persistent memory) and NVME

--- a/docs/QSG/tour.md
+++ b/docs/QSG/tour.md
@@ -47,8 +47,6 @@ bring-up DAOS servers and clients.
 ### required rpm
 
 	$ sudo yum install -y fio
-	or
-	$ sudo yum install -y daos-tests
 
 ### run fio
 


### PR DESCRIPTION
remove references to daos-tests in the quick start docs
(not required for production deployments, and would introduce
dependencies on MPI which are very environment-specific)

Docs-only: true
Signed-off-by: Michael Hennecke <michael.hennecke@intel.com>