### PR TITLE
DAOS-9237 test: Disable some perf checks for multi-client IOR

### DIFF
--- a/src/tests/ftest/ior/intercept_multi_client.py
+++ b/src/tests/ftest/ior/intercept_multi_client.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 """
-  (C) Copyright 2019-2021 Intel Corporation.
+  (C) Copyright 2019-2022 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -41,11 +41,11 @@ class IorInterceptMultiClient(IorTestBase):
         :avocado: tags=daosio,iorinterceptmulticlient
         """
         suffix = self.ior_cmd.transfer_size.value
-        out = self.run_ior_with_pool(test_file_suffix=suffix)
+        out = self.run_ior_with_pool(test_file_suffix=suffix, fail_on_warning=True)
         without_intercept = IorCommand.get_ior_metrics(out)
         intercept = os.path.join(self.prefix, 'lib64', 'libioil.so')
         suffix = suffix + "intercept"
-        out = self.run_ior_with_pool(intercept, test_file_suffix=suffix)
+        out = self.run_ior_with_pool(intercept, test_file_suffix=suffix, fail_on_warning=True)
         with_intercept = IorCommand.get_ior_metrics(out)
         max_mib = int(IorMetrics.Max_MiB)
         min_mib = int(IorMetrics.Min_MiB)
@@ -56,8 +56,9 @@ class IorInterceptMultiClient(IorTestBase):
         # Verifying write performance
         self.assertTrue(float(with_intercept[0][max_mib]) >
                         write_x * float(without_intercept[0][max_mib]))
-        self.assertTrue(float(with_intercept[0][min_mib]) >
-                        write_x * float(without_intercept[0][min_mib]))
+        # DAOS-5857, DAOS-9237 Do not check min performance.
+        #self.assertTrue(float(with_intercept[0][min_mib]) >
+        #                write_x * float(without_intercept[0][min_mib]))
         self.assertTrue(float(with_intercept[0][mean_mib]) >
                         write_x * float(without_intercept[0][mean_mib]))
 
@@ -69,7 +70,7 @@ class IorInterceptMultiClient(IorTestBase):
         read_x = 0.6
         self.assertTrue(float(with_intercept[1][max_mib]) >
                         read_x * float(without_intercept[1][max_mib]))
-        self.assertTrue(float(with_intercept[1][min_mib]) >
-                        read_x * float(without_intercept[1][min_mib]))
+        #self.assertTrue(float(with_intercept[1][min_mib]) >
+        #                read_x * float(without_intercept[1][min_mib]))
         self.assertTrue(float(with_intercept[1][mean_mib]) >
                         read_x * float(without_intercept[1][mean_mib]))

--- a/src/tests/ftest/ior/intercept_multi_client.yaml
+++ b/src/tests/ftest/ior/intercept_multi_client.yaml
@@ -29,34 +29,33 @@ ior:
     client_processes:
       np: 16
     test_file: testFile
-    repetitions: 1
-# Remove the below line once DAOS-3143 is resolved
-    dfs_destroy: False
+    repetitions: 3
     iorflags:
         ssf:
-          flags: "-k -v -D 300 -w -r"
+          flags: "-k -v -D 600 -w -r"
           api: POSIX
           dfs_oclass: "SX"
           transfersize_blocksize: !mux
             512B:
               transfer_size: '512B'
-              block_size: '128M'
+              block_size: '32M'
               write_x: 1
               read_x: 1
             1K:
               transfer_size: '1K'
-              block_size: '512M'
+              block_size: '128M'
               write_x: 2
               read_x: 1
             4K:
               transfer_size: '4K'
-              block_size: '512M'
+              block_size: '128M'
               write_x: 1
               read_x: 1
             1M:
               transfer_size: '1M'
-              block_size: '8G'
+              block_size: '2G'
               write_x: 2
               read_x: 1
 dfuse:
     mount_dir: "/tmp/daos_dfuse/"
+    disable_caching: True


### PR DESCRIPTION
Apply the fix for DAOS-5857 to the weekly ior tests as well.

Quick-Functional: true
Test-tag: iorinterceptmulticlient

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>
