### PR TITLE
DAOS-8901 pool: Randomize distribution of pool svc ranks

### DIFF
--- a/src/control/server/mgmt_pool.go
+++ b/src/control/server/mgmt_pool.go
@@ -316,7 +316,7 @@ func (svc *mgmtSvc) PoolCreate(ctx context.Context, req *mgmtpb.PoolCreateReq) (
 		if len(req.GetRanks()) < DefaultPoolServiceReps {
 			req.Numsvcreps = 1
 		}
-	} else if req.GetNumsvcreps() > maxSvcReps {
+	} else if req.GetNumsvcreps() > maxSvcReps || req.GetNumsvcreps()%2 == 0 {
 		return nil, FaultPoolInvalidServiceReps(maxSvcReps)
 	}
 

--- a/src/control/server/mgmt_pool_test.go
+++ b/src/control/server/mgmt_pool_test.go
@@ -402,6 +402,18 @@ func TestServer_MgmtSvc_PoolCreate(t *testing.T) {
 			},
 			expErr: FaultPoolInvalidServiceReps(uint32(MaxPoolServiceReps - 2)),
 		},
+		"svc replicas even number": {
+			targetCount: 1,
+			memberCount: MaxPoolServiceReps,
+			req: &mgmt.PoolCreateReq{
+				Uuid:       common.MockUUID(0),
+				Totalbytes: 100 * humanize.GByte,
+				Tierratio:  []float64{0.06, 0.94},
+				Numsvcreps: 2,
+				Properties: testPoolLabelProp(),
+			},
+			expErr: FaultPoolInvalidServiceReps(uint32(MaxPoolServiceReps)),
+		},
 		"no label": {
 			targetCount: 8,
 			req: &mgmtpb.PoolCreateReq{

--- a/src/gurt/misc.c
+++ b/src/gurt/misc.c
@@ -308,6 +308,23 @@ d_rank_list_sort(d_rank_list_t *rank_list)
 	      sizeof(d_rank_t), rank_compare);
 }
 
+void
+d_rank_list_shuffle(d_rank_list_t *rank_list)
+{
+	uint32_t	i, j;
+	d_rank_t	tmp;
+
+	if (rank_list == NULL)
+		return;
+
+	for (i = 0; i < rank_list->rl_nr; i++) {
+		j = rand() % rank_list->rl_nr;
+		tmp = rank_list->rl_ranks[i];
+		rank_list->rl_ranks[i] = rank_list->rl_ranks[j];
+		rank_list->rl_ranks[j] = tmp;
+	}
+}
+
 /**
  * Must be previously sorted or not modified at all in order to guarantee
  * consistent indexes.

--- a/src/include/daos/common.h
+++ b/src/include/daos/common.h
@@ -613,6 +613,7 @@ daos_crt_network_error(int err)
 #define daos_rank_list_filter		d_rank_list_filter
 #define daos_rank_list_alloc		d_rank_list_alloc
 #define daos_rank_list_copy		d_rank_list_copy
+#define daos_rank_list_shuffle		d_rank_list_shuffle
 #define daos_rank_list_sort		d_rank_list_sort
 #define daos_rank_list_find		d_rank_list_find
 #define daos_rank_list_identical	d_rank_list_identical

--- a/src/include/gurt/common.h
+++ b/src/include/gurt/common.h
@@ -383,6 +383,7 @@ d_rank_list_t *d_rank_list_alloc(uint32_t size);
 d_rank_list_t *d_rank_list_realloc(d_rank_list_t *ptr, uint32_t size);
 void d_rank_list_free(d_rank_list_t *rank_list);
 int d_rank_list_copy(d_rank_list_t *dst, d_rank_list_t *src);
+void d_rank_list_shuffle(d_rank_list_t *rank_list);
 void d_rank_list_sort(d_rank_list_t *rank_list);
 bool d_rank_list_find(d_rank_list_t *rank_list, d_rank_t rank, int *idx);
 int d_rank_list_del(d_rank_list_t *rank_list, d_rank_t rank);

--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -452,16 +452,25 @@ select_svc_ranks(int nreplicas, const d_rank_list_t *target_addrs,
 {
 	int			i_rank_zero = -1;
 	int			selectable;
+	d_rank_list_t		*rnd_tgts;
 	d_rank_list_t		*ranks;
 	int			i;
 	int			j;
+	int			rc;
 
 	if (nreplicas <= 0)
 		return -DER_INVAL;
 
+	rc = d_rank_list_dup(&rnd_tgts, target_addrs);
+	if (rc != 0)
+		return rc;
+
+	/* Shuffle the target ranks to avoid overloading any particular ranks. */
+	daos_rank_list_shuffle(rnd_tgts);
+
 	/* Determine the number of selectable targets. */
