### PR TITLE
DAOS-9972 test: Workaround for SPDK scan failing when VMD is enabled

### DIFF
--- a/src/control/lib/spdk/nvme.go
+++ b/src/control/lib/spdk/nvme.go
@@ -125,11 +125,14 @@ func (n *NvmeImpl) Discover(log logging.Logger) (storage.NvmeControllers, error)
 	}
 
 	ctrlrs, err := collectCtrlrs(C.nvme_discover(), "NVMe Discover(): C.nvme_discover")
+	if err != nil {
+		return nil, err
+	}
 
 	pciAddrs := ctrlrPCIAddresses(ctrlrs)
 	log.Debugf("discovered nvme ssds: %v", pciAddrs)
 
-	return ctrlrs, wrapCleanError(err, cleanLockfiles(log, realRemove, pciAddrs...))
+	return ctrlrs, cleanLockfiles(log, realRemove, pciAddrs...)
 }
 
 func resultPCIAddresses(results []*FormatResult) []string {

--- a/src/control/server/server_utils.go
+++ b/src/control/server/server_utils.go
@@ -256,20 +256,6 @@ func prepBdevStorage(srv *server, iommuEnabled bool) error {
 	return nil
 }
 
-// scanBdevStorage performs discovery and validates existence of configured NVMe SSDs.
-func scanBdevStorage(srv *server) (*storage.BdevScanResponse, error) {
-	nvmeScanResp, err := srv.ctlSvc.NvmeScan(storage.BdevScanRequest{
-		DeviceList:  cfgGetBdevs(srv.cfg),
-		BypassCache: true, // init cache on first scan
-	})
-	if err != nil {
-		srv.log.Errorf("%s\n", errors.Wrap(err, "NVMe Scan Failed"))
-		return nil, err
-	}
-
-	return nvmeScanResp, nil
-}
-
 // Minimum recommended number of hugepages has already been calculated and set in config so verify
 // we have enough free hugepage memory to satisfy this requirement before setting mem_size and
 // hugepage_size parameters for engine.

--- a/src/control/server/server_utils.go
+++ b/src/control/server/server_utils.go
@@ -263,13 +263,8 @@ func scanBdevStorage(srv *server) (*storage.BdevScanResponse, error) {
 		BypassCache: true, // init cache on first scan
 	})
 	if err != nil {
-		// Return error if fault code is for BdevNotFound.
-		if storage.FaultBdevNotFound().Equals(err) {
-			return nil, err
-		}
-		// Keep going for other scan related failures.
 		srv.log.Errorf("%s\n", errors.Wrap(err, "NVMe Scan Failed"))
-		return &storage.BdevScanResponse{}, nil
+		return nil, err
 	}
 
 	return nvmeScanResp, nil

--- a/src/tests/ftest/util/server_utils.py
+++ b/src/tests/ftest/util/server_utils.py
@@ -203,8 +203,6 @@ class DaosServerManager(SubprocessManager):
         if storage:
             # Prepare server storage
             if self.manager.job.using_nvme or self.manager.job.using_dcpm:
-                self.log.info("Preparing storage in <format> mode")
-                self.prepare_storage("root")
                 if hasattr(self.manager, "mca"):
                     self.manager.mca.update({"plm_rsh_args": "-l root"}, "orterun.mca", True)
 
@@ -537,12 +535,6 @@ class DaosServerManager(SubprocessManager):
         self.manager.kill()
 
         if self.manager.job.using_nvme:
-            # Reset the storage
-            try:
-                self.reset_storage()
-            except ServerFailed as error:
-                messages.append(str(error))
-
             # Make sure the mount directory belongs to non-root user
             self.set_scm_mount_ownership()
 


### PR DESCRIPTION
Verify issue on wolf-[53,126-129].

Workaround the test failures by failing fast on first scan failure,
subsequent scans after daos_server process restart will succeed
and tests will pass.

Changes:
- remove unnecessary storage prepare calls in test setup
- fail daos_server setup on any spdk scan errors

Quick-functional: true
Parallel-build: true
Skip-unit-tests: true
Skip-func-test-vm: true
Skip-func-hw-test-small: true
Skip-func-hw-test-large: true
Test-tag-hw-medium: test_daos_degraded_mode
Test-repeat: 2

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>