### PR TITLE
DAOS-8942 test: Reduce logging of aggregation/shutdown_restart (#8158)

### DIFF
--- a/src/tests/ftest/aggregation/shutdown_restart.yaml
+++ b/src/tests/ftest/aggregation/shutdown_restart.yaml
@@ -9,14 +9,7 @@ timeout: 600
 server_config:
   name: daos_server
   servers:
-    log_mask: DEBUG
-    env_vars:
-      - ABT_ENV_MAX_NUM_XSTREAMS=100
-      - ABT_MAX_NUM_XSTREAMS=100
-      - DAOS_MD_CAP=1024
-      - FI_SOCKETS_MAX_CONN_RETRY=1
-      - FI_SOCKETS_CONN_TIMEOUT=2000
-      - DD_MASK=all
+    log_mask: ERR
     bdev_class: nvme
     bdev_list: ["aaaa:aa:aa.a","bbbb:bb:bb.b"]
 pool:


### PR DESCRIPTION
Avoid cart_logtest.py error by reducing the server log size generated by
the aggregation/shutdown_restart.py test.

Skip-unit-tests: true
Test-tag: ioaggregation

Signed-off-by: Phillip Henderson <phillip.henderson@intel.com>