### PR TITLE
DAOS-9195 vos: Prevent multiple range discard on same object

### DIFF
--- a/src/container/srv_container.c
+++ b/src/container/srv_container.c
@@ -1446,6 +1446,17 @@ cont_agg_eph_leader_ult(void *arg)
 					 DP_CONT(svc->cs_pool_uuid,
 						 ec_agg->ea_cont_uuid),
 					DP_RC(rc));
+
+				/* If there are network error or pool map inconsistency,
+				 * let's skip the following eph sync, which will fail
+				 * anyway.
+				 */
+				if (daos_crt_network_error(rc) || rc == -DER_GRPVER) {
+					D_INFO(DF_UUID": skip refresh due to: "DF_RC"\n",
+					       DP_UUID(svc->cs_pool_uuid), DP_RC(rc));
+					break;
+				}
+
 				continue;
 			}
 			ec_agg->ea_current_eph = min_eph;

--- a/src/container/srv_target.c
+++ b/src/container/srv_target.c
@@ -170,23 +170,18 @@ cont_aggregate_runnable(struct ds_cont_child *cont, struct sched_request *req,
 		return false;
 	}
 
-	if (param->ap_vos_agg) {
-		/* Parse aggregation until reintegrating finish, because
-		 * vos_discard may cause issue if reintegration happened
-		 * at the same time.
-		 */
-		if (pool->sp_reintegrating) {
-			cont->sc_vos_agg_active = 0;
-			D_DEBUG(DB_EPC, DF_CONT": skip aggregation during reintegration %d.\n",
-				DP_CONT(cont->sc_pool->spc_uuid, cont->sc_uuid),
-				pool->sp_reintegrating);
-			return false;
-		}
-		if (!cont->sc_vos_agg_active)
-			D_DEBUG(DB_EPC, DF_CONT": resume aggregation after reintegration.\n",
-				DP_CONT(cont->sc_pool->spc_uuid, cont->sc_uuid));
-		cont->sc_vos_agg_active = 1;
+	if (pool->sp_reintegrating) {
+		cont->sc_agg_active = 0;
+		D_DEBUG(DB_EPC, DF_CONT": skip aggregation during reintegration %d.\n",
+			DP_CONT(cont->sc_pool->spc_uuid, cont->sc_uuid),
+			pool->sp_reintegrating);
+		return false;
 	}
+
+	if (!cont->sc_agg_active)
+		D_DEBUG(DB_EPC, DF_CONT": resume aggregation after reintegration.\n",
+			DP_CONT(cont->sc_pool->spc_uuid, cont->sc_uuid));
+	cont->sc_agg_active = 1;
 
 	if (!cont->sc_props_fetched)
 		ds_cont_csummer_init(cont);
@@ -501,7 +496,7 @@ cont_agg_ult(void *arg)
 	param.ap_req = cont->sc_agg_req;
 	param.ap_cont = cont;
 	param.ap_vos_agg = 1;
-	cont->sc_vos_agg_active = 1;
+	cont->sc_agg_active = 1;
 
 	cont_aggregate_interval(cont, cont_vos_aggregate_cb, &param);
 }

--- a/src/container/srv_target.c
+++ b/src/container/srv_target.c
@@ -506,7 +506,6 @@ cont_agg_ult(void *arg)
 	param.ap_req = cont->sc_agg_req;
 	param.ap_cont = cont;
 	param.ap_vos_agg = 1;
-	cont->sc_vos_agg_active = 1;
 
 	cont_aggregate_interval(cont, cont_vos_aggregate_cb, &param);
 }
@@ -519,7 +518,6 @@ cont_ec_agg_ult(void *arg)
 	D_DEBUG(DB_EPC, "start EC aggregation "DF_UUID"\n",
 		DP_UUID(cont->sc_uuid));
 
-	cont->sc_ec_agg_active = 1;
 	ds_obj_ec_aggregate(arg);
 }
 

--- a/src/container/srv_target.c
+++ b/src/container/srv_target.c
@@ -171,17 +171,27 @@ cont_aggregate_runnable(struct ds_cont_child *cont, struct sched_request *req,
 	}
 
 	if (pool->sp_reintegrating) {
-		cont->sc_agg_active = 0;
-		D_DEBUG(DB_EPC, DF_CONT": skip aggregation during reintegration %d.\n",
+		if (param->ap_vos_agg)
+			cont->sc_vos_agg_active = 0;
+		else
+			cont->sc_ec_agg_active = 0;
+		D_DEBUG(DB_EPC, DF_CONT": skip %s aggregation during reintegration %d.\n",
 			DP_CONT(cont->sc_pool->spc_uuid, cont->sc_uuid),
-			pool->sp_reintegrating);
+			param->ap_vos_agg ? "VOS":"EC", pool->sp_reintegrating);
 		return false;
 	}
 
