### PR TITLE
DAOS-9562 tests: Enabling VMD detection through --nvme auto (#7868)

### DIFF
--- a/src/tests/ftest/launch.py
+++ b/src/tests/ftest/launch.py
@@ -659,233 +659,163 @@ def get_test_files(test_list, args, yaml_dir, vmd_flag=False):
     return test_files
 
 
-def get_nvme_replacement(args):
+def get_device_replacement(args):
     """Determine the value to use for the '--nvme' command line argument.
 
-    Parse the lspci output for any NMVe devices, e.g.
-        $ lspci | grep 'Non-Volatile memory controller:'
-        5e:00.0 Non-Volatile memory controller:
-            Intel Corporation NVMe Datacenter SSD [3DNAND, Beta Rock Controller]
-        5f:00.0 Non-Volatile memory controller:
-            Intel Corporation NVMe Datacenter SSD [3DNAND, Beta Rock Controller]
-        81:00.0 Non-Volatile memory controller:
-            Intel Corporation NVMe Datacenter SSD [Optane]
-        da:00.0 Non-Volatile memory controller:
-            Intel Corporation NVMe Datacenter SSD [Optane]
+    Determine if the specified hosts have homogeneous NVMe drives (either standalone or VMD
+    controlled) and use these values to replace placeholder devices in avocado test yaml files.
 
-    Optionally filter the above output even further with a specified search
-    string (e.g. '--nvme=auto:Optane'):
-        $ lspci | grep 'Non-Volatile memory controller:' | grep 'Optane'
-        81:00.0 Non-Volatile memory controller:
-            Intel Corporation NVMe Datacenter SSD [Optane]
-        da:00.0 Non-Volatile memory controller:
-            Intel Corporation NVMe Datacenter SSD [Optane]
+    Supported auto '--nvme' arguments:
+        auto[:filter]       = select any PCI domain number of a NVMe device or VMD controller
+                              (connected to a VMD enabled NVMe device) in the homogeneous 'lspci -D'
+                              output from each server.  Optionally grep the list of NVMe or VMD
+                              enabled NVMe devices for 'filter'.
+        auto_nvme[:filter]  = select any PCI domain number of a non-VMD controlled NVMe device in
+                              the homogeneous 'lspci -D' output from each server.  Optionally grep
+                              this output for 'filter'.
+        auto_vmd[:filter]   = select any PCI domain number of a VMD controller connected to a VMD
+                              enabled NVMe device in the homogeneous 'lspci -D' output from each
+                              server.  Optionally grep the list of VMD enabled NVMe devices for
+                              'filter'.
 
     Args:
         args (argparse.Namespace): command line arguments for this program
 
     Returns:
-        str: a comma-separated list of nvme device pci addresses available on
-            all of the specified test servers
-        bool: VMD PCI address included in the pci address string (True)
-              VMD PCI address not included in the pci address string (False)
-              Defaults to False (For NVME only)
+        tuple:
+            str: a comma-separated list of nvme device pci addresses available on
+                all of the specified test servers
+            bool: VMD PCI address included in the pci address string (True)
+                VMD PCI address not included in the pci address string (False)
+                Defaults to False (For NVME only)
 
     """
-    # A list of server host is required to able to auto-detect NVMe devices
-    if not args.test_servers:
-        print("ERROR: Missing a test_servers list to auto-detect NVMe devices")
-        sys.exit(1)
-
-    # Get a list of NVMe, VMD devices from each specified server host
-    # if nvme:auto is set, all PCI Non-volatile memory controller
-    # devices are considered NVME (some NVMEs might be behind the VMD
-    # controller). if nvme:vmd, then ignore the NVME
-    # PCI addressed devices behind the VMD controller.
+    devices = []
+    device_types = []
     host_list = list(args.test_servers)
 
-    command_list = [
-        "/sbin/lspci -D",
-        "grep -E '^[0-9a-f]{4}:[0-9a-f]{2}:[0-9a-f]{2}.[0-9a-f] "
-        "Non-Volatile memory controller:'"]
-    if ":" in args.nvme:
-        command_list.append("grep '{}'".format(args.nvme.split(":")[1]))
+    # Separate any optional filter from the key
+    dev_filter = None
+    nvme_args = args.nvme.split(":")
+    if len(nvme_args) > 1:
+        dev_filter = nvme_args[1]
 
-    command = " | ".join(command_list)
+    # First check for any VMD disks, if requested
+    if nvme_args[0] in ["auto", "auto_vmd"]:
+        vmd_devices = auto_detect_devices(host_list, "NVMe", "5", dev_filter)
+        if vmd_devices:
+            # Find the VMD controller for the matching VMD disks
+            vmd_controllers = auto_detect_devices(host_list, "VMD", "4", None)
+            devices.extend(get_vmd_address_backed_nvme(host_list, vmd_devices, vmd_controllers))
+            device_types.append("VMD")
 
-    task = get_remote_output(host_list, command)
+    # Second check for any non-VMD NVMe disks, if requested
+    if nvme_args[0] in ["auto", "auto_nvme"]:
+        dev_list = auto_detect_devices(host_list, "NVMe", "4", dev_filter)
+        if dev_list:
+            devices.extend(dev_list)
+            device_types.append("NVMe")
 
-    # Verify the command was successful on each server host
-    if not check_remote_output(task, command):
-        print("ERROR: Issuing commands to detect NVMe PCI addresses.")
+    # If no VMD or NVMe devices were found exit
+    if not devices:
+        print("ERROR: Unable to auto-detect devices for the '--nvme {}' argument".format(args.nvme))
         sys.exit(1)
 
-    # Verify each server host has the same NVMe PCI addresses
-    output_data = list(task.iter_buffers())
-    if len(output_data) > 1:
-        print("ERROR: Non-homogeneous NVMe PCI addresses.")
-        sys.exit(1)
-
-    # Get the list of NVMe PCI addresses found in the output
-    output_str = "\n".join([line.decode("utf-8") for line in output_data[0][0]])
-    devices = find_pci_address(output_str)
-    print("Auto-detected NVMe devices on {}: {}".format(host_list, devices))
-    return ",".join(devices)
+    print(
+        "Auto-detected {} devices on {}: {}".format(
+            " & ".join(device_types), args.test_servers, devices))
+    return ",".join(devices), "VMD" in device_types
 
 
-def get_vmd_replacement(args):
-    """Determine the value to use for the '--nvme=auto_vmd*' command line argument.
-
-    Parse the lspci output for any VMD devices, (e.g. --nvme=auto_vmd)
-        $ lspci -D | grep Volume
-        0000:5d:05.5 RAID bus controller:
-            Intel Corporation Volume Management Device NVMe RAID Controller (rev 06)
-
-    Other command line options which will be supported are:
-    (e.g. '--nvme=auto_vmd_disks') [Use all NVME devices behind the VMD
-    controller]
-        $ lspci | grep 'Non-Volatile memory controller:' | grep '10001'
-        10001:01:00.0 Non-Volatile memory controller:
-            Intel Corporation NVMe Datacenter SSD [Optane]
-
-    (e.g. '--name=auto_vmd_mixed) [Use the NVME devices and VMD controller PCI
-    address]
-        $ lspci | grep 'Non-Volatile memory controller: \\| Volume'
-        0000:5d:05.5 RAID bus controller:
-            Intel Corporation Volume Management Device NVMe RAID Controller (rev 06)
-        0000:da:00.0 Non-Volatile memory controller:
-            Intel Corporation NVMe Datacenter SSD [Optane]
-
-    (e.g. '--name=auto_vmd_nvme) [Use the NVME devices and NVME devices behind
-    VMD controller]
-        $ lspci | grep 'Non-Volatile memory controller: \\| Volume'
-        0000:da:00.0 Non-Volatile memory controller:
-            Intel Corporation NVMe Datacenter SSD [Optane]
-        10001:01:00.0 Non-Volatile memory controller:
-            Intel Corporation NVMe Datacenter SSD [Optane]
+def auto_detect_devices(host_list, device_type, length, device_filter=None):
+    """Get a list of NVMe/VMD devices found on each specified host.
 
     Args:
-        args (argparse.Namespace): command line arguments for this program
+        host_list (list): list of host on which to find the NVMe/VMD devices
+        device_type (str): device type to find, e.g. 'NVMe' or 'VMD'
+        length (str): number of digits to match in the first PCI domain number
+        device_filter (str, optional): optional filter to apply to device searching. Defaults to
+            None.
 
     Returns:
-        str: a comma-separated list of vmd,nvme device pci addresses available
-        on all of the specified test servers
-        bool: VMD PCI address included in the pci address string (True)
-              VMD PCI address not included in the pci address string (False)
+        list: A list of detected devices - empty if none found
 
     """
-    # A list of server host is required to able to auto-detect NVMe devices
-    if not args.test_servers:
-        print("ERROR: Missing a test_servers list to auto-detect NVMe devices")
-        sys.exit(1)
+    devices = []
 
-    # Get a list of NVMe, VMD devices from each specified server host
-    # if nvme:auto is set, all PCI Non-volatile memory controller
-    # devices are considered NVME (some NVMEs might be behind the VMD
-    # controller). if nvme:vmd, then ignore the NVME
-    # PCI addressed devices behind the VMD controller.
-    host_list = list(args.test_servers)
-    vmd_include_flag = False
-
-    if args.nvme == "auto_vmd":
-        command_list = [
-            "/sbin/lspci -D", "grep 'Volume Management Device NVMe'"]
-        vmd_include_flag = True
-    elif args.nvme == "auto_vmd_disks":
+    # Find the devices on each host
+    if device_type == "VMD":
         command_list = [
             "/sbin/lspci -D",
-            "grep -E '^[0-9a-f]{5}:[0-9a-f]{2}:[0-9a-f]{2}.[0-9a-f] "
-            "Non-Volatile memory controller:'"]
-    elif args.nvme == "auto_vmd_nvme":
+            "grep -E '^[0-9a-f]{{{0}}}:[0-9a-f]{{2}}:[0-9a-f]{{2}}.[0-9a-f] '".format(length),
+            "grep -E 'Volume Management Device NVMe RAID Controller'"]
+    elif device_type == "NVMe":
         command_list = [
             "/sbin/lspci -D",
-            "grep -E '^[0-9a-f]{4,5}:[0-9a-f]{2}:[0-9a-f]{2}.[0-9a-f] "
-            "Non-Volatile memory controller:'"]
-    elif args.nvme == "auto_vmd_mixed":
-        command_list1 = [
-            "/sbin/lspci -D",
-            "grep -E '^[0-9a-f]{4}:[0-9a-f]{2}:[0-9a-f]{2}.[0-9a-f] "
-            "Non-Volatile memory controller:'"]
-        command_list2 = [
-            "/sbin/lspci -D", "grep 'Volume Management Device NVMe'"]
-        vmd_include_flag = True
+            "grep -E '^[0-9a-f]{{{0}}}:[0-9a-f]{{2}}:[0-9a-f]{{2}}.[0-9a-f] '".format(length),
+            "grep -E 'Non-Volatile memory controller:'"]
+        if device_filter:
+            command_list.append("grep '{}'".format(device_filter))
     else:
-        print("ERROR: Invalid --nvme argument")
+        print("ERROR: Invalid 'device_type' for NVMe/VMD auto-detection: {}".format(device_type))
         sys.exit(1)
-
-    if ":" in args.nvme and args.nvme != "auto_vmd_mixed":
-        command_list.append("grep '{}'".format(args.nvme.split(":")[1]))
-    elif ":" in args.nvme and args.nvme == "auto_vmd_mixed":
-        command_list1.append("grep '{}'".format(args.nvme.split(":")[1]))
-        command_list2.append("grep '{}'".format(args.nvme.split(":")[1]))
-
-    if args.nvme != "auto_vmd_mixed":
-        command = " | ".join(command_list)
-    else:
-        command1 = " | ".join(command_list1)
-        command2 = " | ".join(command_list2)
-        command = command1 + ";" + command2
-
+    command = " | ".join(command_list) + " || :"
     task = get_remote_output(host_list, command)
 
     # Verify the command was successful on each server host
-    if not check_remote_output(task, command):
-        print("ERROR: Issuing commands to detect VMD/NVME PCI addresses.")
-        sys.exit(1)
+    if check_remote_output(task, command):
+        # Verify each server host has the same VMD PCI addresses
+        output_data = list(task.iter_buffers())
+        if len(output_data) > 1:
+            print("ERROR: Non-homogeneous {} PCI addresses.".format(device_type))
+        elif len(output_data) == 1:
+            # Get the devices from the successful, homogeneous command output
+            output_str = "\n".join([line.decode("utf-8") for line in output_data[0][0]])
+            devices = find_pci_address(output_str)
 
-    # Verify each server host has the same VMD/NVMe PCI addresses
-    output_data = list(task.iter_buffers())
-    if len(output_data) > 1:
-        print("ERROR: Non-homogeneous VMD/NVMe PCI addresses.")
-        sys.exit(1)
-
-    # Get the list of NVMe PCI addresses found in the output
-    output_str = "\n".join([line.decode("utf-8") for line in output_data[0][0]])
-    all_vmd_devices = find_pci_address(output_str)
-
-    # Get the only VMD device addresses which has NVMe device connected.
-    devices = get_vmd_address_backed_nvme(host_list, all_vmd_devices)
-    print("Auto-detected VMD device which has NVMe devices connected {}: {}"
-          .format(host_list, devices))
-
-    return ",".join(devices), vmd_include_flag
+    return devices
 
 
-def get_vmd_address_backed_nvme(host_list, value):
+def get_vmd_address_backed_nvme(host_list, vmd_disks, vmd_controllers):
     """Find valid VMD address which has backing NVMe.
 
     Args:
         host_list (list): list of hosts
-        value (list): list of all PCI address.
+        vmd_disks (list): list of PCI domain numbers for each VMD controlled disk
+        vmd_controllers (list): list of PCI domain numbers for each VMD controller
 
     Returns:
-        list: a list of the VMD PCI addresses only which has connected NVMe
-              devices.
+        list: a list of the VMD controller PCI domain numbers which are connected to the VMD disks
 
     """
-    command = "ls -l /sys/block/ | grep nvme | cut -d\' \' -f11"
-
+    disk_controllers = []
+    command_list = [
+        "ls -l /sys/block/",
+        "grep nvme",
+        "grep -E '({0})'".format("|".join(vmd_disks)),
+        "cut -d'>' -f2",
+        "cut -d'/' -f4",
+    ]
+    command = " | ".join(command_list) + " || :"
     task = get_remote_output(host_list, command)
 
     # Verify the command was successful on each server host
     if not check_remote_output(task, command):
-        print("ERROR: Issuing commands ls -l /sys/block/")
-        sys.exit(1)
+        print("ERROR: Issuing command '{}'".format(command))
+    else:
+        # Verify each server host has the same NVMe devices behind the same VMD addresses.
+        output_data = list(task.iter_buffers())
+        if len(output_data) > 1:
+            print("ERROR: Non-homogeneous NVMe device behind VMD addresses.")
+        elif len(output_data) == 1:
+            # Add any VMD controller addresses found in the /sys/block output that are also
+            # included in the provided list of VMD controllers.
+            output_str = "\n".join([line.decode("utf-8") for line in output_data[0][0]])
+            for device in vmd_controllers:
+                if device in output_str:
+                    disk_controllers.append(device)
 
-    # Verify each server host has the same NVMe device behind VMD addresses.
-    output_data = list(task.iter_buffers())
-    if len(output_data) > 1:
-        print("ERROR: Non-homogeneous NVMe device behind VMD addresses.")
-        sys.exit(1)
-
-    output_str = "\n".join([line.decode("utf-8") for line in output_data[0][0]])
-
-    # Remove the VMD PCI address if no NVMe is backed-up and connected.
-    for device in value:
-        if device not in output_str:
-            value.remove(device)
-
-    return value
+    return disk_controllers
 
 
 def find_pci_address(value):
@@ -2282,10 +2212,15 @@ def main():
         action="store",
         help="comma-separated list of NVMe device PCI addresses to use as "
              "replacement values for the bdev_list in each test's yaml file.  "
-             "Using the 'auto[:<filter>]' keyword will auto-detect the NVMe "
-             "PCI address list on each of the '--test_servers' hosts - the "
-             "optional '<filter>' can be used to limit auto-detected "
-             "addresses, e.g. 'auto:Optane' for Intel Optane NVMe devices.")
+             "Using the 'auto[:<filter>]' keyword will auto-detect any VMD "
+             "controller or NVMe PCI address list on each of the '--test_servers' "
+             "hosts - the optional '<filter>' can be used to limit auto-detected "
+             "NVMe addresses, e.g. 'auto:Optane' for Intel Optane NVMe devices.  "
+             "To limit the device detection to either VMD controller or NVMe "
+             "devices the 'auto_vmd[:filter]' or 'auto_nvme[:<filter>]' keywords "
+             "can be used, respectively.  When using 'filter' with VMD controllers, "
+             "the filter is applied to devices managed by the controller, therefore "
+             "only selecting controllers that manage the matching devices.")
     parser.add_argument(
         "-r", "--rename",
         action="store_true",
@@ -2355,14 +2290,18 @@ def main():
     args.test_servers = NodeSet(args.test_servers)
     args.test_clients = NodeSet(args.test_clients)
 
+    # A list of server hosts is required
+    if not args.test_servers and not args.list:
+        print("ERROR: Missing a required '--test_servers' argument.")
+        sys.exit(1)
+
     # Setup the user environment
     set_test_environment(args)
-    vmd_flag = False
+
     # Auto-detect nvme test yaml replacement values if requested
-    if args.nvme and args.nvme.startswith("auto_vmd"):
-        args.nvme, vmd_flag = get_vmd_replacement(args)
-    elif args.nvme and args.nvme.startswith("auto"):
-        args.nvme = get_nvme_replacement(args)
+    vmd_flag = False
+    if args.nvme and args.nvme.startswith("auto") and not args.list:
+        args.nvme, vmd_flag = get_device_replacement(args)
 
     # Process the tags argument to determine which tests to run
     tag_filter, test_list = get_test_list(args.tags)

--- a/src/tests/ftest/util/server_utils.py
+++ b/src/tests/ftest/util/server_utils.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 """
-  (C) Copyright 2018-2021 Intel Corporation.
+  (C) Copyright 2018-2022 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -291,10 +291,6 @@ class DaosServerManager(SubprocessManager):
         cmd.sub_command_class.sub_command_class.target_user.value = user
         cmd.sub_command_class.sub_command_class.force.value = True
 
-        # Additionally try to prepare any discovered VMD NVMe devices.
-        if "True" in os.environ["DAOS_ENABLE_VMD"]:
-            cmd.sub_command_class.sub_command_class.enable_vmd.value = True
-
         # Use the configuration file settings if no overrides specified
         if using_dcpm is None:
             using_dcpm = self.manager.job.using_dcpm
@@ -453,10 +449,6 @@ class DaosServerManager(SubprocessManager):
         cmd.sub_command_class.sub_command_class.nvme_only.value = True
         cmd.sub_command_class.sub_command_class.reset.value = True
         cmd.sub_command_class.sub_command_class.force.value = True
-
-        # Use VMD option when resetting storage if it's prepared with VMD.
-        if "True" in os.environ["DAOS_ENABLE_VMD"]:
-            cmd.sub_command_class.sub_command_class.enable_vmd.value = True
 
         self.log.info("Resetting DAOS server storage: %s", str(cmd))
         result = pcmd(self._hosts, str(cmd), timeout=120)

--- a/src/tests/ftest/util/server_utils_base.py
+++ b/src/tests/ftest/util/server_utils_base.py
@@ -1,11 +1,12 @@
 #!/usr/bin/python
 """
-(C) Copyright 2021 Intel Corporation.
+(C) Copyright 2021-2022 Intel Corporation.
 
 SPDX-License-Identifier: BSD-2-Clause-Patent
 """
 from logging import getLogger
 import os
+import re
 
 from ClusterShell.NodeSet import NodeSet
 
@@ -297,7 +298,6 @@ class DaosServerCommand(YamlCommand):
                 self.scm_only = FormattedParameter("--scm-only", False)
                 self.reset = FormattedParameter("--reset", False)
                 self.force = FormattedParameter("--force", False)
-                self.enable_vmd = FormattedParameter("--enable-vmd", False)
 
 class DaosServerInformation():
     """An object that stores the daos_server storage and network scan data."""
@@ -519,8 +519,15 @@ class DaosServerInformation():
             storage_capacity["nvme"].append(0)
             for device in bdev_list:
                 if device in device_capacity["nvme"]:
-                    storage_capacity["nvme"][-1] += min(
-                        device_capacity["nvme"][device])
+                    storage_capacity["nvme"][-1] += min(device_capacity["nvme"][device])
+                else:
+                    # VMD controlled devices include the controller address at the beginning of
+                    # their address, e.g. "0000:85:05.5" -> "850505:01:00.0"
+                    address_split = [int(x, 16) for x in re.split(r":|\.", device)]
+                    vmd_device = "{1:02x}{2:02x}{3:02x}:".format(*address_split)
+                    for controller in device_capacity["nvme"]:
+                        if controller.startswith(vmd_device):
+                            storage_capacity["nvme"][-1] += min(device_capacity["nvme"][controller])
 
             # Get the SCM storage configuration for this engine
             scm_size = engine_param.get_value("scm_size")


### PR DESCRIPTION
Updating the behavior of launch.py --nvme auto argument.  The 'auto'
keyword will now detect and use any homogenous VMD controller or NVMe
devices detected on the specified hosts.  The 'auto_vmd' and 'auto_nvme'
keywords will limit the auto-detection to either VMD controller or NVMe
devices, respectively.

Test-tag-hw-medium: pr daily_regression full_regression

Signed-off-by: Phillip Henderson <phillip.henderson@intel.com>