### PR TITLE
DAOS-7878 vos: Partial revert of punch propagation (#7451)

### DIFF
--- a/src/vos/tests/vts_mvcc.c
+++ b/src/vos/tests/vts_mvcc.c
@@ -1094,6 +1094,17 @@ struct conflicting_rw_excluded_case {
 };
 
 static struct conflicting_rw_excluded_case conflicting_rw_excluded_cases[] = {
+	/** Used to disable specific tests as necessary */
+	/** These specific tests can be enabled when DAOS-4698 is fixed
+	*  and the line in vos_obj.c that references this ticket is
+	*  uncommented.
+	*/
+	{false, "punchd_dne",   "cod",  "puncho_one",   "co",   0, false},
+	{false, "punchd_dne",   "cod",  "puncho_one",   "co",   1, false},
+	{false, "puncha_ane",   "coda", "puncho_one",   "co",   0, false},
+	{false, "puncha_ane",   "coda", "puncho_one",   "co",   1, false},
+	{false, "puncha_ane",   "coda", "puncho_one",   "co",   0, true},
+	{false, "punchd_dne",   "cod",  "puncho_one",   "co",   0, true},
 };
 
 static int64_t

--- a/src/vos/vos_obj.c
+++ b/src/vos/vos_obj.c
@@ -189,7 +189,8 @@ vos_propagate_check(struct vos_object *obj, umem_off_t *known_key, daos_handle_t
 		read_flag = VOS_TS_READ_OBJ;
 		write_flag = VOS_TS_WRITE_OBJ;
 		tree_name = "DKEY";
-		break;
+		/** Skip propagation to object level for now */
+		return 0;
 	case VOS_ITER_AKEY:
 		read_flag = VOS_TS_READ_DKEY;
 		write_flag = VOS_TS_WRITE_DKEY;


### PR DESCRIPTION
Revert just the enabling of propagation to object level.  General
propagation should be faster if a user punches akeys.

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>