### PR TITLE
DAOS-9654 obj: a few refines of iov_buf_len/iov_len (#7910)

### DIFF
--- a/src/include/daos/common.h
+++ b/src/include/daos/common.h
@@ -342,7 +342,7 @@ daos_sgl_buf_extend(d_sg_list_t *sgl, int idx, size_t new_size);
 	} while (0)
 /** Get the leftover space in an iov of sgl */
 #define daos_iov_left(sgl, iov_idx, iov_off)				\
-	((sgl)->sg_iovs[iov_idx].iov_len - (iov_off))
+	((sgl)->sg_iovs[iov_idx].iov_buf_len - (iov_off))
 /** get remaining space in an iov, assuming that iov_len is used and
  * iov_buf_len is total in buf
  */

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2021 Intel Corporation.
+ * (C) Copyright 2016-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -23,7 +23,7 @@
 
 #define CLI_OBJ_IO_PARMS	8
 
-#define OBJ_TGT_INLINE_NR	10
+#define OBJ_TGT_INLINE_NR	9
 #define OBJ_INLINE_BTIMAP	4
 
 struct obj_req_tgts {
@@ -97,6 +97,7 @@ struct obj_auxi_args {
 	/* 64-bits alignment, bitmap for retry next replicas. */
 	uint8_t				 retry_bitmap[OBJ_INLINE_BTIMAP];
 	struct obj_req_tgts		 req_tgts;
+	d_sg_list_t			*sgls_dup;
 	crt_bulk_t			*bulks;
 	uint32_t			 iod_nr;
 	uint32_t			 initial_shard;
@@ -3835,6 +3836,90 @@ obj_size_fetch_cb(const struct dc_object *obj, struct obj_auxi_args *obj_auxi)
 	}
 }
 
+/**
+ * User possibly provides sgl with iov_len < iov_buf_len, this may cause some troubles for internal
+ * handling, such as crt_bulk_create/daos_iov_left() always use iov_buf_len.
+ * For that case, we duplicate the sgls and make its iov_buf_len = iov_len.
+ */
+static int
+obj_update_sgls_dup(struct obj_auxi_args *obj_auxi, daos_obj_update_t *args)
+{
+	daos_iod_t	*iod;
+	d_sg_list_t	*sgls_dup, *sgls;
+	d_sg_list_t	*sg, *sg_dup;
+	d_iov_t		*iov, *iov_dup;
+	bool		 dup = false;
+	uint32_t	 i, j;
+	int		 rc = 0;
+
+	sgls = args->sgls;
+	if (obj_auxi->rw_args.sgls_dup != NULL || sgls == NULL)
+		return 0;
+
+	for (i = 0; i < args->nr; i++) {
+		sg = &sgls[i];
+		iod = &args->iods[i];
+		for (j = 0; j < sg->sg_nr; j++) {
+			iov = &sg->sg_iovs[j];
+			if (iov->iov_len > iov->iov_buf_len ||
+			    (iov->iov_len == 0 && iod->iod_size != DAOS_REC_ANY)) {
+				D_ERROR("invalid args, iov_len "DF_U64", iov_buf_len "DF_U64"\n",
+					iov->iov_len, iov->iov_buf_len);
+				return -DER_INVAL;
+			} else if (iov->iov_len < iov->iov_buf_len) {
+				dup = true;
+			}
+		}
+	}
+	if (dup == false)
+		return 0;
+
+	D_ALLOC_ARRAY(sgls_dup, args->nr);
+	if (sgls_dup == NULL)
+		return -DER_NOMEM;
+
+	for (i = 0; i < args->nr; i++) {
+		sg_dup = &sgls_dup[i];
+		sg = &sgls[i];
+		rc = d_sgl_init(sg_dup, sg->sg_nr);
+		if (rc)
+			goto failed;
+
+		for (j = 0; j < sg_dup->sg_nr; j++) {
+			iov_dup = &sg_dup->sg_iovs[j];
+			iov = &sg->sg_iovs[j];
+			*iov_dup = *iov;
+			iov_dup->iov_buf_len = iov_dup->iov_len;
+		}
+	}
+	obj_auxi->reasb_req.orr_usgls = sgls;
+	obj_auxi->rw_args.sgls_dup = sgls_dup;
+	args->sgls = sgls_dup;
+	return 0;
+
+failed:
+	if (sgls_dup != NULL) {
+		for (i = 0; i < args->nr; i++)
+			d_sgl_fini(&sgls_dup[i], false);
+		D_FREE(sgls_dup);
+	}
+	return rc;
+}
+
+static void
+obj_update_sgls_free(struct obj_auxi_args *obj_auxi)
+{
+	int	i;
+
+	if (obj_auxi->opc == DAOS_OBJ_RPC_UPDATE && obj_auxi->rw_args.sgls_dup != NULL) {
+		for (i = 0; i < obj_auxi->iod_nr; i++)
+			d_sgl_fini(&obj_auxi->rw_args.sgls_dup[i], false);
+		D_FREE(obj_auxi->rw_args.sgls_dup);
+		obj_auxi->rw_args.sgls_dup = NULL;
+		obj_auxi->rw_args.api_args->sgls = obj_auxi->reasb_req.orr_usgls;
+	}
+}
+
 static void
 obj_reasb_io_fini(struct obj_auxi_args *obj_auxi, bool retry)
 {
@@ -3849,6 +3934,7 @@ obj_reasb_io_fini(struct obj_auxi_args *obj_auxi, bool retry)
 	}
 	obj_bulk_fini(obj_auxi);
 	obj_auxi_free_failed_tgt_list(obj_auxi);
