### PR TITLE
DAOS-9178 build: Build fails with oneapi MPI (#7548)

### DIFF
--- a/site_scons/prereq_tools/base.py
+++ b/site_scons/prereq_tools/base.py
@@ -599,7 +599,8 @@ class PreReqComponent():
         for var in ["HOME", "TERM", "SSH_AUTH_SOCK",
                     "http_proxy", "https_proxy",
                     "PKG_CONFIG_PATH", "MODULEPATH",
-                    "MODULESHOME", "MODULESLOADED"]:
+                    "MODULESHOME", "MODULESLOADED",
+                    "I_MPI_ROOT"]:
             value = os.environ.get(var)
             if value:
                 real_env[var] = value


### PR DESCRIPTION
Add I_MPI_ROOT to list of variables to passthrough if set

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>