### PR TITLE
DAOS-9570 object: allow degrade IO on EC obj even if lost all parity shards

### DIFF
--- a/src/object/obj_tx.c
+++ b/src/object/obj_tx.c
@@ -1188,8 +1188,8 @@ dc_tx_classify_common(struct dc_tx *tx, struct daos_cpd_sub_req *dcsr,
 							oca->u.ec.e_p)
 					skipped_parity++;
 
-				if (skipped_parity == oca->u.ec.e_p) {
-					D_ERROR("Two many (%d) shards in the "
+				if (skipped_parity > oca->u.ec.e_p) {
+					D_ERROR("Too many (%d) shards in the "
 						"redundancy group for opc %u "
 						"against the obj "DF_OID
 						" for DTX "DF_DTI" are lost\n",


### PR DESCRIPTION
If all data shards are healthy, only parity shards are unavailable, then EC
related logic can guarantee the data consistency.

Signed-off-by: Fan Yong <fan.yong@intel.com>