### PR TITLE
DAOS-9317 rsvc: ingore ALREADY failure (#7685)

### DIFF
--- a/src/rsvc/srv.c
+++ b/src/rsvc/srv.c
@@ -1225,6 +1225,8 @@ ds_rsvc_start_handler(crt_rpc_t *rpc)
 	rc = ds_rsvc_start(in->sai_class, &in->sai_svc_id, in->sai_db_uuid,
 			   create, in->sai_size,
 			   bootstrap ? in->sai_ranks : NULL, NULL /* arg */);
+	if (rc == -DER_ALREADY)
+		rc = 0;
 
 out:
 	out->sao_rc_errval = rc;
@@ -1322,7 +1324,9 @@ ds_rsvc_stop_handler(crt_rpc_t *rpc)
 
 	rc = ds_rsvc_stop(in->soi_class, &in->soi_svc_id,
 			  in->soi_flags & RDB_OF_DESTROY);
-	out->soo_rc = (rc == 0 || rc == -DER_ALREADY ? 0 : 1);
+	if (rc == -DER_ALREADY)
+		rc = 0;
+	out->soo_rc = (rc == 0 ? 0 : 1);
 	crt_reply_send(rpc);
 }
 


### PR DESCRIPTION
Ignore already failure for ds_rsvc_dist_start(), because
restart svc rank might already start rsvc service.

When re-adding an old RDB replica, we may observe that the first
InstallSnapshot to this replica fails with -DER_MISC. This is due to a
bug in rdb_raft_cb_recv_installsnapshot_resp, which doesn't check if the
whole snapshot is complete in addition to if the chunk is successfully
stored.

Signed-off-by: Di Wang <di.wang@intel.com>
Signed-off-by: Li Wei <wei.g.li@intel.com>