### PR TITLE
DAOS-7420 object: retry inflight I/O for discard obj

### DIFF
--- a/src/common/fail_loc.c
+++ b/src/common/fail_loc.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2021 Intel Corporation.
+ * (C) Copyright 2016-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -119,23 +119,27 @@ daos_shard_fail_value(uint16_t *shards, int nr)
 		D_ERROR("ignore nr %d, should within [1, 4].\n", nr);
 		return fail_val;
 	}
-	for (i = 0; i < nr; i++)
-		fail_val |= ((uint64_t)shards[i] << (16 * i));
+
+	for (i = 0; i < nr; i++) {
+		D_ASSERT(shards[i] != 0xffff);
+		fail_val |= ((shards[i] + 1) << (16 * i));
+	}
+
 	return fail_val;
 }
 
 bool
 daos_shard_in_fail_value(uint16_t shard)
 {
-	int		i;
 	uint64_t	mask = 0xFFFF;
 	uint64_t	fail_val = daos_fail_value_get();
+	int		i;
 
+	D_ASSERT(shard != 0xffff);
 	for (i = 0; i < 4; i++) {
-		if (shard == ((fail_val & (mask << (i * 16))) >> (i * 16)))
+		if ((shard + 1) == (fail_val & (mask << (i * 16))))
 			return true;
 	}
-
 	return false;
 }
 

--- a/src/dtx/dtx_resync.c
+++ b/src/dtx/dtx_resync.c
@@ -173,8 +173,8 @@ dtx_is_leader(struct ds_pool *pool, struct dtx_resync_args *dra,
 		return 1;
 
 	rc = dtx_leader_get(pool, mbs, &target);
-	if (rc != 0)
-		return 0;
+	if (rc < 0)
+		D_GOTO(out, rc);
 
 	D_ASSERT(target != NULL);
 	rc = crt_group_rank(NULL, &myrank);

--- a/src/include/daos/object.h
+++ b/src/include/daos/object.h
@@ -231,6 +231,8 @@ int daos_oclass_fit_max(daos_oclass_id_t oc_id, int domain_nr, int target_nr,
 bool daos_oclass_is_valid(daos_oclass_id_t oc_id);
 daos_oclass_id_t daos_obj_get_oclass(daos_handle_t coh, daos_ofeat_t ofeats,
 				   daos_oclass_hints_t hints, uint32_t args);
+#define daos_oclass_grp_off_by_shard(oca, shard)				\
+	(rounddown(shard, daos_oclass_grp_size(oca)))
 
 /** bits for the specified rank */
 #define DAOS_OC_SR_SHIFT	24
@@ -762,6 +764,7 @@ daos_recx_ep_list_dump(struct daos_recx_ep_list *lists, unsigned int nr)
 struct dc_obj_enum_unpack_io {
 	daos_unit_oid_t		 ui_oid;	/**< type <= OBJ */
 	daos_key_t		 ui_dkey;	/**< type <= DKEY */
+	uint64_t		 ui_dkey_hash;
 	daos_iod_t		*ui_iods;
 	d_iov_t			 ui_csum_iov;
 	/* punched epochs per akey */

--- a/src/include/daos_errno.h
+++ b/src/include/daos_errno.h
@@ -273,6 +273,9 @@ extern "C" {
 		Retry with other target)				\
 	ACTION(DER_NOTSUPPORTED,	(DER_ERR_DAOS_BASE + 37),	\
 	       Operation not supported)					\
+	/** Re-update again */						\
+	ACTION(DER_UPDATE_AGAIN,	(DER_ERR_DAOS_BASE + 38),	\
+	       update again)						\
 
 /** Defines the gurt error codes */
 #define D_FOREACH_ERR_RANGE(ACTION)	\

--- a/src/object/cli_ec.c
+++ b/src/object/cli_ec.c
@@ -274,12 +274,14 @@ obj_ec_seg_pack(struct obj_ec_seg_sorter *sorter, d_sg_list_t *sgl)
 
 static int
 obj_ec_recov_tgt_recx_nrs(struct obj_reasb_req *reasb_req,
-			  uint32_t *tgt_recx_nrs)
+			  uint64_t dkey_hash, uint32_t *tgt_recx_nrs)
 {
 	struct obj_ec_fail_info	*fail_info = reasb_req->orr_fail;
 	struct daos_oclass_attr	*oca = reasb_req->orr_oca;
-	uint32_t		 tgt, tgt_nr;
-	int			 rc = 0;
+	uint32_t		tgt_nr = 0;
+	uint32_t		tgt;
+	int			i;
+	int			rc = 0;
 
 	D_ASSERT(fail_info != NULL);
 	if (fail_info->efi_ntgts > obj_ec_parity_tgt_nr(oca)) {
@@ -289,11 +291,14 @@ obj_ec_recov_tgt_recx_nrs(struct obj_reasb_req *reasb_req,
 			obj_ec_parity_tgt_nr(oca), DP_RC(rc));
 		goto out;
 	}
-	for (tgt = 0, tgt_nr = 0; tgt < obj_ec_tgt_nr(oca); tgt++) {
-		if (obj_ec_tgt_in_err(fail_info->efi_tgt_list,
-				      fail_info->efi_ntgts, tgt))
+
+	for (i = 0, tgt = obj_ec_shard_idx(dkey_hash, oca, 0);
+	     i < obj_ec_tgt_nr(oca); i++, tgt = (tgt + 1) % obj_ec_tgt_nr(oca)) {
+		if (obj_ec_tgt_in_err(fail_info->efi_tgt_list, fail_info->efi_ntgts, tgt)) {
+			D_DEBUG(DB_TRACE, "tgt %ui not available\n", tgt);
 			continue;
-		tgt_recx_nrs[tgt]++;
+		}
+		tgt_recx_nrs[i]++;
 		tgt_nr++;
 		if (tgt_nr == obj_ec_data_tgt_nr(oca))
 			break;
@@ -307,8 +312,8 @@ out:
 
 /** scan the iod to find the full_stripe recxs and some help info */
 static int
-obj_ec_recx_scan(daos_iod_t *iod, d_sg_list_t *sgl,
-		 struct daos_oclass_attr *oca, struct obj_reasb_req *reasb_req,
+obj_ec_recx_scan(daos_iod_t *iod, d_sg_list_t *sgl, struct daos_oclass_attr *oca,
+		 uint64_t dkey_hash, struct obj_reasb_req *reasb_req,
 		 uint32_t iod_idx, bool update)
 {
 	uint8_t				*tgt_bitmap = reasb_req->tgt_bitmap;
@@ -364,7 +369,7 @@ obj_ec_recx_scan(daos_iod_t *iod, d_sg_list_t *sgl,
 			ec_all_tgt_recx_nrs(oca, tgt_recx_nrs, j);
 		} else {
 			if (reasb_req->orr_recov)
-				rc = obj_ec_recov_tgt_recx_nrs(reasb_req, tgt_recx_nrs);
+				rc = obj_ec_recov_tgt_recx_nrs(reasb_req, dkey_hash, tgt_recx_nrs);
 			else
 				ec_data_tgt_recx_nrs(oca, tgt_recx_nrs, j);
 			if (rc)
@@ -428,7 +433,7 @@ obj_ec_recx_scan(daos_iod_t *iod, d_sg_list_t *sgl,
 		ec_recx_array->oer_tgt_recx_idxs[i] = recx_nr;
 		recx_nr += tgt_recx_nrs[i];
 		if (tgt_recx_nrs[i] != 0) {
-			setbit(tgt_bitmap, i);
+			setbit(tgt_bitmap, obj_ec_shard_idx(dkey_hash, oca, i));
 			tgt_nr++;
 		}
 	}
@@ -534,6 +539,34 @@ out:
 	for (i = 0; i < c_idx; i++)
 		D_FREE(c_data[i]);
 	return rc;
+}
+
+int
+obj_ec_encode_buf(daos_obj_id_t oid, struct daos_oclass_attr *oca,
+		  daos_size_t iod_size, unsigned char *buffer,
+		  unsigned char *p_bufs[])
+{
+	struct obj_ec_codec	*codec;
+	daos_size_t	cell_bytes = obj_ec_cell_rec_nr(oca) * iod_size;
+	unsigned int	k = obj_ec_data_tgt_nr(oca);
+	unsigned int	p = obj_ec_parity_tgt_nr(oca);
+	unsigned char	*data[k];
+	int		i;
+
+	codec = obj_ec_codec_get(daos_obj_id2class(oid));
+	D_ASSERT(codec != NULL);
+
+	for (i = 0; i < p && p_bufs[i] == NULL; i++) {
+		D_ALLOC(p_bufs[i], cell_bytes);
+		if (p_bufs[i] == NULL)
+			return -DER_NOMEM;
+	}
+
+	for (i = 0; i < k; i++)
+		data[i] = buffer + i * cell_bytes;
+
+	ec_encode_data((int)cell_bytes, k, p, codec->ec_gftbls, data, p_bufs);
+	return 0;
 }
 
 static struct obj_ec_codec *
@@ -698,8 +731,9 @@ ec_data_recx_add(daos_recx_t *recx, daos_recx_t *r_recx, uint32_t *r_idx,
 	if (recx->rx_nr == 0)
 		return;
 
-	EC_TRACE("adding recx idx "DF_U64", nr "DF_U64", add_parity %d.\n",
-		 recx->rx_idx, recx->rx_nr, add_parity);
+	EC_TRACE("adding recx idx "DF_U64", nr "DF_U64", add_parity %d."
+		"cell/stripe "DF_U64"/"DF_U64"\n", recx->rx_idx, recx->rx_nr,
+		add_parity, cell_rec_nr, stripe_rec_nr);
 
 	if (add_parity) {
 		/* replicated data on parity node need not VOS index mapping */
@@ -1036,9 +1070,9 @@ obj_reasb_req_dump(struct obj_reasb_req *reasb_req, d_sg_list_t *usgl,
 }
 
 static void
-ec_recov_recx_seg_add(struct obj_reasb_req *reasb_req, daos_recx_t *recx,
-		      daos_recx_t *r_recx, uint32_t *r_idx, uint32_t *start_idx,
-		      daos_size_t iod_size, d_sg_list_t *sgl,
+ec_recov_recx_seg_add(struct obj_reasb_req *reasb_req, uint64_t dkey_hash,
+		      daos_recx_t *recx, daos_recx_t *r_recx, uint32_t *r_idx,
+		      uint32_t *start_idx, daos_size_t iod_size, d_sg_list_t *sgl,
 		      struct obj_ec_seg_sorter *sorter)
 {
 	struct obj_ec_fail_info	*fail_info = reasb_req->orr_fail;
@@ -1059,20 +1093,25 @@ ec_recov_recx_seg_add(struct obj_reasb_req *reasb_req, daos_recx_t *recx,
 	stripe_total_sz = cell_sz * obj_ec_tgt_nr(oca);
 	stripe_nr = recx->rx_nr / stripe_rec_nr;
 	recx_nr = recx->rx_nr / obj_ec_data_tgt_nr(oca);
-	for (tgt = 0, tgt_nr = 0; tgt < obj_ec_tgt_nr(oca); tgt++) {
-		if (obj_ec_tgt_in_err(fail_info->efi_tgt_list,
-				      fail_info->efi_ntgts, tgt))
-			continue;
-		recx_idx = ec_vos_idx(recx->rx_idx);
-		if (tgt >= obj_ec_data_tgt_nr(oca))
-			recx_idx |= PARITY_INDICATOR;
-		ec_recx_add(r_recx, r_idx, start_idx, tgt, recx_idx, recx_nr);
 
-		for (i = 0; i < stripe_nr; i++) {
-			buf_stripe = buf_sgl + i * stripe_total_sz;
-			buf = buf_stripe + tgt * cell_sz;
+	for (i = 0, tgt_nr = 0, tgt = obj_ec_shard_idx(dkey_hash, oca, 0);
+	     i < obj_ec_tgt_nr(oca); i++, tgt = (tgt + 1) % obj_ec_tgt_nr(oca)) {
+		int j;
+
+		if (obj_ec_tgt_in_err(fail_info->efi_tgt_list, fail_info->efi_ntgts,
+				      tgt))
+			continue;
+
+		recx_idx = ec_vos_idx(recx->rx_idx);
+		if (i >= obj_ec_data_tgt_nr(oca))
+			recx_idx |= PARITY_INDICATOR;
+		ec_recx_add(r_recx, r_idx, start_idx, i, recx_idx, recx_nr);
+
+		for (j = 0; j < stripe_nr; j++) {
+			buf_stripe = buf_sgl + j * stripe_total_sz;
+			buf = buf_stripe + i * cell_sz;
 			d_iov_set(&iov, buf, cell_sz);
-			obj_ec_seg_insert(sorter, tgt, &iov, 1);
+			obj_ec_seg_insert(sorter, i, &iov, 1);
 		}
 
 		tgt_nr++;
@@ -1090,9 +1129,9 @@ ec_recov_recx_seg_add(struct obj_reasb_req *reasb_req, daos_recx_t *recx,
  */
 static int
 obj_ec_recx_reasb(daos_iod_t *iod, d_sg_list_t *sgl,
-		  struct daos_oclass_attr *oca,
+		  struct daos_oclass_attr *oca, uint64_t dkey_hash,
 		  struct obj_reasb_req *reasb_req, uint32_t iod_idx,
-		  bool update, int *data_tgt_idx, bool *single_data_tgt)
+		  bool update)
 {
 	struct obj_ec_recx_array	*ec_recx_array =
 						&reasb_req->orr_recxs[iod_idx];
@@ -1116,7 +1155,7 @@ obj_ec_recx_reasb(daos_iod_t *iod, d_sg_list_t *sgl,
 	daos_recx_t			*recx, *full_recx, tmp_recx;
 	d_iov_t				*iovs = NULL;
 	uint32_t			 i, j, k, idx, last;
-	uint32_t			 tgt_nr, empty_nr, tmp_nr;
+	uint32_t			 tgt_nr, empty_nr;
 	uint32_t			 iov_idx = 0, iov_nr = 0;
 	uint64_t			 iov_off = 0, recx_end, full_end;
 	uint64_t			 rec_nr, iod_size = iod->iod_size;
@@ -1145,7 +1184,7 @@ obj_ec_recx_reasb(daos_iod_t *iod, d_sg_list_t *sgl,
 			if (reasb_req->orr_recov) {
 				D_ASSERT(!update);
 				D_ASSERT(iod->iod_nr == 1);
-				ec_recov_recx_seg_add(reasb_req, recx,
+				ec_recov_recx_seg_add(reasb_req, dkey_hash, recx,
 					riod->iod_recxs, ridx, tgt_recx_idxs,
 					iod_size, sgl, sorter);
 				continue;
@@ -1254,25 +1293,20 @@ obj_ec_recx_reasb(daos_iod_t *iod, d_sg_list_t *sgl,
 		last = tgt_recx_idxs[i] + tgt_recx_nrs[i];
 	}
 	oiod->oiod_nr = idx;
-	tmp_nr = update ? obj_ec_data_tgt_nr(oca) : tgt_nr;
 	for (i = 0, rec_nr = 0, last = 0; i < tgt_nr; i++) {
 		if (tgt_recx_nrs[i] == 0)
 			continue;
-		if ((*single_data_tgt) && (i < tmp_nr)) {
-			if (*data_tgt_idx == -1)
-				*data_tgt_idx = i;
-			else if (*data_tgt_idx != i)
-				*single_data_tgt = false;
-		}
 		siod = &oiod->oiod_siods[tidx[i]];
-		siod->siod_tgt_idx = i;
+		siod->siod_tgt_idx = obj_ec_shard_idx(dkey_hash, oca, i);
 		siod->siod_idx = tgt_recx_idxs[i];
 		siod->siod_nr = tgt_recx_nrs[i];
+		D_DEBUG(DB_TRACE, "i %d tgt %u idx %u nr %u, start "DF_U64
+			" tgt_recx %u/%u\n", i, siod->siod_tgt_idx, siod->siod_idx,
+			siod->siod_nr, obj_ec_shard_idx(dkey_hash, oca, 0),
+			tgt_recx_idxs[i], tgt_recx_nrs[i]);
 		siod->siod_off = rec_nr * iod_size;
-		for (idx = last; idx < tgt_recx_idxs[i] + tgt_recx_nrs[i];
-		     idx++) {
+		for (idx = last; idx < tgt_recx_idxs[i] + tgt_recx_nrs[i]; idx++)
 			rec_nr += riod->iod_recxs[idx].rx_nr;
-		}
 		last = tgt_recx_idxs[i] + tgt_recx_nrs[i];
 	}
 
@@ -1285,74 +1319,98 @@ obj_ec_recx_reasb(daos_iod_t *iod, d_sg_list_t *sgl,
 	return rc;
 }
 
+/* Get one parity idx within the group, but skip the err list & current existing bitmap.*/
 int
-obj_ec_get_degrade(struct obj_reasb_req *reasb_req, uint16_t fail_tgt_idx,
-		   uint32_t *parity_tgt_idx, bool ignore_fail_tgt_idx)
+obj_ec_fail_info_parity_get(struct obj_reasb_req *reasb_req, uint64_t dkey_hash,
+			    uint32_t *parity_tgt_idx, uint8_t *cur_bitmap)
 {
 	uint16_t		 p = obj_ec_parity_tgt_nr(reasb_req->orr_oca);
-	uint16_t		 k = obj_ec_data_tgt_nr(reasb_req->orr_oca);
-	struct obj_ec_fail_info	*fail_info;
-	uint32_t		*err_list;
-	uint32_t		 nerrs, i;
-	bool			 with_parity = false;
+	uint16_t		 grp_size = obj_ec_tgt_nr(reasb_req->orr_oca);
+	struct obj_ec_fail_info *fail_info = reasb_req->orr_fail;
+	uint32_t		*err_list = NULL;
+	uint32_t		 nerrs = 0;
+	uint32_t		 parity_start;
+	int			 i;
 
-	fail_info = obj_ec_fail_info_get(reasb_req, true, k + p);
-	if (fail_info == NULL)
-		return -DER_NOMEM;
+	parity_start = obj_ec_parity_start(dkey_hash, reasb_req->orr_oca);
+	if (fail_info == NULL) {
+		*parity_tgt_idx = parity_start;
+		return 0;
+	}
 
 	err_list = fail_info->efi_tgt_list;
 	nerrs = fail_info->efi_ntgts;
+	for (i = 0; i < p; i++) {
+		uint32_t parity = (parity_start + i) % grp_size;
 
-	if (!ignore_fail_tgt_idx) {
-		bool	hit = false;
-
-		D_ASSERT(fail_tgt_idx < k + p);
-		for (i = 0; i < nerrs; i++) {
-			if (err_list[i] == fail_tgt_idx) {
-				hit = true;
-				break;
-			}
-		}
-
-		if (!hit) {
-			err_list[nerrs] = fail_tgt_idx;
-			fail_info->efi_ntgts++;
-			if (fail_info->efi_ntgts > p) {
-				D_ERROR("with %d failure, not recoverable.\n",
-					fail_info->efi_ntgts);
-				return -DER_DATA_LOSS;
-			}
-		}
-	}
-
-	if (parity_tgt_idx == NULL)
-		return 0;
-
-	nerrs = fail_info->efi_ntgts;
-	for (i = k; i < k + p; i++) {
-		if (!obj_ec_tgt_in_err(err_list, nerrs, i)) {
-			*parity_tgt_idx = i;
-			with_parity = true;
+		if (!obj_ec_tgt_in_err(err_list, nerrs, parity) &&
+		    (cur_bitmap == NIL_BITMAP || isclr(cur_bitmap, parity))) {
+			*parity_tgt_idx = parity;
 			break;
 		}
 	}
-	if (nerrs > p || !with_parity)
+
+	if (nerrs > p || i == p) {
+		D_ERROR(DF_OID" %d failure, not recoverable.\n",
+			DP_OID(reasb_req->orr_oid), nerrs);
+		for (i = 0; i < nerrs; i++)
+			D_ERROR("fail tgt: %u\n", err_list[i]);
+
 		return -DER_DATA_LOSS;
+	}
+
+	return 0;
+}
+
+/* Insert fail_tgt into the fail_info list, return DATA_LOSS if fail tgts are
+ * more than parity targets.
+ **/
+int
+obj_ec_fail_info_insert(struct obj_reasb_req *reasb_req, uint16_t fail_tgt)
+{
+	uint16_t		grp_size = obj_ec_tgt_nr(reasb_req->orr_oca);
+	struct obj_ec_fail_info	*fail_info;
+	uint32_t		*err_list;
+	uint32_t		nerrs;
+	int			i;
+
+	D_ASSERT(fail_tgt < grp_size);
+	fail_info = obj_ec_fail_info_get(reasb_req, true, grp_size);
+	if (fail_info == NULL)
+		return -DER_NOMEM;
+
+	if (obj_ec_tgt_in_err(fail_info->efi_tgt_list, fail_info->efi_ntgts, fail_tgt))
+		return 0;
+
+	err_list = fail_info->efi_tgt_list;
+	nerrs = fail_info->efi_ntgts;
+	err_list[nerrs] = fail_tgt;
+	fail_info->efi_ntgts++;
+	D_DEBUG(DB_IO, DF_OID" insert fail_tgt %u fail num %u\n", DP_OID(reasb_req->orr_oid),
+		fail_tgt, fail_info->efi_ntgts);
+	if (fail_info->efi_ntgts > obj_ec_parity_tgt_nr(reasb_req->orr_oca)) {
+		D_ERROR(DF_OID" %d failure, not recoverable.\n", DP_OID(reasb_req->orr_oid),
+			fail_info->efi_ntgts);
+		for (i = 0; i < nerrs; i++)
+			D_ERROR("fail tgt: %u\n", err_list[i]);
+
+		return -DER_DATA_LOSS;
+	}
 
 	return 0;
 }
 
 int
 obj_ec_singv_split(daos_unit_oid_t oid, struct daos_oclass_attr *oca,
-		   daos_size_t iod_size, d_sg_list_t *sgl)
+		   uint64_t dkey_hash, daos_size_t iod_size, d_sg_list_t *sgl)
 {
 	uint64_t c_bytes = obj_ec_singv_cell_bytes(iod_size, oca);
-	uint32_t shard_idx = oid.id_shard % obj_ec_data_tgt_nr(oca);
+	uint32_t tgt_idx = obj_ec_shard_off(dkey_hash, oca, oid.id_shard);
 	char	*data = sgl->sg_iovs[0].iov_buf;
 
 	D_ASSERT(iod_size != DAOS_REC_ANY);
-	if (shard_idx > 0)
-		memmove(data, data + shard_idx * c_bytes, c_bytes);
+	if (tgt_idx > 0)
+		memmove(data, data + tgt_idx * c_bytes, c_bytes);
 
 	sgl->sg_iovs[0].iov_len = c_bytes;
 	return 0;
@@ -1383,11 +1441,12 @@ out:
 
 int
 obj_ec_singv_encode_buf(daos_unit_oid_t oid, struct daos_oclass_attr *oca,
-			daos_iod_t *iod, d_sg_list_t *sgl, d_iov_t *e_iov)
+			uint64_t dkey_hash, daos_iod_t *iod, d_sg_list_t *sgl,
+			d_iov_t *e_iov)
 {
 	struct obj_ec_recx_array recxs = { 0 };
 	struct obj_ec_codec *codec;
-	int p_shard; /* parity shard */
+	int p_tgt_off; /* parity shard */
 	int idx;
 	int rc;
 
@@ -1405,9 +1464,9 @@ obj_ec_singv_encode_buf(daos_unit_oid_t oid, struct daos_oclass_attr *oca,
 	if (rc)
 		D_GOTO(out, rc);
 
-	p_shard = oid.id_shard % obj_ec_tgt_nr(oca);
-	D_ASSERT(p_shard >= obj_ec_data_tgt_nr(oca));
-	idx = p_shard - obj_ec_data_tgt_nr(oca);
+	p_tgt_off = obj_ec_shard_off(dkey_hash, oca, oid.id_shard);
+	D_ASSERT(p_tgt_off >= obj_ec_data_tgt_nr(oca));
+	idx = p_tgt_off - obj_ec_data_tgt_nr(oca);
 	D_ASSERT(e_iov->iov_buf_len >=
 		 obj_ec_singv_cell_bytes(iod->iod_size, oca));
 	e_iov->iov_len = obj_ec_singv_cell_bytes(iod->iod_size, oca);
@@ -1417,16 +1476,37 @@ out:
 	return rc;
 }
 
-#define obj_ec_set_tgt(tgt_bitmap, idx, start, end)			\
+#define obj_ec_set_all_bitmaps(tgt_bitmap, oca)				\
 	do {								\
-		for (idx = start; idx <= end; idx++)			\
-			setbit(tgt_bitmap, idx);			\
+		int i;							\
+		for (i = 0; i <= obj_ec_tgt_nr(oca); i++)		\
+			setbit(tgt_bitmap, i);				\
+	} while (0)
+
+#define obj_ec_set_data_bitmaps(tgt_bitmap, dkey_hash, oca)		\
+	do {								\
+		int data_idx = obj_ec_shard_idx(dkey_hash, oca, 0);	\
+		int i;							\
+										\
+		for (idx = data_idx, i = 0; i < obj_ec_data_tgt_nr(oca);	\
+		     i++, idx = (idx + 1) % obj_ec_tgt_nr(oca))			\
+			setbit(tgt_bitmap, idx);				\
+	} while (0)
+
+#define obj_ec_set_parity_bitmaps(tgt_bitmap, dkey_hash, oca)		\
+	do {								\
+		int parity_idx = obj_ec_parity_start(dkey_hash, oca);	\
+		int i;							\
+										\
+		for (idx = parity_idx, i = 0; i < obj_ec_parity_tgt_nr(oca);	\
+		     i++, idx = (idx + 1) % obj_ec_tgt_nr(oca))			\
+			setbit(tgt_bitmap, idx);				\
 	} while (0)
 
 static int
-obj_ec_singv_req_reasb(daos_obj_id_t oid, daos_iod_t *iod, d_sg_list_t *sgl,
+obj_ec_singv_req_reasb(daos_obj_id_t oid, uint64_t dkey_hash, daos_iod_t *iod, d_sg_list_t *sgl,
 		       struct daos_oclass_attr *oca, struct obj_reasb_req *reasb_req,
-		       uint32_t iod_idx, bool update, int *data_tgt_idx, bool *single_data_tgt)
+		       uint32_t iod_idx, bool update)
 {
 	struct obj_ec_recx_array	*ec_recx_array;
 	uint8_t				*tgt_bitmap = reasb_req->tgt_bitmap;
@@ -1449,29 +1529,20 @@ obj_ec_singv_req_reasb(daos_obj_id_t oid, daos_iod_t *iod, d_sg_list_t *sgl,
 		 * parity targets.
 		 */
 		if (reasb_req->orr_recov) {
-			rc = obj_ec_get_degrade(reasb_req, 0, &idx, true);
+			rc = obj_ec_fail_info_parity_get(reasb_req, dkey_hash, &idx, NIL_BITMAP);
 			if (rc) {
-				D_ERROR(DF_OID" obj_ec_get_degrade failed, "
+				D_ERROR(DF_OID" can not get parity failed, "
 					DF_RC".\n", DP_OID(oid), DP_RC(rc));
 				goto out;
 			}
-			D_ASSERT(idx < obj_ec_tgt_nr(oca) &&
-				 idx >= obj_ec_data_tgt_nr(oca));
 		} else {
-			idx = obj_ec_singv_small_idx(oca, iod);
-		}
-		if (*single_data_tgt) {
-			if (*data_tgt_idx == -1)
-				*data_tgt_idx = idx;
-			else if (*data_tgt_idx != idx)
-				*single_data_tgt = false;
+			idx = obj_ec_singv_small_idx(oca, dkey_hash, iod);
 		}
 		setbit(tgt_bitmap, idx);
 		tgt_nr = 1;
 		if (update) {
+			obj_ec_set_parity_bitmaps(tgt_bitmap, dkey_hash, oca);
 			tgt_nr += obj_ec_parity_tgt_nr(oca);
-			obj_ec_set_tgt(tgt_bitmap, idx, obj_ec_data_tgt_nr(oca),
-				       obj_ec_tgt_nr(oca) - 1);
 		}
 	} else {
 		struct dcs_layout	*singv_lo;
@@ -1479,21 +1550,19 @@ obj_ec_singv_req_reasb(daos_obj_id_t oid, daos_iod_t *iod, d_sg_list_t *sgl,
 		singv_lo = &reasb_req->orr_singv_los[iod_idx];
 		singv_lo->cs_even_dist = 1;
 		if (iod->iod_size != DAOS_REC_ANY)
-			singv_lo->cs_bytes =
-				obj_ec_singv_cell_bytes(iod->iod_size, oca);
+			singv_lo->cs_bytes = obj_ec_singv_cell_bytes(iod->iod_size, oca);
 
-		*single_data_tgt = false;
 		/* large singv evenly distributed to all data targets */
 		if (update) {
 			tgt_nr = obj_ec_tgt_nr(oca);
 			singv_lo->cs_nr = tgt_nr;
-			obj_ec_set_tgt(tgt_bitmap, idx, 0,
-				       obj_ec_tgt_nr(oca) - 1);
+			obj_ec_set_all_bitmaps(tgt_bitmap, oca);
 			if (!punch)
 				singv_parity = true;
 		} else {
 			if (reasb_req->orr_recov) {
 				struct obj_ec_fail_info	*fail_info = reasb_req->orr_fail;
+				int	i;
 
 				if (fail_info->efi_ntgts > obj_ec_parity_tgt_nr(oca)) {
 					rc = -DER_DATA_LOSS;
@@ -1504,10 +1573,11 @@ obj_ec_singv_req_reasb(daos_obj_id_t oid, daos_iod_t *iod, d_sg_list_t *sgl,
 				}
 
 				tgt_nr = 0;
-				for (idx = 0; idx < obj_ec_tgt_nr(oca); idx++) {
-					if (obj_ec_tgt_in_err(
-						fail_info->efi_tgt_list,
-						fail_info->efi_ntgts, idx))
+				for (i = 0, idx = obj_ec_shard_idx(dkey_hash, oca, 0);
+				     i < obj_ec_tgt_nr(oca);
+				     idx = (idx + 1) % obj_ec_tgt_nr(oca), i++) {
+					if (obj_ec_tgt_in_err(fail_info->efi_tgt_list,
+							      fail_info->efi_ntgts, idx))
 						continue;
 					setbit(tgt_bitmap, idx);
 					tgt_nr++;
@@ -1516,7 +1586,7 @@ obj_ec_singv_req_reasb(daos_obj_id_t oid, daos_iod_t *iod, d_sg_list_t *sgl,
 				}
 			} else {
 				tgt_nr = obj_ec_data_tgt_nr(oca);
-				obj_ec_set_tgt(tgt_bitmap, idx, 0, tgt_nr - 1);
+				obj_ec_set_data_bitmaps(tgt_bitmap, dkey_hash, oca);
 			}
 			singv_lo->cs_nr = tgt_nr;
 		}
@@ -1615,14 +1685,13 @@ obj_ec_encode(struct obj_reasb_req *reasb_req)
 }
 
 int
-obj_ec_req_reasb(daos_iod_t *iods, d_sg_list_t *sgls, daos_obj_id_t oid,
-		 struct daos_oclass_attr *oca, struct obj_reasb_req *reasb_req,
-		 uint32_t iod_nr, bool update)
+obj_ec_req_reasb(daos_iod_t *iods, uint64_t dkey_hash, d_sg_list_t *sgls, daos_obj_id_t oid,
+		 struct daos_oclass_attr *oca, struct obj_reasb_req *reasb_req, uint32_t iod_nr,
+		 bool update)
 {
 	bool	singv_only = true;
 	int	i, j, rc = 0;
-	int	data_tgt_idx = -1;
-	bool	single_data_tgt = true;
+	int	data_tgt_nr = 0;
 
 	reasb_req->orr_oid = oid;
 	reasb_req->orr_iod_nr = iod_nr;
@@ -1652,9 +1721,9 @@ obj_ec_req_reasb(daos_iod_t *iods, d_sg_list_t *sgls, daos_obj_id_t oid,
 
 	for (i = 0; i < iod_nr; i++) {
 		if (iods[i].iod_type == DAOS_IOD_SINGLE) {
-			rc = obj_ec_singv_req_reasb(oid, &iods[i], sgls ? &sgls[i] : NULL,
-						    oca, reasb_req, i, update,
-						    &data_tgt_idx, &single_data_tgt);
+			rc = obj_ec_singv_req_reasb(oid, dkey_hash, &iods[i],
+						    sgls ? &sgls[i] : NULL,
+						    oca, reasb_req, i, update);
 			if (rc) {
 				D_ERROR(DF_OID" singv_req_reasb failed %d.\n",
 					DP_OID(oid), rc);
@@ -1666,15 +1735,15 @@ obj_ec_req_reasb(daos_iod_t *iods, d_sg_list_t *sgls, daos_obj_id_t oid,
 		singv_only = false;
 		/* For array EC obj, scan/encode/reasb for each iod */
 		rc = obj_ec_recx_scan(&iods[i], sgls ? &sgls[i] : NULL, oca,
-				      reasb_req, i, update);
+				      dkey_hash, reasb_req, i, update);
 		if (rc) {
 			D_ERROR(DF_OID" obj_ec_recx_scan failed %d.\n",
 				DP_OID(oid), rc);
 			goto out;
 		}
 
-		rc = obj_ec_recx_reasb(&iods[i], sgls ? &sgls[i] : NULL, oca, reasb_req, i,
-				       update, &data_tgt_idx, &single_data_tgt);
+		rc = obj_ec_recx_reasb(&iods[i], sgls ? &sgls[i] : NULL, oca,
+				       dkey_hash, reasb_req, i, update);
 		if (rc) {
 			D_ERROR(DF_OID" obj_ec_recx_reasb failed %d.\n",
 				DP_OID(oid), rc);
@@ -1682,7 +1751,15 @@ obj_ec_req_reasb(daos_iod_t *iods, d_sg_list_t *sgls, daos_obj_id_t oid,
 		}
 	}
 
-	if (single_data_tgt) {
+	for (i = 0; !reasb_req->orr_size_fetched && i < obj_ec_tgt_nr(oca); i++) {
+		if (isset(reasb_req->tgt_bitmap, i)) {
+			reasb_req->orr_tgt_nr++;
+			if (is_ec_data_shard(i, dkey_hash, oca) || reasb_req->orr_recov)
+				data_tgt_nr++;
+		}
+	}
+
+	if (data_tgt_nr == 1) {
 		struct obj_io_desc	*oiod;
 		struct obj_shard_iod	*siod;
 
@@ -1699,18 +1776,12 @@ obj_ec_req_reasb(daos_iod_t *iods, d_sg_list_t *sgls, daos_obj_id_t oid,
 			}
 		}
 	}
-	reasb_req->orr_single_tgt = single_data_tgt;
+	reasb_req->orr_single_tgt = data_tgt_nr == 1;
 	reasb_req->orr_singv_only = singv_only;
 	rc = obj_ec_encode(reasb_req);
 	if (rc) {
 		D_ERROR(DF_OID" obj_ec_encode failed %d.\n", DP_OID(oid), rc);
 		goto out;
-	}
-
-	for (i = 0; !reasb_req->orr_size_fetched && i < obj_ec_tgt_nr(oca);
-	     i++) {
-		if (isset(reasb_req->tgt_bitmap, i))
-			reasb_req->orr_tgt_nr++;
 	}
 
 	if (!update) {
@@ -1724,7 +1795,7 @@ obj_ec_req_reasb(daos_iod_t *iods, d_sg_list_t *sgls, daos_obj_id_t oid,
 		}
 		reasb_req->tgt_oiods = obj_ec_tgt_oiod_init(
 			reasb_req->orr_oiods, iod_nr, reasb_req->tgt_bitmap,
-			obj_ec_tgt_nr(oca) - 1, reasb_req->orr_tgt_nr);
+			obj_ec_tgt_nr(oca) - 1, reasb_req->orr_tgt_nr, dkey_hash, oca);
 		if (reasb_req->tgt_oiods == NULL) {
 			D_ERROR(DF_OID" obj_ec_tgt_oiod_init failed.\n",
 				DP_OID(oid));
@@ -1779,7 +1850,7 @@ obj_ec_recx_size(daos_iod_t *iod, struct obj_shard_iod *siod,
 }
 
 void
-obj_ec_fetch_set_sgl(struct obj_reasb_req *reasb_req, uint32_t iod_nr)
+obj_ec_fetch_set_sgl(struct obj_reasb_req *reasb_req, uint64_t dkey_hash, uint32_t iod_nr)
 {
 	daos_iod_t			*uiods, *uiod, *riods, *riod;
 	d_sg_list_t			*usgls, *usgl;
@@ -1822,16 +1893,19 @@ obj_ec_fetch_set_sgl(struct obj_reasb_req *reasb_req, uint32_t iod_nr)
 		recheck = false;
 tgt_check:
 		for (j = start; j >= end; j--) {
+			uint32_t tgt_idx = obj_ec_shard_idx(dkey_hash, oca, j);
+
 			toiod = obj_ec_tgt_oiod_get(reasb_req->tgt_oiods,
-					reasb_req->orr_tgt_nr, j);
+						    reasb_req->orr_tgt_nr, tgt_idx);
 			if (toiod == NULL)
 				continue;
+
 			D_ASSERT(iod_nr == toiod->oto_iod_nr);
 			oiod = &toiod->oto_oiods[i];
 			recx_size = obj_ec_recx_size(riod, oiod->oiod_siods,
 						     uiod->iod_size);
 			data_size = *(reasb_req->orr_data_sizes +
-				      j * iod_nr + i);
+				      toiod->oto_orig_tgt_idx * iod_nr + i);
 			if (data_size == 0) {
 				tail_hole_size += recx_size;
 				continue;
@@ -1840,6 +1914,7 @@ tgt_check:
 			tail_hole_size += recx_size - data_size;
 			D_ASSERT(tail_hole_size <= size_in_iod);
 			dc_sgl_out_set(usgl, size_in_iod - tail_hole_size);
+
 			return;
 		}
 		if (!recheck) {
@@ -2054,15 +2129,16 @@ obj_ec_err_match(uint32_t nerrs, uint32_t *err_list1, uint32_t *err_list2)
 
 static int
 obj_ec_recov_codec_init(struct obj_reasb_req *reasb_req, daos_obj_id_t oid,
-			uint32_t nerrs, uint32_t *err_list)
+			uint64_t dkey_hash, uint32_t nerrs, uint32_t *err_list)
 {
 	struct daos_oclass_attr		*oca = reasb_req->orr_oca;
 	struct obj_ec_fail_info		*fail_info = reasb_req->orr_fail;
 	struct obj_ec_codec		*codec;
 	struct obj_ec_recov_codec	*recov;
-	unsigned char			 s;
-	uint32_t			 i, j, r, k, p;
-	int				 rc;
+	unsigned char			s;
+	uint32_t			i, j, r, k, p;
+	uint32_t			err_tgt_off;
+	int				rc;
 
 	D_ASSERT(fail_info != NULL);
 	k = obj_ec_data_tgt_nr(oca);
@@ -2089,10 +2165,12 @@ obj_ec_recov_codec_init(struct obj_reasb_req *reasb_req, daos_obj_id_t oid,
 	recov->er_data_nerrs = 0;
 	memset(recov->er_in_err, 0, sizeof(bool) * (k + p));
 	for (i = 0; i < nerrs; i++) {
+		err_tgt_off = obj_ec_shard_off(dkey_hash, oca, err_list[i]);
+
 		D_ASSERT(err_list[i] < k + p);
-		recov->er_err_list[i] = err_list[i];
-		recov->er_in_err[err_list[i]] = true;
-		if (err_list[i] < k)
+		recov->er_err_list[i] = err_tgt_off;
+		recov->er_in_err[err_tgt_off] = true;
+		if (err_tgt_off < k)
 			recov->er_data_nerrs++;
 	}
 
@@ -2119,18 +2197,19 @@ obj_ec_recov_codec_init(struct obj_reasb_req *reasb_req, daos_obj_id_t oid,
 
 	/* Generate decode matrix (err_list from invert matrix) */
 	for (i = 0; i < recov->er_data_nerrs; i++) {
+		err_tgt_off = obj_ec_shard_off(dkey_hash, oca, err_list[i]);
 		for (j = 0; j < k; j++)
 			recov->er_de_matrix[k * i + j] =
-				recov->er_inv_matrix[k * err_list[i] + j];
+				recov->er_inv_matrix[k * err_tgt_off + j];
 	}
 	/* err_list from encode_matrix * invert matrix, for parity decoding */
 	for (p = recov->er_data_nerrs; p < recov->er_nerrs; p++) {
+		err_tgt_off = obj_ec_shard_off(dkey_hash, oca, err_list[p]);
 		for (i = 0; i < k; i++) {
 			s = 0;
 			for (j = 0; j < k; j++)
 				s ^= gf_mul(recov->er_inv_matrix[j * k + i],
-					    codec->ec_en_matrix[k * err_list[p]
-								+ j]);
+					    codec->ec_en_matrix[k * err_tgt_off + j]);
 
 			recov->er_de_matrix[k * p + i] = s;
 		}
@@ -2458,7 +2537,7 @@ obj_ec_fail_info_free(struct obj_reasb_req *reasb_req)
 
 int
 obj_ec_recov_prep(struct obj_reasb_req *reasb_req, daos_obj_id_t oid,
-		  daos_iod_t *iods, uint32_t iod_nr)
+		  uint64_t dkey_hash, daos_iod_t *iods, uint32_t iod_nr)
 {
 	struct obj_ec_fail_info	*fail_info = reasb_req->orr_fail;
 	int			 rc;
@@ -2478,7 +2557,7 @@ obj_ec_recov_prep(struct obj_reasb_req *reasb_req, daos_obj_id_t oid,
 			goto out;
 	}
 
-	rc = obj_ec_recov_codec_init(reasb_req, oid, fail_info->efi_ntgts,
+	rc = obj_ec_recov_codec_init(reasb_req, oid, dkey_hash, fail_info->efi_ntgts,
 				     fail_info->efi_tgt_list);
 	if (rc)
 		goto out;
@@ -2747,7 +2826,8 @@ obj_ec_tgt_oiod_get(struct obj_tgt_oiod *tgt_oiods, uint32_t tgt_nr,
 
 struct obj_tgt_oiod *
 obj_ec_tgt_oiod_init(struct obj_io_desc *r_oiods, uint32_t iod_nr,
-		     uint8_t *tgt_bitmap, uint32_t tgt_max_idx, uint32_t tgt_nr)
+		     uint8_t *tgt_bitmap, uint32_t tgt_max_idx, uint32_t tgt_nr,
+		     uint64_t dkey_hash, struct daos_oclass_attr *oca)
 {
 	struct obj_tgt_oiod	*tgt_oiod, *tgt_oiods;
 	struct obj_io_desc	*oiod, *r_oiod;
@@ -2781,6 +2861,7 @@ obj_ec_tgt_oiod_init(struct obj_io_desc *r_oiods, uint32_t iod_nr,
 		tgt_oiod = &tgt_oiods[i];
 		tgt_oiod->oto_iod_nr = iod_nr;
 		tgt_oiod->oto_tgt_idx = idx;
+		tgt_oiod->oto_orig_tgt_idx = idx;
 		tmp_ptr = buf + i * item_size;
 		tgt_oiod->oto_offs = (void *)tmp_ptr;
 		tmp_ptr += off_size * iod_nr;
@@ -2807,7 +2888,9 @@ obj_ec_tgt_oiod_init(struct obj_io_desc *r_oiods, uint32_t iod_nr,
 				oiod = &tgt_oiod->oto_oiods[i];
 				oiod->oiod_flags |= OBJ_SIOD_SINGV;
 				oiod->oiod_nr = 0;
-				oiod->oiod_tgt_idx = tgt_oiod->oto_tgt_idx;
+				oiod->oiod_tgt_idx =
+					obj_ec_shard_off(dkey_hash, oca,
+							 tgt_oiod->oto_tgt_idx);
 				oiod->oiod_siods = NULL;
 			}
 			continue;
@@ -2833,8 +2916,9 @@ obj_ec_tgt_oiod_init(struct obj_io_desc *r_oiods, uint32_t iod_nr,
 
 /* Get all of recxs of the specific target from the daos offset */
 int
-obj_recx_ec2_daos(struct daos_oclass_attr *oca, int shard, daos_recx_t **recxs_p,
-		  daos_epoch_t **recx_ephs_p, unsigned int *nr, bool convert_parity)
+obj_recx_ec2_daos(struct daos_oclass_attr *oca, uint64_t dkey_hash, int shard,
+		  daos_recx_t **recxs_p, daos_epoch_t **recx_ephs_p,
+		  unsigned int *nr, bool convert_parity)
 {
 	int		cell_nr = obj_ec_cell_rec_nr(oca);
 	int		stripe_nr = obj_ec_stripe_rec_nr(oca);
@@ -2849,9 +2933,9 @@ obj_recx_ec2_daos(struct daos_oclass_attr *oca, int shard, daos_recx_t **recxs_p
 	if (oca->ca_resil == DAOS_RES_REPL)
 		return 0;
 
-	tgt_idx = shard % obj_ec_tgt_nr(oca);
+	tgt_idx = obj_ec_shard_off(dkey_hash, oca, shard);
 	/* parity shard conversion */
-	if (is_ec_parity_shard(tgt_idx, oca)) {
+	if (is_ec_parity_shard(shard, dkey_hash, oca)) {
 		for (i = 0; i < *nr; i++) {
 			daos_off_t offset = recxs[i].rx_idx;
 
@@ -2924,8 +3008,9 @@ obj_recx_ec2_daos(struct daos_oclass_attr *oca, int shard, daos_recx_t **recxs_p
 
 /* Convert DAOS offset to specific data target daos offset */
 int
-obj_recx_ec_daos2shard(struct daos_oclass_attr *oca, int shard, daos_recx_t **recxs_p,
-		       daos_epoch_t **recx_ephs_p, unsigned int *iod_nr)
+obj_recx_ec_daos2shard(struct daos_oclass_attr *oca, uint64_t dkey_hash, int shard,
+		       daos_recx_t **recxs_p, daos_epoch_t **recx_ephs_p,
+		       unsigned int *iod_nr)
 {
 	daos_recx_t	*recx = *recxs_p;
 	daos_epoch_t	*new_ephs = NULL;
@@ -2933,19 +3018,19 @@ obj_recx_ec_daos2shard(struct daos_oclass_attr *oca, int shard, daos_recx_t **re
 	int		cell_nr = obj_ec_cell_rec_nr(oca);
 	int		stripe_nr = obj_ec_stripe_rec_nr(oca);
 	daos_recx_t	*tgt_recxs;
-	int		shard_idx = shard % obj_ec_tgt_nr(oca);
+	int		tgt_idx = obj_ec_shard_off(dkey_hash, oca, shard);
 	int		total;
 	int		idx;
 	int		i;
 
-	D_ASSERT(shard_idx < obj_ec_data_tgt_nr(oca));
+	D_ASSERT(tgt_idx < obj_ec_data_tgt_nr(oca));
 	for (i = 0, total = 0; i < nr; i++) {
 		uint64_t offset = recx[i].rx_idx & ~PARITY_INDICATOR;
 		uint64_t end = offset + recx[i].rx_nr;
 
 		while (offset < end) {
 			daos_off_t shard_start = rounddown(offset, stripe_nr) +
-						 shard_idx * cell_nr;
+						 tgt_idx * cell_nr;
 			daos_off_t shard_end = shard_start + cell_nr;
 
 			/* Intersect with the shard cell */
@@ -2985,7 +3070,7 @@ obj_recx_ec_daos2shard(struct daos_oclass_attr *oca, int shard, daos_recx_t **re
 
 		while (offset < end) {
 			daos_off_t shard_start = rounddown(offset, stripe_nr) +
-						 shard_idx * cell_nr;
+						 tgt_idx * cell_nr;
 			daos_off_t shard_end = shard_start + cell_nr;
 
 			if (max(shard_start, offset) >= min(shard_end, end)) {

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -21,112 +21,6 @@
 #include "obj_rpc.h"
 #include "obj_internal.h"
 
-#define CLI_OBJ_IO_PARMS	8
-
-#define OBJ_TGT_INLINE_NR	9
-#define OBJ_INLINE_BTIMAP	4
-
-struct obj_req_tgts {
-	/* to save memory allocation if #targets <= OBJ_TGT_INLINE_NR */
-	struct daos_shard_tgt	 ort_tgts_inline[OBJ_TGT_INLINE_NR];
-	/* Shard target array, with (ort_grp_nr * ort_grp_size) targets.
-	 * If #targets <= OBJ_TGT_INLINE_NR then it points to ort_tgts_inline.
-	 * Within the array, [0, ort_grp_size - 1] is for the first group,
-	 * [ort_grp_size, ort_grp_size * 2 - 1] is the 2nd group and so on.
-	 * If (ort_srv_disp == 1) then within each group the first target is the
-	 * leader shard and following (ort_grp_size - 1) targets are the forward
-	 * non-leader shards.
-	 * Now there is only one case for (ort_grp_nr > 1) that for object
-	 * punch, all other cases with (ort_grp_nr == 1).
-	 */
-	struct daos_shard_tgt	*ort_shard_tgts;
-	uint32_t		 ort_grp_nr;
-	/* ort_grp_size is the size of the group that is sent as forwarded
-	 * shards
-	 */
-	uint32_t		 ort_grp_size;
-	/* ort_start_shard is only for EC object, it is the start shard number
-	 * of the EC stripe. To facilitate calculate the offset of different
-	 * shards in the stripe.
-	 */
-	uint32_t		 ort_start_shard;
-	/* flag of server dispatch */
-	uint32_t		 ort_srv_disp:1;
-};
-
-struct obj_auxi_tgt_list {
-	/** array of target ID */
-	uint32_t	*tl_tgts;
-	/** number of ranks & tgts */
-	uint32_t	tl_nr;
-};
-
-/* Auxiliary args for object I/O */
-struct obj_auxi_args {
-	tse_task_t			*obj_task;
-	daos_handle_t			 th;
-	struct dc_object		*obj;
-	int				 opc;
-	int				 result;
-	uint32_t			 map_ver_req;
-	uint32_t			 map_ver_reply;
-	/* flags for the obj IO task.
-	 * ec_wait_recov -- obj fetch wait another EC recovery task,
-	 * ec_in_recov -- a EC recovery task
-	 */
-	uint32_t			 io_retry:1,
-					 args_initialized:1,
-					 to_leader:1,
-					 spec_shard:1,
-					 spec_group:1,
-					 req_reasbed:1,
-					 is_ec_obj:1,
-					 csum_retry:1,
-					 csum_report:1,
-					 tx_uncertain:1,
-					 no_retry:1,
-					 ec_wait_recov:1,
-					 ec_in_recov:1,
-					 new_shard_tasks:1,
-					 reset_param:1,
-					 force_degraded:1,
-					 shards_scheded:1,
-					 tx_convert:1;
-	/* request flags. currently only: ORF_RESEND */
-	uint32_t			 flags;
-	uint32_t			 specified_shard;
-	/* 64-bits alignment, bitmap for retry next replicas. */
-	uint8_t				 retry_bitmap[OBJ_INLINE_BTIMAP];
-	struct obj_req_tgts		 req_tgts;
-	d_sg_list_t			*sgls_dup;
-	crt_bulk_t			*bulks;
-	uint32_t			 iod_nr;
-	uint32_t			 initial_shard;
-	d_list_t			 shard_task_head;
-	struct obj_reasb_req		 reasb_req;
-	struct obj_auxi_tgt_list	*failed_tgt_list;
-	/* one shard_args embedded to save one memory allocation if the obj
-	 * request only targets for one shard.
-	 */
-	union {
-		struct shard_rw_args	 rw_args;
-		struct shard_punch_args	 p_args;
-		struct shard_list_args	 l_args;
-		struct shard_sync_args	 s_args;
-	};
-};
-
-/**
- * task memory space should enough to use -
- * obj API task with daos_task_args + obj_auxi_args,
- * shard sub-task with shard_auxi_args + obj_auxi_args.
- * When it exceed the limit, can reduce OBJ_TGT_INLINE_NR or enlarge tse_task.
- */
-D_CASSERT(sizeof(struct obj_auxi_args) + sizeof(struct shard_auxi_args) <=
-	  TSE_TASK_ARG_LEN);
-D_CASSERT(sizeof(struct obj_auxi_args) + sizeof(struct daos_task_args) <=
-	  TSE_TASK_ARG_LEN);
-
 /**
  * Open an object shard (shard object), cache the open handle.
  */
@@ -581,6 +475,10 @@ obj_grp_valid_shard_get(struct dc_object *obj, int grp_idx,
 		if (failed_list && tgt_in_failed_tgts_list(tgt_id, failed_list))
 			continue;
 
+		if (DAOS_FAIL_CHECK(DAOS_FAIL_SHARD_OPEN) &&
+		    daos_shard_in_fail_value(index))
+			continue;
+
 		/* Skip the invalid shards and targets */
 		if (obj->cob_shards->do_shards[index].do_target_id != -1 ||
 		    obj->cob_shards->do_shards[index].do_shard != -1) {
@@ -618,22 +516,28 @@ obj_shard_find_replica(struct dc_object *obj, unsigned int target,
 }
 
 static int
-obj_ec_leader_select(struct dc_object *obj, int grp_idx, uint8_t *bit_map)
+obj_ec_leader_select(struct dc_object *obj, int grp_idx, uint32_t map_ver, uint64_t dkey_hash,
+		     uint8_t *bit_map)
 {
 	struct daos_oclass_attr *oca;
 	struct pl_obj_shard	*pl_shard;
 	int			tgt_idx;
 	int			grp_size;
 	int			grp_start;
+	int			rc = 0;
 	int			i;
-	int			shard;
+	int			shard = 0;
 
-	oca = daos_oclass_attr_find(obj->cob_md.omd_id, NULL);
+	D_RWLOCK_RDLOCK(&obj->cob_lock);
+	if (obj->cob_version != map_ver)
+		D_GOTO(unlock, rc = -DER_STALE);
+
+	oca = obj_get_oca(obj);
 	grp_size = obj_ec_tgt_nr(oca);
 	grp_start = grp_idx * grp_size;
 
 	/* 1. Find one from parity, and start from the last parity. */
-	tgt_idx = grp_size - 1;
+	tgt_idx = obj_ec_shard_idx(dkey_hash, oca, grp_size - 1);
 	for (i = 0; i < obj_ec_parity_tgt_nr(oca);
 	     i++, tgt_idx = (tgt_idx - 1 + grp_size) % grp_size) {
 
@@ -644,48 +548,45 @@ obj_ec_leader_select(struct dc_object *obj, int grp_idx, uint8_t *bit_map)
 			/* Then try former one */
 			continue;
 		}
-		goto found;
+		D_GOTO(unlock, rc = shard);
 	}
 
-	shard = -1;
-	tgt_idx = 0;
 	/* Choose one from data shards within bit_map, and also make sure there are
 	 * no further data shards failed.
 	 **/
+	tgt_idx = obj_ec_shard_idx(dkey_hash, oca, 0);
 	for (i = 0; i < obj_ec_data_tgt_nr(oca); i++, tgt_idx = (tgt_idx + 1) % grp_size) {
-		int shard_idx;
-
 		if (bit_map != NIL_BITMAP && isclr(bit_map, tgt_idx))
 			continue;
 
-		shard_idx = grp_start + tgt_idx;
-		pl_shard = obj_get_shard(obj, shard_idx);
+		shard = grp_start + tgt_idx;
+		pl_shard = obj_get_shard(obj, shard);
 		if (pl_shard->po_target == -1 || pl_shard->po_shard == -1 ||
 		    pl_shard->po_rebuilding) {
 			D_ERROR(DF_OID" unhealthy targets exceed the max redundancy, e_p %d\n",
 				DP_OID(obj->cob_md.omd_id), obj_ec_parity_tgt_nr(oca));
-			return -DER_IO;
+			D_GOTO(unlock, rc = -DER_IO);
 		}
-		/* Use the 1st health shard in bitmap as the leader */
-		if (shard == -1)
-			shard = shard_idx;
+		break;
 	}
 
-	if (shard == -1) {
+	if (i == obj_ec_data_tgt_nr(oca)) {
 		D_WARN(DF_OID" no shards %d are in bitmaps, retry later.\n",
 		       DP_OID(obj->cob_md.omd_id), obj_ec_parity_tgt_nr(oca));
-		return -DER_STALE;
+		D_GOTO(unlock, rc = -DER_STALE);
 	}
+	rc = shard;
 
-found:
+unlock:
+	D_RWLOCK_UNLOCK(&obj->cob_lock);
 	D_DEBUG(DB_TRACE, DF_OID" choose shard %d as leader for group%d.\n",
 		DP_OID(obj->cob_md.omd_id), shard, grp_idx);
 
-	return shard;
+	return rc;
 }
 
 static int
-obj_replica_leader_select(struct dc_object *obj, unsigned int grp_idx)
+obj_replica_leader_select(struct dc_object *obj, unsigned int grp_idx, unsigned int map_ver)
 {
 	struct pl_obj_shard	*shard;
 	struct daos_oclass_attr	*oca;
@@ -693,7 +594,12 @@ obj_replica_leader_select(struct dc_object *obj, unsigned int grp_idx)
 	int			start;
 	int			pos;
 	int			replica_idx;
+	int			rc;
 	int			i;
+
+	D_RWLOCK_RDLOCK(&obj->cob_lock);
+	if (obj->cob_version != map_ver)
+		D_GOTO(unlock, rc = -DER_STALE);
 
 	oca = daos_oclass_attr_find(obj->cob_md.omd_id, NULL);
 	D_ASSERT(oca != NULL);
@@ -710,7 +616,7 @@ obj_replica_leader_select(struct dc_object *obj, unsigned int grp_idx)
 		 * it moves between ranks
 		 */
 		/* return pos rather than shard->po_shard for pool extending */
-		return pos;
+		D_GOTO(unlock, rc = pos);
 	}
 
 	/* XXX: The shards within [start, start + replicas) will search from
@@ -745,31 +651,25 @@ obj_replica_leader_select(struct dc_object *obj, unsigned int grp_idx)
 		 * Here should not return "pl_get_shard(data, pos)->po_shard",
 		 * because it possibly not equal to "pos" in pool extending.
 		 */
-		return pos;
+		rc = pos;
+	} else {
+		/* If all the replicas are failed or in-rebuilding, then EIO. */
+		rc = -DER_IO;
 	}
-
-	/* If all the replicas are failed or in-rebuilding, then EIO. */
-	return -DER_IO;
-}
-
-int
-obj_grp_leader_get(struct dc_object *obj, int grp_idx, unsigned int map_ver,
-		   uint8_t *bit_map)
-{
-	int	rc = -DER_STALE;
-
-	D_RWLOCK_RDLOCK(&obj->cob_lock);
-	if (obj->cob_version != map_ver)
-		D_GOTO(unlock, rc);
-
-	if (obj_is_ec(obj))
-		rc = obj_ec_leader_select(obj, grp_idx, bit_map);
-	else
-		rc = obj_replica_leader_select(obj, grp_idx);
 
 unlock:
 	D_RWLOCK_UNLOCK(&obj->cob_lock);
 	return rc;
+}
+
+int
+obj_grp_leader_get(struct dc_object *obj, int grp_idx, uint64_t dkey_hash,
+		   unsigned int map_ver, uint8_t *bit_map)
+{
+	if (obj_is_ec(obj))
+		return obj_ec_leader_select(obj, grp_idx, map_ver, dkey_hash, bit_map);
+
+	return obj_replica_leader_select(obj, grp_idx, map_ver);
 }
 
 static int
@@ -849,31 +749,6 @@ obj_dkey2grpidx(struct dc_object *obj, uint64_t hash, unsigned int map_ver)
 }
 
 static int
-obj_dkey2shard(struct dc_object *obj, uint64_t hash, unsigned int map_ver,
-	       bool to_leader, struct obj_auxi_tgt_list *failed_tgt_list)
-{
-	int	grp_idx;
-
-	grp_idx = obj_dkey2grpidx(obj, hash, map_ver);
-	if (grp_idx < 0)
-		return grp_idx;
-
-	if (!to_leader && obj->cob_time_fetch_leader != NULL &&
-	    obj->cob_time_fetch_leader[grp_idx] != 0 &&
-	    OBJ_FETCH_LEADER_INTERVAL >=
-	    daos_gettime_coarse() - obj->cob_time_fetch_leader[grp_idx])
-		to_leader = true;
-
-	/* For EC object, read from DTX leader is meaningless, because the leader shard may
-	 * not has the expected data. Let's directly (or still) read from related data shard.
-	 */
-	if (to_leader && !obj_is_ec(obj))
-		return obj_grp_leader_get(obj, grp_idx, map_ver, NIL_BITMAP);
-
-	return obj_grp_valid_shard_get(obj, grp_idx, map_ver, failed_tgt_list);
-}
-
-static int
 obj_dkey2grpmemb(struct dc_object *obj, uint64_t hash, uint32_t map_ver,
 		 uint32_t *start_shard, uint32_t *grp_size)
 {
@@ -885,7 +760,6 @@ obj_dkey2grpmemb(struct dc_object *obj, uint64_t hash, uint32_t map_ver,
 
 	*grp_size = obj_get_grp_size(obj);
 	*start_shard = grp_idx * *grp_size;
-
 	return 0;
 }
 
@@ -1015,7 +889,9 @@ obj_rw_req_reassemb(struct dc_object *obj, daos_obj_rw_t *args,
 	struct obj_reasb_req	*reasb_req = &obj_auxi->reasb_req;
 	struct daos_oclass_attr	*oca = obj_get_oca(obj);
 	daos_obj_id_t		 oid = obj->cob_md.omd_id;
-	int			 rc = 0;
+	int			rc = 0;
+
+	D_ASSERT(obj_is_ec(obj));
 
 	if (epoch != NULL && !obj_auxi->req_reasbed)
 		reasb_req->orr_epoch = *epoch;
@@ -1026,15 +902,13 @@ obj_rw_req_reassemb(struct dc_object *obj, daos_obj_rw_t *args,
 		memset(reasb_req->orr_fetch_stat, 0, args->nr * sizeof(*reasb_req->orr_fetch_stat));
 		return 0;
 	}
-	obj_auxi->iod_nr = args->nr;
 
 	/** XXX possible re-order/merge for both replica and EC */
 	if (args->extra_flags & DIOF_CHECK_EXISTENCE ||
-	    args->extra_flags & DIOF_TO_SPEC_SHARD || !obj_is_ec(obj))
+	    args->extra_flags & DIOF_TO_SPEC_SHARD)
 		return 0;
 
 	if (!obj_auxi->req_reasbed) {
-		obj_auxi->is_ec_obj = 1;
 		rc = obj_reasb_req_init(&obj_auxi->reasb_req, obj, args->iods,
 					args->nr, oca);
 		if (rc) {
@@ -1045,8 +919,9 @@ obj_rw_req_reassemb(struct dc_object *obj, daos_obj_rw_t *args,
 		reasb_req->orr_args = args;
 	}
 
-	rc = obj_ec_req_reasb(args->iods, args->sgls, oid, oca, reasb_req,
-			      args->nr, obj_auxi->opc == DAOS_OBJ_RPC_UPDATE);
+	rc = obj_ec_req_reasb(args->iods, obj_ec_dkey_hash_get(obj, obj_auxi->dkey_hash),
+			      args->sgls, oid, oca, reasb_req, args->nr,
+			      obj_auxi->opc == DAOS_OBJ_RPC_UPDATE);
 	if (rc == 0) {
 		obj_auxi->flags |= ORF_EC;
 		obj_auxi->req_reasbed = true;
@@ -1080,113 +955,32 @@ obj_shard_tgts_query(struct dc_object *obj, uint32_t map_ver, uint32_t shard,
 		     struct obj_auxi_args *obj_auxi)
 {
 	struct dc_obj_shard	*obj_shard;
-	bool			 ec_degrade = false;
-	uint32_t		 ec_deg_tgt = 0, start_shard;
-	bool			 csum_err = false;
-	bool			 tx_uncertain = false;
 	int			 rc;
 
+	D_DEBUG(DB_TRACE, DF_OID" query shard %u tgt_idx %u\n",
+		DP_OID(obj->cob_md.omd_id), shard, ec_tgt_idx);
 	shard_tgt->st_ec_tgt = ec_tgt_idx;
-	start_shard = shard - ec_tgt_idx;
-
-	if (obj_auxi->is_ec_obj &&
-	    (obj_auxi->csum_retry || obj_auxi->tx_uncertain ||
-	     obj_auxi->force_degraded || DAOS_FAIL_CHECK(DAOS_OBJ_FORCE_DEGRADE))) {
-		if (obj_auxi->tx_uncertain) {
-			tx_uncertain = true;
-			obj_auxi->tx_uncertain = 0;
-		} else if (obj_auxi->csum_retry) {
-			csum_err = true;
-			obj_auxi->csum_retry = 0;
-		}
-		ec_degrade = true;
-		goto ec_deg_get;
-	}
-shard_open:
 	rc = obj_shard_open(obj, shard, map_ver, &obj_shard);
-	if (unlikely(DAOS_FAIL_CHECK(DAOS_FAIL_SHARD_OPEN) &&
-		     daos_shard_in_fail_value(shard + 1))) {
-		rc = -DER_NONEXIST;
-		D_ERROR("obj_shard_open failed on shard %d, "DF_RC"\n",
-			shard, DP_RC(rc));
+	/* Disable inflight I/O during reintegration for the moment */
+	if (rc == 0 &&
+	    obj_auxi->opc == DAOS_OBJ_RPC_UPDATE && obj_shard->do_reintegrating) {
+		D_ERROR(DF_OID" shard is being reintegrated: %d\n",
+			DP_OID(obj->cob_md.omd_id), -DER_IO);
+		D_GOTO(close, rc = -DER_IO);
 	}
 
-	if (rc == 0) {
-		if (obj_op_is_ec_fetch(obj_auxi) && obj_shard->do_rebuilding) {
-			ec_degrade = true;
-			obj_shard_close(obj_shard);
-		}
-		if (obj_auxi->opc == DAOS_OBJ_RPC_UPDATE && obj_shard->do_reintegrating) {
-			D_ERROR(DF_OID" shard is being reintegrated: %d\n",
-				DP_OID(obj->cob_md.omd_id), -DER_IO);
-			obj_shard_close(obj_shard);
-			D_GOTO(out, rc = -DER_IO);
-		}
-	} else {
-		if (rc == -DER_NONEXIST) {
-			if (!obj_auxi->is_ec_obj) {
-				shard_tgt->st_rank = DAOS_TGT_IGNORE;
-				rc = 0;
-			} else {
-				if (obj_auxi->opc == DAOS_OBJ_RPC_FETCH)
-					ec_degrade = true;
-				else
-					shard_tgt->st_rank = DAOS_TGT_IGNORE;
-			}
-		} else {
-			D_ERROR(DF_OID" obj_shard_open %u, rc "DF_RC".\n",
-				DP_OID(obj->cob_md.omd_id), shard, DP_RC(rc));
-		}
-		if (!ec_degrade)
-			D_GOTO(out, rc);
-	}
-
-ec_deg_get:
-	if (ec_degrade) {
-		rc = obj_ec_get_degrade(&obj_auxi->reasb_req,
-					shard - start_shard, &ec_deg_tgt,
-					false);
-		if (rc) {
-			if (csum_err) {
-				obj_auxi->no_retry = 1;
-				rc = -DER_CSUM;
-			} else if (tx_uncertain) {
-				obj_auxi->no_retry = 1;
-				rc = -DER_TX_UNCERTAIN;
-			}
-
-			D_ERROR(DF_OID" obj_ec_get_degrade failed, rc "
-				DF_RC"\n", DP_OID(obj->cob_md.omd_id),
-				DP_RC(rc));
-			D_GOTO(out, rc);
-		}
-		D_ASSERT(ec_deg_tgt >=
-			 obj_ec_data_tgt_nr(obj_auxi->reasb_req.orr_oca));
-		if (obj_auxi->ec_in_recov ||
-		    (obj_auxi->reasb_req.orr_singv_only && !obj_auxi->reasb_req.orr_size_fetch)) {
-			D_DEBUG(DB_IO, DF_OID" shard %d failed in recovery(%d) "
-				"or singv fetch(%d).\n",
-				DP_OID(obj->cob_md.omd_id), shard,
-				obj_auxi->ec_in_recov,
-				obj_auxi->reasb_req.orr_singv_only);
-			D_GOTO(out, rc = -DER_TGT_RETRY);
-		}
-		shard = start_shard + ec_deg_tgt;
-		D_DEBUG(DB_IO, DF_OID" shard %d fetch re-direct to shard %d.\n",
-			DP_OID(obj->cob_md.omd_id), start_shard + ec_tgt_idx,
-			start_shard + ec_deg_tgt);
-		obj_auxi->reset_param = 1;
-		ec_degrade = false;
-		goto shard_open;
-	}
-	if (rc != 0)
+	if (rc != 0) {
+		D_ERROR(DF_OID" obj_shard_open %u, rc "DF_RC".\n",
+			DP_OID(obj->cob_md.omd_id), shard, DP_RC(rc));
 		D_GOTO(out, rc);
+	}
 
 	shard_tgt->st_rank	= obj_shard->do_target_rank;
 	shard_tgt->st_shard	= shard;
 	shard_tgt->st_shard_id	= obj_shard->do_id.id_shard;
 	shard_tgt->st_tgt_idx	= obj_shard->do_target_idx;
 	rc = obj_shard2tgtid(obj, shard, map_ver, &shard_tgt->st_tgt_id);
+close:
 	obj_shard_close(obj_shard);
 out:
 	return rc;
@@ -1234,11 +1028,10 @@ obj_shards_2_fwtgts(struct dc_object *obj, uint32_t map_ver, uint8_t *bit_map,
 {
 	struct obj_req_tgts	*req_tgts = &obj_auxi->req_tgts;
 	struct daos_shard_tgt	*tgt = NULL;
-	uint32_t		 leader_shard = -1;
-	uint32_t		 i, j;
+	uint32_t		 i;
 	uint32_t		 shard_idx, shard_nr, grp_size;
 	bool			 cli_disp = flags & OBJ_TGT_FLAG_CLI_DISPATCH;
-	int			 rc;
+	int			 rc = 0;
 
 	D_ASSERT(shard_cnt >= 1);
 	grp_size = shard_cnt / grp_nr;
@@ -1262,15 +1055,14 @@ obj_shards_2_fwtgts(struct dc_object *obj, uint32_t map_ver, uint8_t *bit_map,
 		if (req_tgts->ort_shard_tgts != NULL &&
 		    req_tgts->ort_grp_nr * req_tgts->ort_grp_size != shard_nr) {
 			/* shard_nr possibly changed per progressive layout */
-			if (req_tgts->ort_shard_tgts !=
-				req_tgts->ort_tgts_inline)
+			if (req_tgts->ort_shard_tgts != req_tgts->ort_tgts_inline)
 				D_FREE(req_tgts->ort_shard_tgts);
 			req_tgts->ort_shard_tgts = NULL;
 		}
 		if (req_tgts->ort_shard_tgts == NULL) {
 			D_ALLOC_ARRAY(req_tgts->ort_shard_tgts, shard_nr);
 			if (req_tgts->ort_shard_tgts == NULL)
-				return -DER_NOMEM;
+				D_GOTO(out, rc = -DER_NOMEM);
 		}
 	} else {
 		if (req_tgts->ort_shard_tgts != NULL &&
@@ -1280,64 +1072,67 @@ obj_shards_2_fwtgts(struct dc_object *obj, uint32_t map_ver, uint8_t *bit_map,
 	}
 	req_tgts->ort_grp_nr = grp_nr;
 	req_tgts->ort_grp_size = (shard_nr == shard_cnt) ? grp_size : shard_nr;
+	shard_idx = start_shard;
 	for (i = 0; i < grp_nr; i++) {
 		struct daos_shard_tgt	*head;
-		struct daos_oclass_attr	*oca;
-		uint32_t		 fail_nr;
+		uint32_t		leader_shard = 0;
+		uint32_t		grp_start;
+		uint32_t		grp_idx;
+		uint32_t		cur_grp_size;
+		int			tgt_idx;
 
-		shard_idx = start_shard + i * grp_size;
+		cur_grp_size = req_tgts->ort_grp_size;
 		head = tgt = req_tgts->ort_shard_tgts + i * grp_size;
+		grp_idx = shard_idx / obj_get_grp_size(obj);
+		grp_start = grp_idx * obj_get_grp_size(obj);
 		if (req_tgts->ort_srv_disp) {
-			rc = obj_grp_leader_get(obj, shard_idx / grp_size, map_ver, bit_map);
-			if (rc < 0) {
+			leader_shard = obj_grp_leader_get(obj, grp_idx,
+							  obj_ec_dkey_hash_get(obj,
+									       obj_auxi->dkey_hash),
+							  map_ver, bit_map);
+			if (leader_shard < 0) {
 				D_ERROR(DF_OID" no valid shard %u, grp size %u "
-					"grp nr %u, shards %u, reps %u, is %s: "
-					DF_RC"\n", DP_OID(obj->cob_md.omd_id),
+					"grp nr %u, shards %u, reps %u: "DF_RC"\n",
+					DP_OID(obj->cob_md.omd_id),
 					shard_idx, obj->cob_grp_size,
 					obj->cob_grp_nr, obj->cob_shards_nr,
-					obj_get_replicas(obj),
-					obj_is_ec(obj) ? "EC-obj" : "REP-obj",
-					DP_RC(rc));
-				return rc;
+					obj_get_replicas(obj), DP_RC(leader_shard));
+				D_GOTO(out, rc = leader_shard);
 			}
-			leader_shard = rc;
 			rc = obj_shard_tgts_query(obj, map_ver, leader_shard,
-						  0, tgt++, obj_auxi);
+						  leader_shard % obj_get_grp_size(obj), tgt++,
+						  obj_auxi);
 			if (rc != 0)
-				return rc;
+				D_GOTO(out, rc);
 
-			if (flags & OBJ_TGT_FLAG_LEADER_ONLY)
+			cur_grp_size--;
+			/* FIXME: check extending shards */
+			if (flags & OBJ_TGT_FLAG_LEADER_ONLY) {
+				shard_idx = grp_start + obj_get_grp_size(obj);
 				continue;
+			}
 		}
 
-		for (j = 0, fail_nr = 0; j < grp_size; j++, shard_idx++) {
-			if (shard_idx == leader_shard ||
-			    (bit_map != NIL_BITMAP && isclr(bit_map, j)))
-				continue;
-			rc = obj_shard_tgts_query(obj, map_ver, shard_idx,
-						  shard_idx - start_shard,
-						  tgt++, obj_auxi);
-			if (unlikely(DAOS_FAIL_CHECK(DAOS_FAIL_SHARD_NONEXIST)))
-				rc = -DER_NONEXIST;
-			if (rc == -DER_NONEXIST && obj_auxi->is_ec_obj) {
-				fail_nr++;
-				rc = 0;
-				oca = obj_get_oca(obj);
-				if (fail_nr > obj_ec_parity_tgt_nr(oca)) {
-					rc = -DER_IO;
-					D_ERROR(DF_OID" #failed_shard %d, exceed %d, "DF_RC"\n",
-						DP_OID(obj->cob_md.omd_id), fail_nr,
-						obj_ec_parity_tgt_nr(oca), DP_RC(rc));
-					return rc;
-				}
-			} else if (rc != 0)
-				return rc;
+		tgt_idx = shard_idx % obj_get_grp_size(obj);
+		while (cur_grp_size > 0) {
+			shard_idx = grp_start + tgt_idx;
 
+			if ((req_tgts->ort_srv_disp && shard_idx == leader_shard) ||
+			    (bit_map != NIL_BITMAP && isclr(bit_map, tgt_idx))) {
+				tgt_idx = (tgt_idx + 1) % obj_get_grp_size(obj);
+				continue;
+			}
+
+			rc = obj_shard_tgts_query(obj, map_ver, shard_idx,
+						  tgt_idx, tgt++, obj_auxi);
+			if (rc != 0)
+				D_GOTO(out, rc);
+
+			/* FIXME: check extending shards */
 			if (req_tgts->ort_srv_disp) {
 				struct daos_shard_tgt	*tmp, *last;
 
-				for (tmp = head, last = tgt - 1;
-				     tmp != last; tmp++) {
+				for (tmp = head, last = tgt - 1; tmp != last; tmp++) {
 					/* Two shards locate on the same target,
 					 * OSA case, will handle it via internal
 					 * transaction.
@@ -1353,10 +1148,13 @@ obj_shards_2_fwtgts(struct dc_object *obj, uint32_t map_ver, uint8_t *bit_map,
 						DP_OID(obj->cob_md.omd_id),
 						tmp->st_shard, last->st_shard,
 						tmp->st_rank, tmp->st_tgt_id);
-					return -DER_SHARDS_OVERLAP;
+					D_GOTO(out, rc = -DER_SHARDS_OVERLAP);
 				}
 			}
+			tgt_idx = (tgt_idx + 1) % obj_get_grp_size(obj);
+			cur_grp_size--;
 		}
+		shard_idx = grp_start + obj_get_grp_size(obj);
 	}
 
 	if (flags & OBJ_TGT_FLAG_FW_LEADER_INFO)
@@ -1365,7 +1163,10 @@ obj_shards_2_fwtgts(struct dc_object *obj, uint32_t map_ver, uint8_t *bit_map,
 	if ((flags == 0 || flags & OBJ_TGT_FLAG_FW_LEADER_INFO) && bit_map == NIL_BITMAP)
 		D_ASSERT(tgt == req_tgts->ort_shard_tgts + shard_nr);
 
-	return 0;
+out:
+	D_CDEBUG(rc == 0 || rc == -DER_SHARDS_OVERLAP || rc == -DER_TGT_RETRY, DB_IO,
+		 DLOG_ERR, DF_OID", forward:" DF_RC"\n", DP_OID(obj->cob_md.omd_id), DP_RC(rc));
+	return rc;
 }
 
 static void
@@ -1564,6 +1365,7 @@ dc_obj_open(tse_task_t *task)
 	if (rc)
 		D_GOTO(fail_layout_created, rc);
 
+	obj->cob_ec_parity_rotate = 0;
 	obj_hdl_link(obj);
 	*args->oh = obj_ptr2hdl(obj);
 	obj_decref(obj);
@@ -1847,6 +1649,57 @@ recov_task_cb(tse_task_t *task, void *data)
 	return 0;
 }
 
+static inline bool
+obj_shard_is_invalid(struct dc_object *obj, uint32_t shard_idx)
+{
+	return obj->cob_shards->do_shards[shard_idx].do_rebuilding ||
+	       obj->cob_shards->do_shards[shard_idx].do_target_id == -1 ||
+	       obj->cob_shards->do_shards[shard_idx].do_shard == -1 ||
+	       unlikely(DAOS_FAIL_CHECK(DAOS_FAIL_SHARD_OPEN) &&
+			daos_shard_in_fail_value(shard_idx));
+}
+
+/**
+ * Check if there are any EC parity shards still alive under the oh/dkey_hash.
+ * 1: alive,  0: no alive  < 0: failure.
+ */
+int
+obj_ec_parity_alive(daos_handle_t oh, uint64_t dkey_hash, uint32_t map_ver)
+{
+	struct daos_oclass_attr *oca;
+	struct dc_object	*obj;
+	uint32_t		p_shard;
+	int			grp_idx;
+	int			i;
+	int			rc = 0;
+
+	obj = obj_hdl2ptr(oh);
+	grp_idx = obj_dkey2grpidx(obj, dkey_hash, map_ver);
+	if (grp_idx < 0)
+		D_GOTO(out_put, rc = grp_idx);
+
+	if (!obj->cob_ec_parity_rotate)
+		dkey_hash = 0;
+
+	oca = obj_get_oca(obj);
+	p_shard = obj_ec_parity_start(obj_ec_dkey_hash_get(obj, dkey_hash), oca);
+	for (i = 0; i < obj_ec_parity_tgt_nr(oca); i++, p_shard++) {
+		uint32_t shard;
+
+		shard = p_shard % obj_get_grp_size(obj) + grp_idx * obj_get_grp_size(obj);
+		D_DEBUG(DB_TRACE, "shard %u %d/%d/%d\n", shard,
+			obj->cob_shards->do_shards[shard].do_rebuilding,
+			obj->cob_shards->do_shards[shard].do_target_id,
+			obj->cob_shards->do_shards[shard].do_shard);
+		if (!obj_shard_is_invalid(obj, shard))
+			D_GOTO(out_put, rc = 1);
+	}
+
+out_put:
+	obj_decref(obj);
+	return rc;
+}
+
 static void
 obj_ec_recov_cb(tse_task_t *task, struct dc_object *obj,
 		struct obj_auxi_args *obj_auxi, d_iov_t *csum_iov)
@@ -1864,6 +1717,7 @@ obj_ec_recov_cb(tse_task_t *task, struct dc_object *obj,
 	int				 rc;
 
 	rc = obj_ec_recov_prep(&obj_auxi->reasb_req, obj->cob_md.omd_id,
+			       obj_ec_dkey_hash_get(obj, obj_auxi->dkey_hash),
 			       args->iods, args->nr);
 	if (rc) {
 		D_ERROR("task %p "DF_OID" obj_ec_recov_prep failed "DF_RC"\n",
@@ -2545,142 +2399,6 @@ out:
 	return rc;
 }
 
-/* Query the obj request's targets */
-static int
-obj_req_get_tgts(struct dc_object *obj, int *shard, daos_key_t *dkey,
-		 uint64_t dkey_hash, uint8_t *bit_map, uint32_t map_ver,
-		 bool to_leader, bool spec_shard, struct obj_auxi_args *obj_auxi)
-{
-	struct obj_req_tgts	*req_tgts = &obj_auxi->req_tgts;
-	enum obj_rpc_opc	opc = obj_auxi->opc;
-	uint32_t		shard_idx;
-	uint32_t		shard_cnt = 0;
-	uint32_t		grp_nr;
-	uint32_t		flags = 0;
-	int			rc;
-
-	switch (opc) {
-	case DAOS_OBJ_RPC_FETCH:
-		if (bit_map == NIL_BITMAP) {
-			if (spec_shard) {
-				D_ASSERT(shard != NULL);
-
-				rc = obj_dkey2grpidx(obj, dkey_hash, map_ver);
-				if (rc < 0)
-					goto out;
-
-				rc *= obj->cob_grp_size;
-				if (*shard < rc ||
-				    *shard >= rc + obj->cob_grp_size) {
-					D_ERROR("Fetch from invalid shard, "
-						"grp size %u, shard cnt %u, "
-						"grp idx %u, given shard %u, "
-						"dkey hash %lu, dkey "
-						DF_KEY"\n",
-						obj->cob_grp_size,
-						obj->cob_shards_nr,
-						rc / obj->cob_grp_size, *shard,
-						dkey_hash,
-						DP_KEY(dkey));
-					D_GOTO(out, rc = -DER_INVAL);
-				}
-
-				rc = *shard;
-			} else {
-				rc = obj_dkey2shard(obj, dkey_hash, map_ver,
-						    to_leader,
-						    obj_auxi->failed_tgt_list);
-				if (rc < 0)
-					goto out;
-			}
-			shard_idx = rc;
-			shard_cnt = 1;
-		} else {
-			rc = obj_dkey2grpmemb(obj, dkey_hash, map_ver,
-					      &shard_idx, &shard_cnt);
-			if (rc != 0)
-				goto out;
-		}
-		grp_nr = 1;
-		flags = OBJ_TGT_FLAG_CLI_DISPATCH;
-		break;
-	case DAOS_OBJ_RPC_UPDATE:
-	case DAOS_OBJ_RPC_PUNCH_DKEYS:
-	case DAOS_OBJ_RPC_PUNCH_AKEYS:
-		grp_nr = 1;
-		rc = obj_dkey2grpmemb(obj, dkey_hash, map_ver, &shard_idx, &shard_cnt);
-		if (rc != 0)
-			goto out;
-
-		flags = OBJ_TGT_FLAG_FW_LEADER_INFO;
-		D_DEBUG(DB_IO, "shard_idx %u shard_cnt %u\n", shard_idx, shard_cnt);
-		break;
-	case DAOS_OBJ_DKEY_RPC_ENUMERATE:
-	case DAOS_OBJ_RPC_ENUMERATE:
-	case DAOS_OBJ_AKEY_RPC_ENUMERATE:
-	case DAOS_OBJ_RECX_RPC_ENUMERATE:
-		shard_cnt = 1;
-		grp_nr = 1;
-		D_ASSERT(shard != NULL);
-		D_ASSERT((int)*shard != -1);
-		shard_idx = *shard;
-		if (obj_auxi->is_ec_obj) {
-			struct daos_oclass_attr	*oca;
-
-			oca = obj_get_oca(obj);
-			if (shard_idx % obj_get_grp_size(obj) <
-			    obj_ec_data_tgt_nr(oca)) {
-				/* Client dispatch for EC recx enumeration */
-				flags = OBJ_TGT_FLAG_CLI_DISPATCH;
-				if (obj_auxi->spec_shard)
-					shard_cnt = 1;
-				else
-					shard_cnt = obj_ec_data_tgt_nr(oca);
-				D_DEBUG(DB_IO, "data shard %d enumeration for "
-					DF_OID"\n", shard_cnt,
-					DP_OID(obj->cob_md.omd_id));
-			}
-		}
-
-		req_tgts->ort_shard_tgts = req_tgts->ort_tgts_inline;
-		req_tgts->ort_srv_disp = 0;
-		rc = obj_shard_tgts_query(obj, map_ver, *shard, 0,
-					  req_tgts->ort_shard_tgts, obj_auxi);
-		if (rc != 0)
-			goto out;
-		break;
-	case DAOS_OBJ_RPC_SYNC:
-	case DAOS_OBJ_RPC_PUNCH:
-		obj_ptr2shards(obj, &shard_idx, &shard_cnt, &grp_nr);
-		if (opc == DAOS_OBJ_RPC_PUNCH) {
-			flags = OBJ_TGT_FLAG_FW_LEADER_INFO;
-		} else {
-			flags = OBJ_TGT_FLAG_LEADER_ONLY;
-			obj_auxi->to_leader = 1;
-		}
-		break;
-	default:
-		D_ERROR("bad opc %d.\n", opc);
-		rc = -DER_INVAL;
-		D_GOTO(out, rc);
-	}
-
-	rc = obj_shards_2_fwtgts(obj, map_ver, bit_map, shard_idx,
-				 shard_cnt, grp_nr, flags, obj_auxi);
-	if (rc != 0) {
-		if (rc != -DER_SHARDS_OVERLAP && rc != -DER_TGT_RETRY)
-			D_ERROR("opc %d "DF_OID", obj_shards_2_fwtgts failed "
-				DF_RC"\n", opc, DP_OID(obj->cob_md.omd_id),
-				DP_RC(rc));
-		else
-			D_DEBUG(DB_IO, "opc %d "DF_OID", obj_shards_2_fwtgts "
-				DF_RC"\n", opc, DP_OID(obj->cob_md.omd_id),
-				DP_RC(rc));
-	}
-out:
-	return rc;
-}
-
 static int
 shard_task_abort(tse_task_t *task, void *arg)
 {
@@ -2732,7 +2450,7 @@ shard_task_sched(tse_task_t *task, void *arg)
 		 * pool map.
 		 * Also retry the shard IO if it got retryable error last time.
 		 */
-		rc = obj_shard2tgtid(shard_auxi->obj, shard_auxi->shard,
+		rc = obj_shard2tgtid(obj_auxi->obj, shard_auxi->shard,
 				     map_ver, &target);
 		if (rc != 0) {
 			D_ERROR("shard %d, obj_shard2tgtid failed "DF_RC"\n",
@@ -2830,8 +2548,8 @@ obj_embedded_shard_arg(struct obj_auxi_args *obj_auxi)
 static int
 shard_io(tse_task_t *task, struct shard_auxi_args *shard_auxi)
 {
-	struct dc_object		*obj = shard_auxi->obj;
 	struct obj_auxi_args		*obj_auxi = shard_auxi->obj_auxi;
+	struct dc_object		*obj = obj_auxi->obj;
 	struct dc_obj_shard		*obj_shard;
 	struct obj_req_tgts		*req_tgts;
 	struct daos_shard_tgt		*fw_shard_tgts;
@@ -2905,7 +2623,7 @@ shard_io_task(tse_task_t *task)
 typedef int (*shard_io_prep_cb_t)(struct shard_auxi_args *shard_auxi,
 				  struct dc_object *obj,
 				  struct obj_auxi_args *obj_auxi,
-				  uint64_t dkey_hash, uint32_t grp_idx);
+				  uint32_t grp_idx);
 
 struct shard_task_reset_arg {
 	struct obj_req_tgts	*req_tgts;
@@ -2941,7 +2659,7 @@ shard_task_reset_param(tse_task_t *shard_task, void *arg)
 
 static int
 obj_req_fanout(struct dc_object *obj, struct obj_auxi_args *obj_auxi,
-	       uint64_t dkey_hash, uint32_t map_ver, struct dtx_epoch *epoch,
+	       uint32_t map_ver, struct dtx_epoch *epoch,
 	       shard_io_prep_cb_t io_prep_cb, shard_io_cb_t io_cb,
 	       tse_task_t *obj_task)
 {
@@ -3053,11 +2771,9 @@ obj_req_fanout(struct dc_object *obj, struct obj_auxi_args *obj_auxi,
 				     tgt->st_tgt_id, epoch, tgt->st_ec_tgt);
 		shard_auxi->grp_idx = 0;
 		shard_auxi->start_shard = req_tgts->ort_start_shard;
-		shard_auxi->obj = obj;
 		shard_auxi->obj_auxi = obj_auxi;
 		shard_auxi->shard_io_cb = io_cb;
-		rc = io_prep_cb(shard_auxi, obj, obj_auxi, dkey_hash,
-				shard_auxi->grp_idx);
+		rc = io_prep_cb(shard_auxi, obj, obj_auxi, shard_auxi->grp_idx);
 		if (rc)
 			goto out_task;
 
@@ -3088,11 +2804,9 @@ obj_req_fanout(struct dc_object *obj, struct obj_auxi_args *obj_auxi,
 		shard_auxi->grp_idx = req_tgts->ort_srv_disp ? i :
 				      (i / req_tgts->ort_grp_size);
 		shard_auxi->start_shard = req_tgts->ort_start_shard;
-		shard_auxi->obj = obj;
 		shard_auxi->obj_auxi = obj_auxi;
 		shard_auxi->shard_io_cb = io_cb;
-		rc = io_prep_cb(shard_auxi, obj, obj_auxi, dkey_hash,
-				shard_auxi->grp_idx);
+		rc = io_prep_cb(shard_auxi, obj, obj_auxi, shard_auxi->grp_idx);
 		if (rc) {
 			tse_task_complete(shard_task, rc);
 			goto out_task;
@@ -3322,7 +3036,7 @@ obj_ec_recxs_convert(d_list_t *merged_list, daos_recx_t *recx,
 	int			cell_nr;
 	int			stripe_nr;
 
-	oca = obj_get_oca(shard_auxi->obj);
+	oca = obj_get_oca(shard_auxi->obj_auxi->obj);
 	/* Normally the enumeration is sent to the parity node */
 	/* convert the parity off to daos off */
 	if (recx->rx_idx & PARITY_INDICATOR) {
@@ -3335,7 +3049,10 @@ obj_ec_recxs_convert(d_list_t *merged_list, daos_recx_t *recx,
 
 	cell_nr = obj_ec_cell_rec_nr(oca);
 	stripe_nr = obj_ec_stripe_rec_nr(oca);
-	shard = shard_auxi->shard % obj_get_grp_size(shard_auxi->obj);
+	shard = shard_auxi->shard % obj_get_grp_size(shard_auxi->obj_auxi->obj);
+	shard = obj_ec_shard_off(obj_ec_dkey_hash_get(shard_auxi->obj_auxi->obj,
+						      shard_auxi->obj_auxi->dkey_hash),
+				 oca, shard);
 	/* If all parity nodes are down(degraded mode), then
 	 * the enumeration is sent to all data nodes.
 	 */
@@ -3386,23 +3103,6 @@ obj_shard_list_recx_cb(struct shard_auxi_args *shard_auxi,
 }
 
 static int
-obj_enum_shard_process_cb(daos_key_desc_t *kds, void *ptr,
-			  unsigned int size, void *arg)
-{
-	struct obj_enum_rec	*rec = ptr;
-	struct shard_auxi_args	*shard_auxi = arg;
-	int			rc;
-
-	D_ASSERT(size >= sizeof(struct obj_enum_rec));
-
-	rc = obj_ec_recxs_convert(NULL, &rec->rec_recx, shard_auxi);
-	if (rc)
-		return rc;
-
-	return rc;
-}
-
-static int
 obj_shard_list_obj_cb(struct shard_auxi_args *shard_auxi,
 		      struct obj_auxi_args *obj_auxi, void *arg)
 {
@@ -3412,12 +3112,8 @@ obj_shard_list_obj_cb(struct shard_auxi_args *shard_auxi,
 	char			*ptr = obj_arg->sgl->sg_iovs[0].iov_buf;
 	daos_key_desc_t		*kds = obj_arg->kds;
 	int			i;
-	int			rc;
 
 	shard_arg = container_of(shard_auxi, struct shard_list_args, la_auxi);
-	rc = obj_enum_iterate(shard_arg->la_kds, shard_arg->la_sgl,
-			      shard_arg->la_nr, OBJ_ITER_RECX,
-			      obj_enum_shard_process_cb, shard_auxi);
 	ptr += iter_arg->merge_sgl_off;
 	memcpy(ptr, shard_arg->la_sgl->sg_iovs[0].iov_buf,
 	       shard_arg->la_sgl->sg_iovs[0].iov_len);
@@ -3432,7 +3128,7 @@ obj_shard_list_obj_cb(struct shard_auxi_args *shard_auxi,
 
 	D_DEBUG(DB_TRACE, "merge_nr %d/"DF_U64"\n", iter_arg->merge_nr,
 		obj_arg->sgl->sg_iovs[0].iov_len);
-	return rc;
+	return 0;
 }
 
 static void
@@ -3488,7 +3184,7 @@ merge_key(struct dc_object *obj, d_list_t *head, char *key, int key_size)
 	if (!inserted)
 		d_list_add_tail(&new_key->key_list, head);
 
-	return 0;
+	return 1;
 }
 
 static int
@@ -3502,6 +3198,7 @@ obj_shard_list_key_cb(struct shard_auxi_args *shard_auxi,
 	int			sgl_off = 0;
 	int			iov_off = 0;
 	int			i;
+	int			rc = 0;
 
 	shard_arg = container_of(shard_auxi, struct shard_list_args, la_auxi);
 	if (shard_arg->la_sgl == NULL)
@@ -3517,7 +3214,6 @@ obj_shard_list_key_cb(struct shard_auxi_args *shard_auxi,
 		int key_size = shard_arg->la_kds[i].kd_key_len;
 		bool alloc_key = false;
 		char *key = NULL;
-		int rc;
 
 		if (key_size <= (iov->iov_len - iov_off)) {
 			key = (char *)iov->iov_buf + iov_off;
@@ -3531,12 +3227,11 @@ obj_shard_list_key_cb(struct shard_auxi_args *shard_auxi,
 
 			D_ALLOC(key, key_size);
 			if (key == NULL)
-				return -DER_NOMEM;
+				D_GOTO(out, rc = -DER_NOMEM);
 
 			alloc_key = true;
 			while (left > 0) {
-				int copy_size = min(left,
-						    iov->iov_len - iov_off);
+				int copy_size = min(left, iov->iov_len - iov_off);
 				char *ptr = (char *)iov->iov_buf + iov_off;
 
 				memcpy(key, ptr, copy_size);
@@ -3551,14 +3246,22 @@ obj_shard_list_key_cb(struct shard_auxi_args *shard_auxi,
 		}
 
 		rc = merge_key(obj_auxi->obj, iter_arg->merged_list, key, key_size);
-		/* free key first regardless of rc */
 		if (alloc_key)
 			D_FREE(key);
-		if (rc)
-			return rc;
+
+		if (rc < 0)
+			break;
+
+		if (rc == 1) {
+			iter_arg->merge_nr++;
+			D_DEBUG(DB_TRACE, "merged %.*s cnt %d\n", key_size, key,
+				iter_arg->merge_nr);
+			rc = 0;
+		}
 	}
 
-	return 0;
+out:
+	return rc;
 }
 
 static int
@@ -3785,6 +3488,8 @@ update_sub_anchor_cb(struct shard_auxi_args *shard_auxi,
 
 	shard_arg = container_of(shard_auxi, struct shard_list_args, la_auxi);
 	shard = shard_auxi->shard % obj_get_grp_size(obj_auxi->obj);
+	shard = obj_ec_shard_off(obj_ec_dkey_hash_get(obj_auxi->obj, obj_auxi->dkey_hash),
+				 &obj_auxi->obj->cob_oca, shard);
 	if (obj_arg->anchor && obj_arg->anchor->da_sub_anchors) {
 		struct shard_anchors	*sub_anchors;
 
@@ -4144,6 +3849,7 @@ obj_comp_cb_internal(struct obj_auxi_args *obj_auxi)
 				DP_OID(obj_auxi->obj->cob_md.omd_id), rc);
 			obj_auxi->io_retry = 1;
 		}
+		D_DEBUG(DB_TRACE, "exit %d\n", rc);
 		D_GOTO(out, rc);
 	}
 
@@ -4153,7 +3859,7 @@ obj_comp_cb_internal(struct obj_auxi_args *obj_auxi)
 out:
 	if (sub_anchors == NULL && obj_is_enum_opc(obj_auxi->opc))
 		merged_list_free(&merged_list, obj_auxi->opc);
-
+	D_DEBUG(DB_TRACE, "exit %d\n", rc);
 	return rc;
 }
 
@@ -4179,15 +3885,17 @@ obj_io_set_new_shard_task(struct obj_auxi_args *obj_auxi)
 static void
 obj_size_fetch_cb(const struct dc_object *obj, struct obj_auxi_args *obj_auxi)
 {
+	daos_obj_rw_t	*api_args;
 	daos_iod_t	*uiods, *iods;
 	d_sg_list_t	*usgls;
 	unsigned int     iod_nr, i;
 	bool		 size_all_zero = true;
 
+	api_args = dc_task_get_args(obj_auxi->obj_task);
 	/* set iod_size to original user IOD */
 	uiods = obj_auxi->reasb_req.orr_uiods;
-	iods = obj_auxi->rw_args.api_args->iods;
-	iod_nr = obj_auxi->rw_args.api_args->nr;
+	iods = api_args->iods;
+	iod_nr = api_args->nr;
 	D_ASSERT(uiods != iods);
 	for (i = 0; i < iod_nr; i++) {
 		if (uiods[i].iod_size != DAOS_REC_ANY) {
@@ -4296,11 +4004,14 @@ obj_update_sgls_free(struct obj_auxi_args *obj_auxi)
 	int	i;
 
 	if (obj_auxi->opc == DAOS_OBJ_RPC_UPDATE && obj_auxi->rw_args.sgls_dup != NULL) {
+		daos_obj_rw_t	*api_args;
+
 		for (i = 0; i < obj_auxi->iod_nr; i++)
 			d_sgl_fini(&obj_auxi->rw_args.sgls_dup[i], false);
 		D_FREE(obj_auxi->rw_args.sgls_dup);
 		obj_auxi->rw_args.sgls_dup = NULL;
-		obj_auxi->rw_args.api_args->sgls = obj_auxi->reasb_req.orr_usgls;
+		api_args = dc_task_get_args(obj_auxi->obj_task);
+		api_args->sgls = obj_auxi->reasb_req.orr_usgls;
 	}
 }
 
@@ -4328,6 +4039,86 @@ obj_reasb_io_fini(struct obj_auxi_args *obj_auxi, bool retry)
 		memset(obj_auxi, 0, sizeof(*obj_auxi));
 }
 
+/**
+ * Check if need recovery data.
+ */
+static bool
+obj_ec_should_init_recover_cb(struct obj_auxi_args *obj_auxi)
+{
+	struct obj_ec_fail_info	*fail_info;
+	tse_task_t		*task;
+
+	D_ASSERT(obj_auxi->is_ec_obj);
+
+	task = obj_auxi->obj_task;
+	if (!obj_auxi->ec_in_recov && task->dt_result == -DER_TGT_RETRY)
+		return true;
+
+	fail_info = obj_auxi->reasb_req.orr_fail;
+	if (fail_info == NULL)
+		return false;
+
+	if (obj_auxi->ec_wait_recov)
+		return false;
+
+	if (!obj_auxi->ec_in_recov && fail_info->efi_nrecx_lists > 0)
+		return true;
+
+	return false;
+}
+
+static bool
+obj_ec_should_recover_data(struct obj_auxi_args *obj_auxi)
+{
+	if (!obj_auxi->ec_in_recov &&
+	    obj_auxi->ec_wait_recov && obj_auxi->obj_task->dt_result == 0)
+		return true;
+
+	return false;
+}
+
+static void
+obj_ec_comp_cb(struct obj_auxi_args *obj_auxi)
+{
+	tse_task_t	 *task = obj_auxi->obj_task;
+	struct dc_object *obj = obj_auxi->obj;
+
+	D_ASSERT(obj_auxi->is_ec_obj);
+
+	if (obj_is_modification_opc(obj_auxi->opc)) {
+		obj_reasb_io_fini(obj_auxi, false);
+		return;
+	}
+
+	if (obj_ec_should_init_recover_cb(obj_auxi)) {
+		daos_obj_fetch_t *args = dc_task_get_args(task);
+
+		task->dt_result = 0;
+		obj_bulk_fini(obj_auxi);
+		D_DEBUG(DB_IO, "opc %d init recover task for "DF_OID"\n",
+			obj_auxi->opc, DP_OID(obj->cob_md.omd_id));
+		obj_ec_recov_cb(task, obj, obj_auxi, args->csum_iov);
+		return;
+	}
+
+	if (obj_ec_should_recover_data(obj_auxi)) {
+		daos_obj_fetch_t *args = dc_task_get_args(task);
+
+		if (!obj_auxi->reasb_req.orr_size_fetch)
+			obj_ec_recov_data(&obj_auxi->reasb_req, obj->cob_md.omd_id,
+					  args->nr);
+	} else if ((task->dt_result == 0 || task->dt_result == -DER_REC2BIG) &&
+		    obj_auxi->opc == DAOS_OBJ_RPC_FETCH) {
+		daos_obj_fetch_t *args = dc_task_get_args(task);
+
+		obj_ec_update_iod_size(&obj_auxi->reasb_req, args->nr);
+		if (obj_auxi->bulks != NULL && obj_auxi->reasb_req.orr_usgls != NULL)
+			obj_ec_fetch_set_sgl(&obj_auxi->reasb_req, obj_auxi->dkey_hash, args->nr);
+	}
+
+	obj_reasb_io_fini(obj_auxi, false);
+}
+
 static int
 obj_comp_cb(tse_task_t *task, void *data)
 {
@@ -4347,8 +4138,10 @@ obj_comp_cb(tse_task_t *task, void *data)
 	if (rc != 0 || obj_auxi->result) {
 		if (task->dt_result == 0)
 			task->dt_result = rc ? rc : obj_auxi->result;
-		D_DEBUG(DB_IO, "obj complete callback: %d\n", task->dt_result);
 	}
+
+	D_DEBUG(DB_IO, "opc %u retry: %d leader %d obj complete callback: %d\n",
+		obj_auxi->opc, obj_auxi->io_retry, obj_auxi->to_leader, task->dt_result);
 
 	if (obj->cob_time_fetch_leader != NULL &&
 	    obj_auxi->req_tgts.ort_shard_tgts != NULL &&
@@ -4435,6 +4228,16 @@ obj_comp_cb(tse_task_t *task, void *data)
 			obj_auxi->reasb_req.orr_iom_tgt_nr = 0;
 			obj_io_set_new_shard_task(obj_auxi);
 		}
+
+		if (obj_auxi->is_ec_obj && obj_is_enum_opc(obj_auxi->opc)) {
+			/**
+			 * Since enumeration retry might retry to send multiple
+			 * shards, remove the original shard fetch tasks and will
+			 * recreate new shard fetch tasks with new parameters.
+			 */
+			obj_io_set_new_shard_task(obj_auxi);
+		}
+
 		if (!obj_auxi->ec_in_recov)
 			obj_ec_fail_info_reset(&obj_auxi->reasb_req);
 	}
@@ -4449,8 +4252,6 @@ obj_comp_cb(tse_task_t *task, void *data)
 	}
 
 	if (!io_task_reinited) {
-		struct obj_ec_fail_info	*fail_info;
-		bool new_tgt_fail = false;
 		d_list_t *head = &obj_auxi->shard_task_head;
 
 		switch (obj_auxi->opc) {
@@ -4529,53 +4330,10 @@ obj_comp_cb(tse_task_t *task, void *data)
 			D_ASSERT(d_list_empty(head));
 		}
 
-		fail_info = obj_auxi->reasb_req.orr_fail;
-		new_tgt_fail = obj_auxi->ec_wait_recov &&
-			       task->dt_result == -DER_TGT_RETRY;
-		/* for original failed EC obj fetch task, try with EC recovery
-		 * 1. create EC recovery task (with ec_in_recov flag) and mark
-		 *    original obj fetch task with ec_wait_recov flag.
-		 * 2. when ec_in_recov task done, the ec_wait_recov task can
-		 *    recover the data.
-		 */
-		if (fail_info != NULL && !obj_auxi->ec_in_recov &&
-		    ((obj_auxi->reasb_req.orr_singv_only &&
-		     (task->dt_result == -DER_TGT_RETRY ||
-		      task->dt_result == 0)) ||
-		     (fail_info->efi_nrecx_lists > 0 &&
-		      (task->dt_result == 0 ||  new_tgt_fail)))) {
-			if (obj_auxi->ec_wait_recov && task->dt_result == 0) {
-				daos_obj_fetch_t *args = dc_task_get_args(task);
-
-				if (!obj_auxi->reasb_req.orr_size_fetch)
-					obj_ec_recov_data(&obj_auxi->reasb_req, obj->cob_md.omd_id,
-							  args->nr);
-
-				obj_reasb_io_fini(obj_auxi, false);
-			} else {
-				daos_obj_fetch_t *args = dc_task_get_args(task);
-
-				task->dt_result = 0;
-				obj_bulk_fini(obj_auxi);
-				obj_ec_recov_cb(task, obj, obj_auxi,
-						args->csum_iov);
-			}
-		} else {
-			if (obj_auxi->is_ec_obj &&
-			    (task->dt_result == 0 ||
-			     task->dt_result == -DER_REC2BIG) &&
-			    obj_auxi->opc == DAOS_OBJ_RPC_FETCH) {
-				daos_obj_fetch_t *args = dc_task_get_args(task);
-
-				obj_ec_update_iod_size(&obj_auxi->reasb_req,
-						       args->nr);
-				if (obj_auxi->bulks != NULL)
-					obj_ec_fetch_set_sgl(
-						&obj_auxi->reasb_req, args->nr);
-			}
-
+		if (obj_auxi->is_ec_obj)
+			obj_ec_comp_cb(obj_auxi);
+		else
 			obj_reasb_io_fini(obj_auxi, false);
-		}
 	}
 
 	obj_decref(obj);
@@ -4589,6 +4347,8 @@ obj_task_init_common(tse_task_t *task, int opc, uint32_t map_ver,
 {
 	struct obj_auxi_args	*obj_auxi;
 
+	D_DEBUG(DB_IO, "client task init "DF_OID" 0x%x\n",
+		DP_OID(obj->cob_md.omd_id), opc);
 	obj_auxi = tse_task_stack_push(task, sizeof(*obj_auxi));
 	if (obj_is_modification_opc(opc))
 		obj_auxi->spec_group = 0;
@@ -4597,7 +4357,10 @@ obj_task_init_common(tse_task_t *task, int opc, uint32_t map_ver,
 	obj_auxi->obj_task = task;
 	obj_auxi->th = th;
 	obj_auxi->obj = obj;
+	obj_auxi->dkey_hash = 0;
 	shard_task_list_init(obj_auxi);
+	if (obj_is_ec(obj))
+		obj_auxi->is_ec_obj = 1;
 	*auxi = obj_auxi;
 }
 
@@ -4627,15 +4390,12 @@ obj_task_init(tse_task_t *task, int opc, uint32_t map_ver, daos_handle_t th,
 
 static int
 shard_rw_prep(struct shard_auxi_args *shard_auxi, struct dc_object *obj,
-	      struct obj_auxi_args *obj_auxi, uint64_t dkey_hash,
-	      uint32_t grp_idx)
+	      struct obj_auxi_args *obj_auxi, uint32_t grp_idx)
 {
-	daos_obj_rw_t		*obj_args;
 	struct shard_rw_args	*shard_arg;
 	struct obj_reasb_req	*reasb_req;
 	struct obj_tgt_oiod	*toiod;
 
-	obj_args = dc_task_get_args(obj_auxi->obj_task);
 	shard_arg = container_of(shard_auxi, struct shard_rw_args, auxi);
 
 	if (daos_handle_is_inval(obj_auxi->th))
@@ -4646,10 +4406,7 @@ shard_rw_prep(struct shard_auxi_args *shard_auxi, struct dc_object *obj,
 	else
 		dc_tx_get_dti(obj_auxi->th, &shard_arg->dti);
 
-	obj_auxi->rw_args.api_args	= obj_args;
-	shard_arg->api_args		= obj_args;
-	shard_arg->dkey_hash		= dkey_hash;
-	shard_arg->bulks		= obj_auxi->bulks;
+	shard_arg->bulks = obj_auxi->bulks;
 	if (obj_auxi->req_reasbed) {
 		reasb_req = &obj_auxi->reasb_req;
 		if (reasb_req->tgt_oiods != NULL) {
@@ -4657,7 +4414,7 @@ shard_rw_prep(struct shard_auxi_args *shard_auxi, struct dc_object *obj,
 			toiod = obj_ec_tgt_oiod_get(
 				reasb_req->tgt_oiods, reasb_req->orr_tgt_nr,
 				shard_auxi->ec_tgt_idx);
-			D_ASSERT(toiod != NULL);
+			D_ASSERTF(toiod != NULL, "tgt idx %u\n", shard_auxi->ec_tgt_idx);
 			shard_arg->oiods = toiod->oto_oiods;
 			shard_arg->offs = toiod->oto_offs;
 			D_ASSERT(shard_arg->offs != NULL);
@@ -4863,29 +4620,24 @@ obj_csum_fetch(const struct dc_object *obj, daos_obj_fetch_t *args,
  */
 static int
 obj_retry_next_shard(struct dc_object *obj, struct obj_auxi_args *obj_auxi,
-		     uint64_t dkey_hash, unsigned int map_ver)
+		     unsigned int map_ver, uint32_t *shard)
 {
-	unsigned int		 next_shard, retry_size, shard_cnt, start_shard;
-	int			 rc = 0;
+	unsigned int	grp_size;
+	unsigned int	start_shard;
+	int		rc = 0;
 
 	D_WARN("Retrying replica because of %s error.\n",
 	       obj_auxi->csum_retry ? "csum" : "tx_uncertain");
 
-	rc = obj_dkey2grpmemb(obj, dkey_hash, map_ver,
-			      &start_shard, &shard_cnt);
+	/* EC retry is done by degraded fetch */
+	D_ASSERT(!obj_is_ec(obj));
+	rc = obj_dkey2grpmemb(obj, obj_auxi->dkey_hash, map_ver,
+			      &start_shard, &grp_size);
 	if (rc != 0)
 		return rc;
 
-	/* bitmap in obj_auxi_args has only 4 bytes, then let's only retry
-	 * the first 32 replicas, that should be enough for most of cases.
-	 */
-
-	retry_size = shard_cnt <= OBJ_INLINE_BTIMAP * 8 ?
-		     shard_cnt : OBJ_INLINE_BTIMAP * 8;
-	next_shard = (obj_auxi->req_tgts.ort_shard_tgts[0].st_shard + 1) %
-		     retry_size + start_shard;
-
-	if (next_shard == obj_auxi->initial_shard) {
+	*shard = (obj_auxi->req_tgts.ort_shard_tgts[0].st_shard + 1) % grp_size + start_shard;
+	if (*shard == obj_auxi->initial_shard) {
 		obj_auxi->no_retry = 1;
 		if (obj_auxi->csum_retry)
 			return -DER_CSUM;
@@ -4893,10 +4645,225 @@ obj_retry_next_shard(struct dc_object *obj, struct obj_auxi_args *obj_auxi,
 		return -DER_TX_UNCERTAIN;
 	}
 
-	memset(obj_auxi->retry_bitmap, 0, OBJ_INLINE_BTIMAP);
-	setbit(obj_auxi->retry_bitmap, next_shard - start_shard);
+	return rc;
+}
 
+static int
+obj_ec_valid_shard_get(struct obj_auxi_args *obj_auxi, uint8_t *tgt_bitmap,
+		       uint32_t grp_idx, uint32_t *tgt_idx)
+{
+	struct dc_object	*obj = obj_auxi->obj;
+	uint32_t		grp_start = grp_idx * obj_get_grp_size(obj);
+	uint32_t		shard_idx = grp_start + *tgt_idx;
+	bool			force_ec_degrade = false;
+	bool			ec_degrade = false;
+	int			rc = 0;
+
+	if (obj_auxi->csum_retry || obj_auxi->tx_uncertain || obj_auxi->force_degraded)
+		force_ec_degrade = true;
+
+	while (obj_shard_is_invalid(obj, shard_idx) || force_ec_degrade) {
+		D_DEBUG(DB_IO, "tried shard %d/%u %d/%d/%d/%d on "DF_OID"\n", shard_idx, *tgt_idx,
+			obj->cob_shards->do_shards[shard_idx].do_rebuilding,
+			obj->cob_shards->do_shards[shard_idx].do_target_id,
+			obj->cob_shards->do_shards[shard_idx].do_shard, force_ec_degrade,
+			DP_OID(obj->cob_md.omd_id));
+		rc = obj_ec_fail_info_insert(&obj_auxi->reasb_req, (uint16_t)*tgt_idx);
+		if (rc)
+			break;
+
+		rc = obj_ec_fail_info_parity_get(&obj_auxi->reasb_req,
+						 obj_ec_dkey_hash_get(obj, obj_auxi->dkey_hash),
+						 tgt_idx, tgt_bitmap);
+		if (rc)
+			break;
+		shard_idx = grp_start + *tgt_idx;
+		force_ec_degrade = false;
+		obj_auxi->force_degraded = false;
+		ec_degrade = true;
+	}
+
+	if (rc) {
+		if (force_ec_degrade) {
+			obj_auxi->no_retry = 1;
+			if (obj_auxi->csum_retry)
+				rc = -DER_CSUM;
+			else if (obj_auxi->tx_uncertain)
+				rc = -DER_TX_UNCERTAIN;
+		}
+		D_ERROR(DF_OID" can not get parity shard: "DF_RC"\n",
+			DP_OID(obj->cob_md.omd_id), DP_RC(rc));
+	}
+
+	if (ec_degrade) {
+		obj_auxi->tx_uncertain = 0;
+		obj_auxi->csum_retry = 0;
+	}
+
+	return rc;
+}
+
+static int
+obj_ec_fetch_shards_get(struct dc_object *obj, daos_obj_fetch_t *args, unsigned int map_ver,
+			struct obj_auxi_args *obj_auxi, uint32_t *shard, uint32_t *shard_cnt)
+{
+	uint8_t			*tgt_bitmap;
+	int			grp_idx;
+	uint32_t		grp_start;
+	uint32_t		tgt_idx;
+	struct daos_oclass_attr	*oca;
+	int			rc = 0;
+	int			i;
+
+	grp_idx = obj_dkey2grpidx(obj, obj_auxi->dkey_hash, map_ver);
+	if (grp_idx < 0)
+		return grp_idx;
+
+	oca = obj_get_oca(obj);
+	/* Check if it needs to do degraded fetch.*/
+	grp_start = grp_idx * obj_get_grp_size(obj);
+	tgt_bitmap = obj_auxi->reasb_req.tgt_bitmap;
+	tgt_idx = obj_ec_shard_idx(obj_ec_dkey_hash_get(obj, obj_auxi->dkey_hash), oca, 0);
+	D_DEBUG(DB_TRACE, DF_OID" grp idx %d shard start %u\n",
+		DP_OID(obj->cob_md.omd_id), grp_idx, tgt_idx);
+	for (i = 0; i < obj_ec_tgt_nr(oca); i++,
+	     tgt_idx = (tgt_idx + 1) % obj_get_grp_size(obj)) {
+		struct obj_tgt_oiod	*toiod;
+		uint32_t		ec_deg_tgt;
+
+		if (isclr(tgt_bitmap, tgt_idx))
+			continue;
+
+		ec_deg_tgt = tgt_idx;
+		rc = obj_ec_valid_shard_get(obj_auxi, tgt_bitmap, grp_idx, &ec_deg_tgt);
+		if (rc)
+			D_GOTO(out, rc);
+
+		/* Normally, no need degraded fetch */
+		if (likely(ec_deg_tgt == tgt_idx))
+			continue;
+
+		if (obj_auxi->ec_in_recov ||
+		    (obj_auxi->reasb_req.orr_singv_only && !obj_auxi->reasb_req.orr_size_fetch)) {
+			D_DEBUG(DB_IO, DF_OID" shard %d failed recovery(%d) or singv fetch(%d).\n",
+				DP_OID(obj->cob_md.omd_id), grp_start + tgt_idx,
+				obj_auxi->ec_in_recov, obj_auxi->reasb_req.orr_singv_only);
+			D_GOTO(out, rc = -DER_TGT_RETRY);
+		}
+
+		D_DEBUG(DB_IO, DF_OID" shard re-direct %d -> %d for degrade fetch.\n",
+			DP_OID(obj->cob_md.omd_id), grp_start + tgt_idx, grp_start + ec_deg_tgt);
+
+		/* Update the tgt map */
+		D_ASSERT(is_ec_parity_shard(grp_start + ec_deg_tgt,
+					    obj_ec_dkey_hash_get(obj, obj_auxi->dkey_hash), oca));
+		clrbit(tgt_bitmap, tgt_idx);
+		toiod = obj_ec_tgt_oiod_get(obj_auxi->reasb_req.tgt_oiods,
+					    obj_auxi->reasb_req.orr_tgt_nr, tgt_idx);
+		D_ASSERTF(toiod != NULL, "tgt idx %u\n", tgt_idx);
+
+		toiod->oto_tgt_idx = ec_deg_tgt;
+		setbit(tgt_bitmap, ec_deg_tgt);
+
+		obj_auxi->reset_param = 1;
+		obj_auxi->ec_degrade_fetch = 1;
+	}
+
+	/* EC fetch will follow the tgt_bitmap, shard_cnt will be set to group size here */
+	*shard = obj_ec_shard_idx(obj_ec_dkey_hash_get(obj, obj_auxi->dkey_hash), oca, 0) +
+				  grp_start;
+	*shard_cnt = daos_oclass_grp_size(oca);
+out:
+	return rc;
+}
+
+static int
+obj_replica_fetch_shards_get(struct dc_object *obj, struct obj_auxi_args *obj_auxi,
+			     uint32_t map_ver, uint32_t *shard, uint32_t *shard_cnt)
+{
+	bool	to_leader = obj_auxi->to_leader;
+	int	grp_idx;
+	int	rc;
+
+	D_ASSERT(!obj_is_ec(obj));
+	grp_idx = obj_dkey2grpidx(obj, obj_auxi->dkey_hash, map_ver);
+	if (grp_idx < 0)
+		return grp_idx;
+
+	if (!to_leader && obj->cob_time_fetch_leader != NULL &&
+	    obj->cob_time_fetch_leader[grp_idx] != 0 &&
+	    OBJ_FETCH_LEADER_INTERVAL >=
+	    daos_gettime_coarse() - obj->cob_time_fetch_leader[grp_idx])
+		to_leader = true;
+
+	if (to_leader)
+		rc = obj_replica_leader_select(obj, grp_idx, map_ver);
+	else
+		rc = obj_grp_valid_shard_get(obj, grp_idx, map_ver, obj_auxi->failed_tgt_list);
+
+	if (rc < 0)
+		return rc;
+
+	*shard_cnt = 1;
+	*shard = rc;
 	return 0;
+}
+
+static int
+obj_fetch_shards_get(struct dc_object *obj, daos_obj_fetch_t *args, unsigned int map_ver,
+		     struct obj_auxi_args *obj_auxi, uint32_t *shard, uint32_t *shard_cnt)
+{
+	int rc = 0;
+
+	/* Choose the shards to forward the fetch request */
+	if (obj_auxi->spec_shard) {  /* special read */
+		int grp_idx;
+
+		D_ASSERT(!obj_auxi->to_leader);
+
+		if (args->extra_arg != NULL) {
+			*shard = *(int *)args->extra_arg;
+		} else if (obj_auxi->io_retry) {
+			*shard = obj_auxi->specified_shard;
+		} else {
+			*shard = daos_fail_value_get();
+			obj_auxi->specified_shard = *shard;
+		}
+		*shard_cnt = 1;
+
+		/* Check if the special shard match the dkey */
+		grp_idx = obj_dkey2grpidx(obj, obj_auxi->dkey_hash, map_ver);
+		if (grp_idx < 0)
+			D_GOTO(out, rc = grp_idx);
+
+		if (*shard < grp_idx * obj->cob_grp_size ||
+		    *shard >= (grp_idx + 1) * obj->cob_grp_size) {
+			rc = -DER_INVAL;
+			D_ERROR("Fetch from invalid shard, grp size %u, shards_nr %u, "
+				"grp idx %u, given shard %u, dkey hash %lu: "DF_RC"\n",
+				obj->cob_grp_size, obj->cob_shards_nr, grp_idx,
+				*shard, obj_auxi->dkey_hash, DP_RC(rc));
+			D_GOTO(out, rc);
+		}
+	} else if (obj_is_ec(obj)) {
+		rc = obj_ec_fetch_shards_get(obj, args, map_ver, obj_auxi, shard, shard_cnt);
+		if (rc)
+			D_GOTO(out, rc);
+	} else if ((obj_auxi->csum_retry || obj_auxi->tx_uncertain)) {
+		*shard_cnt = 1;
+		rc = obj_retry_next_shard(obj, obj_auxi, map_ver, shard);
+		if (rc)
+			D_GOTO(out, rc);
+	} else {
+		rc = obj_replica_fetch_shards_get(obj, obj_auxi, map_ver, shard, shard_cnt);
+		if (rc < 0)
+			D_GOTO(out, rc);
+	}
+out:
+	D_DEBUG(DB_IO, DF_OID" shard/shard_cnt %u/%u special %s leader %s\n",
+		DP_OID(obj->cob_md.omd_id), *shard, *shard_cnt, obj_auxi->spec_shard ? "yes" : "no",
+		obj_auxi->to_leader ? "yes" : "no");
+	return rc;
 }
 
 int
@@ -4906,11 +4873,11 @@ dc_obj_fetch_task(tse_task_t *task)
 	struct obj_auxi_args	*obj_auxi;
 	struct dc_object	*obj;
 	uint8_t                 *tgt_bitmap = NIL_BITMAP;
-	unsigned int		 map_ver = 0;
-	uint64_t		 dkey_hash;
-	struct dtx_epoch	 epoch;
-	uint32_t		 shard = 0;
-	int			 rc;
+	unsigned int		map_ver = 0;
+	struct dtx_epoch	epoch;
+	uint32_t		shard = 0;
+	uint32_t		shard_cnt = 0;
+	int			rc;
 
 	rc = obj_req_valid(task, args, DAOS_OBJ_RPC_FETCH, &epoch, &map_ver,
 			   &obj);
@@ -4931,9 +4898,6 @@ dc_obj_fetch_task(tse_task_t *task)
 		if ((args->extra_flags & DIOF_EC_RECOV_SNAP) != 0)
 			obj_auxi->reasb_req.orr_recov_snap = 1;
 	}
-	if (obj_auxi->ec_wait_recov)
-		goto out_task;
-
 	if (args->extra_flags & DIOF_FOR_MIGRATION) {
 		obj_auxi->flags |= ORF_FOR_MIGRATION;
 		obj_auxi->no_retry = 1;
@@ -4944,21 +4908,12 @@ dc_obj_fetch_task(tse_task_t *task)
 	if (args->extra_flags & DIOF_EC_RECOV_FROM_PARITY)
 		obj_auxi->flags |= ORF_EC_RECOV_FROM_PARITY;
 
-	if (args->extra_flags & DIOF_FOR_FORCE_DEGRADE)
+	if (args->extra_flags & DIOF_FOR_FORCE_DEGRADE ||
+	    DAOS_FAIL_CHECK(DAOS_OBJ_FORCE_DEGRADE))
 		obj_auxi->force_degraded = 1;
 
-	if (args->extra_flags & DIOF_CHECK_EXISTENCE) {
+	if (args->extra_flags & DIOF_CHECK_EXISTENCE)
 		obj_auxi->flags |= ORF_CHECK_EXISTENCE;
-	} else {
-		rc = obj_rw_req_reassemb(obj, args, &epoch, obj_auxi);
-		if (rc != 0) {
-			D_ERROR(DF_OID" obj_req_reassemb failed %d.\n",
-				DP_OID(obj->cob_md.omd_id), rc);
-			goto out_task;
-		}
-	}
-
-	dkey_hash = obj_dkey2hash(obj->cob_md.omd_id, args->dkey);
 
 	if (args->extra_arg == NULL &&
 	    DAOS_FAIL_CHECK(DAOS_OBJ_SPECIAL_SHARD))
@@ -4966,40 +4921,31 @@ dc_obj_fetch_task(tse_task_t *task)
 
 	obj_auxi->spec_shard = (args->extra_flags & DIOF_TO_SPEC_SHARD) != 0;
 	obj_auxi->spec_group = (args->extra_flags & DIOF_TO_SPEC_GROUP) != 0;
+	obj_auxi->to_leader = (args->extra_flags & DIOF_TO_LEADER) != 0;
 
-	if (obj_auxi->spec_shard) {
-		D_ASSERT(!obj_auxi->to_leader);
+	obj_auxi->dkey_hash = obj_dkey2hash(obj->cob_md.omd_id, args->dkey);
+	obj_auxi->iod_nr = args->nr;
 
-		if (args->extra_arg != NULL) {
-			shard = *(int *)args->extra_arg;
-		} else if (obj_auxi->io_retry) {
-			shard = obj_auxi->specified_shard;
-		} else {
-			shard = daos_fail_value_get();
-			obj_auxi->specified_shard = shard;
+	if (obj_auxi->ec_wait_recov)
+		goto out_task;
+
+	if (obj_is_ec(obj)) {
+		rc = obj_rw_req_reassemb(obj, args, &epoch, obj_auxi);
+		if (rc != 0) {
+			D_ERROR(DF_OID" obj_req_reassemb failed %d.\n",
+				DP_OID(obj->cob_md.omd_id), rc);
+			D_GOTO(out_task, rc);
 		}
-	} else {
-		obj_auxi->to_leader = (args->extra_flags & DIOF_TO_LEADER) != 0;
+		tgt_bitmap = obj_auxi->reasb_req.tgt_bitmap;
 	}
 
-	if ((obj_auxi->csum_retry || obj_auxi->tx_uncertain) &&
-	    !obj_auxi->is_ec_obj) {
-		rc = obj_retry_next_shard(obj, obj_auxi, dkey_hash, map_ver);
-		if (rc)
-			goto out_task;
+	rc = obj_fetch_shards_get(obj, args, map_ver, obj_auxi, &shard, &shard_cnt);
+	if (rc)
+		D_GOTO(out_task, rc);
 
-		tgt_bitmap = obj_auxi->retry_bitmap;
-	} else {
-		if (obj_auxi->is_ec_obj)
-			tgt_bitmap = obj_auxi->reasb_req.tgt_bitmap;
-	}
-
-	if (args->extra_flags & DIOF_CHECK_EXISTENCE)
-		tgt_bitmap = NIL_BITMAP;
-
-	rc = obj_req_get_tgts(obj, (int *)&shard, args->dkey, dkey_hash,
-			      tgt_bitmap, map_ver, obj_auxi->to_leader,
-			      obj_auxi->spec_shard, obj_auxi);
+	/* Map the shard to forward targets */
+	rc = obj_shards_2_fwtgts(obj, map_ver, tgt_bitmap, shard, shard_cnt, 1,
+				 OBJ_TGT_FLAG_CLI_DISPATCH, obj_auxi);
 	if (rc != 0)
 		D_GOTO(out_task, rc);
 
@@ -5010,15 +4956,14 @@ dc_obj_fetch_task(tse_task_t *task)
 	}
 
 	if (!obj_auxi->io_retry && !obj_auxi->is_ec_obj)
-		obj_auxi->initial_shard =
-			obj_auxi->req_tgts.ort_shard_tgts[0].st_shard;
+		obj_auxi->initial_shard = obj_auxi->req_tgts.ort_shard_tgts[0].st_shard;
 
 	rc = obj_rw_bulk_prep(obj, args->iods, args->sgls, args->nr,
 			      false, false, task, obj_auxi);
 	if (rc != 0)
-		goto out_task;
+		D_GOTO(out_task, rc);
 
-	rc = obj_req_fanout(obj, obj_auxi, dkey_hash, map_ver, &epoch,
+	rc = obj_req_fanout(obj, obj_auxi, map_ver, &epoch,
 			    shard_rw_prep, dc_obj_shard_rw, task);
 	return rc;
 
@@ -5028,12 +4973,57 @@ out_task:
 }
 
 static int
+obj_update_shards_get(struct dc_object *obj, daos_obj_fetch_t *args, unsigned int map_ver,
+		      struct obj_auxi_args *obj_auxi, uint32_t *shard, uint32_t *shard_cnt)
+{
+	uint8_t		*tgt_bitmap;
+	uint32_t	failure_cnt = 0;
+	int		i;
+	int		rc;
+
+	rc = obj_dkey2grpmemb(obj, obj_auxi->dkey_hash, map_ver, shard, shard_cnt);
+	if (rc || !obj_is_ec(obj))
+		return rc;
+
+	tgt_bitmap = obj_auxi->reasb_req.tgt_bitmap;
+	for (i = 0; i < *shard_cnt; i++) {
+		int shard_idx;
+
+		if (isclr(tgt_bitmap, i))
+			continue;
+
+		shard_idx = *shard + i;
+		D_ASSERTF(shard_idx < obj->cob_shards_nr, "%d >= %u\n",
+			  shard_idx, obj->cob_shards_nr);
+
+		if (obj->cob_shards->do_shards[shard_idx].do_target_id == -1 ||
+		    obj->cob_shards->do_shards[shard_idx].do_shard == -1 ||
+		    unlikely(DAOS_FAIL_CHECK(DAOS_FAIL_SHARD_NONEXIST))) {
+			if (tgt_bitmap != NIL_BITMAP) {
+				if (++failure_cnt > obj_ec_parity_tgt_nr(obj_get_oca(obj))) {
+					D_ERROR(DF_OID" failures %u is more than parity cnt.\n",
+						DP_OID(obj->cob_md.omd_id), failure_cnt);
+					D_GOTO(out, rc = -DER_IO);
+				}
+				D_DEBUG(DB_IO, DF_OID" skip shard %d\n", DP_OID(obj->cob_md.omd_id),
+					shard_idx);
+				clrbit(tgt_bitmap, i);
+			}
+		}
+	}
+out:
+	return rc;
+}
+
+static int
 dc_obj_update(tse_task_t *task, struct dtx_epoch *epoch, uint32_t map_ver,
 	      daos_obj_update_t *args, struct dc_object *obj)
 {
 	struct obj_auxi_args	*obj_auxi;
-	uint64_t		 dkey_hash;
-	int			 rc;
+	uint8_t			*tgt_bitmap = NIL_BITMAP;
+	uint32_t		shard;
+	uint32_t		shard_cnt;
+	int			rc;
 
 	rc = obj_task_init(task, DAOS_OBJ_RPC_UPDATE, map_ver, args->th,
 			   &obj_auxi, obj);
@@ -5058,17 +5048,24 @@ dc_obj_update(tse_task_t *task, struct dtx_epoch *epoch, uint32_t map_ver,
 		return dc_tx_convert(obj, DAOS_OBJ_RPC_UPDATE, task);
 	}
 
-	rc = obj_rw_req_reassemb(obj, args, NULL, obj_auxi);
-	if (rc) {
-		D_ERROR(DF_OID" obj_req_reassemb failed %d.\n",
-			DP_OID(obj->cob_md.omd_id), rc);
-		D_GOTO(out_task, rc);
+	obj_auxi->dkey_hash = obj_dkey2hash(obj->cob_md.omd_id, args->dkey);
+	obj_auxi->iod_nr = args->nr;
+	if (obj_is_ec(obj)) {
+		rc = obj_rw_req_reassemb(obj, args, NULL, obj_auxi);
+		if (rc) {
+			D_ERROR(DF_OID" obj_req_reassemb failed %d.\n",
+				DP_OID(obj->cob_md.omd_id), rc);
+			D_GOTO(out_task, rc);
+		}
+		tgt_bitmap = obj_auxi->reasb_req.tgt_bitmap;
 	}
 
-	dkey_hash = obj_dkey2hash(obj->cob_md.omd_id, args->dkey);
-	rc = obj_req_get_tgts(obj, NULL, args->dkey, dkey_hash,
-			      obj_auxi->reasb_req.tgt_bitmap, map_ver, false,
-			      false, obj_auxi);
+	rc = obj_update_shards_get(obj, args, map_ver, obj_auxi, &shard, &shard_cnt);
+	if (rc != 0)
+		D_GOTO(out_task, rc);
+
+	rc = obj_shards_2_fwtgts(obj, map_ver, tgt_bitmap, shard, shard_cnt, 1,
+				 OBJ_TGT_FLAG_FW_LEADER_INFO, obj_auxi);
 	if (rc != 0)
 		D_GOTO(out_task, rc);
 
@@ -5093,14 +5090,14 @@ dc_obj_update(tse_task_t *task, struct dtx_epoch *epoch, uint32_t map_ver,
 		obj_auxi->flags |= ORF_DTX_SYNC;
 
 	D_DEBUG(DB_IO, "update "DF_OID" dkey_hash "DF_U64"\n",
-		DP_OID(obj->cob_md.omd_id), dkey_hash);
+		DP_OID(obj->cob_md.omd_id), obj_auxi->dkey_hash);
 
 	rc = obj_rw_bulk_prep(obj, args->iods, args->sgls, args->nr, true,
 			      obj_auxi->req_tgts.ort_srv_disp, task, obj_auxi);
 	if (rc != 0)
 		goto out_task;
 
-	rc = obj_req_fanout(obj, obj_auxi, dkey_hash, map_ver, epoch,
+	rc = obj_req_fanout(obj, obj_auxi, map_ver, epoch,
 			    shard_rw_prep, dc_obj_shard_rw, task);
 	return rc;
 
@@ -5287,6 +5284,7 @@ sub_anchors_prep(struct obj_auxi_args *obj_auxi, int shards_nr)
 		nr /= shards_nr;
 	}
 
+	obj_auxi->sub_anchors = 1;
 	sub_anchors = obj_get_sub_anchors(obj_args, obj_auxi->opc);
 	if (sub_anchors != NULL)
 		return shard_anchors_check_alloc_bufs(obj_auxi, sub_anchors, shards_nr, nr,
@@ -5316,6 +5314,8 @@ obj_shard_list_prep(struct obj_auxi_args *obj_auxi, struct dc_object *obj,
 	D_ASSERT(sub_anchors != NULL);
 	shard_arg->la_nr = sub_anchors->sa_nr;
 	idx = shard_arg->la_auxi.shard % obj_get_grp_size(obj);
+	idx = obj_ec_shard_off(obj_ec_dkey_hash_get(obj, obj_auxi->dkey_hash),
+			       &obj->cob_oca, idx);
 	if (shard_arg->la_sgl == NULL && obj_args->sgl != NULL)
 		shard_arg->la_sgl = &sub_anchors->sa_anchors[idx].ssa_sgl;
 	if (shard_arg->la_kds == NULL && obj_args->kds != NULL)
@@ -5323,6 +5323,9 @@ obj_shard_list_prep(struct obj_auxi_args *obj_auxi, struct dc_object *obj,
 	if (shard_arg->la_recxs == NULL && obj_args->recxs)
 		shard_arg->la_recxs = sub_anchors->sa_anchors[idx].ssa_recxs;
 
+	D_DEBUG(DB_TRACE, DF_OID" shard %d idx %d kds %p sgl %p\n",
+		DP_OID(obj->cob_md.omd_id), shard_arg->la_auxi.shard, idx,
+		shard_arg->la_kds, shard_arg->la_sgl);
 	if (obj_args->anchor) {
 		if (shard_arg->la_anchor == NULL) {
 			D_ALLOC_PTR(shard_arg->la_anchor);
@@ -5367,21 +5370,17 @@ out:
 
 static int
 shard_list_prep(struct shard_auxi_args *shard_auxi, struct dc_object *obj,
-		struct obj_auxi_args *obj_auxi, uint64_t dkey_hash,
-		uint32_t grp_idx)
+		struct obj_auxi_args *obj_auxi, uint32_t grp_idx)
 {
-	struct daos_oclass_attr	*oca;
 	daos_obj_list_t		*obj_args;
 	struct shard_list_args	*shard_arg;
 
 	obj_args = dc_task_get_args(obj_auxi->obj_task);
 	shard_arg = container_of(shard_auxi, struct shard_list_args, la_auxi);
-	shard_arg->la_api_args = obj_args;
-	oca = obj_get_oca(obj);
-	if (obj_auxi->is_ec_obj && !obj_auxi->spec_shard &&
-	    (shard_auxi->shard % obj_get_grp_size(obj) < obj_ec_data_tgt_nr(oca))) {
+	if (obj_auxi->sub_anchors) {
 		int	rc;
 
+		D_ASSERT(obj_auxi->is_ec_obj);
 		rc = obj_shard_list_prep(obj_auxi, obj, shard_arg);
 		if (rc) {
 			D_ERROR(DF_OID" shard list %d prep: %d\n",
@@ -5401,197 +5400,201 @@ shard_list_prep(struct shard_auxi_args *shard_auxi, struct dc_object *obj,
 	return 0;
 }
 
-static void
-obj_ec_get_parity_shards(struct dc_object *obj, int grp_idx,
-			 int parity_tgt_nr, int data_tgt_nr,
-			 int *parities)
-{
-	unsigned int	shard_idx;
-	unsigned int	grp_size;
-	int		idx = 0;
-
-	grp_size = obj_get_grp_size(obj);
-	D_ASSERT(grp_size > 0);
-
-	shard_idx = grp_size * grp_idx +
-		    data_tgt_nr + parity_tgt_nr - 1;
-	while (shard_idx % grp_size >= data_tgt_nr)
-		parities[idx++] = shard_idx--;
-}
-
+/* Get random parity from one group for the EC object */
 static int
-obj_ec_list_get_shard(struct obj_auxi_args *obj_auxi, unsigned int map_ver,
-		      int grp_idx, daos_obj_list_t *args)
+obj_ec_random_parity_get(struct dc_object *obj, uint64_t dkey_hash, int grp)
 {
-	int			parities[OBJ_EC_MAX_P] = { 0 };
-	struct dc_object	*obj = obj_auxi->obj;
 	struct daos_oclass_attr *oca;
 	int			shard = -DER_NONEXIST;
 	int			p_size;
-	unsigned int		first;
+	int			grp_size;
 	int			idx;
 	int			i;
 
 	oca = obj_get_oca(obj);
-	obj_ec_get_parity_shards(obj, grp_idx, obj_ec_parity_tgt_nr(oca),
-				 obj_ec_data_tgt_nr(oca), parities);
-	if (likely(!DAOS_FAIL_CHECK(DAOS_OBJ_SKIP_PARITY))) {
-		if (obj_auxi->to_leader) {
-			/* proper way to choose leader ? XXX */
-			shard = parities[0];
-			D_GOTO(out, shard);
-		}
+	D_ASSERT(daos_oclass_is_ec(obj_get_oca(obj)));
+	p_size = obj_ec_parity_tgt_nr(oca);
+	grp_size = obj_get_grp_size(obj);
+	idx = (d_rand() % p_size + obj_ec_parity_start(dkey_hash, oca)) % grp_size;
+	for (i = 0; i < p_size; i++, idx = (idx + 1) % grp_size) {
+		struct pl_obj_shard *p_shard;
 
-		/* choose one randomly from the parities */
-		p_size = obj_ec_parity_tgt_nr(oca);
-		idx = d_rand() % p_size;
-		for (i = 0; i < p_size; i++, idx = (idx + 1) % p_size) {
-			/* let's skip the rebuild shard for non-update op */
-			shard = parities[idx];
+		shard = grp_size * grp + idx;
+		p_shard = obj_get_shard(obj, shard);
+		if (p_shard->po_rebuilding || p_shard->po_target == -1)
+			continue;
 
-			if (obj->cob_shards->do_shards[shard].do_rebuilding)
-				continue;
-
-			if (obj->cob_shards->do_shards[shard].do_target_id != -1)
-				break;
-		}
-
-		if (i < p_size) {
-			D_DEBUG(DB_IO, "choose parity shard %d\n", shard);
-			D_GOTO(out, shard);
-		}
+		D_DEBUG(DB_IO, "Choose parity shard %d grp %d\n", shard, grp);
+		break;
 	}
 
-	D_DEBUG(DB_IO, "let's choose from the data shard 0 for "DF_OID"\n",
-		DP_OID(obj->cob_md.omd_id));
-
-	/* Check if all data shard are in good state */
-	first = grp_idx * obj_get_grp_size(obj);
-	for (idx = first; idx < first + obj_ec_data_tgt_nr(oca); idx++) {
-		if (obj->cob_shards->do_shards[idx].do_rebuilding ||
-		    obj->cob_shards->do_shards[idx].do_target_id == -1)
-			break;
+	if (i == p_size) {
+		D_DEBUG(DB_IO, DF_OID" grp %d no parity shard available.\n",
+			DP_OID(obj->cob_md.omd_id), grp);
+		return -DER_NONEXIST;
 	}
 
-	if (idx < first + obj_ec_data_tgt_nr(oca)) {
-		shard = -DER_DATA_LOSS;
-		D_ERROR("No shard on "DF_OID"\n", DP_OID(obj->cob_md.omd_id));
-	} else {
-		shard = first;
-	}
-out:
-	D_DEBUG(DB_IO, "grp_idx %d, get shard %d on "DF_OID"\n", grp_idx, shard,
-		DP_OID(obj->cob_md.omd_id));
 	return shard;
 }
 
 static int
-obj_list_get_shard(struct obj_auxi_args *obj_auxi, unsigned int map_ver,
-		   daos_obj_list_t *args)
+obj_ec_list_get_shard(struct obj_auxi_args *obj_auxi, unsigned int map_ver,
+		      int grp_idx, daos_obj_list_t *args, uint32_t *shard_cnt)
 {
-	struct pl_obj_shard	*p_shard;
+	struct dc_object	*obj = obj_auxi->obj;
+	struct daos_oclass_attr *oca;
+	int			i;
+	int			grp_start;
+	int			shard;
+	unsigned int		first;
+
+	oca = obj_get_oca(obj);
+	if (args->dkey == NULL && obj->cob_ec_parity_rotate) {
+		/**
+		 * Normally, it only needs to enumerate from tgt_nr - parity_nr,
+		 * but then if enumeration is shifted to others shards due to
+		 * the failure, if might cause duplicate keys, which is not easy
+		 * to resolve, so let's enumerate from all shards in this case.
+		 */
+		*shard_cnt = obj_ec_tgt_nr(oca);
+		shard = grp_idx * obj_get_grp_size(obj);
+		D_GOTO(out, shard);
+	}
+
+	if (likely(!DAOS_FAIL_CHECK(DAOS_OBJ_SKIP_PARITY))) {
+		*shard_cnt = 1;
+		if (obj_auxi->to_leader) {
+			shard = obj_ec_leader_select(obj, grp_idx, map_ver,
+						     obj_ec_dkey_hash_get(obj, obj_auxi->dkey_hash),
+						     NIL_BITMAP);
+			if (args->dkey == NULL) {
+				uint64_t dkey_hash = obj_ec_dkey_hash_get(obj_auxi->obj,
+									  obj_auxi->dkey_hash);
+
+				if (is_ec_data_shard(shard, dkey_hash, oca))
+					*shard_cnt = obj_ec_data_tgt_nr(oca);
+			}
+			D_GOTO(out, shard);
+		}
+
+		shard = obj_ec_random_parity_get(obj, obj_ec_dkey_hash_get(obj,
+									   obj_auxi->dkey_hash),
+						 grp_idx);
+		if (shard >= 0)
+			D_GOTO(out, shard);
+	}
+
+	grp_start = grp_idx * obj_get_grp_size(obj);
+	first = obj_ec_shard_idx(obj_ec_dkey_hash_get(obj, obj_auxi->dkey_hash), oca, 0);
+	D_DEBUG(DB_IO, "let's choose from the data shard %u for "DF_OID"\n",
+		first, DP_OID(obj->cob_md.omd_id));
+
+	/* Check if all data shard are in good state */
+	for (i = 0; i < obj_ec_data_tgt_nr(oca); i++) {
+		int shard_idx;
+
+		shard_idx = grp_start + (first + i) % obj_get_grp_size(obj);
+		if (obj_shard_is_invalid(obj, shard_idx)) {
+			shard = -DER_DATA_LOSS;
+			D_ERROR("shard %d on "DF_OID" "DF_RC"\n", shard_idx,
+				DP_OID(obj->cob_md.omd_id), DP_RC(shard));
+			D_GOTO(out, shard);
+		}
+	}
+
+	shard = first + grp_start;
+	*shard_cnt = obj_ec_data_tgt_nr(oca);
+out:
+	D_DEBUG(DB_IO, "grp_idx %d, get shard/cnt %d/%d on "DF_OID"\n", grp_idx, shard,
+		*shard_cnt, DP_OID(obj->cob_md.omd_id));
+	return shard;
+}
+
+static int
+obj_list_shards_get(struct obj_auxi_args *obj_auxi, unsigned int map_ver,
+		    daos_obj_list_t *args, uint32_t *shard, uint32_t *shard_cnt)
+{
 	struct dc_object	*obj = obj_auxi->obj;
 	int			grp_idx = 0;
-	int			shard = 0;
-
-	if (args->dkey_anchor != NULL &&
-	    daos_anchor_get_flags(args->dkey_anchor) & DIOF_TO_LEADER)
-		obj_auxi->to_leader = 1;
+	int			rc = 0;
 
 	if (DAOS_FAIL_CHECK(DAOS_OBJ_SPECIAL_SHARD)) {
 		if (obj_auxi->io_retry) {
-			shard = obj_auxi->specified_shard;
+			*shard = obj_auxi->specified_shard;
 		} else {
-			shard = daos_fail_value_get();
-			obj_auxi->specified_shard = shard;
+			*shard = daos_fail_value_get();
+			obj_auxi->specified_shard = *shard;
 		}
-
-		D_DEBUG(DB_IO, DF_OID" spec shard %d\n",
-			DP_OID(obj->cob_md.omd_id), shard);
+		*shard_cnt = 1;
 
 		obj_auxi->spec_shard = 1;
-		obj_auxi->spec_group = 0;
-
-		D_GOTO(out, shard);
+		D_DEBUG(DB_IO, DF_OID" spec shard %u\n", DP_OID(obj->cob_md.omd_id), *shard);
+		return 0;
 	}
 
 	if (args->dkey_anchor != NULL &&
 	    daos_anchor_get_flags(args->dkey_anchor) & DIOF_TO_SPEC_SHARD) {
-		shard = dc_obj_anchor2shard(args->dkey_anchor);
-		obj_auxi->specified_shard = shard;
-		obj_auxi->spec_shard = 1;
-		obj_auxi->spec_group = 0;
+		*shard = dc_obj_anchor2shard(args->dkey_anchor);
+		obj_auxi->specified_shard = *shard;
+		*shard_cnt = 1;
 
-		D_GOTO(out, shard);
+		obj_auxi->spec_shard = 1;
+		D_DEBUG(DB_IO, DF_OID" spec shard %u\n", DP_OID(obj->cob_md.omd_id), *shard);
+		return 0;
 	}
 
 	if (args->dkey_anchor != NULL &&
 	    daos_anchor_get_flags(args->dkey_anchor) & DIOF_TO_SPEC_GROUP) {
-		shard = dc_obj_anchor2shard(args->dkey_anchor);
-		obj_auxi->spec_shard = 0;
+		*shard = dc_obj_anchor2shard(args->dkey_anchor);
 		obj_auxi->spec_group = 1;
-		grp_idx = shard / obj_get_replicas(obj);
+		grp_idx = *shard / obj_get_grp_size(obj);
 	} else {
-		uint64_t dkey_hash;
-
-		obj_auxi->spec_shard = 0;
-		obj_auxi->spec_group = 0;
-
 		if (args->dkey != NULL) {
-			dkey_hash = obj_dkey2hash(obj->cob_md.omd_id,
-						  args->dkey);
-			grp_idx = obj_dkey2grpidx(obj, dkey_hash, map_ver);
+			grp_idx = obj_dkey2grpidx(obj, obj_auxi->dkey_hash, map_ver);
+			if (grp_idx < 0) {
+				D_ERROR(DF_OID" can not find grp %d\n",
+					DP_OID(obj->cob_md.omd_id), grp_idx);
+				D_GOTO(out, rc = grp_idx);
+			}
 		} else {
 			D_ASSERT(args->dkey_anchor != NULL);
 			grp_idx = dc_obj_anchor2shard(args->dkey_anchor) /
 				  obj_get_replicas(obj);
 		}
-
-		if (grp_idx < 0) {
-			D_ERROR(DF_OID" can not find grp %d\n",
-				DP_OID(obj->cob_md.omd_id), grp_idx);
-			return grp_idx;
-		}
 	}
 
 	if (obj_auxi->is_ec_obj) {
-		shard = obj_ec_list_get_shard(obj_auxi, map_ver, grp_idx, args);
+		rc = obj_ec_list_get_shard(obj_auxi, map_ver, grp_idx, args, shard_cnt);
 	} else {
+		*shard_cnt = 1;
 		if (obj_auxi->to_leader) {
-			shard = obj_grp_leader_get(obj, grp_idx,
-						   map_ver, NIL_BITMAP);
+			rc = obj_replica_leader_select(obj, grp_idx, map_ver);
 		} else {
-			shard = obj_grp_valid_shard_get(obj, grp_idx, map_ver,
-							obj_auxi->failed_tgt_list);
-			if (shard == -DER_NONEXIST) {
+			rc = obj_grp_valid_shard_get(obj, grp_idx, map_ver,
+						     obj_auxi->failed_tgt_list);
+			if (rc == -DER_NONEXIST) {
 				D_ERROR(DF_OID" can not find any shard %d\n",
-					DP_OID(obj->cob_md.omd_id),
-					-DER_DATA_LOSS);
-				shard = -DER_DATA_LOSS;
+					DP_OID(obj->cob_md.omd_id), -DER_DATA_LOSS);
+				D_GOTO(out, rc = -DER_DATA_LOSS);
 			}
 		}
 	}
 
-	D_DEBUG(DB_IO, DF_OID" grp/shard %d/%d\n", DP_OID(obj->cob_md.omd_id),
-		grp_idx, shard);
-	if (shard < 0) {
-		D_ERROR(DF_OID" Can not find shard grp %d: %d\n",
-			DP_OID(obj->cob_md.omd_id), grp_idx, shard);
-		D_GOTO(out, shard);
+	if (rc < 0) {
+		D_ERROR(DF_OID" Can not find shard grp %d: "DF_RC"\n",
+			DP_OID(obj->cob_md.omd_id), grp_idx, DP_RC(rc));
+		D_GOTO(out, rc);
 	}
 
-	p_shard = obj_get_shard(obj, shard);
-	if (p_shard->po_rebuilding || p_shard->po_target == -1) {
-		D_DEBUG(DB_IO, DF_OID".%d is being rebuilt rebuild %d/%d\n",
-			DP_OID(obj->cob_md.omd_id), shard, p_shard->po_rebuilding,
-			p_shard->po_target);
-		D_GOTO(out, shard = -DER_NOTAPPLICABLE);
-	}
+	*shard = rc;
+	D_DEBUG(DB_IO, DF_OID" grp/shard/shard_cnt %d/%u/%u\n", DP_OID(obj->cob_md.omd_id),
+		grp_idx, *shard, *shard_cnt);
+
 out:
-	D_DEBUG(DB_IO, DF_OID" list on shard %d leader %s\n",
-		DP_OID(obj->cob_md.omd_id), shard,
-		obj_auxi->to_leader ? "yes" : "no");
-	return shard;
+	D_DEBUG(DB_IO, DF_OID" list on shard %u leader %s: "DF_RC"\n",
+		DP_OID(obj->cob_md.omd_id), *shard,
+		obj_auxi->to_leader ? "yes" : "no", DP_RC(rc));
+	return rc;
 }
 
 static int
@@ -5599,12 +5602,11 @@ obj_list_common(tse_task_t *task, int opc, daos_obj_list_t *args)
 {
 	struct dc_object	*obj;
 	struct obj_auxi_args	*obj_auxi;
-	unsigned int		 map_ver = 0;
-	uint64_t		 dkey_hash = 0;
-	struct dtx_epoch	 epoch = {0};
-	int			 shard = -1;
-	int			tgts_nr;
-	int			 rc;
+	unsigned int		map_ver = 0;
+	struct dtx_epoch	epoch = {0};
+	uint32_t		shard = 0;
+	uint32_t		shard_cnt = 0;
+	int			rc;
 
 	rc = obj_req_valid(task, args, opc, &epoch, &map_ver, &obj);
 	if (rc)
@@ -5616,30 +5618,20 @@ obj_list_common(tse_task_t *task, int opc, daos_obj_list_t *args)
 		D_GOTO(out_task, rc);
 	}
 
-	if (args->dkey_anchor != NULL &&
-	    daos_anchor_get_flags(args->dkey_anchor) & DIOF_FOR_MIGRATION)
-		obj_auxi->no_retry = 1;
+	if (args->dkey_anchor != NULL) {
+		if (daos_anchor_get_flags(args->dkey_anchor) & DIOF_FOR_MIGRATION)
+			obj_auxi->no_retry = 1;
 
-	if (args->dkey_anchor != NULL &&
-	    daos_anchor_get_flags(args->dkey_anchor) & DIOF_FOR_FORCE_DEGRADE)
-		obj_auxi->force_degraded = 1;
+		if (daos_anchor_get_flags(args->dkey_anchor) & DIOF_FOR_FORCE_DEGRADE ||
+		    DAOS_FAIL_CHECK(DAOS_OBJ_FORCE_DEGRADE))
+			obj_auxi->force_degraded = 1;
 
-	if (obj_is_ec(obj)) {
-		obj_auxi->is_ec_obj = 1;
-		if (obj_auxi->io_retry) {
-			/* Since enumeration retry might retry to send multiple
-			 * shards, remove the original shard fetch tasks and will
-			 * recreate new shard fetch tasks with new parameters.
-			 */
-			D_DEBUG(DB_IO, DF_OID" retrying enumeration.\n",
-				DP_OID(obj->cob_md.omd_id));
-			obj_io_set_new_shard_task(obj_auxi);
-		}
+		if (daos_anchor_get_flags(args->dkey_anchor) & DIOF_TO_LEADER)
+			obj_auxi->to_leader = 1;
 	}
 
-	shard = obj_list_get_shard(obj_auxi, map_ver, args);
-	if (shard < 0)
-		D_GOTO(out_task, rc = shard);
+	if (args->dkey)
+		obj_auxi->dkey_hash = obj_dkey2hash(obj->cob_md.omd_id, args->dkey);
 
 	/* reset kd_key_len to 0, since it may return the required size, see
 	 * obj_shard_comp_cb.
@@ -5647,16 +5639,17 @@ obj_list_common(tse_task_t *task, int opc, daos_obj_list_t *args)
 	if (args->kds)
 		args->kds[0].kd_key_len = 0;
 
-	rc = obj_req_get_tgts(obj, &shard, args->dkey, dkey_hash, NIL_BITMAP, map_ver,
-			      obj_auxi->to_leader, obj_auxi->spec_shard, obj_auxi);
-	if (rc != 0)
-		goto out_task;
+	rc = obj_list_shards_get(obj_auxi, map_ver, args, &shard, &shard_cnt);
+	if (rc < 0)
+		D_GOTO(out_task, rc);
 
-	tgts_nr = obj_auxi->req_tgts.ort_srv_disp ?
-		  obj_auxi->req_tgts.ort_grp_nr :
-		  obj_auxi->req_tgts.ort_grp_nr * obj_auxi->req_tgts.ort_grp_size;
-	if (tgts_nr > 1) {
-		rc = sub_anchors_prep(obj_auxi, tgts_nr);
+	rc = obj_shards_2_fwtgts(obj, map_ver, NIL_BITMAP, shard, shard_cnt,
+				 1, OBJ_TGT_FLAG_CLI_DISPATCH, obj_auxi);
+	if (rc != 0)
+		D_GOTO(out_task, rc);
+
+	if (shard_cnt > 1) {
+		rc = sub_anchors_prep(obj_auxi, shard_cnt);
 		if (rc)
 			D_GOTO(out_task, rc);
 	}
@@ -5672,10 +5665,10 @@ obj_list_common(tse_task_t *task, int opc, daos_obj_list_t *args)
 		daos_dti_gen(&obj_auxi->l_args.la_dti, true /* zero */);
 	}
 
-	D_DEBUG(DB_IO, "list opc %d "DF_OID" dkey %llu shard %d\n", opc,
-		DP_OID(obj->cob_md.omd_id), (unsigned long long)dkey_hash, shard);
+	D_DEBUG(DB_IO, "list opc %d "DF_OID" dkey "DF_U64" shard %u\n", opc,
+		DP_OID(obj->cob_md.omd_id), obj_auxi->dkey_hash, shard);
 
-	rc = obj_req_fanout(obj, obj_auxi, dkey_hash, map_ver, &epoch,
+	rc = obj_req_fanout(obj, obj_auxi, map_ver, &epoch,
 			    shard_list_prep, dc_obj_shard_list, task);
 	return rc;
 
@@ -5730,10 +5723,8 @@ dc_obj_list_rec(tse_task_t *task)
 
 static int
 shard_punch_prep(struct shard_auxi_args *shard_auxi, struct dc_object *obj,
-		 struct obj_auxi_args *obj_auxi, uint64_t dkey_hash,
-		 uint32_t grp_idx)
+		 struct obj_auxi_args *obj_auxi, uint32_t grp_idx)
 {
-	daos_obj_punch_t	*obj_args;
 	struct shard_punch_args	*shard_arg;
 	daos_handle_t		 coh;
 	uuid_t			 coh_uuid;
@@ -5748,11 +5739,8 @@ shard_punch_prep(struct shard_auxi_args *shard_auxi, struct dc_object *obj,
 	if (rc != 0)
 		return rc;
 
-	obj_args = dc_task_get_args(obj_auxi->obj_task);
 	shard_arg = container_of(shard_auxi, struct shard_punch_args, pa_auxi);
-	shard_arg->pa_api_args		= obj_args;
 	shard_arg->pa_opc		= obj_auxi->opc;
-	shard_arg->pa_dkey_hash		= dkey_hash;
 	uuid_copy(shard_arg->pa_coh_uuid, coh_uuid);
 	uuid_copy(shard_arg->pa_cont_uuid, cont_uuid);
 
@@ -5770,8 +5758,10 @@ dc_obj_punch(tse_task_t *task, struct dc_object *obj, struct dtx_epoch *epoch,
 	     uint32_t map_ver, enum obj_rpc_opc opc, daos_obj_punch_t *api_args)
 {
 	struct obj_auxi_args	*obj_auxi;
-	uint64_t		 dkey_hash;
-	int			 rc;
+	uint32_t		shard;
+	uint32_t		shard_cnt;
+	uint32_t		grp_cnt;
+	int			rc;
 
 	if (opc == DAOS_OBJ_RPC_PUNCH && obj->cob_grp_nr > 1)
 		/* The object have multiple redundancy groups, use DAOS
@@ -5791,9 +5781,18 @@ dc_obj_punch(tse_task_t *task, struct dc_object *obj, struct dtx_epoch *epoch,
 		return dc_tx_convert(obj, opc, task);
 	}
 
-	dkey_hash = obj_dkey2hash(obj->cob_md.omd_id, api_args->dkey);
-	rc = obj_req_get_tgts(obj, NULL, api_args->dkey, dkey_hash, NIL_BITMAP,
-			      map_ver, false, false, obj_auxi);
+	if (opc == DAOS_OBJ_RPC_PUNCH) {
+		obj_ptr2shards(obj, &shard, &shard_cnt, &grp_cnt);
+	} else {
+		grp_cnt = 1;
+		obj_auxi->dkey_hash = obj_dkey2hash(obj->cob_md.omd_id, api_args->dkey);
+		rc = obj_dkey2grpmemb(obj, obj_auxi->dkey_hash, map_ver, &shard, &shard_cnt);
+		if (rc != 0)
+			D_GOTO(out_task, rc);
+	}
+
+	rc = obj_shards_2_fwtgts(obj, map_ver, NIL_BITMAP, shard, shard_cnt, grp_cnt,
+				 OBJ_TGT_FLAG_FW_LEADER_INFO, obj_auxi);
 	if (rc != 0)
 		D_GOTO(out_task, rc);
 
@@ -5805,10 +5804,10 @@ dc_obj_punch(tse_task_t *task, struct dc_object *obj, struct dtx_epoch *epoch,
 	if (obj_is_ec(obj))
 		obj_auxi->flags |= ORF_EC;
 
-	D_DEBUG(DB_IO, "punch "DF_OID" dkey %llu\n",
-		DP_OID(obj->cob_md.omd_id), (unsigned long long)dkey_hash);
+	D_DEBUG(DB_IO, "punch "DF_OID" dkey "DF_U64"\n",
+		DP_OID(obj->cob_md.omd_id), obj_auxi->dkey_hash);
 
-	rc = obj_req_fanout(obj, obj_auxi, dkey_hash, map_ver, epoch,
+	rc = obj_req_fanout(obj, obj_auxi, map_ver, epoch,
 			    shard_punch_prep, dc_obj_shard_punch, task);
 	return rc;
 
@@ -5879,8 +5878,6 @@ struct shard_query_key_args {
 	struct shard_auxi_args	 kqa_auxi;
 	uuid_t			 kqa_coh_uuid;
 	uuid_t			 kqa_cont_uuid;
-	daos_obj_query_key_t	*kqa_api_args;
-	uint64_t		 kqa_dkey_hash;
 	struct dtx_id		 kqa_dti;
 };
 
@@ -5893,10 +5890,11 @@ shard_query_key_task(tse_task_t *task)
 	struct dc_obj_shard		*obj_shard;
 	daos_handle_t			 th;
 	struct dtx_epoch		*epoch;
+	uint64_t			dkey_hash;
 	int				 rc;
 
 	args = tse_task_buf_embedded(task, sizeof(*args));
-	obj = args->kqa_auxi.obj;
+	obj = args->kqa_auxi.obj_auxi->obj;
 	th = args->kqa_auxi.obj_auxi->th;
 	epoch = &args->kqa_auxi.epoch;
 
@@ -5922,9 +5920,13 @@ shard_query_key_task(tse_task_t *task)
 		return rc;
 	}
 
-	tse_task_stack_push_data(task, &args->kqa_dkey_hash,
-				 sizeof(args->kqa_dkey_hash));
-	api_args = args->kqa_api_args;
+	if (obj_is_ec(obj))
+		dkey_hash = obj_ec_dkey_hash_get(obj, args->kqa_auxi.obj_auxi->dkey_hash);
+	else
+		dkey_hash = args->kqa_auxi.obj_auxi->dkey_hash;
+
+	tse_task_stack_push_data(task, &dkey_hash, sizeof(dkey_hash));
+	api_args = dc_task_get_args(args->kqa_auxi.obj_auxi->obj_task);
 	rc = dc_obj_shard_query_key(obj_shard, epoch, api_args->flags, obj,
 				    api_args->dkey, api_args->akey,
 				    api_args->recx, api_args->max_epoch, args->kqa_coh_uuid,
@@ -5940,10 +5942,9 @@ shard_query_key_task(tse_task_t *task)
 static int
 queue_shard_query_key_task(tse_task_t *api_task, struct obj_auxi_args *obj_auxi,
 			   struct dtx_epoch *epoch, int shard, unsigned int map_ver,
-			   struct dc_object *obj, uint64_t dkey_hash, struct dtx_id *dti,
+			   struct dc_object *obj, struct dtx_id *dti,
 			   uuid_t coh_uuid, uuid_t cont_uuid)
 {
-	daos_obj_query_key_t		*api_args = dc_task_get_args(api_task);
 	tse_sched_t			*sched = tse_task2sched(api_task);
 	tse_task_t			*task;
 	struct shard_query_key_args	*args;
@@ -5955,13 +5956,10 @@ queue_shard_query_key_task(tse_task_t *api_task, struct obj_auxi_args *obj_auxi,
 		return rc;
 
 	args = tse_task_buf_embedded(task, sizeof(*args));
-	args->kqa_api_args	= api_args;
 	args->kqa_auxi.epoch	= *epoch;
 	args->kqa_auxi.shard	= shard;
 	args->kqa_auxi.map_ver	= map_ver;
-	args->kqa_auxi.obj	= obj;
 	args->kqa_auxi.obj_auxi	= obj_auxi;
-	args->kqa_dkey_hash	= dkey_hash;
 	args->kqa_dti		= *dti;
 	uuid_copy(args->kqa_coh_uuid, coh_uuid);
 	uuid_copy(args->kqa_cont_uuid, cont_uuid);
@@ -5996,9 +5994,9 @@ dc_obj_query_key(tse_task_t *api_task)
 	daos_handle_t		coh;
 	uuid_t			coh_uuid;
 	uuid_t			cont_uuid;
-	int			shard_first;
+	int			grp_idx;
+	uint32_t		grp_nr;
 	unsigned int		map_ver = 0;
-	uint64_t		dkey_hash;
 	struct dtx_epoch	epoch;
 	struct dtx_id		dti;
 	int			i = 0;
@@ -6040,26 +6038,25 @@ dc_obj_query_key(tse_task_t *api_task)
 		D_GOTO(out_task, rc);
 
 	D_ASSERTF(api_args->dkey != NULL, "dkey should not be NULL\n");
-	dkey_hash = obj_dkey2hash(obj->cob_md.omd_id, api_args->dkey);
+	obj_auxi->dkey_hash = obj_dkey2hash(obj->cob_md.omd_id, api_args->dkey);
 	if (api_args->flags & DAOS_GET_DKEY) {
-		shard_first = 0;
+		grp_idx = 0;
 		/** set data len to 0 before retrieving dkey. */
 		api_args->dkey->iov_len = 0;
+		grp_nr = obj_get_grp_nr(obj);
 	} else {
-		/* For the specified dkey, only need to query one replica. */
-		shard_first = obj_dkey2shard(obj, dkey_hash, map_ver,
-					     obj_auxi->to_leader,
-					     obj_auxi->failed_tgt_list);
-		if (shard_first < 0)
-			D_GOTO(out_task, rc = shard_first);
+		grp_idx = obj_dkey2grpidx(obj, obj_auxi->dkey_hash, map_ver);
+		if (grp_idx < 0)
+			D_GOTO(out_task, rc = grp_idx);
+
+		grp_nr = 1;
 	}
 
 	obj_auxi->map_ver_reply = 0;
 	obj_auxi->map_ver_req = map_ver;
-	obj_auxi->obj_task = api_task;
 
-	D_DEBUG(DB_IO, "Object Key Query "DF_OID" start %u map %u\n",
-		DP_OID(obj->cob_md.omd_id), shard_first, map_ver);
+	D_DEBUG(DB_IO, "Object Key Query "DF_OID" grp %d/%u map %u\n",
+		DP_OID(obj->cob_md.omd_id), grp_idx, grp_nr, map_ver);
 
 	head = &obj_auxi->shard_task_head;
 
@@ -6085,23 +6082,25 @@ dc_obj_query_key(tse_task_t *api_task)
 	D_ASSERT(!obj_auxi->args_initialized);
 	D_ASSERT(d_list_empty(head));
 
-	for (i = 0; i < obj_get_grp_nr(obj); i++) {
+	for (i = grp_idx; i < grp_idx + grp_nr; i++) {
 		int start_shard;
 		int j;
 
 		/* Try leader for current group */
-		start_shard = i * obj_get_grp_size(obj);
-		if (!obj_is_ec(obj) || likely(!DAOS_FAIL_CHECK(DAOS_OBJ_SKIP_PARITY))) {
+		if (!obj_is_ec(obj)) {
 			int leader;
 
-			leader = obj_grp_leader_get(obj, i, map_ver, NIL_BITMAP);
+			leader = obj_replica_leader_select(obj, i, map_ver);
 			if (leader >= 0) {
-				if (obj_is_ec(obj) && !is_ec_parity_shard(leader, obj_get_oca(obj)))
+				uint64_t dkey_hash = obj_ec_dkey_hash_get(obj, obj_auxi->dkey_hash);
+
+				if (obj_is_ec(obj) && !is_ec_parity_shard(leader, dkey_hash,
+									  obj_get_oca(obj)))
 					goto non_leader;
 
 				rc = queue_shard_query_key_task(api_task, obj_auxi, &epoch, leader,
-								map_ver, obj, dkey_hash, &dti,
-								coh_uuid, cont_uuid);
+								map_ver, obj, &dti, coh_uuid,
+								cont_uuid);
 				if (rc)
 					D_GOTO(out_task, rc);
 
@@ -6110,21 +6109,20 @@ dc_obj_query_key(tse_task_t *api_task)
 				continue;
 			}
 
-			if (!obj_is_ec(obj)) {
-				/* There has to be a leader for non-EC object */
-				D_ERROR(DF_OID" no valid shard, rc " DF_RC"\n",
-					DP_OID(obj->cob_md.omd_id), DP_RC(leader));
-				D_GOTO(out_task, rc = leader);
-			}
+			/* There has to be a leader for non-EC object */
+			D_ERROR(DF_OID" no valid shard, rc " DF_RC"\n",
+				DP_OID(obj->cob_md.omd_id), DP_RC(leader));
+			D_GOTO(out_task, rc = leader);
 		}
 
 non_leader:
 		/* Then Try non-leader shards */
-		D_DEBUG(DB_IO, DF_OID" try non-leader shards for group %d.\n",
+		start_shard = i * obj_get_grp_size(obj);
+		D_DEBUG(DB_IO, DF_OID" EC needs to try all shards for group %d.\n",
 			DP_OID(obj->cob_md.omd_id), i);
-		for (j = start_shard; j < start_shard + obj_ec_data_tgt_nr(&obj->cob_oca); j++) {
+		for (j = start_shard; j < start_shard + daos_oclass_grp_size(&obj->cob_oca); j++) {
 			rc = queue_shard_query_key_task(api_task, obj_auxi, &epoch, j, map_ver,
-							obj, dkey_hash, &dti, coh_uuid, cont_uuid);
+							obj, &dti, coh_uuid, cont_uuid);
 			if (rc)
 				D_GOTO(out_task, rc);
 		}
@@ -6150,8 +6148,7 @@ out_task:
 
 static int
 shard_sync_prep(struct shard_auxi_args *shard_auxi, struct dc_object *obj,
-		struct obj_auxi_args *obj_auxi, uint64_t dkey_hash,
-		uint32_t grp_idx)
+		struct obj_auxi_args *obj_auxi, uint32_t grp_idx)
 {
 	struct daos_obj_sync_args	*obj_args;
 	struct shard_sync_args		*shard_args;
@@ -6171,6 +6168,9 @@ dc_obj_sync(tse_task_t *task)
 	struct dc_object		*obj = NULL;
 	struct dtx_epoch		 epoch;
 	uint32_t			 map_ver = 0;
+	uint32_t			shard;
+	uint32_t			shard_cnt;
+	uint32_t			grp_cnt;
 	int				 rc;
 	int				 i;
 
@@ -6220,8 +6220,10 @@ dc_obj_sync(tse_task_t *task)
 			*args->epochs_p[i] = 0;
 	}
 
-	rc = obj_req_get_tgts(obj, NULL, NULL, 0, NIL_BITMAP, map_ver, true,
-			      false, obj_auxi);
+	obj_auxi->to_leader = 1;
+	obj_ptr2shards(obj, &shard, &shard_cnt, &grp_cnt);
+	rc = obj_shards_2_fwtgts(obj, map_ver, NIL_BITMAP, shard, shard_cnt,
+				 grp_cnt, OBJ_TGT_FLAG_LEADER_ONLY, obj_auxi);
 	if (rc != 0)
 		D_GOTO(out_task, rc);
 
@@ -6229,7 +6231,7 @@ dc_obj_sync(tse_task_t *task)
 		DP_OID(obj->cob_md.omd_id), obj_is_ec(obj) ? "EC" : "REP",
 		obj_get_replicas(obj));
 
-	return obj_req_fanout(obj, obj_auxi, 0, map_ver, &epoch,
+	return obj_req_fanout(obj, obj_auxi, map_ver, &epoch,
 			      shard_sync_prep, dc_obj_shard_sync, task);
 
 out_task:
@@ -6285,6 +6287,7 @@ dc_obj_verify(daos_handle_t oh, daos_epoch_t *epochs, unsigned int nr)
 
 		dova[i].fetch_buf = NULL;
 		dova[i].fetch_buf_len = 0;
+		dova[i].ec_parity_rotate = 0;
 	}
 
 	for (i = 0; i < obj->cob_grp_nr && rc == 0; i++) {

--- a/src/object/cli_shard.c
+++ b/src/object/cli_shard.c
@@ -1271,6 +1271,8 @@ dc_obj_shard_rw(struct dc_obj_shard *shard, enum obj_rpc_opc opc,
 	uuid_copy(orw->orw_co_uuid, cont_uuid);
 	daos_dti_copy(&orw->orw_dti, &args->dti);
 	orw->orw_flags = auxi->flags | flags;
+	if (auxi->obj_auxi->reintegrating)
+		orw->orw_flags |= ORF_REINTEGRATING_IO;
 	orw->orw_tgt_idx = auxi->ec_tgt_idx;
 	if (args->reasb_req && args->reasb_req->orr_oca)
 		orw->orw_tgt_max = obj_ec_tgt_nr(args->reasb_req->orr_oca) - 1;

--- a/src/object/cli_shard.c
+++ b/src/object/cli_shard.c
@@ -179,12 +179,16 @@ dc_rw_cb_iod_sgl_copy(daos_iod_t *iod, d_sg_list_t *sgl, daos_iod_t *cp_iod,
 static d_iov_t *
 rw_args2csum_iov(const struct rw_cb_args *rw_args)
 {
+	daos_obj_rw_t	*api_args;
+
 	D_ASSERT(rw_args != NULL);
 	D_ASSERT(rw_args->shard_args != NULL);
 	D_ASSERT(rw_args->shard_args != NULL);
-	D_ASSERT(rw_args->shard_args->api_args != NULL);
+	D_ASSERT(rw_args->shard_args->auxi.obj_auxi != NULL);
+	D_ASSERT(rw_args->shard_args->auxi.obj_auxi->obj_task != NULL);
 
-	return rw_args->shard_args->api_args->csum_iov;
+	api_args = dc_task_get_args(rw_args->shard_args->auxi.obj_auxi->obj_task);
+	return api_args->csum_iov;
 }
 
 static bool
@@ -292,13 +296,22 @@ dc_rw_cb_csum_verify(const struct rw_cb_args *rw_args)
 		orwo->orw_iod_csums.ca_arrays->ic_data->cs_csum[0]++;
 
 	reasb_req = rw_args->shard_args->reasb_req;
-	shard_idx = rw_args->shard_args->auxi.shard -
-		    rw_args->shard_args->auxi.start_shard;
+	if (obj_is_ec(rw_args->shard_args->auxi.obj_auxi->obj)) {
+		shard_idx = obj_ec_shard_off(
+				obj_ec_dkey_hash_get(rw_args->shard_args->auxi.obj_auxi->obj,
+						     rw_args->shard_args->auxi.obj_auxi->dkey_hash),
+				&rw_args->shard_args->auxi.obj_auxi->obj->cob_oca,
+				orw->orw_oid.id_shard);
+	} else {
+		shard_idx = rw_args->shard_args->auxi.shard -
+			    rw_args->shard_args->auxi.start_shard;
+	}
+
 	singv_los = dc_rw_cb_singv_lo_get(iods, sgls, orw->orw_nr, reasb_req);
 
-	D_DEBUG(DB_CSUM, DF_C_UOID_DKEY"VERIFY %d iods\n",
+	D_DEBUG(DB_CSUM, DF_C_UOID_DKEY"VERIFY %d iods dkey_hash "DF_U64"\n",
 		DP_C_UOID_DKEY(orw->orw_oid, &orw->orw_dkey),
-		orw->orw_nr);
+		orw->orw_nr, rw_args->shard_args->auxi.obj_auxi->dkey_hash);
 
 	for (i = 0; i < orw->orw_nr; i++) {
 #define IOV_INLINE	8
@@ -375,11 +388,11 @@ dc_rw_cb_csum_verify(const struct rw_cb_args *rw_args)
 				uint32_t		 tgt_idx;
 
 				sa = &rw_args->shard_args->auxi;
-				tgt_idx = sa->shard - sa->start_shard;
-				rc = obj_ec_get_degrade(reasb_req, tgt_idx,
-							NULL, false);
+				tgt_idx = sa->shard %
+					  obj_get_grp_size(rw_args->shard_args->auxi.obj_auxi->obj);
+				rc = obj_ec_fail_info_insert(reasb_req, tgt_idx);
 				if (rc) {
-					D_ERROR(DF_OID" obj_ec_get_degrade "
+					D_ERROR(DF_OID" fail info insert"
 						DF_RC"\n",
 						DP_OID(orw->orw_oid.id_pub),
 						DP_RC(rc));
@@ -432,9 +445,9 @@ iom_recx_merge(daos_iom_t *dst, daos_recx_t *recx, bool iom_realloc)
 }
 
 static int
-obj_ec_iom_merge(struct obj_reasb_req *reasb_req, uint32_t shard,
-		 uint32_t tgt_idx, const daos_iom_t *src, daos_iom_t *dst,
-		 struct daos_recx_ep_list *recov_list)
+obj_ec_iom_merge(struct obj_reasb_req *reasb_req, uint64_t dkey_hash,
+		 uint32_t shard, uint32_t tgt_idx, const daos_iom_t *src,
+		 daos_iom_t *dst, struct daos_recx_ep_list *recov_list)
 {
 	struct daos_oclass_attr	*oca = reasb_req->orr_oca;
 	uint64_t		 stripe_rec_nr = obj_ec_stripe_rec_nr(oca);
@@ -443,12 +456,14 @@ obj_ec_iom_merge(struct obj_reasb_req *reasb_req, uint32_t shard,
 	daos_recx_t		 hi, lo, recx, tmpr;
 	daos_recx_t		 recov_hi = { 0 };
 	daos_recx_t		 recov_lo = { 0 };
+	uint32_t		 tgt_off;
 	uint32_t		 iom_nr, i;
 	bool			 done;
 	int			 rc = 0;
 
-	D_ASSERTF(tgt_idx < obj_ec_data_tgt_nr(oca), "tgt_idx %d, tgt_nr %d\n",
-		  tgt_idx, obj_ec_data_tgt_nr(oca));
+	tgt_off = obj_ec_shard_off(dkey_hash, oca, tgt_idx);
+	D_ASSERTF(tgt_off < obj_ec_data_tgt_nr(oca), "tgt_off %d, tgt_nr %d\n",
+		  tgt_off, obj_ec_data_tgt_nr(oca));
 
 	if (recov_list != NULL)
 		daos_recx_ep_list_hilo(recov_list, &recov_hi, &recov_lo);
@@ -462,7 +477,7 @@ obj_ec_iom_merge(struct obj_reasb_req *reasb_req, uint32_t shard,
 		hi.rx_idx = max(hi.rx_idx, rounddown(end - 1, cell_rec_nr));
 		hi.rx_nr = end - hi.rx_idx;
 		hi.rx_idx = obj_ec_idx_vos2daos(hi.rx_idx, stripe_rec_nr,
-						cell_rec_nr, tgt_idx);
+						cell_rec_nr, tgt_off);
 	}
 	if (recov_list != NULL &&
 	    DAOS_RECX_END(recov_hi) > DAOS_RECX_END(hi))
@@ -482,7 +497,7 @@ obj_ec_iom_merge(struct obj_reasb_req *reasb_req, uint32_t shard,
 		lo.rx_nr = min(end, roundup(lo.rx_idx + 1, cell_rec_nr)) -
 			   lo.rx_idx;
 		lo.rx_idx = obj_ec_idx_vos2daos(lo.rx_idx, stripe_rec_nr,
-						cell_rec_nr, tgt_idx);
+						cell_rec_nr, tgt_off);
 	}
 	if (recov_list != NULL && (end == 0 ||
 	    DAOS_RECX_END(recov_lo) < DAOS_RECX_END(lo)))
@@ -536,7 +551,7 @@ obj_ec_iom_merge(struct obj_reasb_req *reasb_req, uint32_t shard,
 			tmpr.rx_idx = obj_ec_idx_vos2daos(tmpr.rx_idx,
 							  stripe_rec_nr,
 							  cell_rec_nr,
-							  tgt_idx);
+							  tgt_off);
 			rc = iom_recx_merge(dst, &tmpr,
 					    reasb_req->orr_iom_realloc);
 			if (rc == -DER_NOMEM)
@@ -724,9 +739,11 @@ dc_shard_update_size(struct rw_cb_args *rw_args, int fetch_rc)
 	for (i = 0; i < orw->orw_nr; i++) {
 		daos_iod_t		*iod;
 		daos_iod_t		*uiod;
+		uint32_t		shard;
 		struct daos_oclass_attr	*oca;
 		struct shard_fetch_stat	*fetch_stat;
-		bool			 conflict = false;
+		uint64_t		dkey_hash;
+		bool			conflict = false;
 
 		D_DEBUG(DB_IO, DF_UOID" size "DF_U64" eph "DF_U64"\n", DP_UOID(orw->orw_oid),
 			sizes[i], orw->orw_epoch);
@@ -756,9 +773,13 @@ dc_shard_update_size(struct rw_cb_args *rw_args, int fetch_rc)
 		/* single-value, trust the size replied from first shard or parity shard,
 		 * because if overwrite those shards must be updated.
 		 */
-		if ((orw->orw_oid.id_shard % obj_get_grp_size(rw_args->shard_args->auxi.obj)) ==
-		     obj_ec_singv_small_idx(oca, iod) ||
-		    is_ec_parity_shard(orw->orw_oid.id_shard, oca)) {
+		shard = orw->orw_oid.id_shard %
+			obj_get_grp_size(rw_args->shard_args->auxi.obj_auxi->obj);
+		dkey_hash = obj_ec_dkey_hash_get(rw_args->shard_args->auxi.obj_auxi->obj,
+						 orw->orw_dkey_hash);
+		if (ec_shard_by_dkey(shard, dkey_hash, oca) ==
+		    obj_ec_singv_small_idx(oca, dkey_hash, iod) ||
+		    is_ec_parity_shard(orw->orw_oid.id_shard, dkey_hash, oca)) {
 			if (uiod->iod_size != 0 && uiod->iod_size < sizes[i] && fetch_rc == 0) {
 				rec2big = true;
 				rc = -DER_REC2BIG;
@@ -848,6 +869,7 @@ dc_rw_cb(tse_task_t *task, void *arg)
 	struct obj_rw_out	*orwo;
 	daos_handle_t		th;
 	struct obj_reasb_req	*reasb_req;
+	daos_obj_rw_t		*api_args;
 	bool			 is_ec_obj;
 	int			 opc;
 	int			 ret = task->dt_result;
@@ -895,7 +917,8 @@ dc_rw_cb(tse_task_t *task, void *arg)
 	 * orwo->orw_epoch may be set even when the status is nonzero (e.g.,
 	 * -DER_TX_RESTART and -DER_INPROGRESS).
 	 */
-	th = rw_args->shard_args->api_args->th;
+	api_args = dc_task_get_args(rw_args->shard_args->auxi.obj_auxi->obj_task);
+	th = api_args->th;
 	if (daos_handle_is_valid(th)) {
 		int rc_tmp;
 
@@ -955,12 +978,11 @@ dc_rw_cb(tse_task_t *task, void *arg)
 				uint32_t		 tgt_idx;
 
 				sa = &rw_args->shard_args->auxi;
-				tgt_idx = sa->shard - sa->start_shard;
-				rc = obj_ec_get_degrade(reasb_req, tgt_idx,
-							NULL, false);
+				tgt_idx = sa->shard %
+					  obj_get_grp_size(rw_args->shard_args->auxi.obj_auxi->obj);
+				rc = obj_ec_fail_info_insert(reasb_req, tgt_idx);
 				if (rc)
-					D_ERROR(DF_OID" obj_ec_get_degrade "
-						DF_RC"\n",
+					D_ERROR(DF_OID" fail info insert: " DF_RC"\n",
 						DP_OID(orw->orw_oid.id_pub),
 						DP_RC(rc));
 				rc = -DER_CSUM;
@@ -1118,15 +1140,18 @@ dc_rw_cb(tse_task_t *task, void *arg)
 				}
 				if (is_ec_obj &&
 				    reply_maps->iom_type == DAOS_IOD_ARRAY) {
-					rc = obj_ec_iom_merge(reasb_req,
-							orw->orw_oid.id_shard,
-							orw->orw_tgt_idx,
-							reply_maps,
-							&rw_args->maps[i],
-							recov_list);
+					struct obj_auxi_args	*obj_auxi;
+					uint64_t		dkey_hash;
+
+					obj_auxi = rw_args->shard_args->auxi.obj_auxi;
+					dkey_hash = obj_ec_dkey_hash_get(obj_auxi->obj,
+									 obj_auxi->dkey_hash);
+					rc = obj_ec_iom_merge(reasb_req, dkey_hash,
+							      orw->orw_oid.id_shard,
+							      orw->orw_tgt_idx, reply_maps,
+							      &rw_args->maps[i], recov_list);
 				} else {
-					rc = daos_iom_copy(reply_maps,
-							   &rw_args->maps[i]);
+					rc = daos_iom_copy(reply_maps, &rw_args->maps[i]);
 				}
 				if (rc)
 					goto out;
@@ -1164,7 +1189,7 @@ dc_obj_shard_rw(struct dc_obj_shard *shard, enum obj_rpc_opc opc,
 {
 	struct shard_rw_args	*args = shard_args;
 	struct shard_auxi_args	*auxi = &args->auxi;
-	daos_obj_rw_t		*api_args = args->api_args;
+	daos_obj_rw_t		*api_args = dc_task_get_args(auxi->obj_auxi->obj_task);
 	struct dc_pool		*pool;
 	daos_key_t		*dkey = api_args->dkey;
 	unsigned int		 nr = api_args->nr;
@@ -1249,16 +1274,26 @@ dc_obj_shard_rw(struct dc_obj_shard *shard, enum obj_rpc_opc opc,
 	orw->orw_tgt_idx = auxi->ec_tgt_idx;
 	if (args->reasb_req && args->reasb_req->orr_oca)
 		orw->orw_tgt_max = obj_ec_tgt_nr(args->reasb_req->orr_oca) - 1;
-	if (obj_op_is_ec_fetch(auxi->obj_auxi) &&
-	    (auxi->shard != (auxi->start_shard + auxi->ec_tgt_idx)))
-		orw->orw_flags |= ORF_EC_DEGRADED;
+	if (auxi->obj_auxi->ec_degrade_fetch) {
+		struct obj_tgt_oiod *toiod;
+
+		toiod = obj_ec_tgt_oiod_get(args->reasb_req->tgt_oiods,
+					    args->reasb_req->orr_tgt_nr,
+					    auxi->ec_tgt_idx);
+		D_ASSERTF(toiod != NULL, "tgt idx %u\n", auxi->ec_tgt_idx);
+		if (toiod->oto_orig_tgt_idx != toiod->oto_tgt_idx) {
+			orw->orw_flags |= ORF_EC_DEGRADED;
+			orw->orw_tgt_idx = toiod->oto_orig_tgt_idx;
+		}
+	}
+
 	orw->orw_dti_cos.ca_count = 0;
 	orw->orw_dti_cos.ca_arrays = NULL;
 
 	orw->orw_api_flags = api_args->flags;
 	orw->orw_epoch = auxi->epoch.oe_value;
 	orw->orw_epoch_first = auxi->epoch.oe_first;
-	orw->orw_dkey_hash = args->dkey_hash;
+	orw->orw_dkey_hash = auxi->obj_auxi->dkey_hash;
 	orw->orw_nr = nr;
 	orw->orw_dkey = *dkey;
 	orw->orw_dkey_csum = args->dkey_csum;
@@ -1317,7 +1352,7 @@ dc_obj_shard_rw(struct dc_obj_shard *shard, enum obj_rpc_opc opc,
 	} else {
 		if (api_args->extra_flags & DIOF_EC_RECOV_FROM_PARITY)
 			orw->orw_flags |= ORF_EC_RECOV_FROM_PARITY;
-		rw_args.maps = args->api_args->ioms;
+		rw_args.maps = api_args->ioms;
 	}
 	if (opc == DAOS_OBJ_RPC_FETCH) {
 		if (args->iod_csums != NULL) {
@@ -1394,8 +1429,8 @@ dc_obj_shard_punch(struct dc_obj_shard *shard, enum obj_rpc_opc opc,
 		   uint32_t fw_cnt, tse_task_t *task)
 {
 	struct shard_punch_args		*args = shard_args;
-	daos_obj_punch_t		*obj_args = args->pa_api_args;
-	daos_key_t			*dkey = obj_args->dkey;
+	daos_obj_punch_t		*obj_args;
+	daos_key_t			*dkey;
 	struct dc_pool			*pool;
 	struct obj_punch_in		*opi;
 	crt_rpc_t			*req;
@@ -1404,6 +1439,8 @@ dc_obj_shard_punch(struct dc_obj_shard *shard, enum obj_rpc_opc opc,
 	crt_endpoint_t			 tgt_ep;
 	int				 rc;
 
+	obj_args = dc_task_get_args(args->pa_auxi.obj_auxi->obj_task);
+	dkey = obj_args->dkey;
 	pool = obj_shard_ptr2pool(shard);
 	if (pool == NULL)
 		D_GOTO(out, rc = -DER_NO_HDL);
@@ -1437,7 +1474,7 @@ dc_obj_shard_punch(struct dc_obj_shard *shard, enum obj_rpc_opc opc,
 	opi->opi_map_ver	 = args->pa_auxi.map_ver;
 	opi->opi_api_flags	 = obj_args->flags;
 	opi->opi_epoch		 = args->pa_auxi.epoch.oe_value;
-	opi->opi_dkey_hash	 = args->pa_dkey_hash;
+	opi->opi_dkey_hash	 = args->pa_auxi.obj_auxi->dkey_hash;
 	opi->opi_oid		 = oid;
 	opi->opi_dkeys.ca_count  = (dkey == NULL) ? 0 : 1;
 	opi->opi_dkeys.ca_arrays = dkey;
@@ -1725,9 +1762,10 @@ dc_enumerate_cb(tse_task_t *task, void *arg)
 
 	if (rc != 0) {
 		if (rc == -DER_KEY2BIG) {
-			D_DEBUG(DB_IO, "key size "DF_U64" too big.\n",
-				oeo->oeo_size);
-			enum_args->eaa_kds[0].kd_key_len = oeo->oeo_size;
+			D_DEBUG(DB_IO, "key size "DF_U64" %p too big.\n",
+				oeo->oeo_size, enum_args->eaa_kds);
+			if (enum_args->eaa_kds)
+				enum_args->eaa_kds[0].kd_key_len = oeo->oeo_size;
 		} else if (rc == -DER_INPROGRESS || rc == -DER_TX_BUSY) {
 			D_DEBUG(DB_TRACE, "rpc %p RPC %d may need retry: "DF_RC"\n",
 				enum_args->rpc, opc, DP_RC(rc));
@@ -1809,6 +1847,7 @@ out:
 	crt_req_decref(enum_args->rpc);
 	dc_pool_put((struct dc_pool *)enum_args->hdlp);
 
+	D_DEBUG(DB_TRACE, "exit %d\n", rc);
 	if (ret == 0 || obj_retry_error(rc))
 		ret = rc;
 	return ret;
@@ -1822,7 +1861,7 @@ dc_obj_shard_list(struct dc_obj_shard *obj_shard, enum obj_rpc_opc opc,
 		  uint32_t fw_cnt, tse_task_t *task)
 {
 	struct shard_list_args *args = shard_args;
-	daos_obj_list_t	       *obj_args = args->la_api_args;
+	daos_obj_list_t		*obj_args = dc_task_get_args(args->la_auxi.obj_auxi->obj_task);
 	daos_key_desc_t	       *kds = args->la_kds;
 	d_sg_list_t	       *sgl = args->la_sgl;
 	crt_endpoint_t		tgt_ep;
@@ -1953,7 +1992,7 @@ dc_obj_shard_list(struct dc_obj_shard *obj_shard, enum obj_rpc_opc opc,
 	enum_args.eaa_map_ver = &args->la_auxi.map_ver;
 	enum_args.eaa_recxs = args->la_recxs;
 	enum_args.epoch = &args->la_auxi.epoch;
-	enum_args.th = &args->la_api_args->th;
+	enum_args.th = &obj_args->th;
 	rc = tse_task_register_comp_cb(task, dc_enumerate_cb, &enum_args,
 				       sizeof(enum_args));
 	if (rc != 0)
@@ -1986,6 +2025,7 @@ struct obj_query_key_cb_args {
 	struct dc_object	*obj;
 	struct dc_obj_shard	*shard;
 	struct dtx_epoch	epoch;
+	uint64_t		dkey_hash;
 	daos_handle_t		th;
 };
 
@@ -1999,11 +2039,11 @@ obj_shard_query_recx_post(struct obj_query_key_cb_args *cb_args, uint32_t shard,
 	daos_recx_t		*tmp_recx;
 	daos_recx_t		 recx[2] = {0};
 	uint64_t		 end[2], tmp_end;
-	uint32_t		 tgt_idx;
-	bool			 parity_checked = false;
+	uint32_t		 tgt_off;
 	bool			 from_data_tgt;
 	struct daos_oclass_attr	*oca;
-	uint64_t		 stripe_rec_nr, cell_rec_nr, rx_idx;
+	uint64_t		dkey_hash;
+	uint64_t		 stripe_rec_nr, cell_rec_nr;
 
 	oca = obj_get_oca(cb_args->obj);
 	if (oca == NULL || !daos_oclass_is_ec(oca)) {
@@ -2011,83 +2051,38 @@ obj_shard_query_recx_post(struct obj_query_key_cb_args *cb_args, uint32_t shard,
 		return;
 	}
 
-	tgt_idx = shard % obj_get_grp_size(cb_args->obj);
-	from_data_tgt = tgt_idx < obj_ec_data_tgt_nr(oca);
+	dkey_hash = obj_ec_dkey_hash_get(cb_args->obj, cb_args->dkey_hash);
+	from_data_tgt = is_ec_data_shard(shard, dkey_hash, oca);
+	tgt_off = obj_ec_shard_off(dkey_hash, oca, shard);
 	stripe_rec_nr = obj_ec_stripe_rec_nr(oca);
 	cell_rec_nr = obj_ec_cell_rec_nr(oca);
 	tmp_recx = &recx[0];
-re_check:
-	if (reply_recx->rx_idx & PARITY_INDICATOR) {
-		daos_recx_t *punched_recx = &okqo->okqo_recx_punched;
-
-		D_ASSERT(!from_data_tgt);
-		rx_idx = (reply_recx->rx_idx & (~PARITY_INDICATOR));
-		D_ASSERTF(rx_idx % cell_rec_nr == 0, "rx_idx "DF_X64
-			  ", cell_rec_nr "DF_U64"\n",
-			  rx_idx, cell_rec_nr);
-		D_ASSERTF(reply_recx->rx_nr % cell_rec_nr == 0,
-			  "rx_nr "DF_U64", cell_rec_nr "DF_U64"\n",
-			  reply_recx->rx_nr, cell_rec_nr);
-		rx_idx = obj_ec_idx_vos2daos(rx_idx, stripe_rec_nr, cell_rec_nr,
-					     0);
-		tmp_recx->rx_idx = rx_idx;
-		tmp_recx->rx_nr = stripe_rec_nr *
-				     (reply_recx->rx_nr / cell_rec_nr);
-
-		if (DAOS_RECX_END(*punched_recx) > 0) {
-			D_DEBUG(DB_IO, "shard %d punched extent "DF_U64" "DF_U64"\n",
-				shard, punched_recx->rx_idx, punched_recx->rx_nr);
-			D_ASSERT(DAOS_RECX_END(*punched_recx) >= tmp_recx->rx_idx);
-			if (DAOS_RECX_END(*punched_recx) < DAOS_RECX_END(*tmp_recx)) {
-				uint64_t r_end = DAOS_RECX_END(*tmp_recx);
-
-				tmp_recx->rx_idx = DAOS_RECX_END(*punched_recx);
-				tmp_recx->rx_nr = r_end - tmp_recx->rx_idx;
-			} else if (punched_recx->rx_idx > tmp_recx->rx_idx) {
-				tmp_recx->rx_nr = min(punched_recx->rx_idx,
-						      DAOS_RECX_END(*tmp_recx)) - tmp_recx->rx_idx;
-			} else {
-				tmp_recx->rx_nr = 0;
-				tmp_recx->rx_idx = 0;
-			}
-		}
-		D_DEBUG(DB_IO, "shard %d get recx "DF_U64" "DF_U64"\n",
-			shard, tmp_recx->rx_idx, tmp_recx->rx_nr);
-	} else {
-		/* data ext from data shard needs to convert to daos ext,
-		 * replica ext from parity shard needs not to convert.
-		 */
-		*tmp_recx = *reply_recx;
-		tmp_end = DAOS_RECX_PTR_END(tmp_recx);
-		if (from_data_tgt && tmp_end > 0) {
-			if (get_max) {
-				tmp_recx->rx_idx = max(tmp_recx->rx_idx,
-					rounddown(tmp_end - 1, cell_rec_nr));
-				tmp_recx->rx_nr = tmp_end - tmp_recx->rx_idx;
-			} else {
-				tmp_recx->rx_nr = min(tmp_end,
-					roundup(tmp_recx->rx_idx + 1,
-						cell_rec_nr)) -
-					tmp_recx->rx_idx;
-			}
+	D_ASSERT(!(reply_recx->rx_idx & PARITY_INDICATOR));
+	/* data ext from data shard needs to convert to daos ext,
+	 * replica ext from parity shard needs not to convert.
+	 */
+	*tmp_recx = *reply_recx;
+	tmp_end = DAOS_RECX_PTR_END(tmp_recx);
+	if (tmp_end > 0) {
+		if (from_data_tgt)
 			tmp_recx->rx_idx = obj_ec_idx_vos2daos(tmp_recx->rx_idx,
 							       stripe_rec_nr,
 							       cell_rec_nr,
-							       tgt_idx);
-			D_DEBUG(DB_IO, "shard %d get recx "DF_U64" "DF_U64"\n",
-				shard, tmp_recx->rx_idx, tmp_recx->rx_nr);
-		}
-	}
-	if (!parity_checked && !from_data_tgt) {
-		parity_checked = true;
-		tmp_recx = &recx[1];
-		reply_recx = &okqo->okqo_recx_parity;
-		D_ASSERTF((reply_recx->rx_idx & PARITY_INDICATOR) ||
-			  reply_recx->rx_nr == 0, "reply_recx "DF_RECX"\n",
-			  DP_RECX(reply_recx[0]));
+							       tgt_off);
 
-		if (reply_recx->rx_nr != 0)
-			goto re_check;
+		if (get_max) {
+			tmp_recx->rx_idx = max(tmp_recx->rx_idx,
+				rounddown(tmp_end - 1, cell_rec_nr));
+			tmp_recx->rx_nr = tmp_end - tmp_recx->rx_idx;
+		} else {
+			tmp_recx->rx_nr = min(tmp_end,
+				roundup(tmp_recx->rx_idx + 1,
+					cell_rec_nr)) -
+				tmp_recx->rx_idx;
+		}
+
+		D_DEBUG(DB_IO, "shard %d/%u get recx "DF_U64" "DF_U64"\n",
+			shard, tgt_off, tmp_recx->rx_idx, tmp_recx->rx_nr);
 	}
 
 	end[0] = DAOS_RECX_END(recx[0]);
@@ -2229,7 +2224,7 @@ obj_shard_query_key_cb(tse_task_t *task, void *data)
 		if (first || changed)
 			*cur = *val;
 		else
-			D_ASSERT(0);
+			D_ASSERT(is_ec_obj);
 	}
 
 	if (check && flags & DAOS_GET_RECX) {
@@ -2303,6 +2298,7 @@ dc_obj_shard_query_key(struct dc_obj_shard *shard, struct dtx_epoch *epoch,
 	cb_args.shard		= shard;
 	cb_args.epoch		= *epoch;
 	cb_args.th		= th;
+	cb_args.dkey_hash	= dkey_hash;
 	cb_args.max_epoch	= max_epoch;
 
 	rc = tse_task_register_comp_cb(task, obj_shard_query_key_cb, &cb_args, sizeof(cb_args));

--- a/src/object/obj_ec.h
+++ b/src/object/obj_ec.h
@@ -147,6 +147,13 @@ struct obj_tgt_oiod {
 	uint32_t		 oto_tgt_idx;
 	/* number of iods */
 	uint32_t		 oto_iod_nr;
+
+	/**
+	 * target original idx (0, k + p), since the fetch request might be
+	 * re-directed to the parity shard.
+	 **/
+	uint32_t		oto_orig_tgt_idx;
+
 	/* offset array, oto_iod_nr offsets for each target */
 	uint64_t		*oto_offs;
 	/* oiod array, oto_iod_nr oiods for each target,
@@ -278,6 +285,31 @@ struct obj_reasb_req;
 /** Query the tgt idx of data cell for daos recx idx */
 #define obj_ec_tgt_of_recx_idx(idx, stripe_rec_nr, e_len)		\
 	(((idx) % (stripe_rec_nr)) / (e_len))
+
+/* Get shard idx according to dkey hash within one group. logical idx -> physical idx */
+#define obj_ec_shard_idx(dkey_hash, oca, t_idx)				\
+	((dkey_hash % obj_ec_tgt_nr(oca) + t_idx) % obj_ec_tgt_nr(oca))
+
+/* Get shard index within the object layout */
+#define obj_ec_shard(dkey_hash, oca, grp_idx, t_idx)					\
+	(grp_idx * obj_ec_tgt_nr(oca) + obj_ec_shard_idx(dkey_hash, oca, t_idx))
+
+/* Get the parity index within one group, logical -> physical */
+#define obj_ec_parity_idx(dkey_hash, oca, p_idx)					\
+	((obj_ec_shard_idx(dkey_hash, oca, 0) + obj_ec_data_tgt_nr(oca) + p_idx) %	\
+	  obj_ec_tgt_nr(oca))
+
+/* Get parity start index according to dkey hash within one group */
+#define obj_ec_parity_start(dkey_hash, oca) obj_ec_parity_idx(dkey_hash, oca, 0)
+
+/* Get parity shard index within the object layout */
+#define obj_ec_parity_shard(dkey_hash, oca, grp_idx, p_idx)		\
+	((grp_idx) * obj_ec_tgt_nr(oca) + obj_ec_parity_idx(dkey_hash, oca, p_idx))
+
+/* Get the logical offset of shard within one group, physical idx -> logical idx */
+#define obj_ec_shard_off(dkey_hash, oca, shard)				\
+	((shard % obj_ec_tgt_nr(oca) + obj_ec_tgt_nr(oca) -		\
+	 obj_ec_shard_idx(dkey_hash, oca, 0)) % obj_ec_tgt_nr(oca))
 /**
  * Query the mapped VOS recx idx on data cells of daos recx idx, it is also the
  * parity's VOS recx idx on parity cells (the difference is parity's VOS recx
@@ -294,7 +326,6 @@ struct obj_reasb_req;
 
 #define obj_ec_idx_parity2daos(vos_off, e_len, stripe_rec_nr)		\
 	(((vos_off) / e_len) * stripe_rec_nr)
-
 /**
  * Threshold size of EC single-value layout (even distribution).
  * When record_size <= OBJ_EC_SINGV_EVENDIST_SZ then stored in one data
@@ -304,11 +335,6 @@ struct obj_reasb_req;
 /** Alignment size of sing value local size */
 #define OBJ_EC_SINGV_CELL_ALIGN			(8)
 
-#define is_ec_data_shard(shard, oca)					\
-		((shard % obj_ec_tgt_nr(oca)) < obj_ec_data_tgt_nr(oca))
-#define is_ec_parity_shard(shard, oca)					\
-		((shard % obj_ec_tgt_nr(oca)) >= obj_ec_data_tgt_nr(oca))
-
 /** Local rec size, padding bytes and offset in the global record */
 struct obj_ec_singv_local {
 	uint64_t	esl_off;
@@ -317,7 +343,27 @@ struct obj_ec_singv_local {
 };
 
 /** Query the target index for small sing-value record */
-#define obj_ec_singv_small_idx(oca, iod)	(0)
+#define obj_ec_singv_small_idx(oca, dkey_hash, iod)	obj_ec_shard_idx(dkey_hash, oca, 0)
+
+static inline bool
+is_ec_data_shard(uint32_t shard, uint64_t dkey_hash, struct daos_oclass_attr *oca)
+{
+	D_ASSERT(daos_oclass_is_ec(oca));
+	return obj_ec_shard_off(dkey_hash, oca, shard) < obj_ec_data_tgt_nr(oca);
+}
+
+static inline bool
+is_ec_parity_shard(uint32_t shard, uint64_t dkey_hash, struct daos_oclass_attr *oca)
+{
+	D_ASSERT(daos_oclass_is_ec(oca));
+	return obj_ec_shard_off(dkey_hash, oca, shard) >= obj_ec_data_tgt_nr(oca);
+}
+
+static inline uint32_t
+ec_shard_by_dkey(uint32_t shard, uint64_t dkey_hash, struct daos_oclass_attr *oca)
+{
+	return shard % obj_ec_tgt_nr(oca);
+}
 
 /** Query if the single value record is stored in one data target */
 static inline bool
@@ -631,12 +677,12 @@ obj_ec_tgt_in_err(uint32_t *err_list, uint32_t nerrs, uint16_t tgt_idx)
 }
 
 static inline bool
-obj_shard_is_ec_parity(daos_unit_oid_t oid, struct daos_oclass_attr *attr)
+obj_shard_is_ec_parity(daos_unit_oid_t oid, uint64_t dkey_hash, struct daos_oclass_attr *attr)
 {
 	if (!daos_oclass_is_ec(attr))
 		return false;
 
-	return is_ec_parity_shard(oid.id_shard, attr);
+	return is_ec_parity_shard(oid.id_shard, dkey_hash, attr);
 }
 
 /* obj_class.c */
@@ -685,19 +731,20 @@ obj_ec_parity_lists_match(struct daos_recx_ep_list *lists_1,
 }
 
 /* cli_ec.c */
-int obj_ec_req_reasb(daos_iod_t *iods, d_sg_list_t *sgls, daos_obj_id_t oid,
-		     struct daos_oclass_attr *oca,
-		     struct obj_reasb_req *reasb_req,
-		     uint32_t iod_nr, bool update);
+int obj_ec_req_reasb(daos_iod_t *iods, uint64_t dkey_hash, d_sg_list_t *sgls,
+		     daos_obj_id_t oid, struct daos_oclass_attr *oca,
+		     struct obj_reasb_req *reasb_req, uint32_t iod_nr, bool update);
 void obj_ec_recxs_fini(struct obj_ec_recx_array *recxs);
 void obj_ec_seg_sorter_fini(struct obj_ec_seg_sorter *sorter);
 void obj_ec_tgt_oiod_fini(struct obj_tgt_oiod *tgt_oiods);
 struct obj_tgt_oiod *obj_ec_tgt_oiod_init(struct obj_io_desc *r_oiods,
 			uint32_t iod_nr, uint8_t *tgt_bitmap,
-			uint32_t tgt_max_idx, uint32_t tgt_nr);
+			uint32_t tgt_max_idx, uint32_t tgt_nr, uint64_t dkey_hash,
+			struct daos_oclass_attr *oca);
 struct obj_tgt_oiod *obj_ec_tgt_oiod_get(struct obj_tgt_oiod *tgt_oiods,
 			uint32_t tgt_nr, uint32_t tgt_idx);
-void obj_ec_fetch_set_sgl(struct obj_reasb_req *reasb_req, uint32_t iod_nr);
+void obj_ec_fetch_set_sgl(struct obj_reasb_req *reasb_req, uint64_t dkey_hash,
+			  uint32_t iod_nr);
 void obj_ec_update_iod_size(struct obj_reasb_req *reasb_req, uint32_t iod_nr);
 int obj_ec_recov_add(struct obj_reasb_req *reasb_req,
 		     struct daos_recx_ep_list *recx_lists, unsigned int nr);
@@ -705,10 +752,14 @@ int obj_ec_parity_check(struct obj_reasb_req *reasb_req,
 			struct daos_recx_ep_list *recx_lists, unsigned int nr);
 struct obj_ec_fail_info *obj_ec_fail_info_get(struct obj_reasb_req *reasb_req,
 					      bool create, uint16_t p);
+
+int obj_ec_fail_info_parity_get(struct obj_reasb_req *reasb_req, uint64_t dkey_hash,
+				uint32_t *parity_tgt_idx, uint8_t *cur_bitmap);
+int obj_ec_fail_info_insert(struct obj_reasb_req *reasb_req, uint16_t fail_tgt);
 void obj_ec_fail_info_reset(struct obj_reasb_req *reasb_req);
 void obj_ec_fail_info_free(struct obj_reasb_req *reasb_req);
 int obj_ec_recov_prep(struct obj_reasb_req *reasb_req, daos_obj_id_t oid,
-		      daos_iod_t *iods, uint32_t iod_nr);
+		      uint64_t dkey_hash, daos_iod_t *iods, uint32_t iod_nr);
 void obj_ec_recov_data(struct obj_reasb_req *reasb_req, daos_obj_id_t oid,
 		       uint32_t iod_nr);
 int obj_ec_get_degrade(struct obj_reasb_req *reasb_req, uint16_t fail_tgt_idx,
@@ -716,7 +767,8 @@ int obj_ec_get_degrade(struct obj_reasb_req *reasb_req, uint16_t fail_tgt_idx,
 
 /* srv_ec.c */
 struct obj_rw_in;
-int obj_ec_rw_req_split(daos_unit_oid_t oid, struct obj_iod_array *iod_array,
+int obj_ec_rw_req_split(daos_unit_oid_t oid, uint64_t dkey_hash,
+			struct obj_iod_array *iod_array,
 			uint32_t iod_nr, uint32_t start_shard,
 			uint32_t max_shard, uint32_t leader_id,
 			void *tgt_map, uint32_t map_size, struct daos_oclass_attr *oca,

--- a/src/object/obj_internal.h
+++ b/src/object/obj_internal.h
@@ -586,7 +586,7 @@ obj_retry_error(int err)
 	       err == -DER_INPROGRESS || err == -DER_GRPVER ||
 	       err == -DER_EXCLUDED || err == -DER_CSUM ||
 	       err == -DER_TX_BUSY || err == -DER_TX_UNCERTAIN ||
-	       err == -DER_SHARDS_OVERLAP ||
+	       err == -DER_SHARDS_OVERLAP || err == -DER_UPDATE_AGAIN ||
 	       daos_crt_network_error(err);
 }
 

--- a/src/object/obj_internal.h
+++ b/src/object/obj_internal.h
@@ -379,6 +379,7 @@ struct obj_auxi_args {
 					 shards_scheded:1,
 					 sub_anchors:1,
 					 ec_degrade_fetch:1,
+					 reintegrating:1,
 					 tx_convert:1;
 	/* request flags. currently only: ORF_RESEND */
 	uint32_t			 flags;

--- a/src/object/obj_internal.h
+++ b/src/object/obj_internal.h
@@ -103,6 +103,7 @@ struct dc_object {
 	uint64_t		*cob_time_fetch_leader;
 	/** shard object ptrs */
 	struct dc_obj_layout	*cob_shards;
+	uint32_t		cob_ec_parity_rotate:1;
 };
 
 /* to record EC singv fetch stat from different shards */
@@ -153,6 +154,8 @@ struct obj_reasb_req {
 	uint32_t			 orr_iom_tgt_nr;
 	/* number of iom extends */
 	uint32_t			 orr_iom_nr;
+	/* #iods of IO req */
+	uint32_t			 orr_iod_nr;
 	struct daos_oclass_attr		*orr_oca;
 	struct obj_ec_codec		*orr_codec;
 	pthread_mutex_t			 orr_mutex;
@@ -166,8 +169,6 @@ struct obj_reasb_req {
 	/* parity recx list (to compare parity ext/epoch when data recovery) */
 	struct daos_recx_ep_list	*orr_parity_lists;
 	uint32_t			 orr_parity_list_nr;
-	/* #iods of IO req */
-	uint32_t			 orr_iod_nr;
 	/* for data recovery flag */
 	uint32_t			 orr_recov:1,
 	/* for snapshot data recovery flag */
@@ -206,7 +207,6 @@ typedef int (*shard_io_cb_t)(struct dc_obj_shard *shard, enum obj_rpc_opc opc,
  * shard_rw_args and shard_punch_args.
  */
 struct shard_auxi_args {
-	struct dc_object	*obj;
 	struct obj_auxi_args	*obj_auxi;
 	shard_io_cb_t		 shard_io_cb;
 	struct dtx_epoch	 epoch;
@@ -224,10 +224,8 @@ struct shard_auxi_args {
 
 struct shard_rw_args {
 	struct shard_auxi_args	 auxi;
-	daos_obj_rw_t		*api_args;
 	d_sg_list_t		*sgls_dup;
 	struct dtx_id		 dti;
-	uint64_t		 dkey_hash;
 	crt_bulk_t		*bulks;
 	struct obj_io_desc	*oiods;
 	uint64_t		*offs;
@@ -238,10 +236,8 @@ struct shard_rw_args {
 
 struct shard_punch_args {
 	struct shard_auxi_args	 pa_auxi;
-	daos_obj_punch_t	*pa_api_args;
 	uuid_t			 pa_coh_uuid;
 	uuid_t			 pa_cont_uuid;
-	uint64_t		 pa_dkey_hash;
 	struct dtx_id		 pa_dti;
 	uint32_t		 pa_opc;
 };
@@ -270,7 +266,6 @@ struct shard_anchors {
 
 struct shard_list_args {
 	struct shard_auxi_args	 la_auxi;
-	daos_obj_list_t		*la_api_args;
 	struct dtx_id		 la_dti;
 	daos_recx_t		*la_recxs;
 	uint32_t		la_nr;
@@ -307,6 +302,120 @@ int
 obj_enum_iterate(daos_key_desc_t *kdss, d_sg_list_t *sgl, int nr,
 		 unsigned int type, obj_enum_process_cb_t cb,
 		 void *cb_arg);
+#define CLI_OBJ_IO_PARMS	8
+
+#define OBJ_TGT_INLINE_NR	9
+#define OBJ_INLINE_BTIMAP	4
+
+struct obj_req_tgts {
+	/* to save memory allocation if #targets <= OBJ_TGT_INLINE_NR */
+	struct daos_shard_tgt	 ort_tgts_inline[OBJ_TGT_INLINE_NR];
+	/* Shard target array, with (ort_grp_nr * ort_grp_size) targets.
+	 * If #targets <= OBJ_TGT_INLINE_NR then it points to ort_tgts_inline.
+	 * Within the array, [0, ort_grp_size - 1] is for the first group,
+	 * [ort_grp_size, ort_grp_size * 2 - 1] is the 2nd group and so on.
+	 * If (ort_srv_disp == 1) then within each group the first target is the
+	 * leader shard and following (ort_grp_size - 1) targets are the forward
+	 * non-leader shards.
+	 * Now there is only one case for (ort_grp_nr > 1) that for object
+	 * punch, all other cases with (ort_grp_nr == 1).
+	 */
+	struct daos_shard_tgt	*ort_shard_tgts;
+	uint32_t		 ort_grp_nr;
+	/* ort_grp_size is the size of the group that is sent as forwarded
+	 * shards
+	 */
+	uint32_t		 ort_grp_size;
+	/* ort_start_shard is only for EC object, it is the start shard number
+	 * of the EC stripe. To facilitate calculate the offset of different
+	 * shards in the stripe.
+	 */
+	uint32_t		 ort_start_shard;
+	/* flag of server dispatch */
+	uint32_t		 ort_srv_disp:1;
+};
+
+struct obj_auxi_tgt_list {
+	/** array of target ID */
+	uint32_t	*tl_tgts;
+	/** number of ranks & tgts */
+	uint32_t	tl_nr;
+};
+
+struct shard_sync_args {
+	struct shard_auxi_args	 sa_auxi;
+	daos_epoch_t		*sa_epoch;
+};
+
+/* Auxiliary args for object I/O */
+struct obj_auxi_args {
+	tse_task_t			*obj_task;
+	daos_handle_t			 th;
+	struct dc_object		*obj;
+	int				 opc;
+	int				 result;
+	uint32_t			 map_ver_req;
+	uint32_t			 map_ver_reply;
+	/* flags for the obj IO task.
+	 * ec_wait_recov -- obj fetch wait another EC recovery task,
+	 * ec_in_recov -- a EC recovery task
+	 */
+	uint32_t			 io_retry:1,
+					 args_initialized:1,
+					 to_leader:1,
+					 spec_shard:1,
+					 spec_group:1,
+					 req_reasbed:1,
+					 is_ec_obj:1,
+					 csum_retry:1,
+					 csum_report:1,
+					 tx_uncertain:1,
+					 no_retry:1,
+					 ec_wait_recov:1,
+					 ec_in_recov:1,
+					 new_shard_tasks:1,
+					 reset_param:1,
+					 force_degraded:1,
+					 shards_scheded:1,
+					 sub_anchors:1,
+					 ec_degrade_fetch:1,
+					 tx_convert:1;
+	/* request flags. currently only: ORF_RESEND */
+	uint32_t			 flags;
+	uint32_t			 specified_shard;
+	/* 64-bits alignment, bitmap for retry next replicas. */
+	struct obj_req_tgts		 req_tgts;
+	d_sg_list_t			*sgls_dup;
+	crt_bulk_t			*bulks;
+	uint32_t			 iod_nr;
+	uint32_t			 initial_shard;
+	d_list_t			 shard_task_head;
+	struct obj_reasb_req		 reasb_req;
+	struct obj_auxi_tgt_list	*failed_tgt_list;
+	uint64_t			dkey_hash;
+	/* one shard_args embedded to save one memory allocation if the obj
+	 * request only targets for one shard.
+	 */
+	union {
+		struct shard_rw_args	 rw_args;
+		struct shard_punch_args	 p_args;
+		struct shard_list_args	 l_args;
+		struct shard_sync_args	 s_args;
+	};
+};
+
+#define obj_ec_dkey_hash_get(obj, dkey_hash)	\
+	(obj->cob_ec_parity_rotate ? dkey_hash : 0)
+/**
+ * task memory space should enough to use -
+ * obj API task with daos_task_args + obj_auxi_args,
+ * shard sub-task with shard_auxi_args + obj_auxi_args.
+ * When it exceed the limit, can reduce OBJ_TGT_INLINE_NR or enlarge tse_task.
+ */
+D_CASSERT(sizeof(struct obj_auxi_args) + sizeof(struct shard_auxi_args) <=
+	  TSE_TASK_ARG_LEN);
+D_CASSERT(sizeof(struct obj_auxi_args) + sizeof(struct daos_task_args) <=
+	  TSE_TASK_ARG_LEN);
 
 int
 merge_recx(d_list_t *head, uint64_t offset, uint64_t size, daos_epoch_t eph);
@@ -336,11 +445,6 @@ ec_bulk_spec_get_skip(int index, struct ec_bulk_spec *skip_list)
 {
 	return skip_list[index].is_skip;
 }
-struct shard_sync_args {
-	struct shard_auxi_args	 sa_auxi;
-	daos_epoch_t		*sa_epoch;
-};
-
 #define DOVA_NUM	32
 #define DOVA_BUF_LEN	4096
 
@@ -362,7 +466,8 @@ struct dc_obj_verify_args {
 	uint32_t			 num;
 	unsigned int			 eof:1,
 					 non_exist:1,
-					 data_fetched:1;
+					 data_fetched:1,
+					 ec_parity_rotate:1;
 	daos_key_desc_t			 kds[DOVA_NUM];
 	d_sg_list_t			 list_sgl;
 	d_sg_list_t			 fetch_sgl;
@@ -420,8 +525,9 @@ int dc_obj_shard_sync(struct dc_obj_shard *shard, enum obj_rpc_opc opc,
 int dc_obj_verify_rdg(struct dc_object *obj, struct dc_obj_verify_args *dova,
 		      uint32_t rdg_idx, uint32_t reps, daos_epoch_t epoch);
 bool obj_op_is_ec_fetch(struct obj_auxi_args *obj_auxi);
-int obj_recx_ec2_daos(struct daos_oclass_attr *oca, int shard, daos_recx_t **recxs_p,
-		      daos_epoch_t **recx_ephs_p, unsigned int *nr, bool convert_parity);
+int obj_recx_ec2_daos(struct daos_oclass_attr *oca, uint64_t dkey_hash, int shard,
+		      daos_recx_t **recxs_p, daos_epoch_t **recx_ephs_p,
+		      unsigned int *nr, bool convert_parity);
 int obj_reasb_req_init(struct obj_reasb_req *reasb_req, struct dc_object *obj,
 		       daos_iod_t *iods, uint32_t iod_nr, struct daos_oclass_attr *oca);
 void obj_reasb_req_fini(struct obj_reasb_req *reasb_req, uint32_t iod_nr);
@@ -439,21 +545,31 @@ int obj_pool_query_task(tse_sched_t *sched, struct dc_object *obj,
 bool obj_csum_dedup_candidate(struct cont_props *props, daos_iod_t *iods,
 			      uint32_t iod_nr);
 
-int obj_grp_leader_get(struct dc_object *obj, int grp_idx,
+int obj_grp_leader_get(struct dc_object *obj, int grp_idx, uint64_t dkey_hash,
 		       unsigned int map_ver, uint8_t *bit_map);
 #define obj_shard_close(shard)	dc_obj_shard_close(shard)
-int obj_recx_ec_daos2shard(struct daos_oclass_attr *oca, int shard, daos_recx_t **recxs_p,
-			   daos_epoch_t **recx_ephs_p, unsigned int *iod_nr);
+int obj_recx_ec_daos2shard(struct daos_oclass_attr *oca, uint64_t dkey_hash, int shard,
+			   daos_recx_t **recxs_p, daos_epoch_t **recx_ephs_p,
+			   unsigned int *iod_nr);
 int obj_ec_singv_encode_buf(daos_unit_oid_t oid, struct daos_oclass_attr *oca,
-			    daos_iod_t *iod, d_sg_list_t *sgl, d_iov_t *e_iov);
+			    uint64_t dkey_hash, daos_iod_t *iod, d_sg_list_t *sgl,
+			    d_iov_t *e_iov);
 int obj_ec_singv_split(daos_unit_oid_t oid, struct daos_oclass_attr *oca,
-		       daos_size_t iod_size, d_sg_list_t *sgl);
+		       uint64_t dkey_hash, daos_size_t iod_size, d_sg_list_t *sgl);
+
 int
 obj_singv_ec_rw_filter(daos_unit_oid_t oid, struct daos_oclass_attr *oca,
-		       daos_iod_t *iods, uint64_t *offs, daos_epoch_t epoch,
-		       uint32_t flags, uint32_t start_shard,
-		       uint32_t nr, bool for_update, bool deg_fetch,
+		       uint64_t dkey_hash, daos_iod_t *iods, uint64_t *offs,
+		       daos_epoch_t epoch, uint32_t flags, uint32_t nr,
+		       bool for_update, bool deg_fetch,
 		       struct daos_recx_ep_list **recov_lists_ptr);
+int
+obj_ec_encode_buf(daos_obj_id_t oid, struct daos_oclass_attr *oca,
+		  daos_size_t iod_size, unsigned char *buffer,
+		  unsigned char *p_bufs[]);
+
+int
+obj_ec_parity_alive(daos_handle_t oh, uint64_t dkey_hash, uint32_t map_ver);
 
 static inline struct pl_obj_shard*
 obj_get_shard(void *data, int idx)
@@ -546,7 +662,8 @@ struct obj_io_context {
 	uint32_t		 ioc_began:1,
 				 ioc_free_sgls:1,
 				 ioc_lost_reply:1,
-				 ioc_fetch_snap:1;
+				 ioc_fetch_snap:1,
+				 ioc_ec_rotate_parity:1;
 };
 
 static inline uint64_t

--- a/src/object/obj_rpc.h
+++ b/src/object/obj_rpc.h
@@ -31,7 +31,7 @@
  * These are for daos_rpc::dr_opc and DAOS_RPC_OPCODE(opc, ...) rather than
  * crt_req_create(..., opc, ...). See daos_rpc.h.
  */
-#define DAOS_OBJ_VERSION 8
+#define DAOS_OBJ_VERSION 9
 /* LIST of internal RPCS in form of:
  * OPCODE, flags, FMT, handler, corpc_hdlr and name
  */
@@ -180,6 +180,8 @@ enum obj_rpc_flags {
 	ORF_CONTAIN_LEADER	= (1 << 20),
 	/*Ascending Order - 0, descending order - 1*/
 	ORF_DESCENDING_ORDER	= (1 << 21),
+	/* send to reintegrating target */
+	ORF_REINTEGRATING_IO	= (1 << 22),
 };
 
 /* common for update/fetch */

--- a/src/object/obj_tx.c
+++ b/src/object/obj_tx.c
@@ -76,7 +76,8 @@ struct dc_tx {
 	uint64_t		 tx_flags;
 	uint32_t		 tx_fixed_epoch:1, /** epoch is specified. */
 				 tx_retry:1, /** Retry the commit RPC. */
-				 tx_set_resend:1; /** Set 'resend' flag. */
+				 tx_set_resend:1, /** Set 'resend' flag. */
+				 tx_reintegrating:1;
 	/** Transaction status (OPEN, COMMITTED, etc.), see dc_tx_status. */
 	enum dc_tx_status	 tx_status;
 	/** The rank for the server on which the TX leader resides. */
@@ -934,7 +935,7 @@ dc_tx_commit_cb(tse_task_t *task, void *data)
 	}
 
 	/* Need to restart the TX with newer epoch. */
-	if (rc == -DER_TX_RESTART || rc == -DER_STALE) {
+	if (rc == -DER_TX_RESTART || rc == -DER_STALE || rc == -DER_UPDATE_AGAIN) {
 		tx->tx_set_resend = 1;
 		tx->tx_status = TX_FAILED;
 
@@ -1177,16 +1178,11 @@ dc_tx_classify_common(struct dc_tx *tx, struct daos_cpd_sub_req *dcsr,
 
 	/* Descending order to guarantee that EC parity is handled firstly. */
 	for (idx = start + obj->cob_grp_size - 1; idx >= start; idx--) {
-		if (reasb_req != NULL && reasb_req->tgt_bitmap != NIL_BITMAP &&
-		    isclr(reasb_req->tgt_bitmap, idx - start))
-			continue;
-
 		rc = obj_shard_open(obj, idx, tx->tx_pm_ver, &shard);
 		if (rc == -DER_NONEXIST) {
 			rc = 0;
 			if (daos_oclass_is_ec(oca) && !all) {
-				if (idx >= start + obj->cob_grp_size -
-							oca->u.ec.e_p)
+				if (idx >= start + obj->cob_grp_size - oca->u.ec.e_p)
 					skipped_parity++;
 
 				if (skipped_parity > oca->u.ec.e_p) {
@@ -1208,6 +1204,16 @@ dc_tx_classify_common(struct dc_tx *tx, struct daos_cpd_sub_req *dcsr,
 		if (rc != 0)
 			goto out;
 
+		if (reasb_req != NULL && reasb_req->tgt_bitmap != NIL_BITMAP &&
+		    isclr(reasb_req->tgt_bitmap, shard->do_shard - start)) {
+			D_DEBUG(DB_TRACE, "idx %d shard %u start %d skip\n", idx,
+				shard->do_shard, start);
+			obj_shard_close(shard);
+			continue;
+		}
+
+		if (shard->do_reintegrating)
+			tx->tx_reintegrating = 1;
 		/* XXX: It is possible that more than one shards locate on the
 		 *	same DAOS target under OSA mode, then the "idx" may be
 		 *	not equal to "shard->do_shard".
@@ -1828,6 +1834,8 @@ dc_tx_commit_trigger(tse_task_t *task, struct dc_tx *tx, daos_tx_commit_t *args)
 	uuid_copy(oci->oci_pool_uuid, tx->tx_pool->dp_pool);
 	oci->oci_map_ver = tx->tx_pm_ver;
 	oci->oci_flags = ORF_CPD_LEADER | (tx->tx_set_resend ? ORF_RESEND : 0);
+	if (tx->tx_reintegrating)
+		oci->oci_flags |= ORF_REINTEGRATING_IO;
 
 	oci->oci_sub_heads.ca_arrays = &tx->tx_head;
 	oci->oci_sub_heads.ca_count = 1;

--- a/src/object/obj_tx.c
+++ b/src/object/obj_tx.c
@@ -1067,6 +1067,7 @@ dc_tx_classify_update(struct dc_tx *tx, struct daos_cpd_sub_req *dcsr,
 			return rc;
 
 		rc = obj_ec_req_reasb(dcu->dcu_iod_array.oia_iods,
+				      obj_ec_dkey_hash_get(obj, dcsr->dcsr_dkey_hash),
 				      dcsr->dcsr_sgls, obj->cob_md.omd_id, oca,
 				      dcsr->dcsr_reasb, dcsr->dcsr_nr, true);
 		if (rc != 0)
@@ -1623,7 +1624,9 @@ dc_tx_commit_prepare(struct dc_tx *tx, tse_task_t *task)
 		else
 			bit_map = NIL_BITMAP;
 
-		i = obj_grp_leader_get(obj, grp_idx, tx->tx_pm_ver, bit_map);
+		i = obj_grp_leader_get(obj, grp_idx,
+				       obj_ec_dkey_hash_get(obj, dcsr->dcsr_dkey_hash),
+				       tx->tx_pm_ver, bit_map);
 		if (i < 0)
 			D_GOTO(out, rc = i);
 

--- a/src/object/obj_verify.c
+++ b/src/object/obj_verify.c
@@ -650,9 +650,13 @@ dc_obj_verify_ec_cb(struct dc_obj_enum_unpack_io *io, void *arg)
 	int				rc;
 
 	D_ASSERT(obj != NULL);
-	D_DEBUG(DB_TRACE, "compare "DF_KEY" nr %d shard "DF_U64"\n", DP_KEY(&io->ui_dkey),
-		nr, shard);
-	if (nr == 0)
+	if (!dova->ec_parity_rotate)
+		io->ui_dkey_hash = 0;
+
+	D_DEBUG(DB_TRACE, "compare "DF_KEY" nr %d shard "DF_U64" dkey_hash "DF_U64
+		"start EC "DF_U64"\n", DP_KEY(&io->ui_dkey), nr, shard, io->ui_dkey_hash,
+		obj_ec_shard_off(io->ui_dkey_hash, obj_get_oca(obj), io->ui_oid.id_shard));
+	if (nr == 0 || is_ec_parity_shard(io->ui_oid.id_shard, io->ui_dkey_hash, obj_get_oca(obj)))
 		return 0;
 
 	for (i = 0; i < nr; i++) {
@@ -685,8 +689,9 @@ dc_obj_verify_ec_cb(struct dc_obj_enum_unpack_io *io, void *arg)
 		sgls_verify[idx].sg_nr_out = 1;
 		sgls_verify[idx].sg_iovs = &iovs_verify[idx];
 		if (iod->iod_type == DAOS_IOD_ARRAY) {
-			rc = obj_recx_ec2_daos(obj_get_oca(obj), io->ui_oid.id_shard,
-					       &iod->iod_recxs, NULL, &iod->iod_nr, true);
+			rc = obj_recx_ec2_daos(obj_get_oca(obj), io->ui_dkey_hash,
+					       io->ui_oid.id_shard, &iod->iod_recxs,
+					       NULL, &iod->iod_nr, true);
 			if (rc != 0)
 				D_GOTO(out, rc);
 		}
@@ -764,15 +769,15 @@ dc_obj_verify_ec_rdg(struct dc_object *obj, struct dc_obj_verify_args *dova,
 {
 	struct daos_oclass_attr *oca;
 	uint32_t		start;
-	int			data_nr;
+	int			tgt_nr;
 	int			i;
 	int			rc = 0;
 
 	oca = obj_get_oca(obj);
 	D_ASSERT(oca->ca_resil == DAOS_RES_EC);
-	data_nr = obj_ec_data_tgt_nr(oca);
+	tgt_nr = obj_ec_tgt_nr(oca);
 	start = rdg_idx * obj_ec_tgt_nr(oca);
-	for (i = 0; i < data_nr; i++) {
+	for (i = 0; i < tgt_nr; i++) {
 		struct dc_obj_verify_cursor	*cursor = &dova->cursor;
 		daos_unit_oid_t			oid;
 

--- a/src/object/srv_ec.c
+++ b/src/object/srv_ec.c
@@ -44,7 +44,8 @@ obj_ec_is_valid_tgt(struct daos_cpd_ec_tgts *tgt_map, uint32_t map_size,
  * split it for different targets before dispatch.
  */
 int
-obj_ec_rw_req_split(daos_unit_oid_t oid, struct obj_iod_array *iod_array,
+obj_ec_rw_req_split(daos_unit_oid_t oid, uint64_t dkey_hash,
+		    struct obj_iod_array *iod_array,
 		    uint32_t iod_nr, uint32_t start_shard, uint32_t max_shard,
 		    uint32_t leader_id, void *tgt_map, uint32_t map_size,
 		    struct daos_oclass_attr *oca, uint32_t tgt_nr,
@@ -152,7 +153,7 @@ obj_ec_rw_req_split(daos_unit_oid_t oid, struct obj_iod_array *iod_array,
 	}
 
 	tgt_oiods = obj_ec_tgt_oiod_init(oiods, iod_nr, tgt_bit_map,
-					 tgt_max_idx, count);
+					 tgt_max_idx, count, dkey_hash, oca);
 	if (tgt_oiods == NULL)
 		D_GOTO(out, rc = -DER_NOMEM);
 
@@ -199,7 +200,8 @@ obj_ec_rw_req_split(daos_unit_oid_t oid, struct obj_iod_array *iod_array,
 					split_iod_csum->ic_data = split_ci;
 					split_ci->cs_nr = 1;
 					split_ci->cs_csum +=
-						leader * ci->cs_len;
+						obj_ec_shard_off(dkey_hash, oca, leader) *
+						ci->cs_len;
 					split_ci->cs_buf_len = ci->cs_len;
 				}
 			}

--- a/src/object/srv_ec_aggregate.c
+++ b/src/object/srv_ec_aggregate.c
@@ -105,12 +105,16 @@ struct ec_agg_entry {
 	d_sg_list_t		 ae_sgl;	 /* Mem for entry processing  */
 	daos_handle_t		 ae_thdl;	 /* Iterator handle           */
 	daos_key_t		 ae_dkey;	 /* Current dkey              */
+	uint64_t		 ae_dkey_hash;
 	daos_key_t		 ae_akey;	 /* Current akey              */
 	daos_size_t		 ae_rsize;	 /* Record size of cur array  */
 	struct ec_agg_stripe	 ae_cur_stripe;  /* Struct for current stripe */
 	struct ec_agg_par_extent ae_par_extent;	 /* Parity extent             */
 	daos_handle_t		 ae_obj_hdl;	 /* Object handle for cur obj */
+	struct pl_obj_layout	*ae_obj_layout;
 	struct daos_shard_loc	 ae_peer_pshards[OBJ_EC_MAX_P];
+	uint32_t		 ae_grp_idx;
+	uint32_t		 ae_rotate_parity:1; /* ec parity rotation or not */
 };
 
 /* Parameters used to drive iterate all.
@@ -205,14 +209,13 @@ ec_age2shard(struct ec_agg_entry *entry)
 static inline uint32_t
 ec_age2pidx(struct ec_agg_entry *entry)
 {
-	uint32_t	k, p, shard;
+	uint32_t shard;
 
-	k = ec_age2k(entry);
-	p = ec_age2p(entry);
-	shard = ec_age2shard(entry) % (k + p);
-	D_ASSERT(shard >= k && shard < (k + p));
+	shard = ec_age2shard(entry) % obj_ec_tgt_nr(&entry->ae_oca);
 
-	return (shard - k) % p;
+	return (shard + obj_ec_tgt_nr(&entry->ae_oca) -
+		obj_ec_parity_start(entry->ae_dkey_hash, &entry->ae_oca)) %
+		obj_ec_tgt_nr(&entry->ae_oca);
 }
 
 #define EC_AGE_EPOCH_NO_PARITY		((daos_epoch_t)(~(0ULL)))
@@ -483,16 +486,14 @@ agg_count_cells(uint8_t *fcbit_map, uint8_t *tbit_map, unsigned int estart,
 static int
 agg_get_obj_handle(struct ec_agg_entry *entry)
 {
-	struct daos_obj_layout	*layout;
 	struct ec_agg_param	*agg_param;
-	unsigned int		 k = ec_age2k(entry);
-	d_rank_t		 myrank;
-	uint32_t		 grp_idx;
-	struct daos_obj_shard	*sd;
-	int			 i, p, rc = 0;
+	uint32_t		grp_start;
+	uint32_t		tgt_ec_idx;
+	int			i;
+	int			rc;
 
 	if (daos_handle_is_valid(entry->ae_obj_hdl))
-		return rc;
+		return 0;
 
 	agg_param = container_of(entry, struct ec_agg_param, ap_agg_entry);
 	rc = dsc_obj_open(agg_param->ap_pool_info.api_cont_hdl,
@@ -501,22 +502,27 @@ agg_get_obj_handle(struct ec_agg_entry *entry)
 	if (rc)
 		goto out;
 
-	crt_group_rank(NULL, &myrank);
-	rc = dc_obj_layout_get(entry->ae_obj_hdl, &layout);
-	if (rc)
-		goto out;
+	if (entry->ae_peer_pshards[0].sd_rank != DAOS_TGT_IGNORE)
+		D_GOTO(out, rc = 0);
 
-	grp_idx = ec_age2shard(entry) / (ec_age2k(entry) + ec_age2p(entry));
-	sd = layout->ol_shards[grp_idx];
-	for (i = k, p = 0; i < sd->os_replica_nr; i++) {
-		entry->ae_peer_pshards[p].sd_rank = sd->os_shard_loc[i].sd_rank;
-		entry->ae_peer_pshards[p].sd_tgt_idx = sd->os_shard_loc[i].sd_tgt_idx;
-		D_DEBUG(DB_TRACE, "ae_peer_pshards[%d] (grp %d), rank %d, tgt_idx %d\n",
-			p, grp_idx, entry->ae_peer_pshards[p].sd_rank,
-			entry->ae_peer_pshards[p].sd_tgt_idx);
-		p++;
+	grp_start = entry->ae_grp_idx * entry->ae_obj_layout->ol_grp_size;
+	tgt_ec_idx = obj_ec_parity_start(entry->ae_dkey_hash, &entry->ae_oca);
+	for (i = 0; i < obj_ec_parity_tgt_nr(&entry->ae_oca); i++,
+	     tgt_ec_idx = (tgt_ec_idx + 1) % entry->ae_obj_layout->ol_grp_size) {
+		struct pl_obj_shard	*p_shard;
+		struct pool_target	*tgt;
+		int			shard_idx;
+
+		shard_idx = grp_start + tgt_ec_idx;
+		p_shard = &entry->ae_obj_layout->ol_shards[shard_idx];
+		rc = pool_map_find_target(agg_param->ap_pool_info.api_pool->sp_map,
+					  p_shard->po_target, &tgt);
+		if (rc == 1) {
+			entry->ae_peer_pshards[i].sd_rank = tgt->ta_comp.co_rank;
+			entry->ae_peer_pshards[i].sd_tgt_idx = tgt->ta_comp.co_index;
+			rc = 0;
+		}
 	}
-	daos_obj_layout_free(layout);
 out:
 	/* NB: entry::ae_obj_hdl will be closed externally */
 	return rc;
@@ -916,17 +922,12 @@ agg_fetch_remote_parity(struct ec_agg_entry *entry)
 	unsigned char	*buf = NULL;
 	uint32_t	 len = ec_age2cs(entry);
 	uint64_t	 cell_b = ec_age2cs_b(entry);
-	uint32_t	 k = ec_age2k(entry);
-	uint32_t	 p = ec_age2p(entry);
 	uint32_t	 shard  = ec_age2shard(entry);
-	uint32_t	 pidx, sidx, peer_shard;
+	uint32_t	 pidx, peer_shard;
 	int		 i, rc = 0;
 
 	/* Only called when p > 1. */
-	D_ASSERT(p > 1);
-	sidx = shard % (k + p);
-	D_ASSERT(sidx >= k && sidx < k + p);
-	pidx = sidx - k;
+	pidx = ec_age2pidx(entry);
 
 	/* set up the iod */
 	recx.rx_idx = (entry->ae_cur_stripe.as_stripenum * len)
@@ -941,11 +942,13 @@ agg_fetch_remote_parity(struct ec_agg_entry *entry)
 	buf = entry->ae_sgl.sg_iovs[AGG_IOV_PARITY].iov_buf;
 	sgl.sg_nr = 1;
 	sgl.sg_iovs = &iov;
-	for (i = 0; i < p; i++) {
+	for (i = 0; i < obj_ec_parity_tgt_nr(&entry->ae_oca); i++) {
 		if (i == pidx)
 			continue;
 		d_iov_set(&iov, &buf[i * cell_b], cell_b);
-		peer_shard = rounddown(shard, k + p) + k + i;
+		peer_shard = obj_ec_parity_shard(entry->ae_dkey_hash,
+						 &entry->ae_oca,
+						 shard / obj_ec_tgt_nr(&entry->ae_oca), i);
 		rc = dsc_obj_fetch(entry->ae_obj_hdl,
 				   entry->ae_par_extent.ape_epoch,
 				   &entry->ae_dkey, 1, &iod, &sgl, NULL,
@@ -1263,7 +1266,6 @@ agg_peer_update_ult(void *arg)
 	uint32_t		 shard  = ec_age2shard(entry);
 	uint32_t		 pidx = ec_age2pidx(entry);
 	uint64_t		 cell_b = ec_age2cs_b(entry);
-	uint32_t		 k = ec_age2k(entry);
 	uint32_t		 p = ec_age2p(entry);
 	uint32_t		 peer, peer_shard;
 	crt_rpc_t		*rpc = NULL;
@@ -1280,6 +1282,7 @@ agg_peer_update_ult(void *arg)
 	for (peer = 0; peer < p; peer++) {
 		if (peer == pidx)
 			continue;
+		D_ASSERT(entry->ae_peer_pshards[peer].sd_rank != DAOS_TGT_IGNORE);
 		tgt_ep.ep_rank = entry->ae_peer_pshards[peer].sd_rank;
 		tgt_ep.ep_tag = entry->ae_peer_pshards[peer].sd_tgt_idx;
 		rc = obj_req_create(dss_get_module_info()->dmi_ctx, &tgt_ep,
@@ -1300,7 +1303,9 @@ agg_peer_update_ult(void *arg)
 		uuid_copy(ec_agg_in->ea_coh_uuid,
 			  agg_param->ap_pool_info.api_coh_uuid);
 		ec_agg_in->ea_oid = entry->ae_oid;
-		peer_shard = rounddown(shard, k + p) + k + peer;
+		peer_shard = obj_ec_parity_shard(entry->ae_dkey_hash,
+						 &entry->ae_oca,
+						 shard / obj_ec_tgt_nr(&entry->ae_oca), peer);
 		ec_agg_in->ea_oid.id_shard = peer_shard;
 		ec_agg_in->ea_dkey = entry->ae_dkey;
 		ec_agg_in->ea_epoch_range.epr_lo = agg_param->ap_epr.epr_lo;
@@ -1409,13 +1414,19 @@ agg_peer_update(struct ec_agg_entry *entry, bool write_parity)
 	D_ASSERT(!write_parity ||
 		 entry->ae_sgl.sg_iovs[AGG_IOV_PARITY].iov_buf);
 
+	rc = agg_get_obj_handle(entry);
+	if (rc) {
+		D_ERROR("Failed to open object: "DF_RC"\n", DP_RC(rc));
+		return rc;
+	}
+
 	agg_param = container_of(entry, struct ec_agg_param, ap_agg_entry);
 	rc = pool_map_find_failed_tgts(agg_param->ap_pool_info.api_pool->sp_map,
 				       &targets, &failed_tgts_cnt);
 	if (rc) {
 		D_ERROR(DF_UOID" pool_map_find_failed_tgts failed: "DF_RC"\n",
 			DP_UOID(entry->ae_oid), DP_RC(rc));
-		goto out;
+		return rc;
 	}
 
 	rc = agg_get_obj_handle(entry);
@@ -1428,9 +1439,10 @@ agg_peer_update(struct ec_agg_entry *entry, bool write_parity)
 		for (peer = 0; peer < p; peer++) {
 			peer_loc = &entry->ae_peer_pshards[peer];
 			for (i = 0; i < failed_tgts_cnt; i++) {
-				if (targets[i].ta_comp.co_rank == peer_loc->sd_rank) {
+				if (targets[i].ta_comp.co_rank == peer_loc->sd_rank ||
+				    peer_loc->sd_rank == DAOS_TGT_IGNORE) {
 					D_DEBUG(DB_EPC, DF_UOID" peer parity "
-						"tgt failed rank %d, tgt_idx "
+						"tgt gailed rank %d, tgt_idx "
 						"%d.\n", DP_UOID(entry->ae_oid),
 						peer_loc->sd_rank,
 						peer_loc->sd_tgt_idx);
@@ -1583,6 +1595,8 @@ agg_process_holes_ult(void *arg)
 
 	/* Invoke peer re-replicate */
 	for (peer = 0; peer < p; peer++) {
+		uint32_t peer_shard;
+
 		if (pidx == peer)
 			continue;
 
@@ -1595,6 +1609,7 @@ agg_process_holes_ult(void *arg)
 			}
 		}
 
+		D_ASSERT(entry->ae_peer_pshards[peer].sd_rank != DAOS_TGT_IGNORE);
 		tgt_ep.ep_rank = entry->ae_peer_pshards[peer].sd_rank;
 		tgt_ep.ep_tag = entry->ae_peer_pshards[peer].sd_tgt_idx;
 		rc = obj_req_create(dss_get_module_info()->dmi_ctx, &tgt_ep,
@@ -1614,7 +1629,10 @@ agg_process_holes_ult(void *arg)
 		uuid_copy(ec_rep_in->er_coh_uuid,
 			  agg_param->ap_pool_info.api_coh_uuid);
 		ec_rep_in->er_oid = entry->ae_oid;
-		ec_rep_in->er_oid.id_shard--;
+		peer_shard = obj_ec_parity_shard(entry->ae_dkey_hash,
+						 &entry->ae_oca,
+				entry->ae_oid.id_shard / obj_ec_tgt_nr(&entry->ae_oca), peer);
+		ec_rep_in->er_oid.id_shard = peer_shard;
 		ec_rep_in->er_dkey = entry->ae_dkey;
 		ec_rep_in->er_iod = *iod;
 		ec_rep_in->er_iod_csums.ca_arrays = stripe_ud->asu_iod_csums;
@@ -1982,20 +2000,130 @@ agg_akey_post(daos_handle_t ih, struct ec_agg_param *agg_param,
 	return rc;
 }
 
-/* Handles dkeys returned by the per-object nested iteratior.
-*/
-static int
-agg_dkey(daos_handle_t ih, vos_iter_entry_t *entry,
-	 struct ec_agg_entry *agg_entry, unsigned int *acts)
+/* Compare function for keys.  Used to reset iterator position.  */
+static inline int
+agg_key_compare(daos_key_t key1, daos_key_t key2)
 {
-	agg_entry->ae_dkey	= entry->ie_key;
+	if (key1.iov_len != key2.iov_len)
+		return 1;
 
-	return 0;
+	return memcmp(key1.iov_buf, key2.iov_buf, key1.iov_len);
 }
 
-/* Handles akeys returned by the iteratior.
- *
- */
+static inline void
+agg_reset_pos(vos_iter_type_t type, struct ec_agg_entry *agg_entry)
+{
+	switch (type) {
+	case VOS_ITER_OBJ:
+		memset(&agg_entry->ae_oid, 0, sizeof(agg_entry->ae_oid));
+		break;
+	case VOS_ITER_DKEY:
+		memset(&agg_entry->ae_dkey, 0, sizeof(agg_entry->ae_dkey));
+		break;
+	case VOS_ITER_AKEY:
+		memset(&agg_entry->ae_akey, 0, sizeof(agg_entry->ae_akey));
+		break;
+	default:
+		break;
+	}
+}
+
+static int
+agg_shard_is_leader(struct ds_pool *pool, struct ec_agg_entry *agg_entry)
+{
+	struct pl_obj_shard	*shard;
+	struct daos_oclass_attr *oca;
+	uint32_t		grp_idx;
+	uint32_t		grp_start;
+	uint32_t		ec_tgt_idx;
+	int			shard_idx;
+	int			rc;
+
+	oca = &agg_entry->ae_oca;
+	grp_idx = agg_entry->ae_oid.id_shard / daos_oclass_grp_size(oca);
+	grp_start = grp_idx * daos_oclass_grp_size(oca);
+	ec_tgt_idx = obj_ec_shard_idx(agg_entry->ae_dkey_hash, oca,
+				      daos_oclass_grp_size(oca) - 1);
+
+	/**
+	 * FIXME: only the last parity shard can be the EC agg leader. What about
+	 * Degraded mode?
+	 */
+	if (agg_entry->ae_oid.id_shard != ec_tgt_idx + grp_start)
+		return 0;
+
+	/* If last parity unavailable, then skip the object via returning -DER_STALE. */
+	shard_idx = grp_idx * agg_entry->ae_obj_layout->ol_grp_size + ec_tgt_idx;
+	shard = pl_obj_get_shard(agg_entry->ae_obj_layout, shard_idx);
+	if (shard->po_target != -1 && shard->po_shard != -1 && !shard->po_rebuilding)
+		rc = (agg_entry->ae_oid.id_shard == shard->po_shard) ? 1 : 0;
+	else
+		rc = -DER_STALE;
+
+	return rc;
+}
+
+/* Initializes the struct holding the iteration state (ec_agg_entry). */
+static void
+agg_reset_dkey_entry(struct ec_agg_entry *agg_entry, vos_iter_entry_t *entry)
+{
+	agg_reset_pos(VOS_ITER_AKEY, agg_entry);
+
+	agg_entry->ae_cur_stripe.as_stripenum	= 0UL;
+	agg_entry->ae_cur_stripe.as_hi_epoch	= 0UL;
+	agg_entry->ae_cur_stripe.as_stripe_fill = 0UL;
+	agg_entry->ae_cur_stripe.as_extent_cnt	= 0U;
+	agg_entry->ae_cur_stripe.as_offset	= 0U;
+}
+
+/* Handles dkeys returned by the per-object nested iteratior. */
+static int
+agg_dkey(daos_handle_t ih, vos_iter_entry_t *entry,
+	 struct ec_agg_param *agg_param, struct ec_agg_entry *agg_entry,
+	 unsigned int *acts)
+{
+	uint64_t	dkey_hash;
+	int		rc;
+
+	if (!agg_key_compare(agg_entry->ae_dkey, entry->ie_key)) {
+		D_DEBUG(DB_EPC, "Skip dkey: "DF_KEY" ec agg on re-probe\n",
+			DP_KEY(&entry->ie_key));
+		*acts |= VOS_ITER_CB_SKIP;
+		return 0;
+	}
+	agg_entry->ae_rotate_parity = 0;
+	agg_entry->ae_dkey = entry->ie_key;
+	agg_entry->ae_grp_idx = agg_entry->ae_oid.id_shard /
+				daos_oclass_grp_size(&agg_entry->ae_oca);
+
+	dkey_hash = obj_dkey2hash(agg_entry->ae_oid.id_pub, &agg_entry->ae_dkey);
+	if (agg_entry->ae_rotate_parity)
+		agg_entry->ae_dkey_hash = dkey_hash;
+	else
+		agg_entry->ae_dkey_hash = 0;
+
+	agg_reset_pos(VOS_ITER_AKEY, agg_entry);
+	rc = agg_shard_is_leader(agg_param->ap_pool_info.api_pool, agg_entry);
+	if (rc == 1) {
+		D_DEBUG(DB_EPC, "oid:"DF_UOID":"DF_KEY" ec agg starting\n",
+			DP_UOID(agg_entry->ae_oid), DP_KEY(&agg_entry->ae_dkey));
+		agg_reset_dkey_entry(&agg_param->ap_agg_entry, entry);
+		rc = 0;
+	} else {
+		if (rc < 0) {
+			D_ERROR("oid:"DF_UOID" ds_pool_check_leader failed "
+				DF_RC"\n", DP_UOID(entry->ie_oid), DP_RC(rc));
+			if (rc == -DER_STALE)
+				agg_param->ap_obj_skipped = 1;
+			rc = 0;
+		}
+		*acts |= VOS_ITER_CB_SKIP;
+	}
+
+	return rc;
+}
+
+/* Handles akeys returned by the iteratior. */
 static int
 agg_akey(daos_handle_t ih, vos_iter_entry_t *entry,
 	 struct ec_agg_entry *agg_entry, unsigned int *acts)
@@ -2010,8 +2138,7 @@ agg_akey(daos_handle_t ih, vos_iter_entry_t *entry,
 	return 0;
 }
 
-/* Invokes the yield function pointer.
-*/
+/* Invokes the yield function pointer. */
 static inline bool
 ec_aggregate_yield(struct ec_agg_param *agg_param)
 {
@@ -2029,8 +2156,7 @@ ec_aggregate_yield(struct ec_agg_param *agg_param)
 	return false;
 }
 
-/* Post iteration call back for outer iterator
-*/
+/* Post iteration call back for outer iterator */
 static int
 agg_iterate_post_cb(daos_handle_t ih, vos_iter_entry_t *entry,
 		    vos_iter_type_t type, vos_iter_param_t *param,
@@ -2042,8 +2168,13 @@ agg_iterate_post_cb(daos_handle_t ih, vos_iter_entry_t *entry,
 
 	switch (type) {
 	case VOS_ITER_OBJ:
+		if (agg_entry->ae_obj_layout) {
+			pl_obj_layout_free(agg_entry->ae_obj_layout);
+			agg_entry->ae_obj_layout = NULL;
+		}
 		break;
 	case VOS_ITER_DKEY:
+		agg_reset_pos(VOS_ITER_DKEY, agg_entry);
 		break;
 	case VOS_ITER_AKEY:
 		rc = agg_akey_post(ih, agg_param, entry, agg_entry, acts);
@@ -2057,12 +2188,12 @@ agg_iterate_post_cb(daos_handle_t ih, vos_iter_entry_t *entry,
 	return rc;
 }
 
-/* Initializes the struct holding the iteration state (ec_agg_entry).
-*/
 static void
 agg_reset_entry(struct ec_agg_entry *agg_entry, vos_iter_entry_t *entry,
 		struct daos_oclass_attr *oca)
 {
+	int i;
+
 	agg_entry->ae_rsize	= 0UL;
 	if (entry) {
 		agg_entry->ae_oid	= entry->ie_oid;
@@ -2078,58 +2209,14 @@ agg_reset_entry(struct ec_agg_entry *agg_entry, vos_iter_entry_t *entry,
 		dsc_obj_close(agg_entry->ae_obj_hdl);
 		agg_entry->ae_obj_hdl = DAOS_HDL_INVAL;
 	}
-	memset(agg_entry->ae_peer_pshards, 0,
-	       (OBJ_EC_MAX_P) * sizeof(struct daos_shard_loc));
 
-	agg_entry->ae_cur_stripe.as_stripenum	= 0UL;
-	agg_entry->ae_cur_stripe.as_hi_epoch	= 0UL;
-	agg_entry->ae_cur_stripe.as_stripe_fill = 0UL;
-	agg_entry->ae_cur_stripe.as_extent_cnt	= 0U;
-	agg_entry->ae_cur_stripe.as_offset	= 0U;
-}
-
-static int
-agg_obj_is_leader(struct ds_pool *pool, struct daos_oclass_attr *oca,
-		  daos_unit_oid_t *oid, uint32_t version)
-{
-	struct daos_obj_md	 md = { 0 };
-	struct pl_map		*map;
-	struct pl_obj_layout	*layout = NULL;
-	struct pl_obj_shard	*shard;
-	uint32_t		 idx;
-	int			 rc;
-
-	/* Only last parity shard can be EC-AGG leader. */
-	if ((oid->id_shard % daos_oclass_grp_size(oca)) != (daos_oclass_grp_size(oca) - 1))
-		return 0;
-
-	map = pl_map_find(pool->sp_uuid, oid->id_pub);
-	if (map == NULL) {
-		D_ERROR("Failed to find pool map to check leader for "DF_UOID"\n", DP_UOID(*oid));
-		return -DER_INVAL;
+	for (i = 0; i < OBJ_EC_MAX_P; i++) {
+		agg_entry->ae_peer_pshards[i].sd_rank = DAOS_TGT_IGNORE;
+		agg_entry->ae_peer_pshards[i].sd_tgt_idx = DAOS_TGT_IGNORE;
 	}
 
-	md.omd_id = oid->id_pub;
-	md.omd_ver = version;
-	rc = pl_obj_place(map, &md, DAOS_OO_RO, NULL, &layout);
-	if (rc != 0)
-		goto out;
-
-	idx = (oid->id_shard / daos_oclass_grp_size(oca)) * layout->ol_grp_size +
-	      daos_oclass_grp_size(oca) - 1;
-	shard = pl_obj_get_shard(layout, idx);
-	if (shard->po_target != -1 && shard->po_shard != -1 && !shard->po_rebuilding) {
-		rc = (oid->id_shard == shard->po_shard) ? 1 : 0;
-	} else {
-		/* If last parity unavailable, then skip the object via returning -DER_STALE. */
-		rc = -DER_STALE;
-	}
-
-out:
-	if (layout != NULL)
-		pl_obj_layout_free(layout);
-	pl_map_decref(map);
-	return rc;
+	agg_reset_pos(VOS_ITER_DKEY, agg_entry);
+	agg_reset_dkey_entry(agg_entry, entry);
 }
 
 static int
@@ -2186,7 +2273,7 @@ done:
 		}
 	}
 
-	return 0;
+	return rc;
 }
 
 /* Iterator pre-callback for objects. Determines if object is subject
@@ -2198,36 +2285,27 @@ ec_agg_object(daos_handle_t ih, vos_iter_entry_t *entry, struct ec_agg_param *ag
 	      unsigned int *acts)
 {
 	struct ec_agg_pool_info *info = &agg_param->ap_pool_info;
+	struct ec_agg_entry	*agg_entry = &agg_param->ap_agg_entry;
+	struct daos_obj_md	 md = { 0 };
+	struct pl_map		*map;
 	struct daos_oclass_attr  oca;
 	int			 rc = 0;
 
 	/** We should have filtered it if it isn't EC */
 	rc = dsc_obj_id2oc_attr(entry->ie_oid.id_pub, &info->api_props, &oca);
 	D_ASSERT(rc == 0 && daos_oclass_is_ec(&oca));
-	rc = agg_obj_is_leader(info->api_pool, &oca, &entry->ie_oid,
-			       info->api_pool->sp_map_version);
-	if (rc == 1) {
-		char	obj_class_name[32] = {0};
-
-		D_ASSERT((entry->ie_oid.id_shard % obj_ec_tgt_nr(&oca)) ==
-			 obj_ec_tgt_nr(&oca) - 1);
-		daos_oclass_id2name(daos_obj_id2class(entry->ie_oid.id_pub), obj_class_name);
-		D_DEBUG(DB_EPC, "oid:"DF_UOID"(%s) ec agg starting\n",
-			DP_UOID(entry->ie_oid), obj_class_name);
-
-		agg_reset_entry(&agg_param->ap_agg_entry, entry, &oca);
-		rc = 0;
-		goto out;
-	} else {
-		if (rc < 0) {
-			D_ERROR("oid:"DF_UOID" ds_pool_check_leader failed "
-				DF_RC"\n", DP_UOID(entry->ie_oid), DP_RC(rc));
-			if (rc == -DER_STALE)
-				agg_param->ap_obj_skipped = 1;
-			rc = 0;
-		}
-		*acts |= VOS_ITER_CB_SKIP;
+	agg_reset_entry(&agg_param->ap_agg_entry, entry, &oca);
+	map = pl_map_find(agg_param->ap_pool_info.api_pool_uuid, entry->ie_oid.id_pub);
+	if (map == NULL) {
+		D_ERROR("Failed to find pool map to check leader for "DF_UOID"\n",
+			DP_UOID(entry->ie_oid));
+		D_GOTO(out, rc = -DER_INVAL);
 	}
+
+	md.omd_id = entry->ie_oid.id_pub;
+	md.omd_ver = agg_param->ap_pool_info.api_pool->sp_map_version;
+	rc = pl_obj_place(map, &md, DAOS_OO_RO, NULL, &agg_entry->ae_obj_layout);
+
 out:
 	return rc;
 }
@@ -2251,7 +2329,7 @@ agg_iterate_pre_cb(daos_handle_t ih, vos_iter_entry_t *entry,
 		rc = ec_agg_object(ih, entry, agg_param, acts);
 		break;
 	case VOS_ITER_DKEY:
-		rc = agg_dkey(ih, entry, agg_entry, acts);
+		rc = agg_dkey(ih, entry, agg_param, agg_entry, acts);
 		break;
 	case VOS_ITER_AKEY:
 		rc = agg_akey(ih, entry, agg_entry, acts);

--- a/src/object/srv_enum.c
+++ b/src/object/srv_enum.c
@@ -645,10 +645,12 @@ fill_rec(daos_handle_t ih, vos_iter_entry_t *key_ent, struct ds_obj_enum_arg *ar
 		/* Check if there are still space */
 		if (is_sgl_full(arg, size) || arg->kds_len >= arg->kds_cap) {
 			/* NB: if it is rebuild object iteration, let's
-			 * check if both dkey & akey was already packed
-			 * (kds_len < 3) before return KEY2BIG.
+			 * check if there are any recxs being packed, otherwise
+			 * it will need return -DER_KEY2BIG to re-allocate
+			 * the buffer and retry.
 			 */
-			if ((arg->chk_key2big && arg->kds_len < 3)) {
+			if (arg->chk_key2big &&
+			    (arg->kds_len < 3 || (arg->kds_len == 3 && !bump_kds_len))) {
 				if (arg->kds[0].kd_key_len < size)
 					arg->kds[0].kd_key_len = size;
 				D_GOTO(out, rc = -DER_KEY2BIG);

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -4649,6 +4649,12 @@ ds_obj_cpd_handler(crt_rpc_t *rpc)
 	if (rc != 0)
 		goto reply;
 
+	if ((oci->oci_flags & ORF_REINTEGRATING_IO) &&
+	    ioc.ioc_coc->sc_pool->spc_rebuild_fence == 0) {
+		D_ERROR("reintegrating "DF_UUID" retry.\n", DP_UUID(oci->oci_pool_uuid));
+		D_GOTO(reply, rc = -DER_UPDATE_AGAIN);
+	}
+
 	if (!leader) {
 		if (tx_count != 1 || oci->oci_sub_reqs.ca_count != 1 ||
 		    oci->oci_disp_ents.ca_count != 1 ||

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -948,9 +948,9 @@ obj_singv_ec_add_recov(uint32_t iod_nr, uint32_t iod_idx, uint64_t rec_size,
 /** Filter and prepare for the sing value EC update/fetch */
 int
 obj_singv_ec_rw_filter(daos_unit_oid_t oid, struct daos_oclass_attr *oca,
-		       daos_iod_t *iods, uint64_t *offs, daos_epoch_t epoch,
-		       uint32_t flags, uint32_t start_shard,
-		       uint32_t nr, bool for_update, bool deg_fetch,
+		       uint64_t dkey_hash, daos_iod_t *iods, uint64_t *offs,
+		       daos_epoch_t epoch, uint32_t flags, uint32_t nr,
+		       bool for_update, bool deg_fetch,
 		       struct daos_recx_ep_list **recov_lists_ptr)
 {
 	daos_iod_t			*iod;
@@ -963,7 +963,7 @@ obj_singv_ec_rw_filter(daos_unit_oid_t oid, struct daos_oclass_attr *oca,
 	if (!(flags & ORF_EC))
 		return rc;
 
-	tgt_idx = oid.id_shard - start_shard;
+	tgt_idx = obj_ec_shard_off(dkey_hash, oca, oid.id_shard);
 	for (i = 0; i < nr; i++) {
 		uint64_t	gsize;
 
@@ -1077,8 +1077,9 @@ obj_fetch_create_maps(crt_rpc_t *rpc, struct bio_desc *biod, daos_iod_t *iods)
 static int
 obj_fetch_shadow(struct obj_io_context *ioc, daos_unit_oid_t oid,
 		 daos_epoch_t epoch, uint64_t cond_flags, daos_key_t *dkey,
-		 unsigned int iod_nr, daos_iod_t *iods, uint32_t tgt_idx,
-		 struct dtx_handle *dth, struct daos_recx_ep_list **pshadows)
+		 uint64_t dkey_hash, unsigned int iod_nr, daos_iod_t *iods,
+		 uint32_t tgt_idx, struct dtx_handle *dth,
+		 struct daos_recx_ep_list **pshadows)
 {
 	daos_handle_t			 ioh = DAOS_HDL_INVAL;
 	int				 rc;
@@ -1099,9 +1100,10 @@ obj_fetch_shadow(struct obj_io_context *ioc, daos_unit_oid_t oid,
 out:
 	obj_iod_idx_parity2vos(iod_nr, iods);
 	if (rc == 0) {
+		uint32_t tgt_off = obj_ec_shard_off(dkey_hash, &ioc->ioc_oca, tgt_idx);
+
 		obj_shadow_list_vos2daos(iod_nr, *pshadows, &ioc->ioc_oca);
-		rc = obj_iod_recx_vos2daos(iod_nr, iods, tgt_idx,
-					   &ioc->ioc_oca);
+		rc = obj_iod_recx_vos2daos(iod_nr, iods, tgt_off, &ioc->ioc_oca);
 	}
 	return rc;
 }
@@ -1285,9 +1287,9 @@ obj_local_rw_internal(crt_rpc_t *rpc, struct obj_io_context *ioc,
 	}
 	dkey = (daos_key_t *)&orw->orw_dkey;
 	D_DEBUG(DB_IO,
-		"opc %d oid "DF_UOID" dkey "DF_KEY" tag %d epc "DF_X64".\n",
+		"opc %d oid "DF_UOID" dkey "DF_KEY" tag %d epc "DF_X64" flags %x.\n",
 		opc_get(rpc->cr_opc), DP_UOID(orw->orw_oid), DP_KEY(dkey),
-		tag, orw->orw_epoch);
+		tag, orw->orw_epoch, orw->orw_flags);
 
 	rma = (orw->orw_bulks.ca_arrays != NULL ||
 	       orw->orw_bulks.ca_count != 0);
@@ -1295,9 +1297,9 @@ obj_local_rw_internal(crt_rpc_t *rpc, struct obj_io_context *ioc,
 
 	/* Prepare IO descriptor */
 	if (obj_rpc_is_update(rpc)) {
-		obj_singv_ec_rw_filter(orw->orw_oid, &ioc->ioc_oca, iods, offs,
-				       orw->orw_epoch, orw->orw_flags,
-				       orw->orw_start_shard,
+		obj_singv_ec_rw_filter(orw->orw_oid, &ioc->ioc_oca,
+				       ioc->ioc_ec_rotate_parity ? orw->orw_dkey_hash : 0,
+				       iods, offs, orw->orw_epoch, orw->orw_flags,
 				       orw->orw_nr, true, false, NULL);
 		bulk_op = CRT_BULK_GET;
 
@@ -1349,9 +1351,12 @@ obj_local_rw_internal(crt_rpc_t *rpc, struct obj_io_context *ioc,
 			  "ec_recov %d, ec_deg_fetch %d.\n",
 			  ec_recov, ec_deg_fetch);
 		if (ec_recov) {
+			uint64_t dkey_hash;
+
+			dkey_hash = ioc->ioc_ec_rotate_parity ? orw->orw_dkey_hash : 0;
 			D_ASSERT(obj_ec_tgt_nr(&ioc->ioc_oca) > 0);
-			is_parity_shard = (orw->orw_oid.id_shard % obj_ec_tgt_nr(&ioc->ioc_oca)) >=
-					  obj_ec_data_tgt_nr(&ioc->ioc_oca);
+			is_parity_shard = is_ec_parity_shard(orw->orw_oid.id_shard, dkey_hash,
+							     &ioc->ioc_oca);
 			get_parity_list = ec_recov && is_parity_shard &&
 					  ((orw->orw_flags & ORF_EC_RECOV_SNAP) == 0);
 		}
@@ -1393,8 +1398,8 @@ obj_local_rw_internal(crt_rpc_t *rpc, struct obj_io_context *ioc,
 
 			rc = obj_fetch_shadow(ioc, orw->orw_oid,
 					      orw->orw_epoch, cond_flags, dkey,
-					      orw->orw_nr, iods,
-					      orw->orw_tgt_idx, dth, &shadows);
+					      ioc->ioc_ec_rotate_parity ? orw->orw_dkey_hash : 0,
+					      orw->orw_nr, iods, orw->orw_tgt_idx, dth, &shadows);
 			if (rc) {
 				D_ERROR(DF_UOID" Fetch shadow failed: "DF_RC
 					"\n", DP_UOID(orw->orw_oid), DP_RC(rc));
@@ -1458,11 +1463,9 @@ obj_local_rw_internal(crt_rpc_t *rpc, struct obj_io_context *ioc,
 			recov_lists = vos_ioh2recx_list(ioh);
 		}
 		rc = obj_singv_ec_rw_filter(orw->orw_oid, &ioc->ioc_oca,
-					    iods, offs, orw->orw_epoch,
-					    orw->orw_flags,
-					    orw->orw_start_shard,
-					    orw->orw_nr, false,
-					    ec_deg_fetch, &recov_lists);
+					    ioc->ioc_ec_rotate_parity ? orw->orw_dkey_hash : 0,
+					    iods, offs, orw->orw_epoch, orw->orw_flags,
+					    orw->orw_nr, false, ec_deg_fetch, &recov_lists);
 		if (rc != 0) {
 			D_ERROR(DF_UOID" obj_singv_ec_rw_filter failed: "
 				DF_RC".\n", DP_UOID(orw->orw_oid), DP_RC(rc));
@@ -1772,6 +1775,7 @@ out:
 	ioc->ioc_vos_coh = coc->sc_hdl;
 	ioc->ioc_coc	 = coc;
 	ioc->ioc_coh	 = coh;
+	ioc->ioc_ec_rotate_parity = 0;
 	return 0;
 failed:
 	if (coc != NULL)
@@ -2568,10 +2572,11 @@ again1:
 
 again2:
 	if (orw->orw_iod_array.oia_oiods != NULL && split_req == NULL) {
-		rc = obj_ec_rw_req_split(orw->orw_oid, &orw->orw_iod_array,
-					 orw->orw_nr, orw->orw_start_shard,
-					 orw->orw_tgt_max, PO_COMP_ID_ALL,
-					 NULL, 0, &ioc.ioc_oca, tgt_cnt, tgts, &split_req);
+		rc = obj_ec_rw_req_split(orw->orw_oid,
+					 ioc.ioc_ec_rotate_parity ? orw->orw_dkey_hash : 0,
+					 &orw->orw_iod_array, orw->orw_nr, orw->orw_start_shard,
+					 orw->orw_tgt_max, PO_COMP_ID_ALL, NULL, 0, &ioc.ioc_oca,
+					 tgt_cnt, tgts, &split_req);
 		if (rc != 0) {
 			D_ERROR(DF_UOID": obj_ec_rw_req_split failed, rc %d.\n",
 				DP_UOID(orw->orw_oid), rc);
@@ -2895,6 +2900,7 @@ re_pack:
 		enum_arg->kds_len = 0;
 		enum_arg->kds[0].kd_key_len = 0;
 		enum_arg->kds_cap = 4;
+		fill_oid(oei->oei_oid, enum_arg);
 		goto re_pack;
 	} else if (enum_arg->size_query) {
 		D_DEBUG(DB_IO, DF_UOID "query size by kds %d total %zd\n",
@@ -3932,9 +3938,9 @@ ds_cpd_handle_one(crt_rpc_t *rpc, struct daos_cpd_sub_head *dcsh,
 				D_GOTO(out, rc);
 
 			obj_singv_ec_rw_filter(dcsr->dcsr_oid, &ioc->ioc_oca,
-					iods, offs, dcsh->dcsh_epoch.oe_value,
-					dcu->dcu_flags, dcu->dcu_start_shard,
-					dcsr->dcsr_nr, true, false, NULL);
+					       ioc->ioc_ec_rotate_parity ? dcsr->dcsr_dkey_hash : 0,
+					       iods, offs, dcsh->dcsh_epoch.oe_value,
+					       dcu->dcu_flags, dcsr->dcsr_nr, true, false, NULL);
 		} else {
 			iods = dcu->dcu_iod_array.oia_iods;
 			csums = dcu->dcu_iod_array.oia_iod_csums;
@@ -4368,7 +4374,8 @@ static int
 ds_obj_dtx_leader_prep_handle(struct daos_cpd_sub_head *dcsh,
 			      struct daos_cpd_sub_req *dcsrs,
 			      struct daos_shard_tgt *tgts,
-			      int tgt_cnt, int req_cnt, uint32_t *flags)
+			      int tgt_cnt, int req_cnt, struct obj_io_context *ioc,
+			      uint32_t *flags)
 {
 	struct dtx_daos_target	*ddt = &dcsh->dcsh_mbs->dm_tgts[0];
 	int			 rc = 0;
@@ -4386,9 +4393,10 @@ ds_obj_dtx_leader_prep_handle(struct daos_cpd_sub_head *dcsh,
 		if (dcu->dcu_iod_array.oia_oiods == NULL)
 			continue;
 
-		rc = obj_ec_rw_req_split(dcsr->dcsr_oid, &dcu->dcu_iod_array,
-					 dcsr->dcsr_nr, dcu->dcu_start_shard, 0,
-					 ddt->ddt_id,
+		rc = obj_ec_rw_req_split(dcsr->dcsr_oid,
+					 ioc->ioc_ec_rotate_parity ? dcsr->dcsr_dkey_hash : 0,
+					 &dcu->dcu_iod_array, dcsr->dcsr_nr,
+					 dcu->dcu_start_shard, 0, ddt->ddt_id,
 					 dcu->dcu_ec_tgts, dcsr->dcsr_ec_tgt_nr,
 					 NULL, tgt_cnt, tgts, &dcu->dcu_ec_split_req);
 		if (rc != 0) {
@@ -4510,7 +4518,7 @@ again:
 		D_GOTO(out, rc = -DER_TX_RESTART);
 
 	rc = ds_obj_dtx_leader_prep_handle(dcsh, dcsrs, tgts, tgt_cnt,
-					   req_cnt, &flags);
+					   req_cnt, dca->dca_ioc, &flags);
 	if (rc != 0)
 		goto out;
 

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -1983,6 +1983,12 @@ obj_ioc_begin(daos_obj_id_t oid, uint32_t rpc_map_ver, uuid_t pool_uuid,
 	if (rc != 0)
 		return rc;
 
+	if (obj_is_modification_opc(opc) && (flags & ORF_REINTEGRATING_IO) &&
+	    ioc->ioc_coc->sc_pool->spc_rebuild_fence == 0) {
+		D_ERROR("reintegrating "DF_UUID" retry.\n", DP_UUID(pool_uuid));
+		D_GOTO(failed, rc = -DER_UPDATE_AGAIN);
+	}
+
 	rc = obj_capa_check(ioc->ioc_coh, obj_is_modification_opc(opc),
 			    obj_is_ec_agg_opc(opc) ||
 			    (flags & ORF_FOR_MIGRATION) ||

--- a/src/object/srv_obj_migrate.c
+++ b/src/object/srv_obj_migrate.c
@@ -40,6 +40,7 @@
 
 struct migrate_one {
 	daos_key_t		 mo_dkey;
+	uint64_t		 mo_dkey_hash;
 	uuid_t			 mo_pool_uuid;
 	uuid_t			 mo_cont_uuid;
 	daos_unit_oid_t		 mo_oid;
@@ -537,7 +538,7 @@ mrone_recx_daos2_vos(struct migrate_one *mrone, daos_iod_t *iods, int iods_num)
 static void
 mrone_recx_vos2_daos(struct migrate_one *mrone, int shard, daos_iod_t *iods, int iods_num)
 {
-	shard = shard % obj_ec_tgt_nr(&mrone->mo_oca);
+	shard = obj_ec_shard_off(mrone->mo_dkey_hash, &mrone->mo_oca, shard);
 	D_ASSERT(shard < obj_ec_data_tgt_nr(&mrone->mo_oca));
 	mrone_recx_daos_vos_internal(mrone, false, shard, iods, iods_num);
 }
@@ -552,18 +553,16 @@ mrone_obj_fetch(struct migrate_one *mrone, daos_handle_t oh, d_sg_list_t *sgls,
 	if (daos_oclass_grp_size(&mrone->mo_oca) > 1)
 		flags |= DIOF_TO_LEADER;
 
+	/**
+	 * For EC data migration, let's force it to do degraded fetch,
+	 * make sure reintegration will not fetch from the original
+	 * shard, which might cause parity corruption.
+	 */
 	if (daos_oclass_is_ec(&mrone->mo_oca) &&
-	    iods[0].iod_type != DAOS_IOD_SINGLE) {
-		unsigned int shard = mrone->mo_oid.id_shard %
-			     daos_oclass_grp_size(&mrone->mo_oca);
-
-		/* For EC data migration, let's force it to do degraded fetch,
-		 * make sure reintegration will not fetch from the original
-		 * shard, which might cause parity corruption.
-		 */
-		if (shard < obj_ec_data_tgt_nr(&mrone->mo_oca))
-			flags |= DIOF_FOR_FORCE_DEGRADE;
-	}
+	    iods[0].iod_type != DAOS_IOD_SINGLE &&
+	    is_ec_data_shard(mrone->mo_oid.id_shard, mrone->mo_dkey_hash,
+			     &mrone->mo_oca))
+		flags |= DIOF_FOR_FORCE_DEGRADE;
 
 	rc = dsc_obj_fetch(oh, mrone->mo_epoch, &mrone->mo_dkey,
 			   iod_num, iods, sgls, NULL,
@@ -705,7 +704,7 @@ migrate_fetch_update_inline(struct migrate_one *mrone, daos_handle_t oh,
 	}
 
 	if (daos_oclass_is_ec(&mrone->mo_oca) &&
-	    !obj_shard_is_ec_parity(mrone->mo_oid, &mrone->mo_oca))
+	    !is_ec_parity_shard(mrone->mo_oid.id_shard, mrone->mo_dkey_hash, &mrone->mo_oca))
 		mrone_recx_daos2_vos(mrone, mrone->mo_iods, mrone->mo_iod_num);
 
 	csummer = dsc_cont2csummer(dc_obj_hdl2cont_hdl(oh));
@@ -774,34 +773,6 @@ out:
 }
 
 static int
-obj_ec_encode_buf(daos_obj_id_t oid, struct daos_oclass_attr *oca,
-		  daos_size_t iod_size, unsigned char *buffer,
-		  unsigned char *p_bufs[])
-{
-	struct obj_ec_codec	*codec;
-	daos_size_t	cell_bytes = obj_ec_cell_rec_nr(oca) * iod_size;
-	unsigned int	k = obj_ec_data_tgt_nr(oca);
-	unsigned int	p = obj_ec_parity_tgt_nr(oca);
-	unsigned char	*data[k];
-	int		i;
-
-	codec = obj_ec_codec_get(daos_obj_id2class(oid));
-	D_ASSERT(codec != NULL);
-
-	for (i = 0; i < p && p_bufs[i] == NULL; i++) {
-		D_ALLOC(p_bufs[i], cell_bytes);
-		if (p_bufs[i] == NULL)
-			return -DER_NOMEM;
-	}
-
-	for (i = 0; i < k; i++)
-		data[i] = buffer + i * cell_bytes;
-
-	ec_encode_data((int)cell_bytes, k, p, codec->ec_gftbls, data, p_bufs);
-	return 0;
-}
-
-static int
 migrate_update_parity(struct migrate_one *mrone, daos_epoch_t parity_eph,
 		      struct ds_cont_child *ds_cont,
 		      unsigned char *buffer, daos_off_t offset,
@@ -829,8 +800,8 @@ migrate_update_parity(struct migrate_one *mrone, daos_epoch_t parity_eph,
 		if (write_nr == stride_nr) {
 			unsigned int shard;
 
-			shard = mrone->mo_oid.id_shard % obj_ec_tgt_nr(oca);
-
+			shard = obj_ec_shard_off(mrone->mo_dkey_hash, oca,
+						 mrone->mo_oid.id_shard);
 			D_ASSERT(shard >= obj_ec_data_tgt_nr(oca));
 			shard -= obj_ec_data_tgt_nr(oca);
 			D_ASSERT(shard < obj_ec_parity_tgt_nr(oca));
@@ -1031,7 +1002,6 @@ migrate_fetch_update_single(struct migrate_one *mrone, daos_handle_t oh,
 
 	for (i = 0; i < mrone->mo_iod_num; i++) {
 		daos_iod_t	*iod = &mrone->mo_iods[i];
-		uint32_t	start_shard;
 
 		if (mrone->mo_iods[i].iod_size == 0) {
 			/* zero size iod will cause assertion failure
@@ -1059,34 +1029,29 @@ migrate_fetch_update_single(struct migrate_one *mrone, daos_handle_t oh,
 		if (!daos_oclass_is_ec(&mrone->mo_oca))
 			continue;
 
-		start_shard = rounddown(mrone->mo_oid.id_shard,
-					obj_ec_tgt_nr(&mrone->mo_oca));
-		if (obj_ec_singv_one_tgt(iod->iod_size, &sgls[i],
-					 &mrone->mo_oca)) {
+		if (obj_ec_singv_one_tgt(iod->iod_size, &sgls[i], &mrone->mo_oca)) {
 			D_DEBUG(DB_REBUILD, DF_UOID" one tgt.\n",
 				DP_UOID(mrone->mo_oid));
 			los[i].cs_even_dist = 0;
 			continue;
 		}
 
-		if (obj_shard_is_ec_parity(mrone->mo_oid, &mrone->mo_oca)) {
-			rc = obj_ec_singv_encode_buf(mrone->mo_oid,
-						     &mrone->mo_oca,
-						     iod, &sgls[i],
+		if (is_ec_parity_shard(mrone->mo_oid.id_shard, mrone->mo_dkey_hash,
+				       &mrone->mo_oca)) {
+			rc = obj_ec_singv_encode_buf(mrone->mo_oid, &mrone->mo_oca,
+						     mrone->mo_dkey_hash, iod, &sgls[i],
 						     &sgls[i].sg_iovs[0]);
 			if (rc)
 				D_GOTO(out, rc);
 		} else {
-			rc = obj_ec_singv_split(mrone->mo_oid, &mrone->mo_oca,
+			rc = obj_ec_singv_split(mrone->mo_oid, &mrone->mo_oca, mrone->mo_dkey_hash,
 						iod->iod_size, &sgls[i]);
 			if (rc)
 				D_GOTO(out, rc);
 		}
 
-		obj_singv_ec_rw_filter(mrone->mo_oid, &mrone->mo_oca, iod,
-				       NULL, mrone->mo_epoch, ORF_EC,
-				       start_shard, 1,
-				       true, false, NULL);
+		obj_singv_ec_rw_filter(mrone->mo_oid, &mrone->mo_oca, mrone->mo_dkey_hash, iod,
+				       NULL, mrone->mo_epoch, ORF_EC, 1, true, false, NULL);
 		los[i].cs_even_dist = 1;
 		los[i].cs_bytes = obj_ec_singv_cell_bytes(
 					mrone->mo_iods[i].iod_size,
@@ -1176,9 +1141,9 @@ __migrate_fetch_update_bulk(struct migrate_one *mrone, daos_handle_t oh,
 	}
 
 	D_DEBUG(DB_REBUILD,
-		DF_UOID" mrone %p dkey "DF_KEY" nr %d eph "DF_X64"\n",
+		DF_UOID" mrone %p dkey "DF_KEY" nr %d eph "DF_X64"/"DF_X64"\n",
 		DP_UOID(mrone->mo_oid), mrone, DP_KEY(&mrone->mo_dkey),
-		iod_num, mrone->mo_epoch);
+		iod_num, mrone->mo_epoch, update_eph);
 
 	if (daos_oclass_is_ec(&mrone->mo_oca))
 		mrone_recx_vos2_daos(mrone, mrone->mo_oid.id_shard, iods, iod_num);
@@ -1257,7 +1222,7 @@ migrate_fetch_update_bulk(struct migrate_one *mrone, daos_handle_t oh,
 {
 	int rc = 0;
 
-	if (obj_shard_is_ec_parity(mrone->mo_oid, &mrone->mo_oca))
+	if (obj_shard_is_ec_parity(mrone->mo_oid, mrone->mo_dkey_hash, &mrone->mo_oca))
 		return migrate_fetch_update_parity(mrone, oh, ds_cont);
 
 	if (!daos_oclass_is_ec(&mrone->mo_oca))
@@ -1470,7 +1435,8 @@ migrate_dkey(struct migrate_pool_tls *tls, struct migrate_one *mrone,
 
 	if (mrone->mo_iods[0].iod_type == DAOS_IOD_SINGLE)
 		rc = migrate_fetch_update_single(mrone, oh, cont);
-	else if (obj_shard_is_ec_parity(mrone->mo_oid, &mrone->mo_oca))
+	else if (obj_shard_is_ec_parity(mrone->mo_oid, mrone->mo_dkey_hash,
+					&mrone->mo_oca))
 		rc = migrate_fetch_update_parity(mrone, oh, cont);
 	else if (data_size < MAX_BUF_SIZE || data_size == (daos_size_t)(-1))
 		rc = migrate_fetch_update_inline(mrone, oh, cont);
@@ -1792,7 +1758,9 @@ rw_iod_pack(struct migrate_one *mrone, daos_iod_t *iod, daos_epoch_t *ephs, d_sg
 			total_size += iod->iod_recxs[i].rx_nr * iod->iod_size;
 			if (iod->iod_recxs[i].rx_idx & PARITY_INDICATOR) {
 				if (nr > 0) {
-					/* Once there are parity extents, let's add replicate */
+					/* Once there are parity extents, let's add previous
+					 * accumulated replicate extents.
+					 **/
 					rc = migrate_insert_recxs_sgl(mrone->mo_iods,
 								      mrone->mo_iods_update_ephs,
 								      &mrone->mo_iod_num, iod,
@@ -1805,11 +1773,16 @@ rw_iod_pack(struct migrate_one *mrone, daos_iod_t *iod, daos_epoch_t *ephs, d_sg
 					nr = 0;
 				}
 				parity_nr++;
+				D_DEBUG(DB_REBUILD, "parity recx "DF_X64"/"DF_X64" %d/%d\n",
+					iod->iod_recxs[i].rx_idx, iod->iod_recxs[i].rx_nr,
+					parity_nr, nr);
 				iod->iod_recxs[i].rx_idx = iod->iod_recxs[i].rx_idx &
 							    ~PARITY_INDICATOR;
 			} else {
 				if (parity_nr > 0) {
-					/* Once there are replicate extents, let's add parity */
+					/* Once there are replicate extents, let's add previous
+					 * accumulated parity extents
+					 **/
 					rc = migrate_insert_recxs_sgl(
 								mrone->mo_iods_from_parity, NULL,
 								&mrone->mo_iods_num_from_parity,
@@ -1822,10 +1795,10 @@ rw_iod_pack(struct migrate_one *mrone, daos_iod_t *iod, daos_epoch_t *ephs, d_sg
 					parity_nr = 0;
 				}
 				nr++;
+				D_DEBUG(DB_REBUILD, "replicate recx "DF_X64"/"DF_X64" %d/%d\n",
+					iod->iod_recxs[i].rx_idx, iod->iod_recxs[i].rx_nr,
+					parity_nr, nr);
 			}
-			D_DEBUG(DB_REBUILD, "new recx "DF_X64"/"DF_U64", parity_nr %d, nr %d, "
-				"start %d.\n", iod->iod_recxs[i].rx_idx, iod->iod_recxs[i].rx_nr,
-				parity_nr, nr, start);
 		}
 
 
@@ -1960,10 +1933,12 @@ out:
 
 struct enum_unpack_arg {
 	struct iter_obj_arg	*arg;
+	daos_handle_t		oh;
 	struct daos_oclass_attr	oc_attr;
 	daos_epoch_range_t	epr;
 	d_list_t		merge_list;
-	uint32_t		iterate_parity:1;
+	uint32_t		version;
+	uint32_t		ec_rotate_parity:1;
 };
 
 static int
@@ -2041,6 +2016,7 @@ migrate_one_create(struct enum_unpack_arg *arg, struct dc_obj_enum_unpack_io *io
 	mrone->mo_iod_alloc_num = iod_eph_total;
 	mrone->mo_min_epoch = DAOS_EPOCH_MAX;
 	mrone->mo_version = version;
+	mrone->mo_dkey_hash = io->ui_dkey_hash;
 
 	/* only do the copy below when each with inline recx data */
 	for (i = 0; i < iod_eph_total; i++) {
@@ -2107,6 +2083,7 @@ static int
 migrate_enum_unpack_cb(struct dc_obj_enum_unpack_io *io, void *data)
 {
 	struct enum_unpack_arg	*arg = data;
+	uint32_t		shard = arg->arg->shard;
 	struct migrate_one	*mo;
 	bool			merged = false;
 	int			rc = 0;
@@ -2115,40 +2092,69 @@ migrate_enum_unpack_cb(struct dc_obj_enum_unpack_io *io, void *data)
 	if (!daos_oclass_is_ec(&arg->oc_attr))
 		return migrate_one_create(arg, io);
 
+	/**
+	 * If parity shard alive for this dkey, then ignore the data shard enumeration
+	 * from data shard.
+	 */
+	rc = obj_ec_parity_alive(arg->oh, io->ui_dkey_hash, arg->version);
+	if (rc < 0)
+		return rc;
+
+	if (!arg->ec_rotate_parity)
+		io->ui_dkey_hash = 0;
+
+	if (rc == 1 &&
+	    is_ec_data_shard(io->ui_oid.id_shard, io->ui_dkey_hash, &arg->oc_attr)) {
+		D_DEBUG(DB_REBUILD, DF_UOID" ignore data shard "DF_KEY"/%u/"DF_U64".\n",
+			DP_UOID(io->ui_oid), DP_KEY(&io->ui_dkey), shard,
+			obj_ec_shard_off(io->ui_dkey_hash, &arg->oc_attr, 0));
+		return 0;
+	}
+	rc = 0;
+
 	/* Convert EC object offset to DAOS offset. */
 	for (i = 0; i <= io->ui_iods_top; i++) {
 		daos_iod_t	*iod = &io->ui_iods[i];
 		daos_epoch_t	**ephs = &io->ui_recx_ephs[i];
-		uint32_t	shard;
 
 		if (iod->iod_type == DAOS_IOD_SINGLE)
 			continue;
 
-		shard = arg->arg->shard % obj_ec_tgt_nr(&arg->oc_attr);
-		/* For data shard, convert to single shard offset */
-		if (is_ec_data_shard(shard, &arg->oc_attr)) {
-			rc = obj_recx_ec2_daos(&arg->oc_attr, io->ui_oid.id_shard,
-					       &iod->iod_recxs, ephs, &iod->iod_nr, false);
-			if (rc != 0)
-				return rc;
+		D_DEBUG(DB_REBUILD, DF_UOID" unpack for shard %u start EC "DF_U64"/"DF_X64"\n",
+			DP_UOID(io->ui_oid), shard,
+			obj_ec_shard_off(io->ui_dkey_hash, &arg->oc_attr, 0), io->ui_dkey_hash);
 
-			D_DEBUG(DB_REBUILD, "convert shard %u tgt %d\n", shard,
+		/**
+		 * Since we do not need split the rebuild into parity rebuild
+		 * (by mo_iods_from_parity) and partial updatei(by mo_iods),
+		 * so it does not need keep the PARITY BIT in recx, see rw_iod_pack().
+		 */
+		rc = obj_recx_ec2_daos(&arg->oc_attr, io->ui_dkey_hash, io->ui_oid.id_shard,
+				       &iod->iod_recxs, ephs, &iod->iod_nr,
+				       is_ec_parity_shard(shard, io->ui_dkey_hash,
+							  &arg->oc_attr) ? true : false);
+		if (rc != 0) {
+			D_ERROR(DF_UOID" ec 2 daos %u failed: "DF_RC"\n",
+				DP_UOID(io->ui_oid), shard, DP_RC(rc));
+			return rc;
+		}
+
+		/* Filter the DAOS recxs to the rebuild data shard */
+		if (is_ec_data_shard(shard, io->ui_dkey_hash, &arg->oc_attr)) {
+			D_DEBUG(DB_REBUILD, DF_UOID" convert shard %u tgt %d\n",
+				DP_UOID(io->ui_oid), shard,
 				obj_ec_data_tgt_nr(&arg->oc_attr));
 
-			rc = obj_recx_ec_daos2shard(&arg->oc_attr, shard, &iod->iod_recxs,
-						    ephs, &iod->iod_nr);
-			if (rc)
+			rc = obj_recx_ec_daos2shard(&arg->oc_attr, io->ui_dkey_hash, shard,
+						    &iod->iod_recxs, ephs, &iod->iod_nr);
+			if (rc) {
+				D_ERROR(DF_UOID" daos to shard %u failed: "DF_RC"\n",
+					DP_UOID(io->ui_oid), shard, DP_RC(rc));
 				return rc;
-
+			}
 			/* No data needs to be migrate. */
 			if (iod->iod_nr == 0)
 				continue;
-		} else {
-			/* parity shard */
-			rc = obj_recx_ec2_daos(&arg->oc_attr, io->ui_oid.id_shard,
-					       &iod->iod_recxs, ephs, &iod->iod_nr, true);
-			if (rc != 0)
-				return rc;
 		}
 	}
 
@@ -2294,7 +2300,7 @@ migrate_one_epoch_object(daos_epoch_range_t *epr, struct migrate_pool_tls *tls,
 	int			 rc = 0;
 
 	D_DEBUG(DB_REBUILD, "migrate obj "DF_UOID" for shard %u eph "
-		DF_U64"-"DF_U64"\n", DP_UOID(arg->oid), arg->shard, epr->epr_lo,
+		DF_X64"-"DF_X64"\n", DP_UOID(arg->oid), arg->shard, epr->epr_lo,
 		epr->epr_hi);
 
 	if (tls->mpt_fini) {
@@ -2329,6 +2335,9 @@ migrate_one_epoch_object(daos_epoch_range_t *epr, struct migrate_pool_tls *tls,
 	memset(&akey_anchor, 0, sizeof(akey_anchor));
 	unpack_arg.arg = arg;
 	unpack_arg.epr = *epr;
+	unpack_arg.oh = oh;
+	unpack_arg.version = tls->mpt_version;
+	unpack_arg.ec_rotate_parity = 0;
 	D_INIT_LIST_HEAD(&unpack_arg.merge_list);
 	buf = stack_buf;
 	buf_len = ITER_BUF_SIZE;
@@ -2379,8 +2388,7 @@ retry:
 			 * shards, so buffer needs to time grp_size to make sure
 			 * retry buffer will be large enough.
 			 */
-			if (daos_oclass_is_ec(&unpack_arg.oc_attr) &&
-			    obj_shard_is_ec_parity(arg->oid, &unpack_arg.oc_attr))
+			if (daos_oclass_is_ec(&unpack_arg.oc_attr))
 				buf_len = roundup(kds[0].kd_key_len * 2 *
 						  daos_oclass_grp_size(&unpack_arg.oc_attr), 8);
 			else

--- a/src/object/srv_obj_migrate.c
+++ b/src/object/srv_obj_migrate.c
@@ -2604,7 +2604,7 @@ destroy_existing_obj(struct migrate_pool_tls *tls, unsigned int tgt_idx,
 		return 0;
 	}
 
-	epr.epr_hi = tls->mpt_max_eph;
+	epr.epr_hi = cont->sc_pool->spc_rebuild_fence;
 	epr.epr_lo = 0;
 	rc = vos_discard(cont->sc_hdl, oid, &epr, NULL, NULL);
 	if (rc != 0) {

--- a/src/object/srv_obj_remote.c
+++ b/src/object/srv_obj_remote.c
@@ -125,7 +125,7 @@ ds_obj_remote_update(struct dtx_leader_handle *dlh, void *data, int idx,
 	orw = crt_req_get(req);
 	*orw = *orw_parent;
 	if (split_req != NULL) {
-		tgt_idx = shard_tgt->st_shard;
+		tgt_idx = shard_tgt->st_shard_id;
 		tgt_oiod = obj_ec_tgt_oiod_get(split_req->osr_tgt_oiods,
 					       dlh->dlh_sub_cnt + 1,
 					       tgt_idx - obj_exec_arg->start);
@@ -356,7 +356,7 @@ ds_obj_cpd_clone_reqs(struct daos_shard_tgt *tgt, struct daos_cpd_disp_ent *dcde
 
 				oiod = obj_ec_tgt_oiod_get(split->osr_tgt_oiods,
 						dcsr_parent[idx].dcsr_ec_tgt_nr,
-						dcri_parent->dcri_shard_off -
+						dcri_parent->dcri_shard_id -
 						dcu_parent->dcu_start_shard);
 				D_ASSERT(oiod != NULL);
 

--- a/src/rebuild/rebuild_iv.c
+++ b/src/rebuild/rebuild_iv.c
@@ -191,7 +191,7 @@ rebuild_iv_ent_refresh(struct ds_iv_entry *entry, struct ds_iv_key *key,
 			DP_UUID(src_iv->riv_pool_uuid), src_iv->riv_ver,
 			src_iv->riv_rebuild_gen, dst_iv->riv_global_scan_done,
 			dst_iv->riv_global_done, dst_iv->riv_stable_epoch,
-			dst_iv->riv_dtx_resyc_version);
+			dst_iv->riv_global_dtx_resyc_version);
 
 		if (rpt->rt_stable_epoch == 0)
 			rpt->rt_stable_epoch = dst_iv->riv_stable_epoch;

--- a/src/tests/suite/daos_aggregate_ec.c
+++ b/src/tests/suite/daos_aggregate_ec.c
@@ -358,8 +358,9 @@ verify_1p(struct ec_agg_test_ctx *ctx, daos_oclass_id_t ec_agg_oc,
 	unsigned char		**data = NULL;
 	unsigned char		**parity = NULL;
 	unsigned char		*buf = NULL;
-	unsigned int		 k, p, len;
-	int			 i, j, rc;
+	unsigned int		p_shard;
+	unsigned int		k, p, len;
+	int			i, j, rc;
 
 	if (shard > 2)
 		ec_setup_obj(ctx, ec_agg_oc, 3);
@@ -400,12 +401,13 @@ verify_1p(struct ec_agg_test_ctx *ctx, daos_oclass_id_t ec_agg_oc,
 						  k * (daos_size_t)len, j,
 						  false, false, 0);
 			ctx->fetch_iom.iom_flags = DAOS_IOMF_DETAIL;
+			p_shard = test_ec_get_parity_off(&ctx->dkey, oca);
 			rc = dc_obj_fetch_task_create(ctx->oh, DAOS_TX_NONE, 0,
 						      &ctx->dkey, 1,
 						      DIOF_TO_SPEC_SHARD,
 						      &ctx->fetch_iod,
 						      &ctx->fetch_sgl,
-						      &ctx->fetch_iom, &shard,
+						      &ctx->fetch_iom, &p_shard,
 						      NULL, NULL, NULL, &task);
 			assert_rc_equal(rc, 0);
 			rc = dc_task_schedule(task, true);
@@ -424,7 +426,7 @@ verify_1p(struct ec_agg_test_ctx *ctx, daos_oclass_id_t ec_agg_oc,
 						      DIOF_TO_SPEC_SHARD,
 						      &ctx->fetch_iod,
 						      &ctx->fetch_sgl,
-						      &ctx->fetch_iom, &shard,
+						      &ctx->fetch_iom, &p_shard,
 						      NULL, NULL, NULL, &task);
 			assert_rc_equal(rc, 0);
 			rc = dc_task_schedule(task, true);
@@ -495,7 +497,8 @@ verify_2p(struct ec_agg_test_ctx *ctx, daos_oclass_id_t ec_agg_oc)
 	unsigned char		**data = NULL;
 	unsigned char		**parity = NULL;
 	unsigned char		*buf = NULL;
-	unsigned int		 k, p, len, shard = 2;
+	unsigned int		 k, p, len;
+	uint32_t		p_shard;
 	int			 i, j, rc;
 
 	ec_setup_obj(ctx, ec_agg_oc, 2);
@@ -524,20 +527,20 @@ verify_2p(struct ec_agg_test_ctx *ctx, daos_oclass_id_t ec_agg_oc)
 
 	codec = obj_ec_codec_get(daos_obj_id2class(ctx->oid));
 	ec_encode_data(len, k, p, codec->ec_gftbls, data, parity);
-
 	for (j = 0; j < NUM_KEYS; j++)
 		for (i = 0; i < NUM_STRIPES; i++) {
 			ec_setup_single_recx_data(ctx, EC_SPECIFIED,
 						  i * (2 * len), 2 * len, j,
 						  false, false, 0);
+			p_shard = test_ec_get_parity_off(&ctx->dkey, oca);
 			ctx->fetch_iom.iom_flags = DAOS_IOMF_DETAIL;
-			shard++;
+			p_shard = (p_shard + 1) % (k + p);
 			rc = dc_obj_fetch_task_create(ctx->oh, DAOS_TX_NONE, 0,
 						      &ctx->dkey, 1,
 						      DIOF_TO_SPEC_SHARD,
 						      &ctx->fetch_iod,
 						      &ctx->fetch_sgl,
-						      &ctx->fetch_iom, &shard,
+						      &ctx->fetch_iom, &p_shard,
 						      NULL, NULL, NULL, &task);
 			assert_rc_equal(rc, 0);
 			rc = dc_task_schedule(task, true);
@@ -547,13 +550,13 @@ verify_2p(struct ec_agg_test_ctx *ctx, daos_oclass_id_t ec_agg_oc)
 			task = NULL;
 			memset(&ctx->fetch_iom, 0, sizeof(daos_iom_t));
 			ctx->fetch_iom.iom_flags = DAOS_IOMF_DETAIL;
-			shard--;
+			p_shard = (p_shard - 1) % (k + p);
 			rc = dc_obj_fetch_task_create(ctx->oh, DAOS_TX_NONE, 0,
 						      &ctx->dkey, 1,
 						      DIOF_TO_SPEC_SHARD,
 						      &ctx->fetch_iod,
 						      &ctx->fetch_sgl,
-						      &ctx->fetch_iom, &shard,
+						      &ctx->fetch_iom, &p_shard,
 						      NULL, NULL, NULL, &task);
 			assert_rc_equal(rc, 0);
 			rc = dc_task_schedule(task, true);
@@ -562,7 +565,7 @@ verify_2p(struct ec_agg_test_ctx *ctx, daos_oclass_id_t ec_agg_oc)
 			assert_int_equal(ctx->fetch_iom.iom_nr_out, 0);
 			task = NULL;
 			memset(&ctx->fetch_iom, 0, sizeof(daos_iom_t));
-			shard++;
+			p_shard = (p_shard + 1) % (k + p);
 			ctx->fetch_iom.iom_flags = DAOS_IOMF_DETAIL;
 			ctx->fetch_iod.iod_recxs[0].rx_idx = (i * len) |
 							PARITY_INDICATOR;
@@ -573,7 +576,7 @@ verify_2p(struct ec_agg_test_ctx *ctx, daos_oclass_id_t ec_agg_oc)
 						      DIOF_TO_SPEC_SHARD,
 						      &ctx->fetch_iod,
 						      &ctx->fetch_sgl,
-						      &ctx->fetch_iom, &shard,
+						      &ctx->fetch_iom, &p_shard,
 						      NULL, NULL, NULL, &task);
 			assert_rc_equal(rc, 0);
 			rc = dc_task_schedule(task, true);
@@ -585,7 +588,7 @@ verify_2p(struct ec_agg_test_ctx *ctx, daos_oclass_id_t ec_agg_oc)
 						parity[1], len), 0);
 			task = NULL;
 			memset(&ctx->fetch_iom, 0, sizeof(daos_iom_t));
-			shard--;
+			p_shard = (p_shard - 1) % (k + p);
 			ctx->fetch_iom.iom_flags = DAOS_IOMF_DETAIL;
 			ctx->iom_recx.rx_nr = len;
 			rc = dc_obj_fetch_task_create(ctx->oh, DAOS_TX_NONE, 0,
@@ -593,7 +596,7 @@ verify_2p(struct ec_agg_test_ctx *ctx, daos_oclass_id_t ec_agg_oc)
 						      DIOF_TO_SPEC_SHARD,
 						      &ctx->fetch_iod,
 						      &ctx->fetch_sgl,
-						      &ctx->fetch_iom, &shard,
+						      &ctx->fetch_iom, &p_shard,
 						      NULL, NULL, NULL, &task);
 			assert_rc_equal(rc, 0);
 			rc = dc_task_schedule(task, true);
@@ -710,13 +713,13 @@ test_range_punch(struct ec_agg_test_ctx *ctx)
 }
 
 static void
-verify_rp1p(struct ec_agg_test_ctx *ctx, daos_oclass_id_t ec_agg_oc,
-	    unsigned int shard)
+verify_rp1p(struct ec_agg_test_ctx *ctx, daos_oclass_id_t ec_agg_oc)
 {
 	struct daos_oclass_attr	*oca, oca1;
 	tse_task_t		*task = NULL;
 	unsigned int		 k, len;
 	int			 i, j, rc;
+	unsigned int		p_shard;
 
 	ec_setup_obj(ctx, ec_agg_oc, 4);
 
@@ -739,12 +742,13 @@ verify_rp1p(struct ec_agg_test_ctx *ctx, daos_oclass_id_t ec_agg_oc,
 			ctx->fetch_iod.iod_recxs[0].rx_nr = len;
 			ctx->iom_recx.rx_nr = len;
 			ctx->iom_recx.rx_idx = i * k * len + len;
+			p_shard = test_ec_get_parity_off(&ctx->dkey, oca);
 			rc = dc_obj_fetch_task_create(ctx->oh, DAOS_TX_NONE, 0,
 						      &ctx->dkey, 1,
 						      DIOF_TO_SPEC_SHARD,
 						      &ctx->fetch_iod,
 						      &ctx->fetch_sgl,
-						      &ctx->fetch_iom, &shard,
+						      &ctx->fetch_iom, &p_shard,
 						      NULL, NULL, NULL, &task);
 			assert_rc_equal(rc, 0);
 			rc = dc_task_schedule(task, true);
@@ -764,7 +768,7 @@ verify_rp1p(struct ec_agg_test_ctx *ctx, daos_oclass_id_t ec_agg_oc,
 						      DIOF_TO_SPEC_SHARD,
 						      &ctx->fetch_iod,
 						      &ctx->fetch_sgl,
-						      &ctx->fetch_iom, &shard,
+						      &ctx->fetch_iom, &p_shard,
 						      NULL, NULL, NULL, &task);
 			assert_rc_equal(rc, 0);
 			rc = dc_task_schedule(task, true);
@@ -784,7 +788,7 @@ verify_rp1p(struct ec_agg_test_ctx *ctx, daos_oclass_id_t ec_agg_oc,
 						      DIOF_TO_SPEC_SHARD,
 						      &ctx->fetch_iod,
 						      &ctx->fetch_sgl,
-						      &ctx->fetch_iom, &shard,
+						      &ctx->fetch_iom, &p_shard,
 						      NULL, NULL, NULL, &task);
 			assert_rc_equal(rc, 0);
 			rc = dc_task_schedule(task, true);
@@ -803,7 +807,7 @@ verify_rp1p(struct ec_agg_test_ctx *ctx, daos_oclass_id_t ec_agg_oc,
 						      DIOF_TO_SPEC_SHARD,
 						      &ctx->fetch_iod,
 						      &ctx->fetch_sgl,
-						      &ctx->fetch_iom, &shard,
+						      &ctx->fetch_iom, &p_shard,
 						      NULL, NULL, NULL, &task);
 			assert_rc_equal(rc, 0);
 			rc = dc_task_schedule(task, true);
@@ -858,7 +862,7 @@ test_all_ec_agg(void **statep)
 	verify_1p(&ctx, OC_EC_2P1G1, 2);
 	verify_2p(&ctx, OC_EC_2P2G1);
 	verify_1p(&ctx, OC_EC_4P1G1, 4);
-	verify_rp1p(&ctx, OC_EC_4P1G1, 4);
+	verify_rp1p(&ctx, OC_EC_4P1G1);
 	cleanup_ec_agg_tests(&ctx);
 	daos_debug_set_params(arg->group, -1, DMG_KEY_FAIL_LOC,
 			      0, 0, NULL);

--- a/src/tests/suite/daos_degrade_ec.c
+++ b/src/tests/suite/daos_degrade_ec.c
@@ -685,6 +685,7 @@ degrade_ec_agg_punch(void **state, int shard)
 			punch_recxs(dkey, "a_key", &recx, 1, DAOS_TX_NONE, &req);
 		}
 	}
+	ioreq_fini(&req);
 
 	/* Trigger aggregation */
 	daos_pool_set_prop(arg->pool.pool_uuid, "reclaim", "time");
@@ -694,6 +695,7 @@ degrade_ec_agg_punch(void **state, int shard)
 	rank = get_rank_by_oid_shard(arg, oid, shard);
 	rebuild_pools_ranks(&arg, 1, &rank, 1, false);
 
+	ioreq_init(&req, arg->coh, oid, DAOS_IOD_ARRAY, arg);
 	for (i = 0; i < 12; i++) {
 		char	    dkey[32];
 		daos_off_t offset = i * EC_CELL_SIZE;
@@ -706,6 +708,7 @@ degrade_ec_agg_punch(void **state, int shard)
 					      (daos_size_t)EC_CELL_SIZE, verify_data,
 					      DAOS_TX_NONE, true);
 	}
+	ioreq_fini(&req);
 
 	free(data);
 	free(verify_data);

--- a/src/tests/suite/daos_dist_tx.c
+++ b/src/tests/suite/daos_dist_tx.c
@@ -2604,7 +2604,7 @@ dtx_36(void **state)
 	}
 	par_barrier(PAR_COMM_WORLD);
 
-	reintegrate_single_pool_rank(arg, kill_rank);
+	reintegrate_single_pool_rank(arg, kill_rank, false);
 
 	dtx_fini_req_akey(reqs, akeys, 2, DTX_NC_CNT);
 }
@@ -2736,7 +2736,7 @@ dtx_37(void **state)
 	}
 	par_barrier(PAR_COMM_WORLD);
 
-	reintegrate_single_pool_rank(arg, kill_rank);
+	reintegrate_single_pool_rank(arg, kill_rank, false);
 
 	dtx_fini_req_akey(&req, akeys, 1, DTX_NC_CNT);
 }
@@ -2909,7 +2909,7 @@ dtx_38(void **state)
 	}
 	par_barrier(PAR_COMM_WORLD);
 
-	reintegrate_single_pool_rank(arg, kill_ranks[0]);
+	reintegrate_single_pool_rank(arg, kill_ranks[0], false);
 
 	dtx_fini_req_akey(reqs, akeys, 2, DTX_NC_CNT);
 }
@@ -2986,7 +2986,7 @@ dtx_39(void **state)
 		ioreq_fini(&req);
 	}
 
-	reintegrate_single_pool_rank(arg, kill_rank);
+	reintegrate_single_pool_rank(arg, kill_rank, false);
 }
 
 static void

--- a/src/tests/suite/daos_obj.c
+++ b/src/tests/suite/daos_obj.c
@@ -187,6 +187,7 @@ ioreq_iod_recxs_set(struct ioreq *req, int idx, daos_size_t size,
 		iod->iod_recxs = recxs;
 	} else {
 		iod->iod_nr = 1;
+		iod->iod_recxs = NULL;
 	}
 }
 

--- a/src/tests/suite/daos_obj_ec.c
+++ b/src/tests/suite/daos_obj_ec.c
@@ -297,6 +297,23 @@ ec_rec_list_punch(void **state)
 	ioreq_fini(&req);
 }
 
+#define ec_parity_rotate	0
+
+uint32_t
+test_ec_get_parity_off(daos_key_t *dkey, struct daos_oclass_attr *oca)
+{
+	uint64_t dkey_hash;
+	uint32_t grp_size;
+
+	grp_size = oca->u.ec.e_p + oca->u.ec.e_k;
+	if (ec_parity_rotate)
+		dkey_hash = d_hash_murmur64((unsigned char *)dkey->iov_buf, dkey->iov_len, 5731);
+	else
+		dkey_hash = 0;
+
+	return (dkey_hash % grp_size + oca->u.ec.e_k) % grp_size;
+}
+
 static void
 ec_agg_check_replica_on_parity(test_arg_t *arg, daos_obj_id_t oid, char *dkey,
 			       char *akey, daos_off_t offset, daos_size_t size,
@@ -310,7 +327,10 @@ ec_agg_check_replica_on_parity(test_arg_t *arg, daos_obj_id_t oid, char *dkey,
 	daos_handle_t	oh;
 	char		*buf;
 	struct daos_oclass_attr *oca;
-	uint64_t	shard;
+	uint32_t	shard;
+	uint32_t	p_shard_off;
+	uint32_t	grp_size;
+	int		i;
 	int		rc;
 
 	rc = daos_obj_open(arg->coh, oid, 0, &oh, NULL);
@@ -338,8 +358,11 @@ ec_agg_check_replica_on_parity(test_arg_t *arg, daos_obj_id_t oid, char *dkey,
 
 	daos_obj_verify(arg->coh, oid, DAOS_EPOCH_MAX);
 	assert_true(oid_is_ec(oid, &oca));
-	for (shard = oca->u.ec.e_k; shard < oca->u.ec.e_k + oca->u.ec.e_p;
-	     shard++) {
+
+	grp_size = oca->u.ec.e_p + oca->u.ec.e_k;
+	p_shard_off = test_ec_get_parity_off(&dkey_iov, oca);
+	for (i = 0, shard = p_shard_off; i < oca->u.ec.e_p;
+	     shard = (shard + 1) % grp_size, i++) {
 		tse_task_t	*task = NULL;
 
 		iod.iod_size = 1;
@@ -365,49 +388,22 @@ trigger_and_wait_ec_aggreation(test_arg_t *arg, daos_obj_id_t *oids,
 			       daos_off_t offset, daos_size_t size,
 			       uint64_t fail_loc)
 {
-	d_rank_t  ec_agg_ranks[10];
 	int i;
 
-	for (i = 0; i < oids_nr; i++) {
-		struct daos_oclass_attr *oca;
-		int parity_nr;
-		int j;
-
-		assert_true(oid_is_ec(oids[i], &oca));
-		parity_nr = oca->u.ec.e_p;
-		assert_true(parity_nr < 10);
-
-		get_killing_rank_by_oid(arg, oids[i], 0, parity_nr,
-					ec_agg_ranks, NULL);
-		for (j = 0; j < parity_nr; j++)
-			daos_debug_set_params(arg->group, ec_agg_ranks[j],
-					      DMG_KEY_FAIL_LOC,
-					      fail_loc | DAOS_FAIL_ALWAYS,
-					      0, NULL);
-	}
+	daos_debug_set_params(arg->group, -1, DMG_KEY_FAIL_LOC,
+			      fail_loc | DAOS_FAIL_ALWAYS, 0, NULL);
 
 	print_message("wait for 30 seconds for EC aggregation.\n");
 	sleep(30);
 
 	for (i = 0; i < oids_nr; i++) {
-		struct daos_oclass_attr *oca;
-		int parity_nr;
-		int j;
-
 		if (size > 0 && fail_loc == DAOS_FORCE_EC_AGG)
 			ec_agg_check_replica_on_parity(arg, oids[i], dkey,
 						       akey, offset, size,
 						       false);
-		assert_true(oid_is_ec(oids[i], &oca));
-		parity_nr = oca->u.ec.e_p;
-		assert_true(parity_nr < 10);
-
-		get_killing_rank_by_oid(arg, oids[i], 0, parity_nr,
-					ec_agg_ranks, NULL);
-		for (j = 0; j < parity_nr; j++)
-			daos_debug_set_params(arg->group, ec_agg_ranks[j],
-					      DMG_KEY_FAIL_LOC, 0, 0, NULL);
 	}
+
+	daos_debug_set_params(arg->group, -1, DMG_KEY_FAIL_LOC, 0, 0, NULL);
 }
 
 void
@@ -746,7 +742,6 @@ dfs_ec_check_size_internal(void **state, unsigned fail_loc)
 		assert_int_equal(rc, 0);
 		assert_int_equal(st.st_size, 30 * buf_size);
 	}
-
 	for (i = 30; i > 10; i--) {
 		daos_fail_loc_set(0);
 		rc = dfs_punch(dfs_mt, obj, (daos_off_t)((i - 1) * buf_size),
@@ -1415,8 +1410,8 @@ ec_singv_size_fetch_oc(void **state, unsigned int ec_oc, uint32_t old_len, uint3
 deg_test:
 	size = new_len != 0 ? new_len : old_len;
 	if (degraded_test) {
-		fail_shards[0] = 1;
-		fail_shards[1] = 4;
+		fail_shards[0] = 0;
+		fail_shards[1] = 3;
 		fail_val = daos_shard_fail_value(fail_shards, 2);
 		daos_fail_value_set(fail_val);
 		daos_fail_loc_set(DAOS_FAIL_SHARD_OPEN | DAOS_FAIL_ALWAYS);

--- a/src/tests/suite/daos_rebuild_ec.c
+++ b/src/tests/suite/daos_rebuild_ec.c
@@ -80,6 +80,8 @@ rebuild_ec_internal(void **state, daos_oclass_id_t oclass, int kill_data_nr,
 	rc = daos_obj_verify(arg->coh, oid, DAOS_EPOCH_MAX);
 	assert_int_equal(rc, 0);
 
+	arg->rebuild_cb = reintegrate_inflight_io;
+	arg->rebuild_cb_arg = &oid;
 	reintegrate_pools_ranks(&arg, 1, kill_ranks, kill_ranks_num, false);
 	if (oclass == OC_EC_2P1G1)
 		reintegrate_pools_ranks(&arg, 1, &extra_kill_ranks[0], 1, false);

--- a/src/tests/suite/daos_rebuild_ec.c
+++ b/src/tests/suite/daos_rebuild_ec.c
@@ -80,11 +80,11 @@ rebuild_ec_internal(void **state, daos_oclass_id_t oclass, int kill_data_nr,
 	rc = daos_obj_verify(arg->coh, oid, DAOS_EPOCH_MAX);
 	assert_int_equal(rc, 0);
 
-	reintegrate_pools_ranks(&arg, 1, kill_ranks, kill_ranks_num);
+	reintegrate_pools_ranks(&arg, 1, kill_ranks, kill_ranks_num, false);
 	if (oclass == OC_EC_2P1G1)
-		reintegrate_pools_ranks(&arg, 1, &extra_kill_ranks[0], 1);
+		reintegrate_pools_ranks(&arg, 1, &extra_kill_ranks[0], 1, false);
 	else /* oclass OC_EC_4P2G1 */
-		reintegrate_pools_ranks(&arg, 1, &extra_kill_ranks[0], 2);
+		reintegrate_pools_ranks(&arg, 1, &extra_kill_ranks[0], 2, false);
 
 	ioreq_init(&req, arg->coh, oid, DAOS_IOD_ARRAY, arg);
 	if (write_type == PARTIAL_UPDATE)
@@ -158,7 +158,7 @@ rebuild_mixed_stripes(void **state)
 	free(verify_data);
 	ioreq_fini(&req);
 
-	reintegrate_pools_ranks(&arg, 1, &rank, 1);
+	reintegrate_pools_ranks(&arg, 1, &rank, 1, false);
 }
 
 static void
@@ -251,7 +251,7 @@ rebuild_ec_multi_stripes(void **state)
 	}
 
 	ioreq_fini(&req);
-	reintegrate_pools_ranks(&arg, 1, &rank, 1);
+	reintegrate_pools_ranks(&arg, 1, &rank, 1, false);
 }
 
 static int
@@ -868,7 +868,7 @@ rebuild_ec_parity_multi_group(void **state)
 	rank = get_rank_by_oid_shard(arg, oid, 9);
 	rebuild_single_pool_rank(arg, rank, false);
 
-	reintegrate_single_pool_rank(arg, rank);
+	reintegrate_single_pool_rank(arg, rank, false);
 	ioreq_fini(&req);
 }
 
@@ -929,7 +929,7 @@ rebuild_ec_snapshot(void **state, daos_oclass_id_t oclass, int shard)
 		assert_int_equal(rc, 0);
 	}
 
-	reintegrate_single_pool_rank(arg, rank);
+	reintegrate_single_pool_rank(arg, rank, false);
 	free(data);
 	free(verify_data);
 	ioreq_fini(&req);

--- a/src/tests/suite/daos_rebuild_simple.c
+++ b/src/tests/suite/daos_rebuild_simple.c
@@ -29,38 +29,6 @@
 
 #define DATA_SIZE	(1048576 * 2 + 512)
 
-static int
-reintegrate_inflight_io(void *data)
-{
-	test_arg_t	*arg = data;
-	daos_obj_id_t	oid = *(daos_obj_id_t *)arg->rebuild_cb_arg;
-	struct ioreq	req;
-	int		i;
-
-	ioreq_init(&req, arg->coh, oid, DAOS_IOD_ARRAY, arg);
-	for (i = 0; i < 5; i++) {
-		char	key[32];
-		daos_recx_t recx;
-		char	buf[DATA_SIZE];
-
-		sprintf(key, "d_inflight_%d", i);
-		insert_single(key, "a_key", 0, "data", strlen("data") + 1,
-			      DAOS_TX_NONE, &req);
-
-		sprintf(key, "d_inflight_1M_%d", i);
-		recx.rx_idx = 0;
-		recx.rx_nr = DATA_SIZE;
-		memset(buf, 'a', DATA_SIZE);
-		insert_recxs(key, "a_key_1M", 1, DAOS_TX_NONE, &recx, 1,
-			     buf, DATA_SIZE, &req);
-	}
-	ioreq_fini(&req);
-	if (arg->myrank == 0)
-		daos_debug_set_params(arg->group, -1, DMG_KEY_FAIL_LOC, 0, 0,
-				      NULL);
-	return 0;
-}
-
 static void
 reintegrate_with_inflight_io(test_arg_t *arg, daos_obj_id_t *oid,
 			     d_rank_t rank, int tgt)

--- a/src/tests/suite/daos_rebuild_simple.c
+++ b/src/tests/suite/daos_rebuild_simple.c
@@ -29,10 +29,6 @@
 
 #define DATA_SIZE	(1048576 * 2 + 512)
 
-#if 0
-/* Disable inflight IO due to DAOS-8775 for 2.0, and re-enable it until inflight I/O
- * during reintegrated are supported.
- */
 static int
 reintegrate_inflight_io(void *data)
 {
@@ -41,7 +37,6 @@ reintegrate_inflight_io(void *data)
 	struct ioreq	req;
 	int		i;
 
-	rebuild_pool_connect_internal(arg);
 	ioreq_init(&req, arg->coh, oid, DAOS_IOD_ARRAY, arg);
 	for (i = 0; i < 5; i++) {
 		char	key[32];
@@ -60,13 +55,11 @@ reintegrate_inflight_io(void *data)
 			     buf, DATA_SIZE, &req);
 	}
 	ioreq_fini(&req);
-	rebuild_pool_disconnect_internal(arg);
 	if (arg->myrank == 0)
 		daos_debug_set_params(arg->group, -1, DMG_KEY_FAIL_LOC, 0, 0,
 				      NULL);
 	return 0;
 }
-#endif
 
 static void
 reintegrate_with_inflight_io(test_arg_t *arg, daos_obj_id_t *oid,
@@ -74,21 +67,18 @@ reintegrate_with_inflight_io(test_arg_t *arg, daos_obj_id_t *oid,
 {
 	daos_obj_id_t inflight_oid;
 
-#if 0
-	/* Disable it due to DAOS-7420 */
 	if (oid != NULL) {
 		inflight_oid = *oid;
 	} else {
-#endif
-	inflight_oid = daos_test_oid_gen(arg->coh,
+		inflight_oid = daos_test_oid_gen(arg->coh,
 					 DAOS_OC_R3S_SPEC_RANK, 0,
 					 0, arg->myrank);
-	inflight_oid = dts_oid_set_rank(inflight_oid, rank);
+		inflight_oid = dts_oid_set_rank(inflight_oid, rank);
+	}
 
-#if 0
 	arg->rebuild_cb = reintegrate_inflight_io;
 	arg->rebuild_cb_arg = &inflight_oid;
-#endif
+
 	/* To make sure the IO will be done before reintegration is done */
 	if (arg->myrank == 0)
 		daos_debug_set_params(arg->group, -1, DMG_KEY_FAIL_LOC,
@@ -97,8 +87,6 @@ reintegrate_with_inflight_io(test_arg_t *arg, daos_obj_id_t *oid,
 	arg->rebuild_cb = NULL;
 	arg->rebuild_cb_arg = NULL;
 
-#if 0
-	/* Disable it due to DAOS-7420 */
 	if (oid == NULL) {
 		int rc;
 
@@ -106,7 +94,6 @@ reintegrate_with_inflight_io(test_arg_t *arg, daos_obj_id_t *oid,
 		if (rc != 0)
 			assert_rc_equal(rc, -DER_NOSYS);
 	}
-#endif
 }
 
 static void
@@ -1213,7 +1200,7 @@ rebuild_with_dfs_open_create_punch(void **state)
 
 	rank = get_rank_by_oid_shard(arg, oid, 0);
 	rebuild_single_pool_rank(arg, rank, false);
-	reintegrate_single_pool_rank_no_disconnect(arg, rank);
+	reintegrate_single_pool_rank(arg, rank, false);
 
 	for (i = 0; i < 20; i++) {
 		sprintf(filename, "degrade_file_%d", i);

--- a/src/tests/suite/daos_test.h
+++ b/src/tests/suite/daos_test.h
@@ -508,6 +508,7 @@ void verify_ec_full_partial(struct ioreq *req, int test_idx, daos_off_t off);
 void make_buffer(char *buffer, char start, int total);
 
 bool oid_is_ec(daos_obj_id_t oid, struct daos_oclass_attr **attr);
+uint32_t test_ec_get_parity_off(daos_key_t *dkey, struct daos_oclass_attr *oca);
 
 static inline void
 daos_test_print(int rank, char *message)

--- a/src/tests/suite/daos_test.h
+++ b/src/tests/suite/daos_test.h
@@ -376,6 +376,8 @@ int run_daos_degrade_simple_ec_test(int rank, int size, int *sub_tests,
 				    int sub_tests_size);
 void daos_kill_server(test_arg_t *arg, const uuid_t pool_uuid, const char *grp,
 		      d_rank_list_t *svc, d_rank_t rank);
+void daos_start_server(test_arg_t *arg, const uuid_t pool_uuid,
+		       const char *grp, d_rank_list_t *svc, d_rank_t rank);
 struct daos_acl *get_daos_acl_with_owner_perms(uint64_t perms);
 daos_prop_t *get_daos_prop_with_owner_acl_perms(uint64_t perms,
 						uint32_t prop_type);
@@ -444,16 +446,14 @@ void dfs_ec_rebuild_io(void **state, int *shards, int shards_nr);
 void rebuild_single_pool_target(test_arg_t *arg, d_rank_t failed_rank,
 				int failed_tgt, bool kill);
 void rebuild_single_pool_rank(test_arg_t *arg, d_rank_t failed_rank, bool kill);
-void reintegrate_single_pool_rank_no_disconnect(test_arg_t *arg, d_rank_t failed_rank);
+void reintegrate_single_pool_rank(test_arg_t *arg, d_rank_t failed_rank, bool restart);
 void rebuild_pools_ranks(test_arg_t **args, int args_cnt,
 		d_rank_t *failed_ranks, int ranks_nr, bool kill);
 
 void reintegrate_single_pool_target(test_arg_t *arg, d_rank_t failed_rank,
-		int failed_tgt);
-void reintegrate_single_pool_rank(test_arg_t *arg, d_rank_t failed_rank);
-void reintegrate_pools_ranks(test_arg_t **args, int args_cnt,
-		d_rank_t *failed_ranks,  int ranks_nr);
-
+				    int failed_tgt);
+void reintegrate_pools_ranks(test_arg_t **args, int args_cnt, d_rank_t *failed_ranks,
+			     int ranks_nr, bool restart);
 void drain_single_pool_target(test_arg_t *arg, d_rank_t failed_rank,
 				int failed_tgt, bool kill);
 void drain_single_pool_rank(test_arg_t *arg, d_rank_t failed_rank, bool kill);

--- a/src/tests/suite/daos_test.h
+++ b/src/tests/suite/daos_test.h
@@ -509,6 +509,7 @@ void make_buffer(char *buffer, char start, int total);
 
 bool oid_is_ec(daos_obj_id_t oid, struct daos_oclass_attr **attr);
 uint32_t test_ec_get_parity_off(daos_key_t *dkey, struct daos_oclass_attr *oca);
+int reintegrate_inflight_io(void *data);
 
 static inline void
 daos_test_print(int rank, char *message)

--- a/src/tests/suite/daos_test_common.c
+++ b/src/tests/suite/daos_test_common.c
@@ -930,6 +930,30 @@ daos_reint_server(const uuid_t pool_uuid, const char *grp,
 }
 
 void
+daos_start_server(test_arg_t *arg, const uuid_t pool_uuid,
+		  const char *grp, d_rank_list_t *svc, d_rank_t rank)
+{
+	char	dmg_cmd[DTS_CFG_MAX];
+	int	rc;
+
+	if (d_rank_in_rank_list(svc, rank))
+		svc->rl_nr++;
+
+	print_message("\tstart rank %d (svc->rl_nr %d)!\n", rank, svc->rl_nr);
+
+	/* build and invoke dmg cmd to stop the server */
+	dts_create_config(dmg_cmd, "dmg system start -r %d", rank);
+	if (arg->dmg_config != NULL)
+		dts_append_config(dmg_cmd, " -o %s", arg->dmg_config);
+
+	rc = system(dmg_cmd);
+	print_message(" %s rc %#x\n", dmg_cmd, rc);
+	assert_rc_equal(rc, 0);
+
+	daos_cont_status_clear(arg->coh, NULL);
+}
+
+void
 daos_kill_server(test_arg_t *arg, const uuid_t pool_uuid,
 		 const char *grp, d_rank_list_t *svc, d_rank_t rank)
 {

--- a/src/vos/vos_obj_cache.c
+++ b/src/vos/vos_obj_cache.c
@@ -408,6 +408,13 @@ check_object:
 		goto failed;
 	}
 
+	if (obj->obj_discard && intent == DAOS_INTENT_UPDATE) {
+		/** Cleanup before assert so unit test that triggers doesn't corrupt the state */
+		vos_obj_release(occ, obj, false);
+		rc = -DER_UPDATE_AGAIN;
+		goto failed;
+	}
+
 	if ((flags & VOS_OBJ_DISCARD) || intent == DAOS_INTENT_KILL || intent == DAOS_INTENT_PUNCH)
 		goto out;
 

--- a/src/vos/vos_query.c
+++ b/src/vos/vos_query.c
@@ -284,7 +284,7 @@ ent2recx(daos_recx_t *recx, const struct evt_entry *ent)
 {
 	recx->rx_idx = ent->en_sel_ext.ex_lo;
 	recx->rx_nr = ent->en_sel_ext.ex_hi - ent->en_sel_ext.ex_lo + 1;
-	D_DEBUG(DB_TRACE, "ec_recx size is "DF_X64"\n", recx->rx_idx + recx->rx_nr);
+	D_DEBUG(DB_TRACE, "ec_recx size is "DF_U64"\n", recx->rx_idx + recx->rx_nr);
 }
 
 static bool


### PR DESCRIPTION
Retry inflight update if the object is being discarded,
so it can allow inflight I/O during reintegration.

Signed-off-by: Di Wang <di.wang@intel.com>