### PR TITLE
DAOS-9658 dtx: avoid removing DTX entry belong to other

### DIFF
--- a/src/dtx/dtx_rpc.c
+++ b/src/dtx/dtx_rpc.c
@@ -196,7 +196,7 @@ dtx_req_cb(const struct crt_cb_info *cb_info)
 			/* The leader does not have related DTX info, we may miss related DTX abort
 			 * request, let's abort it locally.
 			 */
-			rc1 = vos_dtx_abort(dra->dra_cont->sc_hdl, &dsp->dsp_xid, DAOS_EPOCH_MAX);
+			rc1 = vos_dtx_abort(dra->dra_cont->sc_hdl, &dsp->dsp_xid, dsp->dsp_epoch);
 			if (rc1 < 0 && rc1 != -DER_NONEXIST && dra->dra_abt_list != NULL)
 				d_list_add_tail(&dsp->dsp_link, dra->dra_abt_list);
 			else

--- a/src/include/daos_srv/dtx_srv.h
+++ b/src/include/daos_srv/dtx_srv.h
@@ -81,6 +81,12 @@ struct dtx_handle {
 					 dth_for_migration:1,
 					 /* Has prepared locally, for resend. */
 					 dth_prepared:1,
+					 /* The DTX handle has been verified. */
+					 dth_verified:1,
+					 /* The DTX handle is aborted. */
+					 dth_aborted:1,
+					 /* The modification is done by others. */
+					 dth_already:1,
 					 /* Ignore other uncommitted DTXs. */
 					 dth_ignore_uncommitted:1;
 

--- a/src/include/daos_srv/vos.h
+++ b/src/include/daos_srv/vos.h
@@ -38,13 +38,21 @@ void
 vos_dtx_rsrvd_fini(struct dtx_handle *dth);
 
 /**
- * Generate DTX entry for the given DTX.
+ * Generate DTX entry for the given DTX, and attach it to the DTX handle.
  *
  * \param dth		[IN]	The dtx handle
  * \param persistent	[IN]	Save the DTX entry in persistent storage if set.
  */
 int
-vos_dtx_pin(struct dtx_handle *dth, bool persistent);
+vos_dtx_attach(struct dtx_handle *dth, bool persistent);
+
+/**
+ * Detach the DTX entry from the DTX handle.
+ *
+ * \param dth		[IN]	The dtx handle
+ */
+void
+vos_dtx_detach(struct dtx_handle *dth);
 
 /**
  * Check whether DTX entry attached to the DTX handle is still valid or not.

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -1691,7 +1691,7 @@ obj_local_rw(crt_rpc_t *rpc, struct obj_io_context *ioc,
 
 again:
 	if (pin) {
-		rc = vos_dtx_pin(dth, false);
+		rc = vos_dtx_attach(dth, false);
 		if (rc != 0)
 			return rc;
 	}
@@ -1707,7 +1707,7 @@ again:
 			 * that will avoid race with the resent RPC during the
 			 * DTX refresh.
 			 */
-			rc1 = vos_dtx_pin(dth, false);
+			rc1 = vos_dtx_attach(dth, false);
 			if (rc1 != 0)
 				return -DER_INPROGRESS;
 		}
