### PR TITLE
DAOS-9874 test: remove --daos-prefix from datamover

### DIFF
--- a/src/tests/ftest/datamover/negative.py
+++ b/src/tests/ftest/datamover/negative.py
@@ -40,13 +40,13 @@ class DmvrNegativeTest(DataMoverTestBase):
     def test_dm_bad_params_dcp(self):
         """Jira ID: DAOS-5515 - Initial test case.
            Jira ID: DAOS-6355 - Test case reworked.
+           Jira ID: DAOS-9874 - daos-prefix removed.
         Test Description:
             Test POSIX copy with invalid parameters.
             This uses the dcp tool.
             (1) Bad parameter: required argument
             (2) Bad parameter: source is destination.
-            (3) Bad parameter: daos-prefix is invalid.
-            (4) Bad parameter: UUID, UNS, or POSIX path is invalid.
+            (3) Bad parameter: UUID, UNS, or POSIX path is invalid.
         :avocado: tags=all,full_regression
         :avocado: tags=datamover,dcp,dfuse
         :avocado: tags=dm_negative,dm_bad_params_dcp
@@ -121,75 +121,7 @@ class DmvrNegativeTest(DataMoverTestBase):
             expected_rc=1,
             expected_output=self.MFU_ERR_DAOS_INVAL_ARG)
 
-        # (3) Bad parameter: daos-prefix is invalid.
-        self.set_datamover_params(
-            "DAOS_UNS", "/", pool1, cont1,
-            "POSIX", self.posix_local_test_paths[0])
-        self.dcp_cmd.daos_prefix.update("/fake/prefix")
-        self.dcp_cmd.src_path.update("/fake/prefix/dir")
-        self.run_datamover(
-            self.test_id + " (invalid source prefix - not UNS path)",
-            expected_rc=1,
-            expected_output=self.MFU_ERR_DAOS_INVAL_ARG)
-
-        self.set_datamover_params(
-            "POSIX", self.posix_local_test_paths[0], None, None,
-            "DAOS_UNS", "/", pool1, cont1)
-        self.dcp_cmd.daos_prefix.update("/fake/prefix")
-        self.dcp_cmd.dst_path.update("/fake/prefix/dir")
-        self.run_datamover(
-            self.test_id + " (invalid dest prefix - not UNS path)",
-            expected_rc=1,
-            expected_output=self.MFU_ERR_DAOS_INVAL_ARG)
-
-        self.set_datamover_params(
-            "DAOS_UNS", "/temp", pool1, cont1,
-            "POSIX", self.posix_local_test_paths[0])
-        self.dcp_cmd.src_path.update("/fake/fake/fake")
-        self.run_datamover(
-            self.test_id + " (invalid prefix - not match source or dest)",
-            expected_rc=1,
-            expected_output=self.MFU_ERR_DAOS_INVAL_ARG)
-
-        self.set_datamover_params(
-            "DAOS_UNS", "/temp", pool1, cont1,
-            "POSIX", self.posix_local_test_paths[0])
-        src_path = "/fake/fake" + str(self.dcp_cmd.daos_prefix.value)
-        self.dcp_cmd.src_path.update(src_path)
-        self.run_datamover(
-            self.test_id + " (invalid prefix - source substring, not prefix)",
-            expected_rc=1,
-            expected_output=self.MFU_ERR_DAOS_INVAL_ARG)
-
-        self.set_datamover_params(
-            "POSIX", self.posix_local_test_paths[0], None, None,
-            "DAOS_UNS", "/temp", pool1, cont1)
-        dst_path = "/fake/fake" + str(self.dcp_cmd.daos_prefix.value)
-        self.dcp_cmd.dst_path.update(dst_path)
-        self.run_datamover(
-            self.test_id + " (invalid prefix - dest substring, not prefix)",
-            expected_rc=1,
-            expected_output=self.MFU_ERR_DAOS_INVAL_ARG)
-
-        self.set_datamover_params(
-            "POSIX", self.posix_local_test_paths[0], None, None,
-            "DAOS_UUID", "/", pool1, cont1)
-        self.dcp_cmd.daos_prefix.update(self.posix_local_test_paths[0])
-        self.run_datamover(
-            self.test_id + " (invalid prefix - on POSIX source)",
-            expected_rc=1,
-            expected_output=self.MFU_ERR_DAOS_INVAL_ARG)
-
-        self.set_datamover_params(
-            "DAOS_UUID", "/", pool1, cont1,
-            "POSIX", self.posix_local_test_paths[0])
-        self.dcp_cmd.daos_prefix.update(self.posix_local_test_paths[0])
-        self.run_datamover(
-            self.test_id + " (invalid prefix - on POSIX dst)",
-            expected_rc=1,
-            expected_output=self.MFU_ERR_DAOS_INVAL_ARG)
-
-        # (4) Bad parameter: UUID, UNS, or POSIX path does not exist.
+        # (3) Bad parameter: UUID, UNS, or POSIX path does not exist.
         fake_uuid = str(self.gen_uuid())
         self.run_datamover(
             self.test_id + " (invalid source pool)",
@@ -222,9 +154,23 @@ class DmvrNegativeTest(DataMoverTestBase):
             expected_output="No such file or directory")
 
         self.run_datamover(
+            self.test_id + " (invalid source cont UNS path)",
+            "DAOS_UNS", "/fake/fake", pool1, cont1,
+            "POSIX", self.posix_local_test_paths[0],
+            expected_rc=1,
+            expected_output="No such file or directory")
+
+        self.run_datamover(
             self.test_id + " (invalid dest cont path)",
             "POSIX", self.posix_local_test_paths[0], None, None,
             "DAOS_UUID", "/fake/fake", pool1, cont1,
+            expected_rc=1,
+            expected_output="No such file or directory")
+
+        self.run_datamover(
+            self.test_id + " (invalid dest cont UNS path)",
+            "POSIX", self.posix_local_test_paths[0], None, None,
+            "DAOS_UNS", "/fake/fake", pool1, cont1,
             expected_rc=1,
             expected_output="No such file or directory")
 

--- a/src/tests/ftest/util/data_mover_test_base.py
+++ b/src/tests/ftest/util/data_mover_test_base.py
@@ -671,9 +671,6 @@ class DataMoverTestBase(IorTestBase, MdtestBase):
         """Set the params for dcp.
         This is a wrapper for DcpCommand.set_params.
 
