### PR TITLE
DAOS-XXX test: Wrap MPI code in unified interface

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+daos (2.1.100-8) unstable; urgency=medium
+  [ Jeff Olivier ]
+  * Extract MPI from many binaries create dpar and dpar_mpi providing a
+    similar interface to abstract away the direct MPI dependence
+
+ -- Jeff Olivier <jeffrey.v.olivier@intel.com>  Wed, 17 Nov 2021 14:00:01 -0100
+
 daos (2.1.100-7) unstable; urgency=medium
   [ Wang Shilong ]
   * Update for libdaos major version bump

--- a/debian/control
+++ b/debian/control
@@ -92,8 +92,7 @@ Description: The Distributed Asynchronous Object Storage (DAOS) is an open-sourc
 Package: daos-tests
 Architecture: any
 Multi-Arch: same
-Depends: daos-client-tests-openmpi (= ${binary:Version}),
-         daos-server-tests-openmpi (= ${binary:Version})
+Depends: daos-client-tests-openmpi (= ${binary:Version})
 Description: This is the package is a metapackage to install all of the test packages
  .
  This package contains tests
@@ -131,15 +130,6 @@ Multi-Arch: same
 Depends: ${shlibs:Depends}, ${misc:Depends},
          daos-server (= ${binary:Version})
 Description: This is the package needed to run the DAOS test suite (server tests)
- .
- This package contains tests
-
-Package: daos-server-tests-openmpi
-Architecture: any
-Multi-Arch: same
-Depends: ${shlibs:Depends}, ${misc:Depends},
-         daos-server-tests (= ${binary:Version})
-Description: This is the package needed to run the DAOS test suite openmpi tools
  .
  This package contains tests
 

--- a/debian/daos-client-tests-openmpi.install
+++ b/debian/daos-client-tests-openmpi.install
@@ -1,7 +1,2 @@
 usr/bin/crt_launch
-usr/bin/daos_perf
-usr/bin/daos_racer
-usr/bin/daos_test
-usr/bin/dfs_test
-usr/bin/jobtest
-usr/lib64/libdts.so
+usr/lib64/libdpar_mpi.so

--- a/debian/daos-client-tests.install
+++ b/debian/daos-client-tests.install
@@ -12,6 +12,13 @@ usr/bin/io_conf
 usr/bin/fault_status
 usr/lib64/libdaos_tests.so
 etc/daos/fault-inject-cart.yaml
+usr/bin/daos_perf
+usr/bin/daos_racer
+usr/bin/daos_test
+usr/bin/dfs_test
+usr/bin/jobtest
+usr/lib64/libdts.so
+usr/lib64/libdpar.so
 # For avocado tests
 usr/lib/daos/.build_vars.json
 usr/lib/daos/.build_vars.sh

--- a/debian/daos-server-tests-openmpi.install
+++ b/debian/daos-server-tests-openmpi.install
@@ -1,4 +1,0 @@
-usr/bin/vos_perf
-usr/bin/daos_run_io_conf
-usr/bin/obj_ctl
-usr/bin/daos_gen_io_conf

--- a/debian/daos-server-tests.install
+++ b/debian/daos-server-tests.install
@@ -8,3 +8,7 @@ usr/bin/vea_ut
 usr/bin/srv_checksum_tests
 usr/bin/vos_tests
 usr/bin/vea_stress
+usr/bin/vos_perf
+usr/bin/daos_run_io_conf
+usr/bin/obj_ctl
+usr/bin/daos_gen_io_conf

--- a/src/common/SConscript
+++ b/src/common/SConscript
@@ -28,22 +28,32 @@ def build_daos_common(env, client, prereqs):
     common = daos_build.library(denv, libname, COMMON_FILES, LIBS=common_libs)
     denv.Install('$PREFIX/lib64/', common)
 
-def build_dts_library(env):
+def build_dpar(env):
     """Build libdts library"""
-    Import('prereqs')
+
+    serial_lib = daos_build.library(env, 'libdpar', ['dpar_serial.c'])
+    env.Install('$PREFIX/lib64/', serial_lib)
+
+    denv = env.Clone()
+
+    if not GetOption('help') and not GetOption('clean'):
+        mpi = daos_build.configure_mpi(denv, [])
+        if mpi is None:
+            print("\nSkipping compilation for libdpar_mpi as no MPI is found")
+            print("Install and load mpich or openmpi\n")
+            return
+
+    mpi_lib = daos_build.library(denv, 'libdpar_mpi', ['dpar_mpi.c'])
+    denv.Install('$PREFIX/lib64/', mpi_lib)
+
+def build_dts_library(env, prereqs):
+    """Build libdts library"""
 
     denv = env.Clone()
 
     prereqs.require(denv, 'argobots', 'protobufc')
 
-    if not GetOption('help') and not GetOption('clean'):
-        mpi = daos_build.configure_mpi(denv, [])
-        if mpi is None:
-            print("\nSkipping compilation for tests that need MPI")
-            print("Install and load mpich or openmpi\n")
-            return
-
-    libraries = ['cmocka', 'daos', 'daos_tests']
+    libraries = ['cmocka', 'daos', 'daos_tests', 'dpar']
 
     # Add runtime paths for daos libraries
     denv.AppendUnique(LIBPATH=["../client/api"])
@@ -107,7 +117,8 @@ def scons():
     prereqs.require(tenv, 'pmdk')
     SConscript('tests/SConscript', exports='tenv')
 
-    build_dts_library(base_env)
+    build_dpar(base_env)
+    build_dts_library(base_env, prereqs)
 
 if __name__ == "SCons.Script":
     scons()

--- a/src/common/dpar_mpi.c
+++ b/src/common/dpar_mpi.c
@@ -1,0 +1,204 @@
+#include <stdio.h>
+#include <mpi.h>
+#include <daos/dpar.h>
+
+int
+par_init(int *argc, char ***argv)
+{
+	int rc = MPI_Init(argc, argv);
+
+	if (rc == MPI_SUCCESS)
+		return 0;
+
+	fprintf(stderr, "MPI_Init failed with %d\n", rc);
+	return -1;
+}
+
+int
+par_fini(void)
+{
+	int rc = MPI_Finalize();
+
+	if (rc == MPI_SUCCESS)
+		return 0;
+
+	fprintf(stderr, "MPI_Finalize failed with %d\n", rc);
+	return -1;
+}
+
+int
+par_barrier(void)
+{
+	int rc = MPI_Barrier(MPI_COMM_WORLD);
+
+	if (rc == MPI_SUCCESS)
+		return 0;
+
+	fprintf(stderr, "MPI_Barrier failed with %d\n", rc);
+	return -1;
+}
+
+int
+par_rank(int *rank)
+{
+	int rc = MPI_Comm_rank(MPI_COMM_WORLD, rank);
+
+	if (rc == MPI_SUCCESS)
+		return 0;
+
+	fprintf(stderr, "MPI_Comm_rank failed with %d\n", rc);
+	return -1;
+}
+
+int
+par_size(int *size)
+{
+	int rc = MPI_Comm_size(MPI_COMM_WORLD, size);
+
+	if (rc == MPI_SUCCESS)
+		return 0;
+
+	fprintf(stderr, "MPI_Comm_size failed with %d\n", rc);
+	return -1;
+}
+
+static inline
+MPI_Datatype
+type_par2mpi(enum par_type type)
+{
+	switch (type) {
+	case PAR_INT:
+		return MPI_INT;
+	case PAR_CHAR:
+		return MPI_CHAR;
+	case PAR_BYTE:
+		return MPI_BYTE;
+	case PAR_DOUBLE:
+		return MPI_DOUBLE;
+	case PAR_UINT64:
+		return MPI_UINT64_T;
+	default:
+		fprintf(stderr, "Unknown datatype specified %d\n", type);
+		return MPI_DATATYPE_NULL;
+	};
+}
+
+static inline
+MPI_Op
+op_par2mpi(enum par_op op)
+{
+	switch (op) {
+	case PAR_MAX:
+		return MPI_MAX;
+	case PAR_MIN:
+		return MPI_MIN;
+	case PAR_SUM:
+		return MPI_SUM;
+	default:
+		fprintf(stderr, "Unknown op specified %d\n", op);
+		return MPI_OP_NULL;
+	};
+}
+
+int
+par_reduce(const void *sendbuf, void *recvbuf, int count, enum par_type type, enum par_op op,
+	   int root)
+{
+	MPI_Datatype	mtype = type_par2mpi(type);
+	MPI_Op		mop = op_par2mpi(op);
+	int		rc;
+
+	if (mtype == MPI_DATATYPE_NULL)
+		return -1;
+	if (mop == MPI_OP_NULL)
+		return -1;
+
+	rc = MPI_Reduce(sendbuf, recvbuf, count, mtype, mop, root, MPI_COMM_WORLD);
+
+	if (rc == MPI_SUCCESS)
+		return 0;
+
+	fprintf(stderr, "MPI_Reduce failed with %d\n", rc);
+	return -1;
+}
+
+/** Gather from all ranks */
+int
+par_gather(const void *sendbuf, void *recvbuf, int count, enum par_type type,
+	   int root)
+{
+	MPI_Datatype	mtype = type_par2mpi(type);
+	int		rc;
+
+	if (mtype == MPI_DATATYPE_NULL)
+		return -1;
+
+	rc = MPI_Gather(sendbuf, count, mtype, recvbuf, count, mtype, root, MPI_COMM_WORLD);
+
+	if (rc == MPI_SUCCESS)
+		return 0;
+
+	fprintf(stderr, "MPI_Gather failed with %d\n", rc);
+	return -1;
+}
+
+/** All reduce from all ranks */
+int
+par_allreduce(const void *sendbuf, void *recvbuf, int count, enum par_type type, enum par_op op)
+{
+	MPI_Datatype	mtype = type_par2mpi(type);
+	MPI_Op		mop = op_par2mpi(op);
+	int		rc;
+
+	if (mtype == MPI_DATATYPE_NULL)
+		return -1;
+	if (mop == MPI_OP_NULL)
+		return -1;
+
+	rc = MPI_Allreduce(sendbuf, recvbuf, count, mtype, mop, MPI_COMM_WORLD);
+
+
+	if (rc == MPI_SUCCESS)
+		return 0;
+
+	fprintf(stderr, "MPI_Allreduce failed with %d\n", rc);
+	return -1;
+}
+
+/** All gather from all ranks */
+int
+par_allgather(const void *sendbuf, void *recvbuf, int count, enum par_type type)
+{
+	MPI_Datatype	mtype = type_par2mpi(type);
+	int		rc;
+
+	if (mtype == MPI_DATATYPE_NULL)
+		return -1;
+
+	rc = MPI_Allgather(sendbuf, count, mtype, recvbuf, count, mtype, MPI_COMM_WORLD);
+
+	if (rc == MPI_SUCCESS)
+		return 0;
+
+	fprintf(stderr, "MPI_Allgather failed with %d\n", rc);
+	return -1;
+}
+
+/** Broadcast to all ranks */
+int
+par_bcast(void *buffer, int count, enum par_type type, int root)
+{
+	MPI_Datatype	mtype = type_par2mpi(type);
+	int		rc;
+
+	if (mtype == MPI_DATATYPE_NULL)
+		return -1;
+
+	rc = MPI_Bcast(buffer, count, mtype, root, MPI_COMM_WORLD);
+
+	if (rc == MPI_SUCCESS)
+		return 0;
+
+	fprintf(stderr, "MPI_Bcast failed with %d\n", rc);
+	return -1;
+}

--- a/src/common/dpar_serial.c
+++ b/src/common/dpar_serial.c
@@ -1,0 +1,127 @@
+#include <stdio.h>
+#include <inttypes.h>
+#include <string.h>
+#include <daos/dpar.h>
+
+int
+par_init(int *argc, char ***argv)
+{
+	return 0;
+}
+
+int
+par_fini(void)
+{
+	return 0;
+}
+
+int
+par_barrier(void)
+{
+	return 0;
+}
+
+int
+par_rank(int *rank)
+{
+	*rank = 0;
+
+	return 0;
+}
+
+int
+par_size(int *size)
+{
+	*size = 0;
+
+	return 0;
+}
+
+static inline ssize_t
+type2size(enum par_type type)
+{
+	switch (type) {
+	case PAR_BYTE:
+		return sizeof(uint8_t);
+	case PAR_CHAR:
+		return sizeof(char);
+	case PAR_DOUBLE:
+		return sizeof(double);
+	case PAR_INT:
+		return sizeof(int);
+	default:
+		return -1;
+	}
+}
+
+int
+par_reduce(const void *sendbuf, void *recvbuf, int count, enum par_type type, enum par_op op,
+	   int root)
+{
+	ssize_t	size = type2size(type);
+
+	if (size == -1) {
+		fprintf(stderr, "Unrecognized type passed to par_reduce %d\n", type);
+		return -1;
+	}
+
+	memcpy(recvbuf, sendbuf, count * size);
+
+	return 0;
+}
+
+/** Gather from all ranks */
+int
+par_gather(const void *sendbuf, void *recvbuf, int count, enum par_type type,
+	   int root)
+{
+	ssize_t	size = type2size(type);
+
+	if (size == -1) {
+		fprintf(stderr, "Unrecognized type passed to par_gather %d\n", type);
+		return -1;
+	}
+
+	memcpy(recvbuf, sendbuf, count * size);
+
+	return 0;
+}
+
+/** All reduce from all ranks */
+int
+par_allreduce(const void *sendbuf, void *recvbuf, int count, enum par_type type, enum par_op op)
+{
+	ssize_t	size = type2size(type);
+
+	if (size == -1) {
+		fprintf(stderr, "Unrecognized type passed to par_allreduce %d\n", type);
+		return -1;
+	}
+
+	memcpy(recvbuf, sendbuf, count * size);
+
+	return 0;
+}
+
+/** All gather from all ranks */
+int
+par_allgather(const void *sendbuf, void *recvbuf, int count, enum par_type type)
+{
+	ssize_t	size = type2size(type);
+
+	if (size == -1) {
+		fprintf(stderr, "Unrecognized type passed to par_allgather %d\n", type);
+		return -1;
+	}
+
+	memcpy(recvbuf, sendbuf, count * size);
+
+	return 0;
+}
+
+/** Broadcast to all ranks */
+int
+par_bcast(void *buffer, int count, enum par_type type, int root)
+{
+	return 0;
+}

--- a/src/common/dts.c
+++ b/src/common/dts.c
@@ -20,12 +20,12 @@
 #include <stdlib.h>
 #include <unistd.h>
 #include <getopt.h>
-#include <mpi.h>
 #include <daos/common.h>
 #include <daos/credit.h>
 #include <daos/tests_lib.h>
 #include <daos_test.h>
 #include <daos/dts.h>
+#include <daos/dpar.h>
 
 /* path to dmg config file */
 const char *dmg_config_file;
@@ -69,7 +69,7 @@ bcast:
 	if (tsc->tsc_mpi_size <= 1)
 		return rc; /* don't need to share handle */
 
-	MPI_Bcast(&rc, 1, MPI_INT, 0, MPI_COMM_WORLD);
+	par_bcast(&rc, 1, PAR_INT, 0);
 	if (rc)
 		return rc; /* open failed */
 
