### PR TITLE
DAOS-9782 control: Resolve some interop issues in DMG (#8242)

### DIFF
--- a/src/control/cmd/dmg/pretty/storage.go
+++ b/src/control/cmd/dmg/pretty/storage.go
@@ -183,7 +183,7 @@ func printSmdDevice(dev *storage.SmdDevice, iw io.Writer, opts ...PrintConfigOpt
 
 	iw1 := txtfmt.NewIndentWriter(iw)
 	if _, err := fmt.Fprintf(iw1, "Targets:%+v Rank:%d State:%s\n",
-		dev.TargetIDs, dev.Rank, dev.NvmeState.StatusString()); err != nil {
+		dev.TargetIDs, dev.Rank, dev.NvmeState.String()); err != nil {
 
 		return err
 	}

--- a/src/control/cmd/dmg/pretty/storage_nvme_test.go
+++ b/src/control/cmd/dmg/pretty/storage_nvme_test.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2020-2021 Intel Corporation.
+// (C) Copyright 2020-2022 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -397,13 +397,13 @@ PCI:%s Model:%s FW:%s Socket:%d Capacity:%s
 				controllerC.SocketID, humanize.Bytes(controllerC.Capacity()),
 				controllerC.SmdDevices[0].UUID, controllerC.PciAddr,
 				controllerC.SmdDevices[0].TargetIDs,
-				controllerC.SmdDevices[0].Rank, controllerC.SmdDevices[0].NvmeState.StatusString(),
+				controllerC.SmdDevices[0].Rank, controllerC.SmdDevices[0].NvmeState.String(),
 
 				controllerD.PciAddr, controllerD.Model, controllerD.FwRev,
 				controllerD.SocketID, humanize.Bytes(controllerD.Capacity()),
 				controllerD.SmdDevices[0].UUID, controllerD.PciAddr,
 				controllerD.SmdDevices[0].TargetIDs,
-				controllerD.SmdDevices[0].Rank, controllerD.SmdDevices[0].NvmeState.StatusString()),
+				controllerD.SmdDevices[0].Rank, controllerD.SmdDevices[0].NvmeState.String()),
 		},
 		"multiple smd devices on each controller": {
 			hsm: mockHostStorageMap(t,
@@ -439,16 +439,16 @@ PCI:%s Model:%s FW:%s Socket:%d Capacity:%s
 				controllerE.PciAddr, controllerE.Model, controllerE.FwRev,
 				controllerE.SocketID, humanize.Bytes(controllerE.Capacity()),
 				controllerE.SmdDevices[0].UUID, controllerE.SmdDevices[0].TargetIDs,
-				controllerE.SmdDevices[0].Rank, controllerE.SmdDevices[0].NvmeState.StatusString(),
+				controllerE.SmdDevices[0].Rank, controllerE.SmdDevices[0].NvmeState.String(),
 				controllerE.SmdDevices[1].UUID, controllerE.SmdDevices[1].TargetIDs,
-				controllerE.SmdDevices[1].Rank, controllerE.SmdDevices[1].NvmeState.StatusString(),
+				controllerE.SmdDevices[1].Rank, controllerE.SmdDevices[1].NvmeState.String(),
 
 				controllerF.PciAddr, controllerF.Model, controllerF.FwRev,
 				controllerF.SocketID, humanize.Bytes(controllerF.Capacity()),
 				controllerF.SmdDevices[0].UUID, controllerF.SmdDevices[0].TargetIDs,
-				controllerF.SmdDevices[0].Rank, controllerF.SmdDevices[0].NvmeState.StatusString(),
+				controllerF.SmdDevices[0].Rank, controllerF.SmdDevices[0].NvmeState.String(),
 				controllerF.SmdDevices[1].UUID, controllerF.SmdDevices[1].TargetIDs,
-				controllerF.SmdDevices[1].Rank, controllerF.SmdDevices[1].NvmeState.StatusString()),
+				controllerF.SmdDevices[1].Rank, controllerF.SmdDevices[1].NvmeState.String()),
 		},
 	} {
 		t.Run(name, func(t *testing.T) {

--- a/src/control/lib/control/storage.go
+++ b/src/control/lib/control/storage.go
@@ -67,7 +67,7 @@ type HostStorage struct {
 
 	// HugePageInfo contains information about the host's
 	// hugepages.
-	HugePageInfo *HugePageInfo `json:"huge_page_info"`
+	HugePageInfo HugePageInfo `json:"huge_page_info"`
 }
 
 // HashKey returns a uint64 value suitable for use as a key into

--- a/src/control/server/ctl_smd_rpc.go
+++ b/src/control/server/ctl_smd_rpc.go
@@ -94,10 +94,7 @@ func (svc *ControlService) querySmdDevices(ctx context.Context, req *ctlpb.SmdQu
 
 		i := 0 // output index
 		for _, dev := range rResp.Devices {
-			state, err := storage.NvmeDevStateFromString(dev.DevState)
-			if err != nil {
-				return errors.Wrapf(err, "eval state for dev %q", dev.TrAddr)
-			}
+			state := storage.NvmeDevStateFromString(dev.DevState)
 
 			if req.StateMask != 0 && req.StateMask&state.Uint32() == 0 {
 				continue // skip device completely if mask doesn't match
@@ -109,7 +106,7 @@ func (svc *ControlService) querySmdDevices(ctx context.Context, req *ctlpb.SmdQu
 					DevUuid: dev.Uuid,
 				})
 				if err != nil {
-					return errors.Wrapf(err, "device %s, states %q", dev, state.String())
+					return errors.Wrapf(err, "device %s, states %q", dev, state.States())
 				}
 				dev.Health = health
 			}

--- a/src/control/server/ctl_smd_rpc_test.go
+++ b/src/control/server/ctl_smd_rpc_test.go
@@ -24,11 +24,11 @@ import (
 )
 
 func TestServer_CtlSvc_SmdQuery(t *testing.T) {
-	stateUnplugged := storage.NvmeDevState(0).StatusString()
-	stateNew := storage.MockNvmeStateNew.StatusString()
-	stateNormal := storage.MockNvmeStateNormal.StatusString()
-	stateFaulty := storage.MockNvmeStateEvicted.StatusString()
-	stateIdentify := storage.MockNvmeStateIdentify.StatusString()
+	stateUnplugged := storage.NvmeDevState(0).String()
+	stateNew := storage.MockNvmeStateNew.String()
+	stateNormal := storage.MockNvmeStateNormal.String()
+	stateFaulty := storage.MockNvmeStateEvicted.String()
+	stateIdentify := storage.MockNvmeStateIdentify.String()
 
 	pbNormDev := &ctlpb.SmdDevResp_Device{
 		Uuid:     common.MockUUID(),
@@ -380,18 +380,25 @@ func TestServer_CtlSvc_SmdQuery(t *testing.T) {
 									TrAddr: "0000:8a:00.0",
 									TgtIds: []int32{0, 1, 2},
 								},
-								{
-									Uuid:     common.MockUUID(1),
-									TrAddr:   "0000:80:00.0",
-									TgtIds:   []int32{3, 4, 5},
-									DevState: stateFaulty,
-								},
 							},
 						},
 					},
 				},
 			},
-			expErr: errors.New("invalid nvme dev status"),
+			expResp: &ctlpb.SmdQueryResp{
+				Ranks: []*ctlpb.SmdQueryResp_RankResp{
+					{
+						Devices: []*ctlpb.SmdQueryResp_Device{
+							{
+								Uuid:   common.MockUUID(0),
+								TrAddr: "0000:8a:00.0",
+								TgtIds: []int32{0, 1, 2},
+							},
+						},
+						Rank: uint32(0),
+					},
+				},
+			},
 		},
 		"list-devices; show only faulty": {
 			req: &ctlpb.SmdQueryReq{
@@ -672,7 +679,7 @@ func TestServer_CtlSvc_SmdQuery(t *testing.T) {
 						Devices: []*ctlpb.SmdQueryResp_Device{
 							{
 								Uuid:     common.MockUUID(1),
-								DevState: storage.MockNvmeStateNew.StatusString(),
+								DevState: storage.MockNvmeStateNew.String(),
 							},
 						},
 					},

--- a/src/control/server/ctl_storage_rpc_test.go
+++ b/src/control/server/ctl_storage_rpc_test.go
@@ -381,7 +381,7 @@ func TestServer_CtlSvc_StorageScan_PostEngineStart(t *testing.T) {
 		ctrlr.Namespaces = make([]*ctlpb.NvmeController_Namespace, len(smdIndexes))
 		for i, idx := range smdIndexes {
 			sd := proto.MockSmdDevice(ctrlr.PciAddr, idx+1)
-			sd.DevState = storage.MockNvmeStateNormal.StatusString()
+			sd.DevState = storage.MockNvmeStateNormal.String()
 			sd.Rank = uint32(ctrlrIdx)
 			sd.TrAddr = ctrlr.PciAddr
 			ctrlr.SmdDevices[i] = sd
@@ -421,17 +421,17 @@ func TestServer_CtlSvc_StorageScan_PostEngineStart(t *testing.T) {
 	}
 
 	smdDevRespStateNew := newSmdDevResp(1)
-	smdDevRespStateNew.Devices[0].DevState = storage.MockNvmeStateNew.StatusString()
+	smdDevRespStateNew.Devices[0].DevState = storage.MockNvmeStateNew.String()
 
 	ctrlrPBwMetaNew := newCtrlrPBwMeta(1)
 	ctrlrPBwMetaNew.SmdDevices[0].AvailBytes = 0
 	ctrlrPBwMetaNew.SmdDevices[0].TotalBytes = 0
-	ctrlrPBwMetaNew.SmdDevices[0].DevState = storage.MockNvmeStateNew.StatusString()
+	ctrlrPBwMetaNew.SmdDevices[0].DevState = storage.MockNvmeStateNew.String()
 
 	ctrlrPBwMetaNormal := newCtrlrPBwMeta(1)
 	ctrlrPBwMetaNormal.SmdDevices[0].AvailBytes = 0
 	ctrlrPBwMetaNormal.SmdDevices[0].TotalBytes = 0
-	ctrlrPBwMetaNormal.SmdDevices[0].DevState = storage.MockNvmeStateNormal.StatusString()
+	ctrlrPBwMetaNormal.SmdDevices[0].DevState = storage.MockNvmeStateNormal.String()
 
 	mockPbScmMount0 := proto.MockScmMountPoint(0)
 	mockPbScmNamespace0 := proto.MockScmNamespace(0)

--- a/src/control/server/storage/bdev.go
+++ b/src/control/server/storage/bdev.go
@@ -42,6 +42,7 @@ const (
 	NvmeStateInUse    NvmeDevState = C.NVME_DEV_FL_INUSE
 	NvmeStateFaulty   NvmeDevState = C.NVME_DEV_FL_FAULTY
 	NvmeStateIdentify NvmeDevState = C.NVME_DEV_FL_IDENTIFY
+	NvmeStateUnknown  NvmeDevState = C.NVME_DEV_STATE_INVALID
 )
 
 // IsNew returns true if SSD is not in use by DAOS.
@@ -59,12 +60,12 @@ func (bs NvmeDevState) IsFaulty() bool {
 	return bs&NvmeStatePlugged != 0 && bs&NvmeStateFaulty != 0
 }
 
-// StatusString summarizes the device status.
-func (bs NvmeDevState) StatusString() string {
+func (bs NvmeDevState) String() string {
 	return C.GoString(C.nvme_state2str(C.int(bs)))
 }
 
-func (bs NvmeDevState) String() string {
+// States lists each flag in state bitset.
+func (bs NvmeDevState) States() string {
 	return fmt.Sprintf("plugged: %v, in-use: %v, faulty: %v, identify: %v",
 		bs&C.NVME_DEV_FL_PLUGGED != 0, bs&C.NVME_DEV_FL_INUSE != 0,
 		bs&C.NVME_DEV_FL_FAULTY != 0, bs&C.NVME_DEV_FL_IDENTIFY != 0)
@@ -76,17 +77,12 @@ func (bs NvmeDevState) Uint32() uint32 {
 }
 
 // NvmeDevStateFromString converts a status string into a state bitset.
-func NvmeDevStateFromString(status string) (NvmeDevState, error) {
+func NvmeDevStateFromString(status string) NvmeDevState {
 	cStr := C.CString(status)
 	defer C.free(unsafe.Pointer(cStr))
 
-	cState := C.nvme_str2state(cStr)
+	return NvmeDevState(C.nvme_str2state(cStr))
 
-	if cState == C.NVME_DEV_STATE_INVALID {
-		return NvmeDevState(0), errors.Errorf("%q is an invalid nvme dev status string", status)
-	}
-
-	return NvmeDevState(cState), nil
 }
 
 // NvmeHealth represents a set of health statistics for a NVMe device
@@ -180,7 +176,7 @@ func (sd *SmdDevice) MarshalJSON() ([]byte, error) {
 		NvmeStateStr string `json:"dev_state"`
 		*toJSON
 	}{
-		NvmeStateStr: sd.NvmeState.StatusString(),
+		NvmeStateStr: sd.NvmeState.String(),
 		toJSON:       (*toJSON)(sd),
 	})
 }
@@ -205,11 +201,7 @@ func (sd *SmdDevice) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	state, err := NvmeDevStateFromString(from.NvmeStateStr)
-	if err != nil {
-		return err
-	}
-	sd.NvmeState = state
+	sd.NvmeState = NvmeDevStateFromString(from.NvmeStateStr)
 
 	return nil
 }

--- a/src/control/server/storage/bdev_test.go
+++ b/src/control/server/storage/bdev_test.go
@@ -70,23 +70,39 @@ func Test_NvmeDevState(t *testing.T) {
 				"unexpected IsNormal() result")
 			common.AssertEqual(t, tc.expIsFaulty, tc.state.IsFaulty(),
 				"unexpected IsFaulty() result")
-			common.AssertEqual(t, tc.expStr, tc.state.StatusString(),
+			common.AssertEqual(t, tc.expStr, tc.state.String(),
 				"unexpected status string")
 
-			stateNew, err := NvmeDevStateFromString(tc.state.StatusString())
-			if err != nil {
-				t.Fatal(err)
-			}
+			stateNew := NvmeDevStateFromString(tc.state.String())
 
-			common.AssertEqual(t, tc.state.StatusString(), stateNew.StatusString(),
+			common.AssertEqual(t, tc.state.String(), stateNew.String(),
 				fmt.Sprintf("expected string %s to yield state %s",
-					tc.state.StatusString(), stateNew.StatusString()))
+					tc.state.String(), stateNew.String()))
 		})
 	}
 }
 
 func Test_NvmeDevStateFromString_invalid(t *testing.T) {
-	if _, err := NvmeDevStateFromString("BAR"); err == nil {
-		t.Fatal("should fail")
+	for name, tc := range map[string]struct {
+		inStr    string
+		expState NvmeDevState
+		expStr   string
+	}{
+		"empty string": {
+			expState: NvmeStateUnknown,
+			expStr:   "UNKNOWN",
+		},
+		"unrecognized string": {
+			inStr:    "BAD",
+			expState: NvmeStateUnknown,
+			expStr:   "UNKNOWN",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			state := NvmeDevStateFromString(tc.inStr)
+
+			common.AssertEqual(t, tc.expState, state, "unexpected state")
+			common.AssertEqual(t, tc.expStr, state.String(), "unexpected states string")
+		})
 	}
 }

--- a/src/include/daos_srv/control.h
+++ b/src/include/daos_srv/control.h
@@ -43,7 +43,10 @@ dpdk_cli_override_opts;
 static inline char *
 nvme_state2str(int state)
 {
-	/** If unplugged, return early */
+	if (state == NVME_DEV_STATE_INVALID)
+		return "UNKNOWN";
+
+	/** Otherwise, if unplugged, return early */
 	if BIT_UNSET(state, NVME_DEV_FL_PLUGGED)
 		return "UNPLUGGED";
 


### PR DESCRIPTION
Address two incompatibility issues seen when running DAOS 2.1 dmg
against and DAOS 2.0 daos_server.

Fix nil pointer dereference on dmg storage scan by changing
HugePageInfo reference to concrete field type (DAOS-9943)
Fix invalid NVMe device state error on dmg storage query list-devices
by removing error check and instead adding an UNKNOWN state for
invalid strings e.g. empty which covers the zero value for the smd
info state field.

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>