### PR TITLE
DAOS-9169 mgmt: remove overchecks assertion

### DIFF
--- a/src/mgmt/srv_target.c
+++ b/src/mgmt/srv_target.c
@@ -750,7 +750,6 @@ ds_mgmt_hdlr_tgt_create(crt_rpc_t *tc_req)
 		rc = pthread_tryjoin_np(thread, &res);
 		if (rc == 0) {
 			if (canceled_thread) {
-				D_ASSERT(res == PTHREAD_CANCELED);
 				D_DEBUG(DB_MGMT,
 					DF_UUID": tgt_create thread canceled\n",
 					DP_UUID(tc_in->tc_pool_uuid));


### PR DESCRIPTION
The cancel signal can arrive after thread normal complete.
So, this assertion can happens in the corner case but anyway
this consequence nothing.