### PR TITLE
DAOS-0000 duns: build EL7 DAOS RPMs with Lustre-DUNS bindings

### DIFF
--- a/src/client/dfs/SConscript
+++ b/src/client/dfs/SConscript
@@ -22,7 +22,9 @@ def configure_lustre(denv):
         print("Building with Lustre bindings.")
         denv.AppendUnique(CCFLAGS=['-DLUSTRE_INCLUDE'])
     else:
-        print("Not building with Lustre bindings.")
+        #print("Not building with Lustre bindings.")
+        print("Building with Lustre bindings anyway !!...")
+        denv.AppendUnique(CCFLAGS=['-DLUSTRE_INCLUDE'])
     return conf.Finish()
 
 def scons():

--- a/utils/rpms/packaging/Dockerfile.mockbuild
+++ b/utils/rpms/packaging/Dockerfile.mockbuild
@@ -14,7 +14,7 @@ ARG UID=1000
 # Install basic tools
 RUN dnf -y install mock make \
                    rpm-build curl createrepo rpmlint redhat-lsb-core git \
-                   python-srpm-macros rpmdevtools
+                   python-srpm-macros rpmdevtools wget
 
 # get and install recent master Lustre Client RPMs
 RUN wget https://build.whamcloud.com/job/lustre-master/lastBuild/arch=x86_64,build_type=client,distro=el7.8,ib_stack=inkernel/artifact/artifacts/RPMS/x86_64/kmod-lustre-client-2.14.55_169_g9490fd9-1.el7.x86_64.rpm

--- a/utils/rpms/packaging/Dockerfile.mockbuild
+++ b/utils/rpms/packaging/Dockerfile.mockbuild
@@ -20,7 +20,8 @@ RUN dnf -y install mock make \
 RUN wget https://build.whamcloud.com/job/lustre-master/lastBuild/arch=x86_64,build_type=client,distro=el7.8,ib_stack=inkernel/artifact/artifacts/RPMS/x86_64/kmod-lustre-client-2.14.55_169_g9490fd9-1.el7.x86_64.rpm
 RUN wget https://build.whamcloud.com/job/lustre-master/lastBuild/arch=x86_64,build_type=client,distro=el7.8,ib_stack=inkernel/artifact/artifacts/RPMS/x86_64/lustre-client-2.14.55_169_g9490fd9-1.el7.x86_64.rpm
 RUN wget https://build.whamcloud.com/job/lustre-master/lastBuild/arch=x86_64,build_type=client,distro=el7.8,ib_stack=inkernel/artifact/artifacts/RPMS/x86_64/lustre-client-devel-2.14.55_169_g9490fd9-1.el7.x86_64.rpm
-RUN dnf -y localinstall *lustre*.rpm
+# force install regarding dependencies with rpm command
+RUN rpm -i --force --nodeps *lustre*.rpm
 
 # Add build user (to keep rpmbuild happy)
 ENV USER build

--- a/utils/rpms/packaging/Dockerfile.mockbuild
+++ b/utils/rpms/packaging/Dockerfile.mockbuild
@@ -16,6 +16,12 @@ RUN dnf -y install mock make \
                    rpm-build curl createrepo rpmlint redhat-lsb-core git \
                    python-srpm-macros rpmdevtools
 
+# get and install recent master Lustre Client RPMs
+RUN wget https://build.whamcloud.com/job/lustre-master/lastBuild/arch=x86_64,build_type=client,distro=el7.8,ib_stack=inkernel/artifact/artifacts/RPMS/x86_64/kmod-lustre-client-2.14.55_169_g9490fd9-1.el7.x86_64.rpm
+RUN wget https://build.whamcloud.com/job/lustre-master/lastBuild/arch=x86_64,build_type=client,distro=el7.8,ib_stack=inkernel/artifact/artifacts/RPMS/x86_64/lustre-client-2.14.55_169_g9490fd9-1.el7.x86_64.rpm
+RUN wget https://build.whamcloud.com/job/lustre-master/lastBuild/arch=x86_64,build_type=client,distro=el7.8,ib_stack=inkernel/artifact/artifacts/RPMS/x86_64/lustre-client-devel-2.14.55_169_g9490fd9-1.el7.x86_64.rpm
+RUN dnf -y localinstall *lustre*.rpm
+
 # Add build user (to keep rpmbuild happy)
 ENV USER build
 ENV PASSWD build


### PR DESCRIPTION
Try to use CI/Jenkins to build DAOS-v1.2.0 RPMs with Lustre-DUNS
bindings.

Change-Id: Ie93db4d14c9b129e00e79a4e366911b253add100
Signed-off-by: Bruno Faccini <bruno.faccini@intel.com>