### PR TITLE
DAOS-10168 control: Don't exit monitoring loop on leadership loss

### DIFF
--- a/src/control/system/database.go
+++ b/src/control/system/database.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2020-2021 Intel Corporation.
+// (C) Copyright 2020-2022 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -461,8 +461,7 @@ func (db *Database) monitorLeadershipState(parent context.Context) {
 					cancelGainedCtx()
 				}
 				runOnLeadershipLost()
-
-				return
+				break
 			}
 
 			db.log.Debugf("node %s gained MS leader state", db.replicaAddr)


### PR DESCRIPTION
Fixes a longstanding intermittent failure that can occur when a
node loses MS leadership and then regains it.

Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com>
