### PR TITLE
DAOS-9974 test: Fix server state detection.

### DIFF
--- a/src/tests/ftest/launch.py
+++ b/src/tests/ftest/launch.py
@@ -746,10 +746,12 @@ def auto_detect_devices(host_list, device_type, length, device_filter=None):
 
     # Find the devices on each host
     if device_type == "VMD":
+        # Exclude the controller revision as this causes heterogeneous clush output
         command_list = [
             "/sbin/lspci -D",
             "grep -E '^[0-9a-f]{{{0}}}:[0-9a-f]{{2}}:[0-9a-f]{{2}}.[0-9a-f] '".format(length),
-            "grep -E 'Volume Management Device NVMe RAID Controller'"]
+            "grep -E 'Volume Management Device NVMe RAID Controller'",
+            r"sed -E 's/\(rev\s+([a-f0-9])+\)//I'"]
     elif device_type == "NVMe":
         command_list = [
             "/sbin/lspci -D",

--- a/src/tests/ftest/util/command_utils.py
+++ b/src/tests/ftest/util/command_utils.py
@@ -1245,8 +1245,8 @@ class SubprocessManager():
         if set_expected:
             # Assign the expected states to the current job process states
             self.log.info(
-                "<%s> Assigning expected %s states.",
-                self._id.upper(), self._id)
+                "<%s> Assigning expected %s states: %s",
+                self._id.upper(), self._id, current_states)
             self._expected_states = current_states.copy()
 
         # Verify the expected states match the current states
@@ -1254,7 +1254,7 @@ class SubprocessManager():
             "<%s> Verifying %s states: group=%s, hosts=%s",
             self._id.upper(), self._id, self.get_config_value("name"),
             NodeSet.fromlist(self._hosts))
-        if current_states:
+        if current_states and self._expected_states:
             log_format = "  %-4s  %-15s  %-36s  %-22s  %-14s  %s"
             self.log.info(
                 log_format,


### PR DESCRIPTION
If a failure occurs during server startup the expected server states
will not be defined.  This will cause a bug when the server states are
detected as part of the test cleanup leaving the servers running when
they should be stopped.  This code change resolves this situation.

Skip-unit-tests: true
Skip-func-test-vm: true
Skip-func-hw-test-small: true
Skip-func-hw-test-large: true
Test-tag-hw-medium: daos_core_test

Signed-off-by: Phillip Henderson <phillip.henderson@intel.com>