### PR TITLE
DAOS-9100 swim: Revert "DAOS-9033 swim: Avoid busy loop in SWIM progress"

### DIFF
--- a/src/cart/crt_hg.c
+++ b/src/cart/crt_hg.c
@@ -1284,17 +1284,6 @@ crt_hg_reply_send(struct crt_rpc_priv *rpc_priv)
 
 	D_ASSERT(rpc_priv != NULL);
 
-	if (D_LOG_ENABLED(DB_NET)) {
-		uint64_t hlc = crt_hlc_get();
-
-		if (hlc > rpc_priv->crp_create_hlc) {
-			uint64_t delay = crt_hlc2msec(hlc - rpc_priv->crp_create_hlc);
-
-			if (delay > 500)
-				RPC_TRACE(DB_NET, rpc_priv, "RPC reply took %lu ms.\n", delay);
-		}
-	}
-
 	RPC_ADDREF(rpc_priv);
 	hg_ret = HG_Respond(rpc_priv->crp_hg_hdl, crt_hg_reply_send_cb,
 			    rpc_priv, &rpc_priv->crp_pub.cr_output);

--- a/src/cart/crt_rpc.c
+++ b/src/cart/crt_rpc.c
@@ -1245,17 +1245,6 @@ crt_req_send_immediately(struct crt_rpc_priv *rpc_priv)
 	}
 	D_ASSERT(rpc_priv->crp_hg_hdl != NULL);
 
-	if (D_LOG_ENABLED(DB_NET)) {
-		uint64_t hlc = crt_hlc_get();
-
-		if (hlc > rpc_priv->crp_create_hlc) {
-			uint64_t delay = crt_hlc2msec(hlc - rpc_priv->crp_create_hlc);
-
-			if (delay > 20)
-				RPC_TRACE(DB_NET, rpc_priv, "RPC send took %lu ms.\n", delay);
-		}
-	}
-
 	/* set state ahead to avoid race with completion cb */
 	rpc_priv->crp_state = RPC_STATE_REQ_SENT;
 	rc = crt_hg_req_send(rpc_priv);
@@ -1614,7 +1603,6 @@ crt_rpc_priv_init(struct crt_rpc_priv *rpc_priv, crt_context_t crt_ctx,
 	crt_rpc_inout_buff_init(rpc_priv);
 
 	rpc_priv->crp_timeout_sec = ctx->cc_timeout_sec;
-	rpc_priv->crp_create_hlc = crt_hlc_get();
 
 exit:
 	return rc;
@@ -1638,17 +1626,6 @@ crt_handle_rpc(void *arg)
 	rpc_priv = container_of(rpc_pub, struct crt_rpc_priv, crp_pub);
 	D_ASSERT(rpc_priv->crp_opc_info != NULL);
 	D_ASSERT(rpc_priv->crp_opc_info->coi_rpc_cb != NULL);
-
-	if (D_LOG_ENABLED(DB_NET)) {
-		uint64_t hlc = crt_hlc_get();
-
-		if (hlc > rpc_priv->crp_create_hlc) {
-			uint64_t delay = crt_hlc2msec(hlc - rpc_priv->crp_create_hlc);
-
-			if (delay > 20)
-				RPC_TRACE(DB_NET, rpc_priv, "RPC schedule took %lu ms.\n", delay);
-		}
-	}
 
 	/*
 	 * for user initiated corpc if it delivered to itself, in user's RPC
@@ -1723,8 +1700,7 @@ crt_rpc_common_hdlr(struct crt_rpc_priv *rpc_priv)
 	if (!rpc_priv->crp_opc_info->coi_no_reply)
 		rpc_priv->crp_reply_pending = 1;
 
-	if (crt_rpc_cb_customized(crt_ctx, &rpc_priv->crp_pub) &&
-	    !crt_opc_is_swim(rpc_priv->crp_req_hdr.cch_opc)) {
+	if (crt_rpc_cb_customized(crt_ctx, &rpc_priv->crp_pub)) {
 		rc = crt_ctx->cc_rpc_cb((crt_context_t)crt_ctx,
 					&rpc_priv->crp_pub,
 					crt_handle_rpc,
@@ -1785,7 +1761,7 @@ timeout_bp_node_cmp(struct d_binheap_node *a, struct d_binheap_node *b)
 	rpc_priv_a = container_of(a, struct crt_rpc_priv, crp_timeout_bp_node);
 	rpc_priv_b = container_of(b, struct crt_rpc_priv, crp_timeout_bp_node);
 
-	return rpc_priv_a->crp_expire_hlc < rpc_priv_b->crp_expire_hlc;
+	return rpc_priv_a->crp_timeout_ts < rpc_priv_b->crp_timeout_ts;
 }
 
 struct d_binheap_ops crt_timeout_bh_ops = {

--- a/src/cart/crt_rpc.h
+++ b/src/cart/crt_rpc.h
@@ -131,9 +131,8 @@ struct crt_rpc_priv {
 	struct d_binheap_node	crp_timeout_bp_node;
 	/* the timeout in seconds set by user */
 	uint32_t		crp_timeout_sec;
-	/* HLC time stamp to be timeout, the key of timeout binheap */
-	uint64_t		crp_expire_hlc;
-	uint64_t		crp_create_hlc;
+	/* time stamp to be timeout, the key of timeout binheap */
+	uint64_t		crp_timeout_ts;
 	crt_cb_t		crp_complete_cb;
 	void			*crp_arg; /* argument for crp_complete_cb */
 	struct crt_ep_inflight	*crp_epi; /* point back to inflight ep */
@@ -647,17 +646,20 @@ crt_req_timedout(struct crt_rpc_priv *rpc_priv)
 	       !rpc_priv->crp_in_binheap;
 }
 
