### PR TITLE
DAOS-8469 test: use shared posix directory in large tests (#6910)

### DIFF
--- a/src/tests/ftest/datamover/large_dir.py
+++ b/src/tests/ftest/datamover/large_dir.py
@@ -5,7 +5,7 @@
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
 from data_mover_test_base import DataMoverTestBase
-from os.path import basename
+import os
 
 # pylint: disable=too-many-ancestors
 class DmvrLargeDir(DataMoverTestBase):
@@ -28,7 +28,6 @@ class DmvrLargeDir(DataMoverTestBase):
             Create POSIX type cont2.
             Copy data from cont1 to cont2.
             Copy data from cont2 to external POSIX file system.
-            (Assuming dfuse mount as external POSIX FS).
             Create POSIX type cont4.
             Copy data from external POSIX file system to cont4.
             Run mdtest -a DFS with read verify on copied directory to verify
@@ -66,43 +65,30 @@ class DmvrLargeDir(DataMoverTestBase):
             "DAOS", "/", self.pool[0], self.container[0],
             "DAOS", "/", self.pool[0], self.container[1])
 
-        # TODO: commenting out for now until we have a POSIX shared filesystem
-        # to write to for large dir tests. These used to work but do not
-        # anymore because duns now resolves dfuse mount points
+        posix_path = self.new_posix_test_path(shared=True)
 
-        # create cont3 for dfuse (posix)
-        #self.create_cont(self.pool[0])
+        # copy from daos cont2 to posix file system
+        self.run_datamover(
+            self.test_id + " (cont2 to posix)",
+            "DAOS", "/", self.pool[0], self.container[1],
+            "POSIX", posix_path)
 
-        # start dfuse on cont3
-        #self.start_dfuse(self.dfuse_hosts, self.pool[0], self.container[2])
+        # create cont3
+        self.create_cont(self.pool[0])
 
-        # dcp treats a trailing slash on the source as /*
-        # so strip trailing slash from posix path so dcp
-        # behaves similar to "cp"
-        #posix_path = self.dfuse.mount_dir.value.rstrip("/")
-
-        # copy from daos cont2 to posix file system (dfuse)
-        #self.run_datamover(
-        #    self.test_id + " (cont2 to posix)",
-        #    "DAOS", "/", self.pool[0], self.container[1],
-        #    "POSIX", posix_path)
-
-        # create cont4
-        #self.create_cont(self.pool[0])
-
-        # copy from posix file system to daos cont4
-        #self.run_datamover(
-        #    self.test_id + " (posix to cont4)",
-        #    "POSIX", posix_path, None, None,
-        #    "DAOS", "/", self.pool[0], self.container[3])
+        # copy from posix file system to daos cont3
+        self.run_datamover(
+            self.test_id + " (posix to cont3)",
+            "POSIX", posix_path, None, None,
+            "DAOS", "/", self.pool[0], self.container[2])
 
         # the result is that a NEW directory is created in the destination
-        #daos_path = "/" + basename(posix_path) + self.mdtest_cmd.test_dir.value
+        daos_path = "/" + os.path.basename(posix_path) + self.mdtest_cmd.test_dir.value
 
-        # update mdtest params, read back and verify data from cont2
+        # update mdtest params, read back and verify data from cont3
         self.mdtest_cmd.read_bytes.update(file_size)
         self.run_mdtest_with_params(
-            "DAOS", "/", self.pool[0], self.container[1],
+            "DAOS", daos_path, self.pool[0], self.container[2],
             flags=mdtest_flags[1])
 
     def test_dm_large_dir_dcp(self):
@@ -112,7 +98,7 @@ class DmvrLargeDir(DataMoverTestBase):
             an external POSIX file system using dcp.
         :avocado: tags=all,full_regression
         :avocado: tags=hw,large
