### PR TITLE
DAOS-10186 cart_iv: fix wrong ivo_on_put call

### DIFF
--- a/src/cart/crt_iv.c
+++ b/src/cart/crt_iv.c
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2016-2021 Intel Corporation.
+ * (C) Copyright 2016-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -1394,12 +1394,11 @@ crt_hdlr_iv_fetch_aux(void *arg)
 		}
 
 		rc = iv_ops->ivo_on_put(ivns_internal, &iv_value, user_priv);
+		put_needed = false;
 		if (rc != 0) {
 			D_ERROR("ivo_on_put(): "DF_RC"\n", DP_RC(rc));
 			D_GOTO(send_error, rc);
 		}
-
-		put_needed = false;
 
 		/* Reset the iv_value, since it maybe freed in on_put() */
 		memset(&iv_value, 0, sizeof(iv_value));
@@ -1900,11 +1899,11 @@ crt_hdlr_iv_sync_aux(void *arg)
 		}
 
 		rc = iv_ops->ivo_on_put(ivns_internal, &iv_value, user_priv);
+		need_put = false;
 		if (rc != 0) {
 			D_ERROR("ivo_on_put(): "DF_RC"\n", DP_RC(rc));
 			D_GOTO(exit, rc);
 		}
-		need_put = false;
 
 		break;
 	}

--- a/src/engine/server_iv.c
+++ b/src/engine/server_iv.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2017-2021 Intel Corporation.
+ * (C) Copyright 2017-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -173,6 +173,7 @@ ds_iv_ns_get(struct ds_iv_ns *ns)
 void
 ds_iv_ns_put(struct ds_iv_ns *ns)
 {
+	D_ASSERT(ns->iv_refcount > 0);
 	ns->iv_refcount--;
 	D_DEBUG(DB_TRACE, DF_UUID" ns ref %u\n",
 		DP_UUID(ns->iv_pool_uuid), ns->iv_refcount);


### PR DESCRIPTION
In ivc_on_put(), it will call ds_iv_ns_put() upon shutdown
case, so if ivo_on_put() failed, don't call it again.

Signed-off-by: Wang Shilong <shilong.wang@intel.com>