### PR TITLE
DAOS-9972 test: reset nvme bindings after tests

### DIFF
--- a/src/tests/ftest/util/server_utils.py
+++ b/src/tests/ftest/util/server_utils.py
@@ -535,6 +535,12 @@ class DaosServerManager(SubprocessManager):
         self.manager.kill()
 
         if self.manager.job.using_nvme:
+            # Reset the storage
+            try:
+                self.reset_storage()
+            except ServerFailed as error:
+                messages.append(str(error))
+
             # Make sure the mount directory belongs to non-root user
             self.set_scm_mount_ownership()
 


### PR DESCRIPTION
In order for --nvme=auto:Optane to work with VMD enabled, the NVMe
devices should be rebound back to the kernel driver in cleanup.

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>