### PR TITLE
DAOS-7878 vos: Address punch propagation performance (#7218)

### DIFF
--- a/src/include/daos/btree.h
+++ b/src/include/daos/btree.h
@@ -553,6 +553,7 @@ enum {
 	BTR_ITER_EMBEDDED	= (1 << 0),
 };
 
+int dbtree_key2anchor(daos_handle_t toh, d_iov_t *key, daos_anchor_t *anchor);
 int dbtree_iter_prepare(daos_handle_t toh, unsigned int options,
 			daos_handle_t *ih);
 int dbtree_iter_finish(daos_handle_t ih);

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -2339,8 +2339,8 @@ ds_obj_tgt_update_handler(crt_rpc_t *rpc)
 			  (orw->orw_bulks.ca_arrays != NULL ||
 			   orw->orw_bulks.ca_count != 0) ? true : false);
 	if (rc != 0)
-		D_ERROR(DF_UOID": error="DF_RC".\n", DP_UOID(orw->orw_oid),
-			DP_RC(rc));
+		D_CDEBUG(rc == -DER_INPROGRESS || rc == -DER_TX_RESTART, DB_IO, DLOG_ERR,
+			 DF_UOID": error="DF_RC".\n", DP_UOID(orw->orw_oid), DP_RC(rc));
 
 out:
 	rc = dtx_end(&dth, ioc.ioc_coc, rc);

--- a/src/vos/tests/vts_mvcc.c
+++ b/src/vos/tests/vts_mvcc.c
@@ -1094,17 +1094,6 @@ struct conflicting_rw_excluded_case {
 };
 
 static struct conflicting_rw_excluded_case conflicting_rw_excluded_cases[] = {
-	/** Used to disable specific tests as necessary */
-	/** These specific tests can be enabled when DAOS-4698 is fixed
-	 *  and the line in vos_obj.c that references this ticket is
-	 *  uncommented.
-	 */
-	{false,	"punchd_dne",	"cod",	"puncho_one",	"co",	0, false},
-	{false,	"punchd_dne",	"cod",	"puncho_one",	"co",	1, false},
-	{false,	"puncha_ane",	"coda",	"puncho_one",	"co",	0, false},
-	{false,	"puncha_ane",	"coda",	"puncho_one",	"co",	1, false},
-	{false, "puncha_ane",   "coda", "puncho_one",   "co",   0, true},
-	{false, "punchd_dne",   "cod",  "puncho_one",   "co",   0, true},
 };
 
 static int64_t

--- a/src/vos/vos_obj.c
+++ b/src/vos/vos_obj.c
@@ -25,9 +25,31 @@ D_CASSERT((uint32_t)VOS_VIS_FLAG_PARTIAL == (uint32_t)EVT_PARTIAL);
 D_CASSERT((uint32_t)VOS_VIS_FLAG_LAST == (uint32_t)EVT_LAST);
 
 struct vos_key_info {
+	umem_off_t		*ki_known_key;
+	struct vos_object	*ki_obj;
 	bool			 ki_non_empty;
 	bool			 ki_has_uncommitted;
+	const void		*ki_first;
 };
+
+static inline int
+key_iter_fetch_helper(struct vos_obj_iter *oiter, struct vos_rec_bundle *rbund, d_iov_t *keybuf,
+		      daos_anchor_t *anchor)
+{
+	d_iov_t			 kiov;
+	d_iov_t			 riov;
+	struct dcs_csum_info	 csum;
+
+	tree_rec_bundle2iov(rbund, &riov);
+
+	rbund->rb_iov	= keybuf;
+	rbund->rb_csum	= &csum;
+
+	d_iov_set(rbund->rb_iov, NULL, 0); /* no copy */
+	ci_set_null(rbund->rb_csum);
+
+	return dbtree_iter_fetch(oiter->it_hdl, &kiov, &riov, anchor);
+}
 
 /** This callback is invoked only if the tree is not empty */
 static int
@@ -35,14 +57,43 @@ empty_tree_check(daos_handle_t ih, vos_iter_entry_t *entry,
 		 vos_iter_type_t type, vos_iter_param_t *param, void *cb_arg,
 		 unsigned int *acts)
 {
+	struct vos_iterator	*iter;
+	struct vos_obj_iter	*oiter;
+	struct vos_rec_bundle	 rbund = {0};
+	d_iov_t			 key_iov;
+	struct umem_instance	*umm;
 	struct vos_key_info	*kinfo = cb_arg;
+	int			 rc;
+
+	if (kinfo->ki_first == entry->ie_key.iov_buf)
+		return 1; /** We've seen this one before */
+
+	/** Save the first thing we see so we can stop iteration early
+	 *  if we see it again on 2nd pass.
+	 */
+	if (kinfo->ki_first == NULL)
+		kinfo->ki_first = entry->ie_key.iov_buf;
 
 	if (entry->ie_vis_flags == VOS_IT_UNCOMMITTED) {
 		kinfo->ki_has_uncommitted = true;
 		return 0;
 	}
 
+	iter = vos_hdl2iter(ih);
+	oiter = vos_iter2oiter(iter);
+	rc = key_iter_fetch_helper(oiter, &rbund, &key_iov, NULL);
+	if (rc != 0)
+		return rc;
+
+	D_ASSERT(key_iov.iov_len == entry->ie_key.iov_len);
+	D_ASSERT(memcmp(key_iov.iov_buf, entry->ie_key.iov_buf, key_iov.iov_len) == 0);
 	kinfo->ki_non_empty = true;
+	umm = vos_obj2umm(kinfo->ki_obj);
+	rc = umem_tx_add_ptr(umm, kinfo->ki_known_key, sizeof(*(kinfo->ki_known_key)));
+	if (rc != 0)
+		return rc;
+
+	*(kinfo->ki_known_key) = umem_ptr2off(umm, rbund.rb_krec);
 
 	return 1; /* Return positive number to break iteration */
 }
