### PR TITLE
DAOS-9221 test: pass client variables in yaml

### DIFF
--- a/src/tests/ftest/aggregation/basic.yaml
+++ b/src/tests/ftest/aggregation/basic.yaml
@@ -21,6 +21,8 @@ container:
     type: POSIX
     control_method: daos
 ior:
+    env_vars:
+        - D_LOG_MASK=INFO
     client_processes:
         np_12:
             np: 12

--- a/src/tests/ftest/ior/intercept_basic.yaml
+++ b/src/tests/ftest/ior/intercept_basic.yaml
@@ -20,6 +20,8 @@ container:
     type: POSIX
     control_method: daos
 ior:
+    env_vars:
+        - D_LOG_MASK=INFO
     client_processes:
         np: 32
     test_file: testFile

--- a/src/tests/ftest/ior/intercept_messages.py
+++ b/src/tests/ftest/ior/intercept_messages.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 """
   (C) Copyright 2019-2022 Intel Corporation.
 
@@ -33,11 +32,10 @@ class IorInterceptMessages(IorTestBase):
 
         :avocado: tags=all,full_regression
         :avocado: tags=hw,small
-        :avocado: tags=daosio,dfuse,il,ior_intercept
-        :avocado: tags=ior_intercept_messages
+        :avocado: tags=daosio,dfuse,il,ior,ior_intercept
+        :avocado: tags=ior_intercept_messages,test_ior_intercept_messages
         """
-        d_il_report_value = self.params.get("value",
-                                            "/run/tests/D_IL_REPORT/*")
+        d_il_report_value = self.params.get("value", "/run/tests/D_IL_REPORT/*")
         intercept = os.path.join(self.prefix, 'lib64', 'libioil.so')
         summary_pattern = r"^\[libioil\] Performed [0-9]+ reads and [0-9]+ " \
                           "writes from [0-9]+ files*"
@@ -45,8 +43,6 @@ class IorInterceptMessages(IorTestBase):
         # Avoiding any impact to the rest of IOR test cases
         job_manager = self.get_ior_job_manager_command()
         env = self.ior_cmd.get_default_env(str(job_manager), self.client_log)
-        env['DD_MASK '] = 'all'
-        env['DD_SUBSYS'] = 'all'
 
         # D_IL_REPORT VALUES
         #     -1: All printed calls # This needs its own test case
@@ -60,20 +56,17 @@ class IorInterceptMessages(IorTestBase):
 
         # Summary
         match_summary_results = []
-        # pylint: disable=anomalous-backslash-in-string
 
         compiled_sp = re.compile(summary_pattern)
         expected_total_summaries = self.processes
 
         # Intercept
         match_intercept_results = []
-        intercept_pattern = "^\[libioil\] Intercepting write*"  # noqa: W605
+        intercept_pattern = r"^\[libioil\] Intercepting write*"
         compiled_ip = re.compile(intercept_pattern)
         expected_total_intercepts = self.processes * int(env['D_IL_REPORT'])
 
-        out = self.run_ior_with_pool(intercept=intercept,
-                                     fail_on_warning=False,
-                                     env=env)
+        out = self.run_ior_with_pool(intercept=intercept, fail_on_warning=False, env=env)
         # Check for libioil messages within stderr
         for line in out.stderr.decode("utf-8").splitlines():
 
@@ -86,7 +79,5 @@ class IorInterceptMessages(IorTestBase):
             if match:
                 match_summary_results.append(match)
 
-        self.assertEqual(len(match_intercept_results),
-                         expected_total_intercepts)
-        self.assertEqual(len(match_summary_results),
-                         expected_total_summaries)
+        self.assertEqual(len(match_intercept_results), expected_total_intercepts)
+        self.assertEqual(len(match_summary_results), expected_total_summaries)

--- a/src/tests/ftest/ior/intercept_messages.yaml
+++ b/src/tests/ftest/ior/intercept_messages.yaml
@@ -19,6 +19,10 @@ container:
     type: POSIX
     control_method: daos
 ior:
+    env_vars:
+        - D_LOG_MASK=INFO
+        - DD_MASK=all
+        - DD_SUBSYS=all
     api: POSIX
     client_processes:
       np_16:

