### PR TITLE
DAOS-8640 obj: fix a bug in EC obj degraded update

### DIFF
--- a/src/object/srv_ec.c
+++ b/src/object/srv_ec.c
@@ -73,8 +73,6 @@ obj_ec_rw_req_split(daos_unit_oid_t oid, struct obj_iod_array *iod_array,
 	int			 count = 0;
 	int			 rc = 0;
 
-	/* minimal K/P is 2/1, so at least 1 forward targets */
-	D_ASSERT(tgt_nr >= 1);
 	D_ASSERT(oiods != NULL);
 	/* as we select the last parity node as leader, and for any update
 	 * there must be a siod (the last siod) for leader except for singv.

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -2559,7 +2559,7 @@ again1:
 	}
 
 again2:
-	if (orw->orw_iod_array.oia_oiods != NULL && split_req == NULL && tgt_cnt != 0) {
+	if (orw->orw_iod_array.oia_oiods != NULL && split_req == NULL) {
 		rc = obj_ec_rw_req_split(orw->orw_oid, &orw->orw_iod_array,
 					 orw->orw_nr, orw->orw_start_shard,
 					 orw->orw_tgt_max, PO_COMP_ID_ALL,

--- a/src/tests/ftest/erasurecode/rebuild_fio.py
+++ b/src/tests/ftest/erasurecode/rebuild_fio.py
@@ -47,12 +47,17 @@ class EcodFioRebuild(ErasureCodeFio):
             self.server_managers[0].stop_ranks(
                 [self.server_count - 1], self.d_log, force=True)
 
+        # Adding unlink option for final read command
+        if int(self.container.properties.value.split(":")[1]) == 1:
+            self.fio_cmd._jobs['test'].unlink.value = 1
+
         # Read and verify the original data.
         self.fio_cmd._jobs['test'].rw.value = self.read_option
         self.fio_cmd.run()
 
         # If RF is 2 kill one more server and validate the data is not corrupted.
         if int(self.container.properties.value.split(":")[1]) == 2:
+            self.fio_cmd._jobs['test'].unlink.value = 1
             self.log.info("RF is 2,So kill another server and verify data")
             # Kill one more server rank
             self.server_managers[0].stop_ranks([self.server_count - 2],
@@ -83,7 +88,6 @@ class EcodFioRebuild(ErasureCodeFio):
         """
         self.execution('on-line')
 
-    @skipForTicket("DAOS-8640")
     def test_ec_offline_rebuild_fio(self):
         """Jira ID: DAOS-7320.
 

--- a/src/tests/ftest/erasurecode/rebuild_fio.yaml
+++ b/src/tests/ftest/erasurecode/rebuild_fio.yaml
@@ -80,9 +80,9 @@ fio:
     iodepth: 10
     size: 133MB
     read_write: !mux
-      write_read:
-        rw: 'write'
-        rw_read: 'read'
+#      write_read:
+#        rw: 'write'
+#        rw_read: 'read'
       randrw:
         rw: 'randrw'
         rw_read: 'randrw'

--- a/src/tests/ftest/erasurecode/rebuild_fio.yaml
+++ b/src/tests/ftest/erasurecode/rebuild_fio.yaml
@@ -70,6 +70,7 @@ container:
 fio:
   names:
     - test
+  api: POSIX
   test:
     numjobs: 10
     directory: "/tmp/daos_dfuse"
@@ -77,7 +78,7 @@ fio:
     verify_pattern: '0xabcdabcd'
     do_verify: 1
     iodepth: 10
-    size: 33MB
+    size: 133MB
     read_write: !mux
       write_read:
         rw: 'write'

--- a/src/tests/ftest/erasurecode/rebuild_fio.yaml
+++ b/src/tests/ftest/erasurecode/rebuild_fio.yaml
@@ -77,7 +77,7 @@ fio:
     verify_pattern: '0xabcdabcd'
     do_verify: 1
     iodepth: 10
-    size: 333MB
+    size: 33MB
     read_write: !mux
       write_read:
         rw: 'write'

--- a/src/tests/suite/daos_degrade_ec.c
+++ b/src/tests/suite/daos_degrade_ec.c
@@ -582,6 +582,7 @@ degrade_ec_update(void **state)
 	if (!test_runable(arg, 6) || (arg->srv_ntgts / arg->srv_nnodes) < 2)
 		return;
 
+	print_message("test 1 - DER_SHARDS_OVERLAP case\n");
 	data = (char *)malloc(TEST_EC_STRIPE_SIZE);
 	assert_true(data != NULL);
 	oid = daos_test_oid_gen(arg->coh, OC_EC_4P2G2, DAOS_OF_DKEY_UINT64, 0, arg->myrank);
@@ -601,6 +602,7 @@ degrade_ec_update(void **state)
 	}
 	ioreq_fini(&req);
 
+	print_message("test 2 - DAOS_FAIL_SHARD_OPEN case\n");
 	fail_shards[0] = 7;
 	fail_shards[1] = 8;
 	arg->fail_loc = DAOS_FAIL_SHARD_OPEN | DAOS_FAIL_ALWAYS;
@@ -615,6 +617,27 @@ degrade_ec_update(void **state)
 		memset(data, 'a' + i, TEST_EC_STRIPE_SIZE);
 		inset_recxs_dkey_uint64(&dkey_int, "a_key_1", 1, DAOS_TX_NONE, &recx, 1,
 			     data, TEST_EC_STRIPE_SIZE, &req);
+	}
+	ioreq_fini(&req);
+
+	print_message("test 3 - partial update only one leader alive case\n");
+	oid = daos_test_oid_gen(arg->coh, OC_EC_4P1G1, DAOS_OF_DKEY_UINT64, 0, arg->myrank);
+	/* simulate shard 0's failure, then partial update [0, 4096] will need to update
+	 * data shard 0 and parity shard 4, so only the leader shard 4 alive.
+	 */
+	fail_shards[0] = 1;
+	arg->fail_loc = DAOS_FAIL_SHARD_OPEN | DAOS_FAIL_ALWAYS;
+	arg->fail_value = daos_shard_fail_value(fail_shards, 1);
+	ioreq_init(&req, arg->coh, oid, DAOS_IOD_ARRAY, arg);
+	for (i = 0; i < 1; i++) {
+		daos_recx_t recx;
+
+		req.iod_type = DAOS_IOD_ARRAY;
+		recx.rx_nr = 4096;
+		recx.rx_idx = i * TEST_EC_STRIPE_SIZE;
+		memset(data, 'a' + i, 4096);
+		inset_recxs_dkey_uint64(&dkey_int, "a_key_2", 1, DAOS_TX_NONE, &recx, 1,
+					data, 4096, &req);
 	}
 	ioreq_fini(&req);
 


### PR DESCRIPTION
For EC (K+P) obj partial update, it will update to one data shard and
replicate to P parity shard. When that data shard and other parity 
shards failed, the degraded update will be sent to the leader parity shard.
The code of ds_obj_rw_handler() -> obj_gen_dtx_mbs() will change the
tgt_cnt to zero, then will not call obj_ec_rw_req_split() for the update
request. Actually for that case still need to call obj_ec_rw_req_split()
to split the iod->iod_recxs[] for the leader.

Add a test case in degrade_ec_update.
And re-enable test_ec_offline_rebuild_fio in rebuild_fio.py.
(remove the write_read test temporarily)

Test-tag: ec_offline_rebuild_fio

Signed-off-by: Xuezhao Liu [xuezhao.liu@intel.com]