### PR TITLE
DAOS-8640 dfuse: Disable readahead if write-back cache is used.

### DIFF
--- a/src/client/dfuse/ops/read.c
+++ b/src/client/dfuse/ops/read.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2021 Intel Corporation.
+ * (C) Copyright 2016-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -83,7 +83,8 @@ dfuse_cb_read(fuse_req_t req, fuse_ino_t ino, size_t len, off_t position,
 	}
 
 	if (readahead) {
-		buff_len += READAHEAD_SIZE;
+		if (!fs_handle->dpi_info->di_wb_cache)
+			buff_len += READAHEAD_SIZE;
 	} else {
 		if (!skip_read) {
 			rc = daos_event_init(&ev->de_ev,

--- a/src/tests/ftest/erasurecode/rebuild_fio.py
+++ b/src/tests/ftest/erasurecode/rebuild_fio.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 '''
-  (C) Copyright 2019-2021 Intel Corporation.
+  (C) Copyright 2019-2022 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
@@ -83,7 +83,6 @@ class EcodFioRebuild(ErasureCodeFio):
         """
         self.execution('on-line')
 
-    @skipForTicket("DAOS-8640")
     def test_ec_offline_rebuild_fio(self):
         """Jira ID: DAOS-7320.
 


### PR DESCRIPTION
Do not use readahead at the same time as write-back cache as there's
no way of knowing if the kerne has data for the region.

Test-tag: ec_offline_rebuild_fio

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>
