### PR TITLE
DAOS-9121 build: fix socketid in spdk scan with vmd

### DIFF
--- a/utils/build.config
+++ b/utils/build.config
@@ -14,5 +14,5 @@ PSM2 = PSM2_11.2.78
 PROTOBUFC = v1.3.3
 
 [patch_versions]
-spdk=https://github.com/spdk/spdk/commit/690783a3ae82ebe58c00d643520a66103d66d540.diff,https://github.com/spdk/spdk/commit/65425be69a0882ac283fb489aa151d7df06c52ad.diff,https://raw.githubusercontent.com/daos-stack/spdk/master/0003-blob-chunk-clear-operations-in-IU-aligned-chunks.patch
+spdk=https://github.com/spdk/spdk/commit/690783a3ae82ebe58c00d643520a66103d66d540.diff,https://github.com/spdk/spdk/commit/65425be69a0882ac283fb489aa151d7df06c52ad.diff,https://raw.githubusercontent.com/daos-stack/spdk/master/0003-blob-chunk-clear-operations-in-IU-aligned-chunks.patch,https://github.com/spdk/spdk/commit/086223c029389329b7a4f38ec0f9a30be83849bf.diff
 pmdk=https://raw.githubusercontent.com/daos-stack/pmdk/master/DAOS_8273.patch


### PR DESCRIPTION
Fix SPDK bug where incorrect socket-ID is reported in NVMe controller
details when running daos_server storage scan or dmg storage scan -v.

Fix is to apply SPDK patch #10373 in build.config for source builds,
another PR will update SPDK RPM repo to apply the same patch.

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>