### PR TITLE
DAOS-9277 test: Add delay after reintegrating few targets.

### DIFF
--- a/src/tests/ftest/osa/offline_reintegration.py
+++ b/src/tests/ftest/osa/offline_reintegration.py
@@ -4,7 +4,7 @@
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
-import random
+import random, time
 from osa_utils import OSAUtils
 from daos_utils import DaosCommand
 from nvme_utils import ServerFillUp
@@ -152,6 +152,9 @@ class OSAOfflineReintegration(OSAUtils, ServerFillUp):
                     output = self.dmg_command.pool_reintegrate(self.pool.uuid,
                                                                rank[val],
                                                                "0,2")
+                    # Insert a time delay when trying to reintegrate only few targets
+                    # This will avoid intermittent -2031 when we write data to the object.
+                    time.sleep(5)
                 elif (self.test_with_rf is True and val == 0):
                     output = self.dmg_command.pool_reintegrate(self.pool.uuid,
                                                                rank[val])


### PR DESCRIPTION
Test-tag-hw-medium: pr,hw,medium,ib2 offline_reintegration_oclass

Summary:
  - Add 5 second delay after reintegrating few targets.

Signed-off-by: rpadma2 <ravindran.padmanabhan@intel.com>