### PR TITLE
DAOS-9173 ofi: revert OFI patch and apply Mercury workaround

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+daos (1.3.106-11) unstable; urgency=medium
+  [ Johann Lombardi ]
+  * Revert OFI patch for DAOS-9173
+  * Apply DAOS-9173 workaround to mercury
+
+ -- Johann Lombardi <johann.lombardi@intel.com>  Mon, 13 Dec 2021 09:00:00 -0000
+
 daos (1.3.106-10) unstable; urgency=medium
   [ Brian J. Murrell ]
   * Don't make daos-*-tests-openmi a dependency of anything

--- a/debian/control
+++ b/debian/control
@@ -5,7 +5,7 @@ Maintainer: daos-stack <daos@daos.groups.io>
 Build-Depends: debhelper (>= 10),
                dh-python,
                libcmocka-dev,
-               libfabric-dev (>= 1.14.0~rc3-2),
+               libfabric-dev (= 1.14.0~rc3-3),
                libhwloc-dev,
                libopenmpi-dev,
                libssl-dev,
@@ -147,7 +147,7 @@ Package: daos-client
 Section: net
 Architecture: any
 Multi-Arch: same
-Depends: ${shlibs:Depends}, ${misc:Depends}, openmpi-bin, libfabric (>= 1.14.0~rc3-2)
+Depends: ${shlibs:Depends}, ${misc:Depends}, openmpi-bin, libfabric (= 1.14.0~rc3-3)
 Description: The Distributed Asynchronous Object Storage (DAOS) is an open-source
  software-defined object store designed from the ground up for
  massively distributed Non Volatile Memory (NVM). DAOS takes advantage
@@ -166,7 +166,7 @@ Section: net
 Architecture: any
 Multi-Arch: same
 Depends: ${shlibs:Depends}, ${misc:Depends}, openmpi-bin,
-         ipmctl (>02.00.00.3816), libfabric (>= 1.14.0~rc3-2)
+         ipmctl (>02.00.00.3816), libfabric (= 1.14.0~rc3-3)
 Description: The Distributed Asynchronous Object Storage (DAOS) is an open-source
  software-defined object store designed from the ground up for
  massively distributed Non Volatile Memory (NVM). DAOS takes advantage

--- a/debian/control
+++ b/debian/control
@@ -5,7 +5,7 @@ Maintainer: daos-stack <daos@daos.groups.io>
 Build-Depends: debhelper (>= 10),
                dh-python,
                libcmocka-dev,
-               libfabric-dev (= 1.14.0~rc3-3),
+               libfabric-dev (>= 1.14.0~rc3-3),
                libhwloc-dev,
                libopenmpi-dev,
                libssl-dev,
@@ -147,7 +147,7 @@ Package: daos-client
 Section: net
 Architecture: any
 Multi-Arch: same
-Depends: ${shlibs:Depends}, ${misc:Depends}, openmpi-bin, libfabric (= 1.14.0~rc3-3)
+Depends: ${shlibs:Depends}, ${misc:Depends}, openmpi-bin, libfabric (>= 1.14.0~rc3-3)
 Description: The Distributed Asynchronous Object Storage (DAOS) is an open-source
  software-defined object store designed from the ground up for
  massively distributed Non Volatile Memory (NVM). DAOS takes advantage
@@ -166,7 +166,7 @@ Section: net
 Architecture: any
 Multi-Arch: same
 Depends: ${shlibs:Depends}, ${misc:Depends}, openmpi-bin,
-         ipmctl (>02.00.00.3816), libfabric (= 1.14.0~rc3-3)
+         ipmctl (>02.00.00.3816), libfabric (>= 1.14.0~rc3-3)
 Description: The Distributed Asynchronous Object Storage (DAOS) is an open-source
  software-defined object store designed from the ground up for
  massively distributed Non Volatile Memory (NVM). DAOS takes advantage

--- a/utils/build.config
+++ b/utils/build.config
@@ -16,4 +16,4 @@ PROTOBUFC = v1.3.3
 [patch_versions]
 spdk=https://github.com/spdk/spdk/commit/690783a3ae82ebe58c00d643520a66103d66d540.diff,https://github.com/spdk/spdk/commit/65425be69a0882ac283fb489aa151d7df06c52ad.diff,https://raw.githubusercontent.com/daos-stack/spdk/master/0003-blob-chunk-clear-operations-in-IU-aligned-chunks.patch,https://github.com/spdk/spdk/commit/086223c029389329b7a4f38ec0f9a30be83849bf.diff
 pmdk=https://raw.githubusercontent.com/daos-stack/pmdk/master/DAOS_8273.patch
