### PR TITLE
DAOS-9195 vos: Prevent multiple range discard on same object

### DIFF
--- a/src/vos/tests/vts_io.c
+++ b/src/vos/tests/vts_io.c
@@ -839,6 +839,7 @@ io_obj_cache_test(void **state)
 	struct vos_object	*objs[20];
 	struct umem_instance	*ummg;
 	struct umem_instance	*umml;
+	struct vos_object	*obj1, *obj2;
 	daos_epoch_range_t	 epr = {0, 1};
 	daos_unit_oid_t		 oids[2];
 	char			*po_name;
@@ -874,6 +875,17 @@ io_obj_cache_test(void **state)
 			  VOS_OBJ_CREATE | VOS_OBJ_VISIBLE, DAOS_INTENT_DEFAULT,
 			  &objs[0], 0);
 	assert_rc_equal(rc, 0);
+
+	rc = vos_obj_discard_hold(occ, vos_hdl2cont(ctx->tc_co_hdl), oids[0], &obj1);
+	assert_rc_equal(rc, 0);
+	/** Should be prevented because object olready held for discard */
+	rc = vos_obj_discard_hold(occ, vos_hdl2cont(ctx->tc_co_hdl), oids[0], &obj2);
+	assert_rc_equal(rc, -DER_BUSY);
+	vos_obj_discard_release(occ, obj1);
+	/** Now that other one is done, this should work */
+	rc = vos_obj_discard_hold(occ, vos_hdl2cont(ctx->tc_co_hdl), oids[0], &obj2);
+	assert_rc_equal(rc, 0);
+	vos_obj_discard_release(occ, obj2);
 
 	rc = umem_tx_end(ummg, 0);
 	assert_rc_equal(rc, 0);

--- a/src/vos/vos_obj.h
+++ b/src/vos/vos_obj.h
@@ -49,6 +49,8 @@ struct vos_object {
 	struct vos_container		*obj_cont;
 	/** nobody should access this object */
 	bool				obj_zombie;
+	/** Object is in discard */
+	bool				obj_discard;
 };
 
 enum {
@@ -56,6 +58,8 @@ enum {
 	VOS_OBJ_VISIBLE		= (1 << 0),
 	/** Create the object if it doesn't exist */
 	VOS_OBJ_CREATE		= (1 << 1),
+	/** Hold for object specific discard */
+	VOS_OBJ_DISCARD		= (1 << 2),
 };
 
 /**
@@ -207,5 +211,29 @@ vos_oi_punch(struct vos_container *cont, daos_unit_oid_t oid,
 /** delete an object from OI table */
 int
 vos_oi_delete(struct vos_container *cont, daos_unit_oid_t oid);
+
+/** Hold object for range discard
+ *
+ * \param[in]	occ	Object cache, can be per cpu
+ * \param[in]	cont	Open container
+ * \param[in]	oid	The object id
+ * \param[out]	objp	Returned object
+ *
+ * \return	-DER_NONEXIST	object doesn't exist
+ *		-DER_BUSY	Object is already in discard
+ *		-DER_AGAIN	Object is being destroyed
+ *		0		Success
+ */
+int
+vos_obj_discard_hold(struct daos_lru_cache *occ, struct vos_container *cont, daos_unit_oid_t oid,
+		     struct vos_object **objp);
+
+/** Release object held for range discard
+ *
+ * \param[in]	occ	Object cache, can be per cpu
+ * \param[in]	obj	Object to release
+ */
+void
+vos_obj_discard_release(struct daos_lru_cache *occ, struct vos_object *obj);
 
 #endif


### PR DESCRIPTION
Return -DER_BUSY if an attempt is made to discard an object
already in discard.

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>