### PR TITLE
DAOS-9174 bio: Use DMA buffer for rebuild pull

### DIFF
--- a/src/bio/bio_buffer.c
+++ b/src/bio/bio_buffer.c
@@ -1053,7 +1053,8 @@ bio_iod_prep(struct bio_desc *biod, unsigned int type, void *bulk_ctxt,
 		return -DER_INVAL;
 
 	biod->bd_chk_type = type;
-	biod->bd_rdma = (bulk_ctxt != NULL);
+	/* For rebuild pull, the DMA buffer will be used as RDMA client */
+	biod->bd_rdma = (bulk_ctxt != NULL) || (type == BIO_CHK_TYPE_REBUILD);
 
 	if (bulk_ctxt != NULL && !(daos_io_bypass & IOBP_SRV_BULK_CACHE)) {
 		bulk_arg.ba_bulk_ctxt = bulk_ctxt;


### PR DESCRIPTION
Set the 'rdma' flag correctly when the request is for rebuild pull,
otherwise, pmem will be used as RDMA fetch target, and that could
cause failure on system doesn't support pmem MR.

Signed-off-by: Niu Yawei <yawei.niu@intel.com>