### PR TITLE
DAOS-10114 test: Use JSON output for daos container get-prop

### DIFF
--- a/src/tests/ftest/datamover/dst_create.py
+++ b/src/tests/ftest/datamover/dst_create.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 '''
-  (C) Copyright 2020-2021 Intel Corporation.
+  (C) Copyright 2020-2022 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
@@ -8,6 +8,7 @@ from data_mover_test_base import DataMoverTestBase
 from os.path import join
 from pydaos.raw import DaosApiError
 import avocado
+
 
 class DmvrDstCreate(DataMoverTestBase):
     # pylint: disable=too-many-ancestors
@@ -196,14 +197,12 @@ class DmvrDstCreate(DataMoverTestBase):
             cont (TestContainer): the container to get props of.
 
         Returns:
-            list: string list of properties and values from daos command.
+            list: list of dictionaries that contain properties and values from daos
+                command.
 
         """
-        prop_result = self.daos_cmd.container_get_prop(
-            cont.pool.uuid, cont.uuid)
-        prop_text = prop_result.stdout_text
-        prop_list = prop_text.split('\n')[1:]
-        return prop_list
+        prop_result = self.daos_cmd.container_get_prop(cont.pool.uuid, cont.uuid)
+        return prop_result["response"]
 
     def verify_cont_prop(self, cont, prop_list, api):
         """Verify container properties against an input list.
@@ -212,7 +211,6 @@ class DmvrDstCreate(DataMoverTestBase):
         Args:
             cont (TestContainer): the container to verify.
             prop_list (list): list of properties from get_cont_prop.
-
         """
         actual_list = self.get_cont_prop(cont)
 
@@ -225,7 +223,7 @@ class DmvrDstCreate(DataMoverTestBase):
         # Make sure each property matches
         for prop_idx, prop in enumerate(prop_list):
             # This one is not set
-            if api == "DFS" and "OID" in prop_list[prop_idx]:
+            if api == "DFS" and "OID" in prop["value"]:
                 continue
             if prop != actual_list[prop_idx]:
                 self.log.info("Expected\n%s\nbut got\n%s\n",

--- a/src/tests/ftest/datamover/posix_preserve_props.py
+++ b/src/tests/ftest/datamover/posix_preserve_props.py
@@ -9,6 +9,7 @@ from os.path import join
 from pydaos.raw import DaosApiError
 import avocado
 
+
 class DmvrPreserveProps(DataMoverTestBase):
     # pylint: disable=too-many-ancestors
     """Data Mover validation for --preserve-props option only for DFS copies.
@@ -150,14 +151,12 @@ class DmvrPreserveProps(DataMoverTestBase):
             cont (TestContainer): the container to get props of.
 
         Returns:
-            list: string list of properties and values from daos command.
+            list: list of dictionaries that contain properties and values from daos
+                command.
 
         """
-        prop_result = self.daos_cmd.container_get_prop(
-            cont.pool.uuid, cont.uuid)
-        prop_text = prop_result.stdout_text
-        prop_list = prop_text.split('\n')[1:]
-        return prop_list
+        prop_result = self.daos_cmd.container_get_prop(cont.pool.uuid, cont.uuid)
+        return prop_result["response"]
 
     def verify_cont_prop(self, cont, prop_list, api):
         """Verify container properties against an input list.
@@ -179,7 +178,7 @@ class DmvrPreserveProps(DataMoverTestBase):
         # Make sure each property matches
         for prop_idx, prop in enumerate(prop_list):
             # This one is not set
-            if (api == "DFS") and ("OID" in prop_list[prop_idx] or "ROOTS" in prop_list[prop_idx]):
+            if (api == "DFS") and ("OID" in prop["value"] or "ROOTS" in prop["value"]):
                 continue
             if prop != actual_list[prop_idx]:
                 self.log.info("Expected\n%s\nbut got\n%s\n",

--- a/src/tests/ftest/erasurecode/cell_size_property.py
+++ b/src/tests/ftest/erasurecode/cell_size_property.py
@@ -1,13 +1,13 @@
 #!/usr/bin/python
 '''
-  (C) Copyright 2020-2021 Intel Corporation.
+  (C) Copyright 2020-2022 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
 from itertools import product
 
 from ior_test_base import IorTestBase
-from general_utils import human_to_bytes
+
 
 class EcodCellSizeProperty(IorTestBase):
     # pylint: disable=too-many-ancestors
@@ -27,14 +27,14 @@ class EcodCellSizeProperty(IorTestBase):
             expected_size (int): expected container cell size
         """
         daos_cmd = self.get_daos_command()
-        cont_prop = daos_cmd.container_get_prop(self.pool.uuid,
-                                                self.container.uuid)
-        cont_prop_stdout = cont_prop.stdout_text
-        prop_list = cont_prop_stdout.split('\n')[1:]
-        cont_index = [i for i, word in enumerate(prop_list)
-                      if word.startswith('EC Cell Size')][0]
-        cell_size = (prop_list[cont_index].split('EC Cell Size')[1].strip())
-        cont_cell_size = (human_to_bytes(cell_size.replace(" ", "")))
+        cont_prop = daos_cmd.container_get_prop(self.pool.uuid, self.container.uuid)
+
+        cont_cell_size = None
+        for prop in cont_prop["response"]:
+            if prop["name"] == "ec_cell":
+                cont_cell_size = prop["value"]
+                break
+
         self.assertEqual(expected_size, cont_cell_size)
 
     def test_ec_pool_property(self):

--- a/src/tests/ftest/util/daos_utils.py
+++ b/src/tests/ftest/util/daos_utils.py
@@ -380,14 +380,13 @@ class DaosCommand(DaosCommandBase):
             cont (str): Container UUID.
 
         Returns:
-            CmdResult: Object that contains exit status, stdout, and other
-                information.
+            str: JSON that contains the command output.
 
         Raises:
             CommandFailure: if the daos container get-prop command fails.
 
         """
-        return self._get_result(
+        return self._get_json_result(
             ("container", "get-prop"), pool=pool, cont=cont)
 
     def container_set_owner(self, pool, cont, user, group):


### PR DESCRIPTION
Update container_get_prop() to use --json. The change affects the four tests in the "Tag - File" section.

The reason we use cont_sec tag is the following.

In the security/cont_acl.py test case, it calls verify_cont_rw_property(), which is in the following file:

util/pool_security_test_base.py
where verify_cont_rw_property() calls get_container_property(), which is in the following file:

util/cont_security_test_base.py
where get_container_property() calls container_get_prop(), which is where I made the change to use JSON.

Tag - File
cont_sec - security/cont_acl.py
dm_dst_create - datamover/dst_create.py
dm_preserve_props_fs_copy_posix_dfs - datamover/posix_preserve_props.py
ec_cell_property - erasurecode/cell_size_property.py

Skip-unit-tests: true
Test-tag: cont_sec dm_dst_create dm_preserve_props_fs_copy_posix_dfs ec_cell_property
Signed-off-by: Makito Kano <makito.kano@intel.com>