### PR TITLE
DAOS-9355 doc: remove include dir from doc-watchers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -25,7 +25,7 @@ src/include/daos_*.* @daos-stack/client-api-watchers
 mkdocs.yml @daos-stack/doc-watchers
 Doxyfile @daos-stack/doc-watchers
 docs/ @daos-stack/doc-watchers
-src/include/*.h @daos-stack/doc-watchers
+#src/include/*.h @daos-stack/doc-watchers
 *.md @daos-stack/doc-watchers
 
 # ftest-watchers: files affecting functional tests


### PR DESCRIPTION
CODEOWNERS: remove include/*.h from doc-watchers

Doc-only: true
Signed-off-by: Michael Hennecke <michael.hennecke@intel.com>