### PR TITLE
DAOS-9254 test: Improve fault injection testing for fs copy.

### DIFF
--- a/utils/node_local_test.py
+++ b/utils/node_local_test.py
@@ -3984,8 +3984,14 @@ def test_alloc_fail_copy(server, conf, wf):
 
     pool = server.get_test_pool()
     src_dir = tempfile.TemporaryDirectory(prefix='copy_src_',)
-    with open(join(src_dir.name, 'file'), 'w') as ofd:
-        ofd.write('hello')
+    sub_dir = join(src_dir.name, 'new_dir')
+    os.mkdir(sub_dir)
+    for f in range(5):
+        with open(join(sub_dir, 'file.{}'.format(f)), 'w') as ofd:
+            ofd.write('hello')
+
+    os.symlink('broken', join(sub_dir, 'broken'))
+    os.symlink('new_dir/file.0', 'link')
 
     def get_cmd():
         container = str(uuid.uuid4())


### PR DESCRIPTION
Add directories and multiple files.

Skip-python-bandit: true

Skip-build-centos7-rpm: true
Skip-build-centos8-rpm: true
Skip-build-leap15-icc: true
Skip-build-ubuntu20-rpm: true
Skip-build-leap15-rpm: true

Skip-build-centos7-gcc : true

Skip-unit-tests: true
Skip-func-test-el8: true
Skip-test-rpms: true
Skip-func-hw-test: true

Parallel-build: true

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>
