### PR TITLE
DAOS-9142 control: Fix race in superblock access

### DIFF
--- a/src/control/server/instance_drpc.go
+++ b/src/control/server/instance_drpc.go
@@ -72,7 +72,7 @@ func (ei *EngineInstance) CallDrpc(ctx context.Context, method drpc.Method, body
 	}
 
 	rankMsg := ""
-	if sb := ei.getSuperblock(); sb != nil {
+	if sb := ei.getSuperblock(); sb != nil && sb.Rank != nil {
 		rankMsg = fmt.Sprintf(" (rank %s)", sb.Rank)
 	}
 

--- a/src/control/server/instance_superblock.go
+++ b/src/control/server/instance_superblock.go
@@ -75,7 +75,19 @@ func (ei *EngineInstance) setSuperblock(sb *Superblock) {
 func (ei *EngineInstance) getSuperblock() *Superblock {
 	ei.RLock()
 	defer ei.RUnlock()
-	return ei._superblock
+
+	if ei._superblock == nil {
+		return nil
+	}
+
+	// Make a read-only copy to avoid race warnings.
+	// NB: There is not currently any logic that relies
+	// on the returned Superblock being "live", i.e. the
+	// actual in-memory struct. If that changes, then the
+	// Superblock struct will probably need some locking to
+	// provide thread-safe access to its fields.
+	sbCopy := *ei._superblock
+	return &sbCopy
 }
 
 func (ei *EngineInstance) hasSuperblock() bool {


### PR DESCRIPTION
Unguarded access to the Rank field of the superblock was
causing occasional race warnings on server startup.

Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com>
