### PR TITLE
DAOS_10172 rebuild: wait dtx resync globally

### DIFF
--- a/src/rebuild/rebuild_internal.h
+++ b/src/rebuild/rebuild_internal.h
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2017-2021 Intel Corporation.
+ * (C) Copyright 2017-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -78,6 +78,9 @@ struct rebuild_tgt_pool_tracker {
 	 * to make sure aggregation will not cross the epoch
 	 */
 	uint64_t		rt_rebuild_fence;
+
+	/* Global dtx resync version */
+	uint32_t		rt_global_dtx_resync_version;
 	unsigned int		rt_lead_puller_running:1,
 				rt_abort:1,
 				/* re-report #rebuilt cnt per master change */
@@ -90,6 +93,7 @@ struct rebuild_tgt_pool_tracker {
 
 struct rebuild_server_status {
 	d_rank_t	rank;
+	uint32_t	dtx_resync_version;
 	uint32_t	scan_done:1,
 			pull_done:1;
 };
@@ -111,6 +115,9 @@ struct rebuild_global_pool_tracker {
 
 	/** rebuild status for each server */
 	struct rebuild_server_status *rgt_servers;
+
+	/** global resync dtx version */
+	uint32_t	rgt_dtx_resync_version;
 
 	/** number of rgt_server_status */
 	uint32_t	rgt_servers_number;
@@ -240,6 +247,8 @@ struct rebuild_iv {
 	uint64_t	riv_leader_term;
 	uint64_t	riv_stable_epoch;
 	uint32_t	riv_seconds;
+	uint32_t	riv_dtx_resyc_version;
+	uint32_t	riv_global_dtx_resyc_version;
 	unsigned int	riv_rank;
 	unsigned int	riv_master_rank;
 	unsigned int	riv_ver;
@@ -249,6 +258,7 @@ struct rebuild_iv {
 			riv_pull_done:1,
 			riv_sync:1;
 	int		riv_status;
+
 };
 
 #define DEFAULT_YIELD_FREQ	128

--- a/src/rebuild/rebuild_iv.c
+++ b/src/rebuild/rebuild_iv.c
@@ -170,9 +170,10 @@ rebuild_iv_ent_refresh(struct ds_iv_entry *entry, struct ds_iv_key *key,
 	dst_iv->riv_global_done = src_iv->riv_global_done;
 	dst_iv->riv_global_scan_done = src_iv->riv_global_scan_done;
 	dst_iv->riv_stable_epoch = src_iv->riv_stable_epoch;
+	dst_iv->riv_global_dtx_resyc_version = src_iv->riv_global_dtx_resyc_version;
 
 	if (dst_iv->riv_global_done || dst_iv->riv_global_scan_done ||
-	    dst_iv->riv_stable_epoch) {
+	    dst_iv->riv_stable_epoch || dst_iv->riv_dtx_resyc_version) {
 		struct rebuild_tgt_pool_tracker *rpt;
 
 		rpt = rpt_lookup(src_iv->riv_pool_uuid, src_iv->riv_ver);
@@ -185,9 +186,10 @@ rebuild_iv_ent_refresh(struct ds_iv_entry *entry, struct ds_iv_key *key,
 		}
 
 		D_DEBUG(DB_REBUILD, DF_UUID"/%u rebuild status gsd/gd %d/%d"
-			" stable eph "DF_U64"\n", DP_UUID(src_iv->riv_pool_uuid),
-			 src_iv->riv_ver, dst_iv->riv_global_scan_done,
-			 dst_iv->riv_global_done, dst_iv->riv_stable_epoch);
+			" stable eph "DF_U64" resync ver %u\n",
+			DP_UUID(src_iv->riv_pool_uuid), src_iv->riv_ver,
+			dst_iv->riv_global_scan_done, dst_iv->riv_global_done,
+			dst_iv->riv_stable_epoch, dst_iv->riv_dtx_resyc_version);
 
 		if (rpt->rt_stable_epoch == 0)
 			rpt->rt_stable_epoch = dst_iv->riv_stable_epoch;
@@ -197,6 +199,7 @@ rebuild_iv_ent_refresh(struct ds_iv_entry *entry, struct ds_iv_key *key,
 			       dst_iv->riv_stable_epoch);
 		rpt->rt_global_done = dst_iv->riv_global_done;
 		rpt->rt_global_scan_done = dst_iv->riv_global_scan_done;
+		rpt->rt_global_dtx_resync_version = dst_iv->riv_global_dtx_resyc_version;
 		rpt_put(rpt);
 	}
 

--- a/src/rebuild/srv.c
+++ b/src/rebuild/srv.c
@@ -161,7 +161,7 @@ is_rebuild_global_done(struct rebuild_global_pool_tracker *rgt)
 #define PULL_DONE	0x2
 static void
 rebuild_leader_set_status(struct rebuild_global_pool_tracker *rgt,
-			  d_rank_t rank, unsigned flags)
+			  d_rank_t rank, uint32_t resync_ver, unsigned flags)
 {
 	struct rebuild_server_status	*status = NULL;
 	int				i;
@@ -176,10 +176,30 @@ rebuild_leader_set_status(struct rebuild_global_pool_tracker *rgt,
 	}
 
 	D_ASSERTF(status != NULL, "Can not find rank %u\n", rank);
+	status->dtx_resync_version = resync_ver;
 	if (flags & SCAN_DONE)
 		status->scan_done = 1;
 	if (flags & PULL_DONE)
 		status->pull_done = 1;
+}
+
+static uint32_t
+rebuild_get_global_dtx_resync_ver(struct rebuild_global_pool_tracker *rgt)
+{
+	uint32_t	min = -1;
+	int		i;
+
+	D_ASSERT(rgt->rgt_servers_number > 0);
+	D_ASSERT(rgt->rgt_servers != NULL);
+	for (i = 0; i < rgt->rgt_servers_number; i++) {
+		if (rgt->rgt_servers[i].dtx_resync_version == (uint32_t)(-1))
+			continue;
+
+		if (min > rgt->rgt_servers[i].dtx_resync_version)
+			min = rgt->rgt_servers[i].dtx_resync_version;
+	}
+
+	return min;
 }
 
 struct rebuild_tgt_pool_tracker *
@@ -205,14 +225,18 @@ int
 rebuild_global_status_update(struct rebuild_global_pool_tracker *rgt,
 			     struct rebuild_iv *iv)
 {
-	D_DEBUG(DB_REBUILD, "iv rank %d scan_done %d pull_done %d\n",
-		iv->riv_rank, iv->riv_scan_done, iv->riv_pull_done);
+	D_DEBUG(DB_REBUILD, "iv rank %d scan_done %d pull_done %d resync dtx %u\n",
+		iv->riv_rank, iv->riv_scan_done, iv->riv_pull_done,
+		iv->riv_dtx_resyc_version);
 
-	if (!iv->riv_scan_done)
+	if (!iv->riv_scan_done) {
+		rebuild_leader_set_status(rgt, iv->riv_rank, iv->riv_dtx_resyc_version, 0);
 		return 0;
+	}
 
 	if (!is_rebuild_global_scan_done(rgt)) {
-		rebuild_leader_set_status(rgt, iv->riv_rank, SCAN_DONE);
+		rebuild_leader_set_status(rgt, iv->riv_rank, iv->riv_dtx_resyc_version,
+					  SCAN_DONE);
 		D_DEBUG(DB_REBUILD, "rebuild ver %d tgt %d scan done\n",
 			rgt->rgt_rebuild_ver, iv->riv_rank);
 		/* If global scan is not done, then you can not trust
@@ -227,7 +251,8 @@ rebuild_global_status_update(struct rebuild_global_pool_tracker *rgt,
 
 	/* Only trust pull done if scan is done globally */
 	if (iv->riv_pull_done) {
-		rebuild_leader_set_status(rgt, iv->riv_rank, PULL_DONE);
+		rebuild_leader_set_status(rgt, iv->riv_rank, iv->riv_dtx_resyc_version,
+					  PULL_DONE);
 		D_DEBUG(DB_REBUILD, "rebuild ver %d tgt %d pull done\n",
 			rgt->rgt_rebuild_ver, iv->riv_rank);
 	}
@@ -553,12 +578,9 @@ rebuild_leader_status_check(struct ds_pool *pool, uint32_t map_ver, uint32_t op,
 				D_DEBUG(DB_REBUILD, "rank %d/%x.\n",
 					dom->do_comp.co_rank,
 					dom->do_comp.co_status);
-				if (pool_component_unavail(&dom->do_comp,
-							false)) {
-					rebuild_leader_set_status(rgt,
-						dom->do_comp.co_rank,
-						SCAN_DONE|PULL_DONE);
-				}
+				if (pool_component_unavail(&dom->do_comp, false))
+					rebuild_leader_set_status(rgt, dom->do_comp.co_rank,
+								  -1, SCAN_DONE | PULL_DONE);
 			}
 			D_FREE(targets);
 		}
@@ -582,12 +604,12 @@ rebuild_leader_status_check(struct ds_pool *pool, uint32_t map_ver, uint32_t op,
 			iv.riv_ver = rgt->rgt_rebuild_ver;
 			iv.riv_leader_term = rgt->rgt_leader_term;
 			iv.riv_sync = 1;
-
+			iv.riv_global_dtx_resyc_version = rebuild_get_global_dtx_resync_ver(rgt);
 			D_DEBUG(DB_REBUILD, "rebuild IV update "DF_UUID"/%u:"
-				" gsd/gd %d/%d stable eph "DF_U64"\n",
+				" gsd/gd %d/%d stable eph "DF_U64" resync %u\n",
 				DP_UUID(iv.riv_pool_uuid), rgt->rgt_rebuild_ver,
 				iv.riv_global_scan_done, iv.riv_global_done,
-				iv.riv_stable_epoch);
+				iv.riv_stable_epoch, iv.riv_global_dtx_resyc_version);
 			/* Notify others the global scan is done, then
 			 * each target can reliablly report its pull status
 			 */
@@ -1255,6 +1277,7 @@ iv_stop:
 		iv.riv_size		= rgt->rgt_status.rs_size;
 		iv.riv_seconds          = rgt->rgt_status.rs_seconds;
 		iv.riv_stable_epoch	= rgt->rgt_stable_epoch;
+		iv.riv_global_dtx_resyc_version = rebuild_get_global_dtx_resync_ver(rgt);
 
 		D_DEBUG(DB_REBUILD, "rebuild IV %u final "DF_UUID"/%u : %d\n",
 			task->dst_rebuild_op, DP_UUID(task->dst_pool_uuid),
@@ -1916,7 +1939,7 @@ rebuild_tgt_status_check_ult(void *arg)
 			iv.riv_rank = rpt->rt_rank;
 			iv.riv_ver = rpt->rt_rebuild_ver;
 			iv.riv_leader_term = rpt->rt_leader_term;
-
+			iv.riv_dtx_resyc_version = rpt->rt_pool->sp_dtx_resync_version;
 			/* Cart does not support failure recovery yet, let's
 			 * send the status to root for now. FIXME
 			 */

--- a/src/tests/ftest/daos_test/rebuild.yaml
+++ b/src/tests/ftest/daos_test/rebuild.yaml
@@ -6,9 +6,9 @@ hosts:
     - server-B
     - server-C
     - server-D
-timeout: 600
+timeout: 800
 timeouts:
-    test_rebuild_0to10: 1500
+    test_rebuild_0to10: 2000
     test_rebuild_12to15: 1500
     test_rebuild_27: 1500
 pool:

--- a/src/tests/ftest/daos_test/suite.yaml
+++ b/src/tests/ftest/daos_test/suite.yaml
@@ -26,7 +26,7 @@ timeouts:
     test_daos_capability: 104
     test_daos_epoch_recovery: 104
     test_daos_md_replication: 104
-    test_daos_rebuild_simple: 900
+    test_daos_rebuild_simple: 1500
     test_daos_drain_simple: 500
     test_daos_extend_simple: 500
     test_daos_oid_allocator: 640


### PR DESCRIPTION
Let's wait for dtx resync to finish on all engines, then
start rebuild, to make sure rebuild will not miss any
un-commit data during rebuild/reintegration.

Signed-off-by: Di Wang <di.wang@intel.com>