### PR TITLE
DAOS-9080 tests: increase IO consistency test timeout

### DIFF
--- a/src/tests/ftest/io/io_consistency.yaml
+++ b/src/tests/ftest/io/io_consistency.yaml
@@ -7,7 +7,7 @@ hosts:
   test_clients:
     - client-E
     - client-F
-timeout: 150
+timeout: 210
 server_config:
   name: daos_server
   servers:


### PR DESCRIPTION
master-commit: f3ad92f088de1858201cd8f3421a9e6946ad47a7

To avoid kinds of network slowness casused test timeout.

Signed-off-by: Fan Yong <fan.yong@intel.com>