### PR TITLE
DAOS-9223 doc: fix CaRT self_test example

### DIFF
--- a/docs/testing/cartselftest.md
+++ b/docs/testing/cartselftest.md
@@ -7,14 +7,10 @@ in order to obtain the fabric environment from the running
 `daos_agent` process. See `self_test --help` for details.
 
 	# set env
-	SHARED_DIR=<shared dir by all nodes>
 	export FI_UNIVERSE_SIZE=2048
 
-	# generate the attach info file
-	daos_agent -o /etc/daos/daos_agent.yml -l $SHARED_DIR/daos_agent.log dump-attachinfo -o $SHARED_DIR/daos_server.attach_info_tmp
-
 	# for 4 servers --endpoint 0-3:0-1 ranks:tags.
-	self_test --path $SHARED_DIR --group-name daos_server --use-daos-agent-env --endpoint 0-1:0-1
+	self_test --group-name daos_server --use-daos-agent-env --endpoint 0-1:0-1
 
 	Adding endpoints:
 	  ranks: 0-1 (# ranks = 2)

--- a/docs/testing/cartselftest.md
+++ b/docs/testing/cartselftest.md
@@ -1,19 +1,20 @@
-# Run CaRT Self_test
+# Run CaRT self\_test
 
-On the client, run the cart *self_test* to verify basic network
+On the client, run the CaRT `self_test` to verify basic network
 connectivity.
+It is advisable to use the `-u` (or `--use-daos-agent-env`) option
+in order to obtain the fabric environment from the running
+`daos_agent` process. See `self_test --help` for details.
 
 	# set env
 	SHARED_DIR=<shared dir by all nodes>
 	export FI_UNIVERSE_SIZE=2048
-	export OFI_INTERFACE=ib0
 
 	# generate the attach info file
 	daos_agent -o /etc/daos/daos_agent.yml -l $SHARED_DIR/daos_agent.log dump-attachinfo -o $SHARED_DIR/daos_server.attach_info_tmp
 
-	# selt_test --help for more details on params
 	# for 4 servers --endpoint 0-3:0-1 ranks:tags.
-	self_test --path $SHARED_DIR --group-name daos_server --endpoint 0-1:0-1
+	self_test --path $SHARED_DIR --group-name daos_server --use-daos-agent-env --endpoint 0-1:0-1
 
 	Adding endpoints:
 	  ranks: 0-1 (# ranks = 2)


### PR DESCRIPTION
DAOS-9223 doc: fix CaRT self_test example

add --use-daos-agent-env to self_test example
remove dump-attachinfo (redundant when using --use-daos-agent-env)

Doc-only: true
Signed-off-by: Michael Hennecke <michael.hennecke@intel.com>