### PR TITLE
DAOS-9940 sched: differentiating RDB heartbeat request (#8257)

### DIFF
--- a/src/engine/sched.c
+++ b/src/engine/sched.c
@@ -563,7 +563,8 @@ req_kickoff_internal(struct dss_xstream *dx, struct sched_req_attr *attr,
 	D_ASSERT(attr->sra_type < SCHED_REQ_MAX);
 
 	return sched_create_thread(dx, func, arg, ABT_THREAD_ATTR_NULL, NULL,
-				   0);
+				   attr->sra_flags & SCHED_REQ_FL_PERIODIC ?
+					DSS_ULT_FL_PERIODIC : 0);
 }
 
 static int

--- a/src/include/daos_srv/daos_engine.h
+++ b/src/include/daos_srv/daos_engine.h
@@ -256,6 +256,7 @@ enum {
 
 enum {
 	SCHED_REQ_FL_NO_DELAY	= (1 << 0),
+	SCHED_REQ_FL_PERIODIC	= (1 << 1),
 };
 
 struct sched_req_attr {
@@ -419,10 +420,6 @@ dss_ult_yield(void *arg)
 struct dss_module_ops {
 	/* Get schedule request attributes from RPC */
 	int (*dms_get_req_attr)(crt_rpc_t *rpc, struct sched_req_attr *attr);
-
-	/* Each module to start/stop the profiling */
-	int	(*dms_profile_start)(char *path, int avg);
-	int	(*dms_profile_stop)(void);
 };
 
 int srv_profile_stop();

--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -898,7 +898,7 @@ events_handler(void *arg)
 				d_list_del_init(&event->psv_link);
 				break;
 			}
-			ABT_cond_wait(events->pse_cv, events->pse_mutex);
+			sched_cond_wait(events->pse_cv, events->pse_mutex);
 		}
 		ABT_mutex_unlock(events->pse_mutex);
 		if (stop)

--- a/src/rdb/rdb_module.c
+++ b/src/rdb/rdb_module.c
@@ -42,6 +42,30 @@ static struct daos_rpc_handler rdb_handlers[] = {
 
 #undef X
 
+static int
+rdb_get_req_attr(crt_rpc_t *rpc, struct sched_req_attr *attr)
+{
+	attr->sra_type = SCHED_REQ_ANONYM;
+
+	if (opc_get(rpc->cr_opc) == RDB_APPENDENTRIES) {
+		struct rdb_appendentries_in	*in = crt_req_get(rpc);
+
+		/*
+		 * AE request with 0 entries is a heartbeat request, we'd inform the
+		 * scheduler that the request is periodic, so that scheduler will be
+		 * able to ignore it when trying to enter relaxing mode.
+		 */
+		if (in->aei_msg.n_entries == 0)
+			attr->sra_flags |= SCHED_REQ_FL_PERIODIC;
+	}
+
+	return 0;
+}
+
+static struct dss_module_ops rdb_mod_ops = {
+	.dms_get_req_attr = rdb_get_req_attr,
+};
+
 struct dss_module rdb_module = {
 	.sm_name	= "rdb",
 	.sm_mod_id	= DAOS_RDB_MODULE,
@@ -51,5 +75,6 @@ struct dss_module rdb_module = {
 	.sm_proto_fmt	= &rdb_proto_fmt,
 	.sm_cli_count	= 0,
 	.sm_handlers	= rdb_handlers,
-	.sm_key		= NULL
+	.sm_key		= NULL,
+	.sm_mod_ops	= &rdb_mod_ops
 };


### PR DESCRIPTION
Scheduler needs to differentiate RDB heartbeat request and ignore
them when trying to enter relaxing mode, otherwise, the system
xstream on heartbeat receiver side will never enter relaxing mode.

Use sched_cond_wait() instead of ABT_cond_wait() for events handler
ULT, otherwise, scheduler won't enter relaxing mode.

Signed-off-by: Niu Yawei <yawei.niu@intel.com>