### PR TITLE
DAOS-9231 test: fix dm_negative_space_dcp

### DIFF
--- a/src/tests/ftest/datamover/negative.py
+++ b/src/tests/ftest/datamover/negative.py
@@ -6,7 +6,6 @@
 '''
 from data_mover_test_base import DataMoverTestBase
 from os.path import join
-from apricot import skipForTicket
 
 
 class DmvrNegativeTest(DataMoverTestBase):
@@ -241,46 +240,6 @@ class DmvrNegativeTest(DataMoverTestBase):
             "DAOS_UUID", "/", pool1, cont1,
             "POSIX", "/fake/fake/fake",
             expected_rc=1)
-
-    def test_dm_negative_space_dcp(self):
-        """Jira ID: DAOS-5515
-        Test Description:
-            DAOS-5515: destination pool does not have enough space.
-            DAOS-6387: posix filesystem does not have enough space.
-        :avocado: tags=all,full_regression
-        :avocado: tags=datamover,dcp
-        :avocado: tags=dm_negative,dm_negative_space_dcp
-        """
-        self.set_tool("DCP")
-
-        # mount small tmpfs filesystem on posix path, using size required sudo
-        dst_posix_path = self.new_posix_test_path(mount_dir=True)
-
-        # Create a large test file in POSIX
-        block_size_large = self.params.get(
-            "block_size_large", "/run/ior/*")
-        self.ior_cmd.block_size.update(block_size_large)
-        self.run_ior_with_params("POSIX", self.posix_test_file)
-
-        # Create destination test pool and container
-        pool1 = self.create_pool()
-        cont1 = self.create_cont(pool1)
-
-        # Try to copy, and expect a proper error message.
-        self.run_datamover(
-            self.test_id + " (dst pool out of space)",
-            "POSIX", self.posix_local_test_paths[0], None, None,
-            "DAOS_UUID", "/", pool1, cont1,
-            expected_rc=1,
-            expected_output=[self.MFU_ERR_DCP_COPY, "errno=28"])
-
-        # Try to copy. For now, we expect this to just abort.
-        self.run_datamover(
-            self.test_id + " (dst posix out of space)",
-            "POSIX", self.posix_local_test_paths[0], None, None,
-            "POSIX", dst_posix_path,
-            expected_rc=255,
-            expected_err=["errno=28"])
 
     def test_dm_negative_error_check_dcp(self):
         """Jira ID: DAOS-5515

--- a/src/tests/ftest/datamover/negative_space.py
+++ b/src/tests/ftest/datamover/negative_space.py
@@ -1,0 +1,64 @@
+#!/usr/bin/python
+'''
+  (C) Copyright 2020-2021 Intel Corporation.
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+'''
+from data_mover_test_base import DataMoverTestBase
+from os.path import join
+
+
+class DmvrNegativeSpaceTest(DataMoverTestBase):
+    # pylint: disable=too-many-ancestors
+    """Test class for POSIX DataMover negative testing space errors.
+
+    Test Class Description:
+        Tests the following cases:
+            Destination pool out of space.
+            Destination POSIX out of space.
+    :avocado: recursive
+    """
+
+    # DCP error codes
+    MFU_ERR_DCP_COPY = "MFU_ERR(-1101)"
+
+    def test_dm_negative_space_dcp(self):
+        """
+        Test Description:
+            DAOS-5515: destination pool does not have enough space.
+            DAOS-6387: posix filesystem does not have enough space.
+        :avocado: tags=all,full_regression
+        :avocado: tags=hw,small
+        :avocado: tags=datamover,dcp
+        :avocado: tags=dm_negative,dm_negative_space_dcp
+        """
+        self.set_tool("DCP")
+
+        # Create the source file
+        src_posix_path = self.new_posix_test_path()
+        src_posix_file = join(src_posix_path, self.ior_cmd.test_file.value)
+        self.run_ior_with_params("POSIX", src_posix_file)
+
+        # Create destination test pool and container
+        dst_pool = self.create_pool()
+        dst_cont = self.create_cont(dst_pool)
+        dst_daos_path = "/"
+
+        # Try to copy, and expect a proper error message.
+        self.run_datamover(
+            self.test_id + " (dst pool out of space)",
+            "POSIX", src_posix_path, None, None,
+            "DAOS_UUID", dst_daos_path, dst_pool, dst_cont,
+            expected_rc=1,
+            expected_output=[self.MFU_ERR_DCP_COPY, "errno=28"])
+
+        # Mount small tmpfs filesystem on posix path.
+        dst_posix_path = self.new_posix_test_path(mount_dir=True)
+
+        # Try to copy. For now, we expect this to just abort.
+        self.run_datamover(
+            self.test_id + " (dst posix out of space)",
+            "POSIX", src_posix_path, None, None,
+            "POSIX", dst_posix_path,
+            expected_rc=255,
+            expected_err=["errno=28"])

--- a/src/tests/ftest/datamover/negative_space.yaml
+++ b/src/tests/ftest/datamover/negative_space.yaml
@@ -3,13 +3,16 @@ hosts:
         - server-A
     test_clients:
         - client-B
-timeout: 300
+timeout: 180
 server_config:
-    name: daos_server
+   name: daos_server
+   servers:
+     scm_class: dcpm
+     scm_list: ["/dev/pmem0"]
 pool:
     mode: 146
     name: daos_server
-    scm_size: 5.1G
+    size: 5G
     control_method: dmg
 container:
     type: POSIX
@@ -19,11 +22,9 @@ ior:
         np: 1
     test_file: testFile
     flags: "-v -w -k"
-    block_size: '1K'
-    transfer_size: '1K'
+    block_size: '6G' # Over 5G
+    transfer_size: '1M'
     signature: 5
 dcp:
     client_processes:
         np: 3
-dfuse:
-    mount_dir: "/tmp/daos_dfuse"


### PR DESCRIPTION
Move to negative space test to hw small since VM performance
is not reliable.

Skip-unit-tests: true
Skip-fault-injection-test: true
Test-repeat: 15
Test-tag: dm_negative_space_dcp

Signed-off-by: Dalton Bohning <dalton.bohning@intel.com>