### PR TITLE
DAOS-9328 test: Skip tests that require fault injection when disabled

### DIFF
--- a/src/tests/suite/daos_degrade_ec.c
+++ b/src/tests/suite/daos_degrade_ec.c
@@ -457,6 +457,8 @@ degrade_ec_partial_update_agg(void **state)
 	char		*data;
 	char		*verify_data;
 
+	FAULT_INJECTION_REQUIRED();
+
 	if (!test_runable(arg, 6))
 		return;
 

--- a/src/tests/suite/daos_obj.c
+++ b/src/tests/suite/daos_obj.c
@@ -3191,6 +3191,8 @@ fetch_replica_unavail(void **state)
 	d_rank_t		 rank = 2;
 	char			*buf;
 
+	FAULT_INJECTION_REQUIRED();
+
 	/* needs at lest 4 targets, exclude one and another 3 raft nodes */
 	if (!test_runable(arg, 4))
 		skip();
@@ -3762,6 +3764,8 @@ io_pool_map_refresh_trigger(void **state)
 	d_rank_t	leader;
 	d_rank_t	rank = 1;
 
+	FAULT_INJECTION_REQUIRED();
+
 	/* needs at lest 2 targets */
 	if (!test_runable(arg, 2))
 		skip();
@@ -4092,6 +4096,8 @@ io_fetch_retry_another_replica(void **state)
 	struct ioreq	 req;
 	char		fetch_buf[32];
 	char		update_buf[32];
+
+	FAULT_INJECTION_REQUIRED();
 
 	/* needs at lest 2 targets */
 	if (!test_runable(arg, 2))

--- a/src/tests/suite/daos_obj_ec.c
+++ b/src/tests/suite/daos_obj_ec.c
@@ -435,6 +435,8 @@ ec_partial_update_agg(void **state)
 	char		*data;
 	char		*verify_data;
 
+	FAULT_INJECTION_REQUIRED();
+
 	if (!test_runable(arg, 6))
 		return;
 
@@ -482,6 +484,8 @@ ec_cross_cell_partial_update_agg(void **state)
 	char		*data;
 	char		*verify_data;
 	daos_size_t	update_size = 500000;
+
+	FAULT_INJECTION_REQUIRED();
 
 	if (!test_runable(arg, 6))
 		return;
@@ -535,6 +539,8 @@ ec_full_partial_update_agg(void **state)
 	int		data_nr;
 	daos_size_t	full_update_size;
 	daos_size_t	partial_update_size;
+
+	FAULT_INJECTION_REQUIRED();
 
 	if (!test_runable(arg, 6))
 		return;
@@ -598,6 +604,8 @@ ec_partial_full_update_agg(void **state)
 	int		data_nr;
 	daos_size_t	full_update_size;
 	daos_size_t	partial_update_size;
+
+	FAULT_INJECTION_REQUIRED();
 
 	if (!test_runable(arg, 6))
 		return;
@@ -998,6 +1006,8 @@ ec_partial_stripe_snapshot_internal(void **state, int data_size)
 	char		*data;
 	char		*verify_data;
 	int		i;
+
+	FAULT_INJECTION_REQUIRED();
 
 	if (!test_runable(arg, 6))
 		return;


### PR DESCRIPTION
Some core tests require fault injection to pass.  Skip the tests if
fault injection is not enabled.

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>