### PR TITLE
DAOS-9626 test: fix no_cap test timeout

### DIFF
--- a/src/tests/ftest/rebuild/no_cap.yaml
+++ b/src/tests/ftest/rebuild/no_cap.yaml
@@ -10,6 +10,8 @@ timeout: 180
 server_config:
   engines_per_host: 2
   name: daos_server
+# reduce cart timeout to make IV update return timeout
+# quickly to ease test (DAOS-9626)
   env_vars:
     - CRT_TIMEOUT=10
   servers:

--- a/src/tests/ftest/rebuild/no_cap.yaml
+++ b/src/tests/ftest/rebuild/no_cap.yaml
@@ -10,6 +10,8 @@ timeout: 180
 server_config:
   engines_per_host: 2
   name: daos_server
+   env_vars:
+    - CRT_TIMEOUT=10
   servers:
     0:
       targets: 8
@@ -41,7 +43,7 @@ container:
 pool:
   mode: 511
   name: daos_server
-  scm_size: 6G
+  scm_size: 1G
   control_method: dmg
   pool_query_timeout: 30
   pool_query_interval: 1

--- a/src/tests/ftest/rebuild/no_cap.yaml
+++ b/src/tests/ftest/rebuild/no_cap.yaml
@@ -10,7 +10,7 @@ timeout: 180
 server_config:
   engines_per_host: 2
   name: daos_server
-   env_vars:
+  env_vars:
     - CRT_TIMEOUT=10
   servers:
     0:


### PR DESCRIPTION
1. reduce pool size so that rebuild could be restarted
more quickly.

2. reduce cart timeout to make IV update return timeout
quickly to ease test.

Test-tag-hw-medium: no_cap
Test-repeat-hw-medium: 50
Signed-off-by: Wang Shilong <shilong.wang@intel.com>