@@ -85,7 +85,7 @@ engine_pool_fini(struct credit_context *tsc)
 
 	rc = daos_pool_disconnect(tsc->tsc_poh, NULL);
 	D_ASSERTF(rc == 0 || rc == -DER_NO_HDL, "rc="DF_RC"\n", DP_RC(rc));
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	if (tsc->tsc_mpi_rank == 0 && tsc_create_pool(tsc)) {
 		rc = dmg_pool_destroy(dmg_config_file, tsc->tsc_pool_uuid,
@@ -121,7 +121,7 @@ bcast:
 	if (tsc->tsc_mpi_size <= 1)
 		return rc; /* don't need to share handle */
 
-	MPI_Bcast(&rc, 1, MPI_INT, 0, MPI_COMM_WORLD);
+	par_bcast(&rc, 1, PAR_INT, 0);
 	if (rc)
 		return rc; /* open failed */
 

--- a/src/include/daos/dpar.h
+++ b/src/include/daos/dpar.h
@@ -1,0 +1,75 @@
+/**
+ * (C) Copyright 2021 Intel Corporation.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause-Patent
+ */
+
+#ifndef __DAOS_PAR_LIB_H__
+#define __DAOS_PAR_LIB_H__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+enum par_type {
+	PAR_INT		= 0,
+	PAR_CHAR	= 1,
+	PAR_BYTE	= 2,
+	PAR_UINT64	= 3,
+	PAR_DOUBLE	= 4,
+};
+
+enum par_op {
+	PAR_MAX		= 0,
+	PAR_MIN		= 1,
+	PAR_SUM		= 2,
+};
+
+/** Initialize the library */
+int
+par_init(int *argc, char ***argv);
+
+/** Finalize the library */
+int
+par_fini(void);
+
+/** Barrier on all ranks */
+int
+par_barrier(void);
+
+/** Get the global rank */
+int
+par_rank(int *rank);
+
+/** Get the global size */
+int
+par_size(int *size);
+
+/** Reduce from all ranks */
+int
+par_reduce(const void *sendbuf, void *recvbuf, int count, enum par_type type, enum par_op op,
+	   int root);
+
+/** Gather from all ranks */
+int
+par_gather(const void *sendbuf, void *recvbuf, int count, enum par_type type,
+	   int root);
+
+/** All reduce from all ranks */
+int
+par_allreduce(const void *sendbuf, void *recvbuf, int count, enum par_type type, enum par_op op);
+
+/** All gather from all ranks */
+int
+par_allgather(const void *sendbuf, void *recvbuf, int count, enum par_type type);
+
+/** Broadcast to all ranks */
+int
+par_bcast(void *buffer, int count, enum par_type datatype, int root);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /** __DAOS_PAR_LIB_H__ */
+

--- a/src/tests/SConscript
+++ b/src/tests/SConscript
@@ -1,37 +1,18 @@
 """Build tests"""
 import daos_build
 import os
+import compiler_setup
 
-def scons():
-    """Execute build"""
-    Import('base_env', 'prereqs')
+def build_tests(prereqs, env, client_libs):
+    """build the tests"""
+    denv = env.Clone()
+    compiler_setup.base_setup(denv)
 
-    if not prereqs.test_requested():
-        return
+    libs_server = ['daos', 'daos_common_pmem', 'gurt', 'm', 'cart', 'uuid', 'cmocka', 'daos_tests',
+                   'pthread', 'dts', 'dpar']
+    libs_client = client_libs + ['pthread', 'dts', 'dpar']
 
-    libs_client = ['daos', 'daos_common', 'gurt', 'm', 'cart', 'uuid', 'cmocka', 'daos_tests']
-    libs_server = ['daos', 'daos_common_pmem', 'gurt', 'm', 'cart', 'uuid', 'cmocka', 'daos_tests']
-
-    denv = base_env.Clone()
-
-    if not GetOption('help') and not GetOption('clean'):
-        mpi = daos_build.configure_mpi(denv, libs_client)
-        if mpi is None:
-            print("\nSkipping compilation for tests that need MPI")
-            print("Install and load mpich or openmpi\n")
-            return
-
-    # Add runtime paths for daos libraries
-    denv.AppendUnique(RPATH_FULL=['$PREFIX/lib64/daos_srv'])
-
-    denv.Append(CPPPATH=[Dir('suite').srcnode()])
-    denv.AppendUnique(CPPPATH=[Dir('../mgmt').srcnode()])
     prereqs.require(denv, 'argobots', 'hwloc', 'protobufc', 'pmdk', 'isal')
-
-    daos_build.program(denv, 'simple_array', 'simple_array.c', LIBS=libs_client)
-    daos_build.program(denv, 'simple_obj', 'simple_obj.c', LIBS=libs_client)
-    libs_client += ['pthread', 'dts']
-    libs_server += ['pthread', 'dts']
 
     daos_racer = daos_build.program(denv, 'daos_racer',
                                     ['daos_racer.c'],
@@ -73,6 +54,34 @@ def scons():
 
     # ftest
     SConscript('ftest/SConscript')
+
+
+def scons():
+    """Execute build"""
+    Import('base_env', 'prereqs')
+
+    if not prereqs.test_requested():
+        return
+
+    libs_client = ['daos', 'daos_common', 'gurt', 'm', 'cart', 'uuid', 'cmocka', 'daos_tests']
+
+    denv = base_env.Clone()
+    # Add runtime paths for daos libraries
+    denv.AppendUnique(RPATH_FULL=['$PREFIX/lib64/daos_srv'])
+    denv.Append(CPPPATH=[Dir('suite').srcnode()])
+    denv.AppendUnique(CPPPATH=[Dir('../mgmt').srcnode()])
+    build_tests(prereqs, denv, libs_client)
+
+    if not GetOption('help') and not GetOption('clean'):
+        mpi = daos_build.configure_mpi(denv, libs_client)
+        if mpi is None:
+            print("\nSkipping compilation for tests that need MPI")
+            print("Install and load mpich or openmpi\n")
+            return
+
+
+    daos_build.program(denv, 'simple_array', 'simple_array.c', LIBS=libs_client)
+    daos_build.program(denv, 'simple_obj', 'simple_obj.c', LIBS=libs_client)
 
 if __name__ == "SCons.Script":
     scons()

--- a/src/tests/daos_perf.c
+++ b/src/tests/daos_perf.c
@@ -17,11 +17,11 @@
 #include <unistd.h>
 #include <fcntl.h>
 #include <getopt.h>
-#include <mpi.h>
 #include <daos/common.h>
 #include <daos/tests_lib.h>
 #include <daos_test.h>
 #include <daos/dts.h>
+#include <daos/dpar.h>
 #include "perf_internal.h"
 
 enum {
@@ -328,9 +328,9 @@ main(int argc, char **argv)
 
 	ts_dkey_prefix = PF_DKEY_PREF;
 
-	MPI_Init(&argc, &argv);
-	MPI_Comm_rank(MPI_COMM_WORLD, &ts_ctx.tsc_mpi_rank);
-	MPI_Comm_size(MPI_COMM_WORLD, &ts_ctx.tsc_mpi_size);
+	par_init(&argc, &argv);
+	par_rank(&ts_ctx.tsc_mpi_rank);
+	par_size(&ts_ctx.tsc_mpi_size);
 
 	rc = perf_alloc_opts(perf_daos_opts, ARRAY_SIZE(perf_daos_opts),
 			     perf_daos_optstr, &ts_opts, &ts_optstr);
@@ -497,7 +497,7 @@ main(int argc, char **argv)
 		return -1;
 	}
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	rc = run_commands(cmds, pf_tests);
 
@@ -506,7 +506,7 @@ main(int argc, char **argv)
 	stride_buf_fini();
 	dts_ctx_fini(&ts_ctx);
 
-	MPI_Finalize();
+	par_fini();
 
 	perf_free_keys();
 	return 0;

--- a/src/tests/daos_racer.c
+++ b/src/tests/daos_racer.c
@@ -15,12 +15,12 @@
 #include <sys/ioctl.h>
 #include <stdlib.h>
 #include <getopt.h>
-#include <mpi.h>
 #include <daos/common.h>
 #include <daos/tests_lib.h>
 #include <daos_test.h>
 #include <daos/dts.h>
 #include <daos/credit.h>
+#include <daos/dpar.h>
 
 enum {
 	UPDATE,
@@ -99,13 +99,9 @@ daos_obj_id_t
 racer_oid_gen(int random)
 {
 	daos_obj_id_t	oid;
-	uint64_t	hdr;
 	uint16_t	oclass;
 
 	oclass = oclass_get(random);
-
-	hdr = oclass;
-	hdr <<= 32;
 
 	oid.lo	= random % obj_cnt_per_class;
 	oid.lo	|= oclass;
@@ -477,9 +473,9 @@ main(int argc, char **argv)
 	struct racer_sub_tests	sub_tests[TEST_SIZE] = { 0 };
 	int		rc;
 
-	MPI_Init(&argc, &argv);
-	MPI_Comm_rank(MPI_COMM_WORLD, &ts_ctx.tsc_mpi_rank);
-	MPI_Comm_size(MPI_COMM_WORLD, &ts_ctx.tsc_mpi_size);
+	par_init(&argc, &argv);
+	par_rank(&ts_ctx.tsc_mpi_rank);
+	par_size(&ts_ctx.tsc_mpi_size);
 	while ((rc = getopt_long(argc, argv,
 				 "n:p:c:t:",
 				 ts_ops, NULL)) != -1) {
@@ -563,13 +559,13 @@ main(int argc, char **argv)
 	expire = dts_time_now() + duration;
 
 	idx = racer_test_idx(sub_tests);
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	while (1) {
 		sub_tests[idx].sub_test();
 		if (dts_time_now() > expire)
 			break;
 	}
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	if (ts_ctx.tsc_mpi_rank == 0) {
 		daos_pool_info_t	pinfo = { 0 };
@@ -634,6 +630,6 @@ main(int argc, char **argv)
 fini:
 	dts_ctx_fini(&ts_ctx);
 out:
-	MPI_Finalize();
+	par_fini();
 	return rc;
 }

--- a/src/tests/ftest/util/daos_core_base.py
+++ b/src/tests/ftest/util/daos_core_base.py
@@ -110,6 +110,11 @@ class DaosCoreBase(TestWithServers):
         num_clients = self.get_test_param("num_clients")
         if num_clients is None:
             num_clients = self.params.get("num_clients", '/run/daos_tests/*')
+        preload_arg = "libdpar.so"
+        if num_clients > 1:
+            preload_arg = "libdpar_mpi.so"
+
+
         scm_size = self.params.get("scm_size", '/run/pool/*')
         nvme_size = self.params.get("nvme_size", '/run/pool/*')
         args = self.get_test_param("args", "")
@@ -127,6 +132,7 @@ class DaosCoreBase(TestWithServers):
                 self.orterun,
                 self.client_mca,
                 "-n", str(num_clients),
+                "-x", "=".join(["LD_PRELOAD", preload_arg]),
                 "--hostfile", self.hostfile_clients,
                 "-x", "=".join(["D_LOG_FILE", get_log_file(self.client_log)]),
                 "--map-by node", "-x", "D_LOG_MASK=DEBUG",

--- a/src/tests/obj_ctl.c
+++ b/src/tests/obj_ctl.c
@@ -17,7 +17,6 @@
 #include <stdlib.h>
 #include <unistd.h>
 #include <getopt.h>
-#include <mpi.h>
 #include <daos/common.h>
 #include <daos/tests_lib.h>
 #include <daos_srv/vos.h>

--- a/src/tests/perf_common.c
+++ b/src/tests/perf_common.c
@@ -524,7 +524,7 @@ pause_test(char *name)
 			break;
 	}
 	if (ts_ctx.tsc_mpi_size > 1)
-		MPI_Barrier(MPI_COMM_WORLD);
+		par_barrier();
 }
 
 static int
@@ -558,7 +558,7 @@ run_one(struct pf_test *ts, struct pf_param *param)
 	if (ts_ctx.tsc_mpi_size > 1) {
 		int	rc_g = 0;
 
-		MPI_Allreduce(&rc, &rc_g, 1, MPI_INT, MPI_MIN, MPI_COMM_WORLD);
+		par_allreduce(&rc, &rc_g, 1, PAR_INT, PAR_MIN);
 		rc = rc_g;
 	}
 
@@ -645,10 +645,8 @@ show_result(struct pf_param *param, uint64_t start, uint64_t end,
 	double		duration_sum;
 
 	if (ts_ctx.tsc_mpi_size > 1) {
-		MPI_Reduce(&start, &first_start, 1, MPI_UINT64_T,
-			   MPI_MIN, 0, MPI_COMM_WORLD);
-		MPI_Reduce(&end, &last_end, 1, MPI_UINT64_T,
-			   MPI_MAX, 0, MPI_COMM_WORLD);
+		par_reduce(&start, &first_start, 1, PAR_UINT64, PAR_MIN, 0);
+		par_reduce(&end, &last_end, 1, PAR_UINT64, PAR_MAX, 0);
 		agg_duration = (last_end - first_start) /
 			       (1000.0 * 1000 * 1000);
 	} else {
@@ -658,12 +656,9 @@ show_result(struct pf_param *param, uint64_t start, uint64_t end,
 	/* nano sec to sec */
 
 	if (ts_ctx.tsc_mpi_size > 1) {
-		MPI_Reduce(&param->pa_duration, &duration_max, 1, MPI_DOUBLE,
-			   MPI_MAX, 0, MPI_COMM_WORLD);
-		MPI_Reduce(&param->pa_duration, &duration_min, 1, MPI_DOUBLE,
-			   MPI_MIN, 0, MPI_COMM_WORLD);
-		MPI_Reduce(&param->pa_duration, &duration_sum, 1, MPI_DOUBLE,
-			   MPI_SUM, 0, MPI_COMM_WORLD);
+		par_reduce(&param->pa_duration, &duration_max, 1, PAR_DOUBLE, PAR_MAX, 0);
+		par_reduce(&param->pa_duration, &duration_min, 1, PAR_DOUBLE, PAR_MIN, 0);
+		par_reduce(&param->pa_duration, &duration_sum, 1, PAR_DOUBLE, PAR_SUM, 0);
 	} else {
 		duration_max = duration_min =
 		duration_sum = param->pa_duration;

--- a/src/tests/simple_array.c
+++ b/src/tests/simple_array.c
@@ -29,8 +29,7 @@
 
 #include <daos/tests_lib.h>
 #include <daos.h>
-#include "suite/daos_test.h"
-#include <mpi.h>
+#include "simple_common.h"
 
 /** local task information */
 int			 rank = -1;
@@ -98,19 +97,6 @@ char astr[] = "data";
 
 /** data buffer */
 uint64_t data[SLICE_SIZE];
-
-#define FAIL(fmt, ...)						\
-do {								\
-	fprintf(stderr, "Process %d(%s): " fmt " aborting\n",	\
-		rank, node, ## __VA_ARGS__);			\
-	MPI_Abort(MPI_COMM_WORLD, 1);				\
-} while (0)
-
-#define	ASSERT(cond, ...)					\
-do {								\
-	if (!(cond))						\
-		FAIL(__VA_ARGS__);				\
-} while (0)
 
 void
 pool_create(void)

--- a/src/tests/simple_common.h
+++ b/src/tests/simple_common.h
@@ -1,0 +1,101 @@
+/**
+ * (C) Copyright 2016-2021 Intel Corporation.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause-Patent
+ */
+#ifndef __SIMPLE_COMMON_H__
+#define __SIMPLE_COMMON_H__
+#include <mpi.h>
+#include <stdio.h>
+#include <daos.h>
+
+extern char			 node[128];
+#define FAIL(fmt, ...)						\
+do {								\
+	fprintf(stderr, "Process %d(%s): " fmt " aborting\n",	\
+		rank, node, ## __VA_ARGS__);			\
+	MPI_Abort(MPI_COMM_WORLD, 1);				\
+} while (0)
+
+#define	ASSERT(cond, ...)					\
+do {								\
+	if (!(cond))						\
+		FAIL(__VA_ARGS__);				\
+} while (0)
+
+enum {
+	HANDLE_POOL,
+	HANDLE_CO,
+};
+
+static inline void
+handle_share(daos_handle_t *hdl, int type, int rank, daos_handle_t poh,
+	     int verbose)
+{
+	d_iov_t	ghdl = { NULL, 0, 0 };
+	int		rc;
+
+	if (rank == 0) {
+		/** fetch size of global handle */
+		if (type == HANDLE_POOL)
+			rc = daos_pool_local2global(*hdl, &ghdl);
+		else
+			rc = daos_cont_local2global(*hdl, &ghdl);
+		ASSERT(rc == 0);
+	}
+
+	/** broadcast size of global handle to all peers */
+	rc = MPI_Bcast(&ghdl.iov_buf_len, 1, MPI_UINT64_T, 0, MPI_COMM_WORLD);
+	ASSERT(rc == 0);
+
+	/** allocate buffer for global pool handle */
+	D_ALLOC(ghdl.iov_buf, ghdl.iov_buf_len);
+	ghdl.iov_len = ghdl.iov_buf_len;
+
+	if (rank == 0) {
+		/** generate actual global handle to share with peer tasks */
+		if (verbose)
+			printf("rank 0 call local2global on %s handle",
+			       (type == HANDLE_POOL) ?  "pool" : "container");
+		if (type == HANDLE_POOL)
+			rc = daos_pool_local2global(*hdl, &ghdl);
+		else
+			rc = daos_cont_local2global(*hdl, &ghdl);
+		ASSERT(rc == 0);
+		if (verbose)
+			printf("success\n");
+	}
+
+	/** broadcast global handle to all peers */
+	if (rank == 0 && verbose == 1)
+		printf("rank 0 broadcast global %s handle ...",
+		       (type == HANDLE_POOL) ? "pool" : "container");
+	rc = MPI_Bcast(&ghdl.iov_buf, ghdl.iov_len, MPI_BYTE, 0, MPI_COMM_WORLD);
+	ASSERT(rc == 0);
+	if (rank == 0 && verbose == 1)
+		printf("success\n");
+
+	if (rank != 0) {
+		/** unpack global handle */
+		if (verbose)
+			printf("rank %d call global2local on %s handle", rank,
+			       type == HANDLE_POOL ?  "pool" : "container");
+		if (type == HANDLE_POOL) {
+			/* NB: Only pool_global2local are different */
+			rc = daos_pool_global2local(ghdl, hdl);
+		} else {
+			rc = daos_cont_global2local(poh, ghdl, hdl);
+		}
+
+		ASSERT(rc == 0);
+		if (verbose)
+			printf("rank %d global2local success\n", rank);
+	}
+
+	D_FREE(ghdl.iov_buf);
+
+	MPI_Barrier(MPI_COMM_WORLD);
+}
+
+#endif
+

--- a/src/tests/suite/SConscript
+++ b/src/tests/suite/SConscript
@@ -80,7 +80,7 @@ def scons():
     Import('denv')
 
     libraries = ['daos', 'dfs', 'daos_tests', 'gurt', 'cart']
-    libraries += ['uuid', 'cmocka', 'pthread', 'isal']
+    libraries += ['uuid', 'cmocka', 'pthread', 'isal', 'dpar']
 
     denv.AppendUnique(CPPPATH=["#/src/client/dfs"])
     denv.AppendUnique(CPPPATH=[Dir('../../mgmt').srcnode()])

--- a/src/tests/suite/daos_aggregate_ec.c
+++ b/src/tests/suite/daos_aggregate_ec.c
@@ -101,7 +101,7 @@ iov_update_fill(d_iov_t *iov, unsigned int cells, unsigned int len,
 	for (j = 0; j < cells; j++)
 		for (k = 0; k < len; k++)
 			if (overwrite)
-				dest[i++] = 128;
+				dest[i++] = (char)128;
 			else
 				dest[i++] = j;
 }
@@ -970,7 +970,7 @@ int run_daos_aggregation_ec_test(int rank, int size, int *sub_tests,
 {
 	int rc = 0;
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	if (sub_tests_size == 0) {
 		sub_tests_size = ARRAY_SIZE(ec_agg_tests);
 		sub_tests = NULL;
@@ -982,6 +982,6 @@ int run_daos_aggregation_ec_test(int rank, int size, int *sub_tests,
 				 sub_tests_size, ec_setup, test_teardown);
 
 out:
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	return rc;
 }

--- a/src/tests/suite/daos_array.c
+++ b/src/tests/suite/daos_array.c
@@ -40,8 +40,8 @@ array_oh_share(daos_handle_t coh, int rank, daos_handle_t *oh)
 	}
 
 	/** broadcast size of global handle to all peers */
-	rc = MPI_Bcast(&ghdl.iov_buf_len, 1, MPI_UINT64_T, 0, MPI_COMM_WORLD);
-	assert_int_equal(rc, MPI_SUCCESS);
+	rc = par_bcast(&ghdl.iov_buf_len, 1, PAR_UINT64, 0);
+	assert_int_equal(rc, 0);
 
 	/** allocate buffer for global pool handle */
 	D_ALLOC(ghdl.iov_buf, ghdl.iov_buf_len);
@@ -54,8 +54,8 @@ array_oh_share(daos_handle_t coh, int rank, daos_handle_t *oh)
 	}
 
 	/** broadcast global handle to all peers */
-	rc = MPI_Bcast(ghdl.iov_buf, ghdl.iov_len, MPI_BYTE, 0, MPI_COMM_WORLD);
-	assert_int_equal(rc, MPI_SUCCESS);
+	rc = par_bcast(ghdl.iov_buf, ghdl.iov_len, PAR_BYTE, 0);
+	assert_int_equal(rc, 0);
 
 	if (rank != 0) {
 		/** unpack global handle */
@@ -65,7 +65,7 @@ array_oh_share(daos_handle_t coh, int rank, daos_handle_t *oh)
 
 	D_FREE(ghdl.iov_buf);
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 }
 
 static void
@@ -204,7 +204,7 @@ simple_array_mgmt(void **state)
 	rc = daos_array_close(oh, NULL);
 	assert_rc_equal(rc, 0);
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 } /* End simple_array_mgmt */
 
 #define BUFLEN 80
@@ -223,7 +223,7 @@ small_io(void **state)
 	daos_size_t	array_size;
 	int		rc;
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	oid = daos_test_oid_gen(arg->coh, OC_SX, type, 0, arg->myrank);
 
 	/** create the array */
@@ -263,7 +263,7 @@ small_io(void **state)
 
 	rc = daos_array_close(oh, NULL);
 	assert_rc_equal(rc, 0);
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 } /* End small_io */
 
 static int
@@ -273,7 +273,7 @@ change_array_size(test_arg_t *arg, daos_handle_t oh, daos_size_t array_size)
 	daos_size_t new_size, i;
 	int rc;
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	if (arg->myrank != 0)
 		goto out;
@@ -333,7 +333,7 @@ change_array_size(test_arg_t *arg, daos_handle_t oh, daos_size_t array_size)
 	}
 
 out:
-	MPI_Bcast(&rc, 1, MPI_INT, 0, MPI_COMM_WORLD);
+	par_bcast(&rc, 1, PAR_INT, 0);
 	return rc;
 }
 
@@ -352,7 +352,7 @@ contig_mem_contig_arr_io_helper(void **state, daos_size_t cell_size)
 	daos_event_t	ev, *evp;
 	int		rc;
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	/** create the array on rank 0 and share the oh. */
 	if (arg->myrank == 0) {
 		oid = daos_test_oid_gen(arg->coh, OC_SX,
@@ -437,7 +437,7 @@ contig_mem_contig_arr_io_helper(void **state, daos_size_t cell_size)
 	D_FREE(rbuf);
 	D_FREE(wbuf);
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	daos_size_t array_size;
 	daos_size_t expected_size;
@@ -461,7 +461,7 @@ contig_mem_contig_arr_io_helper(void **state, daos_size_t cell_size)
 	rc = daos_array_punch(oh, DAOS_TX_NONE, &iod, NULL);
 	assert_rc_equal(rc, 0);
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	/** Verify size is still the same */
 	rc = daos_array_get_size(oh, DAOS_TX_NONE, &array_size, NULL);
@@ -484,7 +484,7 @@ contig_mem_contig_arr_io_helper(void **state, daos_size_t cell_size)
 		rc = daos_event_fini(&ev);
 		assert_rc_equal(rc, 0);
 	}
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 } /* End contig_mem_contig_arr_io_helper */
 
 static void
@@ -509,7 +509,7 @@ contig_mem_str_arr_io_helper(void **state, daos_size_t cell_size)
 	daos_event_t	ev, *evp;
 	int		rc;
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	/** create the array on rank 0 and share the oh. */
 	if (arg->myrank == 0) {
@@ -600,7 +600,7 @@ contig_mem_str_arr_io_helper(void **state, daos_size_t cell_size)
 	D_FREE(rbuf);
 	D_FREE(wbuf);
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	daos_size_t expected_size;
 	daos_size_t array_size = 0;
@@ -643,7 +643,7 @@ contig_mem_str_arr_io_helper(void **state, daos_size_t cell_size)
 	}
 
 	D_FREE(iod.arr_rgs);
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 } /* End contig_mem_str_arr_io_helper */
 
 static void
@@ -667,7 +667,7 @@ str_mem_str_arr_io_helper(void **state, daos_size_t cell_size)
 	daos_event_t	ev, *evp;
 	int		rc;
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	/** create the array on rank 0 and share the oh. */
 	if (arg->myrank == 0) {
 		oid = daos_test_oid_gen(arg->coh, OC_SX,
@@ -773,7 +773,7 @@ str_mem_str_arr_io_helper(void **state, daos_size_t cell_size)
 	D_FREE(iod.arr_rgs);
 	D_FREE(sgl.sg_iovs);
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	daos_size_t array_size;
 	daos_size_t expected_size;
@@ -798,7 +798,7 @@ str_mem_str_arr_io_helper(void **state, daos_size_t cell_size)
 		rc = daos_event_fini(&ev);
 		assert_rc_equal(rc, 0);
 	}
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 } /* End str_mem_str_arr_io */
 
 static void
@@ -823,7 +823,7 @@ read_empty_records(void **state)
 	daos_event_t	ev;
 	int		rc;
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	oid = daos_test_oid_gen(arg->coh, OC_SX, typeb, 0, arg->myrank);
 
 	if (arg->async) {
@@ -867,7 +867,7 @@ read_empty_records(void **state)
 	assert_rc_equal(rc, 0);
 	assert_int_equal(iod.arr_nr_short_read, NUM_ELEMS * sizeof(int));
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	/** Verify data - rbuf should not be touched */
 	for (i = 0; i < NUM_ELEMS; i++) {
@@ -889,7 +889,7 @@ read_empty_records(void **state)
 	rc = daos_array_write(oh, DAOS_TX_NONE, &iod, &sgl, NULL);
 	assert_rc_equal(rc, 0);
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	/** Read from empty records */
 	for (i = 0; i < NUM_ELEMS; i++) {
@@ -919,7 +919,7 @@ read_empty_records(void **state)
 		rc = daos_event_fini(&ev);
 		assert_rc_equal(rc, 0);
 	}
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 } /* End read_empty_records */
 
 #define NUM 5000
@@ -936,7 +936,7 @@ strided_array(void **state)
 	daos_size_t	i, j, nerrors = 0;
 	int		rc;
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	oid = daos_test_oid_gen(arg->coh, OC_SX, typeb, 0, arg->myrank);
 
 	/** create the array */
@@ -1010,7 +1010,7 @@ strided_array(void **state)
 	assert_rc_equal(rc, 0);
 
 	assert_int_equal(nerrors, 0);
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 } /* End str_mem_str_arr_io */
 
 static void
@@ -1027,7 +1027,7 @@ truncate_array(void **state)
 	int		rc;
 	daos_size_t	size;
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	oid = daos_test_oid_gen(arg->coh, OC_SX, typeb, 0, arg->myrank);
 
 	/** create the array */
@@ -1077,7 +1077,7 @@ truncate_array(void **state)
 
 	D_FREE(buf);
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 } /* End str_mem_str_arr_io */
 
 static const struct CMUnitTest array_api_tests[] = {
@@ -1121,6 +1121,6 @@ run_daos_array_test(int rank, int size)
 					 array_api_tests, daos_array_setup,
 					 test_teardown);
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	return rc;
 }

--- a/src/tests/suite/daos_base_tx.c
+++ b/src/tests/suite/daos_base_tx.c
@@ -23,11 +23,11 @@ static const char *dts_dtx_akey	= "dtx_io akey";
 static void
 dtx_set_fail_loc(test_arg_t *arg, uint64_t fail_loc)
 {
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	if (arg->myrank == 0)
 		daos_debug_set_params(arg->group, -1, DMG_KEY_FAIL_LOC,
 				     fail_loc, 0, NULL);
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 }
 
 static void
@@ -636,7 +636,7 @@ dtx_17(void **state)
 		      DAOS_TX_NONE, &req);
 	punch_akey(dkey, akey1, DAOS_TX_NONE, &req);
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	close_reopen_coh_oh(arg, &req, oid);
 
 	lookup_single(dkey, akey1, 0, fetch_buf, dts_dtx_iosize, DAOS_TX_NONE,
@@ -687,7 +687,7 @@ dtx_resend_delay(test_arg_t *arg, daos_oclass_id_t oclass)
 	assert_int_equal(req.iod[0].iod_size, size);
 	assert_memory_equal(update_buf, fetch_buf, size);
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	daos_fail_loc_set(0);
 	dtx_set_fail_loc(arg, 0);
 
@@ -780,7 +780,7 @@ run_daos_base_tx_test(int rank, int size, int *sub_tests, int sub_tests_size)
 {
 	int rc = 0;
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	if (sub_tests_size == 0) {
 		sub_tests_size = ARRAY_SIZE(dtx_tests);
 		sub_tests = NULL;
@@ -790,7 +790,7 @@ run_daos_base_tx_test(int rank, int size, int *sub_tests, int sub_tests_size)
 				ARRAY_SIZE(dtx_tests), sub_tests,
 				sub_tests_size, dtx_test_setup, test_teardown);
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	return rc;
 }

--- a/src/tests/suite/daos_capa.c
+++ b/src/tests/suite/daos_capa.c
@@ -297,7 +297,7 @@ io_invalid_poh(void **state)
 		assert_rc_equal(rc, 0);
 	}
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	if (arg->myrank != 1) {
 		rc = daos_pool_disconnect(poh, NULL);
@@ -305,7 +305,7 @@ io_invalid_poh(void **state)
 		print_message("invalidating pool handle\n");
 	}
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	if (arg->myrank == 1) {
 		/** open object */
@@ -356,7 +356,7 @@ io_invalid_poh(void **state)
 		print_message("all is fine\n");
 	}
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 }
 
 /** update/fetch with invalid container handle */
