### PR TITLE
DAOS-9335 test: Add log analysis looking for use-after-free issues.

### DIFF
--- a/src/object/srv_ec_aggregate.c
+++ b/src/object/srv_ec_aggregate.c
@@ -2569,8 +2569,10 @@ again:
 
 	if (rc == 0 && ec_agg_param->ap_obj_skipped == 0) {
 		cont->sc_ec_agg_eph = max(cont->sc_ec_agg_eph, epr->epr_hi);
-		if (!cont->sc_stopping && cont->sc_ec_query_agg_eph)
+		if (!cont->sc_stopping && cont->sc_ec_query_agg_eph) {
+			D_DEBUG(DB_EPC, "Writing to %p\n", cont->sc_ec_query_agg_eph);
 			*cont->sc_ec_query_agg_eph = cont->sc_ec_agg_eph;
+		}
 	}
 
 	return rc;

--- a/src/tests/ftest/cart/util/cart_logparse.py
+++ b/src/tests/ftest/cart/util/cart_logparse.py
@@ -331,6 +331,20 @@ class LogLine():
         """Return True if line is record of fault injection for memory allocation"""
         return self._is_type(['fault_id', '0,'], trace=False)
 
+    def check_addr(self):
+        """Return if this line represents a memory address to be verified
+
+        Returns either None, or a hex string of a memory address.
+        """
+        try:
+            if self.function != 'cont_ec_aggregate_cb':
+                return None
+        except AttributeError:
+            return None
+        if not self._is_type(['Writing', 'to'], trace=False):
+            return None
+        return self._fields[4]
+
     def is_fi_alloc_fail(self):
         """Return True if line is showing failed memory allocation"""
         return self._is_type(['out', 'of', 'memory'], trace=False)


### PR DESCRIPTION
Add annotations to ec_aggregate and log-parsing code to check them
to see if we can identify any use-after free of the memory region.

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>