-ofi=https://raw.githubusercontent.com/daos-stack/libfabric/master/daos-9173-ofi.patch
+mercury=https://raw.githubusercontent.com/daos-stack/mercury/master/daos_9173_workaround.patch

--- a/utils/rpms/daos.spec
+++ b/utils/rpms/daos.spec
@@ -30,7 +30,7 @@ BuildRequires: python36-scons >= 2.4
 %else
 BuildRequires: scons >= 2.4
 %endif
-BuildRequires: libfabric-devel = %{libfabric_version}
+BuildRequires: libfabric-devel >= %{libfabric_version}
 BuildRequires: mercury-devel = %{mercury_version}
 %if (0%{?rhel} < 8) || (0%{?suse_version} > 0)
 BuildRequires: openpa-devel
@@ -168,7 +168,7 @@ Requires: libpmemobj = 1.11.0-3%{?dist}
 Requires: mercury = %{mercury_version}
 Requires(post): /sbin/ldconfig
 Requires(postun): /sbin/ldconfig
-Requires: libfabric = %{libfabric_version}
+Requires: libfabric >= %{libfabric_version}
 %{?systemd_requires}
 Obsoletes: cart < 1000
 
@@ -179,7 +179,7 @@ This is the package needed to run a DAOS server
 Summary: The DAOS client
 Requires: %{name}%{?_isa} = %{version}-%{release}
 Requires: mercury = %{mercury_version}
-Requires: libfabric = %{libfabric_version}
+Requires: libfabric >= %{libfabric_version}
 %if (0%{?rhel} >= 8)
 Requires: fuse3 >= 3
 %else

--- a/utils/rpms/daos.spec
+++ b/utils/rpms/daos.spec
@@ -2,8 +2,8 @@
 %define server_svc_name daos_server.service
 %define agent_svc_name daos_agent.service
 
-%global mercury_version 2.1.0~rc4-1%{?dist}
-%global libfabric_version 1.14.0~rc3-2
+%global mercury_version 2.1.0~rc4-2%{?dist}
+%global libfabric_version 1.14.0~rc3-3
 %global __python %{__python3}
 
 %if (0%{?rhel} >= 8)
@@ -14,7 +14,7 @@
 
 Name:          daos
 Version:       1.3.106
-Release:       10%{?relval}%{?dist}
+Release:       11%{?relval}%{?dist}
 Summary:       DAOS Storage Engine
 
 License:       BSD-2-Clause-Patent
@@ -30,7 +30,7 @@ BuildRequires: python36-scons >= 2.4
 %else
 BuildRequires: scons >= 2.4
 %endif
-BuildRequires: libfabric-devel >= %{libfabric_version}
+BuildRequires: libfabric-devel = %{libfabric_version}
 BuildRequires: mercury-devel = %{mercury_version}
 %if (0%{?rhel} < 8) || (0%{?suse_version} > 0)
 BuildRequires: openpa-devel
@@ -168,7 +168,7 @@ Requires: libpmemobj = 1.11.0-3%{?dist}
 Requires: mercury = %{mercury_version}
 Requires(post): /sbin/ldconfig
 Requires(postun): /sbin/ldconfig
-Requires: libfabric >= %{libfabric_version}
+Requires: libfabric = %{libfabric_version}
 %{?systemd_requires}
 Obsoletes: cart < 1000
 
@@ -179,7 +179,7 @@ This is the package needed to run a DAOS server
 Summary: The DAOS client
 Requires: %{name}%{?_isa} = %{version}-%{release}
 Requires: mercury = %{mercury_version}
-Requires: libfabric >= %{libfabric_version}
+Requires: libfabric = %{libfabric_version}
 %if (0%{?rhel} >= 8)
 Requires: fuse3 >= 3
 %else
@@ -516,6 +516,10 @@ getent passwd daos_agent >/dev/null || useradd -s /sbin/nologin -r -g daos_agent
 # No files in a meta-package
 
 %changelog
+* Mon Dec 13 2021 Johann Lombardi <johann.lombardi@intel.com> 1.3.106-11
+- Revert OFI patch for DAOS-9173
+- Apply DAOS-9173 workaround to mercury
+
 * Fri Dec 10 2021 Brian J. Murrell <brian.murrell@intel.com> 1.3.106-10
 - Don't make daos-*-tests-openmi a dependency of anything
   - If they are wanted, they should be installed explicitly, due to


### PR DESCRIPTION
Due to some issues hit during soak (see DAOS-9195 for more info).
Pin both mercury and libfabric version to make sure to pick
the correct version.

PR-repos: libfabric@PR-49

Signed-off-by: Johann Lombardi <johann.lombardi@intel.com>