### PR TITLE
DAOS-9067 dtx: avoid block during DTX commit

### DIFF
--- a/src/dtx/dtx_common.c
+++ b/src/dtx/dtx_common.c
@@ -1761,6 +1761,10 @@ dtx_leader_exec_ops_ult(void *arg)
 			sub->dss_result = rc;
 			break;
 		}
+
+		/* Yield to avoid holding CPU for too long time. */
+		if (i >= DTX_RPC_YIELD_THD)
+			ABT_thread_yield();
 	}
 
 	if (rc != 0) {

--- a/src/dtx/dtx_internal.h
+++ b/src/dtx/dtx_internal.h
@@ -92,6 +92,8 @@ extern uint32_t dtx_agg_thd_cnt_lo;
 #define DTX_AGG_THD_AGE_MIN	210
 #define DTX_AGG_THD_AGE_DEF	630
 
+#define DTX_RPC_YIELD_THD	64
+
 /* The time threshold for triggerring DTX aggregation. If the oldest
  * DTX in the DTX table exceeds such threshold, it will trigger DTX
  * aggregation locally.

--- a/src/dtx/dtx_rpc.c
+++ b/src/dtx/dtx_rpc.c
@@ -389,7 +389,9 @@ dtx_req_list_send(struct dtx_req_args *dra, crt_opcode_t opc, d_list_t *head,
 			}
 		}
 
-		i++;
+		/* Yield to avoid holding CPU for too long time. */
+		if (++i >= DTX_RPC_YIELD_THD)
+			ABT_thread_yield();
 	}
 
 	return 0;
@@ -504,13 +506,12 @@ dtx_classify_one(struct ds_pool *pool, daos_handle_t tree, d_list_t *head,
 		i = 1;
 	else
 		i = 0;
+
 	for (; i < mbs->dm_tgt_cnt && rc >= 0; i++) {
 		struct pool_target	*target;
 
-		ABT_rwlock_rdlock(pool->sp_lock);
 		rc = pool_map_find_target(pool->sp_map,
 					  mbs->dm_tgts[i].ddt_id, &target);
-		ABT_rwlock_unlock(pool->sp_lock);
 		if (rc != 1) {
 			D_WARN("Cannot find target %u at %d/%d, flags %x\n",
 			       mbs->dm_tgts[i].ddt_id, i, mbs->dm_tgt_cnt,
@@ -569,6 +570,7 @@ dtx_dti_classify(struct ds_pool *pool, daos_handle_t tree,
 	int	rc = 0;
 	int	i;
 
+	ABT_rwlock_rdlock(pool->sp_lock);
 	for (i = 0; i < count; i++) {
 		rc = dtx_classify_one(pool, tree, head, &length, dtes[i], count, my_rank, my_tgtid);
 		if (rc < 0)
@@ -577,6 +579,7 @@ dtx_dti_classify(struct ds_pool *pool, daos_handle_t tree,
 		if (dtis != NULL)
 			dtis[i] = dtes[i]->dte_xid;
 	}
+	ABT_rwlock_unlock(pool->sp_lock);
 
 	return rc < 0 ? rc : length;
 }
@@ -797,8 +800,10 @@ dtx_abort(struct ds_cont_child *cont, struct dtx_entry *dte, daos_epoch_t epoch)
 
 	D_INIT_LIST_HEAD(&head);
 	crt_group_rank(NULL, &my_rank);
+	ABT_rwlock_rdlock(pool->sp_lock);
 	rc = dtx_classify_one(pool, DAOS_HDL_INVAL, &head, &length, dte, 1, my_rank,
 			      dss_get_module_info()->dmi_tgt_id);
+	ABT_rwlock_unlock(pool->sp_lock);
 	if (rc < 0)
 		goto out;
 
@@ -859,8 +864,10 @@ dtx_check(struct ds_cont_child *cont, struct dtx_entry *dte, daos_epoch_t epoch)
 
 	D_INIT_LIST_HEAD(&head);
 	crt_group_rank(NULL, &my_rank);
+	ABT_rwlock_rdlock(pool->sp_lock);
 	rc = dtx_classify_one(pool, DAOS_HDL_INVAL, &head, &length, dte, 1, my_rank,
 			      dss_get_module_info()->dmi_tgt_id);
+	ABT_rwlock_unlock(pool->sp_lock);
 	if (rc < 0)
 		goto out;
 


### PR DESCRIPTION
master-commit: 1ef2ac6da2d4ef356f4cb287b7933c3bb2409e02

Two main optimizations:

1. Yield CPU during sending DTX RPCs and IO forward RPCs if the
   targets list exceeds the DTX_RPC_YIELD_THD (64).

2. Take ds_pool::sp_lock out side of dtx_classify_one() to avoid
   frequently lock/unlock against the shared pool.

Signed-off-by: Fan Yong <fan.yong@intel.com>