### PR TITLE
DAOS-9003 dtx: reset DTX tables when close container

### DIFF
--- a/src/container/srv_target.c
+++ b/src/container/srv_target.c
@@ -606,83 +606,6 @@ cont_stop_agg(struct ds_cont_child *cont)
 	}
 }
 
-/* Per VOS container DTX re-index ULT ***************************************/
-
-void
-ds_cont_dtx_reindex_ult(void *arg)
-{
-	struct ds_cont_child		*cont	= arg;
-	struct dss_module_info		*dmi	= dss_get_module_info();
-	uint64_t			 hint	= 0;
-	int				 rc;
-
-	D_DEBUG(DF_DSMS, DF_CONT": starting DTX reindex ULT on xstream %d\n",
-		DP_CONT(NULL, cont->sc_uuid), dmi->dmi_tgt_id);
-
-	while (!cont->sc_dtx_reindex_abort &&
-	       !dss_xstream_exiting(dmi->dmi_xstream)) {
-		rc = vos_dtx_cmt_reindex(cont->sc_hdl, &hint);
-		if (rc < 0) {
-			D_ERROR(DF_UUID": DTX reindex failed: rc = %d\n",
-				DP_UUID(cont->sc_uuid), rc);
-			goto out;
-		}
-
-		if (rc > 0) {
-			D_DEBUG(DF_DSMS, DF_CONT": DTX reindex done\n",
-				DP_CONT(NULL, cont->sc_uuid));
-			goto out;
-		}
-
-		ABT_thread_yield();
-	}
-
-	D_DEBUG(DF_DSMS, DF_CONT": stopping DTX reindex ULT on stream %d\n",
-		DP_CONT(NULL, cont->sc_uuid), dmi->dmi_tgt_id);
-
-out:
-	cont->sc_dtx_reindex = 0;
-	ds_cont_child_put(cont);
-}
-
-static int
-cont_start_dtx_reindex_ult(struct ds_cont_child *cont)
-{
-	int rc;
-
-	D_ASSERT(cont != NULL);
-
-	if (cont->sc_dtx_reindex || cont->sc_dtx_reindex_abort)
-		return 0;
-
-	ds_cont_child_get(cont);
-	cont->sc_dtx_reindex = 1;
-	rc = dss_ult_create(ds_cont_dtx_reindex_ult, cont, DSS_XS_SELF,
-			    0, 0, NULL);
-	if (rc != 0) {
-		D_ERROR(DF_UUID": Failed to create DTX reindex ULT: rc %d\n",
-			DP_UUID(cont->sc_uuid), rc);
-		cont->sc_dtx_reindex = 0;
-		ds_cont_child_put(cont);
-	}
-
-	return rc;
-}
-
-static void
-cont_stop_dtx_reindex_ult(struct ds_cont_child *cont)
-{
-	if (!cont->sc_dtx_reindex || cont->sc_open != 0)
-		return;
-
-	cont->sc_dtx_reindex_abort = 1;
-
-	while (cont->sc_dtx_reindex)
-		ABT_thread_yield();
-
-	cont->sc_dtx_reindex_abort = 0;
-}
-
 /* ds_cont_child *******************************************************/
 static inline struct ds_cont_child *
 cont_child_obj(struct daos_llink *llink)
