### PR TITLE
DAOS-10141 vos: init vo_max_write for upgrading case

### DIFF
--- a/src/vos/vos_obj_index.c
+++ b/src/vos/vos_obj_index.c
@@ -233,12 +233,8 @@ vos_oi_find_alloc(struct vos_container *cont, daos_unit_oid_t oid,
 		DP_UOID(oid));
 
 	rc = vos_oi_find(cont, oid, &obj, ts_set);
-	if (rc == 0) {
-		/* upgrading case, set it to current epoch */
-		if (obj->vo_max_write == 0)
-			obj->vo_max_write = epoch;
+	if (rc == 0)
 		goto do_log;
-	}
 	if (rc != -DER_NONEXIST)
 		return rc;
 
@@ -627,7 +623,11 @@ oi_iter_fetch(struct vos_iterator *iter, vos_iter_entry_t *it_entry,
 	}
 	it_entry->ie_child_type = VOS_ITER_DKEY;
 
-	it_entry->ie_last_update = obj->vo_max_write;
+	/* Upgrading case, set it to current epoch */
+	if (obj->vo_max_write == 0)
+		it_entry->ie_last_update = epr.epr_hi;
+	else
+		it_entry->ie_last_update = obj->vo_max_write;
 
 	return 0;
 }

--- a/src/vos/vos_obj_index.c
+++ b/src/vos/vos_obj_index.c
@@ -233,8 +233,12 @@ vos_oi_find_alloc(struct vos_container *cont, daos_unit_oid_t oid,
 		DP_UOID(oid));
 
 	rc = vos_oi_find(cont, oid, &obj, ts_set);
-	if (rc == 0)
+	if (rc == 0) {
+		/* upgrading case, set it to current epoch */
+		if (obj->vo_max_write == 0)
+			obj->vo_max_write = epoch;
 		goto do_log;
+	}
 	if (rc != -DER_NONEXIST)
 		return rc;
 

--- a/src/vos/vos_obj_index.c
+++ b/src/vos/vos_obj_index.c
@@ -623,9 +623,10 @@ oi_iter_fetch(struct vos_iterator *iter, vos_iter_entry_t *it_entry,
 	}
 	it_entry->ie_child_type = VOS_ITER_DKEY;
 
-	/* Upgrading case, set it to current epoch */
+	/* Upgrading case, set it to latest known epoch */
 	if (obj->vo_max_write == 0)
-		it_entry->ie_last_update = epr.epr_hi;
+		vos_ilog_last_update(&obj->vo_ilog, VOS_TS_TYPE_OBJ,
+				     &it_entry->ie_last_update);
 	else
 		it_entry->ie_last_update = obj->vo_max_write;
 


### PR DESCRIPTION
If object creating before following change:
89809(DAOS-9053 vos: Track accurate latest write time for an object (#7845))

Which could happen while upgrading DAOS from 2.0 to 2.2.

It is possible @vos_max_write is zero with an existed object,
assign current epoch to avoid later assertion.

Signed-off-by: Wang Shilong <shilong.wang@intel.com>