--- a/src/tests/ftest/ior/intercept_multi_client.yaml
+++ b/src/tests/ftest/ior/intercept_multi_client.yaml
@@ -40,6 +40,8 @@ container:
     type: POSIX
     control_method: daos
 ior:
+    env_vars:
+        - D_LOG_MASK=INFO
     client_processes:
         np: 96
     test_file: testFile

--- a/src/tests/ftest/ior/intercept_verify_data_integrity.yaml
+++ b/src/tests/ftest/ior/intercept_verify_data_integrity.yaml
@@ -22,6 +22,8 @@ container:
     type: POSIX
     control_method: daos
 ior:
+    env_vars:
+        - D_LOG_MASK=INFO
     np: 24
     test_file: testFile
     repetitions: 1

--- a/src/tests/ftest/util/command_utils.py
+++ b/src/tests/ftest/util/command_utils.py
@@ -143,7 +143,7 @@ class ExecutableCommand(CommandWithParameters):
         """
         # Clear any previous run results
         self.result = None
-        command = self.__str__()
+        command = str(self)
         try:
             # Block until the command is complete or times out
             self.result = run_command(
@@ -196,7 +196,7 @@ class ExecutableCommand(CommandWithParameters):
         if self._process is None:
             # Start the job manager command as a subprocess
             kwargs = {
-                "cmd": self.__str__(),
+                "cmd": str(self),
                 "verbose": self.verbose,
                 "allow_output_check": "combined",
                 "shell": False,

--- a/src/tests/ftest/util/command_utils.py
+++ b/src/tests/ftest/util/command_utils.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 """
   (C) Copyright 2018-2022 Intel Corporation.
 
@@ -34,8 +33,7 @@ class ExecutableCommand(CommandWithParameters):
     # values from the standard output yielded by the method.
     METHOD_REGEX = {"run": r"(.*)"}
 
