### PR TITLE
DAOS-9781 control: Fix NVMe scan with empty Allow list

### DIFF
--- a/src/control/server/storage/bdev/backend.go
+++ b/src/control/server/storage/bdev/backend.go
@@ -236,11 +236,7 @@ func (sb *spdkBackend) Prepare(req storage.BdevPrepareRequest) (*storage.BdevPre
 // to only those devices discovered and in device list and confirm that the devices specified in
 // the device list have all been discovered.
 func groomDiscoveredBdevs(reqDevs *hardware.PCIAddressSet, discovered storage.NvmeControllers, vmdEnabled bool) (storage.NvmeControllers, error) {
-	if reqDevs == nil {
-		return nil, errors.New("nil device list in bdev scan request")
-	}
-
-	// if empty device list, return all discovered controllers
+	// if the request does not specify a device filter, return all discovered controllers
 	if reqDevs.IsEmpty() {
 		return discovered, nil
 	}
@@ -290,11 +286,7 @@ func groomDiscoveredBdevs(reqDevs *hardware.PCIAddressSet, discovered storage.Nv
 func (sb *spdkBackend) Scan(req storage.BdevScanRequest) (*storage.BdevScanResponse, error) {
 	sb.log.Debugf("spdk backend scan (bindings discover call): %+v", req)
 
-	if req.DeviceList == nil {
-		return nil, errors.New("nil device list in bdev scan request")
-	}
-
-	needDevs := &req.DeviceList.PCIAddressSet
+	needDevs := req.DeviceList.PCIAddressSetPtr()
 	spdkOpts := &spdk.EnvOptions{
 		PCIAllowList: needDevs,
 		EnableVMD:    req.VMDEnabled,
@@ -422,7 +414,7 @@ func (sb *spdkBackend) formatKdev(req *storage.BdevFormatRequest) (*storage.Bdev
 }
 
 func (sb *spdkBackend) formatNvme(req *storage.BdevFormatRequest) (*storage.BdevFormatResponse, error) {
-	needDevs := &req.Properties.DeviceList.PCIAddressSet
+	needDevs := req.Properties.DeviceList.PCIAddressSetPtr()
 
 	if needDevs.IsEmpty() {
 		sb.log.Debug("skip nvme format as bdev device list is empty")

--- a/src/control/server/storage/config.go
+++ b/src/control/server/storage/config.go
@@ -351,6 +351,15 @@ func (bdl *BdevDeviceList) MarshalJSON() ([]byte, error) {
 	return json.Marshal(bdl.Devices())
 }
 
+// PCIAddressSetPtr returns a pointer to the underlying hardware.PCIAddressSet.
+func (bdl *BdevDeviceList) PCIAddressSetPtr() *hardware.PCIAddressSet {
+	if bdl == nil {
+		return nil
+	}
+
+	return &bdl.PCIAddressSet
+}
+
 // Len returns the number of block devices in the list.
 func (bdl *BdevDeviceList) Len() int {
 	if bdl == nil {


### PR DESCRIPTION
Missed this test case in local testing. Relax the input
checking to work with the new implementation.

Features: control

Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com>
