### PR TITLE
DAOS-9089 utils: re-enable autotest punch tests

### DIFF
--- a/src/client/kv/dc_kv.c
+++ b/src/client/kv/dc_kv.c
@@ -93,6 +93,16 @@ kv_hdl2ptr(daos_handle_t oh)
 	return container_of(hlink, struct dc_kv, hlink);
 }
 
+daos_handle_t daos_kv2objhandle(daos_handle_t kv_oh)
+{
+	struct dc_kv *dk = kv_hdl2ptr(kv_oh);
+
+	if (dk)
+		return dk->daos_oh;
+
+	return DAOS_HDL_INVAL;
+}
+
 static void
 kv_hdl_link(struct dc_kv *kv)
 {

--- a/src/include/daos/kv.h
+++ b/src/include/daos/kv.h
@@ -18,5 +18,6 @@ int dc_kv_get(tse_task_t *task);
 int dc_kv_put(tse_task_t *task);
 int dc_kv_remove(tse_task_t *task);
 int dc_kv_list(tse_task_t *task);
+daos_handle_t daos_kv2objhandle(daos_handle_t oh);
 
 #endif /* __DAOS_KVX_H__ */

--- a/src/utils/daos_autotest.c
+++ b/src/utils/daos_autotest.c
@@ -695,7 +695,6 @@ kv_read128(void)
 	return 0;
 }
 
-#if 0
 /**
  * Disable since it triggers an assertion error on the client.
  * Will be enabled once problem is fixed.
@@ -729,7 +728,6 @@ kv_punch(void)
 	step_success("");
 	return 0;
 }
-#endif
 
 static int
 kv_insert4k(void)
@@ -1110,18 +1108,18 @@ static struct step steps[] = {
 	{ 20,	"Inserting 128B values",		kv_insert128,	96 },
 	{ 21,	"Reading 128B values back",		kv_read128,	96 },
 	/** { 22,	"Listing keys",				kv_list,	96 },
-	* { 23,	"Punching object",			kv_punch,	96 },
 	*/
+	{ 23,	"Punching object",			kv_punch,	96 },
 	{ 24,	"Inserting 4KB values",			kv_insert4k,	96 },
 	{ 25,	"Reading 4KB values back",		kv_read4k,	96 },
 	/** { 26,	"Listing keys",				kv_list,	96 },
-	* { 27,	"Punching object",			kv_punch,	96 },
 	*/
+	{ 27,	"Punching object",			kv_punch,	96 },
 	{ 28,	"Inserting 1MB values",			kv_insert1m,	96 },
 	{ 29,	"Reading 1MB values back",		kv_read1m,	96 },
 	/** { 30,	"Listing keys",				kv_list,	96 },
-	* { 31,	"Punching object",			kv_punch,	96 },
 	*/
+	{ 31,	"Punching object",			kv_punch,	96 },
 
 	/** Test aux containers */
 	{ 40,	"Inserting into RF1 cont",		kv_insertrf1,	96 },

--- a/src/utils/daos_autotest.c
+++ b/src/utils/daos_autotest.c
@@ -19,6 +19,7 @@
 #include <daos/common.h>
 #include <daos/placement.h>
 #include <daos/pool.h>
+#include <daos/kv.h>
 
 #include "daos_hdlr.h"
 #include "math.h"
@@ -726,7 +727,8 @@ kv_punch(void)
 		return rc;
 	}
 
-	punch_rc = daos_obj_punch(oh, DAOS_TX_NONE, 0, NULL);
+	punch_rc = daos_obj_punch(daos_kv2objhandle(oh), DAOS_TX_NONE,
+				  0, NULL);
 	rc = daos_kv_close(oh, NULL);
 
 	if (punch_rc) {

--- a/src/utils/daos_autotest.c
+++ b/src/utils/daos_autotest.c
@@ -731,7 +731,7 @@ kv_punch(void)
 
 	if (punch_rc) {
 		step_fail("failed to punch object: %s", d_errdesc(punch_rc));
-		return rc;
+		return punch_rc;
 	}
 
 	if (rc) {
@@ -764,7 +764,7 @@ kv_insert4k(void)
 
 	if (put_rc) {
 		step_fail("failed to insert: %s", d_errdesc(put_rc));
-		return rc;
+		return put_rc;
 	}
 
 	if (rc) {
@@ -794,7 +794,7 @@ kv_read4k(void)
 
 	if (get_rc) {
 		step_fail("failed to read: %s", d_errdesc(get_rc));
-		return rc;
+		return get_rc;
 	}
 
 	if (rc) {
@@ -857,7 +857,7 @@ kv_read1m(void)
 
 	if (get_rc) {
 		step_fail("failed to insert: %s", d_errdesc(get_rc));
-		return rc;
+		return get_rc;
 	}
 
 	if (rc) {
@@ -1006,7 +1006,7 @@ kv_readrf2(void)
 
 	if (get_rc) {
 		step_fail("failed to read: %s", d_errdesc(get_rc));
-		return rc;
+		return get_rc;
 	}
 
 	if (rc) {
@@ -1202,7 +1202,8 @@ pool_autotest_hdlr(struct cmd_args_s *ap)
 
 		if (rc) {
 			force = 1;
-			ret = rc;
+			if (!ret)
+				ret = rc;
 			resume = s->clean_step;
 		}
 	}


### PR DESCRIPTION
A couple of improvements:

1. Enable punch test and fixed assertion because we don't pass correct object handle
   to kv_punch()
2. Fixed to return correct error in some cases.
3. limit write by 1/10 available free space so that pool size doesn't depend on hardware
performance.

Signed-off-by: Wang Shilong <shilong.wang@intel.com>