### PR TITLE
DAOS-9519 mgmt: reduce MGMT_POOL_FIND RPC timeouts (#8279)

### DIFF
--- a/src/cart/crt_rpc.c
+++ b/src/cart/crt_rpc.c
@@ -637,6 +637,24 @@ out:
 	return rc;
 }
 
+int
+crt_req_get_timeout(crt_rpc_t *req, uint32_t *timeout_sec)
+{
+	struct crt_rpc_priv	*rpc_priv;
+	int			 rc = 0;
+
+	if (req == NULL || timeout_sec == NULL) {
+		D_ERROR("invalid parameter (NULL req or timeout_sec).\n");
+		D_GOTO(out, rc = -DER_INVAL);
+	}
+
+	rpc_priv = container_of(req, struct crt_rpc_priv, crp_pub);
+	*timeout_sec = rpc_priv->crp_timeout_sec;
+
+out:
+	return rc;
+}
+
 /* Called from a decref() call when the count drops to zero */
 void
 crt_req_destroy(struct crt_rpc_priv *rpc_priv)
@@ -1599,7 +1617,8 @@ crt_rpc_priv_init(struct crt_rpc_priv *rpc_priv, crt_context_t crt_ctx,
 
 	crt_rpc_inout_buff_init(rpc_priv);
 
-	rpc_priv->crp_timeout_sec = ctx->cc_timeout_sec;
+	rpc_priv->crp_timeout_sec = (ctx->cc_timeout_sec == 0 ? crt_gdata.cg_timeout :
+				     ctx->cc_timeout_sec);
 
 exit:
 	return rc;

--- a/src/include/cart/api.h
+++ b/src/include/cart/api.h
@@ -293,6 +293,17 @@ int
 crt_req_set_timeout(crt_rpc_t *req, uint32_t timeout_sec);
 
 /**
+ * Get the timeout value of an RPC request.
+ *
+ * \param[in] req              pointer to RPC request
+ * \param[out] timeout_sec     timeout value in seconds
+ *
+ * \return                     DER_SUCCESS on success, negative value if error
+ */
+int
+crt_req_get_timeout(crt_rpc_t *req, uint32_t *timeout_sec);
+
+/**
  * Add reference of the RPC request.
  *
  * The typical usage is that user needs to do some asynchronous operations in

--- a/src/mgmt/cli_mgmt.c
+++ b/src/mgmt/cli_mgmt.c
@@ -827,6 +827,8 @@ dc_mgmt_pool_find(struct dc_mgmt_sys *sys, const char *label, uuid_t puuid,
 	srv_ep.ep_grp = sys->sy_group;
 	srv_ep.ep_tag = daos_rpc_tag(DAOS_REQ_MGMT, 0);
 	for (i = 0 ; i < ms_ranks->rl_nr; i++) {
+		uint32_t	timeout;
+
 		srv_ep.ep_rank = ms_ranks->rl_ranks[idx];
 		rpc = NULL;
 		rc = crt_req_create(ctx, &srv_ep, opc, &rpc);
@@ -836,6 +838,12 @@ dc_mgmt_pool_find(struct dc_mgmt_sys *sys, const char *label, uuid_t puuid,
 			idx = (idx + 1) % ms_ranks->rl_nr;
 			continue;
 		}
+
+		/* Shorten the timeout (but not lower than 10 seconds) to speed up pool find */
+		rc = crt_req_get_timeout(rpc, &timeout);
+		D_ASSERTF(rc == 0, "crt_req_get_timeout: "DF_RC"\n", DP_RC(rc));
+		rc = crt_req_set_timeout(rpc, max(10, timeout / 4));
+		D_ASSERTF(rc == 0, "crt_req_set_timeout: "DF_RC"\n", DP_RC(rc));
 
 		rpc_in = NULL;
 		rpc_in = crt_req_get(rpc);

--- a/src/tests/ftest/daos_test/suite.yaml
+++ b/src/tests/ftest/daos_test/suite.yaml
@@ -55,8 +55,9 @@ server_config:
       scm_mount: /mnt/daos0
       log_mask: DEBUG,MEM=ERR
       env_vars:
-        - DD_MASK=mgmt,io,md,epc,rebuild
+        - DD_MASK=mgmt,io,md,epc,rebuild,any
         - D_LOG_FILE_APPEND_PID=1
+        - D_LOG_FLUSH=DEBUG
     1:
       pinned_numa_node: 1
       nr_xs_helpers: 1
@@ -70,8 +71,9 @@ server_config:
       scm_mount: /mnt/daos1
       log_mask: DEBUG,MEM=ERR
       env_vars:
-        - DD_MASK=mgmt,io,md,epc,rebuild
+        - DD_MASK=mgmt,io,md,epc,rebuild,any
         - D_LOG_FILE_APPEND_PID=1
+        - D_LOG_FLUSH=DEBUG
   transport_config:
     allow_insecure: True
 agent_config:

--- a/src/tests/ftest/pool/create_capacity.yaml
+++ b/src/tests/ftest/pool/create_capacity.yaml
@@ -21,6 +21,10 @@ server_config:
       scm_class: dcpm
       scm_list: ["/dev/pmem0"]
       scm_mount: /mnt/daos0
+      log_mask: DEBUG
+      env_vars:
+        - DD_MASK=mgmt,md,dsms,any
+        - D_LOG_FLUSH=DEBUG
 pool:
   name: daos_server
   control_method: dmg


### PR DESCRIPTION
Cherry-pick of PR 8279 master commit 6b5eef3 to the release/2.0 branch.

Speed up client finding pool service replicas particularly for the
situation that a daos_engine rank is no longer reachable. Reduce
the MGMT_POOL_FIND RPC timeout to 1/4 the cart RPC timeout, with
a lower bound of 10 seconds timeout.

Test-tag: pr, daily_regression

Signed-off-by: Kenneth Cain <kenneth.c.cain@intel.com>