### PR TITLE
DAOS-9108 draft test-only patch do not land

### DIFF
--- a/src/tests/ftest/pool/create_capacity.yaml
+++ b/src/tests/ftest/pool/create_capacity.yaml
@@ -1,3 +1,4 @@
+#noop change
 hosts:
   test_servers:
     - server-A

--- a/src/tests/ftest/util/apricot/apricot/test.py
+++ b/src/tests/ftest/util/apricot/apricot/test.py
@@ -181,6 +181,16 @@ class Test(avocadoTest):
 
         for item in skip_list:
             vals = item.split('|')
+
+            # Expected format: [['DAOS-NNNN', 'test_method_name', 'name']]
+            quoted_str_re = r"'[^\]]+'"
+            if not re.search(
+                r"\[\[" + quoted_str_re + "\s*,\s*"
+                        + quoted_str_re + "\s*,\s*"
+                        + quoted_str_re + "\]\]",
+                 vals[0]):
+                continue
+
             skip_it, ticket = self._check_variant_skip(literal_eval(vals[0]))
             if skip_it:
                 # test is on the skiplist


### PR DESCRIPTION
Did DAOS-9173 landings to update OFI with fi_cancel change improve
pool/create_capacity.py test behavior?

Quick-Functional: true
Skip-coverity-test: true
Skip-func-test-vm: true
Skip-func-hw-test-small: true
Skip-func-hw-test-medium: true
Skip-func-hw-test-large: false
Skip-scan-centos-rpms: true
Skip-scan-leap15-rpms: true
Skip-test-centos-rpms: true
Skip-test-centos-8.3-rpms: true
Skip-test-leap-15-rpms: true
Allow-unstable-test: true
Skip-PR-comments: true

Test-tag: create_performance
Test-repeat-hw-large: 15

Signed-off-by: Kenneth Cain <kenneth.c.cain@intel.com>