### PR TITLE
DAOS-9147 control: Use client-side timeout for fanout requests

### DIFF
--- a/src/control/lib/control/rpc.go
+++ b/src/control/lib/control/rpc.go
@@ -216,7 +216,8 @@ func setDeadlineIfUnset(parent context.Context, req UnaryRequest) (context.Conte
 
 	rd := req.getDeadline()
 	if rd.IsZero() {
-		rd = time.Now().Add(defaultRequestTimeout)
+		req.SetTimeout(defaultRequestTimeout)
+		rd = req.getDeadline()
 	}
 	return context.WithDeadline(parent, rd)
 }


### PR DESCRIPTION
Let the client decide how long the request may take; don't set
an arbitrary server-side timeout value.

Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com>
