### PR TITLE
DAOS-10014 control: Disable hugepages when running NLT based tests

### DIFF
--- a/src/control/server/server_utils.go
+++ b/src/control/server/server_utils.go
@@ -258,6 +258,11 @@ func prepBdevStorage(srv *server, iommuEnabled bool) error {
 
 // scanBdevStorage performs discovery and validates existence of configured NVMe SSDs.
 func scanBdevStorage(srv *server) (*storage.BdevScanResponse, error) {
+	if srv.cfg.NrHugepages < 0 {
+		srv.log.Debugf("skip nvme scan as hugepages have been disabled in config")
+		return &storage.BdevScanResponse{}, nil
+	}
+
 	nvmeScanResp, err := srv.ctlSvc.NvmeScan(storage.BdevScanRequest{
 		DeviceList:  cfgGetBdevs(srv.cfg),
 		BypassCache: true, // init cache on first scan

--- a/src/control/server/server_utils.go
+++ b/src/control/server/server_utils.go
@@ -268,13 +268,9 @@ func scanBdevStorage(srv *server) (*storage.BdevScanResponse, error) {
 		BypassCache: true, // init cache on first scan
 	})
 	if err != nil {
-		// Return error if fault code is for BdevNotFound.
-		if storage.FaultBdevNotFound().Equals(err) {
-			return nil, err
-		}
-		// Keep going for other scan related failures.
-		srv.log.Errorf("%s\n", errors.Wrap(err, "NVMe Scan Failed"))
-		return &storage.BdevScanResponse{}, nil
+		err = errors.Wrap(err, "NVMe Scan Failed")
+		srv.log.Errorf("%s", err)
+		return nil, err
 	}
 
 	return nvmeScanResp, nil

--- a/src/tests/ftest/util/server_utils.py
+++ b/src/tests/ftest/util/server_utils.py
@@ -203,8 +203,6 @@ class DaosServerManager(SubprocessManager):
         if storage:
             # Prepare server storage
             if self.manager.job.using_nvme or self.manager.job.using_dcpm:
-                self.log.info("Preparing storage in <format> mode")
-                self.prepare_storage("root")
                 if hasattr(self.manager, "mca"):
                     self.manager.mca.update({"plm_rsh_args": "-l root"}, "orterun.mca", True)
 
@@ -537,12 +535,6 @@ class DaosServerManager(SubprocessManager):
         self.manager.kill()
 
         if self.manager.job.using_nvme:
-            # Reset the storage
-            try:
-                self.reset_storage()
-            except ServerFailed as error:
-                messages.append(str(error))
-
             # Make sure the mount directory belongs to non-root user
             self.set_scm_mount_ownership()
 

--- a/utils/nlt_server.yaml
+++ b/utils/nlt_server.yaml
@@ -1,7 +1,7 @@
 name: daos_server
 port: 10001
 provider: ofi+tcp;ofi_rxm
-nr_hugepages: 0
+nr_hugepages: -1
 control_log_mask: DEBUG
 access_points: ['localhost:10001']
 engines:


### PR DESCRIPTION
Set nr_hugepages to -1 in NLT tests and avoid NVMe scan in setup if
hugepages are disabled.

Remove unnecessary NVMe storage prepare in ftest setup.

Fail service start-up if initial scan errors (8335) to workaround VMD
cluster failure on degraded test.

Test-tag: pr control

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>