### PR TITLE
DAOS-623 test: pylint fixes

### DIFF
--- a/src/tests/ftest/control/dmg_telemetry_basic.py
+++ b/src/tests/ftest/control/dmg_telemetry_basic.py
@@ -107,30 +107,24 @@ class TestWithTelemetryBasic(TestWithTelemetry):
         self.add_pool(connect=False)
         self.pool.set_query_data()
         pool_leader_rank = self.pool.query_data["response"]["leader"]
-        self.pool_leader_host = self.server_managers[0].get_host(
-            pool_leader_rank)
+        self.pool_leader_host = self.server_managers[0].get_host(pool_leader_rank)
         self.log.info(
             "Pool leader host: %s (rank: %s)",
             self.pool_leader_host, pool_leader_rank)
 
         # Verify container telemetry metrics report 0 before container creation
         self.log.info("Before container creation")
-        data = self.telemetry.get_container_metrics()
-        for host in data:
-            self.metrics["open_count"][host] = \
-                data[host]["engine_pool_ops_cont_open"]
-            self.metrics["active_count"][host] = \
-                data[host]["engine_pool_container_handles"]
-            self.metrics["close_count"][host] = \
-                data[host]["engine_pool_ops_cont_close"]
-            self.metrics["destroy_count"][host] = \
-                data[host]["engine_pool_ops_cont_destroy"]
+        container_metrics = self.telemetry.get_container_metrics()
+        for host, data in container_metrics.items():
+            self.metrics["open_count"][host] = data["engine_pool_ops_cont_open"]
+            self.metrics["active_count"][host] = data["engine_pool_container_handles"]
+            self.metrics["close_count"][host] = data["engine_pool_ops_cont_close"]
+            self.metrics["destroy_count"][host] = data["engine_pool_ops_cont_destroy"]
 
         # Create a number of containers and verify metrics
         for loop in range(1, container_qty + 1):
             self.create_container(random.choice([True, False])) #nosec
-            self.log.info(
-                "Container %s/%s: After create()", loop, container_qty)
+            self.log.info("Container %s/%s: After create()", loop, container_qty)
             self.check_metrics()
 
         # Open each container and verify metrics

--- a/src/tests/ftest/util/dfuse_utils.py
+++ b/src/tests/ftest/util/dfuse_utils.py
@@ -118,31 +118,26 @@ class Dfuse(DfuseCommand):
         command = "test -d {0} -a ! -L {0}".format(self.mount_dir.value)
         retcodes = pcmd(nodes, command, expect_rc=None)
         for retcode, hosts in list(retcodes.items()):
-            for host in hosts:
-                if retcode == 0:
-                    check_mounted.add(host)
-                else:
-                    command = "grep 'dfuse {}' /proc/mounts" .format(self.mount_dir.value)
-                    retcodes = pcmd([host], command, expect_rc=None)
-                    for ret_code, host_names in list(retcodes.items()):
-                        for node in host_names:
-                            if ret_code == 0:
-                                check_mounted.add(node)
-                            else:
-                                state["nodirectory"].add(node)
+            if retcode == 0:
+                check_mounted.add(hosts)
+            else:
+                command = "grep 'dfuse {}' /proc/mounts" .format(self.mount_dir.value)
+                retcodes = pcmd(hosts, command, expect_rc=None)
+                for ret_code, host_names in list(retcodes.items()):
+                    if ret_code == 0:
+                        check_mounted.add(host_names)
+                    else:
+                        state["nodirectory"].add(host_names)
 
         if check_mounted:
-            # Detect which hosts with mount point directories have it mounted as
-            # a fuseblk device
-            command = "stat -c %T -f {0} | grep -v fuseblk".format(
-                self.mount_dir.value)
+            # Detect which hosts with mount point directories have it mounted as a fuseblk device
+            command = "stat -c %T -f {0} | grep -v fuseblk".format(self.mount_dir.value)
             retcodes = pcmd(check_mounted, command, expect_rc=None)
             for retcode, hosts in list(retcodes.items()):
-                for host in hosts:
-                    if retcode == 1:
-                        state["mounted"].add(host)
-                    else:
-                        state["unmounted"].add(host)
+                if retcode == 1:
+                    state["mounted"].add(hosts)
+                else:
+                    state["unmounted"].add(hosts)
 
         return state
 

