### PR TITLE
DAOS-9872 API: Expose daos_pool_connect2() as a weak symbol.

### DIFF
--- a/src/client/api/pool.c
+++ b/src/client/api/pool.c
@@ -41,8 +41,8 @@ daos_pool_connect(const char *pool, const char *sys, unsigned int flags,
 #undef daos_pool_connect
 int
 daos_pool_connect(const char *pool, const char *sys, unsigned int flags,
-                  daos_handle_t *poh, daos_pool_info_t *info, daos_event_t *ev)
-		  __attribute__ ((weak, alias("daos_pool_connect2")));
+		 daos_handle_t *poh, daos_pool_info_t *info, daos_event_t *ev)
+		 __attribute__ ((weak, alias("daos_pool_connect2")));
 #define daos_pool_connect daos_pool_connect2
 
 int

--- a/src/client/api/pool.c
+++ b/src/client/api/pool.c
@@ -42,7 +42,7 @@ daos_pool_connect(const char *pool, const char *sys, unsigned int flags,
 int
 daos_pool_connect(const char *pool, const char *sys, unsigned int flags,
                   daos_handle_t *poh, daos_pool_info_t *info, daos_event_t *ev)
-__attribute__ ((weak,alias ("daos_pool_connect2")) );
+		  __attribute__ ((weak,alias ("daos_pool_connect2")) );
 #define daos_pool_connect daos_pool_connect2
 
 int

--- a/src/client/api/pool.c
+++ b/src/client/api/pool.c
@@ -42,7 +42,7 @@ daos_pool_connect(const char *pool, const char *sys, unsigned int flags,
 int
 daos_pool_connect(const char *pool, const char *sys, unsigned int flags,
                   daos_handle_t *poh, daos_pool_info_t *info, daos_event_t *ev)
-		  __attribute__ ((weak,alias ("daos_pool_connect2")) );
+		  __attribute__ ((weak, alias("daos_pool_connect2")));
 #define daos_pool_connect daos_pool_connect2
 
 int

--- a/src/client/api/pool.c
+++ b/src/client/api/pool.c
@@ -38,6 +38,12 @@ daos_pool_connect(const char *pool, const char *sys, unsigned int flags,
 
 	return dc_task_schedule(task, true);
 }
+#undef daos_pool_connect
+int
+daos_pool_connect(const char *pool, const char *sys, unsigned int flags,
+                  daos_handle_t *poh, daos_pool_info_t *info, daos_event_t *ev)
+__attribute__ ((weak,alias ("daos_pool_connect2")) );
+#define daos_pool_connect daos_pool_connect2
 
 int
 daos_pool_disconnect(daos_handle_t poh, daos_event_t *ev)

--- a/src/client/api/pool.c
+++ b/src/client/api/pool.c
@@ -38,12 +38,10 @@ daos_pool_connect(const char *pool, const char *sys, unsigned int flags,
 
 	return dc_task_schedule(task, true);
 }
-#undef daos_pool_connect
 int
-daos_pool_connect(const char *pool, const char *sys, unsigned int flags,
+daos_pool_connect2(const char *pool, const char *sys, unsigned int flags,
 		 daos_handle_t *poh, daos_pool_info_t *info, daos_event_t *ev)
-		 __attribute__ ((weak, alias("daos_pool_connect2")));
-#define daos_pool_connect daos_pool_connect2
+		 __attribute__ ((weak, alias("daos_pool_connect")));
 
 int
 daos_pool_disconnect(daos_handle_t poh, daos_event_t *ev)

--- a/src/client/pydaos/raw/daos_api.py
+++ b/src/client/pydaos/raw/daos_api.py
@@ -2301,7 +2301,7 @@ class DaosContext():
             'close-obj':       self.libdaos.daos_obj_close,
             'close-tx':        self.libdaos.daos_tx_close,
             'commit-tx':       self.libdaos.daos_tx_commit,
-            'connect-pool':    self.libdaos.daos_pool_connect2,
+            'connect-pool':    self.libdaos.daos_pool_connect,
             'convert-cglobal': self.libdaos.daos_cont_global2local,
             'convert-clocal':  self.libdaos.daos_cont_local2global,
             'convert-pglobal': self.libdaos.daos_pool_global2local,

--- a/src/control/cmd/daos/pool.go
+++ b/src/control/cmd/daos/pool.go
@@ -77,7 +77,7 @@ func (cmd *poolBaseCmd) connectPool(flags C.uint) error {
 		defer freeString(cLabel)
 
 		cmd.log.Debugf("connecting to pool: %s", cmd.PoolID().Label)
-		rc = C.daos_pool_connect2(cLabel, cSysName, flags,
+		rc = C.daos_pool_connect(cLabel, cSysName, flags,
 			&cmd.cPoolHandle, &poolInfo, nil)
 		if rc == 0 {
 			var err error
@@ -92,7 +92,7 @@ func (cmd *poolBaseCmd) connectPool(flags C.uint) error {
 		cmd.log.Debugf("connecting to pool: %s", cmd.poolUUID)
 		cUUIDstr := C.CString(cmd.poolUUID.String())
 		defer freeString(cUUIDstr)
-		rc = C.daos_pool_connect2(cUUIDstr, cSysName, flags,
+		rc = C.daos_pool_connect(cUUIDstr, cSysName, flags,
 			&cmd.cPoolHandle, nil, nil)
 	default:
 		return errors.New("no pool UUID or label supplied")

--- a/src/include/daos_pool.h
+++ b/src/include/daos_pool.h
@@ -9,8 +9,6 @@
 #ifndef __DAOS_POOL_H__
 #define __DAOS_POOL_H__
 
-#define daos_pool_connect daos_pool_connect2
-
 #if defined(__cplusplus)
 extern "C" {
 #endif


### PR DESCRIPTION
daos_pool_connect is a weak symbol pointing to daos_pool_connect2().

Signed-off-by: Lei Huang <wiliam_huang@hotmail.com>