-	if (!cont->sc_agg_active)
-		D_DEBUG(DB_EPC, DF_CONT": resume aggregation after reintegration.\n",
-			DP_CONT(cont->sc_pool->spc_uuid, cont->sc_uuid));
-	cont->sc_agg_active = 1;
+	if (param->ap_vos_agg) {
+		if (!cont->sc_vos_agg_active)
+			D_DEBUG(DB_EPC, DF_CONT": resume VOS aggregation after reintegration.\n",
+				DP_CONT(cont->sc_pool->spc_uuid, cont->sc_uuid));
+		cont->sc_vos_agg_active = 1;
+	} else {
+		if (!cont->sc_ec_agg_active)
+			D_DEBUG(DB_EPC, DF_CONT": resume EC aggregation after reintegration.\n",
+				DP_CONT(cont->sc_pool->spc_uuid, cont->sc_uuid));
+		cont->sc_ec_agg_active = 1;
+	}
 
 	if (!cont->sc_props_fetched)
 		ds_cont_csummer_init(cont);
@@ -496,7 +506,7 @@ cont_agg_ult(void *arg)
 	param.ap_req = cont->sc_agg_req;
 	param.ap_cont = cont;
 	param.ap_vos_agg = 1;
-	cont->sc_agg_active = 1;
+	cont->sc_vos_agg_active = 1;
 
 	cont_aggregate_interval(cont, cont_vos_aggregate_cb, &param);
 }
@@ -509,6 +519,7 @@ cont_ec_agg_ult(void *arg)
 	D_DEBUG(DB_EPC, "start EC aggregation "DF_UUID"\n",
 		DP_UUID(cont->sc_uuid));
 
+	cont->sc_ec_agg_active = 1;
 	ds_obj_ec_aggregate(arg);
 }
 

