### PR TITLE
DAOS-9327 ci: Param to enable FI on RC

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -71,6 +71,9 @@ pipeline {
         string(name: 'TestTag',
                defaultValue: "",
                description: 'Test-tag to use for this run (i.e. pr, daily_regression, full_regression, etc.)')
+        string(name: 'BuildType',
+               defaultValue: "",
+               description: 'Type of build.  Passed to scons as BUILD_TYPE.  (I.e. dev, release, debug, etc.).  Defaults to release on an RC or dev otherwise.')
         string(name: 'TestRepeat',
                defaultValue: "",
                description: 'Test-repeat to use for this run.  Specifies the ' +

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+daos (2.0.0-3) unstable; urgency=medium
+  [ Brian J. Murrell ]
+  * NOOP change to keep in parity with RPM version
+
+ -- Brian J. Murrell <brian.murrell@intel.com>  Thu, 16 Dec 2021 15:08:11 -0400
+
 daos (2.0.0-2) unstable; urgency=medium
   [ Jeff Olivier ]
   * Version bump for 2.0.0 RC2

--- a/utils/rpms/daos.spec
+++ b/utils/rpms/daos.spec
@@ -14,7 +14,7 @@
 
 Name:          daos
 Version:       2.0.0
-Release:       2%{?relval}%{?dist}
+Release:       3%{?relval}%{?dist}
 Summary:       DAOS Storage Engine
 
 License:       BSD-2-Clause-Patent
@@ -119,6 +119,7 @@ BuildRequires: cunit-devel
 BuildRequires: ipmctl-devel
 BuildRequires: python3-devel
 BuildRequires: python3-distro
+BuildRequires: python-rpm-macros
 BuildRequires: lua-lmod
 BuildRequires: systemd-rpm-macros
 %if 0%{?is_opensuse}
@@ -516,6 +517,10 @@ getent passwd daos_agent >/dev/null || useradd -s /sbin/nologin -r -g daos_agent
 # No files in a meta-package
 
 %changelog
+* Thu Dec 16 2021 Brian J. Murrell <brian.murrell@intel.com> 2.0.0-3
+- Add BR: python-rpm-macros for Leap 15 as python3-base dropped that
+  as a R:
+
 * Tue Dec 14 2021 Jeff Olivier <jeffrey.v.olivier@intel.com> 2.0.0-2
 - Version bump to 2.0.0-2
 


### PR DESCRIPTION
For release candidate testing, allow a build to enable fault injection,
which is usually disabled for RC runs.