### PR TITLE
Revert "DAOS-8518 prop: Check input for default label values (#8056)"

### DIFF
--- a/src/container/srv_container.c
+++ b/src/container/srv_container.c
@@ -731,21 +731,6 @@ cont_create(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl,
 		D_GOTO(out, rc = -DER_NO_PERM);
 	}
 
-	/* Determine if non-default label property supplied */
-	def_lbl_ent = daos_prop_entry_get(&cont_prop_default,
-					  DAOS_PROP_CO_LABEL);
-	D_ASSERT(def_lbl_ent != NULL);
-	lbl_ent = daos_prop_entry_get(in->cci_prop, DAOS_PROP_CO_LABEL);
-	if (lbl_ent != NULL) {
-		if (strncmp(def_lbl_ent->dpe_str, lbl_ent->dpe_str, DAOS_PROP_LABEL_MAX_LEN) == 0) {
-			D_ERROR(DF_CONT": label is the same as default label\n",
-				DP_CONT(pool_hdl->sph_pool->sp_uuid,
-					in->cci_op.ci_uuid));
-			D_GOTO(out, rc = -DER_INVAL);
-		}
-		lbl = lbl_ent->dpe_str;
-	}
-
 	/* duplicate the default properties, overwrite it with cont create
 	 * parameter (write to rdb below).
 	 */
@@ -763,6 +748,17 @@ cont_create(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl,
 			DP_CONT(pool_hdl->sph_pool->sp_uuid,
 				in->cci_op.ci_uuid), DP_RC(rc));
 		D_GOTO(out, rc);
+	}
+
+	/* Determine if non-default label property supplied */
+	def_lbl_ent = daos_prop_entry_get(&cont_prop_default,
+					  DAOS_PROP_CO_LABEL);
+	D_ASSERT(def_lbl_ent != NULL);
+	lbl_ent = daos_prop_entry_get(prop_dup, DAOS_PROP_CO_LABEL);
+	D_ASSERT(lbl_ent != NULL);
+	if (strncmp(def_lbl_ent->dpe_str, lbl_ent->dpe_str,
+		    DAOS_PROP_LABEL_MAX_LEN)) {
+		lbl = lbl_ent->dpe_str;
 	}
 
 	/* Check if a container with this UUID and label already exists */

--- a/src/container/srv_layout.c
+++ b/src/container/srv_layout.c
@@ -55,7 +55,7 @@ static struct daos_prop_co_roots dummy_roots;
 struct daos_prop_entry cont_prop_entries_default[CONT_PROP_NUM] = {
 	{
 		.dpe_type	= DAOS_PROP_CO_LABEL,
-		.dpe_str	= DAOS_PROP_CO_LABEL_DEFAULT,
+		.dpe_str	= "container_label_not_set",
 	}, {
 		.dpe_type	= DAOS_PROP_CO_LAYOUT_TYPE,
 		.dpe_val	= DAOS_PROP_CO_LAYOUT_UNKNOWN,

--- a/src/control/cmd/daos/property.go
+++ b/src/control/cmd/daos/property.go
@@ -497,7 +497,7 @@ var propHdlrs = propHdlrMap{
 const (
 	maxNameLen     = 20 // arbitrary; came from C code
 	maxValueLen    = C.DAOS_PROP_LABEL_MAX_LEN
-	labelNotSetStr = C.DAOS_PROP_CO_LABEL_DEFAULT
+	labelNotSetStr = "container_label_not_set"
 )
 
 type entryHdlr func(*propHdlr, *C.struct_daos_prop_entry, string) error

--- a/src/include/daos_prop.h
+++ b/src/include/daos_prop.h
@@ -368,10 +368,6 @@ struct daos_prop_entry {
 /** DAOS_PROP_LABEL_MAX_LEN including NULL terminator */
 #define DAOS_PROP_MAX_LABEL_BUF_LEN	(DAOS_PROP_LABEL_MAX_LEN + 1)
 
-/** default values for unset labels */
-#define DAOS_PROP_CO_LABEL_DEFAULT "container_label_not_set"
-#define DAOS_PROP_PO_LABEL_DEFAULT "pool_label_not_set"
-
 /**
  * Check if DAOS (pool or container property) label string is valid.
  * DAOS labels must consist only of alphanumeric characters, colon ':',

--- a/src/pool/srv_layout.c
+++ b/src/pool/srv_layout.c
@@ -37,7 +37,7 @@ RDB_STRING_KEY(ds_pool_attr_, user);
 struct daos_prop_entry pool_prop_entries_default[DAOS_PROP_PO_NUM] = {
 	{
 		.dpe_type	= DAOS_PROP_PO_LABEL,
-		.dpe_str	= DAOS_PROP_PO_LABEL_DEFAULT,
+		.dpe_str	= "pool_label_not_set",
 	}, {
 		.dpe_type	= DAOS_PROP_PO_SPACE_RB,
 		.dpe_val	= 0,

--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -580,25 +580,10 @@ ds_pool_svc_create(const uuid_t pool_uuid, int ntargets, const char *group,
 	struct dss_module_info *info = dss_get_module_info();
 	crt_endpoint_t		ep;
 	crt_rpc_t	       *rpc;
-	struct daos_prop_entry *lbl_ent;
-	struct daos_prop_entry *def_lbl_ent;
 	struct pool_create_in  *in;
 	struct pool_create_out *out;
 	struct d_backoff_seq	backoff_seq;
 	int			rc;
-
-	/* Check for default label property supplied */
-	def_lbl_ent = daos_prop_entry_get(&pool_prop_default,
-					  DAOS_PROP_PO_LABEL);
-	D_ASSERT(def_lbl_ent != NULL);
-	lbl_ent = daos_prop_entry_get(prop, DAOS_PROP_PO_LABEL);
-	if (lbl_ent != NULL) {
-		if (strncmp(def_lbl_ent->dpe_str, lbl_ent->dpe_str, DAOS_PROP_LABEL_MAX_LEN) == 0) {
-			D_ERROR(DF_UUID": label is the same as default label\n",
-				DP_UUID(pool_uuid));
-			D_GOTO(out, rc = -DER_INVAL);
-		}
-	}
 
 	D_ASSERTF(ntargets == target_addrs->rl_nr, "ntargets=%u num=%u\n",
 		  ntargets, target_addrs->rl_nr);

--- a/src/tests/ftest/pool/label.py
+++ b/src/tests/ftest/pool/label.py
@@ -133,7 +133,6 @@ class Label(TestWithServers):
         """Test ID: DAOS-7942
 
         Test Description: Create pool with following invalid labels.
-        * The default string for an unset pool label property.
         * UUID format string: 23ab123e-5296-4f95-be14-641de40b4d5a
         * Long label - 128 random chars.
 
@@ -144,7 +143,6 @@ class Label(TestWithServers):
         self.pool = []
         errors = []
         label_outs = [
-            ("pool_label_not_set", "Invalid parameters"),
             ("23ab123e-5296-4f95-be14-641de40b4d5a", "invalid label"),
             (get_random_string(128), "invalid label")
         ]


### PR DESCRIPTION
This reverts commit d134fd62f3b6718e7e956d5bcdde8caaec6a700e, which is
causing failures in the datamover tests.

Features: datamover

Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com>
