### PR TITLE
DAOS-8981 dfuse: Allow setattr of uid/gid in dfuse if data is unchanged. (#7204)

### DIFF
--- a/src/client/dfuse/ops/setattr.c
+++ b/src/client/dfuse/ops/setattr.c
@@ -37,8 +37,16 @@ dfuse_cb_setattr(fuse_req_t req, struct dfuse_inode_entry *ie,
 	}
 
 	if (to_set & (FUSE_SET_ATTR_UID | FUSE_SET_ATTR_GID)) {
-		DFUSE_TRA_INFO(ie, "File uid/gid support not enabled");
-		D_GOTO(err, rc = ENOTSUP);
+		DFUSE_TRA_DEBUG(ie, "uid flags %#x uid %d gid %d",
+				(to_set & (FUSE_SET_ATTR_UID | FUSE_SET_ATTR_GID)),
+				attr->st_uid, attr->st_gid);
+
+		if (((to_set & FUSE_SET_ATTR_UID) && ie->ie_stat.st_uid != attr->st_uid) ||
+			((to_set & FUSE_SET_ATTR_GID) && ie->ie_stat.st_gid != attr->st_gid)) {
+			DFUSE_TRA_INFO(ie, "File uid/gid support not enabled");
+			D_GOTO(err, rc = ENOTSUP);
+		}
+		to_set &= ~(FUSE_SET_ATTR_UID | FUSE_SET_ATTR_GID);
 	}
 
 	if (to_set & FUSE_SET_ATTR_MODE) {
@@ -63,20 +71,13 @@ dfuse_cb_setattr(fuse_req_t req, struct dfuse_inode_entry *ie,
 		dfs_flags |= DFS_SET_ATTR_MTIME;
 	}
 
-	/* Only set this when caching is enabled as dfs doesn't fully support
-	 * ctime, but rather uses mtime instead.  In practice this is only
-	 * seen when using writeback cache.
+	/* Set this when requested, however dfs doesn't support ctime, only mtime.
 	 *
-	 * This is only seen of entries where caching is enabled, however
-	 * if a file is opened with caching then the operation might then
-	 * happen on the inode, not the file handle so simply check if
-	 * caching might be enabled for the container.
+	 * This is only seen on entries where caching is enabled, however it can happen
+	 * for either data or metadata caching, so just accept it always.
+	 * Update, it can happen with metadata caching, but not data caching.
 	 */
 	if (to_set & FUSE_SET_ATTR_CTIME) {
-		if (!ie->ie_dfs->dfc_data_caching) {
-			DFUSE_TRA_INFO(ie, "CTIME set without data caching");
-			D_GOTO(err, rc = ENOTSUP);
-		}
 		DFUSE_TRA_DEBUG(ie, "ctime %#lx", attr->st_ctime);
 		to_set &= ~FUSE_SET_ATTR_CTIME;
 		attr->st_mtime = attr->st_ctime;

--- a/utils/node_local_test.py
+++ b/utils/node_local_test.py
@@ -22,6 +22,7 @@ import json
 import copy
 import signal
 import stat
+import errno
 import argparse
 import tabulate
 import functools
@@ -1625,6 +1626,36 @@ class posix_tests():
         os.unlink(fname)
         print(os.fstat(ofd.fileno()))
         ofd.close()
+
+    @needs_dfuse
+    def test_chown_self(self):
+        """Test that a file can be chowned to the current user, but not to other users"""
+
+        fname = os.path.join(self.dfuse.dir, 'new_file')
+        with open(fname, 'w') as fd:
+            os.chown(fd.fileno(), os.getuid(), -1)
+            os.chown(fd.fileno(), -1, os.getgid())
+
+            # Chgrp to root, should fail but will likely be refused by the kernel.
+            try:
+                os.chown(fd.fileno(), -1, 1)
+                assert False
+            except PermissionError:
+                pass
+
+            # Chgrp to another group which this process is in, will work for the default group, but
+            # should fail for all others.
+            groups = os.getgroups()
+            print(groups)
+            for group in groups:
+                try:
+                    os.chown(fd.fileno(), -1, group)
+                    assert group == os.getgid()
+                except OSError as e:
+                    print(e)
+                    if e.errno != errno.ENOTSUP:
+                        raise
+                    assert group != os.getgid()
 
     @needs_dfuse
     def test_symlink_broken(self):


### PR DESCRIPTION
A lot of clients seem to do this, often with other metadata updates
in the same call, so if this happens allow the change, but do not
attempt to apply it.

Remove ctime setattr check, this often happens with any type of
caching enabled.

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>