### PR TITLE
DAOS-9725 csum: Eliminate potential race condition for fetch

### DIFF
--- a/src/common/checksum.c
+++ b/src/common/checksum.c
@@ -125,7 +125,8 @@ daos_csummer_copy(const struct daos_csummer *obj)
 	return result;
 }
 
-void daos_csummer_destroy(struct daos_csummer **obj)
+void
+daos_csummer_destroy(struct daos_csummer **obj)
 {
 	struct daos_csummer *csummer = *obj;
 
@@ -137,6 +138,36 @@ void daos_csummer_destroy(struct daos_csummer **obj)
 	D_MUTEX_DESTROY(&csummer->dcs_lock);
 	D_FREE(csummer);
 	*obj = NULL;
+}
+
+int
+daos_csummer_copy_inplace(struct daos_csummer *dst, struct daos_csummer *src)
+{
+	int rc = 0;
+
+	dst->dcs_algo = src->dcs_algo;
+	dst->dcs_chunk_size = src->dcs_chunk_size;
+	dst->dcs_srv_verify = src->dcs_srv_verify;
+	dst->dcs_skip_key_calc = src->dcs_skip_key_calc;
+	dst->dcs_skip_key_verify = src->dcs_skip_key_verify;
+	dst->dcs_skip_data_verify = src->dcs_skip_data_verify;
+
+	if (dst->dcs_algo->cf_init)
+		rc = dst->dcs_algo->cf_init(&dst->dcs_ctx);
+	D_MUTEX_INIT(&dst->dcs_lock, NULL);
+
+	return rc;
+}
+
+void
+daos_csummer_destroy_in_place(struct daos_csummer *obj)
+{
+	if (!obj)
+		return;
+
+	if (obj->dcs_algo->cf_destroy)
+		obj->dcs_algo->cf_destroy(obj->dcs_ctx);
+	D_MUTEX_DESTROY(&obj->dcs_lock);
 }
 
 uint16_t

--- a/src/include/daos/checksum.h
+++ b/src/include/daos/checksum.h
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2019-2021 Intel Corporation.
+ * (C) Copyright 2019-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -187,6 +187,12 @@ daos_csummer_copy(const struct daos_csummer *obj);
 /** Destroy the daos_csummer */
 void
 daos_csummer_destroy(struct daos_csummer **obj);
+
+/* Copy a csummer without allocating memory for the csummer from the heap */
+int daos_csummer_copy_inplace(struct daos_csummer *dst, struct daos_csummer *src);
+
+/* Destroy a csummer that was copied 'inplace' */
+void daos_csummer_destroy_in_place(struct daos_csummer *obj);
 
 /** Get the checksum length from the configured csummer. */
 uint16_t

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -1512,9 +1512,8 @@ obj_local_rw_internal(crt_rpc_t *rpc, struct obj_io_context *ioc,
 			struct daos_csummer csummer = {0};
 
 			rc = daos_csummer_copy_inplace(&csummer, ioc->ioc_coc->sc_csummer);
-
 			if (rc != 0) {
-				rc = -DER_NOMEM;
+				D_ERROR("csummer_copy_inplace failed: "DF_RC"\n", DP_RC(rc));
 				goto post;
 			}
 			rc = csum_add2iods(ioh,

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -1509,19 +1509,21 @@ obj_local_rw_internal(crt_rpc_t *rpc, struct obj_io_context *ioc,
 
 		if (ioc->ioc_coc->sc_props.dcp_csum_enabled &&
 		    daos_csummer_initialized(ioc->ioc_coc->sc_csummer)) {
-			struct daos_csummer *csummer = daos_csummer_copy(ioc->ioc_coc->sc_csummer);
+			struct daos_csummer csummer = {0};
 
-			if (csummer == NULL) {
+			rc = daos_csummer_copy_inplace(&csummer, ioc->ioc_coc->sc_csummer);
+
+			if (rc != 0) {
 				rc = -DER_NOMEM;
 				goto post;
 			}
 			rc = csum_add2iods(ioh,
 					   orw->orw_iod_array.oia_iods,
 					   orw->orw_iod_array.oia_iod_nr,
-					   csummer,
+					   &csummer,
 					   orwo->orw_iod_csums.ca_arrays,
 					   orw->orw_oid, &orw->orw_dkey);
-			daos_csummer_destroy(&csummer);
+			daos_csummer_destroy_in_place(&csummer);
 			if (rc) {
 				D_ERROR(DF_UOID" fetch verify failed: %d.\n",
 					DP_UOID(orw->orw_oid), rc);


### PR DESCRIPTION
The csummer has the same memory buffer to calculate checksums for
an entire container which can be subject to race conditions. This
patch updates the server csum fetch functionality to use
a copied csummer. A similar approach has already been taken
on the client.

Signed-off-by: Ryon Jensen <ryon.jensen@intel.com>