### PR TITLE
DAOS-9849 control: Correct NVMe count in DMG storage format summary (…

### DIFF
--- a/src/control/cmd/dmg/pretty/storage.go
+++ b/src/control/cmd/dmg/pretty/storage.go
@@ -166,7 +166,8 @@ func PrintStorageFormatMap(hsm control.HostStorageMap, out io.Writer, opts ...Pr
 		hosts := getPrintHosts(hss.HostSet.RangedString(), opts...)
 		row := txtfmt.TableRow{hostsTitle: hosts}
 		row[scmTitle] = fmt.Sprintf("%d", len(hss.HostStorage.ScmMountPoints))
-		row[nvmeTitle] = fmt.Sprintf("%d", len(hss.HostStorage.NvmeDevices))
+		row[nvmeTitle] = fmt.Sprintf("%d",
+			len(parseNvmeFormatResults(hss.HostStorage.NvmeDevices)))
 		table = append(table, row)
 	}
 

--- a/src/control/cmd/dmg/pretty/storage_nvme.go
+++ b/src/control/cmd/dmg/pretty/storage_nvme.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2020-2021 Intel Corporation.
+// (C) Copyright 2020-2022 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -159,6 +159,19 @@ func printNvmeHealth(stat *storage.NvmeHealth, out io.Writer, opts ...PrintConfi
 	return w.Err
 }
 
