### PR TITLE
DAOS-8655 tests: Fix mpi tmpdir_base assignment in threads.

### DIFF
--- a/src/tests/ftest/server/metadata.py
+++ b/src/tests/ftest/server/metadata.py
@@ -18,12 +18,13 @@ from job_manager_utils import Orterun
 from thread_manager import ThreadManager
 
 
-def run_ior_loop(manager, uuids):
+def run_ior_loop(manager, uuids, tmpdir_base):
     """IOR run for each UUID provided.
 
     Args:
         manager (str): mpi job manager command
         uuids (list): list of container UUIDs
+        tmpdir_base (str): base directory for the mpi orte_tmpdir_base mca parameter
 
     Returns:
         list: a list of CmdResults from each ior command run
@@ -31,7 +32,6 @@ def run_ior_loop(manager, uuids):
     """
     results = []
     errors = []
-    tmpdir_base = manager.tmpdir_base.value
     for index, cont_uuid in enumerate(uuids):
         manager.job.dfs_cont.update(cont_uuid, "ior.cont_uuid")
 
@@ -390,7 +390,6 @@ class ObjectMetadata(TestWithServers):
 
                 # Define the job manager for the IOR command
                 self.ior_managers.append(Orterun(ior_cmd))
-                self.ior_managers[-1].tmpdir_base.update(self.test_dir, "orterun.tmpdir_base")
                 env = ior_cmd.get_default_env(str(self.ior_managers[-1]))
                 self.ior_managers[-1].assign_hosts(self.hostlist_clients, self.workdir, None)
                 self.ior_managers[-1].assign_processes(processes)
@@ -398,7 +397,9 @@ class ObjectMetadata(TestWithServers):
                 self.ior_managers[-1].verbose = False
 
                 # Add a thread for these IOR arguments
-                thread_manager.add(manager=self.ior_managers[-1], uuids=list_of_uuid_lists[index])
+                thread_manager.add(
+                    manager=self.ior_managers[-1], uuids=list_of_uuid_lists[index],
+                    tmpdir_base=self.test_dir)
                 self.log.info(
                     "Created %s thread %s with container uuids %s", operation,
                     index, list_of_uuid_lists[index])

--- a/src/tests/ftest/server/metadata.py
+++ b/src/tests/ftest/server/metadata.py
@@ -31,11 +31,12 @@ def run_ior_loop(manager, uuids):
     """
     results = []
     errors = []
+    tmpdir_base = manager.tmpdir_base.value
     for index, cont_uuid in enumerate(uuids):
         manager.job.dfs_cont.update(cont_uuid, "ior.cont_uuid")
 
         # Create a unique temporary directory for the the manager command
-        tmp_dir = mkdtemp(dir=manager.tmpdir_base.value)
+        tmp_dir = mkdtemp(dir=tmpdir_base)
         manager.tmpdir_base.update(tmp_dir, "tmpdir_base")
 
         try:


### PR DESCRIPTION
Supplemental fix for previous server/metadata.py
test_metadata_server_restart test case where unique temporary base
directories for each orterun command where based on the previous unique
temporary directory that no longer existed when the next ior command was
issued.

Quick-functional: true
Test-tag: metadata_ior offline_extend_oclass
Test-repeat: 10

Signed-off-by: Phillip Henderson <phillip.henderson@intel.com>