### PR TITLE
CORCI-1176 build: Hold back mock-core-configs (#8216)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -313,7 +313,7 @@ pipeline {
                         dockerfile {
                             filename 'Dockerfile.mockbuild'
                             dir 'utils/rpms/packaging'
-                            label 'docker_ce_runner'
+                            label 'docker_runner'
                             additionalBuildArgs dockerBuildArgs()
                             args  '--group-add mock --cap-add=SYS_ADMIN --privileged=true'
                         }
@@ -348,7 +348,7 @@ pipeline {
                         dockerfile {
                             filename 'Dockerfile.mockbuild'
                             dir 'utils/rpms/packaging'
-                            label 'docker_ce_runner'
+                            label 'docker_runner'
                             additionalBuildArgs dockerBuildArgs()
                             args  '--group-add mock --cap-add=SYS_ADMIN --privileged=true'
                         }
@@ -383,7 +383,7 @@ pipeline {
                         dockerfile {
                             filename 'Dockerfile.mockbuild'
                             dir 'utils/rpms/packaging'
-                            label 'docker_ce_runner'
+                            label 'docker_runner'
                             additionalBuildArgs dockerBuildArgs()
                             args  '--group-add mock --cap-add=SYS_ADMIN --privileged=true'
                         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -313,7 +313,7 @@ pipeline {
                         dockerfile {
                             filename 'Dockerfile.mockbuild'
                             dir 'utils/rpms/packaging'
-                            label 'docker_runner'
+                            label 'docker_ce_runner'
                             additionalBuildArgs dockerBuildArgs()
                             args  '--group-add mock --cap-add=SYS_ADMIN --privileged=true'
                         }
@@ -348,7 +348,7 @@ pipeline {
                         dockerfile {
                             filename 'Dockerfile.mockbuild'
                             dir 'utils/rpms/packaging'
-                            label 'docker_runner'
+                            label 'docker_ce_runner'
                             additionalBuildArgs dockerBuildArgs()
                             args  '--group-add mock --cap-add=SYS_ADMIN --privileged=true'
                         }
@@ -383,7 +383,7 @@ pipeline {
                         dockerfile {
                             filename 'Dockerfile.mockbuild'
                             dir 'utils/rpms/packaging'
-                            label 'docker_runner'
+                            label 'docker_ce_runner'
                             additionalBuildArgs dockerBuildArgs()
                             args  '--group-add mock --cap-add=SYS_ADMIN --privileged=true'
                         }

--- a/utils/rpms/packaging/Dockerfile.mockbuild
+++ b/utils/rpms/packaging/Dockerfile.mockbuild
@@ -5,7 +5,7 @@
 #
 
 # Pull base image
-FROM fedora:latest
+FROM fedora:35
 LABEL maintainer="daos@daos.groups.io"
 
 # use same UID as host and default value of 1000 if not specified
@@ -14,7 +14,7 @@ ARG UID=1000
 # Install basic tools
 RUN dnf -y install mock make \
                    rpm-build curl createrepo rpmlint redhat-lsb-core git \
-                   python-srpm-macros rpmdevtools
+                   python-srpm-macros rpmdevtools mock-core-configs\ \<\ 37.1
 
 # Add build user (to keep rpmbuild happy)
 ENV USER build
@@ -29,5 +29,5 @@ RUN grep use_nspawn /etc/mock/site-defaults.cfg || \
     echo "config_opts['use_nspawn'] = False" >> /etc/mock/site-defaults.cfg
 
 ARG CACHEBUST
-RUN dnf -y upgrade && \
+RUN dnf -y upgrade --exclude mock-core-configs && \
     dnf clean all


### PR DESCRIPTION
*As the update replaces epel-8-* configs with <distro>+epel-8-* which
we are not ready for yet.
* Use Docker CE runner

Signed-off-by: Brian J. Murrell <brian.murrell@intel.com>