### PR TITLE
DAOS-9311 build: build MPI-related test binaries with docker

### DIFF
--- a/site_scons/env_modules.py
+++ b/site_scons/env_modules.py
@@ -39,10 +39,10 @@ class _env_module(): # pylint: disable=invalid-name
         """Load Modules for initializing envirables"""
         # Leap 15's lmod-lua doesn't include the usual module path
         # in it's MODULEPATH, for some unknown reason
-        os.environ["MODULEPATH"] = ":".join([os.path.join("/usr", "share", "modules"),
-                                             os.path.join("/usr", "share", "modulefiles"),
-                                             os.path.join("/etc", "modulefiles")] +
-                                             os.environ.get("MODULEPATH", "").split(":"))
+        os.environ["MODULEPATH"] = ":".join([os.path.join(os.sep, "usr", "share", "modules"),
+                                             os.path.join(os.sep, "usr", "share", "modulefiles"),
+                                             os.path.join(os.sep, "etc", "modulefiles")] +
+                                            os.environ.get("MODULEPATH", "").split(":"))
         self._module_load = self._init_mpi_module()
 
     def _module_func(self, command, *arguments): # pylint: disable=no-self-use

--- a/site_scons/env_modules.py
+++ b/site_scons/env_modules.py
@@ -39,14 +39,10 @@ class _env_module(): # pylint: disable=invalid-name
         """Load Modules for initializing envirables"""
         # Leap 15's lmod-lua doesn't include the usual module path
         # in it's MODULEPATH, for some unknown reason
-        os.environ["MODULEPATH"] = ":".join([os.path.sep +
-                                             os.path.join("usr", "share",
-                                                          "modules"),
-                                             os.path.sep +
-                                             os.path.join("etc",
-                                                          "modulefiles")] +
-                                            os.environ.get("MODULEPATH",
-                                                           "").split(":"))
+        os.environ["MODULEPATH"] = ":".join([os.path.join("/usr", "share", "modules"),
+                                             os.path.join("/usr", "share", "modulefiles"),
+                                             os.path.join("/etc", "modulefiles")] +
+                                             os.environ.get("MODULEPATH", "").split(":"))
         self._module_load = self._init_mpi_module()
 
     def _module_func(self, command, *arguments): # pylint: disable=no-self-use

--- a/utils/docker/Dockerfile.centos.7
+++ b/utils/docker/Dockerfile.centos.7
@@ -302,4 +302,4 @@ WORKDIR /home/daos
 
 ARG DAOS_KEEP_SRC=no
 # Remove local copy
