### PR TITLE
DAOS-9357 EC: refine obj_ec_parity_check() for data recovery

### DIFF
--- a/src/include/daos/object.h
+++ b/src/include/daos/object.h
@@ -645,6 +645,40 @@ daos_recx_ep_lists_dup(struct daos_recx_ep_list *lists, unsigned int nr)
 	return dup_lists;
 }
 
+/* merge adjacent recxs for same epoch */
+static inline void
+daos_recx_ep_lists_merge(struct daos_recx_ep_list *lists, unsigned int nr)
+{
+	struct daos_recx_ep_list	*list;
+	struct daos_recx_ep		*recx_ep, *next;
+	unsigned int			 i, j, k;
+
+	for (i = 0; i < nr; i++) {
+		list = &lists[i];
+		if (list->re_nr < 2)
+			continue;
+		for (j = 0; j < list->re_nr - 1; j++) {
+			recx_ep = &list->re_items[j];
+			next = &list->re_items[j + 1];
+			if (recx_ep->re_ep != next->re_ep ||
+			    recx_ep->re_rec_size != next->re_rec_size ||
+			    recx_ep->re_type != next->re_type ||
+			    !DAOS_RECX_ADJACENT(recx_ep->re_recx, next->re_recx))
+				continue;
+
+			recx_ep->re_recx.rx_nr += next->re_recx.rx_nr;
+			if (recx_ep->re_recx.rx_idx > next->re_recx.rx_idx)
+				recx_ep->re_recx.rx_idx = next->re_recx.rx_idx;
+
+			for (k = j + 1; k < list->re_nr - 1; k++)
+				list->re_items[k] = list->re_items[k + 1];
+
+			list->re_nr--;
+			j--;
+		}
+	}
+}
+
 static inline void
 daos_recx_ep_list_hilo(struct daos_recx_ep_list *list, daos_recx_t *hi_ptr,
 		       daos_recx_t *lo_ptr)

--- a/src/object/cli_ec.c
+++ b/src/object/cli_ec.c
@@ -1931,6 +1931,7 @@ obj_ec_parity_check(struct obj_reasb_req *reasb_req,
 		parity_lists = reasb_req->orr_parity_lists;
 		if (parity_lists == NULL)
 			rc = -DER_NOMEM;
+		daos_recx_ep_lists_merge(parity_lists, nr);
 		goto out;
 	}
 
