### PR TITLE
DAOS-9088 docker: add recipes to run in containers

### DIFF
--- a/utils/docker/vcluster/.env
+++ b/utils/docker/vcluster/.env
@@ -1,0 +1,16 @@
+# Copyright (C) 2021 Intel Corporation
+# All rights reserved.
+#
+# Configuration file for DAOS docker compose
+
+# Container runtime configuration
+DAOS_IFACE_IP="x.x.x.x"
+
+# Image building configuration
+DAOS_AUTH="no"
+DAOS_HUGEPAGES_NBR=4096
+DAOS_IFACE_NAME="eth0"
+DAOS_SCM_SIZE=4
+DAOS_BDEV_SIZE=16
+DAOS_ADMIN_USER="root"
+DAOS_ADMIN_GROUP="root"

--- a/utils/docker/vcluster/README.md
+++ b/utils/docker/vcluster/README.md
@@ -1,0 +1,202 @@
+# Using DAOS with Docker
+
+This section describes how to build and deploy Docker images allowing to simulate a small cluster
+using DAOS as backend storage.  This small cluster is composed of the following three nodes:
+
+- The `daos-server` node running a DAOS server daemon managing data storage devices such as SCM or
+  NVMe disks.
+- The `daos-admin` node allowing to manage the DAOS server thanks to `dmg`command.
+- The `daos-client` node using the the DAOS server to store data.
+
+At this time only emulated hardware storage are supported by this Docker platform:
+
+- SCM (i.e. Stoarage Class Memory) are emulated with standard RAM memory.
+- NVMe disks are emulated with a file device.
+
+!!! warning
+    Virtual Docker network such as [bridge](https://docs.docker.com/network/bridge/) are not yet
+    well supported by DAOS.  Thus, one physical network interface (i.e. loopback interface is also
+    not well supported) of the host should be chosen for being used by the containers through the
+    Docker [host](https://docs.docker.com/network/host/) network.
+
+
+## Prerequisites
+
+To build and deploy the Docker images, `docker` and optionally `docker-compose` shall be available.
+The docker host should have access to the [Docker Hub](https://hub.docker.com/) and
+[CentOS](https://www.centos.org/) official repositories.  Finally,
+[hugepages](https://www.kernel.org/doc/Documentation/vm/hugetlbpage.txt) linux kernel feature shall
+be enabled on the docker host.
+
+The platform was tested and validated with the [CentOS8](https://hub.docker.com/_/centos) official
+docker image.  However other RHEL-like distributions such as
+[rocky8.4](https://hub.docker.com/r/rockylinux/rockylinux) should be supported.
+
+!!! warning
+    Some distributions are not yet well supported such as
+    [rocky8.5](https://hub.docker.com/r/rockylinux/rockylinux): issue with the management of
+    hugepages with the [spdk](https://spdk.io/) library.
+
+
+## Building Docker Images
+
+### Building Base DAOS Image
+
+The first image to create is the `daos-base` image which is not intetended to be used as it, but as
+a base image for building the other three daos images.  This first image could be built directly
+from GitHub with the following command:
+
+```bash
+$ docker build --tag daos-base:centos8 \
+	https://github.com/daos-stack/daos.git#master:utils/docker/vcluster/daos-base/el8
+```
+
+This Docker file accept the following arguments:
+
+- `RHEL_BASE_IMAGE`: Base docker image to use (default centos)
+- `RHEL_BASE_VERSION`: Version of the base docker image to use (default 8)
+- `BUST_CACHE`: Manage docker building cache (default undefined).  To invalidate the cache, a random
+	value such as the date of the day shall be given.
+- `DAOS_AUTH`: Enable DAOS authentication when set to "yes" (default "no")
+- `DAOS_REPOS`: Space separated list of repos needed to install DAOS (default
+	"https://packages.daos.io/v2.0")
+- `DAOS_GPG_KEYS`: Space separated list of GPG keys associated with DAOS repos (default
+	"https://packages.daos.io/RPM-GPG-KEY")
+- `DAOS_REPOS_NOAUTH`: Space separated list of repos to use without GPG authentication
+	(default "")
+
+For example, building a DAOS base image with authentication enabled could be done with the
+following command:
+
+```bash
+$ docker build --tag daos-base:centos8 --build-arg DAOS_AUTH=yes \
+	https://github.com/daos-stack/daos.git#master:utils/docker/vcluster/daos-base/el8
+```
+
+It is also possible to build the `daos-base` image from a local tree with the following command:
+
+```bash
+$ docker build --tag daos-base:centos8 utils/docker/vcluster/daos-base/el8
+```
+
+### Building DAOS Nodes Images
+
+The three images `daos-server`, `daos-admin` and `daos-client` could be built directly from GitHub
+or from a local tree in the same way as for the `daos-base` image.  Following command could be used
+to build directly the three images from GitHub:
+
+```bash
+$ for image in daos-server daos-admin daos-client ; do \
+	docker build --tag "$image:centos8" \
+		"https://github.com/daos-stack/daos.git#master:utils/docker/vcluster/$image/el8"; \
+  done
+```
+
+The Docker file of the `daos-server` image accept the following arguments:
+
+- `DAOS_BASE_IMAGE`: Base docker image to use (default daos-base)
+- `DAOS_BASE_VERSION`: Version of the base docker image to use (default centos8)
+- `DAOS_AUTH`: Enable DAOS authentication when set to "yes" (default "no")
+- `DAOS_HUGEPAGES_NBR`: Number of huge pages to allocate for SPDK (default 4096)
+- `DAOS_SCM_SIZE`: Size in GB of the RAM emulating SCM devices (default 4)
+- `DAOS_BDEV_SIZE`: Size in GB of the file created to emulate NVMe devices (default 16)
+- `DAOS_IFACE_NAME`: Fabric network interface used by the DAOS engine (default "eth0")
+
+!!!note
+   The IP address of the networkf interface referenced by the `DAOS_IFACE_NAME` argument will be
+   required when starting DAOS.
+
+The Dockerfile of the `daos-client` and `daos-admin` images accept the following arguments:
+
+- `DAOS_BASE_IMAGE`: Base docker image to use (default daos-base)
+- `DAOS_BASE_VERSION`: Version of the base docker image to use (default centos8)
+- `DAOS_AUTH`: Enable DAOS authentication when set to "yes" (default "no")
+- `DAOS_ADMIN_USER`: Name or uid of the daos administrattor user (default "root")
+- `DAOS_ADMIN_GROUP`: Name or gid of the daos administrattor group (default "root")
+
+From a local tree, a more straightforward way to build these images could be done with
+`docker-compose` and the following commands:
+
+```bash
+$ docker-compose --file utils/docker/vcluster/docker-compose.yml -- build
+
+```
+
+The same arguments are accepted but they have to be defined in the Docker Compose environment file
+`utils/docker/vcluster/.env`.
+
+!!! warning
+    For working properly, the DAOS authentication have to be enabled in all the images (i.e. nodes
+    images and base image).
+
+## Running DAOS Nodes Container
+
+### Starting Containers with docker command
+
+Once the images are created, the containers could be directly started with docker with the following
+commands:
+
+```bash
+$ export DAOS_IFACE_IP=x.x.x.x
+$ docker run --detach --privileged --name=daos-server --hostname=daos-server \
+	--add-host "daos-server:$DAOS_IFACE_IP" --add-host "daos-admin:$DAOS_IFACE_IP" \
+	--add-host "daos-client:$DAOS_IFACE_IP" --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro \
+	--volume=/dev/hugepages:/dev/hugepages  --tmpfs=/run --network=host \
+	daos-server:centos8
+$ docker run --detach --privileged --name=daos-agent --hostname=daos-agent \
+	--add-host "daos-server:$DAOS_IFACE_IP" --add-host "daos-admin:$DAOS_IFACE_IP" \
+	--add-host "daos-client:$DAOS_IFACE_IP" --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro \
+	--tmpfs=/run --network=host daos-agent:centos8
+$ docker run --detach --privileged --name=daos-client --hostname=daos-client \
+	--add-host "daos-server:$DAOS_IFACE_IP" --add-host "daos-admin:$DAOS_IFACE_IP" \
+	--add-host "daos-client:$DAOS_IFACE_IP" --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro \
+	--tmpfs=/run --network=host daos-client:centos8
+```
+
+The value of the `DAOS_IFACE_IP` shall be replaced with the one of the network interface which was
+provided when the images have been built.
+
+Once started, the DAOS server waits for the administrator to format the system.
+This can be done using the following command:
+
+```bash
+$ docker exec daos-admin dmg -i storage format
+```
+
+Upon successful completion of the format, the storage engine is started, and pools
+can be created using the daos admin tool.  For more advanced configurations and usage refer to the
+section [DAOS Tour](https://docs.daos.io/QSG/tour/).
+
+
+### Starting Containers with docker-compose command
+
+From a local tree, a more straightforward way to start the containers could be done with
+`docker-compose` and the following commands:
+
+```bash
+$ docker-compose --file utils/docker/vcluster/docker-compose.yml -- up --detach
+```
+
+!!! note
+    Before starting the containers with `docker-compose`, the IP address of the network interface,
+    which was provided when the images have been built, shall be defined in the Docker
+    Compose environment file `utils/docker/vcluster/.env`.
+
+As with the docker command, the system shall be formatted, pools created, etc..
+
+
+### Managing Virtual Docker cluster with daos-cm.sh
+
+From a local tree, the bash script `utils/docker/vcluster/daos-cm.sh` could be used to start the
+containers and setup a simple DAOS system composed of the following elements:
+
+- 1 DAOS pool of 10GB (i.e. size of the pool is configurable)
+- 1 DAOS POSIX container mounted on /mnt/daos-posix-fs
+
+This script could also be used to respectively stop and monitor the containers.
+
+More details on the usage of `daos-cm.sh` command could be found with running the following command:
+
+```bash
+$ utils/docker/vcluster/daos-cm.sh --help
+```

--- a/utils/docker/vcluster/README.md
+++ b/utils/docker/vcluster/README.md
@@ -48,7 +48,7 @@ from GitHub with the following command:
 
 ```bash
 $ docker build --tag daos-base:centos8 \
-	https://github.com/daos-stack/daos.git#master:utils/docker/vcluster/daos-base/el8
+	https://github.com/daos-stack/daos.git#release/2.0:utils/docker/vcluster/daos-base/el8
 ```
 
 This Docker file accept the following arguments:
@@ -70,7 +70,7 @@ following command:
 
 ```bash
 $ docker build --tag daos-base:centos8 --build-arg DAOS_AUTH=yes \
-	https://github.com/daos-stack/daos.git#master:utils/docker/vcluster/daos-base/el8
+	https://github.com/daos-stack/daos.git#release/2.0:utils/docker/vcluster/daos-base/el8
 ```
 
 It is also possible to build the `daos-base` image from a local tree with the following command:
@@ -88,7 +88,7 @@ to build directly the three images from GitHub:
 ```bash
 $ for image in daos-server daos-admin daos-client ; do \
 	docker build --tag "$image:centos8" \
-		"https://github.com/daos-stack/daos.git#master:utils/docker/vcluster/$image/el8"; \
+		"https://github.com/daos-stack/daos.git#release/2.0:utils/docker/vcluster/$image/el8"; \
   done
 ```
 

--- a/utils/docker/vcluster/daos-admin/el8/.dockerignore
+++ b/utils/docker/vcluster/daos-admin/el8/.dockerignore
@@ -1,0 +1,3 @@
+# Ignore everything except DAOS configuration file
+*
+!daos_control.yml.in

--- a/utils/docker/vcluster/daos-admin/el8/Dockerfile
+++ b/utils/docker/vcluster/daos-admin/el8/Dockerfile
@@ -1,0 +1,53 @@
+# Copyright (C) 2021 Intel Corporation
+# All rights reserved.
+#
+# 'recipe' for building a RHEL variant docker image of a DAOS administrator node
+#
+# - DAOS_BASE_IMAGE      Base docker image to use (default daos-base)
+# - DAOS_BASE_VERSION    Version of the base docker image to use (default centos8)
+# - DAOS_AUTH            Enable DAOS authentication when set to "yes" (default "no")
+# - DAOS_ADMIN_USER      Name or uid of the daos administrattor user (default "root")
+# - DAOS_ADMIN_GROUP     Name or gid of the daos administrattor group (default "root")
+
+# Pull base image
+ARG	DAOS_BASE_IMAGE=daos-base
+ARG	DAOS_BASE_VERSION=centos8
+FROM	$DAOS_BASE_IMAGE:$DAOS_BASE_VERSION
+LABEL	maintainer="daos@daos.groups.io"
+
+# Install DAOS client package
+RUN	dnf install daos-client &&                                                                 \
+	dnf clean all
+
+# Install certificates
+ARG	DAOS_AUTH=no
+ARG	DAOS_ADMIN_USER=root
+ARG	DAOS_ADMIN_GROUP=root
+# FIXME Should be provided through volumes (or Secrets for K8S)
+# XXX NOTE XXX With a production platform, this configuration file should be provided with a volume
+# XXX NOTE XXX (or ConfigMaps for K8S).
+COPY	daos_control.yml.in /tmp/daos_control.yml.in
+RUN	if [ "$DAOS_AUTH" == yes ] ; then                                                          \
+		sed --regexp-extended                                                              \
+		    --expression '/^@DAOS_NOAUTH_SECTION_BEGIN@$/,/^@DAOS_NOAUTH_SECTION_END@/d'   \
+		    --expression '/(^@DAOS_AUTH_SECTION_BEGIN@$)|(^@DAOS_AUTH_SECTION_END@$)/d'    \
+		    /tmp/daos_control.yml.in > /etc/daos/daos_control.yml &&                       \
+# XXX WARNING XXX With a production platform, these certificates should be provided with a volume
+# XXX WARNING XXX (or Secrets with K8S).
+		chmod 644 /root/daosCA/certs/daosCA.crt &&                                         \
+		chmod 644 /root/daosCA/certs/admin.crt &&                                          \
+		chmod 600 /root/daosCA/certs/admin.key &&                                          \
+		chown "$DAOS_ADMIN_USER:$DAOS_ADMIN_GROUP" /root/daosCA/certs/daosCA.crt &&        \
+		chown "$DAOS_ADMIN_USER:$DAOS_ADMIN_GROUP" /root/daosCA/certs/admin.crt &&         \
+		chown "$DAOS_ADMIN_USER:$DAOS_ADMIN_GROUP" /root/daosCA/certs/admin.key &&         \
+		mv /root/daosCA/certs/daosCA.crt /etc/daos/certs/. &&                              \
+		mv /root/daosCA/certs/admin.crt /etc/daos/certs/. &&                               \
+		mv /root/daosCA/certs/admin.key /etc/daos/certs/. &&                               \
+		rm -fr /root/daosCA ;                                                              \
+	else                                                                                       \
+		sed --regexp-extended                                                              \
+		    --expression '/^@DAOS_AUTH_SECTION_BEGIN@$/,/^@DAOS_AUTH_SECTION_END@/d'       \
+		    --expression '/(^@DAOS_NOAUTH_SECTION_BEGIN@$)|(^@DAOS_NOAUTH_SECTION_END@$)/d'\
+		    /tmp/daos_control.yml.in > /etc/daos/daos_control.yml ;                        \
+	fi &&                                                                                      \
+	rm -f /tmp/daos_control.yml.in

--- a/utils/docker/vcluster/daos-admin/el8/daos_control.yml.in
+++ b/utils/docker/vcluster/daos-admin/el8/daos_control.yml.in
@@ -1,0 +1,17 @@
+---
+# DAOS Administration configuration file
+
+name: daos_server
+hostlist: ['daos-server']
+port: 10001
+
+transport_config:
+@DAOS_NOAUTH_SECTION_BEGIN@
+  allow_insecure: true
+@DAOS_NOAUTH_SECTION_END@
+@DAOS_AUTH_SECTION_BEGIN@
+  allow_insecure: false
+  ca_cert: /etc/daos/certs/daosCA.crt
+  cert: /etc/daos/certs/admin.crt
+  key: /etc/daos/certs/admin.key
+@DAOS_AUTH_SECTION_END@

--- a/utils/docker/vcluster/daos-base/el8/.dockerignore
+++ b/utils/docker/vcluster/daos-base/el8/.dockerignore
@@ -1,0 +1,2 @@
+# Ignore everything
+*

--- a/utils/docker/vcluster/daos-base/el8/Dockerfile
+++ b/utils/docker/vcluster/daos-base/el8/Dockerfile
@@ -1,0 +1,97 @@
+# Copyright (C) 2021 Intel Corporation
+# All rights reserved.
+#
+# 'recipe' for building a base RHEL variant docker image of a DAOS node
+#
+# This Dockerfile accept the following input build arguments:
+# - RHEL_BASE_IMAGE     Base docker image to use (default centos)
+# - RHEL_BASE_VERSION   Version of the base docker image to use (default 8)
+# - BUST_CACHE          Manage docker building cache (default undefined).  To invalidate the cache,
+#                       a random value such as the date of day shall be given.
+# - DAOS_AUTH           Enable DAOS authentication when set to "yes" (default "no")
+# - DAOS_REPOS          Space separated list of repos needed to install DAOS (default
+#                       "https://packages.daos.io/v2.0")
+# - DAOS_GPG_KEYS       Space separated list of GPG keys associated with DAOS repos (default
+#                       "https://packages.daos.io/RPM-GPG-KEY")
+# - DAOS_REPOS_NOAUTH   Space separated list of repos to use without GPG authentication
+#                       (default "")
+
+# Pull base image
+ARG	RHEL_BASE_IMAGE=centos
+ARG	RHEL_BASE_VERSION=8
+FROM	$RHEL_BASE_IMAGE:$RHEL_BASE_VERSION
+LABEL	maintainer="daos@daos.groups.io"
+
+# Configure systemd: more details could be found at following URL:
+# https://markandruth.co.uk/2020/10/10/running-systemd-inside-a-centos-8-docker-container
+# XXX FIXME XXX Should be removed in production with application dedicated entry point
+VOLUME	[ "/sys/fs/cgroup" ]
+RUN	systemctl mask systemd-remount-fs.service graphical.target kdump.service &&                \
+	systemctl unmask dev-hugepages.mount &&                                                    \
+	pushd /lib/systemd/system/sysinit.target.wants &&                                          \
+	for item in * ; do                                                                         \
+		[ "$item" == systemd-tmpfiles-setup.service ] || rm -f "$item" ;                   \
+	done &&                                                                                    \
+	popd &&                                                                                    \
+	rm -f /lib/systemd/system/multi-user.target.wants/* &&                                     \
+	rm -f /etc/systemd/system/*.wants/* &&                                                     \
+	rm -f /lib/systemd/system/local-fs.target.wants/* &&                                       \
+	rm -f /lib/systemd/system/sockets.target.wants/*udev* &&                                   \
+	rm -f /lib/systemd/system/sockets.target.wants/*initctl* &&                                \
+	rm -f /lib/systemd/system/basic.target.wants/* &&                                          \
+	rm -f /lib/systemd/system/anaconda.target.wants/*
+STOPSIGNAL SIGRTMIN+3
+ENTRYPOINT [ "/sbin/init" ]
+
+# Base configuration of dnf and system update
+RUN	dnf clean all &&                                                                           \
+	dnf makecache &&                                                                           \
+	dnf --assumeyes install dnf-plugins-core &&                                                \
+	dnf config-manager --save --setopt=assumeyes=True &&                                       \
+	dnf config-manager --save --setopt=fastestmirror=True &&                                   \
+	dnf config-manager --set-enabled powertools &&                                             \
+	dnf install epel-release &&                                                                \
+	dnf update &&                                                                              \
+	dnf clean all
+
+# Install DAOS package
+# XXX NOTE XXX Variable allowing to build the image without using global --no-cache option and thus
+# XXX NOTE XXX to not update all rpms.  To work properly a random value such as the date of the day
+# XXX NOTE XXX should be given.
+ARG	BUST_CACHE
+ARG	DAOS_REPOS="https://packages.daos.io/v2.0"
+ARG	DAOS_GPG_KEYS="https://packages.daos.io/RPM-GPG-KEY"
+ARG	DAOS_REPOS_NOAUTH=""
+RUN	if [ -n "$BUST_CACHE" ] ; then                                                             \
+		echo "[INFO] Busting cache" &&                                                     \
+		dnf update ;                                                                       \
+	fi &&                                                                                      \
+	for repo in ${DAOS_REPOS} ; do                                                             \
+		echo "[INFO] Adding rpm repository: $repo" &&                                      \
+		dnf config-manager --add-repo "$repo" ;                                            \
+	done &&                                                                                    \
+	for gpg_key in ${DAOS_GPG_KEYS} ; do                                                       \
+		echo "[INFO] Adding repositories gpg key: $gpg_key" &&                             \
+		rpmkeys --import "$gpg_key" ;                                                      \
+	done &&                                                                                    \
+	for repo in ${DAOS_REPOS_NOAUTH} ; do                                                      \
+		echo "[INFO] Disabling authentication for repository: $repo" &&                    \
+		dnf config-manager --save --setopt="${repo}.gpgcheck=0" ;                          \
+	done &&                                                                                    \
+	echo "[INFO] Installing DAOS" &&                                                           \
+	dnf install daos &&                                                                        \
+	dnf clean all
+
+# Generate GPG authentication certificates for using DAOS authentication
+ARG	DAOS_AUTH=no
+RUN	if [ "$DAOS_AUTH" == yes ] ; then                                                          \
+		echo "[INFO] Generating authentication certificates" &&                            \
+		if [ ! -d /etc/daos/certs ] ; then                                                 \
+			mkdir -d /etc/daos/certs &&                                                \
+			chown root:root /etc/daos/certs &&                                         \
+			chmod 755 /etc/daos/certs ;                                                \
+		fi &&                                                                              \
+# XXX WARNING XXX With a production platform, these certificates should be provided with a volume
+# XXX WARNING XXX (or Secrets with K8S).
+		cd /root && /usr/lib64/daos/certgen/gen_certificates.sh ;                          \
+	fi

--- a/utils/docker/vcluster/daos-client/el8/.dockerignore
+++ b/utils/docker/vcluster/daos-client/el8/.dockerignore
@@ -1,0 +1,3 @@
+# Ignore everything except DAOS configuration file
+*
+!daos_agent.yml.in

--- a/utils/docker/vcluster/daos-client/el8/Dockerfile
+++ b/utils/docker/vcluster/daos-client/el8/Dockerfile
@@ -1,0 +1,54 @@
+# Copyright (C) 2021 Intel Corporation
+# All rights reserved.
+#
+# 'recipe' for building a RHEL variant docker image of a DAOS client node
+#
+# This Dockerfile accept the following input build arguments:
+# - DAOS_BASE_IMAGE      Base docker image to use (default daos-base)
+# - DAOS_BASE_VERSION    Version of the base docker image to use (default centos8)
+# - DAOS_AUTH            Enable DAOS authentication when set to "yes" (default "no")
+# - DAOS_ADMIN_USER      Name or uid of the daos administrattor user (default "root")
+# - DAOS_ADMIN_GROUP     Name or gid of the daos administrattor group (default "root")
+
+# Pull base image
+ARG	DAOS_BASE_IMAGE=daos-base
+ARG	DAOS_BASE_VERSION=centos8
+FROM	$DAOS_BASE_IMAGE:$DAOS_BASE_VERSION
+LABEL	maintainer="daos@daos.groups.io"
+
+# Install DAOS client package
+RUN	dnf install daos-client daos-tests &&                                                      \
+	dnf clean all &&                                                                           \
+	systemctl enable daos_agent
+
+# Install certificates
+ARG	DAOS_AUTH=no
+ARG	DAOS_ADMIN_USER=root
+ARG	DAOS_ADMIN_GROUP=root
+# XXX NOTE XXX With a production platform, this configuration file should be provided with a volume
+# XXX NOTE XXX (or ConfigMaps for K8S).
+COPY	daos_agent.yml.in /tmp/daos_agent.yml.in
+RUN	if [ "$DAOS_AUTH" == yes ] ; then                                                          \
+		sed --regexp-extended                                                              \
+		    --expression '/^@DAOS_NOAUTH_SECTION_BEGIN@$/,/^@DAOS_NOAUTH_SECTION_END@/d'   \
+		    --expression '/(^@DAOS_AUTH_SECTION_BEGIN@$)|(^@DAOS_AUTH_SECTION_END@$)/d'    \
+		    /tmp/daos_agent.yml.in > /etc/daos/daos_agent.yml &&                           \
+# XXX WARNING XXX With a production platform, these certificates should be provided with a volume
+# XXX WARNING XXX (or Secrets with K8S).
+		chmod 644 /root/daosCA/certs/daosCA.crt &&                                         \
+		chmod 644 /root/daosCA/certs/agent.crt &&                                          \
+		chmod 600 /root/daosCA/certs/agent.key &&                                          \
+		chown "$DAOS_ADMIN_USER:$DAOS_ADMIN_GROUP" /root/daosCA/certs/daosCA.crt &&        \
+		chown daos_agent:daos_agent /root/daosCA/certs/agent.crt &&                        \
+		chown daos_agent:daos_agent /root/daosCA/certs/agent.key &&                        \
+		mv /root/daosCA/certs/daosCA.crt /etc/daos/certs/. &&                              \
+		mv /root/daosCA/certs/agent.crt /etc/daos/certs/. &&                               \
+		mv /root/daosCA/certs/agent.key /etc/daos/certs/. &&                               \
+		rm -fr /root/daosCA ;                                                              \
+	else                                                                                       \
+		sed --regexp-extended                                                              \
+		    --expression '/^@DAOS_AUTH_SECTION_BEGIN@$/,/^@DAOS_AUTH_SECTION_END@/d'       \
+		    --expression '/(^@DAOS_NOAUTH_SECTION_BEGIN@$)|(^@DAOS_NOAUTH_SECTION_END@$)/d'\
+		    /tmp/daos_agent.yml.in > /etc/daos/daos_agent.yml ;                            \
+	fi &&                                                                                      \
+	rm -f /tmp/daos_agent.yml.in

--- a/utils/docker/vcluster/daos-client/el8/daos_agent.yml.in
+++ b/utils/docker/vcluster/daos-client/el8/daos_agent.yml.in
@@ -1,0 +1,20 @@
+---
+# DAOS Agent configuration file
+
+name: daos_server
+access_points: ['daos-server']
+port: 10001
+
+runtime_dir: /var/run/daos_agent
+log_file: /tmp/daos_agent.log
+
+transport_config:
+@DAOS_NOAUTH_SECTION_BEGIN@
+  allow_insecure: true
+@DAOS_NOAUTH_SECTION_END@
+@DAOS_AUTH_SECTION_BEGIN@
+  allow_insecure: false
+  ca_cert: /etc/daos/certs/daosCA.crt
+  cert: /etc/daos/certs/agent.crt
+  key: /etc/daos/certs/agent.key
+@DAOS_AUTH_SECTION_END@

--- a/utils/docker/vcluster/daos-cm.sh
+++ b/utils/docker/vcluster/daos-cm.sh
@@ -1,0 +1,230 @@
+#!/bin/bash
+
+set -e
+set -o pipefail
+
+VERSION=0.1
+CWD="$(realpath $(dirname $0))"
+
+DAOS_POOL_SIZE=10G
+
+ANSI_COLOR_BLACK=30
+ANSI_COLOR_RED=31
+ANSI_COLOR_GREEN=32
+ANSI_COLOR_YELLOW=33
+ANSI_COLOR_BLUE=34
+ANSI_COLOR_MAGENTA=35
+ANSI_COLOR_CYAN=36
+ANSI_COLOR_WHITE=37
+ANSI_COLOR_BRIGHT_BLACK=90
+ANSI_COLOR_BRIGHT_RED=91
+ANSI_COLOR_BRIGHT_GREEN=92
+ANSI_COLOR_BRIGHT_YELLOW=93
+ANSI_COLOR_BRIGHT_BLUE=94
+ANSI_COLOR_BRIGHT_MAGENTA=95
+ANSI_COLOR_BRIGHT_CYAN=96
+ANSI_COLOR_BRIGHT_WHITE=97
+
+TRACE_LEVEL_QUIET=-1
+TRACE_LEVEL_STANDARD=0
+TRACE_LEVEL_VERBOSE=1
+TRACE_LEVEL_DEBUG=2
+TRACE_LEVEL=$TRACE_LEVEL_STANDARD
+
+function debug
+{
+	if [[ $TRACE_LEVEL -ge $TRACE_LEVEL_DEBUG ]]
+	then
+		echo -e "[\e[${ANSI_COLOR_GREEN}mDEBUG  \e[00m] $@"
+	fi
+}
+
+
+function info
+{
+	if [[ $TRACE_LEVEL -ge $TRACE_LEVEL_VERBOSE ]]
+	then
+		echo -e "[\e[${ANSI_COLOR_CYAN}mINFO   \e[00m] $@"
+	fi
+}
+
+function warning
+{
+	if [[ $TRACE_LEVEL -ge $TRACE_LEVEL_STANDARD ]]
+	then
+		echo -e "[\e[${ANSI_COLOR_YELLOW}mWARNING\e[00m] $@" 1>&2
+	fi
+}
+
+function error
+{
+	if [[ $TRACE_LEVEL -ge $TRACE_LEVEL_STANDARD ]]
+	then
+		echo -e "[\e[${ANSI_COLOR_BRIGHT_RED}mERROR  \e[00m] $@" 1>&2
+	fi
+}
+
+function fatal
+{
+	if [[ $TRACE_LEVEL -ge $TRACE_LEVEL_STANDARD ]]
+	then
+		echo -e "[\e[${ANSI_COLOR_RED}mFATAL  \e[00m] $@" 1>&2
+	fi
+	exit 1
+}
+
+function check_cmds
+{
+	for cmd in $@
+	do
+		{ hash $cmd > "/dev/null" 2>&1 ; } || { fatal "$cmd command not installed" ; }
+	done
+}
+
+check_cmds docker docker-compose
+
+function usage
+{
+	cat <<- EOF
+		usage: daos-cm.sh [OPTIONS] CMD [ARGS]
+
+		Manage DAOS Virtual Cluster containers
+
+		Options:
+		   -z, --pool-size <size>   total size of DAOS pool (default "10G")
+		   -h, --help               show this help message and exit
+		   -V, --version            show version number
+		   -q, --quiet              quiet mode
+		   -v, --verbose            verbose mode
+		   -D, --debug              debug mode
+
+		Commands:
+		   start <ip address>       start DAOS virtual cluster
+		   stop                     stop DAOS virtual cluster
+		   state                    display the state of the DAOS virtual cluster containers
+	EOF
+}
+
+function run
+{
+	if [[ $TRACE_LEVEL -ge $TRACE_LEVEL_STANDARD ]]
+	then
+		"$@"
+	else
+		"$@" &> /dev/null
+	fi
+}
+
+function state
+{
+	info "State of the DAOS virtual cluster containers"
+	if ! run docker-compose ps ; then
+		fatal "Docker platform not healthy"
+	fi
+}
+
+function stop
+{
+	info "Stopping DAOS virtual cluster containers"
+	if ! run docker-compose down ; then
+		fatal "DAOS virtual cluster could not be properly stopped"
+	fi
+}
+
+function start
+{
+	DAOS_IFACE_IP="$1"
+	DAOS_POOL_SIZE="$2"
+
+	info "Starting DAOS virtual cluster containers"
+	if ! run env DAOS_IFACE_IP="$DAOS_IFACE_IP" docker-compose up --detach ; then
+		fatal "DAOS virtual cluster containers could no be started"
+	fi
+
+	info "Formatting DAOS storage"
+	if ! run docker exec daos-admin dmg storage format --host-list=daos-server ; then
+		fatal "DAOS storage could not be formatted"
+	fi
+
+	info "Checking system"
+	if ! run docker exec daos-admin dmg system query --verbose ; then
+		fatal "DAOS system not healthy"
+	fi
+
+	info "Creating pool tank of $DAOS_POOL_SIZE"
+	if ! run docker exec daos-admin dmg pool create --size="$DAOS_POOL_SIZE" tank ; then
+		fatal "DAOS pool tank of $DAOS_POOL_SIZE could not be created"
+	fi
+
+	info "Checking pool tank"
+	if ! run docker exec daos-admin dmg pool query tank ; then
+		fatal "DAOS pool tank not healthy"
+	fi
+
+	info "Creating POSIX container posix-fs in tank pool"
+	if ! run docker exec daos-client daos container create --type=posix --label=posix-fs tank ; then
+		fatal "DAOS POSIX container posix-fs could not be created in tank pool"
+	fi
+
+	info "Checking container posix-fs"
+	if ! run docker exec daos-client daos container query --verbose tank posix-fs ; then
+		fatal "DAOS POSIX container posix-fs could not be created in tank pool"
+	fi
+
+	info "Creating mount point /mnt/daos-posix-fs in client container"
+	if ! run docker exec daos-client mkdir /mnt/daos-posix-fs ; then
+		fatal "Mount point /mnt/daos-posix-fs could not be created in daos-client container"
+	fi
+
+	info "Mounting DAOS posix-fs container on /mnt/daos-posix-fs"
+	if ! run docker exec daos-client dfuse --mountpoint="/mnt/daos-posix-fs" --pool=tank --container=posix-fs ; then
+		fatal "DAOS POSIX container posix-fs could not be created in tank pool"
+	fi
+
+	info "Checking mount point /mnt/daos-posix-fs"
+	if ! run docker exec daos-client /usr/bin/df --human-readable --type=fuse.daos ; then
+
+                fatal "Mount point /mnt/daos-posix-fs not properly mounted"
+        fi
+
+	[[ $TRACE_LEVEL -ge $TRACE_LEVEL_STANDARD ]] || return 0
+
+	cat <<- EOF
+
+		================================================================================
+		Mount point /mnt/daos-posix-fs is ready on daos-client container.
+		fio could be run on DAOS POSIX container with the following command:
+
+		docker exec daos-client /usr/bin/fio --name=random-write --ioengine=pvsync --rw=randwrite --bs=4k --size=128M --nrfiles=4 --directory=/mnt/daos-posix-fs --numjobs=8 --iodepth=16 --runtime=60 --time_based --direct=1 --buffered=0 --randrepeat=0 --norandommap --refill_buffers --group_reporting
+		================================================================================
+	EOF
+}
+
+OPTIONS=$(getopt -o "z:hVvDq" --long "pool-size:,help,version,verbose,debug,quiet" -- "$@")
+eval set -- "$OPTIONS"
+while true
+do
+	case "$1" in
+		-z|--pool-size) DAOS_POOL_SIZE="$2" ; shift 2 ;;
+		-h|--help) usage ; exit 0;;
+		-V|--version) echo "daos-cm.sh version=$VERSION" ; exit 0 ;;
+		-v|--verbose) TRACE_LEVEL=$TRACE_LEVEL_VERBOSE ; shift 1 ;;
+		-D|--debug) TRACE_LEVEL=$TRACE_LEVEL_DEBUG ; set -x ; shift 1 ;;
+		-q|--quiet) TRACE_LEVEL=$TRACE_LEVEL_QUIET ; shift 1 ;;
+		--) shift ; break ;;
+		*) fatal "unrecognized command line option" ;;
+	esac
+done
+
+[[ $1 ]] || fatal "Command not defined: start, stop or state"
+[[ $1 != "start" || $2 ]] || fatal "Start command: missing IP address"
+CMD="$1"
+DAOS_IFACE_IP="$2"
+
+cd "$CWD"
+case "$CMD" in
+	start) start "$DAOS_IFACE_IP" "$DAOS_POOL_SIZE" ;;
+	stop) stop ;;
+	state) state ;;
+	*) fatal "Unsupported command $CMD: try with start, stop or state" ;;
+esac

--- a/utils/docker/vcluster/daos-server/el8/.dockerignore
+++ b/utils/docker/vcluster/daos-server/el8/.dockerignore
@@ -1,0 +1,3 @@
+# Ignore everything except DAOS configuration file
+*
+!daos_server.yml.in

--- a/utils/docker/vcluster/daos-server/el8/Dockerfile
+++ b/utils/docker/vcluster/daos-server/el8/Dockerfile
@@ -1,0 +1,69 @@
+# Copyright (C) 2021 Intel Corporation
+# All rights reserved.
+#
+# 'recipe' for building a RHEL variant docker image of a DAOS server node
+#
+# This Dockerfile accept the following input build arguments:
+# - DAOS_BASE_IMAGE      Base docker image to use (default daos-base)
+# - DAOS_BASE_VERSION    Version of the base docker image to use (default centos8)
+# - DAOS_AUTH            Enable DAOS authentication when set to "yes" (default "no")
+# - DAOS_HUGEPAGES_NBR   Number of huge pages to allocate for SPDK (default 4096)
+# - DAOS_IFACE_NAME      Fabric network interface used by the DAOS engine (default "eth0")
+# - DAOS_SCM_SIZE        Size in GB of the RAM emulating SCM devices (default 4)
+# - DAOS_BDEV_SIZE       Size in GB of the file created to emulate NVMe devices (derault 16)
+
+# Pull base image
+ARG	DAOS_BASE_IMAGE=daos-base
+ARG	DAOS_BASE_VERSION=centos8
+FROM	$DAOS_BASE_IMAGE:$DAOS_BASE_VERSION
+LABEL	maintainer="daos@daos.groups.io"
+
+# Install DAOS server package
+RUN	dnf install daos-server &&                                                                 \
+	dnf clean all &&                                                                           \
+	systemctl enable daos_server
+
+# Configuration of the server
+ARG	DAOS_AUTH=no
+ARG	DAOS_HUGEPAGES_NBR=4096
+ARG	DAOS_IFACE_NAME=eth0
+ARG	DAOS_SCM_SIZE=4
+ARG	DAOS_BDEV_SIZE=16
+# XXX NOTE XXX With a production platform, this configuration file should be provided with a volume
+# XXX NOTE XXX (or ConfigMaps for K8S).
+COPY	daos_server.yml.in /tmp/daos_server.yml.in
+RUN	if [ "$DAOS_AUTH" == yes ] ; then                                                          \
+		sed --regexp-extended                                                              \
+		    --expression "s/@DAOS_HUGEPAGES_NBR@/${DAOS_HUGEPAGES_NBR}/"                   \
+		    --expression "s/@DAOS_IFACE_NAME@/${DAOS_IFACE_NAME}/"                         \
+		    --expression "s/@DAOS_SCM_SIZE@/${DAOS_SCM_SIZE}/"                             \
+		    --expression "s/@DAOS_BDEV_SIZE@/${DAOS_BDEV_SIZE}/"                           \
+		    --expression '/^@DAOS_NOAUTH_SECTION_BEGIN@$/,/^@DAOS_NOAUTH_SECTION_END@/d'   \
+		    --expression '/(^@DAOS_AUTH_SECTION_BEGIN@$)|(^@DAOS_AUTH_SECTION_END@$)/d'    \
+		    /tmp/daos_server.yml.in > /etc/daos/daos_server.yml &&                         \
+# XXX WARNING XXX With a production platform, these certificates should be provided with a volume
+# XXX WARNING XXX (or Secrets with K8S).
+		chmod 644 /root/daosCA/certs/daosCA.crt &&                                         \
+		chmod 644 /root/daosCA/certs/server.crt &&                                         \
+		chmod 600 /root/daosCA/certs/server.key &&                                         \
+		chmod 644 /root/daosCA/certs/agent.crt &&                                          \
+		chown daos_server:daos_server /root/daosCA/certs/daosCA.crt &&                     \
+		chown daos_server:daos_server /root/daosCA/certs/server.crt &&                     \
+		chown daos_server:daos_server /root/daosCA/certs/server.key &&                     \
+		chown daos_server:daos_server /root/daosCA/certs/agent.crt &&                      \
+		mv /root/daosCA/certs/daosCA.crt /etc/daos/certs/. &&                              \
+		mv /root/daosCA/certs/server.crt /etc/daos/certs/. &&                              \
+		mv /root/daosCA/certs/server.key /etc/daos/certs/. &&                              \
+		mv /root/daosCA/certs/agent.crt /etc/daos/certs/clients/. &&                       \
+		rm -fr /root/daosCA ;                                                              \
+	else                                                                                       \
+		sed --regexp-extended                                                              \
+		    --expression "s/@DAOS_HUGEPAGES_NBR@/${DAOS_HUGEPAGES_NBR}/"                   \
+		    --expression "s/@DAOS_IFACE_NAME@/${DAOS_IFACE_NAME}/"                         \
+		    --expression "s/@DAOS_SCM_SIZE@/${DAOS_SCM_SIZE}/"                             \
+		    --expression "s/@DAOS_BDEV_SIZE@/${DAOS_BDEV_SIZE}/"                           \
+		    --expression '/^@DAOS_AUTH_SECTION_BEGIN@$/,/^@DAOS_AUTH_SECTION_END@/d'       \
+		    --expression '/(^@DAOS_NOAUTH_SECTION_BEGIN@$)|(^@DAOS_NOAUTH_SECTION_END@$)/d'\
+		    /tmp/daos_server.yml.in > /etc/daos/daos_server.yml ;                          \
+	fi &&                                                                                      \
+	rm -f /tmp/daos_server.yml.in

--- a/utils/docker/vcluster/daos-server/el8/daos_server.yml.in
+++ b/utils/docker/vcluster/daos-server/el8/daos_server.yml.in
@@ -1,0 +1,44 @@
+---
+# DAOS Server configuration file
+
+name: daos_server
+access_points: ['daos-server']
+port: 10001
+
+provider: ofi+sockets
+socket_dir: /var/run/daos_server
+nr_hugepages: @DAOS_HUGEPAGES_NBR@
+
+transport_config:
+@DAOS_NOAUTH_SECTION_BEGIN@
+  allow_insecure: true
+@DAOS_NOAUTH_SECTION_END@
+@DAOS_AUTH_SECTION_BEGIN@
+  allow_insecure: false
+  client_cert_dir: /etc/daos/certs/clients
+  ca_cert: /etc/daos/certs/daosCA.crt
+  cert: /etc/daos/certs/server.crt
+  key: /etc/daos/certs/server.key
+@DAOS_AUTH_SECTION_END@
+
+control_log_mask: INFO
+
+engines:
+  - targets: 1
+    first_core: 0
+    nr_xs_helpers: 0
+    fabric_iface: @DAOS_IFACE_NAME@
+    fabric_iface_port: 31416
+    log_file: /tmp/daos_engine_0.log
+
+    env_vars:
+      - FI_SOCKETS_MAX_CONN_RETRY=1
+      - FI_SOCKETS_CONN_TIMEOUT=2000
+
+    scm_class: ram
+    scm_mount: /mnt/daos
+    scm_size: @DAOS_SCM_SIZE@
+
+    bdev_class: file
+    bdev_list: [/tmp/daos-bdev]
+    bdev_size: @DAOS_BDEV_SIZE@

--- a/utils/docker/vcluster/docker-compose.yml
+++ b/utils/docker/vcluster/docker-compose.yml
@@ -1,0 +1,103 @@
+---
+# Copyright (C) 2021 Intel Corporation
+# All rights reserved.
+#
+# Docker Compose file allowing to build and deploy locally a DAOS virtual cluster
+
+version: "3"
+
+services:
+
+  daos_server:
+    image: daos-server:centos8
+    build:
+      context: "https://github.com/daos-stack/daos.git#master:utils/docker/vcluster/daos-server/el8"
+      args:
+        - "DAOS_AUTH=${DAOS_AUTH}"
+        - "DAOS_HUGEPAGES_NBR=${DAOS_HUGEPAGES_NBR}"
+        - "DAOS_IFACE_NAME=${DAOS_IFACE_NAME}"
+        - "DAOS_SCM_SIZE=${DAOS_SCM_SIZE}"
+        - "DAOS_BDEV_SIZE=${DAOS_BDEV_SIZE}"
+    container_name: daos-server
+    hostname: daos-server
+    tty: true
+    # FIXME Refine needed capabilities
+    privileged: true
+    # FIXME virtual network such as bridge are not yet supported
+    network_mode: host
+    # FIXME List of hosts needed until virtual network will be supported
+    extra_hosts:
+      - "daos-server:${DAOS_IFACE_IP}"
+      - "daos-admin:${DAOS_IFACE_IP}"
+      - "daos-client:${DAOS_IFACE_IP}"
+    volumes:
+      - type: bind
+        read_only: true
+        source: /sys/fs/cgroup
+        target: /sys/fs/cgroup
+      - type: bind
+        read_only: false
+        source: /dev/hugepages
+        target: /dev/hugepages
+      - type: tmpfs
+        target: /run
+
+  daos_admin:
+    image: daos-admin:centos8
+    build:
+      context: "https://github.com/daos-stack/daos.git#master:utils/docker/vcluster/daos-admin/el8"
+      args:
+        - "DAOS_AUTH=${DAOS_AUTH}"
+        - "DAOS_ADMIN_USER=${DAOS_ADMIN_USER}"
+        - "DAOS_ADMIN_GROUP=${DAOS_ADMIN_GROUP}"
+    container_name: daos-admin
+    hostname: daos-admin
+    tty: true
+    # FIXME Refine needed capabilities
+    privileged: true
+    # FIXME virtual network such as bridge are not yet supported
+    network_mode: host
+    # FIXME List of hosts needed until virtual network will be supported
+    extra_hosts:
+      - "daos-server:${DAOS_IFACE_IP}"
+      - "daos-admin:${DAOS_IFACE_IP}"
+      - "daos-client:${DAOS_IFACE_IP}"
+    volumes:
+      - type: bind
+        read_only: true
+        source: /sys/fs/cgroup
+        target: /sys/fs/cgroup
+      - type: tmpfs
+        target: /run
+    depends_on:
+      - daos_server
+
+  daos_client:
+    image: daos-client:centos8
+    build:
+      context: "https://github.com/daos-stack/daos.git#master:utils/docker/vcluster/daos-client/el8"
+      args:
+        - "DAOS_AUTH=${DAOS_AUTH}"
+        - "DAOS_ADMIN_USER=${DAOS_ADMIN_USER}"
+        - "DAOS_ADMIN_GROUP=${DAOS_ADMIN_GROUP}"
+    container_name: daos-client
+    hostname: daos-client
+    tty: true
+    # FIXME Refine needed capabilities
+    privileged: true
+    # FIXME virtual network such as bridge are not yet supported
+    network_mode: host
+    # FIXME List of hosts needed until virtual network will be supported
+    extra_hosts:
+      - "daos-server:${DAOS_IFACE_IP}"
+      - "daos-admin:${DAOS_IFACE_IP}"
+      - "daos-client:${DAOS_IFACE_IP}"
+    volumes:
+      - type: bind
+        read_only: true
+        source: /sys/fs/cgroup
+        target: /sys/fs/cgroup
+      - type: tmpfs
+        target: /run
+    depends_on:
+      - daos_server

--- a/utils/docker/vcluster/docker-compose.yml
+++ b/utils/docker/vcluster/docker-compose.yml
@@ -11,7 +11,7 @@ services:
   daos_server:
     image: daos-server:centos8
     build:
-      context: "https://github.com/daos-stack/daos.git#master:utils/docker/vcluster/daos-server/el8"
+      context: "https://github.com/daos-stack/daos.git#release/2.0:utils/docker/vcluster/daos-server/el8"
       args:
         - "DAOS_AUTH=${DAOS_AUTH}"
         - "DAOS_HUGEPAGES_NBR=${DAOS_HUGEPAGES_NBR}"
@@ -45,7 +45,7 @@ services:
   daos_admin:
     image: daos-admin:centos8
     build:
-      context: "https://github.com/daos-stack/daos.git#master:utils/docker/vcluster/daos-admin/el8"
+      context: "https://github.com/daos-stack/daos.git#release/2.0:utils/docker/vcluster/daos-admin/el8"
       args:
         - "DAOS_AUTH=${DAOS_AUTH}"
         - "DAOS_ADMIN_USER=${DAOS_ADMIN_USER}"
@@ -75,7 +75,7 @@ services:
   daos_client:
     image: daos-client:centos8
     build:
-      context: "https://github.com/daos-stack/daos.git#master:utils/docker/vcluster/daos-client/el8"
+      context: "https://github.com/daos-stack/daos.git#release/2.0:utils/docker/vcluster/daos-client/el8"
       args:
         - "DAOS_AUTH=${DAOS_AUTH}"
         - "DAOS_ADMIN_USER=${DAOS_ADMIN_USER}"


### PR DESCRIPTION
Backport of the pull request https://github.com/daos-stack/daos/pull/7556

Provide recipe to build and run DAOS docker containers.

This PR add some docker recipes for building images allowing to run small docker cluster using DAOS as backend storage.
More details could be found in the file utils/docker/vcluster/README.md.

***WARNING:*** all the bitbucker URI are not yet valid as they are targeting the branch master of the main DAOS repo.  They should be changed from https://github.com/daos-stack/daos.git#master:utils/docker/vcluster/daos-base/el8 to https://github.com/daos-stack/daos.git#DAOS-9088:utils/docker/vcluster/daos-base/el8

This could be done automatically with the following command:
`find "$DAOS_HOME/utils/docker/vcluster" -type f -exec grep -q -E -e "https://github.com/daos-stack/daos.git#release/2.0" {} \; -print -exec sed -E -i 's&https://github.com/daos-stack/daos.git#release/2.0&https://github.com/daos-stack/daos.git#DAOS-9088&g' {} \;`

***WARNING*** DAOS 2.0 is not yet available. Thus the target repo should be changed. For building the base image, the command could be:
`docker build --tag daos-base:centos8 --build-arg DAOS_AUTH=yes --build-arg BUST_CACHE="$(date)" --build-arg  DAOS_REPOS="https://packages.daos.io/private/v1.3.106/CentOS8/packages/x86_64/" daos-base/el8`

Signed-off-by: Cedric Koch-Hofer <cedric.koch-hofer@intel.com>