### PR TITLE
DAOS-9725 csum: Eliminate potential race condition for fetch

### DIFF
--- a/src/common/checksum.c
+++ b/src/common/checksum.c
@@ -1191,6 +1191,142 @@ ci_buf2uint64(const uint8_t *buf, uint16_t len)
 	return 0;
 }
 
+static int
+dcs_csum_info_list_resize(struct dcs_ci_list *list, daos_size_t number_of_bytes_needed)
+{
+	uint8_t			*new_allocation;
+	uint32_t		 i;
+	uint32_t		 new_buf_size;
+
+	new_buf_size = (list->dcl_buf_size + number_of_bytes_needed) * 2;
+	D_REALLOC(new_allocation, list->dcl_csum_infos, list->dcl_buf_size, new_buf_size);
+
+	if (new_allocation == NULL)
+		return -DER_NOMEM;
+	list->dcl_csum_infos = new_allocation;
+	list->dcl_buf_size = new_buf_size;
+
+	/* need to rewire the csum buffers */
+	for (i = 0; i < list->dcl_csum_infos_nr; i++) {
+		struct dcs_csum_info *dst = dcs_csum_info_get(list, i);
+
+		dst->cs_csum = ((uint8_t *)dst) + sizeof(struct dcs_csum_info);
+	}
+
+	return 0;
+}
+
+static inline bool
+list_has_enough_space(struct dcs_ci_list *list, struct dcs_csum_info *info,
+		      daos_size_t *size_needed)
+{
+	*size_needed = sizeof(struct dcs_csum_info) + ci_csums_len(*info);
+
+	return list->dcl_buf_used + *size_needed <= list->dcl_buf_size;
+}
+
+static inline void
+copy_csum_info(struct dcs_csum_info *dst, struct dcs_csum_info *src)
+{
+	/* copy everything, then will update the csum buffer */
+	*dst = *src;
+	/*
+	 * For a csum_info list, the csum will always be stored just after the csum_info.
+	 * It is assumed that enough memory has been allocated to perform this copy.
+	 */
+	dst->cs_csum = ((uint8_t *)dst) + sizeof(struct dcs_csum_info);
+	memcpy(dst->cs_csum, src->cs_csum, dst->cs_buf_len);
+}
+
+static struct dcs_csum_info *
+csum_info_get_local(struct dcs_ci_list *list, uint32_t idx, bool check_idx)
+{
+	struct dcs_csum_info	*result;
+	int			 i;
+
+	if (check_idx && idx >= list->dcl_csum_infos_nr)
+		return NULL;
+
+	result = (struct dcs_csum_info *) &list->dcl_csum_infos[0];
+	for (i = 0; i < idx; i++)
+		result = (struct dcs_csum_info *)(((uint8_t *)result) +
+						  sizeof(struct dcs_csum_info) +
+						  ci_csums_len(*result));
+
+	return result;
+}
+
+static struct dcs_csum_info *
+dcs_csum_info_get_next(struct dcs_ci_list *list)
+{
+	return csum_info_get_local(list, list->dcl_csum_infos_nr, false);
+}
+
+struct dcs_csum_info *
+dcs_csum_info_get(struct dcs_ci_list *list, uint32_t idx)
+{
+	D_ASSERT(list);
+
+	return csum_info_get_local(list, idx, true);
+}
+
+int
+dcs_csum_info_list_init(struct dcs_ci_list *list, uint32_t nr)
+{
+	/* An initial size. Using 8 extra bytes for csum storage, but the
+	 * buffer will grow as needed.
+	 */
+	daos_size_t initial_size = (sizeof(struct dcs_csum_info) + 8) * nr;
+
+	D_ASSERT(list);
+
+	memset(list, 0, sizeof(*list));
+	if (nr == 0)
+		return 0;
+
+	list->dcl_buf_size = initial_size;
+	D_ALLOC(list->dcl_csum_infos, list->dcl_buf_size);
+	if (list->dcl_csum_infos == NULL)
+		return -DER_NOMEM;
+
+	return 0;
+}
+
+void
+dcs_csum_info_list_fini(struct dcs_ci_list *list)
+{
+	D_FREE(list->dcl_csum_infos);
+	list->dcl_buf_size = 0;
+	list->dcl_csum_infos_nr = 0;
+	list->dcl_buf_used = 0;
+}
+
+int
+dcs_csum_info_save(struct dcs_ci_list *list, struct dcs_csum_info *info,
+		   struct dcs_csum_info **ci_out)
+{
+	daos_size_t		 size_needed;
+	struct dcs_csum_info	*dst;
+	int			 rc;
+
+	if (!list_has_enough_space(list, info, &size_needed)) {
+		rc = dcs_csum_info_list_resize(list, size_needed);
+		if (rc != 0)
+			return rc;
+	}
+
+	dst = dcs_csum_info_get_next(list);
+	copy_csum_info(dst, info);
+
+	list->dcl_csum_infos_nr++;
+	list->dcl_buf_used += size_needed;
+
+	if (ci_out)
+		*ci_out = dst;
+
+	return 0;
+}
+
 /** helper for printing csum as a 64bit value */
 uint64_t
 ci2csum(struct dcs_csum_info ci)

