### PR TITLE
DAOS-10199 tests: more log for rebuild_with_io

### DIFF
--- a/src/tests/ftest/rebuild/with_io.yaml
+++ b/src/tests/ftest/rebuild/with_io.yaml
@@ -13,6 +13,9 @@ server_config:
   name: daos_server
   servers:
     targets: 2
+    log_mask: DEBUG,MEM=ERR
+    env_vars:
+       - DD_MASK=mgmt,md,rebuild,io,trace
 pool:
   mode: 511
   name: daos_server


### PR DESCRIPTION
Only for test.
Enable "io,trace" in the DD_MASK.

Signed-off-by: Fan Yong <fan.yong@intel.com>