-        :avocado: tags=datamover,dcp,dfuse
+        :avocado: tags=datamover,dcp
         :avocado: tags=dm_large_dir,dm_large_dir_dcp
         """
         self.run_dm_large_dir("DCP")

--- a/src/tests/ftest/datamover/large_dir.yaml
+++ b/src/tests/ftest/datamover/large_dir.yaml
@@ -9,7 +9,7 @@ hosts:
     - client-F
     - client-G
     - client-H
-timeout: 480 
+timeout: 1080
 server_config:
   name: daos_server
   servers:
@@ -37,22 +37,19 @@ mdtest:
   dfs_destroy: False
   manager: "MPICH"
   mux_dataset: !mux
-    many_files:                # total 50K files for dcp
-      num_of_files_dirs: 1667
+    many_files:                # total 15K files for dcp
+      num_of_files_dirs: 500
       mdtest_flags:
         - "-F -C"
         - "-F -E"
-    many_files_and_dirs:       # total 40K files and 40K dirs for dcp
-      num_of_files_dirs: 1667
+    many_files_and_dirs:       # total 15K files and 15K dirs for dcp
+      num_of_files_dirs: 500
       mdtest_flags:
         - "-C"
         - "-E"
       depth: 4
       branching_factor: 4
   bytes: 4096
-dfuse:
-  mount_dir: "/tmp/daos_dfuse/"
-  disable_caching: True
 dcp:
   client_processes:
     np: 16

--- a/src/tests/ftest/datamover/large_file.yaml
+++ b/src/tests/ftest/datamover/large_file.yaml
@@ -9,7 +9,7 @@ hosts:
     - client-F
     - client-G
     - client-H
-timeout: 600
+timeout: 840
 server_config:
   name: daos_server
   servers:
@@ -41,13 +41,10 @@ ior:
   transfersize_blocksize:
     1M:
       transfer_size: '1M'
-      block_size: '5G'        # aggregate of 150G for dcp and 50G for fs_copy
+      block_size: '1G'        # aggregate of 30G for dcp and 10G for fs_copy
   objectclass:
     EC_4P1GX:
       dfs_oclass: "EC_4P1GX"
-dfuse:
-  mount_dir: "/tmp/daos_dfuse/"
-  disable_caching: True
 dcp:
   bufsize: "64MB"
   chunksize: "128MB"

--- a/src/tests/ftest/datamover/negative.py
+++ b/src/tests/ftest/datamover/negative.py
@@ -34,7 +34,7 @@ class DmvrNegativeTest(DataMoverTestBase):
 
         # Setup the directory structures
         self.new_posix_test_path()
-        self.posix_test_file = join(self.posix_test_paths[0], self.test_file)
+        self.posix_test_file = join(self.posix_local_test_paths[0], self.test_file)
         self.daos_test_path = "/"
         self.daos_test_file = join(self.daos_test_path, self.test_file)
 
@@ -75,20 +75,20 @@ class DmvrNegativeTest(DataMoverTestBase):
         self.run_datamover(
             self.test_id + " (missing source pool)",
             "DAOS_UUID", "/", None, None,
-            "POSIX", self.posix_test_paths[0],
+            "POSIX", self.posix_local_test_paths[0],
             expected_rc=1,
             expected_output=self.MFU_ERR_DAOS_INVAL_ARG)
 
         self.run_datamover(
             self.test_id + " (missing source cont)",
             "DAOS_UUID", "/", pool1, None,
-            "POSIX", self.posix_test_paths[0],
+            "POSIX", self.posix_local_test_paths[0],
             expected_rc=1,
             expected_output=self.MFU_ERR_DAOS_INVAL_ARG)
 
         self.run_datamover(
             self.test_id + " (missing dest pool)",
-            "POSIX", self.posix_test_paths[0], None, None,
+            "POSIX", self.posix_local_test_paths[0], None, None,
             "DAOS_UUID", "/", None, None,
             expected_rc=1,
             expected_output=self.MFU_ERR_DAOS_INVAL_ARG)
@@ -125,7 +125,7 @@ class DmvrNegativeTest(DataMoverTestBase):
         # (3) Bad parameter: daos-prefix is invalid.
         self.set_datamover_params(
             "DAOS_UNS", "/", pool1, cont1,
-            "POSIX", self.posix_test_paths[0])
+            "POSIX", self.posix_local_test_paths[0])
         self.dcp_cmd.daos_prefix.update("/fake/prefix")
         self.dcp_cmd.src_path.update("/fake/prefix/dir")
         self.run_datamover(
@@ -134,7 +134,7 @@ class DmvrNegativeTest(DataMoverTestBase):
             expected_output=self.MFU_ERR_DAOS_INVAL_ARG)
 
         self.set_datamover_params(
-            "POSIX", self.posix_test_paths[0], None, None,
+            "POSIX", self.posix_local_test_paths[0], None, None,
             "DAOS_UNS", "/", pool1, cont1)
         self.dcp_cmd.daos_prefix.update("/fake/prefix")
         self.dcp_cmd.dst_path.update("/fake/prefix/dir")
@@ -145,7 +145,7 @@ class DmvrNegativeTest(DataMoverTestBase):
 
         self.set_datamover_params(
             "DAOS_UNS", "/temp", pool1, cont1,
-            "POSIX", self.posix_test_paths[0])
+            "POSIX", self.posix_local_test_paths[0])
         self.dcp_cmd.src_path.update("/fake/fake/fake")
         self.run_datamover(
             self.test_id + " (invalid prefix - not match source or dest)",
@@ -154,7 +154,7 @@ class DmvrNegativeTest(DataMoverTestBase):
 
         self.set_datamover_params(
             "DAOS_UNS", "/temp", pool1, cont1,
-            "POSIX", self.posix_test_paths[0])
+            "POSIX", self.posix_local_test_paths[0])
         src_path = "/fake/fake" + str(self.dcp_cmd.daos_prefix.value)
         self.dcp_cmd.src_path.update(src_path)
         self.run_datamover(
@@ -163,7 +163,7 @@ class DmvrNegativeTest(DataMoverTestBase):
             expected_output=self.MFU_ERR_DAOS_INVAL_ARG)
 
         self.set_datamover_params(
-            "POSIX", self.posix_test_paths[0], None, None,
+            "POSIX", self.posix_local_test_paths[0], None, None,
             "DAOS_UNS", "/temp", pool1, cont1)
         dst_path = "/fake/fake" + str(self.dcp_cmd.daos_prefix.value)
         self.dcp_cmd.dst_path.update(dst_path)
@@ -173,9 +173,9 @@ class DmvrNegativeTest(DataMoverTestBase):
             expected_output=self.MFU_ERR_DAOS_INVAL_ARG)
 
         self.set_datamover_params(
-            "POSIX", self.posix_test_paths[0], None, None,
+            "POSIX", self.posix_local_test_paths[0], None, None,
             "DAOS_UUID", "/", pool1, cont1)
-        self.dcp_cmd.daos_prefix.update(self.posix_test_paths[0])
+        self.dcp_cmd.daos_prefix.update(self.posix_local_test_paths[0])
         self.run_datamover(
             self.test_id + " (invalid prefix - on POSIX source)",
             expected_rc=1,
@@ -183,8 +183,8 @@ class DmvrNegativeTest(DataMoverTestBase):
 
         self.set_datamover_params(
             "DAOS_UUID", "/", pool1, cont1,
-            "POSIX", self.posix_test_paths[0])
-        self.dcp_cmd.daos_prefix.update(self.posix_test_paths[0])
+            "POSIX", self.posix_local_test_paths[0])
+        self.dcp_cmd.daos_prefix.update(self.posix_local_test_paths[0])
         self.run_datamover(
             self.test_id + " (invalid prefix - on POSIX dst)",
             expected_rc=1,
@@ -195,7 +195,7 @@ class DmvrNegativeTest(DataMoverTestBase):
         self.run_datamover(
             self.test_id + " (invalid source pool)",
             "DAOS_UUID", "/", fake_uuid, cont1,
-            "POSIX", self.posix_test_paths[0],
+            "POSIX", self.posix_local_test_paths[0],
             expected_rc=1,
             expected_output="DER_NONEXIST")
 
@@ -203,14 +203,14 @@ class DmvrNegativeTest(DataMoverTestBase):
         self.run_datamover(
             self.test_id + " (invalid source cont)",
             "DAOS_UUID", "/", pool1, fake_uuid,
-            "POSIX", self.posix_test_paths[0],
+            "POSIX", self.posix_local_test_paths[0],
             expected_rc=1,
             expected_output="DER_NONEXIST")
 
         fake_uuid = str(self.gen_uuid())
         self.run_datamover(
             self.test_id + " (invalid dest pool)",
-            "POSIX", self.posix_test_paths[0], None, None,
+            "POSIX", self.posix_local_test_paths[0], None, None,
             "DAOS_UUID", "/", fake_uuid, cont1,
             expected_rc=1,
             expected_output="DER_NONEXIST")
@@ -218,13 +218,13 @@ class DmvrNegativeTest(DataMoverTestBase):
         self.run_datamover(
             self.test_id + " (invalid source cont path)",
             "DAOS_UUID", "/fake/fake", pool1, cont1,
-            "POSIX", self.posix_test_paths[0],
+            "POSIX", self.posix_local_test_paths[0],
             expected_rc=1,
             expected_output="No such file or directory")
 
         self.run_datamover(
             self.test_id + " (invalid dest cont path)",
-            "POSIX", self.posix_test_paths[0], None, None,
+            "POSIX", self.posix_local_test_paths[0], None, None,
             "DAOS_UUID", "/fake/fake", pool1, cont1,
             expected_rc=1,
             expected_output="No such file or directory")
@@ -269,7 +269,7 @@ class DmvrNegativeTest(DataMoverTestBase):
         # Try to copy, and expect a proper error message.
         self.run_datamover(
             self.test_id + " (dst pool out of space)",
-            "POSIX", self.posix_test_paths[0], None, None,
+            "POSIX", self.posix_local_test_paths[0], None, None,
             "DAOS_UUID", "/", pool1, cont1,
             expected_rc=1,
             expected_output=[self.MFU_ERR_DCP_COPY, "errno=28"])
@@ -277,7 +277,7 @@ class DmvrNegativeTest(DataMoverTestBase):
         # Try to copy. For now, we expect this to just abort.
         self.run_datamover(
             self.test_id + " (dst posix out of space)",
-            "POSIX", self.posix_test_paths[0], None, None,
+            "POSIX", self.posix_local_test_paths[0], None, None,
             "POSIX", dst_posix_path,
             expected_rc=255,
             expected_err=["errno=28"])
@@ -303,7 +303,7 @@ class DmvrNegativeTest(DataMoverTestBase):
                                  pool1, cont1)
 
         # Use a really long filename
-        dst_path = join(self.posix_test_paths[0], "d"*300)
+        dst_path = join(self.posix_local_test_paths[0], "d"*300)
         self.run_datamover(
             self.test_id + " (filename is too long)",
             "DAOS_UUID", "/", pool1, cont1,

--- a/src/tests/ftest/datamover/posix_symlinks.py
+++ b/src/tests/ftest/datamover/posix_symlinks.py
@@ -121,7 +121,7 @@ class DmvrPosixSymlinks(DataMoverTestBase):
             diff_src = src_posix_path
 
         # DAOS -> DAOS
-        dst_daos_dir = self.new_daos_test_path(False)
+        dst_daos_dir = self.new_daos_test_path(create=False)
         self.run_datamover(
             test_desc + " (DAOS->DAOS)",
             "DAOS", src_daos_dir, pool, cont,
@@ -129,7 +129,7 @@ class DmvrPosixSymlinks(DataMoverTestBase):
         self.run_diff(diff_src, cont.path.value + dst_daos_dir, do_deref)
 
         # DAOS -> POSIX
-        dst_posix_path = self.new_posix_test_path(False)
+        dst_posix_path = self.new_posix_test_path(create=False)
         self.run_datamover(
             test_desc + " (DAOS->POSIX)",
             "DAOS", src_daos_dir, pool, cont,
@@ -137,7 +137,7 @@ class DmvrPosixSymlinks(DataMoverTestBase):
         self.run_diff(diff_src, dst_posix_path)
 
         # POSIX -> DAOS
-        dst_daos_dir = self.new_daos_test_path(False)
+        dst_daos_dir = self.new_daos_test_path(create=False)
         self.run_datamover(
             test_desc + " (POSIX->DAOS)",
             "POSIX", src_posix_path, None, None,

--- a/src/tests/ftest/util/apricot/apricot/test.py
+++ b/src/tests/ftest/util/apricot/apricot/test.py
@@ -663,7 +663,7 @@ class TestWithServers(TestWithoutServers):
             if self.hostlist_clients:
                 hosts.extend(self.hostlist_clients)
             self.log.info("-" * 100)
-            self.stop_leftover_processes(["orterun"], hosts)
+            self.stop_leftover_processes(["orterun", "mpirun"], hosts)
 
             # Ensure write permissions for the daos command log files when
             # using systemctl

--- a/src/tests/ftest/util/data_mover_test_base.py
+++ b/src/tests/ftest/util/data_mover_test_base.py
@@ -80,12 +80,17 @@ class DataMoverTestBase(IorTestBase, MdtestBase):
         self.uuids = []
         self.dfuse_hosts = None
         self.num_run_datamover = 0  # Number of times run_datamover was called
+        self.job_manager = None
+        self.parent = None
 
         # Temp directory for serialize/deserialize
         self.serial_tmp_dir = self.tmp
 
-        # List of test paths to create and remove
-        self.posix_test_paths = []
+        # List of local test paths to create and remove
+        self.posix_local_test_paths = []
+
+        # List of shared test paths to create and remove
+        self.posix_shared_test_paths = []
 
         # paths to unmount in teardown
         self.mounted_posix_test_paths = []
@@ -119,6 +124,8 @@ class DataMoverTestBase(IorTestBase, MdtestBase):
         self.ddeserialize_processes = self.params.get(
             "np", "/run/ddeserialize/client_processes/*", 1)
 
+        self.parent = self.params.get("parent", "/run/datamover/*", self.tmp)
+
         tool = self.params.get("tool", "/run/datamover/*")
         if tool:
             self.set_tool(tool)
@@ -130,8 +137,17 @@ class DataMoverTestBase(IorTestBase, MdtestBase):
             list: a list of error strings to report at the end of tearDown().
 
         """
