### PR TITLE
DAOS-9370 test: fix a bug in test_runable()

### DIFF
--- a/src/tests/suite/daos_test_common.c
+++ b/src/tests/suite/daos_test_common.c
@@ -629,7 +629,7 @@ bool
 test_runable(test_arg_t *arg, unsigned int required_nodes)
 {
 	int	i;
-	bool	runable = true;
+	int	runable = 1;
 
 	if (arg == NULL) {
 		print_message("state not set, likely due to group-setup"
@@ -651,7 +651,7 @@ test_runable(test_arg_t *arg, unsigned int required_nodes)
 					      required_nodes,
 					      arg->srv_ntgts,
 					      arg->srv_disabled_ntgts);
-			runable = false;
+			runable = 0;
 		}
 
 		for (i = 0; i < MAX_KILLS; i++)
@@ -663,7 +663,7 @@ test_runable(test_arg_t *arg, unsigned int required_nodes)
 
 	MPI_Bcast(&runable, 1, MPI_INT, 0, MPI_COMM_WORLD);
 	MPI_Barrier(MPI_COMM_WORLD);
-	return runable;
+	return runable == 1;
 }
 
 int


### PR DESCRIPTION
Commit 2bb877846c removed "static" from runable, that is good. A side
effect is may cause stack_chk_fail() as the bool type size less than
MPI_INT.

Signed-off-by: Xuezhao Liu <xuezhao.liu@intel.com>