### PR TITLE
DAOS-9093 cart: change progress strategy

### DIFF
--- a/src/cart/crt_context.c
+++ b/src/cart/crt_context.c
@@ -758,31 +758,6 @@ crt_req_timeout_untrack(struct crt_rpc_priv *rpc_priv)
 	}
 }
 
-static void
-crt_exec_timeout_cb(struct crt_rpc_priv *rpc_priv)
-{
-	struct crt_timeout_cb_priv	*cbs_timeout;
-	crt_timeout_cb			 cb_func;
-	void				*cb_args;
-	size_t				 cbs_size;
-	size_t				 i;
-
-	if (unlikely(crt_plugin_gdata.cpg_inited == 0 || rpc_priv == NULL))
-		return;
-
-	cbs_size = crt_plugin_gdata.cpg_timeout_size;
-	cbs_timeout = crt_plugin_gdata.cpg_timeout_cbs;
-
-	for (i = 0; i < cbs_size; i++) {
-		cb_func = cbs_timeout[i].ctcp_func;
-		cb_args = cbs_timeout[i].ctcp_args;
-		/* check for and execute timeout callbacks here */
-		if (cb_func != NULL)
-			cb_func(rpc_priv->crp_pub.cr_ctx, &rpc_priv->crp_pub,
-				cb_args);
-	}
-}
-
 static bool
 crt_req_timeout_reset(struct crt_rpc_priv *rpc_priv)
 {
@@ -991,8 +966,6 @@ crt_context_timeout_check(struct crt_context *crt_ctx)
 			  rpc_priv->crp_pub.cr_ep.ep_rank,
 			  rpc_priv->crp_pub.cr_ep.ep_tag);
 
-		/* check for and execute RPC timeout callbacks here */
-		crt_exec_timeout_cb(rpc_priv);
 		crt_req_timeout_hdlr(rpc_priv);
 		RPC_DECREF(rpc_priv);
 	}
@@ -1488,12 +1461,7 @@ crt_progress(crt_context_t crt_ctx, int64_t timeout)
 	struct crt_context	*ctx;
 	int			 rc = 0;
 
-	/** validate input parameters */
-	if (unlikely(crt_ctx == CRT_CONTEXT_NULL)) {
-		D_ERROR("invalid parameter (NULL crt_ctx).\n");
-		return -DER_INVAL;
-	}
-
+	D_ASSERT(crt_ctx != CRT_CONTEXT_NULL);
 	ctx = crt_ctx;
 
 	/**
@@ -1511,7 +1479,7 @@ crt_progress(crt_context_t crt_ctx, int64_t timeout)
 	crt_context_timeout_check(ctx);
 	timeout = crt_exec_progress_cb(ctx, timeout);
 
-	if (timeout != 0 && (rc == 0 || rc == -DER_TIMEDOUT)) {
+	if (unlikely(rc == -DER_TIMEDOUT && timeout != 0)) {
 		/** call progress once again with the real timeout */
 		rc = crt_hg_progress(&ctx->cc_hg_ctx, timeout);
 		if (unlikely(rc && rc != -DER_TIMEDOUT))
@@ -1616,63 +1584,6 @@ out_unlock:
 
 	D_MUTEX_UNLOCK(&crt_plugin_gdata.cpg_mutex);
 out:
