### PR TITLE
DAOS-9548 placement: refine perf_dom handling

### DIFF
--- a/src/common/pool_map.c
+++ b/src/common/pool_map.c
@@ -134,9 +134,9 @@ static struct pool_comp_type_dict comp_type_dict[] = {
 		.td_name	= "rack",
 	},
 	{
-		.td_type	= PO_COMP_TP_PD,
+		.td_type	= PO_COMP_TP_GRP,
 		.td_abbr	= 'g',
-		.td_name	= "group",	/* performance domain group */
+		.td_name	= "group",
 	},
 	{
 		.td_type	= PO_COMP_TP_ROOT,
@@ -470,7 +470,7 @@ pool_buf_parse(struct pool_buf *buf, struct pool_domain **tree_pp)
 			buf->pb_target_nr);
 		return -DER_INVAL;
 	}
-	if (buf->pb_domain_nr != 0 && buf->pb_comps[0].co_type != PO_COMP_TP_PD &&
+	if (buf->pb_domain_nr != 0 && buf->pb_comps[0].co_type != PO_COMP_TP_GRP &&
 	    buf->pb_comps[0].co_type != PO_COMP_TP_NODE) {
 		D_DEBUG(DB_MGMT, "Invalid co_type %s[%d] for first domain.\n",
 			pool_comp_type2str(buf->pb_comps[0].co_type), buf->pb_comps[0].co_type);
@@ -504,12 +504,12 @@ pool_buf_parse(struct pool_buf *buf, struct pool_domain **tree_pp)
 		parent->do_child_nr = buf->pb_node_nr;
 	} else {
 		comp = &buf->pb_comps[0];
-		if (comp->co_type == PO_COMP_TP_PD) {
+		if (comp->co_type == PO_COMP_TP_GRP) {
 			nr = 0;
 			do {
 				nr++;
 				comp++;
-			} while (comp->co_type == PO_COMP_TP_PD);
+			} while (comp->co_type == PO_COMP_TP_GRP);
 			parent->do_child_nr = nr;
 			D_DEBUG(DB_TRACE, "root do_child_nr %d, with performance domain\n",
 				parent->do_child_nr);
@@ -1539,7 +1539,7 @@ gen_pool_buf(struct pool_map *map, struct pool_buf **map_buf_out, int map_versio
 		num_fdom = num_domain_comps - num_pd;
 		fdom_per_pd = num_fdom / num_pd;
 		for (i = 0; i < num_pd; i++) {
-			map_comp.co_type = PO_COMP_TP_PD;
+			map_comp.co_type = PO_COMP_TP_GRP;
 			map_comp.co_status = PO_COMP_ST_UPIN;
 			map_comp.co_padding = 0;
 			map_comp.co_id = i;

--- a/src/include/daos/cont_props.h
+++ b/src/include/daos/cont_props.h
@@ -145,4 +145,10 @@ daos_cont_prop2rp_pda(daos_prop_t *prop);
 uint32_t
 daos_cont_prop2global_version(daos_prop_t *prop);
 
+static inline uint32_t
+daos_cont_props2pda(struct cont_props *props, bool is_ec_obj)
+{
+	return is_ec_obj ? props->dcp_ec_pda : props->dcp_rp_pda;
+}
+
 #endif /** __DAOS_CONT_PROPS_H__ */

--- a/src/include/daos/pool_map.h
+++ b/src/include/daos/pool_map.h
@@ -33,7 +33,7 @@ typedef enum pool_comp_type {
 	PO_COMP_TP_RANK		= 1, /** reserved, hard-coded */
 	PO_COMP_TP_MIN		= 2, /** first user-defined domain */
 	PO_COMP_TP_NODE		= 2, /** for test only */
-	PO_COMP_TP_PD		= 3, /** for performance domain */
+	PO_COMP_TP_GRP		= 3, /** group, commonly used for performance domain */
 	PO_COMP_TP_MAX		= 254, /** last user-defined domain */
 	PO_COMP_TP_ROOT		= 255,
 	PO_COMP_TP_END		= 256,

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -302,6 +302,16 @@ dc_obj_hdl2cont_hdl(daos_handle_t oh)
 	return hdl;
 }
 
+static uint32_t
+dc_obj_get_pda(struct dc_object *obj)
+{
+	struct cont_props	props;
+
+	props = dc_cont_hdl2props(obj->cob_coh);
+
+	return daos_cont_props2pda(&props, obj_is_ec(obj));
+}
+
 static int
 obj_layout_create(struct dc_object *obj, unsigned int mode, bool refresh)
 {
@@ -326,6 +336,7 @@ obj_layout_create(struct dc_object *obj, unsigned int mode, bool refresh)
 	}
 
 	obj->cob_md.omd_ver = dc_pool_get_version(pool);
+	obj->cob_md.omd_pda = dc_obj_get_pda(obj);
 	dc_pool_put(pool);
 	rc = pl_obj_place(map, &obj->cob_md, mode, NULL, &layout);
 	pl_map_decref(map);

--- a/src/object/srv_ec_aggregate.c
+++ b/src/object/srv_ec_aggregate.c
@@ -2130,13 +2130,14 @@ agg_reset_entry(struct ec_agg_entry *agg_entry, vos_iter_entry_t *entry,
 }
 
 static int
-agg_obj_is_leader(struct ds_pool *pool, struct daos_oclass_attr *oca,
+agg_obj_is_leader(struct ds_pool *pool, daos_handle_t cont_hdl, struct daos_oclass_attr *oca,
 		  daos_unit_oid_t *oid, uint32_t version)
 {
 	struct daos_obj_md	 md = { 0 };
 	struct pl_map		*map;
 	struct pl_obj_layout	*layout = NULL;
 	struct pl_obj_shard	*shard;
+	struct cont_props	 props;
 	uint32_t		 idx;
 	int			 rc;
 
@@ -2150,8 +2151,10 @@ agg_obj_is_leader(struct ds_pool *pool, struct daos_oclass_attr *oca,
 		return -DER_INVAL;
 	}
 
+	props = dc_cont_hdl2props(cont_hdl);
 	md.omd_id = oid->id_pub;
 	md.omd_ver = version;
+	md.omd_pda = props.dcp_ec_pda;
 	rc = pl_obj_place(map, &md, DAOS_OO_RO, NULL, &layout);
 	if (rc != 0)
 		goto out;
@@ -2231,7 +2234,7 @@ ec_agg_object(daos_handle_t ih, vos_iter_entry_t *entry, struct ec_agg_param *ag
 	/** We should have filtered it if it isn't EC */
 	rc = dsc_obj_id2oc_attr(entry->ie_oid.id_pub, &info->api_props, &oca);
 	D_ASSERT(rc == 0 && daos_oclass_is_ec(&oca));
-	rc = agg_obj_is_leader(info->api_pool, &oca, &entry->ie_oid,
+	rc = agg_obj_is_leader(info->api_pool, info->api_cont_hdl, &oca, &entry->ie_oid,
 			       info->api_pool->sp_map_version);
 	if (rc == 1) {
 		D_ASSERT((entry->ie_oid.id_shard % obj_ec_tgt_nr(&oca)) ==

--- a/src/placement/jump_map.c
+++ b/src/placement/jump_map.c
@@ -115,8 +115,7 @@ jm_obj_pd_init(struct pl_jump_map *jmap, struct daos_obj_md *md, struct pool_dom
 	jmop->jmop_root = root;
 	if (md->omd_pda == 0)
 		pd_nr = 0;
-	if (pd_nr <= 1)
-		jmop->jmop_pd_nr = pd_nr;
+	jmop->jmop_pd_nr = pd_nr;
 	if (jmop->jmop_pd_nr == 0)
 		return 0;
 
@@ -541,6 +540,18 @@ retry:
 			range_set = isset_range(dom_cur_grp_used, start_dom, end_dom);
 			if (range_set) {
 				if (top == -1) {
+					if (curr_pd != root_pos) {
+						/* all domains within the PD have been used by the
+						 * current group, try to avoid co-located shards for
+						 * same group by ignoring the PD restrict.
+						 */
+						D_INFO("PD[%d] all doms used for group, "
+							"weak the PD restrict\n",
+							(int)(curr_dom - root_pos));
+						curr_pd = root_pos;
+						curr_dom = curr_pd;
+						goto retry;
+					}
 					/* all domains have been used by the current group,
 					 * then we cleanup the dom_cur_grp_used bits, i.e.
 					 * the shards within the same group might be put
@@ -1120,6 +1131,12 @@ jump_map_create(struct pool_map *poolmap, struct pl_map_init_attr *mia,
 		goto ERR;
 	}
 	jmap->jmp_domain_nr = rc;
+
+	if (jmap->jmp_domain_nr < jmap->jmp_pd_nr) {
+		D_ERROR("Bad parameter, dom_nr %d < pd_nr %d\n",
+			jmap->jmp_domain_nr, jmap->jmp_pd_nr);
+		return -DER_INVAL;
+	}
 
 	rc = pool_map_find_upin_tgts(poolmap, NULL, &jmap->jmp_target_nr);
 	if (rc) {

--- a/src/placement/jump_map.c
+++ b/src/placement/jump_map.c
@@ -524,6 +524,17 @@ retry:
 			range_set = isset_range(dom_occupied, start_dom, end_dom);
 			if (range_set) {
 				if (top == -1) {
+					if (curr_pd != root_pos) {
+						/* all domains within the PD occupied, ignore the
+						 * PD restrict and try again.
+						 */
+						D_INFO("PD[%d] all doms occupied, weak the PD "
+							"restrict\n",
+							(int)(curr_dom - root_pos));
+						curr_pd = root_pos;
+						curr_dom = curr_pd;
+						goto retry;
+					}
 					/* shard nr > target nr, no extra target for the shard */
 					*target = NULL;
 					return;

--- a/src/placement/jump_map.c
+++ b/src/placement/jump_map.c
@@ -129,7 +129,7 @@ jm_obj_pd_init(struct pl_jump_map *jmap, struct daos_obj_md *md, struct pool_dom
 	jmop->jmop_pd_nr = min(pd_grp_nr, pd_nr);
 
 	D_ASSERT(pd_nr >= 1);
-	rc = pool_map_find_domain(jmap->jmp_map.pl_poolmap, PO_COMP_TP_PD, PO_COMP_ID_ALL, &pds);
+	rc = pool_map_find_domain(jmap->jmp_map.pl_poolmap, PO_COMP_TP_GRP, PO_COMP_ID_ALL, &pds);
 	D_ASSERT(rc == pd_nr);
 	rc = 0;
 
@@ -1109,7 +1109,7 @@ jump_map_create(struct pool_map *poolmap, struct pl_map_init_attr *mia,
 
 	jmap->jmp_redundant_dom = mia->ia_jump_map.domain;
 
-	rc = pool_map_find_domain(poolmap, PO_COMP_TP_PD, PO_COMP_ID_ALL, &doms);
+	rc = pool_map_find_domain(poolmap, PO_COMP_TP_GRP, PO_COMP_ID_ALL, &doms);
 	if (rc < 0)
 		goto ERR;
 	jmap->jmp_pd_nr = rc;

--- a/src/placement/tests/jump_map_pda.c
+++ b/src/placement/tests/jump_map_pda.c
@@ -15,7 +15,7 @@
 #include "../../pool/srv_pool_map.h"
 
 static void
-base_pda_test(void **state)
+basic_pda_test(void **state)
 {
 	struct pool_map		*po_map;
 	struct pl_map		*pl_map;
@@ -38,12 +38,91 @@ base_pda_test(void **state)
 	assert_placement_success_print(pl_map, OC_EC_4P2G2, 1);
 	print_message("place OC_EC8P2G2 pda 4\n");
 	assert_placement_success_print(pl_map, OC_EC_8P2G2, 4);
+
+	/* --------------------------------------------------------- */
 	print_message("place OC_EC16P2G8 pda 3, need 18 domains will fail\n");
 	assert_invalid_param(pl_map, OC_EC_16P2G8, 3);
 
 	free_pool_and_placement_map(po_map, pl_map);
+}
 
-	/* The End */
+/* set a fault domain's status */
+void
+test_set_tgt(struct pool_map *po_map, uint32_t id, uint32_t status)
+{
+	struct pool_target	*tgt = NULL;
+	static int		 fseq = 10;
+	int			 rc;
+
+	rc = pool_map_find_target(po_map, id, &tgt);
+	assert_rc_equal(rc, 1);
+	D_ASSERT(tgt != NULL);
+
+	tgt->ta_comp.co_status = status;
+	tgt->ta_comp.co_fseq = fseq++;
+	print_message("set target id %d status as %d\n", id, status);
+}
+
+static void
+no_enough_fdom_in_pd(void **state)
+{
+	struct pool_map		*po_map;
+	struct pl_map		*pl_map;
+	uint32_t		 num_pd, fdoms_per_pd, nodes_per_fdom, vos_per_tgt;
+	uint32_t		 num_tgts, i, j, pda, start, num;
+	uint32_t		 shard, tgt, new_tgt, fault_dom, new_dom, tmp_dom;
+	daos_obj_id_t		 oid;
+	struct pl_obj_layout	*layout = NULL;
+
+	/* --------------------------------------------------------- */
+	num_pd = 4;
+	fdoms_per_pd = 4;
+	nodes_per_fdom = 1;
+	vos_per_tgt = 8;
+	num_tgts = num_pd * fdoms_per_pd * nodes_per_fdom * vos_per_tgt;
+	print_message("\nWith %d PDs, %d domains each PD, %d node each domain, "
+		      "%d targets each node = %d targets\n", num_pd, fdoms_per_pd,
+		      nodes_per_fdom, vos_per_tgt, num_tgts);
+
+	gen_maps(num_pd, fdoms_per_pd, nodes_per_fdom, vos_per_tgt, &po_map, &pl_map);
+	print_message("place OC_RP_4G2 pda 4\n");
+	pda = 4;
+	gen_oid(&oid, 1, UINT64_MAX, OC_RP_4G2);
+	assert_success(plt_obj_place(oid, pda, &layout, pl_map, true));
+
+	shard = 5;
+	tgt = layout->ol_shards[shard].po_target;
+	pl_obj_layout_free(layout);
+
+	fault_dom = tgt / (nodes_per_fdom * vos_per_tgt);
+	print_message("place OC_RP_4G2 pda 4, fail all tgts of dom[%d]\n", fault_dom);
+	start = fault_dom * nodes_per_fdom * vos_per_tgt;
+	num = nodes_per_fdom * vos_per_tgt;
+	for (i = start; i < start + num; i++)
+		test_set_tgt(po_map, i, PO_COMP_ST_DOWN);
+	layout = NULL;
+	assert_success(plt_obj_place(oid, pda, &layout, pl_map, true));
+	new_tgt = layout->ol_shards[shard].po_target;
+	new_dom = new_tgt / (nodes_per_fdom * vos_per_tgt);
+	assert_true(new_tgt != tgt);
+	assert_true(new_dom != fault_dom);
+	print_message("shard[%d] changed from tgt[%d]/dom[%d] to tgt[%d]/dom[%d]\n",
+		      shard, tgt, fault_dom, new_tgt, new_dom);
+	print_message("checking should not with co-located shards ...\n");
+	for (i = 0; i < 8; i++) {
+		tgt =  layout->ol_shards[i].po_target;
+		tmp_dom = tgt / (nodes_per_fdom * vos_per_tgt);
+		for (j = 0; j < 8; j++) {
+			if (i == j)
+				continue;
+			new_tgt = layout->ol_shards[j].po_target;
+			new_dom = new_tgt / (nodes_per_fdom * vos_per_tgt);
+			assert_true(tmp_dom != new_dom);
+		}
+	}
+
+	pl_obj_layout_free(layout);
+	free_pool_and_placement_map(po_map, pl_map);
 }
 
 /*
@@ -74,7 +153,8 @@ placement_test_teardown(void **state)
 
 static const struct CMUnitTest pda_tests[] = {
 	/* Standard configurations */
-	T("Base PDA test", base_pda_test),
+	T("Base PDA test", basic_pda_test),
+	T("PDA special case test", no_enough_fdom_in_pd),
 };
 
 int

--- a/src/placement/tests/jump_map_pda.c
+++ b/src/placement/tests/jump_map_pda.c
@@ -63,14 +63,93 @@ test_set_tgt(struct pool_map *po_map, uint32_t id, uint32_t status)
 	print_message("set target id %d status as %d\n", id, status);
 }
 
+static bool
+layout_with_colocated_shards(struct pl_obj_layout *layout, uint32_t tgts_per_dom)
+{
+	uint32_t	i, j, dom, new_dom, tgt, new_tgt;
+
+	for (i = 0; i < layout->ol_nr; i++) {
+		tgt =  layout->ol_shards[i].po_target;
+		dom = tgt / tgts_per_dom;
+		for (j = i + 1; j < layout->ol_nr; j++) {
+			new_tgt = layout->ol_shards[j].po_target;
+			assert_true(new_tgt != tgt);
+			assert_true(tgt != -1 && new_tgt != -1);
+			new_dom = new_tgt / tgts_per_dom;
+			if (dom == new_dom)
+				return true;
+		}
+	}
+
+	return false;
+}
+
 static void
-no_enough_fdom_in_pd(void **state)
+pd_use_all_dom(void **state)
 {
 	struct pool_map		*po_map;
 	struct pl_map		*pl_map;
 	uint32_t		 num_pd, fdoms_per_pd, nodes_per_fdom, vos_per_tgt;
-	uint32_t		 num_tgts, i, j, pda, start, num;
-	uint32_t		 shard, tgt, new_tgt, fault_dom, new_dom, tmp_dom;
+	uint32_t		 num_tgts, pda;
+	daos_obj_id_t		 oid;
+	struct pl_obj_layout	*layout = NULL;
+
+	/* --------------------------------------------------------- */
+	num_pd = 2;
+	fdoms_per_pd = 4;
+	nodes_per_fdom = 1;
+	vos_per_tgt = 1;
+	num_tgts = num_pd * fdoms_per_pd * nodes_per_fdom * vos_per_tgt;
+	print_message("\nWith %d PDs, %d domains each PD, %d node each domain, "
+		      "%d targets each node = %d targets\n", num_pd, fdoms_per_pd,
+		      nodes_per_fdom, vos_per_tgt, num_tgts);
+
+	gen_maps(num_pd, fdoms_per_pd, nodes_per_fdom, vos_per_tgt, &po_map, &pl_map);
+	print_message("place OC_RP_4G2 pda 3\n");
+	pda = 3;
+	gen_oid(&oid, 1, UINT64_MAX, OC_RP_4G2);
+	assert_success(plt_obj_place(oid, pda, &layout, pl_map, true));
+	assert_true(layout_with_colocated_shards(layout, nodes_per_fdom * vos_per_tgt) == false);
+	pl_obj_layout_free(layout);
+}
+
+static void
+pd_shards_colocated(void **state)
+{
+	struct pool_map		*po_map;
+	struct pl_map		*pl_map;
+	uint32_t		 num_pd, fdoms_per_pd, nodes_per_fdom, vos_per_tgt;
+	uint32_t		 num_tgts, pda;
+	daos_obj_id_t		 oid;
+	struct pl_obj_layout	*layout = NULL;
+
+	/* --------------------------------------------------------- */
+	num_pd = 2;
+	fdoms_per_pd = 4;
+	nodes_per_fdom = 1;
+	vos_per_tgt = 2;
+	num_tgts = num_pd * fdoms_per_pd * nodes_per_fdom * vos_per_tgt;
+	print_message("\nWith %d PDs, %d domains each PD, %d node each domain, "
+		      "%d targets each node = %d targets\n", num_pd, fdoms_per_pd,
+		      nodes_per_fdom, vos_per_tgt, num_tgts);
+
+	gen_maps(num_pd, fdoms_per_pd, nodes_per_fdom, vos_per_tgt, &po_map, &pl_map);
+	print_message("place OC_EC_4P2G2 pda 3\n");
+	pda = 3;
+	gen_oid(&oid, 1, UINT64_MAX, OC_EC_4P2G2);
+	assert_success(plt_obj_place(oid, pda, &layout, pl_map, true));
+	assert_true(layout_with_colocated_shards(layout, nodes_per_fdom * vos_per_tgt) == true);
+	pl_obj_layout_free(layout);
+}
+
+static void
+pd_with_failed_dom(void **state)
+{
+	struct pool_map		*po_map;
+	struct pl_map		*pl_map;
+	uint32_t		 num_pd, fdoms_per_pd, nodes_per_fdom, vos_per_tgt;
+	uint32_t		 num_tgts, i, pda, start, num;
+	uint32_t		 shard, tgt, new_tgt, fault_dom, new_dom;
 	daos_obj_id_t		 oid;
 	struct pl_obj_layout	*layout = NULL;
 
@@ -109,17 +188,7 @@ no_enough_fdom_in_pd(void **state)
 	print_message("shard[%d] changed from tgt[%d]/dom[%d] to tgt[%d]/dom[%d]\n",
 		      shard, tgt, fault_dom, new_tgt, new_dom);
 	print_message("checking should not with co-located shards ...\n");
-	for (i = 0; i < 8; i++) {
-		tgt =  layout->ol_shards[i].po_target;
-		tmp_dom = tgt / (nodes_per_fdom * vos_per_tgt);
-		for (j = 0; j < 8; j++) {
-			if (i == j)
-				continue;
-			new_tgt = layout->ol_shards[j].po_target;
-			new_dom = new_tgt / (nodes_per_fdom * vos_per_tgt);
-			assert_true(tmp_dom != new_dom);
-		}
-	}
+	assert_true(layout_with_colocated_shards(layout, nodes_per_fdom * vos_per_tgt) == false);
 
 	pl_obj_layout_free(layout);
 	free_pool_and_placement_map(po_map, pl_map);
@@ -154,7 +223,9 @@ placement_test_teardown(void **state)
 static const struct CMUnitTest pda_tests[] = {
 	/* Standard configurations */
 	T("Base PDA test", basic_pda_test),
-	T("PDA special case test", no_enough_fdom_in_pd),
+	T("PDA test - use all domains", pd_use_all_dom),
+	T("PDA test - colocated shards", pd_shards_colocated),
+	T("PDA test - PD with failed domain", pd_with_failed_dom),
 };
 
 int

--- a/src/placement/tests/place_obj_common.c
+++ b/src/placement/tests/place_obj_common.c
@@ -565,7 +565,7 @@ gen_pool_and_placement_map(int num_pds, int fdoms_per_pd, int nodes_per_domain,
 	comp = &comps[0];
 	/* fake the pool map */
 	for (i = 0; i < num_pds && num_pds >= 2; i++, comp++) {
-		comp->co_type   = PO_COMP_TP_PD;
+		comp->co_type   = PO_COMP_TP_GRP;
 		comp->co_status = PO_COMP_ST_UPIN;
 		comp->co_id     = i;
 		comp->co_rank   = i;

--- a/src/placement/tests/placement_test.c
+++ b/src/placement/tests/placement_test.c
@@ -130,7 +130,7 @@ int main(int argc, char *argv[])
 	}
 	if (pda_test)
 		pda_tests_run(verbose);
-	if (dist_test)
+	else if (dist_test)
 		dist_tests_run(verbose, num_objs, obj_class);
 	else
 		placement_tests_run(verbose);

--- a/src/rebuild/scan.c
+++ b/src/rebuild/scan.c
@@ -322,6 +322,7 @@ rebuild_object_insert(struct rebuild_tgt_pool_tracker *rpt,
 struct rebuild_scan_arg {
 	struct rebuild_tgt_pool_tracker *rpt;
 	uuid_t				co_uuid;
+	struct cont_props		co_props;
 	int				snapshot_cnt;
 	uint32_t			yield_freq;
 };
@@ -524,6 +525,7 @@ rebuild_obj_scan_cb(daos_handle_t ch, vos_iter_entry_t *ent,
 	dc_obj_fetch_md(oid.id_pub, &md);
 	crt_group_rank(rpt->rt_pool->sp_group, &myrank);
 	md.omd_ver = rpt->rt_rebuild_ver;
+	md.omd_pda = daos_cont_props2pda(&arg->co_props, daos_oclass_is_ec(oc_attr));
 
 	if (rpt->rt_rebuild_op == RB_OP_FAIL ||
 	    rpt->rt_rebuild_op == RB_OP_DRAIN ||
@@ -690,7 +692,16 @@ rebuild_container_scan_cb(daos_handle_t ih, vos_iter_entry_t *entry,
 	rc = ds_cont_fetch_snaps(rpt->rt_pool->sp_iv_ns, entry->ie_couuid, NULL,
 				 &snapshot_cnt);
 	if (rc) {
-		D_ERROR("ds_cont_fetch_snaps failed: "DF_RC"\n", DP_RC(rc));
+		D_ERROR("Container "DF_UUID", ds_cont_fetch_snaps failed: "DF_RC"\n",
+			DP_UUID(entry->ie_couuid), DP_RC(rc));
+		vos_cont_close(coh);
+		return rc;
+	}
+
+	rc = ds_cont_get_props(&arg->co_props, rpt->rt_pool->sp_uuid, entry->ie_couuid);
+	if (rc) {
+		D_ERROR("Container "DF_UUID", ds_cont_get_props failed: "DF_RC"\n",
+			DP_UUID(entry->ie_couuid), DP_RC(rc));
 		vos_cont_close(coh);
 		return rc;
 	}


### PR DESCRIPTION
1. avoid co-located shards in PD as far as possible
    If all fault-domains used (or some failed) for the group within the PD,
    then ignore the PD restrict to avoid co-located shards as far as
    possible.
2. allow to select target from other PD if all domains in current PD occupied.
3. integrate with PDA property (get PDA parameter from cont prop)
    Get PDA parameter from container property when calculate layout.
4. Rename PO_COMP_TP_PD as PO_COMP_TP_GRP, as performance domain
    can be set at rack/group level.

Signed-off-by: Xuezhao Liu <xuezhao.liu@intel.com>