### PR TITLE
DAOS-9757 test: Increase NVMe telemetry test timeout (take #2)

### DIFF
--- a/src/tests/ftest/control/dmg_telemetry_nvme.yaml
+++ b/src/tests/ftest/control/dmg_telemetry_nvme.yaml
@@ -2,8 +2,7 @@ hosts:
   test_servers:
     - server-A
     - server-B
-timeouts:
-  test_telemetry_list_nvme: 120
+timeout: 90
 server_config:
   servers:
     bdev_class: nvme


### PR DESCRIPTION
Accidentally bumped timeout for wrong testcase in the previous
commit. Just increase the overall timeout for all testcases to
90s.

Quick-functional: true
Test-tag: test_nvme_telemetry_metrics test_telemetry_list_nvme

Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com>
