### PR TITLE
DAOS-9756 vos: Add pre-check filter to vos iterator

### DIFF
--- a/src/container/srv_target.c
+++ b/src/container/srv_target.c
@@ -2189,7 +2189,7 @@ ds_cont_iter(daos_handle_t ph, uuid_t co_uuid, cont_iter_cb_t callback,
 			break;
 		}
 
-		rc = vos_iter_next(iter_h);
+		rc = vos_iter_next(iter_h, NULL);
 		if (rc != 0) {
 			/* reach to the end of the container */
 			if (rc == -DER_NONEXIST)

--- a/src/include/daos_srv/vos.h
+++ b/src/include/daos_srv/vos.h
@@ -890,8 +890,10 @@ vos_iter_finish(daos_handle_t ih);
  * not NULL, otherwise move the cursor to the begin of the iterator.
  * This function must be called before using vos_iter_next or vos_iter_fetch.
  *
- * \param ih	[IN]	Iterator handle.
- * \param pos	[IN]	Optional, position cursor to move to.
+ * \param ih	[IN]		Iterator handle.
+ * \param pos	[IN,OUT]	Optional, position cursor to move to. May
+ *				be modified if entries are skipped during
+ *				probe.
  *
  * \return		zero if there is an entry at/after @anchor
  *			-DER_NONEXIST if no more entry
@@ -904,13 +906,15 @@ vos_iter_probe(daos_handle_t ih, daos_anchor_t *anchor);
  * Move forward the iterator cursor.
  *
  * \param ih	[IN]	Iterator handle.
+ * \param pos	[OUT]	Optional, current anchor. May be modified if entries
+ *			are skipped.
  *
  * \return		Zero if there is an available entry
  *			-DER_NONEXIST if no more entry
  *			negative value if error
  */
 int
-vos_iter_next(daos_handle_t ih);
+vos_iter_next(daos_handle_t ih, daos_anchor_t *anchor);
 
 /**
  * Return the current data entry of the iterator.

--- a/src/include/daos_srv/vos_types.h
+++ b/src/include/daos_srv/vos_types.h
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2015-2021 Intel Corporation.
+ * (C) Copyright 2015-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -334,6 +334,24 @@ enum {
 	VOS_IT_MASK		= (1 << 10) - 1,
 };
 
+typedef struct {
+	union {
+		/** The object id of the entry */
+		daos_unit_oid_t	 id_oid;
+		/** The key for the entry */
+		d_iov_t		 id_key;
+	};
+	vos_iter_type_t		 id_type;
+} vos_iter_desc_t;
+
+/**
+ * Iteration object/key filter callback
+ *
+ * Supports only VOS_ITER_CB_SKIP or VOS_ITER_CB_ABORT
+ */
+typedef int (*vos_iter_filter_cb_t)(daos_handle_t ih, vos_iter_desc_t *desc,
+				    void *cb_arg, unsigned int *acts);
+
 /**
  * Parameters for initializing VOS iterator
  */
@@ -358,6 +376,10 @@ typedef struct {
 	daos_epoch_range_t	ip_epr;
 	/** epoch logic expression for the iterator. */
 	vos_it_epc_expr_t	ip_epc_expr;
+	/** filter callback for object/key (vos_iterate only) */
+	vos_iter_filter_cb_t	ip_filter_cb;
+	/** filter callback argument (vos_iterate only) */
+	void			*ip_filter_arg;
 	/** flags for for iterator */
 	uint32_t		ip_flags;
 } vos_iter_param_t;
