### PR TITLE
DAOS-9843 vos: few csum helper functions

### DIFF
--- a/src/vos/vos_internal.h
+++ b/src/vos/vos_internal.h
@@ -1323,4 +1323,31 @@ struct csum_recalc_args {
 
 int vos_csum_recalc_fn(void *recalc_args);
 
+static inline struct dcs_csum_info *
+vos_csum_at(struct dcs_iod_csums *iod_csums, unsigned int idx)
+{
+	/** is enabled and has csums (might not for punch) */
+	if (iod_csums != NULL && iod_csums[idx].ic_nr > 0)
+		return iod_csums[idx].ic_data;
+	return NULL;
+}
+
+static inline struct dcs_csum_info *
+recx_csum_at(struct dcs_csum_info *csums, unsigned int idx, daos_iod_t *iod)
+{
+	if (csums != NULL && csum_iod_is_supported(iod))
+		return &csums[idx];
+	return NULL;
+}
+
+static inline daos_size_t
+recx_csum_len(daos_recx_t *recx, struct dcs_csum_info *csum,
+	      daos_size_t rsize)
+{
+	if (!ci_is_valid(csum) || rsize == 0)
+		return 0;
+	return (daos_size_t)csum->cs_len * csum_chunk_count(csum->cs_chunksize,
+			recx->rx_idx, recx->rx_idx + recx->rx_nr - 1, rsize);
+}
+
 #endif /* __VOS_INTERNAL_H__ */

--- a/src/vos/vos_io.c
+++ b/src/vos/vos_io.c
@@ -91,16 +91,6 @@ struct vos_io_context {
 	struct daos_recx_ep_list *ic_recx_lists;
 };
 
-static inline daos_size_t
-recx_csum_len(daos_recx_t *recx, struct dcs_csum_info *csum,
-	      daos_size_t rsize)
-{
-	if (!ci_is_valid(csum) || rsize == 0)
-		return 0;
-	return (daos_size_t)csum->cs_len * csum_chunk_count(csum->cs_chunksize,
-			recx->rx_idx, recx->rx_idx + recx->rx_nr - 1, rsize);
-}
-
 struct dedup_entry {
 	d_list_t	 de_link;
 	uint8_t		*de_csum_buf;
@@ -511,15 +501,6 @@ vos_ioc2ioh(struct vos_io_context *ioc)
 
 	ioh.cookie = (uint64_t)ioc;
 	return ioh;
-}
-
-static struct dcs_csum_info *
-vos_ioc2csum(struct vos_io_context *ioc)
-{
-	/** is enabled and has csums (might not for punch) */
-	if (ioc->iod_csums != NULL && ioc->iod_csums[ioc->ic_sgl_at].ic_nr > 0)
-		return ioc->iod_csums[ioc->ic_sgl_at].ic_data;
-	return NULL;
 }
 
 static void
@@ -1608,7 +1589,7 @@ akey_update_single(daos_handle_t toh, uint32_t pm_ver, daos_size_t rsize,
 
 	tree_rec_bundle2iov(&rbund, &riov);
 
-	struct dcs_csum_info *value_csum = vos_ioc2csum(ioc);
+	struct dcs_csum_info *value_csum = vos_csum_at(ioc->iod_csums, ioc->ic_sgl_at);
 
 	if (value_csum != NULL)
 		rbund.rb_csum	= value_csum;
@@ -1683,8 +1664,8 @@ akey_update(struct vos_io_context *ioc, uint32_t pm_ver, daos_handle_t ak_toh,
 	struct vos_object	*obj = ioc->ic_obj;
 	struct vos_krec_df	*krec = NULL;
 	daos_iod_t		*iod = &ioc->ic_iods[ioc->ic_sgl_at];
-	struct dcs_csum_info	*iod_csums = vos_ioc2csum(ioc);
-	struct dcs_csum_info	*recx_csum = NULL;
+	struct dcs_csum_info	*iod_csums = vos_csum_at(ioc->iod_csums, ioc->ic_sgl_at);
+	struct dcs_csum_info	*recx_csum;
 	uint32_t		 update_cond = 0;
 	bool			 is_array = (iod->iod_type == DAOS_IOD_ARRAY);
 	int			 flags = SUBTR_CREATE;
@@ -1773,8 +1754,7 @@ akey_update(struct vos_io_context *ioc, uint32_t pm_ver, daos_handle_t ak_toh,
 			continue;
 		}
 
-		if (iod_csums != NULL && csum_iod_is_supported(iod))
-			recx_csum = &iod_csums[i];
+		recx_csum = recx_csum_at(iod_csums, i, iod);
 		rc = akey_update_recx(toh, pm_ver, &iod->iod_recxs[i],
 				      recx_csum, iod->iod_size, ioc,
 				      minor_epc);
@@ -2006,7 +1986,7 @@ vos_reserve_single(struct vos_io_context *ioc, uint16_t media,
 	struct bio_iov		 biov;
 	uint64_t		 off = 0;
 	int			 rc;
-	struct dcs_csum_info	*value_csum = vos_ioc2csum(ioc);
+	struct dcs_csum_info	*value_csum = vos_csum_at(ioc->iod_csums, ioc->ic_sgl_at);
 
 	/*
 	 * TODO:
@@ -2114,7 +2094,7 @@ done:
 static int
 akey_update_begin(struct vos_io_context *ioc)
 {
-	struct dcs_csum_info	*iod_csums = vos_ioc2csum(ioc);
+	struct dcs_csum_info	*iod_csums = vos_csum_at(ioc->iod_csums, ioc->ic_sgl_at);
 	struct dcs_csum_info	*recx_csum;
 	daos_iod_t *iod = &ioc->ic_iods[ioc->ic_sgl_at];
 	int i, rc;


### PR DESCRIPTION
Due to duplicated code, some csum fixes in vos_io.c were not applied
to vos_space.c, this patch fixed that by making few helper functions
shared by vos_io.c and vos_space.c

Signed-off-by: Niu Yawei <yawei.niu@intel.com>