### PR TITLE
DAOS-5579 (doc): daos_server.yml clarification

### DIFF
--- a/utils/config/daos_server.yml
+++ b/utils/config/daos_server.yml
@@ -6,7 +6,7 @@
 #
 #
 ## Name associated with the DAOS system.
-## Immutable after reformat.
+## Immutable after running "dmg storage format".
 #
 ## NOTE: Changing the DAOS system name is not supported yet.
 ##       It must not be changed from the default "daos_server".
@@ -16,7 +16,7 @@
 #
 #
 ## Access points
-## Immutable after reformat.
+## Immutable after running "dmg storage format".
 #
 ## To operate, DAOS will need a quorum of access point nodes to be available.
 ## Must have the same value for all agents and servers in a system.
@@ -54,14 +54,14 @@
 #
 #
 ## Fault domain path
-## Immutable after reformat.
+## Immutable after running "dmg storage format".
 #
 ## default: /hostname for a local configuration w/o fault domain
 #fault_path: /vcdu0/rack1/hostname
 #
 #
 ## Fault domain callback
-## Immutable after reformat.
+## Immutable after running "dmg storage format".
 #
 ## Path to executable which will return fault domain string.
 #
@@ -92,7 +92,7 @@
 #
 #
 ## NVMe SSD inclusion list
-## Immutable after reformat.
+## Immutable after running "dmg storage format".
 #
 ## Only use NVMe controllers with specific PCI addresses.
 ## Colons replaced by dots in PCI identifiers.
@@ -102,7 +102,7 @@
 #
 #
 ## NVMe SSD exclusion list
-## Immutable after reformat.
+## Immutable after running "dmg storage format".
 #
 ## Only use NVMe controllers with specific PCI addresses.
 ## Excludes drives listed in bdev_include and forces auto-detection to
@@ -208,7 +208,7 @@
 #engines:
 #-
 #  # Rank to be assigned as identifier for this engine.
-#  # Immutable after reformat.
+#  # Immutable after running "dmg storage format".
 #  #
 #  # Optional parameter; must be unique across all engines in the DAOS system.
 #  #
@@ -217,7 +217,7 @@
 #  rank: 0
 #
 #  # Number of I/O service threads (and network endpoints) per engine.
-#  # Immutable after reformat.
+#  # Immutable after running "dmg storage format".
 #  #
 #  # Each storage target manages a fraction of the (interleaved) SCM storage space,
 #  # and a fraction of one of the NVMe SSDs that are managed by this engine.
@@ -232,7 +232,7 @@
 #  targets: 16
 #
 #  # Number of additional offload service threads per engine.
-#  # Immutable after reformat.
+#  # Immutable after running "dmg storage format".
 #  #
 #  # Helper threads to accelerate checksum and server-side RPC dispatch.
 #  #
@@ -252,7 +252,7 @@
 #  pinned_numa_node: 0
 #
 #  # Offset of the first core to be used for I/O service threads (targets).
-#  # Immutable after reformat.
+#  # Immutable after running "dmg storage format".
 #  #
 #  # For best performance, it is necessary that the fabric_iface of this engine
 #  # resides on the same NUMA node as the first_core.
@@ -309,7 +309,7 @@
 #    # Options are:
 #    # - "dcpm" for real SCM (preferred option), scm_size ignored
 #    # - "ram" to emulate SCM with memory, scm_list ignored
-#    # Immutable after reformat.
+#    # Immutable after running "dmg storage format".
 #
 #    class: ram
 #
@@ -324,14 +324,14 @@
 #    # - "nvme" for NVMe SSDs (preferred option), bdev_size ignored
 #    # - "file" to emulate a NVMe SSD with a regular file
 #    # - "kdev" to use a kernel block device, bdev_size ignored
-#    # Immutable after reformat.
+#    # Immutable after running "dmg storage format".
 #
 #    class: nvme
 #
 #    # Backend block device configuration to be used by this engine instance.
 #    # When class is set to nvme, bdev_list is the list of unique NVMe IDs
 #    # that should be different across different engine instance.
-#    # Immutable after reformat.
+#    # Immutable after running "dmg storage format".
 #    bdev_list: ["0000:81:00.0"]  # generate regular nvme.conf
 #    # If VMD-enabled NVMe SSDs are used, the bdev_list should consist of the VMD
 #    # PCIe addresses, and not the BDF format transport IDs of the backing NVMe SSDs
@@ -340,7 +340,7 @@
 
 #-
 #  # Rank to be assigned as identifier for this engine.
-#  # Immutable after reformat.
+#  # Immutable after running "dmg storage format".
 #  #
 #  # Optional parameter; must be unique across all engines in the DAOS system.
 #  #
@@ -349,7 +349,7 @@
 #  rank: 1
 #
 #  # Number of I/O service threads (and network endpoints) per engine.
-#  # Immutable after reformat.
+#  # Immutable after running "dmg storage format".
 #  #
 #  # Each storage target manages a fraction of the (interleaved) SCM storage space,
 #  # and a fraction of one of the NVMe SSDs that are managed by this engine.
@@ -364,7 +364,7 @@
 #  targets: 16
 #
 #  # Number of additional offload service threads per engine.
-#  # Immutable after reformat.
+#  # Immutable after running "dmg storage format".
 #  #
 #  # Helper threads to accelerate checksum and server-side RPC dispatch.
 #  #
@@ -384,7 +384,7 @@
 #  pinned_numa_node: 1
 #
 #  # Offset of the first core to be used for I/O service threads (targets).
-#  # Immutable after reformat.
+#  # Immutable after running "dmg storage format".
 #  #
 #  # For best performance, it is necessary that the fabric_iface of this engine
 #  # resides on the same NUMA node as the first_core.
@@ -440,7 +440,7 @@
 #    # Options are:
 #    # - "dcpm" for real SCM (preferred option), scm_size is ignored
 #    # - "ram" to emulate SCM with memory, scm_list is ignored
-#    # Immutable after reformat.
+#    # Immutable after running "dmg storage format".
 #
 #    class: dcpm
 #
@@ -455,7 +455,7 @@
 #    # - "nvme" for NVMe SSDs (preferred option), bdev_{size,number} ignored
 #    # - "file" to emulate a NVMe SSD with a regular file, bdev_number ignored
 #    # - "kdev" to use a kernel block device, bdev_{size,number} ignored
-#    # Immutable after reformat.
+#    # Immutable after running "dmg storage format".
 #
 #    # When class is set to file, Linux AIO will be used to emulate NVMe.
 #    # The size of file that will be created is specified by bdev_size in GB units.


### PR DESCRIPTION
clarify "immutable after reformat" in daos_server.yml
(https://github.com/daos-stack/daos/pull/7403 backported to release/2.0)

Doc-only: true
Signed-off-by: Michael Hennecke <michael.hennecke@intel.com>