### PR TITLE
DAOS-9187 placement: Fix dead code in placement map (#7561)

### DIFF
--- a/src/placement/pl_map.c
+++ b/src/placement/pl_map.c
@@ -658,8 +658,6 @@ pl_target_in_mbs(struct pl_obj_shard *shard, struct dtx_memberships *mbs)
 		for (i = 1; i < mbs->dm_tgt_cnt; i++) {
 			if (mbs->dm_tgts[i].ddt_id == shard->po_target)
 				return true;
-
-			break;
 		}
 
 		return false;


### PR DESCRIPTION
Coverity identified an issue where a loop in the placement map code will only
execute once.

Signed-off-by: David Quigley <david.quigley@intel.com>