### PR TITLE
DAOS-9570 Test: Removing skip for test cases.

### DIFF
--- a/src/tests/ftest/erasurecode/multiple_failure.py
+++ b/src/tests/ftest/erasurecode/multiple_failure.py
@@ -5,7 +5,6 @@
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
 from ec_utils import ErasureCodeIor
-from apricot import skipForTicket
 
 class EcodOnlineMultFail(ErasureCodeIor):
     # pylint: disable=too-many-ancestors
@@ -20,7 +19,6 @@ class EcodOnlineMultFail(ErasureCodeIor):
         super().__init__(*args, **kwargs)
         self.set_online_rebuild = True
 
-    @skipForTicket("DAOS-9051")
     def run_ior_cascade_failure(self):
         """Common function to Write and Read IOR"""
         # Write IOR data set with different EC object. kill rank, targets or mix of both while IOR
@@ -35,7 +33,6 @@ class EcodOnlineMultFail(ErasureCodeIor):
         # intact and no data corruption observed.
         self.ior_read_dataset(parity=2)
 
-    @skipForTicket("DAOS-9051")
     def test_ec_multiple_rank_failure(self):
         """Jira ID: DAOS-7344.
 
@@ -88,7 +85,6 @@ class EcodOnlineMultFail(ErasureCodeIor):
         self.pool_exclude[3] = "3"
         self.run_ior_cascade_failure()
 
-    @skipForTicket("DAOS-9051")
     def test_ec_single_target_rank_failure(self):
         """Jira ID: DAOS-7344.
 

--- a/src/tests/ftest/erasurecode/multiple_failure.yaml
+++ b/src/tests/ftest/erasurecode/multiple_failure.yaml
@@ -63,7 +63,7 @@ ior:
   sizes: !mux
      Full_Striped:
        chunk_block_transfer_sizes:
-        - [32M, 8G, 8M]
+        - [32M, 24G, 8M]
      Partial_Striped:
        chunk_block_transfer_sizes:
         - [32M, 512M, 2K]


### PR DESCRIPTION
Picked the PR#8134 fix.
Updated the code to check if thread is alive before join().
Removed the skip for running the tests in Ci.

Quick-Functional: true
Test-tag: pr ec_multiple_failure

Signed-off-by: Samir Raval <samir.raval@intel.com>