### PR TITLE
DAOS-9781 control: Parse bdev_list entries early

### DIFF
--- a/src/control/cmd/daos_admin/handler_test.go
+++ b/src/control/cmd/daos_admin/handler_test.go
@@ -488,7 +488,7 @@ func TestDaosAdmin_BdevFormatHandler(t *testing.T) {
 		ForwardableRequest: pbin.ForwardableRequest{Forwarded: true},
 		Properties: storage.BdevTierProperties{
 			Class:      storage.ClassNvme,
-			DeviceList: []string{"foo"},
+			DeviceList: storage.MustNewBdevDeviceList(common.MockPCIAddr(1)),
 		},
 	})
 	if err != nil {

--- a/src/control/common/collection_utils.go
+++ b/src/control/common/collection_utils.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2019-2021 Intel Corporation.
+// (C) Copyright 2019-2022 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -29,15 +29,32 @@ func (s StringSet) ToSlice() []string {
 	return slice
 }
 
-// Add adds zero or more strings to the StringSet.
-func (s StringSet) Add(values ...string) {
+// AddUnique adds zero or more strings to the StringSet,
+// and returns an error if any already exist.
+func (s StringSet) AddUnique(values ...string) error {
 	if s == nil {
-		return
+		return nil
 	}
 
+	dupes := StringSet{}
 	for _, str := range values {
+		if _, exists := s[str]; exists {
+			dupes.Add(str)
+			continue
+		}
 		s[str] = struct{}{}
 	}
+
+	if len(dupes) > 0 {
+		return errors.Errorf("duplicate strings: %s", dupes)
+	}
+
+	return nil
+}
+
+// Add adds zero or more strings to the StringSet.
+func (s StringSet) Add(values ...string) {
+	s.AddUnique(values...)
 }
 
 // Has checks if the passed string is in the StringSet.

--- a/src/control/common/collection_utils_test.go
+++ b/src/control/common/collection_utils_test.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2020-2021 Intel Corporation.
+// (C) Copyright 2020-2022 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -41,6 +41,42 @@ func TestCommon_NewStringSet(t *testing.T) {
 				}
 			}
 			AssertEqual(t, len(tc.expStrings), len(result), "wrong number of strings")
+		})
+	}
+}
+
+func TestCommon_StringSet_AddUnique(t *testing.T) {
+	for name, tc := range map[string]struct {
+		set    StringSet
+		in     []string
+		expStr string
+		expErr error
+	}{
+		"one dupe": {
+			set:    NewStringSet("one"),
+			in:     []string{"one"},
+			expErr: errors.New("duplicate strings: one"),
+		},
+		"two dupes": {
+			set:    NewStringSet("two", "one"),
+			in:     []string{"one", "two"},
+			expErr: errors.New("duplicate strings: one, two"),
+		},
+		"no dupes": {
+			set:    NewStringSet("two"),
+			in:     []string{"one"},
+			expStr: "one, two",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			gotErr := tc.set.AddUnique(tc.in...)
+
+			CmpErr(t, tc.expErr, gotErr)
+			if tc.expErr != nil {
+				return
+			}
+
+			AssertEqual(t, tc.expStr, tc.set.String(), "wrong string")
 		})
 	}
 }

--- a/src/control/lib/control/auto.go
+++ b/src/control/lib/control/auto.go
@@ -606,7 +606,7 @@ func genConfig(ctx context.Context, log logging.Logger, newEngineCfg newEngineCf
 					WithScmDeviceList(sd.numaPMems[nn][0]),
 			)
 		}
