### PR TITLE
DAOS-8655 tests: Fix orterun tmpdir 'No such file or directory'

### DIFF
--- a/src/tests/ftest/server/metadata.py
+++ b/src/tests/ftest/server/metadata.py
@@ -335,10 +335,6 @@ class ObjectMetadata(TestWithServers):
         # Setup the thread manager
         thread_manager = ThreadManager(run_ior_loop, self.timeout - 30)
 
-        # Setup the orterun command used to run the ior command
-        self.job_manager.assign_hosts(self.hostlist_clients, self.workdir, None)
-        self.job_manager.assign_processes(processes)
-
         # Launch threads to run IOR to write data, restart the agents and
         # servers, and then run IOR to read the data
         for operation in ("write", "read"):

--- a/src/tests/ftest/server/metadata.py
+++ b/src/tests/ftest/server/metadata.py
@@ -361,7 +361,7 @@ class ObjectMetadata(TestWithServers):
                     index, list_of_uuid_lists[index])
 
             # Launch the IOR threads
-            self.log.info("Launching %d IOR %s threads", len(threads), operation)
+            self.log.info("Launching %d IOR %s threads", thread_manager.qty, operation)
             results = thread_manager.run()
             if len(results["FAIL"]) > 0:
                 self.d_log.error("IOR {} Thread FAIL".format(operation))

--- a/src/tests/ftest/server/metadata.py
+++ b/src/tests/ftest/server/metadata.py
@@ -414,6 +414,9 @@ class ObjectMetadata(TestWithServers):
                 # Start the servers
                 self.start_server_managers()
 
+                # Since starting the servers will format the storage the pool will be gone
+                self.pool = None
+
         self.log.info("Test passed")
 
     def test_container_removal_after_der_nospace(self):

--- a/src/tests/ftest/server/metadata.py
+++ b/src/tests/ftest/server/metadata.py
@@ -22,17 +22,23 @@ def run_ior_loop(manager, uuids):
     Args:
         manager (str): mpi job manager command
         uuids (list): list of container UUIDs
