### PR TITLE
CORCI-1106 build: Use pip to install scons in CentOS 8.

### DIFF
--- a/.github/workflows/landing-builds.yml
+++ b/.github/workflows/landing-builds.yml
@@ -8,6 +8,7 @@ on:
   pull_request:
     paths:
       - .github/workflows/landing-builds.yml
+      - utils/docker/Dockerfile.*
 
 jobs:
 

--- a/utils/docker/Dockerfile.centos.8
+++ b/utils/docker/Dockerfile.centos.8
@@ -124,12 +124,12 @@ RUN mkdir -p /opt/daos /mnt/daos /var/run/daos_server /var/run/daos_agent &&   \
     chown daos_server.daos_server /opt/daos /mnt/daos /var/run/daos_server &&  \
     chown daos_agent.daos_agent /var/run/daos_agent
 
-# DPDK/SPDK needs pyelftools now
-# Longer term, we should upload our RPM build of this to the public packaging
-# site and install it by RPM, but for now, we'll just pip install it
+# Install scons from pip to avoid dependency cycle bug.
 USER daos_server:daos_server
-RUN python3 -m pip --no-cache-dir --disable-pip-version-check install --user pyelftools
+RUN python3 -m pip --no-cache-dir --disable-pip-version-check install --user scons
 USER root:root
+
+ENV PATH=/home/daos/.local/bin:$PATH
 
 ARG QUICKBUILD=false
 ARG QUICKBUILD_DEPS
@@ -183,7 +183,7 @@ USER daos_server:daos_server
 ARG DEPS_JOBS=1
 
 RUN [ "$DAOS_DEPS_BUILD" != "yes" ] || \
-    { scons-3 --build-deps=yes --jobs $DEPS_JOBS PREFIX=/opt/daos \
+    { scons --build-deps=yes --jobs $DEPS_JOBS PREFIX=/opt/daos \
       TARGET_TYPE=$DAOS_TARGET_TYPE --deps-only && \
     ([ "$DAOS_KEEP_BUILD" != "no" ] || /bin/rm -rf build *.gz); }
 
@@ -216,7 +216,7 @@ ARG DAOS_BUILD=$DAOS_DEPS_BUILD
 
 # Build DAOS
 RUN [ "$DAOS_BUILD" != "yes" ] || \
-    { scons-3 --jobs $JOBS install PREFIX=/opt/daos COMPILER=$COMPILER \
+    { scons --jobs $JOBS install PREFIX=/opt/daos COMPILER=$COMPILER \
       BUILD_TYPE=$DAOS_BUILD_TYPE TARGET_TYPE=$DAOS_TARGET_TYPE && \
     /bin/rm -rf build && go clean -cache && \
     cp -r utils/config/examples /opt/daos; }

--- a/utils/scripts/install-centos8.sh
+++ b/utils/scripts/install-centos8.sh
@@ -58,9 +58,9 @@ dnf --nodocs install \
     python3-distro \
     python3-junit_xml \
     python3-pip \
+    python3-pyelftools \
     python3-pyxattr \
     python3-tabulate \
-    python3-scons \
     python3-yaml \
     sg3_utils \
     valgrind-devel \


### PR DESCRIPTION
Avoid a bug in CentOS 8 versions of scons by using pip to
install a later version of it.  This avoids occasional build
failures with a "Internal Error: no cycle found for node" error.

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>
