### PR TITLE
DAOS-9173 build: Update build.config

### DIFF
--- a/utils/build.config
+++ b/utils/build.config
@@ -16,3 +16,4 @@ PROTOBUFC = v1.3.3
 [patch_versions]
 spdk=https://github.com/spdk/spdk/commit/690783a3ae82ebe58c00d643520a66103d66d540.diff,https://github.com/spdk/spdk/commit/65425be69a0882ac283fb489aa151d7df06c52ad.diff,https://raw.githubusercontent.com/daos-stack/spdk/master/0003-blob-chunk-clear-operations-in-IU-aligned-chunks.patch,https://github.com/spdk/spdk/commit/148a9ab0c06346f9fec109a1df00651c1f5a0499.diff,https://github.com/spdk/spdk/commit/086223c029389329b7a4f38ec0f9a30be83849bf.diff
 pmdk=https://raw.githubusercontent.com/daos-stack/pmdk/master/DAOS_8273.patch
+ofi=https://raw.githubusercontent.com/daos-stack/libfabric/master/daos-9173-ofi.patch


### PR DESCRIPTION
Update build.config to include daos-9173 ofi patch.

Signed-off-by: Alexander A Oganezov <alexander.a.oganezov@intel.com>