### PR TITLE
DAOS-9770 build: sync SPDK example names with RPM

### DIFF
--- a/docs/admin/predeployment_check.md
+++ b/docs/admin/predeployment_check.md
@@ -317,7 +317,7 @@ the SSDs with a 4K block size.
 
 `spdk_nvme_manage` tool is provided by SPDK and will be found in the following locations:
 - `/usr/bin/spdk_nvme_manage` if DAOS-maintained spdk-21.07-10 (or greater) RPM is installed
-- `<daos_src>/install/prereq/release/spdk/bin/nvme_manage` after build from DAOS source
+- `<daos_src>/install/prereq/release/spdk/bin/spdk_nvme_manage` after build from DAOS source
 
 Choose to format a SSD, use option "6" for formatting:
 ```bash

--- a/site_scons/components/__init__.py
+++ b/site_scons/components/__init__.py
@@ -332,24 +332,21 @@ def define_components(reqs):
 
     reqs.define('spdk',
                 retriever=retriever,
-                commands=['./configure --prefix="$SPDK_PREFIX"'                \
-                          ' --disable-tests --disable-unit-tests '             \
-                          ' --disable-apps --without-vhost '                   \
-                          ' --without-crypto --without-pmdk --without-rbd '    \
-                          ' --with-rdma --without-iscsi-initiator '            \
-                          ' --without-isal --without-vtune --with-shared',
+                commands=['./configure --prefix="$SPDK_PREFIX" --disable-tests '                  \
+                          '--disable-unit-tests --disable-apps --without-vhost --without-crypto ' \
+                          '--without-pmdk --without-rbd --with-rdma --without-iscsi-initiator '   \
+                          '--without-isal --without-vtune --with-shared',
                           'make CONFIG_ARCH={} $JOBS_OPT'.format(spdk_arch),
                           'make install',
                           'cp -r -P dpdk/build/lib/* "$SPDK_PREFIX/lib"',
                           'mkdir -p "$SPDK_PREFIX/include/dpdk"',
-                          'cp -r -P dpdk/build/include/* '                     \
-                          '"$SPDK_PREFIX/include/dpdk"',
+                          'cp -r -P dpdk/build/include/* "$SPDK_PREFIX/include/dpdk"',
                           'mkdir -p "$SPDK_PREFIX/share/spdk"',
                           'cp -r include scripts "$SPDK_PREFIX/share/spdk"',
-                          'cp build/examples/lsvmd "$SPDK_PREFIX/bin"',
-                          'cp build/examples/nvme_manage "$SPDK_PREFIX/bin"',
-                          'cp build/examples/identify "$SPDK_PREFIX/bin"',
-                          'cp build/examples/perf "$SPDK_PREFIX/bin"'],
+                          'cp build/examples/lsvmd "$SPDK_PREFIX/bin/spdk_nvme_lsvmd"',
+                          'cp build/examples/nvme_manage "$SPDK_PREFIX/bin/spdk_nvme_manage"',
+                          'cp build/examples/identify "$SPDK_PREFIX/bin/spdk_nvme_identify"',
+                          'cp build/examples/perf "$SPDK_PREFIX/bin/spdk_nvme_perf"'],
                 headers=['spdk/nvme.h', 'dpdk/rte_eal.h'],
                 extra_include_path=['/usr/include/dpdk',
                                     '$SPDK_PREFIX/include/dpdk',


### PR DESCRIPTION
Rename example application binaries created in source build to be
consistent with SPDK RPM.

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>