-        When both src_type and dst_type are DAOS_UNS, a prefix will
-        only work for either the src or the dst, but not both.
-
         Args:
             src_type (str): how to interpret the src params.
                 Must be in PARAM_TYPES.
@@ -718,7 +715,6 @@ class DataMoverTestBase(IorTestBase, MdtestBase):
                         src_path=src_cont.path.value)
                 else:
                     self.dcp_cmd.set_params(
-                        daos_prefix=src_cont.path.value,
                         src_path=src_cont.path.value + src_path)
 
         # Set the destination params
@@ -735,7 +731,6 @@ class DataMoverTestBase(IorTestBase, MdtestBase):
                         dst_path=dst_cont.path.value)
                 else:
                     self.dcp_cmd.set_params(
-                        daos_prefix=dst_cont.path.value,
                         dst_path=dst_cont.path.value + dst_path)
 
     def _set_dsync_params(self,
@@ -745,9 +740,6 @@ class DataMoverTestBase(IorTestBase, MdtestBase):
                           dst_pool=None, dst_cont=None):
         """Set the params for dsync.
         This is a wrapper for DsyncCommand.set_params.
-
-        When both src_type and dst_type are DAOS_UNS, a prefix will
-        only work for either the src or the dst, but not both.
 
         Args:
             src_type (str): how to interpret the src params.
@@ -783,7 +775,6 @@ class DataMoverTestBase(IorTestBase, MdtestBase):
                         src_path=src_cont.path.value)
                 else:
                     self.dsync_cmd.set_params(
-                        daos_prefix=src_cont.path.value,
                         src_path=src_cont.path.value + src_path)
 
         # Set the destination params
@@ -800,7 +791,6 @@ class DataMoverTestBase(IorTestBase, MdtestBase):
                         dst_path=dst_cont.path.value)
                 else:
                     self.dsync_cmd.set_params(
-                        daos_prefix=dst_cont.path.value,
                         dst_path=dst_cont.path.value + dst_path)
 
     def _set_fs_copy_params(self,
@@ -809,9 +799,6 @@ class DataMoverTestBase(IorTestBase, MdtestBase):
                             dst_type=None, dst_path=None,
                             dst_pool=None, dst_cont=None):
         """Set the params for fs copy.
-
-        daos fs copy does not support a "prefix" on UNS paths,
-        so the param type for DAOS_UNS must have the path "/".
 
         Args:
             src_type (str): how to interpret the src params.
@@ -856,7 +843,7 @@ class DataMoverTestBase(IorTestBase, MdtestBase):
                 if src_path == "/":
                     path = str(src_cont.path)
                 else:
-                    self.fail("daos fs copy does not support a prefix")
+                    path = str(src_cont.path) + src_path
             self.fs_copy_cmd.set_fs_copy_params(
                 src=path)
 
@@ -873,7 +860,7 @@ class DataMoverTestBase(IorTestBase, MdtestBase):
                 if dst_path == "/":
                     path = str(dst_cont.path)
                 else:
-                    self.fail("daos fs copy does not support a prefix")
+                    path = str(dst_cont.path) + dst_path
             self.fs_copy_cmd.set_fs_copy_params(
                 dst=path)
 

--- a/src/tests/ftest/util/data_mover_utils.py
+++ b/src/tests/ftest/util/data_mover_utils.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 """
-  (C) Copyright 2020-2021 Intel Corporation.
+  (C) Copyright 2020-2022 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -150,8 +150,6 @@ class DcpCommand(MfuCommandBase):
         self.bufsize = FormattedParameter("--bufsize {}")
         # work size per task in bytes (default 64MB)
         self.chunksize = FormattedParameter("--chunksize {}")
-        # DAOS prefix for unified namespace path
-        self.daos_prefix = FormattedParameter("--daos-prefix {}")
         # DAOS API in {DFS, DAOS} (default uses DFS for POSIX containers)
         self.daos_api = FormattedParameter("--daos-api {}")
         # read source list from file
@@ -197,8 +195,6 @@ class DsyncCommand(MfuCommandBase):
         self.bufsize = FormattedParameter("--blocksize {}")
         # work size per task in bytes (default 4MB)
         self.chunksize = FormattedParameter("--chunksize {}")
-        # DAOS prefix for unified namespace path
-        self.daos_prefix = FormattedParameter("--daos-prefix {}")
         # DAOS API in {DFS, DAOS} (default uses DFS for POSIX containers)
         self.daos_api = FormattedParameter("--daos-api {}")
         # read and compare file contents rather than compare size and mtime


### PR DESCRIPTION
Test-tag: datamover,-hw
Skip-unit-tests: true
Skip-fault-injection-test: true

Remove --daos-prefix from datamover tests as it's no longer necessary.

Signed-off-by: Dalton Bohning <dalton.bohning@intel.com>