### PR TITLE
DAOS-10050 control: Scan all net providers in config gen

### DIFF
--- a/src/control/lib/control/auto.go
+++ b/src/control/lib/control/auto.go
@@ -127,7 +127,9 @@ func ConfigGenerate(ctx context.Context, req ConfigGenerateReq) (*ConfigGenerate
 //
 // Return host errors, network scan results for the host set or error.
 func getNetworkSet(ctx context.Context, log logging.Logger, hostList []string, client UnaryInvoker) (*HostFabricSet, error) {
-	scanReq := new(NetworkScanReq)
+	scanReq := &NetworkScanReq{
+		Provider: "all", // explicitly request all providers
+	}
 	scanReq.SetHostList(hostList)
 
 	scanResp, err := NetworkScan(ctx, client, scanReq)


### PR DESCRIPTION
In the unusual case where the server already had a configuration,
the network scan during config generate was limited to the
provider already configured. This led to confusing results.

Features: control

Signed-off-by: Kris Jacque <kristin.jacque@intel.com>