@@ -393,7 +393,7 @@ io_invalid_coh(void **state)
 		print_message("closing container handle\n");
 	}
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	if (arg->myrank == 1) {
 		/** open object */
@@ -441,7 +441,7 @@ io_invalid_coh(void **state)
 		print_message("all is fine\n");
 	}
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 }
 
 /** update with read-only container handle */
@@ -506,7 +506,7 @@ update_ro(void **state)
 	assert_rc_equal(rc, 0);
 	print_message("all is fine\n");
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 }
 
 
@@ -541,6 +541,6 @@ run_daos_capa_test(int rank, int size)
 
 	rc = cmocka_run_group_tests_name("DAOS_Capability", capa_tests,
 					 setup, test_teardown);
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	return rc;
 }

--- a/src/tests/suite/daos_checksum.c
+++ b/src/tests/suite/daos_checksum.c
@@ -2680,7 +2680,7 @@ run_daos_checksum_test(int rank, int size, int *sub_tests, int sub_tests_size)
 	int i;
 
 	if (rank != 0) {
-		MPI_Barrier(MPI_COMM_WORLD);
+		par_barrier();
 		return 0;
 	}
 
@@ -2706,6 +2706,6 @@ run_daos_checksum_test(int rank, int size, int *sub_tests, int sub_tests_size)
 					test_teardown);
 	}
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	return rc;
 }

--- a/src/tests/suite/daos_container.c
+++ b/src/tests/suite/daos_container.c
@@ -65,7 +65,7 @@ co_create(void **state)
 	print_message("container closed\n");
 
 	if (arg->hdl_share)
-		MPI_Barrier(MPI_COMM_WORLD);
+		par_barrier();
 
 	/** destroy container */
 	if (arg->myrank == 0) {
@@ -356,7 +356,7 @@ co_properties(void **state)
 			DMG_KEY_FAIL_LOC, DAOS_FORCE_PROP_VERIFY, 0, NULL);
 		assert_rc_equal(rc, 0);
 	}
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	prop_query = get_query_prop_all();
 	rc = daos_cont_query(arg->coh, NULL, prop_query, NULL);
@@ -508,7 +508,7 @@ co_properties(void **state)
 		print_message("destroyed container C3: %s : "
 			      "UUID:"DF_UUIDF"\n", label2_v2, DP_UUID(cuuid3));
 	}
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	daos_prop_free(prop);
 	daos_prop_free(prop_query);
@@ -670,7 +670,7 @@ co_acl(void **state)
 	const char		*exp_owner = "fictionaluser@";
 	const char		*exp_owner_grp = "admins@";
 	struct daos_acl		*exp_acl;
-	struct daos_acl		*update_acl;
+	struct daos_acl		*update_acl = NULL;
 	struct daos_ace		*ace;
 	char			*user;
 	d_string_t		 name_to_remove = "friendlyuser@";
@@ -725,7 +725,7 @@ co_acl(void **state)
 			DMG_KEY_FAIL_LOC, DAOS_FORCE_PROP_VERIFY, 0, NULL);
 		assert_rc_equal(rc, 0);
 	}
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	co_acl_get(arg, exp_acl, exp_owner, exp_owner_grp);
 
@@ -827,7 +827,7 @@ co_acl(void **state)
 	if (arg->myrank == 0)
 		daos_debug_set_params(arg->group, -1, DMG_KEY_FAIL_LOC, 0,
 				     0, NULL);
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	daos_prop_free(prop_in);
 	daos_acl_free(exp_acl);
@@ -857,7 +857,7 @@ co_set_prop(void **state)
 		rc = test_setup_next_step((void **)&arg, NULL, NULL, NULL);
 	assert_int_equal(rc, 0);
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	/*
 	 * Set some props
@@ -902,7 +902,7 @@ co_set_prop(void **state)
 		assert_int_equal(rc, 1); /* fail the test */
 	}
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	daos_prop_free(prop_in);
 	daos_prop_free(prop_out);
@@ -2237,7 +2237,7 @@ co_rf_simple(void **state)
 		assert_rc_equal(rc, 0);
 		assert_int_equal(info.ci_redun_fac, DAOS_PROP_CO_REDUN_RF2);
 	}
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	print_message("verify cont rf and obj open ...\n");
 	oid = daos_test_oid_gen(arg->coh, OC_RP_2G1, 0, 0, arg->myrank);
@@ -2278,7 +2278,7 @@ co_rf_simple(void **state)
 		daos_exclude_server(arg->pool.pool_uuid, arg->group,
 				    arg->dmg_config, 4);
 	}
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	rc = daos_cont_query(arg->coh, NULL, prop, NULL);
 	assert_rc_equal(rc, 0);
 	entry = daos_prop_entry_get(prop, DAOS_PROP_CO_STATUS);
@@ -2316,7 +2316,7 @@ co_rf_simple(void **state)
 	if (arg->myrank == 0)
 		daos_exclude_server(arg->pool.pool_uuid, arg->group,
 				    arg->dmg_config, 3);
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	rc = daos_cont_query(arg->coh, NULL, prop, NULL);
 	assert_rc_equal(rc, 0);
 	entry = daos_prop_entry_get(prop, DAOS_PROP_CO_STATUS);
@@ -2345,7 +2345,7 @@ co_rf_simple(void **state)
 				  arg->dmg_config, 5);
 		test_rebuild_wait(&arg, 1);
 	}
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	print_message("obj update should success after re-integrate\n");
 	rc = daos_obj_update(io_oh, DAOS_TX_NONE, 0, &dkey, 1, &iod, &sgl,
@@ -2581,7 +2581,7 @@ run_daos_cont_test(int rank, int size, int *sub_tests, int sub_tests_size)
 {
 	int rc = 0;
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	if (sub_tests_size == 0) {
 		sub_tests_size = ARRAY_SIZE(co_tests);
 		sub_tests = NULL;
@@ -2591,6 +2591,6 @@ run_daos_cont_test(int rank, int size, int *sub_tests, int sub_tests_size)
 				ARRAY_SIZE(co_tests), sub_tests, sub_tests_size,
 				setup, test_teardown);
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	return rc;
 }

--- a/src/tests/suite/daos_dedup.c
+++ b/src/tests/suite/daos_dedup.c
@@ -352,6 +352,6 @@ run_daos_dedup_test(int rank, int size, int *sub_tests, int sub_tests_size)
 		}
 	}
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	return rc;
 }

--- a/src/tests/suite/daos_degrade_ec.c
+++ b/src/tests/suite/daos_degrade_ec.c
@@ -785,7 +785,7 @@ run_daos_degrade_simple_ec_test(int rank, int size, int *sub_tests,
 {
 	int rc = 0;
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	if (sub_tests_size == 0) {
 		sub_tests_size = ARRAY_SIZE(degrade_tests);
 		sub_tests = NULL;
@@ -794,7 +794,7 @@ run_daos_degrade_simple_ec_test(int rank, int size, int *sub_tests,
 				ARRAY_SIZE(degrade_tests), sub_tests,
 				sub_tests_size);
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	return rc;
 }

--- a/src/tests/suite/daos_degraded.c
+++ b/src/tests/suite/daos_degraded.c
@@ -60,8 +60,8 @@ insert_lookup_enum_with_ops(test_arg_t *arg, int op_kill)
 	daos_pool_info_t	info = {0};
 	int			enumed = 1;
 
-	MPI_Comm_rank(MPI_COMM_WORLD, &rank);
-	MPI_Comm_size(MPI_COMM_WORLD, &size);
+	par_rank(&rank);
+	par_size(&size);
 
 	oid = daos_test_oid_gen(arg->coh, OC_RP_XSF, 0, 0, rank);
 
@@ -72,7 +72,7 @@ insert_lookup_enum_with_ops(test_arg_t *arg, int op_kill)
 		print_message("Inserting %d keys ...\n", g_dkeys * size);
 	}
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	rc = daos_pool_query(arg->pool.poh, NULL, &info, NULL, NULL);
 	assert_rc_equal(rc, 0);
 	if (info.pi_ntargets - info.pi_ndisabled < 2) {
@@ -82,7 +82,7 @@ insert_lookup_enum_with_ops(test_arg_t *arg, int op_kill)
 				      info.pi_ndisabled);
 		skip();
 	}
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	for (i = 0; i < g_dkeys; i++) {
 		D_ALLOC(dkey[i], strlen(dkey_fmt) + g_dkeys_strlen + 1);
@@ -105,7 +105,7 @@ insert_lookup_enum_with_ops(test_arg_t *arg, int op_kill)
 			      rec_size[i], DAOS_TX_NONE, &req);
 
 		if ((i + 1) % (g_dkeys/10) == 0) {
-			MPI_Barrier(MPI_COMM_WORLD);
+			par_barrier();
 			if (rank == 0)
 				print_message("\t%d keys inserted\n",
 					      (i + 1) * size);
@@ -118,7 +118,7 @@ insert_lookup_enum_with_ops(test_arg_t *arg, int op_kill)
 					 arg->group, arg->pool.svc, -1);
 	}
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	if (arg->myrank == 0)
 		print_message("insertion done\nNow looking up %d keys ...\n",
@@ -134,7 +134,7 @@ insert_lookup_enum_with_ops(test_arg_t *arg, int op_kill)
 		assert_memory_equal(val[i], rec_verify, req.iod[0].iod_size);
 
 		if ((i + 1) % (g_dkeys/10) == 0) {
-			MPI_Barrier(MPI_COMM_WORLD);
+			par_barrier();
 			if (rank == 0)
 				print_message("\t%d keys looked up\n",
 					      (i + 1) * size);
@@ -148,7 +148,7 @@ insert_lookup_enum_with_ops(test_arg_t *arg, int op_kill)
 	}
 	D_FREE(rec_verify);
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	if (arg->myrank == 0)
 		print_message("lookup done\nNow enumerating %d keys ...\n",
@@ -180,7 +180,7 @@ insert_lookup_enum_with_ops(test_arg_t *arg, int op_kill)
 		key_nr += number;
 
 		if (key_nr >= enumed * (g_dkeys/10)) {
-			MPI_Barrier(MPI_COMM_WORLD);
+			par_barrier();
 			if (rank == 0)
 				print_message("\t%d keys enumerated\n",
 					      key_nr * size);
@@ -198,7 +198,7 @@ insert_lookup_enum_with_ops(test_arg_t *arg, int op_kill)
 	}
 	assert_int_equal(key_nr, g_dkeys);
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	if (arg->myrank == 0)
 		print_message("enumeration done\n");
@@ -265,10 +265,10 @@ run_daos_degraded_test(int rank, int size)
 {
 	int rc = 0;
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	rc = cmocka_run_group_tests_name("DAOS_Degraded-mode",
 					 degraded_tests, degraded_setup,
 					 degraded_teardown);
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	return rc;
 }

--- a/src/tests/suite/daos_dist_tx.c
+++ b/src/tests/suite/daos_dist_tx.c
@@ -288,7 +288,7 @@ dtx_9(void **state)
 	oid = daos_test_oid_gen(arg->coh, OC_RP_XSF, 0, 0, arg->myrank);
 	ioreq_init(&req, arg->coh, oid, DAOS_IOD_ARRAY, arg);
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	MUST(daos_tx_open(arg->coh, &th, 0, NULL));
 
@@ -322,7 +322,7 @@ dtx_9(void **state)
 	assert_memory_equal(write_bufs[0], fetch_buf, DTX_IO_SMALL);
 	assert_memory_equal(write_bufs[1], &fetch_buf[DTX_IO_SMALL], DTX_IO_SMALL);
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	ioreq_fini(&req);
 }
@@ -351,7 +351,7 @@ dtx_10(void **state)
 	insert_single(dkey, akey, 0, write_buf, DTX_IO_SMALL, DAOS_TX_NONE,
 		      &req);
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	MUST(daos_tx_open(arg->coh, &th, 0, NULL));
 
@@ -380,7 +380,7 @@ dtx_10(void **state)
 	ioreq_fini(&req);
 	MUST(daos_tx_close(th, NULL));
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 }
 
 static void
@@ -446,7 +446,7 @@ dtx_12(void **state)
 
 	print_message("DTX12: zero copy flag\n");
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	MUST(daos_tx_open(arg->coh, &th, DAOS_TF_ZERO_COPY, NULL));
 
@@ -482,7 +482,7 @@ dtx_12(void **state)
 	ioreq_fini(&req);
 	MUST(daos_tx_close(th, NULL));
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 }
 
 static void
@@ -599,13 +599,13 @@ again:
 	arg->expect_result = 0;
 	insert_single(dkey, akey, 0, write_buf, DTX_IO_SMALL, th, &req);
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	/* Simulate the conflict with other DTX. */
 	if (arg->myrank == 0)
 		daos_debug_set_params(arg->group, -1, DMG_KEY_FAIL_LOC,
 				     DAOS_DTX_RESTART | DAOS_FAIL_ALWAYS,
 				     0, NULL);
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	rc = daos_tx_commit(th, NULL);
 	assert_rc_equal(rc, -DER_TX_RESTART);
@@ -617,11 +617,11 @@ again:
 	MUST(daos_tx_restart(th, NULL));
 
 	/* Reset the fail_loc */
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	if (arg->myrank == 0)
 		daos_debug_set_params(arg->group, -1, DMG_KEY_FAIL_LOC, 0,
 				     0, NULL);
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	nrestarts--;
 	if (nrestarts > 0) {
@@ -663,24 +663,24 @@ dtx_15(void **state)
 	oid = daos_test_oid_gen(arg->coh, OC_RP_XSF, 0, 0, arg->myrank);
 	ioreq_init(&req, arg->coh, oid, DAOS_IOD_ARRAY, arg);
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	daos_fail_loc_set(DAOS_DTX_STALE_PM | DAOS_FAIL_ALWAYS);
 	if (arg->myrank == 0)
 		daos_debug_set_params(arg->group, -1, DMG_KEY_FAIL_LOC,
 				     DAOS_DTX_STALE_PM | DAOS_FAIL_ALWAYS,
 				     0, NULL);
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	arg->expect_result = -DER_TX_RESTART;
 	lookup_single(dkey, akey, 0, fetch_buf, DTX_IO_SMALL, th, &req);
 
 	/* Reset the fail_loc */
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	daos_fail_loc_set(0);
 	if (arg->myrank == 0)
 		daos_debug_set_params(arg->group, -1, DMG_KEY_FAIL_LOC, 0,
 				     0, NULL);
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	dts_buf_render(write_buf, DTX_IO_SMALL);
 	/* Not allow new I/O before restart the TX. */
@@ -719,20 +719,20 @@ dtx_handle_resent(test_arg_t *arg, uint64_t fail_loc)
 	dts_buf_render(write_buf, DTX_IO_SMALL);
 	insert_single(dkey, akey, 0, write_buf, DTX_IO_SMALL, th, &req);
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	if (arg->myrank == 0)
 		daos_debug_set_params(arg->group, -1, DMG_KEY_FAIL_LOC,
 				     fail_loc | DAOS_FAIL_ALWAYS, 0, NULL);
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	MUST(daos_tx_commit(th, NULL));
 
 	/* Reset the fail_loc */
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	if (arg->myrank == 0)
 		daos_debug_set_params(arg->group, -1, DMG_KEY_FAIL_LOC, 0,
 				     0, NULL);
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	lookup_single(dkey, akey, 0, fetch_buf, DTX_IO_SMALL,
 		      DAOS_TX_NONE, &req);
@@ -799,21 +799,21 @@ dtx_18(void **state)
 	/* Start read only transaction. */
 	MUST(daos_tx_open(arg->coh, &th, DAOS_TF_RDONLY, NULL));
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	if (arg->myrank == 0)
 		/* DAOS_DTX_NO_READ_TS will skip the initial read TS. */
 		daos_debug_set_params(arg->group, -1, DMG_KEY_FAIL_LOC,
 			DAOS_DTX_NO_READ_TS | DAOS_FAIL_ALWAYS, 0, NULL);
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	lookup_single(dkey, akey, 0, fetch_buf, DTX_IO_SMALL, th, &req);
 	assert_memory_equal(write_buf, fetch_buf, DTX_IO_SMALL);
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	if (arg->myrank == 0)
 		daos_debug_set_params(arg->group, -1, DMG_KEY_FAIL_LOC, 0,
 				     0, NULL);
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	MUST(daos_tx_commit(th, NULL));
 
@@ -822,10 +822,10 @@ dtx_18(void **state)
 
 	MUST(daos_tx_close(th, NULL));
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	daos_fail_loc_set(DAOS_DTX_SPEC_EPOCH | DAOS_FAIL_ALWAYS);
 	daos_fail_value_set(epoch - 1);
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	/* Start another RW transaction. */
 	MUST(daos_tx_open(arg->coh, &th, 0, NULL));
@@ -837,10 +837,10 @@ dtx_18(void **state)
 	rc = daos_tx_commit(th, NULL);
 	assert_rc_equal(rc, -DER_TX_RESTART);
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	daos_fail_value_set(0);
 	daos_fail_loc_set(0);
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	MUST(daos_tx_close(th, NULL));
 
@@ -1023,13 +1023,13 @@ dtx_20(void **state)
 		assert_memory_equal(write_bufs[i], fetch_buf, size);
 	}
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	/* Simulate the case of TX IO error on the shard_1. */
 	if (arg->myrank == 0)
 		daos_debug_set_params(arg->group, -1, DMG_KEY_FAIL_LOC,
 				      DAOS_DTX_FAIL_IO | DAOS_FAIL_ALWAYS,
 				      0, NULL);
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	print_message("Failed transactional update\n");
 
@@ -1045,11 +1045,11 @@ dtx_20(void **state)
 
 	MUST(daos_tx_close(th, NULL));
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	if (arg->myrank == 0)
 		daos_debug_set_params(arg->group, -1, DMG_KEY_FAIL_LOC, 0,
 				      0, NULL);
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	print_message("Verify failed update result\n");
 
@@ -1093,7 +1093,7 @@ dtx_21(void **state)
 
 	dtx_init_oid_req_akey(arg, &oid, &req, &oc, &type, NULL, 1, 0, 0);
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	daos_fail_loc_set(DAOS_DTX_COMMIT_SYNC | DAOS_FAIL_ALWAYS);
 
 	for (i = 0; i < DTX_TEST_SUB_REQS; i++) {
@@ -1109,25 +1109,25 @@ dtx_21(void **state)
 			      size, DAOS_TX_NONE, &req);
 	}
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	daos_fail_loc_set(0);
 	/* Simulate the case of TX IO error on the shard_1. */
 	if (arg->myrank == 0)
 		daos_debug_set_params(arg->group, -1, DMG_KEY_FAIL_LOC,
 				      DAOS_DTX_FAIL_IO | DAOS_FAIL_ALWAYS,
 				      0, NULL);
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	print_message("Failed punch firstly\n");
 
 	rc = daos_obj_punch(req.oh, DAOS_TX_NONE, 0, NULL);
 	assert_rc_equal(rc, -DER_IO);
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	if (arg->myrank == 0)
 		daos_debug_set_params(arg->group, -1, DMG_KEY_FAIL_LOC, 0,
 				      0, NULL);
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	D_ALLOC(fetch_buf, size);
 	assert_non_null(fetch_buf);
@@ -1167,13 +1167,13 @@ dtx_share_oid(daos_obj_id_t *oid)
 {
 	int	rc;
 
-	rc = MPI_Bcast(&oid->lo, 1, MPI_UINT64_T, 0, MPI_COMM_WORLD);
-	assert_int_equal(rc, MPI_SUCCESS);
+	rc = par_bcast(&oid->lo, 1, PAR_UINT64, 0);
+	assert_int_equal(rc, 0);
 
-	rc = MPI_Bcast(&oid->hi, 1, MPI_UINT64_T, 0, MPI_COMM_WORLD);
-	assert_int_equal(rc, MPI_SUCCESS);
+	rc = par_bcast(&oid->hi, 1, PAR_UINT64, 0);
+	assert_int_equal(rc, 0);
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 }
 
 static void