--- a/src/tests/ftest/util/dmg_utils.py
+++ b/src/tests/ftest/util/dmg_utils.py
@@ -374,6 +374,7 @@ class DmgCommand(DmgCommandBase):
     def pool_create(self, scm_size, uid=None, gid=None, nvme_size=None,
                     target_list=None, svcn=None, acl_file=None, size=None,
                     tier_ratio=None, properties=None, label=None, nranks=None):
+        # pylint: disable=too-many-arguments
         """Create a pool with the dmg command.
 
         The uid and gid method arguments can be specified as either an integer
@@ -442,8 +443,7 @@ class DmgCommand(DmgCommandBase):
         # },
         # "error": null,
         # "status": 0
-        output = self._get_json_result(("pool", "create"),
-                                       json_err=True, **kwargs)
+        output = self._get_json_result(("pool", "create"), json_err=True, **kwargs)
         if output["error"] is not None:
             self.log.error(output["error"])
             if self.exit_status_exception:
@@ -453,10 +453,8 @@ class DmgCommand(DmgCommandBase):
             return data
 
         data["uuid"] = output["response"]["uuid"]
-        data["svc"] = ",".join(
-            [str(svc) for svc in output["response"]["svc_reps"]])
-        data["ranks"] = ",".join(
-            [str(r) for r in output["response"]["tgt_ranks"]])
+        data["svc"] = ",".join([str(svc) for svc in output["response"]["svc_reps"]])
+        data["ranks"] = ",".join([str(r) for r in output["response"]["tgt_ranks"]])
         data["scm_per_rank"] = output["response"]["tier_bytes"][0]
         data["nvme_per_rank"] = output["response"]["tier_bytes"][1]
 

--- a/src/tests/ftest/util/job_manager_utils.py
+++ b/src/tests/ftest/util/job_manager_utils.py
@@ -504,7 +504,7 @@ class Srun(JobManager):
 
 
 class Systemctl(JobManager):
-    # pylint: disable=too-many-public-methods,too-many-public-methods
+    # pylint: disable=too-many-public-methods
     """A class for the systemctl job manager command."""
 
     def __init__(self, job):

--- a/src/tests/ftest/util/server_utils.py
+++ b/src/tests/ftest/util/server_utils.py
@@ -21,8 +21,7 @@ from general_utils import pcmd, get_log_file, human_to_bytes, bytes_to_human, \
 from dmg_utils import get_dmg_command
 from server_utils_base import \
     ServerFailed, DaosServerCommand, DaosServerInformation, AutosizeCancel
-from server_utils_params import \
-    DaosServerTransportCredentials, DaosServerYamlParameters
+from server_utils_params import DaosServerTransportCredentials, DaosServerYamlParameters
 from ClusterShell.NodeSet import NodeSet
 
 
@@ -99,8 +98,7 @@ class DaosServerManager(SubprocessManager):
 
         # Dmg command to access this group of servers which will be configured
         # to access the daos_servers when they are started
-        self.dmg = get_dmg_command(
-            group, dmg_cert_dir, bin_dir, dmg_config_file, dmg_config_temp)
+        self.dmg = get_dmg_command(group, dmg_cert_dir, bin_dir, dmg_config_file, dmg_config_temp)
 
         # Set the correct certificate file ownership
         if manager == "Systemctl":
@@ -114,8 +112,7 @@ class DaosServerManager(SubprocessManager):
                 "stopped", "excluded", "errored", "unresponsive", "unknown"],
             "running": ["ready", "joined"],
             "stopped": [
-                "stopping", "stopped", "excluded", "errored", "unresponsive",
-                "unknown"],
+                "stopping", "stopped", "excluded", "errored", "unresponsive", "unknown"],
             "errored": ["errored"],
         }
 
@@ -157,8 +154,7 @@ class DaosServerManager(SubprocessManager):
     def _prepare_dmg_certificates(self):
         """Set up dmg certificates."""
         local_host = socket.gethostname().split('.', 1)[0]
-        self.dmg.copy_certificates(
-            get_log_file("daosCA/certs"), local_host.split())
+        self.dmg.copy_certificates(get_log_file("daosCA/certs"), local_host.split())
 
     def _prepare_dmg_hostlist(self, hosts=None):
         """Set up the dmg command host list to use the specified hosts.
@@ -187,8 +183,7 @@ class DaosServerManager(SubprocessManager):
         self.manager.job.create_yaml_file()
 
         # Copy certificates
