### PR TITLE
DAOS-9040 test: fix rebuild_with_ior (#7668)

### DIFF
--- a/src/tests/ftest/rebuild/with_ior.py
+++ b/src/tests/ftest/rebuild/with_ior.py
@@ -28,7 +28,7 @@ class RbldWithIOR(IorTestBase):
              sequence while failure/rebuild is triggered in another process
 
         :avocado: tags=all,daily_regression
-        :avocado: tags=large
+        :avocado: tags=hw,large
         :avocado: tags=pool,rebuild
         :avocado: tags=rebuildwithior
 
@@ -38,16 +38,7 @@ class RbldWithIOR(IorTestBase):
         ior_timeout = self.params.get("ior_timeout", '/run/ior/*')
         iorflags_write = self.params.get("write_flg", '/run/ior/iorflags/')
         iorflags_read = self.params.get("read_flg", '/run/ior/iorflags/')
-        dfuse_mount_dir = self.params.get("mount_dir", "/run/dfuse/*")
-        test_file = self.params.get("test_file", "/run/ior/*")
-        ior_api = self.params.get("ior_api", '/run/ior/*')
-        obj_class = self.params.get("obj_class", '/run/ior/*')
-        transfer_size = self.params.get("transfer_size",
-                                        "/run/ior/transfer_blk_size_rebld/*")
-        block_size = self.params.get("block_size",
-                                     "/run/ior/transfer_blk_size_rebld/*")
-        rank = self.params.get("rank_to_kill",
-                               "/run/ior/transfer_blk_size_rebld/*")
+        rank_to_kill = self.params.get("rank_to_kill", "/run/ior/*")
 
         # create pool
         self.create_pool()
@@ -69,17 +60,10 @@ class RbldWithIOR(IorTestBase):
 
         # perform IOR write before rebuild
         self.ior_cmd.flags.update(iorflags_write)
-        self.ior_cmd.api.update(ior_api)
-        self.ior_cmd.block_size.update(block_size)
-        self.ior_cmd.transfer_size.update(transfer_size)
-        self.ior_cmd.dfs_oclass.update(obj_class)
-        self.run_ior_with_pool(test_file=test_file,
-                               timeout=ior_timeout,
-                               plugin_path = None,
-                               mount_dir=dfuse_mount_dir)
+        self.run_ior_with_pool(timeout=ior_timeout)
 
         # kill the server
-        self.server_managers[0].stop_ranks([rank], self.d_log)
+        self.server_managers[0].stop_ranks([rank_to_kill], self.d_log)
 
         # wait for rebuild to start
         self.pool.wait_for_rebuild(True)
@@ -98,8 +82,4 @@ class RbldWithIOR(IorTestBase):
 
         # perform IOR read after rebuild
         self.ior_cmd.flags.update(iorflags_read)
-        self.run_ior_with_pool(test_file=test_file,
-                               create_cont=False,
-                               timeout=ior_timeout,
-                               plugin_path = None,
-                               mount_dir=dfuse_mount_dir)
+        self.run_ior_with_pool(create_cont=False, timeout=ior_timeout)

--- a/src/tests/ftest/rebuild/with_ior.yaml
+++ b/src/tests/ftest/rebuild/with_ior.yaml
@@ -8,11 +8,16 @@ hosts:
   test_clients:
     - client-F
     - client-G
-timeout: 800
+timeout: 240
 server_config:
-  name: daos_server
-  servers:
+    name: daos_server
     targets: 2
+    servers:
+        log_mask: INFO
+        bdev_class: nvme
+        bdev_list: ["aaaa:aa:aa.a","bbbb:bb:bb.b"]
+        scm_class: dcpm
+        scm_list: ["/dev/pmem0"]
 pool:
   mode: 146
   name: daos_server
@@ -24,22 +29,17 @@ container:
     type: POSIX
     properties: rf:1
     control_method: daos
-dfuse:
-    mount_dir: "/tmp/daos_dfuse/"
-    disable_caching: True
 ior:
     ior_timeout: 120
+    rank_to_kill: 3
     client_processes:
-        np_16:
-            np: 16
-    repetitions: 2
+        np: 8
+    repetitions: 1
     test_file: daos:/testFile
-    ior_api: DFS
-    obj_class: "RP_2GX"
+    api: DFS
+    dfs_oclass: "RP_2GX"
+    transfer_size: '1M'
+    block_size: '128M'
     iorflags:
-        write_flg: "-C -k -e -w -g -G 27 -D 300 -Q 1 -vv"
-        read_flg: "-C -k -e -r -R -g -G 27 -D 300 -Q 1 -vv"
-    transfer_blk_size_rebld:
-        rank_to_kill: 3
-        transfer_size: '1M'
-        block_size: '64M'
+        write_flg: "-C -k -e -w -g -G 27 -Q 1 -vv"
+        read_flg: "-C -k -e -r -R -g -G 27 -Q 1 -vv"


### PR DESCRIPTION
Test-tag: rebuildwithior
Skip-unit-tests: true
Skip-fault-injection-test: true
Test-repeat: 5

- Reduce to 1 ior repetition
- Remove unused dfuse references
- Remove unnecessary stonewall
- Move manual config settings to yaml
- Reduce client processes to 8 (4 ppn) since vms don't have enough
  virtual cores

Signed-off-by: Dalton Bohning <dalton.bohning@intel.com>