### PR TITLE
DAOS-9328 vos: Add aggregation/discard to vos_perf

### DIFF
--- a/src/tests/perf_common.c
+++ b/src/tests/perf_common.c
@@ -679,6 +679,9 @@ show_result(struct pf_param *param, uint64_t start, uint64_t end,
 		if (strcmp(test_name, "QUERY") == 0) {
 			total = ts_ctx.tsc_mpi_size * param->pa_iteration *
 				ts_obj_p_cont;
+		} else if (strcmp(test_name, "AGGREGATE") == 0 ||
+			   strcmp(test_name, "DISCARD") == 0) {
+			total = ts_ctx.tsc_mpi_size * param->pa_iteration;
 		} else if (strcmp(test_name, "PUNCH") == 0) {
 			total = ts_ctx.tsc_mpi_size * param->pa_iteration * ts_obj_p_cont;
 			if (param->pa_rw.dkey_flag)

--- a/src/tests/vos_perf.c
+++ b/src/tests/vos_perf.c
@@ -467,6 +467,40 @@ pf_fetch(struct pf_test *ts, struct pf_param *param)
 }
 
 static int
+pf_aggregate(struct pf_test *ts, struct pf_param *param)
+{
+	daos_epoch_t epoch = crt_hlc_get();
+	daos_epoch_range_t	epr = {0, ++epoch};
+	int			rc = 0;
+	uint64_t		start = 0;
+
+	TS_TIME_START(&param->pa_duration, start);
+
+	rc = vos_aggregate(ts_ctx.tsc_coh, &epr, NULL, NULL, NULL, true);
+
+	TS_TIME_END(&param->pa_duration, start);
+
+	return rc;
+}
+
+static int
+pf_discard(struct pf_test *ts, struct pf_param *param)
+{
+	daos_epoch_t epoch = crt_hlc_get();
+	daos_epoch_range_t	epr = {0, ++epoch};
+	int			rc = 0;
+	uint64_t		start = 0;
+
+	TS_TIME_START(&param->pa_duration, start);
+
+	rc = vos_discard(ts_ctx.tsc_coh, NULL, &epr, NULL, NULL);
+
+	TS_TIME_END(&param->pa_duration, start);
+
+	return rc;
+}
+
+static int
 pf_verify(struct pf_test *ts, struct pf_param *param)
 {
 	int	rc;
@@ -570,6 +604,12 @@ pf_parse_iterate(char *str, struct pf_param *pa, char **strp)
 	return pf_parse_common(str, pa, pf_parse_iterate_cb, strp);
 }
 
+static int
+pf_parse_aggregate(char *str, struct pf_param *pa, char **strp)
+{
+	return pf_parse_common(str, pa, NULL, strp);
+}
+
 /* predefined test cases */
 struct pf_test pf_tests[] = {
 	{
@@ -607,6 +647,18 @@ struct pf_test pf_tests[] = {
 		.ts_name	= "PUNCH",
 		.ts_parse	= pf_parse_rw,
 		.ts_func	= pf_punch,
+	},
+	{
+		.ts_code	= 'A',
+		.ts_name	= "AGGREGATE",
+		.ts_parse	= pf_parse_aggregate,
+		.ts_func	= pf_aggregate,
+	},
+	{
+		.ts_code	= 'D',
+		.ts_name	= "DISCARD",
+		.ts_parse	= pf_parse_aggregate,
+		.ts_func	= pf_discard,
 	},
 	{
 		.ts_code	= 0,


### PR DESCRIPTION
Enable timing a complete aggregation/discard pass in vos_perf
The intention here is to create a benchmark for testing DSA
but also can be useful for measuring general aggregation
performance as we try to improve it.

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>