### PR TITLE
DAOS-9060 dfuse: Open containers in RO mode if RW fails. (#7359)

### DIFF
--- a/src/client/dfs/dfs.c
+++ b/src/client/dfs/dfs.c
@@ -564,9 +564,8 @@ insert_entry(daos_handle_t oh, daos_handle_t th, const char *name, size_t len,
 	rc = daos_obj_update(oh, th, flags, &dkey, 1, &iod, &sgl, NULL);
 	if (rc) {
 		/** don't log error if conditional failed */
-		if (rc != -DER_EXIST)
-			D_ERROR("Failed to insert entry %s, "DF_RC"\n",
-				name, DP_RC(rc));
+		if (rc != -DER_EXIST && rc != -DER_NO_PERM)
+			D_ERROR("Failed to insert entry '%s', "DF_RC"\n", name, DP_RC(rc));
 		return daos_der2errno(rc);
 	}
 
@@ -984,12 +983,13 @@ open_dir(dfs_t *dfs, dfs_obj_t *parent, int flags, daos_oclass_id_t cid,
 		entry->oclass = parent->d.oclass;
 
 		/** since it's a single conditional op, we don't need a DTX */
-		rc = insert_entry(parent->oh, DAOS_TX_NONE, dir->name, len,
-				  DAOS_COND_DKEY_INSERT, entry);
+		rc = insert_entry(parent->oh, DAOS_TX_NONE, dir->name, len, DAOS_COND_DKEY_INSERT,
+				  entry);
 		if (rc != 0) {
 			daos_obj_close(dir->oh, NULL);
-			D_ERROR("Inserting dir entry %s failed (%d)\n",
-				dir->name, rc);
+			if (rc != EPERM)
+				D_ERROR("Inserting dir entry %s failed (%d)\n",	dir->name, rc);
+			return rc;
 		}
 
 		dir->d.chunk_size = entry->chunk_size;
@@ -1515,15 +1515,14 @@ dfs_mount(daos_handle_t poh, daos_handle_t coh, int flags, dfs_t **_dfs)
 	struct daos_prop_entry	*entry;
 	struct daos_prop_co_roots *roots;
 	struct dfs_entry	root_dir;
-	int			amode, obj_mode;
+	int			amode;
 	int			rc;
 
 	if (_dfs == NULL)
 		return EINVAL;
 
 	amode = (flags & O_ACCMODE);
-	obj_mode = get_daos_obj_mode(flags);
-	if (obj_mode == -1)
+	if (get_daos_obj_mode(flags) == -1)
 		return EINVAL;
 
 	prop = daos_prop_alloc(0);

--- a/src/client/dfuse/dfuse_core.c
+++ b/src/client/dfuse/dfuse_core.c
@@ -702,14 +702,13 @@ dfuse_set_default_cont_cache_values(struct dfuse_cont *dfc)
  * Only used for command line labels, not for paths in dfuse.
  */
 int
-dfuse_cont_open_by_label(struct dfuse_projection_info *fs_handle,
-			struct dfuse_pool *dfp,
-			const char *label,
-			struct dfuse_cont **_dfc)
+dfuse_cont_open_by_label(struct dfuse_projection_info *fs_handle, struct dfuse_pool *dfp,
+			 const char *label, struct dfuse_cont **_dfc)
 {
-	struct dfuse_cont *dfc;
-	daos_cont_info_t c_info = {};
-	int rc;
+	struct dfuse_cont	*dfc;
+	daos_cont_info_t	c_info = {};
+	int			dfs_flags = O_RDWR;
+	int			rc;
 
 	D_ALLOC_PTR(dfc);
 	if (dfc == NULL)
@@ -717,27 +716,24 @@ dfuse_cont_open_by_label(struct dfuse_projection_info *fs_handle,
 
 	DFUSE_TRA_UP(dfc, dfp, "dfc");
 
-	rc = daos_cont_open(dfp->dfp_poh, label, DAOS_COO_RW, &dfc->dfs_coh,
-			    &c_info, NULL);
+	rc = daos_cont_open(dfp->dfp_poh, label, DAOS_COO_RW, &dfc->dfs_coh, &c_info, NULL);
+	if (rc == -DER_NO_PERM) {
+		dfs_flags = O_RDONLY;
+		rc = daos_cont_open(dfp->dfp_poh, label, DAOS_COO_RO, &dfc->dfs_coh, &c_info, NULL);
+	}
 	if (rc == -DER_NONEXIST) {
-		DFUSE_TRA_INFO(dfc,
-			"daos_cont_open() failed: "
-			DF_RC, DP_RC(rc));
+		DFUSE_TRA_INFO(dfc, "daos_cont_open() failed: "	DF_RC, DP_RC(rc));
 		D_GOTO(err_free, rc = daos_der2errno(rc));
 	} else if (rc != -DER_SUCCESS) {
-		DFUSE_TRA_ERROR(dfc,
-				"daos_cont_open() failed: "
-				DF_RC, DP_RC(rc));
+		DFUSE_TRA_ERROR(dfc, "daos_cont_open() failed: " DF_RC, DP_RC(rc));
 		D_GOTO(err_free, rc = daos_der2errno(rc));
 	}
 
 	uuid_copy(dfc->dfs_cont, c_info.ci_uuid);
 
-	rc = dfs_mount(dfp->dfp_poh, dfc->dfs_coh, O_RDWR, &dfc->dfs_ns);
+	rc = dfs_mount(dfp->dfp_poh, dfc->dfs_coh, dfs_flags, &dfc->dfs_ns);
 	if (rc) {
-		DFUSE_TRA_ERROR(dfc,
-				"dfs_mount() failed: (%s)",
-				strerror(rc));
+		DFUSE_TRA_ERROR(dfc, "dfs_mount() failed: (%s)", strerror(rc));
 		D_GOTO(err_close, rc);
 	}
 
@@ -839,25 +835,26 @@ dfuse_cont_open(struct dfuse_projection_info *fs_handle, struct dfuse_pool *dfp,
 		dfc->dfc_ndentry_timeout = 5;
 
 	} else if (*_dfc == NULL) {
-		char	str[37];
+		char str[37];
+		int  dfs_flags = O_RDWR;
 
 		dfc->dfs_ops = &dfuse_dfs_ops;
 		uuid_copy(dfc->dfs_cont, *cont);
 		uuid_unparse(dfc->dfs_cont, str);
-		rc = daos_cont_open(dfp->dfp_poh, str, DAOS_COO_RW,
-				    &dfc->dfs_coh, NULL, NULL);
+		rc = daos_cont_open(dfp->dfp_poh, str, DAOS_COO_RW, &dfc->dfs_coh, NULL, NULL);
+		if (rc == -DER_NO_PERM) {
+			dfs_flags = O_RDONLY;
+			rc = daos_cont_open(dfp->dfp_poh, str, DAOS_COO_RO, &dfc->dfs_coh, NULL,
+					    NULL);
+		}
 		if (rc == -DER_NONEXIST) {
-			DFUSE_TRA_INFO(dfc, "daos_cont_open() failed: "DF_RC,
-				       DP_RC(rc));
+			DFUSE_TRA_INFO(dfc, "daos_cont_open() failed: " DF_RC, DP_RC(rc));
 			D_GOTO(err_free, rc = daos_der2errno(rc));
 		} else if (rc != -DER_SUCCESS) {
-			DFUSE_TRA_ERROR(dfc, "daos_cont_open() failed: "
-					DF_RC, DP_RC(rc));
+			DFUSE_TRA_ERROR(dfc, "daos_cont_open() failed: " DF_RC, DP_RC(rc));
 			D_GOTO(err_free, rc = daos_der2errno(rc));
 		}
-
-		rc = dfs_mount(dfp->dfp_poh, dfc->dfs_coh, O_RDWR,
-			       &dfc->dfs_ns);
+		rc = dfs_mount(dfp->dfp_poh, dfc->dfs_coh, dfs_flags, &dfc->dfs_ns);
 		if (rc) {
 			DFUSE_TRA_ERROR(dfc,
 					"dfs_mount() failed: (%s)",
@@ -868,19 +865,15 @@ dfuse_cont_open(struct dfuse_projection_info *fs_handle, struct dfuse_pool *dfp,
 		if (fs_handle->dpi_info->di_caching) {
 			rc = dfuse_cont_get_cache(dfc);
 			if (rc == ENODATA) {
-				/* If there is no container specific
-				 * attributes then use defaults
-				 */
-				DFUSE_TRA_INFO(dfc,
-					"Using default caching values");
+				/* If there are no container attributes then use defaults */
+				DFUSE_TRA_INFO(dfc, "Using default caching values");
 				dfuse_set_default_cont_cache_values(dfc);
 				rc = 0;
 			} else if (rc != 0) {
 				D_GOTO(err_close, rc);
 			}
 		} else {
-			DFUSE_TRA_INFO(dfc,
-				"Caching disabled");
+			DFUSE_TRA_INFO(dfc, "Caching disabled");
 		}
 	} else {
 		/* This is either a container where a label is set on the

--- a/src/client/dfuse/il/int_posix.c
+++ b/src/client/dfuse/il/int_posix.c
@@ -652,6 +652,7 @@ ioil_open_cont_handles(int fd, struct dfuse_il_reply *il_reply, struct ioil_cont
 	int			rc;
 	struct ioil_pool       *pool = cont->ioc_pool;
 	char			uuid_str[37];
+	int			dfs_flags = O_RDWR;
 
 	if (daos_handle_is_inval(pool->iop_poh)) {
 		uuid_unparse(il_reply->fir_pool, uuid_str);
@@ -661,12 +662,16 @@ ioil_open_cont_handles(int fd, struct dfuse_il_reply *il_reply, struct ioil_cont
 	}
 
 	uuid_unparse(il_reply->fir_cont, uuid_str);
-	rc = daos_cont_open(pool->iop_poh, uuid_str, DAOS_COO_RW,
-			    &cont->ioc_coh, NULL, NULL);
+	rc = daos_cont_open(pool->iop_poh, uuid_str, DAOS_COO_RW, &cont->ioc_coh, NULL, NULL);
+	if (rc == -DER_NO_PERM) {
+		dfs_flags = O_RDONLY;
+		rc = daos_cont_open(pool->iop_poh, uuid_str, DAOS_COO_RO, &cont->ioc_coh, NULL,
+				    NULL);
+	}
 	if (rc)
 		return false;
 
-	rc = dfs_mount(pool->iop_poh, cont->ioc_coh, O_RDWR, &cont->ioc_dfs);
+	rc = dfs_mount(pool->iop_poh, cont->ioc_coh, dfs_flags, &cont->ioc_dfs);
 	if (rc)
 		return false;
 

--- a/src/object/cli_shard.c
+++ b/src/object/cli_shard.c
@@ -335,8 +335,7 @@ dc_rw_cb_csum_verify(const struct rw_cb_args *rw_args)
 					DF_OID"): "DF_RC"\n",
 					DP_OID(orw->orw_oid.id_pub),
 					DP_RC(rc));
-				if (iovs_alloc != NULL)
-					D_FREE(iovs_alloc);
+				D_FREE(iovs_alloc);
 				break;
 			}
 		}
@@ -347,8 +346,7 @@ dc_rw_cb_csum_verify(const struct rw_cb_args *rw_args)
 		rc = daos_csummer_verify_iod(csummer_copy, &shard_iod,
 					     &shard_sgl, iod_csum, singv_lo,
 					     shard_idx, map);
-		if (iovs_alloc != NULL)
-			D_FREE(iovs_alloc);
+		D_FREE(iovs_alloc);
 		if (rc != 0) {
 			bool			 is_ec_obj;
 
@@ -673,7 +671,6 @@ dc_shard_csum_report(tse_task_t *task, crt_endpoint_t *tgt_ep, crt_rpc_t *rpc)
 	return crt_req_send(csum_rpc, csum_report_cb, rpc);
 }
 
-
 static bool
 dc_shard_singv_size_conflict(struct daos_oclass_attr *oca, daos_size_t old_size,
 			     daos_size_t new_size)
@@ -885,7 +882,7 @@ dc_rw_cb(tse_task_t *task, void *arg)
 		 * don't log errors in-case of possible conditionals or
 		 * rec2big errors which can be expected.
 		 */
-		if (rc == -DER_REC2BIG || rc == -DER_NONEXIST ||
+		if (rc == -DER_REC2BIG || rc == -DER_NONEXIST || rc == -DER_NO_PERM ||
 		    rc == -DER_EXIST || rc == -DER_RF)
 			D_DEBUG(DB_IO, "rpc %p opc %d to rank %d tag %d"
 				" failed: "DF_RC"\n", rw_args->rpc, opc,

--- a/src/tests/ftest/cart/util/cart_logparse.py
+++ b/src/tests/ftest/cart/util/cart_logparse.py
@@ -119,6 +119,8 @@ class LogLine():
     re_uiod = re.compile(r"\d{1,20}\.\d{1,20}.(\d{1,10})")
     # Match a RPCID from RPC_TRACE macro.
     re_rpcid = re.compile(r"rpcid=0x[0-9a-f]{1,16}")
+    # Match DF_CONT
+    re_cont = re.compile(r"[0-9a-f]{8}/[0-9a-f]{8}(:?)")
 
     def __init__(self, line):
         fields = line.split()
@@ -246,6 +248,10 @@ class LogLine():
                 r = self.re_rpcid.fullmatch(entry)
                 if r:
                     field = 'rpcid=<rpcid>'
+            if not field:
+                r = self.re_cont.fullmatch(entry)
+                if r:
+                    field = 'pool/cont{}'.format(r.group(1))
             if field:
                 fields.append(field)
             else:

--- a/utils/node_local_test.py
+++ b/utils/node_local_test.py
@@ -1948,6 +1948,49 @@ class posix_tests():
 
         ofd.close()
 
+    def test_cont_ro(self):
+        """Test access to a read-only container"""
+
+        # Update container ACLs so current user has rta permissions only, the minimum required.
+        rc = run_daos_cmd(self.conf, ['container',
+                                      'update-acl',
+                                      self.pool.id(),
+                                      self.container,
+                                      '--entry',
+                                      'A::{}@:rta'.format(os.getlogin())])
+        print(rc)
+        assert rc.returncode == 0
+
+        # Assign the container to someone else.
+        rc = run_daos_cmd(self.conf, ['container',
+                                      'set-owner',
+                                      self.pool.id(),
+                                      self.container,
+                                      '--user',
+                                      'root@'])
+        print(rc)
+        assert rc.returncode == 0
+
+        # Now start dfuse and access the container, this should require read-only opening.
+        dfuse = DFuse(self.server,
+                      self.conf,
+                      pool=self.pool.id(),
+                      container=self.container,
+                      caching=False,
+                      mount_path=os.path.join(self.conf.dfuse_parent_dir, 'dfuse_mount_backend'))
+        dfuse.start(v_hint='cont_ro')
+        print(os.listdir(dfuse.dir))
+
+        try:
+            with open(os.path.join(dfuse.dir, 'testfile'), 'w') as fd:
+                print(fd)
+            assert False
+        except PermissionError:
+            pass
+
+        if dfuse.stop():
+            self.fatal_errors = True
+
     @needs_dfuse
     def test_chmod_ro(self):
         """Test that chmod and fchmod work correctly with files created read-only


### PR DESCRIPTION
Allow read-only access to other peoples containers to be
configures/used.  Previously all containers would be opened
RW, which always works for your own containers regardless
of permissions, however if another user has granted you
read-only access to theirs then cont_open will fail and
dfuse needs to re-try RO.

Remove a local from dfs.c to make it clear open mode is
not used here, and silence some log errors when writes
are attempted in read-only mode.

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>