### PR TITLE
DAOS-9873 control: Adjust permissions on mounted SCM filesystem

### DIFF
--- a/src/control/server/storage/scm/mocks.go
+++ b/src/control/server/storage/scm/mocks.go
@@ -34,6 +34,7 @@ type (
 		MountErr        error
 		UnmountErr      error
 		MkfsErr         error
+		ChmodErr        error
 		GetfsStr        string
 		GetfsErr        error
 		SourceToTarget  map[string]string
@@ -112,6 +113,10 @@ func (msp *MockSysProvider) Unmount(target string, _ int) error {
 
 func (msp *MockSysProvider) Mkfs(_, _ string, _ bool) error {
 	return msp.cfg.MkfsErr
+}
+
+func (msp *MockSysProvider) Chmod(string, os.FileMode) error {
+	return msp.cfg.ChmodErr
 }
 
 func (msp *MockSysProvider) Getfs(_ string) (string, error) {

--- a/src/control/server/storage/scm/provider.go
+++ b/src/control/server/storage/scm/provider.go
@@ -63,6 +63,7 @@ type (
 		Mkfs(fsType, device string, force bool) error
 		Getfs(device string) (string, error)
 		Stat(string) (os.FileInfo, error)
+		Chmod(string, os.FileMode) error
 	}
 
 	defaultSystemProvider struct {
@@ -233,6 +234,11 @@ func (dsp *defaultSystemProvider) Getfs(device string) (string, error) {
 // Stat probes the specified path and returns os level file info.
 func (dsp *defaultSystemProvider) Stat(path string) (os.FileInfo, error) {
 	return os.Stat(path)
+}
+
+// Chmod changes the mode of the specified path.
+func (dsp *defaultSystemProvider) Chmod(path string, mode os.FileMode) error {
+	return os.Chmod(path, mode)
 }
 
 func parseFsType(input string) string {
@@ -620,6 +626,11 @@ func (p *Provider) mount(src, target, fsType string, flags uintptr, opts string)
 	p.log.Debugf("mount %s->%s (%s) (%s)", src, target, fsType, opts)
 	if err := p.sys.Mount(src, target, fsType, flags, opts); err != nil {
 		return nil, errors.Wrapf(err, "mount %s->%s failed", src, target)
+	}
+
+	// Adjust permissions on the mounted filesystem.
+	if err := p.sys.Chmod(target, defaultMountPointPerms); err != nil {
+		return nil, errors.Wrapf(err, "failed to set permissions on %s", target)
 	}
 
 	return &storage.ScmMountResponse{

--- a/src/control/server/storage/scm/provider_test.go
+++ b/src/control/server/storage/scm/provider_test.go
@@ -539,6 +539,7 @@ func TestProvider_Format(t *testing.T) {
 		mountErr       error
 		unmountErr     error
 		mkfsErr        error
+		chmodErr       error
 		request        *storage.ScmFormatRequest
 		expResponse    *storage.ScmFormatResponse
 		expErr         error
@@ -648,6 +649,16 @@ func TestProvider_Format(t *testing.T) {
 			},
 			alreadyMounted: true,
 			unmountErr:     errors.New("unmount failed"),
+		},
+		"ramdisk: format succeeds, chmod fails": {
+			request: &storage.ScmFormatRequest{
+				Mountpoint: goodMountPoint,
+				Ramdisk: &storage.RamdiskParams{
+					Size: 1,
+				},
+			},
+			chmodErr: errors.New("chmod failed"),
+			expErr:   errors.New("chmod failed"),
 		},
 		"ramdisk: already mounted; reformat; mount fails": {
 			request: &storage.ScmFormatRequest{
@@ -805,6 +816,17 @@ func TestProvider_Format(t *testing.T) {
 			getFsStr: fsTypeNone,
 			mountErr: errors.New("mount failed"),
 		},
+		"dcpm: format succeeds, chmod fails": {
+			request: &storage.ScmFormatRequest{
+				Mountpoint: goodMountPoint,
+				Dcpm: &storage.DcpmParams{
+					Device: goodDevice,
+				},
+			},
+			getFsStr: fsTypeNone,
+			chmodErr: errors.New("chmod failed"),
+			expErr:   errors.New("chmod failed"),
+		},
 		"dcpm: missing device": {
 			request: &storage.ScmFormatRequest{
 				Mountpoint: goodMountPoint,
@@ -862,6 +884,7 @@ func TestProvider_Format(t *testing.T) {
 				GetfsStr:      tc.getFsStr,
 				GetfsErr:      tc.getFsErr,
 				MkfsErr:       tc.mkfsErr,
+				ChmodErr:      tc.chmodErr,
 				MountErr:      tc.mountErr,
 				UnmountErr:    tc.unmountErr,
 			}

--- a/src/tests/ftest/util/general_utils.py
+++ b/src/tests/ftest/util/general_utils.py
@@ -583,7 +583,8 @@ def pcmd(hosts, command, verbose=True, timeout=None, expect_rc=0):
     return exit_status
 
 
-def check_file_exists(hosts, filename, user=None, directory=False):
+def check_file_exists(hosts, filename, user=None, directory=False,
+                      sudo=False):
     """Check if a specified file exist on each specified hosts.
 
     If specified, verify that the file exists and is owned by the user.
@@ -592,6 +593,8 @@ def check_file_exists(hosts, filename, user=None, directory=False):
         hosts (list): list of hosts
         filename (str): file to check for the existence of on each host
         user (str, optional): owner of the file. Defaults to None.
+        sudo (bool, optional): whether to run the command via sudo. Defaults to
+            False.
 
     Returns:
         (bool, NodeSet): A tuple of:
@@ -607,6 +610,9 @@ def check_file_exists(hosts, filename, user=None, directory=False):
         command = "test -O {0} && test -d {0}".format(filename)
     elif directory:
         command = "test -d '{0}'".format(filename)
+
+    if sudo:
+        command = "sudo " + command
 
     task = run_task(hosts, command)
     for ret_code, node_list in task.iter_retcodes():
@@ -718,7 +724,7 @@ def check_pool_files(log, hosts, uuid):
     log.info("Checking for pool data on %s", NodeSet.fromlist(hosts))
     pool_files = [uuid, "superblock"]
     for filename in ["/mnt/daos/{}".format(item) for item in pool_files]:
-        result = check_file_exists(hosts, filename)
+        result = check_file_exists(hosts, filename, sudo=True)
         if not result[0]:
             log.error("%s: %s not found", result[1], filename)
             status = False


### PR DESCRIPTION
Set the mounted SCM filesystem's root permissions to match the
underlying mountpoint's permissions.

Features: control

Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com>