-	selectable = target_addrs->rl_nr;
-	if (daos_rank_list_find((d_rank_list_t *)target_addrs, 0 /* rank */,
+	selectable = rnd_tgts->rl_nr;
+	if (daos_rank_list_find((d_rank_list_t *)rnd_tgts, 0 /* rank */,
 				&i_rank_zero)) {
 		/*
 		 * Unless it is the only target available, we don't select rank
@@ -475,24 +484,28 @@ select_svc_ranks(int nreplicas, const d_rank_list_t *target_addrs,
 		nreplicas = selectable;
 	ranks = daos_rank_list_alloc(nreplicas);
 	if (ranks == NULL)
-		return -DER_NOMEM;
+		D_GOTO(out, rc = -DER_NOMEM);
 
 	/* TODO: Choose ranks according to failure domains. */
 	j = 0;
-	for (i = 0; i < target_addrs->rl_nr; i++) {
+	for (i = 0; i < rnd_tgts->rl_nr; i++) {
 		if (j == ranks->rl_nr)
 			break;
 		if (i == i_rank_zero && selectable > 1)
 			/* This is rank 0 and it's not the only rank. */
 			continue;
-		D_DEBUG(DB_MD, "ranks[%d]: %u\n", j, target_addrs->rl_ranks[i]);
-		ranks->rl_ranks[j] = target_addrs->rl_ranks[i];
+		D_DEBUG(DB_MD, "ranks[%d]: %u\n", j, rnd_tgts->rl_ranks[i]);
+		ranks->rl_ranks[j] = rnd_tgts->rl_ranks[i];
 		j++;
 	}
 	D_ASSERTF(j == ranks->rl_nr, "%d == %u\n", j, ranks->rl_nr);
 
 	*ranksp = ranks;
-	return 0;
+	rc = 0;
+
+out:
+	d_rank_list_free(rnd_tgts);
+	return rc;
 }
 
 /* TODO: replace all rsvc_complete_rpc() calls in this file with pool_rsvc_complete_rpc() */

--- a/src/tests/ftest/nvme/pool_exclude.yaml
+++ b/src/tests/ftest/nvme/pool_exclude.yaml
@@ -49,7 +49,7 @@ pool:
   name: daos_server
   scm_size: 50000000000
   nvme_size: 300000000000
-  svcn: 4
+  svcn: 3
   control_method: dmg
   rebuild_timeout: 120
   pool_query_timeout: 30

--- a/src/tests/ftest/nvme/pool_extend.yaml
+++ b/src/tests/ftest/nvme/pool_extend.yaml
@@ -48,7 +48,7 @@ pool:
   name: daos_server
   scm_size: 5000000000
   nvme_size: 30000000000
-  svcn: 4
+  svcn: 3
   control_method: dmg
   rebuild_timeout: 120
   pool_query_timeout: 30

--- a/src/tests/ftest/osa/dmg_negative_test.yaml
+++ b/src/tests/ftest/osa/dmg_negative_test.yaml
@@ -49,7 +49,7 @@ pool:
   name: daos_server
   scm_size: 6000000000
   nvme_size: 54000000000
-  svcn: 4
+  svcn: 3
   control_method: dmg
 container:
   properties:

--- a/src/tests/ftest/osa/offline_drain.yaml
+++ b/src/tests/ftest/osa/offline_drain.yaml
@@ -47,7 +47,7 @@ pool:
     name: daos_server
     scm_size: 12000000000
     nvme_size: 108000000000
-    svcn: 4
+    svcn: 3
     control_method: dmg
 container:
     type: POSIX

--- a/src/tests/ftest/osa/offline_extend.yaml
+++ b/src/tests/ftest/osa/offline_extend.yaml
@@ -48,7 +48,7 @@ pool:
   name: daos_server
   scm_size: 6000000000
   nvme_size: 54000000000
-  svcn: 4
+  svcn: 3
   control_method: dmg
 container:
   type: POSIX

--- a/src/tests/ftest/osa/offline_parallel_test.yaml
+++ b/src/tests/ftest/osa/offline_parallel_test.yaml
@@ -49,7 +49,7 @@ pool:
   name: daos_server
   scm_size: 6000000000
   nvme_size: 54000000000
-  svcn: 4
+  svcn: 3
   control_method: dmg
 container:
   type: POSIX

--- a/src/tests/ftest/osa/offline_reintegration.yaml
+++ b/src/tests/ftest/osa/offline_reintegration.yaml
@@ -53,7 +53,7 @@ pool:
   name: daos_server
   scm_size: 6000000000
   nvme_size: 54000000000
-  svcn: 4
+  svcn: 3
   control_method: dmg
   rebuild_timeout: 120
   pool_query_timeout: 30

--- a/src/tests/ftest/osa/online_drain.yaml
+++ b/src/tests/ftest/osa/online_drain.yaml
@@ -48,7 +48,7 @@ pool:
   name: daos_server
   scm_size: 12000000000
   nvme_size: 108000000000
-  svcn: 4
+  svcn: 3
   control_method: dmg
   rebuild_timeout: 120
   pool_query_timeout: 30

--- a/src/tests/ftest/osa/online_extend.yaml
+++ b/src/tests/ftest/osa/online_extend.yaml
@@ -52,7 +52,7 @@ pool:
   name: daos_server
   scm_size: 12000000000
   nvme_size: 108000000000
-  svcn: 4
+  svcn: 3
   control_method: dmg
   rebuild_timeout: 120
   pool_query_timeout: 30

--- a/src/tests/ftest/osa/online_parallel_test.yaml
+++ b/src/tests/ftest/osa/online_parallel_test.yaml
@@ -44,7 +44,7 @@ pool:
   name: daos_server
   scm_size: 12000000000
   nvme_size: 108000000000
-  svcn: 4
+  svcn: 3
   control_method: dmg
 container:
   type: POSIX

--- a/src/tests/ftest/osa/online_reintegration.yaml
+++ b/src/tests/ftest/osa/online_reintegration.yaml
@@ -46,7 +46,7 @@ pool:
   name: daos_server
   scm_size: 12000000000
   nvme_size: 108000000000
-  svcn: 4
+  svcn: 3
   control_method: dmg
   rebuild_timeout: 120
   pool_query_timeout: 30

--- a/src/tests/ftest/rebuild/cascading_failures.yaml
+++ b/src/tests/ftest/rebuild/cascading_failures.yaml
@@ -17,7 +17,7 @@ pool:
   mode: 511
   name: daos_server
   scm_size: 1073741824
-  svcn: 2
+  svcn: 3
   control_method: dmg
   pool_query_timeout: 30
 container:

--- a/src/tests/ftest/rebuild/delete_objects.yaml
+++ b/src/tests/ftest/rebuild/delete_objects.yaml
@@ -17,7 +17,7 @@ pool:
   mode: 511
   name: daos_server
   scm_size: 1073741824
-  svcn: 2
+  svcn: 3
   debug: True
   control_method: dmg
   pool_query_timeout: 30

--- a/src/tests/ftest/rebuild/read_array.yaml
+++ b/src/tests/ftest/rebuild/read_array.yaml
@@ -19,7 +19,7 @@ pool:
   mode: 511
   name: daos_server
   scm_size: 1073741824
-  svcn: 2
+  svcn: 3
   control_method: dmg
   pool_query_timeout: 30
 container:


### PR DESCRIPTION
Instead of always starting with rank 1, use a shuffled list
of target ranks to choose the pool service ranks. This will
help to avoid "hot spots" caused by putting all of the
pool service instances on the same ranks.

Includes a proactive fix for DAOS-9091 on release/2.0:
To prevent raft quorum failures, the number of pool service
ranks should always be an odd number.

Also updates a number of tests that were using even svcn
values in their config yaml.

Test-tag: pr rebuild osa nvme

Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com
