### PR TITLE
DAOS-10009 dfs: fix move and exchange API to have input names const (#8323)

### DIFF
--- a/src/client/dfs/dfs.c
+++ b/src/client/dfs/dfs.c
@@ -4142,8 +4142,8 @@ dfs_get_symlink_value(dfs_obj_t *obj, char *buf, daos_size_t *size)
 }
 
 static int
-xattr_copy(daos_handle_t src_oh, char *src_name, daos_handle_t dst_oh,
-	   char *dst_name, daos_handle_t th)
+xattr_copy(daos_handle_t src_oh, const char *src_name, daos_handle_t dst_oh, const char *dst_name,
+	   daos_handle_t th)
 {
 	daos_key_t	src_dkey, dst_dkey;
 	daos_anchor_t	anchor = {0};
@@ -4242,8 +4242,8 @@ out:
 
 /* Returns oids for both moved and clobbered files, but does not check either of them */
 int
-dfs_move_internal(dfs_t *dfs, dfs_obj_t *parent, char *name, dfs_obj_t *new_parent, char *new_name,
-		  daos_obj_id_t *moid, daos_obj_id_t *oid)
+dfs_move_internal(dfs_t *dfs, dfs_obj_t *parent, const char *name, dfs_obj_t *new_parent,
+		  const char *new_name, daos_obj_id_t *moid, daos_obj_id_t *oid)
 {
 	struct dfs_entry	entry = {0}, new_entry = {0};
 	daos_handle_t		th = DAOS_TX_NONE;
@@ -4428,15 +4428,15 @@ out:
 
 /* Wrapper function, only permit oid as a input parameter and return if it has data */
 int
-dfs_move(dfs_t *dfs, dfs_obj_t *parent, char *name, dfs_obj_t *new_parent,
-	 char *new_name, daos_obj_id_t *oid)
+dfs_move(dfs_t *dfs, dfs_obj_t *parent, const char *name, dfs_obj_t *new_parent,
+	 const char *new_name, daos_obj_id_t *oid)
 {
 	return dfs_move_internal(dfs, parent, name, new_parent, new_name, NULL, oid);
 }
 
 int
-dfs_exchange(dfs_t *dfs, dfs_obj_t *parent1, char *name1, dfs_obj_t *parent2,
-	     char *name2)
+dfs_exchange(dfs_t *dfs, dfs_obj_t *parent1, const char *name1, dfs_obj_t *parent2,
+	     const char *name2)
 {
 	struct dfs_entry	entry1 = {0}, entry2 = {0};
 	daos_handle_t		th = DAOS_TX_NONE;

--- a/src/client/dfs/dfs_internal.h
+++ b/src/client/dfs/dfs_internal.h
@@ -58,8 +58,8 @@ dfs_lookupx(dfs_t *dfs, dfs_obj_t *parent, const char *name, int flags,
  * destination exists.
  */
 int
-dfs_move_internal(dfs_t *dfs, dfs_obj_t *parent, char *name, dfs_obj_t *new_parent, char *new_name,
-		  daos_obj_id_t *moid, daos_obj_id_t *oid);
+dfs_move_internal(dfs_t *dfs, dfs_obj_t *parent, const char *name, dfs_obj_t *new_parent,
+		  const char *new_name, daos_obj_id_t *moid, daos_obj_id_t *oid);
 
 /* Set the in-memory parent, but takes the parent, rather than another file object */
 void

--- a/src/include/daos_fs.h
+++ b/src/include/daos_fs.h
@@ -576,14 +576,14 @@ dfs_remove(dfs_t *dfs, dfs_obj_t *parent, const char *name, bool force,
  *			Target parent directory object. If NULL, use root obj.
  * \param[in]	new_name
  *			New link name of object.
- * \param[in]	oid	Optionally return the DAOS Object ID of a removed obj
- *			as a result of a rename.
+ * \param[out]	oid	Optional: return the intenal object ID of the removed obj
+ *			if the move clobbered it.
  *
  * \return		0 on success, errno code on failure.
  */
 int
-dfs_move(dfs_t *dfs, dfs_obj_t *parent, char *name, dfs_obj_t *new_parent,
-	 char *new_name, daos_obj_id_t *oid);
+dfs_move(dfs_t *dfs, dfs_obj_t *parent, const char *name, dfs_obj_t *new_parent,
+	 const char *new_name, daos_obj_id_t *oid);
 
 /**
  * Exchange two objects.
@@ -597,8 +597,8 @@ dfs_move(dfs_t *dfs, dfs_obj_t *parent, char *name, dfs_obj_t *new_parent,
  * \return		0 on success, errno code on failure.
  */
 int
-dfs_exchange(dfs_t *dfs, dfs_obj_t *parent1, char *name1,
-	     dfs_obj_t *parent2, char *name2);
+dfs_exchange(dfs_t *dfs, dfs_obj_t *parent1, const char *name1, dfs_obj_t *parent2,
+	     const char *name2);
 
 /**
  * Retrieve mode of an open object.


### PR DESCRIPTION
Signed-off-by: Mohamad Chaarawi <mohamad.chaarawi@intel.com>
Conflicts:
	src/client/dfs/dfs.c
	src/client/dfs/dfs_internal.h