### PR TITLE
DAOS-9072 test: move romio test to hw small  (#7401)

### DIFF
--- a/src/tests/ftest/mpiio/romio.py
+++ b/src/tests/ftest/mpiio/romio.py
@@ -20,7 +20,7 @@ class Romio(MpiioTests):
         Run Romio test provided in mpich package
         Testing various I/O functions provided in romio test suite
         :avocado: tags=all,pr,daily_regression
-        :avocado: tags=small
+        :avocado: tags=hw,small
         :avocado: tags=mpiio,mpich,romio
         """
         # setting romio parameters

--- a/src/tests/ftest/mpiio/romio.yaml
+++ b/src/tests/ftest/mpiio/romio.yaml
@@ -8,10 +8,16 @@ timeout: 150
 # romio test suite directory in CI nodes when available.
 server_config:
     name: daos_server
+    servers:
+        bdev_class: nvme
+        bdev_list: ["aaaa:aa:aa.a","bbbb:bb:bb.b"]
+        scm_class: dcpm
+        scm_list: ["/dev/pmem0"]
 pool:
     mode: 146
     name: daos_server
-    scm_size: 1000000000
+    scm_size: 30G
+    nvme_size: 40G
     svcn: 1
     control_method: dmg
 container:


### PR DESCRIPTION
it seems that some VMs are running slower on async collective tests
that can potentially create background threads and use collective
MPI functions.

Signed-off-by: Mohamad Chaarawi <mohamad.chaarawi@intel.com>