### PR TITLE
DAOS-9880 doc: fix doyxgen.yml syntax

### DIFF
--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -1,9 +1,10 @@
 name: Doxygen
 
 on:
-   pull_request:
-   - 'Doxyfile'
-   - 'src/include/*.h'
+  pull_request:
+    paths:
+    - 'Doxyfile'
+    - 'src/include/*.h'
 
 jobs:
 


### PR DESCRIPTION
add missing paths: line into doxygen.yml

Signed-off-by: Michael Hennecke <michael.hennecke@intel.com>