### PR TITLE
DAOS-9860 dtx: discard stale active DTX entries for reintegration

### DIFF
--- a/src/dtx/dtx_common.c
+++ b/src/dtx/dtx_common.c
@@ -210,6 +210,10 @@ dtx_cleanup_stale_iter_cb(uuid_t co_uuid, vos_iter_entry_t *ent, void *args)
 	if (ent->ie_dtx_flags & DTE_ORPHAN)
 		return 0;
 
+	/* Skip unprepared entry. */
+	if (ent->ie_dtx_tgt_cnt == 0)
+		return 0;
+
 	/* Stop the iteration if current DTX is not too old. */
 	if (dtx_hlc_age2sec(ent->ie_dtx_start_time) <=
 	    DTX_CLEANUP_THD_AGE_LO)
@@ -253,8 +257,7 @@ dtx_cleanup_stale(void *arg)
 	D_INIT_LIST_HEAD(&dcsca.dcsca_list);
 	dcsca.dcsca_count = 0;
 	rc = ds_cont_iter(cont->sc_pool->spc_hdl, cont->sc_uuid,
-			  dtx_cleanup_stale_iter_cb, &dcsca, VOS_ITER_DTX,
-			  VOS_IT_CLEANUP_DTX);
+			  dtx_cleanup_stale_iter_cb, &dcsca, VOS_ITER_DTX, 0);
 	if (rc < 0)
 		D_WARN("Failed to scan stale DTX entry for "
 		       DF_UUID": "DF_RC"\n", DP_UUID(cont->sc_uuid), DP_RC(rc));

--- a/src/dtx/dtx_internal.h
+++ b/src/dtx/dtx_internal.h
@@ -55,6 +55,8 @@ enum dtx_operation {
 
 CRT_RPC_DECLARE(dtx, DAOS_ISEQ_DTX, DAOS_OSEQ_DTX);
 
+#define DTX_YIELD_CYCLE		(DTX_THRESHOLD_COUNT >> 3)
+
 /* The time threshold for triggerring DTX cleanup of stale entries.
  * If the oldest active DTX exceeds such threshold, it will trigger
  * DTX cleanup locally.

--- a/src/dtx/dtx_resync.c
+++ b/src/dtx/dtx_resync.c
@@ -38,7 +38,8 @@ struct dtx_resync_args {
 	struct dtx_resync_head	 tables;
 	daos_epoch_t		 epoch;
 	uint32_t		 version;
-	uint32_t		 resync_all:1;
+	uint32_t		 resync_all:1,
+				 for_discard:1;
 };
 
 static inline void
@@ -380,6 +381,23 @@ dtx_status_handle(struct dtx_resync_args *dra)
 	if (drh->drh_count == 0)
 		goto out;
 
+	if (dra->for_discard) {
+		while ((dre = d_list_pop_entry(&drh->drh_list, struct dtx_resync_entry,
+					       dre_link)) != NULL) {
+			err = vos_dtx_abort(cont->sc_hdl, &dre->dre_xid, dre->dre_epoch);
+			dtx_dre_release(drh, dre);
+			if (err == -DER_NONEXIST)
+				err = 0;
+			if (err != 0)
+				goto out;
+
+			if (unlikely(count++ >= DTX_YIELD_CYCLE))
+				ABT_thread_yield();
+		}
+
+		goto out;
+	}
+
 	ABT_rwlock_rdlock(pool->sp_lock);
 	tgt_cnt = pool_map_target_nr(pool->sp_map);
 	ABT_rwlock_unlock(pool->sp_lock);
@@ -453,7 +471,7 @@ out:
 				       dre_link)) != NULL)
 		dtx_dre_release(drh, dre);
 
-	if (err >= 0 && !cont->sc_closing)
+	if (err >= 0 && !cont->sc_closing && !dra->for_discard)
 		/* Drain old committable DTX to help subsequent rebuild. */
 		err = dtx_obj_sync(cont, NULL, dra->epoch);
 
@@ -513,8 +531,28 @@ dtx_iter_cb(uuid_t co_uuid, vos_iter_entry_t *ent, void *args)
 			return 0;
 	}
 
+	if (dra->for_discard) {
+		/* For discard case, skip new added entry. */
+		if (ent->ie_dtx_ver >= dra->version)
+			return 0;
+
+		D_ALLOC_PTR(dre);
+		if (dre == NULL)
+			return -DER_NOMEM;
+
+		dre->dre_epoch = ent->ie_epoch;
+		dte = &dre->dre_dte;
+		dte->dte_xid = ent->ie_dtx_xid;
+		dte->dte_refs = 1;
+
+		goto out;
+	}
+
+	/* For non-discard case, skip unprepared entry. */
+	if (ent->ie_dtx_tgt_cnt == 0)
+		return 0;
+
 	D_ASSERT(ent->ie_dtx_mbs_dsize > 0);