@@ -736,6 +659,7 @@ cont_child_alloc_ref(void *co_uuid, unsigned int ksize, void *po_uuid,
 	cont->sc_aggregation_max = 0;
 	cont->sc_snapshots_nr = 0;
 	cont->sc_snapshots = NULL;
+	cont->sc_dtx_cos_hdl = DAOS_HDL_INVAL;
 	D_INIT_LIST_HEAD(&cont->sc_link);
 
 	*link = &cont->sc_list;
@@ -884,6 +808,8 @@ cont_child_stop(struct ds_cont_child *cont_child)
 		cont_child->sc_stopping = 1;
 		d_list_del_init(&cont_child->sc_link);
 
+		dtx_cont_deregister(cont_child);
+
 		/* cont_stop_agg() may yield */
 		cont_stop_agg(cont_child);
 		ds_cont_child_put(cont_child);
@@ -944,11 +870,17 @@ cont_child_start(struct ds_pool_child *pool_child, const uuid_t co_uuid,
 		rc = -DER_SHUTDOWN;
 	} else if (!cont_child_started(cont_child)) {
 		rc = cont_start_agg(cont_child);
-		if (!rc) {
-			d_list_add_tail(&cont_child->sc_link,
-					&pool_child->spc_cont_list);
-			ds_cont_child_get(cont_child);
+		if (rc != 0)
+			goto out;
+
+		rc = dtx_cont_register(cont_child);
+		if (rc != 0) {
+			cont_stop_agg(cont_child);
+			goto out;
 		}
+
+		d_list_add_tail(&cont_child->sc_link, &pool_child->spc_cont_list);
+		ds_cont_child_get(cont_child);
 	}
 
 	if (!rc && cont_out != NULL) {
@@ -956,6 +888,7 @@ cont_child_start(struct ds_pool_child *pool_child, const uuid_t co_uuid,
 		ds_cont_child_get(cont_child);
 	}
 
+out:
 	/* Put the ref from cont_child_lookup() */
 	ds_cont_child_put(cont_child);
 	return rc;
@@ -1388,6 +1321,7 @@ ds_cont_local_close(uuid_t cont_hdl_uuid)
 	if (hdl == NULL)
 		return 0;
 
+	hdl->sch_closed = 1;
 	cont_hdl_delete(&tls->dt_cont_hdl_hash, hdl);
 
 	ds_cont_hdl_put(hdl);
@@ -1507,6 +1441,7 @@ ds_cont_local_open(uuid_t pool_uuid, uuid_t cont_hdl_uuid, uuid_t cont_uuid,
 	uuid_copy(hdl->sch_uuid, cont_hdl_uuid);
 	hdl->sch_flags = flags;
 	hdl->sch_sec_capas = sec_capas;
+	hdl->sch_closed = 0;
 
 	rc = cont_hdl_add(&tls->dt_cont_hdl_hash, hdl);
 	if (rc != 0)
@@ -1553,25 +1488,15 @@ ds_cont_local_open(uuid_t pool_uuid, uuid_t cont_hdl_uuid, uuid_t cont_uuid,
 		if (hdl->sch_cont->sc_open > 1)
 			goto opened;
 
-		rc = cont_start_dtx_reindex_ult(hdl->sch_cont);
+		rc = dtx_cont_open(hdl->sch_cont);
 		if (rc != 0) {
 			hdl->sch_cont->sc_open--;
-			goto err_cont;
-		}
-
-		rc = dtx_batched_commit_register(hdl->sch_cont);
-		if (rc != 0) {
-			D_ERROR("Failed to register the container "DF_UUID
-				" to the DTX batched commit list: "
-				"rc = "DF_RC"\n", DP_UUID(cont_uuid),
-				DP_RC(rc));
-			hdl->sch_cont->sc_open--;
-			D_GOTO(err_reindex, rc);
+			D_GOTO(err_cont, rc);
 		}
 
 		D_ALLOC_PTR(ddra);
 		if (ddra == NULL)
-			D_GOTO(err_register, rc = -DER_NOMEM);
+			D_GOTO(err_dtx, rc = -DER_NOMEM);
 
 		ddra->pool = ds_pool_child_get(hdl->sch_cont->sc_pool);
 		uuid_copy(ddra->co_uuid, cont_uuid);
@@ -1580,7 +1505,7 @@ ds_cont_local_open(uuid_t pool_uuid, uuid_t cont_hdl_uuid, uuid_t cont_uuid,
 		if (rc != 0) {
 			ds_pool_child_put(hdl->sch_cont->sc_pool);
 			D_FREE(ddra);
-			D_GOTO(err_register, rc);
+			D_GOTO(err_dtx, rc);
 		}
 
 		D_ASSERT(hdl->sch_cont != NULL);
@@ -1588,7 +1513,7 @@ ds_cont_local_open(uuid_t pool_uuid, uuid_t cont_hdl_uuid, uuid_t cont_uuid,
 		rc = ds_cont_csummer_init(hdl->sch_cont);
 
 		if (rc != 0)
-			D_GOTO(err_register, rc);
+			D_GOTO(err_dtx, rc);
 	}
 opened:
 	if (cont_hdl != NULL) {
@@ -1598,13 +1523,11 @@ opened:
 
 	return 0;
 
-err_register:
+err_dtx:
 	D_ASSERT(hdl->sch_cont->sc_open > 0);
 	hdl->sch_cont->sc_open--;
 	if (hdl->sch_cont->sc_open == 0)
-		dtx_batched_commit_deregister(hdl->sch_cont);
-err_reindex:
-	cont_stop_dtx_reindex_ult(hdl->sch_cont);
+		dtx_cont_close(hdl->sch_cont);
 err_cont:
 	if (daos_handle_is_valid(poh)) {
 		int rc_tmp;
@@ -1739,10 +1662,8 @@ cont_close_hdl(uuid_t cont_hdl_uuid)
 
 		D_ASSERT(cont_child->sc_open > 0);
 		cont_child->sc_open--;
-		if (cont_child->sc_open == 0) {
-			dtx_batched_commit_deregister(cont_child);
-			cont_stop_dtx_reindex_ult(cont_child);
-		}
+		if (cont_child->sc_open == 0)
+			dtx_cont_close(cont_child);
 	}
 
 	cont_hdl_put_internal(&tls->dt_cont_hdl_hash, hdl);

--- a/src/dtx/dtx_common.c
+++ b/src/dtx/dtx_common.c
@@ -33,11 +33,11 @@ struct dtx_batched_pool_args {
 	/* The container that needs to do DTX aggregation. */
 	struct dtx_batched_cont_args	*dbpa_victim;
 	struct dtx_stat			 dbpa_stat;
-	uint32_t			 dbpa_aggregating:1;
+	uint32_t			 dbpa_aggregating;
 };
 
 struct dtx_batched_cont_args {
-	/* Link to dss_module_info::dmi_dtx_batched_cont_list. */
+	/* Link to dss_module_info::dmi_dtx_batched_cont_{open,close}_list. */
 	d_list_t			 dbca_sys_link;
 	/* Link to dtx_batched_pool_args::dbpa_cont_list. */
 	d_list_t			 dbca_pool_link;
@@ -92,22 +92,17 @@ dtx_free_dbca(struct dtx_batched_cont_args *dbca)
 	struct ds_cont_child		*cont = dbca->dbca_cont;
 	struct dtx_batched_pool_args	*dbpa = dbca->dbca_pool;
 
-	/* Nobody re-opened it during waiting dtx_flush_on_deregister(). */
-	if (cont->sc_closing) {
-		if (daos_handle_is_valid(cont->sc_dtx_cos_hdl)) {
-			dbtree_destroy(cont->sc_dtx_cos_hdl, NULL);
-			cont->sc_dtx_cos_hdl = DAOS_HDL_INVAL;
-		}
-
-		D_ASSERT(cont->sc_dtx_committable_count == 0);
-		D_ASSERT(d_list_empty(&cont->sc_dtx_cos_list));
+	if (daos_handle_is_valid(cont->sc_dtx_cos_hdl)) {
+		dbtree_destroy(cont->sc_dtx_cos_hdl, NULL);
+		cont->sc_dtx_cos_hdl = DAOS_HDL_INVAL;
 	}
+
+	D_ASSERT(cont->sc_dtx_committable_count == 0);
+	D_ASSERT(d_list_empty(&cont->sc_dtx_cos_list));
 
 	/* Even if the container is reopened during current deregister, the
 	 * reopen will use new dbca, so current dbca needs to be cleanup.
 	 */
-
-	D_ASSERT(d_list_empty(&dbca->dbca_sys_link));
 
 	if (dbca->dbca_cleanup_req != NULL) {
 		if (!dbca->dbca_cleanup_done)
@@ -145,9 +140,9 @@ dtx_free_dbca(struct dtx_batched_cont_args *dbca)
 		}
 	}
 
-	/* dtx_batched_commit() ULT may hold the last reference on the dbca. */
+	/* batched_commit/aggreagtion ULT may hold reference on the dbca. */
 	while (dbca->dbca_refs > 0) {
-		D_DEBUG(DB_TRACE, "Sleep 10 mseconds for batched commit ULT\n");
+		D_DEBUG(DB_TRACE, "Sleep 10 mseconds for reference release\n");
 		dss_sleep(10);
 	}
 
@@ -170,7 +165,7 @@ dtx_init_sched_req(struct ds_cont_child *cont, struct sched_request **sched_req,
 	D_ASSERT(sched_req != NULL);
 	D_ASSERT(*sched_req == NULL);
 
-	if (cont == NULL || !cont->sc_closing) {
+	if (cont == NULL || dtx_cont_opened(cont)) {
 		uuid_clear(anonym_uuid);
 		sched_req_attr_init(&attr, SCHED_REQ_ANONYM, &anonym_uuid);
 		*sched_req = sched_req_get(&attr, ult);
@@ -340,18 +335,22 @@ dtx_aggregate(void *arg)
 	dbca->dbca_agg_done = 1;
 
 out:
+	D_ASSERT(dbca->dbca_pool->dbpa_aggregating != 0);
+	dbca->dbca_pool->dbpa_aggregating--;
 	dtx_put_dbca(dbca);
 }
 
 static void
-dtx_aggregation_pool(struct dtx_batched_pool_args *dbpa)
+dtx_aggregation_pool(struct dss_module_info *dmi, struct dtx_batched_pool_args *dbpa)
 {
 	ABT_thread			 child;
 	struct dtx_batched_cont_args	*dbca;
 	struct ds_cont_child		*cont;
+	struct dtx_batched_cont_args	*victim_dbca = NULL;
+	struct dtx_stat			 victim_stat = { 0 };
 	int				 rc;
 
-	while (1) {
+	while (!dss_xstream_exiting(dmi->dmi_xstream)) {
 		struct dtx_stat		 stat = { 0 };
 
 		if (d_list_empty(&dbpa->dbpa_cont_list))
@@ -360,6 +359,7 @@ dtx_aggregation_pool(struct dtx_batched_pool_args *dbpa)
 		dbca = d_list_entry(dbpa->dbpa_cont_list.next,
 				    struct dtx_batched_cont_args,
 				    dbca_pool_link);
+		D_ASSERT(!dbca->dbca_deregister);
 
 		if (dbca->dbca_agg_req != NULL && dbca->dbca_agg_done) {
 			sched_req_put(dbca->dbca_agg_req);
@@ -374,18 +374,10 @@ dtx_aggregation_pool(struct dtx_batched_pool_args *dbpa)
 		dbca->dbca_agg_gen = dtx_agg_gen;
 		d_list_move_tail(&dbca->dbca_pool_link, &dbpa->dbpa_cont_list);
 
-		if (dbca->dbca_deregister)
+		if (dbca->dbca_agg_req != NULL)
 			continue;
 
 		cont = dbca->dbca_cont;
-		if (cont->sc_closing)
-			continue;
-
-		if (dbca->dbca_agg_req != NULL) {
-			dbpa->dbpa_aggregating = 1;
-			continue;
-		}
-
 		dtx_stat(cont, &stat);
 		if (stat.dtx_cont_cmt_count == 0 ||
 		    stat.dtx_first_cmt_blob_time_lo == 0)
@@ -416,73 +408,69 @@ dtx_aggregation_pool(struct dtx_batched_pool_args *dbpa)
 				continue;
 			}
 
-			dbpa->dbpa_aggregating = 1;
+			dbpa->dbpa_aggregating++;
 			continue;
 		}
 
-		if (dbpa->dbpa_stat.dtx_first_cmt_blob_time_lo == 0 ||
-		    dbpa->dbpa_stat.dtx_first_cmt_blob_time_lo >
-		    stat.dtx_first_cmt_blob_time_lo ||
-		    (dbpa->dbpa_stat.dtx_first_cmt_blob_time_lo ==
-		     stat.dtx_first_cmt_blob_time_lo &&
-		     dbpa->dbpa_stat.dtx_first_cmt_blob_time_up >
-		     stat.dtx_first_cmt_blob_time_up) ||
-		    (dbpa->dbpa_stat.dtx_first_cmt_blob_time_lo ==
-		     stat.dtx_first_cmt_blob_time_lo &&
-		     dbpa->dbpa_stat.dtx_first_cmt_blob_time_up ==
-		     stat.dtx_first_cmt_blob_time_up &&
-		     dbpa->dbpa_stat.dtx_cont_cmt_count <
-		     stat.dtx_cont_cmt_count)) {
-			dbpa->dbpa_stat = stat;
-			dbpa->dbpa_victim = dbca;
+		if (victim_stat.dtx_first_cmt_blob_time_lo == 0 ||
+		    victim_stat.dtx_first_cmt_blob_time_lo > stat.dtx_first_cmt_blob_time_lo ||
+		    (victim_stat.dtx_first_cmt_blob_time_lo == stat.dtx_first_cmt_blob_time_lo &&
+		     victim_stat.dtx_first_cmt_blob_time_up > stat.dtx_first_cmt_blob_time_up) ||
+		    (victim_stat.dtx_first_cmt_blob_time_lo == stat.dtx_first_cmt_blob_time_lo &&
+		     victim_stat.dtx_first_cmt_blob_time_up == stat.dtx_first_cmt_blob_time_up &&
+		     victim_stat.dtx_cont_cmt_count < stat.dtx_cont_cmt_count)) {
+			victim_stat = stat;
+			victim_dbca = dbca;
 		}
 	}
-
-	if (dbpa->dbpa_aggregating || dbpa->dbpa_victim == NULL ||
-	    dbpa->dbpa_stat.dtx_pool_cmt_count <= dtx_agg_thd_cnt_lo ||
-	    dbpa->dbpa_stat.dtx_first_cmt_blob_time_lo == 0 ||
-	    dtx_hlc_age2sec(dbpa->dbpa_stat.dtx_first_cmt_blob_time_lo) <=
-	    dtx_agg_thd_age_lo)
-		return;
 
 	/* No single container exceeds DTX thresholds, but the whole pool does,
 	 * then we choose the victim container to do the DTX aggregation.
 	 */
 
-	dbca = dbpa->dbpa_victim;
-	cont = dbca->dbca_cont;
-	D_ASSERT(dbca->dbca_agg_req == NULL && !dbca->dbca_agg_done);
-	dtx_get_dbca(dbca);
+	if (!dss_xstream_exiting(dmi->dmi_xstream) && dbpa->dbpa_aggregating == 0 &&
+	    victim_dbca != NULL && victim_stat.dtx_pool_cmt_count >= dtx_agg_thd_cnt_up) {
+		D_ASSERT(victim_dbca->dbca_agg_req == NULL && !victim_dbca->dbca_agg_done);
 
-	rc = dss_ult_create(dtx_aggregate, dbca, DSS_XS_SELF, 0, 0, &child);
-	if (rc != 0) {
-		D_WARN("Fail to start DTX agg ULT (2) for "DF_UUID": "DF_RC"\n",
-		       DP_UUID(cont->sc_uuid), DP_RC(rc));
-		dtx_put_dbca(dbca);
-	} else {
-		dtx_init_sched_req(cont, &dbca->dbca_agg_req, child);
-		if (dbca->dbca_agg_req == NULL) {
-			D_WARN("Fail to get agg sched req (2) for "DF_UUID"\n",
-			       DP_UUID(cont->sc_uuid));
-			ABT_thread_free(&child);
+		dtx_get_dbca(victim_dbca);
+		rc = dss_ult_create(dtx_aggregate, victim_dbca, DSS_XS_SELF, 0, 0, &child);
+		if (rc != 0) {
+			D_WARN("Fail to start DTX agg ULT (2) for "DF_UUID"\n",
+			       DP_UUID(victim_dbca->dbca_cont->sc_uuid));
+			dtx_put_dbca(victim_dbca);
 		} else {
-			dbpa->dbpa_aggregating = 1;
+			dtx_init_sched_req(victim_dbca->dbca_cont, &victim_dbca->dbca_agg_req,
+					   child);
+			if (victim_dbca->dbca_agg_req == NULL) {
+				D_WARN("Fail to get agg sched req (2) for "DF_UUID"\n",
+				       DP_UUID(victim_dbca->dbca_cont->sc_uuid));
+				ABT_thread_free(&child);
+			} else {
+				dbpa->dbpa_aggregating++;
+			}
 		}
 	}
 }
 
-static void
+void
 dtx_aggregation_main(void *arg)
 {
 	struct dss_module_info		*dmi = dss_get_module_info();
 	struct dtx_batched_pool_args	*dbpa;
+	struct sched_req_attr		 attr;
+	uuid_t				 anonym_uuid;
 
-	if (dmi->dmi_dtx_agg_req == NULL)
+	uuid_clear(anonym_uuid);
+	sched_req_attr_init(&attr, SCHED_REQ_ANONYM, &anonym_uuid);
+
+	D_ASSERT(dmi->dmi_dtx_agg_req == NULL);
+	dmi->dmi_dtx_agg_req = sched_req_get(&attr, ABT_THREAD_NULL);
+	if (dmi->dmi_dtx_agg_req == NULL) {
+		D_ERROR("Failed to get DTX aggregation sched request.\n");
 		return;
+	}
 
 	while (1) {
-		int	sleep_time = 50; /* ms */
-
 		if (!d_list_empty(&dmi->dmi_dtx_batched_pool_list)) {
 			dbpa = d_list_entry(dmi->dmi_dtx_batched_pool_list.next,
 					    struct dtx_batched_pool_args,
@@ -491,18 +479,17 @@ dtx_aggregation_main(void *arg)
 					 &dmi->dmi_dtx_batched_pool_list);
 
 			dtx_agg_gen++;
-			dbpa->dbpa_victim = NULL;
-			dbpa->dbpa_aggregating = 0;
-			dtx_aggregation_pool(dbpa);
-			if (dbpa->dbpa_aggregating)
-				sleep_time = 0;
+			dtx_aggregation_pool(dmi, dbpa);
 		}
 
 		if (dss_xstream_exiting(dmi->dmi_xstream))
 			break;
 
-		sched_req_sleep(dmi->dmi_dtx_agg_req, sleep_time);
+		sched_req_sleep(dmi->dmi_dtx_agg_req, 500 /* ms */);
 	}
+
+	sched_req_put(dmi->dmi_dtx_agg_req);
+	dmi->dmi_dtx_agg_req = NULL;
 }
 
 static void
@@ -546,7 +533,7 @@ dtx_batched_commit_one(void *arg)
 		dtx_stat(cont, &stat);
 
 		if (stat.dtx_pool_cmt_count >= dtx_agg_thd_cnt_up &&
-		    !dbca->dbca_pool->dbpa_aggregating)
+		    dbca->dbca_pool->dbpa_aggregating == 0)
 			sched_req_wakeup(dmi->dmi_dtx_agg_req);
 
 		if ((stat.dtx_committable_count <= DTX_THRESHOLD_COUNT) &&
@@ -567,7 +554,6 @@ dtx_batched_commit(void *arg)
 {
 	struct dss_module_info		*dmi = dss_get_module_info();
 	struct dtx_batched_cont_args	*dbca;
-	struct dtx_batched_cont_args	*tmp;
 	ABT_thread			 child;
 	int				 rc;
 
@@ -577,21 +563,6 @@ dtx_batched_commit(void *arg)
 		return;
 	}
 
-	rc = dss_ult_create(dtx_aggregation_main, NULL,
-			    DSS_XS_SELF, 0, 0, &child);
-	if (rc != 0) {
-		D_ERROR("Fail to start DTX aggregation main ULT: "DF_RC"\n",
-			DP_RC(rc));
-		goto out;
-	}
-
-	dtx_init_sched_req(NULL, &dmi->dmi_dtx_agg_req, child);
-	if (dmi->dmi_dtx_agg_req == NULL) {
-		D_ERROR("Failed to get DTX aggregation sched request.\n");
-		ABT_thread_free(&child);
-		goto out;
-	}
-
 	dmi->dmi_dtx_batched_started = 1;
 
 	while (1) {
@@ -599,20 +570,21 @@ dtx_batched_commit(void *arg)
 		struct dtx_stat		 stat = { 0 };
 		int			 sleep_time = 10; /* ms */
 
-		if (d_list_empty(&dmi->dmi_dtx_batched_cont_list))
+		if (d_list_empty(&dmi->dmi_dtx_batched_cont_open_list))
 			goto check;
 
 		if (DAOS_FAIL_CHECK(DAOS_DTX_NO_BATCHED_CMT) ||
 		    DAOS_FAIL_CHECK(DAOS_DTX_NO_COMMITTABLE))
 			goto check;
 
-		dbca = d_list_entry(dmi->dmi_dtx_batched_cont_list.next,
-				    struct dtx_batched_cont_args,
-				    dbca_sys_link);
+		dbca = d_list_entry(dmi->dmi_dtx_batched_cont_open_list.next,
+				    struct dtx_batched_cont_args, dbca_sys_link);
+		D_ASSERT(!dbca->dbca_deregister);
+
 		dtx_get_dbca(dbca);
 		cont = dbca->dbca_cont;
 		d_list_move_tail(&dbca->dbca_sys_link,
-				 &dmi->dmi_dtx_batched_cont_list);
+				 &dmi->dmi_dtx_batched_cont_open_list);
 		dtx_stat(cont, &stat);
 
 		if (dbca->dbca_commit_req != NULL && dbca->dbca_commit_done) {
@@ -621,8 +593,7 @@ dtx_batched_commit(void *arg)
 			dbca->dbca_commit_done = 0;
 		}
 
-		if (!cont->sc_closing &&
-		    !dbca->dbca_deregister && dbca->dbca_commit_req == NULL &&
+		if (dtx_cont_opened(cont) && dbca->dbca_commit_req == NULL &&
 		    ((stat.dtx_committable_count > DTX_THRESHOLD_COUNT) ||
 		     (stat.dtx_oldest_committable_time != 0 &&
 		      dtx_hlc_age2sec(stat.dtx_oldest_committable_time) >=
@@ -655,7 +626,7 @@ dtx_batched_commit(void *arg)
 			dbca->dbca_cleanup_done = 0;
 		}
 
-		if (!cont->sc_closing &&
+		if (dtx_cont_opened(cont) &&
 		    !dbca->dbca_deregister && dbca->dbca_cleanup_req == NULL &&
 		    stat.dtx_oldest_active_time != 0 &&
 		    dtx_hlc_age2sec(stat.dtx_oldest_active_time) >=
@@ -692,20 +663,8 @@ check:
 		sched_req_sleep(dmi->dmi_dtx_cmt_req, sleep_time);
 	}
 
-	if (dmi->dmi_dtx_agg_req != NULL) {
-		sched_req_wait(dmi->dmi_dtx_agg_req, true);
-		sched_req_put(dmi->dmi_dtx_agg_req);
-		dmi->dmi_dtx_agg_req = NULL;
-	}
-
-out:
 	sched_req_put(dmi->dmi_dtx_cmt_req);
 	dmi->dmi_dtx_cmt_req = NULL;
-
-	d_list_for_each_entry_safe(dbca, tmp, &dmi->dmi_dtx_batched_cont_list,
-				   dbca_sys_link)
-		dbca->dbca_cont->sc_dtx_cos_shutdown = 1;
-
 	dmi->dmi_dtx_batched_started = 0;
 }
 
@@ -1138,9 +1097,9 @@ dtx_leader_wait(struct dtx_leader_handle *dlh)
  * \return			Zero on success, negative value if error.
  */
 int
-dtx_leader_end(struct dtx_leader_handle *dlh, struct ds_cont_child *cont,
-	       int result)
+dtx_leader_end(struct dtx_leader_handle *dlh, struct ds_cont_hdl *coh, int result)
 {
+	struct ds_cont_child		*cont = coh->sch_cont;
 	struct dtx_handle		*dth = &dlh->dlh_handle;
 	struct dtx_entry		*dte;
 	struct dtx_memberships		*mbs;
@@ -1167,6 +1126,12 @@ dtx_leader_end(struct dtx_leader_handle *dlh, struct ds_cont_child *cont,
 
 	if (unlikely(result == -DER_ALREADY))
 		result = 0;
+
+	if (result == 0 && rc == 0 && unlikely(coh->sch_closed)) {
+		D_ERROR("Cont hdl "DF_UUID" is closed/evicted unexpectedly\n",
+			DP_UUID(coh->sch_uuid));
+		result = -DER_IO;
+	}
 
 	if (daos_is_zero_dti(&dth->dth_xid))
 		D_GOTO(out, result = result < 0 ? result : rc);
@@ -1491,8 +1456,7 @@ out:
 #define DTX_COS_BTREE_ORDER		23
 
 static void
-dtx_flush_on_deregister(struct dss_module_info *dmi,
-			struct dtx_batched_cont_args *dbca)
+dtx_flush_on_close(struct dss_module_info *dmi, struct dtx_batched_cont_args *dbca)
 {
 	struct ds_cont_child	*cont = dbca->dbca_cont;
 	struct dtx_stat		 stat = { 0 };
@@ -1534,31 +1498,99 @@ dtx_flush_on_deregister(struct dss_module_info *dmi,
 			DP_UUID(cont->sc_uuid), rc);
 }
 
+/* Per VOS container DTX re-index ULT ***************************************/
+
+void
+dtx_reindex_ult(void *arg)
+{
+	struct ds_cont_child		*cont	= arg;
+	struct dss_module_info		*dmi	= dss_get_module_info();
+	uint64_t			 hint	= 0;
+	int				 rc;
+
+	D_DEBUG(DF_DSMS, DF_CONT": starting DTX reindex ULT on xstream %d\n",
+		DP_CONT(NULL, cont->sc_uuid), dmi->dmi_tgt_id);
+
+	while (!cont->sc_dtx_reindex_abort && !dss_xstream_exiting(dmi->dmi_xstream)) {
+		rc = vos_dtx_cmt_reindex(cont->sc_hdl, &hint);
+		if (rc < 0) {
+			D_ERROR(DF_UUID": DTX reindex failed: "DF_RC"\n",
+				DP_UUID(cont->sc_uuid), DP_RC(rc));
+			goto out;
+		}
+
+		if (rc > 0) {
+			D_DEBUG(DF_DSMS, DF_CONT": DTX reindex done\n",
+				DP_CONT(NULL, cont->sc_uuid));
+			goto out;
+		}
+
+		ABT_thread_yield();
+	}
+
+	D_DEBUG(DF_DSMS, DF_CONT": stopping DTX reindex ULT on stream %d\n",
+		DP_CONT(NULL, cont->sc_uuid), dmi->dmi_tgt_id);
+
+out:
+	cont->sc_dtx_reindex = 0;
+	ds_cont_child_put(cont);
+}
+
+static int
+start_dtx_reindex_ult(struct ds_cont_child *cont)
+{
+	int rc;
+
+	D_ASSERT(cont != NULL);
+
+	if (cont->sc_dtx_reindex || cont->sc_dtx_reindex_abort)
+		return 0;
+
+	ds_cont_child_get(cont);
+	cont->sc_dtx_reindex = 1;
+	rc = dss_ult_create(dtx_reindex_ult, cont, DSS_XS_SELF, 0, 0, NULL);
+	if (rc != 0) {
+		D_ERROR(DF_UUID": Failed to create DTX reindex ULT: "DF_RC"\n",
+			DP_UUID(cont->sc_uuid), DP_RC(rc));
+		cont->sc_dtx_reindex = 0;
+		ds_cont_child_put(cont);
+	}
+
+	return rc;
+}
+
+static void
+stop_dtx_reindex_ult(struct ds_cont_child *cont)
+{
+	if (!cont->sc_dtx_reindex || dtx_cont_opened(cont))
+		return;
+
+	cont->sc_dtx_reindex_abort = 1;
+
+	while (cont->sc_dtx_reindex)
+		ABT_thread_yield();
+
+	cont->sc_dtx_reindex_abort = 0;
+}
+
 int
-dtx_batched_commit_register(struct ds_cont_child *cont)
+dtx_cont_register(struct ds_cont_child *cont)
 {
 	struct dss_module_info		*dmi = dss_get_module_info();
-	d_list_t			*pool_head;
-	d_list_t			*cont_head;
-	struct dtx_batched_pool_args	*dbpa;
+	struct dtx_batched_pool_args	*dbpa = NULL;
 	struct dtx_batched_cont_args	*dbca = NULL;
 	struct umem_attr		 uma;
 	int				 rc;
 	bool				 new_pool = true;
 
-	/* If batched commit ULT is not enabled, then sync commit DTX. */
-	if (!dmi->dmi_dtx_batched_started) {
-		cont->sc_dtx_cos_shutdown = 1;
-		goto out;
-	}
+	if (unlikely((!dmi->dmi_dtx_batched_started)))
+		return -DER_SHUTDOWN;
 
 	D_ASSERT(cont != NULL);
-	D_ASSERT(cont->sc_open > 0);
+	D_ASSERT(!dtx_cont_opened(cont));
+	D_ASSERT(daos_handle_is_inval(cont->sc_dtx_cos_hdl));
 
-	pool_head = &dmi->dmi_dtx_batched_pool_list;
-	cont_head = &dmi->dmi_dtx_batched_cont_list;
-
-	d_list_for_each_entry(dbpa, pool_head, dbpa_sys_link) {
+	d_list_for_each_entry(dbpa, &dmi->dmi_dtx_batched_pool_list, dbpa_sys_link) {
 		if (dbpa->dbpa_pool == cont->sc_pool) {
 			/* NOT allow one container to register more than
 			 * once unless its former registered instance has
@@ -1575,7 +1607,7 @@ dtx_batched_commit_register(struct ds_cont_child *cont)
 	if (new_pool) {
 		D_ALLOC_PTR(dbpa);
 		if (dbpa == NULL)
-			return -DER_NOMEM;
+			D_GOTO(out, rc = -DER_NOMEM);
 
 		D_INIT_LIST_HEAD(&dbpa->dbpa_sys_link);
 		D_INIT_LIST_HEAD(&dbpa->dbpa_cont_list);
@@ -1583,18 +1615,8 @@ dtx_batched_commit_register(struct ds_cont_child *cont)
 	}
 
 	D_ALLOC_PTR(dbca);
-	if (dbca == NULL) {
-		if (new_pool)
-			D_FREE(dbpa);
-		return -DER_NOMEM;
-	}
-
-	/* Former dtx_batched_commit_deregister is waiting for
-	 * dtx_flush_on_deregister, we reopening the container.
-	 * Let's reuse the CoS tree.
-	 */
-	if (daos_handle_is_valid(cont->sc_dtx_cos_hdl))
-		goto add;
+	if (dbca == NULL)
+		D_GOTO(out, rc = -DER_NOMEM);
 
 	memset(&uma, 0, sizeof(uma));
 	uma.uma_id = UMEM_CLASS_VMEM;
@@ -1606,69 +1628,125 @@ dtx_batched_commit_register(struct ds_cont_child *cont)
 	if (rc != 0) {
 		D_ERROR("Failed to create DTX CoS btree: "DF_RC"\n",
 			DP_RC(rc));
-		D_FREE(dbca);
-		if (new_pool)
-			D_FREE(dbpa);
-		return rc;
+		D_GOTO(out, rc = -DER_NOMEM);
 	}
 
 	cont->sc_dtx_committable_count = 0;
 	D_INIT_LIST_HEAD(&cont->sc_dtx_cos_list);
-	cont->sc_dtx_resync_ver = 1;
-
-add:
-	cont->sc_dtx_cos_shutdown = 0;
+	cont->sc_dtx_resync_ver = cont->sc_pool->spc_map_version;
 	ds_cont_child_get(cont);
 	dbca->dbca_refs = 0;
 	dbca->dbca_cont = cont;
 	dbca->dbca_pool = dbpa;
 	dbca->dbca_agg_gen = dtx_agg_gen;
-	d_list_add_tail(&dbca->dbca_sys_link, cont_head);
+	d_list_add_tail(&dbca->dbca_sys_link, &dmi->dmi_dtx_batched_cont_close_list);
 	d_list_add_tail(&dbca->dbca_pool_link, &dbpa->dbpa_cont_list);
 	if (new_pool)
-		d_list_add_tail(&dbpa->dbpa_sys_link, pool_head);
+		d_list_add_tail(&dbpa->dbpa_sys_link, &dmi->dmi_dtx_batched_pool_list);
 
 out:
-	cont->sc_closing = 0;
-	cont->sc_dtx_batched_gen++;
-	if (dbca != NULL)
+	if (rc == 0) {
+		cont->sc_dtx_batched_gen = 1;
 		dbca->dbca_reg_gen = cont->sc_dtx_batched_gen;
+	} else {
+		D_FREE(dbca);
+		if (new_pool)
+			D_FREE(dbpa);
+	}
 
-	return 0;
+	return rc;
 }
 
 void
-dtx_batched_commit_deregister(struct ds_cont_child *cont)
+dtx_cont_deregister(struct ds_cont_child *cont)
 {
 	struct dss_module_info		*dmi = dss_get_module_info();
 	struct dtx_batched_pool_args	*dbpa;
 	struct dtx_batched_cont_args	*dbca;
 
 	D_ASSERT(cont != NULL);
-	D_ASSERT(cont->sc_open == 0);
-	D_ASSERT(cont->sc_closing == 0);
+	D_ASSERT(!dtx_cont_opened(cont));
 
-	cont->sc_closing = 1;
-	cont->sc_dtx_cos_shutdown = 1;
+	d_list_for_each_entry(dbpa, &dmi->dmi_dtx_batched_pool_list, dbpa_sys_link) {
+		if (dbpa->dbpa_pool != cont->sc_pool)
+			continue;
 
-	d_list_for_each_entry(dbpa, &dmi->dmi_dtx_batched_pool_list,
-			      dbpa_sys_link) {
-		if (dbpa->dbpa_pool == cont->sc_pool) {
-			d_list_for_each_entry(dbca, &dbpa->dbpa_cont_list,
-					      dbca_pool_link) {
-				if (dbca->dbca_cont == cont) {
-					/* Unlink the dbca firstly, then even
-					 * if the container is reopened during
-					 * my waiting for current deregister,
-					 * it will not find current dbca.
-					 */
-					d_list_del_init(&dbca->dbca_sys_link);
-					d_list_del_init(&dbca->dbca_pool_link);
-					dbca->dbca_deregister = 1;
-					dtx_flush_on_deregister(dmi, dbca);
-					dtx_free_dbca(dbca);
-					return;
-				}
+		d_list_for_each_entry(dbca, &dbpa->dbpa_cont_list, dbca_pool_link) {
+			if (dbca->dbca_cont == cont) {
+				d_list_del_init(&dbca->dbca_sys_link);
+				d_list_del_init(&dbca->dbca_pool_link);
+				dbca->dbca_deregister = 1;
+				dtx_free_dbca(dbca);
+				return;
+			}
+		}
+	}
+}
+
+int
+dtx_cont_open(struct ds_cont_child *cont)
+{
+	struct dss_module_info		*dmi = dss_get_module_info();
+	struct dtx_batched_pool_args	*dbpa;
+	struct dtx_batched_cont_args	*dbca;
+	int				 rc;
+
+	D_ASSERT(cont != NULL);
+	D_ASSERT(cont->sc_open == 1);
+
+	d_list_for_each_entry(dbpa, &dmi->dmi_dtx_batched_pool_list, dbpa_sys_link) {
+		if (dbpa->dbpa_pool != cont->sc_pool)
+			continue;
+
+		d_list_for_each_entry(dbca, &dbpa->dbpa_cont_list, dbca_pool_link) {
+			if (dbca->dbca_cont == cont) {
+				rc = start_dtx_reindex_ult(cont);
+				if (rc != 0)
+					return rc;
+
+				dbca->dbca_reg_gen = ++(cont->sc_dtx_batched_gen);
+				d_list_del(&dbca->dbca_sys_link);
+				d_list_add_tail(&dbca->dbca_sys_link,
+						&dmi->dmi_dtx_batched_cont_open_list);
+				return 0;
+			}
+		}
+	}
+
+	D_ASSERTF(0, "The container "DF_UUID" does not register before open\n",
+		  DP_UUID(cont->sc_uuid));
+
+	return -DER_MISC;
+}
+
+void
+dtx_cont_close(struct ds_cont_child *cont)
+{
+	struct dss_module_info		*dmi = dss_get_module_info();
+	struct dtx_batched_pool_args	*dbpa;
+	struct dtx_batched_cont_args	*dbca;
+
+	D_ASSERT(cont != NULL);
+	D_ASSERT(!dtx_cont_opened(cont));
+
+	d_list_for_each_entry(dbpa, &dmi->dmi_dtx_batched_pool_list, dbpa_sys_link) {
+		if (dbpa->dbpa_pool != cont->sc_pool)
+			continue;
+
+		d_list_for_each_entry(dbca, &dbpa->dbpa_cont_list, dbca_pool_link) {
+			if (dbca->dbca_cont == cont) {
+				stop_dtx_reindex_ult(cont);
+				d_list_del(&dbca->dbca_sys_link);
+				d_list_add_tail(&dbca->dbca_sys_link,
+						&dmi->dmi_dtx_batched_cont_close_list);
+				dtx_flush_on_close(dmi, dbca);
+
+				/* If nobody reopen the container during dtx_flush_on_close,
+				 * then reset DTX table in VOS to release related resources.
+				 */
+				if (!dtx_cont_opened(cont))
+					vos_dtx_cache_reset(cont->sc_hdl, false);
+				return;
 			}
 		}
 	}
@@ -1884,7 +1962,7 @@ dtx_obj_sync(struct ds_cont_child *cont, daos_unit_oid_t *oid,
 	int	cnt;
 	int	rc = 0;
 
-	while (!cont->sc_closing) {
+	while (dtx_cont_opened(cont)) {
 		struct dtx_entry	**dtes = NULL;
 		struct dtx_cos_key	 *dcks = NULL;
 
@@ -1906,7 +1984,7 @@ dtx_obj_sync(struct ds_cont_child *cont, daos_unit_oid_t *oid,
 		}
 	}
 
-	if (rc == 0 && oid != NULL && !cont->sc_closing)
+	if (rc == 0 && oid != NULL && dtx_cont_opened(cont))
 		rc = vos_dtx_mark_sync(cont->sc_hdl, *oid, epoch);
 
 	return rc;

--- a/src/dtx/dtx_cos.c
+++ b/src/dtx/dtx_cos.c
@@ -380,7 +380,7 @@ dtx_add_cos(struct ds_cont_child *cont, struct dtx_entry *dte,
 	d_iov_t				riov;
 	int				rc;
 
-	if (cont->sc_dtx_cos_shutdown || cont->sc_closing)
+	if (!dtx_cont_opened(cont))
 		return -DER_SHUTDOWN;
 
 	D_ASSERT(dte->dte_mbs != NULL);

--- a/src/dtx/dtx_internal.h
+++ b/src/dtx/dtx_internal.h
@@ -140,6 +140,12 @@ dtx_tls_get(void)
 	return dss_module_key_get(dss_tls_get(), &dtx_module_key);
 }
 
+static inline bool
+dtx_cont_opened(struct ds_cont_child *cont)
+{
+	return cont->sc_open > 0;
+}
+
 extern struct crt_proto_format dtx_proto_fmt;
 extern btr_ops_t dbtree_dtx_cf_ops;
 extern btr_ops_t dtx_btr_cos_ops;
@@ -148,6 +154,7 @@ extern uint64_t dtx_agg_gen;
 /* dtx_common.c */
 int dtx_handle_reinit(struct dtx_handle *dth);
 void dtx_batched_commit(void *arg);
+void dtx_aggregation_main(void *arg);
 
 /* dtx_cos.c */
 int dtx_fetch_committable(struct ds_cont_child *cont, uint32_t max_cnt,

--- a/src/dtx/dtx_srv.c
+++ b/src/dtx/dtx_srv.c
@@ -425,9 +425,14 @@ dtx_setup(void)
 	dtx_agg_gen = 1;
 
 	rc = dss_ult_create_all(dtx_batched_commit, NULL, true);
+	if (rc != 0) {
+		D_ERROR("Failed to create DTX batched commit ULT: "DF_RC"\n", DP_RC(rc));
+		return rc;
+	}
+
+	rc = dss_ult_create_all(dtx_aggregation_main, NULL, true);
 	if (rc != 0)
-		D_ERROR("Failed to create DTX batched commit ULT: "DF_RC"\n",
-			DP_RC(rc));
+		D_ERROR("Failed to create DTX aggregation ULT: "DF_RC"\n", DP_RC(rc));
 
 	return rc;
 }

--- a/src/engine/srv.c
+++ b/src/engine/srv.c
@@ -353,7 +353,8 @@ dss_srv_handler(void *arg)
 	dmi->dmi_xs_id	= dx->dx_xs_id;
 	dmi->dmi_tgt_id	= dx->dx_tgt_id;
 	dmi->dmi_ctx_id	= -1;
-	D_INIT_LIST_HEAD(&dmi->dmi_dtx_batched_cont_list);
+	D_INIT_LIST_HEAD(&dmi->dmi_dtx_batched_cont_open_list);
+	D_INIT_LIST_HEAD(&dmi->dmi_dtx_batched_cont_close_list);
 	D_INIT_LIST_HEAD(&dmi->dmi_dtx_batched_pool_list);
 
 	(void)pthread_setname_np(pthread_self(), dx->dx_name);

--- a/src/include/daos_srv/container.h
+++ b/src/include/daos_srv/container.h
@@ -65,8 +65,6 @@ struct ds_cont_child {
 	uint32_t		 sc_dtx_resyncing:1,
 				 sc_dtx_reindex:1,
 				 sc_dtx_reindex_abort:1,
-				 sc_dtx_cos_shutdown:1,
-				 sc_closing:1,
 				 sc_props_fetched:1,
 				 sc_stopping:1,
 				 sc_vos_agg_active:1,
@@ -159,6 +157,7 @@ struct ds_cont_hdl {
 	uint64_t		sch_sec_capas;	/* access control capas */
 	struct ds_cont_child	*sch_cont;
 	int32_t			sch_ref;
+	uint32_t		sch_closed:1;
 };
 
 struct ds_cont_hdl *ds_cont_hdl_lookup(const uuid_t uuid);

--- a/src/include/daos_srv/daos_engine.h
+++ b/src/include/daos_srv/daos_engine.h
@@ -198,7 +198,8 @@ struct dss_module_info {
 	/* the cart context id */
 	int			dmi_ctx_id;
 	uint32_t		dmi_dtx_batched_started:1;
-	d_list_t		dmi_dtx_batched_cont_list;
+	d_list_t		dmi_dtx_batched_cont_open_list;
+	d_list_t		dmi_dtx_batched_cont_close_list;
 	d_list_t		dmi_dtx_batched_pool_list;
 	/* the profile information */
 	struct daos_profile	*dmi_dp;

--- a/src/include/daos_srv/dtx_srv.h
+++ b/src/include/daos_srv/dtx_srv.h
@@ -208,8 +208,7 @@ dtx_leader_begin(daos_handle_t coh, struct dtx_id *dti,
 		 struct daos_shard_tgt *tgts, int tgt_cnt, uint32_t flags,
 		 struct dtx_memberships *mbs, struct dtx_leader_handle **p_dlh);
 int
-dtx_leader_end(struct dtx_leader_handle *dlh, struct ds_cont_child *cont,
-	       int result);
+dtx_leader_end(struct dtx_leader_handle *dlh, struct ds_cont_hdl *coh, int result);
 
 typedef void (*dtx_sub_comp_cb_t)(struct dtx_leader_handle *dlh, int idx,
 				  int rc);
@@ -231,9 +230,13 @@ int
 dtx_leader_exec_ops(struct dtx_leader_handle *dlh, dtx_sub_func_t func,
 		    dtx_agg_cb_t agg_cb, void *agg_cb_arg, void *func_arg);
 
-int dtx_batched_commit_register(struct ds_cont_child *cont);
+int dtx_cont_open(struct ds_cont_child *cont);
 
-void dtx_batched_commit_deregister(struct ds_cont_child *cont);
+void dtx_cont_close(struct ds_cont_child *cont);
+
+int dtx_cont_register(struct ds_cont_child *cont);
+
+void dtx_cont_deregister(struct ds_cont_child *cont);
 
 int dtx_obj_sync(struct ds_cont_child *cont, daos_unit_oid_t *oid,
 		 daos_epoch_t epoch);

--- a/src/include/daos_srv/vos.h
+++ b/src/include/daos_srv/vos.h
@@ -201,11 +201,12 @@ vos_dtx_cleanup(struct dtx_handle *dth);
  * Reset DTX related cached information in VOS.
  *
  * \param coh	[IN]	Container open handle.
+ * \param force	[IN]	Reset all DTX tables by force.
  *
  * \return	Zero on success, negative value if error.
  */
 int
-vos_dtx_cache_reset(daos_handle_t coh);
+vos_dtx_cache_reset(daos_handle_t coh, bool force);
 
 /**
  * Initialize the environment for a VOS instance

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -469,7 +469,7 @@ static int
 obj_bulk_transfer(crt_rpc_t *rpc, crt_bulk_op_t bulk_op, bool bulk_bind,
 		  crt_bulk_t *remote_bulks, uint64_t *remote_offs,
 		  daos_handle_t ioh, d_sg_list_t **sgls, int sgl_nr,
-		  struct obj_bulk_args *p_arg)
+		  struct obj_bulk_args *p_arg, struct ds_cont_hdl *coh)
 {
 	struct obj_bulk_args	arg = { 0 };
 	int			i, rc, *status, ret;
@@ -544,6 +544,13 @@ done:
 		rc = ret ? dss_abterr2der(ret) : *status;
 
 	ABT_eventual_free(&p_arg->eventual);
+
+	if (rc == 0 && coh != NULL && unlikely(coh->sch_closed)) {
+		D_ERROR("Cont hdl "DF_UUID" is closed/evicted unexpectedly\n",
+			DP_UUID(coh->sch_uuid));
+		rc = -DER_IO;
+	}
+
 	/* After RDMA is done, corrupt the server data */
 	if (DAOS_FAIL_CHECK(DAOS_CSUM_CORRUPT_DISK)) {
 		struct bio_sglist	*fbsgl;
@@ -771,7 +778,7 @@ obj_echo_rw(crt_rpc_t *rpc, daos_iod_t *split_iods, uint64_t *split_offs)
 	bulk_bind = orw->orw_flags & ORF_BULK_BIND;
 	rc = obj_bulk_transfer(rpc, bulk_op, bulk_bind,
 			       orw->orw_bulks.ca_arrays, off,
-			       DAOS_HDL_INVAL, &p_sgl, orw->orw_nr, NULL);
+			       DAOS_HDL_INVAL, &p_sgl, orw->orw_nr, NULL, NULL);
 out:
 	orwo->orw_ret = rc;
 	orwo->orw_map_version = orw->orw_map_ver;
@@ -1519,7 +1526,7 @@ obj_local_rw_internal(crt_rpc_t *rpc, struct obj_io_context *ioc,
 		bulk_bind = orw->orw_flags & ORF_BULK_BIND;
 		rc = obj_bulk_transfer(rpc, bulk_op, bulk_bind,
 				       orw->orw_bulks.ca_arrays, offs,
-				       ioh, NULL, orw->orw_nr, NULL);
+				       ioh, NULL, orw->orw_nr, NULL, ioc->ioc_coh);
 		if (rc == 0) {
 			bio_iod_flush(biod);
 
@@ -2032,7 +2039,7 @@ ds_obj_ec_rep_handler(crt_rpc_t *rpc)
 		goto out;
 	}
 	rc = obj_bulk_transfer(rpc, CRT_BULK_PUT, false, &oer->er_bulk, NULL,
-			       ioh, NULL, 1, NULL);
+			       ioh, NULL, 1, NULL, ioc.ioc_coh);
 	if (rc) {
 		D_ERROR(DF_UOID" bulk transfer failed: "DF_RC".\n",
 			DP_UOID(oer->er_oid), DP_RC(rc));
@@ -2116,7 +2123,7 @@ ds_obj_ec_agg_handler(crt_rpc_t *rpc)
 			goto out;
 		}
 		rc = obj_bulk_transfer(rpc, CRT_BULK_GET, false, &oea->ea_bulk,
-				       NULL, ioh, NULL, 1, NULL);
+				       NULL, ioh, NULL, 1, NULL, ioc.ioc_coh);
 		if (rc) {
 			D_ERROR(DF_UOID" bulk transfer failed: "DF_RC".\n",
 				DP_UOID(oea->ea_oid), DP_RC(rc));
@@ -2604,7 +2611,7 @@ again2:
 	rc = dtx_leader_exec_ops(dlh, obj_tgt_update, NULL, NULL, &exec_arg);
 
 	/* Stop the distributed transaction */
-	rc = dtx_leader_end(dlh, ioc.ioc_coc, rc);
+	rc = dtx_leader_end(dlh, ioc.ioc_coh, rc);
 	switch (rc) {
 	case -DER_TX_RESTART:
 		/*
@@ -2932,7 +2939,7 @@ obj_enum_reply_bulk(crt_rpc_t *rpc)
 		return 0;
 
 	rc = obj_bulk_transfer(rpc, CRT_BULK_PUT, false, bulks, NULL,
-			       DAOS_HDL_INVAL, sgls, idx, NULL);
+			       DAOS_HDL_INVAL, sgls, idx, NULL, NULL);
 	if (oei->oei_kds_bulk) {
 		D_FREE(oeo->oeo_kds.ca_arrays);
 		oeo->oeo_kds.ca_count = 0;
@@ -3481,7 +3488,7 @@ again2:
 				 &opi->opi_api_flags, &exec_arg);
 
 	/* Stop the distribute transaction */
-	rc = dtx_leader_end(dlh, ioc.ioc_coc, rc);
+	rc = dtx_leader_end(dlh, ioc.ioc_coh, rc);
 	switch (rc) {
 	case -DER_TX_RESTART:
 		/*
@@ -3937,7 +3944,7 @@ ds_cpd_handle_one(crt_rpc_t *rpc, struct daos_cpd_sub_head *dcsh,
 
 			rc = obj_bulk_transfer(rpc, CRT_BULK_GET,
 				dcu->dcu_flags & ORF_BULK_BIND, dcu->dcu_bulks,
-				offs, iohs[i], NULL, dcsr->dcsr_nr, &bulks[i]);
+				offs, iohs[i], NULL, dcsr->dcsr_nr, &bulks[i], ioc->ioc_coh);
 			if (rc != 0) {
 				D_ERROR("Bulk transfer failed for obj "
 					DF_UOID", DTX "DF_DTI": "DF_RC"\n",
@@ -4509,7 +4516,7 @@ again:
 	rc = dtx_leader_exec_ops(dlh, obj_obj_dtx_leader, NULL, NULL, &exec_arg);
 
 	/* Stop the distribute transaction */
-	rc = dtx_leader_end(dlh, dca->dca_ioc->ioc_coc, rc);
+	rc = dtx_leader_end(dlh, dca->dca_ioc->ioc_coh, rc);
 
 out:
 	D_CDEBUG(rc != 0 && rc != -DER_INPROGRESS && rc != -DER_TX_RESTART &&

--- a/src/vos/vos_container.c
+++ b/src/vos/vos_container.c
@@ -368,6 +368,10 @@ vos_cont_open(daos_handle_t poh, uuid_t co_uuid, daos_handle_t *coh)
 	cont->vc_ts_idx = &cont->vc_cont_df->cd_ts_idx;
 	cont->vc_dtx_active_hdl = DAOS_HDL_INVAL;
 	cont->vc_dtx_committed_hdl = DAOS_HDL_INVAL;
+	if (umoff_is_null(cont->vc_cont_df->cd_dtx_committed_head))
+		cont->vc_cmt_dtx_indexed = 1;
+	else
+		cont->vc_cmt_dtx_indexed = 0;
 	D_INIT_LIST_HEAD(&cont->vc_dtx_act_list);
 	cont->vc_dtx_committed_count = 0;
 	gc_check_cont(cont);

--- a/src/vos/vos_dtx.c
+++ b/src/vos/vos_dtx.c
@@ -99,12 +99,6 @@ dtx_umoff_flag2type(umem_off_t umoff)
 }
 
 static inline bool
-umoff_is_null(umem_off_t umoff)
-{
-	return umoff == UMOFF_NULL;
-}
-
-static inline bool
 dtx_is_aborted(uint32_t tx_lid)
 {
 	return tx_lid == DTX_LID_ABORTED;
@@ -349,14 +343,9 @@ static int
 dtx_cmt_ent_alloc(struct btr_instance *tins, d_iov_t *key_iov,
 		  d_iov_t *val_iov, struct btr_record *rec)
 {
-	struct vos_tls		*tls = vos_tls_get();
-	struct vos_container	*cont = tins->ti_priv;
 	struct vos_dtx_cmt_ent	*dce = val_iov->iov_buf;
 
 	rec->rec_off = umem_ptr2off(&tins->ti_umm, dce);
-	cont->vc_dtx_committed_count++;
-	cont->vc_pool->vp_dtx_committed_count++;
-	d_tm_inc_gauge(tls->vtl_committed, 1);
 
 	return 0;
 }
@@ -365,18 +354,13 @@ static int
 dtx_cmt_ent_free(struct btr_instance *tins, struct btr_record *rec,
 		 void *args)
 {
-	struct vos_tls		*tls = vos_tls_get();
-	struct vos_container	*cont = tins->ti_priv;
 	struct vos_dtx_cmt_ent	*dce;
 
 	dce = umem_off2ptr(&tins->ti_umm, rec->rec_off);
 	D_ASSERT(dce != NULL);
 
 	rec->rec_off = UMOFF_NULL;
-	cont->vc_dtx_committed_count--;
-	cont->vc_pool->vp_dtx_committed_count--;
 	D_FREE_PTR(dce);
-	d_tm_dec_gauge(tls->vtl_committed, 1);
 
 	return 0;
 }
@@ -1838,7 +1822,7 @@ vos_dtx_check(daos_handle_t coh, struct dtx_id *dti, daos_epoch_t *epoch,
 		}
 	}
 
-	if (rc == -DER_NONEXIST && for_resent && cont->vc_reindex_cmt_dtx)
+	if (rc == -DER_NONEXIST && for_resent && !cont->vc_cmt_dtx_indexed)
 		rc = -DER_INPROGRESS;
 
 	return rc;
@@ -2004,6 +1988,18 @@ vos_dtx_post_handle(struct vos_container *cont,
 		}
 
 		return;
+	}
+
+	if (!abort && dces != NULL) {
+		struct vos_tls		*tls = vos_tls_get();
+
+		for (i = 0; i < count; i++) {
+			if (dces[i] != NULL) {
+				cont->vc_dtx_committed_count++;
+				cont->vc_pool->vp_dtx_committed_count++;
+				d_tm_inc_gauge(tls->vtl_committed, 1);
+			}
+		}
 	}
 
 	for (i = 0; i < count; i++) {
@@ -2211,6 +2207,7 @@ out:
 int
 vos_dtx_aggregate(daos_handle_t coh)
 {
+	struct vos_tls			*tls = vos_tls_get();
 	struct vos_container		*cont;
 	struct vos_cont_df		*cont_df;
 	struct umem_instance		*umm;
@@ -2259,6 +2256,10 @@ vos_dtx_aggregate(daos_handle_t coh)
 				UMOFF_P(dbd_off), DP_RC(rc));
 			goto out;
 		}
+
+		cont->vc_dtx_committed_count--;
+		cont->vc_pool->vp_dtx_committed_count--;
+		d_tm_dec_gauge(tls->vtl_committed, 1);
 	}
 
 	if (epoch != cont_df->cd_newest_aggregated) {
@@ -2568,6 +2569,9 @@ vos_dtx_cmt_reindex(daos_handle_t coh, void *hint)
 	cont = vos_hdl2cont(coh);
 	D_ASSERT(cont != NULL);
 
+	if (cont->vc_cmt_dtx_indexed)
+		return 1;
+
 	umm = vos_cont2umm(cont);
 	cont_df = cont->vc_cont_df;
 
@@ -2581,8 +2585,6 @@ vos_dtx_cmt_reindex(daos_handle_t coh, void *hint)
 
 	D_ASSERTF(dbd->dbd_magic == DTX_CMT_BLOB_MAGIC,
 		  "Corrupted committed DTX blob (2) %x\n", dbd->dbd_magic);
-
-	cont->vc_reindex_cmt_dtx = 1;
 
 	for (i = 0; i < dbd->dbd_count; i++) {
 		if (daos_is_zero_dti(&dbd->dbd_committed_data[i].dce_xid) ||
@@ -2624,7 +2626,7 @@ vos_dtx_cmt_reindex(daos_handle_t coh, void *hint)
 
 out:
 	if (rc > 0)
-		cont->vc_reindex_cmt_dtx = 0;
+		cont->vc_cmt_dtx_indexed = 1;
 
 	return rc;
 }
@@ -2875,88 +2877,86 @@ vos_dtx_rsrvd_fini(struct dtx_handle *dth)
 }
 
 int
-vos_dtx_cache_reset(daos_handle_t coh)
+vos_dtx_cache_reset(daos_handle_t coh, bool force)
 {
 	struct vos_container	*cont;
 	struct umem_attr	 uma;
-	uint64_t		 hint = 0;
 	int			 rc = 0;
 
 	cont = vos_hdl2cont(coh);
 	D_ASSERT(cont != NULL);
 
-	if (daos_handle_is_valid(cont->vc_dtx_active_hdl)) {
-		rc = dbtree_destroy(cont->vc_dtx_active_hdl, NULL);
-		if (rc != 0)
-			D_WARN("Failed to destroy act DTX tree: "DF_RC"\n",
-			       DP_RC(rc));
+	memset(&uma, 0, sizeof(uma));
+	uma.uma_id = UMEM_CLASS_VMEM;
+
+	if (!force) {
+		if (cont->vc_dtx_array)
+			lrua_array_aggregate(cont->vc_dtx_array);
+		goto cmt;
 	}
 
-	if (daos_handle_is_valid(cont->vc_dtx_committed_hdl)) {
-		rc = dbtree_destroy(cont->vc_dtx_committed_hdl, NULL);
-		if (rc != 0)
-			D_WARN("Failed to destroy cmt DTX tree: "DF_RC"\n",
-			       DP_RC(rc));
+	if (daos_handle_is_valid(cont->vc_dtx_active_hdl)) {
+		rc = dbtree_destroy(cont->vc_dtx_active_hdl, NULL);
+		if (rc != 0) {
+			D_ERROR("Failed to destroy active DTX tree for "DF_UUID": "DF_RC"\n",
+				DP_UUID(cont->vc_id), DP_RC(rc));
+			return rc;
+		}
+
+		cont->vc_dtx_active_hdl = DAOS_HDL_INVAL;
 	}
 
 	if (cont->vc_dtx_array)
 		lrua_array_free(cont->vc_dtx_array);
 
-	cont->vc_dtx_active_hdl = DAOS_HDL_INVAL;
-	cont->vc_dtx_committed_hdl = DAOS_HDL_INVAL;
-	cont->vc_dtx_committed_count = 0;
-
 	rc = lrua_array_alloc(&cont->vc_dtx_array, DTX_ARRAY_LEN, DTX_ARRAY_NR,
-			      sizeof(struct vos_dtx_act_ent),
-			      LRU_FLAG_REUSE_UNIQUE,
-			      NULL, NULL);
+			      sizeof(struct vos_dtx_act_ent), LRU_FLAG_REUSE_UNIQUE, NULL, NULL);
 	if (rc != 0) {
-		D_ERROR("Failed to re-create DTX active array: "DF_RC"\n",
-			DP_RC(rc));
-		goto out;
+		D_ERROR("Failed to re-create DTX active array for "DF_UUID": "DF_RC"\n",
+			DP_UUID(cont->vc_id), DP_RC(rc));
+		return rc;
 	}
 
-	memset(&uma, 0, sizeof(uma));
-	uma.uma_id = UMEM_CLASS_VMEM;
-
-	rc = dbtree_create_inplace_ex(VOS_BTR_DTX_ACT_TABLE, 0,
-				      DTX_BTREE_ORDER, &uma,
-				      &cont->vc_dtx_active_btr,
-				      DAOS_HDL_INVAL, cont,
+	rc = dbtree_create_inplace_ex(VOS_BTR_DTX_ACT_TABLE, 0, DTX_BTREE_ORDER, &uma,
+				      &cont->vc_dtx_active_btr, DAOS_HDL_INVAL, cont,
 				      &cont->vc_dtx_active_hdl);
 	if (rc != 0) {
-		D_ERROR("Failed to re-create DTX active btree: "DF_RC"\n",
-			DP_RC(rc));
-		goto out;
-	}
-
-	rc = dbtree_create_inplace_ex(VOS_BTR_DTX_CMT_TABLE, 0,
-				      DTX_BTREE_ORDER, &uma,
-				      &cont->vc_dtx_committed_btr,
-				      DAOS_HDL_INVAL, cont,
-				      &cont->vc_dtx_committed_hdl);
-	if (rc != 0) {
-		D_ERROR("Failed to re-create DTX committed btree: "DF_RC"\n",
-			DP_RC(rc));
-		goto out;
+		D_ERROR("Failed to re-create DTX active tree for "DF_UUID": "DF_RC"\n",
+			DP_UUID(cont->vc_id), DP_RC(rc));
+		return rc;
 	}
 
 	rc = vos_dtx_act_reindex(cont);
 	if (rc != 0) {
-		D_ERROR("Fail to reindex active DTX table: "DF_RC"\n",
-			DP_RC(rc));
-		goto out;
+		D_ERROR("Fail to reindex active DTX table for "DF_UUID": "DF_RC"\n",
+			DP_UUID(cont->vc_id), DP_RC(rc));
+		return rc;
 	}
 
-	do {
-		rc = vos_dtx_cmt_reindex(coh, &hint);
-		if (rc < 0)
-			D_ERROR("Fail to reindex committed DTX table: "
-				DF_RC"\n", DP_RC(rc));
-	} while (rc == 0);
+cmt:
+	if (daos_handle_is_valid(cont->vc_dtx_committed_hdl)) {
+		rc = dbtree_destroy(cont->vc_dtx_committed_hdl, NULL);
+		if (rc != 0) {
+			D_ERROR("Failed to destroy committed DTX tree for "DF_UUID": "DF_RC"\n",
+				DP_UUID(cont->vc_id), DP_RC(rc));
+			return rc;
+		}
 
-out:
-	D_DEBUG(DB_TRACE, "Reset the DTX cache: "DF_RC"\n", DP_RC(rc));
+		cont->vc_dtx_committed_hdl = DAOS_HDL_INVAL;
+		cont->vc_dtx_committed_count = 0;
+		cont->vc_cmt_dtx_indexed = 0;
+	}
 
-	return rc > 0 ? 0 : rc;
+	rc = dbtree_create_inplace_ex(VOS_BTR_DTX_CMT_TABLE, 0, DTX_BTREE_ORDER, &uma,
+				      &cont->vc_dtx_committed_btr, DAOS_HDL_INVAL, cont,
+				      &cont->vc_dtx_committed_hdl);
+	if (rc != 0) {
+		D_ERROR("Failed to re-create DTX committed tree for "DF_UUID": "DF_RC"\n",
+			DP_UUID(cont->vc_id), DP_RC(rc));
+		return rc;
+	}
+
+	D_DEBUG(DB_TRACE, "Reset DTX cache for "DF_UUID"\n", DP_UUID(cont->vc_id));
+
+	return 0;
 }

--- a/src/vos/vos_internal.h
+++ b/src/vos/vos_internal.h
@@ -215,7 +215,7 @@ struct vos_container {
 	/* Various flags */
 	unsigned int		vc_in_aggregation:1,
 				vc_in_discard:1,
-				vc_reindex_cmt_dtx:1;
+				vc_cmt_dtx_indexed:1;
 	unsigned int		vc_obj_discard_count;
 	unsigned int		vc_open_count;
 };
@@ -1323,6 +1323,12 @@ recx_csum_len(daos_recx_t *recx, struct dcs_csum_info *csum,
 		return 0;
 	return (daos_size_t)csum->cs_len * csum_chunk_count(csum->cs_chunksize,
 			recx->rx_idx, recx->rx_idx + recx->rx_nr - 1, rsize);
+}
+
+static inline bool
+umoff_is_null(umem_off_t umoff)
+{
+	return umoff == UMOFF_NULL;
 }
 
 #endif /* __VOS_INTERNAL_H__ */


### PR DESCRIPTION
The patch combine the following three patches:

master-commit: 7203ecda1633bf9746555672f971f0d42409ec29
master-commit: a2d7e6f04870b1cf5f6b5eef670bec7d0a78ed14
master-commit: 3cc4be174b40da7715887baf7252da3b47a46a5b

commit-1:
Currently, DAOS server maintains containers cache in the upper layer
of VOS, that causes the VOS level container will not be closed until
the container is destroyed or related DAOS engine shutdown. So if the
application only closes the container, related DRAM resource occupied
by DTX tables (that are attached to the opened VOS container) will not
be released on the server. That may cause DRAM pressure on server.

This patch will release related DRAM via reset DTX tables when close
the container in container level even through the container is still
in the cache.

The patch also fixes some DTX aggregation issues:
If the whole pool committed DTX entries count exceeds the threshold,
then even if every container committed DTX entries does not exceeds
the threshold, we still need to choose at least one container to do
DTX aggregation to relieve the DRAM/space pressure.

Some code cleanup.

commit-2:
In old implementation, we count the committed DTX entries in DRAM for
daos metrics. When application close the container, the committed DTX
entries for the container in DRAM will be dropped to release the DRAM
resource as to the daos metrics for committed DTX entries will become
zero. But related in-PMEM entries are still there. That will misguide
users, and also cause DTX aggregation cannot work properly.

The patch fixes the logic to count the committed DTX entries in PMEM.

commit-3:
Some IO requests may be still inflight when close the container
because of malicious or non-coordinated applications or evicted
by administrator by force. Those inflight IO requests may still
reference related active DTX entries that should be kept during
reset DTX tables when close the container.

On the other hand, the patch also adds some check for the cases
of container closed before IO requests completed.

Signed-off-by: Fan Yong <fan.yong@intel.com>