### PR TITLE
DAOS-10068 java: Bump Hadoop to 3.3.2

### DIFF
--- a/src/client/java/daos-java/pom.xml
+++ b/src/client/java/daos-java/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>io.daos</groupId>
     <artifactId>daos-java-root</artifactId>
-    <version>1.2.1-SNAPSHOT</version>
+    <version>2.0.2-SNAPSHOT</version>
   </parent>
 
   <groupId>io.daos</groupId>

--- a/src/client/java/distribution/pom.xml
+++ b/src/client/java/distribution/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>io.daos</groupId>
     <artifactId>daos-java-root</artifactId>
-    <version>1.2.1-SNAPSHOT</version>
+    <version>2.0.2-SNAPSHOT</version>
   </parent>
 
   <groupId>io.daos</groupId>

--- a/src/client/java/hadoop-daos/pom.xml
+++ b/src/client/java/hadoop-daos/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>io.daos</groupId>
     <artifactId>daos-java-root</artifactId>
-    <version>1.2.1-SNAPSHOT</version>
+    <version>2.0.2-SNAPSHOT</version>
   </parent>
 
   <groupId>io.daos</groupId>
@@ -15,7 +15,7 @@
   <packaging>jar</packaging>
 
   <properties>
-    <hadoop.version>3.3.1</hadoop.version>
+    <hadoop.version>3.3.2</hadoop.version>
     <native.build.path>${project.basedir}/build</native.build.path>
     <daos.install.path>${project.basedir}/install</daos.install.path>
   </properties>

--- a/src/client/java/pom.xml
+++ b/src/client/java/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>io.daos</groupId>
   <artifactId>daos-java-root</artifactId>
-  <version>1.2.1-SNAPSHOT</version>
+  <version>2.0.2-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>${project.groupId}:${project.artifactId}</name>


### PR DESCRIPTION
Hadoop release 3.3.2 brings in various security and bug fixes so make use of
it. Also bump the package version of the DAOS library and plugin to match the
release version.

Signed-off-by: David Quigley <david.quigley@intel.com>