### PR TITLE
DAOS-9036 cart: avoid potential RPC callback leak

### DIFF
--- a/src/cart/crt_rpc.c
+++ b/src/cart/crt_rpc.c
@@ -1357,13 +1357,13 @@ crt_req_send(crt_rpc_t *req, crt_cb_t complete_cb, void *arg)
 	 */
 	RPC_ADDREF(rpc_priv);
 
+	rpc_priv->crp_complete_cb = complete_cb;
+	rpc_priv->crp_arg = arg;
+
 	if (req->cr_ctx == NULL) {
 		D_ERROR("invalid parameter (NULL req->cr_ctx).\n");
 		D_GOTO(out, rc = -DER_INVAL);
 	}
-
-	rpc_priv->crp_complete_cb = complete_cb;
-	rpc_priv->crp_arg = arg;
 
 	if (rpc_priv->crp_coll) {
 		rc = crt_corpc_req_hdlr(rpc_priv);

--- a/src/dtx/dtx_rpc.c
+++ b/src/dtx/dtx_rpc.c
@@ -77,6 +77,7 @@ struct dtx_req_rec {
 	struct dtx_req_args		*drr_parent; /* The top level args */
 	d_rank_t			 drr_rank; /* The server ID */
 	uint32_t			 drr_tag; /* The VOS ID */
+	uint32_t			 drr_completed:1;
 	int				 drr_count; /* DTX count */
 	int				 drr_result; /* The RPC result */
 	struct dtx_id			*drr_dti; /* The DTX array */
@@ -206,6 +207,7 @@ dtx_req_cb(const struct crt_cb_info *cb_info)
 	}
 
 out:
+	drr->drr_completed = 1;
 	drr->drr_result = rc;
 	rc = ABT_future_set(dra->dra_future, drr);
 	D_ASSERTF(rc == ABT_SUCCESS,
@@ -223,7 +225,7 @@ static int
 dtx_req_send(struct dtx_req_rec *drr, daos_epoch_t epoch)
 {
 	struct dtx_req_args	*dra = drr->drr_parent;
-	crt_rpc_t		*req;
+	crt_rpc_t		*req = NULL;
 	crt_endpoint_t		 tgt_ep;
 	crt_opcode_t		 opc;
 	struct dtx_in		*din = NULL;
@@ -251,7 +253,10 @@ dtx_req_send(struct dtx_req_rec *drr, daos_epoch_t epoch)
 		drr->drr_tag, req, dra->dra_future,
 		din != NULL ? din->di_epoch : 0, rc);
 
-	if (rc != 0) {
+	if (rc != 0 && !drr->drr_completed) {
+		D_ASSERT(req == NULL);
+
+		drr->drr_completed = 1;
 		drr->drr_result = rc;
 		ABT_future_set(dra->dra_future, drr);
 	}
@@ -420,6 +425,7 @@ dtx_cf_rec_alloc(struct btr_instance *tins, d_iov_t *key_iov,
 	drr->drr_rank = dcrb->dcrb_rank;
 	drr->drr_tag = dcrb->dcrb_tag;
 	drr->drr_count = 1;
+	drr->drr_completed = 0;
 	drr->drr_dti[0] = *dcrb->dcrb_dti;
 	d_list_add_tail(&drr->drr_link, dcrb->dcrb_head);
 	++(*dcrb->dcrb_length);

--- a/src/include/daos_srv/dtx_srv.h
+++ b/src/include/daos_srv/dtx_srv.h
@@ -130,6 +130,7 @@ struct dtx_handle {
 struct dtx_sub_status {
 	struct daos_shard_tgt		dss_tgt;
 	int				dss_result;
+	uint32_t			dss_completed:1;
 };
 
 struct dtx_leader_handle;


### PR DESCRIPTION
There is potential RPC callback leak when crt_req_send() hit
failure because of invalid RPC CRT context.

Signed-off-by: Fan Yong <fan.yong@intel.com>