### PR TITLE
DAOS-8929 java: Bump protobuf-java from 3.11.4 to 3.16.1 in /src/clie…

### DIFF
--- a/src/client/java/daos-java/pom.xml
+++ b/src/client/java/daos-java/pom.xml
@@ -36,7 +36,7 @@
     <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
-      <version>3.11.4</version>
+      <version>3.16.1</version>
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>


### PR DESCRIPTION
…nt/java/daos-java (#7842)

Bumps [protobuf-java](https://github.com/protocolbuffers/protobuf) from 3.11.4 to 3.16.1.
- [Release notes](https://github.com/protocolbuffers/protobuf/releases)
- [Changelog](https://github.com/protocolbuffers/protobuf/blob/master/generate_changelog.py)
- [Commits](https://github.com/protocolbuffers/protobuf/compare/v3.11.4...v3.16.1)

Master PR#7842

Signed-off-by: dependabot[bot] <support@github.com>