### PR TITLE
DAOS-9630 vea: best-fit policy for small reserve

### DIFF
--- a/src/include/daos_srv/vea.h
+++ b/src/include/daos_srv/vea.h
@@ -20,9 +20,6 @@
 #include <daos/mem.h>
 #include <daos/btree.h>
 
-/* Maximum age, indicating a non-active free extent */
-#define VEA_EXT_AGE_MAX		0
-
 /* Common free extent structure for both SCM & in-memory index */
 struct vea_free_extent {
 	uint64_t	vfe_blk_off;	/* Block offset of the extent */

--- a/src/vea/tests/vea_ut.c
+++ b/src/vea/tests/vea_ut.c
@@ -43,13 +43,15 @@ print_usage(void)
 	fprintf(stdout, "vea_ut [-f <pool_file_name>]\n");
 }
 
+#define	UT_TOTAL_BLKS	(((VEA_LARGE_EXT_MB * 2) + 1) << 20) /* 129MB */
+
 static void
 ut_format(void **state)
 {
 	struct vea_ut_args *args = *state;
 	uint32_t blk_sz = 0; /* use the default size */
 	uint32_t hdr_blks = 1;
-	uint64_t capacity = ((VEA_LARGE_EXT_MB * 2) << 20); /* 128MB */
+	uint64_t capacity = UT_TOTAL_BLKS;
 	int rc;
 
 	/* format */
@@ -100,7 +102,7 @@ ut_query(void **state)
 	/* the values from ut_format() */
 	blk_sz = (1 << 12);
 	hdr_blks = 1;
-	tot_blks = ((VEA_LARGE_EXT_MB * 2) << 20) / blk_sz - hdr_blks;
+	tot_blks = UT_TOTAL_BLKS / blk_sz - hdr_blks;
 
 	/* verify the attributes */
 	assert_int_equal(attr.va_blk_sz, blk_sz);
@@ -222,22 +224,22 @@ ut_reserve(void **state)
 	ext = d_list_entry(r_list->prev, struct vea_resrvd_ext, vre_link);
 	assert_int_equal(ext->vre_hint_off, VEA_HINT_OFF_INVAL);
 	assert_int_equal(ext->vre_blk_cnt, blk_cnt);
-	/* start from the end of the stream 0 */
-	assert_int_equal(ext->vre_blk_off, off_a);
+	/* start from the end of the stream 1 */
+	assert_int_equal(ext->vre_blk_off, off_b);
 
 	/* Verify transient is allocated */
-	rc = vea_verify_alloc(args->vua_vsi, true, off_a, blk_cnt);
+	rc = vea_verify_alloc(args->vua_vsi, true, off_b, blk_cnt);
 	assert_rc_equal(rc, 0);
 	/* Verify persistent is not allocated */
-	rc = vea_verify_alloc(args->vua_vsi, false, off_a, blk_cnt);
+	rc = vea_verify_alloc(args->vua_vsi, false, off_b, blk_cnt);
 	assert_rc_equal(rc, 1);
 
 	/* Verify statistics */
 	rc = vea_query(args->vua_vsi, NULL, &stat);
 	assert_rc_equal(rc, 0);
 
-	assert_int_equal(stat.vs_frags_large, 0);
-	assert_int_equal(stat.vs_frags_small, 2);
+	assert_int_equal(stat.vs_frags_large, 1);
+	assert_int_equal(stat.vs_frags_small, 1);
 	/* 2 hint from the second reserve for io stream 0 & 1 */
 	assert_int_equal(stat.vs_resrv_hint, 2);
 	/* 2 large from the first reserve for io stream 0 & 1 */

--- a/src/vea/vea_alloc.c
+++ b/src/vea/vea_alloc.c
@@ -39,7 +39,6 @@ compound_alloc(struct vea_space_info *vsi, struct vea_free_extent *vfe,
 		/* Adjust in-tree offset & length */
 		remain->vfe_blk_off += vfe->vfe_blk_cnt;
 		remain->vfe_blk_cnt -= vfe->vfe_blk_cnt;
-		remain->vfe_age = get_current_age();
 
 		rc = free_class_add(vsi, entry);
 	}
@@ -93,9 +92,64 @@ reserve_hint(struct vea_space_info *vsi, uint32_t blk_cnt,
 	return 0;
 }
 
-int
-reserve_large(struct vea_space_info *vsi, uint32_t blk_cnt,
+static int
+reserve_small(struct vea_space_info *vsi, uint32_t blk_cnt,
 	      struct vea_resrvd_ext *resrvd)
+{
+	daos_handle_t		 btr_hdl;
+	struct vea_sized_class	*sc;
+	struct vea_free_extent	 vfe;
+	struct vea_entry	*entry;
+	d_iov_t			 key, val_out;
+	uint64_t		 int_key = blk_cnt;
+	int			 rc;
+
+	/* Skip huge allocate request */
+	if (blk_cnt > vsi->vsi_class.vfc_large_thresh)
+		return 0;
+
+	btr_hdl = vsi->vsi_class.vfc_size_btr;
+	D_ASSERT(daos_handle_is_valid(btr_hdl));
+
+	d_iov_set(&key, &int_key, sizeof(int_key));
+	d_iov_set(&val_out, NULL, 0);
+
+	rc = dbtree_fetch(btr_hdl, BTR_PROBE_GE, DAOS_INTENT_DEFAULT, &key, NULL, &val_out);
+	if (rc == -DER_NONEXIST) {
+		return 0;
+	} else if (rc) {
+		D_ERROR("Search size class:%u failed. "DF_RC"\n", blk_cnt, DP_RC(rc));
+		return rc;
+	}
+
+	sc = (struct vea_sized_class *)val_out.iov_buf;
+	D_ASSERT(sc != NULL);
+	D_ASSERT(!d_list_empty(&sc->vsc_lru));
+
+	/* Get the least used item from head */
+	entry = d_list_entry(sc->vsc_lru.next, struct vea_entry, ve_link);
+	D_ASSERT(entry->ve_sized_class == sc);
+	D_ASSERT(entry->ve_ext.vfe_blk_cnt >= blk_cnt);
+
+	vfe.vfe_blk_off = entry->ve_ext.vfe_blk_off;
+	vfe.vfe_blk_cnt = blk_cnt;
+
+	rc = compound_alloc(vsi, &vfe, entry);
+	if (rc)
+		return rc;
+
+	resrvd->vre_blk_off = vfe.vfe_blk_off;
+	resrvd->vre_blk_cnt = blk_cnt;
+	inc_stats(vsi, STAT_RESRV_SMALL, 1);
+
+	D_DEBUG(DB_IO, "["DF_U64", %u]\n", resrvd->vre_blk_off, resrvd->vre_blk_cnt);
+
+	return rc;
+}
+
+int
+reserve_single(struct vea_space_info *vsi, uint32_t blk_cnt,
+	       struct vea_resrvd_ext *resrvd)
 {
 	struct vea_free_class *vfc = &vsi->vsi_class;
 	struct vea_free_extent vfe;
@@ -105,7 +159,7 @@ reserve_large(struct vea_space_info *vsi, uint32_t blk_cnt,
 
 	/* No large free extent available */
 	if (d_binheap_is_empty(&vfc->vfc_heap))
-		return 0;
+		return reserve_small(vsi, blk_cnt, resrvd);
 
 	root = d_binheap_root(&vfc->vfc_heap);
 	entry = container_of(root, struct vea_entry, ve_node);
@@ -119,12 +173,17 @@ reserve_large(struct vea_space_info *vsi, uint32_t blk_cnt,
 		return 0;
 
 	/*
-	 * Reserve from the largest free extent when it's idle or too
-	 * small for splitting, otherwise, divide it in half-and-half
-	 * and reserve from the second half.
+	 * If the largest free extent is large enough for splitting, divide it in
+	 * half-and-half then reserve from the second half, otherwise, try to
+	 * reserve from the small extents first, if it fails, reserve from the
+	 * largest free extent.
 	 */
-	if (ext_is_idle(&entry->ve_ext) ||
-	    (entry->ve_ext.vfe_blk_cnt <= (blk_cnt * 2))) {
+	if (entry->ve_ext.vfe_blk_cnt <= (max(blk_cnt, vfc->vfc_large_thresh) * 2)) {
+		/* Try small extents first */
+		rc = reserve_small(vsi, blk_cnt, resrvd);
+		if (rc != 0 || resrvd->vre_blk_cnt != 0)
+			return rc;
+
 		vfe.vfe_blk_off = entry->ve_ext.vfe_blk_off;
 		vfe.vfe_blk_cnt = blk_cnt;
 
@@ -152,7 +211,7 @@ reserve_large(struct vea_space_info *vsi, uint32_t blk_cnt,
 		if (tot_blks > (half_blks + blk_cnt)) {
 			vfe.vfe_blk_off = blk_off + half_blks + blk_cnt;
 			vfe.vfe_blk_cnt = tot_blks - half_blks - blk_cnt;
-			vfe.vfe_age = get_current_age();
+			vfe.vfe_age = 0;	/* Not used */
 
 			rc = compound_free(vsi, &vfe, VEA_FL_NO_MERGE |
 						VEA_FL_NO_ACCOUNTING);
@@ -171,150 +230,6 @@ reserve_large(struct vea_space_info *vsi, uint32_t blk_cnt,
 		resrvd->vre_blk_cnt);
 
 	return 0;
-}
-
-#define EXT_AGE_WEIGHT	300	/* seconds */
-
-static void
-cursor_update(struct free_ext_cursor *cursor, struct vea_entry *ent,
-	      int ent_idx)
-{
-	uint64_t age_cur, age_next;
-
-	D_ASSERT(ent != NULL);
-
-	if (cursor->fec_cur == NULL)
-		goto update;
-	else if (ext_is_idle(&cursor->fec_cur->ve_ext))
-		return;
-	else if (ext_is_idle(&ent->ve_ext))
-		goto update;
-
-	D_ASSERT(!ext_is_idle(&cursor->fec_cur->ve_ext));
-	D_ASSERT(!ext_is_idle(&ent->ve_ext));
-
-	age_cur = cursor->fec_cur->ve_ext.vfe_age;
-	age_cur += (uint64_t)cursor->fec_idx * EXT_AGE_WEIGHT;
-	age_next = ent->ve_ext.vfe_age;
-	age_next += (uint64_t)ent_idx * EXT_AGE_WEIGHT;
-
-	if (age_cur <= age_next)
-		return;
-update:
-	cursor->fec_cur = ent;
-	cursor->fec_idx = ent_idx;
-}
-
-static struct free_ext_cursor *
-cursor_prepare(struct vea_free_class *vfc, uint32_t blk_cnt)
-{
-	struct free_ext_cursor *cursor = vfc->vfc_cursor;
-	struct vea_entry *entry;
-	int i, e_cnt;
-
-	for (e_cnt = 0; e_cnt < vfc->vfc_lru_cnt; e_cnt++) {
-		if (blk_cnt > vfc->vfc_sizes[e_cnt])
-			break;
-	}
-
-	cursor->fec_cur = NULL;
-	cursor->fec_idx = 0;
-	cursor->fec_entry_cnt = e_cnt;
-	memset(cursor->fec_entries, 0, vfc->vfc_lru_cnt * sizeof(entry));
-
-	/* Initialize vea_entry pointer array, setup starting entry */
-	for (i = 0; i < e_cnt; i++) {
-		d_list_t *lru = &vfc->vfc_lrus[i];
-
-		if (d_list_empty(lru)) {
-			cursor->fec_entries[i] = NULL;
-			continue;
-		}
-
-		entry = d_list_entry(lru->next, struct vea_entry, ve_link);
-		cursor->fec_entries[i] = entry;
-		cursor_update(cursor, entry, i);
-	}
-
-	return cursor;
-}
-
-static struct vea_entry *
-cursor_next(struct vea_free_class *vfc, struct free_ext_cursor *cursor)
-{
-	struct vea_entry *cur, *next;
-	d_list_t *lru_head;
-	int i, cur_idx = cursor->fec_idx;
-
-	D_ASSERT(cursor->fec_cur != NULL);
-	cur = cursor->fec_cur;
-	lru_head = &vfc->vfc_lrus[cur_idx];
-
-	/* Make sure the fec_cur is cleared */
-	cursor->fec_cur = NULL;
-
-	if (cur->ve_link.next == lru_head) {
-		cursor->fec_entries[cur_idx] = NULL;
-	} else {
-		next = d_list_entry(cur->ve_link.next, struct vea_entry,
-				    ve_link);
-		cursor->fec_entries[cur_idx] = next;
-
-		/* Keeping on current size class if the extent is idle */
-		if (ext_is_idle(&next->ve_ext)) {
-			cursor->fec_cur = next;
-			return cursor->fec_cur;
-		}
-	}
-
-	for (i = 0; i < cursor->fec_entry_cnt; i++) {
-		cur = cursor->fec_entries[i];
-		if (cur != NULL)
-			cursor_update(cursor, cur, i);
-	}
-
-	return cursor->fec_cur;
-}
-
-int
-reserve_small(struct vea_space_info *vsi, uint32_t blk_cnt,
-	      struct vea_resrvd_ext *resrvd)
-{
-	struct vea_free_extent vfe;
-	struct vea_entry *entry;
-	struct free_ext_cursor *cursor;
-	int rc = 0;
-
-	/* Skip huge allocate request */
-	if (blk_cnt > vsi->vsi_class.vfc_large_thresh)
-		return 0;
-
-	cursor = cursor_prepare(&vsi->vsi_class, blk_cnt);
-	D_ASSERT(cursor != NULL);
-
-	entry = cursor->fec_cur;
-	while (entry != NULL) {
-		if (entry->ve_ext.vfe_blk_cnt >= blk_cnt) {
-			vfe.vfe_blk_off = entry->ve_ext.vfe_blk_off;
-			vfe.vfe_blk_cnt = blk_cnt;
-
-			rc = compound_alloc(vsi, &vfe, entry);
-			if (rc)
-				break;
-
-			resrvd->vre_blk_off = vfe.vfe_blk_off;
-			resrvd->vre_blk_cnt = blk_cnt;
-
-			inc_stats(vsi, STAT_RESRV_SMALL, 1);
-
-			D_DEBUG(DB_IO, "["DF_U64", %u]\n",
-				resrvd->vre_blk_off, resrvd->vre_blk_cnt);
-			break;
-		}
-		entry = cursor_next(&vsi->vsi_class, cursor);
-	}
-
-	return rc;
 }
 
 int

--- a/src/vea/vea_api.c
+++ b/src/vea/vea_api.c
@@ -10,9 +10,6 @@
 #include <daos/dtx.h>
 #include "vea_internal.h"
 
-#define VEA_BLK_SZ	(4 * 1024)	/* 4K */
-#define VEA_TREE_ODR	20
-
 static void
 erase_md(struct umem_instance *umem, struct vea_space_df *md)
 {
@@ -135,7 +132,7 @@ vea_format(struct umem_instance *umem, struct umem_tx_stage_data *txd,
 	/* Insert the initial free extent */
 	free_ext.vfe_blk_off = hdr_blks;
 	free_ext.vfe_blk_cnt = tot_blks;
-	free_ext.vfe_age = VEA_EXT_AGE_MAX;
+	free_ext.vfe_age = 0;	/* Not used */
 
 	d_iov_set(&key, &free_ext.vfe_blk_off,
 		     sizeof(free_ext.vfe_blk_off));
@@ -270,21 +267,14 @@ error:
 }
 
 /*
- * Reserve an extent on block device.
+ * Reserve an extent on block device, reserve attempting order:
  *
- * Always try to preserve sequential locality by 'hint', 'free extent size'
- * and 'free extent age', if the block device is too fragmented to satisfy
- * a contiguous allocation, reserve an extent vector as the last resort.
- *
- * Reserve attempting order:
- *
- * 1. Reserve from the free extent with 'hinted' start offset. (vsi_free_tree)
- * 2. Reserve from the largest free extent if it isn't non-active (extent age
- *    isn't VEA_EXT_AGE_MAX), otherwise, divide it in half-and-half and resreve
- *    from the latter half. (vfc_heap)
- * 3. Search & reserve from a bunch of extent size classed LRUs in first fit
- *    policy, larger & older free extent has priority. (vfc_lrus)
- * 4. Repeat the search in 3rd step to reserve an extent vector. (vsi_vec_tree)
+ * 1. Reserve from the free extent with 'hinted' start offset. (lookup vsi_free_btr)
+ * 2. If the largest free extent is large enough for splitting, divide it in
+ *    half-and-half then reserve from the latter half. (lookup vfc_heap). Otherwise;
+ * 3. Try to reserve from some small free extent (<= VEA_LARGE_EXT_MB) in best-fit,
+ *    if it fails, reserve from the largest free extent. (lookup vfc_size_btr)
+ * 4. Repeat the search in 3rd step to reserve an extent vector. (vsi_vec_btr)
  * 5. Fail reserve with ENOMEM if all above attempts fail.
  */
 int
@@ -319,15 +309,8 @@ retry:
 	else if (resrvd->vre_blk_cnt != 0)
 		goto done;
 
-	/* Reserve from the large extents */
-	rc = reserve_large(vsi, blk_cnt, resrvd);
-	if (rc != 0)
-		goto error;
-	else if (resrvd->vre_blk_cnt != 0)
-		goto done;
-
-	/* Reserve from the small extents */
-	rc = reserve_small(vsi, blk_cnt, resrvd);
+	/* Reserve from the largest extent or a small extent */
+	rc = reserve_single(vsi, blk_cnt, resrvd);
 	if (rc != 0)
 		goto error;
 	else if (resrvd->vre_blk_cnt != 0)
@@ -366,19 +349,18 @@ process_resrvd_list(struct vea_space_info *vsi, struct vea_hint_context *hint,
 		    d_list_t *resrvd_list, bool publish)
 {
 	struct vea_resrvd_ext	*resrvd, *tmp;
-	struct vea_free_extent vfe = {0};
+	struct vea_free_extent	 vfe;
 	uint64_t		 seq_max = 0, seq_min = 0;
 	uint64_t		 off_c = 0, off_p = 0;
-	uint32_t		 cur_age;
 	unsigned int		 seq_cnt = 0;
 	int			 rc = 0;
 
 	if (d_list_empty(resrvd_list))
 		return 0;
 
-	cur_age = get_current_age();
 	vfe.vfe_blk_off = 0;
 	vfe.vfe_blk_cnt = 0;
+	vfe.vfe_age = 0;	/* Not used */
 
 	d_list_for_each_entry(resrvd, resrvd_list, vre_link) {
 		rc = verify_resrvd_ext(resrvd);
@@ -403,7 +385,6 @@ process_resrvd_list(struct vea_space_info *vsi, struct vea_hint_context *hint,
 		}
 
 		if (vfe.vfe_blk_cnt != 0) {
-			vfe.vfe_age = cur_age;
 			rc = publish ? persistent_alloc(vsi, &vfe) :
 				       compound_free(vsi, &vfe, 0);
 			if (rc)
@@ -415,7 +396,6 @@ process_resrvd_list(struct vea_space_info *vsi, struct vea_hint_context *hint,
 	}
 
 	if (vfe.vfe_blk_cnt != 0) {
-		vfe.vfe_age = cur_age;
 		rc = publish ? persistent_alloc(vsi, &vfe) :
 			       compound_free(vsi, &vfe, 0);
 		if (rc)

--- a/src/vea/vea_free.c
+++ b/src/vea/vea_free.c
@@ -15,80 +15,104 @@ enum vea_free_type {
 	VEA_TYPE_PERSIST,
 };
 
-static d_list_t *
-blkcnt_to_lru(struct vea_free_class *vfc, uint32_t blkcnt)
-{
-	int idx;
-
-	D_ASSERTF(blkcnt <= vfc->vfc_sizes[0], "%u, %u\n",
-		  blkcnt, vfc->vfc_sizes[0]);
-	D_ASSERT(vfc->vfc_lru_cnt > 0);
-
-	for (idx = 0; idx < (vfc->vfc_lru_cnt - 1); idx++) {
-		if (blkcnt > vfc->vfc_sizes[idx + 1])
-			break;
-	}
-
-	return &vfc->vfc_lrus[idx];
-}
-
 void
 free_class_remove(struct vea_space_info *vsi, struct vea_entry *entry)
 {
-	struct vea_free_class *vfc = &vsi->vsi_class;
+	struct vea_free_class	*vfc = &vsi->vsi_class;
+	struct vea_sized_class	*sc = entry->ve_sized_class;
+	uint32_t		 blk_cnt = entry->ve_ext.vfe_blk_cnt;
 
-	if (entry->ve_in_heap) {
-		D_ASSERTF(entry->ve_ext.vfe_blk_cnt > vfc->vfc_large_thresh,
-			  "%u <= %u", entry->ve_ext.vfe_blk_cnt,
-			  vfc->vfc_large_thresh);
+	if (sc == NULL) {
+		D_ASSERTF(blk_cnt > vfc->vfc_large_thresh, "%u <= %u",
+			  blk_cnt, vfc->vfc_large_thresh);
+		D_ASSERT(d_list_empty(&entry->ve_link));
+
 		d_binheap_remove(&vfc->vfc_heap, &entry->ve_node);
-		entry->ve_in_heap = 0;
 		dec_stats(vsi, STAT_FRAGS_LARGE, 1);
 	} else {
+		d_iov_t		key;
+		uint64_t	int_key = blk_cnt;
+		int		rc;
+
+		D_ASSERTF(blk_cnt > 0 && blk_cnt <= vfc->vfc_large_thresh,
+			  "%u > %u", blk_cnt, vfc->vfc_large_thresh);
+		D_ASSERT(daos_handle_is_valid(vfc->vfc_size_btr));
+
+		d_list_del_init(&entry->ve_link);
+		entry->ve_sized_class = NULL;
+		/* Remove the sized class when it's empty */
+		if (d_list_empty(&sc->vsc_lru)) {
+			d_iov_set(&key, &int_key, sizeof(int_key));
+			rc = dbtree_delete(vfc->vfc_size_btr, BTR_PROBE_EQ, &key, NULL);
+			if (rc)
+				D_ERROR("Remove size class:%u failed, "DF_RC"\n",
+					blk_cnt, DP_RC(rc));
+		}
 		dec_stats(vsi, STAT_FRAGS_SMALL, 1);
 	}
-	d_list_del_init(&entry->ve_link);
 }
 
 int
 free_class_add(struct vea_space_info *vsi, struct vea_entry *entry)
 {
-	struct vea_free_class *vfc = &vsi->vsi_class;
-	int rc;
+	struct vea_free_class	*vfc = &vsi->vsi_class;
+	daos_handle_t		 btr_hdl = vfc->vfc_size_btr;
+	uint32_t		 blk_cnt = entry->ve_ext.vfe_blk_cnt;
+	d_iov_t			 key, val, val_out;
+	uint64_t		 int_key = blk_cnt;
+	struct vea_sized_class	 dummy, *sc;
+	int			 rc;
 
-	D_ASSERT(entry->ve_in_heap == 0);
+	D_ASSERT(entry->ve_sized_class == NULL);
 	D_ASSERT(d_list_empty(&entry->ve_link));
 
 	/* Add to heap if it's a large free extent */
-	if (entry->ve_ext.vfe_blk_cnt > vfc->vfc_large_thresh) {
+	if (blk_cnt > vfc->vfc_large_thresh) {
 		rc = d_binheap_insert(&vfc->vfc_heap, &entry->ve_node);
 		if (rc != 0) {
 			D_ERROR("Failed to insert heap: %d\n", rc);
 			return rc;
 		}
 
-		entry->ve_in_heap = 1;
 		inc_stats(vsi, STAT_FRAGS_LARGE, 1);
-	} else { /* Otherwise add to one of size categarized LRU */
-		struct vea_entry *cur;
-		d_list_t *lru_head, *tmp;
-
-		lru_head = blkcnt_to_lru(vfc, entry->ve_ext.vfe_blk_cnt);
-
-		/* List is sorted by free extent age */
-		d_list_for_each_prev(tmp, lru_head) {
-			cur = d_list_entry(tmp, struct vea_entry, ve_link);
-
-			if (entry->ve_ext.vfe_age >= cur->ve_ext.vfe_age) {
-				d_list_add(&entry->ve_link, tmp);
-				break;
-			}
-		}
-		if (d_list_empty(&entry->ve_link))
-			d_list_add(&entry->ve_link, lru_head);
-		inc_stats(vsi, STAT_FRAGS_SMALL, 1);
+		return 0;
 	}
 
+	/* Add to a sized class */
+	D_ASSERT(daos_handle_is_valid(btr_hdl));
+	d_iov_set(&key, &int_key, sizeof(int_key));
+	d_iov_set(&val_out, NULL, 0);
+
+	rc = dbtree_fetch(btr_hdl, BTR_PROBE_EQ, DAOS_INTENT_DEFAULT, &key, NULL, &val_out);
+	if (rc == 0) {
+		/* Found an existing sized class */
+		sc = (struct vea_sized_class *)val_out.iov_buf;
+		D_ASSERT(sc != NULL);
+		D_ASSERT(!d_list_empty(&sc->vsc_lru));
+	} else if (rc == -DER_NONEXIST) {
+		/* Create a new sized class */
+		d_iov_set(&val, &dummy, sizeof(dummy));
+		d_iov_set(&val_out, NULL, 0);
+
+		rc = dbtree_upsert(btr_hdl, BTR_PROBE_BYPASS, DAOS_INTENT_UPDATE, &key, &val,
+				   &val_out);
+		if (rc != 0) {
+			D_ERROR("Insert size class:%u failed. "DF_RC"\n",
+				blk_cnt, DP_RC(rc));
+			return rc;
+		}
+		sc = (struct vea_sized_class *)val_out.iov_buf;
+		D_ASSERT(sc != NULL);
+		D_INIT_LIST_HEAD(&sc->vsc_lru);
+	} else {
+		D_ERROR("Lookup size class:%u failed. "DF_RC"\n", blk_cnt, DP_RC(rc));
+		return rc;
+	}
+
+	entry->ve_sized_class = sc;
+	d_list_add_tail(&entry->ve_link, &sc->vsc_lru);
+
+	inc_stats(vsi, STAT_FRAGS_SMALL, 1);
 	return 0;
 }
 
@@ -361,7 +385,7 @@ persistent_free(struct vea_space_info *vsi, struct vea_free_extent *vfe)
 
 	memset(&dummy, 0, sizeof(dummy));
 	dummy = *vfe;
-	dummy.vfe_age = VEA_EXT_AGE_MAX;
+	dummy.vfe_age = 0; /* Not used */
 
 	/* Add to persistent free extent tree */
 	D_ASSERT(daos_handle_is_valid(btr_hdl));

--- a/src/vea/vea_init.c
+++ b/src/vea/vea_init.c
@@ -7,25 +7,18 @@
 
 #include <daos/common.h>
 #include <daos/dtx.h>
+#include <daos/btree_class.h>
 #include "vea_internal.h"
 
 void
 destroy_free_class(struct vea_free_class *vfc)
 {
-	vfc->vfc_lru_cnt = 0;
+	/* Destroy the in-memory sized free extent tree */
+	if (daos_handle_is_valid(vfc->vfc_size_btr)) {
+		dbtree_destroy(vfc->vfc_size_btr, NULL);
+		vfc->vfc_size_btr = DAOS_HDL_INVAL;
+	}
 
-	if (vfc->vfc_cursor) {
-		D_FREE(vfc->vfc_cursor);
-		vfc->vfc_cursor = NULL;
-	}
-	if (vfc->vfc_lrus) {
-		D_FREE(vfc->vfc_lrus);
-		vfc->vfc_lrus = NULL;
-	}
-	if (vfc->vfc_sizes) {
-		D_FREE(vfc->vfc_sizes);
-		vfc->vfc_sizes = NULL;
-	}
 	d_binheap_destroy_inplace(&vfc->vfc_heap);
 }
 
@@ -50,64 +43,26 @@ struct d_binheap_ops heap_ops = {
 int
 create_free_class(struct vea_free_class *vfc, struct vea_space_df *md)
 {
-	uint32_t max_blks, min_blks;
-	int rc, i, lru_cnt, size;
+	struct umem_attr	uma;
+	int			rc;
 
+	vfc->vfc_size_btr = DAOS_HDL_INVAL;
 	rc = d_binheap_create_inplace(DBH_FT_NOLOCK, 0, NULL, &heap_ops,
 				      &vfc->vfc_heap);
 	if (rc != 0)
 		return -DER_NOMEM;
 
-	/*
-	 * Divide free extents smaller than VEA_LARGE_EXT_MB into bunch of
-	 * size classed groups, the size upper bound of each group will be
-	 * max_blks, max_blks/2, max_blks/4 ... min_blks.
-	 */
 	D_ASSERT(md->vsd_blk_sz > 0 && md->vsd_blk_sz <= (1U << 20));
-	max_blks = (VEA_LARGE_EXT_MB << 20) / md->vsd_blk_sz;
-	min_blks = (1U << 20) / md->vsd_blk_sz;
+	vfc->vfc_large_thresh = (VEA_LARGE_EXT_MB << 20) / md->vsd_blk_sz;
 
-	vfc->vfc_large_thresh = max_blks;
-	lru_cnt = 1;
-	while (max_blks > min_blks) {
-		max_blks >>= 1;
-		lru_cnt++;
-	}
+	memset(&uma, 0, sizeof(uma));
+	uma.uma_id = UMEM_CLASS_VMEM;
+	/* Create in-memory sized free extent tree */
+	rc = dbtree_create(DBTREE_CLASS_IV, BTR_FEAT_UINT_KEY, VEA_TREE_ODR,
+			   &uma, NULL, &vfc->vfc_size_btr);
+	if (rc != 0)
+		destroy_free_class(vfc);
 
-	D_ASSERT(vfc->vfc_lrus == NULL);
-	D_ALLOC_ARRAY(vfc->vfc_lrus, lru_cnt);
-	if (vfc->vfc_lrus == NULL) {
-		rc = -DER_NOMEM;
-		goto error;
-	}
-
-	D_ASSERT(vfc->vfc_sizes == NULL);
-	D_ALLOC_ARRAY(vfc->vfc_sizes, lru_cnt);
-	if (vfc->vfc_sizes == NULL) {
-		rc = -DER_NOMEM;
-		goto error;
-	}
-
-	max_blks = vfc->vfc_large_thresh;
-	for (i = 0; i < lru_cnt; i++) {
-		D_INIT_LIST_HEAD(&vfc->vfc_lrus[i]);
-		vfc->vfc_sizes[i] = max_blks > min_blks ? max_blks : min_blks;
-		max_blks >>= 1;
-	}
-	D_ASSERT(vfc->vfc_lru_cnt == 0);
-	vfc->vfc_lru_cnt = lru_cnt;
-
-	D_ASSERT(vfc->vfc_cursor == NULL);
-	size = lru_cnt * sizeof(struct vea_entry *);
-	D_ALLOC_ARRAY(vfc->vfc_cursor, size);
-	if (vfc->vfc_cursor == NULL) {
-		rc = -DER_NOMEM;
-		goto error;
-	}
-
-	return 0;
-error:
-	destroy_free_class(vfc);
 	return rc;
 }
 

--- a/src/vea/vea_internal.h
+++ b/src/vea/vea_internal.h
@@ -14,6 +14,8 @@
 #include <daos_srv/vea.h>
 
 #define VEA_MAGIC	(0xea201804)
+#define VEA_BLK_SZ	(4 * 1024)	/* 4K */
+#define VEA_TREE_ODR	20
 
 /* Per I/O stream hint context */
 struct vea_hint_context {
@@ -30,51 +32,36 @@ struct vea_entry {
 	 * Always keep it as first item, since vfe_blk_off is the direct key
 	 * of DBTREE_CLASS_IV
 	 */
-	struct vea_free_extent	ve_ext;
-	/* Link to one of vfc_lrus or vsi_agg_lru */
-	d_list_t		ve_link;
+	struct vea_free_extent   ve_ext;
+	/* Link to one of vsc_lru or vsi_agg_lru */
+	d_list_t		 ve_link;
+	/* Back reference to sized tree entry */
+	struct vea_sized_class	*ve_sized_class;
 	/* Link to vfc_heap */
-	struct d_binheap_node	ve_node;
-	uint32_t		ve_in_heap:1;
+	struct d_binheap_node	 ve_node;
 };
 
 #define VEA_LARGE_EXT_MB	64	/* Large extent threshold in MB */
 #define VEA_HINT_OFF_INVAL	0	/* Invalid hint offset */
 #define VEA_MIGRATE_INTVL	10	/* Seconds */
 
-struct free_ext_cursor {
-	struct vea_entry	*fec_cur;
-	int			 fec_idx;
-	int			 fec_entry_cnt;
-	struct vea_entry	*fec_entries[0];
+/* Value entry of sized free extent tree (vfc_size_btr) */
+struct vea_sized_class {
+	/* Small extents LRU list */
+	d_list_t		vsc_lru;
 };
 
 /*
- * Large free extents (>=VEA_LARGE_EXT_MB) are tracked in max a heap, small
- * free extents (< VEA_LARGE_EXT_MB) are tracked in size categorized LRUs
- * respectively.
+ * Large free extents (>VEA_LARGE_EXT_MB) are tracked in max a heap, small
+ * free extents (<= VEA_LARGE_EXT_MB) are tracked in a size tree.
  */
 struct vea_free_class {
 	/* Max heap for tracking the largest free extent */
-	struct d_binheap	 vfc_heap;
+	struct d_binheap	vfc_heap;
+	/* Small free extent tree */
+	daos_handle_t		vfc_size_btr;
 	/* Size threshold for large extent */
-	uint32_t		 vfc_large_thresh;
-	/* How many size classed LRUs for small free extents */
-	uint32_t		 vfc_lru_cnt;
-	/* Extent size classed LRU lists  */
-	d_list_t		*vfc_lrus;
-	/*
-	 * Upper size (in blocks) bounds for all size classes. The lower size
-	 * bound of the size class is the upper bound of previous class (0 for
-	 * first class), so the size of each extent in a size class satisfies:
-	 * vfc_sizes[i + 1] < blk_cnt <= vfc_sizes[i].
-	 */
-	uint32_t		*vfc_sizes;
-	/*
-	 * Cursor used to scan the size classed LRUs when trying to reserve
-	 * from small extents.
-	 */
-	struct free_ext_cursor	*vfc_cursor;
+	uint32_t		vfc_large_thresh;
 };
 
 enum {
@@ -146,11 +133,6 @@ struct vea_space_info {
 	bool				 vsi_agg_scheduled;
 };
 
-static inline bool ext_is_idle(struct vea_free_extent *vfe)
-{
-	return vfe->vfe_age == VEA_EXT_AGE_MAX;
-}
-
 static inline uint32_t
 get_current_age(void)
 {
@@ -186,10 +168,8 @@ void inc_stats(struct vea_space_info *vsi, unsigned int type, uint64_t nr);
 int compound_vec_alloc(struct vea_space_info *vsi, struct vea_ext_vector *vec);
 int reserve_hint(struct vea_space_info *vsi, uint32_t blk_cnt,
 		 struct vea_resrvd_ext *resrvd);
-int reserve_large(struct vea_space_info *vsi, uint32_t blk_cnt,
-		  struct vea_resrvd_ext *resrvd);
-int reserve_small(struct vea_space_info *vsi, uint32_t blk_cnt,
-		  struct vea_resrvd_ext *resrvd);
+int reserve_single(struct vea_space_info *vsi, uint32_t blk_cnt,
+		   struct vea_resrvd_ext *resrvd);
 int reserve_vector(struct vea_space_info *vsi, uint32_t blk_cnt,
 		   struct vea_resrvd_ext *resrvd);
 int persistent_alloc(struct vea_space_info *vsi, struct vea_free_extent *vfe);


### PR DESCRIPTION
To reduce fragmentations and make VEA more scalable when the space is
very fragmented, the original reserving from small extents is changed
from first-fit to best-fit, consequently, the way of tracking small
extents is changed from a LRU array with few fixed size classes into
a size classed LRU tree. (at most 16k size classes in the tree).

Signed-off-by: Niu Yawei <yawei.niu@intel.com>