### PR TITLE
DAOS-9875 tests: Set crt_timeout=10 for daos_test

### DIFF
--- a/src/tests/ftest/daos_test/suite.yaml
+++ b/src/tests/ftest/daos_test/suite.yaml
@@ -42,6 +42,7 @@ pool:
 server_config:
   engines_per_host: 2
   name: daos_server
+  crt_timeout: 10
   servers:
     0:
       pinned_numa_node: 0


### PR DESCRIPTION
Use the server configuration setting crt_timeout=10 for daos_test,
so that tests that stop engines will execute faster and less likely to hit test timeouts.

Quick-build: true
Skip-unit-tests: true
Test-tag: daos_core_test,-test_daos_rebuild_ec
Signed-off-by: Li Wei <wei.g.li@intel.com>