-    def __init__(self, namespace, command, path="", subprocess=False,
-                 check_results=None):
+    def __init__(self, namespace, command, path="", subprocess=False, check_results=None):
         """Create a ExecutableCommand object.
 
         Uses Avocado's utils.process module to run a command str provided.
@@ -58,7 +56,7 @@ class ExecutableCommand(CommandWithParameters):
         self.exit_status_exception = True
         self.output_check = "both"
         self.verbose = True
-        self.env = None
+        self.env = EnvironmentVariables()
         self.sudo = False
 
         # A list of environment variable names to set and export prior to
@@ -105,7 +103,7 @@ class ExecutableCommand(CommandWithParameters):
 
     @property
     def process(self):
-        """Getter for process attribute of the ExecutableCommand class."""
+        """Get the process attribute of the ExecutableCommand class."""
         return self._process
 
     @property
@@ -384,6 +382,19 @@ class ExecutableCommand(CommandWithParameters):
                 "No pattern regex defined for '{}()'".format(regex_method))
         return re.findall(self.METHOD_REGEX[regex_method], stdout)
 
+    def get_params(self, test):
+        """Get values for all of the command params from the yaml file.
+
+        Also gets env_vars from /run/client/* and self.namespace.
+
+        Args:
+            test (Test): avocado Test object
+        """
+        super().get_params(test)
+        for namespace in ['/run/client/*', self.namespace]:
+            if namespace is not None:
+                self.env.update_from_list(test.params.get("env_vars", namespace, []))
+
     def update_env_names(self, new_names):
         """Update environment variable names to export for the command.
 
@@ -408,7 +419,8 @@ class ExecutableCommand(CommandWithParameters):
                 values to export.
 
         """
-        env = EnvironmentVariables()
+        env = self.env.copy()
+        # Update with variables from the server manager
         for name in self._env_names:
             if name == "D_LOG_FILE":
                 if not log_file:

--- a/src/tests/ftest/util/command_utils_base.py
+++ b/src/tests/ftest/util/command_utils_base.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 """
   (C) Copyright 2020-2022 Intel Corporation.
 
@@ -673,6 +672,59 @@ class CommonConfig(YamlParameters):
 class EnvironmentVariables(dict):
     """Dictionary of environment variable keys and values."""
 
+    @classmethod
+    def from_list(cls, kv_list):
+        """Initialize from a list of key=value strings.
+
+        Compatible with output from EnvironmentVariables.to_list.
+
+        Args:
+            kv_list (list):  list of environment variable assignment (key=value) strings
+
+        Returns:
+            EnvironmentVariables: new object.
+        """
+        env = cls()
+        env.update_from_list(kv_list)
+        return env
+
+    def to_list(self):
+        """Convert to a list of environment variable assignments.
+
+        Returns:
+            list: a list of environment variable assignment (key=value) strings
+        """
+        return [
+            key if value is None else "{}={}".format(key, value)
+            for key, value in list(self.items())
+        ]
+
+    def update_from_list(self, kv_list):
+        """Update from a list of key=value strings.
+
+        Args:
+            kv_list (list):  list of environment variable assignment (key=value) strings
+        """
+        for kv in kv_list:
+            key, *value = kv.split('=')
+            self[key] = value[0] if value else None
+
+    def to_export_str(self, separator=";"):
+        """Convert to a command to export all the environment variables.
+
+        Args:
+            separator (str, optional): export command separator.
+                Defaults to ";".
+
+        Returns:
+            str: a string of export commands for each environment variable
+        """
+        export_list = ["export {}".format(export) for export in self.to_list()]
+        export_str = separator.join(export_list)
+        if export_str:
+            export_str = "".join([export_str, separator])
+        return export_str
+
     def copy(self):
         """Return a copy of this object.
 
@@ -681,35 +733,6 @@ class EnvironmentVariables(dict):
 
         """
         return EnvironmentVariables(self)
-
-    def get_list(self):
-        """Get a list of environment variable assignments.
-
-        Returns:
-            list: a list of environment variable assignment (key=value) strings
-
-        """
-        return [
-            key if value is None else "{}={}".format(key, value)
-            for key, value in list(self.items())
-        ]
-
-    def get_export_str(self, separator=";"):
-        """Get the command to export all of the environment variables.
-
-        Args:
-            separator (str, optional): export command separator.
-                Defaults to ";".
-
-        Returns:
-            str: a string of export commands for each environment variable
-
-        """
-        export_list = ["export {}".format(export) for export in self.get_list()]
-        export_str = separator.join(export_list)
-        if export_str:
-            export_str = "".join([export_str, separator])
-        return export_str
 
 
 class PositionalParameter(BasicParameter):

--- a/src/tests/ftest/util/daos_racer_utils.py
+++ b/src/tests/ftest/util/daos_racer_utils.py
@@ -112,10 +112,10 @@ class DaosRacerCommand(ExecutableCommand):
         # Run daos_racer on the specified host
         self.log.info(
             "Running %s on %s with %s timeout",
-            self.__str__(), self.host,
+            str(self), self.host,
             "no" if self.clush_timeout.value is None else
             "a {}s".format(self.clush_timeout.value))
-        return_codes = pcmd(self.host, self.__str__(), True, self.clush_timeout.value)
+        return_codes = pcmd(self.host, str(self), True, self.clush_timeout.value)
         if 0 not in return_codes or len(return_codes) > 1:
             # Kill the daos_racer process if the remote command timed out
             if 255 in return_codes:

--- a/src/tests/ftest/util/daos_racer_utils.py
+++ b/src/tests/ftest/util/daos_racer_utils.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 """
   (C) Copyright 2020-2022 Intel Corporation.
 
@@ -101,7 +100,7 @@ class DaosRacerCommand(ExecutableCommand):
                 names and values to export prior to running daos_racer
         """
         # Include exports prior to the daos_racer command
-        self._pre_command = env.get_export_str()
+        self._pre_command = env.to_export_str()
 
     def run(self):
         """Run the daos_racer command remotely.

--- a/src/tests/ftest/util/dfuse_utils.py
+++ b/src/tests/ftest/util/dfuse_utils.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 """
   (C) Copyright 2019-2022 Intel Corporation.
 
@@ -6,11 +5,11 @@
 """
 
 import time
+from ClusterShell.NodeSet import NodeSet
 
 from command_utils_base import FormattedParameter
 from exception_utils import CommandFailure
 from command_utils import ExecutableCommand
-from ClusterShell.NodeSet import NodeSet
 from general_utils import check_file_exists, pcmd
 
 
@@ -281,7 +280,7 @@ class Dfuse(DfuseCommand):
         self.create_mount_point()
 
         # run dfuse command
-        cmd = self.env.get_export_str()
+        cmd = self.env.to_export_str()
         if bind_cores:
             cmd += 'taskset -c {} '.format(bind_cores)
         cmd += str(self)

--- a/src/tests/ftest/util/ior_test_base.py
+++ b/src/tests/ftest/util/ior_test_base.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 """
 (C) Copyright 2018-2022 Intel Corporation.
 
@@ -256,14 +255,8 @@ class IorTestBase(DfuseTestBase):
             env = self.ior_cmd.get_default_env(str(manager), self.client_log)
         if intercept:
             env['LD_PRELOAD'] = intercept
-            if 'D_LOG_MASK' not in env:
-                env['D_LOG_MASK'] = 'INFO'
             if 'D_IL_REPORT' not in env:
                 env['D_IL_REPORT'] = '1'
-
-            # env['D_LOG_MASK'] = 'INFO,IL=DEBUG'
-            # env['DD_MASK'] = 'all'
-            # env['DD_SUBSYS'] = 'all'
         if plugin_path:
             env["HDF5_VOL_CONNECTOR"] = "daos"
             env["HDF5_PLUGIN_PATH"] = str(plugin_path)
@@ -323,13 +316,14 @@ class IorTestBase(DfuseTestBase):
                       str(self.job_manager))
 
         try:
-            out = self.job_manager.stop()
-            return out
+            return self.job_manager.stop()
         except CommandFailure as error:
             self.log.error("IOR stop Failed: %s", str(error))
             self.fail("Test was expected to pass but it failed.\n")
         finally:
             self.display_pool_space()
+
+        return None
 
     def run_ior_threads_il(self, results, intercept, with_clients,
                            without_clients):

--- a/src/tests/ftest/util/job_manager_utils.py
+++ b/src/tests/ftest/util/job_manager_utils.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 """
   (C) Copyright 2020-2022 Intel Corporation.
 
@@ -339,14 +338,12 @@ class Orterun(JobManager):
             # dictionary keys with the specified values or add new key value
             # pairs to the dictionary.  Finally convert the updated dictionary
             # back to a list for the parameter assignment.
-            original = EnvironmentVariables({
-                item.split("=")[0]: item.split("=")[1] if "=" in item else None
-                for item in self.export.value})
+            original = EnvironmentVariables.from_list(self.export.value)
             original.update(env_vars)
-            self.export.value = original.get_list()
+            self.export.value = original.to_list()
         else:
             # Overwrite the environmental variable assignment
-            self.export.value = env_vars.get_list()
+            self.export.value = env_vars.to_list()
 
     def assign_environment_default(self, env_vars):
         """Assign the default environment variables for the command.
@@ -355,7 +352,7 @@ class Orterun(JobManager):
             env_vars (EnvironmentVariables): the environment variables to
                 assign as the default
         """
-        self.export.update_default(env_vars.get_list())
+        self.export.update_default(env_vars.to_list())
 
     def run(self):
         """Run the orterun command.
@@ -446,10 +443,10 @@ class Mpirun(JobManager):
         # Pass the environment variables via the process.run method env argument
         if append and self.env is not None:
             # Update the existing dictionary with the new values
-            self.genv.update(env_vars.get_list())
+            self.genv.update(env_vars.to_list())
         else:
             # Overwrite/create the dictionary of environment variables
-            self.genv.update((EnvironmentVariables(env_vars)).get_list())
+            self.genv.update((EnvironmentVariables(env_vars)).to_list())
 
     def assign_environment_default(self, env_vars):
         """Assign the default environment variables for the command.
@@ -458,7 +455,7 @@ class Mpirun(JobManager):
             env_vars (EnvironmentVariables): the environment variables to
                 assign as the default
         """
-        self.genv.update_default(env_vars.get_list())
+        self.genv.update_default(env_vars.to_list())
 
     def run(self):
         """Run the mpirun command.
@@ -541,14 +538,12 @@ class Srun(JobManager):
             # dictionary keys with the specified values or add new key value
             # pairs to the dictionary.  Finally convert the updated dictionary
             # back to a string for the parameter assignment.
-            original = EnvironmentVariables({
-                item.split("=")[0]: item.split("=")[1] if "=" in item else None
-                for item in self.export.value.split(",")})
+            original = EnvironmentVariables.from_list(self.export.value.split(","))
             original.update(env_vars)
-            self.export.value = ",".join(original.get_list())
+            self.export.value = ",".join(original.to_list())
         else:
             # Overwrite the environmental variable assignment
-            self.export.value = ",".join(env_vars.get_list())
+            self.export.value = ",".join(env_vars.to_list())
 
     def assign_environment_default(self, env_vars):
         """Assign the default environment variables for the command.
@@ -557,7 +552,7 @@ class Srun(JobManager):
             env_vars (EnvironmentVariables): the environment variables to
                 assign as the default
         """
-        self.export.update_default(env_vars.get_list())
+        self.export.update_default(env_vars.to_list())
 
 
 class Systemctl(JobManager):

--- a/src/tests/ftest/util/job_manager_utils.py
+++ b/src/tests/ftest/util/job_manager_utils.py
@@ -736,19 +736,19 @@ class Systemctl(JobManager):
         """
         self._systemctl.unit_command.value = command
         self.timestamps[command] = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-        result = pcmd(self._hosts, self.__str__(), self.verbose, self.timeout)
+        result = pcmd(self._hosts, str(self), self.verbose, self.timeout)
         if 255 in result:
             raise CommandFailure(
                 "Timeout detected running '{}' with a {}s timeout on {}".format(
-                    self.__str__(), self.timeout, NodeSet.fromlist(result[255])))
+                    str(self), self.timeout, NodeSet.fromlist(result[255])))
 
         if 0 not in result or len(result) > 1:
             failed = []
             for item, value in list(result.items()):
                 if item != 0:
                     failed.extend(value)
-            raise CommandFailure("Error occurred running '{}' on {}".format(
-                self.__str__(), NodeSet.fromlist(failed)))
+            raise CommandFailure(
+                "Error occurred running '{}' on {}".format(str(self), NodeSet.fromlist(failed)))
         return result
 
     def _report_unit_command(self, command):
@@ -854,8 +854,7 @@ class Systemctl(JobManager):
         states = {}
         valid_states = ["active", "activating"]
         self._systemctl.unit_command.value = "is-active"
-        results = run_pcmd(
-            self._hosts, self.__str__(), False, self.timeout, None)
+        results = run_pcmd(self._hosts, str(self), False, self.timeout, None)
         for result in results:
             if result["interrupted"]:
                 states["timeout"] = result["hosts"]

--- a/utils/cq/words.dict
+++ b/utils/cq/words.dict
@@ -160,6 +160,7 @@ enum
 env
 environ
 epcrange
+errored
 ethernet
 fchmod
 fcntl
@@ -373,12 +374,14 @@ stripesize
 struct
 su
 subcommand
+subcommands
 subdir
 subdirectories
 subdirectory
 sublicense
 submodules
 subprocess
+substring
 subtest
 sudo
 superblock
@@ -389,6 +392,7 @@ symlinks
 sys
 systemctl
 systemd
+taskset
 tcp
 teardown
 teardowns


### PR DESCRIPTION
Test-tag: pr daily_regression ior_intercept aggregatebasic daos_racer daosracer
Skip-unit-tests: true
Skip-fault-injection-test: true

Support passing client env_vars in test yamls. These can be specified at
a global level under `client/env_vars`, or a per-cmd level as
`<cmd>/env_vars`.
This is currently supported by any command inheriting from
ExecutableCommand. Conservatively, only a subset of tests are initially
updated.

- Refactor EnvironmentVariables
  - add bi-directional to_list and from_list
  - add bi-directional to_export_str and from_export_str

- Update IOR tests using D_LOG_MASK to instead pass in the yaml.

Signed-off-by: Dalton Bohning <dalton.bohning@intel.com>