### PR TITLE
DAOS-9104 utils: skip container creations properly (#7466)

### DIFF
--- a/src/utils/daos_autotest.c
+++ b/src/utils/daos_autotest.c
@@ -246,6 +246,11 @@ ccreate(void)
 	if (rc)
 		D_GOTO(fail, rc);
 
+	if (domain_nr < 2) {
+		step_skip("Group size 2 is larger than domain_nr(%d)", domain_nr);
+		return 0;
+	}
+
 	/** Create container with RF=1 */
 	daos_prop_t	*prop;
 
@@ -258,6 +263,11 @@ ccreate(void)
 	daos_prop_free(prop);
 	if (rc)
 		D_GOTO(fail, rc);
+
+	if (domain_nr < 3) {
+		step_skip("Group size 3 is larger than domain_nr(%d)", domain_nr);
+		return 0;
+	}
 
 	/** Create container with RF=2 */
 	daos_prop_t	*prop2;
@@ -290,13 +300,17 @@ copen(void)
 	if (rc)
 		D_GOTO(fail, rc);
 
-	rc = daos_cont_open(poh, cuuid2, DAOS_COO_RW, &coh2, NULL, NULL);
-	if (rc)
-		D_GOTO(fail, rc);
+	if (domain_nr >= 2) {
+		rc = daos_cont_open(poh, cuuid2, DAOS_COO_RW, &coh2, NULL, NULL);
+		if (rc)
+			D_GOTO(fail, rc);
+	}
 
-	rc = daos_cont_open(poh, cuuid3, DAOS_COO_RW, &coh3, NULL, NULL);
-	if (rc)
-		D_GOTO(fail, rc);
+	if (domain_nr >= 3) {
+		rc = daos_cont_open(poh, cuuid3, DAOS_COO_RW, &coh3, NULL, NULL);
+		if (rc)
+			D_GOTO(fail, rc);
+	}
 
 	step_success("");
 	return 0;
@@ -1019,13 +1033,17 @@ cclose(void)
 	if (rc)
 		D_GOTO(fail, rc);
 
-	rc = daos_cont_close(coh2, NULL);
-	if (rc)
-		D_GOTO(fail, rc);
+	if (domain_nr >= 2) {
+		rc = daos_cont_close(coh2, NULL);
+		if (rc)
+			D_GOTO(fail, rc);
+	}
 
-	rc = daos_cont_close(coh3, NULL);
-	if (rc)
-		D_GOTO(fail, rc);
+	if (domain_nr >= 3) {
+		rc = daos_cont_close(coh3, NULL);
+		if (rc)
+			D_GOTO(fail, rc);
+	}
 
 	step_success("");
 	return 0;
@@ -1044,13 +1062,17 @@ cdestroy(void)
 	if (rc)
 		D_GOTO(fail, rc);
 
-	rc = daos_cont_destroy(poh, cuuid2, force, NULL);
-	if (rc)
-		D_GOTO(fail, rc);
+	if (cuuid2) {
+		rc = daos_cont_destroy(poh, cuuid2, force, NULL);
+		if (rc)
+			D_GOTO(fail, rc);
+	}
 
-	rc = daos_cont_destroy(poh, cuuid3, force, NULL);
-	if (rc)
-		D_GOTO(fail, rc);
+	if (cuuid3) {
+		rc = daos_cont_destroy(poh, cuuid3, force, NULL);
+		if (rc)
+			D_GOTO(fail, rc);
+	}
 
 	step_success("");
 	return 0;


### PR DESCRIPTION
If domain_nr for pool is 1 or 2, container creation with
rf1 or rf2 will fail, skip this containers to make test happy.

Test-tag-hw-medium: containerautotest
Skip-unit-tests: true
Skip-func-hw-test-small: true
Skip-func-hw-test-large: true

Signed-off-by: Wang Shilong <shilong.wang@intel.com>