### PR TITLE
DAOS-9860 dtx: do not skip DTX resync

### DIFF
--- a/src/dtx/dtx_resync.c
+++ b/src/dtx/dtx_resync.c
@@ -596,7 +596,6 @@ dtx_resync(daos_handle_t po_hdl, uuid_t po_uuid, uuid_t co_uuid, uint32_t ver,
 	d_rank_t			 myrank;
 	int				 rc = 0;
 	int				 rc1 = 0;
-	bool				 resynced = false;
 
 	rc = ds_cont_child_lookup(po_uuid, co_uuid, &cont);
 	if (rc != 0) {
@@ -628,12 +627,12 @@ dtx_resync(daos_handle_t po_hdl, uuid_t po_uuid, uuid_t co_uuid, uint32_t ver,
 		D_DEBUG(DB_TRACE, "Waiting for resync of "DF_UUID"\n",
 			DP_UUID(co_uuid));
 		ABT_cond_wait(cont->sc_dtx_resync_cond, cont->sc_mutex);
-		resynced = true;
-	}
-	if (resynced || /* Someone just did the DTX resync*/
-	    cont->sc_closing) {
-		ABT_mutex_unlock(cont->sc_mutex);
-		goto out;
+
+		if (!dra.for_discard) {
+			/* Someone just did the DTX resync*/
+			ABT_mutex_unlock(cont->sc_mutex);
+			goto out;
+		}
 	}
 
 	if (myrank == daos_fail_value_get() &&

--- a/src/dtx/dtx_rpc.c
+++ b/src/dtx/dtx_rpc.c
@@ -975,7 +975,8 @@ again:
 		 * then pool map may be refreshed during that. Let's retry
 		 * to find out the new leader.
 		 */
-		if (target->ta_comp.co_status != PO_COMP_ST_UPIN)
+		if (target->ta_comp.co_status != PO_COMP_ST_UP &&
+		    target->ta_comp.co_status != PO_COMP_ST_UPIN)
 			goto again;
 
 		d_list_for_each_entry(drr, &head, drr_link) {


### PR DESCRIPTION
Even if no application open the container, or someone just did DTX
resync against the container but current DTX resync is for discard
old DTX entries, then current DTX resync should not be skipped.

Signed-off-by: Fan Yong <fan.yong@intel.com>