### PR TITLE
DAOS-8640 dfuse: Remove truncated readahead feature

### DIFF
--- a/src/client/dfuse/dfuse.h
+++ b/src/client/dfuse/dfuse.h
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2021 Intel Corporation.
+ * (C) Copyright 2016-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -524,13 +524,6 @@ struct dfuse_inode_entry {
 	 * Used by the hash table callbacks
 	 */
 	ATOMIC uint		ie_ref;
-
-	/** written region for truncated files (i.e. ie_truncated set) */
-	size_t			ie_start_off;
-	size_t			ie_end_off;
-
-	/** file was truncated from 0 to a certain size */
-	bool			ie_truncated;
 
 	/** file is the root of a container */
 	bool			ie_root;

--- a/src/client/dfuse/ops/create.c
+++ b/src/client/dfuse/ops/create.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2021 Intel Corporation.
+ * (C) Copyright 2016-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -188,7 +188,6 @@ dfuse_cb_create(fuse_req_t req, struct dfuse_inode_entry *parent,
 
 	strncpy(ie->ie_name, name, NAME_MAX);
 	ie->ie_parent = parent->ie_stat.st_ino;
-	ie->ie_truncated = false;
 	atomic_store_relaxed(&ie->ie_ref, 1);
 
 	LOG_FLAGS(ie, fi->flags);

--- a/src/client/dfuse/ops/mknod.c
+++ b/src/client/dfuse/ops/mknod.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2020-2021 Intel Corporation.
+ * (C) Copyright 2020-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -36,7 +36,6 @@ dfuse_cb_mknod(fuse_req_t req, struct dfuse_inode_entry *parent, const char *nam
 	strncpy(ie->ie_name, name, NAME_MAX);
 	ie->ie_parent = parent->ie_stat.st_ino;
 	ie->ie_dfs = parent->ie_dfs;
-	ie->ie_truncated = false;
 	atomic_store_relaxed(&ie->ie_ref, 1);
 
 	LOG_MODES(ie, mode);

--- a/src/client/dfuse/ops/read.c
+++ b/src/client/dfuse/ops/read.c
@@ -54,9 +54,11 @@ dfuse_cb_read(fuse_req_t req, fuse_ino_t ino, size_t len, off_t position,
 
 	if (oh->doh_caching && len < (1024 * 1024) && oh->doh_ie->ie_stat.st_size > (1024 * 1024)) {
 		/* Only do readahead if the requested size is less than 1Mb and
-		 * the file size is > 1Mb
+		 * the file size is > 1Mb.
+		 * Do not use readahead if wb_caching is on either.
 		 */
-		buff_len += READAHEAD_SIZE;
+		if (!fs_handle->dpi_info->di_wb_cache)
+			buff_len += READAHEAD_SIZE;
 	} else {
 		rc = daos_event_init(&ev->de_ev, fs_handle->dpi_eq, NULL);
 		if (rc != -DER_SUCCESS)

--- a/src/client/dfuse/ops/setattr.c
+++ b/src/client/dfuse/ops/setattr.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2021 Intel Corporation.
+ * (C) Copyright 2016-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -89,16 +89,6 @@ dfuse_cb_setattr(fuse_req_t req, struct dfuse_inode_entry *ie,
 				attr->st_size);
 		to_set &= ~FUSE_SET_ATTR_SIZE;
 		dfs_flags |= DFS_SET_ATTR_SIZE;
-		if (ie->ie_dfs->dfc_data_caching &&
-		    ie->ie_stat.st_size == 0 && attr->st_size > 0) {
-			DFUSE_TRA_DEBUG(ie, "truncating 0-size file");
-			ie->ie_truncated = true;
-			ie->ie_start_off = 0;
-			ie->ie_end_off = 0;
-			ie->ie_stat.st_size = attr->st_size;
-		} else {
-			ie->ie_truncated = false;
-		}
 	}
 
 	if (to_set) {

--- a/src/client/dfuse/ops/write.c
+++ b/src/client/dfuse/ops/write.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2021 Intel Corporation.
+ * (C) Copyright 2016-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -66,23 +66,6 @@ dfuse_cb_write(fuse_req_t req, fuse_ino_t ino, struct fuse_bufvec *bufv,
 	ev->de_sgl.sg_nr = 1;
 	d_iov_set(&ev->de_iov, ibuf.buf[0].mem, len);
 	ev->de_sgl.sg_iovs = &ev->de_iov;
-
-	/* Check for potentially using readahead on this file, ie_truncated
-	 * will only be set if caching is enabled so only check for the one
-	 * flag rather than two here
-	 */
-	if (oh->doh_ie->ie_truncated) {
-		if (oh->doh_ie->ie_start_off == 0 &&
-		    oh->doh_ie->ie_end_off == 0) {
-			oh->doh_ie->ie_start_off = position;
-			oh->doh_ie->ie_end_off = position + len;
-		} else {
-			if (oh->doh_ie->ie_start_off > position)
-				oh->doh_ie->ie_start_off = position;
-			if (oh->doh_ie->ie_end_off < position + len)
-				oh->doh_ie->ie_end_off = position + len;
-		}
-	}
 
 	if (len + position > oh->doh_ie->ie_stat.st_size)
 		oh->doh_ie->ie_stat.st_size = len + position;

--- a/src/tests/ftest/erasurecode/rebuild_fio.py
+++ b/src/tests/ftest/erasurecode/rebuild_fio.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 '''
-  (C) Copyright 2019-2021 Intel Corporation.
+  (C) Copyright 2019-2022 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
@@ -83,7 +83,6 @@ class EcodFioRebuild(ErasureCodeFio):
         """
         self.execution('on-line')
 
-    @skipForTicket("DAOS-8640")
     def test_ec_offline_rebuild_fio(self):
         """Jira ID: DAOS-7320.
 


### PR DESCRIPTION
Test-tag: ec_offline_rebuild_fio

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>