@@ -1211,7 +1211,7 @@ dtx_22(void **state)
 		ioreq_init(&reqs[1], arg->coh, oids[1], types[1], arg);
 	}
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	/* Generate the base objects and values via rank0. */
 	if (arg->myrank == 0) {
 		daos_fail_loc_set(DAOS_DTX_COMMIT_SYNC | DAOS_FAIL_ALWAYS);
@@ -1220,7 +1220,7 @@ dtx_22(void **state)
 				      DAOS_TX_NONE, &reqs[i]);
 		daos_fail_loc_set(0);
 	}
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	for (j = 0; j < 200; j++) {
 		MUST(daos_tx_open(arg->coh, &th, 0, NULL));
@@ -1297,19 +1297,19 @@ dtx_23(void **state)
 
 	dtx_init_oid_req_akey(arg, oids, reqs, ocs, types, NULL, 2, 0, 0);
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	daos_fail_loc_set(DAOS_DTX_COMMIT_SYNC | DAOS_FAIL_ALWAYS);
 	insert_single(dkey, akey, 0, &vals[0], sizeof(vals[0]),
 		      DAOS_TX_NONE, &reqs[0]);
 	insert_single(dkey, akey, 0, &vals[0], sizeof(vals[0]),
 		      DAOS_TX_NONE, &reqs[1]);
 	daos_fail_loc_set(0);
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	if (arg->myrank == 0)
 		daos_debug_set_params(arg->group, -1, DMG_KEY_FAIL_LOC,
 				      DAOS_DTX_START_EPOCH | DAOS_FAIL_ALWAYS,
 				      0, NULL);
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	MUST(daos_tx_open(arg->coh, &th, 0, NULL));
 
@@ -1326,11 +1326,11 @@ restart:
 		once = true;
 		assert_rc_equal(rc, -DER_TX_RESTART);
 
-		MPI_Barrier(MPI_COMM_WORLD);
+		par_barrier();
 		if (arg->myrank == 0)
 			daos_debug_set_params(arg->group, -1, DMG_KEY_FAIL_LOC,
 					      0, 0, NULL);
-		MPI_Barrier(MPI_COMM_WORLD);
+		par_barrier();
 
 		print_message("Handle TX restart %d\n", arg->myrank);
 
@@ -1388,13 +1388,13 @@ dtx_24(void **state)
 	 */
 	sleep(DTX_COMMIT_THRESHOLD_AGE + 3);
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	daos_fail_loc_set(DAOS_DTX_NO_RETRY | DAOS_FAIL_ALWAYS);
 	if (arg->myrank == 0)
 		daos_debug_set_params(arg->group, -1, DMG_KEY_FAIL_LOC,
 				      DAOS_DTX_NO_RETRY | DAOS_FAIL_ALWAYS,
 				      0, NULL);
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	for (i = 0; i < 10; i++) {
 		lookup_single(dkey1, akey, 0, &val, sizeof(val), DAOS_TX_NONE,
@@ -1408,12 +1408,12 @@ dtx_24(void **state)
 		ioreq_fini(&reqs[i]);
 	}
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	daos_fail_loc_set(0);
 	if (arg->myrank == 0)
 		daos_debug_set_params(arg->group, -1, DMG_KEY_FAIL_LOC,
 				      0, 0, NULL);
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 }
 
 static void
@@ -1436,12 +1436,12 @@ dtx_25(void **state)
 	if (!test_runable(arg, 4))
 		skip();
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	if (arg->myrank == 0)
 		daos_debug_set_params(arg->group, -1, DMG_KEY_FAIL_LOC,
 				      DAOS_DTX_NO_BATCHED_CMT |
 				      DAOS_FAIL_ALWAYS, 0, NULL);
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	print_message("Transactional update without batched commit\n");
 
@@ -1478,11 +1478,11 @@ dtx_25(void **state)
 		ioreq_fini(&reqs[i]);
 	}
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	if (arg->myrank == 0)
 		daos_debug_set_params(arg->group, -1, DMG_KEY_FAIL_LOC,
 				      0, 0, NULL);
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 }
 
 static void
@@ -1505,9 +1505,9 @@ dtx_26(void **state)
 	if (!test_runable(arg, 4))
 		skip();
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	daos_fail_loc_set(DAOS_DTX_COMMIT_SYNC | DAOS_FAIL_ALWAYS);
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	for (i = 0, val = 1; i < DTX_NC_CNT; i++, val++) {
 		oids[i] = daos_test_oid_gen(arg->coh, OC_RP_2G2, 0, 0,
@@ -1521,13 +1521,13 @@ dtx_26(void **state)
 			      &reqs[i]);
 	}
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	daos_fail_loc_set(0);
 	if (arg->myrank == 0)
 		daos_debug_set_params(arg->group, -1, DMG_KEY_FAIL_LOC,
 				      DAOS_DTX_NO_COMMITTABLE |
 				      DAOS_FAIL_ALWAYS, 0, NULL);
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	print_message("More transactional update without mark committable\n");
 
@@ -1561,11 +1561,11 @@ dtx_26(void **state)
 		ioreq_fini(&reqs[i]);
 	}
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	if (arg->myrank == 0)
 		daos_debug_set_params(arg->group, -1, DMG_KEY_FAIL_LOC,
 				      0, 0, NULL);
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 }
 
 static void
@@ -1585,9 +1585,9 @@ dtx_uncertainty_miss_request(test_arg_t *arg, uint64_t loc, bool abort,
 	if (!test_runable(arg, 4))
 		skip();
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	daos_fail_loc_set(DAOS_DTX_COMMIT_SYNC | DAOS_FAIL_ALWAYS);
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	for (i = 0, val = 1; i < DTX_NC_CNT; i++, val++) {
 		oids[i] = daos_test_oid_gen(arg->coh, OC_RP_2G2, 0, 0,
@@ -1601,12 +1601,12 @@ dtx_uncertainty_miss_request(test_arg_t *arg, uint64_t loc, bool abort,
 			      &reqs[i]);
 	}
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	daos_fail_loc_set(0);
 	if (arg->myrank == 0)
 		daos_debug_set_params(arg->group, -1, DMG_KEY_FAIL_LOC,
 				      loc | DAOS_FAIL_ALWAYS, 0, NULL);
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	print_message("Transactional update with loc %lx\n", loc);
 
@@ -1626,12 +1626,12 @@ dtx_uncertainty_miss_request(test_arg_t *arg, uint64_t loc, bool abort,
 		MUST(daos_tx_close(th, NULL));
 	}
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	if (arg->myrank == 0)
 		daos_debug_set_params(arg->group, -1, DMG_KEY_FAIL_LOC, delay ?
 				      (DAOS_DTX_UNCERTAIN | DAOS_FAIL_ALWAYS) :
 				      0, 0, NULL);
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	print_message("Verify transactional update result with loc %lx\n", loc);
 
@@ -1660,11 +1660,11 @@ dtx_uncertainty_miss_request(test_arg_t *arg, uint64_t loc, bool abort,
 		}
 		arg->not_check_result = 0;
 
-		MPI_Barrier(MPI_COMM_WORLD);
+		par_barrier();
 		if (arg->myrank == 0)
 			daos_debug_set_params(arg->group, -1, DMG_KEY_FAIL_LOC,
 					      0, 0, NULL);
-		MPI_Barrier(MPI_COMM_WORLD);
+		par_barrier();
 	} else {
 		for (i = 0; i < DTX_NC_CNT; i++) {
 			lookup_single(dkey1, akey, 0, &val, sizeof(val),
@@ -1710,7 +1710,7 @@ dtx_28(void **state)
 static void
 dtx_inject_commit_fail(test_arg_t *arg, int idx)
 {
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	if (arg->myrank == 0) {
 		if (idx % 2 == 1)
 			daos_debug_set_params(arg->group, -1, DMG_KEY_FAIL_LOC,
@@ -1721,7 +1721,7 @@ dtx_inject_commit_fail(test_arg_t *arg, int idx)
 					      DAOS_DTX_MISS_COMMIT |
 					      DAOS_FAIL_ALWAYS, 0, NULL);
 	}
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 }
 
 static void
@@ -1734,9 +1734,9 @@ dtx_generate_layout(test_arg_t *arg, const char *dkey1, const char *dkey2,
 	int		 i, j;
 	int		 rc;
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	daos_fail_loc_set(DAOS_DTX_COMMIT_SYNC | DAOS_FAIL_ALWAYS);
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	print_message("Non-transactional update for base layout\n");
 
@@ -1752,9 +1752,9 @@ dtx_generate_layout(test_arg_t *arg, const char *dkey1, const char *dkey2,
 			      DAOS_TX_NONE, &reqs[1]);
 	}
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	daos_fail_loc_set(0);
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	if (base_only)
 		return;
@@ -1786,11 +1786,11 @@ dtx_generate_layout(test_arg_t *arg, const char *dkey1, const char *dkey2,
 	}
 
 	if (inject_fail) {
-		MPI_Barrier(MPI_COMM_WORLD);
+		par_barrier();
 		if (arg->myrank == 0)
 			daos_debug_set_params(arg->group, -1, DMG_KEY_FAIL_LOC,
 					      0, 0, NULL);
-		MPI_Barrier(MPI_COMM_WORLD);
+		par_barrier();
 	}
 }
 
@@ -1832,9 +1832,9 @@ dtx_29(void **state)
 	dtx_generate_layout(arg, dkey1, dkey2, akeys, reqs,
 			    DTX_NC_CNT, false, true);
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	daos_fail_loc_set(DAOS_DTX_NO_RETRY | DAOS_FAIL_ALWAYS);
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	print_message("Triggering fetch re-entry...\n");
 
@@ -1847,9 +1847,9 @@ dtx_29(void **state)
 		       data_sizes + i, DAOS_TX_NONE, &reqs[1], false);
 	}
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	daos_fail_loc_set(0);
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	print_message("Verifying fetch results...\n");
 
@@ -1989,12 +1989,12 @@ dtx_30(void **state)
 		MUST(daos_tx_close(th, NULL));
 	}
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	if (arg->myrank == 0)
 		daos_debug_set_params(arg->group, -1, DMG_KEY_FAIL_LOC,
 				      0, 0, NULL);
 	daos_fail_loc_set(DAOS_DTX_NO_RETRY | DAOS_FAIL_ALWAYS);
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	print_message("Transactional enumerate to verify update result\n");
 
@@ -2025,9 +2025,9 @@ dtx_30(void **state)
 
 	MUST(dtx_enum_verify_akeys(buf, kds, num, base));
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	daos_fail_loc_set(0);
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	dtx_fini_req_akey(reqs, akeys, 2, DTX_NC_CNT * 2);
 }
@@ -2068,9 +2068,9 @@ dtx_31(void **state)
 	dtx_generate_layout(arg, dkey1, dkey2, akeys, reqs,
 			    DTX_NC_CNT, false, true);
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	daos_fail_loc_set(DAOS_DTX_NO_RETRY | DAOS_FAIL_ALWAYS);
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	print_message("Triggering punch re-entry...\n");
 
@@ -2079,9 +2079,9 @@ dtx_31(void **state)
 	MUST(daos_obj_punch_akeys(reqs[1].oh, DAOS_TX_NONE, 0, &api_dkey2,
 				  DTX_NC_CNT, api_akeys, NULL));
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	daos_fail_loc_set(0);
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	print_message("Verifying punch re-entry results...\n");
 
@@ -2139,9 +2139,9 @@ dtx_32(void **state)
 	for (i = 0, val = 31; i < IOREQ_SG_IOD_NR; i++, val++)
 		data[i] = val;
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	daos_fail_loc_set(DAOS_DTX_COMMIT_SYNC | DAOS_FAIL_ALWAYS);
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	print_message("Triggering update re-entry...\n");
 
@@ -2152,9 +2152,9 @@ dtx_32(void **state)
 	       offsets, (void **)data_addrs, DAOS_TX_NONE, &reqs[1], 0);
 	arg->idx_no_jump = 0;
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	daos_fail_loc_set(0);
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	print_message("Verifying update re-entry results...\n");
 
@@ -2245,11 +2245,11 @@ dtx_33(void **state)
 		}
 	}
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	if (arg->myrank == 0)
 		daos_debug_set_params(arg->group, -1, DMG_KEY_FAIL_LOC,
 				      0, 0, NULL);
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	d_iov_set(&api_akey, &akeys[0], sizeof(uint64_t));
 
@@ -2334,9 +2334,9 @@ dtx_34(void **state)
 	for (i = 0, val = 31; i < DTX_NC_CNT; i++, val++)
 		data[i] = val;
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	daos_fail_loc_set(DAOS_DTX_COMMIT_SYNC | DAOS_FAIL_ALWAYS);
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	print_message("Triggering CPD RPC handler re-entry...\n");
 
@@ -2364,9 +2364,9 @@ dtx_34(void **state)
 		MUST(daos_tx_close(th, NULL));
 	}
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	daos_fail_loc_set(0);
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	print_message("Verifying CPD RPC handler re-entry results...\n");
 
@@ -2411,7 +2411,7 @@ dtx_35(void **state)
 	dtx_generate_layout(arg, dkey1, dkey2, akeys, reqs,
 			    DTX_NC_CNT, false, false);
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	print_message("closing object\n");
 	MUST(daos_obj_close(reqs[0].oh, NULL));
@@ -2420,13 +2420,13 @@ dtx_35(void **state)
 	print_message("closing container\n");
 	MUST(daos_cont_close(arg->coh, NULL));
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	if (arg->myrank == 0) {
 		print_message("reopening container to trigger DTX resync\n");
 		MUST(daos_cont_open(arg->pool.poh, arg->co_str, DAOS_COO_RW,
 				    &arg->coh, &arg->co_info, NULL));
 	}
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	print_message("share container\n");
 	handle_share(&arg->coh, HANDLE_CO, arg->myrank, arg->pool.poh, 1);
@@ -2440,7 +2440,7 @@ dtx_35(void **state)
 		daos_debug_set_params(arg->group, -1, DMG_KEY_FAIL_LOC,
 				      DAOS_DTX_NO_RETRY | DAOS_FAIL_ALWAYS,
 				      0, NULL);
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	/* Sleep 3 seconds, all possible DTX resync should have been done. */
 	sleep(3);
@@ -2457,12 +2457,12 @@ dtx_35(void **state)
 
 	dtx_fini_req_akey(reqs, akeys, 2, DTX_NC_CNT);
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	daos_fail_loc_set(0);
 	if (arg->myrank == 0)
 		daos_debug_set_params(arg->group, -1, DMG_KEY_FAIL_LOC,
 				      0, 0, NULL);
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 }
 
 static d_rank_t
@@ -2530,7 +2530,7 @@ dtx_36(void **state)
 	 * go ahead. So only check on the MPI rank_0.
 	 */
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	if (arg->myrank == 0) {
 		daos_fail_loc_set(DAOS_DTX_SPEC_LEADER | DAOS_FAIL_ALWAYS);
 		daos_debug_set_params(arg->group, -1, DMG_KEY_FAIL_LOC,
@@ -2578,11 +2578,11 @@ dtx_36(void **state)
 		print_message("Exclude rank %d to trigger rebuild\n",
 			      kill_rank);
 	}
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	rebuild_single_pool_rank(arg, kill_rank, false);
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	if (arg->myrank == 0) {
 		daos_debug_set_params(arg->group, -1, DMG_KEY_FAIL_LOC,
 				      0, 0, NULL);
@@ -2602,7 +2602,7 @@ dtx_36(void **state)
 			assert_int_equal(vals[0], i + 31);
 		}
 	}
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	reintegrate_single_pool_rank(arg, kill_rank);
 
@@ -2635,7 +2635,7 @@ dtx_37(void **state)
 	dtx_init_oid_req_akey(arg, &oid, &req, &oc, &type, akeys, 1,
 			      DTX_NC_CNT, 0);
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	daos_fail_loc_set(DAOS_DTX_COMMIT_SYNC | DAOS_FAIL_ALWAYS);
 
 	print_message("Non-transactional update for base layout\n");
@@ -2652,7 +2652,7 @@ dtx_37(void **state)
 	 * It is not easy to control multiple MPI ranks for specified
 	 * leader and some non-leader. So only check on the MPI rank_0.
 	 */
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	daos_fail_loc_set(0);
 	if (arg->myrank == 0) {
 		daos_debug_set_params(arg->group, -1, DMG_KEY_FAIL_LOC,
@@ -2704,11 +2704,11 @@ dtx_37(void **state)
 				      0, 0, NULL);
 		daos_fail_loc_set(0);
 	}
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	rebuild_single_pool_rank(arg, kill_rank, false);
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	if (arg->myrank == 0) {
 		print_message("Verifying data after rebuild...\n");
 
@@ -2734,7 +2734,7 @@ dtx_37(void **state)
 				assert_int_equal(val, i + 1);
 		}
 	}
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	reintegrate_single_pool_rank(arg, kill_rank);
 
@@ -2788,7 +2788,7 @@ dtx_38(void **state)
 		kill_ranks[0] = CRT_NO_RANK;
 	}
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	daos_fail_loc_set(DAOS_DTX_COMMIT_SYNC | DAOS_FAIL_ALWAYS);
 
 	print_message("Non-transactional update for base layout\n");
@@ -2809,7 +2809,7 @@ dtx_38(void **state)
 	 * go ahead. So only check on the MPI rank_0.
 	 */
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	daos_fail_loc_set(0);
 	if (arg->myrank == 0) {
 		daos_fail_loc_set(DAOS_DTX_SPEC_LEADER | DAOS_FAIL_ALWAYS);
@@ -2848,11 +2848,11 @@ dtx_38(void **state)
 				      0, 0, NULL);
 		daos_fail_loc_set(DAOS_DTX_NO_RETRY | DAOS_FAIL_ALWAYS);
 	}
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	rebuild_single_pool_rank(arg, kill_ranks[0], false);
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	if (arg->myrank == 0) {
 		print_message("Verifying data after rebuild...\n");
 
@@ -2907,7 +2907,7 @@ dtx_38(void **state)
 
 		daos_fail_loc_set(0);
 	}
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	reintegrate_single_pool_rank(arg, kill_ranks[0]);
 
@@ -3141,7 +3141,7 @@ run_daos_dist_tx_test(int rank, int size, int *sub_tests, int sub_tests_size)
 {
 	int rc = 0;
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	if (sub_tests_size == 0) {
 		sub_tests_size = ARRAY_SIZE(dtx_tests);
 		sub_tests = NULL;
@@ -3151,7 +3151,7 @@ run_daos_dist_tx_test(int rank, int size, int *sub_tests, int sub_tests_size)
 				ARRAY_SIZE(dtx_tests), sub_tests,
 				sub_tests_size, dtx_test_setup, test_teardown);
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	return rc;
 }

--- a/src/tests/suite/daos_drain_simple.c
+++ b/src/tests/suite/daos_drain_simple.c
@@ -492,7 +492,7 @@ run_daos_drain_simple_test(int rank, int size, int *sub_tests,
 {
 	int rc = 0;
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	if (sub_tests_size == 0) {
 		sub_tests_size = ARRAY_SIZE(drain_tests);
 		sub_tests = NULL;
@@ -502,7 +502,7 @@ run_daos_drain_simple_test(int rank, int size, int *sub_tests,
 				ARRAY_SIZE(drain_tests), sub_tests,
 				sub_tests_size);
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	return rc;
 }

--- a/src/tests/suite/daos_epoch.c
+++ b/src/tests/suite/daos_epoch.c
@@ -391,6 +391,6 @@ run_daos_epoch_test(int rank, int size)
 		rc = cmocka_run_group_tests_name("DAOS_Epoch",
 						 epoch_tests, setup,
 						 test_teardown);
-	MPI_Bcast(&rc, 1, MPI_INT, 0, MPI_COMM_WORLD);
+	par_bcast(&rc, 1, PAR_INT, 0);
 	return rc;
 }

--- a/src/tests/suite/daos_epoch_io.c
+++ b/src/tests/suite/daos_epoch_io.c
@@ -1640,10 +1640,10 @@ run_daos_epoch_io_test(int rank, int size, int *sub_tests, int sub_tests_size)
 {
 	int rc;
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	rc = cmocka_run_group_tests_name("DAOS_Epoch_IO",
 			epoch_io_tests, epoch_io_setup,
 			epoch_io_teardown);
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	return rc;
 }

--- a/src/tests/suite/daos_epoch_recovery.c
+++ b/src/tests/suite/daos_epoch_recovery.c
@@ -98,7 +98,7 @@ epoch_recovery(test_arg_t *arg, enum epoch_recovery_op op)
 	daos_epoch_t	snap;
 	int		rc;
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	print_message("creating and opening container "DF_UUIDF"\n",
 		      DP_UUID(uuid));
@@ -122,13 +122,13 @@ epoch_recovery(test_arg_t *arg, enum epoch_recovery_op op)
 	/* Every rank updates timestep 2. */
 	io(UPDATE, arg, coh, oid, "timestamp 2");
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	print_message("closing container\n");
 	rc = daos_cont_close(coh, NULL /* ev */);
 	assert_rc_equal(rc, 0);
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	if (op == POOL_DISCONNECT) {
 		print_message("disconnecting from pool\n");
@@ -159,7 +159,7 @@ epoch_recovery(test_arg_t *arg, enum epoch_recovery_op op)
 
 	rc = daos_cont_close(coh, NULL /* ev */);
 	assert_rc_equal(rc, 0);
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 }
 
 static void
@@ -196,6 +196,6 @@ run_daos_epoch_recovery_test(int rank, int size)
 	rc = cmocka_run_group_tests_name("DAOS_Epoch_Recovery",
 					 epoch_recovery_tests, setup,
 					 test_teardown);
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	return rc;
 }

