### PR TITLE
DAOS-9922: Fix invalid readlink usage

### DIFF
--- a/src/utils/daos_hdlr.c
+++ b/src/utils/daos_hdlr.c
@@ -1680,7 +1680,7 @@ fs_copy_symlink(struct cmd_args_s *ap,
 		}
 	} else if (src_file_dfs->type == DAOS) {
 		rc = dfs_sys_readlink(src_file_dfs->dfs_sys, src_path, symlink_value,
-				      &(daos_size_t)len);
+				      (daos_size_t*)&len);
 		if (rc != 0) {
 			rc = daos_errno2der(rc);
 			DH_PERROR_DER(ap, rc, "fs_copy_symlink failed on dfs_sys_readlink('%s')",

--- a/src/utils/daos_hdlr.c
+++ b/src/utils/daos_hdlr.c
@@ -1679,7 +1679,8 @@ fs_copy_symlink(struct cmd_args_s *ap,
 			D_GOTO(out_copy_symlink, rc);
 		}
 	} else if (src_file_dfs->type == DAOS) {
-		rc = dfs_sys_readlink(src_file_dfs->dfs_sys, src_path, symlink_value, &(daos_size_t)len);
+		rc = dfs_sys_readlink(src_file_dfs->dfs_sys, src_path, symlink_value,
+				      &(daos_size_t)len);
 		if (rc != 0) {
 			rc = daos_errno2der(rc);
 			DH_PERROR_DER(ap, rc, "fs_copy_symlink failed on dfs_sys_readlink('%s')",

--- a/src/utils/daos_hdlr.c
+++ b/src/utils/daos_hdlr.c
@@ -1680,7 +1680,7 @@ fs_copy_symlink(struct cmd_args_s *ap,
 		}
 	} else if (src_file_dfs->type == DAOS) {
 		rc = dfs_sys_readlink(src_file_dfs->dfs_sys, src_path, symlink_value,
-				      (daos_size_t*)&len);
+				      (daos_size_t *)&len);
 		if (rc != 0) {
 			rc = daos_errno2der(rc);
 			DH_PERROR_DER(ap, rc, "fs_copy_symlink failed on dfs_sys_readlink('%s')",

--- a/src/utils/daos_hdlr.c
+++ b/src/utils/daos_hdlr.c
@@ -1663,7 +1663,7 @@ fs_copy_symlink(struct cmd_args_s *ap,
 		const char *dst_path)
 {
 	int		rc = 0;
-	daos_size_t	len = DFS_MAX_PATH;
+	ssize_t		len = DFS_MAX_PATH;
 	char		*symlink_value = NULL;
 
 	D_ALLOC(symlink_value, len + 1);
@@ -1679,7 +1679,7 @@ fs_copy_symlink(struct cmd_args_s *ap,
 			D_GOTO(out_copy_symlink, rc);
 		}
 	} else if (src_file_dfs->type == DAOS) {
-		rc = dfs_sys_readlink(src_file_dfs->dfs_sys, src_path, symlink_value, &len);
+		rc = dfs_sys_readlink(src_file_dfs->dfs_sys, src_path, symlink_value, &(daos_size_t)len);
 		if (rc != 0) {
 			rc = daos_errno2der(rc);
 			DH_PERROR_DER(ap, rc, "fs_copy_symlink failed on dfs_sys_readlink('%s')",


### PR DESCRIPTION
Fix invalid type of the len variable => fix always true condition of line 1675.

Signed-off-by: Cedric Koch-Hofer <cedric.koch-hofer@intel.com>