### PR TITLE
DAOS-9195 container: disable EC aggregation during reintegration.

### DIFF
--- a/src/container/srv_container.c
+++ b/src/container/srv_container.c
@@ -1446,6 +1446,17 @@ cont_agg_eph_leader_ult(void *arg)
 					 DP_CONT(svc->cs_pool_uuid,
 						 ec_agg->ea_cont_uuid),
 					DP_RC(rc));
+
+				/* If there are network error or pool map inconsistency,
+				 * let's skip the following eph sync, which will fail
+				 * anyway.
+				 */
+				if (daos_crt_network_error(rc) || rc == -DER_GRPVER) {
+					D_INFO(DF_UUID": skip refresh due to: "DF_RC"\n",
+					       DP_UUID(svc->cs_pool_uuid), DP_RC(rc));
+					break;
+				}
+
 				continue;
 			}
 			ec_agg->ea_current_eph = min_eph;

--- a/src/container/srv_target.c
+++ b/src/container/srv_target.c
@@ -170,23 +170,18 @@ cont_aggregate_runnable(struct ds_cont_child *cont, struct sched_request *req,
 		return false;
 	}
 
-	if (param->ap_vos_agg) {
-		/* Parse aggregation until reintegrating finish, because
-		 * vos_discard may cause issue if reintegration happened
-		 * at the same time.
-		 */
-		if (pool->sp_reintegrating) {
-			cont->sc_vos_agg_active = 0;
-			D_DEBUG(DB_EPC, DF_CONT": skip aggregation during reintegration %d.\n",
-				DP_CONT(cont->sc_pool->spc_uuid, cont->sc_uuid),
-				pool->sp_reintegrating);
-			return false;
-		}
-		if (!cont->sc_vos_agg_active)
-			D_DEBUG(DB_EPC, DF_CONT": resume aggregation after reintegration.\n",
-				DP_CONT(cont->sc_pool->spc_uuid, cont->sc_uuid));
-		cont->sc_vos_agg_active = 1;
+	if (pool->sp_reintegrating) {
+		cont->sc_agg_active = 0;
+		D_DEBUG(DB_EPC, DF_CONT": skip aggregation during reintegration %d.\n",
+			DP_CONT(cont->sc_pool->spc_uuid, cont->sc_uuid),
+			pool->sp_reintegrating);
+		return false;
 	}
+
+	if (!cont->sc_agg_active)
+		D_DEBUG(DB_EPC, DF_CONT": resume aggregation after reintegration.\n",
+			DP_CONT(cont->sc_pool->spc_uuid, cont->sc_uuid));
+	cont->sc_agg_active = 1;
 
 	if (!cont->sc_props_fetched)
 		ds_cont_csummer_init(cont);
@@ -501,7 +496,7 @@ cont_agg_ult(void *arg)
 	param.ap_req = cont->sc_agg_req;
 	param.ap_cont = cont;
 	param.ap_vos_agg = 1;
-	cont->sc_vos_agg_active = 1;
+	cont->sc_agg_active = 1;
 
 	cont_aggregate_interval(cont, cont_vos_aggregate_cb, &param);
 }

