### PR TITLE
DAOS-7337 test: Adding EC test cases verification with all DAOS server restart. (#6891)

### DIFF
--- a/src/tests/ftest/erasurecode/aggregation.py
+++ b/src/tests/ftest/erasurecode/aggregation.py
@@ -75,6 +75,9 @@ class EcodAggregationOff(ErasureCodeIor):
                 # Read single IOR
                 self.ior_read_single_dataset(oclass, sizes)
 
+                # Increase the container UUID count and read the latest data.
+                self.cont_number += 1
+
     def test_ec_aggregation_time(self):
         """Jira ID: DAOS-7325.
 

--- a/src/tests/ftest/erasurecode/restart.py
+++ b/src/tests/ftest/erasurecode/restart.py
@@ -1,0 +1,115 @@
+#!/usr/bin/python
+"""
+  (C) Copyright 2020-2021 Intel Corporation.
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+"""
+import time
+from ec_utils import ErasureCodeIor, check_aggregation_status
+
+
+class EcodServerRestart(ErasureCodeIor):
+    # pylint: disable=too-many-ancestors
+    """
+    Test Class Description: To validate Erasure code object data after restarting all servers.
+    :avocado: recursive
+    """
+    def setUp(self):
+        """Set up for test case."""
+        super().setUp()
+        self.percent = self.params.get("size", '/run/ior/data_percentage/*')
+
+    def execution(self, agg_check=None):
+        """
+        Common test execution method to write data, verify aggregation, restart
+        all the servers and read data.
+
+        Args:
+            agg_check: When to check Aggregation status.Either before restarting all the servers or
+                       after.Default is None so not to check aggregation, but wait for 20 seconds
+                       and restart the servers.
+        """
+        # Write all EC object data to NVMe
+        self.ior_write_dataset(operation="Auto_Write", percent=self.percent)
+        self.log.info(self.pool.pool_percentage_used())
+        # Write all EC object data to SCM
+        self.ior_write_dataset(storage='SCM', operation="Auto_Write", percent=self.percent)
+        self.log.info(self.pool.pool_percentage_used())
+
+        if not agg_check:
+            # Set time mode aggregation
+            self.pool.set_property("reclaim", "time")
+            # Aggregation will start in 20 seconds after it sets to time mode. So wait for 20
+            # seconds and restart all the servers.
+            time.sleep(20)
+
+        if agg_check == "Before":
+            # Verify if Aggregation is getting started
+            if not any(check_aggregation_status(self.pool, attempt=50).values()):
+                self.fail("Aggregation failed to start Before server restart..")
+
+        # Shutdown the servers and restart
+        self.get_dmg_command().system_stop(True)
+        time.sleep(5)
+        self.get_dmg_command().system_start()
+
+        if agg_check == "After":
+            # Verify if Aggregation is getting started
+            if not any(check_aggregation_status(self.pool, attempt=50).values()):
+                self.fail("Aggregation failed to start After server restart..")
+
+        # Read all EC object data from NVMe
+        self.ior_read_dataset(operation="Auto_Read", percent=self.percent)
+        # Read all EC object data which was written on SCM
+        self.read_set_from_beginning = False
+        self.ior_read_dataset(storage='SCM', operation="Auto_Read", percent=self.percent)
+
+    def test_ec_restart_before_agg(self):
+        """Jira ID: DAOS-7337.
+
+        Test Description: Test Erasure code object with IOR after all server restart and Aggregation
+                            trigger before restart.
+        Use Case: Create the pool, run IOR with supported EC object type class for small and
+                    large transfer sizes.Verify aggregation starts, Restart all the servers.
+                    Read and verify all IOR data.
+
+        :avocado: tags=all,full_regression
+        :avocado: tags=hw,large,ib2
+        :avocado: tags=ec,ec_array,ec_server_restart,ec_aggregation
+        :avocado: tags=ec_restart_before_agg
+        """
+        self.execution(agg_check="Before")
+
+    def test_ec_restart_after_agg(self):
+        """Jira ID: DAOS-7337.
+
+        Test Description: Test Erasure code object with IOR after all server restart and Aggregation
+                            trigger after restart.
+        Use Case: Create the pool, run IOR with supported EC object type class for small and
+                large transfer sizes.Restart all servers. Verify Aggregation trigger after it's
+                start. Read and verify all IOR data.
+
+        :avocado: tags=all,full_regression
+        :avocado: tags=hw,large,ib2
+        :avocado: tags=ec,ec_array,ec_server_restart,ec_aggregation
+        :avocado: tags=ec_restart_after_agg
+        """
+        self.execution(agg_check="After")
+
+    def test_ec_restart_during_agg(self):
+        """Jira ID: DAOS-7337.
+
+        Test Description: Test server restart works during aggregation and IOR data is intact
+                            after restart.
+        Use Case: Create the pool, disabled rebuild, run IOR with supported EC object type class
+                    for small and large transfer sizes. Enable the time mode aggregation and wait
+                    for 20 seconds. Restart all servers, Read and verify all IOR data.
+
+        :avocado: tags=all,full_regression
+        :avocado: tags=hw,large,ib2
+        :avocado: tags=ec,ec_array,ec_server_restart,ec_aggregation
+        :avocado: tags=ec_restart_during_agg
+        """
+        # Disable the aggregation
+        self.pool.set_property("reclaim", "disabled")
+        self.execution()

--- a/src/tests/ftest/erasurecode/restart.yaml
+++ b/src/tests/ftest/erasurecode/restart.yaml
@@ -1,0 +1,77 @@
+hosts:
+  test_servers:
+    - server-A
+    - server-B
+    - server-C
+    - server-D
+    - server-E
+  test_clients:
+    - client-A
+    - client-B
+    - client-C
+timeout: 1500
+setup:
+  start_agents_once: False
+  start_servers_once: False
+server_config:
+  engines_per_host: 2
+  name: daos_server
+  servers:
+    0:
+      pinned_numa_node: 0
+      nr_xs_helpers: 1
+      fabric_iface: ib0
+      fabric_iface_port: 31317
+      log_file: daos_server0.log
+      bdev_class: nvme
+      bdev_list: ["0000:81:00.0"]
+      scm_class: dcpm
+      scm_list: ["/dev/pmem0"]
+      scm_mount: /mnt/daos0
+      log_mask: ERR
+    1:
+      pinned_numa_node: 1
+      nr_xs_helpers: 1
+      fabric_iface: ib1
+      fabric_iface_port: 31417
+      log_file: daos_server1.log
+      bdev_class: nvme
+      bdev_list: ["0000:da:00.0"]
+      scm_class: dcpm
+      scm_list: ["/dev/pmem1"]
+      scm_mount: /mnt/daos1
+      log_mask: ERR
+pool:
+    mode: 146
+    name: daos_server
+    scm_size: 2%
+    nvme_size: 5%
+    svcn: 1
+    control_method: dmg
+    pool_query_timeout: 30
+container:
+    type: POSIX
+    control_method: daos
+ior:
+  api: "DFS"
+  client_processes:
+   np: 48
+  dfs_destroy: False
+  iorflags:
+   flags: "-w -W -F -k -G 1 -vv"
+   read_flags: "-r -R -F -k -G 1 -vv"
+  test_file: /testFile
+  repetitions: 1
+  chunk_block_transfer_sizes:
+   # [ChunkSize, BlocksSize, TransferSize]
+   - [32M, AUTO, AUTO]
+  objectclass:
+   dfs_oclass_list:
+    #- [EC_Object_Class, Minimum number of servers]
+    - ["EC_2P1GX", 4]
+    - ["EC_2P2GX", 4]
+    - ["EC_4P1GX", 6]
+    - ["EC_4P2GX", 6]
+    - ["EC_8P2GX", 10]
+  data_percentage:
+    size: 1

--- a/src/tests/ftest/nvme/enospace.py
+++ b/src/tests/ftest/nvme/enospace.py
@@ -135,19 +135,19 @@ class NvmeEnospace(ServerFillUp):
         #Fill 75% more of SCM pool,Aggregation is Enabled so NVMe space will be
         #start filling
         print('Starting main IOR load')
-        self.start_ior_load(storage='SCM', percent=75)
+        self.start_ior_load(storage='SCM', operation="Auto_Write", percent=75)
         print(self.pool.pool_percentage_used())
 
         #Fill 50% more of SCM pool,Aggregation is Enabled so NVMe space will be
         #filled
-        self.start_ior_load(storage='SCM', percent=50)
+        self.start_ior_load(storage='SCM', operation="Auto_Write", percent=50)
         print(self.pool.pool_percentage_used())
 
         #Fill 60% more of SCM pool, now NVMe will be Full so data will not be
         #moved to NVMe but it will start filling SCM. SCM size will be going to
         #full and this command expected to fail with DER_NOSPACE
         try:
-            self.start_ior_load(storage='SCM', percent=60)
+            self.start_ior_load(storage='SCM', operation="Auto_Write", percent=60)
             self.fail('This test suppose to FAIL because of DER_NOSPACE'
                       'but it got Passed')
         except TestFail as _error:
@@ -250,7 +250,7 @@ class NvmeEnospace(ServerFillUp):
             time.sleep(60)
 
         #Run last IO
-        self.start_ior_load(storage='SCM', percent=1)
+        self.start_ior_load(storage='SCM', operation="Auto_Write", percent=1)
 
     def test_enospace_time_with_bg(self):
         """Jira ID: DAOS-4756.
@@ -315,7 +315,7 @@ class NvmeEnospace(ServerFillUp):
             time.sleep(120)
 
         #Run last IO
-        self.start_ior_load(storage='SCM', percent=1)
+        self.start_ior_load(storage='SCM', operation="Auto_Write", percent=1)
 
     @skipForTicket("DAOS-8896")
     def test_performance_storage_full(self):
@@ -336,9 +336,9 @@ class NvmeEnospace(ServerFillUp):
         #Write the IOR Baseline and get the Read BW for later comparison.
         print(self.pool.pool_percentage_used())
         #Write First
-        self.start_ior_load(storage='SCM', percent=1)
+        self.start_ior_load(storage='SCM', operation="Auto_Write", percent=1)
         #Read the baseline data set
-        self.start_ior_load(storage='SCM', operation='Read', percent=1)
+        self.start_ior_load(storage='SCM', operation='Auto_Read', percent=1)
         max_mib_baseline = float(self.ior_matrix[0][int(IorMetrics.Max_MiB)])
         baseline_cont_uuid = self.ior_cmd.dfs_cont.value
         print("IOR Baseline Read MiB {}".format(max_mib_baseline))
@@ -348,7 +348,7 @@ class NvmeEnospace(ServerFillUp):
 
         #Read the same container which was written at the beginning.
         self.container.uuid = baseline_cont_uuid
-        self.start_ior_load(storage='SCM', operation='Read', percent=1)
+        self.start_ior_load(storage='SCM', operation='Auto_Read', percent=1)
         max_mib_latest = float(self.ior_matrix[0][int(IorMetrics.Max_MiB)])
         print("IOR Latest Read MiB {}".format(max_mib_latest))
 
@@ -392,13 +392,13 @@ class NvmeEnospace(ServerFillUp):
         for _loop in range(10):
             print("-------enospc_no_aggregation Loop--------- {}".format(_loop))
             #Fill 75% of SCM pool
-            self.start_ior_load(storage='SCM', percent=40)
+            self.start_ior_load(storage='SCM', operation="Auto_Write", percent=40)
 
             print(self.pool.pool_percentage_used())
 
             try:
                 #Fill 10% more to SCM ,which should Fail because no SCM space
-                self.start_ior_load(storage='SCM', percent=40)
+                self.start_ior_load(storage='SCM', operation="Auto_Write", percent=40)
                 self.fail('This test suppose to fail because of DER_NOSPACE'
                           'but it got Passed')
             except TestFail as _error:
@@ -423,4 +423,4 @@ class NvmeEnospace(ServerFillUp):
                           format(pool_usage['scm']))
 
         #Run last IO