@@ -460,20 +482,21 @@ typedef struct {
 typedef int (*vos_iter_cb_t)(daos_handle_t ih, vos_iter_entry_t *entry,
 			     vos_iter_type_t type, vos_iter_param_t *param,
 			     void *cb_arg, unsigned int *acts);
+
 /**
  * Actions performed in iteration callback
  */
 enum {
-	/** Yield */
-	VOS_ITER_CB_YIELD	= (1UL << 0),
 	/** Delete entry */
-	VOS_ITER_CB_DELETE	= (1UL << 1),
+	VOS_ITER_CB_DELETE	= (1UL << 0),
 	/** Skip entry, don't iterate into next level for current entry */
-	VOS_ITER_CB_SKIP	= (1UL << 2),
+	VOS_ITER_CB_SKIP	= (1UL << 1),
+	/** Abort the current level iterator and restart */
+	VOS_ITER_CB_RESTART	= (1UL << 2),
 	/** Abort current level iteration */
 	VOS_ITER_CB_ABORT	= (1UL << 3),
-	/** Abort the current level iterator and restart */
-	VOS_ITER_CB_RESTART	= (1UL << 4),
+	/** Yield */
+	VOS_ITER_CB_YIELD	= (1UL << 4),
 };
 
 /**

--- a/src/object/srv_ec_aggregate.c
+++ b/src/object/srv_ec_aggregate.c
@@ -2245,8 +2245,6 @@ done:
 		agg_param->ap_credits = 0;
 		D_DEBUG(DB_EPC, "EC aggregation yield type %d. acts %u\n",
 			desc->id_type, *acts);
-		if (!(*acts & VOS_ITER_CB_SKIP))
-			agg_reset_pos(desc->id_type, agg_entry);
 		if (ec_aggregate_yield(agg_param)) {
 			D_DEBUG(DB_EPC, "EC aggregation aborted\n");
 			*acts |= VOS_ITER_CB_ABORT;

--- a/src/object/srv_ec_aggregate.c
+++ b/src/object/srv_ec_aggregate.c
@@ -2212,6 +2212,50 @@ out:
 	return rc;
 }
 
+static int
+agg_filter(daos_handle_t ih, vos_iter_desc_t *desc, void *cb_arg, unsigned int *acts)
+{
+	struct ec_agg_param	*agg_param = (struct ec_agg_param *)cb_arg;
+	struct ec_agg_entry	*agg_entry = &agg_param->ap_agg_entry;
+	struct ec_agg_pool_info	*info = &agg_param->ap_pool_info;
+	struct daos_oclass_attr  oca;
+	int			 rc = 0;
+
+	if (desc->id_type != VOS_ITER_OBJ)
+		return 0;
+
+	rc = dsc_obj_id2oc_attr(desc->id_oid.id_pub, &info->api_props, &oca);
+	if (rc) {
+		D_ERROR("Skip object("DF_OID") with unknown class(%u)\n",
+			DP_OID(desc->id_oid.id_pub),
+			daos_obj_id2class(desc->id_oid.id_pub));
+		*acts = VOS_ITER_CB_SKIP;
+		agg_param->ap_credits++;
+		goto done;
+	}
+
+	if (!daos_oclass_is_ec(&oca)) { /* Skip non-EC object */
+		D_DEBUG(DB_EPC, "Skip oid:"DF_UOID" non-ec obj\n",
+			DP_UOID(desc->id_oid));
+		agg_param->ap_credits++;
+		*acts = VOS_ITER_CB_SKIP;
+	}
+done:
+	if (agg_param->ap_credits > agg_param->ap_credits_max) {
+		agg_param->ap_credits = 0;
+		D_DEBUG(DB_EPC, "EC aggregation yield type %d. acts %u\n",
+			desc->id_type, *acts);
+		if (!(*acts & VOS_ITER_CB_SKIP))
+			agg_reset_pos(desc->id_type, agg_entry);
+		if (ec_aggregate_yield(agg_param)) {
+			D_DEBUG(DB_EPC, "EC aggregation aborted\n");
+			*acts |= VOS_ITER_CB_ABORT;
+		}
+	}
+
+	return 0;
+}
+
 /* Iterator pre-callback for objects. Determines if object is subject
  * to aggregation. Skips objects that are not EC, or are not led by
  * this target.
@@ -2232,22 +2276,9 @@ agg_object(daos_handle_t ih, vos_iter_entry_t *entry,
 		goto out;
 	}
 
+	/** We should have filtered it if it isn't EC */
 	rc = dsc_obj_id2oc_attr(entry->ie_oid.id_pub, &info->api_props, &oca);
