### PR TITLE
DAOS-9881 doc: fix doxygen path issues

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -51,7 +51,11 @@ PROJECT_BRIEF          =
 # pixels and the maximum width should not exceed 200 pixels. Doxygen will copy
 # the logo to the output directory.
 
-PROJECT_LOGO           = "https://docs.daos.io/latest/daos_logo.png"
+# Note: This path is relative to the github checkout root.
+#       Running doxygen will copy this logo file into the OUTPUT_DIRECTORY,
+#       so the index.html file in OUTPUT_DIRECTORY will always refer to a
+#       local daos_logo.png, without a path component...
+PROJECT_LOGO           = "docs/daos_logo.png"
 
 # The OUTPUT_DIRECTORY tag is used to specify the (relative or absolute) path
 # into which the generated documentation will be written. If a relative path is

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -109,4 +109,5 @@ nav:
         - 'Dev Environment': 'dev/development.md'
         - 'Contributing': 'dev/contributing.md'
         - 'DAOS Internals': 'https://github.com/daos-stack/daos/blob/master/src/README.md'
-        - 'DAOS API Documentation': 'doxygen/html/index.html'
+        - 'DAOS API Documentation': 'https://docs.daos.io/v2.2/doxygen/html/index.html'
+        # Attention: Don't change that doxygen path to a relative path, or mkdocs will stumble...


### PR DESCRIPTION
fix path specs in Doxyfile and mkdocs.yml

Doc-only: true
Signed-off-by: Michael Hennecke <michael.hennecke@intel.com>