### PR TITLE
DAOS-9639 drpc: use large stack for DRPC process ULT

### DIFF
--- a/src/engine/drpc_listener.c
+++ b/src/engine/drpc_listener.c
@@ -129,7 +129,7 @@ drpc_listener_start_ult(ABT_thread *thread)
 
 	/* Create a ULT to start the drpc listener */
 	rc = dss_ult_create(drpc_listener_run, (void *)ctx, DSS_XS_DRPC,
-			    0, 0, thread);
+			    0, DSS_DEEP_STACK_SZ, thread);
 	if (rc != 0) {
 		D_ERROR("Failed to create drpc listener ULT: "DF_RC"\n",
 			DP_RC(rc));

--- a/src/engine/drpc_progress.c
+++ b/src/engine/drpc_progress.c
@@ -354,7 +354,7 @@ handle_incoming_call(struct drpc *session_ctx)
 	 * Ownership of the call context is passed on to the handler ULT.
 	 */
 	rc = dss_ult_create(drpc_handler_ult, (void *)call_ctx,
-			    DSS_XS_SYS, 0, 0, NULL);
+			    DSS_XS_SYS, 0, DSS_DEEP_STACK_SZ, NULL);
 	if (rc != 0) {
 		D_ERROR("Failed to create drpc handler ULT: "DF_RC"\n",
 			DP_RC(rc));


### PR DESCRIPTION
To avoid ULT stack overflow.

Signed-off-by: Fan Yong <fan.yong@intel.com>