### PR TITLE
DAOS-9674 init: Add new crt_init_opt fields

### DIFF
--- a/src/cart/crt_init.c
+++ b/src/cart/crt_init.c
@@ -393,7 +393,7 @@ crt_init_opt(crt_group_id_t grpid, uint32_t flags, crt_init_options_t *opt)
 			D_DEBUG(DB_ALL, "ENV %s not found.\n", CRT_PHY_ADDR_ENV);
 			goto do_init;
 		} else {
-			D_DEBUG(DB_ALL, "EVN %s: %s.\n", CRT_PHY_ADDR_ENV,addr_env);
+			D_DEBUG(DB_ALL, "EVN %s: %s.\n", CRT_PHY_ADDR_ENV, addr_env);
 		}
 
 		provider_found = false;

--- a/src/cart/crt_init.c
+++ b/src/cart/crt_init.c
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2016-2021 Intel Corporation.
+ * (C) Copyright 2016-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -381,18 +381,19 @@ crt_init_opt(crt_group_id_t grpid, uint32_t flags, crt_init_options_t *opt)
 					"but crt_group_config_path_set failed "
 					"rc: %d, ignore the ENV.\n", path, rc);
 			else
-				D_DEBUG(DB_ALL, "set group_config_path as "
-					"%s.\n", path);
+				D_DEBUG(DB_ALL, "set group_config_path as %s.\n", path);
 		}
 
-		addr_env = (crt_phy_addr_t)getenv(CRT_PHY_ADDR_ENV);
+		if (opt && opt->cio_provider)
+			addr_env = opt->cio_provider;
+		else
+			addr_env = (crt_phy_addr_t)getenv(CRT_PHY_ADDR_ENV);
+
 		if (addr_env == NULL) {
-			D_DEBUG(DB_ALL, "ENV %s not found.\n",
-				CRT_PHY_ADDR_ENV);
+			D_DEBUG(DB_ALL, "ENV %s not found.\n", CRT_PHY_ADDR_ENV);
 			goto do_init;
-		} else{
-			D_DEBUG(DB_ALL, "EVN %s: %s.\n", CRT_PHY_ADDR_ENV,
-				addr_env);
+		} else {
+			D_DEBUG(DB_ALL, "EVN %s: %s.\n", CRT_PHY_ADDR_ENV,addr_env);
 		}
 
 		provider_found = false;
@@ -473,7 +474,7 @@ do_init:
 			D_DEBUG(DB_ALL, "Setting FI_PSM2_NAME_SERVER to 1\n");
 		}
 		if (crt_na_type_is_ofi(prov)) {
-			rc = crt_na_ofi_config_init(prov);
+			rc = crt_na_ofi_config_init(prov, opt);
 			if (rc != 0) {
 				D_ERROR("crt_na_ofi_config_init() failed, "
 					DF_RC"\n", DP_RC(rc));
@@ -744,7 +745,7 @@ crt_port_range_verify(int port)
 	}
 }
 
