### PR TITLE
DAOS-9635 object: multiple shards enumeration fix

### DIFF
--- a/src/common/btree.c
+++ b/src/common/btree.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2021 Intel Corporation.
+ * (C) Copyright 2016-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -379,6 +379,67 @@ do {									\
 		(trace)->tr_at,	## __VA_ARGS__);			\
 } while (0)
 
+void
+hkey_common_gen(d_iov_t *key_iov, void *hkey)
+{
+	struct ktr_hkey	*kkey  = (struct ktr_hkey *)hkey;
+
+	if (key_iov->iov_len <= KH_INLINE_MAX) {
+		kkey->kh_hash[0] = 0;
+		kkey->kh_hash[1] = 0;
+
+		/** Set the lowest bit for inline key */
+		kkey->kh_inline_len = (key_iov->iov_len << 2) | 1;
+		memcpy(&kkey->kh_inline[0], key_iov->iov_buf, key_iov->iov_len);
+		D_ASSERT(kkey->kh_len & 1);
+		return;
+	}
+
+	kkey->kh_murmur64 = d_hash_murmur64(key_iov->iov_buf, key_iov->iov_len,
+					    BTR_MUR_SEED);
+	kkey->kh_str32 = d_hash_string_u32(key_iov->iov_buf, key_iov->iov_len);
+	/** Lowest bit is clear for hashed key */
+	kkey->kh_len = key_iov->iov_len << 2;
+
+	D_ASSERT(!(kkey->kh_inline_len & 1));
+}
+
+int
+hkey_common_cmp(struct ktr_hkey *k1, struct ktr_hkey *k2)
+{
+	/** Since the low bit is set for inline keys, there will never be
+	 *  a conflict between an inline key and a hashed key so we can
+	 *  simply compare as if they are hashed.  Order doesn't matter
+	 *  as long as it's consistent.
+	 */
+	if (k1->kh_hash[0] < k2->kh_hash[0])
+		return BTR_CMP_LT;
+
+	if (k1->kh_hash[0] > k2->kh_hash[0])
+		return BTR_CMP_GT;
+
+	if (k1->kh_hash[1] < k2->kh_hash[1])
+		return BTR_CMP_LT;
+
+	if (k1->kh_hash[1] > k2->kh_hash[1])
+		return BTR_CMP_GT;
+
+	return BTR_CMP_EQ;
+}
+
+void
+hkey_int_gen(d_iov_t *key,  void *hkey)
+{
+	/* Use key directory as unsigned integer in lieu of hkey */
+	D_ASSERT(key->iov_len <= sizeof(uint64_t));
+	/* NB: This works for little endian architectures.  An
+	 * alternative would be explicit casting based on iov_len but
+	 * this is a little nicer to read.
+	 */
+	*(uint64_t *)hkey = 0;
+	memcpy(hkey, key->iov_buf, key->iov_len);
+}
+
 static inline uint32_t
 btr_hkey_size_const(btr_ops_t *ops, uint64_t feats)
 {
@@ -413,14 +474,7 @@ btr_hkey_gen(struct btr_context *tcx, d_iov_t *key, void *hkey)
 		return;
 	}
 	if (btr_is_int_key(tcx)) {
-		/* Use key directory as unsigned integer in lieu of hkey */
-		D_ASSERT(key->iov_len <= sizeof(uint64_t));
-		/* NB: This works for little endian architectures.  An
-		 * alternative would be explicit casting based on iov_len but
-		 * this is a little nicer to read.
-		 */
-		*(uint64_t *)hkey = 0;
-		memcpy(hkey, key->iov_buf, key->iov_len);
+		hkey_int_gen(key, hkey);
 		return;
 	}
 	btr_ops(tcx)->to_hkey_gen(&tcx->tc_tins, key, hkey);

--- a/src/include/daos/btree.h
+++ b/src/include/daos/btree.h
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2021 Intel Corporation.
+ * (C) Copyright 2016-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -541,6 +541,53 @@ int  dbtree_query(daos_handle_t toh, struct btr_attr *attr,
 		  struct btr_stat *stat);
 int  dbtree_is_empty(daos_handle_t toh);
 struct umem_instance *btr_hdl2umm(daos_handle_t toh);
+
+/**
+ * hashed key for the key-btree, it is stored in btr_record::rec_hkey
+ */
+
+/** Inline key is max of 15 bytes.  The extra byte in the struct is used
+ *  to encode the type (hash or inline) and the length of the inline key.
+ */
+#define KH_INLINE_MAX 15
+
+
+struct ktr_hkey {
+	/** murmur64 hash */
+	union {
+		/** NB: This assumes little endian.  We already have little
+		 *  endian assumptions with integer keys so this isn't the
+		 *  first violation.  The hkey_gen code will trigger an
+		 *  assertion if this is violated.
+		 */
+		struct {
+			/** Length of key shifted left by 2 bits. */
+			uint32_t	kh_len;
+			/** string32 hash of key */
+			uint32_t	kh_str32;
+			/** Murmur hash of key */
+			uint64_t	kh_murmur64;
+		};
+		struct {
+			/** length shifted left by 2 bits. Low bit means inline
+			 *  key.  An extra bit is reserved for future use.
+			 */
+			char		kh_inline_len;
+			/** Inline key */
+			char		kh_inline[KH_INLINE_MAX];
+		};
+		/** For comparison convenience */
+		uint64_t		kh_hash[2];
+	};
+};
+
+/** hash seed for murmur hash */
+#define BTR_MUR_SEED	0xC0FFEE
+
+D_CASSERT(sizeof(struct ktr_hkey) == 16);
+void hkey_common_gen(d_iov_t *key_iov, void *hkey);
+int hkey_common_cmp(struct ktr_hkey *k1, struct ktr_hkey *k2);
+void hkey_int_gen(d_iov_t *key,  void *hkey);
 
 /******* iterator API ******************************************************/
 

--- a/src/include/daos_srv/daos_engine.h
+++ b/src/include/daos_srv/daos_engine.h
@@ -764,6 +764,7 @@ struct dss_enum_arg {
 			int			kds_len;
 			d_sg_list_t	       *sgl;
 			d_iov_t			csum_iov;
+			uint32_t		ec_cell_sz;
 			int			sgl_idx;
 		};
 		struct {	/* fill_recxs && type == S||R */

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -3048,7 +3048,7 @@ obj_auxi_list_fini(struct obj_auxi_args *obj_auxi)
 }
 
 struct comp_iter_arg {
-	d_list_t	merge_list;
+	d_list_t	*merged_list;
 	int		merge_nr;
 	daos_off_t	merge_sgl_off;
 	bool		retry;
@@ -3148,7 +3148,7 @@ obj_recx_parity_to_daos(struct daos_oclass_attr *oca, daos_recx_t *recx)
 }
 
 static int
