### PR TITLE
DAOS-0000 dtx: avoid block during DTX commit - large stack

### DIFF
--- a/src/dtx/dtx_common.c
+++ b/src/dtx/dtx_common.c
@@ -1736,6 +1736,7 @@ dtx_leader_exec_ops_ult(void *arg)
 	struct dtx_ult_arg	  *ult_arg = arg;
 	struct dtx_leader_handle  *dlh = ult_arg->dlh;
 	ABT_future		  future = dlh->dlh_future;
+	struct dtx_id		  dtx = dlh->dlh_handle.dth_xid;
 	uint32_t		  saved = dlh->dlh_sub_cnt;
 	uint32_t		  i;
 	int			  rc = 0;
@@ -1766,8 +1767,8 @@ dtx_leader_exec_ops_ult(void *arg)
 		/* Yield to avoid holding CPU for too long time. */
 		if (i >= DTX_RPC_YIELD_THD) {
 			ABT_thread_yield();
-			D_ASSERTF(saved == dlh->dlh_sub_cnt, "corrupted after yield: %u, %u\n",
-				  saved, dlh->dlh_sub_cnt);
+			D_ASSERTF(saved == dlh->dlh_sub_cnt, DF_DTI" corrupted after yield: %u, %u\n",
+				  DP_DTI(&dtx), saved, dlh->dlh_sub_cnt);
 		}
 	}
 
@@ -1813,25 +1814,6 @@ dtx_leader_exec_ops(struct dtx_leader_handle *dlh, dtx_sub_func_t func,
 		D_ERROR("ABT_future_create failed %d.\n", rc);
 		D_FREE_PTR(ult_arg);
 		return dss_abterr2der(rc);
-	}
-
-	if (dlh->dlh_sub_cnt == 79 || dlh->dlh_sub_cnt == 77) {
-		ABT_thread	thread;
-		ABT_thread_attr	attr;
-		size_t		size = 0;
-
-		ABT_thread_self(&thread);
-		rc = ABT_thread_get_attr(thread, &attr);
-		D_ASSERT(rc == ABT_SUCCESS);
-
-		rc = ABT_thread_attr_get_stacksize(attr, &size);
-		D_ASSERT(rc == ABT_SUCCESS);
-
-		if (size < DSS_DEEP_STACK_SZ)
-			D_ERROR("Current ULT stack is too small: %ld, expect %d\n",
-				size, DSS_DEEP_STACK_SZ);
-
-		ABT_thread_attr_free(&attr);
 	}
 
 	/*

--- a/src/dtx/dtx_internal.h
+++ b/src/dtx/dtx_internal.h
@@ -92,6 +92,8 @@ extern uint32_t dtx_agg_thd_cnt_lo;
 #define DTX_AGG_THD_AGE_MIN	210
 #define DTX_AGG_THD_AGE_DEF	630
 
+#define DTX_RPC_YIELD_THD	64
+
 /* The time threshold for triggerring DTX aggregation. If the oldest
  * DTX in the DTX table exceeds such threshold, it will trigger DTX
  * aggregation locally.

--- a/src/dtx/dtx_rpc.c
+++ b/src/dtx/dtx_rpc.c
@@ -389,7 +389,9 @@ dtx_req_list_send(struct dtx_req_args *dra, crt_opcode_t opc, d_list_t *head,
 			}
 		}
 
-		i++;
+		/* Yield to avoid holding CPU for too long time. */
+		if (++i >= DTX_RPC_YIELD_THD)
+			ABT_thread_yield();
 	}
 
 	return 0;
