### PR TITLE
DAOS-9756 vos: ilog_fetch cleanup and optimizations

### DIFF
--- a/src/vos/ilog.c
+++ b/src/vos/ilog.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2019-2021 Intel Corporation.
+ * (C) Copyright 2019-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -103,7 +103,7 @@ ilog_is_same_tx(struct ilog_context *lctx, const struct ilog_id *id, bool *same)
 				     cbs->dc_is_same_tx_args);
 }
 
-static int
+static int16_t
 ilog_status_get(struct ilog_context *lctx, const struct ilog_id *id, uint32_t intent)
 {
 	struct ilog_desc_cbs	*cbs = &lctx->ic_cbs;
@@ -1035,8 +1035,6 @@ ilog_abort(daos_handle_t loh, const struct ilog_id *id)
 struct ilog_priv {
 	/** Embedded context for current log root */
 	struct ilog_context	 ip_lctx;
-	/** Array marking removed entries */
-	uint32_t		*ip_removals;
 	/** Version of log from prior fetch */
 	int32_t			 ip_log_version;
 	/** Intent for prior fetch */
@@ -1046,7 +1044,7 @@ struct ilog_priv {
 	/** Cached return code for fetch operation */
 	int			 ip_rc;
 	/** Embedded status entries */
-	uint32_t		 ip_embedded[NUM_EMBEDDED];
+	struct ilog_info	 ip_embedded[NUM_EMBEDDED];
 };
 D_CASSERT(sizeof(struct ilog_priv) <= ILOG_PRIV_SIZE);
 
@@ -1063,7 +1061,7 @@ ilog_fetch_init(struct ilog_entries *entries)
 
 	D_ASSERT(entries != NULL);
 	memset(entries, 0, sizeof(*entries));
-	entries->ie_statuses = &priv->ip_embedded[0];
+	entries->ie_info = &priv->ip_embedded[0];
 }
 
 void
@@ -1076,11 +1074,10 @@ ilog_fetch_move(struct ilog_entries *dest, struct ilog_entries *src)
 	D_ASSERT(src != NULL);
 
 	/** We've already copied everything, just fix up any pointers here */
-	if (src->ie_statuses == &priv_src->ip_embedded[0])
-		dest->ie_statuses = &priv_dest->ip_embedded[0];
+	if (src->ie_info == &priv_src->ip_embedded[0])
+		dest->ie_info = &priv_dest->ip_embedded[0];
 
 	priv_src->ip_alloc_size = 0;
-	priv_src->ip_removals = NULL;
 }
 
 static void
@@ -1100,11 +1097,12 @@ ilog_status_refresh(struct ilog_context *lctx, uint32_t intent,
 		     entry.ie_status == ILOG_REMOVED))
 			continue;
 		status = ilog_status_get(lctx, &entry.ie_id, intent);
-		if (status < 0) {
+		if (status < 0 && status != -DER_INPROGRESS) {
 			priv->ip_rc = status;
 			return;
 		}
-		entries->ie_statuses[entry.ie_idx] = status;
+		entries->ie_info[entry.ie_idx].ii_removed = 0;
+		entries->ie_info[entry.ie_idx].ii_status = status;
 	}
 }
 
