### PR TITLE
DAOS-9310-test: dtx/basic.py:BasicTxTest.test_tx_basics - pool connect timeout

### DIFF
--- a/src/tests/ftest/dtx/basic.yaml
+++ b/src/tests/ftest/dtx/basic.yaml
@@ -4,7 +4,7 @@ hosts:
   test_servers:
     - server-A
     - server-B
-timeout: 60
+timeout: 120
 faults: !mux
 # commenting out the fault injection bit
 # as it's still under development. Uncomment


### PR DESCRIPTION
DAOS-9310-test: dtx/basic.py:BasicTxTest.test_tx_basics - pool connect timeout
Description: Increase test timeout.

modified:   basic.yaml

Test-tag: basictx
Skip-unit-tests: true
Test-repeat: 5
Signed-off-by: Ding Ho ding-hwa.ho@intel.com