### PR TITLE
DAOS-9125-test2.0: Cherrypick rel_2.0 update test for the recent DAOS object enumeration class changed

### DIFF
--- a/src/tests/ftest/control/daos_object_query.py
+++ b/src/tests/ftest/control/daos_object_query.py
@@ -67,10 +67,10 @@ class DaosObjectQuery(TestWithServers):
         # This mapping could change, so check daos_obj_class.h when this test
         # fails.
         class_name_to_code = {
-            "S1": 200,
-            "RP_2G1": 240,
-            "RP_2G2": 241,
-            "RP_3G1": 280
+            "S1": 16777217,
+            "RP_2G1": 134217729,
+            "RP_2G2": 134217730,
+            "RP_3G1": 150994945
         }
         class_name_to_group_num = {
             "S1": 1,


### PR DESCRIPTION

Description: Update DAOS object enumeration class with recent changed per discussion with Mohamad and ShiLong.
modified: control/daos_object_query.py
Skip-unit-tests: true
Test-tag: daos_object_query
Signed-off-by: Ding Ho ding-hwa.ho@intel.com