### PR TITLE
DAOS-9106 rebuild: not IV rebuild completion until IV for pool map done

### DIFF
--- a/src/include/daos_srv/pool.h
+++ b/src/include/daos_srv/pool.h
@@ -47,6 +47,7 @@ struct ds_pool {
 	struct sched_request	*sp_ec_ephs_req;
 
 	uint32_t		sp_dtx_resync_version;
+	uint32_t		sp_iv_update_version;
 	/* Special pool/container handle uuid, which are
 	 * created on the pool leader step up, and propagated
 	 * to all servers by IV. Then they will be used by server

--- a/src/pool/srv_iv.c
+++ b/src/pool/srv_iv.c
@@ -1054,9 +1054,15 @@ ds_pool_iv_map_update(struct ds_pool *pool, struct pool_buf *buf,
 	rc = pool_iv_update(pool->sp_iv_ns, IV_POOL_MAP, pool->sp_uuid,
 			    iv_entry, iv_entry_size, CRT_IV_SHORTCUT_NONE,
 			    CRT_IV_SYNC_EAGER, false);
-	if (rc != 0)
+	ABT_rwlock_wrlock(pool->sp_lock);
+	if (rc != 0) {
 		D_DEBUG(DB_MD, DF_UUID": map_ver=%u: %d\n",
 			DP_UUID(pool->sp_uuid), map_ver, rc);
+		pool->sp_iv_update_version = 0;
+	} else {
+		pool->sp_iv_update_version = buf == NULL ? 0 : pool->sp_map_version;
+	}
+	ABT_rwlock_unlock(pool->sp_lock);
 
 	D_DEBUG(DB_MD, DF_UUID": map_ver=%u: %d\n", DP_UUID(pool->sp_uuid),
 		map_ver, rc);


### PR DESCRIPTION
When rebuild leader finds current rebuild finished, it will refresh the
pool locally and broadcast the refreshed pool map to the other servers.
Such broadcast is handled via IV_UPDATE asynchronously. Then the rebuild
leader will notify the other servers that current rebuild completed via
another asynchronously IV UPDATE. These two asynchronously IV UPDATE are
processed in parallel. For some non-leader server, it is possible that
the rebuild completion IV UPDATE RPC is received and handled firstly,
but at that time, because the pool map on such server is not refreshed
yet, then it will report -DER_GRPVER that will cause the rebuild leader
to retry the IV UPDATE for rebuild completion.

To avoid above trouble, we will consider to serialize the two IV UPDATE,
that will make IV UPDATE for rebuild completion to be blocked until the
pool refresh IV UPDATE sent out.

Signed-off-by: Fan Yong <fan.yong@intel.com>