### PR TITLE
DAOS-9132 test: Update memcheck suppressions.

### DIFF
--- a/src/cart/utils/memcheck-cart.supp
+++ b/src/cart/utils/memcheck-cart.supp
@@ -64,6 +64,16 @@
 {
    <insert_a_suppression_name_here>
    Memcheck:Addr1
+   fun:bytes.*
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Addr8
+   fun:bytes.*
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Addr1
    fun:internal/bytealg*IndexByte*
 }
 {
@@ -75,11 +85,6 @@
    <insert_a_suppression_name_here>
    Memcheck:Addr8
    fun:internal/bytealg*IndexByte*
-}
-{
-   <insert_a_suppression_name_here>
-   Memcheck:Addr8
-   fun:indexbytebody
 }
 {
    <insert_a_suppression_name_here>
@@ -154,76 +159,103 @@
 {
    <insert_a_suppression_name_here>
    Memcheck:Addr1
+   ...
    fun:regexp*
 }
 {
    <insert_a_suppression_name_here>
    Memcheck:Addr2
+   ...
    fun:regexp*
 }
 {
    <insert_a_suppression_name_here>
    Memcheck:Addr4
+   ...
    fun:regexp*
 }
 {
    <insert_a_suppression_name_here>
    Memcheck:Addr8
+   ...
    fun:regexp*
 }
 {
    <insert_a_suppression_name_here>
    Memcheck:Addr16
+   ...
    fun:regexp*
 }
 {
    <insert_a_suppression_name_here>
    Memcheck:Addr8
+   ...
    fun:sort.*
 }
 {
    <insert_a_suppression_name_here>
+   Memcheck:Addr1
+   ...
+   fun:encoding/*
+}
+{
+   <insert_a_suppression_name_here>
    Memcheck:Addr8
+   ...
+   fun:encoding/*
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Addr16
+   ...
    fun:encoding/*
 }
 {
    <insert_a_suppression_name_here>
    Memcheck:Addr1
+   ...
    fun:hash/*
 }
 {
    <insert_a_suppression_name_here>
    Memcheck:Addr4
+   ...
    fun:hash/*
 }
 {
    <insert_a_suppression_name_here>
    Memcheck:Addr16
+   ...
    fun:hash/*
 }
 {
    <insert_a_suppression_name_here>
    Memcheck:Value8
+   ...
    fun:hash/*
 }
 {
    <insert_a_suppression_name_here>
    Memcheck:Addr1
+   ...
    fun:compress/*
 }
 {
    <insert_a_suppression_name_here>
    Memcheck:Addr8
+   ...
    fun:compress/*
 }
 {
    <insert_a_suppression_name_here>
    Memcheck:Addr8
+   ...
    fun:sync.*
 }
 {
    <insert_a_suppression_name_here>
    Memcheck:Addr16
+   ...
    fun:sync.*
 }
 {
@@ -233,31 +265,31 @@
 }
 {
    <insert_a_suppression_name_here>
+   Memcheck:Addr8
+   fun:memeqbody
+}
+{
+   <insert_a_suppression_name_here>
    Memcheck:Cond
    fun:memeqbody
 }
 {
    <insert_a_suppression_name_here>
-   Memcheck:Addr32
-   fun:indexbytebody
-}
-{
-   <insert_a_suppression_name_here>
    Memcheck:Addr1
    ...
-   fun:main.createWriteStream.*
+   fun:main.*
 }
 {
    <insert_a_suppression_name_here>
    Memcheck:Addr8
    ...
-   fun:main.createWriteStream.*
+   fun:main.*
 }
 {
    <insert_a_suppression_name_here>
    Memcheck:Addr16
    ...
-   fun:main.createWriteStream.*
+   fun:main.*
 }
 {
    <insert_a_suppression_name_here>
@@ -331,6 +363,11 @@
 }
 {
    <insert_a_suppression_name_here>
+   Memcheck:Addr16
+   fun:reflect.*
+}
+{
+   <insert_a_suppression_name_here>
    Memcheck:Addr8
    fun:unicode/utf8*
 }
@@ -351,7 +388,20 @@
 }
 {
    <insert_a_suppression_name_here>
+   Memcheck:Addr8
+   ...
+   fun:indexbytebody
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Addr32
+   ...
+   fun:indexbytebody
+}
+{
+   <insert_a_suppression_name_here>
    Memcheck:Cond
+   ...
    fun:indexbytebody
 }
 {

--- a/src/cart/utils/memcheck-cart.supp
+++ b/src/cart/utils/memcheck-cart.supp
@@ -130,6 +130,115 @@
 {
    <insert_a_suppression_name_here>
    Memcheck:Addr32
+   ...
+   fun:runtime.*
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Value8
+   ...
+   fun:runtime.*
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Addr8
+   ...
+   fun:internal*
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Addr8
+   ...
+   fun:math.*
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Addr1
+   fun:regexp*
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Addr2
+   fun:regexp*
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Addr4
+   fun:regexp*
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Addr8
+   fun:regexp*
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Addr16
+   fun:regexp*
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Addr8
+   fun:sort.*
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Addr8
+   fun:encoding/*
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Addr1
+   fun:hash/*
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Addr4
+   fun:hash/*
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Addr16
+   fun:hash/*
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Value8
+   fun:hash/*
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Addr1
+   fun:compress/*
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Addr8
+   fun:compress/*
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Addr8
+   fun:sync.*
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Addr16
+   fun:sync.*
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Addr16
+   fun:aeshash*
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Cond
+   fun:memeqbody
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Addr32
    fun:indexbytebody
 }
 {
@@ -158,17 +267,62 @@
 {
    <insert_a_suppression_name_here>
    Memcheck:Addr1
-   fun:github.com/jessevdk/*
+   ...
+   fun:github.com/*
 }
 {
    <insert_a_suppression_name_here>
    Memcheck:Addr4
-   fun:github.com/jessevdk/*
+   ...
+   fun:github.com/*
 }
 {
    <insert_a_suppression_name_here>
    Memcheck:Addr8
-   fun:github.com/jessevdk/*
+   ...
+   fun:github.com/*
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Addr16
+   ...
+   fun:github.com/*
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Cond
+   ...
+   fun:*golang.org/*
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Addr1
+   ...
+   fun:*golang.org/*
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Addr4
+   ...
+   fun:*golang.org/*
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Addr8
+   ...
+   fun:*golang.org/*
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Addr16
+   ...
+   fun:*golang.org/*
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Value8
+   ...
+   fun:*golang.org/*
 }
 {
    <insert_a_suppression_name_here>
@@ -192,23 +346,13 @@
 }
 {
    <insert_a_suppression_name_here>
-   Memcheck:Addr8
-   fun:github.com/daos-stack/daos/*
+   Memcheck:Cond
+   fun:racecalladdr
 }
 {
    <insert_a_suppression_name_here>
    Memcheck:Cond
    fun:indexbytebody
-}
-{
-   <insert_a_suppression_name_here>
-   Memcheck:Addr1
-   fun:*protobuf*
-}
-{
-   <insert_a_suppression_name_here>
-   Memcheck:Addr8
-   fun:*protobuf*
 }
 {
    FI leak 8
@@ -252,9 +396,8 @@
    Tcp provider with ofi rxm
    Memcheck:Param
    sendmsg(msg.msg_iov[1])
-   obj:*
+   ...
    fun:ofi_bsock_sendv
    ...
    fun:fi_tsend
-   ...
 }

--- a/src/cart/utils/memcheck-cart.supp
+++ b/src/cart/utils/memcheck-cart.supp
@@ -31,60 +31,12 @@
    socketcall.sendto(msg)
    ...
    fun:send
-   ...
-   fun:sock_pe_progress_thread
-}
-{
-   <insert_a_suppression_name_here>
-   Memcheck:Addr8
-   fun:runtime.asyncPreempt
 }
 {
    <insert_a_suppression_name_here>
    Memcheck:Leak
    ...
    fun:x_cgo_thread_start
-}
-{
-   <insert_a_suppression_name_here>
-   Memcheck:Addr16
-   fun:runtime.asyncPreempt
-}
-{
-   <insert_a_suppression_name_here>
-   Memcheck:Cond
-   ...
-   fun:runtime.copystack
-}
-{
-   <insert_a_suppression_name_here>
-   Memcheck:Cond
-   ...
-   fun:runtime.gcDrain
-}
-{
-   <insert_a_suppression_name_here>
-   Memcheck:Value8
-   ...
-   fun:runtime.gcDrain
-}
-{
-   <insert_a_suppression_name_here>
-   Memcheck:Addr4
-   ...
-   fun:runtime.copystack
-}
-{
-   <insert_a_suppression_name_here>
-   Memcheck:Addr8
-   ...
-   fun:runtime.copystack
-}
-{
-   <insert_a_suppression_name_here>
-   Memcheck:Addr8
-   ...
-   fun:runtime.gentraceback
 }
 {
    <insert_a_suppression_name_here>
@@ -107,17 +59,7 @@
 {
    <insert_a_suppression_name_here>
    Memcheck:Addr8
-   fun:runtime.deferreturn
-}
-{
-   <insert_a_suppression_name_here>
-   Memcheck:Addr8
    fun:os.*
-}
-{
-   <insert_a_suppression_name_here>
-   Memcheck:Addr8
-   fun:runtime.raceread
 }
 {
    <insert_a_suppression_name_here>
@@ -151,37 +93,38 @@
 }
 {
    <insert_a_suppression_name_here>
-   Memcheck:Addr1
-   fun:runtime.(*mheap).allo*
-}
-{
-   <insert_a_suppression_name_here>
-   Memcheck:Addr8
-   fun:runtime.(*mheap).allo*
-}
-{
-   <insert_a_suppression_name_here>
-   Memcheck:Addr8
-   fun:runtime.systemstack
+   Memcheck:Cond
+   ...
+   fun:runtime.*
 }
 {
    <insert_a_suppression_name_here>
    Memcheck:Addr1
+   ...
+   fun:runtime.*
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Addr2
+   ...
    fun:runtime.*
 }
 {
    <insert_a_suppression_name_here>
    Memcheck:Addr4
+   ...
    fun:runtime.*
 }
 {
    <insert_a_suppression_name_here>
    Memcheck:Addr8
+   ...
    fun:runtime.*
 }
 {
    <insert_a_suppression_name_here>
    Memcheck:Addr16
+   ...
    fun:runtime.*
 }
 {
@@ -203,18 +146,49 @@
 }
 {
    <insert_a_suppression_name_here>
-   Memcheck:Addr2
-   fun:runtime.memmove
-}
-{
-   <insert_a_suppression_name_here>
    Memcheck:Addr16
-   fun:runtime.memmove
+   ...
+   fun:main.createWriteStream.*
 }
 {
    <insert_a_suppression_name_here>
    Memcheck:Addr8
    fun:fmt.*
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Addr1
+   fun:github.com/jessevdk/*
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Addr4
+   fun:github.com/jessevdk/*
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Addr8
+   fun:github.com/jessevdk/*
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Addr8
+   fun:reflect.*
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Addr8
+   fun:unicode/utf8*
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Addr8
+   fun:strconv.Unquote
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Addr8
+   fun:racecall
 }
 {
    <insert_a_suppression_name_here>
@@ -225,31 +199,6 @@
    <insert_a_suppression_name_here>
    Memcheck:Cond
    fun:indexbytebody
-}
-{
-   <insert_a_suppression_name_here>
-   Memcheck:Cond
-   fun:runtime.(*mspan).sweep
-}
-{
-   <insert_a_suppression_name_here>
-   Memcheck:Cond
-   fun:runtime.(*mcentral).cacheSpan
-}
-{
-   <insert_a_suppression_name_here>
-   Memcheck:Cond
-   fun:runtime.(*mcache).*
-}
-{
-   <insert_a_suppression_name_here>
-   Memcheck:Cond
-   fun:runtime.mallocgc
-}
-{
-   <insert_a_suppression_name_here>
-   Memcheck:Cond
-   fun:runtime.deductSweepCredit
 }
 {
    <insert_a_suppression_name_here>
@@ -292,16 +241,12 @@
    fun:_dl_allocate_tls
    fun:pthread_create*
    ...
-   fun:sock_domain
-   fun:fi_domain
-   fun:na_ofi_domain_open
    fun:na_ofi_initialize
    fun:NA_Initialize_opt
    fun:hg_core_init
    fun:HG_Core_init_opt
    fun:HG_Init_opt
    fun:crt_hg_class_init
-   fun:crt_hg_ctx_init
 }
 {
    Tcp provider with ofi rxm


### PR DESCRIPTION
Suppress all memcheck failures observed on EL 8 testing.
Add generic runtime.* suppressions, and remove less specific ones.

Skip-build-centos7-rpm: true
Skip-build-el8-rpm: true
Skip-build-centos8-rpm: true
Skip-build-leap15-icc: true
Skip-build-ubuntu20-rpm: true
Skip-build-leap15-rpm: true

Skip-unit-test: true
Skip-unit-test-memcheck: true
Skip-func-test-el8: true
Skip-test-rpms: true
Skip-func-hw-test: true

Parallel-build: true

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>
