### PR TITLE
DAOS-10076 API: Macros are needed for middleware compatibility

### DIFF
--- a/src/client/api/container.c
+++ b/src/client/api/container.c
@@ -176,7 +176,6 @@ int
 daos_cont_open(daos_handle_t poh, const char *cont, unsigned int flags,
 	       daos_handle_t *coh, daos_cont_info_t *info, daos_event_t *ev)
 	       __attribute__ ((weak, alias("daos_cont_open2")));
-#define daos_cont_open daos_cont_open2
 
 int
 daos_cont_close(daos_handle_t coh, daos_event_t *ev)
@@ -229,7 +228,6 @@ int
 daos_cont_destroy(daos_handle_t poh, const char *cont, int force,
 		  daos_event_t *ev)
 		  __attribute__ ((weak, alias("daos_cont_destroy2")));
-#define daos_cont_destroy daos_cont_destroy2
 
 int
 daos_cont_query(daos_handle_t coh, daos_cont_info_t *info,

--- a/src/client/api/container.c
+++ b/src/client/api/container.c
@@ -171,10 +171,12 @@ daos_cont_open(daos_handle_t poh, const char *cont, unsigned int flags,
 	return dc_task_schedule(task, true);
 }
 
+#undef daos_cont_open
 int
-daos_cont_open2(daos_handle_t poh, const char *cont, unsigned int flags,
-		daos_handle_t *coh, daos_cont_info_t *info, daos_event_t *ev)
-		__attribute__ ((weak, alias("daos_cont_open")));
+daos_cont_open(daos_handle_t poh, const char *cont, unsigned int flags,
+	       daos_handle_t *coh, daos_cont_info_t *info, daos_event_t *ev)
+	       __attribute__ ((weak, alias("daos_cont_open2")));
+#define daos_cont_open daos_cont_open2
 
 int
 daos_cont_close(daos_handle_t coh, daos_event_t *ev)
@@ -222,10 +224,12 @@ daos_cont_destroy(daos_handle_t poh, const char *cont, int force,
 	return dc_task_schedule(task, true);
 }
 
+#undef daos_cont_destroy
 int
-daos_cont_destroy2(daos_handle_t poh, const char *cont, int force,
-		   daos_event_t *ev)
-		   __attribute__ ((weak, alias("daos_cont_destroy")));
+daos_cont_destroy(daos_handle_t poh, const char *cont, int force,
+		  daos_event_t *ev)
+		  __attribute__ ((weak, alias("daos_cont_destroy2")));
+#define daos_cont_destroy daos_cont_destroy2
 
 int
 daos_cont_query(daos_handle_t coh, daos_cont_info_t *info,

--- a/src/client/api/pool.c
+++ b/src/client/api/pool.c
@@ -44,7 +44,6 @@ int
 daos_pool_connect(const char *pool, const char *sys, unsigned int flags,
 		  daos_handle_t *poh, daos_pool_info_t *info, daos_event_t *ev)
 		  __attribute__ ((weak, alias("daos_pool_connect2")));
-#define daos_pool_connect daos_pool_connect2
 
 int
 daos_pool_disconnect(daos_handle_t poh, daos_event_t *ev)

--- a/src/client/api/pool.c
+++ b/src/client/api/pool.c
@@ -38,10 +38,13 @@ daos_pool_connect(const char *pool, const char *sys, unsigned int flags,
 
 	return dc_task_schedule(task, true);
 }
+
+#undef daos_pool_connect
 int
-daos_pool_connect2(const char *pool, const char *sys, unsigned int flags,
-		 daos_handle_t *poh, daos_pool_info_t *info, daos_event_t *ev)
-		 __attribute__ ((weak, alias("daos_pool_connect")));
+daos_pool_connect(const char *pool, const char *sys, unsigned int flags,
+		  daos_handle_t *poh, daos_pool_info_t *info, daos_event_t *ev)
+		  __attribute__ ((weak, alias("daos_pool_connect2")));
+#define daos_pool_connect daos_pool_connect2
 
 int
 daos_pool_disconnect(daos_handle_t poh, daos_event_t *ev)

--- a/src/include/daos_cont.h
+++ b/src/include/daos_cont.h
@@ -12,6 +12,9 @@
 #ifndef __DAOS_CONT_H__
 #define __DAOS_CONT_H__
 
+#define daos_cont_open daos_cont_open2
+#define daos_cont_destroy daos_cont_destroy2
+
 #if defined(__cplusplus)
 extern "C" {
 #endif

--- a/src/include/daos_pool.h
+++ b/src/include/daos_pool.h
@@ -9,6 +9,8 @@
 #ifndef __DAOS_POOL_H__
 #define __DAOS_POOL_H__
 
+#define daos_pool_connect daos_pool_connect2
+
 #if defined(__cplusplus)
 extern "C" {
 #endif


### PR DESCRIPTION
We need macros to enforce middleware call daos_pool_connect2(),
daos_cont_open2(), and daos_cont_destroy2(). Without such macros, 
middleware compiled with DAOS master breaks in release 2.0.

Signed-off-by: Lei Huang <wiliam_huang@hotmail.com>