### PR TITLE
DAOS-10062 test: Allow network scan test to run outside CI env

### DIFF
--- a/src/tests/ftest/control/dmg_network_scan.py
+++ b/src/tests/ftest/control/dmg_network_scan.py
@@ -124,8 +124,7 @@ class DmgNetworkScanTest(TestWithServers):
         """Set up each test case."""
         super().setUp()
 
-        # Run the dmg command locally, unset config to run locally
-        self.hostlist_servers = socket.gethostname().split(".")[0].split(",")
+        # create dmg command obj
         self.access_points = self.hostlist_servers[:1]
         self.start_servers()
         self.dmg = self.get_dmg_command()


### PR DESCRIPTION
Test assumes that the test runner node is server

Skip-unit-tests: true
Test-tag: network_scan,basic

Signed-off-by: Maureen Jean <maureen.jean@intel.com>