### PR TITLE
DAOS-9896 sched: check if network poll started (#8197)

### DIFF
--- a/src/engine/sched.c
+++ b/src/engine/sched.c
@@ -1571,7 +1571,7 @@ sched_try_relax(struct dss_xstream *dx, ABT_pool *pools, uint32_t running)
 	 * Wait on external network request if the xstream has Cart context,
 	 * otherwise, sleep for a while.
 	 */
-	if (sched_relax_mode != SCHED_RELAX_MODE_SLEEP && dx->dx_comm) {
+	if (sched_relax_mode != SCHED_RELAX_MODE_SLEEP && dx->dx_progress_started) {
 		/* convert to micro-seconds */
 		dx->dx_timeout = sleep_time * 1000;
 	} else {

--- a/src/engine/srv.c
+++ b/src/engine/srv.c
@@ -478,6 +478,9 @@ dss_srv_handler(void *arg)
 		ABT_cond_wait(xstream_data.xd_ult_barrier, xstream_data.xd_mutex);
 	ABT_mutex_unlock(xstream_data.xd_mutex);
 
+	if (dx->dx_comm)
+		dx->dx_progress_started = true;
+
 	signal_caller = false;
 	/* main service progress loop */
 	for (;;) {
@@ -497,6 +500,9 @@ dss_srv_handler(void *arg)
 
 		ABT_thread_yield();
 	}
+
+	if (dx->dx_comm)
+		dx->dx_progress_started = false;
 
 	wait_all_exited(dx);
 	if (dmi->dmi_dp) {

--- a/src/engine/srv_internal.h
+++ b/src/engine/srv_internal.h
@@ -76,6 +76,7 @@ struct dss_xstream {
 	bool			dx_main_xs;	/* true for main XS */
 	bool			dx_comm;	/* true with cart context */
 	bool			dx_dsc_started;	/* DSC progress ULT started */
+	bool			dx_progress_started;	/* Network poll started */
 };
 
 /** Engine module's metrics */


### PR DESCRIPTION
Before network poll started, for instance, when the cart progress
ULT is blocked on open barrier (waiting for join PG), scheduler
shouldn't rely on the blocking crt_progress(timeout) call to relax
CPU, instead, it should just call usleep().

Signed-off-by: Niu Yawei <yawei.niu@intel.com>