### PR TITLE
DAOS-9804 csum: Checksum in VOS Tests and Aggregation Fix

### DIFF
--- a/src/include/daos_srv/srv_csum.h
+++ b/src/include/daos_srv/srv_csum.h
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2019-2021 Intel Corporation.
+ * (C) Copyright 2019-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -9,27 +9,6 @@
 
 #include <daos_srv/bio.h>
 #include <daos/checksum.h>
-
-/**
- * Determine if the saved checksum for a chunk can be used, or if a
- * new checksum is required.
- * @param raw_ext		Range of the raw (actual) extent (should map
- *				to evt_entry.en_ext)
- * @param req_ext		Range of the requested extent (should map
- *				to evt_entry.en_sel_ext)
- * @param chunk			Range of the chunk under investigation
- * @param csum_started		whether or not a previous biov for the current
- *				chunk exists and started a new checksum that
- *				\biov should contribute to
- * @param has_next_biov		Is there another extent following
- * @return
- */
-bool
-ds_csum_calc_needed(struct daos_csum_range *raw_ext,
-		    struct daos_csum_range *req_ext,
-		    struct daos_csum_range *chunk,
-		    bool csum_started,
-		    bool has_next_biov);
 
 /**
  * Process the bsgl and create new checksums or use the stored
@@ -49,5 +28,25 @@ int
 ds_csum_add2iod(daos_iod_t *iod, struct daos_csummer *csummer,
 		struct bio_sglist *bsgl, struct dcs_csum_info *biov_csums,
 		size_t *biov_csums_used, struct dcs_iod_csums *iod_csums);
+
+/**
+ * Allocate the memory for and populate the IO Maps structure. This structure is used to identify
+ * the parts of the iods' recxes for which there is data and which part are holes.
+ *
+ * @param biod[in]	contains the extents and info on holes
+ * @param iods[in]	IO Descriptor
+ * @param iods_nr[in]	Number of iods
+ * @param flags[in]	if ORF_CREATE_MAP_DETAIL is set, then all mapped extents are requested,
+ *			not just the low and high extents.
+ * @param p_maps[out]	pointer to the resulting structures
+ *
+ * @return		0 on success, else error
+ */
+int
+ds_iom_create(struct bio_desc *biod, daos_iod_t *iods, uint32_t iods_nr, uint32_t flags,
+		 daos_iom_t **p_maps);
+
+void
+ds_iom_free(daos_iom_t **p_maps, uint64_t map_nr);
 
 #endif

--- a/src/object/SConscript
+++ b/src/object/SConscript
@@ -33,8 +33,9 @@ def scons():
     srv = daos_build.library(senv, 'obj',
                              common_tgts + ['srv_obj.c', 'srv_mod.c',
                                             'srv_obj_remote.c', 'srv_ec.c',
-                                            'srv_csum.c', 'srv_obj_migrate.c',
-                                            'srv_cli.c', 'srv_ec_aggregate.c'],
+                                            'srv_obj_migrate.c',
+                                            'srv_cli.c', 'srv_ec_aggregate.c',
+                                            'srv_csum.c', 'srv_io_map.c'],
                              install_off="../..")
     senv.Install('$PREFIX/lib64/daos_srv', srv)
 

--- a/src/object/srv_csum.c
+++ b/src/object/srv_csum.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2019-2021 Intel Corporation.
+ * (C) Copyright 2019-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -13,7 +13,7 @@
 #include "daos_srv/srv_csum.h"
 
 #define C_TRACE(...) D_DEBUG(DB_CSUM, __VA_ARGS__)
-#define CHUNK_IDX(ctx, idx) (((idx) + 1) / (ctx)->cc_rec_chunksize)
+#define YES_NO(b) b ? "YES" : "NO"
 
 /** Holds information about checksum and data to verify when a
  * new checksum for an extent chunk is needed
@@ -310,30 +310,48 @@ cc_biovcsum_incr(struct csum_context *ctx, uint32_t nr)
  * means that a new checksum needs to be calculated for that chunk.
  */
 static bool
-cc_need_new_csum(struct csum_context *ctx, daos_off_t idx)
+cc_need_new_csum(struct csum_context *ctx, daos_off_t recx_idx)
 {
 	struct biov_ranges	*br = &ctx->cc_biov_ranges;
+	uint64_t		 chunk_idx = recx_idx  / ctx->cc_rec_chunksize;
+
+	bool result = false;
 
 	/**
-	 * biov has a prefix and currently in the same chunk as the
-	 * beginning of the biov
+	 * - biov has a prefix
+	 * - current recx idx is in same chunk as beginning of request
+	 * - at least part of the prefix is in the current
 	 */
 	if (br->br_has_prefix &&
-	    cc_in_same_chunk(ctx, idx, br->br_raw.dcr_lo))
-		return true;
+	    chunk_idx == br->br_req.dcr_lo / ctx->cc_rec_chunksize &&
+	    chunk_idx == ((br->br_req.dcr_lo - 1) / ctx->cc_rec_chunksize))
+		result = true;
 	/**
-	 * biov has a suffix and currently in the same chunk as the
-	 * end of the biov
+	 * - biov has a suffix
+	 * - current recx idx in the same chunk as the end of the request
+	 * - at least part of the suffix is in the current chunk
 	 */
