### PR TITLE
DAOS-9036 vos: not retry if hit prepared DTX for list ilog  entries

### DIFF
--- a/src/include/daos_srv/evtree.h
+++ b/src/include/daos_srv/evtree.h
@@ -82,9 +82,8 @@ struct evt_desc_cbs {
 	 * this method is absent.
 	 */
 	int		(*dc_log_status_cb)(struct umem_instance *umm,
-					    daos_epoch_t epoch,
-					    struct evt_desc *desc, int intent,
-					    void *args);
+					    daos_epoch_t epoch, struct evt_desc *desc,
+					    int intent, bool retry, void *args);
 	void		 *dc_log_status_args;
 	/** Add a descriptor to undo log */
 	int		(*dc_log_add_cb)(struct umem_instance *umm,

--- a/src/vos/evtree.c
+++ b/src/vos/evtree.c
@@ -1228,7 +1228,7 @@ evt_desc_log_status(struct evt_context *tcx, daos_epoch_t epoch,
 	if (!cbs->dc_log_status_cb) {
 		return ALB_AVAILABLE_CLEAN;
 	} else {
-		return cbs->dc_log_status_cb(evt_umm(tcx), epoch, desc, intent,
+		return cbs->dc_log_status_cb(evt_umm(tcx), epoch, desc, intent, true,
 					     cbs->dc_log_status_args);
 	}
 }

--- a/src/vos/ilog.c
+++ b/src/vos/ilog.c
@@ -104,7 +104,7 @@ ilog_is_same_tx(struct ilog_context *lctx, const struct ilog_id *id, bool *same)
 }
 
 static int
-ilog_status_get(struct ilog_context *lctx, const struct ilog_id *id, uint32_t intent)
+ilog_status_get(struct ilog_context *lctx, const struct ilog_id *id, uint32_t intent, bool retry)
 {
 	struct ilog_desc_cbs	*cbs = &lctx->ic_cbs;
 	int			 rc;
@@ -115,7 +115,7 @@ ilog_status_get(struct ilog_context *lctx, const struct ilog_id *id, uint32_t in
 	if (!cbs->dc_log_status_cb)
 		return ILOG_COMMITTED;
 
-	rc = cbs->dc_log_status_cb(&lctx->ic_umm, id->id_tx_id, id->id_epoch, intent,
+	rc = cbs->dc_log_status_cb(&lctx->ic_umm, id->id_tx_id, id->id_epoch, intent, retry,
 				   cbs->dc_log_status_args);
 
 	if ((intent == DAOS_INTENT_UPDATE || intent == DAOS_INTENT_PUNCH)
@@ -769,7 +769,7 @@ ilog_tree_modify(struct ilog_context *lctx, const struct ilog_id *id_in,
 
 	if (id_out->id_epoch <= epr->epr_hi &&
 	    id_out->id_epoch >= epr->epr_lo) {
-		visibility = ilog_status_get(lctx, id_out, DAOS_INTENT_UPDATE);
+		visibility = ilog_status_get(lctx, id_out, DAOS_INTENT_UPDATE, true);
 		if (visibility < 0)
 			return visibility;
 	}
@@ -896,7 +896,7 @@ ilog_modify(daos_handle_t loh, const struct ilog_id *id_in,
 
 	if (root->lr_tree.it_embedded && root->lr_id.id_epoch <= epr->epr_hi
 	    && root->lr_id.id_epoch >= epr->epr_lo) {
-		visibility = ilog_status_get(lctx, &root->lr_id, DAOS_INTENT_UPDATE);
+		visibility = ilog_status_get(lctx, &root->lr_id, DAOS_INTENT_UPDATE, true);
 		if (visibility < 0) {
 			rc = visibility;
 			goto done;
@@ -1102,7 +1102,9 @@ ilog_status_refresh(struct ilog_context *lctx, uint32_t intent,
 		    (entry.ie_status == ILOG_COMMITTED ||
 		     entry.ie_status == ILOG_REMOVED))
 			continue;
-		status = ilog_status_get(lctx, &entry.ie_id, intent);
+		status = ilog_status_get(lctx, &entry.ie_id, intent,
+					 (intent == DAOS_INTENT_UPDATE ||
+					  intent == DAOS_INTENT_PUNCH) ? false : true);
 		if (status < 0) {
 			priv->ip_rc = status;
 			return;
@@ -1238,7 +1240,9 @@ ilog_fetch(struct umem_instance *umm, struct ilog_df *root_df,
 
 	for (i = 0; i < cache.ac_nr; i++) {
 		id = &cache.ac_entries[i];
-		status = ilog_status_get(lctx, id, intent);
+		status = ilog_status_get(lctx, id, intent,
+					 (intent == DAOS_INTENT_UPDATE ||
+					  intent == DAOS_INTENT_PUNCH) ? false : true);
 		if (status != -DER_INPROGRESS && status < 0)
 			D_GOTO(fail, rc = status);
 		set_entry(entries, i, status);

--- a/src/vos/ilog.h
+++ b/src/vos/ilog.h
@@ -52,8 +52,7 @@ struct ilog_desc_cbs {
 	 *  return error code < 0.
 	 */
 	int (*dc_log_status_cb)(struct umem_instance *umm, uint32_t tx_id,
-				daos_epoch_t epoch, uint32_t intent,
-				void *args);
+				daos_epoch_t epoch, uint32_t intent, bool retry, void *args);
 	void	*dc_log_status_args;
 	/** Check if the log entry was created by current transaction */
 	int (*dc_is_same_tx_cb)(struct umem_instance *umm, uint32_t tx_id,

--- a/src/vos/tests/vts_ilog.c
+++ b/src/vos/tests/vts_ilog.c
@@ -90,7 +90,7 @@ static D_LIST_HEAD(fake_tx_list);
 
 static int
 fake_tx_status_get(struct umem_instance *umm, uint32_t tx_id,
-		   daos_epoch_t epoch, uint32_t intent, void *args)
+		   daos_epoch_t epoch, uint32_t intent, bool retry, void *args)
 {
 	struct lru_array	*array = args;
 	struct fake_tx_entry	*entry;

--- a/src/vos/vos_dtx.c
+++ b/src/vos/vos_dtx.c
@@ -113,11 +113,14 @@ dtx_set_aborted(uint32_t *tx_lid)
 
 static inline int
 dtx_inprogress(struct vos_dtx_act_ent *dae, struct dtx_handle *dth,
-	       bool hit_again, int pos)
+	       bool hit_again, bool retry, int pos)
 {
 	struct dtx_share_peer	*dsp;
 	struct dtx_memberships	*mbs;
 	bool			 s_try = false;
+
+	if (!retry)
+		return -DER_INPROGRESS;
 
 	if (dth == NULL)
 		goto out;
@@ -1076,7 +1079,7 @@ vos_dtx_append(struct dtx_handle *dth, umem_off_t record, uint32_t type)
  */
 int
 vos_dtx_check_availability(daos_handle_t coh, uint32_t entry,
-			   daos_epoch_t epoch, uint32_t intent, uint32_t type)
+			   daos_epoch_t epoch, uint32_t intent, uint32_t type, bool retry)
 {
 	struct dtx_handle		*dth = vos_dth_get();
 	struct vos_container		*cont;
@@ -1209,7 +1212,7 @@ vos_dtx_check_availability(daos_handle_t coh, uint32_t entry,
 				    intent == DAOS_INTENT_IGNORE_NONCOMMITTED)
 					return ALB_UNAVAILABLE;
 
-				return dtx_inprogress(dae, dth, true, 4);
+				return dtx_inprogress(dae, dth, true, true, 4);
 			}
 		}
 	}
@@ -1227,7 +1230,7 @@ vos_dtx_check_availability(daos_handle_t coh, uint32_t entry,
 		 * modification to guarantee the transaction semantics.
 		 */
 		if (dtx_is_valid_handle(dth))
-			return dtx_inprogress(dae, dth, false, 5);
+			return dtx_inprogress(dae, dth, false, true, 5);
 
 		return ALB_UNAVAILABLE;
 	}
@@ -1240,7 +1243,7 @@ vos_dtx_check_availability(daos_handle_t coh, uint32_t entry,
 	 * the leader.
 	 */
 	if (intent == DAOS_INTENT_MIGRATION)
-		return dtx_inprogress(dae, dth, false, 6);
+		return dtx_inprogress(dae, dth, false, true, 6);
 
 	if (intent == DAOS_INTENT_DEFAULT) {
 		if (!(DAE_FLAGS(dae) & DTE_LEADER) ||
@@ -1248,13 +1251,13 @@ vos_dtx_check_availability(daos_handle_t coh, uint32_t entry,
 			/* Non-leader or rebuild case, return -DER_INPROGRESS,
 			 * then the caller will retry the RPC (with leader).
 			 */
-			return dtx_inprogress(dae, dth, false, 1);
+			return dtx_inprogress(dae, dth, false, true, 1);
 
 		/* For transactional read, has to wait the non-committed
 		 * modification to guarantee the transaction semantics.
 		 */
 		if (dtx_is_valid_handle(dth))
-			return dtx_inprogress(dae, dth, false, 2);
+			return dtx_inprogress(dae, dth, false, true, 2);
 
 		/* For stand-alone read on leader, ignore non-committed DTX. */
 		return ALB_UNAVAILABLE;
@@ -1276,7 +1279,7 @@ vos_dtx_check_availability(daos_handle_t coh, uint32_t entry,
 			 */
 			return ALB_UNAVAILABLE;
 
-		return dtx_inprogress(dae, dth, false, 3);
+		return dtx_inprogress(dae, dth, false, retry, 3);
 	}
 
 	D_ASSERTF(intent == DAOS_INTENT_UPDATE,

--- a/src/vos/vos_ilog.c
+++ b/src/vos/vos_ilog.c
@@ -14,15 +14,14 @@
 
 static int
 vos_ilog_status_get(struct umem_instance *umm, uint32_t tx_id,
-		    daos_epoch_t epoch, uint32_t intent, void *args)
+		    daos_epoch_t epoch, uint32_t intent, bool retry, void *args)
 {
 	int	rc;
 	daos_handle_t coh;
 
 	coh.cookie = (unsigned long)args;
 
-	rc = vos_dtx_check_availability(coh, tx_id, epoch, intent,
-					DTX_RT_ILOG);
+	rc = vos_dtx_check_availability(coh, tx_id, epoch, intent, DTX_RT_ILOG, retry);
 	if (rc < 0)
 		return rc;
 

--- a/src/vos/vos_internal.h
+++ b/src/vos/vos_internal.h
@@ -390,6 +390,7 @@ vos_dtx_cleanup_internal(struct dtx_handle *dth);
  * \param epoch		[IN]	Epoch of update
  * \param intent	[IN]	The request intent.
  * \param type		[IN]	The record type, see vos_dtx_record_types.
+ * \param retry		[IN]	Whether need to retry if hit non-committed DTX entry.
  *
  * \return	positive value	If available to outside.
  *		zero		If unavailable to outside.
@@ -403,7 +404,7 @@ vos_dtx_cleanup_internal(struct dtx_handle *dth);
  */
 int
 vos_dtx_check_availability(daos_handle_t coh, uint32_t entry,
-			   daos_epoch_t epoch, uint32_t intent, uint32_t type);
+			   daos_epoch_t epoch, uint32_t intent, uint32_t type, bool retry);
 
 /**
  * Get local entry DTX state. Only used by VOS aggregation.

--- a/src/vos/vos_tree.c
+++ b/src/vos/vos_tree.c
@@ -758,7 +758,7 @@ svt_check_availability(struct btr_instance *tins, struct btr_record *rec,
 
 	svt = umem_off2ptr(&tins->ti_umm, rec->rec_off);
 	return vos_dtx_check_availability(tins->ti_coh, svt->ir_dtx, *epc,
-					  intent, DTX_RT_SVT);
+					  intent, DTX_RT_SVT, true);
 }
 
 static umem_off_t
@@ -827,14 +827,13 @@ evt_dop_bio_free(struct umem_instance *umm, struct evt_desc *desc,
 
 static int
 evt_dop_log_status(struct umem_instance *umm, daos_epoch_t epoch,
-		   struct evt_desc *desc, int intent, void *args)
+		   struct evt_desc *desc, int intent, bool retry, void *args)
 {
 	daos_handle_t coh;
 
 	coh.cookie = (unsigned long)args;
 	D_ASSERT(coh.cookie != 0);
-	return vos_dtx_check_availability(coh, desc->dc_dtx,
-					  epoch, intent, DTX_RT_EVT);
+	return vos_dtx_check_availability(coh, desc->dc_dtx, epoch, intent, DTX_RT_EVT, retry);
 }
 
 int


### PR DESCRIPTION
When update ilog for update or punch, we fetch related ilog entries
firstly, that may hits many uncommitted DTX entries. That is normal,
will not cause server side DTX refresh or client side RPC retry. So
we do not need to prepare the information for potential DTX refresh.
The patch also fixes related log message to avoid confusing.

Signed-off-by: Fan Yong <fan.yong@intel.com>