### PR TITLE
DAOS-9145 control: Fix racy access to engine's exec.Cmd

### DIFF
--- a/src/control/server/engine/exec.go
+++ b/src/control/server/engine/exec.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2019-2021 Intel Corporation.
+// (C) Copyright 2019-2022 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -24,17 +24,21 @@ const engineBin = "daos_engine"
 
 // Runner starts and manages an instance of a DAOS I/O Engine
 type Runner struct {
-	Config  *Config
-	log     logging.Logger
-	running atm.Bool
-	cmd     *exec.Cmd
+	Config   *Config
+	log      logging.Logger
+	running  atm.Bool
+	sigCh    chan os.Signal
+	sigErrCh chan error
+	pidCh    chan int
 }
 
 // NewRunner returns a configured engine.Runner
 func NewRunner(log logging.Logger, config *Config) *Runner {
 	return &Runner{
-		Config: config,
-		log:    log,
+		Config:   config,
+		log:      log,
+		sigCh:    make(chan os.Signal),
+		sigErrCh: make(chan error),
 	}
 }
 
@@ -74,26 +78,41 @@ func (r *Runner) run(ctx context.Context, args, env []string, errOut chan<- erro
 		return errors.Wrapf(common.GetExitStatus(err),
 			"%s (instance %d) failed to start", binPath, r.Config.Index)
 	}
-	r.cmd = cmd
 
-	waitDone := make(chan struct{})
+	r.pidCh = make(chan int, 1)
+	cmdDone := make(chan struct{})
+	// Start a goroutine to wait for the command to finish.
 	go func() {
 		r.running.SetTrue()
 		defer r.running.SetFalse()
 
-		errOut <- errors.Wrapf(common.GetExitStatus(cmd.Wait()), "%s exited", binPath)
-
-		close(waitDone)
+		errOut <- errors.Wrapf(common.GetExitStatus(cmd.Wait()), "%s exited", cmd.Path)
+		r.pidCh <- cmd.ProcessState.Pid()
+		close(r.pidCh)
+		close(cmdDone)
 	}()
 
+	// Start a monitoring goroutine to handle context cancellation, signals, and command completion.
 	go func() {
-		select {
-		case <-ctx.Done():
-			r.log.Infof("%s:%d context canceled; shutting down", engineBin, r.Config.Index)
-			if err := r.cmd.Process.Signal(syscall.SIGTERM); err != nil {
-				r.log.Errorf("%s:%d failed to kill process: %s", engineBin, r.Config.Index, err)
+		for {
+			select {
+			case <-ctx.Done():
+				r.log.Infof("%s:%d context canceled; shutting down", engineBin, r.Config.Index)
+				if err := cmd.Process.Signal(syscall.SIGTERM); err != nil {
+					r.log.Errorf("%s:%d failed to cleanly kill process: %s", engineBin, r.Config.Index, err)
+					cmd.Process.Signal(syscall.SIGKILL)
+				}
+				return
+			case sig := <-r.sigCh:
+				r.log.Infof("%s:%d received signal %s", engineBin, r.Config.Index, sig)
+				var err error
+				if err = cmd.Process.Signal(sig); err != nil {
+					r.log.Errorf("%s:%d failed to send signal %s to process: %s", engineBin, r.Config.Index, sig, err)
+				}
+				r.sigErrCh <- err
+			case <-cmdDone:
+				return
 			}
-		case <-waitDone:
 		}
 	}()
 
@@ -126,19 +145,16 @@ func (r *Runner) Signal(signal os.Signal) error {
 		return nil
 	}
 
-	r.log.Debugf("Signalling I/O Engine instance %d (%s)", r.Config.Index, signal)
-
-	return r.cmd.Process.Signal(signal)
+	r.sigCh <- signal
+	return <-r.sigErrCh
 }
 
-// GetLastPid returns the PID after runner has exited, return
-// zero if no cmd or ProcessState exists.
+// GetLastPid returns the PID after runner has exited. It
+// is usually an error to call this with a running process,
+// as the PID is not available on the channel until the
+// process exits, and therefore the call may block.
 func (r *Runner) GetLastPid() uint64 {
-	if r.cmd == nil || r.cmd.ProcessState == nil {
-		return 0
-	}
-
-	return uint64(r.cmd.ProcessState.Pid())
+	return uint64(<-r.pidCh)
 }
 
 // GetConfig returns the runner's configuration


### PR DESCRIPTION
Instead of sharing the cmd field of the runner between goroutines,
delegate access to a single goroutine and communicate with it.

Features: control