+        # doesn't append to error list because it reports an error if all
+        # processes completed successfully (nothing to stop), but this call is
+        # necessary in the case that mpi processes are ran across multiple nodes
+        # and a timeout occurs. If this happens then cleanup on shared posix
+        # directories causes errors (because an MPI process might still have it open)
         error_list = []
 
+        if self.job_manager:
+            self.job_manager.kill()
+
+        # cleanup mounted paths
         if self.mounted_posix_test_paths:
             path_list = self._get_posix_test_path_list(path_list=self.mounted_posix_test_paths)
             for item in path_list:
@@ -146,12 +162,24 @@ class DataMoverTestBase(IorTestBase, MdtestBase):
                     self._execute_command(umount_cmd)
                 except CommandFailure as error:
                     error_list.append("Error umounting posix test directory: {}".format(error))
-        if self.posix_test_paths:
+
+        # cleanup local paths
+        if self.posix_local_test_paths:
             command = "rm -rf {}".format(self._get_posix_test_path_string())
             try:
                 self._execute_command(command)
             except CommandFailure as error:
                 error_list.append("Error removing created directories: {}".format(error))
+
+        # cleanup shared paths (only runs on one node in job)
+        if self.posix_shared_test_paths:
+            command = "rm -rf {}".format(self._get_posix_test_path_string(path=self.posix_shared_test_paths))
+            try:
+	        # only call rm on one client since this is cleaning up shared dir
+                self._execute_command(command, hosts=self.hostlist_clients[0:1])
+            except CommandFailure as error:
+                error_list.append(
+                    "Error removing created directories: {}".format(error))
         return error_list
 
     def set_api(self, api):
