### PR TITLE
DAOS-9843 csum: missed csum fix

### DIFF
--- a/src/vos/vos_io.c
+++ b/src/vos/vos_io.c
@@ -2114,13 +2114,12 @@ akey_update_begin(struct vos_io_context *ioc)
 		media = vos_policy_media_select(vos_cont2pool(ioc->ic_cont),
 					 iod->iod_type, size, VOS_IOS_GENERIC);
 
-		recx_csum = (iod_csums != NULL) ? &iod_csums[i] : NULL;
-
 		if (iod->iod_type == DAOS_IOD_SINGLE) {
 			rc = vos_reserve_single(ioc, media, size);
 		} else {
 			daos_size_t csum_len;
 
+			recx_csum = recx_csum_at(iod_csums, i, iod);
 			csum_len = recx_csum_len(&iod->iod_recxs[i], recx_csum,
 						 iod->iod_size);
 			rc = vos_reserve_recx(ioc, media, size, recx_csum,


### PR DESCRIPTION
Fix a recx csum in vos_io.c which is missed during prior csum fix.

Signed-off-by: Niu Yawei <yawei.niu@intel.com>