### PR TITLE
DAOS-9354 control: fix use after free

### DIFF
--- a/src/control/lib/spdk/nvme.go
+++ b/src/control/lib/spdk/nvme.go
@@ -251,10 +251,11 @@ func checkRet(retPtr *C.struct_ret_t, failMsg string) error {
 	}
 
 	if retPtr.rc != 0 {
+		reterr := errors.Wrap(FaultBindingFailed(int(retPtr.rc),
+			C.GoString(&retPtr.info[0])), failMsg)
 		clean(retPtr)
 
-		return errors.Wrap(FaultBindingFailed(int(retPtr.rc),
-			C.GoString(&retPtr.info[0])), failMsg)
+		return reterr
 	}
 
 	return nil


### PR DESCRIPTION
@retPtr was freed before using, see following confusing
output:

[2021-12-22 00:44:12.002315] init.c: 607:spdk_env_init: *ERROR*: Failed to initialize DPDK
wolf-135.wolf.hpdd.intel.com ERROR 2021/12/22 00:44:12 /usr/bin/daos_admin spdk env init: -13
ERROR: spdk: code = 803 description = "SPDK binding failed, rc: 0, "

Signed-off-by: Wang Shilong <shilong.wang@intel.com>