### PR TITLE
DAOS-7174 doc: uniformize style and enable multi-version

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,12 +3,11 @@ site_name: DAOS v1.2
 site_description: Distributed Asynchronous Object Storage
 site_author: DAOS Project
 site_url: http://daos.io
-site_dir: ../site
 
 # Repository
 repo_name: daos-stack/daos
 repo_url: https://github.com/daos-stack/daos
-edit_url: ""
+copyright: Copyright &copy; 2016 - 2021 Intel Corporation
 
 # Theme
 theme:
@@ -18,23 +17,41 @@ theme:
         code: 'Ubuntu Mono'
     language: en
     palette:
-        primary: 'blue grey'
-        accent: 'blue'
-    feature:
-        tabs: true
+        primary: light blue
+        accent: blue
+        scheme: default
+    features:
+        - navigation.tabs
+        - navigation.tabs.sticky
+        - navigation.instant
 
-docs_dir: ./
+extra:
+    homepage: http://daos.io
+    version:
+        provider: mike
+
+plugins:
+    - mike:
+        version_selector: true
+
+docs_dir: ./doc
 
 markdown_extensions:
     - admonition
     - footnotes
     - toc:
         permalink: true
+        toc_depth: 4
 
 # Page tree
 nav:
-    - Home: 'index.md'
-    - Architecture Overview:
+    - Intro:
+        - 'Home': 'index.md'
+        - 'Community Wiki': 'http://wiki.daos.io'
+        - 'Community Roadmap': 'http://wiki.daos.io/spaces/DC/pages/4836661105/Roadmap'
+        - 'Community Mailing list': 'https://daos.groups.io/g/daos'
+        - 'Issue tracker': 'http://jira.daos.io'
+    - Overview:
         - 'Terminology': 'overview/terminology.md'
         - 'Architecture': 'overview/architecture.md'
         - 'Storage Model': 'overview/storage.md'
@@ -81,7 +98,3 @@ nav:
         - 'Contributing': 'dev/contributing.md'
         - 'DAOS Internals': 'https://github.com/daos-stack/daos/blob/master/src/README.md'
         - 'DAOS API Documentation': 'html/index.html'
-    - Community Wiki: 'http://wiki.daos.io/'
-    - Roadmap: 'http://wiki.daos.io/spaces/DC/pages/4836661105/Roadmap'
-    - Mailing list: 'https://daos.groups.io/g/daos'
-    - Issue tracker: 'http://jira.daos.io/'


### PR DESCRIPTION
Use same color scheme as 2.0 documentation and change layout
to be more aligned with 2.0 (not necessarily required, but
this simplifies the naviguation). Move mkdocs.yml to the
root directory for easier scripting.
Enable the mike plugin for multi-version support

doc-only: true

Signed-off-by: Johann Lombardi <johann.lombardi@intel.com>