### PR TITLE
DAOS-9972 build: Fix SPDK failure on VMD init after reboot

### DIFF
--- a/utils/build.config
+++ b/utils/build.config
@@ -14,7 +14,7 @@ PSM2 = PSM2_11.2.78
 PROTOBUFC = v1.3.3
 
 [patch_versions]
-spdk=https://github.com/spdk/spdk/commit/690783a3ae82ebe58c00d643520a66103d66d540.diff,https://github.com/spdk/spdk/commit/65425be69a0882ac283fb489aa151d7df06c52ad.diff,https://raw.githubusercontent.com/daos-stack/spdk/master/0003-blob-chunk-clear-operations-in-IU-aligned-chunks.patch,https://github.com/spdk/spdk/commit/148a9ab0c06346f9fec109a1df00651c1f5a0499.diff,https://github.com/spdk/spdk/commit/086223c029389329b7a4f38ec0f9a30be83849bf.diff,https://github.com/spdk/spdk/commit/a827fd7eeca67209d4c0aaad9a3ed55692e7e36e.diff
+spdk=https://github.com/spdk/spdk/commit/690783a3ae82ebe58c00d643520a66103d66d540.diff,https://github.com/spdk/spdk/commit/65425be69a0882ac283fb489aa151d7df06c52ad.diff,https://raw.githubusercontent.com/daos-stack/spdk/master/0003-blob-chunk-clear-operations-in-IU-aligned-chunks.patch,https://github.com/spdk/spdk/commit/148a9ab0c06346f9fec109a1df00651c1f5a0499.diff,https://github.com/spdk/spdk/commit/086223c029389329b7a4f38ec0f9a30be83849bf.diff,https://github.com/spdk/spdk/commit/a827fd7eeca67209d4c0aaad9a3ed55692e7e36e.diff,https://github.com/spdk/spdk/commit/038f5b2e1b07f840e610ca206902a90661c6a28f.diff,https://github.com/spdk/spdk/commit/6c3fdade83cdf48182b7c2c3561ca7dd269d5aa9.diff
 pmdk=https://raw.githubusercontent.com/daos-stack/pmdk/master/DAOS_8273.patch
 ofi=https://raw.githubusercontent.com/daos-stack/libfabric/master/daos-9173-ofi.patch,https://raw.githubusercontent.com/daos-stack/libfabric/master/daos-9376-ofi.patch
 mercury=https://raw.githubusercontent.com/daos-stack/mercury/master/cpu_usage.patch,https://raw.githubusercontent.com/daos-stack/mercury/40ce6b6f00933518f35e6f0c6f9f6766eca1bfc9/daos-9561-workaround.patch


### PR DESCRIPTION
SPDK operation not permitted failure is related to not clearing VMD
config registers after loading by kernel drive on boot. Fix by applying
SPDK patches in build.

PR-repos: spdk@PR-42

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>