### PR TITLE
DAOS-8905 control: Add sysfs net device detection

### DIFF
--- a/src/control/common/cmdutil/topology.go
+++ b/src/control/common/cmdutil/topology.go
@@ -14,7 +14,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/daos-stack/daos/src/control/lib/hardware"
-	"github.com/daos-stack/daos/src/control/lib/hardware/hwloc"
+	"github.com/daos-stack/daos/src/control/lib/hardware/hwprov"
 	"github.com/daos-stack/daos/src/control/logging"
 )
 
@@ -37,7 +37,7 @@ func (cmd *DumpTopologyCmd) Execute(_ []string) error {
 	}
 
 	log := logging.NewCommandLineLogger()
-	hwProv := hwloc.NewProvider(log)
+	hwProv := hwprov.DefaultTopologyProvider(log)
 	topo, err := hwProv.GetTopology(context.Background())
 	if err != nil {
 		return err

--- a/src/control/common/test_utils.go
+++ b/src/control/common/test_utils.go
@@ -177,13 +177,28 @@ func DefaultCmpOpts() []cmp.Option {
 	}
 }
 
-// CmpOptIgnoreField creates a cmp.Option that allows go-cmp comparisons to ignore a specific field.
-func CmpOptIgnoreField(field string) cmp.Option {
+// CmpOptIgnoreFieldAnyType creates a cmp.Option that allows go-cmp comparisons to ignore all
+// fields with a specific name in any type.
+func CmpOptIgnoreFieldAnyType(field string) cmp.Option {
 	return cmp.FilterPath(
 		func(p cmp.Path) bool {
 			return p.Last().String() == field || p.Last().String() == ("."+field)
 		},
 		cmp.Ignore())
+}
+
+// CmpOptEquateErrorMessages creates a cmp.Option that allows go-cmp to compare errors by message.
+func CmpOptEquateErrorMessages() cmp.Option {
+	areConcreteErrors := func(x, y interface{}) bool {
+		_, ok1 := x.(error)
+		_, ok2 := y.(error)
+		return ok1 && ok2
+	}
+	return cmp.FilterValues(areConcreteErrors, cmp.Comparer(func(x, y interface{}) bool {
+		xe := x.(error)
+		ye := y.(error)
+		return xe.Error() == ye.Error()
+	}))
 }
 
 // CreateTestDir creates a temporary test directory.

--- a/src/control/lib/control/auto_test.go
+++ b/src/control/lib/control/auto_test.go
@@ -993,9 +993,11 @@ func TestControl_AutoConfig_genConfig(t *testing.T) {
 			}
 
 			cmpOpts := []cmp.Option{
-				cmpopts.IgnoreUnexported(security.CertificateConfig{},
-					config.Server{}),
-				cmpopts.IgnoreUnexported(sysfs.Provider{}),
+				cmpopts.IgnoreUnexported(
+					security.CertificateConfig{},
+					config.Server{},
+					sysfs.Provider{},
+				),
 			}
 			cmpOpts = append(cmpOpts, defResCmpOpts()...)
 

--- a/src/control/lib/hardware/fabric_test.go
+++ b/src/control/lib/hardware/fabric_test.go
@@ -882,7 +882,7 @@ func TestHardware_NewFabricScanner(t *testing.T) {
 					MockFabricInterfaceProvider{},
 					MockNetDevClassProvider{},
 				),
-				common.CmpOptIgnoreField("log"),
+				common.CmpOptIgnoreFieldAnyType("log"),
 			); diff != "" {
 				t.Fatalf("(-want, +got)\n%s\n", diff)
 			}
@@ -1095,7 +1095,7 @@ func TestHardware_defaultFabricInterfaceSetBuilders(t *testing.T) {
 		cmp.AllowUnexported(OSDeviceBuilder{}),
 		cmp.AllowUnexported(MockFabricInterfaceProvider{}),
 		cmp.AllowUnexported(MockNetDevClassProvider{}),
-		common.CmpOptIgnoreField("log"),
+		common.CmpOptIgnoreFieldAnyType("log"),
 	); diff != "" {
 		t.Fatalf("(-want, +got)\n%s\n", diff)
 	}

--- a/src/control/lib/hardware/hwloc/bindings.go
+++ b/src/control/lib/hardware/hwloc/bindings.go
@@ -244,7 +244,19 @@ type object struct {
 func (o *object) name() string {
 	objName := C.GoString(o.cObj.name)
 	if objName == "" {
-		objName = fmt.Sprintf("%s %d", o.objTypeString(), o.osIndex())
+		var id string
+		switch o.objType() {
+		case objTypeBridge:
+			lo, hi, err := o.busRange()
+			if err != nil {
+				id = "(unknown range)"
+				break
+			}
+			id = fmt.Sprintf("%04x:[%02x-%02x]", lo.Domain, lo.Bus, hi.Bus)
+		default:
+			id = fmt.Sprintf("%d", o.osIndex())
+		}
+		objName = fmt.Sprintf("%s %s", o.objTypeString(), id)
 	}
 	return objName
 }
@@ -325,10 +337,12 @@ func (o *object) objTypeString() string {
 		return "core"
 	case objTypePCIDevice:
 		return "PCI device"
+	case objTypeBridge:
+		return "bridge"
 	case objTypeOSDevice:
 		return "OS device"
 	}
-	return "unknown object type"
+	return fmt.Sprintf("unknown object type %d (0x%x)", o.objType(), o.objType())
 }
 
 func (o *object) busRange() (*hardware.PCIAddress, *hardware.PCIAddress, error) {

--- a/src/control/lib/hardware/hwloc/provider.go
+++ b/src/control/lib/hardware/hwloc/provider.go
@@ -321,7 +321,7 @@ func (p *Provider) getDeviceNUMANodeID(dev *object, topo *topology) uint {
 		}
 	}
 
-	p.log.Debugf("Unable to determine NUMA socket ID. Using NUMA 0")
+	p.log.Debugf("Unable to determine NUMA socket ID for device %q, using NUMA 0", dev.name())
 	return 0
 
 }

