### PR TITLE
DAOS-9354 Test: Fix daos_control_config and dmg_nvme_scan_test

### DIFF
--- a/src/tests/ftest/control/daos_control_config.py
+++ b/src/tests/ftest/control/daos_control_config.py
@@ -24,7 +24,7 @@ class DaosControlConfigTest(TestWithServers):
         Test Description: Test dmg tool executes with variant positive and
         negative inputs to its configuration file.
 
-        :avocado: tags=all,small,control,daily_regression,control_start,basic
+        :avocado: tags=all,hw,small,control,daily_regression,control_start,basic
         """
         # Get the input to verify
         c_val = self.params.get("config_val", "/run/control_config_val/*/")

--- a/src/tests/ftest/control/dmg_nvme_scan_test.py
+++ b/src/tests/ftest/control/dmg_nvme_scan_test.py
@@ -31,7 +31,7 @@ class DmgNvmeScanTest(TestWithServers):
         JIRA ID: DAOS-2485
         Test Description: Test basic dmg functionality to scan the nvme storage.
         on the system.
-        :avocado: tags=all,tiny,daily_regression,dmg,nvme_scan,basic
+        :avocado: tags=all,tiny,hw,small,daily_regression,dmg,nvme_scan,basic
         """
         # Create dmg command
         dmg = DmgCommand(os.path.join(self.prefix, "bin"))


### PR DESCRIPTION
Run daos_control_config and dmg_nvme_scan_test in hw small

Test-tag: control_start nvme_scan