### PR TITLE
DAOS-9667 test: update large dm tests to use tmpfs (#7917)

### DIFF
--- a/src/tests/ftest/datamover/large_dir.py
+++ b/src/tests/ftest/datamover/large_dir.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 '''
-  (C) Copyright 2020-2021 Intel Corporation.
+  (C) Copyright 2020-2022 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
@@ -43,44 +43,44 @@ class DmvrLargeDir(DataMoverTestBase):
             self.fail("Failed to get mdtest processes for {}".format(tool))
 
         # test params
-        mdtest_flags = self.params.get("mdtest_flags", "/run/mdtest/*")
-        file_size = self.params.get("bytes", "/run/mdtest/*")
+        mdtest_flags = self.params.get("mdtest_flags", self.mdtest_cmd.namespace)
+        file_size = self.params.get("bytes", self.mdtest_cmd.namespace)
 
         # create pool and cont1
-        self.create_pool()
-        self.create_cont(self.pool[0])
+        pool = self.create_pool()
+        cont1 = self.create_cont(pool)
 
         # run mdtest to create data in cont1
         self.mdtest_cmd.write_bytes.update(file_size)
         self.run_mdtest_with_params(
-            "DAOS", "/", self.pool[0], self.container[0],
+            "DAOS", "/", pool, cont1,
             flags=mdtest_flags[0])
 
         # create cont2
-        self.create_cont(self.pool[0])
+        cont2 = self.create_cont(pool)
 
         # copy from daos cont1 to cont2
         self.run_datamover(
             self.test_id + " (cont1 to cont2)",
-            "DAOS", "/", self.pool[0], self.container[0],
-            "DAOS", "/", self.pool[0], self.container[1])
+            "DAOS", "/", pool, cont1,
+            "DAOS", "/", pool, cont2)
 
-        posix_path = self.new_posix_test_path(shared=True)
+        posix_path = self.new_posix_test_path(parent=self.workdir)
 
         # copy from daos cont2 to posix file system
         self.run_datamover(
             self.test_id + " (cont2 to posix)",
-            "DAOS", "/", self.pool[0], self.container[1],
+            "DAOS", "/", pool, cont2,
             "POSIX", posix_path)
 
         # create cont3
-        self.create_cont(self.pool[0])
+        cont3 = self.create_cont(pool)
 
         # copy from posix file system to daos cont3
         self.run_datamover(
             self.test_id + " (posix to cont3)",
             "POSIX", posix_path, None, None,
-            "DAOS", "/", self.pool[0], self.container[2])
+            "DAOS", "/", pool, cont3)
 
         # the result is that a NEW directory is created in the destination
         daos_path = "/" + os.path.basename(posix_path) + self.mdtest_cmd.test_dir.value
@@ -88,7 +88,7 @@ class DmvrLargeDir(DataMoverTestBase):
         # update mdtest params, read back and verify data from cont3
         self.mdtest_cmd.read_bytes.update(file_size)
         self.run_mdtest_with_params(
-            "DAOS", daos_path, self.pool[0], self.container[2],
+            "DAOS", daos_path, pool, cont3,
             flags=mdtest_flags[1])
 
     def test_dm_large_dir_dcp(self):

--- a/src/tests/ftest/datamover/large_dir.yaml
+++ b/src/tests/ftest/datamover/large_dir.yaml
@@ -5,11 +5,11 @@ hosts:
     - server-C
     - server-D
     - server-E
+    - server-F
+    - server-G
   test_clients:
     - client-F
-    - client-G
-    - client-H
-timeout: 1080
+timeout: 420
 server_config:
   name: daos_server
   servers:
@@ -33,7 +33,6 @@ mdtest:
     dcp: 30
   api: DFS
   test_dir: "/"
-  iteration: 1
   dfs_destroy: False
   manager: "MPICH"
   mux_dataset: !mux

--- a/src/tests/ftest/datamover/large_file.py
+++ b/src/tests/ftest/datamover/large_file.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 '''
-  (C) Copyright 2020-2021 Intel Corporation.
+  (C) Copyright 2020-2022 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
@@ -36,52 +36,49 @@ class DmvrPosixLargeFile(DataMoverTestBase):
         self.set_tool(tool)
 
         # Get the number of ior processes
-        self.ior_processes = self.params.get(
-            self.tool.lower(), "/run/ior/client_processes/*")
+        self.ior_processes = self.params.get(self.tool.lower(), "/run/ior/client_processes/*")
         if not self.ior_processes:
             self.fail("Failed to get ior processes for {}".format(self.tool))
 
         # create pool and cont
-        self.create_pool()
-        self.create_cont(self.pool[0])
+        pool = self.create_pool()
+        cont1 = self.create_cont(pool)
 
-        # update and run ior on cont1
-        self.run_ior_with_params(
-            "DAOS", self.ior_cmd.test_file.value,
-            self.pool[0], self.container[0])
+        # create initial data in cont1
+        self.run_ior_with_params("DAOS", self.ior_cmd.test_file.value, pool, cont1)
 
         # create cont2
-        self.create_cont(self.pool[0])
+        cont2 = self.create_cont(pool)
 
         # copy from daos cont1 to cont2
         self.run_datamover(
             self.test_id + " (cont1 to cont2)",
-            "DAOS", "/", self.pool[0], self.container[0],
-            "DAOS", "/", self.pool[0], self.container[1])
+            "DAOS", "/", pool, cont1,
+            "DAOS", "/", pool, cont2)
 
