### PR TITLE
DAOS-10019 control: Move TopologyCmd to hwprov package

### DIFF
--- a/src/control/cmd/daos/main.go
+++ b/src/control/cmd/daos/main.go
@@ -110,16 +110,15 @@ func (c *logCmd) setLog(log *logging.LeveledLogger) {
 }
 
 type cliOptions struct {
-	Debug      bool                    `long:"debug" description:"enable debug output"`
-	Verbose    bool                    `long:"verbose" description:"enable verbose output (when applicable)"`
-	JSON       bool                    `long:"json" short:"j" description:"enable JSON output"`
-	Container  containerCmd            `command:"container" alias:"cont" description:"perform tasks related to DAOS containers"`
-	Pool       poolCmd                 `command:"pool" description:"perform tasks related to DAOS pools"`
-	Filesystem fsCmd                   `command:"filesystem" alias:"fs" description:"POSIX filesystem operations"`
-	Object     objectCmd               `command:"object" alias:"obj" description:"DAOS object operations"`
-	Version    versionCmd              `command:"version" description:"print daos version"`
-	DumpTopo   cmdutil.DumpTopologyCmd `command:"dump-topology" description:"Dump system topology"`
-	ManPage    cmdutil.ManCmd          `command:"manpage" hidden:"true"`
+	Debug      bool           `long:"debug" description:"enable debug output"`
+	Verbose    bool           `long:"verbose" description:"enable verbose output (when applicable)"`
+	JSON       bool           `long:"json" short:"j" description:"enable JSON output"`
+	Container  containerCmd   `command:"container" alias:"cont" description:"perform tasks related to DAOS containers"`
+	Pool       poolCmd        `command:"pool" description:"perform tasks related to DAOS pools"`
+	Filesystem fsCmd          `command:"filesystem" alias:"fs" description:"POSIX filesystem operations"`
+	Object     objectCmd      `command:"object" alias:"obj" description:"DAOS object operations"`
+	Version    versionCmd     `command:"version" description:"print daos version"`
+	ManPage    cmdutil.ManCmd `command:"manpage" hidden:"true"`
 }
 
 type versionCmd struct{}

