### PR TITLE
DAOS-8988 rebuild: abort previous rebuild (#7223) (#7395)

### DIFF
--- a/src/tests/ftest/daos_test/rebuild.py
+++ b/src/tests/ftest/daos_test/rebuild.py
@@ -253,3 +253,18 @@ class DaosCoreTestRebuild(DaosCoreBase):
         :avocado: tags=daos_test,daos_core_test_rebuild,test_rebuild_28
         """
         self.run_subtest()
+    def test_rebuild_29(self):
+        """Jira ID: DAOS-2770
+
+        Test Description:
+            Run daos_test -r -s5 -u subtests=29
+
+        Use cases:
+            Core tests for daos_test rebuild
+
+        :avocado: tags=all,pr,daily_regression
+        :avocado: tags=hw,ib2,medium
+        :avocado: tags=unittest
+        :avocado: tags=daos_test,daos_core_test_rebuild,test_rebuild_29
+        """
+        self.run_subtest()

--- a/src/tests/ftest/daos_test/rebuild.yaml
+++ b/src/tests/ftest/daos_test/rebuild.yaml
@@ -76,6 +76,7 @@ daos_tests:
     test_rebuild_26: DAOS_Rebuild_26
     test_rebuild_27: DAOS_Rebuild_27
     test_rebuild_28: DAOS_Rebuild_28
+    test_rebuild_29: DAOS_Rebuild_29
   daos_test:
     test_rebuild_0to10: r
     test_rebuild_12to15: r
@@ -92,6 +93,7 @@ daos_tests:
     test_rebuild_26: r
     test_rebuild_27: r
     test_rebuild_28: r
+    test_rebuild_29: r
   args:
     test_rebuild_0to10: -s3 -u subtests="0-10"
     test_rebuild_12to15: -s3 -u subtests="12-15"
@@ -108,6 +110,7 @@ daos_tests:
     test_rebuild_26: -s3 -u subtests="26"
     test_rebuild_27: -s6 -u subtests="27"
     test_rebuild_28: -s3 -u subtests="28"
+    test_rebuild_29: -s5 -u subtests="29"
   stopped_ranks:
     test_rebuild_22: [7]
     test_rebuild_23: [7]
@@ -116,3 +119,4 @@ daos_tests:
     test_rebuild_26: ["random"]
     test_rebuild_27: ["random"]
     test_rebuild_28: [7]
+    test_rebuild_29: ["random"]

--- a/src/tests/suite/daos_rebuild.c
+++ b/src/tests/suite/daos_rebuild.c
@@ -1295,6 +1295,40 @@ rebuild_kill_rank_during_rebuild(void **state)
 			 arg->pool.alive_svc, ranks_to_kill[0]);
 }
 
+static void
+rebuild_kill_PS_leader_during_rebuild(void **state)
+{
+	test_arg_t	*arg = *state;
+	daos_obj_id_t	oids[OBJ_NR];
+	d_rank_t	leader;
+	int		i;
+
+	if (!test_runable(arg, 7) || arg->pool.alive_svc->rl_nr < 5) {
+		print_message("need at least 5 svcs, -s5\n");
+		return;
+	}
+
+	test_get_leader(arg, &leader);
+	for (i = 0; i < OBJ_NR; i++) {
+		oids[i] = daos_test_oid_gen(arg->coh, DAOS_OC_R3S_SPEC_RANK, 0,
+					    0, arg->myrank);
+		oids[i] = dts_oid_set_rank(oids[i], 6);
+	}
+	rebuild_io(arg, oids, OBJ_NR);
+
+	daos_kill_server(arg, arg->pool.pool_uuid, arg->group,
+			 arg->pool.alive_svc, 6);
+	/* hang the rebuild */
+	if (arg->myrank == 0) {
+		daos_debug_set_params(arg->group, -1, DMG_KEY_FAIL_LOC,
+				      DAOS_REBUILD_TGT_SCAN_HANG, 0, NULL);
+		daos_debug_set_params(arg->group, -1, DMG_KEY_FAIL_VALUE, 5,
+				      0, NULL);
+	}
+	sleep(2);
+	rebuild_single_pool_rank(arg, leader, true);
+}
+
 /** create a new pool/container for each test */
 static const struct CMUnitTest rebuild_tests[] = {
 	{"REBUILD0: drop rebuild scan reply",
@@ -1367,6 +1401,9 @@ static const struct CMUnitTest rebuild_tests[] = {
 	 rebuild_fail_all_replicas, rebuild_sub_setup, rebuild_sub_teardown},
 	{"REBUILD28: rebuild kill rank during rebuild",
 	 rebuild_kill_rank_during_rebuild, rebuild_sub_setup,
+	 rebuild_sub_teardown},
+	{"REBUILD29: rebuild kill PS leader during rebuild",
+	 rebuild_kill_PS_leader_during_rebuild, rebuild_sub_setup,
 	 rebuild_sub_teardown},
 };
 


### PR DESCRIPTION
If PS leader is killed during rebuild, then each targets
will get rebuild request from the new leader, and it should
check if the previous rebuild might need to be aborted.

Signed-off-by: Di Wang <di.wang@intel.com>