### PR TITLE
DAOS-9639 dtx: use large stack for DTX batched commit ULT

### DIFF
--- a/src/dtx/dtx_srv.c
+++ b/src/dtx/dtx_srv.c
@@ -409,7 +409,7 @@ dtx_setup(void)
 
 	dtx_agg_gen = 1;
 
-	rc = dss_ult_create_all(dtx_batched_commit, NULL, true);
+	rc = dss_ult_create_all(dtx_batched_commit, NULL, true, DSS_DEEP_STACK_SZ);
 	if (rc != 0)
 		D_ERROR("Failed to create DTX batched commit ULT: "DF_RC"\n",
 			DP_RC(rc));

--- a/src/include/daos_srv/daos_engine.h
+++ b/src/include/daos_srv/daos_engine.h
@@ -526,7 +526,7 @@ int dss_ult_create(void (*func)(void *), void *arg, int xs_type, int tgt_id,
 		   size_t stack_size, ABT_thread *ult);
 int dss_ult_execute(int (*func)(void *), void *arg, void (*user_cb)(void *),
 		    void *cb_args, int xs_type, int tgt_id, size_t stack_size);
-int dss_ult_create_all(void (*func)(void *), void *arg, bool main);
+int dss_ult_create_all(void (*func)(void *), void *arg, bool main, size_t stack_size);
 
 /*
  * If server wants to create ULTs periodically, it should call this special


### PR DESCRIPTION
To avoid ULT stack overflow.

Signed-off-by: Fan Yong <fan.yong@intel.com>