### PR TITLE
DAOS-10199 dtx: delay container deregister until closed

### DIFF
--- a/src/dtx/dtx_internal.h
+++ b/src/dtx/dtx_internal.h
@@ -130,6 +130,8 @@ struct dtx_pool_metrics {
  */
 struct dtx_tls {
 	struct d_tm_node_t	*dt_committable;
+	uint64_t		 dt_agg_gen;
+	uint32_t		 dt_registered_cont_cnt;
 };
 
 extern struct dss_module_key dtx_module_key;
@@ -149,7 +151,6 @@ dtx_cont_opened(struct ds_cont_child *cont)
 extern struct crt_proto_format dtx_proto_fmt;
 extern btr_ops_t dbtree_dtx_cf_ops;
 extern btr_ops_t dtx_btr_cos_ops;
-extern uint64_t dtx_agg_gen;
 
 /* dtx_common.c */
 int dtx_handle_reinit(struct dtx_handle *dth);

--- a/src/dtx/dtx_srv.c
+++ b/src/dtx/dtx_srv.c
@@ -27,6 +27,9 @@ dtx_tls_init(int xs_id, int tgt_id)
 	if (tls == NULL)
 		return NULL;
 
+	tls->dt_agg_gen = 1;
+	tls->dt_registered_cont_cnt = 0;
+
 	/** Skip sensor setup on system xstreams */
 	if (tgt_id < 0)
 		return tls;
@@ -44,6 +47,11 @@ dtx_tls_init(int xs_id, int tgt_id)
 static void
 dtx_tls_fini(void *data)
 {
+	struct dtx_tls	*tls = data;
+
+	D_ASSERTF(tls->dt_registered_cont_cnt == 0, "Some containers are not deregistered %d\n",
+		  tls->dt_registered_cont_cnt);
+
 	D_FREE(data);
 }
 
@@ -431,8 +439,6 @@ static int
 dtx_setup(void)
 {
 	int	rc;
-
-	dtx_agg_gen = 1;
 
 	rc = dss_ult_create_all(dtx_batched_commit, NULL, true);
 	if (rc != 0) {


### PR DESCRIPTION
During cont_child_stop, the container may be still opened. Under
such case, we will delay the deregistering of container from DTX
until the last open reference is released.

Some code cleanup.

Signed-off-by: Fan Yong <fan.yong@intel.com>