### PR TITLE
DAOS-9102 tests: Adjust cart timeouts and retries

### DIFF
--- a/src/tests/ftest/cart/no_pmix_group_test.c
+++ b/src/tests/ftest/cart/no_pmix_group_test.c
@@ -6,7 +6,6 @@
 /**
  * Dynamic group testing for primary and secondary groups
  */
-
 #include <stdlib.h>
 #include <stdio.h>
 #include <unistd.h>
@@ -17,6 +16,12 @@
 #include <cart/api.h>
 
 #include "crt_utils.h"
+
+/*
+ * By default expect RPCs to finish in 10 seconds; increase timeout for
+ * when running under the valgrind
+ */
+static int g_exp_rpc_timeout = 10;
 
 #define MY_BASE 0x010000000
 #define MY_VER  0
@@ -309,12 +314,20 @@ int main(int argc, char **argv)
 	sem_t			sem;
 	int			tag;
 	int			rc;
+	int			num_attach_retries = 20;
 
 	env_self_rank = getenv("CRT_L_RANK");
 	my_rank = atoi(env_self_rank);
 
+	/* When under valgrind bump expected timeouts to 60 seconds */
+	if (D_ON_VALGRIND) {
+		DBG_PRINT("Valgrind env detected. bumping timeouts\n");
+		g_exp_rpc_timeout = 60;
+		num_attach_retries = 60;
+	}
+
 	/* rank, num_attach_retries, is_server, assert_on_error */
-	crtu_test_init(my_rank, 20, true, true);
+	crtu_test_init(my_rank, num_attach_retries, true, true);
 
 	rc = d_log_init();
 	assert(rc == 0);
@@ -578,7 +591,7 @@ int main(int argc, char **argv)
 				D_ERROR("crt_req_send() failed; rc=%d\n", rc);
 				assert(0);
 			}
-			crtu_sem_timedwait(&sem, 10, __LINE__);
+			crtu_sem_timedwait(&sem, g_exp_rpc_timeout, __LINE__);
 			DBG_PRINT("RPC to rank=%d finished\n", rank);
 		}
 	}
@@ -601,7 +614,7 @@ int main(int argc, char **argv)
 		D_ERROR("crt_req_send() failed; rc=%d\n", rc);
 		assert(0);
 	}
-	crtu_sem_timedwait(&sem, 10, __LINE__);
+	crtu_sem_timedwait(&sem, g_exp_rpc_timeout, __LINE__);
 	DBG_PRINT("CORRPC to secondary group finished\n");
 
 	/* Send shutdown RPC to all nodes except for self */
@@ -631,7 +644,7 @@ int main(int argc, char **argv)
 			D_ERROR("crt_req_send() failed; rc=%d\n", rc);
 			assert(0);
 		}
-		crtu_sem_timedwait(&sem, 10, __LINE__);
+		crtu_sem_timedwait(&sem, g_exp_rpc_timeout, __LINE__);
 	}
 	D_FREE(rank_list->rl_ranks);
 	D_FREE(rank_list);

--- a/src/tests/ftest/cart/no_pmix_group_version.c
+++ b/src/tests/ftest/cart/no_pmix_group_version.c
@@ -18,6 +18,12 @@
 
 #include "crt_utils.h"
 
+/*
+ * By default expect RPCs to finish in 10 seconds; increase timeout for
+ * when running under the valgrind
+ */
+static int g_exp_rpc_timeout = 10;
+
 #define MY_BASE 0x010000000
 #define MY_VER  0
 
@@ -192,7 +198,7 @@ verify_corpc(crt_context_t ctx, crt_group_t *grp, int exp_rc)
 		assert(0);
 	}
 
-	crtu_sem_timedwait(&wait_info.sem, 10, __LINE__);
+	crtu_sem_timedwait(&wait_info.sem, g_exp_rpc_timeout, __LINE__);
 
 	if (wait_info.rc != exp_rc) {
 		D_ERROR("Expected %d got %d\n", exp_rc, wait_info.rc);
@@ -237,7 +243,7 @@ set_group_version(crt_context_t ctx, crt_group_t *grp,
 		assert(0);
 	}
 
-	crtu_sem_timedwait(&wait_info.sem, 10, __LINE__);
+	crtu_sem_timedwait(&wait_info.sem, g_exp_rpc_timeout, __LINE__);
 }
 
 int main(int argc, char **argv)
@@ -260,12 +266,20 @@ int main(int argc, char **argv)
 	crt_rpc_t		*rpc;
 	sem_t			sem;
 	int			rc;
+	int			num_attach_retries = 20;
 
 	env_self_rank = getenv("CRT_L_RANK");
 	my_rank = atoi(env_self_rank);
 
+	/* When under valgrind bump expected timeouts to 60 seconds */
+	if (D_ON_VALGRIND) {
+		DBG_PRINT("Valgrind env detected. bumping timeouts\n");
+		g_exp_rpc_timeout = 60;
+		num_attach_retries = 60;
+	}
+
 	/* rank, num_attach_retries, is_server, assert_on_error */
-	crtu_test_init(my_rank, 20, true, true);
+	crtu_test_init(my_rank, num_attach_retries, true, true);
 
 	rc = d_log_init();
 	assert(rc == 0);
@@ -485,7 +499,7 @@ int main(int argc, char **argv)
 			D_ERROR("crt_req_send() failed; rc=%d\n", rc);
 			assert(0);
 		}
-		crtu_sem_timedwait(&sem, 10, __LINE__);
+		crtu_sem_timedwait(&sem, g_exp_rpc_timeout, __LINE__);
 	}
 
 	d_rank_list_free(s_list);


### PR DESCRIPTION
- Adjust cart group test timeouts and number of retries for when
running under the valgrind.

Signed-off-by: Alexander A Oganezov <alexander.a.oganezov@intel.com>