### PR TITLE
DAOS-8872 debug: Truncate large keys and print integer keys (#7529)

### DIFF
--- a/ci/unit/test_nlt_node.sh
+++ b/ci/unit/test_nlt_node.sh
@@ -20,4 +20,4 @@ cd build
 sudo bash -c ". ./utils/sl/setup_local.sh; ./utils/setup_daos_admin.sh"
 
 # NLT will mount /mnt/daos itself.
-./utils/node_local_test.py --max-log-size 550MiB --dfuse-dir /localhome/jenkins/ all
+./utils/node_local_test.py --max-log-size 650MiB --dfuse-dir /localhome/jenkins/ all

--- a/src/client/array/dc_array.c
+++ b/src/client/array/dc_array.c
@@ -1490,9 +1490,9 @@ dc_array_io(daos_handle_t array_oh, daos_handle_t th,
 			D_GOTO(err_iotask, rc);
 		}
 
-		D_DEBUG(DB_IO, "DKEY IOD "DF_U64": idx = %d\t num_records = %zu"
-			"\t record_i = %d\n",
-			dkey_val, (int)array_idx, num_records, (int)record_i);
+		D_DEBUG(DB_IO, "DKEY IOD "DF_U64": idx = "DF_U64"\t num_records = %zu"
+			"\t record_i = "DF_U64"\n", dkey_val, array_idx, num_records,
+			record_i);
 
 		/** allocate params for this dkey io */
 		D_ALLOC_PTR(params);

--- a/src/include/daos/common.h
+++ b/src/include/daos/common.h
@@ -153,10 +153,10 @@ char *DP_UUID(const void *uuid);
 #define DP_KEY(key)		(int)((key)->iov_len)
 #else
 char *daos_key2str(daos_key_t *key);
+#define DF_KEY_STR_SIZE		64
 
-#define DF_KEY			"[%d] '%.*s'"
+#define DF_KEY			"[%d] '%s'"
 #define DP_KEY(key)		(int)(key)->iov_len,	\
-				(int)(key)->iov_len,	\
 				daos_key2str(key)
 #endif
 

--- a/src/tests/ftest/rebuild/pool_destroy_race.yaml
+++ b/src/tests/ftest/rebuild/pool_destroy_race.yaml
@@ -43,7 +43,7 @@ pool:
   name: daos_server
   scm_size: 2G
   nvme_size: 28G
-  svcn: 1
+  svcn: 3
   control_method: dmg
   pool_query_timeout: 15
 container:

--- a/src/vos/vos_io.c
+++ b/src/vos/vos_io.c
@@ -1132,11 +1132,10 @@ key_ilog_check(struct vos_io_context *ioc, struct vos_krec_df *krec,
 
 	rc = vos_ilog_check(info, &epr, epr_out, true);
 out:
-	D_DEBUG(DB_TRACE, "ilog check returned "DF_RC" epr_in="DF_X64"-"DF_X64
-		" punch="DF_PUNCH" epr_out="DF_X64"-"DF_X64"\n", DP_RC(rc),
-		epr.epr_lo, epr.epr_hi, DP_PUNCH(&info->ii_prior_punch),
-		epr_out ? epr_out->epr_lo : 0,
-		epr_out ? epr_out->epr_hi : 0);
+	D_CDEBUG(rc == 0, DB_TRACE, DB_IO, "ilog check returned "DF_RC" epr_in="
+		 DF_X64"-"DF_X64" punch="DF_PUNCH" epr_out="DF_X64"-"DF_X64"\n",
+		 DP_RC(rc), epr.epr_lo, epr.epr_hi, DP_PUNCH(&info->ii_prior_punch),
+		 epr_out ? epr_out->epr_lo : 0, epr_out ? epr_out->epr_hi : 0);
 	return rc;
 }
 
@@ -1388,9 +1387,10 @@ dkey_fetch(struct vos_io_context *ioc, daos_key_t *dkey)
 	rc = key_tree_prepare(obj, obj->obj_toh, VOS_BTR_DKEY,
 			      dkey, 0, DAOS_INTENT_DEFAULT, &krec,
 			      &toh, ioc->ic_ts_set);
-
 	if (stop_check(ioc, VOS_COND_FETCH_MASK | VOS_OF_COND_PER_AKEY, NULL,
 		       &rc, true)) {
+		D_DEBUG(DB_IO, "Stop fetch "DF_UOID": "DF_RC"\n", DP_UOID(obj->obj_id),
+			DP_RC(rc));
 		if (rc == 0 && !ioc->ic_read_ts_only) {
 			for (i = 0; i < ioc->ic_iod_nr; i++)
 				iod_empty_sgl(ioc, i);
@@ -1407,6 +1407,8 @@ dkey_fetch(struct vos_io_context *ioc, daos_key_t *dkey)
 	if (stop_check(ioc, VOS_COND_FETCH_MASK | VOS_OF_COND_PER_AKEY, NULL,
 		       &rc, false)) {
 		if (rc == 0 && !ioc->ic_read_ts_only) {
+			D_DEBUG(DB_IO, "Stop fetch "DF_UOID": "DF_RC"\n", DP_UOID(obj->obj_id),
+				DP_RC(rc));
 			if (has_uncertainty(ioc, &ioc->ic_dkey_info)) {
 				/** There is a value in the uncertainty range so
 				 *  we need to continue the fetch.

--- a/src/vos/vos_tree.c
+++ b/src/vos/vos_tree.c
@@ -1085,6 +1085,8 @@ key_tree_prepare(struct vos_object *obj, daos_handle_t toh,
 	if (krecp != NULL)
 		*krecp = krec;
  out:
+	D_CDEBUG(rc == 0, DB_TRACE, DB_IO, "prepare tree, flags=%x, tclass=%d %d\n",
+		 flags, tclass, rc);
 	return rc;
 }
 


### PR DESCRIPTION
* Print INT key for DP_KEY, and limit the DP_KEY
by DF_KEY_STR_SIZE.
* Fix and add a few IO DAOS log.
* Set svnc to be 3 for pool_destory_race.yaml, since
the test will kill 1 rank, which might be PS leader.
* Minor optimizations to key2str
* Increase log file size limit to account for more debug
* Pull in fix for this commit from (#7756)

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>
Co-authored-by: Di Wang <di.wang@intel.com>