### PR TITLE
DAOS-9845 test: Remove infoptr variant from pool/bad_query.py

### DIFF
--- a/src/tests/ftest/pool/bad_query.py
+++ b/src/tests/ftest/pool/bad_query.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 '''
-  (C) Copyright 2018-2021 Intel Corporation.
+  (C) Copyright 2018-2022 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
@@ -27,8 +27,9 @@ class BadQueryTest(TestWithServers):
             Pass bad parameters to pool query
 
         :avocado: tags=all,full_regression
+        :avocado: tags=vm
         :avocado: tags=pool
-        :avocado: tags=tiny,bad_query
+        :avocado: tags=bad_query
         """
         # Accumulate a list of pass/fail indicators representing what is
         # expected for each parameter then "and" them to determine the
@@ -38,10 +39,6 @@ class BadQueryTest(TestWithServers):
         handlelist = self.params.get("handle", '/run/querytests/handles/*/')
         handle = handlelist[0]
         expected_for_param.append(handlelist[1])
-
-        infolist = self.params.get("info", '/run/querytests/infoptr/*/')
-        dummy_infoptr = infolist[0]
-        expected_for_param.append(infolist[1])
 
         # if any parameter is FAIL then the test should FAIL, in this test
         # virtually everyone should FAIL since we are testing bad parameters

--- a/src/tests/ftest/pool/bad_query.yaml
+++ b/src/tests/ftest/pool/bad_query.yaml
@@ -9,7 +9,7 @@ timeout: 150
 pool:
   control_method: dmg
   mode: 511
-  scm_size: 1073741824
+  scm_size: 1GB
   name: daos_server
 querytests:
    handles: !mux
@@ -21,12 +21,3 @@ querytests:
           handle:
              - 0
              - FAIL
-   infoptr: !mux
-     goodptr:
-          info:
-             - VALID
-             - PASS
-     badptr:
-          info:
-             - NULL
-             - PASS


### PR DESCRIPTION
Remove infoptr variant from pool/bad_query.py because this variant
isn’t used.

Skip-unit-tests: true
Test-tag: bad_query
Signed-off-by: Makito Kano <makito.kano@intel.com>