### PR TITLE
DAOS-9355 doc: set up doc-watchers in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -25,6 +25,6 @@ src/include/daos_*.* @daos-stack/client-api-watchers
 mkdocs.yml @daos-stack/doc-watchers
 Doxyfile @daos-stack/doc-watchers
 docs/ @daos-stack/doc-watchers
-src/include/ @daos-stack/doc-watchers
+src/include/*.h @daos-stack/doc-watchers
 *.md @daos-stack/doc-watchers
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -20,3 +20,11 @@ Jenkinsfile @daos-stack/build-and-release-watchers
 # any PR that touches client API or high level client code
 src/client @daos-stack/client-api-watchers
 src/include/daos_*.* @daos-stack/client-api-watchers
+
+# doc-watchers: files affecting documentation (docs, doxygen, etc.)
+mkdocs.yml @daos-stack/doc-watchers
+Doxyfile @daos-stack/doc-watchers
+docs/ @daos-stack/doc-watchers
+src/include/ @daos-stack/doc-watchers
+*.md @daos-stack/doc-watchers
+


### PR DESCRIPTION
set up doc-watchers in CODEOWNERS

Skip-build: true
Skip-test: true
Signed-off-by: Michael Hennecke <michael.hennecke@intel.com>