### PR TITLE
DAOS-9116 test: Increase test pause before killing servers

### DIFF
--- a/src/tests/ftest/control/ms_resilience.py
+++ b/src/tests/ftest/control/ms_resilience.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 """
-(C) Copyright 2021 Intel Corporation.
+(C) Copyright 2021-2022 Intel Corporation.
 
 SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -185,7 +185,7 @@ class ManagementServiceResilience(TestWithServers):
         self.start_servers(server_groups)
 
         # Give SWIM some time to stabilize before we start killing stuff (DAOS-9116)
-        time.sleep(2 * len(self.hostlist_servers))
+        time.sleep(4 * len(self.hostlist_servers))
 
         return replicas
 


### PR DESCRIPTION
The previous pause was 2s * len(servers), but the ticket
was reopened with another finding that seemed to indicate
that SWIM never reported that the stopped rank was DEAD.

Increase the pause to 4s * len(servers), to see if this
improves test reliability.

Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com>
