### PR TITLE
DAOS-9657 object: check obj sync argument

### DIFF
--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -5842,6 +5842,8 @@ dc_obj_sync(tse_task_t *task)
 		*args->epochs_p = tmp;
 	} else {
 		D_ASSERT(*args->epochs_p != NULL);
+		D_ASSERTF(*args->nr == obj->cob_grp_nr, "Invalid obj sync args %d/%d\n",
+			  *args->nr, obj->cob_grp_nr);
 
 		for (i = 0; i < *args->nr; i++)
 			*args->epochs_p[i] = 0;


### PR DESCRIPTION
For retry object sync case, the epoch array length should
be equal to the object redundancy group count. Otherwise,
there is DRAM corruption or accessing released DRAM.

Signed-off-by: Fan Yong <fan.yong@intel.com>