+// Strip NVMe controller format results of skip entries.
+func parseNvmeFormatResults(inResults storage.NvmeControllers) storage.NvmeControllers {
+	parsedResults := make(storage.NvmeControllers, 0, len(inResults))
+	for _, result := range inResults {
+		if result.PciAddr != storage.NilBdevAddress {
+			// ignore skip results
+			parsedResults = append(parsedResults, result)
+		}
+	}
+
+	return parsedResults
+}
+
 func printNvmeFormatResults(devices storage.NvmeControllers, out io.Writer, opts ...PrintConfigOption) error {
 	if len(devices) == 0 {
 		fmt.Fprintln(out, "\tNo NVMe devices found")
@@ -174,7 +187,7 @@ func printNvmeFormatResults(devices storage.NvmeControllers, out io.Writer, opts
 
 	sort.Slice(devices, func(i, j int) bool { return devices[i].PciAddr < devices[j].PciAddr })
 
-	for _, device := range devices {
+	for _, device := range parseNvmeFormatResults(devices) {
 		row := txtfmt.TableRow{pciTitle: device.PciAddr}
 		row[resultTitle] = device.Info
 

--- a/src/control/lib/control/mocks.go
+++ b/src/control/lib/control/mocks.go
@@ -525,7 +525,8 @@ func MockFormatResp(t *testing.T, mfc MockFormatConf) *StorageFormatResp {
 
 		for j := 0; j < mfc.ScmPerHost; j++ {
 			if _, failed := mfc.ScmFailures[j]; failed {
-				if err := hem.Add(hostName, errors.Errorf("/mnt/%d format failed", j+1)); err != nil {
+				err := hem.Add(hostName, errors.Errorf("/mnt/%d format failed", j+1))
+				if err != nil {
 					t.Fatal(err)
 				}
 				continue
@@ -538,7 +539,8 @@ func MockFormatResp(t *testing.T, mfc MockFormatConf) *StorageFormatResp {
 
 		for j := 0; j < mfc.NvmePerHost; j++ {
 			if _, failed := mfc.NvmeFailures[j]; failed {
-				if err := hem.Add(hostName, errors.Errorf("NVMe device %d format failed", j+1)); err != nil {
+				err := hem.Add(hostName, errors.Errorf("NVMe device %d format failed", j+1))
+				if err != nil {
 					t.Fatal(err)
 				}
 				continue

--- a/src/control/lib/spdk/nvme.go
+++ b/src/control/lib/spdk/nvme.go
@@ -134,7 +134,7 @@ func resultPCIAddresses(results []*FormatResult) []string {
 		pciAddrs = append(pciAddrs, r.CtrlrPCIAddr)
 	}
 
-	return pciAddrs
+	return common.DedupeStringSlice(pciAddrs)
 }
 
 // Format devices available through SPDK, destructive operation!

--- a/src/control/server/ctl_storage_rpc.go
+++ b/src/control/server/ctl_storage_rpc.go
@@ -231,7 +231,7 @@ func (c *ControlService) StorageFormat(ctx context.Context, req *ctlpb.StorageFo
 	for _, ei := range instances {
 		if _, hasError := instanceErrored[ei.Index()]; hasError {
 			// if scm errored, indicate skipping bdev format
-			ret := ei.newCret("", nil)
+			ret := ei.newCret(storage.NilBdevAddress, nil)
 			ret.State.Info = fmt.Sprintf(msgNvmeFormatSkip, ei.Index())
 			resp.Crets = append(resp.Crets, ret)
 			continue

--- a/src/control/server/ctl_storage_rpc_test.go
+++ b/src/control/server/ctl_storage_rpc_test.go
@@ -1282,7 +1282,7 @@ func TestServer_CtlSvc_StorageFormat(t *testing.T) {
 			expResp: &ctlpb.StorageFormatResp{
 				Crets: []*ctlpb.NvmeControllerResult{
 					{
-						PciAddr: "<nil>",
+						PciAddr: storage.NilBdevAddress,
 						State: &ctlpb.ResponseState{
 							Status: ctlpb.ResponseStatus_CTL_SUCCESS,
 							Info:   fmt.Sprintf(msgNvmeFormatSkip, 0),
@@ -1318,7 +1318,7 @@ func TestServer_CtlSvc_StorageFormat(t *testing.T) {
 			expResp: &ctlpb.StorageFormatResp{
 				Crets: []*ctlpb.NvmeControllerResult{
 					{
-						PciAddr: "<nil>",
+						PciAddr: storage.NilBdevAddress,
 						State: &ctlpb.ResponseState{
 							Status: ctlpb.ResponseStatus_CTL_SUCCESS,
 							Info:   fmt.Sprintf(msgNvmeFormatSkip, 0),
@@ -1387,7 +1387,7 @@ func TestServer_CtlSvc_StorageFormat(t *testing.T) {
 			expResp: &ctlpb.StorageFormatResp{
 				Crets: []*ctlpb.NvmeControllerResult{
 					{
-						PciAddr: "<nil>",
+						PciAddr: storage.NilBdevAddress,
 						State: &ctlpb.ResponseState{
 							Status: ctlpb.ResponseStatus_CTL_SUCCESS,
 							Info:   fmt.Sprintf(msgNvmeFormatSkip, 0),

--- a/src/control/server/instance_storage_rpc.go
+++ b/src/control/server/instance_storage_rpc.go
@@ -38,7 +38,7 @@ func (ei *EngineInstance) newMntRet(mountPoint string, inErr error) *ctlpb.ScmMo
 func (ei *EngineInstance) newCret(pciAddr string, inErr error) *ctlpb.NvmeControllerResult {
 	var info string
 	if pciAddr == "" {
-		pciAddr = "<nil>"
+		pciAddr = storage.NilBdevAddress
 	}
 	if inErr != nil && fault.HasResolution(inErr) {
 		info = fault.ShowResolutionFor(inErr)
@@ -65,20 +65,21 @@ func (ei *EngineInstance) scmFormat(force bool) (*ctlpb.ScmMountResult, error) {
 }
 
 func (ei *EngineInstance) bdevFormat() (results proto.NvmeControllerResults) {
-	ei.log.Debugf("instance %d: calling into storage provider to format tiers", ei.Index())
-
 	for _, tr := range ei.storage.FormatBdevTiers() {
 		if tr.Error != nil {
 			results = append(results, ei.newCret(fmt.Sprintf("tier %d", tr.Tier), tr.Error))
 			continue
 		}
-		for dev, status := range tr.Result.DeviceResponses {
+		for devAddr, status := range tr.Result.DeviceResponses {
+			ei.log.Debugf("instance %d: tier %d: device fmt of %s, status %+v",
+				ei.Index(), tr.Tier, devAddr, status)
+
 			// TODO DAOS-5828: passing status.Error directly triggers segfault
 			var err error
 			if status.Error != nil {
 				err = status.Error
 			}
-			results = append(results, ei.newCret(dev, err))
+			results = append(results, ei.newCret(devAddr, err))
 		}
 	}
 

--- a/src/control/server/storage/bdev.go
+++ b/src/control/server/storage/bdev.go
@@ -31,7 +31,10 @@ import (
 )
 
 // BdevPciAddrSep defines the separator used between PCI addresses in string lists.
-const BdevPciAddrSep = " "
+const (
+	BdevPciAddrSep = " "
+	NilBdevAddress = "<nil>"
+)
 
 // NvmeDevState represents the health state of NVMe device as reported by DAOS engine BIO module.
 type NvmeDevState uint32

--- a/src/control/server/storage/bdev/backend.go
+++ b/src/control/server/storage/bdev/backend.go
@@ -337,6 +337,11 @@ func (sb *spdkBackend) formatRespFromResults(results []*spdk.FormatResult) (*sto
 
 	// build pci address to namespace errors map
 	for _, result := range results {
+		if result.CtrlrPCIAddr == "" {
+			return nil, errors.Errorf("result is missing ctrlr address: %+v",
+				result)
+		}
+
 		if _, exists := resultMap[result.CtrlrPCIAddr]; !exists {
 			resultMap[result.CtrlrPCIAddr] = make(map[int]error)
 		}
@@ -382,6 +387,7 @@ func (sb *spdkBackend) formatRespFromResults(results []*spdk.FormatResult) (*sto
 		}
 
 		devResp.Formatted = true
+		sb.log.Debugf("format device response for %q: %+v", addr, devResp)
 		resp.DeviceResponses[addr] = devResp
 	}
 
@@ -452,6 +458,7 @@ func (sb *spdkBackend) formatNvme(req *storage.BdevFormatRequest) (*storage.Bdev
 	}
 	defer restoreAfterInit()
 
+	sb.log.Debugf("calling spdk bindings format")
 	results, err := sb.binding.Format(sb.log)
 	if err != nil {
 		return nil, errors.Wrapf(err, "spdk format %s", needDevs)


### PR DESCRIPTION
…#8234)

On platforms with multiple NVMe namespaces per controller, multiple
device format results are being registered for a single controller
causing incorrect number of NVMe devices to be reported in command
output. The cause is that when creating a result for each namespace
wipe operation, only the first result would contain the controller
address meaning that results for both an empty address and the
controllers address are returned. These results are subsequently
interpreted as two device responses.

Changes in this PR:
  * Fix by adding controller address to each namespace wipe result.
  * Also fix device count in situation where NVMe format is skipped.

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>