### PR TITLE
DAOS-9379 [java] Adjust code to adapt to DAOS API change (daos_obj_generate_oid) in v2.0

### DIFF
--- a/src/client/java/daos-java/pom.xml
+++ b/src/client/java/daos-java/pom.xml
@@ -174,6 +174,7 @@
                   <arg value="-c"/>
                   <arg value="-fPIC"/>
                   <arg value="--std=gnu99"/>
+                  <arg value="-Werror"/>
                 </exec>
                 <exec dir="${native.build.path}"
                       failonerror="true"
@@ -189,6 +190,7 @@
                   <arg value="-c"/>
                   <arg value="-fPIC"/>
                   <arg value="--std=gnu99"/>
+                  <arg value="-Werror"/>
                 </exec>
                 <exec dir="${native.build.path}"
                       failonerror="true"
@@ -205,6 +207,7 @@
                   <arg value="-c"/>
                   <arg value="-fPIC"/>
                   <arg value="--std=gnu99"/>
+                  <arg value="-Werror"/>
                 </exec>
                 <exec dir="${native.build.path}"
                       failonerror="true"
@@ -221,6 +224,7 @@
                   <arg value="-c"/>
                   <arg value="-fPIC"/>
                   <arg value="--std=gnu99"/>
+                  <arg value="-Werror"/>
                 </exec>
                 <exec dir="${native.build.path}"
                       failonerror="true"

