### PR TITLE
DAOS-9033 swim: Avoid busy loop in SWIM progress

### DIFF
--- a/src/cart/crt_context.c
+++ b/src/cart/crt_context.c
@@ -926,39 +926,6 @@ crt_context_timeout_check(struct crt_context *crt_ctx)
 
 	D_ASSERT(crt_ctx != NULL);
 
-	if (crt_gdata.cg_swim_inited) {
-		struct crt_grp_priv	*gp = crt_gdata.cg_grp->gg_primary_grp;
-		struct crt_swim_membs	*csm = &gp->gp_membs_swim;
-		swim_id_t		 self_id = swim_self_get(csm->csm_ctx);
-
-		if (crt_ctx->cc_last_unpack_hlc > csm->csm_last_unpack_hlc)
-			csm->csm_last_unpack_hlc = crt_ctx->cc_last_unpack_hlc;
-
-		/*
-		 * Check for network idle in all contexts.
-		 * If the time passed from last received RPC till now is more
-		 * than 2/3 of suspicion timeout suspends eviction.
-		 * The max_delay should be less suspicion timeout to guarantee
-		 * the already suspected members will not be expired.
-		 */
-		if (self_id != SWIM_ID_INVALID && csm->csm_alive_count > 2) {
-			uint64_t hlc1 = csm->csm_last_unpack_hlc;
-			uint64_t hlc2 = crt_hlc_get();
-			uint64_t delay = crt_hlc2msec(hlc2 - hlc1);
-			uint64_t max_delay = swim_suspect_timeout_get() * 2 / 3;
-
-			if (delay > max_delay) {
-				D_ERROR("Network outage detected (idle during "
-					"%lu.%lu sec >  maximum allowed "
-					"%lu.%lu sec).\n",
-					delay / 1000, delay % 1000,
-					max_delay / 1000, max_delay % 1000);
-				swim_net_glitch_update(csm->csm_ctx, self_id, delay);
-				csm->csm_last_unpack_hlc = hlc2;
-			}
-		}
-	}
-
 	D_INIT_LIST_HEAD(&timeout_list);
 	ts_now = d_timeus_secdiff(0);
 
@@ -1071,7 +1038,6 @@ crt_context_req_track(struct crt_rpc_priv *rpc_priv)
 	/* add the RPC req to crt_ep_inflight */
 	D_MUTEX_LOCK(&epi->epi_mutex);
 	D_ASSERT(epi->epi_req_num >= epi->epi_reply_num);
-	crt_set_timeout(rpc_priv);
 	rpc_priv->crp_epi = epi;
 	RPC_ADDREF(rpc_priv);
 
