### PR TITLE
DAOS-9631 control: Increase default timeout for pool operations (#8111)

### DIFF
--- a/src/control/drpc/constants.go
+++ b/src/control/drpc/constants.go
@@ -1,0 +1,14 @@
+//
+// (C) Copyright 2022 Intel Corporation.
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+
+package drpc
+
+import "time"
+
+const (
+	// DefaultCartTimeout defines the default timeout for cart operations.
+	DefaultCartTimeout = 60 * time.Second // Should use CRT_DEFAULT_TIMEOUT_S but it's not exported
+)

--- a/src/control/lib/control/pool.go
+++ b/src/control/lib/control/pool.go
@@ -31,7 +31,7 @@ const (
 	// request can take before being timed out.
 	PoolCreateTimeout = 10 * time.Minute // be generous for large pools
 	// DefaultPoolTimeout is the default timeout for a pool request.
-	DefaultPoolTimeout = 60 * time.Second // fail faster if it's going to fail
+	DefaultPoolTimeout = drpc.DefaultCartTimeout * 3
 )
 
 // checkUUID is a helper function for validating that the supplied


### PR DESCRIPTION
Cherry-pick of PR 8111 from master branch to release/2.0 branch.

The previous timeout of 60s may not be enough in certain scenarios,
so rather than using an arbitrary value, set it to
3 * CRT_DEFAULT_TIMEOUT_S. We can't query the actual timeout
value set on the server, but this should be enough for most situations.

Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com>