### PR TITLE
DAOS-9285 tests: Fix core file processing errors exiting launch.py (#…

### DIFF
--- a/src/tests/ftest/harness/setup.py
+++ b/src/tests/ftest/harness/setup.py
@@ -1,0 +1,25 @@
+#!/usr/bin/python3
+"""
+(C) Copyright 2021 Intel Corporation.
+
+SPDX-License-Identifier: BSD-2-Clause-Patent
+"""
+from apricot import TestWithServers
+
+
+class HarnessSetupTest(TestWithServers):
+    """Harness setup test cases.
+
+    :avocado: recursive
+    """
+
+    def test_setup(self):
+        """Verify the TestWithServers.setUp() method.
+
+        Useful for setting up the /etc/daos/daos_server.yml files on multiple hosts.
+
+        :avocado: tags=all
+        :avocado: tags=hw,large
+        :avocado: tags=harness,harness_setup_test,test_setup
+        """
+        self.log.info("Test passed!")

--- a/src/tests/ftest/harness/setup.yaml
+++ b/src/tests/ftest/harness/setup.yaml
@@ -1,0 +1,19 @@
+hosts:
+  test_servers:
+    - server-A
+    - server-B
+    - server-C
+    - server-D
+    - server-E
+    - server-F
+    - server-G
+    - server-H
+  test_clients:
+    - client-B
+timeout: 120
+server_config:
+  name: daos_server
+  servers:
+    scm_size: 20
+    bdev_class: nvme
+    bdev_list: ["aaaa:aa:aa.a"]


### PR DESCRIPTION
…7692)

Processing core files from failed tests occurs in between executing
each functional test file.  If there are any errors during the core file
processing it should not prevent additional tests from being executed.

This change resolves an issue seen on Leap 15 where gdb was not
installed and adds catching unexpected exceptions to prevent prematuely
exiting launch.py and missing out on executing tests.

It should also resolve issues where some debuginfo packages were missing
from some core file processing.

Skip-func-test-leap15: false
Test-tag: pr test_core_files

Signed-off-by: Phillip Henderson <phillip.henderson@intel.com>