### PR TITLE
DAOS-8953-test: update script for datamove/negative rebuild/container_create_race timeout on Leap15

### DIFF
--- a/src/tests/ftest/datamover/negative.yaml
+++ b/src/tests/ftest/datamover/negative.yaml
@@ -3,7 +3,7 @@ hosts:
         - server-A
     test_clients:
         - server-B
-timeout: 300
+timeout: 450
 server_config:
     name: daos_server
 pool:

--- a/src/tests/ftest/rebuild/container_create_race.yaml
+++ b/src/tests/ftest/rebuild/container_create_race.yaml
@@ -8,7 +8,7 @@ hosts:
     - server-D
   test_clients:
     - client-A
-timeout: 360
+timeout: 600
 server_config:
   name: daos_server
   servers:


### PR DESCRIPTION

Description: Increase test.yaml timeout for Leap15 

Skip-func-test-leap15: false
Skip-unit-tests: true
Test-tag: dm_negative_space_dcp, rebuild_cont_create
Signed-off-by: Ding Ho ding-hwa.ho@intel.com