### PR TITLE
DAOS-9116 test: Pause ms_resilience before killing servers (#7516)

### DIFF
--- a/src/tests/ftest/control/ms_resilience.py
+++ b/src/tests/ftest/control/ms_resilience.py
@@ -183,6 +183,10 @@ class ManagementServiceResilience(TestWithServers):
                 },
         }
         self.start_servers(server_groups)
+
+        # Give SWIM some time to stabilize before we start killing stuff (DAOS-9116)
+        time.sleep(2 * len(self.hostlist_servers))
+
         return replicas
 
     def kill_servers(self, leader, replicas, N):


### PR DESCRIPTION
If a server is killed before it is pinged at least once, it
will not be marked as dead, and the test will never progress.
Just pause long enough to ensure that all ranks have been
pinged before proceeding on to the rest of the test.

Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com>