### PR TITLE
DAOS-10256 control: Allow ucx+dc_x provider (#8636)

### DIFF
--- a/src/control/lib/hardware/ucx/ucx.go
+++ b/src/control/lib/hardware/ucx/ucx.go
@@ -158,7 +158,7 @@ func (p *Provider) getProviderSet(transport string) common.StringSet {
 }
 
 func shouldAddGeneric(transport string) bool {
-	genericTransportAliases := []string{"rc", "ud"}
+	genericTransportAliases := []string{"rc", "ud", "dc"}
 	for _, alias := range genericTransportAliases {
 		if strings.HasPrefix(transport, alias+"_") {
 			return true
@@ -178,9 +178,6 @@ func transportToDAOSProvider(transport string) string {
 	// UCX transport aliases:
 	// https://openucx.readthedocs.io/en/master/faq.html#list-of-main-transports-and-aliases
 	switch {
-	case transportPieces[0] == "dc":
-		// trim suffix from dc
-		transportPieces = transportPieces[:1]
 	case transportPieces[1] == "verbs":
 		transportPieces[1] = "v"
 	case strings.HasPrefix(transportPieces[1], "mlx"):

--- a/src/control/lib/hardware/ucx/ucx_test.go
+++ b/src/control/lib/hardware/ucx/ucx_test.go
@@ -51,7 +51,7 @@ func TestUCX_Provider_getProviderSet(t *testing.T) {
 	}{
 		"dc": {
 			in:     "dc_mlx5",
-			expSet: common.NewStringSet("ucx+dc"),
+			expSet: common.NewStringSet("ucx+dc_x", "ucx+dc"),
 		},
 		"tcp": {
 			in:     "tcp",
@@ -102,8 +102,12 @@ func TestUCX_transportToDAOSProvider(t *testing.T) {
 			in:  "ud_mlx5",
 			exp: "ucx+ud_x",
 		},
+		"dc_mlx5": {
+			in:  "dc_mlx5",
+			exp: "ucx+dc_x",
+		},
 		"dc": {
-			in:  "dc_something",
+			in:  "dc",
 			exp: "ucx+dc",
 		},
 		"tcp": {


### PR DESCRIPTION
We were previously accepting only the ucx+dc alias. ucx+dc_x is
also valid.

Signed-off-by: Kris Jacque <kristin.jacque@intel.com>