### PR TITLE
DAOS-9736-test: erasurecode/rebuild_disabled_single.py:EcodDisabledRebuildSingle.test_ec_degrade_single_value - daos container set-prop unresponsive for 39 seconds

### DIFF
--- a/src/tests/ftest/erasurecode/rebuild_disabled_single.yaml
+++ b/src/tests/ftest/erasurecode/rebuild_disabled_single.yaml
@@ -18,7 +18,7 @@ hosts:
         - server-E
   test_clients:
     - client-A
-timeout: 250
+timeout: 320
 server_config:
   engines_per_host: 2
   name: daos_server

--- a/src/tests/ftest/erasurecode/rebuild_disabled_single.yaml
+++ b/src/tests/ftest/erasurecode/rebuild_disabled_single.yaml
@@ -18,7 +18,7 @@ hosts:
         - server-E
   test_clients:
     - client-A
-timeout: 320
+timeout: 380
 server_config:
   engines_per_host: 2
   name: daos_server


### PR DESCRIPTION
Description: Increase timeout by 70 sec per request.

Skip-unit-tests: true
Test-repeat: 10
Test-tag: ec_disabled_rebuild_single
Signed-off-by: Ding Ho ding-hwa.ho@intel.com