### PR TITLE
DAOS-9583 chk: start DAOS engine with check mode

### DIFF
--- a/src/SConscript
+++ b/src/SConscript
@@ -76,6 +76,7 @@ def scons():
 
     # Build each DAOS component
     SConscript('rsvc/SConscript')
+    SConscript('chk/SConscript')
     SConscript('mgmt/SConscript')
     SConscript('pool/SConscript')
     SConscript('container/SConscript')

--- a/src/chk/SConscript
+++ b/src/chk/SConscript
@@ -1,0 +1,24 @@
+"""Build chk library"""
+import daos_build
+
+def scons():
+    """Execute build"""
+    Import('env', 'prereqs')
+
+    env.AppendUnique(LIBPATH=[Dir('.')])
+
+    if not prereqs.server_requested():
+        return
+
+    denv = env.Clone()
+
+    prereqs.require(denv, 'argobots', 'protobufc')
+
+    # chk
+    chk = daos_build.library(denv, 'chk',
+                             ['check.pb-c.c', 'chk_srv.c', 'chk_common.c'],
+                             install_off="../..")
+    denv.Install('$PREFIX/lib64/daos_srv', chk)
+
+if __name__ == "SCons.Script":
+    scons()

--- a/src/chk/chk_common.c
+++ b/src/chk/chk_common.c
@@ -1,0 +1,56 @@
+/**
+ * (C) Copyright 2022 Intel Corporation.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause-Patent
+ */
+
+#define D_LOGFAC	DD_FAC(chk)
+
+#include <daos_srv/daos_chk.h>
+
+#include "check.pb-c.h"
+#include "chk_internal.h"
+
+int
+chk_start(d_rank_list_t *ranks, struct chk_policy *policies, uuid_t *pools,
+	  int pool_cnt, uint32_t flags)
+{
+	return 0;
+}
+
+int
+chk_stop(uuid_t *pools, int pool_cnt)
+{
+	return 0;
+}
+
+int
+chk_query(uuid_t *pools, int pool_cnt, chk_query_cb_t query_cb,
+	  struct chk_query_target *cqt, void *buf)
+{
+	return 0;
+}
+
+int
+chk_prop(uint32_t *flags, chk_prop_cb_t prop_cb, struct chk_policy *policy, void *buf)
+{
+	return 0;
+}
+
+int
+chk_act(uint64_t seq, uint32_t act, bool for_all)
+{
+	return 0;
+}
+
+int
+chk_rejoin(void)
+{
+	return 0;
+}
+
+int
+chk_pause(void)
+{
+	return 0;
+}

--- a/src/chk/chk_internal.h
+++ b/src/chk/chk_internal.h
@@ -1,0 +1,47 @@
+/**
+ * (C) Copyright 2022 Intel Corporation.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause-Patent
+ */
+
+/**
+ * DAOS global consistency checker RPC Protocol Definitions
+ */
+
+#ifndef __CHK_INTERNAL_H__
+#define __CHK_INTERNAL_H__
+
+#include <daos/rpc.h>
+#include <daos_srv/daos_chk.h>
+
+#include "check.pb-c.h"
+
+/*
+ * RPC operation codes
+ *
+ * These are for daos_rpc::dr_opc and DAOS_RPC_OPCODE(opc, ...) rather than
+ * crt_req_create(..., opc, ...). See daos/rpc.h.
+ */
+#define DAOS_CHK_VERSION 1
+
+#define CHK_PROTO_SRV_RPC_LIST									\
+	X(CHK_START,	0,	&CQF_chk_start,	ds_chk_start_hdlr,	NULL,	"chk_start")	\
+	X(CHK_STOP,	0,	&CQF_chk_stop,	ds_chk_stop_hdlr,	NULL,	"chk_stop")	\
+	X(CHK_QUERY,	0,	&CQF_chk_query,	ds_chk_query_hdlr,	NULL,	"chk_query")	\
+	X(CHK_ACT,	0,	&CQF_chk_act,	ds_chk_act_hdlr,	NULL,	"chk_act")
+
+/* Define for RPC enum population below */
+#define X(a, b, c, d, e, f) a,
+
+enum chk_rpc_opc {
+	CHK_PROTO_SRV_RPC_LIST
+	CHK_PROTO_SRV_RPC_COUNT,
+};
+
+#undef X
+
+int chk_rejoin(void);
+
+int chk_pause(void);
+
+#endif /* __CHK_INTERNAL_H__ */

