### PR TITLE
DAOS-9668 EC: fix segfault when punch EC full-stripe

### DIFF
--- a/src/object/cli_ec.c
+++ b/src/object/cli_ec.c
@@ -573,6 +573,8 @@ obj_ec_recx_encode(struct obj_ec_codec *codec, struct daos_oclass_attr *oca,
 
 	if (recx_array->oer_stripe_total == 0)
 		D_GOTO(out, rc = 0);
+	if (iod->iod_size == DAOS_REC_ANY) /* punch case */
+		D_GOTO(out, rc = 0);
 	singv = (iod->iod_type == DAOS_IOD_SINGLE);
 	if (singv) {
 		cell_bytes = obj_ec_singv_cell_bytes(iod->iod_size, oca);
@@ -1572,6 +1574,9 @@ obj_ec_encode(struct obj_reasb_req *reasb_req)
 	struct obj_ec_codec *codec;
 	uint32_t	i;
 	int		rc;
+
+	if (reasb_req->orr_usgls == NULL) /* punch case */
+		return 0;
 
 	codec = codec_get(reasb_req, reasb_req->orr_oid);
 	if (codec == NULL) {

--- a/src/tests/suite/daos_obj.c
+++ b/src/tests/suite/daos_obj.c
@@ -1747,6 +1747,8 @@ punch_simple_internal(void **state, daos_obj_id_t oid)
 			dkeys[0], num_rec_exts);
 	punch_rec_with_rxnr(dkeys[0], "akey1", /*idx*/0, num_rec_exts,
 			    DAOS_TX_NONE, &req);
+	/* punch non-exist long ext (full-stripe for EC) */
+	punch_rec_with_rxnr(dkeys[0], "akey1", 1 << 20, 1 << 20, DAOS_TX_NONE, &req);
 
 
 	/**


### PR DESCRIPTION
Need not encode for punch case.

Signed-off-by: Xuezhao Liu <xuezhao.liu@intel.com>