### PR TITLE
DAOS-5921 md, test:  DO NOT LAND try to get destroy enospc

### DIFF
--- a/src/include/daos_srv/rdb.h
+++ b/src/include/daos_srv/rdb.h
@@ -246,6 +246,8 @@ int rdb_tx_destroy_kvs(struct rdb_tx *tx, const rdb_path_t *parent,
 		       const d_iov_t *key);
 int rdb_tx_update(struct rdb_tx *tx, const rdb_path_t *kvs,
 		  const d_iov_t *key, const d_iov_t *value);
+int rdb_tx_update_critical(struct rdb_tx *tx, const rdb_path_t *kvs,
+			   const d_iov_t *key, const d_iov_t *value);
 int rdb_tx_delete(struct rdb_tx *tx, const rdb_path_t *kvs,
 		  const d_iov_t *key);
 

--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -6050,8 +6050,7 @@ ds_pool_evict_handler(crt_rpc_t *rpc)
 		d_iov_t		value;
 
 		d_iov_set(&value, &connectable, sizeof(connectable));
-		rc = rdb_tx_update(&tx, &svc->ps_root,
-				   &ds_pool_prop_connectable, &value);
+		rc = rdb_tx_update_critical(&tx, &svc->ps_root, &ds_pool_prop_connectable, &value);
 		if (rc != 0)
 			D_GOTO(out_free, rc);
 

--- a/src/tests/ftest/server/metadata.py
+++ b/src/tests/ftest/server/metadata.py
@@ -280,6 +280,11 @@ class ObjectMetadata(TestWithServers):
             "Phase 3: passed (created %d / %d containers)", len(self.container), loop)
         self.log.info("Test passed")
 
+        # instruct tearDown to skip containers destroy
+        # (we want to invoke pool destroy with a full metadata rdb)
+        self.log.info("Setting self.skip_destroy_containers = True")
+        self.skip_destroy_containers = True
+
     def test_metadata_addremove(self):
         """JIRA ID: DAOS-1512.
 

--- a/src/tests/ftest/util/apricot/apricot/test.py
+++ b/src/tests/ftest/util/apricot/apricot/test.py
@@ -669,6 +669,9 @@ class TestWithServers(TestWithoutServers):
         # Suffix to append to each access point name
         self.access_points_suffix = None
 
+        # Option to skip destroying containers during tearDown (default: destroy containers)
+        self.skip_destroy_containers = False
+
     def setUp(self):
         """Set up each test case."""
         super().setUp()
@@ -1426,7 +1429,13 @@ class TestWithServers(TestWithoutServers):
 
         """
         error_list = []
-        if containers:
+        self.test_log.info("in destroy_containers function")
+        if self.skip_destroy_containers:
+            self.test_log.info("Test wants to skip destroying containers in tearDown")
+        else:
+            self.test_log.info("Test wants to destroy containers in tearDown")
+
+        if containers and not self.skip_destroy_containers:
             if not isinstance(containers, (list, tuple)):
                 containers = [containers]
             self.test_log.info("Destroying containers")
@@ -1452,6 +1461,8 @@ class TestWithServers(TestWithoutServers):
                         self.test_log.info("  {}".format(error))
                         error_list.append(
                             "Error destroying container: {}".format(error))
+        elif self.skip_destroy_containers:
+            self.test_log.info("SKIPPED Destroying containers as requested by test")
         return error_list
 
     def destroy_pools(self, pools):

--- a/src/tests/ftest/util/test_utils_pool.py
+++ b/src/tests/ftest/util/test_utils_pool.py
@@ -421,6 +421,7 @@ class TestPool(TestDaosApiBase):
         status = False
         if self.pool:
             if disconnect:
+                self.log.info("Disconnecting from pool %s", self.identifier)
                 self.disconnect()
             if self.pool.attached:
                 self.log.info("Destroying pool %s", self.identifier)


### PR DESCRIPTION
When metadata capacity becomes exhausted, leave it exhausted
(by not destroying containers), then disconnect from the pool,
leaving no open handles. Then perform pool destroy.

The change makes the pool destroy/evict processing specify
the RDB tx update to pool "connectable" property a critical change,
that should make the pool destroy (even with no open handles)
succeed (by not having to pass a test for available/free SCM space).

Quick-Functional: true
Skip-func-test-vm: true
Skip-func-hw-test-small: true
Skip-func-hw-test-medium: true
Test-tag-hw-large: metadata_fillup pool_create_all_one_hw
Required-githooks: true

Signed-off-by: Kenneth Cain <kenneth.c.cain@intel.com>