### PR TITLE
Revert "DAOS-9307 test: fix a mem usage bug in daos_epoch_io test (#7687)" (#7833)

### DIFF
--- a/src/tests/ftest/util/daos_io_conf.py
+++ b/src/tests/ftest/util/daos_io_conf.py
@@ -93,12 +93,12 @@ def gen_unaligned_io_conf(record_size, filename="testfile"):
         "akey akey_0",
         "iod_size 1",
         "pool --query",
-        "update --tx 0 --recx \"[0, {}]045\"".format(record_size),
-        "update --tx 1 --recx \"[{}, {}]123\"".format(
+        "update --tx 0 --recx \"[0, {}]045 \"".format(record_size),
+        "update --tx 1 --recx \"[{}, {}]123 \"".format(
             rand_ofs_start, rand_ofs_end),
         "fetch  --tx 1 -v --recx \"[0, {0}]045 [{0}, {1}]123 [{1}, "
         "{2}]045\"".format(rand_ofs_start, rand_ofs_end, record_size),
-        "pool --query")
+        "pool --query\n")
 
     try:
         file_hd = open(filename, "w+")


### PR DESCRIPTION
Updating the unaligned file creation to avoid end of file error.

Quick-Functional: true
Test-tag: unaligned_io
Test-repeat: 10

Signed-off-by: Samir Raval <samir.raval@intel.com>