### PR TITLE
DAOS-9355 doc: clarify dmg pool create and pool properties

### DIFF
--- a/docs/admin/pool_operations.md
+++ b/docs/admin/pool_operations.md
@@ -277,19 +277,27 @@ Three options are supported:
 ### Self-healing Policy (self\_heal)
 
 This property defines whether a failing node is automatically evicted from the
-pool. Once excluded, the self-healing mechasnism will be triggered to restore
+pool. Once excluded, the self-healing mechanism will be triggered to restore
 the pool data redundancy on the surviving storage nodes.
+Two options are supported: "exclude" (default strategy) and "rebuild".
 
-### Reserve Space (space\_rb)
+### Reserved Space for Rebuilds (space\_rb)
 
 This property defines the percentage of total space reserved on each storage
-node for self-healing purpose. The reserved space cannot be consumed by the
-applications.
+node for self-healing purpose. The reserved space cannot be consumed by
+applications. Valid values are 0% to 100%, the default is 0%.
+When setting this property, specifying the percentage symbol is optional:
+`space_rb:2%` and `space_rb:2` both specify two percent of storage capacity.
 
-### EC Cell Size (ec\_cell\_sz)
+### Default EC Cell Size (ec\_cell\_sz)
 
 This property defines the default erasure code cell size inherited to DAOS
-containers. The value is typically between 32K and 1MB.
+containers. The EC cell size can be between 1kiB and 1GiB,
+although it should typically be set to a value between 32kiB and 1MiB.
+The default is 1MiB.
+When setting this property, the cell size can be specified in Bytes
+(as a number with no suffix), with a base-10 suffix like `k` or `MB`,
+or with a base-2 suffix like `ki` or `MiB`.
 
 ## Access Control Lists
 

--- a/docs/admin/pool_operations.md
+++ b/docs/admin/pool_operations.md
@@ -510,7 +510,7 @@ The pool reintegrate command accepts 3 parameters:
 * The target indices of the targets to be reintegrated on that rank (optional).
 
 When rebuild is triggered it will list the operations and their related engines/targets
-by their engine rank ID and target index.
+by their engine rank and target index.
 
 ```
 Target (rank 5 idx 0) is down.

--- a/docs/admin/pool_operations.md
+++ b/docs/admin/pool_operations.md
@@ -44,7 +44,7 @@ $ dmg pool create --help
       -P, --properties= Pool properties to be set
       -a, --acl-file=   Access Control List file path for DAOS pool
       -z, --size=       Total size of DAOS pool (auto)
-      -t, --tier-ratio= Percentage of SCM,NVMe storage tiers for pool storage (auto) (default: 6,94)
+      -t, --tier-ratio= Percentage of storage tiers for pool storage (auto) (default: 6% SCM, 94% NVMe)
       -k, --nranks=     Number of ranks to use (auto)
       -v, --nsvc=       Number of pool service replicas
       -s, --scm-size=   Per-engine SCM allocation for DAOS pool (manual)

--- a/docs/admin/pool_operations.md
+++ b/docs/admin/pool_operations.md
@@ -462,7 +462,7 @@ $ dmg pool exclude --rank=${rank} --target-idx=${idx1},${idx2},${idx3} <pool_lab
 
 The pool target exclude command accepts 2 parameters:
 
-* The rank of the target(s) to be excluded.
+* The engine rank of the target(s) to be excluded.
 * The target Indices of the targets to be excluded from that rank (optional).
 
 Upon successful manual exclusion, the self-healing mechanism will be triggered
@@ -488,7 +488,7 @@ $ dmg pool drain --rank=${rank} --target-idx=${idx1},${idx2},${idx3} $DAOS_POOL
 
 The pool target drain command accepts 2 parameters:
 
-* The rank of the target(s) to be drained.
+* The engine rank of the target(s) to be drained.
 * The target Indices of the targets to be drained from that rank (optional).
 
 ### Reintegration
@@ -509,8 +509,8 @@ The pool reintegrate command accepts 3 parameters:
 * The engine rank of the affected targets.
 * The target indices of the targets to be reintegrated on that rank (optional).
 
-When rebuild is triggered it will list the operations and their related targets by their rank ID
-and target index.
+When rebuild is triggered it will list the operations and their related engines/targets
+by their engine rank ID and target index.
 
 ```
 Target (rank 5 idx 0) is down.
