### PR TITLE
DAOS-10221 dtx: reset DTX handle before yield

### DIFF
--- a/src/vos/vos_aggregate.c
+++ b/src/vos/vos_aggregate.c
@@ -315,6 +315,9 @@ vos_aggregate_yield(struct vos_agg_param *agg_param)
 {
 	int	rc;
 
+	/* Current DTX handle must be NULL, since aggregation runs under non-DTX mode. */
+	D_ASSERT(vos_dth_get() == NULL);
+
 	if (agg_param->ap_yield_func == NULL) {
 		bio_yield();
 		credits_set(&agg_param->ap_credits, true);
@@ -2177,6 +2180,9 @@ vos_agg_ev(daos_handle_t ih, vos_iter_entry_t *entry,
 		}
 		return rc;
 	}
+
+	/* Current DTX handle must be NULL, since aggregation runs under non-DTX mode. */
+	D_ASSERT(vos_dth_get() == NULL);
 
 	/* Aggregation Yield for testing purpose */
 	while (DAOS_FAIL_CHECK(DAOS_VOS_AGG_BLOCKED))

--- a/src/vos/vos_gc.c
+++ b/src/vos/vos_gc.c
@@ -1084,6 +1084,9 @@ vos_gc_yield(void *arg)
 	struct vos_gc_param	*param = arg;
 	int			 rc;
 
+	/* Current DTX handle must be NULL, since GC runs under non-DTX mode. */
+	D_ASSERT(vos_dth_get() == NULL);
+
 	if (param->vgc_yield_func == NULL) {
 		param->vgc_credits = GC_CREDS_TIGHT;
 		bio_yield();

--- a/src/vos/vos_query.c
+++ b/src/vos/vos_query.c
@@ -778,7 +778,6 @@ out:
 	if (obj != NULL)
 		vos_obj_release(vos_obj_cache_current(), obj, false);
 
-	vos_dth_set(NULL);
 	if (rc == 0 || rc == -DER_NONEXIST) {
 		if (vos_ts_wcheck(query->qt_ts_set, obj_epr.epr_hi,
 				  query->qt_bound))
@@ -790,6 +789,7 @@ out:
 
 	vos_ts_set_free(query->qt_ts_set);
 free_query:
+	vos_dth_set(NULL);
 	D_FREE(query);
 
 	return rc;


### PR DESCRIPTION
Currently, we use tls to pass DTX handle in VOS. So if any ULT yield
or exit without reset the DTX handle, then it will affect subsequent
ULT's running.

On the other hand, for EC aggregation, since the aggregation leader
is always the last parity node that is also the DTX leader, then it
is unnecessary to trigger DTX refresh for EC aggregation. The patch
removes related logic and avoids the trouble caused by yield during
EC aggregation.

Signed-off-by: Fan Yong <fan.yong@intel.com>