### PR TITLE
DAOS-9757 test: Increase NVMe telemetry test timeout

### DIFF
--- a/src/tests/ftest/control/dmg_telemetry_nvme.yaml
+++ b/src/tests/ftest/control/dmg_telemetry_nvme.yaml
@@ -3,7 +3,7 @@ hosts:
     - server-A
     - server-B
 timeouts:
-  test_telemetry_list_nvme: 90
+  test_telemetry_list_nvme: 120
 server_config:
   servers:
     bdev_class: nvme


### PR DESCRIPTION
The work for DAOS-8905 has likely increased server
startup times just enough to increase the likelihood
of hitting this test's timeout.

Quick-functional: true
Test-tag: test_nvme_telemetry_metrics

Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com>