-	return rc;
-}
-
-/**
- * to use this function, the user has to:
- * 1) define a callback function user_cb
- * 2) call crt_register_timeout_cb_core(user_cb);
- */
-int
-crt_register_timeout_cb(crt_timeout_cb func, void *args)
-{
-	struct crt_timeout_cb_priv *cbs_timeout;
-	size_t i, cbs_size;
-	int rc = 0;
-
-	D_MUTEX_LOCK(&crt_plugin_gdata.cpg_mutex);
-
-	cbs_size = crt_plugin_gdata.cpg_timeout_size;
-	cbs_timeout = crt_plugin_gdata.cpg_timeout_cbs;
-
-	for (i = 0; i < cbs_size; i++) {
-		if (cbs_timeout[i].ctcp_func == func &&
-		    cbs_timeout[i].ctcp_args == args) {
-			D_GOTO(out_unlock, rc = -DER_EXIST);
-		}
-	}
-
-	for (i = 0; i < cbs_size; i++) {
-		if (cbs_timeout[i].ctcp_func == NULL) {
-			cbs_timeout[i].ctcp_args = args;
-			cbs_timeout[i].ctcp_func = func;
-			D_GOTO(out_unlock, rc = 0);
-		}
-	}
-
-	D_FREE(crt_plugin_gdata.cpg_timeout_cbs_old);
-
-	crt_plugin_gdata.cpg_timeout_cbs_old = cbs_timeout;
-	cbs_size += CRT_CALLBACKS_NUM;
-
-	D_ALLOC_ARRAY(cbs_timeout, cbs_size);
-	if (cbs_timeout == NULL) {
-		crt_plugin_gdata.cpg_timeout_cbs_old = NULL;
-		D_GOTO(out_unlock, rc = -DER_NOMEM);
-	}
-
-	if (i > 0)
-		memcpy(cbs_timeout, crt_plugin_gdata.cpg_timeout_cbs_old,
-		       i * sizeof(*cbs_timeout));
-	cbs_timeout[i].ctcp_args = args;
-	cbs_timeout[i].ctcp_func = func;
-
-	crt_plugin_gdata.cpg_timeout_cbs  = cbs_timeout;
-	crt_plugin_gdata.cpg_timeout_size = cbs_size;
-
-out_unlock:
-	D_MUTEX_UNLOCK(&crt_plugin_gdata.cpg_mutex);
 	return rc;
 }
 

