### PR TITLE
DAOS-8655 tests: Fix orterun tmpdir 'No such file or directory' (#6869)

### DIFF
--- a/src/tests/ftest/server/metadata.py
+++ b/src/tests/ftest/server/metadata.py
@@ -4,10 +4,10 @@
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
+import shutil
+from tempfile import mkdtemp
 import traceback
 import uuid
-import threading
-import queue
 
 from avocado.core.exceptions import TestFail
 
@@ -15,28 +15,44 @@ from apricot import TestWithServers
 from ior_utils import IorCommand
 from command_utils_base import CommandFailure
 from job_manager_utils import Orterun
+from thread_manager import ThreadManager
 
 
-def ior_runner_thread(manager, uuids, results):
-    """IOR run thread method.
+def run_ior_loop(manager, uuids):
+    """IOR run for each UUID provided.
 
     Args:
         manager (str): mpi job manager command
-        uuids (list): [description]
-        results (queue): queue for returning thread results
+        uuids (list): list of container UUIDs
+
+    Returns:
+        list: a list of CmdResults from each ior command run
+
     """
+    results = []
+    errors = []
     for index, cont_uuid in enumerate(uuids):
         manager.job.dfs_cont.update(cont_uuid, "ior.cont_uuid")
+
+        # Create a unique temporary directory for the the manager command
+        tmp_dir = mkdtemp(dir=manager.tmpdir_base.value)
+        manager.tmpdir_base.update(tmp_dir, "tmpdir_base")
+
         try:
-            manager.run()
+            results.append(manager.run())
         except CommandFailure as error:
-            print(
-                "--- FAIL --- Thread-{0} Failed to run IOR {1}: "
-                "Exception {2}".format(
-                    index,
-                    "read" if "-r" in manager.job.flags.value else "write",
-                    str(error)))
-            results.put("FAIL")
+            ior_mode = "read" if "-r" in manager.job.flags.value else "write"
+            errors.append(
+                "IOR {} Loop {}/{} failed for container {}: {}".format(
+                    ior_mode, index, len(uuids), cont_uuid, error))
+        finally:
+            # Remove the unique temporary directory and its contents to avoid conflicts
+            shutil.rmtree(tmp_dir, ignore_errors=True)
+
+    if errors:
+        raise CommandFailure(
+            "IOR failed in {}/{} loops: {}".format(len(errors), len(uuids), "\n".join(errors)))
+    return results
 
 
 class ObjectMetadata(TestWithServers):
@@ -55,9 +71,24 @@ class ObjectMetadata(TestWithServers):
     CREATED_CONTAINERS_LIMIT = 3500
 
     def __init__(self, *args, **kwargs):
-        """Initialize a ObjectMetadata object."""
+        """Initialize a TestWithServers object."""
         super().__init__(*args, **kwargs)
-        self.out_queue = None
+        self.ior_managers = []
+
+    def pre_tear_down(self):
+        """Tear down steps to optionally run before tearDown().
+
+        Returns:
+            list: a list of error strings to report at the end of tearDown().
+
+        """
+        error_list = []
+        if self.ior_managers:
+            self.test_log.info("Stopping IOR job managers")
+            error_list = self._stop_managers(self.ior_managers, "IOR job manager")
+        else:
+            self.log.debug("no pre-teardown steps defined")
+        return error_list
 
     def create_pool(self):
         """Create a pool and display the svc ranks."""
@@ -161,30 +192,6 @@ class ObjectMetadata(TestWithServers):
                 self.log.error("  %s", error)
         self.container = []
         return len(errors) == 0
-
-    def thread_control(self, threads, operation):
-        """Start threads and wait until all threads are finished.
-
-        Args:
-            threads (list): list of threads to execute
-            operation (str): IOR operation, e.g. "read" or "write"
-
-        Returns:
-            str: "PASS" if all threads completed successfully; "FAIL" otherwise
-
-        """
-        self.create_pool()
-        self.d_log.debug("IOR {0} Threads Started -----".format(operation))
-        for thread in threads:
-            thread.start()
-        for thread in threads:
-            thread.join()
-
-        while not self.out_queue.empty():
-            if self.out_queue.get() == "FAIL":
-                return "FAIL"
-        self.d_log.debug("IOR {0} Threads Finished -----".format(operation))
-        return "PASS"
 
     def test_metadata_fillup(self):
         """JIRA ID: DAOS-1512.
@@ -358,7 +365,6 @@ class ObjectMetadata(TestWithServers):
         self.create_pool()
         files_per_thread = 400
         total_ior_threads = 5
-        self.out_queue = queue.Queue()
 
         processes = self.params.get("slots", "/run/ior/clientslots/*")
 
@@ -366,13 +372,15 @@ class ObjectMetadata(TestWithServers):
             [str(uuid.uuid4()) for _ in range(files_per_thread)]
             for _ in range(total_ior_threads)]
 
