### PR TITLE
DAOS-9623 control: Use comma separator for providers

### DIFF
--- a/src/control/server/engine/config.go
+++ b/src/control/server/engine/config.go
@@ -24,7 +24,7 @@ const (
 	maxHelperStreamCount = 2
 
 	// MultiProviderSeparator delineates between providers in a multi-provider config.
-	MultiProviderSeparator = " "
+	MultiProviderSeparator = ","
 )
 
 // FabricConfig encapsulates networking fabric configuration.

--- a/src/control/server/server_utils_test.go
+++ b/src/control/server/server_utils_test.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"net"
 	"os/user"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -779,9 +780,9 @@ func TestServer_getNetDevClass(t *testing.T) {
 		},
 		"multi interface": {
 			configA: configA().
-				WithFabricInterface("eth0 ib0"),
+				WithFabricInterface(strings.Join([]string{"eth0", "ib0"}, engine.MultiProviderSeparator)),
 			configB: configB().
-				WithFabricInterface("eth1 ib1"),
+				WithFabricInterface(strings.Join([]string{"eth1", "ib1"}, engine.MultiProviderSeparator)),
 			expNetDevCls: []hardware.NetDevClass{hardware.Ether, hardware.Infiniband},
 		},
 		"mismatching net dev class with primary server as ib0 / Infiniband": {


### PR DESCRIPTION
Use a comma to separate the multiple provider list instead of a
space. This matches up with what CART is expecting.

Signed-off-by: Kris Jacque <kristin.jacque@intel.com>