-static inline void
+static inline uint64_t
 crt_set_timeout(struct crt_rpc_priv *rpc_priv)
 {
-	uint64_t hlc = crt_hlc_get();
+	uint64_t	sec_diff;
 
 	D_ASSERT(rpc_priv != NULL);
 
 	if (rpc_priv->crp_timeout_sec == 0)
 		rpc_priv->crp_timeout_sec = crt_gdata.cg_timeout;
 
-	rpc_priv->crp_expire_hlc = hlc + crt_sec2hlc(rpc_priv->crp_timeout_sec);
+	sec_diff = d_timeus_secdiff(rpc_priv->crp_timeout_sec);
+	rpc_priv->crp_timeout_ts = sec_diff;
+
+	return sec_diff;
 }
 
 /* Convert opcode to string. Only returns string for internal RPCs */

--- a/src/cart/crt_swim.c
+++ b/src/cart/crt_swim.c
@@ -756,16 +756,10 @@ static int64_t crt_swim_progress_cb(crt_context_t crt_ctx, int64_t timeout, void
 			D_ERROR("SWIM shutdown\n");
 		swim_self_set(ctx, SWIM_ID_INVALID);
 	} else if (rc == -DER_TIMEDOUT || rc == -DER_CANCELED) {
-		/*
-		 * Change only for very long timeout to avoid confusing of DAOS scheduler.
-		 * NB: !!! Mercury only supports milli-second timeout !!!
-		 */
-		if (timeout > 1000) {
-			uint64_t hlc = crt_hlc_get();
+		uint64_t now = swim_now_ms();
 
-			if (hlc < ctx->sc_next_event)
-				timeout = crt_hlc2msec(ctx->sc_next_event - hlc);
-		}
+		if (now < ctx->sc_next_event)
+			timeout = ctx->sc_next_event - now;
 	} else if (rc) {
 		D_ERROR("swim_progress(): "DF_RC"\n", DP_RC(rc));
 	}
@@ -1075,11 +1069,7 @@ void crt_swim_accommodate(void)
 		else if (average > max_timeout)
 			average = max_timeout;
 
-		/*
-		 * (x >> 5) is just (x / 32) but a way faster.
-		 * This should avoid changes for small deltas.
-		 */
-		if ((average >> 5) != (ping_timeout >> 5)) {
+		if (average != ping_timeout) {
 			D_INFO("change PING timeout from %lu ms to %lu ms\n",
 			       ping_timeout, average);
 			swim_ping_timeout_set(average);

--- a/src/cart/swim/swim_internal.h
+++ b/src/cart/swim/swim_internal.h
@@ -19,8 +19,8 @@
 #include <string.h>
 #include <sys/queue.h>
 #include <errno.h>
+#include <time.h>
 
-#include <cart/api.h>
 #include <cart/swim.h>
 #include <gurt/debug.h>
 #include <gurt/common.h>
@@ -131,6 +131,17 @@ swim_ctx_unlock(struct swim_context *ctx)
 		SWIM_ERROR("SWIM_MUTEX_UNLOCK() failed rc=%d\n", rc);
 
 	return rc;
+}
+
+static inline uint64_t
+swim_now_ms(void)
+{
+	struct timespec now;
+	int rc;
+
+	rc = clock_gettime(CLOCK_MONOTONIC, &now);
+
+	return rc ? 0 : now.tv_sec * 1000 + now.tv_nsec / 1000000;
 }
 
 static inline enum swim_context_state

--- a/src/tests/ftest/cart/test_swim_emu.c
+++ b/src/tests/ftest/cart/test_swim_emu.c
@@ -84,7 +84,7 @@ static int test_send_message(struct swim_context *ctx, swim_id_t id,
 		item->np_to    = to;
 		item->np_upds  = upds;
 		item->np_nupds = nupds;
-		item->np_time  = crt_hlc_get();
+		item->np_time  = swim_now_ms();
 
 		D_SPIN_LOCK(&g.lock);
 		TAILQ_INSERT_TAIL(&g.pkts, item, np_link);
@@ -217,7 +217,7 @@ int test_run(void)
 {
 	enum swim_member_status s;
 	struct timespec now;
-	uint64_t time = crt_hlc_get();
+	uint64_t time = swim_now_ms();
 	int i, j, cs, cd, tick, rc = 0;
 
 	sleep(1);
@@ -320,7 +320,7 @@ static void deliver_pkt(struct network_pkt *item)
 	int i, rc = 0;
 
 	max_delay = swim_ping_timeout_get() / 2;
-	rcv_delay = crt_hlc2msec(crt_hlc_get() - item->np_time);
+	rcv_delay = swim_now_ms() - item->np_time;
 
 	for (i = 0; i < item->np_nupds; i++) {
 		id = item->np_upds[i].smu_id;
@@ -470,6 +470,10 @@ int test_fini(void)
 
 	return rc;
 }
+
+#ifdef USE_CART_FOR_DEBUG_LOG
+extern int crt_init_opt(char *grpid, uint32_t flags, void *opt);
+#endif
 
 int test_init(void)
 {


### PR DESCRIPTION
Reverts daos-stack/daos#7186 due to spurious exclusion issues.