+
+    Returns:
+        list: a list of CmdResults from each ior command run
+
     """
+    results = []
     errors = []
     for index, cont_uuid in enumerate(uuids):
         manager.job.dfs_cont.update(cont_uuid, "ior.cont_uuid")
         try:
-            manager.run()
+            results.append(manager.run())
         except CommandFailure as error:
             errors.append("IOR Loop {}/{} failed: {}".format(index, len(uuids), error))
     if errors:
         raise CommandFailure(
             "IOR failed in {}/{} loops: {}".format(len(errors), len(uuids), "\n".join(errors)))
+    return results
 
 
 class ObjectMetadata(TestWithServers):

--- a/src/tests/ftest/server/metadata.py
+++ b/src/tests/ftest/server/metadata.py
@@ -362,21 +362,7 @@ class ObjectMetadata(TestWithServers):
 
             # Launch the IOR threads
             self.log.info("Launching %d IOR %s threads", thread_manager.qty, operation)
-            results = thread_manager.run()
-            for key in sorted(results):
-                self.log.info("IOR results from threads that %sED", key)
-                for entry in results[key]:
-                    self.log.info(" command: %s", entry.command)
-                    self.log.info(
-                        " exit_status: %s, duration: %s, interrupted: %s",
-                        entry.exit_status, entry.duration, str(entry.interrupted))
-                    self.log.info(" stdout:")
-                    for line in entry.stdout_text.splitlines():
-                        self.log.info("    %s", line)
-                    self.log.info(" stderr:")
-                    for line in entry.stderr_text.splitlines():
-                        self.log.info("    %s", line)
-            if len(results["FAIL"]) > 0:
+            if thread_manager.check_run():
                 self.d_log.error("IOR {} Thread FAIL".format(operation))
                 self.fail("IOR {} Thread FAIL".format(operation))
 

--- a/src/tests/ftest/server/metadata.py
+++ b/src/tests/ftest/server/metadata.py
@@ -402,20 +402,14 @@ class ObjectMetadata(TestWithServers):
                     len(errors), 0,
                     "Error stopping agents:\n  {}".format("\n  ".join(errors)))
 
-                # Stop the servers
-                errors = self.stop_servers()
+                # Restart the servers w/o formatting the storage
+                errors = self.restart_servers()
                 self.assertEqual(
                     len(errors), 0,
                     "Error stopping servers:\n  {}".format("\n  ".join(errors)))
 
                 # Start the agents
                 self.start_agent_managers()
-
-                # Start the servers
-                self.start_server_managers()
-
-                # Since starting the servers will format the storage the pool will be gone
-                self.pool = None
 
         self.log.info("Test passed")
 

--- a/src/tests/ftest/server/metadata.py
+++ b/src/tests/ftest/server/metadata.py
@@ -332,7 +332,7 @@ class ObjectMetadata(TestWithServers):
             for _ in range(total_ior_threads)]
 
         # Setup the thread manager
-        thread_manager = ThreadManager(self.run_ior_loop, self.timeout - 30)
+        thread_manager = ThreadManager(run_ior_loop, self.timeout - 30)
 
         # Setup the orterun command used to run the ior command
         self.job_manager.assign_hosts(self.hostlist_clients, self.workdir, None)

--- a/src/tests/ftest/server/metadata.py
+++ b/src/tests/ftest/server/metadata.py
@@ -14,7 +14,6 @@ from avocado.core.exceptions import TestFail
 from apricot import TestWithServers
 from ior_utils import IorCommand
 from command_utils_base import CommandFailure
-from job_manager_utils import Orterun
 
 
 def ior_runner_thread(manager, uuids, results):
@@ -366,6 +365,10 @@ class ObjectMetadata(TestWithServers):
             [str(uuid.uuid4()) for _ in range(files_per_thread)]
             for _ in range(total_ior_threads)]
 
+        # Setup the orterun command used to run the ior command
+        self.job_manager.assign_hosts(self.hostlist_clients, self.workdir, None)
+        self.job_manager.assign_processes(processes)
+
         # Launch threads to run IOR to write data, restart the agents and
         # servers, and then run IOR to read the data
         for operation in ("write", "read"):
@@ -379,20 +382,16 @@ class ObjectMetadata(TestWithServers):
                 ior_cmd.flags.value = self.params.get(
                     "F", "/run/ior/ior{}flags/".format(operation))
 
-                # Define the job manager for the IOR command
-                manager = Orterun(ior_cmd)
-                env = ior_cmd.get_default_env(str(manager))
-                manager.assign_hosts(self.hostlist_clients, self.workdir, None)
-                manager.assign_processes(processes)
-                manager.assign_environment(env)
-                manager.tmpdir.update(self.test_dir, "tmpdir")
+                # Update the environment variables for the IOR command's job manager
+                env = ior_cmd.get_default_env(str(self.job_manager))
+                self.job_manager.assign_environment(env)
 
                 # Add a thread for these IOR arguments
                 threads.append(
                     threading.Thread(
                         target=ior_runner_thread,
                         kwargs={
-                            "manager": manager,
+                            "manager": self.job_manager,
                             "uuids": list_of_uuid_lists[index],
                             "results": self.out_queue}))
 

--- a/src/tests/ftest/server/metadata.py
+++ b/src/tests/ftest/server/metadata.py
@@ -363,6 +363,19 @@ class ObjectMetadata(TestWithServers):
             # Launch the IOR threads
             self.log.info("Launching %d IOR %s threads", thread_manager.qty, operation)
             results = thread_manager.run()
+            for key in sorted(results):
+                self.log.info("IOR results from threads that %sED", key)
+                for entry in results[key]:
+                    self.log.info(" command: %s", entry.command)
+                    self.log.info(
+                        " exit_status: %s, duration: %s, interrupted: %s",
+                        entry.exit_status, entry.duration, str(entry.interrupted))
+                    self.log.info(" stdout:")
+                    for line in entry.stdout_text.splitlines():
+                        self.log.info("    %s", line)
+                    self.log.info(" stderr:")
+                    for line in entry.stderr_text.splitlines():
+                        self.log.info("    %s", line)
             if len(results["FAIL"]) > 0:
                 self.d_log.error("IOR {} Thread FAIL".format(operation))
                 self.fail("IOR {} Thread FAIL".format(operation))

--- a/src/tests/ftest/server/metadata.py
+++ b/src/tests/ftest/server/metadata.py
@@ -374,6 +374,7 @@ class ObjectMetadata(TestWithServers):
                 self.ior_managers[-1].assign_hosts(self.hostlist_clients, self.workdir, None)
                 self.ior_managers[-1].assign_processes(processes)
                 self.ior_managers[-1].assign_environment(env)
+                self.ior_managers[-1].verbose = False
 
                 # Add a thread for these IOR arguments
                 thread_manager.add(manager=self.ior_managers[-1], uuids=list_of_uuid_lists[index])

--- a/src/tests/ftest/server/metadata.py
+++ b/src/tests/ftest/server/metadata.py
@@ -385,6 +385,7 @@ class ObjectMetadata(TestWithServers):
                 manager.assign_hosts(self.hostlist_clients, self.workdir, None)
                 manager.assign_processes(processes)
                 manager.assign_environment(env)
+                manager.tmpdir.update(self.test_dir, "tmpdir")
 
                 # Add a thread for these IOR arguments
                 threads.append(

--- a/src/tests/ftest/server/metadata.yaml
+++ b/src/tests/ftest/server/metadata.yaml
@@ -50,6 +50,7 @@ server_config:
       env_vars:
         - DAOS_MD_CAP=128
         - DD_MASK=mgmt,md,dsms,any
+job_manager_class_name: Orterun
 pool:
   name: daos_server
   svcn: 3

--- a/src/tests/ftest/server/metadata.yaml
+++ b/src/tests/ftest/server/metadata.yaml
@@ -50,7 +50,6 @@ server_config:
       env_vars:
         - DAOS_MD_CAP=128
         - DD_MASK=mgmt,md,dsms,any
-job_manager_class_name: Orterun
 pool:
   name: daos_server
   svcn: 3

--- a/src/tests/ftest/util/apricot/apricot/test.py
+++ b/src/tests/ftest/util/apricot/apricot/test.py
@@ -717,7 +717,7 @@ class TestWithServers(TestWithoutServers):
             self.job_manager = get_job_manager_class(
                 manager_class_name, None, manager_subprocess, manager_mpi_type)
             self.set_job_manager_timeout()
-            self.job_manager.tmpdir.update(self.test_dir, "tmpdir")
+            self.job_manager.tmpdir_base.update(self.test_dir, "tmpdir_base")
 
         # Mark the end of setup
         self.log.info("=" * 100)

--- a/src/tests/ftest/util/apricot/apricot/test.py
+++ b/src/tests/ftest/util/apricot/apricot/test.py
@@ -717,6 +717,7 @@ class TestWithServers(TestWithoutServers):
             self.job_manager = get_job_manager_class(
                 manager_class_name, None, manager_subprocess, manager_mpi_type)
             self.set_job_manager_timeout()
+            self.job_manager.tmpdir.update(self.test_dir, "tmpdir")
 
         # Mark the end of setup
         self.log.info("=" * 100)

--- a/src/tests/ftest/util/job_manager_utils.py
+++ b/src/tests/ftest/util/job_manager_utils.py
@@ -236,6 +236,7 @@ class Orterun(JobManager):
         self.tag_output = FormattedParameter("--tag-output", True)
         self.ompi_server = FormattedParameter("--ompi-server {}", None)
         self.working_dir = FormattedParameter("-wdir {}", None)
+        self.tmpdir = FormattedParameter("--tmpdir {}", None)
 
     def assign_hosts(self, hosts, path=None, slots=None):
         """Assign the hosts to use with the command (--hostfile).

