### PR TITLE
DAOS-8905 control: Add lib for hwloc

### DIFF
--- a/src/control/lib/hardware/hwloc/bindings.go
+++ b/src/control/lib/hardware/hwloc/bindings.go
@@ -1,0 +1,413 @@
+//
+// (C) Copyright 2021 Intel Corporation.
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+
+package hwloc
+
+/*
+#cgo LDFLAGS: -lhwloc
+#include <hwloc.h>
+
+int node_get_osdev_type(hwloc_obj_t node)
+{
+	if (node->attr == NULL) {
+		return -1;
+	}
+
+	return node->attr->osdev.type;
+}
+
+struct hwloc_pcidev_attr_s *node_get_pcidev_attr(hwloc_obj_t node) {
+	if (node->attr == NULL) {
+		return NULL;
+	}
+
+	return &node->attr->pcidev;
+}
+
+#if HWLOC_API_VERSION >= 0x00020000
+
+int topo_setFlags(hwloc_topology_t topology)
+{
+	return hwloc_topology_set_all_types_filter(topology, HWLOC_TYPE_FILTER_KEEP_ALL);
+}
+
+int node_get_arity(hwloc_obj_t node)
+{
+	return node->io_arity;
+}
+
+int node_get_parent_arity(hwloc_obj_t node)
+{
+	return node->parent->io_arity;
+}
+
+hwloc_obj_t node_get_sibling(hwloc_obj_t node, int idx)
+{
+	hwloc_obj_t child;
+	int i;
+
+	child = node->parent->io_first_child;
+	for (i = 0; i < idx; i++) {
+		child = child->next_sibling;
+	}
+	return child;
+}
+
+hwloc_obj_t node_get_child(hwloc_obj_t node, int idx)
+{
+	hwloc_obj_t child;
+	int i;
+
+	child = node->io_first_child;
+	for (i = 0; i < idx; i++) {
+		child = child->next_sibling;
+	}
+	return child;
+}
+#else
+int topo_setFlags(hwloc_topology_t topology)
+{
+	return hwloc_topology_set_flags(topology, HWLOC_TOPOLOGY_FLAG_IO_DEVICES);
+}
+
+int node_get_arity(hwloc_obj_t node)
+{
+	return node->arity;
+}
+
+int node_get_parent_arity(hwloc_obj_t node)
+{
+	return node->parent->arity;
+}
+
+hwloc_obj_t node_get_sibling(hwloc_obj_t node, int idx)
+{
+	return node->parent->children[idx];
+}
+
+hwloc_obj_t node_get_child(hwloc_obj_t node, int idx)
+{
+	return node->children[idx];
+}
+#endif
+*/
+import "C"
+
+import (
+	"fmt"
+	"sync"
+	"unsafe"
+
+	"github.com/pkg/errors"
+)
+
+type api struct {
+	sync.Mutex
+}
+
+func (a *api) runtimeVersion() uint {
+	return uint(C.hwloc_get_api_version())
+}
+
+func (a *api) compiledVersion() uint {
+	return C.HWLOC_API_VERSION
+}
+
+func (a *api) newTopology() (*topology, func(), error) {
+	topo := &topology{
+		api: a,
+	}
+	status := C.hwloc_topology_init(&topo.cTopology)
+	if status != 0 {
+		return nil, nil, errors.Errorf("hwloc topology init failed: %v", status)
+	}
+
+	return topo, func() {
+		C.hwloc_topology_destroy(topo.cTopology)
+	}, nil
+}
+
+// topology is a thin wrapper for the hwloc topology and related functions.
+type topology struct {
+	api       *api
+	cTopology C.hwloc_topology_t
+}
+
+func (t *topology) raw() C.hwloc_topology_t {
+	return t.cTopology
+}
+
+func (t *topology) getProcessCPUSet(pid int32, flags int) (*cpuSet, func(), error) {
+	// Access to hwloc_get_proc_cpubind must be synchronized
+	t.api.Lock()
+	defer t.api.Unlock()
+
+	cpuset := C.hwloc_bitmap_alloc()
+	if cpuset == nil {
+		return nil, nil, errors.New("hwloc_bitmap_alloc failed")
+	}
+	cleanup := func() {
+		C.hwloc_bitmap_free(cpuset)
+	}
+
+	if status := C.hwloc_get_proc_cpubind(t.cTopology, C.int(pid), cpuset, C.int(flags)); status != 0 {
+		cleanup()
+		return nil, nil, errors.Errorf("hwloc get proc cpubind failed: %v", status)
+	}
+
+	return newCPUSet(t, cpuset), cleanup, nil
+}
+
+func (t *topology) setFlags() error {
+	if status := C.topo_setFlags(t.cTopology); status != 0 {
+		return errors.Errorf("hwloc set flags failed: %v", status)
+	}
+	return nil
+}
+
+func (t *topology) load() error {
+	if status := C.hwloc_topology_load(t.cTopology); status != 0 {
+		return errors.Errorf("hwloc topology load failed: %v", status)
+	}
+	return nil
+}
+
+func (t *topology) getNextObjByType(objType int, prev *object) (*object, error) {
+	var cPrev C.hwloc_obj_t
+	if prev != nil {
+		cPrev = prev.cObj
+	}
+	obj := C.hwloc_get_next_obj_by_type(t.cTopology, C.hwloc_obj_type_t(objType), cPrev)
+	if obj == nil {
+		return nil, errors.Errorf("no next hwloc object found with type=%d", objType)
+	}
+	return newObject(t, obj), nil
+}
+
+func (t *topology) getNumObjByType(objType int) uint {
+	return uint(C.hwloc_get_nbobjs_by_type(t.cTopology, C.hwloc_obj_type_t(objType)))
+}
+
+const (
+	objTypeOSDevice  = C.HWLOC_OBJ_OS_DEVICE
+	objTypePCIDevice = C.HWLOC_OBJ_PCI_DEVICE
+	objTypeNUMANode  = C.HWLOC_OBJ_NUMANODE
+	objTypeCore      = C.HWLOC_OBJ_CORE
+
+	osDevTypeNetwork     = C.HWLOC_OBJ_OSDEV_NETWORK
+	osDevTypeOpenFabrics = C.HWLOC_OBJ_OSDEV_OPENFABRICS
+)
+
+type rawTopology interface {
+	raw() C.hwloc_topology_t
+}
+
+// object is a thin wrapper for hwloc_obj_t and related functions.
+type object struct {
+	cObj C.hwloc_obj_t
+	topo rawTopology
+}
+
+func (o *object) name() string {
+	objName := C.GoString(o.cObj.name)
+	if objName == "" {
+		objName = fmt.Sprintf("%s %d", o.objTypeString(), o.osIndex())
+	}
+	return objName
+}
+
+func (o *object) osIndex() uint {
+	return uint(o.cObj.os_index)
+}
+
+func (o *object) logicalIndex() uint {
+	return uint(o.cObj.logical_index)
+}
+
+func (o *object) getNumSiblings() uint {
+	return uint(C.node_get_parent_arity(o.cObj))
+}
+
+func (o *object) getSibling(index uint) (*object, error) {
+	cResult := C.node_get_sibling(o.cObj, C.int(index))
+	if cResult == nil {
+		return nil, errors.Errorf("sibling of object %q not found", o.name())
+	}
+
+	return newObject(o.topo, cResult), nil
+}
+
+func (o *object) getNumChildren() uint {
+	return uint(C.node_get_arity(o.cObj))
+}
+
+func (o *object) getChild(index uint) (*object, error) {
+	if o.cObj.children == nil {
+		return nil, errors.Errorf("object %q has no children", o.name())
+	}
+
+	if index >= o.getNumChildren() {
+		return nil, errors.Errorf("index %d not possible; object %q has %d children", index, o.name(), o.getNumChildren())
+	}
+
+	cResult := C.node_get_child(o.cObj, C.int(index))
+	return newObject(o.topo, cResult), nil
+}
+
+func (o *object) getAncestorByType(objType int) (*object, error) {
+	cResult := C.hwloc_get_ancestor_obj_by_type(o.topo.raw(), C.hwloc_obj_type_t(objType), o.cObj)
+	if cResult == nil {
+		return nil, errors.Errorf("type %d ancestor of object %q not found", objType, o.name())
+	}
+
+	return newObject(o.topo, cResult), nil
+}
+
+func (o *object) getNonIOAncestor() (*object, error) {
+	cResult := C.hwloc_get_non_io_ancestor_obj(o.topo.raw(), o.cObj)
+	if cResult == nil {
+		return nil, errors.Errorf("unable to find non-io ancestor for object %q", o.name())
+	}
+
+	return newObject(o.topo, cResult), nil
+}
+
+func (o *object) cpuSet() *cpuSet {
+	return newCPUSet(o.topo, o.cObj.cpuset)
+}
+
+func (o *object) nodeSet() *nodeSet {
+	return newNodeSet(o.cObj.nodeset)
+}
+
+func (o *object) objType() int {
+	return int(o.cObj._type)
+}
+
+func (o *object) objTypeString() string {
+	switch o.objType() {
+	case objTypeNUMANode:
+		return "NUMA node"
+	case objTypeCore:
+		return "core"
+	case objTypePCIDevice:
+		return "PCI device"
+	case objTypeOSDevice:
+		return "OS device"
+	}
+	return "unknown object type"
+}
+
+func (o *object) osDevType() (int, error) {
+	if o.objType() != objTypeOSDevice {
+		return 0, errors.Errorf("device %q is not an OS Device", o.name())
+	}
+	devType := C.node_get_osdev_type(o.cObj)
+	if devType < 0 {
+		return 0, errors.Errorf("device %q attrs are nil", o.name())
+	}
+	return int(devType), nil
+}
+
+func (o *object) pciAddr() (string, error) {
+	if o.objType() != objTypePCIDevice {
+		return "", errors.Errorf("device %q is not a PCI Device", o.name())
+	}
+	pciDevAttr := C.node_get_pcidev_attr(o.cObj)
+	if pciDevAttr == nil {
+		return "", errors.Errorf("device %q attrs are nil", o.name())
+	}
+	return fmt.Sprintf("%04x:%02x:%02x.%01x", pciDevAttr.domain, pciDevAttr.bus,
+		pciDevAttr.dev, pciDevAttr._func), nil
+}
+
+func newObject(topo rawTopology, cObj C.hwloc_obj_t) *object {
+	if cObj == nil {
+		panic("nil hwloc_obj_t")
+	}
+	return &object{
+		cObj: cObj,
+		topo: topo,
+	}
+}
+
+type bitmap struct {
+	cSet C.hwloc_bitmap_t
+}
+
+func (b *bitmap) raw() C.hwloc_bitmap_t {
+	return b.cSet
+}
+
+func (b *bitmap) String() string {
+	var str *C.char
+
+	strLen := C.hwloc_bitmap_asprintf(&str, b.raw())
+	if strLen <= 0 {
+		return ""
+	}
+	defer C.free(unsafe.Pointer(str))
+	return C.GoString(str)
+}
+
+func (b *bitmap) intersectsBitmap(other *bitmap) bool {
+	return C.hwloc_bitmap_intersects(b.raw(), other.raw()) != 0
+}
+
+func (b *bitmap) isSubsetOfBitmap(other *bitmap) bool {
+	return C.hwloc_bitmap_isincluded(b.raw(), other.raw()) != 0
+}
+
+type cpuSet struct {
+	bitmap
+	topo rawTopology
+}
+
+func (c *cpuSet) intersects(other *cpuSet) bool {
+	return c.intersectsBitmap(&other.bitmap)
+}
+
+func (c *cpuSet) isSubsetOf(other *cpuSet) bool {
+	return c.isSubsetOfBitmap(&other.bitmap)
+}
+
+func (c *cpuSet) toNodeSet() (*nodeSet, func(), error) {
+	nodeset := C.hwloc_bitmap_alloc()
+	if nodeset == nil {
+		return nil, nil, errors.New("hwloc_bitmap_alloc failed")
+	}
+	cleanup := func() {
+		C.hwloc_bitmap_free(nodeset)
+	}
+	C.hwloc_cpuset_to_nodeset(c.topo.raw(), c.cSet, nodeset)
+
+	return newNodeSet(nodeset), cleanup, nil
+}
+
+type nodeSet struct {
+	bitmap
+}
+
+func (n *nodeSet) intersects(other *nodeSet) bool {
+	return n.intersectsBitmap(&other.bitmap)
+}
+
+func newCPUSet(topo rawTopology, cSet C.hwloc_bitmap_t) *cpuSet {
+	return &cpuSet{
+		bitmap: bitmap{
+			cSet: cSet,
+		},
+		topo: topo,
+	}
+}
+
+func newNodeSet(cSet C.hwloc_bitmap_t) *nodeSet {
+	return &nodeSet{
+		bitmap: bitmap{
+			cSet: cSet,
+		},
+	}
+}

--- a/src/control/lib/hardware/hwloc/provider.go
+++ b/src/control/lib/hardware/hwloc/provider.go
@@ -1,0 +1,278 @@
+//
+// (C) Copyright 2021 Intel Corporation.
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+
+package hwloc
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+
+	"github.com/daos-stack/daos/src/control/lib/hardware"
+	"github.com/daos-stack/daos/src/control/logging"
+)
+
+// NewProvider returns a new hwloc Provider.
+func NewProvider(log logging.Logger) *Provider {
+	return &Provider{
+		api: &api{},
+		log: log,
+	}
+}
+
+// Provider provides access to hwloc topology functionality.
+type Provider struct {
+	api *api
+	log logging.Logger
+}
+
+// GetTopology fetches a simplified hardware topology via hwloc.
+func (p *Provider) GetTopology(ctx context.Context) (*hardware.Topology, error) {
+	ch := make(chan topologyResult)
+	go p.getTopologyAsync(ch)
+
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case result := <-ch:
+		return result.topology, result.err
+	}
+}
+
+type topologyResult struct {
+	topology *hardware.Topology
+	err      error
+}
+
+func (p *Provider) getTopologyAsync(ch chan topologyResult) {
+	p.log.Debugf("getting topology with hwloc version 0x%x", p.api.compiledVersion())
+
+	topo, cleanup, err := p.initTopology()
+	if err != nil {
+		ch <- topologyResult{
+			err: err,
+		}
+		return
+	}
+	defer cleanup()
+
+	nodes, err := p.getNUMANodes(topo)
+	if err != nil {
+		ch <- topologyResult{
+			err: err,
+		}
+		return
+	}
+
+	ch <- topologyResult{
+		topology: &hardware.Topology{
+			NUMANodes: nodes,
+		},
+	}
+}
+
+// initTopo initializes the hwloc topology and returns it to the caller along with the topology
+// cleanup function.
+func (p *Provider) initTopology() (*topology, func(), error) {
+	if err := checkVersion(p.api); err != nil {
+		return nil, nil, err
+	}
+
+	p.api.Lock()
+	defer p.api.Unlock()
+
+	topo, cleanup, err := p.api.newTopology()
+	if err != nil {
+		return nil, nil, err
+	}
+	defer func() {
+		if err != nil {
+			cleanup()
+		}
+	}()
+
+	if err = topo.setFlags(); err != nil {
+		return nil, nil, err
+	}
+
+	if err = topo.load(); err != nil {
+		return nil, nil, err
+	}
+
+	return topo, cleanup, nil
+}
+
+// checkVersion verifies the runtime API is compatible with the compiled version of the API.
+func checkVersion(api *api) error {
+	version := api.runtimeVersion()
+	compVersion := api.compiledVersion()
+	if (version >> 16) != (compVersion >> 16) {
+		return errors.Errorf("hwloc API incompatible with runtime: compiled for version 0x%x but using 0x%x\n",
+			compVersion, version)
+	}
+	return nil
+}
+
+func (p *Provider) getNUMANodes(topo *topology) (map[uint]*hardware.NUMANode, error) {
+	coresByNode := p.getCoreCountsPerNodeSet(topo)
+	pciDevsByNode := p.getPCIDevsPerNUMANode(topo)
+
+	nodes := make(map[uint]*hardware.NUMANode)
+
+	prevNode := (*object)(nil)
+	for {
+		numaObj, err := topo.getNextObjByType(objTypeNUMANode, prevNode)
+		if err != nil {
+			break
+		}
+		prevNode = numaObj
+
+		nodeStr := numaObj.nodeSet().String()
+
+		id := numaObj.osIndex()
+		newNode := &hardware.NUMANode{
+			ID:       id,
+			NumCores: coresByNode[nodeStr],
+		}
+
+		if devs, exists := pciDevsByNode[id]; exists {
+			newNode.Devices = devs
+		} else {
+			newNode.Devices = make(hardware.PCIDevices)
+		}
+
+		nodes[id] = newNode
+	}
+
+	if len(nodes) == 0 {
+		// If hwloc didn't detect any NUMA nodes, create a virtual NUMA node 0
+		totalCores := uint(0)
+		for _, numCores := range coresByNode {
+			totalCores += numCores
+		}
+		nodes[0] = &hardware.NUMANode{
+			ID:       0,
+			NumCores: totalCores,
+			Devices:  pciDevsByNode[0],
+		}
+	}
+
+	return nodes, nil
+}
+
+func (p *Provider) getCoreCountsPerNodeSet(topo *topology) map[string]uint {
+	prevCore := (*object)(nil)
+	coresPerNode := make(map[string]uint)
+	for {
+		coreObj, err := topo.getNextObjByType(objTypeCore, prevCore)
+		if err != nil {
+			break
+		}
+
+		coresPerNode[coreObj.nodeSet().String()]++
+
+		prevCore = coreObj
+	}
+
+	return coresPerNode
+}
+
+func (p *Provider) getPCIDevsPerNUMANode(topo *topology) map[uint]hardware.PCIDevices {
+	pciPerNUMA := make(map[uint]hardware.PCIDevices)
+
+	prev := (*object)(nil)
+	for {
+		osDev, err := topo.getNextObjByType(objTypeOSDevice, prev)
+		if err != nil {
+			// end of the list
+			break
+		}
+		prev = osDev
+
+		osDevType, err := osDev.osDevType()
+		if err != nil {
+			// shouldn't be possible
+			p.log.Error(err.Error())
+			continue
+		}
+
+		switch osDevType {
+		case osDevTypeNetwork, osDevTypeOpenFabrics:
+			addr := "none"
+			if pciDev, err := osDev.getAncestorByType(objTypePCIDevice); err == nil {
+				addr, err = pciDev.pciAddr()
+				if err != nil {
+					// shouldn't be possible
+					p.log.Error(err.Error())
+				}
+			} else {
+				// unexpected - network devices should be on the PCI bus
+				p.log.Error(err.Error())
+
+			}
+
+			numaID := p.getDeviceNUMANodeID(osDev, topo)
+
+			if _, exists := pciPerNUMA[numaID]; !exists {
+				pciPerNUMA[numaID] = make(hardware.PCIDevices)
+			}
+
+			pciPerNUMA[numaID].Add(&hardware.Device{
+				Name:         osDev.name(),
+				Type:         osDevTypeToHardwareDevType(osDevType),
+				PCIAddr:      addr,
+				NUMAAffinity: numaID,
+			})
+		}
+	}
+
+	return pciPerNUMA
+}
+
+func (p *Provider) getDeviceNUMANodeID(dev *object, topo *topology) uint {
+	if numaNode, err := dev.getAncestorByType(objTypeNUMANode); err == nil {
+		return numaNode.osIndex()
+	}
+
+	// If we made it here, it means that we're running in some flavor of a restricted environment
+	// which caused the numa node ancestor lookup to fail.  We're not restricted from looking at the
+	// cpuset for each numa node, so we can look for an intersection of the node's cpuset with each
+	// numa node cpuset until a match is found or we run out of candidates.
+	ancestor, err := dev.getNonIOAncestor()
+	if err != nil {
+		p.log.Errorf(err.Error())
+		return 0
+	}
+
+	prev := (*object)(nil)
+	for {
+		numaNode, err := topo.getNextObjByType(objTypeNUMANode, prev)
+		if err != nil {
+			// end of list
+			break
+		}
+		prev = numaNode
+
+		if ancestor.cpuSet().isSubsetOf(numaNode.cpuSet()) {
+			return numaNode.osIndex()
+		}
+	}
+
+	p.log.Debugf("Unable to determine NUMA socket ID. Using NUMA 0")
+	return 0
+
+}
+
+func osDevTypeToHardwareDevType(osType int) hardware.DeviceType {
+	switch osType {
+	case osDevTypeNetwork:
+		return hardware.DeviceTypeNetInterface
+	case osDevTypeOpenFabrics:
+		return hardware.DeviceTypeOFIDomain
+	}
+
+	return hardware.DeviceTypeUnknown
+}

