### PR TITLE
DAOS-5061 tests: Set memlock ulimit values to unlimited (#7328)

### DIFF
--- a/src/tests/ftest/scripts/setup_nodes.sh
+++ b/src/tests/ftest/scripts/setup_nodes.sh
@@ -56,6 +56,11 @@ sysctl --system
 if [ \"\$(ulimit -c)\" != \"unlimited\" ]; then
     echo \"*  soft  core  unlimited\" >> /etc/security/limits.conf
 fi
+if [ \"\$(ulimit -l)\" != \"unlimited\" ]; then
+    echo \"*  soft  memlock  unlimited\" >> /etc/security/limits.conf
+    echo \"*  hard  memlock  unlimited\" >> /etc/security/limits.conf
+fi
+ulimit -a
 echo \"/var/tmp/core.%e.%t.%p\" > /proc/sys/kernel/core_pattern"
 sudo rm -f /var/tmp/core.*
 if [ "${HOSTNAME%%.*}" != "$FIRST_NODE" ]; then


### PR DESCRIPTION
Set memlock ulimit value to unlimited to avoid cannot allocate memory
errors with verbs.

Test-tag: pr daily_regression
Allow-unstable-test: true

Signed-off-by: Phillip Henderson <phillip.henderson@intel.com>