### PR TITLE
DAOS-9860 dtx: do not skip DTX resync

### DIFF
--- a/src/dtx/dtx_rpc.c
+++ b/src/dtx/dtx_rpc.c
@@ -977,7 +977,8 @@ again:
 		 * then pool map may be refreshed during that. Let's retry
 		 * to find out the new leader.
 		 */
-		if (target->ta_comp.co_status != PO_COMP_ST_UPIN) {
+		if (target->ta_comp.co_status != PO_COMP_ST_UP &&
+		    target->ta_comp.co_status != PO_COMP_ST_UPIN) {
 			if (unlikely(++count % 10 == 3))
 				D_WARN("Get stale DTX leader %u/%u (st: %x) for "DF_DTI
 				       " %d times, maybe dead loop\n",


### PR DESCRIPTION
Even if no application open the container, or someone just did DTX
resync against the container but current DTX resync is for discard
old DTX entries, then current DTX resync should not be skipped.

Signed-off-by: Fan Yong <fan.yong@intel.com>