### PR TITLE
DAOS-9214 Test: Removing the Fio random data for rebuild tests.

### DIFF
--- a/src/tests/ftest/erasurecode/rebuild_fio.yaml
+++ b/src/tests/ftest/erasurecode/rebuild_fio.yaml
@@ -85,9 +85,6 @@ fio:
       randrw:
         rw: 'randrw'
         rw_read: 'randrw'
-      randwrite:
-        rw: 'randwrite'
-        rw_read: 'randread'
 dfuse:
   mount_dir: "/tmp/daos_dfuse"
   disable_caching: True


### PR DESCRIPTION
IOR covers the rebuild test for EC and Fio may not be ideal
application to validate the aggregation in this case.

Doc-only: true

Signed-off-by: Samir Raval <samir.raval@intel.com>