### PR TITLE
DAOS-8775 object: missing reintegrating setting (#7322)

### DIFF
--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -369,6 +369,7 @@ obj_layout_create(struct dc_object *obj, bool refresh)
 		obj_shard->do_target_id = layout->ol_shards[i].po_target;
 		obj_shard->do_fseq = layout->ol_shards[i].po_fseq;
 		obj_shard->do_rebuilding = layout->ol_shards[i].po_rebuilding;
+		obj_shard->do_reintegrating = layout->ol_shards[i].po_reintegrating;
 	}
 out:
 	if (layout)

--- a/src/placement/pl_map.c
+++ b/src/placement/pl_map.c
@@ -282,12 +282,14 @@ obj_layout_dump(daos_obj_id_t oid, struct pl_obj_layout *layout)
 		DP_OID(oid), layout->ol_ver);
 
 	for (i = 0; i < layout->ol_nr; i++)
-		D_DEBUG(DB_PL, "%d: shard_id %d, tgt_id %d, f_seq %d, %s\n",
+		D_DEBUG(DB_PL, "%d: shard_id %d, tgt_id %d, f_seq %d, %s %s\n",
 			i, layout->ol_shards[i].po_shard,
 			layout->ol_shards[i].po_target,
 			layout->ol_shards[i].po_fseq,
 			layout->ol_shards[i].po_rebuilding ?
-			"rebuilding" : "healthy");
+			"rebuilding" : "healthy",
+			layout->ol_shards[i].po_reintegrating ?
+			"reintegrating" : "healthy");
 }
 
 /**

--- a/src/tests/suite/daos_rebuild_simple.c
+++ b/src/tests/suite/daos_rebuild_simple.c
@@ -29,6 +29,10 @@
 
 #define DATA_SIZE	(1048576 * 2 + 512)
 
+#if 0
+/* Disable inflight IO due to DAOS-8775 for 2.0, and re-enable it until inflight I/O
+ * during reintegrated are supported.
+ */
 static int
 reintegrate_inflight_io(void *data)
 {
@@ -62,6 +66,7 @@ reintegrate_inflight_io(void *data)
 				      NULL);
 	return 0;
 }
+#endif
 
 static void
 reintegrate_with_inflight_io(test_arg_t *arg, daos_obj_id_t *oid,
@@ -80,9 +85,10 @@ reintegrate_with_inflight_io(test_arg_t *arg, daos_obj_id_t *oid,
 					 0, arg->myrank);
 	inflight_oid = dts_oid_set_rank(inflight_oid, rank);
 
+#if 0
 	arg->rebuild_cb = reintegrate_inflight_io;
 	arg->rebuild_cb_arg = &inflight_oid;
-
+#endif
 	/* To make sure the IO will be done before reintegration is done */
 	if (arg->myrank == 0)
 		daos_debug_set_params(arg->group, -1, DMG_KEY_FAIL_LOC,


### PR DESCRIPTION
Missing reintegrating setting for inflight I/O.

Remove reintegrate I/O from rebuild simple test.

Signed-off-by: Di Wang <di.wang@intel.com>
Co-authored-by: Jeff Olivier <jeffrey.v.olivier@intel.com>