### PR TITLE
DAOS-9236 EC: merge parity list at server side

### DIFF
--- a/src/include/daos/object.h
+++ b/src/include/daos/object.h
@@ -647,7 +647,7 @@ daos_recx_ep_lists_dup(struct daos_recx_ep_list *lists, unsigned int nr)
 
 /* merge adjacent recxs for same epoch */
 static inline void
-daos_recx_ep_lists_merge(struct daos_recx_ep_list *lists, unsigned int nr)
+daos_recx_ep_list_merge(struct daos_recx_ep_list *lists, unsigned int nr)
 {
 	struct daos_recx_ep_list	*list;
 	struct daos_recx_ep		*recx_ep, *next;

--- a/src/object/cli_ec.c
+++ b/src/object/cli_ec.c
@@ -1931,7 +1931,6 @@ obj_ec_parity_check(struct obj_reasb_req *reasb_req,
 		parity_lists = reasb_req->orr_parity_lists;
 		if (parity_lists == NULL)
 			rc = -DER_NOMEM;
-		daos_recx_ep_lists_merge(parity_lists, nr);
 		goto out;
 	}
 
@@ -1939,7 +1938,6 @@ obj_ec_parity_check(struct obj_reasb_req *reasb_req,
 		rc = -DER_FETCH_AGAIN;
 		D_ERROR("simulate parity list mismatch, "DF_RC"\n", DP_RC(rc));
 	} else {
-		daos_recx_ep_lists_merge(recx_lists, nr);
 		rc = obj_ec_parity_lists_match(parity_lists, recx_lists, nr);
 		if (rc) {
 			D_ERROR("got different parity lists, "DF_RC"\n", DP_RC(rc));

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -1482,6 +1482,7 @@ obj_local_rw_internal(crt_rpc_t *rpc, struct obj_io_context *ioc,
 			parity_list = vos_ioh2recx_list(ioh);
 			if (parity_list != NULL) {
 				daos_recx_ep_list_set(parity_list, orw->orw_nr, 0, 0);
+				daos_recx_ep_list_merge(parity_list, orw->orw_nr);
 				orwo->orw_rels.ca_arrays = parity_list;
 				orwo->orw_rels.ca_count = orw->orw_nr;
 			}
@@ -1539,6 +1540,7 @@ obj_local_rw_internal(crt_rpc_t *rpc, struct obj_io_context *ioc,
 			}
 			daos_recx_ep_list_set(recov_lists, orw->orw_nr,
 					      recov_epoch, recov_snap);
+			daos_recx_ep_list_merge(recov_lists, orw->orw_nr);
 			orwo->orw_rels.ca_arrays = recov_lists;
 			orwo->orw_rels.ca_count = orw->orw_nr;
 		}

--- a/src/tests/ftest/daos_test/suite.yaml
+++ b/src/tests/ftest/daos_test/suite.yaml
@@ -19,7 +19,7 @@ timeouts:
     test_daos_verify_consistency: 105
     test_daos_io: 290
     test_daos_ec_io: 450
-    test_daos_ec_obj: 500
+    test_daos_ec_obj: 600
     test_daos_object_array: 105
     test_daos_array: 106
     test_daos_kv: 105
@@ -33,7 +33,7 @@ timeouts:
     test_daos_checksum: 500
     test_daos_rebuild_ec: 1800
     test_daos_aggregate_ec: 200
-    test_daos_degraded_ec: 1800
+    test_daos_degraded_ec: 1900
     test_daos_dedup: 220
 pool:
   #This will create 8G of SCM and 16G of NVMe size of pool.

--- a/src/tests/suite/daos_epoch_io.c
+++ b/src/tests/suite/daos_epoch_io.c
@@ -477,8 +477,9 @@ squeeze_spaces(char *line)
 	char	*current = line;
 	int	 spacing = 0;
 	int	 leading_space = 1;
+	int	 i;
 
-	for (; line && *line != '\n'; line++) {
+	for (i = 0; line && *line != '\n' && i < CMD_LINE_LEN_MAX - 1; line++, i++) {
 		if (isspace(*line)) {
 			if (!spacing && !leading_space) {
 				*current++ = *line;
@@ -497,13 +498,16 @@ static int
 cmd_line_get(FILE *fp, char *line)
 {
 	char	*p;
+	int	 i;
 
 	D_ASSERT(line != NULL && fp != NULL);
 	do {
 		if (fgets(line, CMD_LINE_LEN_MAX - 1, fp) == NULL)
 			return -DER_ENOENT;
-		for (p = line; isspace(*p); p++)
+		for (p = line, i = 0; isspace(*p) && i < CMD_LINE_LEN_MAX - 1; p++, i++)
 			;
+		if (i == CMD_LINE_LEN_MAX - 1)
+			continue;
 		if (*p != '\0' && *p != '#' && *p != '\n')
 			break;
 	} while (1);

--- a/src/tests/suite/daos_obj_ec.c
+++ b/src/tests/suite/daos_obj_ec.c
@@ -376,8 +376,8 @@ trigger_and_wait_ec_aggreation(test_arg_t *arg, daos_obj_id_t *oids,
 					      0, NULL);
 	}
 
-	print_message("wait for 20 seconds for EC aggregation.\n");
-	sleep(20);
+	print_message("wait for 30 seconds for EC aggregation.\n");
+	sleep(30);
 
 	for (i = 0; i < oids_nr; i++) {
 		struct daos_oclass_attr *oca;


### PR DESCRIPTION
For EC data recovery, merge parity list at server side.
And two small refines on test code.

Signed-off-by: Xuezhao Liu <xuezhao.liu@intel.com>