### PR TITLE
DAOS-9189 Test: Fix the common code JSON to not to use the loop. (#7586)

### DIFF
--- a/src/common/tests_dmg_helpers.c
+++ b/src/common/tests_dmg_helpers.c
@@ -852,7 +852,8 @@ dmg_storage_query_device_health(const char *dmg_config_file, char *host,
 	struct json_object	*smd_info = NULL;
 	struct json_object	*storage_info = NULL;
 	struct json_object	*health_info = NULL;
-	struct json_object	*dev = NULL;
+	struct json_object	*devices = NULL;
+	struct json_object	*dev_info = NULL;
 	struct json_object	*tmp = NULL;
 	char			uuid_str[DAOS_UUID_STR_SIZE];
 	int			argcount = 0;
@@ -874,7 +875,6 @@ dmg_storage_query_device_health(const char *dmg_config_file, char *host,
 		D_ERROR("dmg command failed");
 		goto out_json;
 	}
-
 	if (!json_object_object_get_ex(dmg_out, "host_storage_map",
 				       &storage_map)) {
 		D_ERROR("unable to extract host_storage_map from JSON\n");
@@ -884,25 +884,27 @@ dmg_storage_query_device_health(const char *dmg_config_file, char *host,
 	json_object_object_foreach(storage_map, key, val) {
 		D_DEBUG(DB_TEST, "key:\"%s\",val=%s\n", key,
 			json_object_to_json_string(val));
+
 		if (!json_object_object_get_ex(val, "storage", &storage_info)) {
-			D_ERROR("unable to extract hosts from JSON\n");
+			D_ERROR("unable to extract storage info from JSON\n");
 			D_GOTO(out_json, rc = -DER_INVAL);
 		}
 		if (!json_object_object_get_ex(storage_info, "smd_info",
 					       &smd_info)) {
-			D_ERROR("unable to extract hosts from JSON\n");
+			D_ERROR("unable to extract smd_info from JSON\n");
 			D_GOTO(out_json, rc = -DER_INVAL);
 		}
-		json_object_object_foreach(smd_info, key1, val1) {
-			D_DEBUG(DB_TEST, "key1:\"%s\",val1=%s\n", key1,
-				json_object_to_json_string(val1));
-			dev = json_object_array_get_idx(val1, 0);
-			json_object_object_get_ex(dev, "health", &health_info);
-			if (health_info != NULL) {
-				json_object_object_get_ex(health_info, stats,
-							  &tmp);
-				strcpy(stats, json_object_to_json_string(tmp));
-			}
+		if (!json_object_object_get_ex(smd_info, "devices", &devices)) {
+			D_ERROR("unable to extract devices list from JSON\n");
+			D_GOTO(out_json, rc = -DER_INVAL);
+		}
+
+		dev_info = json_object_array_get_idx(devices, 0);
+		json_object_object_get_ex(dev_info, "health", &health_info);
+		if (health_info != NULL) {
+			json_object_object_get_ex(health_info, stats,
+						  &tmp);
+			strcpy(stats, json_object_to_json_string(tmp));
 		}
 	}
 


### PR DESCRIPTION
On CentOS 8.4 which has json package 0.13.1-0.4.On latest changes
json_object_object_get_ex() fails if the value is empty. And in device-health
pools is key with no value which is getting Assertion on latest JSON.

So removed the for loop and instead use the value of device and read
health info.

Signed-off-by: Samir Raval <samir.raval@intel.com>