### PR TITLE
DAOS-9693 doc: README contains wrong url links to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,14 +28,16 @@ information.
 The DAOS documentation is available [online](https://daos-stack.github.io/).
 
 This includes:
-* [DAOS Architecture Overview](https://daos-stack.github.io/overview/terminology/)
-* [Administration Guide](https://daos-stack.github.io/admin/hardware/) to install, manage
+* [DAOS Architecture Overview](https://daos-stack.github.io/latest/overview/terminology/)
+* [Administration Guide](https://daos-stack.github.io/latest/admin/hardware/) to install, manage
   and monitor a DAOS system.
-* [User Guide](https://daos-stack.github.io/user/container/) documenting the
+* [User Guide](https://daos-stack.github.io/latest/user/container/) documenting the
   DAOS native API, as well as the integration with POSIX, MPI-IO, HDF5, and Spark.
-* [Release Notes](https://daos-stack.github.io/release/releaseNote_v1_0/)
-  for the 1.0 release.
-* [Developer documentation](https://daos-stack.github.io/dev/development/)
+* [Release Notes](https://daos-stack.github.io/v1.2/release/releaseNote_v1_0/)
+  for the 1.0 release;  
+  [Release Notes](https://daos-stack.github.io/latest/release/release_notes/)
+  for the latest stable release
+* [Developer documentation](https://daos-stack.github.io/latest/dev/development/)
   to learn more about DAOS internals and contribute to the development effort.
 
 More information can also be found on the [wiki](http://wiki.daos.io).


### PR DESCRIPTION
Five links in the README are broken. Just to make an example:
https://daos-stack.github.io/overview/terminology/ points to a 404 page.
The problem seems to be that in the links that point to the docs,
one should pass an alias (e.g. latest or dev before the endpoints,
except for the one with the root url doc which is not affected by
that as the alias seems automatically added when clicking it).
This patch fixes these five broken links by adding the "latest" alias
under the assumption that the user will be redirected to the latest
stable release of the documentation.
To make a concrete example, this means changing:
https://daos-stack.github.io/overview/terminology/ into
https://daos-stack.github.io/latest/overview/terminology/
and in this way the proper redirection works and one doesn't get 404
page anymore.
In addition, I added the right url redirect for the v1.x release notes
and the release notes link for the latest stable release.

Signed-off-by: Federico Padua <fgpadua@gmail.com>