### PR TITLE
DAOS-6344 build: create daos_daemons secondary group (#8331)

### DIFF
--- a/debian/daos-client.preinst
+++ b/debian/daos-client.preinst
@@ -1,0 +1,7 @@
+#!/bin/sh
+set -e
+
+addgroup --system daos_agent
+adduser --system --ingroup daos_agent daos_agent
+addgroup --system daos_daemons
+usermod -G -a daos_daemons daos_agent

--- a/debian/daos-server.preinst
+++ b/debian/daos-server.preinst
@@ -5,3 +5,5 @@ addgroup --system daos_server
 adduser --system --ingroup daos_server daos_server
 addgroup --system daos_metrics
 usermod -G -a daos_metrics daos_server
+addgroup --system daos_daemons
+usermod -G -a daos_daemons daos_server

--- a/utils/rpms/daos.spec
+++ b/utils/rpms/daos.spec
@@ -14,7 +14,7 @@
 
 Name:          daos
 Version:       2.0.1
-Release:       5%{?relval}%{?dist}
+Release:       6%{?relval}%{?dist}
 Summary:       DAOS Storage Engine
 
 License:       BSD-2-Clause-Patent

--- a/utils/rpms/daos.spec
+++ b/utils/rpms/daos.spec
@@ -516,7 +516,7 @@ getent passwd daos_agent >/dev/null || useradd -s /sbin/nologin -r -g daos_agent
 # No files in a meta-package
 
 %changelog
-* Wed Mar 03 2022 Michael Hennecke <michael.hennecke@intel.com> 2.0.1-6
+* Mon Mar 14 2022 Michael Hennecke <michael.hennecke@intel.com> 2.0.1-6
 - DAOS-6344: Create secondary group daos_daemons for daos_server and daos_agent
 
 * Wed Mar 02 2022 Liu Xuezhao <xuezhao.liu@intel.com> 2.0.1-5

--- a/utils/rpms/daos.spec
+++ b/utils/rpms/daos.spec
@@ -340,7 +340,8 @@ mv %{buildroot}/%{conf_dir}/bash_completion.d %{buildroot}/%{_sysconfdir}
 %pre server
 getent group daos_metrics >/dev/null || groupadd -r daos_metrics
 getent group daos_server >/dev/null || groupadd -r daos_server
-getent passwd daos_server >/dev/null || useradd -s /sbin/nologin -r -g daos_server -G daos_metrics daos_server
+getent group daos_daemons >/dev/null || groupadd -r daos_daemons
+getent passwd daos_server >/dev/null || useradd -s /sbin/nologin -r -g daos_server -G daos_metrics,daos_daemons daos_server
 %post server
 /sbin/ldconfig
 %systemd_post %{server_svc_name}
@@ -352,7 +353,8 @@ getent passwd daos_server >/dev/null || useradd -s /sbin/nologin -r -g daos_serv
 
 %pre client
 getent group daos_agent >/dev/null || groupadd -r daos_agent
-getent passwd daos_agent >/dev/null || useradd -s /sbin/nologin -r -g daos_agent daos_agent
+getent group daos_daemons >/dev/null || groupadd -r daos_daemons
+getent passwd daos_agent >/dev/null || useradd -s /sbin/nologin -r -g daos_agent -G daos_daemons daos_agent
 %post client
 %systemd_post %{agent_svc_name}
 %preun client
@@ -514,6 +516,9 @@ getent passwd daos_agent >/dev/null || useradd -s /sbin/nologin -r -g daos_agent
 # No files in a meta-package
 
 %changelog
+* Wed Mar 03 2022 Michael Hennecke <michael.hennecke@intel.com> 2.0.1-6
+- DAOS-6344: Create secondary group daos_daemons for daos_server and daos_agent
+
 * Wed Mar 02 2022 Liu Xuezhao <xuezhao.liu@intel.com> 2.0.1-5
 - Update mercury to include DAOS-9561 workaround
 


### PR DESCRIPTION
Create daos_daemons secondary group for daos_server and daos_agent,
to enable both daemons to write their logfiles into the same
non-world-writeable logfile directory (being writeable by the
daos_daemons group will be sufficient).

Signed-off-by: Michael Hennecke <michael.hennecke@intel.com>