### PR TITLE
DAOS-10157 test: Increase timeout for erasurecode/rebuild_disabled_si…

### DIFF
--- a/src/tests/ftest/erasurecode/rebuild_disabled_single.yaml
+++ b/src/tests/ftest/erasurecode/rebuild_disabled_single.yaml
@@ -18,7 +18,7 @@ hosts:
         - server-E
   test_clients:
     - client-A
-timeout: 250
+timeout: 400
 server_config:
   engines_per_host: 2
   name: daos_server


### PR DESCRIPTION
…ngle.py

Default RPC timeout was changed, so the test takes longer.
Increase the timeout to incorporate this change.

Skip-unit-tests: true
Test-tag: ec_disabled_rebuild_single
Signed-off-by: Makito Kano <makito.kano@intel.com>