@@ -554,7 +554,7 @@ $ dmg pool extend $DAOS_POOL --ranks=${rank1},${rank2}...
 ```
 
 The pool extend command accepts one required parameter which is a comma
-separated list of server ranks to include in the pool.
+separated list of engine ranks to include in the pool.
 
 The pool rebalance operation will work most efficiently when the pool is
 extended to its desired size in a single operation, as opposed to multiple,

--- a/docs/admin/pool_operations.md
+++ b/docs/admin/pool_operations.md
@@ -59,12 +59,12 @@ $ dmg pool create --size 50GB tank
 Creating DAOS pool with automatic storage allocation: 50 GB NVMe + 6.00% SCM
 Pool created with 6.00% SCM/NVMe ratio
 -----------------------------------------
-  UUID          : 8a05bf3a-a088-4a77-bb9f-df989fce7cc8
-  Replica Ranks : [1-3]
-  Target Ranks  : [0-15]
-  Size          : 50 GB
-  SCM           : 3.0 GB (188 MB / rank)
-  NVMe          : 47 GB (3.0 GB / rank)
+  UUID                 : 8a05bf3a-a088-4a77-bb9f-df989fce7cc8
+  Service Ranks        : [1-3]
+  Storage Ranks        : [0-15]
+  Total Size           : 50 GB
+  Storage tier 0 (SCM) : 3.0 GB (188 MB / rank)
+  Storage tier 1 (NVMe): 47 GB (3.0 GB / rank)
 ```
 
 This created a pool with UUID 8a05bf3a-a088-4a77-bb9f-df989fce7cc8,
@@ -80,7 +80,7 @@ will be distributed as follows:
 - 6% is allocated on SCM (i.e., 3GB in the example above)
 - 94% is allocated on NVMe SSD (i.e., 47GB in the example above)
 
-Note that it is difficult to determine the usable space by the user and
+Note that it is difficult to determine the usable space by the user, and
 currently we cannot provide the precise value. The usable space depends not only
 on pool size, but also on number of targets, target size, object class,
 storage redundancy factor, etc.

--- a/docs/admin/pool_operations.md
+++ b/docs/admin/pool_operations.md
@@ -17,8 +17,8 @@ $ dmg pool create --size=<N>TB tank
 ```
 
 This command creates a pool labeled `tank` distributed across the DAOS servers
-with a target size on each server that is comprised of N TB of NVMe storage
-and N * 0.06 (i.e., 6% of NVMe) of SCM storage. The default SCM:NVMe ratio
+with a target size on each server that is comprised of N * 0.94 TB of NVMe storage
+and N * 0.06 TB (i.e., 6% of NVMe) of SCM storage. The default SCM:NVMe ratio
 may be adjusted at pool creation time as described below.
 
 The UUID allocated to the newly created pool is printed to stdout
@@ -44,12 +44,12 @@ $ dmg pool create --help
       -P, --properties= Pool properties to be set
       -a, --acl-file=   Access Control List file path for DAOS pool
       -z, --size=       Total size of DAOS pool (auto)
-      -t, --tier-ratio= Distribution of pool storage allocation over storage tiers (auto) (default: 6)
+      -t, --tier-ratio= Percentage of SCM,NVMe storage tiers for pool storage (auto) (default: 6,94)
       -k, --nranks=     Number of ranks to use (auto)
       -v, --nsvc=       Number of pool service replicas
-      -s, --scm-size=   Per-server SCM allocation for DAOS pool (manual)
-      -n, --nvme-size=  Per-server NVMe allocation for DAOS pool (manual)
-      -r, --ranks=      Storage server unique identifiers (ranks) for DAOS pool
+      -s, --scm-size=   Per-engine SCM allocation for DAOS pool (manual)
+      -n, --nvme-size=  Per-engine NVMe allocation for DAOS pool (manual)
+      -r, --ranks=      Storage engine unique identifiers (ranks) for DAOS pool
 ```
 
 The typical output of this command is as follows:
