### PR TITLE
DAOS-9994 test: Updating detect() method with missing distros

### DIFF
--- a/src/tests/ftest/launch.py
+++ b/src/tests/ftest/launch.py
@@ -1724,7 +1724,7 @@ def install_debuginfos():
     """
     # The distro_utils.py file is installed in the util sub-directory relative to this file location
     sys.path.append(os.path.join(os.getcwd(), "util"))
-    from distro_utils import detect
+    from distro_utils import detect         # pylint: disable=import-outside-toplevel
 
     distro_info = detect()
     install_pkgs = [{'name': 'gdb'}]

--- a/src/tests/ftest/launch.py
+++ b/src/tests/ftest/launch.py
@@ -25,15 +25,13 @@ import yaml
 from defusedxml import minidom
 import defusedxml.ElementTree as ET
 
+from ClusterShell.NodeSet import NodeSet
+from ClusterShell.Task import task_self
+
 # Graft some functions from xml.etree into defusedxml etree.
 ET.Element = Element
 ET.SubElement = SubElement
 ET.tostring = tostring
-
-
-from avocado.utils.distro import detect
-from ClusterShell.NodeSet import NodeSet
-from ClusterShell.Task import task_self
 
 try:
     # For python versions >= 3.2
@@ -1724,6 +1722,10 @@ def install_debuginfos():
         on this node also.
 
     """
+    # The distro_utils.py file is installed in the util sub-directory relative to this file location
+    sys.path.append(os.path.join(os.getcwd(), "util"))
+    from distro_utils import detect
+
     distro_info = detect()
     install_pkgs = [{'name': 'gdb'}]
     if "centos" in distro_info.name.lower():

--- a/src/tests/ftest/util/apricot/apricot/test.py
+++ b/src/tests/ftest/util/apricot/apricot/test.py
@@ -13,7 +13,7 @@ import re
 
 from avocado import Test as avocadoTest
 from avocado import skip, TestFail, fail_on
-from avocado.utils.distro import detect
+from distro_utils import detect
 from avocado.core import exceptions
 from ast import literal_eval
 from ClusterShell.NodeSet import NodeSet

--- a/src/tests/ftest/util/apricot/apricot/test.py
+++ b/src/tests/ftest/util/apricot/apricot/test.py
@@ -6,34 +6,33 @@
 """
 # pylint: disable=too-many-lines
 
-# Some useful test classes inherited from avocado.Test
+from ast import literal_eval
 import os
 import json
 import re
 
+from avocado import fail_on, skip, TestFail
 from avocado import Test as avocadoTest
-from avocado import skip, TestFail, fail_on
 from avocado.core import exceptions
-from ast import literal_eval
 from ClusterShell.NodeSet import NodeSet
 
-from distro_utils import detect
-from fault_config_utils import FaultInjection
-from pydaos.raw import DaosContext, DaosLog, DaosApiError
-from command_utils_base import CommandFailure, EnvironmentVariables
 from agent_utils import DaosAgentManager, include_local_host
-from dmg_utils import get_dmg_command
-from daos_utils import DaosCommand
 from cart_ctl_utils import CartCtl
-from server_utils import DaosServerManager
+from command_utils_base import CommandFailure, EnvironmentVariables
+from daos_utils import DaosCommand
+from distro_utils import detect
+from distutils.spawn import find_executable
+from dmg_utils import get_dmg_command
+from env_modules import load_mpi
+from fault_config_utils import FaultInjection
 from general_utils import \
     get_partition_hosts, stop_processes, get_job_manager_class, \
     get_default_config_file, pcmd, get_file_listing, DaosTestError, run_command
 from logger_utils import TestLogger
-from test_utils_pool import TestPool, LabelGenerator
+from pydaos.raw import DaosContext, DaosLog, DaosApiError
+from server_utils import DaosServerManager
 from test_utils_container import TestContainer
-from env_modules import load_mpi
-from distutils.spawn import find_executable
+from test_utils_pool import TestPool, LabelGenerator
 from write_host_file import write_host_file
 
 

--- a/src/tests/ftest/util/apricot/apricot/test.py
+++ b/src/tests/ftest/util/apricot/apricot/test.py
@@ -13,11 +13,11 @@ import re
 
 from avocado import Test as avocadoTest
 from avocado import skip, TestFail, fail_on
-from distro_utils import detect
 from avocado.core import exceptions
 from ast import literal_eval
 from ClusterShell.NodeSet import NodeSet
 
+from distro_utils import detect
 from fault_config_utils import FaultInjection
 from pydaos.raw import DaosContext, DaosLog, DaosApiError
 from command_utils_base import CommandFailure, EnvironmentVariables

--- a/src/tests/ftest/util/distro_utils.py
+++ b/src/tests/ftest/util/distro_utils.py
@@ -1,0 +1,30 @@
+#!/usr/bin/python
+"""
+(C) Copyright 2022 Intel Corporation.
+
+SPDX-License-Identifier: BSD-2-Clause-Patent
+"""
+from avocado.utils.distro import *      # noqa: F403    # pylint: disable=wildcard-import
+import re
+
+
+class RockyProbe(Probe):                # noqa: F405
+    """Probe with version checks for Rocky Linux systems."""
+
+    CHECK_FILE = "/etc/rocky-release"
+    CHECK_FILE_CONTAINS = "Rocky Linux"
+    CHECK_FILE_DISTRO_NAME = "rocky"
+    CHECK_VERSION_REGEX = re.compile(r"Rocky Linux release (\d{1,2})\.(\d{1,2}).*")
+
+
+class AlmaProbe(Probe):                 # noqa: F405
+    """Probe with version checks for AlmaLinux systems."""
+
+    CHECK_FILE = "/etc/almalinux-release"
+    CHECK_FILE_CONTAINS = "AlmaLinux"
+    CHECK_FILE_DISTRO_NAME = "alma"
+    CHECK_VERSION_REGEX = re.compile(r"AlmaLinux release (\d{1,2})\.(\d{1,2}).*")
+
+
+register_probe(RockyProbe)              # noqa: F405
+register_probe(AlmaProbe)               # noqa: F405


### PR DESCRIPTION
Adding support for Rocky Linux and AlmaLinux to the avocado.utils.distro method.

Skip-unit-tests: true
Features: harness_advanced_test

Signed-off-by: Phillip Henderson <phillip.henderson@intel.com>