### PR TITLE
DAOS-XXX control: improve online bdev scan logic

### DIFF
--- a/src/control/lib/control/storage.go
+++ b/src/control/lib/control/storage.go
@@ -153,7 +153,7 @@ type (
 // and adding it to the StorageScanResp.
 //
 // TODO: pass info field that is embedded in message to response receiver.
-func (ssp *StorageScanResp) addHostResponse(hr *HostResponse) error {
+func (ssr *StorageScanResp) addHostResponse(hr *HostResponse) error {
 	pbResp, ok := hr.Message.(*ctlpb.StorageScanResp)
 	if !ok {
 		return errors.Errorf("unable to unpack message: %+v", hr.Message)
@@ -176,7 +176,7 @@ func (ssp *StorageScanResp) addHostResponse(hr *HostResponse) error {
 		if nvmeState.GetInfo() != "" {
 			pbErrMsg += fmt.Sprintf(" (%s)", nvmeState.GetInfo())
 		}
-		if err := ssp.addHostError(hr.Addr, errors.New(pbErrMsg)); err != nil {
+		if err := ssr.addHostError(hr.Addr, errors.New(pbErrMsg)); err != nil {
 			return err
 		}
 	}
@@ -199,15 +199,15 @@ func (ssp *StorageScanResp) addHostResponse(hr *HostResponse) error {
 		if scmState.GetInfo() != "" {
 			pbErrMsg += fmt.Sprintf(" (%s)", scmState.GetInfo())
 		}
-		if err := ssp.addHostError(hr.Addr, errors.New(pbErrMsg)); err != nil {
+		if err := ssr.addHostError(hr.Addr, errors.New(pbErrMsg)); err != nil {
 			return err
 		}
 	}
 
-	if ssp.HostStorage == nil {
-		ssp.HostStorage = make(HostStorageMap)
+	if ssr.HostStorage == nil {
+		ssr.HostStorage = make(HostStorageMap)
 	}
-	if err := ssp.HostStorage.Add(hr.Addr, hs); err != nil {
+	if err := ssr.HostStorage.Add(hr.Addr, hs); err != nil {
 		return err
 	}
 
@@ -224,6 +224,8 @@ func (ssp *StorageScanResp) addHostResponse(hr *HostResponse) error {
 // NumaMeta option requests DAOS server meta data stored on SSDs.
 // NumaBasic option strips SSD details down to only the most basic.
 func StorageScan(ctx context.Context, rpcClient UnaryInvoker, req *StorageScanReq) (*StorageScanResp, error) {
+	rpcClient.Debugf("DAOS storage scan request: %+v", req)
+
 	req.setRPC(func(ctx context.Context, conn *grpc.ClientConn) (proto.Message, error) {
 		return ctlpb.NewCtlSvcClient(conn).StorageScan(ctx, &ctlpb.StorageScanReq{
 			Scm: &ctlpb.ScanScmReq{
@@ -257,6 +259,10 @@ func StorageScan(ctx context.Context, rpcClient UnaryInvoker, req *StorageScanRe
 		}
 	}
 
+	for k, v := range ssr.HostStorage {
+		rpcClient.Debugf("host %q storage: %+v", k, v)
+	}
+	rpcClient.Debugf("DAOS storage scan response: %+v", ssr)
 	return ssr, nil
 }
 

--- a/src/control/server/ctl_storage.go
+++ b/src/control/server/ctl_storage.go
@@ -230,7 +230,7 @@ func (cs *ControlService) scanAssignedBdevs(ctx context.Context, statsReq bool) 
 			return nil, err
 		}
 
-		// If the is not running or we aren't interested in temporal
+		// If the engine is not running or we aren't interested in temporal
 		// statistics for the bdev devices then continue to next.
 		if !ei.IsReady() || !statsReq {
 			for _, tsr := range tsrs {
@@ -248,6 +248,7 @@ func (cs *ControlService) scanAssignedBdevs(ctx context.Context, statsReq bool) 
 			if err != nil {
 				return nil, errors.Wrap(err, "create controller map")
 			}
+			cs.log.Debugf("nvme ctrlr map for tier %+v: %+v", tsr, ctrlrMap)
 
 			if err := ei.updateInUseBdevs(ctx, ctrlrMap); err != nil {
 				return nil, err

--- a/src/control/server/instance_drpc.go
+++ b/src/control/server/instance_drpc.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/dustin/go-humanize"
 	"github.com/pkg/errors"
 	"google.golang.org/protobuf/proto"
 
@@ -215,42 +216,13 @@ func (ei *EngineInstance) getSmdDetails(smd *ctlpb.SmdDevResp_Device) (*storage.
 	return smdDev, nil
 }
 
-func (ei *EngineInstance) addBdevStats(ctx context.Context, smdDev *storage.SmdDevice, ctrlr *storage.NvmeController) (bool, error) {
-	msg := fmt.Sprintf("instance %d: smd %s with transport address %s", ei.Index(),
-		smdDev.UUID, smdDev.TrAddr)
-
-	pbStats, err := ei.GetBioHealth(ctx, &ctlpb.BioHealthReq{DevUuid: smdDev.UUID})
-	if err != nil {
-		status, ok := errors.Cause(err).(drpc.DaosStatus)
-
-		// if error indicates non-existent health and smd has abnormal state then return
-		if ok && status == drpc.DaosNonexistant && !smdDev.NvmeState.IsNormal() {
-			ei.log.Debugf("%s: health stats not found, device states: %q", msg,
-				smdDev.NvmeState.String())
-
-			return false, nil
-		}
-
-		return false, errors.Wrapf(err, "instance %d, ctrlr %s", ei.Index(), smdDev.TrAddr)
-	}
-
-	// populate space usage for each smd device from health stats
-	smdDev.TotalBytes = pbStats.TotalBytes
-	smdDev.AvailBytes = pbStats.AvailBytes
-	msg = fmt.Sprintf("%s: smd space usage updated", msg)
-
-	if ctrlr == nil {
-		ei.log.Debug(msg)
-		return false, nil
-	}
-
+func updateCtrlrHealth(pbStats *ctlpb.BioHealthResp, ctrlr *storage.NvmeController) error {
 	ctrlr.HealthStats = new(storage.NvmeHealth)
 	if err := convert.Types(pbStats, ctrlr.HealthStats); err != nil {
-		return false, errors.Wrap(err, "convert health stats")
+		return errors.Wrap(err, "convert health stats")
 	}
 
-	ei.log.Debugf("%s: health stats updated", msg)
-	return true, nil
+	return nil
 }
 
 // updateInUseBdevs updates-in-place the input list of controllers with new NVMe health stats and
@@ -258,43 +230,69 @@ func (ei *EngineInstance) addBdevStats(ctx context.Context, smdDev *storage.SmdD
 //
 // Query each SmdDevice on each I/O Engine instance for health stats and update existing controller
 // data in ctrlrMap using PCI address key.
-func (ei *EngineInstance) updateInUseBdevs(ctx context.Context, ctrlrMap map[string]*storage.NvmeController) error {
+func (ei *EngineInstance) updateInUseBdevs(ctx context.Context, ctrlrMap map[string]*storage.NvmeController) (err error) {
+	defer func() {
+		err = errors.Wrapf(err, "instance %d", ei.Index())
+	}()
+
 	smdDevs, err := ei.ListSmdDevices(ctx, new(ctlpb.SmdDevReq))
 	if err != nil {
-		return errors.Wrapf(err, "instance %d listSmdDevices()", ei.Index())
+		return errors.Wrapf(err, "list smd devices")
 	}
+	ei.log.Debugf("smdDevs %+v", smdDevs)
 
 	hasUpdatedHealth := make(map[string]bool)
 	for _, smd := range smdDevs.Devices {
+		msg := fmt.Sprintf("instance %d: smd %s: ctrlr %s", ei.Index(), smd.Uuid,
+			smd.TrAddr)
+
 		ctrlr, exists := ctrlrMap[smd.GetTrAddr()]
 		if !exists {
-			return errors.Errorf("instance %d: smd %s: unknown controller %s",
-				ei.Index(), smd.GetUuid(), smd.GetTrAddr())
+			ei.log.Errorf("%s: ctrlr not found", msg)
+			continue
 		}
 
 		smdDev, err := ei.getSmdDetails(smd)
 		if err != nil {
-			return errors.Wrapf(err, "collect smd info for ctrlr %s", ctrlr.PciAddr)
+			ei.log.Errorf("%s: collect smd info: %s", msg, err.Error())
+			continue
 		}
+
+		pbStats, err := ei.GetBioHealth(ctx, &ctlpb.BioHealthReq{DevUuid: smdDev.UUID})
+		if err != nil {
+			// continue if error indicates non-existent health and smd has abnormal state
+			status, ok := errors.Cause(err).(drpc.DaosStatus)
+			if ok && status == drpc.DaosNonexistant && !smdDev.NvmeState.IsNormal() {
+				ei.log.Debugf("%s: stats not found (device state: %q), skip update",
+					msg, smdDev.NvmeState.String())
+				continue
+			}
+			ei.log.Errorf("%s: fetch stats: %s", msg, err.Error())
+			continue
+		}
+
+		// populate space usage for each smd device from health stats
+		smdDev.TotalBytes = pbStats.TotalBytes
+		smdDev.AvailBytes = pbStats.AvailBytes
+		msg = fmt.Sprintf("%s: smd usage = %s/%s", msg, humanize.Bytes(smdDev.AvailBytes),
+			humanize.Bytes(smdDev.TotalBytes))
+		ctrlr.UpdateSmd(smdDev)
 
 		// multiple updates for the same key expected when more than one controller
 		// namespaces (and resident blobstores) exist, stats will be the same for each
 		// so only pass valid ctrlr reference when stats haven't yet been updated
-		var ctrlrRef *storage.NvmeController
-		if _, already := hasUpdatedHealth[ctrlr.PciAddr]; !already {
-			ctrlrRef = ctrlr
+		if hasUpdatedHealth[ctrlr.PciAddr] {
+			ei.log.Debugf("%s: health stats already added so skip update", msg)
+			continue
 		}
 
-		ctrlrUpdated, err := ei.addBdevStats(ctx, smdDev, ctrlrRef)
-		if err != nil {
-			return err
+		if err := updateCtrlrHealth(pbStats, ctrlr); err != nil {
+			ei.log.Errorf("%s: update ctrlr health: %s", err.Error())
+			continue
 		}
+		hasUpdatedHealth[ctrlr.PciAddr] = true
 
-		if ctrlrUpdated {
-			hasUpdatedHealth[ctrlr.PciAddr] = true
-		}
-
-		ctrlr.UpdateSmd(smdDev)
+		ei.log.Debugf("%s: ctrlr health updated", msg)
 	}
 
 	return nil


### PR DESCRIPTION
Make logic more robust and add relevant logging when updating in-use
bdev details during storage scan.

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>