@@ -68,7 +68,8 @@ Pool created with 6.00% SCM/NVMe ratio
 ```
 
 This created a pool with UUID 8a05bf3a-a088-4a77-bb9f-df989fce7cc8,
-with redundancy enabled by default (pool service replicas on ranks 1-3).
+with pool service redundancy enabled by default
+(pool service replicas on ranks 1-3).
 
 If no redundancy is desired, use --nsvc=1 in order to specify that only
 a single pool service replica should be created.
@@ -82,7 +83,7 @@ will be distributed as follows:
 Note that it is difficult to determine the usable space by the user and
 currently we cannot provide the precise value. The usable space depends not only
 on pool size, but also on number of targets, target size, object class,
-redundancy factor, etc.
+storage redundancy factor, etc.
 
 ### Listing Pools
 

--- a/src/control/cmd/dmg/pool.go
+++ b/src/control/cmd/dmg/pool.go
@@ -387,7 +387,7 @@ func (cmd *PoolEvictCmd) Execute(args []string) error {
 // PoolExcludeCmd is the struct representing the command to exclude a DAOS target.
 type PoolExcludeCmd struct {
 	poolCmd
-	Rank      uint32 `long:"rank" required:"1" description:"Rank of the targets to be excluded"`
+	Rank      uint32 `long:"rank" required:"1" description:"Engine rank of the targets to be excluded"`
 	Targetidx string `long:"target-idx" description:"Comma-separated list of target idx(s) to be excluded from the rank"`
 }
 
@@ -415,7 +415,7 @@ func (cmd *PoolExcludeCmd) Execute(args []string) error {
 // PoolDrainCmd is the struct representing the command to Drain a DAOS target.
 type PoolDrainCmd struct {
 	poolCmd
-	Rank      uint32 `long:"rank" required:"1" description:"Rank of the targets to be drained"`
+	Rank      uint32 `long:"rank" required:"1" description:"Engine rank of the targets to be drained"`
 	Targetidx string `long:"target-idx" description:"Comma-separated list of target idx(s) to be drained on the rank"`
 }
 
@@ -474,7 +474,7 @@ func (cmd *PoolExtendCmd) Execute(args []string) error {
 // PoolReintegrateCmd is the struct representing the command to Add a DAOS target.
 type PoolReintegrateCmd struct {
 	poolCmd
-	Rank      uint32 `long:"rank" required:"1" description:"Rank of the targets to be reintegrated"`
+	Rank      uint32 `long:"rank" required:"1" description:"Engine rank of the targets to be reintegrated"`
 	Targetidx string `long:"target-idx" description:"Comma-separated list of target idx(s) to be reintegrated into the rank"`
 }
 

--- a/src/control/cmd/dmg/pool.go
+++ b/src/control/cmd/dmg/pool.go
@@ -56,7 +56,7 @@ type PoolCreateCmd struct {
 	Properties    PoolSetPropsFlag `short:"P" long:"properties" description:"Pool properties to be set"`
 	ACLFile       string           `short:"a" long:"acl-file" description:"Access Control List file path for DAOS pool"`
 	Size          string           `short:"z" long:"size" description:"Total size of DAOS pool or its percentage ratio (auto)"`
-	TierRatio     string           `short:"t" long:"tier-ratio" default:"6% SCM, 94% NVMe" description:"Percentage of storage tiers for pool storage (auto)"`
+	TierRatio     string           `short:"t" long:"tier-ratio" default:"6,94" description:"Percentage of storage tiers for pool storage (auto)"`
 	NumRanks      uint32           `short:"k" long:"nranks" description:"Number of ranks to use (auto)"`
 	NumSvcReps    uint32           `short:"v" long:"nsvc" description:"Number of pool service replicas"`
 	ScmSize       string           `short:"s" long:"scm-size" description:"Per-engine SCM allocation for DAOS pool (manual)"`

--- a/src/control/cmd/dmg/pool.go
+++ b/src/control/cmd/dmg/pool.go
@@ -56,7 +56,7 @@ type PoolCreateCmd struct {
 	Properties    PoolSetPropsFlag `short:"P" long:"properties" description:"Pool properties to be set"`
 	ACLFile       string           `short:"a" long:"acl-file" description:"Access Control List file path for DAOS pool"`
 	Size          string           `short:"z" long:"size" description:"Total size of DAOS pool or its percentage ratio (auto)"`
-	TierRatio     string           `short:"t" long:"tier-ratio" default:"6,94" description:"Percentage of SCM,NVMe storage tiers for pool storage (auto)"`
+	TierRatio     string           `short:"t" long:"tier-ratio" default:"6% SCM, 94% NVMe" description:"Percentage of storage tiers for pool storage (auto)"`
 	NumRanks      uint32           `short:"k" long:"nranks" description:"Number of ranks to use (auto)"`
 	NumSvcReps    uint32           `short:"v" long:"nsvc" description:"Number of pool service replicas"`
 	ScmSize       string           `short:"s" long:"scm-size" description:"Per-engine SCM allocation for DAOS pool (manual)"`

--- a/src/control/cmd/dmg/pool.go
+++ b/src/control/cmd/dmg/pool.go
@@ -56,12 +56,12 @@ type PoolCreateCmd struct {
 	Properties    PoolSetPropsFlag `short:"P" long:"properties" description:"Pool properties to be set"`
 	ACLFile       string           `short:"a" long:"acl-file" description:"Access Control List file path for DAOS pool"`
 	Size          string           `short:"z" long:"size" description:"Total size of DAOS pool or its percentage ratio (auto)"`
-	TierRatio     string           `short:"t" long:"tier-ratio" default:"6,94" description:"Percentage of storage tiers for pool storage (auto)"`
+	TierRatio     string           `short:"t" long:"tier-ratio" default:"6,94" description:"Percentage of SCM,NVMe storage tiers for pool storage (auto)"`
 	NumRanks      uint32           `short:"k" long:"nranks" description:"Number of ranks to use (auto)"`
 	NumSvcReps    uint32           `short:"v" long:"nsvc" description:"Number of pool service replicas"`
-	ScmSize       string           `short:"s" long:"scm-size" description:"Per-server SCM allocation for DAOS pool (manual)"`
-	NVMeSize      string           `short:"n" long:"nvme-size" description:"Per-server NVMe allocation for DAOS pool (manual)"`
-	RankList      string           `short:"r" long:"ranks" description:"Storage server unique identifiers (ranks) for DAOS pool"`
+	ScmSize       string           `short:"s" long:"scm-size" description:"Per-engine SCM allocation for DAOS pool (manual)"`
+	NVMeSize      string           `short:"n" long:"nvme-size" description:"Per-engine NVMe allocation for DAOS pool (manual)"`
+	RankList      string           `short:"r" long:"ranks" description:"Storage engine unique identifiers (ranks) for DAOS pool"`
 
 	Args struct {
 		PoolLabel string `positional-arg-name:"<pool label>"`

--- a/src/placement/jump_map.c
+++ b/src/placement/jump_map.c
@@ -1148,9 +1148,9 @@ out:
  * \param[in]   md              Metadata describing the object.
  * \param[in]   shard_md        Metadata describing how the shards.
  * \param[in]   rebuild_ver     Current Rebuild version
- * \param[out]   tgt_rank       The rank of the targets that need to be rebuild
- *                              will be stored in this array to be passed out
- *                              (this is allocated by the caller)
+ * \param[out]   tgt_rank       The engine rank of the targets that need to be
+ *                              rebuilt will be stored in this array to be passed
+ *                              out (this is allocated by the caller)
  * \param[out]   shard_id       The shard IDs of the shards that need to be
  *                              rebuilt (This is allocated by the caller)
  * \param[in]   array_size      The max size of the passed in arrays to store


### PR DESCRIPTION
for dmg pool create:
* clarify tier-ratio and server versus engine
* clarify pool service replication versus storage replication

for dmg pool get-prop/set-prop:
* clarify valid ranges and defaults for pool properties

Signed-off-by: Michael Hennecke <michael.hennecke@intel.com>