### PR TITLE
DAOS-9629 control: Replace storage class helper functions

### DIFF
--- a/src/control/cmd/daos_server/start_test.go
+++ b/src/control/cmd/daos_server/start_test.go
@@ -42,7 +42,7 @@ func genMinimalConfig() *config.Server {
 			engine.MockConfig().
 				WithStorage(
 					storage.NewTierConfig().
-						WithScmClass("ram").
+						WithStorageClass("ram").
 						WithScmRamdiskSize(1).
 						WithScmMountPoint("/mnt/daos"),
 				).
@@ -59,7 +59,7 @@ func genDefaultExpected() *config.Server {
 			engine.MockConfig().
 				WithStorage(
 					storage.NewTierConfig().
-						WithScmClass("ram").
+						WithStorageClass("ram").
 						WithScmRamdiskSize(1).
 						WithScmMountPoint("/mnt/daos"),
 				).

--- a/src/control/cmd/dmg/auto_test.go
+++ b/src/control/cmd/dmg/auto_test.go
@@ -195,11 +195,11 @@ hyperthreads: false
 				WithPinnedNumaNode(0).
 				WithStorage(
 					storage.NewTierConfig().
-						WithScmClass(storage.ClassDcpm.String()).
+						WithStorageClass(storage.ClassDcpm.String()).
 						WithScmDeviceList("/dev/pmem0").
 						WithScmMountPoint("/mnt/daos0"),
 					storage.NewTierConfig().
-						WithBdevClass(storage.ClassNvme.String()).
+						WithStorageClass(storage.ClassNvme.String()).
 						WithBdevDeviceList(common.MockPCIAddrs(0, 1, 2, 3)...),
 				).
 				WithStorageConfigOutputPath("/mnt/daos0/daos_nvme.conf").
@@ -216,11 +216,11 @@ hyperthreads: false
 				WithPinnedNumaNode(1).
 				WithStorage(
 					storage.NewTierConfig().
-						WithScmClass(storage.ClassDcpm.String()).
+						WithStorageClass(storage.ClassDcpm.String()).
 						WithScmDeviceList("/dev/pmem1").
 						WithScmMountPoint("/mnt/daos1"),
 					storage.NewTierConfig().
-						WithBdevClass(storage.ClassNvme.String()).
+						WithStorageClass(storage.ClassNvme.String()).
 						WithBdevDeviceList(common.MockPCIAddrs(4, 5, 6)...),
 				).
 				WithStorageConfigOutputPath("/mnt/daos1/daos_nvme.conf").

--- a/src/control/lib/control/auto.go
+++ b/src/control/lib/control/auto.go
@@ -603,7 +603,7 @@ func genConfig(ctx context.Context, log logging.Logger, newEngineCfg newEngineCf
 		if len(sd.numaPMems) > 0 {
 			engineCfg.WithStorage(
 				storage.NewTierConfig().
-					WithScmClass(storage.ClassDcpm.String()).
+					WithStorageClass(storage.ClassDcpm.String()).
 					WithScmMountPoint(fmt.Sprintf("%s%d", scmMountPrefix, nn)).
 					WithScmDeviceList(sd.numaPMems[nn][0]),
 			)
@@ -611,7 +611,7 @@ func genConfig(ctx context.Context, log logging.Logger, newEngineCfg newEngineCf
 		if len(sd.numaSSDs) > 0 {
 			engineCfg.WithStorage(
 				storage.NewTierConfig().
-					WithBdevClass(storage.ClassNvme.String()).
+					WithStorageClass(storage.ClassNvme.String()).
 					WithBdevDeviceList(sd.numaSSDs[nn][:minSsds]...),
 			)
 		}

--- a/src/control/lib/control/auto_test.go
+++ b/src/control/lib/control/auto_test.go
@@ -727,7 +727,7 @@ func TestControl_AutoConfig_genConfig(t *testing.T) {
 					WithFabricProvider("ofi+psm2").
 					WithStorage(
 						storage.NewTierConfig().
-							WithScmClass(storage.ClassDcpm.String()).
+							WithStorageClass(storage.ClassDcpm.String()).
 							WithScmDeviceList("/dev/pmem0").
 							WithScmMountPoint("/mnt/daos0"),
 					).
@@ -749,7 +749,7 @@ func TestControl_AutoConfig_genConfig(t *testing.T) {
 					WithFabricProvider("ofi+psm2").
 					WithStorage(
 						storage.NewTierConfig().
-							WithScmClass(storage.ClassDcpm.String()).
+							WithStorageClass(storage.ClassDcpm.String()).
 							WithScmDeviceList("/dev/pmem0").
 							WithScmMountPoint("/mnt/daos0"),
 					).
@@ -779,7 +779,7 @@ func TestControl_AutoConfig_genConfig(t *testing.T) {
 					WithFabricProvider("ofi+psm2").
 					WithStorage(
 						storage.NewTierConfig().
-							WithScmClass(storage.ClassDcpm.String()).
+							WithStorageClass(storage.ClassDcpm.String()).
 							WithScmDeviceList("/dev/pmem0").
 							WithScmMountPoint("/mnt/daos0"),
 					).
@@ -810,7 +810,7 @@ func TestControl_AutoConfig_genConfig(t *testing.T) {
 					WithFabricProvider("ofi+psm2").
 					WithStorage(
 						storage.NewTierConfig().
-							WithScmClass(storage.ClassDcpm.String()).
+							WithStorageClass(storage.ClassDcpm.String()).
 							WithScmDeviceList("/dev/pmem0").
 							WithScmMountPoint("/mnt/daos0"),
 					).
@@ -831,11 +831,11 @@ func TestControl_AutoConfig_genConfig(t *testing.T) {
 					WithFabricProvider("ofi+psm2").
 					WithStorage(
 						storage.NewTierConfig().
-							WithScmClass(storage.ClassDcpm.String()).
+							WithStorageClass(storage.ClassDcpm.String()).
 							WithScmDeviceList("/dev/pmem0").
 							WithScmMountPoint("/mnt/daos0"),
 						storage.NewTierConfig().
-							WithBdevClass(storage.ClassNvme.String()).
+							WithStorageClass(storage.ClassNvme.String()).
 							WithBdevDeviceList(common.MockPCIAddr(1)),
 					).
 					WithStorageConfigOutputPath("/mnt/daos0/daos_nvme.conf").
@@ -861,11 +861,11 @@ func TestControl_AutoConfig_genConfig(t *testing.T) {
 					WithFabricProvider("ofi+psm2").
 					WithStorage(
 						storage.NewTierConfig().
-							WithScmClass(storage.ClassDcpm.String()).
+							WithStorageClass(storage.ClassDcpm.String()).
 							WithScmDeviceList("/dev/pmem0").
 							WithScmMountPoint("/mnt/daos0"),
 						storage.NewTierConfig().
-							WithBdevClass(storage.ClassNvme.String()).
+							WithStorageClass(storage.ClassNvme.String()).
 							WithBdevDeviceList(common.MockPCIAddrs(0, 1, 2)...),
 					).
 					WithStorageConfigOutputPath("/mnt/daos0/daos_nvme.conf").
@@ -881,11 +881,11 @@ func TestControl_AutoConfig_genConfig(t *testing.T) {
 					WithFabricNumaNodeIndex(1).
 					WithStorage(
 						storage.NewTierConfig().
-							WithScmClass(storage.ClassDcpm.String()).
+							WithStorageClass(storage.ClassDcpm.String()).
 							WithScmDeviceList("/dev/pmem1").
 							WithScmMountPoint("/mnt/daos1"),
 						storage.NewTierConfig().
-							WithBdevClass(storage.ClassNvme.String()).
+							WithStorageClass(storage.ClassNvme.String()).
 							WithBdevDeviceList(common.MockPCIAddrs(4, 5, 6)...),
 					).
 					WithStorageConfigOutputPath("/mnt/daos1/daos_nvme.conf").
@@ -909,11 +909,11 @@ func TestControl_AutoConfig_genConfig(t *testing.T) {
 					WithFabricProvider("ofi+psm2").
 					WithStorage(
 						storage.NewTierConfig().
-							WithScmClass(storage.ClassDcpm.String()).
+							WithStorageClass(storage.ClassDcpm.String()).
 							WithScmDeviceList("/dev/pmem0").
 							WithScmMountPoint("/mnt/daos0"),
 						storage.NewTierConfig().
-							WithBdevClass(storage.ClassNvme.String()).
+							WithStorageClass(storage.ClassNvme.String()).
 							WithBdevDeviceList(common.MockPCIAddr(1)),
 					).
 					WithStorageConfigOutputPath("/mnt/daos0/daos_nvme.conf").
@@ -940,11 +940,11 @@ func TestControl_AutoConfig_genConfig(t *testing.T) {
 					WithFabricProvider("ofi+psm2").
 					WithStorage(
 						storage.NewTierConfig().
-							WithScmClass(storage.ClassDcpm.String()).
+							WithStorageClass(storage.ClassDcpm.String()).
 							WithScmDeviceList("/dev/pmem0").
 							WithScmMountPoint("/mnt/daos0"),
 						storage.NewTierConfig().
-							WithBdevClass(storage.ClassNvme.String()).
+							WithStorageClass(storage.ClassNvme.String()).
 							WithBdevDeviceList(common.MockPCIAddrs(0, 1, 2)...),
 					).
 					WithStorageConfigOutputPath("/mnt/daos0/daos_nvme.conf").
@@ -960,11 +960,11 @@ func TestControl_AutoConfig_genConfig(t *testing.T) {
 					WithFabricNumaNodeIndex(1).
 					WithStorage(
 						storage.NewTierConfig().
-							WithScmClass(storage.ClassDcpm.String()).
+							WithStorageClass(storage.ClassDcpm.String()).
 							WithScmDeviceList("/dev/pmem1").
 							WithScmMountPoint("/mnt/daos1"),
 						storage.NewTierConfig().
-							WithBdevClass(storage.ClassNvme.String()).
+							WithStorageClass(storage.ClassNvme.String()).
 							WithBdevDeviceList(common.MockPCIAddrs(4, 5, 6)...),
 					).
 					WithStorageConfigOutputPath("/mnt/daos1/daos_nvme.conf").

--- a/src/control/server/config/server.go
+++ b/src/control/server/config/server.go
@@ -423,7 +423,7 @@ func (cfg *Server) Validate(ctx context.Context, log logging.Logger) (err error)
 			if ec.LegacyStorage.ScmClass != storage.ClassNone {
 				tierCfgs = append(tierCfgs,
 					storage.NewTierConfig().
-						WithScmClass(ec.LegacyStorage.ScmClass.String()).
+						WithStorageClass(ec.LegacyStorage.ScmClass.String()).
 						WithScmDeviceList(ec.LegacyStorage.ScmConfig.DeviceList...).
 						WithScmMountPoint(ec.LegacyStorage.MountPoint).
 						WithScmRamdiskSize(ec.LegacyStorage.RamdiskSize),
@@ -443,7 +443,7 @@ func (cfg *Server) Validate(ctx context.Context, log logging.Logger) (err error)
 			default:
 				tierCfgs = append(tierCfgs,
 					storage.NewTierConfig().
-						WithBdevClass(ec.LegacyStorage.BdevClass.String()).
+						WithStorageClass(ec.LegacyStorage.BdevClass.String()).
 						WithBdevDeviceCount(ec.LegacyStorage.DeviceCount).
 						WithBdevDeviceList(ec.LegacyStorage.BdevConfig.DeviceList...).
 						WithBdevFileSize(ec.LegacyStorage.FileSize).

--- a/src/control/server/config/server_test.go
+++ b/src/control/server/config/server_test.go
@@ -227,10 +227,10 @@ func TestServerConfig_Constructed(t *testing.T) {
 			WithStorage(
 				storage.NewTierConfig().
 					WithScmMountPoint("/mnt/daos/1").
-					WithScmClass("ram").
+					WithStorageClass("ram").
 					WithScmRamdiskSize(16),
 				storage.NewTierConfig().
-					WithBdevClass("nvme").
+					WithStorageClass("nvme").
 					WithBdevDeviceList("0000:81:00.0", "0000:82:00.0").
 					WithBdevBusidRange("0x80-0x8f"),
 			).
@@ -255,10 +255,10 @@ func TestServerConfig_Constructed(t *testing.T) {
 			WithStorage(
 				storage.NewTierConfig().
 					WithScmMountPoint("/mnt/daos/2").
-					WithScmClass("dcpm").
+					WithStorageClass("dcpm").
 					WithScmDeviceList("/dev/pmem1"),
 				storage.NewTierConfig().
-					WithBdevClass("file").
+					WithStorageClass("file").
 					WithBdevDeviceList("/tmp/daos-bdev1", "/tmp/daos-bdev2").
 					WithBdevFileSize(16),
 			).
@@ -637,11 +637,11 @@ func TestServerConfig_Parsing(t *testing.T) {
 						WithFabricInterfacePort(20000).
 						WithStorage(
 							storage.NewTierConfig().
-								WithScmClass("ram").
+								WithStorageClass("ram").
 								WithScmRamdiskSize(1).
 								WithScmMountPoint("/mnt/daos/2"),
 							storage.NewTierConfig().
-								WithBdevClass("nvme").
+								WithStorageClass("nvme").
 								WithBdevDeviceList(MockPCIAddr(1), MockPCIAddr(1)),
 						))
 			},
@@ -854,7 +854,7 @@ func TestServerConfig_DuplicateValues(t *testing.T) {
 			WithFabricInterfacePort(42).
 			WithStorage(
 				storage.NewTierConfig().
-					WithScmClass("ram").
+					WithStorageClass("ram").
 					WithScmRamdiskSize(1).
 					WithScmMountPoint("a"),
 			)
@@ -866,7 +866,7 @@ func TestServerConfig_DuplicateValues(t *testing.T) {
 			WithFabricInterfacePort(42).
 			WithStorage(
 				storage.NewTierConfig().
-					WithScmClass("ram").
+					WithStorageClass("ram").
 					WithScmRamdiskSize(1).
 					WithScmMountPoint("b"),
 			)
@@ -898,7 +898,7 @@ func TestServerConfig_DuplicateValues(t *testing.T) {
 			configB: configB().
 				WithStorage(
 					storage.NewTierConfig().
-						WithScmClass(storage.ClassDcpm.String()).
+						WithStorageClass(storage.ClassDcpm.String()).
 						WithScmDeviceList("a").
 						WithScmMountPoint(configA().Storage.Tiers.ScmConfigs()[0].Scm.MountPoint),
 				),
@@ -908,14 +908,14 @@ func TestServerConfig_DuplicateValues(t *testing.T) {
 			configA: configA().
 				WithStorage(
 					storage.NewTierConfig().
-						WithScmClass(storage.ClassDcpm.String()).
+						WithStorageClass(storage.ClassDcpm.String()).
 						WithScmMountPoint("aa").
 						WithScmDeviceList("a"),
 				),
 			configB: configB().
 				WithStorage(
 					storage.NewTierConfig().
-						WithScmClass(storage.ClassDcpm.String()).
+						WithStorageClass(storage.ClassDcpm.String()).
 						WithScmMountPoint("bb").
 						WithScmDeviceList("a"),
 				),
@@ -925,13 +925,13 @@ func TestServerConfig_DuplicateValues(t *testing.T) {
 			configA: configA().
 				WithStorage(
 					storage.NewTierConfig().
-						WithBdevClass(storage.ClassNvme.String()).
+						WithStorageClass(storage.ClassNvme.String()).
 						WithBdevDeviceList(MockPCIAddr(1)),
 				),
 			configB: configB().
 				WithStorage(
 					storage.NewTierConfig().
-						WithBdevClass(storage.ClassNvme.String()).
+						WithStorageClass(storage.ClassNvme.String()).
 						WithBdevDeviceList(MockPCIAddr(2), MockPCIAddr(1)),
 				),
 			expErr: FaultConfigOverlappingBdevDeviceList(1, 0),
@@ -940,13 +940,13 @@ func TestServerConfig_DuplicateValues(t *testing.T) {
 			configA: configA().
 				WithStorage(
 					storage.NewTierConfig().
-						WithBdevClass(storage.ClassNvme.String()).
+						WithStorageClass(storage.ClassNvme.String()).
 						WithBdevDeviceList(MockPCIAddr(1), MockPCIAddr(1)),
 				),
 			configB: configB().
 				WithStorage(
 					storage.NewTierConfig().
-						WithBdevClass(storage.ClassNvme.String()).
+						WithStorageClass(storage.ClassNvme.String()).
 						WithBdevDeviceList(MockPCIAddr(2), MockPCIAddr(2)),
 				),
 			expErr: errors.New("bdev_list contains duplicate pci addresses"),
@@ -987,7 +987,7 @@ func TestServerConfig_NetworkDeviceClass(t *testing.T) {
 			WithLogFile("a").
 			WithStorage(
 				storage.NewTierConfig().
-					WithScmClass("ram").
+					WithStorageClass("ram").
 					WithScmRamdiskSize(1).
 					WithScmMountPoint("a"),
 			).
@@ -999,7 +999,7 @@ func TestServerConfig_NetworkDeviceClass(t *testing.T) {
 			WithLogFile("b").
 			WithStorage(
 				storage.NewTierConfig().
-					WithScmClass("ram").
+					WithStorageClass("ram").
 					WithScmRamdiskSize(1).
 					WithScmMountPoint("b"),
 			).

--- a/src/control/server/ctl_ranks_rpc_test.go
+++ b/src/control/server/ctl_ranks_rpc_test.go
@@ -712,13 +712,13 @@ func TestServer_CtlSvc_ResetFormatRanks(t *testing.T) {
 					WithTargetCount(1).
 					WithStorage(
 						storage.NewTierConfig().
-							WithScmClass("ram"),
+							WithStorageClass("ram"),
 					),
 				engine.MockConfig().
 					WithTargetCount(1).
 					WithStorage(
 						storage.NewTierConfig().
-							WithScmClass("ram"),
+							WithStorageClass("ram"),
 					),
 			)
 			svc := mockControlService(t, log, cfg, nil, nil, nil)

--- a/src/control/server/ctl_storage_rpc_test.go
+++ b/src/control/server/ctl_storage_rpc_test.go
@@ -272,7 +272,7 @@ func TestServer_CtlSvc_StorageScan_PreEngineStart(t *testing.T) {
 			defer common.ShowBufferOnFailure(t, buf)
 
 			tCfg := storage.NewTierConfig().
-				WithBdevClass(storage.ClassNvme.String()).
+				WithStorageClass(storage.ClassNvme.String()).
 				WithBdevDeviceList(storage.MockNvmeController().PciAddr)
 
 			engineCfg := engine.MockConfig().WithStorage(tCfg)
@@ -463,7 +463,7 @@ func TestServer_CtlSvc_StorageScan_PostEngineStart(t *testing.T) {
 			storageCfgs: []storage.TierConfigs{
 				{
 					storage.NewTierConfig().
-						WithBdevClass(storage.ClassNvme.String()).
+						WithStorageClass(storage.ClassNvme.String()).
 						WithBdevDeviceList(newCtrlr(1).PciAddr),
 				},
 			},
@@ -493,7 +493,7 @@ func TestServer_CtlSvc_StorageScan_PostEngineStart(t *testing.T) {
 			storageCfgs: []storage.TierConfigs{
 				{
 					storage.NewTierConfig().
-						WithBdevClass(storage.ClassNvme.String()).
+						WithStorageClass(storage.ClassNvme.String()).
 						WithBdevDeviceList(newCtrlr(1).PciAddr),
 				},
 			},
@@ -524,7 +524,7 @@ func TestServer_CtlSvc_StorageScan_PostEngineStart(t *testing.T) {
 			storageCfgs: []storage.TierConfigs{
 				{
 					storage.NewTierConfig().
-						WithBdevClass(storage.ClassNvme.String()).
+						WithStorageClass(storage.ClassNvme.String()).
 						WithBdevDeviceList(newCtrlr(1).PciAddr),
 				},
 			},
@@ -558,12 +558,12 @@ func TestServer_CtlSvc_StorageScan_PostEngineStart(t *testing.T) {
 			storageCfgs: []storage.TierConfigs{
 				{
 					storage.NewTierConfig().
-						WithBdevClass(storage.ClassNvme.String()).
+						WithStorageClass(storage.ClassNvme.String()).
 						WithBdevDeviceList(newCtrlr(1).PciAddr),
 				},
 				{
 					storage.NewTierConfig().
-						WithBdevClass(storage.ClassNvme.String()).
+						WithStorageClass(storage.ClassNvme.String()).
 						WithBdevDeviceList(newCtrlr(2).PciAddr),
 				},
 			},
@@ -604,12 +604,12 @@ func TestServer_CtlSvc_StorageScan_PostEngineStart(t *testing.T) {
 			storageCfgs: []storage.TierConfigs{
 				{
 					storage.NewTierConfig().
-						WithBdevClass(storage.ClassNvme.String()).
+						WithStorageClass(storage.ClassNvme.String()).
 						WithBdevDeviceList(newCtrlr(1).PciAddr),
 				},
 				{
 					storage.NewTierConfig().
-						WithBdevClass(storage.ClassNvme.String()).
+						WithStorageClass(storage.ClassNvme.String()).
 						WithBdevDeviceList(newCtrlr(2).PciAddr),
 				},
 			},
@@ -651,12 +651,12 @@ func TestServer_CtlSvc_StorageScan_PostEngineStart(t *testing.T) {
 			storageCfgs: []storage.TierConfigs{
 				{
 					storage.NewTierConfig().
-						WithBdevClass(storage.ClassNvme.String()).
+						WithStorageClass(storage.ClassNvme.String()).
 						WithBdevDeviceList(newCtrlr(1).PciAddr),
 				},
 				{
 					storage.NewTierConfig().
-						WithBdevClass(storage.ClassNvme.String()).
+						WithStorageClass(storage.ClassNvme.String()).
 						WithBdevDeviceList(newCtrlr(2).PciAddr),
 				},
 			},
@@ -701,12 +701,12 @@ func TestServer_CtlSvc_StorageScan_PostEngineStart(t *testing.T) {
 			storageCfgs: []storage.TierConfigs{
 				{
 					storage.NewTierConfig().
-						WithBdevClass(storage.ClassNvme.String()).
+						WithStorageClass(storage.ClassNvme.String()).
 						WithBdevDeviceList(newCtrlr(1).PciAddr),
 				},
 				{
 					storage.NewTierConfig().
-						WithBdevClass(storage.ClassNvme.String()).
+						WithStorageClass(storage.ClassNvme.String()).
 						WithBdevDeviceList(newCtrlr(2).PciAddr),
 				},
 			},
@@ -753,7 +753,7 @@ func TestServer_CtlSvc_StorageScan_PostEngineStart(t *testing.T) {
 			storageCfgs: []storage.TierConfigs{
 				{
 					storage.NewTierConfig().
-						WithScmClass(storage.ClassDcpm.String()).
+						WithStorageClass(storage.ClassDcpm.String()).
 						WithScmMountPoint(mockPbScmMount0.Path).
 						WithScmDeviceList(mockPbScmNamespace0.Blockdev),
 				},
@@ -791,7 +791,7 @@ func TestServer_CtlSvc_StorageScan_PostEngineStart(t *testing.T) {
 			storageCfgs: []storage.TierConfigs{
 				{
 					storage.NewTierConfig().
-						WithScmClass(storage.ClassDcpm.String()).
+						WithStorageClass(storage.ClassDcpm.String()).
 						WithScmMountPoint(mockPbScmMount0.Path).
 						WithScmDeviceList("/dev/foo", "/dev/bar"),
 				},
@@ -831,7 +831,7 @@ func TestServer_CtlSvc_StorageScan_PostEngineStart(t *testing.T) {
 			storageCfgs: []storage.TierConfigs{
 				{
 					storage.NewTierConfig().
-						WithScmClass(storage.ClassRam.String()).
+						WithStorageClass(storage.ClassRam.String()).
 						WithScmMountPoint(mockPbScmMount0.Path).
 						WithScmRamdiskSize(16),
 				},
@@ -897,20 +897,20 @@ func TestServer_CtlSvc_StorageScan_PostEngineStart(t *testing.T) {
 			storageCfgs: []storage.TierConfigs{
 				{
 					storage.NewTierConfig().
-						WithScmClass(storage.ClassDcpm.String()).
+						WithStorageClass(storage.ClassDcpm.String()).
 						WithScmMountPoint(mockPbScmMount0.Path).
 						WithScmDeviceList(mockPbScmNamespace0.Blockdev),
 					storage.NewTierConfig().
-						WithBdevClass(storage.ClassNvme.String()).
+						WithStorageClass(storage.ClassNvme.String()).
 						WithBdevDeviceList(newCtrlr(1).PciAddr),
 				},
 				{
 					storage.NewTierConfig().
-						WithScmClass(storage.ClassDcpm.String()).
+						WithStorageClass(storage.ClassDcpm.String()).
 						WithScmMountPoint(mockPbScmMount1.Path).
 						WithScmDeviceList(mockPbScmNamespace1.Blockdev),
 					storage.NewTierConfig().
-						WithBdevClass(storage.ClassNvme.String()).
+						WithStorageClass(storage.ClassNvme.String()).
 						WithBdevDeviceList(newCtrlr(2).PciAddr),
 				},
 			},
@@ -957,7 +957,7 @@ func TestServer_CtlSvc_StorageScan_PostEngineStart(t *testing.T) {
 			storageCfgs: []storage.TierConfigs{
 				{
 					storage.NewTierConfig().
-						WithBdevClass(storage.ClassNvme.String()).
+						WithStorageClass(storage.ClassNvme.String()).
 						WithBdevDeviceList(newCtrlr(1).PciAddr),
 				},
 			},
@@ -992,7 +992,7 @@ func TestServer_CtlSvc_StorageScan_PostEngineStart(t *testing.T) {
 			storageCfgs: []storage.TierConfigs{
 				{
 					storage.NewTierConfig().
-						WithBdevClass(storage.ClassNvme.String()).
+						WithStorageClass(storage.ClassNvme.String()).
 						WithBdevDeviceList(newCtrlr(1).PciAddr),
 				},
 			},
@@ -1030,7 +1030,7 @@ func TestServer_CtlSvc_StorageScan_PostEngineStart(t *testing.T) {
 			storageCfgs: []storage.TierConfigs{
 				{
 					storage.NewTierConfig().
-						WithBdevClass(storage.ClassNvme.String()).
+						WithStorageClass(storage.ClassNvme.String()).
 						WithBdevDeviceList(newCtrlr(1).PciAddr),
 				},
 			},
@@ -1604,11 +1604,11 @@ func TestServer_CtlSvc_StorageFormat(t *testing.T) {
 					WithStorage(
 						storage.NewTierConfig().
 							WithScmMountPoint(scmMount).
-							WithScmClass(tc.sClass.String()).
+							WithStorageClass(tc.sClass.String()).
 							WithScmRamdiskSize(uint(tc.sSize)).
 							WithScmDeviceList(tc.sDevs[idx]),
 						storage.NewTierConfig().
-							WithBdevClass(tc.bClass.String()).
+							WithStorageClass(tc.bClass.String()).
 							WithBdevFileSize(tc.bSize).
 							WithBdevDeviceList(tc.bDevs[idx]...),
 					)

--- a/src/control/server/ctl_storage_test.go
+++ b/src/control/server/ctl_storage_test.go
@@ -41,7 +41,7 @@ func TestServer_CtlSvc_getScmUsage(t *testing.T) {
 			storageCfgs: []storage.TierConfigs{
 				{
 					storage.NewTierConfig().
-						WithScmClass(storage.ClassDcpm.String()).
+						WithStorageClass(storage.ClassDcpm.String()).
 						WithScmMountPoint(mockScmMountPath0).
 						WithScmDeviceList(mockScmNs0.BlockDevice),
 				},
@@ -64,7 +64,7 @@ func TestServer_CtlSvc_getScmUsage(t *testing.T) {
 			storageCfgs: []storage.TierConfigs{
 				{
 					storage.NewTierConfig().
-						WithScmClass(storage.ClassDcpm.String()).
+						WithStorageClass(storage.ClassDcpm.String()).
 						WithScmMountPoint(mockScmMountPath0).
 						WithScmDeviceList(mockScmNs0.BlockDevice),
 				},
@@ -78,7 +78,7 @@ func TestServer_CtlSvc_getScmUsage(t *testing.T) {
 			storageCfgs: []storage.TierConfigs{
 				{
 					storage.NewTierConfig().
-						WithScmClass(storage.ClassDcpm.String()).
+						WithStorageClass(storage.ClassDcpm.String()).
 						WithScmMountPoint(mockScmMountPath0).
 						WithScmDeviceList(mockScmNs0.BlockDevice),
 				},
@@ -99,7 +99,7 @@ func TestServer_CtlSvc_getScmUsage(t *testing.T) {
 			storageCfgs: []storage.TierConfigs{
 				{
 					storage.NewTierConfig().
-						WithScmClass(storage.ClassDcpm.String()).
+						WithStorageClass(storage.ClassDcpm.String()).
 						WithScmMountPoint(mockScmMountPath0).
 						WithScmDeviceList(mockScmNs0.BlockDevice),
 				},
@@ -123,7 +123,7 @@ func TestServer_CtlSvc_getScmUsage(t *testing.T) {
 			storageCfgs: []storage.TierConfigs{
 				{
 					storage.NewTierConfig().
-						WithScmClass(storage.ClassDcpm.String()).
+						WithStorageClass(storage.ClassDcpm.String()).
 						WithScmMountPoint(mockScmMountPath0).
 						WithScmDeviceList(mockScmNs0.BlockDevice),
 				},
@@ -156,13 +156,13 @@ func TestServer_CtlSvc_getScmUsage(t *testing.T) {
 			storageCfgs: []storage.TierConfigs{
 				{
 					storage.NewTierConfig().
-						WithScmClass(storage.ClassDcpm.String()).
+						WithStorageClass(storage.ClassDcpm.String()).
 						WithScmMountPoint(mockScmMountPath0).
 						WithScmDeviceList(mockScmNs0.BlockDevice),
 				},
 				{
 					storage.NewTierConfig().
-						WithScmClass(storage.ClassDcpm.String()).
+						WithStorageClass(storage.ClassDcpm.String()).
 						WithScmMountPoint(mockScmMountPath1).
 						WithScmDeviceList(mockScmNs1.BlockDevice),
 				},

--- a/src/control/server/engine/config_test.go
+++ b/src/control/server/engine/config_test.go
@@ -134,12 +134,12 @@ func TestConstructedConfig(t *testing.T) {
 		WithModules("foo,bar,baz").
 		WithStorage(
 			storage.NewTierConfig().
-				WithScmClass("ram").
+				WithStorageClass("ram").
 				WithScmRamdiskSize(42).
 				WithScmMountPoint("/mnt/daostest").
 				WithScmDeviceList("/dev/a", "/dev/b"),
 			storage.NewTierConfig().
-				WithBdevClass("kdev").
+				WithStorageClass("kdev").
 				WithBdevDeviceCount(2).
 				WithBdevFileSize(20).
 				WithBdevDeviceList("/dev/c", "/dev/d"),
@@ -204,7 +204,7 @@ func TestConfig_ScmValidation(t *testing.T) {
 			cfg: baseValidConfig().
 				WithStorage(
 					storage.NewTierConfig().
-						WithScmClass("ram"),
+						WithStorageClass("ram"),
 				),
 			expErr: errors.New("scm_mount"),
 		},
@@ -212,7 +212,7 @@ func TestConfig_ScmValidation(t *testing.T) {
 			cfg: baseValidConfig().
 				WithStorage(
 					storage.NewTierConfig().
-						WithScmClass("ram").
+						WithStorageClass("ram").
 						WithScmRamdiskSize(1).
 						WithScmMountPoint("test"),
 				),
@@ -221,7 +221,7 @@ func TestConfig_ScmValidation(t *testing.T) {
 			cfg: baseValidConfig().
 				WithStorage(
 					storage.NewTierConfig().
-						WithScmClass("ram").
+						WithStorageClass("ram").
 						WithScmMountPoint("test"),
 				),
 			expErr: errors.New("scm_size"),
@@ -230,7 +230,7 @@ func TestConfig_ScmValidation(t *testing.T) {
 			cfg: baseValidConfig().
 				WithStorage(
 					storage.NewTierConfig().
-						WithScmClass("ram").
+						WithStorageClass("ram").
 						WithScmRamdiskSize(0).
 						WithScmMountPoint("test"),
 				),
@@ -240,7 +240,7 @@ func TestConfig_ScmValidation(t *testing.T) {
 			cfg: baseValidConfig().
 				WithStorage(
 					storage.NewTierConfig().
-						WithScmClass("ram").
+						WithStorageClass("ram").
 						WithScmRamdiskSize(1).
 						WithScmDeviceList("foo", "bar").
 						WithScmMountPoint("test"),
@@ -251,7 +251,7 @@ func TestConfig_ScmValidation(t *testing.T) {
 			cfg: baseValidConfig().
 				WithStorage(
 					storage.NewTierConfig().
-						WithScmClass("dcpm").
+						WithStorageClass("dcpm").
 						WithScmDeviceList("foo").
 						WithScmMountPoint("test"),
 				),
@@ -260,7 +260,7 @@ func TestConfig_ScmValidation(t *testing.T) {
 			cfg: baseValidConfig().
 				WithStorage(
 					storage.NewTierConfig().
-						WithScmClass("dcpm").
+						WithStorageClass("dcpm").
 						WithScmDeviceList("foo", "bar").
 						WithScmMountPoint("test"),
 				),
@@ -270,7 +270,7 @@ func TestConfig_ScmValidation(t *testing.T) {
 			cfg: baseValidConfig().
 				WithStorage(
 					storage.NewTierConfig().
-						WithScmClass("dcpm").
+						WithStorageClass("dcpm").
 						WithScmMountPoint("test"),
 				),
 			expErr: errors.New("scm_list"),
@@ -279,7 +279,7 @@ func TestConfig_ScmValidation(t *testing.T) {
 			cfg: baseValidConfig().
 				WithStorage(
 					storage.NewTierConfig().
-						WithScmClass("dcpm").
+						WithStorageClass("dcpm").
 						WithScmDeviceList("foo").
 						WithScmRamdiskSize(1).
 						WithScmMountPoint("test"),
@@ -304,7 +304,7 @@ func TestConfig_BdevValidation(t *testing.T) {
 			WithFabricInterfacePort(42).
 			WithStorage(
 				storage.NewTierConfig().
-					WithScmClass("dcpm").
+					WithStorageClass("dcpm").
 					WithScmDeviceList("foo").
 					WithScmMountPoint("test"),
 			)
@@ -320,7 +320,7 @@ func TestConfig_BdevValidation(t *testing.T) {
 			cfg: baseValidConfig().
 				WithStorage(
 					storage.NewTierConfig().
-						WithBdevClass("nvmed"),
+						WithStorageClass("nvmed"),
 				),
 			expErr: errors.New("no storage class"),
 		},
@@ -329,7 +329,7 @@ func TestConfig_BdevValidation(t *testing.T) {
 			cfg: baseValidConfig().
 				WithStorage(
 					storage.NewTierConfig().
-						WithBdevClass("nvme"),
+						WithStorageClass("nvme"),
 				),
 			expEmptyCfgPath: true,
 		},
@@ -337,7 +337,7 @@ func TestConfig_BdevValidation(t *testing.T) {
 			cfg: baseValidConfig().
 				WithStorage(
 					storage.NewTierConfig().
-						WithBdevClass("nvme").
+						WithStorageClass("nvme").
 						WithBdevDeviceList(common.MockPCIAddr(1), common.MockPCIAddr(2)),
 				),
 		},
@@ -345,7 +345,7 @@ func TestConfig_BdevValidation(t *testing.T) {
 			cfg: baseValidConfig().
 				WithStorage(
 					storage.NewTierConfig().
-						WithBdevClass("nvme").
+						WithStorageClass("nvme").
 						WithBdevDeviceList(common.MockPCIAddr(1), common.MockPCIAddr(1)),
 				),
 			expErr: errors.New("bdev_list"),
@@ -354,7 +354,7 @@ func TestConfig_BdevValidation(t *testing.T) {
 			cfg: baseValidConfig().
 				WithStorage(
 					storage.NewTierConfig().
-						WithBdevClass("nvme").
+						WithStorageClass("nvme").
 						WithBdevDeviceList(common.MockPCIAddr(1), "0000:00:00"),
 				),
 			expErr: errors.New("unexpected pci address"),
@@ -363,7 +363,7 @@ func TestConfig_BdevValidation(t *testing.T) {
 			cfg: baseValidConfig().
 				WithStorage(
 					storage.NewTierConfig().
-						WithBdevClass("kdev"),
+						WithStorageClass("kdev"),
 				),
 			expErr: errors.New("kdev requires non-empty bdev_list"),
 		},
@@ -371,7 +371,7 @@ func TestConfig_BdevValidation(t *testing.T) {
 			cfg: baseValidConfig().
 				WithStorage(
 					storage.NewTierConfig().
-						WithBdevClass("kdev").
+						WithStorageClass("kdev").
 						WithBdevDeviceList("/dev/sda"),
 				),
 			expCls: storage.ClassKdev,
@@ -380,7 +380,7 @@ func TestConfig_BdevValidation(t *testing.T) {
 			cfg: baseValidConfig().
 				WithStorage(
 					storage.NewTierConfig().
-						WithBdevClass("file").
+						WithStorageClass("file").
 						WithBdevDeviceList("bdev1"),
 				),
 			expErr: errors.New("file requires non-zero bdev_size"),
@@ -389,7 +389,7 @@ func TestConfig_BdevValidation(t *testing.T) {
 			cfg: baseValidConfig().
 				WithStorage(
 					storage.NewTierConfig().
-						WithBdevClass("file").
+						WithStorageClass("file").
 						WithBdevDeviceList("bdev1").
 						WithBdevFileSize(-1),
 				),
@@ -399,7 +399,7 @@ func TestConfig_BdevValidation(t *testing.T) {
 			cfg: baseValidConfig().
 				WithStorage(
 					storage.NewTierConfig().
-						WithBdevClass("file").
+						WithStorageClass("file").
 						WithBdevFileSize(10),
 				),
 			expErr: errors.New("file requires non-empty bdev_list"),
@@ -408,7 +408,7 @@ func TestConfig_BdevValidation(t *testing.T) {
 			cfg: baseValidConfig().
 				WithStorage(
 					storage.NewTierConfig().
-						WithBdevClass("file").
+						WithStorageClass("file").
 						WithBdevFileSize(10).
 						WithBdevDeviceList("bdev1", "bdev2"),
 				),
@@ -458,7 +458,7 @@ func TestConfig_Validation(t *testing.T) {
 		WithFabricInterfacePort(42).
 		WithStorage(
 			storage.NewTierConfig().
-				WithScmClass("ram").
+				WithStorageClass("ram").
 				WithScmRamdiskSize(1).
 				WithScmMountPoint("/foo/bar"),
 		)

--- a/src/control/server/engine/exec_test.go
+++ b/src/control/server/engine/exec_test.go
@@ -146,7 +146,7 @@ func TestRunnerNormalExit(t *testing.T) {
 		WithCrtTimeout(30).
 		WithStorage(
 			storage.NewTierConfig().
-				WithScmClass("ram").
+				WithStorageClass("ram").
 				WithScmMountPoint("/foo/bar"),
 		)
 	runner := NewRunner(log, cfg)

--- a/src/control/server/harness_test.go
+++ b/src/control/server/harness_test.go
@@ -195,7 +195,7 @@ func TestServer_Harness_Start(t *testing.T) {
 				engineCfgs[i] = engine.MockConfig().
 					WithStorage(
 						storage.NewTierConfig().
-							WithScmClass("ram").
+							WithStorageClass("ram").
 							WithScmRamdiskSize(1).
 							WithScmMountPoint(filepath.Join(testDir, strconv.Itoa(i))),
 					)

--- a/src/control/server/instance_storage_test.go
+++ b/src/control/server/instance_storage_test.go
@@ -138,13 +138,13 @@ func TestEngineInstance_NeedsScmFormat(t *testing.T) {
 	var (
 		ramCfg = engine.MockConfig().WithStorage(
 			storage.NewTierConfig().
-				WithBdevClass(storage.ClassRam.String()).
+				WithStorageClass(storage.ClassRam.String()).
 				WithScmMountPoint(goodMountPoint).
 				WithScmRamdiskSize(1),
 		)
 		dcpmCfg = engine.MockConfig().WithStorage(
 			storage.NewTierConfig().
-				WithBdevClass(storage.ClassDcpm.String()).
+				WithStorageClass(storage.ClassDcpm.String()).
 				WithScmMountPoint(goodMountPoint).
 				WithScmDeviceList("/dev/foo"),
 		)
@@ -224,7 +224,7 @@ func TestEngineInstance_NeedsScmFormat(t *testing.T) {
 		"check dcpm fails (missing device)": {
 			engineCfg: engine.MockConfig().WithStorage(
 				storage.NewTierConfig().
-					WithBdevClass(storage.ClassDcpm.String()).
+					WithStorageClass(storage.ClassDcpm.String()).
 					WithScmMountPoint(goodMountPoint)),
 			expErr: storage.ErrInvalidDcpmCount,
 		},
@@ -280,7 +280,7 @@ func TestIOEngineInstance_awaitStorageReady(t *testing.T) {
 	errStarted := errors.New("already started")
 	dcpmCfg := engine.MockConfig().WithStorage(
 		storage.NewTierConfig().
-			WithBdevClass(storage.ClassDcpm.String()).
+			WithStorageClass(storage.ClassDcpm.String()).
 			WithScmMountPoint("/mnt/test").
 			WithScmDeviceList("/dev/foo"),
 	)

--- a/src/control/server/instance_superblock_test.go
+++ b/src/control/server/instance_superblock_test.go
@@ -37,7 +37,7 @@ func TestServer_Instance_createSuperblock(t *testing.T) {
 			WithSystemName(t.Name()).
 			WithStorage(
 				storage.NewTierConfig().
-					WithScmClass("ram").
+					WithStorageClass("ram").
 					WithScmRamdiskSize(1).
 					WithScmMountPoint(mnt),
 			)

--- a/src/control/server/instance_test.go
+++ b/src/control/server/instance_test.go
@@ -39,7 +39,7 @@ var (
 func getTestEngineInstance(log logging.Logger) *EngineInstance {
 	cfg := engine.MockConfig().WithStorage(
 		storage.NewTierConfig().
-			WithScmClass("ram").
+			WithStorageClass("ram").
 			WithScmMountPoint("/foo/bar"),
 	)
 	runner := engine.NewRunner(log, cfg)

--- a/src/control/server/mgmt_pool_test.go
+++ b/src/control/server/mgmt_pool_test.go
@@ -232,7 +232,7 @@ func TestServer_MgmtSvc_calculateCreateStorage(t *testing.T) {
 				engineCfg = engineCfg.
 					WithStorage(
 						storage.NewTierConfig().
-							WithBdevClass("nvme").
+							WithStorageClass("nvme").
 							WithBdevDeviceList("foo", "bar"),
 					)
 			}
@@ -423,7 +423,7 @@ func TestServer_MgmtSvc_PoolCreate(t *testing.T) {
 					WithTargetCount(tc.targetCount).
 					WithStorage(
 						storage.NewTierConfig().
-							WithBdevClass("nvme").
+							WithStorageClass("nvme").
 							WithBdevDeviceList("foo", "bar"),
 					)
 				r := engine.NewTestRunner(nil, engineCfg)
@@ -496,10 +496,10 @@ func TestServer_MgmtSvc_PoolCreateDownRanks(t *testing.T) {
 		WithTargetCount(1).
 		WithStorage(
 			storage.NewTierConfig().
-				WithScmClass("ram").
+				WithStorageClass("ram").
 				WithScmMountPoint("/foo/bar"),
 			storage.NewTierConfig().
-				WithBdevClass("nvme").
+				WithStorageClass("nvme").
 				WithBdevDeviceList("foo", "bar"),
 		)
 	sp := storage.NewProvider(log, 0, &ec.Storage, nil, nil, nil)

--- a/src/control/server/storage/bdev/backend_class_test.go
+++ b/src/control/server/storage/bdev/backend_class_test.go
@@ -461,7 +461,7 @@ func TestBackend_writeJSONFile(t *testing.T) {
 				WithFabricInterfacePort(42).
 				WithStorage(
 					storage.NewTierConfig().
-						WithScmClass("dcpm").
+						WithStorageClass("dcpm").
 						WithScmDeviceList("foo").
 						WithScmMountPoint("scmmnt"),
 					&tc.confIn,

--- a/src/control/server/storage/bdev/backend_json_test.go
+++ b/src/control/server/storage/bdev/backend_json_test.go
@@ -194,7 +194,7 @@ func TestBackend_newSpdkConfig(t *testing.T) {
 				WithFabricInterfacePort(42).
 				WithStorage(
 					storage.NewTierConfig().
-						WithScmClass("dcpm").
+						WithStorageClass("dcpm").
 						WithScmDeviceList("foo").
 						WithScmMountPoint(mockMntpt),
 					cfg,

--- a/src/control/server/storage/config.go
+++ b/src/control/server/storage/config.go
@@ -117,9 +117,9 @@ func (tc *TierConfig) WithTier(tier int) *TierConfig {
 	return tc
 }
 
-// WithScmClass defines the type of SCM storage to be configured.
-func (tc *TierConfig) WithScmClass(scmClass string) *TierConfig {
-	tc.Class = Class(scmClass)
+// WithStorageClass defines the type of storage (scm or bdev) to be configured.
+func (tc *TierConfig) WithStorageClass(cls string) *TierConfig {
+	tc.Class = Class(cls)
 	return tc
 }
 
@@ -139,12 +139,6 @@ func (tc *TierConfig) WithScmRamdiskSize(size uint) *TierConfig {
 // WithScmDeviceList sets the list of devices to be used for SCM storage.
 func (tc *TierConfig) WithScmDeviceList(devices ...string) *TierConfig {
 	tc.Scm.DeviceList = devices
-	return tc
-}
-
-// WithBdevClass defines the type of block device storage to be used.
-func (tc *TierConfig) WithBdevClass(bdevClass string) *TierConfig {
-	tc.Class = Class(bdevClass)
 	return tc
 }
 

--- a/src/control/server/storage/provider_test.go
+++ b/src/control/server/storage/provider_test.go
@@ -146,7 +146,7 @@ func Test_BdevWriteRequestFromConfig(t *testing.T) {
 			cfg: &Config{
 				Tiers: TierConfigs{
 					NewTierConfig().
-						WithScmClass(ClassDcpm.String()).
+						WithStorageClass(ClassDcpm.String()).
 						WithScmMountPoint(fmt.Sprintf("/mnt/daos0")).
 						WithScmDeviceList(fmt.Sprintf("/dev/pmem0")),
 				},
@@ -165,11 +165,11 @@ func Test_BdevWriteRequestFromConfig(t *testing.T) {
 			cfg: &Config{
 				Tiers: TierConfigs{
 					NewTierConfig().
-						WithScmClass(ClassDcpm.String()).
+						WithStorageClass(ClassDcpm.String()).
 						WithScmMountPoint(fmt.Sprintf("/mnt/daos0")).
 						WithScmDeviceList(fmt.Sprintf("/dev/pmem0")),
 					NewTierConfig().
-						WithBdevClass(ClassNvme.String()).
+						WithStorageClass(ClassNvme.String()).
 						WithBdevBusidRange("0x00-0x7f"),
 				},
 			},
@@ -187,11 +187,11 @@ func Test_BdevWriteRequestFromConfig(t *testing.T) {
 			cfg: &Config{
 				Tiers: TierConfigs{
 					NewTierConfig().
-						WithScmClass(ClassDcpm.String()).
+						WithStorageClass(ClassDcpm.String()).
 						WithScmMountPoint(fmt.Sprintf("/mnt/daos0")).
 						WithScmDeviceList(fmt.Sprintf("/dev/pmem0")),
 					NewTierConfig().
-						WithBdevClass(ClassNvme.String()).
+						WithStorageClass(ClassNvme.String()).
 						WithBdevBusidRange("0x70-0x7f"),
 				},
 				EnableHotplug: true,
@@ -213,11 +213,11 @@ func Test_BdevWriteRequestFromConfig(t *testing.T) {
 			cfg: &Config{
 				Tiers: TierConfigs{
 					NewTierConfig().
-						WithScmClass(ClassDcpm.String()).
+						WithStorageClass(ClassDcpm.String()).
 						WithScmMountPoint(fmt.Sprintf("/mnt/daos0")).
 						WithScmDeviceList(fmt.Sprintf("/dev/pmem0")),
 					NewTierConfig().
-						WithBdevClass(ClassNvme.String()),
+						WithStorageClass(ClassNvme.String()),
 				},
 				EnableHotplug: true,
 			},

--- a/src/control/server/test_utils.go
+++ b/src/control/server/test_utils.go
@@ -163,7 +163,7 @@ func newTestEngine(log logging.Logger, isAP bool, provider *storage.Provider, en
 			WithTargetCount(1).
 			WithStorage(
 				storage.NewTierConfig().
-					WithBdevClass("nvme").
+					WithStorageClass("nvme").
 					WithBdevDeviceList("foo", "bar"),
 			),
 		)


### PR DESCRIPTION
Since storage tiering has been implemented, storage class identifiers
are not bdev or scm specific. Replace WithScmClass() and WithBdevClass()
with WithStorageClass().

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>