### PR TITLE
DAOS-9757 control: Optimize daos_server network scan

### DIFF
--- a/src/control/lib/hardware/fabric.go
+++ b/src/control/lib/hardware/fabric.go
@@ -12,6 +12,7 @@ import (
 	"math"
 	"sort"
 	"strings"
+	"sync"
 
 	"github.com/pkg/errors"
 
@@ -632,6 +633,7 @@ func (c *FabricScannerConfig) Validate() error {
 // FabricScanner is a type that scans the system for fabric interfaces.
 type FabricScanner struct {
 	log      logging.Logger
+	mutex    sync.Mutex
 	config   *FabricScannerConfig
 	builders []FabricInterfaceSetBuilder
 	topo     *Topology
@@ -678,6 +680,9 @@ func (s *FabricScanner) Scan(ctx context.Context) (*FabricInterfaceSet, error) {
 		return nil, errors.New("FabricScanner is nil")
 	}
 
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
 	if !s.isInitialized() {
 		if err := s.init(ctx); err != nil {
 			return nil, err
@@ -710,6 +715,9 @@ func (s *FabricScanner) CacheTopology(t *Topology) error {
 	if t == nil {
 		return errors.New("Topology is nil")
 	}
+
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
 
 	s.topo = t
 	return nil

--- a/src/control/lib/hardware/fabric_test.go
+++ b/src/control/lib/hardware/fabric_test.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2021 Intel Corporation.
+// (C) Copyright 2021-2022 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -909,11 +909,12 @@ func TestHardware_FabricScanner_Scan(t *testing.T) {
 	)
 
 	for name, tc := range map[string]struct {
-		config     *FabricScannerConfig
-		nilScanner bool
-		builders   []FabricInterfaceSetBuilder
-		expResult  *FabricInterfaceSet
-		expErr     error
+		config        *FabricScannerConfig
+		cacheTopology *Topology
+		nilScanner    bool
+		builders      []FabricInterfaceSetBuilder
+		expResult     *FabricInterfaceSet
+		expErr        error
 	}{
 		"nil": {
 			nilScanner: true,
@@ -1029,6 +1030,34 @@ func TestHardware_FabricScanner_Scan(t *testing.T) {
 				},
 			),
 		},
+		"topology cached": {
+			config: &FabricScannerConfig{
+				TopologyProvider: &MockTopologyProvider{
+					GetTopoErr: errors.New("mock GetTopology"),
+				},
+				FabricInterfaceProviders: []FabricInterfaceProvider{
+					&MockFabricInterfaceProvider{
+						GetFabricReturn: testFis,
+					},
+				},
+				NetDevClassProvider: &MockNetDevClassProvider{
+					GetNetDevClassReturn: []MockGetNetDevClassResult{
+						{
+							NDC:      Ether,
+							ExpInput: "os_test01",
+						},
+					},
+				},
+			},
+			cacheTopology: testTopo,
+			expResult: NewFabricInterfaceSet(
+				&FabricInterface{
+					Name:        "test01",
+					OSDevice:    "os_test01",
+					DeviceClass: Ether,
+				},
+			),
+		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			log, buf := logging.NewTestLogger(t.Name())
@@ -1041,6 +1070,8 @@ func TestHardware_FabricScanner_Scan(t *testing.T) {
 				if err != nil {
 					t.Fatal(err)
 				}
+
+				scanner.topo = tc.cacheTopology
 
 				if len(tc.builders) > 0 {
 					scanner.builders = tc.builders
@@ -1060,6 +1091,60 @@ func TestHardware_FabricScanner_Scan(t *testing.T) {
 					t.Fatalf("bad test setup: test builders aren't mocks")
 				}
 				common.AssertEqual(t, 1, mock.buildPartCalled, "")
+			}
+		})
+	}
+}
+
+func TestHardware_FabricScanner_CacheTopology(t *testing.T) {
+	for name, tc := range map[string]struct {
+		fs     *FabricScanner
+		topo   *Topology
+		expErr error
+	}{
+		"nil": {
+			topo:   &Topology{},
+			expErr: errors.New("nil"),
+		},
+		"nil input": {
+			fs:     &FabricScanner{},
+			expErr: errors.New("nil"),
+		},
+		"success": {
+			fs:   &FabricScanner{},
+			topo: &Topology{},
+		},
+		"overwrite": {
+			fs: &FabricScanner{
+				topo: &Topology{
+					NUMANodes: NodeMap{
+						0: MockNUMANode(0, 8),
+						1: MockNUMANode(1, 8),
+					},
+				},
+			},
+			topo: &Topology{},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			log, buf := logging.NewTestLogger(t.Name())
+			defer common.ShowBufferOnFailure(t, buf)
+
+			if tc.fs != nil {
+				tc.fs.log = log
+			}
+
+			err := tc.fs.CacheTopology(tc.topo)
+
+			common.CmpErr(t, tc.expErr, err)
+
+			if tc.fs == nil {
+				return
+			}
+
+			// Verify the new topology was saved
+			if diff := cmp.Diff(tc.topo, tc.fs.topo); diff != "" {
+				t.Fatalf("(-want, +got)\n%s\n", diff)
 			}
 		})
 	}

--- a/src/control/lib/hardware/fabric_test.go
+++ b/src/control/lib/hardware/fabric_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/pkg/errors"
 
 	"github.com/daos-stack/daos/src/control/common"
@@ -883,6 +884,7 @@ func TestHardware_NewFabricScanner(t *testing.T) {
 					MockNetDevClassProvider{},
 				),
 				common.CmpOptIgnoreFieldAnyType("log"),
+				cmpopts.IgnoreFields(FabricScanner{}, "mutex"),
 			); diff != "" {
 				t.Fatalf("(-want, +got)\n%s\n", diff)
 			}

--- a/src/control/lib/hardware/hwprov/defaults_test.go
+++ b/src/control/lib/hardware/hwprov/defaults_test.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2021 Intel Corporation.
+// (C) Copyright 2021-2022 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -132,6 +132,7 @@ func TestHwprov_DefaultFabricScanner(t *testing.T) {
 			sysfs.Provider{},
 		),
 		common.CmpOptIgnoreFieldAnyType("log"),
+		cmpopts.IgnoreFields(hardware.FabricScanner{}, "mutex"),
 	); diff != "" {
 		t.Fatalf("(-want, +got)\n%s\n", diff)
 	}

