### PR TITLE
DAOS-10179 rdb: Add missing KVS cache evictions

### DIFF
--- a/src/rdb/rdb_kvs.c
+++ b/src/rdb/rdb_kvs.c
@@ -7,8 +7,8 @@
  * rdb: KVSs
  *
  * This file implements an LRU cache of rdb_kvs objects, each of which maps a
- * KVS path to the matching VOS object. The cache provides better KVS path
- * lookup performance.
+ * KVS path to the matching VOS object in the LC at the last index. The cache
+ * provides better KVS path lookup performance.
  */
 
 #define D_LOGFAC	DD_FAC(rdb)

--- a/src/rdb/rdb_util.c
+++ b/src/rdb/rdb_util.c
@@ -588,4 +588,3 @@ rdb_scm_left(struct rdb *db, daos_size_t *scm_left_outp)
 
 	return 0;
 }
-


### PR DESCRIPTION
The rdb module caches <KVS path, VOS object ID> pairs for the Log
Container at the last index. When popping log entries, we should empty
this cache just in case that the popping reverts some KVS create
operations and leaves incorrect <KVS path, VOS object ID> pairs in the
cache. This patch adds two such rdb_kvs_cache_evict calls that are
missing when popping entries and when loading snapshots.

The rdb_raft_log_offer_single function has a few error paths that
discards the same index more than once. Since discarding an index may be
expensive, this patch avoids that.

Signed-off-by: Li Wei <wei.g.li@intel.com>