### PR TITLE
DAOS-10174 control: Reduce duration of NVMe storage format

### DIFF
--- a/src/control/lib/spdk/src/nvme_control.c
+++ b/src/control/lib/spdk/src/nvme_control.c
@@ -130,6 +130,8 @@ wipe_ctrlr(struct ctrlr_entry *centry)
 
 	res = init_wipe_res();
 
+	fprintf(stderr, "wipe_ctrlr: checkpoint 1\n");
+
 	/** convert pci addr to string */
 	rc = spdk_pci_addr_fmt(res->ctrlr_pci_addr, sizeof(res->ctrlr_pci_addr),
 			       &centry->pci_addr);
@@ -138,6 +140,8 @@ wipe_ctrlr(struct ctrlr_entry *centry)
 		return res;
 	}
 
+	fprintf(stderr, "wipe_ctrlr: checkpoint 2\n");
+
 	/** allocate NVMe queue pair for the controller */
 	qpair = spdk_nvme_ctrlr_alloc_io_qpair(centry->ctrlr, NULL, 0);
 	if (qpair == NULL) {
@@ -145,6 +149,8 @@ wipe_ctrlr(struct ctrlr_entry *centry)
 		res->rc = -ENOMEM;
 		return res;
 	}
+
+	fprintf(stderr, "wipe_ctrlr: checkpoint 3\n");
 
 	/** allocate a 4K page, with 4K alignment */
 	buf =  spdk_dma_zmalloc(4096, 4096, NULL);
@@ -161,11 +167,15 @@ wipe_ctrlr(struct ctrlr_entry *centry)
 	while (nentry != NULL) {
 		uint32_t sector_size;
 
+		fprintf(stderr, "wipe_ctrlr: checkpoint 4-A\n");
+
 		if (tmp == NULL) {
 			/** first iteration */
 			tmp = res;
+			fprintf(stderr, "wipe_ctrlr: checkpoint 4-B\n");
 		} else {
 			/** allocate new result */
+			fprintf(stderr, "wipe_ctrlr: checkpoint 4-C\n");
 			res = init_wipe_res();
 			rc = spdk_pci_addr_fmt(res->ctrlr_pci_addr, sizeof(res->ctrlr_pci_addr),
 					       &centry->pci_addr);
@@ -175,6 +185,7 @@ wipe_ctrlr(struct ctrlr_entry *centry)
 			}
 			res->next = tmp;
 			tmp = res;
+			fprintf(stderr, "wipe_ctrlr: checkpoint 4-D\n");
 		}
 
 		/** retrieve namespace ID and sector size */
@@ -195,6 +206,7 @@ wipe_ctrlr(struct ctrlr_entry *centry)
 			break;
 		}
 
+		fprintf(stderr, "wipe_ctrlr: checkpoint 4-E\n");
 		/** wait for command completion */
 		while (data.result == LBA0_WRITE_PENDING) {
 			rc = spdk_nvme_qpair_process_completions(qpair, 0);
@@ -204,6 +216,7 @@ wipe_ctrlr(struct ctrlr_entry *centry)
 			}
 		}
 
+		fprintf(stderr, "wipe_ctrlr: checkpoint 4-F\n");
 		/** check command result */
 		if (data.result != LBA0_WRITE_SUCCESS) {
 			snprintf(res->info, sizeof(res->info),
@@ -211,12 +224,14 @@ wipe_ctrlr(struct ctrlr_entry *centry)
 			res->rc = -1;
 			break;
 		}
+		fprintf(stderr, "wipe_ctrlr: checkpoint 4-H\n");
 
 		nentry = nentry->next;
 	}
 
 	spdk_free(buf);
 	spdk_nvme_ctrlr_free_io_qpair(qpair);
+	fprintf(stderr, "wipe_ctrlr: checkpoint 5\n");
 
 	return res;
 }
@@ -228,9 +243,11 @@ wipe_ctrlrs(void)
 	struct wipe_res_t	*start = NULL, *end = NULL;
 
 	while (centry != NULL) {
+		fprintf(stderr, "wipe_ctrlrs: checkpoint 1-A\n");
 		struct wipe_res_t *results = wipe_ctrlr(centry);
 		struct wipe_res_t *tmp = results;
 
+		fprintf(stderr, "wipe_ctrlrs: checkpoint 1-B\n");
 		if (results == NULL) {
 			continue;
 		}
@@ -248,6 +265,8 @@ wipe_ctrlrs(void)
 		}
 
 		centry = centry->next;
+
+		fprintf(stderr, "wipe_ctrlrs: checkpoint 1-C\n");
 	}
 
 	return start;
@@ -259,6 +278,7 @@ nvme_wipe_namespaces(void)
 	struct ret_t	*ret;
 	int		 rc;
 
