### PR TITLE
DAOS-9129-test: Fix container create oclass RP_3G5 error

### DIFF
--- a/src/tests/ftest/nvme/pool_exclude.yaml
+++ b/src/tests/ftest/nvme/pool_exclude.yaml
@@ -57,7 +57,7 @@ container:
     type: POSIX
     control_method: daos
     properties: cksum:crc16,cksum_size:16384,srv_cksum:on,rf:2
-    oclass: OC_RP_3G6
+    oclass: RP_3G6
 ior:
   client_processes:
     np: 48
@@ -68,8 +68,8 @@ ior:
     write_flags: "-w -F -k -G 1"
     read_flags: "-F -r -R -k -G 1"
     api: DFS
-    dfs_oclass: OC_RP_3G6
-    dfs_dir_oclass: OC_RP_3G6
+    dfs_oclass: RP_3G6
+    dfs_dir_oclass: RP_3G6
     ior_test_sequence:
     #   - [scm_size, nvme_size, transfersize, blocksize]
     #    The values are set to be in the multiples of 10.
@@ -79,8 +79,8 @@ ior:
         - [50000000000, 300000000000, 1000000000, 8000000000]  #[1G, 8G]
 test_obj_class:
   oclass:
-    - OC_RP_3G6
-    - OC_RP_4G1
+    - RP_3G6
+    - RP_4G1
 loop_test:
   iterations: 2
 aggregation:

--- a/src/tests/ftest/nvme/pool_exclude.yaml
+++ b/src/tests/ftest/nvme/pool_exclude.yaml
@@ -57,7 +57,7 @@ container:
     type: POSIX
     control_method: daos
     properties: cksum:crc16,cksum_size:16384,srv_cksum:on,rf:2
-    oclass: RP_3G5
+    oclass: OC_RP_3G6
 ior:
   client_processes:
     np: 48
@@ -68,8 +68,8 @@ ior:
     write_flags: "-w -F -k -G 1"
     read_flags: "-F -r -R -k -G 1"
     api: DFS
-    dfs_oclass: RP_3G5
-    dfs_dir_oclass: RP_3G5
+    dfs_oclass: OC_RP_3G6
+    dfs_dir_oclass: OC_RP_3G6
     ior_test_sequence:
     #   - [scm_size, nvme_size, transfersize, blocksize]
     #    The values are set to be in the multiples of 10.
@@ -79,8 +79,8 @@ ior:
         - [50000000000, 300000000000, 1000000000, 8000000000]  #[1G, 8G]
 test_obj_class:
   oclass:
-    - RP_3G5
-    - RP_4G1
+    - OC_RP_3G6
+    - OC_RP_4G1
 loop_test:
   iterations: 2
 aggregation:


### PR DESCRIPTION
Description: Updated pool_exclude.yaml with newly updated supported oclass RP_3G6

Skip-unit-tests: true
Test-tag: nvme_pool_exclude
Signed-off-by: Ding Ho ding-hwa.ho@intel.com