### PR TITLE
DAOS-9844 test: Remove unnecessary variants from pool/bad_connect.py

### DIFF
--- a/src/tests/ftest/pool/bad_connect.py
+++ b/src/tests/ftest/pool/bad_connect.py
@@ -11,71 +11,51 @@ from apricot import TestWithServers
 
 
 class BadConnectTest(TestWithServers):
-    """
-    Tests pool connect calls passing NULL and otherwise inappropriate
-    parameters.  This use the python API.
+    """Test pool connect with different UUIDs.
     :avocado: recursive
     """
     def test_connect(self):
         """
-        Pass bad parameters to pool connect
+        Test pool connect with valid and invalid UUIDs. Invalid UUIDs are None and the
+        invalid value.
 
         :avocado: tags=all,full_regression
         :avocado: tags=vm
-        :avocado: tags=pool,bad_connect
+        :avocado: tags=pool
+        :avocado: tags=bad_connect
         """
-        # Accumulate a list of pass/fail indicators representing what is
-        # expected for each parameter then "and" them to determine the
-        # expected result of the test
-        expected_for_param = []
-
-        modelist = self.params.get("mode", '/run/connecttests/connectmode/*/')
-        connectmode = modelist[0]
-        expected_for_param.append(modelist[1])
-
-        uuidlist = self.params.get("uuid", '/run/connecttests/UUID/*/')
-        connectuuid = uuidlist[0]
-        expected_for_param.append(uuidlist[1])
-
-        # if any parameter is FAIL then the test should FAIL, in this test
-        # virtually everyone should FAIL since we are testing bad parameters
-        expected_result = 'PASS'
-        for result in expected_for_param:
-            if result == 'FAIL':
-                expected_result = 'FAIL'
-                break
-
-        puuid = (ctypes.c_ubyte * 16)()
-        # initialize a python pool object then create the underlying
-        # daos storage
         self.add_pool(connect=False)
-        # save this uuid since we might trash it as part of the test
-        ctypes.memmove(puuid, self.pool.pool.uuid, 16)
 
-        # trash the UUID value in various ways
-        if connectuuid == 'NULLPTR':
-            self.pool.pool.uuid = None
-        if connectuuid == 'JUNK':
-            self.pool.pool.uuid[4] = 244
+        # save this uuid since we might trash it as part of the test
+        original_uuid = (ctypes.c_ubyte * 16)()
+        ctypes.memmove(original_uuid, self.pool.pool.uuid, 16)
+
+        uuid_result = self.params.get("uuid", '/run/uuids/*/')
+        uuid = uuid_result[0]
+        expected_result = uuid_result[1]
+
+        # Set invalid UUID, or keep it to test the valid case.
+        if uuid != "VALID":
+            if uuid == "None":
+                self.pool.pool.uuid = None
+            else:
+                self.pool.pool.uuid[4] = int(uuid)
 
         try:
-            self.pool.connect(1 << connectmode)
-
-            if expected_result in ['FAIL']:
-                self.fail("Test was expected to fail but it passed.\n")
-
+            self.pool.connect()
+            if expected_result == "FAIL":
+                self.fail("Test was expected to fail but it passed.")
         except TestFail as excep:
             print(excep)
             print(traceback.format_exc())
-            if expected_result in ['PASS']:
-                self.fail("Test was expected to pass but it failed.\n")
-
+            if expected_result == "PASS":
+                self.fail("Test was expected to pass but it failed.")
         # cleanup the pool
         finally:
             if self.pool is not None and self.pool.pool.attached == 1:
                 # restore values in case we trashed them during test
                 if self.pool.pool.uuid is None:
                     self.pool.pool.uuid = (ctypes.c_ubyte * 16)()
-                ctypes.memmove(self.pool.pool.uuid, puuid, 16)
+                ctypes.memmove(self.pool.pool.uuid, original_uuid, 16)
                 print("pool uuid after restore {}".format(
                     self.pool.pool.get_uuid_str()))

--- a/src/tests/ftest/pool/bad_connect.py
+++ b/src/tests/ftest/pool/bad_connect.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 '''
-  (C) Copyright 2018-2021 Intel Corporation.
+  (C) Copyright 2018-2022 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
@@ -21,7 +21,7 @@ class BadConnectTest(TestWithServers):
         Pass bad parameters to pool connect
 
         :avocado: tags=all,full_regression
-        :avocado: tags=tiny
+        :avocado: tags=vm
         :avocado: tags=pool,bad_connect
         """
         # Accumulate a list of pass/fail indicators representing what is
@@ -32,10 +32,6 @@ class BadConnectTest(TestWithServers):
         modelist = self.params.get("mode", '/run/connecttests/connectmode/*/')
         connectmode = modelist[0]
         expected_for_param.append(modelist[1])
-
-        setlist = self.params.get("setname",
-                                  '/run/connecttests/connectsetnames/*/')
-        expected_for_param.append(setlist[1])
 
         uuidlist = self.params.get("uuid", '/run/connecttests/UUID/*/')
         connectuuid = uuidlist[0]

--- a/src/tests/ftest/pool/bad_connect.yaml
+++ b/src/tests/ftest/pool/bad_connect.yaml
@@ -9,7 +9,7 @@ timeout: 700
 pool:
   control_method: dmg
   mode: 511
-  scm_size: 1073741824
+  scm_size: 1GB
   name: daos_server
 connecttests:
    connectmode: !mux
@@ -28,15 +28,6 @@ connecttests:
      badmode1:
           mode:
              - 512
-             - FAIL
-   connectsetnames: !mux
-     goodname:
-          setname:
-             - scott_server
-             - PASS
-     badname:
-          setname:
-             - NULLPTR
              - FAIL
    UUID: !mux
      gooduuid:

--- a/src/tests/ftest/pool/bad_connect.yaml
+++ b/src/tests/ftest/pool/bad_connect.yaml
@@ -1,44 +1,28 @@
-# Note that stuff that is commented out represents tests that presently
-# cause issues and will be uncommented as the daos code is fixed
 server_config:
-   name: daos_server
+  name: daos_server
+
 hosts:
   test_servers:
     - server-A
+
 timeout: 700
+
 pool:
   control_method: dmg
   mode: 511
   scm_size: 1GB
   name: daos_server
-connecttests:
-   connectmode: !mux
-     testmode1:
-          mode:
-             - 0
-             - PASS
-     testmode2:
-           mode:
-             - 1
-             - PASS
-     testmode3:
-           mode:
-             - 2
-             - PASS
-     badmode1:
-          mode:
-             - 512
-             - FAIL
-   UUID: !mux
-     gooduuid:
-          uuid:
-             - VALID
-             - PASS
-     nulluuid:
-          uuid:
-             - NULLPTR
-             - FAIL
-     baduuid:
-          uuid:
-             - JUNK
-             - FAIL
+
+uuids: !mux
+  good_uuid:
+    uuid:
+      - VALID
+      - PASS
+  null_uuid:
+    uuid:
+      - None
+      - FAIL
+  invalid_uuid:
+    uuid:
+      - 244
+      - FAIL


### PR DESCRIPTION
- Removed connectsetnames variant from pool/bad_connect.py because these variants are not used.
- Removed permission variants (connectmode) because they're tested in permission.py
- Refactored.

Skip-unit-tests: true
Test-tag: bad_connect
Signed-off-by: Makito Kano <makito.kano@intel.com>