### PR TITLE
DAOS-9154 control: Enable SRX by default

### DIFF
--- a/src/control/common/test_utils.go
+++ b/src/control/common/test_utils.go
@@ -162,6 +162,14 @@ func ShowBufferOnFailure(t *testing.T, buf fmt.Stringer) {
 	}
 }
 
+// BoolAsInt converts a bool to an int.
+func BoolAsInt(b bool) int {
+	if b {
+		return 1
+	}
+	return 0
+}
+
 // DefaultCmpOpts gets default go-cmp comparison options for tests.
 func DefaultCmpOpts() []cmp.Option {
 	return []cmp.Option{

--- a/src/control/server/engine/config.go
+++ b/src/control/server/engine/config.go
@@ -30,6 +30,7 @@ type FabricConfig struct {
 	BypassHealthChk *bool  `yaml:"bypass_health_chk,omitempty" cmdLongFlag:"--bypass_health_chk" cmdShortFlag:"-b"`
 	CrtCtxShareAddr uint32 `yaml:"crt_ctx_share_addr,omitempty" cmdEnv:"CRT_CTX_SHARE_ADDR"`
 	CrtTimeout      uint32 `yaml:"crt_timeout,omitempty" cmdEnv:"CRT_TIMEOUT"`
+	DisableSRX      bool   `yaml:"disable_srx,omitempty" cmdEnv:"FI_OFI_RXM_USE_SRX,invertBool,intBool"`
 }
 
 // Update fills in any missing fields from the provided FabricConfig.

--- a/src/control/server/engine/config_test.go
+++ b/src/control/server/engine/config_test.go
@@ -574,6 +574,7 @@ func TestConfig_ToCmdVals(t *testing.T) {
 		"D_LOG_MASK=" + logMask,
 		"CRT_TIMEOUT=" + strconv.FormatUint(uint64(crtTimeout), 10),
 		"CRT_CTX_SHARE_ADDR=" + strconv.FormatUint(uint64(crtCtxShareAddr), 10),
+		"FI_OFI_RXM_USE_SRX=1",
 	}
 
 	gotArgs, err := cfg.CmdLineArgs()

--- a/src/control/server/engine/exec_test.go
+++ b/src/control/server/engine/exec_test.go
@@ -166,6 +166,7 @@ func TestRunnerNormalExit(t *testing.T) {
 	wantArgs := "-t 42 -x 1 -T 1 -p 1 -I 0 -r 0 -H 0 -s /foo/bar"
 	var gotArgs string
 	env := []string{
+		"FI_OFI_RXM_USE_SRX=1",
 		"CRT_CTX_SHARE_ADDR=1",
 		"CRT_TIMEOUT=30",
 		"OFI_INTERFACE=qib0",

--- a/src/control/server/engine/tags_test.go
+++ b/src/control/server/engine/tags_test.go
@@ -27,6 +27,8 @@ type testConfig struct {
 	StringEnv        string `cmdEnv:"STRING_ENV"`
 	SetBoolEnv       bool   `cmdEnv:"SET_BOOL_ENV"`
 	UnsetBoolEnv     bool   `cmdEnv:"UNSET_BOOL_ENV"`
+	InvertBoolIntEnv bool   `cmdEnv:"INVERT_BOOL_INT_ENV,invertBool,intBool"`
+	BoolIntEnv       bool   `cmdEnv:"BOOL_INT_ENV,intBool"`
 	IntPtrOpt        *int   `cmdShortFlag:"-p" cmdLongFlag:"--int_ptr"`
 	UnsetIntPtrOpt   *int   `cmdShortFlag:"-r" cmdLongFlag:"--unset_int_ptr"`
 	SliceOpt         []int  `cmdShortFlag:"-S,nonzero" cmdLongFlag:"--slice_length,nonzero"`
@@ -111,6 +113,8 @@ func TestParseEnvVars(t *testing.T) {
 		"INT_ENV=-1",
 		"STRING_ENV=stringEnv",
 		"SET_BOOL_ENV=true",
+		"INVERT_BOOL_INT_ENV=1",
+		"BOOL_INT_ENV=0",
 	}
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Fatalf("(-want, +got):\n%s", diff)

--- a/src/control/server/server_utils.go
+++ b/src/control/server/server_utils.go
@@ -416,26 +416,28 @@ func getSrxSetting(cfg *config.Server) (int32, error) {
 	}
 
 	srxVarName := "FI_OFI_RXM_USE_SRX"
-	getSetting := func(ev string) (bool, int32) {
+	getSetting := func(ev string) (bool, int32, error) {
 		kv := strings.Split(ev, "=")
 		if len(kv) != 2 {
-			return false, -1
+			return false, -1, nil
 		}
 		if kv[0] != srxVarName {
-			return false, -1
+			return false, -1, nil
 		}
 		v, err := strconv.ParseInt(kv[1], 10, 32)
 		if err != nil {
-			return true, -1
+			return false, -1, err
 		}
-		return true, int32(v)
+		return true, int32(v), nil
 	}
 
 	engineVals := make([]int32, len(cfg.Engines))
 	for idx, ec := range cfg.Engines {
 		engineVals[idx] = -1 // default to unset
 		for _, ev := range ec.EnvVars {
-			if match, engSrx := getSetting(ev); match {
+			if match, engSrx, err := getSetting(ev); err != nil {
+				return -1, err
+			} else if match {
 				engineVals[idx] = engSrx
 				break
 			}
@@ -453,6 +455,12 @@ func getSrxSetting(cfg *config.Server) (int32, error) {
 		if engineVals[i] != cliSrx {
 			return -1, errors.Errorf("%s setting must be the same for all engines", srxVarName)
 		}
+	}
+
+	// If the SRX config was not explicitly set via env vars, use the
+	// global config value.
+	if cliSrx == -1 {
+		cliSrx = int32(common.BoolAsInt(!cfg.Fabric.DisableSRX))
 	}
 
 	return cliSrx, nil

--- a/src/control/server/server_utils_test.go
+++ b/src/control/server/server_utils_test.go
@@ -103,6 +103,8 @@ func TestServer_checkFabricInterface(t *testing.T) {
 }
 
 func TestServer_getSrxSetting(t *testing.T) {
+	defCfg := config.DefaultServer()
+
 	for name, tc := range map[string]struct {
 		cfg        *config.Server
 		expSetting int32
@@ -112,12 +114,12 @@ func TestServer_getSrxSetting(t *testing.T) {
 			cfg:        config.DefaultServer(),
 			expSetting: -1,
 		},
-		"not set": {
+		"not set defaults to cfg value": {
 			cfg: config.DefaultServer().WithEngines(
 				engine.NewConfig(),
 				engine.NewConfig(),
 			),
-			expSetting: -1,
+			expSetting: int32(common.BoolAsInt(!defCfg.Fabric.DisableSRX)),
 		},
 		"set to 0 in both (single)": {
 			cfg: config.DefaultServer().WithEngines(
@@ -193,7 +195,7 @@ func TestServer_getSrxSetting(t *testing.T) {
 			cfg: config.DefaultServer().WithEngines(
 				engine.NewConfig().WithEnvVars("FI_OFI_RXM_USE_SRX=on"),
 			),
-			expSetting: -1,
+			expErr: errors.New("on"),
 		},
 		"set in env_pass_through": {
 			cfg: config.DefaultServer().WithEngines(

--- a/utils/config/daos_server.yml
+++ b/utils/config/daos_server.yml
@@ -91,6 +91,12 @@
 #crt_timeout: 30
 #
 #
+## CART: Disable SRX
+## parameters shared with client.
+#
+#disable_srx: false
+#
+#
 ## NVMe SSD inclusion list
 ## Immutable after running "dmg storage format".
 #


### PR DESCRIPTION
As CaRT is already doing this behind the scenes, the
server config should explicitly enable it to avoid
confusing client behavior.

Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com>
