### PR TITLE
DAOS-8935 build: fix rmem values in sysctl conf file

### DIFF
--- a/utils/rpms/10-daos_server.conf
+++ b/utils/rpms/10-daos_server.conf
@@ -2,5 +2,5 @@
 # (e.g. /usr/lib/sysctl.d/90-override.conf), and put any assignments
 # there.
 
-net.core.rmem_max=104857
-net.core.rmem_default=104857
+net.core.rmem_max=1048576
+net.core.rmem_default=1048576


### PR DESCRIPTION
Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>