### PR TITLE
DAOS-7607 test: Update slurm for soak testing (#6820)

### DIFF
--- a/src/client/api/container.c
+++ b/src/client/api/container.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2015-2021 Intel Corporation.
+ * (C) Copyright 2015-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */

--- a/src/include/daos_cont.h
+++ b/src/include/daos_cont.h
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2020-2021 Intel Corporation.
+ * (C) Copyright 2020-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */

--- a/src/include/daos_srv/vea.h
+++ b/src/include/daos_srv/vea.h
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2018-2021 Intel Corporation.
+ * (C) Copyright 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */

--- a/src/tests/ftest/nvme/io_verification.py
+++ b/src/tests/ftest/nvme/io_verification.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 """
-  (C) Copyright 2020-2021 Intel Corporation.
+  (C) Copyright 2020-2022 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """

--- a/src/tests/ftest/osa/dmg_negative_test.py
+++ b/src/tests/ftest/osa/dmg_negative_test.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 """
-  (C) Copyright 2020-2021 Intel Corporation.
+  (C) Copyright 2020-2022 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """

--- a/src/tests/ftest/pool/permission.py
+++ b/src/tests/ftest/pool/permission.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 '''
-  (C) Copyright 2018-2021 Intel Corporation.
+  (C) Copyright 2018-2022 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''

--- a/src/tests/ftest/scripts/main.sh
+++ b/src/tests/ftest/scripts/main.sh
@@ -214,7 +214,7 @@ fi
 
 # check if slurm needs to be configured for soak
 if [[ "${TEST_TAG_ARG}" =~ soak ]]; then
-    if ! ./slurm_setup.py -c "$FIRST_NODE" -n "${TEST_NODES}" -s -i; then
+    if ! ./slurm_setup.py -d -c "$FIRST_NODE" -n "${TEST_NODES}" -s -i; then
         exit "${PIPESTATUS[0]}"
     else
         rc=0

--- a/src/tests/ftest/slurm_setup.py
+++ b/src/tests/ftest/slurm_setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 """
-  (C) Copyright 2018-2021 Intel Corporation.
+  (C) Copyright 2018-2022 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -15,14 +15,10 @@ import sys
 from ClusterShell.NodeSet import NodeSet
 from util.general_utils import pcmd, run_task
 
-
 SLURM_CONF = "/etc/slurm/slurm.conf"
-
 
 PACKAGE_LIST = ["slurm", "slurm-example-configs",
                 "slurm-slurmctld", "slurm-slurmd"]
-
-PACKAGE_VERSION = "18.08.8-1.el7.x86_64"
 
 COPY_LIST = ["cp /etc/slurm/slurm.conf.example /etc/slurm/slurm.conf",
              "cp /etc/slurm/cgroup.conf.example /etc/slurm/cgroup.conf",
@@ -37,9 +33,17 @@ SLURMCTLD_STARTUP = [
     "systemctl restart slurmctld",
     "systemctl enable slurmctld"]
 
+SLURMCTLD_STARTUP_DEBUG = [
+    "cat /var/log/slurmctld.log",
+    "grep -v \"^#\\w\" /etc/slurm/slurm.conf"]
+
 SLURMD_STARTUP = [
     "systemctl restart slurmd",
     "systemctl enable slurmd"]
+
+SLURMD_STARTUP_DEBUG = [
+    "cat /var/log/slurmd.log",
+    "grep -v \"^#\\w\" /etc/slurm/slurm.conf"]
 
 
 def update_config_cmdlist(args):
@@ -53,6 +57,14 @@ def update_config_cmdlist(args):
 
     """
     all_nodes = NodeSet("{},{}".format(str(args.control), str(args.nodes)))
+    cmd_list = [
+        "sed -i -e 's/ClusterName=cluster/ClusterName=ci_cluster/g' {}".format(
+            SLURM_CONF),
+        "sed -i -e 's/SlurmUser=slurm/SlurmUser={}/g' {}".format(
+            args.user, SLURM_CONF),
+        "sed -i -e 's/NodeName/#NodeName/g' {}".format(
+            SLURM_CONF),
+        ]
     if not args.sudo:
         sudo = ""
     else:
@@ -60,17 +72,21 @@ def update_config_cmdlist(args):
     # Copy the slurm*example.conf files to /etc/slurm/
     if execute_cluster_cmds(all_nodes, COPY_LIST, args.sudo) > 0:
         sys.exit(1)
-
-    cmd_list = [
-        "sed -i -e 's/ControlMachine=linux0/ControlMachine={}/g' {}".format(
-            args.control, SLURM_CONF),
-        "sed -i -e 's/ClusterName=linux/ClusterName=ci_cluster/g' {}".format(
-            SLURM_CONF),
-        "sed -i -e 's/SlurmUser=slurm/SlurmUser={}/g' {}".format(
-            args.user, SLURM_CONF),
-        "sed -i -e 's/NodeName/#NodeName/g' {}".format(
-            SLURM_CONF),
-        ]
+    match = False
+    # grep SLURM_CONF to determine format of the the file
+    for ctl_host in ["SlurmctldHost", "ControlMachine"]:
+        command = r"grep {} {}".format(ctl_host, SLURM_CONF)
+        task = run_task(all_nodes, command)
+        results = dict(task.iter_retcodes())
+        if len(results) == 1 and 0 in results:
+            ctl_str = "sed -i -e 's/{0}=linux0/{0}={1}/g' {2}".format(
+                ctl_host, args.control, SLURM_CONF)
+            cmd_list.insert(0, ctl_str)
+            match = True
+            break
+    if not match:
+        logging.error("% could not be updated. Check conf file format", SLURM_CONF)
+        sys.exit(1)
 
     # This info needs to be gathered from every node that can run a slurm job
     command = r"lscpu | grep -E '(Socket|Core|Thread)\(s\)'"
@@ -93,7 +109,7 @@ def update_config_cmdlist(args):
                             info["Core"], info["Thread"], sudo, SLURM_CONF))
 
     #
-    cmd_list.append("echo \"PartitionName= {} Nodes={} Default=YES "
+    cmd_list.append("echo \"PartitionName={} Nodes={} Default=YES "
                     "MaxTime=INFINITE State=UP\" |{} tee -a {}".format(
                         args.partition, args.nodes, sudo, SLURM_CONF))
 
@@ -131,14 +147,12 @@ def configuring_packages(args, action):
         action (str):  install or remove
 
     """
-    # Install yum packages on control and compute nodes
+    # Install packages on control and compute nodes
     all_nodes = NodeSet("{},{}".format(str(args.control), str(args.nodes)))
     cmd_list = []
     for package in PACKAGE_LIST:
-        if PACKAGE_VERSION:
-            package = package + "-" + PACKAGE_VERSION
         logging.info("%s %s on %s", action, package, all_nodes)
-        cmd_list.append("yum {} -y ".format(action) + package)
+        cmd_list.append("dnf {} -y ".format(action) + package)
     return execute_cluster_cmds(all_nodes, cmd_list, args.sudo)
 
 
@@ -206,26 +220,44 @@ def start_slurm(args):
     cmd_list = [
         "mkdir -p /var/log/slurm",
         "chown {}. {}".format(args.user, "/var/log/slurm"),
+        "mkdir -p /var/spool/slurmd",
+        "mkdir -p /var/spool/slurmctld",
         "mkdir -p /var/spool/slurm/d",
         "mkdir -p /var/spool/slurm/ctld",
-        "chown {}. {}/ctld".format(args.user, "/var/spool/slurm")
+        "chown {}. {}/ctld".format(args.user, "/var/spool/slurm"),
+        "chown {}. {}".format(args.user, "/var/spool/slurmctld"),
+        "chmod 775 {}".format("/var/spool/slurmctld"),
+        "rm -f /var/spool/slurmctld/clustername"
         ]
 
     if execute_cluster_cmds(all_nodes, cmd_list, args.sudo) > 0:
         return 1
 
     # Startup the slurm control service
-    if execute_cluster_cmds(args.control, SLURMCTLD_STARTUP, args.sudo) > 0:
+    status = execute_cluster_cmds(args.control, SLURMCTLD_STARTUP, args.sudo)
+    if status > 0 or args.debug:
+        execute_cluster_cmds(args.control, SLURMCTLD_STARTUP_DEBUG, args.sudo)
+    if status > 0:
         return 1
 
     # Startup the slurm service
-    if execute_cluster_cmds(all_nodes, SLURMD_STARTUP, args.sudo) > 0:
+    status = execute_cluster_cmds(all_nodes, SLURMD_STARTUP, args.sudo)
+    if status > 0 or args.debug:
+        execute_cluster_cmds(all_nodes, SLURMD_STARTUP_DEBUG, args.sudo)
+    if status > 0:
         return 1
 
     # ensure that the nodes are in the idle state
-    cmd_list = ["scontrol update nodename={} state=idle".format(
-        args.nodes)]
-    return execute_cluster_cmds(args.control, cmd_list, args.sudo)
+    cmd_list = ["scontrol update nodename={} state=idle".format(args.nodes)]
+    status = execute_cluster_cmds(args.nodes, cmd_list, args.sudo)
+    if status > 0 or args.debug:
+        cmd_list = (SLURMCTLD_STARTUP_DEBUG)
+        execute_cluster_cmds(args.control, cmd_list, args.sudo)
+        cmd_list = (SLURMD_STARTUP_DEBUG)
+        execute_cluster_cmds(all_nodes, cmd_list, args.sudo)
+    if status > 0:
+        return 1
+    return 0
 
 
 def main():
@@ -264,6 +296,10 @@ def main():
         "-s", "--sudo",
         action="store_true",
         help="Run all commands with privileges")
+    parser.add_argument(
+        "-d", "--debug",
+        action="store_true",
+        help="Run all debug commands")
 
     args = parser.parse_args()
     logging.info("Arguments: %s", args)

--- a/src/tests/ftest/soak/harassers.yaml
+++ b/src/tests/ftest/soak/harassers.yaml
@@ -46,7 +46,6 @@ server_config:
             log_mask: ERR
             env_vars:
                 - FI_UNIVERSE_SIZE=2048
-                - ABT_THREAD_STACKSIZE=32768
         1:
             pinned_numa_node: 1
             nr_xs_helpers: 1
@@ -61,7 +60,6 @@ server_config:
             log_mask: ERR
             env_vars:
                 - FI_UNIVERSE_SIZE=2048
-                - ABT_THREAD_STACKSIZE=32768
 # pool_params - attributes of the pools to create; Currently only create one
 pool_jobs:
     name: daos_server
@@ -163,6 +161,7 @@ ior_harasser:
         mount_dir: "/tmp/daos_dfuse/ior"
         disable_caching: True
 fio_harasser:
+  job_timeout: 20
   names:
       - global
       - test

--- a/src/tests/ftest/soak/smoke.yaml
+++ b/src/tests/ftest/soak/smoke.yaml
@@ -95,6 +95,8 @@ smoke:
         - fio_smoke
         - daos_racer
         - mdtest_smoke
+    # num of bytes to write to reserved container
+    resv_bytes: 500
 # Commandline parameters
 # Benchmark and application params
 # IOR params -a DFS and -a MPIIO
@@ -132,7 +134,7 @@ ior_smoke:
         mount_dir: "/tmp/daos_dfuse/ior/"
         disable_caching: True
 fio_smoke:
-    # maximum timeout for a single job in test in minutes
+    job_timeout: 10
     names:
         - global
         - test

--- a/src/tests/ftest/soak/stress_2h.yaml
+++ b/src/tests/ftest/soak/stress_2h.yaml
@@ -11,6 +11,7 @@ hosts:
     client_reservation: daos-test
 orterun:
     allow_run_as_root: True
+mpi_module: mpich/gnu-sockets/43.2
 # This timeout must be longer than the test_timeout param (+15minutes)
 # 2 hour test
 timeout: 1H15M

--- a/src/tests/ftest/soak/stress_48h.yaml
+++ b/src/tests/ftest/soak/stress_48h.yaml
@@ -46,8 +46,7 @@ server_config:
             log_mask: ERR
             env_vars:
                 - FI_UNIVERSE_SIZE=2048
-                - DAOS_MC_CAP=1024
-                - ABT_THREAD_STACKSIZE=32768
+                - DAOS_MD_CAP=1024
         1:
             pinned_numa_node: 1
             nr_xs_helpers: 1
@@ -62,8 +61,7 @@ server_config:
             log_mask: ERR
             env_vars:
                 - FI_UNIVERSE_SIZE=2048
-                - DAOS_MC_CAP=1024
-                - ABT_THREAD_STACKSIZE=32768
+                - DAOS_MD_CAP=1024
 # pool_params - attributes of the pools to create; Currently only create one
 pool_jobs:
     name: daos_server
@@ -148,6 +146,7 @@ ior_stress:
         mount_dir: "/tmp/daos_dfuse/ior/"
         disable_caching: True
 fio_stress:
+  job_timeout: 30
   names:
     - global
     - test

--- a/src/tests/ftest/soak/test_base.py
+++ b/src/tests/ftest/soak/test_base.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 """
-(C) Copyright 2019-2021 Intel Corporation.
+(C) Copyright 2019-2022 Intel Corporation.
 
 SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -13,19 +13,20 @@ import threading
 import random
 from filecmp import cmp
 from apricot import TestWithServers
-from general_utils import run_command, DaosTestError, get_log_file
+from general_utils import run_command, DaosTestError
 from command_utils_base import CommandFailure
 import slurm_utils
 from ClusterShell.NodeSet import NodeSet
 from getpass import getuser
 import socket
 from agent_utils import include_local_host
-from utils import DDHHMMSS_format, add_pools, get_remote_logs, \
+from utils import DDHHMMSS_format, add_pools, get_remote_dir, \
     launch_snapshot, launch_exclude_reintegrate, \
     create_ior_cmdline, cleanup_dfuse, create_fio_cmdline, \
     build_job_script, SoakTestError, launch_server_stop_start, get_harassers, \
     create_racer_cmdline, run_event_check, run_monitor_check, \
-    create_mdtest_cmdline, reserved_file_copy, run_metrics_check
+    create_mdtest_cmdline, reserved_file_copy, run_metrics_check, \
+    get_journalctl, get_daos_server_logs
 
 
 class SoakTestBase(TestWithServers):
@@ -40,13 +41,13 @@ class SoakTestBase(TestWithServers):
         """Initialize a SoakBase object."""
         super().__init__(*args, **kwargs)
         self.failed_job_id_list = None
-        self.test_log_dir = None
+        self.soaktest_dir = None
         self.exclude_slurm_nodes = None
         self.loop = None
-        self.log_dir = None
-        self.outputsoakdir = None
+        self.outputsoak_dir = None
         self.test_name = None
         self.test_timeout = None
+        self.start_time = None
         self.end_time = None
         self.soak_results = None
         self.srun_params = None
@@ -62,6 +63,9 @@ class SoakTestBase(TestWithServers):
         self.all_failed_harassers = None
         self.soak_errors = None
         self.check_errors = None
+        self.initial_resv_file = None
+        self.resv_cont = None
+        self.mpi_module = None
 
     def setUp(self):
         """Define test setup to be done."""
@@ -73,13 +77,12 @@ class SoakTestBase(TestWithServers):
         self.exclude_slurm_nodes = []
         # Setup logging directories for soak logfiles
         # self.output dir is an avocado directory .../data/
-        self.log_dir = get_log_file("soak")
-        self.outputsoakdir = self.outputdir + "/soak"
+        self.outputsoak_dir = self.outputdir + "/soak"
         # Create the remote log directories on all client nodes
-        self.test_log_dir = self.log_dir + "/pass" + str(self.loop)
-        self.local_pass_dir = self.outputsoakdir + "/pass" + str(self.loop)
-        self.sharedlog_dir = self.tmp + "/soak"
-        self.sharedsoakdir = self.sharedlog_dir + "/pass" + str(self.loop)
+        self.soak_dir = self.base_test_dir + "/soak"
+        self.soaktest_dir = self.soak_dir + "/pass" + str(self.loop)
+        self.sharedsoak_dir = self.tmp + "/soak"
+        self.sharedsoaktest_dir = self.sharedsoak_dir + "/pass" + str(self.loop)
         # Initialize dmg cmd
         self.dmg_command = self.get_dmg_command()
         # Fail if slurm partition is not defined
@@ -123,8 +126,6 @@ class SoakTestBase(TestWithServers):
         """
         self.log.info("<<preTearDown Started>> at %s", time.ctime())
         errors = []
-        # display final metrics
-        run_metrics_check(self, prefix="final")
         # clear out any jobs in squeue;
         if self.failed_job_id_list:
             job_id = " ".join([str(job) for job in self.failed_job_id_list])
@@ -140,6 +141,39 @@ class SoakTestBase(TestWithServers):
         if self.all_failed_jobs:
             errors.append("SOAK FAILED: The following jobs failed {} ".format(
                 " ,".join(str(j_id) for j_id in self.all_failed_jobs)))
+
+        # verify reserved container data
+        if self.resv_cont:
+            final_resv_file = os.path.join(self.test_dir, "final", "resv_file")
+            try:
+                reserved_file_copy(self, final_resv_file, self.pool[0], self.resv_cont)
+            except CommandFailure:
+                self.soak_errors.append("<<FAILED: Soak reserved container read failed>>")
+
+            if not cmp(self.initial_resv_file, final_resv_file):
+                self.soak_errors.append("<<FAILED: Data verification error on reserved pool"
+                                        " after SOAK completed>>")
+
+            for file in [self.initial_resv_file, final_resv_file]:
+                os.remove(file)
+
+            self.container.append(self.resv_cont)
+
+        # display final metrics
+        run_metrics_check(self, prefix="final")
+        # Gather server logs
+        get_daos_server_logs(self)
+        # Gather journalctl logs
+        hosts = list(set(self.hostlist_servers))
+        since = time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(self.start_time))
+        until = time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(self.end_time))
+        for journalctl_type in ["kernel", "daos_server"]:
+            get_journalctl(self, hosts, since, until, journalctl_type, logging=True)
+        # Gather client daos logs with resource manager
+        get_remote_dir(
+            self, self.base_test_dir, self.outputsoak_dir, self.hostlist_clients,
+            shared_dir=self.sharedsoak_dir, rm_remote=False, append="/daos_logs-")
+
         if self.all_failed_harassers:
             errors.extend(self.all_failed_harassers)
         if self.soak_errors:
@@ -388,8 +422,6 @@ class SoakTestBase(TestWithServers):
                                 offline_harasser, self.pool)
                             # wait 2 minutes to issue next harasser
                             time.sleep(120)
-            # Gather metrics data after jobs complete
-            run_metrics_check(self)
             # check journalctl for events;
             until = datetime.now().strftime('%Y-%m-%d %H:%M:%S')
             event_check_messages = run_event_check(self, since, until)
@@ -409,7 +441,7 @@ class SoakTestBase(TestWithServers):
                         "<< Job %s failed with status %s>>", job, result)
             # gather all the logfiles for this pass and cleanup test nodes
             try:
-                get_remote_logs(self)
+                get_remote_dir(self, self.soaktest_dir, self.outputsoak_dir, self.hostlist_clients)
             except SoakTestError as error:
                 self.log.info("Remote copy failed with %s", error)
             self.soak_results = {}
@@ -436,19 +468,22 @@ class SoakTestBase(TestWithServers):
         """
         job_script_list = []
         # Update the remote log directories from new loop/pass
-        self.sharedsoakdir = self.sharedlog_dir + "/pass" + str(self.loop)
-        self.test_log_dir = self.log_dir + "/pass" + str(self.loop)
-        local_pass_dir = self.outputsoakdir + "/pass" + str(self.loop)
+        self.sharedsoaktest_dir = self.sharedsoak_dir + "/pass" + str(self.loop)
+        self.soaktest_dir = self.soak_dir + "/pass" + str(self.loop)
+        outputsoaktest_dir = self.outputsoak_dir + "/pass" + str(self.loop)
         result = slurm_utils.srun(
             NodeSet.fromlist(self.hostlist_clients), "mkdir -p {}".format(
-                self.test_log_dir), self.srun_params)
+                self.soaktest_dir), self.srun_params)
         if result.exit_status > 0:
             raise SoakTestError(
                 "<<FAILED: logfile directory not"
                 "created on clients>>: {}".format(self.hostlist_clients))
-        # Create local log directory
-        os.makedirs(local_pass_dir)
-        os.makedirs(self.sharedsoakdir)
+        # Create local avocado log directory for this pass
+        os.makedirs(outputsoaktest_dir)
+        # Create shared log directory for this pass
+        os.makedirs(self.sharedsoaktest_dir)
+        # Create local test log directory for this pass
+        os.makedirs(self.soaktest_dir)
         # create the batch scripts
         job_script_list = self.job_setup(jobs, pools)
         # randomize job list
@@ -490,12 +525,14 @@ class SoakTestBase(TestWithServers):
         self.soak_errors = []
         self.check_errors = []
         self.used = []
+        self.mpi_module = self.params.get("mpi_module", "/run/*", default="mpi/mpich-x86_64")
         test_to = self.params.get("test_timeout", test_param + "*")
         self.test_name = self.params.get("name", test_param + "*")
         single_test_pool = self.params.get(
             "single_test_pool", test_param + "*", True)
         harassers = self.params.get("harasserlist", test_param + "*")
         job_list = self.params.get("joblist", test_param + "*")
+        resv_bytes = self.params.get("resv_bytes", test_param + "*", 500000000)
         ignore_soak_errors = self.params.get("ignore_soak_errors", test_param + "*", False)
         if harassers:
             run_harasser = True
@@ -506,14 +543,13 @@ class SoakTestBase(TestWithServers):
         # self.pool[0] will always be the reserved pool
         add_pools(self, ["pool_reserved"])
         # Create the reserved container
-        resv_cont = self.get_container(
+        self.resv_cont = self.get_container(
             self.pool[0], "/run/container_reserved/*", True)
-        # populate reserved container with a 500MB file
-        initial_resv_file = os.path.join(
-            os.environ["DAOS_TEST_LOG_DIR"], "initial", "resv_file")
+        # populate reserved container with a 500MB file unless test is smoke
+        self.initial_resv_file = os.path.join(self.test_dir, "initial", "resv_file")
         try:
-            reserved_file_copy(self, initial_resv_file, self.pool[0], resv_cont,
-                               num_bytes=500000000, cmd="write")
+            reserved_file_copy(self, self.initial_resv_file, self.pool[0], self.resv_cont,
+                               num_bytes=resv_bytes, cmd="write")
         except CommandFailure as error:
             self.fail(error)
 
@@ -527,13 +563,13 @@ class SoakTestBase(TestWithServers):
         # cleanup soak log directories before test on all nodes
         result = slurm_utils.srun(
             NodeSet.fromlist(self.hostlist_clients), "rm -rf {}".format(
-                self.log_dir), self.srun_params)
+                self.soak_dir), self.srun_params)
         if result.exit_status > 0:
             raise SoakTestError(
                 "<<FAILED: Soak directories not removed"
                 "from clients>>: {}".format(self.hostlist_clients))
         # cleanup test_node
-        for log_dir in [self.log_dir, self.sharedlog_dir]:
+        for log_dir in [self.soak_dir, self.sharedsoak_dir]:
             cmd = "rm -rf {}".format(log_dir)
             try:
                 result = run_command(cmd, timeout=30)
@@ -544,9 +580,9 @@ class SoakTestBase(TestWithServers):
         # Baseline metrics data
         run_metrics_check(self, prefix="initial")
         # Initialize time
-        start_time = time.time()
+        self.start_time = time.time()
         self.test_timeout = int(3600 * test_to)
-        self.end_time = start_time + self.test_timeout
+        self.end_time = self.start_time + self.test_timeout
         self.log.info("<<START %s >> at %s", self.test_name, time.ctime())
         while time.time() < self.end_time:
             # Start new pass
@@ -586,6 +622,8 @@ class SoakTestBase(TestWithServers):
             self.log.info(
                 "Current pools: %s",
                 " ".join([pool.uuid for pool in self.pool]))
+            # Gather metrics data after jobs complete
+            run_metrics_check(self)
             # Fail if the pool/containers did not clean up correctly
             if not ignore_soak_errors:
                 self.assertEqual(
@@ -601,32 +639,6 @@ class SoakTestBase(TestWithServers):
             if self.loop == 1 and run_harasser:
                 self.harasser_loop_time = loop_time
             self.loop += 1
-        # verify reserved container data
-        final_resv_file = os.path.join(
-            os.environ["DAOS_TEST_LOG_DIR"], "final", "resv_file")
-        try:
-            reserved_file_copy(self, final_resv_file, self.pool[0], resv_cont)
-        except CommandFailure as error:
-            self.soak_errors.append(
-                "<<FAILED: Soak reserved container read failed>>")
-
-        if not cmp(initial_resv_file, final_resv_file):
-            self.soak_errors.append("Data verification error on reserved pool"
-                                    " after SOAK completed")
-        for file in [initial_resv_file, final_resv_file]:
-            if os.path.isfile(file):
-                file_name = os.path.split(os.path.dirname(file))[-1]
-                # save a copy of the POSIX file in self.outputsoakdir
-                copy_cmd = "cp -p {} {}/{}_resv_file".format(
-                    file, self.outputsoakdir, file_name)
-                try:
-                    run_command(copy_cmd, timeout=30)
-                except DaosTestError as error:
-                    self.soak_errors.append(
-                        "Reserved data file {} failed to archive".format(file))
-                os.remove(file)
-        self.container.append(resv_cont)
-        # Gather the daos logs from the client nodes
         self.log.info(
             "<<<<SOAK TOTAL TEST TIME = %s>>>>", DDHHMMSS_format(
-                time.time() - start_time))
+                time.time() - self.start_time))

--- a/src/tests/ftest/soak/utils.py
+++ b/src/tests/ftest/soak/utils.py
@@ -1,9 +1,11 @@
 #!/usr/bin/python
 """
-(C) Copyright 2019-2021 Intel Corporation.
+(C) Copyright 2019-2022 Intel Corporation.
 
 SPDX-License-Identifier: BSD-2-Clause-Patent
 """
+# pylint: disable=too-many-lines
+
 import os
 import time
 import random
@@ -15,16 +17,16 @@ from mdtest_utils import MdtestCommand
 from daos_racer_utils import DaosRacerCommand
 from data_mover_utils import FsCopy
 from dfuse_utils import Dfuse
-from job_manager_utils import Srun
+from job_manager_utils import Srun, Mpirun
 from general_utils import get_host_data, get_random_string, \
-    run_command, DaosTestError, pcmd, get_random_bytes, run_pcmd
+    run_command, DaosTestError, pcmd, get_random_bytes, \
+    run_pcmd
 import slurm_utils
 from daos_utils import DaosCommand
 from test_utils_container import TestContainer
 from ClusterShell.NodeSet import NodeSet
 from avocado.core.exceptions import TestFail
 from pydaos.raw import DaosSnapshot, DaosApiError
-
 
 H_LOCK = threading.Lock()
 
@@ -41,7 +43,7 @@ def DDHHMMSS_format(seconds):
     seconds = int(seconds)
     if seconds < 86400:
         return time.strftime("%H:%M:%S", time.gmtime(seconds))
-    num_days = seconds / 86400
+    num_days = int(seconds / 86400)
     return "{} {} {}".format(
         num_days, 'Day' if num_days == 1 else 'Days', time.strftime(
             "%H:%M:%S", time.gmtime(seconds % 86400)))
@@ -144,52 +146,78 @@ def reserved_file_copy(self, file, pool, container, num_bytes=None, cmd="read"):
         fscopy_cmd.run()
 
 
-def get_remote_logs(self):
+def get_remote_dir(self, source_dir, dest_dir, host_list, shared_dir=None,
+                   rm_remote=True, append=None):
     """Copy files from remote dir to local dir.
 
     Args:
         self (obj): soak obj
+        source_dir (str): Source directory to archive
+        dest_dir (str): Destinaton directory
+        host_list (list): list of hosts
 
     Raises:
         SoakTestError: if there is an error with the remote copy
 
     """
-    # copy the files from the client nodes to a shared directory
-    command = "/usr/bin/rsync -avtr --min-size=1B {0} {1}/..".format(
-        self.test_log_dir, self.sharedsoakdir)
-    result = slurm_utils.srun(
-        NodeSet.fromlist(self.hostlist_clients), command, self.srun_params)
-    if result.exit_status == 0:
-        # copy the local logs and the logs in the shared dir to avocado dir
-        for directory in [self.test_log_dir, self.sharedsoakdir]:
-            command = "/usr/bin/cp -R -p {0}/ \'{1}\'".format(
-                directory, self.outputsoakdir)
+    if shared_dir is None:
+        shared_dir = self.sharedsoaktest_dir
+    if append:
+        for host in host_list:
+            shared_dir_tmp = shared_dir + append + "{}".format(host)
+            dest_dir_tmp = dest_dir + append + "{}".format(host)
+            if not os.path.exists(shared_dir_tmp):
+                os.mkdir(shared_dir_tmp)
+            if not os.path.exists(dest_dir_tmp):
+                os.mkdir(dest_dir_tmp)
+            # copy the directory from each client node to a shared directory
+            # tagged with the hostname
+            command = "/usr/bin/rsync -avtr --min-size=1B {0} {1}/..".format(
+                source_dir, shared_dir_tmp)
             try:
-                result = run_command(command, timeout=30)
+                slurm_utils.srun(NodeSet.fromlist([host]), command, self.srun_params, timeout=300)
             except DaosTestError as error:
                 raise SoakTestError(
-                    "<<FAILED: job logs failed to copy>>") from error
+                    "<<FAILED: Soak remote logfiles not copied from clients>>: {}".format(
+                        host)) from error
+            command = "/usr/bin/cp -R -p {0}/ \'{1}\'".format(shared_dir_tmp, dest_dir)
+            try:
+                run_command(command, timeout=30)
+            except DaosTestError as error:
+                raise SoakTestError("<<FAILED: job logs failed to copy>>") from error
+    else:
+        # copy the remote dir on all client nodes to a shared directory
+        command = "/usr/bin/rsync -avtr --min-size=1B {0} {1}/..".format(
+            source_dir, shared_dir)
+        try:
+            slurm_utils.srun(NodeSet.fromlist(host_list), command, self.srun_params, timeout=300)
+        except DaosTestError as error:
+            raise SoakTestError(
+                "<<FAILED: Soak remote logfiles not copied from clients>>: {}".format(
+                    host_list)) from error
+        # copy the local logs and the logs in the shared dir to avocado dir
+        for directory in [source_dir, shared_dir]:
+            command = "/usr/bin/cp -R -p {0}/ \'{1}\'".format(directory, dest_dir)
+            try:
+                run_command(command, timeout=30)
+            except DaosTestError as error:
+                raise SoakTestError("<<FAILED: job logs failed to copy>>") from error
+    if rm_remote:
         # remove the remote soak logs for this pass
-        command = "/usr/bin/rm -rf {0}".format(self.test_log_dir)
-        slurm_utils.srun(
-            NodeSet.fromlist(self.hostlist_clients), command,
-            self.srun_params)
+        command = "/usr/bin/rm -rf {0}".format(source_dir)
+        slurm_utils.srun(NodeSet.fromlist(host_list), command, self.srun_params)
         # remove the local log for this pass
-        for directory in [self.test_log_dir, self.sharedsoakdir]:
+        for directory in [source_dir, shared_dir]:
             command = "/usr/bin/rm -rf {0}".format(directory)
             try:
-                result = run_command(command)
+                run_command(command)
             except DaosTestError as error:
                 raise SoakTestError(
                     "<<FAILED: job logs failed to delete>>") from error
-    else:
-        raise SoakTestError(
-            "<<FAILED: Soak remote logfiles not copied "
-            "from clients>>: {}".format(self.hostlist_clients))
 
 
 def write_logfile(data, name, destination):
-    """Write date to the local destination file.
+    """Write data to the local destination file.
 
     Args:
         self (obj): soak obj
@@ -198,14 +226,14 @@ def write_logfile(data, name, destination):
     """
     if not os.path.exists(destination):
         os.makedirs(destination)
-    scriptfile = destination + "/" + str(name)
-    with open(scriptfile, 'w') as script_file:
+    logfile = destination + "/" + str(name)
+    with open(logfile, 'w') as log_file:
         # identify what be used to run this script
         if isinstance(data, list):
             text = "\n".join(data)
-            script_file.write(text)
+            log_file.write(text)
         else:
-            script_file.write(str(data))
+            log_file.write(str(data))
 
 
 def run_event_check(self, since, until):
@@ -213,34 +241,82 @@ def run_event_check(self, since, until):
 
     Args:
         self (obj): soak obj
+        since (str): start time
+        until (str): end time
+        log (bool):  If true; write the events to a logfile
 
     Returns list of any matched events found in system log
 
     """
+    # pylint: disable=too-many-nested-blocks
+
     events_found = []
     detected = 0
-    # to do: currently all events are from - t kernel;
-    # when systemctl is enabled add daos events
     events = self.params.get("events", "/run/*")
-    # check events on all nodes
+    # check events on all server nodes
     hosts = list(set(self.hostlist_servers))
     if events:
-        command = ("sudo /usr/bin/journalctl --system -t kernel -t "
-                   "daos_server --since=\"{}\" --until=\"{}\"".format(
-                       since, until))
-        err = "Error gathering system log events"
-        for event in events:
-            for output in get_host_data(hosts, command, "journalctl", err):
-                lines = output["data"].splitlines()
-                for line in lines:
-                    match = re.search(r"{}".format(event), str(line))
-                    if match:
-                        events_found.append(line)
-                        detected += 1
-                self.log.info(
-                    "Found %s instances of %s in system log from %s through %s",
-                    detected, event, since, until)
+        for journalctl_type in ["kernel", "daos_server"]:
+            for output in get_journalctl(self, hosts, since, until, journalctl_type):
+                for event in events:
+                    lines = output["data"].splitlines()
+                    for line in lines:
+                        match = re.search(r"{}".format(event), str(line))
+                        if match:
+                            events_found.append(line)
+                            detected += 1
+                    self.log.info(
+                        "Found %s instances of %s in system log from %s through %s",
+                        detected, event, since, until)
     return events_found
+
+
+def get_journalctl(self, hosts, since, until, journalctl_type, logging=False):
+    """Run the journalctl on daos servers.
+
+    Args:
+        self (obj): soak obj
+        since (str): start time
+        until (str): end time
+        journalctl_type (str): the -t param for journalctl
+        log (bool):  If true; write the events to a logfile
+
+    Returns:
+        list: a list of dictionaries containing the following key/value pairs:
+            "hosts": NodeSet containing the hosts with this data
+            "data":  data requested for the group of hosts
+
+    """
+    command = "sudo /usr/bin/journalctl --system -t {} --since=\"{}\" --until=\"{}\"".format(
+        journalctl_type, since, until)
+    err = "Error gathering system log events"
+    results = get_host_data(hosts, command, "journalctl", err)
+    name = "journalctl_{}.log".format(journalctl_type)
+    destination = self.outputsoak_dir
+    if logging:
+        for result in results:
+            host = result["hosts"]
+            log_name = name + "-" + str(host)
+            self.log.info("Logging %s output to %s", command, log_name)
+            write_logfile(result["data"], log_name, destination)
+    return results
+
+
+def get_daos_server_logs(self):
+    """Gather server logs.
+
+    Args:
+        self (obj): soak obj
+
+    """
+    for host in self.hostlist_servers:
+        daos_dir = self.outputsoak_dir + "/daos_logs-" + "{}".format(host)
+        if not os.path.exists(daos_dir):
+            os.mkdir(daos_dir)
+            commands = ["scp {}:/var/tmp/daos_testing/daos*.log.* {}".format(host, daos_dir),
+                        "scp {}:/var/tmp/daos_testing/daos*.log {}".format(host, daos_dir)]
+            for command in commands:
+                run_command(command, timeout=120)
 
 
 def run_monitor_check(self):
@@ -274,16 +350,18 @@ def run_metrics_check(self, logging=True, prefix=None):
             name = "pass" + str(self.loop) + "_metrics_{}.csv".format(engine)
             if prefix:
                 name = prefix + "_metrics_{}.csv".format(engine)
-            destination = self.outputsoakdir
+            destination = self.outputsoak_dir
+            daos_metrics = "sudo daos_metrics -S {} --csv".format(engine)
+            self.log.info("Running %s", daos_metrics)
             results = run_pcmd(hosts=self.hostlist_servers,
-                               command="sudo daos_metrics -S {} --csv".format(
-                                   engine),
+                               command=daos_metrics,
                                verbose=(not logging),
                                timeout=60)
             if logging:
                 for result in results:
                     hosts = result["hosts"]
                     log_name = name + "-" + str(hosts)
+                    self.log.info("Logging %s output to %s", daos_metrics, log_name)
                     write_logfile(result["stdout"], log_name, destination)
 
 
@@ -549,6 +627,7 @@ def launch_server_stop_start(self, pools, name, results, args):
                 self.log.error(
                     "<<<FAILED:dmg system stop failed", exc_info=error)
                 status = False
+            time.sleep(30)
             if not drain:
                 rebuild_status = True
                 for pool in pools:
@@ -655,8 +734,7 @@ def get_srun_cmd(cmd, nodesperjob=1, ppn=1, srun_params=None, env=None):
     return str(srun_cmd)
 
 
-def start_dfuse(self, pool, container, nodesperjob, resource_mgr=None,
-                name=None, job_spec=None):
+def start_dfuse(self, pool, container, name=None, job_spec=None):
     """Create dfuse start command line for slurm.
 
     Args:
@@ -678,45 +756,40 @@ def start_dfuse(self, pool, container, nodesperjob, resource_mgr=None,
     dfuse.set_dfuse_params(pool)
     dfuse.set_dfuse_cont_param(container)
     dfuse_log = os.path.join(
-        self.test_log_dir,
-        self.test_name + "_" + name + "_${SLURM_JOB_NODELIST}_"
+        self.soaktest_dir,
+        self.test_name + "_" + name + "_`hostname -s`_"
         "" + "${SLURM_JOB_ID}_" + "daos_dfuse_" + unique)
     dfuse_env = "export D_LOG_MASK=ERR;export D_LOG_FILE={}".format(dfuse_log)
+    module_load = "module load {}".format(self.mpi_module)
     dfuse_start_cmds = [
-        "mkdir -p {}".format(dfuse.mount_dir.value),
-        "clush -S -w $SLURM_JOB_NODELIST \"cd {};{};{}\"".format(
-            dfuse.mount_dir.value, dfuse_env, dfuse.__str__()),
+        "clush -S -w $SLURM_JOB_NODELIST \"mkdir -p {}\"".format(dfuse.mount_dir.value),
+        "clush -S -w $SLURM_JOB_NODELIST \"cd {};{};{};{}\"".format(
+            dfuse.mount_dir.value, dfuse_env, module_load, dfuse.__str__()),
         "sleep 10",
-        "df -h {}".format(dfuse.mount_dir.value),
+        "clush -S -w $SLURM_JOB_NODELIST \"df -h {}\"".format(dfuse.mount_dir.value),
     ]
-    if resource_mgr == "SLURM":
-        cmds = []
-        for cmd in dfuse_start_cmds:
-            if cmd.startswith("clush") or cmd.startswith("sleep"):
-                cmds.append(cmd)
-            else:
-                cmds.append(get_srun_cmd(cmd, nodesperjob))
-        dfuse_start_cmds = cmds
     return dfuse, dfuse_start_cmds
 
 
-def stop_dfuse(dfuse, nodesperjob, resource_mgr=None):
+def stop_dfuse(dfuse, vol=False):
     """Create dfuse stop command line for slurm.
 
     Args:
         dfuse (obj): Dfuse obj
+        vol:(bool): cmd is ior hdf5 with vol connector
 
     Returns cmd(list):    list of cmds to pass to slurm script
     """
-    dfuse_stop_cmds = [
-        "fusermount3 -uz {0}".format(dfuse.mount_dir.value),
-        "rm -rf {0}".format(dfuse.mount_dir.value)
-    ]
-    if resource_mgr == "SLURM":
-        cmds = []
-        for dfuse_stop_cmd in dfuse_stop_cmds:
-            cmds.append(get_srun_cmd(dfuse_stop_cmd, nodesperjob))
-        dfuse_stop_cmds = cmds
+    dfuse_stop_cmds = []
+    if vol:
+        dfuse_stop_cmds.extend([
+            "for file in $(ls {0}) ; "
+            "do daos container destroy --path={0}/\"$file\" ; done".format(
+                dfuse.mount_dir.value)])
+
+    dfuse_stop_cmds.extend([
+        "clush -S -w $SLURM_JOB_NODELIST \"fusermount3 -uz {0}\"".format(dfuse.mount_dir.value),
+        "clush -S -w $SLURM_JOB_NODELIST \"rm -rf {0}\"".format(dfuse.mount_dir.value)])
     return dfuse_stop_cmds
 
 
@@ -740,16 +813,16 @@ def cleanup_dfuse(self):
         slurm_utils.srun(
             NodeSet.fromlist(
                 self.hostlist_clients), "{}".format(
-                    ";".join(cmd)), self.srun_params, timeout=180)
+                    ";".join(cmd)), self.srun_params, timeout=600)
     except slurm_utils.SlurmFailed as error:
-        self.log.info("Dfuse processes not stopped")
+        self.log.info("Dfuse processes not stopped Error:%s", error)
     try:
         slurm_utils.srun(
             NodeSet.fromlist(
                 self.hostlist_clients), "{}".format(
-                    ";".join(cmd2)), self.srun_params, timeout=180)
+                    ";".join(cmd2)), self.srun_params, timeout=600)
     except slurm_utils.SlurmFailed as error:
-        self.log.info("Dfuse mountpoints not deleted")
+        self.log.info("Dfuse mountpoints not deleted Error:%s", error)
 
 
 def create_ior_cmdline(self, job_spec, pool, ppn, nodesperjob):
@@ -768,10 +841,9 @@ def create_ior_cmdline(self, job_spec, pool, ppn, nodesperjob):
 
     """
     commands = []
+    vol = False
     ior_params = os.path.join(os.sep, "run", job_spec, "*")
     ior_timeout = self.params.get("job_timeout", ior_params, 10)
-    mpi_module = self.params.get(
-        "mpi_module", "/run/*", default="mpi/mpich-x86_64")
     # IOR job specs with a list of parameters; update each value
     api_list = self.params.get("api", ior_params)
     tsize_list = self.params.get("transfer_size", ior_params)
@@ -822,34 +894,37 @@ def create_ior_cmdline(self, job_spec, pool, ppn, nodesperjob):
                     add_containers(self, pool, o_type)
                     ior_cmd.set_daos_params(
                         self.server_group, pool, self.container[-1].uuid)
-                    env = ior_cmd.get_default_env("srun")
-                    sbatch_cmds = ["module load -q {}".format(mpi_module)]
-                    # include dfuse cmdlines
                     log_name = "{}_{}_{}_{}_{}_{}_{}_{}".format(
-                        job_spec, api, b_size, t_size, o_type,
-                        nodesperjob * ppn, nodesperjob, ppn)
+                        job_spec, api, b_size, t_size,
+                        o_type, nodesperjob * ppn, nodesperjob, ppn)
+                    daos_log = os.path.join(
+                        self.soaktest_dir, self.test_name + "_" + log_name +
+                        "_`hostname -s`_${SLURM_JOB_ID}_daos.log")
+                    env = ior_cmd.get_default_env("mpirun", log_file=daos_log)
+                    sbatch_cmds = ["module purge", "module load {}".format(self.mpi_module)]
+                    # include dfuse cmdlines
                     if api in ["HDF5-VOL", "POSIX"]:
                         dfuse, dfuse_start_cmdlist = start_dfuse(
-                            self, pool, self.container[-1], nodesperjob,
-                            "SLURM", name=log_name, job_spec=job_spec)
+                            self, pool, self.container[-1], name=log_name, job_spec=job_spec)
                         sbatch_cmds.extend(dfuse_start_cmdlist)
                         ior_cmd.test_file.update(
                             os.path.join(dfuse.mount_dir.value, "testfile"))
                     # add envs if api is HDF5-VOL
                     if api == "HDF5-VOL":
+                        vol = True
                         env["HDF5_VOL_CONNECTOR"] = "daos"
                         env["HDF5_PLUGIN_PATH"] = "{}".format(plugin_path)
                         # env["H5_DAOS_BYPASS_DUNS"] = 1
-                    srun_cmd = Srun(ior_cmd)
-                    srun_cmd.assign_processes(nodesperjob * ppn)
-                    srun_cmd.assign_environment(env, True)
-                    srun_cmd.ntasks_per_node.update(ppn)
-                    srun_cmd.nodes.update(nodesperjob)
-                    sbatch_cmds.append(str(srun_cmd))
+                    mpirun_cmd = Mpirun(ior_cmd, mpitype="mpich")
+                    mpirun_cmd.assign_processes(nodesperjob * ppn)
+                    mpirun_cmd.assign_environment(env, True)
+                    env_list = mpirun_cmd.env.get_list()
+                    mpirun_cmd.genv.update(env_list)
+                    mpirun_cmd.ppn.update(ppn)
+                    sbatch_cmds.append(str(mpirun_cmd))
                     sbatch_cmds.append("status=$?")
                     if api in ["HDF5-VOL", "POSIX"]:
-                        sbatch_cmds.extend(
-                            stop_dfuse(dfuse, nodesperjob, "SLURM"))
+                        sbatch_cmds.extend(stop_dfuse(dfuse, vol))
                     commands.append([sbatch_cmds, log_name])
                     self.log.info(
                         "<<IOR {} cmdlines>>:".format(api))
@@ -873,10 +948,10 @@ def create_mdtest_cmdline(self, job_spec, pool, ppn, nodesperjob):
         cmd: cmdline string
 
     """
+    # pylint: disable=too-many-nested-blocks
+
     commands = []
     mdtest_params = os.path.join(os.sep, "run", job_spec, "*")
-    mpi_module = self.params.get(
-        "mpi_module", "/run/*", default="mpi/mpich-x86_64")
     # mdtest job specs with a list of parameters; update each value
     api_list = self.params.get("api", mdtest_params)
     write_bytes_list = self.params.get("write_bytes", mdtest_params)
@@ -903,14 +978,9 @@ def create_mdtest_cmdline(self, job_spec, pool, ppn, nodesperjob):
                         mdtest_cmd.read_bytes.update(read_bytes)
                         mdtest_cmd.depth.update(depth)
                         mdtest_cmd.flags.update(flag)
-                        mdtest_cmd.num_of_files_dirs.update(
-                            num_of_files_dirs)
-                        if "POSIX" in api:
-                            mdtest_cmd.dfs_oclass.update(None)
-                            mdtest_cmd.dfs_dir_oclass.update(None)
-                        else:
-                            mdtest_cmd.dfs_oclass.update(oclass)
-                            mdtest_cmd.dfs_dir_oclass.update(oclass)
+                        mdtest_cmd.num_of_files_dirs.update(num_of_files_dirs)
+                        mdtest_cmd.dfs_oclass.update(oclass)
+                        mdtest_cmd.dfs_dir_oclass.update(oclass)
                         if "EC" in oclass:
                             # oclass_dir can not be EC must be RP based on rf
                             rf = get_rf(oclass)
@@ -924,31 +994,34 @@ def create_mdtest_cmdline(self, job_spec, pool, ppn, nodesperjob):
                         mdtest_cmd.set_daos_params(
                             self.server_group, pool,
                             self.container[-1].uuid)
-                        env = mdtest_cmd.get_default_env("srun")
-                        sbatch_cmds = [
-                            "module load -q {}".format(mpi_module)]
-                        # include dfuse cmdlines
                         log_name = "{}_{}_{}_{}_{}_{}_{}_{}_{}".format(
                             job_spec, api, write_bytes, read_bytes, depth,
                             oclass, nodesperjob * ppn, nodesperjob,
                             ppn)
+                        daos_log = os.path.join(
+                            self.soaktest_dir, self.test_name + "_" + log_name +
+                            "_`hostname -s`_${SLURM_JOB_ID}_daos.log")
+                        env = mdtest_cmd.get_default_env("mpirun", log_file=daos_log)
+                        sbatch_cmds = [
+                            "module purge", "module load {}".format(self.mpi_module)]
+                        # include dfuse cmdlines
+
                         if api in ["POSIX"]:
                             dfuse, dfuse_start_cmdlist = start_dfuse(
-                                self, pool, self.container[-1], nodesperjob,
-                                "SLURM", name=log_name, job_spec=job_spec)
+                                self, pool, self.container[-1], name=log_name, job_spec=job_spec)
                             sbatch_cmds.extend(dfuse_start_cmdlist)
                             mdtest_cmd.test_dir.update(
                                 dfuse.mount_dir.value)
-                        srun_cmd = Srun(mdtest_cmd)
-                        srun_cmd.assign_processes(nodesperjob * ppn)
-                        srun_cmd.assign_environment(env, True)
-                        srun_cmd.ntasks_per_node.update(ppn)
-                        srun_cmd.nodes.update(nodesperjob)
-                        sbatch_cmds.append(str(srun_cmd))
+                        mpirun_cmd = Mpirun(mdtest_cmd, mpitype="mpich")
+                        mpirun_cmd.assign_processes(nodesperjob * ppn)
+                        mpirun_cmd.assign_environment(env, True)
+                        env_list = mpirun_cmd.env.get_list()
+                        mpirun_cmd.genv.update(env_list)
+                        mpirun_cmd.ppn.update(ppn)
+                        sbatch_cmds.append(str(mpirun_cmd))
                         sbatch_cmds.append("status=$?")
                         if api in ["POSIX"]:
-                            sbatch_cmds.extend(
-                                stop_dfuse(dfuse, nodesperjob, "SLURM"))
+                            sbatch_cmds.extend(stop_dfuse(dfuse))
                         commands.append([sbatch_cmds, log_name])
                         self.log.info(
                             "<<MDTEST {} cmdlines>>:".format(api))
@@ -974,19 +1047,19 @@ def create_racer_cmdline(self, job_spec):
     daos_racer.namespace = racer_namespace
     daos_racer.get_params(self)
     racer_log = os.path.join(
-        self.test_log_dir,
-        self.test_name + "_" + job_spec + "_${SLURM_JOB_NODELIST}_"
+        self.soaktest_dir,
+        self.test_name + "_" + job_spec + "_`hostname -s`_"
         "${SLURM_JOB_ID}_" + "racer_log")
     env = daos_racer.get_environment(self.server_managers[0], racer_log)
     daos_racer.set_environment(env)
     log_name = job_spec
-    srun_cmds = []
-    srun_cmds.append(str(daos_racer.__str__()))
-    srun_cmds.append("status=$?")
+    cmds = []
+    cmds.append(str(daos_racer.__str__()))
+    cmds.append("status=$?")
     # add exit code
-    commands.append([srun_cmds, log_name])
+    commands.append([cmds, log_name])
     self.log.info("<<DAOS racer cmdlines>>:")
-    for cmd in srun_cmds:
+    for cmd in cmds:
         self.log.info("%s", cmd)
     return commands
 
@@ -1032,7 +1105,7 @@ def create_fio_cmdline(self, job_spec, pool):
                     fio_cmd.update(
                         "global", "rw", rw,
                         "fio --name=global --rw")
-                    srun_cmds = []
+                    cmds = []
                     # add srun start dfuse cmds if api is POSIX
                     if fio_cmd.api.value == "POSIX":
                         # Connect to the pool, create container
@@ -1045,23 +1118,22 @@ def create_fio_cmdline(self, job_spec, pool):
                                                     'on')
                         log_name = "{}_{}_{}_{}_{}".format(
                             job_spec, blocksize, size, rw, o_type)
-                        dfuse, srun_cmds = start_dfuse(
-                            self, pool, self.container[-1], nodesperjob=1,
-                            name=log_name, job_spec=job_spec)
+                        dfuse, cmds = start_dfuse(
+                            self, pool, self.container[-1], name=log_name, job_spec=job_spec)
                     # Update the FIO cmdline
                     fio_cmd.update(
                         "global", "directory",
                         dfuse.mount_dir.value,
                         "fio --name=global --directory")
                     # add fio cmline
-                    srun_cmds.append(str(fio_cmd.__str__()))
-                    srun_cmds.append("status=$?")
+                    cmds.append(str(fio_cmd.__str__()))
+                    cmds.append("status=$?")
                     # If posix, add the srun dfuse stop cmds
                     if fio_cmd.api.value == "POSIX":
-                        srun_cmds.extend(stop_dfuse(dfuse, nodesperjob=1))
-                    commands.append([srun_cmds, log_name])
+                        cmds.extend(stop_dfuse(dfuse))
+                    commands.append([cmds, log_name])
                     self.log.info("<<Fio cmdlines>>:")
-                    for cmd in srun_cmds:
+                    for cmd in cmds:
                         self.log.info("%s", cmd)
     return commands
 
@@ -1084,12 +1156,14 @@ def build_job_script(self, commands, job, nodesperjob):
     # if additional cmds are needed in the batch script
     prepend_cmds = [
         "set -e",
+        "echo Job_Start_Time `date \\+\"%Y-%m-%d %T\"`",
         "daos pool query {} ".format(self.pool[1].uuid),
         "daos pool query {} ".format(self.pool[0].uuid)
         ]
     append_cmds = [
         "daos pool query {} ".format(self.pool[1].uuid),
-        "daos pool query {} ".format(self.pool[0].uuid)
+        "daos pool query {} ".format(self.pool[0].uuid),
+        "echo Job_End_Time `date \\+\"%Y-%m-%d %T\"`"
         ]
     exit_cmd = ["exit $status"]
     # Create the sbatch script for each list of cmdlines
@@ -1097,19 +1171,20 @@ def build_job_script(self, commands, job, nodesperjob):
         if isinstance(cmd, str):
             cmd = [cmd]
         output = os.path.join(
-            self.test_log_dir, self.test_name + "_" + log_name + "_%N_" + "%j_")
+            self.soaktest_dir, self.test_name + "_" + log_name + "_%N_" + "%j_")
         error = os.path.join(str(output) + "ERROR_")
         sbatch = {
             "time": str(job_timeout) + ":00",
             "exclude": NodeSet.fromlist(self.exclude_slurm_nodes),
             "error": str(error),
-            "export": "ALL"
+            "export": "ALL",
+            "exclusive": None
         }
         # include the cluster specific params
         sbatch.update(self.srun_params)
         unique = get_random_string(5, self.used)
         script = slurm_utils.write_slurm_script(
-            self.test_log_dir, job, output, nodesperjob,
+            self.soaktest_dir, job, output, nodesperjob,
             prepend_cmds + cmd + append_cmds + exit_cmd, unique, sbatch)
         script_list.append(script)
         self.used.append(unique)

--- a/src/tests/ftest/util/job_manager_utils.py
+++ b/src/tests/ftest/util/job_manager_utils.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 """
-  (C) Copyright 2020-2021 Intel Corporation.
+  (C) Copyright 2020-2022 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -349,6 +349,7 @@ class Mpirun(JobManager):
         self.processes = FormattedParameter("-np {}", 1)
         self.ppn = FormattedParameter("-ppn {}", None)
         self.envlist = FormattedParameter("-envlist {}", None)
+        self.genv = FormattedParameter("-genv {}", None)
         self.mca = FormattedParameter("--mca {}", mca_default)
         self.working_dir = FormattedParameter("-wdir {}", None)
         self.tmpdir_base = FormattedParameter("--mca orte_tmpdir_base {}", None)

--- a/src/tests/ftest/util/slurm_utils.py
+++ b/src/tests/ftest/util/slurm_utils.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 """
-(C) Copyright 2019-2021 Intel Corporation.
+(C) Copyright 2019-2022 Intel Corporation.
 
 SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -134,7 +134,6 @@ def write_slurm_script(path, name, output, nodecount, cmds, uniq, sbatch=None):
         raise SlurmFailed("Bad parameters passed for slurm script.")
     if uniq is None:
         uniq = random.randint(1, 100000) #nosec
-
     if not os.path.exists(path):
         os.makedirs(path)
     scriptfile = path + '/jobscript' + "_" + str(uniq) + ".sh"
@@ -151,9 +150,12 @@ def write_slurm_script(path, name, output, nodecount, cmds, uniq, sbatch=None):
             script_file.write("#SBATCH --output={}\n".format(output))
         if sbatch:
             for key, value in list(sbatch.items()):
-                if key == "error":
-                    value = value + str(uniq)
-                script_file.write("#SBATCH --{}={}\n".format(key, value))
+                if value is not None:
+                    if key == "error":
+                        value = value + str(uniq)
+                    script_file.write("#SBATCH --{}={}\n".format(key, value))
+                else:
+                    script_file.write("#SBATCH --{}\n".format(key))
         script_file.write("\n")
 
         # debug
@@ -163,6 +165,7 @@ def write_slurm_script(path, name, output, nodecount, cmds, uniq, sbatch=None):
 
         for cmd in list(cmds):
             script_file.write(cmd + "\n")
+        script_file.close()
     return scriptfile
 
 
@@ -263,7 +266,7 @@ def watch_job(handle, maxwait, test_obj):
         test_obj.job_done(params)
 
 
-def srun_str(hosts, cmd, srun_params=None):
+def srun_str(hosts, cmd, srun_params=None, timeout=None):
     """Create string of cmd with srun and params.
 
     Args:
@@ -279,6 +282,8 @@ def srun_str(hosts, cmd, srun_params=None):
     params = ""
     if hosts is not None:
         params_list.append("--nodelist {}".format(hosts))
+    if timeout is not None:
+        params_list.append("--time {}".format(timeout))
     if srun_params is not None:
         for key, value in list(srun_params.items()):
             params_list.extend(["--{}={}".format(key, value)])
@@ -287,20 +292,22 @@ def srun_str(hosts, cmd, srun_params=None):
     return str(cmd)
 
 
-def srun(hosts, cmd, srun_params=None, timeout=30):
+def srun(hosts, cmd, srun_params=None, timeout=60):
     """Run srun cmd on slurm partition.
 
     Args:
         hosts (str): hosts to allocate
         cmd (str): cmdline to execute
         srun_params(dict): additional params for srun
+        timeout
 
     Returns:
         CmdResult: object containing the result (exit status, stdout, etc.) of
             the srun command
 
     """
-    cmd = srun_str(hosts, cmd, srun_params)
+    srun_time = max(int(timeout/60), 1)
+    cmd = srun_str(hosts, cmd, srun_params, str(srun_time))
     try:
         result = run_command(cmd, timeout)
     except DaosTestError as error:

--- a/src/tests/jobtest.c
+++ b/src/tests/jobtest.c
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2020-2021 Intel Corporation.
+ * (C) Copyright 2020-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */

--- a/src/tests/suite/daos_container.c
+++ b/src/tests/suite/daos_container.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2021 Intel Corporation.
+ * (C) Copyright 2016-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */

--- a/src/tests/suite/daos_epoch.c
+++ b/src/tests/suite/daos_epoch.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2021 Intel Corporation.
+ * (C) Copyright 2016-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */

--- a/src/vea/tests/vea_ut.c
+++ b/src/vea/tests/vea_ut.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2018-2021 Intel Corporation.
+ * (C) Copyright 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */

--- a/src/vea/vea_alloc.c
+++ b/src/vea/vea_alloc.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2018-2021 Intel Corporation.
+ * (C) Copyright 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */

--- a/src/vea/vea_api.c
+++ b/src/vea/vea_api.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2018-2021 Intel Corporation.
+ * (C) Copyright 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */

--- a/src/vea/vea_free.c
+++ b/src/vea/vea_free.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2018-2021 Intel Corporation.
+ * (C) Copyright 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */

--- a/src/vea/vea_init.c
+++ b/src/vea/vea_init.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2018-2021 Intel Corporation.
+ * (C) Copyright 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */


### PR DESCRIPTION
Update the slurm setup script to install slurm on Centos8 and Suse153
Update soak scripts to correctly import modules after DAOS-8595
Change daos metric collection to before container destroy
Add change to hdf5-vol to remove hdf5 container in batch script
Update soak yaml files to remove/update server env
Remove the large reserved file from avocado artifacts
Replace srun with mpich in sbatch scripts

Signed-off-by: Maureen Jean <maureen.jean@intel.com>