-	if (rc) {
-		D_ERROR("SKip object("DF_OID") with unknown class(%u)\n",
-			DP_OID(entry->ie_oid.id_pub),
-			daos_obj_id2class(entry->ie_oid.id_pub));
-		*acts |= VOS_ITER_CB_SKIP;
-		goto out;
-	}
-
-	if (!daos_oclass_is_ec(&oca)) { /* Skip non-EC object */
-		D_DEBUG(DB_EPC, "Skip oid:"DF_UOID" non-ec obj\n",
-			DP_UOID(entry->ie_oid));
-		*acts |= VOS_ITER_CB_SKIP;
-		goto out;
-	}
-
+	D_ASSERT(rc == 0 && daos_oclass_is_ec(&oca));
 	rc = agg_obj_is_leader(info->api_pool, &oca, &entry->ie_oid,
 			       info->api_pool->sp_map_version);
 	if (rc == 1) {
@@ -2507,6 +2538,8 @@ cont_ec_aggregate_cb(struct ds_cont_child *cont, daos_epoch_range_t *epr,
 	iter_param.ip_flags		= VOS_IT_RECX_VISIBLE;
 	iter_param.ip_recx.rx_idx	= 0ULL;
 	iter_param.ip_recx.rx_nr	= ~PARITY_INDICATOR;
+	iter_param.ip_filter_cb		= agg_filter;
+	iter_param.ip_filter_arg	= ec_agg_param;
 
 	agg_reset_entry(&ec_agg_param->ap_agg_entry, NULL, NULL);
 

--- a/src/object/srv_ec_aggregate.c
+++ b/src/object/srv_ec_aggregate.c
@@ -57,7 +57,7 @@
 #include "obj_ec.h"
 #include "obj_internal.h"
 
-#define EC_AGG_ITERATION_MAX	256
+#define EC_AGG_ITERATION_MAX	2048
 
 /* Pool/container info. Shared handle UUIDs, and service list are initialized
  * in system Xstream.
@@ -2339,7 +2339,7 @@ agg_iterate_pre_cb(daos_handle_t ih, vos_iter_entry_t *entry,
 		return rc;
 	}
 
-	agg_param->ap_credits++;
+	agg_param->ap_credits+=10;
 	if (agg_param->ap_credits > agg_param->ap_credits_max) {
 		agg_param->ap_credits = 0;
 		D_DEBUG(DB_EPC, "EC aggregation yield type %d. acts %u\n",

--- a/src/object/srv_ec_aggregate.c
+++ b/src/object/srv_ec_aggregate.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2020-2021 Intel Corporation.
+ * (C) Copyright 2020-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -2216,7 +2216,6 @@ static int
 agg_filter(daos_handle_t ih, vos_iter_desc_t *desc, void *cb_arg, unsigned int *acts)
 {
 	struct ec_agg_param	*agg_param = (struct ec_agg_param *)cb_arg;
-	struct ec_agg_entry	*agg_entry = &agg_param->ap_agg_entry;
 	struct ec_agg_pool_info	*info = &agg_param->ap_pool_info;
 	struct daos_oclass_attr  oca;
 	int			 rc = 0;

--- a/src/object/srv_ec_aggregate.c
+++ b/src/object/srv_ec_aggregate.c
@@ -57,7 +57,7 @@
 #include "obj_ec.h"
 #include "obj_internal.h"
 
-#define EC_AGG_ITERATION_MAX	2048
+#define EC_AGG_ITERATION_MAX	4096
 
 /* Pool/container info. Shared handle UUIDs, and service list are initialized
  * in system Xstream.
@@ -2339,7 +2339,7 @@ agg_iterate_pre_cb(daos_handle_t ih, vos_iter_entry_t *entry,
 		return rc;
 	}
 
-	agg_param->ap_credits+=10;
+	agg_param->ap_credits += 20;
 	if (agg_param->ap_credits > agg_param->ap_credits_max) {
 		agg_param->ap_credits = 0;
 		D_DEBUG(DB_EPC, "EC aggregation yield type %d. acts %u\n",

--- a/src/rdb/rdb_util.c
+++ b/src/rdb/rdb_util.c
@@ -493,7 +493,7 @@ rdb_vos_iterate(daos_handle_t cont, daos_epoch_t epoch, rdb_oid_t oid,
 		}
 
 		/* Move to next a-key. */
-		rc = vos_iter_next(iter);
+		rc = vos_iter_next(iter, NULL /* anchor */);
 		if (rc != 0) {
 			if (rc == -DER_NONEXIST)
 				/* No more a-keys. */

--- a/src/tests/obj_ctl.c
+++ b/src/tests/obj_ctl.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2017-2021 Intel Corporation.
+ * (C) Copyright 2017-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -165,7 +165,7 @@ ctl_vos_list(struct io_credit *cred)
 			D_GOTO(out, rc = -1);
 		}
 
-		rc = vos_iter_next(ih);
+		rc = vos_iter_next(ih, NULL);
 		opstr = "next";
 	}
 out:

--- a/src/vos/tests/vts_container.c
+++ b/src/vos/tests/vts_container.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2021 Intel Corporation.
+ * (C) Copyright 2016-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -266,7 +266,7 @@ co_uuid_iter_test(struct vc_test_args *arg)
 		}
 
 
