### PR TITLE
DAOS-8929 java: Bump log4j-core from 2.17.0 to 2.17.1 in /src/client/…

### DIFF
--- a/src/client/java/pom.xml
+++ b/src/client/java/pom.xml
@@ -16,7 +16,7 @@
     <junit.platform.version>1.4.0</junit.platform.version>
     <junit.jupiter.version>5.4.0</junit.jupiter.version>
     <slf4j.version>1.7.25</slf4j.version>
-    <log4j.version>2.17.0</log4j.version>
+    <log4j.version>2.17.1</log4j.version>
     <checkstyle.failOnViolation>true</checkstyle.failOnViolation>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>


### PR DESCRIPTION
…java (#7801)

Bumps log4j-core from 2.17.0 to 2.17.1.

---
updated-dependencies:
- dependency-name: org.apache.logging.log4j:log4j-core
  dependency-type: direct:production
...

Signed-off-by: dependabot[bot] <support@github.com>