@@ -1938,6 +1939,7 @@ obj_ec_parity_check(struct obj_reasb_req *reasb_req,
 		rc = -DER_FETCH_AGAIN;
 		D_ERROR("simulate parity list mismatch, "DF_RC"\n", DP_RC(rc));
 	} else {
+		daos_recx_ep_lists_merge(recx_lists, nr);
 		rc = obj_ec_parity_lists_match(parity_lists, recx_lists, nr);
 		if (rc) {
 			D_ERROR("got different parity lists, "DF_RC"\n", DP_RC(rc));

--- a/src/object/srv_ec_aggregate.c
+++ b/src/object/srv_ec_aggregate.c
@@ -2176,12 +2176,11 @@ agg_obj_is_leader(struct ds_pool *pool, struct daos_oclass_attr *oca,
 	struct pl_map		*map;
 	struct pl_obj_layout	*layout = NULL;
 	struct pl_obj_shard	*shard;
-	uint32_t		 start;
+	uint32_t		 idx;
 	int			 rc;
-	int			 i;
 
-	/* Only parity shard can be EC-AGG leader. */
-	if (oid->id_shard % daos_oclass_grp_size(oca) < oca->u.ec.e_k)
+	/* Only last parity shard can be EC-AGG leader. */
+	if ((oid->id_shard % daos_oclass_grp_size(oca)) != (daos_oclass_grp_size(oca) - 1))
 		return 0;
 
 	map = pl_map_find(pool->sp_uuid, oid->id_pub);
@@ -2196,16 +2195,15 @@ agg_obj_is_leader(struct ds_pool *pool, struct daos_oclass_attr *oca,
 	if (rc != 0)
 		goto out;
 
-	start = oid->id_shard / daos_oclass_grp_size(oca) * layout->ol_grp_size;
-	for (i = start + oca->u.ec.e_k + oca->u.ec.e_p - 1; i >= start + oca->u.ec.e_k; i--) {
-		shard = pl_obj_get_shard(layout, i);
-		if (shard->po_target != -1 && shard->po_shard != -1 && !shard->po_rebuilding)
-			/* Select the last non-rebuilding parity shard as the EC-AGG leader. */
-			D_GOTO(out, rc = (oid->id_shard == shard->po_shard ? 1 : 0));
+	idx = (oid->id_shard / daos_oclass_grp_size(oca)) * layout->ol_grp_size +
+	      daos_oclass_grp_size(oca) - 1;
+	shard = pl_obj_get_shard(layout, idx);
+	if (shard->po_target != -1 && shard->po_shard != -1 && !shard->po_rebuilding) {
+		rc = (oid->id_shard == shard->po_shard) ? 1 : 0;
+	} else {
+		/* If last parity unavailable, then skip the object via returning -DER_STALE. */
+		rc = -DER_STALE;
 	}
-
-	/* If all parity shards are unavailable, then skip the object via returning -DER_STALE. */
-	rc = -DER_STALE;
 
 out:
 	if (layout != NULL)
@@ -2252,7 +2250,9 @@ agg_object(daos_handle_t ih, vos_iter_entry_t *entry,
 
 	rc = agg_obj_is_leader(info->api_pool, &oca, &entry->ie_oid,
 			       info->api_pool->sp_map_version);
-	if (rc == 1 && entry->ie_oid.id_shard >= oca.u.ec.e_k) {
+	if (rc == 1) {
+		D_ASSERT((entry->ie_oid.id_shard % obj_ec_tgt_nr(&oca)) ==
+			 obj_ec_tgt_nr(&oca) - 1);
 		D_DEBUG(DB_EPC, "oid:"DF_UOID" ec agg starting\n",
 			DP_UOID(entry->ie_oid));
 

--- a/src/tests/suite/daos_degrade_ec.c
+++ b/src/tests/suite/daos_degrade_ec.c
@@ -479,10 +479,10 @@ degrade_ec_partial_update_agg(void **state)
 			     data, EC_CELL_SIZE, &req);
 	}
 
-	/* Kill the last parity shard, which is the aggregate leader to verify
+	/* Kill one parity shard, which is the aggregate leader to verify
 	 * aggregate works in degraded mode.
 	 */
-	rank = get_rank_by_oid_shard(arg, oid, 5);
+	rank = get_rank_by_oid_shard(arg, oid, 4);
 	rebuild_pools_ranks(&arg, 1, &rank, 1, false);
 
 	/* Trigger aggregation */

--- a/src/tests/suite/daos_epoch_io.c
+++ b/src/tests/suite/daos_epoch_io.c
@@ -207,13 +207,13 @@ daos_test_cb_uf(test_arg_t *arg, struct test_op_record *op, char **rbuf,
 		if (uf_arg->snap == true) {
 			rc = daos_cont_create_snap(arg->coh, &snap_epoch, NULL,
 						   NULL);
-			*op->snap_epoch  = snap_epoch;
+			op->snap_epoch  = snap_epoch;
 		}
 	} else{
 		th_open = DAOS_TX_NONE;
 		/*Open snapshot and read the data from snapshot epoch*/
 		if (uf_arg->snap == true) {
-			rc = daos_tx_open_snap(arg->coh, *op->snap_epoch,
+			rc = daos_tx_open_snap(arg->coh, op->snap_epoch,
 					       &th_open, NULL);
 			D_ASSERT(rc == 0);
 		}
@@ -1462,8 +1462,6 @@ io_conf_run(test_arg_t *arg, const char *io_conf)
 	FILE			*fp;
 	char			 cmd_line[CMD_LINE_LEN_MAX - 1] = {};
 	int			 rc = 0;
-	/*Array for snapshot epoch*/
-	daos_epoch_t		sn_epoch[DTS_MAX_EPOCH_TIMES] = {};
 
 	if (io_conf == NULL || strlen(io_conf) == 0) {
 		print_message("invalid io_conf.\n");
@@ -1500,7 +1498,6 @@ io_conf_run(test_arg_t *arg, const char *io_conf)
 		}
 
 		if (op != NULL) {
-			op->snap_epoch = &sn_epoch[op->tx];
 			print_message("will run cmd_line %s, line_nr %d\n", cmd_line, ++line_nr);
 			rc = cmd_line_run(arg, op);
 			if (rc) {

--- a/src/tests/suite/daos_iotest.h
+++ b/src/tests/suite/daos_iotest.h
@@ -234,7 +234,7 @@ struct test_op_record {
 	d_list_t		or_queue_link;
 	struct test_key_record	*or_key_rec; /* back pointer */
 	int			tx;
-	daos_epoch_t		*snap_epoch;
+	daos_epoch_t		snap_epoch;
 	enum test_op_type	or_op;
 	union {
 		struct test_update_fetch_arg	uf_arg;


### PR DESCRIPTION
(master 4567079de5d)
In EC data recovery, the parity recx list replied from different
parity shards is used to check if the parity extents are matched.
When VOS aggregation race with the data recovery, one parity shard
may return fragmented recxs and another return merged recxs, that
case is not an error.

and backport two other bug fix from master -
930126b835cb4 - EC: only select last parity shard as EC agg leader
647453235ebfc - test: fix a mem usage bug in daos_epoch_io test

Signed-off-by: Xuezhao Liu <xuezhao.liu@intel.com>