### PR TITLE
DAOS-9793 placement: Do not add extending shards for readonly open

### DIFF
--- a/src/common/pool_map.c
+++ b/src/common/pool_map.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2021 Intel Corporation.
+ * (C) Copyright 2016-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */

--- a/src/include/daos/placement.h
+++ b/src/include/daos/placement.h
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2021 Intel Corporation.
+ * (C) Copyright 2016-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -127,10 +127,8 @@ bool pl_obj_layout_contains(struct pool_map *map, struct pl_obj_layout *layout,
 			    uint32_t rank, uint32_t target_index,
 			    uint32_t shard);
 
-int pl_obj_place(struct pl_map *map,
-		 struct daos_obj_md *md,
-		 struct daos_obj_shard_md *shard_md,
-		 struct pl_obj_layout **layout_pp);
+int pl_obj_place(struct pl_map *map, struct daos_obj_md *md, unsigned int mode,
+		 struct daos_obj_shard_md *shard_md, struct pl_obj_layout **layout_pp);
 
 int pl_obj_find_rebuild(struct pl_map *map,
 			struct daos_obj_md *md,

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -302,7 +302,7 @@ dc_obj_hdl2cont_hdl(daos_handle_t oh)
 }
 
 static int
-obj_layout_create(struct dc_object *obj, bool refresh)
+obj_layout_create(struct dc_object *obj, unsigned int mode, bool refresh)
 {
 	struct pl_obj_layout	*layout = NULL;
 	struct dc_pool		*pool;
@@ -326,7 +326,7 @@ obj_layout_create(struct dc_object *obj, bool refresh)
 
 	obj->cob_md.omd_ver = dc_pool_get_version(pool);
 	dc_pool_put(pool);
-	rc = pl_obj_place(map, &obj->cob_md, NULL, &layout);
+	rc = pl_obj_place(map, &obj->cob_md, mode, NULL, &layout);
 	pl_map_decref(map);
 	if (rc != 0) {
 		D_DEBUG(DB_PL, "Failed to generate object layout\n");
@@ -385,7 +385,7 @@ obj_layout_refresh(struct dc_object *obj)
 
 	D_RWLOCK_WRLOCK(&obj->cob_lock);
 	obj_layout_free(obj);
-	rc = obj_layout_create(obj, true);
+	rc = obj_layout_create(obj, 0, true);
 	D_RWLOCK_UNLOCK(&obj->cob_lock);
 
 	return rc;
@@ -1413,7 +1413,7 @@ dc_obj_open(tse_task_t *task)
 	if (rc != 0)
 		D_GOTO(fail_rwlock_created, rc);
 
-	rc = obj_layout_create(obj, false);
+	rc = obj_layout_create(obj, obj->cob_mode, false);
 	if (rc != 0)
 		D_GOTO(fail_rwlock_created, rc);
 

--- a/src/object/srv_ec_aggregate.c
+++ b/src/object/srv_ec_aggregate.c
@@ -2191,7 +2191,7 @@ agg_obj_is_leader(struct ds_pool *pool, struct daos_oclass_attr *oca,
 
 	md.omd_id = oid->id_pub;
 	md.omd_ver = version;
-	rc = pl_obj_place(map, &md, NULL, &layout);
+	rc = pl_obj_place(map, &md, DAOS_OO_RO, NULL, &layout);
 	if (rc != 0)
 		goto out;
 

--- a/src/object/srv_obj_migrate.c
+++ b/src/object/srv_obj_migrate.c
@@ -1487,7 +1487,7 @@ migrate_dkey(struct migrate_pool_tls *tls, struct migrate_one *mrone,
 		D_GOTO(pool_close, rc);
 
 	/* Open the remote object */
-	rc = dsc_obj_open(coh, mrone->mo_oid.id_pub, DAOS_OO_RW, &oh);
+	rc = dsc_obj_open(coh, mrone->mo_oid.id_pub, DAOS_OO_RO, &oh);
 	if (rc)
 		D_GOTO(cont_close, rc);
 
@@ -2377,7 +2377,7 @@ migrate_one_epoch_object(daos_epoch_range_t *epr, struct migrate_pool_tls *tls,
 		D_GOTO(out_pool, rc);
 	}
 
-	rc = dsc_obj_open(coh, arg->oid.id_pub, DAOS_OO_RW, &oh);
+	rc = dsc_obj_open(coh, arg->oid.id_pub, DAOS_OO_RO, &oh);
 	if (rc) {
 		D_ERROR("dsc_obj_open failed: "DF_RC"\n", DP_RC(rc));
 		D_GOTO(out_cont, rc);

--- a/src/placement/jump_map.c
+++ b/src/placement/jump_map.c
@@ -1032,6 +1032,7 @@ jump_map_query(struct pl_map *map, struct pl_map_attr *attr)
  *                              place the object shard.
  * \param[in]   md              The object metadata which contains data about
  *                              the object being placed such as the object ID.
+ * \param[in]   mode		mode of daos_obj_open(DAOS_OO_RO, DAOS_OO_RW etc).
  * \param[in]   shard_md        Shard metadata.
  * \param[out]  layout_pp       The layout generated for the object. Contains
  *                              references to the targets in the pool map where
@@ -1043,7 +1044,7 @@ jump_map_query(struct pl_map *map, struct pl_map_attr *attr)
  */
 static int
 jump_map_obj_place(struct pl_map *map, struct daos_obj_md *md,
-		   struct daos_obj_shard_md *shard_md,
+		   unsigned int mode, struct daos_obj_shard_md *shard_md,
 		   struct pl_obj_layout **layout_pp)
 {
 	struct pl_jump_map	*jmap;
@@ -1088,10 +1089,11 @@ jump_map_obj_place(struct pl_map *map, struct daos_obj_md *md,
 	if (is_pool_adding(root))
 		is_adding_new = true;
 
-	/* If the layout might being extended, i.e. so extra shards needs
-	 * to be added to the layout.
+	/**
+	 * If the layout might being extended, i.e. so extra shards needs
+	 * to be added to the layout. But this is only needed for update.
 	 */
-	if (unlikely(is_extending || is_adding_new)) {
+	if (unlikely(is_extending || is_adding_new) && !(mode & DAOS_OO_RO)) {
 		/* Needed to check if domains are being added to pool map */
 		D_DEBUG(DB_PL, DF_OID"/%d is being added: %s or extended: %s\n",
 			DP_OID(oid), md->omd_ver, is_adding_new ? "yes" : "no",
@@ -1104,10 +1106,6 @@ jump_map_obj_place(struct pl_map *map, struct daos_obj_md *md,
 		if (is_extending)
 			allow_status |= PO_COMP_ST_UP;
 
-		/* Don't repeat remapping failed shards during this phase -
-		 * they have already been remapped.
-		 */
-		allow_status |= PO_COMP_ST_DOWN;
 		rc = obj_layout_alloc_and_get(jmap, &jmop, md, allow_status, -1,
 					      &extend_layout, NULL, NULL);
 		if (rc)

--- a/src/placement/pl_map.c
+++ b/src/placement/pl_map.c
@@ -117,13 +117,13 @@ void pl_map_print(struct pl_map *map)
  */
 int
 pl_obj_place(struct pl_map *map, struct daos_obj_md *md,
-	     struct daos_obj_shard_md *shard_md,
+	     unsigned int mode, struct daos_obj_shard_md *shard_md,
 	     struct pl_obj_layout **layout_pp)
 {
 	D_ASSERT(map->pl_ops != NULL);
 	D_ASSERT(map->pl_ops->o_obj_place != NULL);
 
-	return map->pl_ops->o_obj_place(map, md, shard_md, layout_pp);
+	return map->pl_ops->o_obj_place(map, md, mode, shard_md, layout_pp);
 }
 
 /**

--- a/src/placement/pl_map.h
+++ b/src/placement/pl_map.h
@@ -35,6 +35,7 @@ struct pl_map_ops {
 	/** see \a pl_map_obj_select and \a pl_map_obj_rebalance */
 	int (*o_obj_place)(struct pl_map *map,
 			   struct daos_obj_md *md,
+			   unsigned int	mode,
 			   struct daos_obj_shard_md *shard_md,
 			   struct pl_obj_layout **layout_pp);
 	/** see \a pl_map_obj_rebuild */

--- a/src/placement/ring_map.c
+++ b/src/placement/ring_map.c
@@ -1103,7 +1103,7 @@ out:
 
 static int
 ring_obj_place(struct pl_map *map, struct daos_obj_md *md,
-	       struct daos_obj_shard_md *shard_md,
+	       unsigned int mode, struct daos_obj_shard_md *shard_md,
 	       struct pl_obj_layout **layout_pp)
 {
 	struct ring_obj_placement  rop;

--- a/src/placement/tests/jump_map_place_obj.c
+++ b/src/placement/tests/jump_map_place_obj.c
@@ -1609,8 +1609,10 @@ placement_handles_multiple_states(void **state)
 	ver_after_fail = ctx.ver;
 
 	rebuilding = jtc_get_layout_rebuild_count(&ctx);
-	/* One reintegrating plus one failure recovery */
-	assert_int_equal(2, rebuilding);
+	/* One reintegrating plus one failure recovery, but due to co-location,
+	 * some other shards might change their location either after remap.
+	 **/
+	assert_true(rebuilding >= 2);
 
 	/* third shard is queued for drain */
 	jtc_set_status_on_shard_target(&ctx, DRAIN, 2);
@@ -1633,7 +1635,7 @@ placement_handles_multiple_states(void **state)
 	 */
 	jtc_scan(&ctx);
 	rebuilding = jtc_get_layout_rebuild_count(&ctx);
-	assert_int_equal(3, rebuilding);
+	assert_true(rebuilding >= 3);
 
 	/*
 	 * Compute find_reint() using the correct version of rebuild which

--- a/src/placement/tests/pl_bench.c
+++ b/src/placement/tests/pl_bench.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2021 Intel Corporation.
+ * (C) Copyright 2016-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -222,7 +222,7 @@ benchmark_placement(int argc, char **argv, uint32_t num_domains,
 
 	/* Warm up the cache and check that it works correctly */
 	for (i = 0; i < BENCHMARK_COUNT; i++)
-		pl_obj_place(pl_map, &obj_table[i], NULL, &layout_table[i]);
+		pl_obj_place(pl_map, &obj_table[i], 0, NULL, &layout_table[i]);
 	check_unique_layout(num_domains, nodes_per_domain, vos_per_target,
 			    layout_table, BENCHMARK_COUNT, 0);
 
@@ -230,7 +230,7 @@ benchmark_placement(int argc, char **argv, uint32_t num_domains,
 		D_PRINT("Starting vtune loop!\n");
 		while (1)
 			for (i = 0; i < BENCHMARK_COUNT; i++)
-				pl_obj_place(pl_map, &obj_table[i], NULL,
+				pl_obj_place(pl_map, &obj_table[i], 0, NULL,
 					     &layout_table[i]);
 	}
 
@@ -243,7 +243,7 @@ benchmark_placement(int argc, char **argv, uint32_t num_domains,
 
 		benchmark_start(bench_hdl);
 		for (i = 0; i < BENCHMARK_COUNT; i++)
-			pl_obj_place(pl_map, &obj_table[i], NULL,
+			pl_obj_place(pl_map, &obj_table[i], 0, NULL,
 				     &layout_table[i]);
 		benchmark_stop(bench_hdl);
 
@@ -320,7 +320,7 @@ compute_data_movement(uint32_t domains, uint32_t nodes_per_domain,
 
 	/* Calculate new placement using this configuration */
 	for (obj_idx = 0; obj_idx < test_entries; obj_idx++)
-		pl_obj_place(iter_pl_map, &obj_table[obj_idx],
+		pl_obj_place(iter_pl_map, &obj_table[obj_idx], 0,
 			     NULL, &iter_layout[obj_idx]);
 
 	/* Compute the number of objects that moved */
@@ -508,7 +508,7 @@ benchmark_add_data_movement(int argc, char **argv, uint32_t num_domains,
 
 		/* Initial placement */
 		for (obj_idx = 0; obj_idx < test_entries; obj_idx++)
-			pl_obj_place(initial_pl_map, &obj_table[obj_idx], NULL,
+			pl_obj_place(initial_pl_map, &obj_table[obj_idx], 0, NULL,
 				     &initial_layout[obj_idx]);
 
 		for (added = 0; added <= domains_to_add; added++) {

--- a/src/placement/tests/place_obj_common.c
+++ b/src/placement/tests/place_obj_common.c
@@ -51,7 +51,7 @@ plt_obj_place(daos_obj_id_t oid, struct pl_obj_layout **layout,
 	D_ASSERT(pl_map != NULL);
 	md.omd_ver = pool_map_get_version(pl_map->pl_poolmap);
 
-	rc = pl_obj_place(pl_map, &md, NULL, layout);
+	rc = pl_obj_place(pl_map, &md, 0, NULL, layout);
 
 	if (print_layout_flag) {
 		if (*layout != NULL)

--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -5658,7 +5658,7 @@ ds_pool_elect_dtx_leader(struct ds_pool *pool, daos_unit_oid_t *oid,
 
 	md.omd_id = oid->id_pub;
 	md.omd_ver = version;
-	rc = pl_obj_place(map, &md, NULL, &layout);
+	rc = pl_obj_place(map, &md, DAOS_OO_RO, NULL, &layout);
 	if (rc != 0)
 		goto out;
 

--- a/src/rebuild/scan.c
+++ b/src/rebuild/scan.c
@@ -553,7 +553,7 @@ rebuild_obj_scan_cb(daos_handle_t ch, vos_iter_entry_t *ent,
 		 * still includes the current rank. If not, the object can be
 		 * deleted/reclaimed because it is no longer reachable
 		 */
-		rc = pl_obj_place(map, &md, NULL, &layout);
+		rc = pl_obj_place(map, &md, DAOS_OO_RO, NULL, &layout);
 		if (rc != 0)
 			D_GOTO(out, rc);
 


### PR DESCRIPTION
Since extending shards are only needed for update, so do not need
add extending shards for readonly open, for example migration enum
or fetch.

Do not need check DOWN status for extending shards. Then extra shards
might change their location due to co-location, so it also needs to
update pl map test.

Signed-off-by: Di Wang <di.wang@intel.com>