### PR TITLE
DAOS-9185 doc: fix pool/cont usage - positional args and labels (#7666)

### DIFF
--- a/docs/QSG/tour.md
+++ b/docs/QSG/tour.md
@@ -5,11 +5,11 @@
 ## Introduction
 
 This documentation provides a general tour to the DAOS management commands
-(dmg) for daos_admin, and DAOS tools (daos) for daos_client users.
+(dmg) for daos\_admin, and DAOS tools (daos) for daos\_client users.
 Help and setup for the following is provided in this chapter:
 
 - Pool and Container create, list, query and destroy on
-DAOS server for daos_admin and daos_client users.
+DAOS server for daos\_admin and daos\_client users.
 - Common errors and workarounds for new users when using the dmg and daos tools. 
 - Example runs of data transfer between DAOS file systems, by setting up
 of the DAOS dfuse mount point and run traffic with dfuse fio and mpirun
@@ -536,15 +536,11 @@ bring-up DAOS servers and clients.
 
 ### run fio
 
-	$ dmg pool create --size=10G
-	$ daos cont create --pool=$DAOS_POOL --type=POSIX
-	$ daos cont query --pool=$DAOS_POOL --cont=$DAOS_CONT
-	Pool UUID: f688f2ad-76ae-4368-8d1b-5697ca016a43
-	Container UUID: bcc5c793-60dc-4ec1-8bab-9d63ea18e794
-	Number of snapshots: 0
-	Latest Persistent Snapshot: 0
-	Highest Aggregated Epoch: 0
-	Container redundancy factor: 0
+	$ export DAOS_POOL="mypool"
+	$ export DAOS_CONT="mycont"
+	$ dmg pool create --size 10G $DAOS_POOL
+	$ daos cont create --label $DAOS_CONT --type POSIX $DAOS_POOL
+	$ daos cont query $DAOS_POOL $DAOS_CONT
 	$ /usr/bin/mkdir /tmp/daos_test1
 	$ /usr/bin/touch /tmp/daos_test1/testfile
 	$ /usr/bin/df -h -t fuse.daos
@@ -721,7 +717,7 @@ bring-up DAOS servers and clients.
 	Tree removal : 0.000 0.000 0.000 0.000
 	– finished at 04/16/2021 22:02:27 –
 
-## Run with 4 DAOS hosts server, rebuild with dfuse_io and mpirun
+## Run with 4 DAOS hosts server, rebuild with dfuse io and mpirun
 
 ### Environment variables setup
 
@@ -748,13 +744,13 @@ bring-up DAOS servers and clients.
 	733bee7b-c2af-499e-99dd-313b1ef092a9
 	[1-3]
 
-	$ daos cont create --pool=$DAOS_POOL --type=POSIX --oclass=RP_3G1 --properties=rf:2
+	$ daos cont create --label mycont --type POSIX --oclass RP_3G1 --properties rf:2 $DAOS_POOL
 	Successfully created container 2649aa0f-3ad7-4943-abf5-4343205a637b
 
-	$ daos pool list-cont --pool=$DAOS_POOL
+	$ daos pool list-cont $DAOS_POOL
 	2649aa0f-3ad7-4943-abf5-4343205a637b
 
-	$ dmg pool query --pool=$DAOS_POOL
+	$ dmg pool query $DAOS_POOL
 	Pool 733bee7b-c2af-499e-99dd-313b1ef092a9, ntarget=32, disabled=0, leader=2, version=1
 	Pool space info:
 	- Target(VOS) count:32
@@ -849,10 +845,10 @@ bring-up DAOS servers and clients.
 	--------- ------
 	3 stop OK
 
-	$ daos pool list-cont --pool=$DAOS_POOL
+	$ daos pool list-cont $DAOS_POOL
 	cf2a95ce-9910-4d5e-814c-cafb0a7f0944
 
-	$ dmg pool query --pool=$DAOS_POOL
+	$ dmg pool query $DAOS_POOL
 	Pool 70f73efc-848e-4f6e-b4fd-909bcf9bd427,
 	ntarget=32,
 	disabled=8,
@@ -893,7 +889,9 @@ bring-up DAOS servers and clients.
 
 ### Run mpirun mdtest with rebuild
 
-	$ dmg pool create --size=50G
+	$ export DAOS_POOL="mypool1"
+	$ export DAOS_CONT="mycont"
+	$ dmg pool create --size=50G $DAOS_POOL
 	Creating DAOS pool with automatic storage allocation: 50 GB NVMe + 6.00% SCM
 	Pool created with 100.00% SCM/NVMe ratio
 	-----------------------------------------
@@ -904,7 +902,7 @@ bring-up DAOS servers and clients.
 	 SCM : 50 GB (12 GB / rank)
 	 NVMe : 0 B (0 B / rank)
 
-	$ daos cont create --pool=$DAOS_POOL --type=POSIX --oclass=RP_3G1 --properties=rf:2
+	$ daos cont create --label $DAOS_CONT --type POSIX --oclass RP_3G1 --properties rf:2 $DAOS_POOL
 	Successfully created container d71ff6a5-15a5-43fe-b829-bef9c65b9ccb
 
 	$ /usr/lib64/mpich/bin/mpirun -host boro-8 -np 30 mdtest -a DFS -z 0 -F -C -i 100 -n 1667 -e 4096 -d / -w 4096 --dfs.chunk_size 1048576 --dfs.cont $DAOS_CONT --dfs.destroy --dfs.dir_oclass RP_3G1 --dfs.group daos_server --dfs.oclass RP_3G1 --dfs.pool $DAOS_POOL
@@ -946,14 +944,14 @@ bring-up DAOS servers and clients.
 ## Clean-Up
 
 	# pool reintegrate
-	$ dmg pool reintegrate --pool=$DAOS_POOL --rank=2
+	$ dmg pool reintegrate $DAOS_POOL --rank=2
 	Reintegration command succeeded
 
 	# destroy container
-	$ daos container destroy --pool=$DAOS_POOL --cont=$DAOS_CONT
+	$ daos container destroy $DAOS_POOL $DAOS_CONT
 
 	# destroy pool
-	$ dmg pool destroy --pool=$DAOS_POOL
+	$ dmg pool destroy $DAOS_POOL
 	Pool-destroy command succeeded
 
 	# stop clients

--- a/docs/admin/pool_operations.md
+++ b/docs/admin/pool_operations.md
@@ -40,7 +40,7 @@ $ dmg pool create --help
 [create command options]
       -g, --group=      DAOS pool to be owned by given group, format name@domain
       -u, --user=       DAOS pool to be owned by given user, format name@domain
-      -p, --label=      Unique label for pool
+      -p, --label=      Unique label for pool (deprecated, use positional argument)
       -P, --properties= Pool properties to be set
       -a, --acl-file=   Access Control List file path for DAOS pool
       -z, --size=       Total size of DAOS pool (auto)
@@ -55,7 +55,7 @@ $ dmg pool create --help
 The typical output of this command is as follows:
 
 ```bash
-$ dmg pool create --size 50GB --label tank
+$ dmg pool create --size 50GB tank
 Creating DAOS pool with automatic storage allocation: 50 GB NVMe + 6.00% SCM
 Pool created with 6.00% SCM/NVMe ratio
 -----------------------------------------
@@ -218,7 +218,7 @@ Rebuild space ratio (space_rb)  0%
 All properties can be specified when creating the pool.
 
 ```bash
-$ dmg pool create --size 50GB --label tank2 --properties reclaim:disabled
+$ dmg pool create --size 50GB --properties reclaim:disabled tank2
 Creating DAOS pool with automatic storage allocation: 50 GB NVMe + 6.00% SCM
 Pool created with 100.00% SCM/NVMe ratio
 -----------------------------------------
@@ -469,7 +469,7 @@ data would not be integrated into a rebuild and would be lost.
 To drain a target from a pool:
 
 ```bash
-$ dmg pool drain --rank=${rank} --target-idx=${idx1},${idx2},${idx3} <pool_label>
+$ dmg pool drain --rank=${rank} --target-idx=${idx1},${idx2},${idx3} $DAOS_POOL
 ```
 
 The pool target drain command accepts 2 parameters:
@@ -486,7 +486,7 @@ The operator can either reintegrate specific targets for an engine rank by
 supplying a target idx list, or reintegrate an entire rank by omitting the list.
 
 ```
-$ dmg pool reintegrate --pool=${puuid} --rank=${rank} --target-idx=${idx1},${idx2},${idx3}
+$ dmg pool reintegrate $DAOS_POOL --rank=${rank} --target-idx=${idx1},${idx2},${idx3}
 ```
 
 The pool reintegrate command accepts 3 parameters:
@@ -509,7 +509,7 @@ Target (rank 5 idx 1) is down.
 These should be the same values used when reintegrating the targets.
 
 ```
-$ dmg pool reintegrate --rank=5 --target-idx=0,1 <pool_label>
+$ dmg pool reintegrate $DAOS_POOL --rank=5 --target-idx=0,1
 ```
 
 !!! warning
@@ -536,7 +536,7 @@ This will automatically trigger a server rebalance operation where objects
 within the extended pool will be rebalanced across the new storage.
 
 ```
-$ dmg pool extend --ranks=${rank1},${rank2}... <pool_label>
+$ dmg pool extend $DAOS_POOL --ranks=${rank1},${rank2}...
 ```
 
 The pool extend command accepts one required parameter which is a comma

--- a/docs/admin/troubleshooting.md
+++ b/docs/admin/troubleshooting.md
@@ -305,6 +305,114 @@ sudo ipcrm -M 0x10242049
 ### Applications run slow
 Verify if you're using Infiniband for `fabric_iface`: in the server config. The IO will be significantly slower with Ethernet.
 
+## Common Errors and Workarounds
+
+### Use dmg command without daos_admin privilege
+
+	# Error message or timeout after dmg system query
+	$ dmg system query
+	ERROR: dmg: Unable to load Certificate Data: could not load cert: stat /etc/daos/certs/admin.crt: no such file or directory
+
+	# Workaround
+
+	# 1. Make sure the admin-host /etc/daos/daos_control.yml is correctly configured.
+		# including:
+			# hostlist: <daos_server_lists>
+			# port: <port_num>
+			# transport\config:
+				# allow_insecure: <true/false>
+				# ca\cert: /etc/daos/certs/daosCA.crt
+				# cert: /etc/daos/certs/admin.crt
+				# key: /etc/daos/certs/admin.key
+
+	# 2. Make sure the admin-host allow_insecure mode matches the applicable servers.
+
+### use daos command before daos_agent started
+
+	$ daos cont create $DAOS_POOL
+	daos ERR  src/common/drpc.c:217 unixcomm_connect() Failed to connect to /var/run/daos_agent/daos_agent.sock, errno=2(No such file or directory)
+	mgmt ERR  src/mgmt/cli_mgmt.c:222 get_attach_info() failed to connect to /var/run/daos_agent/daos_agent.sock DER_MISC(-1025): 'Miscellaneous error'
+	failed to initialize daos: Miscellaneous error (-1025)
+
+
+	# Work around to check for daos_agent certification and start daos_agent
+		#check for /etc/daos/certs/daosCA.crt, agent.crt and agent.key
+		$ sudo systemctl enable daos_agent.service
+		$ sudo systemctl start daos_agent.service
+
+### use daos command with invalid or wrong parameters
+
+	# Lack of providing daos pool_uuid
+	$ daos pool list-cont
+	pool UUID required
+	rc: 2
+	daos command (v1.2), libdaos 1.2.0
+	usage: daos RESOURCE COMMAND [OPTIONS]
+	resources:
+			  pool             pool
+			  container (cont) container
+			  filesystem (fs)  copy to and from a POSIX filesystem
+			  object (obj)     object
+			  shell            Interactive obj ctl shell for DAOS
+			  version          print command version
+			  help             print this message and exit
+	use 'daos help RESOURCE' for resource specifics
+
+	# Invalid sub-command cont-list
+	$ daos pool cont-list --pool=$DAOS_POOL
+	invalid pool command: cont-list
+	error parsing command line arguments
+	daos command (v1.2), libdaos 1.2.0
+	usage: daos RESOURCE COMMAND [OPTIONS]
+	resources:
+			  pool             pool
+			  container (cont) container
+			  filesystem (fs)  copy to and from a POSIX filesystem
+			  object (obj)     object
+			  shell            Interactive obj ctl shell for DAOS
+			  version          print command version
+			  help             print this message and exit
+	use 'daos help RESOURCE' for resource specifics
+
+	# Working daos pool command
+	$ daos pool list-cont --pool=$DAOS_POOL
+	bc4fe707-7470-4b7d-83bf-face75cc98fc
+
+## dmg pool create failed due to no space
+
+	$ dmg pool create --size=50G mypool
+	Creating DAOS pool with automatic storage allocation: 50 GB NVMe + 6.00% SCM
+	ERROR: dmg: pool create failed: DER_NOSPACE(-1007): No space on storage target
+
+	# Workaround: dmg storage query scan to find current available storage
+		dmg storage query usage
+		Hosts  SCM-Total SCM-Free SCM-Used NVMe-Total NVMe-Free NVMe-Used
+		-----  --------- -------- -------- ---------- --------- ---------
+		boro-8 17 GB     6.0 GB   65 %     0 B        0 B       N/A
+
+		$ dmg pool create --size=2G mypool
+		Creating DAOS pool with automatic storage allocation: 2.0 GB NVMe + 6.00% SCM
+		Pool created with 100.00% SCM/NVMe ratio
+		-----------------------------------------
+		  UUID          : b5ce2954-3f3e-4519-be04-ea298d776132
+		  Service Ranks : 0
+		  Storage Ranks : 0
+		  Total Size    : 2.0 GB
+		  SCM           : 2.0 GB (2.0 GB / rank)
+		  NVMe          : 0 B (0 B / rank)
+
+		$ dmg storage query usage
+		Hosts  SCM-Total SCM-Free SCM-Used NVMe-Total NVMe-Free NVMe-Used
+		-----  --------- -------- -------- ---------- --------- ---------
+		boro-8 17 GB     2.9 GB   83 %     0 B        0 B       N/A
+
+### dmg pool destroy timeout
+
+	# dmg pool destroy Timeout or failed due to pool has active container(s)
+	# Workaround pool destroy --force option
+
+		$ dmg pool destroy --pool=$DAOS_POOL --force
+		Pool-destroy command succeeded
 
 ## Bug Report
 

--- a/docs/testing/autotest.md
+++ b/docs/testing/autotest.md
@@ -7,7 +7,7 @@ a container, then reading and writing to the container.
 First of all, a pool must be created with dmg to run autotest:
 
 ```sh
-$ dmg pool create --size=50G --label autotest_pool
+$ dmg pool create --size=50G autotest_pool
 
 # sample output
 Creating DAOS pool with automatic storage allocation: 50 GB NVMe + 6.00% SCM

--- a/docs/user/container.md
+++ b/docs/user/container.md
@@ -58,7 +58,7 @@ are stored in an extended attribute of the target file or directory that can
 then be used in subsequent command invocations to identify the container.
 
 ```bash
-$ daos cont create tank --path /tmp/mycontainer --type=POSIX --oclass=SX
+$ daos cont create tank --label mycont --path /tmp/mycontainer --type POSIX --oclass=SX
   Container UUID : 30e5d364-62c9-4ddf-9284-1021359455f2
   Container Type : POSIX
 
@@ -589,7 +589,9 @@ permission in the container's ACL.
 To create a container labeled mycont in a pool labeled tank with a custom ACL:
 
 ```bash
-$ daos cont create <pool_label> --label <container_label> --acl-file=<path>
+$ export DAOS_POOL="tank"
+$ export DAOS_CONT="mycont"
+$ daos cont create $DAOS_POOL --label $DAOS_CONT --acl-file=<path>
 ```
 
 The ACL file format is detailed in the
@@ -600,7 +602,7 @@ The ACL file format is detailed in the
 To view a container's ACL:
 
 ```bash
-$ daos cont get-acl <pool_label> <container_label>
+$ daos cont get-acl $DAOS_POOL $DAOS_CONT
 ```
 
 The output is in the same string format used in the ACL file during creation,
@@ -616,7 +618,7 @@ noted above for container creation.
 To replace a container's ACL with a new ACL:
 
 ```bash
-$ daos cont overwrite-acl <pool_label> <container_label> --acl-file=<path>
+$ daos cont overwrite-acl $DAOS_POOL $DAOS_CONT --acl-file=<path>
 ```
 
 #### Adding and Updating ACEs
@@ -624,13 +626,13 @@ $ daos cont overwrite-acl <pool_label> <container_label> --acl-file=<path>
 To add or update multiple entries in an existing container ACL:
 
 ```bash
-$ daos cont update-acl <pool_label> <container_label> --acl-file=<path>
+$ daos cont update-acl $DAOS_POOL $DAOS_CONT --acl-file=<path>
 ```
 
 To add or update a single entry in an existing container ACL:
 
 ```bash
-$ daos cont update-acl <pool_label> <container_label> --entry <ACE>
+$ daos cont update-acl $DAOS_POOL $DAOS_CONT --entry <ACE>
 ```
 
 If there is no existing entry for the principal in the ACL, the new entry is
@@ -642,7 +644,7 @@ is replaced with the new one.
 To delete an entry for a given principal in an existing container ACL:
 
 ```bash
-$ daos cont delete-acl <pool_label> <container_label> --principal=<principal>
+$ daos cont delete-acl $DAOS_POOL $DAOS_CONT --principal=<principal>
 ```
 
 The `principal` argument refers to the
@@ -698,7 +700,7 @@ creating the container. However, a specific user and/or group may be specified
 at container creation time.
 
 ```bash
-$ daos cont create <pool_label> <container_label> --user=<owner-user> --group=<owner-group>
+$ daos cont create $DAOS_POOL --label $DAOS_CONT --user=<owner-user> --group=<owner-group>
 ```
 
 The user and group names are case sensitive and must be formatted as
@@ -709,13 +711,13 @@ The user and group names are case sensitive and must be formatted as
 To change the owner user:
 
 ```bash
-$ daos cont set-owner <pool_label> <container_label> --user=<owner-user>
+$ daos cont set-owner $DAOS_POOL $DAOS_CONT --user=<owner-user>
 ```
 
 To change the owner group:
 
 ```bash
-$ daos cont set-owner <pool_label> <container_label> --group=<owner-group>
+$ daos cont set-owner $DAOS_POOL $DAOS_CONT --group=<owner-group>
 ```
 
 The user and group names are case sensitive and must be formatted as

--- a/docs/user/filesystem.md
+++ b/docs/user/filesystem.md
@@ -188,7 +188,7 @@ itself. Files can be accessed by simply concatenating the mount point and the
 name of the file, relative to the root of the container.
 
 ```bash
-$ daos cont create tank -l mycont -t POSIX
+$ daos cont create tank --label mycont --type POSIX
   Container UUID : 8a8f08bb-5034-41e8-b7ae-0cdce347c558
   Container Label: mycont
   Container Type : POSIX
@@ -213,7 +213,7 @@ accessed by the path `<mount point>/<container uuid>`. The container uuid
 will have to be provided from an external source.
 
 ```bash
-$ daos cont create tank -l mycont2 -t POSIX
+$ daos cont create tank --label mycont2 --type POSIX
   Container UUID : 0db21789-5372-4f2a-b7bc-14c0a5e968df
   Container Label: mycont2
   Container Type : POSIX
@@ -300,7 +300,7 @@ $ dfuse -m /tmp/dfuse --pool tank --cont mycont
 $ cd /tmp/dfuse/
 $ ls
 foo
-$ daos cont create tank -l mycont3 --type POSIX --path ./link_to_externa_container
+$ daos cont create tank --label mycont3 --type POSIX --path ./link_to_externa_container
   Container UUID : 933944a9-ddf2-491a-bdbf-4442f0437d56
   Container Label: mycont3
   Container Type : POSIX

--- a/docs/user/mpi-io.md
+++ b/docs/user/mpi-io.md
@@ -108,7 +108,7 @@ container uuids/labels.
 Create a container with a path on dfuse or lustre, or any file system that supports extended
 attributes:
 ```bash
-daos cont create mypool --path=/mnt/dfuse/ --type=POSIX
+daos cont create mypool --label mycont --path=/mnt/dfuse/ --type POSIX
 ```
 
 Then using that path, one can start creating files using the DAOS MPIIO driver by just appending

--- a/docs/user/spark.md
+++ b/docs/user/spark.md
@@ -73,8 +73,10 @@ If the DAOS pool and container have not been created, we can use the following
 command to create them and get the pool UUID and container UUID.
 
 ```bash
-$ dmg pool create --scm-size=<scm size> --nvme-size=<nvme size>
-$ daos cont create --pool <pool UUID> --type POSIX
+$ export DAOS_POOL="mypool"
+$ export DAOS_CONT="mycont"
+$ dmg pool create --scm-size=<scm size> --nvme-size=<nvme size> $DAOS_POOL
+$ daos cont create --label $DAOS_CONT --type POSIX $DAOS_POOL
 ```
 
 After that, configure `daos-site.xml` with the pool and container created.
@@ -173,12 +175,12 @@ DAOS UNS method, `DaosUns.create()`. The "\[sub path\]" is optional. You can
 create the UNS path with below command.
 
 ```bash
-$ daos cont create --pool <pool UUID> -path <your path> --type=POSIX
+$ daos cont create --label $DAOS_CONT --path <your_path> --type POSIX $DAOS_POOL
 ```
 Or
 
 ```bash
-$ java -Dpath="your path" -Dpool_id="your pool uuid" -cp ./daos-java-<version>-shaded.jar io.daos.dfs.DaosUns create
+$ java -Dpath="your_path" -Dpool_id=$DAOS_POOL -cp ./daos-java-<version>-shaded.jar io.daos.dfs.DaosUns create
 ```
 
 After creation, you can use below command to see what DAOS properties set to
@@ -242,8 +244,10 @@ Then replicate `daos-site.xml`, `core-site.xml`, `yarn-site.xml` and
 
 #### Known Issues
 
-If you use Omni-path PSM2 provider in DAOS, you'll get connection issue in
+If you use Omni-Path PSM2 provider in DAOS, you'll get connection issue in
 Yarn container due to PSM2 resource not being released properly in time.
+The PSM2 provides has known issues with DAOS and is not supported in
+production environments.
 
 ### Tune More Configurations
 


### PR DESCRIPTION
make documentation of the dmg and daos commands consistent
to use positional arguments for pools and containers

include container labels in the examples

Signed-off-by: Michael Hennecke <michael.hennecke@intel.com>