### PR TITLE
DAOS-9209-test: pool/query_attribute.py test failed on pool query Expected != actual

### DIFF
--- a/src/tests/ftest/pool/query_attribute.py
+++ b/src/tests/ftest/pool/query_attribute.py
@@ -54,6 +54,7 @@ class QueryAttributeTest(TestWithServers):
         query_result = daos_cmd.pool_query(pool=self.pool.uuid)
         actual_uuid = query_result["response"]["uuid"]
         actual_size = query_result["response"]["tier_stats"][0]["total"]
+        actual_size_roundup = int(actual_size/100000)*100000
 
         expected_uuid = self.pool.uuid.lower()
         if expected_uuid != actual_uuid:
@@ -61,10 +62,10 @@ class QueryAttributeTest(TestWithServers):
                 "Expected = {}; Actual = {}".format(expected_uuid, actual_uuid)
             errors.append(msg)
 
-        if expected_size != actual_size:
-            msg = "Unexpected Total Storage Tier 0 size from daos pool " +\
-                "query! Expected = {}; Actual = {}".format(
-                    expected_size, actual_size)
+        if expected_size != actual_size_roundup:
+            msg = "#Unexpected Total Storage Tier 0 size from daos pool " +\
+                "query! Expected = {}; Actual roundup = {}".format(
+                    expected_size, actual_size_roundup)
             errors.append(msg)
 
         # 2. Test pool set-attr, get-attr, and list-attrs.


### PR DESCRIPTION
Description: Roundup pool query size in script after discussed with Mohamad and Jeff, reference DAOS-9030.

Skip-unit-tests: true
Test-tag: pool_query_attr
Signed-off-by: Ding Ho ding-hwa.ho@intel.com