### PR TITLE
DAOS-9635 object: multiple shards enumeration fix

### DIFF
--- a/src/object/obj_internal.h
+++ b/src/object/obj_internal.h
@@ -370,6 +370,22 @@ struct shard_punch_args {
 	uint32_t		 pa_opc;
 };
 
+struct shard_sub_anchor {
+	daos_anchor_t	ssa_anchor;
+	daos_anchor_t	*ssa_dkey_anchor;
+	daos_anchor_t	*ssa_akey_anchor;
+	d_sg_list_t	ssa_sgl;
+	daos_key_desc_t	*ssa_kds;
+	daos_recx_t	*ssa_recxs;
+};
+
+struct shard_anchors {
+	d_list_t		sa_merged_list;
+	int			sa_nr;
+	int			sa_anchors_nr;
+	struct shard_sub_anchor	sa_anchors[0];
+};
+
 struct shard_list_args {
 	struct shard_auxi_args	 la_auxi;
 	daos_obj_list_t		*la_api_args;
@@ -391,6 +407,7 @@ struct obj_auxi_list_recx {
 
 struct obj_auxi_list_key {
 	d_iov_t		key;
+	uint64_t	hkey;
 	d_list_t	key_list;
 };
 

--- a/src/object/srv_obj_migrate.c
+++ b/src/object/srv_obj_migrate.c
@@ -2422,11 +2422,11 @@ migrate_one_epoch_object(daos_epoch_range_t *epr, struct migrate_pool_tls *tls,
 		if (p_csum != NULL)
 			p_csum->iov_len = 0;
 
-		num = KDS_NUM;
 		daos_anchor_set_flags(&dkey_anchor,
 				      DIOF_TO_LEADER | DIOF_WITH_SPEC_EPOCH |
 				      DIOF_TO_SPEC_GROUP | DIOF_FOR_MIGRATION);
 retry:
+		num = KDS_NUM;
 		rc = dsc_obj_list_obj(oh, epr, NULL, NULL, NULL,
 				     &num, kds, &sgl, &anchor,
 				     &dkey_anchor, &akey_anchor, p_csum);


### PR DESCRIPTION
The patch fix the enumeration from multiple data shards,
for example degrade enumeration, or parity rotation,

1. Each shard will prepare KDS/SGL/RECX buffer invidually,
and attached to the anchor.

2. After each shard get the enumeration buffer, it
needs to sort these dkey/recxs from all shards altogether
by its order inside the VOS, so to avoid duplicate/missing
keys for enumeration.

3. Then these merged/sorted keys/recxs are dumped to
the user kds/sgl/recx, and the leftover will be left in
the merged list, which will be retrieved in the following
enumeration.

Signed-off-by: Di Wang <di.wang@intel.com>