### PR TITLE
DAOS-9510 tests: Increasing the pool/attribute.py test timeout

### DIFF
--- a/src/tests/ftest/pool/attribute.yaml
+++ b/src/tests/ftest/pool/attribute.yaml
@@ -3,7 +3,7 @@
 hosts:
   test_servers:
     - server-A
-timeout: 60
+timeout: 90
 server_config:
   name: daos_server
 pool:


### PR DESCRIPTION
Increasing the pool/attribute.py test timeout by 30 seconds to
compensate for running on VMs.

Skip-unit-tests: true
Skip-func-test-leap15: false
Test-tag: large_poolattribute sync_poolattribute async_poolattribute
Test-repeat: 10

Signed-off-by: Phillip Henderson <phillip.henderson@intel.com>