### PR TITLE
DAOS-9380 dtx: do not retry RPC if DTX is committed by race

### DIFF
--- a/src/dtx/dtx_common.c
+++ b/src/dtx/dtx_common.c
@@ -784,6 +784,8 @@ dtx_handle_reinit(struct dtx_handle *dth)
 	dth->dth_touched_leader_oid = 0;
 	dth->dth_local_tx_started = 0;
 	dth->dth_cos_done = 0;
+	dth->dth_verified = 0;
+	dth->dth_aborted = 0;
 
 	dth->dth_op_seq = 0;
 	dth->dth_oid_cnt = 0;
@@ -835,6 +837,8 @@ dtx_handle_init(struct dtx_id *dti, daos_handle_t coh, struct dtx_epoch *epoch,
 	dth->dth_for_migration = migration ? 1 : 0;
 	dth->dth_ignore_uncommitted = ignore_uncommitted ? 1 : 0;
 	dth->dth_prepared = prepared ? 1 : 0;
+	dth->dth_verified = 0;
+	dth->dth_aborted = 0;
 
 	dth->dth_dti_cos = dti_cos;
 	dth->dth_dti_cos_count = dti_cos_cnt;
@@ -1146,15 +1150,25 @@ dtx_leader_end(struct dtx_leader_handle *dlh, struct ds_cont_child *cont,
 	 * should still wait for remote object to finish the request.
 	 */
 
-	if (dlh->dlh_sub_cnt != 0)
+	if (dlh->dlh_sub_cnt != 0) {
 		rc = dtx_leader_wait(dlh);
+		if (unlikely(rc == -DER_ALREADY))
+			rc = 0;
+	}
+
+	if (unlikely(result == -DER_ALREADY))
+		result = 0;
 
 	if (daos_is_zero_dti(&dth->dth_xid))
 		D_GOTO(out, result = result < 0 ? result : rc);
 
 	if (dth->dth_pinned || dth->dth_prepared) {
+		/* During waiting for bulk data transfer or other non-leaders, the DTX
+		 * status may be changes by others (such as DTX resync or DTX refresh)
+		 * by race. Let's check it.
+		 */
 		status = vos_dtx_validation(dth);
-		if (status == DTX_ST_COMMITTED || status == DTX_ST_COMMITTABLE)
+		if (unlikely(status == DTX_ST_COMMITTED || status == DTX_ST_COMMITTABLE))
 			D_GOTO(out, result = 0);
 	}
 
@@ -1166,10 +1180,9 @@ dtx_leader_end(struct dtx_leader_handle *dlh, struct ds_cont_child *cont,
 	case DTX_ST_PREPARED:
 		break;
 	case DTX_ST_INITED:
-		if (dth->dth_modification_cnt == 0 ||
-		    !dth->dth_active)
+		if (dth->dth_modification_cnt == 0 || !dth->dth_active)
 			break;
-		/* full through */
+		/* Fall through */
 	case DTX_ST_ABORTED:
 		D_GOTO(abort, result = -DER_INPROGRESS);
 	default:
@@ -1326,6 +1339,7 @@ out:
 			vos_dtx_cleanup(dth);
 
 		vos_dtx_rsrvd_fini(dth);
+		vos_dtx_detach(dth);
 
 		D_DEBUG(DB_IO,
 			"Stop the DTX "DF_DTI" ver %u, dkey %lu, %s, "
@@ -1455,6 +1469,7 @@ dtx_end(struct dtx_handle *dth, struct ds_cont_child *cont, int result)
 	D_ASSERTF(result <= 0, "unexpected return value %d\n", result);
 
 	vos_dtx_rsrvd_fini(dth);
+	vos_dtx_detach(dth);
 
 out:
 	D_FREE(dth->dth_oid_array);

--- a/src/include/daos_srv/dtx_srv.h
+++ b/src/include/daos_srv/dtx_srv.h
@@ -81,6 +81,10 @@ struct dtx_handle {
 					 dth_for_migration:1,
 					 /* Has prepared locally, for resend. */
 					 dth_prepared:1,
+					 /* The DTX handle has been verified. */
+					 dth_verified:1,
+					 /* The DTX handle is aborted. */
+					 dth_aborted:1,
 					 /* Ignore other uncommitted DTXs. */
 					 dth_ignore_uncommitted:1;
 

--- a/src/include/daos_srv/vos.h
+++ b/src/include/daos_srv/vos.h
@@ -38,13 +38,21 @@ void
 vos_dtx_rsrvd_fini(struct dtx_handle *dth);
 
 /**
- * Generate DTX entry for the given DTX.
+ * Generate DTX entry for the given DTX, and attach it to the DTX handle.
  *
  * \param dth		[IN]	The dtx handle
  * \param persistent	[IN]	Save the DTX entry in persistent storage if set.
  */
 int
-vos_dtx_pin(struct dtx_handle *dth, bool persistent);
+vos_dtx_attach(struct dtx_handle *dth, bool persistent);
+
+/**
+ * Detach the DTX entry from the DTX handle.
+ *
+ * \param dth		[IN]	The dtx handle
+ */
+void
+vos_dtx_detach(struct dtx_handle *dth);
 
 /**
  * Check whether DTX entry attached to the DTX handle is still valid or not.

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -1691,7 +1691,7 @@ obj_local_rw(crt_rpc_t *rpc, struct obj_io_context *ioc,
 
 again:
 	if (pin) {
-		rc = vos_dtx_pin(dth, false);
+		rc = vos_dtx_attach(dth, false);
 		if (rc != 0)
 			return rc;
 	}
@@ -1707,7 +1707,7 @@ again:
 			 * that will avoid race with the resent RPC during the
 			 * DTX refresh.
 			 */
-			rc1 = vos_dtx_pin(dth, false);
+			rc1 = vos_dtx_attach(dth, false);
 			if (rc1 != 0)
 				return -DER_INPROGRESS;
 		}
@@ -3151,7 +3151,7 @@ obj_local_punch(struct obj_punch_in *opi, crt_opcode_t opc,
 
 again:
 	if (pin) {
-		rc = vos_dtx_pin(dth, false);
+		rc = vos_dtx_attach(dth, false);
 		if (rc != 0)
 			return rc;
 	}
@@ -3199,7 +3199,7 @@ again:
 			 * that will avoid race with the resent RPC during the
 			 * DTX refresh.
 			 */
-			rc1 = vos_dtx_pin(dth, false);
+			rc1 = vos_dtx_attach(dth, false);
 			if (rc1 != 0)
 				return -DER_INPROGRESS;
 		}
@@ -4206,7 +4206,7 @@ ds_cpd_handle_one_wrap(crt_rpc_t *rpc, struct daos_cpd_sub_head *dcsh,
 
 again:
 	if (pin) {
-		rc = vos_dtx_pin(dth, false);
+		rc = vos_dtx_attach(dth, false);
 		if (rc != 0)
 			return rc;
 	}
@@ -4220,7 +4220,7 @@ again:
 		if (!dth->dth_pinned) {
 			int	rc1;
 
-			rc1 = vos_dtx_pin(dth, false);
+			rc1 = vos_dtx_attach(dth, false);
 			if (rc1 != 0)
 				return -DER_INPROGRESS;
 		}
@@ -4311,7 +4311,7 @@ ds_obj_dtx_follower(crt_rpc_t *rpc, struct obj_io_context *ioc)
 	 * generate DTX entry for DTX recovery. Similarly for noop case.
 	 */
 	if (rc == 0 && (dth->dth_modification_cnt == 0 || !dth->dth_active))
-		rc = vos_dtx_pin(dth, true);
+		rc = vos_dtx_attach(dth, true);
 
 	rc = dtx_end(dth, ioc->ioc_coc, rc);
 

--- a/src/vos/tests/vts_dtx.c
+++ b/src/vos/tests/vts_dtx.c
@@ -66,6 +66,8 @@ vts_dtx_begin(const daos_unit_oid_t *oid, daos_handle_t coh, daos_epoch_t epoch,
 	dth->dth_for_migration = 0;
 	dth->dth_ignore_uncommitted = 0;
 	dth->dth_prepared = 0;
+	dth->dth_verified = 0;
+	dth->dth_aborted = 0;
 
 	dth->dth_dti_cos_count = 0;
 	dth->dth_dti_cos = NULL;
@@ -122,6 +124,7 @@ vts_dtx_end(struct dtx_handle *dth)
 	}
 
 	vos_dtx_rsrvd_fini(dth);
+	vos_dtx_detach(dth);
 	D_FREE(dth->dth_dte.dte_mbs);
 	D_FREE_PTR(dth);
 }

--- a/src/vos/vos_internal.h
+++ b/src/vos/vos_internal.h
@@ -252,6 +252,8 @@ struct vos_dtx_act_ent {
 	daos_epoch_t			 dae_start_time;
 	/* Link into container::vc_dtx_act_list. */
 	d_list_t			 dae_link;
+	/* Back pointer to the DTX handle. */
+	struct dtx_handle		*dae_dth;
 
 	unsigned int			 dae_committable:1,
 					 dae_committed:1,


### PR DESCRIPTION
master-commit: 746f1936c70c6e13ec4bc7a5423507b9bab46a4a

During current IO handler ULT waits for bulk data transfer or other
non-leaders (for leader case), the DTX status may be changes by other
(such as DTX resync or refresh) by race. If the DTX has been prepared
or committed under such case, then just handle it as done instead of
retrying related RPC.

Signed-off-by: Fan Yong <fan.yong@intel.com>