--- a/src/include/daos_srv/container.h
+++ b/src/include/daos_srv/container.h
@@ -69,7 +69,7 @@ struct ds_cont_child {
 				 sc_closing:1,
 				 sc_props_fetched:1,
 				 sc_stopping:1,
-				 sc_vos_agg_active:1;
+				 sc_agg_active:1;
 	uint32_t		 sc_dtx_batched_gen;
 	/* Tracks the schedule request for aggregation ULT */
 	struct sched_request	*sc_agg_req;

--- a/src/include/daos_srv/container.h
+++ b/src/include/daos_srv/container.h
@@ -69,7 +69,8 @@ struct ds_cont_child {
 				 sc_closing:1,
 				 sc_props_fetched:1,
 				 sc_stopping:1,
-				 sc_agg_active:1;
+				 sc_vos_agg_active:1,
+				 sc_ec_agg_active:1;
 	uint32_t		 sc_dtx_batched_gen;
 	/* Tracks the schedule request for aggregation ULT */
 	struct sched_request	*sc_agg_req;

--- a/src/include/daos_srv/daos_engine.h
+++ b/src/include/daos_srv/daos_engine.h
@@ -851,10 +851,7 @@ ds_object_migrate(struct ds_pool *pool, uuid_t pool_hdl_uuid, uuid_t cont_uuid,
 		  daos_epoch_t *punched_ephs, unsigned int *shards, int cnt,
 		  unsigned int migrate_opc);
 void
-ds_migrate_fini_one(uuid_t pool_uuid, uint32_t ver);
-
-void
-ds_migrate_abort(uuid_t pool_uuid, uint32_t ver);
+ds_migrate_stop(struct ds_pool *pool, uint32_t ver);
 
 /** Server init state (see server_init) */
 enum dss_init_state {

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -2340,7 +2340,8 @@ ds_obj_tgt_update_handler(crt_rpc_t *rpc)
 			  (orw->orw_bulks.ca_arrays != NULL ||
 			   orw->orw_bulks.ca_count != 0) ? true : false);
 	if (rc != 0)
-		D_CDEBUG(rc == -DER_INPROGRESS || rc == -DER_TX_RESTART, DB_IO, DLOG_ERR,
+		D_CDEBUG(rc == -DER_EXIST || rc == -DER_NONEXIST || rc == -DER_INPROGRESS ||
+			 rc == -DER_TX_RESTART, DB_IO, DLOG_ERR,
 			 DF_UOID": error="DF_RC".\n", DP_UOID(orw->orw_oid), DP_RC(rc));
 
 out:
@@ -3289,7 +3290,7 @@ ds_obj_tgt_punch_handler(crt_rpc_t *rpc)
 	/* non-leader local RPC handler, do not need pin the DTX entry.  */
 	rc = obj_local_punch(opi, opc_get(rpc->cr_opc), &ioc, dth, false);
 	if (rc != 0)
-		D_CDEBUG(rc == -DER_INPROGRESS || rc == -DER_TX_RESTART,
+		D_CDEBUG(rc == -DER_NONEXIST || rc == -DER_INPROGRESS || rc == -DER_TX_RESTART,
 			 DB_IO, DLOG_ERR,
 			 DF_UOID": error="DF_RC".\n", DP_UOID(opi->opi_oid),
 			 DP_RC(rc));

--- a/src/object/srv_obj_migrate.c
+++ b/src/object/srv_obj_migrate.c
@@ -476,6 +476,9 @@ migrate_pool_tls_lookup_create(struct ds_pool *pool, int version,
 
 	tls = migrate_pool_tls_lookup(pool->sp_uuid, version);
 	D_ASSERT(tls != NULL);
+	if (opc == RB_OP_REINT)
+		pool->sp_reintegrating++;
+
 out:
 	D_DEBUG(DB_TRACE, "create tls "DF_UUID": "DF_RC"\n",
 		DP_UUID(pool->sp_uuid), DP_RC(rc));
@@ -2553,14 +2556,20 @@ out:
 	return rc;
 }
 
-void
-ds_migrate_fini_one(uuid_t pool_uuid, uint32_t ver)
+struct migrate_stop_arg {
+	uuid_t	pool_uuid;
+	uint32_t version;
+};
+
+static int
+migrate_fini_one_ult(void *data)
 {
+	struct migrate_stop_arg *arg = data;
 	struct migrate_pool_tls *tls;
 
-	tls = migrate_pool_tls_lookup(pool_uuid, ver);
+	tls = migrate_pool_tls_lookup(arg->pool_uuid, arg->version);
 	if (tls == NULL)
-		return;
+		return 0;
 
 	tls->mpt_fini = 1;
 
@@ -2573,43 +2582,33 @@ ds_migrate_fini_one(uuid_t pool_uuid, uint32_t ver)
 
 	migrate_pool_tls_put(tls); /* destroy */
 
-	D_DEBUG(DB_TRACE, "migrate fini one ult "DF_UUID"\n", pool_uuid);
-}
-
-struct migrate_abort_arg {
-	uuid_t	pool_uuid;
-	uint32_t version;
-};
-
-int
-migrate_fini_one_ult(void *data)
-{
-	struct migrate_abort_arg *arg = data;
-
-	ds_migrate_fini_one(arg->pool_uuid, arg->version);
-
+	D_INFO("migrate fini one ult "DF_UUID"\n", arg->pool_uuid);
 	return 0;
 }
 
-/* Abort the migration */
+/* stop the migration */
 void
-ds_migrate_abort(uuid_t pool_uuid, unsigned int version)
+ds_migrate_stop(struct ds_pool *pool, unsigned int version)
 {
 	struct migrate_pool_tls *tls;
-	struct migrate_abort_arg arg;
+	struct migrate_stop_arg arg;
 	int			 rc;
 
-	tls = migrate_pool_tls_lookup(pool_uuid, version);
+	tls = migrate_pool_tls_lookup(pool->sp_uuid, version);
 	if (tls == NULL)
 		return;
 
-	uuid_copy(arg.pool_uuid, pool_uuid);
+	uuid_copy(arg.pool_uuid, pool->sp_uuid);
 	arg.version = version;
 	rc = dss_thread_collective(migrate_fini_one_ult, &arg, 0);
 	if (rc)
-		D_ERROR("migrate abort: %d\n", rc);
+		D_ERROR(DF_UUID" migrate stop: %d\n", DP_UUID(pool->sp_uuid), rc);
 
+	if (tls->mpt_opc == RB_OP_REINT)
+		pool->sp_reintegrating--;
 	migrate_pool_tls_put(tls);
+	migrate_pool_tls_put(tls);
+	D_INFO(DF_UUID" migrate stopped\n", DP_UUID(pool->sp_uuid));
 }
 
 static int

--- a/src/object/srv_obj_migrate.c
+++ b/src/object/srv_obj_migrate.c
@@ -2582,7 +2582,7 @@ migrate_fini_one_ult(void *data)
 
 	migrate_pool_tls_put(tls); /* destroy */
 
-	D_INFO("migrate fini one ult "DF_UUID"\n", arg->pool_uuid);
+	D_INFO("migrate fini one ult "DF_UUID"\n", DP_UUID(arg->pool_uuid));
 	return 0;
 }
 

--- a/src/object/srv_obj_migrate.c
+++ b/src/object/srv_obj_migrate.c
@@ -2641,7 +2641,8 @@ destroy_existing_obj(struct migrate_pool_tls *tls, unsigned int tgt_idx,
 	}
 
 	/* Wait until container aggregation are stopped */
-	while (cont->sc_agg_active && !tls->mpt_fini && !cont->sc_stopping) {
+	while (cont->sc_ec_agg_active && cont->sc_vos_agg_active &&
+	       !tls->mpt_fini && !cont->sc_stopping) {
 		D_DEBUG(DB_REBUILD, "wait for "DF_UUID"/"DF_UUID"/%u vos aggregation"
 			" to be inactive\n", DP_UUID(tls->mpt_pool_uuid),
 			DP_UUID(cont_uuid), tls->mpt_version);

--- a/src/object/srv_obj_migrate.c
+++ b/src/object/srv_obj_migrate.c
@@ -2641,7 +2641,7 @@ destroy_existing_obj(struct migrate_pool_tls *tls, unsigned int tgt_idx,
 	}
 
 	/* Wait until container aggregation are stopped */
-	while (cont->sc_ec_agg_active && cont->sc_vos_agg_active &&
+	while ((cont->sc_ec_agg_active || cont->sc_vos_agg_active) &&
 	       !tls->mpt_fini && !cont->sc_stopping) {
 		D_DEBUG(DB_REBUILD, "wait for "DF_UUID"/"DF_UUID"/%u vos aggregation"
 			" to be inactive\n", DP_UUID(tls->mpt_pool_uuid),

--- a/src/object/srv_obj_migrate.c
+++ b/src/object/srv_obj_migrate.c
@@ -2641,7 +2641,7 @@ destroy_existing_obj(struct migrate_pool_tls *tls, unsigned int tgt_idx,
 	}
 
 	/* Wait until container aggregation are stopped */
-	while (cont->sc_vos_agg_active && !tls->mpt_fini && !cont->sc_stopping) {
+	while (cont->sc_agg_active && !tls->mpt_fini && !cont->sc_stopping) {
 		D_DEBUG(DB_REBUILD, "wait for "DF_UUID"/"DF_UUID"/%u vos aggregation"
 			" to be inactive\n", DP_UUID(tls->mpt_pool_uuid),
 			DP_UUID(cont_uuid), tls->mpt_version);

--- a/src/pool/srv_target.c
+++ b/src/pool/srv_target.c
@@ -723,7 +723,7 @@ ds_pool_stop(uuid_t uuid)
 	pool_fetch_hdls_ult_abort(pool);
 
 	ds_rebuild_abort(pool->sp_uuid, -1);
-	ds_migrate_abort(pool->sp_uuid, -1);
+	ds_migrate_stop(pool, -1);
 	ds_pool_put(pool); /* held by ds_pool_start */
 	ds_pool_put(pool);
 	D_INFO(DF_UUID": pool service is aborted\n", DP_UUID(uuid));

--- a/src/rebuild/srv.c
+++ b/src/rebuild/srv.c
@@ -611,11 +611,11 @@ rebuild_leader_status_check(struct ds_pool *pool, uint32_t map_ver, uint32_t op,
 		snprintf(sbuf, RBLD_SBUF_LEN,
 			 "%s [%s] (pool "DF_UUID" ver=%u, toberb_obj="
 			 DF_U64", rb_obj="DF_U64", rec="DF_U64", size="DF_U64
-			 " done %d status %d/%d duration=%d secs)\n",
+			 " done %d status %d/%d epoch "DF_U64" duration=%d secs)\n",
 			 RB_OP_STR(op), str, DP_UUID(pool->sp_uuid), map_ver,
 			 rs->rs_toberb_obj_nr, rs->rs_obj_nr, rs->rs_rec_nr,
 			 rs->rs_size, rs->rs_done, rs->rs_errno,
-			 rs->rs_fail_rank, rs->rs_seconds);
+			 rs->rs_fail_rank, rgt->rgt_stable_epoch, rs->rs_seconds);
 
 		D_INFO("%s", sbuf);
 		if (rs->rs_done || rebuild_gst.rg_abort || rgt->rgt_abort) {
@@ -1780,7 +1780,6 @@ rebuild_fini_one(void *arg)
 		return 0;
 
 	rebuild_pool_tls_destroy(pool_tls);
-	ds_migrate_fini_one(rpt->rt_pool_uuid, rpt->rt_rebuild_ver);
 	/* close the opened local ds_cont on main XS */
 	D_ASSERT(dss_get_module_info()->dmi_xs_id != 0);
 
@@ -1848,7 +1847,7 @@ rebuild_tgt_fini(struct rebuild_tgt_pool_tracker *rpt)
 	rc = dss_task_collective(rebuild_fini_one, rpt, 0);
 
 	/* destroy the migrate_tls of 0-xstream */
-	ds_migrate_fini_one(rpt->rt_pool_uuid, rpt->rt_rebuild_ver);
+	ds_migrate_stop(rpt->rt_pool, rpt->rt_rebuild_ver);
 	rpt_put(rpt);
 	/* No one should access rpt after rebuild_fini_one.
 	 */

--- a/src/vos/evtree.c
+++ b/src/vos/evtree.c
@@ -2787,7 +2787,7 @@ evt_has_data(struct evt_root *root, struct umem_attr *uma)
 	rc = 0; /* Assume there is no data */
 	evt_ent_array_for_each(ent, tcx->tc_iter.it_entries) {
 		if (ent->en_minor_epc != EVT_MINOR_EPC_MAX) {
-			D_DEBUG(DB_IO, "Found "DF_ENT", stopping search\n", DP_ENT(ent));
+			D_INFO("Found orphaned extent "DF_ENT"\n", DP_ENT(ent));
 			rc = 1;
 			break;
 		}

--- a/src/vos/vos_obj.h
+++ b/src/vos/vos_obj.h
@@ -49,6 +49,8 @@ struct vos_object {
 	struct vos_container		*obj_cont;
 	/** nobody should access this object */
 	bool				obj_zombie;
+	/** Object is in discard */
+	bool				obj_discard;
 };
 
 enum {
@@ -56,6 +58,8 @@ enum {
 	VOS_OBJ_VISIBLE		= (1 << 0),
 	/** Create the object if it doesn't exist */
 	VOS_OBJ_CREATE		= (1 << 1),
+	/** Hold for object specific discard */
+	VOS_OBJ_DISCARD		= (1 << 2),
 };
 
 /**
@@ -207,5 +211,29 @@ vos_oi_punch(struct vos_container *cont, daos_unit_oid_t oid,
 /** delete an object from OI table */
 int
 vos_oi_delete(struct vos_container *cont, daos_unit_oid_t oid);
+
+/** Hold object for range discard
+ *
+ * \param[in]	occ	Object cache, can be per cpu
+ * \param[in]	cont	Open container
+ * \param[in]	oid	The object id
+ * \param[out]	objp	Returned object
+ *
+ * \return	-DER_NONEXIST	object doesn't exist
+ *		-DER_BUSY	Object is already in discard
+ *		-DER_AGAIN	Object is being destroyed
+ *		0		Success
+ */
+int
+vos_obj_discard_hold(struct daos_lru_cache *occ, struct vos_container *cont, daos_unit_oid_t oid,
+		     struct vos_object **objp);
+
+/** Release object held for range discard
+ *
+ * \param[in]	occ	Object cache, can be per cpu
+ * \param[in]	obj	Object to release
+ */
+void
+vos_obj_discard_release(struct daos_lru_cache *occ, struct vos_object *obj);
 
 #endif


### PR DESCRIPTION
* Assert if vos_obj_hold is done for write while vos_discard
  is in progress
* Add some debug
* Fix issue where ec aggregation could race with discard

Co-authored-by: Di Wang <di.wang@intel.com>
Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>