-	if (br->br_has_suffix &&
-	    cc_in_same_chunk(ctx, idx, br->br_raw.dcr_hi))
-		return true;
+	else if (br->br_has_suffix &&
+	    chunk_idx == (br->br_req.dcr_hi / ctx->cc_rec_chunksize) &&
+	    chunk_idx == ((br->br_req.dcr_hi + 1) / ctx->cc_rec_chunksize))
+		result = true;
 
-	/** another extent in the same chunk */
-	if (cc_next_non_hole_extent_in_chunk(ctx, idx))
-		return true;
+	/**
+	 * has no prefix or suffix portion in the current extent, but
+	 * there's another extent in the same chunk
+	 */
+	else if (cc_next_non_hole_extent_in_chunk(ctx, recx_idx))
+		result = true;
 
-	return false;
+	C_TRACE("br_has_prefix: %s, br_has_suffix: %s, recx_idx: %lu, chunk_idx: %lu, br_req: "
+			DF_RANGE", br_raw: "DF_RANGE", result: %s\n",
+		YES_NO(br->br_has_prefix), YES_NO(br->br_has_suffix), recx_idx, chunk_idx,
+		DP_RANGE(br->br_req),
+		DP_RANGE(br->br_raw),
+		YES_NO(result)
+		);
+
+	return result;
 }
 
 /** copy the number of csums and then increment csum indexes */
@@ -408,7 +426,7 @@ cc_biov_move_next(struct csum_context *ctx, bool biov_csum_used)
 	/** move to the next biov */
 	ctx->cc_bsgl_idx.iov_idx++;
 	ctx->cc_bsgl_idx.iov_offset = 0;
-	C_TRACE("Moving to biov %d", ctx->cc_bsgl_idx.iov_idx);
+	C_TRACE("Moving to biov %d\n", ctx->cc_bsgl_idx.iov_idx);
 
 	/** Need to know if biov csum was used. For holes there is no csum, but
 	 * still need to move to next biov
@@ -433,20 +451,31 @@ cc_move_forward(struct csum_context *ctx, uint64_t nr, bool biov_csum_used)
 		cc_biov_move_next(ctx, biov_csum_used);
 }
 
-void cc_skip_hole(struct csum_context *ctx)
+/* Count the number of checksums to copy or skip for a hole */
+#define num_csums_to_biov_end(ctx) \
+	((ctx->cc_biov_ranges.br_req.dcr_hi / ctx->cc_rec_chunksize) - \
+	(ctx->cc_cur_recx_idx / ctx->cc_rec_chunksize) + 1)
+
+#define nr_to_biov_end(ctx) (ctx->cc_biov_ranges.br_req.dcr_hi - ctx->cc_cur_recx_idx + 1)
+#define cur_chunk_idx(ctx) (ctx->cc_cur_recx_idx / ctx->cc_rec_chunksize)
+#define first_chunk_idx(ctx) (ctx->cc_cur_recx->rx_idx / ctx->cc_rec_chunksize)
+
+static void
+cc_skip_hole(struct csum_context *ctx)
 {
-	daos_size_t csum_nr;
-	daos_size_t nr;
-	daos_size_t hi = ctx->cc_biov_ranges.br_req.dcr_hi;
+	daos_size_t csum_nr = num_csums_to_biov_end(ctx);
+	daos_size_t nr = nr_to_biov_end(ctx);
 
-	csum_nr = (CHUNK_IDX(ctx, hi) -
-		   CHUNK_IDX(ctx, ctx->cc_cur_recx->rx_idx)) - ctx->cc_csum_idx;
+	if (ctx->cc_csum_idx >  cur_chunk_idx(ctx) - first_chunk_idx(ctx))
+		csum_nr--; /* Already passed the current chunk */
 
-	nr = hi - ctx->cc_cur_recx_idx + 1;
+	if (cc_need_new_csum(ctx, ctx->cc_biov_ranges.br_req.dcr_hi))
+		csum_nr--;
 
-	C_TRACE("Skipping hole [%lu-%lu]. %lu csums and %lu records\n",
+	C_TRACE("Skipping hole ["DF_X64"-"DF_X64"]. %lu csums and %lu records, csum_idx %lu->%lu\n",
 		ctx->cc_biov_ranges.br_req.dcr_lo,
-		ctx->cc_biov_ranges.br_req.dcr_hi, csum_nr, nr);
+		ctx->cc_biov_ranges.br_req.dcr_hi, csum_nr, nr,
+		ctx->cc_csum_idx, ctx->cc_csum_idx + csum_nr);
 	cc_iodcsum_incr(ctx, csum_nr);
 	cc_move_forward(ctx, nr, false);
 }
