### PR TITLE
DAOS-9084 daos: fix resolving dfuse destination type

### DIFF
--- a/src/tests/ftest/datamover/posix_subsets.py
+++ b/src/tests/ftest/datamover/posix_subsets.py
@@ -56,10 +56,10 @@ class DmvrPosixSubsets(DataMoverTestBase):
 	# create dfuse containers to test copying to dfuse subdirectories
         dfuse_cont1 = self.create_cont(pool1)
         dfuse_cont2 = self.create_cont(pool1)
-        dfuse_cont1_dir = str(join(self.dfuse.mount_dir.value, pool1.uuid, dfuse_cont1.uuid))
+        dfuse_cont1_dir = join(self.dfuse.mount_dir.value, pool1.uuid, dfuse_cont1.uuid)
 	# destination directory should be created by program
         dfuse_cont2_dir = self.new_posix_test_path(create=False,
-            parent=str(join(self.dfuse.mount_dir.value, pool1.uuid, dfuse_cont2.uuid)))
+            parent=join(self.dfuse.mount_dir.value, pool1.uuid, dfuse_cont2.uuid))
         # Create a special container to hold UNS entries
         uns_cont = self.create_cont(pool1)
 
@@ -133,8 +133,7 @@ class DmvrPosixSubsets(DataMoverTestBase):
                 dst[0], dst[1], dst[2], dst[3])
             self.read_verify_location(*dst)
             if self.tool == "FS_COPY":
-                fs_copy_search = re.search(r"Successfully copied to DAOS", result.stdout_text)
-                if not fs_copy_search.group(0) == "Successfully copied to DAOS":
+                if not re.search(r"Successfully copied to DAOS", result.stdout_text):
                     self.fail("Failed to copy to DAOS")
 
     def write_location(self, param_type, path, pool=None, cont=None):

--- a/src/tests/ftest/datamover/posix_subsets.py
+++ b/src/tests/ftest/datamover/posix_subsets.py
@@ -5,7 +5,8 @@
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
 from data_mover_test_base import DataMoverTestBase
-
+from os.path import join
+import re
 
 class DmvrPosixSubsets(DataMoverTestBase):
     # pylint: disable=too-many-ancestors
@@ -52,6 +53,13 @@ class DmvrPosixSubsets(DataMoverTestBase):
         # Create 1 pool
         pool1 = self.create_pool()
 
+	# create dfuse containers to test copying to dfuse subdirectories
+        dfuse_cont1 = self.create_cont(pool1)
+        dfuse_cont2 = self.create_cont(pool1)
+        dfuse_cont1_dir = str(join(self.dfuse.mount_dir.value, pool1.uuid, dfuse_cont1.uuid))
+	# destination directory should be created by program
+        dfuse_cont2_dir = self.new_posix_test_path(create=False,
+            parent=str(join(self.dfuse.mount_dir.value, pool1.uuid, dfuse_cont2.uuid)))
         # Create a special container to hold UNS entries
         uns_cont = self.create_cont(pool1)
 
@@ -65,8 +73,14 @@ class DmvrPosixSubsets(DataMoverTestBase):
         # Create initial test files
         self.write_location("DAOS_UUID", sub_dir, pool1, container1)
         self.write_location("DAOS_UUID", sub_sub_dir, pool1, container1)
+        self.write_location("POSIX", dfuse_cont1_dir)
 
         copy_list = []
+
+        if self.tool == "FS_COPY":
+            copy_list.append(["dfuse copy (dfuse cont1 dir to dfuse cont2 dir that doesn't exist)",
+                ["POSIX", dfuse_cont1_dir, None, None],
+                ["POSIX", dfuse_cont2_dir, None, None]])
 
         # For each copy, use a new destination directory.
         # This ensures that the source directory is copied
@@ -113,11 +127,15 @@ class DmvrPosixSubsets(DataMoverTestBase):
         # Each src or dst is a list of params:
         #   [param_type, path, pool, cont]
         for (test_desc, src, dst) in copy_list:
