### PR TITLE
DAOS-623 dfs: add accidently removed function to free sb layout info

### DIFF
--- a/src/client/dfs/dfs_internal.c
+++ b/src/client/dfs/dfs_internal.c
@@ -252,3 +252,9 @@ err_free:
 	D_FREE(hdl);
 	return rc;
 }
+
+void
+dfs_free_sb_layout(daos_iod_t *iods[])
+{
+	D_FREE(*iods);
+}


### PR DESCRIPTION
Signed-off-by: Mohamad Chaarawi <mohamad.chaarawi@intel.com>