### PR TITLE
DAOS-9643 agent: Add log level to agent config file

### DIFF
--- a/src/control/cmd/daos_agent/config.go
+++ b/src/control/cmd/daos_agent/config.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2020-2021 Intel Corporation.
+// (C) Copyright 2020-2022 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -14,6 +14,7 @@ import (
 	"gopkg.in/yaml.v2"
 
 	"github.com/daos-stack/daos/src/control/build"
+	"github.com/daos-stack/daos/src/control/common"
 	"github.com/daos-stack/daos/src/control/security"
 )
 
@@ -30,6 +31,7 @@ type Config struct {
 	ControlPort      int                       `yaml:"port"`
 	RuntimeDir       string                    `yaml:"runtime_dir"`
 	LogFile          string                    `yaml:"log_file"`
+	LogLevel         common.ControlLogLevel    `yaml:"control_log_mask,omitempty"`
 	TransportConfig  *security.TransportConfig `yaml:"transport_config"`
 	FabricInterfaces []*NUMAFabricConfig       `yaml:"fabric_ifaces,omitempty"`
 }
@@ -73,6 +75,7 @@ func DefaultConfig() *Config {
 		AccessPoints:    []string{localServer},
 		RuntimeDir:      defaultRuntimeDir,
 		LogFile:         defaultLogFile,
+		LogLevel:        common.DefaultControlLogLevel,
 		TransportConfig: security.DefaultAgentTransportConfig(),
 	}
 }

--- a/src/control/cmd/daos_agent/config_test.go
+++ b/src/control/cmd/daos_agent/config_test.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2021 Intel Corporation.
+// (C) Copyright 2021-2022 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -34,12 +34,13 @@ transport_config:
   allow_insecure: true
 `)
 
-	fabricCfg := common.CreateTestFile(t, dir, `
+	optCfg := common.CreateTestFile(t, dir, `
 name: shire
 access_points: ["one:10001", "two:10001"]
 port: 4242
 runtime_dir: /tmp/runtime
 log_file: /home/frodo/logfile
+control_log_mask: debug
 transport_config:
   allow_insecure: true
 fabric_ifaces:
@@ -61,6 +62,17 @@ fabric_ifaces:
   -
      iface: ib3
      domain: mlx5_3
+`)
+
+	badLogMaskCfg := common.CreateTestFile(t, dir, `
+name: shire
+access_points: ["one:10001", "two:10001"]
+port: 4242
+runtime_dir: /tmp/runtime
+log_file: /home/frodo/logfile
+control_log_mask: gandalf
+transport_config:
+  allow_insecure: true
 `)
 
 	for name, tc := range map[string]struct {
@@ -91,20 +103,26 @@ fabric_ifaces:
 				ControlPort:  4242,
 				RuntimeDir:   "/tmp/runtime",
 				LogFile:      "/home/frodo/logfile",
+				LogLevel:     common.DefaultControlLogLevel,
 				TransportConfig: &security.TransportConfig{
 					AllowInsecure:     true,
 					CertificateConfig: DefaultConfig().TransportConfig.CertificateConfig,
 				},
 			},
 		},
