### PR TITLE
DAOS-9760 dtx: use helper ULT for DTX RPC if has enough helper XS

### DIFF
--- a/src/dtx/dtx_internal.h
+++ b/src/dtx/dtx_internal.h
@@ -110,6 +110,13 @@ extern uint32_t dtx_agg_thd_age_up;
  */
 extern uint32_t dtx_agg_thd_age_lo;
 
+/* The threshold for using helper ULT when handle DTX RPC. */
+#define DTX_RPC_HELPER_THD_MAX	(~0U)
+#define DTX_RPC_HELPER_THD_MIN	18
+#define DTX_RPC_HELPER_THD_DEF	(DTX_THRESHOLD_COUNT + 1)
+
+extern uint32_t dtx_rpc_helper_thd;
+
 struct dtx_pool_metrics {
 	struct d_tm_node_t	*dpm_batched_degree;
 	struct d_tm_node_t	*dpm_batched_total;

--- a/src/dtx/dtx_rpc.c
+++ b/src/dtx/dtx_rpc.c
@@ -109,6 +109,8 @@ D_CASSERT(sizeof(((struct dtx_cf_rec_bundle *)0)->dcrb_rank) +
 	  sizeof(((struct dtx_cf_rec_bundle *)0)->dcrb_tag) ==
 	  sizeof(((struct dtx_cf_rec_bundle *)0)->dcrb_key));
 
+uint32_t dtx_rpc_helper_thd;
+
 static void
 dtx_req_cb(const struct crt_cb_info *cb_info)
 {
@@ -487,8 +489,6 @@ btr_ops_t dbtree_dtx_cf_ops = {
 };
 
 #define DTX_CF_BTREE_ORDER	20
-/* The threshold for using helper ULT when handle DTX RPC. */
-#define DTX_RPC_HELPER_THD	10
 
 static int
 dtx_classify_one(struct ds_pool *pool, daos_handle_t tree, d_list_t *head,
@@ -648,7 +648,8 @@ dtx_rpc_helper(void *arg)
 static int
 dtx_rpc_prep(struct ds_cont_child *cont, d_list_t *head, struct btr_root *tree_root,
 	     daos_handle_t *tree_hdl, struct dtx_req_args *dra, ABT_thread *helper,
-	     struct dtx_id dtis[], struct dtx_entry **dtes, daos_epoch_t epoch, int count, int opc)
+	     struct dtx_id dtis[], struct dtx_entry **dtes, daos_epoch_t epoch,
+	     uint32_t count, int opc)
 {
 	d_rank_t	my_rank;
 	uint32_t	my_tgtid;
@@ -659,7 +660,9 @@ dtx_rpc_prep(struct ds_cont_child *cont, d_list_t *head, struct btr_root *tree_r
 	crt_group_rank(NULL, &my_rank);
 	my_tgtid = dss_get_module_info()->dmi_tgt_id;
 
-	if (dtes[0]->dte_mbs->dm_tgt_cnt * count >= DTX_RPC_HELPER_THD) {
+	/* Use helper ULT to handle DTX RPC if there are enough helper XS. */
+	if (dss_has_enough_helper() &&
+	    (dtes[0]->dte_mbs->dm_tgt_cnt - 1) * count >= dtx_rpc_helper_thd) {
 		struct dtx_helper_args	*dha = NULL;
 
 		D_ALLOC_PTR(dha);

--- a/src/dtx/dtx_srv.c
+++ b/src/dtx/dtx_srv.c
@@ -386,6 +386,23 @@ dtx_init(void)
 	D_INFO("Set DTX aggregation time threshold as %d (seconds)\n",
 	       dtx_agg_thd_age_up);
 
+	str = getenv("DTX_RPC_HELPER_THD");
+	if (str != NULL) {
+		dtx_rpc_helper_thd = atoi(str);
+		if (dtx_rpc_helper_thd == 0) {
+			dtx_rpc_helper_thd = DTX_RPC_HELPER_THD_MAX;
+		} else if (dtx_rpc_helper_thd < DTX_RPC_HELPER_THD_MIN) {
+			D_WARN("Invalid DTX RPC helper threshold %u, the valid range is "
+			       "[%u, unlimited), 0 is for unlimited, use the default value %u\n",
+			       dtx_rpc_helper_thd, DTX_RPC_HELPER_THD_MIN, DTX_RPC_HELPER_THD_DEF);
+			dtx_rpc_helper_thd = DTX_RPC_HELPER_THD_DEF;
+		}
+	} else {
+		dtx_rpc_helper_thd = DTX_RPC_HELPER_THD_DEF;
+	}
+
+	D_INFO("Set DTX RPC helper threshold as %u\n", dtx_rpc_helper_thd);
+
 	rc = dbtree_class_register(DBTREE_CLASS_DTX_CF,
 				   BTR_FEAT_UINT_KEY | BTR_FEAT_DYNAMIC_ROOT,
 				   &dbtree_dtx_cf_ops);

--- a/src/engine/srv.c
+++ b/src/engine/srv.c
@@ -1424,3 +1424,9 @@ dss_set_start_epoch(void)
 {
 	dss_start_epoch = crt_hlc_get();
 }
+
+bool
+dss_has_enough_helper(void)
+{
+	return dss_tgt_offload_xs_nr > 1 && dss_tgt_offload_xs_nr >= dss_tgt_nr / 4;
+}

--- a/src/include/daos_srv/daos_engine.h
+++ b/src/include/daos_srv/daos_engine.h
@@ -185,6 +185,7 @@ bool dss_xstream_exiting(struct dss_xstream *dxs);
 bool dss_xstream_is_busy(void);
 daos_epoch_t dss_get_start_epoch(void);
 void dss_set_start_epoch(void);
+bool dss_has_enough_helper(void);
 
 struct dss_module_info {
 	crt_context_t		dmi_ctx;


### PR DESCRIPTION
master-commit: 459e2dc69e62c3a2da8be8573e2f847e965d7c32

If there is not enough helper XS, then starting more ULT on the helper
XS cannot give much help to DTX RPC handling.

The patch also allows admin to adjust the threshold for using helper ULT
to handle DTX RPC when start DAOS engine via the server side environment
"DTX_RPC_HELPER_THD", "0" means disable helper ULT to handle DTX RPC.

Signed-off-by: Fan Yong <fan.yong@intel.com>