-	D_ASSERT(ent->ie_dtx_tgt_cnt > 0);
 
 	size = sizeof(*dre) + sizeof(*mbs) + ent->ie_dtx_mbs_dsize;
 	D_ALLOC(dre, size);
@@ -540,6 +578,7 @@ dtx_iter_cb(uuid_t co_uuid, vos_iter_entry_t *ent, void *args)
 	dte->dte_refs = 1;
 	dte->dte_mbs = mbs;
 
+out:
 	d_list_add_tail(&dre->dre_link, &dra->tables.drh_list);
 	dra->tables.drh_count++;
 
@@ -551,6 +590,8 @@ dtx_resync(daos_handle_t po_hdl, uuid_t po_uuid, uuid_t co_uuid, uint32_t ver,
 	   bool block, bool resync_all)
 {
 	struct ds_cont_child		*cont = NULL;
+	struct ds_pool			*pool;
+	struct pool_target		*target;
 	struct dtx_resync_args		 dra = { 0 };
 	d_rank_t			 myrank;
 	int				 rc = 0;
@@ -564,6 +605,18 @@ dtx_resync(daos_handle_t po_hdl, uuid_t po_uuid, uuid_t co_uuid, uint32_t ver,
 			DP_UUID(po_uuid), DP_UUID(co_uuid), rc);
 		return rc;
 	}
+
+	crt_group_rank(NULL, &myrank);
+
+	pool = cont->sc_pool->spc_pool;
+	ABT_rwlock_rdlock(pool->sp_lock);
+	rc = pool_map_find_target_by_rank_idx(pool->sp_map, myrank,
+					      dss_get_module_info()->dmi_tgt_id, &target);
+	D_ASSERT(rc == 1);
+	ABT_rwlock_unlock(pool->sp_lock);
+
+	if (target->ta_comp.co_status == PO_COMP_ST_UP)
+		dra.for_discard = 1;
 
 	ABT_mutex_lock(cont->sc_mutex);
 
@@ -583,7 +636,6 @@ dtx_resync(daos_handle_t po_hdl, uuid_t po_uuid, uuid_t co_uuid, uint32_t ver,
 		goto out;
 	}
 
