### PR TITLE
DAOS-9763 test: Duplicate functional test name - test_mdtest_large

### DIFF
--- a/src/tests/ftest/erasurecode/mdtest_smoke.py
+++ b/src/tests/ftest/erasurecode/mdtest_smoke.py
@@ -16,7 +16,7 @@ class EcodMdtest(MdtestBase):
     :avocado: recursive
     """
 
-    def test_ec_mdtest_large(self):
+    def test_ec_mdtest_smoke(self):
         """Jira ID: DAOS-2494.
 
         Test Description:

--- a/src/tests/ftest/erasurecode/mdtest_smoke.py
+++ b/src/tests/ftest/erasurecode/mdtest_smoke.py
@@ -16,7 +16,7 @@ class EcodMdtest(MdtestBase):
     :avocado: recursive
     """
 
-    def test_mdtest_large(self):
+    def test_ec_mdtest_large(self):
         """Jira ID: DAOS-2494.
 
         Test Description:
@@ -27,7 +27,7 @@ class EcodMdtest(MdtestBase):
         :avocado: tags=all,pr,daily_regression
         :avocado: tags=hw,large
         :avocado: tags=ec,ec_smoke,mdtest
-        :avocado: tags=ec_mdtest
+        :avocado: tags=ec_mdtest_smoke
         """
         mdtest_flags = self.params.get("flags", "/run/mdtest/*")
         self.mdtest_cmd.flags.update(mdtest_flags)

--- a/src/tests/ftest/erasurecode/offline_rebuild_aggregation.py
+++ b/src/tests/ftest/erasurecode/offline_rebuild_aggregation.py
@@ -6,7 +6,6 @@
 '''
 import time
 from ec_utils import ErasureCodeIor, check_aggregation_status
-from apricot import skipForTicket
 
 class EcodAggregationOffRebuild(ErasureCodeIor):
     # pylint: disable=too-many-ancestors
@@ -112,7 +111,6 @@ class EcodAggregationOffRebuild(ErasureCodeIor):
         """
         self.execution(agg_trigger=True)
 
-    @skipForTicket("DAOS-9208")
     def test_ec_offline_agg_during_rebuild(self):
         """Jira ID: DAOS-7313.
 


### PR DESCRIPTION
DAOS-9763 test: Duplicate functional test name - test_mdtest_large
Description: Update fixing of the test duplicate name on DAOS-9706 by Samir.
           - Fixing the mdtest smoke test name
           - Removing the skip for ec aggregation.

Test-tag: ec_mdtest_smoke ec_offline_rebuild_agg_default ec_offline_agg_during_rebuild
Test-repeat: 5
Signed-off-by: Ding Ho ding-hwa.ho@intel.com