### PR TITLE
DAOS-9522 Test: Checking the memory size to confirm that aggregation happen after server restart.

### DIFF
--- a/src/tests/ftest/erasurecode/restart.py
+++ b/src/tests/ftest/erasurecode/restart.py
@@ -6,7 +6,6 @@
 """
 import time
 from ec_utils import ErasureCodeIor, check_aggregation_status
-from apricot import skipForTicket
 
 class EcodServerRestart(ErasureCodeIor):
     # pylint: disable=too-many-ancestors
@@ -35,6 +34,7 @@ class EcodServerRestart(ErasureCodeIor):
         # Write all EC object data to SCM
         self.ior_write_dataset(storage='SCM', operation="Auto_Write", percent=self.percent)
         self.log.info(self.pool.pool_percentage_used())
+        size_before_restart = self.pool.pool_percentage_used()
 
         if not agg_check:
             # Set time mode aggregation
@@ -54,8 +54,10 @@ class EcodServerRestart(ErasureCodeIor):
         self.get_dmg_command().system_start()
 
         if agg_check == "After":
+            size_after_restart = self.pool.pool_percentage_used()
+            self.log.info("Size after Restarti: %s ", self.pool.pool_percentage_used())
             # Verify if Aggregation is getting started
-            if not any(check_aggregation_status(self.pool, attempt=50).values()):
+            if not size_after_restart['scm'] > size_before_restart['scm']:
                 self.fail("Aggregation failed to start After server restart..")
 
         # Read all EC object data from NVMe
@@ -64,7 +66,6 @@ class EcodServerRestart(ErasureCodeIor):
         self.read_set_from_beginning = False
         self.ior_read_dataset(storage='SCM', operation="Auto_Read", percent=self.percent)
 
-    @skipForTicket("DAOS-9051")
     def test_ec_restart_before_agg(self):
         """Jira ID: DAOS-7337.
 
@@ -81,7 +82,6 @@ class EcodServerRestart(ErasureCodeIor):
         """
         self.execution(agg_check="Before")
 
-    @skipForTicket("DAOS-9051")
     def test_ec_restart_after_agg(self):
         """Jira ID: DAOS-7337.
 
@@ -98,7 +98,6 @@ class EcodServerRestart(ErasureCodeIor):
         """
         self.execution(agg_check="After")
 
-    @skipForTicket("DAOS-9051")
     def test_ec_restart_during_agg(self):
         """Jira ID: DAOS-7337.
 


### PR DESCRIPTION
Aggregation is happening faster incase of server restart the size checking logic in loop
will not work
Updating the logic to compare the memory size before and after server restart instead.

Test-tag: pr ec_server_restart

Signed-off-by: Samir Raval <samir.raval@intel.com>