-        self.manager.job.copy_certificates(
-            get_log_file("daosCA/certs"), self._hosts)
+        self.manager.job.copy_certificates(get_log_file("daosCA/certs"), self._hosts)
         self._prepare_dmg_certificates()
 
         # Prepare dmg for running storage format on all server hosts
@@ -196,8 +191,7 @@ class DaosServerManager(SubprocessManager):
         if not self.dmg.yaml:
             # If using a dmg config file, transport security was
             # already configured.
-            self.dmg.insecure.update(
-                self.get_config_value("allow_insecure"), "dmg.insecure")
+            self.dmg.insecure.update(self.get_config_value("allow_insecure"), "dmg.insecure")
 
         # Kill any daos servers running on the hosts
         self.manager.kill()
@@ -211,8 +205,7 @@ class DaosServerManager(SubprocessManager):
                 self.log.info("Preparing storage in <format> mode")
                 self.prepare_storage("root")
                 if hasattr(self.manager, "mca"):
-                    self.manager.mca.update(
-                        {"plm_rsh_args": "-l root"}, "orterun.mca", True)
+                    self.manager.mca.update({"plm_rsh_args": "-l root"}, "orterun.mca", True)
 
         # Verify the socket directory exists when using a non-systemctl manager
         self.verify_socket_directory(getuser())
@@ -224,8 +217,7 @@ class DaosServerManager(SubprocessManager):
             verbose (bool, optional): display clean commands. Defaults to True.
         """
         clean_commands = []
-        for index, engine_params in \
-                enumerate(self.manager.job.yaml.engine_params):
+        for index, engine_params in enumerate(self.manager.job.yaml.engine_params):
             scm_mount = engine_params.get_value("scm_mount")
             self.log.info("Cleaning up the %s directory.", str(scm_mount))
 
@@ -246,9 +238,7 @@ class DaosServerManager(SubprocessManager):
             if self.manager.job.using_dcpm:
                 scm_list = engine_params.get_value("scm_list")
                 if isinstance(scm_list, list):
-                    self.log.info(
-                        "Cleaning up the following device(s): %s.",
-                        ", ".join(scm_list))
+                    self.log.info("Cleaning up the following device(s): %s.", ", ".join(scm_list))
                     # Umount and wipefs the dcpm device
                     cmd_list = [
                         "for dev in {}".format(" ".join(scm_list)),
@@ -323,8 +313,7 @@ class DaosServerManager(SubprocessManager):
             result[res["exit_status"]].add(res["hosts"])
 
         if len(result) > 1 or 0 not in result or \
-            (using_dcpm and \
-             "No SCM modules detected; skipping operation" in stdouts):
+            (using_dcpm and "No SCM modules detected; skipping operation" in stdouts):
             dev_type = "nvme"
             if using_dcpm and using_nvme:
                 dev_type = "dcpm & nvme"
@@ -353,8 +342,7 @@ class DaosServerManager(SubprocessManager):
         except CommandFailure as error:
             self.manager.kill()
             raise ServerFailed(
-                "Failed to start servers before format: {}".format(
-                    error)) from error
+                "Failed to start servers before format: {}".format(error)) from error
 
     def detect_engine_start(self, hosts_qty=None):
         """Detect when all the engines have started.
@@ -363,8 +351,7 @@ class DaosServerManager(SubprocessManager):
             hosts_qty (int): number of servers expected to have been started.
 
         Raises:
-            ServerFailed: if there was an error starting the servers after
-                formatting.
+            ServerFailed: if there was an error starting the servers after formatting.
 
         """
         if hosts_qty is None:
@@ -483,8 +470,7 @@ class DaosServerManager(SubprocessManager):
                 scm_mount = [scm_mount]
 
             self.log.info("Changing ownership to %s for: %s", user, scm_mount)
-            cmd_list.add(
-                "sudo chown -R {0}:{0} {1}".format(user, " ".join(scm_mount)))
+            cmd_list.add("sudo chown -R {0}:{0} {1}".format(user, " ".join(scm_mount)))
 
         if cmd_list:
             pcmd(self._hosts, "; ".join(cmd_list), verbose)
@@ -495,8 +481,7 @@ class DaosServerManager(SubprocessManager):
 
         Args:
             hosts (list): List of servers to restart.
-            wait (bool): Whether or not to wait until the servers
-                         have joined.
+            wait (bool): Whether or not to wait until the servers have joined.
         """
         orig_hosts = self.manager.hosts
         self.manager.assign_hosts(hosts)
