### PR TITLE
DAOS-9350 log: Fix issues with DF_KEY and daos_key2str

### DIFF
--- a/src/common/debug.c
+++ b/src/common/debug.c
@@ -241,10 +241,10 @@ daos_key2str(daos_key_t *key)
 
 		if (can_print) {
 			if (is_int)
-				snprintf(buf, DF_KEY_STR_SIZE, "%*s uint64:"DF_U64, len, akey,
+				snprintf(buf, DF_KEY_STR_SIZE, "%.*s uint64:"DF_U64, len, akey,
 					 *(uint64_t *)akey);
 			else
-				snprintf(buf, DF_KEY_STR_SIZE, "%*s", len, akey);
+				snprintf(buf, DF_KEY_STR_SIZE, "%.*s", len, akey);
 		} else if (is_int) {
 			snprintf(buf, DF_KEY_STR_SIZE, "uint64:"DF_U64, *(uint64_t *)akey);
 		} else {

--- a/src/include/daos/common.h
+++ b/src/include/daos/common.h
@@ -155,9 +155,8 @@ char *DP_UUID(const void *uuid);
 char *daos_key2str(daos_key_t *key);
 #define DF_KEY_STR_SIZE		64
 
-#define DF_KEY			"[%d] '%.*s'"
+#define DF_KEY			"[%d] '%s'"
 #define DP_KEY(key)		(int)(key)->iov_len,	\
-				DF_KEY_STR_SIZE,	\
 				daos_key2str(key)
 #endif
 


### PR DESCRIPTION
First of all, daos_key2str returns a NULL terminated string
so there is no need to limit the characters we print.

Secondly, the %*s in daos_key2str should be %.*s.  The former
is valid printf but simply is a format specifier whereas the
latter actually limits the characters printed.

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>