### PR TITLE
DAOS-623 doc: fix minor typo, punctuation, grammar

### DIFF
--- a/docs/admin/pool_operations.md
+++ b/docs/admin/pool_operations.md
@@ -73,8 +73,8 @@ with redundancy enabled by default (pool service replicas on ranks 1-3).
 If no redundancy is desired, use --nsvc=1 in order to specify that only
 a single pool service replica should be created.
 
-The -t option allows to define the ration between SCM and NVMe SSD space.
-The default value is 6% which means that the space provided after --size
+The -t option allows defining the ratio between SCM and NVMe SSD space.
+The default value is 6%, which means the space provided after --size
 will be distributed as follows:
 - 6% is allocated on SCM (i.e., 3GB in the example above)
 - 94% is allocated on NVMe SSD (i.e., 47GB in the example above)
@@ -102,7 +102,7 @@ with the following information for each pool:
   the pool was originally configured with (total).
 
 The --verbose option provides more detailed information including the
-number of service replicate, the full UUIDs and space distribution
+number of service replicas, the full UUIDs and space distribution
 between SCM and NVMe for each pool:
 
 ```bash


### PR DESCRIPTION
Fix some minor typos and punctutation, as well as improve grammar.

Skip-build: true
Skip-test: true
Doc-only: true

Signed-off-by: Dalton Bohning <dalton.bohning@intel.com>