### PR TITLE
DAOS-9193 dtx: keep DTX handle until IO forward ULT exited

### DIFF
--- a/src/dtx/dtx_common.c
+++ b/src/dtx/dtx_common.c
@@ -1679,6 +1679,9 @@ dtx_sub_comp_cb(struct dtx_leader_handle *dlh, int idx, int rc)
 	struct dtx_sub_status	*sub = &dlh->dlh_subs[idx];
 	ABT_future		future = dlh->dlh_future;
 
+	D_ASSERTF(sub->dss_comp == 0, "Repeat sub completion for idx %d: %d\n", idx, rc);
+	sub->dss_comp = 1;
+
 	sub->dss_result = rc;
 	rc = ABT_future_set(future, dlh);
 	D_ASSERTF(rc == ABT_SUCCESS, "ABT_future_set failed %d.\n", rc);
@@ -1697,32 +1700,30 @@ struct dtx_ult_arg {
 static void
 dtx_leader_exec_ops_ult(void *arg)
 {
-	struct dtx_ult_arg	  *ult_arg = arg;
-	struct dtx_leader_handle  *dlh = ult_arg->dlh;
-	ABT_future		  future = dlh->dlh_future;
-	uint32_t		  i;
-	int			  rc = 0;
+	struct dtx_ult_arg		*ult_arg = arg;
+	struct dtx_leader_handle	*dlh = ult_arg->dlh;
+	struct dtx_sub_status		*sub;
+	ABT_future			 future = dlh->dlh_future;
+	uint32_t			 i;
+	int				 rc = 0;
 
 	D_ASSERT(future != ABT_FUTURE_NULL);
 	for (i = 0; i < dlh->dlh_sub_cnt; i++) {
-		struct dtx_sub_status *sub = &dlh->dlh_subs[i];
-
+		sub = &dlh->dlh_subs[i];
 		sub->dss_result = 0;
+		sub->dss_comp = 0;
 
 		if (sub->dss_tgt.st_rank == DAOS_TGT_IGNORE ||
 		    (i == daos_fail_value_get() &&
 		     DAOS_FAIL_CHECK(DAOS_DTX_SKIP_PREPARE))) {
-			int ret;
-
-			ret = ABT_future_set(future, dlh);
-			D_ASSERTF(ret == ABT_SUCCESS,
-				  "ABT_future_set failed %d.\n", ret);
+			dtx_sub_comp_cb(dlh, i, 0);
 			continue;
 		}
 
 		rc = ult_arg->func(dlh, ult_arg->func_arg, i, dtx_sub_comp_cb);
-		if (rc) {
-			sub->dss_result = rc;
+		if (rc != 0) {
+			if (sub->dss_comp == 0)
+				dtx_sub_comp_cb(dlh, i, rc);
 			break;
 		}
 
@@ -1732,14 +1733,13 @@ dtx_leader_exec_ops_ult(void *arg)
 	}
 
 	if (rc != 0) {
-		for (i++; i < dlh->dlh_sub_cnt; i++) {
-			int ret;
-
-			ret = ABT_future_set(future, dlh);
-			D_ASSERTF(ret == ABT_SUCCESS,
-				  "ABT_future_set failed %d.\n", ret);
-		}
+		for (i++; i < dlh->dlh_sub_cnt; i++)
+			dtx_sub_comp_cb(dlh, i, 0);
 	}
+
+	/* To indicate that the IO forward ULT itself has done. */
+	rc = ABT_future_set(future, dlh);
+	D_ASSERTF(rc == ABT_SUCCESS, "ABT_future_set failed (3) %d.\n", rc);
 
 	D_FREE(ult_arg);
 }
@@ -1766,9 +1766,12 @@ dtx_leader_exec_ops(struct dtx_leader_handle *dlh, dtx_sub_func_t func,
 	dlh->dlh_agg_cb = agg_cb;
 	dlh->dlh_agg_cb_arg = agg_cb_arg;
 
-	/* the future should already be freed */
 	D_ASSERT(dlh->dlh_future == ABT_FUTURE_NULL);
-	rc = ABT_future_create(dlh->dlh_sub_cnt, dtx_comp_cb, &dlh->dlh_future);
+
+	/* Create the future with sub_cnt + 1, the additional one is used by the IO forward
+	 * ULT itself to prevent the DTX handle being freed before the IO forward ULT exit.
+	 */
+	rc = ABT_future_create(dlh->dlh_sub_cnt + 1, dtx_comp_cb, &dlh->dlh_future);
 	if (rc != ABT_SUCCESS) {
 		D_ERROR("ABT_future_create failed %d.\n", rc);
 		D_FREE_PTR(ult_arg);

--- a/src/dtx/dtx_rpc.c
+++ b/src/dtx/dtx_rpc.c
@@ -79,6 +79,7 @@ struct dtx_req_rec {
 	uint32_t			 drr_tag; /* The VOS ID */
 	int				 drr_count; /* DTX count */
 	int				 drr_result; /* The RPC result */
+	uint32_t			 drr_comp:1;
 	struct dtx_id			*drr_dti; /* The DTX array */
 	struct dtx_share_peer		**drr_cb_args; /* Used by dtx_req_cb. */
 };
@@ -118,6 +119,8 @@ dtx_req_cb(const struct crt_cb_info *cb_info)
 	struct dtx_out		*dout;
 	int			 rc = cb_info->cci_rc;
 	int			 i;
+
+	D_ASSERT(drr->drr_comp == 0);
 
 	if (rc != 0)
 		goto out;
@@ -206,6 +209,7 @@ dtx_req_cb(const struct crt_cb_info *cb_info)
 	}
 
 out:
+	drr->drr_comp = 1;
 	drr->drr_result = rc;
 	rc = ABT_future_set(dra->dra_future, drr);
 	D_ASSERTF(rc == ABT_SUCCESS,
@@ -251,7 +255,8 @@ dtx_req_send(struct dtx_req_rec *drr, daos_epoch_t epoch)
 		drr->drr_tag, req, dra->dra_future,
 		din != NULL ? din->di_epoch : 0, rc);
 
-	if (rc != 0) {
+	if (rc != 0 && drr->drr_comp == 0) {
+		drr->drr_comp = 1;
 		drr->drr_result = rc;
 		ABT_future_set(dra->dra_future, drr);
 	}
@@ -420,6 +425,7 @@ dtx_cf_rec_alloc(struct btr_instance *tins, d_iov_t *key_iov,
 	drr->drr_rank = dcrb->dcrb_rank;
 	drr->drr_tag = dcrb->dcrb_tag;
 	drr->drr_count = 1;
+	drr->drr_comp = 0;
 	drr->drr_dti[0] = *dcrb->dcrb_dti;
 	d_list_add_tail(&drr->drr_link, dcrb->dcrb_head);
 	++(*dcrb->dcrb_length);

--- a/src/include/daos_srv/dtx_srv.h
+++ b/src/include/daos_srv/dtx_srv.h
@@ -130,6 +130,7 @@ struct dtx_handle {
 struct dtx_sub_status {
 	struct daos_shard_tgt		dss_tgt;
 	int				dss_result;
+	uint32_t			dss_comp:1;
 };
 
 struct dtx_leader_handle;

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -4362,12 +4362,8 @@ obj_obj_dtx_leader(struct dtx_leader_handle *dlh, void *arg, int idx,
 			 */
 			if (dcde->dcde_write_cnt != 0) {
 				rc = obj_capa_check(ioc->ioc_coh, true, false);
-				if (rc != 0) {
-					if (comp_cb != NULL)
-						comp_cb(dlh, idx, rc);
-
-					return rc;
-				}
+				if (rc != 0)
+					goto comp;
 			}
 
 			dcsh = ds_obj_cpd_get_dcsh(dca->dca_rpc, dca->dca_idx);
@@ -4384,6 +4380,7 @@ obj_obj_dtx_leader(struct dtx_leader_handle *dlh, void *arg, int idx,
 						    &dlh->dlh_handle, pin);
 		}
 
+comp:
 		if (comp_cb != NULL)
 			comp_cb(dlh, idx, rc);
 

--- a/src/object/srv_obj_remote.c
+++ b/src/object/srv_obj_remote.c
@@ -37,15 +37,12 @@ struct obj_remote_cb_arg {
 };
 
 static void
-shard_update_req_cb(const struct crt_cb_info *cb_info)
+do_shard_update_req_cb(crt_rpc_t *req, struct obj_remote_cb_arg *arg, int rc)
 {
-	crt_rpc_t			*req = cb_info->cci_rpc;
-	struct obj_remote_cb_arg	*arg = cb_info->cci_arg;
 	crt_rpc_t			*parent_req = arg->parent_req;
 	struct obj_rw_out		*orwo = crt_reply_get(req);
 	struct obj_rw_in		*orw_parent = crt_req_get(parent_req);
 	struct dtx_leader_handle	*dlh = arg->dlh;
-	int				rc = cb_info->cci_rc;
 	int				rc1 = 0;
 
 	if (orw_parent->orw_map_ver < orwo->orw_map_version) {
@@ -60,11 +57,15 @@ shard_update_req_cb(const struct crt_cb_info *cb_info)
 	if (rc >= 0)
 		rc = rc1;
 
-	if (arg->comp_cb)
-		arg->comp_cb(dlh, arg->idx, rc);
-
+	arg->comp_cb(dlh, arg->idx, rc);
 	crt_req_decref(parent_req);
 	D_FREE(arg);
+}
+
+static inline void
+shard_update_req_cb(const struct crt_cb_info *cb_info)
+{
+	do_shard_update_req_cb(cb_info->cci_rpc, cb_info->cci_arg, cb_info->cci_rc);
 }
 
 /* Execute update on the remote target */
@@ -145,15 +146,16 @@ ds_obj_remote_update(struct dtx_leader_handle *dlh, void *data, int idx,
 	D_DEBUG(DB_TRACE, DF_UOID" forwarding to rank:%d tag:%d.\n",
 		DP_UOID(orw->orw_oid), tgt_ep.ep_rank, tgt_ep.ep_tag);
 	rc = crt_req_send(req, shard_update_req_cb, remote_arg);
-	if (rc != 0)
+	if (rc != 0) {
+		D_ASSERT(sub->dss_comp == 1);
 		D_ERROR("crt_req_send failed, rc "DF_RC"\n", DP_RC(rc));
+	}
 	return rc;
 
 out:
 	if (rc) {
 		sub->dss_result = rc;
-		if (comp_cb)
-			comp_cb(dlh, idx, rc);
+		comp_cb(dlh, idx, rc);
 		if (remote_arg) {
 			crt_req_decref(parent_req);
 			D_FREE(remote_arg);
@@ -163,15 +165,12 @@ out:
 }
 
 static void
-shard_punch_req_cb(const struct crt_cb_info *cb_info)
+do_shard_punch_req_cb(crt_rpc_t *req, struct obj_remote_cb_arg *arg, int rc)
 {
-	crt_rpc_t			*req = cb_info->cci_rpc;
-	struct obj_remote_cb_arg	*arg = cb_info->cci_arg;
 	crt_rpc_t			*parent_req = arg->parent_req;
 	struct obj_punch_out		*opo = crt_reply_get(req);
 	struct obj_punch_in		*opi_parent = crt_req_get(req);
 	struct dtx_leader_handle	*dlh = arg->dlh;
-	int				rc = cb_info->cci_rc;
 	int				rc1 = 0;
 
 	if (opi_parent->opi_map_ver < opo->opo_map_version) {
@@ -186,11 +185,15 @@ shard_punch_req_cb(const struct crt_cb_info *cb_info)
 	if (rc >= 0)
 		rc = rc1;
 
-	if (arg->comp_cb)
-		arg->comp_cb(dlh, arg->idx, rc);
-
+	arg->comp_cb(dlh, arg->idx, rc);
 	crt_req_decref(parent_req);
 	D_FREE(arg);
+}
+
+static inline void
+shard_punch_req_cb(const struct crt_cb_info *cb_info)
+{
+	do_shard_punch_req_cb(cb_info->cci_rpc, cb_info->cci_arg, cb_info->cci_rc);
 }
 
 /* Execute punch on the remote target */
@@ -257,15 +260,16 @@ ds_obj_remote_punch(struct dtx_leader_handle *dlh, void *data, int idx,
 		DP_UOID(opi->opi_oid), tgt_ep.ep_rank, tgt_ep.ep_tag);
 
 	rc = crt_req_send(req, shard_punch_req_cb, remote_arg);
-	if (rc != 0)
+	if (rc != 0) {
+		D_ASSERT(sub->dss_comp == 1);
 		D_ERROR("crt_req_send failed, rc "DF_RC"\n", DP_RC(rc));
+	}
 	return rc;
 
 out:
 	if (rc) {
 		sub->dss_result = rc;
-		if (comp_cb != NULL)
-			comp_cb(dlh, idx, rc);
+		comp_cb(dlh, idx, rc);
 		if (remote_arg) {
 			crt_req_decref(parent_req);
 			D_FREE(remote_arg);
@@ -275,12 +279,9 @@ out:
 }
 
 static void
-shard_cpd_req_cb(const struct crt_cb_info *cb_info)
+do_shard_cpd_req_cb(crt_rpc_t *req, struct obj_remote_cb_arg *arg, int rc)
 {
-	crt_rpc_t			*req = cb_info->cci_rpc;
-	struct obj_remote_cb_arg	*arg = cb_info->cci_arg;
-	struct obj_cpd_out		*oco = crt_reply_get(req);
-	int				rc = cb_info->cci_rc;
+	struct obj_cpd_out	*oco = crt_reply_get(req);
 
 	if (rc >= 0)
 		rc = oco->oco_ret;
@@ -295,12 +296,16 @@ shard_cpd_req_cb(const struct crt_cb_info *cb_info)
 	D_FREE(arg);
 }
 
+static inline void
+shard_cpd_req_cb(const struct crt_cb_info *cb_info)
+{
+	do_shard_cpd_req_cb(cb_info->cci_rpc, cb_info->cci_arg, cb_info->cci_rc);
+}
+
 static int
-ds_obj_cpd_clone_reqs(struct dtx_leader_handle *dlh, struct daos_shard_tgt *tgt,
-		      struct daos_cpd_disp_ent *dcde_parent,
+ds_obj_cpd_clone_reqs(struct daos_shard_tgt *tgt, struct daos_cpd_disp_ent *dcde_parent,
 		      struct daos_cpd_sub_req *dcsr_parent, int total,
-		      struct daos_cpd_disp_ent **p_dcde,
-		      struct daos_cpd_sub_req **p_dcsr)
+		      struct daos_cpd_disp_ent **p_dcde, struct daos_cpd_sub_req **p_dcsr)
 {
 	struct daos_cpd_disp_ent	*dcde = NULL;
 	struct daos_cpd_sub_req		*dcsr = NULL;
@@ -480,7 +485,7 @@ ds_obj_cpd_dispatch(struct dtx_leader_handle *dlh, void *arg, int idx,
 
 	count = dcde_parent->dcde_read_cnt + dcde_parent->dcde_write_cnt;
 	if (count < total || (exec_arg->flags & ORF_HAS_EC_SPLIT)) {
-		rc = ds_obj_cpd_clone_reqs(dlh, shard_tgt, dcde_parent,
+		rc = ds_obj_cpd_clone_reqs(shard_tgt, dcde_parent,
 					   dcsr_parent, total, &dcde, &dcsr);
 		if (rc != 0)
 			D_GOTO(out, rc);
@@ -509,8 +514,10 @@ ds_obj_cpd_dispatch(struct dtx_leader_handle *dlh, void *arg, int idx,
 		tgt_ep.ep_rank, tgt_ep.ep_tag, idx, DP_DTI(&dcsh->dcsh_xid));
 
 	rc = crt_req_send(req, shard_cpd_req_cb, remote_arg);
-	if (rc != 0)
+	if (rc != 0) {
+		D_ASSERT(sub->dss_comp == 1);
 		D_ERROR("crt_req_send failed, rc "DF_RC"\n", DP_RC(rc));
+	}
 
 	D_CDEBUG(rc != 0, DLOG_ERR, DB_TRACE,
 		 "Forwarded CPD RPC to rank:%d tag:%d idx %u for DXT "
@@ -523,7 +530,6 @@ out:
 		crt_req_decref(req);
 
 	comp_cb(dlh, idx, rc);
-
 	if (remote_arg != NULL) {
 		crt_req_decref(parent_req);
 		D_FREE(remote_arg);

--- a/src/tests/ftest/erasurecode/online_rebuild_mdtest.py
+++ b/src/tests/ftest/erasurecode/online_rebuild_mdtest.py
@@ -5,7 +5,6 @@
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
 from ec_utils import ErasureCodeMdtest
-from apricot import skipForTicket
 
 class EcodOnlineRebuildMdtest(ErasureCodeMdtest):
     # pylint: disable=too-many-ancestors
@@ -21,7 +20,6 @@ class EcodOnlineRebuildMdtest(ErasureCodeMdtest):
         super().__init__(*args, **kwargs)
         self.set_online_rebuild = True
 
-    @skipForTicket("DAOS-9193")
     def test_ec_online_rebuild_mdtest(self):
         """Jira ID: DAOS-7320.
 


### PR DESCRIPTION
There is race between the IO handler ULT (main IO ULT) and related
IO forward ULT for using the DTX handle. It is possible that the IO
forward ULT is still using the DTX handle but related IO handler ULT
has already freed the DTX handle via dtx_leader_end(). For avoiding
such case, we add additional one compartment when create the future
dtx_leader_handle::dlh_future, it will be set by the IO forward ULT
after using the DTX handle.

The patch also adds some check to avoid repeated or leak task/RPC
completion callback. The former case may cause the one waiting on
related ABT future to be wakenup earlier unexpectedly; the latter
case will cause related RPC leak.

Some code cleanup.

Signed-off-by: Fan Yong <fan.yong@intel.com>