### PR TITLE
DAOS-9623 control: Check multiprovider interfaces

### DIFF
--- a/src/control/server/server.go
+++ b/src/control/server/server.go
@@ -56,8 +56,15 @@ func processConfig(log *logging.LeveledLogger, cfg *config.Server, fis *hardware
 		return iface, nil
 	}
 	for _, ec := range cfg.Engines {
-		if err := checkFabricInterface(ec.Fabric.Interface, lookupNetIF); err != nil {
+		fabricIFs, err := ec.Fabric.GetInterfaces()
+		if err != nil {
 			return nil, err
+		}
+
+		for _, iface := range fabricIFs {
+			if err := checkFabricInterface(iface, lookupNetIF); err != nil {
+				return nil, err
+			}
 		}
 
 		if err := updateFabricEnvars(log, ec, fis); err != nil {


### PR DESCRIPTION
- Check all the fabric interfaces in the server.

Signed-off-by: Kris Jacque <kristin.jacque@intel.com>