### PR TITLE
DAOS-623 vos: fix typo in vos aggregation

### DIFF
--- a/src/vos/vos_aggregate.c
+++ b/src/vos/vos_aggregate.c
@@ -176,7 +176,7 @@ static inline void
 credits_set(struct vos_agg_credits *vac, bool tight)
 {
 	vac->vac_creds_scan = tight ? AGG_CREDS_SCAN_TIGHT : AGG_CREDS_SCAN_SLACK;
-	vac->vac_creds_del = tight ? AGG_CREDS_DEL_TIGHT : AGG_CREDS_SCAN_SLACK;
+	vac->vac_creds_del = tight ? AGG_CREDS_DEL_TIGHT : AGG_CREDS_DEL_SLACK;
 	vac->vac_creds_merge = tight ? AGG_CREDS_MERGE_TIGHT : AGG_CREDS_MERGE_SLACK;
 }
 


### PR DESCRIPTION
Fixed a typo in VOS aggregation.

Signed-off-by: Niu Yawei <yawei.niu@intel.com>