### PR TITLE
DAOS-9642 control: improve error reporting from spdk bindings

### DIFF
--- a/src/control/lib/spdk/faults.go
+++ b/src/control/lib/spdk/faults.go
@@ -1,8 +1,9 @@
 //
-// (C) Copyright 2020-2021 Intel Corporation.
+// (C) Copyright 2020-2022 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
+
 package spdk
 
 import (
@@ -23,17 +24,20 @@ var (
 		"NVMe controller details are missing health statistics",
 		"",
 	)
-	FaultBindingRetNull = spdkFault(
-		code.SpdkBindingRetNull,
-		"SPDK binding unexpectedly returned NULL",
-		"",
-	)
 )
 
-func FaultBindingFailed(rc int, errMsg string) *fault.Fault {
+func FaultBindingRetNull(msg string) *fault.Fault {
+	return spdkFault(
+		code.SpdkBindingRetNull,
+		fmt.Sprintf("SPDK binding unexpectedly returned NULL, %s", msg),
+		"",
+	)
+}
+
+func FaultBindingFailed(rc int, msg string) *fault.Fault {
 	return spdkFault(
 		code.SpdkBindingFailed,
-		fmt.Sprintf("SPDK binding failed, rc: %d, %s", rc, errMsg),
+		fmt.Sprintf("SPDK binding failed, rc: %d, %s", rc, msg),
 		"",
 	)
 }

--- a/src/control/lib/spdk/spdk.go
+++ b/src/control/lib/spdk/spdk.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2018-2021 Intel Corporation.
+// (C) Copyright 2018-2022 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -13,8 +13,8 @@ package spdk
 /*
 #cgo CFLAGS: -I .
 #cgo LDFLAGS: -L . -lnvme_control
-#cgo LDFLAGS: -lspdk_log -lspdk_env_dpdk -lspdk_nvme -lspdk_vmd -lrte_mempool
-#cgo LDFLAGS: -lrte_mempool_ring -lrte_bus_pci
+#cgo LDFLAGS: -lspdk_util -lspdk_log -lspdk_env_dpdk -lspdk_nvme -lspdk_vmd
+#cgo LDFLAGS: -lrte_mempool -lrte_mempool_ring -lrte_bus_pci
 
 #include "stdlib.h"
 #include "daos_srv/control.h"
@@ -62,9 +62,14 @@ type Env interface {
 // EnvImpl is a an implementation of the Env interface.
 type EnvImpl struct{}
 
-// Rc2err returns error from label and rc.
-func Rc2err(label string, rc C.int) error {
-	return fmt.Errorf("%s: %d", label, rc)
+// rc2err returns error from label and rc.
+func rc2err(label string, rc C.int) error {
+	msgErrno := C.GoString(C.spdk_strerror(-rc))
+
+	if msgErrno != "" {
+		return fmt.Errorf("%s: %s (rc=%d)", label, msgErrno, rc)
+	}
+	return fmt.Errorf("%s: rc=%d", label, rc)
 }
 
 // EnvOptions describe parameters to be used when initializing a processes
@@ -114,14 +119,15 @@ func (e *EnvImpl) InitSPDKEnv(log logging.Logger, opts *EnvOptions) error {
 
 	retPtr := C.daos_spdk_init(0, envCtx, C.ulong(opts.PCIAllowList.Len()),
 		cAllowList)
+	defer clean(retPtr)
+
 	if err := checkRet(retPtr, "daos_spdk_init()"); err != nil {
 		return err
 	}
-	clean(retPtr)
 
 	if opts.EnableVMD {
 		if rc := C.spdk_vmd_init(); rc != 0 {
-			return Rc2err("spdk_vmd_init()", rc)
+			return rc2err("spdk_vmd_init()", rc)
 		}
 	}
 

--- a/src/control/lib/spdk/src/nvme_control_common.c
+++ b/src/control/lib/spdk/src/nvme_control_common.c
@@ -495,7 +495,8 @@ _collect(struct ret_t *ret, data_copier copy_data, pci_getter get_pci,
 fail:
 	ret->rc = rc;
 	if (ret->rc == 0)
-		ret->rc = -1;
+		/* Catch unexpected failures */
+		ret->rc = -EINVAL;
 	if (ctrlr_tmp)
 		free(ctrlr_tmp);
 	clean_ret(ret);


### PR DESCRIPTION
Control plane SPDK binding calls should report meaningful strings from
spdk_strerror in case of failure rather than the raw return codes.

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>