### PR TITLE
DAOS-4842 test: verify format time is less than 20s

### DIFF
--- a/src/tests/ftest/control/dmg_storage_format_perf.py
+++ b/src/tests/ftest/control/dmg_storage_format_perf.py
@@ -1,0 +1,59 @@
+#!/usr/bin/python
+"""
+  (C) Copyright 2020-2021 Intel Corporation.
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+"""
+
+from control_test_base import ControlTestBase
+
+
+class DmgStorageFormatPerfTest(ControlTestBase):
+    # pylint: disable=too-many-ancestors
+    """Test Class Description:
+    Verify storage format performance
+
+    :avocado: recursive
+    """
+
+    def __init__(self, *args, **kwargs):
+        """Initialize a DmgStorageFormatPerfTest object."""
+        super().__init__(*args, **kwargs)
+        self.setup_start_agents = False
+
+    def test_dmg_storage_format_perf(self):
+        """JIRA ID: DAOS-4842
+
+        Test Description: Verify storage format takes less than <max_s_per_device>.
+                          For example: node1 and node2 each have 2 devices.
+                                       Format should take less than 2 * <max_s_per_device>
+
+        :avocado: tags=all,full_regression
+        :avocado: tags=hw,medium,ib2
+        :avocado: tags=control,dmg
+        :avocado: tags=dmg_storage_format_perf
+        """
+        max_devices = self.get_max_devices()
+        max_s_per_device = self.params.get("max_s_per_device", "/run/dmg_storage_format_perf/*")
+        max_format_time = max_s_per_device * max_devices
+        dmg = self.server_managers[0].dmg
+
+        self.log.info("Stopping and erasing system before format")
+        dmg.system_stop(force=True)
+        if dmg.result.exit_status != 0:
+            self.fail("Failed to stop system")
+
+        dmg.system_erase()
+        if dmg.result.exit_status != 0:
+            self.fail("Failed to erase system")
+
+        self.server_managers[0].detect_format_ready(reformat=True)
+
+        self.log.info("Formatting storage with a timeout of %ss per device", str(max_s_per_device))
+        
+        dmg.storage_format(reformat=True, timeout=max_format_time)
+        if dmg.result.exit_status != 0:
+            self.fail("Failed to format system")
+
+        # Make sure servers restart
+        self.server_managers[0].detect_engine_start()

--- a/src/tests/ftest/control/dmg_storage_format_perf.yaml
+++ b/src/tests/ftest/control/dmg_storage_format_perf.yaml
@@ -1,0 +1,14 @@
+hosts:
+  test_servers:
+    - server-A
+    - server-B
+    - server-C
+    - server-D
+timeout: 90
+server_config:
+  name: daos_server
+  servers:
+    bdev_class: nvme
+    bdev_list: ["aaaa:aa:aa.a","bbbb:bb:bb.b"]
+dmg_storage_format_perf:
+  max_s_per_device: 20

--- a/src/tests/ftest/control/dmg_storage_format_perf.yaml
+++ b/src/tests/ftest/control/dmg_storage_format_perf.yaml
@@ -1,14 +1,14 @@
 hosts:
-  test_servers:
-    - server-A
-    - server-B
-    - server-C
-    - server-D
-timeout: 90
+    test_servers:
+        - server-A
+        - server-B
+        - server-C
+        - server-D
+timeout: 60
 server_config:
-  name: daos_server
-  servers:
-    bdev_class: nvme
-    bdev_list: ["aaaa:aa:aa.a","bbbb:bb:bb.b"]
+    name: daos_server
+    servers:
+        bdev_class: nvme
+        bdev_list: ["aaaa:aa:aa.a","bbbb:bb:bb.b"]
 dmg_storage_format_perf:
-  max_s_per_device: 20
+    max_s_per_device: 20

--- a/src/tests/ftest/util/control_test_base.py
+++ b/src/tests/ftest/util/control_test_base.py
@@ -79,19 +79,6 @@ class ControlTestBase(TestWithServers):
                 self.get_dmg_output("storage_query_list_devices", **kwargs))
         return info
 
