### PR TITLE
DAOS-9756 vos: Offload object/key punch aggregation to gc (#8236)

### DIFF
--- a/src/vos/tests/vts_aggregate.c
+++ b/src/vos/tests/vts_aggregate.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2019-2021 Intel Corporation.
+ * (C) Copyright 2019-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -1247,6 +1247,11 @@ agg_punches_test(void **state, int record_type, bool discard)
 			}
 		}
 	}
+	/** cleanup() sets the flag to assert if there are items in container garbage collection
+	 *  heap which will always be the case for these punch tests.  So let's run garbage
+	 *  collection before cleanup in this case.
+	 */
+	gc_wait();
 }
 static void
 discard_14(void **state)

--- a/src/vos/vos_ilog.c
+++ b/src/vos/vos_ilog.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2019-2021 Intel Corporation.
+ * (C) Copyright 2019-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -129,13 +129,13 @@ vos_ilog_punch_covered(const struct ilog_entry *entry,
 }
 
 static int
-vos_parse_ilog(struct vos_ilog_info *info, daos_epoch_t epoch,
+vos_parse_ilog(struct vos_ilog_info *info, const daos_epoch_range_t *epr,
 	       daos_epoch_t bound, const struct vos_punch_record *punch) {
 	struct ilog_entry	entry;
 	struct vos_punch_record	*any_punch = &info->ii_prior_any_punch;
 	daos_epoch_t		 entry_epc;
 
-	D_ASSERT(punch->pr_epc <= epoch);
+	D_ASSERT(punch->pr_epc <= epr->epr_hi);
 
 	ilog_foreach_entry_reverse(&info->ii_entries, &entry) {
 		if (entry.ie_status == ILOG_REMOVED)
@@ -155,7 +155,14 @@ vos_parse_ilog(struct vos_ilog_info *info, daos_epoch_t epoch,
 		}
 
 		entry_epc = entry.ie_id.id_epoch;
-		if (entry_epc > epoch) {
+		if (entry_epc > epr->epr_hi) {
+			info->ii_full_scan = false;
+			if (epr->epr_lo != 0) {
+				/** If this is non-zero, we know this is used for punch check */
+				D_DEBUG(DB_TRACE, "Detected ilog entries outside epoch range "
+					DF_X64"-"DF_X64"\n", epr->epr_lo, epr->epr_hi);
+				return 0;
+			}
 			if (ilog_has_punch(&entry)) {
 				/** Entry is punched within uncertainty range,
 				 * so restart the transaction.
@@ -216,6 +223,21 @@ vos_parse_ilog(struct vos_ilog_info *info, daos_epoch_t epoch,
 		info->ii_create = entry.ie_id.id_epoch;
 	}
 
+	if (epr->epr_lo != 0) {
+		ilog_foreach_entry(&info->ii_entries, &entry) {
+			if (entry.ie_id.id_epoch >= epr->epr_lo)
+				break;
+
+			if (entry.ie_status == ILOG_REMOVED)
+				continue;
+
+			info->ii_full_scan = false;
+			D_DEBUG(DB_TRACE, "Detected ilog entries outside epoch range "DF_X64"-"
+				DF_X64"\n", epr->epr_lo, epr->epr_hi);
+			return 0;
+		}
+	}
+
 	if (vos_epc_punched(info->ii_prior_punch.pr_epc,
 			    info->ii_prior_punch.pr_minor_epc,
 			    punch))
@@ -226,18 +248,18 @@ vos_parse_ilog(struct vos_ilog_info *info, daos_epoch_t epoch,
 		info->ii_prior_any_punch = *punch;
 
 	D_DEBUG(DB_TRACE, "After fetch at "DF_X64": create="DF_X64
-		" prior_punch="DF_PUNCH" next_punch="DF_X64"%s\n", epoch,
+		" prior_punch="DF_PUNCH" next_punch="DF_X64"%s\n", epr->epr_hi,
 		info->ii_create, DP_PUNCH(&info->ii_prior_punch),
 		info->ii_next_punch, info->ii_empty ? " is empty" : "");
 
 	return 0;
 }
 
-int
-vos_ilog_fetch_(struct umem_instance *umm, daos_handle_t coh, uint32_t intent,
-		struct ilog_df *ilog, daos_epoch_t epoch, daos_epoch_t bound,
-		const struct vos_punch_record *punched,
-		const struct vos_ilog_info *parent, struct vos_ilog_info *info)
+static int
+vos_ilog_fetch_internal(struct umem_instance *umm, daos_handle_t coh, uint32_t intent,
+			struct ilog_df *ilog, const daos_epoch_range_t *epr, daos_epoch_t bound,
+			const struct vos_punch_record *punched, const struct vos_ilog_info *parent,
+			struct vos_ilog_info *info)
 {
 	struct ilog_desc_cbs	 cbs;
 	struct vos_punch_record	 punch = {0};
@@ -256,6 +278,7 @@ vos_ilog_fetch_(struct umem_instance *umm, daos_handle_t coh, uint32_t intent,
 init:
 	info->ii_uncommitted = 0;
 	info->ii_create = 0;
+	info->ii_full_scan = true;
 	info->ii_next_punch = 0;
 	info->ii_uncertain_create = 0;
 	info->ii_empty = true;
@@ -272,9 +295,22 @@ init:
 	}
 
 	if (rc == 0)
-		rc = vos_parse_ilog(info, epoch, bound, &punch);
+		rc = vos_parse_ilog(info, epr, bound, &punch);
 
 	return rc;
+}
+
+int
+vos_ilog_fetch_(struct umem_instance *umm, daos_handle_t coh, uint32_t intent, struct ilog_df *ilog,
+		daos_epoch_t epoch, daos_epoch_t bound, const struct vos_punch_record *punched,
+		const struct vos_ilog_info *parent, struct vos_ilog_info *info)
+{
+	daos_epoch_range_t epr;
+
+	epr.epr_lo = 0;
+	epr.epr_hi = epoch;
+
+	return vos_ilog_fetch_internal(umm, coh, intent, ilog, &epr, bound, punched, parent, info);
 }
 
 int
@@ -533,6 +569,27 @@ vos_ilog_aggregate(daos_handle_t coh, struct ilog_df *ilog, const daos_epoch_ran
 
 	return vos_ilog_fetch(umm, coh, DAOS_INTENT_PURGE, ilog, epr->epr_hi, 0,
 			      &punch_rec, NULL, info);
+}
+
+bool
+vos_ilog_is_punched(daos_handle_t coh, struct ilog_df *ilog, const daos_epoch_range_t *epr,
+		    const struct vos_punch_record *parent_punch, struct vos_ilog_info *info)
+{
+	struct vos_container	*cont = vos_hdl2cont(coh);
+	struct umem_instance	*umm = vos_cont2umm(cont);
+	struct vos_punch_record	 punch_rec = {0, 0};
+	int			 rc;
+
+	if (parent_punch)
+		punch_rec = *parent_punch;
+
+	rc = vos_ilog_fetch_internal(umm, coh, DAOS_INTENT_PURGE, ilog, epr, 0, &punch_rec, NULL,
+				     info);
+
+	if (rc != 0 || !info->ii_full_scan || info->ii_create != 0)
+		return false;
+
+	return true;
 }
 
 void

--- a/src/vos/vos_ilog.h
+++ b/src/vos/vos_ilog.h
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2019-2021 Intel Corporation.
+ * (C) Copyright 2019-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -64,6 +64,8 @@ struct vos_ilog_info {
 	daos_epoch_t		 ii_uncertain_create;
 	/** The entity has no valid log entries */
 	bool			 ii_empty;
+	/** All data is contained within specified epoch range */
+	bool			 ii_full_scan;
 };
 
 /** Initialize the incarnation log globals */
@@ -205,6 +207,21 @@ int
 vos_ilog_aggregate(daos_handle_t coh, struct ilog_df *ilog, const daos_epoch_range_t *epr,
 		   bool discard, bool inprogress, const struct vos_punch_record *parent_punch,
 		   struct vos_ilog_info *info);
+
+/** Check if the ilog can be discarded.  This will only return true if the ilog is punched at the
+ *  specified epoch and there are no creation stamps outside of the range
+ *
+ * \param	coh[IN]		container handle
+ * \param	ilog[IN]	Incarnation log
+ * \param	epr[IN]		Aggregation range
+ * \param	punched[IN]	Highest epoch where parent is punched
+ * \param	info[IN]	Incarnation log info
+ *
+ * \return	true if fully punched, false otherwise
+ */
+bool
+vos_ilog_is_punched(daos_handle_t coh, struct ilog_df *ilog, const daos_epoch_range_t *epr,
+		    const struct vos_punch_record *parent_punch, struct vos_ilog_info *info);
 
 /* #define ILOG_TRACE */
 #ifdef ILOG_TRACE

--- a/src/vos/vos_internal.h
+++ b/src/vos/vos_internal.h
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2021 Intel Corporation.
+ * (C) Copyright 2016-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -1098,6 +1098,18 @@ vos_gc_pool_tight(daos_handle_t poh, int *credits);
 void
 gc_reserve_space(daos_size_t *rsrvd);
 
+/**
+ * If the object is fully punched, bypass normal aggregation and move it to container
+ * discard pool
+ *
+ * \param ih[IN]	Iterator handle
+ *
+ * \return		Zero on Success
+ *			Positive value if a reprobe is needed
+ *			Negative value otherwise
+ */
+int
+oi_iter_pre_aggregate(daos_handle_t ih);
 
 /**
  * Aggregate the creation/punch records in the current entry of the object
@@ -1113,6 +1125,19 @@ gc_reserve_space(daos_size_t *rsrvd);
  */
 int
 oi_iter_aggregate(daos_handle_t ih, bool range_discard);
+
+/**
+ * If the key is fully punched, bypass normal aggregation and move it to container
+ * discard pool
+ *
+ * \param ih[IN]	Iterator handle
+ *
+ * \return		Zero on Success
+ *			Positive value if a reprobe is needed
+ *			Negative value otherwise
+ */
+int
+vos_obj_iter_pre_aggregate(daos_handle_t ih);
 
 /**
  * Aggregate the creation/punch records in the current entry of the key

--- a/src/vos/vos_obj.c
+++ b/src/vos/vos_obj.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2021 Intel Corporation.
+ * (C) Copyright 2016-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -1893,6 +1893,55 @@ exit:
 	return rc;
 }
 
+int
+vos_obj_iter_pre_aggregate(daos_handle_t ih)
+{
+	struct vos_iterator	*iter = vos_hdl2iter(ih);
+	struct vos_obj_iter	*oiter = vos_iter2oiter(iter);
+	struct umem_instance	*umm;
+	struct vos_krec_df	*krec;
+	struct vos_object	*obj;
+	daos_key_t		 key;
+	struct vos_rec_bundle	 rbund;
+	int			 rc;
+
+	D_ASSERTF(iter->it_type == VOS_ITER_AKEY ||
+		  iter->it_type == VOS_ITER_DKEY,
+		  "Aggregation only supported on keys\n");
+
+	rc = key_iter_fetch_helper(oiter, &rbund, &key, NULL);
+	D_ASSERTF(rc != -DER_NONEXIST,
+		  "Iterator should probe before aggregation\n");
+	if (rc != 0)
+		return rc;
+
+	obj = oiter->it_obj;
+	krec = rbund.rb_krec;
+	umm = vos_obj2umm(oiter->it_obj);
+
+	if (!vos_ilog_is_punched(vos_cont2hdl(obj->obj_cont), &krec->kr_ilog, &oiter->it_epr,
+				 &oiter->it_punched, &oiter->it_ilog_info))
+		return 0;
+
+	/** Ok, ilog is fully punched, so we can move it to gc heap */
+	rc = umem_tx_begin(umm, NULL);
+	if (rc != 0)
+		goto exit;
+
+	/* Incarnation log is empty, delete the object */
+	D_DEBUG(DB_IO, "Moving %s to gc heap\n",
+		iter->it_type == VOS_ITER_DKEY ? "dkey" : "akey");
+
+	rc = dbtree_iter_delete(oiter->it_hdl, obj->obj_cont);
+	D_ASSERT(rc != -DER_NONEXIST);
+
+	rc = umem_tx_end(umm, rc);
+exit:
+	if (rc == 0)
+		return 1;
+
+	return rc;
+}
 int
 vos_obj_iter_aggregate(daos_handle_t ih, bool range_discard)
 {

--- a/src/vos/vos_obj_index.c
+++ b/src/vos/vos_obj_index.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2021 Intel Corporation.
+ * (C) Copyright 2016-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -645,6 +645,57 @@ oi_iter_delete(struct vos_iterator *iter, void *args)
 	if (rc != 0)
 		D_ERROR("Failed to delete oid entry: "DF_RC"\n", DP_RC(rc));
 exit:
+	return rc;
+}
+
+int
+oi_iter_pre_aggregate(daos_handle_t ih)
+{
+	struct vos_iterator	*iter = vos_hdl2iter(ih);
+	struct vos_oi_iter	*oiter = iter2oiter(iter);
+	struct vos_obj_df	*obj;
+	daos_unit_oid_t		 oid;
+	d_iov_t			 rec_iov;
+	int			 rc;
+
+	D_ASSERT(iter->it_type == VOS_ITER_OBJ);
+
+	d_iov_set(&rec_iov, NULL, 0);
+	rc = dbtree_iter_fetch(oiter->oit_hdl, NULL, &rec_iov, NULL);
+	D_ASSERTF(rc != -DER_NONEXIST,
+		  "Probe should be done before aggregation\n");
+	if (rc != 0)
+		return rc;
+	D_ASSERT(rec_iov.iov_len == sizeof(struct vos_obj_df));
+	obj = (struct vos_obj_df *)rec_iov.iov_buf;
+	oid = obj->vo_id;
+
+	if (!vos_ilog_is_punched(vos_cont2hdl(oiter->oit_cont), &obj->vo_ilog, &oiter->oit_epr,
+				 NULL, &oiter->oit_ilog_info))
+		return 0;
+
+	/** Ok, ilog is fully punched, so we can move it to gc heap */
+	rc = umem_tx_begin(vos_cont2umm(oiter->oit_cont), NULL);
+	if (rc != 0)
+		goto exit;
+
+	/* Incarnation log is empty, delete the object */
+	D_DEBUG(DB_IO, "Moving object "DF_UOID" to gc heap\n",
+		DP_UOID(oid));
+	/* Evict the object from cache */
+	rc = vos_obj_evict_by_oid(vos_obj_cache_current(),
+				  oiter->oit_cont, oid);
+	if (rc != 0)
+		D_ERROR("Could not evict object "DF_UOID" "DF_RC"\n",
+			DP_UOID(oid), DP_RC(rc));
+	rc = dbtree_iter_delete(oiter->oit_hdl, oiter->oit_cont);
+	D_ASSERT(rc != -DER_NONEXIST);
+
+	rc = umem_tx_end(vos_cont2umm(oiter->oit_cont), rc);
+exit:
+	if (rc == 0)
+		return 1;
+
 	return rc;
 }
 


### PR DESCRIPTION
Where possible, offload the punch aggregation of object and
key subtrees to garbage collection.   If an object or key is
punched in the specified range and not visible outside of
that range, we can avoid scanning it for aggregation and just
put it in the container garbage collection heap.

Skipped the vos_perf changes as the branches have diverged

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>