### PR TITLE
DAOS-8433 dtx: allocate DTX handle dynamically

### DIFF
--- a/src/dtx/dtx_common.c
+++ b/src/dtx/dtx_common.c
@@ -1044,7 +1044,7 @@ out:
  * \param tgt_cnt	[IN]	number of targets.
  * \param flags		[IN]	See dtx_flags.
  * \param mbs		[IN]	DTX participants information.
- * \param dth		[OUT]	Pointer to the DTX handle.
+ * \param p_dlh		[OUT]	Pointer to the DTX handle.
  *
  * \return			Zero on success, negative value if error.
  */
@@ -1054,25 +1054,26 @@ dtx_leader_begin(daos_handle_t coh, struct dtx_id *dti,
 		 uint32_t pm_ver, daos_unit_oid_t *leader_oid,
 		 struct dtx_id *dti_cos, int dti_cos_cnt,
 		 struct daos_shard_tgt *tgts, int tgt_cnt, uint32_t flags,
-		 struct dtx_memberships *mbs, struct dtx_leader_handle *dlh)
+		 struct dtx_memberships *mbs, struct dtx_leader_handle **p_dlh)
 {
-	struct dtx_handle	*dth = &dlh->dlh_handle;
-	int			 rc;
-	int			 i;
+	struct dtx_leader_handle	*dlh;
+	struct dtx_handle		*dth;
+	int				 rc;
+	int				 i;
 
-	memset(dlh, 0, sizeof(*dlh));
+	D_ALLOC(dlh, sizeof(*dlh) + sizeof(struct dtx_sub_status) * tgt_cnt);
+	if (dlh == NULL)
+		return -DER_NOMEM;
 
 	if (tgt_cnt > 0) {
 		dlh->dlh_future = ABT_FUTURE_NULL;
-		D_ALLOC_ARRAY(dlh->dlh_subs, tgt_cnt);
-		if (dlh->dlh_subs == NULL)
-			return -DER_NOMEM;
-
+		dlh->dlh_subs = (struct dtx_sub_status *)(dlh + 1);
 		for (i = 0; i < tgt_cnt; i++)
 			dlh->dlh_subs[i].dss_tgt = tgts[i];
 		dlh->dlh_sub_cnt = tgt_cnt;
 	}
 
+	dth = &dlh->dlh_handle;
 	rc = dtx_handle_init(dti, coh, epoch, sub_modification_cnt, pm_ver,
 			     leader_oid, dti_cos, dti_cos_cnt, mbs, true,
 			     (flags & DTX_SOLO) ? true : false,
@@ -1088,7 +1089,9 @@ dtx_leader_begin(daos_handle_t coh, struct dtx_id *dti,
 		DP_UOID(*leader_oid), dti_cos_cnt, flags, DP_RC(rc));
 
 	if (rc != 0)
-		D_FREE(dlh->dlh_subs);
+		D_FREE(dlh);
+	else
+		*p_dlh = dlh;
 
 	return rc;
 }
@@ -1347,8 +1350,8 @@ out:
 				    &dth->dth_leader_oid, dth->dth_dkey_hash);
 	}
 
-	D_FREE(dlh->dlh_subs);
 	D_FREE(dth->dth_oid_array);
+	D_FREE(dlh);
 
 	return result;
 }
@@ -1367,7 +1370,7 @@ out:
  * \param dti_cos_cnt	[IN]	The @dti_cos array size.
  * \param flags		[IN]	See dtx_flags.
  * \param mbs		[IN]	DTX participants information.
- * \param dth		[OUT]	Pointer to the DTX handle.
+ * \param p_dth		[OUT]	Pointer to the DTX handle.
  *
  * \return			Zero on success, negative value if error.
  */
@@ -1376,9 +1379,14 @@ dtx_begin(daos_handle_t coh, struct dtx_id *dti,
 	  struct dtx_epoch *epoch, uint16_t sub_modification_cnt,
 	  uint32_t pm_ver, daos_unit_oid_t *leader_oid,
 	  struct dtx_id *dti_cos, int dti_cos_cnt, uint32_t flags,
-	  struct dtx_memberships *mbs, struct dtx_handle *dth)
+	  struct dtx_memberships *mbs, struct dtx_handle **p_dth)
 {
-	int	rc;
+	struct dtx_handle	*dth;
+	int			 rc;
+
+	D_ALLOC(dth, sizeof(*dth));
+	if (dth == NULL)
+		return -DER_NOMEM;
 
 	rc = dtx_handle_init(dti, coh, epoch, sub_modification_cnt,
 			     pm_ver, leader_oid, dti_cos, dti_cos_cnt, mbs,
@@ -1393,6 +1401,11 @@ dtx_begin(daos_handle_t coh, struct dtx_id *dti,
 		DP_DTI(dti), sub_modification_cnt,
 		dth->dth_ver, dti_cos_cnt, flags, DP_RC(rc));
 
+	if (rc != 0)
+		D_FREE(dth);
+	else
+		*p_dth = dth;
+
 	return rc;
 }
 
@@ -1404,7 +1417,7 @@ dtx_end(struct dtx_handle *dth, struct ds_cont_child *cont, int result)
 	dtx_shares_fini(dth);
 
 	if (daos_is_zero_dti(&dth->dth_xid))
-		return result;
+		goto out;
 
 	if (result < 0) {
 		if (dth->dth_dti_cos_count > 0 && !dth->dth_cos_done) {
@@ -1441,9 +1454,11 @@ dtx_end(struct dtx_handle *dth, struct ds_cont_child *cont, int result)
 
 	D_ASSERTF(result <= 0, "unexpected return value %d\n", result);
 
-	D_FREE(dth->dth_oid_array);
-
 	vos_dtx_rsrvd_fini(dth);
+
+out:
+	D_FREE(dth->dth_oid_array);
+	D_FREE(dth);
 
 	return result;
 }

--- a/src/include/daos_srv/dtx_srv.h
+++ b/src/include/daos_srv/dtx_srv.h
@@ -199,7 +199,7 @@ dtx_leader_begin(daos_handle_t coh, struct dtx_id *dti,
 		 uint32_t pm_ver, daos_unit_oid_t *leader_oid,
 		 struct dtx_id *dti_cos, int dti_cos_cnt,
 		 struct daos_shard_tgt *tgts, int tgt_cnt, uint32_t flags,
-		 struct dtx_memberships *mbs, struct dtx_leader_handle *dlh);
+		 struct dtx_memberships *mbs, struct dtx_leader_handle **p_dlh);
 int
 dtx_leader_end(struct dtx_leader_handle *dlh, struct ds_cont_child *cont,
 	       int result);
@@ -214,7 +214,7 @@ dtx_begin(daos_handle_t coh, struct dtx_id *dti,
 	  struct dtx_epoch *epoch, uint16_t sub_modification_cnt,
 	  uint32_t pm_ver, daos_unit_oid_t *leader_oid,
 	  struct dtx_id *dti_cos, int dti_cos_cnt, uint32_t flags,
-	  struct dtx_memberships *mbs, struct dtx_handle *dth);
+	  struct dtx_memberships *mbs, struct dtx_handle **p_dth);
 int
 dtx_end(struct dtx_handle *dth, struct ds_cont_child *cont, int result);
 int