@@ -2271,9 +2271,9 @@ ds_obj_tgt_update_handler(crt_rpc_t *rpc)
 
 	/* Handle resend. */
 	if (orw->orw_flags & ORF_RESEND) {
-		rc = dtx_handle_resend(ioc.ioc_vos_coh, &orw->orw_dti,
-				       &orw->orw_epoch, NULL);
+		daos_epoch_t	e = orw->orw_epoch;
 
+		rc = dtx_handle_resend(ioc.ioc_vos_coh, &orw->orw_dti, &e, NULL);
 		/* Do nothing if 'prepared' or 'committed'. */
 		if (rc == -DER_ALREADY || rc == 0)
 			D_GOTO(out, rc = 0);
@@ -2285,7 +2285,7 @@ ds_obj_tgt_update_handler(crt_rpc_t *rpc)
 			/* Abort it by force with MAX epoch to guarantee
 			 * that it can be aborted.
 			 */
-			rc = vos_dtx_abort(ioc.ioc_vos_coh, &orw->orw_dti, DAOS_EPOCH_MAX);
+			rc = vos_dtx_abort(ioc.ioc_vos_coh, &orw->orw_dti, e);
 
 		if (rc < 0 && rc != -DER_NONEXIST)
 			D_GOTO(out, rc);
@@ -3151,7 +3151,7 @@ obj_local_punch(struct obj_punch_in *opi, crt_opcode_t opc,
 
 again:
 	if (pin) {
-		rc = vos_dtx_pin(dth, false);
+		rc = vos_dtx_attach(dth, false);
 		if (rc != 0)
 			return rc;
 	}
@@ -3199,7 +3199,7 @@ again:
 			 * that will avoid race with the resent RPC during the
 			 * DTX refresh.
 			 */
-			rc1 = vos_dtx_pin(dth, false);
+			rc1 = vos_dtx_attach(dth, false);
 			if (rc1 != 0)
 				return -DER_INPROGRESS;
 		}
@@ -3238,9 +3238,9 @@ ds_obj_tgt_punch_handler(crt_rpc_t *rpc)
 
 	/* Handle resend. */
 	if (opi->opi_flags & ORF_RESEND) {
-		rc = dtx_handle_resend(ioc.ioc_vos_coh, &opi->opi_dti,
-				       &opi->opi_epoch, NULL);
+		daos_epoch_t	e = opi->opi_epoch;
 
+		rc = dtx_handle_resend(ioc.ioc_vos_coh, &opi->opi_dti, &e, NULL);
 		/* Do nothing if 'prepared' or 'committed'. */
 		if (rc == -DER_ALREADY || rc == 0)
 			D_GOTO(out, rc = 0);
@@ -3252,7 +3252,7 @@ ds_obj_tgt_punch_handler(crt_rpc_t *rpc)
 			/* Abort it by force with MAX epoch to guarantee
 			 * that it can be aborted.
 			 */
-			rc = vos_dtx_abort(ioc.ioc_vos_coh, &opi->opi_dti, DAOS_EPOCH_MAX);
+			rc = vos_dtx_abort(ioc.ioc_vos_coh, &opi->opi_dti, e);
 
 		if (rc < 0 && rc != -DER_NONEXIST)
 			D_GOTO(out, rc);
@@ -4206,7 +4206,7 @@ ds_cpd_handle_one_wrap(crt_rpc_t *rpc, struct daos_cpd_sub_head *dcsh,
 
 again:
 	if (pin) {
-		rc = vos_dtx_pin(dth, false);
+		rc = vos_dtx_attach(dth, false);
 		if (rc != 0)
 			return rc;
 	}
@@ -4220,7 +4220,7 @@ again:
 		if (!dth->dth_pinned) {
 			int	rc1;
 
-			rc1 = vos_dtx_pin(dth, false);
+			rc1 = vos_dtx_attach(dth, false);
 			if (rc1 != 0)
 				return -DER_INPROGRESS;
 		}
@@ -4241,6 +4241,7 @@ ds_obj_dtx_follower(crt_rpc_t *rpc, struct obj_io_context *ioc)
 	struct daos_cpd_sub_head	*dcsh = ds_obj_cpd_get_dcsh(rpc, 0);
 	struct daos_cpd_disp_ent	*dcde = ds_obj_cpd_get_dcde(rpc, 0, 0);
 	struct daos_cpd_sub_req		*dcsr = ds_obj_cpd_get_dcsr(rpc, 0);
+	daos_epoch_t			 e = dcsh->dcsh_epoch.oe_value;
 	uint32_t			 dtx_flags = DTX_DIST;
 	int				 rc = 0;
 	int				 rc1 = 0;
@@ -4252,9 +4253,7 @@ ds_obj_dtx_follower(crt_rpc_t *rpc, struct obj_io_context *ioc)
 	D_ASSERT(dcsh->dcsh_epoch.oe_value != DAOS_EPOCH_MAX);
 
 	if (oci->oci_flags & ORF_RESEND) {
-		rc1 = dtx_handle_resend(ioc->ioc_vos_coh, &dcsh->dcsh_xid,
-					&dcsh->dcsh_epoch.oe_value, NULL);
-
+		rc1 = dtx_handle_resend(ioc->ioc_vos_coh, &dcsh->dcsh_xid, &e, NULL);
 		/* Do nothing if 'prepared' or 'committed'. */
 		if (rc1 == -DER_ALREADY || rc1 == 0)
 			D_GOTO(out, rc = 0);
@@ -4284,8 +4283,7 @@ ds_obj_dtx_follower(crt_rpc_t *rpc, struct obj_io_context *ioc)
 		/* For resent RPC, abort it firstly if exist but with different
 		 * (old) epoch, then re-execute with new epoch.
 		 */
-		rc = vos_dtx_abort(ioc->ioc_vos_coh, &dcsh->dcsh_xid, DAOS_EPOCH_MAX);
-
+		rc = vos_dtx_abort(ioc->ioc_vos_coh, &dcsh->dcsh_xid, e);
 		if (rc < 0 && rc != -DER_NONEXIST)
 			D_GOTO(out, rc);
 		break;
@@ -4311,7 +4309,7 @@ ds_obj_dtx_follower(crt_rpc_t *rpc, struct obj_io_context *ioc)
 	 * generate DTX entry for DTX recovery. Similarly for noop case.
 	 */
 	if (rc == 0 && (dth->dth_modification_cnt == 0 || !dth->dth_active))
-		rc = vos_dtx_pin(dth, true);
+		rc = vos_dtx_attach(dth, true);
 
 	rc = dtx_end(dth, ioc->ioc_coc, rc);
 

--- a/src/vos/evtree.c
+++ b/src/vos/evtree.c
@@ -1233,7 +1233,7 @@ evt_desc_log_status(struct evt_context *tcx, daos_epoch_t epoch,
 	}
 }
 
-int
+static int
 evt_desc_log_add(struct evt_context *tcx, struct evt_desc *desc)
 {
 	struct evt_desc_cbs *cbs = &tcx->tc_desc_cbs;

--- a/src/vos/ilog.c
+++ b/src/vos/ilog.c
@@ -918,11 +918,8 @@ ilog_modify(daos_handle_t loh, const struct ilog_id *id_in,
 		D_ASSERTF(id_in->id_epoch != 0, "epoch "DF_U64" opc %d\n",
 			  id_in->id_epoch, opc);
 		rc = ilog_ptr_set(lctx, root, &tmp);
-		if (rc != 0)
-			goto done;
-		rc = ilog_log_add(lctx, &root->lr_id);
-		if (rc != 0)
-			goto done;
+		if (rc == 0)
+			rc = ilog_log_add(lctx, &root->lr_id);
 	} else if (root->lr_tree.it_embedded) {
 		bool	is_equal;
 

--- a/src/vos/tests/vts_dtx.c
+++ b/src/vos/tests/vts_dtx.c
@@ -66,6 +66,9 @@ vts_dtx_begin(const daos_unit_oid_t *oid, daos_handle_t coh, daos_epoch_t epoch,
 	dth->dth_for_migration = 0;
 	dth->dth_ignore_uncommitted = 0;
 	dth->dth_prepared = 0;
+	dth->dth_verified = 0;
+	dth->dth_aborted = 0;
+	dth->dth_already = 0;
 
 	dth->dth_dti_cos_count = 0;
 	dth->dth_dti_cos = NULL;
@@ -122,6 +125,7 @@ vts_dtx_end(struct dtx_handle *dth)
 	}
 
 	vos_dtx_rsrvd_fini(dth);
+	vos_dtx_detach(dth);
 	D_FREE(dth->dth_dte.dte_mbs);
 	D_FREE_PTR(dth);
 }

--- a/src/vos/vos_dtx.c
+++ b/src/vos/vos_dtx.c
@@ -36,6 +36,11 @@ enum {
 
 #define dtx_evict_lid(cont, dae)					\
 	do {								\
+		if (dae->dae_dth != NULL &&				\
+		    dae->dae_dth->dth_ent != NULL) {			\
+			D_ASSERT(dae->dae_dth->dth_ent == dae);		\
+			dae->dae_dth->dth_ent = NULL;			\
+		}							\
 		D_DEBUG(DB_TRACE, "Evicting lid "DF_DTI": lid=%d\n",	\
 			DP_DTI(&DAE_XID(dae)), DAE_LID(dae));		\
 		d_list_del_init(&dae->dae_link);			\
@@ -1006,6 +1011,8 @@ vos_dtx_alloc(struct vos_dtx_blob_df *dbd, struct dtx_handle *dth)
 	/* Will be set as dbd::dbd_index via vos_dtx_prepared(). */
 	DAE_INDEX(dae) = DTX_INDEX_INVAL;
 	dae->dae_dbd = dbd;
+	dae->dae_dth = dth;
+
 	D_DEBUG(DB_IO, "Allocated new lid DTX: "DF_DTI" lid=%d dae=%p"
 		" dae_dbd=%p\n", DP_DTI(&dth->dth_xid), DAE_LID(dae), dae, dbd);
 
@@ -1294,14 +1301,17 @@ uint32_t
 vos_dtx_get(void)
 {
 	struct dtx_handle	*dth = vos_dth_get();
-	struct vos_dtx_act_ent	*dae;
 
-	if (!dtx_is_valid_handle(dth) || dth->dth_ent == NULL)
+	if (!dtx_is_valid_handle(dth))
 		return DTX_LID_COMMITTED;
 
-	dae = dth->dth_ent;
+	if (unlikely(dth->dth_aborted))
+		return DTX_LID_ABORTED;
 
-	return DAE_LID(dae);
+	if (dth->dth_ent == NULL)
+		return DTX_LID_COMMITTED;
+
+	return DAE_LID((struct vos_dtx_act_ent *)dth->dth_ent);
 }
 
 int
@@ -1312,6 +1322,7 @@ vos_dtx_validation(struct dtx_handle *dth)
 
 	D_ASSERT(dtx_is_valid_handle(dth));
 
+	dth->dth_verified = 1;
 	dae = dth->dth_ent;
 
 	/* During current ULT waiting for some event, such as bulk data
@@ -1321,13 +1332,12 @@ vos_dtx_validation(struct dtx_handle *dth)
 	 * It is also possible that the DTX has been committed by other
 	 * (for resend), then return DTX_ST_COMMITTED.
 	 *
-	 * More cases, the DTX entry is aborted by other during current
-	 * ULT waiting. Then the DTX entry is recreated on the same (or
-	 * not) cache slot.
+	 * More cases, the DTX entry has been is aborted by other during
+	 * current ULT yield, and then the DTX was recreated on the same
+	 * (or different) DTX LRU array slot.
 	 */
 
-	if (dae == NULL /* resentc case */ ||
-	    !daos_dti_equal(&dth->dth_xid, &DAE_XID(dae))) {
+	if (unlikely(dae == NULL || dth->dth_aborted)) {
 		struct vos_container	*cont;
 		d_iov_t			 kiov;
 		d_iov_t			 riov;
@@ -1347,8 +1357,11 @@ vos_dtx_validation(struct dtx_handle *dth)
 
 		rc = dbtree_lookup(cont->vc_dtx_active_hdl, &kiov, &riov);
 		if (rc != 0) {
-			D_DEBUG(DB_IO, "DTX "DF_DTI" is aborted by race(1)\n",
-				DP_DTI(&dth->dth_xid));
+			/* Failed to lookup DTX entry, in spite of whether it is DER_NONEXIST
+			 * or not, then handle it as aborted that will cause client to retry.
+			 */
+			D_DEBUG(DB_IO, "DTX "DF_DTI" is aborted by race(1): "DF_RC"\n",
+				DP_DTI(&dth->dth_xid), DP_RC(rc));
 			return DTX_ST_ABORTED;
 		}
 
@@ -1373,7 +1386,7 @@ vos_dtx_validation(struct dtx_handle *dth)
 	if (dae->dae_prepared)
 		return DTX_ST_PREPARED;
 
-	return DTX_ST_INITED;
+	return dth->dth_aborted ? DTX_ST_ABORTED : DTX_ST_INITED;
 }
 
 /* The caller has started PMDK transaction. */
@@ -1399,7 +1412,7 @@ vos_dtx_register_record(struct umem_instance *umm, umem_off_t record,
 		return 0;
 	}
 
-	if (dth->dth_pinned) {
+	if (dth->dth_pinned && !dth->dth_verified) {
 		rc = vos_dtx_validation(dth);
 		switch (rc) {
 		case DTX_ST_INITED:
@@ -1407,11 +1420,16 @@ vos_dtx_register_record(struct umem_instance *umm, umem_off_t record,
 		case DTX_ST_PREPARED:
 		case DTX_ST_COMMITTED:
 		case DTX_ST_COMMITTABLE:
-			/* Prepared/committed (and may has been re-created
-			 * before that), return -DER_AGAIN for leader retry.
+			/* Aborted then prepared/committed by race.
+			 * Return -DER_ALREADY to avoid repeated modification.
+			 *
+			 * Reset current dth->dth_ent to bypass cleanup.
 			 */
-			D_GOTO(out, rc = -DER_AGAIN);
+			dth->dth_ent = NULL;
+			dth->dth_already = 1;
+			D_GOTO(out, rc = -DER_ALREADY);
 		case DTX_ST_ABORTED:
+			D_ASSERT(dth->dth_ent == NULL);
 			/* Aborted, return -DER_INPROGRESS for client retry. */
 			D_GOTO(out, rc = -DER_INPROGRESS);
 		default:
@@ -1470,10 +1488,9 @@ vos_dtx_register_record(struct umem_instance *umm, umem_off_t record,
 
 out:
 	D_DEBUG(DB_TRACE, "Register DTX record for "DF_DTI
-		": lid=%d entry %p, type %d, %s ilog entry, rc %d\n",
-		DP_DTI(&dth->dth_xid),
-		DAE_LID((struct vos_dtx_act_ent *)dth->dth_ent), dth->dth_ent,
-		type, dth->dth_modify_shared ? "has" : "has not", rc);
+		": lid=%d entry %p, type %d, %s ilog entry, rc %d\n", DP_DTI(&dth->dth_xid),
+		dth->dth_ent == NULL ? 0 : DAE_LID((struct vos_dtx_act_ent *)dth->dth_ent),
+		dth->dth_ent, type, dth->dth_modify_shared ? "has" : "has not", rc);
 
 	return rc;
 }
@@ -1788,14 +1805,14 @@ vos_dtx_check(daos_handle_t coh, struct dtx_id *dti, daos_epoch_t *epoch,
 		if (mbs != NULL)
 			dae->dae_maybe_shared = 1;
 
-		/* Leader has not finish the 'prepare' phase. */
 		if (dae->dae_dbd == NULL)
 			return -DER_INPROGRESS;
 
 		if (epoch != NULL) {
-			if (*epoch == 0)
-				*epoch = DAE_EPOCH(dae);
-			else if (*epoch != DAE_EPOCH(dae))
+			daos_epoch_t	e = *epoch;
+
+			*epoch = DAE_EPOCH(dae);
+			if (e != 0 && e != DAE_EPOCH(dae))
 				return -DER_MISMATCH;
 		}
 
@@ -2085,6 +2102,7 @@ vos_dtx_abort(daos_handle_t coh, struct dtx_id *dti, daos_epoch_t epoch)
 
 	cont = vos_hdl2cont(coh);
 	D_ASSERT(cont != NULL);
+	D_ASSERT(epoch != 0);
 
 	d_iov_set(&kiov, dti, sizeof(*dti));
 	d_iov_set(&riov, NULL, 0);
@@ -2104,7 +2122,7 @@ vos_dtx_abort(daos_handle_t coh, struct dtx_id *dti, daos_epoch_t epoch)
 	if (dae->dae_aborted)
 		D_GOTO(out, rc = -DER_ALREADY);
 
-	if (DAE_EPOCH(dae) > epoch)
+	if (epoch != DAOS_EPOCH_MAX && epoch != DAE_EPOCH(dae))
 		D_GOTO(out, rc = -DER_NONEXIST);
 
 	umm = vos_cont2umm(cont);
@@ -2112,6 +2130,16 @@ vos_dtx_abort(daos_handle_t coh, struct dtx_id *dti, daos_epoch_t epoch)
 	if (rc == 0) {
 		rc = dtx_rec_release(cont, dae, true);
 		rc = umem_tx_end(umm, rc);
+		if (rc == 0 && dae->dae_dth != NULL) {
+			struct dtx_handle	*dth = dae->dae_dth;
+
+			D_ASSERT(dth->dth_ent == dae || dth->dth_ent == NULL);
+
+			dae->dae_dth = NULL;
+			dth->dth_aborted = 1;
+			dtx_act_ent_cleanup(cont, dae, dth, true);
+			dth->dth_ent = NULL;
+		}
 	}
 
 out:
@@ -2655,6 +2683,10 @@ vos_dtx_cleanup_internal(struct dtx_handle *dth)
 			if (dae->dae_committable || dae->dae_committed)
 				goto out;
 
+			/* Skip the @dae if it belong to another instance for resent request. */
+			if (DAE_EPOCH(dae) != dth->dth_epoch)
+				goto out;
+
 			rc = dbtree_delete(cont->vc_dtx_active_hdl, BTR_PROBE_BYPASS, &kiov, &dae);
 			D_ASSERT(rc == 0);
 		}
@@ -2687,7 +2719,7 @@ vos_dtx_cleanup(struct dtx_handle *dth)
 		/* 'prepared' DTX can be either committed or aborted,
 		 * but not cleanup.
 		 */
-		if (dae->dae_prepared)
+		if (dae->dae_prepared || dae->dae_committable || dae->dae_committed)
 			return;
 	}
 
@@ -2700,7 +2732,7 @@ vos_dtx_cleanup(struct dtx_handle *dth)
 }
 
 int
-vos_dtx_pin(struct dtx_handle *dth, bool persistent)
+vos_dtx_attach(struct dtx_handle *dth, bool persistent)
 {
 	struct vos_container	*cont;
 	struct umem_instance	*umm = NULL;
@@ -2745,10 +2777,9 @@ vos_dtx_pin(struct dtx_handle *dth, bool persistent)
 
 	if (dth->dth_ent == NULL) {
 		rc = vos_dtx_alloc(dbd, dth);
-	} else {
+	} else if (dbd != NULL) {
 		struct vos_dtx_act_ent	*dae = dth->dth_ent;
 
-		D_ASSERT(dbd != NULL);
 		D_ASSERT(dbd->dbd_magic == DTX_ACT_BLOB_MAGIC);
 
 		dae->dae_df_off = cont->vc_cont_df->cd_dtx_active_tail +
@@ -2789,6 +2820,20 @@ out:
 	}
 
 	return rc;
+}
+
+void
+vos_dtx_detach(struct dtx_handle *dth)
+{
+	struct vos_dtx_act_ent	*dae = dth->dth_ent;
+
+	if (dae != NULL) {
+		D_ASSERT(dae->dae_dth == dth);
+
+		dae->dae_dth = NULL;
+		dth->dth_ent = NULL;
+	}
+	dth->dth_pinned = 0;
 }
 
 /** Allocate space for saving the vos reservations and deferred actions */

--- a/src/vos/vos_ilog.c
+++ b/src/vos/vos_ilog.c
@@ -400,7 +400,7 @@ update:
 
 	ilog_close(loh);
 
-	if (rc == -DER_ALREADY) /* operation had no effect */
+	if (rc == -DER_ALREADY && (dth == NULL || !dth->dth_already)) /* operation had no effect */
 		rc = 0;
 done:
 	VOS_TX_LOG_FAIL(rc, "Could not update ilog %p at "DF_X64": "DF_RC"\n",
@@ -500,7 +500,7 @@ punch_log:
 
 	ilog_close(loh);
 
-	if (rc == -DER_ALREADY) /* operation had no effect */
+	if (rc == -DER_ALREADY && (dth == NULL || !dth->dth_already)) /* operation had no effect */
 		rc = 0;
 	VOS_TX_LOG_FAIL(rc, "Could not update incarnation log: "DF_RC"\n",
 			DP_RC(rc));

--- a/src/vos/vos_internal.h
+++ b/src/vos/vos_internal.h
@@ -252,6 +252,8 @@ struct vos_dtx_act_ent {
 	daos_epoch_t			 dae_start_time;
 	/* Link into container::vc_dtx_act_list. */
 	d_list_t			 dae_link;
+	/* Back pointer to the DTX handle. */
+	struct dtx_handle		*dae_dth;
 
 	unsigned int			 dae_committable:1,
 					 dae_committed:1,


### PR DESCRIPTION
This patch combines the following two master commit:

master-commit: 746f1936c70c6e13ec4bc7a5423507b9bab46a4a
master-commit: 457df4db26438b6f73142652b2413f1990681b81

When current IO handler ULT waits for bulk data transfer or other
non-leaders (for leader case), the DTX status may be changes by other
(such as DTX resync or refresh) by race. If the DTX has been prepared
or committed under such case, then just handle it as done instead of
retrying related RPC.

During current DTX leader waiting for non-leaders' reply,
someone (for resent rquest) may abort the DTX, that will
cause current DTX leader to do cleanup after the waiting,
such cleanup needs to avoid removing the new created DTX
entry (that belong to resent request) from the DTX table.

Do not abort current DTX if it has been always aborted by
other (for resent request) by race.

Signed-off-by: Fan Yong <fan.yong@intel.com>