### PR TITLE
DAOS-9623 agent: Support configurable provider

### DIFF
--- a/src/control/cmd/daos_agent/config.go
+++ b/src/control/cmd/daos_agent/config.go
@@ -34,6 +34,7 @@ type Config struct {
 	LogLevel         common.ControlLogLevel    `yaml:"control_log_mask,omitempty"`
 	TransportConfig  *security.TransportConfig `yaml:"transport_config"`
 	FabricInterfaces []*NUMAFabricConfig       `yaml:"fabric_ifaces,omitempty"`
+	Provider         string                    `yaml:"provider,omitempty"`
 }
 
 // NUMAFabricConfig defines a list of fabric interfaces that belong to a NUMA

--- a/src/control/cmd/daos_agent/config_test.go
+++ b/src/control/cmd/daos_agent/config_test.go
@@ -62,6 +62,7 @@ fabric_ifaces:
   -
      iface: ib3
      domain: mlx5_3
+provider: ofi+tcp
 `)
 
 	badLogMaskCfg := common.CreateTestFile(t, dir, `
@@ -155,6 +156,7 @@ transport_config:
 						},
 					},
 				},
+				Provider: "ofi+tcp",
 			},
 		},
 	} {

--- a/src/control/cmd/daos_agent/mgmt_rpc_test.go
+++ b/src/control/cmd/daos_agent/mgmt_rpc_test.go
@@ -22,7 +22,254 @@ import (
 	"github.com/daos-stack/daos/src/control/logging"
 )
 
+func hostResps(resps ...*mgmtpb.GetAttachInfoResp) []*control.HostResponse {
+	result := []*control.HostResponse{}
+	for _, r := range resps {
+		result = append(result, &control.HostResponse{
+			Message: r,
+		})
+	}
+	return result
+}
+
 func TestAgent_mgmtModule_getAttachInfo(t *testing.T) {
+	testSrvResp := func() *mgmtpb.GetAttachInfoResp {
+		return &mgmtpb.GetAttachInfoResp{
+			RankUris: []*mgmtpb.GetAttachInfoResp_RankUri{
+				{
+					Rank:     0,
+					Uri:      "uri0",
+					Provider: "ofi+verbs",
+				},
+				{
+					Rank:     1,
+					Uri:      "uri1",
+					Provider: "ofi+verbs",
+				},
+				{
+					Rank:     3,
+					Uri:      "uri3",
+					Provider: "ofi+verbs",
+				},
+			},
+			SecondaryRankUris: []*mgmtpb.GetAttachInfoResp_RankUri{
+				{
+					Rank:     0,
+					Uri:      "uri4-sec",
+					Provider: "ofi+sockets",
+				},
+				{
+					Rank:     1,
+					Uri:      "uri5-sec",
+					Provider: "ofi+sockets",
+				},
+				{
+					Rank:     3,
+					Uri:      "uri6-sec",
+					Provider: "ofi+sockets",
+				},
+				{
+					Rank:     0,
+					Uri:      "uri0-sec",
+					Provider: "ofi+tcp",
+				},
+				{
+					Rank:     1,
+					Uri:      "uri1-sec",
+					Provider: "ofi+tcp",
+				},
+				{
+					Rank:     3,
+					Uri:      "uri3-sec",
+					Provider: "ofi+tcp",
+				},
+			},
+			MsRanks: []uint32{0, 1, 3},
+			ClientNetHint: &mgmtpb.ClientNetHint{
+				Provider:    "ofi+verbs",
+				NetDevClass: uint32(hardware.Infiniband),
+			},
+			SecondaryClientNetHints: []*mgmtpb.ClientNetHint{
+				{
+					Provider:    "ofi+tcp",
+					NetDevClass: uint32(hardware.Ether),
+				},
+			},
+		}
+	}
+
+	hintResp := func(fi, domain string) *mgmtpb.GetAttachInfoResp {
+		withHint := testSrvResp()
+		withHint.ClientNetHint.Interface = fi
+		withHint.ClientNetHint.Domain = domain
+
+		return withHint
+	}
+
+	for name, tc := range map[string]struct {
+		provider string
+		numaNode int
+		rpcResp  *control.HostResponse
+		expResp  *mgmtpb.GetAttachInfoResp
+		expErr   error
+	}{
+		"RPC error": {
+			rpcResp: &control.HostResponse{
+				Error: errors.New("mock RPC"),
+			},
+			expErr: errors.New("mock RPC"),
+		},
+		"no provider hint": {
+			rpcResp: &control.HostResponse{
+				Message: &mgmtpb.GetAttachInfoResp{
+					RankUris: []*mgmtpb.GetAttachInfoResp_RankUri{
+						{
+							Rank:     0,
+							Uri:      "uri0",
+							Provider: "ofi+verbs",
+						},
+					},
+					MsRanks: []uint32{0},
+					ClientNetHint: &mgmtpb.ClientNetHint{
+						NetDevClass: uint32(hardware.Infiniband),
+					},
+				},
+			},
+			expErr: errors.New("no provider"),
+		},
+		"no provider match": {
+			rpcResp: &control.HostResponse{
+				Message: &mgmtpb.GetAttachInfoResp{
+					RankUris: []*mgmtpb.GetAttachInfoResp_RankUri{
+						{
+							Rank:     0,
+							Uri:      "uri0",
+							Provider: "notreal",
+						},
+					},
+					MsRanks: []uint32{0},
+					ClientNetHint: &mgmtpb.ClientNetHint{
+						Provider:    "notreal",
+						NetDevClass: uint32(hardware.Infiniband),
+					},
+				},
+			},
+			expErr: errors.New("no suitable fabric interface"),
+		},
+		"basic success": {
+
+			rpcResp: &control.HostResponse{
+				Message: testSrvResp(),
+			},
+			expResp: hintResp("fi0", "d0"),
+		},
+		"primary provider": {
+			provider: "ofi+verbs",
+			rpcResp: &control.HostResponse{
+				Message: testSrvResp(),
+			},
+			expResp: hintResp("fi0", "d0"),
+		},
+		"secondary provider": {
+			provider: "ofi+tcp",
+			rpcResp: &control.HostResponse{
+				Message: testSrvResp(),
+			},
+			expResp: &mgmtpb.GetAttachInfoResp{
+				RankUris: []*mgmtpb.GetAttachInfoResp_RankUri{
+					{
+						Rank:     0,
+						Uri:      "uri0-sec",
+						Provider: "ofi+tcp",
+					},
+					{
+						Rank:     1,
+						Uri:      "uri1-sec",
+						Provider: "ofi+tcp",
+					},
+					{
+						Rank:     3,
+						Uri:      "uri3-sec",
+						Provider: "ofi+tcp",
+					},
+				},
+				MsRanks: []uint32{0, 1, 3},
+				ClientNetHint: &mgmtpb.ClientNetHint{
+					Provider:    "ofi+tcp",
+					NetDevClass: uint32(hardware.Ether),
+					Interface:   "fi1",
+					Domain:      "fi1",
+				},
+			},
+		},
+		"config provider not found": {
+			provider: "notreal",
+			rpcResp: &control.HostResponse{
+				Message: testSrvResp(),
+			},
+			expErr: errors.New("no rank URIs for provider"),
+		},
+		"config provider hint missing": {
+			provider: "ofi+sockets",
+			rpcResp: &control.HostResponse{
+				Message: testSrvResp(),
+			},
+			expErr: errors.New("no ClientNetHint for provider"),
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			log, buf := logging.NewTestLogger(t.Name())
+			defer common.ShowBufferOnFailure(t, buf)
+
+			testFabric := &NUMAFabric{
+				log: log,
+				numaMap: map[int][]*FabricInterface{
+					0: {
+						{
+							Name:        "fi0",
+							Domain:      "d0",
+							NetDevClass: hardware.Infiniband,
+							Providers:   []string{"ofi+verbs"},
+						},
+						{
+							Name:        "fi1",
+							NetDevClass: hardware.Ether,
+							Providers:   []string{"ofi+tcp"},
+						},
+					},
+				},
+			}
+
+			sysName := "dontcare"
+			mod := &mgmtModule{
+				log:        log,
+				sys:        sysName,
+				fabricInfo: newTestFabricCache(t, log, testFabric),
+				attachInfo: newAttachInfoCache(log, true),
+				ctlInvoker: control.NewMockInvoker(log, &control.MockInvokerConfig{
+					Sys: sysName,
+					UnaryResponse: &control.UnaryResponse{
+						Responses: []*control.HostResponse{tc.rpcResp},
+					},
+				}),
+				provider: tc.provider,
+			}
+
+			resp, err := mod.getAttachInfo(context.Background(), tc.numaNode, sysName)
+
+			common.CmpErr(t, tc.expErr, err)
+			if diff := cmp.Diff(tc.expResp, resp, cmpopts.IgnoreUnexported(
+				mgmtpb.GetAttachInfoResp{},
+				mgmtpb.GetAttachInfoResp_RankUri{},
+				mgmtpb.ClientNetHint{},
+			)); diff != "" {
+				t.Fatalf("-want, +got:\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestAgent_mgmtModule_getAttachInfo_cacheResp(t *testing.T) {
 	testResps := []*mgmtpb.GetAttachInfoResp{
 		{
 			MsRanks: []uint32{0, 1, 3},
@@ -47,18 +294,6 @@ func TestAgent_mgmtModule_getAttachInfo(t *testing.T) {
 		},
 	}
 
-	hostResps := func(resps []*mgmtpb.GetAttachInfoResp) []*control.HostResponse {
-		result := []*control.HostResponse{}
-
-		for _, r := range resps {
-			result = append(result, &control.HostResponse{
-				Message: r,
-			})
-		}
-
-		return result
-	}
-
 	testFI := &FabricInterface{
 		Name:        "test0",
 		Domain:      "test0",
@@ -68,7 +303,7 @@ func TestAgent_mgmtModule_getAttachInfo(t *testing.T) {
 
 	hintResp := func(resp *mgmtpb.GetAttachInfoResp) *mgmtpb.GetAttachInfoResp {
 		withHint := new(mgmtpb.GetAttachInfoResp)
-		*withHint = *testResps[0]
+		*withHint = *resp
 		withHint.ClientNetHint.Interface = testFI.Name
 		withHint.ClientNetHint.Domain = testFI.Name
 
@@ -77,12 +312,12 @@ func TestAgent_mgmtModule_getAttachInfo(t *testing.T) {
 
 	for name, tc := range map[string]struct {
 		cacheDisabled bool
-		rpcResps      []*control.HostResponse
+		rpcResps      []*mgmtpb.GetAttachInfoResp
 		expResps      []*mgmtpb.GetAttachInfoResp
 	}{
 		"cache disabled": {
 			cacheDisabled: true,
-			rpcResps:      hostResps(testResps),
+			rpcResps:      testResps,
 			expResps: []*mgmtpb.GetAttachInfoResp{
 				hintResp(testResps[0]),
 				hintResp(testResps[1]),
@@ -90,7 +325,7 @@ func TestAgent_mgmtModule_getAttachInfo(t *testing.T) {
 			},
 		},
 		"cached": {
-			rpcResps: hostResps(testResps),
+			rpcResps: testResps,
 			expResps: []*mgmtpb.GetAttachInfoResp{
 				hintResp(testResps[0]),
 				hintResp(testResps[0]),
@@ -103,6 +338,19 @@ func TestAgent_mgmtModule_getAttachInfo(t *testing.T) {
 			defer common.ShowBufferOnFailure(t, buf)
 
 			sysName := "dontcare"
+			mockInvokerCfg := &control.MockInvokerConfig{
+				Sys:              sysName,
+				UnaryResponseSet: []*control.UnaryResponse{},
+			}
+
+			for _, rpcResp := range tc.rpcResps {
+				mockInvokerCfg.UnaryResponseSet = append(mockInvokerCfg.UnaryResponseSet,
+					&control.UnaryResponse{
+						Responses: hostResps(rpcResp),
+					},
+				)
+			}
+
 			mod := &mgmtModule{
 				log: log,
 				sys: sysName,
@@ -115,12 +363,7 @@ func TestAgent_mgmtModule_getAttachInfo(t *testing.T) {
 					},
 				}),
 				attachInfo: newAttachInfoCache(log, !tc.cacheDisabled),
-				ctlInvoker: control.NewMockInvoker(log, &control.MockInvokerConfig{
-					Sys: sysName,
-					UnaryResponse: &control.UnaryResponse{
-						Responses: tc.rpcResps,
-					},
-				}),
+				ctlInvoker: control.NewMockInvoker(log, mockInvokerCfg),
 			}
 
 			for _, expResp := range tc.expResps {

--- a/src/control/cmd/daos_agent/start.go
+++ b/src/control/cmd/daos_agent/start.go
@@ -94,6 +94,7 @@ func (cmd *startCmd) Execute(_ []string) error {
 		numaAware:  numaAware,
 		netCtx:     netCtx,
 		monitor:    procmon,
+		provider:   cmd.cfg.Provider,
 	})
 
 	err = drpcServer.Start()

--- a/src/control/lib/control/network.go
+++ b/src/control/lib/control/network.go
@@ -207,8 +207,9 @@ type (
 	// PrimaryServiceRank provides a rank->uri mapping for a DAOS
 	// Primary Service Rank (PSR).
 	PrimaryServiceRank struct {
-		Rank uint32
-		Uri  string
+		Rank     uint32
+		Uri      string
+		Provider string
 	}
 
 	ClientNetworkHint struct {
@@ -224,9 +225,11 @@ type (
 	}
 
 	GetAttachInfoResp struct {
-		ServiceRanks  []*PrimaryServiceRank `json:"rank_uris"`
-		MSRanks       []uint32              `json:"ms_ranks"`
-		ClientNetHint ClientNetworkHint     `json:"client_net_hint"`
+		ServiceRanks            []*PrimaryServiceRank `json:"rank_uris"`
+		AlternateServiceRanks   []*PrimaryServiceRank `json:"secondary_rank_uris"`
+		MSRanks                 []uint32              `json:"ms_ranks"`
+		ClientNetHint           ClientNetworkHint     `json:"client_net_hint"`
+		AlternateClientNetHints []ClientNetworkHint   `json:"secondary_client_net_hints"`
 	}
 )
 

--- a/utils/config/daos_agent.yml
+++ b/utils/config/daos_agent.yml
@@ -84,3 +84,8 @@
 #  -
 #    iface: ib3
 #    domain: mlx5_3
+
+# Manually force a specific fabric provider to be used by all clients, in the event that the server
+# supports multiple providers.
+#
+#provider: ofi+verbs


### PR DESCRIPTION
This patch allows the agent to support secondary providers if any
are returned by the server in the GetAttachInfo call.

The client requires no knowledge of primary and secondary providers.
The agent decides which provider to return based on its config file.

- Add support for secondary providers to GetAttachInfo messages.
- Add optional "provider" parameter for the agent configuration. If
  specified the agent will search secondary providers for the
  requested provider, and return the appropriate network info to
  the client as if it was the primary provider.

Signed-off-by: Kris Jacque <kristin.jacque@intel.com>