--- a/src/chk/chk_srv.c
+++ b/src/chk/chk_srv.c
@@ -1,0 +1,106 @@
+/**
+ * (C) Copyright 2022 Intel Corporation.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause-Patent
+ */
+
+#define D_LOGFAC	DD_FAC(chk)
+
+#include <daos/rpc.h>
+#include <daos_srv/daos_chk.h>
+#include <daos_srv/daos_engine.h>
+
+#include "check.pb-c.h"
+#include "chk_internal.h"
+
+static bool
+ds_chk_need_rejoin(void) {
+	return true;
+}
+
+static void
+ds_chk_start_hdlr(crt_rpc_t *rpc)
+{
+}
+
+static void
+ds_chk_stop_hdlr(crt_rpc_t *rpc)
+{
+}
+
+static void
+ds_chk_query_hdlr(crt_rpc_t *rpc)
+{
+}
+
+static void
+ds_chk_act_hdlr(crt_rpc_t *rpc)
+{
+}
+
+static int
+ds_chk_init(void)
+{
+	return 0;
+}
+
+static int
+ds_chk_fini(void)
+{
+	return 0;
+}
+
+static int
+ds_chk_setup(void)
+{
+	int	rc;
+
+	/* TBD: open log. */
+
+	if (ds_chk_need_rejoin()) {
+		rc = chk_rejoin();
+		/* Rejoin check may fail, that is normal. Because former check instance may has
+		 * already been stopped or exited, or current rank may miss some critical phase
+		 * or has been excluded. Just some warning message without stopping the engine.
+		 */
+		if (rc != 0)
+			D_WARN("Cannot rejoin CHECK: "DF_RC"\n", DP_RC(rc));
+	}
+
+	return 0;
+}
+
+static int
+ds_chk_cleanup(void)
+{
+	chk_pause();
+
+	/* TBD: close log. */
+
+	return 0;
+}
+
+#define X(a, b, c, d, e, f)	\
+{				\
+	.dr_opc       = a,	\
+	.dr_hdlr      = d,	\
+	.dr_corpc_ops = e,	\
+},
+
+static struct daos_rpc_handler chk_handlers[] = {
+	CHK_PROTO_SRV_RPC_LIST
+};
+
+#undef X
+
+struct dss_module chk_module = {
+	.sm_name		= "chk",
+	.sm_mod_id		= DAOS_CHK_MODULE,
+	.sm_ver			= DAOS_CHK_VERSION,
+	.sm_init		= ds_chk_init,
+	.sm_fini		= ds_chk_fini,
+	.sm_setup		= ds_chk_setup,
+	.sm_cleanup		= ds_chk_cleanup,
+	.sm_cli_count		= 0,
+	.sm_handlers		= chk_handlers,
+};

--- a/src/include/daos/debug.h
+++ b/src/include/daos/debug.h
@@ -47,6 +47,7 @@
 	ACTION(drpc,      drpc,      arg)	\
 	ACTION(security,  security,  arg)	\
 	ACTION(dtx,       dtx,       arg)	\
+	ACTION(chk,       chk,       arg)	\
 	ACTION(dfuse,     dfuse,     arg)	\
 	ACTION(il,        il,        arg)	\
 	ACTION(csum,      csum,      arg)

--- a/src/include/daos/rpc.h
+++ b/src/include/daos/rpc.h
@@ -51,8 +51,9 @@ enum daos_module_id {
 	DAOS_RDBT_MODULE	= 8, /** rdb test */
 	DAOS_SEC_MODULE		= 9, /** security framework */
 	DAOS_DTX_MODULE		= 10, /** DTX */
+	DAOS_CHK_MODULE		= 11, /** check */
 
-	DAOS_NR_MODULE		= 11, /** number of defined modules */
+	DAOS_NR_MODULE		= 12, /** number of defined modules */
 	DAOS_MAX_MODULE		= 64  /** Size of uint64_t see dmg profile */
 };
 

--- a/src/include/daos_srv/daos_chk.h
+++ b/src/include/daos_srv/daos_chk.h
@@ -1,0 +1,60 @@
+/**
+ * (C) Copyright 2022 Intel Corporation.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause-Patent
+ */
+
+#ifndef __DAOS_CHK_H__
+#define __DAOS_CHK_H__
+
+#include <daos_prop.h>
+#include <daos_types.h>
+
+struct chk_policy {
+	uint32_t		cp_class;
+	uint32_t		cp_action;
+};
+
+/* Check query result for the pool (all ranks) or pool shard (per target). */
+struct chk_query_pool {
+	uuid_t			cqp_uuid;
+	char			cqp_label[DAOS_PROP_MAX_LABEL_BUF_LEN];
+	uint32_t		cqp_status;
+	uint32_t		cqp_phase;
+	uint32_t		cqp_total;
+	uint32_t		cqp_repaired;
+	uint32_t		cqp_ignored;
+	uint32_t		cqp_failed;
+	uint64_t		cqp_start_time;
+	union {
+		uint64_t	cqp_remain_time;
+		uint64_t	cqp_stop_time;
+	};
+};
+
+/* Check query result for the target including all the pool shards on this target. */
+struct chk_query_target {
+	d_rank_t		dqt_rank;
+	uint32_t		dqt_tgt;
+	uint32_t		dqt_status;
+	uint32_t		dqt_cnt;
+	struct chk_query_pool	dqt_shards[0];
+};
+
+typedef int (*chk_query_cb_t)(void *buf, struct chk_query_target *cqt);
+
+typedef int (*chk_prop_cb_t)(void *buf, struct chk_policy *policies);
+
+int chk_start(d_rank_list_t *ranks, struct chk_policy *policies, uuid_t *pools,
+	      int pool_cnt, uint32_t flags);
+
+int chk_stop(uuid_t *pools, int pool_cnt);
+
+int chk_query(uuid_t *pools, int pool_cnt, chk_query_cb_t query_cb,
+	      struct chk_query_target *cqt, void *buf);
+
+int chk_prop(uint32_t *flags, chk_prop_cb_t prop_cb, struct chk_policy *policy, void *buf);
+
+int chk_act(uint64_t seq, uint32_t act, bool for_all);
+
+#endif /* __DAOS_CHK_H__ */


### PR DESCRIPTION
The check module infrastructure and bootstrap sequence.
New options for start engine with check mode:

-C|--check:     Start engine with check mode, global consistency check.

Signed-off-by: Fan Yong <fan.yong@intel.com>