+	fprintf(stderr, "nvme_wipe_namespaces: checkpoint 1\n");
 	ret = init_ret();
 
 	/*
@@ -275,12 +295,14 @@ nvme_wipe_namespaces(void)
 		goto out;
 	}
 
+	fprintf(stderr, "nvme_wipe_namespaces: checkpoint 2\n");
 	if (g_controllers == NULL) {
 		snprintf(ret->info, sizeof(ret->info), "no controllers found\n");
 		ret->rc = -ENOENT;
 		goto out;
 	}
 
+	fprintf(stderr, "nvme_wipe_namespaces: checkpoint 3\n");
 	ret->wipe_results = wipe_ctrlrs();
 	if (ret->wipe_results == NULL) {
 		snprintf(ret->info, sizeof(ret->info), "no namespaces on controller\n");
@@ -288,8 +310,10 @@ nvme_wipe_namespaces(void)
 		goto out;
 	}
 
+	fprintf(stderr, "nvme_wipe_namespaces: checkpoint 4\n");
 out:
 	cleanup(true);
+	fprintf(stderr, "nvme_wipe_namespaces: checkpoint 5\n");
 	return ret;
 }
 

--- a/src/control/lib/spdk/src/nvme_control_common.c
+++ b/src/control/lib/spdk/src/nvme_control_common.c
@@ -520,25 +520,34 @@ cleanup(bool detach)
 {
 	struct ns_entry		*nentry;
 	struct ctrlr_entry	*centry, *cnext;
+	fprintf(stderr, "cleanup: checkpoint 1\n");
 
 	centry = g_controllers;
 
 	while (centry) {
-		if ((centry->ctrlr) && (detach))
+		fprintf(stderr, "cleanup: checkpoint 2-A\n");
+		if ((centry->ctrlr) && (detach)) {
+			fprintf(stderr, "cleanup: checkpoint 2-B\n");
 			spdk_nvme_detach(centry->ctrlr);
+			fprintf(stderr, "cleanup: checkpoint 2-C\n");
+		}
+		fprintf(stderr, "cleanup: checkpoint 2-D\n");
 		while (centry->nss) {
 			nentry = centry->nss->next;
 			free(centry->nss);
 			centry->nss = nentry;
 		}
+		fprintf(stderr, "cleanup: checkpoint 2-E\n");
 		if (centry->health)
 			free(centry->health);
 
 		cnext = centry->next;
 		free(centry);
 		centry = cnext;
+		fprintf(stderr, "cleanup: checkpoint 2-F\n");
 	}
 
 	g_controllers = NULL;
+	fprintf(stderr, "cleanup: checkpoint 3\n");
 }
 

--- a/src/control/lib/spdk/src/nvme_control_common.c
+++ b/src/control/lib/spdk/src/nvme_control_common.c
@@ -521,37 +521,28 @@ cleanup(bool detach)
 	struct ns_entry			*nentry;
 	struct ctrlr_entry		*centry, *cnext;
 	struct spdk_nvme_detach_ctx	*detach_ctx = NULL;
-	fprintf(stderr, "cleanup: checkpoint 1\n");
 
 	centry = g_controllers;
 
 	while (centry) {
-		fprintf(stderr, "cleanup: checkpoint 2-A\n");
-		if ((centry->ctrlr) && (detach)) {
-			fprintf(stderr, "cleanup: checkpoint 2-B\n");
+		if ((centry->ctrlr) && (detach))
 			spdk_nvme_detach_async(centry->ctrlr, &detach_ctx);
-			fprintf(stderr, "cleanup: checkpoint 2-C\n");
-		}
-		fprintf(stderr, "cleanup: checkpoint 2-D\n");
 		while (centry->nss) {
 			nentry = centry->nss->next;
 			free(centry->nss);
 			centry->nss = nentry;
 		}
-		fprintf(stderr, "cleanup: checkpoint 2-E\n");
 		if (centry->health)
 			free(centry->health);
 
 		cnext = centry->next;
 		free(centry);
 		centry = cnext;
-		fprintf(stderr, "cleanup: checkpoint 2-F\n");
 	}
 
 	if (detach_ctx)
 		spdk_nvme_detach_poll(detach_ctx);
 
 	g_controllers = NULL;
-	fprintf(stderr, "cleanup: checkpoint 3\n");
 }
 

--- a/src/control/lib/spdk/src/nvme_control_common.c
+++ b/src/control/lib/spdk/src/nvme_control_common.c
@@ -518,8 +518,9 @@ collect(void)
 void
 cleanup(bool detach)
 {
-	struct ns_entry		*nentry;
-	struct ctrlr_entry	*centry, *cnext;
+	struct ns_entry			*nentry;
+	struct ctrlr_entry		*centry, *cnext;
+	struct spdk_nvme_detach_ctx	*detach_ctx = NULL;
 	fprintf(stderr, "cleanup: checkpoint 1\n");
 
 	centry = g_controllers;
@@ -528,7 +529,7 @@ cleanup(bool detach)
 		fprintf(stderr, "cleanup: checkpoint 2-A\n");
 		if ((centry->ctrlr) && (detach)) {
 			fprintf(stderr, "cleanup: checkpoint 2-B\n");
-			spdk_nvme_detach(centry->ctrlr);
+			spdk_nvme_detach_async(centry->ctrlr, &detach_ctx);
 			fprintf(stderr, "cleanup: checkpoint 2-C\n");
 		}
 		fprintf(stderr, "cleanup: checkpoint 2-D\n");
@@ -546,6 +547,9 @@ cleanup(bool detach)
 		centry = cnext;
 		fprintf(stderr, "cleanup: checkpoint 2-F\n");
 	}
+
+	if (detach_ctx)
+		spdk_nvme_detach_poll(detach_ctx);
 
 	g_controllers = NULL;
 	fprintf(stderr, "cleanup: checkpoint 3\n");


### PR DESCRIPTION
To reduce duration of dmg storage format command, which wipes NVMe
namespaces, use the async version of spdk_nvme_detach API which batches
detach tasks and performs them together when poll is called at a later time.
Format operations with 16TB NVMe SSDs previously took ~14s per SSD and
should now take ~15s per engine regardless of the number of SSDs.

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>