-RUN [ $"DAOS_KEEP_SRC" != "no" ] || rm -rf /home/daos/*
+RUN [ "$DAOS_KEEP_SRC" != "no" ] || rm -rf /home/daos/*

--- a/utils/docker/Dockerfile.centos.7
+++ b/utils/docker/Dockerfile.centos.7
@@ -260,9 +260,13 @@ ARG JOBS=$DEPS_JOBS
 ARG DAOS_BUILD_TYPE=$DAOS_TARGET_TYPE
 ARG DAOS_BUILD=$DAOS_DEPS_BUILD
 
+# MPI modules configuration file
+ARG MODULES_CFG_PATH=/etc/profile.d/modules.sh
+
 # Build DAOS
 RUN [ "$DAOS_BUILD" != "yes" ] || \
-    { scons-3 --jobs $JOBS install PREFIX=/opt/daos COMPILER=$COMPILER \
+    { { [ ! -f "$MODULES_CFG_PATH" ] || source "$MODULES_CFG_PATH" ; } && \
+    scons-3 --jobs $JOBS install PREFIX=/opt/daos COMPILER=$COMPILER \
       BUILD_TYPE=$DAOS_BUILD_TYPE TARGET_TYPE=$DAOS_TARGET_TYPE && \
     /bin/rm -rf build && go clean -cache && \
     cp -r utils/config/examples /opt/daos; }

--- a/utils/docker/Dockerfile.centos.7
+++ b/utils/docker/Dockerfile.centos.7
@@ -260,13 +260,9 @@ ARG JOBS=$DEPS_JOBS
 ARG DAOS_BUILD_TYPE=$DAOS_TARGET_TYPE
 ARG DAOS_BUILD=$DAOS_DEPS_BUILD
 
-# MPI modules configuration file
-ARG MODULES_CFG_PATH=/etc/profile.d/modules.sh
-
 # Build DAOS
 RUN [ "$DAOS_BUILD" != "yes" ] || \
-    { { [ ! -f "$MODULES_CFG_PATH" ] || source "$MODULES_CFG_PATH" ; } && \
-    scons-3 --jobs $JOBS install PREFIX=/opt/daos COMPILER=$COMPILER \
+    { scons-3 --jobs $JOBS install PREFIX=/opt/daos COMPILER=$COMPILER \
       BUILD_TYPE=$DAOS_BUILD_TYPE TARGET_TYPE=$DAOS_TARGET_TYPE && \
     /bin/rm -rf build && go clean -cache && \
     cp -r utils/config/examples /opt/daos; }

--- a/utils/docker/Dockerfile.centos.8
+++ b/utils/docker/Dockerfile.centos.8
@@ -276,9 +276,13 @@ ARG JOBS=$DEPS_JOBS
 ARG DAOS_BUILD_TYPE=$DAOS_TARGET_TYPE
 ARG DAOS_BUILD=$DAOS_DEPS_BUILD
 
+# MPI modules configuration file
+ARG MODULES_CFG_PATH=/etc/profile.d/modules.sh
+
 # Build DAOS
 RUN [ "$DAOS_BUILD" != "yes" ] || \
-    { scons-3 --jobs $JOBS install PREFIX=/opt/daos COMPILER=$COMPILER \
+    { { [ ! -f "$MODULES_CFG_PATH" ] || source "$MODULES_CFG_PATH" ; } && \
+    scons-3 --jobs $JOBS install PREFIX=/opt/daos COMPILER=$COMPILER \
       BUILD_TYPE=$DAOS_BUILD_TYPE TARGET_TYPE=$DAOS_TARGET_TYPE && \
     /bin/rm -rf build && go clean -cache && \
     cp -r utils/config/examples /opt/daos; }

--- a/utils/docker/Dockerfile.centos.8
+++ b/utils/docker/Dockerfile.centos.8
@@ -276,13 +276,9 @@ ARG JOBS=$DEPS_JOBS
 ARG DAOS_BUILD_TYPE=$DAOS_TARGET_TYPE
 ARG DAOS_BUILD=$DAOS_DEPS_BUILD
 
-# MPI modules configuration file
-ARG MODULES_CFG_PATH=/etc/profile.d/modules.sh
-
 # Build DAOS
 RUN [ "$DAOS_BUILD" != "yes" ] || \
-    { { [ ! -f "$MODULES_CFG_PATH" ] || source "$MODULES_CFG_PATH" ; } && \
-    scons-3 --jobs $JOBS install PREFIX=/opt/daos COMPILER=$COMPILER \
+    { scons-3 --jobs $JOBS install PREFIX=/opt/daos COMPILER=$COMPILER \
       BUILD_TYPE=$DAOS_BUILD_TYPE TARGET_TYPE=$DAOS_TARGET_TYPE && \
     /bin/rm -rf build && go clean -cache && \
     cp -r utils/config/examples /opt/daos; }

--- a/utils/docker/Dockerfile.centos.8
+++ b/utils/docker/Dockerfile.centos.8
@@ -318,4 +318,4 @@ WORKDIR /home/daos
 
 ARG DAOS_KEEP_SRC=no
 # Remove local copy
-RUN [ $"DAOS_KEEP_SRC" != "no" ] || rm -rf /home/daos/*
+RUN [ "$DAOS_KEEP_SRC" != "no" ] || rm -rf /home/daos/*

--- a/utils/docker/Dockerfile.leap.15
+++ b/utils/docker/Dockerfile.leap.15
@@ -281,4 +281,4 @@ WORKDIR /home/daos
 
 ARG DAOS_KEEP_SRC=no
 # Remove local copy
-RUN [ $"DAOS_KEEP_SRC" != "no" ] || rm -rf /home/daos/*
+RUN [ "$DAOS_KEEP_SRC" != "no" ] || rm -rf /home/daos/*

--- a/utils/docker/Dockerfile.leap.15
+++ b/utils/docker/Dockerfile.leap.15
@@ -239,9 +239,13 @@ ARG JOBS=$DEPS_JOBS
 ARG DAOS_BUILD_TYPE=$DAOS_TARGET_TYPE
 ARG DAOS_BUILD=$DAOS_DEPS_BUILD
 
+# MPI modules configuration file
+ARG MODULES_CFG_PATH=/etc/profile.d/modules.sh
+
 # Build DAOS
 RUN [ "$DAOS_BUILD" != "yes" ] || \
-    { scons --jobs $JOBS install PREFIX=/opt/daos COMPILER=$COMPILER \
+    { { [ ! -f "$MODULES_CFG_PATH" ] || source "$MODULES_CFG_PATH" ; } && \
+    scons --jobs $JOBS install PREFIX=/opt/daos COMPILER=$COMPILER \
       BUILD_TYPE=$DAOS_BUILD_TYPE TARGET_TYPE=$DAOS_TARGET_TYPE && \
     /bin/rm -rf build && go clean -cache && \
     cp -r utils/config/examples /opt/daos; }

--- a/utils/docker/Dockerfile.leap.15
+++ b/utils/docker/Dockerfile.leap.15
@@ -239,13 +239,9 @@ ARG JOBS=$DEPS_JOBS
 ARG DAOS_BUILD_TYPE=$DAOS_TARGET_TYPE
 ARG DAOS_BUILD=$DAOS_DEPS_BUILD
 
-# MPI modules configuration file
-ARG MODULES_CFG_PATH=/etc/profile.d/modules.sh
-
 # Build DAOS
 RUN [ "$DAOS_BUILD" != "yes" ] || \
-    { { [ ! -f "$MODULES_CFG_PATH" ] || source "$MODULES_CFG_PATH" ; } && \
-    scons --jobs $JOBS install PREFIX=/opt/daos COMPILER=$COMPILER \
+    { scons --jobs $JOBS install PREFIX=/opt/daos COMPILER=$COMPILER \
       BUILD_TYPE=$DAOS_BUILD_TYPE TARGET_TYPE=$DAOS_TARGET_TYPE && \
     /bin/rm -rf build && go clean -cache && \
     cp -r utils/config/examples /opt/daos; }

--- a/utils/docker/Dockerfile.ubuntu.20.04
+++ b/utils/docker/Dockerfile.ubuntu.20.04
@@ -148,13 +148,9 @@ ARG JOBS=$DEPS_JOBS
 ARG DAOS_BUILD_TYPE=$DAOS_TARGET_TYPE
 ARG DAOS_BUILD=$DAOS_DEPS_BUILD
 
-# MPI modules configuration file
-ARG MODULES_CFG_PATH=/etc/profile.d/modules.sh
-
 # Build DAOS
 RUN [ "$DAOS_BUILD" != "yes" ] || \
-    { { [ ! -f "$MODULES_CFG_PATH" ] || source "$MODULES_CFG_PATH" ; } && \
-    scons --jobs $JOBS install PREFIX=/opt/daos COMPILER=$COMPILER \
+    { scons --jobs $JOBS install PREFIX=/opt/daos COMPILER=$COMPILER \
       BUILD_TYPE=$DAOS_BUILD_TYPE TARGET_TYPE=$DAOS_TARGET_TYPE && \
     /bin/rm -rf build && go clean -cache && \
     cp -r utils/config/examples /opt/daos; }

--- a/utils/docker/Dockerfile.ubuntu.20.04
+++ b/utils/docker/Dockerfile.ubuntu.20.04
@@ -190,4 +190,4 @@ WORKDIR /home/daos
 
 ARG DAOS_KEEP_SRC=no
 # Remove local copy
-RUN [ $"DAOS_KEEP_SRC" != "no" ] || rm -rf /home/daos/*
+RUN [ "$DAOS_KEEP_SRC" != "no" ] || rm -rf /home/daos/*

--- a/utils/docker/Dockerfile.ubuntu.20.04
+++ b/utils/docker/Dockerfile.ubuntu.20.04
@@ -148,9 +148,13 @@ ARG JOBS=$DEPS_JOBS
 ARG DAOS_BUILD_TYPE=$DAOS_TARGET_TYPE
 ARG DAOS_BUILD=$DAOS_DEPS_BUILD
 
+# MPI modules configuration file
+ARG MODULES_CFG_PATH=/etc/profile.d/modules.sh
+
 # Build DAOS
 RUN [ "$DAOS_BUILD" != "yes" ] || \
-    { scons --jobs $JOBS install PREFIX=/opt/daos COMPILER=$COMPILER \
+    { { [ ! -f "$MODULES_CFG_PATH" ] || source "$MODULES_CFG_PATH" ; } && \
+    scons --jobs $JOBS install PREFIX=/opt/daos COMPILER=$COMPILER \
       BUILD_TYPE=$DAOS_BUILD_TYPE TARGET_TYPE=$DAOS_TARGET_TYPE && \
     /bin/rm -rf build && go clean -cache && \
     cp -r utils/config/examples /opt/daos; }


### PR DESCRIPTION
Dockerfile RUN use /bin/sh to run command. As indicated in the bash manual: "A non-interactive shell invoked with the name sh does not attempt to read any other startup files."
More information could be found at https://www.gnu.org/software/bash/manual/html_node/Bash-Startup-Files.html

Building MPI-related test binaries of DAOS (e.g. daos_perf, daos_test, etc.) needs some environment variables releated to modules tool.  These environmant variables are  defined in /etc/profile.d/modules.sh.

Do not hesitate to add reviewers if I forgot someone: I used git blame to create the list of reviewers.
