### PR TITLE
DAOS-9641 control: append rxm when parsing config file

### DIFF
--- a/src/control/server/engine/config.go
+++ b/src/control/server/engine/config.go
@@ -41,6 +41,12 @@ func (fc *FabricConfig) Update(other FabricConfig) {
 	if fc.Provider == "" {
 		fc.Provider = other.Provider
 	}
+	if fc.Provider == "ofi+tcp" {
+		fc.Provider = "ofi+tcp;ofi_rxm"
+	}
+	if fc.Provider == "ofi+verbs" {
+		fc.Provider = "ofi+verbs;ofi_rxm"
+	}
 	if fc.Interface == "" {
 		fc.Interface = other.Interface
 	}


### PR DESCRIPTION
Automatically add rxm to ofi+tcp and ofi+verbs when parsing
the config.

Signed-off-by: Johann Lombardi <johann.lombardi@intel.com>