### PR TITLE
DAOS-4679 fixed static runable variable in test_runable()

### DIFF
--- a/src/tests/suite/daos_test_common.c
+++ b/src/tests/suite/daos_test_common.c
@@ -628,8 +628,8 @@ d_rank_t ranks_to_kill[MAX_KILLS];
 bool
 test_runable(test_arg_t *arg, unsigned int required_nodes)
 {
-	int		 i;
-	bool	 runable = true;
+	int	i;
+	bool	runable = true;
 
 	if (arg == NULL) {
 		print_message("state not set, likely due to group-setup"

--- a/src/tests/suite/daos_test_common.c
+++ b/src/tests/suite/daos_test_common.c
@@ -629,7 +629,7 @@ bool
 test_runable(test_arg_t *arg, unsigned int required_nodes)
 {
 	int		 i;
-	static bool	 runable = true;
+	bool	 runable = true;
 
 	if (arg == NULL) {
 		print_message("state not set, likely due to group-setup"


### PR DESCRIPTION
"runable" was defined as a static bool. Once a test case is determined as "skipped",
runable is set false. The following tests cases will be skipped unexpectedly.