### PR TITLE
DAOS-9064 dfuse:  Ensure new files have correct permissions. (#7417)

### DIFF
--- a/src/client/dfuse/dfuse.h
+++ b/src/client/dfuse/dfuse.h
@@ -669,6 +669,9 @@ dfuse_reply_entry(struct dfuse_projection_info *fs_handle,
 		  bool is_new,
 		  fuse_req_t req);
 
+int
+_dfuse_mode_update(fuse_req_t req, struct dfuse_inode_entry *parent, mode_t *_mode);
+
 /* Mark object as removed and invalidate any kernel data for it */
 void
 dfuse_oid_unlinked(struct dfuse_projection_info *fs_handle, fuse_req_t req, daos_obj_id_t *oid,

--- a/src/client/dfuse/ops/create.c
+++ b/src/client/dfuse/ops/create.c
@@ -7,6 +7,96 @@
 #include "dfuse_common.h"
 #include "dfuse.h"
 
+/* Optionally, modify requested mode bits so the file creator can access the file.  In single-user
+ * dfuse, when accessing a container belonging to somebody else all files within that container
+ * will belong to the container owner, and this includes any new files created.
+ *
+ * To avoid a case where a user is granted write permission to a container and is then able to
+ * create files which they cannot then access detect this case and promote the user mode bits
+ * to either group or other as appropriate so the creator of the file retains access.
+ */
+
+/* Number of initial groups to sample.  It doesn't really matter what this value is as if it's
+ * not sufficient then a larger array will be allocated.  Set it large enough to be big enough
+ * on a standard Linux setup
+ */
+#define START_GROUP_SIZE 8
+
+int
+_dfuse_mode_update(fuse_req_t req, struct dfuse_inode_entry *parent, mode_t *_mode)
+{
+	const struct fuse_ctx *ctx = fuse_req_ctx(req);
+	mode_t mode = *_mode;
+
+	/* First check the UID, if this is different then copy the mode bits from user to group */
+	if (ctx->uid != parent->ie_stat.st_uid) {
+		DFUSE_TRA_DEBUG(parent, "create with mismatched UID, setting group perms\n");
+		if (mode & S_IRUSR)
+			mode |= S_IRGRP;
+		if (mode & S_IWUSR)
+			mode |= S_IWGRP;
+		if (mode & S_IXUSR)
+			mode |= S_IXGRP;
+	}
+
+	/* Check the GID, if this is different then check all groups, of no groups match then copy
+	 * bits from user to other
+	 */
+	if (ctx->gid != parent->ie_stat.st_gid) {
+		int gcount;
+		int gsize;
+		gid_t glist[START_GROUP_SIZE];
+		bool have_group_match = false;
+		int i;
+
+		DFUSE_TRA_DEBUG(parent, "create with mismatched GID\n");
+
+		gcount = fuse_req_getgroups(req, START_GROUP_SIZE, glist);
+		gsize = min(2, gcount);
+
+		for (i = 0 ; i < gsize; i++)
+			if (glist[i] == parent->ie_stat.st_gid)
+				have_group_match = true;
+
+		if (gcount > START_GROUP_SIZE) {
+			gid_t *garray;
+
+			D_ALLOC_ARRAY(garray, gcount);
+			if (garray == NULL)
+				return ENOMEM;
+
+			gsize = fuse_req_getgroups(req, gcount, garray);
+			gsize = min(gsize, gcount);
+
+			for (i = 0 ; i < gsize; i++)
+				if (glist[i] == parent->ie_stat.st_gid)
+					have_group_match = true;
+
+			if (gcount != gsize)
+				DFUSE_TRA_WARNING(parent, "group count changed during sample %d %d",
+						  gcount, gsize);
+			D_FREE(garray);
+		}
+
+		if (!have_group_match) {
+			DFUSE_TRA_DEBUG(parent, "No GIDs match, setting other perms\n");
+
+			if (mode & S_IRUSR)
+				mode |= S_IROTH;
+			if (mode & S_IWUSR)
+				mode |= S_IWOTH;
+			if (mode & S_IXUSR)
+				mode |= S_IXOTH;
+		}
+	}
+
+	if (*_mode != mode)
+		DFUSE_TRA_DEBUG(parent, "Updated mode from %#o to %#o", *_mode, mode);
+
+	*_mode = mode;
+	return 0;
+}
+
 void
 dfuse_cb_create(fuse_req_t req, struct dfuse_inode_entry *parent,
 		const char *name, mode_t mode, struct fuse_file_info *fi)
@@ -16,33 +106,29 @@ dfuse_cb_create(fuse_req_t req, struct dfuse_inode_entry *parent,
 	struct dfuse_obj_hdl		*oh = NULL;
 	struct fuse_file_info		fi_out = {0};
 	struct dfuse_cont		*dfs = parent->ie_dfs;
-	int rc;
+	int				rc;
 
-	DFUSE_TRA_INFO(parent, "Parent:%#lx '%s'", parent->ie_stat.st_ino,
-		       name);
+	DFUSE_TRA_INFO(parent, "Parent:%#lx '%s'", parent->ie_stat.st_ino, name);
 
 	/* O_LARGEFILE should always be set on 64 bit systems, and in fact is
 	 * defined to 0 so IOF defines LARGEFILE to the value that O_LARGEFILE
 	 * would otherwise be using and check that is set.
 	 */
 	if (!(fi->flags & LARGEFILE)) {
-		DFUSE_TRA_INFO(parent, "O_LARGEFILE required 0%o",
-			       fi->flags);
+		DFUSE_TRA_INFO(parent, "O_LARGEFILE required 0%o", fi->flags);
 		D_GOTO(err, rc = ENOTSUP);
 	}
 
 	/* Check for flags that do not make sense in this context. */
 	if (fi->flags & DFUSE_UNSUPPORTED_CREATE_FLAGS) {
-		DFUSE_TRA_INFO(parent, "unsupported flag requested 0%o",
-			       fi->flags);
+		DFUSE_TRA_INFO(parent, "unsupported flag requested 0%o", fi->flags);
 		D_GOTO(err, rc = ENOTSUP);
 	}
 
 	/* Upgrade fd permissions from O_WRONLY to O_RDWR if wb caching is
 	 * enabled so the kernel can do read-modify-write
 	 */
-	if (parent->ie_dfs->dfc_data_caching &&
-		fs_handle->dpi_info->di_wb_cache &&
+	if (parent->ie_dfs->dfc_data_caching && fs_handle->dpi_info->di_wb_cache &&
 		(fi->flags & O_ACCMODE) == O_WRONLY) {
 		DFUSE_TRA_INFO(parent, "Upgrading fd to O_RDRW");
 		fi->flags &= ~O_ACCMODE;
@@ -51,9 +137,7 @@ dfuse_cb_create(fuse_req_t req, struct dfuse_inode_entry *parent,
 
 	/* Check that only the flag for a regular file is specified */
 	if (!S_ISREG(mode)) {
-		DFUSE_TRA_INFO(parent,
-			       "unsupported mode requested 0%o",
-			       mode);
+		DFUSE_TRA_INFO(parent, "unsupported mode requested 0%o", mode);
 		D_GOTO(err, rc = ENOTSUP);
 	}
 
@@ -68,17 +152,19 @@ dfuse_cb_create(fuse_req_t req, struct dfuse_inode_entry *parent,
 	DFUSE_TRA_UP(oh, ie, "open handle");
 	ie->ie_dfs = dfs;
 
-	DFUSE_TRA_DEBUG(ie, "file '%s' flags 0%o mode 0%o", name, fi->flags,
-			mode);
+	rc = _dfuse_mode_update(req, parent, &mode);
+	if (rc != 0)
+		D_GOTO(err, rc);
 
-	rc = dfs_open_stat(dfs->dfs_ns, parent->ie_obj, name, mode,
-			   fi->flags, 0, 0, NULL, &oh->doh_obj, &ie->ie_stat);
+	DFUSE_TRA_DEBUG(ie, "file '%s' flags 0%o mode 0%o", name, fi->flags, mode);
+
+	rc = dfs_open_stat(dfs->dfs_ns, parent->ie_obj, name, mode, fi->flags, 0, 0, NULL,
+			   &oh->doh_obj, &ie->ie_stat);
 	if (rc)
 		D_GOTO(err, rc);
 
 	/** duplicate the file handle for the fuse handle */
-	rc = dfs_dup(dfs->dfs_ns, oh->doh_obj, O_RDWR,
-		     &ie->ie_obj);
+	rc = dfs_dup(dfs->dfs_ns, oh->doh_obj, O_RDWR, &ie->ie_obj);
 	if (rc)
 		D_GOTO(release, rc);
 
@@ -110,8 +196,7 @@ dfuse_cb_create(fuse_req_t req, struct dfuse_inode_entry *parent,
 
 	dfs_obj2id(ie->ie_obj, &ie->ie_oid);
 
-	dfuse_compute_inode(dfs, &ie->ie_oid,
-			    &ie->ie_stat.st_ino);
+	dfuse_compute_inode(dfs, &ie->ie_oid, &ie->ie_stat.st_ino);
 
 	/* Return the new inode data, and keep the parent ref */
 	dfuse_reply_entry(fs_handle, ie, &fi_out, true, req);

--- a/utils/node_local_test.py
+++ b/utils/node_local_test.py
@@ -1372,6 +1372,38 @@ def needs_dfuse_with_cache(method):
         return rc
     return _helper
 
+class print_stat():
+    """Class for nicely showing file 'stat' data, similar to ls -l"""
+
+    headers = ['uid', 'gid', 'size', 'mode', 'filename']
+
+    def __init__(self, filename=None):
+        # Setup the object, and maybe add some data to it.
+        self._stats = []
+        if filename:
+            self.add(filename)
+
+    def add(self, filename, attr=None, show_dir=False):
+        """Add an entry to be displayed"""
+
+        if attr is None:
+            attr = os.stat(filename)
+
+        self._stats.append([attr.st_uid,
+                            attr.st_gid,
+                            attr.st_size,
+                            stat.filemode(attr.st_mode),
+                            filename])
+
+        if show_dir:
+            tab = '.' * len(filename)
+            for fname in os.listdir(filename):
+                self.add(os.path.join(tab, fname),
+                         attr=os.stat(os.path.join(filename, fname)))
+
+    def __str__(self):
+        return tabulate.tabulate(self._stats, self.headers)
+
 # This is test code where methods are tests, so we want to have lots of them.
 # pylint: disable=too-many-public-methods
 class posix_tests():
@@ -1903,6 +1935,86 @@ class posix_tests():
 
         for fd in fds:
             fd.close()
+
+    def test_cont_rw(self):
+        """Test write access to another users container"""
+
+        dfuse = DFuse(self.server,
+                      self.conf,
+                      pool=self.pool.id(),
+                      container=self.container,
+                      caching=False)
+
+        dfuse.start(v_hint='cont_rw_1')
+
+        ps = print_stat(dfuse.dir)
+        testfile = os.path.join(dfuse.dir, 'testfile')
+        with open(testfile, 'w') as fd:
+            ps.add(testfile, attr=os.fstat(fd.fileno()))
+
+        dirname = os.path.join(dfuse.dir, 'rw_dir')
+        os.mkdir(dirname)
+
+        ps.add(dirname)
+
+        dir_perms = os.stat(dirname).st_mode
+        base_perms = stat.S_IMODE(dir_perms)
+
+        os.chmod(dirname, base_perms | stat.S_IWGRP | stat.S_IXGRP | stat.S_IXOTH | stat.S_IWOTH)
+        ps.add(dirname)
+        print(ps)
+
+        if dfuse.stop():
+            self.fatal_errors = True
+
+            # Update container ACLs so current user has rw permissions only, the minimum required.
+        rc = run_daos_cmd(self.conf, ['container',
+                                      'update-acl',
+                                      self.pool.id(),
+                                      self.container,
+                                      '--entry',
+                                      'A::{}@:rwta'.format(os.getlogin())])
+        print(rc)
+
+        # Assign the container to someone else.
+        rc = run_daos_cmd(self.conf, ['container',
+                                      'set-owner',
+                                      self.pool.id(),
+                                      self.container,
+                                      '--user',
+                                      'root@',
+                                      '--group',
+                                      'root@'])
+        print(rc)
+
+        # Now start dfuse and access the container, see who the file is owned by.
+        dfuse = DFuse(self.server,
+                      self.conf,
+                      pool=self.pool.id(),
+                      container=self.container,
+                      caching=False)
+        dfuse.start(v_hint='cont_rw_2')
+
+        ps = print_stat()
+        ps.add(dfuse.dir, show_dir=True)
+
+        with open(os.path.join(dfuse.dir, 'testfile'), 'r') as fd:
+            ps.add(os.path.join(dfuse.dir, 'testfile'), os.fstat(fd.fileno()))
+
+        dirname = os.path.join(dfuse.dir, 'rw_dir')
+        testfile = os.path.join(dirname, 'new_file')
+        fd = os.open(testfile, os.O_RDWR | os.O_CREAT, mode=int('600', base=8))
+        os.write(fd, b'read-only-data')
+        ps.add(testfile, attr=os.fstat(fd))
+        os.close(fd)
+        print(ps)
+
+        with open(os.path.join(dfuse.dir, 'rw_dir', 'new_file'), 'r') as fd:
+            data = fd.read()
+            print(data)
+
+        if dfuse.stop():
+            self.fatal_errors = True
 
     @needs_dfuse
     def test_complex_rename(self):


### PR DESCRIPTION
On create/mkdir then check the uid us the container, and if
they're different then apply the user bits to the group and
possibly other bits.

This is to avoid an issue where accessing other users containers
where any newly created files are owned by the container owner
and it's possible to create files without having perms to access
them.  This change will copy the user perms to the group perms,
and if there's no group overlap to the other perms as well, to
ensure the creating process is able to access the files.

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>