### PR TITLE
DAOS-9738 dfuse: Disable readahead when write-through cache is used. (#7986)

### DIFF
--- a/src/client/dfuse/ops/read.c
+++ b/src/client/dfuse/ops/read.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2021 Intel Corporation.
+ * (C) Copyright 2016-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -83,7 +83,8 @@ dfuse_cb_read(fuse_req_t req, fuse_ino_t ino, size_t len, off_t position,
 	}
 
 	if (readahead) {
-		buff_len += READAHEAD_SIZE;
+		if (!fs_handle->dpi_info->di_wb_cache)
+			buff_len += READAHEAD_SIZE;
 	} else {
 		if (!skip_read) {
 			rc = daos_event_init(&ev->de_ev,

--- a/src/tests/ftest/dfuse/fio_small.yaml
+++ b/src/tests/ftest/dfuse/fio_small.yaml
@@ -64,7 +64,10 @@ fio:
     ioengine: 'libaio'
     thread: 1
     group_reporting: 1
-    direct: 1
+    direct_io: !mux
+      on:
+        direct: 1
+      off:
     verify: 'crc64'
     iodepth: 16
     bs: !mux
@@ -73,7 +76,7 @@ fio:
         size: '1M'
       bs_1M:
         blocksize: '1M'
-        size: '1G'
+        size: '2G'
     read_write: !mux
       sequential:
         rw: 'rw'


### PR DESCRIPTION
Do not use readahead when the kernel is also using write-back cache.

Add fio with random read to check for this.

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>