### PR TITLE
DAOS-9376 ofi: update to 1.14.0 and apply workaround (#7904)

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+daos (2.0.0-6) unstable; urgency=medium
+  [ Johann Lombardi ]
+  * Update libfabric to 1.14.0 GA and apply fix for DAOS-9376
+
+ -- Johann Lombardi <johann.lombardi@intel.com>  Wed, 19 Jan 2022 10:00:00 -0100
+
 daos (2.0.0-4) unstable; urgency=medium
   [ Alexander Oganezov ]
   * Update mercury to v2.1.0~rc4-3 to pick a fix for DAOS-9325 high cpu usage

--- a/debian/control
+++ b/debian/control
@@ -5,7 +5,7 @@ Maintainer: daos-stack <daos@daos.groups.io>
 Build-Depends: debhelper (>= 10),
                dh-python,
                libcmocka-dev,
-               libfabric-dev (>= 1.14.0~rc3-2),
+               libfabric-dev (>= 1.14.0-1),
                libhwloc-dev,
                libopenmpi-dev,
                libssl-dev,
@@ -147,7 +147,7 @@ Package: daos-client
 Section: net
 Architecture: any
 Multi-Arch: same
-Depends: ${shlibs:Depends}, ${misc:Depends}, openmpi-bin, libfabric (>= 1.14.0~rc3-2)
+Depends: ${shlibs:Depends}, ${misc:Depends}, openmpi-bin, libfabric (>= 1.14.0-1)
 Description: The Distributed Asynchronous Object Storage (DAOS) is an open-source
  software-defined object store designed from the ground up for
  massively distributed Non Volatile Memory (NVM). DAOS takes advantage
@@ -166,7 +166,7 @@ Section: net
 Architecture: any
 Multi-Arch: same
 Depends: ${shlibs:Depends}, ${misc:Depends}, openmpi-bin,
-         ipmctl (>02.00.00.3816), libfabric (>= 1.14.0~rc3-2)
+         ipmctl (>02.00.00.3816), libfabric (>= 1.14.0-1)
 Description: The Distributed Asynchronous Object Storage (DAOS) is an open-source
  software-defined object store designed from the ground up for
  massively distributed Non Volatile Memory (NVM). DAOS takes advantage

--- a/utils/build.config
+++ b/utils/build.config
@@ -7,7 +7,7 @@ PMDK = 1.11.0
 ISAL = v2.30.0
 ISAL_CRYPTO = v2.23.0
 SPDK = v21.07
-OFI = v1.14.0rc3
+OFI = v1.14.0
 OPENPA = v1.0.4
 MERCURY = v2.1.0rc4
 PSM2 = PSM2_11.2.78
@@ -16,5 +16,5 @@ PROTOBUFC = v1.3.3
 [patch_versions]
 spdk=https://github.com/spdk/spdk/commit/690783a3ae82ebe58c00d643520a66103d66d540.diff,https://github.com/spdk/spdk/commit/65425be69a0882ac283fb489aa151d7df06c52ad.diff,https://raw.githubusercontent.com/daos-stack/spdk/master/0003-blob-chunk-clear-operations-in-IU-aligned-chunks.patch,https://github.com/spdk/spdk/commit/086223c029389329b7a4f38ec0f9a30be83849bf.diff
 pmdk=https://raw.githubusercontent.com/daos-stack/pmdk/master/DAOS_8273.patch
-ofi=https://raw.githubusercontent.com/daos-stack/libfabric/master/daos-9173-ofi.patch
+ofi=https://raw.githubusercontent.com/daos-stack/libfabric/master/daos-9173-ofi.patch,https://raw.githubusercontent.com/daos-stack/libfabric/master/daos-9376-ofi.patch
 mercury=https://raw.githubusercontent.com/daos-stack/mercury/master/cpu_usage.patch

--- a/utils/rpms/daos.spec
+++ b/utils/rpms/daos.spec
@@ -3,7 +3,7 @@
 %define agent_svc_name daos_agent.service
 
 %global mercury_version 2.1.0~rc4-3%{?dist}
-%global libfabric_version 1.14.0~rc3-2
+%global libfabric_version 1.14.0-1
 %global __python %{__python3}
 
 %if (0%{?rhel} >= 8)
@@ -14,7 +14,7 @@
 
 Name:          daos
 Version:       2.0.0
-Release:       5%{?relval}%{?dist}
+Release:       6%{?relval}%{?dist}
 Summary:       DAOS Storage Engine
 
 License:       BSD-2-Clause-Patent
@@ -517,6 +517,9 @@ getent passwd daos_agent >/dev/null || useradd -s /sbin/nologin -r -g daos_agent
 # No files in a meta-package
 
 %changelog
+* Wed Jan 19 2022 Johann Lombardi <johann.lombardi@intel.com> 2.0.0-6
+- Update libfabric to 1.14.0 GA and apply fix for DAOS-9376
+
 * Wed Jan 12 2022 Phillip Henderson <phillip.henderson@intel.com> 2.0.0-5
 - Fix name of daos serialize package
 


### PR DESCRIPTION
Upgrade from libfabric 1.14.0-rc3 to 1.14.0 GA.
Grab libfabric fix to store ibv_wr_opcode and reuse it
it in error cases in the verbs provider.
Move build.cfg to the official tag, the additional libfabric
patch will be added in a subsequent PR.

Signed-off-by: Johann Lombardi <johann.lombardi@intel.com>