### PR TITLE
DAOS-9003 dtx: release the DRAM/space occupied by DTX entries

### DIFF
--- a/src/common/tests/btree.c
+++ b/src/common/tests/btree.c
@@ -847,7 +847,7 @@ ik_btr_drain(void **state)
 	ik_btr_query(NULL);
 	while (1) {
 		int	creds = drain_creds;
-		bool	empty = false;
+		bool	empty = true;
 		int	rc;
 
 		rc = dbtree_drain(ik_toh, &creds, NULL, &empty);

--- a/src/dtx/dtx_common.c
+++ b/src/dtx/dtx_common.c
@@ -30,10 +30,7 @@ struct dtx_batched_pool_args {
 	/* The list of containers belong to the pool. */
 	d_list_t			 dbpa_cont_list;
 	struct ds_pool_child		*dbpa_pool;
-	/* The container that needs to do DTX aggregation. */
-	struct dtx_batched_cont_args	*dbpa_victim;
-	struct dtx_stat			 dbpa_stat;
-	uint32_t			 dbpa_aggregating:1;
+	uint32_t			 dbpa_aggregating;
 };
 
 struct dtx_batched_cont_args {
@@ -305,17 +302,17 @@ dtx_aggregate(void *arg)
 		 * to do DTX aggregation.
 		 */
 
-		if (stat.dtx_cont_cmt_count == 0 ||
-		    stat.dtx_first_cmt_blob_time_lo == 0 ||
+		if (stat.dtx_cont_cmt_count == 0 || stat.dtx_first_cmt_blob_time_lo == 0 ||
 		    (stat.dtx_cont_cmt_count <= dtx_agg_thd_cnt_lo &&
-		     dtx_hlc_age2sec(stat.dtx_first_cmt_blob_time_lo) <=
-		     dtx_agg_thd_age_lo))
+		     dtx_hlc_age2sec(stat.dtx_first_cmt_blob_time_lo) <= dtx_agg_thd_age_lo))
 			break;
 	}
 
 	dbca->dbca_agg_done = 1;
 
 out:
+	D_ASSERT(dbca->dbca_pool->dbpa_aggregating != 0);
+	dbca->dbca_pool->dbpa_aggregating--;
 	dtx_put_dbca(dbca);
 }
 
@@ -325,6 +322,8 @@ dtx_aggregation_pool(struct dtx_batched_pool_args *dbpa)
 	struct dtx_batched_cont_args	*dbca;
 	struct ds_cont_child		*cont;
 	struct sched_req_attr		 attr;
+	struct dtx_batched_cont_args	*victim_dbca = NULL;
+	struct dtx_stat			 victim_stat = { 0 };
 
 	D_ASSERT(dbpa->dbpa_pool);
 	sched_req_attr_init(&attr, SCHED_REQ_GC, &dbpa->dbpa_pool->spc_uuid);
@@ -339,6 +338,8 @@ dtx_aggregation_pool(struct dtx_batched_pool_args *dbpa)
 				    struct dtx_batched_cont_args,
 				    dbca_pool_link);
 
+		D_ASSERT(!dbca->dbca_deregister);
+
 		if (dbca->dbca_agg_req != NULL && dbca->dbca_agg_done) {
 			sched_req_put(dbca->dbca_agg_req);
 			dbca->dbca_agg_req = NULL;
@@ -352,28 +353,21 @@ dtx_aggregation_pool(struct dtx_batched_pool_args *dbpa)
 		dbca->dbca_agg_gen = dtx_agg_gen;
 		d_list_move_tail(&dbca->dbca_pool_link, &dbpa->dbpa_cont_list);
 
-		if (dbca->dbca_deregister)
+		if (dbca->dbca_agg_req != NULL)
 			continue;
 
 		cont = dbca->dbca_cont;
 		if (cont->sc_closing)
 			continue;
 
-		if (dbca->dbca_agg_req != NULL) {
-			dbpa->dbpa_aggregating = 1;
-			continue;
-		}
-
 		dtx_stat(cont, &stat);
-		if (stat.dtx_cont_cmt_count == 0 ||
-		    stat.dtx_first_cmt_blob_time_lo == 0)
+		if (stat.dtx_cont_cmt_count == 0 || stat.dtx_first_cmt_blob_time_lo == 0)
 			continue;
 
 		if (stat.dtx_cont_cmt_count >= dtx_agg_thd_cnt_up ||
 		    ((stat.dtx_cont_cmt_count > dtx_agg_thd_cnt_lo ||
 		      stat.dtx_pool_cmt_count >= dtx_agg_thd_cnt_up) &&
-		     (dtx_hlc_age2sec(stat.dtx_first_cmt_blob_time_lo) >=
-		      dtx_agg_thd_age_up))) {
+		     (dtx_hlc_age2sec(stat.dtx_first_cmt_blob_time_lo) >= dtx_agg_thd_age_up))) {
 			D_ASSERT(!dbca->dbca_agg_done);
 			dtx_get_dbca(dbca);
 			dbca->dbca_agg_req = sched_create_ult(&attr, dtx_aggregate, dbca, 0);
@@ -384,51 +378,39 @@ dtx_aggregation_pool(struct dtx_batched_pool_args *dbpa)
 				continue;
 			}
 
