### PR TITLE
DAOS-9856 vos: aggregate to highest epoch

### DIFF
--- a/src/vos/vos_aggregate.c
+++ b/src/vos/vos_aggregate.c
@@ -828,13 +828,11 @@ prepare_segments(struct agg_merge_window *mw)
 
 		lgc_seg->ls_idx_end = i;
 		ent_in->ei_rect.rc_ex.ex_hi = ext.ex_hi;
-		/* Merge to lowest epoch */
-		if (ent_in->ei_rect.rc_epc == 0 ||
-		    ent_in->ei_rect.rc_epc > phy_ent->pe_rect.rc_epc)
+		/* Merge to highest epoch */
+		if (ent_in->ei_rect.rc_epc < phy_ent->pe_rect.rc_epc)
 			ent_in->ei_rect.rc_epc = phy_ent->pe_rect.rc_epc;
-		/* Merge to lowest pool map version */
-		if (ent_in->ei_ver == 0 ||
-		    ent_in->ei_ver > phy_ent->pe_ver)
+		/* Merge to highest pool map version */
+		if (ent_in->ei_ver < phy_ent->pe_ver)
 			ent_in->ei_ver = phy_ent->pe_ver;
 		ent_in->ei_rect.rc_minor_epc = VOS_SUB_OP_MAX;
 	}


### PR DESCRIPTION
The issue described at DAOS-6227(PR-4072) has been resolved by a
different way.

Let's choose the highest epoch during aggregation, which can help
incremental aggregation and also avoid missing the data during
migration if we choose to reintegrate from non-zero epoch.

Signed-off-by: Di Wang <di.wang@intel.com>