### PR TITLE
DAOS-8905 test: Adjust hwloc test for real hardware

### DIFF
--- a/src/control/lib/hardware/hwloc/provider_test.go
+++ b/src/control/lib/hardware/hwloc/provider_test.go
@@ -357,6 +357,13 @@ func runTest_GetNUMANodeForPID_Parallel(t *testing.T, parent context.Context, lo
 	doneCh := make(chan error)
 	total := 500
 
+	// If we aren't testing with a cached context, reduce the number
+	// of goroutines in order to avoid timing out on more complex
+	// topologies.
+	if _, err := topologyFromContext(ctx); err != nil {
+		total = 128
+	}
+
 	for i := 0; i < total; i++ {
 		go func() {
 			_, err := p.GetNUMANodeIDForPID(ctx, int32(os.Getpid()))


### PR DESCRIPTION
On more complex systems, the unit test for the worst-case
uncached topology will time out with a large number of
goroutines. In this case, reduce the number of goroutines
to a number that is likely to pass while still testing
thread-safety.

Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com>
