### PR TITLE
DAOS-9774 control: do not call spdk setup with zero hugepages

### DIFF
--- a/src/control/server/storage/bdev/runner.go
+++ b/src/control/server/storage/bdev/runner.go
@@ -20,7 +20,7 @@ import (
 
 const (
 	spdkSetupPath      = "../share/daos/control/setup_spdk.sh"
-	defaultNrHugepages = 4096
+	defaultNrHugepages = 1024 // default number applied by SPDK
 	nrHugepagesEnv     = "_NRHUGE"
 	targetUserEnv      = "_TARGET_USER"
 	pciAllowListEnv    = "_PCI_ALLOWED"
@@ -99,7 +99,9 @@ func defaultScriptRunner(log logging.Logger) *spdkSetupScript {
 // NOTE: will make the controller disappear from /dev until reset() called.
 func (s *spdkSetupScript) Prepare(req *storage.BdevPrepareRequest) error {
 	nrHugepages := req.HugePageCount
-	if nrHugepages < 0 {
+	// Always supply non-zero number of hugepages in request otherwise devices cannot be
+	// accessed.
+	if nrHugepages <= 0 {
 		nrHugepages = defaultNrHugepages
 	}
 


### PR DESCRIPTION
This regression was introduced in commit ccf0027af99ce803c3642787426f00f6d1924d19.

daos_server storage prepare can call SPDK setup with NRHUGE set to 0
which results in the NVMe controllers being inaccessible and reporting
permission denied.

The fix applied is to always set hugepages explicitly to a non-zero
value when calling storage prepare for NVMe, otherwise devices will
not be accessible. Use default value recommended by SPDK and if no
hugepages are required then storage prepare for NVMe should not be
called (only call if NVMe devices are to be scanned or used by engine).

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>