-		if len(sd.numaSSDs) > 0 {
+		if len(sd.numaSSDs) > 0 && len(sd.numaSSDs[nn]) > 0 {
 			engineCfg.WithStorage(
 				storage.NewTierConfig().
 					WithStorageClass(storage.ClassNvme.String()).

--- a/src/control/lib/control/auto_test.go
+++ b/src/control/lib/control/auto_test.go
@@ -998,6 +998,12 @@ func TestControl_AutoConfig_genConfig(t *testing.T) {
 					config.Server{},
 					sysfs.Provider{},
 				),
+				cmp.Comparer(func(x, y *storage.BdevDeviceList) bool {
+					if x == nil && y == nil {
+						return true
+					}
+					return x.Equals(y)
+				}),
 			}
 			cmpOpts = append(cmpOpts, defResCmpOpts()...)
 

--- a/src/control/lib/hardware/pci.go
+++ b/src/control/lib/hardware/pci.go
@@ -204,6 +204,11 @@ type PCIAddressSet struct {
 	addrMap map[string]*PCIAddress
 }
 
+// Equals compares two PCIAddressSets for equality.
+func (pas *PCIAddressSet) Equals(other *PCIAddressSet) bool {
+	return pas.Difference(other).Len() == 0
+}
+
 // Contains returns true if provided address is already in set.
 func (pas *PCIAddressSet) Contains(a *PCIAddress) bool {
 	if pas == nil {

--- a/src/control/server/config/server.go
+++ b/src/control/server/config/server.go
@@ -429,7 +429,7 @@ func (cfg *Server) Validate(ctx context.Context, log logging.Logger) (err error)
 			// devices to maintain backward compatible behavior.
 			bc := ec.LegacyStorage.BdevClass
 			switch {
-			case bc == storage.ClassNvme && len(ec.LegacyStorage.BdevConfig.DeviceList) == 0:
+			case bc == storage.ClassNvme && ec.LegacyStorage.BdevConfig.DeviceList.Len() == 0:
 				log.Debugf("legacy storage config conversion skipped for class %s with empty bdev_list",
 					storage.ClassNvme)
 			case bc == storage.ClassNone:
@@ -440,7 +440,7 @@ func (cfg *Server) Validate(ctx context.Context, log logging.Logger) (err error)
 					storage.NewTierConfig().
 						WithStorageClass(ec.LegacyStorage.BdevClass.String()).
 						WithBdevDeviceCount(ec.LegacyStorage.DeviceCount).
-						WithBdevDeviceList(ec.LegacyStorage.BdevConfig.DeviceList...).
+						WithBdevDeviceList(ec.LegacyStorage.BdevConfig.DeviceList.Devices()...).
 						WithBdevFileSize(ec.LegacyStorage.FileSize).
 						WithBdevBusidRange(ec.LegacyStorage.BdevConfig.BusidRange.String()),
 				)
@@ -573,14 +573,14 @@ func (cfg *Server) validateMultiServerConfig(log logging.Logger) error {
 
 		var bdevCount int
 		for _, bdevConf := range engine.Storage.Tiers.BdevConfigs() {
-			for _, dev := range bdevConf.Bdev.DeviceList {
+			for _, dev := range bdevConf.Bdev.DeviceList.Devices() {
 				if seenIn, exists := seenBdevSet[dev]; exists {
 					log.Debugf("bdev_list entry %s in %d overlaps %d", dev, idx, seenIn)
 					return FaultConfigOverlappingBdevDeviceList(idx, seenIn)
 				}
 				seenBdevSet[dev] = idx
 			}
-			bdevCount += len(bdevConf.Bdev.DeviceList)
+			bdevCount += bdevConf.Bdev.DeviceList.Len()
 		}
 		if seenBdevCount != -1 && bdevCount != seenBdevCount {
 			return FaultConfigBdevCountMismatch(idx, bdevCount, seenIdx, seenBdevCount)

--- a/src/control/server/config/server_test.go
+++ b/src/control/server/config/server_test.go
@@ -41,6 +41,12 @@ var defConfigCmpOpts = []cmp.Option{
 		security.CertificateConfig{},
 	),
 	cmpopts.IgnoreFields(Server{}, "Path"),
+	cmp.Comparer(func(x, y *storage.BdevDeviceList) bool {
+		if x == nil && y == nil {
+			return true
+		}
+		return x.Equals(y)
+	}),
 }
 
 // uncommentServerConfig removes leading comment chars from daos_server.yml
@@ -629,7 +635,7 @@ func TestServerConfig_Parsing(t *testing.T) {
 								WithBdevDeviceList(MockPCIAddr(1), MockPCIAddr(1)),
 						))
 			},
-			expValidateErr: errors.New("bdev_list contains duplicate pci"),
+			expValidateErr: errors.New("valid PCI addresses"),
 		},
 		"bad busid range": {
 			// fail first engine storage
@@ -928,7 +934,7 @@ func TestServerConfig_DuplicateValues(t *testing.T) {
 						WithStorageClass(storage.ClassNvme.String()).
 						WithBdevDeviceList(MockPCIAddr(2), MockPCIAddr(2)),
 				),
-			expErr: errors.New("bdev_list contains duplicate pci addresses"),
+			expErr: errors.New("valid PCI addresses"),
 		},
 	} {
 		t.Run(name, func(t *testing.T) {

--- a/src/control/server/ctl_storage.go
+++ b/src/control/server/ctl_storage.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2019-2021 Intel Corporation.
+// (C) Copyright 2019-2022 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -29,7 +29,7 @@ type StorageControlService struct {
 // Setup performs storage discovery and validates existence of configured devices.
 func (scs *StorageControlService) Setup() {
 	if _, err := scs.ScmScan(storage.ScmScanRequest{}); err != nil {
-		scs.log.Debugf("%s\n", errors.Wrap(err, "Warning, SCM Scan"))
+		scs.log.Debugf("%s", errors.Wrap(err, "Warning, SCM Scan"))
 	}
 
 	bdevAddrs := &storage.BdevDeviceList{}
@@ -40,7 +40,7 @@ func (scs *StorageControlService) Setup() {
 				return
 			}
 			if err := bdevAddrs.Add(tierCfg.Bdev.DeviceList.Addresses()...); err != nil {
-				scs.log.Debugf("%s\n", errors.Wrap(err, "Failed to add bdev addresses"))
+				scs.log.Debugf("%s", errors.Wrap(err, "Failed to add bdev addresses"))
 			}
 		}
 	}
@@ -49,7 +49,7 @@ func (scs *StorageControlService) Setup() {
 		DeviceList: bdevAddrs,
 	})
 	if err != nil {
-		scs.log.Debugf("%s\n", errors.Wrap(err, "Warning, NVMe Scan"))
+		scs.log.Debugf("%s", errors.Wrap(err, "Warning, NVMe Scan"))
 		return
 	}
 

--- a/src/control/server/engine/config_test.go
+++ b/src/control/server/engine/config_test.go
@@ -29,6 +29,12 @@ var update = flag.Bool("update", false, "update .golden files")
 
 var defConfigCmpOpts = []cmp.Option{
 	cmpopts.SortSlices(func(a, b string) bool { return a < b }),
+	cmp.Comparer(func(x, y *storage.BdevDeviceList) bool {
+		if x == nil && y == nil {
+			return true
+		}
+		return x.Equals(y)
+	}),
 }
 
 func TestConfig_MergeEnvVars(t *testing.T) {
@@ -325,13 +331,12 @@ func TestConfig_BdevValidation(t *testing.T) {
 			expErr: errors.New("no storage class"),
 		},
 		"nvme class; no devices": {
-			// output config path should be empty and the empty tier removed
 			cfg: baseValidConfig().
 				WithStorage(
 					storage.NewTierConfig().
 						WithStorageClass("nvme"),
 				),
-			expEmptyCfgPath: true,
+			expErr: errors.New("valid PCI addresses"),
 		},
 		"nvme class; good pci addresses": {
 			cfg: baseValidConfig().
@@ -357,7 +362,7 @@ func TestConfig_BdevValidation(t *testing.T) {
 						WithStorageClass("nvme").
 						WithBdevDeviceList(common.MockPCIAddr(1), "0000:00:00"),
 				),
-			expErr: errors.New("unexpected pci address"),
+			expErr: errors.New("valid PCI addresses"),
 		},
 		"kdev class; no devices": {
 			cfg: baseValidConfig().

--- a/src/control/server/engine/tags.go
+++ b/src/control/server/engine/tags.go
@@ -189,11 +189,13 @@ func parseCmdTags(in interface{}, tagFilter string, joiner joinFn, seenRefs refM
 			continue
 		}
 
-		nested, err := parseCmdTags(fVal.Interface(), tagFilter, joiner, seenRefs)
-		if err != nil {
-			return nil, err
+		if fVal.CanInterface() {
+			nested, err := parseCmdTags(fVal.Interface(), tagFilter, joiner, seenRefs)
+			if err != nil {
+				return nil, err
+			}
+			out = append(out, nested...)
 		}
-		out = append(out, nested...)
 	}
 
 	return

--- a/src/control/server/server_utils.go
+++ b/src/control/server/server_utils.go
@@ -46,7 +46,7 @@ const (
 func cfgHasBdevs(cfg *config.Server) bool {
 	for _, engineCfg := range cfg.Engines {
 		for _, bc := range engineCfg.Storage.Tiers.BdevConfigs() {
-			if len(bc.Bdev.DeviceList) > 0 {
+			if bc.Bdev.DeviceList.Len() > 0 {
 				return true
 			}
 		}

--- a/src/control/server/storage/bdev.go
+++ b/src/control/server/storage/bdev.go
@@ -363,7 +363,7 @@ type (
 	// BdevScanRequest defines the parameters for a Scan operation.
 	BdevScanRequest struct {
 		pbin.ForwardableRequest
-		DeviceList  []string
+		DeviceList  *BdevDeviceList
 		VMDEnabled  bool
 		BypassCache bool
 	}
@@ -377,7 +377,7 @@ type (
 	// BdevTierProperties contains basic configuration properties of a bdev tier.
 	BdevTierProperties struct {
 		Class          Class
-		DeviceList     []string
+		DeviceList     *BdevDeviceList
 		DeviceFileSize uint64 // size in bytes for NVMe device emulation
 		Tier           int
 	}

--- a/src/control/server/storage/bdev/backend_class.go
+++ b/src/control/server/storage/bdev/backend_class.go
@@ -98,7 +98,7 @@ func writeJsonConfig(log logging.Logger, req *storage.BdevWriteConfigRequest) er
 	}
 	hasBdevs := false
 	for _, tierProp := range req.TierProps {
-		if tierProp.Class != storage.ClassNvme || len(tierProp.DeviceList) > 0 {
+		if tierProp.Class != storage.ClassNvme || tierProp.DeviceList.Len() > 0 {
 			hasBdevs = true
 			break
 		}

--- a/src/control/server/storage/bdev/backend_class_test.go
+++ b/src/control/server/storage/bdev/backend_class_test.go
@@ -102,7 +102,7 @@ func TestBackend_writeJSONFile(t *testing.T) {
 				Tier:  tierID,
 				Class: storage.ClassNvme,
 				Bdev: storage.BdevConfig{
-					DeviceList: common.MockPCIAddrs(1),
+					DeviceList: storage.MustNewBdevDeviceList(common.MockPCIAddrs(1)...),
 				},
 			},
 			expOut: `
@@ -157,7 +157,7 @@ func TestBackend_writeJSONFile(t *testing.T) {
 				Tier:  tierID,
 				Class: storage.ClassNvme,
 				Bdev: storage.BdevConfig{
-					DeviceList: common.MockPCIAddrs(1, 2),
+					DeviceList: storage.MustNewBdevDeviceList(common.MockPCIAddrs(1, 2)...),
 				},
 			},
 			expOut: `
@@ -220,7 +220,7 @@ func TestBackend_writeJSONFile(t *testing.T) {
 				Tier:  tierID,
 				Class: storage.ClassNvme,
 				Bdev: storage.BdevConfig{
-					DeviceList: common.MockPCIAddrs(1, 2),
+					DeviceList: storage.MustNewBdevDeviceList(common.MockPCIAddrs(1, 2)...),
 					BusidRange: storage.MustNewBdevBusRange("0x80-0x8f"),
 				},
 			},
@@ -294,7 +294,7 @@ func TestBackend_writeJSONFile(t *testing.T) {
 				Tier:  tierID,
 				Class: storage.ClassNvme,
 				Bdev: storage.BdevConfig{
-					DeviceList: common.MockPCIAddrs(1, 2),
+					DeviceList: storage.MustNewBdevDeviceList(common.MockPCIAddrs(1, 2)...),
 					BusidRange: storage.MustNewBdevBusRange("0x80-0x8f"),
 				},
 			},
@@ -367,7 +367,7 @@ func TestBackend_writeJSONFile(t *testing.T) {
 				Tier:  tierID,
 				Class: storage.ClassNvme,
 				Bdev: storage.BdevConfig{
-					DeviceList: common.MockPCIAddrs(1, 2),
+					DeviceList: storage.MustNewBdevDeviceList(common.MockPCIAddrs(1, 2)...),
 				},
 			},
 			enableHotplug: true,

--- a/src/control/server/storage/bdev/backend_json.go
+++ b/src/control/server/storage/bdev/backend_json.go
@@ -219,7 +219,7 @@ func getSpdkConfigMethods(req *storage.BdevWriteConfigRequest) (sscs []*SpdkSubs
 			f = getAioKdevCreateMethod
 		}
 
-		for index, dev := range tier.DeviceList {
+		for index, dev := range tier.DeviceList.Devices() {
 			name := fmt.Sprintf("%s_%d_%d", req.Hostname, index, tier.Tier)
 			sscs = append(sscs, f(name, dev))
 		}

--- a/src/control/server/storage/bdev/backend_json_test.go
+++ b/src/control/server/storage/bdev/backend_json_test.go
@@ -74,7 +74,7 @@ func TestBackend_newSpdkConfig(t *testing.T) {
 		"config validation failure": {
 			class:          storage.ClassNvme,
 			devList:        []string{"not a pci address"},
-			expValidateErr: errors.New("unexpected pci address"),
+			expValidateErr: errors.New("valid PCI addresses"),
 		},
 		"multiple controllers": {
 			class:       storage.ClassNvme,
@@ -176,7 +176,7 @@ func TestBackend_newSpdkConfig(t *testing.T) {
 				Tier:  tierID,
 				Class: storage.ClassNvme,
 				Bdev: storage.BdevConfig{
-					DeviceList: tc.devList,
+					DeviceList: storage.MustNewBdevDeviceList(tc.devList...),
 					FileSize:   tc.fileSizeGB,
 					BusidRange: storage.MustNewBdevBusRange(tc.busidRange),
 				},

--- a/src/control/server/storage/bdev/provider.go
+++ b/src/control/server/storage/bdev/provider.go
@@ -71,7 +71,7 @@ func (p *Provider) Prepare(req storage.BdevPrepareRequest) (*storage.BdevPrepare
 // Format attempts to initialize NVMe devices for use by DAOS.
 // Note that this is a no-op for non-NVMe devices.
 func (p *Provider) Format(req storage.BdevFormatRequest) (*storage.BdevFormatResponse, error) {
-	if len(req.Properties.DeviceList) == 0 {
+	if req.Properties.DeviceList.Len() == 0 {
 		return nil, errors.New("empty DeviceList in FormatRequest")
 	}
 

--- a/src/control/server/storage/bdev/provider_test.go
+++ b/src/control/server/storage/bdev/provider_test.go
@@ -158,7 +158,7 @@ func TestProvider_Format(t *testing.T) {
 			req: storage.BdevFormatRequest{
 				Properties: storage.BdevTierProperties{
 					Class:      storage.ClassNvme,
-					DeviceList: []string{mockSingle.PciAddr},
+					DeviceList: storage.MustNewBdevDeviceList(mockSingle.PciAddr),
 				},
 			},
 			mbc: &MockBackendConfig{
@@ -184,7 +184,7 @@ func TestProvider_Format(t *testing.T) {
 			req: storage.BdevFormatRequest{
 				Properties: storage.BdevTierProperties{
 					Class:      storage.ClassNvme,
-					DeviceList: []string{mockSingle.PciAddr},
+					DeviceList: storage.MustNewBdevDeviceList(mockSingle.PciAddr),
 				},
 			},
 			mbc: &MockBackendConfig{

--- a/src/control/server/storage/config.go
+++ b/src/control/server/storage/config.go
@@ -7,15 +7,16 @@
 package storage
 
 import (
+	"encoding/json"
 	"fmt"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 
 	"github.com/pkg/errors"
 	"gopkg.in/yaml.v2"
 
-	"github.com/daos-stack/daos/src/control/common"
 	"github.com/daos-stack/daos/src/control/lib/hardware"
 )
 
@@ -144,7 +145,14 @@ func (tc *TierConfig) WithScmDeviceList(devices ...string) *TierConfig {
 
 // WithBdevDeviceList sets the list of block devices to be used.
 func (tc *TierConfig) WithBdevDeviceList(devices ...string) *TierConfig {
-	tc.Bdev.DeviceList = devices
+	if set, err := NewBdevDeviceList(devices...); err == nil {
+		tc.Bdev.DeviceList = set
+	} else {
+		tc.Bdev.DeviceList = &BdevDeviceList{stringBdevSet: stringSet{}}
+		for _, d := range devices {
+			tc.Bdev.DeviceList.stringBdevSet.Add(d)
+		}
+	}
 	return tc
 }
 
@@ -170,7 +178,7 @@ type TierConfigs []*TierConfig
 
 func (tcs TierConfigs) CfgHasBdevs() bool {
 	for _, bc := range tcs.BdevConfigs() {
-		if len(bc.Bdev.DeviceList) > 0 {
+		if bc.Bdev.DeviceList.Len() > 0 {
 			return true
 		}
 	}
@@ -259,6 +267,177 @@ func (sc *ScmConfig) Validate(class Class) error {
 	return nil
 }
 
+type stringSet map[string]struct{}
+
+func (ss stringSet) Add(s string) error {
+	if _, exists := ss[s]; exists {
+		return errors.Errorf("duplicate device %q", s)
+	}
+	ss[s] = struct{}{}
+	return nil
+}
+
+func (ss stringSet) Strings() []string {
+	var out []string
+	for s := range ss {
+		out = append(out, s)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// BdevDeviceList represents a set of block device addresses.
+type BdevDeviceList struct {
+	// As this is the most common use case, we'll make the embedded type's methods
+	// available directly on the type.
+	hardware.PCIAddressSet
+
+	// As a fallback for non-PCI bdevs, maintain a map of strings.
+	stringBdevSet stringSet
+}
+
+// maybePCI does a quick check to see if a string could possibly be a PCI address.
+func maybePCI(addr string) bool {
+	comps := strings.Split(addr, ":")
+	if len(comps) != 3 {
+		return false
+	}
+	return (len(comps[0]) == 6 || len(comps[0]) == 4) && len(comps[1]) == 2 && len(comps[2]) >= 2
+}
+
+// fromStrings creates a BdevDeviceList from a list of strings.
+func (bdl *BdevDeviceList) fromStrings(addrs []string) error {
+	if bdl == nil {
+		return errors.New("nil BdevDeviceList")
+	}
+
+	if bdl.stringBdevSet == nil {
+		bdl.stringBdevSet = stringSet{}
+	}
+
+	for _, strAddr := range addrs {
+		if !maybePCI(strAddr) {
+			if err := bdl.stringBdevSet.Add(strAddr); err != nil {
+				return err
+			}
+			continue
+		}
+
+		addr, err := hardware.NewPCIAddress(strAddr)
+		if err != nil {
+			return err
+		}
+
+		if bdl.Contains(addr) {
+			return errors.Errorf("duplicate PCI address %s", addr)
+		}
+
+		if err := bdl.Add(addr); err != nil {
+			return err
+		}
+	}
+
+	if len(bdl.stringBdevSet) > 0 && bdl.PCIAddressSet.Len() > 0 {
+		return errors.New("cannot mix PCI and non-PCI block device addresses")
+	}
+
+	return nil
+}
+
+func (bdl *BdevDeviceList) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var tmp []string
+	if err := unmarshal(&tmp); err != nil {
+		return err
+	}
+
+	return bdl.fromStrings(tmp)
+}
+
+func (bdl *BdevDeviceList) MarshalYAML() (interface{}, error) {
+	return bdl.Devices(), nil
+}
+
+func (bdl *BdevDeviceList) UnmarshalJSON(data []byte) error {
+	var tmp []string
+	if err := json.Unmarshal(data, &tmp); err != nil {
+		return err
+	}
+
+	return bdl.fromStrings(tmp)
+}
+
+func (bdl *BdevDeviceList) MarshalJSON() ([]byte, error) {
+	return json.Marshal(bdl.Devices())
+}
+
+// Len returns the number of block devices in the list.
+func (bdl *BdevDeviceList) Len() int {
+	if bdl == nil {
+		return 0
+	}
+
+	if bdl.PCIAddressSet.Len() > 0 {
+		return bdl.PCIAddressSet.Len()
+	}
+
+	return len(bdl.stringBdevSet)
+}
+
+// Equals returns true if the two lists are equivalent.
+func (bdl *BdevDeviceList) Equals(other *BdevDeviceList) bool {
+	if bdl == nil || other == nil {
+		return false
+	}
+
+	if bdl.Len() != other.Len() {
+		return false
+	}
+
+	if bdl.PCIAddressSet.Len() > 0 {
+		return bdl.PCIAddressSet.Equals(&other.PCIAddressSet)
+	}
+
+	for addr := range bdl.stringBdevSet {
+		if _, ok := other.stringBdevSet[addr]; !ok {
+			return false
+		}
+	}
+
+	return true
+}
+
+// Devices returns a slice of strings representing the block device addresses.
+func (bdl *BdevDeviceList) Devices() []string {
+	if bdl.PCIAddressSet.Len() == 0 {
+		return bdl.stringBdevSet.Strings()
+	}
+
+	var addresses []string
+	for _, addr := range bdl.Addresses() {
+		addresses = append(addresses, addr.String())
+	}
+	return addresses
+}
+
+func (bdl *BdevDeviceList) String() string {
+	return strings.Join(bdl.Devices(), ",")
+}
+
+// NewBdevDeviceList creates a new BdevDeviceList from a list of strings.
+func NewBdevDeviceList(devices ...string) (*BdevDeviceList, error) {
+	bdl := &BdevDeviceList{stringBdevSet: stringSet{}}
+	return bdl, bdl.fromStrings(devices)
+}
+
+// MustNewBdevDeviceList creates a new BdevDeviceList from a string representation of a set of block device addresses. Panics on error.
+func MustNewBdevDeviceList(devices ...string) *BdevDeviceList {
+	bdl, err := NewBdevDeviceList(devices...)
+	if err != nil {
+		panic(err)
+	}
+	return bdl
+}
+
 // BdevBusRange represents a bus-ID range to be used to filter hot plug events.
 type BdevBusRange struct {
 	hardware.PCIBus
@@ -315,10 +494,10 @@ func MustNewBdevBusRange(rangeStr string) *BdevBusRange {
 
 // BdevConfig represents a Block Device (NVMe, etc.) configuration entry.
 type BdevConfig struct {
-	DeviceList  []string      `yaml:"bdev_list,omitempty"`
-	DeviceCount int           `yaml:"bdev_number,omitempty"`
-	FileSize    int           `yaml:"bdev_size,omitempty"`
-	BusidRange  *BdevBusRange `yaml:"bdev_busid_range,omitempty"`
+	DeviceList  *BdevDeviceList `yaml:"bdev_list,omitempty"`
+	DeviceCount int             `yaml:"bdev_number,omitempty"`
+	FileSize    int             `yaml:"bdev_size,omitempty"`
+	BusidRange  *BdevBusRange   `yaml:"bdev_busid_range,omitempty"`
 }
 
 func (bc *BdevConfig) checkNonZeroDevFileSize(class Class) error {
@@ -331,7 +510,7 @@ func (bc *BdevConfig) checkNonZeroDevFileSize(class Class) error {
 }
 
 func (bc *BdevConfig) checkNonEmptyDevList(class Class) error {
-	if len(bc.DeviceList) == 0 {
+	if bc.DeviceList == nil || bc.DeviceList.Len() == 0 {
 		return errors.Errorf("bdev_class %s requires non-empty bdev_list",
 			class)
 	}
@@ -341,9 +520,6 @@ func (bc *BdevConfig) checkNonEmptyDevList(class Class) error {
 
 // Validate sanity checks engine bdev config parameters and update VOS env.
 func (bc *BdevConfig) Validate(class Class) error {
-	if common.StringSliceHasDuplicates(bc.DeviceList) {
-		return errors.New("bdev_list contains duplicate pci addresses")
-	}
 	if bc.FileSize < 0 {
 		return errors.New("negative bdev_size")
 	}
@@ -361,8 +537,9 @@ func (bc *BdevConfig) Validate(class Class) error {
 			return err
 		}
 	case ClassNvme:
-		if _, err := hardware.NewPCIAddressSet(bc.DeviceList...); err != nil {
-			return errors.Wrapf(err, "parse pci addresses %v", bc.DeviceList)
+		// NB: We are specifically checking that the embedded PCIAddressSet is non-empty.
+		if bc.DeviceList == nil || bc.DeviceList.PCIAddressSet.Len() == 0 {
+			return errors.New("bdev_class nvme requires valid PCI addresses in bdev_list")
 		}
 	default:
 		return errors.Errorf("bdev_class value %q not supported (valid: nvme/kdev/file)", class)
@@ -372,7 +549,7 @@ func (bc *BdevConfig) Validate(class Class) error {
 }
 
 // parsePCIBusRange takes a string of format <Begin-End> and returns the begin and end values.
-// Number base is detected from the string prefixes e.g. 0x for hexadecimal.
+// Number bdle is detected from the string prefixes e.g. 0x for hexadecimal.
 // bitSize parameter sets a cut-off for the return values e.g. 8 for uint8.
 func parsePCIBusRange(numRange string, bitSize int) (uint8, uint8, error) {
 	if numRange == "" {
@@ -416,7 +593,7 @@ func (c *Config) Validate() error {
 
 	var pruned TierConfigs
 	for _, tier := range c.Tiers {
-		if tier.IsBdev() && len(tier.Bdev.DeviceList) == 0 {
+		if tier.IsBdev() && tier.Bdev.DeviceList.Len() == 0 {
 			continue // prune empty bdev tier
 		}
 		pruned = append(pruned, tier)

--- a/src/control/server/storage/config_test.go
+++ b/src/control/server/storage/config_test.go
@@ -41,7 +41,7 @@ func TestStorage_BdevDeviceList(t *testing.T) {
 		"empty": {
 			expList:    &BdevDeviceList{},
 			expYamlStr: "[]\n",
-			expJSONStr: "null",
+			expJSONStr: "[]",
 		},
 		"valid pci addresses": {
 			devices: []string{"0000:81:00.0", "0000:82:00.0"},
@@ -63,10 +63,7 @@ func TestStorage_BdevDeviceList(t *testing.T) {
 		"non-pci devices": {
 			devices: []string{"/dev/block0", "/dev/block1"},
 			expList: &BdevDeviceList{
-				stringBdevSet: stringSet{
-					"/dev/block0": struct{}{},
-					"/dev/block1": struct{}{},
-				},
+				stringBdevSet: common.NewStringSet("/dev/block0", "/dev/block1"),
 			},
 			expYamlStr: `
 - /dev/block0
@@ -149,10 +146,7 @@ func TestStorage_BdevDeviceList_FromYAML(t *testing.T) {
 - /dev/block1
 `,
 			expList: &BdevDeviceList{
-				stringBdevSet: stringSet{
-					"/dev/block0": struct{}{},
-					"/dev/block1": struct{}{},
-				},
+				stringBdevSet: common.NewStringSet("/dev/block0", "/dev/block1"),
 			},
 		},
 		"mixed pci and non-pci devices": {
@@ -200,10 +194,7 @@ func TestStorage_BdevDeviceList_FromJSON(t *testing.T) {
 		"non-pci devices": {
 			input: `["/dev/block0","/dev/block1"]`,
 			expList: &BdevDeviceList{
-				stringBdevSet: stringSet{
-					"/dev/block0": struct{}{},
-					"/dev/block1": struct{}{},
-				},
+				stringBdevSet: common.NewStringSet("/dev/block0", "/dev/block1"),
 			},
 		},
 		"mixed pci and non-pci devices": {

--- a/src/control/server/storage/config_test.go
+++ b/src/control/server/storage/config_test.go
@@ -7,11 +7,224 @@
 package storage
 
 import (
+	"encoding/json"
+	"strings"
 	"testing"
 
-	"github.com/daos-stack/daos/src/control/common"
+	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
+	"gopkg.in/yaml.v2"
+
+	"github.com/daos-stack/daos/src/control/common"
+	"github.com/daos-stack/daos/src/control/lib/hardware"
 )
+
+func defConfigCmpOpts() cmp.Options {
+	return cmp.Options{
+		cmp.Comparer(func(x, y *BdevDeviceList) bool {
+			if x == nil && y == nil {
+				return true
+			}
+			return x.Equals(y)
+		}),
+	}
+}
+
+func TestStorage_BdevDeviceList(t *testing.T) {
+	for name, tc := range map[string]struct {
+		devices    []string
+		expList    *BdevDeviceList
+		expYamlStr string
+		expJSONStr string
+		expErr     error
+	}{
+		"empty": {
+			expList:    &BdevDeviceList{},
+			expYamlStr: "[]\n",
+			expJSONStr: "null",
+		},
+		"valid pci addresses": {
+			devices: []string{"0000:81:00.0", "0000:82:00.0"},
+			expList: &BdevDeviceList{
+				PCIAddressSet: func() hardware.PCIAddressSet {
+					set, err := hardware.NewPCIAddressSetFromString("0000:81:00.0 0000:82:00.0")
+					if err != nil {
+						panic(err)
+					}
+					return *set
+				}(),
+			},
+			expYamlStr: `
+- 0000:81:00.0
+- 0000:82:00.0
+`,
+			expJSONStr: `["0000:81:00.0","0000:82:00.0"]`,
+		},
+		"non-pci devices": {
+			devices: []string{"/dev/block0", "/dev/block1"},
+			expList: &BdevDeviceList{
+				stringBdevSet: stringSet{
+					"/dev/block0": struct{}{},
+					"/dev/block1": struct{}{},
+				},
+			},
+			expYamlStr: `
+- /dev/block0
+- /dev/block1
+`,
+			expJSONStr: `["/dev/block0","/dev/block1"]`,
+		},
+		"invalid pci device": {
+			devices: []string{"0000:8g:00.0"},
+			expErr:  errors.New("unable to parse \"0000:8g:00.0\""),
+		},
+		"mixed pci and non-pci devices": {
+			devices: []string{"/dev/block0", "0000:81:00.0"},
+			expErr:  errors.New("mix"),
+		},
+		"duplicate pci device": {
+			devices: []string{"0000:81:00.0", "0000:81:00.0"},
+			expErr:  errors.New("duplicate"),
+		},
+		"duplicate non-pci device": {
+			devices: []string{"/dev/block0", "/dev/block0"},
+			expErr:  errors.New("duplicate"),
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			list, err := NewBdevDeviceList(tc.devices...)
+			common.CmpErr(t, tc.expErr, err)
+			if tc.expErr != nil {
+				return
+			}
+
+			if diff := cmp.Diff(tc.expList, list, defConfigCmpOpts()...); diff != "" {
+				t.Fatalf("bad list (-want +got):\n%s", diff)
+			}
+
+			yamlData, err := yaml.Marshal(list)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if diff := cmp.Diff(strings.TrimLeft(tc.expYamlStr, "\n"), string(yamlData)); diff != "" {
+				t.Fatalf("bad yaml (-want +got):\n%s", diff)
+			}
+
+			jsonData, err := json.Marshal(list)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if diff := cmp.Diff(strings.TrimLeft(tc.expJSONStr, "\n"), string(jsonData)); diff != "" {
+				t.Fatalf("bad json (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestStorage_BdevDeviceList_FromYAML(t *testing.T) {
+	for name, tc := range map[string]struct {
+		input   string
+		expList *BdevDeviceList
+		expErr  error
+	}{
+		"empty": {
+			input:   "[]\n",
+			expList: &BdevDeviceList{},
+		},
+		"valid pci addresses": {
+			input: `["0000:81:00.0","0000:82:00.0"]`,
+			expList: &BdevDeviceList{
+				PCIAddressSet: func() hardware.PCIAddressSet {
+					set, err := hardware.NewPCIAddressSetFromString("0000:81:00.0 0000:82:00.0")
+					if err != nil {
+						panic(err)
+					}
+					return *set
+				}(),
+			},
+		},
+		"non-pci devices": {
+			input: `
+- /dev/block0
+- /dev/block1
+`,
+			expList: &BdevDeviceList{
+				stringBdevSet: stringSet{
+					"/dev/block0": struct{}{},
+					"/dev/block1": struct{}{},
+				},
+			},
+		},
+		"mixed pci and non-pci devices": {
+			input:  `["/dev/block0", "0000:81:00.0"]`,
+			expErr: errors.New("mix"),
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			list := &BdevDeviceList{}
+			err := yaml.Unmarshal([]byte(tc.input), list)
+			common.CmpErr(t, tc.expErr, err)
+			if tc.expErr != nil {
+				return
+			}
+
+			if diff := cmp.Diff(tc.expList, list, defConfigCmpOpts()...); diff != "" {
+				t.Fatalf("bad list (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestStorage_BdevDeviceList_FromJSON(t *testing.T) {
+	for name, tc := range map[string]struct {
+		input   string
+		expList *BdevDeviceList
+		expErr  error
+	}{
+		"empty": {
+			input:   "[]\n",
+			expList: &BdevDeviceList{},
+		},
+		"valid pci addresses": {
+			input: `["0000:81:00.0","0000:82:00.0"]`,
+			expList: &BdevDeviceList{
+				PCIAddressSet: func() hardware.PCIAddressSet {
+					set, err := hardware.NewPCIAddressSetFromString("0000:81:00.0 0000:82:00.0")
+					if err != nil {
+						panic(err)
+					}
+					return *set
+				}(),
+			},
+		},
+		"non-pci devices": {
+			input: `["/dev/block0","/dev/block1"]`,
+			expList: &BdevDeviceList{
+				stringBdevSet: stringSet{
+					"/dev/block0": struct{}{},
+					"/dev/block1": struct{}{},
+				},
+			},
+		},
+		"mixed pci and non-pci devices": {
+			input:  `["/dev/block0", "0000:81:00.0"]`,
+			expErr: errors.New("mix"),
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			list := &BdevDeviceList{}
+			err := json.Unmarshal([]byte(tc.input), list)
+			common.CmpErr(t, tc.expErr, err)
+			if tc.expErr != nil {
+				return
+			}
+
+			if diff := cmp.Diff(tc.expList, list, defConfigCmpOpts()...); diff != "" {
+				t.Fatalf("bad list (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
 
 func TestStorage_parsePCIBusRange(t *testing.T) {
 	for name, tc := range map[string]struct {

--- a/src/control/server/storage/provider.go
+++ b/src/control/server/storage/provider.go
@@ -223,7 +223,7 @@ func (p *Provider) PrepareBdevs(req BdevPrepareRequest) (*BdevPrepareResponse, e
 // block devices.
 func (p *Provider) HasBlockDevices() bool {
 	for _, cfg := range p.engineStorage.Tiers.BdevConfigs() {
-		if len(cfg.Bdev.DeviceList) > 0 {
+		if cfg.Bdev.DeviceList.Len() > 0 {
 			return true
 		}
 	}
@@ -411,7 +411,7 @@ func (p *Provider) scanBdevTiers(direct bool, scan scanFn) (results []BdevTierSc
 		if cfg.Class != ClassNvme {
 			continue
 		}
-		if len(cfg.Bdev.DeviceList) == 0 {
+		if cfg.Bdev.DeviceList.Len() == 0 {
 			continue
 		}
 


### PR DESCRIPTION
Instead of passing around strings which need to be parsed
and validated in different parts of the system, convert
the configuration to use structured device lists. This
will allow errors to be caught earlier and simplify
other parts of the codebase.

Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com>
