### PR TITLE
DAOS-7174 doc: refine reintegration section (#7380)

### DIFF
--- a/docs/admin/administration.md
+++ b/docs/admin/administration.md
@@ -461,10 +461,10 @@ device would remain in this state until replaced by a new device.
 
 ## System Operations
 
-The DAOS Control Server acting as the access point records details of DAOS I/O
-Server instances that join the DAOS system. Once an I/O Engine has joined the
-DAOS system, it is identified by a unique system "rank". Multiple ranks can
-reside on the same host machine, accessible via the same network address.
+The DAOS server acting as the access point records details of engines
+that join the DAOS system. Once an engine has joined the DAOS system, it is
+identified by a unique system "rank". Multiple ranks can reside on the same
+host machine, accessible via the same network address.
 
 A DAOS system can be shutdown and restarted to perform maintenance and/or
 reboot hosts. Pool data and state will be maintained providing no changes are
@@ -484,19 +484,14 @@ config file
 [`daos_server.yml`](https://github.com/daos-stack/daos/blob/master/utils/config/daos_server.yml)
 specified when starting `daos_server` instances.
 
-!!! warning
-    Controlled start/stop/reformat have some known limitations.
-    While individual system instances can be stopped, if a subset is restarted,
-    existing pools will not be automatically integrated with restarted instances.
-
 ### Membership
 
 The system membership can be queried using the command:
 
 `$ dmg system query [--verbose] [--ranks <rankset>|--host-ranks <hostset>]`
 
-- `<rankset>` is a pattern describing rank ranges e.g. 0,5-10,20-100
-- `<hostset>` is a pattern describing host ranges e.g.
+- `<rankset>` is a pattern describing rank ranges e.g., 0,5-10,20-100
+- `<hostset>` is a pattern describing host ranges e.g.,
 storagehost[0,5-10],10.8.1.[20-100]
 - `--verbose` flag gives more information on each rank
 
@@ -507,34 +502,62 @@ UUID, in addition to the rank state.
 
 When up and running, the entire system can be shutdown with the command:
 
-`$ dmg system stop [--force] [--ranks <rankset>|--host-ranks <hostset>]`
-
-- `<rankset>` is a pattern describing rank ranges e.g. 0,5-10,20-100
-- `<hostset>` is a pattern describing host ranges e.g.
-storagehost[0,5-10],10.8.1.[20-100]
+`$ dmg system stop [--force]`
 
 The output table will indicate action and result.
 
-DAOS Control Servers will continue to operate and listen on the management
-network.
+While the engines are stopped, the DAOS servers will continue to
+operate and listen on the management network.
+
+!!! warning
+    All engines monitor each other and pro-actively exclude unresponsive
+    members. It is critical to properly stop a DAOS system as with dmg in
+    the case of a planned maintenance on all or a majority of the DAOS
+    storage nodes. An abrupt reboot of the storage nodes might result
+    in massive exclusion that will take time to recover.
+
+The force option can be passed to dmg system stop for cases when a clean
+shutown is not working. Monitoring is not disabled in this case and spurious
+exclusion might happen, but the engines are guaranteed to be killed.
+
+dmg also allows to stop a list of engines identified by ranks or hostnames.
+This is useful to stop (and restart) misbehaving engines.
+
+`$ dmg system stop [--force] [--ranks <rankset>|--host-ranks <hostset>]`
+
+- `<rankset>` is a pattern describing rank ranges e.g., 0,5-10,20-100
+- `<hostset>` is a pattern describing host ranges e.g.,
+storagehost[0,5-10],10.8.1.[20-100]
 
 ### Start
 
-To start the system after a controlled shutdown run the command:
+To start the system after a controlled shutdown, run the command:
 
-`$ dmg system start [--ranks <rankset>|--host-ranks <hostset>]`
+`$ dmg system start`
 
-- `<rankset>` is a pattern describing rank ranges e.g. 0,5-10,20-100
-- `<hostset>` is a pattern describing host ranges e.g.
+- `<rankset>` is a pattern describing rank ranges e.g., 0,5-10,20-100
+- `<hostset>` is a pattern describing host ranges e.g.,
 storagehost[0,5-10],10.8.1.[20-100]
 
 The output table will indicate action and result.
 
 DAOS I/O Engines will be started.
 
+As for shutdown, a list of engines to restart can be specified on the command
+line:
+
+`$ dmg system start [--ranks <rankset>|--host-ranks <hostset>]`
+
+- `<rankset>` is a pattern describing rank ranges e.g., 0,5-10,20-100
+- `<hostset>` is a pattern describing host ranges e.g.,
+storagehost[0,5-10],10.8.1.[20-100]
+
+If the ranks were excluded from pools (e.g., unclean shutdown), they will need to
+be reintegrated. Please see the pool operation section for more information.
+
 ### Reformat
 
-To reformat the system after a controlled shutdown run the command:
+To reformat the system after a controlled shutdown, run the command:
 
 `$ dmg storage format --reformat`
 
@@ -551,7 +574,9 @@ DAOS I/O Engines will be started, and all DAOS pools will have been removed.
 
 ### Manual Fresh Start
 
-To reset the DAOS metadata across all hosts, the system must be reformatted.
+While it should not be required during normal operations, one may still want to
+restart the DAOS installation from scratch without using the DAOS control plane.
+
 First, ensure all `daos_server` processes on all hosts have been
 stopped, then for each SCM mount specified in the config file
 (`scm_mount` in the `servers` section) umount and wipe FS signatures.
@@ -570,7 +595,7 @@ Example illustration with two IO instances specified in the config file:
 
 ### Fault Domain
 
-Details on how to drain an individual storage node or fault domain (e.g.
+Details on how to drain an individual storage node or fault domain (e.g.,
 rack) in preparation for maintenance activity and how to reintegrate it
 will be provided in a future revision.
 

--- a/docs/user/container.md
+++ b/docs/user/container.md
@@ -1,21 +1,31 @@
 # Container Management
 
-DAOS containers (not to be confused with Linux containers) are datasets (or
-buckets if you are more familiar with cloud object stores) managed
-by the users. A container is the unit of snapshot and has a type. It can be a
-POSIX namespace, an HDF5 file or any other application-specific data model.
-The chapter explains how to manage a container, while the subsequent ones detail
-how to access a DAOS container from applications.
+DAOS containers are datasets managed by the users. Similarly to S3 buckets,
+a DAOS container is a collection of objects that can be presented to applications
+through different interfaces including POSIX I/O (files and directories),
+HDF5, SQL or any other data models of your choice.
 
-## Container Basic Operations
+A container belongs to a single pool and shares the space with other containers.
+It is identified by a label selected by the user and an immutable UUID allocated
+when the container is first created.
+
+The container is the unit of data management in DAOS and can be snapshotted or
+cloned.
+
+!!! warning
+    DAOS containers are storage containers and should not be confused with Linux
+    containers.
+
+## Container Basics
+
+Containers can be created, queried, relabeled, listed and destroyed through the
+`daos(1)` utility or native DAOS API.
 
 ### Creating a Container
 
-Containers can be created and destroyed through the `daos(1)` utility.
-provided to manage containers.
+To create and then query a container labeled `mycont` on a pool
+labeled `tank`:
 
-**To create and then query a container labeled `mycont` on a pool
-(labeled `tank`):**
 ```bash
 $ daos cont create tank --label mycont
   Container UUID : daefe12c-45d4-44f7-8e56-995d02549041
@@ -35,15 +45,17 @@ $ daos cont query tank mycont
   Snapshot Epochs            :
 ```
 
-Like pools, container labels can be up to 127 characters long and must only include
-alphanumeric characters, colon (':'), period ('.'), hyphen ('-') or underscore ('\_').
+While a label is not mandatory, it is highly recommended. Like pools, container
+labels can be up to 127 characters long and must only include alphanumeric
+characters, colon (':'), period ('.'), hyphen ('-') or underscore ('\_').
 Labels that can be parsed as UUID are not allowed.
 
 The container type (i.e., POSIX or HDF5) can be passed via the --type option.
-As shown below, the pool UUID, container UUID, and container attributes can be
-stored in the extended attributes of a POSIX file or directory for convenience.
-Then subsequent invocations of the daos tools need to reference the path
-to the POSIX file or directory.
+
+For convenience, a container can also be identified by a path to a filesystem
+supporting extended attributes. In this case, the pool and container UUIDs
+are stored in an extended attribute of the target file or directory that can
+then be used in subsequent command invocations to identify the container.
 
 ```bash
 $ daos cont create tank --path /tmp/mycontainer --type=POSIX --oclass=SX
@@ -67,7 +79,7 @@ $ daos cont query --path /tmp/mycontainer
 
 ### Listing Containers
 
-**To list all containers available in a pool:**
+To list all containers available in a pool:
 
 ```bash
 $ daos cont list tank
@@ -79,7 +91,7 @@ daefe12c-45d4-44f7-8e56-995d02549041 mycont
 
 ### Destroying a Container
 
-**To destroy a container:**
+To destroy a container:
 ```bash
 $ daos cont destroy tank mycont
 Successfully destroyed container mycont
@@ -88,10 +100,17 @@ $ daos cont destroy --path /tmp/mycontainer
 Successfully destroyed container 30e5d364-62c9-4ddf-9284-1021359455f2
 ```
 
+If the container is in use, the force option (i.e., --force or -f) must be added.
+Active users of a force-deleted container will fail with a bad handle error.
+
+!!! note
+    It is orders of magniture faster to delete a container compared to
+    destroying each object individually.
+
 ## Container Properties
 
 Container properties are the main mechanism that one can use to control the
-behavior of container. This includes the type of middleware, whether some
+behavior of containers. This includes the type of middleware, whether some
 features like deduplication or checksum are enabled. Some properties are
 immutable after creation creation, while some others can be dynamically
 changed.
@@ -303,15 +322,15 @@ data copies in order to decrease capacity requirements. DAOS has some initial
 support of inline dedup.
 
 When dedup is enabled, each DAOS server maintains a per-pool table indexing
-extents by their hash (i.e. checksum). Any new I/Os bigger than the
+extents by their hash (i.e., checksum). Any new I/Os bigger than the
 deduplication threshold will thus be looked up in this table to find out
 whether an existing extent with the same signature has already been stored.
 If an extent is found, then two options are provided:
 
 - Transferring the data from the client to the server and doing a memory compare
-  (i.e. memcmp) of the two extents to verify that they are indeed identical.
+  (i.e., memcmp) of the two extents to verify that they are indeed identical.
 - Trusting the hash function and skipping the data transfer. To minimize issue
-  with hash collision, a cryptographic hash function (i.e. SHA256) is used in
+  with hash collision, a cryptographic hash function (i.e., SHA256) is used in
   this case. The benefit of this approarch is that the data to be written does
   not need to be transferred to the server. Data processing is thus greatly
   accelerated.

--- a/docs/user/workflow.md
+++ b/docs/user/workflow.md
@@ -130,7 +130,7 @@ number of targets is also provided.
 This information can also be retrieved programmatically via the
 `daos_pool_query()` function of the libdaos library and python equivalent.
 
-## Pool Attributes
+### Pool Attributes
 
 Project-wise information can be stored in pool user attributes (not to be
 confused with pool properties). Pool attributes can be manipulated via the


### PR DESCRIPTION
Provide more details on reintegration and document the current
limitation.
Add a more detailed definition of what a container is and
how it can be used.
Fix a few nits where UUID are still used on the cmd line.

doc-only: true

Signed-off-by: Johann Lombardi <johann.lombardi@intel.com>