@@ -535,8 +520,7 @@ class DaosServerManager(SubprocessManager):
         self.information.collect_network_information()
 
         # Format storage and wait for server to change ownership
-        self.log.info(
-            "<SERVER> Formatting hosts: <%s>", self.dmg.hostlist)
+        self.log.info("<SERVER> Formatting hosts: <%s>", self.dmg.hostlist)
         # Temporarily increasing timeout to avoid CI errors until DAOS-5764 can
         # be further investigated.
         self.dmg.storage_format(timeout=40)
@@ -548,8 +532,7 @@ class DaosServerManager(SubprocessManager):
 
     def stop(self):
         """Stop the server through the runner."""
-        self.log.info(
-            "<SERVER> Stopping server %s command", self.manager.command)
+        self.log.info("<SERVER> Stopping server %s command", self.manager.command)
 
         # Maintain a running list of errors detected trying to stop
         messages = []
@@ -559,8 +542,7 @@ class DaosServerManager(SubprocessManager):
             super().stop()
         except CommandFailure as error:
             messages.append(
-                "Error stopping the {} subprocess: {}".format(
-                    self.manager.command, error))
+                "Error stopping the {} subprocess: {}".format(self.manager.command, error))
 
         # Kill any leftover processes that may not have been stopped correctly
         self.manager.kill()
@@ -577,8 +559,7 @@ class DaosServerManager(SubprocessManager):
 
         # Report any errors after all stop actions have been attempted
         if messages:
-            raise ServerFailed(
-                "Failed to stop servers:\n  {}".format("\n  ".join(messages)))
+            raise ServerFailed("Failed to stop servers:\n  {}".format("\n  ".join(messages)))
 
     def get_environment_value(self, name):
         """Get the server config value associated with the env variable name.
@@ -619,20 +600,17 @@ class DaosServerManager(SubprocessManager):
         data = self.get_current_state()
         if not data:
             # The regex failed to get the rank and state
-            raise ServerFailed(
-                "Error obtaining {} output: {}".format(self.dmg, data))
+            raise ServerFailed("Error obtaining {} output: {}".format(self.dmg, data))
         try:
-            states = list(set([data[rank]["state"] for rank in data]))
+            states = {rank["state"] for rank in data.values()}
         except KeyError as error:
             raise ServerFailed(
                 "Unexpected result from {} - missing 'state' key: {}".format(
                     self.dmg, data)) from error
         if len(states) > 1:
             # Multiple states for different ranks detected
-            raise ServerFailed(
-                "Multiple system states ({}) detected:\n  {}".format(
-                    states, data))
-        return states[0]
+            raise ServerFailed("Multiple system states ({}) detected:\n  {}".format(states, data))
+        return states.pop()
 
     def check_rank_state(self, rank, valid_state, max_checks=1):
         """Check the state of single rank in DAOS system
@@ -673,8 +651,7 @@ class DaosServerManager(SubprocessManager):
         checks.
 
         Args:
-            valid_states (list): expected DAOS system states as a list of
-                lowercase strings
+            valid_states (list): expected DAOS system states as a list of lowercase strings
             max_checks (int, optional): number of times to check the state.
                 Defaults to 1.
 
@@ -714,8 +691,7 @@ class DaosServerManager(SubprocessManager):
         self.check_system_state(("stopped"))
         self.dmg.system_start()
         if self.dmg.result.exit_status != 0:
-            raise ServerFailed(
-                "Error starting DAOS:\n{}".format(self.dmg.result))
+            raise ServerFailed("Error starting DAOS:\n{}".format(self.dmg.result))
 
     def system_stop(self, extra_states=None):
         """Stop the DAOS I/O Engines.
@@ -736,8 +712,7 @@ class DaosServerManager(SubprocessManager):
         self.check_system_state(valid_states)
         self.dmg.system_stop(force=True)
         if self.dmg.result.exit_status != 0:
-            raise ServerFailed(
-                "Error stopping DAOS:\n{}".format(self.dmg.result))
+            raise ServerFailed("Error stopping DAOS:\n{}".format(self.dmg.result))
 
     def get_current_state(self):
         """Get the current state of the daos_server ranks.
@@ -746,8 +721,7 @@ class DaosServerManager(SubprocessManager):
             dict: dictionary of server rank keys, each referencing a dictionary
                 of information containing at least the following information:
                     {"host": <>, "uuid": <>, "state": <>}
