### PR TITLE
DAOS-10045 dtx: not cleanup old DTX entry with leader on current target

### DIFF
--- a/src/dtx/dtx_common.c
+++ b/src/dtx/dtx_common.c
@@ -202,6 +202,10 @@ dtx_cleanup_stale_iter_cb(uuid_t co_uuid, vos_iter_entry_t *ent, void *args)
 
 	D_ASSERT(!(ent->ie_dtx_flags & DTE_INVALID));
 
+	/* Skip the DTX entry which leader resides on current target and may be still alive. */
+	if (ent->ie_dtx_flags & DTE_LEADER)
+		return 0;
+
 	/* Skip corrupted entry that will be handled via other special tool. */
 	if (ent->ie_dtx_flags & DTE_CORRUPTED)
 		return 0;


### PR DESCRIPTION
The DTX cleanup ULT cannot know whether current DTX leader is still alive
or not. There is race case that the DTX leader is blocked because of some
non-leader(s) no-respond (down/crashed) then the DTX cleanup ULT may make
wrong decision to commit the DTX, but the DTX leader would abort such DTX
after related IO RPC to the bad non-leader(s) timeout.

Signed-off-by: Fan Yong <fan.yong@intel.com>