### PR TITLE
DAOS-10015 EC: refine for EC IO with single data target case

### DIFF
--- a/src/object/cli_ec.c
+++ b/src/object/cli_ec.c
@@ -1092,7 +1092,7 @@ static int
 obj_ec_recx_reasb(daos_iod_t *iod, d_sg_list_t *sgl,
 		  struct daos_oclass_attr *oca,
 		  struct obj_reasb_req *reasb_req, uint32_t iod_idx,
-		  bool update, int *valid_tgt_nr)
+		  bool update, int *data_tgt_idx, bool *single_data_tgt)
 {
 	struct obj_ec_recx_array	*ec_recx_array =
 						&reasb_req->orr_recxs[iod_idx];
@@ -1116,7 +1116,7 @@ obj_ec_recx_reasb(daos_iod_t *iod, d_sg_list_t *sgl,
 	daos_recx_t			*recx, *full_recx, tmp_recx;
 	d_iov_t				*iovs = NULL;
 	uint32_t			 i, j, k, idx, last;
-	uint32_t			 tgt_nr, empty_nr;
+	uint32_t			 tgt_nr, empty_nr, tmp_nr;
 	uint32_t			 iov_idx = 0, iov_nr = 0;
 	uint64_t			 iov_off = 0, recx_end, full_end;
 	uint64_t			 rec_nr, iod_size = iod->iod_size;
@@ -1254,11 +1254,16 @@ obj_ec_recx_reasb(daos_iod_t *iod, d_sg_list_t *sgl,
 		last = tgt_recx_idxs[i] + tgt_recx_nrs[i];
 	}
 	oiod->oiod_nr = idx;
-	*valid_tgt_nr = 0;
+	tmp_nr = update ? obj_ec_data_tgt_nr(oca) : tgt_nr;
 	for (i = 0, rec_nr = 0, last = 0; i < tgt_nr; i++) {
 		if (tgt_recx_nrs[i] == 0)
 			continue;
-		(*valid_tgt_nr)++;
+		if ((*single_data_tgt) && (i < tmp_nr)) {
+			if (*data_tgt_idx == -1)
+				*data_tgt_idx = i;
+			else if (*data_tgt_idx != i)
+				*single_data_tgt = false;
+		}
 		siod = &oiod->oiod_siods[tidx[i]];
 		siod->siod_tgt_idx = i;
 		siod->siod_idx = tgt_recx_idxs[i];
@@ -1420,9 +1425,8 @@ out:
 
 static int
 obj_ec_singv_req_reasb(daos_obj_id_t oid, daos_iod_t *iod, d_sg_list_t *sgl,
-		       struct daos_oclass_attr *oca,
-		       struct obj_reasb_req *reasb_req,
-		       uint32_t iod_idx, bool update)
+		       struct daos_oclass_attr *oca, struct obj_reasb_req *reasb_req,
+		       uint32_t iod_idx, bool update, int *data_tgt_idx, bool *single_data_tgt)
 {
 	struct obj_ec_recx_array	*ec_recx_array;
 	uint8_t				*tgt_bitmap = reasb_req->tgt_bitmap;
@@ -1456,6 +1460,12 @@ obj_ec_singv_req_reasb(daos_obj_id_t oid, daos_iod_t *iod, d_sg_list_t *sgl,
 		} else {
 			idx = obj_ec_singv_small_idx(oca, iod);
 		}
+		if (*single_data_tgt) {
+			if (*data_tgt_idx == -1)
+				*data_tgt_idx = idx;
+			else if (*data_tgt_idx != idx)
+				*single_data_tgt = false;
+		}
 		setbit(tgt_bitmap, idx);
 		tgt_nr = 1;
 		if (update) {
@@ -1471,6 +1481,8 @@ obj_ec_singv_req_reasb(daos_obj_id_t oid, daos_iod_t *iod, d_sg_list_t *sgl,
 		if (iod->iod_size != DAOS_REC_ANY)
 			singv_lo->cs_bytes =
 				obj_ec_singv_cell_bytes(iod->iod_size, oca);
+
+		*single_data_tgt = false;
 		/* large singv evenly distributed to all data targets */
 		if (update) {
 			tgt_nr = obj_ec_tgt_nr(oca);
@@ -1608,8 +1620,9 @@ obj_ec_req_reasb(daos_iod_t *iods, d_sg_list_t *sgls, daos_obj_id_t oid,
 		 uint32_t iod_nr, bool update)
 {
 	bool	singv_only = true;
-	int	i, rc = 0;
-	int	valid_tgt_nr = 0;
+	int	i, j, rc = 0;
+	int	data_tgt_idx = -1;
+	bool	single_data_tgt = true;
 
 	reasb_req->orr_oid = oid;
 	reasb_req->orr_iod_nr = iod_nr;
@@ -1638,12 +1651,10 @@ obj_ec_req_reasb(daos_iod_t *iods, d_sg_list_t *sgls, daos_obj_id_t oid,
 	}
 
 	for (i = 0; i < iod_nr; i++) {
-		int tgt_nr = 0;
-
 		if (iods[i].iod_type == DAOS_IOD_SINGLE) {
-			rc = obj_ec_singv_req_reasb(oid, &iods[i],
-						    sgls ? &sgls[i] : NULL,
-						    oca, reasb_req, i, update);
+			rc = obj_ec_singv_req_reasb(oid, &iods[i], sgls ? &sgls[i] : NULL,
+						    oca, reasb_req, i, update,
+						    &data_tgt_idx, &single_data_tgt);
 			if (rc) {
 				D_ERROR(DF_OID" singv_req_reasb failed %d.\n",
 					DP_OID(oid), rc);
@@ -1662,17 +1673,33 @@ obj_ec_req_reasb(daos_iod_t *iods, d_sg_list_t *sgls, daos_obj_id_t oid,
 			goto out;
 		}
 
-		rc = obj_ec_recx_reasb(&iods[i], sgls ? &sgls[i] : NULL, oca,
-				       reasb_req, i, update, &tgt_nr);
+		rc = obj_ec_recx_reasb(&iods[i], sgls ? &sgls[i] : NULL, oca, reasb_req, i,
+				       update, &data_tgt_idx, &single_data_tgt);
 		if (rc) {
 			D_ERROR(DF_OID" obj_ec_recx_reasb failed %d.\n",
 				DP_OID(oid), rc);
 			goto out;
 		}
-		valid_tgt_nr = max(valid_tgt_nr, tgt_nr);
 	}
 
-	reasb_req->orr_single_tgt = valid_tgt_nr == 1;
+	if (single_data_tgt) {
+		struct obj_io_desc	*oiod;
+		struct obj_shard_iod	*siod;
+
+		/* if with single data target, zero the offset as each target start from same sgl
+		 * (user original input sgl).
+		 */
+		for (i = 0; i < iod_nr; i++) {
+			oiod = &reasb_req->orr_oiods[i];
+			if (oiod->oiod_siods == NULL)
+				continue;
+			for (j = 0; j < oiod->oiod_nr; j++) {
+				siod = &oiod->oiod_siods[j];
+				siod->siod_off = 0;
+			}
+		}
+	}
+	reasb_req->orr_single_tgt = single_data_tgt;
 	reasb_req->orr_singv_only = singv_only;
 	rc = obj_ec_encode(reasb_req);
 	if (rc) {

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -1893,7 +1893,8 @@ obj_rw_bulk_prep(struct dc_object *obj, daos_iod_t *iods, d_sg_list_t *sgls,
 	 * if need bulk transferring.
 	 */
 	sgls_size = daos_sgls_packed_size(sgls, nr, NULL);
-	if (sgls_size >= DAOS_BULK_LIMIT || obj_auxi->reasb_req.orr_tgt_nr > 1) {
+	if (sgls_size >= DAOS_BULK_LIMIT ||
+	    (obj_is_ec(obj) && !obj_auxi->reasb_req.orr_single_tgt)) {
 		bulk_perm = update ? CRT_BULK_RO : CRT_BULK_RW;
 		rc = obj_bulk_prep(sgls, nr, bulk_bind, bulk_perm, task,
 				   &obj_auxi->bulks);
@@ -4904,11 +4905,19 @@ dc_obj_update(tse_task_t *task, struct dtx_epoch *epoch, uint32_t map_ver,
 		goto out_task;
 	}
 
+	/* For update, based on re-assembled sgl for csum calculate (to match with iod).
+	 * Then if with single data target use original user sgl in IO request to avoid
+	 * pack the same data multiple times.
+	 */
+	if (obj_auxi->is_ec_obj && obj_auxi->req_reasbed)
+		args->sgls = obj_auxi->reasb_req.orr_sgls;
 	rc = obj_csum_update(obj, args, obj_auxi);
 	if (rc) {
 		D_ERROR("obj_csum_update error: "DF_RC"\n", DP_RC(rc));
 		goto out_task;
 	}
+	if (obj_auxi->is_ec_obj && obj_auxi->req_reasbed && obj_auxi->reasb_req.orr_single_tgt)
+		args->sgls = obj_auxi->reasb_req.orr_usgls;
 
 	if (DAOS_FAIL_CHECK(DAOS_DTX_COMMIT_SYNC))
 		obj_auxi->flags |= ORF_DTX_SYNC;

--- a/src/object/obj_internal.h
+++ b/src/object/obj_internal.h
@@ -181,7 +181,7 @@ struct obj_reasb_req {
 					 orr_size_fetch:1,
 	/* for iod_size fetched flag */
 					 orr_size_fetched:1,
-	/* only with single target flag */
+	/* only with single data target flag */
 					 orr_single_tgt:1,
 	/* only for single-value IO flag */
 					 orr_singv_only:1,

--- a/utils/docker/Dockerfile.checkpatch
+++ b/utils/docker/Dockerfile.checkpatch
@@ -15,8 +15,8 @@ ARG CB0
 # Clean up any repos afterwards to save space.
 RUN dnf -y install dnf-plugins-core &&				\
     dnf config-manager --save --setopt=install_weak_deps=False && \
-    dnf -y upgrade &&						\
-    dnf -y install codespell file findutils git golang-bin	\
+    dnf -y upgrade &&							\
+    dnf -y install codespell diffutils file findutils git golang-bin	\
 	python3-clustershell python3-pygithub python3-numpy	\
 	python3-paramiko python3-pylint python3-pyxattr		\
 	python3-tabulate python-unversioned-command		\


### PR DESCRIPTION
If with single data target shard, use RPC inline transferring for small
size IO.

Signed-off-by: Xuezhao Liu <xuezhao.liu@intel.com>