### PR TITLE
DAOS-9103 test: Change daos_test to use --nsvc=3

### DIFF
--- a/src/control/server/faults.go
+++ b/src/control/server/faults.go
@@ -55,7 +55,7 @@ var (
 func FaultPoolInvalidServiceReps(maxSvcReps uint32) *fault.Fault {
 	return serverFault(
 		code.ServerPoolInvalidServiceReps,
-		fmt.Sprintf("pool service replicas number should be an odd number between 1 and %d", maxSvcReps),
+		fmt.Sprintf("pool service replicas number should be an odd number from 1 to %d", maxSvcReps),
 		"retry the request with a valid number of pool service replicas",
 	)
 }

--- a/src/control/server/mgmt_pool.go
+++ b/src/control/server/mgmt_pool.go
@@ -304,6 +304,11 @@ func (svc *mgmtSvc) PoolCreate(ctx context.Context, req *mgmtpb.PoolCreateReq) (
 		if allRanks > MaxPoolServiceReps {
 			return uint32(MaxPoolServiceReps)
 		}
+		// Must be an odd number.
+		if allRanks%2 == 0 {
+			allRanks--
+		}
+
 		return uint32(allRanks)
 	}(len(req.GetRanks()))
 

--- a/src/tests/ftest/daos_test/suite.yaml
+++ b/src/tests/ftest/daos_test/suite.yaml
@@ -164,6 +164,8 @@ daos_tests:
     test_daos_degraded_ec: X
     test_daos_dedup: U
   args:
+    test_daos_degraded_mode: -s3
+    test_daos_oid_allocator: -s3
     test_daos_ec_io: -l"EC_4P2G1"
     test_daos_rebuild_ec: -s5
   scalable_endpoint:

--- a/src/tests/ftest/util/daos_core_base.py
+++ b/src/tests/ftest/util/daos_core_base.py
@@ -121,8 +121,6 @@ class DaosCoreBase(TestWithServers):
                 get_log_file("daosCA/certs"), self.hostlist_clients)
             dmg.copy_configuration(self.hostlist_clients)
         self.client_mca += " --mca btl_tcp_if_include eth0"
-        # use a resilient PS if ranks will be stopped
-        svcn = "3" if len(stopped_ranks) > 0 else "1"
 
         cmd = " ".join(
             [
@@ -135,7 +133,6 @@ class DaosCoreBase(TestWithServers):
                 "-x", "DD_MASK=mgmt,io,md,epc,rebuild",
                 "-x", "COVFILE=/tmp/test.cov",
                 self.daos_test,
-                "-s", svcn,
                 "-n", dmg_config_file,
                 "".join(["-", subtest]),
                 str(args)

--- a/src/tests/ftest/util/daos_core_base.py
+++ b/src/tests/ftest/util/daos_core_base.py
@@ -121,6 +121,8 @@ class DaosCoreBase(TestWithServers):
                 get_log_file("daosCA/certs"), self.hostlist_clients)
             dmg.copy_configuration(self.hostlist_clients)
         self.client_mca += " --mca btl_tcp_if_include eth0"
+        # use a resilient PS if ranks will be stopped
+        svcn = "3" if len(stopped_ranks) > 0 else "1"
 
         cmd = " ".join(
             [
@@ -133,6 +135,7 @@ class DaosCoreBase(TestWithServers):
                 "-x", "DD_MASK=mgmt,io,md,epc,rebuild",
                 "-x", "COVFILE=/tmp/test.cov",
                 self.daos_test,
+                "-s", svcn,
                 "-n", dmg_config_file,
                 "".join(["-", subtest]),
                 str(args)


### PR DESCRIPTION
After the change to randomize pool service ranks landed,
the degraded mode tests started randomly failing. The
problem is that the test always tries to kill ranks 7,6,5
without regard for where the pool service is running.
The test does avoid killing the pool service rank, but then
the test fails because it expects all three ranks to be in
the excluded state at the end.

The primary fix for this problem is to create a pool with
a resilient pool service when ranks will be killed so that
it can survive the failure of a rank. The secondary fix is
to modify the daos_kill_server() helper to allow killing of
svc ranks unless there is only a single svc rank.

Test-tag: pr test_daos_degraded_mode test_daos_oid_allocator

Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com>
