### PR TITLE
DOS-9886 control: allocate minimum number of hugepages for scan

### DIFF
--- a/src/control/server/server_utils_test.go
+++ b/src/control/server/server_utils_test.go
@@ -282,6 +282,42 @@ func TestServer_prepBdevStorage(t *testing.T) {
 					WithEngines(scmEngine(0), scmEngine(1))
 			},
 		},
+		"no bdevs configured; nr_hugepages unset": {
+			srvCfgExtra: func(sc *config.Server) *config.Server {
+				return sc.WithNrHugePages(0).
+					WithEngines(scmEngine(0), scmEngine(1))
+			},
+			expResetCalls: []storage.BdevPrepareRequest{
+				{
+					Reset_:     true,
+					TargetUser: username,
+				},
+			},
+			expPrepCalls: []storage.BdevPrepareRequest{
+				{
+					HugePageCount: scanMinHugePageCount,
+					TargetUser:    username,
+				},
+			},
+		},
+		"no bdevs configured; nr_hugepages set": {
+			srvCfgExtra: func(sc *config.Server) *config.Server {
+				return sc.WithNrHugePages(1024).
+					WithEngines(scmEngine(0), scmEngine(1))
+			},
+			expResetCalls: []storage.BdevPrepareRequest{
+				{
+					Reset_:     true,
+					TargetUser: username,
+				},
+			},
+			expPrepCalls: []storage.BdevPrepareRequest{
+				{
+					HugePageCount: 1024,
+					TargetUser:    username,
+				},
+			},
+		},
 		"nvme prep succeeds; 2 engines both numa 0; hugepage alloc only on numa 0": {
 			srvCfgExtra: func(sc *config.Server) *config.Server {
 				return sc.WithNrHugePages(16384).

--- a/src/tests/ftest/util/server_utils_params.py
+++ b/src/tests/ftest/util/server_utils_params.py
@@ -159,10 +159,6 @@ class DaosServerYamlParameters(YamlParameters):
         for engine_params in self.engine_params:
             engine_params.get_params(test)
 
-        if self.nr_hugepages.value == 0 and not self.using_nvme:
-            self.log.debug("Disabling hugepages when bdev class is not 'nvme'")
-            self.nr_hugepages.update(-1, "nr_hugepages")
-
     def get_yaml_data(self):
         """Convert the parameters into a dictionary to use to write a yaml file.
 


### PR DESCRIPTION
To address a regression in commit
1c9fbacf95281de9c61dd7db37b01aa1580dbc0d that causes SPDK initialisation
failures during storage scan when no NVMe is configured, simplify the
logic so that unless hugepages are explicitly disabled in config (by
setting nr_hugepages: -1), always allocate a minimum number on NUMA-0 so
that NVMe storage scan can complete (and SPDK initialiise).

Also leave nr_hugepages unset in functional tests to let the
control-plane to do the right thing.

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>