### PR TITLE
DAOS-9829 dtx: prevent closing container if have active transaction

### DIFF
--- a/src/container/srv_target.c
+++ b/src/container/srv_target.c
@@ -1409,6 +1409,7 @@ ds_cont_local_open(uuid_t pool_uuid, uuid_t cont_hdl_uuid, uuid_t cont_uuid,
 	uuid_copy(hdl->sch_uuid, cont_hdl_uuid);
 	hdl->sch_flags = flags;
 	hdl->sch_sec_capas = sec_capas;
+	hdl->sch_dtx_count = 0;
 
 	rc = cont_hdl_add(&tls->dt_cont_hdl_hash, hdl);
 	if (rc != 0)
@@ -1615,6 +1616,13 @@ cont_close_hdl(uuid_t cont_hdl_uuid)
 		D_DEBUG(DF_DSMS, DF_CONT": already closed: hdl="DF_UUID"\n",
 			DP_CONT(NULL, NULL), DP_UUID(cont_hdl_uuid));
 		return 0;
+	}
+
+	if (hdl->sch_dtx_count > 0) {
+		D_WARN(DF_CONT" still have non-stopped transactions %d: hdl="DF_UUID"\n",
+		       DP_CONT(NULL, NULL), hdl->sch_dtx_count, DP_UUID(cont_hdl_uuid));
+		cont_hdl_put_internal(&tls->dt_cont_hdl_hash, hdl);
+		return -DER_BUSY;
 	}
 
 	/* Remove the handle from hash first, following steps may yield */

--- a/src/dtx/dtx_common.c
+++ b/src/dtx/dtx_common.c
@@ -1262,13 +1262,6 @@ out:
 		if (result < 0 && !aborted)
 			vos_dtx_cleanup(dth);
 
-		vos_dtx_rsrvd_fini(dth);
-		vos_dtx_detach(dth);
-		if (dth->dth_hdl != NULL) {
-			D_ASSERT(dth->dth_hdl->sch_dtx_count > 0);
-			dth->dth_hdl->sch_dtx_count--;
-		}
-
 		D_DEBUG(DB_IO,
 			"Stop the DTX "DF_DTI" ver %u, dkey %lu, %s, "
 			"%s participator(s), cos %d/%d: rc "DF_RC"\n",
@@ -1290,6 +1283,13 @@ out:
 		for (i = 0; i < dth->dth_dti_cos_count; i++)
 			dtx_del_cos(cont, &dth->dth_dti_cos[i],
 				    &dth->dth_leader_oid, dth->dth_dkey_hash);
+	}
+
+	vos_dtx_rsrvd_fini(dth);
+	vos_dtx_detach(dth);
+	if (dth->dth_hdl != NULL) {
+		D_ASSERT(dth->dth_hdl->sch_dtx_count > 0);
+		dth->dth_hdl->sch_dtx_count--;
 	}
 
 	D_FREE(dth->dth_oid_array);

--- a/src/include/daos_srv/container.h
+++ b/src/include/daos_srv/container.h
@@ -153,6 +153,7 @@ struct ds_cont_hdl {
 	uint64_t		sch_sec_capas;	/* access control capas */
 	struct ds_cont_child	*sch_cont;
 	int32_t			sch_ref;
+	uint32_t		sch_dtx_count;
 };
 
 struct ds_cont_hdl *ds_cont_hdl_lookup(const uuid_t uuid);

--- a/src/include/daos_srv/dtx_srv.h
+++ b/src/include/daos_srv/dtx_srv.h
@@ -42,7 +42,9 @@ struct dtx_handle {
 			struct dtx_memberships	*dth_mbs;
 		};
 	};
-	/** The container handle */
+	/* The container open handle. */
+	struct ds_cont_hdl		*dth_hdl;
+	/** VOS container handle. */
 	daos_handle_t			 dth_coh;
 	/** The epoch# for the DTX. */
 	daos_epoch_t			 dth_epoch;
