### PR TITLE
DAOS-9098 test: set svcn as 5 for destroy_rebuild.py

### DIFF
--- a/src/tests/ftest/pool/destroy_rebuild.yaml
+++ b/src/tests/ftest/pool/destroy_rebuild.yaml
@@ -19,6 +19,7 @@ pool:
   mode: 511
   name: daos_server
   scm_size: 134217728
+  svcn: 5
   control_method: dmg
   pool_query_timeout: 30
 testparams:


### PR DESCRIPTION
In the test it kills rank 1 and 4 at the same time, the default
svcn is 3, if rank 1 and 4 happened to be two PS replica, it will
cause no new PS leader can be selected.

Quick-build: true
Test-tag: destroy_pool_rebuild

Signed-off-by: Xuezhao Liu <xuezhao.liu@intel.com>