### PR TITLE
Revert "DAOS-9307 test: fix a mem usage bug in daos_epoch_io test (#7687)" [Not To Merge]

### DIFF
--- a/src/tests/suite/daos_epoch_io.c
+++ b/src/tests/suite/daos_epoch_io.c
@@ -207,13 +207,13 @@ daos_test_cb_uf(test_arg_t *arg, struct test_op_record *op, char **rbuf,
 		if (uf_arg->snap == true) {
 			rc = daos_cont_create_snap(arg->coh, &snap_epoch, NULL,
 						   NULL);
-			op->snap_epoch  = snap_epoch;
+			*op->snap_epoch  = snap_epoch;
 		}
 	} else{
 		th_open = DAOS_TX_NONE;
 		/*Open snapshot and read the data from snapshot epoch*/
 		if (uf_arg->snap == true) {
-			rc = daos_tx_open_snap(arg->coh, op->snap_epoch,
+			rc = daos_tx_open_snap(arg->coh, *op->snap_epoch,
 					       &th_open, NULL);
 			D_ASSERT(rc == 0);
 		}
@@ -1462,6 +1462,8 @@ io_conf_run(test_arg_t *arg, const char *io_conf)
 	FILE			*fp;
 	char			 cmd_line[CMD_LINE_LEN_MAX - 1] = {};
 	int			 rc = 0;
+	/*Array for snapshot epoch*/
+	daos_epoch_t		sn_epoch[DTS_MAX_EPOCH_TIMES] = {};
 
 	if (io_conf == NULL || strlen(io_conf) == 0) {
 		print_message("invalid io_conf.\n");
@@ -1498,6 +1500,7 @@ io_conf_run(test_arg_t *arg, const char *io_conf)
 		}
 
 		if (op != NULL) {
+			op->snap_epoch = &sn_epoch[op->tx];
 			print_message("will run cmd_line %s, line_nr %d\n", cmd_line, ++line_nr);
 			rc = cmd_line_run(arg, op);
 			if (rc) {

--- a/src/tests/suite/daos_iotest.h
+++ b/src/tests/suite/daos_iotest.h
@@ -234,7 +234,7 @@ struct test_op_record {
 	d_list_t		or_queue_link;
 	struct test_key_record	*or_key_rec; /* back pointer */
 	int			tx;
-	daos_epoch_t		snap_epoch;
+	daos_epoch_t		*snap_epoch;
 	enum test_op_type	or_op;
 	union {
 		struct test_update_fetch_arg	uf_arg;


### PR DESCRIPTION
This reverts commit 647453235ebfcdd506ff1ac6980f71c0df402588.

Quick-Functional: true
Test-tag: unaligned_io
Test-repeat: 10

Signed-off-by: Samir Raval <samir.raval@intel.com>