### PR TITLE
DAOS-9109 packaging: Drop dependency on openmpi

### DIFF
--- a/ci/functional/required_packages.sh
+++ b/ci/functional/required_packages.sh
@@ -32,9 +32,11 @@ elif [[ $distro = el* ]] || [[ $distro = centos* ]] ||
           hdf5-vol-daos-mpich-tests    \
           MACSio-mpich                 \
           MACSio-$openmpi              \
-          mpifileutils-mpich"
+          mpifileutils-mpich           \
+          daos-server-tests-openmpi    \
+          daos-client-tests-openmpi"
 else
-    echo "I don't know which packages should be installed for distro"
+    echo "I don't know which packages should be installed for distro" \
          "\"$distro\""
     exit 1
 fi

--- a/ci/rpm/test_daos_node.sh
+++ b/ci/rpm/test_daos_node.sh
@@ -28,7 +28,7 @@ fi
 sudo $YUM -y erase $OPENMPI_RPM
 sudo $YUM -y install daos-client-tests-"${DAOS_PKG_VERSION}"
 if rpm -q $OPENMPI_RPM; then
-  echo "$OPENMPI_RPM RPM should be installed as a dependency of daos-client-tests"
+  echo "$OPENMPI_RPM RPM should not be installed as a dependency of daos-client-tests"
   exit 1
 fi
 if ! sudo $YUM -y history undo last; then
@@ -38,7 +38,7 @@ if ! sudo $YUM -y history undo last; then
 fi
 sudo $YUM -y install daos-server-tests-"${DAOS_PKG_VERSION}"
 if rpm -q $OPENMPI_RPM; then
-  echo "$OPENMPI_RPM RPM should be installed as a dependency of daos-server-tests"
+  echo "$OPENMPI_RPM RPM should not be installed as a dependency of daos-server-tests"
   exit 1
 fi
 if ! sudo $YUM -y history undo last; then
@@ -57,6 +57,10 @@ if rpm -q daos-server; then
 fi
 if ! rpm -q daos-client-tests; then
   echo "daos-client-tests RPM should be installed as a dependency of daos-client-tests-openmpi"
+  exit 1
+fi
+if ! rpm -q $OPENMPI_RPM; then
+  echo "$OPENMPI_RPM RPM should be installed as a dependency of daos-client-tests-openmpi"
   exit 1
 fi
 if ! sudo $YUM -y history undo last; then

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+daos (1.3.106-10) unstable; urgency=medium
+  [ Brian J. Murrell ]
+  * Don't make daos-*-tests-openmi a dependency of anything
+    - If they are wanted, they should be installed explicitly, due to
+      potential conflicts with other MPI stacks
+
+ -- Brian J. Murrell <brian.murrell@intel.com>  Fri, 10 Dec 2021 09:44:14 -0400
+
 daos (1.3.106-9) unstable; urgency=medium
   [ Alexander Oganezov ]
   * Apply OFI patch for DAOS-9173

--- a/debian/control
+++ b/debian/control
@@ -92,8 +92,8 @@ Description: The Distributed Asynchronous Object Storage (DAOS) is an open-sourc
 Package: daos-tests
 Architecture: any
 Multi-Arch: same
-Depends: daos-client-tests-openmpi (= ${binary:Version}),
-         daos-server-tests-openmpi (= ${binary:Version})
+Depends: daos-client-tests (= ${binary:Version}),
+         daos-server-tests (= ${binary:Version})
 Description: This is the package is a metapackage to install all of the test packages
  .
  This package contains tests

--- a/utils/rpms/daos.spec
+++ b/utils/rpms/daos.spec
@@ -14,7 +14,7 @@
 
 Name:          daos
 Version:       1.3.106
-Release:       9%{?relval}%{?dist}
+Release:       10%{?relval}%{?dist}
 Summary:       DAOS Storage Engine
 
 License:       BSD-2-Clause-Patent
@@ -204,8 +204,8 @@ This is the package needed to run a DAOS client
 
 %package tests
 Summary: The entire DAOS test suite
-Requires: %{name}-client-tests-openmpi%{?_isa} = %{version}-%{release}
-Requires: %{name}-server-tests-openmpi%{?_isa} = %{version}-%{release}
+Requires: %{name}-client-tests%{?_isa} = %{version}-%{release}
+Requires: %{name}-server-tests%{?_isa} = %{version}-%{release}
 
 %description tests
 This is the package is a metapackage to install all of the test packages
@@ -516,6 +516,11 @@ getent passwd daos_agent >/dev/null || useradd -s /sbin/nologin -r -g daos_agent
 # No files in a meta-package
 
 %changelog
+* Fri Dec 10 2021 Brian J. Murrell <brian.murrell@intel.com> 1.3.106-10
+- Don't make daos-*-tests-openmi a dependency of anything
+  - If they are wanted, they should be installed explicitly, due to
+    potential conflicts with other MPI stacks
+
 * Wed Dec 08 2021 Alexander Oganezov <alexander.a.oganezov@intel.com> 1.3.106-9
 - Apply OFI patch for DAOS-9173
 


### PR DESCRIPTION
Testing packages.

This allows the daos-*-tests-openmpi packages to be not included in the
distribution, due to MPI stack conflicts on target installations.

daos-*-tests-openmpi will have to be instaled explicitly where it's
desired or needed.

Adjust RPM tests accordingly

Also make respective debian/ changes.