-                This will be empty if there was error obtaining the dmg system
-                query output.
+                This will be empty if there was error obtaining the dmg system query output.
 
         """
         data = {}
@@ -780,8 +754,7 @@ class DaosServerManager(SubprocessManager):
                 stop. Defaults to False.
 
         Raises:
-            avocado.core.exceptions.TestFail: if there is an issue stopping the
-                server ranks.
+            avocado.core.exceptions.TestFail: if there is an issue stopping the server ranks.
 
         """
         msg = "Stopping DAOS ranks {} from server group {}".format(
@@ -801,16 +774,13 @@ class DaosServerManager(SubprocessManager):
         # Try to dump all server's ULTs stacks before kill.
         result = stop_processes(self._hosts, regex, dump_ult_stacks=True)
         if 0 in result and len(result) == 1:
-            print(
-                "No remote {} server processes killed (none found), "
-                "done.".format(regex))
+            print("No remote {} server processes killed (none found), done.".format(regex))
         else:
             print(
                 "***At least one remote {} server process needed to be killed! "
                 "Please investigate/report.***".format(regex))
         # set stopped servers state to make teardown happy
-        self.update_expected_states(
-            None, ["stopped", "excluded", "errored"])
+        self.update_expected_states(None, ["stopped", "excluded", "errored"])
 
     def get_host(self, rank):
         """Get the host name that matches the specified rank.
@@ -835,8 +805,7 @@ class DaosServerManager(SubprocessManager):
         be wiped.
 
         Args:
-            dst_hosts (list): Destination server hostnames to place the new
-                config file.
+            dst_hosts (list): Destination server hostnames to place the new config file.
             test_dir (str): Directory where the server config data from
                 generated_yaml will be written.
             generated_yaml (YAMLObject): New server config data.
@@ -849,15 +818,13 @@ class DaosServerManager(SubprocessManager):
                 yaml.dump(generated_yaml, write_file, default_flow_style=False)
         except Exception as error:
             raise CommandFailure(
-                "Error writing the yaml file! {}: {}".format(
-                    temp_file_path, error)) from error
+                "Error writing the yaml file! {}: {}".format(temp_file_path, error)) from error
 
         # Copy the config from temp dir to /etc/daos of the server node.
         default_server_config = get_default_config_file("server")
         try:
             distribute_files(
-                dst_hosts, temp_file_path, default_server_config,
-                verbose=False, sudo=True)
+                dst_hosts, temp_file_path, default_server_config, verbose=False, sudo=True)
         except DaosTestError as error:
             raise CommandFailure(
                 "ERROR: Copying yaml configuration file to {}: "
@@ -881,8 +848,7 @@ class DaosServerManager(SubprocessManager):
                 self.log.info("class = %s", storage_tier["class"])
                 self.log.info("scm_list = %s", storage_tier["scm_list"])
 
-                per_engine_yaml_parameters =\
-                    DaosServerYamlParameters.PerEngineYamlParameters(i)
+                per_engine_yaml_parameters = DaosServerYamlParameters.PerEngineYamlParameters(i)
                 per_engine_yaml_parameters.scm_mount.update(storage_tier["scm_mount"])
                 per_engine_yaml_parameters.scm_class.update(storage_tier["class"])
                 per_engine_yaml_parameters.scm_size.update(None)
@@ -921,15 +887,13 @@ class DaosServerManager(SubprocessManager):
 
         """
         storage = {}
-        storage_capacity = self.information.get_storage_capacity(
-            self.manager.job.engine_params)
+        storage_capacity = self.information.get_storage_capacity(self.manager.job.engine_params)
 
         self.log.info("Largest storage size available per engine:")
         for key in sorted(storage_capacity):
             # Use the same storage size across all engines
             storage[key] = min(storage_capacity[key])
-            self.log.info(
-                "  %-4s:  %s", key.upper(), get_display_size(storage[key]))
+            self.log.info("  %-4s:  %s", key.upper(), get_display_size(storage[key]))
         return storage
 
     def autosize_pool_params(self, size, tier_ratio, scm_size, nvme_size,
@@ -952,10 +916,8 @@ class DaosServerManager(SubprocessManager):
             nvme_size.  This is intended to allow testing of these combinations.
 
         Args:
-            size (object): the str, int, or None value for the dmg pool create
-                size parameter.
-            tier_ratio (object): the int or None value for the dmg pool create
-                size parameter.
+            size (object): the str, int, or None value for the dmg pool create size parameter.
+            tier_ratio (object): the int or None value for the dmg pool create size parameter.
             scm_size (object): the str, int, or None value for the dmg pool
                 create scm_size parameter.
             nvme_size (object): the str, int, or None value for the dmg pool
@@ -967,8 +929,7 @@ class DaosServerManager(SubprocessManager):
                 Defaults to 1.
 
         Raises:
-            ServerFailed: if there was a error obtaining auto-sized TestPool
-                parameters.
+            ServerFailed: if there was a error obtaining auto-sized TestPool parameters.
             AutosizeCancel: if a valid pool parameter size could not be obtained
 
         Returns:
@@ -995,16 +956,14 @@ class DaosServerManager(SubprocessManager):
                 "Autosizing TestPool parameters ending with a \"%%\" for %s:",
                 pool_msg)
             for key in ("size", "scm_size", "nvme_size"):
-                self.log.info(
-                    "  - %-9s : %s (%s)", key, adjusted[key], key in keys)
+                self.log.info("  - %-9s : %s (%s)", key, adjusted[key], key in keys)
 
             # Determine the largest SCM and NVMe pool sizes can be used with
             # this server configuration with an optionally applied ratio.
             try:
                 available_storage = self.get_available_storage()
             except ServerFailed as error:
-                raise ServerFailed(
-                    "Error obtaining available storage") from error
+                raise ServerFailed("Error obtaining available storage") from error
 
             # Determine the SCM and NVMe size limits for the size and tier_ratio
             # arguments for the total number of engines
@@ -1016,8 +975,7 @@ class DaosServerManager(SubprocessManager):
                 engine_qty * available_storage["nvme"],
                 (engine_qty * available_storage["scm"]) / float(tier_ratio / 100)
             )
