### PR TITLE
DAOS-9663 vos: set prepared for reindexed active DTX entry

### DIFF
--- a/src/vos/vos_dtx.c
+++ b/src/vos/vos_dtx.c
@@ -2507,6 +2507,7 @@ vos_dtx_act_reindex(struct vos_container *cont)
 			memcpy(&dae->dae_base, dae_df, sizeof(dae->dae_base));
 			dae->dae_df_off = umem_ptr2off(umm, dae_df);
 			dae->dae_dbd = dbd;
+			dae->dae_prepared = 1;
 			D_INIT_LIST_HEAD(&dae->dae_link);
 
 			if (DAE_REC_CNT(dae) > DTX_INLINE_REC_CNT) {


### PR DESCRIPTION
Otherwise, subsequent vos_dtx_check() will handle related DTX
entry as initialized but not prepared. That may cause related
DTX cannot be resynced or fail related DTX refresh for others.

Signed-off-by: Fan Yong <fan.yong@intel.com>