### PR TITLE
DAOS-9725 csum: Server Side Verify on Fetch

### DIFF
--- a/src/include/daos/common.h
+++ b/src/include/daos/common.h
@@ -39,7 +39,7 @@
 
 #define DAOS_ON_VALGRIND D_ON_VALGRIND
 
-#define DF_OID		DF_U64"."DF_U64
+#define DF_OID		DF_X64"."DF_X64
 #define DP_OID(o)	(o).hi, (o).lo
 
 #define DF_UOID		DF_OID".%u"

--- a/src/object/obj_enum.c
+++ b/src/object/obj_enum.c
@@ -1501,7 +1501,7 @@ obj_enum_iterate(daos_key_desc_t *kdss, d_sg_list_t *sgl, int nr,
 		}
 		sgl_move_forward(sgl, &sgl_idx, kds->kd_key_len);
 		if (rc) {
-			D_ERROR("iterate %dth failed: rc"DF_RC"\n", i,
+			D_ERROR("iterate %dth failed: "DF_RC"\n", i,
 				DP_RC(rc));
 			break;
 		}

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -1636,6 +1636,16 @@ obj_local_rw_internal(crt_rpc_t *rpc, struct obj_io_context *ioc,
 			dcf_corrupt(orw->orw_sgls.ca_arrays,
 				    orw->orw_sgls.ca_count);
 		}
+	} else {
+		rc = obj_verify_bio_csum(orw->orw_oid.id_pub, iods, orwo->orw_iod_csums.ca_arrays,
+					 biod, ioc->ioc_coc->sc_csummer,
+					 orw->orw_iod_array.oia_iod_nr);
+
+		if (rc != 0)
+			D_ERROR(DF_C_UOID_DKEY " verify_bio_csum failed: "
+				DF_RC"\n",
+				DP_C_UOID_DKEY(orw->orw_oid, dkey),
+				DP_RC(rc));
 	}
 	if (obj_rpc_is_fetch(rpc) && create_map) {
 		/* EC degraded fetch converted original iod to replica daos ext,


### PR DESCRIPTION
When the server side property is enabled on a container, also
verify the data on the server before returning it to the client.
This can help determine where corruption might have occurred.

Signed-off-by: Ryon Jensen <ryon.jensen@intel.com>