### PR TITLE
DAOS-9672 placement: ignore further pool map changes during reintegra…

### DIFF
--- a/src/include/daos/pool_map.h
+++ b/src/include/daos/pool_map.h
@@ -18,9 +18,9 @@
 #define POOL_MAP_VER_2		(2)
 #define POOL_MAP_VERSION	POOL_MAP_VER_2
 
-#define DF_TARGET "Target[%d] (rank %u idx %u status %u)"
+#define DF_TARGET "Target[%d] (rank %u idx %u status %u ver %u)"
 #define DP_TARGET(t) t->ta_comp.co_id, t->ta_comp.co_rank, t->ta_comp.co_index,\
-		     t->ta_comp.co_status
+		     t->ta_comp.co_status, t->ta_comp.co_ver
 
 /**
  * pool component types

--- a/src/placement/jump_map.c
+++ b/src/placement/jump_map.c
@@ -543,7 +543,7 @@ struct dom_grp_used {
 static int
 obj_remap_shards(struct pl_jump_map *jmap, struct daos_obj_md *md,
 		 struct pl_obj_layout *layout, struct jm_obj_placement *jmop,
-		 d_list_t *remap_list, uint32_t allow_status,
+		 d_list_t *remap_list, uint32_t allow_status, uint32_t allow_version,
 		 uint8_t *tgts_used, uint8_t *dom_used, uint8_t *dom_occupied,
 		 uint32_t failed_in_layout, bool *is_extending)
 {
@@ -607,9 +607,8 @@ obj_remap_shards(struct pl_jump_map *jmap, struct daos_obj_md *md,
 			spares_left--;
 		}
 
-		determine_valid_spares(spare_tgt, md, spare_avail, &current,
-				       remap_list, allow_status, f_shard,
-				       l_shard, is_extending);
+		determine_valid_spares(spare_tgt, md, spare_avail, &current, remap_list,
+				       allow_status, allow_version, f_shard, l_shard, is_extending);
 	}
 
 	return 0;
@@ -693,6 +692,9 @@ remap_gpu_alloc_one(d_list_t *remap_list, uint8_t *dom_cur_grp_used)
  * \param[in]   jmop            The layout group size and count.
  * \param[in]   md              Object metadata.
  * \param[in]	allow_status	target status allowed to be in the layout.
+ * \param[in]	allow_version	the maximum pool version during remap, i.e.
+ *                              it can ignore the further pool map version
+ *                              changes during remap.
  * \param[out]  layout          This will contain the layout for the object
  * \param[out]  out_list	This will contain the targets that need to
  *                              be rebuilt and in the case of rebuild, may be
@@ -709,7 +711,7 @@ remap_gpu_alloc_one(d_list_t *remap_list, uint8_t *dom_cur_grp_used)
 static int
 get_object_layout(struct pl_jump_map *jmap, struct pl_obj_layout *layout,
 		  struct jm_obj_placement *jmop, d_list_t *out_list,
-		  uint32_t allow_status, struct daos_obj_md *md,
+		  uint32_t allow_status, uint32_t allow_version, struct daos_obj_md *md,
 		  bool *is_extending)
 {
 	struct pool_target      *target;
@@ -830,7 +832,7 @@ get_object_layout(struct pl_jump_map *jmap, struct pl_obj_layout *layout,
 			layout->ol_shards[k].po_shard = k;
 
 			/** If target is failed queue it for remap*/
