### PR TITLE
DAOS-10194 control: Fix forced PoolDestroy flow (#8598)

### DIFF
--- a/src/control/common/test_utils.go
+++ b/src/control/common/test_utils.go
@@ -15,9 +15,11 @@ import (
 	"reflect"
 	"sort"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"golang.org/x/sys/unix"
 	"google.golang.org/protobuf/testing/protocmp"
 )
@@ -165,6 +167,7 @@ func ShowBufferOnFailure(t *testing.T, buf fmt.Stringer) {
 // DefaultCmpOpts gets default go-cmp comparison options for tests.
 func DefaultCmpOpts() []cmp.Option {
 	return []cmp.Option{
+		cmpopts.IgnoreTypes(sync.Mutex{}, sync.RWMutex{}),
 		protocmp.Transform(), // makes Protobuf structs comparable
 	}
 }

--- a/src/control/server/mgmt_pool.go
+++ b/src/control/server/mgmt_pool.go
@@ -516,18 +516,20 @@ func (svc *mgmtSvc) PoolDestroy(ctx context.Context, req *mgmtpb.PoolDestroyReq)
 		ds := drpc.DaosStatus(evresp.Status)
 		svc.log.Debugf("MgmtSvc.PoolDestroy drpc.MethodPoolEvict, evresp:%+v\n", evresp)
 
-		// Transition pool state (unless evict returned busy, and not force destroying).
-		if !(ds == drpc.DaosBusy && !req.Force) {
-			ps.State = system.PoolServiceStateDestroying
-			if err := svc.sysdb.UpdatePoolService(ps); err != nil {
-				return nil, errors.Wrapf(err, "failed to update pool %s", uuid)
-			}
-		}
-
 		// If the destroy request is being forced, we should additionally zap the label
 		// so the entry doesn't prevent a new pool with the same label from being created.
 		if req.Force {
 			ps.PoolLabel = ""
+		}
+
+		// If the request is being forced, or the evict request did not fail
+		// due to the pool being busy, then transition to the destroying state
+		// and persist the update(s).
+		if req.Force || ds != drpc.DaosBusy {
+			ps.State = system.PoolServiceStateDestroying
+			if err := svc.sysdb.UpdatePoolService(ps); err != nil {
+				return nil, errors.Wrapf(err, "failed to update pool %s", uuid)
+			}
 		}
 
 		if ds != drpc.DaosSuccess {

--- a/src/control/server/mgmt_pool_test.go
+++ b/src/control/server/mgmt_pool_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/dustin/go-humanize"
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	uuid "github.com/google/uuid"
 	"github.com/pkg/errors"
 	"google.golang.org/protobuf/proto"
@@ -569,15 +570,25 @@ func TestServer_MgmtSvc_PoolDestroy(t *testing.T) {
 	missingSB.harness.instances[0].(*EngineInstance)._superblock = nil
 	notAP := newTestMgmtSvc(t, testLog)
 	testPoolService := &system.PoolService{
-		PoolUUID: uuid.MustParse(mockUUID),
-		Replicas: []system.Rank{0, 1, 2},
-		State:    system.PoolServiceStateReady,
+		PoolLabel: "test-pool",
+		PoolUUID:  uuid.MustParse(mockUUID),
+		Replicas:  []system.Rank{0, 1, 2},
+		State:     system.PoolServiceStateReady,
 		Storage: &system.PoolServiceStorage{
 			CreationRankStr: system.MustCreateRankSet("0-7").String(),
 		},
 	}
-	stateAddr := func(s system.PoolServiceState) *system.PoolServiceState {
-		return &s
+	svcWithLabel := func(in *system.PoolService, label string) (out *system.PoolService) {
+		out = new(system.PoolService)
+		*out = *in
+		out.PoolLabel = label
+		return
+	}
+	svcWithState := func(in *system.PoolService, state system.PoolServiceState) (out *system.PoolService) {
+		out = new(system.PoolService)
+		*out = *in
+		out.State = state
+		return
 	}
 
 	// Note: PoolDestroy will invoke one or two dRPCs (evict, evict+destroy)
@@ -590,7 +601,7 @@ func TestServer_MgmtSvc_PoolDestroy(t *testing.T) {
 		expDrpcEvReq  *mgmtpb.PoolEvictReq
 		expDrpcReq    *mgmtpb.PoolDestroyReq
 		expResp       *mgmtpb.PoolDestroyResp
-		expSvcState   *system.PoolServiceState
+		expSvc        *system.PoolService
 		expErr        error
 	}{
 		"nil request": {
@@ -646,7 +657,7 @@ func TestServer_MgmtSvc_PoolDestroy(t *testing.T) {
 			expResp: &mgmtpb.PoolDestroyResp{
 				Status: int32(drpc.DaosBusy),
 			},
-			expSvcState: stateAddr(system.PoolServiceStateReady),
+			expSvc: testPoolService,
 		},
 		"evict dRPC fails due to engine error": {
 			req: &mgmtpb.PoolDestroyReq{Id: mockUUID},
@@ -665,7 +676,7 @@ func TestServer_MgmtSvc_PoolDestroy(t *testing.T) {
 			expResp: &mgmtpb.PoolDestroyResp{
 				Status: int32(drpc.DaosMiscError),
 			},
-			expSvcState: stateAddr(system.PoolServiceStateDestroying),
+			expSvc: svcWithState(testPoolService, system.PoolServiceStateDestroying),
 		},
 		"force=true, evict dRPC fails due to engine error": {
 			req: &mgmtpb.PoolDestroyReq{Id: mockUUID, Force: true},
@@ -684,7 +695,7 @@ func TestServer_MgmtSvc_PoolDestroy(t *testing.T) {
 			expResp: &mgmtpb.PoolDestroyResp{
 				Status: int32(drpc.DaosMiscError),
 			},
-			expSvcState: stateAddr(system.PoolServiceStateDestroying),
+			expSvc: svcWithLabel(svcWithState(testPoolService, system.PoolServiceStateDestroying), ""),
 		},
 		"already destroying, destroy dRPC fails due to engine error": {
 			req: &mgmtpb.PoolDestroyReq{Id: mockUUID},
@@ -698,17 +709,11 @@ func TestServer_MgmtSvc_PoolDestroy(t *testing.T) {
 					Status: int32(drpc.DaosMiscError),
 				}, nil)
 			},
-			poolSvc: &system.PoolService{
-				PoolUUID: uuid.MustParse(mockUUID),
-				Replicas: []system.Rank{0, 1, 2},
-				State:    system.PoolServiceStateDestroying,
-				Storage: &system.PoolServiceStorage{
-					CreationRankStr: system.MustCreateRankSet("0-7").String(),
-				},
-			},
+			poolSvc: svcWithState(testPoolService, system.PoolServiceStateDestroying),
 			expResp: &mgmtpb.PoolDestroyResp{
 				Status: int32(drpc.DaosMiscError),
 			},
+			expSvc: svcWithState(testPoolService, system.PoolServiceStateDestroying),
 		},
 		"force=true already destroying, destroy dRPC fails due to engine error": {
 			req: &mgmtpb.PoolDestroyReq{Id: mockUUID, Force: true},
@@ -723,17 +728,11 @@ func TestServer_MgmtSvc_PoolDestroy(t *testing.T) {
 					Status: int32(drpc.DaosMiscError),
 				}, nil)
 			},
-			poolSvc: &system.PoolService{
-				PoolUUID: uuid.MustParse(mockUUID),
-				Replicas: []system.Rank{0, 1, 2},
-				State:    system.PoolServiceStateDestroying,
-				Storage: &system.PoolServiceStorage{
-					CreationRankStr: system.MustCreateRankSet("0-7").String(),
-				},
-			},
+			poolSvc: svcWithState(testPoolService, system.PoolServiceStateDestroying),
 			expResp: &mgmtpb.PoolDestroyResp{
 				Status: int32(drpc.DaosMiscError),
 			},
+			expSvc: svcWithState(testPoolService, system.PoolServiceStateDestroying),
 		},
 		"evict dRPC fails with -DER_NOTLEADER on first try": {
 			req: &mgmtpb.PoolDestroyReq{Id: mockUUID},
@@ -752,7 +751,7 @@ func TestServer_MgmtSvc_PoolDestroy(t *testing.T) {
 			expResp: &mgmtpb.PoolDestroyResp{
 				Status: int32(drpc.DaosNotLeader),
 			},
-			expSvcState: stateAddr(system.PoolServiceStateDestroying),
+			expSvc: svcWithState(testPoolService, system.PoolServiceStateDestroying),
 		},
 		// Note: expect PoolDestroy() converts to successful status in this case
 		"already destroying, destroy dRPC fails with -DER_NOTLEADER in cleanup": {
@@ -767,14 +766,7 @@ func TestServer_MgmtSvc_PoolDestroy(t *testing.T) {
 					Status: int32(drpc.DaosNotLeader),
 				}, nil)
 			},
-			poolSvc: &system.PoolService{
-				PoolUUID: uuid.MustParse(mockUUID),
-				Replicas: []system.Rank{0, 1, 2},
-				State:    system.PoolServiceStateDestroying,
-				Storage: &system.PoolServiceStorage{
-					CreationRankStr: system.MustCreateRankSet("0-7").String(),
-				},
-			},
+			poolSvc: svcWithState(testPoolService, system.PoolServiceStateDestroying),
 			expResp: &mgmtpb.PoolDestroyResp{},
 		},
 		"evict dRPC fails with -DER_NOTREPLICA on first try": {
@@ -794,7 +786,7 @@ func TestServer_MgmtSvc_PoolDestroy(t *testing.T) {
 			expResp: &mgmtpb.PoolDestroyResp{
 				Status: int32(drpc.DaosNotReplica),
 			},
-			expSvcState: stateAddr(system.PoolServiceStateDestroying),
+			expSvc: svcWithState(testPoolService, system.PoolServiceStateDestroying),
 		},
 		// Note: expect PoolDestroy() converts to successful status in this case
 		"already destroying, destroy dRPC fails with -DER_NOTREPLICA in cleanup": {
@@ -809,14 +801,7 @@ func TestServer_MgmtSvc_PoolDestroy(t *testing.T) {
 					Status: int32(drpc.DaosNotReplica),
 				}, nil)
 			},
-			poolSvc: &system.PoolService{
-				PoolUUID: uuid.MustParse(mockUUID),
-				Replicas: []system.Rank{0, 1, 2},
-				State:    system.PoolServiceStateDestroying,
-				Storage: &system.PoolServiceStorage{
-					CreationRankStr: system.MustCreateRankSet("0-7").String(),
-				},
-			},
+			poolSvc: svcWithState(testPoolService, system.PoolServiceStateDestroying),
 			expResp: &mgmtpb.PoolDestroyResp{},
 		},
 		"already destroying, destroy dRPC succeeds": {
@@ -827,14 +812,7 @@ func TestServer_MgmtSvc_PoolDestroy(t *testing.T) {
 				SvcRanks: []uint32{0, 1, 2, 3, 4, 5, 6, 7},
 			},
 			expResp: &mgmtpb.PoolDestroyResp{},
-			poolSvc: &system.PoolService{
-				PoolUUID: uuid.MustParse(mockUUID),
-				Replicas: []system.Rank{0, 1, 2},
-				State:    system.PoolServiceStateDestroying,
-				Storage: &system.PoolServiceStorage{
-					CreationRankStr: system.MustCreateRankSet("0-7").String(),
-				},
-			},
+			poolSvc: svcWithState(testPoolService, system.PoolServiceStateDestroying),
 		},
 		// Note: PoolDestroy() is going to run both evict and destroy dRPCs each of which will succeed
 		"successful destroy": {
@@ -890,19 +868,26 @@ func TestServer_MgmtSvc_PoolDestroy(t *testing.T) {
 				return
 			}
 
-			cmpOpts := common.DefaultCmpOpts()
+			cmpOpts := append(
+				common.DefaultCmpOpts(),
+				cmpopts.IgnoreTypes(system.PoolServiceStorage{}),
+				cmpopts.IgnoreFields(system.PoolService{}, "LastUpdate"),
+			)
 			if diff := cmp.Diff(tc.expResp, gotResp, cmpOpts...); diff != "" {
 				t.Fatalf("unexpected response (-want, +got)\n%s\n", diff)
 			}
 
-			if tc.expSvcState != nil {
-				ps, err := tc.mgmtSvc.sysdb.FindPoolServiceByUUID(uuid.MustParse(mockUUID))
-				if err != nil {
-					t.Fatal(err)
+			gotSvc, err := tc.mgmtSvc.sysdb.FindPoolServiceByUUID(uuid.MustParse(mockUUID))
+			if err != nil {
+				if tc.expSvc != nil || !system.IsPoolNotFound(err) {
+					t.Fatalf("unexpected error: %v", err)
 				}
-				if diff := cmp.Diff(*tc.expSvcState, ps.State); diff != "" {
-					t.Fatalf("unexpected ps state (-want, +got):\n%s\n", diff)
-				}
+			}
+			if tc.expSvc == nil && gotSvc != nil {
+				t.Fatalf("expected pool to be destroyed, but found %+v", gotSvc)
+			}
+			if diff := cmp.Diff(tc.expSvc, gotSvc, cmpOpts...); diff != "" {
+				t.Fatalf("unexpected ending PS values (-want, +got)\n%s\n", diff)
 			}
 
 			if tc.expDrpcReq != nil {


### PR DESCRIPTION
The PoolDestroy RPC handler's behavior was changed slightly
with the result that a forced destroy could sometimes fail
to zap the label on the existing pool service. This could
lead to confusing behavior when the admin tries to create a
new pool with the same label.

Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com>