### PR TITLE
DAOS-9687 test: Remove sudo from docker and fault injection tests.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -888,8 +888,9 @@ pipeline {
                             filename 'utils/docker/Dockerfile.centos.7'
                             label 'docker_runner'
                             additionalBuildArgs dockerBuildArgs(repo_type: 'stable',
+                                                                parallel_build: true,
                                                                 deps_build: true)
-                            args '--tmpfs /mnt/daos_0'
+                            args '--tmpfs /mnt/daos_0 --user root:root'
                         }
                     }
                     steps {

--- a/utils/docker/Dockerfile.centos.7
+++ b/utils/docker/Dockerfile.centos.7
@@ -99,7 +99,6 @@ RUN useradd --no-log-init --uid $UID --user-group --create-home --shell /bin/bas
 RUN echo "daos_server:daos_server" | chpasswd
 RUN useradd --no-log-init --user-group --create-home --shell /bin/bash daos_agent
 RUN echo "daos_agent:daos_agent" | chpasswd
-RUN echo "daos_server ALL=(root) NOPASSWD: ALL" >> /etc/sudoers.d/daos_sudo_setup
 
 # Create directory for DAOS backend storage
 RUN mkdir -p /opt/daos /mnt/daos /var/run/daos_server /var/run/daos_agent &&   \

--- a/utils/docker_nlt.sh
+++ b/utils/docker_nlt.sh
@@ -29,7 +29,7 @@ popd
 
 cp "$TMP_DIR"/*.json .
 cp "$TMP_DIR"/*.xml .
-sudo chmod -R o+r "$TMP_DIR"/nlt_logs
+chmod -R o+r "$TMP_DIR"/nlt_logs
 cp -r "$TMP_DIR"/nlt_logs .
 
 exit $RC

--- a/utils/docker_nlt.sh
+++ b/utils/docker_nlt.sh
@@ -10,7 +10,7 @@ set -x
 
 . utils/sl/setup_local.sh
 
-sudo --preserve-env=SL_PREFIX,SL_SPDK_PREFIX ./utils/setup_daos_admin.sh
+./utils/setup_daos_admin.sh
 
 TMP_DIR=$(mktemp -d)
 
@@ -21,7 +21,7 @@ pushd "$TMP_DIR"
 
 set +e
 
-sudo ./node_local_test.py --no-root --memcheck no --server-debug WARN "$@"
+./node_local_test.py --no-root --memcheck no --server-debug WARN "$@"
 
 RC=$?
 set -e

--- a/utils/scripts/install-centos7.sh
+++ b/utils/scripts/install-centos7.sh
@@ -67,7 +67,6 @@ dnf -y install \
     python36-PyYAML \
     python36-scons \
     sg3_utils \
-    sudo \
     valgrind-devel \
     yasm
 dnf clean all


### PR DESCRIPTION
Skip-checkpatch: true
Skip-python-bandit: true
Skip-build-centos7-rpm: true
Skip-build-centos8-rpm: true
Skip-build-leap15-icc: true
Skip-build-ubuntu20-rpm: true
Skip-build-leap15-rpm: true
Skip-build-centos7: true
Skip-unit-tests: true
Skip-func-test-el8: true
Skip-test-rpms: true
Skip-func-hw-test: true

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>
