### PR TITLE
DAOS-10187 rebuild: close vos container in rebuild_container_scan_cb()

### DIFF
--- a/src/rebuild/scan.c
+++ b/src/rebuild/scan.c
@@ -691,6 +691,7 @@ rebuild_container_scan_cb(daos_handle_t ih, vos_iter_entry_t *entry,
 				 &snapshot_cnt);
 	if (rc) {
 		D_ERROR("ds_cont_fetch_snaps failed: "DF_RC"\n", DP_RC(rc));
+		vos_cont_close(coh);
 		return rc;
 	}
 


### PR DESCRIPTION
In rebuild_container_scan_cb() if ds_cont_fetch_snaps() failed,
vos_cont_close() will be not called.

Signed-off-by: Wang Shilong <shilong.wang@intel.com>