-        posix_path = self.new_posix_test_path(shared=True)
+        posix_path = self.new_posix_test_path(parent=self.workdir)
 
         # copy from daos cont2 to posix file system
         self.run_datamover(
             self.test_id + " (cont2 to posix)",
-            "DAOS", "/", self.pool[0], self.container[1],
+            "DAOS", "/", pool, cont2,
             "POSIX", posix_path)
 
         # create cont3
-        self.create_cont(self.pool[0])
+        cont3 = self.create_cont(pool)
 
         # copy from posix file system to daos cont3
         self.run_datamover(
             self.test_id + " (posix to cont3)",
             "POSIX", posix_path, None, None,
-            "DAOS", "/", self.pool[0], self.container[2])
+            "DAOS", "/", pool, cont3)
 
         # the result is that a NEW directory is created in the destination
         daos_path = "/" + os.path.basename(posix_path) + self.ior_cmd.test_file.value
 
         # update ior params, read back and verify data from cont3
         self.run_ior_with_params(
-            "DAOS", daos_path, self.pool[0], self.container[2],
+            "DAOS", daos_path, pool, cont3,
             flags="-r -R")
 
     def test_dm_large_file_dcp(self):

--- a/src/tests/ftest/datamover/large_file.yaml
+++ b/src/tests/ftest/datamover/large_file.yaml
@@ -5,11 +5,11 @@ hosts:
     - server-C
     - server-D
     - server-E
+    - server-F
+    - server-G
   test_clients:
     - client-F
-    - client-G
-    - client-H
-timeout: 840
+timeout: 420
 server_config:
   name: daos_server
   servers:
@@ -30,21 +30,16 @@ container:
   control_method: daos
 ior:
   client_processes:
-    dcp: 30
+    dcp: 20
     fs_copy: 10
   api: DFS
   flags: "-w -k"
   dfs_destroy: False
   test_file: /testFile
-  repetitions: 1
   signature: 5
-  transfersize_blocksize:
-    1M:
-      transfer_size: '1M'
-      block_size: '1G'        # aggregate of 30G for dcp and 10G for fs_copy
-  objectclass:
-    EC_4P1GX:
-      dfs_oclass: "EC_4P1GX"
+  transfer_size: '1M'
+  block_size: '1G'        # aggregate of 20G for dcp and 10G for fs_copy
+  dfs_oclass: "EC_4P1GX"
 dcp:
   bufsize: "64MB"
   chunksize: "128MB"

--- a/src/tests/ftest/util/data_mover_test_base.py
+++ b/src/tests/ftest/util/data_mover_test_base.py
@@ -5,7 +5,6 @@
 SPDX-License-Identifier: BSD-2-Clause-Patent
 """
 from command_utils_base import CommandFailure
-from daos_utils import DaosCommand
 from test_utils_container import TestContainer
 from pydaos.raw import str_to_c_uuid, DaosContainer, DaosObj, IORequest
 from ior_test_base import IorTestBase
@@ -106,7 +105,7 @@ class DataMoverTestBase(IorTestBase, MdtestBase):
         self.dfuse_hosts = self.agent_managers[0].hosts
 
         # initialize daos_cmd
-        self.daos_cmd = DaosCommand(self.bin)
+        self.daos_cmd = self.get_daos_command()
 
         # Get the processes for each explicitly
         # This is needed because both IorTestBase and MdtestBase


### PR DESCRIPTION
Test-tag: dm_large_dir dm_large_file
Skip-unit-tests: true
Skip-fault-injection-test: true

- Update large datamover tests to use tmpfs on a single client
  instead of shared NFS, since NFS is too slow.
- Reduce 30G file to 20G (tmpfs observed to have ~25G)
- Reduce test timeout
- General test cleanup

Signed-off-by: Dalton Bohning <dalton.bohning@intel.com>