### PR TITLE
DAOS-9106 engine: yield CPU for asynchronous IV_UPDATE retry

### DIFF
--- a/src/engine/server_iv.c
+++ b/src/engine/server_iv.c
@@ -1037,25 +1037,6 @@ sync_comp_cb(void *arg, int rc)
 	if (cb_arg == NULL)
 		return rc;
 
-	/* Let's retry asynchronous IV only for GRPVER for the moment */
-	if (cb_arg->retry && rc == -DER_GRPVER && !cb_arg->ns->iv_stop) {
-		int rc1;
-
-		/* If the IV ns leader has been changed, then it will retry
-		 * in the mean time, it will rely on others to update the
-		 * ns for it.
-		 */
-		D_WARN("retry for class %d opc %d rc "DF_RC"\n",
-			cb_arg->iv_key.class_id, IV_UPDATE, DP_RC(rc));
-		rc1 = iv_op(cb_arg->ns, &cb_arg->iv_key, &cb_arg->iv_value,
-			    &cb_arg->iv_sync, cb_arg->shortcut, cb_arg->retry,
-			    cb_arg->opc);
-		if (rc1) {
-			D_ERROR("ds iv update retry failed: %d\n", rc1);
-			rc = rc1;
-		}
-	}
-
 	ds_iv_ns_put(cb_arg->ns);
 	d_sgl_fini(&cb_arg->iv_value, true);
 	D_FREE(cb_arg);


### PR DESCRIPTION
Asynchronous IV_UPDATE may hit -DER_GRPVER when the group member
changed. Under such case, if we directly retry without CPU yield,
then it may cause grp_ver for current IV_UPDATE has no chance to
be refreshed as to deadloop.

Signed-off-by: Fan Yong <fan.yong@intel.com>