### PR TITLE
DAOS-10055 test: Adjust ghost rpc test

### DIFF
--- a/src/tests/ftest/cart/test_rpc_to_ghost_rank.c
+++ b/src/tests/ftest/cart/test_rpc_to_ghost_rank.c
@@ -172,8 +172,8 @@ completion_cb_common(const struct crt_cb_info *cb_info)
 		rpc_req_output = crt_reply_get(rpc_req);
 		if (rpc_req_output == NULL)
 			return;
-		if (cb_info->cci_rc != -DER_UNREACH && cb_info->cci_rc !=
-				-DER_TIMEDOUT) {
+		if (cb_info->cci_rc != -DER_UNREACH && cb_info->cci_rc != -DER_TIMEDOUT &&
+		    cb_info->cci_rc != -DER_HG) {
 			D_ERROR("rpc (opc: %#x) failed, rc: %d, "
 				"expecting rc: %d.\n",
 				rpc_req->cr_opc, cb_info->cci_rc, -DER_UNREACH);


### PR DESCRIPTION
- Adjust ghost rpc test to expect potential DER_HG error when sending
RPC to a dead host

Signed-off-by: Alexander A Oganezov <alexander.a.oganezov@intel.com>