### PR TITLE
DAOS-9829 dtx: keep active DTX entry when close container

### DIFF
--- a/src/container/srv_target.c
+++ b/src/container/srv_target.c
@@ -1409,6 +1409,7 @@ ds_cont_local_open(uuid_t pool_uuid, uuid_t cont_hdl_uuid, uuid_t cont_uuid,
 	uuid_copy(hdl->sch_uuid, cont_hdl_uuid);
 	hdl->sch_flags = flags;
 	hdl->sch_sec_capas = sec_capas;
+	hdl->sch_closed = 0;
 
 	rc = cont_hdl_add(&tls->dt_cont_hdl_hash, hdl);
 	if (rc != 0)
@@ -1620,6 +1621,7 @@ cont_close_hdl(uuid_t cont_hdl_uuid)
 	/* Remove the handle from hash first, following steps may yield */
 	ds_cont_local_close(cont_hdl_uuid);
 
+	hdl->sch_closed = 1;
 	cont_child = hdl->sch_cont;
 	if (cont_child != NULL) {
 		D_DEBUG(DF_DSMS, DF_CONT": closing (%d): hdl="DF_UUID"\n",

--- a/src/dtx/dtx_common.c
+++ b/src/dtx/dtx_common.c
@@ -1046,9 +1046,9 @@ dtx_leader_wait(struct dtx_leader_handle *dlh)
  * \return			Zero on success, negative value if error.
  */
 int
-dtx_leader_end(struct dtx_leader_handle *dlh, struct ds_cont_child *cont,
-	       int result)
+dtx_leader_end(struct dtx_leader_handle *dlh, struct ds_cont_hdl *coh, int result)
 {
+	struct ds_cont_child		*cont = coh->sch_cont;
 	struct dtx_handle		*dth = &dlh->dlh_handle;
 	struct dtx_entry		*dte;
 	struct dtx_memberships		*mbs;
@@ -1075,6 +1075,12 @@ dtx_leader_end(struct dtx_leader_handle *dlh, struct ds_cont_child *cont,
 
 	if (unlikely(result == -DER_ALREADY))
 		result = 0;
+
+	if (result == 0 && rc == 0 && unlikely(coh->sch_closed)) {
+		D_ERROR("Cont hdl "DF_UUID" is closed/evicted unexpectedly\n",
+			DP_UUID(coh->sch_uuid));
+		result = -DER_IO;
+	}
 
 	if (daos_is_zero_dti(&dth->dth_xid))
 		D_GOTO(out, result = result < 0 ? result : rc);
@@ -1686,7 +1692,7 @@ dtx_cont_close(struct ds_cont_child *cont)
 				 * then reset DTX table in VOS to release related resources.
 				 */
 				if (!dtx_cont_opened(cont))
-					vos_dtx_cache_reset(cont->sc_hdl);
+					vos_dtx_cache_reset(cont->sc_hdl, false);
 				return;
 			}
 		}

--- a/src/dtx/dtx_resync.c
+++ b/src/dtx/dtx_resync.c
@@ -591,7 +591,7 @@ dtx_resync(daos_handle_t po_hdl, uuid_t po_uuid, uuid_t co_uuid, uint32_t ver,
 		uint64_t	hint = 0;
 
 		dss_set_start_epoch();
-		vos_dtx_cache_reset(cont->sc_hdl);
+		vos_dtx_cache_reset(cont->sc_hdl, true);
 
 		while (1) {
 			rc = vos_dtx_cmt_reindex(cont->sc_hdl, &hint);

--- a/src/include/daos_srv/container.h
+++ b/src/include/daos_srv/container.h
@@ -153,6 +153,7 @@ struct ds_cont_hdl {
 	uint64_t		sch_sec_capas;	/* access control capas */
 	struct ds_cont_child	*sch_cont;
 	int32_t			sch_ref;
+	uint32_t		sch_closed:1;
 };
 
 struct ds_cont_hdl *ds_cont_hdl_lookup(const uuid_t uuid);

--- a/src/include/daos_srv/dtx_srv.h
+++ b/src/include/daos_srv/dtx_srv.h
@@ -208,8 +208,7 @@ dtx_leader_begin(daos_handle_t coh, struct dtx_id *dti,
 		 struct daos_shard_tgt *tgts, int tgt_cnt, uint32_t flags,
 		 struct dtx_memberships *mbs, struct dtx_leader_handle **p_dlh);
 int
-dtx_leader_end(struct dtx_leader_handle *dlh, struct ds_cont_child *cont,
-	       int result);
+dtx_leader_end(struct dtx_leader_handle *dlh, struct ds_cont_hdl *coh, int result);
 
 typedef void (*dtx_sub_comp_cb_t)(struct dtx_leader_handle *dlh, int idx,
 				  int rc);

--- a/src/include/daos_srv/vos.h
+++ b/src/include/daos_srv/vos.h
@@ -200,11 +200,12 @@ vos_dtx_cleanup(struct dtx_handle *dth);
  * Reset DTX related cached information in VOS.
  *
  * \param coh	[IN]	Container open handle.
+ * \param force	[IN]	Reset all DTX tables by force.
  *
  * \return	Zero on success, negative value if error.
  */
 int
-vos_dtx_cache_reset(daos_handle_t coh);
+vos_dtx_cache_reset(daos_handle_t coh, bool force);
 
 /**
  * Initialize the environment for a VOS instance

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -472,7 +472,7 @@ static int
 obj_bulk_transfer(crt_rpc_t *rpc, crt_bulk_op_t bulk_op, bool bulk_bind,
 		  crt_bulk_t *remote_bulks, uint64_t *remote_offs,
 		  daos_handle_t ioh, d_sg_list_t **sgls, int sgl_nr,
-		  struct obj_bulk_args *p_arg)
+		  struct obj_bulk_args *p_arg, struct ds_cont_hdl *coh)
 {
 	struct obj_bulk_args	arg = { 0 };
 	int			i, rc, *status, ret;
@@ -547,6 +547,13 @@ done:
 		rc = ret ? dss_abterr2der(ret) : *status;
 
 	ABT_eventual_free(&p_arg->eventual);
+
+	if (rc == 0 && coh != NULL && unlikely(coh->sch_closed)) {
+		D_ERROR("Cont hdl "DF_UUID" is closed/evicted unexpectedly\n",
+			DP_UUID(coh->sch_uuid));
+		rc = -DER_IO;
+	}
+
 	/* After RDMA is done, corrupt the server data */
 	if (DAOS_FAIL_CHECK(DAOS_CSUM_CORRUPT_DISK)) {
 		struct bio_sglist	*fbsgl;
@@ -774,7 +781,7 @@ obj_echo_rw(crt_rpc_t *rpc, daos_iod_t *split_iods, uint64_t *split_offs)
 	bulk_bind = orw->orw_flags & ORF_BULK_BIND;
 	rc = obj_bulk_transfer(rpc, bulk_op, bulk_bind,
 			       orw->orw_bulks.ca_arrays, off,
-			       DAOS_HDL_INVAL, &p_sgl, orw->orw_nr, NULL);
+			       DAOS_HDL_INVAL, &p_sgl, orw->orw_nr, NULL, NULL);
 out:
 	orwo->orw_ret = rc;
 	orwo->orw_map_version = orw->orw_map_ver;
@@ -1586,7 +1593,7 @@ obj_local_rw_internal(crt_rpc_t *rpc, struct obj_io_context *ioc,
 		bulk_bind = orw->orw_flags & ORF_BULK_BIND;
 		rc = obj_bulk_transfer(rpc, bulk_op, bulk_bind,
 				       orw->orw_bulks.ca_arrays, offs,
-				       ioh, NULL, orw->orw_nr, NULL);
+				       ioh, NULL, orw->orw_nr, NULL, ioc->ioc_coh);
 		if (rc == 0) {
 			bio_iod_flush(biod);
 
@@ -2105,7 +2112,7 @@ ds_obj_ec_rep_handler(crt_rpc_t *rpc)
 		goto end;
 	}
 	rc = obj_bulk_transfer(rpc, CRT_BULK_PUT, false, &oer->er_bulk, NULL,
-			       ioh, NULL, 1, NULL);
+			       ioh, NULL, 1, NULL, ioc.ioc_coh);
 	if (rc)
 		D_ERROR(DF_UOID" bulk transfer failed: "DF_RC".\n",
 			DP_UOID(oer->er_oid), DP_RC(rc));
@@ -2186,7 +2193,7 @@ ds_obj_ec_agg_handler(crt_rpc_t *rpc)
 			goto end;
 		}
 		rc = obj_bulk_transfer(rpc, CRT_BULK_GET, false, &oea->ea_bulk,
-				       NULL, ioh, NULL, 1, NULL);
+				       NULL, ioh, NULL, 1, NULL, ioc.ioc_coh);
 		if (rc)
 			D_ERROR(DF_UOID" bulk transfer failed: "DF_RC".\n",
 				DP_UOID(oea->ea_oid), DP_RC(rc));
@@ -2681,7 +2688,7 @@ again2:
 	rc = dtx_leader_exec_ops(dlh, obj_tgt_update, NULL, NULL, &exec_arg);
 
 	/* Stop the distributed transaction */
-	rc = dtx_leader_end(dlh, ioc.ioc_coc, rc);
+	rc = dtx_leader_end(dlh, ioc.ioc_coh, rc);
 	switch (rc) {
 	case -DER_TX_RESTART:
 		/*
@@ -3011,7 +3018,7 @@ obj_enum_reply_bulk(crt_rpc_t *rpc)
 		return 0;
 
 	rc = obj_bulk_transfer(rpc, CRT_BULK_PUT, false, bulks, NULL,
-			       DAOS_HDL_INVAL, sgls, idx, NULL);
+			       DAOS_HDL_INVAL, sgls, idx, NULL, NULL);
 	if (oei->oei_kds_bulk) {
 		D_FREE(oeo->oeo_kds.ca_arrays);
 		oeo->oeo_kds.ca_count = 0;
@@ -3565,7 +3572,7 @@ again2:
 				 &opi->opi_api_flags, &exec_arg);
 
 	/* Stop the distribute transaction */
-	rc = dtx_leader_end(dlh, ioc.ioc_coc, rc);
+	rc = dtx_leader_end(dlh, ioc.ioc_coh, rc);
 	switch (rc) {
 	case -DER_TX_RESTART:
 		/*
@@ -4021,7 +4028,7 @@ ds_cpd_handle_one(crt_rpc_t *rpc, struct daos_cpd_sub_head *dcsh,
 
 			rc = obj_bulk_transfer(rpc, CRT_BULK_GET,
 				dcu->dcu_flags & ORF_BULK_BIND, dcu->dcu_bulks,
-				offs, iohs[i], NULL, dcsr->dcsr_nr, &bulks[i]);
+				offs, iohs[i], NULL, dcsr->dcsr_nr, &bulks[i], ioc->ioc_coh);
 			if (rc != 0) {
 				D_ERROR("Bulk transfer failed for obj "
 					DF_UOID", DTX "DF_DTI": "DF_RC"\n",
@@ -4580,7 +4587,7 @@ again:
 	rc = dtx_leader_exec_ops(dlh, obj_obj_dtx_leader, NULL, NULL, &exec_arg);
 
 	/* Stop the distribute transaction */
-	rc = dtx_leader_end(dlh, dca->dca_ioc->ioc_coc, rc);
+	rc = dtx_leader_end(dlh, dca->dca_ioc->ioc_coh, rc);
 
 out:
 	D_CDEBUG(rc != 0 && rc != -DER_INPROGRESS && rc != -DER_TX_RESTART &&

--- a/src/vos/vos_dtx.c
+++ b/src/vos/vos_dtx.c
@@ -2873,7 +2873,7 @@ vos_dtx_rsrvd_fini(struct dtx_handle *dth)
 }
 
 int
-vos_dtx_cache_reset(daos_handle_t coh)
+vos_dtx_cache_reset(daos_handle_t coh, bool force)
 {
 	struct vos_container	*cont;
 	struct umem_attr	 uma;
@@ -2881,6 +2881,15 @@ vos_dtx_cache_reset(daos_handle_t coh)
 
 	cont = vos_hdl2cont(coh);
 	D_ASSERT(cont != NULL);
+
+	memset(&uma, 0, sizeof(uma));
+	uma.uma_id = UMEM_CLASS_VMEM;
+
+	if (!force) {
+		if (cont->vc_dtx_array)
+			lrua_array_aggregate(cont->vc_dtx_array);
+		goto cmt;
+	}
 
 	if (daos_handle_is_valid(cont->vc_dtx_active_hdl)) {
 		rc = dbtree_destroy(cont->vc_dtx_active_hdl, NULL);
@@ -2891,19 +2900,6 @@ vos_dtx_cache_reset(daos_handle_t coh)
 		}
 
 		cont->vc_dtx_active_hdl = DAOS_HDL_INVAL;
-	}
-
-	if (daos_handle_is_valid(cont->vc_dtx_committed_hdl)) {
-		rc = dbtree_destroy(cont->vc_dtx_committed_hdl, NULL);
-		if (rc != 0) {
-			D_ERROR("Failed to destroy committed DTX tree for "DF_UUID": "DF_RC"\n",
-				DP_UUID(cont->vc_id), DP_RC(rc));
-			return rc;
-		}
-
-		cont->vc_dtx_committed_hdl = DAOS_HDL_INVAL;
-		cont->vc_dtx_committed_count = 0;
-		cont->vc_cmt_dtx_indexed = 0;
 	}
 
 	if (cont->vc_dtx_array)
@@ -2917,9 +2913,6 @@ vos_dtx_cache_reset(daos_handle_t coh)
 		return rc;
 	}
 
-	memset(&uma, 0, sizeof(uma));
-	uma.uma_id = UMEM_CLASS_VMEM;
-
 	rc = dbtree_create_inplace_ex(VOS_BTR_DTX_ACT_TABLE, 0, DTX_BTREE_ORDER, &uma,
 				      &cont->vc_dtx_active_btr, DAOS_HDL_INVAL, cont,
 				      &cont->vc_dtx_active_hdl);
@@ -2929,18 +2922,32 @@ vos_dtx_cache_reset(daos_handle_t coh)
 		return rc;
 	}
 
+	rc = vos_dtx_act_reindex(cont);
+	if (rc != 0) {
+		D_ERROR("Fail to reindex active DTX table for "DF_UUID": "DF_RC"\n",
+			DP_UUID(cont->vc_id), DP_RC(rc));
+		return rc;
+	}
+
+cmt:
+	if (daos_handle_is_valid(cont->vc_dtx_committed_hdl)) {
+		rc = dbtree_destroy(cont->vc_dtx_committed_hdl, NULL);
+		if (rc != 0) {
+			D_ERROR("Failed to destroy committed DTX tree for "DF_UUID": "DF_RC"\n",
+				DP_UUID(cont->vc_id), DP_RC(rc));
+			return rc;
+		}
+
+		cont->vc_dtx_committed_hdl = DAOS_HDL_INVAL;
+		cont->vc_dtx_committed_count = 0;
+		cont->vc_cmt_dtx_indexed = 0;
+	}
+
 	rc = dbtree_create_inplace_ex(VOS_BTR_DTX_CMT_TABLE, 0, DTX_BTREE_ORDER, &uma,
 				      &cont->vc_dtx_committed_btr, DAOS_HDL_INVAL, cont,
 				      &cont->vc_dtx_committed_hdl);
 	if (rc != 0) {
 		D_ERROR("Failed to re-create DTX committed tree for "DF_UUID": "DF_RC"\n",
-			DP_UUID(cont->vc_id), DP_RC(rc));
-		return rc;
-	}
-
-	rc = vos_dtx_act_reindex(cont);
-	if (rc != 0) {
-		D_ERROR("Fail to reindex active DTX table for "DF_UUID": "DF_RC"\n",
 			DP_UUID(cont->vc_id), DP_RC(rc));
 		return rc;
 	}


### PR DESCRIPTION
Some IO requests may be still inflight when close the container
because of malicious or non-coordinated applications or evicted
by administrator by force. Those inflight IO requests may still
reference related active DTX entries that should be kept during
reset DTX tables when close the container.

On the other hand, the patch also adds some check for the cases
of container closed before IO requests completed.

Signed-off-by: Fan Yong <fan.yong@intel.com>