### PR TITLE
DAOS-9172 Test: Remove daos_server prepare storage command from Avcoado setup.

### DIFF
--- a/src/tests/ftest/util/server_utils.py
+++ b/src/tests/ftest/util/server_utils.py
@@ -205,15 +205,6 @@ class DaosServerManager(SubprocessManager):
         # Clean up any files that exist on the hosts
         self.clean_files()
 
-        if storage:
-            # Prepare server storage
-            if self.manager.job.using_nvme or self.manager.job.using_dcpm:
-                self.log.info("Preparing storage in <format> mode")
-                self.prepare_storage("root")
-                if hasattr(self.manager, "mca"):
-                    self.manager.mca.update(
-                        {"plm_rsh_args": "-l root"}, "orterun.mca", True)
-
         # Verify the socket directory exists when using a non-systemctl manager
         self.verify_socket_directory(getuser())
 


### PR DESCRIPTION
No need to call storage prepare as it's being done internally when daos_server starts.

Test-tag: pr daily_regression

Signed-off-by: Samir Raval <samir.raval@intel.com>