-		"manual fabric config": {
-			path: fabricCfg,
+		"bad log mask": {
+			path:   badLogMaskCfg,
+			expErr: errors.New("not a valid log level"),
+		},
+		"all options": {
+			path: optCfg,
 			expResult: &Config{
 				SystemName:   "shire",
 				AccessPoints: []string{"one:10001", "two:10001"},
 				ControlPort:  4242,
 				RuntimeDir:   "/tmp/runtime",
 				LogFile:      "/home/frodo/logfile",
+				LogLevel:     common.ControlLogLevelDebug,
 				TransportConfig: &security.TransportConfig{
 					AllowInsecure:     true,
 					CertificateConfig: DefaultConfig().TransportConfig.CertificateConfig,

--- a/src/control/cmd/daos_agent/main.go
+++ b/src/control/cmd/daos_agent/main.go
@@ -181,6 +181,11 @@ func parseOpts(args []string, opts *cliOptions, invoker control.Invoker, log *lo
 			if cfg, err = LoadConfig(cfgPath); err != nil {
 				return errors.WithMessage(err, "failed to load agent configuration")
 			}
+
+			// Command line debug option overrides log level in config file
+			if !opts.Debug {
+				log.WithLogLevel(logging.LogLevel(cfg.LogLevel))
+			}
 			log.Debugf("agent config loaded from %s", cfgPath)
 		}
 

--- a/src/control/cmd/daos_server/start_test.go
+++ b/src/control/cmd/daos_server/start_test.go
@@ -350,7 +350,7 @@ func TestStartLoggingConfiguration(t *testing.T) {
 		},
 		"Debug": {
 			configFn: func(cfg *config.Server) *config.Server {
-				return cfg.WithControlLogMask(config.ControlLogLevelDebug)
+				return cfg.WithControlLogMask(common.ControlLogLevelDebug)
 			},
 			logFnName: "Debug",
 			input:     "hello",
@@ -358,7 +358,7 @@ func TestStartLoggingConfiguration(t *testing.T) {
 		},
 		"Error": {
 			configFn: func(cfg *config.Server) *config.Server {
-				return cfg.WithControlLogMask(config.ControlLogLevelError)
+				return cfg.WithControlLogMask(common.ControlLogLevelError)
 			},
 			logFnName: "Info",
 			input:     "hello",

--- a/src/control/common/loglevel.go
+++ b/src/control/common/loglevel.go
@@ -4,7 +4,7 @@
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
 
-package config
+package common
 
 import "github.com/daos-stack/daos/src/control/logging"
 
@@ -17,6 +17,8 @@ const (
 	ControlLogLevelDebug = ControlLogLevel(logging.LogLevelDebug)
 	ControlLogLevelInfo  = ControlLogLevel(logging.LogLevelInfo)
 	ControlLogLevelError = ControlLogLevel(logging.LogLevelError)
+
+	DefaultControlLogLevel = ControlLogLevel(logging.DefaultLogLevel)
 )
 
 // UnmarshalYAML implements yaml.Unmarshaler on ControlLogMask struct

--- a/src/control/common/loglevel_test.go
+++ b/src/control/common/loglevel_test.go
@@ -1,0 +1,126 @@
+//
+// (C) Copyright 2022 Intel Corporation.
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+
+package common
+
+import (
+	"testing"
+
+	"github.com/daos-stack/daos/src/control/logging"
+	"github.com/pkg/errors"
+)
+
+func TestCommon_ControlLogLevel_String(t *testing.T) {
+	for name, tc := range map[string]struct {
+		level     ControlLogLevel
+		expResult string
+	}{
+		"error": {
+			level:     ControlLogLevelError,
+			expResult: logging.LogLevelError.String(),
+		},
+		"info": {
+			level:     ControlLogLevelInfo,
+			expResult: logging.LogLevelInfo.String(),
+		},
+		"debug": {
+			level:     ControlLogLevelDebug,
+			expResult: logging.LogLevelDebug.String(),
+		},
+		"unknown": {
+			level:     ControlLogLevel(0xffff),
+			expResult: "UNKNOWN",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			AssertEqual(t, tc.expResult, tc.level.String(), "")
+		})
+	}
+}
+
+func TestCommon_ControlLogLevel_MarshalYAML(t *testing.T) {
+	for name, tc := range map[string]struct {
+		level     ControlLogLevel
+		expResult string
+	}{
+		"error": {
+			level:     ControlLogLevelError,
+			expResult: logging.LogLevelError.String(),
+		},
+		"info": {
+			level:     ControlLogLevelInfo,
+			expResult: logging.LogLevelInfo.String(),
+		},
+		"debug": {
+			level:     ControlLogLevelDebug,
+			expResult: logging.LogLevelDebug.String(),
+		},
+		"unknown": {
+			level:     ControlLogLevel(0xffff),
+			expResult: "UNKNOWN",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			result, err := tc.level.MarshalYAML()
+
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			AssertEqual(t, tc.expResult, result, "")
+		})
+	}
+}
+
+func TestCommon_ControlLogLevel_UnmarshalYAML(t *testing.T) {
+	for name, tc := range map[string]struct {
+		yamlStr  string
+		yamlErr  error
+		expLevel ControlLogLevel
+		expErr   error
+	}{
+		"error": {
+			yamlStr:  logging.LogLevelError.String(),
+			expLevel: ControlLogLevelError,
+		},
+		"info": {
+			yamlStr:  logging.LogLevelInfo.String(),
+			expLevel: ControlLogLevelInfo,
+		},
+		"debug": {
+			yamlStr:  logging.LogLevelDebug.String(),
+			expLevel: ControlLogLevelDebug,
+		},
+		"case insensitive": {
+			yamlStr:  "dEbUg",
+			expLevel: ControlLogLevelDebug,
+		},
+		"string unmarshal fails": {
+			yamlErr: errors.New("test unmarshal yaml"),
+			expErr:  errors.New("test unmarshal yaml"),
+		},
+		"string not a log level": {
+			yamlStr: "garbage",
+			expErr:  errors.New("not a valid log level"),
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			var level ControlLogLevel
+
+			err := level.UnmarshalYAML(func(result interface{}) error {
+				if strResult, ok := result.(*string); ok {
+					*strResult = tc.yamlStr
+				} else {
+					t.Fatalf("%+v wasn't a string", result)
+				}
+				return tc.yamlErr
+			})
+
+			CmpErr(t, tc.expErr, err)
+			AssertEqual(t, tc.expLevel, level, "")
+		})
+	}
+}

--- a/src/control/server/config/server.go
+++ b/src/control/server/config/server.go
@@ -42,22 +42,22 @@ type Server struct {
 	ControlPort     int                       `yaml:"port"`
 	TransportConfig *security.TransportConfig `yaml:"transport_config"`
 	// Detect outdated "servers" config, to direct users to change their config file
-	Servers             []*engine.Config `yaml:"servers,omitempty"`
-	Engines             []*engine.Config `yaml:"engines"`
-	BdevInclude         []string         `yaml:"bdev_include,omitempty"`
-	BdevExclude         []string         `yaml:"bdev_exclude,omitempty"`
-	DisableVFIO         bool             `yaml:"disable_vfio"`
-	EnableVMD           bool             `yaml:"enable_vmd"`
-	EnableHotplug       bool             `yaml:"enable_hotplug"`
-	NrHugepages         int              `yaml:"nr_hugepages"` // total for all engines
-	ControlLogMask      ControlLogLevel  `yaml:"control_log_mask"`
-	ControlLogFile      string           `yaml:"control_log_file"`
-	ControlLogJSON      bool             `yaml:"control_log_json,omitempty"`
-	HelperLogFile       string           `yaml:"helper_log_file"`
-	FWHelperLogFile     string           `yaml:"firmware_helper_log_file"`
-	RecreateSuperblocks bool             `yaml:"recreate_superblocks,omitempty"`
-	FaultPath           string           `yaml:"fault_path"`
-	TelemetryPort       int              `yaml:"telemetry_port,omitempty"`
+	Servers             []*engine.Config       `yaml:"servers,omitempty"`
+	Engines             []*engine.Config       `yaml:"engines"`
+	BdevInclude         []string               `yaml:"bdev_include,omitempty"`
+	BdevExclude         []string               `yaml:"bdev_exclude,omitempty"`
+	DisableVFIO         bool                   `yaml:"disable_vfio"`
+	EnableVMD           bool                   `yaml:"enable_vmd"`
+	EnableHotplug       bool                   `yaml:"enable_hotplug"`
+	NrHugepages         int                    `yaml:"nr_hugepages"` // total for all engines
+	ControlLogMask      common.ControlLogLevel `yaml:"control_log_mask"`
+	ControlLogFile      string                 `yaml:"control_log_file"`
+	ControlLogJSON      bool                   `yaml:"control_log_json,omitempty"`
+	HelperLogFile       string                 `yaml:"helper_log_file"`
+	FWHelperLogFile     string                 `yaml:"firmware_helper_log_file"`
+	RecreateSuperblocks bool                   `yaml:"recreate_superblocks,omitempty"`
+	FaultPath           string                 `yaml:"fault_path"`
+	TelemetryPort       int                    `yaml:"telemetry_port,omitempty"`
 
 	// duplicated in engine.Config
 	SystemName string              `yaml:"name"`
@@ -242,7 +242,7 @@ func (cfg *Server) WithNrHugePages(nr int) *Server {
 }
 
 // WithControlLogMask sets the daos_server log level.
-func (cfg *Server) WithControlLogMask(lvl ControlLogLevel) *Server {
+func (cfg *Server) WithControlLogMask(lvl common.ControlLogLevel) *Server {
 	cfg.ControlLogMask = lvl
 	return cfg
 }
@@ -288,7 +288,7 @@ func DefaultServer() *Server {
 		TransportConfig: security.DefaultServerTransportConfig(),
 		Hyperthreads:    false,
 		Path:            defaultConfigPath,
-		ControlLogMask:  ControlLogLevel(logging.LogLevelInfo),
+		ControlLogMask:  common.ControlLogLevel(logging.LogLevelInfo),
 		EnableVMD:       false, // disabled by default
 		EnableHotplug:   false, // disabled by default
 	}

--- a/src/tests/ftest/util/agent_utils_params.py
+++ b/src/tests/ftest/util/agent_utils_params.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 """
-  (C) Copyright 2020-2021 Intel Corporation.
+  (C) Copyright 2020-2022 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -48,8 +48,11 @@ class DaosAgentYamlParameters(YamlParameters):
         #       Use the given directory for creating unix domain sockets
         #   - log_file: <str>, e.g. /tmp/daos_agent.log
         #       Full path and name of the DAOS agent logfile.
+        #   - control_log_mask: <str>, one of: error, info, debug
+        #       Specifies the log level for agent logs.
         self.runtime_dir = BasicParameter(None, "/var/run/daos_agent")
         self.log_file = LogParameter(log_dir, None, "daos_agent.log")
+        self.control_log_mask = BasicParameter(None, "debug")
 
     def update_log_file(self, name):
         """Update the log file name for the daos agent.

--- a/utils/config/daos_agent.yml
+++ b/utils/config/daos_agent.yml
@@ -53,6 +53,13 @@
 # default: /tmp/daos_agent.log
 #log_file: /tmp/daos_agent.log
 
+## Force specific debug mask for daos_agent (control plane).
+## Mask specifies minimum level of message significance to pass to logger.
+## Currently supported values are DEBUG, INFO and ERROR.
+#
+## default: INFO
+#control_log_mask: DEBUG
+
 # Manually define the fabric interfaces and domains to be used by the agent,
 # organized by NUMA node.
 # If not defined, the agent will automatically detect all fabric interfaces and


### PR DESCRIPTION
- Add control_log_mask to agent config file to specify agent log
  level.
- Set default test agent log level to debug.

Features: control

Signed-off-by: Kris Jacque <kristin.jacque@intel.com>