### PR TITLE
DAOS-9153 control: enforce equal number of targets and ssds across en…

### DIFF
--- a/src/control/fault/code/codes.go
+++ b/src/control/fault/code/codes.go
@@ -143,6 +143,9 @@ const (
 	ServerConfigDuplicateScmMount
 	ServerConfigDuplicateScmDeviceList
 	ServerConfigOverlappingBdevDeviceList
+	ServerConfigBdevCountMismatch
+	ServerConfigTargetCountMismatch
+	ServerConfigHelperStreamCountMismatch
 	ServerConfigFaultDomainInvalid
 	ServerConfigFaultCallbackNotFound
 	ServerConfigFaultCallbackInsecure

--- a/src/control/lib/control/auto_test.go
+++ b/src/control/lib/control/auto_test.go
@@ -9,6 +9,7 @@ package control
 import (
 	"context"
 	"fmt"
+	"sort"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -22,38 +23,10 @@ import (
 	"github.com/daos-stack/daos/src/control/logging"
 	"github.com/daos-stack/daos/src/control/security"
 	"github.com/daos-stack/daos/src/control/server/config"
-	"github.com/daos-stack/daos/src/control/server/engine"
 	"github.com/daos-stack/daos/src/control/server/storage"
 )
 
 var (
-	engineCfg = func(t *testing.T, numa int) *engine.Config {
-		return engine.NewConfig().
-			WithStorage(
-				storage.NewTierConfig().
-					WithScmClass(storage.ClassDcpm.String()).
-					WithScmMountPoint(fmt.Sprintf("/mnt/daos%d", numa)).
-					WithScmDeviceList(fmt.Sprintf("/dev/pmem%d", numa)),
-				storage.NewTierConfig().
-					WithBdevClass(storage.ClassNvme.String()),
-			)
-	}
-	engineCfgWithSSDs = func(t *testing.T, numa int) *engine.Config {
-		var pciAddrs []string
-		for _, c := range MockServerScanResp(t, "withSpaceUsage").Nvme.Ctrlrs {
-			if int(c.SocketId) == numa {
-				pciAddrs = append(pciAddrs, c.PciAddr)
-			}
-		}
-
-		cfg := engineCfg(t, numa)
-		for _, sc := range cfg.Storage.Tiers {
-			if sc.IsBdev() {
-				sc.WithBdevDeviceList(pciAddrs...)
-			}
-		}
-		return cfg
-	}
 	ib0 = &HostFabricInterface{
 		Provider: "ofi+psm2", Device: "ib0", NumaNode: 0, NetDevClass: 32, Priority: 0,
 	}
@@ -350,31 +323,101 @@ func TestControl_AutoConfig_getNetworkDetails(t *testing.T) {
 	}
 }
 
-func TestControl_AutoConfig_getStorageDetails(t *testing.T) {
-	dualHostResp := func(r1, r2 string) []*HostResponse {
-		return []*HostResponse{
-			{
-				Addr:    "host1",
-				Message: MockServerScanResp(t, r1),
+type mockHostResponses struct {
+	resps     []*HostResponse
+	numaSSDs  map[uint32][]string
+	numaPMEMs map[uint32][]string
+}
+
+func newMockHostResponses(t *testing.T, variants ...string) *mockHostResponses {
+	t.Helper()
+
+	switch len(variants) {
+	case 0:
+		t.Fatal("no host response variants")
+	case 1:
+		resp := MockServerScanResp(t, variants[0])
+
+		pmems := make(map[uint32][]string)
+		for _, p := range resp.Scm.Namespaces {
+			pmems[p.NumaNode] = append(pmems[p.NumaNode],
+				fmt.Sprintf("%s/%s", scmBdevDir, p.Blockdev))
+			sort.Strings(pmems[p.NumaNode])
+		}
+
+		ssds := make(map[uint32][]string)
+		for _, c := range resp.Nvme.Ctrlrs {
+			ssds[uint32(c.SocketId)] = append(ssds[uint32(c.SocketId)], c.PciAddr)
+			sort.Strings(ssds[uint32(c.SocketId)])
+		}
+
+		return &mockHostResponses{
+			resps: []*HostResponse{
+				{
+					Addr:    "host1",
+					Message: resp,
+				},
+				{
+					Addr:    "host2",
+					Message: resp,
+				},
 			},
-			{
-				Addr:    "host2",
-				Message: MockServerScanResp(t, r2),
+			numaSSDs:  ssds,
+			numaPMEMs: pmems,
+		}
+	case 2:
+		return &mockHostResponses{
+			resps: []*HostResponse{
+				{
+					Addr:    "host1",
+					Message: MockServerScanResp(t, variants[0]),
+				},
+				{
+					Addr:    "host2",
+					Message: MockServerScanResp(t, variants[1]),
+				},
 			},
 		}
+	default:
+		t.Fatal("no host response variants")
 	}
-	dualHostRespSame := func(r1 string) []*HostResponse {
-		return dualHostResp(r1, r1)
+
+	return nil
+}
+
+func (mhr *mockHostResponses) getNUMASSDs(t *testing.T, numa uint32) []string {
+	t.Helper()
+
+	addrs, exists := mhr.numaSSDs[numa]
+	if !exists {
+		t.Fatalf("no ssds for numa %d", numa)
 	}
-	hostRespOneScanFail := dualHostResp("standard", "bothFailed")
-	hostRespScanFail := dualHostRespSame("bothFailed")
-	hostRespNoScmNs := dualHostRespSame("standard")
-	hostRespOneWithScmNs := dualHostResp("pmemSingle", "standard")
-	hostRespWithScmNs := dualHostRespSame("pmemSingle")
-	hostRespWithScmNss := dualHostRespSame("pmemA")
-	hostRespWithScmNssNumaZero := dualHostRespSame("pmemDupNuma")
-	hostRespWithSingleSSD := dualHostRespSame("nvmeSingle")
-	hostRespWithSSDs := dualHostRespSame("withSpaceUsage")
+
+	return addrs
+}
+
+func (mhr *mockHostResponses) getNUMAPMEMs(t *testing.T, numa uint32) []string {
+	t.Helper()
+
+	pmems, exists := mhr.numaPMEMs[numa]
+	if !exists {
+		t.Fatalf("no pmems for numa %d", numa)
+	}
+
+	return pmems
+}
+
+func TestControl_AutoConfig_getStorageDetails(t *testing.T) {
+	oneScanFail := newMockHostResponses(t, "standard", "bothFailed")
+	scanFail := newMockHostResponses(t, "bothFailed")
+	noScmNs := newMockHostResponses(t, "standard")
+	oneWithScmNs := newMockHostResponses(t, "pmemSingle", "standard")
+	withScmNs := newMockHostResponses(t, "pmemSingle")
+	withScmNss := newMockHostResponses(t, "pmemA")
+	withScmNssNumaZero := newMockHostResponses(t, "pmemDupNuma")
+	withSingleSSD := newMockHostResponses(t, "nvmeSingle")
+	withSSDs := newMockHostResponses(t, "withSpaceUsage")
+	noSSDsOnNUMA1 := newMockHostResponses(t, "noNvmeOnNuma1")
 
 	for name, tc := range map[string]struct {
 		engineCount   int
@@ -393,21 +436,21 @@ func TestControl_AutoConfig_getStorageDetails(t *testing.T) {
 		"invoker error": {
 			engineCount:   1,
 			uErr:          errors.New("unary error"),
-			hostResponses: hostRespOneWithScmNs,
+			hostResponses: oneWithScmNs.resps,
 			expErr:        errors.New("unary error"),
 		},
-		"host storage scan failed": {
+		"host storage scan; failed": {
 			engineCount:   1,
-			hostResponses: hostRespOneScanFail,
+			hostResponses: oneScanFail.resps,
 			expHostErrs: []*MockHostError{
 				{"host2", "scm scan failed"},
 				{"host2", "nvme scan failed"},
 			},
 			expErr: errors.New("1 host had errors"),
 		},
-		"host storage scan failed on multiple hosts": {
+		"host storage scan; failed on multiple hosts": {
 			engineCount:   1,
-			hostResponses: hostRespScanFail,
+			hostResponses: scanFail.resps,
 			expHostErrs: []*MockHostError{
 				{"host1", "scm scan failed"},
 				{"host1", "nvme scan failed"},
@@ -416,85 +459,95 @@ func TestControl_AutoConfig_getStorageDetails(t *testing.T) {
 			},
 			expErr: errors.New("2 hosts had errors"),
 		},
-		"host storage scan no hosts": {
+		"host storage scan; no hosts": {
 			engineCount:   1,
 			hostResponses: []*HostResponse{},
 			expErr:        errors.New("no host responses"),
 		},
-		"host storage mismatch": {
+		"host storage scan; mismatch": {
 			engineCount:   1,
-			hostResponses: hostRespOneWithScmNs,
+			hostResponses: oneWithScmNs.resps,
 			expErr:        errors.New("storage hardware not consistent across hosts"),
 		},
-		"single engine zero pmems": {
+		"2 numa nodes; 0 pmems": {
 			engineCount:   1,
-			hostResponses: hostRespNoScmNs,
+			hostResponses: noScmNs.resps,
 			expErr:        errors.Errorf(errInsufNrPMemGroups, make(numaPMemsMap), 1, 0),
 		},
-		"dual engine single pmem": {
+		"2 numa nodes; 1 pmem": {
 			engineCount:   2,
-			hostResponses: hostRespWithScmNs,
+			hostResponses: withScmNs.resps,
 			expErr: errors.Errorf(errInsufNrPMemGroups,
-				numaPMemsMap{0: []string{
-					engineCfgWithSSDs(t, 0).Storage.Tiers.ScmConfigs()[0].Scm.DeviceList[0],
-				}}, 2, 1),
+				numaPMemsMap{0: withScmNs.getNUMAPMEMs(t, 0)}, 2, 1),
 		},
-		"dual engine dual pmems zero ssds": {
+		"2 numa nodes; 2 pmems; 0 ssds": {
 			engineCount:   2,
-			hostResponses: hostRespWithScmNss,
+			hostResponses: withScmNss.resps,
 			expErr:        errors.Errorf(errInsufNrSSDs, 0, 1, 0),
 		},
-		"single engine dual pmems both numa zero": {
+		"1 numa node; 2 pmems; both numa zero": {
 			engineCount:   1,
-			hostResponses: hostRespWithScmNssNumaZero,
+			hostResponses: withScmNssNumaZero.resps,
 			expErr:        errors.Errorf(errInsufNrSSDs, 0, 1, 0),
 		},
-		"dual engine dual pmems both numa zero": {
+		"2 numa nodes; 2 pmems; both numa zero": {
 			engineCount:   2,
-			hostResponses: hostRespWithScmNssNumaZero,
+			hostResponses: withScmNssNumaZero.resps,
 			expErr: errors.Errorf(errInsufNrPMemGroups,
-				numaPMemsMap{0: []string{
-					engineCfgWithSSDs(t, 0).Storage.Tiers.ScmConfigs()[0].Scm.DeviceList[0],
-					engineCfgWithSSDs(t, 1).Storage.Tiers.ScmConfigs()[0].Scm.DeviceList[0],
-				}}, 2, 1),
+				numaPMemsMap{0: withScmNssNumaZero.getNUMAPMEMs(t, 0)}, 2, 1),
 		},
-		"single min ssd single ctrlr on single numa node": {
+		"2 numa nodes; unset min ssds; 1 ssd": {
 			engineCount:   2,
-			hostResponses: hostRespWithSingleSSD,
+			hostResponses: withSingleSSD.resps,
 			expErr:        errors.Errorf(errInsufNrSSDs, 1, 1, 0),
 		},
-		"single min ssd multiple ctrlrs on dual numa nodes": {
+		"2 numa nodes; unset min ssds; 2 ssds": {
 			engineCount:   2,
-			hostResponses: hostRespWithSSDs,
+			hostResponses: withSSDs.resps,
 			expPMems: [][]string{
-				engineCfgWithSSDs(t, 0).Storage.Tiers.ScmConfigs()[0].Scm.DeviceList,
-				engineCfgWithSSDs(t, 1).Storage.Tiers.ScmConfigs()[0].Scm.DeviceList,
+				withSSDs.getNUMAPMEMs(t, 0),
+				withSSDs.getNUMAPMEMs(t, 1),
 			},
 			expSSDs: [][]string{
-				engineCfgWithSSDs(t, 0).Storage.Tiers.BdevConfigs()[0].Bdev.DeviceList,
-				engineCfgWithSSDs(t, 1).Storage.Tiers.BdevConfigs()[0].Bdev.DeviceList,
+				withSSDs.getNUMASSDs(t, 0),
+				withSSDs.getNUMASSDs(t, 1),
 			},
 		},
-		"dual min ssd multiple ctrlrs on dual numa nodes": {
+		"2 numa nodes; 2 min ssds; 2 ssds": {
 			engineCount:   2,
 			minSSDs:       2,
-			hostResponses: hostRespWithSSDs,
+			hostResponses: withSSDs.resps,
 			expPMems: [][]string{
-				engineCfgWithSSDs(t, 0).Storage.Tiers.ScmConfigs()[0].Scm.DeviceList,
-				engineCfgWithSSDs(t, 1).Storage.Tiers.ScmConfigs()[0].Scm.DeviceList,
+				withSSDs.getNUMAPMEMs(t, 0),
+				withSSDs.getNUMAPMEMs(t, 1),
 			},
 			expSSDs: [][]string{
-				engineCfgWithSSDs(t, 0).Storage.Tiers.BdevConfigs()[0].Bdev.DeviceList,
-				engineCfgWithSSDs(t, 1).Storage.Tiers.BdevConfigs()[0].Bdev.DeviceList,
+				withSSDs.getNUMASSDs(t, 0),
+				withSSDs.getNUMASSDs(t, 1),
 			},
 		},
-		"zero min ssd multiple ctrlrs on dual numa nodes": {
+		"2 numa nodes; 0 min ssds; 2 ssds": {
 			engineCount:   2,
 			disableNVMe:   true,
-			hostResponses: hostRespWithSSDs,
+			hostResponses: withSSDs.resps,
 			expPMems: [][]string{
-				engineCfgWithSSDs(t, 0).Storage.Tiers.ScmConfigs()[0].Scm.DeviceList,
-				engineCfgWithSSDs(t, 1).Storage.Tiers.ScmConfigs()[0].Scm.DeviceList,
+				withSSDs.getNUMAPMEMs(t, 0),
+				withSSDs.getNUMAPMEMs(t, 1),
+			},
+			expSSDs: [][]string{{}, {}},
+		},
+		"2 numa nodes; unset min ssds; 0 ssds on numa 1": {
+			engineCount:   2,
+			hostResponses: noSSDsOnNUMA1.resps,
+			expErr:        errors.Errorf(errInsufNrSSDs, 1, 1, 0),
+		},
+		"2 numa nodes; 0 min ssds; 0 ssds on numa 1": {
+			engineCount:   2,
+			disableNVMe:   true,
+			hostResponses: noSSDsOnNUMA1.resps,
+			expPMems: [][]string{
+				noSSDsOnNUMA1.getNUMAPMEMs(t, 0),
+				noSSDsOnNUMA1.getNUMAPMEMs(t, 1),
 			},
 			expSSDs: [][]string{{}, {}},
 		},
@@ -524,9 +577,9 @@ func TestControl_AutoConfig_getStorageDetails(t *testing.T) {
 				Log:       log,
 			}
 
-			storageDetails, gotErr := getStorageDetails(
-				context.TODO(), req, tc.engineCount)
+			storageDetails, gotErr := getStorageDetails(context.TODO(), req, tc.engineCount)
 			common.CmpErr(t, tc.expErr, gotErr)
+
 			var gotHostErrs *HostErrorsResp
 			if cge, ok := gotErr.(*ConfigGenerateError); ok {
 				gotHostErrs = &cge.HostErrorsResp
@@ -795,7 +848,7 @@ func TestControl_AutoConfig_genConfig(t *testing.T) {
 			numaCoreCounts: numaCoreCountsMap{
 				0: &coreCounts{16, 7}, 1: &coreCounts{15, 6},
 			},
-			expCfg: baseConfig("ofi+psm2").WithAccessPoints("hostX:10002").WithNrHugePages(8192).WithEngines(
+			expCfg: baseConfig("ofi+psm2").WithAccessPoints("hostX:10002").WithNrHugePages(7680).WithEngines(
 				defaultEngineCfg(0).
 					WithFabricInterface("ib0").
 					WithFabricInterfacePort(defaultFiPort).
@@ -808,11 +861,12 @@ func TestControl_AutoConfig_genConfig(t *testing.T) {
 							WithScmMountPoint("/mnt/daos0"),
 						storage.NewTierConfig().
 							WithBdevClass(storage.ClassNvme.String()).
-							WithBdevDeviceList(common.MockPCIAddrs(0, 1, 2, 3)...),
+							WithBdevDeviceList(common.MockPCIAddrs(0, 1, 2)...),
 					).
 					WithStorageConfigOutputPath("/mnt/daos0/daos_nvme.conf").
 					WithStorageVosEnv("NVME").
-					WithHelperStreamCount(7),
+					WithTargetCount(15).
+					WithHelperStreamCount(6),
 				defaultEngineCfg(1).
 					WithFabricInterface("ib1").
 					WithFabricInterfacePort(
@@ -860,7 +914,7 @@ func TestControl_AutoConfig_genConfig(t *testing.T) {
 					WithTargetCount(8).
 					WithHelperStreamCount(2)),
 		},
-		"hugepages test, multiple target counts": {
+		"hugepages test, multiple engines": {
 			engineCount:  2,
 			accessPoints: []string{"hostX:10002"},
 			numaPMems:    numaPMemsMap{0: []string{"/dev/pmem0"}, 1: []string{"/dev/pmem1"}},
@@ -871,7 +925,7 @@ func TestControl_AutoConfig_genConfig(t *testing.T) {
 			numaCoreCounts: numaCoreCountsMap{
 				0: &coreCounts{12, 2}, 1: &coreCounts{6, 0},
 			},
-			expCfg: baseConfig("ofi+psm2").WithAccessPoints("hostX:10002").WithNrHugePages(6144).WithEngines(
+			expCfg: baseConfig("ofi+psm2").WithAccessPoints("hostX:10002").WithNrHugePages(3072).WithEngines(
 				defaultEngineCfg(0).
 					WithFabricInterface("ib0").
 					WithFabricInterfacePort(defaultFiPort).
@@ -884,12 +938,12 @@ func TestControl_AutoConfig_genConfig(t *testing.T) {
 							WithScmMountPoint("/mnt/daos0"),
 						storage.NewTierConfig().
 							WithBdevClass(storage.ClassNvme.String()).
-							WithBdevDeviceList(common.MockPCIAddrs(0, 1, 2, 3)...),
+							WithBdevDeviceList(common.MockPCIAddrs(0, 1, 2)...),
 					).
 					WithStorageConfigOutputPath("/mnt/daos0/daos_nvme.conf").
 					WithStorageVosEnv("NVME").
-					WithTargetCount(12).
-					WithHelperStreamCount(2),
+					WithTargetCount(6).
+					WithHelperStreamCount(0),
 				defaultEngineCfg(1).
 					WithFabricInterface("ib1").
 					WithFabricInterfacePort(

--- a/src/control/lib/control/mocks.go
+++ b/src/control/lib/control/mocks.go
@@ -448,6 +448,13 @@ func MockServerScanResp(t *testing.T, variant string) *ctlpb.StorageScanResp {
 			Status: ctlpb.ResponseStatus_CTL_ERR_NVME,
 			Error:  "nvme scan failed",
 		}
+	case "noNvmeOnNuma1":
+		if err := convert.Types(nss(0, 1), &ssr.Scm.Namespaces); err != nil {
+			t.Fatal(err)
+		}
+		if err := convert.Types(ctrlrs(0, 2), &ssr.Nvme.Ctrlrs); err != nil {
+			t.Fatal(err)
+		}
 	case "standard":
 	default:
 		t.Fatalf("MockServerScanResp(): variant %s unrecognized", variant)

--- a/src/control/server/config/faults.go
+++ b/src/control/server/config/faults.go
@@ -126,6 +126,33 @@ func FaultConfigOverlappingBdevDeviceList(curIdx, seenIdx int) *fault.Fault {
 	)
 }
 
+func FaultConfigBdevCountMismatch(curIdx, curCount, seenIdx, seenCount int) *fault.Fault {
+	return serverConfigFault(
+		code.ServerConfigBdevCountMismatch,
+		fmt.Sprintf("the total number of bdev_list entries in all tiers is not equal across engines, engine %d has %d but engine %d has %d",
+			curIdx, curCount, seenIdx, seenCount),
+		"ensure that each I/O Engine has an equal number of total bdev_list entries and restart",
+	)
+}
+
+func FaultConfigTargetCountMismatch(curIdx, curCount, seenIdx, seenCount int) *fault.Fault {
+	return serverConfigFault(
+		code.ServerConfigTargetCountMismatch,
+		fmt.Sprintf("the target count is not equal across engines, engine %d has %d but engine %d has %d",
+			curIdx, curCount, seenIdx, seenCount),
+		"ensure that each I/O Engine has an equal integer value for targets parameter and restart",
+	)
+}
+
+func FaultConfigHelperStreamCountMismatch(curIdx, curCount, seenIdx, seenCount int) *fault.Fault {
+	return serverConfigFault(
+		code.ServerConfigHelperStreamCountMismatch,
+		fmt.Sprintf("the helper stream count is not equal across engines, engine %d has %d but engine %d has %d",
+			curIdx, curCount, seenIdx, seenCount),
+		"ensure that each I/O Engine has an equal integer value for nr_xs_helpers parameter and restart",
+	)
+}
+
 func FaultConfigInvalidNetDevClass(curIdx int, primaryDevClass, thisDevClass uint32, iface string) *fault.Fault {
 	return serverConfigFault(
 		code.ServerConfigInvalidNetDevClass,

--- a/src/control/server/config/server.go
+++ b/src/control/server/config/server.go
@@ -552,6 +552,10 @@ func (cfg *Server) validateMultiServerConfig(log logging.Logger) error {
 	seenValues := make(map[string]int)
 	seenScmSet := make(map[string]int)
 	seenBdevSet := make(map[string]int)
+	seenIdx := 0
+	seenBdevCount := -1
+	seenTargetCount := -1
+	seenHelperStreamCount := -1
 
 	for idx, engine := range cfg.Engines {
 		fabricConfig := fmt.Sprintf("fabric:%s-%s-%d",
@@ -593,6 +597,7 @@ func (cfg *Server) validateMultiServerConfig(log logging.Logger) error {
 			}
 		}
 
+		var bdevCount int
 		for _, bdevConf := range engine.Storage.Tiers.BdevConfigs() {
 			for _, dev := range bdevConf.Bdev.DeviceList {
 				if seenIn, exists := seenBdevSet[dev]; exists {
@@ -601,7 +606,23 @@ func (cfg *Server) validateMultiServerConfig(log logging.Logger) error {
 				}
 				seenBdevSet[dev] = idx
 			}
+			bdevCount += len(bdevConf.Bdev.DeviceList)
 		}
+		if seenBdevCount != -1 && bdevCount != seenBdevCount {
+			return FaultConfigBdevCountMismatch(idx, bdevCount, seenIdx, seenBdevCount)
+		}
+		if seenTargetCount != -1 && engine.TargetCount != seenTargetCount {
+			return FaultConfigTargetCountMismatch(idx, engine.TargetCount, seenIdx,
+				seenTargetCount)
+		}
+		if seenHelperStreamCount != -1 && engine.HelperStreamCount != seenHelperStreamCount {
+			return FaultConfigHelperStreamCountMismatch(idx, engine.HelperStreamCount,
+				seenIdx, seenHelperStreamCount)
+		}
+		seenIdx = idx
+		seenBdevCount = bdevCount
+		seenTargetCount = engine.TargetCount
+		seenHelperStreamCount = engine.HelperStreamCount
 	}
 
 	return nil

--- a/utils/config/daos_server.yml
+++ b/utils/config/daos_server.yml
@@ -337,7 +337,8 @@
 #    # When class is set to nvme, bdev_list is the list of unique NVMe IDs
 #    # that should be different across different engine instance.
 #    # Immutable after running "dmg storage format".
-#    bdev_list: ["0000:81:00.0"]  # generate regular nvme.conf
+#    bdev_list: ["0000:81:00.0", "0000:82:00.0"]  # generate regular nvme.conf
+#
 #    # If VMD-enabled NVMe SSDs are used, the bdev_list should consist of the VMD
 #    # PCIe addresses, and not the BDF format transport IDs of the backing NVMe SSDs
 #    # behind the VMD address. Also, 'disable_vmd' needs to be set to false.
@@ -477,5 +478,5 @@
 #    # If Volume Management Devices (VMD) are to be used, then the disable_vmd
 #    # flag needs to be set to false (default). The class will remain the
 #    # default "nvme" type, and bdev_list will include the VMD addresses.
-#    class: nvme
-#    bdev_list: ["0000:82:00.0","0000:5d:05.5"]
+#    #class: nvme
+#    #bdev_list: ["0000:5d:05.5"]


### PR DESCRIPTION
…… (#7774)

Validate that a multi-engine config has equal values for targets and
nr_xs_helpers parameters and has an equal number of SSD address entries
in bdev_list parameters across all engine sections.

dmg config generate will produce engine configs adhering to the above
validation rules even when there are different numbers of SSDs bound
to each engine's respective NUMA node.

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>