### PR TITLE
DAOS-9200 Remove compatibility code for daos_obj_generate_oid

### DIFF
--- a/src/common/tests_lib.c
+++ b/src/common/tests_lib.c
@@ -35,13 +35,12 @@ dts_oid_gen(unsigned seed)
 }
 
 daos_unit_oid_t
-dts_unit_oid_gen(daos_ofeat_t ofeats, uint32_t shard)
+dts_unit_oid_gen(enum daos_otype_t type, uint32_t shard)
 {
 	daos_unit_oid_t	uoid;
 
 	uoid.id_pub	= dts_oid_gen(time(NULL));
-	daos_obj_set_oid(&uoid.id_pub, daos_obj_feat2type(ofeats),
-			 DTS_OCLASS_DEF, shard + 1, 0);
+	daos_obj_set_oid(&uoid.id_pub, type, DTS_OCLASS_DEF, shard + 1, 0);
 	uoid.id_shard	= shard;
 	uoid.id_pad_32	= 0;
 

--- a/src/include/daos/object.h
+++ b/src/include/daos/object.h
@@ -229,7 +229,7 @@ unsigned int daos_oclass_grp_nr(struct daos_oclass_attr *oc_attr,
 int daos_oclass_fit_max(daos_oclass_id_t oc_id, int domain_nr, int target_nr,
 			enum daos_obj_redun *ord, uint32_t *nr);
 bool daos_oclass_is_valid(daos_oclass_id_t oc_id);
-daos_oclass_id_t daos_obj_get_oclass(daos_handle_t coh, daos_ofeat_t ofeats,
+daos_oclass_id_t daos_obj_get_oclass(daos_handle_t coh, enum daos_otype_t type,
 				   daos_oclass_hints_t hints, uint32_t args);
 
 /** bits for the specified rank */
@@ -321,39 +321,6 @@ static inline bool
 daos_oid_is_oit(daos_obj_id_t oid)
 {
 	return daos_obj_id2type(oid) == DAOS_OT_OIT;
-}
-
-/**
- * For backward compatibility purpose
- */
-static inline enum daos_otype_t
-daos_obj_feat2type(daos_ofeat_t feat)
-{
-	if (feat == (DAOS_OF_AKEY_UINT64 | DAOS_OF_DKEY_UINT64))
-		return DAOS_OT_MULTI_UINT64;
-	else if (feat == DAOS_OF_AKEY_UINT64)
-		return DAOS_OT_AKEY_UINT64;
-	else if (feat == DAOS_OF_DKEY_UINT64)
-		return DAOS_OT_DKEY_UINT64;
-	else if (feat == DAOS_OF_DKEY_LEXICAL)
-		return DAOS_OT_DKEY_LEXICAL;
-	else if (feat == DAOS_OF_AKEY_LEXICAL)
-		return DAOS_OT_AKEY_LEXICAL;
-	else if (feat == (DAOS_OF_DKEY_LEXICAL | DAOS_OF_AKEY_LEXICAL))
-		return DAOS_OT_MULTI_LEXICAL;
-	else if (feat == (DAOS_OF_DKEY_UINT64 | DAOS_OF_KV_FLAT | DAOS_OF_ARRAY))
-		return DAOS_OT_ARRAY;
-	else if (feat == (DAOS_OF_DKEY_UINT64 | DAOS_OF_KV_FLAT | DAOS_OF_ARRAY_BYTE))
-		return DAOS_OT_ARRAY_BYTE;
-	else if (feat == (DAOS_OF_DKEY_UINT64 | DAOS_OF_KV_FLAT))
-		return DAOS_OT_ARRAY_ATTR;
-	else if (feat == DAOS_OF_KV_FLAT)
-		return DAOS_OT_KV_HASHED;
-	else if (feat == (DAOS_OF_KV_FLAT | DAOS_OF_DKEY_LEXICAL))
-		return DAOS_OT_KV_LEXICAL;
-
-	/** default */
-	return DAOS_OT_MULTI_HASHED;
 }
 
 /*

--- a/src/include/daos/tests_lib.h
+++ b/src/include/daos/tests_lib.h
@@ -49,7 +49,7 @@ void dts_key_gen(char *key, unsigned int key_len, const char *prefix);
 daos_obj_id_t dts_oid_gen(unsigned seed);
 
 /** generate a random and unique baseline object ID */
-daos_unit_oid_t dts_unit_oid_gen(daos_ofeat_t ofeats, uint32_t shard);
+daos_unit_oid_t dts_unit_oid_gen(enum daos_otype_t type, uint32_t shard);
 
 /** Set rank into the oid */
 #define dts_oid_set_rank(oid, rank)	daos_oclass_sr_set_rank(oid, rank)

--- a/src/include/daos_obj.h
+++ b/src/include/daos_obj.h
@@ -539,9 +539,9 @@ enum {
  * \param[in]	args	Reserved.
  */
 int
-daos_obj_generate_oid(daos_handle_t coh, daos_obj_id_t *oid,
-		      enum daos_otype_t type, daos_oclass_id_t cid,
-		      daos_oclass_hints_t hints, uint32_t args);
+daos_obj_generate_oid2(daos_handle_t coh, daos_obj_id_t *oid,
+                       enum daos_otype_t type, daos_oclass_id_t cid,
+                       daos_oclass_hints_t hints, uint32_t args);
 
 /**
  * Open an DAOS object.
@@ -1130,15 +1130,6 @@ daos_oit_list(daos_handle_t oh, daos_obj_id_t *oids, uint32_t *oids_nr,
  * Backward compatibility code.
  * Please don't use directly
  */
-typedef uint16_t daos_ofeat_t;
-int
-daos_obj_generate_oid1(daos_handle_t coh, daos_obj_id_t *oid,
-		       daos_ofeat_t type, daos_oclass_id_t cid,
-		       daos_oclass_hints_t hints, uint32_t args);
-int
-daos_obj_generate_oid2(daos_handle_t coh, daos_obj_id_t *oid,
-		       enum daos_otype_t type, daos_oclass_id_t cid,
-		       daos_oclass_hints_t hints, uint32_t args);
 enum {
 	/** DKEY keys not hashed and sorted numerically.   Keys are accepted
 	 *  in client's byte order and DAOS is responsible for correct behavior
@@ -1173,40 +1164,8 @@ enum {
 
 #if defined(__cplusplus)
 }
-#define daos_obj_generate_oid daos_obj_generate_oid_cpp
-static inline int
-daos_obj_generate_oid_cpp(daos_handle_t coh, daos_obj_id_t *oid,
-			  enum daos_otype_t type, daos_oclass_id_t cid,
-			  daos_oclass_hints_t hints, uint32_t args)
-{
-	return daos_obj_generate_oid2(coh, oid, type, cid, hints, args);
-}
-static inline int
-daos_obj_generate_oid_cpp(daos_handle_t coh, daos_obj_id_t *oid,
-			  daos_ofeat_t feat, daos_oclass_id_t cid,
-			  daos_oclass_hints_t hints, uint32_t args)
-{
-	return daos_obj_generate_oid1(coh, oid, feat, cid, hints, args);
-}
-#else
-/**
- * for backward compatility, support old api where the type was a set of feature
- * flags
- */
-#define daos_obj_generate_oid(coh, oid, type, ...)			\
-	({								\
-		int _ret;						\
-		if (__builtin_types_compatible_p(__typeof__(type),	\
-						 daos_ofeat_t)) {	\
-			_ret = daos_obj_generate_oid((coh), (oid),	\
-						     (type),		\
-						     __VA_ARGS__);	\
-		} else {						\
-			_ret = daos_obj_generate_oid2((coh), (oid),	\
-						      (type),		\
-						      __VA_ARGS__);	\
-		}							\
-		_ret;							\
-	})
 #endif /* __cplusplus */
+
+#define daos_obj_generate_oid daos_obj_generate_oid2
+
 #endif /* __DAOS_OBJ_H__ */

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -5796,28 +5796,6 @@ daos_dc_obj2id(void *ptr, daos_obj_id_t *id)
 /** Disable backward compat code */
 #undef daos_obj_generate_oid
 
-int
-daos_obj_generate_oid(daos_handle_t coh, daos_obj_id_t *oid,
-		      enum daos_otype_t in, daos_oclass_id_t cid,
-		      daos_oclass_hints_t hints, uint32_t args)
-{
-	daos_ofeat_t	feat = (daos_ofeat_t)in;
-
-	return daos_obj_generate_oid2(coh, oid, daos_obj_feat2type(feat), cid, hints, args);
-}
-
-/**
- * Create version that uses the deprecated daos_ofeat_t
- */
-int
-daos_obj_generate_oid1(daos_handle_t coh, daos_obj_id_t *oid,
-		       daos_ofeat_t feat, daos_oclass_id_t cid,
-		       daos_oclass_hints_t hints, uint32_t args)
-{
-	return daos_obj_generate_oid(coh, oid, (enum daos_otype_t)feat, cid,
-				     hints, args);
-}
-
 /**
  * Real latest & greatest implementation of container create.
  * Used by anyone including the daos_obj.h header file.
@@ -5904,7 +5882,7 @@ daos_obj_generate_oid_by_rf(daos_handle_t poh, uint64_t rf_factor,
 }
 
 daos_oclass_id_t
-daos_obj_get_oclass(daos_handle_t coh, daos_ofeat_t ofeats,
+daos_obj_get_oclass(daos_handle_t coh, enum daos_otype_t type,
 		    daos_oclass_hints_t hints, uint32_t args)
 {
 	daos_handle_t		poh;
@@ -5914,7 +5892,6 @@ daos_obj_get_oclass(daos_handle_t coh, daos_ofeat_t ofeats,
 	int			rc;
 	enum daos_obj_redun	ord;
 	uint32_t		nr_grp;
-	enum daos_otype_t	type = daos_obj_feat2type(ofeats);
 
 	/** select the oclass */
 	poh = dc_cont_hdl2pool_hdl(coh);

--- a/src/tests/suite/daos_dist_tx.c
+++ b/src/tests/suite/daos_dist_tx.c
@@ -940,13 +940,12 @@ dtx_19(void **state)
 static void
 dtx_init_oid_req_akey(test_arg_t *arg, daos_obj_id_t *oids, struct ioreq *reqs,
 		      daos_oclass_id_t *ocs, daos_iod_type_t *types, char *akeys[],
-		      int oid_req_cnt, int akey_cnt, uint8_t ofeats)
+		      int oid_req_cnt, int akey_cnt, enum daos_otype_t type)
 {
 	int	i;
 
 	for (i = 0; i < oid_req_cnt; i++) {
-		oids[i] = daos_test_oid_gen(arg->coh, ocs[i],
-				daos_obj_feat2type(ofeats), 0, arg->myrank);
+		oids[i] = daos_test_oid_gen(arg->coh, ocs[i], type, 0, arg->myrank);
 		ioreq_init(&reqs[i], arg->coh, oids[i], types[i], arg);
 	}
 

--- a/src/vos/tests/vts_common.h
+++ b/src/vos/tests/vts_common.h
@@ -119,7 +119,7 @@ int run_aggregate_tests(bool slow, const char *cfg);
 int run_dtx_tests(const char *cfg);
 int run_gc_tests(const char *cfg);
 int run_pm_tests(const char *cfg);
-int run_io_test(daos_ofeat_t feats, int keys, bool nest_iterators,
+int run_io_test(enum daos_otype_t type, int keys, bool nest_iterators,
 		const char *cfg);
 int run_ts_tests(const char *cfg);
 

--- a/src/vos/tests/vts_io.h
+++ b/src/vos/tests/vts_io.h
@@ -71,7 +71,7 @@ struct io_test_args {
 	const char		*dkey;
 	const char		*akey;
 	void			*custom;
-	int			 ofeat;
+	enum daos_otype_t 	 ofeat;
 	int			 akey_size;
 	int			 dkey_size;
 	int			 co_create_step;
@@ -90,9 +90,9 @@ struct vts_counter {
 };
 
 daos_epoch_t		gen_rand_epoch(void);
-daos_unit_oid_t		gen_oid(daos_ofeat_t ofeats);
+daos_unit_oid_t		gen_oid(enum daos_otype_t type);
 void			reset_oid_stable(uint32_t seed);
-daos_unit_oid_t		gen_oid_stable(daos_ofeat_t ofeats);
+daos_unit_oid_t		gen_oid_stable(enum daos_otype_t type);
 void			inc_cntr(unsigned long op_flags);
 void			test_args_reset(struct io_test_args *args,
 					uint64_t pool_size);

--- a/src/vos/tests/vts_mvcc.c
+++ b/src/vos/tests/vts_mvcc.c
@@ -167,7 +167,7 @@ set_oid(int i, char *path, daos_unit_oid_t *oid)
 	D_ASSERT(L_O < strlen(path));
 	oid->id_pub.lo = (i << 8) + path[L_O];
 	daos_obj_set_oid(&oid->id_pub,
-			 daos_obj_feat2type(DAOS_OF_AKEY_UINT64 | DAOS_OF_DKEY_UINT64),
+			 DAOS_OF_AKEY_UINT64 | DAOS_OF_DKEY_UINT64,
 			 OR_RP_1, 1, 0);
 	oid->id_shard = 0;
 	oid->id_pad_32 = 0;


### PR DESCRIPTION
daos_obj_generate_oid() is removed. Only daos_obj_generate_oid2 is
supported in API. daos_obj_generate_oid() is used in all other
places. Type daos_ofeat_t is removed. Only enum daos_otype_t is
used.

Signed-off-by: Lei Huang <wiliam_huang@hotmail.com>