@@ -51,10 +102,43 @@ static int
 tree_is_empty(struct vos_object *obj, umem_off_t *known_key, daos_handle_t toh,
 	      const daos_epoch_range_t *epr, vos_iter_type_t type)
 {
+	daos_anchor_t		 anchor = {0};
 	struct dtx_handle	*dth = vos_dth_get();
+	d_iov_t			 key;
 	struct vos_key_info	 kinfo = {0};
+	struct vos_krec_df	*krec;
 	int			 rc;
 
+	/** The address of the known_key, which actually points at the krec is guaranteed by PMDK
+	 *  to be allocated at an 8 byte alignment so the low order bit is available to mark it as
+	 *  punched.
+	 */
+	if (*known_key != UMOFF_NULL && (*known_key & 0x1) == 0)
+		return 0;
+
+	kinfo.ki_obj = obj;
+	kinfo.ki_known_key = known_key;
+
+	if (*known_key == UMOFF_NULL)
+		goto tail;
+
+	krec = umem_off2ptr(vos_obj2umm(obj), (*known_key & ~(1ULL)));
+	d_iov_set(&key, vos_krec2key(krec), krec->kr_size);
+	dbtree_key2anchor(toh, &key, &anchor);
+
+	rc = vos_iterate_key(obj, toh, type, epr, true, empty_tree_check,
+			     &kinfo, dth, &anchor);
+
+	if (rc < 0)
+		return rc;
+
+	if (kinfo.ki_non_empty)
+		return 0;
+
+	/** Start from beginning one more time.  It will iterate until it
+	 *  sees the first thing it saw
+	 */
+tail:
 	rc = vos_iterate_key(obj, toh, type, epr, true, empty_tree_check,
 			     &kinfo, dth, NULL);
 
@@ -93,8 +177,7 @@ vos_propagate_check(struct vos_object *obj, umem_off_t *known_key, daos_handle_t
 		read_flag = VOS_TS_READ_OBJ;
 		write_flag = VOS_TS_WRITE_OBJ;
 		tree_name = "DKEY";
-		/** Skip object punch propagation until performation is addressed */
-		return 0;
+		break;
 	case VOS_ITER_AKEY:
 		read_flag = VOS_TS_READ_DKEY;
 		write_flag = VOS_TS_WRITE_DKEY;
@@ -621,24 +704,6 @@ fail:
  * - iterate a-key (array)
  * - iterate recx
  */
-static int
-key_iter_fetch_helper(struct vos_obj_iter *oiter, struct vos_rec_bundle *rbund,
-		      d_iov_t *keybuf, daos_anchor_t *anchor)
-{
-	d_iov_t			 kiov;
-	d_iov_t			 riov;
-	struct dcs_csum_info	 csum;
-
-	tree_rec_bundle2iov(rbund, &riov);
-
-	rbund->rb_iov	= keybuf;
-	rbund->rb_csum	= &csum;
-
-	d_iov_set(rbund->rb_iov, NULL, 0); /* no copy */
-	ci_set_null(rbund->rb_csum);
-
-	return dbtree_iter_fetch(oiter->it_hdl, &kiov, &riov, anchor);
-}
 
 static int
 key_iter_fetch(struct vos_obj_iter *oiter, vos_iter_entry_t *ent,

--- a/src/vos/vos_tree.c
+++ b/src/vos/vos_tree.c
@@ -1177,10 +1177,8 @@ key_tree_punch(struct vos_object *obj, daos_handle_t toh, daos_epoch_t epoch,
 	if (rc != 0)
 		goto done;
 
-	if (*known_key != umem_ptr2off(vos_obj2umm(obj), krec)) {
-		/** Set the bit to mark the key as punched.   Since this version doesn't support
-		 *  the optimization, this makes it compatible with versions that do.
-		 */
+	if (*known_key == umem_ptr2off(vos_obj2umm(obj), krec)) {
+		/** Set the value to UMOFF_NULL so punch propagation will run full check */
 		rc = umem_tx_add_ptr(vos_obj2umm(obj), known_key, sizeof(*known_key));
 		if (rc)
 			D_GOTO(done, rc);


### PR DESCRIPTION
* Rather than potentially iterating all keys twice during punch
propagation, iterate once and track whether we've seen
entries or uncommitted data.
* Use existing, unused space in the object and dkey durable format
to save offset of last key known to exist so we can skip scan.  This can
significantly speed up punch propagation in the common case by limiting
full scan to the occasional instance where the saved key is punched.
for punch propagation if the key hasn't been punched.
* Enable punch propagation to object level and associated mvcc tests

In vos_perf tests, I got the following results for punch of 100K dkeys
With this patch:                                0.7 seconds
with master branch:                             0.6 seconds
master branch with propagation to object level: 118 seconds

Seems like a good tradeoff.  It should improve delete performance of
directories containing many objects as in the ticket.

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>