+        # Setup the thread manager
+        thread_manager = ThreadManager(run_ior_loop, self.timeout - 30)
+
         # Launch threads to run IOR to write data, restart the agents and
         # servers, and then run IOR to read the data
         for operation in ("write", "read"):
             # Create the IOR threads
-            threads = []
             for index in range(total_ior_threads):
-                # Define the arguments for the ior_runner_thread method
+                # Define the arguments for the run_ior_loop method
                 ior_cmd = IorCommand()
                 ior_cmd.get_params(self)
                 ior_cmd.set_daos_params(self.server_group, self.pool)
@@ -380,29 +388,27 @@ class ObjectMetadata(TestWithServers):
                     "F", "/run/ior/ior{}flags/".format(operation))
 
                 # Define the job manager for the IOR command
-                manager = Orterun(ior_cmd)
-                env = ior_cmd.get_default_env(str(manager))
-                manager.assign_hosts(self.hostlist_clients, self.workdir, None)
-                manager.assign_processes(processes)
-                manager.assign_environment(env)
+                self.ior_managers.append(Orterun(ior_cmd))
+                self.ior_managers[-1].tmpdir_base.update(self.test_dir, "orterun.tmpdir_base")
+                env = ior_cmd.get_default_env(str(self.ior_managers[-1]))
+                self.ior_managers[-1].assign_hosts(self.hostlist_clients, self.workdir, None)
+                self.ior_managers[-1].assign_processes(processes)
+                self.ior_managers[-1].assign_environment(env)
+                self.ior_managers[-1].verbose = False
 
                 # Add a thread for these IOR arguments
-                threads.append(
-                    threading.Thread(
-                        target=ior_runner_thread,
-                        kwargs={
-                            "manager": manager,
-                            "uuids": list_of_uuid_lists[index],
-                            "results": self.out_queue}))
-
+                thread_manager.add(manager=self.ior_managers[-1], uuids=list_of_uuid_lists[index])
                 self.log.info(
                     "Created %s thread %s with container uuids %s", operation,
                     index, list_of_uuid_lists[index])
 
             # Launch the IOR threads
-            if self.thread_control(threads, operation) == "FAIL":
-                self.d_log.error("IOR {} Thread FAIL".format(operation))
-                self.fail("IOR {} Thread FAIL".format(operation))
+            self.log.info("Launching %d IOR %s threads", thread_manager.qty, operation)
+            failed_thread_count = thread_manager.check_run()
+            if failed_thread_count > 0:
+                msg = "{} FAILED IOR {} Thread(s)".format(failed_thread_count, operation)
+                self.d_log.error(msg)
+                self.fail(msg)
 
             # Restart the agents and servers after the write / before the read
             if operation == "write":
@@ -412,17 +418,14 @@ class ObjectMetadata(TestWithServers):
                     len(errors), 0,
                     "Error stopping agents:\n  {}".format("\n  ".join(errors)))
 
-                # Stop the servers
-                errors = self.stop_servers()
+                # Restart the servers w/o formatting the storage
+                errors = self.restart_servers()
                 self.assertEqual(
                     len(errors), 0,
                     "Error stopping servers:\n  {}".format("\n  ".join(errors)))
 
                 # Start the agents
                 self.start_agent_managers()
-
-                # Start the servers
-                self.start_server_managers()
 
         self.log.info("Test passed")
 

--- a/src/tests/ftest/util/job_manager_utils.py
+++ b/src/tests/ftest/util/job_manager_utils.py
@@ -184,6 +184,16 @@ class JobManager(ExecutableCommand):
         # processes running by returning a "R" state.
         return "R" if 1 not in results or len(results) > 1 else None
 
+    def stop(self):
+        """Stop the subprocess command and kill any job processes running on hosts.
+
+        Raises:
+            CommandFailure: if unable to stop
+
+        """
+        super().stop()
+        self.kill()
+
     def kill(self):
         """Forcibly terminate any job processes running on hosts."""
         regex = self.job.command_regex
@@ -236,6 +246,7 @@ class Orterun(JobManager):
         self.tag_output = FormattedParameter("--tag-output", True)
         self.ompi_server = FormattedParameter("--ompi-server {}", None)
         self.working_dir = FormattedParameter("-wdir {}", None)
