### PR TITLE
DAOS-9091 control: Prevent non-odd nsvc values in pool create

### DIFF
--- a/src/control/server/mgmt_pool.go
+++ b/src/control/server/mgmt_pool.go
@@ -316,7 +316,7 @@ func (svc *mgmtSvc) PoolCreate(ctx context.Context, req *mgmtpb.PoolCreateReq) (
 		if len(req.GetRanks()) < DefaultPoolServiceReps {
 			req.Numsvcreps = 1
 		}
-	} else if req.GetNumsvcreps() > maxSvcReps {
+	} else if req.GetNumsvcreps() > maxSvcReps || req.GetNumsvcreps()%2 == 0 {
 		return nil, FaultPoolInvalidServiceReps(maxSvcReps)
 	}
 

--- a/src/control/server/mgmt_pool_test.go
+++ b/src/control/server/mgmt_pool_test.go
@@ -402,6 +402,18 @@ func TestServer_MgmtSvc_PoolCreate(t *testing.T) {
 			},
 			expErr: FaultPoolInvalidServiceReps(uint32(MaxPoolServiceReps - 2)),
 		},
+		"svc replicas even number": {
+			targetCount: 1,
+			memberCount: MaxPoolServiceReps,
+			req: &mgmt.PoolCreateReq{
+				Uuid:       common.MockUUID(0),
+				Totalbytes: 100 * humanize.GByte,
+				Tierratio:  []float64{0.06, 0.94},
+				Numsvcreps: 2,
+				Properties: testPoolLabelProp(),
+			},
+			expErr: FaultPoolInvalidServiceReps(uint32(MaxPoolServiceReps)),
+		},
 		"no label": {
 			targetCount: 8,
 			req: &mgmtpb.PoolCreateReq{

--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -468,10 +468,7 @@ select_svc_ranks(int nreplicas, const d_rank_list_t *target_addrs,
 		return rc;
 
 	/* Shuffle the target ranks to avoid overloading any particular ranks. */
-	/*
-	 * DAOS-9177: Temporarily disable shuffle to give us more time to stabilize tests.
-	 */
-	/*daos_rank_list_shuffle(rnd_tgts);*/
+	daos_rank_list_shuffle(rnd_tgts);
 
 	/* Determine the number of selectable targets. */
 	selectable = rnd_tgts->rl_nr;

--- a/src/tests/ftest/daos_test/rebuild.py
+++ b/src/tests/ftest/daos_test/rebuild.py
@@ -226,7 +226,7 @@ class DaosCoreTestRebuild(DaosCoreBase):
         """Jira ID: DAOS-2770
 
         Test Description:
-            Run daos_test -r -s3 -u subtests=27
+            Run daos_test -r -s7 -u subtests=27
 
         Use cases:
             Core tests for daos_test rebuild

--- a/src/tests/ftest/daos_test/rebuild.yaml
+++ b/src/tests/ftest/daos_test/rebuild.yaml
@@ -108,7 +108,7 @@ daos_tests:
     test_rebuild_24: -s3 -u subtests="24"
     test_rebuild_25: -s3 -u subtests="25"
     test_rebuild_26: -s3 -u subtests="26"
-    test_rebuild_27: -s6 -u subtests="27"
+    test_rebuild_27: -s7 -u subtests="27"
     test_rebuild_28: -s3 -u subtests="28"
     test_rebuild_29: -s5 -u subtests="29"
   stopped_ranks:

--- a/src/tests/ftest/erasurecode/offline_rebuild.py
+++ b/src/tests/ftest/erasurecode/offline_rebuild.py
@@ -29,11 +29,14 @@ class EcodOfflineRebuild(ErasureCodeIor):
         :avocado: tags=ec_offline_rebuild_array
 
         """
+        # Get a set of ranks to kill
+        ranks_to_kill = self.pool.choose_rebuild_ranks(num_ranks=2)
+
         # Write IOR data set with different EC object and different sizes
         self.ior_write_dataset()
 
-        # Kill the last server rank
-        self.server_managers[0].stop_ranks([self.server_count - 1], self.d_log,
+        # Kill a server rank
+        self.server_managers[0].stop_ranks([ranks_to_kill[0]], self.d_log,
                                            force=True)
 
         # Wait for rebuild to complete
@@ -43,8 +46,8 @@ class EcodOfflineRebuild(ErasureCodeIor):
         # written before killing the single server
         self.ior_read_dataset()
 
-        # Kill the another server rank
-        self.server_managers[0].stop_ranks([self.server_count - 2], self.d_log,
+        # Kill another server rank
+        self.server_managers[0].stop_ranks([ranks_to_kill[1]], self.d_log,
                                            force=True)
 
         # Wait for rebuild to complete

--- a/src/tests/ftest/erasurecode/offline_rebuild_aggregation.py
+++ b/src/tests/ftest/erasurecode/offline_rebuild_aggregation.py
@@ -42,8 +42,11 @@ class EcodAggregationOffRebuild(ErasureCodeIor):
         # Read IOR data and verify content
         self.ior_read_dataset()
 
+        # Choose some ranks to kill
+        ranks_to_kill = self.pool.choose_rebuild_ranks(num_ranks=2)
+
         # Kill the last server rank
-        self.server_managers[0].stop_ranks([self.server_count - 1], self.d_log,
+        self.server_managers[0].stop_ranks([ranks_to_kill[0]], self.d_log,
                                            force=True)
 
         # Wait for rebuild to complete
@@ -54,7 +57,7 @@ class EcodAggregationOffRebuild(ErasureCodeIor):
         self.ior_read_dataset()
 
         # Kill the another server rank
-        self.server_managers[0].stop_ranks([self.server_count - 2], self.d_log,
+        self.server_managers[0].stop_ranks([ranks_to_kill[1]], self.d_log,
                                            force=True)
 
         # Wait for rebuild to complete
@@ -130,6 +133,9 @@ class EcodAggregationOffRebuild(ErasureCodeIor):
         :avocado: tags=ec,aggregation,ec_array,ec_aggregation
         :avocado: tags=ec_offline_agg_during_rebuild
         """
+        # Choose some ranks to kill
+        ranks_to_kill = self.pool.choose_rebuild_ranks(num_ranks=2)
+
         # Disable the aggregation
         self.pool.set_property("reclaim", "disabled")
         self.pool.connect()
@@ -144,9 +150,9 @@ class EcodAggregationOffRebuild(ErasureCodeIor):
         self.pool.set_property("reclaim", "time")
 
         # Aggregation will start in 20 seconds after it sets to time mode.
-        # So wait for 20 seconds and kill the last server rank
+        # So wait for 20 seconds and kill a server rank
         time.sleep(20)
-        self.server_managers[0].stop_ranks([self.server_count - 1], self.d_log,
+        self.server_managers[0].stop_ranks([ranks_to_kill[0]], self.d_log,
                                            force=True)
 
         # Verify if Aggregation is getting started
@@ -160,8 +166,8 @@ class EcodAggregationOffRebuild(ErasureCodeIor):
         # written before killing the single server
         self.ior_read_dataset()
 
-        # Kill the another server rank
-        self.server_managers[0].stop_ranks([self.server_count - 2], self.d_log,
+        # Kill another server rank
+        self.server_managers[0].stop_ranks([ranks_to_kill[1]], self.d_log,
                                            force=True)
 
         # Wait for rebuild to complete

--- a/src/tests/ftest/erasurecode/offline_rebuild_single.py
+++ b/src/tests/ftest/erasurecode/offline_rebuild_single.py
@@ -30,11 +30,14 @@ class EcodOfflineRebuildSingle(ErasureCodeSingle):
         :avocado: tags=ec_offline_rebuild_single
 
         """
+        # Get a set of ranks to kill
+        ranks_to_kill = self.pool.choose_rebuild_ranks(num_ranks=2)
+
         # Write single type data set with all the EC object type
         self.write_single_type_dataset()
 
-        # Kill the last server rank
-        self.server_managers[0].stop_ranks([self.server_count - 1], self.d_log,
+        # Kill a server rank
+        self.server_managers[0].stop_ranks([ranks_to_kill[0]], self.d_log,
                                            force=True)
 
         # Wait for rebuild to complete
@@ -43,8 +46,8 @@ class EcodOfflineRebuildSingle(ErasureCodeSingle):
         # Read data set and verify for different EC object for parity 1 and 2.
         self.read_single_type_dataset()
 
-        # Kill the another server rank
-        self.server_managers[0].stop_ranks([self.server_count - 2], self.d_log,
+        # Kill another server rank
+        self.server_managers[0].stop_ranks([ranks_to_kill[1]], self.d_log,
                                            force=True)
 
         # Wait for rebuild to complete

--- a/src/tests/ftest/erasurecode/online_rebuild.py
+++ b/src/tests/ftest/erasurecode/online_rebuild.py
@@ -33,8 +33,9 @@ class EcodOnlineRebuild(ErasureCodeIor):
         :avocado: tags=ec,ec_array,ec_online_rebuild,rebuild
         :avocado: tags=ec_online_rebuild_array
         """
-        # Kill last server rank
-        self.rank_to_kill = self.server_count - 1
+        # Choose some ranks to kill
+        ranks_to_kill = self.pool.choose_rebuild_ranks(num_ranks=2)
+        self.rank_to_kill = ranks_to_kill[0]
 
         # Run only object type which matches the server count and
         # remove other objects
@@ -57,7 +58,7 @@ class EcodOnlineRebuild(ErasureCodeIor):
         # Enabled Online rebuild during Read phase
         self.set_online_rebuild = True
         # Kill another server rank
-        self.rank_to_kill = self.server_count - 2
+        self.rank_to_kill = ranks_to_kill[1]
         # Read IOR data and verify for EC object again
         # EC data was written with +2 parity so after killing Two servers data
         # should be intact and no data corruption observed.

--- a/src/tests/ftest/erasurecode/online_rebuild_mdtest.py
+++ b/src/tests/ftest/erasurecode/online_rebuild_mdtest.py
@@ -36,8 +36,8 @@ class EcodOnlineRebuildMdtest(ErasureCodeMdtest):
         :avocado: tags=ec,ec_array,mdtest,ec_online_rebuild
         :avocado: tags=ec_online_rebuild_array,ec_online_rebuild_mdtest
         """
-        # Kill last server rank
-        self.rank_to_kill = self.server_count - 1
+        # Kill a non-svc rank
+        self.rank_to_kill = self.pool.choose_rebuild_ranks(num_ranks=1)[0]
 
         # Run only object type which matches the server count and
         # remove other objects

--- a/src/tests/ftest/erasurecode/online_rebuild_single.py
+++ b/src/tests/ftest/erasurecode/online_rebuild_single.py
@@ -36,8 +36,9 @@ class EcodOnlineRebuildSingle(ErasureCodeSingle):
         :avocado: tags=ec,ec_single,ec_online_rebuild,rebuild
         :avocado: tags=ec_online_rebuild_single
         """
-        # Kill last server rank
-        self.rank_to_kill = self.server_count - 1
+        # Get non-svc ranks to kill
+        ranks_to_kill = self.pool.choose_rebuild_ranks(num_ranks=2)
+        self.rank_to_kill = ranks_to_kill[0]
 
         # Run only object type which matches the server count and
         # remove other objects
@@ -59,7 +60,7 @@ class EcodOnlineRebuildSingle(ErasureCodeSingle):
         # Enabled Online rebuild during Read phase
         self.set_online_rebuild = True
         # Kill another server rank
-        self.rank_to_kill = self.server_count - 2
+        self.rank_to_kill = ranks_to_kill[1]
         # Read data and verify while another server being killed during read
         # EC data was written with +2 parity so after killing Two servers data
         # should be intact and no data corruption observed.

--- a/src/tests/ftest/erasurecode/rebuild_disabled.py
+++ b/src/tests/ftest/erasurecode/rebuild_disabled.py
@@ -29,6 +29,9 @@ class EcodDisabledRebuild(ErasureCodeIor):
         :avocado: tags=ec_disabled_rebuild_array
 
         """
+        # Choose some ranks to kill
+        ranks_to_kill = self.pool.choose_rebuild_ranks(num_ranks=2)
+
         # Disabled pool Rebuild
         self.pool.set_property("self_heal", "exclude")
         # self.pool.set_property("reclaim", "disabled")
@@ -40,9 +43,9 @@ class EcodDisabledRebuild(ErasureCodeIor):
         if not any(check_aggregation_status(self.pool).values()):
             self.fail("Aggregation failed to start..")
 
-        # Kill the last server rank and wait for 20 seconds, Rebuild is disabled
+        # Kill a server rank and wait for 20 seconds, Rebuild is disabled
         # so data should not be rebuild
-        self.server_managers[0].stop_ranks([self.server_count - 1], self.d_log,
+        self.server_managers[0].stop_ranks([ranks_to_kill[0]], self.d_log,
                                            force=True)
         time.sleep(20)
 
@@ -50,9 +53,9 @@ class EcodDisabledRebuild(ErasureCodeIor):
         # written before killing the single server
         self.ior_read_dataset()
 
-        # Kill the another server rank and wait for 20 seconds,Rebuild will
+        # Kill another server rank and wait for 20 seconds,Rebuild will
         # not happens because i's disabled.Read/verify data with Parity 2.
-        self.server_managers[0].stop_ranks([self.server_count - 2], self.d_log,
+        self.server_managers[0].stop_ranks([ranks_to_kill[1]], self.d_log,
                                            force=True)
         time.sleep(20)
 

--- a/src/tests/ftest/erasurecode/rebuild_disabled_single.py
+++ b/src/tests/ftest/erasurecode/rebuild_disabled_single.py
@@ -29,6 +29,9 @@ class EcodDisabledRebuildSingle(ErasureCodeSingle):
         :avocado: tags=ec_disabled_rebuild_single
 
         """
+        # Choose some ranks to kill
+        ranks_to_kill = self.pool.choose_rebuild_ranks(num_ranks=2)
+
         # Disabled pool Rebuild
         self.pool.set_property("self_heal", "exclude")
 
@@ -38,10 +41,10 @@ class EcodDisabledRebuildSingle(ErasureCodeSingle):
         # Read data set with given all the EC object type
         self.read_single_type_dataset()
 
-        # Kill the last server rank and wait for 20 seconds,
+        # Kill a server rank and wait for 20 seconds,
         # Rebuild is disabled so data will not be rebuild.
         self.server_managers[0].stop_ranks(
-            [self.server_count - 1], self.d_log, force=True)
+            [ranks_to_kill[0]], self.d_log, force=True)
         time.sleep(20)
 
         # Read data set and verify for different EC object for parity 1 and 2.
@@ -50,7 +53,7 @@ class EcodDisabledRebuildSingle(ErasureCodeSingle):
         # Kill another server rank and wait for 20 seconds,
         # Rebuild is disabled so data will not be rebuild.
         self.server_managers[0].stop_ranks(
-            [self.server_count - 2], self.d_log, force=True)
+            [ranks_to_kill[1]], self.d_log, force=True)
         time.sleep(20)
 
         # Read data set and verify for different EC object for 2 only.

--- a/src/tests/ftest/erasurecode/rebuild_fio.py
+++ b/src/tests/ftest/erasurecode/rebuild_fio.py
@@ -28,8 +28,9 @@ class EcodFioRebuild(ErasureCodeFio):
         Args:
             rebuild_mode: On-line or off-line rebuild mode
         """
-        # Kill last server rank first
-        self.rank_to_kill = self.server_count - 1
+        # Choose some ranks to kill
+        ranks_to_kill = self.pool.choose_rebuild_ranks(num_ranks=2)
+        self.rank_to_kill = ranks_to_kill[0]
 
         if 'on-line' in rebuild_mode:
             # Enabled on-line rebuild for the test
@@ -44,7 +45,7 @@ class EcodFioRebuild(ErasureCodeFio):
 
         if 'off-line' in rebuild_mode:
             self.server_managers[0].stop_ranks(
-                [self.server_count - 1], self.d_log, force=True)
+                [ranks_to_kill[0]], self.d_log, force=True)
 
         # Read and verify the original data.
         self.fio_cmd._jobs['test'].rw.value = self.read_option
@@ -54,7 +55,7 @@ class EcodFioRebuild(ErasureCodeFio):
         if int(self.container.properties.value.split(":")[1]) == 2:
             self.log.info("RF is 2,So kill another server and verify data")
             # Kill one more server rank
-            self.server_managers[0].stop_ranks([self.server_count - 2],
+            self.server_managers[0].stop_ranks([ranks_to_kill[1]],
                                                self.d_log, force=True)
             # Read and verify the original data.
             self.fio_cmd.run()

--- a/src/tests/ftest/ior/hard_rebuild.py
+++ b/src/tests/ftest/ior/hard_rebuild.py
@@ -37,8 +37,9 @@ class EcodIorHardRebuild(ErasureCodeIor):
         # This is IOR Hard so skip the warning messages
         self.fail_on_warning = False
 
-        # Kill last server rank
-        self.rank_to_kill = self.server_count - 1
+        # Choose some ranks to kill
+        ranks_to_kill = self.pool.choose_rebuild_ranks(num_ranks=2)
+        self.rank_to_kill = ranks_to_kill[0]
 
         # Run only object type which matches the server count and remove other objects
         tmp_obj_class = []
@@ -63,7 +64,7 @@ class EcodIorHardRebuild(ErasureCodeIor):
         # Enabled Online rebuild during Read phase
         self.set_online_rebuild = True
         # Kill another server rank
-        self.rank_to_kill = self.server_count - 2
+        self.rank_to_kill = ranks_to_kill[1]
         # Read IOR data and verify for EC object again EC data was written with +2 parity so after
         # killing Two servers data should be intact and no data corruption observed.
         self.ior_read_dataset(parity=2)

--- a/src/tests/ftest/nvme/pool_exclude.yaml
+++ b/src/tests/ftest/nvme/pool_exclude.yaml
@@ -49,7 +49,7 @@ pool:
   name: daos_server
   scm_size: 50000000000
   nvme_size: 300000000000
-  svcn: 4
+  svcn: 3
   control_method: dmg
   rebuild_timeout: 120
   pool_query_timeout: 30

--- a/src/tests/ftest/nvme/pool_extend.yaml
+++ b/src/tests/ftest/nvme/pool_extend.yaml
@@ -48,7 +48,7 @@ pool:
   name: daos_server
   scm_size: 5000000000
   nvme_size: 30000000000
-  svcn: 4
+  svcn: 3
   control_method: dmg
   rebuild_timeout: 120
   pool_query_timeout: 30

--- a/src/tests/ftest/osa/dmg_negative_test.yaml
+++ b/src/tests/ftest/osa/dmg_negative_test.yaml
@@ -49,7 +49,7 @@ pool:
   name: daos_server
   scm_size: 6000000000
   nvme_size: 54000000000
-  svcn: 4
+  svcn: 3
   control_method: dmg
 container:
   properties:

--- a/src/tests/ftest/osa/offline_drain.yaml
+++ b/src/tests/ftest/osa/offline_drain.yaml
@@ -47,7 +47,7 @@ pool:
     name: daos_server
     scm_size: 12000000000
     nvme_size: 108000000000
-    svcn: 4
+    svcn: 3
     control_method: dmg
     rebuild_timeout: 240
 container:

--- a/src/tests/ftest/osa/offline_extend.yaml
+++ b/src/tests/ftest/osa/offline_extend.yaml
@@ -48,7 +48,7 @@ pool:
   name: daos_server
   scm_size: 6000000000
   nvme_size: 54000000000
-  svcn: 4
+  svcn: 3
   control_method: dmg
 container:
   type: POSIX

--- a/src/tests/ftest/osa/offline_parallel_test.yaml
+++ b/src/tests/ftest/osa/offline_parallel_test.yaml
@@ -49,7 +49,7 @@ pool:
   name: daos_server
   scm_size: 6000000000
   nvme_size: 54000000000
-  svcn: 4
+  svcn: 3
   control_method: dmg
 container:
   type: POSIX

--- a/src/tests/ftest/osa/offline_reintegration.yaml
+++ b/src/tests/ftest/osa/offline_reintegration.yaml
@@ -55,7 +55,7 @@ pool:
   name: daos_server
   scm_size: 6000000000
   nvme_size: 54000000000
-  svcn: 4
+  svcn: 3
   control_method: dmg
   rebuild_timeout: 240
   pool_query_timeout: 30

--- a/src/tests/ftest/osa/online_drain.yaml
+++ b/src/tests/ftest/osa/online_drain.yaml
@@ -48,7 +48,7 @@ pool:
   name: daos_server
   scm_size: 12000000000
   nvme_size: 108000000000
-  svcn: 4
+  svcn: 3
   control_method: dmg
   rebuild_timeout: 120
   pool_query_timeout: 30

--- a/src/tests/ftest/osa/online_extend.yaml
+++ b/src/tests/ftest/osa/online_extend.yaml
@@ -52,7 +52,7 @@ pool:
   name: daos_server
   scm_size: 12000000000
   nvme_size: 108000000000
-  svcn: 4
+  svcn: 3
   control_method: dmg
   rebuild_timeout: 120
   pool_query_timeout: 30

--- a/src/tests/ftest/osa/online_parallel_test.yaml
+++ b/src/tests/ftest/osa/online_parallel_test.yaml
@@ -44,7 +44,7 @@ pool:
   name: daos_server
   scm_size: 12000000000
   nvme_size: 108000000000
-  svcn: 4
+  svcn: 3
   control_method: dmg
 container:
   type: POSIX

--- a/src/tests/ftest/osa/online_reintegration.yaml
+++ b/src/tests/ftest/osa/online_reintegration.yaml
@@ -46,7 +46,7 @@ pool:
   name: daos_server
   scm_size: 12000000000
   nvme_size: 108000000000
-  svcn: 4
+  svcn: 3
   control_method: dmg
   rebuild_timeout: 120
   pool_query_timeout: 30

--- a/src/tests/ftest/pool/destroy_rebuild.py
+++ b/src/tests/ftest/pool/destroy_rebuild.py
@@ -5,6 +5,7 @@
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
 from apricot import TestWithServers
+from general_utils import convert_list
 
 
 class DestroyRebuild(TestWithServers):
@@ -15,9 +16,6 @@ class DestroyRebuild(TestWithServers):
 
     :avocado: recursive
     """
-
-    # also remove the commented line form yaml file for rank 0
-    CANCEL_FOR_TICKET = [["DAOS-4891", "rank_to_kill", "[0]"]]
 
     def test_destroy_while_rebuilding(self):
         """Jira ID: DAOS-xxxx.
@@ -35,10 +33,12 @@ class DestroyRebuild(TestWithServers):
         """
         # Get the test parameters
         targets = self.params.get("targets", "/run/server_config/servers/*")
-        ranks = self.params.get("rank_to_kill", "/run/testparams/*")
 
         # Create a pool
         self.add_pool()
+
+        # kill 2 ranks, including 1 svc rank
+        ranks = self.pool.choose_rebuild_ranks(num_ranks=2, num_svc=1)
 
         # Verify the pool information before starting rebuild
         checks = {
@@ -58,5 +58,5 @@ class DestroyRebuild(TestWithServers):
         self.pool.destroy()
 
         self.log.info("Test Passed")
-        self.get_dmg_command().system_start(",".join(ranks))
-        self.server_managers[0].update_expected_states(",".join(ranks), ["joined"])
+        self.get_dmg_command().system_start(convert_list(ranks))
+        self.server_managers[0].update_expected_states(ranks, ["joined"])

--- a/src/tests/ftest/pool/destroy_rebuild.yaml
+++ b/src/tests/ftest/pool/destroy_rebuild.yaml
@@ -21,8 +21,3 @@ pool:
   scm_size: 134217728
   control_method: dmg
   pool_query_timeout: 30
-testparams:
-  rank_to_kill:
-#    - 0    Skipped until DAOS-4891 is resolved
-    - "1"
-    - "4"

--- a/src/tests/ftest/rebuild/cascading_failures.yaml
+++ b/src/tests/ftest/rebuild/cascading_failures.yaml
@@ -17,7 +17,7 @@ pool:
   mode: 511
   name: daos_server
   scm_size: 1073741824
-  svcn: 2
+  svcn: 3
   control_method: dmg
   pool_query_timeout: 30
 container:

--- a/src/tests/ftest/rebuild/container_create_race.py
+++ b/src/tests/ftest/rebuild/container_create_race.py
@@ -18,15 +18,15 @@ class RbldContainerCreate(IorTestBase):
     :avocado: recursive
     """
 
-    def add_containers_during_rebuild(self, qty=10, index=-1):
+    def add_containers_during_rebuild(self, rank, qty=10, index=-1):
         """Add containers to a pool while rebuild is still in progress.
         Args:
+            rank (int): rank to write objects to
             qty (int, optional): the number of containers to create
             index (int, optional): the container index to perform write
                 during rebuild
 
         """
-        rank = self.params.get("rank_to_kill", "/run/testparams/*")
         object_qty = self.params.get("object_qty", "/run/io/*")
         record_qty = self.params.get("record_qty", "/run/io/*")
         data_size = self.params.get("data_size", "/run/io/*")
@@ -96,13 +96,15 @@ class RbldContainerCreate(IorTestBase):
         """
         # set params
         targets = self.params.get("targets", "/run/server_config/*")
-        rank = self.params.get("rank_to_kill", "/run/testparams/*")
         ior_loop = self.params.get("ior_test_loop", "/run/ior/*")
         cont_qty = self.params.get("cont_qty", "/run/io/*")
         node_qty = len(self.hostlist_servers)
 
         # create pool
         self.create_pool()
+
+        # choose a rank to kill
+        rank = self.pool.choose_rebuild_ranks(num_ranks=1)[0]
 
         # make sure pool looks good before we start
         info_checks = {
@@ -141,7 +143,7 @@ class RbldContainerCreate(IorTestBase):
 
         # Race condition, create containers write and read during rebuild.
         self.log.info("..(4)Create containers, write/read during rebuild")
-        self.add_containers_during_rebuild(qty=cont_qty)
+        self.add_containers_during_rebuild(rank, qty=cont_qty)
         self.access_container()
 
         # Wait for rebuild to complete.

--- a/src/tests/ftest/rebuild/container_create_race.yaml
+++ b/src/tests/ftest/rebuild/container_create_race.yaml
@@ -13,9 +13,6 @@ server_config:
   name: daos_server
   servers:
     targets: 2
-testparams:
-  ranks:
-    rank_to_kill: 3
 pool:
   mode: 146
   name: daos_server

--- a/src/tests/ftest/rebuild/delete_objects.yaml
+++ b/src/tests/ftest/rebuild/delete_objects.yaml
@@ -17,7 +17,7 @@ pool:
   mode: 511
   name: daos_server
   scm_size: 1073741824
-  svcn: 2
+  svcn: 3
   debug: True
   control_method: dmg
   pool_query_timeout: 30

--- a/src/tests/ftest/rebuild/no_cap.py
+++ b/src/tests/ftest/rebuild/no_cap.py
@@ -48,7 +48,6 @@ class RbldNoCapacity(TestWithServers):
         """
         # Get the test params
         targets = self.params.get("targets", "/run/server_config/*/0/*")
-        rank = self.params.get("rank_to_kill", "/run/rebuild/*")
         engines_per_host = self.params.get("engines_per_host",
                                            "/run/server_config/*")
         pool_query_timeout = self.params.get('pool_query_timeout', "/run/pool/*")
@@ -61,6 +60,8 @@ class RbldNoCapacity(TestWithServers):
         self.prepare_pool()
         self.add_container(self.pool)
         self.container.open()
+
+        rank = self.pool.choose_rebuild_ranks(num_ranks=1)[0]
 
         # make sure pool looks good before we start
         self.log.info("..(1)Check for pool and rebuild info ")
@@ -127,7 +128,6 @@ class RbldNoCapacity(TestWithServers):
             "..Pool %s query data: %s\n", self.pool.uuid, self.pool.query_data)
 
         # Start rebuild
-        rank = 1
         self.log.info("..(5)Stop rank for rebuild")
         self.server_managers[0].stop_ranks([rank], self.d_log, force=True)
 

--- a/src/tests/ftest/rebuild/no_cap.yaml
+++ b/src/tests/ftest/rebuild/no_cap.yaml
@@ -47,5 +47,3 @@ pool:
   pool_query_interval: 1
   test_data_list: [1048576]
   oclass: "OC_RP_2G1"
-rebuild:
-  rank_to_kill: 1

--- a/src/tests/ftest/rebuild/pool_destroy_race.py
+++ b/src/tests/ftest/rebuild/pool_destroy_race.py
@@ -40,12 +40,14 @@ class RbldPoolDestroyWithIO(IorTestBase):
         """
         # set params
         targets = self.params.get("targets", "/run/server_config/*/0/*")
-        rank = self.params.get("rank_to_kill", "/run/testparams/*")
         engines_per_host = self.params.get("engines_per_host",
                                            "/run/server_config/*")
 
         # create pool
         self.create_pool()
+
+        # get a rank to kill
+        rank = self.pool.choose_rebuild_ranks(num_ranks=1)[0]
 
         # make sure pool looks good before we start
         checks = {

--- a/src/tests/ftest/rebuild/pool_destroy_race.yaml
+++ b/src/tests/ftest/rebuild/pool_destroy_race.yaml
@@ -35,9 +35,6 @@ server_config:
       scm_class: dcpm
       scm_list: ["/dev/pmem1"]
       scm_mount: /mnt/daos1
-testparams:
-  ranks:
-    rank_to_kill: 3
 pool:
   mode: 146
   name: daos_server

--- a/src/tests/ftest/rebuild/read_array.yaml
+++ b/src/tests/ftest/rebuild/read_array.yaml
@@ -19,7 +19,7 @@ pool:
   mode: 511
   name: daos_server
   scm_size: 1073741824
-  svcn: 2
+  svcn: 3
   control_method: dmg
   pool_query_timeout: 30
 container:

--- a/src/tests/ftest/rebuild/widely_striped.py
+++ b/src/tests/ftest/rebuild/widely_striped.py
@@ -51,11 +51,13 @@ class RbldWidelyStriped(MdtestBase):
         """
         # set params
         targets = self.params.get("targets", "/run/server_config/*")
-        rank = self.params.get("rank_to_kill", "/run/testparams/*")
         self.dmg = self.get_dmg_command()
 
         # create pool
         self.add_pool(connect=False)
+
+        # choose 4 ranks
+        ranks = self.pool.choose_rebuild_ranks(num_ranks=4)
 
         # make sure pool looks good before we start
         checks = {
@@ -77,8 +79,8 @@ class RbldWidelyStriped(MdtestBase):
         self.add_container(self.pool)
         # start 1st mdtest run and let it complete
         self.execute_mdtest()
-        # Kill rank[6] and wait for rebuild to complete
-        self.server_managers[0].stop_ranks([rank[0]], self.d_log, force=True)
+        # Kill a rank and wait for rebuild to complete
+        self.server_managers[0].stop_ranks([ranks[0]], self.d_log, force=True)
         self.pool.wait_for_rebuild(False, interval=1)
 
         # create 2nd container
@@ -88,9 +90,9 @@ class RbldWidelyStriped(MdtestBase):
         thread.start()
         time.sleep(3)
 
-        # Kill rank[5] in the middle of mdtest run and
+        # Kill another rank in the middle of mdtest run and
         # wait for rebuild to complete
-        self.server_managers[0].stop_ranks([rank[1]], self.d_log, force=True)
+        self.server_managers[0].stop_ranks([ranks[1]], self.d_log, force=True)
         self.pool.wait_for_rebuild(False, interval=1)
         # wait for mdtest to complete
         thread.join()
@@ -103,8 +105,8 @@ class RbldWidelyStriped(MdtestBase):
         thread.start()
         time.sleep(3)
 
-        # Kill 2 server ranks [3,4]
-        self.server_managers[0].stop_ranks(rank[2], self.d_log, force=True)
+        # Kill 2 more ranks
+        self.server_managers[0].stop_ranks(ranks[2:3], self.d_log, force=True)
         self.pool.wait_for_rebuild(False, interval=1)
         # wait for mdtest to complete
         thread.join()

--- a/src/tests/ftest/rebuild/widely_striped.yaml
+++ b/src/tests/ftest/rebuild/widely_striped.yaml
@@ -20,12 +20,6 @@ server_config:
     bdev_list: ["0000:81:00.0","0000:da:00.0"]
     scm_class: dcpm
     scm_list: ["/dev/pmem0"]
-testparams:
-  ranks:
-    rank_to_kill:
-      - 6
-      - 5
-      - [3,4]
 pool:
   mode: 146
   name: daos_server

--- a/src/tests/ftest/rebuild/with_ior.py
+++ b/src/tests/ftest/rebuild/with_ior.py
@@ -46,11 +46,12 @@ class RbldWithIOR(IorTestBase):
                                         "/run/ior/transfer_blk_size_rebld/*")
         block_size = self.params.get("block_size",
                                      "/run/ior/transfer_blk_size_rebld/*")
-        rank = self.params.get("rank_to_kill",
-                               "/run/ior/transfer_blk_size_rebld/*")
 
         # create pool
         self.create_pool()
+
+        # choose a non-svc rank to kill
+        rank = self.pool.choose_rebuild_ranks(num_ranks=1)[0]
 
         # make sure pool looks good before we start
         checks = {

--- a/src/tests/ftest/rebuild/with_ior.yaml
+++ b/src/tests/ftest/rebuild/with_ior.yaml
@@ -40,6 +40,5 @@ ior:
         write_flg: "-C -k -e -w -g -G 27 -D 300 -Q 1 -vv"
         read_flg: "-C -k -e -r -R -g -G 27 -D 300 -Q 1 -vv"
     transfer_blk_size_rebld:
-        rank_to_kill: 3
         transfer_size: '1M'
         block_size: '64M'

--- a/src/tests/ftest/util/test_utils_pool.py
+++ b/src/tests/ftest/util/test_utils_pool.py
@@ -8,6 +8,7 @@ import os
 from time import sleep, time
 import ctypes
 import json
+import random
 
 from test_utils_base import TestDaosApiBase
 from avocado import fail_on
@@ -78,6 +79,7 @@ class TestPool(TestDaosApiBase):
         self.pool = None
         self.info = None
         self.svc_ranks = None
+        self.tgt_ranks = None
         self.connected = False
         # Flag to allow the non-create operations to use UUID. e.g., if you want
         # to destroy the pool with UUID, set this to False, then call destroy().
@@ -274,6 +276,10 @@ class TestPool(TestDaosApiBase):
                 int(self.pool.svc.rl_ranks[index])
                 for index in range(self.pool.svc.rl_nr)]
 
+            # Set the storage (target) ranks.
+            self.tgt_ranks = [int(v) for v in data["ranks"].split(",")]
+
+
     @fail_on(DaosApiError)
     def connect(self, permission=2):
         """Connect to the pool.
@@ -343,6 +349,7 @@ class TestPool(TestDaosApiBase):
             self.pool = None
             self.info = None
             self.svc_ranks = None
+            self.tgt_ranks = None
 
         return status
 
@@ -461,6 +468,102 @@ class TestPool(TestDaosApiBase):
             for key, val in list(locals().items())
             if key != "self" and val is not None]
         return self._check_info(checks)
+
+    def choose_rebuild_ranks(self, num_ranks, num_svc=0, max_svc=1, shuffle=True,
+                             skip_ms_rank=True):
+        """Choose a list of ranks to kill for rebuild tests.
+
+        The list of ranks to be killed will be chosen based on a set
+        of criteria defined by the current state of the product code.
+        The goal is to choose "safe" ranks in order to avoid killing
+        too many svc ranks, non-resilient MS ranks, or other problems
+        that are likely to result in intermittent test failures.
+
+        Args:
+            num_ranks (int): the total number of ranks to be chosen
+            num_svc (int, optional): the explicit number of pool service ranks to kill
+            max_svc (int, optional): the allowed number of pool service ranks to kill
+            shuffle (bool, optional): whether to shuffle the storage ranks before choosing
+            skip_ms_rank (bool, optional): avoid the MS rank (DAOS-4891)
+
+        Returns:
+            list: list of ranks to be killed
+        """
+        svc_ranks = {s:True for s in self.svc_ranks}
+        tgt_ranks = self.tgt_ranks.copy()
+        to_kill = {}
+
+        # If there is only 1 svc rank and the test has not
+        # explicitly requested to kill it, then don't allow it
+        # to be chosen.
+        if len(svc_ranks) == 1 and num_svc == 0:
+            max_svc = 0
+
+        # If the test has made an explicit request to kill some number
+        # of service ranks, set that value as the ceiling.
+        if num_svc > max_svc:
+            max_svc = num_svc
+
+        if skip_ms_rank:
+            # Avoid the MS rank (DAOS-4891)
+            tgt_ranks.remove(0)
+
+        if num_svc > len(svc_ranks):
+            raise DaosTestError("num_svc > svc_ranks ({} < {})".format(num_svc, len(svc_ranks)))
+
+        if num_ranks > len(tgt_ranks):
+            raise DaosTestError("num_ranks > tgt_ranks ({} < {})".format(num_ranks, len(tgt_ranks)))
+
+        if shuffle:
+            random.shuffle(tgt_ranks)
+
+        svc_chosen = 0
+        passes = 0
+        while len(to_kill) < num_ranks and passes < 2:
+            for tr in tgt_ranks:
+                if tr in to_kill:
+                    continue
+
+                if tr in svc_ranks:
+                    # skip if we already have enough svc ranks
+                    if svc_chosen == max_svc:
+                        continue
+                    svc_chosen += 1
+                elif svc_chosen < num_svc:
+                    # skip until we find another svc rank
+                    continue
+
+                to_kill[tr] = True
+
+                if len(to_kill) == num_ranks:
+                    break
+            passes += 1
+
+        if len(to_kill) < num_ranks:
+            raise DaosTestError(
+                "Not enough non-svc ranks! (num_ranks: {}, max_svc: {})".format(num_ranks, max_svc)
+            )
+
+        self.log.debug("ranks to kill: %s", to_kill.keys())
+        return list(to_kill.keys())
+
+    def get_storage_ranks(self, exclude_svc_ranks=True):
+        """Get the list of storage ranks for the pool.
+
+        By default, the pool service ranks are excluded from the result, if
+        there are more storage-only ranks than storage+service ranks.
+
+        Args:
+            exclude_svc_ranks (bool, optional): exclude service ranks, if possible.
+
+        Returns:
+            list: list of storage ranks
+        """
+        if not exclude_svc_ranks or len(self.svc_ranks) >= len(self.tgt_ranks):
+            return self.tgt_ranks
+
+        svc_ranks = {s:True for s in self.svc_ranks}
+        return [t for t in self.tgt_ranks if t not in svc_ranks]
 
     def check_pool_space(self, ps_free_min=None, ps_free_max=None,
                          ps_free_mean=None, ps_ntargets=None, ps_padding=None):

--- a/src/tests/suite/daos_rebuild.c
+++ b/src/tests/suite/daos_rebuild.c
@@ -1162,10 +1162,10 @@ rebuild_fail_all_replicas(void **state)
 	int		i;
 
 	/* This test will kill 3 replicas, which might include the ranks
-	 * in svcs, so make sure there are at least 6 ranks in svc, so
+	 * in svcs, so make sure there are at least 7 ranks in svc, so
 	 * the new leader can be chosen.
 	 */
-	if (!test_runable(arg, 6) || arg->pool.alive_svc->rl_nr < 6) {
+	if (!test_runable(arg, 7) || arg->pool.alive_svc->rl_nr < 7) {
 		print_message("need at least 6 svcs, -s6\n");
 		return;
 	}


### PR DESCRIPTION
The Raft consensus protocol does not strictly require an odd number
of replicas, but as fault tolerance is defined by the formula (2N + 1),
where the required majority will always be an odd number, best
practices dictate that the configured replica set should have an
odd number of members.

Includes a number of test updates to reflect the changed requirements,
and introduces a new test helper to choose ranks to kill based on
test requirements and current product capabilities. This test helper
will centralize knowledge about which ranks are safe to kill in order
to achieve the test's goals rather than allowing tests to make naive
choices.

Test-tag: pr rebuild osa nvme

Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com>
