### PR TITLE
DAOS-9748 tests: Fixing test_metadata_server_restart (#7979)

### DIFF
--- a/src/tests/ftest/util/apricot/apricot/test.py
+++ b/src/tests/ftest/util/apricot/apricot/test.py
@@ -842,6 +842,7 @@ class TestWithServers(TestWithoutServers):
                 "Starting server: group=%s, hosts=%s, config=%s",
                 manager.get_config_value("name"), manager.hosts,
                 manager.get_config_value("filename"))
+            manager.manager.job.update_pattern("normal", len(manager.hosts))
             try:
                 manager.manager.run()
             except CommandFailure as error:


### PR DESCRIPTION
Resolving an issue with the test_metadata_server_restart where it fails
to detect all of the daos_server engines have restarted by ensuring the
expected number of engines is properly set.

Quick-build: true
Skip-unit-tests: true
Skip-func-test-vm: true
Test-tag: offline_extend_oclass metadata_ior

Signed-off-by: Phillip Henderson <phillip.henderson@intel.com>