### PR TITLE
DAOS-9255 control: Improve pool creation size faults

### DIFF
--- a/src/control/server/faults.go
+++ b/src/control/server/faults.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2020-2021 Intel Corporation.
+// (C) Copyright 2020-2022 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -68,25 +68,25 @@ func FaultInstancesNotStopped(action string, rank system.Rank) *fault.Fault {
 	)
 }
 
-func FaultPoolNvmeTooSmall(reqBytes uint64, targetCount int) *fault.Fault {
+func FaultPoolNvmeTooSmall(minTotal, minNVMe uint64) *fault.Fault {
 	return serverFault(
 		code.ServerPoolNvmeTooSmall,
-		fmt.Sprintf("requested NVMe capacity (%s / %d) is too small (min %s per target)",
-			humanize.Bytes(reqBytes), targetCount,
+		fmt.Sprintf("requested NVMe capacity too small (min %s per target)",
 			humanize.IBytes(engine.NvmeMinBytesPerTarget)),
-		fmt.Sprintf("NVMe capacity should be larger than %s",
-			humanize.Bytes(engine.NvmeMinBytesPerTarget*uint64(targetCount))),
+		fmt.Sprintf("retry the request with a pool size of at least %s, with at least %s NVMe",
+			humanize.Bytes(minTotal+humanize.MiByte), humanize.Bytes(minNVMe+humanize.MiByte),
+		),
 	)
 }
 
-func FaultPoolScmTooSmall(reqBytes uint64, targetCount int) *fault.Fault {
+func FaultPoolScmTooSmall(minTotal, minSCM uint64) *fault.Fault {
 	return serverFault(
 		code.ServerPoolScmTooSmall,
-		fmt.Sprintf("requested SCM capacity (%s / %d) is too small (min %s per target)",
-			humanize.Bytes(reqBytes), targetCount,
+		fmt.Sprintf("requested SCM capacity is too small (min %s per target)",
 			humanize.IBytes(engine.ScmMinBytesPerTarget)),
-		fmt.Sprintf("SCM capacity should be larger than %s",
-			humanize.Bytes(engine.ScmMinBytesPerTarget*uint64(targetCount))),
+		fmt.Sprintf("retry the request with a pool size of at least %s, with at least %s SCM",
+			humanize.Bytes(minTotal+humanize.MiByte), humanize.Bytes(minSCM+humanize.MiByte),
+		),
 	)
 }
 

--- a/src/control/server/mgmt_pool_test.go
+++ b/src/control/server/mgmt_pool_test.go
@@ -144,6 +144,8 @@ func TestServer_MgmtSvc_calculateCreateStorage(t *testing.T) {
 	defaultScmBytes := uint64(float64(defaultTotal) * DefaultPoolScmRatio)
 	defaultNvmeBytes := uint64(float64(defaultTotal) * DefaultPoolNvmeRatio)
 	testTargetCount := 8
+	minPoolScm := minPoolScm(uint64(testTargetCount), 1)
+	minPoolNvme := minPoolNvme(uint64(testTargetCount), 1)
 	scmTooSmallRatio := 0.01
 	scmTooSmallTotal := uint64(testTargetCount * engine.NvmeMinBytesPerTarget)
 	scmTooSmallReq := uint64(float64(scmTooSmallTotal) * scmTooSmallRatio)
@@ -174,7 +176,7 @@ func TestServer_MgmtSvc_calculateCreateStorage(t *testing.T) {
 				Tierratio:  []float64{scmTooSmallRatio},
 				Ranks:      []uint32{0},
 			},
-			expErr: FaultPoolScmTooSmall(scmTooSmallReq, testTargetCount),
+			expErr: FaultPoolScmTooSmall(scmTooSmallReq, minPoolScm),
 		},
 		"auto sizing (not enough NVMe)": {
 			in: &mgmtpb.PoolCreateReq{
@@ -182,7 +184,7 @@ func TestServer_MgmtSvc_calculateCreateStorage(t *testing.T) {
 				Tierratio:  []float64{DefaultPoolScmRatio, DefaultPoolNvmeRatio},
 				Ranks:      []uint32{0},
 			},
-			expErr: FaultPoolNvmeTooSmall(uint64(float64(nvmeTooSmallReq)*DefaultPoolNvmeRatio), testTargetCount),
+			expErr: FaultPoolNvmeTooSmall(uint64(float64(nvmeTooSmallReq)*DefaultPoolNvmeRatio), minPoolNvme),
 		},
 		"auto sizing (no NVMe in config)": {
 			disableNVMe: true,
@@ -213,14 +215,14 @@ func TestServer_MgmtSvc_calculateCreateStorage(t *testing.T) {
 				Tierbytes: []uint64{scmTooSmallReq},
 				Ranks:     []uint32{0},
 			},
-			expErr: FaultPoolScmTooSmall(scmTooSmallReq, testTargetCount),
+			expErr: FaultPoolScmTooSmall(scmTooSmallReq, minPoolScm),
 		},
 		"manual sizing (not enough NVMe)": {
 			in: &mgmtpb.PoolCreateReq{
 				Tierbytes: []uint64{defaultScmBytes, nvmeTooSmallReq},
 				Ranks:     []uint32{0},
 			},
-			expErr: FaultPoolNvmeTooSmall(nvmeTooSmallReq, testTargetCount),
+			expErr: FaultPoolNvmeTooSmall(nvmeTooSmallReq, minPoolNvme),
 		},
 	} {
 		t.Run(name, func(t *testing.T) {


### PR DESCRIPTION
The error and resolution strings should be simpler and
more focused on giving the admin specific and actionable
information (e.g. the minimum pool size).

Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com>