--- a/src/tests/ftest/util/job_manager_utils.py
+++ b/src/tests/ftest/util/job_manager_utils.py
@@ -236,7 +236,7 @@ class Orterun(JobManager):
         self.tag_output = FormattedParameter("--tag-output", True)
         self.ompi_server = FormattedParameter("--ompi-server {}", None)
         self.working_dir = FormattedParameter("-wdir {}", None)
-        self.tmpdir = FormattedParameter("--tmpdir {}", None)
+        self.tmpdir_base = FormattedParameter("--mca orte_tmpdir_base {}", None)
 
     def assign_hosts(self, hosts, path=None, slots=None):
         """Assign the hosts to use with the command (--hostfile).
@@ -341,6 +341,7 @@ class Mpirun(JobManager):
         self.envlist = FormattedParameter("-envlist {}", None)
         self.mca = FormattedParameter("--mca {}", mca_default)
         self.working_dir = FormattedParameter("-wdir {}", None)
+        self.tmpdir_base = FormattedParameter("--mca orte_tmpdir_base {}", None)
         self.mpitype = mpitype
 
     def assign_hosts(self, hosts, path=None, slots=None):

--- a/src/tests/ftest/util/job_manager_utils.py
+++ b/src/tests/ftest/util/job_manager_utils.py
@@ -184,6 +184,16 @@ class JobManager(ExecutableCommand):
         # processes running by returning a "R" state.
         return "R" if 1 not in results or len(results) > 1 else None
 
+    def stop(self):
+        """Stop the subprocess command and kill any job processes running on hosts.
+
+        Raises:
+            CommandFailure: if unable to stop
+
+        """
+        super().stop()
+        self.kill()
+
     def kill(self):
         """Forcibly terminate any job processes running on hosts."""
         regex = self.job.command_regex

--- a/src/tests/ftest/util/thread_manager.py
+++ b/src/tests/ftest/util/thread_manager.py
@@ -1,0 +1,48 @@
+#!/usr/bin/python3
+"""
+(C) Copyright 2021 Intel Corporation.
+
+SPDX-License-Identifier: BSD-2-Clause-Patent
+"""
+from concurrent.futures import ThreadPoolExecutor, as_completed, CancelledError, TimeoutError
+
+
+class ThreadManager():
+    """Class to manage running any method as multiple threads."""
+
+    def __init__(self, method, timeout=None):
+        """Initialize a ThreadManager object with the the method to run as a thread.
+
+        Args:
+            method (callable): [description]
+            timeout (int, optional): [description]. Defaults to None.
+        """
+        self.method = method
+        self.timeout = timeout
+        self.job_kwargs = []
+
+    def add(self, **kwargs):
+        """Add a thread to run by specifying the keyword arguments for the thread method."""
+        self.job_kwargs.append(kwargs)
+
+    def run(self):
+        """Asynchronously run the method as a thread for each set of method arguments.
+
+        Returns:
+            dict: a dictionary of lists of results returned by each thread under either a "PASS" or
+                "FAIL" key
+
+        """
+        results = {"PASS": [], "FAIL": []}
+        with ThreadPoolExecutor() as thread_executor:
+            futures = {thread_executor.submit(self.method, **kwargs) for kwargs in self.job_kwargs}
+            for future in as_completed(futures, self.timeout):
+                try:
+                    results["PASS"].append(future.result())
+                except CancelledError as error:
+                    results["FAIL"].append("{} was cancelled: {}".format(future, error))
+                except TimeoutError as error:
+                    results["FAIL"].append("{} timed out: {}".format(future, error))
+                except Exception as error:
+                    results["FAIL"].append("{} failed with an exception: {}".format(future, error))
+        return results

--- a/src/tests/ftest/util/thread_manager.py
+++ b/src/tests/ftest/util/thread_manager.py
@@ -21,6 +21,16 @@ class ThreadManager():
         self.timeout = timeout
         self.job_kwargs = []
 
+    @property
+    def qty(self):
+        """Get the number of threads.
+
+        Returns:
+            int: number of threads
+
+        """
+        return len(self.job_kwargs)
+
     def add(self, **kwargs):
         """Add a thread to run by specifying the keyword arguments for the thread method."""
         self.job_kwargs.append(kwargs)

--- a/src/tests/ftest/util/thread_manager.py
+++ b/src/tests/ftest/util/thread_manager.py
@@ -123,13 +123,13 @@ class ThreadManager():
         self.log.info("Results from threads that passed:")
         for result in results:
             if result.passed:
-                self.log.info(str(result.display))
+                self.log.info(str(result))
             else:
                 failed.append(result)
         if failed:
-            self.log.info("Results from threads that passed:")
+            self.log.info("Results from threads that failed:")
             for result in failed:
-                self.log.info(str(result.display))
+                self.log.info(str(result))
         return len(failed) > 0
 
     def check_run(self):

--- a/src/tests/ftest/util/thread_manager.py
+++ b/src/tests/ftest/util/thread_manager.py
@@ -7,7 +7,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 from concurrent.futures import ThreadPoolExecutor, as_completed, CancelledError, TimeoutError
 from logging import getLogger
 
-from avocado.utils import CmdResult
+from avocado.utils.process import CmdResult
 
 
 class ThreadManager():

--- a/utils/rpms/daos.spec
+++ b/utils/rpms/daos.spec
@@ -2,7 +2,7 @@
 %define server_svc_name daos_server.service
 %define agent_svc_name daos_agent.service
 
-%global mercury_version 2.0.1-1%{?dist}
+%global mercury_version 2.1.0~rc4-2%{?dist}
 %global libfabric_version 1.14.0~rc3-1
 %global __python %{__python3}
 


### PR DESCRIPTION
Use a test-specific temporary directory for temporary files generated
during the test and remove the files after test completion to free up
space for the next test.

Quick-functional: true
Test-tag: metadata_ior offline_extend_oclass
Test-repeat: 10

Signed-off-by: Phillip Henderson phillip.henderson@intel.com