-int crt_na_ofi_config_init(int provider)
+int crt_na_ofi_config_init(int provider, crt_init_options_t *opt)
 {
 	char		*port_str;
 	char		*interface;
@@ -760,7 +761,11 @@ int crt_na_ofi_config_init(int provider)
 
 	na_ofi_cfg = &crt_gdata.cg_prov_gdata[provider].cpg_na_ofi_config;
 
-	interface = getenv("OFI_INTERFACE");
+	if (opt && opt->cio_interface)
+		interface = opt->cio_interface;
+	else
+		interface = getenv("OFI_INTERFACE");
+
 	if (interface != NULL && strlen(interface) > 0) {
 		D_STRNDUP(na_ofi_cfg->noc_interface, interface, 64);
 		if (na_ofi_cfg->noc_interface == NULL)
@@ -771,7 +776,11 @@ int crt_na_ofi_config_init(int provider)
 		D_GOTO(out, rc = -DER_INVAL);
 	}
 
-	domain = getenv("OFI_DOMAIN");
+	if (opt && opt->cio_domain)
+		domain = opt->cio_domain;
+	else
+		domain = getenv("OFI_DOMAIN");
+
 	if (domain == NULL) {
 		D_DEBUG(DB_ALL, "OFI_DOMAIN is not set. Setting it to %s\n",
 			interface);
@@ -836,7 +845,12 @@ int crt_na_ofi_config_init(int provider)
 	}
 
 	port = -1;
-	port_str = getenv("OFI_PORT");
+
+	if (opt && opt->cio_port)
+		port_str = opt->cio_port;
+	else
+		port_str = getenv("OFI_PORT");
+
 	if (crt_is_service() && port_str != NULL && strlen(port_str) > 0) {
 		if (!is_integer_str(port_str)) {
 			D_DEBUG(DB_ALL, "ignoring invalid OFI_PORT %s.",

--- a/src/cart/crt_internal_types.h
+++ b/src/cart/crt_internal_types.h
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2016-2021 Intel Corporation.
+ * (C) Copyright 2016-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -283,7 +283,7 @@ struct crt_opc_map {
 };
 
 
-int crt_na_ofi_config_init(int provider);
+int crt_na_ofi_config_init(int provider, crt_init_options_t *opt);
 void crt_na_ofi_config_fini(int provider);
 
 #endif /* __CRT_INTERNAL_TYPES_H__ */

--- a/src/include/cart/types.h
+++ b/src/include/cart/types.h
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2016-2021 Intel Corporation.
+ * (C) Copyright 2016-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -73,6 +73,19 @@ typedef struct crt_init_options {
 	uint32_t	cio_max_unexpected_size;
 			/** swim crt index */
 	int		cio_swim_crt_idx;
+
+	/** if set, used as a provider value instead of CRT_PHY_ADDR_STR env */
+	char		*cio_provider;
+
+	/** If set, used as an interface setting instead of OFI_INTERFACE env */
+	char		*cio_interface;
+
+	/** If set, used as a domain setting instead of OFI_DOMAIN env */
+	char		*cio_domain;
+
+	/** If set, used as a port setting instead of OFI_PORT env */
+	char		*cio_port;
+
 } crt_init_options_t;
 
 typedef int		crt_status_t;

--- a/src/tests/ftest/cart/dual_iface_server.c
+++ b/src/tests/ftest/cart/dual_iface_server.c
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2018-2021 Intel Corporation.
+ * (C) Copyright 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -240,11 +240,8 @@ server_main(d_rank_t my_rank, const char *str_port, const char *str_interface,
 	size_t			size = 0;
 	int			fd;
 	struct stat		st;
+	crt_init_options_t	init_opts;
 
-	setenv("OFI_PORT", str_port, 1);
-	setenv("OFI_INTERFACE", str_interface, 1);
-	setenv("OFI_DOMAIN", str_domain, 1);
-	setenv("CRT_PHY_ADDR_STR", str_provider, 1);
 	setenv("FI_UNIVERSE_SIZE", "1024", 1);
 	setenv("D_LOG_MASK", "ERR", 1);
 
@@ -263,7 +260,13 @@ server_main(d_rank_t my_rank, const char *str_port, const char *str_interface,
 		error_exit();
 	}
 
-	rc = crt_init("server_grp", CRT_FLAG_BIT_SERVER | CRT_FLAG_BIT_AUTO_SWIM_DISABLE);
+	init_opts.cio_provider = (char*)str_provider;
+	init_opts.cio_interface = (char*)str_interface;
+	init_opts.cio_domain = (char*)str_domain;
+	init_opts.cio_port = (char*)str_port;
+
+	rc = crt_init_opt("server_grp", CRT_FLAG_BIT_SERVER | CRT_FLAG_BIT_AUTO_SWIM_DISABLE,
+			  &init_opts);
 	if (rc != 0) {
 		D_ERROR("crt_init() failed; rc=%d\n", rc);
 		error_exit();

--- a/src/tests/ftest/cart/dual_iface_server.c
+++ b/src/tests/ftest/cart/dual_iface_server.c
@@ -260,10 +260,10 @@ server_main(d_rank_t my_rank, const char *str_port, const char *str_interface,
 		error_exit();
 	}
 
-	init_opts.cio_provider = (char*)str_provider;
-	init_opts.cio_interface = (char*)str_interface;
-	init_opts.cio_domain = (char*)str_domain;
-	init_opts.cio_port = (char*)str_port;
+	init_opts.cio_provider = (char *)str_provider;
+	init_opts.cio_interface = (char *)str_interface;
+	init_opts.cio_domain = (char *)str_domain;
+	init_opts.cio_port = (char *)str_port;
 
 	rc = crt_init_opt("server_grp", CRT_FLAG_BIT_SERVER | CRT_FLAG_BIT_AUTO_SWIM_DISABLE,
 			  &init_opts);


### PR DESCRIPTION
- New fields to control provider, interface, domain, port instead
of using envariables.

Signed-off-by: Alexander A Oganezov <alexander.a.oganezov@intel.com>