### PR TITLE
DAOS-8936 tests: Support detecting engine start via dmg (#7425)

### DIFF
--- a/src/tests/ftest/control/daos_admin_privileged.py
+++ b/src/tests/ftest/control/daos_admin_privileged.py
@@ -88,8 +88,9 @@ class DaosAdminPrivTest(TestWithServers):
         if result is None:
             self.fail("Failed to format storage")
 
-        # Verify format success when all the daos_engine start
+        # Verify format success when all the daos_engine start. Use dmg to detect server start.
         try:
+            self.server_managers[0].detect_start_via_dmg = True
             self.server_managers[0].detect_engine_start()
         except ServerFailed as error:
             self.fail(

--- a/src/tests/ftest/util/command_utils.py
+++ b/src/tests/ftest/util/command_utils.py
@@ -705,45 +705,50 @@ class SubProcessCommand(CommandWithSubCommand):
             #   - the time out is reached (failure)
             #   - the subprocess is no longer running (failure)
             while not complete and not timed_out and sub_process.poll() is None:
-                output = get_subprocess_stdout(sub_process)
-                detected = len(re.findall(self.pattern, output))
+                detected = len(re.findall(self.pattern, get_subprocess_stdout(sub_process)))
                 complete = detected == self.pattern_count
                 timed_out = time.time() - start > self.pattern_timeout.value
 
             # Summarize results
-            msg = "{}/{} '{}' messages detected in".format(
-                detected, self.pattern_count, self.pattern)
-            runtime = "{}/{} seconds".format(
-                time.time() - start, self.pattern_timeout.value)
-
-            if not complete:
-                # Report the error / timeout
-                reason = "ERROR detected"
-                details = ""
-                if timed_out:
-                    reason = "TIMEOUT detected, exceeded {} seconds".format(
-                        self.pattern_timeout.value)
-                    runtime = "{} seconds".format(time.time() - start)
-                if not self.verbose:
-                    # Include the stdout if verbose is not enabled
-                    details = ":\n{}".format(get_subprocess_stdout(sub_process))
-                self.log.info("%s - %s %s%s", reason, msg, runtime, details)
-                if timed_out:
-                    self.log.debug(
-                        "If needed the %s second timeout can be adjusted via "
-                        "the 'pattern_timeout' test yaml parameter under %s",
-                        self.pattern_timeout.value, self.namespace)
-
-                # Stop the timed out process
-                if timed_out:
-                    self.stop()
-            else:
-                # Report the successful start
-                self.log.info(
-                    "%s subprocess startup detected - %s %s",
-                    self._command, msg, runtime)
+            self.report_subprocess_status(start, detected, complete, timed_out, sub_process)
 
         return complete
+
+    def report_subprocess_status(self, start, detected, complete, timed_out, sub_process):
+        """Summarize the results of checking the status of the command.
+
+        Args:
+            start (float): start time of check
+            detected (int): number of patterns detected in the check
+            complete (bool): whether the check succeeded
+            timed_out (bool): whether the check timed out
+            sub_process (process.SubProcess): subprocess used to run the command
+        """
+        msg = "{}/{} '{}' messages detected in".format(detected, self.pattern_count, self.pattern)
+        runtime = "{}/{} seconds".format(time.time() - start, self.pattern_timeout.value)
+
+        if not complete:
+            # Report the error / timeout
+            reason = "ERROR detected"
+            details = ""
+            if timed_out:
+                reason = "TIMEOUT detected, exceeded {} seconds".format(self.pattern_timeout.value)
+                runtime = "{} seconds".format(time.time() - start)
+            if not self.verbose:
+                # Include the stdout if verbose is not enabled
+                details = ":\n{}".format(get_subprocess_stdout(sub_process))
+            self.log.info("%s - %s %s%s", reason, msg, runtime, details)
+            if timed_out:
+                self.log.debug(
+                    "If needed the %s second timeout can be adjusted via the 'pattern_timeout' "
+                    "test yaml parameter under %s", self.pattern_timeout.value, self.namespace)
+
+            # Stop the timed out process
+            if timed_out:
+                self.stop()
+        else:
+            # Report the successful start
+            self.log.info("%s subprocess startup detected - %s %s", self._command, msg, runtime)
 
 
 class YamlCommand(SubProcessCommand):

--- a/src/tests/ftest/util/server_utils.py
+++ b/src/tests/ftest/util/server_utils.py
@@ -122,6 +122,9 @@ class DaosServerManager(SubprocessManager):
         # Storage and network information
         self.information = DaosServerInformation(self.dmg)
 
+        # Flag used to determine which method is used to detect that the server has started
+        self.detect_start_via_dmg = False
+
     def get_params(self, test):
         """Get values for all of the command params from the yaml file.
 
@@ -366,9 +369,17 @@ class DaosServerManager(SubprocessManager):
         """
         if host_qty is None:
             hosts_qty = len(self._hosts)
-        self.log.info("<SERVER> Waiting for the daos_engine to start")
-        self.manager.job.update_pattern("normal", hosts_qty)
-        if not self.manager.check_subprocess_status(self.manager.process):
+
+        if self.detect_start_via_dmg:
+            self.log.info("<SERVER> Waiting for the daos_engine to start via dmg system query")
+            self.manager.job.update_pattern("dmg", hosts_qty)
+            started = self.get_detected_engine_count(self.manager.process)
+        else:
+            self.log.info("<SERVER> Waiting for the daos_engine to start")
+            self.manager.job.update_pattern("normal", hosts_qty)
+            started = self.manager.check_subprocess_status(self.manager.process)
+
+        if not started:
             self.manager.kill()
             raise ServerFailed("Failed to start servers after format")
 
@@ -377,6 +388,55 @@ class DaosServerManager(SubprocessManager):
 
         # Define the expected states for each rank
         self._expected_states = self.get_current_state()
+
+    def get_detected_engine_count(self, sub_process):
+        """Get the number of detected joined engines.
+
+        Args:
+            sub_process (process.SubProcess): subprocess used to run the command
+
+        Returns:
+            int: number of patterns detected in the job output
+
+        """
+        expected_states = self.manager.job.pattern.split(",")
+        detected = 0
+        complete = False
+        timed_out = False
+        start = time.time()
+
+        # Search for patterns in the dmg system query output:
+        #   - the expected number of pattern matches are detected (success)
+        #   - the time out is reached (failure)
+        #   - the subprocess is no longer running (failure)
+        while not complete and not timed_out and sub_process.poll() is None:
+            detected = self.detect_engine_states(expected_states)
+            complete = detected == self.manager.job.pattern_count
+            timed_out = time.time() - start > self.manager.job.pattern_timeout.value
+            if not complete and not timed_out:
+                time.sleep(1)
+
+        # Summarize results
+        self.manager.job.report_subprocess_status(start, detected, complete, timed_out, sub_process)
+
+        return complete
+
+    def detect_engine_states(self, expected_states):
+        """Detect the number of engine states that match the expected states.
+
+        Args:
+            expected_states (list): a list of engine state strings to detect
+
+        Returns:
+            int: number of engine states that match the expected states
+
+        """
+        detected = 0
+        states = self.get_current_state()
+        for rank in sorted(states):
+            if states[rank]["state"].lower() in expected_states:
+                detected += 1
+        return detected
 
     def reset_storage(self):
         """Reset the server storage.

--- a/src/tests/ftest/util/server_utils_base.py
+++ b/src/tests/ftest/util/server_utils_base.py
@@ -28,6 +28,7 @@ class DaosServerCommand(YamlCommand):
     NORMAL_PATTERN = "DAOS I/O Engine.*started"
     FORMAT_PATTERN = "(SCM format required)(?!;)"
     REFORMAT_PATTERN = "Metadata format required"
+    SYSTEM_QUERY_PATTERN = "joined"
 
     DEFAULT_CONFIG_FILE = os.path.join(os.sep, "etc", "daos", "daos_server.yml")
 
@@ -118,6 +119,8 @@ class DaosServerCommand(YamlCommand):
             self.pattern = self.FORMAT_PATTERN
         elif mode == "reformat":
             self.pattern = self.REFORMAT_PATTERN
+        elif mode == "dmg":
+            self.pattern = self.SYSTEM_QUERY_PATTERN
         else:
             self.pattern = self.NORMAL_PATTERN
         self.pattern_count = host_qty * len(self.yaml.engine_params)


### PR DESCRIPTION
Enable tests to optionally detect if all the daos server engines have
started successfully via dmg system query instead of searching the
command output for engine started messages.

Signed-off-by: Phillip Henderson <phillip.henderson@intel.com>