--- a/src/object/srv_ec_aggregate.c
+++ b/src/object/srv_ec_aggregate.c
@@ -2478,9 +2478,9 @@ cont_ec_aggregate_cb(struct ds_cont_child *cont, daos_epoch_range_t *epr,
 		     bool full_scan, struct agg_param *agg_param, uint64_t *msec)
 {
 	struct ec_agg_param	 *ec_agg_param = agg_param->ap_data;
+	struct dtx_handle	 *dth = NULL;
 	vos_iter_param_t	 iter_param = { 0 };
 	struct vos_iter_anchors  anchors = { 0 };
-	struct dtx_handle	 dth = { 0 };
 	struct dtx_id		 dti = { 0 };
 	struct dtx_epoch	 epoch = { 0 };
 	daos_unit_oid_t		 oid = { 0 };
@@ -2518,15 +2518,14 @@ cont_ec_aggregate_cb(struct ds_cont_child *cont, daos_epoch_range_t *epr,
 		return rc;
 	}
 
-	ec_agg_param->ap_dth = &dth;
+	ec_agg_param->ap_dth = dth;
 	ec_agg_param->ap_obj_skipped = 0;
 
 again:
 	rc = vos_iterate(&iter_param, VOS_ITER_OBJ, true, &anchors,
-			 agg_iterate_pre_cb, agg_iterate_post_cb,
-			 ec_agg_param, &dth);
-	if (obj_dtx_need_refresh(&dth, rc)) {
-		rc = dtx_refresh(&dth, cont);
+			 agg_iterate_pre_cb, agg_iterate_post_cb, ec_agg_param, dth);
+	if (obj_dtx_need_refresh(dth, rc)) {
+		rc = dtx_refresh(dth, cont);
 		if (rc == -DER_AGAIN) {
 			anchors.ia_reprobe_co = 0;
 			anchors.ia_reprobe_obj = 0;
@@ -2538,7 +2537,7 @@ again:
 		}
 	}
 
-	dtx_end(&dth, cont, rc);
+	dtx_end(dth, cont, rc);
 
 	if (daos_handle_is_valid(ec_agg_param->ap_agg_entry.ae_obj_hdl)) {
 		dsc_obj_close(ec_agg_param->ap_agg_entry.ae_obj_hdl);

--- a/src/rebuild/scan.c
+++ b/src/rebuild/scan.c
@@ -664,10 +664,10 @@ rebuild_container_scan_cb(daos_handle_t ih, vos_iter_entry_t *entry,
 {
 	struct rebuild_scan_arg		*arg = data;
 	struct rebuild_tgt_pool_tracker *rpt = arg->rpt;
+	struct dtx_handle		*dth = NULL;
 	vos_iter_param_t		param = { 0 };
 	struct vos_iter_anchors		anchor = { 0 };
 	daos_handle_t			coh;
-	struct dtx_handle		dth = { 0 };
 	struct dtx_id			dti = { 0 };
 	struct dtx_epoch		epoch = { 0 };
 	daos_unit_oid_t			oid = { 0 };
@@ -713,8 +713,8 @@ rebuild_container_scan_cb(daos_handle_t ih, vos_iter_entry_t *entry,
 		param.ip_flags |= VOS_IT_PUNCHED;
 
 	rc = vos_iterate(&param, VOS_ITER_OBJ, false, &anchor,
-			 rebuild_obj_scan_cb, NULL, arg, &dth);
-	dtx_end(&dth, NULL, rc);
+			 rebuild_obj_scan_cb, NULL, arg, dth);
+	dtx_end(dth, NULL, rc);
 	vos_cont_close(coh);
 
 	*acts |= VOS_ITER_CB_YIELD;


### PR DESCRIPTION
master-commit: 5b42f33c0227d3b5aecf54a42ed55737221f6259

Current, the size for dtx_leader_handle is more than 300 bytes, that
is some large for being as static variable on ULT stack, and may be
one of the important factors of ULT stack overflow. In the patch, we
dynamically allocate the DTX handle via dtx_leader_begin(), and free
it via dtx_leader_end(). Similar for dtx_begin() and dtx_end().

Signed-off-by: Fan Yong <fan.yong@intel.com>