### PR TITLE
DAOS-9354 control: use min hugepages for scan

### DIFF
--- a/src/control/server/server_utils.go
+++ b/src/control/server/server_utils.go
@@ -183,7 +183,11 @@ func prepBdevStorage(srv *server, iommuEnabled bool, hpiGetter common.GetHugePag
 	// The config value is intended to be per-engine, so we need to adjust
 	// based on the number of engines.
 	if srv.cfg.NrHugepages > 0 {
-		prepReq.HugePageCount = srv.cfg.NrHugepages * len(srv.cfg.Engines)
+		if len(srv.cfg.Engines) == 0 {
+			prepReq.HugePageCount = srv.cfg.NrHugepages
+		} else {
+			prepReq.HugePageCount = srv.cfg.NrHugepages * len(srv.cfg.Engines)
+		}
 	}
 	if hasBdevs {
 		// Perform these checks to avoid even trying a prepare if the system

--- a/src/control/server/server_utils.go
+++ b/src/control/server/server_utils.go
@@ -40,7 +40,7 @@ type resolveTCPFn func(string, string) (*net.TCPAddr, error)
 
 const (
 	iommuPath        = "/sys/class/iommu"
-	minHugePageCount = 0
+	minHugePageCount = 128
 )
 
 func cfgHasBdevs(cfg *config.Server) bool {
@@ -182,7 +182,9 @@ func prepBdevStorage(srv *server, iommuEnabled bool, hpiGetter common.GetHugePag
 	}
 	// The config value is intended to be per-engine, so we need to adjust
 	// based on the number of engines.
-	prepReq.HugePageCount = srv.cfg.NrHugepages * len(srv.cfg.Engines)
+	if srv.cfg.NrHugepages > 0 {
+		prepReq.HugePageCount = srv.cfg.NrHugepages * len(srv.cfg.Engines)
+	}
 	if hasBdevs {
 		// Perform these checks to avoid even trying a prepare if the system
 		// isn't configured properly.
@@ -217,14 +219,14 @@ func prepBdevStorage(srv *server, iommuEnabled bool, hpiGetter common.GetHugePag
 	}
 
 	// Double-check that we got the requested number of huge pages after prepare.
-	if hugePages.Free < prepReq.HugePageCount {
+	if srv.cfg.NrHugepages > 0 && hugePages.Free < prepReq.HugePageCount {
 		return FaultInsufficientFreeHugePages(hugePages.Free, prepReq.HugePageCount)
 	}
 
 	for _, engineCfg := range srv.cfg.Engines {
 		// Calculate mem_size per I/O engine (in MB)
 		PageSizeMb := hugePages.PageSizeKb >> 10
-		engineCfg.MemSize = prepReq.HugePageCount / len(srv.cfg.Engines)
+		engineCfg.MemSize = srv.cfg.NrHugepages
 		engineCfg.MemSize *= PageSizeMb
 		// Pass hugepage size, do not assume 2MB is used
 		engineCfg.HugePageSz = PageSizeMb


### PR DESCRIPTION
A small amount of huge pages is needed to do storage
scan for SPDK device probing.

Test-tag: control_start nvme_scan
Signed-off-by: Wang Shilong <shilong.wang@intel.com>