### PR TITLE
DAOS-9238-test: nvme/io_verification nvme_server_restart 2 tests failed due to timeout

### DIFF
--- a/src/tests/ftest/nvme/io_verification.yaml
+++ b/src/tests/ftest/nvme/io_verification.yaml
@@ -9,7 +9,7 @@ hosts:
    - boro-G
  test_clients:
    - boro-H
-timeout: 4000
+timeout: 5200
 server_config:
  name: daos_server
  servers:


### PR DESCRIPTION
Description: running timeout increase, test passed on weekly_rel2.0 #6

Skip-unit-tests: true
Test-tag: nvme_server_restart
Signed-off-by: Ding Ho ding-hwa.ho@intel.com