### PR TITLE
DAOS-8952 vos: Check positive timestamp after upgrading negative entries

### DIFF
--- a/src/vos/vos_io.c
+++ b/src/vos/vos_io.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2018-2021 Intel Corporation.
+ * (C) Copyright 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -2319,10 +2319,12 @@ abort:
 		}
 	}
 
+	if (err == 0)
+		err = vos_ts_set_upgrade(ioc->ic_ts_set, ioc->ic_epr.epr_hi);
+
 	err = vos_tx_end(ioc->ic_cont, dth, &ioc->ic_rsrvd_scm,
 			 &ioc->ic_blk_exts, tx_started, err);
 	if (err == 0) {
-		vos_ts_set_upgrade(ioc->ic_ts_set);
 		if (daes != NULL) {
 			vos_dtx_post_handle(ioc->ic_cont, daes, dces,
 					    dth->dth_dti_cos_count,

--- a/src/vos/vos_obj.c
+++ b/src/vos/vos_obj.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2021 Intel Corporation.
+ * (C) Copyright 2016-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -506,10 +506,12 @@ reset:
 			rc = -DER_TX_RESTART;
 	}
 
+	if (rc == 0)
+		rc = vos_ts_set_upgrade(ts_set, epr.epr_hi);
+
 	rc = vos_tx_end(cont, dth, NULL, NULL, true, rc);
 
 	if (rc == 0) {
-		vos_ts_set_upgrade(ts_set);
 		if (daes != NULL) {
 			vos_dtx_post_handle(cont, daes, dces,
 					    dth->dth_dti_cos_count,

--- a/src/vos/vos_ts.h
+++ b/src/vos/vos_ts.h
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2020-2021 Intel Corporation.
+ * (C) Copyright 2020-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -633,9 +633,13 @@ vos_ts_set_allocate(struct vos_ts_set **ts_set, uint64_t flags,
  *  update/punch has committed
  *
  *  \param[in]	ts_set	Pointer to set
+ *  \param[in]	epoch	Write epoch
+ *
+ *  \return	0		on success
+ *		-DER_TX_RESTART	on timestamp conflict
  */
-void
-vos_ts_set_upgrade(struct vos_ts_set *ts_set);
+int
+vos_ts_set_upgrade(struct vos_ts_set *ts_set, daos_epoch_t epoch);
 
 /** Free an allocated timestamp set
  *


### PR DESCRIPTION
In case the positive timestamp has been updated by a creation entry,
we can check it's timestamp after upgrade to avoid conflicts for
entries that still exist physically but have been punched.

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>