@@ -1116,9 +1114,9 @@ ilog_fetch_cached(struct umem_instance *umm, struct ilog_root *root,
 	struct ilog_priv	*priv = ilog_ent2priv(entries);
 	struct ilog_context	*lctx = &priv->ip_lctx;
 
-	D_ASSERT(entries->ie_statuses != NULL);
+	D_ASSERT(entries->ie_info != NULL);
 	D_ASSERT(priv->ip_alloc_size != 0 ||
-		 entries->ie_statuses == &priv->ip_embedded[0]);
+		 entries->ie_info == &priv->ip_embedded[0]);
 
 	if (priv->ip_lctx.ic_root != root ||
 	    priv->ip_log_version != ilog_mag2ver(root->lr_magic)) {
@@ -1153,10 +1151,7 @@ static int
 prepare_entries(struct ilog_entries *entries, struct ilog_array_cache *cache)
 {
 	struct ilog_priv	*priv = ilog_ent2priv(entries);
-	uint32_t		*statuses;
-
-	/** Ensure removals gets reallocated, if necessary */
-	D_FREE(priv->ip_removals);
+	struct ilog_info	*info;
 
 	if (cache->ac_nr <= NUM_EMBEDDED)
 		goto done;
@@ -1164,29 +1159,18 @@ prepare_entries(struct ilog_entries *entries, struct ilog_array_cache *cache)
 	if (cache->ac_nr <= priv->ip_alloc_size)
 		goto done;
 
-	D_ALLOC_ARRAY(statuses, cache->ac_nr);
-	if (statuses == NULL)
+	D_ALLOC_ARRAY(info, cache->ac_nr);
+	if (info == NULL)
 		return -DER_NOMEM;
 
-	if (entries->ie_statuses != &priv->ip_embedded[0])
-		D_FREE(entries->ie_statuses);
+	if (entries->ie_info != &priv->ip_embedded[0])
+		D_FREE(entries->ie_info);
 
-	entries->ie_statuses = statuses;
+	entries->ie_info = info;
 	priv->ip_alloc_size = cache->ac_nr;
 
 done:
 	entries->ie_ids = cache->ac_entries;
-
-	return 0;
-}
-static int
-set_entry(struct ilog_entries *entries, int i, int status)
-{
-	struct ilog_priv	*priv = ilog_ent2priv(entries);
-
-	D_ASSERT(i < NUM_EMBEDDED || i < priv->ip_alloc_size);
-	D_ASSERT(i == entries->ie_num_entries);
-	entries->ie_statuses[entries->ie_num_entries++] = status;
 
 	return 0;
 }
@@ -1210,10 +1194,10 @@ ilog_fetch(struct umem_instance *umm, struct ilog_df *root_df,
 	root = (struct ilog_root *)root_df;
 
 	if (ilog_fetch_cached(umm, root, cbs, intent, entries)) {
-		if (priv->ip_rc == -DER_INPROGRESS ||
-		    priv->ip_rc == -DER_NONEXIST)
+		if (priv->ip_rc == -DER_NONEXIST)
 			return priv->ip_rc;
 		if (priv->ip_rc < 0) {
+			D_ASSERT(priv->ip_rc != -DER_INPROGRESS);
 			/* Don't cache error return codes */
 			rc = priv->ip_rc;
 			priv->ip_rc = 0;
@@ -1236,9 +1220,10 @@ ilog_fetch(struct umem_instance *umm, struct ilog_df *root_df,
 	for (i = 0; i < cache.ac_nr; i++) {
 		id = &cache.ac_entries[i];
 		status = ilog_status_get(lctx, id, intent);
-		if (status != -DER_INPROGRESS && status < 0)
+		if (status < 0 && status != -DER_INPROGRESS)
 			D_GOTO(fail, rc = status);
-		set_entry(entries, i, status);
+		entries->ie_info[entries->ie_num_entries].ii_removed = 0;
+		entries->ie_info[entries->ie_num_entries++].ii_status = status;
 	}
 
 out:
@@ -1263,8 +1248,7 @@ ilog_fetch_finish(struct ilog_entries *entries)
 
 	D_ASSERT(entries != NULL);
 	if (priv->ip_alloc_size)
-		D_FREE(entries->ie_statuses);
-	D_FREE(priv->ip_removals);
+		D_FREE(entries->ie_info);
 }
 
 struct agg_arg {
@@ -1419,8 +1403,8 @@ done:
 }
 
 static int
-collapse_tree(struct ilog_context *lctx, struct ilog_array_cache *cache, struct ilog_priv *priv,
-	      int removed)
+collapse_tree(struct ilog_context *lctx, struct ilog_array_cache *cache,
+	      struct ilog_entries *entries, int removed)
 {
 	struct ilog_id		*dest;
 	struct ilog_array	*array;
@@ -1438,10 +1422,12 @@ collapse_tree(struct ilog_context *lctx, struct ilog_array_cache *cache, struct 
 	array = cache->ac_array;
 
 	for (i = 0; i < cache->ac_nr; i++) {
-		if (!priv->ip_removals[i])
+
+		if (!entries->ie_info[i].ii_removed)
 			continue;
 
 		dest = &cache->ac_entries[i];
+
 		D_DEBUG(DB_TRACE, "Removing ilog entry at "DF_X64"\n",
 			dest->id_epoch);
 
@@ -1460,7 +1446,7 @@ collapse_tree(struct ilog_context *lctx, struct ilog_array_cache *cache, struct 
 	if (cache->ac_nr == removed + 1) {
 		/** all but one entry removed, move it to root */
 		for (i = 0; i < cache->ac_nr; i++) {
-			if (!priv->ip_removals[i])
+			if (!entries->ie_info[i].ii_removed)
 				return reset_root(lctx, cache, i);
 		}
 		D_ASSERT(0);
@@ -1474,7 +1460,7 @@ collapse_tree(struct ilog_context *lctx, struct ilog_array_cache *cache, struct 
 	dest = &array->ia_id[0];
 
 	for (i = 0; i < cache->ac_nr; i++) {
-		if (priv->ip_removals[i])
+		if (entries->ie_info[i].ii_removed)
 			continue;
 
 		dest->id_value = cache->ac_entries[i].id_value;
@@ -1533,12 +1519,6 @@ ilog_aggregate(struct umem_instance *umm, struct ilog_df *ilog,
 
 	ilog_log2cache(lctx, &cache);
 
-	if (priv->ip_removals == NULL) {
-		D_ALLOC_ARRAY(priv->ip_removals, cache.ac_nr);
-		if (priv->ip_removals == NULL)
-			return -DER_NOMEM;
-	}
-
 	agg_arg.aa_epr = epr;
 	agg_arg.aa_prev = -1;
 	agg_arg.aa_prior_punch = -1;
@@ -1549,7 +1529,6 @@ ilog_aggregate(struct umem_instance *umm, struct ilog_df *ilog,
 
 	ilog_foreach_entry(entries, &entry) {
 		D_ASSERT(entry.ie_idx < cache.ac_nr);
-		priv->ip_removals[entry.ie_idx] = false;
 		rc = check_agg_entry(entries, &entry, &agg_arg);
 
 		switch (rc) {
@@ -1559,12 +1538,12 @@ ilog_aggregate(struct umem_instance *umm, struct ilog_df *ilog,
 			agg_arg.aa_prev = entry.ie_idx;
 			break;
 		case AGG_RC_REMOVE_PREV:
-			priv->ip_removals[agg_arg.aa_prev] = true;
+			entries->ie_info[agg_arg.aa_prev].ii_removed = 1;
 			removed++;
 			agg_arg.aa_prev = agg_arg.aa_prior_punch;
 			/* Fall through */
 		case AGG_RC_REMOVE:
-			priv->ip_removals[entry.ie_idx] = true;
+			entries->ie_info[entry.ie_idx].ii_removed = 1;
 			removed++;
 			break;
 		case AGG_RC_ABORT:
@@ -1577,7 +1556,7 @@ ilog_aggregate(struct umem_instance *umm, struct ilog_df *ilog,
 	}
 
 collapse:
-	rc = collapse_tree(lctx, &cache, priv, removed);
+	rc = collapse_tree(lctx, &cache, entries, removed);
 
 	empty = ilog_empty(root);
 done:

--- a/src/vos/ilog.h
+++ b/src/vos/ilog.h
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2019-2021 Intel Corporation.
+ * (C) Copyright 2019-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -167,7 +167,15 @@ struct ilog_entry {
 	int32_t		ie_idx;
 };
 
-#define ILOG_PRIV_SIZE 416
+#define ILOG_PRIV_SIZE 408
+/* Information about ilog entries */
+struct ilog_info {
+	/** Status of ilog entry */
+	int16_t		ii_status;
+	/** Used internally to indicate removal during aggregation */
+	uint16_t	ii_removed;
+};
+
 /** Structure for storing the full incarnation log for ilog_fetch.  The
  * fields shouldn't generally be accessed directly but via the iteration
  * APIs below.
@@ -175,7 +183,8 @@ struct ilog_entry {
 struct ilog_entries {
 	/** Array of log entries */
 	struct ilog_id		*ie_ids;
-	uint32_t		*ie_statuses;
+	/** Parsed information about each ilog entry */
+	struct ilog_info	*ie_info;
 	/** Number of entries in the log */
 	int64_t			 ie_num_entries;
 	/** Private log data */
@@ -257,7 +266,7 @@ ilog_cache_entry(const struct ilog_entries *entries, struct ilog_entry *entry, i
 {
 	entry->ie_id.id_value = entries->ie_ids[idx].id_value;
 	entry->ie_id.id_epoch = entries->ie_ids[idx].id_epoch;
-	entry->ie_status = entries->ie_statuses[idx];
+	entry->ie_status = entries->ie_info[idx].ii_status;
 	return true;
 }
 

--- a/src/vos/vos_ilog.c
+++ b/src/vos/vos_ilog.c
@@ -209,7 +209,8 @@ vos_parse_ilog(struct vos_ilog_info *info, const daos_epoch_range_t *epr,
 		if (entry.ie_id.id_epoch > info->ii_uncommitted)
 			info->ii_uncommitted = 0;
 
-		D_ASSERT(entry.ie_status == ILOG_COMMITTED);
+		D_ASSERTF(entry.ie_status == ILOG_COMMITTED, "entry.ie_status is %d\n",
+			  entry.ie_status);
 
 		if (ilog_has_punch(&entry)) {
 			info->ii_prior_punch.pr_epc = entry.ie_id.id_epoch;

--- a/src/vos/vos_io.c
+++ b/src/vos/vos_io.c
@@ -1758,8 +1758,8 @@ akey_update(struct vos_io_context *ioc, uint32_t pm_ver, daos_handle_t ak_toh,
 				      recx_csum, iod->iod_size, ioc,
 				      minor_epc);
 		if (rc != 0) {
-			D_ERROR("akey "DF_KEY" update, akey_update_recx failed, "DF_RC"\n",
-				DP_KEY(&iod->iod_name), DP_RC(rc));
+			VOS_TX_LOG_FAIL(rc, "akey "DF_KEY" update, akey_update_recx failed, "
+					DF_RC"\n", DP_KEY(&iod->iod_name), DP_RC(rc));
 			goto out;
 		}
 	}


### PR DESCRIPTION
master branch PRs: #8376, #8410

In first implementation of ilog tracking, we added a separate
allocation for tracking removals. Embed this information
in the, normally embedded, status array. This doesn't make
a big difference in practice but does reduce allocations on the
critical path for aggregation.

There is an inconsistency in the handling of -DER_INPROGRESS entries.
In all cases, the whole ilog should be parsed and the entries should
be marked such, letting the higher level parsing function handle
things. There was previously an inconsistency between the behavior
when updating status on a cached ilog and reading a new one.

Also, remove some unecessary assertions on the critical path and,
since we no longer ever return -DER_INPROGRESS from ilog_fetch,
remove a check on the critical path as well. Ultimately, this
removes a few branches from the critical path and does seem to help
performance a little in my local testing.

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>