### PR TITLE
DAOS-9671 nlt: use os.read() vs file.read() in cont_rw

### DIFF
--- a/utils/node_local_test.py
+++ b/utils/node_local_test.py
@@ -2334,9 +2334,16 @@ class posix_tests():
         os.close(fd)
         print(ps)
 
-        with open(join(dfuse.dir, 'rw_dir', 'new_file'), 'r') as fd:
-            data = fd.read()
-            print(data)
+        fd = os.open(testfile, os.O_RDONLY)
+        # previous code was using stream/file methods and it appears that
+        # file.read() (no size) is doing a fstat() and reads size + 1
+        stat = os.fstat(fd)
+        bytes = os.read(fd, stat.st_size + 1)
+        assert bytes == b'read-only-data'
+        data = bytes.decode('utf-8', 'ignore')
+        assert data == 'read-only-data'
+        print(data)
+        os.close(fd)
 
         if dfuse.stop():
             self.fatal_errors = True


### PR DESCRIPTION
For some still not fully explained reasons, NLT cont_rw()
test is failing frequently due to garbage being read from
newly created file which triggers Unicode encoding errors.
Doing some testing iit seems that using basic os.read()
method versus file.read() is a workaround.
Also adding an assert to verify datas and not only via
Unicode codec.

Change-Id: I866f43467f32c31c154e79e4f7fc1f16446db0bd
Signed-off-by: Bruno Faccini <bruno.faccini@intel.com>