### PR TITLE
DAOS-8640 ftest: Re-enable the fio/rebuild test.

### DIFF
--- a/src/tests/ftest/erasurecode/rebuild_fio.py
+++ b/src/tests/ftest/erasurecode/rebuild_fio.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 '''
-  (C) Copyright 2019-2021 Intel Corporation.
+  (C) Copyright 2019-2022 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
@@ -83,7 +83,6 @@ class EcodFioRebuild(ErasureCodeFio):
         """
         self.execution('on-line')
 
-    @skipForTicket("DAOS-8640")
     def test_ec_offline_rebuild_fio(self):
         """Jira ID: DAOS-7320.
 

--- a/src/tests/ftest/erasurecode/rebuild_fio.yaml
+++ b/src/tests/ftest/erasurecode/rebuild_fio.yaml
@@ -74,6 +74,7 @@ fio:
     numjobs: 10
     directory: "/tmp/daos_dfuse"
     verify: 'crc32'
+    api: dfs
     verify_pattern: '0xabcdabcd'
     do_verify: 1
     iodepth: 10


### PR DESCRIPTION
Test-tag: ec_offline_rebuild_fio

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>
