### PR TITLE
DAOS-9195 migrate: wait all migrate to finish before migrate stop.

### DIFF
--- a/src/object/srv_obj_migrate.c
+++ b/src/object/srv_obj_migrate.c
@@ -2567,8 +2567,13 @@ ds_migrate_fini_one(uuid_t pool_uuid, uint32_t ver)
 	ABT_mutex_lock(tls->mpt_inflight_mutex);
 	ABT_cond_broadcast(tls->mpt_inflight_cond);
 	ABT_mutex_unlock(tls->mpt_inflight_mutex);
+
 	migrate_pool_tls_put(tls); /* lookup */
+	ABT_eventual_wait(tls->mpt_done_eventual, NULL);
+
 	migrate_pool_tls_put(tls); /* destroy */
+
+	D_DEBUG(DB_TRACE, "migrate fini one ult "DF_UUID"\n", pool_uuid);
 }
 
 struct migrate_abort_arg {
@@ -2580,23 +2585,9 @@ int
 migrate_fini_one_ult(void *data)
 {
 	struct migrate_abort_arg *arg = data;
-	struct migrate_pool_tls	*tls;
 
-	tls = migrate_pool_tls_lookup(arg->pool_uuid, arg->version);
-	if (tls == NULL)
-		return 0;
+	ds_migrate_fini_one(arg->pool_uuid, arg->version);
 
-	D_ASSERT(tls->mpt_refcount > 1);
-	tls->mpt_fini = 1;
-
-	ABT_mutex_lock(tls->mpt_inflight_mutex);
-	ABT_cond_broadcast(tls->mpt_inflight_cond);
-	ABT_mutex_unlock(tls->mpt_inflight_mutex);
-
-	ABT_eventual_wait(tls->mpt_done_eventual, NULL);
-	migrate_pool_tls_put(tls); /* destroy */
-
-	D_DEBUG(DB_TRACE, "abort one ult "DF_UUID"\n", DP_UUID(arg->pool_uuid));
 	return 0;
 }
 

--- a/src/vos/evtree.c
+++ b/src/vos/evtree.c
@@ -2795,7 +2795,6 @@ evt_has_data(struct evt_root *root, struct umem_attr *uma)
 	}
 out:
 	evt_tcx_decref(tcx); /* -1 for tcx_create */
-	evt_tcx_decref(tcx); /* -1 for open */
 	return rc;
 }
 

--- a/src/vos/tests/evt_ctl.c
+++ b/src/vos/tests/evt_ctl.c
@@ -1216,6 +1216,9 @@ test_evt_iter_delete(void **state)
 	assert_rc_equal(rc, 0);
 	rc = utest_sync_mem_status(arg->ta_utx);
 	assert_int_equal(rc, 0);
+
+	rc = evt_has_data(arg->ta_root, arg->ta_uma);
+	assert_rc_equal(rc, 0);
 	/* Insert a bunch of entries */
 	for (epoch = 1; epoch <= NUM_EPOCHS; epoch++) {
 		for (offset = epoch; offset < NUM_EXTENTS + epoch; offset++) {
@@ -1239,6 +1242,8 @@ test_evt_iter_delete(void **state)
 			assert_int_equal(rc, 0);
 		}
 	}
+	rc = evt_has_data(arg->ta_root, arg->ta_uma);
+	assert_rc_equal(rc, 1);
 
 	rc = evt_iter_prepare(toh, EVT_ITER_VISIBLE, NULL, &ih);
 	assert_rc_equal(rc, 0);


### PR DESCRIPTION
Let's wait all migrate ULT to finish before stopping
migrate, otherwise if the previous migrate failed,
one object might be discarded by previous migration
and retry migration concurrently.

Signed-off-by: Di Wang <di.wang@intel.com>