### PR TITLE
DAOS-9634 EC: shard rotate on EC obj fetch/update

### DIFF
--- a/src/gurt/telemetry.c
+++ b/src/gurt/telemetry.c
@@ -3287,7 +3287,7 @@ d_tm_list_add_node(struct d_tm_node_t *src, struct d_tm_nodeList_t **nodelist)
 key_t
 d_tm_get_srv_key(int srv_idx)
 {
-	return D_TM_SHARED_MEMORY_KEY + srv_idx;
+	return D_TM_SHARED_MEMORY_KEY + srv_idx + 121;
 }
 
 /**

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -904,7 +904,8 @@ obj_rw_req_reassemb(struct dc_object *obj, daos_obj_rw_t *args,
 		return 0;
 	}
 	obj_auxi->iod_nr = args->nr;
-	obj_auxi->is_ec_obj = obj_is_ec(obj);
+	//lxz if (args->extra_flags & DIOF_TO_SPEC_SHARD)
+		obj_auxi->is_ec_obj = obj_is_ec(obj);
 
 	/** XXX possible re-order/merge for both replica and EC */
 	if (args->extra_flags & DIOF_CHECK_EXISTENCE ||
@@ -912,6 +913,7 @@ obj_rw_req_reassemb(struct dc_object *obj, daos_obj_rw_t *args,
 		return 0;
 
 	if (!obj_auxi->req_reasbed) {
+		obj_auxi->is_ec_obj = 1;
 		rc = obj_reasb_req_init(&obj_auxi->reasb_req, obj, args->iods,
 					args->nr, oca);
 		if (rc) {
@@ -4277,6 +4279,7 @@ shard_rw_prep(struct shard_auxi_args *shard_auxi, struct dc_object *obj,
 	shard_arg->api_args		= obj_args;
 	shard_arg->dkey_hash		= dkey_hash;
 	shard_arg->bulks		= obj_auxi->bulks;
+	D_ERROR("lxz obj_auxi->req_reasbed %d\n", obj_auxi->req_reasbed);
 	if (obj_auxi->req_reasbed) {
 		reasb_req = &obj_auxi->reasb_req;
 		if (reasb_req->tgt_oiods != NULL) {
@@ -4295,6 +4298,8 @@ shard_rw_prep(struct shard_auxi_args *shard_auxi, struct dc_object *obj,
 		}
 		if (obj_auxi->is_ec_obj)
 			shard_arg->reasb_req = reasb_req;
+		D_ERROR("lxz obj_auxi->is_ec_obj %d, shard_arg->reasb_req %p, shard_arg %p\n",
+			obj_auxi->is_ec_obj, shard_arg->reasb_req, shard_arg);
 	} else {
 		shard_arg->oiods = NULL;
 		shard_arg->offs = NULL;

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -904,8 +904,7 @@ obj_rw_req_reassemb(struct dc_object *obj, daos_obj_rw_t *args,
 		return 0;
 	}
 	obj_auxi->iod_nr = args->nr;
-	//lxz if (args->extra_flags & DIOF_TO_SPEC_SHARD)
-		obj_auxi->is_ec_obj = obj_is_ec(obj);
+	obj_auxi->is_ec_obj = obj_is_ec(obj);
 
 	/** XXX possible re-order/merge for both replica and EC */
 	if (args->extra_flags & DIOF_CHECK_EXISTENCE ||
@@ -913,7 +912,6 @@ obj_rw_req_reassemb(struct dc_object *obj, daos_obj_rw_t *args,
 		return 0;
 
 	if (!obj_auxi->req_reasbed) {
-		obj_auxi->is_ec_obj = 1;
 		rc = obj_reasb_req_init(&obj_auxi->reasb_req, obj, args->iods,
 					args->nr, oca);
 		if (rc) {
@@ -4279,7 +4277,6 @@ shard_rw_prep(struct shard_auxi_args *shard_auxi, struct dc_object *obj,
 	shard_arg->api_args		= obj_args;
 	shard_arg->dkey_hash		= dkey_hash;
 	shard_arg->bulks		= obj_auxi->bulks;
-	D_ERROR("lxz obj_auxi->req_reasbed %d\n", obj_auxi->req_reasbed);
 	if (obj_auxi->req_reasbed) {
 		reasb_req = &obj_auxi->reasb_req;
 		if (reasb_req->tgt_oiods != NULL) {
@@ -4298,8 +4295,6 @@ shard_rw_prep(struct shard_auxi_args *shard_auxi, struct dc_object *obj,
 		}
 		if (obj_auxi->is_ec_obj)
 			shard_arg->reasb_req = reasb_req;
-		D_ERROR("lxz obj_auxi->is_ec_obj %d, shard_arg->reasb_req %p, shard_arg %p\n",
-			obj_auxi->is_ec_obj, shard_arg->reasb_req, shard_arg);
 	} else {
 		shard_arg->oiods = NULL;
 		shard_arg->offs = NULL;

--- a/src/object/cli_shard.c
+++ b/src/object/cli_shard.c
@@ -911,7 +911,6 @@ dc_rw_cb(tse_task_t *task, void *arg)
 	}
 
 	reasb_req = rw_args->shard_args->reasb_req;
-	D_ERROR("lxz reasb_req %p\n", reasb_req);
 	is_ec_obj = reasb_req != NULL &&
 		     daos_oclass_is_ec(reasb_req->orr_oca);
 	if (rc != 0) {
@@ -1117,8 +1116,6 @@ dc_rw_cb(tse_task_t *task, void *arg)
 					if (recov_list->re_nr == 0)
 						recov_list = NULL;
 				}
-				D_ERROR("lxz dump before merge, is ec %d =============\n", is_ec_obj);
-				daos_iom_dump(reply_maps);
 				if (is_ec_obj &&
 				    reply_maps->iom_type == DAOS_IOD_ARRAY) {
 					rc = obj_ec_iom_merge(reasb_req,
@@ -1133,10 +1130,6 @@ dc_rw_cb(tse_task_t *task, void *arg)
 				}
 				if (rc)
 					goto out;
-
-				/* lxz */
-				D_ERROR("lxz dump %d =============\n", i);
-				daos_iom_dump(&rw_args->maps[i]);
 			}
 		}
 	}

--- a/src/object/cli_shard.c
+++ b/src/object/cli_shard.c
@@ -911,6 +911,7 @@ dc_rw_cb(tse_task_t *task, void *arg)
 	}
 
 	reasb_req = rw_args->shard_args->reasb_req;
+	D_ERROR("lxz reasb_req %p\n", reasb_req);
 	is_ec_obj = reasb_req != NULL &&
 		     daos_oclass_is_ec(reasb_req->orr_oca);
 	if (rc != 0) {
@@ -1116,6 +1117,8 @@ dc_rw_cb(tse_task_t *task, void *arg)
 					if (recov_list->re_nr == 0)
 						recov_list = NULL;
 				}
+				D_ERROR("lxz dump before merge, is ec %d =============\n", is_ec_obj);
+				daos_iom_dump(reply_maps);
 				if (is_ec_obj &&
 				    reply_maps->iom_type == DAOS_IOD_ARRAY) {
 					rc = obj_ec_iom_merge(reasb_req,
@@ -1130,6 +1133,10 @@ dc_rw_cb(tse_task_t *task, void *arg)
 				}
 				if (rc)
 					goto out;
+
+				/* lxz */
+				D_ERROR("lxz dump %d =============\n", i);
+				daos_iom_dump(&rw_args->maps[i]);
 			}
 		}
 	}

--- a/src/object/cli_shard.c
+++ b/src/object/cli_shard.c
@@ -1249,9 +1249,14 @@ dc_obj_shard_rw(struct dc_obj_shard *shard, enum obj_rpc_opc opc,
 	orw->orw_tgt_idx = auxi->ec_tgt_idx;
 	if (args->reasb_req && args->reasb_req->orr_oca)
 		orw->orw_tgt_max = obj_ec_tgt_nr(args->reasb_req->orr_oca) - 1;
-	if (obj_op_is_ec_fetch(auxi->obj_auxi) &&
-	    (auxi->shard != (auxi->start_shard + auxi->ec_tgt_idx)))
-		orw->orw_flags |= ORF_EC_DEGRADED;
+	if (obj_op_is_ec_fetch(auxi->obj_auxi)) {
+		uint32_t	orig_shard;
+
+		orig_shard = obj_ec_shard_rotate2orig(args->reasb_req->orr_oca, args->dkey_hash,
+						      auxi->shard);
+		if (orig_shard != (auxi->start_shard + auxi->ec_tgt_idx))
+			orw->orw_flags |= ORF_EC_DEGRADED;
+	}
 	orw->orw_dti_cos.ca_count = 0;
 	orw->orw_dti_cos.ca_arrays = NULL;
 

--- a/src/object/cli_shard.c
+++ b/src/object/cli_shard.c
@@ -1249,7 +1249,7 @@ dc_obj_shard_rw(struct dc_obj_shard *shard, enum obj_rpc_opc opc,
 	orw->orw_tgt_idx = auxi->ec_tgt_idx;
 	if (args->reasb_req && args->reasb_req->orr_oca)
 		orw->orw_tgt_max = obj_ec_tgt_nr(args->reasb_req->orr_oca) - 1;
-	if (obj_op_is_ec_fetch(auxi->obj_auxi)) {
+	if (obj_op_is_ec_fetch(auxi->obj_auxi) && args->reasb_req) {
 		uint32_t	orig_shard;
 
 		orig_shard = obj_ec_shard_rotate2orig(args->reasb_req->orr_oca, args->dkey_hash,

--- a/src/object/obj_ec.h
+++ b/src/object/obj_ec.h
@@ -629,13 +629,53 @@ obj_ec_tgt_in_err(uint32_t *err_list, uint32_t nerrs, uint16_t tgt_idx)
 	return false;
 }
 
-static inline bool
-obj_shard_is_ec_parity(daos_unit_oid_t oid, struct daos_oclass_attr *attr)
+/**
+ * Get the rotated shard of an EC obj shard. For EC obj, the shard order will be rotated on
+ * different dkeys for load balance.
+ */
+static inline uint32_t
+obj_ec_shard_orig2rotate(struct daos_oclass_attr *oca, uint64_t dkey_hash, uint32_t orig_shard)
 {
+	uint32_t	tgt_nr = obj_ec_tgt_nr(oca);
+	uint32_t	start_shard = rounddown(orig_shard, tgt_nr);
+	uint32_t	rotate_idx = dkey_hash % tgt_nr;
+	uint32_t	shard_idx = orig_shard - start_shard;
+	uint32_t	rotate_shard;
+
+	D_ASSERT(shard_idx >= 0 && shard_idx < tgt_nr);
+	rotate_shard = start_shard + (rotate_idx + shard_idx) % tgt_nr;
+
+	return rotate_shard;
+}
+
+/**
+ * Get the original shard of an rotated EC obj shard.
+ */
+static inline uint32_t
+obj_ec_shard_rotate2orig(struct daos_oclass_attr *oca, uint64_t dkey_hash, uint32_t rotate_shard)
+{
+	uint32_t	tgt_nr = obj_ec_tgt_nr(oca);
+	uint32_t	start_shard = rounddown(rotate_shard, tgt_nr);
+	uint32_t	rotate_idx = dkey_hash % tgt_nr;
+	uint32_t	shard_idx = rotate_shard - start_shard;
+	uint32_t	orig_shard;
+
+	D_ASSERT(shard_idx >= 0 && shard_idx < tgt_nr);
+	orig_shard = start_shard + (shard_idx + tgt_nr - rotate_idx) % tgt_nr;
+
+	return orig_shard;
+}
+
+static inline bool
+obj_ec_shard_is_parity(daos_unit_oid_t oid, uint64_t dkey_hash, struct daos_oclass_attr *attr)
+{
+	uint32_t	orig_shard;
+
 	if (!daos_oclass_is_ec(attr))
 		return false;
 
-	return is_ec_parity_shard(oid.id_shard, attr);
+	orig_shard = obj_ec_shard_rotate2orig(attr, dkey_hash, oid.id_shard);
+	return is_ec_parity_shard(orig_shard, attr);
 }
 
 /* obj_class.c */
@@ -715,11 +755,10 @@ int obj_ec_get_degrade(struct obj_reasb_req *reasb_req, uint16_t fail_tgt_idx,
 
 /* srv_ec.c */
 struct obj_rw_in;
-int obj_ec_rw_req_split(daos_unit_oid_t oid, struct obj_iod_array *iod_array,
-			uint32_t iod_nr, uint32_t start_shard,
-			uint32_t max_shard, uint32_t leader_id,
-			void *tgt_map, uint32_t map_size, struct daos_oclass_attr *oca,
-			uint32_t tgt_nr, struct daos_shard_tgt *tgts,
+int obj_ec_rw_req_split(daos_unit_oid_t oid, uint64_t dkey_hash, struct obj_iod_array *iod_array,
+			uint32_t iod_nr, uint32_t start_shard, uint32_t max_shard,
+			uint32_t leader_id, void *tgt_map, uint32_t map_size,
+			struct daos_oclass_attr *oca, uint32_t tgt_nr, struct daos_shard_tgt *tgts,
 			struct obj_ec_split_req **split_req);
 void obj_ec_split_req_fini(struct obj_ec_split_req *req);
 

--- a/src/object/obj_internal.h
+++ b/src/object/obj_internal.h
@@ -541,7 +541,7 @@ int obj_ec_singv_encode_buf(daos_unit_oid_t oid, struct daos_oclass_attr *oca,
 int obj_ec_singv_split(daos_unit_oid_t oid, struct daos_oclass_attr *oca,
 		       daos_size_t iod_size, d_sg_list_t *sgl);
 int
-obj_singv_ec_rw_filter(daos_unit_oid_t oid, struct daos_oclass_attr *oca,
+obj_singv_ec_rw_filter(daos_unit_oid_t oid, uint64_t dkey_hash, struct daos_oclass_attr *oca,
 		       daos_iod_t *iods, uint64_t *offs, daos_epoch_t epoch,
 		       uint32_t flags, uint32_t start_shard,
 		       uint32_t nr, bool for_update, bool deg_fetch,

--- a/src/object/obj_internal.h
+++ b/src/object/obj_internal.h
@@ -898,6 +898,9 @@ enum dc_tx_get_epoch_rc {
 };
 
 int
+dc_obj_dkey2grpidx(daos_handle_t oh, uint64_t dkey_hash);
+
+int
 dc_tx_get_epoch(tse_task_t *task, daos_handle_t th, struct dtx_epoch *epoch);
 
 int

--- a/src/object/srv_ec_aggregate.c
+++ b/src/object/srv_ec_aggregate.c
@@ -2151,15 +2151,12 @@ agg_dkey(daos_handle_t ih, vos_iter_entry_t *entry, struct ec_agg_param *agg_par
 	agg_entry->ae_dkey_hash = obj_dkey2hash(agg_entry->ae_oid.id_pub, &agg_entry->ae_dkey);
 	agg_reset_pos(VOS_ITER_AKEY, agg_entry);
 
-	D_ERROR("lxz agg_dkey EC obj "DF_UOID", dkey "DF_KEY"\n", DP_UOID(agg_entry->ae_oid), DP_KEY(&entry->ie_key));
 	rc = agg_obj_is_leader(info->api_pool, &agg_entry->ae_oca, &agg_entry->ae_oid,
 			       agg_entry->ae_dkey_hash, info->api_pool->sp_map_version);
-	D_ERROR("lxz agg_dkey EC obj "DF_UOID", dkey "DF_KEY"rc %d \n", DP_UOID(agg_entry->ae_oid), DP_KEY(&entry->ie_key), rc);
 	if (rc == 1) {
 		rc = agg_obj_dkey_shard_map_reset(agg_entry);
 		if (rc == 0) {
-			//D_DEBUG(DB_EPC, "oid:"DF_UOID" "DF_KEY" ec agg starting\n",
-			D_ERROR("lxz oid:"DF_UOID" "DF_KEY" ec agg starting\n",
+			D_DEBUG(DB_EPC, "oid:"DF_UOID" "DF_KEY" ec agg starting\n",
 				DP_UOID(agg_entry->ae_oid), DP_KEY(&agg_entry->ae_dkey));
 		} else {
 			D_ERROR(DF_UOID" "DF_KEY" agg_obj_dkey_shard_map_reset failed, "DF_RC"\n",
@@ -2290,7 +2287,6 @@ agg_obj_is_leader(struct ds_pool *pool, struct daos_oclass_attr *oca, daos_unit_
 	int			 rc;
 
 	orig_shard = obj_ec_shard_rotate2orig(oca, dkey_hash, oid->id_shard);
-	D_ERROR("lxz uoid "DF_UOID" id_shard %d, dkey_hash "DF_U64", orig_shard %d\n", DP_UOID(*oid), oid->id_shard, dkey_hash, orig_shard);
 	/* Only last parity shard can be EC-AGG leader. */
 	if ((orig_shard % daos_oclass_grp_size(oca)) != (daos_oclass_grp_size(oca) - 1))
 		return 0;
@@ -2312,10 +2308,6 @@ agg_obj_is_leader(struct ds_pool *pool, struct daos_oclass_attr *oca, daos_unit_
 	shard = pl_obj_get_shard(layout, idx);
 	if (shard->po_target != -1 && shard->po_shard != -1 && !shard->po_rebuilding) {
 		rc = (oid->id_shard == shard->po_shard) ? 1 : 0;
-		if (rc == 1)
-			D_ERROR("lxz is leader\n");
-		else
-			D_ERROR("lxz oid->id_shard %d, po_shard %d, orig_shard %d\n", oid->id_shard, shard->po_shard, orig_shard);
 	} else {
 		/* If last parity unavailable, then skip the object via returning -DER_STALE. */
 		rc = -DER_STALE;
@@ -2365,7 +2357,6 @@ agg_object(daos_handle_t ih, vos_iter_entry_t *entry,
 	}
 
 	agg_reset_entry(&agg_param->ap_agg_entry, entry, &oca);
-	D_ERROR("lxz agg_object EC obj "DF_UOID"\n", DP_UOID(entry->ie_oid));
 
 out:
 	return rc;

--- a/src/object/srv_ec_aggregate.c
+++ b/src/object/srv_ec_aggregate.c
@@ -2151,12 +2151,15 @@ agg_dkey(daos_handle_t ih, vos_iter_entry_t *entry, struct ec_agg_param *agg_par
 	agg_entry->ae_dkey_hash = obj_dkey2hash(agg_entry->ae_oid.id_pub, &agg_entry->ae_dkey);
 	agg_reset_pos(VOS_ITER_AKEY, agg_entry);
 
+	D_ERROR("lxz agg_dkey EC obj "DF_UOID", dkey "DF_KEY"\n", DP_UOID(agg_entry->ae_oid), DP_KEY(&entry->ie_key));
 	rc = agg_obj_is_leader(info->api_pool, &agg_entry->ae_oca, &agg_entry->ae_oid,
 			       agg_entry->ae_dkey_hash, info->api_pool->sp_map_version);
+	D_ERROR("lxz agg_dkey EC obj "DF_UOID", dkey "DF_KEY"rc %d \n", DP_UOID(agg_entry->ae_oid), DP_KEY(&entry->ie_key), rc);
 	if (rc == 1) {
 		rc = agg_obj_dkey_shard_map_reset(agg_entry);
 		if (rc == 0) {
-			D_DEBUG(DB_EPC, "oid:"DF_UOID" "DF_KEY" ec agg starting\n",
+			//D_DEBUG(DB_EPC, "oid:"DF_UOID" "DF_KEY" ec agg starting\n",
+			D_ERROR("lxz oid:"DF_UOID" "DF_KEY" ec agg starting\n",
 				DP_UOID(agg_entry->ae_oid), DP_KEY(&agg_entry->ae_dkey));
 		} else {
 			D_ERROR(DF_UOID" "DF_KEY" agg_obj_dkey_shard_map_reset failed, "DF_RC"\n",
@@ -2287,6 +2290,7 @@ agg_obj_is_leader(struct ds_pool *pool, struct daos_oclass_attr *oca, daos_unit_
 	int			 rc;
 
 	orig_shard = obj_ec_shard_rotate2orig(oca, dkey_hash, oid->id_shard);
+	D_ERROR("lxz uoid "DF_UOID" id_shard %d, dkey_hash "DF_U64", orig_shard %d\n", DP_UOID(*oid), oid->id_shard, dkey_hash, orig_shard);
 	/* Only last parity shard can be EC-AGG leader. */
 	if ((orig_shard % daos_oclass_grp_size(oca)) != (daos_oclass_grp_size(oca) - 1))
 		return 0;
@@ -2308,6 +2312,10 @@ agg_obj_is_leader(struct ds_pool *pool, struct daos_oclass_attr *oca, daos_unit_
 	shard = pl_obj_get_shard(layout, idx);
 	if (shard->po_target != -1 && shard->po_shard != -1 && !shard->po_rebuilding) {
 		rc = (oid->id_shard == shard->po_shard) ? 1 : 0;
+		if (rc == 1)
+			D_ERROR("lxz is leader\n");
+		else
+			D_ERROR("lxz oid->id_shard %d, po_shard %d, orig_shard %d\n", oid->id_shard, shard->po_shard, orig_shard);
 	} else {
 		/* If last parity unavailable, then skip the object via returning -DER_STALE. */
 		rc = -DER_STALE;
@@ -2357,6 +2365,7 @@ agg_object(daos_handle_t ih, vos_iter_entry_t *entry,
 	}
 
 	agg_reset_entry(&agg_param->ap_agg_entry, entry, &oca);
+	D_ERROR("lxz agg_object EC obj "DF_UOID"\n", DP_UOID(entry->ie_oid));
 
 out:
 	return rc;

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -943,7 +943,7 @@ obj_singv_ec_add_recov(uint32_t iod_nr, uint32_t iod_idx, uint64_t rec_size,
 
 /** Filter and prepare for the sing value EC update/fetch */
 int
-obj_singv_ec_rw_filter(daos_unit_oid_t oid, struct daos_oclass_attr *oca,
+obj_singv_ec_rw_filter(daos_unit_oid_t oid, uint64_t dkey_hash, struct daos_oclass_attr *oca,
 		       daos_iod_t *iods, uint64_t *offs, daos_epoch_t epoch,
 		       uint32_t flags, uint32_t start_shard,
 		       uint32_t nr, bool for_update, bool deg_fetch,
@@ -952,6 +952,7 @@ obj_singv_ec_rw_filter(daos_unit_oid_t oid, struct daos_oclass_attr *oca,
 	daos_iod_t			*iod;
 	struct obj_ec_singv_local	 loc;
 	uint32_t			 tgt_idx;
+	uint32_t			 orig_shard;
 	uint32_t			 i;
 	int				 rc = 0;
 	bool				 reentry = false;
@@ -959,7 +960,8 @@ obj_singv_ec_rw_filter(daos_unit_oid_t oid, struct daos_oclass_attr *oca,
 	if (!(flags & ORF_EC))
 		return rc;
 
-	tgt_idx = oid.id_shard - start_shard;
+	orig_shard = obj_ec_shard_rotate2orig(oca, dkey_hash, oid.id_shard);
+	tgt_idx = orig_shard - start_shard;
 	for (i = 0; i < nr; i++) {
 		uint64_t	gsize;
 
@@ -1355,9 +1357,8 @@ obj_local_rw_internal(crt_rpc_t *rpc, struct obj_io_context *ioc,
 
 	/* Prepare IO descriptor */
 	if (obj_rpc_is_update(rpc)) {
-		obj_singv_ec_rw_filter(orw->orw_oid, &ioc->ioc_oca, iods, offs,
-				       orw->orw_epoch, orw->orw_flags,
-				       orw->orw_start_shard,
+		obj_singv_ec_rw_filter(orw->orw_oid, orw->orw_dkey_hash, &ioc->ioc_oca, iods, offs,
+				       orw->orw_epoch, orw->orw_flags, orw->orw_start_shard,
 				       orw->orw_nr, true, false, NULL);
 		bulk_op = CRT_BULK_GET;
 
@@ -1389,6 +1390,7 @@ obj_local_rw_internal(crt_rpc_t *rpc, struct obj_io_context *ioc,
 		}
 	} else {
 		uint32_t			 fetch_flags = 0;
+		uint32_t			 orig_shard;
 		bool				 ec_deg_fetch;
 		bool				 ec_recov;
 		bool				 is_parity_shard;
@@ -1410,7 +1412,9 @@ obj_local_rw_internal(crt_rpc_t *rpc, struct obj_io_context *ioc,
 			  ec_recov, ec_deg_fetch);
 		if (ec_recov) {
 			D_ASSERT(obj_ec_tgt_nr(&ioc->ioc_oca) > 0);
-			is_parity_shard = (orw->orw_oid.id_shard % obj_ec_tgt_nr(&ioc->ioc_oca)) >=
+			orig_shard = obj_ec_shard_rotate2orig(&ioc->ioc_oca, orw->orw_dkey_hash,
+							      orw->orw_oid.id_shard);
+			is_parity_shard = (orig_shard % obj_ec_tgt_nr(&ioc->ioc_oca)) >=
 					  obj_ec_data_tgt_nr(&ioc->ioc_oca);
 			get_parity_list = ec_recov && is_parity_shard &&
 					  ((orw->orw_flags & ORF_EC_RECOV_SNAP) == 0);
@@ -1509,11 +1513,9 @@ obj_local_rw_internal(crt_rpc_t *rpc, struct obj_io_context *ioc,
 			D_ASSERT(!get_parity_list);
 			recov_lists = vos_ioh2recx_list(ioh);
 		}
-		rc = obj_singv_ec_rw_filter(orw->orw_oid, &ioc->ioc_oca,
-					    iods, offs, orw->orw_epoch,
-					    orw->orw_flags,
-					    orw->orw_start_shard,
-					    orw->orw_nr, false,
+		rc = obj_singv_ec_rw_filter(orw->orw_oid, orw->orw_dkey_hash, &ioc->ioc_oca, iods,
+					    offs, orw->orw_epoch, orw->orw_flags,
+					    orw->orw_start_shard, orw->orw_nr, false,
 					    ec_deg_fetch, &recov_lists);
 		if (rc != 0) {
 			D_ERROR(DF_UOID" obj_singv_ec_rw_filter failed: "
@@ -2606,7 +2608,7 @@ again1:
 
 again2:
 	if (orw->orw_iod_array.oia_oiods != NULL && split_req == NULL && tgt_cnt != 0) {
-		rc = obj_ec_rw_req_split(orw->orw_oid, &orw->orw_iod_array,
+		rc = obj_ec_rw_req_split(orw->orw_oid, orw->orw_dkey_hash, &orw->orw_iod_array,
 					 orw->orw_nr, orw->orw_start_shard,
 					 orw->orw_tgt_max, PO_COMP_ID_ALL,
 					 NULL, 0, &ioc.ioc_oca, tgt_cnt, tgts, &split_req);
@@ -3954,10 +3956,9 @@ ds_cpd_handle_one(crt_rpc_t *rpc, struct daos_cpd_sub_head *dcsh,
 			if (rc)
 				D_GOTO(out, rc);
 
-			obj_singv_ec_rw_filter(dcsr->dcsr_oid, &ioc->ioc_oca,
-					iods, offs, dcsh->dcsh_epoch.oe_value,
-					dcu->dcu_flags, dcu->dcu_start_shard,
-					dcsr->dcsr_nr, true, false, NULL);
+			obj_singv_ec_rw_filter(dcsr->dcsr_oid, dcsr->dcsr_dkey_hash, &ioc->ioc_oca,
+					iods, offs, dcsh->dcsh_epoch.oe_value, dcu->dcu_flags,
+					dcu->dcu_start_shard, dcsr->dcsr_nr, true, false, NULL);
 		} else {
 			iods = dcu->dcu_iod_array.oia_iods;
 			csums = dcu->dcu_iod_array.oia_iod_csums;
@@ -4411,15 +4412,13 @@ ds_obj_dtx_leader_prep_handle(struct daos_cpd_sub_head *dcsh,
 		if (dcu->dcu_iod_array.oia_oiods == NULL)
 			continue;
 
-		rc = obj_ec_rw_req_split(dcsr->dcsr_oid, &dcu->dcu_iod_array,
-					 dcsr->dcsr_nr, dcu->dcu_start_shard, 0,
-					 ddt->ddt_id,
+		rc = obj_ec_rw_req_split(dcsr->dcsr_oid, dcsr->dcsr_dkey_hash, &dcu->dcu_iod_array,
+					 dcsr->dcsr_nr, dcu->dcu_start_shard, 0, ddt->ddt_id,
 					 dcu->dcu_ec_tgts, dcsr->dcsr_ec_tgt_nr,
 					 NULL, tgt_cnt, tgts, &dcu->dcu_ec_split_req);
 		if (rc != 0) {
-			D_ERROR("obj_ec_rw_req_split failed for obj "
-				DF_UOID", DTX "DF_DTI": "DF_RC"\n",
-				DP_UOID(dcsr->dcsr_oid),
+			D_ERROR("obj_ec_rw_req_split failed for obj "DF_UOID", DTX "DF_DTI": "
+				DF_RC"\n", DP_UOID(dcsr->dcsr_oid),
 				DP_DTI(&dcsh->dcsh_xid), DP_RC(rc));
 			break;
 		}

--- a/src/object/srv_obj_remote.c
+++ b/src/object/srv_obj_remote.c
@@ -85,7 +85,7 @@ ds_obj_remote_update(struct dtx_leader_handle *dlh, void *data, int idx,
 	struct obj_remote_cb_arg	*remote_arg = NULL;
 	struct obj_rw_in		*orw;
 	struct obj_rw_in		*orw_parent;
-	uint32_t			 tgt_idx;
+	uint32_t			 orig_shard;
 	int				 rc = 0;
 
 	D_ASSERT(idx < dlh->dlh_sub_cnt);
@@ -125,10 +125,10 @@ ds_obj_remote_update(struct dtx_leader_handle *dlh, void *data, int idx,
 	orw = crt_req_get(req);
 	*orw = *orw_parent;
 	if (split_req != NULL) {
-		tgt_idx = shard_tgt->st_shard;
-		tgt_oiod = obj_ec_tgt_oiod_get(split_req->osr_tgt_oiods,
-					       dlh->dlh_sub_cnt + 1,
-					       tgt_idx - obj_exec_arg->start);
+		orig_shard = obj_ec_shard_rotate2orig(&obj_exec_arg->ioc->ioc_oca,
+						      orw->orw_dkey_hash, shard_tgt->st_shard);
+		tgt_oiod = obj_ec_tgt_oiod_get(split_req->osr_tgt_oiods, dlh->dlh_sub_cnt + 1,
+					       orig_shard - obj_exec_arg->start);
 		D_ASSERT(tgt_oiod != NULL);
 		orw->orw_iod_array.oia_oiods = tgt_oiod->oto_oiods;
 		orw->orw_iod_array.oia_oiod_nr = orw->orw_iod_array.oia_iod_nr;

--- a/src/tests/suite/daos_aggregate_ec.c
+++ b/src/tests/suite/daos_aggregate_ec.c
@@ -308,7 +308,6 @@ ec_cleanup_data(struct ec_agg_test_ctx *ctx)
 
 #define NUM_STRIPES 64
 #define NUM_KEYS 3
-//lxz #define NUM_KEYS 1
 
 #define EXTS_PER_STRIPE 4
 static void
@@ -529,7 +528,6 @@ verify_2p(struct ec_agg_test_ctx *ctx, daos_oclass_id_t ec_agg_oc)
 						  false, false, 0);
 			ctx->fetch_iom.iom_flags = DAOS_IOMF_DETAIL;
 			shard++;
-			print_message("lxz will fetch EC obj, shard %d\n", shard);
 			rc = dc_obj_fetch_task_create(ctx->oh, DAOS_TX_NONE, 0,
 						      &ctx->dkey, 1,
 						      DIOF_TO_SPEC_SHARD,
@@ -540,7 +538,6 @@ verify_2p(struct ec_agg_test_ctx *ctx, daos_oclass_id_t ec_agg_oc)
 			assert_rc_equal(rc, 0);
 			rc = dc_task_schedule(task, true);
 			assert_rc_equal(rc, 0);
-			print_message("lxz i %d, j %d, shard %d\n", i, j, shard);
 			/* verify no remaining replicas on parity tgt */
 			assert_int_equal(ctx->fetch_iom.iom_nr_out, 0);
 			task = NULL;

--- a/src/tests/suite/daos_aggregate_ec.c
+++ b/src/tests/suite/daos_aggregate_ec.c
@@ -308,6 +308,7 @@ ec_cleanup_data(struct ec_agg_test_ctx *ctx)
 
 #define NUM_STRIPES 64
 #define NUM_KEYS 3
+//lxz #define NUM_KEYS 1
 
 #define EXTS_PER_STRIPE 4
 static void
@@ -528,6 +529,7 @@ verify_2p(struct ec_agg_test_ctx *ctx, daos_oclass_id_t ec_agg_oc)
 						  false, false, 0);
 			ctx->fetch_iom.iom_flags = DAOS_IOMF_DETAIL;
 			shard++;
+			print_message("lxz will fetch EC obj, shard %d\n", shard);
 			rc = dc_obj_fetch_task_create(ctx->oh, DAOS_TX_NONE, 0,
 						      &ctx->dkey, 1,
 						      DIOF_TO_SPEC_SHARD,
@@ -538,6 +540,7 @@ verify_2p(struct ec_agg_test_ctx *ctx, daos_oclass_id_t ec_agg_oc)
 			assert_rc_equal(rc, 0);
 			rc = dc_task_schedule(task, true);
 			assert_rc_equal(rc, 0);
+			print_message("lxz i %d, j %d, shard %d\n", i, j, shard);
 			/* verify no remaining replicas on parity tgt */
 			assert_int_equal(ctx->fetch_iom.iom_nr_out, 0);
 			task = NULL;


### PR DESCRIPTION
Rotate shard order on different target shard based on dkey hash,
for load balance.
Fixed a bug of peer addressing for multi-groups in EC aggregation.
    
Signed-off-by: Xuezhao Liu <xuezhao.liu@intel.com>