### PR TITLE
DAOS-9990: Fix various coverity issues

### DIFF
--- a/src/common/compression.c
+++ b/src/common/compression.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2020-2021 Intel Corporation.
+ * (C) Copyright 2020-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -135,6 +135,8 @@ daos_compressor_init(struct daos_compressor **obj,
 
 	if (rc == DC_STATUS_OK)
 		*obj = result;
+	else
+		D_FREE(result);
 
 	return rc;
 }

--- a/src/placement/ring_map.c
+++ b/src/placement/ring_map.c
@@ -1254,7 +1254,7 @@ ring_obj_find_reint(struct pl_map *map, struct daos_obj_md *md,
 		rc = pl_obj_layout_alloc(rop.rop_grp_size, rop.rop_grp_nr,
 				&reint_layout);
 		if (rc) {
-			D_FREE(layout);
+			pl_obj_layout_free(layout);
 			return rc;
 		}
 	} else {

--- a/src/placement/ring_map.c
+++ b/src/placement/ring_map.c
@@ -1253,8 +1253,10 @@ ring_obj_find_reint(struct pl_map *map, struct daos_obj_md *md,
 			return rc;
 		rc = pl_obj_layout_alloc(rop.rop_grp_size, rop.rop_grp_nr,
 				&reint_layout);
-		if (rc)
+		if (rc) {
+			D_FREE(layout);
 			return rc;
+		}
 	} else {
 		layout = &layout_on_stack;
 		reint_layout = &reint_layout_on_stack;

--- a/src/vea/vea_free.c
+++ b/src/vea/vea_free.c
@@ -505,7 +505,6 @@ migrate_end_cb(void *data, bool noop)
 		if (vsi->vsi_unmap_ctxt.vnc_unmap != NULL) {
 			D_ALLOC_PTR(vue);
 			if (vue == NULL) {
-				rc = -DER_NOMEM;
 				break;
 			}
 


### PR DESCRIPTION
Coverity identified some dead code and leaked resources. This patch fixes
resource leaks in the compression and ring_map code and removes an unchecked
return code assignment.

Signed-off-by: David Quigley <david.quigley@intel.com>