### PR TITLE
DAOS-9181 EC: only select last parity shard as EC agg leader

### DIFF
--- a/src/object/srv_ec_aggregate.c
+++ b/src/object/srv_ec_aggregate.c
@@ -2176,12 +2176,11 @@ agg_obj_is_leader(struct ds_pool *pool, struct daos_oclass_attr *oca,
 	struct pl_map		*map;
 	struct pl_obj_layout	*layout = NULL;
 	struct pl_obj_shard	*shard;
-	uint32_t		 start;
+	uint32_t		 idx;
 	int			 rc;
-	int			 i;
 
-	/* Only parity shard can be EC-AGG leader. */
-	if (oid->id_shard % daos_oclass_grp_size(oca) < oca->u.ec.e_k)
+	/* Only last parity shard can be EC-AGG leader. */
+	if ((oid->id_shard % daos_oclass_grp_size(oca)) != (daos_oclass_grp_size(oca) - 1))
 		return 0;
 
 	map = pl_map_find(pool->sp_uuid, oid->id_pub);
@@ -2196,16 +2195,15 @@ agg_obj_is_leader(struct ds_pool *pool, struct daos_oclass_attr *oca,
 	if (rc != 0)
 		goto out;
 
-	start = oid->id_shard / daos_oclass_grp_size(oca) * layout->ol_grp_size;
-	for (i = start + oca->u.ec.e_k + oca->u.ec.e_p - 1; i >= start + oca->u.ec.e_k; i--) {
-		shard = pl_obj_get_shard(layout, i);
-		if (shard->po_target != -1 && shard->po_shard != -1 && !shard->po_rebuilding)
-			/* Select the last non-rebuilding parity shard as the EC-AGG leader. */
-			D_GOTO(out, rc = (oid->id_shard == shard->po_shard ? 1 : 0));
+	idx = (oid->id_shard / daos_oclass_grp_size(oca)) * layout->ol_grp_size +
+	      daos_oclass_grp_size(oca) - 1;
+	shard = pl_obj_get_shard(layout, idx);
+	if (shard->po_target != -1 && shard->po_shard != -1 && !shard->po_rebuilding) {
+		rc = (oid->id_shard == shard->po_shard) ? 1 : 0;
+	} else {
+		/* If last parity unavailable, then skip the object via returning -DER_STALE. */
+		rc = -DER_STALE;
 	}
-
-	/* If all parity shards are unavailable, then skip the object via returning -DER_STALE. */
-	rc = -DER_STALE;
 
 out:
 	if (layout != NULL)
@@ -2252,7 +2250,9 @@ agg_object(daos_handle_t ih, vos_iter_entry_t *entry,
 
 	rc = agg_obj_is_leader(info->api_pool, &oca, &entry->ie_oid,
 			       info->api_pool->sp_map_version);
-	if (rc == 1 && entry->ie_oid.id_shard >= oca.u.ec.e_k) {
+	if (rc == 1) {
+		D_ASSERT((entry->ie_oid.id_shard % obj_ec_tgt_nr(&oca)) ==
+			 obj_ec_tgt_nr(&oca) - 1);
 		D_DEBUG(DB_EPC, "oid:"DF_UOID" ec agg starting\n",
 			DP_UOID(entry->ie_oid));
 

--- a/src/tests/suite/daos_degrade_ec.c
+++ b/src/tests/suite/daos_degrade_ec.c
@@ -479,10 +479,10 @@ degrade_ec_partial_update_agg(void **state)
 			     data, EC_CELL_SIZE, &req);
 	}
 
-	/* Kill the last parity shard, which is the aggregate leader to verify
+	/* Kill one parity shard, which is the aggregate leader to verify
 	 * aggregate works in degraded mode.
 	 */
-	rank = get_rank_by_oid_shard(arg, oid, 5);
+	rank = get_rank_by_oid_shard(arg, oid, 4);
 	rebuild_pools_ranks(&arg, 1, &rank, 1, false);
 
 	/* Trigger aggregation */


### PR DESCRIPTION
To avoid both parity shards treat the other is leader when they with
different pm version.
For example, 4P2G1 EC obj, with shards 0~5,on server of shard 4 with
pool map ver 10 all are alive and it check shard 5 should be EC agg
leader so shard 4 will do nothing; at that time, on server of shard 5
with pool map ver 11, it checks itself failed or in-rebuilding, then it
think shard 4 should be the leader so shard 5 will do nothing.
Both servers will not prevent the EC agg epoch move ahead but actually
did not do EC agg work.

Signed-off-by: Xuezhao Liu <xuezhao.liu@intel.com>