### PR TITLE
DAOS-623 review: add ftest-watchers to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -28,3 +28,5 @@ docs/ @daos-stack/doc-watchers
 src/include/*.h @daos-stack/doc-watchers
 *.md @daos-stack/doc-watchers
 
+# ftest-watchers: files affecting functional tests
+src/tests/ftest @daos-stack/ftest-watchers


### PR DESCRIPTION
Skip-build: true
Skip-test: true
Skip-unit-tests: true

Signed-off-by: Dalton Bohning <dalton.bohning@intel.com>