@@ -201,15 +203,14 @@ enum dtx_flags {
 int
 dtx_sub_init(struct dtx_handle *dth, daos_unit_oid_t *oid, uint64_t dkey_hash);
 int
-dtx_leader_begin(daos_handle_t coh, struct dtx_id *dti,
+dtx_leader_begin(struct ds_cont_hdl *hdl, daos_handle_t coh, struct dtx_id *dti,
 		 struct dtx_epoch *epoch, uint16_t sub_modification_cnt,
 		 uint32_t pm_ver, daos_unit_oid_t *leader_oid,
 		 struct dtx_id *dti_cos, int dti_cos_cnt,
 		 struct daos_shard_tgt *tgts, int tgt_cnt, uint32_t flags,
 		 struct dtx_memberships *mbs, struct dtx_leader_handle **p_dlh);
 int
-dtx_leader_end(struct dtx_leader_handle *dlh, struct ds_cont_child *cont,
-	       int result);
+dtx_leader_end(struct dtx_leader_handle *dlh, int result);
 
 typedef void (*dtx_sub_comp_cb_t)(struct dtx_leader_handle *dlh, int idx,
 				  int rc);
@@ -217,13 +218,13 @@ typedef int (*dtx_sub_func_t)(struct dtx_leader_handle *dlh, void *arg, int idx,
 			      dtx_sub_comp_cb_t comp_cb);
 
 int
-dtx_begin(daos_handle_t coh, struct dtx_id *dti,
+dtx_begin(struct ds_cont_hdl *hdl, daos_handle_t coh, struct dtx_id *dti,
 	  struct dtx_epoch *epoch, uint16_t sub_modification_cnt,
 	  uint32_t pm_ver, daos_unit_oid_t *leader_oid,
 	  struct dtx_id *dti_cos, int dti_cos_cnt, uint32_t flags,
 	  struct dtx_memberships *mbs, struct dtx_handle **p_dth);
 int
-dtx_end(struct dtx_handle *dth, struct ds_cont_child *cont, int result);
+dtx_end(struct dtx_handle *dth, int result);
 int
 dtx_list_cos(struct ds_cont_child *cont, daos_unit_oid_t *oid,
 	     uint64_t dkey_hash, int max, struct dtx_id **dtis);
@@ -249,7 +250,7 @@ int dtx_refresh(struct dtx_handle *dth, struct ds_cont_child *cont);
 /**
  * Check whether the given DTX is resent one or not.
  *
- * \param coh		[IN]	Container open handle.
+ * \param coh		[IN]	VOS container handle.
  * \param xid		[IN]	Pointer to the DTX identifier.
  * \param epoch		[IN,OUT] Pointer to current epoch, if it is zero and
  *				 if the DTX exists, then the DTX's epoch will

--- a/src/object/srv_ec_aggregate.c
+++ b/src/object/srv_ec_aggregate.c
@@ -2524,7 +2524,7 @@ cont_ec_aggregate_cb(struct ds_cont_child *cont, daos_epoch_range_t *epr,
 
 	agg_reset_entry(&ec_agg_param->ap_agg_entry, NULL, NULL);
 
-	rc = dtx_begin(cont->sc_hdl, &dti, &epoch, 0, 0, &oid,
+	rc = dtx_begin(NULL, cont->sc_hdl, &dti, &epoch, 0, 0, &oid,
 		       NULL, 0, 0, NULL, &dth);
 	if (rc != 0) {
 		D_ERROR("Fail to start DTX for EC aggregation: "DF_RC"\n",
@@ -2551,7 +2551,7 @@ again:
 		}
 	}
 
-	dtx_end(dth, cont, rc);
+	dtx_end(dth, rc);
 
 	if (daos_handle_is_valid(ec_agg_param->ap_agg_entry.ae_obj_hdl)) {
 		dsc_obj_close(ec_agg_param->ap_agg_entry.ae_obj_hdl);

--- a/src/rebuild/scan.c
+++ b/src/rebuild/scan.c
@@ -695,7 +695,7 @@ rebuild_container_scan_cb(daos_handle_t ih, vos_iter_entry_t *entry,
 	}
 
 	epoch.oe_value = rpt->rt_stable_epoch;
-	rc = dtx_begin(coh, &dti, &epoch, 0, rpt->rt_rebuild_ver,
+	rc = dtx_begin(NULL, coh, &dti, &epoch, 0, rpt->rt_rebuild_ver,
 		       &oid, NULL, 0, DTX_IGNORE_UNCOMMITTED, NULL, &dth);
 	D_ASSERT(rc == 0);
 	memset(&param, 0, sizeof(param));
@@ -714,7 +714,7 @@ rebuild_container_scan_cb(daos_handle_t ih, vos_iter_entry_t *entry,
 
 	rc = vos_iterate(&param, VOS_ITER_OBJ, false, &anchor,
 			 rebuild_obj_scan_cb, NULL, arg, dth);
-	dtx_end(dth, NULL, rc);
+	dtx_end(dth, rc);
 	vos_cont_close(coh);
 
 	*acts |= VOS_ITER_CB_YIELD;


### PR DESCRIPTION
Currently, it is applications' duty to guarantee the container will
not be closed until all the transactions on the container have been
stopped. But that is difficult because of malicious applications or
non-coordinated applications. DAOS server needs be robust enough to
avoid crash under some unexpected client behavior.

The patch tracks the events of DTX begin and end, if someone try to
close the container with active transactions, it will get -DER_BUSY.

Signed-off-by: Fan Yong <fan.yong@intel.com>