### PR TITLE
Disable kernal write-back cache, but rather complete writes as they happen.

### DIFF
--- a/src/client/dfuse/dfuse.h
+++ b/src/client/dfuse/dfuse.h
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2021 Intel Corporation.
+ * (C) Copyright 2016-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -208,6 +208,7 @@ struct dfuse_cont {
 	double			dfc_dentry_dir_timeout;
 	double			dfc_ndentry_timeout;
 	bool			dfc_data_caching;
+	bool			dfc_wb_cache;
 	bool			dfc_direct_io_disable;
 	pthread_mutex_t		dfs_read_mutex;
 };

--- a/src/client/dfuse/dfuse_core.c
+++ b/src/client/dfuse/dfuse_core.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2021 Intel Corporation.
+ * (C) Copyright 2016-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -540,7 +540,7 @@ err:
 	return rc;
 }
 
-#define ATTR_COUNT 6
+#define ATTR_COUNT 7
 
 char const *const
 cont_attr_names[ATTR_COUNT] = {"dfuse-attr-time",
@@ -548,7 +548,9 @@ cont_attr_names[ATTR_COUNT] = {"dfuse-attr-time",
 			       "dfuse-dentry-dir-time",
 			       "dfuse-ndentry-time",
 			       "dfuse-data-cache",
-			       "dfuse-direct-io-disable"};
+			       "dfuse-direct-io-disable",
+			       "dfuse-data-wb-cache",
+};
 
 #define ATTR_TIME_INDEX		0
 #define ATTR_DENTRY_INDEX	1
@@ -556,6 +558,7 @@ cont_attr_names[ATTR_COUNT] = {"dfuse-attr-time",
 #define ATTR_NDENTRY_INDEX	3
 #define ATTR_DATA_CACHE_INDEX	4
 #define ATTR_DIRECT_IO_DISABLE_INDEX	5
+#define ATTR_DATA_CACHE_WB_INDEX 6
 
 /* Attribute values are of the form "120M", so the buffer does not need to be
  * large.
@@ -639,6 +642,22 @@ dfuse_cont_get_cache(struct dfuse_cont *dfc)
 			}
 			continue;
 		}
+		if (i == ATTR_DATA_CACHE_WB_INDEX) {
+			if (strncmp(buff_addrs[i], "on", sizes[i]) == 0) {
+				dfc->dfc_wb_cache = true;
+			} else if (strncmp(buff_addrs[i], "off",
+				   sizes[i]) == 0) {
+				have_cache_off = true;
+				dfc->dfc_wb_cache = false;
+			} else {
+				DFUSE_TRA_WARNING(dfc,
+						  "Failed to parse '%s' for '%s'",
+						  buff_addrs[i],
+						  cont_attr_names[i]);
+				dfc->dfc_wb_cache = false;
+			}
+			continue;
+		}
 		if (i == ATTR_DIRECT_IO_DISABLE_INDEX) {
 			if (strncmp(buff_addrs[i], "on", sizes[i]) == 0) {
 				have_dio = true;
@@ -718,6 +737,7 @@ dfuse_set_default_cont_cache_values(struct dfuse_cont *dfc)
 	dfc->dfc_dentry_dir_timeout = 5;
 	dfc->dfc_ndentry_timeout = 1;
 	dfc->dfc_data_caching = true;
+	dfc->dfc_wb_cache = true;
 	dfc->dfc_direct_io_disable = false;
 }
 

--- a/src/client/dfuse/dfuse_fuseops.c
+++ b/src/client/dfuse/dfuse_fuseops.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2021 Intel Corporation.
+ * (C) Copyright 2016-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -82,9 +82,6 @@ dfuse_fuse_init(void *arg, struct fuse_conn_info *conn)
 	conn->want |= FUSE_CAP_READDIRPLUS_AUTO;
 
 	conn->time_gran = 1000000000;
-
-	if (fs_handle->dpi_info->di_wb_cache)
-		conn->want |= FUSE_CAP_WRITEBACK_CACHE;
 
 	dfuse_show_flags(fs_handle, conn->want);
 

--- a/src/client/dfuse/ops/create.c
+++ b/src/client/dfuse/ops/create.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2021 Intel Corporation.
+ * (C) Copyright 2016-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -128,7 +128,7 @@ dfuse_cb_create(fuse_req_t req, struct dfuse_inode_entry *parent,
 	/* Upgrade fd permissions from O_WRONLY to O_RDWR if wb caching is
 	 * enabled so the kernel can do read-modify-write
 	 */
-	if (parent->ie_dfs->dfc_data_caching && fs_handle->dpi_info->di_wb_cache &&
+	if (parent->ie_dfs->dfc_data_caching && parent->ie_dfs->dfc_wb_cache &&
 		(fi->flags & O_ACCMODE) == O_WRONLY) {
 		DFUSE_TRA_INFO(parent, "Upgrading fd to O_RDRW");
 		fi->flags &= ~O_ACCMODE;

--- a/src/client/dfuse/ops/open.c
+++ b/src/client/dfuse/ops/open.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2021 Intel Corporation.
+ * (C) Copyright 2016-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -31,10 +31,10 @@ dfuse_cb_open(fuse_req_t req, fuse_ino_t ino, struct fuse_file_info *fi)
 	DFUSE_TRA_UP(oh, ie, "open handle");
 
 	/* Upgrade fd permissions from O_WRONLY to O_RDWR if wb caching is
-	 * enabled so the kernel can do read-modify-write
+	 * enabled so the kernel can do read-modify-write.  It's not clear
+	 * if this is still needed.
 	 */
-	if (ie->ie_dfs->dfc_data_caching &&
-		fs_handle->dpi_info->di_wb_cache &&
+	if (ie->ie_dfs->dfc_data_caching && ie->ie_dfs->dfc_wb_cache &&
 		(fi->flags & O_ACCMODE) == O_WRONLY) {
 		DFUSE_TRA_INFO(ie, "Upgrading fd to O_RDRW");
 		fi->flags &= ~O_ACCMODE;

--- a/src/client/dfuse/ops/read.c
+++ b/src/client/dfuse/ops/read.c
@@ -83,8 +83,7 @@ dfuse_cb_read(fuse_req_t req, fuse_ino_t ino, size_t len, off_t position,
 	}
 
 	if (readahead) {
-		if (!fs_handle->dpi_info->di_wb_cache)
-			buff_len += READAHEAD_SIZE;
+		buff_len += READAHEAD_SIZE;
 	} else {
 		if (!skip_read) {
 			rc = daos_event_init(&ev->de_ev,


### PR DESCRIPTION
This still gives a performance boost as writes complete faster, and it
allows per-file settings.  There's the potential for read-after-write
corruption here, so a per-file read/write lock might be reqired.

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>
