### PR TITLE
DAOS-9972 test: Workaround for SPDK scan failing when VMD is enabled

### DIFF
--- a/src/control/fault/code/codes.go
+++ b/src/control/fault/code/codes.go
@@ -85,6 +85,7 @@ const (
 	BdevNotFound
 	BdevDuplicatesInDeviceList
 	BdevNoDevicesMatchFilter
+	BdevHugepagesDisabled
 )
 
 // DAOS system fault codes

--- a/src/control/lib/spdk/nvme.go
+++ b/src/control/lib/spdk/nvme.go
@@ -125,11 +125,14 @@ func (n *NvmeImpl) Discover(log logging.Logger) (storage.NvmeControllers, error)
 	}
 
 	ctrlrs, err := collectCtrlrs(C.nvme_discover(), "NVMe Discover(): C.nvme_discover")
+	if err != nil {
+		return nil, err
+	}
 
 	pciAddrs := ctrlrPCIAddresses(ctrlrs)
 	log.Debugf("discovered nvme ssds: %v", pciAddrs)
 
-	return ctrlrs, wrapCleanError(err, cleanLockfiles(log, realRemove, pciAddrs...))
+	return ctrlrs, cleanLockfiles(log, realRemove, pciAddrs...)
 }
 
 func resultPCIAddresses(results []*FormatResult) []string {

--- a/src/control/server/ctl_storage.go
+++ b/src/control/server/ctl_storage.go
@@ -66,6 +66,12 @@ func (scs *StorageControlService) WithVMDEnabled() *StorageControlService {
 	return scs
 }
 
+// WithHugepagesDisabled sets hugepages disabled flag on storage provider.
+func (scs *StorageControlService) WithHugepagesDisabled() *StorageControlService {
+	scs.storage.WithHugepagesDisabled()
+	return scs
+}
+
 func newStorageControlService(l logging.Logger, ecs []*engine.Config, sp *storage.Provider, hpiFn common.GetHugePageInfoFn) *StorageControlService {
 	instanceStorage := make(map[uint32]*storage.Config)
 	for i, c := range ecs {

--- a/src/control/server/server.go
+++ b/src/control/server/server.go
@@ -251,24 +251,35 @@ func (srv *server) createEngine(ctx context.Context, idx int, cfg *engine.Config
 // addEngines creates and adds engine instances to harness then starts goroutine to execute
 // callbacks when all engines are started.
 func (srv *server) addEngines(ctx context.Context) error {
-	var allStarted sync.WaitGroup
-	registerTelemetryCallbacks(ctx, srv)
-
 	// Allocate hugepages and rebind NVMe devices to userspace drivers.
 	if err := prepBdevStorage(srv, iommuDetected()); err != nil {
-		return err
-	}
-
-	// Retrieve NVMe device details (before engines are started) so static details can be
-	// recovered by the engine storage provider(s) during scan even if devices are in use.
-	nvmeScanResp, err := scanBdevStorage(srv)
-	if err != nil {
 		return err
 	}
 
 	if len(srv.cfg.Engines) == 0 {
 		return nil
 	}
+
+	nvmeScanResp := &storage.BdevScanResponse{}
+	if srv.cfg.NrHugepages >= 0 {
+		// Retrieve NVMe device details (before engines are started) so static details can
+		// be recovered by the engine storage provider(s) during scan even if devices are
+		// in use.
+		nsr, err := srv.ctlSvc.NvmeScan(storage.BdevScanRequest{
+			DeviceList:  cfgGetBdevs(srv.cfg),
+			BypassCache: true, // init cache on first scan
+		})
+		if err != nil {
+			srv.log.Errorf("%s\n", errors.Wrap(err, "NVMe Scan Failed"))
+			return err
+		}
+		nvmeScanResp = nsr
+	} else {
+		srv.log.Debugf("skip nvme scan as hugepages disabled in config")
+	}
+
+	var allStarted sync.WaitGroup
+	registerTelemetryCallbacks(ctx, srv)
 
 	for i, c := range srv.cfg.Engines {
 		engine, err := srv.createEngine(ctx, i, c)

--- a/src/control/server/storage/faults.go
+++ b/src/control/server/storage/faults.go
@@ -14,6 +14,14 @@ import (
 	"github.com/daos-stack/daos/src/control/fault/code"
 )
 
+// FaultBdevHugepagesDisabled is a Fault for when bdev backend is called but
+// hugepages have been disabled in config.
+var FaultBdevHugepagesDisabled = storageFault(
+	code.BdevHugepagesDisabled,
+	"bdev storage cannot be accessed as hugepages have been disabled in config",
+	"remove nr_hugepages parameter from config to have the value automatically calculated",
+)
+
 // FaultBdevNotFound creates a Fault for the case where no NVMe storage devices
 // match expected PCI addresses.
 func FaultBdevNotFound(bdevs ...string) *fault.Fault {

--- a/src/tests/ftest/util/server_utils.py
+++ b/src/tests/ftest/util/server_utils.py
@@ -203,8 +203,6 @@ class DaosServerManager(SubprocessManager):
         if storage:
             # Prepare server storage
             if self.manager.job.using_nvme or self.manager.job.using_dcpm:
-                self.log.info("Preparing storage in <format> mode")
-                self.prepare_storage("root")
                 if hasattr(self.manager, "mca"):
                     self.manager.mca.update({"plm_rsh_args": "-l root"}, "orterun.mca", True)
 
@@ -537,12 +535,6 @@ class DaosServerManager(SubprocessManager):
         self.manager.kill()
 
         if self.manager.job.using_nvme:
-            # Reset the storage
-            try:
-                self.reset_storage()
-            except ServerFailed as error:
-                messages.append(str(error))
-
             # Make sure the mount directory belongs to non-root user
             self.set_scm_mount_ownership()
 

--- a/utils/nlt_server.yaml
+++ b/utils/nlt_server.yaml
@@ -1,7 +1,7 @@
 name: daos_server
 port: 10001
 provider: ofi+tcp;ofi_rxm
-nr_hugepages: 0
+nr_hugepages: -1
 control_log_mask: DEBUG
 access_points: ['localhost:10001']
 engines:


### PR DESCRIPTION
Workaround the test failures by failing fast on first scan failure,
subsequent scans after daos_server process restart will succeed
and tests will pass.

Verified in CI on VMD enabled hardware medium clusters.

Changes:
    - remove unnecessary storage prepare calls in test setup
    - fail daos_server setup on any spdk scan errors
    - update unit tests
    - set nr_hugepages to -1 in nlt based tests
    - skip initial nvme scan on start-up if hugepages disabled
    - set flag on storage provider when hugepages disabled
    - return fault on bdev provider access if hugepages disabled

Quick-build: true
Test-tag: pr daily_regression control
Allow-unstable-test: true

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>