### PR TITLE
DAOS-9195 container: disable EC aggregation during reintegration.

### DIFF
--- a/src/include/daos_srv/container.h
+++ b/src/include/daos_srv/container.h
@@ -69,7 +69,7 @@ struct ds_cont_child {
 				 sc_closing:1,
 				 sc_props_fetched:1,
 				 sc_stopping:1,
-				 sc_vos_agg_active:1;
+				 sc_agg_active:1;
 	uint32_t		 sc_dtx_batched_gen;
 	/* Tracks the schedule request for aggregation ULT */
 	struct sched_request	*sc_agg_req;

--- a/src/object/srv_obj_migrate.c
+++ b/src/object/srv_obj_migrate.c
@@ -2642,7 +2642,7 @@ destroy_existing_obj(struct migrate_pool_tls *tls, unsigned int tgt_idx,
 	}
 
 	/* Wait until container aggregation are stopped */
-	while (cont->sc_vos_agg_active && !tls->mpt_fini && !cont->sc_stopping) {
+	while (cont->sc_agg_active && !tls->mpt_fini && !cont->sc_stopping) {
 		D_DEBUG(DB_REBUILD, "wait for "DF_UUID"/"DF_UUID"/%u vos aggregation"
 			" to be inactive\n", DP_UUID(tls->mpt_pool_uuid),
 			DP_UUID(cont_uuid), tls->mpt_version);


### PR DESCRIPTION
Let's disable both VOS aggregation and EC aggregation, since
both of them might do discard.

Signed-off-by: Di Wang <di.wang@intel.com>