### PR TITLE
DAOS-8942 test: Reduce logging of aggregation/shutdown_restart

### DIFF
--- a/src/tests/ftest/aggregation/shutdown_restart.yaml
+++ b/src/tests/ftest/aggregation/shutdown_restart.yaml
@@ -9,7 +9,7 @@ timeout: 600
 server_config:
   name: daos_server
   servers:
-    log_mask: INFO
+    log_mask: ERR
     bdev_class: nvme
     bdev_list: ["aaaa:aa:aa.a","bbbb:bb:bb.b"]
 pool:


### PR DESCRIPTION
Avoid cart_logtest.py error by reducing the server log size generated by
the aggregation/shutdown_restart.py test.

Skip-unit-tests: true
Test-tag: ioaggregation

Signed-off-by: Phillip Henderson <phillip.henderson@intel.com>