### PR TITLE
DAOS-9730 test: Always run nvme/fragmentation.py on verbs

### DIFF
--- a/src/tests/ftest/nvme/fragmentation.py
+++ b/src/tests/ftest/nvme/fragmentation.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 """
-  (C) Copyright 2020-2021 Intel Corporation.
+  (C) Copyright 2020-2022 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -132,7 +132,7 @@ class NvmeFragmentation(TestWithServers):
         not to fail with NO ENOM SPAC.
 
         :avocado: tags=all,full_regression
-        :avocado: tags=hw,medium
+        :avocado: tags=hw,large
         :avocado: tags=nvme,ib2,nvme_fragmentation
         """
         no_of_jobs = self.params.get("no_parallel_job", '/run/ior/*')


### PR DESCRIPTION
Run the nvme/fragmentation.py test on the HW Large cluster to ensure it
is always run with verbs.

Skip-unit-tests: true
Test-tag: nvme_fragmentation
Test-repeat: 5

Signed-off-by: Phillip Henderson <phillip.henderson@intel.com>