### PR TITLE
DAOS-9658 dtx: avoid removing DTX entry belong to other

### DIFF
--- a/src/dtx/dtx_common.c
+++ b/src/dtx/dtx_common.c
@@ -778,6 +778,7 @@ dtx_handle_reinit(struct dtx_handle *dth)
 {
 	D_ASSERT(dth->dth_ent == NULL);
 	D_ASSERT(dth->dth_pinned == 0);
+	D_ASSERT(dth->dth_already == 0);
 
 	dth->dth_modify_shared = 0;
 	dth->dth_active = 0;
@@ -839,6 +840,7 @@ dtx_handle_init(struct dtx_id *dti, daos_handle_t coh, struct dtx_epoch *epoch,
 	dth->dth_prepared = prepared ? 1 : 0;
 	dth->dth_verified = 0;
 	dth->dth_aborted = 0;
+	dth->dth_already = 0;
 
 	dth->dth_dti_cos = dti_cos;
 	dth->dth_dti_cos_count = dti_cos_cnt;
@@ -1184,7 +1186,8 @@ dtx_leader_end(struct dtx_leader_handle *dlh, struct ds_cont_child *cont,
 			break;
 		/* Fall through */
 	case DTX_ST_ABORTED:
-		D_GOTO(abort, result = -DER_INPROGRESS);
+		aborted = true;
+		D_GOTO(out, result = -DER_INPROGRESS);
 	default:
 		D_ASSERT(0);
 	}

--- a/src/dtx/dtx_rpc.c
+++ b/src/dtx/dtx_rpc.c
@@ -196,7 +196,7 @@ dtx_req_cb(const struct crt_cb_info *cb_info)
 			/* The leader does not have related DTX info, we may miss related DTX abort
 			 * request, let's abort it locally.
 			 */
-			rc1 = vos_dtx_abort(dra->dra_cont->sc_hdl, &dsp->dsp_xid, DAOS_EPOCH_MAX);
+			rc1 = vos_dtx_abort(dra->dra_cont->sc_hdl, &dsp->dsp_xid, dsp->dsp_epoch);
 			if (rc1 < 0 && rc1 != -DER_NONEXIST && dra->dra_abt_list != NULL)
 				d_list_add_tail(&dsp->dsp_link, dra->dra_abt_list);
 			else

--- a/src/include/daos_srv/dtx_srv.h
+++ b/src/include/daos_srv/dtx_srv.h
@@ -85,6 +85,8 @@ struct dtx_handle {
 					 dth_verified:1,
 					 /* The DTX handle is aborted. */
 					 dth_aborted:1,
+					 /* The modification is done by others. */
+					 dth_already:1,
 					 /* Ignore other uncommitted DTXs. */
 					 dth_ignore_uncommitted:1;
 

--- a/src/vos/evtree.c
+++ b/src/vos/evtree.c
@@ -1233,7 +1233,7 @@ evt_desc_log_status(struct evt_context *tcx, daos_epoch_t epoch,
 	}
 }
 
-int
+static int
 evt_desc_log_add(struct evt_context *tcx, struct evt_desc *desc)
 {
 	struct evt_desc_cbs *cbs = &tcx->tc_desc_cbs;

--- a/src/vos/ilog.c
+++ b/src/vos/ilog.c
@@ -918,11 +918,8 @@ ilog_modify(daos_handle_t loh, const struct ilog_id *id_in,
 		D_ASSERTF(id_in->id_epoch != 0, "epoch "DF_U64" opc %d\n",
 			  id_in->id_epoch, opc);
 		rc = ilog_ptr_set(lctx, root, &tmp);
-		if (rc != 0)
-			goto done;
-		rc = ilog_log_add(lctx, &root->lr_id);
-		if (rc != 0)
-			goto done;
+		if (rc == 0)
+			rc = ilog_log_add(lctx, &root->lr_id);
 	} else if (root->lr_tree.it_embedded) {
 		bool	is_equal;
 

--- a/src/vos/tests/vts_dtx.c
+++ b/src/vos/tests/vts_dtx.c
@@ -68,6 +68,7 @@ vts_dtx_begin(const daos_unit_oid_t *oid, daos_handle_t coh, daos_epoch_t epoch,
 	dth->dth_prepared = 0;
 	dth->dth_verified = 0;
 	dth->dth_aborted = 0;
+	dth->dth_already = 0;
 
 	dth->dth_dti_cos_count = 0;
 	dth->dth_dti_cos = NULL;

--- a/src/vos/vos_ilog.c
+++ b/src/vos/vos_ilog.c
@@ -400,7 +400,7 @@ update:
 
 	ilog_close(loh);
 
-	if (rc == -DER_ALREADY) /* operation had no effect */
+	if (rc == -DER_ALREADY && (dth == NULL || !dth->dth_already)) /* operation had no effect */
 		rc = 0;
 done:
 	VOS_TX_LOG_FAIL(rc, "Could not update ilog %p at "DF_X64": "DF_RC"\n",
@@ -500,7 +500,7 @@ punch_log:
 
 	ilog_close(loh);
 
-	if (rc == -DER_ALREADY) /* operation had no effect */
+	if (rc == -DER_ALREADY && (dth == NULL || !dth->dth_already)) /* operation had no effect */
 		rc = 0;
 	VOS_TX_LOG_FAIL(rc, "Could not update incarnation log: "DF_RC"\n",
 			DP_RC(rc));


### PR DESCRIPTION
master-commit: 457df4db26438b6f73142652b2413f1990681b81

During current DTX leader waiting for non-leaders' reply,
someone (for resent rquest) may abort the DTX, that will
cause current DTX leader to do cleanup after the waiting,
such cleanup needs to avoid removing the new created DTX
entry (that belong to resent request) from the DTX table.

Drop unnecessary ASSERTION inside vos_dtx_register_record
for DTX entry validity check.

Do not abort current DTX if it has been always aborted by
other (for resent request) by race.

Signed-off-by: Fan Yong <fan.yong@intel.com>