### PR TITLE
DAOS-9562 test: Support multiple rev VMD NVMe RAID controller (#8209)

### DIFF
--- a/src/tests/ftest/launch.py
+++ b/src/tests/ftest/launch.py
@@ -745,10 +745,12 @@ def auto_detect_devices(host_list, device_type, length, device_filter=None):
 
     # Find the devices on each host
     if device_type == "VMD":
+        # Exclude the controller revision as this causes heterogeneous clush output
         command_list = [
             "/sbin/lspci -D",
             "grep -E '^[0-9a-f]{{{0}}}:[0-9a-f]{{2}}:[0-9a-f]{{2}}.[0-9a-f] '".format(length),
-            "grep -E 'Volume Management Device NVMe RAID Controller'"]
+            "grep -E 'Volume Management Device NVMe RAID Controller'",
+            r"sed -E 's/\(rev\s+([a-f0-9])+\)//I'"]
     elif device_type == "NVMe":
         command_list = [
             "/sbin/lspci -D",


### PR DESCRIPTION
Exclude the VMD NVMe RAID Controller hardware revision from the lspci -D
output that causes the clush output to be different from multiple nodes
when the pci addresses are common to all hosts resulting in an error.

Skip-unit-tests: true
Skip-func-test-vm: true
Skip-func-hw-test-small: true
Skip-func-hw-test-large: true
Test-tag-hw-medium: pr daily_regression full_regression

Signed-off-by: Phillip Henderson <phillip.henderson@intel.com>