-        self.start_ior_load(storage='SCM', percent=1)
+        self.start_ior_load(storage='SCM', operation="Auto_Write", percent=1)

--- a/src/tests/ftest/nvme/fault.py
+++ b/src/tests/ftest/nvme/fault.py
@@ -48,7 +48,7 @@ class NvmeFault(ServerFillUp):
         self.create_pool_max_size(nvme=True)
 
         #Start the IOR Command and generate the NVMe fault.
-        self.start_ior_load(percent=self.capacity)
+        self.start_ior_load(operation="Auto_Write", percent=self.capacity)
 
         print(
             "pool_percentage_used -- After -- {}".format(

--- a/src/tests/ftest/util/ec_utils.py
+++ b/src/tests/ftest/util/ec_utils.py
@@ -36,12 +36,14 @@ def get_data_parity_number(log, oclass):
     tmp = re.findall(r'\d+', oclass)
     return {'data': tmp[0], 'parity': tmp[1]}
 
-def check_aggregation_status(pool, quick_check=True):
+
+def check_aggregation_status(pool, quick_check=True, attempt=20):
     """EC Aggregation triggered status.
     Args:
         pool(object): pool object to get the query.
-        quick_check(bool): Return immediately when Aggregation starts for any
-                           storage type.
+        quick_check(bool): Return immediately when Aggregation starts for any storage type.
+        attempt(int): Number of attempts to do pool query at interval of 5 seconds.
+                      default is 20 attempts.
     return:
         result(dic): Storage Aggregation stats SCM/NVMe True/False.
     """
@@ -49,26 +51,26 @@ def check_aggregation_status(pool, quick_check=True):
     pool.connect()
     initial_usage = pool.pool_percentage_used()
 
-    for _tmp in range(20):
+    for _tmp in range(attempt):
         current_usage = pool.pool_percentage_used()
         print("pool_percentage during Aggregation = {}".format(current_usage))
         for storage_type in ['scm', 'nvme']:
             if current_usage[storage_type] > initial_usage[storage_type]:
                 print("Aggregation Started for {}.....".format(storage_type))
                 agg_status[storage_type] = True
-                #Return immediately once aggregation starts for quick check
+                # Return immediately once aggregation starts for quick check
                 if quick_check:
                     return agg_status
         time.sleep(5)
     return agg_status
+
 
 class ErasureCodeIor(ServerFillUp):
     # pylint: disable=too-many-ancestors
     """
 
     Class to used for EC testing.
-    It will get the object types from yaml file write the IOR data set with
-    IOR.
+    It will get the object types from yaml file write the IOR data set with IOR.
 
     """
 
@@ -78,6 +80,8 @@ class ErasureCodeIor(ServerFillUp):
         self.server_count = None
         self.ec_container = None
         self.cont_uuid = []
+        self.cont_number = 0
+        self.read_set_from_beginning = True
 
     def setUp(self):
         """Set up each test case."""
@@ -86,29 +90,23 @@ class ErasureCodeIor(ServerFillUp):
 
         # Fail IOR test in case of Warnings
         self.fail_on_warning = True
-        engine_count = self.server_managers[0].get_config_value(
-            "engines_per_host")
+        engine_count = self.server_managers[0].get_config_value("engines_per_host")
         self.server_count = len(self.hostlist_servers) * engine_count
         # Create the Pool
         self.create_pool_max_size()
         self.update_ior_cmd_with_pool()
-        self.obj_class = self.params.get("dfs_oclass_list",
-                                         '/run/ior/objectclass/*')
-        self.ior_chu_trs_blk_size = self.params.get(
-            "chunk_block_transfer_sizes", '/run/ior/*')
+        self.obj_class = self.params.get("dfs_oclass_list", '/run/ior/objectclass/*')
+        self.ior_chu_trs_blk_size = self.params.get("chunk_block_transfer_sizes", '/run/ior/*')
 
     def ec_container_create(self, oclass):
         """Create the container for EC object"""
         # Get container params
-        self.ec_container = TestContainer(
-            self.pool, daos_command=DaosCommand(self.bin))
+        self.ec_container = TestContainer(self.pool, daos_command=DaosCommand(self.bin))
         self.ec_container.get_params(self)
         self.ec_container.oclass.update(oclass)
-        # update object class for container create, if supplied
-        # explicitly.
+        # update object class for container create, if supplied explicitly.
         ec_object = get_data_parity_number(self.log, oclass)
-        self.ec_container.properties.update("rf:{}".format(
-            ec_object['parity']))
+        self.ec_container.properties.update("rf:{}".format(ec_object['parity']))
 
         # create container
         self.ec_container.create()
@@ -120,21 +118,27 @@ class ErasureCodeIor(ServerFillUp):
             oclass(list): list of the obj class to use with IOR
             sizes(list): Update Transfer, Chunk and Block sizes
         """
+        self.ior_cmd.dfs_chunk.update(sizes[0])
         self.ior_cmd.block_size.update(sizes[1])
         self.ior_cmd.transfer_size.update(sizes[2])
         self.ior_cmd.dfs_oclass.update(oclass[0])
         self.ior_cmd.dfs_dir_oclass.update(oclass[0])
-        self.ior_cmd.dfs_chunk.update(sizes[0])
 
-    def ior_write_single_dataset(self, oclass, sizes, percent=1):
+    def ior_write_single_dataset(self, oclass, sizes, storage='NVMe', operation="WriteRead",
+                                 percent=1):
+        # pylint: disable=too-many-arguments
         """Write IOR single data set with EC object.
 
         Args:
             oclass(list): list of the obj class to use with IOR
             sizes(list): Update Transfer, Chunk and Block sizes
-            percent(int): %of storage to be filled. Default it will use the
-                          given parameters in yaml file.
+            storage(str): Data to be written on storage,default to NVMe.
+            operation(str): Data to be Written only or Write and Read both. default to WriteRead
+                            both
+            percent(int): %of storage to be filled. Default it will use the given parameters in
+                            yaml file.
         """
+        self.log.info(self.pool.pool_percentage_used())
         self.ior_param_update(oclass, sizes)
 
         # Create the new container with correct redundancy factor for EC
@@ -143,60 +147,81 @@ class ErasureCodeIor(ServerFillUp):
 
         # Start IOR Write
         self.container.uuid = self.ec_container.uuid
-        self.start_ior_load(operation="WriteRead", percent=percent,
-                            create_cont=False)
+        self.start_ior_load(storage, operation, percent, create_cont=False)
+
+        # Store the container UUID for future reading
         self.cont_uuid.append(self.ior_cmd.dfs_cont.value)
 
-    def ior_write_dataset(self, percent=1):
-        """Write IOR data set with different EC object and different sizes."""
+    def ior_write_dataset(self, storage='NVMe', operation="WriteRead", percent=1):
+        """Write IOR data set with different EC object and different sizes.
+
+        Args:
+            storage(str): Data to be written on storage, default to NVMe
+            operation(str): Data to be Written only or Write and Read both. default to WriteRead
+                            both.
+            percent(int): %of storage to be filled. Default it's 1%.
+        """
         for oclass in self.obj_class:
             for sizes in self.ior_chu_trs_blk_size:
-                # Skip the object type if server count does not meet the
-                # minimum EC object server count
+                # Skip the object type if server count does not meet the minimum EC object server
+                # count
                 if oclass[1] > self.server_count:
                     continue
-                self.ior_write_single_dataset(oclass, sizes, percent)
+                self.ior_write_single_dataset(oclass, sizes, storage, operation, percent)
 
-    def ior_read_single_dataset(self, oclass, sizes, percent=1):
+    def ior_read_single_dataset(self, oclass, sizes, storage='NVMe', operation="Read", percent=1):
+        # pylint: disable=too-many-arguments
         """Read IOR single data set with EC object.
 
         Args:
             oclass(list): list of the obj class to use with IOR
             sizes(list): Update Transfer, Chunk and Block sizes
-            percent(int): %of storage to be filled. Default it will use the
-                          given parameters in yaml file
+            storage(str): Data to be written on which storage
+            operation(str): Data to be Read only or Auto_Read which select IOR blocksize during
+                            runtime.
+            percent(int): %of storage to be filled. Default it's 1%.
         """
         self.ior_param_update(oclass, sizes)
-        # Start IOR Read
-        self.start_ior_load(operation='Read', percent=percent,
-                            create_cont=False)
 
-    def ior_read_dataset(self, parity=1):
+        # retrieve the container UUID to read the existing data
+        self.container.uuid = self.cont_uuid[self.cont_number]
+
+        # Start IOR Read
+        self.start_ior_load(storage, operation, percent, create_cont=False)
+
+    def ior_read_dataset(self, storage='NVMe', operation="Read", percent=1, parity=1):
         """Read IOR data and verify for different EC object and different sizes
 
         Args:
-           data_parity(str): object parity type for reading, default All.
+            storage(str): Data to be written on storage, default to NVMe
+            percent(int): %of storage to be filled. Default it's 1%
+            operation(str): Data to be Read only or Auto_Read which select IOR blocksize during
+                            runtime.
+            parity(int): object parity type for reading data, default is 1.
         """
-        con_count = 0
+        # By default read the data set from beginning, or start from the specific container UUID
+        if self.read_set_from_beginning:
+            self.cont_number = 0
+
         for oclass in self.obj_class:
             for sizes in self.ior_chu_trs_blk_size:
-                # Skip the object type if server count does not meet the
-                # minimum EC object server count.
+                # Skip the object type if server count does not meet the minimum EC object server
+                # count.
                 if oclass[1] > self.server_count:
                     continue
                 parity_set = "P{}".format(parity)
                 # Read the requested data+parity data set only
                 if parity != 1 and parity_set not in oclass[0]:
-                    print("Skipping Read as object type is {}"
-                          .format(oclass[0]))
-                    con_count += 1
+                    print("Skipping Read as object type is {}".format(oclass[0]))
+                    self.cont_number += 1
                     continue
-                self.container.uuid = self.cont_uuid[con_count]
-                self.ior_read_single_dataset(oclass, sizes, parity)
-                con_count += 1
+
+                self.ior_read_single_dataset(oclass, sizes, storage, operation, percent)
+                self.cont_number += 1
 
 class ErasureCodeSingle(TestWithServers):
     # pylint: disable=too-many-ancestors
+    # pylint: disable=too-many-instance-attributes
     """
     Class to used for EC testing for single type data.
     """
@@ -217,10 +242,8 @@ class ErasureCodeSingle(TestWithServers):
         engine_count = self.server_managers[0].get_config_value(
             "engines_per_host")
         self.server_count = len(self.hostlist_servers) * engine_count
-        self.obj_class = self.params.get("dfs_oclass_list",
-                                         '/run/objectclass/*')
-        self.singledata_set = self.params.get("single_data_set",
-                                              '/run/container/*')
+        self.obj_class = self.params.get("dfs_oclass_list", '/run/objectclass/*')
+        self.singledata_set = self.params.get("single_data_set", '/run/container/*')
         self.add_pool()
         self.out_queue = queue.Queue()
 
@@ -234,13 +257,13 @@ class ErasureCodeSingle(TestWithServers):
         self.container.append(TestContainer(self.pool))
         # Get container parameters
         self.container[index].get_params(self)
-        # update object class for container create, if supplied
-        # explicitly.
+
+        # update object class for container create, if supplied explicitly.
         self.container[index].oclass.update(oclass)
+
         # Get the Parity count for setting the container RF property.
         ec_object = get_data_parity_number(self.log, oclass)
-        self.container[index].properties.update("rf:{}".format(
-            ec_object['parity']))
+        self.container[index].properties.update("rf:{}".format(ec_object['parity']))
 
         # create container
         self.container[index].create()
@@ -259,8 +282,7 @@ class ErasureCodeSingle(TestWithServers):
         self.container[index].data_size.update(data[4])
 
     def write_single_type_dataset(self, results=None):
-        """Write single type data set with different EC object
-           and different sizes.
+        """Write single type data set with different EC object and different sizes.
 
         Args:
             results (queue): queue for returning thread results
@@ -268,18 +290,16 @@ class ErasureCodeSingle(TestWithServers):
         cont_count = 0
         for oclass in self.obj_class:
             for sizes in self.singledata_set:
-                # Skip the object type if server count does not meet
-                # the minimum EC object server count
+                # Skip the object type if server count does not meet the minimum EC object server
+                # count
                 if oclass[1] > self.server_count:
                     continue
-                # Create the new container with correct redundancy factor
-                # for EC object type
+                # Create the new container with correct redundancy factor for EC object type
                 try:
                     self.ec_container_create(cont_count, oclass[0])
                     self.single_type_param_update(cont_count, sizes)
                     # Write the data
-                    self.container[cont_count].write_objects(
-                        obj_class=oclass[0])
+                    self.container[cont_count].write_objects(obj_class=oclass[0])
                     cont_count += 1
                     if results is not None:
                         results.put("PASS")
@@ -289,40 +309,38 @@ class ErasureCodeSingle(TestWithServers):
                     raise
 
     def read_single_type_dataset(self, results=None, parity=1):
-        """Read single type data and verify for different EC object
-            and different sizes.
+        """Read single type data and verify for different EC object and different sizes.
 
         Args:
-           parity(int): object parity number for reading, default All.
+            results (queue): queue for returning thread results
+            parity(int): object parity number for reading, default All.
         """
         cont_count = 0
         self.daos_cmd = DaosCommand(self.bin)
         for oclass in self.obj_class:
-            for _sizes in  self.singledata_set:
-                # Skip the object type if server count does not meet
-                # the minimum EC object server count
+            for _sizes in self.singledata_set:
+                # Skip the object type if server count does not meet the minimum EC object server
+                # count
                 if oclass[1] > self.server_count:
                     continue
                 parity_set = "P{}".format(parity)
                 # Read the requested data+parity data set only
                 if parity != 1 and parity_set not in oclass[0]:
-                    print("Skipping Read as object type is {}"
-                          .format(oclass[0]))
+                    print("Skipping Read as object type is {}".format(oclass[0]))
                     cont_count += 1
                     continue
 
-                self.daos_cmd.container_set_prop(
-                    pool=self.pool.uuid,
-                    cont=self.container[cont_count].uuid,
-                    prop="status",
-                    value="healthy")
+                self.daos_cmd.container_set_prop(pool=self.pool.uuid,
+                                                 cont=self.container[cont_count].uuid,
+                                                 prop="status",
+                                                 value="healthy")
 
                 # Read data and verified the content
                 try:
                     if not self.container[cont_count].read_objects():
-                        self.fail("Data verification Error")
                         if results is not None:
                             results.put("FAIL")
+                        self.fail("Data verification Error")
                     cont_count += 1
                     if results is not None:
                         results.put("PASS")
@@ -354,9 +372,7 @@ class ErasureCodeSingle(TestWithServers):
             time.sleep(10)
             # Kill the server rank
             if self.rank_to_kill is not None:
-                self.server_managers[0].stop_ranks([self.rank_to_kill],
-                                                   self.d_log,
-                                                   force=True)
+                self.server_managers[0].stop_ranks([self.rank_to_kill], self.d_log, force=True)
 
         # Wait to finish the thread
         job.join()
@@ -365,6 +381,7 @@ class ErasureCodeSingle(TestWithServers):
         while not self.out_queue.empty():
             if self.out_queue.get() == "FAIL":
                 self.fail("FAIL")
+
 
 class ErasureCodeMdtest(MdtestBase):
     # pylint: disable=too-many-ancestors
@@ -383,11 +400,9 @@ class ErasureCodeMdtest(MdtestBase):
     def setUp(self):
         """Set up each test case."""
         super().setUp()
-        engine_count = self.server_managers[0].get_config_value(
-            "engines_per_host")
+        engine_count = self.server_managers[0].get_config_value("engines_per_host")
         self.server_count = len(self.hostlist_servers) * engine_count
-        self.obj_class = self.params.get("dfs_oclass_list",
-                                         '/run/mdtest/objectclass/*')
+        self.obj_class = self.params.get("dfs_oclass_list", '/run/mdtest/objectclass/*')
         # Create Pool
         self.add_pool()
         self.out_queue = queue.Queue()
@@ -402,8 +417,8 @@ class ErasureCodeMdtest(MdtestBase):
         self.execute_mdtest(self.out_queue)
 
     def start_online_mdtest(self):
-        """Run MDtest operation with thread in background. Trigger the server
-           failure while MDtest is running
+        """Run MDtest operation with thread in background. Trigger the server failure while
+        MDtest is running
 
         """
         # Create the MDtest run thread
@@ -429,6 +444,7 @@ class ErasureCodeMdtest(MdtestBase):
             if self.out_queue.get() == "Mdtest Failed":
                 self.fail("FAIL")
 
+
 class ErasureCodeFio(FioBase):
     # pylint: disable=too-many-ancestors
     """
@@ -445,8 +461,7 @@ class ErasureCodeFio(FioBase):
     def setUp(self):
         """Set up each test case."""
         super().setUp()
-        engine_count = self.server_managers[0].get_config_value(
-            "engines_per_host")
+        engine_count = self.server_managers[0].get_config_value("engines_per_host")
         self.server_count = len(self.hostlist_servers) * engine_count
 
         # Create Pool
@@ -469,8 +484,8 @@ class ErasureCodeFio(FioBase):
                 raise
 
     def start_online_fio(self):
-        """Run Fio operation with thread in background. Trigger the server
-           failure while Fio is running
+        """Run Fio operation with thread in background. Trigger the server failure while Fio is
+        running
         """
         # Create the Fio run thread
         job = threading.Thread(target=self.write_single_fio_dataset,

--- a/src/tests/ftest/util/nvme_utils.py
+++ b/src/tests/ftest/util/nvme_utils.py
@@ -35,9 +35,7 @@ def get_device_ids(dmg, servers):
         try:
             result = dmg.run()
         except CommandFailure as _error:
-            raise CommandFailure(
-                "dmg list-devices failed with error {}".format(
-                    _error)) from _error
+            raise CommandFailure("dmg list-devices failed with error {}".format(_error)) from _error
         drive_list = []
         for line in result.stdout_text.split('\n'):
             if 'UUID' in line:
@@ -81,35 +79,36 @@ class ServerFillUp(IorTestBase):
         super().setUp()
         self.hostfile_clients = None
         self.ior_default_flags = self.ior_cmd.flags.value
-        self.ior_scm_xfersize = self.ior_cmd.transfer_size.value
-        self.ior_read_flags = self.params.get("read_flags",
-                                              '/run/ior/iorflags/*',
-                                              '-r -R -k -G 1')
-        self.ior_nvme_xfersize = self.params.get(
-            "nvme_transfer_size", '/run/ior/transfersize_blocksize/*',
-            '16777216')
+        self.ior_scm_xfersize = self.params.get("transfer_size",
+                                                '/run/ior/transfersize_blocksize/*', '2048')
+        self.ior_read_flags = self.params.get("read_flags", '/run/ior/iorflags/*', '-r -R -k -G 1')
+        self.ior_nvme_xfersize = self.params.get("nvme_transfer_size",
+                                                 '/run/ior/transfersize_blocksize/*', '16777216')
         # Get the number of daos_engine
-        self.engines = (self.server_managers[0].manager.job.yaml.engine_params)
+        self.engines = self.server_managers[0].manager.job.yaml.engine_params
         self.out_queue = queue.Queue()
 
-    def start_ior_thread(self, results, create_cont, operation='WriteRead'):
+    def start_ior_thread(self, results, create_cont, operation):
         """Start IOR write/read threads and wait until all threads are finished.
 
         Args:
             results (queue): queue for returning thread results
-            operation (str): IOR operation for read/write.
-                             Default it will do whatever mention in ior_flags
-                             set.
+            create_cont (Bool): To create the new container or not.
+            operation (str):
+                Write/WriteRead: It will Write or Write/Read base on IOR parameter in yaml file.
+                Auto_Write/Auto_Read: It will calculate the IOR block size based on requested
+                                        storage % to be fill.
         """
+        # IOR flag can be Write only or Write/Read based on test yaml
         self.ior_cmd.flags.value = self.ior_default_flags
 
-        # For IOR Other operation, calculate the block size based on server %
-        # to fill up. Store the container UUID for future reading operation.
-        if operation == 'Write':
+        # Calculate the block size based on server % to fill up.
+        if 'Auto' in operation:
             block_size = self.calculate_ior_block_size()
             self.ior_cmd.block_size.update('{}'.format(block_size))
-        # For IOR Read only operation, retrieve the stored container UUID
-        elif operation == 'Read':
+
+        # For IOR Read operation update the read flax from yaml file.
+        if 'Auto_Read' in operation or operation == "Read":
             create_cont = False
             self.ior_cmd.flags.value = self.ior_read_flags
 
@@ -129,17 +128,6 @@ class ServerFillUp(IorTestBase):
             block_size(int): IOR Block size
 
         """
-        # Check the replica for IOR object to calculate the correct block size.
-        _replica = re.findall(r'_(.+?)G', self.ior_cmd.dfs_oclass.value)
-        if not _replica:
-            replica_server = 1
-        # This is for EC Parity
-        elif 'P' in _replica[0]:
-            replica_server = re.findall(r'\d+', _replica[0])[0]
-        else:
-            replica_server = _replica[0]
-
-        print('Replica Server = {}'.format(replica_server))
         if self.scm_fill:
             free_space = self.pool.get_pool_daos_space()["s_total"][0]
             self.ior_cmd.transfer_size.value = self.ior_scm_xfersize
@@ -151,18 +139,38 @@ class ServerFillUp(IorTestBase):
 
         # Get the block size based on the capacity to be filled. For example
         # If nvme_free_space is 100G and to fill 50% of capacity.
-        # Formula : (107374182400 / 100) * 50.This will give 50% of space to be
-        # filled. Divide with total number of process, 16 process means each
-        # process will write 3.12Gb.last, if there is replica set, For RP_2G1
-        # will divide the individual process size by number of replica.
-        # 3.12G (Single process size)/2 (No of Replica) = 1.56G
-        # To fill 50 % of 100GB pool with total 16 process and replica 2, IOR
-        # single process size will be 1.56GB.
-        _tmp_block_size = (((free_space/100)*self.capacity)/self.processes)
-        _tmp_block_size = int(_tmp_block_size / int(replica_server))
-        block_size = (
-            int(_tmp_block_size / int(self.ior_cmd.transfer_size.value)) *
-            int(self.ior_cmd.transfer_size.value))
+        # Formula : (107374182400 / 100) * 50.This will give 50%(50G) of space to be filled.
+        _tmp_block_size = ((free_space/100)*self.capacity)
+
+        # Check the IOR object type to calculate the correct block size.
+        _replica = re.findall(r'_(.+?)G', self.ior_cmd.dfs_oclass.value)
+
+        # This is for non replica and EC class where _tmp_block_size will not change.
+        if not _replica:
+            pass
+
+        # If it's EC object, Calculate the tmp block size based on number of data + parity
+        # targets. And calculate the write data size for the total number data targets.
+        # For example: 100Gb of total pool to be filled 10% in total: For EC_4P1GX,  Get the data
+        # target fill size = 8G, which will fill 8G of data and 2G of Parity. So total 10G (10%
+        # of 100G of pool size)
+        elif 'P' in _replica[0]:
+            replica_server = re.findall(r'\d+', _replica[0])[0]
+            parity_count = re.findall(r'\d+', _replica[0])[1]
+            _tmp_block_size = int(_tmp_block_size / (int(replica_server) + int(parity_count)))
+            _tmp_block_size = int(_tmp_block_size) * int(replica_server)
+
+        # This is Replica type object class
+        else:
+            _tmp_block_size = int(_tmp_block_size / int(_replica[0]))
+
+        # Last divide the Total sized with IOR number of process
+        _tmp_block_size = int(_tmp_block_size) / self.processes
+
+        # Calculate the Final block size of IOR multiple of Transfer size.
+        block_size = (int(_tmp_block_size / int(self.ior_cmd.transfer_size.value)) * int(
+            self.ior_cmd.transfer_size.value))
+
         return block_size
 
     def set_device_faulty(self, server, disk_id):
@@ -177,8 +185,8 @@ class ServerFillUp(IorTestBase):
         result = self.dmg.storage_query_device_health(disk_id)
         # Check if device state changed to EVICTED.
         if 'State:EVICTED' not in result.stdout_text:
-            self.fail("device State {} on host {} suppose to be EVICTED"
-                      .format(disk_id, server))
+            self.fail("device State {} on host {} suppose to be EVICTED".format(disk_id, server))
+
         # Wait for rebuild to start
         self.pool.wait_for_rebuild(True)
         # Wait for rebuild to complete
@@ -189,8 +197,8 @@ class ServerFillUp(IorTestBase):
         # Get the device ids from all servers and try to eject the disks
         device_ids = get_device_ids(self.dmg, self.hostlist_servers)
 
-        # no_of_servers and no_of_drives can be set from test yaml.
-        # 1 Server, 1 Drive = Remove single drive from single server
+        # no_of_servers and no_of_drives can be set from test yaml. 1 Server, 1 Drive = Remove
+        # single drive from single server
         for num in range(0, self.no_of_servers):
             server = self.hostlist_servers[num]
             for disk_id in range(0, self.no_of_drives):
@@ -209,8 +217,7 @@ class ServerFillUp(IorTestBase):
         except (ServerFailed, KeyError) as error:
             self.fail(error)
 
-        # Return the 96% of storage space as it won't be used 100%
-        # for pool creation.
+        # Return the 96% of storage space as it won't be used 100% for pool creation.
         for index, _size in enumerate(sizes):
             sizes[index] = int(sizes[index] * 0.96)
 
@@ -223,9 +230,8 @@ class ServerFillUp(IorTestBase):
             scm (bool): To create the pool with max SCM size or not.
             nvme (bool): To create the pool with max NVMe size or not.
 
-        Note: Method to Fill up the server. It will get the maximum Storage
-              space and create the pool.
-              Replace with dmg options in future when it's available.
+        Note: Method to Fill up the server. It will get the maximum Storage space and create the
+              pool. Replace with dmg options in future when it's available.
         """
         # Create a pool
         self.add_pool(create=False)
@@ -244,8 +250,8 @@ class ServerFillUp(IorTestBase):
         # Create the Pool
         self.pool.create()
 
-    def start_ior_load(self, storage='NVMe', operation="Write", percent=1,
-                       create_cont=True):
+    def start_ior_load(self, storage='NVMe', operation="WriteRead",
+                       percent=1, create_cont=True):
         """Fill up the server either SCM or NVMe.
 
         Fill up based on percent amount given using IOR.
@@ -262,10 +268,9 @@ class ServerFillUp(IorTestBase):
         self.scm_fill = 'SCM' in storage
 
         # Create the IOR threads
-        job = threading.Thread(target=self.start_ior_thread,
-                               kwargs={"results": self.out_queue,
-                                       "create_cont": create_cont,
-                                       "operation": operation})
+        job = threading.Thread(target=self.start_ior_thread, kwargs={"results": self.out_queue,
+                                                                     "create_cont": create_cont,
+                                                                     "operation": operation})
         # Launch the IOR thread
         job.start()
 
@@ -280,7 +285,7 @@ class ServerFillUp(IorTestBase):
             time.sleep(30)
             # Kill the server rank
             if self.rank_to_kill is not None:
-                self.get_dmg_command().system_stop(True, self.rank_to_kill)
+                self.server_managers[0].stop_ranks([self.rank_to_kill], self.d_log, force=True)
 
         # Wait to finish the thread
         job.join()


### PR DESCRIPTION
- Adding test which will write EC date with different object types,
  Wait for aggregation to trigger and restart all the servers.
  Read and verify the data after start.
- Adding test which will write the EC data with different object types,
  Restart all the servers, Verify aggregation is getting trigger after start.
  Read and verify the data after aggregation.
- Disabled the aggregation, Write EC data with different object types,
  Enable the time mode aggregation and wait for ~20 seconds.
  Restart all the servers when aggregation is also happening.
  read and verify the data after aggregation.

Quick-build: true
Test-tag: ec nvme

Signed-off-by: Samir Raval <samir.raval@intel.com>