### PR TITLE
DAOS-9105 control: Generate VMD-enabled server configs with DMG

### DIFF
--- a/src/control/common/mocks.go
+++ b/src/control/common/mocks.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2020-2021 Intel Corporation.
+// (C) Copyright 2020-2022 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -8,6 +8,7 @@ package common
 
 import (
 	"fmt"
+	"math"
 	"net"
 	"strings"
 )
@@ -58,9 +59,27 @@ func MockPCIAddr(varIdx ...int32) string {
 	return fmt.Sprintf("0000:%02d:00.0", idx)
 }
 
+// MockPCIAddrs returns slice of mock PCIAddr values for use in tests.
 func MockPCIAddrs(idxs ...int) (addrs []string) {
 	for _, i := range idxs {
 		addrs = append(addrs, MockPCIAddr(int32(i)))
+	}
+
+	return
+}
+
+// MockVMDPCIAddr returns mock PCIAddr values for use in tests.
+// VMD PCI address domains start at 0x10000 to avoid overlapping with standard ACPI addresses.
+func MockVMDPCIAddr(dom int32, varIdx ...int32) string {
+	idx := GetIndex(varIdx...)
+
+	return fmt.Sprintf("%06x:%02x:00.0", (math.MaxUint16+1)*dom, idx)
+}
+
+// MockVMDPCIAddrs returns slice of mock VMD PCIAddr values for use in tests.
+func MockVMDPCIAddrs(dom int, idxs ...int) (addrs []string) {
+	for _, i := range idxs {
+		addrs = append(addrs, MockVMDPCIAddr(int32(dom), int32(i)))
 	}
 
 	return

--- a/src/control/fault/code/codes.go
+++ b/src/control/fault/code/codes.go
@@ -105,6 +105,7 @@ const (
 	ClientConnectionClosed
 	ClientFormatRunningSystem
 	ClientRpcTimeout
+	ClientConfigVMDImbalance
 )
 
 // server fault codes

--- a/src/control/lib/control/auto_test.go
+++ b/src/control/lib/control/auto_test.go
@@ -624,7 +624,7 @@ func TestControl_AutoConfig_getStorageDetails(t *testing.T) {
 			common.AssertEqual(t, len(tc.expSSDs), len(storageDetails.numaSSDs),
 				"unexpected number of ssds")
 			for nn, ssds := range storageDetails.numaSSDs {
-				if diff := cmp.Diff(tc.expSSDs[nn], []string(ssds)); diff != "" {
+				if diff := cmp.Diff(tc.expSSDs[nn], ssds.Strings()); diff != "" {
 					t.Fatalf("unexpected list of ssds (-want, +got):\n%s\n", diff)
 				}
 			}
@@ -680,11 +680,18 @@ func TestControl_AutoConfig_getCPUDetails(t *testing.T) {
 			log, buf := logging.NewTestLogger(t.Name())
 			defer common.ShowBufferOnFailure(t, buf)
 
-			numaSSDs := make(numaSSDsMap)
+			var ctrlrs storage.NvmeControllers
 			for nn, count := range tc.ssdListSizes {
 				for i := 0; i < count; i++ {
-					numaSSDs[nn] = append(numaSSDs[nn], common.MockPCIAddr(int32(i)))
+					ctrlrs = append(ctrlrs, &storage.NvmeController{
+						SocketID: int32(nn),
+						PciAddr:  common.MockPCIAddr(int32(i)),
+					})
 				}
+			}
+			numaSSDs, err := mapSSDs(ctrlrs)
+			if err != nil {
+				t.Fatal(err)
 			}
 
 			nccs, gotErr := getCPUDetails(log, numaSSDs, tc.numaCoreCount)
@@ -739,7 +746,8 @@ func TestControl_AutoConfig_genConfig(t *testing.T) {
 			numaPMems:      numaPMemsMap{0: []string{"/dev/pmem0"}},
 			numaIfaces:     numaNetIfaceMap{0: ib0},
 			numaCoreCounts: numaCoreCountsMap{0: &coreCounts{16, 7}},
-			expCfg: baseConfig("ofi+psm2").WithAccessPoints("hostX:10001").WithNrHugePages(8192).WithEngines(
+			expCfg: baseConfig("ofi+psm2").WithAccessPoints("hostX:10001").
+				WithNrHugePages(8192).WithEngines(
 				defaultEngineCfg(0).
 					WithPinnedNumaNode(0).
 					WithFabricInterface("ib0").
@@ -761,7 +769,8 @@ func TestControl_AutoConfig_genConfig(t *testing.T) {
 			numaPMems:      numaPMemsMap{0: []string{"/dev/pmem0"}},
 			numaIfaces:     numaNetIfaceMap{0: ib0},
 			numaCoreCounts: numaCoreCountsMap{0: &coreCounts{16, 7}},
-			expCfg: baseConfig("ofi+psm2").WithAccessPoints("hostX:10002").WithNrHugePages(8192).WithEngines(
+			expCfg: baseConfig("ofi+psm2").WithAccessPoints("hostX:10002").
+				WithNrHugePages(8192).WithEngines(
 				defaultEngineCfg(0).
 					WithPinnedNumaNode(0).
 					WithFabricInterface("ib0").
@@ -781,7 +790,7 @@ func TestControl_AutoConfig_genConfig(t *testing.T) {
 			accessPoints:   []string{"hostX:-10001"},
 			numaPMems:      numaPMemsMap{0: []string{"/dev/pmem0"}},
 			numaIfaces:     numaNetIfaceMap{0: ib0},
-			numaSSDs:       numaSSDsMap{0: []string{}},
+			numaSSDs:       numaSSDsMap{0: hardware.MustNewPCIAddressSet()},
 			numaCoreCounts: numaCoreCountsMap{0: &coreCounts{16, 7}},
 			expErr:         config.FaultConfigBadControlPort,
 		},
@@ -791,7 +800,8 @@ func TestControl_AutoConfig_genConfig(t *testing.T) {
 			numaPMems:      numaPMemsMap{0: []string{"/dev/pmem0"}},
 			numaIfaces:     numaNetIfaceMap{0: ib0},
 			numaCoreCounts: numaCoreCountsMap{0: &coreCounts{16, 7}},
-			expCfg: baseConfig("ofi+psm2").WithAccessPoints("192.168.1.1:10002").WithNrHugePages(8192).WithEngines(
+			expCfg: baseConfig("ofi+psm2").WithAccessPoints("192.168.1.1:10002").
+				WithNrHugePages(8192).WithEngines(
 				defaultEngineCfg(0).
 					WithPinnedNumaNode(0).
 					WithFabricInterface("ib0").
@@ -811,7 +821,7 @@ func TestControl_AutoConfig_genConfig(t *testing.T) {
 			accessPoints:   []string{"192.168.1.1:-10001"},
 			numaPMems:      numaPMemsMap{0: []string{"/dev/pmem0"}},
 			numaIfaces:     numaNetIfaceMap{0: ib0},
-			numaSSDs:       numaSSDsMap{0: []string{}},
+			numaSSDs:       numaSSDsMap{0: hardware.MustNewPCIAddressSet()},
 			numaCoreCounts: numaCoreCountsMap{0: &coreCounts{16, 7}},
 			expErr:         config.FaultConfigBadControlPort,
 		},
@@ -820,9 +830,10 @@ func TestControl_AutoConfig_genConfig(t *testing.T) {
 			accessPoints:   []string{"hostX:10002"},
 			numaPMems:      numaPMemsMap{0: []string{"/dev/pmem0"}},
 			numaIfaces:     numaNetIfaceMap{0: ib0},
-			numaSSDs:       numaSSDsMap{0: []string{}},
+			numaSSDs:       numaSSDsMap{0: hardware.MustNewPCIAddressSet()},
 			numaCoreCounts: numaCoreCountsMap{0: &coreCounts{16, 7}},
-			expCfg: baseConfig("ofi+psm2").WithAccessPoints("hostX:10002").WithNrHugePages(8192).WithEngines(
+			expCfg: baseConfig("ofi+psm2").WithAccessPoints("hostX:10002").
+				WithNrHugePages(8192).WithEngines(
 				defaultEngineCfg(0).
 					WithPinnedNumaNode(0).
 					WithFabricInterface("ib0").
@@ -837,13 +848,16 @@ func TestControl_AutoConfig_genConfig(t *testing.T) {
 					WithHelperStreamCount(7)),
 		},
 		"single pmem single ssd": {
-			engineCount:    1,
-			accessPoints:   []string{"hostX:10002"},
-			numaPMems:      numaPMemsMap{0: []string{"/dev/pmem0"}},
-			numaIfaces:     numaNetIfaceMap{0: ib0},
-			numaSSDs:       numaSSDsMap{0: []string{common.MockPCIAddr(1)}},
+			engineCount:  1,
+			accessPoints: []string{"hostX:10002"},
+			numaPMems:    numaPMemsMap{0: []string{"/dev/pmem0"}},
+			numaIfaces:   numaNetIfaceMap{0: ib0},
+			numaSSDs: numaSSDsMap{
+				0: hardware.MustNewPCIAddressSet(common.MockPCIAddr(1)),
+			},
 			numaCoreCounts: numaCoreCountsMap{0: &coreCounts{16, 7}},
-			expCfg: baseConfig("ofi+psm2").WithAccessPoints("hostX:10002").WithNrHugePages(8192).WithEngines(
+			expCfg: baseConfig("ofi+psm2").WithAccessPoints("hostX:10002").
+				WithNrHugePages(8192).WithEngines(
 				defaultEngineCfg(0).
 					WithPinnedNumaNode(0).
 					WithFabricInterface("ib0").
@@ -868,12 +882,14 @@ func TestControl_AutoConfig_genConfig(t *testing.T) {
 			numaPMems:    numaPMemsMap{0: []string{"/dev/pmem0"}, 1: []string{"/dev/pmem1"}},
 			numaIfaces:   numaNetIfaceMap{0: ib0, 1: ib1},
 			numaSSDs: numaSSDsMap{
-				0: common.MockPCIAddrs(0, 1, 2, 3), 1: common.MockPCIAddrs(4, 5, 6),
+				0: hardware.MustNewPCIAddressSet(common.MockPCIAddrs(0, 1, 2, 3)...),
+				1: hardware.MustNewPCIAddressSet(common.MockPCIAddrs(4, 5, 6)...),
 			},
 			numaCoreCounts: numaCoreCountsMap{
 				0: &coreCounts{16, 7}, 1: &coreCounts{15, 6},
 			},
-			expCfg: baseConfig("ofi+psm2").WithAccessPoints("hostX:10002").WithNrHugePages(15360).WithEngines(
+			expCfg: baseConfig("ofi+psm2").WithAccessPoints("hostX:10002").
+				WithNrHugePages(15360).WithEngines(
 				defaultEngineCfg(0).
 					WithPinnedNumaNode(0).
 					WithFabricInterface("ib0").
@@ -914,13 +930,16 @@ func TestControl_AutoConfig_genConfig(t *testing.T) {
 					WithHelperStreamCount(6)),
 		},
 		"hugepages test": {
-			engineCount:    1,
-			accessPoints:   []string{"hostX:10002"},
-			numaPMems:      numaPMemsMap{0: []string{"/dev/pmem0"}},
-			numaIfaces:     numaNetIfaceMap{0: ib0},
-			numaSSDs:       numaSSDsMap{0: []string{common.MockPCIAddr(1)}},
+			engineCount:  1,
+			accessPoints: []string{"hostX:10002"},
+			numaPMems:    numaPMemsMap{0: []string{"/dev/pmem0"}},
+			numaIfaces:   numaNetIfaceMap{0: ib0},
+			numaSSDs: numaSSDsMap{
+				0: hardware.MustNewPCIAddressSet(common.MockPCIAddr(1)),
+			},
 			numaCoreCounts: numaCoreCountsMap{0: &coreCounts{8, 2}},
-			expCfg: baseConfig("ofi+psm2").WithAccessPoints("hostX:10002").WithNrHugePages(4096).WithEngines(
+			expCfg: baseConfig("ofi+psm2").WithAccessPoints("hostX:10002").
+				WithNrHugePages(4096).WithEngines(
 				defaultEngineCfg(0).
 					WithPinnedNumaNode(0).
 					WithFabricInterface("ib0").
@@ -946,12 +965,14 @@ func TestControl_AutoConfig_genConfig(t *testing.T) {
 			numaPMems:    numaPMemsMap{0: []string{"/dev/pmem0"}, 1: []string{"/dev/pmem1"}},
 			numaIfaces:   numaNetIfaceMap{0: ib0, 1: ib1},
 			numaSSDs: numaSSDsMap{
-				0: common.MockPCIAddrs(0, 1, 2, 3), 1: common.MockPCIAddrs(4, 5, 6),
+				0: hardware.MustNewPCIAddressSet(common.MockPCIAddrs(0, 1, 2, 3)...),
+				1: hardware.MustNewPCIAddressSet(common.MockPCIAddrs(4, 5, 6)...),
 			},
 			numaCoreCounts: numaCoreCountsMap{
 				0: &coreCounts{12, 2}, 1: &coreCounts{6, 0},
 			},
-			expCfg: baseConfig("ofi+psm2").WithAccessPoints("hostX:10002").WithNrHugePages(6144).WithEngines(
+			expCfg: baseConfig("ofi+psm2").WithAccessPoints("hostX:10002").
+				WithNrHugePages(6144).WithEngines(
 				defaultEngineCfg(0).
 					WithPinnedNumaNode(0).
 					WithFabricInterface("ib0").
@@ -992,6 +1013,92 @@ func TestControl_AutoConfig_genConfig(t *testing.T) {
 					WithTargetCount(6).
 					WithHelperStreamCount(0)),
 		},
+		"vmd enabled; balanced nr ssds": {
+			engineCount:  2,
+			accessPoints: []string{"hostX"},
+			numaPMems:    numaPMemsMap{0: []string{"/dev/pmem0"}, 1: []string{"/dev/pmem1"}},
+			numaIfaces:   numaNetIfaceMap{0: ib0, 1: ib1},
+			numaSSDs: numaSSDsMap{
+				0: hardware.MustNewPCIAddressSet("5d0505:01:00.0", "5d0505:02:00.0"),
+				1: hardware.MustNewPCIAddressSet("d70701:03:00.0", "d70701:05:00.0"),
+			},
+			numaCoreCounts: numaCoreCountsMap{
+				0: &coreCounts{22, 1}, 1: &coreCounts{22, 1},
+			},
+			expCfg: baseConfig("ofi+psm2").WithAccessPoints("hostX:10001").
+				WithNrHugePages(22528).WithEngines(
+				defaultEngineCfg(0).
+					WithPinnedNumaNode(0).
+					WithFabricInterface("ib0").
+					WithFabricInterfacePort(defaultFiPort).
+					WithFabricProvider("ofi+psm2").
+					WithStorage(
+						storage.NewTierConfig().
+							WithStorageClass(storage.ClassDcpm.String()).
+							WithScmDeviceList("/dev/pmem0").
+							WithScmMountPoint("/mnt/daos0"),
+						storage.NewTierConfig().
+							WithStorageClass(storage.ClassNvme.String()).
+							WithBdevDeviceList("0000:5d:05.5"),
+					).
+					WithStorageConfigOutputPath("/mnt/daos0/daos_nvme.conf").
+					WithStorageVosEnv("NVME").
+					WithTargetCount(22).
+					WithHelperStreamCount(1),
+				defaultEngineCfg(1).
+					WithPinnedNumaNode(1).
+					WithFabricInterface("ib1").
+					WithFabricInterfacePort(
+						int(defaultFiPort+defaultFiPortInterval)).
+					WithFabricProvider("ofi+psm2").
+					WithFabricNumaNodeIndex(1).
+					WithStorage(
+						storage.NewTierConfig().
+							WithStorageClass(storage.ClassDcpm.String()).
+							WithScmDeviceList("/dev/pmem1").
+							WithScmMountPoint("/mnt/daos1"),
+						storage.NewTierConfig().
+							WithStorageClass(storage.ClassNvme.String()).
+							WithBdevDeviceList("0000:d7:07.1"),
+					).
+					WithStorageConfigOutputPath("/mnt/daos1/daos_nvme.conf").
+					WithStorageVosEnv("NVME").
+					WithStorageNumaNodeIndex(1).
+					WithTargetCount(22).
+					WithHelperStreamCount(1)),
+		},
+		"vmd enabled; imbalanced nr ssds": {
+			engineCount:  2,
+			accessPoints: []string{"hostX"},
+			numaPMems:    numaPMemsMap{0: []string{"/dev/pmem0"}, 1: []string{"/dev/pmem1"}},
+			numaIfaces:   numaNetIfaceMap{0: ib0, 1: ib1},
+			numaSSDs: numaSSDsMap{
+				0: hardware.MustNewPCIAddressSet(common.MockVMDPCIAddrs(5, 2, 4)...),
+				1: hardware.MustNewPCIAddressSet(common.MockVMDPCIAddrs(13, 1, 2, 3)...),
+			},
+			numaCoreCounts: numaCoreCountsMap{
+				0: &coreCounts{22, 1}, 1: &coreCounts{22, 1},
+			},
+			expErr: FaultConfigVMDImbalance,
+		},
+		// If there is an equal total number of backing devices behind VMDs attached to each
+		// engine but the number of VMDs for each engine differs then validation will fail.
+		// It is expected that there are an equal number of VMD addresses per engine.
+		"vmd enabled; balanced nr ssds; imbalanced nr vmds": {
+			engineCount:  2,
+			accessPoints: []string{"hostX"},
+			numaPMems:    numaPMemsMap{0: []string{"/dev/pmem0"}, 1: []string{"/dev/pmem1"}},
+			numaIfaces:   numaNetIfaceMap{0: ib0, 1: ib1},
+			numaSSDs: numaSSDsMap{
+				0: hardware.MustNewPCIAddressSet(common.MockVMDPCIAddrs(5, 2, 4)...),
+				1: hardware.MustNewPCIAddressSet(append(common.MockVMDPCIAddrs(13, 1),
+					common.MockVMDPCIAddrs(14, 1)...)...),
+			},
+			numaCoreCounts: numaCoreCountsMap{
+				0: &coreCounts{22, 1}, 1: &coreCounts{22, 1},
+			},
+			expErr: config.FaultConfigBdevCountMismatch(1, 2, 0, 1),
+		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			log, buf := logging.NewTestLogger(t.Name())
@@ -1007,8 +1114,8 @@ func TestControl_AutoConfig_genConfig(t *testing.T) {
 				numaSSDs:     tc.numaSSDs,
 			}
 
-			gotCfg, gotErr := genConfig(log, mockEngineCfg,
-				tc.accessPoints, nd, sd, tc.numaCoreCounts)
+			gotCfg, gotErr := genConfig(log, mockEngineCfg, tc.accessPoints, nd, sd,
+				tc.numaCoreCounts)
 
 			common.CmpErr(t, tc.expErr, gotErr)
 			if tc.expErr != nil {

--- a/src/control/lib/control/faults.go
+++ b/src/control/lib/control/faults.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2020-2021 Intel Corporation.
+// (C) Copyright 2020-2022 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -35,6 +35,11 @@ var (
 		code.ClientFormatRunningSystem,
 		"storage format invoked on a running system",
 		"stop and erase the system, then retry the format operation",
+	)
+	FaultConfigVMDImbalance = clientFault(
+		code.ClientConfigVMDImbalance,
+		"different number of backing devices behind each engine's VMD addresses",
+		"assign an equal number of NVMe SSDs to each VMD when configuring in BIOS",
 	)
 )
 

--- a/src/control/lib/hardware/pci.go
+++ b/src/control/lib/hardware/pci.go
@@ -188,7 +188,7 @@ func NewPCIAddress(addr string) (*PCIAddress, error) {
 	}, nil
 }
 
-// MustNewPCIAddressSet creates a new PCIAddressSet from input string,
+// MustNewPCIAddress creates a new PCIAddress from input string,
 // which must be valid, otherwise a panic will occur.
 func MustNewPCIAddress(addr string) *PCIAddress {
 	pa, err := NewPCIAddress(addr)
@@ -348,6 +348,21 @@ func (pas *PCIAddressSet) Difference(in *PCIAddressSet) *PCIAddressSet {
 	return difference
 }
 
+// HasVMD returns true if any of the addresses in set is for a VMD backing device.
+func (pas *PCIAddressSet) HasVMD() bool {
+	if pas == nil {
+		return false
+	}
+
+	for _, inAddr := range pas.Addresses() {
+		if inAddr.IsVMDBackingAddress() {
+			return true
+		}
+	}
+
+	return false
+}
+
 // BackingToVMDAddresses converts all VMD backing device PCI addresses (with the VMD address
 // encoded in the domain component of the PCI address) in set back to the PCI address of the VMD
 // e.g. [5d0505:01:00.0, 5d0505:03:00.0] -> [0000:5d:05.5].
@@ -384,12 +399,23 @@ func (pas *PCIAddressSet) BackingToVMDAddresses(log logging.Logger) (*PCIAddress
 
 // NewPCIAddressSet takes a variable number of strings and attempts to create an address set.
 func NewPCIAddressSet(addrs ...string) (*PCIAddressSet, error) {
-	al := &PCIAddressSet{}
-	if err := al.AddStrings(addrs...); err != nil {
+	as := &PCIAddressSet{}
+	if err := as.AddStrings(addrs...); err != nil {
 		return nil, err
 	}
 
-	return al, nil
+	return as, nil
+}
+
+// MustNewPCIAddressSet creates a new PCIAddressSet from input strings,
+// which must be valid, otherwise a panic will occur.
+func MustNewPCIAddressSet(addrs ...string) *PCIAddressSet {
+	as, err := NewPCIAddressSet(addrs...)
+	if err != nil {
+		panic(err)
+	}
+
+	return as
 }
 
 // NewPCIAddressSetFromString takes a space-separated string and attempts to create an address set.

--- a/src/control/lib/spdk/nvme.go
+++ b/src/control/lib/spdk/nvme.go
@@ -120,6 +120,10 @@ func ctrlrPCIAddresses(ctrlrs storage.NvmeControllers) []string {
 // containing any Namespace and DeviceHealth structs.
 // Afterwards remove lockfile for each discovered device.
 func (n *NvmeImpl) Discover(log logging.Logger) (storage.NvmeControllers, error) {
+	if n == nil {
+		return nil, errors.New("nil NvmeImpl")
+	}
+
 	ctrlrs, err := collectCtrlrs(C.nvme_discover(), "NVMe Discover(): C.nvme_discover")
 
 	pciAddrs := ctrlrPCIAddresses(ctrlrs)
@@ -142,6 +146,10 @@ func resultPCIAddresses(results []*FormatResult) []string {
 // Attempt wipe of each controller namespace's LBA-0.
 // Afterwards remove lockfile for each formatted device.
 func (n *NvmeImpl) Format(log logging.Logger) ([]*FormatResult, error) {
+	if n == nil {
+		return nil, errors.New("nil NvmeImpl")
+	}
+
 	results, err := collectFormatResults(C.nvme_wipe_namespaces(),
 		"NVMe Format(): C.nvme_wipe_namespaces()")
 
@@ -155,6 +163,10 @@ func (n *NvmeImpl) Format(log logging.Logger) ([]*FormatResult, error) {
 //
 // Afterwards remove lockfile for the updated device.
 func (n *NvmeImpl) Update(log logging.Logger, ctrlrPciAddr string, path string, slot int32) error {
+	if n == nil {
+		return errors.New("nil NvmeImpl")
+	}
+
 	csPath := C.CString(path)
 	defer C.free(unsafe.Pointer(csPath))
 

--- a/src/control/lib/spdk/spdk.go
+++ b/src/control/lib/spdk/spdk.go
@@ -79,18 +79,6 @@ type EnvOptions struct {
 	EnableVMD    bool                    // flag if VMD functionality should be enabled
 }
 
-// NewEnvOptions returns an initialized EnvOptions struct.
-func NewEnvOptions(addrSet *hardware.PCIAddressSet, enableVMD bool) *EnvOptions {
-	if addrSet == nil {
-		addrSet = hardware.MustNewPCIAddressSet()
-	}
-
-	return &EnvOptions{
-		PCIAllowList: addrSet,
-		EnableVMD:    enableVMD,
-	}
-}
-
 func (eo *EnvOptions) sanitizeAllowList(log logging.Logger) error {
 	if eo == nil {
 		return errors.New("nil EnvOptions")
@@ -122,7 +110,7 @@ func (ei *EnvImpl) InitSPDKEnv(log logging.Logger, opts *EnvOptions) error {
 		return errors.New("nil EnvOptions")
 	}
 	if opts.PCIAllowList == nil {
-		return errors.New("nil EnvOptions.PCIAllowList")
+		opts.PCIAllowList = hardware.MustNewPCIAddressSet()
 	}
 
 	log.Debugf("spdk init go opts: %+v", opts)

--- a/src/control/lib/spdk/spdk.go
+++ b/src/control/lib/spdk/spdk.go
@@ -80,14 +80,12 @@ type EnvOptions struct {
 }
 
 func (o *EnvOptions) sanitizeAllowList(log logging.Logger) error {
-	if o.EnableVMD {
-		// DPDK will not accept VMD backing device addresses so convert to VMD addresses
-		newSet, err := o.PCIAllowList.BackingToVMDAddresses(log)
-		if err != nil {
-			return err
-		}
-		o.PCIAllowList = newSet
+	// DPDK will not accept VMD backing device addresses so convert to VMD addresses
+	newSet, err := o.PCIAllowList.BackingToVMDAddresses(log)
+	if err != nil {
+		return err
 	}
+	o.PCIAllowList = newSet
 
 	return nil
 }

--- a/src/control/lib/spdk/spdk.go
+++ b/src/control/lib/spdk/spdk.go
@@ -79,13 +79,32 @@ type EnvOptions struct {
 	EnableVMD    bool                    // flag if VMD functionality should be enabled
 }
 
-func (o *EnvOptions) sanitizeAllowList(log logging.Logger) error {
+// NewEnvOptions returns an initialized EnvOptions struct.
+func NewEnvOptions(addrSet *hardware.PCIAddressSet, enableVMD bool) *EnvOptions {
+	if addrSet == nil {
+		addrSet = hardware.MustNewPCIAddressSet()
+	}
+
+	return &EnvOptions{
+		PCIAllowList: addrSet,
+		EnableVMD:    enableVMD,
+	}
+}
+
+func (eo *EnvOptions) sanitizeAllowList(log logging.Logger) error {
+	if eo == nil {
+		return errors.New("nil EnvOptions")
+	}
+	if eo.PCIAllowList == nil {
+		return errors.New("nil EnvOptions.PCIAllowList")
+	}
+
 	// DPDK will not accept VMD backing device addresses so convert to VMD addresses
-	newSet, err := o.PCIAllowList.BackingToVMDAddresses(log)
+	newSet, err := eo.PCIAllowList.BackingToVMDAddresses(log)
 	if err != nil {
 		return err
 	}
-	o.PCIAllowList = newSet
+	eo.PCIAllowList = newSet
 
 	return nil
 }
@@ -95,7 +114,17 @@ func (o *EnvOptions) sanitizeAllowList(log logging.Logger) error {
 // SPDK relies on an abstraction around the local environment
 // named env that handles memory allocation and PCI device operations.
 // The library must be initialized first.
-func (e *EnvImpl) InitSPDKEnv(log logging.Logger, opts *EnvOptions) error {
+func (ei *EnvImpl) InitSPDKEnv(log logging.Logger, opts *EnvOptions) error {
+	if ei == nil {
+		return errors.New("nil EnvImpl")
+	}
+	if opts == nil {
+		return errors.New("nil EnvOptions")
+	}
+	if opts.PCIAllowList == nil {
+		return errors.New("nil EnvOptions.PCIAllowList")
+	}
+
 	log.Debugf("spdk init go opts: %+v", opts)
 
 	// Only print error and more severe to stderr.
@@ -133,7 +162,14 @@ func (e *EnvImpl) InitSPDKEnv(log logging.Logger, opts *EnvOptions) error {
 }
 
 // FiniSPDKEnv initializes the SPDK environment.
-func (e *EnvImpl) FiniSPDKEnv(log logging.Logger, opts *EnvOptions) {
+func (ei *EnvImpl) FiniSPDKEnv(log logging.Logger, opts *EnvOptions) {
+	if ei == nil {
+		return
+	}
+	if opts == nil {
+		return
+	}
+
 	log.Debugf("spdk fini go opts: %+v", opts)
 
 	if opts.EnableVMD {

--- a/src/control/server/config/server.go
+++ b/src/control/server/config/server.go
@@ -416,24 +416,6 @@ func (cfg *Server) Validate(log logging.Logger, hugePageSize int, fis *hardware.
 	log.Debugf("vfio=%v hotplug=%v vmd=%v requested in config", !cfg.DisableVFIO,
 		cfg.EnableHotplug, cfg.EnableVMD)
 
-	// A config without engines is valid when initially discovering hardware prior to adding
-	// per-engine sections with device allocations.
-	if len(cfg.Engines) == 0 {
-		log.Infof("No %ss in configuration, %s starting in discovery mode",
-			build.DataPlaneName, build.ControlPlaneName)
-		cfg.Engines = nil
-		return nil
-	}
-
-	switch {
-	case cfg.Fabric.Provider == "":
-		return FaultConfigNoProvider
-	case cfg.ControlPort <= 0:
-		return FaultConfigBadControlPort
-	case cfg.TelemetryPort < 0:
-		return FaultConfigBadTelemetryPort
-	}
-
 	// Update access point addresses with control port if port is not supplied.
 	newAPs := make([]string, 0, len(cfg.AccessPoints))
 	for _, ap := range cfg.AccessPoints {
@@ -449,11 +431,29 @@ func (cfg *Server) Validate(log logging.Logger, hugePageSize int, fis *hardware.
 	}
 	cfg.AccessPoints = newAPs
 
+	// A config without engines is valid when initially discovering hardware prior to adding
+	// per-engine sections with device allocations.
+	if len(cfg.Engines) == 0 {
+		log.Infof("No %ss in configuration, %s starting in discovery mode",
+			build.DataPlaneName, build.ControlPlaneName)
+		cfg.Engines = nil
+		return nil
+	}
+
 	switch {
 	case len(cfg.AccessPoints) < 1:
 		return FaultConfigBadAccessPoints
 	case len(cfg.AccessPoints)%2 == 0:
 		return FaultConfigEvenAccessPoints
+	}
+
+	switch {
+	case cfg.Fabric.Provider == "":
+		return FaultConfigNoProvider
+	case cfg.ControlPort <= 0:
+		return FaultConfigBadControlPort
+	case cfg.TelemetryPort < 0:
+		return FaultConfigBadTelemetryPort
 	}
 
 	cfgHasBdevs := false

--- a/src/control/server/server.go
+++ b/src/control/server/server.go
@@ -263,6 +263,10 @@ func (srv *server) addEngines(ctx context.Context) error {
 	// recovered by the engine storage provider(s) during scan even if devices are in use.
 	nvmeScanResp := scanBdevStorage(srv)
 
+	if len(srv.cfg.Engines) == 0 {
+		return nil
+	}
+
 	for i, c := range srv.cfg.Engines {
 		engine, err := srv.createEngine(ctx, i, c)
 		if err != nil {

--- a/src/control/server/storage/bdev/backend.go
+++ b/src/control/server/storage/bdev/backend.go
@@ -295,7 +295,10 @@ func (sb *spdkBackend) Scan(req storage.BdevScanRequest) (*storage.BdevScanRespo
 	sb.log.Debugf("spdk backend scan (bindings discover call): %+v", req)
 
 	needDevs := req.DeviceList.PCIAddressSetPtr()
-	spdkOpts := spdk.NewEnvOptions(needDevs, req.VMDEnabled)
+	spdkOpts := &spdk.EnvOptions{
+		PCIAllowList: needDevs,
+		EnableVMD:    req.VMDEnabled,
+	}
 
 	restoreAfterInit, err := sb.binding.init(sb.log, spdkOpts)
 	if err != nil {
@@ -435,7 +438,10 @@ func (sb *spdkBackend) formatNvme(req *storage.BdevFormatRequest) (*storage.Bdev
 		needDevs = dl
 	}
 
-	spdkOpts := spdk.NewEnvOptions(needDevs, req.VMDEnabled)
+	spdkOpts := &spdk.EnvOptions{
+		PCIAllowList: needDevs,
+		EnableVMD:    req.VMDEnabled,
+	}
 
 	restoreAfterInit, err := sb.binding.init(sb.log, spdkOpts)
 	if err != nil {

--- a/src/control/server/storage/bdev/backend.go
+++ b/src/control/server/storage/bdev/backend.go
@@ -295,10 +295,7 @@ func (sb *spdkBackend) Scan(req storage.BdevScanRequest) (*storage.BdevScanRespo
 	sb.log.Debugf("spdk backend scan (bindings discover call): %+v", req)
 
 	needDevs := req.DeviceList.PCIAddressSetPtr()
-	spdkOpts := &spdk.EnvOptions{
-		PCIAllowList: needDevs,
-		EnableVMD:    req.VMDEnabled,
-	}
+	spdkOpts := spdk.NewEnvOptions(needDevs, req.VMDEnabled)
 
 	restoreAfterInit, err := sb.binding.init(sb.log, spdkOpts)
 	if err != nil {
@@ -438,10 +435,7 @@ func (sb *spdkBackend) formatNvme(req *storage.BdevFormatRequest) (*storage.Bdev
 		needDevs = dl
 	}
 
-	spdkOpts := &spdk.EnvOptions{
-		PCIAllowList: needDevs,
-		EnableVMD:    req.VMDEnabled,
-	}
+	spdkOpts := spdk.NewEnvOptions(needDevs, req.VMDEnabled)
 
 	restoreAfterInit, err := sb.binding.init(sb.log, spdkOpts)
 	if err != nil {


### PR DESCRIPTION
Update control API to enable dmg config generate to work with
VMD-enabled storage servers. The cmd output YAML should contain
bdev_list of discovered (NUMA locality aligned) VMD endpoint addresses
and have verified that the number of VMD endpoints and total number of
backing NVMe SSDs behind the endpoints are both equal for each engine.

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>