### PR TITLE
DAOS-7080 control: Deprecate format reformat option

### DIFF
--- a/src/control/cmd/dmg/storage.go
+++ b/src/control/cmd/dmg/storage.go
@@ -107,9 +107,8 @@ type storageFormatCmd struct {
 	ctlInvokerCmd
 	hostListCmd
 	jsonOutputCmd
-	Verbose  bool `short:"v" long:"verbose" description:"Show results of each SCM & NVMe device format operation"`
-	Reformat bool `long:"reformat" description:"Alias for --force, will be removed in a future release"`
-	Force    bool `long:"force" description:"Force storage format on a host, stopping any running engines (CAUTION: destructive operation)"`
+	Verbose bool `short:"v" long:"verbose" description:"Show results of each SCM & NVMe device format operation"`
+	Force   bool `long:"force" description:"Force storage format on a host, stopping any running engines (CAUTION: destructive operation)"`
 }
 
 // Execute is run when storageFormatCmd activates.
@@ -120,14 +119,6 @@ func (cmd *storageFormatCmd) Execute(args []string) (err error) {
 
 	req := &control.StorageFormatReq{Reformat: cmd.Force}
 	req.SetHostList(cmd.hostlist)
-
-	// TODO (DAOS-7080): Deprecate this parameter in favor of wiping SCM
-	// during the erase operation. For the moment, though, the reworked
-	// logic will prevent format of a running system, so the main use case
-	// here is to enable backward-compatibility for existing scripts.
-	if cmd.Reformat {
-		req.Reformat = true
-	}
 
 	resp, err := control.StorageFormat(ctx, cmd.ctlInvoker, req)
 	if err != nil {

--- a/src/control/cmd/dmg/storage_test.go
+++ b/src/control/cmd/dmg/storage_test.go
@@ -42,6 +42,12 @@ func TestStorageCommands(t *testing.T) {
 		{
 			"Format with reformat",
 			"storage format --reformat",
+			"",
+			errors.New("unknown flag"),
+		},
+		{
+			"Format with force",
+			"storage format --force",
 			strings.Join([]string{
 				printRequest(t, systemQueryReq),
 				printRequest(t, &control.StorageFormatReq{Reformat: true}),

--- a/src/control/server/storage/scm/faults.go
+++ b/src/control/server/storage/scm/faults.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2019-2021 Intel Corporation.
+// (C) Copyright 2019-2022 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -59,7 +59,7 @@ var (
 	// on SCM storage that was already formatted.
 	FaultFormatNoReformat = scmFault(
 		code.StorageAlreadyFormatted,
-		"format request for already-formatted storage",
+		"format request for device with an existing filesystem signature",
 		"retry the operation with force option to overwrite existing data",
 	)
 

--- a/src/control/server/storage/scm/provider.go
+++ b/src/control/server/storage/scm/provider.go
@@ -245,6 +245,7 @@ func (dsp *defaultSystemProvider) Stat(path string) (os.FileInfo, error) {
 func parseFsType(input string) string {
 	// /dev/pmem0: Linux rev 1.0 ext4 filesystem data, UUID=09619a0d-0c9e-46b4-add5-faf575dd293d
 	// /dev/pmem1: data
+	// /dev/pmem1: COM executable for DOS
 	fields := strings.Fields(input)
 	switch {
 	case len(fields) == 2 && fields[1] == parseFsUnformatted:

--- a/src/control/server/storage/scm/provider_test.go
+++ b/src/control/server/storage/scm/provider_test.go
@@ -1059,6 +1059,10 @@ func TestParseFsType(t *testing.T) {
 			input:     "/dev/pmem0: Linux rev 1.0 ext2 filesystem data, UUID=0ce47201-6f25-4569-9e82-34c9d91173bb (large files)\n",
 			expFsType: "ext2",
 		},
+		"garbage in header": {
+			input:     "/dev/pmem1: COM executable for DOS",
+			expFsType: "DOS",
+		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			if diff := cmp.Diff(tc.expFsType, parseFsType(tc.input)); diff != "" {

--- a/src/tests/ftest/server/daos_server_restart.py
+++ b/src/tests/ftest/server/daos_server_restart.py
@@ -20,11 +20,11 @@ class DaosServerTest(TestWithServers):
     """
     @fail_on(ServerFailed)
     @fail_on(CommandFailure)
-    def restart_daos_server(self, reformat=True):
+    def restart_daos_server(self, force=True):
         """Perform server stop and start.
 
         Args:
-            reformat (bool): always reformat storage, could be destructive.
+            force (bool): always reformat storage, could be destructive.
         """
         self.log.info("=Restart daos_server, server stop().")
         self.server_managers[0].stop()
@@ -33,7 +33,7 @@ class DaosServerTest(TestWithServers):
         self.log.info("=Restart daos_server, detect_format_ready().")
         self.server_managers[0].detect_format_ready()
         self.log.info("=Restart daos_server, dmg storage_format.")
-        self.server_managers[0].dmg.storage_format(reformat)
+        self.server_managers[0].dmg.storage_format(force)
         self.log.info("=Restart daos_server, detect_engine_start().")
         self.server_managers[0].detect_engine_start()
         self.log.info("=Restart daos_agent, stop")

--- a/src/tests/ftest/util/dmg_utils.py
+++ b/src/tests/ftest/util/dmg_utils.py
@@ -238,22 +238,19 @@ class DmgCommand(DmgCommandBase):
         # }
         return self._get_json_result(("storage", "scan"), verbose=verbose)
 
-    def storage_format(self, reformat=False, timeout=30, verbose=False,
-                       force=False):
+    def storage_format(self, force=False, timeout=30, verbose=False):
         """Get the result of the dmg storage format command.
 
         Args:
-            reformat (bool): always reformat storage, could be destructive.
+            force (bool): force storage format on a host, stopping any
+                running engines (CAUTION: destructive operation).
                 This will create control-plane related metadata i.e. superblock
                 file and reformat if the storage media is available and
-                formattable.
+                formattable.  Defaults to False
             timeout: seconds after which the format is considered a failure and
                 times out.
             verbose (bool): show results of each SCM & NVMe device format
                 operation.
-            force (bool, optional): force storage format on a host, stopping any
-                running engines (CAUTION: destructive operation). Defaults to
-                False.
 
         Returns:
             CmdResult: an avocado CmdResult object containing the dmg command
@@ -266,8 +263,7 @@ class DmgCommand(DmgCommandBase):
         saved_timeout = self.timeout
         self.timeout = timeout
         self._get_result(
-            ("storage", "format"), reformat=reformat, verbose=verbose,
-            force=force)
+            ("storage", "format"), force=force, verbose=verbose)
         self.timeout = saved_timeout
         return self.result
 

--- a/src/tests/ftest/util/dmg_utils_base.py
+++ b/src/tests/ftest/util/dmg_utils_base.py
@@ -381,7 +381,6 @@ class DmgCommandBase(YamlCommand):
                 """Create a dmg storage format command object."""
                 super().__init__("/run/dmg/storage/format/*", "format")
                 self.verbose = FormattedParameter("--verbose", False)
-                self.reformat = FormattedParameter("--reformat", False)
                 self.force = FormattedParameter("--force", False)
 
         class QuerySubCommand(CommandWithSubCommand):


### PR DESCRIPTION
Remove dmg storage format --reformat as it's been replaced by --force.
Replace already-formatted terminology with filesystem signature found.

Test-tag: pr daily_regression

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>