--- a/src/tests/suite/daos_extend_simple.c
+++ b/src/tests/suite/daos_extend_simple.c
@@ -258,7 +258,7 @@ run_daos_extend_simple_test(int rank, int size, int *sub_tests,
 {
 	int rc = 0;
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	if (sub_tests_size == 0) {
 		sub_tests_size = ARRAY_SIZE(extend_tests);
 		sub_tests = NULL;
@@ -268,7 +268,7 @@ run_daos_extend_simple_test(int rank, int size, int *sub_tests,
 				ARRAY_SIZE(extend_tests), sub_tests,
 				sub_tests_size);
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	return rc;
 }

--- a/src/tests/suite/daos_kv.c
+++ b/src/tests/suite/daos_kv.c
@@ -341,6 +341,6 @@ run_daos_kv_test(int rank, int size)
 
 	rc = cmocka_run_group_tests_name("DAOS_KV_API", kv_tests,
 					 kv_setup, test_teardown);
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	return rc;
 }

--- a/src/tests/suite/daos_md_replication.c
+++ b/src/tests/suite/daos_md_replication.c
@@ -29,14 +29,11 @@ mdr_stop_pool_svc(void **argv)
 				     NULL, 128 * 1024 * 1024, 0,
 				     NULL, arg->pool.svc, uuid);
 	}
-	MPI_Bcast(&rc, 1, MPI_INT, 0, MPI_COMM_WORLD);
+	par_bcast(&rc, 1, PAR_INT, 0);
 	assert_rc_equal(rc, 0);
-	MPI_Bcast(uuid, 16, MPI_CHAR, 0, MPI_COMM_WORLD);
-	MPI_Bcast(&arg->pool.svc->rl_nr, sizeof(arg->pool.svc->rl_nr), MPI_CHAR,
-		  0, MPI_COMM_WORLD);
-	MPI_Bcast(arg->pool.ranks,
-		  sizeof(arg->pool.ranks[0]) * arg->pool.svc->rl_nr,
-		  MPI_CHAR, 0, MPI_COMM_WORLD);
+	par_bcast(uuid, 16, PAR_CHAR, 0);
+	par_bcast(&arg->pool.svc->rl_nr, sizeof(arg->pool.svc->rl_nr), PAR_CHAR, 0);
+	par_bcast(arg->pool.ranks, sizeof(arg->pool.ranks[0]) * arg->pool.svc->rl_nr, PAR_CHAR, 0);
 
 	/* Check the number of pool service replicas. */
 	if (arg->pool.svc->rl_nr < 3) {
@@ -56,7 +53,7 @@ mdr_stop_pool_svc(void **argv)
 				       DAOS_PC_RW, &poh, NULL /* info */,
 				       NULL /* ev */);
 	}
-	MPI_Bcast(&rc, 1, MPI_INT, 0, MPI_COMM_WORLD);
+	par_bcast(&rc, 1, PAR_INT, 0);
 	assert_rc_equal(rc, 0);
 	handle_share(&poh, HANDLE_POOL, arg->myrank, DAOS_HDL_INVAL, 0);
 
@@ -91,7 +88,7 @@ mdr_stop_pool_svc(void **argv)
 		print_message("repeating %d queries: end\n", n);
 	}
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	print_message("disconnecting from pool\n");
 	rc = daos_pool_disconnect(poh, NULL /* ev */);
@@ -197,6 +194,6 @@ run_daos_md_replication_test(int rank, int size)
 
 	rc = cmocka_run_group_tests_name("DAOS_MD_Replication", mdr_tests,
 					 setup, test_teardown);
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	return rc;
 }

--- a/src/tests/suite/daos_mgmt.c
+++ b/src/tests/suite/daos_mgmt.c
@@ -132,7 +132,7 @@ teardown_pools(void **state)
 			if (arg->myrank == 0)
 				rc = pool_destroy_safe(arg, &lparg->tpools[i]);
 			if (arg->multi_rank)
-				MPI_Bcast(&rc, 1, MPI_INT, 0, MPI_COMM_WORLD);
+				par_bcast(&rc, 1, PAR_INT, 0);
 			if (rc != 0)
 				return rc;
 		}
@@ -434,6 +434,6 @@ run_daos_mgmt_test(int rank, int size, int *sub_tests, int sub_tests_size)
 		}
 	}
 
-	MPI_Bcast(&rc, 1, MPI_INT, 0, MPI_COMM_WORLD);
+	par_bcast(&rc, 1, PAR_INT, 0);
 	return rc;
 }

--- a/src/tests/suite/daos_nvme_recovery.c
+++ b/src/tests/suite/daos_nvme_recovery.c
@@ -22,7 +22,7 @@ set_fail_loc(test_arg_t *arg, d_rank_t rank, uint64_t tgtidx,
 	if (arg->myrank == 0)
 		daos_debug_set_params(arg->group, rank, DMG_KEY_FAIL_LOC,
 				     fail_loc, tgtidx, NULL);
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 }
 
 static void
@@ -30,7 +30,7 @@ reset_fail_loc(test_arg_t *arg)
 {
 	if (arg->myrank == 0)
 		daos_fail_loc_reset();
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 }
 
 static bool
@@ -244,7 +244,7 @@ nvme_fault_reaction(void **state, int mode)
 	print_message("Waiting for rebuild done...\n");
 	if (arg->myrank == 0)
 		test_rebuild_wait(&arg, 1);
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	print_message("Waiting for faulty reaction done...\n");
 	/**
@@ -780,7 +780,7 @@ run_daos_nvme_recov_test(int rank, int size, int *sub_tests,
 {
 	int rc = 0;
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	if (sub_tests_size == 0) {
 		sub_tests_size = ARRAY_SIZE(nvme_recov_tests);
 		sub_tests = NULL;
@@ -791,7 +791,7 @@ run_daos_nvme_recov_test(int rank, int size, int *sub_tests,
 				sub_tests_size, nvme_recov_test_setup,
 				test_teardown);
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	return rc;
 }

--- a/src/tests/suite/daos_obj.c
+++ b/src/tests/suite/daos_obj.c
@@ -1944,7 +1944,7 @@ punch_simple_internal(void **state, daos_obj_id_t oid)
 		D_FREE(dkeys[i]);
 
 	ioreq_fini(&req);
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 }
 
 #define MANYREC_NUMRECS	5
@@ -2590,7 +2590,7 @@ tx_discard(void **state)
 	int		 i, t;
 	int		 rc;
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	D_ALLOC(rec_nvme, IO_SIZE_NVME);
 	assert_non_null(rec_nvme);
@@ -2640,7 +2640,7 @@ tx_discard(void **state)
 		}
 		insert(dkey, nakeys, (const char **)akey, rec_size, rx_nr,
 		       offset, (void **)rec, th[t], &req);
-		MPI_Barrier(MPI_COMM_WORLD);
+		par_barrier();
 	}
 
 	for (t = 0; t < 3; t++) {
@@ -2654,7 +2654,7 @@ tx_discard(void **state)
 			rc = daos_tx_commit(th[t], NULL);
 			assert_int_equal(rc, 0);
 		}
-		MPI_Barrier(MPI_COMM_WORLD);
+		par_barrier();
 	}
 
 	/** Check the three transactions. */
@@ -2692,7 +2692,7 @@ tx_discard(void **state)
 	}
 
 	/** Close and reopen the container and the obj. */
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	close_reopen_coh_oh(arg, &req, oid);
 
 	/** Verify record is the same as the last committed transaction. */
@@ -2728,7 +2728,7 @@ tx_discard(void **state)
 	D_FREE(rec_scm);
 
 	ioreq_fini(&req);
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 #endif
 }
 
@@ -2769,7 +2769,7 @@ tx_commit(void **state)
 	int		 i, t;
 	int		 rc;
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	D_ALLOC(rec_nvme, IO_SIZE_NVME);
 	assert_non_null(rec_nvme);
@@ -2818,7 +2818,7 @@ tx_commit(void **state)
 		}
 		insert(dkey, nakeys, (const char **)akey, /*iod_size*/rec_size,
 			rx_nr, offset, (void **)rec, th[t], &req);
-		MPI_Barrier(MPI_COMM_WORLD);
+		par_barrier();
 	}
 
 	/** Check the three transactions. */
@@ -2845,7 +2845,7 @@ tx_commit(void **state)
 		}
 	}
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	/** Commit only the first 2 transactions */
 	for (t = 0; t < 3; t++) {
@@ -2860,7 +2860,7 @@ tx_commit(void **state)
 		}
 		rc = daos_tx_close(th[t], NULL);
 		assert_int_equal(rc, 0);
-		MPI_Barrier(MPI_COMM_WORLD);
+		par_barrier();
 	}
 
 	/** Close and reopen the container and the obj */
@@ -2921,7 +2921,7 @@ tx_commit(void **state)
 	D_FREE(rec_scm);
 
 	ioreq_fini(&req);
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 #endif
 }
 
@@ -3072,7 +3072,7 @@ tgt_idx_change_retry(void **state)
 				     DAOS_OBJ_TGT_IDX_CHANGE,
 				     replica, NULL);
 	}
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	ioreq_init(&req, arg->coh, oid, DAOS_IOD_ARRAY, arg);
 
@@ -3142,7 +3142,7 @@ tgt_idx_change_retry(void **state)
 		daos_debug_set_params(arg->group, -1, DMG_KEY_FAIL_LOC, 0,
 				     0, NULL);
 	}
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	insert_wait(&req);
 
 	daos_fail_loc_set(DAOS_OBJ_SPECIAL_SHARD);
@@ -3172,7 +3172,7 @@ tgt_idx_change_retry(void **state)
 		daos_reint_server(arg->pool.pool_uuid, arg->group,
 				  arg->dmg_config, rank);
 	}
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	ioreq_fini(&req);
 }
 
@@ -3209,7 +3209,7 @@ fetch_replica_unavail(void **state)
 		daos_exclude_server(arg->pool.pool_uuid, arg->group,
 				    arg->dmg_config, rank);
 	}
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	/** Lookup */
 	buf = calloc(size, 1);
@@ -3232,7 +3232,7 @@ fetch_replica_unavail(void **state)
 
 	}
 	D_FREE(buf);
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	ioreq_fini(&req);
 }
 
@@ -3457,7 +3457,7 @@ blob_unmap_trigger(void **state)
 	int		 i, t;
 	int		 rc;
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	oid = daos_test_oid_gen(arg->coh, dts_obj_class, 0, 0, arg->myrank);
 	/* Tx discard only currently supports DAOS_IOD_SINGLE type */
@@ -3492,7 +3492,7 @@ blob_unmap_trigger(void **state)
 			assert_memory_equal(update_buf, fetch_buf,
 					    IO_SIZE_NVME);
 		}
-		MPI_Barrier(MPI_COMM_WORLD);
+		par_barrier();
 	}
 
 	/* Discard the NVMe records (Discard second tx) */
@@ -3502,7 +3502,7 @@ blob_unmap_trigger(void **state)
 	rc = daos_tx_close(th[1], NULL);
 	assert_int_equal(rc, 0);
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	/* Wait for >= VEA_MIGRATE_INTVL */
 	print_message("Wait for free extents to expire (15 sec)\n");
@@ -3530,7 +3530,7 @@ blob_unmap_trigger(void **state)
 	D_FREE(fetch_buf);
 	D_FREE(update_buf);
 	ioreq_fini(&req);
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 #endif
 }
 
@@ -3778,7 +3778,7 @@ io_pool_map_refresh_trigger(void **state)
 		daos_debug_set_params(arg->group, -1, DMG_KEY_FAIL_LOC,
 				 DAOS_FORCE_REFRESH_POOL_MAP | DAOS_FAIL_ONCE,
 				 0, NULL);
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	ioreq_init(&req, arg->coh, oid, DAOS_IOD_ARRAY, arg);
 	/** Insert */
@@ -3979,7 +3979,7 @@ io_capa_iv_fetch(void **state)
 		daos_debug_set_params(arg->group, -1, DMG_KEY_FAIL_LOC,
 				 DAOS_FORCE_CAPA_FETCH | DAOS_FAIL_ONCE,
 				 0, NULL);
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	ioreq_init(&req, arg->coh, oid, DAOS_IOD_ARRAY, arg);
 	/** Insert */
@@ -4700,7 +4700,7 @@ run_daos_io_test(int rank, int size, int *sub_tests, int sub_tests_size)
 	char oclass[16] = {0};
 	char buf[32];
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	if (sub_tests_size == 0) {
 		sub_tests_size = ARRAY_SIZE(io_tests);
 		sub_tests = NULL;
@@ -4717,6 +4717,6 @@ run_daos_io_test(int rank, int size, int *sub_tests, int sub_tests_size)
 				ARRAY_SIZE(io_tests), sub_tests, sub_tests_size,
 				obj_setup, test_teardown);
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	return rc;
 }

--- a/src/tests/suite/daos_obj_array.c
+++ b/src/tests/suite/daos_obj_array.c
@@ -1457,6 +1457,6 @@ run_daos_obj_array_test(int rank, int size)
 		rc = cmocka_run_group_tests_name("DAOS_Obj_Array",
 						 array_tests, obj_array_setup,
 						 test_teardown);
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	return rc;
 }

--- a/src/tests/suite/daos_obj_ec.c
+++ b/src/tests/suite/daos_obj_ec.c
@@ -1535,7 +1535,7 @@ run_daos_ec_io_test(int rank, int size, int *sub_tests, int sub_tests_size)
 {
 	int rc = 0;
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	if (sub_tests_size == 0) {
 		sub_tests_size = ARRAY_SIZE(ec_tests);
 		sub_tests = NULL;
@@ -1545,7 +1545,7 @@ run_daos_ec_io_test(int rank, int size, int *sub_tests, int sub_tests_size)
 				sub_tests, sub_tests_size, ec_setup,
 				test_teardown);
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	return rc;
 }

--- a/src/tests/suite/daos_oid_alloc.c
+++ b/src/tests/suite/daos_oid_alloc.c
@@ -16,14 +16,14 @@ reconnect(test_arg_t *arg) {
 	int rc;
 	unsigned int flags;
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	rc = daos_cont_close(arg->coh, NULL);
 	assert_rc_equal(rc, 0);
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	rc = daos_pool_disconnect(arg->pool.poh, NULL /* ev */);
 	arg->pool.poh = DAOS_HDL_INVAL;
 	assert_rc_equal(rc, 0);
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	flags = (DAOS_COO_RW | DAOS_COO_FORCE);
 	if (arg->myrank == 0) {
@@ -39,7 +39,7 @@ reconnect(test_arg_t *arg) {
 bcast:
 	/** broadcast container open result */
 	if (arg->rank_size > 1)
-		MPI_Bcast(&rc, 1, MPI_INT, 0, MPI_COMM_WORLD);
+		par_bcast(&rc, 1, PAR_INT, 0);
 	assert_rc_equal(rc, 0);
 	/** l2g and g2l the container handle */
 	if (arg->rank_size > 1) {
@@ -60,10 +60,10 @@ simple_oid_allocator(void **state)
 	int		rc;
 
 	for (i = 0; i < 10; i++) {
-		MPI_Barrier(MPI_COMM_WORLD);
+		par_barrier();
 		if (arg->myrank == 0)
 			fprintf(stderr, "%d ---------------------\n", i);
-		MPI_Barrier(MPI_COMM_WORLD);
+		par_barrier();
 
 		rc = daos_cont_alloc_oids(arg->coh, num_oids, &oid, NULL);
 		if (rc)
@@ -86,7 +86,7 @@ multi_cont_oid_allocator(void **state)
 	int		i;
 	int		rc = 0, rc_reduce;
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	if (arg->myrank != 0)
 		goto verify_rc;
 
@@ -139,7 +139,7 @@ multi_cont_oid_allocator(void **state)
 	}
 
 verify_rc:
-	MPI_Allreduce(&rc, &rc_reduce, 1, MPI_INT, MPI_MIN, MPI_COMM_WORLD);
+	par_allreduce(&rc, &rc_reduce, 1, PAR_INT, PAR_MIN);
 	assert_int_equal(rc_reduce, 0);
 }
 
@@ -154,13 +154,11 @@ check_ranges(int *num_oids, uint64_t *oids, int num_rgs, test_arg_t *arg)
 	D_ALLOC_ARRAY(g_num_oids, num_rgs * arg->rank_size);
 	D_ALLOC_ARRAY(g_oids, num_rgs * arg->rank_size);
 
-	rc = MPI_Gather(num_oids, num_rgs, MPI_INT, g_num_oids, num_rgs,
-			MPI_INT, 0, MPI_COMM_WORLD);
-	assert_int_equal(rc, MPI_SUCCESS);
+	rc = par_gather(num_oids, g_num_oids, num_rgs, PAR_INT, 0);
+	assert_int_equal(rc, 0);
 
-	rc = MPI_Gather(oids, num_rgs, MPI_UINT64_T, g_oids, num_rgs,
-			MPI_UINT64_T, 0, MPI_COMM_WORLD);
-	assert_int_equal(rc, MPI_SUCCESS);
+	rc = par_gather(oids, g_oids, num_rgs, PAR_UINT64, 0);
+	assert_int_equal(rc, 0);
 
 	if (arg->myrank != 0) {
 		rc = 0;
@@ -194,7 +192,7 @@ check_ranges(int *num_oids, uint64_t *oids, int num_rgs, test_arg_t *arg)
 	print_message("Verified %d ranges...\n", i);
 
 out:
-	MPI_Bcast(&rc, 1, MPI_INT, 0, MPI_COMM_WORLD);
+	par_bcast(&rc, 1, PAR_INT, 0);
 	return rc;
 }
 
@@ -218,7 +216,7 @@ oid_allocator_mult_hdls(void **state)
 		assert_rc_equal(rc, 0);
 	}
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	while (i < NUM_OIDS) {
 		rc = daos_pool_connect(arg->pool.pool_uuid, arg->group, DAOS_PC_RW,
 				       &poh1, NULL, NULL);
@@ -257,12 +255,12 @@ oid_allocator_mult_hdls(void **state)
 	rc = check_ranges(num_oids, oids, NUM_OIDS, arg);
 	assert_int_equal(rc, 0);
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	if (arg->myrank == 0) {
 		rc = daos_cont_destroy(arg->pool.poh, label, 0, NULL);
 		assert_rc_equal(rc, 0);
 	}
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 }
 
 #define NUM_RGS 1000
@@ -304,7 +302,7 @@ oid_allocator_checker(void **state)
 		if (i && i % (NUM_RGS/3 + 1) == 0) {
 			daos_pool_info_t info = {0};
 
-			MPI_Barrier(MPI_COMM_WORLD);
+			par_barrier();
 			rc = daos_pool_query(arg->pool.poh, NULL, &info, NULL,
 					     NULL);
 			assert_rc_equal(rc, 0);
@@ -315,15 +313,14 @@ oid_allocator_checker(void **state)
 						arg->group,
 						arg->pool.svc, -1);
 			}
-			MPI_Barrier(MPI_COMM_WORLD);
+			par_barrier();
 		}
 		i++;
 	}
 
 check:
 	if (arg->rank_size > 1) {
-		MPI_Allreduce(&rc, &rc_reduce, 1, MPI_INT, MPI_MIN,
-			      MPI_COMM_WORLD);
+		par_allreduce(&rc, &rc_reduce, 1, PAR_INT, PAR_MIN);
 		rc = rc_reduce;
 	}
 	assert_int_equal(rc, 0);
@@ -417,9 +414,9 @@ run_daos_oid_alloc_test(int rank, int size)
 {
 	int rc = 0;
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	rc = cmocka_run_group_tests_name("DAOS_OID_Allocator", oid_alloc_tests,
 					 oid_alloc_setup, test_teardown);
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	return rc;
 }

--- a/src/tests/suite/daos_pool.c
+++ b/src/tests/suite/daos_pool.c
@@ -24,7 +24,7 @@ pool_connect_nonexist(void **state)
 	daos_handle_t	 poh;
 	int		 rc;
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	if (arg->myrank != 0)
 		return;
@@ -47,7 +47,7 @@ pool_connect(void **state)
 	daos_pool_info_t info = {0};
 	int		 rc;
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	if (!arg->hdl_share && arg->myrank != 0)
 		return;
@@ -112,7 +112,7 @@ pool_connect_exclusively(void **state)
 	daos_handle_t	 poh_ex;
 	int		 rc;
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	if (arg->myrank != 0)
 		return;
@@ -165,7 +165,7 @@ pool_exclude(void **state)
 	int		 rc;
 	int		 idx;
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	if (1) {
 		print_message("Skip it for now, because CaRT can't support "
@@ -267,7 +267,7 @@ pool_attribute(void **state)
 	size_t			 out_sizes[] =	{ BUFSIZE, BUFSIZE, BUFSIZE };
 	size_t			 total_size;
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	if (arg->myrank != 0)
 		return;
@@ -373,7 +373,7 @@ init_fini_conn(void **state)
 	daos_handle_t		 poh;
 	int			 rc;
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	rc = daos_pool_connect(arg->pool.pool_str, arg->group, DAOS_PC_RW, &poh, NULL, NULL);
 	assert_rc_equal(rc, 0);
@@ -500,7 +500,7 @@ pool_properties(void **state)
 	char			*expected_owner;
 	char			*expected_group;
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	print_message("create pool with properties, and query it to verify.\n");
 	rc = test_setup((void **)&arg, SETUP_EQ, arg0->multi_rank,
@@ -532,7 +532,7 @@ pool_properties(void **state)
 			DMG_KEY_FAIL_LOC, DAOS_FORCE_PROP_VERIFY, 0, NULL);
 		assert_rc_equal(rc, 0);
 	}
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	prop_query = daos_prop_alloc(0);
 	rc = daos_pool_query(arg->pool.poh, NULL, NULL, prop_query, NULL);
@@ -598,7 +598,7 @@ pool_properties(void **state)
 	if (arg->myrank == 0)
 		daos_debug_set_params(arg->group, -1, DMG_KEY_FAIL_LOC, 0,
 				     0, NULL);
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	daos_prop_free(prop);
 	daos_prop_free(prop_query);
@@ -613,7 +613,7 @@ pool_op_retry(void **state)
 	daos_pool_info_t info = {0};
 	int		 rc;
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	if (arg->myrank != 0)
 		return;
@@ -717,7 +717,7 @@ setup_containers(void **state, daos_size_t nconts)
 	}
 
 	if (arg->multi_rank) {
-		MPI_Bcast(&rc, 1, MPI_INT, 0, MPI_COMM_WORLD);
+		par_bcast(&rc, 1, PAR_INT, 0);
 		if (rc == 0) {
 			handle_share(&lcarg->tpool.poh, HANDLE_POOL,
 				     arg->myrank, lcarg->tpool.poh, 0);
@@ -754,12 +754,10 @@ setup_containers(void **state, daos_size_t nconts)
 		}
 
 		if (arg->multi_rank) {
-			MPI_Bcast(&rc, 1, MPI_INT, 0, MPI_COMM_WORLD);
+			par_bcast(&rc, 1, PAR_INT, 0);
 			/** broadcast container UUID */
 			if (rc == 0)
-				MPI_Bcast(lcarg->conts[i],
-					  sizeof(lcarg->conts[i]), MPI_CHAR,
-					  0, MPI_COMM_WORLD);
+				par_bcast(lcarg->conts[i], sizeof(lcarg->conts[i]), PAR_CHAR, 0);
 		}
 
 		if (rc != 0)
@@ -822,7 +820,7 @@ teardown_containers(void **state)
 		}
 
 		if (arg->multi_rank)