+        self.tmpdir_base = FormattedParameter("--mca orte_tmpdir_base {}", None)
 
     def assign_hosts(self, hosts, path=None, slots=None):
         """Assign the hosts to use with the command (--hostfile).
@@ -340,6 +351,7 @@ class Mpirun(JobManager):
         self.envlist = FormattedParameter("-envlist {}", None)
         self.mca = FormattedParameter("--mca {}", mca_default)
         self.working_dir = FormattedParameter("-wdir {}", None)
+        self.tmpdir_base = FormattedParameter("--mca orte_tmpdir_base {}", None)
         self.mpitype = mpitype
 
     def assign_hosts(self, hosts, path=None, slots=None):

--- a/src/tests/ftest/util/thread_manager.py
+++ b/src/tests/ftest/util/thread_manager.py
@@ -1,0 +1,164 @@
+#!/usr/bin/python3
+"""
+(C) Copyright 2021 Intel Corporation.
+
+SPDX-License-Identifier: BSD-2-Clause-Patent
+"""
+from concurrent.futures import ThreadPoolExecutor, as_completed, TimeoutError
+from logging import getLogger
+
+from avocado.utils.process import CmdResult
+
+
+class ThreadResult():
+    """Class containing the results of a method executed by the ThreadManager class."""
+
+    def __init__(self, id, passed, args, result):
+        """Initialize a ThreadResult object.
+
+        Args:
+            id (int): the thread id for this result
+            passed (bool): whether the thread completed or raised an exception
+            args (dict): the arguments passed to the thread method
+            result (object): the object returned by the thread method
+        """
+        self.id = id
+        self.passed = passed
+        self.args = args
+        self.result = result
+
+    def __str__(self):
+        """Return the string respresentation of this object.
+
+        Returns:
+            str: the string respresentation of this object
+
+        """
+        def get_result(result):
+            """Get the result information to display.
+
+            Args:
+                result (object): the result returned by the thread
+
+            Returns:
+                list: each line of the result information
+
+            """
+            data = []
+            if isinstance(result, CmdResult):
+                data.append("    command:     {}".format(result.command))
+                data.append("    exit_status: {}".format(result.exit_status))
+                data.append("    duration:    {}".format(result.duration))
+                data.append("    interrupted: {}".format(result.interrupted))
+                data.append("    stdout:")
+                for line in result.stdout_text.splitlines():
+                    data.append("      {}".format(line))
+                data.append("    stderr:")
+                for line in result.stderr_text.splitlines():
+                    data.append("      {}".format(line))
+            else:
+                for line in str(result).splitlines():
+                    data.append("    {}".format(line))
+            return data
+
+        info = ["Thread {} results:".format(self.id), "  args: {}".format(self.args), "  result:"]
+        if isinstance(self.result, list):
+            for this_result in self.result:
+                info.extend(get_result(this_result))
+        else:
+            info.extend(get_result(self.result))
+        return "\n".join(info)
+
+
+class ThreadManager():
+    """Class to manage running any method as multiple threads."""
+
+    def __init__(self, method, timeout=None):
+        """Initialize a ThreadManager object with the the method to run as a thread.
+
+        Args:
+            method (callable): python method to execute in each thread
+            timeout (int, optional): timeout for all thread execution. Defaults to None.
+        """
+        self.log = getLogger()
+        self.method = method
+        self.timeout = timeout
+        self.job_kwargs = []
+        self.futures = {}
+
+    @property
+    def qty(self):
+        """Get the number of threads.
+
+        Returns:
+            int: number of threads
+
+        """
+        return len(self.job_kwargs)
+
+    def add(self, **kwargs):
+        """Add a thread to run by specifying the keyword arguments for the thread method."""
+        self.job_kwargs.append(kwargs)
+
+    def run(self):
+        """Asynchronously run the method as a thread for each set of method arguments.
+
+        Returns:
+            list: a list of ThreadResult objects containing the results of each method.
+
+        """
+        results = []
+        with ThreadPoolExecutor() as thread_executor:
+            self.log.info("Submitting %d threads ...", len(self.job_kwargs))
+            # Keep track of thread ids by assigning an index to each Future object
+            futures = {
+                thread_executor.submit(self.method, **kwargs): index
+                for index, kwargs in enumerate(self.job_kwargs)}
+            try:
+                for future in as_completed(futures, self.timeout):
+                    id = futures[future]
+                    try:
+                        results.append(
+                            ThreadResult(id, True, self.job_kwargs[id], future.result()))
+                        self.log.info("Thread %d passed: %s", id, results[-1])
+                    except Exception as error:
+                        results.append(ThreadResult(id, False, self.job_kwargs[id], str(error)))
+                        self.log.info("Thread %d failed: %s", id, results[-1])
+            except TimeoutError as error:
+                for future in futures:
+                    if not future.done():
+                        results.append(ThreadResult(id, False, self.job_kwargs[id], str(error)))
+                        self.log.info("Thread %d timed out: %s", id, results[-1])
+        return results
+
+    def check(self, results):
+        """Display the results from self.run() and indicate if any threads failed.
+
+        Args:
+            results (list): a list of ThreadResults from self.run()
+
+        Returns:
+            int: number of threads that failed
+
+        """
+        failed = []
+        self.log.info("Results from threads that passed:")
+        for result in results:
+            if result.passed:
+                self.log.info(str(result))
+            else:
+                failed.append(result)
+        if failed:
+            self.log.info("Results from threads that failed:")
+            for result in failed:
+                self.log.info(str(result))
+        return len(failed)
+
+    def check_run(self):
+        """Run the threads and check thr result.
+
+        Returns:
+            int: number of threads that failed
+
+        """
+        return self.check(self.run())


### PR DESCRIPTION
Use a test-specific temporary directory for temporary files generated
during the test and remove the files after test completion to free up
space for the next test.

Signed-off-by: Phillip Henderson <phillip.henderson@intel.com>