### PR TITLE
DAOS-732 Add arg for storage path to vos unit tests

### DIFF
--- a/src/vos/tests/vts_common.c
+++ b/src/vos/tests/vts_common.c
@@ -38,7 +38,8 @@ enum {
 	TCX_READY,
 };
 
-int gc, oid_cnt;
+int		gc, oid_cnt;
+extern char	vos_path[STORAGE_PATH_LEN];
 
 bool
 vts_file_exists(const char *filename)
@@ -58,7 +59,7 @@ vts_alloc_gen_fname(char **fname)
 	file_name = malloc(25);
 	if (!file_name)
 		return -ENOMEM;
-	n = snprintf(file_name, 25, VPOOL_NAME);
+	n = snprintf(file_name, 25, vos_path);
 	snprintf(file_name+n, 25-n, ".%d", gc++);
 	*fname = file_name;
 
@@ -335,7 +336,7 @@ dts_ctx_init(struct credit_context *tsc)
 		goto out;
 	tsc->tsc_init = DTS_INIT_DEBUG;
 
-	rc = vos_self_init("/mnt/daos");
+	rc = vos_self_init(vos_path);
 	if (rc)
 		goto out;
 	tsc->tsc_init = DTS_INIT_MODULE;

--- a/src/vos/tests/vts_common.h
+++ b/src/vos/tests/vts_common.h
@@ -41,8 +41,9 @@
 
 #define VPOOL_SIZE	VPOOL_2G
 
-#define VPOOL_NAME	"/mnt/daos/vpool"
 #define	VP_OPS 10
+
+#define STORAGE_PATH_LEN 64
 
 extern int gc;
 

--- a/src/vos/tests/vts_io.c
+++ b/src/vos/tests/vts_io.c
@@ -27,6 +27,7 @@ static uint64_t			update_akey_sv;
 static uint64_t			update_akey_array;
 static bool			vts_nest_iterators;
 
+extern char			vos_path[STORAGE_PATH_LEN];
 /**
  * Stores the last key and can be used for
  * punching or overwrite
@@ -197,8 +198,8 @@ test_args_init(struct io_test_args *args,
 		args->dkey = NULL;
 		args->dkey_size = sizeof(uint64_t);
 	}
-	snprintf(args->fname, VTS_BUF_SIZE, "/mnt/daos/vpool.test_%x",
-		 init_ofeats);
+	snprintf(args->fname, VTS_BUF_SIZE, "%s/vpool.test_%x",
+		 vos_path, init_ofeats);
 
 
 }

--- a/src/vos/vos_common.c
+++ b/src/vos/vos_common.c
@@ -555,7 +555,6 @@ vos_self_nvme_fini(void)
 }
 
 /* Storage path, NVMe config & shm_id used by standalone VOS */
-#define VOS_STORAGE_PATH	"/mnt/daos"
 #define VOS_NVME_CONF		"/etc/daos_nvme.conf"
 #define VOS_NVME_SHM_ID		DAOS_NVME_SHMID_NONE
 #define VOS_NVME_MEM_SIZE	1024

--- a/src/vos/vos_size.c
+++ b/src/vos/vos_size.c
@@ -47,6 +47,8 @@
 #define PRINT_RECORD(name, type, feats)					\
 	print_record(buf, #name, &name);
 
+extern char vos_path[64];
+
 static void
 print_dynamic(struct d_string_buffer_t *buf, const char *name,
 	      const struct daos_tree_overhead *ovhd)
@@ -147,7 +149,7 @@ get_vos_structure_sizes_yaml(int alloc_overhead, struct d_string_buffer_t *buf)
 		goto exit_0;
 	}
 
-	rc = vos_self_init("/mnt/daos");
+	rc = vos_self_init(vos_path);
 	if (rc) {
 		goto exit_1;
 	}


### PR DESCRIPTION
Add a command line arg to the vos unit tests in src/vos/tests/vos_tests.c
that allows the user to specify a non-default mount point for the pool
it will create/use.

Signed-off-by: Lei Huang <wiliam_huang@hotmail.com>