### PR TITLE
DAOS-9101 vos: selectively merge records on aggregation

### DIFF
--- a/src/container/srv_target.c
+++ b/src/container/srv_target.c
@@ -245,7 +245,7 @@ cont_child_aggregate(struct ds_cont_child *cont, cont_aggregate_cb_t agg_cb,
 	uint64_t		*snapshots = NULL;
 	int			snapshots_nr;
 	int			tgt_id = dss_get_module_info()->dmi_tgt_id;
-	bool			full_scan = false;
+	uint32_t		flags = 0;
 	int			i, rc = 0;
 
 	/* Check if it's ok to start aggregation in every 2 seconds */
@@ -260,7 +260,7 @@ cont_child_aggregate(struct ds_cont_child *cont, cont_aggregate_cb_t agg_cb,
 		 * aggregation, let's restart from 0.
 		 */
 		epoch_min = 0;
-		full_scan = true;
+		flags |= VOS_AGG_FL_FORCE_SCAN;
 		D_DEBUG(DB_EPC, "change hlc "DF_X64" > full "DF_X64"\n",
 			change_hlc, param->ap_full_scan_hlc);
 	} else {
@@ -373,7 +373,8 @@ cont_child_aggregate(struct ds_cont_child *cont, cont_aggregate_cb_t agg_cb,
 			DP_CONT(cont->sc_pool->spc_uuid, cont->sc_uuid),
 			tgt_id, epoch_range.epr_lo, epoch_range.epr_hi);
 
-		rc = agg_cb(cont, &epoch_range, full_scan, param, msecs);
+		flags |= VOS_AGG_FL_FORCE_MERGE;
+		rc = agg_cb(cont, &epoch_range, flags, param, msecs);
 		if (rc)
 			D_GOTO(free, rc);
 		epoch_range.epr_lo = epoch_range.epr_hi + 1;
@@ -388,7 +389,9 @@ cont_child_aggregate(struct ds_cont_child *cont, cont_aggregate_cb_t agg_cb,
 		DP_CONT(cont->sc_pool->spc_uuid, cont->sc_uuid),
 		tgt_id, epoch_range.epr_lo, epoch_range.epr_hi);
 
-	rc = agg_cb(cont, &epoch_range, full_scan, param, msecs);
+	if (dss_xstream_is_busy())
+		flags &= ~VOS_AGG_FL_FORCE_MERGE;
+	rc = agg_cb(cont, &epoch_range, flags, param, msecs);
 out:
 	if (rc == 0 && epoch_min == 0)
 		param->ap_full_scan_hlc = hlc;
@@ -449,11 +452,11 @@ out:
 
 static int
 cont_vos_aggregate_cb(struct ds_cont_child *cont, daos_epoch_range_t *epr,
-		      bool full_scan, struct agg_param *param, uint64_t *msecs)
+		      uint32_t flags, struct agg_param *param, uint64_t *msecs)
 {
 	int rc;
 
-	rc = vos_aggregate(cont->sc_hdl, epr, agg_rate_ctl, param, full_scan);
+	rc = vos_aggregate(cont->sc_hdl, epr, agg_rate_ctl, param, flags);
 
 	/* Suppress csum error and continue on other epoch ranges */
 	if (rc == -DER_CSUM)

--- a/src/include/daos/common.h
+++ b/src/include/daos/common.h
@@ -278,16 +278,13 @@ daos_getutime(void)
 	return d_time2us(tv);
 }
 
-static inline int daos_gettime_coarse(uint64_t *time)
+static inline uint64_t
+daos_gettime_coarse(void)
 {
-	struct timespec	now;
-	int		rc;
+	struct timespec	tv;
 
-	rc = clock_gettime(CLOCK_MONOTONIC_COARSE, &now);
-	if (rc == 0)
-		*time = now.tv_sec;
-
-	return rc;
+	clock_gettime(CLOCK_MONOTONIC_COARSE, &tv);
+	return tv.tv_sec;
 }
 
 /** Function table for combsort and binary search */

--- a/src/include/daos_srv/container.h
+++ b/src/include/daos_srv/container.h
@@ -136,7 +136,7 @@ struct agg_param {
 };
 
 typedef int (*cont_aggregate_cb_t)(struct ds_cont_child *cont,
-				   daos_epoch_range_t *epr, bool full_scan,
+				   daos_epoch_range_t *epr, uint32_t flags,
 				   struct agg_param *param, uint64_t *msecs);
 void
 cont_aggregate_interval(struct ds_cont_child *cont, cont_aggregate_cb_t cb,

--- a/src/include/daos_srv/vos.h
+++ b/src/include/daos_srv/vos.h
@@ -397,6 +397,11 @@ vos_cont_close(daos_handle_t coh);
 int
 vos_cont_query(daos_handle_t coh, vos_cont_info_t *cinfo);
 
+enum {
+	VOS_AGG_FL_FORCE_SCAN	= (1UL << 0),	/* Scan all obj/dkey/akeys */
+	VOS_AGG_FL_FORCE_MERGE	= (1UL << 1),	/* Merge all coalesce-able EV records */
+};
+
 /**
  * Aggregates all epochs within the epoch range \a epr.
  * Data in all these epochs will be aggregated to the last epoch
@@ -407,13 +412,13 @@ vos_cont_query(daos_handle_t coh, vos_cont_info_t *cinfo);
  * \param epr	  [IN]		The epoch range of aggregation
  * \param yield_func [IN]	Pointer to customized yield function
  * \param yield_arg  [IN]	Argument of yield function
- * \param full_scan  [IN]	Full scan for snapshot deletion
+ * \param flags      [IN]	Aggregation flags
  *
  * \return			Zero on success, negative value if error
  */
 int
 vos_aggregate(daos_handle_t coh, daos_epoch_range_t *epr,
-	      bool (*yield_func)(void *arg), void *yield_arg, bool full_scan);
+	      bool (*yield_func)(void *arg), void *yield_arg, uint32_t flags);
 
 /**
  * Discards changes in all epochs with the epoch range \a epr

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -712,7 +712,6 @@ static int
 obj_dkey2shard(struct dc_object *obj, uint64_t hash, unsigned int map_ver,
 	       bool to_leader, struct obj_auxi_tgt_list *failed_tgt_list)
 {
-	uint64_t	time = 0;
 	int		grp_idx;
 	int		grp_size;
 	int		idx;
@@ -726,8 +725,8 @@ obj_dkey2shard(struct dc_object *obj, uint64_t hash, unsigned int map_ver,
 
 	if (!to_leader && obj->cob_time_fetch_leader != NULL &&
 	    obj->cob_time_fetch_leader[grp_idx] != 0 &&
-	    daos_gettime_coarse(&time) == 0 && OBJ_FETCH_LEADER_INTERVAL >=
-	    time - obj->cob_time_fetch_leader[grp_idx])
+	    OBJ_FETCH_LEADER_INTERVAL >=
+	    daos_gettime_coarse() - obj->cob_time_fetch_leader[grp_idx])
 		to_leader = true;
 
 	/* For EC object, read from DTX leader is meaningless, because the leader shard may
@@ -3890,8 +3889,7 @@ obj_comp_cb(tse_task_t *task, void *data)
 
 		idx = obj_auxi->req_tgts.ort_shard_tgts->st_shard /
 			obj_get_grp_size(obj);
-		rc = daos_gettime_coarse(&obj->cob_time_fetch_leader[idx]);
-		D_ASSERT(rc == 0);
+		obj->cob_time_fetch_leader[idx] = daos_gettime_coarse();
 	}
 
 	/* Check if the pool map needs to refresh */

--- a/src/object/srv_ec_aggregate.c
+++ b/src/object/srv_ec_aggregate.c
@@ -2489,7 +2489,7 @@ out:
  */
 static int
 cont_ec_aggregate_cb(struct ds_cont_child *cont, daos_epoch_range_t *epr,
-		     bool full_scan, struct agg_param *agg_param, uint64_t *msec)
+		     uint32_t flags, struct agg_param *agg_param, uint64_t *msec)
 {
 	struct ec_agg_param	 *ec_agg_param = agg_param->ap_data;
 	struct dtx_handle	 *dth = NULL;

--- a/src/rdb/rdb_util.c
+++ b/src/rdb/rdb_util.c
@@ -559,7 +559,8 @@ rdb_vos_aggregate(daos_handle_t cont, daos_epoch_t high)
 	epr.epr_lo = 0;
 	epr.epr_hi = high;
 
-	return vos_aggregate(cont, &epr, NULL, NULL, true);
+	return vos_aggregate(cont, &epr, NULL, NULL,
+			     VOS_AGG_FL_FORCE_SCAN | VOS_AGG_FL_FORCE_MERGE);
 }
 
 /* Return amount of vos pool SCM memory available accounting for

--- a/src/rebuild/srv.c
+++ b/src/rebuild/srv.c
@@ -1113,8 +1113,7 @@ rebuild_task_ult(void *arg)
 	uint64_t				cur_ts = 0;
 	int					rc;
 
-	rc = daos_gettime_coarse(&cur_ts);
-	D_ASSERT(rc == 0);
+	cur_ts = daos_gettime_coarse();
 	if (cur_ts < task->dst_schedule_time) {
 		D_DEBUG(DB_REBUILD, "rebuild task sleep "DF_U64" second\n",
 			task->dst_schedule_time - cur_ts);
@@ -1125,7 +1124,7 @@ rebuild_task_ult(void *arg)
 	if (pool == NULL) {
 		D_ERROR(DF_UUID": failed to look up pool\n",
 			DP_UUID(task->dst_pool_uuid));
-		D_GOTO(out_task, rc);
+		D_GOTO(out_task, rc = -DER_NONEXIST);
 	}
 
 	rc = rebuild_notify_ras_start(&task->dst_pool_uuid, task->dst_map_ver,
@@ -1563,8 +1562,7 @@ ds_rebuild_schedule(struct ds_pool *pool, uint32_t map_ver,
 	if (new_task == NULL)
 		return -DER_NOMEM;
 
-	rc = daos_gettime_coarse(&cur_ts);
-	D_ASSERT(rc == 0);
+	cur_ts = daos_gettime_coarse();
 
 	new_task->dst_schedule_time = cur_ts + delay_sec;
 	new_task->dst_map_ver = map_ver;

--- a/src/tests/vos_perf.c
+++ b/src/tests/vos_perf.c
@@ -469,7 +469,8 @@ pf_aggregate(struct pf_test *ts, struct pf_param *param)
 
 	TS_TIME_START(&param->pa_duration, start);
 
-	rc = vos_aggregate(ts_ctx.tsc_coh, &epr, NULL, NULL, true);
+	rc = vos_aggregate(ts_ctx.tsc_coh, &epr, NULL, NULL,
+			   VOS_AGG_FL_FORCE_SCAN | VOS_AGG_FL_FORCE_MERGE);
 
 	TS_TIME_END(&param->pa_duration, start);
 

--- a/src/vea/vea_internal.h
+++ b/src/vea/vea_internal.h
@@ -154,12 +154,9 @@ static inline bool ext_is_idle(struct vea_free_extent *vfe)
 static inline uint32_t
 get_current_age(void)
 {
-	uint64_t	age = 0;
-	int		rc;
+	uint64_t age = 0;
 
-	rc = daos_gettime_coarse(&age);
-	D_ASSERT(rc == 0);
-
+	age = daos_gettime_coarse();
 	return (uint32_t)age;
 }
 

--- a/src/vos/tests/vts_pm.c
+++ b/src/vos/tests/vts_pm.c
@@ -1572,7 +1572,8 @@ remove_test(void **state)
 		    FETCH_DATA, 1, &REM_VAL3[sizeof(REM_VAL3) - 2], FETCH_END);
 
 	epr.epr_lo = 0;
-	rc = vos_aggregate(arg->ctx.tc_co_hdl, &epr, NULL, NULL, true);
+	rc = vos_aggregate(arg->ctx.tc_co_hdl, &epr, NULL, NULL,
+			   VOS_AGG_FL_FORCE_SCAN | VOS_AGG_FL_FORCE_MERGE);
 
 	/* Should get same result after aggregation */
 	check_array(arg, oid, &dkey, &iod.iod_name, epoch,
@@ -2376,7 +2377,7 @@ start_over:
 		if ((epoch - 200) < epr.epr_lo)
 			continue;
 		epr.epr_hi = epoch - 200;
-		rc = vos_aggregate(coh, &epr, NULL, NULL, false);
+		rc = vos_aggregate(coh, &epr, NULL, NULL, 0);
 		assert_rc_equal(rc, 0);
 	}
 	for (i = 0; i < NR_TX - 1; i++) {

--- a/src/vos/vos_aggregate.c
+++ b/src/vos/vos_aggregate.c
@@ -15,6 +15,8 @@
 #include "vos_internal.h"
 #include "evt_priv.h"
 
+unsigned int vos_agg_nvme_thresh = VOS_MW_NVME_THRESH;
+
 /*
  * EV tree sorted iterator returns logical entry in extent start order, and
  * the information like: physical entry it belongs to, visibility, is it the
@@ -148,9 +150,10 @@ struct vos_agg_param {
 	daos_unit_oid_t		ap_oid;		/* current object ID */
 	daos_key_t		ap_dkey;	/* current dkey */
 	daos_key_t		ap_akey;	/* current akey */
+	uint32_t		ap_flags;
 	unsigned int		ap_discard:1,
 				ap_csum_err:1,
-				ap_full_scan:1,
+				ap_nospc_err:1,
 				ap_discard_obj:1;
 	struct umem_instance	*ap_umm;
 	bool			(*ap_yield_func)(void *arg);
@@ -219,13 +222,13 @@ need_aggregate(struct vos_agg_param *agg_param, vos_iter_entry_t *entry)
 	if (agg_param->ap_discard_obj || agg_param->ap_discard)
 		return true;
 
-	D_DEBUG(DB_EPC, "full_scan:%d, hae:"DF_U64", last_update:"DF_U64", "
-		"flags:%u\n", agg_param->ap_full_scan,
+	D_DEBUG(DB_EPC, "flags:%u, hae:"DF_U64", last_update:"DF_U64", "
+		"flags:%u\n", agg_param->ap_flags,
 		cont->vc_cont_df->cd_hae, entry->ie_last_update,
 		entry->ie_vis_flags);
 
 	/* Don't skip aggregation for full scan */
-	if (agg_param->ap_full_scan)
+	if (agg_param->ap_flags & VOS_AGG_FL_FORCE_SCAN)
 		return true;
 
 	/* Don't skip aggregation when the obj/dkey/akey is punched */
@@ -864,11 +867,12 @@ process_physical:
 	return rc;
 }
 
+#define NOSPC_ERROR_INTVL	60	/* seconds */
 static int
 reserve_segment(struct vos_object *obj, struct agg_io_context *io,
 		daos_size_t size, bio_addr_t *addr)
 {
-	uint64_t	off;
+	uint64_t	off, now;
 	uint16_t	media;
 	int		rc;
 
@@ -878,7 +882,11 @@ reserve_segment(struct vos_object *obj, struct agg_io_context *io,
 	if (media == DAOS_MEDIA_SCM) {
 		off = vos_reserve_scm(obj->obj_cont, io->ic_rsrvd_scm, size);
 		if (UMOFF_IS_NULL(off)) {
-			D_ERROR("Reserve "DF_U64" from SCM failed.\n", size);
+			now = daos_gettime_coarse();
+			if (now - obj->obj_cont->vc_agg_nospc_ts > NOSPC_ERROR_INTVL) {
+				D_ERROR("Reserve "DF_U64" from SCM failed.\n", size);
+				obj->obj_cont->vc_agg_nospc_ts = now;
+			}
 			return -DER_NOSPACE;
 		}
 		bio_addr_set(addr, media, off);
@@ -888,11 +896,19 @@ reserve_segment(struct vos_object *obj, struct agg_io_context *io,
 	D_ASSERT(media == DAOS_MEDIA_NVME);
 	rc = vos_reserve_blocks(obj->obj_cont, &io->ic_nvme_exts, size,
 				VOS_IOS_AGGREGATION, &off);
-	if (rc)
+	if (rc == -DER_NOSPACE) {
+		now = daos_gettime_coarse();
+		if (now - obj->obj_cont->vc_agg_nospc_ts > NOSPC_ERROR_INTVL) {
+			D_ERROR("Reserve "DF_U64" from NVMe failed. "DF_RC"\n",
+				size, DP_RC(rc));
+			obj->obj_cont->vc_agg_nospc_ts = now;
+		}
+	} else if (rc) {
 		D_ERROR("Reserve "DF_U64" from NVMe failed. "DF_RC"\n",
 			size, DP_RC(rc));
-	else
+	} else {
 		bio_addr_set(addr, media, off);
+	}
 
 	return rc;
 }
@@ -1071,8 +1087,8 @@ fill_one_segment(daos_handle_t ih, struct agg_merge_window *mw,
 
 	rc = reserve_segment(obj, io, seg_size, &ent_in->ei_addr);
 	if (rc) {
-		D_ERROR("Reserve "DF_U64" segment error: "DF_RC"\n",
-			seg_size, DP_RC(rc));
+		D_CDEBUG(rc == -DER_NOSPACE, DB_EPC, DLOG_ERR,
+			"Reserve "DF_U64" segment error: "DF_RC"\n", seg_size, DP_RC(rc));
 		goto out;
 	}
 	D_ASSERT(!bio_addr_is_hole(&ent_in->ei_addr));
@@ -1151,11 +1167,10 @@ fill_segments(daos_handle_t ih, struct agg_merge_window *mw,
 
 		rc = fill_one_segment(ih, mw, lgc_seg, acts);
 		if (rc) {
-			D_ERROR("Fill seg %u-%u %p "DF_RECT" error: "DF_RC"\n",
-				lgc_seg->ls_idx_start, lgc_seg->ls_idx_end,
-				lgc_seg->ls_phy_ent,
-				DP_RECT(&lgc_seg->ls_ent_in.ei_rect),
-					DP_RC(rc));
+			D_CDEBUG(rc == -DER_NOSPACE, DB_EPC, DLOG_ERR,
+				"Fill seg %u-%u %p "DF_RECT" error: "DF_RC"\n",
+				lgc_seg->ls_idx_start, lgc_seg->ls_idx_end, lgc_seg->ls_phy_ent,
+				DP_RECT(&lgc_seg->ls_ent_in.ei_rect), DP_RC(rc));
 			break;
 		}
 	}
@@ -1431,35 +1446,68 @@ free_removal_records(struct agg_merge_window *mw, d_list_t *head, bool top)
 	}
 }
 
-static bool
-need_flush(struct agg_merge_window *mw, bool last)
+static inline bool
+need_merge(daos_handle_t ih, uint16_t src_media, int lgc_cnt, daos_size_t seg_size)
 {
+	struct vos_obj_iter	*oiter = vos_hdl2oiter(ih);
+	struct vos_object	*obj = oiter->it_obj;
+	unsigned int		 seg_blks, nvme_blks;
+	uint16_t		 tgt_media;
+
+	D_ASSERT(lgc_cnt > 0 && seg_size > 0);
+	if (lgc_cnt == 1)
+		return false;
+
+	tgt_media = vos_media_select(vos_obj2pool(obj), DAOS_IOD_ARRAY, seg_size);
+	/* Some data can be migrated from SCM to NVMe to alleviate SCM pressure */
+	if (src_media != tgt_media)
+		return true;
+
+	/*
+	 * Only trigger SCM to SCM data migration when there are enough amount of
+	 * SCM records accumulated.
+	 */
+	if (tgt_media == DAOS_MEDIA_SCM)
+		return lgc_cnt >= VOS_EVT_ORDER;
+
+	/*
+	 * Only trigger NVMe to NVMe data migration when:
+	 * - Coalesced record is larger than threshold; And
+	 * - Enough small NVMe records accumuoated, or coalesced size is threshold
+	 *   size aligned;
+	 */
+	seg_blks = (seg_size + VOS_BLK_SZ - 1) >> VOS_BLK_SHIFT;
+	if (seg_blks < vos_agg_nvme_thresh)
+		return false;
+
+	nvme_blks = (seg_blks / vos_agg_nvme_thresh);
+	return (lgc_cnt >= VOS_EVT_ORDER) || (seg_blks == (nvme_blks * vos_agg_nvme_thresh));
+}
+
+/*
+ * General rules for deciding if a merge window needs be flushed or skipped:
+ *
+ * 1. If any invisible data to be removed, flush merge window to free space.
+ * 2. If any data could be migrated from SCM to NVMe, flush merge window to alleviate
+ *    SCM space pressure.
+ * 3. If any removal records, punch records could be removed or merged, flush merge
+ *    window to condense VOS tree.
+ * 4. If only records coalescing within same media (eg. merging small SCM records to a
+ *    larger SCM record, or merging small NVMe records to a larger NVMe record), make
+ *    a trade-off between VOS tree condensing and data relocating (which consumes CPU
+ *    & storage bandwidth, yet likely to generate more fragmentations).
+ */
+static bool
+need_flush(daos_handle_t ih, struct vos_agg_param *agg_param, bool last)
+{
+	struct agg_merge_window	*mw = &agg_param->ap_window;
 	struct agg_phy_ent	*phy_ent;
 	struct agg_lgc_ent	*lgc_ent;
 	struct evt_extent	 lgc_ext, phy_ext;
-	int			 i;
+	int			 i, lgc_cnt = 0;
 	bool			 hole = false;
-
-	for (i = 0; i < mw->mw_lgc_cnt; i++) {
-		lgc_ent = &mw->mw_lgc_ents[i];
-		phy_ent = lgc_ent->le_phy_ent;
-		phy_ext = phy_ent->pe_rect.rc_ex;
-		lgc_ext = lgc_ent->le_ext;
-
-		/*
-		 * Any physical entry is partially covered, or appeared
-		 * in other window
-		 */
-		if (lgc_ext.ex_lo != phy_ext.ex_lo ||
-		    lgc_ext.ex_hi != phy_ext.ex_hi)
-			return true;
-
-		/* If any consecutive visible entries can be merged */
-		if (i != 0 && hole == bio_addr_is_hole(&phy_ent->pe_addr))
-			return true;
-
-		hole = bio_addr_is_hole(&phy_ent->pe_addr);
-	}
+	daos_size_t		 seg_width = 0;
+	uint16_t		 src_media = DAOS_MEDIA_SCM;
 
 	/* Any invisible physical entries ? */
 	if (mw->mw_lgc_cnt != mw->mw_phy_cnt)
@@ -1469,6 +1517,50 @@ need_flush(struct agg_merge_window *mw, bool last)
 	if (last && mw->mw_rmv_cnt != 0)
 		return true;
 
+	/*
+	 * To reduce fragmentation, we don't flush (migrate) segment individually,
+	 * that means the whole merge window data will be migrated to a new location
+	 * when any segment in the window needs be flushed.
+	 */
+	for (i = 0; i < mw->mw_lgc_cnt; i++) {
+		lgc_ent = &mw->mw_lgc_ents[i];
+		phy_ent = lgc_ent->le_phy_ent;
+		phy_ext = phy_ent->pe_rect.rc_ex;
+		lgc_ext = lgc_ent->le_ext;
+
+		/* Any physical entry is partially covered, or appeared in other window */
+		if (lgc_ext.ex_lo != phy_ext.ex_lo ||
+		    lgc_ext.ex_hi != phy_ext.ex_hi)
+			return true;
+
+		if (i == 0 || (hole != bio_addr_is_hole(&phy_ent->pe_addr))) {
+			if (i && need_merge(ih, src_media, lgc_cnt, seg_width * mw->mw_rsize))
+				return true;
+
+			src_media = phy_ent->pe_addr.ba_type;
+			seg_width = evt_extent_width(&lgc_ext);
+			lgc_cnt = 1;
+		} else {
+			/*
+			 * Any consecutive punch records need be merged, Or;
+			 * Caller wants to merge any kinds of consecutive records.
+			 */
+			if (hole || (agg_param->ap_flags & VOS_AGG_FL_FORCE_MERGE))
+				return true;
+
+			/* Regard source media as SCM when any source record is on SCM */
+			if (phy_ent->pe_addr.ba_type == DAOS_MEDIA_SCM)
+				src_media = DAOS_MEDIA_SCM;
+			seg_width += evt_extent_width(&lgc_ext);
+			lgc_cnt++;
+		}
+
+		hole = bio_addr_is_hole(&phy_ent->pe_addr);
+	}
+
+	if (lgc_cnt && need_merge(ih, src_media, lgc_cnt, seg_width * mw->mw_rsize))
+		return true;
+
 	clear_merge_window(mw);
 	D_DEBUG(DB_EPC, "Skip window flush "DF_EXT"\n", DP_EXT(&mw->mw_ext));
 
@@ -1476,18 +1568,13 @@ need_flush(struct agg_merge_window *mw, bool last)
 }
 
 static int
-flush_merge_window(daos_handle_t ih, struct agg_merge_window *mw,
+flush_merge_window(daos_handle_t ih, struct vos_agg_param *agg_param,
 		   bool last, unsigned int *acts)
 {
-	int	rc;
+	struct agg_merge_window	*mw = &agg_param->ap_window;
+	int			 rc;
 
-	/*
-	 * If no new updates in an already aggregated window, window flush will
-	 * be skipped, otherwise, all the data within the window will be
-	 * migrated to a new location, such batch data migration is good for
-	 * anti-fragmentaion.
-	 */
-	if (!need_flush(mw, last))
+	if (!need_flush(ih, agg_param, last))
 		return 0;
 
 	/* Prepare the new segments to be inserted */
@@ -1501,7 +1588,8 @@ flush_merge_window(daos_handle_t ih, struct agg_merge_window *mw,
 	/* Transfer data from old logical records to reserved new segments */
 	rc = fill_segments(ih, mw, acts);
 	if (rc) {
-		D_ERROR("Fill segments "DF_EXT" error: "DF_RC"\n",
+		D_CDEBUG(rc == -DER_NOSPACE, DB_EPC, DLOG_ERR,
+			"Fill segments "DF_EXT" error: "DF_RC"\n",
 			DP_EXT(&mw->mw_ext), DP_RC(rc));
 		goto out;
 	}
@@ -1726,10 +1814,11 @@ mark_removals(struct agg_merge_window *mw, struct agg_phy_ent *phy_ent,
 }
 
 static int
-join_merge_window(daos_handle_t ih, struct agg_merge_window *mw,
+join_merge_window(daos_handle_t ih, struct vos_agg_param *agg_param,
 		  vos_iter_entry_t *entry, unsigned int *acts)
 {
 	struct vos_obj_iter	*oiter = vos_hdl2oiter(ih);
+	struct agg_merge_window	*mw = &agg_param->ap_window;
 	struct evt_extent	 phy_ext, lgc_ext;
 	struct agg_phy_ent	*phy_ent;
 	bool			 remove, visible, partial, last;
@@ -1813,9 +1902,10 @@ join_merge_window(daos_handle_t ih, struct agg_merge_window *mw,
 	if (visible && trigger_flush(mw, &lgc_ext)) {
 		/* The window flush doesn't expect holes caused by removal records */
 		mw->mw_ext.ex_hi = lgc_ext.ex_lo - 1;
-		rc = flush_merge_window(ih, mw, false, acts);
+		rc = flush_merge_window(ih, agg_param, false, acts);
 		if (rc) {
-			D_ERROR("Flush window "DF_EXT" error: "DF_RC"\n",
+			D_CDEBUG(rc == -DER_NOSPACE, DB_EPC, DLOG_ERR,
+				"Flush window "DF_EXT" error: "DF_RC"\n",
 				DP_EXT(&mw->mw_ext), DP_RC(rc));
 			return rc;
 		}
@@ -1862,9 +1952,10 @@ join_merge_window(daos_handle_t ih, struct agg_merge_window *mw,
 out:
 	/* Flush & close window on last entry */
 	if (last) {
-		rc = flush_merge_window(ih, mw, true, acts);
+		rc = flush_merge_window(ih, agg_param, true, acts);
 		if (rc)
-			D_ERROR("Flush window "DF_EXT" error: "DF_RC"\n",
+			D_CDEBUG(rc == -DER_NOSPACE, DB_EPC, DLOG_ERR,
+				"Flush window "DF_EXT" error: "DF_RC"\n",
 				DP_EXT(&mw->mw_ext), DP_RC(rc));
 
 		close_merge_window(mw, rc);
@@ -1971,12 +2062,11 @@ vos_agg_ev(daos_handle_t ih, vos_iter_entry_t *entry,
 	if (rc)
 		goto out;
 
-	rc = join_merge_window(ih, mw, entry, acts);
+	rc = join_merge_window(ih, agg_param, entry, acts);
 	if (rc)
-		D_CDEBUG(rc == -DER_TX_RESTART || rc == -DER_TX_BUSY, DB_TRACE,
-			 DLOG_ERR, "Join window "DF_EXT"/"DF_EXT" error: "
-			 DF_RC"\n", DP_EXT(&mw->mw_ext), DP_EXT(&phy_ext),
-			 DP_RC(rc));
+		D_CDEBUG(rc == -DER_TX_RESTART || rc == -DER_TX_BUSY || rc == -DER_NOSPACE,
+			DB_TRACE, DLOG_ERR, "Join window "DF_EXT"/"DF_EXT" error: "DF_RC"\n",
+			DP_EXT(&mw->mw_ext), DP_EXT(&phy_ext), DP_RC(rc));
 out:
 	if (rc)
 		close_merge_window(mw, rc);
@@ -2030,13 +2120,15 @@ vos_aggregate_pre_cb(daos_handle_t ih, vos_iter_entry_t *entry,
 	case VOS_ITER_SINGLE:
 		if (type == VOS_ITER_SINGLE)
 			rc = vos_agg_sv(ih, entry, agg_param, acts);
-		if (rc == -DER_CSUM || rc == -DER_TX_BUSY) {
+		if (rc == -DER_CSUM || rc == -DER_TX_BUSY || rc == -DER_NOSPACE) {
 			D_DEBUG(DB_EPC, "Abort value aggregation "DF_RC"\n",
 				DP_RC(rc));
 
 			*acts |= VOS_ITER_CB_ABORT;
 			if (rc == -DER_CSUM) {
 				agg_param->ap_csum_err = true;
+			} else if (rc == -DER_NOSPACE) {
+				agg_param->ap_nospc_err = true;
 			} else if (rc == -DER_TX_BUSY) {
 				/** Must not aggregate anything above
 				 *  this entry to avoid orphaned tree
@@ -2307,7 +2399,7 @@ struct agg_data {
 
 int
 vos_aggregate(daos_handle_t coh, daos_epoch_range_t *epr,
-	      bool (*yield_func)(void *arg), void *yield_arg, bool full_scan)
+	      bool (*yield_func)(void *arg), void *yield_arg, uint32_t flags)
 {
 	struct vos_container	*cont = vos_hdl2cont(coh);
 	struct agg_data		*ad;
@@ -2347,14 +2439,13 @@ vos_aggregate(daos_handle_t coh, daos_epoch_range_t *epr,
 	ad->ad_agg_param.ap_yield_func = yield_func;
 	ad->ad_agg_param.ap_yield_arg = yield_arg;
 	merge_window_init(&ad->ad_agg_param.ap_window);
-	/* A full scan caused by snapshot deletion */
-	ad->ad_agg_param.ap_full_scan = full_scan;
+	ad->ad_agg_param.ap_flags = flags;
 
 	ad->ad_iter_param.ip_flags |= VOS_IT_FOR_PURGE;
 	rc = vos_iterate(&ad->ad_iter_param, VOS_ITER_OBJ, true, &ad->ad_anchors,
 			 vos_aggregate_pre_cb, vos_aggregate_post_cb,
 			 &ad->ad_agg_param, NULL);
-	if (rc != 0) {
+	if (rc != 0 || ad->ad_agg_param.ap_nospc_err) {
 		close_merge_window(&ad->ad_agg_param.ap_window, rc);
 		goto exit;
 	} else if (ad->ad_agg_param.ap_csum_err) {

--- a/src/vos/vos_common.c
+++ b/src/vos/vos_common.c
@@ -479,6 +479,16 @@ vos_mod_init(void)
 	if (rc)
 		D_ERROR("Failed to initialize incarnation log capability\n");
 
+	d_getenv_int("DAOS_VOS_AGG_THRESH", &vos_agg_nvme_thresh);
+	if (vos_agg_nvme_thresh == 0 || vos_agg_nvme_thresh > 256)
+		vos_agg_nvme_thresh = VOS_MW_NVME_THRESH;
+	/* Round down to 2^n blocks */
+	if (vos_agg_nvme_thresh > 1)
+		vos_agg_nvme_thresh = (vos_agg_nvme_thresh / 2) * 2;
+
+	D_INFO("Set aggregate NVMe record threshold to %u blocks (blk_sz:%lu).\n",
+	       vos_agg_nvme_thresh, VOS_BLK_SZ);
+
 	return rc;
 }
 

--- a/src/vos/vos_internal.h
+++ b/src/vos/vos_internal.h
@@ -100,8 +100,16 @@ enum {
  */
 #define VOS_MW_FLUSH_THRESH	(1UL << 23)	/* 8MB */
 
+/*
+ * Default size (in blocks) threshold for merging NVMe records, we choose
+ * 256 blocks as default value since the default DFS chunk size is 1MB.
+ */
+#define VOS_MW_NVME_THRESH	256		/* 256 * VOS_BLK_SZ = 1MB */
+
 /* Force aggregation/discard ULT yield on certain amount of tight loops */
 #define VOS_AGG_CREDITS_MAX	32
+
+extern unsigned int vos_agg_nvme_thresh;
 
 static inline uint32_t vos_byte2blkcnt(uint64_t bytes)
 {
@@ -218,6 +226,8 @@ struct vos_container {
 	daos_epoch_range_t	vc_epr_aggregation;
 	/* Current ongoing discard EPR */
 	daos_epoch_range_t	vc_epr_discard;
+	/* Last timestamp when VOS aggregation reporting ENOSPACE */
+	uint64_t		vc_agg_nospc_ts;
 	/* Various flags */
 	unsigned int		vc_in_aggregation:1,
 				vc_in_discard:1,


### PR DESCRIPTION
To minimize the performance impact, VOS aggregation needs to make
trade-off on VOS tree condensing and data merging/relocating (which
consumes CPU & storage bandwidth, yet likely to generate more
fragmentations).

This patch introduced 'force_merge' flag for vos_aggregate(), when
'force_merge' isn't provided, VOS aggregation will selectively merge
records on same media to minimize the performance impact.
vos_aggregate() caller is responsible for using proper flag based on
the IO workload or aggregation EPR.

This patch also suppressed NOSPACE error messages in aggregation.

Signed-off-by: Niu Yawei <yawei.niu@intel.com>