### PR TITLE
DAOS-9232 test: sleep between system start and pool query

### DIFF
--- a/src/tests/ftest/aggregation/shutdown_restart.py
+++ b/src/tests/ftest/aggregation/shutdown_restart.py
@@ -82,6 +82,8 @@ class IoAggregation(IorTestBase):
             self.fail("One or more servers crashed")
 
         # Now check if the space is returned back.
+        # FIXME? slight delay after system start before pool query for free space?
+        self.log.info("No delay after system start/query and before pool query")
         counter = 1
         returned_space = (self.get_nvme_free_space() -
                           free_space_before_snap_destroy)


### PR DESCRIPTION
Before this change, the aggregation/shutdown_restart.py test procedure
included system stop, sleep, system start, system query, pool query.
In some test failures, the pool query was shown to time out in the
client log, and in the (restarted) engine log there was no evidence of
receiving the pool query RPC.

With this change, add a very short sleep to allow enough time for the
engine to come up and be ready to process cart RPCs on its system XS.

Quick-Functional: true
Skip-coverity-test: true
Skip-func-test-vm: true
Skip-func-hw-test-small: false
Skip-func-hw-test-medium: true
Skip-func-hw-test-large: true
Skip-scan-centos-rpms: true
Skip-scan-leap15-rpms: true
Skip-test-centos-rpms: true
Skip-test-centos-8.3-rpms: true
Skip-test-leap-15-rpms: true
Allow-unstable-test: true
Skip-PR-comments: true

Test-tag: io_aggregation
Test-repeat: 20

Signed-off-by: Kenneth Cain <kenneth.c.cain@intel.com>