### PR TITLE
DAOS-10216 test: remove unecessary soak sudo cmds

### DIFF
--- a/src/tests/ftest/slurm_setup.py
+++ b/src/tests/ftest/slurm_setup.py
@@ -63,7 +63,8 @@ def update_config_cmdlist(args):
         "sed -i -e 's/SlurmUser=slurm/SlurmUser={}/g' {}".format(
             args.user, SLURM_CONF),
         "sed -i -e 's/NodeName/#NodeName/g' {}".format(
-            SLURM_CONF), ]
+            SLURM_CONF),
+        ]
     if not args.sudo:
         sudo = ""
     else:
@@ -162,6 +163,10 @@ def start_munge(args):
         args (Namespace): Commandline arguments
 
     """
+    if not args.sudo:
+        sudo = ""
+    else:
+        sudo = "sudo"
     all_nodes = NodeSet("{},{}".format(str(args.control), str(args.nodes)))
     # exclude the control node
     nodes = NodeSet(str(args.nodes))
@@ -170,8 +175,8 @@ def start_munge(args):
     # copy key to all nodes FROM slurmctl node;
     # change the protections/ownership on the munge dir on all nodes
     cmd_list = [
-        "sudo chmod -R 777 /etc/munge; sudo chown {}. /etc/munge".format(
-            args.user)]
+        "{} chmod -R 777 /etc/munge; {} chown {}. /etc/munge".format(
+            sudo, sudo, args.user)]
     if execute_cluster_cmds(all_nodes, cmd_list) > 0:
         return 1
 
@@ -180,25 +185,25 @@ def start_munge(args):
     cmd_list = ["set -Eeu",
                 "rc=0",
                 "if [ ! -f /etc/munge/munge.key ]",
-                "then sudo create-munge-key",
+                "then {} create-munge-key".format(sudo),
                 "fi",
-                "sudo chmod 777 /etc/munge/munge.key",
-                "sudo chown {}. /etc/munge/munge.key".format(args.user)]
+                "{} chmod 777 /etc/munge/munge.key".format(sudo),
+                "{} chown {}. /etc/munge/munge.key".format(sudo, args.user)]
 
     if execute_cluster_cmds(args.control, ["; ".join(cmd_list)]) > 0:
         return 1
     # remove any existing key from other nodes
-    cmd_list = ["sudo rm -f /etc/munge/munge.key",
+    cmd_list = ["{} rm -f /etc/munge/munge.key".format(sudo),
                 "scp -p {}:/etc/munge/munge.key /etc/munge/munge.key".format(
                     args.control)]
     if execute_cluster_cmds(nodes, ["; ".join(cmd_list)]) > 0:
         return 1
     # set the protection back to defaults
     cmd_list = [
-        "sudo chmod 400 /etc/munge/munge.key",
-        "sudo chown munge. /etc/munge/munge.key",
-        "sudo chmod 700 /etc/munge",
-        "sudo chown munge. /etc/munge"]
+        "{} chmod 400 /etc/munge/munge.key".format(sudo),
+        "{} chown munge. /etc/munge/munge.key".format(sudo),
+        "{} chmod 700 /etc/munge".format(sudo),
+        "{} chown munge. /etc/munge".format(sudo)]
     if execute_cluster_cmds(all_nodes, ["; ".join(cmd_list)]) > 0:
         return 1
 
@@ -216,16 +221,18 @@ def start_slurm(args):
     """
     # Setting up slurm on all nodes
     all_nodes = NodeSet("{},{}".format(str(args.control), str(args.nodes)))
-    cmd_list = ["mkdir -p /var/log/slurm",
-                "chown {}. {}".format(args.user, "/var/log/slurm"),
-                "mkdir -p /var/spool/slurmd",
-                "mkdir -p /var/spool/slurmctld",
-                "mkdir -p /var/spool/slurm/d",
-                "mkdir -p /var/spool/slurm/ctld",
-                "chown {}. {}/ctld".format(args.user, "/var/spool/slurm"),
-                "chown {}. {}".format(args.user, "/var/spool/slurmctld"),
-                "chmod 775 {}".format("/var/spool/slurmctld"),
-                "rm -f /var/spool/slurmctld/clustername"]
+    cmd_list = [
+        "mkdir -p /var/log/slurm",
+        "chown {}. {}".format(args.user, "/var/log/slurm"),
+        "mkdir -p /var/spool/slurmd",
+        "mkdir -p /var/spool/slurmctld",
+        "mkdir -p /var/spool/slurm/d",
+        "mkdir -p /var/spool/slurm/ctld",
+        "chown {}. {}/ctld".format(args.user, "/var/spool/slurm"),
+        "chown {}. {}".format(args.user, "/var/spool/slurmctld"),
+        "chmod 775 {}".format("/var/spool/slurmctld"),
+        "rm -f /var/spool/slurmctld/clustername"
+        ]
 
     if execute_cluster_cmds(all_nodes, cmd_list, args.sudo) > 0:
         return 1

--- a/src/tests/ftest/soak/utils.py
+++ b/src/tests/ftest/soak/utils.py
@@ -330,7 +330,7 @@ def run_monitor_check(self):
     hosts = self.hostlist_servers
     if monitor_cmds:
         for cmd in monitor_cmds:
-            command = "sudo {}".format(cmd)
+            command = "{}".format(cmd)
             pcmd(hosts, command, timeout=30)
 
 
@@ -802,7 +802,7 @@ def cleanup_dfuse(self):
     """
     cmd = [
         "/usr/bin/bash -c 'for pid in $(pgrep dfuse)",
-        "do sudo kill $pid",
+        "do kill $pid",
         "done'"]
     cmd2 = [
         "/usr/bin/bash -c 'for dir in $(find /tmp/daos_dfuse/)",


### PR DESCRIPTION
Skip-unit-tests: true
Test-tag: pr soak_smoke

Some command lines in soak have prepended sudo and they are unnecessary and should be removed.

Signed-off-by: Maureen Jean <maureen.jean@intel.com>