### PR TITLE
DAOS-9972 control: Fail service start-up if initial scan errors

### DIFF
--- a/src/control/server/server_utils.go
+++ b/src/control/server/server_utils.go
@@ -268,13 +268,9 @@ func scanBdevStorage(srv *server) (*storage.BdevScanResponse, error) {
 		BypassCache: true, // init cache on first scan
 	})
 	if err != nil {
-		// Return error if fault code is for BdevNotFound.
-		if storage.FaultBdevNotFound().Equals(err) {
-			return nil, err
-		}
-		// Keep going for other scan related failures.
-		srv.log.Errorf("%s\n", errors.Wrap(err, "NVMe Scan Failed"))
-		return &storage.BdevScanResponse{}, nil
+		err = errors.Wrap(err, "NVMe Scan Failed")
+		srv.log.Errorf("%s", err)
+		return nil, err
 	}
 
 	return nvmeScanResp, nil


### PR DESCRIPTION
Workaround VMD cluster failure on degraded test.

Test-tag: pr daily_regression control test_daos_degraded_mode
Allow-unstable-test: true

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>