### PR TITLE
DAOS-10126 test: fix rs_state before rebuild

### DIFF
--- a/src/tests/ftest/rebuild/with_ior.py
+++ b/src/tests/ftest/rebuild/with_ior.py
@@ -54,7 +54,7 @@ class RbldWithIOR(IorTestBase):
             "Invalid pool information detected before rebuild")
 
         self.assertTrue(
-            self.pool.check_rebuild_status(rs_errno=0, rs_state=0,
+            self.pool.check_rebuild_status(rs_errno=0, rs_state=1,
                                            rs_obj_nr=0, rs_rec_nr=0),
             "Invalid pool rebuild info detected before rebuild")
 


### PR DESCRIPTION
@rs_state expect rebuild not started(DRS_NOT_STARTED) which is 1 after pool created,
0 means DRS_IN_PROGRESS which is not case here, fix it.

Test-tag: rebuildwithior
Skip-unit-tests: true
Signed-off-by: Wang Shilong <shilong.wang@intel.com>