@@ -504,13 +506,12 @@ dtx_classify_one(struct ds_pool *pool, daos_handle_t tree, d_list_t *head,
 		i = 1;
 	else
 		i = 0;
+
 	for (; i < mbs->dm_tgt_cnt && rc >= 0; i++) {
 		struct pool_target	*target;
 
-		ABT_rwlock_rdlock(pool->sp_lock);
 		rc = pool_map_find_target(pool->sp_map,
 					  mbs->dm_tgts[i].ddt_id, &target);
-		ABT_rwlock_unlock(pool->sp_lock);
 		if (rc != 1) {
 			D_WARN("Cannot find target %u at %d/%d, flags %x\n",
 			       mbs->dm_tgts[i].ddt_id, i, mbs->dm_tgt_cnt,
@@ -569,6 +570,7 @@ dtx_dti_classify(struct ds_pool *pool, daos_handle_t tree,
 	int	rc = 0;
 	int	i;
 
+	ABT_rwlock_rdlock(pool->sp_lock);
 	for (i = 0; i < count; i++) {
 		rc = dtx_classify_one(pool, tree, head, &length, dtes[i], count, my_rank, my_tgtid);
 		if (rc < 0)
@@ -577,6 +579,7 @@ dtx_dti_classify(struct ds_pool *pool, daos_handle_t tree,
 		if (dtis != NULL)
 			dtis[i] = dtes[i]->dte_xid;
 	}
+	ABT_rwlock_unlock(pool->sp_lock);
 
 	return rc < 0 ? rc : length;
 }
@@ -797,8 +800,10 @@ dtx_abort(struct ds_cont_child *cont, struct dtx_entry *dte, daos_epoch_t epoch)
 
 	D_INIT_LIST_HEAD(&head);
 	crt_group_rank(NULL, &my_rank);
+	ABT_rwlock_rdlock(pool->sp_lock);
 	rc = dtx_classify_one(pool, DAOS_HDL_INVAL, &head, &length, dte, 1, my_rank,
 			      dss_get_module_info()->dmi_tgt_id);
+	ABT_rwlock_unlock(pool->sp_lock);
 	if (rc < 0)
 		goto out;
 
@@ -859,8 +864,10 @@ dtx_check(struct ds_cont_child *cont, struct dtx_entry *dte, daos_epoch_t epoch)
 
 	D_INIT_LIST_HEAD(&head);
 	crt_group_rank(NULL, &my_rank);
+	ABT_rwlock_rdlock(pool->sp_lock);
 	rc = dtx_classify_one(pool, DAOS_HDL_INVAL, &head, &length, dte, 1, my_rank,
 			      dss_get_module_info()->dmi_tgt_id);
+	ABT_rwlock_unlock(pool->sp_lock);
 	if (rc < 0)
 		goto out;
 

--- a/src/engine/srv_internal.h
+++ b/src/engine/srv_internal.h
@@ -259,7 +259,7 @@ sched_create_thread(struct dss_xstream *dx, void (*func)(void *), void *arg,
 		if (rc != ABT_SUCCESS)
 			return dss_abterr2der(rc);
 
-		rc = ABT_thread_attr_set_stacksize(attr, DSS_DEEP_STACK_SZ);
+		rc = ABT_thread_attr_set_stacksize(attr, DSS_DEEP_STACK_SZ / 2);
 		D_ASSERT(rc == ABT_SUCCESS);
 
 		rc = ABT_thread_create(abt_pool, func, arg, attr, thread);

--- a/src/engine/srv_internal.h
+++ b/src/engine/srv_internal.h
@@ -252,7 +252,22 @@ sched_create_thread(struct dss_xstream *dx, void (*func)(void *), void *arg,
 		/* Atomic integer assignment from different xstream */
 		info->si_stats.ss_busy_ts = info->si_cur_ts;
 
-	rc = ABT_thread_create(abt_pool, func, arg, t_attr, thread);
+	if (t_attr == ABT_THREAD_ATTR_NULL) {
+		ABT_thread_attr		attr;
+
+		rc = ABT_thread_attr_create(&attr);
+		if (rc != ABT_SUCCESS)
+			return dss_abterr2der(rc);
+
+		rc = ABT_thread_attr_set_stacksize(attr, DSS_DEEP_STACK_SZ);
+		D_ASSERT(rc == ABT_SUCCESS);
+
+		rc = ABT_thread_create(abt_pool, func, arg, attr, thread);
+		ABT_thread_attr_free(&attr);
+	} else {
+		rc = ABT_thread_create(abt_pool, func, arg, t_attr, thread);
+	}
+
 	return dss_abterr2der(rc);
 }
 

--- a/src/tests/ftest/erasurecode/mdtest_smoke.yaml
+++ b/src/tests/ftest/erasurecode/mdtest_smoke.yaml
@@ -25,7 +25,9 @@ server_config:
       scm_class: dcpm
       scm_list: ["/dev/pmem0"]
       scm_mount: /mnt/daos0
-      log_mask: ERR
+      log_mask: DEBUG,MEM=ERR
+      env_vars:
+        - DD_MASK=all
     1:
       pinned_numa_node: 1
       nr_xs_helpers: 1
@@ -37,7 +39,9 @@ server_config:
       scm_class: dcpm
       scm_list: ["/dev/pmem1"]
       scm_mount: /mnt/daos1
-      log_mask: ERR
+      log_mask: DEBUG,MEM=ERR
+      env_vars:
+        - DD_MASK=all
 pool:
     name: daos_server
     control_method: dmg


### PR DESCRIPTION
Use deep stack by default.

1. Yield CPU during sending DTX RPCs and IO forward RPCs if the
   targets list exceeds the DTX_RPC_YIELD_THD (64).

2. Take ds_pool::sp_lock out side of dtx_classify_one() to avoid
   frequently lock/unlock against the shared pool.

Signed-off-by: Fan Yong <fan.yong@intel.com>