### PR TITLE
DAOS-9141 engine: fix potential invalid memory access

### DIFF
--- a/src/engine/drpc_handler.c
+++ b/src/engine/drpc_handler.c
@@ -35,7 +35,7 @@ drpc_hdlr_fini(void)
 static bool
 module_id_is_valid(int module_id)
 {
-	return module_id < NUM_DRPC_MODULES;
+	return (module_id >= 0 && module_id < NUM_DRPC_MODULES);
 }
 
 int

--- a/src/engine/srv.c
+++ b/src/engine/srv.c
@@ -30,7 +30,7 @@
 /**
  * DAOS server threading model:
  * 1) a set of "target XS (xstream) set" per engine (dss_tgt_nr)
- * There is a "-c" option of daos_server to set the number.
+ * There is a "-t" option of daos_server to set the number.
  * For DAOS pool, one target XS set per VOS target to avoid extra lock when
  * accessing VOS file.
  * With in each target XS set, there is one "main XS":

--- a/src/engine/tests/drpc_handler_tests.c
+++ b/src/engine/tests/drpc_handler_tests.c
@@ -148,6 +148,8 @@ drpc_hdlr_register_bad_module_id(void **state)
 {
 	assert_rc_equal(drpc_hdlr_register(NUM_DRPC_MODULES,
 					   dummy_drpc_handler2), -DER_INVAL);
+	assert_rc_equal(drpc_hdlr_register(-1,
+					   dummy_drpc_handler2), -DER_INVAL);
 }
 
 static void

--- a/src/engine/ult.c
+++ b/src/engine/ult.c
@@ -413,8 +413,13 @@ ult_create_internal(void (*func)(void *), void *arg, int xs_type, int tgt_idx,
 	ABT_thread_attr		 attr;
 	struct dss_xstream	*dx;
 	int			 rc, rc1;
+	int			 stream_id;
 
-	dx = dss_get_xstream(sched_ult2xs(xs_type, tgt_idx));
+	stream_id = sched_ult2xs(xs_type, tgt_idx);
+	if (stream_id == -DER_INVAL)
+		return stream_id;
+
+	dx = dss_get_xstream(stream_id);
 	if (dx == NULL)
 		return -DER_NONEXIST;
 


### PR DESCRIPTION
1. if negative module id is passed in, drpc_hdlr_get_handler() will try
to access a random memory which is unexpected.

2. sched_ult2xs() might return negative, check return value early to
avoid assertion in dss_get_xstream()

3. -c option is deprecated, use -t in the comments instead.

Signed-off-by: Wang Shilong <shilong.wang@intel.com>