--- a/src/cart/crt_hg.c
+++ b/src/cart/crt_hg.c
@@ -1337,9 +1337,9 @@ crt_hg_reply_error_send(struct crt_rpc_priv *rpc_priv, int error_code)
 int
 crt_hg_progress(struct crt_hg_context *hg_ctx, int64_t timeout)
 {
-	hg_context_t		*hg_context;
-	unsigned int		hg_timeout;
-	unsigned int		total = 256;
+	hg_context_t	*hg_context;
+	unsigned int	hg_timeout;
+	unsigned int	total = 256;
 
 	hg_context = hg_ctx->chc_hgctx;
 
@@ -1352,15 +1352,15 @@ crt_hg_progress(struct crt_hg_context *hg_ctx, int64_t timeout)
 		hg_timeout = timeout / 1000;
 
 	do {
-		hg_return_t     hg_ret = HG_SUCCESS;
-		int             rc = 0;
-		unsigned int count = 0;
+		hg_return_t	hg_ret;
+		int		rc = 0;
+		unsigned int	count = 0;
 
 		/** progress RPC execution */
 		hg_ret = HG_Progress(hg_context, hg_timeout);
 		if (hg_ret == HG_TIMEOUT) {
 			rc = -DER_TIMEDOUT;
-		} else if (hg_ret != HG_SUCCESS) {
+		} else if (unlikely(hg_ret != HG_SUCCESS)) {
 			D_ERROR("HG_Progress failed, hg_ret: %d.\n", hg_ret);
 			return -DER_HG;
 		}
@@ -1370,12 +1370,12 @@ crt_hg_progress(struct crt_hg_context *hg_ctx, int64_t timeout)
 		if (hg_ret == HG_TIMEOUT) {
 			/** nothing to trigger */
 			return rc;
-		} else if (hg_ret != HG_SUCCESS) {
+		} else if (unlikely(hg_ret != HG_SUCCESS)) {
 			D_ERROR("HG_Trigger failed, hg_ret: %d.\n", hg_ret);
 			return -DER_HG;
 		}
 
-		if (count == 0 || rc)
+		if (rc || count == 0)
 			/** nothing to trigger */
 			return rc;
 

--- a/src/cart/crt_init.c
+++ b/src/cart/crt_init.c
@@ -235,7 +235,6 @@ static int
 crt_plugin_init(void)
 {
 	struct crt_prog_cb_priv *cbs_prog;
-	struct crt_timeout_cb_priv *cbs_timeout;
 	struct crt_event_cb_priv *cbs_event;
 	size_t cbs_size = CRT_CALLBACKS_NUM;
 	int i, rc;
@@ -254,18 +253,10 @@ crt_plugin_init(void)
 		crt_plugin_gdata.cpg_prog_cbs[i]  = cbs_prog;
 	}
 
-	crt_plugin_gdata.cpg_timeout_cbs_old = NULL;
-	D_ALLOC_ARRAY(cbs_timeout, cbs_size);
-	if (cbs_timeout == NULL)
-		D_GOTO(out_destroy_prog, rc = -DER_NOMEM);
-
-	crt_plugin_gdata.cpg_timeout_size = cbs_size;
-	crt_plugin_gdata.cpg_timeout_cbs  = cbs_timeout;
-
 	crt_plugin_gdata.cpg_event_cbs_old = NULL;
 	D_ALLOC_ARRAY(cbs_event, cbs_size);
 	if (cbs_event == NULL) {
-		D_GOTO(out_destroy_timeout, rc = -DER_NOMEM);
+		D_GOTO(out_destroy_prog, rc = -DER_NOMEM);
 	}
 	crt_plugin_gdata.cpg_event_size = cbs_size;
 	crt_plugin_gdata.cpg_event_cbs  = cbs_event;
@@ -279,8 +270,6 @@ crt_plugin_init(void)
 
 out_destroy_event:
 	D_FREE(crt_plugin_gdata.cpg_event_cbs);
-out_destroy_timeout:
-	D_FREE(crt_plugin_gdata.cpg_timeout_cbs);
 out_destroy_prog:
 	for (i = 0; i < CRT_SRV_CONTEXT_NUM; i++)
 		D_FREE(crt_plugin_gdata.cpg_prog_cbs[i]);
@@ -302,9 +291,6 @@ crt_plugin_fini(void)
 		if (crt_plugin_gdata.cpg_prog_cbs_old[i])
 			D_FREE(crt_plugin_gdata.cpg_prog_cbs_old[i]);
 	}
-
-	D_FREE(crt_plugin_gdata.cpg_timeout_cbs);
-	D_FREE(crt_plugin_gdata.cpg_timeout_cbs_old);
 
 	D_FREE(crt_plugin_gdata.cpg_event_cbs);
 	D_FREE(crt_plugin_gdata.cpg_event_cbs_old);

--- a/src/cart/crt_internal_types.h
+++ b/src/cart/crt_internal_types.h
@@ -122,11 +122,6 @@ struct crt_prog_cb_priv {
 	void			*cpcp_args;
 };
 
-struct crt_timeout_cb_priv {
-	crt_timeout_cb		 ctcp_func;
-	void			*ctcp_args;
-};
-
 struct crt_event_cb_priv {
 	crt_event_cb		 cecp_func;
 	void			*cecp_args;
@@ -147,10 +142,6 @@ struct crt_plugin_gdata {
 	size_t				 cpg_prog_size[CRT_SRV_CONTEXT_NUM];
 	struct crt_prog_cb_priv		*cpg_prog_cbs[CRT_SRV_CONTEXT_NUM];
 	struct crt_prog_cb_priv		*cpg_prog_cbs_old[CRT_SRV_CONTEXT_NUM];
-	/* list of rpc timeout callbacks */
-	size_t				 cpg_timeout_size;
-	struct crt_timeout_cb_priv	*cpg_timeout_cbs;
-	struct crt_timeout_cb_priv	*cpg_timeout_cbs_old;
 	/* list of event notification callbacks */
 	size_t				 cpg_event_size;
 	struct crt_event_cb_priv	*cpg_event_cbs;

--- a/src/include/cart/api.h
+++ b/src/include/cart/api.h
@@ -1738,15 +1738,6 @@ crt_register_progress_cb(crt_progress_cb cb, int ctx_idx, void *arg);
 int
 crt_unregister_progress_cb(crt_progress_cb cb, int ctx_idx, void *arg);
 
-typedef void
-(*crt_timeout_cb) (crt_context_t ctx, crt_rpc_t *rpc, void *arg);
-
-int
-crt_register_timeout_cb(crt_timeout_cb cb, void *arg);
-
-typedef void
-(*crt_eviction_cb) (crt_group_t *grp, d_rank_t rank, void *arg);
-
 enum crt_event_source {
 	CRT_EVS_UNKNOWN,
 	/**< Event triggered by SWIM >*/


### PR DESCRIPTION
- Dont' call hg_progress again in cart_progress if the first
  call with zero timeout processed anything.
- Remove unused timeout callback mechanism.

Signed-off-by: Johann Lombardi <johann.lombardi@intel.com>