### PR TITLE
DAOS-9117 tests: Adding more ranks to rebuild/no_cap.py

### DIFF
--- a/src/tests/ftest/rebuild/no_cap.py
+++ b/src/tests/ftest/rebuild/no_cap.py
@@ -47,7 +47,7 @@ class RbldNoCapacity(TestWithServers):
 
         """
         # Get the test params
-        targets = self.params.get("targets", "/run/server_config/*")
+        targets = self.params.get("targets", "/run/server_config/*/0/*")
         rank = self.params.get("rank_to_kill", "/run/rebuild/*")
         pool_query_timeout = self.params.get('pool_query_timeout', "/run/pool/*")
         interval = self.params.get('pool_query_interval', "/run/pool/*")

--- a/src/tests/ftest/rebuild/no_cap.py
+++ b/src/tests/ftest/rebuild/no_cap.py
@@ -49,6 +49,8 @@ class RbldNoCapacity(TestWithServers):
         # Get the test params
         targets = self.params.get("targets", "/run/server_config/*/0/*")
         rank = self.params.get("rank_to_kill", "/run/rebuild/*")
+        engines_per_host = self.params.get("engines_per_host",
+                                           "/run/server_config/*")
         pool_query_timeout = self.params.get('pool_query_timeout', "/run/pool/*")
         interval = self.params.get('pool_query_interval', "/run/pool/*")
         test_data_list = self.params.get('test_data_list', "/run/pool/*")
@@ -63,8 +65,8 @@ class RbldNoCapacity(TestWithServers):
         # make sure pool looks good before we start
         self.log.info("..(1)Check for pool and rebuild info ")
         pool_checks = {
-            "pi_nnodes": len(self.hostlist_servers),
-            "pi_ntargets": len(self.hostlist_servers) * targets,
+            "pi_nnodes": len(self.hostlist_servers) * engines_per_host,
+            "pi_ntargets": len(self.hostlist_servers) * targets * engines_per_host,
             "pi_ndisabled": 0
         }
         rebuild_checks = {

--- a/src/tests/ftest/rebuild/no_cap.yaml
+++ b/src/tests/ftest/rebuild/no_cap.yaml
@@ -8,9 +8,33 @@ hosts:
     - client-A
 timeout: 180
 server_config:
+  engines_per_host: 2
   name: daos_server
   servers:
-    targets: 8
+    0:
+      pinned_numa_node: 0
+      nr_xs_helpers: 1
+      fabric_iface: ib0
+      fabric_iface_port: 31317
+      log_file: daos_server0.log
+      bdev_class: nvme
+      bdev_list: ["0000:81:00.0"]
+      scm_class: dcpm
+      scm_list: ["/dev/pmem0"]
+      scm_mount: /mnt/daos0
+      targets: 8
+    1:
+      pinned_numa_node: 1
+      nr_xs_helpers: 1
+      fabric_iface: ib1
+      fabric_iface_port: 31417
+      log_file: daos_server1.log
+      bdev_class: nvme
+      bdev_list: ["0000:da:00.0"]
+      scm_class: dcpm
+      scm_list: ["/dev/pmem1"]
+      scm_mount: /mnt/daos1
+      targets: 8
 container:
   control_method: daos
   properties: "rf:1"
@@ -24,4 +48,4 @@ pool:
   test_data_list: [1048576]
   oclass: "OC_RP_2G1"
 rebuild:
-    rank_to_kill: 1
+  rank_to_kill: 1

--- a/src/tests/ftest/rebuild/no_cap.yaml
+++ b/src/tests/ftest/rebuild/no_cap.yaml
@@ -12,6 +12,7 @@ server_config:
   name: daos_server
   servers:
     0:
+      targets: 4
       pinned_numa_node: 0
       nr_xs_helpers: 1
       fabric_iface: ib0
@@ -22,8 +23,8 @@ server_config:
       scm_class: dcpm
       scm_list: ["/dev/pmem0"]
       scm_mount: /mnt/daos0
-      targets: 8
     1:
+      targets: 4
       pinned_numa_node: 1
       nr_xs_helpers: 1
       fabric_iface: ib1
@@ -34,7 +35,6 @@ server_config:
       scm_class: dcpm
       scm_list: ["/dev/pmem1"]
       scm_mount: /mnt/daos1
-      targets: 8
 container:
   control_method: daos
   properties: "rf:1"

--- a/src/tests/ftest/rebuild/no_cap.yaml
+++ b/src/tests/ftest/rebuild/no_cap.yaml
@@ -12,7 +12,7 @@ server_config:
   name: daos_server
   servers:
     0:
-      targets: 4
+      targets: 8
       pinned_numa_node: 0
       nr_xs_helpers: 1
       fabric_iface: ib0
@@ -24,7 +24,7 @@ server_config:
       scm_list: ["/dev/pmem0"]
       scm_mount: /mnt/daos0
     1:
-      targets: 4
+      targets: 8
       pinned_numa_node: 1
       nr_xs_helpers: 1
       fabric_iface: ib1

--- a/src/tests/ftest/util/rebuild_test_base.py
+++ b/src/tests/ftest/util/rebuild_test_base.py
@@ -44,7 +44,7 @@ class RebuildTestBase(TestWithServers):
         self.inputs.get_params(self)
 
         # Get the number of targets per engine for pool info calculations
-        self.targets = self.params.get("targets", "/run/server_config/*")
+        self.targets = self.server_managers[0].get_config_value("targets")
 
         self.server_count = len(self.hostlist_servers)
 


### PR DESCRIPTION
The rebuild/no_cap.py is currently failing with unable to find any
available service ranks for the pool after stopping rank 1.  This change
increases the initial number of available ranks from 2 to 4.

Quick-functional: true
Test-tag: no_cap

Signed-off-by: Phillip Henderson <phillip.henderson@intel.com>