### PR TITLE
DAOS-9753 object: fix daos_obj_generate_oid() back compatible feat flags

### DIFF
--- a/src/include/daos_obj.h
+++ b/src/include/daos_obj.h
@@ -107,7 +107,7 @@ enum daos_otype_t {
 static inline bool
 daos_otype_t_is_valid(enum daos_otype_t type)
 {
-	return type >= 0 && type <= DAOS_OT_MAX;
+	return type <= DAOS_OT_MAX;
 }
 
 static inline enum daos_otype_t

--- a/src/include/daos_obj.h
+++ b/src/include/daos_obj.h
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2015-2021 Intel Corporation.
+ * (C) Copyright 2015-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -92,6 +92,7 @@ enum daos_otype_t {
 	/** Byte Array with no metadata (eg DFS/POSIX) */
 	DAOS_OT_ARRAY_BYTE	= 13,
 
+	DAOS_OT_MAX		= 13,
 	/**
 	 * reserved: Multi Dimensional Array
 	 * DAOS_OT_ARRAY_MD	= 64,
@@ -102,6 +103,12 @@ enum daos_otype_t {
 	 * DAOS_OT_BDEV	= 96,
 	 */
 };
+
+static inline bool
+daos_otype_t_is_valid(enum daos_otype_t type)
+{
+	return type >= 0 && type <= DAOS_OT_MAX;
+}
 
 static inline enum daos_otype_t
 daos_obj_id2type(daos_obj_id_t oid)
@@ -1139,37 +1146,36 @@ int
 daos_obj_generate_oid2(daos_handle_t coh, daos_obj_id_t *oid,
 		       enum daos_otype_t type, daos_oclass_id_t cid,
 		       daos_oclass_hints_t hints, uint32_t args);
-enum {
-	/** DKEY keys not hashed and sorted numerically.   Keys are accepted
-	 *  in client's byte order and DAOS is responsible for correct behavior
-	 */
-	DAOS_OF_DKEY_UINT64	= (1 << 0),
-	/** DKEY keys not hashed and sorted lexically */
-	DAOS_OF_DKEY_LEXICAL	= (1 << 1),
-	/** AKEY keys not hashed and sorted numerically.   Keys are accepted
-	 *  in client's byte order and DAOS is responsible for correct behavior
-	 */
-	DAOS_OF_AKEY_UINT64	= (1 << 2),
-	/** AKEY keys not hashed and sorted lexically */
-	DAOS_OF_AKEY_LEXICAL	= (1 << 3),
-	/** reserved: 1-level flat KV store */
-	DAOS_OF_KV_FLAT		= (1 << 4),
-	/** reserved: 1D Array with metadata stored in the DAOS object */
-	DAOS_OF_ARRAY		= (1 << 5),
-	/** reserved: Multi Dimensional Array */
-	DAOS_OF_ARRAY_MD	= (1 << 6),
-	/** reserved: Byte Array with no metadata (eg DFS/POSIX) */
-	DAOS_OF_ARRAY_BYTE	= (1 << 7),
-	/**
-	 * benchmark-only feature bit, I/O is a network echo, no data is going
-	 * to be stored/returned
-	 *
-	 * NB: this is the last feature bits.
-	 */
-	DAOS_OF_ECHO		= (1 << 15),
-	/** Mask for convenience (16-bit) */
-	DAOS_OF_MASK		= ((1 << 16) - 1),
-};
+
+/** DKEY keys not hashed and sorted numerically.   Keys are accepted
+ *  in client's byte order and DAOS is responsible for correct behavior
+ */
+#define	DAOS_OF_DKEY_UINT64	((daos_ofeat_t)(1 << 0))
+/** DKEY keys not hashed and sorted lexically */
+#define DAOS_OF_DKEY_LEXICAL	((daos_ofeat_t)(1 << 1))
+/** AKEY keys not hashed and sorted numerically.   Keys are accepted
+ *  in client's byte order and DAOS is responsible for correct behavior
+ */
+#define DAOS_OF_AKEY_UINT64	((daos_ofeat_t)(1 << 2))
+/** AKEY keys not hashed and sorted lexically */
+#define DAOS_OF_AKEY_LEXICAL	((daos_ofeat_t)(1 << 3))
+/** reserved: 1-level flat KV store */
+#define DAOS_OF_KV_FLAT		((daos_ofeat_t)(1 << 4))
+/** reserved: 1D Array with metadata stored in the DAOS object */
+#define DAOS_OF_ARRAY		((daos_ofeat_t)(1 << 5))
+/** reserved: Multi Dimensional Array */
+#define DAOS_OF_ARRAY_MD	((daos_ofeat_t)(1 << 6))
+/** reserved: Byte Array with no metadata (eg DFS/POSIX) */
+#define DAOS_OF_ARRAY_BYTE	((daos_ofeat_t)(1 << 7))
+/**
+ * benchmark-only feature bit, I/O is a network echo, no data is going
+ * to be stored/returned
+ *
+ * NB: this is the last feature bits.
+ */
+#define DAOS_OF_ECHO		((daos_ofeat_t)(1 << 15))
+/** Mask for convenience (16-bit) */
+#define DAOS_OF_MASK		((daos_ofeat_t)((1 << 16) - 1))
 
 #if defined(__cplusplus)
 }

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -5865,6 +5865,8 @@ daos_obj_generate_oid(daos_handle_t coh, daos_obj_id_t *oid,
 {
 	daos_ofeat_t	feat = (daos_ofeat_t)in;
 
+	D_WARN("daos_ofeat_t(DAOS_OF_XXX) will be deprecated soon, "
+		"please use enum daos_otype_t(DAOS_OT_XXX) instead!\n");
 	return daos_obj_generate_oid2(coh, oid, daos_obj_feat2type(feat), cid, hints, args);
 }
 
@@ -5895,6 +5897,9 @@ daos_obj_generate_oid2(daos_handle_t coh, daos_obj_id_t *oid,
 	enum daos_obj_redun	ord;
 	uint32_t		nr_grp;
 	int			rc;
+
+	if (!daos_otype_t_is_valid(type))
+		return -DER_INVAL;
 
 	/** select the oclass */
 	poh = dc_cont_hdl2pool_hdl(coh);
@@ -5942,6 +5947,9 @@ daos_obj_generate_oid_by_rf(daos_handle_t poh, uint64_t rf_factor,
 	enum daos_obj_redun	ord;
 	uint32_t		nr_grp;
 	int			rc;
+
+	if (!daos_otype_t_is_valid(type))
+		return -DER_INVAL;
 
 	pool = dc_hdl2pool(poh);
 	D_ASSERT(pool);

--- a/src/tests/simple_obj.c
+++ b/src/tests/simple_obj.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2020-2021 Intel Corporation.
+ * (C) Copyright 2020-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -480,11 +480,9 @@ example_daos_array()
 	oid.hi = 0;
 	oid.lo = 3;
 
-	/*
-	 * generate an array objid to encode feature flags and object class to
-	 * the OID. This is a convenience function over the
-	 * daos_obj_generate_oid() that adds the required feature flags for an
-	 * array: DAOS_OF_DKEY_UINT64 | DAOS_OF_KV_FLAT | DAOS_OF_ARRAY
+	/**
+	 * Convenience function to generate a DAOS Array object ID by encoding
+	 * the private DAOS bits of the object address space.
 	 */
 	daos_array_generate_oid(coh, &oid, true, 0, 0, 0);
 
@@ -611,7 +609,6 @@ example_daos_kv()
 
 	oid.hi = 0;
 	oid.lo = 4;
-	/** the KV API requires the flat feature flag be set in the oid */
 	daos_obj_generate_oid(coh, &oid, DAOS_OT_KV_HASHED, OC_SX, 0, 0);
 
 	rc = daos_kv_open(coh, oid, DAOS_OO_RW, &oh, NULL);

--- a/src/tests/suite/daos_kv.c
+++ b/src/tests/suite/daos_kv.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2021 Intel Corporation.
+ * (C) Copyright 2016-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -71,7 +71,8 @@ list_keys(daos_handle_t oh, int *num_keys)
 }
 
 static void
-simple_put_get(void **state)
+simple_put_get_flags(void **state, bool is_old_flag)
+
 {
 	test_arg_t	*arg = *state;
 	daos_obj_id_t	oid;
@@ -92,8 +93,12 @@ simple_put_get(void **state)
 	D_ALLOC(buf_out, buf_size);
 	assert_non_null(buf_out);
 
-	oid = daos_test_oid_gen(arg->coh, OC_SX, type, 0, arg->myrank);
-
+	oid = dts_oid_gen(arg->myrank);
+	if (is_old_flag)
+		daos_obj_generate_oid(arg->coh, &oid, DAOS_OF_KV_FLAT,
+				      OC_SX, 0, 0);
+	else
+		daos_obj_generate_oid(arg->coh, &oid, type, OC_SX, 0, 0);
 	if (arg->async) {
 		rc = daos_event_init(&ev, arg->eq, NULL);
 		assert_rc_equal(rc, 0);
@@ -251,6 +256,18 @@ simple_put_get(void **state)
 } /* End simple_put_get */
 
 static void
+simple_put_get(void **state)
+{
+	simple_put_get_flags(state, false);
+}
+
+static void
+simple_put_get_old(void **state)
+{
+	simple_put_get_flags(state, true);
+}
+
+static void
 kv_cond_ops(void **state)
 {
 	test_arg_t	*arg = *state;
@@ -321,6 +338,8 @@ kv_cond_ops(void **state)
 static const struct CMUnitTest kv_tests[] = {
 	{"KV: Object Put/GET (blocking)",
 	 simple_put_get, async_disable, NULL},
+	{"KV: Object Put/GET with daos_ofeat_t flag(blocking)",
+	 simple_put_get_old, async_disable, NULL},
 	{"KV: Object Put/GET (non-blocking)",
 	 simple_put_get, async_enable, NULL},
 	{"KV: Object Conditional Ops (blocking)",

--- a/src/utils/daos_autotest.c
+++ b/src/utils/daos_autotest.c
@@ -690,7 +690,11 @@ kv_insert128(void)
 	int		rc;
 
 	new_oid();
-	daos_obj_generate_oid(coh, &oid, DAOS_OT_KV_HASHED, 0, 0, 0);
+	/**
+	 * Use daos_ofeat_t DAOS_OF_KV_FLAT rather than DAOS_OT_KV_FLASH
+	 * to test if function compatible with old flags.
+	 */
+	daos_obj_generate_oid(coh, &oid, DAOS_OF_KV_FLAT, 0, 0, 0);
 
 	rc = daos_kv_open(coh, oid, DAOS_OO_RW, &oh, NULL);
 	if (rc) {

--- a/src/utils/daos_autotest.c
+++ b/src/utils/daos_autotest.c
@@ -690,11 +690,7 @@ kv_insert128(void)
 	int		rc;
 
 	new_oid();
-	/**
-	 * Use daos_ofeat_t DAOS_OF_KV_FLAT rather than DAOS_OT_KV_FLASH
-	 * to test if function compatible with old flags.
-	 */
-	daos_obj_generate_oid(coh, &oid, DAOS_OF_KV_FLAT, 0, 0, 0);
+	daos_obj_generate_oid(coh, &oid, DAOS_OT_KV_HASHED, 0, 0, 0);
 
 	rc = daos_kv_open(coh, oid, DAOS_OO_RW, &oh, NULL);
 	if (rc) {


### PR DESCRIPTION
Current detecting ofeats check won't work if DAOS_OF_XXX is passing
directly as ofeat flag, this patch try to fix by declaring DAOS_OF_XXX
as macro rather than enum.

Also add sanity check for daos_otype_t is valid or not before generating
oid, added deprecated warning for old flags.

Signed-off-by: Wang Shilong <shilong.wang@intel.com>