-			MPI_Bcast(&rc, 1, MPI_INT, 0, MPI_COMM_WORLD);
+			par_bcast(&rc, 1, PAR_INT, 0);
 
 		if (rc != 0)
 			return rc;
@@ -832,7 +830,7 @@ teardown_containers(void **state)
 		rc = pool_destroy_safe(arg, &lcarg->tpool);
 
 	if (arg->multi_rank)
-		MPI_Bcast(&rc, 1, MPI_INT, 0, MPI_COMM_WORLD);
+		par_bcast(&rc, 1, PAR_INT, 0);
 
 	if (rc != 0)
 		return rc;
@@ -950,7 +948,7 @@ list_containers_test(void **state)
 	struct daos_pool_cont_info	*conts = NULL;
 	int				 tnum = 0;
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	if (arg->myrank != 0)
 		return;
@@ -1081,7 +1079,7 @@ pool_connect_access(void **state)
 {
 	test_arg_t	*arg0 = *state;
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	print_message("pool ACL gives the owner no permissions\n");
 	expect_pool_connect_access(arg0, 0, DAOS_PC_RO, -DER_NO_PERM);
@@ -1164,7 +1162,7 @@ label_strings_test(void **state)
 	size_t	n_valid = ARRAY_SIZE(valid_labels);
 	size_t	n_invalid = ARRAY_SIZE(invalid_labels);
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	if (arg->myrank == 0) {
 		print_message("Verify %zu valid labels\n", n_valid);
@@ -1192,7 +1190,7 @@ pool_map_refreshes(void **state)
 	d_rank_t	 rank = ranks_to_kill[0];
 	int		 tgt = 0;
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	/*
 	 * Since the rebuild_single_pool_target call below refreshes the pool
@@ -1242,7 +1240,7 @@ pool_map_refreshes(void **state)
 		daos_fail_loc_set(0);
 	}
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	print_message("reintegrating the excluded targets\n");
 	reintegrate_single_pool_target(arg, rank, tgt);
@@ -1295,11 +1293,11 @@ run_daos_pool_test(int rank, int size, int *sub_tests, int sub_tests_size)
 {
 	int rc;
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	rc = run_daos_sub_tests("DAOS_Pool", pool_tests, ARRAY_SIZE(pool_tests), sub_tests,
 				sub_tests_size, setup, test_teardown);
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	return rc;
 }

--- a/src/tests/suite/daos_rebuild.c
+++ b/src/tests/suite/daos_rebuild.c
@@ -60,7 +60,7 @@ rebuild_drop_scan(void **state)
 				     DAOS_REBUILD_NO_HDL | DAOS_FAIL_ONCE,
 				     0, NULL);
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	rebuild_single_pool_target(arg, ranks_to_kill[0], tgt, false);
 	rebuild_io_verify(arg, oids, OBJ_NR);
 
@@ -93,7 +93,7 @@ rebuild_retry_rebuild(void **state)
 		daos_debug_set_params(arg->group, -1, DMG_KEY_FAIL_LOC,
 				     DAOS_REBUILD_NO_HDL | DAOS_FAIL_ONCE,
 				     0, NULL);
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	rebuild_single_pool_target(arg, ranks_to_kill[0], tgt, false);
 	rebuild_io_verify(arg, oids, OBJ_NR);
 
@@ -129,7 +129,7 @@ rebuild_retry_for_stale_pool(void **state)
 				     0, NULL);
 	}
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	rebuild_single_pool_rank(arg, ranks_to_kill[0], false);
 	rebuild_io_verify(arg, oids, OBJ_NR);
 
@@ -160,7 +160,7 @@ rebuild_drop_obj(void **state)
 		daos_debug_set_params(arg->group, 0, DMG_KEY_FAIL_LOC,
 				     DAOS_REBUILD_DROP_OBJ | DAOS_FAIL_ONCE,
 				     0, NULL);
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	rebuild_single_pool_rank(arg, ranks_to_kill[0], false);
 	rebuild_io_verify(arg, oids, OBJ_NR);
 
@@ -193,7 +193,7 @@ rebuild_update_failed(void **state)
 		daos_debug_set_params(arg->group, 0, DMG_KEY_FAIL_LOC,
 				     DAOS_REBUILD_UPDATE_FAIL | DAOS_FAIL_ONCE,
 				     0, NULL);
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	rebuild_single_pool_target(arg, ranks_to_kill[0], tgt, false);
 	reintegrate_single_pool_target(arg, ranks_to_kill[0], tgt);
 }
@@ -249,8 +249,7 @@ rebuild_close_container_cb(void *data)
 
 	rc = daos_cont_close(arg->coh, NULL);
 	if (arg->multi_rank) {
-		MPI_Allreduce(&rc, &rc_reduce, 1, MPI_INT, MPI_MIN,
-			      MPI_COMM_WORLD);
+		par_allreduce(&rc, &rc_reduce, 1, PAR_INT, PAR_MIN);
 		rc = rc_reduce;
 	}
 	print_message("container close "DF_UUIDF"\n",
@@ -290,7 +289,7 @@ rebuild_destroy_container_cb(void *data)
 	print_message("container "DF_UUIDF"/"DF_UUIDF" destroyed\n",
 		      DP_UUID(arg->pool.pool_uuid), DP_UUID(arg->co_uuid));
 	if (arg->multi_rank)
-		MPI_Bcast(&rc, 1, MPI_INT, 0, MPI_COMM_WORLD);
+		par_bcast(&rc, 1, PAR_INT, 0);
 	if (rc)
 		print_message("failed to destroy container "DF_UUIDF
 			      ": %d\n", DP_UUID(arg->co_uuid), rc);
@@ -388,7 +387,7 @@ rebuild_destroy_pool_cb(void *data)
 	print_message("pool destroyed "DF_UUIDF"\n",
 		      DP_UUID(arg->pool.pool_uuid));
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 out:
 	return rc;
@@ -467,7 +466,7 @@ rebuild_iv_tgt_fail(void **state)
 		daos_debug_set_params(arg->group, -1, DMG_KEY_FAIL_LOC,
 				     DAOS_REBUILD_TGT_IV_UPDATE_FAIL |
 				     DAOS_FAIL_ONCE, 0, NULL);
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	rebuild_single_pool_rank(arg, ranks_to_kill[0], false);
 	rebuild_io_verify(arg, oids, OBJ_NR);
 
@@ -500,7 +499,7 @@ rebuild_tgt_start_fail(void **state)
 				     DMG_KEY_FAIL_LOC,
 				  DAOS_REBUILD_TGT_START_FAIL | DAOS_FAIL_ONCE,
 				  0, NULL);
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	/* Rebuild rank 1 */
 	rebuild_single_pool_rank(arg, ranks_to_kill[0], false);
@@ -529,7 +528,7 @@ rebuild_send_objects_fail(void **state)
 		daos_debug_set_params(arg->group, -1, DMG_KEY_FAIL_LOC,
 				      DAOS_REBUILD_TGT_SEND_OBJS_FAIL |
 				      DAOS_FAIL_ONCE, 0, NULL);
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	/* Even do not sending the objects, the rebuild should still be
 	 * able to finish.
 	 */
@@ -539,7 +538,7 @@ rebuild_send_objects_fail(void **state)
 	if (arg->myrank == 0)
 		daos_debug_set_params(arg->group, -1, DMG_KEY_FAIL_LOC, 0,
 				     0, NULL);
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	reintegrate_single_pool_rank(arg, ranks_to_kill[0]);
 	rebuild_add_back_tgts(arg, ranks_to_kill[0], NULL, 1);
@@ -557,7 +556,7 @@ rebuild_pool_disconnect_cb(void *data)
 	if (arg->myrank == 0)
 		daos_debug_set_params(arg->group, -1, DMG_KEY_FAIL_LOC,
 				     0, 0, NULL);
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	return 0;
 }
@@ -598,7 +597,7 @@ rebuild_tgt_pool_disconnect_internal(void **state, unsigned int fail_loc)
 	if (arg->myrank == 0)
 		daos_debug_set_params(arg->group, -1, DMG_KEY_FAIL_LOC,
 				      fail_loc, 0, NULL);
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	/* NB: During the test, one target will be excluded from the pool map,
 	 * then container/pool will be closed/disconnectd during the rebuild,
@@ -642,7 +641,7 @@ rebuild_pool_connect_cb(void *data)
 	if (arg->myrank == 0)
 		daos_debug_set_params(arg->group, -1, DMG_KEY_FAIL_LOC,
 				     0, 0, NULL);
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	return 0;
 }
 
@@ -668,7 +667,7 @@ rebuild_offline_pool_connect_internal(void **state, unsigned int fail_loc)
 	if (arg->myrank == 0)
 		daos_debug_set_params(arg->group, -1, DMG_KEY_FAIL_LOC,
 				      fail_loc, 0, NULL);
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	arg->rebuild_pre_cb = rebuild_pool_disconnect_internal;
 	arg->rebuild_cb = rebuild_pool_connect_cb;
@@ -761,7 +760,7 @@ rebuild_change_leader_cb(void *arg)
 		daos_debug_set_params(test_arg->group, -1, DMG_KEY_FAIL_LOC,
 				     0, 0, NULL);
 	}
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	return 0;
 }
 
@@ -787,7 +786,7 @@ rebuild_master_change_during_scan(void **state)
 	if (arg->myrank == 0)
 		daos_debug_set_params(arg->group, -1, DMG_KEY_FAIL_LOC,
 				     DAOS_REBUILD_TGT_SCAN_HANG, 0, NULL);
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	arg->rebuild_cb = rebuild_change_leader_cb;
 
 	rebuild_single_pool_rank(arg, ranks_to_kill[0], false);
@@ -818,7 +817,7 @@ rebuild_master_change_during_rebuild(void **state)
 	if (arg->myrank == 0)
 		daos_debug_set_params(arg->group, -1, DMG_KEY_FAIL_LOC,
 				     DAOS_REBUILD_TGT_REBUILD_HANG, 0, NULL);
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	arg->rebuild_cb = rebuild_change_leader_cb;
 
 	rebuild_single_pool_rank(arg, ranks_to_kill[0], false);
@@ -847,7 +846,7 @@ rebuild_nospace_cb(void *data)
 		daos_debug_set_params(arg->group, -1,
 				     DMG_KEY_REBUILD_THROTTLING, 30, 0, NULL);
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	return 0;
 }
@@ -874,7 +873,7 @@ rebuild_nospace(void **state)
 		daos_debug_set_params(arg->group, -1, DMG_KEY_FAIL_LOC,
 				     DAOS_REBUILD_TGT_NOSPACE, 0, NULL);
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	arg->rebuild_cb = rebuild_nospace_cb;
 	rebuild_single_pool_rank(arg, ranks_to_kill[0], false);
@@ -935,7 +934,7 @@ rebuild_multiple_tgts(void **state)
 				     0, NULL);
 	}
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	/* Rebuild 2 ranks at the same time */
 	if (arg->myrank == 0)
@@ -953,7 +952,7 @@ rebuild_multiple_tgts(void **state)
 					  arg->dmg_config,
 					  exclude_ranks[i]);
 	}
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 }
 
 #if 0
@@ -1149,7 +1148,7 @@ rebuild_fail_all_replicas_before_rebuild(void **state)
 	if (arg->myrank == 0)
 		test_rebuild_wait(&arg, 1);
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	daos_obj_layout_free(layout);
 }
 
@@ -1198,7 +1197,7 @@ rebuild_fail_all_replicas(void **state)
 	if (arg->myrank == 0)
 		test_rebuild_wait(&arg, 1);
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	daos_obj_layout_free(layout);
 }
 
@@ -1423,7 +1422,7 @@ rebuild_test_setup(void **state)
 	if (arg && arg->myrank == 0)
 		daos_debug_set_params(arg->group, -1, DMG_KEY_FAIL_LOC,
 				     1, 0, NULL);
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	return 0;
 }
 
@@ -1435,7 +1434,7 @@ rebuild_test_teardown(void **state)
 	if (arg && arg->myrank == 0)
 		daos_debug_set_params(arg->group, -1, DMG_KEY_FAIL_LOC,
 				     0, 0, NULL);
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	test_teardown(state);
 	return 0;
@@ -1446,7 +1445,7 @@ run_daos_rebuild_test(int rank, int size, int *sub_tests, int sub_tests_size)
 {
 	int rc = 0;
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	if (sub_tests_size == 0) {
 		sub_tests_size = ARRAY_SIZE(rebuild_tests);
 		sub_tests = NULL;
@@ -1456,7 +1455,7 @@ run_daos_rebuild_test(int rank, int size, int *sub_tests, int sub_tests_size)
 				     ARRAY_SIZE(rebuild_tests), sub_tests,
 				     sub_tests_size);
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	return rc;
 }