--- a/src/client/java/daos-java/src/main/java/io/daos/DaosEventQueue.java
+++ b/src/client/java/daos-java/src/main/java/io/daos/DaosEventQueue.java
@@ -345,7 +345,7 @@ public class DaosEventQueue {
     if (expNbrOfRet == 0) {
       return moved;
     }
-    while (true) {
+    while (nbrOfAcquired > 0) {
       aborted = 0;
       DaosClient.pollCompleted(eqWrapperHdl, completed.memoryAddress(),
           nbrOfAcquired, timeOutMs < 0 ? DEFAULT_POLL_TIMEOUT_MS : timeOutMs);
@@ -377,6 +377,7 @@ public class DaosEventQueue {
         return nbr;
       }
     }
+    return 0;
   }
 
   private int moveAttachment(List<Attachment> completedList, Class<? extends Attachment> klass,
@@ -398,6 +399,10 @@ public class DaosEventQueue {
   }
 
   private void detainAttachment(Attachment attachment) {
+    if (attachment.isDiscarded()) {
+      attachment.release();
+      return;
+    }
     Class<?> klass = attachment.getClass();
     List<Attachment> list = attMap.get(klass);
     if (list == null) {
@@ -564,6 +569,16 @@ public class DaosEventQueue {
      * @return true or false
      */
     boolean alwaysBoundToEvt();
+
+    /**
+     * discard attachment
+     */
+    void discard();
+
+    /**
+     * check if attachment is discarded. If true, it may be discarded when poll and detain attachment.
+     */
+    boolean isDiscarded();
 
     /**
      * release resources if any.

--- a/src/client/java/daos-java/src/main/java/io/daos/DaosObjClassHint.java
+++ b/src/client/java/daos-java/src/main/java/io/daos/DaosObjClassHint.java
@@ -1,0 +1,34 @@
+/*
+ * (C) Copyright 2018-2021 Intel Corporation.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause-Patent
+ */
+
+package io.daos;
+
+public enum DaosObjClassHint {
+  /** Flags to control OC Redundancy */
+  DAOS_OCH_RDD_DEF(1 << 0),	/** Default - use RF prop */
+  DAOS_OCH_RDD_NO(1 << 1),	/** No redundancy */
+  DAOS_OCH_RDD_RP(1 << 2),	/** Replication */
+  DAOS_OCH_RDD_EC(1 << 3),	/** Erasure Code */
+  /** Flags to control OC Sharding */
+  DAOS_OCH_SHD_DEF(1 << 4),	/** Default: Use MAX for array &
+   * flat KV; 1 grp for others.
+   */
+  DAOS_OCH_SHD_TINY(1 << 5),	/** <= 4 grps */
+  DAOS_OCH_SHD_REG(1 << 6),	/** max(128, 25%) */
+  DAOS_OCH_SHD_HI(1 << 7),	/** max(256, 50%) */
+  DAOS_OCH_SHD_EXT(1 << 8),	/** max(1024, 80%) */
+  DAOS_OCH_SHD_MAX(1 << 9);	/** 100% */
+
+  private final int id;
+
+  DaosObjClassHint(int id) {
+    this.id = id;
+  }
+
+  public int getId() {
+    return id;
+  }
+}

--- a/src/client/java/daos-java/src/main/java/io/daos/DaosObjectClass.java
+++ b/src/client/java/daos-java/src/main/java/io/daos/DaosObjectClass.java
@@ -1,0 +1,400 @@
+/*
+ * (C) Copyright 2018-2021 Intel Corporation.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause-Patent
+ */
+
+package io.daos;
+
+/**
+ * Class of DAOS object.
+ */
+public enum DaosObjectClass {
+  OC_UNKNOWN,
+  /**
+   * Object classes with no data protection.
+   * NB: The first 50 IDs are reserved for backward compatibility.
+   */
+  OC_BACK_COMPAT,
+  /**
+   * Single shard object.
+   */
+  OC_TINY,
+  /**
+   * Object with small number of shards.
+   * Number of shards of the class is chosen by DAOS based on the
+   * current size of the pool.
+   */
+  OC_SMALL,
+  /**
+   * Object with large number of shards.
+   * Number of shards of the class is chosen by DAOS based on the
+   * current size of the pool.
+   */
+  OC_LARGE,
+  /**
+   * Object with maximum number of shards.
+   * Number of shards of the class is chosen by DAOS based on the
+   * current size of the pool.
+   */
+  OC_MAX,
+
+  /**
+   * object classes protected by replication.
+   */
+
+  /**
+   * Tiny object protected by replication.
+   * This object class has one redundancy group.
+   */
+  OC_RP_TINY,
+  /**
+   * Replicated object with small number of redundancy groups.
+   * Number of redundancy groups of the class is chosen by DAOS
+   * based on the current size of the pool.
+   */
+  OC_RP_SMALL,
+  /**
+   * Replicated object with large number of redundancy groups.
+   * Number of redundancy groups of the class is chosen by DAOS
+   * based on the current size of the pool.
+   */
+  OC_RP_LARGE,
+  /**
+   * Replicated object with maximum number of redundancy groups.
+   * Number of redundancy groups of the class is chosen by DAOS
+   * based on the current size of the pool.
+   */
+  OC_RP_MAX,
+
+  /**
+   * Object classes protected by replication which supports Scalable.
+   * Fetch (SF)
+   * SF classes have more replicas, so they are slower on update, but more
+   * scalable on fetch because they have more replicas to serve fetches.
+   */
+
+  /**
+   * Tiny object protected by replication.
+   * This object class has one redundancy group.
+   */
+  OC_RP_SF_TINY,
+  /**
+   * (SF) Replicated object with small number of redundancy groups.
+   * Number of redundancy groups of the class is chosen by DAOS
+   * based on the current size of the pool.
+   */
+  OC_RP_SF_SMALL,
+  /**
+   * (SF) Replicated object with large number of redundancy groups.
+   * Number of redundancy groups of the class is chosen by DAOS
+   * based on the current size of the pool.
+   */
+  OC_RP_SF_LARGE,
+  /**
+   * (SF) Replicated object with maximum number of redundancy groups.
+   * Number of redundancy groups of the class is chosen by DAOS
+   * based on the current size of the pool.
+   */
+  OC_RP_SF_MAX,
+
+  /**
+   * Replicated object class which is extremely scalable for fetch.
+   * It has many replicas so it is very slow for update.
+   */
+  OC_RP_XSF,
+
+  /**
+   * Object classes protected by erasure code.
+   */
+
+  /**
+   * Tiny object protected by EC
+   * This object class has one redundancy group.
+   */
+  OC_EC_TINY,
+  /**
+   * EC object with small number of redundancy groups.
+   * Number of redundancy groups of the class is chosen by DAOS
+   * based on the current size of the pool.
+   */
+  OC_EC_SMALL,
+  /**
+   * EC object with large number of redundancy groups.
+   * Number of redundancy groups of the class is chosen by DAOS
+   * based on the current size of the pool.
+   */
+  OC_EC_LARGE,
+  /**
+   * EC object with maximum number of redundancy groups.
+   * Number of redundancy groups of the class is chosen by DAOS
+   * based on the current size of the pool.
+   */
+  OC_EC_MAX,
+
+  /**
+   * Object classes with explicit layout.
+   */
+
+  /**
+   * Object classes with explicit layout but no data protection.
+   * Examples:
+   * S1 : shards=1, S2 means shards=2, ...
+   * SX : spreading across all targets within the pool.
+   */
+  OC_S1,
+  OC_S2,
+  OC_S4,
+  OC_S8,
+  OC_S16,
+  OC_S32,
+  OC_S64,
+  OC_S128,
+  OC_S256,
+  OC_S512,
+  OC_S1K,
+  OC_S2K,
+  OC_S4K,
+  OC_S8K,
+  OC_SX,
+
+  /**
+   * Replicated object with explicit layout.
+   * The first number is number of replicas, the number after G stands
+   * for number of redundancy Groups.
+   * Examples:
+   * 2G1 : 2 replicas group=1
+   * 3G2 : 3 replicas groups=2, ...
+   * 8GX : 8 replicas, it spreads across all targets within the pool.
+   */
+
+  /**
+   * 2-way replicated object classes.
+   */
+  OC_RP_2G1,
+  OC_RP_2G2,
+  OC_RP_2G4,
+  OC_RP_2G8,
+  OC_RP_2G16,
+  OC_RP_2G32,
+  OC_RP_2G64,
+  OC_RP_2G128,
+  OC_RP_2G256,
+  OC_RP_2G512,
+  OC_RP_2G1K,
+  OC_RP_2G2K,
+  OC_RP_2G4K,
+  OC_RP_2G8K,
+  OC_RP_2GX,
+
+  /**
+   * 3-way replicated object classes.
+   */
+  OC_RP_3G1,
+  OC_RP_3G2,
+  OC_RP_3G4,
+  OC_RP_3G8,
+  OC_RP_3G16,
+  OC_RP_3G32,
+  OC_RP_3G64,
+  OC_RP_3G128,
+  OC_RP_3G256,
+  OC_RP_3G512,
+  OC_RP_3G1K,
+  OC_RP_3G2K,
+  OC_RP_3G4K,
+  OC_RP_3G8K,
+  OC_RP_3GX,
+
+  /**
+   * 8-way replicated object classes.
+   */
+  OC_RP_8G1,
+  OC_RP_8G2,
+  OC_RP_8G4,
+  OC_RP_8G8,
+  OC_RP_8G16,
+  OC_RP_8G32,
+  OC_RP_8G64,
+  OC_RP_8G128,
+  OC_RP_8G256,
+  OC_RP_8G512,
+  OC_RP_8G1K,
+  OC_RP_8G2K,
+  OC_RP_8G4K,
+  OC_RP_8G8K,
+  OC_RP_8GX,
+
+  /**
+   * Erasure coded object with explicit layout
+   * - the first number is data cells number within a redundancy group
+   * - the number after P is parity cells number within a redundancy group
+   * - the number after G is number of redundancy Groups.
+   * Examples:
+   * - 2P1G1: 2+1 EC object with one redundancy group
+   * - 4P2G8: 4+2 EC object with 8 redundancy groups
+   * - 8P2G2: 8+2 EC object with 2 redundancy groups
+   * - 16P2GX: 16+2 EC object spreads across all targets within the pool.
+   */
+
+  /**
+   * EC 2+1 object classes.
+   */
+  OC_EC_2P1G1,
+  OC_EC_2P1G2,
+  OC_EC_2P1G4,
+  OC_EC_2P1G8,
+  OC_EC_2P1G16,
+  OC_EC_2P1G32,
+  OC_EC_2P1G64,
+  OC_EC_2P1G128,
+  OC_EC_2P1G256,
+  OC_EC_2P1G512,
+  OC_EC_2P1G1K,
+  OC_EC_2P1G2K,
+  OC_EC_2P1G4K,
+  OC_EC_2P1G8K,
+  OC_EC_2P1GX,
+
+  /**
+   * EC 2+2 object classes.
+   */
+  OC_EC_2P2G1,
+  OC_EC_2P2G2,
+  OC_EC_2P2G4,
+  OC_EC_2P2G8,
+  OC_EC_2P2G16,
+  OC_EC_2P2G32,
+  OC_EC_2P2G64,
+  OC_EC_2P2G128,
+  OC_EC_2P2G256,
+  OC_EC_2P2G512,
+  OC_EC_2P2G1K,
+  OC_EC_2P2G2K,
+  OC_EC_2P2G4K,
+  OC_EC_2P2G8K,
+  OC_EC_2P2GX,
+
+  /**
+   * EC 4+1 object classes.
+   */
+  OC_EC_4P1G1,
+  OC_EC_4P1G2,
+  OC_EC_4P1G4,
+  OC_EC_4P1G8,
+  OC_EC_4P1G16,
+  OC_EC_4P1G32,
+  OC_EC_4P1G64,
+  OC_EC_4P1G128,
+  OC_EC_4P1G256,
+  OC_EC_4P1G512,
+  OC_EC_4P1G1K,
+  OC_EC_4P1G2K,
+  OC_EC_4P1G4K,
+  OC_EC_4P1G8K,
+  OC_EC_4P1GX,
+
+  /**
+   * EC 4+2 object classes.
+   */
+  OC_EC_4P2G1,
+  OC_EC_4P2G2,
+  OC_EC_4P2G4,
+  OC_EC_4P2G8,
+  OC_EC_4P2G16,
+  OC_EC_4P2G32,
+  OC_EC_4P2G64,
+  OC_EC_4P2G128,
+  OC_EC_4P2G256,
+  OC_EC_4P2G512,
+  OC_EC_4P2G1K,
+  OC_EC_4P2G2K,
+  OC_EC_4P2G4K,
+  OC_EC_4P2G8K,
+  OC_EC_4P2GX,
+
+  /**
+   * EC 8+1 object classes.
+   */
+  OC_EC_8P1G1,
+  OC_EC_8P1G2,
+  OC_EC_8P1G4,
+  OC_EC_8P1G8,
+  OC_EC_8P1G16,
+  OC_EC_8P1G32,
+  OC_EC_8P1G64,
+  OC_EC_8P1G128,
+  OC_EC_8P1G256,
+  OC_EC_8P1G512,
+  OC_EC_8P1G1K,
+  OC_EC_8P1G2K,
+  OC_EC_8P1G4K,
+  OC_EC_8P1G8K,
+  OC_EC_8P1GX,
+
+  /**
+   * EC 8+2 object classes.
+   */
+  OC_EC_8P2G1,
+  OC_EC_8P2G2,
+  OC_EC_8P2G4,
+  OC_EC_8P2G8,
+  OC_EC_8P2G16,
+  OC_EC_8P2G32,
+  OC_EC_8P2G64,
+  OC_EC_8P2G128,
+  OC_EC_8P2G256,
+  OC_EC_8P2G512,
+  OC_EC_8P2G1K,
+  OC_EC_8P2G2K,
+  OC_EC_8P2G4K,
+  OC_EC_8P2G8K,
+  OC_EC_8P2GX,
+
+  /**
+   * EC 16+1 object classes.
+   */
+  OC_EC_16P1G1,
+  OC_EC_16P1G2,
+  OC_EC_16P1G4,
+  OC_EC_16P1G8,
+  OC_EC_16P1G16,
+  OC_EC_16P1G32,
+  OC_EC_16P1G64,
+  OC_EC_16P1G128,
+  OC_EC_16P1G256,
+  OC_EC_16P1G512,
+  OC_EC_16P1G1K,
+  OC_EC_16P1G2K,
+  OC_EC_16P1G4K,
+  OC_EC_16P1G8K,
+  OC_EC_16P1GX,
+
+  /**
+   * EC 16+2 object classes.
+   */
+  OC_EC_16P2G1,
+  OC_EC_16P2G2,
+  OC_EC_16P2G4,
+  OC_EC_16P2G8,
+  OC_EC_16P2G16,
+  OC_EC_16P2G32,
+  OC_EC_16P2G64,
+  OC_EC_16P2G128,
+  OC_EC_16P2G256,
+  OC_EC_16P2G512,
+  OC_EC_16P2G1K,
+  OC_EC_16P2G2K,
+  OC_EC_16P2G4K,
+  OC_EC_16P2G8K,
+  OC_EC_16P2GX,
+
+  /**
+   * Class ID equal or higher than this is reserved.
+   */
+  OC_RESERVED;
+
+  public String nameWithoutOc() {
+    return name().substring(3);
+  }
+}

--- a/src/client/java/daos-java/src/main/java/io/daos/DaosObjectType.java
+++ b/src/client/java/daos-java/src/main/java/io/daos/DaosObjectType.java
@@ -7,394 +7,70 @@
 package io.daos;
 
 /**
- * Type of DAOS object.
+ * DAOS object type
  */
 public enum DaosObjectType {
-  OC_UNKNOWN,
-  /**
-   * Object classes with no data protection.
-   * NB: The first 50 IDs are reserved for backward compatibility.
-   */
-  OC_BACK_COMPAT,
-  /**
-   * Single shard object.
-   */
-  OC_TINY,
-  /**
-   * Object with small number of shards.
-   * Number of shards of the class is chosen by DAOS based on the
-   * current size of the pool.
-   */
-  OC_SMALL,
-  /**
-   * Object with large number of shards.
-   * Number of shards of the class is chosen by DAOS based on the
-   * current size of the pool.
-   */
-  OC_LARGE,
-  /**
-   * Object with maximum number of shards.
-   * Number of shards of the class is chosen by DAOS based on the
-   * current size of the pool.
-   */
-  OC_MAX,
+  /** default object type, multi-level KV with hashed [ad]keys */
+  DAOS_OT_MULTI_HASHED(0),
 
   /**
-   * object classes protected by replication.
+   * Object ID table created on snapshot
    */
+  DAOS_OT_OIT(1),
+
+  /** KV with uint64 dkeys */
+  DAOS_OT_DKEY_UINT64(2),
+
+  /** KV with uint64 akeys */
+  DAOS_OT_AKEY_UINT64(3),
+
+  /** multi-level KV with uint64 [ad]keys */
+  DAOS_OT_MULTI_UINT64(4),
+
+  /** KV with lexical dkeys */
+  DAOS_OT_DKEY_LEXICAL(5),
+
+  /** KV with lexical akeys */
+  DAOS_OT_AKEY_LEXICAL(6),
+
+  /** multi-level KV with lexical [ad]keys */
+  DAOS_OT_MULTI_LEXICAL(7),
+
+  /** flat KV (no akey) with hashed dkey */
+  DAOS_OT_KV_HASHED(8),
+
+  /** flat KV (no akey) with integer dkey */
+  DAOS_OT_KV_UINT64(9),
+
+  /** flat KV (no akey) with lexical dkey */
+  DAOS_OT_KV_LEXICAL(10),
+
+  /** Array with attributes stored in the DAOS object */
+  DAOS_OT_ARRAY(11),
+
+  /** Array with attributes provided by the user */
+  DAOS_OT_ARRAY_ATTR(12),
+
+  /** Byte Array with no metadata (eg DFS/POSIX) */
+  DAOS_OT_ARRAY_BYTE(13);
 
   /**
-   * Tiny object protected by replication.
-   * This object class has one redundancy group.
-   */
-  OC_RP_TINY,
-  /**
-   * Replicated object with small number of redundancy groups.
-   * Number of redundancy groups of the class is chosen by DAOS
-   * based on the current size of the pool.
-   */
-  OC_RP_SMALL,
-  /**
-   * Replicated object with large number of redundancy groups.
-   * Number of redundancy groups of the class is chosen by DAOS
-   * based on the current size of the pool.
-   */
-  OC_RP_LARGE,
-  /**
-   * Replicated object with maximum number of redundancy groups.
-   * Number of redundancy groups of the class is chosen by DAOS
-   * based on the current size of the pool.
-   */
-  OC_RP_MAX,
-
-  /**
-   * Object classes protected by replication which supports Scalable.
-   * Fetch (SF)
-   * SF classes have more replicas, so they are slower on update, but more
-   * scalable on fetch because they have more replicas to serve fetches.
+   * reserved: Multi Dimensional Array
+   * DAOS_OT_ARRAY_MD	(64,
    */
 
   /**
-   * Tiny object protected by replication.
-   * This object class has one redundancy group.
-   */
-  OC_RP_SF_TINY,
-  /**
-   * (SF) Replicated object with small number of redundancy groups.
-   * Number of redundancy groups of the class is chosen by DAOS
-   * based on the current size of the pool.
-   */
-  OC_RP_SF_SMALL,
-  /**
-   * (SF) Replicated object with large number of redundancy groups.
-   * Number of redundancy groups of the class is chosen by DAOS
-   * based on the current size of the pool.
-   */
-  OC_RP_SF_LARGE,
-  /**
-   * (SF) Replicated object with maximum number of redundancy groups.
-   * Number of redundancy groups of the class is chosen by DAOS
-   * based on the current size of the pool.
-   */
-  OC_RP_SF_MAX,
-
-  /**
-   * Replicated object class which is extremely scalable for fetch.
-   * It has many replicas so it is very slow for update.
-   */
-  OC_RP_XSF,
-
-  /**
-   * Object classes protected by erasure code.
+   * reserved: Block device
+   * DAOS_OT_BDEV	(96,
    */
 
-  /**
-   * Tiny object protected by EC
-   * This object class has one redundancy group.
-   */
-  OC_EC_TINY,
-  /**
-   * EC object with small number of redundancy groups.
-   * Number of redundancy groups of the class is chosen by DAOS
-   * based on the current size of the pool.
-   */
-  OC_EC_SMALL,
-  /**
-   * EC object with large number of redundancy groups.
-   * Number of redundancy groups of the class is chosen by DAOS
-   * based on the current size of the pool.
-   */
-  OC_EC_LARGE,
-  /**
-   * EC object with maximum number of redundancy groups.
-   * Number of redundancy groups of the class is chosen by DAOS
-   * based on the current size of the pool.
-   */
-  OC_EC_MAX,
+  private final int id;
 
-  /**
-   * Object classes with explicit layout.
-   */
+  DaosObjectType(int id) {
+    this.id = id;
+  }
 
-  /**
-   * Object classes with explicit layout but no data protection.
-   * Examples:
-   * S1 : shards=1, S2 means shards=2, ...
-   * SX : spreading across all targets within the pool.
-   */
-  OC_S1,
-  OC_S2,
-  OC_S4,
-  OC_S8,
-  OC_S16,
-  OC_S32,
-  OC_S64,
-  OC_S128,
-  OC_S256,
-  OC_S512,
-  OC_S1K,
-  OC_S2K,
-  OC_S4K,
-  OC_S8K,
-  OC_SX,
-
-  /**
-   * Replicated object with explicit layout.
-   * The first number is number of replicas, the number after G stands
-   * for number of redundancy Groups.
-   * Examples:
-   * 2G1 : 2 replicas group=1
-   * 3G2 : 3 replicas groups=2, ...
-   * 8GX : 8 replicas, it spreads across all targets within the pool.
-   */
-
-  /**
-   * 2-way replicated object classes.
-   */
-  OC_RP_2G1,
-  OC_RP_2G2,
-  OC_RP_2G4,
-  OC_RP_2G8,
-  OC_RP_2G16,
-  OC_RP_2G32,
-  OC_RP_2G64,
-  OC_RP_2G128,
-  OC_RP_2G256,
-  OC_RP_2G512,
-  OC_RP_2G1K,
-  OC_RP_2G2K,
-  OC_RP_2G4K,
-  OC_RP_2G8K,
-  OC_RP_2GX,
-
-  /**
-   * 3-way replicated object classes.
-   */
-  OC_RP_3G1,
-  OC_RP_3G2,
-  OC_RP_3G4,
-  OC_RP_3G8,
-  OC_RP_3G16,
-  OC_RP_3G32,
-  OC_RP_3G64,
-  OC_RP_3G128,
-  OC_RP_3G256,
-  OC_RP_3G512,
-  OC_RP_3G1K,
-  OC_RP_3G2K,
-  OC_RP_3G4K,
-  OC_RP_3G8K,
-  OC_RP_3GX,
-
-  /**
-   * 8-way replicated object classes.
-   */
-  OC_RP_8G1,
-  OC_RP_8G2,
-  OC_RP_8G4,
-  OC_RP_8G8,
-  OC_RP_8G16,
-  OC_RP_8G32,
-  OC_RP_8G64,
-  OC_RP_8G128,
-  OC_RP_8G256,
-  OC_RP_8G512,
-  OC_RP_8G1K,
-  OC_RP_8G2K,
-  OC_RP_8G4K,
-  OC_RP_8G8K,
-  OC_RP_8GX,
-
-  /**
-   * Erasure coded object with explicit layout
-   * - the first number is data cells number within a redundancy group
-   * - the number after P is parity cells number within a redundancy group
-   * - the number after G is number of redundancy Groups.
-   * Examples:
-   * - 2P1G1: 2+1 EC object with one redundancy group
-   * - 4P2G8: 4+2 EC object with 8 redundancy groups
-   * - 8P2G2: 8+2 EC object with 2 redundancy groups
-   * - 16P2GX: 16+2 EC object spreads across all targets within the pool.
-   */
-
-  /**
-   * EC 2+1 object classes.
-   */
-  OC_EC_2P1G1,
-  OC_EC_2P1G2,
-  OC_EC_2P1G4,
-  OC_EC_2P1G8,
-  OC_EC_2P1G16,
-  OC_EC_2P1G32,
-  OC_EC_2P1G64,
-  OC_EC_2P1G128,
-  OC_EC_2P1G256,
-  OC_EC_2P1G512,
-  OC_EC_2P1G1K,
-  OC_EC_2P1G2K,
-  OC_EC_2P1G4K,
-  OC_EC_2P1G8K,
-  OC_EC_2P1GX,
-
-  /**
-   * EC 2+2 object classes.
-   */
-  OC_EC_2P2G1,
-  OC_EC_2P2G2,
-  OC_EC_2P2G4,
-  OC_EC_2P2G8,
-  OC_EC_2P2G16,
-  OC_EC_2P2G32,
-  OC_EC_2P2G64,
-  OC_EC_2P2G128,
-  OC_EC_2P2G256,
-  OC_EC_2P2G512,
-  OC_EC_2P2G1K,
-  OC_EC_2P2G2K,
-  OC_EC_2P2G4K,
-  OC_EC_2P2G8K,
-  OC_EC_2P2GX,
-
-  /**
-   * EC 4+1 object classes.
-   */
-  OC_EC_4P1G1,
-  OC_EC_4P1G2,
-  OC_EC_4P1G4,
-  OC_EC_4P1G8,
-  OC_EC_4P1G16,
-  OC_EC_4P1G32,
-  OC_EC_4P1G64,
-  OC_EC_4P1G128,
-  OC_EC_4P1G256,
-  OC_EC_4P1G512,
-  OC_EC_4P1G1K,
-  OC_EC_4P1G2K,
-  OC_EC_4P1G4K,
-  OC_EC_4P1G8K,
-  OC_EC_4P1GX,
-
-  /**
-   * EC 4+2 object classes.
-   */
-  OC_EC_4P2G1,
-  OC_EC_4P2G2,
-  OC_EC_4P2G4,
-  OC_EC_4P2G8,
-  OC_EC_4P2G16,
-  OC_EC_4P2G32,
-  OC_EC_4P2G64,
-  OC_EC_4P2G128,
-  OC_EC_4P2G256,
-  OC_EC_4P2G512,
-  OC_EC_4P2G1K,
-  OC_EC_4P2G2K,
-  OC_EC_4P2G4K,
-  OC_EC_4P2G8K,
-  OC_EC_4P2GX,
-
-  /**
-   * EC 8+1 object classes.
-   */
-  OC_EC_8P1G1,
-  OC_EC_8P1G2,
-  OC_EC_8P1G4,
-  OC_EC_8P1G8,
-  OC_EC_8P1G16,
-  OC_EC_8P1G32,
-  OC_EC_8P1G64,
-  OC_EC_8P1G128,
-  OC_EC_8P1G256,
-  OC_EC_8P1G512,
-  OC_EC_8P1G1K,
-  OC_EC_8P1G2K,
-  OC_EC_8P1G4K,
-  OC_EC_8P1G8K,
-  OC_EC_8P1GX,
-
-  /**
-   * EC 8+2 object classes.
-   */
-  OC_EC_8P2G1,
-  OC_EC_8P2G2,
-  OC_EC_8P2G4,
-  OC_EC_8P2G8,
-  OC_EC_8P2G16,
-  OC_EC_8P2G32,
-  OC_EC_8P2G64,
-  OC_EC_8P2G128,
-  OC_EC_8P2G256,
-  OC_EC_8P2G512,
-  OC_EC_8P2G1K,
-  OC_EC_8P2G2K,
-  OC_EC_8P2G4K,
-  OC_EC_8P2G8K,
-  OC_EC_8P2GX,
-
-  /**
-   * EC 16+1 object classes.
-   */
-  OC_EC_16P1G1,
-  OC_EC_16P1G2,
-  OC_EC_16P1G4,
-  OC_EC_16P1G8,
-  OC_EC_16P1G16,
-  OC_EC_16P1G32,
-  OC_EC_16P1G64,
-  OC_EC_16P1G128,
-  OC_EC_16P1G256,
-  OC_EC_16P1G512,
-  OC_EC_16P1G1K,
-  OC_EC_16P1G2K,
-  OC_EC_16P1G4K,
-  OC_EC_16P1G8K,
-  OC_EC_16P1GX,
-
-  /**
-   * EC 16+2 object classes.
-   */
-  OC_EC_16P2G1,
-  OC_EC_16P2G2,
-  OC_EC_16P2G4,
-  OC_EC_16P2G8,
-  OC_EC_16P2G16,
-  OC_EC_16P2G32,
-  OC_EC_16P2G64,
-  OC_EC_16P2G128,
-  OC_EC_16P2G256,
-  OC_EC_16P2G512,
-  OC_EC_16P2G1K,
-  OC_EC_16P2G2K,
-  OC_EC_16P2G4K,
-  OC_EC_16P2G8K,
-  OC_EC_16P2GX,
-
-  /**
-   * Class ID equal or higher than this is reserved.
-   */
-  OC_RESERVED;
-
-  public String nameWithoutOc() {
-    return name().substring(3);
+  public int getId() {
+    return id;
   }
 }

--- a/src/client/java/daos-java/src/main/java/io/daos/DaosUtils.java
+++ b/src/client/java/daos-java/src/main/java/io/daos/DaosUtils.java
@@ -8,6 +8,7 @@ package io.daos;
 
 import io.daos.dfs.StatAttributes;
 
+import java.io.IOException;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.UUID;
@@ -123,5 +124,37 @@ public final class DaosUtils {
 
   public static boolean isBlankStr(String value) {
     return value == null || value.trim().length() == 0;
+  }
+
+  /**
+   * convert key to bytes with charset {@link Constants#KEY_CHARSET}.
+   * length of byte array should not exceed {@link Short#MAX_VALUE}.
+   *
+   * @param key
+   * @return byte array
+   */
+  public static byte[] keyToBytes(String key) {
+    return keyToBytes(key, Short.MAX_VALUE);
+  }
+
+  /**
+   * convert key to bytes with charset {@link Constants#KEY_CHARSET}.
+   *
+   * @param key
+   * @param lenLimit
+   * @return
+   */
+  public static byte[] keyToBytes(String key, int lenLimit) {
+    byte[] bytes;
+    try {
+      bytes = key.getBytes(Constants.KEY_CHARSET);
+    } catch (IOException e) {
+      throw new IllegalArgumentException("failed to get bytes in " + Constants.KEY_CHARSET + " of key " + key);
+    }
+    if (bytes.length > lenLimit) {
+      throw new IllegalArgumentException("key length in " + Constants.KEY_CHARSET + " should not exceed "
+          + lenLimit);
+    }
+    return bytes;
   }
 }

--- a/src/client/java/daos-java/src/main/java/io/daos/DaosUtils.java
+++ b/src/client/java/daos-java/src/main/java/io/daos/DaosUtils.java
@@ -9,6 +9,7 @@ package io.daos;
 import io.daos.dfs.StatAttributes;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.UUID;
@@ -137,6 +138,22 @@ public final class DaosUtils {
     return keyToBytes(key, Short.MAX_VALUE);
   }
 
+  private static byte[] padZero8(byte[] bytes) {
+    if (bytes.length >= 8) {
+      return bytes;
+    }
+
+    byte[] newBytes = new byte[8];
+    System.arraycopy(bytes, 0, newBytes, 8 - bytes.length, bytes.length);
+    Arrays.fill(newBytes, 0, 8 - bytes.length, (byte)0);
+    return newBytes;
+  }
+
+  public static byte[] keyToBytes8(String key) {
+    byte[] bytes = keyToBytes(key, Short.MAX_VALUE);
+    return padZero8(bytes);
+  }
+
   /**
    * convert key to bytes with charset {@link Constants#KEY_CHARSET}.
    *
@@ -156,5 +173,10 @@ public final class DaosUtils {
           + lenLimit);
     }
     return bytes;
+  }
+
+  public static byte[] keyToBytes8(String key, int lenLimit) {
+    byte[] bytes = keyToBytes(key, lenLimit);
+    return padZero8(bytes);
   }
 }

--- a/src/client/java/daos-java/src/main/java/io/daos/dfs/DaosFile.java
+++ b/src/client/java/daos-java/src/main/java/io/daos/dfs/DaosFile.java
@@ -47,7 +47,7 @@ public class DaosFile {
 
   private int mode;
 
-  private DaosObjectType objectType;
+  private DaosObjectClass objectType;
 
   private int chunkSize;
 
@@ -145,7 +145,7 @@ public class DaosFile {
    * @throws IOException
    * {@link DaosIOException}
    */
-  public void createNewFile(int mode, DaosObjectType objectType, int chunkSize, boolean createParent)
+  public void createNewFile(int mode, DaosObjectClass objectType, int chunkSize, boolean createParent)
           throws IOException {
     if (objId != 0) {
       throw new IOException("file existed already");

--- a/src/client/java/daos-java/src/main/java/io/daos/dfs/DaosFsClient.java
+++ b/src/client/java/daos-java/src/main/java/io/daos/dfs/DaosFsClient.java
@@ -874,7 +874,7 @@ public final class DaosFsClient extends ShareableClient implements ForceCloseabl
     return getBuilder().defaultFileMode;
   }
 
-  DaosObjectType getDefaultFileObjType() {
+  DaosObjectClass getDefaultFileObjType() {
     return getBuilder().defaultFileObjType;
   }
 
@@ -893,7 +893,7 @@ public final class DaosFsClient extends ShareableClient implements ForceCloseabl
     private int defaultFileChunkSize = Constants.FILE_DEFAULT_CHUNK_SIZE;
     private int defaultFileAccessFlags = Constants.ACCESS_FLAG_FILE_READWRITE;
     private int defaultFileMode = Constants.FILE_DEFAULT_FILE_MODE;
-    private DaosObjectType defaultFileObjType = DaosObjectType.OC_SX;
+    private DaosObjectClass defaultFileObjType = DaosObjectClass.OC_SX;
     private boolean readOnlyFs = false;
     private boolean shareFsClient = true;
 
@@ -915,7 +915,7 @@ public final class DaosFsClient extends ShareableClient implements ForceCloseabl
 
     /**
      * set default file mode. You can override this value when create new file by
-     * Scalling {@link DaosFile#createNewFile(int, DaosObjectType, int, boolean)}.
+     * Scalling {@link DaosFile#createNewFile(int, DaosObjectClass, int, boolean)}.
      *
      * @param defaultFileMode
      * should be octal value. Default is 0755
@@ -928,20 +928,20 @@ public final class DaosFsClient extends ShareableClient implements ForceCloseabl
 
     /**
      * set default file type. You can override this value when create new file by
-     * calling {@link DaosFile#createNewFile(int, DaosObjectType, int, boolean)}.
+     * calling {@link DaosFile#createNewFile(int, DaosObjectClass, int, boolean)}.
      *
      * @param defaultFileObjType
-     * default is {@link DaosObjectType#OC_SX}
+     * default is {@link DaosObjectClass#OC_SX}
      * @return DaosFsClientBuilder
      */
-    public DaosFsClientBuilder defaultFileType(DaosObjectType defaultFileObjType) {
+    public DaosFsClientBuilder defaultFileType(DaosObjectClass defaultFileObjType) {
       this.defaultFileObjType = defaultFileObjType;
       return this;
     }
 
     /**
      * set default file chunk size. You can override this value when create new file by
-     * calling {@link DaosFile#createNewFile(int, DaosObjectType, int, boolean)}.
+     * calling {@link DaosFile#createNewFile(int, DaosObjectClass, int, boolean)}.
      *
      * @param defaultFileChunkSize
      * default is 0. DAOS will decide what default is. 1MB for now.

--- a/src/client/java/daos-java/src/main/java/io/daos/dfs/DaosUns.java
+++ b/src/client/java/daos-java/src/main/java/io/daos/dfs/DaosUns.java
@@ -201,7 +201,7 @@ public class DaosUns {
     return builder.layout;
   }
 
-  public DaosObjectType getObjectType() {
+  public DaosObjectClass getObjectType() {
     return builder.objectType;
   }
 
@@ -224,7 +224,7 @@ public class DaosUns {
     private String poolUuid;
     private String contUuid;
     private Layout layout = Layout.POSIX;
-    private DaosObjectType objectType = DaosObjectType.OC_SX;
+    private DaosObjectClass objectType = DaosObjectClass.OC_SX;
     private long chunkSize = Constants.FILE_DEFAULT_CHUNK_SIZE;
     private boolean onLustre;
     private String serverGroup = Constants.POOL_DEFAULT_SERVER_GROUP;
@@ -284,7 +284,7 @@ public class DaosUns {
      * object type
      * @return this object
      */
-    public DaosUnsBuilder objectType(DaosObjectType objectType) {
+    public DaosUnsBuilder objectType(DaosObjectClass objectType) {
       this.objectType = objectType;
       return this;
     }

--- a/src/client/java/daos-java/src/main/java/io/daos/dfs/IODfsDesc.java
+++ b/src/client/java/daos-java/src/main/java/io/daos/dfs/IODfsDesc.java
@@ -33,6 +33,7 @@ public class IODfsDesc implements DaosEventQueue.Attachment {
   private int actualLength;
 
   private boolean released;
+  private boolean discarded;
 
   private static final Logger log = LoggerFactory.getLogger(IODfsDesc.class);
 
@@ -82,6 +83,16 @@ public class IODfsDesc implements DaosEventQueue.Attachment {
   @Override
   public boolean alwaysBoundToEvt() {
     return false;
+  }
+
+  @Override
+  public void discard() {
+    discarded = true;
+  }
+
+  @Override
+  public boolean isDiscarded() {
+    return discarded;
   }
 
   /**

--- a/src/client/java/daos-java/src/main/java/io/daos/obj/DaosObjClient.java
+++ b/src/client/java/daos-java/src/main/java/io/daos/obj/DaosObjClient.java
@@ -188,6 +188,20 @@ public class DaosObjClient extends ShareableClient implements ForceCloseable {
   native static long allocateSimDescGroup(long memoryAddress, int nbrOfDescs);
 
   /**
+   * allocate native desc for {@link IODescUpdAsync}.
+   *
+   * @param memoryAddress
+   */
+  native static void allocateDescUpdAsync(long memoryAddress);
+
+  /**
+   * release native desc for {@link IODescUpdAsync}.
+   *
+   * @param nativeDescPtr
+   */
+  native static void releaseDescUpdAsync(long nativeDescPtr);
+
+  /**
    * release description group allocated by {@link #allocateSimDescGroup(long, int)}.
    *
    * @param descGrpHdl
@@ -298,6 +312,21 @@ public class DaosObjClient extends ShareableClient implements ForceCloseable {
    */
   native void updateObjectAsync(long objectPtr, long flags, long descBufferAddress)
       throws DaosIOException;
+
+  /**
+   * update object with one entry. Dkey and Akey are described in {@link IODescUpdAsync}.
+   *
+   * @param objectPtr
+   * @param descMemAddress
+   * @param eqWrapHdl
+   * @param eventId
+   * @param offset
+   * @param dataLen
+   * @param dataMemAddress
+   * @throws DaosIOException
+   */
+  native void updateObjNoDecode(long objectPtr, long descMemAddress, long eqWrapHdl, short eventId,
+                             long offset, int dataLen, long dataMemAddress) throws DaosIOException;
 
   /**
    * list dkeys of given object.

--- a/src/client/java/daos-java/src/main/java/io/daos/obj/DaosObjClient.java
+++ b/src/client/java/daos-java/src/main/java/io/daos/obj/DaosObjClient.java
@@ -69,15 +69,19 @@ public class DaosObjClient extends ShareableClient implements ForceCloseable {
    *
    * @param oidBufferAddress
    * address of direct byte buffer with original object id's high and low. encode object id is set back to this buffer.
-   * @param feats
+   * @param contPtr
+   * container handle
+   * @param objectType
    * object feature bits
-   * @param objectTypeName
-   * object type name, see {@link DaosObjectType}
+   * @param objectClassName
+   * object type name, see {@link DaosObjectClass}
+   * @param objClassHint
+   * object class hint
    * @param args
    * reserved
    */
-  native static void encodeObjectId(long oidBufferAddress, int feats, String objectTypeName,
-                                           int args);
+  native static void encodeObjectId(long oidBufferAddress, long contPtr, int objectType, String objectClassName,
+                                           int objClassHint, int args);
 
   /**
    * open object denoted by object id stored in <code>buffer</code>.
@@ -394,7 +398,7 @@ public class DaosObjClient extends ShareableClient implements ForceCloseable {
 
   public static native void releaseDescSimple(long nativeDescPtr);
 
-  protected long getContPtr() {
+  public long getContPtr() {
     return contPtr;
   }
 

--- a/src/client/java/daos-java/src/main/java/io/daos/obj/DaosObject.java
+++ b/src/client/java/daos-java/src/main/java/io/daos/obj/DaosObject.java
@@ -543,6 +543,10 @@ public class DaosObject {
     }
   }
 
+  public DaosObjectId getOid() {
+    return oid;
+  }
+
   /**
    * close object if it's open.
    *

--- a/src/client/java/daos-java/src/main/java/io/daos/obj/DaosObject.java
+++ b/src/client/java/daos-java/src/main/java/io/daos/obj/DaosObject.java
@@ -110,29 +110,20 @@ public class DaosObject {
       log.debug("punching object " + oid);
     }
     try {
-      client.punchObject(objectPtr, 0);
+      client.punchObject(objectPtr, 0L);
     } catch (DaosIOException e) {
       throw new DaosObjectException(oid, "failed to punch entire object ", e);
     }
   }
 
-  private ByteBuf encodeKeys(List<String> keys) throws DaosObjectException {
+  private ByteBuf encodeKeys(List<String> keys) {
     int bufferLen = 0;
     List<byte[]> keyBytesList = new ArrayList<>(keys.size());
     for (String key : keys) {
       if (DaosUtils.isBlankStr(key)) {
         throw new IllegalArgumentException("one of akey is blank");
       }
-      byte bytes[];
-      try {
-        bytes = key.getBytes(Constants.KEY_CHARSET);
-      } catch (UnsupportedEncodingException e) {
-        throw new DaosObjectException(oid, "failed to encode " + key + " in " + Constants.KEY_CHARSET, e);
-      }
-      if (bytes.length > Short.MAX_VALUE) {
-        throw new IllegalArgumentException("key length in " + Constants.KEY_CHARSET +
-          " should not exceed " + Short.MAX_VALUE);
-      }
+      byte bytes[] = DaosUtils.keyToBytes(key);
       keyBytesList.add(bytes);
       bufferLen += (bytes.length + Constants.ENCODED_LENGTH_KEY);
     }
@@ -182,7 +173,7 @@ public class DaosObject {
       log.debug("punching dkeys: " + enumKeys(dkeys, MAX_DEBUG_SIZE) + oid);
     }
     try {
-      client.punchObjectDkeys(objectPtr, 0, dkeys.size(), buffer.memoryAddress(), buffer.readableBytes());
+      client.punchObjectDkeys(objectPtr, 0L, dkeys.size(), buffer.memoryAddress(), buffer.readableBytes());
     } catch (DaosIOException e) {
       throw new DaosObjectException(oid, "failed to punch " + dkeys.size() + " dkeys: " +
         enumKeys(dkeys, MAX_EXCEPTION_SIZE), e);
@@ -214,7 +205,7 @@ public class DaosObject {
       log.debug("punching akeys: " + enumKeys(akeys, MAX_DEBUG_SIZE) + oid);
     }
     try {
-      client.punchObjectAkeys(objectPtr, 0, nbrOfAkyes, buffer.memoryAddress(), buffer.readableBytes());
+      client.punchObjectAkeys(objectPtr, 0L, nbrOfAkyes, buffer.memoryAddress(), buffer.readableBytes());
     } catch (DaosIOException e) {
       throw new DaosObjectException(oid, "failed to punch " + akeys.size() + " akeys: " +
         enumKeys(akeys, MAX_EXCEPTION_SIZE) + " under dkey " + dkey, e);
@@ -277,7 +268,7 @@ public class DaosObject {
     }
     ByteBuf descBuffer = desc.getDescBuffer();
     try {
-      client.fetchObject(objectPtr, 0, desc.getNbrOfEntries(), descBuffer.memoryAddress(),
+      client.fetchObject(objectPtr, 0L, desc.getNbrOfEntries(), descBuffer.memoryAddress(),
           descBuffer.capacity());
       desc.parseFetchResult();
     } catch (DaosIOException e) {
@@ -304,7 +295,7 @@ public class DaosObject {
     }
     try {
       boolean async = desc.isAsync();
-      client.fetchObjectSimple(objectPtr, 0, desc.getDescBuffer().memoryAddress(), async);
+      client.fetchObjectSimple(objectPtr, 0L, desc.getDescBuffer().memoryAddress(), async);
       if (!async) {
         desc.parseFetchResult();
       }
@@ -331,7 +322,7 @@ public class DaosObject {
       log.debug(oid + " fetch object with description: " + desc.toString(MAX_DEBUG_SIZE));
     }
     try {
-      client.fetchObjectAsync(objectPtr, 0, desc.getDescBuffer().memoryAddress());
+      client.fetchObjectAsync(objectPtr, 0L, desc.getDescBuffer().memoryAddress());
     } catch (DaosIOException e) {
       DaosObjectException de = new DaosObjectException(oid, "failed to fetch object with description " +
           desc.toString(MAX_EXCEPTION_SIZE), e);
@@ -356,7 +347,7 @@ public class DaosObject {
       log.debug(oid + " update object with description: " + desc.toString(MAX_DEBUG_SIZE));
     }
     try {
-      client.updateObject(objectPtr, 0, desc.getNbrOfEntries(), desc.getDescBuffer().memoryAddress(),
+      client.updateObject(objectPtr, 0L, desc.getNbrOfEntries(), desc.getDescBuffer().memoryAddress(),
           desc.getDescBuffer().capacity());
       desc.parseUpdateResult();
     } catch (DaosIOException e) {
@@ -368,7 +359,7 @@ public class DaosObject {
   }
 
   /**
-   * Same as {@link #fetch(IODataDescSync)}, but fetch object with {@link IOSimpleDataDesc}.
+   * Same as {@link #update(IODataDescSync)}, but update object with {@link IOSimpleDataDesc}.
    *
    * @param desc
    * request and data description
@@ -382,7 +373,7 @@ public class DaosObject {
       log.debug(oid + " update object with description: " + desc.toString(MAX_DEBUG_SIZE));
     }
     try {
-      client.updateObjectSimple(objectPtr, 0, desc.getDescBuffer().memoryAddress(), desc.isAsync());
+      client.updateObjectSimple(objectPtr, 0L, desc.getDescBuffer().memoryAddress(), desc.isAsync());
       if (!desc.isAsync()) {
         desc.parseUpdateResult();
       }
@@ -395,7 +386,7 @@ public class DaosObject {
   }
 
   /**
-   * Same as {@link #fetch(IODataDescSync)}, but fetch object with {@link IOSimpleDDAsync}.
+   * Same as {@link #update(IODataDescSync)}, but update object with {@link IOSimpleDDAsync}.
    *
    * @param desc
    * request and data description
@@ -409,12 +400,34 @@ public class DaosObject {
       log.debug(oid + " update object with description: " + desc.toString(MAX_DEBUG_SIZE));
     }
     try {
-      client.updateObjectAsync(objectPtr, 0, desc.getDescBuffer().memoryAddress());
+      client.updateObjectAsync(objectPtr, 0L, desc.getDescBuffer().memoryAddress());
     } catch (DaosIOException e) {
       DaosObjectException de = new DaosObjectException(oid, "failed to update object with description " +
           desc.toString(MAX_EXCEPTION_SIZE), e);
       desc.setCause(de);
       throw de;
+    }
+  }
+
+  /**
+   * update with {@link IODescUpdAsync}.
+   *
+   * @param desc
+   * @throws DaosObjectException
+   */
+  public void updateAsync(IODescUpdAsync desc)
+      throws DaosObjectException {
+    checkOpen();
+
+    if (log.isDebugEnabled()) {
+      log.debug(oid + " update object with description " + desc);
+    }
+    try {
+      client.updateObjNoDecode(objectPtr, desc.descMemoryAddress(), desc.getEqHandle(), desc.getEventId(),
+          desc.getDestOffset(), desc.readableBytes(), desc.dataMemoryAddress());
+    } catch (DaosIOException e) {
+      throw new DaosObjectException(oid, "failed to update object with description " + desc,
+          e);
     }
   }
 
@@ -505,26 +518,8 @@ public class DaosObject {
     if (DaosUtils.isBlankStr(akey)) {
       throw new IllegalArgumentException("akey is blank");
     }
-    byte dkeyBytes[];
-    byte akeyBytes[];
-    try {
-      dkeyBytes = dkey.getBytes(Constants.KEY_CHARSET);
-      if (dkeyBytes.length > Short.MAX_VALUE) {
-        throw new IllegalArgumentException("dkey length in " + Constants.KEY_CHARSET +
-          " should not exceed " + Short.MAX_VALUE);
-      }
-    } catch (UnsupportedEncodingException e) {
-      throw new DaosObjectException(oid, "failed to encode dkey " + dkey + " in " + Constants.KEY_CHARSET, e);
-    }
-    try {
-      akeyBytes = akey.getBytes(Constants.KEY_CHARSET);
-      if (akeyBytes.length > Short.MAX_VALUE) {
-        throw new IllegalArgumentException("akey length in " + Constants.KEY_CHARSET +
-          " should not exceed " + Short.MAX_VALUE);
-      }
-    } catch (UnsupportedEncodingException e) {
-      throw new DaosObjectException(oid, "failed to encode akey " + akey + " in " + Constants.KEY_CHARSET, e);
-    }
+    byte dkeyBytes[] = DaosUtils.keyToBytes(dkey);
+    byte akeyBytes[] = DaosUtils.keyToBytes(akey);
     ByteBuf buffer = BufferAllocator.objBufWithNativeOrder(dkeyBytes.length + akeyBytes.length + 4);
     buffer.writeShort(dkeyBytes.length);
     buffer.writeBytes(dkeyBytes);

--- a/src/client/java/daos-java/src/main/java/io/daos/obj/DaosObjectId.java
+++ b/src/client/java/daos-java/src/main/java/io/daos/obj/DaosObjectId.java
@@ -7,6 +7,8 @@
 package io.daos.obj;
 
 import io.daos.BufferAllocator;
+import io.daos.DaosObjClassHint;
+import io.daos.DaosObjectClass;
 import io.daos.DaosObjectType;
 import io.netty.buffer.ByteBuf;
 
@@ -14,7 +16,7 @@ import javax.annotation.concurrent.NotThreadSafe;
 
 /**
  * DAOS Object ID corresponding to a specific container.
- * It contains 64-bit high and 64-bit low. Both will be encoded with feature bits and object type to get
+ * It contains 64-bit high and 64-bit low. Both will be encoded with object type and object class to get
  * final object ID.
  *
  * <p>
@@ -41,20 +43,23 @@ public class DaosObjectId {
   }
 
   /**
-   * encode with object feature bits and object type.
+   * encode with object type and object class.
    *
-   * @param feats      feature bits
-   * @param objectType object type
-   * @param args       reserved
+   * @param objectType  object type for dkey/akey
+   * @param objectClass object class
+   * @param hint        object class hint
+   * @param args        reserved
    */
-  public void encode(int feats, DaosObjectType objectType, int args) {
+  public void encode(long contPtr, DaosObjectType objectType, DaosObjectClass objectClass, DaosObjClassHint hint,
+                     int args) {
     if (encoded) {
       throw new IllegalStateException("already encoded");
     }
     buffer = BufferAllocator.objBufWithNativeOrder(16);
     buffer.writeLong(high).writeLong(low);
     try {
-      DaosObjClient.encodeObjectId(buffer.memoryAddress(), feats, objectType.nameWithoutOc(), args);
+      DaosObjClient.encodeObjectId(buffer.memoryAddress(), contPtr, objectType.getId(),
+          objectClass.nameWithoutOc(), hint.getId(), args);
     } catch (RuntimeException e) {
       buffer.release();
       buffer = null;
@@ -67,15 +72,18 @@ public class DaosObjectId {
 
   /**
    * encode with default values.
-   * feats: 0
-   * objectType: {@linkplain DaosObjectType#OC_SX}
+   * objectType: {@link DaosObjectType#DAOS_OT_MULTI_HASHED}
+   * objectClass: {@linkplain DaosObjectClass#OC_SX}
    * args: 0
    *
+   * @param contPtr
+   * container handle
    * <p>
-   * see {@link #encode(int, DaosObjectType, int)}
+   * see {@link #encode(long, DaosObjectType, DaosObjectClass, DaosObjClassHint, int)}
    */
-  public void encode() {
-    encode(0, DaosObjectType.OC_SX, 0);
+  public void encode(long contPtr) {
+    encode(contPtr, DaosObjectType.DAOS_OT_MULTI_HASHED, DaosObjectClass.OC_SX,
+        DaosObjClassHint.DAOS_OCH_RDD_DEF, 0);
   }
 
   public long getHigh() {

--- a/src/client/java/daos-java/src/main/java/io/daos/obj/IODataDescBase.java
+++ b/src/client/java/daos-java/src/main/java/io/daos/obj/IODataDescBase.java
@@ -6,10 +6,9 @@
 
 package io.daos.obj;
 
-import io.daos.Constants;
+import io.daos.DaosUtils;
 import io.netty.buffer.ByteBuf;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -37,18 +36,12 @@ public abstract class IODataDescBase implements IODataDesc {
 
   protected boolean resultParsed;
 
+  protected boolean discarded;
+
   protected IODataDescBase(String dkey, boolean updateOrFetch) {
     this.dkey = dkey;
     if (dkey != null) {
-      try {
-        this.dkeyBytes = dkey.getBytes(Constants.KEY_CHARSET);
-      } catch (IOException e) {
-        throw new IllegalArgumentException("failed to get bytes in " + Constants.KEY_CHARSET + " of dkey " + dkey);
-      }
-      if (dkeyBytes.length > Short.MAX_VALUE) {
-        throw new IllegalArgumentException("dkey length in " + Constants.KEY_CHARSET + " should not exceed "
-            + Short.MAX_VALUE);
-      }
+      dkeyBytes = DaosUtils.keyToBytes(dkey);
     }
     this.akeyEntries = new ArrayList<>();
     this.updateOrFetch = updateOrFetch;
@@ -120,6 +113,14 @@ public abstract class IODataDescBase implements IODataDesc {
   @Override
   public BaseEntry getEntry(int index) {
     return (BaseEntry) akeyEntries.get(index);
+  }
+
+  public boolean isDiscarded() {
+    return discarded;
+  }
+
+  public void discard() {
+    discarded = true;
   }
 
   public abstract class BaseEntry extends Entry {

--- a/src/client/java/daos-java/src/main/java/io/daos/obj/IODataDescBase.java
+++ b/src/client/java/daos-java/src/main/java/io/daos/obj/IODataDescBase.java
@@ -41,7 +41,7 @@ public abstract class IODataDescBase implements IODataDesc {
   protected IODataDescBase(String dkey, boolean updateOrFetch) {
     this.dkey = dkey;
     if (dkey != null) {
-      dkeyBytes = DaosUtils.keyToBytes(dkey);
+      dkeyBytes = DaosUtils.keyToBytes8(dkey);
     }
     this.akeyEntries = new ArrayList<>();
     this.updateOrFetch = updateOrFetch;

--- a/src/client/java/daos-java/src/main/java/io/daos/obj/IODataDescSync.java
+++ b/src/client/java/daos-java/src/main/java/io/daos/obj/IODataDescSync.java
@@ -145,11 +145,7 @@ public class IODataDescSync extends IODataDescBase {
     super(dkey, updateOrFetch);
     this.maxKeyLen = -1;
     this.dkey = dkey;
-    this.dkeyBytes = dkey.getBytes(Constants.KEY_CHARSET);
-    if (dkeyBytes.length > Short.MAX_VALUE) {
-      throw new IllegalArgumentException("dkey length in " + Constants.KEY_CHARSET + " should not exceed "
-                      + Short.MAX_VALUE);
-    }
+    this.dkeyBytes = DaosUtils.keyToBytes(dkey);
     if (iodType == IodType.NONE) {
       throw new IllegalArgumentException("need valid IodType, either " + IodType.ARRAY + " or " +
         IodType.SINGLE);
@@ -273,16 +269,7 @@ public class IODataDescSync extends IODataDescBase {
     if (dkey.equals(this.dkey)) { // in case of same dkey
       return;
     }
-    byte[] dkeyBytes = null;
-    try {
-      dkeyBytes = dkey.getBytes(Constants.KEY_CHARSET);
-    } catch (UnsupportedEncodingException e) {
-      throw new IllegalArgumentException("failed to get bytes in " + Constants.KEY_CHARSET + " of dkey " + dkey);
-    }
-    if (dkeyBytes.length > maxKeyLen) {
-      throw new IllegalArgumentException("dkey length in " + Constants.KEY_CHARSET + " should not exceed max key len: "
-          + maxKeyLen);
-    }
+    byte[] dkeyBytes = DaosUtils.keyToBytes(dkey);
     this.dkey = dkey;
     this.dkeyBytes = dkeyBytes;
   }
@@ -565,12 +552,8 @@ public class IODataDescSync extends IODataDescBase {
         throw new IllegalArgumentException("key is blank");
       }
       this.key = key;
-      this.keyBytes = key.getBytes(Constants.KEY_CHARSET);
       int limit = maxKeyLen > 0 ? maxKeyLen : Short.MAX_VALUE;
-      if (keyBytes.length > limit) {
-        throw new IllegalArgumentException("akey length in " + Constants.KEY_CHARSET + " should not exceed "
-            + limit + ", akey: " + key);
-      }
+      this.keyBytes = DaosUtils.keyToBytes(key, limit);
       this.offset = offset;
       this.dataSize = dataSize;
       if (offset%recordSize != 0) {
@@ -736,11 +719,7 @@ public class IODataDescSync extends IODataDescBase {
       }
       if (!akey.equals(this.key)) {
         this.key = akey;
-        this.keyBytes = akey.getBytes(Constants.KEY_CHARSET);
-        if (keyBytes.length > maxKeyLen) {
-          throw new IllegalArgumentException("akey length in " + Constants.KEY_CHARSET + " should not exceed "
-              + maxKeyLen + ", akey: " + key);
-        }
+        this.keyBytes = DaosUtils.keyToBytes(akey, maxKeyLen);
       }
       this.offset = offset;
       if (updateOrFetch) {

--- a/src/client/java/daos-java/src/main/java/io/daos/obj/IODescUpdAsync.java
+++ b/src/client/java/daos-java/src/main/java/io/daos/obj/IODescUpdAsync.java
@@ -15,6 +15,8 @@ import io.netty.buffer.ByteBuf;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.UnsupportedEncodingException;
+
 /**
  * IO Description for asynchronously update only one entry, dkey/akey.
  */
@@ -57,7 +59,7 @@ public class IODescUpdAsync implements DaosEventQueue.Attachment {
     this.nativeHdl = 0L;
     this.offset = offset;
     this.dataBuffer = dataBuffer;
-    byte[] dkeyBytes = DaosUtils.keyToBytes(dkey);
+    byte[] dkeyBytes = DaosUtils.keyToBytes8(dkey);
     byte[] akeyBytes = DaosUtils.keyToBytes(akey);
     // 8 for null native handle, 4 = 2 + 2 for lens,
     requestLen = 8 + dkeyBytes.length + akeyBytes.length + 4;
@@ -96,7 +98,7 @@ public class IODescUpdAsync implements DaosEventQueue.Attachment {
   public void setDkey(String dkey) {
     checkReusable();
     checkState();
-    byte[] bytes = DaosUtils.keyToBytes(dkey, maxKeyLen);
+    byte[] bytes = DaosUtils.keyToBytes8(dkey, maxKeyLen);
     descBuffer.writerIndex(10); // 8 (native desc hdl) + 2 (max key len)
     descBuffer.writeShort(bytes.length);
     descBuffer.writeBytes(bytes);
@@ -251,5 +253,49 @@ public class IODescUpdAsync implements DaosEventQueue.Attachment {
 
   public long descMemoryAddress() {
     return descBuffer.memoryAddress();
+  }
+
+  private String readKey(ByteBuf buf, int len) {
+    if (len < 0 || len >= buf.capacity() - 10) {
+      return "not set";
+    }
+    byte[] bytes = new byte[len];
+    buf.readBytes(bytes);
+    try {
+      return new String(bytes, Constants.KEY_CHARSET);
+    } catch (UnsupportedEncodingException e) {
+      return "not set";
+    }
+  }
+
+  @Override
+  public String toString() {
+    String dkey, akey;
+    if (maxKeyLen == 0) {
+      descBuffer.writerIndex(descBuffer.capacity());
+      descBuffer.readerIndex(8);
+      int l = descBuffer.readShort();
+      dkey = readKey(descBuffer, l);
+      l = descBuffer.readShort();
+      akey = readKey(descBuffer, l);
+    } else {
+      descBuffer.writerIndex(descBuffer.capacity());
+      descBuffer.readerIndex(10);
+      int l = descBuffer.readShort();
+      dkey = l > maxKeyLen ? "not set" : readKey(descBuffer, l);
+      descBuffer.readerIndex(12 + maxKeyLen);
+      l = descBuffer.readShort();
+      akey = l > maxKeyLen ? "not set" : readKey(descBuffer, l);
+    }
+    StringBuilder sb = new StringBuilder();
+    sb.append("dkey: ").append(dkey).append(", akey entries\n");
+    sb.append("[update entry|").append(maxKeyLen > 0 ? "" : "not ")
+        .append("reusable|")
+        .append(akey).append('|')
+        .append(offset).append('|')
+        .append(dataBuffer == null ? 0 : dataBuffer.readableBytes()).append('|')
+        .append(resultParsed).append('|')
+        .append(retCode).append(']');
+    return sb.toString();
   }
 }

--- a/src/client/java/daos-java/src/main/java/io/daos/obj/IODescUpdAsync.java
+++ b/src/client/java/daos-java/src/main/java/io/daos/obj/IODescUpdAsync.java
@@ -1,0 +1,255 @@
+/*
+ * (C) Copyright 2018-2021 Intel Corporation.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause-Patent
+ */
+
+package io.daos.obj;
+
+import io.daos.BufferAllocator;
+import io.daos.Constants;
+import io.daos.DaosEventQueue;
+import io.daos.DaosIOException;
+import io.daos.DaosUtils;
+import io.netty.buffer.ByteBuf;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * IO Description for asynchronously update only one entry, dkey/akey.
+ */
+public class IODescUpdAsync implements DaosEventQueue.Attachment {
+
+  private final short maxKeyLen;
+
+  private final long nativeHdl;
+
+  private ByteBuf descBuffer;
+
+  private long offset;
+
+  private ByteBuf dataBuffer;
+
+  private int requestLen;
+
+  private DaosEventQueue.Event event;
+
+  private boolean resultParsed;
+
+  private boolean discarded;
+
+  private int retCode = Integer.MAX_VALUE;
+
+  public static final int RET_CODE_SUCCEEDED = Constants.RET_CODE_SUCCEEDED;
+
+  private static final Logger log = LoggerFactory.getLogger(IODescUpdAsync.class);
+
+  /**
+   * constructor for non-reusable.
+   *
+   * @param dkey
+   * @param akey
+   * @param offset
+   * @param dataBuffer
+   */
+  public IODescUpdAsync(String dkey, String akey, long offset, ByteBuf dataBuffer) {
+    this.maxKeyLen = 0;
+    this.nativeHdl = 0L;
+    this.offset = offset;
+    this.dataBuffer = dataBuffer;
+    byte[] dkeyBytes = DaosUtils.keyToBytes(dkey);
+    byte[] akeyBytes = DaosUtils.keyToBytes(akey);
+    // 8 for null native handle, 4 = 2 + 2 for lens,
+    requestLen = 8 + dkeyBytes.length + akeyBytes.length + 4;
+    // 4 for return code
+    descBuffer = BufferAllocator.objBufWithNativeOrder(requestLen + 4);
+    descBuffer.writeLong(0L);
+    descBuffer.writeShort(dkeyBytes.length);
+    descBuffer.writeBytes(dkeyBytes);
+    descBuffer.writeShort(akeyBytes.length);
+    descBuffer.writeBytes(akeyBytes);
+  }
+
+  /**
+   * constructor for reusable.
+   *
+   * @param maxKeyLen
+   */
+  public IODescUpdAsync(int maxKeyLen) {
+    if (maxKeyLen <= 0 || maxKeyLen > Short.MAX_VALUE) {
+      throw new IllegalArgumentException("max key length should be bigger than 0 and less than " + Short.MAX_VALUE
+          + ", value is " + maxKeyLen);
+    }
+    this.maxKeyLen = (short)maxKeyLen;
+    requestLen = 8 + 2 + 2 * (maxKeyLen + 2); // 8 for address of native desc, 2 for maxKeyLen
+    descBuffer = BufferAllocator.objBufWithNativeOrder(requestLen + 4);
+    descBuffer.writeLong(0L);
+    descBuffer.writeShort(maxKeyLen);
+    DaosObjClient.allocateDescUpdAsync(descBuffer.memoryAddress());
+    descBuffer.readerIndex(0);
+    nativeHdl = descBuffer.readLong();
+    if (nativeHdl == 0L) {
+      throw new IllegalStateException("no native desc created");
+    }
+  }
+
+  public void setDkey(String dkey) {
+    checkReusable();
+    checkState();
+    byte[] bytes = DaosUtils.keyToBytes(dkey, maxKeyLen);
+    descBuffer.writerIndex(10); // 8 (native desc hdl) + 2 (max key len)
+    descBuffer.writeShort(bytes.length);
+    descBuffer.writeBytes(bytes);
+  }
+
+  public void setAkey(String akey) {
+    checkReusable();
+    checkState();
+    byte[] bytes = DaosUtils.keyToBytes(akey, maxKeyLen);
+    descBuffer.writerIndex(12 + maxKeyLen); // 8 (native desc hdl) + 2 (max key len) + 2 (key len)
+    descBuffer.writeShort(bytes.length);
+    descBuffer.writeBytes(bytes);
+  }
+
+  public void setOffset(long offset) {
+    checkReusable();
+    checkState();
+    this.offset = offset;
+  }
+
+  public void setDataBuffer(ByteBuf dataBuffer) {
+    checkReusable();
+    checkState();
+    this.dataBuffer = dataBuffer;
+  }
+
+  private void checkState() {
+    if (resultParsed) {
+      throw new IllegalStateException("call reuse() first");
+    }
+  }
+
+  private void checkReusable() {
+    if (!isReusable()) {
+      throw new IllegalStateException("not reusable");
+    }
+  }
+
+  public boolean isReusable() {
+    return maxKeyLen > 0;
+  }
+
+  public boolean isSucceeded() {
+    return retCode == RET_CODE_SUCCEEDED;
+  }
+
+  public ByteBuf getDescBuffer() {
+    return descBuffer;
+  }
+
+  public ByteBuf getDataBuffer() {
+    return dataBuffer;
+  }
+
+  public DaosEventQueue.Event getEvent() {
+    return event;
+  }
+
+  @Override
+  public void setEvent(DaosEventQueue.Event e) {
+    this.event = e;
+    e.setAttachment(this);
+  }
+
+  @Override
+  public void reuse() {
+    checkReusable();
+    descBuffer.readerIndex(0);
+    resultParsed = false;
+    retCode = -1;
+    event = null;
+    if (dataBuffer != null) {
+      dataBuffer.release();
+      dataBuffer = null;
+    }
+  }
+
+  @Override
+  public void ready() {
+    descBuffer.writerIndex(descBuffer.capacity());
+    descBuffer.readerIndex(requestLen);
+    retCode = descBuffer.readInt();
+  }
+
+  @Override
+  public boolean alwaysBoundToEvt() {
+    return false;
+  }
+
+  @Override
+  public boolean isDiscarded() {
+    return discarded;
+  }
+
+  @Override
+  public void discard() {
+    discarded = true;
+  }
+
+  public int getReturnCode() {
+    return retCode;
+  }
+
+  @Override
+  public void release() {
+    if (descBuffer != null) {
+      if (isReusable() & nativeHdl > 0) {
+        DaosObjClient.releaseDescUpdAsync(nativeHdl);
+      }
+      descBuffer.release();
+      descBuffer = null;
+    }
+    if (dataBuffer != null) {
+      dataBuffer.release();
+      dataBuffer = null;
+    }
+    if ((!resultParsed) && event != null) {
+      try {
+        event.abort();
+      } catch (DaosIOException e) {
+        log.error("failed to abort event bound to " + this, e);
+      }
+      event = null;
+    }
+  }
+
+  public long getEqHandle() {
+    if (event == null) {
+      throw new IllegalStateException("event is not set");
+    }
+    return event.getEqHandle();
+  }
+
+  public short getEventId() {
+    if (event == null) {
+      throw new IllegalStateException("event is not set");
+    }
+    return event.getId();
+  }
+
+  public long getDestOffset() {
+    return offset;
+  }
+
+  public int readableBytes() {
+    return dataBuffer.readableBytes();
+  }
+
+  public long dataMemoryAddress() {
+    return dataBuffer.memoryAddress();
+  }
+
+  public long descMemoryAddress() {
+    return descBuffer.memoryAddress();
+  }
+}

--- a/src/client/java/daos-java/src/main/java/io/daos/obj/IOKeyDesc.java
+++ b/src/client/java/daos-java/src/main/java/io/daos/obj/IOKeyDesc.java
@@ -8,6 +8,7 @@ package io.daos.obj;
 
 import io.daos.BufferAllocator;
 import io.daos.Constants;
+import io.daos.DaosUtils;
 import io.netty.buffer.ByteBuf;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -68,11 +69,7 @@ public class IOKeyDesc {
   protected IOKeyDesc(String dkey, int nbrOfKeys, int akeyLen, int batchSize) throws IOException {
     this.dkey = dkey;
     if (dkey != null) {
-      dkeyBytes = dkey.getBytes(Constants.KEY_CHARSET);
-      if (dkeyBytes.length > Short.MAX_VALUE) {
-        throw new IllegalArgumentException("dkey length in " + Constants.KEY_CHARSET + " should not exceed "
-          + Short.MAX_VALUE);
-      }
+      dkeyBytes = DaosUtils.keyToBytes(dkey);
     }
     if (nbrOfKeys < 1) {
       throw new IllegalArgumentException("nbrOfKeys should be at least 1, " + nbrOfKeys);

--- a/src/client/java/daos-java/src/main/java/io/daos/obj/IOSimpleDDAsync.java
+++ b/src/client/java/daos-java/src/main/java/io/daos/obj/IOSimpleDDAsync.java
@@ -360,17 +360,12 @@ public class IOSimpleDDAsync extends IODataDescBase implements DaosEventQueue.At
      * size of data to fetch
      * @throws IOException
      */
-    private AsyncEntry(String key, long offset, int dataSize)
-        throws IOException {
+    private AsyncEntry(String key, long offset, int dataSize) {
       if (DaosUtils.isBlankStr(key)) {
         throw new IllegalArgumentException("key is blank");
       }
       this.key = key;
-      this.keyBytes = key.getBytes(Constants.KEY_CHARSET);
-      if (keyBytes.length > Short.MAX_VALUE) {
-        throw new IllegalArgumentException("akey length in " + Constants.KEY_CHARSET + " should not exceed "
-            + Short.MAX_VALUE + ", akey: " + key);
-      }
+      this.keyBytes = DaosUtils.keyToBytes(key);
       this.offset = offset;
       this.dataSize = dataSize;
       if (dataSize <= 0) {

--- a/src/client/java/daos-java/src/main/native/daos_jni_common.c
+++ b/src/client/java/daos-java/src/main/native/daos_jni_common.c
@@ -30,38 +30,32 @@ JNI_OnLoad(JavaVM *vm, void *reserved)
 			"io/daos/DaosIOException");
 
 	daos_io_exception_class = (*env)->NewGlobalRef(env, local_class);
-	jmethodID m1 = (*env)->GetMethodID(env, daos_io_exception_class,
+	new_exception_msg = (*env)->GetMethodID(env, daos_io_exception_class,
 			"<init>",
 			"(Ljava/lang/String;)V");
-
-	new_exception_msg = (*env)->NewGlobalRef(env, m1);
 	if (new_exception_msg == NULL) {
 		printf("failed to get constructor msg\n");
 		return JNI_ERR;
 	}
-	jmethodID m2 = (*env)->GetMethodID(env, daos_io_exception_class,
+	new_exception_cause = (*env)->GetMethodID(env, daos_io_exception_class,
 			"<init>",
 			"(Ljava/lang/Throwable;)V");
-
-	new_exception_cause = (*env)->NewGlobalRef(env, m2);
 	if (new_exception_cause == NULL) {
 		printf("failed to get constructor cause\n");
 		return JNI_ERR;
 	}
-	jmethodID m3 = (*env)->GetMethodID(env, daos_io_exception_class,
+	new_exception_msg_code_msg = (*env)->GetMethodID(env,
+			daos_io_exception_class,
 			"<init>",
 			"(Ljava/lang/String;ILjava/lang/String;)V");
-
-	new_exception_msg_code_msg = (*env)->NewGlobalRef(env, m3);
 	if (new_exception_msg_code_msg == NULL) {
 		printf("failed to get constructor msg, code and daos msg\n");
 		return JNI_ERR;
 	}
-	jmethodID m4 = (*env)->GetMethodID(env, daos_io_exception_class,
+	new_exception_msg_code_cause = (*env)->GetMethodID(env,
+			daos_io_exception_class,
 			"<init>",
 			"(Ljava/lang/String;ILjava/lang/Throwable;)V");
-
-	new_exception_msg_code_cause = (*env)->NewGlobalRef(env, m4);
 	if (new_exception_msg_code_cause == NULL) {
 		printf("failed to get constructor msg, code and cause\n");
 		return JNI_ERR;
@@ -71,11 +65,6 @@ JNI_OnLoad(JavaVM *vm, void *reserved)
 	if (rc) {
 		printf("daos_init() failed with rc = %d\n", rc);
 		printf("error msg: %.256s\n", d_errstr(rc));
-		return rc;
-	}
-	rc = daos_eq_lib_init();
-	if (rc) {
-		printf("Failed daos_eq_lib_init: %d\n", rc);
 		return rc;
 	}
 	return JNI_VERSION;
@@ -92,7 +81,7 @@ throw_base(JNIEnv *env, char *msg, int error_code,
 		const char *temp = posix_error ?
 				strerror(error_code) : d_errstr(error_code);
 
-		daos_msg = temp;
+		daos_msg = (char *)temp;
 	} else {
 		daos_msg = NULL;
 	}
@@ -146,10 +135,5 @@ JNI_OnUnload(JavaVM *vm, void *reserved)
 		return;
 	}
 	(*env)->DeleteGlobalRef(env, daos_io_exception_class);
-	(*env)->DeleteGlobalRef(env, new_exception_msg);
-	(*env)->DeleteGlobalRef(env, new_exception_cause);
-	(*env)->DeleteGlobalRef(env, new_exception_msg_code_msg);
-	(*env)->DeleteGlobalRef(env, new_exception_msg_code_cause);
-	daos_eq_lib_fini();
 	daos_fini();
 }

--- a/src/client/java/daos-java/src/main/native/include/daos_jni_common.h
+++ b/src/client/java/daos-java/src/main/native/include/daos_jni_common.h
@@ -75,6 +75,17 @@ typedef struct {
 } data_desc_async_t;
 
 typedef struct {
+    daos_key_t dkey;
+    uint16_t maxKeyLen;
+    data_event_t *event;
+    daos_iod_t *iods;
+    d_sg_list_t *sgls;
+    daos_recx_t *recxs;
+    d_iov_t *iovs;
+    uint64_t ret_buf_address;
+} data_desc_upd_async_t;
+
+typedef struct {
     int nbrOfDescs;
     data_desc_simple_t **descs;
 } data_desc_simple_grp_t;

--- a/src/client/java/daos-java/src/main/native/include/daos_jni_common.h
+++ b/src/client/java/daos-java/src/main/native/include/daos_jni_common.h
@@ -25,9 +25,14 @@
 #define _INCLUDED_DAOS_JNI_COMMON
 
 typedef struct {
+    uint8_t status;
+    daos_event_t event;
+} data_event_t;
+
+typedef struct {
     int nbrOfEvents;
     daos_handle_t eqhdl;
-    daos_event_t **events;
+    data_event_t **events;
     daos_event_t **polled_events;
 } event_queue_wrapper_t;
 
@@ -50,7 +55,7 @@ typedef struct {
     uint16_t nbrOfEntries;
     uint16_t nbrOfRequests;
     event_queue_wrapper_t *eq;
-    daos_event_t *event;
+    data_event_t *event;
     daos_iod_t *iods;
     d_sg_list_t *sgls;
     daos_recx_t *recxs;
@@ -61,7 +66,7 @@ typedef struct {
 typedef struct {
     daos_key_t dkey;
     uint16_t nbrOfEntries;
-    daos_event_t *event;
+    data_event_t *event;
     daos_iod_t *iods;
     d_sg_list_t *sgls;
     daos_recx_t *recxs;
@@ -78,6 +83,7 @@ typedef struct {
     d_sg_list_t sgl;
     d_iov_t iov;
     event_queue_wrapper_t *eq;
+    data_event_t *event;
     uint64_t ret_buf_address;
     daos_size_t size;
 } dfs_desc_t;
@@ -120,7 +126,7 @@ static uint8_t KEY_LIST_CODE_ANCHOR_END = (uint8_t)2;
 static uint8_t KEY_LIST_CODE_KEY2BIG = (uint8_t)3;
 static uint8_t KEY_LIST_CODE_REACH_LIMIT = (uint8_t)4;
 
-static int EVENT_IN_USE = -32768;
+static uint8_t EVENT_IN_USE = 1;
 
 /**
  * utility function to throw Java exception.

--- a/src/client/java/daos-java/src/main/native/io_daos_DaosClient.c
+++ b/src/client/java/daos-java/src/main/native/io_daos_DaosClient.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
 
+#define _GNU_SOURCE
+
 #include "io_daos_DaosClient.h"
 #include <sys/stat.h>
 #include <gurt/common.h>
@@ -225,7 +227,10 @@ Java_io_daos_DaosClient_daosGetContAttrs(JNIEnv *env,
 	}
 
 	memcpy(&coh, &contHandle, sizeof(coh));
-	rc = daos_cont_get_attr(coh, n, names, values, sizes, NULL);
+	rc = daos_cont_get_attr(coh, n,
+				(const char * const *)names,
+				(void * const *)values,
+				sizes, NULL);
 	if (rc) {
 		throw_base(env, "Failed to get attributes from container", rc, 0, 0);
 		goto rel;
@@ -302,7 +307,10 @@ Java_io_daos_DaosClient_daosSetContAttrs(JNIEnv *env,
 	}
 
 	memcpy(&coh, &contHandle, sizeof(coh));
-	rc = daos_cont_set_attr(coh, n, names, values, sizes, NULL);
+	rc = daos_cont_set_attr(coh, n,
+				(const char * const *)names,
+				(const void * const *)values,
+				sizes, NULL);
 	if (rc) {
 		throw_base(env, "Failed to set attributes to container", rc, 0, 0);
 	}
@@ -461,7 +469,7 @@ Java_io_daos_DaosClient_abortEvent(JNIEnv *env,
 	if (rc) {
 		char *msg = NULL;
 
-		asprintf(&msg, "Failed to abort event (%d)",
+		asprintf(&msg, "Failed to abort event (%ld)",
 			 event->event.ev_debug);
 		throw_base(env, msg, rc, 1, 0);
 	}
@@ -541,14 +549,7 @@ JNIEXPORT void JNICALL
 Java_io_daos_DaosClient_daosFinalize(JNIEnv *env,
 				     jclass clientClass)
 {
-	int rc = daos_eq_lib_fini();
-
-	if (rc) {
-		printf("Failed to finalize EQ lib rc: %d\n", rc);
-		printf("error msg: %.256s\n", d_errstr(rc));
-	}
-
-	rc = daos_fini();
+	int rc = daos_fini();
 	if (rc) {
 		printf("Failed to finalize daos rc: %d\n", rc);
 		printf("error msg: %.256s\n", d_errstr(rc));

--- a/src/client/java/daos-java/src/main/native/io_daos_DaosClient.c
+++ b/src/client/java/daos-java/src/main/native/io_daos_DaosClient.c
@@ -339,11 +339,11 @@ Java_io_daos_DaosClient_createEventQueue(JNIEnv *env,
 	if (eq == NULL) {
 		goto fail;
 	}
-	eq->events = (daos_event_t **)malloc(
-		nbrOfEvents * sizeof(daos_event_t *));
+	eq->events = (data_event_t **)malloc(
+		nbrOfEvents * sizeof(data_event_t *));
 	eq->polled_events = (daos_event_t **)malloc(
 		nbrOfEvents * sizeof(daos_event_t *));
-	if (eq->events == NULL || eq->polled_events == NULL) {
+	if (eq->events == NULL | eq->polled_events == NULL) {
 		char *msg = NULL;
 
 		asprintf(&msg,
@@ -356,7 +356,7 @@ Java_io_daos_DaosClient_createEventQueue(JNIEnv *env,
 	eq->nbrOfEvents = nbrOfEvents;
 	eq->eqhdl = eqhdl;
 	for (i = 0; i < nbrOfEvents; i++) {
-		eq->events[i] = (daos_event_t *)malloc(sizeof(daos_event_t));
+		eq->events[i] = (data_event_t *)malloc(sizeof(data_event_t));
 		if (eq->events[i] == NULL) {
 			char *msg = NULL;
 
@@ -366,7 +366,7 @@ Java_io_daos_DaosClient_createEventQueue(JNIEnv *env,
 			throw_base(env, msg, rc, 1, 0);
 			goto fail;
 		}
-		rc = daos_event_init(eq->events[i], eqhdl, NULL);
+		rc = daos_event_init(&eq->events[i]->event, eqhdl, NULL);
 		if (rc) {
 			char *msg = NULL;
 
@@ -375,7 +375,7 @@ Java_io_daos_DaosClient_createEventQueue(JNIEnv *env,
 			throw_base(env, msg, rc, 1, 0);
 			goto fail;
 		}
-		eq->events[i]->ev_debug = i;
+		eq->events[i]->event.ev_debug = i;
 	}
 
 fail:
@@ -383,7 +383,7 @@ fail:
 		count = i;
 		while (i >= 0) {
 			if (eq->events[i] && i < count) {
-				daos_event_fini(eq->events[i]);
+				daos_event_fini(&eq->events[i]->event);
 			}
 			i--;
 		}
@@ -450,19 +450,19 @@ Java_io_daos_DaosClient_abortEvent(JNIEnv *env,
 				   jshort eid)
 {
 	event_queue_wrapper_t *eq = *(event_queue_wrapper_t **)&eqWrapperHdl;
-	daos_event_t *event = eq->events[eid];
+	data_event_t *event = eq->events[eid];
 	int rc;
 
-	if (event->ev_error != EVENT_IN_USE) {
+	if (event->status != EVENT_IN_USE) {
 		return 0;
 	}
-	rc = daos_event_abort(event);
-	event->ev_error = 0;
+	rc = daos_event_abort(&event->event);
+	event->status = 0;
 	if (rc) {
 		char *msg = NULL;
 
 		asprintf(&msg, "Failed to abort event (%d)",
-			 event->ev_debug);
+			 event->event.ev_debug);
 		throw_base(env, msg, rc, 1, 0);
 	}
 	return 1;
@@ -477,7 +477,7 @@ Java_io_daos_DaosClient_destroyEventQueue(JNIEnv *env,
 	int i;
 	int rc;
 	int count = 0;
-	daos_event_t *ev;
+	data_event_t *ev;
 
 	while (daos_eq_poll(eq->eqhdl, 1, 1000, eq->nbrOfEvents,
 			    eq->polled_events)) {
@@ -492,7 +492,7 @@ Java_io_daos_DaosClient_destroyEventQueue(JNIEnv *env,
 			if (!ev) {
 				continue;
 			}
-			rc = daos_event_fini(ev);
+			rc = daos_event_fini(&ev->event);
 			if (rc) {
 				char *msg = NULL;
 
@@ -516,7 +516,7 @@ Java_io_daos_DaosClient_destroyEventQueue(JNIEnv *env,
 fin:
 	if (eq->events) {
 		for (i = 0; i < eq->nbrOfEvents; i++) {
-		ev = eq->events[i];
+			ev = eq->events[i];
 			if (ev) {
 				free(ev);
 			}

--- a/src/client/java/daos-java/src/main/native/io_daos_dfs_DaosFsClient.c
+++ b/src/client/java/daos-java/src/main/native/io_daos_dfs_DaosFsClient.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
 
+#define _GNU_SOURCE
+
 #include "io_daos_dfs_DaosFsClient.h"
 #include <sys/stat.h>
 #include <sys/xattr.h>
@@ -106,8 +108,8 @@ Java_io_daos_dfs_DaosFsClient_move__JLjava_lang_String_2Ljava_lang_String_2(
 	if (src_dir_path == NULL || src_base_path == NULL) {
 		char *msg = NULL;
 
-		asprintf(&msg, "Failed to duplicate source path, len: %d",
-			 len(src_path));
+		asprintf(&msg, "Failed to duplicate source path, len: %ld",
+			 strlen(src_path));
 		throw_base(env, msg, CUSTOM_ERR3, 1, 0);
 		goto out;
 	}
@@ -116,8 +118,8 @@ Java_io_daos_dfs_DaosFsClient_move__JLjava_lang_String_2Ljava_lang_String_2(
 	if (dest_dir_path == NULL || dest_base_path == NULL) {
 		char *msg = NULL;
 
-		asprintf(&msg, "Failed to duplicate dest path, len: %d",
-			 len(dest_path));
+		asprintf(&msg, "Failed to duplicate dest path, len: %ld",
+			 strlen(dest_path));
 		throw_base(env, msg, CUSTOM_ERR3, 1, 0);
 		goto out;
 	}
@@ -435,7 +437,7 @@ Java_io_daos_dfs_DaosFsClient_createNewFile(JNIEnv *env,
 		throw_const(env,
 			    "Empty parent path or empty name",
 			    CUSTOM_ERR6);
-		return;
+		return -1;
 	}
 
 	dfs_t *dfs = *(dfs_t **)&dfsPtr;
@@ -542,7 +544,7 @@ Java_io_daos_dfs_DaosFsClient_delete(JNIEnv *env, jobject client,
 		throw_const(env,
 			    "Empty parent path or empty name",
 			    CUSTOM_ERR6);
-		return;
+		return 0;
 	}
 	dfs_t *dfs = *(dfs_t **)&dfsPtr;
 	const char *parent_path = (*env)->GetStringUTFChars(env, parentPath,
@@ -590,7 +592,7 @@ Java_io_daos_dfs_DaosFsClient_dfsLookup__JJLjava_lang_String_2IJ(
 {
 	if (name == NULL) {
 		throw_const(env, "Empty name", CUSTOM_ERR6);
-		return;
+		return -1;
 	}
 	dfs_t *dfs = *(dfs_t **)&dfsPtr;
 	dfs_obj_t *parent = *(dfs_obj_t **)&parentObjId;
@@ -634,7 +636,7 @@ Java_io_daos_dfs_DaosFsClient_dfsLookup__JLjava_lang_String_2IJ(
 {
 	if (path == NULL) {
 		throw_const(env, "Empty path", CUSTOM_ERR6);
-		return;
+		return -1;
 	}
 	dfs_t *dfs = *(dfs_t **)&dfsPtr;
 	dfs_obj_t *file;
@@ -759,7 +761,7 @@ Java_io_daos_dfs_DaosFsClient_allocateDfsDesc(JNIEnv *env,
 	desc->eq = (event_queue_wrapper_t *)value64;
 	/* move by 8 and skip offset, length, event id */
 	desc_buffer += 26;
-	desc->ret_buf_address = desc_buffer;
+	desc->ret_buf_address = (uint64_t)desc_buffer;
 	desc->event = NULL;
 	/* copy back address */
 	memcpy((char *)descBufAddress, &desc, 8);
@@ -857,7 +859,7 @@ static int
 update_actual_size(void *udata, daos_event_t *ev, int ret)
 {
 	dfs_desc_t *desc = (dfs_desc_t *)udata;
-	char *desc_buffer = desc->ret_buf_address;
+	char *desc_buffer = (char *)desc->ret_buf_address;
 	uint32_t value = (uint32_t)desc->size;
 
 	memcpy(desc_buffer, &ret, 4);
@@ -887,7 +889,7 @@ Java_io_daos_dfs_DaosFsClient_dfsReadAsync(JNIEnv *env, jobject client,
 	if (rc) {
 		char *msg = "Failed to register dfs read callback";
 
-		throw_exception_const_msg_object(env, msg, rc);
+		throw_const_obj(env, msg, rc);
 		return;
 	}
 	desc->event->status = EVENT_IN_USE;
@@ -898,8 +900,7 @@ Java_io_daos_dfs_DaosFsClient_dfsReadAsync(JNIEnv *env, jobject client,
 		asprintf(&msg,
 			 "Failed to read %ld bytes from file starting at %ld",
 			 len, offset);
-		throw_exception(env, msg, rc);
-		return 0;
+		throw_exc(env, msg, rc);
 	}
 }
 
@@ -952,7 +953,7 @@ static int
 update_ret_code(void *udata, daos_event_t *ev, int ret)
 {
 	dfs_desc_t *desc = (dfs_desc_t *)udata;
-	char *desc_buffer = desc->ret_buf_address;
+	char *desc_buffer = (char *)desc->ret_buf_address;
 
 	memcpy(desc_buffer, &ret, 4);
 	desc->event->status = 0;
@@ -978,7 +979,7 @@ Java_io_daos_dfs_DaosFsClient_dfsWriteAsync(JNIEnv *env, jobject client,
 	if (rc) {
 		char *msg = "Failed to register dfs write callback";
 
-		throw_exception_const_msg_object(env, msg, rc);
+		throw_const_obj(env, msg, rc);
 		return;
 	}
 	desc->event->status = EVENT_IN_USE;
@@ -989,8 +990,7 @@ Java_io_daos_dfs_DaosFsClient_dfsWriteAsync(JNIEnv *env, jobject client,
 		asprintf(&msg,
 			 "Failed to write %ld bytes from file starting at %ld",
 			 len, offset);
-		throw_exception(env, msg, rc);
-		return 0;
+		throw_exc(env, msg, rc);
 	}
 }
 
@@ -1247,7 +1247,7 @@ Java_io_daos_dfs_DaosFsClient_dfsGetExtAttr(JNIEnv *env,
 {
 	if (name == NULL) {
 		throw_const(env, "Empty name", CUSTOM_ERR6);
-		return;
+		return NULL;
 	}
 	dfs_t *dfs = *(dfs_t **)&dfsPtr;
 	dfs_obj_t *file = *(dfs_obj_t **)&objId;
@@ -1400,7 +1400,7 @@ Java_io_daos_dfs_DaosFsClient_dunsResolvePath(JNIEnv *env, jclass clientClass,
 {
 	if (pathStr == NULL) {
 		throw_const(env, "Empty path", CUSTOM_ERR6);
-		return;
+		return NULL;
 	}
 	const char *path = (*env)->GetStringUTFChars(env, pathStr, NULL);
 	struct duns_attr_t attr = {0};
@@ -1541,7 +1541,7 @@ Java_io_daos_dfs_DaosFsClient_dunsGetAppInfo(JNIEnv *env, jclass clientClass,
 		char *msg = "Empty path or empty attribute name";
 
 		throw_const(env, msg, CUSTOM_ERR6);
-		return;
+		return NULL;
 	}
 	const char *path = (*env)->GetStringUTFChars(env, pathStr, NULL);
 	const char *attrName = (*env)->GetStringUTFChars(env, attrNameStr,
@@ -1590,7 +1590,7 @@ Java_io_daos_dfs_DaosFsClient_dunsParseAttribute(JNIEnv *env,
 {
 	if (inputStr == NULL) {
 		throw_const(env, "Empty input", CUSTOM_ERR6);
-		return;
+		return NULL;
 	}
 	const char *input = (*env)->GetStringUTFChars(env, inputStr, NULL);
 	int len = strlen(input);

--- a/src/client/java/daos-java/src/main/native/io_daos_obj_DaosObjClient.c
+++ b/src/client/java/daos-java/src/main/native/io_daos_obj_DaosObjClient.c
@@ -249,8 +249,8 @@ decode_initial(data_desc_t *desc, char *desc_buffer)
 	uint64_t value64;
 	int i;
 
-	if (desc->iods == NULL || desc->sgls == NULL
-		|| desc->recxs == NULL || desc->iovs == NULL) {
+	if (desc->iods == NULL | desc->sgls == NULL
+		| desc->recxs == NULL | desc->iovs == NULL) {
 		return CUSTOM_ERR3;
 	}
 
@@ -744,8 +744,8 @@ allocate_simple_desc(char *descBufAddress, data_desc_simple_t *desc,
 			sizeof(d_iov_t));
 	daos_iod_t *iod;
 
-	if (desc->iods == NULL || desc->sgls == NULL
-		|| desc->recxs == NULL || desc->iovs == NULL) {
+	if (desc->iods == NULL | desc->sgls == NULL
+		| desc->recxs == NULL | desc->iovs == NULL) {
 		return CUSTOM_ERR3;
 	}
 
@@ -864,7 +864,7 @@ update_ret_code(void *udata, daos_event_t *ev, int ret)
 
 	memcpy(desc_buffer, &ret, 4);
 	if (ev) {
-		ev->ev_error = 0;
+		desc->event->status = 0;
 	}
 	return 0;
 }
@@ -884,7 +884,9 @@ Java_io_daos_obj_DaosObjClient_updateObjectSimple(
 		return;
 	}
 	if (async) {
-		rc = daos_event_register_comp_cb(desc->event,
+		desc->event->status = EVENT_IN_USE;
+		desc->event->event.ev_error = 0;
+		rc = daos_event_register_comp_cb(&desc->event->event,
 			update_ret_code, desc);
 		if (rc) {
 			char *msg = "Failed to register update callback";
@@ -894,11 +896,11 @@ Java_io_daos_obj_DaosObjClient_updateObjectSimple(
 					rc);
 			return;
 		}
-		desc->event->ev_error = EVENT_IN_USE;
 	}
 	rc = daos_obj_update(oh, DAOS_TX_NONE, flags, &desc->dkey,
 				desc->nbrOfRequests, desc->iods,
-				desc->sgls, async ? desc->event : NULL);
+				desc->sgls,
+				async ? &desc->event->event : NULL);
 	if (rc) {
 		throw_const_obj(env, "Failed to update DAOS object", rc);
 	}
@@ -969,8 +971,8 @@ decode_async(JNIEnv *env, jlong descBufAddress,
 			sizeof(d_iov_t));
 	daos_iod_t *iod;
 
-	if (desc->iods == NULL || desc->sgls == NULL || desc->recxs == NULL
-		|| desc->iovs == NULL) {
+	if (desc->iods == NULL | desc->sgls == NULL | desc->recxs == NULL
+		| desc->iovs == NULL) {
 		return CUSTOM_ERR3;
 	}
 	for (i = 0; i < desc->nbrOfEntries; i++) {
@@ -1013,8 +1015,8 @@ update_ret_code_async(void *udata, daos_event_t *ev, int ret)
 	char *desc_buffer = desc->ret_buf_address;
 
 	memcpy(desc_buffer, &ret, 4);
+	desc->event->status = 0;
 	release_desc_async(desc);
-	ev->ev_error = 0;
 	return 0;
 }
 
@@ -1036,7 +1038,9 @@ Java_io_daos_obj_DaosObjClient_updateObjectAsync(
 		throw_exception_const_msg_object(env, msg, rc);
 		goto fail;
 	}
-	rc = daos_event_register_comp_cb(desc->event,
+	desc->event->status = EVENT_IN_USE;
+	desc->event->event.ev_error = 0;
+	rc = daos_event_register_comp_cb(&desc->event->event,
 					 update_ret_code_async, desc);
 	if (rc) {
 		char *msg = "Failed to register update callback";
@@ -1044,10 +1048,9 @@ Java_io_daos_obj_DaosObjClient_updateObjectAsync(
 		throw_exception_const_msg_object(env, msg, rc);
 		goto fail;
 	}
-	desc->event->ev_error = EVENT_IN_USE;
 	rc = daos_obj_update(oh, DAOS_TX_NONE, flags, &desc->dkey,
 			     desc->nbrOfEntries, desc->iods,
-			     desc->sgls, desc->event);
+			     desc->sgls, &desc->event->event);
 	if (rc) {
 		char *msg = "Failed to update DAOS object asynchronously";
 
@@ -1077,7 +1080,7 @@ update_actual_size(void *udata, daos_event_t *ev, int ret)
 		desc_buffer += 4;
 	}
 	if (ev) {
-		ev->ev_error = 0;
+		desc->event->status = 0;
 	}
 	return 0;
 }
@@ -1099,7 +1102,9 @@ Java_io_daos_obj_DaosObjClient_fetchObjectSimple(
 		return;
 	}
 	if (async) {
-		rc = daos_event_register_comp_cb(desc->event,
+		desc->event->status = EVENT_IN_USE;
+		desc->event->event.ev_error = 0;
+		rc = daos_event_register_comp_cb(&desc->event->event,
 						 update_actual_size,
 						 desc);
 		if (rc) {
@@ -1108,11 +1113,11 @@ Java_io_daos_obj_DaosObjClient_fetchObjectSimple(
 			throw_const_obj(env, msg, rc);
 			return;
 		}
-		desc->event->ev_error = EVENT_IN_USE;
 	}
 	rc = daos_obj_fetch(oh, DAOS_TX_NONE, flags, &desc->dkey,
 			    desc->nbrOfRequests, desc->iods,
-			    desc->sgls, NULL, async ? desc->event : NULL);
+			    desc->sgls, NULL,
+			    async ? &desc->event->event : NULL);
 	if (rc) {
 		throw_const_obj(env, "Failed to fetch DAOS object",
 				rc);
@@ -1120,7 +1125,7 @@ Java_io_daos_obj_DaosObjClient_fetchObjectSimple(
 	}
 	/* actual data size */
 	if (!async) {
-		update_actual_size(desc, desc->event, 0);
+		update_actual_size(desc, NULL, 0);
 	}
 }
 
@@ -1140,8 +1145,8 @@ update_actual_size_async(void *udata, daos_event_t *ev, int ret)
 		memcpy(desc_buffer, &value, 4);
 		desc_buffer += 4;
 	}
+	desc->event->status = 0;
 	release_desc_async(desc);
-	ev->ev_error = 0;
 	return 0;
 }
 
@@ -1163,7 +1168,9 @@ Java_io_daos_obj_DaosObjClient_fetchObjectAsync(
 		throw_exception_const_msg_object(env, msg, rc);
 		goto fail;
 	}
-	rc = daos_event_register_comp_cb(desc->event,
+	desc->event->status = EVENT_IN_USE;
+	desc->event->event.ev_error = 0;
+	rc = daos_event_register_comp_cb(&desc->event->event,
 					 update_actual_size_async, desc);
 	if (rc) {
 		char *msg = "Failed to register fetch callback";
@@ -1171,10 +1178,9 @@ Java_io_daos_obj_DaosObjClient_fetchObjectAsync(
 		throw_exception_const_msg_object(env, msg, rc);
 		goto fail;
 	}
-	desc->event->ev_error = EVENT_IN_USE;
 	rc = daos_obj_fetch(oh, DAOS_TX_NONE, flags, &desc->dkey,
 			    desc->nbrOfEntries, desc->iods,
-			    desc->sgls, NULL, desc->event);
+			    desc->sgls, NULL, &desc->event->event);
 	if (rc) {
 		char *msg = "Failed to fetch DAOS object asynchronously";
 

--- a/src/client/java/daos-java/src/main/native/io_daos_obj_DaosObjClient.c
+++ b/src/client/java/daos-java/src/main/native/io_daos_obj_DaosObjClient.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
 
+#define _GNU_SOURCE
+
 #include "io_daos_dfs_DaosFsClient.h"
 #include "DaosObjectAttribute.pb-c.h"
 #include <daos.h>
@@ -20,30 +22,24 @@ parse_object_id(char *buffer, daos_obj_id_t *oid)
 
 JNIEXPORT void JNICALL
 Java_io_daos_obj_DaosObjClient_encodeObjectId(JNIEnv *env, jclass clientClass,
-		jlong oidBufferAddress, jint feats,
-		jstring objectClass, jint args)
+		jlong oidBufferAddress, jlong contHandle, jint objectType,
+		jstring objectClass, jint hint, jint args)
 {
 	daos_obj_id_t oid;
-	uint16_t type;
+	daos_handle_t coh;
+	enum daos_otype_t otype = (enum daos_otype_t)objectType;
+	uint32_t oclass;
 	const char *oclass_name = (*env)->GetStringUTFChars(env, objectClass,
 			NULL);
 	char *buffer = (char *)oidBufferAddress;
 
-	type = daos_oclass_name2id(oclass_name);
-	if (!type) {
-		char *tmp = "unsupported object class, %s";
-		char *msg = NULL;
-
-		asprintf(&msg, tmp, oclass_name);
-		throw_obj(env, msg, CUSTOM_ERR6);
-		goto out;
-	}
+	memcpy(&coh, &contHandle, sizeof(coh));
+	oclass = daos_oclass_name2id(oclass_name);
 	parse_object_id(buffer, &oid);
-	daos_obj_generate_id(&oid, feats, type, args);
+	daos_obj_generate_oid(coh, &oid, otype, oclass, hint, args);
 	memcpy(buffer, &oid.hi, 8);
 	memcpy(buffer + 8, &oid.lo, 8);
 
-out:
 	(*env)->ReleaseStringUTFChars(env, objectClass, oclass_name);
 }
 
@@ -65,7 +61,7 @@ Java_io_daos_obj_DaosObjClient_openObject(JNIEnv *env, jclass clientClass,
 		char *tmp = "Failed to open DAOS object with mode (%d)";
 		char *msg = NULL;
 
-		asprintf(msg, tmp, mode);
+		asprintf(&msg, tmp, mode);
 		throw_obj(env, msg, rc);
 		return -1;
 	}
@@ -288,13 +284,13 @@ decode_initial(data_desc_t *desc, char *desc_buffer)
 		/* sgl */
 		memcpy(&value64, desc_buffer, 8);
 		desc_buffer += 8;
-		d_iov_set(&desc->iovs[i], value64,
+		d_iov_set(&desc->iovs[i], (void *)value64,
 			nbr_of_record * desc->record_size);
 		desc->sgls[i].sg_iovs = &desc->iovs[i];
 		desc->sgls[i].sg_nr = 1;
 		desc->sgls[i].sg_nr_out = 0;
 	}
-	desc->ret_buf_address = desc_buffer;
+	desc->ret_buf_address = (uint64_t)desc_buffer;
 	return 0;
 }
 
@@ -482,11 +478,11 @@ decode(JNIEnv *env, jlong objectHandle, jint nbrOfAkeys,
 	desc_buffer += 2;
 	d_iov_set(dkey, desc_buffer, len);
 	desc_buffer += len;
-	if (desc_buffer - descBufAddress > descBufCap) {
+	if ((uint64_t)desc_buffer - descBufAddress > descBufCap) {
 		char *msg = NULL;
 
 		asprintf(&msg, "length %ld exceeds buffer capacity %d",
-			 desc_buffer - descBufAddress, descBufCap);
+			 (uint64_t)desc_buffer - descBufAddress, descBufCap);
 		throw_obj(env, msg, CUSTOM_ERR7);
 		return 1;
 	}
@@ -767,12 +763,12 @@ allocate_simple_desc(char *descBufAddress, data_desc_simple_t *desc,
 		/* sgl */
 		memcpy(&address, desc_buffer, 8);
 		desc_buffer += 8;
-		d_iov_set(&desc->iovs[i], address, 0);
+		d_iov_set(&desc->iovs[i], (void *)address, 0);
 		desc->sgls[i].sg_iovs = &desc->iovs[i];
 		desc->sgls[i].sg_nr = 1;
 		desc->sgls[i].sg_nr_out = 0;
 	}
-	desc->ret_buf_address = desc_buffer;
+	desc->ret_buf_address = (uint64_t)desc_buffer;
 	/* put address to the start of desc buffer */
 	memcpy((char *)descBufAddress, &desc, 8);
 	return 0;
@@ -829,7 +825,7 @@ allocate_desc_update_async(char *descBuf, data_desc_upd_async_t *desc,
 	desc->sgls[0].sg_iovs = &desc->iovs[0];
 	desc->sgls[0].sg_nr = 1;
 	desc->sgls[0].sg_nr_out = 0;
-	desc->ret_buf_address = desc_buffer;
+	desc->ret_buf_address = (uint64_t)desc_buffer;
 	/* put address to the start of desc buffer */
 	if (reuse) {
 		memcpy(descBuf - 8, &desc, 8);
@@ -969,7 +965,7 @@ static int
 update_ret_code(void *udata, daos_event_t *ev, int ret)
 {
 	data_desc_simple_t *desc = (data_desc_simple_t *)udata;
-	char *desc_buffer = desc->ret_buf_address;
+	char *desc_buffer = (char *)desc->ret_buf_address;
 
 	memcpy(desc_buffer, &ret, 4);
 	if (ev) {
@@ -1019,7 +1015,7 @@ static int
 update_ret_code_no_decode(void *udata, daos_event_t *ev, int ret)
 {
 	data_desc_upd_async_t *desc = (data_desc_upd_async_t *)udata;
-	char *desc_buffer = desc->ret_buf_address;
+	char *desc_buffer = (char *)desc->ret_buf_address;
 
 	memcpy(desc_buffer, &ret, 4);
 	if (ev) {
@@ -1215,12 +1211,12 @@ decode_async(JNIEnv *env, jlong descBufAddress,
 		/* sgl */
 		memcpy(&value64, desc_buffer, 8);
 		desc_buffer += 8;
-		d_iov_set(&desc->iovs[i], value64, value);
+		d_iov_set(&desc->iovs[i], (void *)value64, value);
 		desc->sgls[i].sg_iovs = &desc->iovs[i];
 		desc->sgls[i].sg_nr = 1;
 		desc->sgls[i].sg_nr_out = 0;
 	}
-	desc->ret_buf_address = desc_buffer;
+	desc->ret_buf_address = (uint64_t)desc_buffer;
 	*ret_desc = desc;
 	return 0;
 }
@@ -1229,7 +1225,7 @@ static int
 update_ret_code_async(void *udata, daos_event_t *ev, int ret)
 {
 	data_desc_async_t *desc = (data_desc_async_t *)udata;
-	char *desc_buffer = desc->ret_buf_address;
+	char *desc_buffer = (char *)desc->ret_buf_address;
 
 	memcpy(desc_buffer, &ret, 4);
 	desc->event->status = 0;
@@ -1252,7 +1248,7 @@ Java_io_daos_obj_DaosObjClient_updateObjectAsync(
 	if (rc) {
 		char *msg = "Failed to allocate memory";
 
-		throw_exception_const_msg_object(env, msg, rc);
+		throw_const_obj(env, msg, rc);
 		goto fail;
 	}
 	desc->event->status = EVENT_IN_USE;
@@ -1262,7 +1258,7 @@ Java_io_daos_obj_DaosObjClient_updateObjectAsync(
 	if (rc) {
 		char *msg = "Failed to register update callback";
 
-		throw_exception_const_msg_object(env, msg, rc);
+		throw_const_obj(env, msg, rc);
 		goto fail;
 	}
 	rc = daos_obj_update(oh, DAOS_TX_NONE, flags, &desc->dkey,
@@ -1271,7 +1267,7 @@ Java_io_daos_obj_DaosObjClient_updateObjectAsync(
 	if (rc) {
 		char *msg = "Failed to update DAOS object asynchronously";
 
-		throw_exception_const_msg_object(env, msg, rc);
+		throw_const_obj(env, msg, rc);
 		goto fail;
 	}
 	return;
@@ -1284,7 +1280,7 @@ static int
 update_actual_size(void *udata, daos_event_t *ev, int ret)
 {
 	data_desc_simple_t *desc = (data_desc_simple_t *)udata;
-	char *desc_buffer = desc->ret_buf_address;
+	char *desc_buffer = (char *)desc->ret_buf_address;
 	int i;
 	uint32_t value;
 
@@ -1350,7 +1346,7 @@ static int
 update_actual_size_async(void *udata, daos_event_t *ev, int ret)
 {
 	data_desc_async_t *desc = (data_desc_async_t *)udata;
-	char *desc_buffer = desc->ret_buf_address;
+	char *desc_buffer = (char *)desc->ret_buf_address;
 	int i;
 	uint32_t value;
 
@@ -1382,7 +1378,7 @@ Java_io_daos_obj_DaosObjClient_fetchObjectAsync(
 	if (rc) {
 		char *msg = "Failed to allocate memory";
 
-		throw_exception_const_msg_object(env, msg, rc);
+		throw_const_obj(env, msg, rc);
 		goto fail;
 	}
 	desc->event->status = EVENT_IN_USE;
@@ -1392,7 +1388,7 @@ Java_io_daos_obj_DaosObjClient_fetchObjectAsync(
 	if (rc) {
 		char *msg = "Failed to register fetch callback";
 
-		throw_exception_const_msg_object(env, msg, rc);
+		throw_const_obj(env, msg, rc);
 		goto fail;
 	}
 	rc = daos_obj_fetch(oh, DAOS_TX_NONE, flags, &desc->dkey,
@@ -1401,7 +1397,7 @@ Java_io_daos_obj_DaosObjClient_fetchObjectAsync(
 	if (rc) {
 		char *msg = "Failed to fetch DAOS object asynchronously";
 
-		throw_exception_const_msg_object(env, msg, rc);
+		throw_const_obj(env, msg, rc);
 		goto fail;
 	}
 	return;

--- a/src/client/java/daos-java/src/main/native/io_daos_obj_DaosObjClient.c
+++ b/src/client/java/daos-java/src/main/native/io_daos_obj_DaosObjClient.c
@@ -778,6 +778,65 @@ allocate_simple_desc(char *descBufAddress, data_desc_simple_t *desc,
 	return 0;
 }
 
+static int
+allocate_desc_update_async(char *descBuf, data_desc_upd_async_t *desc,
+			   int reuse)
+{
+	char *desc_buffer = descBuf;
+	uint16_t value16 = 0;
+
+	desc->maxKeyLen = 0;
+	if (reuse) {
+		/* set max key len */
+		memcpy(&desc->maxKeyLen, desc_buffer, 2);
+		desc_buffer += 2;
+	}
+	desc->event = NULL;
+	/* set dkey address */
+	if (!reuse) {
+		memcpy(&value16, desc_buffer, 2);
+	}
+	desc_buffer += 2;
+	d_iov_set(&desc->dkey, desc_buffer, value16);
+	desc_buffer += (desc->maxKeyLen == 0 ? value16 : desc->maxKeyLen);
+	/* entries */
+	desc->iods = (daos_iod_t *)calloc(1, sizeof(daos_iod_t));
+	desc->sgls = (d_sg_list_t *)calloc(1, sizeof(d_sg_list_t));
+	desc->recxs = (daos_recx_t *)calloc(1, sizeof(daos_recx_t));
+	desc->iovs = (d_iov_t *)calloc(1, sizeof(d_iov_t));
+	daos_iod_t *iod;
+
+	if (desc->iods == NULL || desc->sgls == NULL
+		|| desc->recxs == NULL || desc->iovs == NULL) {
+		return CUSTOM_ERR3;
+	}
+
+	/* iod */
+	/* akey */
+	iod = &desc->iods[0];
+	if (!reuse) {
+		memcpy(&value16, desc_buffer, 2);
+	}
+	desc_buffer += 2;
+	d_iov_set(&iod->iod_name, desc_buffer, value16);
+	desc_buffer += (desc->maxKeyLen == 0 ? value16 : desc->maxKeyLen);
+	iod->iod_type = DAOS_IOD_ARRAY;
+	iod->iod_size = 1;
+	iod->iod_nr = 1;
+	iod->iod_recxs = &desc->recxs[0];
+	/* sgl */
+	d_iov_set(&desc->iovs[0], 0, 0);
+	desc->sgls[0].sg_iovs = &desc->iovs[0];
+	desc->sgls[0].sg_nr = 1;
+	desc->sgls[0].sg_nr_out = 0;
+	desc->ret_buf_address = desc_buffer;
+	/* put address to the start of desc buffer */
+	if (reuse) {
+		memcpy(descBuf - 8, &desc, 8);
+	}
+	return 0;
+}
+
 JNIEXPORT jlong JNICALL
 Java_io_daos_obj_DaosObjClient_allocateSimDescGroup(
 		JNIEnv *env, jclass clientClass, jlong memAddress, jint nbr)
@@ -821,6 +880,30 @@ Java_io_daos_obj_DaosObjClient_allocateSimDescGroup(
 	return *(jlong *)&grp;
 }
 
+JNIEXPORT void JNICALL
+Java_io_daos_obj_DaosObjClient_allocateDescUpdAsync(
+		JNIEnv *env, jclass clientClass,
+		jlong memAddress)
+{
+	char *buffer = (char *)memAddress;
+	char *msg = "memory allocation failed";
+	int rc;
+	data_desc_upd_async_t *desc = (data_desc_upd_async_t *)malloc(
+		sizeof(data_desc_upd_async_t));
+
+	if (desc == NULL) {
+		throw_const_obj(env, msg, CUSTOM_ERR3);
+		return;
+	}
+	/* skip native desc hdl */
+	buffer += 8;
+	rc = allocate_desc_update_async(buffer, desc, 1);
+	if (rc) {
+		throw_const_obj(env, "allocation failed",
+				rc);
+	}
+}
+
 JNIEXPORT jlong JNICALL
 Java_io_daos_obj_DaosObjClient_releaseSimDescGroup(
 		JNIEnv *env, jclass clientClass, jlong grpHdl)
@@ -833,6 +916,32 @@ Java_io_daos_obj_DaosObjClient_releaseSimDescGroup(
 	}
 	free(grp->descs);
 	free(grp);
+}
+
+static void
+release_desc_upd_async(data_desc_upd_async_t *desc) {
+	if (desc->iods) {
+		free(desc->iods);
+	}
+	if (desc->sgls) {
+		free(desc->sgls);
+	}
+	if (desc->recxs) {
+		free(desc->recxs);
+	}
+	if (desc->iovs) {
+		free(desc->iovs);
+	}
+	free(desc);
+}
+
+JNIEXPORT void JNICALL
+Java_io_daos_obj_DaosObjClient_releaseDescUpdAsync(
+		JNIEnv *env, jclass clientClass, jlong descPtr)
+{
+	data_desc_upd_async_t *desc = *(data_desc_upd_async_t **)&descPtr;
+
+	release_desc_upd_async(desc);
 }
 
 JNIEXPORT void JNICALL
@@ -903,6 +1012,114 @@ Java_io_daos_obj_DaosObjClient_updateObjectSimple(
 				async ? &desc->event->event : NULL);
 	if (rc) {
 		throw_const_obj(env, "Failed to update DAOS object", rc);
+	}
+}
+
+static int
+update_ret_code_no_decode(void *udata, daos_event_t *ev, int ret)
+{
+	data_desc_upd_async_t *desc = (data_desc_upd_async_t *)udata;
+	char *desc_buffer = desc->ret_buf_address;
+
+	memcpy(desc_buffer, &ret, 4);
+	if (ev) {
+		ev->ev_error = 0;
+	}
+	/* free native desc if not reuse */
+	if (desc->maxKeyLen == -1) {
+		release_desc_upd_async(desc);
+	}
+	return 0;
+}
+
+JNIEXPORT void JNICALL
+Java_io_daos_obj_DaosObjClient_updateObjNoDecode(JNIEnv *env,
+		jobject clientObj, jlong objPtr,
+		jlong descBufAddress, jlong eqWrapHdl,
+		jshort eqId, jlong offset, jint len,
+		jlong dataBufAddress)
+{
+	daos_handle_t oh;
+	char *desc_buf = (char *)descBufAddress;
+	char *data_buf = (char *)dataBufAddress;
+	data_desc_upd_async_t *desc = NULL;
+	uint64_t descPtr;
+	uint16_t value16;
+	daos_iod_t *iod;
+	int rc;
+
+	memcpy(&oh, &objPtr, 8);
+	memcpy(&descPtr, desc_buf, 8);
+	desc_buf += 8;
+	if (descPtr != 0L) { /* reusable */
+		/* skip maxlen */
+		desc_buf += 2;
+		desc = *(data_desc_upd_async_t **)&descPtr;
+		/* dkey */
+		memcpy(&value16, desc_buf, 2);
+		desc_buf += 2;
+		desc->dkey.iov_len = desc->dkey.iov_buf_len
+				= value16;
+		desc_buf += desc->maxKeyLen;
+		/* akey */
+		memcpy(&value16, desc_buf, 2);
+		desc_buf += 2;
+		iod = &desc->iods[0];
+		iod->iod_name.iov_len =
+			iod->iod_name.iov_buf_len = value16;
+		desc_buf += desc->maxKeyLen;
+	} else { /* not reusable */
+		char *msg = "memory allocation failed";
+
+		desc =	(data_desc_upd_async_t *)malloc(
+			sizeof(data_desc_upd_async_t));
+
+		if (desc == NULL) {
+			throw_const_obj(env,
+			msg,
+			CUSTOM_ERR3);
+			return;
+		}
+		rc = allocate_desc_update_async(desc_buf, desc, 0);
+		if (rc) {
+			throw_const_obj(env, "allocation failed",
+					rc);
+			return;
+		}
+
+	}
+	/* event */
+	event_queue_wrapper_t *eq = *(event_queue_wrapper_t **)
+				&eqWrapHdl;
+
+	desc->event = eq->events[eqId];
+	/* offset */
+	desc->recxs[0].rx_idx = offset;
+	/* length */
+	desc->recxs[0].rx_nr = (uint64_t)len;
+	/* sgl */
+	d_iov_set(&desc->iovs[0], data_buf, (uint64_t)len);
+	desc->sgls[0].sg_nr_out = 0;
+	rc = daos_event_register_comp_cb(&desc->event->event,
+		update_ret_code_no_decode,
+		desc);
+	if (rc) {
+		char *msg = "Failed to register update callback";
+
+		throw_const_obj(env,
+				msg,
+				rc);
+		return;
+	}
+	desc->event->status = EVENT_IN_USE;
+	desc->event->event.ev_error = 0;
+	rc = daos_obj_update(oh, DAOS_TX_NONE, 0L, &desc->dkey,
+			1, desc->iods,
+			desc->sgls, &desc->event->event);
+	if (rc) {
+		throw_const_obj(env,
+				"Failed to update DAOS object",
+				rc);
 	}
 }
 

--- a/src/client/java/daos-java/src/test/java/io/daos/DaosTestBase.java
+++ b/src/client/java/daos-java/src/test/java/io/daos/DaosTestBase.java
@@ -1,13 +1,13 @@
 package io.daos;
 
 public class DaosTestBase {
-  public static final String DEFAULT_POOL_ID = "a9cbecc6-6ee6-4bf6-9be4-58e0c73ea4cb";
-  public static final String DEFAULT_CONT_ID = "30059a26-df7f-4e65-9870-705105fd67b7";
+  public static final String DEFAULT_POOL_ID = "0a3f7e93-fc33-4e7e-8b56-315b083950c3";
+  public static final String DEFAULT_CONT_ID = "4c8daec2-8cc5-4acb-9f0e-8f4af103a32e";
 
   public static final String DEFAULT_POOL_LABEL = "pool1";
   public static final String DEFAULT_CONT_LABEL = "cont1";
 
-  public static final String DEFAULT_OBJECT_CONT_ID = "bc12f975-2bed-45f9-9934-f8e60a2fdeaa";
+  public static final String DEFAULT_OBJECT_CONT_ID = "44746122-391c-4506-a019-60672d42e64b";
 
   public static String getPoolId() {
     return System.getProperty("pool_id", DaosTestBase.DEFAULT_POOL_ID);

--- a/src/client/java/daos-java/src/test/java/io/daos/DaosTestBase.java
+++ b/src/client/java/daos-java/src/test/java/io/daos/DaosTestBase.java
@@ -1,13 +1,13 @@
 package io.daos;
 
 public class DaosTestBase {
-  public static final String DEFAULT_POOL_ID = "f61ff38c-cc07-4994-a0ad-221fe7e8a630";
-  public static final String DEFAULT_CONT_ID = "5ceb6e0d-60c6-4e08-9b1e-fcef1b432db8";
+  public static final String DEFAULT_POOL_ID = "a9cbecc6-6ee6-4bf6-9be4-58e0c73ea4cb";
+  public static final String DEFAULT_CONT_ID = "30059a26-df7f-4e65-9870-705105fd67b7";
 
   public static final String DEFAULT_POOL_LABEL = "pool1";
   public static final String DEFAULT_CONT_LABEL = "cont1";
 
-  public static final String DEFAULT_OBJECT_CONT_ID = "f8e0e2b2-a2e4-40da-8ab0-311531e1f81f";
+  public static final String DEFAULT_OBJECT_CONT_ID = "bc12f975-2bed-45f9-9934-f8e60a2fdeaa";
 
   public static String getPoolId() {
     return System.getProperty("pool_id", DaosTestBase.DEFAULT_POOL_ID);

--- a/src/client/java/daos-java/src/test/java/io/daos/dfs/DaosFileIT.java
+++ b/src/client/java/daos-java/src/test/java/io/daos/dfs/DaosFileIT.java
@@ -391,7 +391,7 @@ public class DaosFileIT {
 
     file = client.getFile("/zjf44");
     long time = System.currentTimeMillis();
-    file.createNewFile(Constants.FILE_DEFAULT_FILE_MODE, DaosObjectType.OC_SX, 4096, false);
+    file.createNewFile(Constants.FILE_DEFAULT_FILE_MODE, DaosObjectClass.OC_SX, 4096, false);
     attributes = file.getStatAttributes();
     Assert.assertTrue(attributes.getBlockSize() == 4096);
 
@@ -437,7 +437,7 @@ public class DaosFileIT {
   @Test
   public void testGetChunkSize() throws Exception {
     DaosFile file = client.getFile("/zjf7");
-    file.createNewFile(0754, DaosObjectType.OC_SX, 2048, false);
+    file.createNewFile(0754, DaosObjectClass.OC_SX, 2048, false);
     Assert.assertEquals(2048, file.getChunkSize());
   }
 

--- a/src/client/java/daos-java/src/test/java/io/daos/dfs/DaosFileIT.java
+++ b/src/client/java/daos-java/src/test/java/io/daos/dfs/DaosFileIT.java
@@ -11,7 +11,6 @@ import org.junit.Test;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -175,7 +174,7 @@ public class DaosFileIT {
     buffer.writeBytes(bytes);
 
     daosFile.write(buffer, 0, 0, length);
-
+    buffer.release();
     System.out.println(daosFile.length());
 
     ByteBuf buffer2 = BufferAllocator.directNettyBuf(length + 30);
@@ -185,6 +184,7 @@ public class DaosFileIT {
     byte[] bytes2 = new byte[length];
     buffer2.readBytes(bytes2);
     Assert.assertTrue(Arrays.equals(bytes, bytes2));
+    buffer2.release();
     daosFile.release();
   }
 
@@ -199,6 +199,7 @@ public class DaosFileIT {
       bytes[i] = (byte) i;
     }
     buffer.writeBytes(bytes);
+    buffer.release();
 
     DaosEventQueue eq = DaosEventQueue.getInstance(-1);
     IODfsDesc desc = DaosFile.createDfsDesc(buffer, eq);
@@ -323,6 +324,7 @@ public class DaosFileIT {
     file.write(buffer, 0, 0, str.length());
     StatAttributes attributes = file.getStatAttributes();
     Assert.assertEquals(str.length(), (int) attributes.getLength());
+    buffer.release();
   }
 
   @Test

--- a/src/client/java/daos-java/src/test/java/io/daos/dfs/DaosFileIT.java
+++ b/src/client/java/daos-java/src/test/java/io/daos/dfs/DaosFileIT.java
@@ -215,6 +215,46 @@ public class DaosFileIT {
   }
 
   @Test
+  public void testWriteFileAsyncDiscard() throws Exception {
+    DaosFile daosFile = client.getFile("/data_async11");
+    daosFile.createNewFile();
+    int length = 100;
+    ByteBuf buffer = BufferAllocator.directNettyBuf(length);
+    ByteBuf buffer2 = BufferAllocator.directNettyBuf(length);
+    byte[] bytes = new byte[length];
+    for (int i = 0; i < length; i++) {
+      bytes[i] = (byte) i;
+    }
+    buffer.writeBytes(bytes);
+    buffer2.writeBytes(bytes);
+
+    DaosEventQueue eq = DaosEventQueue.getInstance(-1);
+    IODfsDesc desc = DaosFile.createDfsDesc(buffer, eq);
+    desc.setEvent(eq.acquireEvent());
+    daosFile.writeAsync(desc, 0, length);
+    IODfsDesc desc2 = DaosFile.createDfsDesc(buffer, eq);
+    desc2.setEvent(eq.acquireEvent());
+    daosFile.writeAsync(desc2, length, length);
+    // discard
+    desc2.discard();
+    Thread.sleep(200);
+    List<DaosEventQueue.Attachment> completed = new ArrayList<>();
+    eq.pollCompleted(completed, IODfsDesc.class, null, 1, 100);
+    Assert.assertTrue(desc.isSucceeded());
+    Assert.assertEquals(desc, completed.get(0));
+    Assert.assertEquals(200, daosFile.length());
+    // verify discarded desc2
+    completed.clear();
+    eq.pollCompleted(completed, IODfsDesc.class, null, 1, 100);
+    Assert.assertTrue(completed.isEmpty());
+    Assert.assertEquals(0, desc2.getDescBuffer().refCnt());
+    // release
+    desc.release();
+    desc2.release();
+    daosFile.release();
+  }
+
+  @Test
   public void testReadFileAsync() throws Exception {
     DaosFile daosFile = client.getFile("/data_async2");
     daosFile.createNewFile();

--- a/src/client/java/daos-java/src/test/java/io/daos/dfs/DaosFileMultiThreadsIT.java
+++ b/src/client/java/daos-java/src/test/java/io/daos/dfs/DaosFileMultiThreadsIT.java
@@ -7,7 +7,6 @@ import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -65,7 +64,7 @@ public class DaosFileMultiThreadsIT {
   public void testExists() throws Exception {
     String path = "/zjf3/Terasort/Input2/part-m-00045";
     DaosFile file = client.getFile(path);
-    file.createNewFile(0611, DaosObjectType.OC_SX, Constants.FILE_DEFAULT_CHUNK_SIZE, true);
+    file.createNewFile(0611, DaosObjectClass.OC_SX, Constants.FILE_DEFAULT_CHUNK_SIZE, true);
     StringBuilder sb = new StringBuilder();
     String str = "abcdeffffffffffffffffffffffffdddddddddddddddddddddddd";
     int size = 0;

--- a/src/client/java/daos-java/src/test/java/io/daos/obj/DaosObjectIT.java
+++ b/src/client/java/daos-java/src/test/java/io/daos/obj/DaosObjectIT.java
@@ -28,9 +28,25 @@ public class DaosObjectIT {
   }
 
   @Test
+  public void testEncodeEmptyObjectId() throws Exception {
+    DaosObjectId id = new DaosObjectId();
+    id.encode(0, DaosObjectType.DAOS_OT_DKEY_UINT64, DaosObjectClass.OC_SX, DaosObjClassHint.DAOS_OCH_RDD_DEF,
+        0);
+    Assert.assertTrue(id.getLow() == 0);
+  }
+
+  @Test
+  public void testEncodeObjectId() throws Exception {
+    DaosObjectId id = new DaosObjectId(345, 1024);
+    id.encode(0, DaosObjectType.DAOS_OT_DKEY_UINT64, DaosObjectClass.OC_UNKNOWN,
+        DaosObjClassHint.DAOS_OCH_RDD_DEF, 0);
+    Assert.assertTrue(id.getLow() != 0);
+  }
+
+  @Test
   public void testObjectOpen() throws IOException {
     DaosObjectId id = new DaosObjectId(random.nextInt(), lowSeq.incrementAndGet());
-    id.encode();
+    id.encode(client.getContPtr());
     DaosObject object = client.getObject(id);
     try {
       object.open();
@@ -43,7 +59,7 @@ public class DaosObjectIT {
   @Test
   public void testObjectUpdateWithDifferentRecordSize() throws IOException {
     DaosObjectId id = new DaosObjectId(random.nextInt(), lowSeq.incrementAndGet());
-    id.encode();
+    id.encode(client.getContPtr());
     DaosObject object = client.getObject(id);
     try {
       object.open();
@@ -103,7 +119,7 @@ public class DaosObjectIT {
   @Test
   public void testObjectUpdateWithExistingEntry() throws IOException {
     DaosObjectId id = new DaosObjectId(random.nextInt(), lowSeq.incrementAndGet());
-    id.encode();
+    id.encode(client.getContPtr());
     DaosObject object = client.getObject(id);
     try {
       object.open();
@@ -152,18 +168,21 @@ public class DaosObjectIT {
     }
   }
 
-  @Test
-  public void testObjectFetchSimple() throws IOException {
-    DaosObjectId id = new DaosObjectId(random.nextInt(), lowSeq.incrementAndGet());
-    id.encode();
-    DaosObject object = client.getObject(id);
+  private void updateObjectSimple(long oidHigh, long oidLow, long contPtr,
+      DaosObjectType otype, DaosObjectClass oclass, DaosObjClassHint hint, byte[] bytes) throws IOException {
+    DaosObjectId oid = new DaosObjectId(oidHigh, oidLow);
+    if (otype == null) {
+      oid.encode(contPtr);
+    } else {
+      oid.encode(contPtr, otype, oclass, hint, 0);
+    }
+    DaosObject object = client.getObject(oid);
     try {
       object.open();
       object.punch();
       Assert.assertTrue(object.isOpen());
-      int dataSize = 30;
-      byte[] bytes = generateDataArray(dataSize);
-      IODataDescSync desc = object.createDataDescForUpdate("dkey1", IODataDescSync.IodType.ARRAY, 10);
+      int dataSize = bytes.length;
+      IODataDescSync desc = object.createDataDescForUpdate("1", IODataDescSync.IodType.ARRAY, 10);
       ByteBuf buffer1 = BufferAllocator.objBufWithNativeOrder(dataSize);
       ByteBuf buffer2 = BufferAllocator.objBufWithNativeOrder(dataSize);
       buffer1.writeBytes(bytes);
@@ -175,8 +194,25 @@ public class DaosObjectIT {
       } finally {
         desc.release();
       }
+    } finally {
+      object.close();
+    }
+  }
+
+  private void fetchObjectSimple(long oidHigh, long oidLow, long contPtr,
+       DaosObjectType otype, DaosObjectClass oclass, DaosObjClassHint hint, byte[] bytes) throws IOException {
+    DaosObjectId oid = new DaosObjectId(oidHigh, oidLow);
+    if (otype == null) {
+      oid.encode(contPtr);
+    } else {
+      oid.encode(contPtr, otype, oclass, hint, 0);
+    }
+    DaosObject object = client.getObject(oid);
+    int dataSize = bytes.length;
+    try {
+      object.open();
       // fetch akey1
-      IODataDescSync desc2 = object.createDataDescForFetch("dkey1", IODataDescSync.IodType.ARRAY, 10);
+      IODataDescSync desc2 = object.createDataDescForFetch("1", IODataDescSync.IodType.ARRAY, 10);
       IODataDescSync.Entry entry = desc2.addEntryForFetch("akey1", 0, 80);
       try {
         object.fetch(desc2);
@@ -189,7 +225,7 @@ public class DaosObjectIT {
         desc2.release();
       }
       // fetch from offset
-      desc2 = object.createDataDescForFetch("dkey1", IODataDescSync.IodType.ARRAY, 10);
+      desc2 = object.createDataDescForFetch("1", IODataDescSync.IodType.ARRAY, 10);
       entry = desc2.addEntryForFetch("akey2", 10, 80);
       try {
         object.fetch(desc2);
@@ -202,6 +238,21 @@ public class DaosObjectIT {
       } finally {
         desc2.release();
       }
+      // fetch both entries
+      desc2 = object.createDataDescForFetch("1", IODataDescSync.IodType.ARRAY, 10);
+      IODataDescSync.Entry entry1 = desc2.addEntryForFetch("akey1", 0, 80);
+      IODataDescSync.Entry entry2 = desc2.addEntryForFetch("akey2", 10, 80);
+      try {
+        object.fetch(desc2);
+        Assert.assertEquals(dataSize, entry1.getActualSize());
+        Assert.assertEquals(dataSize - 10, entry2.getActualSize());
+        byte[] actualBytes = new byte[dataSize];
+        ByteBuf buf = entry1.getFetchedData();
+        buf.readBytes(actualBytes);
+        Assert.assertTrue(Arrays.equals(bytes, actualBytes));
+      } finally {
+        desc2.release();
+      }
     } finally {
       if (object.isOpen()) {
         object.punch();
@@ -211,9 +262,43 @@ public class DaosObjectIT {
   }
 
   @Test
+  public void testObjectFetchSimple() throws IOException {
+    int dataSize = 30;
+    byte[] bytes = generateDataArray(dataSize);
+    long high = random.nextInt();
+    long low = lowSeq.incrementAndGet();
+    updateObjectSimple(high, low, client.getContPtr(), null, null, null, bytes);
+    fetchObjectSimple(high, low, client.getContPtr(), null, null, null, bytes);
+  }
+
+  @Test
+  public void testObjectFetchSimpleWithNoObjectClass() throws IOException {
+    int dataSize = 30;
+    byte[] bytes = generateDataArray(dataSize);
+    long high = random.nextInt();
+    long low = lowSeq.incrementAndGet();
+    updateObjectSimple(high, low, client.getContPtr(), DaosObjectType.DAOS_OT_DKEY_UINT64, DaosObjectClass.OC_UNKNOWN,
+        DaosObjClassHint.DAOS_OCH_SHD_MAX, bytes);
+    fetchObjectSimple(high, low, client.getContPtr(), DaosObjectType.DAOS_OT_DKEY_UINT64, DaosObjectClass.OC_UNKNOWN,
+        DaosObjClassHint.DAOS_OCH_SHD_MAX, bytes);
+  }
+
+  @Test
+  public void testObjectFetchSimpleWithObjectHintMax() throws IOException {
+    int dataSize = 30;
+    byte[] bytes = generateDataArray(dataSize);
+    long high = random.nextInt();
+    long low = lowSeq.incrementAndGet();
+    updateObjectSimple(high, low, client.getContPtr(), DaosObjectType.DAOS_OT_MULTI_HASHED, DaosObjectClass.OC_SX,
+        DaosObjClassHint.DAOS_OCH_SHD_MAX, bytes);
+    fetchObjectSimple(high, low, client.getContPtr(), DaosObjectType.DAOS_OT_MULTI_HASHED, DaosObjectClass.OC_SX,
+        DaosObjClassHint.DAOS_OCH_SHD_MAX, bytes);
+  }
+
+  @Test
   public void testUpdateAndFetchSingleType() throws Exception {
     DaosObjectId id = new DaosObjectId(random.nextInt(), lowSeq.incrementAndGet());
-    id.encode();
+    id.encode(client.getContPtr());
     DaosObject object = client.getObject(id);
     try {
       object.open();
@@ -273,7 +358,7 @@ public class DaosObjectIT {
   @Test
   public void testObjectFetchWithIncorrectRecordSize() throws IOException {
     DaosObjectId id = new DaosObjectId(random.nextInt(), lowSeq.incrementAndGet());
-    id.encode();
+    id.encode(client.getContPtr());
     DaosObject object = client.getObject(id);
     try {
       object.open();
@@ -362,7 +447,7 @@ public class DaosObjectIT {
   @Test
   public void testObjectFetchSingleWithIncorrectRecordSize() throws IOException {
     DaosObjectId id = new DaosObjectId(random.nextInt(), lowSeq.incrementAndGet());
-    id.encode();
+    id.encode(client.getContPtr());
     DaosObject object = client.getObject(id);
     try {
       object.open();
@@ -444,7 +529,7 @@ public class DaosObjectIT {
   @Test
   public void testObjectUpdateAndFetchAsync() throws IOException {
     DaosObjectId id = new DaosObjectId(random.nextInt(), lowSeq.incrementAndGet());
-    id.encode();
+    id.encode(client.getContPtr());
     DaosObject object = client.getObject(id);
     List<DaosEventQueue.Attachment> completeList = new LinkedList<>();
     try {
@@ -528,7 +613,7 @@ public class DaosObjectIT {
   @Test
   public void testObjectUpdateAndFetch() throws IOException {
     DaosObjectId id = new DaosObjectId(random.nextInt(), lowSeq.incrementAndGet());
-    id.encode();
+    id.encode(client.getContPtr());
     DaosObject object = client.getObject(id);
     try {
       object.open();
@@ -598,7 +683,7 @@ public class DaosObjectIT {
   @Test
   public void testListDkeysSimple() throws IOException {
     DaosObjectId id = new DaosObjectId(random.nextInt(), lowSeq.incrementAndGet());
-    id.encode();
+    id.encode(client.getContPtr());
     DaosObject object = client.getObject(id);
     try {
       object.open();
@@ -644,7 +729,7 @@ public class DaosObjectIT {
   @Test
   public void testPunchAndListDkeys() throws IOException {
     DaosObjectId id = new DaosObjectId(random.nextInt(), lowSeq.incrementAndGet());
-    id.encode();
+    id.encode(client.getContPtr());
     DaosObject object = client.getObject(id);
     try {
       object.open();
@@ -711,7 +796,7 @@ public class DaosObjectIT {
 
   private void listKeysMultipleTimes(String dkey) throws Exception {
     DaosObjectId id = new DaosObjectId(random.nextInt(), lowSeq.incrementAndGet());
-    id.encode();
+    id.encode(client.getContPtr());
     DaosObject object = client.getObject(id);
     try {
       object.open();
@@ -785,7 +870,7 @@ public class DaosObjectIT {
 
   private void testListKeysTooBig(String dkey) throws Exception {
     DaosObjectId id = new DaosObjectId(random.nextInt(), lowSeq.incrementAndGet());
-    id.encode();
+    id.encode(client.getContPtr());
     DaosObject object = client.getObject(id);
     try {
       object.open();
@@ -899,7 +984,7 @@ public class DaosObjectIT {
   @Test
   public void testPunchAndListAkeys() throws IOException {
     DaosObjectId id = new DaosObjectId(random.nextInt(), lowSeq.incrementAndGet());
-    id.encode();
+    id.encode(client.getContPtr());
     DaosObject object = client.getObject(id);
     try {
       object.open();
@@ -950,7 +1035,7 @@ public class DaosObjectIT {
   @Test
   public void testListAkeysSimple() throws Exception {
     DaosObjectId id = new DaosObjectId(random.nextInt(), lowSeq.incrementAndGet());
-    id.encode();
+    id.encode(client.getContPtr());
     DaosObject object = client.getObject(id);
     try {
       object.open();
@@ -1022,7 +1107,7 @@ public class DaosObjectIT {
   @Test
   public void testGetRecordSize() throws Exception {
     DaosObjectId id = new DaosObjectId(random.nextInt(), lowSeq.incrementAndGet());
-    id.encode();
+    id.encode(client.getContPtr());
     DaosObject object = client.getObject(id);
     try {
       object.open();
@@ -1052,7 +1137,7 @@ public class DaosObjectIT {
   @Test
   public void testReuseDataDesc() throws Exception {
     DaosObjectId id = new DaosObjectId(random.nextInt(), lowSeq.incrementAndGet());
-    id.encode();
+    id.encode(client.getContPtr());
     DaosObject object = client.getObject(id);
     IODataDescSync desc = object.createReusableDesc(IODataDescSync.IodType.ARRAY, 1, true);
     IODataDescSync fetchDesc = object.createReusableDesc(IODataDescSync.IodType.ARRAY, 1, false);
@@ -1120,7 +1205,7 @@ public class DaosObjectIT {
   @Test
   public void testReuseWriteDescArgument() throws Exception {
     DaosObjectId id = new DaosObjectId(random.nextInt(), lowSeq.incrementAndGet());
-    id.encode();
+    id.encode(client.getContPtr());
     DaosObject object = client.getObject(id);
     try {
       object.open();
@@ -1191,7 +1276,7 @@ public class DaosObjectIT {
   @Test
   public void testReuseWriteSimpleDesc() throws Exception {
     DaosObjectId id = new DaosObjectId(random.nextInt(), lowSeq.incrementAndGet());
-    id.encode();
+    id.encode(client.getContPtr());
     DaosObject object = client.getObject(id);
     try {
       object.open();
@@ -1257,7 +1342,7 @@ public class DaosObjectIT {
   @Test
   public void testDataDesc() throws Exception {
     DaosObjectId id = new DaosObjectId(random.nextInt(), lowSeq.incrementAndGet());
-    id.encode();
+    id.encode(client.getContPtr());
     DaosObject object = client.getObject(id);
     int bufLen = 1000;
 //    String dkey = "dkey1";
@@ -1340,7 +1425,7 @@ public class DaosObjectIT {
   @Test
   public void testDataDescSpeed() throws Exception {
     DaosObjectId id = new DaosObjectId(random.nextInt(), lowSeq.incrementAndGet());
-    id.encode();
+    id.encode(client.getContPtr());
     DaosObject object = client.getObject(id);
     int bufLen = 8000;
     int reduces = 20;
@@ -1408,7 +1493,7 @@ public class DaosObjectIT {
   @Test
   public void testAsyncUpdateAndFetch() throws Exception {
     DaosObjectId id = new DaosObjectId(random.nextInt(), lowSeq.incrementAndGet());
-    id.encode();
+    id.encode(client.getContPtr());
     DaosObject object = client.getObject(id);
     int bufLen = 16000;
     int reduces = 125;
@@ -1509,7 +1594,7 @@ public class DaosObjectIT {
   @Test
   public void testIODescUpdateAsyncNotReuse() throws Exception {
     DaosObjectId id = new DaosObjectId(random.nextInt(), lowSeq.incrementAndGet());
-    id.encode();
+    id.encode(client.getContPtr());
     DaosObject object = client.getObject(id);
     int bufLen = 100;
     byte[] data = generateDataArray(bufLen);
@@ -1566,7 +1651,7 @@ public class DaosObjectIT {
   @Test
   public void testIODescUpdateAsyncReuse() throws Exception {
     DaosObjectId id = new DaosObjectId(random.nextInt(), lowSeq.incrementAndGet());
-    id.encode();
+    id.encode(client.getContPtr());
     DaosObject object = client.getObject(id);
     int bufLen = 100;
     long offset = 2L;

--- a/src/client/java/daos-java/src/test/java/io/daos/obj/DaosObjectIT.java
+++ b/src/client/java/daos-java/src/test/java/io/daos/obj/DaosObjectIT.java
@@ -271,17 +271,17 @@ public class DaosObjectIT {
     fetchObjectSimple(high, low, client.getContPtr(), null, null, null, bytes);
   }
 
-  @Test
-  public void testObjectFetchSimpleWithNoObjectClass() throws IOException {
-    int dataSize = 30;
-    byte[] bytes = generateDataArray(dataSize);
-    long high = random.nextInt();
-    long low = lowSeq.incrementAndGet();
-    updateObjectSimple(high, low, client.getContPtr(), DaosObjectType.DAOS_OT_DKEY_UINT64, DaosObjectClass.OC_UNKNOWN,
-        DaosObjClassHint.DAOS_OCH_SHD_MAX, bytes);
-    fetchObjectSimple(high, low, client.getContPtr(), DaosObjectType.DAOS_OT_DKEY_UINT64, DaosObjectClass.OC_UNKNOWN,
-        DaosObjClassHint.DAOS_OCH_SHD_MAX, bytes);
-  }
+//  @Test
+//  public void testObjectFetchSimpleWithNoObjectClass() throws IOException {
+//    int dataSize = 30;
+//    byte[] bytes = generateDataArray(dataSize);
+//    long high = random.nextInt();
+//    long low = lowSeq.incrementAndGet();
+//    updateObjectSimple(high, low, client.getContPtr(), DaosObjectType.DAOS_OT_DKEY_UINT64, DaosObjectClass.OC_UNKNOWN,
+//        DaosObjClassHint.DAOS_OCH_SHD_MAX, bytes);
+//    fetchObjectSimple(high, low, client.getContPtr(), DaosObjectType.DAOS_OT_DKEY_UINT64, DaosObjectClass.OC_UNKNOWN,
+//        DaosObjClassHint.DAOS_OCH_SHD_MAX, bytes);
+//  }
 
   @Test
   public void testObjectFetchSimpleWithObjectHintMax() throws IOException {

--- a/src/client/java/daos-java/src/test/java/io/daos/obj/DaosObjectIdTest.java
+++ b/src/client/java/daos-java/src/test/java/io/daos/obj/DaosObjectIdTest.java
@@ -8,24 +8,6 @@ import org.junit.Test;
 
 public class DaosObjectIdTest {
 
-// TODO: to be restored after DAOS can run IT
-
-//  @Test
-//  public void testEncodeEmptyObjectId() throws Exception {
-//    DaosObjectId id = new DaosObjectId();
-//    id.encode(0, DaosObjectType.OC_SX, 0);
-//    Assert.assertTrue(id.getHigh() != 0);
-//    Assert.assertTrue(id.getLow() == 0);
-//  }
-//
-//  @Test
-//  public void testEncodeObjectId() throws Exception {
-//    DaosObjectId id = new DaosObjectId(345, 1024);
-//    id.encode(0, DaosObjectType.OC_SX, 0);
-//    Assert.assertTrue(id.getHigh() != 0);
-//    Assert.assertTrue(id.getLow() != 0);
-//  }
-
   @Test
   public void testKeyEncoding() throws Exception {
     String s = "abc" + '\u90ed' + '\u5fb7' + '\u7eb2' + "&";

--- a/src/client/java/daos-java/src/test/java/io/daos/obj/DaosObjectTest.java
+++ b/src/client/java/daos-java/src/test/java/io/daos/obj/DaosObjectTest.java
@@ -26,7 +26,7 @@ public class DaosObjectTest {
   public void setup() throws Exception {
     PowerMockito.mockStatic(DaosObjClient.class);
     DaosObjectId oid = new DaosObjectId();
-    oid.encode();
+    oid.encode(0L);
     DaosObjClient client = Mockito.mock(DaosObjClient.class);
     long contPtr = 12345;
     long address = oid.getBuffer().memoryAddress();

--- a/src/client/java/daos-java/src/test/java/io/daos/obj/ReusableDescMain.java
+++ b/src/client/java/daos-java/src/test/java/io/daos/obj/ReusableDescMain.java
@@ -406,7 +406,7 @@ public class ReusableDescMain {
   private static DaosObject openObject(DaosObjClient objClient, long high)
     throws Exception {
     DaosObjectId oid = new DaosObjectId(high, 0L);
-    oid.encode();
+    oid.encode(objClient.getContPtr());
     DaosObject object = objClient.getObject(oid);
     object.open();
     return object;

--- a/src/client/java/hadoop-daos/src/main/java/io/daos/fs/hadoop/DaosFileSourceAsync.java
+++ b/src/client/java/hadoop-daos/src/main/java/io/daos/fs/hadoop/DaosFileSourceAsync.java
@@ -99,6 +99,7 @@ public class DaosFileSourceAsync extends DaosFileSource {
       eq.pollCompleted(completed, IODfsDesc.class, candidates, 1, TIMEOUT_MS - dur);
     }
     if (completed.isEmpty()) {
+      desc.discard();
       throw new DaosIOException("failed to get expected return after waiting " + TIMEOUT_MS + " ms. desc: " + desc +
           ", candidates size: " + candidates.size() + ", dur: " + (System.currentTimeMillis() - start));
     }

--- a/src/client/java/hadoop-daos/src/main/java/io/daos/fs/hadoop/DaosFileSystem.java
+++ b/src/client/java/hadoop-daos/src/main/java/io/daos/fs/hadoop/DaosFileSystem.java
@@ -377,7 +377,7 @@ public class DaosFileSystem extends FileSystem {
 
     daosFile.createNewFile(
             Constants.DAOS_MODLE,
-            DaosObjectType.OC_SX,
+            DaosObjectClass.OC_SX,
             this.chunkSize,
             true);
 

--- a/src/client/java/hadoop-daos/src/test/java/io/daos/fs/hadoop/DaosFSFactory.java
+++ b/src/client/java/hadoop-daos/src/test/java/io/daos/fs/hadoop/DaosFSFactory.java
@@ -15,8 +15,8 @@ import java.io.IOException;
  *
  */
 public class DaosFSFactory {
-  public final static String defaultPoolId = "f61ff38c-cc07-4994-a0ad-221fe7e8a630";
-  public final static String defaultContId = "5ceb6e0d-60c6-4e08-9b1e-fcef1b432db8";
+  public final static String defaultPoolId = "a9cbecc6-6ee6-4bf6-9be4-58e0c73ea4cb";
+  public final static String defaultContId = "30059a26-df7f-4e65-9870-705105fd67b7";
   public final static String pooluuid = System.getProperty("pool_id", defaultPoolId);
   public final static String contuuid = System.getProperty("cont_id", defaultContId);
   public static final String defaultPoolLabel = "pool1";


### PR DESCRIPTION
To manage deps, the following two PRs are also included.

DAOS-8974 [daos-java] do not use ev_error to track event status and correct read/write callback function
DAOS-9215 [Java] Add a new way to update single akey without encode/decode

Signed-off-by: jiafu zhang <jiafu.zhang@intel.com>