### PR TITLE
DAOS-9221 test: pass client variables in yaml

### DIFF
--- a/src/tests/ftest/aggregation/basic.yaml
+++ b/src/tests/ftest/aggregation/basic.yaml
@@ -29,6 +29,8 @@ container:
     type: POSIX
     control_method: daos
 ior:
+    env_vars:
+        - D_LOG_MASK=INFO
     client_processes:
         np_12:
             np: 12

--- a/src/tests/ftest/ior/intercept_basic.yaml
+++ b/src/tests/ftest/ior/intercept_basic.yaml
@@ -22,6 +22,8 @@ container:
     type: POSIX
     control_method: daos
 ior:
+    env_vars:
+        - D_LOG_MASK=INFO
     client_processes:
         np: 32
     test_file: testFile

--- a/src/tests/ftest/ior/intercept_messages.py
+++ b/src/tests/ftest/ior/intercept_messages.py
@@ -33,11 +33,10 @@ class IorInterceptMessages(IorTestBase):
 
         :avocado: tags=all,full_regression
         :avocado: tags=hw,small
-        :avocado: tags=daosio,dfuse,il,ior_intercept
+        :avocado: tags=daosio,dfuse,il,ior,ior_intercept
         :avocado: tags=ior_intercept_messages
         """
-        d_il_report_value = self.params.get("value",
-                                            "/run/tests/D_IL_REPORT/*")
+        d_il_report_value = self.params.get("value", "/run/tests/D_IL_REPORT/*")
         intercept = os.path.join(self.prefix, 'lib64', 'libioil.so')
         summary_pattern = r"^\[libioil\] Performed [0-9]+ reads and [0-9]+ " \
                           "writes from [0-9]+ files*"
@@ -45,8 +44,6 @@ class IorInterceptMessages(IorTestBase):
         # Avoiding any impact to the rest of IOR test cases
         job_manager = self.get_ior_job_manager_command()
         env = self.ior_cmd.get_default_env(str(job_manager), self.client_log)
-        env['DD_MASK '] = 'all'
-        env['DD_SUBSYS'] = 'all'
 
         # D_IL_REPORT VALUES
         #     -1: All printed calls # This needs its own test case
@@ -71,9 +68,7 @@ class IorInterceptMessages(IorTestBase):
         compiled_ip = re.compile(intercept_pattern)
         expected_total_intercepts = self.processes * int(env['D_IL_REPORT'])
 
-        out = self.run_ior_with_pool(intercept=intercept,
-                                     fail_on_warning=False,
-                                     env=env)
+        out = self.run_ior_with_pool(intercept=intercept, fail_on_warning=False, env=env)
         # Check for libioil messages within stderr
         for line in out.stderr.decode("utf-8").splitlines():
 
@@ -86,7 +81,5 @@ class IorInterceptMessages(IorTestBase):
             if match:
                 match_summary_results.append(match)
 
-        self.assertEqual(len(match_intercept_results),
-                         expected_total_intercepts)
-        self.assertEqual(len(match_summary_results),
-                         expected_total_summaries)
+        self.assertEqual(len(match_intercept_results), expected_total_intercepts)
+        self.assertEqual(len(match_summary_results), expected_total_summaries)

--- a/src/tests/ftest/ior/intercept_messages.yaml
+++ b/src/tests/ftest/ior/intercept_messages.yaml
@@ -21,6 +21,10 @@ container:
     type: POSIX
     control_method: daos
 ior:
+    env_vars:
+        - D_LOG_MASK=INFO
+        - DD_MASK=all
+        - DD_SUBSYS=all
     api: POSIX
     client_processes:
       np_16:

--- a/src/tests/ftest/ior/intercept_multi_client.yaml
+++ b/src/tests/ftest/ior/intercept_multi_client.yaml
@@ -44,6 +44,8 @@ container:
     type: POSIX
     control_method: daos
 ior:
+    env_vars:
+        - D_LOG_MASK=INFO
     client_processes:
         np: 96
     test_file: testFile

--- a/src/tests/ftest/ior/intercept_verify_data_integrity.yaml
+++ b/src/tests/ftest/ior/intercept_verify_data_integrity.yaml
@@ -36,6 +36,8 @@ container:
     type: POSIX
     control_method: daos
 ior:
+    env_vars:
+        - D_LOG_MASK=INFO
     client_processes:
         np_24:
             np: 24

--- a/src/tests/ftest/util/command_utils_base.py
+++ b/src/tests/ftest/util/command_utils_base.py
@@ -626,6 +626,59 @@ class CommonConfig(YamlParameters):
 class EnvironmentVariables(dict):
     """Dictionary of environment variable keys and values."""
 
+    @classmethod
+    def from_list(cls, kv_list):
+        """Initialize from a list of key=value strings.
+
+        Compatible with output from EnvironmentVariables.to_list.
+
+        Args:
+            kv_list (list):  list of environment variable assignment (key=value) strings
+
+        Returns:
+            EnvironmentVariables: new object.
+        """
+        env = cls()
+        env.update_from_list(kv_list)
+        return env
+
+    def to_list(self):
+        """Convert to a list of environment variable assignments.
+
+        Returns:
+            list: a list of environment variable assignment (key=value) strings
+        """
+        return [
+            key if value is None else "{}={}".format(key, value)
+            for key, value in list(self.items())
+        ]
+
+    def update_from_list(self, kv_list):
+        """Update from a list of key=value strings.
+
+        Args:
+            kv_list (list):  list of environment variable assignment (key=value) strings
+        """
+        for kv in kv_list:
+            key, *value = kv.split('=')
+            self[key] = value[0] if value else None
+
+    def to_export_str(self, separator=";"):
+        """Convert to a command to export all the environment variables.
+
+        Args:
+            separator (str, optional): export command separator.
+                Defaults to ";".
+
+        Returns:
+            str: a string of export commands for each environment variable
+        """
+        export_list = ["export {}".format(export) for export in self.to_list()]
+        export_str = separator.join(export_list)
+        if export_str:
+            export_str = "".join([export_str, separator])
+        return export_str
+
     def copy(self):
         """Return a copy of this object.
 
