### PR TITLE
DAOS-9525 Test: Fix JSON output based on name change in PR#7613

### DIFF
--- a/src/common/tests_dmg_helpers.c
+++ b/src/common/tests_dmg_helpers.c
@@ -697,7 +697,7 @@ parse_device_info(struct json_object *smd_dev, device_list *devices,
 		}
 		devices[*disks].n_tgtidx = tgts_len;
 
-		if (!json_object_object_get_ex(dev, "state", &tmp)) {
+		if (!json_object_object_get_ex(dev, "dev_state", &tmp)) {
 			D_ERROR("unable to extract state from JSON\n");
 			return -DER_INVAL;
 		}

--- a/src/tests/ftest/daos_test/nvme_recovery.py
+++ b/src/tests/ftest/daos_test/nvme_recovery.py
@@ -5,7 +5,6 @@
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
 from daos_core_base import DaosCoreBase
-from apricot import skipForTicket
 
 class DaosCoreTestNvme(DaosCoreBase):
     # pylint: disable=too-many-ancestors
@@ -62,7 +61,6 @@ class DaosCoreTestNvme(DaosCoreBase):
         """
         self.run_subtest()
 
-    @skipForTicket("DAOS-9189")
     def test_daos_nvme_recovery_4(self):
         """Jira ID: DAOS-3846.
 


### PR DESCRIPTION
dmg json output has changed name for state --> dev_state in PR#7613.
Removing the skip for NVMe Recovery 4 test.

Test-tag: pr daos_core_test_nvme

Signed-off-by: Samir Raval <samir.raval@intel.com>