### PR TITLE
DAOS-10001-EX3 test: Create a new simple test with target_failure.py …

### DIFF
--- a/src/tests/ftest/pool/target_failure.py
+++ b/src/tests/ftest/pool/target_failure.py
@@ -1,0 +1,27 @@
+#!/usr/bin/python3
+"""
+  (C) Copyright 2018-2021 Intel Corporation.
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+"""
+from apricot import TestWithServers
+from ior_test_base import IorTestBase
+
+
+class TargetFailure(IorTestBase):
+    """Test class for pool query.
+
+    :avocado: recursive
+    """
+
+    def test_target_failure_wo_rf(self):
+        """Jira ID: DAOS-xxxx.
+
+        :avocado: tags=all,full_regression,
+        :avocado: tags=vm
+        :avocado: tags=deployment
+        :avocado: tags=target_failure_wo_rf
+        """
+        self.add_pool()
+
+        self.log.info("Test Passed")

--- a/src/tests/ftest/pool/target_failure.yaml
+++ b/src/tests/ftest/pool/target_failure.yaml
@@ -1,0 +1,14 @@
+hosts:
+  test_servers:
+    - server-A
+
+timeout: 90
+
+server_config:
+  name: daos_server
+  servers:
+    targets: 1
+
+pool:
+  scm_size: 1G
+  control_method: dmg


### PR DESCRIPTION
…in pool directory

Create a new simple test with target_failure.py in other directory.

Skip-unit-tests: true
Test-tag: target_failure_wo_rf
Signed-off-by: Makito Kano <makito.kano@intel.com>