### PR TITLE
DAOS-9561 dtx: warning message if dead loop for DTX refresh

### DIFF
--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -1689,6 +1689,7 @@ obj_local_rw(crt_rpc_t *rpc, struct obj_io_context *ioc,
 	     uint64_t *split_offs, struct dtx_handle *dth, bool pin)
 {
 	int	rc;
+	int	count = 0;
 
 again:
 	if (pin) {
@@ -1711,6 +1712,16 @@ again:
 			rc1 = vos_dtx_attach(dth, false);
 			if (rc1 != 0)
 				return -DER_INPROGRESS;
+		}
+
+		if (unlikely(++count % 10 == 3)) {
+			struct dtx_share_peer	*dsp;
+
+			dsp = d_list_entry(dth->dth_share_tbd_list.next, struct dtx_share_peer,
+					   dsp_link);
+			D_WARN("DTX refresh for "DF_DTI" because of "DF_DTI" (%d) for %d times, "
+			       "maybe dead loop\n", DP_DTI(&dth->dth_xid), DP_DTI(&dsp->dsp_xid),
+			       dth->dth_share_tbd_count, count);
 		}
 
 		rc = dtx_refresh(dth, ioc->ioc_coc);


### PR DESCRIPTION
Under some bad case, if the IO handler ULT fall into dead loop
for refresh some DTX, then print some warning message in log.

Signed-off-by: Fan Yong <fan.yong@intel.com>