### PR TITLE
Revert "DAOS-9748 doc: document FI_OFI_RXM_USE_SRX in daos_server.yml…

### DIFF
--- a/utils/config/daos_server.yml
+++ b/utils/config/daos_server.yml
@@ -92,7 +92,8 @@
 #
 #
 ## CART: Disable SRX
-## parameters shared with client.
+## parameters shared with client. set it to true if network card
+## does not support shared receive context, eg intel E810-C.
 #
 #disable_srx: false
 #
@@ -458,8 +459,6 @@
 #
 #  env_vars:
 #      - CRT_TIMEOUT=100
-#      - FI_OFI_RXM_USE_SRX=1 # set it to 0 if network card does not support
-#                             # shared receive context, eg intel E810-C.
 #
 #  storage:
 #  -


### PR DESCRIPTION
… (#8116)"

This reverts commit 31a4519df0b9d0f49b4d50e5666319af17b875d5.

Better use disable_srx option.

Signed-off-by: Wang Shilong <shilong.wang@intel.com>