### PR TITLE
DAOS-9208 rebuild: merge recxs

### DIFF
--- a/src/include/daos_srv/daos_engine.h
+++ b/src/include/daos_srv/daos_engine.h
@@ -736,6 +736,7 @@ struct dss_enum_arg {
 			int			kds_len;
 			d_sg_list_t	       *sgl;
 			d_iov_t			csum_iov;
+			uint32_t		ec_cell_sz;
 			int			sgl_idx;
 		};
 		struct {	/* fill_recxs && type == S||R */

--- a/src/object/obj_enum.c
+++ b/src/object/obj_enum.c
@@ -535,16 +535,94 @@ csum_copy_inline(int type, vos_iter_entry_t *ent, struct dss_enum_arg *arg,
 	return 0;
 }
 
+static bool
+need_new_entry(struct dss_enum_arg *arg, vos_iter_entry_t *key_ent,
+	       daos_size_t iod_size, int type)
+{
+	struct obj_enum_rec	*rec;
+	d_iov_t			*iovs = arg->sgl->sg_iovs;
+	uint64_t		curr_off = key_ent->ie_recx.rx_idx;
+	uint64_t		curr_size = key_ent->ie_recx.rx_nr;
+	uint64_t		prev_off;
+	uint64_t		prev_size;
+
+	if (arg->last_type != OBJ_ITER_RECX || type != OBJ_ITER_RECX)
+		return true;
+
+	rec = iovs[arg->sgl_idx].iov_buf + iovs[arg->sgl_idx].iov_len - sizeof(*rec);
+	prev_off = rec->rec_recx.rx_idx;
+	prev_size = rec->rec_recx.rx_nr;
+	if (prev_off + prev_size != curr_off) /* not continuous */
+		return true;
+
+	if (arg->rsize != iod_size)
+		return true;
+
+	if (arg->ec_cell_sz > 0 &&
+	    (prev_off + prev_size - 1) / arg->ec_cell_sz !=
+	    (curr_off + curr_size) / arg->ec_cell_sz)
+		return true;
+
+	return false;
+}
+
+static void
+insert_new_rec(struct dss_enum_arg *arg, vos_iter_entry_t *new_ent, int type,
+	       daos_size_t iod_size, struct obj_enum_rec **new_rec)
+{
+	d_iov_t			*iovs = arg->sgl->sg_iovs;
+	struct obj_enum_rec	*rec;
+	daos_size_t		new_idx = new_ent->ie_recx.rx_idx;
+	daos_off_t		new_nr = new_ent->ie_recx.rx_nr;
+
+	/* For cross-cell recx, let's check if the new recx needs to merge with current
+	 * recx, then insert the left to the new recx.
+	 */
+	if (arg->last_type == OBJ_ITER_RECX && type == OBJ_ITER_RECX &&
+	    arg->ec_cell_sz > 0 && arg->rsize == iod_size) {
+		rec = iovs[arg->sgl_idx].iov_buf + iovs[arg->sgl_idx].iov_len - sizeof(*rec);
+		*new_rec = rec;
+		if (rec->rec_recx.rx_idx + rec->rec_recx.rx_nr == new_ent->ie_recx.rx_idx) {
+			new_idx = roundup(DAOS_RECX_END(rec->rec_recx), arg->ec_cell_sz);
+			if (new_idx > new_ent->ie_recx.rx_idx) {
+				new_nr -= new_idx - new_ent->ie_recx.rx_idx;
+				rec->rec_recx.rx_nr += new_ent->ie_recx.rx_nr - new_nr;
+				rec->rec_epr.epr_lo = max(new_ent->ie_epoch, rec->rec_epr.epr_lo);
+			}
+			if (new_nr == 0)
+				return;
+		}
+	}
+
+	/* Grow the next new descriptor (instead of creating yet a new one). */
+	arg->kds[arg->kds_len].kd_val_type = type;
+	arg->kds[arg->kds_len].kd_key_len += sizeof(*rec);
+	rec = iovs[arg->sgl_idx].iov_buf + iovs[arg->sgl_idx].iov_len;
+	/* Append the recx record to iovs. */
+	D_ASSERT(iovs[arg->sgl_idx].iov_len + sizeof(*rec) <= iovs[arg->sgl_idx].iov_buf_len);
+	rec->rec_recx.rx_idx = new_idx;
+	rec->rec_recx.rx_nr = new_nr;
+	rec->rec_size = iod_size;
+	rec->rec_epr.epr_lo = new_ent->ie_epoch;
+	rec->rec_epr.epr_hi = DAOS_EPOCH_MAX;
+	rec->rec_version = new_ent->ie_ver;
+	rec->rec_flags = 0;
+	iovs[arg->sgl_idx].iov_len += sizeof(*rec);
+	arg->rsize = iod_size;
+	*new_rec = rec;
+}
+
 /* Callers are responsible for incrementing arg->kds_len. See iter_akey_cb. */
 static int
 fill_rec(daos_handle_t ih, vos_iter_entry_t *key_ent, struct dss_enum_arg *arg,
 	 vos_iter_type_t vos_type, vos_iter_param_t *param, unsigned int *acts)
 {
 	d_iov_t			*iovs = arg->sgl->sg_iovs;
-	struct obj_enum_rec	*rec;
 	daos_size_t		data_size = 0, iod_size;
+	struct obj_enum_rec	*rec;
 	daos_size_t		size = sizeof(*rec);
 	bool			inline_data = false, bump_kds_len = false;
+	bool			insert_new_entry = false;
 	int			type;
 	int			rc = 0;
 
@@ -559,11 +637,8 @@ fill_rec(daos_handle_t ih, vos_iter_entry_t *key_ent, struct dss_enum_arg *arg,
 			iod_size = key_ent->ie_gsize;
 			if (iod_size == key_ent->ie_rsize)
 				data_size = iod_size;
-			else
-				data_size = 0;
 		} else {
 			iod_size = key_ent->ie_rsize;
-			data_size = iod_size * key_ent->ie_recx.rx_nr;
 		}
 	}
 
@@ -596,34 +671,30 @@ fill_rec(daos_handle_t ih, vos_iter_entry_t *key_ent, struct dss_enum_arg *arg,
 		return 0;
 	}
 
-	if (is_sgl_full(arg, size) || arg->kds_len >= arg->kds_cap) {
-		/* NB: if it is rebuild object iteration, let's
-		 * check if both dkey & akey was already packed
-		 * (kds_len < 3) before return KEY2BIG.
-		 */
-		if ((arg->chk_key2big && arg->kds_len < 3)) {
-			if (arg->kds[0].kd_key_len < size)
-				arg->kds[0].kd_key_len = size;
-			D_GOTO(out, rc = -DER_KEY2BIG);
+	insert_new_entry = need_new_entry(arg, key_ent, iod_size, type);
+	if (insert_new_entry) {
+		/* Check if there are still space */
+		if (is_sgl_full(arg, size) || arg->kds_len >= arg->kds_cap) {
+			/* NB: if it is rebuild object iteration, let's
+			 * check if both dkey & akey was already packed
+			 * (kds_len < 3) before return KEY2BIG.
+			 */
+			if ((arg->chk_key2big && arg->kds_len < 3)) {
+				if (arg->kds[0].kd_key_len < size)
+					arg->kds[0].kd_key_len = size;
+				D_GOTO(out, rc = -DER_KEY2BIG);
+			}
+			D_GOTO(out, rc = 1);
+		} else {
+			insert_new_rec(arg, key_ent, type, iod_size, &rec);
 		}
-		D_GOTO(out, rc = 1);
+	} else {
+		D_ASSERTF(arg->last_type == OBJ_ITER_RECX, "type=%d\n", arg->last_type);
+		D_ASSERTF(type == OBJ_ITER_RECX, "type=%d\n", type);
+		rec = iovs[arg->sgl_idx].iov_buf + iovs[arg->sgl_idx].iov_len - sizeof(*rec);
+		rec->rec_recx.rx_nr += key_ent->ie_recx.rx_nr;
+		rec->rec_epr.epr_lo = max(key_ent->ie_epoch, rec->rec_epr.epr_lo);
 	}
-
-	/* Grow the next new descriptor (instead of creating yet a new one). */
-	arg->kds[arg->kds_len].kd_val_type = type;
-	arg->kds[arg->kds_len].kd_key_len += sizeof(*rec);
-
-	/* Append the recx record to iovs. */
-	D_ASSERT(iovs[arg->sgl_idx].iov_len + sizeof(*rec) <=
-		 iovs[arg->sgl_idx].iov_buf_len);
-	rec = iovs[arg->sgl_idx].iov_buf + iovs[arg->sgl_idx].iov_len;
-	rec->rec_recx = key_ent->ie_recx;
-	rec->rec_size = iod_size;
-	rec->rec_epr.epr_lo = key_ent->ie_epoch;
-	rec->rec_epr.epr_hi = DAOS_EPOCH_MAX;
-	rec->rec_version = key_ent->ie_ver;
-	rec->rec_flags = 0;
-	iovs[arg->sgl_idx].iov_len += sizeof(*rec);
 
 	/*
 	 * If we've decided to inline the data, append the data to iovs.
@@ -638,15 +709,12 @@ fill_rec(daos_handle_t ih, vos_iter_entry_t *key_ent, struct dss_enum_arg *arg,
 		 * may be invisible to current enumeration. Then it
 		 * may be located on SCM or NVMe.
 		 */
-		if (type != OBJ_ITER_RECX)
-			D_ASSERTF(key_ent->ie_biov.bi_addr.ba_type ==
-				  DAOS_MEDIA_SCM,
-				  "Invalid storage media type %d, ba_off "
-				  DF_X64", thres %ld, data_size %ld, type %d, "
-				  "iod_size %ld\n",
-				  key_ent->ie_biov.bi_addr.ba_type,
-				  key_ent->ie_biov.bi_addr.ba_off,
-				  arg->inline_thres, data_size, type, iod_size);
+		D_ASSERT(type != OBJ_ITER_RECX);
+		D_ASSERTF(key_ent->ie_biov.bi_addr.ba_type ==
+			  DAOS_MEDIA_SCM, "Invalid storage media type %d, ba_off "
+			  DF_X64", thres %ld, data_size %ld, type %d, iod_size %ld\n",
+			  key_ent->ie_biov.bi_addr.ba_type, key_ent->ie_biov.bi_addr.ba_off,
+			  arg->inline_thres, data_size, type, iod_size);
 
 		d_iov_set(&iov_out, iovs[arg->sgl_idx].iov_buf +
 				       iovs[arg->sgl_idx].iov_len, data_size);

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -2853,15 +2853,18 @@ obj_local_enum(struct obj_io_context *ioc, crt_rpc_t *rpc,
 		/* object iteration for rebuild or consistency verification. */
 		D_ASSERT(opc == DAOS_OBJ_RPC_ENUMERATE);
 		type = VOS_ITER_DKEY;
+		param.ip_flags |= VOS_IT_RECX_VISIBLE;
 		if (daos_anchor_get_flags(&anchors[0].ia_dkey) &
 		      DIOF_WITH_SPEC_EPOCH) {
 			/* For obj verification case. */
-			param.ip_flags |= VOS_IT_RECX_VISIBLE;
 			param.ip_epc_expr = VOS_IT_EPC_RR;
 		} else {
 			param.ip_epc_expr = VOS_IT_EPC_RE;
 		}
 		recursive = true;
+
+		if (daos_oclass_is_ec(&ioc->ioc_oca))
+			enum_arg->ec_cell_sz = ioc->ioc_oca.u.ec.e_len;
 		enum_arg->chk_key2big = 1;
 		enum_arg->need_punch = 1;
 		enum_arg->copy_data_cb = vos_iter_copy;

--- a/src/tests/suite/daos_checksum.c
+++ b/src/tests/suite/daos_checksum.c
@@ -2446,8 +2446,8 @@ test_enumerate_object2(void **state)
 	 */
 	assert_int_equal(4, nr);
 
-	/** only 3 checksums, dkey, akey, and inlined recx */
-	assert_int_equal(3, get_csum_count(&csum_iov));
+	/** only 2 checksums, dkey, akey */
+	assert_int_equal(2, get_csum_count(&csum_iov));
 
 	/** Clean up */
 	d_sgl_fini(&list_sgl, true);
@@ -2505,14 +2505,6 @@ test_enumerate_object_csum_buf_too_small(void **state)
 	assert_memory_equal(&zero_anchor, &anchor, sizeof(zero_anchor));
 	assert_memory_equal(&zero_anchor, &dkey_anchor, sizeof(zero_anchor));
 	assert_memory_equal(&zero_anchor, &akey_anchor, sizeof(zero_anchor));
-
-	/** csum iov buf len shouldn't change, but iov_len should reflect
-	 * what's needed to hold all csum info. Caller can decide what to do
-	 * from here.
-	 */
-	assert_int_equal(10, csum_iov.iov_buf_len);
-	assert_int_equal(11 * (sizeof(struct dcs_csum_info) + 8),
-		csum_iov.iov_len);
 
 	/** Clean up */
 	d_sgl_fini(&sgl, true);

--- a/src/vos/vos_obj.c
+++ b/src/vos/vos_obj.c
@@ -1253,7 +1253,8 @@ singv_iter_next(struct vos_obj_iter *oiter)
 	 */
 	vis_flag = oiter->it_flags & VOS_IT_RECX_COVERED;
 	if (vis_flag == VOS_IT_RECX_VISIBLE) {
-		D_ASSERT(oiter->it_epc_expr == VOS_IT_EPC_RR);
+		D_ASSERT(oiter->it_epc_expr == VOS_IT_EPC_RR ||
+			 oiter->it_epc_expr == VOS_IT_EPC_RE);
 		return -DER_NONEXIST;
 	}
 


### PR DESCRIPTION
Merge continous recxs to shrink the enumeration size. Since
EC rebuild needs to know the epoch for each cell, so the
merging can not cross the cell boundary.

Signed-off-by: Di Wang <di.wang@intel.com>