### PR TITLE
DAOS-9173 ofi: Update workarounds

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+daos (2.1.100-13) unstable; urgency=medium
+  [ Alexander Oganezov ]
+  * Remove DAOS-9173 workaround from mercury. Apply patch to OFI instead.
+
+ -- Alexander Oganezov <alexander.a.oganezov@intel.com>  Wed, 08 Dec 2021 10:00:01 -0100
+
 daos (2.1.100-12) unstable; urgency=medium
   [ Alexander Oganezov ]
   * Apply DAOS-9173 workaround patch

--- a/debian/control
+++ b/debian/control
@@ -5,7 +5,7 @@ Maintainer: daos-stack <daos@daos.groups.io>
 Build-Depends: debhelper (>= 10),
                dh-python,
                libcmocka-dev,
-               libfabric-dev (>= 1.12.0),
+               libfabric-dev (>= 1.14.0~rc3-2),
                libhwloc-dev,
                libopenmpi-dev,
                libssl-dev,
@@ -147,7 +147,7 @@ Package: daos-client
 Section: net
 Architecture: any
 Multi-Arch: same
-Depends: ${shlibs:Depends}, ${misc:Depends}, openmpi-bin, libfabric (>= 1.12.0)
+Depends: ${shlibs:Depends}, ${misc:Depends}, openmpi-bin, libfabric (>= 1.14.0~rc3-2)
 Description: The Distributed Asynchronous Object Storage (DAOS) is an open-source
  software-defined object store designed from the ground up for
  massively distributed Non Volatile Memory (NVM). DAOS takes advantage
@@ -166,7 +166,7 @@ Section: net
 Architecture: any
 Multi-Arch: same
 Depends: ${shlibs:Depends}, ${misc:Depends}, openmpi-bin,
-         ipmctl (>02.00.00.3816), libfabric (>= 1.12.0)
+         ipmctl (>02.00.00.3816), libfabric (>= 1.14.0~rc3-2)
 Description: The Distributed Asynchronous Object Storage (DAOS) is an open-source
  software-defined object store designed from the ground up for
  massively distributed Non Volatile Memory (NVM). DAOS takes advantage

--- a/utils/build.config
+++ b/utils/build.config
@@ -16,4 +16,3 @@ PROTOBUFC = v1.3.3
 [patch_versions]
 spdk=https://github.com/spdk/spdk/commit/690783a3ae82ebe58c00d643520a66103d66d540.diff,https://github.com/spdk/spdk/commit/65425be69a0882ac283fb489aa151d7df06c52ad.diff,https://raw.githubusercontent.com/daos-stack/spdk/master/0003-blob-chunk-clear-operations-in-IU-aligned-chunks.patch,https://github.com/spdk/spdk/commit/148a9ab0c06346f9fec109a1df00651c1f5a0499.diff,https://github.com/spdk/spdk/commit/086223c029389329b7a4f38ec0f9a30be83849bf.diff
 pmdk=https://raw.githubusercontent.com/daos-stack/pmdk/master/DAOS_8273.patch
-mercury=https://raw.githubusercontent.com/daos-stack/mercury/master/daos_9173_workaround.patch

--- a/utils/rpms/daos.spec
+++ b/utils/rpms/daos.spec
@@ -3,8 +3,8 @@
 %define agent_svc_name daos_agent.service
 %define sysctl_script_name 10-daos_server.conf
 
-%global mercury_version 2.1.0~rc4-2%{?dist}
-%global libfabric_version 1.14.0~rc3-1
+%global mercury_version 2.1.0~rc4-1%{?dist}
+%global libfabric_version 1.14.0~rc3-2
 %global __python %{__python3}
 
 %if (0%{?rhel} >= 8)
@@ -15,7 +15,7 @@
 
 Name:          daos
 Version:       2.1.100
-Release:       12%{?relval}%{?dist}
+Release:       13%{?relval}%{?dist}
 Summary:       DAOS Storage Engine
 
 License:       BSD-2-Clause-Patent
@@ -521,6 +521,9 @@ getent passwd daos_agent >/dev/null || useradd -s /sbin/nologin -r -g daos_agent
 # No files in a meta-package
 
 %changelog
+* Wed Dec 08 2021 Alexander Oganezov <alexander.a.oganezov@intel.com> 2.1.100-13
+- Remove DAOS-9173 workaround from mercury. Apply DAOS-9173 to ofi
+
 * Tue Dec 07 2021 Alexander Oganezov <alexander.a.oganezov@intel.com> 2.1.100-12
 - Apply DAOS-9173 workaround to mercury
 


### PR DESCRIPTION
- Remove mercury workaround for DAOS-9173
- Apply OFI patch for DAOS-9173 instead

NOTE: build.config patching is not included for now to avoid
build conflicts

Signed-off-by: Alexander A Oganezov <alexander.a.oganezov@intel.com>