### PR TITLE
DAOS-9548 placement: add basic PD and PDA support

### DIFF
--- a/src/include/daos/object.h
+++ b/src/include/daos/object.h
@@ -121,7 +121,8 @@ typedef struct {
 struct daos_obj_md {
 	daos_obj_id_t		omd_id;
 	uint32_t		omd_ver;
-	uint32_t		omd_padding;
+	/* Performance domain affinity */
+	uint32_t		omd_pda;
 	union {
 		uint32_t	omd_split;
 		uint64_t	omd_loff;

--- a/src/include/daos/pool_map.h
+++ b/src/include/daos/pool_map.h
@@ -33,6 +33,7 @@ typedef enum pool_comp_type {
 	PO_COMP_TP_RANK		= 1, /** reserved, hard-coded */
 	PO_COMP_TP_MIN		= 2, /** first user-defined domain */
 	PO_COMP_TP_NODE		= 2, /** for test only */
+	PO_COMP_TP_PD		= 3, /** for performance domain */
 	PO_COMP_TP_MAX		= 254, /** last user-defined domain */
 	PO_COMP_TP_ROOT		= 255,
 	PO_COMP_TP_END		= 256,

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -1472,10 +1472,10 @@ dc_obj_fetch_md(daos_obj_id_t oid, struct daos_obj_md *md)
 	/* For predefined object classes, do nothing at here. But for those
 	 * customized classes, we need to fetch for the remote OI table.
 	 */
-	md->omd_id      = oid;
-	md->omd_ver     = 0;
-	md->omd_padding = 0;
-	md->omd_loff    = 0;
+	md->omd_id	= oid;
+	md->omd_ver	= 0;
+	md->omd_pda	= 0;
+	md->omd_loff	= 0;
 	return 0;
 }
 

--- a/src/placement/jump_map.c
+++ b/src/placement/jump_map.c
@@ -11,6 +11,7 @@
 
 #include "pl_map.h"
 #include <inttypes.h>
+#include <daos/common.h>
 #include <daos/pool_map.h>
 #include <isa-l.h>
 
@@ -35,12 +36,23 @@ enum PL_OP_TYPE {
 	PL_ADD,
 };
 
+#define JMOP_PD_INLINE	(8)
 /**
  * Contains information related to object layout size.
  */
 struct jm_obj_placement {
-	unsigned int    jmop_grp_size;
-	unsigned int    jmop_grp_nr;
+	/* root domain, used when no PD defined */
+	struct pool_domain	 *jmop_root;
+	unsigned int		  jmop_grp_size;
+	unsigned int		  jmop_grp_nr;
+	/* #PDs to-be-used for the obj */
+	unsigned int		  jmop_pd_nr;
+	/* For zero jmop_pd_nr, non-sense for below fields */
+	/* PD group size (min(pda, doms_per_pd)) */
+	unsigned int		  jmop_pd_grp_size;
+	/* PD domain pointers array */
+	struct pool_domain	**jmop_pd_ptrs;
+	struct pool_domain	 *jmop_pd_ptrs_inline[JMOP_PD_INLINE];
 };
 
 /**
@@ -52,6 +64,8 @@ struct jm_obj_placement {
 struct pl_jump_map {
 	/** placement map interface */
 	struct pl_map		jmp_map;
+	/** Number of performance domains (can be zero) */
+	unsigned int		jmp_pd_nr;
 	/* Total size of domain type specified during map creation */
 	unsigned int		jmp_domain_nr;
 	/* # UPIN targets */
@@ -59,6 +73,113 @@ struct pl_jump_map {
 	/* The dom that will contain no colocated shards */
 	pool_comp_type_t	jmp_redundant_dom;
 };
+
+/**
+ * This is useful for jump_map placement to pseudorandomly permute input keys
+ * that are similar to each other. This dramatically improves the even-ness of
+ * the distribution of output placements.
+ */
+static inline uint64_t
+crc(uint64_t data, uint32_t init_val)
+{
+	return crc64_ecma_refl(init_val, (uint8_t *)&data, sizeof(data));
+}
+
+/** Initialize the PDs for object to prepare for the layout calculation */
+#define LOCAL_PD_ARRAY_SIZE	(4)
+static int
+jm_obj_pd_init(struct pl_jump_map *jmap, struct daos_obj_md *md, struct pool_domain *root,
+	       struct jm_obj_placement *jmop)
+{
+	struct pool_domain	*pds, *pd;
+	uint8_t			*pd_used = NULL;
+	uint8_t			 pd_used_array[LOCAL_PD_ARRAY_SIZE] = {0};
+	uint32_t		 pd_array_size;
+	daos_obj_id_t		 oid;
+	uint64_t		 key;
+	uint32_t		 selected_pd, pd_id;
+	uint32_t		 pd_nr = jmap->jmp_pd_nr;
+	uint32_t		 dom_nr = jmap->jmp_domain_nr;
+	uint32_t		 shard_nr = jmop->jmop_grp_size * jmop->jmop_grp_nr;
+	uint32_t		 doms_per_pd;
+	uint32_t		 pd_grp_size, pd_grp_nr;
+	int			 i, rc;
+
+	jmop->jmop_root = root;
+	if (md->omd_pda == 0)
+		pd_nr = 0;
+	if (pd_nr <= 1)
+		jmop->jmop_pd_nr = pd_nr;
+	if (jmop->jmop_pd_nr == 0)
+		return 0;
+
+	doms_per_pd = dom_nr / pd_nr;
+	D_ASSERTF(doms_per_pd >= 1, "bad dom_nr %d, pd_nr %d\n", dom_nr, pd_nr);
+
+	pd_grp_size = min(md->omd_pda, doms_per_pd);
+	pd_grp_nr = shard_nr / pd_grp_size + (shard_nr % pd_grp_size != 0);
+	jmop->jmop_pd_grp_size = pd_grp_size;
+	jmop->jmop_pd_nr = min(pd_grp_nr, pd_nr);
+
+	D_ASSERT(pd_nr >= 1);
+	rc = pool_map_find_domain(jmap->jmp_map.pl_poolmap, PO_COMP_TP_PD, PO_COMP_ID_ALL, &pds);
+	D_ASSERT(rc == pd_nr);
+	rc = 0;
+
+	if (jmop->jmop_pd_nr <= JMOP_PD_INLINE) {
+		jmop->jmop_pd_ptrs = jmop->jmop_pd_ptrs_inline;
+	} else {
+		D_ALLOC_ARRAY(jmop->jmop_pd_ptrs, jmop->jmop_pd_nr);
+		if (jmop->jmop_pd_ptrs == NULL)
+			D_GOTO(out, rc = -DER_NOMEM);
+	}
+	pd_array_size = jmap->jmp_pd_nr / NBBY + 1;
+	if (pd_array_size > LOCAL_PD_ARRAY_SIZE) {
+		D_ALLOC_ARRAY(pd_used, pd_array_size);
+		if (pd_used == NULL)
+			D_GOTO(out, rc = -DER_NOMEM);
+	} else {
+		pd_used = pd_used_array;
+	}
+
+	oid = md->omd_id;
+	key = oid.hi ^ oid.lo;
+	for (i = 0; i < jmop->jmop_pd_nr; i++) {
+		key = crc(key, i);
+		selected_pd = d_hash_jump(key, jmap->jmp_pd_nr);
+		do {
+			selected_pd = selected_pd % jmap->jmp_pd_nr;
+			pd = &pds[selected_pd];
+			pd_id = pd->do_comp.co_id;
+			selected_pd++;
+		} while (isset(pd_used, pd_id));
+
+		setbit(pd_used, pd_id);
+		jmop->jmop_pd_ptrs[i] = pd;
+	}
+
+out:
+	if (pd_used != NULL && pd_used != pd_used_array)
+		D_FREE(pd_used);
+	if (rc && jmop->jmop_pd_ptrs != NULL && jmop->jmop_pd_ptrs != jmop->jmop_pd_ptrs_inline)
+		D_FREE(jmop->jmop_pd_ptrs);
+	return rc;
+}
+
+/** Calculates the PD for the shard */
+struct pool_domain *
+jm_obj_shard_pd(struct jm_obj_placement *jmop, uint32_t shard)
+{
+	uint32_t pd_idx;
+
+	if (jmop->jmop_pd_nr == 0)
+		return jmop->jmop_root;
+
+	D_ASSERT(shard < jmop->jmop_grp_size * jmop->jmop_grp_nr);
+	pd_idx = (shard / jmop->jmop_pd_grp_size) % jmop->jmop_pd_nr;
+
+	return jmop->jmop_pd_ptrs[pd_idx];
+}
 
 /**
  * This functions finds the pairwise differences in the two layouts provided
@@ -116,16 +237,6 @@ layout_find_diff(struct pl_jump_map *jmap, struct pl_obj_layout *original,
 		}
 	}
 }
-/**
- * This is useful for jump_map placement to pseudorandomly permute input keys
- * that are similar to each other. This dramatically improves the even-ness of
- * the distribution of output placements.
- */
-static inline uint64_t
-crc(uint64_t data, uint32_t init_val)
-{
-	return crc64_ecma_refl(init_val, (uint8_t *)&data, sizeof(data));
-}
 
 /**
  * This function gets the replication and size requirements and then
@@ -143,9 +254,9 @@ crc(uint64_t data, uint32_t init_val)
  *                      layout requirements could not be determined / satisfied.
  */
 static int
-jm_obj_placement_get(struct pl_jump_map *jmap, struct daos_obj_md *md,
-		     struct daos_obj_shard_md *shard_md,
-		     struct jm_obj_placement *jmop)
+jm_obj_placement_init(struct pl_jump_map *jmap, struct daos_obj_md *md,
+		      struct daos_obj_shard_md *shard_md,
+		      struct jm_obj_placement *jmop)
 {
 	struct daos_oclass_attr *oc_attr;
 	struct pool_domain      *root;
@@ -153,6 +264,7 @@ jm_obj_placement_get(struct pl_jump_map *jmap, struct daos_obj_md *md,
 	int                     rc;
 	uint32_t		nr_grps;
 
+	jmop->jmop_pd_ptrs = NULL;
 	/* Get the Object ID and the Object class */
 	oid = md->omd_id;
 	oc_attr = daos_oclass_attr_find(oid, &nr_grps);
@@ -193,7 +305,18 @@ jm_obj_placement_get(struct pl_jump_map *jmap, struct daos_obj_md *md,
 		"obj="DF_OID"/ grp_size=%u grp_nr=%d\n",
 		DP_OID(oid), jmop->jmop_grp_size, jmop->jmop_grp_nr);
 
-	return 0;
+	rc = jm_obj_pd_init(jmap, md, root, jmop);
+	if (rc)
+		D_ERROR("obj="DF_OID", jm_obj_pd_init failed, "DF_RC"\n", DP_OID(oid), DP_RC(rc));
+
+	return rc;
+}
+
+static void
+jm_obj_placement_fini(struct jm_obj_placement *jmop)
+{
+	if (jmop->jmop_pd_ptrs != NULL && jmop->jmop_pd_ptrs != jmop->jmop_pd_ptrs_inline)
+		D_FREE(jmop->jmop_pd_ptrs);
 }
 
 /**
@@ -287,9 +410,10 @@ reset_dom_cur_grp(uint8_t *dom_cur_grp_used, uint8_t *dom_occupied, uint32_t dom
  * object shard layout. This function is called for every shard that needs a
  * placement location.
  *
- * \param[in]   curr_dom        The current domain that is being used to
+ * \param[in]   root_pos        The root domain of the pool map.
+ * \param[in]   curr_pd         The current performance domain that is being used to
  *                              determine the target location for this shard.
- *                              initially the root node of the pool map.
+ *                              When there is no PD, it is same as root domain.
  * \param[out]  target          This variable is used when returning the
  *                              selected target for this shard.
  * \param[in]   obj_key         a unique key generated using the object ID.
@@ -315,22 +439,21 @@ reset_dom_cur_grp(uint8_t *dom_cur_grp_used, uint8_t *dom_occupied, uint32_t dom
  */
 #define MAX_STACK	5
 static void
-get_target(struct pool_domain *curr_dom, struct pool_target **target,
-	   uint64_t obj_key, uint8_t *dom_used, uint8_t *dom_occupied,
-	   uint8_t *dom_cur_grp_used, uint8_t *tgts_used, int shard_num,
-	   uint32_t allow_status)
+get_target(struct pool_domain *root_pos, struct pool_domain *curr_pd, struct pool_target **target,
+	   uint64_t obj_key, uint8_t *dom_used, uint8_t *dom_occupied, uint8_t *dom_cur_grp_used,
+	   uint8_t *tgts_used, int shard_num, uint32_t allow_status)
 {
+	struct pool_domain	*curr_dom;
 	int                     range_set;
 	uint8_t                 found_target = 0;
 	uint32_t                selected_dom;
-	struct pool_domain      *root_pos;
 	struct pool_domain	*dom_stack[MAX_STACK] = { 0 };
 	uint32_t		dom_size;
 	int			top = -1;
 
 	obj_key = crc(obj_key, shard_num);
-	root_pos = curr_dom;
 	dom_size = (struct pool_domain *)(root_pos->do_targets) - (root_pos) + 1;
+	curr_dom = curr_pd;
 retry:
 	do {
 		uint32_t        num_doms;
@@ -460,7 +583,7 @@ retry:
 				 * used, then let's go back its parent to check
 				 * its siblings.
 				 */
-				if (curr_dom != root_pos) {
+				if (curr_dom != curr_pd) {
 					setbit(dom_used, curr_dom - root_pos);
 					D_ASSERT(top != -1);
 					curr_dom = dom_stack[top--];
@@ -473,7 +596,7 @@ retry:
 					if (!reset_used)
 						reset_dom_cur_grp(dom_cur_grp_used, dom_occupied,
 								  dom_size);
-					curr_dom = root_pos;
+					curr_dom = curr_pd;
 				}
 				continue;
 			}
@@ -550,7 +673,7 @@ obj_remap_shards(struct pl_jump_map *jmap, struct daos_obj_md *md,
 	struct failed_shard     *f_shard;
 	struct pl_obj_shard     *l_shard;
 	struct pool_target      *spare_tgt;
-	struct pool_domain      *root;
+	struct pool_domain      *root, *curr_pd;
 	d_list_t                *current;
 	daos_obj_id_t           oid;
 	bool                    spare_avail = true;
@@ -597,10 +720,9 @@ obj_remap_shards(struct pl_jump_map *jmap, struct daos_obj_md *md,
 
 			D_ASSERT(dgu != NULL);
 			rebuild_key = crc(key, f_shard->fs_shard_idx);
-			get_target(root, &spare_tgt, crc(key, rebuild_key),
-				   dom_used, dom_occupied,
-				   dgu->dgu_used, tgts_used,
-				   shard_id, allow_status);
+			curr_pd = jm_obj_shard_pd(jmop, shard_id);
+			get_target(root, curr_pd, &spare_tgt, crc(key, rebuild_key), dom_used,
+				   dom_occupied, dgu->dgu_used, tgts_used, shard_id, allow_status);
 			D_ASSERT(spare_tgt != NULL);
 			D_DEBUG(DB_PL, "Trying new target: "DF_TARGET"\n",
 				DP_TARGET(spare_tgt));
@@ -715,7 +837,7 @@ get_object_layout(struct pl_jump_map *jmap, struct pl_obj_layout *layout,
 		  bool *is_extending)
 {
 	struct pool_target      *target;
-	struct pool_domain      *root;
+	struct pool_domain      *root, *curr_pd;
 	daos_obj_id_t           oid;
 	uint8_t                 *dom_used = NULL;
 	uint8_t                 *dom_occupied = NULL;
@@ -812,9 +934,9 @@ get_object_layout(struct pl_jump_map *jmap, struct pl_obj_layout *layout,
 				}
 				setbit(tgts_used, target->ta_comp.co_id);
 			} else {
-				get_target(root, &target, key, dom_used,
-					   dom_occupied, dom_cur_grp_used,
-					   tgts_used, k, allow_status);
+				curr_pd = jm_obj_shard_pd(jmop, k);
+				get_target(root, curr_pd, &target, key, dom_used, dom_occupied,
+					   dom_cur_grp_used, tgts_used, k, allow_status);
 			}
 
 			if (target == NULL) {
@@ -978,8 +1100,7 @@ jump_map_create(struct pool_map *poolmap, struct pl_map_init_attr *mia,
 	pool_map_addref(poolmap);
 	jmap->jmp_map.pl_poolmap = poolmap;
 
-	rc = pool_map_find_domain(poolmap, PO_COMP_TP_ROOT,
-				  PO_COMP_ID_ALL, &root);
+	rc = pool_map_find_domain(poolmap, PO_COMP_TP_ROOT, PO_COMP_ID_ALL, &root);
 	if (rc == 0) {
 		D_ERROR("Could not find root node in pool map.");
 		rc = -DER_NONEXIST;
@@ -987,14 +1108,19 @@ jump_map_create(struct pool_map *poolmap, struct pl_map_init_attr *mia,
 	}
 
 	jmap->jmp_redundant_dom = mia->ia_jump_map.domain;
-	rc = pool_map_find_domain(poolmap, mia->ia_jump_map.domain,
-				  PO_COMP_ID_ALL, &doms);
+
+	rc = pool_map_find_domain(poolmap, PO_COMP_TP_PD, PO_COMP_ID_ALL, &doms);
+	if (rc < 0)
+		goto ERR;
+	jmap->jmp_pd_nr = rc;
+
+	rc = pool_map_find_domain(poolmap, mia->ia_jump_map.domain, PO_COMP_ID_ALL, &doms);
 	if (rc <= 0) {
 		rc = (rc == 0) ? -DER_INVAL : rc;
 		goto ERR;
 	}
-
 	jmap->jmp_domain_nr = rc;
+
 	rc = pool_map_find_upin_tgts(poolmap, NULL, &jmap->jmp_target_nr);
 	if (rc) {
 		D_ERROR("cannot find active targets: %d\n", rc);
@@ -1061,12 +1187,12 @@ jump_map_obj_place(struct pl_map *map, struct daos_obj_md *md,
 
 	jmap = pl_map2jmap(map);
 	oid = md->omd_id;
-	D_DEBUG(DB_PL, "Determining location for object: "DF_OID", ver: %d\n",
-		DP_OID(oid), md->omd_ver);
+	D_DEBUG(DB_PL, "Determining location for object: "DF_OID", ver: %d, pda: %d\n",
+		DP_OID(oid), md->omd_ver, md->omd_pda);
 
-	rc = jm_obj_placement_get(jmap, md, shard_md, &jmop);
+	rc = jm_obj_placement_init(jmap, md, shard_md, &jmop);
 	if (rc) {
-		D_ERROR("jm_obj_placement_get failed, rc "DF_RC"\n", DP_RC(rc));
+		D_ERROR("jm_obj_placement_init failed, rc "DF_RC"\n", DP_RC(rc));
 		return rc;
 	}
 
@@ -1123,6 +1249,7 @@ jump_map_obj_place(struct pl_map *map, struct daos_obj_md *md,
 
 	*layout_pp = layout;
 out:
+	jm_obj_placement_fini(&jmop);
 	remap_list_free_all(&extend_list);
 
 	if (extend_layout != NULL)
@@ -1184,9 +1311,9 @@ jump_map_obj_find_rebuild(struct pl_map *map, struct daos_obj_md *md,
 	jmap = pl_map2jmap(map);
 	oid = md->omd_id;
 
-	rc = jm_obj_placement_get(jmap, md, shard_md, &jmop);
+	rc = jm_obj_placement_init(jmap, md, shard_md, &jmop);
 	if (rc) {
-		D_ERROR("jm_obj_placement_get failed, rc "DF_RC"\n", DP_RC(rc));
+		D_ERROR("jm_obj_placement_init failed, rc "DF_RC"\n", DP_RC(rc));
 		return rc;
 	}
 
@@ -1201,6 +1328,7 @@ jump_map_obj_find_rebuild(struct pl_map *map, struct daos_obj_md *md,
 			     array_size, &idx, layout, &remap_list, false);
 
 out:
+	jm_obj_placement_fini(&jmop);
 	remap_list_free_all(&remap_list);
 	if (layout != NULL)
 		pl_obj_layout_free(layout);
@@ -1234,9 +1362,9 @@ jump_map_obj_find_reint(struct pl_map *map, struct daos_obj_md *md,
 	}
 
 	jmap = pl_map2jmap(map);
-	rc = jm_obj_placement_get(jmap, md, shard_md, &jop);
+	rc = jm_obj_placement_init(jmap, md, shard_md, &jop);
 	if (rc) {
-		D_ERROR("jm_obj_placement_get failed, rc %d.\n", rc);
+		D_ERROR("jm_obj_placement_init failed, rc %d.\n", rc);
 		return rc;
 	}
 
@@ -1262,6 +1390,7 @@ jump_map_obj_find_reint(struct pl_map *map, struct daos_obj_md *md,
 			     array_size, &idx, reint_layout, &reint_list,
 			     false);
 out:
+	jm_obj_placement_fini(&jop);
 	remap_list_free_all(&reint_list);
 	if (layout != NULL)
 		pl_obj_layout_free(layout);
@@ -1298,9 +1427,9 @@ jump_map_obj_find_addition(struct pl_map *map, struct daos_obj_md *md,
 
 	jmap = pl_map2jmap(map);
 
-	rc = jm_obj_placement_get(jmap, md, shard_md, &jop);
+	rc = jm_obj_placement_init(jmap, md, shard_md, &jop);
 	if (rc) {
-		D_ERROR("jm_obj_placement_get failed, rc %d.\n", rc);
+		D_ERROR("jm_obj_placement_init failed, rc %d.\n", rc);
 		return rc;
 	}
 
@@ -1321,6 +1450,7 @@ jump_map_obj_find_addition(struct pl_map *map, struct daos_obj_md *md,
 	rc = remap_list_fill(map, md, shard_md, reint_ver, tgt_rank, shard_id,
 			     array_size, &idx, add_layout, &add_list, true);
 out:
+	jm_obj_placement_fini(&jop);
 	remap_list_free_all(&add_list);
 
 	if (layout != NULL)

--- a/src/placement/jump_map.c
+++ b/src/placement/jump_map.c
@@ -85,6 +85,13 @@ crc(uint64_t data, uint32_t init_val)
 	return crc64_ecma_refl(init_val, (uint8_t *)&data, sizeof(data));
 }
 
+static void
+jm_obj_placement_fini(struct jm_obj_placement *jmop)
+{
+	if (jmop->jmop_pd_ptrs != NULL && jmop->jmop_pd_ptrs != jmop->jmop_pd_ptrs_inline)
+		D_FREE(jmop->jmop_pd_ptrs);
+}
+
 /** Initialize the PDs for object to prepare for the layout calculation */
 #define LOCAL_PD_ARRAY_SIZE	(4)
 static int
@@ -161,8 +168,8 @@ jm_obj_pd_init(struct pl_jump_map *jmap, struct daos_obj_md *md, struct pool_dom
 out:
 	if (pd_used != NULL && pd_used != pd_used_array)
 		D_FREE(pd_used);
-	if (rc && jmop->jmop_pd_ptrs != NULL && jmop->jmop_pd_ptrs != jmop->jmop_pd_ptrs_inline)
-		D_FREE(jmop->jmop_pd_ptrs);
+	if (rc)
+		jm_obj_placement_fini(jmop);
 	return rc;
 }
 
@@ -310,13 +317,6 @@ jm_obj_placement_init(struct pl_jump_map *jmap, struct daos_obj_md *md,
 		D_ERROR("obj="DF_OID", jm_obj_pd_init failed, "DF_RC"\n", DP_OID(oid), DP_RC(rc));
 
 	return rc;
-}
-
-static void
-jm_obj_placement_fini(struct jm_obj_placement *jmop)
-{
-	if (jmop->jmop_pd_ptrs != NULL && jmop->jmop_pd_ptrs != jmop->jmop_pd_ptrs_inline)
-		D_FREE(jmop->jmop_pd_ptrs);
 }
 
 /**

--- a/src/placement/tests/SConscript
+++ b/src/placement/tests/SConscript
@@ -12,6 +12,7 @@ def scons():
     ring_test_tgt = denv.SharedObject(['ring_map_place_obj.c',
                                        'place_obj_common.c'])
     jump_test_tgt = denv.SharedObject(['jump_map_place_obj.c',
+                                       'jump_map_pda.c',
                                        'place_obj_common.c',
                                        'placement_test.c'])
     pl_bench_tgt = denv.SharedObject(['pl_bench.c', 'place_obj_common.c'])

--- a/src/placement/tests/SConscript
+++ b/src/placement/tests/SConscript
@@ -13,6 +13,7 @@ def scons():
                                        'place_obj_common.c'])
     jump_test_tgt = denv.SharedObject(['jump_map_place_obj.c',
                                        'jump_map_pda.c',
+                                       'jump_map_dist.c',
                                        'place_obj_common.c',
                                        'placement_test.c'])
     pl_bench_tgt = denv.SharedObject(['pl_bench.c', 'place_obj_common.c'])
@@ -28,7 +29,7 @@ def scons():
                                       ['../../pool/srv_pool_map.c'],
                                       LIBS=['daos', 'daos_common', 'gurt',
                                             'cart', 'placement', 'uuid',
-                                            'pthread', 'isal', 'cmocka'])
+                                            'pthread', 'isal', 'cmocka', 'm'])
 
     pl_bench = daos_build.program(denv, 'pl_bench', pl_bench_tgt + common_tgts,
                                   LIBS=['daos', 'daos_common', 'gurt', 'cart',

--- a/src/placement/tests/jump_map_dist.c
+++ b/src/placement/tests/jump_map_dist.c
@@ -1,0 +1,174 @@
+/**
+ * (C) Copyright 2021-2022 Intel Corporation.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause-Patent
+ */
+#define D_LOGFAC	DD_FAC(tests)
+
+#include <daos/common.h>
+#include <daos/placement.h>
+#include <daos.h>
+#include <daos/object.h>
+#include <math.h>
+
+#include "place_obj_common.h"
+/* Gain some internal knowledge of pool server */
+#include "../../pool/rpc.h"
+#include "../../pool/srv_pool_map.h"
+
+static int test_num_objs = 1024;
+static int test_obj_class = OC_EC_8P2G2;
+
+static void
+layout_count_tgt(struct pl_obj_layout *layout, uint32_t *tgt_counters, uint32_t size)
+{
+	int grp;
+	int sz;
+	int index;
+
+	for (grp = 0; grp < layout->ol_grp_nr; ++grp) {
+		for (sz = 0; sz < layout->ol_grp_size; ++sz) {
+			struct pl_obj_shard shard;
+
+			index = (grp * layout->ol_grp_size) + sz;
+			shard = layout->ol_shards[index];
+			D_ASSERT(shard.po_target >= 0);
+			D_ASSERT(shard.po_target < size);
+			tgt_counters[shard.po_target]++;
+		}
+	}
+}
+
+#define MAX_OID_HI ((1UL << 32) - 1)
+static void
+layout_dist_test(void **state, uint32_t pd_nr, uint32_t doms_per_pd, uint32_t nodes_per_dom,
+		 uint32_t tgts_per_node, uint32_t pda)
+{
+	struct pool_map		*po_map;
+	struct pl_map		*pl_map;
+	struct pl_obj_layout	**layouts;
+	daos_obj_id_t		*oids;
+	char			 obj_class_name[64] = {0};
+	uint32_t		*tgt_counters;
+	uint32_t		 tgt_max = 0, tgt_min = -1, tgt_avg = 0;
+	double			 std_dev;
+	uint64_t		 lo = 0, hi = 0;
+	uint32_t		 i, total_tgts;
+	int			 rc;
+
+	if (pd_nr == 0)
+		pd_nr = 1;
+	total_tgts = pd_nr * doms_per_pd * nodes_per_dom * tgts_per_node;
+	daos_oclass_id2name(test_obj_class, obj_class_name);
+	print_message("\nWith %d PDs, %d domains each PD, %d nodes each domain, "
+		      "%d targets each node = %d targets, num_objs %d, obj_class %s\n",
+		      pd_nr, doms_per_pd, nodes_per_dom, tgts_per_node, total_tgts,
+		      test_num_objs, obj_class_name);
+	gen_maps(pd_nr, doms_per_pd, nodes_per_dom, tgts_per_node, &po_map, &pl_map);
+
+	D_ALLOC_ARRAY(layouts, test_num_objs);
+	D_ASSERT(layouts != NULL);
+	D_ALLOC_ARRAY(oids, test_num_objs);
+	D_ASSERT(oids != NULL);
+	D_ALLOC_ARRAY(tgt_counters, total_tgts);
+	D_ASSERT(tgt_counters != NULL);
+
+	for (i = 0; i < test_num_objs; i++) {
+		if (i % MAX_OID_HI == 0) {
+			lo++;
+			hi = 0;
+		}
+		gen_oid(&oids[i], lo, hi++, test_obj_class);
+		rc = plt_obj_place(oids[i], pda, &layouts[i], pl_map, false);
+		assert_rc_equal(rc, 0);
+		layout_count_tgt(layouts[i], tgt_counters, total_tgts);
+		pl_obj_layout_free(layouts[i]);
+	}
+
+	for (i = 0; i < total_tgts; i++) {
+		tgt_max = max(tgt_counters[i], tgt_max);
+		tgt_min = min(tgt_counters[i], tgt_min);
+		tgt_avg += tgt_counters[i];
+	}
+	tgt_avg /= total_tgts;
+
+	std_dev = 0;
+	print_message("Place %d object (class %s), on %d targets, #shards on each target -\n",
+		      test_num_objs, obj_class_name, total_tgts);
+	for (i = 0; i < total_tgts; i++) {
+		if (i > 0 && i % 8 == 0)
+			print_message("\n");
+		std_dev += pow(tgt_counters[i] - tgt_avg, 2);
+		print_message("[%4d]: %4d;||", i, tgt_counters[i]);
+	}
+	print_message("\n");
+	std_dev /= total_tgts;
+	std_dev = sqrt(std_dev);
+
+	print_message("\nPlace %d object (class %s), on %d targets, statistics of #shards on tgts\n"
+		      "\t\tmin:      %d\n"
+		      "\t\taverage:  %d\n"
+		      "\t\tmax:      %d\n"
+		      "\t\tstd_dev:  %.2f\n",
+		      test_num_objs, obj_class_name, total_tgts,
+		      tgt_min, tgt_avg, tgt_max, std_dev);
+
+	free_pool_and_placement_map(po_map, pl_map);
+	D_FREE(oids);
+	D_FREE(layouts);
+	D_FREE(tgt_counters);
+}
+
+static void
+basic_dist_test(void **state)
+{
+	layout_dist_test(state, 0, 16, 8, 8, 0);
+}
+
+/*
+ * ------------------------------------------------
+ * End Test Cases
+ * ------------------------------------------------
+ */
+
+static int
+placement_test_setup(void **state)
+{
+	assert_success(obj_class_init());
+
+	return pl_init();
+}
+
+static int
+placement_test_teardown(void **state)
+{
+	pl_fini();
+	obj_class_fini();
+
+	return 0;
+}
+
+#define T(dsc, test) { "PLACEMENT "STR(__COUNTER__)" ("#test"): " dsc, test, \
+			  placement_test_setup, placement_test_teardown }
+
+static const struct CMUnitTest dist_tests[] = {
+	/* Standard configurations */
+	T("Basic obj layout distribution test", basic_dist_test),
+};
+
+int
+dist_tests_run(bool verbose, uint32_t num_objs, int obj_class)
+{
+	int rc = 0;
+
+	g_verbose = verbose;
+	if (num_objs != 0)
+		test_num_objs = num_objs;
+	if (obj_class != 0)
+		test_obj_class = obj_class;
+
+	rc += cmocka_run_group_tests_name("Obj placement distribution Tests",
+					  dist_tests, NULL, NULL);
+
+	return rc;
+}

--- a/src/placement/tests/jump_map_pda.c
+++ b/src/placement/tests/jump_map_pda.c
@@ -1,0 +1,91 @@
+/**
+ * (C) Copyright 2016-2022 Intel Corporation.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause-Patent
+ */
+#define D_LOGFAC	DD_FAC(tests)
+
+#include <daos/common.h>
+#include <daos/placement.h>
+#include <daos.h>
+#include <daos/object.h>
+#include "place_obj_common.h"
+/* Gain some internal knowledge of pool server */
+#include "../../pool/rpc.h"
+#include "../../pool/srv_pool_map.h"
+
+static void
+base_pda_test(void **state)
+{
+	struct pool_map		*po_map;
+	struct pl_map		*pl_map;
+
+	/* --------------------------------------------------------- */
+	print_message("\nWith 2 domains, 2 nodes each, 2 targets each = 8 targets\n");
+	gen_maps(1, 2, 2, 2, &po_map, &pl_map);
+	/* even though it's 8 total, still need a domain for each replica */
+	assert_invalid_param(pl_map, OC_RP_4G2, 0);
+
+	free_pool_and_placement_map(po_map, pl_map);
+
+	/* --------------------------------------------------------- */
+	print_message("\nWith 4 PDs, 4 domains each PD, 2 nodes each domain, "
+		      "8 targets each node = 256 targets\n");
+	gen_maps(4, 4, 2, 8, &po_map, &pl_map);
+	print_message("place OC_RP_4G2 pda 3\n");
+	assert_placement_success_print(pl_map, OC_RP_4G2, 3);
+	print_message("place OC_EC_4P2G2 pda 1\n");
+	assert_placement_success_print(pl_map, OC_EC_4P2G2, 1);
+	print_message("place OC_EC8P2G2 pda 4\n");
+	assert_placement_success_print(pl_map, OC_EC_8P2G2, 4);
+	print_message("place OC_EC16P2G8 pda 3, need 18 domains will fail\n");
+	assert_invalid_param(pl_map, OC_EC_16P2G8, 3);
+
+	free_pool_and_placement_map(po_map, pl_map);
+
+	/* The End */
+}
+
+/*
+ * ------------------------------------------------
+ * End Test Cases
+ * ------------------------------------------------
+ */
+
+static int
+placement_test_setup(void **state)
+{
+	assert_success(obj_class_init());
+
+	return pl_init();
+}
+
+static int
+placement_test_teardown(void **state)
+{
+	pl_fini();
+	obj_class_fini();
+
+	return 0;
+}
+
+#define T(dsc, test) { "PLACEMENT "STR(__COUNTER__)" ("#test"): " dsc, test, \
+			  placement_test_setup, placement_test_teardown }
+
+static const struct CMUnitTest pda_tests[] = {
+	/* Standard configurations */
+	T("Base PDA test", base_pda_test),
+};
+
+int
+pda_tests_run(bool verbose)
+{
+	int rc = 0;
+
+	g_verbose = verbose;
+
+	rc += cmocka_run_group_tests_name("Jump Map Placement PDA Tests", pda_tests,
+					  NULL, NULL);
+
+	return rc;
+}

--- a/src/placement/tests/jump_map_pda.c
+++ b/src/placement/tests/jump_map_pda.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2022 Intel Corporation.
+ * (C) Copyright 2021-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */

--- a/src/placement/tests/pl_bench.c
+++ b/src/placement/tests/pl_bench.c
@@ -195,7 +195,7 @@ benchmark_placement(int argc, char **argv, uint32_t num_domains,
 	}
 
 	/* Create reference pool/placement map */
-	gen_pool_and_placement_map(num_domains, nodes_per_domain,
+	gen_pool_and_placement_map(1, num_domains, nodes_per_domain,
 				   vos_per_target, map_type,
 				   &pool_map, &pl_map);
 	D_ASSERT(pool_map != NULL);
@@ -313,7 +313,7 @@ compute_data_movement(uint32_t domains, uint32_t nodes_per_domain,
 	 * Generate a new pool/placement map combination for
 	 * this new configuration
 	 */
-	gen_pool_and_placement_map(domains, nodes_per_domain, vos_per_target,
+	gen_pool_and_placement_map(1, domains, nodes_per_domain, vos_per_target,
 				   map_type, &iter_pool_map, &iter_pl_map);
 	D_ASSERT(iter_pool_map != NULL);
 	D_ASSERT(iter_pl_map != NULL);
@@ -500,7 +500,7 @@ benchmark_add_data_movement(int argc, char **argv, uint32_t num_domains,
 	/* Measure movement for all but ideal case */
 	for (type_idx = 0; type_idx < num_map_types - 1; type_idx++) {
 		/* Create initial reference pool/placement map */
-		gen_pool_and_placement_map(num_domains, nodes_per_domain,
+		gen_pool_and_placement_map(1, num_domains, nodes_per_domain,
 					   vos_per_target, map_types[type_idx],
 					   &initial_pool_map, &initial_pl_map);
 		D_ASSERT(initial_pool_map != NULL);

--- a/src/placement/tests/place_obj_common.c
+++ b/src/placement/tests/place_obj_common.c
@@ -40,7 +40,7 @@ print_layout(struct pl_obj_layout *layout)
 }
 
 int
-plt_obj_place(daos_obj_id_t oid, struct pl_obj_layout **layout,
+plt_obj_place(daos_obj_id_t oid, uint32_t pda, struct pl_obj_layout **layout,
 		struct pl_map *pl_map, bool print_layout_flag)
 {
 	struct daos_obj_md	 md;
@@ -48,6 +48,7 @@ plt_obj_place(daos_obj_id_t oid, struct pl_obj_layout **layout,
 
 	memset(&md, 0, sizeof(md));
 	md.omd_id  = oid;
+	md.omd_pda = pda;
 	D_ASSERT(pl_map != NULL);
 	md.omd_ver = pool_map_get_version(pl_map->pl_poolmap);
 
@@ -538,26 +539,38 @@ plt_spare_tgts_get(uuid_t pl_uuid, daos_obj_id_t oid, uint32_t *failed_tgts,
 }
 
 void
-gen_pool_and_placement_map(int num_domains, int nodes_per_domain,
+gen_pool_and_placement_map(int num_pds, int fdoms_per_pd, int nodes_per_domain,
 			   int vos_per_target, pl_map_type_t pl_type,
-			   struct pool_map **po_map_out,
-			   struct pl_map **pl_map_out)
+			   struct pool_map **po_map_out, struct pl_map **pl_map_out)
 {
 	struct pool_buf         *buf;
 	int                      i;
 	struct pl_map_init_attr  mia;
-	int                      nr;
+	int                      nr = 0;
 	struct pool_component   *comps;
 	struct pool_component   *comp;
+	int			 num_domains;
 	int                      rc;
 
-	nr = num_domains + (nodes_per_domain * num_domains) +
-	     (num_domains * nodes_per_domain * vos_per_target);
+	num_domains = num_pds * fdoms_per_pd;
+	if (num_pds >= 2)
+		nr = num_pds;
+	nr += num_domains + (nodes_per_domain * num_domains) +
+	      (num_domains * nodes_per_domain * vos_per_target);
 	D_ALLOC_ARRAY(comps, nr);
 	D_ASSERT(comps != NULL);
 
 	comp = &comps[0];
 	/* fake the pool map */
+	for (i = 0; i < num_pds && num_pds >= 2; i++, comp++) {
+		comp->co_type   = PO_COMP_TP_PD;
+		comp->co_status = PO_COMP_ST_UPIN;
+		comp->co_id     = i;
+		comp->co_rank   = i;
+		comp->co_ver    = 1;
+		comp->co_nr     = fdoms_per_pd;
+	}
+
 	for (i = 0; i < num_domains; i++, comp++) {
 		comp->co_type   = PO_COMP_TP_NODE;
 		comp->co_status = PO_COMP_ST_UPIN;
@@ -602,9 +615,8 @@ gen_pool_and_placement_map(int num_domains, int nodes_per_domain,
 	/* No longer needed, copied into pool map */
 	D_FREE(buf);
 
-	mia.ia_type         = pl_type;
-	mia.ia_ring.ring_nr = 1;
-	mia.ia_ring.domain  = PO_COMP_TP_NODE;
+	mia.ia_type		= pl_type;
+	mia.ia_jump_map.domain	= PO_COMP_TP_NODE;
 
 	rc = pl_map_create(*po_map_out, &mia, pl_map_out);
 	assert_success(rc);

--- a/src/placement/tests/place_obj_common.c
+++ b/src/placement/tests/place_obj_common.c
@@ -552,6 +552,8 @@ gen_pool_and_placement_map(int num_pds, int fdoms_per_pd, int nodes_per_domain,
 	int			 num_domains;
 	int                      rc;
 
+	if (num_pds < 1)
+		num_pds = 1;
 	num_domains = num_pds * fdoms_per_pd;
 	if (num_pds >= 2)
 		nr = num_pds;

--- a/src/placement/tests/place_obj_common.h
+++ b/src/placement/tests/place_obj_common.h
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2021 Intel Corporation.
+ * (C) Copyright 2016-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -12,11 +12,27 @@
 #include <daos/placement.h>
 #include <daos.h>
 
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include <daos/tests_lib.h>
+#define STR_HELPER(x) #x
+#define STR(x) STR_HELPER(x)
+
+extern bool g_verbose;
+
+#define skip_msg(msg) do { print_message(__FILE__":" STR(__LINE__) \
+			" Skipping > "msg"\n"); skip(); } \
+			while (0)
+#define is_true assert_true
+#define is_false assert_false
+
 void
 print_layout(struct pl_obj_layout *layout);
 
 int
-plt_obj_place(daos_obj_id_t oid, struct pl_obj_layout **layout,
+plt_obj_place(daos_obj_id_t oid, uint32_t pda, struct pl_obj_layout **layout,
 		struct pl_map *pl_map, bool print_layout);
 
 void
@@ -94,10 +110,9 @@ plt_spare_tgts_get(uuid_t pl_uuid, daos_obj_id_t oid, uint32_t *failed_tgts,
 		   struct pool_map *po_map, struct pl_map *pl_map);
 
 void
-gen_pool_and_placement_map(int num_domains, int nodes_per_domain,
+gen_pool_and_placement_map(int num_pds, int fdoms_per_pd, int nodes_per_domain,
 			   int vos_per_target, pl_map_type_t pl_type,
-			   struct pool_map **po_map_out,
-			   struct pl_map **pl_map_out);
+			   struct pool_map **po_map_out, struct pl_map **pl_map_out);
 
 void
 gen_pool_and_placement_map_non_standard(int num_domains,
@@ -128,4 +143,77 @@ extend_test_pool_map(struct pool_map *map, uint32_t nnodes, d_rank_list_t *rank_
 
 bool
 is_max_class_obj(daos_oclass_id_t cid);
+
+int
+placement_tests_run(bool verbose);
+int
+pda_tests_run(bool verbose);
+
+static inline void
+verbose_msg(char *msg, ...)
+{
+	if (g_verbose) {
+		va_list vargs;
+
+		va_start(vargs, msg);
+		vprint_message(msg, vargs);
+		va_end(vargs);
+	}
+}
+
+static inline void
+gen_maps(int num_pds, int fdoms_per_pd, int nodes_per_domain, int vos_per_target,
+	 struct pool_map **po_map, struct pl_map **pl_map)
+{
+	*po_map = NULL;
+	*pl_map = NULL;
+	gen_pool_and_placement_map(num_pds, fdoms_per_pd, nodes_per_domain, vos_per_target,
+				   PL_TYPE_JUMP_MAP, po_map, pl_map);
+	assert_non_null(*po_map);
+	assert_non_null(*pl_map);
+}
+
+static inline void
+gen_oid(daos_obj_id_t *oid, uint64_t lo, uint64_t hi, daos_oclass_id_t cid)
+{
+	int rc;
+
+	oid->lo = lo;
+	/* make sure top 32 bits are unset (DAOS only) */
+	oid->hi = hi & 0xFFFFFFFF;
+	rc = daos_obj_set_oid_by_class(oid, 0, cid, 0);
+	assert_rc_equal(rc, cid == OC_UNKNOWN ? -DER_INVAL : 0);
+}
+
+#define assert_placement_success_print(pl_map, cid, pda)			\
+	do {									\
+		daos_obj_id_t __oid;						\
+		struct pl_obj_layout *__layout = NULL;				\
+		gen_oid(&__oid, 1, UINT64_MAX, cid);				\
+		assert_success(plt_obj_place(__oid, pda, &__layout, pl_map,	\
+				true));						\
+		pl_obj_layout_free(__layout);					\
+	} while (0)
+
+#define assert_placement_success(pl_map, cid, pda)				\
+	do {									\
+		daos_obj_id_t __oid;						\
+		struct pl_obj_layout *__layout = NULL;				\
+		gen_oid(&__oid, 1, UINT64_MAX, cid);				\
+		assert_success(plt_obj_place(__oid, pda, &__layout, pl_map,	\
+				false));					\
+		pl_obj_layout_free(__layout);					\
+	} while (0)
+
+#define assert_invalid_param(pl_map, cid, pda)					\
+	do {									\
+		daos_obj_id_t __oid;						\
+		struct pl_obj_layout *__layout = NULL;				\
+		int rc;								\
+		gen_oid(&__oid, 1, UINT64_MAX, cid);				\
+		rc = plt_obj_place(__oid, pda, &__layout,			\
+				   pl_map, false);				\
+		assert_rc_equal(rc, -DER_INVAL);				\
+	} while (0)
+
 #endif /*   PL_MAP_COMMON_H   */

--- a/src/placement/tests/place_obj_common.h
+++ b/src/placement/tests/place_obj_common.h
@@ -148,6 +148,8 @@ int
 placement_tests_run(bool verbose);
 int
 pda_tests_run(bool verbose);
+int
+dist_tests_run(bool verbose, uint32_t num_obj, int obj_class);
 
 static inline void
 verbose_msg(char *msg, ...)

--- a/src/placement/tests/placement_test.c
+++ b/src/placement/tests/placement_test.c
@@ -15,7 +15,7 @@
 #include <daos/tests_lib.h>
 
 
-const char *s_opts = "he:f:vp";
+const char *s_opts = "he:f:vpdn:l:";
 static int idx;
 static struct option l_opts[] = {
 	{"exclude", required_argument, NULL, 'e'},
@@ -23,6 +23,9 @@ static struct option l_opts[] = {
 	{"help",    no_argument,       NULL, 'h'},
 	{"verbose", no_argument,       NULL, 'v'},
 	{"pda",     no_argument,       NULL, 'p'},
+	{"distribute", no_argument,    NULL, 'd'},
+	{"num_objs", required_argument, NULL, 'n'},
+	{"obj_class", required_argument, NULL, 'l'},
 };
 
 static bool
@@ -54,16 +57,21 @@ print_usage(char *name)
 		"\n\nCOMMON TESTS\n==========================\n");
 	print_message("%s -e|--exclude <TESTS>\n", name);
 	print_message("%s -f|--filter <TESTS>\n", name);
+	print_message("%s -p|--pda <TESTS>\n", name);
+	print_message("%s -d|--distribut [-n num_objs] [-l obj_class] <TESTS>\n", name);
 	print_message("%s -h|--help\n", name);
 	print_message("%s -v|--verbose\n", name);
 }
 
 int main(int argc, char *argv[])
 {
-	int	opt;
-	char	filter[1024];
-	bool	pda_test = false;
-	bool	verbose = false;
+	int		opt;
+	char		filter[1024];
+	bool		pda_test = false;
+	bool		dist_test = false;
+	bool		verbose = false;
+	uint32_t	num_objs = 0;
+	int		obj_class = 0;
 
 	assert_success(daos_debug_init(DAOS_LOG_DEFAULT));
 
@@ -103,12 +111,27 @@ int main(int argc, char *argv[])
 		case 'p':
 			pda_test = true;
 			break;
+		case 'd':
+			dist_test = true;
+			break;
+		case 'n':
+			num_objs = atoi(optarg);
+			break;
+		case 'l':
+			obj_class = daos_oclass_name2id(optarg);
+			if (obj_class == OC_UNKNOWN) {
+				D_ERROR("invalid obj class %s\n", optarg);
+				return -1;
+			}
+			break;
 		default:
 			break;
 		}
 	}
 	if (pda_test)
 		pda_tests_run(verbose);
+	if (dist_test)
+		dist_tests_run(verbose, num_objs, obj_class);
 	else
 		placement_tests_run(verbose);
 

--- a/src/placement/tests/placement_test.c
+++ b/src/placement/tests/placement_test.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2021 Intel Corporation.
+ * (C) Copyright 2021-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  *
@@ -15,13 +15,14 @@
 #include <daos/tests_lib.h>
 
 
-const char *s_opts = "he:f:v";
+const char *s_opts = "he:f:vp";
 static int idx;
 static struct option l_opts[] = {
 	{"exclude", required_argument, NULL, 'e'},
 	{"filter",  required_argument, NULL, 'f'},
 	{"help",    no_argument,       NULL, 'h'},
 	{"verbose", no_argument,       NULL, 'v'},
+	{"pda",     no_argument,       NULL, 'p'},
 };
 
 static bool
@@ -57,12 +58,11 @@ print_usage(char *name)
 	print_message("%s -v|--verbose\n", name);
 }
 
-int placement_tests_run(bool verbose);
-
 int main(int argc, char *argv[])
 {
 	int	opt;
 	char	filter[1024];
+	bool	pda_test = false;
 	bool	verbose = false;
 
 	assert_success(daos_debug_init(DAOS_LOG_DEFAULT));
@@ -100,11 +100,17 @@ int main(int argc, char *argv[])
 			D_PRINT("filter not enabled. %s not applied", filter);
 #endif
 			break;
+		case 'p':
+			pda_test = true;
+			break;
 		default:
 			break;
 		}
 	}
-	placement_tests_run(verbose);
+	if (pda_test)
+		pda_tests_run(verbose);
+	else
+		placement_tests_run(verbose);
 
 	daos_debug_fini();
 

--- a/src/placement/tests/ring_map_place_obj.c
+++ b/src/placement/tests/ring_map_place_obj.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2021 Intel Corporation.
+ * (C) Copyright 2016-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -57,7 +57,7 @@ main(int argc, char **argv)
 		return rc;
 	}
 
-	gen_pool_and_placement_map(DOM_NR, NODE_PER_DOM,
+	gen_pool_and_placement_map(1, DOM_NR, NODE_PER_DOM,
 				   VOS_PER_TARGET, PL_TYPE_RING,
 				   &po_map, &pl_map);
 	D_ASSERT(po_map != NULL);
@@ -74,7 +74,7 @@ main(int argc, char **argv)
 	rc = daos_obj_set_oid_by_class(&oid, 0, OC_RP_4G2, 0);
 	assert_success(rc == 0);
 	D_PRINT("\ntest initial placement when no failed shard ...\n");
-	assert_success(plt_obj_place(oid, &lo_1, pl_map, true));
+	assert_success(plt_obj_place(oid, 0, &lo_1, pl_map, true));
 	plt_obj_layout_check(lo_1, COMPONENT_NR, 0);
 
 	/* test plt_obj_place when some/all shards failed */
@@ -82,7 +82,7 @@ main(int argc, char **argv)
 	for (i = 0; i < SPARE_MAX_NUM && i < lo_1->ol_nr; i++)
 		plt_fail_tgt(lo_1->ol_shards[i].po_target, &po_ver, po_map,
 			     pl_debug_msg);
-	assert_success(plt_obj_place(oid, &lo_2, pl_map, true));
+	assert_success(plt_obj_place(oid, 0, &lo_2, pl_map, true));
 	plt_obj_layout_check(lo_2, COMPONENT_NR, 0);
 	D_ASSERT(!plt_obj_layout_match(lo_1, lo_2));
 	D_PRINT("spare target candidate:");
@@ -96,7 +96,7 @@ main(int argc, char **argv)
 	for (i = 0; i < SPARE_MAX_NUM && i < lo_1->ol_nr; i++)
 		plt_reint_tgt_up(lo_1->ol_shards[i].po_target, &po_ver, po_map,
 			    pl_debug_msg);
-	assert_success(plt_obj_place(oid, &lo_3, pl_map, true));
+	assert_success(plt_obj_place(oid, 0, &lo_3, pl_map, true));
 	plt_obj_layout_check(lo_3, COMPONENT_NR, 0);
 	D_ASSERT(plt_obj_layout_match(lo_1, lo_3));
 


### PR DESCRIPTION
Pool map change -
add PO_COMP_TP_PD component type
pool_buf_parse().

Placement change -
add pda parameter (omd_pda) to struct daos_obj_md.
add pda selection and constrain to jump_map placement code.

Added a simple unit test - "placement/tests/jump_map_pda.c".
Added a simple layout distribution test - "placement/tests/jump_map_dist.c"
(check if contiguous OIDs shards evenly distributed on all targets)  

Signed-off-by: Xuezhao Liu <xuezhao.liu@intel.com>