### PR TITLE
DAOS-9876 control: Create multiple SCM namespaces per NUMA node

### DIFF
--- a/src/control/cmd/daos_server/storage.go
+++ b/src/control/cmd/daos_server/storage.go
@@ -103,7 +103,7 @@ func (cmd *storagePrepareCmd) prepScm(scanErrors *errs, prep scmPrepFn) error {
 
 	// Prepare SCM modules to be presented as pmem device files.
 	resp, err := prep(storage.ScmPrepareRequest{
-		Reset: cmd.Reset,
+		Reset: cmd.Reset, NrNamespacesPerNUMA: cmd.NrNamespacesPerNUMA,
 	})
 	if err != nil {
 		return scanErrors.add(err)

--- a/src/control/cmd/daos_server/storage.go
+++ b/src/control/cmd/daos_server/storage.go
@@ -103,7 +103,8 @@ func (cmd *storagePrepareCmd) prepScm(scanErrors *errs, prep scmPrepFn) error {
 
 	// Prepare SCM modules to be presented as pmem device files.
 	resp, err := prep(storage.ScmPrepareRequest{
-		Reset: cmd.Reset, NrNamespacesPerNUMA: cmd.NrNamespacesPerNUMA,
+		Reset:               cmd.Reset,
+		NrNamespacesPerNUMA: cmd.NrNamespacesPerNUMA,
 	})
 	if err != nil {
 		return scanErrors.add(err)

--- a/src/control/common/storage/commands.go
+++ b/src/control/common/storage/commands.go
@@ -25,7 +25,9 @@ type StoragePrepareNvmeCmd struct {
 	TargetUser   string `short:"u" long:"target-user" description:"User that will own hugepage mountpoint directory and vfio groups."`
 }
 
-type StoragePrepareScmCmd struct{}
+type StoragePrepareScmCmd struct {
+	NrNamespacesPerNUMA uint `short:"S" long:"scm-namespaces-per-numa" description:"Number of SCM namespaces to create per NUMA node"`
+}
 
 type StoragePrepareCmd struct {
 	StoragePrepareNvmeCmd

--- a/src/control/fault/code/codes.go
+++ b/src/control/fault/code/codes.go
@@ -76,6 +76,7 @@ const (
 	ScmNoDevicesMatchFilter
 	ScmNotInterleaved
 	ScmNoModules
+	ScmNamespacesNrMismatch
 )
 
 // Bdev fault codes

--- a/src/control/server/storage/faults.go
+++ b/src/control/server/storage/faults.go
@@ -18,12 +18,25 @@ import (
 // mode, this is unsupported.
 var FaultScmNotInterleaved = storageFault(code.ScmNotInterleaved,
 	"PMem regions are in AppDirect non-interleaved mode",
-	"Rerun the command first with the reset option and then without to recreate the PMem regions in the recommended mode")
+	"Rerun the command first with the --reset option and then without to recreate the "+
+		"PMem regions in the recommended mode")
 
 // FaultScmNoModules represents an error where no PMem modules exist.
 var FaultScmNoModules = storageFault(code.ScmNoModules,
 	"No PMem modules exist on storage server",
 	"Install PMem modules and retry command")
+
+// FaultScmNamespacesNrMismatch creates a Fault for the case where the number of SCM namespaces
+// doesn't match the number expected.
+func FaultScmNamespacesNrMismatch(nrExpPerNUMA, nrNUMA, nrExisting uint) *fault.Fault {
+	return storageFault(
+		code.ScmNamespacesNrMismatch,
+		fmt.Sprintf("want %d PMem namespaces but got %d, %d PMem namespaces expected per "+
+			"NUMA node and found %d nodes", (nrExpPerNUMA*nrNUMA), nrExisting,
+			nrExpPerNUMA, nrNUMA),
+		"Rerun the command first with the --reset option and then without to recreate the "+
+			"required number of PMem regions")
+}
 
 // FaultBdevNotFound creates a Fault for the case where no NVMe storage devices
 // match expected PCI addresses.
@@ -31,7 +44,8 @@ func FaultBdevNotFound(bdevs ...string) *fault.Fault {
 	return storageFault(
 		code.BdevNotFound,
 		fmt.Sprintf("NVMe SSD%s %v not found", common.Pluralise("", len(bdevs)), bdevs),
-		fmt.Sprintf("check SSD%s %v that are specified in server config exist", common.Pluralise("", len(bdevs)), bdevs),
+		fmt.Sprintf("check SSD%s %v that are specified in server config exist",
+			common.Pluralise("", len(bdevs)), bdevs),
 	)
 }
 

--- a/src/control/server/storage/scm.go
+++ b/src/control/server/storage/scm.go
@@ -253,8 +253,8 @@ type (
 	// ScmPrepareRequest defines the parameters for a Prepare operation.
 	ScmPrepareRequest struct {
 		pbin.ForwardableRequest
-		// Reset indicates that the operation should reset (clear) PMem namespaces.
-		Reset bool
+		Reset               bool // Clear PMem namespaces and regions.
+		NrNamespacesPerNUMA uint // Request this many PMem namespaces per NUMA node.
 	}
 
 	// ScmPrepareResponse contains the results of a successful Prepare operation.

--- a/src/control/server/storage/scm/ipmctl.go
+++ b/src/control/server/storage/scm/ipmctl.go
@@ -541,11 +541,6 @@ func (cr *cmdRunner) prepReset(scanRes *storage.ScmScanResponse) (*storage.ScmPr
 		return nil, err
 	}
 
-	// Handle specified NrNamespacesPerNUMA in request.
-	if req.NrNamespacesPerNUMA != 0 {
-		cr.log.Debug("number of namespaces per-numa option ignored for scm prepare reset")
-	}
-
 	switch state {
 	case storage.ScmStateNoRegions:
 		return resp, nil
@@ -620,14 +615,7 @@ func (cr *cmdRunner) createDualNamespacesPerNUMA() (storage.ScmNamespaces, error
 	// For each region, create two namespaces each with half the total free capacity.
 	// Sanity check alignment.
 
-	out, err := cr.showRegions()
-	if err != nil {
-		return nil, errors.WithMessage(err, "show regions cmd")
-	}
-	if strings.Contains(out, outScmNoRegions) {
-		return nil, errors.New("no regions found")
-	}
-	regionFreeBytes, err := parseShowRegionOutput(cr.log, out)
+	regionFreeBytes, err := cr.getRegionFreeSpace()
 	if err != nil {
 		return nil, err
 	}

--- a/src/control/server/storage/scm/ipmctl.go
+++ b/src/control/server/storage/scm/ipmctl.go
@@ -541,6 +541,11 @@ func (cr *cmdRunner) prepReset(scanRes *storage.ScmScanResponse) (*storage.ScmPr
 		return nil, err
 	}
 
+	// Handle specified NrNamespacesPerNUMA in request.
+	if req.NrNamespacesPerNUMA != 0 {
+		cr.log.Debug("number of namespaces per-numa option ignored for scm prepare reset")
+	}
+
 	switch state {
 	case storage.ScmStateNoRegions:
 		return resp, nil

--- a/src/control/server/storage/scm/ipmctl_test.go
+++ b/src/control/server/storage/scm/ipmctl_test.go
@@ -237,9 +237,9 @@ func TestIpmctl_getRegionStateFromCLI(t *testing.T) {
 		"unexpected output": {
 			runOut: []string{
 				"Intel(R) Optane(TM) Persistent Memory Command Line Interface Version 02.00.00.3825",
-				"---ISetID=0x2aba7f4828ef2ccc---\naga\n",
+				"---ISetID=0x2aba7f4828ef2ccc---\n",
 			},
-			expErr: errors.New("expecting at least 3 lines, got 2"),
+			expErr: errors.New("expecting at least 3 lines, got 1"),
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
@@ -269,7 +269,7 @@ func TestIpmctl_getRegionStateFromCLI(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			_, scmState, err := cr.getRegionState()
+			scmState, err := cr.getRegionState()
 			common.CmpErr(t, tc.expErr, err)
 			if tc.expErr != nil {
 				return

--- a/src/control/server/storage/scm/ipmctl_test.go
+++ b/src/control/server/storage/scm/ipmctl_test.go
@@ -237,9 +237,9 @@ func TestIpmctl_getRegionStateFromCLI(t *testing.T) {
 		"unexpected output": {
 			runOut: []string{
 				"Intel(R) Optane(TM) Persistent Memory Command Line Interface Version 02.00.00.3825",
-				"---ISetID=0x2aba7f4828ef2ccc---\n",
+				"---ISetID=0x2aba7f4828ef2ccc---\naga\n",
 			},
-			expErr: errors.New("expecting at least 4 lines, got 2"),
+			expErr: errors.New("expecting at least 3 lines, got 2"),
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
@@ -269,7 +269,7 @@ func TestIpmctl_getRegionStateFromCLI(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			scmState, err := cr.getRegionState()
+			_, scmState, err := cr.getRegionState()
 			common.CmpErr(t, tc.expErr, err)
 			if tc.expErr != nil {
 				return
@@ -607,7 +607,7 @@ func TestIpmctl_prep(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			resp, err := cr.prep(tc.scanResp)
+			resp, err := cr.prep(storage.ScmPrepareRequest{}, tc.scanResp)
 			log.Debugf("calls made %+v", calls)
 			common.CmpErr(t, tc.expErr, err)
 

--- a/src/control/server/storage/scm/mocks.go
+++ b/src/control/server/storage/scm/mocks.go
@@ -193,11 +193,11 @@ func (mb *MockBackend) getNamespaces() (storage.ScmNamespaces, error) {
 	return mb.cfg.GetNamespacesRes, mb.cfg.GetNamespacesErr
 }
 
-func (mb *MockBackend) getRegionState() (storage.ScmState, error) {
-	return mb.cfg.GetStateRes, mb.cfg.GetStateErr
+func (mb *MockBackend) getRegionState() ([]uint64, storage.ScmState, error) {
+	return nil, mb.cfg.GetStateRes, mb.cfg.GetStateErr
 }
 
-func (mb *MockBackend) prep(*storage.ScmScanResponse) (*storage.ScmPrepareResponse, error) {
+func (mb *MockBackend) prep(storage.ScmPrepareRequest, *storage.ScmScanResponse) (*storage.ScmPrepareResponse, error) {
 	return mb.cfg.PrepRes, mb.cfg.PrepErr
 }
 

--- a/src/control/server/storage/scm/mocks.go
+++ b/src/control/server/storage/scm/mocks.go
@@ -193,8 +193,8 @@ func (mb *MockBackend) getNamespaces() (storage.ScmNamespaces, error) {
 	return mb.cfg.GetNamespacesRes, mb.cfg.GetNamespacesErr
 }
 
-func (mb *MockBackend) getRegionState() ([]uint64, storage.ScmState, error) {
-	return nil, mb.cfg.GetStateRes, mb.cfg.GetStateErr
+func (mb *MockBackend) getRegionState() (storage.ScmState, error) {
+	return mb.cfg.GetStateRes, mb.cfg.GetStateErr
 }
 
 func (mb *MockBackend) prep(storage.ScmPrepareRequest, *storage.ScmScanResponse) (*storage.ScmPrepareResponse, error) {

--- a/src/control/server/storage/scm/provider.go
+++ b/src/control/server/storage/scm/provider.go
@@ -46,9 +46,9 @@ type (
 	// Backend defines a set of methods to be implemented by a SCM backend.
 	Backend interface {
 		getModules() (storage.ScmModules, error)
-		getRegionState() (storage.ScmState, error)
+		getRegionState() ([]uint64, storage.ScmState, error)
 		getNamespaces() (storage.ScmNamespaces, error)
-		prep(*storage.ScmScanResponse) (*storage.ScmPrepareResponse, error)
+		prep(storage.ScmPrepareRequest, *storage.ScmScanResponse) (*storage.ScmPrepareResponse, error)
 		prepReset(*storage.ScmScanResponse) (*storage.ScmPrepareResponse, error)
 		GetFirmwareStatus(deviceUID string) (*storage.ScmFirmwareInfo, error)
 		UpdateFirmware(deviceUID string, firmwarePath string) error
@@ -289,7 +289,7 @@ func (p *Provider) Scan(req storage.ScmScanRequest) (*storage.ScmScanResponse, e
 	}
 	p.log.Debugf("scm backend: namespaces %+v", namespaces)
 
-	state, err := p.backend.getRegionState()
+	_, state, err := p.backend.getRegionState()
 	if err != nil {
 		return nil, err
 	}
@@ -348,7 +348,7 @@ func (p *Provider) prepare(req storage.ScmPrepareRequest, scan scanFn) (*storage
 	}
 
 	p.log.Debug("scm provider prepare: calling backend prep")
-	return p.backend.prep(scanResp)
+	return p.backend.prep(req, scanResp)
 }
 
 // Prepare attempts to fulfill a SCM Prepare request.

--- a/src/control/server/storage/scm/provider.go
+++ b/src/control/server/storage/scm/provider.go
@@ -46,7 +46,7 @@ type (
 	// Backend defines a set of methods to be implemented by a SCM backend.
 	Backend interface {
 		getModules() (storage.ScmModules, error)
-		getRegionState() ([]uint64, storage.ScmState, error)
+		getRegionState() (storage.ScmState, error)
 		getNamespaces() (storage.ScmNamespaces, error)
 		prep(storage.ScmPrepareRequest, *storage.ScmScanResponse) (*storage.ScmPrepareResponse, error)
 		prepReset(*storage.ScmScanResponse) (*storage.ScmPrepareResponse, error)
@@ -289,7 +289,7 @@ func (p *Provider) Scan(req storage.ScmScanRequest) (*storage.ScmScanResponse, e
 	}
 	p.log.Debugf("scm backend: namespaces %+v", namespaces)
 
-	_, state, err := p.backend.getRegionState()
+	state, err := p.backend.getRegionState()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Add (-S N|--scm-namespaces-per-numa N) option to daos_server storage prepare
subcommand to enable creation of multiple SCM namespaces per NUMA node.

For example, on a typical dual-socket platform, the command:
  daos_server storage prepare -s -S 2
would generate the following PMem block devices:
  /dev/pmem0 /dev/pmem0.1 /dev/pmem1 /dev/pmem1.1

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>