--- a/src/control/lib/hardware/hwloc/provider_test.go
+++ b/src/control/lib/hardware/hwloc/provider_test.go
@@ -1,0 +1,286 @@
+//
+// (C) Copyright 2021 Intel Corporation.
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+
+package hwloc
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/daos-stack/daos/src/control/common"
+	"github.com/daos-stack/daos/src/control/lib/hardware"
+	"github.com/daos-stack/daos/src/control/logging"
+)
+
+func TestHwlocProvider_GetTopology_Samples(t *testing.T) {
+	_, filename, _, _ := runtime.Caller(0)
+	testdataDir := filepath.Join(filepath.Dir(filename), "testdata")
+
+	// sample hwloc topologies taken from real systems
+	for name, tc := range map[string]struct {
+		hwlocXMLFile string
+		expResult    *hardware.Topology
+	}{
+		"boro-84": {
+			hwlocXMLFile: filepath.Join(testdataDir, "boro-84.xml"),
+			expResult: &hardware.Topology{
+				NUMANodes: map[uint]*hardware.NUMANode{
+					0: {
+						ID:       0,
+						NumCores: 24,
+						Devices: hardware.PCIDevices{
+							"0000:18:00.0": {
+								{
+									Name:    "ib0",
+									Type:    hardware.DeviceTypeNetInterface,
+									PCIAddr: "0000:18:00.0",
+								},
+								{
+									Name:    "hfi1_0",
+									Type:    hardware.DeviceTypeOFIDomain,
+									PCIAddr: "0000:18:00.0",
+								},
+							},
+							"0000:3d:00.0": {
+								{
+									Name:    "eth0",
+									Type:    hardware.DeviceTypeNetInterface,
+									PCIAddr: "0000:3d:00.0",
+								},
+								{
+									Name:    "i40iw1",
+									Type:    hardware.DeviceTypeOFIDomain,
+									PCIAddr: "0000:3d:00.0",
+								},
+							},
+							"0000:3d:00.1": {
+								{
+									Name:    "eth1",
+									Type:    hardware.DeviceTypeNetInterface,
+									PCIAddr: "0000:3d:00.1",
+								},
+								{
+									Name:    "i40iw0",
+									Type:    hardware.DeviceTypeOFIDomain,
+									PCIAddr: "0000:3d:00.1",
+								},
+							},
+						},
+					},
+					1: {
+						ID:       1,
+						NumCores: 24,
+						Devices:  hardware.PCIDevices{},
+					},
+				},
+			},
+		},
+		"wolf-133": {
+			hwlocXMLFile: filepath.Join(testdataDir, "wolf-133.xml"),
+			expResult: &hardware.Topology{
+				NUMANodes: map[uint]*hardware.NUMANode{
+					0: {
+						ID:       0,
+						NumCores: 24,
+						Devices: hardware.PCIDevices{
+							"0000:18:00.0": {
+								{
+									Name:    "ib0",
+									Type:    hardware.DeviceTypeNetInterface,
+									PCIAddr: "0000:18:00.0",
+								},
+								{
+									Name:    "hfi1_0",
+									Type:    hardware.DeviceTypeOFIDomain,
+									PCIAddr: "0000:18:00.0",
+								},
+							},
+							"0000:3d:00.0": {
+								{
+									Name:    "eth0",
+									Type:    hardware.DeviceTypeNetInterface,
+									PCIAddr: "0000:3d:00.0",
+								},
+								{
+									Name:    "i40iw1",
+									Type:    hardware.DeviceTypeOFIDomain,
+									PCIAddr: "0000:3d:00.0",
+								},
+							},
+							"0000:3d:00.1": {
+								{
+									Name:    "eth1",
+									Type:    hardware.DeviceTypeNetInterface,
+									PCIAddr: "0000:3d:00.1",
+								},
+								{
+									Name:    "i40iw0",
+									Type:    hardware.DeviceTypeOFIDomain,
+									PCIAddr: "0000:3d:00.1",
+								},
+							},
+						},
+					},
+					1: {
+						ID:       1,
+						NumCores: 24,
+						Devices: hardware.PCIDevices{
+							"0000:af:00.0": {
+								{
+									Name:         "ib1",
+									Type:         hardware.DeviceTypeNetInterface,
+									PCIAddr:      "0000:af:00.0",
+									NUMAAffinity: 1,
+								},
+								{
+									Name:         "hfi1_1",
+									Type:         hardware.DeviceTypeOFIDomain,
+									PCIAddr:      "0000:af:00.0",
+									NUMAAffinity: 1,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"no devices": {
+			hwlocXMLFile: filepath.Join(testdataDir, "gcp_topology.xml"),
+			expResult: &hardware.Topology{
+				NUMANodes: map[uint]*hardware.NUMANode{
+					0: {
+						ID:       0,
+						NumCores: 8,
+						Devices:  hardware.PCIDevices{},
+					},
+					1: {
+						ID:       1,
+						NumCores: 8,
+						Devices:  hardware.PCIDevices{},
+					},
+				},
+			},
+		},
+		"multiport": {
+			hwlocXMLFile: filepath.Join(testdataDir, "multiport_hfi_topology.xml"),
+			expResult: &hardware.Topology{
+				NUMANodes: map[uint]*hardware.NUMANode{
+					0: {
+						ID:       0,
+						NumCores: 8,
+						Devices: hardware.PCIDevices{
+							"0000:02:00.0": {
+								{
+									Name:    "ib0",
+									Type:    hardware.DeviceTypeNetInterface,
+									PCIAddr: "0000:02:00.0",
+								},
+								{
+									Name:    "enp2s0",
+									Type:    hardware.DeviceTypeNetInterface,
+									PCIAddr: "0000:02:00.0",
+								},
+								{
+									Name:    "mlx4_0",
+									Type:    hardware.DeviceTypeOFIDomain,
+									PCIAddr: "0000:02:00.0",
+								},
+							},
+							"0000:06:00.0": {
+								{
+									Name:    "enp6s0",
+									Type:    hardware.DeviceTypeNetInterface,
+									PCIAddr: "0000:06:00.0",
+								},
+							},
+						},
+					},
+					1: {
+						ID:       1,
+						NumCores: 8,
+						Devices: hardware.PCIDevices{
+							"0000:83:00.0": {
+								{
+									Name:         "ib1",
+									Type:         hardware.DeviceTypeNetInterface,
+									PCIAddr:      "0000:83:00.0",
+									NUMAAffinity: 1,
+								},
+								{
+									Name:         "ib2",
+									Type:         hardware.DeviceTypeNetInterface,
+									PCIAddr:      "0000:83:00.0",
+									NUMAAffinity: 1,
+								},
+								{
+									Name:         "mlx4_1",
+									Type:         hardware.DeviceTypeOFIDomain,
+									PCIAddr:      "0000:83:00.0",
+									NUMAAffinity: 1,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"no NUMA nodes in topology": {
+			hwlocXMLFile: filepath.Join(testdataDir, "no-numa-nodes.xml"),
+			expResult: &hardware.Topology{
+				NUMANodes: map[uint]*hardware.NUMANode{
+					0: {
+						ID:       0,
+						NumCores: 4,
+						Devices: hardware.PCIDevices{
+							"0000:18:00.0": {
+								{
+									Name:    "ib0",
+									Type:    hardware.DeviceTypeNetInterface,
+									PCIAddr: "0000:18:00.0",
+								},
+								{
+									Name:    "hfi1_0",
+									Type:    hardware.DeviceTypeOFIDomain,
+									PCIAddr: "0000:18:00.0",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			log, buf := logging.NewTestLogger(name)
+			defer common.ShowBufferOnFailure(t, buf)
+
+			_, err := os.Stat(tc.hwlocXMLFile)
+			common.AssertEqual(t, err, nil, "unable to read hwloc XML file")
+			os.Setenv("HWLOC_XMLFILE", tc.hwlocXMLFile)
+			defer os.Unsetenv("HWLOC_XMLFILE")
+
+			provider := NewProvider(log)
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+
+			result, err := provider.GetTopology(ctx)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if diff := cmp.Diff(tc.expResult, result); diff != "" {
+				t.Errorf("(-want, +got)\n%s\n", diff)
+			}
+		})
+
+	}
+}

--- a/src/control/lib/hardware/hwloc/testdata/boro-84.xml
+++ b/src/control/lib/hardware/hwloc/testdata/boro-84.xml
@@ -1,0 +1,766 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE topology SYSTEM "hwloc.dtd">
+<topology>
+  <object type="Machine" os_index="0" cpuset="0xffffffff,0xffffffff,0xffffffff" complete_cpuset="0xffffffff,0xffffffff,0xffffffff" online_cpuset="0xffffffff,0xffffffff,0xffffffff" allowed_cpuset="0xffffffff,0xffffffff,0xffffffff" nodeset="0x00000003" complete_nodeset="0x00000003" allowed_nodeset="0x00000003">
+    <page_type size="4096" count="0"/>
+    <page_type size="2097152" count="0"/>
+    <page_type size="1073741824" count="0"/>
+    <info name="DMIProductName" value="S2600WFT"/>
+    <info name="DMIProductVersion" value="R2208WFTZS"/>
+    <info name="DMIBoardVendor" value="Intel Corporation"/>
+    <info name="DMIBoardName" value="S2600WFT"/>
+    <info name="DMIBoardVersion" value="H48104-853"/>
+    <info name="DMIBoardAssetTag" value="Base Board Asset Tag"/>
+    <info name="DMIChassisVendor" value="..............................."/>
+    <info name="DMIChassisType" value="23"/>
+    <info name="DMIChassisVersion" value=".................."/>
+    <info name="DMIChassisAssetTag" value="...................."/>
+    <info name="DMIBIOSVendor" value="Intel Corporation"/>
+    <info name="DMIBIOSVersion" value="SE5C620.86B.0D.01.0286.011120190816"/>
+    <info name="DMIBIOSDate" value="01/11/2019"/>
+    <info name="DMISysVendor" value="Intel Corporation"/>
+    <info name="Backend" value="Linux"/>
+    <info name="LinuxCgroup" value="/"/>
+    <info name="OSName" value="Linux"/>
+    <info name="OSRelease" value="3.10.0-693.21.1.el7.x86_64"/>
+    <info name="OSVersion" value="#1 SMP Wed Mar 7 19:03:37 UTC 2018"/>
+    <info name="HostName" value="boro-84.boro.hpdd.intel.com"/>
+    <info name="Architecture" value="x86_64"/>
+    <info name="hwlocVersion" value="1.11.5"/>
+    <info name="ProcessName" value="lstopo"/>
+    <distances nbobjs="2" relative_depth="1" latency_base="10.000000">
+      <latency value="1.000000"/>
+      <latency value="2.100000"/>
+      <latency value="2.100000"/>
+      <latency value="1.000000"/>
+    </distances>
+    <object type="NUMANode" os_index="0" cpuset="0x000000ff,0xffff0000,0x00ffffff" complete_cpuset="0x000000ff,0xffff0000,0x00ffffff" online_cpuset="0x000000ff,0xffff0000,0x00ffffff" allowed_cpuset="0x000000ff,0xffff0000,0x00ffffff" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" local_memory="101673537536">
+      <page_type size="4096" count="23774065"/>
+      <page_type size="2097152" count="2048"/>
+      <page_type size="1073741824" count="0"/>
+      <object type="Package" os_index="0" cpuset="0x000000ff,0xffff0000,0x00ffffff" complete_cpuset="0x000000ff,0xffff0000,0x00ffffff" online_cpuset="0x000000ff,0xffff0000,0x00ffffff" allowed_cpuset="0x000000ff,0xffff0000,0x00ffffff" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+        <info name="CPUVendor" value="GenuineIntel"/>
+        <info name="CPUFamilyNumber" value="6"/>
+        <info name="CPUModelNumber" value="85"/>
+        <info name="CPUModel" value="Intel(R) Xeon(R) Platinum 8260L CPU @ 2.40GHz"/>
+        <info name="CPUStepping" value="6"/>
+        <object type="Cache" cpuset="0x000000ff,0xffff0000,0x00ffffff" complete_cpuset="0x000000ff,0xffff0000,0x00ffffff" online_cpuset="0x000000ff,0xffff0000,0x00ffffff" allowed_cpuset="0x000000ff,0xffff0000,0x00ffffff" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="37486592" depth="3" cache_linesize="64" cache_associativity="11" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="Cache" cpuset="0x00010000,0x00000001" complete_cpuset="0x00010000,0x00000001" online_cpuset="0x00010000,0x00000001" allowed_cpuset="0x00010000,0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x00010000,0x00000001" complete_cpuset="0x00010000,0x00000001" online_cpuset="0x00010000,0x00000001" allowed_cpuset="0x00010000,0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00010000,0x00000001" complete_cpuset="0x00010000,0x00000001" online_cpuset="0x00010000,0x00000001" allowed_cpuset="0x00010000,0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="0" cpuset="0x00010000,0x00000001" complete_cpuset="0x00010000,0x00000001" online_cpuset="0x00010000,0x00000001" allowed_cpuset="0x00010000,0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="0" cpuset="0x00000001" complete_cpuset="0x00000001" online_cpuset="0x00000001" allowed_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="48" cpuset="0x00010000,0x0" complete_cpuset="0x00010000,0x0" online_cpuset="0x00010000,0x0" allowed_cpuset="0x00010000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00020000,0x00000002" complete_cpuset="0x00020000,0x00000002" online_cpuset="0x00020000,0x00000002" allowed_cpuset="0x00020000,0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x00020000,0x00000002" complete_cpuset="0x00020000,0x00000002" online_cpuset="0x00020000,0x00000002" allowed_cpuset="0x00020000,0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00020000,0x00000002" complete_cpuset="0x00020000,0x00000002" online_cpuset="0x00020000,0x00000002" allowed_cpuset="0x00020000,0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="1" cpuset="0x00020000,0x00000002" complete_cpuset="0x00020000,0x00000002" online_cpuset="0x00020000,0x00000002" allowed_cpuset="0x00020000,0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="1" cpuset="0x00000002" complete_cpuset="0x00000002" online_cpuset="0x00000002" allowed_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="49" cpuset="0x00020000,0x0" complete_cpuset="0x00020000,0x0" online_cpuset="0x00020000,0x0" allowed_cpuset="0x00020000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00040000,0x00000004" complete_cpuset="0x00040000,0x00000004" online_cpuset="0x00040000,0x00000004" allowed_cpuset="0x00040000,0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x00040000,0x00000004" complete_cpuset="0x00040000,0x00000004" online_cpuset="0x00040000,0x00000004" allowed_cpuset="0x00040000,0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00040000,0x00000004" complete_cpuset="0x00040000,0x00000004" online_cpuset="0x00040000,0x00000004" allowed_cpuset="0x00040000,0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="2" cpuset="0x00040000,0x00000004" complete_cpuset="0x00040000,0x00000004" online_cpuset="0x00040000,0x00000004" allowed_cpuset="0x00040000,0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="2" cpuset="0x00000004" complete_cpuset="0x00000004" online_cpuset="0x00000004" allowed_cpuset="0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="50" cpuset="0x00040000,0x0" complete_cpuset="0x00040000,0x0" online_cpuset="0x00040000,0x0" allowed_cpuset="0x00040000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00080000,0x00000008" complete_cpuset="0x00080000,0x00000008" online_cpuset="0x00080000,0x00000008" allowed_cpuset="0x00080000,0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x00080000,0x00000008" complete_cpuset="0x00080000,0x00000008" online_cpuset="0x00080000,0x00000008" allowed_cpuset="0x00080000,0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00080000,0x00000008" complete_cpuset="0x00080000,0x00000008" online_cpuset="0x00080000,0x00000008" allowed_cpuset="0x00080000,0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="3" cpuset="0x00080000,0x00000008" complete_cpuset="0x00080000,0x00000008" online_cpuset="0x00080000,0x00000008" allowed_cpuset="0x00080000,0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="3" cpuset="0x00000008" complete_cpuset="0x00000008" online_cpuset="0x00000008" allowed_cpuset="0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="51" cpuset="0x00080000,0x0" complete_cpuset="0x00080000,0x0" online_cpuset="0x00080000,0x0" allowed_cpuset="0x00080000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00100000,0x00000010" complete_cpuset="0x00100000,0x00000010" online_cpuset="0x00100000,0x00000010" allowed_cpuset="0x00100000,0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x00100000,0x00000010" complete_cpuset="0x00100000,0x00000010" online_cpuset="0x00100000,0x00000010" allowed_cpuset="0x00100000,0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00100000,0x00000010" complete_cpuset="0x00100000,0x00000010" online_cpuset="0x00100000,0x00000010" allowed_cpuset="0x00100000,0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="4" cpuset="0x00100000,0x00000010" complete_cpuset="0x00100000,0x00000010" online_cpuset="0x00100000,0x00000010" allowed_cpuset="0x00100000,0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="4" cpuset="0x00000010" complete_cpuset="0x00000010" online_cpuset="0x00000010" allowed_cpuset="0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="52" cpuset="0x00100000,0x0" complete_cpuset="0x00100000,0x0" online_cpuset="0x00100000,0x0" allowed_cpuset="0x00100000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00200000,0x00000020" complete_cpuset="0x00200000,0x00000020" online_cpuset="0x00200000,0x00000020" allowed_cpuset="0x00200000,0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x00200000,0x00000020" complete_cpuset="0x00200000,0x00000020" online_cpuset="0x00200000,0x00000020" allowed_cpuset="0x00200000,0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00200000,0x00000020" complete_cpuset="0x00200000,0x00000020" online_cpuset="0x00200000,0x00000020" allowed_cpuset="0x00200000,0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="5" cpuset="0x00200000,0x00000020" complete_cpuset="0x00200000,0x00000020" online_cpuset="0x00200000,0x00000020" allowed_cpuset="0x00200000,0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="5" cpuset="0x00000020" complete_cpuset="0x00000020" online_cpuset="0x00000020" allowed_cpuset="0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="53" cpuset="0x00200000,0x0" complete_cpuset="0x00200000,0x0" online_cpuset="0x00200000,0x0" allowed_cpuset="0x00200000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00400000,0x00000040" complete_cpuset="0x00400000,0x00000040" online_cpuset="0x00400000,0x00000040" allowed_cpuset="0x00400000,0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x00400000,0x00000040" complete_cpuset="0x00400000,0x00000040" online_cpuset="0x00400000,0x00000040" allowed_cpuset="0x00400000,0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00400000,0x00000040" complete_cpuset="0x00400000,0x00000040" online_cpuset="0x00400000,0x00000040" allowed_cpuset="0x00400000,0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="6" cpuset="0x00400000,0x00000040" complete_cpuset="0x00400000,0x00000040" online_cpuset="0x00400000,0x00000040" allowed_cpuset="0x00400000,0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="6" cpuset="0x00000040" complete_cpuset="0x00000040" online_cpuset="0x00000040" allowed_cpuset="0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="54" cpuset="0x00400000,0x0" complete_cpuset="0x00400000,0x0" online_cpuset="0x00400000,0x0" allowed_cpuset="0x00400000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00800000,0x00000080" complete_cpuset="0x00800000,0x00000080" online_cpuset="0x00800000,0x00000080" allowed_cpuset="0x00800000,0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x00800000,0x00000080" complete_cpuset="0x00800000,0x00000080" online_cpuset="0x00800000,0x00000080" allowed_cpuset="0x00800000,0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00800000,0x00000080" complete_cpuset="0x00800000,0x00000080" online_cpuset="0x00800000,0x00000080" allowed_cpuset="0x00800000,0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="8" cpuset="0x00800000,0x00000080" complete_cpuset="0x00800000,0x00000080" online_cpuset="0x00800000,0x00000080" allowed_cpuset="0x00800000,0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="7" cpuset="0x00000080" complete_cpuset="0x00000080" online_cpuset="0x00000080" allowed_cpuset="0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="55" cpuset="0x00800000,0x0" complete_cpuset="0x00800000,0x0" online_cpuset="0x00800000,0x0" allowed_cpuset="0x00800000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x01000000,0x00000100" complete_cpuset="0x01000000,0x00000100" online_cpuset="0x01000000,0x00000100" allowed_cpuset="0x01000000,0x00000100" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x01000000,0x00000100" complete_cpuset="0x01000000,0x00000100" online_cpuset="0x01000000,0x00000100" allowed_cpuset="0x01000000,0x00000100" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x01000000,0x00000100" complete_cpuset="0x01000000,0x00000100" online_cpuset="0x01000000,0x00000100" allowed_cpuset="0x01000000,0x00000100" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="9" cpuset="0x01000000,0x00000100" complete_cpuset="0x01000000,0x00000100" online_cpuset="0x01000000,0x00000100" allowed_cpuset="0x01000000,0x00000100" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="8" cpuset="0x00000100" complete_cpuset="0x00000100" online_cpuset="0x00000100" allowed_cpuset="0x00000100" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="56" cpuset="0x01000000,0x0" complete_cpuset="0x01000000,0x0" online_cpuset="0x01000000,0x0" allowed_cpuset="0x01000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x02000000,0x00000200" complete_cpuset="0x02000000,0x00000200" online_cpuset="0x02000000,0x00000200" allowed_cpuset="0x02000000,0x00000200" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x02000000,0x00000200" complete_cpuset="0x02000000,0x00000200" online_cpuset="0x02000000,0x00000200" allowed_cpuset="0x02000000,0x00000200" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x02000000,0x00000200" complete_cpuset="0x02000000,0x00000200" online_cpuset="0x02000000,0x00000200" allowed_cpuset="0x02000000,0x00000200" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="10" cpuset="0x02000000,0x00000200" complete_cpuset="0x02000000,0x00000200" online_cpuset="0x02000000,0x00000200" allowed_cpuset="0x02000000,0x00000200" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="9" cpuset="0x00000200" complete_cpuset="0x00000200" online_cpuset="0x00000200" allowed_cpuset="0x00000200" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="57" cpuset="0x02000000,0x0" complete_cpuset="0x02000000,0x0" online_cpuset="0x02000000,0x0" allowed_cpuset="0x02000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x04000000,0x00000400" complete_cpuset="0x04000000,0x00000400" online_cpuset="0x04000000,0x00000400" allowed_cpuset="0x04000000,0x00000400" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x04000000,0x00000400" complete_cpuset="0x04000000,0x00000400" online_cpuset="0x04000000,0x00000400" allowed_cpuset="0x04000000,0x00000400" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x04000000,0x00000400" complete_cpuset="0x04000000,0x00000400" online_cpuset="0x04000000,0x00000400" allowed_cpuset="0x04000000,0x00000400" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="11" cpuset="0x04000000,0x00000400" complete_cpuset="0x04000000,0x00000400" online_cpuset="0x04000000,0x00000400" allowed_cpuset="0x04000000,0x00000400" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="10" cpuset="0x00000400" complete_cpuset="0x00000400" online_cpuset="0x00000400" allowed_cpuset="0x00000400" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="58" cpuset="0x04000000,0x0" complete_cpuset="0x04000000,0x0" online_cpuset="0x04000000,0x0" allowed_cpuset="0x04000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x08000000,0x00000800" complete_cpuset="0x08000000,0x00000800" online_cpuset="0x08000000,0x00000800" allowed_cpuset="0x08000000,0x00000800" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x08000000,0x00000800" complete_cpuset="0x08000000,0x00000800" online_cpuset="0x08000000,0x00000800" allowed_cpuset="0x08000000,0x00000800" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x08000000,0x00000800" complete_cpuset="0x08000000,0x00000800" online_cpuset="0x08000000,0x00000800" allowed_cpuset="0x08000000,0x00000800" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="12" cpuset="0x08000000,0x00000800" complete_cpuset="0x08000000,0x00000800" online_cpuset="0x08000000,0x00000800" allowed_cpuset="0x08000000,0x00000800" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="11" cpuset="0x00000800" complete_cpuset="0x00000800" online_cpuset="0x00000800" allowed_cpuset="0x00000800" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="59" cpuset="0x08000000,0x0" complete_cpuset="0x08000000,0x0" online_cpuset="0x08000000,0x0" allowed_cpuset="0x08000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x10000000,0x00001000" complete_cpuset="0x10000000,0x00001000" online_cpuset="0x10000000,0x00001000" allowed_cpuset="0x10000000,0x00001000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x10000000,0x00001000" complete_cpuset="0x10000000,0x00001000" online_cpuset="0x10000000,0x00001000" allowed_cpuset="0x10000000,0x00001000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x10000000,0x00001000" complete_cpuset="0x10000000,0x00001000" online_cpuset="0x10000000,0x00001000" allowed_cpuset="0x10000000,0x00001000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="13" cpuset="0x10000000,0x00001000" complete_cpuset="0x10000000,0x00001000" online_cpuset="0x10000000,0x00001000" allowed_cpuset="0x10000000,0x00001000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="12" cpuset="0x00001000" complete_cpuset="0x00001000" online_cpuset="0x00001000" allowed_cpuset="0x00001000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="60" cpuset="0x10000000,0x0" complete_cpuset="0x10000000,0x0" online_cpuset="0x10000000,0x0" allowed_cpuset="0x10000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x20000000,0x00002000" complete_cpuset="0x20000000,0x00002000" online_cpuset="0x20000000,0x00002000" allowed_cpuset="0x20000000,0x00002000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x20000000,0x00002000" complete_cpuset="0x20000000,0x00002000" online_cpuset="0x20000000,0x00002000" allowed_cpuset="0x20000000,0x00002000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x20000000,0x00002000" complete_cpuset="0x20000000,0x00002000" online_cpuset="0x20000000,0x00002000" allowed_cpuset="0x20000000,0x00002000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="16" cpuset="0x20000000,0x00002000" complete_cpuset="0x20000000,0x00002000" online_cpuset="0x20000000,0x00002000" allowed_cpuset="0x20000000,0x00002000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="13" cpuset="0x00002000" complete_cpuset="0x00002000" online_cpuset="0x00002000" allowed_cpuset="0x00002000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="61" cpuset="0x20000000,0x0" complete_cpuset="0x20000000,0x0" online_cpuset="0x20000000,0x0" allowed_cpuset="0x20000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x40000000,0x00004000" complete_cpuset="0x40000000,0x00004000" online_cpuset="0x40000000,0x00004000" allowed_cpuset="0x40000000,0x00004000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x40000000,0x00004000" complete_cpuset="0x40000000,0x00004000" online_cpuset="0x40000000,0x00004000" allowed_cpuset="0x40000000,0x00004000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x40000000,0x00004000" complete_cpuset="0x40000000,0x00004000" online_cpuset="0x40000000,0x00004000" allowed_cpuset="0x40000000,0x00004000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="17" cpuset="0x40000000,0x00004000" complete_cpuset="0x40000000,0x00004000" online_cpuset="0x40000000,0x00004000" allowed_cpuset="0x40000000,0x00004000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="14" cpuset="0x00004000" complete_cpuset="0x00004000" online_cpuset="0x00004000" allowed_cpuset="0x00004000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="62" cpuset="0x40000000,0x0" complete_cpuset="0x40000000,0x0" online_cpuset="0x40000000,0x0" allowed_cpuset="0x40000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x80000000,0x00008000" complete_cpuset="0x80000000,0x00008000" online_cpuset="0x80000000,0x00008000" allowed_cpuset="0x80000000,0x00008000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x80000000,0x00008000" complete_cpuset="0x80000000,0x00008000" online_cpuset="0x80000000,0x00008000" allowed_cpuset="0x80000000,0x00008000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x80000000,0x00008000" complete_cpuset="0x80000000,0x00008000" online_cpuset="0x80000000,0x00008000" allowed_cpuset="0x80000000,0x00008000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="18" cpuset="0x80000000,0x00008000" complete_cpuset="0x80000000,0x00008000" online_cpuset="0x80000000,0x00008000" allowed_cpuset="0x80000000,0x00008000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="15" cpuset="0x00008000" complete_cpuset="0x00008000" online_cpuset="0x00008000" allowed_cpuset="0x00008000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="63" cpuset="0x80000000,0x0" complete_cpuset="0x80000000,0x0" online_cpuset="0x80000000,0x0" allowed_cpuset="0x80000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000001,,0x00010000" complete_cpuset="0x00000001,,0x00010000" online_cpuset="0x00000001,,0x00010000" allowed_cpuset="0x00000001,,0x00010000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x00000001,,0x00010000" complete_cpuset="0x00000001,,0x00010000" online_cpuset="0x00000001,,0x00010000" allowed_cpuset="0x00000001,,0x00010000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000001,,0x00010000" complete_cpuset="0x00000001,,0x00010000" online_cpuset="0x00000001,,0x00010000" allowed_cpuset="0x00000001,,0x00010000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="19" cpuset="0x00000001,,0x00010000" complete_cpuset="0x00000001,,0x00010000" online_cpuset="0x00000001,,0x00010000" allowed_cpuset="0x00000001,,0x00010000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="16" cpuset="0x00010000" complete_cpuset="0x00010000" online_cpuset="0x00010000" allowed_cpuset="0x00010000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="64" cpuset="0x00000001,,0x0" complete_cpuset="0x00000001,,0x0" online_cpuset="0x00000001,,0x0" allowed_cpuset="0x00000001,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000002,,0x00020000" complete_cpuset="0x00000002,,0x00020000" online_cpuset="0x00000002,,0x00020000" allowed_cpuset="0x00000002,,0x00020000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x00000002,,0x00020000" complete_cpuset="0x00000002,,0x00020000" online_cpuset="0x00000002,,0x00020000" allowed_cpuset="0x00000002,,0x00020000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000002,,0x00020000" complete_cpuset="0x00000002,,0x00020000" online_cpuset="0x00000002,,0x00020000" allowed_cpuset="0x00000002,,0x00020000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="20" cpuset="0x00000002,,0x00020000" complete_cpuset="0x00000002,,0x00020000" online_cpuset="0x00000002,,0x00020000" allowed_cpuset="0x00000002,,0x00020000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="17" cpuset="0x00020000" complete_cpuset="0x00020000" online_cpuset="0x00020000" allowed_cpuset="0x00020000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="65" cpuset="0x00000002,,0x0" complete_cpuset="0x00000002,,0x0" online_cpuset="0x00000002,,0x0" allowed_cpuset="0x00000002,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000004,,0x00040000" complete_cpuset="0x00000004,,0x00040000" online_cpuset="0x00000004,,0x00040000" allowed_cpuset="0x00000004,,0x00040000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x00000004,,0x00040000" complete_cpuset="0x00000004,,0x00040000" online_cpuset="0x00000004,,0x00040000" allowed_cpuset="0x00000004,,0x00040000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000004,,0x00040000" complete_cpuset="0x00000004,,0x00040000" online_cpuset="0x00000004,,0x00040000" allowed_cpuset="0x00000004,,0x00040000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="21" cpuset="0x00000004,,0x00040000" complete_cpuset="0x00000004,,0x00040000" online_cpuset="0x00000004,,0x00040000" allowed_cpuset="0x00000004,,0x00040000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="18" cpuset="0x00040000" complete_cpuset="0x00040000" online_cpuset="0x00040000" allowed_cpuset="0x00040000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="66" cpuset="0x00000004,,0x0" complete_cpuset="0x00000004,,0x0" online_cpuset="0x00000004,,0x0" allowed_cpuset="0x00000004,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000008,,0x00080000" complete_cpuset="0x00000008,,0x00080000" online_cpuset="0x00000008,,0x00080000" allowed_cpuset="0x00000008,,0x00080000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x00000008,,0x00080000" complete_cpuset="0x00000008,,0x00080000" online_cpuset="0x00000008,,0x00080000" allowed_cpuset="0x00000008,,0x00080000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000008,,0x00080000" complete_cpuset="0x00000008,,0x00080000" online_cpuset="0x00000008,,0x00080000" allowed_cpuset="0x00000008,,0x00080000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="25" cpuset="0x00000008,,0x00080000" complete_cpuset="0x00000008,,0x00080000" online_cpuset="0x00000008,,0x00080000" allowed_cpuset="0x00000008,,0x00080000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="19" cpuset="0x00080000" complete_cpuset="0x00080000" online_cpuset="0x00080000" allowed_cpuset="0x00080000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="67" cpuset="0x00000008,,0x0" complete_cpuset="0x00000008,,0x0" online_cpuset="0x00000008,,0x0" allowed_cpuset="0x00000008,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000010,,0x00100000" complete_cpuset="0x00000010,,0x00100000" online_cpuset="0x00000010,,0x00100000" allowed_cpuset="0x00000010,,0x00100000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x00000010,,0x00100000" complete_cpuset="0x00000010,,0x00100000" online_cpuset="0x00000010,,0x00100000" allowed_cpuset="0x00000010,,0x00100000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000010,,0x00100000" complete_cpuset="0x00000010,,0x00100000" online_cpuset="0x00000010,,0x00100000" allowed_cpuset="0x00000010,,0x00100000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="26" cpuset="0x00000010,,0x00100000" complete_cpuset="0x00000010,,0x00100000" online_cpuset="0x00000010,,0x00100000" allowed_cpuset="0x00000010,,0x00100000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="20" cpuset="0x00100000" complete_cpuset="0x00100000" online_cpuset="0x00100000" allowed_cpuset="0x00100000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="68" cpuset="0x00000010,,0x0" complete_cpuset="0x00000010,,0x0" online_cpuset="0x00000010,,0x0" allowed_cpuset="0x00000010,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000020,,0x00200000" complete_cpuset="0x00000020,,0x00200000" online_cpuset="0x00000020,,0x00200000" allowed_cpuset="0x00000020,,0x00200000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x00000020,,0x00200000" complete_cpuset="0x00000020,,0x00200000" online_cpuset="0x00000020,,0x00200000" allowed_cpuset="0x00000020,,0x00200000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000020,,0x00200000" complete_cpuset="0x00000020,,0x00200000" online_cpuset="0x00000020,,0x00200000" allowed_cpuset="0x00000020,,0x00200000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="27" cpuset="0x00000020,,0x00200000" complete_cpuset="0x00000020,,0x00200000" online_cpuset="0x00000020,,0x00200000" allowed_cpuset="0x00000020,,0x00200000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="21" cpuset="0x00200000" complete_cpuset="0x00200000" online_cpuset="0x00200000" allowed_cpuset="0x00200000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="69" cpuset="0x00000020,,0x0" complete_cpuset="0x00000020,,0x0" online_cpuset="0x00000020,,0x0" allowed_cpuset="0x00000020,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000040,,0x00400000" complete_cpuset="0x00000040,,0x00400000" online_cpuset="0x00000040,,0x00400000" allowed_cpuset="0x00000040,,0x00400000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x00000040,,0x00400000" complete_cpuset="0x00000040,,0x00400000" online_cpuset="0x00000040,,0x00400000" allowed_cpuset="0x00000040,,0x00400000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000040,,0x00400000" complete_cpuset="0x00000040,,0x00400000" online_cpuset="0x00000040,,0x00400000" allowed_cpuset="0x00000040,,0x00400000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="28" cpuset="0x00000040,,0x00400000" complete_cpuset="0x00000040,,0x00400000" online_cpuset="0x00000040,,0x00400000" allowed_cpuset="0x00000040,,0x00400000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="22" cpuset="0x00400000" complete_cpuset="0x00400000" online_cpuset="0x00400000" allowed_cpuset="0x00400000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="70" cpuset="0x00000040,,0x0" complete_cpuset="0x00000040,,0x0" online_cpuset="0x00000040,,0x0" allowed_cpuset="0x00000040,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000080,,0x00800000" complete_cpuset="0x00000080,,0x00800000" online_cpuset="0x00000080,,0x00800000" allowed_cpuset="0x00000080,,0x00800000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x00000080,,0x00800000" complete_cpuset="0x00000080,,0x00800000" online_cpuset="0x00000080,,0x00800000" allowed_cpuset="0x00000080,,0x00800000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000080,,0x00800000" complete_cpuset="0x00000080,,0x00800000" online_cpuset="0x00000080,,0x00800000" allowed_cpuset="0x00000080,,0x00800000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="29" cpuset="0x00000080,,0x00800000" complete_cpuset="0x00000080,,0x00800000" online_cpuset="0x00000080,,0x00800000" allowed_cpuset="0x00000080,,0x00800000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="23" cpuset="0x00800000" complete_cpuset="0x00800000" online_cpuset="0x00800000" allowed_cpuset="0x00800000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="71" cpuset="0x00000080,,0x0" complete_cpuset="0x00000080,,0x0" online_cpuset="0x00000080,,0x0" allowed_cpuset="0x00000080,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="Bridge" os_index="0" bridge_type="0-1" depth="0" bridge_pci="0000:[00-02]">
+        <object type="PCIDev" os_index="277" pci_busid="0000:00:11.5" pci_type="0106 [8086:a1d2] [8086:35ce] 09" pci_link_speed="0.000000">
+          <object type="OSDev" name="sda" osdev_type="0">
+            <info name="LinuxDeviceID" value="8:0"/>
+            <info name="Model" value="INTEL_SSDSCKKI256G8"/>
+            <info name="Revision" value="LHF001D"/>
+            <info name="SerialNumber" value="BTLA80121CE5256J"/>
+            <info name="Type" value="Disk"/>
+          </object>
+        </object>
+        <object type="PCIDev" os_index="368" pci_busid="0000:00:17.0" pci_type="0106 [8086:a182] [8086:35ce] 09" pci_link_speed="0.000000"/>
+        <object type="Bridge" os_index="448" bridge_type="1-1" depth="1" bridge_pci="0000:[01-02]" pci_busid="0000:00:1c.0" pci_type="0604 [8086:a193] [8086:35ce] f9" pci_link_speed="0.000000">
+          <object type="Bridge" os_index="4096" bridge_type="1-1" depth="2" bridge_pci="0000:[02-02]" pci_busid="0000:01:00.0" pci_type="0604 [1a03:1150] [1a03:1150] 04" pci_link_speed="0.000000">
+            <object type="PCIDev" os_index="8192" pci_busid="0000:02:00.0" pci_type="0300 [1a03:2000] [1a03:2000] 41" pci_link_speed="0.000000">
+              <object type="OSDev" name="card0" osdev_type="1"/>
+              <object type="OSDev" name="controlD64" osdev_type="1"/>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="Bridge" os_index="1" bridge_type="0-1" depth="0" bridge_pci="0000:[17-18]">
+        <object type="Bridge" os_index="94208" bridge_type="1-1" depth="1" bridge_pci="0000:[18-18]" pci_busid="0000:17:00.0" pci_type="0604 [8086:2030] [8086:35ce] 06" pci_link_speed="0.000000">
+          <info name="PCISlot" value="785"/>
+          <object type="PCIDev" os_index="98304" pci_busid="0000:18:00.0" pci_type="0208 [8086:24f0] [8086:24f0] 11" pci_link_speed="0.000000">
+            <object type="OSDev" name="ib0" osdev_type="2">
+              <info name="Address" value="80:00:00:02:fe:80:00:00:00:00:00:00:00:11:75:09:01:05:64:4f"/>
+              <info name="Port" value="1"/>
+            </object>
+            <object type="OSDev" name="hfi1_0" osdev_type="3">
+              <info name="NodeGUID" value="0011:7509:0105:644f"/>
+              <info name="SysImageGUID" value="0011:7509:0105:644f"/>
+              <info name="Port1State" value="4"/>
+              <info name="Port1LID" value="0x59"/>
+              <info name="Port1LMC" value="0"/>
+              <info name="Port1GID0" value="fe80:0000:0000:0000:0011:7509:0105:644f"/>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="Bridge" os_index="2" bridge_type="0-1" depth="0" bridge_pci="0000:[3a-3e]">
+        <object type="Bridge" os_index="237568" bridge_type="1-1" depth="1" bridge_pci="0000:[3b-3e]" pci_busid="0000:3a:00.0" pci_type="0604 [8086:2030] [8086:35ce] 06" pci_link_speed="0.000000">
+          <info name="PCISlot" value="0-1"/>
+          <object type="Bridge" os_index="241664" bridge_type="1-1" depth="2" bridge_pci="0000:[3c-3e]" pci_busid="0000:3b:00.0" pci_type="0604 [8086:37c0] [8086:dead] 09" pci_link_speed="0.000000">
+            <object type="Bridge" os_index="245808" bridge_type="1-1" depth="3" bridge_pci="0000:[3d-3e]" pci_busid="0000:3c:03.0" pci_type="0604 [8086:37c5] [8086:dead] 09" pci_link_speed="0.000000">
+              <object type="PCIDev" os_index="249856" pci_busid="0000:3d:00.0" pci_type="0200 [8086:37d2] [8086:35ce] 09" pci_link_speed="0.000000">
+                <object type="OSDev" name="eth0" osdev_type="2">
+                  <info name="Address" value="a4:bf:01:58:31:0b"/>
+                  <info name="Port" value="1"/>
+                </object>
+                <object type="OSDev" name="i40iw1" osdev_type="3">
+                  <info name="NodeGUID" value="a4bf:0158:310b:0000"/>
+                  <info name="SysImageGUID" value="a4bf:0158:310b:0000"/>
+                  <info name="Port1State" value="4"/>
+                  <info name="Port1LID" value="0x1"/>
+                  <info name="Port1LMC" value="0"/>
+                </object>
+              </object>
+              <object type="PCIDev" os_index="249857" pci_busid="0000:3d:00.1" pci_type="0200 [8086:37d2] [8086:35ce] 09" pci_link_speed="0.000000">
+                <object type="OSDev" name="eth1" osdev_type="2">
+                  <info name="Address" value="a4:bf:01:58:31:0c"/>
+                  <info name="Port" value="1"/>
+                </object>
+                <object type="OSDev" name="i40iw0" osdev_type="3">
+                  <info name="NodeGUID" value="a4bf:0158:310c:0000"/>
+                  <info name="SysImageGUID" value="a4bf:0158:310c:0000"/>
+                  <info name="Port1State" value="1"/>
+                  <info name="Port1LID" value="0x1"/>
+                  <info name="Port1LMC" value="0"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+    </object>
+    <object type="NUMANode" os_index="1" cpuset="0xffffff00,0x0000ffff,0xff000000" complete_cpuset="0xffffff00,0x0000ffff,0xff000000" online_cpuset="0xffffff00,0x0000ffff,0xff000000" allowed_cpuset="0xffffff00,0x0000ffff,0xff000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" local_memory="103079215104">
+      <page_type size="4096" count="24117248"/>
+      <page_type size="2097152" count="2048"/>
+      <page_type size="1073741824" count="0"/>
+      <object type="Package" os_index="1" cpuset="0xffffff00,0x0000ffff,0xff000000" complete_cpuset="0xffffff00,0x0000ffff,0xff000000" online_cpuset="0xffffff00,0x0000ffff,0xff000000" allowed_cpuset="0xffffff00,0x0000ffff,0xff000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+        <info name="CPUVendor" value="GenuineIntel"/>
+        <info name="CPUFamilyNumber" value="6"/>
+        <info name="CPUModelNumber" value="85"/>
+        <info name="CPUModel" value="Intel(R) Xeon(R) Platinum 8260L CPU @ 2.40GHz"/>
+        <info name="CPUStepping" value="6"/>
+        <object type="Cache" cpuset="0xffffff00,0x0000ffff,0xff000000" complete_cpuset="0xffffff00,0x0000ffff,0xff000000" online_cpuset="0xffffff00,0x0000ffff,0xff000000" allowed_cpuset="0xffffff00,0x0000ffff,0xff000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="37486592" depth="3" cache_linesize="64" cache_associativity="11" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="Cache" cpuset="0x00000100,,0x01000000" complete_cpuset="0x00000100,,0x01000000" online_cpuset="0x00000100,,0x01000000" allowed_cpuset="0x00000100,,0x01000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x00000100,,0x01000000" complete_cpuset="0x00000100,,0x01000000" online_cpuset="0x00000100,,0x01000000" allowed_cpuset="0x00000100,,0x01000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000100,,0x01000000" complete_cpuset="0x00000100,,0x01000000" online_cpuset="0x00000100,,0x01000000" allowed_cpuset="0x00000100,,0x01000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="0" cpuset="0x00000100,,0x01000000" complete_cpuset="0x00000100,,0x01000000" online_cpuset="0x00000100,,0x01000000" allowed_cpuset="0x00000100,,0x01000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="24" cpuset="0x01000000" complete_cpuset="0x01000000" online_cpuset="0x01000000" allowed_cpuset="0x01000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                  <object type="PU" os_index="72" cpuset="0x00000100,,0x0" complete_cpuset="0x00000100,,0x0" online_cpuset="0x00000100,,0x0" allowed_cpuset="0x00000100,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000200,,0x02000000" complete_cpuset="0x00000200,,0x02000000" online_cpuset="0x00000200,,0x02000000" allowed_cpuset="0x00000200,,0x02000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x00000200,,0x02000000" complete_cpuset="0x00000200,,0x02000000" online_cpuset="0x00000200,,0x02000000" allowed_cpuset="0x00000200,,0x02000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000200,,0x02000000" complete_cpuset="0x00000200,,0x02000000" online_cpuset="0x00000200,,0x02000000" allowed_cpuset="0x00000200,,0x02000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="1" cpuset="0x00000200,,0x02000000" complete_cpuset="0x00000200,,0x02000000" online_cpuset="0x00000200,,0x02000000" allowed_cpuset="0x00000200,,0x02000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="25" cpuset="0x02000000" complete_cpuset="0x02000000" online_cpuset="0x02000000" allowed_cpuset="0x02000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                  <object type="PU" os_index="73" cpuset="0x00000200,,0x0" complete_cpuset="0x00000200,,0x0" online_cpuset="0x00000200,,0x0" allowed_cpuset="0x00000200,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000400,,0x04000000" complete_cpuset="0x00000400,,0x04000000" online_cpuset="0x00000400,,0x04000000" allowed_cpuset="0x00000400,,0x04000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x00000400,,0x04000000" complete_cpuset="0x00000400,,0x04000000" online_cpuset="0x00000400,,0x04000000" allowed_cpuset="0x00000400,,0x04000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000400,,0x04000000" complete_cpuset="0x00000400,,0x04000000" online_cpuset="0x00000400,,0x04000000" allowed_cpuset="0x00000400,,0x04000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="2" cpuset="0x00000400,,0x04000000" complete_cpuset="0x00000400,,0x04000000" online_cpuset="0x00000400,,0x04000000" allowed_cpuset="0x00000400,,0x04000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="26" cpuset="0x04000000" complete_cpuset="0x04000000" online_cpuset="0x04000000" allowed_cpuset="0x04000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                  <object type="PU" os_index="74" cpuset="0x00000400,,0x0" complete_cpuset="0x00000400,,0x0" online_cpuset="0x00000400,,0x0" allowed_cpuset="0x00000400,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000800,,0x08000000" complete_cpuset="0x00000800,,0x08000000" online_cpuset="0x00000800,,0x08000000" allowed_cpuset="0x00000800,,0x08000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x00000800,,0x08000000" complete_cpuset="0x00000800,,0x08000000" online_cpuset="0x00000800,,0x08000000" allowed_cpuset="0x00000800,,0x08000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000800,,0x08000000" complete_cpuset="0x00000800,,0x08000000" online_cpuset="0x00000800,,0x08000000" allowed_cpuset="0x00000800,,0x08000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="3" cpuset="0x00000800,,0x08000000" complete_cpuset="0x00000800,,0x08000000" online_cpuset="0x00000800,,0x08000000" allowed_cpuset="0x00000800,,0x08000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="27" cpuset="0x08000000" complete_cpuset="0x08000000" online_cpuset="0x08000000" allowed_cpuset="0x08000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                  <object type="PU" os_index="75" cpuset="0x00000800,,0x0" complete_cpuset="0x00000800,,0x0" online_cpuset="0x00000800,,0x0" allowed_cpuset="0x00000800,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00001000,,0x10000000" complete_cpuset="0x00001000,,0x10000000" online_cpuset="0x00001000,,0x10000000" allowed_cpuset="0x00001000,,0x10000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x00001000,,0x10000000" complete_cpuset="0x00001000,,0x10000000" online_cpuset="0x00001000,,0x10000000" allowed_cpuset="0x00001000,,0x10000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00001000,,0x10000000" complete_cpuset="0x00001000,,0x10000000" online_cpuset="0x00001000,,0x10000000" allowed_cpuset="0x00001000,,0x10000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="4" cpuset="0x00001000,,0x10000000" complete_cpuset="0x00001000,,0x10000000" online_cpuset="0x00001000,,0x10000000" allowed_cpuset="0x00001000,,0x10000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="28" cpuset="0x10000000" complete_cpuset="0x10000000" online_cpuset="0x10000000" allowed_cpuset="0x10000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                  <object type="PU" os_index="76" cpuset="0x00001000,,0x0" complete_cpuset="0x00001000,,0x0" online_cpuset="0x00001000,,0x0" allowed_cpuset="0x00001000,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00002000,,0x20000000" complete_cpuset="0x00002000,,0x20000000" online_cpuset="0x00002000,,0x20000000" allowed_cpuset="0x00002000,,0x20000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x00002000,,0x20000000" complete_cpuset="0x00002000,,0x20000000" online_cpuset="0x00002000,,0x20000000" allowed_cpuset="0x00002000,,0x20000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00002000,,0x20000000" complete_cpuset="0x00002000,,0x20000000" online_cpuset="0x00002000,,0x20000000" allowed_cpuset="0x00002000,,0x20000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="5" cpuset="0x00002000,,0x20000000" complete_cpuset="0x00002000,,0x20000000" online_cpuset="0x00002000,,0x20000000" allowed_cpuset="0x00002000,,0x20000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="29" cpuset="0x20000000" complete_cpuset="0x20000000" online_cpuset="0x20000000" allowed_cpuset="0x20000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                  <object type="PU" os_index="77" cpuset="0x00002000,,0x0" complete_cpuset="0x00002000,,0x0" online_cpuset="0x00002000,,0x0" allowed_cpuset="0x00002000,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00004000,,0x40000000" complete_cpuset="0x00004000,,0x40000000" online_cpuset="0x00004000,,0x40000000" allowed_cpuset="0x00004000,,0x40000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x00004000,,0x40000000" complete_cpuset="0x00004000,,0x40000000" online_cpuset="0x00004000,,0x40000000" allowed_cpuset="0x00004000,,0x40000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00004000,,0x40000000" complete_cpuset="0x00004000,,0x40000000" online_cpuset="0x00004000,,0x40000000" allowed_cpuset="0x00004000,,0x40000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="6" cpuset="0x00004000,,0x40000000" complete_cpuset="0x00004000,,0x40000000" online_cpuset="0x00004000,,0x40000000" allowed_cpuset="0x00004000,,0x40000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="30" cpuset="0x40000000" complete_cpuset="0x40000000" online_cpuset="0x40000000" allowed_cpuset="0x40000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                  <object type="PU" os_index="78" cpuset="0x00004000,,0x0" complete_cpuset="0x00004000,,0x0" online_cpuset="0x00004000,,0x0" allowed_cpuset="0x00004000,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00008000,,0x80000000" complete_cpuset="0x00008000,,0x80000000" online_cpuset="0x00008000,,0x80000000" allowed_cpuset="0x00008000,,0x80000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x00008000,,0x80000000" complete_cpuset="0x00008000,,0x80000000" online_cpuset="0x00008000,,0x80000000" allowed_cpuset="0x00008000,,0x80000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00008000,,0x80000000" complete_cpuset="0x00008000,,0x80000000" online_cpuset="0x00008000,,0x80000000" allowed_cpuset="0x00008000,,0x80000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="9" cpuset="0x00008000,,0x80000000" complete_cpuset="0x00008000,,0x80000000" online_cpuset="0x00008000,,0x80000000" allowed_cpuset="0x00008000,,0x80000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="31" cpuset="0x80000000" complete_cpuset="0x80000000" online_cpuset="0x80000000" allowed_cpuset="0x80000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                  <object type="PU" os_index="79" cpuset="0x00008000,,0x0" complete_cpuset="0x00008000,,0x0" online_cpuset="0x00008000,,0x0" allowed_cpuset="0x00008000,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00010000,0x00000001,0x0" complete_cpuset="0x00010000,0x00000001,0x0" online_cpuset="0x00010000,0x00000001,0x0" allowed_cpuset="0x00010000,0x00000001,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x00010000,0x00000001,0x0" complete_cpuset="0x00010000,0x00000001,0x0" online_cpuset="0x00010000,0x00000001,0x0" allowed_cpuset="0x00010000,0x00000001,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00010000,0x00000001,0x0" complete_cpuset="0x00010000,0x00000001,0x0" online_cpuset="0x00010000,0x00000001,0x0" allowed_cpuset="0x00010000,0x00000001,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="10" cpuset="0x00010000,0x00000001,0x0" complete_cpuset="0x00010000,0x00000001,0x0" online_cpuset="0x00010000,0x00000001,0x0" allowed_cpuset="0x00010000,0x00000001,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="32" cpuset="0x00000001,0x0" complete_cpuset="0x00000001,0x0" online_cpuset="0x00000001,0x0" allowed_cpuset="0x00000001,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                  <object type="PU" os_index="80" cpuset="0x00010000,,0x0" complete_cpuset="0x00010000,,0x0" online_cpuset="0x00010000,,0x0" allowed_cpuset="0x00010000,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00020000,0x00000002,0x0" complete_cpuset="0x00020000,0x00000002,0x0" online_cpuset="0x00020000,0x00000002,0x0" allowed_cpuset="0x00020000,0x00000002,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x00020000,0x00000002,0x0" complete_cpuset="0x00020000,0x00000002,0x0" online_cpuset="0x00020000,0x00000002,0x0" allowed_cpuset="0x00020000,0x00000002,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00020000,0x00000002,0x0" complete_cpuset="0x00020000,0x00000002,0x0" online_cpuset="0x00020000,0x00000002,0x0" allowed_cpuset="0x00020000,0x00000002,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="11" cpuset="0x00020000,0x00000002,0x0" complete_cpuset="0x00020000,0x00000002,0x0" online_cpuset="0x00020000,0x00000002,0x0" allowed_cpuset="0x00020000,0x00000002,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="33" cpuset="0x00000002,0x0" complete_cpuset="0x00000002,0x0" online_cpuset="0x00000002,0x0" allowed_cpuset="0x00000002,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                  <object type="PU" os_index="81" cpuset="0x00020000,,0x0" complete_cpuset="0x00020000,,0x0" online_cpuset="0x00020000,,0x0" allowed_cpuset="0x00020000,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00040000,0x00000004,0x0" complete_cpuset="0x00040000,0x00000004,0x0" online_cpuset="0x00040000,0x00000004,0x0" allowed_cpuset="0x00040000,0x00000004,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x00040000,0x00000004,0x0" complete_cpuset="0x00040000,0x00000004,0x0" online_cpuset="0x00040000,0x00000004,0x0" allowed_cpuset="0x00040000,0x00000004,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00040000,0x00000004,0x0" complete_cpuset="0x00040000,0x00000004,0x0" online_cpuset="0x00040000,0x00000004,0x0" allowed_cpuset="0x00040000,0x00000004,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="12" cpuset="0x00040000,0x00000004,0x0" complete_cpuset="0x00040000,0x00000004,0x0" online_cpuset="0x00040000,0x00000004,0x0" allowed_cpuset="0x00040000,0x00000004,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="34" cpuset="0x00000004,0x0" complete_cpuset="0x00000004,0x0" online_cpuset="0x00000004,0x0" allowed_cpuset="0x00000004,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                  <object type="PU" os_index="82" cpuset="0x00040000,,0x0" complete_cpuset="0x00040000,,0x0" online_cpuset="0x00040000,,0x0" allowed_cpuset="0x00040000,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00080000,0x00000008,0x0" complete_cpuset="0x00080000,0x00000008,0x0" online_cpuset="0x00080000,0x00000008,0x0" allowed_cpuset="0x00080000,0x00000008,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x00080000,0x00000008,0x0" complete_cpuset="0x00080000,0x00000008,0x0" online_cpuset="0x00080000,0x00000008,0x0" allowed_cpuset="0x00080000,0x00000008,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00080000,0x00000008,0x0" complete_cpuset="0x00080000,0x00000008,0x0" online_cpuset="0x00080000,0x00000008,0x0" allowed_cpuset="0x00080000,0x00000008,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="13" cpuset="0x00080000,0x00000008,0x0" complete_cpuset="0x00080000,0x00000008,0x0" online_cpuset="0x00080000,0x00000008,0x0" allowed_cpuset="0x00080000,0x00000008,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="35" cpuset="0x00000008,0x0" complete_cpuset="0x00000008,0x0" online_cpuset="0x00000008,0x0" allowed_cpuset="0x00000008,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                  <object type="PU" os_index="83" cpuset="0x00080000,,0x0" complete_cpuset="0x00080000,,0x0" online_cpuset="0x00080000,,0x0" allowed_cpuset="0x00080000,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00100000,0x00000010,0x0" complete_cpuset="0x00100000,0x00000010,0x0" online_cpuset="0x00100000,0x00000010,0x0" allowed_cpuset="0x00100000,0x00000010,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x00100000,0x00000010,0x0" complete_cpuset="0x00100000,0x00000010,0x0" online_cpuset="0x00100000,0x00000010,0x0" allowed_cpuset="0x00100000,0x00000010,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00100000,0x00000010,0x0" complete_cpuset="0x00100000,0x00000010,0x0" online_cpuset="0x00100000,0x00000010,0x0" allowed_cpuset="0x00100000,0x00000010,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="16" cpuset="0x00100000,0x00000010,0x0" complete_cpuset="0x00100000,0x00000010,0x0" online_cpuset="0x00100000,0x00000010,0x0" allowed_cpuset="0x00100000,0x00000010,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="36" cpuset="0x00000010,0x0" complete_cpuset="0x00000010,0x0" online_cpuset="0x00000010,0x0" allowed_cpuset="0x00000010,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                  <object type="PU" os_index="84" cpuset="0x00100000,,0x0" complete_cpuset="0x00100000,,0x0" online_cpuset="0x00100000,,0x0" allowed_cpuset="0x00100000,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00200000,0x00000020,0x0" complete_cpuset="0x00200000,0x00000020,0x0" online_cpuset="0x00200000,0x00000020,0x0" allowed_cpuset="0x00200000,0x00000020,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x00200000,0x00000020,0x0" complete_cpuset="0x00200000,0x00000020,0x0" online_cpuset="0x00200000,0x00000020,0x0" allowed_cpuset="0x00200000,0x00000020,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00200000,0x00000020,0x0" complete_cpuset="0x00200000,0x00000020,0x0" online_cpuset="0x00200000,0x00000020,0x0" allowed_cpuset="0x00200000,0x00000020,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="17" cpuset="0x00200000,0x00000020,0x0" complete_cpuset="0x00200000,0x00000020,0x0" online_cpuset="0x00200000,0x00000020,0x0" allowed_cpuset="0x00200000,0x00000020,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="37" cpuset="0x00000020,0x0" complete_cpuset="0x00000020,0x0" online_cpuset="0x00000020,0x0" allowed_cpuset="0x00000020,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                  <object type="PU" os_index="85" cpuset="0x00200000,,0x0" complete_cpuset="0x00200000,,0x0" online_cpuset="0x00200000,,0x0" allowed_cpuset="0x00200000,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00400000,0x00000040,0x0" complete_cpuset="0x00400000,0x00000040,0x0" online_cpuset="0x00400000,0x00000040,0x0" allowed_cpuset="0x00400000,0x00000040,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x00400000,0x00000040,0x0" complete_cpuset="0x00400000,0x00000040,0x0" online_cpuset="0x00400000,0x00000040,0x0" allowed_cpuset="0x00400000,0x00000040,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00400000,0x00000040,0x0" complete_cpuset="0x00400000,0x00000040,0x0" online_cpuset="0x00400000,0x00000040,0x0" allowed_cpuset="0x00400000,0x00000040,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="18" cpuset="0x00400000,0x00000040,0x0" complete_cpuset="0x00400000,0x00000040,0x0" online_cpuset="0x00400000,0x00000040,0x0" allowed_cpuset="0x00400000,0x00000040,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="38" cpuset="0x00000040,0x0" complete_cpuset="0x00000040,0x0" online_cpuset="0x00000040,0x0" allowed_cpuset="0x00000040,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                  <object type="PU" os_index="86" cpuset="0x00400000,,0x0" complete_cpuset="0x00400000,,0x0" online_cpuset="0x00400000,,0x0" allowed_cpuset="0x00400000,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00800000,0x00000080,0x0" complete_cpuset="0x00800000,0x00000080,0x0" online_cpuset="0x00800000,0x00000080,0x0" allowed_cpuset="0x00800000,0x00000080,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x00800000,0x00000080,0x0" complete_cpuset="0x00800000,0x00000080,0x0" online_cpuset="0x00800000,0x00000080,0x0" allowed_cpuset="0x00800000,0x00000080,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00800000,0x00000080,0x0" complete_cpuset="0x00800000,0x00000080,0x0" online_cpuset="0x00800000,0x00000080,0x0" allowed_cpuset="0x00800000,0x00000080,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="19" cpuset="0x00800000,0x00000080,0x0" complete_cpuset="0x00800000,0x00000080,0x0" online_cpuset="0x00800000,0x00000080,0x0" allowed_cpuset="0x00800000,0x00000080,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="39" cpuset="0x00000080,0x0" complete_cpuset="0x00000080,0x0" online_cpuset="0x00000080,0x0" allowed_cpuset="0x00000080,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                  <object type="PU" os_index="87" cpuset="0x00800000,,0x0" complete_cpuset="0x00800000,,0x0" online_cpuset="0x00800000,,0x0" allowed_cpuset="0x00800000,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x01000000,0x00000100,0x0" complete_cpuset="0x01000000,0x00000100,0x0" online_cpuset="0x01000000,0x00000100,0x0" allowed_cpuset="0x01000000,0x00000100,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x01000000,0x00000100,0x0" complete_cpuset="0x01000000,0x00000100,0x0" online_cpuset="0x01000000,0x00000100,0x0" allowed_cpuset="0x01000000,0x00000100,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x01000000,0x00000100,0x0" complete_cpuset="0x01000000,0x00000100,0x0" online_cpuset="0x01000000,0x00000100,0x0" allowed_cpuset="0x01000000,0x00000100,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="20" cpuset="0x01000000,0x00000100,0x0" complete_cpuset="0x01000000,0x00000100,0x0" online_cpuset="0x01000000,0x00000100,0x0" allowed_cpuset="0x01000000,0x00000100,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="40" cpuset="0x00000100,0x0" complete_cpuset="0x00000100,0x0" online_cpuset="0x00000100,0x0" allowed_cpuset="0x00000100,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                  <object type="PU" os_index="88" cpuset="0x01000000,,0x0" complete_cpuset="0x01000000,,0x0" online_cpuset="0x01000000,,0x0" allowed_cpuset="0x01000000,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x02000000,0x00000200,0x0" complete_cpuset="0x02000000,0x00000200,0x0" online_cpuset="0x02000000,0x00000200,0x0" allowed_cpuset="0x02000000,0x00000200,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x02000000,0x00000200,0x0" complete_cpuset="0x02000000,0x00000200,0x0" online_cpuset="0x02000000,0x00000200,0x0" allowed_cpuset="0x02000000,0x00000200,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x02000000,0x00000200,0x0" complete_cpuset="0x02000000,0x00000200,0x0" online_cpuset="0x02000000,0x00000200,0x0" allowed_cpuset="0x02000000,0x00000200,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="21" cpuset="0x02000000,0x00000200,0x0" complete_cpuset="0x02000000,0x00000200,0x0" online_cpuset="0x02000000,0x00000200,0x0" allowed_cpuset="0x02000000,0x00000200,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="41" cpuset="0x00000200,0x0" complete_cpuset="0x00000200,0x0" online_cpuset="0x00000200,0x0" allowed_cpuset="0x00000200,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                  <object type="PU" os_index="89" cpuset="0x02000000,,0x0" complete_cpuset="0x02000000,,0x0" online_cpuset="0x02000000,,0x0" allowed_cpuset="0x02000000,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x04000000,0x00000400,0x0" complete_cpuset="0x04000000,0x00000400,0x0" online_cpuset="0x04000000,0x00000400,0x0" allowed_cpuset="0x04000000,0x00000400,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x04000000,0x00000400,0x0" complete_cpuset="0x04000000,0x00000400,0x0" online_cpuset="0x04000000,0x00000400,0x0" allowed_cpuset="0x04000000,0x00000400,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x04000000,0x00000400,0x0" complete_cpuset="0x04000000,0x00000400,0x0" online_cpuset="0x04000000,0x00000400,0x0" allowed_cpuset="0x04000000,0x00000400,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="24" cpuset="0x04000000,0x00000400,0x0" complete_cpuset="0x04000000,0x00000400,0x0" online_cpuset="0x04000000,0x00000400,0x0" allowed_cpuset="0x04000000,0x00000400,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="42" cpuset="0x00000400,0x0" complete_cpuset="0x00000400,0x0" online_cpuset="0x00000400,0x0" allowed_cpuset="0x00000400,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                  <object type="PU" os_index="90" cpuset="0x04000000,,0x0" complete_cpuset="0x04000000,,0x0" online_cpuset="0x04000000,,0x0" allowed_cpuset="0x04000000,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x08000000,0x00000800,0x0" complete_cpuset="0x08000000,0x00000800,0x0" online_cpuset="0x08000000,0x00000800,0x0" allowed_cpuset="0x08000000,0x00000800,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x08000000,0x00000800,0x0" complete_cpuset="0x08000000,0x00000800,0x0" online_cpuset="0x08000000,0x00000800,0x0" allowed_cpuset="0x08000000,0x00000800,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x08000000,0x00000800,0x0" complete_cpuset="0x08000000,0x00000800,0x0" online_cpuset="0x08000000,0x00000800,0x0" allowed_cpuset="0x08000000,0x00000800,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="25" cpuset="0x08000000,0x00000800,0x0" complete_cpuset="0x08000000,0x00000800,0x0" online_cpuset="0x08000000,0x00000800,0x0" allowed_cpuset="0x08000000,0x00000800,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="43" cpuset="0x00000800,0x0" complete_cpuset="0x00000800,0x0" online_cpuset="0x00000800,0x0" allowed_cpuset="0x00000800,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                  <object type="PU" os_index="91" cpuset="0x08000000,,0x0" complete_cpuset="0x08000000,,0x0" online_cpuset="0x08000000,,0x0" allowed_cpuset="0x08000000,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x10000000,0x00001000,0x0" complete_cpuset="0x10000000,0x00001000,0x0" online_cpuset="0x10000000,0x00001000,0x0" allowed_cpuset="0x10000000,0x00001000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x10000000,0x00001000,0x0" complete_cpuset="0x10000000,0x00001000,0x0" online_cpuset="0x10000000,0x00001000,0x0" allowed_cpuset="0x10000000,0x00001000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x10000000,0x00001000,0x0" complete_cpuset="0x10000000,0x00001000,0x0" online_cpuset="0x10000000,0x00001000,0x0" allowed_cpuset="0x10000000,0x00001000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="26" cpuset="0x10000000,0x00001000,0x0" complete_cpuset="0x10000000,0x00001000,0x0" online_cpuset="0x10000000,0x00001000,0x0" allowed_cpuset="0x10000000,0x00001000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="44" cpuset="0x00001000,0x0" complete_cpuset="0x00001000,0x0" online_cpuset="0x00001000,0x0" allowed_cpuset="0x00001000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                  <object type="PU" os_index="92" cpuset="0x10000000,,0x0" complete_cpuset="0x10000000,,0x0" online_cpuset="0x10000000,,0x0" allowed_cpuset="0x10000000,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x20000000,0x00002000,0x0" complete_cpuset="0x20000000,0x00002000,0x0" online_cpuset="0x20000000,0x00002000,0x0" allowed_cpuset="0x20000000,0x00002000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x20000000,0x00002000,0x0" complete_cpuset="0x20000000,0x00002000,0x0" online_cpuset="0x20000000,0x00002000,0x0" allowed_cpuset="0x20000000,0x00002000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x20000000,0x00002000,0x0" complete_cpuset="0x20000000,0x00002000,0x0" online_cpuset="0x20000000,0x00002000,0x0" allowed_cpuset="0x20000000,0x00002000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="27" cpuset="0x20000000,0x00002000,0x0" complete_cpuset="0x20000000,0x00002000,0x0" online_cpuset="0x20000000,0x00002000,0x0" allowed_cpuset="0x20000000,0x00002000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="45" cpuset="0x00002000,0x0" complete_cpuset="0x00002000,0x0" online_cpuset="0x00002000,0x0" allowed_cpuset="0x00002000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                  <object type="PU" os_index="93" cpuset="0x20000000,,0x0" complete_cpuset="0x20000000,,0x0" online_cpuset="0x20000000,,0x0" allowed_cpuset="0x20000000,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x40000000,0x00004000,0x0" complete_cpuset="0x40000000,0x00004000,0x0" online_cpuset="0x40000000,0x00004000,0x0" allowed_cpuset="0x40000000,0x00004000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x40000000,0x00004000,0x0" complete_cpuset="0x40000000,0x00004000,0x0" online_cpuset="0x40000000,0x00004000,0x0" allowed_cpuset="0x40000000,0x00004000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x40000000,0x00004000,0x0" complete_cpuset="0x40000000,0x00004000,0x0" online_cpuset="0x40000000,0x00004000,0x0" allowed_cpuset="0x40000000,0x00004000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="28" cpuset="0x40000000,0x00004000,0x0" complete_cpuset="0x40000000,0x00004000,0x0" online_cpuset="0x40000000,0x00004000,0x0" allowed_cpuset="0x40000000,0x00004000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="46" cpuset="0x00004000,0x0" complete_cpuset="0x00004000,0x0" online_cpuset="0x00004000,0x0" allowed_cpuset="0x00004000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                  <object type="PU" os_index="94" cpuset="0x40000000,,0x0" complete_cpuset="0x40000000,,0x0" online_cpuset="0x40000000,,0x0" allowed_cpuset="0x40000000,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x80000000,0x00008000,0x0" complete_cpuset="0x80000000,0x00008000,0x0" online_cpuset="0x80000000,0x00008000,0x0" allowed_cpuset="0x80000000,0x00008000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x80000000,0x00008000,0x0" complete_cpuset="0x80000000,0x00008000,0x0" online_cpuset="0x80000000,0x00008000,0x0" allowed_cpuset="0x80000000,0x00008000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x80000000,0x00008000,0x0" complete_cpuset="0x80000000,0x00008000,0x0" online_cpuset="0x80000000,0x00008000,0x0" allowed_cpuset="0x80000000,0x00008000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="29" cpuset="0x80000000,0x00008000,0x0" complete_cpuset="0x80000000,0x00008000,0x0" online_cpuset="0x80000000,0x00008000,0x0" allowed_cpuset="0x80000000,0x00008000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="47" cpuset="0x00008000,0x0" complete_cpuset="0x00008000,0x0" online_cpuset="0x00008000,0x0" allowed_cpuset="0x00008000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                  <object type="PU" os_index="95" cpuset="0x80000000,,0x0" complete_cpuset="0x80000000,,0x0" online_cpuset="0x80000000,,0x0" allowed_cpuset="0x80000000,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+    </object>
+  </object>
+</topology>

--- a/src/control/lib/hardware/hwloc/testdata/gcp_topology.xml
+++ b/src/control/lib/hardware/hwloc/testdata/gcp_topology.xml
@@ -1,0 +1,284 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE topology SYSTEM "hwloc.dtd">
+<topology>
+  <object type="Machine" os_index="0" cpuset="0xffffffff" complete_cpuset="0xffffffff" online_cpuset="0xffffffff" allowed_cpuset="0xffffffff" nodeset="0x00000003" complete_nodeset="0x00000003" allowed_nodeset="0x00000003">
+    <page_type size="4096" count="0"/>
+    <page_type size="2097152" count="0"/>
+    <page_type size="1073741824" count="0"/>
+    <info name="DMIProductName" value="Google Compute Engine"/>
+    <info name="DMIProductVersion" value=""/>
+    <info name="DMIBoardVendor" value="Google"/>
+    <info name="DMIBoardName" value="Google Compute Engine"/>
+    <info name="DMIBoardVersion" value=""/>
+    <info name="DMIBoardAssetTag" value="70330D72-2C31-A673-E717-AC1E312C572B"/>
+    <info name="DMIChassisVendor" value="Google"/>
+    <info name="DMIChassisType" value="1"/>
+    <info name="DMIChassisVersion" value=""/>
+    <info name="DMIChassisAssetTag" value=""/>
+    <info name="DMIBIOSVendor" value="Google"/>
+    <info name="DMIBIOSVersion" value="Google"/>
+    <info name="DMIBIOSDate" value="01/01/2011"/>
+    <info name="DMISysVendor" value="Google"/>
+    <info name="Backend" value="Linux"/>
+    <info name="LinuxCgroup" value="/"/>
+    <info name="OSName" value="Linux"/>
+    <info name="OSRelease" value="3.10.0-1127.13.1.el7.x86_64"/>
+    <info name="OSVersion" value="#1 SMP Tue Jun 23 15:46:38 UTC 2020"/>
+    <info name="HostName" value="daos-server-03f8"/>
+    <info name="Architecture" value="x86_64"/>
+    <info name="hwlocVersion" value="1.11.8"/>
+    <info name="ProcessName" value="hwloc-ls"/>
+    <distances nbobjs="2" relative_depth="1" latency_base="10.000000">
+      <latency value="1.000000"/>
+      <latency value="2.000000"/>
+      <latency value="2.000000"/>
+      <latency value="1.000000"/>
+    </distances>
+    <object type="NUMANode" os_index="0" cpuset="0x00ff00ff" complete_cpuset="0x00ff00ff" online_cpuset="0x00ff00ff" allowed_cpuset="0x00ff00ff" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" local_memory="67398012928">
+      <page_type size="4096" count="15406017"/>
+      <page_type size="2097152" count="2048"/>
+      <page_type size="1073741824" count="0"/>
+      <object type="Package" os_index="0" cpuset="0x00ff00ff" complete_cpuset="0x00ff00ff" online_cpuset="0x00ff00ff" allowed_cpuset="0x00ff00ff" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+        <info name="CPUVendor" value="GenuineIntel"/>
+        <info name="CPUFamilyNumber" value="6"/>
+        <info name="CPUModelNumber" value="85"/>
+        <info name="CPUModel" value="Intel(R) Xeon(R) CPU"/>
+        <info name="CPUStepping" value="7"/>
+        <object type="Cache" cpuset="0x00ff00ff" complete_cpuset="0x00ff00ff" online_cpuset="0x00ff00ff" allowed_cpuset="0x00ff00ff" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="34603008" depth="3" cache_linesize="64" cache_associativity="11" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="Cache" cpuset="0x00010001" complete_cpuset="0x00010001" online_cpuset="0x00010001" allowed_cpuset="0x00010001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x00010001" complete_cpuset="0x00010001" online_cpuset="0x00010001" allowed_cpuset="0x00010001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00010001" complete_cpuset="0x00010001" online_cpuset="0x00010001" allowed_cpuset="0x00010001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="0" cpuset="0x00010001" complete_cpuset="0x00010001" online_cpuset="0x00010001" allowed_cpuset="0x00010001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="0" cpuset="0x00000001" complete_cpuset="0x00000001" online_cpuset="0x00000001" allowed_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="16" cpuset="0x00010000" complete_cpuset="0x00010000" online_cpuset="0x00010000" allowed_cpuset="0x00010000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00020002" complete_cpuset="0x00020002" online_cpuset="0x00020002" allowed_cpuset="0x00020002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x00020002" complete_cpuset="0x00020002" online_cpuset="0x00020002" allowed_cpuset="0x00020002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00020002" complete_cpuset="0x00020002" online_cpuset="0x00020002" allowed_cpuset="0x00020002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="1" cpuset="0x00020002" complete_cpuset="0x00020002" online_cpuset="0x00020002" allowed_cpuset="0x00020002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="1" cpuset="0x00000002" complete_cpuset="0x00000002" online_cpuset="0x00000002" allowed_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="17" cpuset="0x00020000" complete_cpuset="0x00020000" online_cpuset="0x00020000" allowed_cpuset="0x00020000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00040004" complete_cpuset="0x00040004" online_cpuset="0x00040004" allowed_cpuset="0x00040004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x00040004" complete_cpuset="0x00040004" online_cpuset="0x00040004" allowed_cpuset="0x00040004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00040004" complete_cpuset="0x00040004" online_cpuset="0x00040004" allowed_cpuset="0x00040004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="2" cpuset="0x00040004" complete_cpuset="0x00040004" online_cpuset="0x00040004" allowed_cpuset="0x00040004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="2" cpuset="0x00000004" complete_cpuset="0x00000004" online_cpuset="0x00000004" allowed_cpuset="0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="18" cpuset="0x00040000" complete_cpuset="0x00040000" online_cpuset="0x00040000" allowed_cpuset="0x00040000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00080008" complete_cpuset="0x00080008" online_cpuset="0x00080008" allowed_cpuset="0x00080008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x00080008" complete_cpuset="0x00080008" online_cpuset="0x00080008" allowed_cpuset="0x00080008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00080008" complete_cpuset="0x00080008" online_cpuset="0x00080008" allowed_cpuset="0x00080008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="3" cpuset="0x00080008" complete_cpuset="0x00080008" online_cpuset="0x00080008" allowed_cpuset="0x00080008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="3" cpuset="0x00000008" complete_cpuset="0x00000008" online_cpuset="0x00000008" allowed_cpuset="0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="19" cpuset="0x00080000" complete_cpuset="0x00080000" online_cpuset="0x00080000" allowed_cpuset="0x00080000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00100010" complete_cpuset="0x00100010" online_cpuset="0x00100010" allowed_cpuset="0x00100010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x00100010" complete_cpuset="0x00100010" online_cpuset="0x00100010" allowed_cpuset="0x00100010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00100010" complete_cpuset="0x00100010" online_cpuset="0x00100010" allowed_cpuset="0x00100010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="4" cpuset="0x00100010" complete_cpuset="0x00100010" online_cpuset="0x00100010" allowed_cpuset="0x00100010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="4" cpuset="0x00000010" complete_cpuset="0x00000010" online_cpuset="0x00000010" allowed_cpuset="0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="20" cpuset="0x00100000" complete_cpuset="0x00100000" online_cpuset="0x00100000" allowed_cpuset="0x00100000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00200020" complete_cpuset="0x00200020" online_cpuset="0x00200020" allowed_cpuset="0x00200020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x00200020" complete_cpuset="0x00200020" online_cpuset="0x00200020" allowed_cpuset="0x00200020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00200020" complete_cpuset="0x00200020" online_cpuset="0x00200020" allowed_cpuset="0x00200020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="5" cpuset="0x00200020" complete_cpuset="0x00200020" online_cpuset="0x00200020" allowed_cpuset="0x00200020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="5" cpuset="0x00000020" complete_cpuset="0x00000020" online_cpuset="0x00000020" allowed_cpuset="0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="21" cpuset="0x00200000" complete_cpuset="0x00200000" online_cpuset="0x00200000" allowed_cpuset="0x00200000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00400040" complete_cpuset="0x00400040" online_cpuset="0x00400040" allowed_cpuset="0x00400040" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x00400040" complete_cpuset="0x00400040" online_cpuset="0x00400040" allowed_cpuset="0x00400040" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00400040" complete_cpuset="0x00400040" online_cpuset="0x00400040" allowed_cpuset="0x00400040" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="6" cpuset="0x00400040" complete_cpuset="0x00400040" online_cpuset="0x00400040" allowed_cpuset="0x00400040" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="6" cpuset="0x00000040" complete_cpuset="0x00000040" online_cpuset="0x00000040" allowed_cpuset="0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="22" cpuset="0x00400000" complete_cpuset="0x00400000" online_cpuset="0x00400000" allowed_cpuset="0x00400000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00800080" complete_cpuset="0x00800080" online_cpuset="0x00800080" allowed_cpuset="0x00800080" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x00800080" complete_cpuset="0x00800080" online_cpuset="0x00800080" allowed_cpuset="0x00800080" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00800080" complete_cpuset="0x00800080" online_cpuset="0x00800080" allowed_cpuset="0x00800080" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="7" cpuset="0x00800080" complete_cpuset="0x00800080" online_cpuset="0x00800080" allowed_cpuset="0x00800080" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="7" cpuset="0x00000080" complete_cpuset="0x00000080" online_cpuset="0x00000080" allowed_cpuset="0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="23" cpuset="0x00800000" complete_cpuset="0x00800000" online_cpuset="0x00800000" allowed_cpuset="0x00800000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+    </object>
+    <object type="NUMANode" os_index="1" cpuset="0xff00ff00" complete_cpuset="0xff00ff00" online_cpuset="0xff00ff00" allowed_cpuset="0xff00ff00" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" local_memory="67625783296">
+      <page_type size="4096" count="15461625"/>
+      <page_type size="2097152" count="2048"/>
+      <page_type size="1073741824" count="0"/>
+      <object type="Package" os_index="1" cpuset="0xff00ff00" complete_cpuset="0xff00ff00" online_cpuset="0xff00ff00" allowed_cpuset="0xff00ff00" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+        <info name="CPUVendor" value="GenuineIntel"/>
+        <info name="CPUFamilyNumber" value="6"/>
+        <info name="CPUModelNumber" value="85"/>
+        <info name="CPUModel" value="Intel(R) Xeon(R) CPU"/>
+        <info name="CPUStepping" value="7"/>
+        <object type="Cache" cpuset="0xff00ff00" complete_cpuset="0xff00ff00" online_cpuset="0xff00ff00" allowed_cpuset="0xff00ff00" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="34603008" depth="3" cache_linesize="64" cache_associativity="11" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="Cache" cpuset="0x01000100" complete_cpuset="0x01000100" online_cpuset="0x01000100" allowed_cpuset="0x01000100" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x01000100" complete_cpuset="0x01000100" online_cpuset="0x01000100" allowed_cpuset="0x01000100" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x01000100" complete_cpuset="0x01000100" online_cpuset="0x01000100" allowed_cpuset="0x01000100" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="0" cpuset="0x01000100" complete_cpuset="0x01000100" online_cpuset="0x01000100" allowed_cpuset="0x01000100" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="8" cpuset="0x00000100" complete_cpuset="0x00000100" online_cpuset="0x00000100" allowed_cpuset="0x00000100" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                  <object type="PU" os_index="24" cpuset="0x01000000" complete_cpuset="0x01000000" online_cpuset="0x01000000" allowed_cpuset="0x01000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x02000200" complete_cpuset="0x02000200" online_cpuset="0x02000200" allowed_cpuset="0x02000200" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x02000200" complete_cpuset="0x02000200" online_cpuset="0x02000200" allowed_cpuset="0x02000200" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x02000200" complete_cpuset="0x02000200" online_cpuset="0x02000200" allowed_cpuset="0x02000200" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="1" cpuset="0x02000200" complete_cpuset="0x02000200" online_cpuset="0x02000200" allowed_cpuset="0x02000200" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="9" cpuset="0x00000200" complete_cpuset="0x00000200" online_cpuset="0x00000200" allowed_cpuset="0x00000200" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                  <object type="PU" os_index="25" cpuset="0x02000000" complete_cpuset="0x02000000" online_cpuset="0x02000000" allowed_cpuset="0x02000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x04000400" complete_cpuset="0x04000400" online_cpuset="0x04000400" allowed_cpuset="0x04000400" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x04000400" complete_cpuset="0x04000400" online_cpuset="0x04000400" allowed_cpuset="0x04000400" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x04000400" complete_cpuset="0x04000400" online_cpuset="0x04000400" allowed_cpuset="0x04000400" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="2" cpuset="0x04000400" complete_cpuset="0x04000400" online_cpuset="0x04000400" allowed_cpuset="0x04000400" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="10" cpuset="0x00000400" complete_cpuset="0x00000400" online_cpuset="0x00000400" allowed_cpuset="0x00000400" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                  <object type="PU" os_index="26" cpuset="0x04000000" complete_cpuset="0x04000000" online_cpuset="0x04000000" allowed_cpuset="0x04000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x08000800" complete_cpuset="0x08000800" online_cpuset="0x08000800" allowed_cpuset="0x08000800" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x08000800" complete_cpuset="0x08000800" online_cpuset="0x08000800" allowed_cpuset="0x08000800" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x08000800" complete_cpuset="0x08000800" online_cpuset="0x08000800" allowed_cpuset="0x08000800" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="3" cpuset="0x08000800" complete_cpuset="0x08000800" online_cpuset="0x08000800" allowed_cpuset="0x08000800" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="11" cpuset="0x00000800" complete_cpuset="0x00000800" online_cpuset="0x00000800" allowed_cpuset="0x00000800" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                  <object type="PU" os_index="27" cpuset="0x08000000" complete_cpuset="0x08000000" online_cpuset="0x08000000" allowed_cpuset="0x08000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x10001000" complete_cpuset="0x10001000" online_cpuset="0x10001000" allowed_cpuset="0x10001000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x10001000" complete_cpuset="0x10001000" online_cpuset="0x10001000" allowed_cpuset="0x10001000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x10001000" complete_cpuset="0x10001000" online_cpuset="0x10001000" allowed_cpuset="0x10001000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="4" cpuset="0x10001000" complete_cpuset="0x10001000" online_cpuset="0x10001000" allowed_cpuset="0x10001000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="12" cpuset="0x00001000" complete_cpuset="0x00001000" online_cpuset="0x00001000" allowed_cpuset="0x00001000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                  <object type="PU" os_index="28" cpuset="0x10000000" complete_cpuset="0x10000000" online_cpuset="0x10000000" allowed_cpuset="0x10000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x20002000" complete_cpuset="0x20002000" online_cpuset="0x20002000" allowed_cpuset="0x20002000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x20002000" complete_cpuset="0x20002000" online_cpuset="0x20002000" allowed_cpuset="0x20002000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x20002000" complete_cpuset="0x20002000" online_cpuset="0x20002000" allowed_cpuset="0x20002000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="5" cpuset="0x20002000" complete_cpuset="0x20002000" online_cpuset="0x20002000" allowed_cpuset="0x20002000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="13" cpuset="0x00002000" complete_cpuset="0x00002000" online_cpuset="0x00002000" allowed_cpuset="0x00002000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                  <object type="PU" os_index="29" cpuset="0x20000000" complete_cpuset="0x20000000" online_cpuset="0x20000000" allowed_cpuset="0x20000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x40004000" complete_cpuset="0x40004000" online_cpuset="0x40004000" allowed_cpuset="0x40004000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x40004000" complete_cpuset="0x40004000" online_cpuset="0x40004000" allowed_cpuset="0x40004000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x40004000" complete_cpuset="0x40004000" online_cpuset="0x40004000" allowed_cpuset="0x40004000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="6" cpuset="0x40004000" complete_cpuset="0x40004000" online_cpuset="0x40004000" allowed_cpuset="0x40004000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="14" cpuset="0x00004000" complete_cpuset="0x00004000" online_cpuset="0x00004000" allowed_cpuset="0x00004000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                  <object type="PU" os_index="30" cpuset="0x40000000" complete_cpuset="0x40000000" online_cpuset="0x40000000" allowed_cpuset="0x40000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x80008000" complete_cpuset="0x80008000" online_cpuset="0x80008000" allowed_cpuset="0x80008000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x80008000" complete_cpuset="0x80008000" online_cpuset="0x80008000" allowed_cpuset="0x80008000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x80008000" complete_cpuset="0x80008000" online_cpuset="0x80008000" allowed_cpuset="0x80008000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="7" cpuset="0x80008000" complete_cpuset="0x80008000" online_cpuset="0x80008000" allowed_cpuset="0x80008000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="15" cpuset="0x00008000" complete_cpuset="0x00008000" online_cpuset="0x00008000" allowed_cpuset="0x00008000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                  <object type="PU" os_index="31" cpuset="0x80000000" complete_cpuset="0x80000000" online_cpuset="0x80000000" allowed_cpuset="0x80000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+    </object>
+    <object type="Bridge" os_index="0" bridge_type="0-1" depth="0" bridge_pci="0000:[00-00]">
+      <object type="PCIDev" os_index="64" pci_busid="0000:00:04.0" pci_type="0108 [1ae0:001f] [0000:0000] 01" pci_link_speed="0.000000">
+        <info name="PCISlot" value="4"/>
+      </object>
+      <object type="PCIDev" os_index="80" pci_busid="0000:00:05.0" pci_type="0200 [1af4:1000] [1af4:0001] 00" pci_link_speed="0.000000">
+        <info name="PCISlot" value="5"/>
+      </object>
+    </object>
+  </object>
+</topology>

--- a/src/control/lib/hardware/hwloc/testdata/multiport_hfi_topology.xml
+++ b/src/control/lib/hardware/hwloc/testdata/multiport_hfi_topology.xml
@@ -1,0 +1,379 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE topology SYSTEM "hwloc.dtd">
+<topology>
+  <object type="Machine" os_index="0" cpuset="0xffffffff" complete_cpuset="0xffffffff" online_cpuset="0xffffffff" allowed_cpuset="0xffffffff" nodeset="0x00000003" complete_nodeset="0x00000003" allowed_nodeset="0x00000003">
+    <page_type size="4096" count="0"/>
+    <page_type size="2097152" count="0"/>
+    <page_type size="1073741824" count="0"/>
+    <info name="DMIProductName" value="DoubleDiamond"/>
+    <info name="DMIProductVersion" value="TCA-00638"/>
+    <info name="DMIBoardVendor" value="Newisys"/>
+    <info name="DMIBoardName" value="DoubleDiamond"/>
+    <info name="DMIBoardVersion" value="TCA-00638"/>
+    <info name="DMIBoardAssetTag" value="5 Asset Tag To be filled by O.E"/>
+    <info name="DMIChassisVendor" value="Newisys"/>
+    <info name="DMIChassisType" value="17"/>
+    <info name="DMIChassisVersion" value="TCA-00638"/>
+    <info name="DMIChassisAssetTag" value="4 Asset TagTo be filled by O.E."/>
+    <info name="DMIBIOSVendor" value="Newisys"/>
+    <info name="DMIBIOSVersion" value="10.03"/>
+    <info name="DMIBIOSDate" value="04/27/2016"/>
+    <info name="DMISysVendor" value="Newisys"/>
+    <info name="Backend" value="Linux"/>
+    <info name="LinuxCgroup" value="/"/>
+    <info name="OSName" value="Linux"/>
+    <info name="OSRelease" value="3.10.0-1062.el7.x86_64"/>
+    <info name="OSVersion" value="#1 SMP Wed Aug 7 18:08:02 UTC 2019"/>
+    <info name="HostName" value="hl-c507"/>
+    <info name="Architecture" value="x86_64"/>
+    <info name="hwlocVersion" value="1.11.5"/>
+    <info name="ProcessName" value="lstopo"/>
+    <distances nbobjs="2" relative_depth="1" latency_base="10.000000">
+      <latency value="1.000000"/>
+      <latency value="2.100000"/>
+      <latency value="2.100000"/>
+      <latency value="1.000000"/>
+    </distances>
+    <object type="NUMANode" os_index="0" cpuset="0x00ff00ff" complete_cpuset="0x00ff00ff" online_cpuset="0x00ff00ff" allowed_cpuset="0x00ff00ff" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" local_memory="68608454656">
+      <page_type size="4096" count="16487967"/>
+      <page_type size="2097152" count="512"/>
+      <page_type size="1073741824" count="0"/>
+      <object type="Package" os_index="0" cpuset="0x00ff00ff" complete_cpuset="0x00ff00ff" online_cpuset="0x00ff00ff" allowed_cpuset="0x00ff00ff" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+        <info name="CPUVendor" value="GenuineIntel"/>
+        <info name="CPUFamilyNumber" value="6"/>
+        <info name="CPUModelNumber" value="63"/>
+        <info name="CPUModel" value="Intel(R) Xeon(R) CPU E5-2640 v3 @ 2.60GHz"/>
+        <info name="CPUStepping" value="2"/>
+        <object type="Cache" cpuset="0x00ff00ff" complete_cpuset="0x00ff00ff" online_cpuset="0x00ff00ff" allowed_cpuset="0x00ff00ff" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="20971520" depth="3" cache_linesize="64" cache_associativity="20" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="Cache" cpuset="0x00010001" complete_cpuset="0x00010001" online_cpuset="0x00010001" allowed_cpuset="0x00010001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x00010001" complete_cpuset="0x00010001" online_cpuset="0x00010001" allowed_cpuset="0x00010001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00010001" complete_cpuset="0x00010001" online_cpuset="0x00010001" allowed_cpuset="0x00010001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="0" cpuset="0x00010001" complete_cpuset="0x00010001" online_cpuset="0x00010001" allowed_cpuset="0x00010001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="0" cpuset="0x00000001" complete_cpuset="0x00000001" online_cpuset="0x00000001" allowed_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="16" cpuset="0x00010000" complete_cpuset="0x00010000" online_cpuset="0x00010000" allowed_cpuset="0x00010000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00020002" complete_cpuset="0x00020002" online_cpuset="0x00020002" allowed_cpuset="0x00020002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x00020002" complete_cpuset="0x00020002" online_cpuset="0x00020002" allowed_cpuset="0x00020002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00020002" complete_cpuset="0x00020002" online_cpuset="0x00020002" allowed_cpuset="0x00020002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="1" cpuset="0x00020002" complete_cpuset="0x00020002" online_cpuset="0x00020002" allowed_cpuset="0x00020002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="1" cpuset="0x00000002" complete_cpuset="0x00000002" online_cpuset="0x00000002" allowed_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="17" cpuset="0x00020000" complete_cpuset="0x00020000" online_cpuset="0x00020000" allowed_cpuset="0x00020000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00040004" complete_cpuset="0x00040004" online_cpuset="0x00040004" allowed_cpuset="0x00040004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x00040004" complete_cpuset="0x00040004" online_cpuset="0x00040004" allowed_cpuset="0x00040004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00040004" complete_cpuset="0x00040004" online_cpuset="0x00040004" allowed_cpuset="0x00040004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="2" cpuset="0x00040004" complete_cpuset="0x00040004" online_cpuset="0x00040004" allowed_cpuset="0x00040004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="2" cpuset="0x00000004" complete_cpuset="0x00000004" online_cpuset="0x00000004" allowed_cpuset="0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="18" cpuset="0x00040000" complete_cpuset="0x00040000" online_cpuset="0x00040000" allowed_cpuset="0x00040000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00080008" complete_cpuset="0x00080008" online_cpuset="0x00080008" allowed_cpuset="0x00080008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x00080008" complete_cpuset="0x00080008" online_cpuset="0x00080008" allowed_cpuset="0x00080008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00080008" complete_cpuset="0x00080008" online_cpuset="0x00080008" allowed_cpuset="0x00080008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="3" cpuset="0x00080008" complete_cpuset="0x00080008" online_cpuset="0x00080008" allowed_cpuset="0x00080008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="3" cpuset="0x00000008" complete_cpuset="0x00000008" online_cpuset="0x00000008" allowed_cpuset="0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="19" cpuset="0x00080000" complete_cpuset="0x00080000" online_cpuset="0x00080000" allowed_cpuset="0x00080000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00100010" complete_cpuset="0x00100010" online_cpuset="0x00100010" allowed_cpuset="0x00100010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x00100010" complete_cpuset="0x00100010" online_cpuset="0x00100010" allowed_cpuset="0x00100010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00100010" complete_cpuset="0x00100010" online_cpuset="0x00100010" allowed_cpuset="0x00100010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="4" cpuset="0x00100010" complete_cpuset="0x00100010" online_cpuset="0x00100010" allowed_cpuset="0x00100010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="4" cpuset="0x00000010" complete_cpuset="0x00000010" online_cpuset="0x00000010" allowed_cpuset="0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="20" cpuset="0x00100000" complete_cpuset="0x00100000" online_cpuset="0x00100000" allowed_cpuset="0x00100000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00200020" complete_cpuset="0x00200020" online_cpuset="0x00200020" allowed_cpuset="0x00200020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x00200020" complete_cpuset="0x00200020" online_cpuset="0x00200020" allowed_cpuset="0x00200020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00200020" complete_cpuset="0x00200020" online_cpuset="0x00200020" allowed_cpuset="0x00200020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="5" cpuset="0x00200020" complete_cpuset="0x00200020" online_cpuset="0x00200020" allowed_cpuset="0x00200020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="5" cpuset="0x00000020" complete_cpuset="0x00000020" online_cpuset="0x00000020" allowed_cpuset="0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="21" cpuset="0x00200000" complete_cpuset="0x00200000" online_cpuset="0x00200000" allowed_cpuset="0x00200000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00400040" complete_cpuset="0x00400040" online_cpuset="0x00400040" allowed_cpuset="0x00400040" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x00400040" complete_cpuset="0x00400040" online_cpuset="0x00400040" allowed_cpuset="0x00400040" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00400040" complete_cpuset="0x00400040" online_cpuset="0x00400040" allowed_cpuset="0x00400040" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="6" cpuset="0x00400040" complete_cpuset="0x00400040" online_cpuset="0x00400040" allowed_cpuset="0x00400040" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="6" cpuset="0x00000040" complete_cpuset="0x00000040" online_cpuset="0x00000040" allowed_cpuset="0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="22" cpuset="0x00400000" complete_cpuset="0x00400000" online_cpuset="0x00400000" allowed_cpuset="0x00400000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00800080" complete_cpuset="0x00800080" online_cpuset="0x00800080" allowed_cpuset="0x00800080" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x00800080" complete_cpuset="0x00800080" online_cpuset="0x00800080" allowed_cpuset="0x00800080" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00800080" complete_cpuset="0x00800080" online_cpuset="0x00800080" allowed_cpuset="0x00800080" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="7" cpuset="0x00800080" complete_cpuset="0x00800080" online_cpuset="0x00800080" allowed_cpuset="0x00800080" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="7" cpuset="0x00000080" complete_cpuset="0x00000080" online_cpuset="0x00000080" allowed_cpuset="0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="23" cpuset="0x00800000" complete_cpuset="0x00800000" online_cpuset="0x00800000" allowed_cpuset="0x00800000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="Bridge" os_index="0" bridge_type="0-1" depth="0" bridge_pci="0000:[00-07]">
+        <object type="Bridge" os_index="16" bridge_type="1-1" depth="1" bridge_pci="0000:[01-01]" pci_busid="0000:00:01.0" pci_type="0604 [8086:2f02] [8086:0000] 02" pci_link_speed="0.000000">
+          <object type="PCIDev" os_index="4096" pci_busid="0000:01:00.0" pci_type="0107 [1000:0097] [1000:0090] 02" pci_link_speed="0.000000">
+            <info name="PCISlot" value="11"/>
+          </object>
+        </object>
+        <object type="Bridge" os_index="32" bridge_type="1-1" depth="1" bridge_pci="0000:[02-02]" pci_busid="0000:00:02.0" pci_type="0604 [8086:2f04] [8086:0000] 02" pci_link_speed="0.000000">
+          <object type="PCIDev" os_index="8192" pci_busid="0000:02:00.0" pci_type="0280 [15b3:1003] [15b3:0050] 00" pci_link_speed="0.000000">
+            <info name="PCISlot" value="0"/>
+            <object type="OSDev" name="ib0" osdev_type="2">
+              <info name="Address" value="80:00:02:28:fe:80:00:00:00:00:00:00:e4:1d:2d:03:00:d9:28:62"/>
+              <info name="Port" value="2"/>
+            </object>
+            <object type="OSDev" name="enp2s0" osdev_type="2">
+              <info name="Address" value="e4:1d:2d:d9:28:61"/>
+              <info name="Port" value="1"/>
+            </object>
+            <object type="OSDev" name="mlx4_0" osdev_type="3">
+              <info name="NodeGUID" value="e41d:2d03:00d9:2860"/>
+              <info name="SysImageGUID" value="e41d:2d03:00d9:2863"/>
+              <info name="Port1State" value="1"/>
+              <info name="Port1LID" value="0x0"/>
+              <info name="Port1LMC" value="0"/>
+              <info name="Port1GID0" value="fe80:0000:0000:0000:e61d:2dff:fed9:2861"/>
+              <info name="Port2State" value="4"/>
+              <info name="Port2LID" value="0x9"/>
+              <info name="Port2LMC" value="0"/>
+              <info name="Port2GID0" value="fe80:0000:0000:0000:e41d:2d03:00d9:2862"/>
+            </object>
+          </object>
+        </object>
+        <object type="Bridge" os_index="50" bridge_type="1-1" depth="1" bridge_pci="0000:[04-04]" pci_busid="0000:00:03.2" pci_type="0604 [8086:2f0a] [8086:0000] 02" pci_link_speed="0.000000">
+          <object type="PCIDev" os_index="16384" pci_busid="0000:04:00.0" pci_type="0107 [1000:0097] [1000:0090] 02" pci_link_speed="0.000000">
+            <info name="PCISlot" value="0-1"/>
+          </object>
+        </object>
+        <object type="Bridge" os_index="452" bridge_type="1-1" depth="1" bridge_pci="0000:[06-06]" pci_busid="0000:00:1c.4" pci_type="0604 [8086:8d18] [8086:7270] d5" pci_link_speed="0.000000">
+          <object type="PCIDev" os_index="24576" pci_busid="0000:06:00.0" pci_type="0200 [8086:10d3] [8086:0000] 00" pci_link_speed="0.000000">
+            <object type="OSDev" name="enp6s0" osdev_type="2">
+              <info name="Address" value="00:09:3d:02:5a:f5"/>
+            </object>
+          </object>
+        </object>
+        <object type="Bridge" os_index="453" bridge_type="1-1" depth="1" bridge_pci="0000:[07-07]" pci_busid="0000:00:1c.5" pci_type="0604 [8086:8d1a] [8086:7270] d5" pci_link_speed="0.000000">
+          <object type="PCIDev" os_index="28672" pci_busid="0000:07:00.0" pci_type="0300 [102b:0522] [19a2:0102] 00" pci_link_speed="0.000000">
+            <object type="OSDev" name="card0" osdev_type="1"/>
+            <object type="OSDev" name="controlD64" osdev_type="1"/>
+          </object>
+        </object>
+        <object type="PCIDev" os_index="498" pci_busid="0000:00:1f.2" pci_type="0106 [8086:8d02] [8086:7270] 05" pci_link_speed="0.000000">
+          <object type="OSDev" name="sda" osdev_type="0">
+            <info name="LinuxDeviceID" value="8:0"/>
+            <info name="Model" value="TS64GMTS400"/>
+            <info name="Revision" value="N1126I"/>
+            <info name="SerialNumber" value="C196500679"/>
+            <info name="Type" value="Disk"/>
+          </object>
+          <object type="OSDev" name="sdb" osdev_type="0">
+            <info name="LinuxDeviceID" value="8:16"/>
+            <info name="Model" value="TS64GMTS400"/>
+            <info name="Revision" value="N1126I"/>
+            <info name="SerialNumber" value="C307450241"/>
+            <info name="Type" value="Disk"/>
+          </object>
+        </object>
+      </object>
+    </object>
+    <object type="NUMANode" os_index="1" cpuset="0xff00ff00" complete_cpuset="0xff00ff00" online_cpuset="0xff00ff00" allowed_cpuset="0xff00ff00" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" local_memory="68719476736">
+      <page_type size="4096" count="16515072"/>
+      <page_type size="2097152" count="512"/>
+      <page_type size="1073741824" count="0"/>
+      <object type="Package" os_index="1" cpuset="0xff00ff00" complete_cpuset="0xff00ff00" online_cpuset="0xff00ff00" allowed_cpuset="0xff00ff00" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+        <info name="CPUVendor" value="GenuineIntel"/>
+        <info name="CPUFamilyNumber" value="6"/>
+        <info name="CPUModelNumber" value="63"/>
+        <info name="CPUModel" value="Intel(R) Xeon(R) CPU E5-2640 v3 @ 2.60GHz"/>
+        <info name="CPUStepping" value="2"/>
+        <object type="Cache" cpuset="0xff00ff00" complete_cpuset="0xff00ff00" online_cpuset="0xff00ff00" allowed_cpuset="0xff00ff00" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="20971520" depth="3" cache_linesize="64" cache_associativity="20" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="Cache" cpuset="0x01000100" complete_cpuset="0x01000100" online_cpuset="0x01000100" allowed_cpuset="0x01000100" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x01000100" complete_cpuset="0x01000100" online_cpuset="0x01000100" allowed_cpuset="0x01000100" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x01000100" complete_cpuset="0x01000100" online_cpuset="0x01000100" allowed_cpuset="0x01000100" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="0" cpuset="0x01000100" complete_cpuset="0x01000100" online_cpuset="0x01000100" allowed_cpuset="0x01000100" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="8" cpuset="0x00000100" complete_cpuset="0x00000100" online_cpuset="0x00000100" allowed_cpuset="0x00000100" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                  <object type="PU" os_index="24" cpuset="0x01000000" complete_cpuset="0x01000000" online_cpuset="0x01000000" allowed_cpuset="0x01000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x02000200" complete_cpuset="0x02000200" online_cpuset="0x02000200" allowed_cpuset="0x02000200" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x02000200" complete_cpuset="0x02000200" online_cpuset="0x02000200" allowed_cpuset="0x02000200" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x02000200" complete_cpuset="0x02000200" online_cpuset="0x02000200" allowed_cpuset="0x02000200" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="1" cpuset="0x02000200" complete_cpuset="0x02000200" online_cpuset="0x02000200" allowed_cpuset="0x02000200" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="9" cpuset="0x00000200" complete_cpuset="0x00000200" online_cpuset="0x00000200" allowed_cpuset="0x00000200" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                  <object type="PU" os_index="25" cpuset="0x02000000" complete_cpuset="0x02000000" online_cpuset="0x02000000" allowed_cpuset="0x02000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x04000400" complete_cpuset="0x04000400" online_cpuset="0x04000400" allowed_cpuset="0x04000400" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x04000400" complete_cpuset="0x04000400" online_cpuset="0x04000400" allowed_cpuset="0x04000400" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x04000400" complete_cpuset="0x04000400" online_cpuset="0x04000400" allowed_cpuset="0x04000400" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="2" cpuset="0x04000400" complete_cpuset="0x04000400" online_cpuset="0x04000400" allowed_cpuset="0x04000400" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="10" cpuset="0x00000400" complete_cpuset="0x00000400" online_cpuset="0x00000400" allowed_cpuset="0x00000400" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                  <object type="PU" os_index="26" cpuset="0x04000000" complete_cpuset="0x04000000" online_cpuset="0x04000000" allowed_cpuset="0x04000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x08000800" complete_cpuset="0x08000800" online_cpuset="0x08000800" allowed_cpuset="0x08000800" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x08000800" complete_cpuset="0x08000800" online_cpuset="0x08000800" allowed_cpuset="0x08000800" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x08000800" complete_cpuset="0x08000800" online_cpuset="0x08000800" allowed_cpuset="0x08000800" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="3" cpuset="0x08000800" complete_cpuset="0x08000800" online_cpuset="0x08000800" allowed_cpuset="0x08000800" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="11" cpuset="0x00000800" complete_cpuset="0x00000800" online_cpuset="0x00000800" allowed_cpuset="0x00000800" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                  <object type="PU" os_index="27" cpuset="0x08000000" complete_cpuset="0x08000000" online_cpuset="0x08000000" allowed_cpuset="0x08000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x10001000" complete_cpuset="0x10001000" online_cpuset="0x10001000" allowed_cpuset="0x10001000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x10001000" complete_cpuset="0x10001000" online_cpuset="0x10001000" allowed_cpuset="0x10001000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x10001000" complete_cpuset="0x10001000" online_cpuset="0x10001000" allowed_cpuset="0x10001000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="4" cpuset="0x10001000" complete_cpuset="0x10001000" online_cpuset="0x10001000" allowed_cpuset="0x10001000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="12" cpuset="0x00001000" complete_cpuset="0x00001000" online_cpuset="0x00001000" allowed_cpuset="0x00001000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                  <object type="PU" os_index="28" cpuset="0x10000000" complete_cpuset="0x10000000" online_cpuset="0x10000000" allowed_cpuset="0x10000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x20002000" complete_cpuset="0x20002000" online_cpuset="0x20002000" allowed_cpuset="0x20002000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x20002000" complete_cpuset="0x20002000" online_cpuset="0x20002000" allowed_cpuset="0x20002000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x20002000" complete_cpuset="0x20002000" online_cpuset="0x20002000" allowed_cpuset="0x20002000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="5" cpuset="0x20002000" complete_cpuset="0x20002000" online_cpuset="0x20002000" allowed_cpuset="0x20002000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="13" cpuset="0x00002000" complete_cpuset="0x00002000" online_cpuset="0x00002000" allowed_cpuset="0x00002000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                  <object type="PU" os_index="29" cpuset="0x20000000" complete_cpuset="0x20000000" online_cpuset="0x20000000" allowed_cpuset="0x20000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x40004000" complete_cpuset="0x40004000" online_cpuset="0x40004000" allowed_cpuset="0x40004000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x40004000" complete_cpuset="0x40004000" online_cpuset="0x40004000" allowed_cpuset="0x40004000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x40004000" complete_cpuset="0x40004000" online_cpuset="0x40004000" allowed_cpuset="0x40004000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="6" cpuset="0x40004000" complete_cpuset="0x40004000" online_cpuset="0x40004000" allowed_cpuset="0x40004000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="14" cpuset="0x00004000" complete_cpuset="0x00004000" online_cpuset="0x00004000" allowed_cpuset="0x00004000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                  <object type="PU" os_index="30" cpuset="0x40000000" complete_cpuset="0x40000000" online_cpuset="0x40000000" allowed_cpuset="0x40000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x80008000" complete_cpuset="0x80008000" online_cpuset="0x80008000" allowed_cpuset="0x80008000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x80008000" complete_cpuset="0x80008000" online_cpuset="0x80008000" allowed_cpuset="0x80008000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x80008000" complete_cpuset="0x80008000" online_cpuset="0x80008000" allowed_cpuset="0x80008000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="7" cpuset="0x80008000" complete_cpuset="0x80008000" online_cpuset="0x80008000" allowed_cpuset="0x80008000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="15" cpuset="0x00008000" complete_cpuset="0x00008000" online_cpuset="0x00008000" allowed_cpuset="0x00008000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                  <object type="PU" os_index="31" cpuset="0x80000000" complete_cpuset="0x80000000" online_cpuset="0x80000000" allowed_cpuset="0x80000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="Bridge" os_index="2" bridge_type="0-1" depth="0" bridge_pci="0000:[80-84]">
+        <object type="Bridge" os_index="524304" bridge_type="1-1" depth="1" bridge_pci="0000:[82-82]" pci_busid="0000:80:01.0" pci_type="0604 [8086:2f02] [8086:0000] 02" pci_link_speed="0.000000">
+          <object type="PCIDev" os_index="532480" pci_busid="0000:82:00.0" pci_type="0107 [1000:0097] [1000:0090] 02" pci_link_speed="0.000000">
+            <info name="PCISlot" value="3"/>
+          </object>
+        </object>
+        <object type="Bridge" os_index="524320" bridge_type="1-1" depth="1" bridge_pci="0000:[83-83]" pci_busid="0000:80:02.0" pci_type="0604 [8086:2f04] [8086:0000] 02" pci_link_speed="0.000000">
+          <object type="PCIDev" os_index="536576" pci_busid="0000:83:00.0" pci_type="0280 [15b3:1003] [15b3:0050] 00" pci_link_speed="0.000000">
+            <info name="PCISlot" value="4"/>
+            <object type="OSDev" name="ib1" osdev_type="2">
+              <info name="Address" value="80:00:02:08:fe:80:00:00:00:00:00:00:00:02:c9:03:00:f9:de:81"/>
+              <info name="Port" value="1"/>
+            </object>
+            <object type="OSDev" name="ib2" osdev_type="2">
+              <info name="Address" value="80:00:02:09:fe:80:00:00:00:00:00:00:00:02:c9:03:00:f9:de:82"/>
+              <info name="Port" value="2"/>
+            </object>
+            <object type="OSDev" name="mlx4_1" osdev_type="3">
+              <info name="NodeGUID" value="0002:c903:00f9:de80"/>
+              <info name="SysImageGUID" value="0002:c903:00f9:de83"/>
+              <info name="Port1State" value="1"/>
+              <info name="Port1LID" value="0x0"/>
+              <info name="Port1LMC" value="0"/>
+              <info name="Port1GID0" value="fe80:0000:0000:0000:0002:c903:00f9:de81"/>
+              <info name="Port2State" value="1"/>
+              <info name="Port2LID" value="0x0"/>
+              <info name="Port2LMC" value="0"/>
+              <info name="Port2GID0" value="fe80:0000:0000:0000:0002:c903:00f9:de82"/>
+            </object>
+          </object>
+        </object>
+        <object type="Bridge" os_index="524338" bridge_type="1-1" depth="1" bridge_pci="0000:[84-84]" pci_busid="0000:80:03.2" pci_type="0604 [8086:2f0a] [8086:0000] 02" pci_link_speed="0.000000">
+          <object type="PCIDev" os_index="540672" pci_busid="0000:84:00.0" pci_type="0107 [1000:0097] [1000:0090] 02" pci_link_speed="0.000000">
+            <info name="PCISlot" value="6"/>
+          </object>
+        </object>
+      </object>
+    </object>
+  </object>
+</topology>

--- a/src/control/lib/hardware/hwloc/testdata/no-numa-no-devices.xml
+++ b/src/control/lib/hardware/hwloc/testdata/no-numa-no-devices.xml
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE topology SYSTEM "hwloc.dtd">
+<topology>
+  <object type="Machine" os_index="0" cpuset="0x0000000f" complete_cpuset="0x0000000f" online_cpuset="0x0000000f" allowed_cpuset="0x0000000f" local_memory="7575797760">
+    <page_type size="4096" count="1784024"/>
+    <page_type size="2097152" count="128"/>
+    <info name="DMIProductName" value="Parallels Virtual Platform"/>
+    <info name="DMIProductVersion" value="None"/>
+    <info name="DMIBoardVendor" value="Parallels Software International Inc."/>
+    <info name="DMIBoardName" value="Parallels Virtual Platform"/>
+    <info name="DMIBoardVersion" value="None"/>
+    <info name="DMIBoardAssetTag" value=""/>
+    <info name="DMIChassisVendor" value="Parallels Software International Inc."/>
+    <info name="DMIChassisType" value="10"/>
+    <info name="DMIChassisVersion" value=" "/>
+    <info name="DMIChassisAssetTag" value=" "/>
+    <info name="DMIBIOSVendor" value="Parallels Software International Inc."/>
+    <info name="DMIBIOSVersion" value="15.1.4 (47270)"/>
+    <info name="DMIBIOSDate" value="04/13/2020"/>
+    <info name="DMISysVendor" value="Parallels Software International Inc."/>
+    <info name="Backend" value="Linux"/>
+    <info name="LinuxCgroup" value="/"/>
+    <info name="OSName" value="Linux"/>
+    <info name="OSRelease" value="3.10.0-1127.10.1.el7.x86_64"/>
+    <info name="OSVersion" value="#1 SMP Wed Jun 3 14:28:03 UTC 2020"/>
+    <info name="HostName" value="localhost.localdomain"/>
+    <info name="Architecture" value="x86_64"/>
+    <info name="hwlocVersion" value="1.11.8"/>
+    <info name="ProcessName" value="hwloc-ls"/>
+    <object type="Package" os_index="0" cpuset="0x0000000f" complete_cpuset="0x0000000f" online_cpuset="0x0000000f" allowed_cpuset="0x0000000f">
+      <info name="CPUVendor" value="GenuineIntel"/>
+      <info name="CPUFamilyNumber" value="6"/>
+      <info name="CPUModelNumber" value="70"/>
+      <info name="CPUModel" value="Intel(R) Core(TM) i7-4870HQ CPU @ 2.50GHz"/>
+      <info name="CPUStepping" value="1"/>
+      <object type="Cache" cpuset="0x0000000f" complete_cpuset="0x0000000f" online_cpuset="0x0000000f" allowed_cpuset="0x0000000f" cache_size="134217728" depth="4" cache_linesize="64" cache_associativity="16" cache_type="0">
+        <info name="Inclusive" value="0"/>
+        <object type="Cache" cpuset="0x00000001" complete_cpuset="0x00000001" online_cpuset="0x00000001" allowed_cpuset="0x00000001" cache_size="6291456" depth="3" cache_linesize="64" cache_associativity="12" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="Cache" cpuset="0x00000001" complete_cpuset="0x00000001" online_cpuset="0x00000001" allowed_cpuset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x00000001" complete_cpuset="0x00000001" online_cpuset="0x00000001" allowed_cpuset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000001" complete_cpuset="0x00000001" online_cpuset="0x00000001" allowed_cpuset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="0" cpuset="0x00000001" complete_cpuset="0x00000001" online_cpuset="0x00000001" allowed_cpuset="0x00000001">
+                  <object type="PU" os_index="0" cpuset="0x00000001" complete_cpuset="0x00000001" online_cpuset="0x00000001" allowed_cpuset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="Cache" cpuset="0x00000002" complete_cpuset="0x00000002" online_cpuset="0x00000002" allowed_cpuset="0x00000002" cache_size="6291456" depth="3" cache_linesize="64" cache_associativity="12" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="Cache" cpuset="0x00000002" complete_cpuset="0x00000002" online_cpuset="0x00000002" allowed_cpuset="0x00000002" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x00000002" complete_cpuset="0x00000002" online_cpuset="0x00000002" allowed_cpuset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000002" complete_cpuset="0x00000002" online_cpuset="0x00000002" allowed_cpuset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="1" cpuset="0x00000002" complete_cpuset="0x00000002" online_cpuset="0x00000002" allowed_cpuset="0x00000002">
+                  <object type="PU" os_index="1" cpuset="0x00000002" complete_cpuset="0x00000002" online_cpuset="0x00000002" allowed_cpuset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="Cache" cpuset="0x00000004" complete_cpuset="0x00000004" online_cpuset="0x00000004" allowed_cpuset="0x00000004" cache_size="6291456" depth="3" cache_linesize="64" cache_associativity="12" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="Cache" cpuset="0x00000004" complete_cpuset="0x00000004" online_cpuset="0x00000004" allowed_cpuset="0x00000004" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x00000004" complete_cpuset="0x00000004" online_cpuset="0x00000004" allowed_cpuset="0x00000004" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000004" complete_cpuset="0x00000004" online_cpuset="0x00000004" allowed_cpuset="0x00000004" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="2" cpuset="0x00000004" complete_cpuset="0x00000004" online_cpuset="0x00000004" allowed_cpuset="0x00000004">
+                  <object type="PU" os_index="2" cpuset="0x00000004" complete_cpuset="0x00000004" online_cpuset="0x00000004" allowed_cpuset="0x00000004"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="Cache" cpuset="0x00000008" complete_cpuset="0x00000008" online_cpuset="0x00000008" allowed_cpuset="0x00000008" cache_size="6291456" depth="3" cache_linesize="64" cache_associativity="12" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="Cache" cpuset="0x00000008" complete_cpuset="0x00000008" online_cpuset="0x00000008" allowed_cpuset="0x00000008" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x00000008" complete_cpuset="0x00000008" online_cpuset="0x00000008" allowed_cpuset="0x00000008" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000008" complete_cpuset="0x00000008" online_cpuset="0x00000008" allowed_cpuset="0x00000008" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="3" cpuset="0x00000008" complete_cpuset="0x00000008" online_cpuset="0x00000008" allowed_cpuset="0x00000008">
+                  <object type="PU" os_index="3" cpuset="0x00000008" complete_cpuset="0x00000008" online_cpuset="0x00000008" allowed_cpuset="0x00000008"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+    </object>
+    <object type="Bridge" os_index="0" bridge_type="0-1" depth="0" bridge_pci="0000:[00-03]">
+      <object type="Bridge" os_index="16" bridge_type="1-1" depth="1" bridge_pci="0000:[01-01]" pci_busid="0000:00:01.0" pci_type="0604 [8086:2981] [8086:0000] 02" pci_link_speed="0.000000">
+        <object type="PCIDev" os_index="4096" pci_busid="0000:01:00.0" pci_type="0300 [1ab8:4005] [1ab8:0400] 00" pci_link_speed="0.000000"/>
+      </object>
+      <object type="PCIDev" os_index="80" pci_busid="0000:00:05.0" pci_type="0200 [1af4:1000] [1af4:0001] 00" pci_link_speed="0.000000"/>
+      <object type="PCIDev" os_index="497" pci_busid="0000:00:1f.1" pci_type="0101 [8086:244b] [1ab8:0400] 05" pci_link_speed="0.000000"/>
+      <object type="PCIDev" os_index="498" pci_busid="0000:00:1f.2" pci_type="0106 [8086:2821] [1ab8:0400] 02" pci_link_speed="0.000000">
+      </object>
+    </object>
+  </object>
+</topology>

--- a/src/control/lib/hardware/hwloc/testdata/no-numa-nodes.xml
+++ b/src/control/lib/hardware/hwloc/testdata/no-numa-nodes.xml
@@ -1,0 +1,143 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE topology SYSTEM "hwloc.dtd">
+<topology>
+  <object type="Machine" os_index="0" cpuset="0x0000000f" complete_cpuset="0x0000000f" online_cpuset="0x0000000f" allowed_cpuset="0x0000000f" local_memory="7575797760">
+    <page_type size="4096" count="1784024"/>
+    <page_type size="2097152" count="128"/>
+    <info name="DMIProductName" value="Parallels Virtual Platform"/>
+    <info name="DMIProductVersion" value="None"/>
+    <info name="DMIBoardVendor" value="Parallels Software International Inc."/>
+    <info name="DMIBoardName" value="Parallels Virtual Platform"/>
+    <info name="DMIBoardVersion" value="None"/>
+    <info name="DMIBoardAssetTag" value=""/>
+    <info name="DMIChassisVendor" value="Parallels Software International Inc."/>
+    <info name="DMIChassisType" value="10"/>
+    <info name="DMIChassisVersion" value=" "/>
+    <info name="DMIChassisAssetTag" value=" "/>
+    <info name="DMIBIOSVendor" value="Parallels Software International Inc."/>
+    <info name="DMIBIOSVersion" value="15.1.4 (47270)"/>
+    <info name="DMIBIOSDate" value="04/13/2020"/>
+    <info name="DMISysVendor" value="Parallels Software International Inc."/>
+    <info name="Backend" value="Linux"/>
+    <info name="LinuxCgroup" value="/"/>
+    <info name="OSName" value="Linux"/>
+    <info name="OSRelease" value="3.10.0-1127.10.1.el7.x86_64"/>
+    <info name="OSVersion" value="#1 SMP Wed Jun 3 14:28:03 UTC 2020"/>
+    <info name="HostName" value="localhost.localdomain"/>
+    <info name="Architecture" value="x86_64"/>
+    <info name="hwlocVersion" value="1.11.8"/>
+    <info name="ProcessName" value="hwloc-ls"/>
+    <object type="Package" os_index="0" cpuset="0x0000000f" complete_cpuset="0x0000000f" online_cpuset="0x0000000f" allowed_cpuset="0x0000000f">
+      <info name="CPUVendor" value="GenuineIntel"/>
+      <info name="CPUFamilyNumber" value="6"/>
+      <info name="CPUModelNumber" value="70"/>
+      <info name="CPUModel" value="Intel(R) Core(TM) i7-4870HQ CPU @ 2.50GHz"/>
+      <info name="CPUStepping" value="1"/>
+      <object type="Cache" cpuset="0x0000000f" complete_cpuset="0x0000000f" online_cpuset="0x0000000f" allowed_cpuset="0x0000000f" cache_size="134217728" depth="4" cache_linesize="64" cache_associativity="16" cache_type="0">
+        <info name="Inclusive" value="0"/>
+        <object type="Cache" cpuset="0x00000001" complete_cpuset="0x00000001" online_cpuset="0x00000001" allowed_cpuset="0x00000001" cache_size="6291456" depth="3" cache_linesize="64" cache_associativity="12" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="Cache" cpuset="0x00000001" complete_cpuset="0x00000001" online_cpuset="0x00000001" allowed_cpuset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x00000001" complete_cpuset="0x00000001" online_cpuset="0x00000001" allowed_cpuset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000001" complete_cpuset="0x00000001" online_cpuset="0x00000001" allowed_cpuset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="0" cpuset="0x00000001" complete_cpuset="0x00000001" online_cpuset="0x00000001" allowed_cpuset="0x00000001">
+                  <object type="PU" os_index="0" cpuset="0x00000001" complete_cpuset="0x00000001" online_cpuset="0x00000001" allowed_cpuset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="Cache" cpuset="0x00000002" complete_cpuset="0x00000002" online_cpuset="0x00000002" allowed_cpuset="0x00000002" cache_size="6291456" depth="3" cache_linesize="64" cache_associativity="12" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="Cache" cpuset="0x00000002" complete_cpuset="0x00000002" online_cpuset="0x00000002" allowed_cpuset="0x00000002" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x00000002" complete_cpuset="0x00000002" online_cpuset="0x00000002" allowed_cpuset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000002" complete_cpuset="0x00000002" online_cpuset="0x00000002" allowed_cpuset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="1" cpuset="0x00000002" complete_cpuset="0x00000002" online_cpuset="0x00000002" allowed_cpuset="0x00000002">
+                  <object type="PU" os_index="1" cpuset="0x00000002" complete_cpuset="0x00000002" online_cpuset="0x00000002" allowed_cpuset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="Cache" cpuset="0x00000004" complete_cpuset="0x00000004" online_cpuset="0x00000004" allowed_cpuset="0x00000004" cache_size="6291456" depth="3" cache_linesize="64" cache_associativity="12" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="Cache" cpuset="0x00000004" complete_cpuset="0x00000004" online_cpuset="0x00000004" allowed_cpuset="0x00000004" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x00000004" complete_cpuset="0x00000004" online_cpuset="0x00000004" allowed_cpuset="0x00000004" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000004" complete_cpuset="0x00000004" online_cpuset="0x00000004" allowed_cpuset="0x00000004" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="2" cpuset="0x00000004" complete_cpuset="0x00000004" online_cpuset="0x00000004" allowed_cpuset="0x00000004">
+                  <object type="PU" os_index="2" cpuset="0x00000004" complete_cpuset="0x00000004" online_cpuset="0x00000004" allowed_cpuset="0x00000004"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="Cache" cpuset="0x00000008" complete_cpuset="0x00000008" online_cpuset="0x00000008" allowed_cpuset="0x00000008" cache_size="6291456" depth="3" cache_linesize="64" cache_associativity="12" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="Cache" cpuset="0x00000008" complete_cpuset="0x00000008" online_cpuset="0x00000008" allowed_cpuset="0x00000008" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x00000008" complete_cpuset="0x00000008" online_cpuset="0x00000008" allowed_cpuset="0x00000008" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000008" complete_cpuset="0x00000008" online_cpuset="0x00000008" allowed_cpuset="0x00000008" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="3" cpuset="0x00000008" complete_cpuset="0x00000008" online_cpuset="0x00000008" allowed_cpuset="0x00000008">
+                  <object type="PU" os_index="3" cpuset="0x00000008" complete_cpuset="0x00000008" online_cpuset="0x00000008" allowed_cpuset="0x00000008"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+    </object>
+    <object type="Bridge" os_index="0" bridge_type="0-1" depth="0" bridge_pci="0000:[00-03]">
+      <object type="Bridge" os_index="16" bridge_type="1-1" depth="1" bridge_pci="0000:[01-01]" pci_busid="0000:00:01.0" pci_type="0604 [8086:2981] [8086:0000] 02" pci_link_speed="0.000000">
+        <object type="PCIDev" os_index="4096" pci_busid="0000:01:00.0" pci_type="0300 [1ab8:4005] [1ab8:0400] 00" pci_link_speed="0.000000"/>
+      </object>
+      <object type="PCIDev" os_index="80" pci_busid="0000:00:05.0" pci_type="0200 [1af4:1000] [1af4:0001] 00" pci_link_speed="0.000000"/>
+      <object type="PCIDev" os_index="497" pci_busid="0000:00:1f.1" pci_type="0101 [8086:244b] [1ab8:0400] 05" pci_link_speed="0.000000"/>
+      <object type="PCIDev" os_index="498" pci_busid="0000:00:1f.2" pci_type="0106 [8086:2821] [1ab8:0400] 02" pci_link_speed="0.000000">
+        <object type="OSDev" name="sda" osdev_type="0">
+          <info name="LinuxDeviceID" value="8:0"/>
+          <info name="Model" value="CentOS_Linux_7-0_SSD"/>
+          <info name="Revision" value="F.ZDSG90"/>
+          <info name="SerialNumber" value="RSQDEVQ5RVR45EJJ1V33"/>
+          <info name="Type" value="Disk"/>
+        </object>
+        <object type="OSDev" name="sr0" osdev_type="0">
+          <info name="LinuxDeviceID" value="11:0"/>
+          <info name="Model" value="Virtual_DVD-ROM__1_"/>
+          <info name="Revision" value="FWR1"/>
+          <info name="SerialNumber" value="-_31415B265"/>
+          <info name="Type" value="Removable Media Device"/>
+        </object>
+      </object>
+    </object>
+    <object type="Bridge" os_index="1" bridge_type="0-1" depth="0" bridge_pci="0000:[17-18]">
+      <object type="Bridge" os_index="94208" bridge_type="1-1" depth="1" bridge_pci="0000:[18-18]" pci_busid="0000:17:00.0" pci_type="0604 [8086:2030] [8086:35ce] 06" pci_link_speed="0.000000">
+        <info name="PCISlot" value="785"/>
+        <object type="PCIDev" os_index="98304" pci_busid="0000:18:00.0" pci_type="0208 [8086:24f0] [8086:24f0] 11" pci_link_speed="0.000000">
+          <object type="OSDev" name="ib0" osdev_type="2">
+            <info name="Address" value="80:00:00:02:fe:80:00:00:00:00:00:00:00:11:75:09:01:05:64:4f"/>
+            <info name="Port" value="1"/>
+          </object>
+          <object type="OSDev" name="hfi1_0" osdev_type="3">
+            <info name="NodeGUID" value="0011:7509:0105:644f"/>
+            <info name="SysImageGUID" value="0011:7509:0105:644f"/>
+            <info name="Port1State" value="4"/>
+            <info name="Port1LID" value="0x59"/>
+            <info name="Port1LMC" value="0"/>
+            <info name="Port1GID0" value="fe80:0000:0000:0000:0011:7509:0105:644f"/>
+          </object>
+        </object>
+      </object>
+    </object>
+  </object>
+</topology>

--- a/src/control/lib/hardware/hwloc/testdata/wolf-133.xml
+++ b/src/control/lib/hardware/hwloc/testdata/wolf-133.xml
@@ -1,0 +1,801 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE topology SYSTEM "hwloc.dtd">
+<topology>
+  <object type="Machine" os_index="0" cpuset="0xffffffff,0xffffffff,0xffffffff" complete_cpuset="0xffffffff,0xffffffff,0xffffffff" online_cpuset="0xffffffff,0xffffffff,0xffffffff" allowed_cpuset="0xffffffff,0xffffffff,0xffffffff" nodeset="0x00000003" complete_nodeset="0x00000003" allowed_nodeset="0x00000003">
+    <page_type size="4096" count="0"/>
+    <page_type size="2097152" count="0"/>
+    <page_type size="1073741824" count="0"/>
+    <info name="DMIProductName" value="S2600WFT"/>
+    <info name="DMIProductVersion" value="R2208WFTZS"/>
+    <info name="DMIBoardVendor" value="Intel Corporation"/>
+    <info name="DMIBoardName" value="S2600WFT"/>
+    <info name="DMIBoardVersion" value="H48104-853"/>
+    <info name="DMIBoardAssetTag" value="Base Board Asset Tag"/>
+    <info name="DMIChassisVendor" value="..............................."/>
+    <info name="DMIChassisType" value="23"/>
+    <info name="DMIChassisVersion" value=".................."/>
+    <info name="DMIChassisAssetTag" value="...................."/>
+    <info name="DMIBIOSVendor" value="Intel Corporation"/>
+    <info name="DMIBIOSVersion" value="SE5C620.86B.0D.01.0286.011120190816"/>
+    <info name="DMIBIOSDate" value="01/11/2019"/>
+    <info name="DMISysVendor" value="Intel Corporation"/>
+    <info name="Backend" value="Linux"/>
+    <info name="LinuxCgroup" value="/"/>
+    <info name="OSName" value="Linux"/>
+    <info name="OSRelease" value="3.10.0-957.12.1.el7.x86_64"/>
+    <info name="OSVersion" value="#1 SMP Mon Apr 29 14:59:59 UTC 2019"/>
+    <info name="HostName" value="wolf-133.wolf.hpdd.intel.com"/>
+    <info name="Architecture" value="x86_64"/>
+    <info name="hwlocVersion" value="1.11.5"/>
+    <info name="ProcessName" value="lstopo"/>
+    <distances nbobjs="2" relative_depth="1" latency_base="10.000000">
+      <latency value="1.000000"/>
+      <latency value="2.100000"/>
+      <latency value="2.100000"/>
+      <latency value="1.000000"/>
+    </distances>
+    <object type="NUMANode" os_index="0" cpuset="0x000000ff,0xffff0000,0x00ffffff" complete_cpuset="0x000000ff,0xffff0000,0x00ffffff" online_cpuset="0x000000ff,0xffff0000,0x00ffffff" allowed_cpuset="0x000000ff,0xffff0000,0x00ffffff" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" local_memory="3232704679936">
+      <page_type size="4096" count="789234541"/>
+      <page_type size="2097152" count="0"/>
+      <page_type size="1073741824" count="0"/>
+      <object type="Package" os_index="0" cpuset="0x000000ff,0xffff0000,0x00ffffff" complete_cpuset="0x000000ff,0xffff0000,0x00ffffff" online_cpuset="0x000000ff,0xffff0000,0x00ffffff" allowed_cpuset="0x000000ff,0xffff0000,0x00ffffff" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+        <info name="CPUVendor" value="GenuineIntel"/>
+        <info name="CPUFamilyNumber" value="6"/>
+        <info name="CPUModelNumber" value="85"/>
+        <info name="CPUModel" value="Intel(R) Xeon(R) Platinum 8260L CPU @ 2.40GHz"/>
+        <info name="CPUStepping" value="6"/>
+        <object type="Cache" cpuset="0x000000ff,0xffff0000,0x00ffffff" complete_cpuset="0x000000ff,0xffff0000,0x00ffffff" online_cpuset="0x000000ff,0xffff0000,0x00ffffff" allowed_cpuset="0x000000ff,0xffff0000,0x00ffffff" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="37486592" depth="3" cache_linesize="64" cache_associativity="11" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="Cache" cpuset="0x00010000,0x00000001" complete_cpuset="0x00010000,0x00000001" online_cpuset="0x00010000,0x00000001" allowed_cpuset="0x00010000,0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x00010000,0x00000001" complete_cpuset="0x00010000,0x00000001" online_cpuset="0x00010000,0x00000001" allowed_cpuset="0x00010000,0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00010000,0x00000001" complete_cpuset="0x00010000,0x00000001" online_cpuset="0x00010000,0x00000001" allowed_cpuset="0x00010000,0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="0" cpuset="0x00010000,0x00000001" complete_cpuset="0x00010000,0x00000001" online_cpuset="0x00010000,0x00000001" allowed_cpuset="0x00010000,0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="0" cpuset="0x00000001" complete_cpuset="0x00000001" online_cpuset="0x00000001" allowed_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="48" cpuset="0x00010000,0x0" complete_cpuset="0x00010000,0x0" online_cpuset="0x00010000,0x0" allowed_cpuset="0x00010000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00020000,0x00000002" complete_cpuset="0x00020000,0x00000002" online_cpuset="0x00020000,0x00000002" allowed_cpuset="0x00020000,0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x00020000,0x00000002" complete_cpuset="0x00020000,0x00000002" online_cpuset="0x00020000,0x00000002" allowed_cpuset="0x00020000,0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00020000,0x00000002" complete_cpuset="0x00020000,0x00000002" online_cpuset="0x00020000,0x00000002" allowed_cpuset="0x00020000,0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="1" cpuset="0x00020000,0x00000002" complete_cpuset="0x00020000,0x00000002" online_cpuset="0x00020000,0x00000002" allowed_cpuset="0x00020000,0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="1" cpuset="0x00000002" complete_cpuset="0x00000002" online_cpuset="0x00000002" allowed_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="49" cpuset="0x00020000,0x0" complete_cpuset="0x00020000,0x0" online_cpuset="0x00020000,0x0" allowed_cpuset="0x00020000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00040000,0x00000004" complete_cpuset="0x00040000,0x00000004" online_cpuset="0x00040000,0x00000004" allowed_cpuset="0x00040000,0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x00040000,0x00000004" complete_cpuset="0x00040000,0x00000004" online_cpuset="0x00040000,0x00000004" allowed_cpuset="0x00040000,0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00040000,0x00000004" complete_cpuset="0x00040000,0x00000004" online_cpuset="0x00040000,0x00000004" allowed_cpuset="0x00040000,0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="2" cpuset="0x00040000,0x00000004" complete_cpuset="0x00040000,0x00000004" online_cpuset="0x00040000,0x00000004" allowed_cpuset="0x00040000,0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="2" cpuset="0x00000004" complete_cpuset="0x00000004" online_cpuset="0x00000004" allowed_cpuset="0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="50" cpuset="0x00040000,0x0" complete_cpuset="0x00040000,0x0" online_cpuset="0x00040000,0x0" allowed_cpuset="0x00040000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00080000,0x00000008" complete_cpuset="0x00080000,0x00000008" online_cpuset="0x00080000,0x00000008" allowed_cpuset="0x00080000,0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x00080000,0x00000008" complete_cpuset="0x00080000,0x00000008" online_cpuset="0x00080000,0x00000008" allowed_cpuset="0x00080000,0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00080000,0x00000008" complete_cpuset="0x00080000,0x00000008" online_cpuset="0x00080000,0x00000008" allowed_cpuset="0x00080000,0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="3" cpuset="0x00080000,0x00000008" complete_cpuset="0x00080000,0x00000008" online_cpuset="0x00080000,0x00000008" allowed_cpuset="0x00080000,0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="3" cpuset="0x00000008" complete_cpuset="0x00000008" online_cpuset="0x00000008" allowed_cpuset="0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="51" cpuset="0x00080000,0x0" complete_cpuset="0x00080000,0x0" online_cpuset="0x00080000,0x0" allowed_cpuset="0x00080000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00100000,0x00000010" complete_cpuset="0x00100000,0x00000010" online_cpuset="0x00100000,0x00000010" allowed_cpuset="0x00100000,0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x00100000,0x00000010" complete_cpuset="0x00100000,0x00000010" online_cpuset="0x00100000,0x00000010" allowed_cpuset="0x00100000,0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00100000,0x00000010" complete_cpuset="0x00100000,0x00000010" online_cpuset="0x00100000,0x00000010" allowed_cpuset="0x00100000,0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="4" cpuset="0x00100000,0x00000010" complete_cpuset="0x00100000,0x00000010" online_cpuset="0x00100000,0x00000010" allowed_cpuset="0x00100000,0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="4" cpuset="0x00000010" complete_cpuset="0x00000010" online_cpuset="0x00000010" allowed_cpuset="0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="52" cpuset="0x00100000,0x0" complete_cpuset="0x00100000,0x0" online_cpuset="0x00100000,0x0" allowed_cpuset="0x00100000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00200000,0x00000020" complete_cpuset="0x00200000,0x00000020" online_cpuset="0x00200000,0x00000020" allowed_cpuset="0x00200000,0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x00200000,0x00000020" complete_cpuset="0x00200000,0x00000020" online_cpuset="0x00200000,0x00000020" allowed_cpuset="0x00200000,0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00200000,0x00000020" complete_cpuset="0x00200000,0x00000020" online_cpuset="0x00200000,0x00000020" allowed_cpuset="0x00200000,0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="5" cpuset="0x00200000,0x00000020" complete_cpuset="0x00200000,0x00000020" online_cpuset="0x00200000,0x00000020" allowed_cpuset="0x00200000,0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="5" cpuset="0x00000020" complete_cpuset="0x00000020" online_cpuset="0x00000020" allowed_cpuset="0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="53" cpuset="0x00200000,0x0" complete_cpuset="0x00200000,0x0" online_cpuset="0x00200000,0x0" allowed_cpuset="0x00200000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00400000,0x00000040" complete_cpuset="0x00400000,0x00000040" online_cpuset="0x00400000,0x00000040" allowed_cpuset="0x00400000,0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x00400000,0x00000040" complete_cpuset="0x00400000,0x00000040" online_cpuset="0x00400000,0x00000040" allowed_cpuset="0x00400000,0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00400000,0x00000040" complete_cpuset="0x00400000,0x00000040" online_cpuset="0x00400000,0x00000040" allowed_cpuset="0x00400000,0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="6" cpuset="0x00400000,0x00000040" complete_cpuset="0x00400000,0x00000040" online_cpuset="0x00400000,0x00000040" allowed_cpuset="0x00400000,0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="6" cpuset="0x00000040" complete_cpuset="0x00000040" online_cpuset="0x00000040" allowed_cpuset="0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="54" cpuset="0x00400000,0x0" complete_cpuset="0x00400000,0x0" online_cpuset="0x00400000,0x0" allowed_cpuset="0x00400000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00800000,0x00000080" complete_cpuset="0x00800000,0x00000080" online_cpuset="0x00800000,0x00000080" allowed_cpuset="0x00800000,0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x00800000,0x00000080" complete_cpuset="0x00800000,0x00000080" online_cpuset="0x00800000,0x00000080" allowed_cpuset="0x00800000,0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00800000,0x00000080" complete_cpuset="0x00800000,0x00000080" online_cpuset="0x00800000,0x00000080" allowed_cpuset="0x00800000,0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="9" cpuset="0x00800000,0x00000080" complete_cpuset="0x00800000,0x00000080" online_cpuset="0x00800000,0x00000080" allowed_cpuset="0x00800000,0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="7" cpuset="0x00000080" complete_cpuset="0x00000080" online_cpuset="0x00000080" allowed_cpuset="0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="55" cpuset="0x00800000,0x0" complete_cpuset="0x00800000,0x0" online_cpuset="0x00800000,0x0" allowed_cpuset="0x00800000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x01000000,0x00000100" complete_cpuset="0x01000000,0x00000100" online_cpuset="0x01000000,0x00000100" allowed_cpuset="0x01000000,0x00000100" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x01000000,0x00000100" complete_cpuset="0x01000000,0x00000100" online_cpuset="0x01000000,0x00000100" allowed_cpuset="0x01000000,0x00000100" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x01000000,0x00000100" complete_cpuset="0x01000000,0x00000100" online_cpuset="0x01000000,0x00000100" allowed_cpuset="0x01000000,0x00000100" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="10" cpuset="0x01000000,0x00000100" complete_cpuset="0x01000000,0x00000100" online_cpuset="0x01000000,0x00000100" allowed_cpuset="0x01000000,0x00000100" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="8" cpuset="0x00000100" complete_cpuset="0x00000100" online_cpuset="0x00000100" allowed_cpuset="0x00000100" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="56" cpuset="0x01000000,0x0" complete_cpuset="0x01000000,0x0" online_cpuset="0x01000000,0x0" allowed_cpuset="0x01000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x02000000,0x00000200" complete_cpuset="0x02000000,0x00000200" online_cpuset="0x02000000,0x00000200" allowed_cpuset="0x02000000,0x00000200" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x02000000,0x00000200" complete_cpuset="0x02000000,0x00000200" online_cpuset="0x02000000,0x00000200" allowed_cpuset="0x02000000,0x00000200" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x02000000,0x00000200" complete_cpuset="0x02000000,0x00000200" online_cpuset="0x02000000,0x00000200" allowed_cpuset="0x02000000,0x00000200" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="11" cpuset="0x02000000,0x00000200" complete_cpuset="0x02000000,0x00000200" online_cpuset="0x02000000,0x00000200" allowed_cpuset="0x02000000,0x00000200" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="9" cpuset="0x00000200" complete_cpuset="0x00000200" online_cpuset="0x00000200" allowed_cpuset="0x00000200" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="57" cpuset="0x02000000,0x0" complete_cpuset="0x02000000,0x0" online_cpuset="0x02000000,0x0" allowed_cpuset="0x02000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x04000000,0x00000400" complete_cpuset="0x04000000,0x00000400" online_cpuset="0x04000000,0x00000400" allowed_cpuset="0x04000000,0x00000400" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x04000000,0x00000400" complete_cpuset="0x04000000,0x00000400" online_cpuset="0x04000000,0x00000400" allowed_cpuset="0x04000000,0x00000400" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x04000000,0x00000400" complete_cpuset="0x04000000,0x00000400" online_cpuset="0x04000000,0x00000400" allowed_cpuset="0x04000000,0x00000400" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="12" cpuset="0x04000000,0x00000400" complete_cpuset="0x04000000,0x00000400" online_cpuset="0x04000000,0x00000400" allowed_cpuset="0x04000000,0x00000400" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="10" cpuset="0x00000400" complete_cpuset="0x00000400" online_cpuset="0x00000400" allowed_cpuset="0x00000400" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="58" cpuset="0x04000000,0x0" complete_cpuset="0x04000000,0x0" online_cpuset="0x04000000,0x0" allowed_cpuset="0x04000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x08000000,0x00000800" complete_cpuset="0x08000000,0x00000800" online_cpuset="0x08000000,0x00000800" allowed_cpuset="0x08000000,0x00000800" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x08000000,0x00000800" complete_cpuset="0x08000000,0x00000800" online_cpuset="0x08000000,0x00000800" allowed_cpuset="0x08000000,0x00000800" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x08000000,0x00000800" complete_cpuset="0x08000000,0x00000800" online_cpuset="0x08000000,0x00000800" allowed_cpuset="0x08000000,0x00000800" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="13" cpuset="0x08000000,0x00000800" complete_cpuset="0x08000000,0x00000800" online_cpuset="0x08000000,0x00000800" allowed_cpuset="0x08000000,0x00000800" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="11" cpuset="0x00000800" complete_cpuset="0x00000800" online_cpuset="0x00000800" allowed_cpuset="0x00000800" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="59" cpuset="0x08000000,0x0" complete_cpuset="0x08000000,0x0" online_cpuset="0x08000000,0x0" allowed_cpuset="0x08000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x10000000,0x00001000" complete_cpuset="0x10000000,0x00001000" online_cpuset="0x10000000,0x00001000" allowed_cpuset="0x10000000,0x00001000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x10000000,0x00001000" complete_cpuset="0x10000000,0x00001000" online_cpuset="0x10000000,0x00001000" allowed_cpuset="0x10000000,0x00001000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x10000000,0x00001000" complete_cpuset="0x10000000,0x00001000" online_cpuset="0x10000000,0x00001000" allowed_cpuset="0x10000000,0x00001000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="16" cpuset="0x10000000,0x00001000" complete_cpuset="0x10000000,0x00001000" online_cpuset="0x10000000,0x00001000" allowed_cpuset="0x10000000,0x00001000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="12" cpuset="0x00001000" complete_cpuset="0x00001000" online_cpuset="0x00001000" allowed_cpuset="0x00001000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="60" cpuset="0x10000000,0x0" complete_cpuset="0x10000000,0x0" online_cpuset="0x10000000,0x0" allowed_cpuset="0x10000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x20000000,0x00002000" complete_cpuset="0x20000000,0x00002000" online_cpuset="0x20000000,0x00002000" allowed_cpuset="0x20000000,0x00002000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x20000000,0x00002000" complete_cpuset="0x20000000,0x00002000" online_cpuset="0x20000000,0x00002000" allowed_cpuset="0x20000000,0x00002000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x20000000,0x00002000" complete_cpuset="0x20000000,0x00002000" online_cpuset="0x20000000,0x00002000" allowed_cpuset="0x20000000,0x00002000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="17" cpuset="0x20000000,0x00002000" complete_cpuset="0x20000000,0x00002000" online_cpuset="0x20000000,0x00002000" allowed_cpuset="0x20000000,0x00002000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="13" cpuset="0x00002000" complete_cpuset="0x00002000" online_cpuset="0x00002000" allowed_cpuset="0x00002000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="61" cpuset="0x20000000,0x0" complete_cpuset="0x20000000,0x0" online_cpuset="0x20000000,0x0" allowed_cpuset="0x20000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x40000000,0x00004000" complete_cpuset="0x40000000,0x00004000" online_cpuset="0x40000000,0x00004000" allowed_cpuset="0x40000000,0x00004000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x40000000,0x00004000" complete_cpuset="0x40000000,0x00004000" online_cpuset="0x40000000,0x00004000" allowed_cpuset="0x40000000,0x00004000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x40000000,0x00004000" complete_cpuset="0x40000000,0x00004000" online_cpuset="0x40000000,0x00004000" allowed_cpuset="0x40000000,0x00004000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="18" cpuset="0x40000000,0x00004000" complete_cpuset="0x40000000,0x00004000" online_cpuset="0x40000000,0x00004000" allowed_cpuset="0x40000000,0x00004000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="14" cpuset="0x00004000" complete_cpuset="0x00004000" online_cpuset="0x00004000" allowed_cpuset="0x00004000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="62" cpuset="0x40000000,0x0" complete_cpuset="0x40000000,0x0" online_cpuset="0x40000000,0x0" allowed_cpuset="0x40000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x80000000,0x00008000" complete_cpuset="0x80000000,0x00008000" online_cpuset="0x80000000,0x00008000" allowed_cpuset="0x80000000,0x00008000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x80000000,0x00008000" complete_cpuset="0x80000000,0x00008000" online_cpuset="0x80000000,0x00008000" allowed_cpuset="0x80000000,0x00008000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x80000000,0x00008000" complete_cpuset="0x80000000,0x00008000" online_cpuset="0x80000000,0x00008000" allowed_cpuset="0x80000000,0x00008000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="19" cpuset="0x80000000,0x00008000" complete_cpuset="0x80000000,0x00008000" online_cpuset="0x80000000,0x00008000" allowed_cpuset="0x80000000,0x00008000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="15" cpuset="0x00008000" complete_cpuset="0x00008000" online_cpuset="0x00008000" allowed_cpuset="0x00008000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="63" cpuset="0x80000000,0x0" complete_cpuset="0x80000000,0x0" online_cpuset="0x80000000,0x0" allowed_cpuset="0x80000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000001,,0x00010000" complete_cpuset="0x00000001,,0x00010000" online_cpuset="0x00000001,,0x00010000" allowed_cpuset="0x00000001,,0x00010000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x00000001,,0x00010000" complete_cpuset="0x00000001,,0x00010000" online_cpuset="0x00000001,,0x00010000" allowed_cpuset="0x00000001,,0x00010000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000001,,0x00010000" complete_cpuset="0x00000001,,0x00010000" online_cpuset="0x00000001,,0x00010000" allowed_cpuset="0x00000001,,0x00010000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="20" cpuset="0x00000001,,0x00010000" complete_cpuset="0x00000001,,0x00010000" online_cpuset="0x00000001,,0x00010000" allowed_cpuset="0x00000001,,0x00010000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="16" cpuset="0x00010000" complete_cpuset="0x00010000" online_cpuset="0x00010000" allowed_cpuset="0x00010000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="64" cpuset="0x00000001,,0x0" complete_cpuset="0x00000001,,0x0" online_cpuset="0x00000001,,0x0" allowed_cpuset="0x00000001,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000002,,0x00020000" complete_cpuset="0x00000002,,0x00020000" online_cpuset="0x00000002,,0x00020000" allowed_cpuset="0x00000002,,0x00020000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x00000002,,0x00020000" complete_cpuset="0x00000002,,0x00020000" online_cpuset="0x00000002,,0x00020000" allowed_cpuset="0x00000002,,0x00020000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000002,,0x00020000" complete_cpuset="0x00000002,,0x00020000" online_cpuset="0x00000002,,0x00020000" allowed_cpuset="0x00000002,,0x00020000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="21" cpuset="0x00000002,,0x00020000" complete_cpuset="0x00000002,,0x00020000" online_cpuset="0x00000002,,0x00020000" allowed_cpuset="0x00000002,,0x00020000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="17" cpuset="0x00020000" complete_cpuset="0x00020000" online_cpuset="0x00020000" allowed_cpuset="0x00020000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="65" cpuset="0x00000002,,0x0" complete_cpuset="0x00000002,,0x0" online_cpuset="0x00000002,,0x0" allowed_cpuset="0x00000002,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000004,,0x00040000" complete_cpuset="0x00000004,,0x00040000" online_cpuset="0x00000004,,0x00040000" allowed_cpuset="0x00000004,,0x00040000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x00000004,,0x00040000" complete_cpuset="0x00000004,,0x00040000" online_cpuset="0x00000004,,0x00040000" allowed_cpuset="0x00000004,,0x00040000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000004,,0x00040000" complete_cpuset="0x00000004,,0x00040000" online_cpuset="0x00000004,,0x00040000" allowed_cpuset="0x00000004,,0x00040000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="24" cpuset="0x00000004,,0x00040000" complete_cpuset="0x00000004,,0x00040000" online_cpuset="0x00000004,,0x00040000" allowed_cpuset="0x00000004,,0x00040000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="18" cpuset="0x00040000" complete_cpuset="0x00040000" online_cpuset="0x00040000" allowed_cpuset="0x00040000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="66" cpuset="0x00000004,,0x0" complete_cpuset="0x00000004,,0x0" online_cpuset="0x00000004,,0x0" allowed_cpuset="0x00000004,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000008,,0x00080000" complete_cpuset="0x00000008,,0x00080000" online_cpuset="0x00000008,,0x00080000" allowed_cpuset="0x00000008,,0x00080000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x00000008,,0x00080000" complete_cpuset="0x00000008,,0x00080000" online_cpuset="0x00000008,,0x00080000" allowed_cpuset="0x00000008,,0x00080000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000008,,0x00080000" complete_cpuset="0x00000008,,0x00080000" online_cpuset="0x00000008,,0x00080000" allowed_cpuset="0x00000008,,0x00080000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="25" cpuset="0x00000008,,0x00080000" complete_cpuset="0x00000008,,0x00080000" online_cpuset="0x00000008,,0x00080000" allowed_cpuset="0x00000008,,0x00080000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="19" cpuset="0x00080000" complete_cpuset="0x00080000" online_cpuset="0x00080000" allowed_cpuset="0x00080000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="67" cpuset="0x00000008,,0x0" complete_cpuset="0x00000008,,0x0" online_cpuset="0x00000008,,0x0" allowed_cpuset="0x00000008,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000010,,0x00100000" complete_cpuset="0x00000010,,0x00100000" online_cpuset="0x00000010,,0x00100000" allowed_cpuset="0x00000010,,0x00100000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x00000010,,0x00100000" complete_cpuset="0x00000010,,0x00100000" online_cpuset="0x00000010,,0x00100000" allowed_cpuset="0x00000010,,0x00100000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000010,,0x00100000" complete_cpuset="0x00000010,,0x00100000" online_cpuset="0x00000010,,0x00100000" allowed_cpuset="0x00000010,,0x00100000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="26" cpuset="0x00000010,,0x00100000" complete_cpuset="0x00000010,,0x00100000" online_cpuset="0x00000010,,0x00100000" allowed_cpuset="0x00000010,,0x00100000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="20" cpuset="0x00100000" complete_cpuset="0x00100000" online_cpuset="0x00100000" allowed_cpuset="0x00100000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="68" cpuset="0x00000010,,0x0" complete_cpuset="0x00000010,,0x0" online_cpuset="0x00000010,,0x0" allowed_cpuset="0x00000010,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000020,,0x00200000" complete_cpuset="0x00000020,,0x00200000" online_cpuset="0x00000020,,0x00200000" allowed_cpuset="0x00000020,,0x00200000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x00000020,,0x00200000" complete_cpuset="0x00000020,,0x00200000" online_cpuset="0x00000020,,0x00200000" allowed_cpuset="0x00000020,,0x00200000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000020,,0x00200000" complete_cpuset="0x00000020,,0x00200000" online_cpuset="0x00000020,,0x00200000" allowed_cpuset="0x00000020,,0x00200000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="27" cpuset="0x00000020,,0x00200000" complete_cpuset="0x00000020,,0x00200000" online_cpuset="0x00000020,,0x00200000" allowed_cpuset="0x00000020,,0x00200000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="21" cpuset="0x00200000" complete_cpuset="0x00200000" online_cpuset="0x00200000" allowed_cpuset="0x00200000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="69" cpuset="0x00000020,,0x0" complete_cpuset="0x00000020,,0x0" online_cpuset="0x00000020,,0x0" allowed_cpuset="0x00000020,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000040,,0x00400000" complete_cpuset="0x00000040,,0x00400000" online_cpuset="0x00000040,,0x00400000" allowed_cpuset="0x00000040,,0x00400000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x00000040,,0x00400000" complete_cpuset="0x00000040,,0x00400000" online_cpuset="0x00000040,,0x00400000" allowed_cpuset="0x00000040,,0x00400000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000040,,0x00400000" complete_cpuset="0x00000040,,0x00400000" online_cpuset="0x00000040,,0x00400000" allowed_cpuset="0x00000040,,0x00400000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="28" cpuset="0x00000040,,0x00400000" complete_cpuset="0x00000040,,0x00400000" online_cpuset="0x00000040,,0x00400000" allowed_cpuset="0x00000040,,0x00400000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="22" cpuset="0x00400000" complete_cpuset="0x00400000" online_cpuset="0x00400000" allowed_cpuset="0x00400000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="70" cpuset="0x00000040,,0x0" complete_cpuset="0x00000040,,0x0" online_cpuset="0x00000040,,0x0" allowed_cpuset="0x00000040,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000080,,0x00800000" complete_cpuset="0x00000080,,0x00800000" online_cpuset="0x00000080,,0x00800000" allowed_cpuset="0x00000080,,0x00800000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x00000080,,0x00800000" complete_cpuset="0x00000080,,0x00800000" online_cpuset="0x00000080,,0x00800000" allowed_cpuset="0x00000080,,0x00800000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000080,,0x00800000" complete_cpuset="0x00000080,,0x00800000" online_cpuset="0x00000080,,0x00800000" allowed_cpuset="0x00000080,,0x00800000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="29" cpuset="0x00000080,,0x00800000" complete_cpuset="0x00000080,,0x00800000" online_cpuset="0x00000080,,0x00800000" allowed_cpuset="0x00000080,,0x00800000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="23" cpuset="0x00800000" complete_cpuset="0x00800000" online_cpuset="0x00800000" allowed_cpuset="0x00800000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="71" cpuset="0x00000080,,0x0" complete_cpuset="0x00000080,,0x0" online_cpuset="0x00000080,,0x0" allowed_cpuset="0x00000080,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="Bridge" os_index="0" bridge_type="0-1" depth="0" bridge_pci="0000:[00-02]">
+        <object type="PCIDev" os_index="277" pci_busid="0000:00:11.5" pci_type="0106 [8086:a1d2] [8086:35ce] 09" pci_link_speed="0.000000">
+          <object type="OSDev" name="sda" osdev_type="0">
+            <info name="LinuxDeviceID" value="8:0"/>
+            <info name="Model" value="INTEL_SSDSCKKI256G8"/>
+            <info name="Revision" value="LHF001D"/>
+            <info name="SerialNumber" value="BTLA80230PFN256J"/>
+            <info name="Type" value="Disk"/>
+          </object>
+        </object>
+        <object type="PCIDev" os_index="368" pci_busid="0000:00:17.0" pci_type="0106 [8086:a182] [8086:35ce] 09" pci_link_speed="0.000000"/>
+        <object type="Bridge" os_index="448" bridge_type="1-1" depth="1" bridge_pci="0000:[01-02]" pci_busid="0000:00:1c.0" pci_type="0604 [8086:a193] [8086:35ce] f9" pci_link_speed="0.000000">
+          <object type="Bridge" os_index="4096" bridge_type="1-1" depth="2" bridge_pci="0000:[02-02]" pci_busid="0000:01:00.0" pci_type="0604 [1a03:1150] [1a03:1150] 04" pci_link_speed="0.000000">
+            <object type="PCIDev" os_index="8192" pci_busid="0000:02:00.0" pci_type="0300 [1a03:2000] [1a03:2000] 41" pci_link_speed="0.000000">
+              <object type="OSDev" name="card0" osdev_type="1"/>
+              <object type="OSDev" name="controlD64" osdev_type="1"/>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="Bridge" os_index="1" bridge_type="0-1" depth="0" bridge_pci="0000:[17-18]">
+        <object type="Bridge" os_index="94208" bridge_type="1-1" depth="1" bridge_pci="0000:[18-18]" pci_busid="0000:17:00.0" pci_type="0604 [8086:2030] [8086:35ce] 06" pci_link_speed="0.000000">
+          <info name="PCISlot" value="785"/>
+          <object type="PCIDev" os_index="98304" pci_busid="0000:18:00.0" pci_type="0208 [8086:24f0] [8086:24f0] 11" pci_link_speed="0.000000">
+            <object type="OSDev" name="ib0" osdev_type="2">
+              <info name="Address" value="80:81:00:02:fe:80:00:00:00:00:00:00:00:11:75:09:01:05:6b:92"/>
+              <info name="Port" value="1"/>
+            </object>
+            <object type="OSDev" name="hfi1_0" osdev_type="3">
+              <info name="NodeGUID" value="0011:7509:0105:6b92"/>
+              <info name="SysImageGUID" value="0011:7509:0105:6b92"/>
+              <info name="Port1State" value="4"/>
+              <info name="Port1LID" value="0x230"/>
+              <info name="Port1LMC" value="3"/>
+              <info name="Port1GID0" value="fe80:0000:0000:0000:0011:7509:0105:6b92"/>
+              <info name="Port1GID1" value="fe80:0000:0000:0000:0006:6a00:0000:0230"/>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="Bridge" os_index="2" bridge_type="0-1" depth="0" bridge_pci="0000:[3a-3e]">
+        <object type="Bridge" os_index="237568" bridge_type="1-1" depth="1" bridge_pci="0000:[3b-3e]" pci_busid="0000:3a:00.0" pci_type="0604 [8086:2030] [8086:35ce] 06" pci_link_speed="0.000000">
+          <info name="PCISlot" value="0-1"/>
+          <object type="Bridge" os_index="241664" bridge_type="1-1" depth="2" bridge_pci="0000:[3c-3e]" pci_busid="0000:3b:00.0" pci_type="0604 [8086:37c0] [8086:dead] 09" pci_link_speed="0.000000">
+            <object type="Bridge" os_index="245808" bridge_type="1-1" depth="3" bridge_pci="0000:[3d-3e]" pci_busid="0000:3c:03.0" pci_type="0604 [8086:37c5] [8086:dead] 09" pci_link_speed="0.000000">
+              <object type="PCIDev" os_index="249856" pci_busid="0000:3d:00.0" pci_type="0200 [8086:37d2] [8086:35ce] 09" pci_link_speed="0.000000">
+                <object type="OSDev" name="eth0" osdev_type="2">
+                  <info name="Address" value="a4:bf:01:5a:3e:c7"/>
+                  <info name="Port" value="1"/>
+                </object>
+                <object type="OSDev" name="i40iw1" osdev_type="3">
+                  <info name="NodeGUID" value="a4bf:015a:3ec7:0000"/>
+                  <info name="SysImageGUID" value="a4bf:015a:3ec7:0000"/>
+                  <info name="Port1State" value="4"/>
+                  <info name="Port1LID" value="0x1"/>
+                  <info name="Port1LMC" value="0"/>
+                </object>
+              </object>
+              <object type="PCIDev" os_index="249857" pci_busid="0000:3d:00.1" pci_type="0200 [8086:37d2] [8086:35ce] 09" pci_link_speed="0.000000">
+                <object type="OSDev" name="eth1" osdev_type="2">
+                  <info name="Address" value="a4:bf:01:5a:3e:c8"/>
+                  <info name="Port" value="1"/>
+                </object>
+                <object type="OSDev" name="i40iw0" osdev_type="3">
+                  <info name="NodeGUID" value="a4bf:015a:3ec8:0000"/>
+                  <info name="SysImageGUID" value="a4bf:015a:3ec8:0000"/>
+                  <info name="Port1State" value="1"/>
+                  <info name="Port1LID" value="0x1"/>
+                  <info name="Port1LMC" value="0"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="Bridge" os_index="3" bridge_type="0-1" depth="0" bridge_pci="0000:[5d-5f]">
+        <object type="Bridge" os_index="380960" bridge_type="1-1" depth="1" bridge_pci="0000:[5e-5e]" pci_busid="0000:5d:02.0" pci_type="0604 [8086:2032] [8086:35ce] 06" pci_link_speed="0.000000">
+          <info name="PCISlot" value="257"/>
+          <object type="PCIDev" os_index="385024" pci_busid="0000:5e:00.0" pci_type="0108 [8086:0a54] [8086:4812] 00" pci_link_speed="0.000000">
+            <info name="PCISlot" value="257-1"/>
+          </object>
+        </object>
+        <object type="Bridge" os_index="380976" bridge_type="1-1" depth="1" bridge_pci="0000:[5f-5f]" pci_busid="0000:5d:03.0" pci_type="0604 [8086:2033] [8086:35ce] 06" pci_link_speed="0.000000">
+          <info name="PCISlot" value="258"/>
+          <object type="PCIDev" os_index="389120" pci_busid="0000:5f:00.0" pci_type="0108 [8086:0a54] [8086:4812] 00" pci_link_speed="0.000000">
+            <info name="PCISlot" value="258-1"/>
+          </object>
+        </object>
+      </object>
+    </object>
+    <object type="NUMANode" os_index="1" cpuset="0xffffff00,0x0000ffff,0xff000000" complete_cpuset="0xffffff00,0x0000ffff,0xff000000" online_cpuset="0xffffff00,0x0000ffff,0xff000000" allowed_cpuset="0xffffff00,0x0000ffff,0xff000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" local_memory="3234110373888">
+      <page_type size="4096" count="789577728"/>
+      <page_type size="2097152" count="0"/>
+      <page_type size="1073741824" count="0"/>
+      <object type="Package" os_index="1" cpuset="0xffffff00,0x0000ffff,0xff000000" complete_cpuset="0xffffff00,0x0000ffff,0xff000000" online_cpuset="0xffffff00,0x0000ffff,0xff000000" allowed_cpuset="0xffffff00,0x0000ffff,0xff000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+        <info name="CPUVendor" value="GenuineIntel"/>
+        <info name="CPUFamilyNumber" value="6"/>
+        <info name="CPUModelNumber" value="85"/>
+        <info name="CPUModel" value="Intel(R) Xeon(R) Platinum 8260L CPU @ 2.40GHz"/>
+        <info name="CPUStepping" value="6"/>
+        <object type="Cache" cpuset="0xffffff00,0x0000ffff,0xff000000" complete_cpuset="0xffffff00,0x0000ffff,0xff000000" online_cpuset="0xffffff00,0x0000ffff,0xff000000" allowed_cpuset="0xffffff00,0x0000ffff,0xff000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="37486592" depth="3" cache_linesize="64" cache_associativity="11" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="Cache" cpuset="0x00000100,,0x01000000" complete_cpuset="0x00000100,,0x01000000" online_cpuset="0x00000100,,0x01000000" allowed_cpuset="0x00000100,,0x01000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x00000100,,0x01000000" complete_cpuset="0x00000100,,0x01000000" online_cpuset="0x00000100,,0x01000000" allowed_cpuset="0x00000100,,0x01000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000100,,0x01000000" complete_cpuset="0x00000100,,0x01000000" online_cpuset="0x00000100,,0x01000000" allowed_cpuset="0x00000100,,0x01000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="0" cpuset="0x00000100,,0x01000000" complete_cpuset="0x00000100,,0x01000000" online_cpuset="0x00000100,,0x01000000" allowed_cpuset="0x00000100,,0x01000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="24" cpuset="0x01000000" complete_cpuset="0x01000000" online_cpuset="0x01000000" allowed_cpuset="0x01000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                  <object type="PU" os_index="72" cpuset="0x00000100,,0x0" complete_cpuset="0x00000100,,0x0" online_cpuset="0x00000100,,0x0" allowed_cpuset="0x00000100,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000200,,0x02000000" complete_cpuset="0x00000200,,0x02000000" online_cpuset="0x00000200,,0x02000000" allowed_cpuset="0x00000200,,0x02000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x00000200,,0x02000000" complete_cpuset="0x00000200,,0x02000000" online_cpuset="0x00000200,,0x02000000" allowed_cpuset="0x00000200,,0x02000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000200,,0x02000000" complete_cpuset="0x00000200,,0x02000000" online_cpuset="0x00000200,,0x02000000" allowed_cpuset="0x00000200,,0x02000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="1" cpuset="0x00000200,,0x02000000" complete_cpuset="0x00000200,,0x02000000" online_cpuset="0x00000200,,0x02000000" allowed_cpuset="0x00000200,,0x02000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="25" cpuset="0x02000000" complete_cpuset="0x02000000" online_cpuset="0x02000000" allowed_cpuset="0x02000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                  <object type="PU" os_index="73" cpuset="0x00000200,,0x0" complete_cpuset="0x00000200,,0x0" online_cpuset="0x00000200,,0x0" allowed_cpuset="0x00000200,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000400,,0x04000000" complete_cpuset="0x00000400,,0x04000000" online_cpuset="0x00000400,,0x04000000" allowed_cpuset="0x00000400,,0x04000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x00000400,,0x04000000" complete_cpuset="0x00000400,,0x04000000" online_cpuset="0x00000400,,0x04000000" allowed_cpuset="0x00000400,,0x04000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000400,,0x04000000" complete_cpuset="0x00000400,,0x04000000" online_cpuset="0x00000400,,0x04000000" allowed_cpuset="0x00000400,,0x04000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="2" cpuset="0x00000400,,0x04000000" complete_cpuset="0x00000400,,0x04000000" online_cpuset="0x00000400,,0x04000000" allowed_cpuset="0x00000400,,0x04000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="26" cpuset="0x04000000" complete_cpuset="0x04000000" online_cpuset="0x04000000" allowed_cpuset="0x04000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                  <object type="PU" os_index="74" cpuset="0x00000400,,0x0" complete_cpuset="0x00000400,,0x0" online_cpuset="0x00000400,,0x0" allowed_cpuset="0x00000400,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000800,,0x08000000" complete_cpuset="0x00000800,,0x08000000" online_cpuset="0x00000800,,0x08000000" allowed_cpuset="0x00000800,,0x08000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x00000800,,0x08000000" complete_cpuset="0x00000800,,0x08000000" online_cpuset="0x00000800,,0x08000000" allowed_cpuset="0x00000800,,0x08000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000800,,0x08000000" complete_cpuset="0x00000800,,0x08000000" online_cpuset="0x00000800,,0x08000000" allowed_cpuset="0x00000800,,0x08000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="3" cpuset="0x00000800,,0x08000000" complete_cpuset="0x00000800,,0x08000000" online_cpuset="0x00000800,,0x08000000" allowed_cpuset="0x00000800,,0x08000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="27" cpuset="0x08000000" complete_cpuset="0x08000000" online_cpuset="0x08000000" allowed_cpuset="0x08000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                  <object type="PU" os_index="75" cpuset="0x00000800,,0x0" complete_cpuset="0x00000800,,0x0" online_cpuset="0x00000800,,0x0" allowed_cpuset="0x00000800,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00001000,,0x10000000" complete_cpuset="0x00001000,,0x10000000" online_cpuset="0x00001000,,0x10000000" allowed_cpuset="0x00001000,,0x10000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x00001000,,0x10000000" complete_cpuset="0x00001000,,0x10000000" online_cpuset="0x00001000,,0x10000000" allowed_cpuset="0x00001000,,0x10000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00001000,,0x10000000" complete_cpuset="0x00001000,,0x10000000" online_cpuset="0x00001000,,0x10000000" allowed_cpuset="0x00001000,,0x10000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="5" cpuset="0x00001000,,0x10000000" complete_cpuset="0x00001000,,0x10000000" online_cpuset="0x00001000,,0x10000000" allowed_cpuset="0x00001000,,0x10000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="28" cpuset="0x10000000" complete_cpuset="0x10000000" online_cpuset="0x10000000" allowed_cpuset="0x10000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                  <object type="PU" os_index="76" cpuset="0x00001000,,0x0" complete_cpuset="0x00001000,,0x0" online_cpuset="0x00001000,,0x0" allowed_cpuset="0x00001000,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00002000,,0x20000000" complete_cpuset="0x00002000,,0x20000000" online_cpuset="0x00002000,,0x20000000" allowed_cpuset="0x00002000,,0x20000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x00002000,,0x20000000" complete_cpuset="0x00002000,,0x20000000" online_cpuset="0x00002000,,0x20000000" allowed_cpuset="0x00002000,,0x20000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00002000,,0x20000000" complete_cpuset="0x00002000,,0x20000000" online_cpuset="0x00002000,,0x20000000" allowed_cpuset="0x00002000,,0x20000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="6" cpuset="0x00002000,,0x20000000" complete_cpuset="0x00002000,,0x20000000" online_cpuset="0x00002000,,0x20000000" allowed_cpuset="0x00002000,,0x20000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="29" cpuset="0x20000000" complete_cpuset="0x20000000" online_cpuset="0x20000000" allowed_cpuset="0x20000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                  <object type="PU" os_index="77" cpuset="0x00002000,,0x0" complete_cpuset="0x00002000,,0x0" online_cpuset="0x00002000,,0x0" allowed_cpuset="0x00002000,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00004000,,0x40000000" complete_cpuset="0x00004000,,0x40000000" online_cpuset="0x00004000,,0x40000000" allowed_cpuset="0x00004000,,0x40000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x00004000,,0x40000000" complete_cpuset="0x00004000,,0x40000000" online_cpuset="0x00004000,,0x40000000" allowed_cpuset="0x00004000,,0x40000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00004000,,0x40000000" complete_cpuset="0x00004000,,0x40000000" online_cpuset="0x00004000,,0x40000000" allowed_cpuset="0x00004000,,0x40000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="8" cpuset="0x00004000,,0x40000000" complete_cpuset="0x00004000,,0x40000000" online_cpuset="0x00004000,,0x40000000" allowed_cpuset="0x00004000,,0x40000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="30" cpuset="0x40000000" complete_cpuset="0x40000000" online_cpuset="0x40000000" allowed_cpuset="0x40000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                  <object type="PU" os_index="78" cpuset="0x00004000,,0x0" complete_cpuset="0x00004000,,0x0" online_cpuset="0x00004000,,0x0" allowed_cpuset="0x00004000,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00008000,,0x80000000" complete_cpuset="0x00008000,,0x80000000" online_cpuset="0x00008000,,0x80000000" allowed_cpuset="0x00008000,,0x80000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x00008000,,0x80000000" complete_cpuset="0x00008000,,0x80000000" online_cpuset="0x00008000,,0x80000000" allowed_cpuset="0x00008000,,0x80000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00008000,,0x80000000" complete_cpuset="0x00008000,,0x80000000" online_cpuset="0x00008000,,0x80000000" allowed_cpuset="0x00008000,,0x80000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="9" cpuset="0x00008000,,0x80000000" complete_cpuset="0x00008000,,0x80000000" online_cpuset="0x00008000,,0x80000000" allowed_cpuset="0x00008000,,0x80000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="31" cpuset="0x80000000" complete_cpuset="0x80000000" online_cpuset="0x80000000" allowed_cpuset="0x80000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                  <object type="PU" os_index="79" cpuset="0x00008000,,0x0" complete_cpuset="0x00008000,,0x0" online_cpuset="0x00008000,,0x0" allowed_cpuset="0x00008000,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00010000,0x00000001,0x0" complete_cpuset="0x00010000,0x00000001,0x0" online_cpuset="0x00010000,0x00000001,0x0" allowed_cpuset="0x00010000,0x00000001,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x00010000,0x00000001,0x0" complete_cpuset="0x00010000,0x00000001,0x0" online_cpuset="0x00010000,0x00000001,0x0" allowed_cpuset="0x00010000,0x00000001,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00010000,0x00000001,0x0" complete_cpuset="0x00010000,0x00000001,0x0" online_cpuset="0x00010000,0x00000001,0x0" allowed_cpuset="0x00010000,0x00000001,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="10" cpuset="0x00010000,0x00000001,0x0" complete_cpuset="0x00010000,0x00000001,0x0" online_cpuset="0x00010000,0x00000001,0x0" allowed_cpuset="0x00010000,0x00000001,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="32" cpuset="0x00000001,0x0" complete_cpuset="0x00000001,0x0" online_cpuset="0x00000001,0x0" allowed_cpuset="0x00000001,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                  <object type="PU" os_index="80" cpuset="0x00010000,,0x0" complete_cpuset="0x00010000,,0x0" online_cpuset="0x00010000,,0x0" allowed_cpuset="0x00010000,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00020000,0x00000002,0x0" complete_cpuset="0x00020000,0x00000002,0x0" online_cpuset="0x00020000,0x00000002,0x0" allowed_cpuset="0x00020000,0x00000002,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x00020000,0x00000002,0x0" complete_cpuset="0x00020000,0x00000002,0x0" online_cpuset="0x00020000,0x00000002,0x0" allowed_cpuset="0x00020000,0x00000002,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00020000,0x00000002,0x0" complete_cpuset="0x00020000,0x00000002,0x0" online_cpuset="0x00020000,0x00000002,0x0" allowed_cpuset="0x00020000,0x00000002,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="11" cpuset="0x00020000,0x00000002,0x0" complete_cpuset="0x00020000,0x00000002,0x0" online_cpuset="0x00020000,0x00000002,0x0" allowed_cpuset="0x00020000,0x00000002,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="33" cpuset="0x00000002,0x0" complete_cpuset="0x00000002,0x0" online_cpuset="0x00000002,0x0" allowed_cpuset="0x00000002,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                  <object type="PU" os_index="81" cpuset="0x00020000,,0x0" complete_cpuset="0x00020000,,0x0" online_cpuset="0x00020000,,0x0" allowed_cpuset="0x00020000,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00040000,0x00000004,0x0" complete_cpuset="0x00040000,0x00000004,0x0" online_cpuset="0x00040000,0x00000004,0x0" allowed_cpuset="0x00040000,0x00000004,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x00040000,0x00000004,0x0" complete_cpuset="0x00040000,0x00000004,0x0" online_cpuset="0x00040000,0x00000004,0x0" allowed_cpuset="0x00040000,0x00000004,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00040000,0x00000004,0x0" complete_cpuset="0x00040000,0x00000004,0x0" online_cpuset="0x00040000,0x00000004,0x0" allowed_cpuset="0x00040000,0x00000004,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="12" cpuset="0x00040000,0x00000004,0x0" complete_cpuset="0x00040000,0x00000004,0x0" online_cpuset="0x00040000,0x00000004,0x0" allowed_cpuset="0x00040000,0x00000004,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="34" cpuset="0x00000004,0x0" complete_cpuset="0x00000004,0x0" online_cpuset="0x00000004,0x0" allowed_cpuset="0x00000004,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                  <object type="PU" os_index="82" cpuset="0x00040000,,0x0" complete_cpuset="0x00040000,,0x0" online_cpuset="0x00040000,,0x0" allowed_cpuset="0x00040000,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00080000,0x00000008,0x0" complete_cpuset="0x00080000,0x00000008,0x0" online_cpuset="0x00080000,0x00000008,0x0" allowed_cpuset="0x00080000,0x00000008,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x00080000,0x00000008,0x0" complete_cpuset="0x00080000,0x00000008,0x0" online_cpuset="0x00080000,0x00000008,0x0" allowed_cpuset="0x00080000,0x00000008,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00080000,0x00000008,0x0" complete_cpuset="0x00080000,0x00000008,0x0" online_cpuset="0x00080000,0x00000008,0x0" allowed_cpuset="0x00080000,0x00000008,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="13" cpuset="0x00080000,0x00000008,0x0" complete_cpuset="0x00080000,0x00000008,0x0" online_cpuset="0x00080000,0x00000008,0x0" allowed_cpuset="0x00080000,0x00000008,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="35" cpuset="0x00000008,0x0" complete_cpuset="0x00000008,0x0" online_cpuset="0x00000008,0x0" allowed_cpuset="0x00000008,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                  <object type="PU" os_index="83" cpuset="0x00080000,,0x0" complete_cpuset="0x00080000,,0x0" online_cpuset="0x00080000,,0x0" allowed_cpuset="0x00080000,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00100000,0x00000010,0x0" complete_cpuset="0x00100000,0x00000010,0x0" online_cpuset="0x00100000,0x00000010,0x0" allowed_cpuset="0x00100000,0x00000010,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x00100000,0x00000010,0x0" complete_cpuset="0x00100000,0x00000010,0x0" online_cpuset="0x00100000,0x00000010,0x0" allowed_cpuset="0x00100000,0x00000010,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00100000,0x00000010,0x0" complete_cpuset="0x00100000,0x00000010,0x0" online_cpuset="0x00100000,0x00000010,0x0" allowed_cpuset="0x00100000,0x00000010,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="16" cpuset="0x00100000,0x00000010,0x0" complete_cpuset="0x00100000,0x00000010,0x0" online_cpuset="0x00100000,0x00000010,0x0" allowed_cpuset="0x00100000,0x00000010,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="36" cpuset="0x00000010,0x0" complete_cpuset="0x00000010,0x0" online_cpuset="0x00000010,0x0" allowed_cpuset="0x00000010,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                  <object type="PU" os_index="84" cpuset="0x00100000,,0x0" complete_cpuset="0x00100000,,0x0" online_cpuset="0x00100000,,0x0" allowed_cpuset="0x00100000,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00200000,0x00000020,0x0" complete_cpuset="0x00200000,0x00000020,0x0" online_cpuset="0x00200000,0x00000020,0x0" allowed_cpuset="0x00200000,0x00000020,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x00200000,0x00000020,0x0" complete_cpuset="0x00200000,0x00000020,0x0" online_cpuset="0x00200000,0x00000020,0x0" allowed_cpuset="0x00200000,0x00000020,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00200000,0x00000020,0x0" complete_cpuset="0x00200000,0x00000020,0x0" online_cpuset="0x00200000,0x00000020,0x0" allowed_cpuset="0x00200000,0x00000020,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="17" cpuset="0x00200000,0x00000020,0x0" complete_cpuset="0x00200000,0x00000020,0x0" online_cpuset="0x00200000,0x00000020,0x0" allowed_cpuset="0x00200000,0x00000020,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="37" cpuset="0x00000020,0x0" complete_cpuset="0x00000020,0x0" online_cpuset="0x00000020,0x0" allowed_cpuset="0x00000020,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                  <object type="PU" os_index="85" cpuset="0x00200000,,0x0" complete_cpuset="0x00200000,,0x0" online_cpuset="0x00200000,,0x0" allowed_cpuset="0x00200000,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00400000,0x00000040,0x0" complete_cpuset="0x00400000,0x00000040,0x0" online_cpuset="0x00400000,0x00000040,0x0" allowed_cpuset="0x00400000,0x00000040,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x00400000,0x00000040,0x0" complete_cpuset="0x00400000,0x00000040,0x0" online_cpuset="0x00400000,0x00000040,0x0" allowed_cpuset="0x00400000,0x00000040,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00400000,0x00000040,0x0" complete_cpuset="0x00400000,0x00000040,0x0" online_cpuset="0x00400000,0x00000040,0x0" allowed_cpuset="0x00400000,0x00000040,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="18" cpuset="0x00400000,0x00000040,0x0" complete_cpuset="0x00400000,0x00000040,0x0" online_cpuset="0x00400000,0x00000040,0x0" allowed_cpuset="0x00400000,0x00000040,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="38" cpuset="0x00000040,0x0" complete_cpuset="0x00000040,0x0" online_cpuset="0x00000040,0x0" allowed_cpuset="0x00000040,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                  <object type="PU" os_index="86" cpuset="0x00400000,,0x0" complete_cpuset="0x00400000,,0x0" online_cpuset="0x00400000,,0x0" allowed_cpuset="0x00400000,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00800000,0x00000080,0x0" complete_cpuset="0x00800000,0x00000080,0x0" online_cpuset="0x00800000,0x00000080,0x0" allowed_cpuset="0x00800000,0x00000080,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x00800000,0x00000080,0x0" complete_cpuset="0x00800000,0x00000080,0x0" online_cpuset="0x00800000,0x00000080,0x0" allowed_cpuset="0x00800000,0x00000080,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00800000,0x00000080,0x0" complete_cpuset="0x00800000,0x00000080,0x0" online_cpuset="0x00800000,0x00000080,0x0" allowed_cpuset="0x00800000,0x00000080,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="19" cpuset="0x00800000,0x00000080,0x0" complete_cpuset="0x00800000,0x00000080,0x0" online_cpuset="0x00800000,0x00000080,0x0" allowed_cpuset="0x00800000,0x00000080,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="39" cpuset="0x00000080,0x0" complete_cpuset="0x00000080,0x0" online_cpuset="0x00000080,0x0" allowed_cpuset="0x00000080,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                  <object type="PU" os_index="87" cpuset="0x00800000,,0x0" complete_cpuset="0x00800000,,0x0" online_cpuset="0x00800000,,0x0" allowed_cpuset="0x00800000,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x01000000,0x00000100,0x0" complete_cpuset="0x01000000,0x00000100,0x0" online_cpuset="0x01000000,0x00000100,0x0" allowed_cpuset="0x01000000,0x00000100,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x01000000,0x00000100,0x0" complete_cpuset="0x01000000,0x00000100,0x0" online_cpuset="0x01000000,0x00000100,0x0" allowed_cpuset="0x01000000,0x00000100,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x01000000,0x00000100,0x0" complete_cpuset="0x01000000,0x00000100,0x0" online_cpuset="0x01000000,0x00000100,0x0" allowed_cpuset="0x01000000,0x00000100,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="20" cpuset="0x01000000,0x00000100,0x0" complete_cpuset="0x01000000,0x00000100,0x0" online_cpuset="0x01000000,0x00000100,0x0" allowed_cpuset="0x01000000,0x00000100,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="40" cpuset="0x00000100,0x0" complete_cpuset="0x00000100,0x0" online_cpuset="0x00000100,0x0" allowed_cpuset="0x00000100,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                  <object type="PU" os_index="88" cpuset="0x01000000,,0x0" complete_cpuset="0x01000000,,0x0" online_cpuset="0x01000000,,0x0" allowed_cpuset="0x01000000,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x02000000,0x00000200,0x0" complete_cpuset="0x02000000,0x00000200,0x0" online_cpuset="0x02000000,0x00000200,0x0" allowed_cpuset="0x02000000,0x00000200,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x02000000,0x00000200,0x0" complete_cpuset="0x02000000,0x00000200,0x0" online_cpuset="0x02000000,0x00000200,0x0" allowed_cpuset="0x02000000,0x00000200,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x02000000,0x00000200,0x0" complete_cpuset="0x02000000,0x00000200,0x0" online_cpuset="0x02000000,0x00000200,0x0" allowed_cpuset="0x02000000,0x00000200,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="21" cpuset="0x02000000,0x00000200,0x0" complete_cpuset="0x02000000,0x00000200,0x0" online_cpuset="0x02000000,0x00000200,0x0" allowed_cpuset="0x02000000,0x00000200,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="41" cpuset="0x00000200,0x0" complete_cpuset="0x00000200,0x0" online_cpuset="0x00000200,0x0" allowed_cpuset="0x00000200,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                  <object type="PU" os_index="89" cpuset="0x02000000,,0x0" complete_cpuset="0x02000000,,0x0" online_cpuset="0x02000000,,0x0" allowed_cpuset="0x02000000,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x04000000,0x00000400,0x0" complete_cpuset="0x04000000,0x00000400,0x0" online_cpuset="0x04000000,0x00000400,0x0" allowed_cpuset="0x04000000,0x00000400,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x04000000,0x00000400,0x0" complete_cpuset="0x04000000,0x00000400,0x0" online_cpuset="0x04000000,0x00000400,0x0" allowed_cpuset="0x04000000,0x00000400,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x04000000,0x00000400,0x0" complete_cpuset="0x04000000,0x00000400,0x0" online_cpuset="0x04000000,0x00000400,0x0" allowed_cpuset="0x04000000,0x00000400,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="22" cpuset="0x04000000,0x00000400,0x0" complete_cpuset="0x04000000,0x00000400,0x0" online_cpuset="0x04000000,0x00000400,0x0" allowed_cpuset="0x04000000,0x00000400,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="42" cpuset="0x00000400,0x0" complete_cpuset="0x00000400,0x0" online_cpuset="0x00000400,0x0" allowed_cpuset="0x00000400,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                  <object type="PU" os_index="90" cpuset="0x04000000,,0x0" complete_cpuset="0x04000000,,0x0" online_cpuset="0x04000000,,0x0" allowed_cpuset="0x04000000,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x08000000,0x00000800,0x0" complete_cpuset="0x08000000,0x00000800,0x0" online_cpuset="0x08000000,0x00000800,0x0" allowed_cpuset="0x08000000,0x00000800,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x08000000,0x00000800,0x0" complete_cpuset="0x08000000,0x00000800,0x0" online_cpuset="0x08000000,0x00000800,0x0" allowed_cpuset="0x08000000,0x00000800,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x08000000,0x00000800,0x0" complete_cpuset="0x08000000,0x00000800,0x0" online_cpuset="0x08000000,0x00000800,0x0" allowed_cpuset="0x08000000,0x00000800,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="25" cpuset="0x08000000,0x00000800,0x0" complete_cpuset="0x08000000,0x00000800,0x0" online_cpuset="0x08000000,0x00000800,0x0" allowed_cpuset="0x08000000,0x00000800,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="43" cpuset="0x00000800,0x0" complete_cpuset="0x00000800,0x0" online_cpuset="0x00000800,0x0" allowed_cpuset="0x00000800,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                  <object type="PU" os_index="91" cpuset="0x08000000,,0x0" complete_cpuset="0x08000000,,0x0" online_cpuset="0x08000000,,0x0" allowed_cpuset="0x08000000,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x10000000,0x00001000,0x0" complete_cpuset="0x10000000,0x00001000,0x0" online_cpuset="0x10000000,0x00001000,0x0" allowed_cpuset="0x10000000,0x00001000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x10000000,0x00001000,0x0" complete_cpuset="0x10000000,0x00001000,0x0" online_cpuset="0x10000000,0x00001000,0x0" allowed_cpuset="0x10000000,0x00001000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x10000000,0x00001000,0x0" complete_cpuset="0x10000000,0x00001000,0x0" online_cpuset="0x10000000,0x00001000,0x0" allowed_cpuset="0x10000000,0x00001000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="26" cpuset="0x10000000,0x00001000,0x0" complete_cpuset="0x10000000,0x00001000,0x0" online_cpuset="0x10000000,0x00001000,0x0" allowed_cpuset="0x10000000,0x00001000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="44" cpuset="0x00001000,0x0" complete_cpuset="0x00001000,0x0" online_cpuset="0x00001000,0x0" allowed_cpuset="0x00001000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                  <object type="PU" os_index="92" cpuset="0x10000000,,0x0" complete_cpuset="0x10000000,,0x0" online_cpuset="0x10000000,,0x0" allowed_cpuset="0x10000000,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x20000000,0x00002000,0x0" complete_cpuset="0x20000000,0x00002000,0x0" online_cpuset="0x20000000,0x00002000,0x0" allowed_cpuset="0x20000000,0x00002000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x20000000,0x00002000,0x0" complete_cpuset="0x20000000,0x00002000,0x0" online_cpuset="0x20000000,0x00002000,0x0" allowed_cpuset="0x20000000,0x00002000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x20000000,0x00002000,0x0" complete_cpuset="0x20000000,0x00002000,0x0" online_cpuset="0x20000000,0x00002000,0x0" allowed_cpuset="0x20000000,0x00002000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="27" cpuset="0x20000000,0x00002000,0x0" complete_cpuset="0x20000000,0x00002000,0x0" online_cpuset="0x20000000,0x00002000,0x0" allowed_cpuset="0x20000000,0x00002000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="45" cpuset="0x00002000,0x0" complete_cpuset="0x00002000,0x0" online_cpuset="0x00002000,0x0" allowed_cpuset="0x00002000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                  <object type="PU" os_index="93" cpuset="0x20000000,,0x0" complete_cpuset="0x20000000,,0x0" online_cpuset="0x20000000,,0x0" allowed_cpuset="0x20000000,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x40000000,0x00004000,0x0" complete_cpuset="0x40000000,0x00004000,0x0" online_cpuset="0x40000000,0x00004000,0x0" allowed_cpuset="0x40000000,0x00004000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x40000000,0x00004000,0x0" complete_cpuset="0x40000000,0x00004000,0x0" online_cpuset="0x40000000,0x00004000,0x0" allowed_cpuset="0x40000000,0x00004000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x40000000,0x00004000,0x0" complete_cpuset="0x40000000,0x00004000,0x0" online_cpuset="0x40000000,0x00004000,0x0" allowed_cpuset="0x40000000,0x00004000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="28" cpuset="0x40000000,0x00004000,0x0" complete_cpuset="0x40000000,0x00004000,0x0" online_cpuset="0x40000000,0x00004000,0x0" allowed_cpuset="0x40000000,0x00004000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="46" cpuset="0x00004000,0x0" complete_cpuset="0x00004000,0x0" online_cpuset="0x00004000,0x0" allowed_cpuset="0x00004000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                  <object type="PU" os_index="94" cpuset="0x40000000,,0x0" complete_cpuset="0x40000000,,0x0" online_cpuset="0x40000000,,0x0" allowed_cpuset="0x40000000,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x80000000,0x00008000,0x0" complete_cpuset="0x80000000,0x00008000,0x0" online_cpuset="0x80000000,0x00008000,0x0" allowed_cpuset="0x80000000,0x00008000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x80000000,0x00008000,0x0" complete_cpuset="0x80000000,0x00008000,0x0" online_cpuset="0x80000000,0x00008000,0x0" allowed_cpuset="0x80000000,0x00008000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x80000000,0x00008000,0x0" complete_cpuset="0x80000000,0x00008000,0x0" online_cpuset="0x80000000,0x00008000,0x0" allowed_cpuset="0x80000000,0x00008000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="29" cpuset="0x80000000,0x00008000,0x0" complete_cpuset="0x80000000,0x00008000,0x0" online_cpuset="0x80000000,0x00008000,0x0" allowed_cpuset="0x80000000,0x00008000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="47" cpuset="0x00008000,0x0" complete_cpuset="0x00008000,0x0" online_cpuset="0x00008000,0x0" allowed_cpuset="0x00008000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                  <object type="PU" os_index="95" cpuset="0x80000000,,0x0" complete_cpuset="0x80000000,,0x0" online_cpuset="0x80000000,,0x0" allowed_cpuset="0x80000000,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="Bridge" os_index="6" bridge_type="0-1" depth="0" bridge_pci="0000:[ae-af]">
+        <object type="Bridge" os_index="712704" bridge_type="1-1" depth="1" bridge_pci="0000:[af-af]" pci_busid="0000:ae:00.0" pci_type="0604 [8086:2030] [8086:35ce] 06" pci_link_speed="0.000000">
+          <info name="PCISlot" value="801"/>
+          <object type="PCIDev" os_index="716800" pci_busid="0000:af:00.0" pci_type="0208 [8086:24f0] [8086:24f0] 11" pci_link_speed="0.000000">
+            <object type="OSDev" name="ib1" osdev_type="2">
+              <info name="Address" value="80:81:00:02:fe:80:00:00:00:00:00:00:00:11:75:09:01:0a:e0:7c"/>
+              <info name="Port" value="1"/>
+            </object>
+            <object type="OSDev" name="hfi1_1" osdev_type="3">
+              <info name="NodeGUID" value="0011:7509:010a:e07c"/>
+              <info name="SysImageGUID" value="0011:7509:0105:6b92"/>
+              <info name="Port1State" value="4"/>
+              <info name="Port1LID" value="0x228"/>
+              <info name="Port1LMC" value="3"/>
+              <info name="Port1GID0" value="fe80:0000:0000:0000:0011:7509:010a:e07c"/>
+              <info name="Port1GID1" value="fe80:0000:0000:0000:0006:6a00:0000:0228"/>
+            </object>
+          </object>
+        </object>
+      </object>
+    </object>
+  </object>
+</topology>

--- a/src/control/lib/hardware/topology.go
+++ b/src/control/lib/hardware/topology.go
@@ -1,0 +1,102 @@
+//
+// (C) Copyright 2021 Intel Corporation.
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+
+package hardware
+
+import (
+	"context"
+	"sort"
+)
+
+// Topology is a hierarchy of hardware devices grouped under NUMA nodes.
+type Topology struct {
+	// NUMANodes is the set of NUMA nodes mapped by their ID.
+	NUMANodes map[uint]*NUMANode `json:"numa_nodes"`
+}
+
+// AllDevices returns a map of all system Devices sorted by their name.
+func (t *Topology) AllDevices() map[string]*Device {
+	devsByName := make(map[string]*Device)
+	if t == nil {
+		return devsByName
+	}
+
+	for _, numaNode := range t.NUMANodes {
+		for _, devs := range numaNode.Devices {
+			for _, dev := range devs {
+				devsByName[dev.Name] = dev
+			}
+		}
+	}
+	return devsByName
+}
+
+type (
+	// NUMANode represents an individual NUMA node in the system and the devices associated with it.
+	NUMANode struct {
+		ID       uint       `json:"id"`
+		NumCores uint       `json:"num_cores"`
+		Devices  PCIDevices `json:"devices"`
+	}
+
+	// PCIDevices groups hardware devices by PCI address.
+	PCIDevices map[string][]*Device
+)
+
+// Add adds a device to the PCIDevices.
+func (d PCIDevices) Add(dev *Device) {
+	if d == nil || dev == nil {
+		return
+	}
+	addr := dev.PCIAddr
+	d[addr] = append(d[addr], dev)
+}
+
+// Keys fetches the sorted keys for the map.
+func (d PCIDevices) Keys() []string {
+	keys := make([]string, 0, len(d))
+	for k := range d {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// DeviceType indicates the type of a hardware device.
+type DeviceType uint
+
+const (
+	// DeviceTypeUnknown indicates a device type that is not recognized.
+	DeviceTypeUnknown DeviceType = iota
+	// DeviceTypeNetInterface indicates a standard network interface.
+	DeviceTypeNetInterface
+	// DeviceTypeOFIDomain indicates an OpenFabrics domain device.
+	DeviceTypeOFIDomain
+)
+
+func (t DeviceType) String() string {
+	switch t {
+	case DeviceTypeNetInterface:
+		return "network interface"
+	case DeviceTypeOFIDomain:
+		return "OFI domain"
+	}
+
+	return "unknown device type"
+}
+
+// Device represents an individual hardware device.
+type Device struct {
+	Name         string     `json:"name"`
+	Type         DeviceType `json:"type"`
+	NUMAAffinity uint       `json:"numa_affinity"`
+	PCIAddr      string     `json:"pci_address"`
+}
+
+// TopologyProvider is an interface for acquiring a system topology.
+type TopologyProvider interface {
+	GetTopology(context.Context) (*Topology, error)
+}

--- a/src/control/lib/hardware/topology_test.go
+++ b/src/control/lib/hardware/topology_test.go
@@ -1,0 +1,358 @@
+//
+// (C) Copyright 2021 Intel Corporation.
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+
+package hardware
+
+import (
+	"testing"
+
+	"github.com/daos-stack/daos/src/control/common"
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestHardware_Topology_AllDevices(t *testing.T) {
+	for name, tc := range map[string]struct {
+		topo      *Topology
+		expResult map[string]*Device
+	}{
+		"nil": {
+			expResult: make(map[string]*Device),
+		},
+		"no NUMA nodes": {
+			topo:      &Topology{},
+			expResult: make(map[string]*Device),
+		},
+		"no PCI addrs": {
+			topo: &Topology{
+				NUMANodes: map[uint]*NUMANode{
+					0: {
+						ID:       0,
+						NumCores: 8,
+					},
+				},
+			},
+			expResult: make(map[string]*Device),
+		},
+		"no devices": {
+			topo: &Topology{
+				NUMANodes: map[uint]*NUMANode{
+					0: {
+						ID:       0,
+						NumCores: 8,
+						Devices: PCIDevices{
+							"0000:01:01.1": []*Device{},
+						},
+					},
+				},
+			},
+			expResult: make(map[string]*Device),
+		},
+		"single device": {
+			topo: &Topology{
+				NUMANodes: map[uint]*NUMANode{
+					0: {
+						ID:       0,
+						NumCores: 8,
+						Devices: PCIDevices{
+							"0000:01:01.1": []*Device{
+								{
+									Name:    "test0",
+									Type:    DeviceTypeNetInterface,
+									PCIAddr: "0000:01:01.1",
+								},
+							},
+						},
+					},
+				},
+			},
+			expResult: map[string]*Device{
+				"test0": {
+					Name:    "test0",
+					Type:    DeviceTypeNetInterface,
+					PCIAddr: "0000:01:01.1",
+				},
+			},
+		},
+		"multi device": {
+			topo: &Topology{
+				NUMANodes: map[uint]*NUMANode{
+					0: {
+						ID:       0,
+						NumCores: 8,
+						Devices: PCIDevices{
+							"0000:01:01.1": []*Device{
+								{
+									Name:    "test0",
+									Type:    DeviceTypeNetInterface,
+									PCIAddr: "0000:01:01.1",
+								},
+								{
+									Name:    "test1",
+									Type:    DeviceTypeOFIDomain,
+									PCIAddr: "0000:01:01.1",
+								},
+							},
+							"0000:01:02.1": []*Device{
+								{
+									Name:    "test2",
+									Type:    DeviceTypeNetInterface,
+									PCIAddr: "0000:01:02.1",
+								},
+								{
+									Name:    "test3",
+									Type:    DeviceTypeUnknown,
+									PCIAddr: "0000:01:02.1",
+								},
+							},
+						},
+					},
+					1: {
+						ID:       1,
+						NumCores: 8,
+						Devices: PCIDevices{
+							"0000:02:01.1": []*Device{
+								{
+									Name:    "test4",
+									Type:    DeviceTypeNetInterface,
+									PCIAddr: "0000:02:01.1",
+								},
+								{
+									Name:    "test5",
+									Type:    DeviceTypeOFIDomain,
+									PCIAddr: "0000:02:01.1",
+								},
+							},
+							"0000:02:02.1": []*Device{
+								{
+									Name:    "test6",
+									Type:    DeviceTypeUnknown,
+									PCIAddr: "0000:02:02.1",
+								},
+							},
+						},
+					},
+				},
+			},
+			expResult: map[string]*Device{
+				"test0": {
+					Name:    "test0",
+					Type:    DeviceTypeNetInterface,
+					PCIAddr: "0000:01:01.1",
+				},
+				"test1": {
+					Name:    "test1",
+					Type:    DeviceTypeOFIDomain,
+					PCIAddr: "0000:01:01.1",
+				},
+				"test2": {
+					Name:    "test2",
+					Type:    DeviceTypeNetInterface,
+					PCIAddr: "0000:01:02.1",
+				},
+				"test3": {
+					Name:    "test3",
+					Type:    DeviceTypeUnknown,
+					PCIAddr: "0000:01:02.1",
+				},
+				"test4": {
+					Name:    "test4",
+					Type:    DeviceTypeNetInterface,
+					PCIAddr: "0000:02:01.1",
+				},
+				"test5": {
+					Name:    "test5",
+					Type:    DeviceTypeOFIDomain,
+					PCIAddr: "0000:02:01.1",
+				},
+				"test6": {
+					Name:    "test6",
+					Type:    DeviceTypeUnknown,
+					PCIAddr: "0000:02:02.1",
+				},
+			},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			result := tc.topo.AllDevices()
+
+			if diff := cmp.Diff(tc.expResult, result); diff != "" {
+				t.Fatalf("(-want, +got)\n%s\n", diff)
+			}
+		})
+	}
+}
+
+func TestHardware_PCIDevices_Keys(t *testing.T) {
+	for name, tc := range map[string]struct {
+		devices   PCIDevices
+		expResult []string
+	}{
+		"nil": {
+			expResult: []string{},
+		},
+		"empty": {
+			devices:   PCIDevices{},
+			expResult: []string{},
+		},
+		"keys": {
+			devices: PCIDevices{
+				"0000:01:01.1": []*Device{
+					{
+						Name:    "test0",
+						Type:    DeviceTypeNetInterface,
+						PCIAddr: "0000:01:01.1",
+					},
+					{
+						Name:    "test1",
+						Type:    DeviceTypeOFIDomain,
+						PCIAddr: "0000:01:01.1",
+					},
+				},
+				"0000:01:02.1": []*Device{
+					{
+						Name:    "test2",
+						Type:    DeviceTypeNetInterface,
+						PCIAddr: "0000:01:02.1",
+					},
+					{
+						Name:    "test3",
+						Type:    DeviceTypeUnknown,
+						PCIAddr: "0000:01:02.1",
+					},
+				},
+				"0000:01:03.1": []*Device{},
+			},
+			expResult: []string{"0000:01:01.1", "0000:01:02.1", "0000:01:03.1"},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			result := tc.devices.Keys()
+
+			if diff := cmp.Diff(tc.expResult, result); diff != "" {
+				t.Fatalf("(-want, +got)\n%s\n", diff)
+			}
+		})
+	}
+}
+
+func TestHardware_PCIDevices_Add(t *testing.T) {
+	for name, tc := range map[string]struct {
+		devices   PCIDevices
+		newDev    *Device
+		expResult PCIDevices
+	}{
+		"nil": {},
+		"add nil Device": {
+			devices:   PCIDevices{},
+			expResult: PCIDevices{},
+		},
+		"add to empty": {
+			devices: PCIDevices{},
+			newDev: &Device{
+				Name:         "test1",
+				Type:         DeviceTypeNetInterface,
+				NUMAAffinity: 1,
+				PCIAddr:      "0000:01:01.01",
+			},
+			expResult: PCIDevices{
+				"0000:01:01.01": {
+					{
+						Name:         "test1",
+						Type:         DeviceTypeNetInterface,
+						NUMAAffinity: 1,
+						PCIAddr:      "0000:01:01.01",
+					},
+				},
+			},
+		},
+		"add to existing": {
+			devices: PCIDevices{
+				"0000:01:01.01": {
+					{
+						Name:         "test1",
+						Type:         DeviceTypeNetInterface,
+						NUMAAffinity: 1,
+						PCIAddr:      "0000:01:01.01",
+					},
+				},
+				"0000:01:02.01": {
+					{
+						Name:         "test2",
+						Type:         DeviceTypeUnknown,
+						NUMAAffinity: 1,
+						PCIAddr:      "0000:01:02.01",
+					},
+				},
+			},
+			newDev: &Device{
+				Name:         "test3",
+				Type:         DeviceTypeOFIDomain,
+				NUMAAffinity: 1,
+				PCIAddr:      "0000:01:01.01",
+			},
+			expResult: PCIDevices{
+				"0000:01:01.01": {
+					{
+						Name:         "test1",
+						Type:         DeviceTypeNetInterface,
+						NUMAAffinity: 1,
+						PCIAddr:      "0000:01:01.01",
+					},
+					{
+						Name:         "test3",
+						Type:         DeviceTypeOFIDomain,
+						NUMAAffinity: 1,
+						PCIAddr:      "0000:01:01.01",
+					},
+				},
+				"0000:01:02.01": {
+					{
+						Name:         "test2",
+						Type:         DeviceTypeUnknown,
+						NUMAAffinity: 1,
+						PCIAddr:      "0000:01:02.01",
+					},
+				},
+			},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			tc.devices.Add(tc.newDev)
+
+			if diff := cmp.Diff(tc.expResult, tc.devices); diff != "" {
+				t.Fatalf("(-want, +got)\n%s\n", diff)
+			}
+		})
+	}
+}
+
+func TestHardware_DeviceType_String(t *testing.T) {
+	for name, tc := range map[string]struct {
+		devType   DeviceType
+		expResult string
+	}{
+		"network": {
+			devType:   DeviceTypeNetInterface,
+			expResult: "network interface",
+		},
+		"OFI domain": {
+			devType:   DeviceTypeOFIDomain,
+			expResult: "OFI domain",
+		},
+		"unknown": {
+			devType:   DeviceTypeUnknown,
+			expResult: "unknown device type",
+		},
+		"not recognized": {
+			devType:   DeviceType(0xffffffff),
+			expResult: "unknown device type",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			common.AssertEqual(t, tc.expResult, tc.devType.String(), "")
+		})
+	}
+}


### PR DESCRIPTION
- Create an interface for getting a hardware topology, including
  NUMA node, PCI address, and devices.
- Create bindings for hwloc satisfying that interface.

Signed-off-by: Kris Jacque <kristin.jacque@intel.com>