### PR TITLE
DAOS-9375 dtx: remove RPC resent related logic from VOS

### DIFF
--- a/src/dtx/dtx_common.c
+++ b/src/dtx/dtx_common.c
@@ -1149,8 +1149,7 @@ dtx_leader_end(struct dtx_leader_handle *dlh, struct ds_cont_child *cont,
 	 * Let's check DTX status locally before marking as 'committable'.
 	 */
 	if (dth->dth_ver < cont->sc_dtx_resync_ver) {
-		rc = vos_dtx_check(cont->sc_hdl, &dth->dth_xid,
-				   NULL, NULL, NULL, NULL, false);
+		rc = vos_dtx_check(cont->sc_hdl, &dth->dth_xid, NULL, NULL, NULL, NULL);
 		/* Committed by race, do nothing. */
 		if (rc == DTX_ST_COMMITTED || rc == DTX_ST_COMMITTABLE)
 			D_GOTO(abort, result = 0);
@@ -1175,12 +1174,11 @@ dtx_leader_end(struct dtx_leader_handle *dlh, struct ds_cont_child *cont,
 		}
 
 		if (rc != DTX_ST_PREPARED) {
-			D_ASSERT(rc < 0);
+			D_ASSERTF(rc < 0, "Invalid status %d for DTX "DF_DTI"\n",
+				  rc, DP_DTI(&dth->dth_xid));
 
-			D_WARN(DF_UUID": Failed to check local DTX "DF_DTI
-			       "status: "DF_RC"\n",
-			       DP_UUID(cont->sc_uuid), DP_DTI(&dth->dth_xid),
-			       DP_RC(rc));
+			D_WARN(DF_UUID": Failed to check local DTX "DF_DTI" status: "DF_RC"\n",
+			       DP_UUID(cont->sc_uuid), DP_DTI(&dth->dth_xid), DP_RC(rc));
 			D_GOTO(abort, result = rc);
 		}
 	}
@@ -1617,8 +1615,10 @@ dtx_handle_resend(daos_handle_t coh,  struct dtx_id *dti,
 		 */
 		return -DER_NONEXIST;
 
-	rc = vos_dtx_check(coh, dti, epoch, pm_ver, NULL, NULL, true);
+	rc = vos_dtx_check(coh, dti, epoch, pm_ver, NULL, NULL);
 	switch (rc) {
+	case DTX_ST_INITED:
+		return -DER_INPROGRESS;
 	case DTX_ST_PREPARED:
 		return 0;
 	case DTX_ST_COMMITTED:

--- a/src/dtx/dtx_internal.h
+++ b/src/dtx/dtx_internal.h
@@ -166,10 +166,9 @@ int dtx_status_handle_one(struct ds_cont_child *cont, struct dtx_entry *dte,
 enum dtx_status_handle_result {
 	DSHR_NEED_COMMIT	= 1,
 	DSHR_NEED_RETRY		= 2,
-	DSHR_COMMITTED		= 3,
-	DSHR_ABORTED		= 4,
-	DSHR_ABORT_FAILED	= 5,
-	DSHR_CORRUPT		= 6,
+	DSHR_IGNORE		= 3,
+	DSHR_ABORT_FAILED	= 4,
+	DSHR_CORRUPT		= 5,
 };
 
 #endif /* __DTX_INTERNAL_H__ */

--- a/src/dtx/dtx_resync.c
+++ b/src/dtx/dtx_resync.c
@@ -81,13 +81,21 @@ dtx_resync_commit(struct ds_cont_child *cont,
 		 * committed or aborted the DTX during we handling other
 		 * DTXs. So double check the status before current commit.
 		 */
-		rc = vos_dtx_check(cont->sc_hdl, &dre->dre_xid,
-				   NULL, NULL, NULL, NULL, false);
+		rc = vos_dtx_check(cont->sc_hdl, &dre->dre_xid, NULL, NULL, NULL, NULL);
 
 		/* Skip this DTX since it has been committed or aggregated. */
-		if (rc == DTX_ST_COMMITTED || rc == DTX_ST_COMMITTABLE ||
-		    rc == -DER_NONEXIST)
+		if (rc == DTX_ST_COMMITTED || rc == DTX_ST_COMMITTABLE || rc == -DER_NONEXIST)
 			goto next;
+
+		/* Remote ones are all ready, but local is not, then abort such DTX.
+		 * If related RPC sponsor is still alive, related RPC will be resent.
+		 */
+		if (unlikely(rc == DTX_ST_INITED)) {
+			rc = dtx_abort(cont, &dre->dre_dte, dre->dre_epoch);
+			D_DEBUG(DB_TRACE, "As new leader for DTX "DF_DTI", abort it (1): "DF_RC"\n",
+				DP_DTI(&dre->dre_dte.dte_xid), DP_RC(rc));
+			goto next;
+		}
 
 		/* If we failed to check the status, then assume that it is
 		 * not committed, then commit it (again), that is harmless.
@@ -307,16 +315,14 @@ dtx_status_handle_one(struct ds_cont_child *cont, struct dtx_entry *dte,
 		 * committed or aborted the DTX during we handling other
 		 * DTXs. So double check the status before next action.
 		 */
-		rc = vos_dtx_check(cont->sc_hdl, &dte->dte_xid,
-				   NULL, NULL, NULL, NULL, false);
+		rc = vos_dtx_check(cont->sc_hdl, &dte->dte_xid, NULL, NULL, NULL, NULL);
 
-		/* Skip this DTX that it may has been committed or aborted. */
-		if (rc == DTX_ST_COMMITTED || rc == DTX_ST_COMMITTABLE ||
-		    rc == -DER_NONEXIST)
-			D_GOTO(out, rc = DSHR_COMMITTED);
+		/* Skip the DTX that may has been committed or aborted. */
+		if (rc == DTX_ST_COMMITTED || rc == DTX_ST_COMMITTABLE || rc == -DER_NONEXIST)
+			D_GOTO(out, rc = DSHR_IGNORE);
 
 		/* Skip this DTX if failed to get the status. */
-		if (rc != DTX_ST_PREPARED) {
+		if (rc != DTX_ST_PREPARED && rc != DTX_ST_INITED) {
 			D_WARN("Not sure about whether the DTX "DF_DTI
 			       " can be abort or not: %d, skip it.\n",
 			       DP_DTI(&dte->dte_xid), rc);
@@ -338,9 +344,8 @@ dtx_status_handle_one(struct ds_cont_child *cont, struct dtx_entry *dte,
 		 */
 		rc = dtx_abort(cont, dte, epoch);
 
-		D_DEBUG(DB_TRACE,
-			"As the new leader for TX "DF_DTI", abort it: "
-			DF_RC"\n", DP_DTI(&dte->dte_xid), DP_RC(rc));
+		D_DEBUG(DB_TRACE, "As new leader for DTX "DF_DTI", abort it (2): "DF_RC"\n",
+			DP_DTI(&dte->dte_xid), DP_RC(rc));
 
 		if (rc < 0) {
 			if (err != NULL)
@@ -349,7 +354,7 @@ dtx_status_handle_one(struct ds_cont_child *cont, struct dtx_entry *dte,
 			return DSHR_ABORT_FAILED;
 		}
 
-		return DSHR_ABORTED;
+		return DSHR_IGNORE;
 	default:
 		D_WARN("Not sure about whether the DTX "DF_DTI
 		       " can be committed or not: %d, skip it.\n",
@@ -419,8 +424,7 @@ dtx_status_handle(struct dtx_resync_args *dra)
 			d_list_del(&dre->dre_link);
 			d_list_add_tail(&dre->dre_link, &drh->drh_list);
 			continue;
-		case DSHR_COMMITTED:
-		case DSHR_ABORTED:
+		case DSHR_IGNORE:
 		case DSHR_ABORT_FAILED:
 		case DSHR_CORRUPT:
 		default:

--- a/src/dtx/dtx_rpc.c
+++ b/src/dtx/dtx_rpc.c
@@ -1055,8 +1055,7 @@ next:
 			if (failout)
 				D_GOTO(out, rc = -DER_INPROGRESS);
 			continue;
-		case DSHR_COMMITTED:
-		case DSHR_ABORTED:
+		case DSHR_IGNORE:
 			D_FREE(dsp);
 			continue;
 		case DSHR_ABORT_FAILED:

--- a/src/include/daos_srv/vos.h
+++ b/src/include/daos_srv/vos.h
@@ -68,7 +68,6 @@ vos_dtx_validation(struct dtx_handle *dth);
  * \param pm_ver	[OUT]	Hold the DTX's pool map version.
  * \param mbs		[OUT]	Pointer to the DTX participants information.
  * \param dck		[OUT]	Pointer to the key for CoS cache.
- * \param for_resent	[IN]	The check is for check resent or not.
  *
  * \return		DTX_ST_PREPARED	means that the DTX has been 'prepared',
  *					so the local modification has been done
@@ -82,12 +81,12 @@ vos_dtx_validation(struct dtx_handle *dth);
  *			-DER_AGAIN means DTX re-index is in processing, not sure
  *				   about the existence of the DTX entry, need to
  *				   retry sometime later.
+ *			DTX_ST_INITED	means that the DTX is just initialized but not prepared.
  *			Other negative value if error.
  */
 int
 vos_dtx_check(daos_handle_t coh, struct dtx_id *dti, daos_epoch_t *epoch,
-	      uint32_t *pm_ver, struct dtx_memberships **mbs,
-	      struct dtx_cos_key *dck, bool for_resent);
+	      uint32_t *pm_ver, struct dtx_memberships **mbs, struct dtx_cos_key *dck);
 
 /**
  * Commit the specified DTXs.

--- a/src/vos/tests/vts_dtx.c
+++ b/src/vos/tests/vts_dtx.c
@@ -824,8 +824,7 @@ dtx_18(void **state)
 	assert_rc_equal(rc, 10);
 
 	for (i = 0; i < 10; i++) {
-		rc = vos_dtx_check(args->ctx.tc_co_hdl, &xid[i],
-				   NULL, NULL, NULL, NULL, false);
+		rc = vos_dtx_check(args->ctx.tc_co_hdl, &xid[i], NULL, NULL, NULL, NULL);
 		assert_rc_equal(rc, DTX_ST_COMMITTED);
 	}
 
@@ -836,8 +835,7 @@ dtx_18(void **state)
 	assert_rc_equal(rc, 0);
 
 	for (i = 0; i < 10; i++) {
-		rc = vos_dtx_check(args->ctx.tc_co_hdl, &xid[i],
-				   NULL, NULL, NULL, NULL, false);
+		rc = vos_dtx_check(args->ctx.tc_co_hdl, &xid[i], NULL, NULL, NULL, NULL);
 		assert_rc_equal(rc, -DER_NONEXIST);
 	}
 

--- a/src/vos/vos_dtx.c
+++ b/src/vos/vos_dtx.c
@@ -422,11 +422,8 @@ dtx_cmt_ent_update(struct btr_instance *tins, struct btr_record *rec,
 		rec->rec_off = umem_ptr2off(&tins->ti_umm, dce_new);
 		D_FREE(dce_old);
 	} else if (!dce_old->dce_reindex) {
-		D_ASSERTF(dce_new->dce_reindex, "Repeatedly commit DTX "
-			  DF_DTI": old is %s, new is %s\n",
-			  DP_DTI(&DCE_XID(dce_new)),
-			  dce_old->dce_resent ? "resent" : "original",
-			  dce_new->dce_resent ? "resent" : "original");
+		D_ASSERTF(dce_new->dce_reindex, "Repeatedly commit DTX "DF_DTI"\n",
+			  DP_DTI(&DCE_XID(dce_new)));
 		dce_new->dce_exist = 1;
 	}
 
@@ -757,8 +754,7 @@ dtx_rec_release(struct vos_container *cont, struct vos_dtx_act_ent *dae,
 
 static int
 vos_dtx_commit_one(struct vos_container *cont, struct dtx_id *dti,
-		   daos_epoch_t epoch, bool resent,
-		   struct vos_dtx_cmt_ent **dce_p,
+		   daos_epoch_t epoch, struct vos_dtx_cmt_ent **dce_p,
 		   struct vos_dtx_act_ent **dae_p,
 		   bool *rm_cos, bool *fatal)
 {
@@ -827,7 +823,6 @@ vos_dtx_commit_one(struct vos_container *cont, struct dtx_id *dti,
 		DCE_XID(dce) = DAE_XID(dae);
 		DCE_EPOCH(dce) = DAE_EPOCH(dae);
 		DCE_HANDLE_TIME(dce) = dae->dae_start_time;
-		dce->dce_resent = dae->dae_resent;
 	} else {
 		struct dtx_handle	*dth = vos_dth_get();
 
@@ -836,7 +831,6 @@ vos_dtx_commit_one(struct vos_container *cont, struct dtx_id *dti,
 		DCE_XID(dce) = *dti;
 		DCE_EPOCH(dce) = dth->dth_epoch;
 		DCE_HANDLE_TIME(dce) = crt_hlc_get();
-		dce->dce_resent = resent;
 	}
 
 	d_iov_set(&riov, dce, sizeof(*dce));
@@ -965,7 +959,7 @@ vos_dtx_alloc(struct vos_dtx_blob_df *dbd, struct dtx_handle *dth)
 
 	rc = lrua_allocx(cont->vc_dtx_array, &idx, dth->dth_epoch, &dae);
 	if (rc != 0) {
-		/** The array is full, need to commit some transactions first */
+		/* The array is full, need to commit some transactions first */
 		if (rc == -DER_BUSY)
 			return -DER_INPROGRESS;
 		return rc;
@@ -979,9 +973,6 @@ vos_dtx_alloc(struct vos_dtx_blob_df *dbd, struct dtx_handle *dth)
 	DAE_EPOCH(dae) = dth->dth_epoch;
 	DAE_FLAGS(dae) = dth->dth_flags;
 	DAE_VER(dae) = dth->dth_ver;
-
-	if (dth->dth_resent)
-		dae->dae_resent = 1;
 
 	if (dth->dth_mbs != NULL) {
 		DAE_TGT_CNT(dae) = dth->dth_mbs->dm_tgt_cnt;
@@ -1589,9 +1580,7 @@ vos_dtx_prepared(struct dtx_handle *dth, struct vos_dtx_cmt_ent **dce_p)
 
 	if (dth->dth_solo) {
 		rc = vos_dtx_commit_internal(cont, &dth->dth_xid, 1,
-					     dth->dth_epoch,
-					     dth->dth_resent ? true : false,
-					     NULL, NULL, dce_p);
+					     dth->dth_epoch, NULL, NULL, dce_p);
 		dth->dth_active = 0;
 		dth->dth_pinned = 0;
 		if (rc >= 0) {
@@ -1732,8 +1721,7 @@ vos_dtx_pack_mbs(struct umem_instance *umm, struct vos_dtx_act_ent *dae)
 
 int
 vos_dtx_check(daos_handle_t coh, struct dtx_id *dti, daos_epoch_t *epoch,
-	      uint32_t *pm_ver, struct dtx_memberships **mbs,
-	      struct dtx_cos_key *dck, bool for_resent)
+	      uint32_t *pm_ver, struct dtx_memberships **mbs, struct dtx_cos_key *dck)
 {
 	struct vos_container	*cont;
 	struct vos_dtx_act_ent	*dae;
@@ -1799,10 +1787,10 @@ vos_dtx_check(daos_handle_t coh, struct dtx_id *dti, daos_epoch_t *epoch,
 				return -DER_MISMATCH;
 		}
 
-		if (dae->dae_prepared || !for_resent)
+		if (dae->dae_prepared)
 			return DTX_ST_PREPARED;
 
-		return -DER_INPROGRESS;
+		return DTX_ST_INITED;
 	}
 
 	if (rc == -DER_NONEXIST) {
@@ -1821,7 +1809,7 @@ vos_dtx_check(daos_handle_t coh, struct dtx_id *dti, daos_epoch_t *epoch,
 		}
 	}
 
-	if (rc == -DER_NONEXIST && for_resent && cont->vc_reindex_cmt_dtx)
+	if (rc == -DER_NONEXIST && cont->vc_reindex_cmt_dtx)
 		rc = -DER_INPROGRESS;
 
 	return rc;
@@ -1829,7 +1817,7 @@ vos_dtx_check(daos_handle_t coh, struct dtx_id *dti, daos_epoch_t *epoch,
 
 int
 vos_dtx_commit_internal(struct vos_container *cont, struct dtx_id dtis[],
-			int count, daos_epoch_t epoch, bool resent, bool rm_cos[],
+			int count, daos_epoch_t epoch, bool rm_cos[],
 			struct vos_dtx_act_ent **daes, struct vos_dtx_cmt_ent **dces)
 {
 	struct vos_cont_df		*cont_df = cont->vc_cont_df;
@@ -1865,10 +1853,9 @@ again:
 	     i++, cur++) {
 		struct vos_dtx_cmt_ent	*dce = NULL;
 
-		rc = vos_dtx_commit_one(cont, &dtis[cur], epoch, resent, &dce,
+		rc = vos_dtx_commit_one(cont, &dtis[cur], epoch, &dce,
 					daes != NULL ? &daes[cur] : NULL,
-					rm_cos != NULL ? &rm_cos[cur] : NULL,
-					&fatal);
+					rm_cos != NULL ? &rm_cos[cur] : NULL, &fatal);
 		if (dces != NULL)
 			dces[cur] = dce;
 
@@ -2052,8 +2039,7 @@ vos_dtx_commit(daos_handle_t coh, struct dtx_id dtis[], int count, bool rm_cos[]
 	/* Commit multiple DTXs via single PMDK transaction. */
 	rc = umem_tx_begin(vos_cont2umm(cont), NULL);
 	if (rc == 0) {
-		committed = vos_dtx_commit_internal(cont, dtis, count, 0,
-						    false, rm_cos, daes, dces);
+		committed = vos_dtx_commit_internal(cont, dtis, count, 0, rm_cos, daes, dces);
 		rc = umem_tx_end(vos_cont2umm(cont),
 				 committed > 0 ? 0 : committed);
 		if (rc == 0)
@@ -2205,7 +2191,7 @@ vos_dtx_aggregate(daos_handle_t coh)
 	if (dbd == NULL || dbd->dbd_count == 0)
 		return 0;
 
-	/** Take the opportunity to free some memory if we can */
+	/* Take the opportunity to free some memory if we can */
 	lrua_array_aggregate(cont->vc_dtx_array);
 
 	rc = umem_tx_begin(umm, NULL);

--- a/src/vos/vos_internal.h
+++ b/src/vos/vos_internal.h
@@ -263,8 +263,7 @@ struct vos_dtx_act_ent {
 					 dae_committed:1,
 					 dae_aborted:1,
 					 dae_maybe_shared:1,
-					 dae_prepared:1,
-					 dae_resent:1;
+					 dae_prepared:1;
 };
 
 #define DAE_XID(dae)		((dae)->dae_base.dae_xid)
@@ -290,8 +289,7 @@ struct vos_dtx_cmt_ent {
 
 	uint32_t			 dce_reindex:1,
 					 dce_exist:1,
-					 dce_invalid:1,
-					 dce_resent:1;
+					 dce_invalid:1;
 };
 
 #define DCE_XID(dce)		((dce)->dce_base.dce_xid)
@@ -472,11 +470,10 @@ int
 vos_dtx_prepared(struct dtx_handle *dth, struct vos_dtx_cmt_ent **dce_p);
 
 int
-vos_dtx_commit_internal(struct vos_container *cont, struct dtx_id *dtis,
-			int count, daos_epoch_t epoch,
-			bool resent, bool *rm_cos,
-			struct vos_dtx_act_ent **daes,
-			struct vos_dtx_cmt_ent **dces);
+vos_dtx_commit_internal(struct vos_container *cont, struct dtx_id dtis[],
+			int count, daos_epoch_t epoch, bool rm_cos[],
+			struct vos_dtx_act_ent **daes, struct vos_dtx_cmt_ent **dces);
+
 void
 vos_dtx_post_handle(struct vos_container *cont,
 		    struct vos_dtx_act_ent **daes,

--- a/src/vos/vos_io.c
+++ b/src/vos/vos_io.c
@@ -2263,8 +2263,7 @@ vos_update_end(daos_handle_t ioh, uint32_t pm_ver, daos_key_t *dkey, int err,
 			D_GOTO(abort, err = -DER_NOMEM);
 
 		err = vos_dtx_commit_internal(ioc->ic_cont, dth->dth_dti_cos,
-					      dth->dth_dti_cos_count,
-					      0, false, NULL, daes, dces);
+					      dth->dth_dti_cos_count, 0, NULL, daes, dces);
 		if (err <= 0)
 			D_FREE(daes);
 	}

--- a/src/vos/vos_obj.c
+++ b/src/vos/vos_obj.c
@@ -465,8 +465,7 @@ vos_obj_punch(daos_handle_t coh, daos_unit_oid_t oid, daos_epoch_t epoch,
 			D_GOTO(reset, rc = -DER_NOMEM);
 
 		rc = vos_dtx_commit_internal(cont, dth->dth_dti_cos,
-					     dth->dth_dti_cos_count,
-					     0, false, NULL, daes, dces);
+					     dth->dth_dti_cos_count, 0, NULL, daes, dces);
 		if (rc <= 0)
 			D_FREE(daes);
 	}


### PR DESCRIPTION
RPC resent related logic belong to up layer, such as object layer
or DTX module instead of inside VOS. So RPC resent related logic,
including some VOS APIs, such as vos_dtx_check(), are adjusted.

Some code cleanup.

Signed-off-by: Fan Yong <fan.yong@intel.com>