@@ -1091,6 +1057,7 @@ crt_context_req_track(struct crt_rpc_priv *rpc_priv)
 		rpc_priv->crp_state = RPC_STATE_QUEUED;
 		rc = CRT_REQ_TRACK_IN_WAITQ;
 	} else {
+		crt_set_timeout(rpc_priv);
 		D_MUTEX_LOCK(&crt_ctx->cc_mutex);
 		rc = crt_req_timeout_track(rpc_priv);
 		D_MUTEX_UNLOCK(&crt_ctx->cc_mutex);

--- a/src/cart/crt_rpc.c
+++ b/src/cart/crt_rpc.c
@@ -1700,7 +1700,8 @@ crt_rpc_common_hdlr(struct crt_rpc_priv *rpc_priv)
 	if (!rpc_priv->crp_opc_info->coi_no_reply)
 		rpc_priv->crp_reply_pending = 1;
 
-	if (crt_rpc_cb_customized(crt_ctx, &rpc_priv->crp_pub)) {
+	if (crt_rpc_cb_customized(crt_ctx, &rpc_priv->crp_pub) &&
+	    !crt_opc_is_swim(rpc_priv->crp_req_hdr.cch_opc)) {
 		rc = crt_ctx->cc_rpc_cb((crt_context_t)crt_ctx,
 					&rpc_priv->crp_pub,
 					crt_handle_rpc,

--- a/src/cart/crt_rpc.h
+++ b/src/cart/crt_rpc.h
@@ -646,20 +646,15 @@ crt_req_timedout(struct crt_rpc_priv *rpc_priv)
 	       !rpc_priv->crp_in_binheap;
 }
 
-static inline uint64_t
+static inline void
 crt_set_timeout(struct crt_rpc_priv *rpc_priv)
 {
-	uint64_t	sec_diff;
-
 	D_ASSERT(rpc_priv != NULL);
 
 	if (rpc_priv->crp_timeout_sec == 0)
 		rpc_priv->crp_timeout_sec = crt_gdata.cg_timeout;
 
-	sec_diff = d_timeus_secdiff(rpc_priv->crp_timeout_sec);
-	rpc_priv->crp_timeout_ts = sec_diff;
-
-	return sec_diff;
+	rpc_priv->crp_timeout_ts = d_timeus_secdiff(rpc_priv->crp_timeout_sec);
 }
 
 /* Convert opcode to string. Only returns string for internal RPCs */

--- a/src/cart/crt_swim.c
+++ b/src/cart/crt_swim.c
@@ -68,8 +68,7 @@ crt_swim_fault_init(const char *args)
 			s++; /* skip space */
 		if (!strncasecmp(s, "delay=", 6)) {
 			crt_swim_fail_delay = strtoul(s + 6, &end, 0);
-			D_EMIT("CRT_SWIM_FAIL_DELAY=%lu\n",
-			       crt_swim_fail_delay);
+			D_EMIT("CRT_SWIM_FAIL_DELAY=%lu\n", crt_swim_fail_delay);
 		} else if (!strncasecmp(s, "rank=", 5)) {
 			crt_swim_fail_id = strtoul(s + 5, &end, 0);
 			D_EMIT("CRT_SWIM_FAIL_ID=%lu\n", crt_swim_fail_id);
@@ -163,7 +162,7 @@ crt_swim_update_delays(struct crt_swim_membs *csm, uint64_t hlc,
 
 static void crt_swim_srv_cb(crt_rpc_t *rpc)
 {
-	struct crt_rpc_priv	*rpc_priv = NULL;
+	struct crt_rpc_priv	*rpc_priv = container_of(rpc, struct crt_rpc_priv, crp_pub);
 	struct crt_grp_priv	*grp_priv = crt_gdata.cg_grp->gg_primary_grp;
 	struct crt_swim_membs	*csm = &grp_priv->gp_membs_swim;
 	struct swim_context	*ctx = csm->csm_ctx;
@@ -181,8 +180,7 @@ static void crt_swim_srv_cb(crt_rpc_t *rpc)
 
 	D_ASSERT(crt_is_service());
 
-	rpc_priv = container_of(rpc, struct crt_rpc_priv, crp_pub);
-	from_id  = rpc_priv->crp_req_hdr.cch_src_rank;
+	from_id = rpc_priv->crp_req_hdr.cch_src_rank;
 
 	/* Initialize empty array in case of error in reply */
 	rpc_out->upds.ca_arrays = NULL;
@@ -202,20 +200,20 @@ static void crt_swim_srv_cb(crt_rpc_t *rpc)
 		break;
 	}
 
-	D_TRACE_DEBUG(DB_TRACE, rpc,
-		      "incoming %s with %zu updates. %lu: %lu <= %lu\n",
-		      SWIM_RPC_TYPE_STR[rpc_type], rpc_in->upds.ca_count,
-		      self_id, to_id, from_id);
-
-	if (self_id == SWIM_ID_INVALID)
-		D_GOTO(out_reply, rc = -DER_UNINIT);
-
 	/*
 	 * crt_hg_unpack_header may have failed to synchronize the HLC with
 	 * this request.
 	 */
 	if (hlc > rpc_priv->crp_req_hdr.cch_hlc)
 		rcv_delay = crt_hlc2msec(hlc - rpc_priv->crp_req_hdr.cch_hlc);
+
+	RPC_TRACE(DB_NET, rpc_priv,
+		  "incoming %s with %zu updates with %u ms delay. %lu: %lu <= %lu\n",
+		  SWIM_RPC_TYPE_STR[rpc_type], rpc_in->upds.ca_count, rcv_delay,
+		  self_id, to_id, from_id);
+
+	if (self_id == SWIM_ID_INVALID)
+		D_GOTO(out_reply, rc = -DER_UNINIT);
 
 	snd_delay = crt_swim_update_delays(csm, hlc, from_id, rcv_delay,
 					   rpc_in->upds.ca_arrays,
@@ -232,6 +230,7 @@ static void crt_swim_srv_cb(crt_rpc_t *rpc)
 	}
 
 	if (csm->csm_nmessages > CRT_SWIM_NMESSAGES_TRESHOLD) {
+		crt_swim_accommodate();
 		csm->csm_nglitches = 0;
 		csm->csm_nmessages = 0;
 	}
@@ -261,9 +260,9 @@ static void crt_swim_srv_cb(crt_rpc_t *rpc)
 			swim_self_set(ctx, SWIM_ID_INVALID);
 			D_GOTO(out_reply, rc);
 		} else if (rc) {
-			D_TRACE_ERROR(rpc,
-				      "updates parse. %lu: %lu <= %lu failed: "
-				      DF_RC"\n", self_id, to_id, from_id, DP_RC(rc));
+			RPC_ERROR(rpc_priv,
+				  "updates parse. %lu: %lu <= %lu failed: "DF_RC"\n",
+				  self_id, to_id, from_id, DP_RC(rc));
 		}
 
 		switch (rpc_type) {
@@ -275,11 +274,9 @@ static void crt_swim_srv_cb(crt_rpc_t *rpc)
 		case SWIM_RPC_IREQ:
 			rc = swim_ipings_suspend(ctx, from_id, to_id, rpc);
 			if (rc == 0 || rc == -DER_ALREADY) {
-				D_TRACE_DEBUG(DB_TRACE, rpc,
-					      "suspend %s reply. "
-					      "%lu: %lu <= %lu\n",
-					      SWIM_RPC_TYPE_STR[rpc_type],
-					      self_id, to_id, from_id);
+				RPC_TRACE(DB_NET, rpc_priv,
+					  "suspend %s reply. %lu: %lu <= %lu\n",
+					  SWIM_RPC_TYPE_STR[rpc_type], self_id, to_id, from_id);
 				/* Keep this RPC in ipings queue */
 				RPC_ADDREF(rpc_priv);
 
@@ -288,9 +285,8 @@ static void crt_swim_srv_cb(crt_rpc_t *rpc)
 
 				rc = swim_updates_send(ctx, to_id, to_id);
 				if (rc)
-					D_TRACE_ERROR(rpc,
-						      "swim_updates_send(): "
-						      DF_RC"\n", DP_RC(rc));
+					RPC_ERROR(rpc_priv,
+						  "swim_updates_send(): "DF_RC"\n", DP_RC(rc));
 				return;
 			}
 			break;
@@ -299,21 +295,21 @@ static void crt_swim_srv_cb(crt_rpc_t *rpc)
 			break;
 		}
 	}
-	crt_swim_accommodate();
 
 out_reply:
-	D_TRACE_DEBUG(DB_TRACE, rpc,
-		      "reply %s with %zu updates. %lu: %lu <= %lu "DF_RC"\n",
-		      SWIM_RPC_TYPE_STR[rpc_type], rpc_out->upds.ca_count,
-		      self_id, to_id, from_id, DP_RC(rc));
+	RPC_TRACE(DB_NET, rpc_priv,
+		  "reply %s with %zu updates. %lu: %lu <= %lu "DF_RC"\n",
+		  SWIM_RPC_TYPE_STR[rpc_type], rpc_out->upds.ca_count,
+		  self_id, to_id, from_id, DP_RC(rc));
 
 	rpc_out->rc  = rc;
 	rpc_out->pad = 0;
 	rc = crt_reply_send(rpc);
 	D_FREE(rpc_out->upds.ca_arrays);
 	if (rc)
-		D_TRACE_ERROR(rpc, "send reply: "DF_RC" failed: "DF_RC"\n",
-			      DP_RC(rpc_out->rc), DP_RC(rc));
+		RPC_ERROR(rpc_priv,
+			  "send reply: "DF_RC" failed: "DF_RC"\n",
+			  DP_RC(rpc_out->rc), DP_RC(rc));
 }
 
 static int crt_swim_get_member_state(struct swim_context *ctx, swim_id_t id,
@@ -328,10 +324,13 @@ static void crt_swim_cli_cb(const struct crt_cb_info *cb_info)
 	crt_rpc_t		*rpc = cb_info->cci_rpc;
 	struct crt_rpc_swim_in	*rpc_in  = crt_req_get(rpc);
 	struct crt_rpc_swim_out *rpc_out = crt_reply_get(rpc);
+	struct crt_rpc_priv	*rpc_priv = container_of(rpc, struct crt_rpc_priv, crp_pub);
 	enum swim_rpc_type	 rpc_type;
 	swim_id_t		 self_id = swim_self_get(ctx);
 	swim_id_t		 from_id;
 	swim_id_t		 to_id = rpc->cr_ep.ep_rank;
+	uint64_t		 hlc = crt_hlc_get();
+	uint32_t		 rcv_delay = 0;
 	int			 reply_rc;
 	int			 rc;
 
@@ -350,12 +349,15 @@ static void crt_swim_cli_cb(const struct crt_cb_info *cb_info)
 		break;
 	}
 
-	D_TRACE_DEBUG(DB_TRACE, rpc,
-		      "complete %s with %zu/%zu updates. %lu: %lu => %lu "
-		      DF_RC" remote: "DF_RC"\n",
-		      SWIM_RPC_TYPE_STR[rpc_type], rpc_in->upds.ca_count,
-		      rpc_out->upds.ca_count, self_id, from_id, to_id,
-		      DP_RC(cb_info->cci_rc), DP_RC(rpc_out->rc));
+	if (hlc > rpc_priv->crp_reply_hdr.cch_hlc)
+		rcv_delay = crt_hlc2msec(hlc - rpc_priv->crp_reply_hdr.cch_hlc);
+
+	RPC_TRACE(DB_NET, rpc_priv,
+		  "complete %s with %zu/%zu updates with %u ms delay. %lu: %lu => %lu "
+		  DF_RC" remote: "DF_RC"\n",
+		  SWIM_RPC_TYPE_STR[rpc_type], rpc_in->upds.ca_count,
+		  rpc_out->upds.ca_count, rcv_delay, self_id, from_id, to_id,
+		  DP_RC(cb_info->cci_rc), DP_RC(rpc_out->rc));
 
 	if (self_id == SWIM_ID_INVALID)
 		D_GOTO(out, rc = -DER_UNINIT);
@@ -368,9 +370,9 @@ static void crt_swim_cli_cb(const struct crt_cb_info *cb_info)
 		if (reply_rc == -DER_UNINIT || reply_rc == -DER_NONEXIST) {
 			struct swim_member_update *upds;
 
-			D_TRACE_DEBUG(DB_TRACE, rpc,
-				      "%lu: %lu => %lu answered but not bootstrapped yet.\n",
-				      self_id, from_id, to_id);
+			RPC_TRACE(DB_NET, rpc_priv,
+				  "%lu: %lu => %lu answered but not bootstrapped yet.\n",
+				  self_id, from_id, to_id);
 
 			/* Simulate ALIVE answer */
 			D_FREE(rpc_out->upds.ca_arrays);
@@ -385,8 +387,9 @@ static void crt_swim_cli_cb(const struct crt_cb_info *cb_info)
 			 * because of it's fine if simulation of valid answer fails.
 			 */
 		} else {
-			D_TRACE_ERROR(rpc, "%lu: %lu => %lu remote failed: "DF_RC"\n",
-				      self_id, from_id, to_id, DP_RC(reply_rc));
+			RPC_ERROR(rpc_priv,
+				  "%lu: %lu => %lu remote failed: "DF_RC"\n",
+				  self_id, from_id, to_id, DP_RC(reply_rc));
 		}
 	}
 
@@ -398,19 +401,20 @@ static void crt_swim_cli_cb(const struct crt_cb_info *cb_info)
 		swim_self_set(ctx, SWIM_ID_INVALID);
 		D_GOTO(out, rc);
 	} else if (rc) {
-		D_TRACE_ERROR(rpc, "updates parse. %lu: %lu <= %lu failed: "
-			      DF_RC"\n", self_id, from_id, to_id, DP_RC(rc));
+		RPC_ERROR(rpc_priv,
+			  "updates parse. %lu: %lu <= %lu failed: "DF_RC"\n",
+			  self_id, from_id, to_id, DP_RC(rc));
 	}
 
 	rc = swim_ipings_reply(ctx, to_id, reply_rc);
 	if (rc)
