### PR TITLE
DAOS-8969 test: Use linker wrap for drpc unit tests (#7306)

### DIFF
--- a/src/common/tests/SConscript
+++ b/src/common/tests/SConscript
@@ -18,8 +18,6 @@ def scons():
     """Execute build"""
     Import('tenv')
 
-    common_test_utils = tenv.SharedObject(['test_mocks.c', 'test_utils.c'])
-    Export('common_test_utils')
     tenv.Append(CPPDEFINES=['-DDAOS_PMEM_BUILD'])
 
     utest_utils = tenv.SharedObject('utest_common.c')
@@ -56,31 +54,44 @@ def scons():
     tenv.Install('$PREFIX/bin/', [common_test])
 
     unit_env = tenv.Clone()
-    # Some syscalls are aliased when fortification is enabled, which makes
-    # mocking in unit tests into a headache.
-    # The compiler decides this on its own, but let's force the issue.
-    compiler_setup.remove_fortify(unit_env)
+    unit_env.AppendUnique(OBJPREFIX='utest_')
+
+    common_mock_ld_script = "%s/common-mock-ld-opts" % Dir('.').srcnode()
+    unit_env.AppendUnique(LINKFLAGS=['-Wl,@%s' % common_mock_ld_script])
+
+    mock_test_utils = unit_env.SharedObject(['test_mocks.c', 'test_utils.c'])
+    drpc_test_utils = unit_env.SharedObject(['../drpc.c']) + mock_test_utils
+    Export('drpc_test_utils')
 
     acl_api = unit_env.Object('../acl_api.c')
 
-    daos_build.test(unit_env, 'drpc_tests',
-                    ['drpc_tests.c', '../drpc.c', '../drpc.pb-c.c',
-                     common_test_utils],
-                    LIBS=['protobuf-c', 'daos_common', 'gurt', 'cmocka'])
+    Depends('acl_api_tests', common_mock_ld_script)
     daos_build.test(unit_env, 'acl_api_tests',
-                    source=['acl_api_tests.c', acl_api,
-                            common_test_utils],
+                    source=['acl_api_tests.c', acl_api, mock_test_utils],
                     LIBS=['protobuf-c', 'daos_common', 'gurt', 'cmocka'])
+
+    Depends('acl_valid_tests', common_mock_ld_script)
     daos_build.test(unit_env, 'acl_valid_tests',
-                    source=['acl_valid_tests.c', acl_api,
-                            common_test_utils],
+                    source=['acl_valid_tests.c', acl_api, mock_test_utils],
                     LIBS=['protobuf-c', 'daos_common', 'gurt', 'cmocka'])
+
+    Depends('acl_util_tests', common_mock_ld_script)
     daos_build.test(unit_env, 'acl_util_tests',
-                    source=['acl_util_tests.c', '../acl_util.c'],
+                    source=['acl_util_tests.c', '../acl_util.c', mock_test_utils],
                     LIBS=['protobuf-c', 'daos_common', 'gurt', 'cmocka'])
+
+    Depends('acl_principal_tests', common_mock_ld_script)
     daos_build.test(unit_env, 'acl_principal_tests',
-                    source=['acl_principal_tests.c', '../acl_principal.c'],
+                    source=['acl_principal_tests.c', '../acl_principal.c', mock_test_utils],
                     LIBS=['protobuf-c', 'daos_common', 'gurt', 'cmocka'])
+
+    Depends('drpc_tests', common_mock_ld_script)
+    daos_build.test(unit_env, 'drpc_tests',
+                    ['drpc_tests.c', '../drpc.c', '../drpc.pb-c.c', mock_test_utils],
+                    LIBS=['protobuf-c', 'daos_common', 'gurt', 'cmocka'])
+
+
+
 
 if __name__ == "SCons.Script":
     scons()

--- a/src/common/tests/common-mock-ld-opts
+++ b/src/common/tests/common-mock-ld-opts
@@ -1,0 +1,11 @@
+--wrap=socket
+--wrap=connect
+--wrap=bind
+--wrap=fcntl
+--wrap=listen
+--wrap=accept
+--wrap=close
+--wrap=sendmsg
+--wrap=recvmsg
+--wrap=poll
+--wrap=unlink

--- a/src/common/tests/test_mocks.c
+++ b/src/common/tests/test_mocks.c
@@ -6,10 +6,6 @@
 #include <daos/test_mocks.h>
 #include <daos/test_utils.h>
 
-#if D_HAS_WARNING(4, "-Wframe-larger-than=")
-	#pragma GCC diagnostic ignored "-Wframe-larger-than="
-#endif
-
 /**
  * Generic mocks for external functions
  */
@@ -28,7 +24,7 @@ int socket_family; /* saved input */
 int socket_type; /* saved input */
 int socket_protocol; /* saved input */
 int
-socket(int family, int type, int protocol)
+__wrap_socket(int family, int type, int protocol)
 {
 	socket_family = family;
 	socket_type = type;
@@ -56,7 +52,7 @@ const struct sockaddr *connect_addr_ptr; /* for nullcheck */
 struct sockaddr_un connect_addr; /* saved copy of input value */
 socklen_t connect_addrlen; /* saved input */
 int
-connect(int sockfd, const struct sockaddr *addr, socklen_t addrlen)
+__wrap_connect(int sockfd, const struct sockaddr *addr, socklen_t addrlen)
 {
 	connect_sockfd = sockfd;
 	connect_addr_ptr = addr;
@@ -87,7 +83,7 @@ const struct sockaddr *bind_addr_ptr; /* for nullcheck */
 struct sockaddr_un bind_addr; /* saved copy of input value */
 socklen_t bind_addrlen; /* saved input */
 int
-bind(int sockfd, const struct sockaddr *addr, socklen_t addrlen)
+__wrap_bind(int sockfd, const struct sockaddr *addr, socklen_t addrlen)
 {
 	bind_sockfd = sockfd;
 	bind_addr_ptr = addr;
@@ -117,7 +113,7 @@ int fcntl_fd; /* saved input */
 int fcntl_cmd; /* saved input */
 int fcntl_arg; /* saved input */
 int
-fcntl(int fd, int cmd, ...)
+__wrap_fcntl(int fd, int cmd, ...)
 {
 	va_list arglist;
 
@@ -145,7 +141,7 @@ int listen_return; /* value to be returned by listen() */
 int listen_sockfd; /* saved input */
 int listen_backlog; /* saved input */
 int
-listen(int sockfd, int backlog)
+__wrap_listen(int sockfd, int backlog)
 {
 	listen_sockfd = sockfd;
 	listen_backlog = backlog;
@@ -168,7 +164,7 @@ int accept_sockfd; /* saved input */
 struct sockaddr *accept_addr_ptr; /* saved input ptr */
 socklen_t *accept_addrlen_ptr; /* saved input ptr */
 int
-accept(int sockfd, struct sockaddr *addr, socklen_t *addrlen)
+__wrap_accept(int sockfd, struct sockaddr *addr, socklen_t *addrlen)
 {
 	accept_sockfd = sockfd;
 	accept_addr_ptr = addr;
@@ -189,7 +185,7 @@ int close_call_count;
 int close_return; /* value to be returned by close() */
 int close_fd; /* saved input */
 int
-close(int fd)
+__wrap_close(int fd)
 {
 	close_fd = fd;
 	close_call_count++;
@@ -222,7 +218,7 @@ size_t sendmsg_msg_iov_len; /* saved iov len */
 uint8_t sendmsg_msg_content[UNIXCOMM_MAXMSGSIZE]; /* copied into iov */
 int sendmsg_flags; /* saved input */
 ssize_t
-sendmsg(int sockfd, const struct msghdr *msg, int flags)
+__wrap_sendmsg(int sockfd, const struct msghdr *msg, int flags)
 {
 	sendmsg_call_count++;
 
@@ -264,7 +260,7 @@ size_t recvmsg_msg_iov_len; /* saved iov len */
 uint8_t recvmsg_msg_content[UNIXCOMM_MAXMSGSIZE]; /* copied into iov */
 int recvmsg_flags; /* saved input */
 ssize_t
-recvmsg(int sockfd, struct msghdr *msg, int flags)
+__wrap_recvmsg(int sockfd, struct msghdr *msg, int flags)
 {
 	recvmsg_call_count++;
 
@@ -286,6 +282,32 @@ recvmsg(int sockfd, struct msghdr *msg, int flags)
 		return -1;
 	}
 	return recvmsg_return;
+}
+
+void
+mock_valid_drpc_call_in_recvmsg(void)
+{
+	Drpc__Call *call = new_drpc_call();
+
+	/* Mock a valid DRPC call coming in */
+	recvmsg_return = drpc__call__get_packed_size(call);
+	drpc__call__pack(call, recvmsg_msg_content);
+
+	drpc__call__free_unpacked(call, NULL);
+}
+
+void
+mock_valid_drpc_resp_in_recvmsg(Drpc__Status status)
+{
+	Drpc__Response *resp = new_drpc_response();
+
+	resp->status = status;
+
+	/* Mock a valid DRPC response coming in */
+	recvmsg_return = drpc__response__get_packed_size(resp);
+	drpc__response__pack(resp, recvmsg_msg_content);
+
+	drpc__response__free_unpacked(resp, NULL);
 }
 
 void
@@ -312,7 +334,7 @@ nfds_t poll_nfds; /* saved input */
 int poll_timeout; /* saved input */
 int poll_revents_return[1024]; /* to be returned in revents struct */
 int
-poll(struct pollfd *fds, nfds_t nfds, int timeout)
+__wrap_poll(struct pollfd *fds, nfds_t nfds, int timeout)
 {
 	poll_fds_ptr = (void *)fds;
 	if (fds != NULL) {
@@ -346,80 +368,11 @@ mock_unlink_setup(void)
 int unlink_call_count;
 const char *unlink_name;
 int
-unlink(const char *__name)
+__wrap_unlink(const char *__name)
 {
 	unlink_call_count++;
 	unlink_name = __name;
 	return 0;
-}
-
-/* Mock for the drpc->handler function pointer */
-void
-mock_drpc_handler_setup(void)
-{
-	mock_drpc_handler_call_count = 0;
-	mock_drpc_handler_call = NULL;
-	mock_drpc_handler_resp_ptr = NULL;
-	mock_drpc_handler_resp_return = new_drpc_response();
-}
-
-void
-mock_drpc_handler_teardown(void)
-{
-	if (mock_drpc_handler_call != NULL) {
-		drpc__call__free_unpacked(mock_drpc_handler_call, NULL);
-	}
-
-	drpc__response__free_unpacked(mock_drpc_handler_resp_return, NULL);
-}
-
-int mock_drpc_handler_call_count; /* how many times it was called */
-Drpc__Call *mock_drpc_handler_call; /* alloc copy of the structure passed in */
-void *mock_drpc_handler_resp_ptr; /* saved value of resp ptr */
-Drpc__Response *mock_drpc_handler_resp_return; /* to be returned in *resp */
-void
-mock_drpc_handler(Drpc__Call *call, Drpc__Response *resp)
-{
-	uint8_t buffer[UNIXCOMM_MAXMSGSIZE];
-
-	mock_drpc_handler_call_count++;
-
-	if (call == NULL) {
-		mock_drpc_handler_call = NULL;
-	} else {
-		/*
-		 * Caller will free the original so we want to make a copy.
-		 * Keep only the latest call.
-		 */
-		if (mock_drpc_handler_call != NULL) {
-			drpc__call__free_unpacked(mock_drpc_handler_call, NULL);
-		}
-
-		/*
-		 * Drpc__Call has hierarchy of pointers - easiest way to
-		 * copy is to pack and unpack.
-		 */
-		drpc__call__pack(call, buffer);
-		mock_drpc_handler_call = drpc__call__unpack(NULL,
-				drpc__call__get_packed_size(call),
-				buffer);
-	}
-
-	mock_drpc_handler_resp_ptr = (void *)resp;
-
-	if (resp != NULL && mock_drpc_handler_resp_return != NULL) {
-		size_t len;
-
-		len = mock_drpc_handler_resp_return->body.len;
-		memcpy(resp, mock_drpc_handler_resp_return,
-				sizeof(Drpc__Response));
-		resp->body.len = len;
-		if (len > 0) {
-			D_ALLOC(resp->body.data, len);
-			memcpy(resp->body.data,
-				mock_drpc_handler_resp_return->body.data, len);
-		}
-	}
 }
 
 /* Mocks/stubs for Argobots functions */

--- a/src/common/tests/test_utils.c
+++ b/src/common/tests/test_utils.c
@@ -8,8 +8,11 @@
  * Some convenience functions for unit tests
  */
 
-#include <daos/test_mocks.h>
 #include <daos/test_utils.h>
+
+#if D_HAS_WARNING(4, "-Wframe-larger-than=")
+	#pragma GCC diagnostic ignored "-Wframe-larger-than="
+#endif
 
 struct drpc*
 new_drpc_with_fd(int fd)
@@ -28,7 +31,6 @@ new_drpc_with_fd(int fd)
 
 	return ctx;
 }
-
 
 void
 free_drpc(struct drpc *ctx)
@@ -60,18 +62,6 @@ new_drpc_call_with_module(int module_id)
 	return call;
 }
 
-void
-mock_valid_drpc_call_in_recvmsg(void)
-{
-	Drpc__Call *call = new_drpc_call();
-
-	/* Mock a valid DRPC call coming in */
-	recvmsg_return = drpc__call__get_packed_size(call);
-	drpc__call__pack(call, recvmsg_msg_content);
-
-	drpc__call__free_unpacked(call, NULL);
-}
-
 Drpc__Response*
 new_drpc_response(void)
 {
@@ -83,20 +73,6 @@ new_drpc_response(void)
 	resp->status = DRPC__STATUS__FAILURE;
 
 	return resp;
-}
-
-void
-mock_valid_drpc_resp_in_recvmsg(Drpc__Status status)
-{
-	Drpc__Response *resp = new_drpc_response();
-
-	resp->status = status;
-
-	/* Mock a valid DRPC response coming in */
-	recvmsg_return = drpc__response__get_packed_size(resp);
-	drpc__response__pack(resp, recvmsg_msg_content);
-
-	drpc__response__free_unpacked(resp, NULL);
 }
 
 void
@@ -120,6 +96,75 @@ free_all_aces(struct daos_ace *ace[], size_t num_aces)
 
 	for (i = 0; i < num_aces; i++) {
 		daos_ace_free(ace[i]);
+	}
+}
+
+/* Mock for the drpc->handler function pointer */
+void
+mock_drpc_handler_setup(void)
+{
+	mock_drpc_handler_call_count = 0;
+	mock_drpc_handler_call = NULL;
+	mock_drpc_handler_resp_ptr = NULL;
+	mock_drpc_handler_resp_return = new_drpc_response();
+}
+
+void
+mock_drpc_handler_teardown(void)
+{
+	if (mock_drpc_handler_call != NULL) {
+		drpc__call__free_unpacked(mock_drpc_handler_call, NULL);
+	}
+
+	drpc__response__free_unpacked(mock_drpc_handler_resp_return, NULL);
+}
+
+int mock_drpc_handler_call_count; /* how many times it was called */
+Drpc__Call *mock_drpc_handler_call; /* alloc copy of the structure passed in */
+void *mock_drpc_handler_resp_ptr; /* saved value of resp ptr */
+Drpc__Response *mock_drpc_handler_resp_return; /* to be returned in *resp */
+void
+mock_drpc_handler(Drpc__Call *call, Drpc__Response *resp)
+{
+	uint8_t buffer[UNIXCOMM_MAXMSGSIZE];
+
+	mock_drpc_handler_call_count++;
+
+	if (call == NULL) {
+		mock_drpc_handler_call = NULL;
+	} else {
+		/*
+		 * Caller will free the original so we want to make a copy.
+		 * Keep only the latest call.
+		 */
+		if (mock_drpc_handler_call != NULL) {
+			drpc__call__free_unpacked(mock_drpc_handler_call, NULL);
+		}
+
+		/*
+		 * Drpc__Call has hierarchy of pointers - easiest way to
+		 * copy is to pack and unpack.
+		 */
+		drpc__call__pack(call, buffer);
+		mock_drpc_handler_call = drpc__call__unpack(NULL,
+				drpc__call__get_packed_size(call),
+				buffer);
+	}
+
+	mock_drpc_handler_resp_ptr = (void *)resp;
+
+	if (resp != NULL && mock_drpc_handler_resp_return != NULL) {
+		size_t len;
+
+		len = mock_drpc_handler_resp_return->body.len;
+		memcpy(resp, mock_drpc_handler_resp_return,
+				sizeof(Drpc__Response));
+		resp->body.len = len;
+		if (len > 0) {
+			D_ALLOC(resp->body.data, len);
+			memcpy(resp->body.data,
+				mock_drpc_handler_resp_return->body.data, len);
+		}
 	}
 }
 

--- a/src/engine/tests/SConscript
+++ b/src/engine/tests/SConscript
@@ -4,32 +4,35 @@ import compiler_setup
 
 def scons():
     """Execute build"""
-    Import('denv', 'common_test_utils')
+    Import('denv', 'drpc_test_utils')
 
     unit_env = denv.Clone()
     unit_env.AppendUnique(OBJPREFIX='utest_')
-    # Some syscalls are aliased when fortification is enabled, which makes
-    # mocking in unit tests into a headache.
-    # The compiler decides this on its own, but let's force the issue.
-    compiler_setup.remove_fortify(unit_env)
 
+    common_mock_ld_script = "%s/../../common/tests/common-mock-ld-opts" % Dir('.').srcnode()
+    unit_env.AppendUnique(LINKFLAGS=['-Wl,@%s' % common_mock_ld_script])
+
+    Depends('drpc_progress_tests', common_mock_ld_script)
     daos_build.test(unit_env, 'drpc_progress_tests',
-                    ['drpc_progress_tests.c', common_test_utils,
+                    ['drpc_progress_tests.c', drpc_test_utils,
                      '../drpc_progress.c'],
                     LIBS=['daos_common', 'protobuf-c', 'gurt', 'cmocka'])
 
+    Depends('drpc_handler_tests', common_mock_ld_script)
     daos_build.test(unit_env, 'drpc_handler_tests',
-                    ['drpc_handler_tests.c', common_test_utils,
+                    ['drpc_handler_tests.c', drpc_test_utils,
                      '../drpc_handler.c'],
                     LIBS=['daos_common', 'protobuf-c', 'gurt', 'cmocka'])
 
+    Depends('drpc_listener_tests', common_mock_ld_script)
     daos_build.test(unit_env, 'drpc_listener_tests',
-                    ['drpc_listener_tests.c', common_test_utils,
+                    ['drpc_listener_tests.c', drpc_test_utils,
                      '../drpc_listener.c'],
                     LIBS=['daos_common', 'protobuf-c', 'gurt', 'cmocka'])
 
+    Depends('drpc_client_tests', common_mock_ld_script)
     daos_build.test(unit_env, 'drpc_client_tests',
-                    ['drpc_client_tests.c', common_test_utils,
+                    ['drpc_client_tests.c', drpc_test_utils,
                      '../drpc_client.c', '../drpc_ras.c', '../srv.pb-c.c',
                      '../event.pb-c.c'],
                     LIBS=['daos_common', 'protobuf-c', 'gurt', 'cmocka',

--- a/src/include/daos/test_mocks.h
+++ b/src/include/daos/test_mocks.h
@@ -84,6 +84,16 @@ extern size_t recvmsg_msg_iov_len; /* saved iov len */
 extern uint8_t recvmsg_msg_content[UNIXCOMM_MAXMSGSIZE]; /* copied into iov */
 extern int recvmsg_flags; /* saved input */
 
+/**
+ * Sets up recvmsg mock to populate a valid serialized Drpc__Call as the message received.
+ */
+void mock_valid_drpc_call_in_recvmsg(void);
+
+/**
+ * Sets up recvmsg mock to populate a valid serialized Drpc__Response as the message received.
+ */
+void mock_valid_drpc_resp_in_recvmsg(Drpc__Status status);
+
 void mock_poll_setup(void);
 void mock_poll_teardown(void);
 extern int poll_return; /* value to be returned */
@@ -96,15 +106,6 @@ extern int poll_revents_return[1024]; /* to be returned in revents struct */
 void mock_unlink_setup(void);
 extern int unlink_call_count;
 extern const char *unlink_name;
-
-/* Mock to be used for the drpc->handler function pointer */
-void mock_drpc_handler_setup(void);
-void mock_drpc_handler_teardown(void);
-extern int mock_drpc_handler_call_count; /* how many times it was called */
-extern Drpc__Call *mock_drpc_handler_call; /* alloc copy of input param */
-extern void *mock_drpc_handler_resp_ptr; /* saved value of resp ptr */
-extern Drpc__Response *mock_drpc_handler_resp_return; /* returned in *resp */
-void mock_drpc_handler(Drpc__Call *call, Drpc__Response *resp);
 
 void mock_ABT_mutex_create_setup(void);
 extern int ABT_mutex_create_return; /* value to be returned */

--- a/src/include/daos/test_utils.h
+++ b/src/include/daos/test_utils.h
@@ -51,18 +51,6 @@ Drpc__Call *new_drpc_call(void);
 Drpc__Call *new_drpc_call_with_module(int module_id);
 
 /**
- * Using mocks in test_mocks.h, sets up recvmsg mock to populate a valid
- * serialized Drpc__Call as the message received.
- */
-void mock_valid_drpc_call_in_recvmsg(void);
-
-/**
- * Using mocks in test_mocks.h, sets up recvmsg mock to populate a valid
- * serialized Drpc__Response as the message received.
- */
-void mock_valid_drpc_resp_in_recvmsg(Drpc__Status status);
-
-/**
  * Generates a valid Drpc__Response structure.
  *
  * \return	Newly allocated Drpc__Response
@@ -90,5 +78,14 @@ fill_ace_list_with_users(struct daos_ace *ace[], size_t num_aces);
  */
 void
 free_all_aces(struct daos_ace *ace[], size_t num_aces);
+
+/* Mock to be used for the drpc->handler function pointer */
+void mock_drpc_handler_setup(void);
+void mock_drpc_handler_teardown(void);
+extern int mock_drpc_handler_call_count; /* how many times it was called */
+extern Drpc__Call *mock_drpc_handler_call; /* alloc copy of input param */
+extern void *mock_drpc_handler_resp_ptr; /* saved value of resp ptr */
+extern Drpc__Response *mock_drpc_handler_resp_return; /* returned in *resp */
+void mock_drpc_handler(Drpc__Call *call, Drpc__Response *resp);
 
 #endif /* __DAOS_TEST_UTILS_H__ */


### PR DESCRIPTION
Simple link-time symbol substitution was becoming unreliable for
mocking system calls. Changed the affected tests to use the linker's
--wrap option instead via a linker script
- Rearranged unit test utils and mocks to remove a circular
  dependency.
- Ensure all tests built with the --wrap flag include the __wrap_*
  symbols.

Signed-off-by: Kris Jacque <kristin.jacque@intel.com>