### PR TITLE
DAOS-9342 test: Increasing block size for ior run command (#7755)

### DIFF
--- a/src/tests/ftest/ior/crash_ior.yaml
+++ b/src/tests/ftest/ior/crash_ior.yaml
@@ -17,7 +17,7 @@ pool:
   mode: 146
   name: daos_server
   scm_size: 6000000000
-  nvme_size: 60000000000
+  nvme_size: 100000000000
   control_method: dmg
 container:
   type: POSIX
@@ -35,7 +35,7 @@ ior:
   transfersize_blocksize:
     4K:
       transfer_size: '4K'
-      block_size: '4G'
+      block_size: '100G'
   objectclass:
     SX:
       dfs_oclass: "SX"


### PR DESCRIPTION
Increasing block size for ior run command
to increase aggregate file size. As the hardware
medium tests have moved to verbs the orignal
checks inside the test for write and read completion
are at borderline and the test has the scope to
return false failure intermittently, hence increasing
the aggregate io size 1.5 times that of previous value.

Signed-off-by: Saurabh Tandan <saurabh.tandan@intel.com>
Signed-off-by: Dalton Bohning <dalton.bohning@intel.com>