### PR TITLE
DAOS-10250: show all rank states of a pool

### DIFF
--- a/src/control/cmd/dmg/pool.go
+++ b/src/control/cmd/dmg/pool.go
@@ -497,8 +497,8 @@ func (cmd *PoolReintegrateCmd) Execute(args []string) error {
 // PoolQueryCmd is the struct representing the command to query a DAOS pool.
 type PoolQueryCmd struct {
 	poolCmd
-	ShowEnabledRanks  bool `long:"show-enabled-ranks" description:"Show engine unique identifiers (ranks) which are enabled"`
-	ShowDisabledRanks bool `long:"show-disabled-ranks" description:"Show engine unique identifiers (ranks) which are disabled"`
+	ShowEnabledRanks  bool `short:"e" long:"show-enabled" description:"Show engine unique identifiers (ranks) which are enabled"`
+	ShowDisabledRanks bool `short:"b" long:"show-disabled" description:"Show engine unique identifiers (ranks) which are disabled"`
 }
 
 // Execute is run when PoolQueryCmd subcommand is activated
@@ -507,7 +507,7 @@ func (cmd *PoolQueryCmd) Execute(args []string) error {
 		ID: cmd.PoolID().String(),
 	}
 
-	// TODO: The two options should not be incompatible (i.e. engine limitation)
+	// TODO (DAOS-10250) The two options should not be incompatible (i.e. engine limitation)
 	if cmd.ShowEnabledRanks && cmd.ShowDisabledRanks {
 		return errIncompatFlags("show-enabled-ranks", "show-disabled-ranks")
 	}

--- a/src/control/cmd/dmg/pool_test.go
+++ b/src/control/cmd/dmg/pool_test.go
@@ -759,7 +759,18 @@ func TestPoolCommands(t *testing.T) {
 		},
 		{
 			"Query pool with UUID and enabled ranks",
-			"pool query --show-enabled-ranks 12345678-1234-1234-1234-1234567890ab",
+			"pool query --show-enabled 12345678-1234-1234-1234-1234567890ab",
+			strings.Join([]string{
+				printRequest(t, &control.PoolQueryReq{
+					ID:                  "12345678-1234-1234-1234-1234567890ab",
+					IncludeEnabledRanks: true,
+				}),
+			}, " "),
+			nil,
+		},
+		{
+			"Query pool with UUID and enabled ranks",
+			"pool query -e 12345678-1234-1234-1234-1234567890ab",
 			strings.Join([]string{
 				printRequest(t, &control.PoolQueryReq{
 					ID:                  "12345678-1234-1234-1234-1234567890ab",
@@ -770,7 +781,18 @@ func TestPoolCommands(t *testing.T) {
 		},
 		{
 			"Query pool with UUID and disabled ranks",
-			"pool query --show-disabled-ranks 12345678-1234-1234-1234-1234567890ab",
+			"pool query --show-disabled 12345678-1234-1234-1234-1234567890ab",
+			strings.Join([]string{
+				printRequest(t, &control.PoolQueryReq{
+					ID:                   "12345678-1234-1234-1234-1234567890ab",
+					IncludeDisabledRanks: true,
+				}),
+			}, " "),
+			nil,
+		},
+		{
+			"Query pool with UUID and disabled ranks",
+			"pool query -b 12345678-1234-1234-1234-1234567890ab",
 			strings.Join([]string{
 				printRequest(t, &control.PoolQueryReq{
 					ID:                   "12345678-1234-1234-1234-1234567890ab",
@@ -813,7 +835,7 @@ func TestPoolCommands(t *testing.T) {
 		},
 		{
 			"Query pool with incompatible arguments",
-			"pool query --show-disabled-ranks --show-enabled-ranks 12345678-1234-1234-1234-1234567890ab",
+			"pool query --show-disabled --show-enabled 12345678-1234-1234-1234-1234567890ab",
 			"",
 			errors.New("may not be mixed"),
 		},

--- a/src/gurt/misc.c
+++ b/src/gurt/misc.c
@@ -611,6 +611,7 @@ d_rank_range_list_realloc(d_rank_range_list_t *range_list, uint32_t size)
 	return range_list;
 }
 
+/* TODO (DAOS-10253) Add unit tests for this function */
 d_rank_range_list_t *
 d_rank_range_list_create_from_ranks(d_rank_list_t *rank_list)
 {
@@ -656,6 +657,7 @@ d_rank_range_list_create_from_ranks(d_rank_list_t *rank_list)
 	return range_list;
 }
 
+/* TODO (DAOS-10253) Add unit tests for this function */
 char *
 d_rank_range_list_str(d_rank_range_list_t *list, bool *truncated)
 {

--- a/src/mgmt/srv_drpc.c
+++ b/src/mgmt/srv_drpc.c
@@ -1675,7 +1675,7 @@ ds_mgmt_drpc_pool_query(Drpc__Call *drpc_req, Drpc__Response *drpc_resp)
 	if (svc_ranks == NULL)
 		D_GOTO(out, rc = -DER_NOMEM);
 
-	/* TODO: Enabled and disabled engines should be retrieve both if needed */
+	/* TODO (DAOS-10250) Enabled and disabled engines should be retrieve both if needed */
 	pool_info.pi_bits = req->include_enabled_ranks ? DPI_ALL : (DPI_ALL & ~DPI_ENGINES_ENABLED);
 	rc = ds_mgmt_pool_query(uuid, svc_ranks, &ranks, &pool_info);
 	if (rc != 0) {


### PR DESCRIPTION
# Description

Engine can only retrieve enabled or disabled ranks with the `ds_mgmt_pool_query()` function. This function should be updated to be able get the two lists with the same query and allow dmg to print this information with only one drpc pool query transaction.

The default behavior should also be changed in the following way:

* if there are 0 disabled targets, show Enabled ranks: <ranklist>

* if there are > 0 disabled targets, show Disabled ranks: <ranklist>

Last comments of the reviewers with the PR [DAOS-10072: add ranks state to pool query by knard-intel · Pull Request #8587 · daos-stack/daos](https://github.com/daos-stack/daos/pull/8587) should also be fixed.