### PR TITLE
DAOS-9885 object: Avoid retrying a new replica for existence checks

### DIFF
--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -3455,12 +3455,16 @@ obj_shard_comp_cb(struct shard_auxi_args *shard_auxi,
 	}
 
 	if (ret) {
-		if (ret != -DER_REC2BIG && !obj_retry_error(ret) &&
-		    !obj_is_modification_opc(obj_auxi->opc) &&
-		    !obj_auxi->is_ec_obj && !obj_auxi->spec_shard &&
-		    !obj_auxi->spec_group && !obj_auxi->to_leader &&
-		    ret != -DER_TX_RESTART &&
-		    !DAOS_FAIL_CHECK(DAOS_DTX_NO_RETRY)) {
+		if (ret == -DER_NONEXIST && obj_is_fetch_opc(obj_auxi->opc)) {
+			/** Conditional fetch returns -DER_NONEXIST if the key doesn't exist. We
+			 *  do not want to try another replica in this case.
+			 */
+			iter_arg->retry = false;
+		} else if (ret != -DER_REC2BIG && !obj_retry_error(ret) &&
+			   !obj_is_modification_opc(obj_auxi->opc) &&
+			   !obj_auxi->is_ec_obj && !obj_auxi->spec_shard &&
+			   !obj_auxi->spec_group && !obj_auxi->to_leader &&
+			   ret != -DER_TX_RESTART && !DAOS_FAIL_CHECK(DAOS_DTX_NO_RETRY)) {
 			int new_tgt;
 
 			/* Check if there are other replicas available to

--- a/src/object/obj_rpc.h
+++ b/src/object/obj_rpc.h
@@ -590,6 +590,12 @@ obj_is_modification_opc(uint32_t opc)
 }
 
 static inline bool
+obj_is_fetch_opc(uint32_t opc)
+{
+	return opc == DAOS_OBJ_RPC_FETCH;
+}
+
+static inline bool
 obj_is_ec_agg_opc(uint32_t opc)
 {
 	return opc == DAOS_OBJ_RPC_EC_AGGREGATE ||


### PR DESCRIPTION
We should not retry a new replica when an existence check correctly
returns -DER_NONEXIST.  For instance, a user does a condtional fetch
and the key doesn't exist.  This is not indicative of a replica failure

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>