### PR TITLE
DAOS-9374 vos: Fix vos_perf integer key handling

### DIFF
--- a/src/tests/perf_internal.h
+++ b/src/tests/perf_internal.h
@@ -10,8 +10,6 @@
 #include <daos/common.h>
 #include <daos/dts.h>
 
-/* unused object class to identify VOS (storage only) test mode */
-#define DAOS_OC_RAW	(0xBEE)
 #define RANK_ZERO	(0)
 #define STRIDE_MIN	(4) /* Should be changed with updating NB places */
 
@@ -146,8 +144,6 @@ pf_class2name(int obj_class)
 	switch (obj_class) {
 	default:
 		return "unknown";
-	case DAOS_OC_RAW:
-		return "VOS (storage only)";
 	case DAOS_OC_ECHO_TINY_RW:
 		return "ECHO TINY (network only, non-replica)";
 	case DAOS_OC_ECHO_R2S_RW:

--- a/src/tests/vos_perf.c
+++ b/src/tests/vos_perf.c
@@ -393,18 +393,11 @@ objects_open(void)
 
 	perf_setup_keys();
 
-	for (i = 0; i < ts_obj_p_cont; i++) {
-		if (!ts_oid_init) {
-			ts_oids[i] = daos_test_oid_gen(
-				DAOS_HDL_INVAL, DAOS_OC_RAW, ts_flags, 0,
-				ts_ctx.tsc_mpi_rank);
-		}
-
-		ts_uoids[i].id_pub = ts_oids[i];
-		ts_uoids[i].id_shard = 0;
-		ts_uoids[i].id_pad_32 = 0;
+	if (!ts_oid_init) {
+		for (i = 0; i < ts_obj_p_cont; i++)
+			ts_uoids[i] = dts_unit_oid_gen(ts_flags, 0);
+		ts_oid_init = true;
 	}
-	ts_oid_init = true;
 	return 0;
 }
 

--- a/src/tests/vos_perf.c
+++ b/src/tests/vos_perf.c
@@ -844,7 +844,7 @@ main(int argc, char **argv)
 
 	if (ts_ctx.tsc_mpi_rank == 0) {
 		fprintf(stdout,
-			"Test :\n\t%s\n"
+			"Test :\n\tVOS storage\n"
 			"Pool :\n\t%s\n"
 			"Parameters :\n"
 			"\tpool size     : SCM: %u MB, NVMe: %u MB\n"
@@ -857,7 +857,7 @@ main(int argc, char **argv)
 			"\tstride size   : %u\n"
 			"\tzero copy     : %s\n"
 			"\tVOS file      : %s\n",
-			pf_class2name(DAOS_OC_RAW), uuid_buf,
+			uuid_buf,
 			(unsigned int)(ts_scm_size >> 20),
 			(unsigned int)(ts_nvme_size >> 20),
 			credits,


### PR DESCRIPTION
API for creating the oid was incorrectly handling flags so
key query check was failing

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>