### PR TITLE
DAOS-9525 Test: Fix JSON output based on name change in PR#7613

### DIFF
--- a/src/common/tests_dmg_helpers.c
+++ b/src/common/tests_dmg_helpers.c
@@ -697,7 +697,7 @@ parse_device_info(struct json_object *smd_dev, device_list *devices,
 		}
 		devices[*disks].n_tgtidx = tgts_len;
 
-		if (!json_object_object_get_ex(dev, "state", &tmp)) {
+		if (!json_object_object_get_ex(dev, "dev_state", &tmp)) {
 			D_ERROR("unable to extract state from JSON\n");
 			return -DER_INVAL;
 		}


### PR DESCRIPTION
dmg json output has changed name for state --> dev_state in PR#7613.
Removing the skip for NVMe Recovery 4 test.

Test-tag: pr daos_core_test_nvme

Signed-off-by: Samir Raval <samir.raval@intel.com>