--- a/src/control/cmd/daos_agent/main.go
+++ b/src/control/cmd/daos_agent/main.go
@@ -18,25 +18,25 @@ import (
 
 	"github.com/daos-stack/daos/src/control/build"
 	"github.com/daos-stack/daos/src/control/common"
-	"github.com/daos-stack/daos/src/control/common/cmdutil"
 	"github.com/daos-stack/daos/src/control/lib/control"
+	"github.com/daos-stack/daos/src/control/lib/hardware/hwprov"
 	"github.com/daos-stack/daos/src/control/logging"
 )
 
 type cliOptions struct {
-	AllowProxy bool                    `long:"allow-proxy" description:"Allow proxy configuration via environment"`
-	Debug      bool                    `short:"d" long:"debug" description:"Enable debug output"`
-	JSON       bool                    `short:"j" long:"json" description:"Enable JSON output"`
-	JSONLogs   bool                    `short:"J" long:"json-logging" description:"Enable JSON-formatted log output"`
-	ConfigPath string                  `short:"o" long:"config-path" description:"Path to agent configuration file"`
-	Insecure   bool                    `short:"i" long:"insecure" description:"have agent attempt to connect without certificates"`
-	RuntimeDir string                  `short:"s" long:"runtime_dir" description:"Path to agent communications socket"`
-	LogFile    string                  `short:"l" long:"logfile" description:"Full path and filename for daos agent log file"`
-	Start      startCmd                `command:"start" description:"Start daos_agent daemon (default behavior)"`
-	Version    versionCmd              `command:"version" description:"Print daos_agent version"`
-	DumpInfo   dumpAttachInfoCmd       `command:"dump-attachinfo" description:"Dump system attachinfo"`
-	DumpTopo   cmdutil.DumpTopologyCmd `command:"dump-topology" description:"Dump system topology"`
-	NetScan    netScanCmd              `command:"net-scan" description:"Perform local network fabric scan"`
+	AllowProxy bool                   `long:"allow-proxy" description:"Allow proxy configuration via environment"`
+	Debug      bool                   `short:"d" long:"debug" description:"Enable debug output"`
+	JSON       bool                   `short:"j" long:"json" description:"Enable JSON output"`
+	JSONLogs   bool                   `short:"J" long:"json-logging" description:"Enable JSON-formatted log output"`
+	ConfigPath string                 `short:"o" long:"config-path" description:"Path to agent configuration file"`
+	Insecure   bool                   `short:"i" long:"insecure" description:"have agent attempt to connect without certificates"`
+	RuntimeDir string                 `short:"s" long:"runtime_dir" description:"Path to agent communications socket"`
+	LogFile    string                 `short:"l" long:"logfile" description:"Full path and filename for daos agent log file"`
+	Start      startCmd               `command:"start" description:"Start daos_agent daemon (default behavior)"`
+	Version    versionCmd             `command:"version" description:"Print daos_agent version"`
+	DumpInfo   dumpAttachInfoCmd      `command:"dump-attachinfo" description:"Dump system attachinfo"`
+	DumpTopo   hwprov.DumpTopologyCmd `command:"dump-topology" description:"Dump system topology"`
+	NetScan    netScanCmd             `command:"net-scan" description:"Perform local network fabric scan"`
 }
 
 type (
@@ -158,7 +158,7 @@ func parseOpts(args []string, opts *cliOptions, invoker control.Invoker, log *lo
 		}
 
 		switch cmd.(type) {
-		case *versionCmd, *netScanCmd, *cmdutil.DumpTopologyCmd:
+		case *versionCmd, *netScanCmd, *hwprov.DumpTopologyCmd:
 			// these commands don't need the rest of the setup
 			return cmd.Execute(args)
 		}

--- a/src/control/cmd/daos_server/main.go
+++ b/src/control/cmd/daos_server/main.go
@@ -17,8 +17,8 @@ import (
 
 	"github.com/daos-stack/daos/src/control/build"
 	"github.com/daos-stack/daos/src/control/common"
-	"github.com/daos-stack/daos/src/control/common/cmdutil"
 	"github.com/daos-stack/daos/src/control/fault"
+	"github.com/daos-stack/daos/src/control/lib/hardware/hwprov"
 	"github.com/daos-stack/daos/src/control/logging"
 	"github.com/daos-stack/daos/src/control/pbin"
 )
@@ -38,11 +38,11 @@ type mainOpts struct {
 	Syslog  bool `long:"syslog" description:"Enable logging to syslog"`
 
 	// Define subcommands
-	Storage  storageCmd              `command:"storage" description:"Perform tasks related to locally-attached storage"`
-	Start    startCmd                `command:"start" description:"Start daos_server"`
-	Network  networkCmd              `command:"network" description:"Perform network device scan based on fabric provider"`
-	Version  versionCmd              `command:"version" description:"Print daos_server version"`
-	DumpTopo cmdutil.DumpTopologyCmd `command:"dump-topology" description:"Dump system topology"`
+	Storage  storageCmd             `command:"storage" description:"Perform tasks related to locally-attached storage"`
+	Start    startCmd               `command:"start" description:"Start daos_server"`
+	Network  networkCmd             `command:"network" description:"Perform network device scan based on fabric provider"`
+	Version  versionCmd             `command:"version" description:"Print daos_server version"`
+	DumpTopo hwprov.DumpTopologyCmd `command:"dump-topology" description:"Dump system topology"`
 }
 
 type versionCmd struct{}

--- a/src/control/lib/hardware/hwprov/topology_cmd.go
+++ b/src/control/lib/hardware/hwprov/topology_cmd.go
@@ -4,7 +4,7 @@
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
 
-package cmdutil
+package hwprov
 
 import (
 	"context"
@@ -14,7 +14,6 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/daos-stack/daos/src/control/lib/hardware"
-	"github.com/daos-stack/daos/src/control/lib/hardware/hwprov"
 	"github.com/daos-stack/daos/src/control/logging"
 )
 
@@ -37,7 +36,7 @@ func (cmd *DumpTopologyCmd) Execute(_ []string) error {
 	}
 
 	log := logging.NewCommandLineLogger()
-	hwProv := hwprov.DefaultTopologyProvider(log)
+	hwProv := DefaultTopologyProvider(log)
 	topo, err := hwProv.GetTopology(context.Background())
 	if err != nil {
 		return err


### PR DESCRIPTION
Not a perfect home for it, but isolates the dependencies
on hwloc, libfabric, etc. Also removes the dump-topology
subcommand from the daos utility because it pulls in
unnecessary dependencies from the control plane.

Features: control

Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com>