--- a/src/control/lib/hardware/hwprov/defaults.go
+++ b/src/control/lib/hardware/hwprov/defaults.go
@@ -32,6 +32,7 @@ func DefaultTopologyProvider(log logging.Logger) hardware.TopologyProvider {
 func DefaultFabricInterfaceProviders(log logging.Logger) []hardware.FabricInterfaceProvider {
 	return []hardware.FabricInterfaceProvider{
 		libfabric.NewProvider(log),
+		sysfs.NewProvider(log),
 	}
 }
 

--- a/src/control/lib/hardware/hwprov/defaults.go
+++ b/src/control/lib/hardware/hwprov/defaults.go
@@ -16,7 +16,16 @@ import (
 
 // DefaultTopologyProvider gets the default hardware topology provider.
 func DefaultTopologyProvider(log logging.Logger) hardware.TopologyProvider {
-	return hwloc.NewProvider(log)
+	return hardware.NewTopologyFactory(
+		&hardware.WeightedTopologyProvider{
+			Provider: hwloc.NewProvider(log),
+			Weight:   100,
+		},
+		&hardware.WeightedTopologyProvider{
+			Provider: sysfs.NewProvider(log),
+			Weight:   90,
+		},
+	)
 }
 
 // DefaultFabricInterfaceProviders returns the default fabric interface providers.
@@ -27,8 +36,8 @@ func DefaultFabricInterfaceProviders(log logging.Logger) []hardware.FabricInterf
 }
 
 // DefaultNetDevClassProvider gets the default provider for the network device class.
-func DefaultNetDevClassProvider() hardware.NetDevClassProvider {
-	return sysfs.NewProvider()
+func DefaultNetDevClassProvider(log logging.Logger) hardware.NetDevClassProvider {
+	return sysfs.NewProvider(log)
 }
 
 // DefaultFabricScannerConfig gets a default FabricScanner configuration.
@@ -36,7 +45,7 @@ func DefaultFabricScannerConfig(log logging.Logger) *hardware.FabricScannerConfi
 	return &hardware.FabricScannerConfig{
 		TopologyProvider:         DefaultTopologyProvider(log),
 		FabricInterfaceProviders: DefaultFabricInterfaceProviders(log),
-		NetDevClassProvider:      DefaultNetDevClassProvider(),
+		NetDevClassProvider:      DefaultNetDevClassProvider(log),
 	}
 }
 

--- a/src/control/lib/hardware/hwprov/defaults_test.go
+++ b/src/control/lib/hardware/hwprov/defaults_test.go
@@ -24,12 +24,23 @@ func TestHwprov_DefaultTopologyProvider(t *testing.T) {
 	log, buf := logging.NewTestLogger(t.Name())
 	defer common.ShowBufferOnFailure(t, buf)
 
-	expResult := hwloc.NewProvider(log)
+	expResult := hardware.NewTopologyFactory(
+		&hardware.WeightedTopologyProvider{
+			Provider: hwloc.NewProvider(log),
+			Weight:   100,
+		},
+		&hardware.WeightedTopologyProvider{
+			Provider: sysfs.NewProvider(log),
+			Weight:   90,
+		},
+	)
 
 	result := DefaultTopologyProvider(log)
 
 	if diff := cmp.Diff(expResult, result,
+		cmp.AllowUnexported(hardware.TopologyFactory{}),
 		cmpopts.IgnoreUnexported(hwloc.Provider{}),
+		cmpopts.IgnoreUnexported(sysfs.Provider{}),
 	); diff != "" {
 		t.Fatalf("(-want, +got)\n%s\n", diff)
 	}
@@ -54,9 +65,12 @@ func TestHwprov_DefaultFabricInterfaceProvider(t *testing.T) {
 }
 
 func TestHwprov_DefaultNetDevClassProvider(t *testing.T) {
-	expResult := sysfs.NewProvider()
+	log, buf := logging.NewTestLogger(t.Name())
+	defer common.ShowBufferOnFailure(t, buf)
 
-	result := DefaultNetDevClassProvider()
+	expResult := sysfs.NewProvider(log)
+
+	result := DefaultNetDevClassProvider(log)
 
 	if diff := cmp.Diff(expResult, result,
 		cmpopts.IgnoreUnexported(sysfs.Provider{}),
@@ -72,18 +86,19 @@ func TestHwprov_DefaultFabricScannerConfig(t *testing.T) {
 	expResult := &hardware.FabricScannerConfig{
 		TopologyProvider:         DefaultTopologyProvider(log),
 		FabricInterfaceProviders: DefaultFabricInterfaceProviders(log),
-		NetDevClassProvider:      DefaultNetDevClassProvider(),
+		NetDevClassProvider:      DefaultNetDevClassProvider(log),
 	}
 
 	result := DefaultFabricScannerConfig(log)
 
 	if diff := cmp.Diff(expResult, result,
 		cmpopts.IgnoreUnexported(
+			hardware.TopologyFactory{},
 			hwloc.Provider{},
 			libfabric.Provider{},
 			sysfs.Provider{},
 		),
-		common.CmpOptIgnoreField("log"),
+		common.CmpOptIgnoreFieldAnyType("log"),
 	); diff != "" {
 		t.Fatalf("(-want, +got)\n%s\n", diff)
 	}
@@ -96,7 +111,7 @@ func TestHwprov_DefaultFabricScanner(t *testing.T) {
 	expResult, err := hardware.NewFabricScanner(log, &hardware.FabricScannerConfig{
 		TopologyProvider:         DefaultTopologyProvider(log),
 		FabricInterfaceProviders: DefaultFabricInterfaceProviders(log),
-		NetDevClassProvider:      DefaultNetDevClassProvider(),
+		NetDevClassProvider:      DefaultNetDevClassProvider(log),
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -107,13 +122,14 @@ func TestHwprov_DefaultFabricScanner(t *testing.T) {
 	if diff := cmp.Diff(expResult, result,
 		cmp.AllowUnexported(
 			hardware.FabricScanner{},
+			hardware.TopologyFactory{},
 		),
 		cmpopts.IgnoreUnexported(
 			hwloc.Provider{},
 			libfabric.Provider{},
 			sysfs.Provider{},
 		),
-		common.CmpOptIgnoreField("log"),
+		common.CmpOptIgnoreFieldAnyType("log"),
 	); diff != "" {
 		t.Fatalf("(-want, +got)\n%s\n", diff)
 	}

--- a/src/control/lib/hardware/hwprov/defaults_test.go
+++ b/src/control/lib/hardware/hwprov/defaults_test.go
@@ -46,18 +46,20 @@ func TestHwprov_DefaultTopologyProvider(t *testing.T) {
 	}
 }
 
-func TestHwprov_DefaultFabricInterfaceProvider(t *testing.T) {
+func TestHwprov_DefaultFabricInterfaceProviders(t *testing.T) {
 	log, buf := logging.NewTestLogger(t.Name())
 	defer common.ShowBufferOnFailure(t, buf)
 
 	expResult := []hardware.FabricInterfaceProvider{
 		libfabric.NewProvider(log),
+		sysfs.NewProvider(log),
 	}
 
 	result := DefaultFabricInterfaceProviders(log)
 
 	if diff := cmp.Diff(expResult, result,
 		cmpopts.IgnoreUnexported(libfabric.Provider{}),
+		cmpopts.IgnoreUnexported(sysfs.Provider{}),
 	); diff != "" {
 		t.Fatalf("(-want, +got)\n%s\n", diff)
 	}

--- a/src/control/lib/hardware/pci.go
+++ b/src/control/lib/hardware/pci.go
@@ -478,12 +478,16 @@ func (d PCIDevices) MarshalJSON() ([]byte, error) {
 }
 
 // Add adds a device to the PCIDevices.
-func (d PCIDevices) Add(dev *PCIDevice) {
-	if d == nil || dev == nil {
-		return
+func (d PCIDevices) Add(dev *PCIDevice) error {
+	if d == nil {
+		return errors.New("nil PCIDevices map")
+	}
+	if dev == nil {
+		return errors.New("nil PCIDevice")
 	}
 	addr := dev.PCIAddr
 	d[addr] = append(d[addr], dev)
+	return nil
 }
 
 // Keys fetches the sorted keys for the map.

--- a/src/control/lib/hardware/pci_test.go
+++ b/src/control/lib/hardware/pci_test.go
@@ -389,11 +389,15 @@ func TestHardware_PCIDevices_Add(t *testing.T) {
 	for name, tc := range map[string]struct {
 		devices   PCIDevices
 		newDev    *PCIDevice
+		expErr    error
 		expResult PCIDevices
 	}{
-		"nil": {},
+		"nil": {
+			expErr: errors.New("nil"),
+		},
 		"add nil Device": {
 			devices:   PCIDevices{},
+			expErr:    errors.New("nil"),
 			expResult: PCIDevices{},
 		},
 		"add to empty": {
@@ -459,8 +463,9 @@ func TestHardware_PCIDevices_Add(t *testing.T) {
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			tc.devices.Add(tc.newDev)
+			err := tc.devices.Add(tc.newDev)
 
+			common.CmpErr(t, tc.expErr, err)
 			if diff := cmp.Diff(tc.expResult, tc.devices); diff != "" {
 				t.Fatalf("(-want, +got)\n%s\n", diff)
 			}

--- a/src/control/lib/hardware/sysfs/provider.go
+++ b/src/control/lib/hardware/sysfs/provider.go
@@ -7,24 +7,31 @@
 package sysfs
 
 import (
-	"errors"
+	"context"
+	"io"
 	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
 
+	"github.com/pkg/errors"
+
 	"github.com/daos-stack/daos/src/control/lib/hardware"
+	"github.com/daos-stack/daos/src/control/logging"
 )
 
 // NewProvider creates a new SysfsProvider.
-func NewProvider() *Provider {
+func NewProvider(log logging.Logger) *Provider {
 	return &Provider{
 		root: "/sys",
+		log:  log,
 	}
 }
 
 // SysfsProvider provides system information from sysfs.
 type Provider struct {
+	log  logging.Logger
 	root string
 }
 
@@ -35,17 +42,159 @@ func (s *Provider) getRoot() string {
 	return s.root
 }
 
+func (s *Provider) sysPath(pathElem ...string) string {
+	pathElem = append([]string{s.getRoot()}, pathElem...)
+
+	return filepath.Join(pathElem...)
+}
+
 // GetNetDevClass fetches the network device class for the given network interface.
 func (s *Provider) GetNetDevClass(dev string) (hardware.NetDevClass, error) {
 	if dev == "" {
 		return 0, errors.New("device name required")
 	}
 
-	devClass, err := ioutil.ReadFile(filepath.Join(s.getRoot(), "class", "net", dev, "type"))
+	devClass, err := ioutil.ReadFile(s.sysPath("class", "net", dev, "type"))
 	if err != nil {
 		return 0, err
 	}
 
 	res, err := strconv.Atoi(strings.TrimSpace(string(devClass)))
 	return hardware.NetDevClass(res), err
+}
+
+// GetTopology builds a minimal topology of network devices from the contents of sysfs.
+func (s *Provider) GetTopology(ctx context.Context) (*hardware.Topology, error) {
+	if s == nil {
+		return nil, errors.New("sysfs provider is nil")
+	}
+
+	topo := &hardware.Topology{}
+
+	err := filepath.Walk(s.sysPath("devices"), func(path string, fi os.FileInfo, err error) error {
+		if fi == nil {
+			return nil
+		}
+
+		if err != nil {
+			return err
+		}
+
+		if s.isVirtual(path) {
+			// skip virtual devices
+			return nil
+		}
+
+		subsystem, err := s.getSubsystemClass(path)
+		if err != nil {
+			// Current directory does not represent a device
+			return nil
+		}
+
+		var dev *hardware.PCIDevice
+		switch subsystem {
+		case "net", "infiniband", "cxi":
+			dev, err = s.getNetworkDevice(path)
+			if err != nil {
+				s.log.Debug(err.Error())
+				return nil
+			}
+		default:
+			return nil
+		}
+
+		numaID, err := s.getNUMANode(path)
+		if err != nil {
+			s.log.Debug(err.Error())
+			return nil
+		}
+
+		pciAddr, err := s.getPCIAddress(path)
+		if err != nil {
+			s.log.Debug(err.Error())
+			return nil
+		}
+		dev.PCIAddr = *pciAddr
+
+		s.log.Debugf("adding device found at %q (type %s, NUMA node %d)", path, dev.Type, numaID)
+
+		topo.AddDevice(uint(numaID), dev)
+
+		return nil
+	})
+
+	if err == io.EOF || err == nil {
+		return topo, nil
+	}
+	return nil, err
+}
+
+func (s *Provider) isVirtual(path string) bool {
+	return strings.HasPrefix(path, s.sysPath("devices", "virtual"))
+}
+
+func (s *Provider) getSubsystemClass(path string) (string, error) {
+	subsysPath, err := filepath.EvalSymlinks(filepath.Join(path, "subsystem"))
+	if err != nil {
+		return "", errors.Wrap(err, "couldn't get subsystem data")
+	}
+
+	return filepath.Base(subsysPath), nil
+}
+
+func (s *Provider) getNetworkDevice(path string) (*hardware.PCIDevice, error) {
+	// Network devices will have the device/net subdirectory structure
+	netDev, err := ioutil.ReadDir(filepath.Join(path, "device", "net"))
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to read net device")
+	}
+
+	if len(netDev) == 0 {
+		return nil, errors.Errorf("no network device for %q", filepath.Base(path))
+	}
+
+	devName := filepath.Base(path)
+	netDevName := netDev[0].Name()
+
+	var devType hardware.DeviceType
+	if netDevName == devName {
+		devType = hardware.DeviceTypeNetInterface
+	} else {
+		devType = hardware.DeviceTypeOFIDomain
+	}
+
+	return &hardware.PCIDevice{
+		Name: devName,
+		Type: devType,
+	}, nil
+}
+
+func (s *Provider) getNUMANode(path string) (uint, error) {
+	numaPath := filepath.Join(path, "device", "numa_node")
+	numaBytes, err := ioutil.ReadFile(numaPath)
+	if err != nil {
+		return 0, errors.Wrapf(err, "couldn't read %q", numaPath)
+	}
+	numaStr := strings.TrimSpace(string(numaBytes))
+
+	numaID, err := strconv.Atoi(numaStr)
+	if err != nil || numaID < 0 {
+		s.log.Debugf("invalid NUMA node ID %q, using NUMA node 0", numaStr)
+		numaID = 0
+	}
+	return uint(numaID), nil
+}
+
+func (s *Provider) getPCIAddress(path string) (*hardware.PCIAddress, error) {
+	pciPath, err := filepath.EvalSymlinks(filepath.Join(path, "device"))
+	if err != nil {
+		return nil, errors.Wrap(err, "couldn't get PCI device")
+	}
+
+	pciAddr, err := hardware.NewPCIAddress(filepath.Base(pciPath))
+	if err != nil {
+		return nil, errors.Wrapf(err, "%q not parsed as PCI address", pciAddr)
+	}
+
+	return pciAddr, nil
 }

--- a/src/control/lib/hardware/sysfs/provider_test.go
+++ b/src/control/lib/hardware/sysfs/provider_test.go
@@ -7,18 +7,26 @@
 package sysfs
 
 import (
+	"context"
 	"errors"
 	"fmt"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
+
 	"github.com/daos-stack/daos/src/control/common"
 	"github.com/daos-stack/daos/src/control/lib/hardware"
+	"github.com/daos-stack/daos/src/control/logging"
 )
 
 func TestSysfs_NewProvider(t *testing.T) {
-	p := NewProvider()
+	log, buf := logging.NewTestLogger(t.Name())
+	defer common.ShowBufferOnFailure(t, buf)
+
+	p := NewProvider(log)
 
 	if p == nil {
 		t.Fatal("nil provider returned")
@@ -74,13 +82,345 @@ func TestSysfs_Provider_GetNetDevClass(t *testing.T) {
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			p := NewProvider()
+			log, buf := logging.NewTestLogger(name)
+			defer common.ShowBufferOnFailure(t, buf)
+
+			p := NewProvider(log)
 			p.root = testDir
 
 			result, err := p.GetNetDevClass(tc.in)
 
 			common.CmpErr(t, tc.expErr, err)
 			common.AssertEqual(t, tc.expResult, result, "")
+		})
+	}
+}
+
+func writeTestFile(t *testing.T, path, contents string) {
+	t.Helper()
+
+	if err := ioutil.WriteFile(path, []byte(contents), 0644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestProvider_GetTopology(t *testing.T) {
+	validPCIAddr := "0000:02:00.0"
+	getPCIPath := func(root, pciAddr string) string {
+		return filepath.Join(root, "devices", "pci0000:00", "0000:00:01.0", pciAddr)
+	}
+
+	setupPCIDev := func(t *testing.T, root, pciAddr, class, dev string) string {
+		t.Helper()
+
+		pciPath := getPCIPath(root, pciAddr)
+		path := filepath.Join(pciPath, class, dev)
+		if err := os.MkdirAll(path, 0755); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := os.Symlink(pciPath, filepath.Join(path, "device")); err != nil {
+			t.Fatal(err)
+		}
+
+		return path
+	}
+
+	setupClassLink := func(t *testing.T, root, class, devPath string) {
+		classPath := filepath.Join(root, "class", class)
+		if err := os.MkdirAll(classPath, 0755); err != nil {
+			t.Fatal(err)
+		}
+
+		if devPath == "" {
+			return
+		}
+
+		if err := os.Symlink(devPath, filepath.Join(classPath, filepath.Base(devPath))); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := os.Symlink(classPath, filepath.Join(devPath, "subsystem")); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	setupNUMANode := func(t *testing.T, devPath, numaStr string) {
+		writeTestFile(t, filepath.Join(devPath, "device", "numa_node"), numaStr)
+	}
+
+	for name, tc := range map[string]struct {
+		setup     func(*testing.T, string)
+		p         *Provider
+		expResult *hardware.Topology
+		expErr    error
+	}{
+		"nil": {
+			expErr: errors.New("nil"),
+		},
+		"empty": {
+			p:         &Provider{},
+			expResult: &hardware.Topology{},
+		},
+		"no net devices": {
+			setup: func(t *testing.T, root string) {
+				for _, class := range []string{"net", "infiniband", "cxi"} {
+					setupClassLink(t, root, class, "")
+				}
+			},
+			p:         &Provider{},
+			expResult: &hardware.Topology{},
+		},
+		"net device only": {
+			setup: func(t *testing.T, root string) {
+				path := setupPCIDev(t, root, validPCIAddr, "net", "net0")
+				setupNUMANode(t, path, "2\n")
+				setupClassLink(t, root, "net", path)
+			},
+			p: &Provider{},
+			expResult: &hardware.Topology{
+				NUMANodes: hardware.NodeMap{
+					2: hardware.MockNUMANode(2, 0).
+						WithDevices([]*hardware.PCIDevice{
+							{
+								Name:    "net0",
+								Type:    hardware.DeviceTypeNetInterface,
+								PCIAddr: *hardware.MustNewPCIAddress(validPCIAddr),
+							},
+						}),
+				},
+			},
+		},
+		"fabric devices": {
+			setup: func(t *testing.T, root string) {
+				for _, dev := range []struct {
+					class string
+					name  string
+				}{
+					{class: "net", name: "net0"},
+					{class: "infiniband", name: "ib0"},
+					{class: "cxi", name: "cxi0"},
+				} {
+					path := setupPCIDev(t, root, validPCIAddr, dev.class, dev.name)
+					setupClassLink(t, root, dev.class, path)
+					setupNUMANode(t, path, "2\n")
+				}
+			},
+			p: &Provider{},
+			expResult: &hardware.Topology{
+				NUMANodes: hardware.NodeMap{
+					2: hardware.MockNUMANode(2, 0).
+						WithDevices([]*hardware.PCIDevice{
+							{
+								Name:    "cxi0",
+								Type:    hardware.DeviceTypeOFIDomain,
+								PCIAddr: *hardware.MustNewPCIAddress(validPCIAddr),
+							},
+							{
+								Name:    "ib0",
+								Type:    hardware.DeviceTypeOFIDomain,
+								PCIAddr: *hardware.MustNewPCIAddress(validPCIAddr),
+							},
+							{
+								Name:    "net0",
+								Type:    hardware.DeviceTypeNetInterface,
+								PCIAddr: *hardware.MustNewPCIAddress(validPCIAddr),
+							},
+						}),
+				},
+			},
+		},
+		"exclude non-specified classes": {
+			setup: func(t *testing.T, root string) {
+				for _, dev := range []struct {
+					class string
+					name  string
+				}{
+					{class: "net", name: "net0"},
+					{class: "hwmon", name: "hwmon0"},
+					{class: "cxi", name: "cxi0"},
+					{class: "cxi_user", name: "cxi0"},
+					{class: "ptp", name: "ptp0"},
+					{class: "infiniband_verbs", name: "uverbs0"},
+					{class: "infiniband", name: "mlx0"},
+				} {
+					path := setupPCIDev(t, root, validPCIAddr, dev.class, dev.name)
+					setupClassLink(t, root, dev.class, path)
+					setupNUMANode(t, path, "2\n")
+				}
+			},
+			p: &Provider{},
+			expResult: &hardware.Topology{
+				NUMANodes: hardware.NodeMap{
+					2: hardware.MockNUMANode(2, 0).
+						WithDevices([]*hardware.PCIDevice{
+							{
+								Name:    "cxi0",
+								Type:    hardware.DeviceTypeOFIDomain,
+								PCIAddr: *hardware.MustNewPCIAddress(validPCIAddr),
+							},
+							{
+								Name:    "mlx0",
+								Type:    hardware.DeviceTypeOFIDomain,
+								PCIAddr: *hardware.MustNewPCIAddress(validPCIAddr),
+							},
+							{
+								Name:    "net0",
+								Type:    hardware.DeviceTypeNetInterface,
+								PCIAddr: *hardware.MustNewPCIAddress(validPCIAddr),
+							},
+						}),
+				},
+			},
+		},
+		"exclude virtual devices": {
+			setup: func(t *testing.T, root string) {
+				for _, dev := range []struct {
+					class string
+					name  string
+				}{
+					{class: "net", name: "net0"},
+					{class: "cxi", name: "cxi0"},
+					{class: "infiniband", name: "mlx0"},
+				} {
+					path := setupPCIDev(t, root, validPCIAddr, dev.class, dev.name)
+					setupClassLink(t, root, dev.class, path)
+					setupNUMANode(t, path, "2\n")
+				}
+
+				virtPath := filepath.Join(root, "devices", "virtual", "net", "virt_net0")
+				if err := os.MkdirAll(virtPath, 0755); err != nil {
+					t.Fatal(err)
+				}
+
+				if err := os.Symlink(getPCIPath(root, validPCIAddr), filepath.Join(virtPath, "device")); err != nil {
+					t.Fatal(err)
+				}
+
+				setupClassLink(t, root, "net", virtPath)
+			},
+			p: &Provider{},
+			expResult: &hardware.Topology{
+				NUMANodes: hardware.NodeMap{
+					2: hardware.MockNUMANode(2, 0).
+						WithDevices([]*hardware.PCIDevice{
+							{
+								Name:    "cxi0",
+								Type:    hardware.DeviceTypeOFIDomain,
+								PCIAddr: *hardware.MustNewPCIAddress(validPCIAddr),
+							},
+							{
+								Name:    "mlx0",
+								Type:    hardware.DeviceTypeOFIDomain,
+								PCIAddr: *hardware.MustNewPCIAddress(validPCIAddr),
+							},
+							{
+								Name:    "net0",
+								Type:    hardware.DeviceTypeNetInterface,
+								PCIAddr: *hardware.MustNewPCIAddress(validPCIAddr),
+							},
+						}),
+				},
+			},
+		},
+		"no NUMA node": {
+			setup: func(t *testing.T, root string) {
+				path := setupPCIDev(t, root, validPCIAddr, "net", "net0")
+				setupNUMANode(t, path, "-1\n")
+				setupClassLink(t, root, "net", path)
+			},
+			p: &Provider{},
+			expResult: &hardware.Topology{
+				NUMANodes: hardware.NodeMap{
+					0: hardware.MockNUMANode(0, 0).
+						WithDevices([]*hardware.PCIDevice{
+							{
+								Name:    "net0",
+								Type:    hardware.DeviceTypeNetInterface,
+								PCIAddr: *hardware.MustNewPCIAddress(validPCIAddr),
+							},
+						}),
+				},
+			},
+		},
+		"garbage NUMA file": {
+			setup: func(t *testing.T, root string) {
+				path := setupPCIDev(t, root, validPCIAddr, "net", "net0")
+				setupNUMANode(t, path, "abcdef\n")
+				setupClassLink(t, root, "net", path)
+			},
+			p: &Provider{},
+			expResult: &hardware.Topology{
+				NUMANodes: hardware.NodeMap{
+					0: hardware.MockNUMANode(0, 0).
+						WithDevices([]*hardware.PCIDevice{
+							{
+								Name:    "net0",
+								Type:    hardware.DeviceTypeNetInterface,
+								PCIAddr: *hardware.MustNewPCIAddress(validPCIAddr),
+							},
+						}),
+				},
+			},
+		},
+		"no NUMA file": {
+			setup: func(t *testing.T, root string) {
+				path := setupPCIDev(t, root, validPCIAddr, "net", "net0")
+				setupClassLink(t, root, "net", path)
+			},
+			p:         &Provider{},
+			expResult: &hardware.Topology{},
+		},
+		"no PCI device link": {
+			setup: func(t *testing.T, root string) {
+				path := setupPCIDev(t, root, validPCIAddr, "net", "net0")
+				setupNUMANode(t, path, "2\n")
+				setupClassLink(t, root, "net", path)
+
+				if err := os.Remove(filepath.Join(path, "device")); err != nil {
+					t.Fatal(err)
+				}
+			},
+			p:         &Provider{},
+			expResult: &hardware.Topology{},
+		},
+		"device link not valid PCI addr": {
+			setup: func(t *testing.T, root string) {
+				path := setupPCIDev(t, root, "junk", "net", "net0")
+				setupNUMANode(t, path, "2\n")
+				setupClassLink(t, root, "net", path)
+			},
+			p:         &Provider{},
+			expResult: &hardware.Topology{},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			log, buf := logging.NewTestLogger(name)
+			defer common.ShowBufferOnFailure(t, buf)
+
+			testDir, cleanupTestDir := common.CreateTestDir(t)
+			defer cleanupTestDir()
+
+			if tc.setup == nil {
+				tc.setup = func(t *testing.T, root string) {}
+			}
+
+			tc.setup(t, testDir)
+
+			if tc.p != nil {
+				tc.p.log = log
+
+				// Mock out a fake sysfs in the testDir
+				tc.p.root = testDir
+			}
+
+			result, err := tc.p.GetTopology(context.Background())
+
+			common.CmpErr(t, tc.expErr, err)
+
+			if diff := cmp.Diff(tc.expResult, result); diff != "" {
+				t.Errorf("(-want, +got)\n%s\n", diff)
+			}
 		})
 	}
 }

--- a/src/control/lib/hardware/topology_test.go
+++ b/src/control/lib/hardware/topology_test.go
@@ -7,10 +7,12 @@
 package hardware
 
 import (
+	"context"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/pkg/errors"
 
 	"github.com/daos-stack/daos/src/control/common"
 )
@@ -168,6 +170,286 @@ func TestTopology_NumCoresPerNUMA(t *testing.T) {
 	}
 }
 
+func TestHardware_Topology_AddDevice(t *testing.T) {
+	for name, tc := range map[string]struct {
+		topo      *Topology
+		numaNode  uint
+		device    *PCIDevice
+		expResult *Topology
+	}{
+		"nil topology": {
+			device: &PCIDevice{
+				Name:    "test",
+				PCIAddr: *MustNewPCIAddress("0000:00:00.1"),
+			},
+		},
+		"nil input": {
+			topo:      &Topology{},
+			expResult: &Topology{},
+		},
+		"add to empty": {
+			topo:     &Topology{},
+			numaNode: 1,
+			device: &PCIDevice{
+				Name:    "test",
+				PCIAddr: *MustNewPCIAddress("0000:00:00.1"),
+			},
+			expResult: &Topology{
+				NUMANodes: NodeMap{
+					1: MockNUMANode(1, 0).WithDevices([]*PCIDevice{
+						{
+							Name:    "test",
+							PCIAddr: *MustNewPCIAddress("0000:00:00.1"),
+						},
+					}),
+				},
+			},
+		},
+		"add to existing node": {
+			topo: &Topology{
+				NUMANodes: NodeMap{
+					1: MockNUMANode(1, 6).WithDevices([]*PCIDevice{
+						{
+							Name:    "test0",
+							PCIAddr: *MustNewPCIAddress("0000:00:00.1"),
+						},
+					}),
+				},
+			},
+			numaNode: 1,
+			device: &PCIDevice{
+				Name:    "test1",
+				PCIAddr: *MustNewPCIAddress("0000:00:00.2"),
+			},
+			expResult: &Topology{
+				NUMANodes: NodeMap{
+					1: MockNUMANode(1, 6).WithDevices([]*PCIDevice{
+						{
+							Name:    "test0",
+							PCIAddr: *MustNewPCIAddress("0000:00:00.1"),
+						},
+						{
+							Name:    "test1",
+							PCIAddr: *MustNewPCIAddress("0000:00:00.2"),
+						},
+					}),
+				},
+			},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			tc.topo.AddDevice(tc.numaNode, tc.device)
+
+			if diff := cmp.Diff(tc.expResult, tc.topo); diff != "" {
+				t.Fatalf("(-want, +got)\n%s\n", diff)
+			}
+		})
+	}
+}
+
+func TestHardware_Topology_Merge(t *testing.T) {
+	testNuma := func(idx int) *NUMANode {
+		nodes := []*NUMANode{
+			MockNUMANode(1, 4).
+				WithDevices([]*PCIDevice{
+					{
+						Name:      "test0",
+						PCIAddr:   *MustNewPCIAddress("0000:00:00.1"),
+						LinkSpeed: 60,
+					},
+				}).
+				WithCPUCores([]CPUCore{}).
+				WithPCIBuses([]*PCIBus{
+					{
+						LowAddress:  *MustNewPCIAddress("0000:00:00.0"),
+						HighAddress: *MustNewPCIAddress("0000:05:00.0"),
+					},
+				}),
+			MockNUMANode(2, 4).
+				WithDevices([]*PCIDevice{
+					{
+						Name:    "test1",
+						PCIAddr: *MustNewPCIAddress("0000:0a:00.1"),
+					},
+				}).
+				WithCPUCores([]CPUCore{}).
+				WithPCIBuses([]*PCIBus{
+					{
+						LowAddress:  *MustNewPCIAddress("0000:05:00.0"),
+						HighAddress: *MustNewPCIAddress("0000:0f:00.0"),
+					},
+				}),
+		}
+		return nodes[idx]
+	}
+
+	for name, tc := range map[string]struct {
+		topo      *Topology
+		input     *Topology
+		expResult *Topology
+	}{
+		"nil base": {
+			input: &Topology{},
+		},
+		"nil input": {
+			topo:      &Topology{},
+			expResult: &Topology{},
+		},
+		"all empties": {
+			topo:      &Topology{},
+			input:     &Topology{},
+			expResult: &Topology{},
+		},
+		"add to empty": {
+			topo: &Topology{},
+			input: &Topology{
+				NUMANodes: NodeMap{
+					testNuma(0).ID: testNuma(0),
+				},
+			},
+			expResult: &Topology{
+				NUMANodes: NodeMap{
+					testNuma(0).ID: testNuma(0),
+				},
+			},
+		},
+		"no intersection": {
+			topo: &Topology{
+				NUMANodes: NodeMap{
+					testNuma(0).ID: testNuma(0),
+				},
+			},
+			input: &Topology{
+				NUMANodes: NodeMap{
+					testNuma(1).ID: testNuma(1),
+				},
+			},
+			expResult: &Topology{
+				NUMANodes: NodeMap{
+					testNuma(0).ID: testNuma(0),
+					testNuma(1).ID: testNuma(1),
+				},
+			},
+		},
+		"add to same NUMA node": {
+			topo: &Topology{
+				NUMANodes: NodeMap{
+					testNuma(0).ID: testNuma(0),
+				},
+			},
+			input: &Topology{
+				NUMANodes: NodeMap{
+					testNuma(0).ID: MockNUMANode(testNuma(0).ID, 0).
+						WithDevices([]*PCIDevice{
+							{
+								Name:    "test1",
+								Type:    DeviceTypeNetInterface,
+								PCIAddr: *MustNewPCIAddress("0000:00:00.2"),
+							},
+						}).
+						WithCPUCores([]CPUCore{
+							{
+								ID: 4,
+							},
+						}).
+						WithPCIBuses([]*PCIBus{
+							{
+								LowAddress:  *MustNewPCIAddress("0000:0f:00.0"),
+								HighAddress: *MustNewPCIAddress("0000:20:00.0"),
+							},
+						}),
+				},
+			},
+			expResult: &Topology{
+				NUMANodes: NodeMap{
+					testNuma(0).ID: MockNUMANode(testNuma(0).ID, 5).
+						WithDevices([]*PCIDevice{
+							testNuma(0).PCIDevices[*MustNewPCIAddress("0000:00:00.1")][0],
+							{
+								Name:    "test1",
+								Type:    DeviceTypeNetInterface,
+								PCIAddr: *MustNewPCIAddress("0000:00:00.2"),
+							},
+						}).
+						WithPCIBuses([]*PCIBus{
+							testNuma(0).PCIBuses[0],
+							{
+								LowAddress:  *MustNewPCIAddress("0000:0f:00.0"),
+								HighAddress: *MustNewPCIAddress("0000:20:00.0"),
+							},
+						}),
+				},
+			},
+		},
+		"update": {
+			topo: &Topology{
+				NUMANodes: NodeMap{
+					testNuma(0).ID: testNuma(0),
+				},
+			},
+			input: &Topology{
+				NUMANodes: NodeMap{
+					testNuma(0).ID: MockNUMANode(testNuma(0).ID, 5).
+						WithDevices([]*PCIDevice{
+							{
+								Name:    "test0",
+								Type:    DeviceTypeNetInterface,
+								PCIAddr: *MustNewPCIAddress("0000:00:00.1"),
+							},
+							{
+								Name:      "test1",
+								Type:      DeviceTypeNetInterface,
+								PCIAddr:   *MustNewPCIAddress("0000:00:00.2"),
+								LinkSpeed: 75,
+							},
+						}).
+						WithPCIBuses([]*PCIBus{
+							testNuma(0).PCIBuses[0],
+							{
+								LowAddress:  *MustNewPCIAddress("0000:0f:00.0"),
+								HighAddress: *MustNewPCIAddress("0000:20:00.0"),
+							},
+						}),
+				},
+			},
+			expResult: &Topology{
+				NUMANodes: NodeMap{
+					testNuma(0).ID: MockNUMANode(testNuma(0).ID, 5).
+						WithDevices([]*PCIDevice{
+							{
+								Name:      "test0",
+								Type:      DeviceTypeNetInterface,
+								PCIAddr:   *MustNewPCIAddress("0000:00:00.1"),
+								LinkSpeed: 60,
+							},
+							{
+								Name:      "test1",
+								Type:      DeviceTypeNetInterface,
+								PCIAddr:   *MustNewPCIAddress("0000:00:00.2"),
+								LinkSpeed: 75,
+							},
+						}).
+						WithPCIBuses([]*PCIBus{
+							testNuma(0).PCIBuses[0],
+							{
+								LowAddress:  *MustNewPCIAddress("0000:0f:00.0"),
+								HighAddress: *MustNewPCIAddress("0000:20:00.0"),
+							},
+						}),
+				},
+			},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			tc.topo.Merge(tc.input)
+
+			if diff := cmp.Diff(tc.expResult, tc.topo, common.CmpOptIgnoreFieldAnyType("NUMANode")); diff != "" {
+				t.Fatalf("(-want, +got)\n%s\n", diff)
+			}
+		})
+	}
+}
+
 func TestHardware_DeviceType_String(t *testing.T) {
 	for name, tc := range map[string]struct {
 		devType   DeviceType
@@ -192,6 +474,205 @@ func TestHardware_DeviceType_String(t *testing.T) {
 	} {
 		t.Run(name, func(t *testing.T) {
 			common.AssertEqual(t, tc.expResult, tc.devType.String(), "")
+		})
+	}
+}
+
+func TestHardware_NewTopologyFactory(t *testing.T) {
+	for name, tc := range map[string]struct {
+		input     []*WeightedTopologyProvider
+		expResult *TopologyFactory
+	}{
+		"empty": {
+			expResult: &TopologyFactory{
+				providers: []TopologyProvider{},
+			},
+		},
+		"one provider": {
+			input: []*WeightedTopologyProvider{
+				{
+					Provider: &MockTopologyProvider{},
+					Weight:   1,
+				},
+			},
+			expResult: &TopologyFactory{
+				providers: []TopologyProvider{
+					&MockTopologyProvider{},
+				},
+			},
+		},
+		"multiple providers": {
+			input: []*WeightedTopologyProvider{
+				{
+					Provider: &MockTopologyProvider{
+						GetTopoErr: errors.New("provider 1"),
+					},
+					Weight: 1,
+				},
+				{
+					Provider: &MockTopologyProvider{
+						GetTopoErr: errors.New("provider 3"),
+					},
+					Weight: 3,
+				},
+				{
+					Provider: &MockTopologyProvider{
+						GetTopoErr: errors.New("provider 2"),
+					},
+					Weight: 2,
+				},
+				{
+					Provider: &MockTopologyProvider{
+						GetTopoErr: errors.New("provider 4"),
+					},
+					Weight: 4,
+				},
+			},
+			expResult: &TopologyFactory{
+				providers: []TopologyProvider{
+					&MockTopologyProvider{
+						GetTopoErr: errors.New("provider 4"),
+					},
+					&MockTopologyProvider{
+						GetTopoErr: errors.New("provider 3"),
+					},
+					&MockTopologyProvider{
+						GetTopoErr: errors.New("provider 2"),
+					},
+					&MockTopologyProvider{
+						GetTopoErr: errors.New("provider 1"),
+					},
+				},
+			},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			result := NewTopologyFactory(tc.input...)
+
+			if diff := cmp.Diff(tc.expResult, result,
+				cmp.AllowUnexported(TopologyFactory{}),
+				common.CmpOptEquateErrorMessages(),
+			); diff != "" {
+				t.Fatalf("(-want, +got)\n%s\n", diff)
+			}
+		})
+	}
+}
+
+func TestHardware_TopologyFactory_GetTopology(t *testing.T) {
+	testTopo1 := func() *Topology {
+		return &Topology{
+			NUMANodes: NodeMap{
+				0: MockNUMANode(0, 6).
+					WithDevices([]*PCIDevice{
+						{
+							Name: "net0",
+							Type: DeviceTypeNetInterface,
+						},
+						{
+							Name: "ofi0",
+							Type: DeviceTypeOFIDomain,
+						},
+					}),
+				1: MockNUMANode(1, 6).
+					WithDevices([]*PCIDevice{
+						{
+							Name: "net1",
+							Type: DeviceTypeNetInterface,
+						},
+						{
+							Name: "ofi1",
+							Type: DeviceTypeOFIDomain,
+						},
+					}),
+			},
+		}
+	}
+
+	testTopo2 := func() *Topology {
+		return &Topology{
+			NUMANodes: NodeMap{
+				0: MockNUMANode(0, 6).
+					WithDevices([]*PCIDevice{
+						{
+							Name: "net0",
+							Type: DeviceTypeNetInterface,
+						},
+						{
+							Name: "net2",
+							Type: DeviceTypeNetInterface,
+						},
+					}),
+				1: MockNUMANode(1, 6).
+					WithDevices([]*PCIDevice{
+						{
+							Name: "net1",
+							Type: DeviceTypeNetInterface,
+						},
+					}),
+			},
+		}
+	}
+
+	testMerged := testTopo1()
+	testMerged.Merge(testTopo2())
+
+	for name, tc := range map[string]struct {
+		tf        *TopologyFactory
+		expResult *Topology
+		expErr    error
+	}{
+		"nil": {
+			expErr: errors.New("nil"),
+		},
+		"no providers in factory": {
+			tf:     &TopologyFactory{},
+			expErr: errors.New("no TopologyProviders"),
+		},
+		"successful provider": {
+			tf: &TopologyFactory{
+				providers: []TopologyProvider{
+					&MockTopologyProvider{
+						GetTopoReturn: testTopo1(),
+					},
+				},
+			},
+			expResult: testTopo1(),
+		},
+		"multi provider": {
+			tf: &TopologyFactory{
+				providers: []TopologyProvider{
+					&MockTopologyProvider{
+						GetTopoReturn: testTopo1(),
+					},
+					&MockTopologyProvider{
+						GetTopoReturn: testTopo2(),
+					},
+				},
+			},
+			expResult: testMerged,
+		},
+		"one provider fails": {
+			tf: &TopologyFactory{
+				providers: []TopologyProvider{
+					&MockTopologyProvider{
+						GetTopoErr: errors.New("mock GetTopology"),
+					},
+					&MockTopologyProvider{
+						GetTopoReturn: testTopo2(),
+					},
+				},
+			},
+			expErr: errors.New("mock GetTopology"),
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			result, err := tc.tf.GetTopology(context.Background())
+
+			common.CmpErr(t, tc.expErr, err)
+			if diff := cmp.Diff(tc.expResult, result); diff != "" {
+				t.Fatalf("(-want, +got)\n%s\n", diff)
+			}
 		})
 	}
 }


### PR DESCRIPTION
    - Add a TopologyProvider to detect network devices via sysfs, to
      find devices not in the hwloc topology.
    - Add the TopologyFactory, a TopologyProvider that merges the
      results of other TopologyProviders.
    - Fix error in NetDevClassBuilder.
    - Add weighted inputs to NewTopologyFactory, to make explicit
      the expected order in which TopologyProviders should be run.
    - Make improvements to debug logging.

Signed-off-by: Kris Jacque <kristin.jacque@intel.com>