### PR TITLE
DAOS-9088 docker: fix documentation and helper script

### DIFF
--- a/docs/QSG/docker.md
+++ b/docs/QSG/docker.md
@@ -26,7 +26,19 @@ To build and deploy the Docker images, `docker` and optionally `docker-compose` 
 The docker host should have access to the [Docker Hub](https://hub.docker.com/) and
 [Rocky Linux](https://rockylinux.org/) official repositories.  Finally,
 [hugepages](https://www.kernel.org/doc/Documentation/vm/hugetlbpage.txt) linux kernel feature shall
-be enabled on the docker host.
+be enabled on the docker host.  At least, 4096 pages of 2048kB should be available.  The number of
+huge pages allocated could be checked with the following command:
+
+```bash
+$ sysctl vm.nr_hugepages
+```
+
+The default size of a huge page, the number of available huge pages, etc. could be found with the
+following command:
+
+```bash
+$ cat /proc/meminfo | grep -e "^Huge"
+```
 
 The platform was tested and validated with the
 [rockylinux/rockylinux:8.4](https://hub.docker.com/r/rockylinux/rockylinux) and
@@ -39,6 +51,28 @@ distributions should be supported.
     management of hugepages with the [spdk](https://spdk.io/) library.
 
 
+
+### Configuring HugePages
+
+First the Linux kernel needs to be built with the `CONFIG_HUGETLBFS` (present under "File systems")
+and `CONFIG_HUGETLB_PAGE` (selected automatically when `CONFIG_HUGETLBFS` is selected) configuration
+options.
+
+To avoid memory fragmentation, huge pages could be allocated on the kernel boot command line by
+specifying the "hugepages=N" parameter, where 'N' = the number of huge pages requested.  It is also
+possible to allocate them at run time, thanks to the `sysctl` command:
+
+```bash
+$ sysctl vm.nr_hugepages=8192
+```
+
+It is also possible to use the `sysctl` command to allocate huge pages at boot time with the
+following command:
+
+```bash
+$ cat <<< "vm.nr_hugepages = 8192" > /etc/sysctl.d/50-hugepages.conf
+$ sysctl -p
+````
 
 ## Building Docker Images
 


### PR DESCRIPTION
This commit contains the following updates:
- Add paragraph on HugePages configuration.
- Fix daos-cm.sh helper bash script: wait for startup of the daos_server
  service.

Doc-only: true

Signed-off-by: Cedric Koch-Hofer <cedric.koch-hofer@intel.com>