@@ -634,35 +687,6 @@ class EnvironmentVariables(dict):
 
         """
         return EnvironmentVariables(self)
-
-    def get_list(self):
-        """Get a list of environment variable assignments.
-
-        Returns:
-            list: a list of environment variable assignment (key=value) strings
-
-        """
-        return [
-            key if value is None else "{}={}".format(key, value)
-            for key, value in list(self.items())
-        ]
-
-    def get_export_str(self, separator=";"):
-        """Get the command to export all of the environment variables.
-
-        Args:
-            separator (str, optional): export command separator.
-                Defaults to ";".
-
-        Returns:
-            str: a string of export commands for each environment variable
-
-        """
-        export_list = ["export {}".format(export) for export in self.get_list()]
-        export_str = separator.join(export_list)
-        if export_str:
-            export_str = "".join([export_str, separator])
-        return export_str
 
 class PositionalParameter(BasicParameter):
     """Parameter that defines position.

--- a/src/tests/ftest/util/daos_racer_utils.py
+++ b/src/tests/ftest/util/daos_racer_utils.py
@@ -90,7 +90,7 @@ class DaosRacerCommand(ExecutableCommand):
                 names and values to export prior to running daos_racer
         """
         # Include exports prior to the daos_racer command
-        self._pre_command = env.get_export_str()
+        self._pre_command = env.to_export_str()
 
     def run(self):
         """Run the daos_racer command remotely.

--- a/src/tests/ftest/util/dfuse_utils.py
+++ b/src/tests/ftest/util/dfuse_utils.py
@@ -273,7 +273,7 @@ class Dfuse(DfuseCommand):
         self.create_mount_point()
 
         # run dfuse command
-        cmd = self.env.get_export_str()
+        cmd = self.env.to_export_str()
         if bind_cores:
             cmd += 'taskset -c {} '.format(bind_cores)
         cmd += str(self)

--- a/src/tests/ftest/util/ior_test_base.py
+++ b/src/tests/ftest/util/ior_test_base.py
@@ -273,14 +273,8 @@ class IorTestBase(DfuseTestBase):
             env = self.ior_cmd.get_default_env(str(manager), self.client_log)
         if intercept:
             env['LD_PRELOAD'] = intercept
-            if 'D_LOG_MASK' not in env:
-                env['D_LOG_MASK'] = 'INFO'
             if 'D_IL_REPORT' not in env:
                 env['D_IL_REPORT'] = '1'
