### PR TITLE
Revert "DAOS-10014 control: Disable HP when running NLT and VMD workaround (#8334)"

### DIFF
--- a/src/control/server/server_utils.go
+++ b/src/control/server/server_utils.go
@@ -258,19 +258,18 @@ func prepBdevStorage(srv *server, iommuEnabled bool) error {
 
 // scanBdevStorage performs discovery and validates existence of configured NVMe SSDs.
 func scanBdevStorage(srv *server) (*storage.BdevScanResponse, error) {
-	if srv.cfg.NrHugepages < 0 {
-		srv.log.Debugf("skip nvme scan as hugepages have been disabled in config")
-		return &storage.BdevScanResponse{}, nil
-	}
-
 	nvmeScanResp, err := srv.ctlSvc.NvmeScan(storage.BdevScanRequest{
 		DeviceList:  cfgGetBdevs(srv.cfg),
 		BypassCache: true, // init cache on first scan
 	})
 	if err != nil {
-		err = errors.Wrap(err, "NVMe Scan Failed")
-		srv.log.Errorf("%s", err)
-		return nil, err
+		// Return error if fault code is for BdevNotFound.
+		if storage.FaultBdevNotFound().Equals(err) {
+			return nil, err
+		}
+		// Keep going for other scan related failures.
+		srv.log.Errorf("%s\n", errors.Wrap(err, "NVMe Scan Failed"))
+		return &storage.BdevScanResponse{}, nil
 	}
 
 	return nvmeScanResp, nil

--- a/src/control/server/server_utils_test.go
+++ b/src/control/server/server_utils_test.go
@@ -668,15 +668,13 @@ func TestServer_prepBdevStorage(t *testing.T) {
 // also be covered.
 func TestServer_scanBdevStorage(t *testing.T) {
 	for name, tc := range map[string]struct {
-		nrHugepages int
-		bmbc        *bdev.MockBackendConfig
-		expErr      error
+		bmbc   *bdev.MockBackendConfig
+		expErr error
 	}{
 		"spdk fails init": {
 			bmbc: &bdev.MockBackendConfig{
 				ScanErr: errors.New("spdk failed"),
 			},
-			expErr: errors.New("spdk failed"),
 		},
 		"bdev in config not found by spdk": {
 			bmbc: &bdev.MockBackendConfig{
@@ -691,19 +689,12 @@ func TestServer_scanBdevStorage(t *testing.T) {
 				},
 			},
 		},
-		"hugepages disabled": {
-			nrHugepages: -1,
-			bmbc: &bdev.MockBackendConfig{
-				ScanErr: errors.New("spdk failed"),
-			},
-		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			log, buf := logging.NewTestLogger(name)
 			defer common.ShowBufferOnFailure(t, buf)
 
-			cfg := config.DefaultServer().WithFabricProvider("ofi+verbs").
-				WithNrHugePages(tc.nrHugepages)
+			cfg := config.DefaultServer().WithFabricProvider("ofi+verbs")
 
 			// test only with 2M hugepage size
 			if err := cfg.Validate(log, 2048, nil); err != nil {

--- a/src/tests/ftest/util/server_utils.py
+++ b/src/tests/ftest/util/server_utils.py
@@ -203,6 +203,8 @@ class DaosServerManager(SubprocessManager):
         if storage:
             # Prepare server storage
             if self.manager.job.using_nvme or self.manager.job.using_dcpm:
+                self.log.info("Preparing storage in <format> mode")
+                self.prepare_storage("root")
                 if hasattr(self.manager, "mca"):
                     self.manager.mca.update({"plm_rsh_args": "-l root"}, "orterun.mca", True)
 
@@ -535,6 +537,12 @@ class DaosServerManager(SubprocessManager):
         self.manager.kill()
 
         if self.manager.job.using_nvme:
+            # Reset the storage
+            try:
+                self.reset_storage()
+            except ServerFailed as error:
+                messages.append(str(error))
+
             # Make sure the mount directory belongs to non-root user
             self.set_scm_mount_ownership()
 

--- a/utils/nlt_server.yaml
+++ b/utils/nlt_server.yaml
@@ -1,7 +1,7 @@
 name: daos_server
 port: 10001
 provider: ofi+tcp;ofi_rxm
-nr_hugepages: -1
+nr_hugepages: 0
 control_log_mask: DEBUG
 access_points: ['localhost:10001']
 engines:


### PR DESCRIPTION
Feature: control

This reverts commit ec8f3d71d295bef28ccf4f826a1a0af4e6bcd188.
