### PR TITLE
DAOS-9623 control: Add secondary context count to config

### DIFF
--- a/src/control/server/config/server.go
+++ b/src/control/server/config/server.go
@@ -60,10 +60,11 @@ type Server struct {
 	TelemetryPort       int                    `yaml:"telemetry_port,omitempty"`
 
 	// duplicated in engine.Config
-	SystemName string              `yaml:"name"`
-	SocketDir  string              `yaml:"socket_dir"`
-	Fabric     engine.FabricConfig `yaml:",inline"`
-	Modules    string              `yaml:"-"`
+	SystemName     string              `yaml:"name"`
+	SocketDir      string              `yaml:"socket_dir"`
+	Fabric         engine.FabricConfig `yaml:",inline"`
+	Modules        string              `yaml:"-"`
+	NrSecondaryCtx int                 `yaml:"nr_secondary_contexts,omitempty"`
 
 	AccessPoints []string `yaml:"access_points"`
 
@@ -135,6 +136,15 @@ func (cfg *Server) WithCrtTimeout(timeout uint32) *Server {
 	return cfg
 }
 
+// WithNrSecondaryCtx sets the number of CART contexts for each engine's secondary provider.
+func (cfg *Server) WithNrSecondaryCtx(nr int) *Server {
+	cfg.NrSecondaryCtx = nr
+	for _, engine := range cfg.Engines {
+		engine.WithNrSecondaryCtx(cfg.perEngineNrSecondaryCtx())
+	}
+	return cfg
+}
+
 // NB: In order to ease maintenance, the set of chained config functions
 // which modify nested engine configurations should be kept above this
 // one as a reference for which things should be set/updated in the next
@@ -154,7 +164,16 @@ func (cfg *Server) updateServerConfig(cfgPtr **engine.Config) {
 	engineCfg.SystemName = cfg.SystemName
 	engineCfg.SocketDir = cfg.SocketDir
 	engineCfg.Modules = cfg.Modules
+	engineCfg.NrSecondaryCtx = cfg.perEngineNrSecondaryCtx()
 	engineCfg.Storage.EnableHotplug = cfg.EnableHotplug
+}
+
+func (cfg *Server) perEngineNrSecondaryCtx() int {
+	numSecProviders := cfg.Fabric.GetNumProviders() - 1
+	if numSecProviders < 1 {
+		return 0
+	}
+	return numSecProviders * cfg.NrSecondaryCtx
 }
 
 // WithEngines sets the list of engine configurations.

--- a/src/control/server/engine/config.go
+++ b/src/control/server/engine/config.go
@@ -75,6 +75,15 @@ func splitMultiProviderStr(str string) []string {
 	return result
 }
 
+// GetNumProviders gets the number of fabric providers configured.
+func (fc *FabricConfig) GetNumProviders() int {
+	providers, err := fc.GetProviders()
+	if err != nil {
+		return 0
+	}
+	return len(providers)
+}
+
 // GetPrimaryInterface parses the primary fabric interface from the Interface string.
 func (fc *FabricConfig) GetPrimaryInterface() (string, error) {
 	interfaces, err := fc.GetInterfaces()
@@ -264,6 +273,7 @@ type Config struct {
 	Index             uint32         `yaml:"-" cmdLongFlag:"--instance_idx" cmdShortFlag:"-I"`
 	MemSize           int            `yaml:"-" cmdLongFlag:"--mem_size" cmdShortFlag:"-r"`
 	HugePageSz        int            `yaml:"-" cmdLongFlag:"--hugepage_size" cmdShortFlag:"-H"`
+	NrSecondaryCtx    int            `yaml:"-" cmdLongFlag:"--nr_sec_ctx,nonzero" cmdShortFlag:"-S,nonzero"`
 }
 
 // NewConfig returns an I/O Engine config.
@@ -507,6 +517,12 @@ func (c *Config) WithCrtCtxShareAddr(addr uint32) *Config {
 // WithCrtTimeout defines the CRT_TIMEOUT for this instance
 func (c *Config) WithCrtTimeout(timeout uint32) *Config {
 	c.Fabric.CrtTimeout = timeout
+	return c
+}
+
+// WithNrSecondaryCtx sets the number of CART contexts for each secondary provider.
+func (c *Config) WithNrSecondaryCtx(nr int) *Config {
+	c.NrSecondaryCtx = nr
 	return c
 }
 

--- a/src/control/server/engine/config_test.go
+++ b/src/control/server/engine/config_test.go
@@ -796,6 +796,34 @@ func TestFabricConfig_GetProviders(t *testing.T) {
 	}
 }
 
+func TestFabricConfig_GetNumProviders(t *testing.T) {
+	for name, tc := range map[string]struct {
+		cfg    *FabricConfig
+		expNum int
+	}{
+		"nil": {},
+		"empty": {
+			cfg: &FabricConfig{},
+		},
+		"single": {
+			cfg: &FabricConfig{
+				Provider: "p1",
+			},
+			expNum: 1,
+		},
+		"multi": {
+			cfg: &FabricConfig{
+				Provider: "p1 p2 p3 p4",
+			},
+			expNum: 4,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			common.AssertEqual(t, tc.expNum, tc.cfg.GetNumProviders(), "")
+		})
+	}
+}
+
 func TestFabricConfig_GetPrimaryProvider(t *testing.T) {
 	for name, tc := range map[string]struct {
 		cfg         *FabricConfig

--- a/src/engine/init.c
+++ b/src/engine/init.c
@@ -898,6 +898,7 @@ parse(int argc, char **argv)
 		{ "instance_idx",	required_argument,	NULL,	'I' },
 		{ "bypass_health_chk",	no_argument,		NULL,	'b' },
 		{ "storage_tiers",	required_argument,	NULL,	'T' },
+		{ "nr_sec_ctx",		required_argument,	NULL,	'S' },
 		{ NULL,			0,			NULL,	0}
 	};
 	int	rc = 0;
@@ -905,7 +906,7 @@ parse(int argc, char **argv)
 
 	/* load all of modules by default */
 	sprintf(modules, "%s", MODULE_LIST);
-	while ((c = getopt_long(argc, argv, "c:d:f:g:hi:m:n:p:r:H:t:s:x:I:bT:",
+	while ((c = getopt_long(argc, argv, "c:d:f:g:hi:m:n:p:r:H:t:s:x:I:bT:S:",
 				opts, NULL)) != -1) {
 		switch (c) {
 		case 'm':
@@ -973,6 +974,9 @@ parse(int argc, char **argv)
 				printf("Requires 1 or 2 tiers\n");
 				rc = -DER_INVAL;
 			}
+			break;
+		case 'S':
+			rc = arg_strtoul(optarg, &dss_sec_xs_nr, "\"-S\"");
 			break;
 		default:
 			usage(argv[0], stderr);

--- a/utils/config/daos_server.yml
+++ b/utils/config/daos_server.yml
@@ -193,6 +193,17 @@
 ##nr_hugepages: -1
 #
 #
+## Number of CART contexts per secondary provider per engine
+#
+## Specifies the number of secondary CART contexts each engine will create for
+## each additional fabric provider after the first. This only applies when
+## running in multi-provider mode.
+#
+## default: 0
+#
+#nr_secondary_contexts: 1
+#
+#
 ## Force specific debug mask for daos_server (control plane).
 ## By default, just use the default debug mask used by daos_server.
 ## Mask specifies minimum level of message significance to pass to logger.


### PR DESCRIPTION
The new parameter in the server config, nr_secondary_contexts,
defines the number of secondary CART contexts to be created by
each engine for each secondary fabric provider. The primary
provider is not affected.

Signed-off-by: Kris Jacque <kristin.jacque@intel.com>