### PR TITLE
DAOS-9356-test_2.0: Cherrypick script fix for release_2.0

### DIFF
--- a/src/tests/ftest/rebuild/container_create_race.py
+++ b/src/tests/ftest/rebuild/container_create_race.py
@@ -35,15 +35,19 @@ class RbldContainerCreate(IorTestBase):
         cont_oclass = self.params.get("oclass", "/run/io/*")
         count = 0
         self.container = []
-        while not self.pool.rebuild_complete() and count < qty:
+        rebuild_done = False
+        self.log.info("..Create %s containers and write data during rebuild.",
+                      qty)
+        while not rebuild_done and count < qty:
             count += 1
             self.log.info(
                 "..Creating container %s/%s in pool %s during rebuild",
                 count, qty, self.pool.uuid)
             self.container.append(self.get_container(self.pool))
+            rebuild_done = self.pool.rebuild_complete()
+            self.log.info(
+                "..Rebuild status, rebuild_done= %s", rebuild_done)
 
-        self.log.info("..Create %s containers and write data during rebuild.",
-                      qty)
         self.container[index].object_qty.value = object_qty
         self.container[index].record_qty.value = record_qty
         self.container[index].data_size.value = data_size
@@ -80,7 +84,7 @@ class RbldContainerCreate(IorTestBase):
             Test steps:
             (1)Start IOR before rebuild.
             (2)Starting rebuild by killing rank.
-            (3)Wait for rebuild to start.
+            (3)Wait for rebuild to start for race condition.
             (4)Race condition, create containers, data write/read during
                rebuild.
             (5)Wait for rebuild to finish.
@@ -89,7 +93,7 @@ class RbldContainerCreate(IorTestBase):
             Basic rebuild of container objects of array values with sufficient
             numbers of rebuild targets and no available rebuild targets.
         :avocado: tags=all,full_regression
-        :avocado: tags=large
+        :avocado: tags=hw,large
         :avocado: tags=rebuild
         :avocado: tags=rebuild_cont_create
 
@@ -136,7 +140,7 @@ class RbldContainerCreate(IorTestBase):
         self.server_managers[0].stop_ranks([rank], self.d_log, force=True)
 
         # Wait for rebuild to start.
-        self.log.info("..(3)Wait for rebuild to start")
+        self.log.info("..(3)Wait for rebuild to start for race condition")
         self.pool.wait_for_rebuild(True, interval=1)
 
         # Race condition, create containers write and read during rebuild.

--- a/src/tests/ftest/rebuild/container_create_race.yaml
+++ b/src/tests/ftest/rebuild/container_create_race.yaml
@@ -19,7 +19,7 @@ testparams:
 pool:
   mode: 146
   name: daos_server
-  scm_size: 7G
+  scm_size: 8G 
   svcn: 1
   control_method: dmg
   pool_query_timeout: 15


### PR DESCRIPTION
Description: Per request, cherrypick the script fix to rel_2.0.

Quick-Functional: true
Test-tag: rebuild_cont_create
Test-repeat: 10
Signed-off-by: Ding Ho ding-hwa.ho@intel.com