-		rc = vos_iter_next(ih);
+		rc = vos_iter_next(ih, NULL);
 		if (rc == -DER_NONEXIST)
 			break;
 

--- a/src/vos/tests/vts_io.c
+++ b/src/vos/tests/vts_io.c
@@ -334,7 +334,7 @@ io_recx_iterate(struct io_test_args *arg, vos_iter_param_t *param,
 			D_PRINT("\tepoch: "DF_U64"\n", ent.ie_epoch);
 		}
 
-		rc = vos_iter_next(ih);
+		rc = vos_iter_next(ih, NULL);
 		if (rc != 0 && rc != -DER_NONEXIST) {
 			print_error("Failed to move cursor: "DF_RC"\n",
 				DP_RC(rc));
@@ -402,7 +402,7 @@ io_akey_iterate(struct io_test_args *arg, vos_iter_param_t *param,
 				     recs, print_ent);
 
 		nr++;
-		rc = vos_iter_next(ih);
+		rc = vos_iter_next(ih, NULL);
 		if (rc != 0 && rc != -DER_NONEXIST) {
 			print_error("Failed to move cursor: "DF_RC"\n",
 				DP_RC(rc));
@@ -482,7 +482,7 @@ io_obj_iter_test(struct io_test_args *arg, daos_epoch_range_t *epr,
 			goto out;
 
 		nr++;
-		rc = vos_iter_next(ih);
+		rc = vos_iter_next(ih, NULL);
 		if (rc == -DER_NONEXIST) {
 			print_message("Finishing d-key iteration\n");
 			break;
@@ -1448,7 +1448,7 @@ io_oid_iter_test(struct io_test_args *arg)
 			DP_UOID(ent.ie_oid));
 		nr++;
 
-		rc = vos_iter_next(ih);
+		rc = vos_iter_next(ih, NULL);
 		if (rc == -DER_NONEXIST)
 			break;
 

--- a/src/vos/vos_container.c
+++ b/src/vos/vos_container.c
@@ -737,7 +737,7 @@ cont_iter_fetch(struct vos_iterator *iter, vos_iter_entry_t *it_entry,
 }
 
 static int
-cont_iter_next(struct vos_iterator *iter)
+cont_iter_next(struct vos_iterator *iter, daos_anchor_t *anchor)
 {
 	struct cont_iterator	*co_iter = vos_iter2co_iter(iter);
 
@@ -753,7 +753,7 @@ cont_iter_probe(struct vos_iterator *iter, daos_anchor_t *anchor)
 
 	D_ASSERT(iter->it_type == VOS_ITER_COUUID);
 
-	opc = anchor == NULL ? BTR_PROBE_FIRST : BTR_PROBE_GE;
+	opc = vos_anchor_is_zero(anchor) ? BTR_PROBE_FIRST : BTR_PROBE_GE;
 	/* The container tree will not be affected by the iterator intent,
 	 * just set it as DAOS_INTENT_DEFAULT.
 	 */

--- a/src/vos/vos_dtx_iter.c
+++ b/src/vos/vos_dtx_iter.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2019-2021 Intel Corporation.
+ * (C) Copyright 2019-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -105,7 +105,7 @@ dtx_iter_probe(struct vos_iterator *iter, daos_anchor_t *anchor)
 
 	D_ASSERT(iter->it_type == VOS_ITER_DTX);
 
-	if (anchor == NULL) {
+	if (vos_anchor_is_zero(anchor)) {
 		oiter->oit_linear = true;
 		if (d_list_empty(&oiter->oit_cont->vc_dtx_act_list)) {
 			oiter->oit_cur = NULL;
@@ -170,7 +170,7 @@ out:
 }
 
 static int
-dtx_iter_next(struct vos_iterator *iter)
+dtx_iter_next(struct vos_iterator *iter, daos_anchor_t *anchor)
 {
 	struct vos_dtx_iter	*oiter = iter2oiter(iter);
 	struct vos_dtx_act_ent	*dae;

--- a/src/vos/vos_iterator.c
+++ b/src/vos/vos_iterator.c
@@ -659,11 +659,11 @@ vos_iterate_internal(vos_iter_param_t *param, vos_iter_type_t type,
 probe:
 	rc = vos_iter_probe(ih, anchor);
 	if (rc == VOS_ITER_CB_YIELD) {
-		printf("reprobe1\n");
 		set_reprobe(type, VOS_ITER_CB_YIELD, anchors, 0);
 		D_ASSERT(need_reprobe(type, anchors));
 		goto probe;
 	}
+	/** Let VOS_ITER_CB_ABORT fall through and get handled as a non-zero exit */
 	if (rc != 0) {
 		if (rc == -DER_NONEXIST || rc == -DER_AGAIN) {
 			daos_anchor_set_eof(anchor);
@@ -785,6 +785,7 @@ probe:
 			D_ASSERT(need_reprobe(type, anchors));
 			goto probe;
 		}
+		/** Let VOS_ITER_CB_ABORT fall through and get handled as a non-zero exit */
 		if (rc) {
 			VOS_TX_TRACE_FAIL(rc,
 					  "failed to iterate next (type=%d): "

--- a/src/vos/vos_iterator.c
+++ b/src/vos/vos_iterator.c
@@ -658,7 +658,7 @@ vos_iterate_internal(vos_iter_param_t *param, vos_iter_type_t type,
 	read_time = dtx_is_valid_handle(dth) ? dth->dth_epoch : 0 /* unused */;
 probe:
 	rc = vos_iter_probe(ih, anchor);
-	if (rc == VOS_ITER_CB_YIELD) {
+	if (rc > 0 && rc == VOS_ITER_CB_YIELD) {
 		set_reprobe(type, VOS_ITER_CB_YIELD, anchors, 0);
 		D_ASSERT(need_reprobe(type, anchors));
 		goto probe;
@@ -780,7 +780,7 @@ probe:
 		}
 
 		rc = vos_iter_next(ih, anchor);
-		if (rc == VOS_ITER_CB_YIELD) {
+		if (rc > 0 && rc == VOS_ITER_CB_YIELD) {
 			set_reprobe(type, VOS_ITER_CB_YIELD, anchors, 0);
 			D_ASSERT(need_reprobe(type, anchors));
 			goto probe;

--- a/src/vos/vos_obj.c
+++ b/src/vos/vos_obj.c
@@ -1391,7 +1391,7 @@ recx_iter_probe(struct vos_obj_iter *oiter, daos_anchor_t *anchor)
 	int	rc;
 
 	opc = vos_anchor_is_zero(anchor) ? EVT_ITER_FIRST : EVT_ITER_FIND;
-	rc = evt_iter_probe(oiter->it_hdl, opc, NULL, daos_anchor_is_zero(anchor) ? NULL : anchor);
+	rc = evt_iter_probe(oiter->it_hdl, opc, NULL, vos_anchor_is_zero(anchor) ? NULL : anchor);
 	return rc;
 }
 

--- a/src/vos/vos_obj.c
+++ b/src/vos/vos_obj.c
@@ -723,10 +723,13 @@ key_iter_fetch(struct vos_obj_iter *oiter, vos_iter_entry_t *ent,
 	       daos_anchor_t *anchor, bool check_existence)
 {
 
+	uint64_t		 start_seq;
+	vos_iter_desc_t		 desc;
 	struct vos_krec_df	*krec;
 	struct vos_rec_bundle	 rbund;
 	daos_epoch_range_t	 epr = {0, DAOS_EPOCH_MAX};
 	uint32_t		 ts_type;
+	unsigned int		 acts;
 	int			 rc;
 
 	rc = key_iter_fetch_helper(oiter, &rbund, &ent->ie_key, anchor);
@@ -734,6 +737,27 @@ key_iter_fetch(struct vos_obj_iter *oiter, vos_iter_entry_t *ent,
 		  "Iterator should probe before fetch\n");
 	if (rc != 0)
 		return rc;
+
+	if (check_existence && oiter->it_iter.it_filter_cb != NULL) {
+		desc.id_type = oiter->it_iter.it_type;
+		desc.id_key = ent->ie_key;
+		acts = 0;
+		start_seq = vos_sched_seq();
+		rc = oiter->it_iter.it_filter_cb(vos_iter2hdl(&oiter->it_iter), &desc,
+						 oiter->it_iter.it_filter_arg,
+						 &acts);
+		if (rc != 0)
+			return rc;
+		if (acts & VOS_ITER_CB_ABORT)
+			return VOS_ITER_CB_ABORT;
+		if (start_seq != vos_sched_seq())
+			return VOS_ITER_CB_YIELD;
+		if (acts != 0) {
+			if (acts & VOS_ITER_CB_SKIP)
+				return IT_OPC_NEXT;
+			D_ASSERTF(0, "Invalid acts returned from iterator filter %x\n", acts);
+		}
+	}
 
 	D_ASSERT(rbund.rb_krec);
 	if (oiter->it_iter.it_type == VOS_ITER_AKEY) {
@@ -845,7 +869,7 @@ key_iter_copy(struct vos_obj_iter *oiter, vos_iter_entry_t *ent,
  * probed and its epoch range are also returned to @ent.
  */
 static int
-key_iter_match(struct vos_obj_iter *oiter, vos_iter_entry_t *ent)
+key_iter_match(struct vos_obj_iter *oiter, vos_iter_entry_t *ent, daos_anchor_t *anchor)
 {
 	struct vos_object	*obj = oiter->it_obj;
 	daos_epoch_range_t	*epr = &oiter->it_epr;
@@ -853,10 +877,9 @@ key_iter_match(struct vos_obj_iter *oiter, vos_iter_entry_t *ent)
 	daos_handle_t		 toh;
 	int			 rc;
 
-	rc = key_iter_fetch(oiter, ent, NULL, true);
+	rc = key_iter_fetch(oiter, ent, anchor, true);
 	if (rc != 0) {
-		VOS_TX_TRACE_FAIL(rc, "Failed to fetch the entry: "DF_RC"\n",
-				  DP_RC(rc));
+		VOS_TX_TRACE_FAIL(rc, "Failed to fetch the entry: "DF_RC"\n", DP_RC(rc));
 		return rc;
 	}
 
@@ -901,35 +924,33 @@ key_iter_match(struct vos_obj_iter *oiter, vos_iter_entry_t *ent)
  * traverses the tree until a matched item is found.
  */
 static int
-key_iter_match_probe(struct vos_obj_iter *oiter)
+key_iter_match_probe(struct vos_obj_iter *oiter, daos_anchor_t *anchor)
 {
-	int	rc;
+	static __thread vos_iter_entry_t	entry;
+	int					rc;
 
-	while (1) {
-		static __thread vos_iter_entry_t	entry;
-
-		rc = key_iter_match(oiter, &entry);
-		switch (rc) {
-		default:
-			D_ASSERT(rc < 0);
-			VOS_TX_TRACE_FAIL(rc, "match failed, rc="DF_RC"\n",
-					  DP_RC(rc));
-			goto out;
-
-		case IT_OPC_NOOP:
-			/* already match the condition, no further operation */
-			rc = 0;
-			goto out;
-
-		case IT_OPC_NEXT:
-			/* move to the next tree record */
-			rc = dbtree_iter_next(oiter->it_hdl);
-			if (rc)
-				goto out;
-			break;
-		}
+retry:
+	rc = key_iter_match(oiter, &entry, anchor);
+	switch (rc) {
+	default:
+		/** Either there is an error, we aborted the iterator, or
+		 *  the callback imposed a yield and we need to tell upper
+		 *  layer to re-probe
+		 */
+		break;
+	case IT_OPC_NOOP:
+		/* already match the condition, no further operation */
+		rc = 0;
+		break;
+	case IT_OPC_NEXT:
+		/* move to the next tree record */
+		rc = dbtree_iter_next(oiter->it_hdl);
+		if (rc == 0)
+			goto retry;
 	}
- out:
+	D_ASSERT(rc <= 0 || rc == VOS_ITER_CB_ABORT || rc == VOS_ITER_CB_YIELD);
+	VOS_TX_TRACE_FAIL(rc, "match failed, rc="DF_RC"\n",
+			  DP_RC(rc));
 	return rc;
 }
 
@@ -939,21 +960,19 @@ key_iter_probe(struct vos_obj_iter *oiter, daos_anchor_t *anchor)
 	int	rc;
 
 	rc = dbtree_iter_probe(oiter->it_hdl,
-			       anchor ? BTR_PROBE_GE : BTR_PROBE_FIRST,
+			       vos_anchor_is_zero(anchor) ? BTR_PROBE_FIRST : BTR_PROBE_GE,
 			       vos_iter_intent(&oiter->it_iter),
 			       NULL, anchor);
 	if (rc)
 		D_GOTO(out, rc);
 
-	rc = key_iter_match_probe(oiter);
-	if (rc)
-		D_GOTO(out, rc);
+	rc = key_iter_match_probe(oiter, anchor);
  out:
 	return rc;
 }
 
 static int
-key_iter_next(struct vos_obj_iter *oiter)
+key_iter_next(struct vos_obj_iter *oiter, daos_anchor_t *anchor)
 {
 	int	rc;
 
@@ -961,9 +980,7 @@ key_iter_next(struct vos_obj_iter *oiter)
 	if (rc)
 		D_GOTO(out, rc);
 
-	rc = key_iter_match_probe(oiter);
-	if (rc)
-		D_GOTO(out, rc);
+	rc = key_iter_match_probe(oiter, anchor);
 out:
 	return rc;
 }
@@ -1171,9 +1188,9 @@ singv_iter_probe(struct vos_obj_iter *oiter, daos_anchor_t *anchor)
 	int			rc;
 
 	if (oiter->it_epc_expr == VOS_IT_EPC_RR)
-		opc = anchor == NULL ? BTR_PROBE_LAST : BTR_PROBE_LE;
+		opc = vos_anchor_is_zero(anchor) ? BTR_PROBE_LAST : BTR_PROBE_LE;
 	else
-		opc = anchor == NULL ? BTR_PROBE_FIRST : BTR_PROBE_GE;
+		opc = vos_anchor_is_zero(anchor) ? BTR_PROBE_FIRST : BTR_PROBE_GE;
 
 	rc = dbtree_iter_probe(oiter->it_hdl, opc,
 			       vos_iter_intent(&oiter->it_iter), NULL, anchor);
@@ -1373,8 +1390,8 @@ recx_iter_probe(struct vos_obj_iter *oiter, daos_anchor_t *anchor)
 	int	opc;
 	int	rc;
 
-	opc = anchor ? EVT_ITER_FIND : EVT_ITER_FIRST;
-	rc = evt_iter_probe(oiter->it_hdl, opc, NULL, anchor);
+	opc = vos_anchor_is_zero(anchor) ? EVT_ITER_FIRST : EVT_ITER_FIND;
+	rc = evt_iter_probe(oiter->it_hdl, opc, NULL, daos_anchor_is_zero(anchor) ? NULL : anchor);
 	return rc;
 }
 
@@ -1476,6 +1493,8 @@ vos_obj_iter_prep(vos_iter_type_t type, vos_iter_param_t *param,
 	bound = dtx_is_valid_handle(dth) ? dth->dth_epoch_bound :
 		param->ip_epr.epr_hi;
 	oiter->it_iter.it_bound = MAX(bound, param->ip_epr.epr_hi);
+	oiter->it_iter.it_filter_cb = param->ip_filter_cb;
+	oiter->it_iter.it_filter_arg = param->ip_filter_arg;
 	vos_ilog_fetch_init(&oiter->it_ilog_info);
 	oiter->it_iter.it_type = type;
 	oiter->it_epr = param->ip_epr;
@@ -1808,7 +1827,7 @@ vos_obj_iter_probe(struct vos_iterator *iter, daos_anchor_t *anchor)
 }
 
 static int
-vos_obj_iter_next(struct vos_iterator *iter)
+vos_obj_iter_next(struct vos_iterator *iter, daos_anchor_t *anchor)
 {
 	struct vos_obj_iter *oiter = vos_iter2oiter(iter);
 
@@ -1819,7 +1838,7 @@ vos_obj_iter_next(struct vos_iterator *iter)
 
 	case VOS_ITER_DKEY:
 	case VOS_ITER_AKEY:
-		return key_iter_next(oiter);
+		return key_iter_next(oiter, anchor);
 
 	case VOS_ITER_SINGLE:
 		return singv_iter_next(oiter);


### PR DESCRIPTION
Master PR #8429

In order to filter non-EC objects from EC aggregation without checking
the incarnation log, we add a pre-check filter callback to the
iterator interface.
Modify some of the callbacks for the vos iterator to enable
updates to the anchor on probe and next since objects/keys
skip several entries during these operations.

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>