### PR TITLE
DAOS-9327 ci: Param to enable FI on RC

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -72,9 +72,9 @@ pipeline {
         string(name: 'TestTag',
                defaultValue: "",
                description: 'Test-tag to use for this run (i.e. pr, daily_regression, full_regression, etc.)')
-        booleanParam(name: 'FIEnabledRC',
-               defaultValue: false,
-               description: 'Enable Fault Injection on a release candidate (it\'s always enabled on non-release candidate builds)')
+        string(name: 'BuildType',
+               defaultValue: "",
+               description: 'Type of build.  (I.e. dev or release).  Defaults to release on an RC or dev otherwise.')
         string(name: 'TestRepeat',
                defaultValue: "",
                description: 'Test-repeat to use for this run.  Specifies the ' +

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -72,6 +72,9 @@ pipeline {
         string(name: 'TestTag',
                defaultValue: "",
                description: 'Test-tag to use for this run (i.e. pr, daily_regression, full_regression, etc.)')
+        booleanParam(name: 'FIEnabledRC',
+               defaultValue: false,
+               description: 'Enable Fault Injection on a release candidate (it\'s always enabled on non-release candidate builds)')
         string(name: 'TestRepeat',
                defaultValue: "",
                description: 'Test-repeat to use for this run.  Specifies the ' +

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -74,7 +74,7 @@ pipeline {
                description: 'Test-tag to use for this run (i.e. pr, daily_regression, full_regression, etc.)')
         string(name: 'BuildType',
                defaultValue: "",
-               description: 'Type of build.  (I.e. dev or release).  Defaults to release on an RC or dev otherwise.')
+               description: 'Type of build.  Passed to scons as BUILD_TYPE.  (I.e. dev, release, debug, etc.).  Defaults to release on an RC or dev otherwise.')
         string(name: 'TestRepeat',
                defaultValue: "",
                description: 'Test-repeat to use for this run.  Specifies the ' +

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+daos (2.1.100-16) unstable; urgency=medium
+  [ Brian J. Murrell ]
+  * NOOP change to keep in parity with RPM version
+
+ -- Brian J. Murrell <brian.murrell@intel.com>  Thu, 16 Dec 2021 15:08:11 -0400
+
 daos (2.1.100-15) unstable; urgency=medium
   [ Brian J. Murrell ]
   * NOOP change to keep in parity with RPM version

--- a/utils/rpms/daos.spec
+++ b/utils/rpms/daos.spec
@@ -15,7 +15,7 @@
 
 Name:          daos
 Version:       2.1.100
-Release:       15%{?relval}%{?dist}
+Release:       16%{?relval}%{?dist}
 Summary:       DAOS Storage Engine
 
 License:       BSD-2-Clause-Patent
@@ -120,6 +120,7 @@ BuildRequires: cunit-devel
 BuildRequires: ipmctl-devel
 BuildRequires: python3-devel
 BuildRequires: python3-distro
+BuildRequires: python-rpm-macros
 BuildRequires: lua-lmod
 BuildRequires: systemd-rpm-macros
 %if 0%{?is_opensuse}
@@ -538,6 +539,10 @@ getent passwd daos_agent >/dev/null || useradd -s /sbin/nologin -r -g daos_agent
 # No files in a shim package
 
 %changelog
+* Thu Dec 16 2021 Brian J. Murrell <brian.murrell@intel.com> 2.1.100-16
+- Add BR: python-rpm-macros for Leap 15 as python3-base dropped that
+  as a R:
+
 * Sat Dec 11 2021 Brian J. Murrell <brian.murrell@intel.com> 2.1.100-15
 - Create a shim package to allow daos openmpi packages built with the
   distribution openmpi to install on MOFED systems


### PR DESCRIPTION
For release candidate testing, allow a build to enable fault injection,
which is usually disabled for RC runs.