### PR TITLE
DAOS-9972 test: experiment with vmd fail on degraded mode

### DIFF
--- a/src/bio/bio_buffer.c
+++ b/src/bio/bio_buffer.c
@@ -40,8 +40,7 @@ dma_alloc_chunk(unsigned int cnt)
 	}
 
 	if (bio_spdk_inited) {
-		chunk->bdc_ptr = spdk_dma_malloc_socket(bytes, BIO_DMA_PAGE_SZ, NULL,
-							bio_numa_node);
+		chunk->bdc_ptr = spdk_dma_malloc(bytes, BIO_DMA_PAGE_SZ, NULL);
 	} else {
 		rc = posix_memalign(&chunk->bdc_ptr, BIO_DMA_PAGE_SZ, bytes);
 		if (rc)

--- a/src/bio/bio_xstream.c
+++ b/src/bio/bio_xstream.c
@@ -106,13 +106,13 @@ bio_spdk_env_init(void)
 
 	opts.env_context = (char *)dpdk_cli_override_opts;
 
-	if (bio_nvme_configured()) {
+	/*if (bio_nvme_configured()) {
 		rc = bio_set_hotplug_filter(nvme_glb.bd_nvme_conf);
 		if (rc != 0) {
 			D_ERROR("Failed to set hotplug filter, "DF_RC"\n", DP_RC(rc));
 			goto out;
 		}
-	}
+	}*/
 
 	rc = spdk_env_init(&opts);
 	if (rc != 0) {

--- a/src/control/server/storage/bdev/backend.go
+++ b/src/control/server/storage/bdev/backend.go
@@ -451,6 +451,7 @@ func (sb *spdkBackend) formatNvme(req *storage.BdevFormatRequest) (*storage.Bdev
 		return nil, err
 	}
 	defer restoreAfterInit()
+	defer sb.binding.FiniSPDKEnv(sb.log, spdkOpts)
 
 	results, err := sb.binding.Format(sb.log)
 	if err != nil {


### PR DESCRIPTION
Quick-functional: true
Parallel-build: true
Skip-unit-tests: true
Skip-func-test-vm: true
Skip-func-hw-test-small: true
Skip-func-hw-test-large: true
Test-tag-hw-medium: test_daos_degraded_mode
Test-repeat: 2

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>