--- a/src/tests/suite/daos_rebuild_common.c
+++ b/src/tests/suite/daos_rebuild_common.c
@@ -125,7 +125,7 @@ rebuild_targets(test_arg_t **args, int args_cnt, d_rank_t *ranks,
 		if (args[i]->rebuild_pre_cb)
 			args[i]->rebuild_pre_cb(args[i]);
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	/** include or exclude the target from the pool */
 	if (args[0]->myrank == 0) {
 		for (i = 0; i < rank_nr; i++) {
@@ -159,7 +159,7 @@ rebuild_targets(test_arg_t **args, int args_cnt, d_rank_t *ranks,
 			}
 		}
 	}
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	for (i = 0; i < args_cnt; i++)
 		if (args[i]->rebuild_cb)
@@ -168,7 +168,7 @@ rebuild_targets(test_arg_t **args, int args_cnt, d_rank_t *ranks,
 	if (args[0]->myrank == 0 && !args[0]->no_rebuild)
 		test_rebuild_wait(args, args_cnt);
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	for (i = 0; i < args_cnt; i++) {
 		daos_cont_status_clear(args[i]->coh, NULL);
 
@@ -244,8 +244,7 @@ rebuild_pool_disconnect_internal(void *data)
 	/* Close cont and disconnect pool */
 	rc = daos_cont_close(arg->coh, NULL);
 	if (arg->multi_rank) {
-		MPI_Allreduce(&rc, &rc_reduce, 1, MPI_INT, MPI_MIN,
-		MPI_COMM_WORLD);
+		par_allreduce(&rc, &rc_reduce, 1, PAR_INT, PAR_MIN);
 		rc = rc_reduce;
 	}
 	print_message("container close "DF_UUIDF"\n",
@@ -266,7 +265,7 @@ rebuild_pool_disconnect_internal(void *data)
 	DP_UUID(arg->pool.pool_uuid));
 
 	arg->pool.poh = DAOS_HDL_INVAL;
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	return rc;
 }
 
@@ -276,7 +275,7 @@ rebuild_pool_connect_internal(void *data)
 	test_arg_t      *arg = data;
 	int             rc = 0;
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	if (arg->myrank == 0) {
 		rc = daos_pool_connect(arg->pool.pool_str, arg->group,
 				       DAOS_PC_RW,
@@ -287,22 +286,21 @@ rebuild_pool_connect_internal(void *data)
 
 		print_message("pool connect %s\n", arg->pool.pool_str);
 	}
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	if (arg->multi_rank)
-		MPI_Bcast(&rc, 1, MPI_INT, 0, MPI_COMM_WORLD);
+		par_bcast(&rc, 1, PAR_INT, 0);
 	if (rc)
 		return rc;
 
 	/** broadcast pool info */
 	if (arg->multi_rank) {
-		MPI_Bcast(&arg->pool.pool_info, sizeof(arg->pool.pool_info),
-		MPI_CHAR, 0, MPI_COMM_WORLD);
+		par_bcast(&arg->pool.pool_info, sizeof(arg->pool.pool_info), PAR_CHAR, 0);
 		handle_share(&arg->pool.poh, HANDLE_POOL, arg->myrank,
 		arg->pool.poh, 0);
 	}
 
 	/** open container */
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	if (arg->myrank == 0) {
 		rc = daos_cont_open(arg->pool.poh, arg->co_str,
 				    DAOS_COO_RW | DAOS_COO_FORCE,
@@ -313,15 +311,15 @@ rebuild_pool_connect_internal(void *data)
 		print_message("container open "DF_UUIDF"\n",
 		DP_UUID(arg->co_uuid));
 	}
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	if (arg->multi_rank)
-		MPI_Bcast(&rc, 1, MPI_INT, 0, MPI_COMM_WORLD);
+		par_bcast(&rc, 1, PAR_INT, 0);
 	if (rc)
 		return rc;
 
 	/** broadcast container info */
 	if (arg->multi_rank) {
-		MPI_Bcast(&rc, 1, MPI_INT, 0, MPI_COMM_WORLD);
+		par_bcast(&rc, 1, PAR_INT, 0);
 		handle_share(&arg->coh, HANDLE_CO, arg->myrank, arg->pool.poh,
 		0);
 	}
@@ -393,7 +391,7 @@ void
 rebuild_add_back_tgts(test_arg_t *arg, d_rank_t failed_rank, int *failed_tgts,
 		      int nr)
 {
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	/* Add back the target if it is not being killed */
 	if (arg->myrank == 0 && !arg->pool.destroyed) {
 		int i;
@@ -404,7 +402,7 @@ rebuild_add_back_tgts(test_arg_t *arg, d_rank_t failed_rank, int *failed_tgts,
 					  failed_rank,
 					  failed_tgts ? failed_tgts[i] : -1);
 	}
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 }
 
 static int

--- a/src/tests/suite/daos_rebuild_ec.c
+++ b/src/tests/suite/daos_rebuild_ec.c
@@ -1122,7 +1122,7 @@ run_daos_rebuild_simple_ec_test(int rank, int size, int *sub_tests,
 {
 	int rc = 0;
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	if (sub_tests_size == 0) {
 		sub_tests_size = ARRAY_SIZE(rebuild_tests);
 		sub_tests = NULL;
@@ -1132,7 +1132,7 @@ run_daos_rebuild_simple_ec_test(int rank, int size, int *sub_tests,
 				ARRAY_SIZE(rebuild_tests), sub_tests,
 				sub_tests_size);
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	return rc;
 }

--- a/src/tests/suite/daos_rebuild_simple.c
+++ b/src/tests/suite/daos_rebuild_simple.c
@@ -1289,7 +1289,7 @@ run_daos_rebuild_simple_test(int rank, int size, int *sub_tests,
 {
 	int rc = 0;
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	if (sub_tests_size == 0) {
 		sub_tests_size = ARRAY_SIZE(rebuild_tests);
 		sub_tests = NULL;
@@ -1299,7 +1299,7 @@ run_daos_rebuild_simple_test(int rank, int size, int *sub_tests,
 				     ARRAY_SIZE(rebuild_tests), sub_tests,
 				     sub_tests_size);
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	return rc;
 }

--- a/src/tests/suite/daos_test.c
+++ b/src/tests/suite/daos_test.c
@@ -320,11 +320,11 @@ main(int argc, char **argv)
 
 	d_register_alt_assert(mock_assert);
 
-	MPI_Init(&argc, &argv);
+	par_init(&argc, &argv);
 
-	MPI_Comm_rank(MPI_COMM_WORLD, &rank);
-	MPI_Comm_size(MPI_COMM_WORLD, &size);
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_rank(&rank);
+	par_size(&size);
+	par_barrier();
 
 	static struct option long_options[] = {
 		{"all",		no_argument,		NULL,	'a'},
@@ -539,8 +539,7 @@ main(int argc, char **argv)
 					sub_tests_idx);
 
 exit:
-	MPI_Allreduce(&nr_failed, &nr_total_failed, 1, MPI_INT, MPI_SUM,
-		      MPI_COMM_WORLD);
+	par_allreduce(&nr_failed, &nr_total_failed, 1, PAR_INT, PAR_SUM);
 
 	rc = daos_fini();
 	if (rc)
@@ -555,7 +554,7 @@ exit:
 				      nr_total_failed);
 	}
 
-	MPI_Finalize();
+	par_fini();
 
 	D_FREE(test_io_dir);
 

--- a/src/tests/suite/daos_test.h
+++ b/src/tests/suite/daos_test.h
@@ -50,7 +50,7 @@
 	} while (0)
 #endif /* FAULT_INJECTION */
 
-#include <mpi.h>
+#include <daos/dpar.h>
 #include <daos/debug.h>
 #include <daos/common.h>
 #include <daos/mgmt.h>
@@ -532,8 +532,8 @@ handle_share(daos_handle_t *hdl, int type, int rank, daos_handle_t poh,
 	}
 
 	/** broadcast size of global handle to all peers */
-	rc = MPI_Bcast(&ghdl.iov_buf_len, 1, MPI_UINT64_T, 0, MPI_COMM_WORLD);
-	assert_int_equal(rc, MPI_SUCCESS);
+	rc = par_bcast(&ghdl.iov_buf_len, 1, PAR_UINT64, 0);
+	assert_int_equal(rc, 0);
 
 	/** allocate buffer for global pool handle */
 	D_ALLOC(ghdl.iov_buf, ghdl.iov_buf_len);
@@ -558,9 +558,8 @@ handle_share(daos_handle_t *hdl, int type, int rank, daos_handle_t poh,
 	if (rank == 0 && verbose == 1)
 		print_message("rank 0 broadcast global %s handle ...",
 			      (type == HANDLE_POOL) ? "pool" : "container");
-	rc = MPI_Bcast(ghdl.iov_buf, ghdl.iov_len, MPI_BYTE, 0,
-		       MPI_COMM_WORLD);
-	assert_int_equal(rc, MPI_SUCCESS);
+	rc = par_bcast(ghdl.iov_buf, ghdl.iov_len, PAR_BYTE, 0);
+	assert_int_equal(rc, 0);
 	if (rank == 0 && verbose == 1)
 		print_message("success\n");
 
@@ -584,7 +583,7 @@ handle_share(daos_handle_t *hdl, int type, int rank, daos_handle_t poh,
 
 	D_FREE(ghdl.iov_buf);
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 }
 
 #define MAX_KILLS	3

--- a/src/tests/suite/daos_test_common.c
+++ b/src/tests/suite/daos_test_common.c
@@ -57,7 +57,7 @@ test_setup_pool_create(void **state, struct test_pool *ipool,
 		d_rank_list_dup(&outpool->svc, ipool->svc);
 		outpool->slave = 1;
 		if (arg->multi_rank)
-			MPI_Barrier(MPI_COMM_WORLD);
+			par_barrier();
 		return 0;
 	}
 
@@ -112,23 +112,19 @@ test_setup_pool_create(void **state, struct test_pool *ipool,
 out:
 	/** broadcast pool create result */
 	if (arg->multi_rank) {
-		MPI_Bcast(&rc, 1, MPI_INT, 0, MPI_COMM_WORLD);
+		par_bcast(&rc, 1, PAR_INT, 0);
 		/** broadcast pool UUID and svc addresses */
 		if (!rc) {
-			MPI_Bcast(outpool->pool_uuid, 16,
-				  MPI_CHAR, 0, MPI_COMM_WORLD);
+			par_bcast(outpool->pool_uuid, 16, PAR_CHAR, 0);
 			uuid_unparse(outpool->pool_uuid, outpool->pool_str);
 
 			/* TODO: Should we even be broadcasting this now? */
 			if (outpool->svc == NULL)
 				return rc;
-			MPI_Bcast(&outpool->svc->rl_nr,
-				  sizeof(outpool->svc->rl_nr),
-				  MPI_CHAR, 0, MPI_COMM_WORLD);
-			MPI_Bcast(outpool->svc->rl_ranks,
-				  sizeof(outpool->svc->rl_ranks[0]) *
-					 outpool->svc->rl_nr,
-				  MPI_CHAR, 0, MPI_COMM_WORLD);
+			par_bcast(&outpool->svc->rl_nr, sizeof(outpool->svc->rl_nr), PAR_CHAR, 0);
+			par_bcast(outpool->svc->rl_ranks,
+				  sizeof(outpool->svc->rl_ranks[0]) * outpool->svc->rl_nr,
+				  PAR_CHAR, 0);
 		}
 	}
 	return rc;
@@ -147,7 +143,7 @@ test_setup_pool_connect(void **state, struct test_pool *pool)
 		       sizeof(pool->pool_info));
 		arg->pool.poh = pool->poh;
 		if (arg->multi_rank)
-			MPI_Barrier(MPI_COMM_WORLD);
+			par_barrier();
 		return 0;
 	}
 
@@ -190,12 +186,10 @@ test_setup_pool_connect(void **state, struct test_pool *pool)
 
 	/** broadcast pool connect result */
 	if (arg->multi_rank) {
-		MPI_Bcast(&rc, 1, MPI_INT, 0, MPI_COMM_WORLD);
+		par_bcast(&rc, 1, PAR_INT, 0);
 		if (!rc) {
 			/** broadcast pool info */
-			MPI_Bcast(&arg->pool.pool_info,
-				  sizeof(arg->pool.pool_info),
-				  MPI_CHAR, 0, MPI_COMM_WORLD);
+			par_bcast(&arg->pool.pool_info, sizeof(arg->pool.pool_info), PAR_CHAR, 0);
 			/** l2g and g2l the pool handle */
 			handle_share(&arg->pool.poh, HANDLE_POOL,
 				     arg->myrank, arg->pool.poh, 0);
@@ -234,11 +228,10 @@ test_setup_cont_create(void **state, daos_prop_t *co_prop)
 	}
 	/** broadcast container create result */
 	if (arg->multi_rank) {
-		MPI_Bcast(&rc, 1, MPI_INT, 0, MPI_COMM_WORLD);
+		par_bcast(&rc, 1, PAR_INT, 0);
 		/** broadcast container UUID */
 		if (!rc) {
-			MPI_Bcast(arg->co_uuid, 16,
-				  MPI_CHAR, 0, MPI_COMM_WORLD);
+			par_bcast(arg->co_uuid, 16, PAR_CHAR, 0);
 			uuid_unparse(arg->co_uuid, arg->co_str);
 		}
 	}
@@ -273,7 +266,7 @@ test_setup_cont_open(void **state)
 	}
 	/** broadcast container open result */
 	if (arg->multi_rank) {
-		MPI_Bcast(&rc, 1, MPI_INT, 0, MPI_COMM_WORLD);
+		par_bcast(&rc, 1, PAR_INT, 0);
 		/** l2g and g2l the container handle */
 		if (!rc)
 			handle_share(&arg->coh, HANDLE_CO,
@@ -334,8 +327,8 @@ test_setup(void **state, unsigned int step, bool multi_rank,
 		*state = arg;
 		memset(arg, 0, sizeof(*arg));
 
-		MPI_Comm_rank(MPI_COMM_WORLD, &arg->myrank);
-		MPI_Comm_size(MPI_COMM_WORLD, &arg->rank_size);
+		par_rank(&arg->myrank);
+		par_size(&arg->rank_size);
 		arg->multi_rank = multi_rank;
 		arg->pool.pool_size = pool_size;
 		arg->setup_state = -1;
@@ -474,8 +467,7 @@ test_teardown_cont_hdl(test_arg_t *arg)
 
 	rc = daos_cont_close(arg->coh, NULL);
 	if (arg->multi_rank) {
-		MPI_Allreduce(&rc, &rc_reduce, 1, MPI_INT, MPI_MIN,
-			      MPI_COMM_WORLD);
+		par_allreduce(&rc, &rc_reduce, 1, PAR_INT, PAR_MIN);
 		rc = rc_reduce;
 	}
 	arg->coh = DAOS_HDL_INVAL;
@@ -505,7 +497,7 @@ test_teardown_cont(test_arg_t *arg)
 		break;
 	}
 	if (arg->multi_rank)
-		MPI_Bcast(&rc, 1, MPI_INT, 0, MPI_COMM_WORLD);
+		par_bcast(&rc, 1, PAR_INT, 0);
 	if (rc)
 		print_message("failed to destroy container "DF_UUIDF
 			      ": %d\n", DP_UUID(arg->co_uuid), rc);
@@ -531,7 +523,7 @@ test_teardown(void **state)
 	}
 
 	if (arg->multi_rank)
-		MPI_Barrier(MPI_COMM_WORLD);
+		par_barrier();
 
 	if (daos_handle_is_valid(arg->coh)) {
 		rc = test_teardown_cont_hdl(arg);
@@ -562,12 +554,12 @@ test_teardown(void **state)
 				rc = daos_pool_disconnect(arg->pool.poh, NULL);
 		}
 		if (arg->multi_rank)
-			MPI_Barrier(MPI_COMM_WORLD);
+			par_barrier();
 		if (arg->myrank == 0)
 			rc = pool_destroy_safe(arg, NULL);
 
 		if (arg->multi_rank)
-			MPI_Bcast(&rc, 1, MPI_INT, 0, MPI_COMM_WORLD);
+			par_bcast(&rc, 1, PAR_INT, 0);
 		if (rc) {
 			print_message("failed to destroy pool "DF_UUIDF
 				      " rc: %d\n",
@@ -661,8 +653,8 @@ test_runable(test_arg_t *arg, unsigned int required_nodes)
 		arg->hce = crt_hlc_get();
 	}
 
-	MPI_Bcast(&runable, 1, MPI_INT, 0, MPI_COMM_WORLD);
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_bcast(&runable, 1, PAR_INT, 0);
+	par_barrier();
 	return runable;
 }
 

--- a/src/tests/suite/daos_verify_consistency.c
+++ b/src/tests/suite/daos_verify_consistency.c
@@ -44,7 +44,7 @@ vc_set_fail_loc(test_arg_t *arg, uint64_t fail_loc, int total, int cur)
 	if (fail_loc == 0 || cur > total || cur < total - 1)
 		return;
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	if (cur == total) {
 		if (arg->myrank == 0)
 			daos_debug_set_params(arg->group, -1, DMG_KEY_FAIL_LOC,
@@ -54,7 +54,7 @@ vc_set_fail_loc(test_arg_t *arg, uint64_t fail_loc, int total, int cur)
 			daos_debug_set_params(arg->group, -1, DMG_KEY_FAIL_LOC,
 					      fail_loc, 0, NULL);
 	}
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 }
 
 static void
@@ -315,21 +315,21 @@ vc_8(void **state)
 
 	vc_gen_modifications(arg, &req, oid, 7, 7, 7, 0, 0, 0);
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	if (arg->myrank == 0)
 		daos_debug_set_params(arg->group, -1, DMG_KEY_FAIL_LOC,
 				      DAOS_VC_LOST_REPLICA | DAOS_FAIL_ALWAYS,
 				      0, NULL);
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	rc = vc_obj_verify(arg, oid);
 	assert_rc_equal(rc, -DER_MISMATCH);
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	if (arg->myrank == 0)
 		daos_debug_set_params(arg->group, -1, DMG_KEY_FAIL_LOC,
 				      0, 0, NULL);
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	ioreq_fini(&req);
 }
@@ -398,7 +398,7 @@ run_daos_vc_test(int rank, int size, int *sub_tests, int sub_tests_size)
 {
 	int rc = 0;
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	if (sub_tests_size == 0) {
 		sub_tests_size = ARRAY_SIZE(vc_tests);
 		sub_tests = NULL;
@@ -408,7 +408,7 @@ run_daos_vc_test(int rank, int size, int *sub_tests, int sub_tests_size)
 				sub_tests, sub_tests_size, vc_test_setup,
 				test_teardown);
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	return rc;
 }

--- a/src/tests/suite/dfs_par_test.c
+++ b/src/tests/suite/dfs_par_test.c
@@ -13,19 +13,19 @@ static daos_handle_t	co_hdl;
 static dfs_t		*dfs_mt;
 
 static int
-check_one_success(int rc, int err, MPI_Comm comm)
+check_one_success(int rc, int err)
 {
 	int *rc_arr;
 	int mpi_size, mpi_rank, i;
 	int passed, expect_fail, failed;
 
-	MPI_Comm_size(comm, &mpi_size);
-	MPI_Comm_rank(comm, &mpi_rank);
+	par_size(&mpi_size);
+	par_rank(&mpi_rank);
 
 	D_ALLOC_ARRAY(rc_arr, mpi_size);
 	assert_non_null(rc_arr);
 
-	MPI_Allgather(&rc, 1, MPI_INT, rc_arr, 1, MPI_INT, comm);
+	par_allgather(&rc, rc_arr, 1, PAR_INT);
 	passed = expect_fail = failed = 0;
 	for (i = 0; i < mpi_size; i++) {
 		if (rc_arr[i] == 0)
@@ -56,7 +56,7 @@ test_cond_helper(test_arg_t *arg, int rf)
 	char		*dirname = "cond_testdir";
 	int		rc, op_rc;
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	if (arg->myrank == 0) {
 		dfs_attr_t attr = {};
 
@@ -74,50 +74,50 @@ test_cond_helper(test_arg_t *arg, int rf)
 
 	handle_share(&coh, HANDLE_CO, arg->myrank, arg->pool.poh, 0);
 	dfs_test_share(arg->pool.poh, coh, arg->myrank, &dfs);
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	if (arg->myrank == 0)
 		print_message("All ranks create the same file with O_EXCL\n");
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	op_rc = dfs_open(dfs, NULL, filename, S_IFREG | S_IWUSR | S_IRUSR,
 			 O_RDWR | O_CREAT | O_EXCL, 0, 0, NULL, &file);
-	rc = check_one_success(op_rc, EEXIST, MPI_COMM_WORLD);
+	rc = check_one_success(op_rc, EEXIST);
 	assert_int_equal(rc, 0);
 	if (op_rc == 0) {
 		rc = dfs_release(file);
 		assert_int_equal(rc, 0);
 	}
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	if (arg->myrank == 0)
 		print_message("All ranks unlink the same file\n");
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	op_rc = dfs_remove(dfs, NULL, filename, true, NULL);
-	rc = check_one_success(op_rc, ENOENT, MPI_COMM_WORLD);
+	rc = check_one_success(op_rc, ENOENT);
 	if (rc)
 		print_error("Failed concurrent file unlink\n");
 	assert_int_equal(rc, 0);
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	if (arg->myrank == 0)
 		print_message("All ranks create the same directory\n");
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	op_rc = dfs_mkdir(dfs, NULL, dirname, S_IWUSR | S_IRUSR, 0);
-	rc = check_one_success(op_rc, EEXIST, MPI_COMM_WORLD);
+	rc = check_one_success(op_rc, EEXIST);
 	if (rc)
 		print_error("Failed concurrent dir creation\n");
 	assert_int_equal(rc, 0);
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	if (arg->myrank == 0)
 		print_message("All ranks remove the same directory\n");
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	op_rc = dfs_remove(dfs, NULL, dirname, true, NULL);
-	rc = check_one_success(op_rc, ENOENT, MPI_COMM_WORLD);
+	rc = check_one_success(op_rc, ENOENT);
 	if (rc)
 		print_error("Failed concurrent rmdir\n");
 	assert_int_equal(rc, 0);
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	/** test atomic rename with DFS DTX mode */
 	bool use_dtx = false;
@@ -135,17 +135,17 @@ test_cond_helper(test_arg_t *arg, int rf)
 		rc = dfs_release(file);
 		assert_int_equal(rc, 0);
 	}
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	char newfilename[1024];
 
 	sprintf(newfilename, "%s_new.%d", filename, arg->myrank);
 	op_rc = dfs_move(dfs, NULL, filename, NULL, newfilename, NULL);
-	rc = check_one_success(op_rc, ENOENT, MPI_COMM_WORLD);
+	rc = check_one_success(op_rc, ENOENT);
 	if (rc)
 		print_error("Failed concurrent rename\n");
 	assert_int_equal(rc, 0);
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	/* Verify TX consistency semantics. */
 	if (op_rc == 0 && arg->myrank == 0) {
@@ -176,7 +176,7 @@ out:
 	rc = daos_cont_close(coh, NULL);
 	assert_rc_equal(rc, 0);
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	if (arg->myrank == 0) {
 		char	str[37];
 
@@ -186,7 +186,7 @@ out:
 		printf("Destroyed DFS Container "DF_UUIDF"\n",
 		       DP_UUID(cuuid));
 	}
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 }
 
 static void
@@ -225,7 +225,7 @@ dfs_test_short_read_internal(void **state, daos_oclass_id_t cid,
 	d_iov_t			iov;
 	int			i, rc;
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	D_ALLOC(wbuf, buf_size);
 	assert_non_null(wbuf);
 	for (i = 0; i < buf_size / sizeof(int); i++)
@@ -257,12 +257,12 @@ dfs_test_short_read_internal(void **state, daos_oclass_id_t cid,
 	assert_int_equal(read_size, 0);
 
 	/** write strided pattern and check read size with segmented buffers */
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	if (arg->myrank == 0) {
 		rc = dfs_write(dfs_mt, obj, &wsgl, 0, NULL);
 		assert_int_equal(rc, 0);
 	}
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	/** set contig mem location */
 	rsgl.sg_nr = 1;
@@ -286,64 +286,64 @@ dfs_test_short_read_internal(void **state, daos_oclass_id_t cid,
 	assert_int_equal(rc, 0);
 	assert_int_equal(read_size, buf_size);
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	if (arg->myrank == 0) {
 		rc = dfs_write(dfs_mt, obj, &wsgl, 2 * buf_size, NULL);
 		assert_int_equal(rc, 0);
 	}
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	rc = dfs_read(dfs_mt, obj, &rsgl, 0, &read_size, NULL);
 	assert_int_equal(rc, 0);
 	assert_int_equal(read_size, buf_size * 3);
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	if (arg->myrank == 0) {
 		rc = dfs_write(dfs_mt, obj, &wsgl, 5 * buf_size, NULL);
 		assert_int_equal(rc, 0);
 	}
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	rc = dfs_read(dfs_mt, obj, &rsgl, 0, &read_size, NULL);
 	assert_int_equal(rc, 0);
 	assert_int_equal(read_size, buf_size * 6);
 
 	/** truncate the buffer to a large size, read should return all */
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	if (arg->myrank == 0) {
 		rc = dfs_punch(dfs_mt, obj, 1048576 * 2, DFS_MAX_FSIZE);
 		assert_int_equal(rc, 0);
 	}
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	rc = dfs_read(dfs_mt, obj, &rsgl, 0, &read_size, NULL);
 	assert_int_equal(rc, 0);
 	assert_int_equal(read_size, buf_size * NUM_SEGS);
 
 	/** punch all the data, read should return 0 */
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	if (arg->myrank == 0) {
 		rc = dfs_punch(dfs_mt, obj, 0, DFS_MAX_FSIZE);
 		assert_int_equal(rc, 0);
 	}
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	rc = dfs_read(dfs_mt, obj, &rsgl, 0, &read_size, NULL);
 	assert_int_equal(rc, 0);
 	assert_int_equal(read_size, 0);
 
 	/** write to 2 chunks with a large gap in the middle */
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	if (arg->myrank == 0) {
 		rc = dfs_write(dfs_mt, obj, &wsgl, 0, NULL);
 		assert_int_equal(rc, 0);
 		rc = dfs_write(dfs_mt, obj, &wsgl, 1048576 * 3, NULL);
 		assert_int_equal(rc, 0);
 	}
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	/** reading in between, even holes should not be a short read */
 	rc = dfs_read(dfs_mt, obj, &rsgl, 1048576, &read_size, NULL);
 	assert_int_equal(rc, 0);
 	assert_int_equal(read_size, buf_size * NUM_SEGS);
 
 	rc = dfs_release(obj);
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	if (arg->myrank == 0) {
 		rc = dfs_remove(dfs_mt, NULL, name, 0, NULL);
 		assert_int_equal(rc, 0);
@@ -405,7 +405,7 @@ dfs_test_hole_mgmt(void **state)
 	struct stat		stbuf;
 	int			i, rc;
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	D_ALLOC(wbuf, buf_size);
 	assert_non_null(wbuf);
 	memset(wbuf, 'c', buf_size);
@@ -446,7 +446,7 @@ dfs_test_hole_mgmt(void **state)
 	assert_int_equal(rc, 0);
 
 	/** write 1 byte at a large offset */
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	if (arg->myrank == 0) {
 		d_iov_set(&iov, wbuf, 1);
 		wsgl.sg_nr = 1;
@@ -455,7 +455,7 @@ dfs_test_hole_mgmt(void **state)
 		rc = dfs_write(dfs_mt, obj, &wsgl, 10485760, NULL);
 		assert_int_equal(rc, 0);
 	}
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	rc = dfs_ostat(dfs_mt, obj, &stbuf);
 	assert_int_equal(rc, 0);
@@ -472,13 +472,13 @@ dfs_test_hole_mgmt(void **state)
 	/** reset */
 	memset(rbuf[0], '-', buf_size + 100);
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	/** truncate file back to 0 */
 	if (arg->myrank == 0) {
 		rc = dfs_punch(dfs_mt, obj, 0, DFS_MAX_FSIZE);
 		assert_int_equal(rc, 0);
 	}
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	rc = dfs_ostat(dfs_mt, obj, &stbuf);
 	assert_int_equal(rc, 0);
@@ -492,7 +492,7 @@ dfs_test_hole_mgmt(void **state)
 	assert_int_equal(rc, 0);
 
 	/** write a strided pattern, every 1k bytes */
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	if (arg->myrank == 0) {
 		d_iov_set(&iov, wbuf, buf_size);
 		wsgl.sg_nr = 1;
@@ -504,7 +504,7 @@ dfs_test_hole_mgmt(void **state)
 			assert_int_equal(rc, 0);
 		}
 	}
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	rc = dfs_ostat(dfs_mt, obj, &stbuf);
 	assert_int_equal(rc, 0);
@@ -561,20 +561,20 @@ dfs_test_hole_mgmt(void **state)
 	for (i = 0; i < NUM_SEGS; i++)
 		memset(rbuf[i], '-', buf_size + 100);
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	/** truncate file back to 0 */
 	if (arg->myrank == 0) {
 		rc = dfs_punch(dfs_mt, obj, 0, DFS_MAX_FSIZE);
 		assert_int_equal(rc, 0);
 	}
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	rc = dfs_ostat(dfs_mt, obj, &stbuf);
 	assert_int_equal(rc, 0);
 	assert_int_equal(stbuf.st_size, 0);
 
 	/** write strided 64 byte blocks */
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	if (arg->myrank == 0) {
 		char		*ptr = wbuf;
 		daos_off_t	off = 0;
@@ -590,7 +590,7 @@ dfs_test_hole_mgmt(void **state)
 			off += 64 * 2;
 		}
 	}
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	rc = dfs_ostat(dfs_mt, obj, &stbuf);
 	assert_int_equal(rc, 0);
@@ -631,7 +631,7 @@ dfs_test_hole_mgmt(void **state)
 	}
 
 	rc = dfs_release(obj);
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	if (arg->myrank == 0) {
 		rc = dfs_remove(dfs_mt, NULL, name, 0, NULL);
 		assert_int_equal(rc, 0);
@@ -660,9 +660,9 @@ dfs_test_cont_atomic(void **state)
 
 	op_rc = dfs_cont_create_with_label(arg->pool.poh, "dfs_par_test_cont",
 					   NULL, NULL, NULL, NULL);
-	rc = check_one_success(op_rc, EEXIST, MPI_COMM_WORLD);
+	rc = check_one_success(op_rc, EEXIST);
 	assert_int_equal(rc, 0);
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	if (arg->myrank == 0)
 		print_message("one rank Created POSIX Container dfs_par_test_cont\n");
@@ -678,13 +678,13 @@ dfs_test_cont_atomic(void **state)
 	rc = daos_cont_close(coh, NULL);
 	assert_int_equal(rc, 0);
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	if (arg->myrank == 0) {
 		rc = daos_cont_destroy(arg->pool.poh, "dfs_par_test_cont", 1, NULL);
 		assert_int_equal(rc, 0);
 		print_message("Destroyed POSIX Container dfs_par_test_cont\n");
 	}
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 }
 
 static void
@@ -700,7 +700,7 @@ file_atomicity_test_helper(test_arg_t *arg, int rf)
 	int		i;
 	int		rc;
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	if (arg->myrank == 0) {
 		dfs_attr_t attr = {};
 
@@ -719,13 +719,13 @@ file_atomicity_test_helper(test_arg_t *arg, int rf)
 	handle_share(&coh, HANDLE_CO, arg->myrank, arg->pool.poh, 0);
 	dfs_test_share(arg->pool.poh, coh, arg->myrank, &dfs);
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	/** all should succeed with the same file oid */
 	rc = dfs_open(dfs, NULL, filename, S_IFREG | S_IWUSR | S_IRUSR, O_RDWR | O_CREAT, 0, 0,
 		      NULL, &file);
 	assert_int_equal(rc, 0);
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	rc = dfs_obj2id(file, &oid1);
 	assert_int_equal(rc, 0);
@@ -737,8 +737,8 @@ file_atomicity_test_helper(test_arg_t *arg, int rf)
 		assert_non_null(oids_lo);
 	}
 
-	MPI_Gather(&oid1.hi, 1, MPI_UINT64_T, oids_hi, 1, MPI_UINT64_T, 0, MPI_COMM_WORLD);
-	MPI_Gather(&oid1.lo, 1, MPI_UINT64_T, oids_lo, 1, MPI_UINT64_T, 0, MPI_COMM_WORLD);
+	par_gather(&oid1.hi, oids_hi, 1, PAR_UINT64, 0);
+	par_gather(&oid1.lo, oids_lo, 1, PAR_UINT64, 0);
 
 	if (arg->myrank == 0) {
 		for (i = 0; i < arg->rank_size; i++) {
@@ -754,23 +754,23 @@ file_atomicity_test_helper(test_arg_t *arg, int rf)
 	rc = dfs_release(file);
 	assert_int_equal(rc, 0);
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	if (arg->myrank == 0) {
 		print_message("remove the file\n");
 		rc = dfs_remove(dfs, NULL, filename, true, NULL);
 		assert_int_equal(rc, 0);
 	}
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	if (arg->myrank == 0)
 		print_message("reopen the file with OCREAT from all ranks\n");
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	/** all should succeed with the same file oid */
 	rc = dfs_open(dfs, NULL, filename, S_IFREG | S_IWUSR | S_IRUSR, O_RDWR | O_CREAT, 0, 0,
 		      NULL, &file);
 	assert_int_equal(rc, 0);
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	rc = dfs_obj2id(file, &oid2);
 	assert_int_equal(rc, 0);
@@ -780,8 +780,8 @@ file_atomicity_test_helper(test_arg_t *arg, int rf)
 		assert_false(oid2.hi == oid1.hi && oid2.lo == oid1.lo);
 	}
 
-	MPI_Gather(&oid2.hi, 1, MPI_UINT64_T, oids_hi, 1, MPI_UINT64_T, 0, MPI_COMM_WORLD);
-	MPI_Gather(&oid2.lo, 1, MPI_UINT64_T, oids_lo, 1, MPI_UINT64_T, 0, MPI_COMM_WORLD);
+	par_gather(&oid2.hi, oids_hi, 1, PAR_UINT64, 0);
+	par_gather(&oid2.lo, oids_lo, 1, PAR_UINT64, 0);
 
 	if (arg->myrank == 0) {
 		for (i = 0; i < arg->rank_size; i++) {
@@ -801,20 +801,20 @@ file_atomicity_test_helper(test_arg_t *arg, int rf)
 		D_FREE(oids_lo);
 	}
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	if (arg->myrank == 0) {
 		print_message("remove the file\n");
 		rc = dfs_remove(dfs, NULL, filename, true, NULL);
 		assert_int_equal(rc, 0);
 	}
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	rc = dfs_umount(dfs);
 	assert_int_equal(rc, 0);
 	rc = daos_cont_close(coh, NULL);
 	assert_rc_equal(rc, 0);
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	if (arg->myrank == 0) {
 		char str[37];
 
@@ -824,7 +824,7 @@ file_atomicity_test_helper(test_arg_t *arg, int rf)
 		printf("Destroyed DFS Container "DF_UUIDF"\n",
 		       DP_UUID(cuuid));
 	}
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 }
 
 static void
@@ -902,7 +902,7 @@ dfs_teardown(void **state)
 	rc = daos_cont_close(co_hdl, NULL);
 	assert_rc_equal(rc, 0);
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	if (arg->myrank == 0) {
 		char	str[37];
 
@@ -912,7 +912,7 @@ dfs_teardown(void **state)
 		printf("Destroyed DFS Container "DF_UUIDF"\n",
 		       DP_UUID(co_uuid));
 	}
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	return test_teardown(state);
 }
@@ -922,10 +922,10 @@ run_dfs_par_test(int rank, int size)
 {
 	int rc = 0;
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	rc = cmocka_run_group_tests_name("DAOS_FileSystem_DFS_Parallel",
 					 dfs_par_tests, dfs_setup,
 					 dfs_teardown);
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	return rc;
 }

--- a/src/tests/suite/dfs_sys_unit_test.c
+++ b/src/tests/suite/dfs_sys_unit_test.c
@@ -771,7 +771,7 @@ dfs_sys_teardown(void **state)
 	rc = daos_cont_close(co_hdl, NULL);
 	assert_rc_equal(rc, 0);
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	if (arg->myrank == 0) {
 		char str[37];
 
@@ -781,7 +781,7 @@ dfs_sys_teardown(void **state)
 		print_message("Destroyed DFS Container "DF_UUIDF"\n",
 			      DP_UUID(co_uuid));
 	}
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	return test_teardown(state);
 }
@@ -791,10 +791,10 @@ run_dfs_sys_unit_test(int rank, int size)
 {
 	int rc = 0;
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	rc = cmocka_run_group_tests_name("DAOS_FileSystem_DFS_Sys_Unit",
 					 dfs_sys_unit_tests, dfs_sys_setup,
 					 dfs_sys_teardown);
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	return rc;
 }

--- a/src/tests/suite/dfs_test.c
+++ b/src/tests/suite/dfs_test.c
@@ -94,11 +94,11 @@ main(int argc, char **argv)
 
 	d_register_alt_assert(mock_assert);
 
-	MPI_Init(&argc, &argv);
+	par_init(&argc, &argv);
 
-	MPI_Comm_rank(MPI_COMM_WORLD, &rank);
-	MPI_Comm_size(MPI_COMM_WORLD, &size);
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_rank(&rank);
+	par_size(&size);
+	par_barrier();
 
 	static struct option long_options[] = {
 		{"all",		no_argument,		NULL,	'a'},
@@ -169,8 +169,7 @@ main(int argc, char **argv)
 	nr_failed = run_specified_tests(tests, rank, size, NULL, 0);
 
 exit:
-	MPI_Allreduce(&nr_failed, &nr_total_failed, 1, MPI_INT, MPI_SUM,
-		      MPI_COMM_WORLD);
+	par_allreduce(&nr_failed, &nr_total_failed, 1, PAR_INT, PAR_SUM);
 
 	rc = daos_fini();
 	if (rc)
@@ -185,7 +184,7 @@ exit:
 				      nr_total_failed);
 	}
 
-	MPI_Finalize();
+	par_fini();
 
 	return nr_failed;
 }

--- a/src/tests/suite/dfs_test.h
+++ b/src/tests/suite/dfs_test.h
@@ -33,8 +33,8 @@ dfs_test_share(daos_handle_t poh, daos_handle_t coh, int rank, dfs_t **dfs)
 	}
 
 	/** broadcast size of global handle to all peers */
-	rc = MPI_Bcast(&ghdl.iov_buf_len, 1, MPI_UINT64_T, 0, MPI_COMM_WORLD);
-	assert_int_equal(rc, MPI_SUCCESS);
+	rc = par_bcast(&ghdl.iov_buf_len, 1, PAR_UINT64, 0);
+	assert_int_equal(rc, 0);
 
 	/** allocate buffer for global pool handle */
 	D_ALLOC(ghdl.iov_buf, ghdl.iov_buf_len);
@@ -47,8 +47,8 @@ dfs_test_share(daos_handle_t poh, daos_handle_t coh, int rank, dfs_t **dfs)
 	}
 
 	/** broadcast global handle to all peers */
-	rc = MPI_Bcast(ghdl.iov_buf, ghdl.iov_len, MPI_BYTE, 0, MPI_COMM_WORLD);
-	assert_int_equal(rc, MPI_SUCCESS);
+	rc = par_bcast(ghdl.iov_buf, ghdl.iov_len, PAR_BYTE, 0);
+	assert_int_equal(rc, 0);
 
 	if (rank != 0) {
 		/** unpack global handle */
@@ -58,7 +58,7 @@ dfs_test_share(daos_handle_t poh, daos_handle_t coh, int rank, dfs_t **dfs)
 
 	D_FREE(ghdl.iov_buf);
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 }
 
 static inline void
@@ -75,8 +75,8 @@ dfs_sys_test_share(daos_handle_t poh, daos_handle_t coh, int rank, int sflags,
 	}
 
 	/** broadcast size of global handle to all peers */
-	rc = MPI_Bcast(&ghdl.iov_buf_len, 1, MPI_UINT64_T, 0, MPI_COMM_WORLD);
-	assert_int_equal(rc, MPI_SUCCESS);
+	rc = par_bcast(&ghdl.iov_buf_len, 1, PAR_UINT64, 0);
+	assert_int_equal(rc, 0);
 
 	/** allocate buffer for global pool handle */
 	D_ALLOC(ghdl.iov_buf, ghdl.iov_buf_len);
@@ -89,8 +89,8 @@ dfs_sys_test_share(daos_handle_t poh, daos_handle_t coh, int rank, int sflags,
 	}
 
 	/** broadcast global handle to all peers */
-	rc = MPI_Bcast(ghdl.iov_buf, ghdl.iov_len, MPI_BYTE, 0, MPI_COMM_WORLD);
-	assert_int_equal(rc, MPI_SUCCESS);
+	rc = par_bcast(ghdl.iov_buf, ghdl.iov_len, PAR_BYTE, 0);
+	assert_int_equal(rc, 0);
 
 	if (rank != 0) {
 		/** unpack global handle */
@@ -100,7 +100,7 @@ dfs_sys_test_share(daos_handle_t poh, daos_handle_t coh, int rank, int sflags,
 
 	D_FREE(ghdl.iov_buf);
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 }
 
 static inline void
@@ -116,8 +116,8 @@ dfs_test_obj_share(dfs_t *dfs, int flags, int rank, dfs_obj_t **obj)
 	}
 
 	/** broadcast size of global handle to all peers */
-	rc = MPI_Bcast(&ghdl.iov_buf_len, 1, MPI_UINT64_T, 0, MPI_COMM_WORLD);
-	assert_int_equal(rc, MPI_SUCCESS);
+	rc = par_bcast(&ghdl.iov_buf_len, 1, PAR_UINT64, 0);
+	assert_int_equal(rc, 0);
 
 	/** allocate buffer for global pool handle */
 	D_ALLOC(ghdl.iov_buf, ghdl.iov_buf_len);
@@ -130,8 +130,8 @@ dfs_test_obj_share(dfs_t *dfs, int flags, int rank, dfs_obj_t **obj)
 	}
 
 	/** broadcast global handle to all peers */
-	rc = MPI_Bcast(ghdl.iov_buf, ghdl.iov_len, MPI_BYTE, 0, MPI_COMM_WORLD);
-	assert_int_equal(rc, MPI_SUCCESS);
+	rc = par_bcast(ghdl.iov_buf, ghdl.iov_len, PAR_BYTE, 0);
+	assert_int_equal(rc, 0);
 
 	if (rank != 0) {
 		/** unpack global handle */
@@ -140,7 +140,7 @@ dfs_test_obj_share(dfs_t *dfs, int flags, int rank, dfs_obj_t **obj)
 	}
 
 	D_FREE(ghdl.iov_buf);
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 }
 
 #endif

--- a/src/tests/suite/dfs_unit_test.c
+++ b/src/tests/suite/dfs_unit_test.c
@@ -364,11 +364,11 @@ dfs_test_syml(void **state)
 	assert_int_equal(rc, 0);
 
 syml_stat:
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	rc = dfs_stat(dfs_mt, NULL, filename, &stbuf);
 	assert_int_equal(rc, 0);
 	assert_int_equal(stbuf.st_size, strlen(val));
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 }
 
 static void
