### PR TITLE
DAOS-10164 test: Correct using user group for chown commands

### DIFF
--- a/src/tests/ftest/util/command_utils.py
+++ b/src/tests/ftest/util/command_utils.py
@@ -24,7 +24,7 @@ from exception_utils import CommandFailure
 from general_utils import check_file_exists, get_log_file, \
     run_command, DaosTestError, get_job_manager_class, create_directory, \
     distribute_files, change_file_owner, get_file_listing, run_pcmd, \
-    get_subprocess_stdout
+    get_subprocess_stdout, get_primary_group
 
 
 class ExecutableCommand(CommandWithParameters):
@@ -966,7 +966,7 @@ class YamlCommand(SubProcessCommand):
                     self.command, directory, user, nodes)
                 try:
                     create_directory(nodes, directory, sudo=True)
-                    change_file_owner(nodes, directory, user, user, sudo=True)
+                    change_file_owner(nodes, directory, user, get_primary_group(user), sudo=True)
                 except DaosTestError as error:
                     raise CommandFailure(
                         "{}: error setting up missing socket directory {} for "

--- a/src/tests/ftest/util/general_utils.py
+++ b/src/tests/ftest/util/general_utils.py
@@ -7,7 +7,9 @@
 # pylint: disable=too-many-lines
 
 from logging import getLogger
+import grp
 import os
+import pwd
 import re
 import random
 import string
@@ -1146,7 +1148,7 @@ def distribute_files(hosts, source, destination, mkdir=True, timeout=60,
         # If requested update the ownership of the destination file
         if owner is not None and result.exit_status == 0:
             change_file_owner(
-                hosts, destination, owner, owner, timeout=timeout,
+                hosts, destination, owner, get_primary_group(owner), timeout=timeout,
                 verbose=verbose, raise_exception=raise_exception, sudo=sudo)
     return result
 
@@ -1299,3 +1301,19 @@ def percent_change(val1, val2):
     if val1 and val2:
         return (float(val2) - float(val1)) / float(val1)
     return 0.0
+
+
+def get_primary_group(user=None):
+    """Get the name of the user's primary group.
+
+    Args:
+        user (str, optional): the user account name. Defaults to None, which uses the current user.
+
+    Returns:
+        str: the primary group name
+
+    """
+    if user is None:
+        user = getuser()
+    gid = pwd.getpwnam(user).pw_gid
+    return grp.getgrgid(gid).gr_name

--- a/src/tests/ftest/util/server_utils.py
+++ b/src/tests/ftest/util/server_utils.py
@@ -19,7 +19,7 @@ from exception_utils import CommandFailure
 from command_utils import SubprocessManager
 from general_utils import pcmd, get_log_file, human_to_bytes, bytes_to_human, \
     convert_list, get_default_config_file, distribute_files, DaosTestError, \
-    stop_processes, get_display_size, run_pcmd
+    stop_processes, get_display_size, run_pcmd, get_primary_group
 from dmg_utils import get_dmg_command
 from server_utils_base import \
     ServerFailed, DaosServerCommand, DaosServerInformation, AutosizeCancel
@@ -458,7 +458,8 @@ class DaosServerManager(SubprocessManager):
                 scm_mount = [scm_mount]
 
             self.log.info("Changing ownership to %s for: %s", user, scm_mount)
-            cmd_list.add("sudo chown -R {0}:{0} {1}".format(user, " ".join(scm_mount)))
+            cmd_list.add(
+                "sudo chown -R {}:{} {}".format(user, get_primary_group(user), " ".join(scm_mount)))
 
         if cmd_list:
             pcmd(self._hosts, "; ".join(cmd_list), verbose)


### PR DESCRIPTION
Fix using the the user's primary group in chown commands instead of
assuming the group uses the same name as the user account.

Signed-off-by: Phillip Henderson <phillip.henderson@intel.com>