### PR TITLE
DAOS-9036 dtx: avoid potential RPC related leak

### DIFF
--- a/src/cart/crt_rpc.c
+++ b/src/cart/crt_rpc.c
@@ -1357,13 +1357,13 @@ crt_req_send(crt_rpc_t *req, crt_cb_t complete_cb, void *arg)
 	 */
 	RPC_ADDREF(rpc_priv);
 
+	rpc_priv->crp_complete_cb = complete_cb;
+	rpc_priv->crp_arg = arg;
+
 	if (req->cr_ctx == NULL) {
 		D_ERROR("invalid parameter (NULL req->cr_ctx).\n");
 		D_GOTO(out, rc = -DER_INVAL);
 	}
-
-	rpc_priv->crp_complete_cb = complete_cb;
-	rpc_priv->crp_arg = arg;
 
 	if (rpc_priv->crp_coll) {
 		rc = crt_corpc_req_hdlr(rpc_priv);

--- a/src/include/daos_srv/dtx_srv.h
+++ b/src/include/daos_srv/dtx_srv.h
@@ -130,6 +130,7 @@ struct dtx_handle {
 struct dtx_sub_status {
 	struct daos_shard_tgt		dss_tgt;
 	int				dss_result;
+	uint32_t			dss_completed:1;
 };
 
 struct dtx_leader_handle;


### PR DESCRIPTION
There is potential RPC related leak when crt_req_send() return failure
but without calling related completion callback.

Signed-off-by: Fan Yong <fan.yong@intel.com>