### PR TITLE
DAOS-9584 chk: Add srv handlers for checker upcalls

### DIFF
--- a/src/control/common/proto/srv/srv.pb.go
+++ b/src/control/common/proto/srv/srv.pb.go
@@ -644,7 +644,7 @@ func (x *CheckRegPoolResp) GetStatus() int32 {
 }
 
 // Deregister pool from MS.
-type CheckDeregPoolRep struct {
+type CheckDeregPoolReq struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
@@ -653,8 +653,8 @@ type CheckDeregPoolRep struct {
 	Uuid string `protobuf:"bytes,2,opt,name=uuid,proto3" json:"uuid,omitempty"` // The pool to be deregistered.
 }
 
-func (x *CheckDeregPoolRep) Reset() {
-	*x = CheckDeregPoolRep{}
+func (x *CheckDeregPoolReq) Reset() {
+	*x = CheckDeregPoolReq{}
 	if protoimpl.UnsafeEnabled {
 		mi := &file_srv_srv_proto_msgTypes[10]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -662,13 +662,13 @@ func (x *CheckDeregPoolRep) Reset() {
 	}
 }
 
-func (x *CheckDeregPoolRep) String() string {
+func (x *CheckDeregPoolReq) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*CheckDeregPoolRep) ProtoMessage() {}
+func (*CheckDeregPoolReq) ProtoMessage() {}
 
-func (x *CheckDeregPoolRep) ProtoReflect() protoreflect.Message {
+func (x *CheckDeregPoolReq) ProtoReflect() protoreflect.Message {
 	mi := &file_srv_srv_proto_msgTypes[10]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -680,19 +680,19 @@ func (x *CheckDeregPoolRep) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use CheckDeregPoolRep.ProtoReflect.Descriptor instead.
-func (*CheckDeregPoolRep) Descriptor() ([]byte, []int) {
+// Deprecated: Use CheckDeregPoolReq.ProtoReflect.Descriptor instead.
+func (*CheckDeregPoolReq) Descriptor() ([]byte, []int) {
 	return file_srv_srv_proto_rawDescGZIP(), []int{10}
 }
 
-func (x *CheckDeregPoolRep) GetSeq() uint64 {
+func (x *CheckDeregPoolReq) GetSeq() uint64 {
 	if x != nil {
 		return x.Seq
 	}
 	return 0
 }
 
-func (x *CheckDeregPoolRep) GetUuid() string {
+func (x *CheckDeregPoolReq) GetUuid() string {
 	if x != nil {
 		return x.Uuid
 	}
@@ -771,7 +771,7 @@ type CheckReportReq struct {
 	Akey      string   `protobuf:"bytes,11,opt,name=akey,proto3" json:"akey,omitempty"`                        // The consistency is in which akey if applicable.
 	Timestamp string   `protobuf:"bytes,12,opt,name=timestamp,proto3" json:"timestamp,omitempty"`              // The time of report (and repair) the inconsistency.
 	Msg       string   `protobuf:"bytes,13,opt,name=msg,proto3" json:"msg,omitempty"`                          // Information to describe the inconsistency in detail.
-	Options   []string `protobuf:"bytes,14,rep,name=options,proto3" json:"options,omitempty"`                  // Options list for interation mode.
+	Options   []string `protobuf:"bytes,14,rep,name=options,proto3" json:"options,omitempty"`                  // Options list for interaction mode.
 }
 
 func (x *CheckReportReq) Reset() {
@@ -1083,7 +1083,7 @@ var file_srv_srv_proto_rawDesc = []byte{
 	0x0a, 0x10, 0x43, 0x68, 0x65, 0x63, 0x6b, 0x52, 0x65, 0x67, 0x50, 0x6f, 0x6f, 0x6c, 0x52, 0x65,
 	0x73, 0x70, 0x12, 0x16, 0x0a, 0x06, 0x73, 0x74, 0x61, 0x74, 0x75, 0x73, 0x18, 0x01, 0x20, 0x01,
 	0x28, 0x05, 0x52, 0x06, 0x73, 0x74, 0x61, 0x74, 0x75, 0x73, 0x22, 0x39, 0x0a, 0x11, 0x43, 0x68,
-	0x65, 0x63, 0x6b, 0x44, 0x65, 0x72, 0x65, 0x67, 0x50, 0x6f, 0x6f, 0x6c, 0x52, 0x65, 0x70, 0x12,
+	0x65, 0x63, 0x6b, 0x44, 0x65, 0x72, 0x65, 0x67, 0x50, 0x6f, 0x6f, 0x6c, 0x52, 0x65, 0x71, 0x12,
 	0x10, 0x0a, 0x03, 0x73, 0x65, 0x71, 0x18, 0x01, 0x20, 0x01, 0x28, 0x04, 0x52, 0x03, 0x73, 0x65,
 	0x71, 0x12, 0x12, 0x0a, 0x04, 0x75, 0x75, 0x69, 0x64, 0x18, 0x02, 0x20, 0x01, 0x28, 0x09, 0x52,
 	0x04, 0x75, 0x75, 0x69, 0x64, 0x22, 0x2c, 0x0a, 0x12, 0x43, 0x68, 0x65, 0x63, 0x6b, 0x44, 0x65,
@@ -1144,7 +1144,7 @@ var file_srv_srv_proto_goTypes = []interface{}{
 	(*CheckListPoolResp)(nil),         // 7: srv.CheckListPoolResp
 	(*CheckRegPoolReq)(nil),           // 8: srv.CheckRegPoolReq
 	(*CheckRegPoolResp)(nil),          // 9: srv.CheckRegPoolResp
-	(*CheckDeregPoolRep)(nil),         // 10: srv.CheckDeregPoolRep
+	(*CheckDeregPoolReq)(nil),         // 10: srv.CheckDeregPoolReq
 	(*CheckDeregPoolResp)(nil),        // 11: srv.CheckDeregPoolResp
 	(*CheckReportReq)(nil),            // 12: srv.CheckReportReq
 	(*CheckReportResp)(nil),           // 13: srv.CheckReportResp
@@ -1286,7 +1286,7 @@ func file_srv_srv_proto_init() {
 			}
 		}
 		file_srv_srv_proto_msgTypes[10].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*CheckDeregPoolRep); i {
+			switch v := v.(*CheckDeregPoolReq); i {
 			case 0:
 				return &v.state
 			case 1:

--- a/src/control/server/mgmt_drpc_checker.go
+++ b/src/control/server/mgmt_drpc_checker.go
@@ -1,0 +1,146 @@
+//
+// (C) Copyright 2022 Intel Corporation.
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+
+package server
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+	"google.golang.org/protobuf/proto"
+
+	srvpb "github.com/daos-stack/daos/src/control/common/proto/srv"
+	"github.com/daos-stack/daos/src/control/drpc"
+	"github.com/daos-stack/daos/src/control/system"
+)
+
+func (mod *srvModule) handleCheckerListPools(_ context.Context, reqb []byte) (out []byte, outErr error) {
+	// TODO: Remove if we never add request fields?
+	req := new(srvpb.CheckListPoolReq)
+	if err := proto.Unmarshal(reqb, req); err != nil {
+		return nil, drpc.UnmarshalingPayloadFailure()
+	}
+	mod.log.Debugf("handling CheckerListPools: %+v", req)
+
+	resp := new(srvpb.CheckListPoolResp)
+	defer func() {
+		mod.log.Debugf("CheckerListPools resp: %+v", resp)
+		out, outErr = proto.Marshal(resp)
+	}()
+
+	pools, err := mod.poolDB.PoolServiceList(true)
+	if err != nil {
+		mod.log.Errorf("failed to list pools: %s", err)
+		resp.Status = int32(drpc.DaosMiscError)
+		return
+	}
+
+	for _, ps := range pools {
+		resp.Pools = append(resp.Pools, &srvpb.CheckListPoolResp_OnePool{
+			Uuid:    ps.PoolUUID.String(),
+			Label:   ps.PoolLabel,
+			Svcreps: system.RanksToUint32(ps.Replicas),
+		})
+	}
+
+	return
+}
+
+func (mod *srvModule) handleCheckerRegisterPool(_ context.Context, reqb []byte) (out []byte, outErr error) {
+	req := new(srvpb.CheckRegPoolReq)
+	if err := proto.Unmarshal(reqb, req); err != nil {
+		return nil, drpc.UnmarshalingPayloadFailure()
+	}
+	mod.log.Debugf("handling CheckerRegisterPool: %+v", req)
+
+	resp := new(srvpb.CheckRegPoolResp)
+	defer func() {
+		mod.log.Debugf("CheckerRegisterPool resp: %+v", resp)
+		out, outErr = proto.Marshal(resp)
+	}()
+
+	uuid, err := uuid.Parse(req.Uuid)
+	if err != nil {
+		mod.log.Errorf("invalid pool UUID %q: %s", req.Uuid, err)
+		resp.Status = int32(drpc.DaosInvalidInput)
+		return
+	}
+	if !drpc.LabelIsValid(req.Label) {
+		mod.log.Errorf("bad pool label %q", req.Label)
+		resp.Status = int32(drpc.DaosInvalidInput)
+		return
+	}
+	if len(req.Svcreps) == 0 {
+		mod.log.Errorf("pool %q has zero svcreps", req.Uuid)
+		resp.Status = int32(drpc.DaosInvalidInput)
+		return
+	}
+	if _, err := mod.poolDB.FindPoolServiceByUUID(uuid); err == nil {
+		mod.log.Errorf("pool with uuid %q already exists", req.Uuid)
+		resp.Status = int32(drpc.DaosExists)
+		return
+	}
+	if _, err := mod.poolDB.FindPoolServiceByLabel(req.Label); err == nil {
+		mod.log.Errorf("pool with label %q already exists", req.Label)
+		resp.Status = int32(drpc.DaosExists)
+		return
+	}
+
+	ps := &system.PoolService{
+		PoolUUID:  uuid,
+		PoolLabel: req.Label,
+		State:     system.PoolServiceStateReady,
+		Replicas:  system.RanksFromUint32(req.Svcreps),
+	}
+
+	if err := mod.poolDB.AddPoolService(ps); err != nil {
+		mod.log.Errorf("failed to register pool: %s", err)
+		resp.Status = int32(drpc.DaosMiscError)
+		return
+	}
+
+	return
+}
+
+func (mod *srvModule) handleCheckerDeregisterPool(_ context.Context, reqb []byte) (out []byte, outErr error) {
+	req := new(srvpb.CheckDeregPoolReq)
+	if err := proto.Unmarshal(reqb, req); err != nil {
+		return nil, drpc.UnmarshalingPayloadFailure()
+	}
+	mod.log.Debugf("handling CheckerDeregisterPool: %+v", req)
+
+	resp := new(srvpb.CheckDeregPoolResp)
+	defer func() {
+		mod.log.Debugf("CheckerDeregisterPool resp: %+v", resp)
+		out, outErr = proto.Marshal(resp)
+	}()
+
+	uuid, err := uuid.Parse(req.Uuid)
+	if err != nil {
+		mod.log.Errorf("invalid pool UUID %q: %s", req.Uuid, err)
+		resp.Status = int32(drpc.DaosInvalidInput)
+		return
+	}
+
+	if _, err := mod.poolDB.FindPoolServiceByUUID(uuid); err != nil {
+		if system.IsPoolNotFound(err) {
+			mod.log.Errorf("pool with uuid %q does not exist", req.Uuid)
+			resp.Status = int32(drpc.DaosNonexistant)
+		} else {
+			mod.log.Errorf("failed to check pool uuid: %s", err)
+			resp.Status = int32(drpc.DaosMiscError)
+		}
+		return
+	}
+
+	if err := mod.poolDB.RemovePoolService(uuid); err != nil {
+		mod.log.Errorf("failed to remove pool: %s", err)
+		resp.Status = int32(drpc.DaosMiscError)
+		return
+	}
+
+	return
+}

--- a/src/control/server/mgmt_drpc_checker_test.go
+++ b/src/control/server/mgmt_drpc_checker_test.go
@@ -1,0 +1,269 @@
+//
+// (C) Copyright 2022 Intel Corporation.
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+
+package server
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	uuid "github.com/google/uuid"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/testing/protocmp"
+
+	"github.com/daos-stack/daos/src/control/common"
+	srvpb "github.com/daos-stack/daos/src/control/common/proto/srv"
+	"github.com/daos-stack/daos/src/control/drpc"
+	"github.com/daos-stack/daos/src/control/logging"
+	"github.com/daos-stack/daos/src/control/system"
+)
+
+func mockSrvModule(t *testing.T, log logging.Logger, ec int) *srvModule {
+	srv := &srvModule{
+		log:    log,
+		poolDB: system.MockDatabase(t, log),
+	}
+	addEngineInstances(srv, ec, log)
+
+	return srv
+}
+
+func TestSrvModule_HandleCheckerListPools(t *testing.T) {
+	testPool := &system.PoolService{
+		PoolUUID:  uuid.New(),
+		PoolLabel: "test-pool",
+		Replicas:  []system.Rank{0, 1, 2},
+	}
+
+	for name, tc := range map[string]struct {
+		req        []byte
+		notReplica bool
+		expResp    *srvpb.CheckListPoolResp
+		expErr     error
+	}{
+		"bad payload": {
+			req:    []byte{'b', 'a', 'd'},
+			expErr: drpc.UnmarshalingPayloadFailure(),
+		},
+		"not replica": {
+			notReplica: true,
+			expResp:    &srvpb.CheckListPoolResp{Status: int32(drpc.DaosMiscError)},
+		},
+		"success": {
+			expResp: &srvpb.CheckListPoolResp{
+				Pools: []*srvpb.CheckListPoolResp_OnePool{
+					{
+						Uuid:    testPool.PoolUUID.String(),
+						Label:   testPool.PoolLabel,
+						Svcreps: system.RanksToUint32(testPool.Replicas),
+					},
+				},
+			},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			log, buf := logging.NewTestLogger(t.Name())
+			defer common.ShowBufferOnFailure(t, buf)
+
+			mod := mockSrvModule(t, log, 1)
+			if tc.notReplica {
+				mod.poolDB = system.MockDatabaseWithCfg(t, log, &system.DatabaseConfig{})
+			} else {
+				if err := mod.poolDB.AddPoolService(testPool); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			ctx := context.Background()
+			gotMsg, gotErr := mod.handleCheckerListPools(ctx, tc.req)
+			common.CmpErr(t, tc.expErr, gotErr)
+			if tc.expErr != nil {
+				return
+			}
+
+			gotResp := new(srvpb.CheckListPoolResp)
+			if err := proto.Unmarshal(gotMsg, gotResp); err != nil {
+				t.Fatal(err)
+			}
+			if diff := cmp.Diff(tc.expResp, gotResp, protocmp.Transform()); diff != "" {
+				t.Fatalf("unexpected response (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestSrvModule_HandleCheckerRegisterPool(t *testing.T) {
+	existingPool := &system.PoolService{
+		PoolUUID:  uuid.New(),
+		PoolLabel: "test-pool",
+		Replicas:  []system.Rank{0, 1, 2},
+	}
+	makeReqBytes := func(id, label string, replicas []system.Rank) []byte {
+		req := &srvpb.CheckRegPoolReq{
+			Uuid:    id,
+			Label:   label,
+			Svcreps: system.RanksToUint32(replicas),
+		}
+		b, err := proto.Marshal(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return b
+	}
+	newUUID := uuid.New().String()
+
+	for name, tc := range map[string]struct {
+		req        []byte
+		notReplica bool
+		expResp    *srvpb.CheckRegPoolResp
+		expErr     error
+	}{
+		"bad payload": {
+			req:    []byte{'b', 'a', 'd'},
+			expErr: drpc.UnmarshalingPayloadFailure(),
+		},
+		"not replica": {
+			req:        makeReqBytes(newUUID, "new", []system.Rank{0}),
+			notReplica: true,
+			expResp:    &srvpb.CheckRegPoolResp{Status: int32(drpc.DaosMiscError)},
+		},
+		"bad uuid": {
+			req:     makeReqBytes("ow", "new", []system.Rank{0}),
+			expResp: &srvpb.CheckRegPoolResp{Status: int32(drpc.DaosInvalidInput)},
+		},
+		"bad label": {
+			req:     makeReqBytes(newUUID, newUUID, []system.Rank{0}),
+			expResp: &srvpb.CheckRegPoolResp{Status: int32(drpc.DaosInvalidInput)},
+		},
+		"empty label": {
+			req:     makeReqBytes(newUUID, "", []system.Rank{0}),
+			expResp: &srvpb.CheckRegPoolResp{Status: int32(drpc.DaosInvalidInput)},
+		},
+		"zero svcreps": {
+			req:     makeReqBytes(newUUID, "new", []system.Rank{}),
+			expResp: &srvpb.CheckRegPoolResp{Status: int32(drpc.DaosInvalidInput)},
+		},
+		"duplicate uuid": {
+			req:     makeReqBytes(existingPool.PoolUUID.String(), "new", []system.Rank{0}),
+			expResp: &srvpb.CheckRegPoolResp{Status: int32(drpc.DaosExists)},
+		},
+		"duplicate label": {
+			req:     makeReqBytes(newUUID, existingPool.PoolLabel, []system.Rank{0}),
+			expResp: &srvpb.CheckRegPoolResp{Status: int32(drpc.DaosExists)},
+		},
+		"success": {
+			req:     makeReqBytes(newUUID, "new", []system.Rank{0}),
+			expResp: &srvpb.CheckRegPoolResp{},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			log, buf := logging.NewTestLogger(t.Name())
+			defer common.ShowBufferOnFailure(t, buf)
+
+			mod := mockSrvModule(t, log, 1)
+			if tc.notReplica {
+				mod.poolDB = system.MockDatabaseWithCfg(t, log, &system.DatabaseConfig{})
+			} else {
+				if err := mod.poolDB.AddPoolService(existingPool); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			ctx := context.Background()
+			gotMsg, gotErr := mod.handleCheckerRegisterPool(ctx, tc.req)
+			common.CmpErr(t, tc.expErr, gotErr)
+			if tc.expErr != nil {
+				return
+			}
+
+			gotResp := new(srvpb.CheckRegPoolResp)
+			if err := proto.Unmarshal(gotMsg, gotResp); err != nil {
+				t.Fatal(err)
+			}
+			if diff := cmp.Diff(tc.expResp, gotResp, protocmp.Transform()); diff != "" {
+				t.Fatalf("unexpected response (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestSrvModule_HandleCheckerDeregisterPool(t *testing.T) {
+	existingPool := &system.PoolService{
+		PoolUUID:  uuid.New(),
+		PoolLabel: "test-pool",
+		Replicas:  []system.Rank{0, 1, 2},
+	}
+	makeReqBytes := func(id string) []byte {
+		req := &srvpb.CheckDeregPoolReq{
+			Uuid: id,
+		}
+		b, err := proto.Marshal(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return b
+	}
+	unkUUID := uuid.New().String()
+
+	for name, tc := range map[string]struct {
+		req        []byte
+		notReplica bool
+		expResp    *srvpb.CheckDeregPoolResp
+		expErr     error
+	}{
+		"bad payload": {
+			req:    []byte{'b', 'a', 'd'},
+			expErr: drpc.UnmarshalingPayloadFailure(),
+		},
+		"not replica": {
+			req:        makeReqBytes(existingPool.PoolUUID.String()),
+			notReplica: true,
+			expResp:    &srvpb.CheckDeregPoolResp{Status: int32(drpc.DaosMiscError)},
+		},
+		"bad uuid": {
+			req:     makeReqBytes("ow"),
+			expResp: &srvpb.CheckDeregPoolResp{Status: int32(drpc.DaosInvalidInput)},
+		},
+		"unknown uuid": {
+			req:     makeReqBytes(unkUUID),
+			expResp: &srvpb.CheckDeregPoolResp{Status: int32(drpc.DaosNonexistant)},
+		},
+		"success": {
+			req:     makeReqBytes(existingPool.PoolUUID.String()),
+			expResp: &srvpb.CheckDeregPoolResp{},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			log, buf := logging.NewTestLogger(t.Name())
+			defer common.ShowBufferOnFailure(t, buf)
+
+			mod := mockSrvModule(t, log, 1)
+			if tc.notReplica {
+				mod.poolDB = system.MockDatabaseWithCfg(t, log, &system.DatabaseConfig{})
+			} else {
+				if err := mod.poolDB.AddPoolService(existingPool); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			ctx := context.Background()
+			gotMsg, gotErr := mod.handleCheckerDeregisterPool(ctx, tc.req)
+			common.CmpErr(t, tc.expErr, gotErr)
+			if tc.expErr != nil {
+				return
+			}
+
+			gotResp := new(srvpb.CheckDeregPoolResp)
+			if err := proto.Unmarshal(gotMsg, gotResp); err != nil {
+				t.Fatal(err)
+			}
+			if diff := cmp.Diff(tc.expResp, gotResp, protocmp.Transform()); diff != "" {
+				t.Fatalf("unexpected response (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/src/control/server/mgmt_system_test.go
+++ b/src/control/server/mgmt_system_test.go
@@ -220,6 +220,25 @@ func stateString(s system.MemberState) string {
 
 func TestServer_MgmtSvc_LeaderQuery(t *testing.T) {
 	localhost := common.LocalhostCtrlAddr()
+	log, buf := logging.NewTestLogger(t.Name())
+
+	db, cleanup := system.TestDatabase(t, log)
+	defer cleanup()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err := db.Start(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	// wait for the bootstrap to finish
+	for {
+		if leader, _, _ := db.LeaderQuery(); leader != "" {
+			break
+		}
+		time.Sleep(250 * time.Millisecond)
+	}
 
 	for name, tc := range map[string]struct {
 		req     *mgmtpb.LeaderQueryReq
@@ -244,27 +263,11 @@ func TestServer_MgmtSvc_LeaderQuery(t *testing.T) {
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			log, buf := logging.NewTestLogger(t.Name())
+			buf.Reset()
 			defer common.ShowBufferOnFailure(t, buf)
 
 			svc := newTestMgmtSvc(t, log)
-			db, cleanup := system.TestDatabase(t, log)
-			defer cleanup()
 			svc.sysdb = db
-
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
-			if err := db.Start(ctx); err != nil {
-				t.Fatal(err)
-			}
-
-			// wait for the bootstrap to finish
-			for {
-				if leader, _, _ := db.LeaderQuery(); leader != "" {
-					break
-				}
-				time.Sleep(250 * time.Millisecond)
-			}
 
 			gotResp, gotErr := svc.LeaderQuery(context.TODO(), tc.req)
 			common.CmpErr(t, tc.expErr, gotErr)

--- a/src/engine/srv.pb-c.c
+++ b/src/engine/srv.pb-c.c
@@ -463,49 +463,49 @@ void   srv__check_reg_pool_resp__free_unpacked
   assert(message->base.descriptor == &srv__check_reg_pool_resp__descriptor);
   protobuf_c_message_free_unpacked ((ProtobufCMessage*)message, allocator);
 }
-void   srv__check_dereg_pool_rep__init
-                     (Srv__CheckDeregPoolRep         *message)
+void   srv__check_dereg_pool_req__init
+                     (Srv__CheckDeregPoolReq         *message)
 {
-  static const Srv__CheckDeregPoolRep init_value = SRV__CHECK_DEREG_POOL_REP__INIT;
+  static const Srv__CheckDeregPoolReq init_value = SRV__CHECK_DEREG_POOL_REQ__INIT;
   *message = init_value;
 }
-size_t srv__check_dereg_pool_rep__get_packed_size
-                     (const Srv__CheckDeregPoolRep *message)
+size_t srv__check_dereg_pool_req__get_packed_size
+                     (const Srv__CheckDeregPoolReq *message)
 {
-  assert(message->base.descriptor == &srv__check_dereg_pool_rep__descriptor);
+  assert(message->base.descriptor == &srv__check_dereg_pool_req__descriptor);
   return protobuf_c_message_get_packed_size ((const ProtobufCMessage*)(message));
 }
-size_t srv__check_dereg_pool_rep__pack
-                     (const Srv__CheckDeregPoolRep *message,
+size_t srv__check_dereg_pool_req__pack
+                     (const Srv__CheckDeregPoolReq *message,
                       uint8_t       *out)
 {
-  assert(message->base.descriptor == &srv__check_dereg_pool_rep__descriptor);
+  assert(message->base.descriptor == &srv__check_dereg_pool_req__descriptor);
   return protobuf_c_message_pack ((const ProtobufCMessage*)message, out);
 }
-size_t srv__check_dereg_pool_rep__pack_to_buffer
-                     (const Srv__CheckDeregPoolRep *message,
+size_t srv__check_dereg_pool_req__pack_to_buffer
+                     (const Srv__CheckDeregPoolReq *message,
                       ProtobufCBuffer *buffer)
 {
-  assert(message->base.descriptor == &srv__check_dereg_pool_rep__descriptor);
+  assert(message->base.descriptor == &srv__check_dereg_pool_req__descriptor);
   return protobuf_c_message_pack_to_buffer ((const ProtobufCMessage*)message, buffer);
 }
-Srv__CheckDeregPoolRep *
-       srv__check_dereg_pool_rep__unpack
+Srv__CheckDeregPoolReq *
+       srv__check_dereg_pool_req__unpack
                      (ProtobufCAllocator  *allocator,
                       size_t               len,
                       const uint8_t       *data)
 {
-  return (Srv__CheckDeregPoolRep *)
-     protobuf_c_message_unpack (&srv__check_dereg_pool_rep__descriptor,
+  return (Srv__CheckDeregPoolReq *)
+     protobuf_c_message_unpack (&srv__check_dereg_pool_req__descriptor,
                                 allocator, len, data);
 }
-void   srv__check_dereg_pool_rep__free_unpacked
-                     (Srv__CheckDeregPoolRep *message,
+void   srv__check_dereg_pool_req__free_unpacked
+                     (Srv__CheckDeregPoolReq *message,
                       ProtobufCAllocator *allocator)
 {
   if(!message)
     return;
-  assert(message->base.descriptor == &srv__check_dereg_pool_rep__descriptor);
+  assert(message->base.descriptor == &srv__check_dereg_pool_req__descriptor);
   protobuf_c_message_free_unpacked ((ProtobufCMessage*)message, allocator);
 }
 void   srv__check_dereg_pool_resp__init
@@ -1314,7 +1314,7 @@ const ProtobufCMessageDescriptor srv__check_reg_pool_resp__descriptor =
   (ProtobufCMessageInit) srv__check_reg_pool_resp__init,
   NULL,NULL,NULL    /* reserved[123] */
 };
-static const ProtobufCFieldDescriptor srv__check_dereg_pool_rep__field_descriptors[2] =
+static const ProtobufCFieldDescriptor srv__check_dereg_pool_req__field_descriptors[2] =
 {
   {
     "seq",
@@ -1322,7 +1322,7 @@ static const ProtobufCFieldDescriptor srv__check_dereg_pool_rep__field_descripto
     PROTOBUF_C_LABEL_NONE,
     PROTOBUF_C_TYPE_UINT64,
     0,   /* quantifier_offset */
-    offsetof(Srv__CheckDeregPoolRep, seq),
+    offsetof(Srv__CheckDeregPoolReq, seq),
     NULL,
     NULL,
     0,             /* flags */
@@ -1334,35 +1334,35 @@ static const ProtobufCFieldDescriptor srv__check_dereg_pool_rep__field_descripto
     PROTOBUF_C_LABEL_NONE,
     PROTOBUF_C_TYPE_STRING,
     0,   /* quantifier_offset */
-    offsetof(Srv__CheckDeregPoolRep, uuid),
+    offsetof(Srv__CheckDeregPoolReq, uuid),
     NULL,
     &protobuf_c_empty_string,
     0,             /* flags */
     0,NULL,NULL    /* reserved1,reserved2, etc */
   },
 };
-static const unsigned srv__check_dereg_pool_rep__field_indices_by_name[] = {
+static const unsigned srv__check_dereg_pool_req__field_indices_by_name[] = {
   0,   /* field[0] = seq */
   1,   /* field[1] = uuid */
 };
-static const ProtobufCIntRange srv__check_dereg_pool_rep__number_ranges[1 + 1] =
+static const ProtobufCIntRange srv__check_dereg_pool_req__number_ranges[1 + 1] =
 {
   { 1, 0 },
   { 0, 2 }
 };
-const ProtobufCMessageDescriptor srv__check_dereg_pool_rep__descriptor =
+const ProtobufCMessageDescriptor srv__check_dereg_pool_req__descriptor =
 {
   PROTOBUF_C__MESSAGE_DESCRIPTOR_MAGIC,
-  "srv.CheckDeregPoolRep",
-  "CheckDeregPoolRep",
-  "Srv__CheckDeregPoolRep",
+  "srv.CheckDeregPoolReq",
+  "CheckDeregPoolReq",
+  "Srv__CheckDeregPoolReq",
   "srv",
-  sizeof(Srv__CheckDeregPoolRep),
+  sizeof(Srv__CheckDeregPoolReq),
   2,
-  srv__check_dereg_pool_rep__field_descriptors,
-  srv__check_dereg_pool_rep__field_indices_by_name,
-  1,  srv__check_dereg_pool_rep__number_ranges,
-  (ProtobufCMessageInit) srv__check_dereg_pool_rep__init,
+  srv__check_dereg_pool_req__field_descriptors,
+  srv__check_dereg_pool_req__field_indices_by_name,
+  1,  srv__check_dereg_pool_req__number_ranges,
+  (ProtobufCMessageInit) srv__check_dereg_pool_req__init,
   NULL,NULL,NULL    /* reserved[123] */
 };
 static const ProtobufCFieldDescriptor srv__check_dereg_pool_resp__field_descriptors[1] =

--- a/src/engine/srv.pb-c.h
+++ b/src/engine/srv.pb-c.h
@@ -26,7 +26,7 @@ typedef struct _Srv__CheckListPoolResp Srv__CheckListPoolResp;
 typedef struct _Srv__CheckListPoolResp__OnePool Srv__CheckListPoolResp__OnePool;
 typedef struct _Srv__CheckRegPoolReq Srv__CheckRegPoolReq;
 typedef struct _Srv__CheckRegPoolResp Srv__CheckRegPoolResp;
-typedef struct _Srv__CheckDeregPoolRep Srv__CheckDeregPoolRep;
+typedef struct _Srv__CheckDeregPoolReq Srv__CheckDeregPoolReq;
 typedef struct _Srv__CheckDeregPoolResp Srv__CheckDeregPoolResp;
 typedef struct _Srv__CheckReportReq Srv__CheckReportReq;
 typedef struct _Srv__CheckReportResp Srv__CheckReportResp;
@@ -274,7 +274,7 @@ struct  _Srv__CheckRegPoolResp
 /*
  * Deregister pool from MS.
  */
-struct  _Srv__CheckDeregPoolRep
+struct  _Srv__CheckDeregPoolReq
 {
   ProtobufCMessage base;
   /*
@@ -286,8 +286,8 @@ struct  _Srv__CheckDeregPoolRep
    */
   char *uuid;
 };
-#define SRV__CHECK_DEREG_POOL_REP__INIT \
- { PROTOBUF_C_MESSAGE_INIT (&srv__check_dereg_pool_rep__descriptor) \
+#define SRV__CHECK_DEREG_POOL_REQ__INIT \
+ { PROTOBUF_C_MESSAGE_INIT (&srv__check_dereg_pool_req__descriptor) \
     , 0, (char *)protobuf_c_empty_string }
 
 
@@ -368,7 +368,7 @@ struct  _Srv__CheckReportReq
    */
   char *msg;
   /*
-   * Options list for interation mode.
+   * Options list for interaction mode.
    */
   size_t n_options;
   char **options;
@@ -584,24 +584,24 @@ Srv__CheckRegPoolResp *
 void   srv__check_reg_pool_resp__free_unpacked
                      (Srv__CheckRegPoolResp *message,
                       ProtobufCAllocator *allocator);
-/* Srv__CheckDeregPoolRep methods */
-void   srv__check_dereg_pool_rep__init
-                     (Srv__CheckDeregPoolRep         *message);
-size_t srv__check_dereg_pool_rep__get_packed_size
-                     (const Srv__CheckDeregPoolRep   *message);
-size_t srv__check_dereg_pool_rep__pack
-                     (const Srv__CheckDeregPoolRep   *message,
+/* Srv__CheckDeregPoolReq methods */
+void   srv__check_dereg_pool_req__init
+                     (Srv__CheckDeregPoolReq         *message);
+size_t srv__check_dereg_pool_req__get_packed_size
+                     (const Srv__CheckDeregPoolReq   *message);
+size_t srv__check_dereg_pool_req__pack
+                     (const Srv__CheckDeregPoolReq   *message,
                       uint8_t             *out);
-size_t srv__check_dereg_pool_rep__pack_to_buffer
-                     (const Srv__CheckDeregPoolRep   *message,
+size_t srv__check_dereg_pool_req__pack_to_buffer
+                     (const Srv__CheckDeregPoolReq   *message,
                       ProtobufCBuffer     *buffer);
-Srv__CheckDeregPoolRep *
-       srv__check_dereg_pool_rep__unpack
+Srv__CheckDeregPoolReq *
+       srv__check_dereg_pool_req__unpack
                      (ProtobufCAllocator  *allocator,
                       size_t               len,
                       const uint8_t       *data);
-void   srv__check_dereg_pool_rep__free_unpacked
-                     (Srv__CheckDeregPoolRep *message,
+void   srv__check_dereg_pool_req__free_unpacked
+                     (Srv__CheckDeregPoolReq *message,
                       ProtobufCAllocator *allocator);
 /* Srv__CheckDeregPoolResp methods */
 void   srv__check_dereg_pool_resp__init
@@ -695,8 +695,8 @@ typedef void (*Srv__CheckRegPoolReq_Closure)
 typedef void (*Srv__CheckRegPoolResp_Closure)
                  (const Srv__CheckRegPoolResp *message,
                   void *closure_data);
-typedef void (*Srv__CheckDeregPoolRep_Closure)
-                 (const Srv__CheckDeregPoolRep *message,
+typedef void (*Srv__CheckDeregPoolReq_Closure)
+                 (const Srv__CheckDeregPoolReq *message,
                   void *closure_data);
 typedef void (*Srv__CheckDeregPoolResp_Closure)
                  (const Srv__CheckDeregPoolResp *message,
@@ -724,7 +724,7 @@ extern const ProtobufCMessageDescriptor srv__check_list_pool_resp__descriptor;
 extern const ProtobufCMessageDescriptor srv__check_list_pool_resp__one_pool__descriptor;
 extern const ProtobufCMessageDescriptor srv__check_reg_pool_req__descriptor;
 extern const ProtobufCMessageDescriptor srv__check_reg_pool_resp__descriptor;
-extern const ProtobufCMessageDescriptor srv__check_dereg_pool_rep__descriptor;
+extern const ProtobufCMessageDescriptor srv__check_dereg_pool_req__descriptor;
 extern const ProtobufCMessageDescriptor srv__check_dereg_pool_resp__descriptor;
 extern const ProtobufCMessageDescriptor srv__check_report_req__descriptor;
 extern const ProtobufCMessageDescriptor srv__check_report_resp__descriptor;

--- a/src/proto/srv/srv.proto
+++ b/src/proto/srv/srv.proto
@@ -81,7 +81,7 @@ message CheckRegPoolResp {
 }
 
 // Deregister pool from MS.
-message CheckDeregPoolRep {
+message CheckDeregPoolReq {
 	uint64 seq = 1; // DAOS Check event sequence, unique for the instance.
 	string uuid = 2; // The pool to be deregistered.
 }
@@ -111,7 +111,7 @@ message CheckReportReq {
 	string akey = 11; // The consistency is in which akey if applicable.
 	string timestamp = 12; // The time of report (and repair) the inconsistency.
 	string msg = 13; // Information to describe the inconsistency in detail.
-	repeated string options = 14; // Options list for interation mode.
+	repeated string options = 14; // Options list for interaction mode.
 }
 
 message CheckReportResp {


### PR DESCRIPTION
Implement control plane handlers for the following
engine checker dRPC upcalls:
  * CheckerListPools
  * CheckerRegisterPool
  * CheckerDeregisterPool
 
Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com>