### PR TITLE
DAOS-9102 test: Adjust shutdown time

### DIFF
--- a/src/tests/ftest/cart/no_pmix_group_test.c
+++ b/src/tests/ftest/cart/no_pmix_group_test.c
@@ -329,6 +329,9 @@ int main(int argc, char **argv)
 	/* rank, num_attach_retries, is_server, assert_on_error */
 	crtu_test_init(my_rank, num_attach_retries, true, true);
 
+	if (D_ON_VALGRIND)
+		crtu_set_shutdown_delay(5);
+
 	rc = d_log_init();
 	assert(rc == 0);
 

--- a/src/tests/ftest/cart/no_pmix_group_version.c
+++ b/src/tests/ftest/cart/no_pmix_group_version.c
@@ -281,6 +281,9 @@ int main(int argc, char **argv)
 	/* rank, num_attach_retries, is_server, assert_on_error */
 	crtu_test_init(my_rank, num_attach_retries, true, true);
 
+	if (D_ON_VALGRIND)
+		crtu_set_shutdown_delay(5);
+
 	rc = d_log_init();
 	assert(rc == 0);
 


### PR DESCRIPTION
- Adjust timeout time in test when running under valgrind.

Skip-func-test-el7: false
Skip-func-test-leap15: false
Skip-func-test-vm-valgrind: false
Skip-func-hw-test: true
Skip-unit-tests: true
Test-tag: group_test

Signed-off-by: Alexander A Oganezov <alexander.a.oganezov@intel.com>