### PR TITLE
DAOS-9519: mgmt: reduce MGMT_POOL_FIND RPC timeouts

### DIFF
--- a/src/cart/crt_rpc.c
+++ b/src/cart/crt_rpc.c
@@ -637,6 +637,24 @@ out:
 	return rc;
 }
 
+int
+crt_req_get_timeout(crt_rpc_t *req, uint32_t *timeout_sec)
+{
+	struct crt_rpc_priv	*rpc_priv;
+	int			 rc = 0;
+
+	if (req == NULL || timeout_sec == NULL) {
+		D_ERROR("invalid parameter (NULL req or timeout_sec).\n");
+		D_GOTO(out, rc = -DER_INVAL);
+	}
+
+	rpc_priv = container_of(req, struct crt_rpc_priv, crp_pub);
+	*timeout_sec = rpc_priv->crp_timeout_sec;
+
+out:
+	return rc;
+}
+
 /* Called from a decref() call when the count drops to zero */
 void
 crt_req_destroy(struct crt_rpc_priv *rpc_priv)
@@ -1599,7 +1617,8 @@ crt_rpc_priv_init(struct crt_rpc_priv *rpc_priv, crt_context_t crt_ctx,
 
 	crt_rpc_inout_buff_init(rpc_priv);
 
-	rpc_priv->crp_timeout_sec = ctx->cc_timeout_sec;
+	rpc_priv->crp_timeout_sec = (ctx->cc_timeout_sec == 0 ? crt_gdata.cg_timeout :
+				     ctx->cc_timeout_sec);
 
 exit:
 	return rc;

--- a/src/include/cart/api.h
+++ b/src/include/cart/api.h
@@ -293,6 +293,17 @@ int
 crt_req_set_timeout(crt_rpc_t *req, uint32_t timeout_sec);
 
 /**
+ * Get the timeout value of an RPC request.
+ *
+ * \param[in] req              pointer to RPC request
+ * \param[out] timeout_sec     timeout value in seconds
+ *
+ * \return                     DER_SUCCESS on success, negative value if error
+ */
+int
+crt_req_get_timeout(crt_rpc_t *req, uint32_t *timeout_sec);
+
+/**
  * Add reference of the RPC request.
  *
  * The typical usage is that user needs to do some asynchronous operations in

--- a/src/tests/ftest/daos_test/suite.yaml
+++ b/src/tests/ftest/daos_test/suite.yaml
@@ -56,8 +56,9 @@ server_config:
       scm_mount: /mnt/daos0
       log_mask: DEBUG,MEM=ERR
       env_vars:
-        - DD_MASK=mgmt,io,md,epc,rebuild
+        - DD_MASK=mgmt,io,md,epc,rebuild,any
         - D_LOG_FILE_APPEND_PID=1
+        - D_LOG_FLUSH=DEBUG
     1:
       pinned_numa_node: 1
       nr_xs_helpers: 1
@@ -71,8 +72,9 @@ server_config:
       scm_mount: /mnt/daos1
       log_mask: DEBUG,MEM=ERR
       env_vars:
-        - DD_MASK=mgmt,io,md,epc,rebuild
+        - DD_MASK=mgmt,io,md,epc,rebuild,any
         - D_LOG_FILE_APPEND_PID=1
+        - D_LOG_FLUSH=DEBUG
   transport_config:
     allow_insecure: True
 agent_config:

--- a/src/tests/ftest/pool/create_capacity.yaml
+++ b/src/tests/ftest/pool/create_capacity.yaml
@@ -21,6 +21,10 @@ server_config:
       scm_class: dcpm
       scm_list: ["/dev/pmem0"]
       scm_mount: /mnt/daos0
+      log_mask: DEBUG
+      env_vars:
+        - DD_MASK=mgmt,md,dsms,any
+        - D_LOG_FLUSH=DEBUG
 pool:
   name: daos_server
   control_method: dmg


### PR DESCRIPTION
Speed up client finding pool service replicas particularly for the
situation that a daos_engine rank is no longer reachable. Reduce
the MGMT_POOL_FIND RPC timeout to 1/4 the cart RPC timeout, with
a lower bound of 10 seconds timeout.

Test-tag: pr, daily_regression

Signed-off-by: Kenneth Cain <kenneth.c.cain@intel.com>