-		D_TRACE_ERROR(rpc, "send reply: "DF_RC" failed: "DF_RC"\n",
-			      DP_RC(rpc_out->rc), DP_RC(rc));
+		RPC_ERROR(rpc_priv,
+			  "send reply: "DF_RC" failed: "DF_RC"\n",
+			  DP_RC(rpc_out->rc), DP_RC(rc));
 
 out:
 	if (crt_swim_fail_delay && crt_swim_fail_id == self_id) {
-		crt_swim_fail_hlc = crt_hlc_get() +
-				    crt_sec2hlc(crt_swim_fail_delay);
+		crt_swim_fail_hlc = crt_hlc_get() + crt_sec2hlc(crt_swim_fail_delay);
 		crt_swim_fail_delay = 0;
 	}
 }
@@ -425,6 +429,7 @@ static int crt_swim_send_request(struct swim_context *ctx, swim_id_t id,
 	enum swim_rpc_type	 rpc_type;
 	crt_context_t		 crt_ctx;
 	crt_rpc_t		*rpc = NULL;
+	struct crt_rpc_priv	*rpc_priv;
 	crt_endpoint_t		 ep;
 	crt_opcode_t		 opc;
 	swim_id_t		 self_id = swim_self_get(ctx);
@@ -453,6 +458,7 @@ static int crt_swim_send_request(struct swim_context *ctx, swim_id_t id,
 		D_GOTO(out, rc);
 	}
 
+	rpc_priv = container_of(rpc, struct crt_rpc_priv, crp_pub);
 	rpc_in = crt_req_get(rpc);
 	rpc_in->swim_id = id;
 	rpc_in->upds.ca_arrays = upds;
@@ -487,15 +493,15 @@ static int crt_swim_send_request(struct swim_context *ctx, swim_id_t id,
 		timeout_sec *= 2;
 	rc = crt_req_set_timeout(rpc, timeout_sec);
 	if (rc) {
-		D_TRACE_ERROR(rpc, "crt_req_set_timeout(): "DF_RC"\n",
-			      DP_RC(rc));
+		RPC_ERROR(rpc_priv,
+			  "crt_req_set_timeout(): "DF_RC"\n", DP_RC(rc));
 		D_GOTO(out, rc);
 	}
 
-	D_TRACE_DEBUG(DB_TRACE, rpc,
-		      "send %s with %zu updates. %lu: %lu => %lu\n",
-		      SWIM_RPC_TYPE_STR[rpc_type], rpc_in->upds.ca_count,
-		      self_id, (rpc_type == SWIM_RPC_PING) ? self_id : id, to);
+	RPC_TRACE(DB_NET, rpc_priv,
+		  "send %s with %zu updates. %lu: %lu => %lu\n",
+		  SWIM_RPC_TYPE_STR[rpc_type], rpc_in->upds.ca_count,
+		  self_id, (rpc_type == SWIM_RPC_PING) ? self_id : id, to);
 
 	return crt_req_send(rpc, crt_swim_cli_cb, ctx);
 
@@ -509,7 +515,7 @@ static int crt_swim_send_reply(struct swim_context *ctx, swim_id_t from,
 			       swim_id_t to, int ret_rc, void *args)
 {
 	crt_rpc_t		*rpc = args;
-	struct crt_rpc_priv	*rpc_priv;
+	struct crt_rpc_priv	*rpc_priv = container_of(rpc, struct crt_rpc_priv, crp_pub);
 	struct crt_rpc_swim_out	*rpc_out;
 	swim_id_t		 self_id = swim_self_get(ctx);
 	int			 rc;
@@ -523,25 +529,23 @@ static int crt_swim_send_reply(struct swim_context *ctx, swim_id_t from,
 	rpc_out->rc = rc ? rc : ret_rc;
 	rpc_out->pad = 0;
 
-	D_TRACE_DEBUG(DB_TRACE, rpc,
-		      "complete %s with %zu updates. "
-		      "%lu: %lu => %lu "DF_RC"\n",
-		      SWIM_RPC_TYPE_STR[SWIM_RPC_IREQ],
-		      rpc_out->upds.ca_count,
-		      self_id, from, to, DP_RC(rpc_out->rc));
+	RPC_TRACE(DB_NET, rpc_priv,
+		  "complete %s with %zu updates. %lu: %lu => %lu "DF_RC"\n",
+		  SWIM_RPC_TYPE_STR[SWIM_RPC_IREQ],
+		  rpc_out->upds.ca_count, self_id, from, to, DP_RC(rpc_out->rc));
 
 	rc = crt_reply_send(rpc);
 	D_FREE(rpc_out->upds.ca_arrays);
 	if (rc)
-		D_TRACE_ERROR(rpc, "send reply: "DF_RC" failed: "DF_RC"\n",
-			      DP_RC(rpc_out->rc), DP_RC(rc));
+		RPC_ERROR(rpc_priv,
+			  "send reply: "DF_RC" failed: "DF_RC"\n",
+			  DP_RC(rpc_out->rc), DP_RC(rc));
 
 	/*
 	 * This RPC was removed from ipings queue.
 	 * So, we need to decrement reference.
 	 * Was incremented in crt_swim_srv_cb().
 	 */
-	rpc_priv = container_of(rpc, struct crt_rpc_priv, crp_pub);
 	RPC_DECREF(rpc_priv);
 	return rc;
 }
@@ -577,8 +581,7 @@ out_unlock:
 out:
 	if (id != SWIM_ID_INVALID)
 		D_DEBUG(DB_TRACE, "select dping target: %lu => {%lu %c %lu}\n",
-			self_id, id, SWIM_STATUS_CHARS[
-					csm->csm_target->cst_state.sms_status],
+			self_id, id, SWIM_STATUS_CHARS[csm->csm_target->cst_state.sms_status],
 			csm->csm_target->cst_state.sms_incarnation);
 	else
 		D_DEBUG(DB_TRACE, "there is no dping target\n");
@@ -616,8 +619,7 @@ out_unlock:
 out:
 	if (id != SWIM_ID_INVALID)
 		D_DEBUG(DB_TRACE, "select iping target: %lu => {%lu %c %lu}\n",
-			self_id, id, SWIM_STATUS_CHARS[
-					csm->csm_target->cst_state.sms_status],
+			self_id, id, SWIM_STATUS_CHARS[csm->csm_target->cst_state.sms_status],
 			csm->csm_target->cst_state.sms_incarnation);
 	else
 		D_DEBUG(DB_TRACE, "there is no iping target\n");
@@ -733,7 +735,25 @@ static void crt_swim_new_incarnation(struct swim_context *ctx,
 	state->sms_incarnation = incarnation;
 }
 
-static int64_t crt_swim_progress_cb(crt_context_t crt_ctx, int64_t timeout, void *arg)
+static void crt_swim_update_last_unpack_hlc(struct crt_swim_membs *csm)
+{
+	struct crt_context	*ctx = NULL;
+	d_list_t		*ctx_list;
+
+	D_RWLOCK_RDLOCK(&crt_gdata.cg_rwlock);
+
+	ctx_list = crt_provider_get_ctx_list(crt_gdata.cg_init_prov);
+	d_list_for_each_entry(ctx, ctx_list, cc_link) {
+		uint64_t hlc = ctx->cc_last_unpack_hlc;
+
+		if (csm->csm_last_unpack_hlc < hlc)
+			csm->csm_last_unpack_hlc = hlc;
+	}
+
+	D_RWLOCK_UNLOCK(&crt_gdata.cg_rwlock);
+}
+
+static int64_t crt_swim_progress_cb(crt_context_t crt_ctx, int64_t timeout_us, void *arg)
 {
 	struct crt_grp_priv	*grp_priv = crt_gdata.cg_grp->gg_primary_grp;
 	struct crt_swim_membs	*csm = &grp_priv->gp_membs_swim;
@@ -742,7 +762,7 @@ static int64_t crt_swim_progress_cb(crt_context_t crt_ctx, int64_t timeout, void
 	int			 rc;
 
 	if (self_id == SWIM_ID_INVALID)
-		return timeout;
+		return timeout_us;
 
 	if (crt_swim_fail_hlc && crt_hlc_get() >= crt_swim_fail_hlc) {
 		crt_swim_should_fail = true;
@@ -750,21 +770,52 @@ static int64_t crt_swim_progress_cb(crt_context_t crt_ctx, int64_t timeout, void
 		D_EMIT("SWIM id=%lu should fail\n", crt_swim_fail_id);
 	}
 
-	rc = swim_progress(ctx, timeout);
+	rc = swim_progress(ctx, timeout_us);
 	if (rc == -DER_SHUTDOWN) {
 		if (grp_priv->gp_size > 1)
 			D_ERROR("SWIM shutdown\n");
 		swim_self_set(ctx, SWIM_ID_INVALID);
 	} else if (rc == -DER_TIMEDOUT || rc == -DER_CANCELED) {
-		uint64_t now = swim_now_ms();
+		crt_swim_update_last_unpack_hlc(csm);
 
-		if (now < ctx->sc_next_event)
-			timeout = ctx->sc_next_event - now;
+		/*
+		 * Check for network idle in all contexts.
+		 * If the time passed from last received RPC till now is more
+		 * than 2/3 of suspicion timeout suspends eviction.
+		 * The max_delay should be less suspicion timeout to guarantee
+		 * the already suspected members will not be expired.
+		 */
+		if (csm->csm_alive_count > 2) {
+			uint64_t hlc1 = csm->csm_last_unpack_hlc;
+			uint64_t hlc2 = crt_hlc_get();
+			uint64_t delay = crt_hlc2msec(hlc2 - hlc1);
+			uint64_t max_delay = swim_suspect_timeout_get() * 2 / 3;
+
+			if (delay > max_delay) {
+				D_ERROR("Network outage detected (idle during "
+					"%lu.%lu sec > expected %lu.%lu sec).\n",
+					delay / 1000, delay % 1000,
+					max_delay / 1000, max_delay % 1000);
+				swim_net_glitch_update(csm->csm_ctx, self_id, delay);
+				csm->csm_last_unpack_hlc = hlc2;
+			}
+		}
+
+		/*
+		 * Change only for very long timeout to avoid confusing of DAOS scheduler.
+		 * NB: !!! Mercury only supports milli-second timeout !!!
+		 */
+		if (timeout_us > 1000) {
+			uint64_t now = swim_now_ms();
+
+			if (now < ctx->sc_next_event)
+				timeout_us = (ctx->sc_next_event - now) * 1000; /* timeout in us */
+		}
 	} else if (rc) {
 		D_ERROR("swim_progress(): "DF_RC"\n", DP_RC(rc));
 	}
 
-	return timeout;
+	return timeout_us;
 }
 
 void crt_swim_fini(void)
@@ -1069,7 +1120,11 @@ void crt_swim_accommodate(void)
 		else if (average > max_timeout)
 			average = max_timeout;
 
-		if (average != ping_timeout) {
+		/*
+		 * (x >> 5) is just (x / 32) but a way faster.
+		 * This should avoid changes for small deltas.
+		 */
+		if ((average >> 5) != (ping_timeout >> 5)) {
 			D_INFO("change PING timeout from %lu ms to %lu ms\n",
 			       ping_timeout, average);
 			swim_ping_timeout_set(average);

--- a/src/cart/swim/swim.c
+++ b/src/cart/swim/swim.c
@@ -102,7 +102,7 @@ swim_dump_updates(swim_id_t self_id, swim_id_t from_id, swim_id_t to_id,
 	if (fp != NULL) {
 		for (i = 0; i < nupds; i++) {
 			rc = fprintf(fp, " {%lu %c %lu}", upds[i].smu_id,
-				SWIM_STATUS_CHARS[upds[i].smu_state.sms_status],
+				     SWIM_STATUS_CHARS[upds[i].smu_state.sms_status],
 				     upds[i].smu_state.sms_incarnation);
 			if (rc < 0)
 				break;
@@ -160,8 +160,7 @@ swim_updates_prepare(struct swim_context *ctx, swim_id_t id, swim_id_t to,
 		rc = ctx->sc_ops->get_member_state(ctx, self_id,
 						   &upds[n].smu_state);
 		if (rc) {
-			SWIM_ERROR("get_member_state(%lu): "DF_RC"\n", self_id,
-				   DP_RC(rc));
+			SWIM_ERROR("get_member_state(%lu): "DF_RC"\n", self_id, DP_RC(rc));
 			D_GOTO(out_unlock, rc);
 		}
 		upds[n++].smu_id = self_id;
@@ -200,8 +199,7 @@ swim_updates_prepare(struct swim_context *ctx, swim_id_t id, swim_id_t to,
 			if (rc) {
 				if (rc == -DER_NONEXIST) {
 					/* this member was removed already */
-					TAILQ_REMOVE(&ctx->sc_updates, item,
-						     si_link);
+					TAILQ_REMOVE(&ctx->sc_updates, item, si_link);
 					D_FREE(item);
 					item = next;
 					continue;
@@ -284,8 +282,7 @@ update:
 }
 
 static int
-swim_member_alive(struct swim_context *ctx, swim_id_t from,
-		  swim_id_t id, uint64_t nr)
+swim_member_alive(struct swim_context *ctx, swim_id_t from, swim_id_t id, uint64_t nr)
 {
 	struct swim_member_state	 id_state;
 	struct swim_item		*item;
@@ -337,8 +334,7 @@ out:
 }
 
 static int
-swim_member_dead(struct swim_context *ctx, swim_id_t from,
-		 swim_id_t id, uint64_t nr)
+swim_member_dead(struct swim_context *ctx, swim_id_t from, swim_id_t id, uint64_t nr)
 {
 	struct swim_member_state	 id_state;
 	struct swim_item		*item;
@@ -385,8 +381,7 @@ out:
 }
 
 static int
-swim_member_suspect(struct swim_context *ctx, swim_id_t from,
-		    swim_id_t id, uint64_t nr)
+swim_member_suspect(struct swim_context *ctx, swim_id_t from, swim_id_t id, uint64_t nr)
 {
 	struct swim_member_state	 id_state;
 	struct swim_item		*item;
@@ -439,8 +434,7 @@ out:
 }
 
 static int
-swim_member_update_suspected(struct swim_context *ctx, uint64_t now,
-			     uint64_t net_glitch_delay)
+swim_member_update_suspected(struct swim_context *ctx, uint64_t now, uint64_t net_glitch_delay)
 {
 	TAILQ_HEAD(, swim_item)		 targets;
 	struct swim_member_state	 id_state;
@@ -458,9 +452,7 @@ swim_member_update_suspected(struct swim_context *ctx, uint64_t now,
 		next = TAILQ_NEXT(item, si_link);
 		item->u.si_deadline += net_glitch_delay;
 		if (now > item->u.si_deadline) {
-			rc = ctx->sc_ops->get_member_state(ctx,
-							   item->si_id,
-							   &id_state);
+			rc = ctx->sc_ops->get_member_state(ctx, item->si_id, &id_state);
 			if (rc || (id_state.sms_status != SWIM_MEMBER_SUSPECT)) {
 				/* this member was removed or updated already */
 				TAILQ_REMOVE(&ctx->sc_suspects, item, si_link);
@@ -490,8 +482,7 @@ swim_member_update_suspected(struct swim_context *ctx, uint64_t now,
 				 * its allowable suspicion timeout,
 				 * we mark it as dead
 				 */
-				swim_member_dead(ctx, item->si_from,
-						 item->si_id,
+				swim_member_dead(ctx, item->si_from, item->si_id,
 						 id_state.sms_incarnation);
 				D_FREE(item);
 			}
@@ -524,8 +515,7 @@ next_item:
 }
 
 static int
-swim_ipings_update(struct swim_context *ctx, uint64_t now,
-		   uint64_t net_glitch_delay)
+swim_ipings_update(struct swim_context *ctx, uint64_t now, uint64_t net_glitch_delay)
 {
 	TAILQ_HEAD(, swim_item)		 targets;
 	struct swim_item		*next, *item;
@@ -610,8 +600,7 @@ swim_ipings_reply(struct swim_context *ctx, swim_id_t to_id, int ret_rc)
 }
 
 int
-swim_ipings_suspend(struct swim_context *ctx, swim_id_t from_id,
-		    swim_id_t to_id, void *args)
+swim_ipings_suspend(struct swim_context *ctx, swim_id_t from_id, swim_id_t to_id, void *args)
 {
 	struct swim_item	*item;
 	int			 rc = 0;
@@ -752,9 +741,6 @@ swim_init(swim_id_t self_id, struct swim_ops *swim_ops, void *data)
 	/* force to choose next target first */
 	ctx->sc_target = SWIM_ID_INVALID;
 
-	/* delay the first ping until all things will be initialized */
-	ctx->sc_next_tick_time = swim_now_ms() + 3 * SWIM_PROTOCOL_PERIOD_LEN;
-
 	/* set global tunable defaults */
 	swim_prot_period_len = swim_prot_period_len_default();
 	swim_suspect_timeout = swim_suspect_timeout_default();
@@ -762,6 +748,8 @@ swim_init(swim_id_t self_id, struct swim_ops *swim_ops, void *data)
 
 	ctx->sc_default_ping_timeout = swim_ping_timeout;
 
+	/* delay the first ping until all things will be initialized */
+	ctx->sc_next_tick_time = swim_now_ms() + 3 * swim_prot_period_len;
 out:
 	return ctx;
 }
@@ -849,7 +837,7 @@ swim_net_glitch_update(struct swim_context *ctx, swim_id_t id, uint64_t delay)
 }
 
 int
-swim_progress(struct swim_context *ctx, int64_t timeout)
+swim_progress(struct swim_context *ctx, int64_t timeout_us)
 {
 	enum swim_context_state	 ctx_state = SCS_TIMEDOUT;
 	struct swim_member_state target_state;
@@ -870,9 +858,9 @@ swim_progress(struct swim_context *ctx, int64_t timeout)
 		D_GOTO(out_err, rc = 0); /* Ignore this update */
 
 	now = swim_now_ms();
-	if (timeout > 0)
-		end = now + timeout;
-	ctx->sc_next_event = now + swim_period_get() / 3;
+	if (timeout_us > 0)
+		end = now + timeout_us / 1000; /* timeout in us */
+	ctx->sc_next_event = now + swim_period_get();
 
 	if (now > ctx->sc_expect_progress_time &&
 	    0  != ctx->sc_expect_progress_time) {
@@ -884,15 +872,13 @@ swim_progress(struct swim_context *ctx, int64_t timeout)
 	for (; now <= end || ctx_state == SCS_TIMEDOUT; now = swim_now_ms()) {
 		rc = swim_member_update_suspected(ctx, now, net_glitch_delay);
 		if (rc) {
-			SWIM_ERROR("swim_member_update_suspected(): "DF_RC"\n",
-				   DP_RC(rc));
+			SWIM_ERROR("swim_member_update_suspected(): "DF_RC"\n", DP_RC(rc));
 			D_GOTO(out, rc);
 		}
 
 		rc = swim_ipings_update(ctx, now, net_glitch_delay);
 		if (rc) {
-			SWIM_ERROR("swim_ipings_update(): "DF_RC"\n",
-				   DP_RC(rc));
+			SWIM_ERROR("swim_ipings_update(): "DF_RC"\n", DP_RC(rc));
 			D_GOTO(out, rc);
 		}
 
@@ -961,7 +947,7 @@ swim_progress(struct swim_context *ctx, int64_t timeout)
 					/* suspect this member */
 					swim_member_suspect(ctx, ctx->sc_self,
 							    ctx->sc_target,
-						  target_state.sms_incarnation);
+							    target_state.sms_incarnation);
 					ctx_state = SCS_TIMEDOUT;
 				} else {
 					/* just goto next member,
@@ -1060,18 +1046,17 @@ done_item:
 		if (send_updates) {
 			rc = swim_updates_send(ctx, target_id, sendto_id);
 			if (rc) {
-				SWIM_ERROR("swim_updates_send(): "
-					   DF_RC"\n", DP_RC(rc));
+				SWIM_ERROR("swim_updates_send(): "DF_RC"\n", DP_RC(rc));
 				D_GOTO(out, rc);
 			}
 			send_updates = false;
 		} else if (now + 100 < ctx->sc_next_event) {
-			break;
+			break; /* break loop if need to wait more than 100 ms. */
 		}
 	}
 	rc = (now > end) ? -DER_TIMEDOUT : -DER_CANCELED;
 out:
-	ctx->sc_expect_progress_time = now + swim_period_get() / 2;
+	ctx->sc_expect_progress_time = now + swim_period_get();
 out_err:
 	return rc;
 }
@@ -1140,20 +1125,16 @@ swim_updates_parse(struct swim_context *ctx, swim_id_t from_id,
 				SWIM_ERROR("{%lu %c %lu} self %s received "
 					   "{%lu %c %lu} from %lu\n",
 					   self_id,
-					   SWIM_STATUS_CHARS[
-							 self_state.sms_status],
+					   SWIM_STATUS_CHARS[self_state.sms_status],
 					   self_state.sms_incarnation,
-					   SWIM_STATUS_STR[
-						  upds[i].smu_state.sms_status],
+					   SWIM_STATUS_STR[upds[i].smu_state.sms_status],
 					   self_id,
-					   SWIM_STATUS_CHARS[
-						  upds[i].smu_state.sms_status],
+					   SWIM_STATUS_CHARS[upds[i].smu_state.sms_status],
 					   upds[i].smu_state.sms_incarnation,
 					   from_id);
 
 				ctx->sc_ops->new_incarnation(ctx, self_id, &self_state);
-				rc = swim_updates_notify(ctx, self_id, self_id,
-							 &self_state, 0);
+				rc = swim_updates_notify(ctx, self_id, self_id, &self_state, 0);
 				if (rc) {
 					swim_ctx_unlock(ctx);
 					SWIM_ERROR("swim_updates_notify(): "


### PR DESCRIPTION
Turned off scheduling incoming SWIM RPCs by DAOS customization.
Changed progress timeout only for very long timeout to avoid
confusing of DAOS scheduler.