### PR TITLE
DAOS-9095 vos: improve oid hash to reduce false collisions

### DIFF
--- a/src/vos/tests/vts_pm.c
+++ b/src/vos/tests/vts_pm.c
@@ -1358,13 +1358,12 @@ cond_test(void **state)
 	start_epoch = epoch + 1;
 }
 
-/** Making the oid generation deterministic, I get to 102 before I hit a false
- *  collision on the oid.   This may indicate the hashing needs to be improved
- *  but for now, it's good enough.  In general, the chance of a single
- *  collision is very high well before we get close to saturation due
+/** Making the oid generation deterministic, I get to 18201 before I hit a false
+ *  collision on the oid. For now, it's good enough. In general, the chance of
+ *  a single collision is very high well before we get close to saturation due
  *  to the birthday paradox.
  */
-#define NUM_OIDS 102
+#define NUM_OIDS 18201
 static void
 multiple_oid_cond_test(void **state)
 {

--- a/src/vos/vos_ts.h
+++ b/src/vos/vos_ts.h
@@ -497,8 +497,19 @@ vos_ts_set_add(struct vos_ts_set *ts_set, uint32_t *idx, const void *rec,
 	}
 
 calc_hash:
-	if (ts_set->ts_etype > VOS_TS_TYPE_CONT)
-		hash = vos_hash_get(rec, rec_size);
+	if (ts_set->ts_etype > VOS_TS_TYPE_CONT) {
+		if (ts_set->ts_etype != VOS_TS_TYPE_OBJ) {
+			hash = vos_hash_get(rec, rec_size);
+		} else {
+			daos_unit_oid_t *oid = (daos_unit_oid_t *)rec;
+
+			/*
+			 * Test shows using d_hash_murmur64() for oid
+			 * is easy to conflict.
+			 */
+			hash = oid->id_pub.lo ^ oid->id_pub.hi;
+		}
+	}
 
 	if (idx != NULL) {
 		entry = vos_ts_alloc(ts_set, idx, hash);


### PR DESCRIPTION
Using d_hash_murmur64() for OID hash might be bad, testing
shows loops could be increased from 102 to 18201 if hash was
calculated as oid hi xor lo bits.

Signed-off-by: Wang Shilong <shilong.wang@intel.com>