-            available_storage["tier_ratio"] = \
-                available_storage["size"] * float(tier_ratio / 100)
+            available_storage["tier_ratio"] = available_storage["size"] * float(tier_ratio / 100)
             self.log.info(
                 "Largest storage size available for %s engines with a %.2f%% "
                 "tier_ratio:", engine_qty, tier_ratio)
@@ -1029,8 +987,7 @@ class DaosServerManager(SubprocessManager):
                 get_display_size(available_storage["tier_ratio"]))
             self.log.info(
                 "  - COMBINED : %s",
-                get_display_size(
-                    available_storage["size"] + available_storage["tier_ratio"]))
+                get_display_size(available_storage["size"] + available_storage["tier_ratio"]))
 
             # Apply any requested percentages to the pool parameters
             available = {
@@ -1044,10 +1001,8 @@ class DaosServerManager(SubprocessManager):
                     ratio = int(str(adjusted[key]).replace("%", ""))
                 except NameError as error:
                     raise ServerFailed(
-                        "Invalid '{}' format: {}".format(
-                            key, adjusted[key])) from error
-                adjusted[key] = \
-                    (available[key]["size"] * float(ratio / 100)) / quantity
+                        "Invalid '{}' format: {}".format(key, adjusted[key])) from error
+                adjusted[key] = (available[key]["size"] * float(ratio / 100)) / quantity
                 self.log.info(
                     "  - %-9s : %-4s storage adjusted by %.2f%%: %s",
                     key, available[key]["type"], ratio,
@@ -1060,8 +1015,7 @@ class DaosServerManager(SubprocessManager):
                 "nvme_size": human_to_bytes("1GiB")}
             self.log.info("Increment sizes per target:")
             for key in keys:
-                self.log.info(
-                    "  - %-9s : %s", key, get_display_size(increment[key]))
+                self.log.info("  - %-9s : %s", key, get_display_size(increment[key]))
 
             # Adjust the size to use a SCM/NVMe target multiplier
             self.log.info("Pool sizes adjusted to fit by increment sizes:")


### PR DESCRIPTION
Skip-unit-tests: true
skip-test-rpms: true
Skip-fault-injection-test: true
Test-tag: pr daily_regression dfuse,-manual test_container_telemetry

- dfuse_utils.py
  - simplify nodeset operations to reduce nested statements

- server_utils.py
  - use set comprehension to silence warning. It's also simpler
  - adjust for 80->100 line length

- dmg_utils.py
  - disable=too-many-arguments for a valid use case

- dmg_telemetry_basic.py
  - Iterate with .items()
  - adjust for 80->100 line length

Signed-off-by: Dalton Bohning <dalton.bohning@intel.com>