### PR TITLE
DAOS-9806 control: clear cached controller smd info before update (#8…

### DIFF
--- a/src/control/server/ctl_storage.go
+++ b/src/control/server/ctl_storage.go
@@ -217,8 +217,8 @@ func mapCtrlrs(ctrlrs storage.NvmeControllers) (map[string]*storage.NvmeControll
 // controller claimed by another process. Only update info for controllers
 // assigned to I/O Engines.
 func (cs *ControlService) scanAssignedBdevs(ctx context.Context, statsReq bool) (*storage.BdevScanResponse, error) {
-	var ctrlrs storage.NvmeControllers
 	instances := cs.harness.Instances()
+	ctrlrs := storage.NvmeControllers{}
 
 	for _, ei := range instances {
 		if !ei.HasBlockDevices() {
@@ -230,7 +230,7 @@ func (cs *ControlService) scanAssignedBdevs(ctx context.Context, statsReq bool) 
 			return nil, err
 		}
 
-		// If the is not running or we aren't interested in temporal
+		// If the engine is not running or we aren't interested in temporal
 		// statistics for the bdev devices then continue to next.
 		if !ei.IsReady() || !statsReq {
 			for _, tsr := range tsrs {

--- a/src/control/server/ctl_storage_rpc.go
+++ b/src/control/server/ctl_storage_rpc.go
@@ -100,7 +100,6 @@ func (c *ControlService) scanBdevs(ctx context.Context, req *ctlpb.ScanNvmeReq) 
 		return newScanNvmeResp(req, resp, err)
 	}
 
-	c.log.Debugf("scanning only bdevs in cfg")
 	resp, err := c.scanAssignedBdevs(ctx, req.GetHealth() || req.GetMeta())
 
 	return newScanNvmeResp(req, resp, err)

--- a/src/control/server/ctl_storage_rpc_test.go
+++ b/src/control/server/ctl_storage_rpc_test.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2019-2021 Intel Corporation.
+// (C) Copyright 2019-2022 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -431,6 +431,11 @@ func TestServer_CtlSvc_StorageScan_PostEngineStart(t *testing.T) {
 	ctrlrPBwMetaNew.SmdDevices[0].TotalBytes = 0
 	ctrlrPBwMetaNew.SmdDevices[0].DevState = storage.NvmeDevStateNew.Uint32()
 
+	ctrlrPBwMetaNormal := newCtrlrPBwMeta(1)
+	ctrlrPBwMetaNormal.SmdDevices[0].AvailBytes = 0
+	ctrlrPBwMetaNormal.SmdDevices[0].TotalBytes = 0
+	ctrlrPBwMetaNormal.SmdDevices[0].DevState = storage.NvmeDevStateNormal.Uint32()
+
 	mockPbScmMount0 := proto.MockScmMountPoint(0)
 	mockPbScmNamespace0 := proto.MockScmNamespace(0)
 	mockPbScmNamespace0.Mount = mockPbScmMount0
@@ -440,7 +445,8 @@ func TestServer_CtlSvc_StorageScan_PostEngineStart(t *testing.T) {
 
 	for name, tc := range map[string]struct {
 		req         *ctlpb.StorageScanReq
-		bmbc        *bdev.MockBackendConfig
+		csCtrlrs    *storage.NvmeControllers   // control service storage provider
+		eCtrlrs     []*storage.NvmeControllers // engine storage provider
 		smbc        *scm.MockBackendConfig
 		smsc        *scm.MockSysConfig
 		storageCfgs []storage.TierConfigs
@@ -455,11 +461,7 @@ func TestServer_CtlSvc_StorageScan_PostEngineStart(t *testing.T) {
 				Scm:  new(ctlpb.ScanScmReq),
 				Nvme: &ctlpb.ScanNvmeReq{Basic: true},
 			},
-			bmbc: &bdev.MockBackendConfig{
-				ScanRes: &storage.BdevScanResponse{
-					Controllers: storage.NvmeControllers{newCtrlr(1)},
-				},
-			},
+			csCtrlrs: &storage.NvmeControllers{newCtrlr(1)},
 			storageCfgs: []storage.TierConfigs{
 				{
 					storage.NewTierConfig().
@@ -483,13 +485,7 @@ func TestServer_CtlSvc_StorageScan_PostEngineStart(t *testing.T) {
 				Scm:  new(ctlpb.ScanScmReq),
 				Nvme: &ctlpb.ScanNvmeReq{Health: true},
 			},
-			bmbc: &bdev.MockBackendConfig{
-				ScanRes: &storage.BdevScanResponse{
-					Controllers: storage.NvmeControllers{
-						newCtrlr(1),
-					},
-				},
-			},
+			csCtrlrs: &storage.NvmeControllers{newCtrlr(1)},
 			storageCfgs: []storage.TierConfigs{
 				{
 					storage.NewTierConfig().
@@ -516,11 +512,7 @@ func TestServer_CtlSvc_StorageScan_PostEngineStart(t *testing.T) {
 				Scm:  new(ctlpb.ScanScmReq),
 				Nvme: &ctlpb.ScanNvmeReq{Meta: true},
 			},
-			bmbc: &bdev.MockBackendConfig{
-				ScanRes: &storage.BdevScanResponse{
-					Controllers: storage.NvmeControllers{newCtrlr(1)},
-				},
-			},
+			csCtrlrs: &storage.NvmeControllers{newCtrlr(1)},
 			storageCfgs: []storage.TierConfigs{
 				{
 					storage.NewTierConfig().
@@ -547,14 +539,8 @@ func TestServer_CtlSvc_StorageScan_PostEngineStart(t *testing.T) {
 				Scm:  new(ctlpb.ScanScmReq),
 				Nvme: &ctlpb.ScanNvmeReq{Health: true},
 			},
-			bmbc: &bdev.MockBackendConfig{
-				ScanRes: &storage.BdevScanResponse{
-					Controllers: storage.NvmeControllers{
-						newCtrlr(1),
-						newCtrlr(2),
-					},
-				},
-			},
+			csCtrlrs: &storage.NvmeControllers{newCtrlr(1), newCtrlr(2)},
+			eCtrlrs:  []*storage.NvmeControllers{{newCtrlr(1)}, {newCtrlr(2)}},
 			storageCfgs: []storage.TierConfigs{
 				{
 					storage.NewTierConfig().
@@ -593,14 +579,8 @@ func TestServer_CtlSvc_StorageScan_PostEngineStart(t *testing.T) {
 				Scm:  new(ctlpb.ScanScmReq),
 				Nvme: &ctlpb.ScanNvmeReq{Meta: true},
 			},
-			bmbc: &bdev.MockBackendConfig{
-				ScanRes: &storage.BdevScanResponse{
-					Controllers: storage.NvmeControllers{
-						newCtrlr(1),
-						newCtrlr(2),
-					},
-				},
-			},
+			csCtrlrs: &storage.NvmeControllers{newCtrlr(1), newCtrlr(2)},
+			eCtrlrs:  []*storage.NvmeControllers{{newCtrlr(1)}, {newCtrlr(2)}},
 			storageCfgs: []storage.TierConfigs{
 				{
 					storage.NewTierConfig().
@@ -634,20 +614,14 @@ func TestServer_CtlSvc_StorageScan_PostEngineStart(t *testing.T) {
 				Scm: &ctlpb.ScanScmResp{State: new(ctlpb.ResponseState)},
 			},
 		},
-		// make sure information is not duplicated in cache
-		"verify cache integrity over multiple storage scan calls": {
+		// make sure stale information is cleared and not used from cache
+		"verify cache invalidation over multiple storage scan calls": {
 			req: &ctlpb.StorageScanReq{
 				Scm:  new(ctlpb.ScanScmReq),
 				Nvme: &ctlpb.ScanNvmeReq{Meta: true},
 			},
-			bmbc: &bdev.MockBackendConfig{
-				ScanRes: &storage.BdevScanResponse{
-					Controllers: storage.NvmeControllers{
-						newCtrlr(1),
-						newCtrlr(2),
-					},
-				},
-			},
+			csCtrlrs: &storage.NvmeControllers{newCtrlr(1), newCtrlr(2)},
+			eCtrlrs:  []*storage.NvmeControllers{{newCtrlr(1)}, {newCtrlr(2)}},
 			storageCfgs: []storage.TierConfigs{
 				{
 					storage.NewTierConfig().
@@ -663,14 +637,18 @@ func TestServer_CtlSvc_StorageScan_PostEngineStart(t *testing.T) {
 			scanTwice: true,
 			drpcResps: map[int][]*mockDrpcResponse{
 				0: {
-					{Message: newSmdDevResp(1)},
-					{Message: newBioHealthResp(1)},
+					{Message: newSmdDevResp(1, 1, 2, 3)},
+					{Message: newBioHealthResp(1, 1)},
+					{Message: newBioHealthResp(1, 2)},
+					{Message: newBioHealthResp(1, 3)},
 					{Message: newSmdDevResp(1)},
 					{Message: newBioHealthResp(1)},
 				},
 				1: {
-					{Message: newSmdDevResp(2)},
-					{Message: newBioHealthResp(2)},
+					{Message: newSmdDevResp(2, 1, 2, 3)},
+					{Message: newBioHealthResp(1, 1)},
+					{Message: newBioHealthResp(1, 2)},
+					{Message: newBioHealthResp(1, 3)},
 					{Message: newSmdDevResp(2)},
 					{Message: newBioHealthResp(2)},
 				},
@@ -691,12 +669,11 @@ func TestServer_CtlSvc_StorageScan_PostEngineStart(t *testing.T) {
 				Scm:  new(ctlpb.ScanScmReq),
 				Nvme: &ctlpb.ScanNvmeReq{Meta: true},
 			},
-			bmbc: &bdev.MockBackendConfig{
-				ScanRes: &storage.BdevScanResponse{
-					Controllers: storage.NvmeControllers{
-						newCtrlrMultiNs(1, 2), newCtrlrMultiNs(2, 2),
-					},
-				},
+			csCtrlrs: &storage.NvmeControllers{
+				newCtrlrMultiNs(1, 2), newCtrlrMultiNs(2, 2),
+			},
+			eCtrlrs: []*storage.NvmeControllers{
+				{newCtrlrMultiNs(1, 2)}, {newCtrlrMultiNs(2, 2)},
 			},
 			storageCfgs: []storage.TierConfigs{
 				{
@@ -865,14 +842,8 @@ func TestServer_CtlSvc_StorageScan_PostEngineStart(t *testing.T) {
 				Scm:  &ctlpb.ScanScmReq{Usage: true},
 				Nvme: &ctlpb.ScanNvmeReq{Meta: true},
 			},
-			bmbc: &bdev.MockBackendConfig{
-				ScanRes: &storage.BdevScanResponse{
-					Controllers: storage.NvmeControllers{
-						newCtrlr(1),
-						newCtrlr(2),
-					},
-				},
-			},
+			csCtrlrs: &storage.NvmeControllers{newCtrlr(1), newCtrlr(2)},
+			eCtrlrs:  []*storage.NvmeControllers{{newCtrlr(1)}, {newCtrlr(2)}},
 			smbc: &scm.MockBackendConfig{
 				DiscoverRes: storage.ScmModules{
 					storage.MockScmModule(0),
@@ -949,11 +920,7 @@ func TestServer_CtlSvc_StorageScan_PostEngineStart(t *testing.T) {
 				Scm:  new(ctlpb.ScanScmReq),
 				Nvme: &ctlpb.ScanNvmeReq{Meta: true},
 			},
-			bmbc: &bdev.MockBackendConfig{
-				ScanRes: &storage.BdevScanResponse{
-					Controllers: storage.NvmeControllers{newCtrlr(1)},
-				},
-			},
+			csCtrlrs: &storage.NvmeControllers{newCtrlr(1)},
 			storageCfgs: []storage.TierConfigs{
 				{
 					storage.NewTierConfig().
@@ -984,11 +951,7 @@ func TestServer_CtlSvc_StorageScan_PostEngineStart(t *testing.T) {
 				Scm:  new(ctlpb.ScanScmReq),
 				Nvme: &ctlpb.ScanNvmeReq{Meta: true},
 			},
-			bmbc: &bdev.MockBackendConfig{
-				ScanRes: &storage.BdevScanResponse{
-					Controllers: storage.NvmeControllers{newCtrlr(1)},
-				},
-			},
+			csCtrlrs: &storage.NvmeControllers{newCtrlr(1)},
 			storageCfgs: []storage.TierConfigs{
 				{
 					storage.NewTierConfig().
@@ -1008,11 +971,8 @@ func TestServer_CtlSvc_StorageScan_PostEngineStart(t *testing.T) {
 			},
 			expResp: &ctlpb.StorageScanResp{
 				Nvme: &ctlpb.ScanNvmeResp{
-					State: &ctlpb.ResponseState{
-						Error: fmt.Sprintf("instance 0, ctrlr %s: GetBioHealth response status: %s",
-							newCtrlr(1).PciAddr, drpc.DaosFreeMemError.Error()),
-						Status: ctlpb.ResponseStatus_CTL_ERR_NVME,
-					},
+					Ctrlrs: proto.NvmeControllers{ctrlrPBwMetaNew},
+					State:  new(ctlpb.ResponseState),
 				},
 				Scm: &ctlpb.ScanScmResp{State: new(ctlpb.ResponseState)},
 			},
@@ -1022,11 +982,7 @@ func TestServer_CtlSvc_StorageScan_PostEngineStart(t *testing.T) {
 				Scm:  new(ctlpb.ScanScmReq),
 				Nvme: &ctlpb.ScanNvmeReq{Meta: true},
 			},
-			bmbc: &bdev.MockBackendConfig{
-				ScanRes: &storage.BdevScanResponse{
-					Controllers: storage.NvmeControllers{newCtrlr(1)},
-				},
-			},
+			csCtrlrs: &storage.NvmeControllers{newCtrlr(1)},
 			storageCfgs: []storage.TierConfigs{
 				{
 					storage.NewTierConfig().
@@ -1046,11 +1002,8 @@ func TestServer_CtlSvc_StorageScan_PostEngineStart(t *testing.T) {
 			},
 			expResp: &ctlpb.StorageScanResp{
 				Nvme: &ctlpb.ScanNvmeResp{
-					State: &ctlpb.ResponseState{
-						Error: fmt.Sprintf("instance 0, ctrlr %s: GetBioHealth response status: %s",
-							newCtrlr(1).PciAddr, drpc.DaosNonexistant.Error()),
-						Status: ctlpb.ResponseStatus_CTL_ERR_NVME,
-					},
+					Ctrlrs: proto.NvmeControllers{ctrlrPBwMetaNormal},
+					State:  new(ctlpb.ResponseState),
 				},
 				Scm: &ctlpb.ScanScmResp{State: new(ctlpb.ResponseState)},
 			},
@@ -1064,12 +1017,24 @@ func TestServer_CtlSvc_StorageScan_PostEngineStart(t *testing.T) {
 				t.Fatalf("number of tc.storageCfgs doesn't match num drpc msg groups")
 			}
 
+			if len(tc.storageCfgs) == 1 && tc.eCtrlrs == nil && tc.csCtrlrs != nil {
+				log.Debugf("using control service storage provider for first engine")
+				tc.eCtrlrs = []*storage.NvmeControllers{tc.csCtrlrs}
+			}
+
+			var csbmbc *bdev.MockBackendConfig
+			if tc.csCtrlrs != nil {
+				csbmbc = &bdev.MockBackendConfig{
+					ScanRes: &storage.BdevScanResponse{Controllers: *tc.csCtrlrs},
+				}
+			}
+
 			var engineCfgs []*engine.Config
 			for _, sc := range tc.storageCfgs {
 				engineCfgs = append(engineCfgs, engine.NewConfig().WithStorage(sc...))
 			}
 			sCfg := config.DefaultServer().WithEngines(engineCfgs...)
-			cs := mockControlService(t, log, sCfg, tc.bmbc, tc.smbc, tc.smsc)
+			cs := mockControlService(t, log, sCfg, csbmbc, tc.smbc, tc.smsc)
 
 			// In production, during server/server.go:srv.addEngines() and after
 			// srv.createEngine(), engine.storage.SetBdevCache() is called to load the
@@ -1079,37 +1044,40 @@ func TestServer_CtlSvc_StorageScan_PostEngineStart(t *testing.T) {
 			// cached results have to be explicitly shared so cache is available when
 			// engines are up.
 
-			// This block mimics control service start-up and engine creation where
-			// cache is shared, Setup() runs discovery for nvme & scm.
-			cs.Setup()
-			nvmeScanResp, err := cs.NvmeScan(storage.BdevScanRequest{})
-			if err != nil {
-				t.Fatal(err)
-			}
-			for i, ec := range engineCfgs {
+			for idx, ec := range engineCfgs {
+				var ebmbc *bdev.MockBackendConfig
+				if tc.eCtrlrs != nil && len(tc.eCtrlrs) > idx {
+					log.Debugf("bdevs %v for engine %d", *tc.eCtrlrs[idx], idx)
+					ebmbc = &bdev.MockBackendConfig{
+						ScanRes: &storage.BdevScanResponse{
+							Controllers: *tc.eCtrlrs[idx],
+						},
+					}
+				}
 				// replace harness instance with mock I/O Engine
 				// to enable mocking of harness instance drpc channel
-				sp := storage.MockProvider(log, 0, &ec.Storage,
+				sp := storage.MockProvider(log, idx, &ec.Storage,
 					cs.storage.Sys, // share system provider cfo
 					scm.NewMockProvider(log, tc.smbc, nil),
-					bdev.NewMockProvider(log, tc.bmbc))
-				// share bdev cache with control service
-				sp.SetBdevCache(*nvmeScanResp)
-				ne := newTestEngine(log, false, sp)
+					bdev.NewMockProvider(log, ebmbc))
+				ne := newTestEngine(log, false, sp, ec)
 
 				// mock drpc responses
 				dcc := new(mockDrpcClientConfig)
 				if tc.junkResp {
-					dcc.setSendMsgResponse(drpc.Status_SUCCESS, makeBadBytes(42), nil)
-				} else if len(tc.drpcResps) > i {
-					dcc.setSendMsgResponseList(t, tc.drpcResps[i]...)
+					dcc.setSendMsgResponse(drpc.Status_SUCCESS,
+						makeBadBytes(42), nil)
+				} else if len(tc.drpcResps) > idx {
+					t.Logf("setting %d drpc responses for engine %d",
+						len(tc.drpcResps[idx]), idx)
+					dcc.setSendMsgResponseList(t, tc.drpcResps[idx]...)
 				} else {
 					t.Fatal("drpc response mocks unpopulated")
 				}
 				ne.setDrpcClient(newMockDrpcClient(dcc))
-				ne._superblock.Rank = system.NewRankPtr(uint32(i + 1))
+				ne._superblock.Rank = system.NewRankPtr(uint32(idx + 1))
 
-				cs.harness.instances[i] = ne
+				cs.harness.instances[idx] = ne
 			}
 			cs.harness.started.SetTrue()
 

--- a/src/control/server/instance_drpc.go
+++ b/src/control/server/instance_drpc.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/dustin/go-humanize"
 	"github.com/pkg/errors"
 	"google.golang.org/protobuf/proto"
 
@@ -215,42 +216,13 @@ func (ei *EngineInstance) getSmdDetails(smd *ctlpb.SmdDevResp_Device) (*storage.
 	return smdDev, nil
 }
 
-func (ei *EngineInstance) addBdevStats(ctx context.Context, smdDev *storage.SmdDevice, ctrlr *storage.NvmeController) (bool, error) {
-	msg := fmt.Sprintf("instance %d: smd %s with transport address %s", ei.Index(),
-		smdDev.UUID, smdDev.TrAddr)
-
-	pbStats, err := ei.GetBioHealth(ctx, &ctlpb.BioHealthReq{DevUuid: smdDev.UUID})
-	if err != nil {
-		status, ok := errors.Cause(err).(drpc.DaosStatus)
-
-		// if error indicates non-existent health and smd has abnormal state then return
-		if ok && status == drpc.DaosNonexistant && !smdDev.NvmeState.IsNormal() {
-			ei.log.Debugf("%s: health stats not found, device states: %q", msg,
-				smdDev.NvmeState.String())
-
-			return false, nil
-		}
-
-		return false, errors.Wrapf(err, "instance %d, ctrlr %s", ei.Index(), smdDev.TrAddr)
-	}
-
-	// populate space usage for each smd device from health stats
-	smdDev.TotalBytes = pbStats.TotalBytes
-	smdDev.AvailBytes = pbStats.AvailBytes
-	msg = fmt.Sprintf("%s: smd space usage updated", msg)
-
-	if ctrlr == nil {
-		ei.log.Debug(msg)
-		return false, nil
-	}
-
+func updateCtrlrHealth(pbStats *ctlpb.BioHealthResp, ctrlr *storage.NvmeController) error {
 	ctrlr.HealthStats = new(storage.NvmeHealth)
 	if err := convert.Types(pbStats, ctrlr.HealthStats); err != nil {
-		return false, errors.Wrap(err, "convert health stats")
+		return errors.Wrap(err, "convert health stats")
 	}
 
-	ei.log.Debugf("%s: health stats updated", msg)
-	return true, nil
+	return nil
 }
 
 // updateInUseBdevs updates-in-place the input list of controllers with new NVMe health stats and
@@ -258,43 +230,74 @@ func (ei *EngineInstance) addBdevStats(ctx context.Context, smdDev *storage.SmdD
 //
 // Query each SmdDevice on each I/O Engine instance for health stats and update existing controller
 // data in ctrlrMap using PCI address key.
-func (ei *EngineInstance) updateInUseBdevs(ctx context.Context, ctrlrMap map[string]*storage.NvmeController) error {
+func (ei *EngineInstance) updateInUseBdevs(ctx context.Context, ctrlrMap map[string]*storage.NvmeController) (err error) {
+	defer func() {
+		err = errors.Wrapf(err, "instance %d", ei.Index())
+	}()
+
+	// Clear SMD info for controllers in ctrlrMap, populate smd info from scratch.
+	for _, ctrlr := range ctrlrMap {
+		ctrlr.SmdDevices = []*storage.SmdDevice{}
+	}
+
 	smdDevs, err := ei.ListSmdDevices(ctx, new(ctlpb.SmdDevReq))
 	if err != nil {
-		return errors.Wrapf(err, "instance %d listSmdDevices()", ei.Index())
+		return errors.Wrapf(err, "list smd devices")
 	}
+	ei.log.Debugf("engine %d: smdDevs %+v", ei.Index(), smdDevs)
 
 	hasUpdatedHealth := make(map[string]bool)
 	for _, smd := range smdDevs.Devices {
+		msg := fmt.Sprintf("instance %d: smd %s: ctrlr %s", ei.Index(), smd.Uuid,
+			smd.TrAddr)
+
 		ctrlr, exists := ctrlrMap[smd.GetTrAddr()]
 		if !exists {
-			return errors.Errorf("instance %d: smd %s: unknown controller %s",
-				ei.Index(), smd.GetUuid(), smd.GetTrAddr())
+			ei.log.Errorf("%s: ctrlr not found", msg)
+			continue
 		}
 
 		smdDev, err := ei.getSmdDetails(smd)
 		if err != nil {
-			return errors.Wrapf(err, "collect smd info for ctrlr %s", ctrlr.PciAddr)
+			return errors.Wrapf(err, "%s: collect smd info", msg)
 		}
 
-		// multiple updates for the same key expected when more than one controller
-		// namespaces (and resident blobstores) exist, stats will be the same for each
-		// so only pass valid ctrlr reference when stats haven't yet been updated
-		var ctrlrRef *storage.NvmeController
-		if _, already := hasUpdatedHealth[ctrlr.PciAddr]; !already {
-			ctrlrRef = ctrlr
-		}
-
-		ctrlrUpdated, err := ei.addBdevStats(ctx, smdDev, ctrlrRef)
+		pbStats, err := ei.GetBioHealth(ctx, &ctlpb.BioHealthReq{DevUuid: smdDev.UUID})
 		if err != nil {
-			return err
+			// Only log error if error indicates non-existent health and the SMD entity
+			// has abnormal state.
+			status, ok := errors.Cause(err).(drpc.DaosStatus)
+			if ok && status == drpc.DaosNonexistant && !smdDev.NvmeState.IsNormal() {
+				ei.log.Debugf("%s: stats not found (device state: %q), skip update",
+					msg, smdDev.NvmeState.String())
+			} else {
+				ei.log.Errorf("%s: fetch stats: %s", msg, err.Error())
+			}
+			ctrlr.UpdateSmd(smdDev)
+			continue
 		}
 
-		if ctrlrUpdated {
-			hasUpdatedHealth[ctrlr.PciAddr] = true
-		}
-
+		// Populate space usage for each SMD device from health stats.
+		smdDev.TotalBytes = pbStats.TotalBytes
+		smdDev.AvailBytes = pbStats.AvailBytes
+		msg = fmt.Sprintf("%s: smd usage = %s/%s", msg, humanize.Bytes(smdDev.AvailBytes),
+			humanize.Bytes(smdDev.TotalBytes))
 		ctrlr.UpdateSmd(smdDev)
+
+		// Multiple SMD entries for the same address key may exist when there are multiple
+		// NVMe namespaces (and resident blobstores) exist on a single controller. In this
+		// case only update once as health stats will be the same for each.
+		if hasUpdatedHealth[ctrlr.PciAddr] {
+			continue
+		}
+
+		if err := updateCtrlrHealth(pbStats, ctrlr); err != nil {
+			ei.log.Errorf("%s: update ctrlr health: %s", err.Error())
+			continue
+		}
+		hasUpdatedHealth[ctrlr.PciAddr] = true
+
+		ei.log.Debugf("%s: ctrlr health updated", msg)
 	}
 
 	return nil


### PR DESCRIPTION
…062)

SMD info is populated from an up-to-date list of SMD devices fetched
over dRPC when NVMe devices are in-use by engine processes and cannot
be accessed directly by control plane over SPDK bindings.

During system reformat, engine processes are restarted but the storage
providers running in the control plane process retain cached NVMe
controller details, including linked SMD device info.

Clear any cached SMD information attached to a controller object
(stored in the storage provider) before repopulating during an online
scan. This avoids the undesirable situation where old SMD entries are
retained after system reformat and bogus usage stats are reported by
the dmg storage query usage command.

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>