### PR TITLE
DAOS-9345 control: notify when daos_server cmd doesn't use config

### DIFF
--- a/src/control/cmd/daos_server/main.go
+++ b/src/control/cmd/daos_server/main.go
@@ -105,14 +105,14 @@ func parseOpts(args []string, opts *mainOpts, log *logging.LeveledLogger) error 
 			logCmd.setLog(log)
 		}
 
-		if opts.ConfigPath == "" {
-			defaultConfigPath := path.Join(build.ConfigDir, defaultConfigFile)
-			if _, err := os.Stat(defaultConfigPath); err == nil {
-				opts.ConfigPath = defaultConfigPath
-			}
-		}
-
 		if cfgCmd, ok := cmd.(cfgLoader); ok {
+			if opts.ConfigPath == "" {
+				defaultConfigPath := path.Join(build.ConfigDir, defaultConfigFile)
+				if _, err := os.Stat(defaultConfigPath); err == nil {
+					opts.ConfigPath = defaultConfigPath
+				}
+			}
+
 			if err := cfgCmd.loadConfig(opts.ConfigPath); err != nil {
 				return errors.Wrapf(err, "failed to load config from %s", cfgCmd.configPath())
 			}
@@ -123,6 +123,8 @@ func parseOpts(args []string, opts *mainOpts, log *logging.LeveledLogger) error 
 					return errors.Wrap(err, "failed to set CLI config overrides")
 				}
 			}
+		} else if opts.ConfigPath != "" {
+			log.Infof("DAOS Server config has been supplied but this command will not use it")
 		}
 
 		if err := cmd.Execute(cmdArgs); err != nil {


### PR DESCRIPTION
Print informational message when the user supplies a config file but the
command doesn't support using one.

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>