-			dbpa->dbpa_aggregating = 1;
+			dbpa->dbpa_aggregating++;
 			continue;
 		}
 
-		if (dbpa->dbpa_stat.dtx_first_cmt_blob_time_lo == 0 ||
-		    dbpa->dbpa_stat.dtx_first_cmt_blob_time_lo >
-		    stat.dtx_first_cmt_blob_time_lo ||
-		    (dbpa->dbpa_stat.dtx_first_cmt_blob_time_lo ==
-		     stat.dtx_first_cmt_blob_time_lo &&
-		     dbpa->dbpa_stat.dtx_first_cmt_blob_time_up >
-		     stat.dtx_first_cmt_blob_time_up) ||
-		    (dbpa->dbpa_stat.dtx_first_cmt_blob_time_lo ==
-		     stat.dtx_first_cmt_blob_time_lo &&
-		     dbpa->dbpa_stat.dtx_first_cmt_blob_time_up ==
-		     stat.dtx_first_cmt_blob_time_up &&
-		     dbpa->dbpa_stat.dtx_cont_cmt_count <
-		     stat.dtx_cont_cmt_count)) {
-			dbpa->dbpa_stat = stat;
-			dbpa->dbpa_victim = dbca;
+		if (victim_stat.dtx_first_cmt_blob_time_lo == 0 ||
+		    victim_stat.dtx_first_cmt_blob_time_lo > stat.dtx_first_cmt_blob_time_lo ||
+		    (victim_stat.dtx_first_cmt_blob_time_lo == stat.dtx_first_cmt_blob_time_lo &&
+		     victim_stat.dtx_first_cmt_blob_time_up > stat.dtx_first_cmt_blob_time_up) ||
+		    (victim_stat.dtx_first_cmt_blob_time_lo == stat.dtx_first_cmt_blob_time_lo &&
+		     victim_stat.dtx_first_cmt_blob_time_up == stat.dtx_first_cmt_blob_time_up &&
+		     victim_stat.dtx_cont_cmt_count < stat.dtx_cont_cmt_count)) {
+			victim_stat = stat;
+			victim_dbca = dbca;
 		}
 	}
-
-	if (dbpa->dbpa_aggregating || dbpa->dbpa_victim == NULL ||
-	    dbpa->dbpa_stat.dtx_pool_cmt_count <= dtx_agg_thd_cnt_lo ||
-	    dbpa->dbpa_stat.dtx_first_cmt_blob_time_lo == 0 ||
-	    dtx_hlc_age2sec(dbpa->dbpa_stat.dtx_first_cmt_blob_time_lo) <=
-	    dtx_agg_thd_age_lo)
-		return;
 
 	/* No single container exceeds DTX thresholds, but the whole pool does,
 	 * then we choose the victim container to do the DTX aggregation.
 	 */
 
-	dbca = dbpa->dbpa_victim;
-	cont = dbca->dbca_cont;
-	D_ASSERT(dbca->dbca_agg_req == NULL && !dbca->dbca_agg_done);
-	dtx_get_dbca(dbca);
+	if (dbpa->dbpa_aggregating == 0 && victim_dbca != NULL &&
+	    victim_stat.dtx_pool_cmt_count >= dtx_agg_thd_cnt_up) {
+		D_ASSERT(victim_dbca->dbca_agg_req == NULL && !victim_dbca->dbca_agg_done);
 
-	dbca->dbca_agg_req = sched_create_ult(&attr, dtx_aggregate, dbca, 0);
-	if (dbca->dbca_agg_req == NULL) {
-		D_WARN("Fail to start DTX agg ULT (2) for "DF_UUID"\n",
-		       DP_UUID(cont->sc_uuid));
-		dtx_put_dbca(dbca);
-	} else {
-		dbpa->dbpa_aggregating = 1;
+		dtx_get_dbca(victim_dbca);
+		victim_dbca->dbca_agg_req = sched_create_ult(&attr, dtx_aggregate, victim_dbca, 0);
+		if (victim_dbca->dbca_agg_req == NULL) {
+			D_WARN("Fail to start DTX agg ULT (2) for "DF_UUID"\n",
+				DP_UUID(victim_dbca->dbca_cont->sc_uuid));
+			dtx_put_dbca(victim_dbca);
+		} else {
+			dbpa->dbpa_aggregating++;
+		}
 	}
 }
 
@@ -442,8 +424,6 @@ dtx_aggregation_main(void *arg)
 		return;
 
 	while (1) {
-		int	sleep_time = 50; /* ms */
-
 		if (!d_list_empty(&dmi->dmi_dtx_batched_pool_list)) {
 			dbpa = d_list_entry(dmi->dmi_dtx_batched_pool_list.next,
 					    struct dtx_batched_pool_args,
@@ -452,17 +432,13 @@ dtx_aggregation_main(void *arg)
 					 &dmi->dmi_dtx_batched_pool_list);
 
 			dtx_agg_gen++;
-			dbpa->dbpa_victim = NULL;
-			dbpa->dbpa_aggregating = 0;
 			dtx_aggregation_pool(dbpa);
-			if (dbpa->dbpa_aggregating)
-				sleep_time = 0;
 		}
 
 		if (dss_xstream_exiting(dmi->dmi_xstream))
 			break;
 
-		sched_req_sleep(dmi->dmi_dtx_agg_req, sleep_time);
+		sched_req_sleep(dmi->dmi_dtx_agg_req, 500 /* ms */);
 	}
 }
 
