### PR TITLE
DAOS-623 tools: Fix the pre-commit hook for older versions of git

### DIFF
--- a/utils/githooks/pre-commit
+++ b/utils/githooks/pre-commit
@@ -9,32 +9,31 @@ regex='(^[[:blank:]]*[\*/]*.*)((Copyright[[:blank:]]*)([0-9]{4})(-([0-9]{4}))?)(
 year=$(date +%Y)
 errors=0
 targets=(
-	# code source files
-	'*.c'
-	'*.h'
-	'*.go'
-	'*.py'
-	'*.proto'
-	'*.java'
-	'*.yml'
-	'*.yaml'
-	'*.sh'
-	'*.bash'
-	# DevOps files
-	'Makefile'
-	'Jenkinsfile'
-	'SConscript'
-	'SConstruct'
-	'Dockerfile*'
-	# Documentation files
-	'*.txt'
-	'*.md'
-	'README*'
-	'NOTICE*'
-	'LICENSE*'
-	'copyright'
-	# Miscellaneous files
-	'.env'
+    # Entries with wildcard.  These must be first and start with '*' or
+    # older versions of git will return files that were not changed.
+    '*.c'
+    '*.h'
+    '*.go'
+    '*.py'
+    '*.proto'
+    '*.java'
+    '*.yml'
+    '*.yaml'
+    '*.sh'
+    '*.bash'
+    '*Dockerfile*'
+    '*README*'
+    '*LICENSE*'
+    '*NOTICE*'
+    '*.txt'
+    '*.md'
+    # Entries without a wildcard
+    'Makefile'
+    'Jenkinsfile'
+    'SConscript'
+    'SConstruct'
+    'copyright'
+    '.env'
 )
 
 files=$(git diff --diff-filter=AM --name-only --cached -- "${targets[@]}")


### PR DESCRIPTION
Older versions of git do not handle the wildcards well.  From
copious experimentation, I discovered that the wildcard entries
must start with '*' and that all such entries need to be before
non-wildcard entries.  Otherwise, the diff command in the hook
will match every file in the repo whether modified or not.

Skip-build: true
Skip-test: true

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>