-    def get_max_devices(self, rank=None):
-        """Get the max number of devices for all/specified ranks.
-
-        Args:
-            rank (int, optional): Limit response to devices on this rank.
-                Defaults to None.
-
-        Returns:
-            int: max number of devices.
-
-        """
-        return max([len(devices) for devices in self.get_device_info(rank).items()])
-
     def get_pool_info(self, uuid=None, rank=None, verbose=False):
         """Query pool information.
 

--- a/src/tests/ftest/util/control_test_base.py
+++ b/src/tests/ftest/util/control_test_base.py
@@ -79,6 +79,19 @@ class ControlTestBase(TestWithServers):
                 self.get_dmg_output("storage_query_list_devices", **kwargs))
         return info
 
+    def get_max_devices(self, rank=None):
+        """Get the max number of devices for all/specified ranks.
+
+        Args:
+            rank (int, optional): Limit response to devices on this rank.
+                Defaults to None.
+
+        Returns:
+            int: max number of devices.
+
+        """
+        return max([len(devices) for devices in self.get_device_info(rank).items()])
+
     def get_pool_info(self, uuid=None, rank=None, verbose=False):
         """Query pool information.
 

--- a/src/tests/ftest/util/dmg_utils.py
+++ b/src/tests/ftest/util/dmg_utils.py
@@ -238,22 +238,15 @@ class DmgCommand(DmgCommandBase):
         # }
         return self._get_json_result(("storage", "scan"), verbose=verbose)
 
-    def storage_format(self, reformat=False, timeout=30, verbose=False,
-                       force=False):
+    def storage_format(self, reformat=False, timeout=30, verbose=False, force=False):
         """Get the result of the dmg storage format command.
 
         Args:
-            reformat (bool): always reformat storage, could be destructive.
-                This will create control-plane related metadata i.e. superblock
-                file and reformat if the storage media is available and
-                formattable.
-            timeout: seconds after which the format is considered a failure and
-                times out.
-            verbose (bool): show results of each SCM & NVMe device format
-                operation.
-            force (bool, optional): force storage format on a host, stopping any
-                running engines (CAUTION: destructive operation). Defaults to
-                False.
+            reformat (bool): Alias for --force, will be removed in a future release.
+            timeout: seconds after which the format is considered a failure and times out.
+            verbose (bool): Show results of each SCM & NVMe device format operation.
+            force (bool, optional): Force storage format on a host, stopping any running engines
+                (CAUTION: destructive operation). Defaults to False.
 
         Returns:
             CmdResult: an avocado CmdResult object containing the dmg command
@@ -265,9 +258,7 @@ class DmgCommand(DmgCommandBase):
         """
         saved_timeout = self.timeout
         self.timeout = timeout
-        self._get_result(
-            ("storage", "format"), reformat=reformat, verbose=verbose,
-            force=force)
+        self._get_result(("storage", "format"), reformat=reformat, verbose=verbose, force=force)
         self.timeout = saved_timeout
         return self.result
 

--- a/src/tests/ftest/util/server_utils.py
+++ b/src/tests/ftest/util/server_utils.py
@@ -125,6 +125,11 @@ class DaosServerManager(SubprocessManager):
         # Flag used to determine which method is used to detect that the server has started
         self.detect_start_via_dmg = False
 
+        # Timeout for dmg storage format
+        # Temporarily increasing timeout to avoid CI errors until DAOS-5764 can
+        # be further investigated.
+        self.dmg_storage_format_timeout = 40
+
     def get_params(self, test):
         """Get values for all of the command params from the yaml file.
 
@@ -536,9 +541,7 @@ class DaosServerManager(SubprocessManager):
         # Format storage and wait for server to change ownership
         self.log.info(
             "<SERVER> Formatting hosts: <%s>", self.dmg.hostlist)
-        # Temporarily increasing timeout to avoid CI errors until DAOS-5764 can
-        # be further investigated.
-        self.dmg.storage_format(timeout=40)
+        self.dmg.storage_format(timeout=self.dmg_storage_format_timeout)
 
         # Wait for all the engines to start
         self.detect_engine_start()


### PR DESCRIPTION
Test to verify storage format takes less than 20s per device.

Quick-build: true
Skip-unit-tests: true

Test-tag: dmg_storage_format_perf

Signed-off-by: Dalton Bohning <dalton.bohning@intel.com>