### PR TITLE
DAOS-7821 gha: Remove CentOS 8 from GHA builds.

### DIFF
--- a/.github/workflows/landing-builds.yml
+++ b/.github/workflows/landing-builds.yml
@@ -209,14 +209,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        distro: [centos.7, centos.8, alma]
+        distro: [centos.7, alma]
         include:
           - distro: centos.7
             base: centos.7
             with: centos.7
-          - distro: centos.8
-            base: centos.8
-            with: centos:8
           - distro: alma
             base: centos.8
             with: almalinux:8

--- a/utils/docker/Dockerfile.centos.8
+++ b/utils/docker/Dockerfile.centos.8
@@ -1,4 +1,4 @@
-# Copyright (C) 2018-2021 Intel Corporation
+# Copyright (C) 2018-2022 Intel Corporation
 # All rights reserved.
 #
 # 'recipe' for Docker to build an image of centOS 8 based
@@ -6,7 +6,7 @@
 #
 
 # Pull base image
-ARG BASE_DISTRO=centos:8
+ARG BASE_DISTRO=rockylinux/rockylinux:8
 FROM $BASE_DISTRO
 LABEL maintainer="daos@daos.groups.io"
 


### PR DESCRIPTION
Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>