+	obj_update_sgls_free(obj_auxi);
 	obj_reasb_req_fini(&obj_auxi->reasb_req, obj_auxi->iod_nr);
 
 	/* zero it as user might reuse/resched the task, for
@@ -4560,6 +4646,14 @@ dc_obj_update(tse_task_t *task, struct dtx_epoch *epoch, uint32_t map_ver,
 
 	obj_task_init_common(task, DAOS_OBJ_RPC_UPDATE, map_ver, args->th,
 			     &obj_auxi, obj);
+
+	rc = obj_update_sgls_dup(obj_auxi, args);
+	if (rc) {
+		D_ERROR(DF_OID" obj_update_sgls_dup failed %d.\n", DP_OID(obj->cob_md.omd_id), rc);
+		obj_comp_cb(task, NULL);
+		goto out_task;
+	}
+
 	rc = obj_rw_req_reassemb(obj, args, NULL, obj_auxi);
 	if (rc) {
 		D_ERROR(DF_OID" obj_req_reassemb failed %d.\n",

--- a/src/object/obj_internal.h
+++ b/src/object/obj_internal.h
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2021 Intel Corporation.
+ * (C) Copyright 2016-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -350,6 +350,7 @@ struct shard_auxi_args {
 struct shard_rw_args {
 	struct shard_auxi_args	 auxi;
 	daos_obj_rw_t		*api_args;
+	d_sg_list_t		*sgls_dup;
 	struct dtx_id		 dti;
 	uint64_t		 dkey_hash;
 	crt_bulk_t		*bulks;

--- a/src/tests/suite/daos_obj.c
+++ b/src/tests/suite/daos_obj.c
@@ -2203,8 +2203,21 @@ next_step:
 	assert_rc_equal(rc, 0);
 
 	/** fetch */
-	iod.iod_size	= DAOS_REC_ANY;
+	print_message("fetch with zero iov_len\n");
+	iod.iod_size	= 1;
+	recx[0].rx_idx	= 0;
+	recx[0].rx_nr	= tmp_len * 1;
+	iod.iod_nr	= 1;
+	sg_iov[0].iov_len = 0;
+	rc = daos_obj_fetch(oh, DAOS_TX_NONE, 0, &dkey, 1, &iod, &sgl, NULL,
+			    NULL);
+	assert_rc_equal(rc, 0);
+
 	print_message("reading data back with less buffer ...\n");
+	recx[0].rx_idx	= 0;
+	recx[0].rx_nr	= tmp_len;
+	iod.iod_nr	= 3;
+	iod.iod_size	= DAOS_REC_ANY;
 	buf_out = step == 1 ? stack_buf_out : bulk_buf_out;
 	memset(buf_out, 0, buf_len);
 	tmp_len = buf_len / 2;
@@ -3402,8 +3415,10 @@ io_obj_key_query(void **state)
 	assert_rc_equal(rc, 0);
 
 	dkey_val = 10;
+	val_iov.iov_buf_len += 1024;
 	rc = daos_obj_update(oh, DAOS_TX_NONE, 0, &dkey, 1, &iod, &sgl, NULL);
 	assert_rc_equal(rc, 0);
+	d_iov_set(&val_iov, &update_var, sizeof(update_var));
 
 	recx.rx_idx = 50;
 	rc = daos_obj_update(oh, DAOS_TX_NONE, 0, &dkey, 1, &iod, &sgl, NULL);


### PR DESCRIPTION
User may provide fetch buffer iov with zero iov_len, so need to check
iov_buf_len rather than iov_len in daos_iov_left().
And user possibly provide update buffer sgl/iov with iov_len < iov_buf_len,
to avoid bulk_create's confuse, in that case dup a new sgl and set iov_buf_len
as iov_len.

Signed-off-by: Xuezhao Liu <xuezhao.liu@intel.com>