### PR TITLE
DAOS-9990 dfuse: Remove double close from test

### DIFF
--- a/src/client/dfuse/test/test_ioil.c
+++ b/src/client/dfuse/test/test_ioil.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2021 Intel Corporation.
+ * (C) Copyright 2016-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -371,9 +371,6 @@ skip_mmap:
 	if (fp != NULL) {
 		rc = fclose(fp);
 		printf("fclose returned %d\n", rc);
-	} else {
-		rc = close(new_fd);
-		printf("close returned %d\n", rc);
 	}
 	CU_ASSERT_EQUAL(rc, 0);
 


### PR DESCRIPTION
Coverity identified a double close on a fd in the do_misc_tests test. This fixes the issue by removing the double close and subsequent reporting of the close return value for the double close.

Signed-off-by: David Quigley <david.quigley@intel.com>