### PR TITLE
DAOS-623 build: Fix build

### DIFF
--- a/src/tests/vos_perf.c
+++ b/src/tests/vos_perf.c
@@ -469,7 +469,7 @@ pf_aggregate(struct pf_test *ts, struct pf_param *param)
 
 	TS_TIME_START(&param->pa_duration, start);
 
-	rc = vos_aggregate(ts_ctx.tsc_coh, &epr, NULL, NULL, NULL, true);
+	rc = vos_aggregate(ts_ctx.tsc_coh, &epr, NULL, NULL, true);
 
 	TS_TIME_END(&param->pa_duration, start);
 


### PR DESCRIPTION
Two conflicting patches caused master branch build to fail
vos_aggregate API changed and vos_perf started calling the
old API and both patches landed.

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>