-obj_ec_recxs_convert(d_list_t *merge_list, daos_recx_t *recx,
+obj_ec_recxs_convert(d_list_t *merged_list, daos_recx_t *recx,
 		     struct shard_auxi_args *shard_auxi)
 {
 	struct daos_oclass_attr	*oca;
@@ -3167,12 +3167,12 @@ obj_ec_recxs_convert(d_list_t *merge_list, daos_recx_t *recx,
 		return 0;
 	}
 
-	if (merge_list == NULL)
+	if (merged_list == NULL)
 		return 0;
 
 	cell_nr = obj_ec_cell_rec_nr(oca);
 	stripe_nr = obj_ec_stripe_rec_nr(oca);
-	shard = shard_auxi->shard % obj_ec_tgt_nr(oca);
+	shard = shard_auxi->shard % obj_get_grp_size(shard_auxi->obj);
 	/* If all parity nodes are down(degraded mode), then
 	 * the enumeration is sent to all data nodes.
 	 */
@@ -3183,7 +3183,7 @@ obj_ec_recxs_convert(d_list_t *merge_list, daos_recx_t *recx,
 		daos_off = obj_ec_idx_vos2daos(cur_off, stripe_nr, cell_nr, shard);
 		data_size = min(roundup(cur_off + 1, cell_nr) - cur_off,
 				total_size);
-		rc = merge_recx(merge_list, daos_off, data_size, 0);
+		rc = merge_recx(merged_list, daos_off, data_size, 0);
 		if (rc)
 			break;
 		D_DEBUG(DB_IO, "total "DF_U64" merge "DF_U64"/"DF_U64"\n",
@@ -3207,7 +3207,7 @@ obj_shard_list_recx_cb(struct shard_auxi_args *shard_auxi,
 	for (i = 0; i < shard_arg->la_nr; i++) {
 		int rc;
 
-		rc = obj_ec_recxs_convert(&iter_arg->merge_list,
+		rc = obj_ec_recxs_convert(iter_arg->merged_list,
 					  &shard_arg->la_recxs[i],
 					  shard_auxi);
 		if (rc) {
@@ -3248,6 +3248,7 @@ obj_shard_list_obj_cb(struct shard_auxi_args *shard_auxi,
 	daos_obj_list_t		*obj_arg = dc_task_get_args(obj_auxi->obj_task);
 	char			*ptr = obj_arg->sgl->sg_iovs[0].iov_buf;
 	daos_key_desc_t		*kds = obj_arg->kds;
+	int			i;
 	int			rc;
 
 	shard_arg = container_of(shard_auxi, struct shard_list_args, la_auxi);
@@ -3255,20 +3256,15 @@ obj_shard_list_obj_cb(struct shard_auxi_args *shard_auxi,
 			      shard_arg->la_nr, OBJ_ITER_RECX,
 			      obj_enum_shard_process_cb, shard_auxi);
 	ptr += iter_arg->merge_sgl_off;
-	if (ptr != shard_arg->la_sgl->sg_iovs[0].iov_buf)
-		memmove(ptr, shard_arg->la_sgl->sg_iovs[0].iov_buf,
-			shard_arg->la_sgl->sg_iovs[0].iov_len);
+	memcpy(ptr, shard_arg->la_sgl->sg_iovs[0].iov_buf,
+	       shard_arg->la_sgl->sg_iovs[0].iov_len);
 	obj_arg->sgl->sg_iovs[0].iov_len +=
-			shard_arg->la_sgl->sg_iovs[0].iov_len;
+		shard_arg->la_sgl->sg_iovs[0].iov_len;
 	iter_arg->merge_sgl_off += shard_arg->la_sgl->sg_iovs[0].iov_len;
 
 	kds += iter_arg->merge_nr;
-	if (kds != shard_arg->la_kds) {
-		int i;
-
-		for (i = 0; i < shard_arg->la_nr; i++)
-			kds[i] = shard_arg->la_kds[i];
-	}
+	for (i = 0; i < shard_arg->la_nr; i++)
+		kds[i] = shard_arg->la_kds[i];
 	iter_arg->merge_nr += shard_arg->la_nr;
 
 	D_DEBUG(DB_TRACE, "merge_nr %d/"DF_U64"\n", iter_arg->merge_nr,
@@ -3276,10 +3272,23 @@ obj_shard_list_obj_cb(struct shard_auxi_args *shard_auxi,
 	return rc;
 }
 
-static int
-merge_key(d_list_t *head, char *key, int key_size)
+static void
+enum_hkey_gen(struct dc_object *obj, daos_key_t *key, void *hkey)
 {
-	struct obj_auxi_list_key *key_one;
+	if (daos_is_dkey_uint64(obj->cob_md.omd_id)) {
+		hkey_int_gen(key, hkey);
+		return;
+	}
+
+	hkey_common_gen(key, hkey);
+}
+
+static int
+merge_key(struct dc_object *obj, d_list_t *head, char *key, int key_size)
+{
+	struct obj_auxi_list_key	*new_key;
+	struct obj_auxi_list_key	*key_one;
+	bool				inserted = false;
 
 	d_list_for_each_entry(key_one, head, key_list) {
 		if (key_size == key_one->key.iov_len &&
@@ -3288,21 +3297,34 @@ merge_key(d_list_t *head, char *key, int key_size)
 		}
 	}
 
-	D_ALLOC_PTR(key_one);
-	if (key_one == NULL)
+	D_ALLOC_PTR(new_key);
+	if (new_key == NULL)
 		return -DER_NOMEM;
 
-	D_ALLOC(key_one->key.iov_buf, key_size);
-	if (key_one->key.iov_buf == NULL) {
-		D_FREE(key_one);
+	D_ALLOC(new_key->key.iov_buf, key_size);
+	if (new_key->key.iov_buf == NULL) {
+		D_FREE(new_key);
 		return -DER_NOMEM;
 	}
 
-	memcpy(key_one->key.iov_buf, key, key_size);
-	key_one->key.iov_buf_len = key_size;
-	key_one->key.iov_len = key_size;
-	D_INIT_LIST_HEAD(&key_one->key_list);
-	d_list_add_tail(&key_one->key_list, head);
+	memcpy(new_key->key.iov_buf, key, key_size);
+	new_key->key.iov_buf_len = key_size;
+	new_key->key.iov_len = key_size;
+	enum_hkey_gen(obj, &new_key->key, &new_key->hkey);
+	D_INIT_LIST_HEAD(&new_key->key_list);
+
+	/* Insert the key into the sorted list */
+	d_list_for_each_entry(key_one, head, key_list) {
+		if (hkey_common_cmp(&new_key->hkey, &key_one->hkey) == BTR_CMP_LT) {
+			d_list_add_tail(&new_key->key_list, &key_one->key_list);
+			inserted = true;
+			break;
+		}
+	}
+
+	if (!inserted)
+		d_list_add_tail(&new_key->key_list, head);
+
 	return 0;
 }
 
@@ -3362,7 +3384,7 @@ obj_shard_list_key_cb(struct shard_auxi_args *shard_auxi,
 			}
 		}
 
-		rc = merge_key(&iter_arg->merge_list, key, key_size);
+		rc = merge_key(obj_auxi->obj, iter_arg->merged_list, key, key_size);
 		/* free key first regardless of rc */
 		if (alloc_key)
 			D_FREE(key);
@@ -3479,8 +3501,12 @@ obj_shard_comp_cb(struct shard_auxi_args *shard_auxi,
 				obj_arg = dc_task_get_args(obj_auxi->obj_task);
 				shard_arg = container_of(shard_auxi,
 							 struct shard_list_args, la_auxi);
-				if (obj_arg->kds != shard_arg->la_kds)
+				if (obj_arg->kds[0].kd_key_len < shard_arg->la_kds[0].kd_key_len) {
+					D_DEBUG(DB_IO, "shard %u size "DF_U64" -> "DF_U64"\n",
+						shard_auxi->shard, obj_arg->kds[0].kd_key_len,
+						shard_arg->la_kds[0].kd_key_len);
 					obj_arg->kds[0] = shard_arg->la_kds[0];
+				}
 			}
 
 			iter_arg->retry = false;
@@ -3542,29 +3568,175 @@ obj_auxi_shards_iterate(struct obj_auxi_args *obj_auxi, shard_comp_cb_t cb,
 	return tse_task_list_traverse(head, shard_auxi_task_cb, &arg);
 }
 
-/* Check anchor eof by sub anchors */
-static void
-anchor_check_eof(struct dc_object *obj, daos_anchor_t *anchor)
+static struct shard_anchors*
+obj_get_sub_anchors(daos_obj_list_t *obj_args, int opc)
 {
-	struct daos_oclass_attr	*oca = obj_get_oca(obj);
+	switch (opc) {
+	case DAOS_OBJ_DKEY_RPC_ENUMERATE:
+	case DAOS_OBJ_RPC_ENUMERATE:
+		return (struct shard_anchors *)obj_args->dkey_anchor->da_sub_anchors;
+	case DAOS_OBJ_AKEY_RPC_ENUMERATE:
+		return (struct shard_anchors *)obj_args->akey_anchor->da_sub_anchors;
+	case DAOS_OBJ_RECX_RPC_ENUMERATE:
+		return (struct shard_anchors *)obj_args->anchor->da_sub_anchors;
+	}
+	return NULL;
+}
+
+static void
+obj_set_sub_anchors(daos_obj_list_t *obj_args, int opc, struct shard_anchors *anchors)
+{
+	switch (opc) {
+	case DAOS_OBJ_DKEY_RPC_ENUMERATE:
+	case DAOS_OBJ_RPC_ENUMERATE:
+		obj_args->dkey_anchor->da_sub_anchors = (uint64_t)anchors;
+		break;
+	case DAOS_OBJ_AKEY_RPC_ENUMERATE:
+		obj_args->akey_anchor->da_sub_anchors = (uint64_t)anchors;
+		break;
+	case DAOS_OBJ_RECX_RPC_ENUMERATE:
+		obj_args->anchor->da_sub_anchors = (uint64_t)anchors;
+		break;
+	}
+}
+
+static int
+update_sub_anchor_cb(struct shard_auxi_args *shard_auxi,
+		     struct obj_auxi_args *obj_auxi, void *cb_arg)
+{
+	tse_task_t		*task = obj_auxi->obj_task;
+	daos_obj_list_t		*obj_arg = dc_task_get_args(task);
+	struct shard_list_args	*shard_arg;
+	int			shard;
+
+	shard_arg = container_of(shard_auxi, struct shard_list_args, la_auxi);
+	shard = shard_auxi->shard % obj_get_grp_size(obj_auxi->obj);
+	if (obj_arg->anchor && obj_arg->anchor->da_sub_anchors) {
+		struct shard_anchors	*sub_anchors;
+
+		sub_anchors = (struct shard_anchors *)obj_arg->anchor->da_sub_anchors;
+		memcpy(&sub_anchors->sa_anchors[shard].ssa_anchor,
+		       shard_arg->la_anchor, sizeof(daos_anchor_t));
+	}
+
+	if (obj_arg->dkey_anchor && obj_arg->dkey_anchor->da_sub_anchors) {
+		struct shard_anchors *sub_anchors;
+
+		sub_anchors = (struct shard_anchors *)obj_arg->dkey_anchor->da_sub_anchors;
+		memcpy(&sub_anchors->sa_anchors[shard].ssa_anchor,
+		       shard_arg->la_dkey_anchor, sizeof(daos_anchor_t));
+
+		if (sub_anchors->sa_anchors[shard].ssa_recx_anchor && shard_arg->la_anchor)
+			memcpy(sub_anchors->sa_anchors[shard].ssa_recx_anchor,
+			       shard_arg->la_anchor, sizeof(daos_anchor_t));
+		if (sub_anchors->sa_anchors[shard].ssa_akey_anchor && shard_arg->la_akey_anchor)
+			memcpy(sub_anchors->sa_anchors[shard].ssa_akey_anchor,
+			       shard_arg->la_akey_anchor, sizeof(daos_anchor_t));
+	}
+
+	if (obj_arg->akey_anchor && obj_arg->akey_anchor->da_sub_anchors) {
+		struct shard_anchors *sub_anchors;
+
+		sub_anchors = (struct shard_anchors *)obj_arg->akey_anchor->da_sub_anchors;
+		memcpy(&sub_anchors->sa_anchors[shard].ssa_anchor,
+		       shard_arg->la_akey_anchor, sizeof(daos_anchor_t));
+	}
+
+	return 0;
+}
+
+static void
+merged_list_free(d_list_t *merged_list, int opc)
+{
+	if (opc == DAOS_OBJ_RECX_RPC_ENUMERATE) {
+		struct obj_auxi_list_recx *recx;
+		struct obj_auxi_list_recx *tmp;
+
+		d_list_for_each_entry_safe(recx, tmp, merged_list, recx_list) {
+			d_list_del(&recx->recx_list);
+			D_FREE(recx);
+		}
+	} else {
+		struct obj_auxi_list_key *key;
+		struct obj_auxi_list_key *tmp;
+
+		d_list_for_each_entry_safe(key, tmp, merged_list, key_list) {
+			d_list_del(&key->key_list);
+			daos_iov_free(&key->key);
+			D_FREE(key);
+		}
+	}
+}
+
+static void
+shard_anchors_free(struct shard_anchors *sub_anchors, int opc)
+{
 	int i;
 
-	if (!anchor->da_sub_anchors || !obj_is_ec(obj))
+	merged_list_free(&sub_anchors->sa_merged_list, opc);
+	for (i = 0; i < sub_anchors->sa_anchors_nr; i++) {
+		struct shard_sub_anchor *sub;
+
+		sub = &sub_anchors->sa_anchors[i];
+		d_sgl_fini(&sub->ssa_sgl, true);
+		if (sub->ssa_kds)
+			D_FREE(sub->ssa_kds);
+		if (sub->ssa_recxs)
+			D_FREE(sub->ssa_recxs);
+		if (sub->ssa_recx_anchor)
+			D_FREE(sub->ssa_recx_anchor);
+		if (sub->ssa_akey_anchor)
+			D_FREE(sub->ssa_akey_anchor);
+	}
+	D_FREE(sub_anchors);
+}
+
+static void
+sub_anchors_free(daos_obj_list_t *obj_args, int opc)
+{
+	struct shard_anchors *sub_anchors;
+
+	sub_anchors = obj_get_sub_anchors(obj_args, opc);
+	if (sub_anchors == NULL)
+		return;
+
+	shard_anchors_free(sub_anchors, opc);
+	obj_set_sub_anchors(obj_args, opc, NULL);
+}
+
+/* Update and Check anchor eof by sub anchors */
+static void
+anchor_update_check_eof(struct obj_auxi_args *obj_auxi, daos_anchor_t *anchor)
+{
+	struct shard_anchors	*sub_anchors;
+	struct daos_oclass_attr	*oca = obj_get_oca(obj_auxi->obj);
+	int i;
+
+	if (!anchor->da_sub_anchors || !obj_is_ec(obj_auxi->obj))
+		return;
+
+	/* update_anchor */
+	obj_auxi_shards_iterate(obj_auxi, update_sub_anchor_cb, NULL);
+
+	sub_anchors = (struct shard_anchors *)anchor->da_sub_anchors;
+	if (!d_list_empty(&sub_anchors->sa_merged_list))
 		return;
 
 	for (i = 0; i < obj_ec_data_tgt_nr(oca); i++) {
-		daos_anchor_t *sub_anchor =
-			&((daos_anchor_t *)anchor->da_sub_anchors)[i];
+		daos_anchor_t *sub_anchor;
+
+		sub_anchor = &sub_anchors->sa_anchors[i].ssa_anchor;
 		if (!daos_anchor_is_eof(sub_anchor))
 			break;
 	}
 
 	if (i == obj_ec_data_tgt_nr(oca)) {
-		void *ptr = (void *)anchor->da_sub_anchors;
+		daos_obj_list_t *obj_args;
 
 		daos_anchor_set_eof(anchor);
-		D_FREE(ptr);
-		anchor->da_sub_anchors = 0;
+
+		obj_args = dc_task_get_args(obj_auxi->obj_task);
+		sub_anchors_free(obj_args, obj_auxi->opc);
 	}
 }
 
@@ -3573,25 +3745,27 @@ dump_key_and_anchor_eof_check(struct obj_auxi_args *obj_auxi,
 			      daos_anchor_t *anchor,
 			      struct comp_iter_arg *arg)
 {
-	struct dc_object *obj = obj_auxi->obj;
 	struct obj_auxi_list_key *key;
 	struct obj_auxi_list_key *tmp;
 	daos_obj_list_t *obj_args;
+	daos_key_t	last_key = { 0 };
 	d_sg_list_t *sgl;
 	int sgl_off = 0;
 	int iov_off = 0;
 	int cnt = 0;
 	d_iov_t *iov;
 
-	/* 1. Dump the keys from merge_list into user input buffer(@sgl) */
+	/* 1. Dump the keys from merged_list into user input buffer(@sgl) */
 	D_ASSERT(obj_auxi->is_ec_obj);
 	obj_args = dc_task_get_args(obj_auxi->obj_task);
 	sgl = obj_args->sgl;
 	iov = &sgl->sg_iovs[sgl_off];
-	d_list_for_each_entry_safe(key, tmp, &arg->merge_list,
+	d_list_for_each_entry_safe(key, tmp, arg->merged_list,
 				   key_list) {
 		int left = key->key.iov_len;
 
+		last_key.iov_len = last_key.iov_buf_len = left;
+		last_key.iov_buf = iov->iov_buf + iov_off;
 		while (left > 0) {
 			int copy_size = min(iov->iov_buf_len - iov_off,
 					    key->key.iov_len);
@@ -3612,7 +3786,7 @@ dump_key_and_anchor_eof_check(struct obj_auxi_args *obj_auxi,
 	*obj_args->nr = cnt;
 
 	/* 2. Check sub anchors to see if anchors is eof */
-	anchor_check_eof(obj, anchor);
+	anchor_update_check_eof(obj_auxi, anchor);
 }
 
 static void
@@ -3681,21 +3855,21 @@ obj_list_recxs_cb(tse_task_t *task, struct obj_auxi_args *obj_auxi,
 	int			  idx = 0;
 
 	obj_args = dc_task_get_args(obj_auxi->obj_task);
-	anchor_check_eof(obj_auxi->obj, obj_args->anchor);
-	if (d_list_empty(&arg->merge_list)) {
+	if (d_list_empty(arg->merged_list)) {
+		anchor_update_check_eof(obj_auxi, obj_args->anchor);
 		*obj_args->nr = arg->merge_nr;
 		return 0;
 	}
 
 	D_ASSERT(obj_is_ec(obj_auxi->obj));
-	d_list_for_each_entry_safe(recx, tmp, &arg->merge_list,
-				   recx_list) {
-		D_ASSERTF(idx <= *obj_args->nr, "more recx %d max_num %d\n",
-			  idx, *obj_args->nr);
+	d_list_for_each_entry_safe(recx, tmp, arg->merged_list, recx_list) {
+		if (idx >= *obj_args->nr)
+			break;
 		obj_args->recxs[idx++] = recx->recx;
 		d_list_del(&recx->recx_list);
 		D_FREE(recx);
 	}
+	anchor_update_check_eof(obj_auxi, obj_args->anchor);
 	*obj_args->nr = idx;
 	return 0;
 }
@@ -3707,7 +3881,7 @@ obj_list_obj_cb(tse_task_t *task, struct obj_auxi_args *obj_auxi,
 	daos_obj_list_t *obj_arg = dc_task_get_args(obj_auxi->obj_task);
 
 	*obj_arg->nr = arg->merge_nr;
-	anchor_check_eof(obj_auxi->obj, obj_arg->dkey_anchor);
+	anchor_update_check_eof(obj_auxi, obj_arg->dkey_anchor);
 }
 
 static int
@@ -3739,11 +3913,21 @@ obj_list_comp(struct obj_auxi_args *obj_auxi,
 static int
 obj_comp_cb_internal(struct obj_auxi_args *obj_auxi)
 {
-	struct comp_iter_arg iter_arg = { 0 };
-	int rc;
+	daos_obj_list_t		*obj_args;
+	struct shard_anchors	*sub_anchors;
+	d_list_t		merged_list;
+	struct comp_iter_arg	iter_arg = { 0 };
+	int			rc;
 
 	iter_arg.retry = true;
-	D_INIT_LIST_HEAD(&iter_arg.merge_list);
+	obj_args = dc_task_get_args(obj_auxi->obj_task);
+	sub_anchors = obj_get_sub_anchors(obj_args, obj_auxi->opc);
+	if (sub_anchors == NULL) {
+		D_INIT_LIST_HEAD(&merged_list);
+		iter_arg.merged_list = &merged_list;
+	} else {
+		iter_arg.merged_list = &sub_anchors->sa_merged_list;
+	}
 	/* Process each shards */
 	rc = obj_auxi_shards_iterate(obj_auxi, obj_shard_comp_cb, &iter_arg);
 	if (rc != 0) {
@@ -3758,26 +3942,8 @@ obj_comp_cb_internal(struct obj_auxi_args *obj_auxi)
 	if (obj_is_enum_opc(obj_auxi->opc))
 		rc = obj_list_comp(obj_auxi, &iter_arg);
 out:
-	if (obj_auxi->opc == DAOS_OBJ_DKEY_RPC_ENUMERATE ||
-	    obj_auxi->opc == DAOS_OBJ_AKEY_RPC_ENUMERATE) {
-		struct obj_auxi_list_key *key;
-		struct obj_auxi_list_key *tmp;
-
-		d_list_for_each_entry_safe(key, tmp, &iter_arg.merge_list,
-					   key_list) {
-			d_list_del(&key->key_list);
-			D_FREE(key);
-		}
-	} else if (obj_auxi->opc == DAOS_OBJ_RECX_RPC_ENUMERATE) {
-		struct obj_auxi_list_recx *recx;
-		struct obj_auxi_list_recx *tmp;
-
-		d_list_for_each_entry_safe(recx, tmp, &iter_arg.merge_list,
-					   recx_list) {
-			d_list_del(&recx->recx_list);
-			D_FREE(recx);
-		}
-	}
+	if (sub_anchors == NULL)
+		merged_list_free(&merged_list, obj_auxi->opc);
 
 	return rc;
 }
@@ -4768,139 +4934,219 @@ comp:
 	return rc > 0 ? 0 : rc;
 }
 
-static void
-shard_anchors_free(daos_anchor_t *anchor)
+static int
+shard_anchors_check_and_reallocate_bufs(struct obj_auxi_args *obj_auxi,
+					struct shard_anchors *sub_anchors,
+					int shards_nr, int nr, daos_size_t buf_size)
 {
-	void *tmp;
+	struct shard_sub_anchor *sub_anchor;
+	daos_obj_list_t		*obj_args;
+	int			rc = 0;
+	int			i;
 
-	if (anchor == NULL)
-		return;
+	D_ASSERT(nr > 0);
+	obj_args = dc_task_get_args(obj_auxi->obj_task);
+	if (obj_args->sgl != NULL) {
+		for (i = 0; i < shards_nr; i++) {
+			d_sg_list_t *sgl;
 
-	if (anchor->da_sub_anchors == 0)
-		return;
+			sub_anchor = &sub_anchors->sa_anchors[i];
+			/**
+			 * check if sg_iovs needs to be re-allocated, since it may
+			 * reallocate sgl with REC2BIG.
+			 **/
+			if (sub_anchor->ssa_sgl.sg_iovs) {
+				if (sub_anchor->ssa_sgl.sg_iovs->iov_buf_len == buf_size)
+					continue;
+				else
+					d_sgl_fini(&sub_anchor->ssa_sgl, true);
+			}
 
-	tmp = (void *)anchor->da_sub_anchors;
-	D_FREE(tmp);
-	anchor->da_sub_anchors = 0;
+			rc = d_sgl_init(&sub_anchor->ssa_sgl, 1);
+			if (rc)
+				D_GOTO(out, rc);
+
+			sgl = &sub_anchor->ssa_sgl;
+			rc = daos_iov_alloc(&sgl->sg_iovs[0], buf_size, false);
+			if (rc)
+				D_GOTO(out, rc);
+		}
+	}
+
+	if (obj_args->kds != NULL) {
+		for (i = 0; i < shards_nr; i++) {
+			sub_anchor = &sub_anchors->sa_anchors[i];
+			if (sub_anchor->ssa_kds != NULL)
+				continue;
+			D_ALLOC_ARRAY(sub_anchor->ssa_kds, nr);
+			if (sub_anchor->ssa_kds == NULL)
+				D_GOTO(out, rc = -DER_NOMEM);
+		}
+	}
+
+	if (obj_args->recxs != NULL) {
+		for (i = 0; i < shards_nr; i++) {
+			sub_anchor = &sub_anchors->sa_anchors[i];
+			if (sub_anchor->ssa_recxs != NULL)
+				continue;
+			D_ALLOC_ARRAY(sub_anchor->ssa_recxs, nr);
+			if (sub_anchor->ssa_recxs == NULL)
+				D_GOTO(out, rc = -DER_NOMEM);
+		}
+	}
+	sub_anchors->sa_nr = nr;
+out:
+	return rc;
 }
 
-static int
-shard_anchor_prep(daos_anchor_t *anchor, int nr)
+struct shard_anchors *
+shard_anchors_alloc(struct obj_auxi_args *obj_auxi, int shards_nr, int nr,
+		    daos_size_t buf_size)
 {
-	daos_anchor_t	*sub_anchors;
-	int		i;
+	struct shard_anchors	*sub_anchors;
+	int			rc;
+	int			i;
 
-	D_ASSERT(anchor->da_sub_anchors == 0);
-	D_ALLOC_ARRAY(sub_anchors, nr);
+	D_ALLOC(sub_anchors, sizeof(*sub_anchors) +
+			     sizeof(struct shard_sub_anchor) * shards_nr);
 	if (sub_anchors == NULL)
-		return -DER_NOMEM;
+		return NULL;
 
-	for (i = 0; i < nr; i++)
-		sub_anchors[i] = *anchor;
+	D_INIT_LIST_HEAD(&sub_anchors->sa_merged_list);
+	sub_anchors->sa_anchors_nr = shards_nr;
+	rc = shard_anchors_check_and_reallocate_bufs(obj_auxi, sub_anchors, shards_nr,
+						     nr, buf_size);
+	if (rc)
+		D_GOTO(out, rc);
 
-	anchor->da_sub_anchors = (uint64_t)sub_anchors;
-	return 0;
-}
-
-static int
-shard_anchors_prep(daos_obj_list_t *obj_args, int nr)
-{
-	int rc = 0;
-
-	if (obj_args->anchor &&
-	    obj_args->anchor->da_sub_anchors == 0) {
-		rc = shard_anchor_prep(obj_args->anchor, nr);
-		if (rc != 0)
-			D_GOTO(out, rc);
-	}
-
-	if (obj_args->dkey_anchor &&
-	    obj_args->dkey_anchor->da_sub_anchors == 0) {
-		rc = shard_anchor_prep(obj_args->dkey_anchor, nr);
-		if (rc != 0)
-			D_GOTO(out, rc);
-	}
-
-	if (obj_args->akey_anchor &&
-	    obj_args->akey_anchor->da_sub_anchors == 0) {
-		rc = shard_anchor_prep(obj_args->akey_anchor, nr);
-		if (rc != 0)
-			D_GOTO(out, rc);
+	if (obj_auxi->opc == DAOS_OBJ_RPC_ENUMERATE) {
+		for (i = 0; i < shards_nr; i++) {
+			D_ALLOC_PTR(sub_anchors->sa_anchors[i].ssa_akey_anchor);
+			D_ALLOC_PTR(sub_anchors->sa_anchors[i].ssa_recx_anchor);
+			if (sub_anchors->sa_anchors[i].ssa_akey_anchor == NULL ||
+			    sub_anchors->sa_anchors[i].ssa_recx_anchor == NULL)
+				D_GOTO(out, rc = -DER_NOMEM);
+		}
 	}
 
 out:
 	if (rc) {
-		shard_anchors_free(obj_args->akey_anchor);
-		shard_anchors_free(obj_args->dkey_anchor);
-		shard_anchors_free(obj_args->anchor);
+		shard_anchors_free(sub_anchors, obj_auxi->opc);
+		sub_anchors = NULL;
 	}
 
-	return rc;
+	return sub_anchors;
 }
 
-static void
-obj_shard_list_fini(daos_obj_list_t *obj_args,
-		    struct shard_list_args *shard_arg)
+/**
+ * For migrate enumeration(OBJ_RPC_ENUMERATE), all 3 sub anchors(ssa_anchors, ssa_recx_anchors,
+ * ssa_akey_anchors) will be attached to obj_args->dkey_anchors, i.e. anchors and akey_anchors
+ * are "useless" here.
+ * Though for normal migrate enumeration (no sub anchors), anchors/dkey_anchors/akey_anchors
+ * will all be used.
+ */
+static int
+sub_anchors_prep(struct obj_auxi_args *obj_auxi, int shards_nr)
 {
-	if (shard_arg->la_sgl && shard_arg->la_sgl != obj_args->sgl) {
-		d_sgl_fini(shard_arg->la_sgl, false);
-		D_FREE(shard_arg->la_sgl);
+	daos_obj_list_t		*obj_args;
+	struct shard_anchors	*sub_anchors;
+	int			nr;
+	daos_size_t		buf_size;
+
+	obj_args = dc_task_get_args(obj_auxi->obj_task);
+	nr = *obj_args->nr;
+	buf_size = daos_sgl_buf_size(obj_args->sgl);
+	if (obj_auxi->opc == DAOS_OBJ_RPC_ENUMERATE) {
+		D_ASSERTF(nr >= shards_nr, "nr %d shards_nr %d\n", nr, shards_nr);
+		buf_size /= shards_nr;
+		nr /= shards_nr;
 	}
-	shard_arg->la_kds = NULL;
-	shard_arg->la_recxs = NULL;
-	shard_anchors_free(obj_args->akey_anchor);
-	shard_anchors_free(obj_args->dkey_anchor);
-	shard_anchors_free(obj_args->anchor);
+
+	sub_anchors = obj_get_sub_anchors(obj_args, obj_auxi->opc);
+	if (sub_anchors != NULL) {
+		int rc;
+
+		rc = shard_anchors_check_and_reallocate_bufs(obj_auxi, sub_anchors, shards_nr,
+							     nr, buf_size);
+		return rc;
+	}
+
+	sub_anchors = shard_anchors_alloc(obj_auxi, shards_nr, nr, buf_size);
+	if (sub_anchors == NULL)
+		return -DER_NOMEM;
+
+	obj_set_sub_anchors(obj_args, obj_auxi->opc, sub_anchors);
+	return 0;
 }
 
 /* prepare the object enumeration for each shards */
 static int
-obj_shard_list_prep(daos_obj_list_t *obj_args, struct dc_object *obj,
-		    struct shard_list_args *shard_arg, int shard_nr,
-		    int opc)
+obj_shard_list_prep(struct obj_auxi_args *obj_auxi, struct dc_object *obj,
+		    struct shard_list_args *shard_arg, int shard_nr)
 {
-	int idx;
-	int rc = 0;
+	daos_obj_list_t		*obj_args;
+	struct shard_anchors	*sub_anchors;
+	int			idx;
+	int			rc = 0;
 
+	obj_args = dc_task_get_args(obj_auxi->obj_task);
+	D_ASSERT(obj_is_ec(obj));
 	if (*obj_args->nr < shard_nr) {
 		D_ERROR("Degraded enumeration nr %d > shards %d\n",
 			*obj_args->nr, shard_nr);
 		return -DER_INVAL;
 	}
 
-	shard_arg->la_nr = *obj_args->nr / shard_nr;
+	sub_anchors = obj_get_sub_anchors(obj_args, obj_auxi->opc);
+	D_ASSERT(sub_anchors != NULL);
+	shard_arg->la_nr = sub_anchors->sa_nr;
 	idx = shard_arg->la_auxi.shard % obj_get_grp_size(obj);
+	if (shard_arg->la_sgl == NULL && obj_args->sgl != NULL)
+		shard_arg->la_sgl = &sub_anchors->sa_anchors[idx].ssa_sgl;
 	if (shard_arg->la_kds == NULL && obj_args->kds != NULL)
-		shard_arg->la_kds = &obj_args->kds[idx * shard_arg->la_nr];
-
+		shard_arg->la_kds = sub_anchors->sa_anchors[idx].ssa_kds;
 	if (shard_arg->la_recxs == NULL && obj_args->recxs)
-		shard_arg->la_recxs = &obj_args->recxs[idx * shard_arg->la_nr];
+		shard_arg->la_recxs = sub_anchors->sa_anchors[idx].ssa_recxs;
 
-	if (shard_arg->la_sgl == NULL && obj_args->sgl) {
-		d_iov_t	*shard_iov;
-		char	*ptr;
-		int	seg_size;
+	if (obj_args->anchor) {
+		if (shard_arg->la_anchor == NULL) {
+			D_ALLOC_PTR(shard_arg->la_anchor);
+			if (shard_arg->la_anchor == NULL)
+				D_GOTO(out, rc = -DER_NOMEM);
+		}
 
-		seg_size = obj_args->sgl->sg_iovs[0].iov_buf_len / shard_nr;
+		if (sub_anchors->sa_anchors[idx].ssa_recx_anchor)
+			memcpy(shard_arg->la_anchor,
+			       sub_anchors->sa_anchors[idx].ssa_recx_anchor, sizeof(daos_anchor_t));
+		else
+			memcpy(shard_arg->la_anchor, &sub_anchors->sa_anchors[idx].ssa_anchor,
+			       sizeof(daos_anchor_t));
+	}
 
-		D_ALLOC_PTR(shard_arg->la_sgl);
-		if (shard_arg->la_sgl == NULL)
-			D_GOTO(out, rc = -DER_NOMEM);
+	if (obj_args->dkey_anchor) {
+		if (shard_arg->la_dkey_anchor == NULL) {
+			D_ALLOC_PTR(shard_arg->la_dkey_anchor);
+			if (shard_arg->la_dkey_anchor == NULL)
+				D_GOTO(out, rc = -DER_NOMEM);
+		}
+		memcpy(shard_arg->la_dkey_anchor,
+		       &sub_anchors->sa_anchors[idx].ssa_anchor, sizeof(daos_anchor_t));
+	}
 
-		D_ALLOC_PTR(shard_iov);
-		if (shard_iov == NULL)
-			D_GOTO(out, rc = -DER_NOMEM);
-
-		ptr = obj_args->sgl->sg_iovs[0].iov_buf + idx * seg_size;
-
-		d_iov_set(shard_iov, ptr, seg_size);
-		shard_arg->la_sgl->sg_nr = 1;
-		shard_arg->la_sgl->sg_nr_out = 1;
-		shard_arg->la_sgl->sg_iovs = shard_iov;
+	if (obj_args->akey_anchor) {
+		if (shard_arg->la_akey_anchor == NULL) {
+			D_ALLOC_PTR(shard_arg->la_akey_anchor);
+			if (shard_arg->la_akey_anchor == NULL)
+				D_GOTO(out, rc = -DER_NOMEM);
+		}
+		if (sub_anchors->sa_anchors[idx].ssa_akey_anchor)
+			memcpy(shard_arg->la_akey_anchor,
+			       sub_anchors->sa_anchors[idx].ssa_akey_anchor, sizeof(daos_anchor_t));
+		else
+			memcpy(shard_arg->la_akey_anchor,
+			       &sub_anchors->sa_anchors[idx].ssa_anchor, sizeof(daos_anchor_t));
 	}
 out:
-	if (rc)
-		obj_shard_list_fini(obj_args, shard_arg);
 	return rc;
 }
 
@@ -4917,48 +5163,17 @@ shard_list_prep(struct shard_auxi_args *shard_auxi, struct dc_object *obj,
 	shard_arg = container_of(shard_auxi, struct shard_list_args, la_auxi);
 	shard_arg->la_api_args = obj_args;
 	oca = obj_get_oca(obj);
-	if (obj_auxi->is_ec_obj &&
-	    (shard_auxi->shard % obj_get_grp_size(obj)) < obj_ec_data_tgt_nr(oca) &&
-	    !obj_auxi->spec_shard) {
-		uint32_t		idx = shard_auxi->shard % obj_get_grp_size(obj);
-		daos_anchor_t		*sub_anchors;
-		int			shard_nr;
-		int			rc;
+	if (obj_auxi->is_ec_obj && !obj_auxi->spec_shard &&
+	    (shard_auxi->shard % obj_get_grp_size(obj) < obj_ec_data_tgt_nr(oca))) {
+		int	shard_nr;
+		int	rc;
 
-		D_ASSERT(obj_is_ec(obj));
 		shard_nr = obj_ec_data_tgt_nr(oca);
-
-		/* check and allocate the sub_anchors */
-		rc = shard_anchors_prep(obj_args, shard_nr);
+		rc = obj_shard_list_prep(obj_auxi, obj, shard_arg, shard_nr);
 		if (rc) {
 			D_ERROR(DF_OID" shard list %d prep: %d\n",
 				DP_OID(obj->cob_md.omd_id), grp_idx, rc);
 			return rc;
-		}
-
-		rc = obj_shard_list_prep(obj_args, obj, shard_arg, shard_nr,
-					 obj_auxi->opc);
-		if (rc) {
-			D_ERROR(DF_OID" shard list %d prep: %d\n",
-				DP_OID(obj->cob_md.omd_id), grp_idx, rc);
-			return rc;
-		}
-
-		if (obj_args->anchor) {
-			sub_anchors =
-			(daos_anchor_t *)obj_args->anchor->da_sub_anchors;
-			shard_arg->la_anchor = &sub_anchors[idx];
-		}
-
-		if (obj_args->dkey_anchor) {
-			sub_anchors =
-			(daos_anchor_t *)obj_args->dkey_anchor->da_sub_anchors;
-			shard_arg->la_dkey_anchor = &sub_anchors[idx];
-		}
-		if (obj_args->akey_anchor) {
-			sub_anchors =
-			(daos_anchor_t *)obj_args->akey_anchor->da_sub_anchors;
-			shard_arg->la_akey_anchor = &sub_anchors[idx];
 		}
 	} else {
 		shard_arg->la_nr = *obj_args->nr;
@@ -4966,7 +5181,6 @@ shard_list_prep(struct shard_auxi_args *shard_auxi, struct dc_object *obj,
 		shard_arg->la_anchor = obj_args->anchor;
 		shard_arg->la_akey_anchor = obj_args->akey_anchor;
 		shard_arg->la_dkey_anchor = obj_args->dkey_anchor;
-		shard_arg->la_nr = *obj_args->nr;
 		shard_arg->la_kds = obj_args->kds;
 		shard_arg->la_sgl = obj_args->sgl;
 	}
@@ -5175,6 +5389,7 @@ obj_list_common(tse_task_t *task, int opc, daos_obj_list_t *args)
 	uint64_t		 dkey_hash = 0;
 	struct dtx_epoch	 epoch = {0};
 	int			 shard = -1;
+	int			 tgts_nr;
 	int			 rc;
 
 	rc = obj_req_valid(task, args, opc, &epoch, &map_ver, &obj);
@@ -5217,6 +5432,15 @@ obj_list_common(tse_task_t *task, int opc, daos_obj_list_t *args)
 			      obj_auxi->spec_shard, obj_auxi);
 	if (rc != 0)
 		goto out_task;
+
+	tgts_nr = obj_auxi->req_tgts.ort_srv_disp ?
+		  obj_auxi->req_tgts.ort_grp_nr :
+		  obj_auxi->req_tgts.ort_grp_nr * obj_auxi->req_tgts.ort_grp_size;
+	if (tgts_nr > 1) {
+		rc = sub_anchors_prep(obj_auxi, tgts_nr);
+		if (rc)
+			D_GOTO(out_task, rc);
+	}
 
 	if (daos_handle_is_valid(args->th)) {
 		rc = dc_tx_get_dti(args->th, &obj_auxi->l_args.la_dti);

--- a/src/object/cli_shard.c
+++ b/src/object/cli_shard.c
@@ -1,5 +1,5 @@
 /*
- *  (C) Copyright 2016-2021 Intel Corporation.
+ *  (C) Copyright 2016-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -756,7 +756,7 @@ dc_shard_update_size(struct rw_cb_args *rw_args, int fetch_rc)
 		/* single-value, trust the size replied from first shard or parity shard,
 		 * because if overwrite those shards must be updated.
 		 */
-		if ((orw->orw_oid.id_shard % obj_ec_tgt_nr(oca)) ==
+		if ((orw->orw_oid.id_shard % obj_get_grp_size(rw_args->shard_args->auxi.obj)) ==
 		     obj_ec_singv_small_idx(oca, iod) ||
 		    is_ec_parity_shard(orw->orw_oid.id_shard, oca)) {
 			if (uiod->iod_size != 0 && uiod->iod_size < sizes[i] && fetch_rc == 0) {
@@ -2008,7 +2008,7 @@ obj_shard_query_recx_post(struct obj_query_key_cb_args *cb_args, uint32_t shard,
 		return;
 	}
 
-	tgt_idx = shard % obj_ec_tgt_nr(oca);
+	tgt_idx = shard % obj_get_grp_size(cb_args->obj);
 	from_data_tgt = tgt_idx < obj_ec_data_tgt_nr(oca);
 	stripe_rec_nr = obj_ec_stripe_rec_nr(oca);
 	cell_rec_nr = obj_ec_cell_rec_nr(oca);

--- a/src/object/obj_enum.c
+++ b/src/object/obj_enum.c
@@ -535,16 +535,94 @@ csum_copy_inline(int type, vos_iter_entry_t *ent, struct dss_enum_arg *arg,
 	return 0;
 }
 
+static bool
+need_new_entry(struct dss_enum_arg *arg, vos_iter_entry_t *key_ent,
+	       daos_size_t iod_size, int type)
+{
+	struct obj_enum_rec	*rec;
+	d_iov_t			*iovs = arg->sgl->sg_iovs;
+	uint64_t		curr_off = key_ent->ie_recx.rx_idx;
+	uint64_t		curr_size = key_ent->ie_recx.rx_nr;
+	uint64_t		prev_off;
+	uint64_t		prev_size;
+
+	if (arg->last_type != OBJ_ITER_RECX || type != OBJ_ITER_RECX)
+		return true;
+
+	rec = iovs[arg->sgl_idx].iov_buf + iovs[arg->sgl_idx].iov_len - sizeof(*rec);
+	prev_off = rec->rec_recx.rx_idx;
+	prev_size = rec->rec_recx.rx_nr;
+	if (prev_off + prev_size != curr_off) /* not continuous */
+		return true;
+
+	if (arg->rsize != iod_size)
+		return true;
+
+	if (arg->ec_cell_sz > 0 &&
+	    (prev_off + prev_size - 1) / arg->ec_cell_sz !=
+	    (curr_off + curr_size) / arg->ec_cell_sz)
+		return true;
+
+	return false;
+}
+
+static void
+insert_new_rec(struct dss_enum_arg *arg, vos_iter_entry_t *new_ent, int type,
+	       daos_size_t iod_size, struct obj_enum_rec **new_rec)
+{
+	d_iov_t			*iovs = arg->sgl->sg_iovs;
+	struct obj_enum_rec	*rec;
+	daos_size_t		new_idx = new_ent->ie_recx.rx_idx;
+	daos_off_t		new_nr = new_ent->ie_recx.rx_nr;
+
+	/* For cross-cell recx, let's check if the new recx needs to merge with current
+	 * recx, then insert the left to the new recx.
+	 */
+	if (arg->last_type == OBJ_ITER_RECX && type == OBJ_ITER_RECX &&
+	    arg->ec_cell_sz > 0 && arg->rsize == iod_size) {
+		rec = iovs[arg->sgl_idx].iov_buf + iovs[arg->sgl_idx].iov_len - sizeof(*rec);
+		*new_rec = rec;
+		if (rec->rec_recx.rx_idx + rec->rec_recx.rx_nr == new_ent->ie_recx.rx_idx) {
+			new_idx = roundup(DAOS_RECX_END(rec->rec_recx), arg->ec_cell_sz);
+			if (new_idx > new_ent->ie_recx.rx_idx) {
+				new_nr -= new_idx - new_ent->ie_recx.rx_idx;
+				rec->rec_recx.rx_nr += new_ent->ie_recx.rx_nr - new_nr;
+				rec->rec_epr.epr_lo = max(new_ent->ie_epoch, rec->rec_epr.epr_lo);
+			}
+			if (new_nr == 0)
+				return;
+		}
+	}
+
+	/* Grow the next new descriptor (instead of creating yet a new one). */
+	arg->kds[arg->kds_len].kd_val_type = type;
+	arg->kds[arg->kds_len].kd_key_len += sizeof(*rec);
+	rec = iovs[arg->sgl_idx].iov_buf + iovs[arg->sgl_idx].iov_len;
+	/* Append the recx record to iovs. */
+	D_ASSERT(iovs[arg->sgl_idx].iov_len + sizeof(*rec) <= iovs[arg->sgl_idx].iov_buf_len);
+	rec->rec_recx.rx_idx = new_idx;
+	rec->rec_recx.rx_nr = new_nr;
+	rec->rec_size = iod_size;
+	rec->rec_epr.epr_lo = new_ent->ie_epoch;
+	rec->rec_epr.epr_hi = DAOS_EPOCH_MAX;
+	rec->rec_version = new_ent->ie_ver;
+	rec->rec_flags = 0;
+	iovs[arg->sgl_idx].iov_len += sizeof(*rec);
+	arg->rsize = iod_size;
+	*new_rec = rec;
+}
+
 /* Callers are responsible for incrementing arg->kds_len. See iter_akey_cb. */
 static int
 fill_rec(daos_handle_t ih, vos_iter_entry_t *key_ent, struct dss_enum_arg *arg,
 	 vos_iter_type_t vos_type, vos_iter_param_t *param, unsigned int *acts)
 {
 	d_iov_t			*iovs = arg->sgl->sg_iovs;
-	struct obj_enum_rec	*rec;
 	daos_size_t		data_size = 0, iod_size;
+	struct obj_enum_rec	*rec;
 	daos_size_t		size = sizeof(*rec);
 	bool			inline_data = false, bump_kds_len = false;
+	bool			insert_new_entry = false;
 	int			type;
 	int			rc = 0;
 
@@ -559,11 +637,8 @@ fill_rec(daos_handle_t ih, vos_iter_entry_t *key_ent, struct dss_enum_arg *arg,
 			iod_size = key_ent->ie_gsize;
 			if (iod_size == key_ent->ie_rsize)
 				data_size = iod_size;
-			else
-				data_size = 0;
 		} else {
 			iod_size = key_ent->ie_rsize;
-			data_size = iod_size * key_ent->ie_recx.rx_nr;
 		}
 	}
 
@@ -596,34 +671,30 @@ fill_rec(daos_handle_t ih, vos_iter_entry_t *key_ent, struct dss_enum_arg *arg,
 		return 0;
 	}
 
-	if (is_sgl_full(arg, size) || arg->kds_len >= arg->kds_cap) {
-		/* NB: if it is rebuild object iteration, let's
-		 * check if both dkey & akey was already packed
-		 * (kds_len < 3) before return KEY2BIG.
-		 */
-		if ((arg->chk_key2big && arg->kds_len < 3)) {
-			if (arg->kds[0].kd_key_len < size)
-				arg->kds[0].kd_key_len = size;
-			D_GOTO(out, rc = -DER_KEY2BIG);
+	insert_new_entry = need_new_entry(arg, key_ent, iod_size, type);
+	if (insert_new_entry) {
+		/* Check if there are still space */
+		if (is_sgl_full(arg, size) || arg->kds_len >= arg->kds_cap) {
+			/* NB: if it is rebuild object iteration, let's
+			 * check if both dkey & akey was already packed
+			 * (kds_len < 3) before return KEY2BIG.
+			 */
+			if ((arg->chk_key2big && arg->kds_len < 3)) {
+				if (arg->kds[0].kd_key_len < size)
+					arg->kds[0].kd_key_len = size;
+				D_GOTO(out, rc = -DER_KEY2BIG);
+			}
+			D_GOTO(out, rc = 1);
+		} else {
+			insert_new_rec(arg, key_ent, type, iod_size, &rec);
 		}
-		D_GOTO(out, rc = 1);
+	} else {
+		D_ASSERTF(arg->last_type == OBJ_ITER_RECX, "type=%d\n", arg->last_type);
+		D_ASSERTF(type == OBJ_ITER_RECX, "type=%d\n", type);
+		rec = iovs[arg->sgl_idx].iov_buf + iovs[arg->sgl_idx].iov_len - sizeof(*rec);
+		rec->rec_recx.rx_nr += key_ent->ie_recx.rx_nr;
+		rec->rec_epr.epr_lo = max(key_ent->ie_epoch, rec->rec_epr.epr_lo);
 	}
-
-	/* Grow the next new descriptor (instead of creating yet a new one). */
-	arg->kds[arg->kds_len].kd_val_type = type;
-	arg->kds[arg->kds_len].kd_key_len += sizeof(*rec);
-
-	/* Append the recx record to iovs. */
-	D_ASSERT(iovs[arg->sgl_idx].iov_len + sizeof(*rec) <=
-		 iovs[arg->sgl_idx].iov_buf_len);
-	rec = iovs[arg->sgl_idx].iov_buf + iovs[arg->sgl_idx].iov_len;
-	rec->rec_recx = key_ent->ie_recx;
-	rec->rec_size = iod_size;
-	rec->rec_epr.epr_lo = key_ent->ie_epoch;
-	rec->rec_epr.epr_hi = DAOS_EPOCH_MAX;
-	rec->rec_version = key_ent->ie_ver;
-	rec->rec_flags = 0;
-	iovs[arg->sgl_idx].iov_len += sizeof(*rec);
 
 	/*
 	 * If we've decided to inline the data, append the data to iovs.
@@ -638,15 +709,12 @@ fill_rec(daos_handle_t ih, vos_iter_entry_t *key_ent, struct dss_enum_arg *arg,
 		 * may be invisible to current enumeration. Then it
 		 * may be located on SCM or NVMe.
 		 */
-		if (type != OBJ_ITER_RECX)
-			D_ASSERTF(key_ent->ie_biov.bi_addr.ba_type ==
-				  DAOS_MEDIA_SCM,
-				  "Invalid storage media type %d, ba_off "
-				  DF_X64", thres %ld, data_size %ld, type %d, "
-				  "iod_size %ld\n",
-				  key_ent->ie_biov.bi_addr.ba_type,
-				  key_ent->ie_biov.bi_addr.ba_off,
-				  arg->inline_thres, data_size, type, iod_size);
+		D_ASSERT(type != OBJ_ITER_RECX);
+		D_ASSERTF(key_ent->ie_biov.bi_addr.ba_type ==
+			  DAOS_MEDIA_SCM, "Invalid storage media type %d, ba_off "
+			  DF_X64", thres %ld, data_size %ld, type %d, iod_size %ld\n",
+			  key_ent->ie_biov.bi_addr.ba_type, key_ent->ie_biov.bi_addr.ba_off,
+			  arg->inline_thres, data_size, type, iod_size);
 
 		d_iov_set(&iov_out, iovs[arg->sgl_idx].iov_buf +
 				       iovs[arg->sgl_idx].iov_len, data_size);

--- a/src/object/obj_internal.h
+++ b/src/object/obj_internal.h
@@ -371,6 +371,28 @@ struct shard_punch_args {
 	uint32_t		 pa_opc;
 };
 
+struct shard_sub_anchor {
+	daos_anchor_t	ssa_anchor;
+	/* These two extra anchors are for migration enumeration */
+	daos_anchor_t	*ssa_akey_anchor;
+	daos_anchor_t	*ssa_recx_anchor;
+	d_sg_list_t	ssa_sgl;
+	daos_key_desc_t	*ssa_kds;
+	daos_recx_t	*ssa_recxs;
+};
+
+/**
+ * This structure is attached to daos_anchor_t->da_sub_anchor for
+ * tracking multiple shards enumeration, for example degraded EC
+ * enumeration or EC parity rotate enumeration.
+ */
+struct shard_anchors {
+	d_list_t		sa_merged_list;
+	int			sa_nr;
+	int			sa_anchors_nr;
+	struct shard_sub_anchor	sa_anchors[0];
+};
+
 struct shard_list_args {
 	struct shard_auxi_args	 la_auxi;
 	daos_obj_list_t		*la_api_args;
@@ -392,6 +414,7 @@ struct obj_auxi_list_recx {
 
 struct obj_auxi_list_key {
 	d_iov_t		key;
+	struct ktr_hkey	hkey;
 	d_list_t	key_list;
 };
 

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -2852,15 +2852,18 @@ obj_local_enum(struct obj_io_context *ioc, crt_rpc_t *rpc,
 		/* object iteration for rebuild or consistency verification. */
 		D_ASSERT(opc == DAOS_OBJ_RPC_ENUMERATE);
 		type = VOS_ITER_DKEY;
+		param.ip_flags |= VOS_IT_RECX_VISIBLE;
 		if (daos_anchor_get_flags(&anchors[0].ia_dkey) &
 		      DIOF_WITH_SPEC_EPOCH) {
 			/* For obj verification case. */
-			param.ip_flags |= VOS_IT_RECX_VISIBLE;
 			param.ip_epc_expr = VOS_IT_EPC_RR;
 		} else {
 			param.ip_epc_expr = VOS_IT_EPC_RE;
 		}
 		recursive = true;
+
+		if (daos_oclass_is_ec(&ioc->ioc_oca))
+			enum_arg->ec_cell_sz = ioc->ioc_oca.u.ec.e_len;
 		enum_arg->chk_key2big = 1;
 		enum_arg->need_punch = 1;
 		enum_arg->copy_data_cb = vos_iter_copy;

--- a/src/object/srv_obj_migrate.c
+++ b/src/object/srv_obj_migrate.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2019-2021 Intel Corporation.
+ * (C) Copyright 2019-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -2419,11 +2419,11 @@ migrate_one_epoch_object(daos_epoch_range_t *epr, struct migrate_pool_tls *tls,
 		if (p_csum != NULL)
 			p_csum->iov_len = 0;
 
-		num = KDS_NUM;
 		daos_anchor_set_flags(&dkey_anchor,
 				      DIOF_TO_LEADER | DIOF_WITH_SPEC_EPOCH |
 				      DIOF_TO_SPEC_GROUP | DIOF_FOR_MIGRATION);
 retry:
+		num = KDS_NUM;
 		rc = dsc_obj_list_obj(oh, epr, NULL, NULL, NULL,
 				     &num, kds, &sgl, &anchor,
 				     &dkey_anchor, &akey_anchor, p_csum);

--- a/src/tests/suite/daos_checksum.c
+++ b/src/tests/suite/daos_checksum.c
@@ -2446,8 +2446,8 @@ test_enumerate_object2(void **state)
 	 */
 	assert_int_equal(4, nr);
 
-	/** only 3 checksums, dkey, akey, and inlined recx */
-	assert_int_equal(3, get_csum_count(&csum_iov));
+	/** only 2 checksums, dkey, akey */
+	assert_int_equal(2, get_csum_count(&csum_iov));
 
 	/** Clean up */
 	d_sgl_fini(&list_sgl, true);
@@ -2505,14 +2505,6 @@ test_enumerate_object_csum_buf_too_small(void **state)
 	assert_memory_equal(&zero_anchor, &anchor, sizeof(zero_anchor));
 	assert_memory_equal(&zero_anchor, &dkey_anchor, sizeof(zero_anchor));
 	assert_memory_equal(&zero_anchor, &akey_anchor, sizeof(zero_anchor));
-
-	/** csum iov buf len shouldn't change, but iov_len should reflect
-	 * what's needed to hold all csum info. Caller can decide what to do
-	 * from here.
-	 */
-	assert_int_equal(10, csum_iov.iov_buf_len);
-	assert_int_equal(11 * (sizeof(struct dcs_csum_info) + 8),
-		csum_iov.iov_len);
 
 	/** Clean up */
 	d_sgl_fini(&sgl, true);

--- a/src/tests/suite/daos_rebuild_ec.c
+++ b/src/tests/suite/daos_rebuild_ec.c
@@ -803,6 +803,7 @@ enumerate_cb(void *data)
 				    buf_len, req);
 		assert_rc_equal(rc, 0);
 		total += number;
+		print_message("total %d  number %d\n", total, number);
 	}
 
 	assert_int_equal(total, 100);

--- a/src/vos/vos_obj.c
+++ b/src/vos/vos_obj.c
@@ -1254,7 +1254,8 @@ singv_iter_next(struct vos_obj_iter *oiter)
 	 */
 	vis_flag = oiter->it_flags & VOS_IT_RECX_COVERED;
 	if (vis_flag == VOS_IT_RECX_VISIBLE) {
-		D_ASSERT(oiter->it_epc_expr == VOS_IT_EPC_RR);
+		D_ASSERT(oiter->it_epc_expr == VOS_IT_EPC_RR ||
+			 oiter->it_epc_expr == VOS_IT_EPC_RE);
 		return -DER_NONEXIST;
 	}
 

--- a/src/vos/vos_tls.h
+++ b/src/vos/vos_tls.h
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2021 Intel Corporation.
+ * (C) Copyright 2016-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -159,9 +159,6 @@ vos_kh_get(uint64_t *hash)
 	return tls->vtl_hash_set;
 }
 
-/** hash seed for murmur hash */
-#define VOS_BTR_MUR_SEED	0xC0FFEE
-
 static inline uint64_t
 vos_hash_get(const void *buf, uint64_t len)
 {
@@ -172,7 +169,7 @@ vos_hash_get(const void *buf, uint64_t len)
 		return hash;
 	}
 
-	return d_hash_murmur64(buf, len, VOS_BTR_MUR_SEED);
+	return d_hash_murmur64(buf, len, BTR_MUR_SEED);
 }
 
 #ifdef VOS_STANDALONE

--- a/src/vos/vos_tree.c
+++ b/src/vos/vos_tree.c
@@ -54,46 +54,6 @@ iov2rec_bundle(d_iov_t *val_iov)
  * @defgroup vos_key_btree vos key-btree
  * @{
  */
-
-/** Inline key is max of 15 bytes.  The extra byte in the struct is used
- *  to encode the type (hash or inline) and the length of the inline key.
- */
-#define KH_INLINE_MAX 15
-
-/**
- * hashed key for the key-btree, it is stored in btr_record::rec_hkey
- */
-struct ktr_hkey {
-	/** murmur64 hash */
-	union {
-		/** NB: This assumes little endian.  We already have little
-		 *  endian assumptions with integer keys so this isn't the
-		 *  first violation.  The hkey_gen code will trigger an
-		 *  assertion if this is violated.
-		 */
-		struct {
-			/** Length of key shifted left by 2 bits. */
-			uint32_t	kh_len;
-			/** string32 hash of key */
-			uint32_t	kh_str32;
-			/** Murmur hash of key */
-			uint64_t	kh_murmur64;
-		};
-		struct {
-			/** length shifted left by 2 bits. Low bit means inline
-			 *  key.  An extra bit is reserved for future use.
-			 */
-			char		kh_inline_len;
-			/** Inline key */
-			char		kh_inline[KH_INLINE_MAX];
-		};
-		/** For comparison convenience */
-		uint64_t		kh_hash[2];
-	};
-};
-
-D_CASSERT(sizeof(struct ktr_hkey) == 16);
-
 /**
  * Store a key and its checksum as a durable struct.
  */
@@ -188,27 +148,12 @@ ktr_rec_msize(int alloc_overhead)
 static void
 ktr_hkey_gen(struct btr_instance *tins, d_iov_t *key_iov, void *hkey)
 {
-	struct ktr_hkey		*kkey  = (struct ktr_hkey *)hkey;
+	struct ktr_hkey	*kkey = (struct ktr_hkey *)hkey;
 
-	if (key_iov->iov_len <= KH_INLINE_MAX) {
-		kkey->kh_hash[0] = 0;
-		kkey->kh_hash[1] = 0;
+	hkey_common_gen(key_iov, hkey);
 
-		/** Set the lowest bit for inline key */
-		kkey->kh_inline_len = (key_iov->iov_len << 2) | 1;
-		memcpy(&kkey->kh_inline[0], key_iov->iov_buf, key_iov->iov_len);
-		D_ASSERT(kkey->kh_len & 1);
-		return;
-	}
-
-	kkey->kh_murmur64 = d_hash_murmur64(key_iov->iov_buf, key_iov->iov_len,
-					    VOS_BTR_MUR_SEED);
-	kkey->kh_str32 = d_hash_string_u32(key_iov->iov_buf, key_iov->iov_len);
-	/** Lowest bit is clear for hashed key */
-	kkey->kh_len = key_iov->iov_len << 2;
-
-	vos_kh_set(kkey->kh_murmur64);
-	D_ASSERT(!(kkey->kh_inline_len & 1));
+	if (key_iov->iov_len > KH_INLINE_MAX)
+		vos_kh_set(kkey->kh_murmur64);
 }
 
 /** compare the hashed key */
@@ -218,24 +163,7 @@ ktr_hkey_cmp(struct btr_instance *tins, struct btr_record *rec, void *hkey)
 	struct ktr_hkey *k1 = (struct ktr_hkey *)&rec->rec_hkey[0];
 	struct ktr_hkey *k2 = (struct ktr_hkey *)hkey;
 
-	/** Since the low bit is set for inline keys, there will never be
-	 *  a conflict between an inline key and a hashed key so we can
-	 *  simply compare as if they are hashed.  Order doesn't matter
-	 *  as long as it's consistent.
-	 */
-	if (k1->kh_hash[0] < k2->kh_hash[0])
-		return BTR_CMP_LT;
-
-	if (k1->kh_hash[0] > k2->kh_hash[0])
-		return BTR_CMP_GT;
-
-	if (k1->kh_hash[1] < k2->kh_hash[1])
-		return BTR_CMP_LT;
-
-	if (k1->kh_hash[1] > k2->kh_hash[1])
-		return BTR_CMP_GT;
-
-	return BTR_CMP_EQ;
+	return hkey_common_cmp(k1, k2);
 }
 
 static int


### PR DESCRIPTION
The patch fix the enumeration from multiple data shards,
for example degrade enumeration, or parity rotation,

1. Each shard will prepare KDS/SGL/RECX buffer invidually,
and attached to the anchor.

2. After each shard get the enumeration buffer, it
needs to sort these dkey/recxs from all shards altogether
by its order inside the VOS, so to avoid duplicate/missing
keys for enumeration.

3. Then these merged/sorted keys/recxs are dumped to
the user kds/sgl/recx, and the leftover will be left in
the merged list, which will be retrieved in the following
enumeration.

Signed-off-by: Di Wang <di.wang@intel.com>