### PR TITLE
DAOS-9994 test: Updating detect() method with missing distros (#8342)

### DIFF
--- a/src/tests/ftest/launch.py
+++ b/src/tests/ftest/launch.py
@@ -30,8 +30,6 @@ ET.Element = Element
 ET.SubElement = SubElement
 ET.tostring = tostring
 
-
-from avocado.utils.distro import detect
 from ClusterShell.NodeSet import NodeSet
 from ClusterShell.Task import task_self
 
@@ -1723,6 +1721,8 @@ def install_debuginfos():
         on this node also.
 
     """
+    from distro_utils import detect     # pylint: disable=import-outside-toplevel
+
     distro_info = detect()
     install_pkgs = [{'name': 'gdb'}]
     if "centos" in distro_info.name.lower():
@@ -1754,19 +1754,16 @@ def install_debuginfos():
         if os.getenv("TEST_RPMS", 'false') == 'true':
             if "suse" in distro_info.name.lower():
                 dnf_args.extend(["libpmemobj1", "python3", "openmpi3"])
-            elif "centos" in distro_info.name.lower() and \
-                 distro_info.version == "7":
+            elif "centos" in distro_info.name.lower() and distro_info.version == "7":
                 dnf_args.extend(["--enablerepo=*-debuginfo", "--exclude",
                                  "nvml-debuginfo", "libpmemobj",
                                  "python36", "openmpi3", "gcc"])
-            elif "centos" in distro_info.name.lower() and \
-                 distro_info.version == "8":
+            elif "centos" in distro_info.name.lower() and distro_info.version == "8":
                 dnf_args.extend(["--enablerepo=*-debuginfo", "libpmemobj",
                                  "python3", "openmpi", "gcc"])
             else:
                 raise RuntimeError(
-                    "install_debuginfos(): Unsupported distro: {}".format(
-                        distro_info))
+                    "install_debuginfos(): Unsupported distro: {}".format(distro_info))
             cmds.append(["sudo", "dnf", "-y", "install"] + dnf_args)
         rpm_version = get_output(["rpm", "-q", "--qf", "%{evr}", "daos"], check=False)
         cmds.append(

--- a/src/tests/ftest/util/apricot/apricot/test.py
+++ b/src/tests/ftest/util/apricot/apricot/test.py
@@ -13,7 +13,7 @@ import re
 
 from avocado import Test as avocadoTest
 from avocado import skip, TestFail, fail_on
-from avocado.utils.distro import detect
+from distro_utils import detect
 from avocado.core import exceptions
 from ast import literal_eval
 from ClusterShell.NodeSet import NodeSet

--- a/src/tests/ftest/util/distro_utils.py
+++ b/src/tests/ftest/util/distro_utils.py
@@ -1,0 +1,30 @@
+#!/usr/bin/python
+"""
+(C) Copyright 2022 Intel Corporation.
+
+SPDX-License-Identifier: BSD-2-Clause-Patent
+"""
+from avocado.utils.distro import *      # pylint: disable=wildcard-import
+import re
+
+
+class RockyProbe(Probe):
+    """Probe with version checks for Rocky Linux systems."""
+
+    CHECK_FILE = "/etc/rocky-release"
+    CHECK_FILE_CONTAINS = "Rocky Linux"
+    CHECK_FILE_DISTRO_NAME = "rocky"
+    CHECK_VERSION_REGEX = re.compile(r"Rocky Linux release (\d{1,2})\.(\d{1,2}).*")
+
+
+class AlmaProbe(Probe):
+    """Probe with version checks for AlmaLinux systems."""
+
+    CHECK_FILE = "/etc/almalinux-release"
+    CHECK_FILE_CONTAINS = "AlmaLinux"
+    CHECK_FILE_DISTRO_NAME = "alma"
+    CHECK_VERSION_REGEX = re.compile(r"AlmaLinux release (\d{1,2})\.(\d{1,2}).*")
+
+
+register_probe(RockyProbe)
+register_probe(AlmaProbe)


### PR DESCRIPTION
Adding support for Rocky Linux and AlmaLinux to the avocado.utils.distro method.

Signed-off-by: Phillip Henderson <phillip.henderson@intel.com>