--- a/src/common/checksum.c
+++ b/src/common/checksum.c
@@ -1303,8 +1303,7 @@ dcs_csum_info_list_fini(struct dcs_ci_list *list)
 }
 
 int
-dcs_csum_info_save(struct dcs_ci_list *list, struct dcs_csum_info *info,
-		   struct dcs_csum_info **ci_out)
+dcs_csum_info_save(struct dcs_ci_list *list, struct dcs_csum_info *info)
 {
 	daos_size_t		 size_needed;
 	struct dcs_csum_info	*dst;
@@ -1321,9 +1320,6 @@ dcs_csum_info_save(struct dcs_ci_list *list, struct dcs_csum_info *info,
 
 	list->dcl_csum_infos_nr++;
 	list->dcl_buf_used += size_needed;
-
-	if (ci_out)
-		*ci_out = dst;
 
 	return 0;
 }

--- a/src/common/checksum.c
+++ b/src/common/checksum.c
@@ -1244,6 +1244,7 @@ csum_info_get_local(struct dcs_ci_list *list, uint32_t idx, bool check_idx)
 	struct dcs_csum_info	*result;
 	int			 i;
 
+	idx += list->dcl_csum_offset;
 	if (check_idx && idx >= list->dcl_csum_infos_nr)
 		return NULL;
 

--- a/src/common/tests/checksum_tests.c
+++ b/src/common/tests/checksum_tests.c
@@ -685,9 +685,8 @@ test_csum_info_list_handle_many(void **state)
 
 	dcs_csum_info_list_fini(&list);
 
-	for (i = 0; i < ARRAY_SIZE(info); i++) {
+	for (i = 0; i < ARRAY_SIZE(info); i++)
 		D_FREE(info->cs_csum);
-	}
 }
 
 #define MAP_MAX 10

--- a/src/common/tests/checksum_tests.c
+++ b/src/common/tests/checksum_tests.c
@@ -642,6 +642,7 @@ test_csum_info_list_handling(void **state)
 	}
 
 
+	/* invalid index returns NULL */
 	assert_null(dcs_csum_info_get(&list, 999));
 
 	dcs_csum_info_list_fini(&list);

--- a/src/include/daos/checksum.h
+++ b/src/include/daos/checksum.h
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2019-2021 Intel Corporation.
+ * (C) Copyright 2019-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -517,6 +517,8 @@ struct dcs_ci_list {
 	uint32_t		 dcl_csum_infos_nr;
 	uint32_t		 dcl_buf_used;
 	uint32_t		 dcl_buf_size;
+	/* hack for supporting biov_csums_used usage in csum_add2iods */
+	uint32_t		 dcl_csum_offset;
 };
 
 /**

--- a/src/include/daos/checksum.h
+++ b/src/include/daos/checksum.h
@@ -510,6 +510,29 @@ void
 ci_cast(struct dcs_csum_info **obj, const d_iov_t *iov);
 
 /**
+ * A dcs_ci_list and associated functions manages the memory for storing a list of csum_infos.
+ */
+struct dcs_ci_list {
+	uint8_t			*dcl_csum_infos;
+	uint32_t		 dcl_csum_infos_nr;
+	uint32_t		 dcl_buf_used;
+	uint32_t		 dcl_buf_size;
+};
+
+/**
+ * Initialize memory for storing the csum_infos. The nr helps to allocate an amount of memory,
+ * but depending on the number of checksums in each csum_info, the list may need to reallocate
+ * more memory to store nr checksums. The reallocation happens internally and the caller doesn't
+ * need to worry about that. dcs_csum_info_list_fini must be called when done so that the memory
+ * allocated is freed.
+ */
+int dcs_csum_info_list_init(struct dcs_ci_list *list, uint32_t nr);
+void dcs_csum_info_list_fini(struct dcs_ci_list *list);
+int dcs_csum_info_save(struct dcs_ci_list *list, struct dcs_csum_info *info,
+		       struct dcs_csum_info **ci_out);
+struct dcs_csum_info *dcs_csum_info_get(struct dcs_ci_list *list, uint32_t idx);
+
+/**
  * change the iov so that buf points to the next csum_info, assuming the
  * current csum info's csum buf is right after it in the buffer.
  */