--- a/src/control/server/ctl_network_rpc.go
+++ b/src/control/server/ctl_network_rpc.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2019-2021 Intel Corporation.
+// (C) Copyright 2019-2022 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -36,17 +36,21 @@ func (c *ControlService) NetworkScan(ctx context.Context, req *ctlpb.NetworkScan
 		provider = req.GetProvider()
 	}
 
+	topo, err := hwprov.DefaultTopologyProvider(c.log).GetTopology(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := c.fabric.CacheTopology(topo); err != nil {
+		return nil, err
+	}
+
 	result, err := c.fabric.Scan(ctx)
 	if err != nil {
 		return nil, err
 	}
 
 	resp := c.fabricInterfaceSetToNetworkScanResp(result, provider)
-
-	topo, err := hwprov.DefaultTopologyProvider(c.log).GetTopology(ctx)
-	if err != nil {
-		return nil, err
-	}
 
 	resp.Numacount = int32(topo.NumNUMANodes())
 	resp.Corespernuma = int32(topo.NumCoresPerNUMA())


### PR DESCRIPTION
- Add optional CacheTopology method to cache an externally-
  acquired Topology in the FabricScanner.
- Use CacheTopology in the daos_server network scan to avoid
  crawling the hardware topology more than once.

Signed-off-by: Kris Jacque <kristin.jacque@intel.com>