### PR TITLE
DAOS-10058 test: Update default SCM format timeout

### DIFF
--- a/src/tests/ftest/util/server_utils_base.py
+++ b/src/tests/ftest/util/server_utils_base.py
@@ -34,7 +34,7 @@ class DaosServerCommand(YamlCommand):
 
     DEFAULT_CONFIG_FILE = os.path.join(os.sep, "etc", "daos", "daos_server.yml")
 
-    def __init__(self, path="", yaml_cfg=None, timeout=30):
+    def __init__(self, path="", yaml_cfg=None, timeout=45):
         """Create a daos_server command object.
 
         Args:
@@ -42,7 +42,7 @@ class DaosServerCommand(YamlCommand):
             yaml_cfg (YamlParameters, optional): yaml configuration parameters.
                 Defaults to None.
             timeout (int, optional): number of seconds to wait for patterns to
-                appear in the subprocess output. Defaults to 30 seconds.
+                appear in the subprocess output. Defaults to 45 seconds.
         """
         super().__init__(
             "/run/daos_server/*", "daos_server", path, yaml_cfg, timeout)


### PR DESCRIPTION
Test-tag: offline_drain_multiple_pools  online_drain_with_csum
Test-repeat: 5

Summary:
- We are noticing intermittent SCM format timeout issues
  due to format taking more than 30 seconds. Increasing
  it to 45 seconds.

Signed-off-by: rpadma2 <ravindran.padmanabhan@intel.com>