### PR TITLE
DAOS-9355 doc: set up doc-watchers in CODEOWNERS (#8176)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,5 +10,17 @@ utils/rpms @release-engineering
 # any PR that touches VOS files should get a review from VOS
 src/vos/* src/common/btree*.* @VOS
 
-# Jenkinsfile changes should be reviewed by Brian
-Jenkinsfile @brianjmurrell
+# Jenkinsfile changes should be reviewed by Release Engineering
+Jenkinsfile @daos-stack/build-and-release-watchers
+
+# any PR that touches client API or high level client code
+src/client @daos-stack/client-api-watchers
+src/include/daos_*.* @daos-stack/client-api-watchers
+
+# doc-watchers: files affecting documentation (docs, doxygen, etc.)
+mkdocs.yml @daos-stack/doc-watchers
+Doxyfile @daos-stack/doc-watchers
+docs/ @daos-stack/doc-watchers
+src/include/*.h @daos-stack/doc-watchers
+*.md @daos-stack/doc-watchers
+

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,14 +1,18 @@
-# have release-engineering added as a reviewer to any PR that updates
-# a component sha1
-utils/build.config @release-engineering
+# have Release Engineering added as a reviewer to any PR that updates
+# a component sha1 to ensure that corresponding package build is done
+#utils/build.config @daos-stack/release-engineering
 # or updates packaging in any way
-utils/rpms @release-engineering
+utils/rpms @daos-stack/build-and-release-watchers
 
 # any PR that touches Go files should get a review from go-owners
-*.go @go-owners
+*.go @daos-stack/go-watchers
 
-# any PR that touches VOS files should get a review from VOS
-src/vos/* src/common/btree*.* @VOS
+# Notify vos-watcher of files touched affecting VOS
+src/vos/ @daos-stack/vos-watchers
+src/common/btree*.* @daos-stack/vos-watchers
+src/include/daos/btree*.* @daos-stack/vos-watchers
+src/include/daos_srv/vos*.* @daos-stack/vos-watchers
+src/include/daos_srv/evtree.h @daos-stack/vos-watchers
 
 # Jenkinsfile changes should be reviewed by Release Engineering
 Jenkinsfile @daos-stack/build-and-release-watchers


### PR DESCRIPTION
set up doc-watchers in CODEOWNERS
(also set up build-and-release-watchers and
client-api-watchers for consistency with 2.2)

Skip-build: true
Skip-test: true
Signed-off-by: Michael Hennecke <michael.hennecke@intel.com>