### PR TITLE
DAOS-9193 dtx: avoid repeated completion callback (3)

### DIFF
--- a/src/dtx/dtx_internal.h
+++ b/src/dtx/dtx_internal.h
@@ -92,6 +92,8 @@ extern uint32_t dtx_agg_thd_cnt_lo;
 #define DTX_AGG_THD_AGE_MIN	210
 #define DTX_AGG_THD_AGE_DEF	630
 
+#define DTX_RPC_YIELD_THD	64
+
 /* The time threshold for triggerring DTX aggregation. If the oldest
  * DTX in the DTX table exceeds such threshold, it will trigger DTX
  * aggregation locally.

--- a/src/dtx/dtx_rpc.c
+++ b/src/dtx/dtx_rpc.c
@@ -79,6 +79,7 @@ struct dtx_req_rec {
 	uint32_t			 drr_tag; /* The VOS ID */
 	int				 drr_count; /* DTX count */
 	int				 drr_result; /* The RPC result */
+	uint32_t			 drr_comp:1;
 	struct dtx_id			*drr_dti; /* The DTX array */
 	struct dtx_share_peer		**drr_cb_args; /* Used by dtx_req_cb. */
 };
@@ -118,6 +119,8 @@ dtx_req_cb(const struct crt_cb_info *cb_info)
 	struct dtx_out		*dout;
 	int			 rc = cb_info->cci_rc;
 	int			 i;
+
+	D_ASSERT(drr->drr_comp == 0);
 
 	if (rc != 0)
 		goto out;
@@ -206,6 +209,7 @@ dtx_req_cb(const struct crt_cb_info *cb_info)
 	}
 
 out:
+	drr->drr_comp = 1;
 	drr->drr_result = rc;
 	rc = ABT_future_set(dra->dra_future, drr);
 	D_ASSERTF(rc == ABT_SUCCESS,
@@ -251,7 +255,8 @@ dtx_req_send(struct dtx_req_rec *drr, daos_epoch_t epoch)
 		drr->drr_tag, req, dra->dra_future,
 		din != NULL ? din->di_epoch : 0, rc);
 
-	if (rc != 0) {
+	if (rc != 0 && drr->drr_comp == 0) {
+		drr->drr_comp = 1;
 		drr->drr_result = rc;
 		ABT_future_set(dra->dra_future, drr);
 	}
@@ -389,7 +394,9 @@ dtx_req_list_send(struct dtx_req_args *dra, crt_opcode_t opc, d_list_t *head,
 			}
 		}
 
-		i++;
+		/* Yield to avoid holding CPU for too long time. */
+		if (++i >= DTX_RPC_YIELD_THD)
+			ABT_thread_yield();
 	}
 
 	return 0;
