### PR TITLE
DAOS-7878 vos: Reset known key if no entries are found (#7484)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -900,7 +900,7 @@ pipeline {
                         always {
                             recordIssues enabledForFailure: true,
                                          failOnError: false,
-                                         ignoreFailedBuilds: false,
+                                         ignoreFailedBuilds: true,
                                          ignoreQualityGate: true,
                                          qualityGates: [[threshold: 1, type: 'TOTAL_ERROR'],
                                                         [threshold: 1, type: 'TOTAL_HIGH'],


### PR DESCRIPTION
When doing punch propagation, the known key needs to be reset
if no entries are found.  Otherwise, it can cause us to access
a garbage address.
Change the ignoreFailedBuilds setting for fault injection testing.

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>
Co-authored-by: Ashley Pittman <ashley.m.pittman@intel.com>