### PR TITLE
DAOS-9089 autotest: fix alignment and change status

### DIFF
--- a/src/utils/daos_autotest.c
+++ b/src/utils/daos_autotest.c
@@ -23,6 +23,7 @@
 
 #include "daos_hdlr.h"
 #include "math.h"
+
 /** Input arguments passed to daos utility */
 struct cmd_args_s *autotest_ap;
 
@@ -79,7 +80,7 @@ setup_progress()
 {
 	ticks = 20;
 	tick_size = total_nr / ticks;
-	fprintf(autotest_ap->outstream, "    ");
+	fprintf(autotest_ap->outstream, "     ");
 }
 
 void
@@ -89,8 +90,8 @@ increment_progress(int progress)
 		int percentage;
 
 		percentage = ceil((double) progress / (double) total_nr * 100.0);
-		fprintf(autotest_ap->outstream, "\b\b\b\b");
-		fprintf(autotest_ap->outstream, "% 4d", percentage);
+		fprintf(autotest_ap->outstream, "\b\b\b\b\b");
+		fprintf(autotest_ap->outstream, "% 4d%%", percentage);
 		fflush(autotest_ap->outstream);
 	}
 }
@@ -98,7 +99,7 @@ increment_progress(int progress)
 void
 finish_progress()
 {
-	fprintf(autotest_ap->outstream, "\b\b\b\b");
+	fprintf(autotest_ap->outstream, "\b\b\b\b\b");
 }
 
 
@@ -136,7 +137,7 @@ step_print(const char *status, const char *comment, va_list ap)
 	int	i;
 
 	end = clock();
-	fprintf(autotest_ap->outstream, "  %s    ", status);
+	fprintf(autotest_ap->outstream, "  %s  ", status);
 	sprintf(timing, "%03.3f", duration());
 	for (i = strlen(timing); i < 7; i++)
 		fprintf(autotest_ap->outstream, " ");
@@ -151,7 +152,7 @@ step_success(const char *comment, ...)
 	va_list	ap;
 
 	va_start(ap, comment);
-	step_print("\033[0;32mOK\033[0m", comment, ap);
+	step_print("\033[0;32mPASS\033[0m", comment, ap);
 	va_end(ap);
 }
 
@@ -161,7 +162,7 @@ step_fail(const char *comment, ...)
 	va_list	ap;
 
 	va_start(ap, comment);
-	step_print("\033[0;31mKO\033[0m", comment, ap);
+	step_print("\033[0;31mFAIL\033[0m", comment, ap);
 	va_end(ap);
 }
 
@@ -171,7 +172,7 @@ step_skip(const char *comment, ...)
 	va_list ap;
 
 	va_start(ap, comment);
-	step_print("\033[0;37mSK\033[0m", comment, ap);
+	step_print("\033[0;33mSKIP\033[0m", comment, ap);
 	va_end(ap);
 }
 static inline void
@@ -189,7 +190,7 @@ static inline void
 step_init(void)
 {
 	fprintf(autotest_ap->outstream,
-		"\033[1;35mStep Operation               ");
+		"\033[1;35mStep Operation                 ");
 	fprintf(autotest_ap->outstream, "Status Time(sec) Comment\033[0m\n");
 }
 


### PR DESCRIPTION
Change status to PASS/FAIL/SKIP and color for SKIP to yellow.
Also fix alignment issue with progress and add % sign.

Signed-off-by: Johann Lombardi <johann.lombardi@intel.com>