### PR TITLE
DAOS-9166 pool: coverity CID 351284 illegal accesses

### DIFF
--- a/src/pool/cli.c
+++ b/src/pool/cli.c
@@ -1340,7 +1340,7 @@ pool_query_cb(tse_task_t *task, void *data)
 	struct pool_buf		       *map_buf = arg->dqa_map_buf;
 	struct pool_query_in	       *in = crt_req_get(arg->rpc);
 	struct pool_query_out	       *out = crt_reply_get(arg->rpc);
-	d_rank_list_t		       *ranks;
+	d_rank_list_t		       *ranks = NULL;
 	d_rank_list_t		      **ranks_arg;
 	int				rc = task->dt_result;
 


### PR DESCRIPTION
pool_query_cb() calls d_rank_list_free(ranks) where ranks should be
assigned (non-NULL) when the preceding process_query_reply() succeeds.
However, Coverity is flagging the usage. Initialize ranks to NULL.

Signed-off-by: Kenneth Cain <kenneth.c.cain@intel.com>