### PR TITLE
DAOS-9790 build: Disable centos 8 builds in GHA

### DIFF
--- a/.github/workflows/ci2.yml
+++ b/.github/workflows/ci2.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        distro: [ubuntu.20.04, centos.8, leap.15]
+        distro: [ubuntu.20.04, leap.15]
     steps:
     - uses: actions/checkout@v2
     - uses: satackey/action-docker-layer-caching@v0.0.11
@@ -96,7 +96,7 @@ jobs:
       fail-fast: false
       matrix:
         # Run this on distros where we don't run the ci1 Workflow.
-        distro: [ubuntu.20.04, centos.8, leap.15]
+        distro: [ubuntu.20.04, leap.15]
         compiler: [clang, gcc]
     steps:
     - name: Checkout code


### PR DESCRIPTION
Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>