### PR TITLE
DAOS-9328 fi: Downgrade fault injection warning to info

### DIFF
--- a/src/gurt/fault_inject.c
+++ b/src/gurt/fault_inject.c
@@ -666,25 +666,25 @@ out:
 #else /* FAULT_INJECT */
 int d_fault_inject_init(void)
 {
-	D_WARN("Fault Injection not initialized feature not included in build");
+	D_INFO("Fault Injection not initialized feature not included in build");
 	return -DER_NOSYS;
 }
 
 int d_fault_inject_fini(void)
 {
-	D_WARN("Fault Injection not finalized feature not included in build");
+	D_INFO("Fault Injection not finalized feature not included in build");
 	return -DER_NOSYS;
 }
 
 int d_fault_inject_enable(void)
 {
-	D_WARN("Fault Injection not enabled feature not included in build");
+	D_INFO("Fault Injection not enabled feature not included in build");
 	return -DER_NOSYS;
 }
 
 int d_fault_inject_disable(void)
 {
-	D_WARN("Fault Injection not disabled feature not included in build");
+	D_INFO("Fault Injection not disabled feature not included in build");
 	return -DER_NOSYS;
 }
 
@@ -703,7 +703,7 @@ d_should_fail(struct d_fault_attr_t *fault_attr)
 int
 d_fault_attr_set(uint32_t fault_id, struct d_fault_attr_t fa_in)
 {
-	D_WARN("Fault Injection attr not set feature not included in build");
+	D_INFO("Fault Injection attr not set feature not included in build");
 	return 0;
 }
 


### PR DESCRIPTION
In release builds, fault injection is disabled by design.  The user can
check if it's enabled.  No need to put a warning into the log.

Allow-unstable-test: true

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>