@@ -418,6 +425,7 @@ dtx_cf_rec_alloc(struct btr_instance *tins, d_iov_t *key_iov,
 	drr->drr_rank = dcrb->dcrb_rank;
 	drr->drr_tag = dcrb->dcrb_tag;
 	drr->drr_count = 1;
+	drr->drr_comp = 0;
 	drr->drr_dti[0] = *dcrb->dcrb_dti;
 	d_list_add_tail(&drr->drr_link, dcrb->dcrb_head);
 	++(*dcrb->dcrb_length);
@@ -504,13 +512,12 @@ dtx_classify_one(struct ds_pool *pool, daos_handle_t tree, d_list_t *head,
 		i = 1;
 	else
 		i = 0;
+
 	for (; i < mbs->dm_tgt_cnt && rc >= 0; i++) {
 		struct pool_target	*target;
 
-		ABT_rwlock_rdlock(pool->sp_lock);
 		rc = pool_map_find_target(pool->sp_map,
 					  mbs->dm_tgts[i].ddt_id, &target);
-		ABT_rwlock_unlock(pool->sp_lock);
 		if (rc != 1) {
 			D_WARN("Cannot find target %u at %d/%d, flags %x\n",
 			       mbs->dm_tgts[i].ddt_id, i, mbs->dm_tgt_cnt,
@@ -569,6 +576,7 @@ dtx_dti_classify(struct ds_pool *pool, daos_handle_t tree,
 	int	rc = 0;
 	int	i;
 
+	ABT_rwlock_rdlock(pool->sp_lock);
 	for (i = 0; i < count; i++) {
 		rc = dtx_classify_one(pool, tree, head, &length, dtes[i], count, my_rank, my_tgtid);
 		if (rc < 0)
@@ -577,6 +585,7 @@ dtx_dti_classify(struct ds_pool *pool, daos_handle_t tree,
 		if (dtis != NULL)
 			dtis[i] = dtes[i]->dte_xid;
 	}
+	ABT_rwlock_unlock(pool->sp_lock);
 
 	return rc < 0 ? rc : length;
 }
@@ -797,8 +806,10 @@ dtx_abort(struct ds_cont_child *cont, struct dtx_entry *dte, daos_epoch_t epoch)
 
 	D_INIT_LIST_HEAD(&head);
 	crt_group_rank(NULL, &my_rank);
+	ABT_rwlock_rdlock(pool->sp_lock);
 	rc = dtx_classify_one(pool, DAOS_HDL_INVAL, &head, &length, dte, 1, my_rank,
 			      dss_get_module_info()->dmi_tgt_id);
+	ABT_rwlock_unlock(pool->sp_lock);
 	if (rc < 0)
 		goto out;
 
@@ -859,8 +870,10 @@ dtx_check(struct ds_cont_child *cont, struct dtx_entry *dte, daos_epoch_t epoch)
 
 	D_INIT_LIST_HEAD(&head);
 	crt_group_rank(NULL, &my_rank);
+	ABT_rwlock_rdlock(pool->sp_lock);
 	rc = dtx_classify_one(pool, DAOS_HDL_INVAL, &head, &length, dte, 1, my_rank,
 			      dss_get_module_info()->dmi_tgt_id);
+	ABT_rwlock_unlock(pool->sp_lock);
 	if (rc < 0)
 		goto out;
 

--- a/src/include/daos_srv/dtx_srv.h
+++ b/src/include/daos_srv/dtx_srv.h
@@ -130,6 +130,7 @@ struct dtx_handle {
 struct dtx_sub_status {
 	struct daos_shard_tgt		dss_tgt;
 	int				dss_result;
+	uint32_t			dss_comp:1;
 };
 
 struct dtx_leader_handle;
@@ -150,6 +151,7 @@ struct dtx_leader_handle {
 
 	/* How many sub leader transaction */
 	uint32_t			dlh_sub_cnt;
+	uint32_t			dlh_helper_done:1;
 	/* Sub transaction handle to manage the dtx leader */
 	struct dtx_sub_status		*dlh_subs;
 	dtx_agg_cb_t			dlh_agg_cb;

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -4346,12 +4346,8 @@ obj_obj_dtx_leader(struct dtx_leader_handle *dlh, void *arg, int idx,
 			 */
 			if (dcde->dcde_write_cnt != 0) {
 				rc = obj_capa_check(ioc->ioc_coh, true, false);
-				if (rc != 0) {
-					if (comp_cb != NULL)
-						comp_cb(dlh, idx, rc);
-
-					return rc;
-				}
+				if (rc != 0)
+					goto comp;
 			}
 
 			dcsh = ds_obj_cpd_get_dcsh(dca->dca_rpc, dca->dca_idx);
@@ -4368,6 +4364,7 @@ obj_obj_dtx_leader(struct dtx_leader_handle *dlh, void *arg, int idx,
 						    &dlh->dlh_handle, pin);
 		}
 
+comp:
 		if (comp_cb != NULL)
 			comp_cb(dlh, idx, rc);
 

--- a/src/object/srv_obj_remote.c
+++ b/src/object/srv_obj_remote.c
@@ -296,11 +296,9 @@ shard_cpd_req_cb(const struct crt_cb_info *cb_info)
 }
 
 static int
-ds_obj_cpd_clone_reqs(struct dtx_leader_handle *dlh, struct daos_shard_tgt *tgt,
-		      struct daos_cpd_disp_ent *dcde_parent,
+ds_obj_cpd_clone_reqs(struct daos_shard_tgt *tgt, struct daos_cpd_disp_ent *dcde_parent,
 		      struct daos_cpd_sub_req *dcsr_parent, int total,
-		      struct daos_cpd_disp_ent **p_dcde,
-		      struct daos_cpd_sub_req **p_dcsr)
+		      struct daos_cpd_disp_ent **p_dcde, struct daos_cpd_sub_req **p_dcsr)
 {
 	struct daos_cpd_disp_ent	*dcde = NULL;
 	struct daos_cpd_sub_req		*dcsr = NULL;
@@ -480,7 +478,7 @@ ds_obj_cpd_dispatch(struct dtx_leader_handle *dlh, void *arg, int idx,
 
 	count = dcde_parent->dcde_read_cnt + dcde_parent->dcde_write_cnt;
 	if (count < total || (exec_arg->flags & ORF_HAS_EC_SPLIT)) {
-		rc = ds_obj_cpd_clone_reqs(dlh, shard_tgt, dcde_parent,
+		rc = ds_obj_cpd_clone_reqs(shard_tgt, dcde_parent,
 					   dcsr_parent, total, &dcde, &dcsr);
 		if (rc != 0)
 			D_GOTO(out, rc);


### PR DESCRIPTION
That may cause the one waiting on some ABT future to be wakenup earlier.

Allow-unstable-test: true

Signed-off-by: Fan Yong <fan.yong@intel.com>