-	crt_group_rank(NULL, &myrank);
 	if (myrank == daos_fail_value_get() &&
 	    DAOS_FAIL_CHECK(DAOS_DTX_SRV_RESTART)) {
 		dss_set_start_epoch();
@@ -629,7 +681,7 @@ dtx_resync(daos_handle_t po_hdl, uuid_t po_uuid, uuid_t co_uuid, uint32_t ver,
 
 out:
 	ds_cont_child_put(cont);
-	return rc;
+	return rc > 0 ? 0 : rc;
 }
 
 struct dtx_container_scan_arg {

--- a/src/dtx/dtx_srv.c
+++ b/src/dtx/dtx_srv.c
@@ -17,8 +17,6 @@
 #include <gurt/telemetry_consumer.h>
 #include "dtx_internal.h"
 
-#define DTX_YIELD_CYCLE		(DTX_THRESHOLD_COUNT >> 3)
-
 static void *
 dtx_tls_init(int xs_id, int tgt_id)
 {

--- a/src/include/daos_srv/vos_types.h
+++ b/src/include/daos_srv/vos_types.h
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2015-2021 Intel Corporation.
+ * (C) Copyright 2015-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -325,13 +325,11 @@ enum {
 	/** Iterate only show punched records in interval */
 	VOS_IT_PUNCHED		= (1 << 6),
 	/** Cleanup stale DTX entry. */
-	VOS_IT_CLEANUP_DTX	= (1 << 7),
-	/** Cleanup stale DTX entry. */
-	VOS_IT_FOR_DISCARD	= (1 << 8),
+	VOS_IT_FOR_DISCARD	= (1 << 7),
 	/** Entry is not committed */
-	VOS_IT_UNCOMMITTED	= (1 << 9),
+	VOS_IT_UNCOMMITTED	= (1 << 8),
 	/** Mask for all flags */
-	VOS_IT_MASK		= (1 << 10) - 1,
+	VOS_IT_MASK		= (1 << 9) - 1,
 };
 
 /**

--- a/src/vos/vos_dtx_iter.c
+++ b/src/vos/vos_dtx_iter.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2019-2021 Intel Corporation.
+ * (C) Copyright 2019-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -74,9 +74,6 @@ dtx_iter_prep(vos_iter_type_t type, vos_iter_param_t *param,
 	if (oiter == NULL)
 		return -DER_NOMEM;
 
-	if (param->ip_flags & VOS_IT_CLEANUP_DTX)
-		oiter->oit_iter.it_cleanup_stale_dtx = 1;
-
 	oiter->oit_iter.it_type = type;
 	oiter->oit_cont = cont;
 	vos_cont_addref(cont);
@@ -116,8 +113,6 @@ dtx_iter_probe(struct vos_iterator *iter, daos_anchor_t *anchor)
 			d_list_entry(oiter->oit_cont->vc_dtx_act_list.next,
 				     struct vos_dtx_act_ent, dae_link);
 	} else {
-		D_ASSERT(!oiter->oit_iter.it_cleanup_stale_dtx);
-
 		oiter->oit_linear = false;
 		rc = dbtree_iter_probe(oiter->oit_hdl, BTR_PROBE_GE,
 				       vos_iter_intent(iter), NULL, anchor);
@@ -136,8 +131,7 @@ dtx_iter_probe(struct vos_iterator *iter, daos_anchor_t *anchor)
 		dae = rec_iov.iov_buf;
 	}
 
-	while (dae->dae_committable || dae->dae_committed ||
-	       dae->dae_aborted || dae->dae_dbd == NULL) {
+	while (dae->dae_committable || dae->dae_committed || dae->dae_aborted) {
 		if (oiter->oit_linear) {
 			if (dae->dae_link.next ==
 			    &oiter->oit_cont->vc_dtx_act_list) {
@@ -208,8 +202,7 @@ dtx_iter_next(struct vos_iterator *iter)
 				 sizeof(struct vos_dtx_act_ent));
 			dae = rec_iov.iov_buf;
 		}
-	} while (dae->dae_committable || dae->dae_committed ||
-		 dae->dae_aborted || dae->dae_dbd == NULL);
+	} while (dae->dae_committable || dae->dae_committed || dae->dae_aborted);
 
 out:
 	return rc;
@@ -248,25 +241,33 @@ dtx_iter_fetch(struct vos_iterator *iter, vos_iter_entry_t *it_entry,
 	D_ASSERT(!dae->dae_committable);
 	D_ASSERT(!dae->dae_committed);
 	D_ASSERT(!dae->dae_aborted);
-	D_ASSERT(dae->dae_dbd != NULL);
 
 	it_entry->ie_epoch = DAE_EPOCH(dae);
 	it_entry->ie_dtx_xid = DAE_XID(dae);
 	it_entry->ie_dtx_oid = DAE_OID(dae);
 	it_entry->ie_dtx_ver = DAE_VER(dae);
 	it_entry->ie_dtx_flags = DAE_FLAGS(dae);
-	it_entry->ie_dtx_mbs_flags = DAE_MBS_FLAGS(dae);
-	it_entry->ie_dtx_tgt_cnt = DAE_TGT_CNT(dae);
-	it_entry->ie_dtx_grp_cnt = DAE_GRP_CNT(dae);
-	it_entry->ie_dtx_mbs_dsize = DAE_MBS_DSIZE(dae);
 	it_entry->ie_dtx_start_time = dae->dae_start_time;
 	it_entry->ie_dkey_hash = DAE_DKEY_HASH(dae);
-	if (DAE_MBS_DSIZE(dae) <= sizeof(DAE_MBS_INLINE(dae)))
-		it_entry->ie_dtx_mbs = DAE_MBS_INLINE(dae);
-	else
-		it_entry->ie_dtx_mbs = umem_off2ptr(
-					&oiter->oit_cont->vc_pool->vp_umm,
-					DAE_MBS_OFF(dae));
+
+	if (dae->dae_dbd == NULL) {
+		/* Unprepared entry, the MBS data is not initialized. */
+		it_entry->ie_dtx_mbs_flags = 0;
+		it_entry->ie_dtx_tgt_cnt = 0;
+		it_entry->ie_dtx_grp_cnt = 0;
+		it_entry->ie_dtx_mbs_dsize = 0;
+		it_entry->ie_dtx_mbs = NULL;
+	} else {
+		it_entry->ie_dtx_mbs_flags = DAE_MBS_FLAGS(dae);
+		it_entry->ie_dtx_tgt_cnt = DAE_TGT_CNT(dae);
+		it_entry->ie_dtx_grp_cnt = DAE_GRP_CNT(dae);
+		it_entry->ie_dtx_mbs_dsize = DAE_MBS_DSIZE(dae);
+		if (DAE_MBS_DSIZE(dae) <= sizeof(DAE_MBS_INLINE(dae)))
+			it_entry->ie_dtx_mbs = DAE_MBS_INLINE(dae);
+		else
+			it_entry->ie_dtx_mbs = umem_off2ptr(&oiter->oit_cont->vc_pool->vp_umm,
+							    DAE_MBS_OFF(dae));
+	}
 
 	D_DEBUG(DB_IO, "DTX iterator fetch the one "DF_DTI"\n",
 		DP_DTI(&DAE_XID(dae)));

--- a/src/vos/vos_internal.h
+++ b/src/vos/vos_internal.h
@@ -812,7 +812,6 @@ struct vos_iterator {
 				 it_for_purge:1,
 				 it_for_discard:1,
 				 it_for_migration:1,
-				 it_cleanup_stale_dtx:1,
 				 it_show_uncommitted:1,
 				 it_ignore_uncommitted:1;
 };

--- a/src/vos/vos_obj.c
+++ b/src/vos/vos_obj.c
@@ -1950,7 +1950,6 @@ vos_obj_iter_aggregate(daos_handle_t ih, bool range_discard)
 	struct umem_instance	*umm;
 	struct vos_krec_df	*krec;
 	struct vos_object	*obj;
-	struct umem_attr	 uma;
 	daos_key_t		 key;
 	struct vos_rec_bundle	 rbund;
 	bool			 reprobe = false;
@@ -1983,22 +1982,11 @@ vos_obj_iter_aggregate(daos_handle_t ih, bool range_discard)
 		reprobe = true;
 		D_DEBUG(DB_IO, "Removing %s from tree\n",
 			iter->it_type == VOS_ITER_DKEY ? "dkey" : "akey");
-		/** Orphaned values indicate an incarnation log bug.  It happens
-		 *  when the key containing the subtree doesn't have a creation
-		 *  timestamp for updates in the subtree.
+
+		/* XXX: The value tree may be not empty because related prepared transaction can
+		 *	be aborted. Then it will be added and handled via GC when ktr_rec_free().
 		 */
-		if (krec->kr_bmap & KREC_BF_BTR) {
-			D_ASSERTF(dbtree_is_empty_inplace(&krec->kr_btr),
-				  "Orphaned %s detected\n",
-				  iter->it_type == VOS_ITER_DKEY ?
-				  "akey" : "single value");
-		} else if (krec->kr_bmap & KREC_BF_EVT) {
-			umem_attr_get(umm, &uma);
-			rc = evt_has_data(&krec->kr_evt, &uma);
-			if (rc < 0)
-				goto end;
-			D_ASSERTF(rc == 0, "Orphaned array value detected\n");
-		}
+
 		rc = dbtree_iter_delete(oiter->it_hdl, NULL);
 		D_ASSERT(rc != -DER_NONEXIST);
 	} else if (rc == -DER_NONEXIST) {
@@ -2007,7 +1995,6 @@ vos_obj_iter_aggregate(daos_handle_t ih, bool range_discard)
 		rc = 0;
 	}
 
-end:
 	rc = umem_tx_end(umm, rc);
 
 exit:

--- a/src/vos/vos_obj_index.c
+++ b/src/vos/vos_obj_index.c
@@ -734,12 +734,11 @@ oi_iter_aggregate(daos_handle_t ih, bool range_discard)
 		D_DEBUG(DB_IO, "Removing object "DF_UOID" from tree\n",
 			DP_UOID(oid));
 		reprobe = true;
-		if (!dbtree_is_empty_inplace(&obj->vo_tree)) {
-			/* This can be an assert once we have sane under punch
-			 * detection.
-			 */
-			D_ERROR("Removing orphaned dkey tree\n");
-		}
+
+		/* XXX: The dkey tree may be not empty because related prepared transaction can
+		 *	be aborted. Then it will be added and handled via GC when oi_rec_free().
+		 */
+
 		/* Evict the object from cache */
 		rc = vos_obj_evict_by_oid(vos_obj_cache_current(),
 					  oiter->oit_cont, oid);


### PR DESCRIPTION
When a DAOS target is down, related active DTX entries on it will
be handled via DTX resync by other alive targets: either committed
or aborted. When the target is reintegrated back, these DTX entries
are stale and need to be discarded before doing real data migration.

Signed-off-by: Fan Yong <fan.yong@intel.com>