### PR TITLE
DAOS-9108 pool: diagnostic run of create_performance

### DIFF
--- a/src/tests/ftest/pool/create_capacity.yaml
+++ b/src/tests/ftest/pool/create_capacity.yaml
@@ -21,6 +21,10 @@ server_config:
       scm_class: dcpm
       scm_list: ["/dev/pmem0"]
       scm_mount: /mnt/daos0
+      log_mask: DEBUG
+      env_vars:
+        - DD_MASK=mgmt,md,dsms,any
+        - D_LOG_FLUSH=DEBUG
 pool:
   name: daos_server
   control_method: dmg


### PR DESCRIPTION
Quick-Functional: true
Skip-coverity-test: true
Skip-func-test-vm: true
Skip-func-hw-test-small: true
Skip-func-hw-test-medium: true
Skip-func-hw-test-large: false
Skip-scan-centos-rpms: true
Skip-scan-leap15-rpms: true
Skip-test-centos-rpms: true
Skip-test-centos-8.3-rpms: true
Skip-test-leap-15-rpms: true
Allow-unstable-test: true
Skip-PR-comments: true

Test-tag: create_performance
Test-repeat: 10

Signed-off-by: Kenneth Cain <kenneth.c.cain@intel.com>