### PR TITLE
DAOS-9185 doc: fix pool/cont usage - positional args and labels

### DIFF
--- a/docs/admin/pool_operations.md
+++ b/docs/admin/pool_operations.md
@@ -509,7 +509,7 @@ Target (rank 5 idx 1) is down.
 These should be the same values used when reintegrating the targets.
 
 ```
-$ dmg pool reintegrate --rank=5 --target-idx=0,1 <pool_label>
+$ dmg pool reintegrate $DAOS_POOL --rank=5 --target-idx=0,1
 ```
 
 !!! warning


### PR DESCRIPTION
make documentation of the dmg and daos commands consistent
to use positional arguments for pools and containers

include container labels in the examples

Signed-off-by: Michael Hennecke <michael.hennecke@intel.com>