@@ -186,45 +214,51 @@ class DataMoverTestBase(IorTestBase, MdtestBase):
             list: a list of quoted posix test path strings
 
         """
-        # default
         if path_list == None:
-            path_list = self.posix_test_paths
+            path_list = self.posix_local_test_paths
 
         return ["'{}'".format(item) for item in path_list]
 
-    def _get_posix_test_path_string(self):
+    def _get_posix_test_path_string(self, path=None):
         """Get a string of all of the quoted posix test path strings.
 
         Returns:
             str: a string of all of the quoted posix test path strings
 
         """
-        return " ".join(self._get_posix_test_path_list())
+        return " ".join(self._get_posix_test_path_list(path_list=path))
 
-    def new_posix_test_path(self, create=True, parent=None, mount_dir=False):
+    def new_posix_test_path(self, shared=False, create=True, parent=None, mount_dir=False):
         """Generate a new, unique posix path.
 
         Args:
+            shared (bool): Whether to create a directory shared across nodes or local.
+                Defaults to False.
             create (bool): Whether to create the directory.
                 Defaults to True.
             mount_dir (bool): Whether or not posix directory will be manually
 	        mounted in tmpfs.
             parent (str, optional): The parent directory to create the
-                path in. Defaults to self.tmp.
+                path in. Defaults to self.parent, which has a default of self.tmp.
 
         Returns:
             str: the posix path.
 
         """
-        dir_name = "posix_test{}".format(len(self.posix_test_paths))
+        # make dirname unique to datamover test
+        method = self.get_test_info()["method"]
+        dir_name = "{}{}".format(method, len(self.posix_local_test_paths))
 
         if parent:
             path = join(parent, dir_name)
         else:
-            path = join(self.tmp, dir_name)
+            path = join(self.parent, dir_name)
 
         # Add to the list of posix paths
-        self.posix_test_paths.append(path)
+        if shared:
+            self.posix_shared_test_paths.append(path)
+        else:
+            self.posix_local_test_paths.append(path)
 
         if create:
             # Create the directory
@@ -1115,21 +1149,21 @@ class DataMoverTestBase(IorTestBase, MdtestBase):
                     processes = self.dcp_processes
                 # If we expect an rc other than 0, don't fail
                 self.dcp_cmd.exit_status_exception = (expected_rc == 0)
-                result = self.dcp_cmd.run(processes)
+                result = self.dcp_cmd.run(processes, self.job_manager)
             elif self.tool == "DSYNC":
                 if not processes:
                     processes = self.dsync_processes
                 # If we expect an rc other than 0, don't fail
                 self.dsync_cmd.exit_status_exception = (expected_rc == 0)
-                result = self.dsync_cmd.run(processes)
+                result = self.dsync_cmd.run(processes, self.job_manager)
             elif self.tool== "DSERIAL":
                 if processes:
                     processes1 = processes2 = processes
                 else:
                     processes1 = self.dserialize_processes
                     processes2 = self.ddeserialize_processes
-                result = self.dserialize_cmd.run(processes1)
-                result = self.ddeserialize_cmd.run(processes2)
+                result = self.dserialize_cmd.run(processes1, self.job_manager)
+                result = self.ddeserialize_cmd.run(processes2, self.job_manager)
             elif self.tool == "FS_COPY":
                 result = self.fs_copy_cmd.run()
             elif self.tool == "CONT_CLONE":

--- a/src/tests/ftest/util/data_mover_utils.py
+++ b/src/tests/ftest/util/data_mover_utils.py
@@ -106,12 +106,13 @@ class MfuCommandBase(ExecutableCommand):
         param_names.sort(key=self.__param_sort)
         return param_names
 
-    def run(self, processes):
+    def run(self, processes, job_manager):
         # pylint: disable=arguments-differ
         """Run the MpiFileUtils command.
 
         Args:
             processes: Number of processes for the command.
