### PR TITLE
DAOS-9305 control: Fix group update handler

### DIFF
--- a/src/control/server/mgmt_pool_test.go
+++ b/src/control/server/mgmt_pool_test.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/daos-stack/daos/src/control/build"
 	"github.com/daos-stack/daos/src/control/common"
-	"github.com/daos-stack/daos/src/control/common/proto/mgmt"
 	mgmtpb "github.com/daos-stack/daos/src/control/common/proto/mgmt"
 	"github.com/daos-stack/daos/src/control/drpc"
 	"github.com/daos-stack/daos/src/control/events"
@@ -381,7 +380,7 @@ func TestServer_MgmtSvc_PoolCreate(t *testing.T) {
 		"svc replicas > max": {
 			targetCount: 1,
 			memberCount: MaxPoolServiceReps + 2,
-			req: &mgmt.PoolCreateReq{
+			req: &mgmtpb.PoolCreateReq{
 				Uuid:       common.MockUUID(0),
 				Totalbytes: 100 * humanize.GByte,
 				Tierratio:  []float64{0.06, 0.94},
@@ -393,7 +392,7 @@ func TestServer_MgmtSvc_PoolCreate(t *testing.T) {
 		"svc replicas > numRanks": {
 			targetCount: 1,
 			memberCount: MaxPoolServiceReps - 2,
-			req: &mgmt.PoolCreateReq{
+			req: &mgmtpb.PoolCreateReq{
 				Uuid:       common.MockUUID(0),
 				Totalbytes: 100 * humanize.GByte,
 				Tierratio:  []float64{0.06, 0.94},
@@ -1764,7 +1763,7 @@ func TestServer_MgmtSvc_PoolSetProp(t *testing.T) {
 		"garbage resp": {
 			req: &mgmtpb.PoolSetPropReq{
 				Id: mockUUID,
-				Properties: []*mgmt.PoolProperty{
+				Properties: []*mgmtpb.PoolProperty{
 					{
 						Number: drpc.PoolPropertyLabel,
 						Value:  &mgmtpb.PoolProperty_Strval{"0"},
@@ -1786,7 +1785,7 @@ func TestServer_MgmtSvc_PoolSetProp(t *testing.T) {
 		"label is not unique": {
 			req: &mgmtpb.PoolSetPropReq{
 				Id: common.MockUUID(3),
-				Properties: []*mgmt.PoolProperty{
+				Properties: []*mgmtpb.PoolProperty{
 					{
 						Number: drpc.PoolPropertyLabel,
 						Value:  &mgmtpb.PoolProperty_Strval{"0"},
@@ -1804,7 +1803,7 @@ func TestServer_MgmtSvc_PoolSetProp(t *testing.T) {
 		"label set is idempotent": {
 			req: &mgmtpb.PoolSetPropReq{
 				Id: mockUUID,
-				Properties: []*mgmt.PoolProperty{
+				Properties: []*mgmtpb.PoolProperty{
 					{
 						Number: drpc.PoolPropertyLabel,
 						Value:  &mgmtpb.PoolProperty_Strval{"0"},
@@ -1815,7 +1814,7 @@ func TestServer_MgmtSvc_PoolSetProp(t *testing.T) {
 				Sys:      build.DefaultSystemName,
 				SvcRanks: []uint32{0},
 				Id:       mockUUID,
-				Properties: []*mgmt.PoolProperty{
+				Properties: []*mgmtpb.PoolProperty{
 					{
 						Number: drpc.PoolPropertyLabel,
 						Value:  &mgmtpb.PoolProperty_Strval{"0"},
@@ -1826,7 +1825,7 @@ func TestServer_MgmtSvc_PoolSetProp(t *testing.T) {
 		"success": {
 			req: &mgmtpb.PoolSetPropReq{
 				Id: mockUUID,
-				Properties: []*mgmt.PoolProperty{
+				Properties: []*mgmtpb.PoolProperty{
 					{
 						Number: drpc.PoolPropertyLabel,
 						Value:  &mgmtpb.PoolProperty_Strval{"ok"},
@@ -1842,7 +1841,7 @@ func TestServer_MgmtSvc_PoolSetProp(t *testing.T) {
 				Sys:      build.DefaultSystemName,
 				SvcRanks: []uint32{0},
 				Id:       mockUUID,
-				Properties: []*mgmt.PoolProperty{
+				Properties: []*mgmtpb.PoolProperty{
 					{
 						Number: drpc.PoolPropertySpaceReclaim,
 						Value:  &mgmtpb.PoolProperty_Numval{drpc.PoolSpaceReclaimDisabled},
@@ -1902,7 +1901,7 @@ func TestServer_MgmtSvc_PoolGetProp(t *testing.T) {
 		"garbage resp": {
 			req: &mgmtpb.PoolGetPropReq{
 				Id: mockUUID,
-				Properties: []*mgmt.PoolProperty{
+				Properties: []*mgmtpb.PoolProperty{
 					{
 						Number: drpc.PoolPropertyLabel,
 					},
@@ -1923,7 +1922,7 @@ func TestServer_MgmtSvc_PoolGetProp(t *testing.T) {
 		"success": {
 			req: &mgmtpb.PoolGetPropReq{
 				Id: mockUUID,
-				Properties: []*mgmt.PoolProperty{
+				Properties: []*mgmtpb.PoolProperty{
 					{
 						Number: drpc.PoolPropertyLabel,
 					},

--- a/src/control/server/mgmt_system.go
+++ b/src/control/server/mgmt_system.go
@@ -181,8 +181,8 @@ func (svc *mgmtSvc) joinLoop(parent context.Context) {
 					svc.log.Errorf("sync GroupUpdate failed: %s", err)
 					continue
 				}
+				groupUpdateNeeded = false
 			}
-			groupUpdateNeeded = false
 		case <-groupUpdateTimer.C:
 			if !groupUpdateNeeded {
 				continue

--- a/src/control/server/mgmt_system.go
+++ b/src/control/server/mgmt_system.go
@@ -395,7 +395,7 @@ func (svc *mgmtSvc) Join(ctx context.Context, req *mgmtpb.JoinReq) (*mgmtpb.Join
 	if err := svc.checkLeaderRequest(req); err != nil {
 		return nil, err
 	}
-	svc.log.Debugf("MgmtSvc.Join dispatch, req:%#v\n", req)
+	svc.log.Debugf("MgmtSvc.Join dispatch, req:%s", mgmtpb.Debug(req))
 
 	replyAddr, err := getPeerListenAddr(ctx, req.GetAddr())
 	if err != nil {
@@ -426,7 +426,7 @@ func (svc *mgmtSvc) Join(ctx context.Context, req *mgmtpb.JoinReq) (*mgmtpb.Join
 		resp = &r.JoinResp
 	}
 
-	svc.log.Debugf("MgmtSvc.Join dispatch, resp:%#v\n", resp)
+	svc.log.Debugf("MgmtSvc.Join dispatch, resp:%s", mgmtpb.Debug(resp))
 
 	return resp, nil
 }
@@ -520,7 +520,7 @@ func (svc *mgmtSvc) rpcFanout(ctx context.Context, req *fanoutRequest, resp *fan
 	// Not strictly necessary but helps with debugging.
 	dl, ok := ctx.Deadline()
 	if ok {
-		ranksReq.SetTimeout(dl.Sub(time.Now()))
+		ranksReq.SetTimeout(time.Until(dl))
 	}
 
 	ranksReq.SetHostList(svc.membership.HostList(req.Ranks))

--- a/src/control/server/mgmt_system_test.go
+++ b/src/control/server/mgmt_system_test.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"net"
 	"sort"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -19,6 +20,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/pkg/errors"
 	"google.golang.org/grpc/peer"
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/testing/protocmp"
 
 	"github.com/daos-stack/daos/src/control/build"
@@ -221,6 +223,29 @@ func stateString(s system.MemberState) string {
 func TestServer_MgmtSvc_LeaderQuery(t *testing.T) {
 	localhost := common.LocalhostCtrlAddr()
 
+	// Set up one instance of the test DB, as this takes
+	// a while, and the table tests don't change the DB
+	// so there's no need to have a clean slate for each test.
+	dbLog, dbBuf := logging.NewTestLogger(t.Name())
+	defer common.ShowBufferOnFailure(t, dbBuf)
+
+	db, cleanup := system.TestDatabase(t, dbLog)
+	defer cleanup()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err := db.Start(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	// wait for the bootstrap to finish
+	for {
+		if leader, _, _ := db.LeaderQuery(); leader != "" {
+			break
+		}
+		time.Sleep(250 * time.Millisecond)
+	}
+
 	for name, tc := range map[string]struct {
 		req     *mgmtpb.LeaderQueryReq
 		expResp *mgmtpb.LeaderQueryResp
@@ -248,23 +273,7 @@ func TestServer_MgmtSvc_LeaderQuery(t *testing.T) {
 			defer common.ShowBufferOnFailure(t, buf)
 
 			svc := newTestMgmtSvc(t, log)
-			db, cleanup := system.TestDatabase(t, log)
-			defer cleanup()
 			svc.sysdb = db
-
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
-			if err := db.Start(ctx); err != nil {
-				t.Fatal(err)
-			}
-
-			// wait for the bootstrap to finish
-			for {
-				if leader, _, _ := db.LeaderQuery(); leader != "" {
-					break
-				}
-				time.Sleep(250 * time.Millisecond)
-			}
 
 			gotResp, gotErr := svc.LeaderQuery(context.TODO(), tc.req)
 			common.CmpErr(t, tc.expErr, gotErr)
@@ -439,7 +448,19 @@ func mockMember(t *testing.T, r, a int32, s string) *system.Member {
 		t.Fatalf("testcase specifies unknown member state %s", s)
 	}
 
-	return system.NewMember(system.Rank(r), common.MockUUID(r), "", common.MockHostAddr(a), state)
+	addr := common.MockHostAddr(a)
+	fd, err := system.NewFaultDomain(addr.String(), strconv.Itoa(int(r)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	uri := fmt.Sprintf("tcp://%s", addr)
+
+	m := system.NewMember(system.Rank(r), common.MockUUID(r), uri, addr, state).WithFaultDomain(fd)
+	m.FabricContexts = uint32(r)
+	m.FaultDomain = fd
+	m.Incarnation = uint64(r)
+
+	return m
 }
 
 func checkMembers(t *testing.T, exp system.Members, ms *system.Membership) {
@@ -488,7 +509,7 @@ func mgmtSystemTestSetup(t *testing.T, l logging.Logger, mbs system.Members, r .
 	svc := newTestMgmtSvcMulti(t, l, maxEngines, false)
 	svc.harness.started.SetTrue()
 	svc.harness.instances[0].(*EngineInstance)._superblock.Rank = system.NewRankPtr(0)
-	svc.membership, _ = system.MockMembership(t, l, mockResolver)
+	svc.membership, svc.sysdb = system.MockMembership(t, l, mockResolver)
 	for _, m := range mbs {
 		if _, err := svc.membership.Add(m); err != nil {
 			t.Fatal(err)
@@ -1599,6 +1620,185 @@ func TestServer_MgmtSvc_SystemErase(t *testing.T) {
 			}
 			common.AssertEqual(t, tc.expResults, gotResp.Results, name)
 			checkMembers(t, tc.expMembers, svc.membership)
+		})
+	}
+}
+
+func TestServer_MgmtSvc_Join(t *testing.T) {
+	curMember := mockMember(t, 0, 0, "excluded")
+	newMember := mockMember(t, 1, 1, "joined")
+
+	for name, tc := range map[string]struct {
+		req      *mgmtpb.JoinReq
+		guResp   *mgmtpb.GroupUpdateResp
+		expGuReq *mgmtpb.GroupUpdateReq
+		expResp  *mgmtpb.JoinResp
+		expErr   error
+	}{
+		"bad sys": {
+			req: &mgmtpb.JoinReq{
+				Sys: "bad sys",
+			},
+			expErr: errors.New("bad sys"),
+		},
+		"bad uuid": {
+			req: &mgmtpb.JoinReq{
+				Uuid: "bad uuid",
+			},
+			expErr: errors.New("bad uuid"),
+		},
+		"bad fault domain": {
+			req: &mgmtpb.JoinReq{
+				SrvFaultDomain: "bad fault domain",
+			},
+			expErr: errors.New("bad fault domain"),
+		},
+		"dupe host same rank diff uuid": {
+			req: &mgmtpb.JoinReq{
+				Rank: curMember.Rank.Uint32(),
+				Uuid: common.MockUUID(5),
+			},
+			expErr: errors.New("uuid changed"),
+		},
+		"dupe host diff rank same uuid": {
+			req: &mgmtpb.JoinReq{
+				Rank: 22,
+				Uuid: curMember.UUID.String(),
+			},
+			expErr: errors.New("already exists"),
+		},
+		"rejoining host": {
+			req: &mgmtpb.JoinReq{
+				Rank: curMember.Rank.Uint32(),
+				Uuid: curMember.UUID.String(),
+			},
+			expGuReq: &mgmtpb.GroupUpdateReq{
+				MapVersion: 2,
+				Engines: []*mgmtpb.GroupUpdateReq_Engine{
+					{
+						Rank: curMember.Rank.Uint32(),
+						Uri:  curMember.FabricURI,
+					},
+				},
+			},
+			expResp: &mgmtpb.JoinResp{
+				Status: 0,
+				Rank:   curMember.Rank.Uint32(),
+				State:  mgmtpb.JoinResp_IN,
+			},
+		},
+		"new host (non local)": {
+			req: &mgmtpb.JoinReq{
+				Rank: uint32(system.NilRank),
+			},
+			expGuReq: &mgmtpb.GroupUpdateReq{
+				MapVersion: 2,
+				Engines: []*mgmtpb.GroupUpdateReq_Engine{
+					// rank 0 is excluded, so shouldn't be in the map
+					{
+						Rank: newMember.Rank.Uint32(),
+						Uri:  newMember.FabricURI,
+					},
+				},
+			},
+			expResp: &mgmtpb.JoinResp{
+				Status:    0,
+				Rank:      newMember.Rank.Uint32(),
+				State:     mgmtpb.JoinResp_IN,
+				LocalJoin: false,
+			},
+		},
+		"new host (local)": {
+			req: &mgmtpb.JoinReq{
+				Addr: common.LocalhostCtrlAddr().String(),
+				Uri:  "tcp://" + common.LocalhostCtrlAddr().String(),
+				Rank: uint32(system.NilRank),
+			},
+			expGuReq: &mgmtpb.GroupUpdateReq{
+				MapVersion: 2,
+				Engines: []*mgmtpb.GroupUpdateReq_Engine{
+					// rank 0 is excluded, so shouldn't be in the map
+					{
+						Rank: newMember.Rank.Uint32(),
+						Uri:  "tcp://" + common.LocalhostCtrlAddr().String(),
+					},
+				},
+			},
+			expResp: &mgmtpb.JoinResp{
+				Status:    0,
+				Rank:      newMember.Rank.Uint32(),
+				State:     mgmtpb.JoinResp_IN,
+				LocalJoin: true,
+			},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			log, buf := logging.NewTestLogger(t.Name())
+			defer common.ShowBufferOnFailure(t, buf)
+
+			// Make a copy to avoid test side-effects.
+			curCopy := &system.Member{}
+			*curCopy = *curMember
+			curCopy.Rank = system.NilRank // ensure that db.data.NextRank is incremented
+
+			svc := mgmtSystemTestSetup(t, log, system.Members{curCopy}, nil)
+
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			svc.startJoinLoop(ctx)
+
+			if tc.req.Sys == "" {
+				tc.req.Sys = build.DefaultSystemName
+			}
+			if tc.req.Uuid == "" {
+				tc.req.Uuid = newMember.UUID.String()
+			}
+			if tc.req.Addr == "" {
+				tc.req.Addr = newMember.Addr.String()
+			}
+			if tc.req.Uri == "" {
+				tc.req.Uri = newMember.FabricURI
+			}
+			if tc.req.SrvFaultDomain == "" {
+				tc.req.SrvFaultDomain = newMember.FaultDomain.String()
+			}
+			if tc.req.Nctxs == 0 {
+				tc.req.Nctxs = newMember.FabricContexts
+			}
+			if tc.req.Incarnation == 0 {
+				tc.req.Incarnation = newMember.Incarnation
+			}
+			peerAddr, err := net.ResolveTCPAddr("tcp", tc.req.Addr)
+			if err != nil {
+				t.Fatal(err)
+			}
+			peerCtx := peer.NewContext(ctx, &peer.Peer{Addr: peerAddr})
+
+			setupMockDrpcClient(svc, tc.guResp, nil)
+			ei := svc.harness.instances[0].(*EngineInstance)
+			mdc := ei._drpcClient.(*mockDrpcClient)
+
+			gotResp, gotErr := svc.Join(peerCtx, tc.req)
+			common.CmpErr(t, tc.expErr, gotErr)
+			if tc.expErr != nil {
+				return
+			}
+
+			gotGuReq := new(mgmtpb.GroupUpdateReq)
+			if err := proto.Unmarshal(mdc.calls[len(mdc.calls)-1].Body, gotGuReq); err != nil {
+				t.Fatal(err)
+			}
+			cmpOpts := cmp.Options{
+				protocmp.Transform(),
+				protocmp.SortRepeatedFields(&mgmtpb.GroupUpdateReq{}, "engines"),
+			}
+			if diff := cmp.Diff(tc.expGuReq, gotGuReq, cmpOpts...); diff != "" {
+				t.Fatalf("unexpected GroupUpdate request (-want, +got):\n%s", diff)
+			}
+
+			if diff := cmp.Diff(tc.expResp, gotResp, protocmp.Transform()); diff != "" {
+				t.Fatalf("unexpected response (-want, +got)\n%s\n", diff)
+			}
 		})
 	}
 }

--- a/src/control/system/mocks.go
+++ b/src/control/system/mocks.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/hashicorp/raft"
 
-	"github.com/daos-stack/daos/src/control/build"
 	"github.com/daos-stack/daos/src/control/common"
 	"github.com/daos-stack/daos/src/control/logging"
 )
@@ -158,11 +157,7 @@ func MockDatabaseWithAddr(t *testing.T, log logging.Logger, addr *net.TCPAddr) *
 // database that does not support raft replication and does all
 // operations in memory.
 func MockDatabase(t *testing.T, log logging.Logger) *Database {
-	localhost := &net.TCPAddr{
-		IP:   net.IPv4(127, 0, 0, 1),
-		Port: build.DefaultControlPort,
-	}
-	return MockDatabaseWithAddr(t, log, localhost)
+	return MockDatabaseWithAddr(t, log, common.LocalhostCtrlAddr())
 }
 
 // TestDatabase returns a database that is backed by temporary storage

--- a/src/gurt/misc.c
+++ b/src/gurt/misc.c
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2016-2021 Intel Corporation.
+ * (C) Copyright 2016-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -190,7 +190,7 @@ d_rank_list_filter(d_rank_list_t *src_set, d_rank_list_t *dst_set,
 
 	if (src_set == NULL || dst_set == NULL)
 		return;
-	if (src_set->rl_ranks == NULL || dst_set->rl_ranks == NULL)
+	if (dst_set->rl_ranks == NULL)
 		return;
 
 	rank_num = dst_set->rl_nr;
@@ -450,7 +450,7 @@ d_rank_in_rank_list(d_rank_list_t *rank_list, d_rank_t rank)
 {
 	uint32_t	rank_num, i;
 
-	if (rank_list == NULL)
+	if (rank_list == NULL || rank_list->rl_ranks == NULL)
 		return false;
 
 	rank_num = rank_list->rl_nr;

--- a/src/include/gurt/common.h
+++ b/src/include/gurt/common.h
@@ -394,6 +394,7 @@ d_rank_list_t *d_rank_list_alloc(uint32_t size);
 d_rank_list_t *d_rank_list_realloc(d_rank_list_t *ptr, uint32_t size);
 void d_rank_list_free(d_rank_list_t *rank_list);
 int d_rank_list_copy(d_rank_list_t *dst, d_rank_list_t *src);
+int d_rank_list_to_str(d_rank_list_t *rank_list, struct d_string_buffer_t *buf);
 void d_rank_list_shuffle(d_rank_list_t *rank_list);
 void d_rank_list_sort(d_rank_list_t *rank_list);
 bool d_rank_list_find(d_rank_list_t *rank_list, d_rank_t rank, int *idx);

--- a/src/mgmt/srv_pool.c
+++ b/src/mgmt/srv_pool.c
@@ -167,7 +167,7 @@ ds_mgmt_create_pool(uuid_t pool_uuid, const char *group, char *tgt_dev,
 		    daos_prop_t *prop, uint32_t svc_nr, d_rank_list_t **svcp,
 		    int domains_nr, uint32_t *domains)
 {
-	d_rank_list_t			*oog_ranks = NULL;
+	d_rank_list_t			*filtered_targets = NULL;
 	d_rank_list_t			*pg_ranks = NULL;
 	uint32_t			pg_size;
 	int				rc;
@@ -184,28 +184,37 @@ ds_mgmt_create_pool(uuid_t pool_uuid, const char *group, char *tgt_dev,
 		D_GOTO(out, rc);
 	}
 
-	struct d_string_buffer_t pg_buf = {0};
-	d_rank_list_to_str(pg_ranks, &pg_buf);
-	D_ERROR(DF_UUID": pg_ranks: %s\n", DP_UUID(pool_uuid), pg_buf.str);
-	d_free_string(&pg_buf);
-
-	rc = d_rank_list_dup(&oog_ranks, targets);
+	rc = d_rank_list_dup(&filtered_targets, targets);
 	if (rc) {
 		rc = -DER_NOMEM;
 		D_GOTO(out, rc);
 	}
-	/* Find any targets not included in pg_ranks */
-	d_rank_list_filter(pg_ranks, oog_ranks, true /* exclude */);
-	if (oog_ranks->rl_nr > 0) {
+	/* Remove any targets not found in pg_ranks */
+	d_rank_list_filter(pg_ranks, filtered_targets, false /* exclude */);
+	if (!d_rank_list_identical(filtered_targets, targets)) {
+		struct d_string_buffer_t pg_buf = {0};
 		struct d_string_buffer_t tgt_buf = {0};
 
-		rc = d_rank_list_to_str(oog_ranks, &tgt_buf);
+		/* find missing targets for error message */
+		d_rank_list_free(filtered_targets);
+		rc = d_rank_list_dup(&filtered_targets, targets);
+		if (rc) {
+			rc = -DER_NOMEM;
+			D_GOTO(out, rc);
+		}
+		d_rank_list_filter(pg_ranks, filtered_targets, true);
+
+		rc = d_rank_list_to_str(pg_ranks, &pg_buf);
+		if (rc != 0)
+			D_GOTO(out, rc);
+		rc = d_rank_list_to_str(filtered_targets, &tgt_buf);
 		if (rc != 0)
 			D_GOTO(out, rc);
 
-		D_ERROR(DF_UUID": targets not in cart primary group: %s\n",
-			DP_UUID(pool_uuid), tgt_buf.str);
+		D_ERROR(DF_UUID": targets not in cart primary group (%s): %s\n",
+			DP_UUID(pool_uuid), pg_buf.str, tgt_buf.str);
 
+		d_free_string(&pg_buf);
 		d_free_string(&tgt_buf);
 		D_GOTO(out, rc = -DER_OOG);
 	}
@@ -245,7 +254,7 @@ out_svcp:
 				DF_RC"\n", DP_UUID(pool_uuid), DP_RC(rc));
 	}
 out:
-	d_rank_list_free(oog_ranks);
+	d_rank_list_free(filtered_targets);
 	d_rank_list_free(pg_ranks);
 	D_DEBUG(DB_MGMT, "create pool "DF_UUID": "DF_RC"\n", DP_UUID(pool_uuid),
 		DP_RC(rc));

--- a/src/mgmt/srv_pool.c
+++ b/src/mgmt/srv_pool.c
@@ -183,6 +183,12 @@ ds_mgmt_create_pool(uuid_t pool_uuid, const char *group, char *tgt_dev,
 		rc = -DER_NOMEM;
 		D_GOTO(out, rc);
 	}
+
+	struct d_string_buffer_t pg_buf = {0};
+	d_rank_list_to_str(pg_ranks, &pg_buf);
+	D_ERROR(DF_UUID": pg_ranks: %s\n", DP_UUID(pool_uuid), pg_buf.str);
+	d_free_string(&pg_buf);
+
 	rc = d_rank_list_dup(&filtered_targets, targets);
 	if (rc) {
 		rc = -DER_NOMEM;

--- a/src/mgmt/srv_pool.c
+++ b/src/mgmt/srv_pool.c
@@ -191,7 +191,16 @@ ds_mgmt_create_pool(uuid_t pool_uuid, const char *group, char *tgt_dev,
 	/* Remove any targets not found in pg_ranks */
 	d_rank_list_filter(pg_ranks, filtered_targets, false /* exclude */);
 	if (!d_rank_list_identical(filtered_targets, targets)) {
-		D_ERROR("some ranks not found in cart primary group\n");
+		struct d_string_buffer_t tgt_buf = {0};
+
+		rc = d_rank_list_to_str(filtered_targets, &tgt_buf);
+		if (rc != 0)
+			D_GOTO(out, rc);
+
+		D_ERROR(DF_UUID": targets not in cart primary group: %s\n",
+			DP_UUID(pool_uuid), tgt_buf.str);
+
+		d_free_string(&tgt_buf);
 		D_GOTO(out, rc = -DER_OOG);
 	}
 

--- a/src/mgmt/srv_util.c
+++ b/src/mgmt/srv_util.c
@@ -56,6 +56,11 @@ ds_mgmt_group_update(crt_group_mod_op_t op, struct server_entry *servers,
 		D_ERROR("failed to update group (op=%d version=%u): %d\n",
 			op, version, rc);
 
+	struct d_string_buffer_t buf = {0};
+	d_rank_list_to_str(ranks, &buf);
+	D_DEBUG(DB_MGMT, "version %u ranks: %s\n", version, buf.str);
+	d_free_string(&buf);
+
 out:
 	if (uris != NULL)
 		D_FREE(uris);

--- a/src/mgmt/srv_util.c
+++ b/src/mgmt/srv_util.c
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2019-2021 Intel Corporation.
+ * (C) Copyright 2019-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -22,6 +22,7 @@ ds_mgmt_group_update(crt_group_mod_op_t op, struct server_entry *servers,
 	uint32_t		version_current;
 	d_rank_list_t	       *ranks = NULL;
 	char		      **uris = NULL;
+	struct d_string_buffer_t ranks_buf = {0};
 	int			i;
 	int			rc;
 
@@ -56,10 +57,9 @@ ds_mgmt_group_update(crt_group_mod_op_t op, struct server_entry *servers,
 		D_ERROR("failed to update group (op=%d version=%u): %d\n",
 			op, version, rc);
 
-	struct d_string_buffer_t buf = {0};
-	d_rank_list_to_str(ranks, &buf);
-	D_DEBUG(DB_MGMT, "version %u ranks: %s\n", version, buf.str);
-	d_free_string(&buf);
+	if (d_rank_list_to_str(ranks, &ranks_buf) == 0)
+		D_DEBUG(DB_MGMT, "version %u ranks: %s\n", version, ranks_buf.str);
+	d_free_string(&ranks_buf);
 
 out:
 	if (uris != NULL)


### PR DESCRIPTION
Fix a subtle bug in the group update handler. Group update
should only be canceled in the handler if the request was
synchronous and successful.

Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com>
