### PR TITLE
DAOS-9860 dtx: discard stale active DTX entries for reintegration

### DIFF
--- a/src/dtx/dtx_internal.h
+++ b/src/dtx/dtx_internal.h
@@ -55,6 +55,8 @@ enum dtx_operation {
 
 CRT_RPC_DECLARE(dtx, DAOS_ISEQ_DTX, DAOS_OSEQ_DTX);
 
+#define DTX_YIELD_CYCLE		(DTX_THRESHOLD_COUNT >> 3)
+
 /* The time threshold for triggerring DTX cleanup of stale entries.
  * If the oldest active DTX exceeds such threshold, it will trigger
  * DTX cleanup locally.

--- a/src/dtx/dtx_srv.c
+++ b/src/dtx/dtx_srv.c
@@ -17,8 +17,6 @@
 #include <gurt/telemetry_consumer.h>
 #include "dtx_internal.h"
 
-#define DTX_YIELD_CYCLE		(DTX_THRESHOLD_COUNT >> 3)
-
 static void *
 dtx_tls_init(int xs_id, int tgt_id)
 {

--- a/src/include/daos_srv/container.h
+++ b/src/include/daos_srv/container.h
@@ -122,6 +122,7 @@ struct ds_cont_child {
 	uint32_t		 sc_status_pm_ver;
 	/* flag of CONT_CAPA_READ_DATA/_WRITE_DATA disabled */
 	uint32_t		 sc_rw_disabled:1;
+	daos_epoch_t		 sc_migrate_epoch;
 };
 
 typedef uint64_t (*agg_param_get_eph_t)(struct ds_cont_child *cont);

--- a/src/include/daos_srv/dtx_srv.h
+++ b/src/include/daos_srv/dtx_srv.h
@@ -242,6 +242,8 @@ int dtx_abort(struct ds_cont_child *cont, struct dtx_entry *dte, daos_epoch_t ep
 
 int dtx_refresh(struct dtx_handle *dth, struct ds_cont_child *cont);
 
+int dtx_discard(struct ds_cont_child *cont, daos_epoch_t max_epoch);
+
 /**
  * Check whether the given DTX is resent one or not.
  *

--- a/src/include/daos_srv/vos_types.h
+++ b/src/include/daos_srv/vos_types.h
@@ -330,8 +330,10 @@ enum {
 	VOS_IT_FOR_DISCARD	= (1 << 8),
 	/** Entry is not committed */
 	VOS_IT_UNCOMMITTED	= (1 << 9),
+	/* Iterate all active DTX entries. */
+	VOS_IT_LIST_ACT_DTX	= (1 << 10),
 	/** Mask for all flags */
-	VOS_IT_MASK		= (1 << 10) - 1,
+	VOS_IT_MASK		= (1 << 11) - 1,
 };
 
 /**

--- a/src/vos/vos_internal.h
+++ b/src/vos/vos_internal.h
@@ -821,6 +821,7 @@ struct vos_iterator {
 				 it_for_discard:1,
 				 it_for_migration:1,
 				 it_cleanup_stale_dtx:1,
+				 it_list_act_dtx:1,
 				 it_show_uncommitted:1,
 				 it_ignore_uncommitted:1;
 };


### PR DESCRIPTION
When a DAOS target is down, related active DTX entries on it will
be handled via DTX resync by other alive targets: either committed
or aborted. When the target is reintegrated back, these DTX entries
are stale and need to be discarded before doing real data migration.

Signed-off-by: Fan Yong <fan.yong@intel.com>