### PR TITLE
DAOS-9094 control: daos_server storage scan to show VMD backing devices (#7440)

### DIFF
--- a/src/control/cmd/daos_server/storage_test.go
+++ b/src/control/cmd/daos_server/storage_test.go
@@ -49,26 +49,28 @@ func TestDaosServer_StoragePrepare(t *testing.T) {
 	bdevResetCmd.Reset = true
 
 	for name, tc := range map[string]struct {
-		prepCmd       commands.StoragePrepareCmd
-		enableVmd     bool
-		bmbc          *bdev.MockBackendConfig
-		smbc          *scm.MockBackendConfig
-		expLogMsg     string
-		expErr        error
-		expPrepCalls  []storage.BdevPrepareRequest
-		expResetCalls []storage.BdevPrepareRequest
+		prepCmd      commands.StoragePrepareCmd
+		bmbc         *bdev.MockBackendConfig
+		smbc         *scm.MockBackendConfig
+		expLogMsg    string
+		expErr       error
+		expPrepCall  *storage.BdevPrepareRequest
+		expResetCall *storage.BdevPrepareRequest
 	}{
 		"default no devices; success": {
-			expPrepCalls: []storage.BdevPrepareRequest{
-				{TargetUser: username},
+			expPrepCall: &storage.BdevPrepareRequest{
+				TargetUser: username,
+				// always set in local storage prepare to allow automatic detection
+				EnableVMD: true,
 			},
 		},
 		"nvme-only no devices; success": {
 			prepCmd: commands.StoragePrepareCmd{
 				NvmeOnly: true,
 			},
-			expPrepCalls: []storage.BdevPrepareRequest{
-				{TargetUser: username},
+			expPrepCall: &storage.BdevPrepareRequest{
+				TargetUser: username,
+				EnableVMD:  true,
 			},
 		},
 		"scm-only no devices; success": {
@@ -161,14 +163,13 @@ func TestDaosServer_StoragePrepare(t *testing.T) {
 		},
 		"nvme prep succeeds; user params": {
 			prepCmd: bdevPrepCmd,
-			expPrepCalls: []storage.BdevPrepareRequest{
-				{
-					HugePageCount: testNrHugePages,
-					TargetUser:    username,
-					PCIAllowList: fmt.Sprintf("%s%s%s", common.MockPCIAddr(1),
-						storage.BdevPciAddrSep, common.MockPCIAddr(2)),
-					PCIBlockList: common.MockPCIAddr(1),
-				},
+			expPrepCall: &storage.BdevPrepareRequest{
+				HugePageCount: testNrHugePages,
+				TargetUser:    username,
+				PCIAllowList: fmt.Sprintf("%s%s%s", common.MockPCIAddr(1),
+					storage.BdevPciAddrSep, common.MockPCIAddr(2)),
+				PCIBlockList: common.MockPCIAddr(1),
+				EnableVMD:    true,
 			},
 		},
 		"nvme prep fails; user params": {
@@ -176,44 +177,26 @@ func TestDaosServer_StoragePrepare(t *testing.T) {
 			bmbc: &bdev.MockBackendConfig{
 				PrepareErr: errors.New("backed prep setup failed"),
 			},
-			expPrepCalls: []storage.BdevPrepareRequest{
-				{
-					HugePageCount: testNrHugePages,
-					TargetUser:    username,
-					PCIAllowList: fmt.Sprintf("%s%s%s", common.MockPCIAddr(1),
-						storage.BdevPciAddrSep, common.MockPCIAddr(2)),
-					PCIBlockList: common.MockPCIAddr(1),
-				},
+			expPrepCall: &storage.BdevPrepareRequest{
+				HugePageCount: testNrHugePages,
+				TargetUser:    username,
+				PCIAllowList: fmt.Sprintf("%s%s%s", common.MockPCIAddr(1),
+					storage.BdevPciAddrSep, common.MockPCIAddr(2)),
+				PCIBlockList: common.MockPCIAddr(1),
+				EnableVMD:    true,
 			},
 			expErr: errors.New("backed prep setup failed"),
 		},
-		"nvme prep succeeds; user params; vmd enabled": {
-			prepCmd:   bdevPrepCmd,
-			enableVmd: true,
-			expPrepCalls: []storage.BdevPrepareRequest{
-				// backend will call spdk script twice, first time for VMD and
-				// second time for non-VMD devices
-				{
-					EnableVMD:     true,
-					HugePageCount: testNrHugePages,
-					TargetUser:    username,
-					PCIAllowList: fmt.Sprintf("%s%s%s", common.MockPCIAddr(1),
-						storage.BdevPciAddrSep, common.MockPCIAddr(2)),
-					PCIBlockList: common.MockPCIAddr(1),
-				},
-			},
-		},
 		"nvme prep reset succeeds; user params": {
 			prepCmd: bdevResetCmd,
-			expResetCalls: []storage.BdevPrepareRequest{
-				{
-					Reset_:        true,
-					HugePageCount: testNrHugePages,
-					TargetUser:    username,
-					PCIAllowList: fmt.Sprintf("%s%s%s", common.MockPCIAddr(1),
-						storage.BdevPciAddrSep, common.MockPCIAddr(2)),
-					PCIBlockList: common.MockPCIAddr(1),
-				},
+			expResetCall: &storage.BdevPrepareRequest{
+				Reset_:        true,
+				HugePageCount: testNrHugePages,
+				TargetUser:    username,
+				PCIAllowList: fmt.Sprintf("%s%s%s", common.MockPCIAddr(1),
+					storage.BdevPciAddrSep, common.MockPCIAddr(2)),
+				PCIBlockList: common.MockPCIAddr(1),
+				EnableVMD:    true,
 			},
 		},
 		"nvme prep reset fails; user params": {
@@ -221,34 +204,16 @@ func TestDaosServer_StoragePrepare(t *testing.T) {
 			bmbc: &bdev.MockBackendConfig{
 				ResetErr: errors.New("backed prep reset failed"),
 			},
-			expResetCalls: []storage.BdevPrepareRequest{
-				{
-					Reset_:        true,
-					HugePageCount: testNrHugePages,
-					TargetUser:    username,
-					PCIAllowList: fmt.Sprintf("%s%s%s", common.MockPCIAddr(1),
-						storage.BdevPciAddrSep, common.MockPCIAddr(2)),
-					PCIBlockList: common.MockPCIAddr(1),
-				},
+			expResetCall: &storage.BdevPrepareRequest{
+				Reset_:        true,
+				HugePageCount: testNrHugePages,
+				TargetUser:    username,
+				PCIAllowList: fmt.Sprintf("%s%s%s", common.MockPCIAddr(1),
+					storage.BdevPciAddrSep, common.MockPCIAddr(2)),
+				PCIBlockList: common.MockPCIAddr(1),
+				EnableVMD:    true,
 			},
 			expErr: errors.New("backed prep reset failed"),
-		},
-		"nvme prep reset succeeds; user params; vmd enabled": {
-			prepCmd:   bdevResetCmd,
-			enableVmd: true,
-			expResetCalls: []storage.BdevPrepareRequest{
-				// backend will call spdk script twice, first time for VMD and
-				// second time for non-VMD devices
-				{
-					EnableVMD:     true,
-					Reset_:        true,
-					HugePageCount: testNrHugePages,
-					TargetUser:    username,
-					PCIAllowList: fmt.Sprintf("%s%s%s", common.MockPCIAddr(1),
-						storage.BdevPciAddrSep, common.MockPCIAddr(2)),
-					PCIBlockList: common.MockPCIAddr(1),
-				},
-			},
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
@@ -265,20 +230,37 @@ func TestDaosServer_StoragePrepare(t *testing.T) {
 				},
 				scs: server.NewMockStorageControlService(log, nil, nil,
 					scm.NewMockProvider(log, tc.smbc, nil), mbp),
-				EnableVMD: tc.enableVmd,
 			}
 
 			gotErr := cmd.Execute(nil)
 
 			mbb.RLock()
-			if diff := cmp.Diff(tc.expPrepCalls, mbb.PrepareCalls); diff != "" {
-				t.Fatalf("unexpected prepare calls (-want, +got):\n%s\n", diff)
+			if tc.expPrepCall == nil {
+				if len(mbb.PrepareCalls) != 0 {
+					t.Fatal("unexpected number of prepared calls")
+				}
+			} else {
+				if len(mbb.PrepareCalls) != 1 {
+					t.Fatal("unexpected number of prepared calls")
+				}
+				if diff := cmp.Diff(*tc.expPrepCall, mbb.PrepareCalls[0]); diff != "" {
+					t.Fatalf("unexpected prepare calls (-want, +got):\n%s\n", diff)
+				}
 			}
 			mbb.RUnlock()
 
 			mbb.RLock()
-			if diff := cmp.Diff(tc.expResetCalls, mbb.ResetCalls); diff != "" {
-				t.Fatalf("unexpected reset calls (-want, +got):\n%s\n", diff)
+			if tc.expResetCall == nil {
+				if len(mbb.ResetCalls) != 0 {
+					t.Fatal("unexpected number of prepared calls")
+				}
+			} else {
+				if len(mbb.ResetCalls) != 1 {
+					t.Fatal("unexpected number of prepared calls")
+				}
+				if diff := cmp.Diff(*tc.expResetCall, mbb.ResetCalls[0]); diff != "" {
+					t.Fatalf("unexpected prepare calls (-want, +got):\n%s\n", diff)
+				}
 			}
 			mbb.RUnlock()
 

--- a/src/control/common/pci_utils.go
+++ b/src/control/common/pci_utils.go
@@ -18,7 +18,7 @@ import (
 )
 
 const (
-	// bdevPciAddrSep defines the separator used between PCI addresses in string lists.
+	// bdevPciAddrSep defines the separator used between PCI addresses in string sets.
 	bdevPciAddrSep = " "
 	// vmdDomainLen defines the expected length of a VMD backing devices address domain.
 	vmdDomainLen = 6
@@ -147,12 +147,12 @@ func NewPCIAddress(addr string) (*PCIAddress, error) {
 	return pa, nil
 }
 
-// PCIAddressSet represents a unique list of PCI addresses.
+// PCIAddressSet represents a unique set of PCI addresses.
 type PCIAddressSet struct {
 	addrMap map[string]*PCIAddress
 }
 
-// Contains returns true if provided address is already in list.
+// Contains returns true if provided address is already in set.
 func (pas *PCIAddressSet) Contains(a *PCIAddress) bool {
 	if pas == nil {
 		return false
@@ -170,7 +170,7 @@ func (pas *PCIAddressSet) add(a *PCIAddress) {
 	pas.addrMap[a.String()] = a
 }
 
-// Add adds PCI addresses to slice. Ignores duplicate addresses.
+// Add adds PCI addresses to set. Ignores duplicate addresses.
 func (pas *PCIAddressSet) Add(addrs ...*PCIAddress) error {
 	if pas == nil {
 		return errors.New("PCIAddressSet is nil")
@@ -183,8 +183,8 @@ func (pas *PCIAddressSet) Add(addrs ...*PCIAddress) error {
 	return nil
 }
 
-// AddStrings adds PCI addresses to slice from supplied strings. If any input string is not a valid PCI
-// address then return error and don't add any elements to slice. Ignores duplicateaddresses.
+// AddStrings adds PCI addresses to set from supplied strings. If any input string is not a valid PCI
+// address then return error and don't add any elements to set.
 func (pas *PCIAddressSet) AddStrings(addrs ...string) error {
 	if pas == nil {
 		return errors.New("PCIAddressSet is nil")
@@ -240,7 +240,7 @@ func (pas *PCIAddressSet) String() string {
 	return strings.Join(pas.Strings(), bdevPciAddrSep)
 }
 
-// Len returns length of slice. Required by sort.Interface.
+// Len returns length of set. Required by sort.Interface.
 func (pas *PCIAddressSet) Len() int {
 	if pas == nil {
 		return 0
@@ -262,7 +262,7 @@ func hexStr2Int(s string) int64 {
 	return i
 }
 
-// Intersect returns elements in 'this' AND input address lists.
+// Intersect returns elements in 'this' AND input address sets.
 func (pas *PCIAddressSet) Intersect(in *PCIAddressSet) *PCIAddressSet {
 	intersection := &PCIAddressSet{}
 
@@ -286,7 +286,7 @@ func (pas *PCIAddressSet) Intersect(in *PCIAddressSet) *PCIAddressSet {
 	return intersection
 }
 
-// Difference returns elements in 'this' list but NOT IN input address list.
+// Difference returns elements in 'this' set but NOT IN input address set.
 func (pas *PCIAddressSet) Difference(in *PCIAddressSet) *PCIAddressSet {
 	difference := &PCIAddressSet{}
 

--- a/src/control/server/ctl_storage.go
+++ b/src/control/server/ctl_storage.go
@@ -26,6 +26,72 @@ type StorageControlService struct {
 	instanceStorage map[uint32]*storage.Config
 }
 
+// Setup performs storage discovery and validates existence of configured devices.
+func (scs *StorageControlService) Setup() {
+	if _, err := scs.ScmScan(storage.ScmScanRequest{}); err != nil {
+		scs.log.Debugf("%s\n", errors.Wrap(err, "Warning, SCM Scan"))
+	}
+
+	var cfgBdevs []string
+
+	for _, storageCfg := range scs.instanceStorage {
+		for _, tierCfg := range storageCfg.Tiers.BdevConfigs() {
+			if tierCfg.Class != storage.ClassNvme {
+				// don't scan if any tier is using emulated NVMe
+				return
+			}
+			cfgBdevs = append(cfgBdevs, tierCfg.Bdev.DeviceList...)
+		}
+	}
+
+	nvmeScanResp, err := scs.NvmeScan(storage.BdevScanRequest{
+		DeviceList: cfgBdevs,
+	})
+	if err != nil {
+		scs.log.Debugf("%s\n", errors.Wrap(err, "Warning, NVMe Scan"))
+		return
+	}
+
+	scs.storage.SetBdevCache(*nvmeScanResp)
+}
+
+// GetScmState performs required initialization and returns current state
+// of SCM module preparation.
+func (scs *StorageControlService) GetScmState() (storage.ScmState, error) {
+	return scs.storage.Scm.GetPmemState()
+}
+
+// ScmPrepare preps locally attached modules and returns need to reboot message,
+// list of pmem device files and error directly.
+//
+// Suitable for commands invoked directly on server, not over gRPC.
+func (scs *StorageControlService) ScmPrepare(req storage.ScmPrepareRequest) (*storage.ScmPrepareResponse, error) {
+	// transition to the next state in SCM preparation
+	return scs.storage.Scm.Prepare(req)
+}
+
+// ScmScan scans locally attached modules, namespaces and state of DCPM config.
+func (scs *StorageControlService) ScmScan(req storage.ScmScanRequest) (*storage.ScmScanResponse, error) {
+	return scs.storage.Scm.Scan(req)
+}
+
+// NvmePrepare preps locally attached SSDs and returns error.
+func (scs *StorageControlService) NvmePrepare(req storage.BdevPrepareRequest) (*storage.BdevPrepareResponse, error) {
+	scs.log.Debugf("calling bdev provider prepare: %+v", req)
+	return scs.storage.PrepareBdevs(req)
+}
+
+// NvmeScan scans locally attached SSDs.
+func (scs *StorageControlService) NvmeScan(req storage.BdevScanRequest) (*storage.BdevScanResponse, error) {
+	return scs.storage.ScanBdevs(req)
+}
+
+// WithVMDEnabled enables VMD support in storage provider.
+func (scs *StorageControlService) WithVMDEnabled() *StorageControlService {
+	scs.storage.WithVMDEnabled()
+	return scs
+}
+
 func newStorageControlService(l logging.Logger, ecs []*engine.Config, sp *storage.Provider) *StorageControlService {
 	instanceStorage := make(map[uint32]*storage.Config)
 	for i, c := range ecs {
@@ -58,35 +124,6 @@ func NewMockStorageControlService(log logging.Logger, engineCfgs []*engine.Confi
 	)
 }
 
-// Setup performs storage discovery and validates existence of configured devices.
-func (c *StorageControlService) Setup() {
-	if _, err := c.ScmScan(storage.ScmScanRequest{}); err != nil {
-		c.log.Debugf("%s\n", errors.Wrap(err, "Warning, SCM Scan"))
-	}
-
-	var cfgBdevs []string
-
-	for _, storageCfg := range c.instanceStorage {
-		for _, tierCfg := range storageCfg.Tiers.BdevConfigs() {
-			if tierCfg.Class != storage.ClassNvme {
-				// don't scan if any tier is using emulated NVMe
-				return
-			}
-			cfgBdevs = append(cfgBdevs, tierCfg.Bdev.DeviceList...)
-		}
-	}
-
-	nvmeScanResp, err := c.NvmeScan(storage.BdevScanRequest{
-		DeviceList: cfgBdevs,
-	})
-	if err != nil {
-		c.log.Debugf("%s\n", errors.Wrap(err, "Warning, NVMe Scan"))
-		return
-	}
-
-	c.storage.SetBdevCache(*nvmeScanResp)
-}
-
 func findPMemInScan(ssr *storage.ScmScanResponse, pmemDevs []string) *storage.ScmNamespace {
 	for _, scanned := range ssr.Namespaces {
 		for _, path := range pmemDevs {
@@ -107,12 +144,12 @@ func findPMemInScan(ssr *storage.ScmScanResponse, pmemDevs []string) *storage.Sc
 //
 // Usage is only retrieved for active mountpoints being used by online DAOS I/O
 // Server instances.
-func (c *ControlService) getScmUsage(ssr *storage.ScmScanResponse) (*storage.ScmScanResponse, error) {
+func (cs *ControlService) getScmUsage(ssr *storage.ScmScanResponse) (*storage.ScmScanResponse, error) {
 	if ssr == nil {
 		return nil, errors.New("input scm scan response is nil")
 	}
 
-	instances := c.harness.Instances()
+	instances := cs.harness.Instances()
 
 	nss := make(storage.ScmNamespaces, len(instances))
 	for idx, ei := range instances {
@@ -151,37 +188,11 @@ func (c *ControlService) getScmUsage(ssr *storage.ScmScanResponse) (*storage.Scm
 			nss[idx] = ns
 		}
 
-		c.log.Debugf("updated scm fs usage on device %s mounted at %s: %+v",
+		cs.log.Debugf("updated scm fs usage on device %s mounted at %s: %+v",
 			nss[idx].BlockDevice, mount.Path, nss[idx].Mount)
 	}
 
 	return &storage.ScmScanResponse{Namespaces: nss}, nil
-}
-
-// GetScmState performs required initialization and returns current state
-// of SCM module preparation.
-func (c *StorageControlService) GetScmState() (storage.ScmState, error) {
-	return c.storage.Scm.GetPmemState()
-}
-
-// ScmPrepare preps locally attached modules and returns need to reboot message,
-// list of pmem device files and error directly.
-//
-// Suitable for commands invoked directly on server, not over gRPC.
-func (c *StorageControlService) ScmPrepare(req storage.ScmPrepareRequest) (*storage.ScmPrepareResponse, error) {
-	// transition to the next state in SCM preparation
-	return c.storage.Scm.Prepare(req)
-}
-
-// ScmScan scans locally attached modules, namespaces and state of DCPM config.
-func (c *StorageControlService) ScmScan(req storage.ScmScanRequest) (*storage.ScmScanResponse, error) {
-	return c.storage.Scm.Scan(req)
-}
-
-// NvmePrepare preps locally attached SSDs and returns error.
-func (c *StorageControlService) NvmePrepare(req storage.BdevPrepareRequest) (*storage.BdevPrepareResponse, error) {
-	c.log.Debugf("calling bdev provider prepare: %+v", req)
-	return c.storage.PrepareBdevs(req)
 }
 
 // mapCtrlrs maps each controller to it's PCI address.
@@ -205,9 +216,9 @@ func mapCtrlrs(ctrlrs storage.NvmeControllers) (map[string]*storage.NvmeControll
 // then query is issued over dRPC as go-spdk bindings cannot be used to access
 // controller claimed by another process. Only update info for controllers
 // assigned to I/O Engines.
-func (c *ControlService) scanAssignedBdevs(ctx context.Context, statsReq bool) (*storage.BdevScanResponse, error) {
+func (cs *ControlService) scanAssignedBdevs(ctx context.Context, statsReq bool) (*storage.BdevScanResponse, error) {
 	var ctrlrs storage.NvmeControllers
-	instances := c.harness.Instances()
+	instances := cs.harness.Instances()
 
 	for _, ei := range instances {
 		if !ei.HasBlockDevices() {
@@ -247,9 +258,4 @@ func (c *ControlService) scanAssignedBdevs(ctx context.Context, statsReq bool) (
 	}
 
 	return &storage.BdevScanResponse{Controllers: ctrlrs}, nil
-}
-
-// NvmeScan scans locally attached SSDs.
-func (c *StorageControlService) NvmeScan(req storage.BdevScanRequest) (*storage.BdevScanResponse, error) {
-	return c.storage.ScanBdevs(req)
 }

--- a/src/control/server/storage/bdev/backend.go
+++ b/src/control/server/storage/bdev/backend.go
@@ -216,7 +216,7 @@ func (sb *spdkBackend) reset(req storage.BdevPrepareRequest, vmdDetect vmdDetect
 // bdev_include and bdev_exclude list filters provided in the server config file.
 func (sb *spdkBackend) Reset(req storage.BdevPrepareRequest) error {
 	sb.log.Debugf("spdk backend reset (script call): %+v", req)
-	return sb.reset(req, detectVMD)
+	return sb.reset(req, DetectVMD)
 }
 
 // Prepare will perform a lookup on the requested target user to validate existence
@@ -228,7 +228,7 @@ func (sb *spdkBackend) Reset(req storage.BdevPrepareRequest) error {
 // bdev_include and bdev_exclude list filters provided in the server config file.
 func (sb *spdkBackend) Prepare(req storage.BdevPrepareRequest) (*storage.BdevPrepareResponse, error) {
 	sb.log.Debugf("spdk backend prepare (script call): %+v", req)
-	return sb.prepare(req, user.Lookup, detectVMD, cleanHugePages)
+	return sb.prepare(req, user.Lookup, DetectVMD, cleanHugePages)
 }
 
 // groomDiscoveredBdevs ensures that for a non-empty device list, restrict output controller data

--- a/src/control/server/storage/bdev/backend_vmd.go
+++ b/src/control/server/storage/bdev/backend_vmd.go
@@ -140,9 +140,9 @@ func substituteVMDAddresses(log logging.Logger, inPCIAddrs *common.PCIAddressSet
 	return dl, nil
 }
 
-// detectVMD returns whether VMD devices have been found and a slice of VMD
+// DetectVMD returns whether VMD devices have been found and a slice of VMD
 // PCI addresses if found. Implements vmdDetectFn.
-func detectVMD() (*common.PCIAddressSet, error) {
+func DetectVMD() (*common.PCIAddressSet, error) {
 	distro := system.GetDistribution()
 	var lspciCmd *exec.Cmd
 

--- a/src/control/server/storage/provider.go
+++ b/src/control/server/storage/provider.go
@@ -435,6 +435,12 @@ func (p *Provider) SetBdevCache(resp BdevScanResponse) {
 	p.vmdEnabled = resp.VMDEnabled
 }
 
+// WithVMDEnabled enables VMD on storage provider.
+func (p *Provider) WithVMDEnabled() *Provider {
+	p.vmdEnabled = true
+	return p
+}
+
 // QueryBdevFirmware queries NVMe SSD firmware.
 func (p *Provider) QueryBdevFirmware(req NVMeFirmwareQueryRequest) (*NVMeFirmwareQueryResponse, error) {
 	return p.bdev.QueryFirmware(req)


### PR DESCRIPTION
Allow local storage scan to detect VMD backing devices and display details.

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>