### PR TITLE
DAOS-9384 bio: improve bio_iod_post() interface

### DIFF
--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -1316,7 +1316,7 @@ obj_local_rw_internal(crt_rpc_t *rpc, struct obj_io_context *ioc,
 	daos_iod_t			*iods_dup = NULL; /* for EC deg fetch */
 	bool				 get_parity_list = false;
 	struct daos_recx_ep_list	*parity_list = NULL;
-	int				err, rc = 0;
+	int				 rc = 0;
 
 	create_map = orw->orw_flags & ORF_CREATE_MAP;
 
@@ -1649,8 +1649,7 @@ obj_local_rw_internal(crt_rpc_t *rpc, struct obj_io_context *ioc,
 	if (rc == -DER_CSUM)
 		obj_log_csum_err();
 post:
-	err = bio_iod_post(biod);
-	rc = rc ? : err;
+	rc = bio_iod_post(biod, rc);
 out:
 	/* There is CPU yield after DTX start, and the resent RPC may be handled during that.
 	 * Let's check resent again before further process.
@@ -2091,22 +2090,19 @@ ds_obj_ec_rep_handler(crt_rpc_t *rpc)
 	if (rc) {
 		D_ERROR(DF_UOID" bio_iod_prep failed: "DF_RC".\n",
 			DP_UOID(oer->er_oid), DP_RC(rc));
-		goto out;
+		goto end;
 	}
 	rc = obj_bulk_transfer(rpc, CRT_BULK_PUT, false, &oer->er_bulk, NULL,
 			       ioh, NULL, 1, NULL);
-	if (rc) {
+	if (rc)
 		D_ERROR(DF_UOID" bulk transfer failed: "DF_RC".\n",
 			DP_UOID(oer->er_oid), DP_RC(rc));
-		goto out;
-	}
 
-	rc = bio_iod_post(biod);
-	if (rc) {
+	rc = bio_iod_post(biod, rc);
+	if (rc)
 		D_ERROR(DF_UOID" bio_iod_post failed: "DF_RC".\n",
 			DP_UOID(oer->er_oid), DP_RC(rc));
-		goto out;
-	}
+end:
 	rc = vos_update_end(ioh, ioc.ioc_map_ver, dkey, rc,
 			    &ioc.ioc_io_size, NULL);
 	if (rc) {
@@ -2175,23 +2171,19 @@ ds_obj_ec_agg_handler(crt_rpc_t *rpc)
 		if (rc) {
 			D_ERROR(DF_UOID" bio_iod_prep failed: "DF_RC".\n",
 				DP_UOID(oea->ea_oid), DP_RC(rc));
-			goto out;
+			goto end;
 		}
 		rc = obj_bulk_transfer(rpc, CRT_BULK_GET, false, &oea->ea_bulk,
 				       NULL, ioh, NULL, 1, NULL);
-		if (rc) {
+		if (rc)
 			D_ERROR(DF_UOID" bulk transfer failed: "DF_RC".\n",
 				DP_UOID(oea->ea_oid), DP_RC(rc));
-			goto out;
-		}
 
-		rc = bio_iod_post(biod);
-		if (rc) {
+		rc = bio_iod_post(biod, rc);
+		if (rc)
 			D_ERROR(DF_UOID" bio_iod_post failed: "DF_RC".\n",
 				DP_UOID(oea->ea_oid), DP_RC(rc));
-			goto out;
-		}
-
+end:
 		rc = vos_update_end(ioh, ioc.ioc_map_ver, dkey, rc,
 				    &ioc.ioc_io_size, NULL);
 		if (rc) {
@@ -4093,7 +4085,7 @@ ds_cpd_handle_one(crt_rpc_t *rpc, struct daos_cpd_sub_head *dcsh,
 			goto out;
 		}
 
-		rc = bio_iod_post(biods[i]);
+		rc = bio_iod_post(biods[i], 0);
 		biods[i] = NULL;
 		if (rc != 0) {
 			D_ERROR("iod_post failed for obj "DF_UOID", DTX "DF_DTI": "DF_RC"\n",
@@ -4187,7 +4179,7 @@ out:
 		if (biods != NULL) {
 			for (i = 0; i < dcde->dcde_write_cnt; i++) {
 				if (biods[i] != NULL)
-					bio_iod_post(biods[i]);
+					bio_iod_post(biods[i], rc);
 			}
 		}
 

--- a/src/object/srv_obj_migrate.c
+++ b/src/object/srv_obj_migrate.c
@@ -1181,7 +1181,7 @@ __migrate_fetch_update_bulk(struct migrate_one *mrone, daos_handle_t oh,
 {
 	d_sg_list_t		 sgls[DSS_ENUM_UNPACK_MAX_IODS];
 	daos_handle_t		 ioh;
-	int			 rc, rc1, i, ret, sgl_cnt = 0;
+	int			 rc, rc1, i, sgl_cnt = 0;
 	struct daos_csummer	*csummer = NULL;
 	d_iov_t			 csum_iov_fetch = {0};
 	struct dcs_iod_csums	*iod_csums = NULL;
@@ -1274,12 +1274,10 @@ post:
 	if (daos_oclass_is_ec(&mrone->mo_oca))
 		mrone_recx_daos2_vos(mrone, iods, iod_num);
 
-	ret = bio_iod_post(vos_ioh2desc(ioh));
-	if (ret) {
+	rc = bio_iod_post(vos_ioh2desc(ioh), rc);
+	if (rc)
 		D_ERROR("Post EIOD for "DF_UOID" error: "DF_RC"\n",
-			DP_UOID(mrone->mo_oid), DP_RC(ret));
-		rc = rc ? : ret;
-	}
+			DP_UOID(mrone->mo_oid), DP_RC(rc));
 
 	for (i = 0; rc == 0 && i < iod_num; i++) {
 		if (iods[i].iod_size == 0) {

--- a/src/rdb/rdb_util.c
+++ b/src/rdb/rdb_util.c
@@ -354,7 +354,7 @@ rdb_vos_fetch_addr(daos_handle_t cont, daos_epoch_t epoch, rdb_oid_t oid,
 		value->iov_len = bio_iov2len(biov);
 	}
 
-	rc = bio_iod_post(vos_ioh2desc(io));
+	rc = bio_iod_post(vos_ioh2desc(io), 0);
 	D_ASSERTF(rc == 0, ""DF_RC"\n", DP_RC(rc));
 out:
 	rc = vos_fetch_end(io, NULL, 0 /* err */);

--- a/src/tests/vos_perf.c
+++ b/src/tests/vos_perf.c
@@ -148,7 +148,7 @@ _vos_update_or_fetch(int obj_idx, enum ts_op_type op_type,
 			       cred->tc_sgl.sg_iovs[0].iov_len);
 		}
 