@@ -467,10 +496,11 @@ cc_create(struct csum_context *ctx)
 
 	csum = cc2iodcsum(ctx);
 	D_ASSERT(csum != NULL);
+	C_TRACE("Creating new checksum for csum_idx: %lu\n", ctx->cc_csum_idx);
 	cc_iodcsum_incr(ctx, 1);
 
-	C_TRACE("(CALC) Starting new checksum for recx idx: %lu\n",
-		ctx->cc_cur_recx_idx);
+	C_TRACE("(CALC) Starting new checksum for recx idx: "DF_X64", recx: "DF_RECX"\n",
+		ctx->cc_cur_recx_idx, DP_RECX(*ctx->cc_cur_recx));
 	/** Setup csum to start updating */
 	memset(csum, 0, ctx->cc_csum_len);
 	daos_csummer_set_buffer(ctx->cc_csummer, csum, ctx->cc_csum_len);
@@ -511,30 +541,22 @@ cc_create(struct csum_context *ctx)
 static int
 cc_copy(struct csum_context *ctx)
 {
-	/** trust that if checksums needed to be created for earlier chunks
-	 * has already been handled any new csums
-	 */
-	daos_size_t csum_nr = ctx->cc_biov_ranges.br_req.dcr_hi /
-			      ctx->cc_rec_chunksize -
-			      ctx->cc_cur_recx_idx / ctx->cc_rec_chunksize + 1;
-	daos_size_t nr = ctx->cc_biov_ranges.br_req.dcr_hi -
-			 ctx->cc_cur_recx_idx + 1;
+	daos_size_t csum_nr = num_csums_to_biov_end(ctx);
+	daos_size_t nr = nr_to_biov_end(ctx);
 
 	/**
-	 * If the last chunk the biov is in needs a new csum then remove it. It
+	 * If the last chunk in the biov is in need of a new csum then remove it. It
 	 * will be created on the next pass of the \cc_add_csums_for_recx
-	 *
 	 */
 	if (cc_need_new_csum(ctx, ctx->cc_biov_ranges.br_req.dcr_hi)) {
 		csum_nr--;
-		nr -= (ctx->cc_biov_ranges.br_req.dcr_hi + 1) %
-		      ctx->cc_rec_chunksize;
+		nr -= (ctx->cc_biov_ranges.br_req.dcr_hi + 1) % ctx->cc_rec_chunksize;
 	}
 
 	if (csum_nr == 0)
 		return 0;
 
-	C_TRACE("Copying %lu csums for %lu records [%lu-%lu]\n", csum_nr, nr,
+	C_TRACE("Copying %lu csums for %lu records ["DF_X64"-"DF_X64"]\n", csum_nr, nr,
 		ctx->cc_cur_recx_idx, ctx->cc_cur_recx_idx + nr - 1);
 	cc_copy_csum(ctx, csum_nr);
 	cc_move_forward(ctx, nr, true);
@@ -557,6 +579,7 @@ cc_add_csums_for_recx(struct csum_context *ctx, daos_recx_t *recx,
 	ctx->cc_cur_recx = recx;
 	ctx->cc_csum_idx = 0;
 	set_biov_ranges(ctx, recx->rx_idx);
+	C_TRACE("recx: "DF_RECX"\n", DP_RECX(*recx));
 
 	while (cc_has_biov(ctx) && !cc_end_of_recx(ctx)) {
 		if (bio_addr_is_hole(&cc2biov(ctx)->bi_addr))
@@ -570,6 +593,7 @@ cc_add_csums_for_recx(struct csum_context *ctx, daos_recx_t *recx,
 			return rc;
 	}
 
+	C_TRACE("rc: "DF_RC"\n", DP_RC(rc));
 	return rc;
 }
 
@@ -591,7 +615,8 @@ ds_csum_add2iod_array(daos_iod_t *iod, struct daos_csummer *csummer,
 	 */
 	for (i = 0, j = 0; i < bsgl->bs_nr_out; i++) {
 		if (bio_addr_is_hole(&(bio_sgl_iov(bsgl, i)->bi_addr))) {
-			D_DEBUG(DB_CSUM, "biov is a hole. skipping\n");
+			C_TRACE("biov is a hole. skipping "DF_U64" bytes\n",
+				bio_sgl_iov(bsgl, i)->bi_data_len);
 			continue;
 		}
 		if (!ci_is_valid(&biov_csums[j++])) {
@@ -611,11 +636,10 @@ ds_csum_add2iod_array(daos_iod_t *iod, struct daos_csummer *csummer,
 		struct dcs_csum_info	*info = &iod_csums->ic_data[i];
 
 		if (ctx.cc_rec_len > 0 && ci_is_valid(info)) {
-			D_DEBUG(DB_CSUM, "Adding csums for recx %d\n", i);
+			C_TRACE("Adding csums for recx %d: "DF_RECX"\n", i, DP_RECX(*recx));
 			rc = cc_add_csums_for_recx(&ctx, recx, info);
 			if (rc != 0)
-				D_ERROR("Failed to add csum for "
-						"recx"DF_RECX": %d\n",
+				D_ERROR("Failed to add csum for recx"DF_RECX": %d\n",
 					DP_RECX(*recx), rc);
 		}
 	}
@@ -647,7 +671,7 @@ ds_csum_add2iod(daos_iod_t *iod, struct daos_csummer *csummer,
 		return 0;
 
 	if (iod->iod_type == DAOS_IOD_SINGLE) {
-	D_DEBUG(DB_CSUM, "Adding fetched to IOD: "DF_C_IOD", csum: "DF_CI"\n",
+	C_TRACE("Adding fetched to IOD: "DF_C_IOD", csum: "DF_CI"\n",
 		DP_C_IOD(iod), DP_CI(biov_csums[0]));
 		ci_insert(&iod_csums->ic_data[0], 0,
 			  biov_csums[0].cs_csum, biov_csums[0].cs_len);

--- a/src/object/srv_io_map.c
+++ b/src/object/srv_io_map.c
@@ -1,0 +1,105 @@
+/**
+ * (C) Copyright 2022 Intel Corporation.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause-Patent
+ */
+
+#include <daos_srv/bio.h>
+#include "obj_internal.h"
+
+static void
+map_add_recx(daos_iom_t *map, const struct bio_iov *biov, uint64_t rec_idx)
+{
+	map->iom_recxs[map->iom_nr_out].rx_idx = rec_idx;
+	map->iom_recxs[map->iom_nr_out].rx_nr = bio_iov2req_len(biov) / map->iom_size;
+	map->iom_nr_out++;
+}
+
+int
+ds_iom_create(struct bio_desc *biod, daos_iod_t *iods, uint32_t iods_nr, uint32_t flags,
+		 daos_iom_t **p_maps)
+{
+	daos_iom_t		*maps;
+
+	daos_iom_t		*map;
+	daos_iod_t		*iod;
+	struct bio_iov		*biov;
+	uint32_t		 i, r;
+	uint64_t		 rec_idx;
+	uint32_t		 bsgl_iov_idx;
+	struct bio_sglist	*bsgl;
+
+	D_ALLOC_ARRAY(maps, iods_nr);
+	if (maps == NULL)
+		return -DER_NOMEM;
+
+	for (i = 0; i <  iods_nr; i++) {
+		bsgl = bio_iod_sgl(biod, i); /** 1 bsgl per iod */
+		iod = &iods[i];
+		map = &maps[i];
+		map->iom_nr = bsgl->bs_nr_out - bio_sgl_holes(bsgl);
+
+		D_ALLOC_ARRAY(map->iom_recxs, map->iom_nr);
+		if (map->iom_recxs == NULL) {
+			for (r = 0; r < i; r++)
+				D_FREE(maps[r].iom_recxs);
+			D_FREE(maps);
+			return -DER_NOMEM;
+		}
+
+		map->iom_size = iod->iod_size;
+		map->iom_type = iod->iod_type;
+
+		if (map->iom_type != DAOS_IOD_ARRAY || bsgl->bs_nr_out == 0)
+			continue;
+
+		/** start rec_idx at first record of iod.recxs */
+		bsgl_iov_idx = 0;
+		for (r = 0; r < iod->iod_nr; r++) {
+			daos_recx_t recx = iod->iod_recxs[r];
+
+			D_DEBUG(DB_CSUM, "processing recx[%d]: "DF_RECX"\n",
+				r, DP_RECX(recx));
+			rec_idx = recx.rx_idx;
+
+			while (rec_idx <= recx.rx_idx + recx.rx_nr - 1) {
+				biov = bio_sgl_iov(bsgl, bsgl_iov_idx);
+				if (biov == NULL) /** reached end of bsgl */
+					break;
+				if (!bio_addr_is_hole(&biov->bi_addr))
+					map_add_recx(map, biov, rec_idx);
+
+				rec_idx += (bio_iov2req_len(biov) /
+					    map->iom_size);
+				bsgl_iov_idx++;
+			}
+		}
+
+		daos_iom_sort(map);
+
+		/** allocated and used should be the same */
+		D_ASSERTF(map->iom_nr == map->iom_nr_out,
+			  "map->iom_nr(%d) == map->iom_nr_out(%d)",
+			  map->iom_nr, map->iom_nr_out);
+		map->iom_recx_lo = map->iom_recxs[0];
+		map->iom_recx_hi = map->iom_recxs[map->iom_nr - 1];
+		if (flags & ORF_CREATE_MAP_DETAIL)
+			map->iom_flags = DAOS_IOMF_DETAIL;
+	}
+	if (p_maps != NULL)
+		*p_maps = maps;
+
+	return 0;
+}
+
+void
+ds_iom_free(daos_iom_t **p_maps, uint64_t map_nr)
+{
+	daos_iom_t	*maps = *p_maps;
+	int		 i;
+
+	for (i = 0; i < map_nr; i++)
+		D_FREE(maps[i].iom_recxs);
+
+	D_FREE(*p_maps);
+}

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -195,10 +195,7 @@ obj_rw_reply(crt_rpc_t *rpc, int status, uint64_t epoch,
 		}
 
 		if (orwo->orw_maps.ca_arrays != NULL) {
-			for (i = 0; i < orwo->orw_maps.ca_count; i++)
-				D_FREE(orwo->orw_maps.ca_arrays[i].iom_recxs);
-
-			D_FREE(orwo->orw_maps.ca_arrays);
+			ds_iom_free(&orwo->orw_maps.ca_arrays, orwo->orw_maps.ca_count);
 			orwo->orw_maps.ca_count = 0;
 		}
 
@@ -1032,14 +1029,10 @@ obj_log_csum_err(void)
 	bio_log_csum_err(bxc);
 }
 
-static void
-map_add_recx(daos_iom_t *map, const struct bio_iov *biov, uint64_t rec_idx)
-{
-	map->iom_recxs[map->iom_nr_out].rx_idx = rec_idx;
-	map->iom_recxs[map->iom_nr_out].rx_nr = bio_iov2req_len(biov)
-						/ map->iom_size;
-	map->iom_nr_out++;
-}
+/**
+ * Create maps for actually written to extents.
+ * Memory allocated here will be freed in obj_rw_reply.
+ */
 
 /** create maps for actually written to extents. */
 static int
@@ -1048,14 +1041,9 @@ obj_fetch_create_maps(crt_rpc_t *rpc, struct bio_desc *biod, daos_iod_t *iods)
 	struct obj_rw_in	*orw = crt_req_get(rpc);
 	struct obj_rw_out	*orwo = crt_reply_get(rpc);
 	daos_iom_t		*maps;
-	daos_iom_t		*map;
-	struct bio_sglist	*bsgl;
-	daos_iod_t		*iod;
-	struct bio_iov		*biov;
+	uint32_t		 flags = orw->orw_flags;
 	uint32_t		 iods_nr;
-	uint32_t		 i, r;
-	uint64_t		 rec_idx;
-	uint32_t		 bsgl_iov_idx;
+	int rc;
 
 	/**
 	 * Allocate memory for the maps. There will be 1 per iod
@@ -1069,64 +1057,9 @@ obj_fetch_create_maps(crt_rpc_t *rpc, struct bio_desc *biod, daos_iod_t *iods)
 		return 0;
 	}
 
-	D_ALLOC_ARRAY(maps, iods_nr);
-	if (maps == NULL)
-		return -DER_NOMEM;
-	for (i = 0; i <  iods_nr; i++) {
-		bsgl = bio_iod_sgl(biod, i); /** 1 bsgl per iod */
-		iod = &iods[i];
-		map = &maps[i];
-		map->iom_nr = bsgl->bs_nr_out - bio_sgl_holes(bsgl);
-
-		/** will be freed in obj_rw_reply */
-		D_ALLOC_ARRAY(map->iom_recxs, map->iom_nr);
-		if (map->iom_recxs == NULL) {
-			for (r = 0; r < i; r++)
-				D_FREE(maps[r].iom_recxs);
-			D_FREE(maps);
-			return -DER_NOMEM;
-		}
-
-		map->iom_size = iod->iod_size;
-		map->iom_type = iod->iod_type;
-
-		if (map->iom_type != DAOS_IOD_ARRAY ||
-			bsgl->bs_nr_out == 0)
-			continue;
-
-		/** start rec_idx at first record of iod.recxs */
-		bsgl_iov_idx = 0;
-		for (r = 0; r < iod->iod_nr; r++) {
-			daos_recx_t recx = iod->iod_recxs[r];
-
-			D_DEBUG(DB_CSUM, "processing recx[%d]: "DF_RECX"\n",
-				r, DP_RECX(recx));
-			rec_idx = recx.rx_idx;
-
-			while (rec_idx <= recx.rx_idx + recx.rx_nr - 1) {
-				biov = bio_sgl_iov(bsgl, bsgl_iov_idx);
-				if (biov == NULL) /** reached end of bsgl */
-					break;
-				if (!bio_addr_is_hole(&biov->bi_addr))
-					map_add_recx(map, biov, rec_idx);
-
-				rec_idx += (bio_iov2req_len(biov) /
-					    map->iom_size);
-				bsgl_iov_idx++;
-			}
-		}
-
-		daos_iom_sort(map);
-
-		/** allocated and used should be the same */
-		D_ASSERTF(map->iom_nr == map->iom_nr_out,
-			  "map->iom_nr(%d) == map->iom_nr_out(%d)",
-			  map->iom_nr, map->iom_nr_out);
-		map->iom_recx_lo = map->iom_recxs[0];
-		map->iom_recx_hi = map->iom_recxs[map->iom_nr - 1];
-		if (orw->orw_flags & ORF_CREATE_MAP_DETAIL)
-			map->iom_flags = DAOS_IOMF_DETAIL;
-	}
+	rc = ds_iom_create(biod, iods, iods_nr, flags, &maps);
+	if (rc != 0)
+		return rc;
 
 	orwo->orw_maps.ca_count = iods_nr;
 	orwo->orw_maps.ca_arrays = maps;

--- a/src/vos/tests/SConscript
+++ b/src/vos/tests/SConscript
@@ -13,11 +13,13 @@ def scons():
 
     # Add runtime paths for daos libraries
     denv.AppendUnique(RPATH_FULL=['$PREFIX/lib64/daos_srv'])
+    denv.Append(OBJPREFIX="b_")
 
     vos_test_src = ['vos_tests.c', 'vts_io.c', 'vts_pool.c', 'vts_container.c',
                     denv.Object("vts_common.c"), 'vts_aggregate.c', 'vts_dtx.c',
                     'vts_gc.c', 'vts_checksum.c', 'vts_ilog.c', 'vts_array.c',
-                    'vts_pm.c', 'vts_ts.c', 'vts_mvcc.c']
+                    'vts_pm.c', 'vts_ts.c', 'vts_mvcc.c',
+                    '../../object/srv_csum.c', '../../object/srv_io_map.c']
     vos_tests = daos_build.program(denv, 'vos_tests', vos_test_src,
                                    LIBS=libraries)
     denv.AppendUnique(CPPPATH=["../../common/tests"])

--- a/src/vos/tests/vos_tests.c
+++ b/src/vos/tests/vos_tests.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2021 Intel Corporation.
+ * (C) Copyright 2016-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -22,6 +22,9 @@
 #include <daos_srv/vos.h>
 #include <vos_internal.h>
 
+#define		FORCE_CSUM 0x1001
+#define		FORCE_NO_ZERO_COPY 0x1002
+
 static void
 print_usage()
 {
@@ -37,13 +40,16 @@ print_usage()
 	print_message("vos_tests -l|--incarnation-log-tests\n");
 	print_message("vos_tests -z|--csum_tests\n");
 	print_message("vos_tests -A|--all_tests\n");
-	print_message("vos_tests -f|--filter <filter>\n");
-	print_message("vos_tests -e|--exclude <filter>\n");
 	print_message("vos_tests -m|--punch-model-tests\n");
 	print_message("vos_tests -C|--mvcc-tests\n");
 	print_message("-S|--storage <storage path>\n");
 	print_message("vos_tests -h|--help\n");
 	print_message("Default <vos_tests> runs all tests\n");
+	print_message("The following options can be used with any of the above:\n");
+	print_message("  -f|--filter <filter>\n");
+	print_message("  -e|--exclude <filter>\n");
+	print_message("  --force_checksum\n");
+	print_message("  --force_no_zero_copy\n");
 }
 
 static int dkey_feats[] = {
@@ -136,6 +142,9 @@ main(int argc, char **argv)
 		{"filter",		required_argument, 0, 'f'},
 		{"exclude",		required_argument, 0, 'e'},
 		{"storage",		required_argument, 0, 'S'},
+		{"force_csum",		no_argument, 0, FORCE_CSUM},
+		{"force_no_zero_copy",	no_argument, 0, FORCE_NO_ZERO_COPY},
+		{NULL},
 	};
 
 	d_register_alt_assert(mock_assert);
@@ -184,6 +193,12 @@ main(int argc, char **argv)
 #else
 			D_PRINT("filter not enabled");
 #endif
+			break;
+		case FORCE_CSUM:
+			g_force_checksum = true;
+			break;
+		case FORCE_NO_ZERO_COPY:
+			g_force_no_zero_copy = true;
 			break;
 		default:
 			break;
@@ -269,6 +284,8 @@ main(int argc, char **argv)
 		case 'S':
 		case 'f':
 		case 'e':
+		case FORCE_CSUM:
+		case FORCE_NO_ZERO_COPY:
 			/** already handled */
 			break;
 		default:

--- a/src/vos/tests/vts_aggregate.c
+++ b/src/vos/tests/vts_aggregate.c
@@ -269,7 +269,7 @@ generate_view(struct io_test_args *arg, daos_unit_oid_t oid, char *dkey,
 	epr_a = &ds->td_agg_epr;
 	view_len = get_view_len(ds, &recx);
 
-	VERBOSE_MSG("Generate logcial view: OID:"DF_UOID", DKEY:%s, AKEY:%s, "
+	VERBOSE_MSG("Generate logical view: OID:"DF_UOID", DKEY:%s, AKEY:%s, "
 		    "U_ERP:["DF_U64", "DF_U64"], A_EPR["DF_U64", "DF_U64"], "
 		    "discard:%d, expected_nr:%d\n", DP_UOID(oid), dkey, akey,
 		    epr_u->epr_lo, epr_u->epr_hi, epr_a->epr_lo, epr_a->epr_hi,
@@ -369,7 +369,7 @@ aggregate_basic_lb(struct io_test_args *arg, struct agg_tst_dataset *ds, int pun
 	char			*buf_u;
 	daos_recx_t		 recx = { 0 }, *recx_p;
 	daos_size_t		 view_len;
-	int			 punch_idx = 0, recx_idx = 0, rc;
+	int			 punch_idx = 0, recx_idx = 0, rc = 0;
 	int			 punch_or_delete = TF_PUNCH;
 
 	if (ds->td_delete)
@@ -1946,7 +1946,8 @@ aggregate_14(void **state)
 		epr.epr_hi = epc_hi;
 		rc = vos_aggregate(arg->ctx.tc_co_hdl, &epr, NULL, NULL, 0);
 		if (rc) {
-			print_error("aggregate %d failed:%d\n", i, rc);
+			print_error("aggregate %d failed: "DF_RC"\n", i,
+				    DP_RC(rc));
 			break;
 		}
 

--- a/src/vos/tests/vts_common.h
+++ b/src/vos/tests/vts_common.h
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2021 Intel Corporation.
+ * (C) Copyright 2016-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -46,6 +46,8 @@
 #define STORAGE_PATH_LEN 96
 extern char	vos_path[STORAGE_PATH_LEN+1];
 extern int	gc;
+extern bool	g_force_checksum;
+extern bool	g_force_no_zero_copy;
 
 enum vts_ops_type {
 	CREAT,

--- a/src/vos/tests/vts_io.c
+++ b/src/vos/tests/vts_io.c
@@ -15,6 +15,7 @@
 #include "vts_io.h"
 #include <daos_api.h>
 #include <daos/checksum.h>
+#include <daos_srv/srv_csum.h>
 #include "vts_array.h"
 #include <linux/limits.h>
 
@@ -212,6 +213,8 @@ test_args_reset(struct io_test_args *args, uint64_t pool_size)
 }
 
 static struct io_test_args	test_args;
+bool				g_force_checksum;
+bool				g_force_no_zero_copy;
 
 int
 setup_io(void **state)
@@ -520,18 +523,28 @@ io_obj_iter_test(struct io_test_args *arg, daos_epoch_range_t *epr,
 	return rc;
 }
 
+static struct daos_csummer *
+io_test_init_csummer()
+{
+	enum DAOS_HASH_TYPE	 type = HASH_TYPE_CRC16;
+	size_t			 chunk_size = 1 << 12;
+	struct daos_csummer	*csummer = NULL;
+
+	assert_success(daos_csummer_init_with_type(&csummer, type,
+						   chunk_size, 0));
+
+	return csummer;
+
+}
+
 static int
 io_test_add_csums(daos_iod_t *iod, d_sg_list_t *sgl,
 		  struct daos_csummer **p_csummer,
 		  struct dcs_iod_csums **p_iod_csums)
 {
-	enum DAOS_HASH_TYPE	 type = HASH_TYPE_CRC64;
-	size_t			 chunk_size = 1 << 12;
-	int			 rc = 0;
+	int rc = 0;
 
-	rc = daos_csummer_init_with_type(p_csummer, type, chunk_size, 0);
-	if (rc)
-		return rc;
+	*p_csummer = io_test_init_csummer();
 	rc = daos_csummer_calc_iods(*p_csummer, sgl, iod, NULL, 1, false,
 				    NULL, 0, p_iod_csums);
 	if (rc)
@@ -550,7 +563,10 @@ io_test_obj_update(struct io_test_args *arg, daos_epoch_t epoch, uint64_t flags,
 	d_iov_t			*srv_iov;
 	daos_epoch_range_t	 epr = {arg->epr_lo, epoch};
 	daos_handle_t		 ioh;
+	bool			 use_checksums;
 	int			 rc = 0;
+
+	use_checksums = arg->ta_flags & TF_USE_CSUMS || g_force_checksum;
 
 	if (arg->ta_flags & TF_DELETE) {
 		rc = vos_obj_array_remove(arg->ctx.tc_co_hdl, arg->oid, &epr,
@@ -558,8 +574,7 @@ io_test_obj_update(struct io_test_args *arg, daos_epoch_t epoch, uint64_t flags,
 					  &iod->iod_recxs[0]);
 		return rc;
 	}
-
-	if ((arg->ta_flags & TF_USE_CSUMS) && iod->iod_size > 0) {
+	if (use_checksums && iod->iod_size > 0) {
 		rc = io_test_add_csums(iod, sgl, &csummer, &iod_csums);
 		if (rc != 0)
 			return rc;
@@ -612,11 +627,78 @@ end:
 	if (rc != 0 && verbose && rc != -DER_INPROGRESS &&
 		(arg->ta_flags & TF_ZERO_COPY))
 		print_error("Failed to submit ZC update: "DF_RC"\n", DP_RC(rc));
-	if ((arg->ta_flags & TF_USE_CSUMS) && iod->iod_size > 0) {
+	if (use_checksums && iod->iod_size > 0) {
 		daos_csummer_free_ic(csummer, &iod_csums);
 		daos_csummer_destroy(&csummer);
 	}
 
+	return rc;
+}
+
+static int
+io_test_vos_obj_fetch(daos_handle_t coh, daos_unit_oid_t oid, daos_epoch_t epoch, uint64_t flags,
+		      daos_key_t *dkey,  daos_iod_t *iod, d_sg_list_t *sgl, bool use_checksums)
+{
+	daos_handle_t	 ioh;
+	struct bio_desc *biod;
+	int		 rc;
+
+	rc = vos_fetch_begin(coh, oid, epoch, dkey, 1, iod, flags, NULL, &ioh, NULL);
+	assert_success(rc);
+
+	biod = vos_ioh2desc(ioh);
+	rc = bio_iod_prep(biod, BIO_CHK_TYPE_IO, NULL, CRT_BULK_RW);
+	assert_success(rc);
+
+	biod = vos_ioh2desc(ioh);
+	rc = bio_iod_copy(biod, sgl, 1);
+	assert_success(rc);
+
+	if (use_checksums) {
+		struct dcs_csum_info	*csum_infos = vos_ioh2ci(ioh);
+		struct dcs_iod_csums	*iod_csums = NULL;
+		struct daos_csummer	*csummer;
+		daos_iom_t		*maps = NULL;
+
+		csummer = io_test_init_csummer();
+
+		rc = daos_csummer_alloc_iods_csums(csummer, iod, 1, false, NULL, &iod_csums);
+
+		if (rc < DER_SUCCESS) {
+			daos_csummer_destroy(&csummer);
+			fail_msg("daos_csummer_alloc_iods_csums failed. "DF_RC"\n", DP_RC(rc));
+		}
+
+		rc = ds_csum_add2iod(iod, csummer, bio_iod_sgl(biod, 0),
+				     &csum_infos[0], NULL, iod_csums);
+		if (rc != DER_SUCCESS) {
+			daos_csummer_free_ic(csummer, &iod_csums);
+			daos_csummer_destroy(&csummer);
+			fail_msg("ds_csum_add2iod failed. "DF_RC"\n", DP_RC(rc));
+		}
+
+
+		rc = ds_iom_create(biod, iod, 1, 0, &maps);
+		if (rc != DER_SUCCESS) {
+			daos_csummer_free_ic(csummer, &iod_csums);
+			daos_csummer_destroy(&csummer);
+			fail_msg("ds_iom_create failed. "DF_RC"\n", DP_RC(rc));
+		}
+
+		rc = daos_csummer_verify_iod(csummer, iod, sgl, iod_csums, NULL, -1, maps);
+		if (rc != DER_SUCCESS)
+			print_error("ds_csum_add2iod failed. "DF_RC"\n", DP_RC(rc));
+
+		daos_csummer_free_ic(csummer, &iod_csums);
+		daos_csummer_destroy(&csummer);
+		ds_iom_free(&maps, 1);
+	}
+
+	rc = bio_iod_post(biod, rc);
+	assert_success(rc);
+
+	rc = vos_fetch_end(ioh, NULL, rc);
+	assert_success(rc);
 	return rc;
 }
 
@@ -632,11 +714,13 @@ io_test_obj_fetch(struct io_test_args *arg, daos_epoch_t epoch, uint64_t flags,
 	unsigned int		 off;
 	int			 i;
 	int			 rc;
+	bool			 use_checksums;
 
-	if (!(arg->ta_flags & TF_ZERO_COPY)) {
-		rc = vos_obj_fetch(arg->ctx.tc_co_hdl,
-				   arg->oid, epoch, flags, dkey, 1, iod,
-				   sgl);
+	use_checksums = arg->ta_flags & TF_USE_CSUMS || g_force_checksum;
+
+	if (!(arg->ta_flags & TF_ZERO_COPY) || g_force_no_zero_copy) {
+		rc = io_test_vos_obj_fetch(arg->ctx.tc_co_hdl, arg->oid, epoch, flags,
+					   dkey, iod, sgl, use_checksums);
 		if (rc != 0 && verbose)
 			print_error("Failed to fetch: "DF_RC"\n", DP_RC(rc));
 		return rc;


### PR DESCRIPTION
Added the ability to run VOS tests with checksums. The test, acting
as the client, is responsible for calculating the checksums on an
update and verifying the checksums on a fetch. While running the
VOS aggregation tests with checksums a few issues were discovered
and fixed.
- Previously, while inserting segments, the phy_ent's csum was
  updated to the truncated ent_int, however, it pointed to the
  ent_in's csum buffer instead of copying the checksum into its own
  buffer. Updated it to memcpy now. The phy_ent's csum buffer should
  always be big enough.
- In some cases, while adding checksums from raw extents for the
  requested extents, the holes weren't managed correctly and
  which could cause the incorrect checksum to be added for a
  chunk. This would result in a false positive checksum error.

Signed-off-by: Ryon Jensen <ryon.jensen@intel.com>