### PR TITLE
DAOS-9115: socket dirs and systemd RuntimeDirectory should match

### DIFF
--- a/docs/QSG/setup.md
+++ b/docs/QSG/setup.md
@@ -309,7 +309,6 @@ configuration files will be defined. Examples are available at
 		  cert: /etc/daos/certs/server.crt
 		  key: /etc/daos/certs/server.key
 		provider: ofi+verbs;ofi_rxm
-		socket_dir: /var/run/daos_server
 		nr_hugepages: 4096
 		control_log_mask: DEBUG
 		control_log_file: /tmp/daos_server.log
@@ -359,7 +358,6 @@ configuration files will be defined. Examples are available at
 		  ca_cert: /etc/daos/certs/daosCA.crt
 		  cert: /etc/daos/certs/agent.crt
 		  key: /etc/daos/certs/agent.key
-		runtime_dir: /var/run/daos_agent
 		log_file: /tmp/daos_agent.log
 
 1. Create a dmg configuration file by modifying the default `/etc/daos/daos_control.yml` file on the admin node. The following is an example of the `daos_control.yml`.

--- a/docs/QSG/suse_setup.md
+++ b/docs/QSG/suse_setup.md
@@ -323,7 +323,6 @@ configuration files will be defined. Examples are available at
 		  cert: /etc/daos/certs/server.crt
 		  key: /etc/daos/certs/server.key
 		provider: ofi+verbs;ofi_rxm
-		socket_dir: /var/run/daos_server
 		nr_hugepages: 4096
 		control_log_mask: DEBUG
 		control_log_file: /tmp/daos_server.log
@@ -373,7 +372,6 @@ configuration files will be defined. Examples are available at
 		  ca_cert: /etc/daos/certs/daosCA.crt
 		  cert: /etc/daos/certs/agent.crt
 		  key: /etc/daos/certs/agent.key
-		runtime_dir: /var/run/daos_agent
 		log_file: /tmp/daos_agent.log
 
 1. Create a dmg configuration file by modifying the default `/etc/daos/daos_control.yml` file on the admin node. The following is an example of the `daos_control.yml`.

--- a/docs/admin/predeployment_check.md
+++ b/docs/admin/predeployment_check.md
@@ -139,6 +139,13 @@ For the daos_agent, either uncomment and set the runtime_dir configuration value
 /etc/daos/daos_agent.yml or a location can be passed on the command line using
 the --runtime_dir flag (`daos_agent -d /tmp/daos_agent`).
 
+NOTE: Do not change these when running under `systemd` control.
+      If these directories need to be changed, then make sure that they match the
+      RuntimeDirectory setting in the /usr/lib/systemd/system/daos_agent.service
+      and /usr/lib/systemd/system/daos_server.service configuration files.
+      The socket directories will be created and removed by `systemd` when the
+      services are started and stopped.
+
 ### Default Directory (non-persistent)
 
 Files and directories created in /run and /var/run only survive until

--- a/utils/config/daos_agent.yml
+++ b/utils/config/daos_agent.yml
@@ -41,6 +41,11 @@
 #  key: /etc/daos/certs/agent.key
 
 # Use the given directory for creating unix domain sockets
+#
+# NOTE: Do not change this when running under systemd control. If it needs to
+#       be changed, then make sure that it matches the RuntimeDirectory setting
+#       in /usr/lib/systemd/system/daos_agent.service
+#
 # default: /var/run/daos_agent
 #runtime_dir: /var/run/daos_agent
 

--- a/utils/config/daos_server.yml
+++ b/utils/config/daos_server.yml
@@ -158,7 +158,12 @@
 ## with other system components. This setting is the base location to place
 ## the sockets in.
 #
+## NOTE: Do not change this when running under systemd control. If it needs to
+##       be changed, then make sure that it matches the RuntimeDirectory setting
+##       in /usr/lib/systemd/system/daos_server.service
+#
 ## default: /var/run/daos_server
+#
 #socket_dir: ./.daos/daos_server
 #
 #

--- a/utils/config/examples/daos_server_sockets.yml
+++ b/utils/config/examples/daos_server_sockets.yml
@@ -4,7 +4,6 @@ name: daos_server           # sys group daos_server
 access_points: ['example']  # management service leader (bootstrap)
 # port: 10001               # control listen port, default 10001
 provider: ofi+sockets       # map to CRT_PHY_ADDR_STR=ofi+sockets
-socket_dir: /tmp/daos_sockets
 nr_hugepages: 4096
 control_log_mask: DEBUG
 control_log_file: /tmp/daos_server.log

--- a/utils/config/examples/daos_server_unittests.yml
+++ b/utils/config/examples/daos_server_unittests.yml
@@ -4,7 +4,6 @@ name: daos_server           # sys group daos_server
 access_points: ['example']  # management service leader (bootstrap)
 # port: 10001               # control listen port, default 10001
 provider: ofi+sockets       # map to CRT_PHY_ADDR_STR=ofi+sockets
-socket_dir: /tmp/daos_sockets
 control_log_mask: DEBUG
 control_log_file: /tmp/daos_server.log
 


### PR DESCRIPTION
The daos_server.yml socket_dir and daos_agent.yml runtime_dir settings
for the socket directories should be kept at their defaults, especially
if the daemons are under systemd control. The systemd RuntimeDirectory
controls the location of these socket directories, and systemd will
create/remove them with the right permissions when the services are
started/stopped.

The example YML files and documentation have been updated with a warning
that these must match the systemd RuntimeDirectory (when daemons are under
systemd control), and/or those lines have been removed from the examples.

Doc-only: true
Signed-off-by: Michael Hennecke <michael.hennecke@intel.com>