+            job_manager: Job manager variable to set/assign  
 
         Returns:
             CmdResult: Object that contains exit status, stdout, and other
@@ -124,13 +125,13 @@ class MfuCommandBase(ExecutableCommand):
         self.log.info('Starting %s', str(self.command).lower())
 
         # Get job manager cmd
-        mpirun = Mpirun(self, mpitype="mpich")
-        mpirun.assign_hosts(self.hosts, self.tmp)
-        mpirun.assign_processes(processes)
-        mpirun.exit_status_exception = self.exit_status_exception
+        job_manager = Mpirun(self, mpitype="mpich")
+        job_manager.assign_hosts(self.hosts, self.tmp)
+        job_manager.assign_processes(processes)
+        job_manager.exit_status_exception = self.exit_status_exception
 
         # Run the command
-        out = mpirun.run()
+        out = job_manager.run()
 
         return out
 

--- a/src/tests/ftest/util/ior_test_base.py
+++ b/src/tests/ftest/util/ior_test_base.py
@@ -492,7 +492,7 @@ class IorTestBase(DfuseTestBase):
 
         return result
 
-    def _execute_command(self, command, fail_on_err=True, display_output=True):
+    def _execute_command(self, command, fail_on_err=True, display_output=True, hosts=None):
         """Execute the command on all client hosts.
 
         Optionally verify if the command returns a non zero return code.
@@ -513,8 +513,9 @@ class IorTestBase(DfuseTestBase):
                 values indicating which hosts yielded the return code.
 
         """
-        result = pcmd(
-            self.hostlist_clients, command, verbose=display_output, timeout=300)
+        if hosts is None:
+            hosts = self.hostlist_clients
+        result = pcmd(hosts, command, verbose=display_output, timeout=300)
         if 0 not in result and fail_on_err:
             hosts = [str(
                 nodes) for code, nodes in list(


### PR DESCRIPTION
Modify tests to use a shared POSIX directory for large
directory and large file tests.

Quick-functional: true
Skip-fault-injection-test: true

Test-tag: datamover

Signed-off-by: Danielle Sikich <danielle.sikich@intel.com>
Signed-off-by: Dalton Bohning <dalton.bohning@intel.com>