### PR TITLE
DAOS-10030 doc: fix some undocumented API structures, members

### DIFF
--- a/src/include/daos_pool.h
+++ b/src/include/daos_pool.h
@@ -59,35 +59,41 @@ enum daos_media_type_t {
 
 /** Pool target space usage information */
 struct daos_space {
-	/* Total space in bytes */
+	/** Total space in bytes */
 	uint64_t		s_total[DAOS_MEDIA_MAX];
-	/* Free space in bytes */
+	/** Free space in bytes */
 	uint64_t		s_free[DAOS_MEDIA_MAX];
 };
 
 /** Target information */
 typedef struct {
+	/** Target type */
 	daos_target_type_t	ta_type;
+	/** Target state */
 	daos_target_state_t	ta_state;
+	/** Target performance */
 	daos_target_perf_t	ta_perf;
+	/** Target space usage */
 	struct daos_space	ta_space;
 } daos_target_info_t;
 
 /** Pool space usage information */
 struct daos_pool_space {
-	/* Aggregated space for all live targets */
+	/** Aggregated space for all live targets */
 	struct daos_space	ps_space;
-	/* Min target free space in bytes */
+	/** Min target free space in bytes */
 	uint64_t		ps_free_min[DAOS_MEDIA_MAX];
-	/* Max target free space in bytes */
+	/** Max target free space in bytes */
 	uint64_t		ps_free_max[DAOS_MEDIA_MAX];
-	/* Average target free space in bytes */
+	/** Average target free space in bytes */
 	uint64_t		ps_free_mean[DAOS_MEDIA_MAX];
-	/* Target(VOS) count */
+	/** Target(VOS) count */
 	uint32_t		ps_ntargets;
+	/** padding - not used */
 	uint32_t		ps_padding;
 };
 
+/** Pool rebuild status */
 struct daos_rebuild_status {
 	/** pool map version in rebuilding or last completed rebuild */
 	uint32_t		rs_version;
@@ -96,14 +102,14 @@ struct daos_rebuild_status {
 	/** errno for rebuild failure */
 	int32_t			rs_errno;
 	/**
-	 * rebuild is done or not, it is valid only if @rs_version is non-zero
+	 * rebuild is done or not, it is valid only if #rs_version is non-zero
 	 */
 	int32_t			rs_done;
 
-	/* padding of rebuild status */
+	/** padding of rebuild status */
 	int32_t			rs_padding32;
 
-	/* Failure on which rank */
+	/** Failure on which rank */
 	int32_t			rs_fail_rank;
 	/** # total to-be-rebuilt objects, it's non-zero and increase when
 	 * rebuilding in progress, when rs_done is 1 it will not change anymore
@@ -161,7 +167,9 @@ typedef struct {
 
 /** DAOS pool container information */
 struct daos_pool_cont_info {
+	/** Container UUID */
 	uuid_t		pci_uuid;
+	/** Container label */
 	char		pci_label[DAOS_PROP_LABEL_MAX_LEN+1];
 };
 

--- a/src/include/daos_task.h
+++ b/src/include/daos_task.h
@@ -277,8 +277,11 @@ typedef struct {
 
 /** Blobstore state query args */
 typedef struct {
+	/** daos system name (server group) */
 	const char		*grp;
+	/** blobstore UUID */
 	uuid_t			uuid;
+	/** pointer to user-provided blobstore state */
 	int			*state;
 } daos_mgmt_get_bs_state_t;
 
@@ -399,7 +402,7 @@ typedef struct {
 typedef struct {
 	/** Container open handle. */
 	daos_handle_t		coh;
-	/*
+	/**
 	 * [in]: epoch of snapshot to wait for.
 	 * [out]: epoch of persistent snapshot taken.
 	 */
@@ -468,7 +471,7 @@ typedef struct {
 typedef struct {
 	/** Container open handle. */
 	daos_handle_t		coh;
-	/*
+	/**
 	 * [in]: Number of snapshots in epochs and names.
 	 * [out]: Actual number of snapshots returned
 	 */
@@ -585,11 +588,11 @@ typedef struct {
 	daos_handle_t		oh;
 } daos_obj_close_t;
 
-/*
+/**
  * Object & Object Key Punch args.
  * NB:
- * - If @dkey is NULL, it is parameter for object punch.
- * - If @akeys is NULL, it is parameter for dkey punch.
+ * - If #dkey is NULL, it is parameter for object punch.
+ * - If #akeys is NULL, it is parameter for dkey punch.
  * - API allows user to punch multiple dkeys, in this case, client module needs
  *   to allocate multiple instances of this data structure.
  */
@@ -626,12 +629,12 @@ typedef struct {
 	daos_handle_t		oh;
 	/** Transaction open handle. */
 	daos_handle_t		th;
-	/*
+	/**
 	 * [in]: allocated integer dkey.
 	 * [out]: max or min dkey (if flag includes dkey query).
 	 */
 	daos_key_t		*dkey;
-	/*
+	/**
 	 * [in]: allocated integer akey.
 	 * [out]: max or min akey (if flag includes akey query).
 	 */
@@ -711,7 +714,8 @@ typedef struct {
 	daos_recx_t		*recxs;
 	/** epoch ranges */
 	daos_epoch_range_t	*eprs;
-	/* anchors for obj list -
+	/** anchor for list_recx.
+	 *  anchors for obj list -
 	 * list_dkey uses dkey_anchor,
 	 * list_akey uses akey_anchor,
 	 * list_recx uses anchor,
@@ -950,7 +954,7 @@ typedef struct {
 	daos_handle_t		oh;
 	/** Transaction open handle. */
 	daos_handle_t		th;
-	/*
+	/**
 	 * [in]: number of key descriptors in \a kds.
 	 * [out]: number of returned key descriptors.
 	 */


### PR DESCRIPTION
In most instances, use "/**" rather than "/*" to address doxygen
reports of undocumented structures or members.

Skip-test: true

Signed-off-by: Kenneth Cain <kenneth.c.cain@intel.com>