### PR TITLE
Add compilation_db tool and cdb command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,5 @@ src/client/java/hadoop-daos/target/
 src/client/java/daos-java/build/
 docs/doxygen/
 venv
+compile_commands.json
+.vscode

--- a/SConstruct
+++ b/SConstruct
@@ -338,7 +338,9 @@ def scons(): # pylint: disable=too-many-locals
 
         Exit(0)
 
-    env = Environment(TOOLS=['extra', 'default', 'textfile'])
+    env = Environment(TOOLS=['extra', 'default', 'textfile', 'compilation_db'], COMPILATIONDB_USE_ABSPATH=True)
+    cdb = env.CompilationDatabase()
+    Alias('cdb', cdb)
 
     opts_file = os.path.join(Dir('#').abspath, 'daos.conf')
     opts = Variables(opts_file)

--- a/SConstruct
+++ b/SConstruct
@@ -7,6 +7,8 @@ import time
 import errno
 import SCons.Warnings
 from SCons.Script import BUILD_TARGETS
+import SCons as sc
+import packaging.version
 
 if sys.version_info.major < 3:
     print(""""Python 2.7 is no longer supported in the DAOS build.
@@ -338,9 +340,12 @@ def scons(): # pylint: disable=too-many-locals
 
         Exit(0)
 
-    env = Environment(TOOLS=['extra', 'default', 'textfile', 'compilation_db'], COMPILATIONDB_USE_ABSPATH=True)
-    cdb = env.CompilationDatabase()
-    Alias('cdb', cdb)
+    if packaging.version.parse(sc.__version__) >= packaging.version.parse('4.0.0'):
+        env = Environment(TOOLS=['extra', 'default', 'textfile', 'compilation_db'], COMPILATIONDB_USE_ABSPATH=True)
+        cdb = env.CompilationDatabase()
+        Alias('cdb', cdb)
+    else:
+         env = Environment(TOOLS=['extra', 'default', 'textfile'])
 
     opts_file = os.path.join(Dir('#').abspath, 'daos.conf')
     opts = Variables(opts_file)


### PR DESCRIPTION
This change allows the creation of [compile_commands.json](https://scons.org/doc/production/HTML/scons-user/ch27.html) ([example](https://github.com/daos-stack/daos/files/8384552/compile_commands.json.txt)) using the following command:
```bash
scons [...] cdb
```
and the file `compile_commands.json` will be created in the same directory.

# Why?
Generating `compile_commands.json` helps with static code analysis using tools like [scanyp](https://www.scanyp.com/ScanyxForC) (commercial) or [cppcheck](https://cppcheck.sourceforge.io/) (Free - GPLv3)

# Notes
a side effect of this is that the minimum required version for scons is 4.0. The version installed by pip is always the latest version, but package managers might have outdated versions.
