### PR TITLE
DAOS-5458 test: Moving intercept_basic from weekly to daily

### DIFF
--- a/src/tests/ftest/ior/intercept_basic.py
+++ b/src/tests/ftest/ior/intercept_basic.py
@@ -39,7 +39,7 @@ class IorIntercept(IorTestBase):
             Compare the results and check whether using interception
                 library provides better performance.
 
-        :avocado: tags=all,full_regression
+        :avocado: tags=all,daily_regression
         :avocado: tags=hw,small
         :avocado: tags=daosio,dfuse,il
         :avocado: tags=iorinterceptbasic


### PR DESCRIPTION
Changing the frequency of intercept_basic.py test from
weekly to daily as there is not a single interception test
running as part of daily_regression.

Signed-off-by: Saurabh Tandan <saurabh.tandan@intel.com>