--- a/src/include/daos/checksum.h
+++ b/src/include/daos/checksum.h
@@ -530,8 +530,7 @@ struct dcs_ci_list {
  */
 int dcs_csum_info_list_init(struct dcs_ci_list *list, uint32_t nr);
 void dcs_csum_info_list_fini(struct dcs_ci_list *list);
-int dcs_csum_info_save(struct dcs_ci_list *list, struct dcs_csum_info *info,
-		       struct dcs_csum_info **ci_out);
+int dcs_csum_info_save(struct dcs_ci_list *list, struct dcs_csum_info *info);
 struct dcs_csum_info *dcs_csum_info_get(struct dcs_ci_list *list, uint32_t idx);
 
 /**

--- a/src/include/daos_srv/srv_csum.h
+++ b/src/include/daos_srv/srv_csum.h
@@ -25,9 +25,9 @@
  * @return
  */
 int
-ds_csum_add2iod(daos_iod_t *iod, struct daos_csummer *csummer,
-		struct bio_sglist *bsgl, struct dcs_csum_info *biov_csums,
-		size_t *biov_csums_used, struct dcs_iod_csums *iod_csums);
+ds_csum_add2iod(daos_iod_t *iod, struct daos_csummer *csummer, struct bio_sglist *bsgl,
+		struct dcs_ci_list *biov_csums, size_t *biov_csums_used,
+		struct dcs_iod_csums *iod_csums);
 
 /**
  * Allocate the memory for and populate the IO Maps structure. This structure is used to identify

--- a/src/include/daos_srv/vos.h
+++ b/src/include/daos_srv/vos.h
@@ -795,7 +795,7 @@ vos_ioh2recx_list(daos_handle_t ioh);
 struct bio_desc *
 vos_ioh2desc(daos_handle_t ioh);
 
-struct dcs_csum_info *
+struct dcs_ci_list *
 vos_ioh2ci(daos_handle_t ioh);
 
 uint32_t

--- a/src/object/srv_csum.c
+++ b/src/object/srv_csum.c
@@ -59,7 +59,7 @@ struct csum_context {
 	/** checksums for the bsgl. There should be 1
 	 * csum info for each iov in bsgl (that's not a hole)
 	 */
-	struct dcs_csum_info	*cc_biov_csums;
+	struct dcs_ci_list	*cc_biov_csums;
 	uint64_t		 cc_biov_csums_idx;
 	/** while processing, keep an index of csum within csum info  */
 	uint64_t		 cc_biov_csum_idx;
@@ -77,9 +77,8 @@ struct csum_context {
 };
 
 static void
-cc_init(struct csum_context *ctx, struct daos_csummer *csummer,
-	struct bio_sglist *bsgl, struct dcs_csum_info *biov_csums,
-	daos_size_t size)
+cc_init(struct csum_context *ctx, struct daos_csummer *csummer, struct bio_sglist *bsgl,
+	struct dcs_ci_list *biov_csums, daos_size_t size)
 {
 	ctx->cc_csummer = csummer;
 	ctx->cc_rec_len = size;
@@ -293,8 +292,10 @@ cc_iodcsum_incr(struct csum_context *ctx, uint32_t nr)
 static uint8_t *
 cc2biovcsum(const struct csum_context *ctx)
 {
-	return ci_idx2csum(&ctx->cc_biov_csums[ctx->cc_biov_csums_idx],
-			   ctx->cc_biov_csum_idx);
+	struct dcs_csum_info *ci = dcs_csum_info_get(ctx->cc_biov_csums, ctx->cc_biov_csums_idx);
+
+	D_ASSERT(ci);
+	return ci_idx2csum(ci, ctx->cc_biov_csum_idx);
 }
 
 static void
@@ -598,9 +599,8 @@ cc_add_csums_for_recx(struct csum_context *ctx, daos_recx_t *recx,
 }
 
 static int
-ds_csum_add2iod_array(daos_iod_t *iod, struct daos_csummer *csummer,
-		      struct bio_sglist *bsgl,
-		      struct dcs_csum_info *biov_csums, size_t *biov_csums_used,
+ds_csum_add2iod_array(daos_iod_t *iod, struct daos_csummer *csummer, struct bio_sglist *bsgl,
+		      struct dcs_ci_list *biov_csums, size_t *biov_csums_used,
 		      struct dcs_iod_csums *iod_csums)
 {
 	struct csum_context	ctx = {0};
@@ -619,7 +619,7 @@ ds_csum_add2iod_array(daos_iod_t *iod, struct daos_csummer *csummer,
 				bio_sgl_iov(bsgl, i)->bi_data_len);
 			continue;
 		}
-		if (!ci_is_valid(&biov_csums[j++])) {
+		if (!ci_is_valid(dcs_csum_info_get(biov_csums, j++))) {
 			D_ERROR("Invalid csum for biov %d.\n", i);
 			return -DER_CSUM;
 		}
@@ -657,9 +657,9 @@ ds_csum_add2iod_array(daos_iod_t *iod, struct daos_csummer *csummer,
 }
 
 int
-ds_csum_add2iod(daos_iod_t *iod, struct daos_csummer *csummer,
-		struct bio_sglist *bsgl, struct dcs_csum_info *biov_csums,
-		size_t *biov_csums_used, struct dcs_iod_csums *iod_csums)
+ds_csum_add2iod(daos_iod_t *iod, struct daos_csummer *csummer, struct bio_sglist *bsgl,
+		struct dcs_ci_list *biov_csums, size_t *biov_csums_used,
+		struct dcs_iod_csums *iod_csums)
 {
 	if (biov_csums_used != NULL)
 		*biov_csums_used = 0;
@@ -671,10 +671,12 @@ ds_csum_add2iod(daos_iod_t *iod, struct daos_csummer *csummer,
 		return 0;
 
 	if (iod->iod_type == DAOS_IOD_SINGLE) {
-	C_TRACE("Adding fetched to IOD: "DF_C_IOD", csum: "DF_CI"\n",
-		DP_C_IOD(iod), DP_CI(biov_csums[0]));
+		struct dcs_csum_info *ci = dcs_csum_info_get(biov_csums, 0);
+
+		C_TRACE("Adding fetched to IOD: "DF_C_IOD", csum: "DF_CI"\n",
+			DP_C_IOD(iod), DP_CI(*ci));
 		ci_insert(&iod_csums->ic_data[0], 0,
-			  biov_csums[0].cs_csum, biov_csums[0].cs_len);
+			  ci->cs_csum, ci->cs_len);
 		if (biov_csums_used != NULL)
 			(*biov_csums_used) = 1;
 		return 0;

--- a/src/object/srv_csum.c
+++ b/src/object/srv_csum.c
@@ -427,7 +427,6 @@ cc_biov_move_next(struct csum_context *ctx, bool biov_csum_used)
 	/** move to the next biov */
 	ctx->cc_bsgl_idx.iov_idx++;
 	ctx->cc_bsgl_idx.iov_offset = 0;
-	C_TRACE("Moving to biov %d\n", ctx->cc_bsgl_idx.iov_idx);
 
 	/** Need to know if biov csum was used. For holes there is no csum, but
 	 * still need to move to next biov
@@ -436,6 +435,9 @@ cc_biov_move_next(struct csum_context *ctx, bool biov_csum_used)
 		ctx->cc_biov_csum_idx = 0;
 		ctx->cc_biov_csums_idx++;
 	}
+
+	C_TRACE("Moving to biov %d, biov_csum_used: %s, csums_idx: %lu\n", ctx->cc_bsgl_idx.iov_idx,
+		biov_csum_used ? "YES": "NO", ctx->cc_biov_csums_idx);
 
 	set_biov_ranges(ctx, ctx->cc_cur_recx_idx);
 }
@@ -675,8 +677,7 @@ ds_csum_add2iod(daos_iod_t *iod, struct daos_csummer *csummer, struct bio_sglist
 
 		C_TRACE("Adding fetched to IOD: "DF_C_IOD", csum: "DF_CI"\n",
 			DP_C_IOD(iod), DP_CI(*ci));
-		ci_insert(&iod_csums->ic_data[0], 0,
-			  ci->cs_csum, ci->cs_len);
+		ci_insert(&iod_csums->ic_data[0], 0, ci->cs_csum, ci->cs_len);
 		if (biov_csums_used != NULL)
 			(*biov_csums_used) = 1;
 		return 0;

--- a/src/object/srv_csum.c
+++ b/src/object/srv_csum.c
@@ -437,7 +437,7 @@ cc_biov_move_next(struct csum_context *ctx, bool biov_csum_used)
 	}
 
 	C_TRACE("Moving to biov %d, biov_csum_used: %s, csums_idx: %lu\n", ctx->cc_bsgl_idx.iov_idx,
-		biov_csum_used ? "YES": "NO", ctx->cc_biov_csums_idx);
+		biov_csum_used ? "YES" : "NO", ctx->cc_biov_csums_idx);
 
 	set_biov_ranges(ctx, ctx->cc_cur_recx_idx);
 }

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -844,6 +844,7 @@ csum_add2iods(daos_handle_t ioh, daos_iod_t *iods, uint32_t iods_nr,
 				 DF_C_IOD", csum: "DF_CI"\n",
 			DP_C_UOID_DKEY(oid, dkey),
 			DP_C_IOD(&iods[i]), DP_CI(*dcs_csum_info_get(csum_infos, biov_csums_idx)));
+		csum_infos->dcl_csum_offset += biov_csums_used;
 		rc = ds_csum_add2iod(
 			&iods[i], csummer,
 			bio_iod_sgl(biod, i), csum_infos,

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -834,7 +834,7 @@ csum_add2iods(daos_handle_t ioh, daos_iod_t *iods, uint32_t iods_nr,
 	int	 i;
 
 	struct bio_desc *biod = vos_ioh2desc(ioh);
-	struct dcs_csum_info *csum_infos = vos_ioh2ci(ioh);
+	struct dcs_ci_list *csum_infos = vos_ioh2ci(ioh);
 	uint32_t csum_info_nr = vos_ioh2ci_nr(ioh);
 
 	for (i = 0; i < iods_nr; i++) {
@@ -843,11 +843,10 @@ csum_add2iods(daos_handle_t ioh, daos_iod_t *iods, uint32_t iods_nr,
 		D_DEBUG(DB_CSUM, DF_C_UOID_DKEY"Adding fetched to IOD: "
 				 DF_C_IOD", csum: "DF_CI"\n",
 			DP_C_UOID_DKEY(oid, dkey),
-			DP_C_IOD(&iods[i]), DP_CI(csum_infos[biov_csums_idx]));
+			DP_C_IOD(&iods[i]), DP_CI(*dcs_csum_info_get(csum_infos, biov_csums_idx)));
 		rc = ds_csum_add2iod(
 			&iods[i], csummer,
-			bio_iod_sgl(biod, i),
-			&csum_infos[biov_csums_idx],
+			bio_iod_sgl(biod, i), csum_infos,
 			&biov_csums_used, get_iod_csum(iod_csums, i));
 
 		if (rc != 0) {

--- a/src/object/tests/srv_checksum_tests.c
+++ b/src/object/tests/srv_checksum_tests.c
@@ -145,7 +145,7 @@ void fake_update_saw(char *file, int line, char *buf, size_t len)
 struct vos_fetch_test_context {
 	size_t			 nr; /** Num of bsgl.bio_iov/biov_csums pairs */
 	struct bio_sglist	 bsgl;
-	struct dcs_csum_info	*biov_csums;
+	struct dcs_ci_list	 biov_csums;
 	daos_iod_t		 iod;
 	struct daos_csummer	*csummer;
 	struct dcs_iod_csums	*iod_csum;
@@ -178,7 +178,6 @@ array_test_case_create(struct vos_fetch_test_context *ctx,
 	uint32_t	 cs;
 	size_t		 i = 0;
 	size_t		 j;
-	size_t		 c;
 	size_t		 nr;
 	uint8_t		*dummy_csums;
 
@@ -198,15 +197,14 @@ array_test_case_create(struct vos_fetch_test_context *ctx,
 	ctx->nr = nr;
 	bio_sgl_init(&ctx->bsgl, nr);
 	ctx->bsgl.bs_nr_out = nr;
-	D_ALLOC_ARRAY(ctx->biov_csums, nr);
-	assert_non_null(ctx->biov_csums);
+	assert_success(dcs_csum_info_list_init(&ctx->biov_csums, 10));
 
-	c = 0;
 	for (i = 0; i < nr; i++) {
 		struct extent_info	*l;
 		char			*data;
 		struct bio_iov		*biov;
-		struct dcs_csum_info	*info;
+		struct dcs_csum_info	 info;
+		uint8_t			 csum_buf[128];
 		size_t			 data_len;
 		size_t			 num_of_csum;
 		bio_addr_t		 addr = {0};
@@ -234,14 +232,16 @@ array_test_case_create(struct vos_fetch_test_context *ctx,
 			/** Just a rough count */
 			num_of_csum = data_len / cs + 1;
 
-			info = &ctx->biov_csums[c++];
-			D_ALLOC(info->cs_csum, csum_len * num_of_csum);
-			info->cs_buf_len = csum_len * num_of_csum;
-			info->cs_nr = num_of_csum;
-			info->cs_len = csum_len;
-			info->cs_chunksize = cs;
+			assert_true(csum_len * num_of_csum <= ARRAY_SIZE(csum_buf));
+			info.cs_csum = csum_buf;
+			info.cs_buf_len = csum_len * num_of_csum;
+			info.cs_nr = num_of_csum;
+			info.cs_len = csum_len;
+			info.cs_chunksize = cs;
 			for (j = 0; j < num_of_csum; j++)
-				ci_insert(info, j, dummy_csums, csum_len);
+				ci_insert(&info, j, dummy_csums, csum_len);
+			dcs_csum_info_save(&ctx->biov_csums, &info, NULL);
+
 		}
 	}
 
@@ -268,10 +268,8 @@ test_case_destroy(struct vos_fetch_test_context *ctx)
 
 		if (bio_buf)
 			D_FREE(bio_buf);
-
-		if (ctx->biov_csums[i].cs_csum)
-			D_FREE(ctx->biov_csums[i].cs_csum);
 	}
+	dcs_csum_info_list_fini(&ctx->biov_csums);
 
 	if (ctx->iod.iod_recxs)
 		D_FREE(ctx->iod.iod_recxs);
@@ -284,7 +282,7 @@ static int
 fetch_csum_verify_bsgl_with_args(struct vos_fetch_test_context *ctx)
 {
 	return ds_csum_add2iod(
-		&ctx->iod, ctx->csummer, &ctx->bsgl, ctx->biov_csums, NULL,
+		&ctx->iod, ctx->csummer, &ctx->bsgl, &ctx->biov_csums, NULL,
 		ctx->iod_csum);
 }
 
@@ -1492,6 +1490,7 @@ update_fetch_sv(void **state)
 	 * biov 'extent'
 	 */
 	struct dcs_csum_info	 from_vos_begin = {0};
+	struct dcs_ci_list	 from_vos_begin_list = {0};
 	struct dcs_csum_info	 csum_info = {0};
 	struct dcs_iod_csums	 iod_csums = {0};
 
@@ -1519,8 +1518,10 @@ update_fetch_sv(void **state)
 
 	ci_set(&from_vos_begin, &csum, sizeof(uint32_t), sizeof(uint32_t), 1,
 	       CSUM_NO_CHUNK, 1);
+	dcs_csum_info_list_init(&from_vos_begin_list, 1);
+	dcs_csum_info_save(&from_vos_begin_list, &from_vos_begin, NULL);
 
-	ds_csum_add2iod(&iod, csummer, &bsgl, &from_vos_begin, NULL,
+	ds_csum_add2iod(&iod, csummer, &bsgl, &from_vos_begin_list, NULL,
 			&iod_csums);
 
 	assert_memory_equal(csum_info.cs_csum, from_vos_begin.cs_csum,

--- a/src/object/tests/srv_checksum_tests.c
+++ b/src/object/tests/srv_checksum_tests.c
@@ -240,8 +240,7 @@ array_test_case_create(struct vos_fetch_test_context *ctx,
 			info.cs_chunksize = cs;
 			for (j = 0; j < num_of_csum; j++)
 				ci_insert(&info, j, dummy_csums, csum_len);
-			dcs_csum_info_save(&ctx->biov_csums, &info, NULL);
-
+			dcs_csum_info_save(&ctx->biov_csums, &info);
 		}
 	}
 
@@ -1519,7 +1518,7 @@ update_fetch_sv(void **state)
 	ci_set(&from_vos_begin, &csum, sizeof(uint32_t), sizeof(uint32_t), 1,
 	       CSUM_NO_CHUNK, 1);
 	dcs_csum_info_list_init(&from_vos_begin_list, 1);
-	dcs_csum_info_save(&from_vos_begin_list, &from_vos_begin, NULL);
+	dcs_csum_info_save(&from_vos_begin_list, &from_vos_begin);
 
 	ds_csum_add2iod(&iod, csummer, &bsgl, &from_vos_begin_list, NULL,
 			&iod_csums);

--- a/src/vos/tests/vts_io.c
+++ b/src/vos/tests/vts_io.c
@@ -670,7 +670,7 @@ io_test_vos_obj_fetch(daos_handle_t coh, daos_unit_oid_t oid, daos_epoch_t epoch
 		}
 
 		rc = ds_csum_add2iod(iod, csummer, bio_iod_sgl(biod, 0),
-				     dcs_csum_info_get(csum_infos, 0), NULL, iod_csums);
+				     csum_infos, NULL, iod_csums);
 		if (rc != DER_SUCCESS) {
 			daos_csummer_free_ic(csummer, &iod_csums);
 			daos_csummer_destroy(&csummer);

--- a/src/vos/tests/vts_io.c
+++ b/src/vos/tests/vts_io.c
@@ -655,7 +655,7 @@ io_test_vos_obj_fetch(daos_handle_t coh, daos_unit_oid_t oid, daos_epoch_t epoch
 	assert_success(rc);
 
 	if (use_checksums) {
-		struct dcs_ci_list *csum_infos = vos_ioh2ci(ioh);
+		struct dcs_ci_list	*csum_infos = vos_ioh2ci(ioh);
 		struct dcs_iod_csums	*iod_csums = NULL;
 		struct daos_csummer	*csummer;
 		daos_iom_t		*maps = NULL;

--- a/src/vos/tests/vts_io.c
+++ b/src/vos/tests/vts_io.c
@@ -655,7 +655,7 @@ io_test_vos_obj_fetch(daos_handle_t coh, daos_unit_oid_t oid, daos_epoch_t epoch
 	assert_success(rc);
 
 	if (use_checksums) {
-		struct dcs_csum_info	*csum_infos = vos_ioh2ci(ioh);
+		struct dcs_ci_list *csum_infos = vos_ioh2ci(ioh);
 		struct dcs_iod_csums	*iod_csums = NULL;
 		struct daos_csummer	*csummer;
 		daos_iom_t		*maps = NULL;
@@ -670,7 +670,7 @@ io_test_vos_obj_fetch(daos_handle_t coh, daos_unit_oid_t oid, daos_epoch_t epoch
 		}
 
 		rc = ds_csum_add2iod(iod, csummer, bio_iod_sgl(biod, 0),
-				     &csum_infos[0], NULL, iod_csums);
+				     dcs_csum_info_get(csum_infos, 0), NULL, iod_csums);
 		if (rc != DER_SUCCESS) {
 			daos_csummer_free_ic(csummer, &iod_csums);
 			daos_csummer_destroy(&csummer);

--- a/src/vos/vos_io.c
+++ b/src/vos/vos_io.c
@@ -774,7 +774,9 @@ save_csum(struct vos_io_context *ioc, struct dcs_csum_info *csum_info,
 	if (ioc->ic_size_fetch)
 		return 0;
 
-	dcs_csum_info_save(&ioc->ic_csum_list, csum_info, &saved_csum_info);
+	rc = dcs_csum_info_save(&ioc->ic_csum_list, csum_info, &saved_csum_info);
+	if (rc != 0)
+		return rc;
 	if (entry != NULL)
 		evt_entry_csum_update(&entry->en_ext, &entry->en_sel_ext,
 				      saved_csum_info, rec_size);

--- a/src/vos/vos_io.c
+++ b/src/vos/vos_io.c
@@ -36,9 +36,7 @@ struct vos_io_context {
 	struct bio_desc		*ic_biod;
 	struct vos_ts_set	*ic_ts_set;
 	/** Checksums for bio_iovs in \ic_biod */
-	struct dcs_csum_info	*ic_biov_csums;
-	uint32_t		 ic_biov_csums_at;
-	uint32_t		 ic_biov_csums_nr;
+	struct dcs_ci_list	 ic_csum_list;
 	/** current dkey info */
 	struct vos_ilog_info	 ic_dkey_info;
 	/** current akey info */
@@ -581,7 +579,7 @@ vos_ioc_destroy(struct vos_io_context *ioc, bool evict)
 	if (ioc->ic_biod != NULL)
 		bio_iod_free(ioc->ic_biod);
 
-	D_FREE(ioc->ic_biov_csums);
+	dcs_csum_info_list_fini(&ioc->ic_csum_list);
 
 	if (ioc->ic_obj)
 		vos_obj_release(vos_obj_cache_current(), ioc->ic_obj, evict);
@@ -697,13 +695,9 @@ vos_ioc_create(daos_handle_t coh, daos_unit_oid_t oid, bool read_only,
 		goto error;
 	}
 
-	ioc->ic_biov_csums_nr = 1;
-	ioc->ic_biov_csums_at = 0;
-	D_ALLOC_ARRAY(ioc->ic_biov_csums, ioc->ic_biov_csums_nr);
-	if (ioc->ic_biov_csums == NULL) {
-		rc = -DER_NOMEM;
+	rc = dcs_csum_info_list_init(&ioc->ic_csum_list, iod_nr);
+	if (rc != 0)
 		goto error;
-	}
 
 	for (i = 0; i < iod_nr; i++) {
 		int iov_nr = iods[i].iod_nr;
@@ -769,27 +763,6 @@ iod_fetch(struct vos_io_context *ioc, struct bio_iov *biov)
 	return 0;
 }
 
-static int
-bsgl_csums_resize(struct vos_io_context *ioc)
-{
-	struct dcs_csum_info *csums = ioc->ic_biov_csums;
-	uint32_t	 dcb_nr = ioc->ic_biov_csums_nr;
-
-	if (ioc->ic_biov_csums_at == dcb_nr - 1) {
-		struct dcs_csum_info *new_infos;
-		uint32_t	 new_nr = dcb_nr * 2;
-
-		D_REALLOC_ARRAY(new_infos, csums, dcb_nr, new_nr);
-		if (new_infos == NULL)
-			return -DER_NOMEM;
-
-		ioc->ic_biov_csums = new_infos;
-		ioc->ic_biov_csums_nr = new_nr;
-	}
-
-	return 0;
-}
-
 /** Save the checksum to a list that can be retrieved later */
 static int
 save_csum(struct vos_io_context *ioc, struct dcs_csum_info *csum_info,
@@ -801,22 +774,10 @@ save_csum(struct vos_io_context *ioc, struct dcs_csum_info *csum_info,
 	if (ioc->ic_size_fetch)
 		return 0;
 
-	rc = bsgl_csums_resize(ioc);
-	if (rc != 0)
-		return rc;
-
-	/**
-	 * it's expected that the csum the csum_info points to is in memory
-	 * that will persist until fetch is complete ... so memcpy isn't needed
-	 */
-	saved_csum_info = &ioc->ic_biov_csums[ioc->ic_biov_csums_at];
-	*saved_csum_info = *csum_info;
+	dcs_csum_info_save(&ioc->ic_csum_list, csum_info, &saved_csum_info);
 	if (entry != NULL)
 		evt_entry_csum_update(&entry->en_ext, &entry->en_sel_ext,
 				      saved_csum_info, rec_size);
-
-	ioc->ic_biov_csums_at++;
-
 	return 0;
 }
 
@@ -2444,12 +2405,12 @@ vos_ioh2desc(daos_handle_t ioh)
 	return ioc->ic_biod;
 }
 
-struct dcs_csum_info *
+struct dcs_ci_list *
 vos_ioh2ci(daos_handle_t ioh)
 {
 	struct vos_io_context *ioc = vos_ioh2ioc(ioh);
 
-	return ioc->ic_biov_csums;
+	return &ioc->ic_csum_list;
 }
 
 uint32_t
@@ -2457,7 +2418,7 @@ vos_ioh2ci_nr(daos_handle_t ioh)
 {
 	struct vos_io_context *ioc = vos_ioh2ioc(ioh);
 
-	return ioc->ic_biov_csums_at;
+	return ioc->ic_csum_list.dcl_csum_infos_nr;
 }
 
 struct bio_sglist *

--- a/src/vos/vos_io.c
+++ b/src/vos/vos_io.c
@@ -768,19 +768,17 @@ static int
 save_csum(struct vos_io_context *ioc, struct dcs_csum_info *csum_info,
 	  struct evt_entry *entry, daos_size_t rec_size)
 {
-	struct dcs_csum_info	*saved_csum_info;
-	int			 rc;
+	struct dcs_csum_info ci_duplicate;
 
 	if (ioc->ic_size_fetch)
 		return 0;
 
-	rc = dcs_csum_info_save(&ioc->ic_csum_list, csum_info, &saved_csum_info);
-	if (rc != 0)
-		return rc;
-	if (entry != NULL)
-		evt_entry_csum_update(&entry->en_ext, &entry->en_sel_ext,
-				      saved_csum_info, rec_size);
-	return 0;
+	if (entry == NULL)
+		return dcs_csum_info_save(&ioc->ic_csum_list, csum_info);
+
+	ci_duplicate = *csum_info;
+	evt_entry_csum_update(&entry->en_ext, &entry->en_sel_ext, &ci_duplicate, rec_size);
+	return dcs_csum_info_save(&ioc->ic_csum_list, &ci_duplicate);
 }
 
 /** Fetch the single value within the specified epoch range of an key */


### PR DESCRIPTION
During a vos_fetch_begin() the checksums are collected into an
array of csum_info structures. These structures pointed to the
checksums in SCM. However, after vos_fetch_begin() a call to
bio_iod_prep() can yield because of NVMe access. During the yield
the checksum the csum_info structures reference could change,
corrupting the csum. Instead of pointing to the checksum in SCM
we need to copy it into memory.

In order to manage the csum_infos and csum_buf in memory a new
structure and functions for better managing a list
of csum_infos is introduced. These functions and structure are
used during vos fetch.

Signed-off-by: Ryon Jensen <ryon.jensen@intel.com>