### PR TITLE
DAOS-9237 test: rework interception perf tests (#8112)

### DIFF
--- a/src/tests/ftest/ior/intercept_basic.py
+++ b/src/tests/ftest/ior/intercept_basic.py
@@ -5,17 +5,13 @@
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
 
-import os
-from ior_test_base import IorTestBase
-from ior_utils import IorCommand, IorMetrics
+from ior_intercept_test_base import IorInterceptTestBase
 
 
-class IorIntercept(IorTestBase):
+class IorInterceptBasic(IorInterceptTestBase):
     # pylint: disable=too-many-ancestors
-    """Test class Description: Runs IOR with and without interception.
-
-       library on a single server and single client setting with
-       basic parameters.
+    """Test class Description: Verify IOR performance with DFUSE + IL is similar to DFS
+                               for a single server and single client node.
 
     :avocado: recursive
     """
@@ -24,58 +20,16 @@ class IorIntercept(IorTestBase):
         """Jira ID: DAOS-3498.
 
         Test Description:
-            Purpose of this test is to run ior using dfuse for 5 minutes
-            and capture the metrics and use the intercepiton library by
-            exporting LD_PRELOAD to the libioil.so path and rerun the
-            above ior and capture the metrics and compare the
-            performance difference and check using interception
-            library make significant performance improvement.
+            Verify IOR performance with DFUSE + IL is similar to DFS.
 
         Use case:
-            Run ior with read, write, CheckWrite, CheckRead
-                for 5 minutes
-            Run ior with read, write, CheckWrite, CheckRead
-                for 5 minutes with interception library
-            Compare the results and check whether using interception
-                library provides better performance.
+            Run IOR write + read with DFS.
+            Run IOR write + read with DFUSE + IL.
+            Verify performance with DFUSE + IL is similar to DFS.
 
         :avocado: tags=all,full_regression
         :avocado: tags=hw,small
-        :avocado: tags=daosio,dfuse,il
-        :avocado: tags=iorinterceptbasic
+        :avocado: tags=daosio,dfuse,il,ior,ior_intercept
+        :avocado: tags=ior_intercept_basic
         """
-        apis = self.params.get("ior_api", '/run/ior/iorflags/ssf/*')
-        for api in apis:
-            self.ior_cmd.api.update(api)
-            out = self.run_ior_with_pool(fail_on_warning=True)
-            without_intercept = IorCommand.get_ior_metrics(out)
-            if api == "POSIX":
-                intercept = os.path.join(self.prefix, 'lib64', 'libioil.so')
-                out = self.run_ior_with_pool(intercept, fail_on_warning=True)
-                with_intercept = IorCommand.get_ior_metrics(out)
-                max_mib = int(IorMetrics.Max_MiB)
-                min_mib = int(IorMetrics.Min_MiB)
-                mean_mib = int(IorMetrics.Mean_MiB)
-                write_x = self.params.get("write_x",
-                                          "/run/ior/iorflags/ssf/*", 1)
-                read_x = self.params.get("read_x",
-                                         "/run/ior/iorflags/ssf/*", 1)
-
-                # Verifying write performance
-                self.assertTrue(float(with_intercept[0][max_mib]) >
-                                write_x * float(without_intercept[0][max_mib]))
-                self.assertTrue(float(with_intercept[0][min_mib]) >
-                                write_x * float(without_intercept[0][min_mib]))
-                self.assertTrue(float(with_intercept[0][mean_mib]) >
-                                write_x * float(without_intercept[0][mean_mib]))
-
-                # Verifying read performance
-                self.assertTrue(float(with_intercept[1][max_mib]) >
-                                read_x * float(without_intercept[1][max_mib]))
-                # DAOS-5857 There's a lot of volatility in this result, so disable it to reduce
-                # testing noise.  This test runs IOR with multiple iterations so it should only
-                # affect min results, mean and max results should be more resilient.
-                #self.assertTrue(float(with_intercept[1][min_mib]) >
-                #                read_x * float(without_intercept[1][min_mib]))
-                self.assertTrue(float(with_intercept[1][mean_mib]) >
-                                read_x * float(without_intercept[1][mean_mib]))
+        self.run_il_perf_check()

--- a/src/tests/ftest/ior/intercept_basic.yaml
+++ b/src/tests/ftest/ior/intercept_basic.yaml
@@ -3,7 +3,7 @@ hosts:
         - server-A
     test_clients:
         - client-A
-timeout: 2400
+timeout: 1000
 server_config:
     name: daos_server
     servers:
@@ -15,9 +15,7 @@ server_config:
 pool:
     mode: 146 # 146 is RW
     name: daos_server
-    # 300 G
-    scm_size: 30000000000
-    nvme_size: 420000000000
+    size: 90%
     svcn: 1
     control_method: dmg
 container:
@@ -25,29 +23,15 @@ container:
     control_method: daos
 ior:
     client_processes:
-        np_16:
-            np: 16
+        np: 32
     test_file: testFile
-    repetitions: 5
-    iorflags:
-        ssf:
-          flags: "-v -D 600 -w -r"
-          ior_api:
-            - DFS
-            - POSIX
-          transfersize_blocksize:
-            1M:
-              transfer_size: '1M'
-              block_size: '2G'
-              # Expected performance improvement
-              # of write and read for the specific
-              # transfer/block size when using
-              # interception library.
-              write_x: 1.5
-              read_x: 1.5
-          objectclass:
-            oclass_SX:
-              dfs_oclass: "SX"
+    repetitions: 3
+    flags: "-v -D 60 -w -r -R"
+    dfs_oclass: 'SX'
+    transfer_size: '1M'
+    block_size: '100G'
+    write_x: 0.08 # Max 8% performance difference.
+    read_x: 0.08  # Loosely derived from 3% stddev + 5% actual deviation.
 dfuse:
     mount_dir: "/tmp/daos_dfuse/"
     disable_caching: True

--- a/src/tests/ftest/ior/intercept_messages.py
+++ b/src/tests/ftest/ior/intercept_messages.py
@@ -33,8 +33,8 @@ class IorInterceptMessages(IorTestBase):
 
         :avocado: tags=all,full_regression
         :avocado: tags=hw,small
-        :avocado: tags=daosio,dfuse,il
-        :avocado: tags=iorinterceptmessages
+        :avocado: tags=daosio,dfuse,il,ior_intercept
+        :avocado: tags=ior_intercept_messages
         """
         d_il_report_value = self.params.get("value",
                                             "/run/tests/D_IL_REPORT/*")

--- a/src/tests/ftest/ior/intercept_multi_client.py
+++ b/src/tests/ftest/ior/intercept_multi_client.py
@@ -5,17 +5,13 @@
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
 
-import os
-from ior_test_base import IorTestBase
-from ior_utils import IorCommand, IorMetrics
-import write_host_file
+from ior_intercept_test_base import IorInterceptTestBase
 
 
-class IorInterceptMultiClient(IorTestBase):
+class IorInterceptMultiClient(IorInterceptTestBase):
     # pylint: disable=too-many-ancestors
-    """Test class Description: Runs IOR with and without interception
-       library on a single server and multi client settings with
-       basic parameters.
+    """Test class Description: Verify IOR performance with DFUSE + IL is similar to DFS
+                               for a single server and multiple client nodes.
 
     :avocado: recursive
     """
@@ -24,52 +20,16 @@ class IorInterceptMultiClient(IorTestBase):
         """Jira ID: DAOS-3499.
 
         Test Description:
-            Purpose of this test is to run ior through dfuse in multiple
-            clients for 5 minutes and capture the metrics and use the
-            intercepiton library by exporting LD_PRELOAD to the libioil.so
-            path and rerun the above ior and capture the metrics and
-            compare the performance difference and check using interception
-            library make significant performance improvement.
+            Verify IOR performance with DFUSE + IL is similar to DFS.
 
         Use case:
-            Run ior with read, write for 5 minutes
-            Run ior with read, write for 5 minutes with interception library
-            Compare the results and check whether using interception
-                library provides better performance.
+            Run IOR write + read with DFS.
+            Run IOR write + read with DFUSE + IL.
+            Verify performance with DFUSE + IL is similar to DFS.
 
-        :avocado: tags=all,full_regression,hw,large
-        :avocado: tags=daosio,iorinterceptmulticlient
+        :avocado: tags=all,full_regression
+        :avocado: tags=hw,medium,ib2
+        :avocado: tags=daosio,dfuse,il,ior,ior_intercept
+        :avocado: tags=ior_intercept_multi_client
         """
-        suffix = self.ior_cmd.transfer_size.value
-        out = self.run_ior_with_pool(test_file_suffix=suffix)
-        without_intercept = IorCommand.get_ior_metrics(out)
-        intercept = os.path.join(self.prefix, 'lib64', 'libioil.so')
-        suffix = suffix + "intercept"
-        out = self.run_ior_with_pool(intercept, test_file_suffix=suffix)
-        with_intercept = IorCommand.get_ior_metrics(out)
-        max_mib = int(IorMetrics.Max_MiB)
-        min_mib = int(IorMetrics.Min_MiB)
-        mean_mib = int(IorMetrics.Mean_MiB)
-
-        write_x = self.params.get("write_x", "/run/ior/iorflags/ssf/*", 1)
-
-        # Verifying write performance
-        self.assertTrue(float(with_intercept[0][max_mib]) >
-                        write_x * float(without_intercept[0][max_mib]))
-        self.assertTrue(float(with_intercept[0][min_mib]) >
-                        write_x * float(without_intercept[0][min_mib]))
-        self.assertTrue(float(with_intercept[0][mean_mib]) >
-                        write_x * float(without_intercept[0][mean_mib]))
-
-        # Verifying read performance
-        # The read performance is almost same with or without intercept
-        # library. But arbitrarily the read performance with interception
-        # library can be bit lower than without it. Verifying that it is
-        # not drastically lower by checking it is at least  60% or above.
-        read_x = 0.6
-        self.assertTrue(float(with_intercept[1][max_mib]) >
-                        read_x * float(without_intercept[1][max_mib]))
-        self.assertTrue(float(with_intercept[1][min_mib]) >
-                        read_x * float(without_intercept[1][min_mib]))
-        self.assertTrue(float(with_intercept[1][mean_mib]) >
-                        read_x * float(without_intercept[1][mean_mib]))
+        self.run_il_perf_check()

--- a/src/tests/ftest/ior/intercept_multi_client.yaml
+++ b/src/tests/ftest/ior/intercept_multi_client.yaml
@@ -5,21 +5,39 @@ hosts:
         - client-A
         - client-B
         - client-C
-        - client-D
-timeout: 8000
+timeout: 1000
 server_config:
-    name: daos_server
-    servers:
-        log_mask: INFO
-        bdev_class: nvme
-        bdev_list: ["0000:81:00.0","0000:da:00.0"]
-        scm_class: dcpm
-        scm_list: ["/dev/pmem0"]
+  engines_per_host: 2
+  name: daos_server
+  servers:
+    0:
+      pinned_numa_node: 0
+      nr_xs_helpers: 1
+      fabric_iface: ib0
+      fabric_iface_port: 31317
+      log_file: daos_server0.log
+      log_mask: INFO
+      bdev_class: nvme
+      bdev_list: ["aaaa:aa:aa.a"]
+      scm_class: dcpm
+      scm_list: ["/dev/pmem0"]
+      scm_mount: /mnt/daos0
+    1:
+      pinned_numa_node: 1
+      nr_xs_helpers: 1
+      fabric_iface: ib1
+      fabric_iface_port: 31417
+      log_file: daos_server1.log
+      log_mask: INFO
+      bdev_class: nvme
+      bdev_list: ["bbbb:bb:bb.b"]
+      scm_class: dcpm
+      scm_list: ["/dev/pmem1"]
+      scm_mount: /mnt/daos1
 pool:
     mode: 146
     name: daos_server
-    scm_size: 40000000000
-    nvme_size: 400000000000
+    size: 90%
     svcn: 1
     control_method: dmg
 container:
@@ -27,36 +45,23 @@ container:
     control_method: daos
 ior:
     client_processes:
-      np: 16
+        np: 96
     test_file: daos:testFile
-    repetitions: 1
-# Remove the below line once DAOS-3143 is resolved
-    dfs_destroy: False
-    iorflags:
-        ssf:
-          flags: "-k -v -D 300 -w -r"
-          api: POSIX
-          dfs_oclass: "SX"
-          transfersize_blocksize: !mux
-            512B:
-              transfer_size: '512B'
-              block_size: '128M'
-              write_x: 1
-              read_x: 1
-            1K:
-              transfer_size: '1K'
-              block_size: '512M'
-              write_x: 2
-              read_x: 1
-            4K:
-              transfer_size: '4K'
-              block_size: '512M'
-              write_x: 1
-              read_x: 1
-            1M:
-              transfer_size: '1M'
-              block_size: '8G'
-              write_x: 2
-              read_x: 1
+    repetitions: 3
+    flags: "-v -D 60 -w -r"
+    dfs_oclass: "SX"
+    block_size: '100G'
+    write_x: 0.08 # Max 8% performance difference.
+    read_x: 0.08  # Loosely derived from 3% stddev + 5% actual deviation.
+    transfersize: !mux
+        512B:
+            transfer_size: '512B'
+        1K:
+            transfer_size: '1K'
+        4K:
+            transfer_size: '4K'
+        1M:
+            transfer_size: '1M'
 dfuse:
     mount_dir: "/tmp/daos_dfuse/"
+    disable_caching: True

--- a/src/tests/ftest/ior/intercept_verify_data_integrity.py
+++ b/src/tests/ftest/ior/intercept_verify_data_integrity.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 """
-  (C) Copyright 2019-2021 Intel Corporation.
+  (C) Copyright 2019-2022 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -36,7 +36,8 @@ class IorInterceptVerifyDataIntegrity(IorTestBase):
 
         :avocado: tags=all,full_regression
         :avocado: tags=hw,large
-        :avocado: tags=daosio,ior_intercept_verify_data
+        :avocado: tags=daosio,dfuse,il,ior_intercept
+        :avocado: tags=ior_intercept_verify_data
         """
         self.add_pool()
         self.add_container(self.pool)

--- a/src/tests/ftest/util/ior_intercept_test_base.py
+++ b/src/tests/ftest/util/ior_intercept_test_base.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""
+  (C) Copyright 2019-2022 Intel Corporation.
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+"""
+
+import os
+from ior_test_base import IorTestBase
+from ior_utils import IorCommand, IorMetrics
+from general_utils import percent_change
+
+
+class IorInterceptTestBase(IorTestBase):
+    # pylint: disable=too-many-ancestors
+    # pylint: disable=too-few-public-methods
+    """Base IOR interception test class.
+
+    :avocado: recursive
+    """
+
+    def run_il_perf_check(self):
+        """Verify IOR performance with DFUSE + IL is similar to DFS.
+
+        Steps:
+            Run IOR with DFS.
+            Run IOR with DFUSE + IL.
+            Verify performance with DFUSE + IL is similar to DFS.
+
+        """
+        # Write and read performance thresholds
+        write_x = self.params.get("write_x", self.ior_cmd.namespace, None)
+        read_x = self.params.get("read_x", self.ior_cmd.namespace, None)
+        if write_x is None or read_x is None:
+            self.fail("Failed to get write_x and read_x from config")
+
+        # Run IOR with DFS
+        self.ior_cmd.api.update("DFS")
+        dfs_out = self.run_ior_with_pool(fail_on_warning=self.log.info)
+        dfs_perf = IorCommand.get_ior_metrics(dfs_out)
+
+        # Destroy and use a new pool and container
+        self.container.destroy()
+        self.container = None
+        self.pool.destroy()
+        self.pool = None
+
+        # Run IOR with dfuse + IL
+        self.ior_cmd.api.update("POSIX")
+        dfuse_out = self.run_ior_with_pool(
+            intercept=os.path.join(self.prefix, 'lib64', 'libioil.so'),
+            fail_on_warning=self.log.info)
+        dfuse_perf = IorCommand.get_ior_metrics(dfuse_out)
+
+        # Verify write and read performance are within the thresholds.
+        # Since Min can have a lot of variance, don't check Min or Mean.
+        # Ideally, we might want to look at the Std Dev to ensure the results are admissible.
+        dfs_max_write = float(dfs_perf[0][IorMetrics.Max_MiB])
+        dfuse_max_write = float(dfuse_perf[0][IorMetrics.Max_MiB])
+        actual_write_x = percent_change(dfs_max_write, dfuse_max_write)
+        self.log.info("DFS Max Write:      %.2f", dfs_max_write)
+        self.log.info("DFUSE IL Max Write: %.2f", dfuse_max_write)
+        self.log.info("Percent Diff:       %.2f%%", actual_write_x * 100)
+        self.assertLessEqual(abs(actual_write_x), write_x, "Max Write Diff too large")
+
+        dfs_max_read = float(dfs_perf[1][IorMetrics.Max_MiB])
+        dfuse_max_read = float(dfuse_perf[1][IorMetrics.Max_MiB])
+        actual_read_x = percent_change(dfs_max_read, dfuse_max_read)
+        self.log.info("DFS Max Read:      %.2f", dfs_max_read)
+        self.log.info("DFUSE IL Max Read: %.2f", dfuse_max_read)
+        self.log.info("Percent Diff:      %.2f%%", actual_read_x * 100)
+        self.assertLessEqual(abs(actual_read_x), read_x, "Max Read Diff too large")

--- a/src/tests/ftest/util/ior_test_base.py
+++ b/src/tests/ftest/util/ior_test_base.py
@@ -115,8 +115,9 @@ class IorTestBase(DfuseTestBase):
                 This will enable dfuse (xattr) working directory which is
                 needed to run vol connector for DAOS. Default is None.
             timeout (int, optional): command timeout. Defaults to None.
-            fail_on_warning (bool, optional): Controls whether the test
-                should fail if a 'WARNING' is found. Default is False.
+            fail_on_warning (bool/callable, optional): Controls test behavior when a 'WARNING' is
+                found. If True, call self.fail. If False, call self.log.warn. If callable, call it.
+                Default is False.
             mount_dir (str, optional): Create specific mount point
             out_queue (queue, optional): Pass the exception to the queue.
                 Defaults to None
@@ -234,8 +235,9 @@ class IorTestBase(DfuseTestBase):
             plugin_path (str, optional): HDF5 vol connector library path.
                 This will enable dfuse (xattr) working directory which is
                 needed to run vol connector for DAOS. Default is None.
-            fail_on_warning (bool, optional): Controls whether the test
-                should fail if a 'WARNING' is found. Default is False.
+            fail_on_warning (bool/callable, optional): Controls test behavior when a 'WARNING' is
+                found. If True, call self.fail. If False, call self.log.warn. If callable, call it.
+                Defaults is False.
             pool (TestPool, optional): The pool for which to display space.
                 Default is self.pool.
             out_queue (queue, optional): Pass the exception to the queue.
@@ -274,7 +276,9 @@ class IorTestBase(DfuseTestBase):
             if self.subprocess:
                 return out
 
-            if fail_on_warning:
+            if callable(fail_on_warning):
+                report_warning = fail_on_warning
+            elif fail_on_warning:
                 report_warning = self.fail
             else:
                 report_warning = self.log.warning


### PR DESCRIPTION
Test-tag: ior_intercept ior_intercept_basic ior_intercept_multi_client
Skip-unit-tests: true
Skip-fault-injection-test: true

Rework interception performance tests to be more robust
  - Create ior_intercept_test_base.py for common test procedure
  - Run with 60s stonewall for 3 iterations
  - Only check "Max" value until we have a better handle on variance
  - Add human-readable description of performance difference
  - Update tags for interception tests

Signed-off-by: Dalton Bohning <dalton.bohning@intel.com>
Conflicts:
	src/tests/ftest/ior/intercept_multi_client.py
	src/tests/ftest/ior/intercept_multi_client.yaml