### PR TITLE
DAOS-7764 build: Tell spdk to build for x86_64 arch.

### DIFF
--- a/.github/workflows/ci2.yml
+++ b/.github/workflows/ci2.yml
@@ -135,8 +135,7 @@ jobs:
                           --build-arg DAOS_JAVA_BUILD=no
                           --build-arg DAOS_BUILD_TYPE=dev
                           --build-arg COMPILER
-# Should work, but enable on master only for now.
-#    - name: Run NLT
-#      run: docker run --mount type=tmpfs,destination=/mnt/daos_0,tmpfs-mode=1777 --user root:root
-#               --name build-post build-image
-#               ./daos/utils/node_local_test.py --no-root --memcheck no --test cont_copy
+    - name: Run NLT
+      run: docker run --mount type=tmpfs,destination=/mnt/daos_0,tmpfs-mode=1777 --user root:root
+               --name build-post build-image
+               ./daos/utils/node_local_test.py --no-root --memcheck no --test cont_copy

--- a/.github/workflows/landing-builds.yml
+++ b/.github/workflows/landing-builds.yml
@@ -203,10 +203,9 @@ jobs:
                           --build-arg DAOS_JAVA_BUILD=no
                           --build-arg DAOS_BUILD_TYPE=dev
                           --build-arg COMPILER
-# Fails with Ubuntu still for the spdk issue.
-#    - name: Run NLT
-#      run: docker run --mount type=tmpfs,destination=/mnt/daos_0,tmpfs-mode=1777 --user root:root
-#               build-image ./daos/utils/node_local_test.py --no-root --memcheck no --test cont_copy
+    - name: Run NLT
+      run: docker run --mount type=tmpfs,destination=/mnt/daos_0,tmpfs-mode=1777 --user root:root
+               build-image ./daos/utils/node_local_test.py --no-root --memcheck no --test cont_copy
 
   Build-branch:
     name: Build DAOS

--- a/site_scons/components/__init__.py
+++ b/site_scons/components/__init__.py
@@ -24,7 +24,6 @@
 import sys
 import os
 import platform
-import distro
 from prereq_tools import GitRepoRetriever
 from prereq_tools import WebRetriever
 from prereq_tools import ProgramBinary
@@ -313,23 +312,6 @@ def define_components(reqs):
 
     retriever = GitRepoRetriever("https://github.com/spdk/spdk.git", True)
 
-    # Tell SPDK which CPU to optimize for, by default this is native which works well unless you
-    # are relocating binaries across systems, for example in CI under github actions etc.  There
-    # isn't a minimum value needed here, but getting this wrong will cause daos server to exit
-    # prematurely with SIGILL (-4).
-    # https://docs.microsoft.com/en-us/azure/virtual-machines/dv2-dsv2-series#dsv2-series says
-    # that GHA can schedule on any of Skylake, Broadwell or Haswell CPUs.
-    # Ubuntu systems seem to fail more often, there may be something different going on here,
-    # it has also failed with sandybridge.
-    # https://gcc.gnu.org/onlinedocs/gcc/x86-Options.html
-    dist = distro.linux_distribution()
-    if dist[0] == 'CentOS Linux' and dist[1] == '7':
-        spdk_arch='native'
-    elif dist[0] == 'Ubuntu' and dist[1] == '20.04':
-        spdk_arch = 'nehalem'
-    else:
-        spdk_arch = 'haswell'
-
     reqs.define('spdk',
                 retriever=retriever,
                 commands=['./configure --prefix="$SPDK_PREFIX"'                \
@@ -338,7 +320,7 @@ def define_components(reqs):
                           ' --without-crypto --without-pmdk --without-rbd '    \
                           ' --with-rdma --without-iscsi-initiator '            \
                           ' --without-isal --without-vtune --with-shared',
-                          'make CONFIG_ARCH={} $JOBS_OPT'.format(spdk_arch),
+                          'make CONFIG_ARCH=x86_64 $JOBS_OPT',
                           'make install',
                           'cp -r -P dpdk/build/lib/* "$SPDK_PREFIX/lib"',
                           'mkdir -p "$SPDK_PREFIX/include/dpdk"',

--- a/utils/run_in_ga.sh
+++ b/utils/run_in_ga.sh
@@ -11,15 +11,8 @@ then
     SCONS=scons-3
 fi
 
-# Probably not needed now, but leave on PRs until we have confidence of landings builds.
-echo ::group::Rebuild spdk
-rm -rf /opt/daos/prereq/release/spdk
-$SCONS --jobs "$DEPS_JOBS" PREFIX=/opt/daos --build-deps=yes --deps-only
-echo ::endgroup::
-
 echo "::group::Stack analyzer output (post build)"
-# $SCONS --jobs "$DEPS_JOBS" PREFIX=/opt/daos --analyze-stack="-x tests -c 128" server
-$SCONS --jobs "$DEPS_JOBS" --analyze-stack="-x tests -c 128" server
+$SCONS --jobs "$DEPS_JOBS" PREFIX=/opt/daos --analyze-stack="-x tests -c 128" server
 echo ::endgroup::
 
 echo "::group::Stack analyzer output (immediate)"


### PR DESCRIPTION
Enable NLT on all distros in GHA now that spdk should work.

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>