--- a/src/include/daos_srv/container.h
+++ b/src/include/daos_srv/container.h
@@ -69,7 +69,7 @@ struct ds_cont_child {
 				 sc_closing:1,
 				 sc_props_fetched:1,
 				 sc_stopping:1,
-				 sc_vos_agg_active:1;
+				 sc_agg_active:1;
 	uint32_t		 sc_dtx_batched_gen;
 	/* Tracks the schedule request for aggregation ULT */
 	struct sched_request	*sc_agg_req;

--- a/src/include/daos_srv/daos_engine.h
+++ b/src/include/daos_srv/daos_engine.h
@@ -851,10 +851,7 @@ ds_object_migrate(struct ds_pool *pool, uuid_t pool_hdl_uuid, uuid_t cont_uuid,
 		  daos_epoch_t *punched_ephs, unsigned int *shards, int cnt,
 		  unsigned int migrate_opc);
 void
-ds_migrate_fini_one(uuid_t pool_uuid, uint32_t ver);
-
-void
-ds_migrate_abort(uuid_t pool_uuid, uint32_t ver);
+ds_migrate_stop(struct ds_pool *pool, uint32_t ver);
 
 /** Server init state (see server_init) */
 enum dss_init_state {

--- a/src/object/srv_obj_migrate.c
+++ b/src/object/srv_obj_migrate.c
@@ -476,6 +476,9 @@ migrate_pool_tls_lookup_create(struct ds_pool *pool, int version,
 
 	tls = migrate_pool_tls_lookup(pool->sp_uuid, version);
 	D_ASSERT(tls != NULL);
+	if (opc == RB_OP_REINT)
+		pool->sp_reintegrating++;
+
 out:
 	D_DEBUG(DB_TRACE, "create tls "DF_UUID": "DF_RC"\n",
 		DP_UUID(pool->sp_uuid), DP_RC(rc));
@@ -2553,14 +2556,20 @@ out:
 	return rc;
 }
 
-void
-ds_migrate_fini_one(uuid_t pool_uuid, uint32_t ver)
+struct migrate_stop_arg {
+	uuid_t	pool_uuid;
+	uint32_t version;
+};
+
+static int
+migrate_fini_one_ult(void *data)
 {
+	struct migrate_stop_arg *arg = data;
 	struct migrate_pool_tls *tls;
 
-	tls = migrate_pool_tls_lookup(pool_uuid, ver);
+	tls = migrate_pool_tls_lookup(arg->pool_uuid, arg->version);
 	if (tls == NULL)
-		return;
+		return 0;
 
 	tls->mpt_fini = 1;
 
@@ -2573,43 +2582,33 @@ ds_migrate_fini_one(uuid_t pool_uuid, uint32_t ver)
 
 	migrate_pool_tls_put(tls); /* destroy */
 
-	D_DEBUG(DB_TRACE, "migrate fini one ult "DF_UUID"\n", pool_uuid);
-}
-
-struct migrate_abort_arg {
-	uuid_t	pool_uuid;
-	uint32_t version;
-};
-
-int
-migrate_fini_one_ult(void *data)
-{
-	struct migrate_abort_arg *arg = data;
-
-	ds_migrate_fini_one(arg->pool_uuid, arg->version);
-
+	D_INFO("migrate fini one ult "DF_UUID"\n", DP_UUID(arg->pool_uuid));
 	return 0;
 }
 
-/* Abort the migration */
+/* stop the migration */
 void
-ds_migrate_abort(uuid_t pool_uuid, unsigned int version)
+ds_migrate_stop(struct ds_pool *pool, unsigned int version)
 {
 	struct migrate_pool_tls *tls;
-	struct migrate_abort_arg arg;
+	struct migrate_stop_arg arg;
 	int			 rc;
 
-	tls = migrate_pool_tls_lookup(pool_uuid, version);
+	tls = migrate_pool_tls_lookup(pool->sp_uuid, version);
 	if (tls == NULL)
 		return;
 
-	uuid_copy(arg.pool_uuid, pool_uuid);
+	uuid_copy(arg.pool_uuid, pool->sp_uuid);
 	arg.version = version;
 	rc = dss_thread_collective(migrate_fini_one_ult, &arg, 0);
 	if (rc)
-		D_ERROR("migrate abort: %d\n", rc);
+		D_ERROR(DF_UUID" migrate stop: %d\n", DP_UUID(pool->sp_uuid), rc);
 
+	if (tls->mpt_opc == RB_OP_REINT)
+		pool->sp_reintegrating--;
 	migrate_pool_tls_put(tls);
+	migrate_pool_tls_put(tls);
+	D_INFO(DF_UUID" migrate stopped\n", DP_UUID(pool->sp_uuid));
 }
 
 static int
@@ -2642,7 +2641,7 @@ destroy_existing_obj(struct migrate_pool_tls *tls, unsigned int tgt_idx,
 	}
 
 	/* Wait until container aggregation are stopped */
-	while (cont->sc_vos_agg_active && !tls->mpt_fini && !cont->sc_stopping) {
+	while (cont->sc_agg_active && !tls->mpt_fini && !cont->sc_stopping) {
 		D_DEBUG(DB_REBUILD, "wait for "DF_UUID"/"DF_UUID"/%u vos aggregation"
 			" to be inactive\n", DP_UUID(tls->mpt_pool_uuid),
 			DP_UUID(cont_uuid), tls->mpt_version);

--- a/src/pool/srv_target.c
+++ b/src/pool/srv_target.c
@@ -723,7 +723,7 @@ ds_pool_stop(uuid_t uuid)
 	pool_fetch_hdls_ult_abort(pool);
 
 	ds_rebuild_abort(pool->sp_uuid, -1);
-	ds_migrate_abort(pool->sp_uuid, -1);
+	ds_migrate_stop(pool, -1);
 	ds_pool_put(pool); /* held by ds_pool_start */
 	ds_pool_put(pool);
 	D_INFO(DF_UUID": pool service is aborted\n", DP_UUID(uuid));

--- a/src/rebuild/scan.c
+++ b/src/rebuild/scan.c
@@ -954,9 +954,6 @@ rebuild_tgt_scan_handler(crt_rpc_t *rpc)
 		D_GOTO(out, rc);
 	}
 
-	if (rpt->rt_rebuild_op == RB_OP_REINT)
-		rpt->rt_pool->sp_reintegrating++; /* reset in rebuild_tgt_fini */
-
 	rpt_get(rpt);
 	/* step-3: start scan leader */
 	rc = dss_ult_create(rebuild_scan_leader, rpt, DSS_XS_SELF, 0, 0, NULL);


### PR DESCRIPTION
Disable both VOS aggregation and EC aggregation(discard parity),
since both of them might do discard.

Move sp_reintegrating check to reintegration node where
vos_discard happens.

merge ds_migrate_abort and ds_migrate_fini.

Signed-off-by: Di Wang <di.wang@intel.com>