-            self.run_datamover(
+            result = self.run_datamover(
                 test_desc,
                 src[0], src[1], src[2], src[3],
                 dst[0], dst[1], dst[2], dst[3])
             self.read_verify_location(*dst)
+            if self.tool == "FS_COPY":
+                fs_copy_search = re.search(r"Successfully copied to DAOS", result.stdout_text)
+                if not fs_copy_search.group(0) == "Successfully copied to DAOS":
+                    self.fail("Failed to copy to DAOS")
 
     def write_location(self, param_type, path, pool=None, cont=None):
         """Write the test data using ior."""

--- a/src/utils/daos_hdlr.c
+++ b/src/utils/daos_hdlr.c
@@ -2256,7 +2256,6 @@ dm_parse_path(struct file_dfs *file, char *path, size_t path_len, char (*pool_st
 
 		/* Check if this path represents a daos pool and/or container. */
 		rc = duns_resolve_path(path_dirname, &dattr);
-		/* if it succeeds get the basename and append it to the rel_path */
 		if (rc == 0) {
 			/* if duns_resolve_path succeeds then concat basename to da_rel_path */
 			D_STRNDUP(tmp_path2, path, path_len);
@@ -2270,7 +2269,7 @@ dm_parse_path(struct file_dfs *file, char *path, size_t path_len, char (*pool_st
 			if (dattr.da_rel_path == NULL)
 				D_ALLOC(tmp, path_len);
 			else
-				tmp = realloc(dattr.da_rel_path, path_len);
+				D_REALLOC(tmp, dattr.da_rel_path, path_len, path_len);
 			if (tmp == NULL)
 				D_GOTO(out, rc = ENOMEM);
 			dattr.da_rel_path = tmp;
@@ -2285,7 +2284,7 @@ dm_parse_path(struct file_dfs *file, char *path, size_t path_len, char (*pool_st
 			D_GOTO(out, rc);
 		} else if (strncmp(path, "daos://", 7) == 0) {
 			/* Error, since we expect a DAOS path */
-			D_GOTO(out, rc = EINVAL);
+			D_GOTO(out, rc);
 		} else {
 			/* not a DAOS path, set type to POSIX,
 			 * POSIX dir will be checked with stat

--- a/src/utils/daos_hdlr.c
+++ b/src/utils/daos_hdlr.c
@@ -2295,6 +2295,8 @@ dm_parse_path(struct file_dfs *file, char *path, size_t path_len, char (*pool_st
 		}
 	}
 out:
+	D_FREE(tmp_path1);
+	D_FREE(tmp_path2);
 	duns_destroy_attr(&dattr);
 	return daos_errno2der(rc);
 }

--- a/src/utils/daos_hdlr.c
+++ b/src/utils/daos_hdlr.c
@@ -2230,17 +2230,15 @@ dm_parse_path(struct file_dfs *file, char *path, size_t path_len, char (*pool_st
 	char			*path_dirname = NULL;
 	char			*tmp_path2 = NULL;
 	char			*path_basename = NULL;
-	char			*tmp = NULL;
 
 	rc = duns_resolve_path(path, &dattr);
 	if (rc == 0) {
 		snprintf(*pool_str, DAOS_PROP_LABEL_MAX_LEN + 1, "%s", dattr.da_pool);
 		snprintf(*cont_str, DAOS_PROP_LABEL_MAX_LEN + 1, "%s", dattr.da_cont);
-		if (dattr.da_rel_path == NULL) {
+		if (dattr.da_rel_path == NULL)
 			strncpy(path, "/", path_len);
-		} else {
+		else
 			strncpy(path, dattr.da_rel_path, path_len);
-		}
 	} else {
 		/* If basename does not exist yet then duns_resolve_path will fail even if
 		 * dirname is a UNS path
@@ -2267,18 +2265,11 @@ dm_parse_path(struct file_dfs *file, char *path, size_t path_len, char (*pool_st
 			 * then da_rel_path might be NULL
 			 */
 			if (dattr.da_rel_path == NULL)
-				D_ALLOC(tmp, path_len);
+				snprintf(path, path_len, "/%s", path_basename);
 			else
-				D_REALLOC(tmp, dattr.da_rel_path, path_len, path_len);
-			if (tmp == NULL)
-				D_GOTO(out, rc = ENOMEM);
-			dattr.da_rel_path = tmp;
-			strcat(dattr.da_rel_path, "/");
-			strcat(dattr.da_rel_path, path_basename);
-
+				snprintf(path, path_len, "%s/%s", dattr.da_rel_path, path_basename);
 			snprintf(*pool_str, DAOS_PROP_LABEL_MAX_LEN + 1, "%s", dattr.da_pool);
 			snprintf(*cont_str, DAOS_PROP_LABEL_MAX_LEN + 1, "%s", dattr.da_cont);
-			strncpy(path, dattr.da_rel_path, path_len);
 		} else if (rc == ENOMEM) {
 			/* TODO: Take this path of rc != ENOENT? */
 			D_GOTO(out, rc);

--- a/src/utils/daos_hdlr.c
+++ b/src/utils/daos_hdlr.c
@@ -2226,6 +2226,11 @@ dm_parse_path(struct file_dfs *file, char *path, size_t path_len, char (*pool_st
 {
 	struct duns_attr_t	dattr = {0};
 	int			rc = 0;
+	char			*tmp_path1 = NULL;
+	char			*path_dirname = NULL;
+	char			*tmp_path2 = NULL;
+	char			*path_basename = NULL;
+	char			*tmp = NULL;
 
 	rc = duns_resolve_path(path, &dattr);
 	if (rc == 0) {
@@ -2236,19 +2241,59 @@ dm_parse_path(struct file_dfs *file, char *path, size_t path_len, char (*pool_st
 		} else {
 			strncpy(path, dattr.da_rel_path, path_len);
 		}
-	} else if (rc == ENOMEM) {
-		/* TODO: Take this path of rc != ENOENT? */
-		D_GOTO(out, rc);
-	} else if (strncmp(path, "daos://", 7) == 0) {
-		/* Error, since we expect a DAOS path */
-		D_GOTO(out, rc = EINVAL);
 	} else {
-		/* not a DAOS path, set type to POSIX,
-		 * POSIX dir will be checked with stat
-		 * at the beginning of fs_copy
+		/* If basename does not exist yet then duns_resolve_path will fail even if
+		 * dirname is a UNS path
 		 */
-		rc = 0;
-		file->type = POSIX;
+
+		/* get dirname */
+		D_STRNDUP(tmp_path1, path, path_len);
+		if (tmp_path1 == NULL)
+			D_GOTO(out, rc = ENOMEM);
+		path_dirname = dirname(tmp_path1);
+		/* reset before calling duns_resolve_path with new string */
+		memset(&dattr, 0, sizeof(struct duns_attr_t));
+
+		/* Check if this path represents a daos pool and/or container. */
+		rc = duns_resolve_path(path_dirname, &dattr);
+		/* if it succeeds get the basename and append it to the rel_path */
+		if (rc == 0) {
+			/* if duns_resolve_path succeeds then concat basename to da_rel_path */
+			D_STRNDUP(tmp_path2, path, path_len);
+			if (tmp_path2 == NULL)
+				D_GOTO(out, rc = ENOMEM);
+			path_basename = basename(tmp_path2);
+
+			/* dirname might be root uns path, if that is the case,
+			 * then da_rel_path might be NULL
+			 */
+			if (dattr.da_rel_path == NULL)
+				D_ALLOC(tmp, path_len);
+			else
+				tmp = realloc(dattr.da_rel_path, path_len);
+			if (tmp == NULL)
+				D_GOTO(out, rc = ENOMEM);
+			dattr.da_rel_path = tmp;
+			strcat(dattr.da_rel_path, "/");
+			strcat(dattr.da_rel_path, path_basename);
+
+			snprintf(*pool_str, DAOS_PROP_LABEL_MAX_LEN + 1, "%s", dattr.da_pool);
+			snprintf(*cont_str, DAOS_PROP_LABEL_MAX_LEN + 1, "%s", dattr.da_cont);
+			strncpy(path, dattr.da_rel_path, path_len);
+		} else if (rc == ENOMEM) {
+			/* TODO: Take this path of rc != ENOENT? */
+			D_GOTO(out, rc);
+		} else if (strncmp(path, "daos://", 7) == 0) {
+			/* Error, since we expect a DAOS path */
+			D_GOTO(out, rc = EINVAL);
+		} else {
+			/* not a DAOS path, set type to POSIX,
+			 * POSIX dir will be checked with stat
+			 * at the beginning of fs_copy
+			 */
+			rc = 0;
+			file->type = POSIX;
+		}
 	}
 out:
 	duns_destroy_attr(&dattr);


### PR DESCRIPTION
duns_resolve_path does not resolve a path as residing in DAOS if the
basename of the dfuse target directory does not exist, and instead copies
to a regular POSIX directory. If one level up from the target dfuse
directory exists in DAOS, then the directory should be created and data
should be copied into DAOS, not POSIX.

Test-tag: pr fs_copy cont_clone

Signed-off-by: Danielle Sikich <danielle.sikich@intel.com>