### PR TITLE
DAOS-9555 control: Suppress spurious messages for unsupported fabrics

### DIFF
--- a/src/control/lib/hardware/hwprov/defaults.go
+++ b/src/control/lib/hardware/hwprov/defaults.go
@@ -84,7 +84,10 @@ func Init(log logging.Logger) (func(), error) {
 			numLoaded++
 			cleanupFns = append(cleanupFns, cleanupLib)
 		} else {
-			log.Error(err.Error())
+			log.Debugf("failed to load library: %s", err)
+			if !hardware.IsUnsupportedFabric(err) {
+				log.Error(err.Error())
+			}
 		}
 	}
 

--- a/src/control/lib/hardware/ucx/disabled_bindings.go
+++ b/src/control/lib/hardware/ucx/disabled_bindings.go
@@ -9,12 +9,11 @@
 package ucx
 
 import (
-	"github.com/pkg/errors"
-
 	"github.com/daos-stack/daos/src/control/lib/dlopen"
+	"github.com/daos-stack/daos/src/control/lib/hardware"
 )
 
-var errNotSupported = errors.New("ucx is not supported in this build")
+var errNotSupported = hardware.ErrUnsupportedFabric("ucx")
 
 // Load reports that the library is not supported.
 func Load() (func(), error) {
@@ -22,7 +21,7 @@ func Load() (func(), error) {
 }
 
 func openUCT() (*dlopen.LibHandle, error) {
-	return nil, errors.Wrap(dlopen.ErrSoNotFound, errNotSupported.Error())
+	return nil, errNotSupported
 }
 
 type uctComponent struct {


### PR DESCRIPTION
When a given fabric provider is unsupported, don't
emit an info or error message, just skip it.

Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com>