### PR TITLE
DAOS-9354 test: fix daos_server_config failure

### DIFF
--- a/src/tests/ftest/server/daos_server_config.py
+++ b/src/tests/ftest/server/daos_server_config.py
@@ -34,7 +34,8 @@ class DaosServerConfigTest(TestWithServers):
         Test Description: Test daos_server start/stops properly.
         on the system.
 
-        :avocado: tags=all,small,control,daily_regression,server_start,basic
+        :avocado: tags=all,control,daily_regression,server_start,basic
+        :avocado: tags=hw,small
         """
         # Setup the servers
         self.add_server_manager()

--- a/src/tests/ftest/server/daos_server_config.yaml
+++ b/src/tests/ftest/server/daos_server_config.yaml
@@ -92,7 +92,7 @@ server_config_val: !mux
     config_val:
       - "nr_hugepages"
       - 1000000000000000000
-      - "PASS"
+      - "FAIL"
   nr_hugepages_negative_int:
     config_val:
       - "nr_hugepages"


### PR DESCRIPTION
After commit: DAOS-9146 engine: some fixes for daos server

1. Hugepages will be used if configured even without NVME configured,
And we will check huegpages with system avail free pages, it will return
fail which is expected.

2. configuring nr_hugepages with negative will set it to 4096, so
fix this test run in the hardware environment.

Test-tag: control,server_start
Signed-off-by: Wang Shilong <shilong.wang@intel.com>