### PR TITLE
DAOS-623 test: bump timeout on oid allocator test

### DIFF
--- a/src/tests/ftest/daos_test/suite.yaml
+++ b/src/tests/ftest/daos_test/suite.yaml
@@ -29,7 +29,7 @@ timeouts:
     test_daos_rebuild_simple: 900
     test_daos_drain_simple: 500
     test_daos_extend_simple: 500
-    test_daos_oid_allocator: 320
+    test_daos_oid_allocator: 640
     test_daos_checksum: 500
     test_daos_rebuild_ec: 3600
     test_daos_aggregate_ec: 200


### PR DESCRIPTION
to avoid the cascading RPC issue and further CI failures, bump timeout
on test.

Quick-Functional: true
Test-tag: test_daos_oid_allocator

Signed-off-by: Mohamad Chaarawi <mohamad.chaarawi@intel.com>