### PR TITLE
DAOS-9114 build: Add cmake flags to mercury build

### DIFF
--- a/site_scons/components/__init__.py
+++ b/site_scons/components/__init__.py
@@ -179,6 +179,7 @@ def define_mercury(reqs):
                           check(reqs, 'openpa', '', '64') + '/libopa.a '
                           '-DOPA_INCLUDE_DIR=$OPENPA_PREFIX/include/ '
                           '-DCMAKE_INSTALL_PREFIX=$MERCURY_PREFIX '
+                          '-DCMAKE_CXX_FLAGS="-std=c++11" '
                           '-DBUILD_EXAMPLES=OFF '
                           '-DMERCURY_USE_BOOST_PP=ON '
                           + MERCURY_DEBUG +


### PR DESCRIPTION
- Add cmake flags to mercury build that appear to be required with
more recent cmakes.

Signed-off-by: Alexander Oganezov <alexander.a.oganezov@intel.com>