@@ -507,7 +483,7 @@ dtx_batched_commit_one(void *arg)
 		dtx_stat(cont, &stat);
 
 		if (stat.dtx_pool_cmt_count >= dtx_agg_thd_cnt_up &&
-		    !dbca->dbca_pool->dbpa_aggregating)
+		    dbca->dbca_pool->dbpa_aggregating == 0)
 			sched_req_wakeup(dmi->dmi_dtx_agg_req);
 
 		if ((stat.dtx_committable_count <= DTX_THRESHOLD_COUNT) &&
@@ -566,6 +542,9 @@ dtx_batched_commit(void *arg)
 		dbca = d_list_entry(dmi->dmi_dtx_batched_cont_list.next,
 				    struct dtx_batched_cont_args,
 				    dbca_sys_link);
+
+		D_ASSERT(!dbca->dbca_deregister);
+
 		dtx_get_dbca(dbca);
 		cont = dbca->dbca_cont;
 		d_list_move_tail(&dbca->dbca_sys_link,
@@ -578,8 +557,7 @@ dtx_batched_commit(void *arg)
 			dbca->dbca_commit_done = 0;
 		}
 
-		if (!cont->sc_closing &&
-		    !dbca->dbca_deregister && dbca->dbca_commit_req == NULL &&
+		if (!cont->sc_closing && dbca->dbca_commit_req == NULL &&
 		    ((stat.dtx_committable_count > DTX_THRESHOLD_COUNT) ||
 		     (stat.dtx_oldest_committable_time != 0 &&
 		      dtx_hlc_age2sec(stat.dtx_oldest_committable_time) >=

--- a/src/include/daos/btree.h
+++ b/src/include/daos/btree.h
@@ -528,7 +528,7 @@ int  dbtree_open_inplace_ex(struct btr_root *root, struct umem_attr *uma,
 			    daos_handle_t coh, void *priv, daos_handle_t *toh);
 int  dbtree_close(daos_handle_t toh);
 int  dbtree_destroy(daos_handle_t toh, void *args);
-int  dbtree_drain(daos_handle_t toh, int *credits, void *args, bool *destroyed);
+int  dbtree_drain(daos_handle_t toh, int *credits, void *args, bool *destroy);
 int  dbtree_lookup(daos_handle_t toh, d_iov_t *key, d_iov_t *val_out);
 int  dbtree_update(daos_handle_t toh, d_iov_t *key, d_iov_t *val);
 int  dbtree_fetch(daos_handle_t toh, dbtree_probe_opc_t opc, uint32_t intent,

--- a/src/vos/vos_gc.c
+++ b/src/vos/vos_gc.c
@@ -81,6 +81,7 @@ gc_drain_btr(struct vos_gc *gc, struct vos_pool *pool, daos_handle_t coh,
 {
 	daos_handle_t	toh;
 	int		rc;
+	bool		destroy = true;
 
 	rc = dbtree_open_inplace_ex(root, &pool->vp_uma, coh, pool, &toh);
 	if (rc == -DER_NONEXIST) { /* empty tree */
@@ -92,10 +93,12 @@ gc_drain_btr(struct vos_gc *gc, struct vos_pool *pool, daos_handle_t coh,
 
 	D_DEBUG(DB_TRACE, "drain btree for %s, creds=%d\n",
 		gc->gc_name, *credits);
-	rc = dbtree_drain(toh, credits, vos_hdl2cont(coh), empty);
+	rc = dbtree_drain(toh, credits, vos_hdl2cont(coh), &destroy);
 	dbtree_close(toh);
 	if (rc)
 		goto failed;
+
+	*empty = destroy;
 
 	D_ASSERT(*credits >= 0);
 	D_ASSERT(*empty || *credits == 0);


### PR DESCRIPTION
For the following cases:

1. Trigger DTX aggregation properly
   If the whole pool committed DTX entries count exceeds the threshold,
   then even if every container committed DTX entries does not exceeds
   the threshold, we still need to choose at least one container to do
   DTX aggregation to reduce the DRAM/space pressure.

2. Purge the DTX committed table from DRAM when close the container
   There will be no resent RPC check after closing the container, then
   it is almost useless to maintain the committed DTX entries in DRAM.

3. Shrink DTX LRU array when close the container
   There will be no new active DTX entries to consume the DTX LRU array,
   then shrink it to release DRAM. Please note that we cannot guarantee
   no DTX commit after the container closed locally because related DTX
   leader may resides on remote target. So it may be not enough to only
   shrink the DTX LRU array when close, we still need to shrink it when
   DTX commit after the container closed locally.

Signed-off-by: Fan Yong <fan.yong@intel.com>