### PR TITLE
DAOS-623 test: remove snapshot tag in favor of snap

### DIFF
--- a/src/tests/ftest/container/snapshot_aggregation.py
+++ b/src/tests/ftest/container/snapshot_aggregation.py
@@ -47,7 +47,7 @@ class SnapshotAggregation(IorTestBase):
 
         :avocado: tags=all,pr,daily_regression
         :avocado: tags=hw,large
-        :avocado: tags=container,snapshot,snap
+        :avocado: tags=container,snap
         :avocado: tags=snapshot_aggregation
         """
         self.dmg = self.get_dmg_command()


### PR DESCRIPTION
Quick-functional: true
Test-tag: snapshot_aggregation

Remove a "snapshot" avocado tag, since all other snapshot test use
"snap". This will hopefully prevent spreading the use of both tags.

Signed-off-by: Dalton Bohning <dalton.bohning@intel.com>