-
-            #env['D_LOG_MASK'] = 'INFO,IL=DEBUG'
-            #env['DD_MASK'] = 'all'
-            #env['DD_SUBSYS'] = 'all'
         if plugin_path:
             env["HDF5_VOL_CONNECTOR"] = "daos"
             env["HDF5_PLUGIN_PATH"] = str(plugin_path)
@@ -340,13 +334,14 @@ class IorTestBase(DfuseTestBase):
                       str(self.job_manager))
 
         try:
-            out = self.job_manager.stop()
-            return out
+            return self.job_manager.stop()
         except CommandFailure as error:
             self.log.error("IOR stop Failed: %s", str(error))
             self.fail("Test was expected to pass but it failed.\n")
         finally:
             self.display_pool_space()
+
+        return None
 
     def run_ior_threads_il(self, results, intercept, with_clients,
                            without_clients):

--- a/src/tests/ftest/util/job_manager_utils.py
+++ b/src/tests/ftest/util/job_manager_utils.py
@@ -286,14 +286,12 @@ class Orterun(JobManager):
             # dictionary keys with the specified values or add new key value
             # pairs to the dictionary.  Finally convert the updated dictionary
             # back to a list for the parameter assignment.
-            original = EnvironmentVariables({
-                item.split("=")[0]: item.split("=")[1] if "=" in item else None
-                for item in self.export.value})
+            original = EnvironmentVariables.from_list(self.export.value)
             original.update(env_vars)
-            self.export.value = original.get_list()
+            self.export.value = original.to_list()
         else:
             # Overwrite the environmental variable assignment
-            self.export.value = env_vars.get_list()
+            self.export.value = env_vars.to_list()
 
     def assign_environment_default(self, env_vars):
         """Assign the default environment variables for the command.
@@ -302,7 +300,7 @@ class Orterun(JobManager):
             env_vars (EnvironmentVariables): the environment variables to
                 assign as the default
         """
-        self.export.update_default(env_vars.get_list())
+        self.export.update_default(env_vars.to_list())
 
     def run(self):
         """Run the orterun command.
@@ -402,7 +400,7 @@ class Mpirun(JobManager):
             env_vars (EnvironmentVariables): the environment variables to
                 assign as the default
         """
-        self.envlist.update_default(env_vars.get_list())
+        self.envlist.update_default(env_vars.to_list())
 
     def run(self):
         """Run the mpirun command.
@@ -485,14 +483,12 @@ class Srun(JobManager):
             # dictionary keys with the specified values or add new key value
             # pairs to the dictionary.  Finally convert the updated dictionary
             # back to a string for the parameter assignment.
-            original = EnvironmentVariables({
-                item.split("=")[0]: item.split("=")[1] if "=" in item else None
-                for item in self.export.value.split(",")})
+            original = EnvironmentVariables.from_list(self.export.value.split(","))
             original.update(env_vars)
-            self.export.value = ",".join(original.get_list())
+            self.export.value = ",".join(original.to_list())
         else:
             # Overwrite the environmental variable assignment
-            self.export.value = ",".join(env_vars.get_list())
+            self.export.value = ",".join(env_vars.to_list())
 
     def assign_environment_default(self, env_vars):
         """Assign the default environment variables for the command.
@@ -501,7 +497,7 @@ class Srun(JobManager):
             env_vars (EnvironmentVariables): the environment variables to
                 assign as the default
         """
-        self.export.update_default(env_vars.get_list())
+        self.export.update_default(env_vars.to_list())
 
 
 class Systemctl(JobManager):


### PR DESCRIPTION
Test-tag: pr daily_regression iorinterceptbasic iorinterceptmessages ior_intercept_mix iorinterceptmulticlient ior_intercept_verify_data

Support passing client env_vars in test yamls. These can be specified at
a global level under `client/env_vars`, or a per-cmd level as
`<cmd>/env_vars`.
This is currently supported by any command inheriting from
ExecutableCommand. Conservatively, only a subset of tests are initially
updated.

- Refactor EnvironmentVariables
  - add bi-directional to_list and from_list
  - rename get_export_str -> to_export_str

- Add base_env_namespace to ExecutableCommand
  - Get env_vars from /run/client/env_vars and namespace/env_vars
    - Named env_vars to be similar to server config

- Update IOR tests using D_LOG_MASK to instead pass in the yaml.

Signed-off-by: Dalton Bohning <dalton.bohning@intel.com>