### PR TITLE
DAOS-9098 control: Retry -DER_EXCLUDED on pool operations

### DIFF
--- a/src/control/lib/control/pool.go
+++ b/src/control/lib/control/pool.go
@@ -198,7 +198,8 @@ func (r *poolRequest) canRetry(reqErr error, try uint) bool {
 		switch e {
 		// These pool errors can be retried.
 		case drpc.DaosTimedOut, drpc.DaosGroupVersionMismatch,
-			drpc.DaosTryAgain, drpc.DaosOutOfGroup, drpc.DaosUnreachable:
+			drpc.DaosTryAgain, drpc.DaosOutOfGroup, drpc.DaosUnreachable,
+			drpc.DaosExcluded:
 			return true
 		default:
 			return false


### PR DESCRIPTION
Per the advice in the ticket, add this error to the set of
retryable errors for Control API clients (e.g. dmg).

Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com>