-		rc = bio_iod_post(vos_ioh2desc(ioh));
+		rc = bio_iod_post(vos_ioh2desc(ioh), 0);
 end:
 		if (op_type == TS_DO_UPDATE)
 			rc = vos_update_end(ioh, 0, &cred->tc_dkey, rc, NULL,

--- a/src/vos/tests/vts_gc.c
+++ b/src/vos/tests/vts_gc.c
@@ -125,7 +125,7 @@ gc_obj_update(struct gc_test_args *args, daos_handle_t coh, daos_unit_oid_t oid,
 		}
 
 		/* write garbage, we don't care */
-		rc = bio_iod_post(vos_ioh2desc(ioh));
+		rc = bio_iod_post(vos_ioh2desc(ioh), 0);
 		if (rc) {
 			print_error("Failed to post bio request\n");
 			return rc;

--- a/src/vos/tests/vts_io.c
+++ b/src/vos/tests/vts_io.c
@@ -604,7 +604,7 @@ io_test_obj_update(struct io_test_args *arg, daos_epoch_t epoch, uint64_t flags,
 	*/
 	assert_true(srv_iov->iov_len == sgl->sg_iovs[0].iov_len);
 
-	rc = bio_iod_post(vos_ioh2desc(ioh));
+	rc = bio_iod_post(vos_ioh2desc(ioh), rc);
 end:
 	if (rc == 0 && (arg->ta_flags & TF_ZERO_COPY))
 		rc = vos_update_end(ioh, 0, dkey, rc, NULL, dth);
@@ -668,7 +668,7 @@ io_test_obj_fetch(struct io_test_args *arg, daos_epoch_t epoch, uint64_t flags,
 	dst_iov->iov_len = off;
 	assert_true(dst_iov->iov_buf_len >= dst_iov->iov_len);
 
-	rc = bio_iod_post(vos_ioh2desc(ioh));
+	rc = bio_iod_post(vos_ioh2desc(ioh), 0);
 end:
 	rc = vos_fetch_end(ioh, NULL, rc);
 	if (((flags & VOS_COND_FETCH_MASK) && rc == -DER_NONEXIST) ||

--- a/src/vos/vos_aggregate.c
+++ b/src/vos/vos_aggregate.c
@@ -980,7 +980,7 @@ fill_one_segment(daos_handle_t ih, struct agg_merge_window *mw,
 	daos_off_t		 phy_lo = 0;
 	unsigned int		 i, seg_count, biov_idx = 0;
 	struct bio_copy_desc	*copy_desc;
-	int			 rc, err;
+	int			 rc;
 
 	D_ASSERT(obj != NULL);
 	D_ASSERT(mw->mw_rsize > 0);
@@ -1099,13 +1099,10 @@ fill_one_segment(daos_handle_t ih, struct agg_merge_window *mw,
 		D_ERROR("Copy to "DF_RECT" error "DF_RC"\n",
 			DP_RECT(&ent_in->ei_rect), DP_RC(rc));
 post:
-	err = bio_copy_post(copy_desc);
-	if (err) {
+	rc = bio_copy_post(copy_desc, rc);
+	if (rc)
 		D_ERROR("Write to "DF_RECT" error "DF_RC"\n",
-			DP_RECT(&ent_in->ei_rect), DP_RC(err));
-		if (rc == 0)
-			rc = err;
-	}
+			DP_RECT(&ent_in->ei_rect), DP_RC(rc));
 out:
 	bio_sgl_fini(&bsgl);
 	bio_sgl_fini(&bsgl_dst);

--- a/src/vos/vos_io.c
+++ b/src/vos/vos_io.c
@@ -2677,17 +2677,17 @@ static int
 vos_obj_copy(struct vos_io_context *ioc, d_sg_list_t *sgls,
 	     unsigned int sgl_nr)
 {
-	int rc, err;
+	int rc;
 
 	D_ASSERT(sgl_nr == ioc->ic_iod_nr);
 	rc = bio_iod_prep(ioc->ic_biod, BIO_CHK_TYPE_IO, NULL, 0);
 	if (rc)
 		return rc;
 
-	err = bio_iod_copy(ioc->ic_biod, sgls, sgl_nr);
-	rc = bio_iod_post(ioc->ic_biod);
+	rc = bio_iod_copy(ioc->ic_biod, sgls, sgl_nr);
+	rc = bio_iod_post(ioc->ic_biod, rc);
 
-	return err ? err : rc;
+	return rc;
 }
 
 int


### PR DESCRIPTION
Adding an "error code from prior data transfer operation" parameter
to bio_iod_post() & bio_copy_post() interface, so that they could
internally skip data write back once prior data transfer failed.

Fix EC aggregation RPC handler, where bio_iod_post() and the
vos_update_end() were missed on error cleanup.

Signed-off-by: Niu Yawei <yawei.niu@intel.com>