@@ -652,7 +652,7 @@ dfs_test_read_shared_file(void **state)
 	int			i;
 	int			rc;
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	sprintf(name, "MTA_file_%d\n", arg->myrank);
 	rc = dfs_test_file_gen(name, chunk_size, file_size);
@@ -680,7 +680,7 @@ dfs_test_read_shared_file(void **state)
 	}
 
 	dfs_test_rm(name);
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 }
 
 static void
@@ -879,7 +879,7 @@ dfs_test_mt_mkdir(void **state)
 	int			i, one_success;
 	int			rc;
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	sprintf(name, "MTA_dir_%d\n", arg->myrank);
 
@@ -923,7 +923,7 @@ dfs_test_mt_mkdir(void **state)
 	assert_int_equal(one_success, 1);
 
 	dfs_test_rm(name);
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 }
 
 static void
@@ -1098,7 +1098,7 @@ dfs_teardown(void **state)
 	rc = daos_cont_close(co_hdl, NULL);
 	assert_rc_equal(rc, 0);
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	if (arg->myrank == 0) {
 		char str[37];
 
@@ -1108,7 +1108,7 @@ dfs_teardown(void **state)
 		print_message("Destroyed DFS Container "DF_UUIDF"\n",
 			      DP_UUID(co_uuid));
 	}
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	return test_teardown(state);
 }
@@ -1118,10 +1118,10 @@ run_dfs_unit_test(int rank, int size)
 {
 	int rc = 0;
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	rc = cmocka_run_group_tests_name("DAOS_FileSystem_DFS_Unit",
 					 dfs_unit_tests, dfs_setup,
 					 dfs_teardown);
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	return rc;
 }

--- a/src/tests/suite/io_conf/SConscript
+++ b/src/tests/suite/io_conf/SConscript
@@ -7,7 +7,7 @@ def scons():
 
     libraries = ['daos_common_pmem', 'daos', 'daos_tests', 'gurt', 'cart']
     libraries += ['uuid']
-    libraries += ['cmocka', 'json-c']
+    libraries += ['cmocka', 'json-c', 'dpar']
 
     Import('daos_test_tgt')
     Import('daos_epoch_io')

--- a/src/tests/suite/io_conf/daos_run_io_conf.c
+++ b/src/tests/suite/io_conf/daos_run_io_conf.c
@@ -31,7 +31,7 @@ main(int argc, char **argv)
 	void			*state = NULL;
 	int			rc;
 
-	MPI_Init(&argc, &argv);
+	par_init(&argc, &argv);
 	rc = daos_init();
 	if (rc) {
 		fprintf(stderr, "daos init failed: rc %d\n", rc);
@@ -84,7 +84,7 @@ main(int argc, char **argv)
 	}
 	arg->eio_args.op_no_verify = 1;	/* No verification for now */
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	rc = io_conf_run(arg, fname);
 	if (rc)
@@ -92,11 +92,11 @@ main(int argc, char **argv)
 
 	test_teardown(&state);
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 	fprintf(stdout, "daos_run_io_conf completed successfully\n");
 out_fini:
 	daos_fini();
 out_mpi:
-	MPI_Finalize();
+	par_fini();
 	return rc;
 }

--- a/src/tests/vos_perf.c
+++ b/src/tests/vos_perf.c
@@ -664,9 +664,9 @@ main(int argc, char **argv)
 	ts_dkey_prefix = PF_DKEY_PREF;
 	ts_flags = 0;
 
-	MPI_Init(&argc, &argv);
-	MPI_Comm_rank(MPI_COMM_WORLD, &ts_ctx.tsc_mpi_rank);
-	MPI_Comm_size(MPI_COMM_WORLD, &ts_ctx.tsc_mpi_size);
+	par_init(&argc, &argv);
+	par_rank(&ts_ctx.tsc_mpi_rank);
+	par_size(&ts_ctx.tsc_mpi_size);
 
 	rc = perf_alloc_opts(perf_vos_opts, ARRAY_SIZE(perf_vos_opts),
 			     perf_vos_optstr, &ts_opts, &ts_optstr);
@@ -752,7 +752,8 @@ main(int argc, char **argv)
 
 		snprintf(id, sizeof(id), "%d", ts_ctx.tsc_mpi_rank);
 		strncat(ts_pmem_file, id,
-			(sizeof(ts_pmem_file) - strlen(ts_pmem_file)));
+			(sizeof(ts_pmem_file) - strlen(ts_pmem_file) - 1));
+		ts_pmem_file[PATH_MAX - 1] = 0;
 	}
 	ts_ctx.tsc_pmem_file = ts_pmem_file;
 
@@ -840,7 +841,7 @@ main(int argc, char **argv)
 		return -1;
 	}
 
-	MPI_Barrier(MPI_COMM_WORLD);
+	par_barrier();
 
 	rc = run_commands(cmds, pf_tests);
 
@@ -852,7 +853,7 @@ main(int argc, char **argv)
 	stride_buf_fini();
 	dts_ctx_fini(&ts_ctx);
 
-	MPI_Finalize();
+	par_fini();
 
 	if (ts_uoids)
 		free(ts_uoids);

--- a/utils/rpms/daos.spec
+++ b/utils/rpms/daos.spec
@@ -14,7 +14,7 @@
 
 Name:          daos
 Version:       2.1.100
-Release:       7%{?relval}%{?dist}
+Release:       8%{?relval}%{?dist}
 Summary:       DAOS Storage Engine
 
 License:       BSD-2-Clause-Patent
@@ -205,7 +205,6 @@ This is the package needed to run a DAOS client
 %package tests
 Summary: The entire DAOS test suite
 Requires: %{name}-client-tests-openmpi%{?_isa} = %{version}-%{release}
-Requires: %{name}-server-tests-openmpi%{?_isa} = %{version}-%{release}
 
 %description tests
 This is the package is a metapackage to install all of the test packages
@@ -246,13 +245,6 @@ Requires: %{name}-server%{?_isa} = %{version}-%{release}
 
 %description server-tests
 This is the package needed to run the DAOS server test suite (server tests)
-
-%package server-tests-openmpi
-Summary: The DAOS server test suite - tools which need openmpi
-Requires: %{name}-server-tests%{?_isa} = %{version}-%{release}
-
-%description server-tests-openmpi
-This is the package needed to run the DAOS server test suite openmpi tools
 
 %package devel
 Summary: The DAOS development libraries and headers
@@ -470,15 +462,17 @@ getent passwd daos_agent >/dev/null || useradd -s /sbin/nologin -r -g daos_agent
 # For avocado tests
 %{_prefix}/lib/daos/.build_vars.json
 %{_prefix}/lib/daos/.build_vars.sh
-
-%files client-tests-openmpi
-%{_bindir}/crt_launch
 %{_bindir}/daos_perf
 %{_bindir}/daos_racer
 %{_bindir}/daos_test
 %{_bindir}/dfs_test
 %{_bindir}/jobtest
 %{_libdir}/libdts.so
+%{_libdir}/libdpar.so
+
+%files client-tests-openmpi
+%{_bindir}/crt_launch
+%{_libdir}/libdpar_mpi.so
 
 %files server-tests
 %{_bindir}/evt_ctl
@@ -491,8 +485,6 @@ getent passwd daos_agent >/dev/null || useradd -s /sbin/nologin -r -g daos_agent
 %{_bindir}/vea_ut
 %{_bindir}/vos_tests
 %{_bindir}/vea_stress
-
-%files server-tests-openmpi
 %{_bindir}/daos_gen_io_conf
 %{_bindir}/daos_run_io_conf
 %{_bindir}/obj_ctl
@@ -516,6 +508,9 @@ getent passwd daos_agent >/dev/null || useradd -s /sbin/nologin -r -g daos_agent
 # No files in a meta-package
 
 %changelog
+* Wed Nov 17 2021 Jeff Olivier <jeffrey.v.olivier@intel.com> 2.1.100-8
+- Remove direct MPI dependency from most of tests
+
 * Tue Nov 16 2021 Wang Shilong <shilong.wang@intel.com> 2.1.100-7
 - Update for libdaos major version bump
 - Fix version of libpemobj1 for SUSE


### PR DESCRIPTION
Link all daos test code with serial version.  Parallel version
can be loaded via LD_PRELOAD

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>