-			if (!pool_target_avail(target, allow_status)) {
+			if (need_remap_target(target, allow_status, allow_version)) {
 				fail_tgt_cnt++;
 				D_DEBUG(DB_PL, "Target unavailable " DF_TARGET
 					". Adding to remap_list: fail cnt %d\n",
@@ -857,7 +859,7 @@ get_object_layout(struct pl_jump_map *jmap, struct pl_obj_layout *layout,
 
 	if (fail_tgt_cnt > 0)
 		rc = obj_remap_shards(jmap, md, layout, jmop, remap_list,
-				      allow_status, tgts_used, dom_used,
+				      allow_status, allow_version, tgts_used, dom_used,
 				      dom_occupied, fail_tgt_cnt, is_extending);
 out:
 	if (rc)
@@ -896,8 +898,9 @@ out:
 static int
 obj_layout_alloc_and_get(struct pl_jump_map *jmap,
 			 struct jm_obj_placement *jmop, struct daos_obj_md *md,
-			 uint32_t allow_status, struct pl_obj_layout **layout_p,
-			 d_list_t *remap_list, bool *is_extending)
+			 uint32_t allow_status, uint32_t allow_version,
+			 struct pl_obj_layout **layout_p, d_list_t *remap_list,
+			 bool *is_extending)
 {
 	int rc;
 
@@ -913,7 +916,7 @@ obj_layout_alloc_and_get(struct pl_jump_map *jmap,
 	}
 
 	rc = get_object_layout(jmap, *layout_p, jmop, remap_list, allow_status,
-			       md, is_extending);
+			       allow_version, md, is_extending);
 	if (rc) {
 		D_ERROR("get object layout failed, rc "DF_RC"\n",
 			DP_RC(rc));
@@ -1068,7 +1071,7 @@ jump_map_obj_place(struct pl_map *map, struct daos_obj_md *md,
 
 	D_INIT_LIST_HEAD(&extend_list);
 	allow_status = PO_COMP_ST_UPIN | PO_COMP_ST_DRAIN;
-	rc = obj_layout_alloc_and_get(jmap, &jmop, md, allow_status, &layout,
+	rc = obj_layout_alloc_and_get(jmap, &jmop, md, allow_status, -1, &layout,
 				      NULL, &is_extending);
 	if (rc != 0) {
 		D_ERROR("get_layout_alloc failed, rc "DF_RC"\n", DP_RC(rc));
@@ -1105,7 +1108,7 @@ jump_map_obj_place(struct pl_map *map, struct daos_obj_md *md,
 		 * they have already been remapped.
 		 */
 		allow_status |= PO_COMP_ST_DOWN;
-		rc = obj_layout_alloc_and_get(jmap, &jmop, md, allow_status,
+		rc = obj_layout_alloc_and_get(jmap, &jmop, md, allow_status, -1,
 					      &extend_layout, NULL, NULL);
 		if (rc)
 			D_GOTO(out, rc);
@@ -1190,7 +1193,7 @@ jump_map_obj_find_rebuild(struct pl_map *map, struct daos_obj_md *md,
 	}
 
 	D_INIT_LIST_HEAD(&remap_list);
-	rc = obj_layout_alloc_and_get(jmap, &jmop, md, PO_COMP_ST_UPIN, &layout,
+	rc = obj_layout_alloc_and_get(jmap, &jmop, md, PO_COMP_ST_UPIN, -1, &layout,
 				      &remap_list, NULL);
 	if (rc < 0)
 		D_GOTO(out, rc);
@@ -1209,8 +1212,9 @@ out:
 static int
 jump_map_obj_find_reint(struct pl_map *map, struct daos_obj_md *md,
 			struct daos_obj_shard_md *shard_md,
-			uint32_t reint_ver, uint32_t *tgt_rank,
-			uint32_t *shard_id, unsigned int array_size)
+			uint32_t reint_ver,
+			uint32_t *tgt_rank, uint32_t *shard_id,
+			unsigned int array_size)
 {
 	struct pl_jump_map              *jmap;
 	struct pl_obj_layout            *layout = NULL;
@@ -1243,13 +1247,13 @@ jump_map_obj_find_reint(struct pl_map *map, struct daos_obj_md *md,
 	 */
 	allow_status = PO_COMP_ST_UPIN | PO_COMP_ST_DOWN | PO_COMP_ST_DRAIN;
 	D_INIT_LIST_HEAD(&reint_list);
-	rc = obj_layout_alloc_and_get(jmap, &jop, md, allow_status, &layout,
-				      NULL, NULL);
+	rc = obj_layout_alloc_and_get(jmap, &jop, md, allow_status, reint_ver,
+				      &layout, NULL, NULL);
 	if (rc < 0)
 		D_GOTO(out, rc);
 
 	allow_status |= PO_COMP_ST_UP;
-	rc = obj_layout_alloc_and_get(jmap, &jop, md, allow_status,
+	rc = obj_layout_alloc_and_get(jmap, &jop, md, allow_status, reint_ver,
 				      &reint_layout, NULL, NULL);
 	if (rc < 0)
 		D_GOTO(out, rc);
@@ -1272,8 +1276,9 @@ out:
 static int
 jump_map_obj_find_addition(struct pl_map *map, struct daos_obj_md *md,
 			   struct daos_obj_shard_md *shard_md,
-			   uint32_t reint_ver, uint32_t *tgt_rank,
-			   uint32_t *shard_id, unsigned int array_size)
+			   uint32_t reint_ver,
+			   uint32_t *tgt_rank, uint32_t *shard_id,
+			   unsigned int array_size)
 {
 	struct pl_jump_map              *jmap;
 	struct pl_obj_layout            *layout = NULL;
@@ -1303,13 +1308,13 @@ jump_map_obj_find_addition(struct pl_map *map, struct daos_obj_md *md,
 
 	allow_status = PO_COMP_ST_UPIN;
 	D_INIT_LIST_HEAD(&add_list);
-	rc = obj_layout_alloc_and_get(jmap, &jop, md, allow_status,
+	rc = obj_layout_alloc_and_get(jmap, &jop, md, allow_status, reint_ver,
 				      &layout, NULL, NULL);
 	if (rc)
 		D_GOTO(out, rc);
 
 	allow_status |= PO_COMP_ST_NEW;
-	rc = obj_layout_alloc_and_get(jmap, &jop, md, allow_status,
+	rc = obj_layout_alloc_and_get(jmap, &jop, md, allow_status, reint_ver,
 				      &add_layout, NULL, NULL);
 	if (rc)
 		D_GOTO(out, rc);

--- a/src/placement/pl_map.h
+++ b/src/placement/pl_map.h
@@ -121,7 +121,7 @@ void
 determine_valid_spares(struct pool_target *spare_tgt, struct daos_obj_md *md,
 		       bool spare_avail, d_list_t **current,
 		       d_list_t *remap_list, uint32_t allow_status,
-		       struct failed_shard *f_shard,
+		       uint32_t allow_version, struct failed_shard *f_shard,
 		       struct pl_obj_shard *l_shard, bool *extending);
 
 int
@@ -134,4 +134,6 @@ pl_map_extend(struct pl_obj_layout *layout, d_list_t *extended_list);
 bool
 is_pool_adding(struct pool_domain *dom);
 
+bool
+need_remap_target(struct pool_target *tgt, uint32_t allow_status, uint32_t allow_version);
 #endif /* __PL_MAP_H__ */

--- a/src/placement/pl_map_common.c
+++ b/src/placement/pl_map_common.c
@@ -232,11 +232,36 @@ remap_list_fill(struct pl_map *map, struct daos_obj_md *md,
 	return 0;
 }
 
+bool
+need_remap_target(struct pool_target *tgt, uint32_t allow_status, uint32_t allow_version)
+{
+	if (!pool_target_avail(tgt, allow_status))
+		return true;
+
+	if (tgt->ta_comp.co_status == PO_COMP_ST_UPIN || allow_version == (uint32_t)(-1))
+		return false;
+
+	if (tgt->ta_comp.co_status == PO_COMP_ST_DRAIN) {
+		/* If Drain happenes later, let's ignore it for current rebuild/reintegration */
+		if (tgt->ta_comp.co_fseq > allow_version)
+			return false;
+		else
+			return true;
+	}
+
+	/* For other cases, let's ignore all future pool map changes for current rebuild. */
+	if (tgt->ta_comp.co_in_ver > allow_version)
+		return true;
+
+	return false;
+}
+
 void
 determine_valid_spares(struct pool_target *spare_tgt, struct daos_obj_md *md,
 		bool spare_avail, d_list_t **current, d_list_t *remap_list,
-		uint32_t allow_status, struct failed_shard *f_shard,
-		struct pl_obj_shard *l_shard, bool *is_extending)
+		uint32_t allow_status, uint32_t allow_version,
+		struct failed_shard *f_shard, struct pl_obj_shard *l_shard,
+		bool *is_extending)
 {
 	struct failed_shard *f_tmp;
 
@@ -249,7 +274,7 @@ determine_valid_spares(struct pool_target *spare_tgt, struct daos_obj_md *md,
 		*is_extending = true;
 
 	/* The selected spare target is down as well */
-	if (!pool_target_avail(spare_tgt, allow_status)) {
+	if (need_remap_target(spare_tgt, allow_status, allow_version)) {
 		D_ASSERTF(spare_tgt->ta_comp.co_fseq !=
 			  f_shard->fs_fseq, "same fseq %u!\n",
 			  f_shard->fs_fseq);

--- a/src/placement/ring_map.c
+++ b/src/placement/ring_map.c
@@ -1023,7 +1023,7 @@ ring_obj_remap_shards(struct pl_ring_map *rimap, struct daos_obj_md *md,
 		spare_tgt = &tgts[plts[spare_idx].pt_pos];
 
 		determine_valid_spares(spare_tgt, md, spare_avail, &current,
-				       remap_list, for_reint, f_shard, l_shard,
+				       remap_list, for_reint, -1, f_shard, l_shard,
 				       NULL);
 	}
 

--- a/src/pool/srv_pool_map.c
+++ b/src/pool/srv_pool_map.c
@@ -155,12 +155,17 @@ update_one_tgt(struct pool_map *map, struct pool_target *target,
 			 * Need to update this target AND all of its parents
 			 * domains from NEW -> UPIN
 			 */
-
 			target->ta_comp.co_flags = 0;
 			rc = pool_map_activate_new_target(map,
 						target->ta_comp.co_id);
 			D_ASSERT(rc != 0); /* This target must be findable */
 			target->ta_comp.co_in_ver = ++(*version);
+			if (print_changes)
+				D_PRINT(DF_TARGET " is reintegrated.\n",
+					DP_TARGET(target));
+			else
+				D_INFO(DF_TARGET " is reintegrated.\n",
+				       DP_TARGET(target));
 			break;
 		}
 		break;

--- a/src/tests/ftest/daos_test/suite.yaml
+++ b/src/tests/ftest/daos_test/suite.yaml
@@ -31,7 +31,7 @@ timeouts:
     test_daos_extend_simple: 500
     test_daos_oid_allocator: 320
     test_daos_checksum: 500
-    test_daos_rebuild_ec: 1800
+    test_daos_rebuild_ec: 3600
     test_daos_aggregate_ec: 200
     test_daos_degraded_ec: 1900
     test_daos_dedup: 220

--- a/src/tests/suite/daos_rebuild_ec.c
+++ b/src/tests/suite/daos_rebuild_ec.c
@@ -81,9 +81,9 @@ rebuild_ec_internal(void **state, daos_oclass_id_t oclass, int kill_data_nr,
 
 	reintegrate_pools_ranks(&arg, 1, kill_ranks, kill_ranks_num);
 	if (oclass == OC_EC_2P1G1)
-		reintegrate_pools_ranks(&arg, 1, &extra_kill_ranks[1], 1);
+		reintegrate_pools_ranks(&arg, 1, &extra_kill_ranks[0], 1);
 	else /* oclass OC_EC_4P2G1 */
-		reintegrate_pools_ranks(&arg, 1, &extra_kill_ranks[2], 2);
+		reintegrate_pools_ranks(&arg, 1, &extra_kill_ranks[0], 2);
 
 	ioreq_init(&req, arg->coh, oid, DAOS_IOD_ARRAY, arg);
 	if (write_type == PARTIAL_UPDATE)


### PR DESCRIPTION
…tion

Let's ignore the further pool map changes for layout calculation
once reintegration starts, otherwise it may cause data corruption.

See this example.

1.reintegrate rank1(targets_1 --->UP), schedule reintegrate job1.
2.reintegrate rank2(targets_2 --->UP), schedule reintegrate job2.
3.job1 will do reintegration, since targets_2 are also in UP status,
so both targets 1 and 2 will be reintegrated. But only targets_1 will
be changed to UPIN after reintegration, even though targets_2 has been
reintegrated into the new location, but it still in UP status, which can
cause data corruption.

Add extra information for pool reintegration procecess.

Fix a typo in rebuild_ec test.

Signed-off-by: Di Wang <di.wang@intel.com>