### PR TITLE
DAOS-9757 test: Increase NVMe telemetry test timeout (take #2)

### DIFF
--- a/src/tests/ftest/control/dmg_telemetry_nvme.yaml
+++ b/src/tests/ftest/control/dmg_telemetry_nvme.yaml
@@ -4,6 +4,7 @@ hosts:
     - server-B
 timeouts:
   test_telemetry_list_nvme: 90
+  test_nvme_telemetry_metrics: 120
 server_config:
   servers:
     bdev_class: nvme


### PR DESCRIPTION
Accidentally bumped timeout for wrong testcase in the previous
commit.

Quick-functional: true
Test-tag: test_nvme_telemetry_metrics

Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com>