### PR TITLE
DAOS-9769 obj: reject integer keys that are less than 8 bytes

### DIFF
--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -1998,7 +1998,7 @@ obj_iod_sgl_valid(daos_obj_id_t oid, unsigned int nr, daos_iod_t *iods,
 			return -DER_INVAL;
 		}
 		if (daos_is_akey_uint64(oid) &&
-		    iods[i].iod_name.iov_len > sizeof(uint64_t))
+		    iods[i].iod_name.iov_len != sizeof(uint64_t))
 			return -DER_INVAL;
 		for (j = 0; j < iods[i].iod_nr; j++) {
 			if (iods[i].iod_recxs != NULL && (!spec_shard &&
@@ -2141,11 +2141,11 @@ obj_key_valid(daos_obj_id_t oid, daos_key_t *key, bool check_dkey)
 {
 	if (check_dkey) {
 		if (daos_is_dkey_uint64(oid) &&
-		    key->iov_len > sizeof(uint64_t))
+		    key->iov_len != sizeof(uint64_t))
 			return false;
 	} else {
 		if (daos_is_akey_uint64(oid) &&
-		    key->iov_len > sizeof(uint64_t))
+		    key->iov_len != sizeof(uint64_t))
 			return false;
 	}
 

--- a/src/tests/suite/daos_obj.c
+++ b/src/tests/suite/daos_obj.c
@@ -4516,20 +4516,26 @@ oclass_auto_setting(void **state)
 }
 
 static void
-int_key_setting(void **state)
+int_key_setting(void **state, int size)
 {
 	test_arg_t              *arg = *state;
 	daos_obj_id_t		oid;
 	daos_handle_t		oh;
 	d_iov_t			dkey;
-	char			dkey_buf[128];
-	char			akey_buf[128];
+	char			*dkey_buf;
+	char			*akey_buf;
 	d_sg_list_t		sgl;
 	d_iov_t			sg_iov;
 	daos_iod_t		iod;
 	char			buf[STACK_BUF_LEN];
 	int                     rc;
 
+	dkey_buf = malloc(size);
+	akey_buf = malloc(size);
+	if (!dkey_buf || !akey_buf) {
+		print_message("allocation memory failed\n");
+		return;
+	}
 	/*
 	 * Object with integer dkey / akey should fail IO with -DER_INVAL if
 	 * key size is not correct.
@@ -4538,11 +4544,11 @@ int_key_setting(void **state)
 				arg->myrank);
 
 	dts_buf_render(buf, STACK_BUF_LEN);
-	dts_buf_render(dkey_buf, 128);
-	dts_buf_render(akey_buf, 128);
+	dts_buf_render(dkey_buf, size);
+	dts_buf_render(akey_buf, size);
 
 	/** init dkey */
-	d_iov_set(&dkey, dkey_buf, sizeof(dkey_buf));
+	d_iov_set(&dkey, dkey_buf, size);
 
 	/** init scatter/gather */
 	d_iov_set(&sg_iov, buf, sizeof(buf));
@@ -4551,7 +4557,7 @@ int_key_setting(void **state)
 	sgl.sg_iovs		= &sg_iov;
 
 	/** init I/O descriptor */
-	d_iov_set(&iod.iod_name, akey_buf, sizeof(akey_buf));
+	d_iov_set(&iod.iod_name, akey_buf, size);
 	iod.iod_size    = STACK_BUF_LEN;
 	iod.iod_type	= DAOS_IOD_SINGLE;
 	iod.iod_recxs	= NULL;
@@ -4607,6 +4613,14 @@ int_key_setting(void **state)
 
 	rc = daos_obj_close(oh, NULL);
 	assert_rc_equal(rc, 0);
+
+	free(dkey_buf);
+	free(akey_buf);
+}
+
+static void invalid_int_key_setting(void **state) {
+	int_key_setting(state, 128);
+	int_key_setting(state, 3);
 }
 
 static void
@@ -4762,7 +4776,7 @@ static const struct CMUnitTest io_tests[] = {
 	{ "IO43: Object class selection",
 	  oclass_auto_setting, async_disable, test_case_teardown},
 	{ "IO44: INT dkey/akey checks",
-	  int_key_setting, async_disable, test_case_teardown},
+	  invalid_int_key_setting, async_disable, test_case_teardown},
 	{ "IO45: enum recxs with aggregation",
 	  enum_recxs_with_aggregation, async_disable, test_case_teardown},
 };


### PR DESCRIPTION
Signed-off-by: Wang Shilong <shilong.wang@intel.com>