### PR TITLE
DAOS-9561 mercury: Update mercury to include bulk timeout patch (#8278)

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+daos (2.0.1-5) unstable; urgency=medium
+  [ Liu Xuezhao ]
+  * Update mercury to include DAOS-9561 workaround
+
+ -- Liu Xuezhao <xuezhao.liu@intel.com>  Wed, 2 Mar 2022 21:53:00 +0800
+
 daos (2.0.1-3) unstable; urgency=medium
   [ Li Wei ]
   * Update raft to 0.9.0-1394.gc81505f to fix membership change bugs

--- a/utils/build.config
+++ b/utils/build.config
@@ -17,4 +17,4 @@ PROTOBUFC = v1.3.3
 spdk=https://github.com/spdk/spdk/commit/690783a3ae82ebe58c00d643520a66103d66d540.diff,https://github.com/spdk/spdk/commit/65425be69a0882ac283fb489aa151d7df06c52ad.diff,https://raw.githubusercontent.com/daos-stack/spdk/master/0003-blob-chunk-clear-operations-in-IU-aligned-chunks.patch,https://github.com/spdk/spdk/commit/086223c029389329b7a4f38ec0f9a30be83849bf.diff
 pmdk=https://raw.githubusercontent.com/daos-stack/pmdk/master/DAOS_8273.patch
 ofi=https://raw.githubusercontent.com/daos-stack/libfabric/master/daos-9173-ofi.patch,https://raw.githubusercontent.com/daos-stack/libfabric/master/daos-9376-ofi.patch
-mercury=https://raw.githubusercontent.com/daos-stack/mercury/master/cpu_usage.patch
+mercury=https://raw.githubusercontent.com/daos-stack/mercury/master/cpu_usage.patch,https://raw.githubusercontent.com/daos-stack/mercury/95e9ac9bd706bc256a6f984c4a847fa264a3975a/mercury_ucx_parse_addr_change.patch,https://raw.githubusercontent.com/daos-stack/mercury/40ce6b6f00933518f35e6f0c6f9f6766eca1bfc9/daos-9561-workaround.patch

--- a/utils/rpms/daos.spec
+++ b/utils/rpms/daos.spec
@@ -2,7 +2,7 @@
 %define server_svc_name daos_server.service
 %define agent_svc_name daos_agent.service
 
-%global mercury_version 2.1.0~rc4-3%{?dist}
+%global mercury_version 2.1.0~rc4-4%{?dist}
 %global libfabric_version 1.14.0-1
 %global __python %{__python3}
 
@@ -14,7 +14,7 @@
 
 Name:          daos
 Version:       2.0.1
-Release:       4%{?relval}%{?dist}
+Release:       5%{?relval}%{?dist}
 Summary:       DAOS Storage Engine
 
 License:       BSD-2-Clause-Patent
@@ -514,6 +514,9 @@ getent passwd daos_agent >/dev/null || useradd -s /sbin/nologin -r -g daos_agent
 # No files in a meta-package
 
 %changelog
+* Wed Mar 02 2022 Liu Xuezhao <xuezhao.liu@intel.com> 2.0.1-5
+- Update mercury to include DAOS-9561 workaround
+
 * Tue Feb 22 2022 Michael MacDonald <mjmac.macdonald@intel.com> 2.0.1-4
 - Update go toolchain requirements
 


### PR DESCRIPTION
Bulk transfer will now have a timeout of 90 seconds.
This addresses an issue with request ULTs being stuck when the client
is down.

Signed-off-by: Xuezhao Liu <xuezhao.liu@intel.com>