### PR TITLE
DAOS-9356 test: Cherrypick rebuild/container_create_race.py:RbldContainerCreatetest_rebuild_container_create - test timeout while running ior

### DIFF
--- a/src/tests/ftest/rebuild/container_create_race.yaml
+++ b/src/tests/ftest/rebuild/container_create_race.yaml
@@ -19,7 +19,7 @@ testparams:
 pool:
   mode: 146
   name: daos_server
-  scm_size: 7G
+  scm_size: 8G
   svcn: 1
   control_method: dmg
   pool_query_timeout: 15


### PR DESCRIPTION
Description: Per request, cherrypick the script fix to rel_2.0.

Quick-Functional: true
Skip-unit-tests: true
Test-tag: rebuild_cont_create
Test-repeat: 10
Signed-off-by: Ding Ho ding-hwa.ho@intel.com