### PR TITLE
DAOS-8052 agent: Add disable_caching option to config (#8629)

### DIFF
--- a/docs/admin/performance_tuning.md
+++ b/docs/admin/performance_tuning.md
@@ -460,17 +460,13 @@ into the configuration problem.
 
 The default configuration enables the Agent GetAttachInfo cache.  If it is
 desired, the cache may be disabled prior to DAOS Agent startup by setting the
-Agent's environment variable `DAOS_AGENT_DISABLE_CACHE=true`.  The cache is
-loaded only at Agent startup. The following debug message will be found in the
-Agent's log:
-```
-GetAttachInfo agent caching has been disabled
-```
+Agent's environment variable `DAOS_AGENT_DISABLE_CACHE=true` or updating the
+Agent configuration file with `disable_caching: true`.
 
-If the network configuration changes while the Agent is running, it must be
-restarted to gain visibility to these changes. For additional information,
-please refer to the [System Deployment: Agent Startup][6] documentation
-section.
+If the network configuration changes while the Agent is running, and the cache
+is enabled, the Agent must be restarted to gain visibility to these changes.
+For additional information, please refer to the
+[System Deployment: Agent Startup][6] documentation section.
 
 [1]: <https://github.com/daos-stack/daos/blob/release/2.2/src/cart#readme> (Collective and RPC Transport)
 [2]: <installation.md#distribution-packages> (DAOS distribution packages)

--- a/src/control/cmd/daos_agent/config.go
+++ b/src/control/cmd/daos_agent/config.go
@@ -33,6 +33,7 @@ type Config struct {
 	LogFile          string                    `yaml:"log_file"`
 	LogLevel         common.ControlLogLevel    `yaml:"control_log_mask,omitempty"`
 	TransportConfig  *security.TransportConfig `yaml:"transport_config"`
+	DisableCache     bool                      `yaml:"disable_caching,omitempty"`
 	FabricInterfaces []*NUMAFabricConfig       `yaml:"fabric_ifaces,omitempty"`
 }
 

--- a/src/control/cmd/daos_agent/config_test.go
+++ b/src/control/cmd/daos_agent/config_test.go
@@ -41,6 +41,7 @@ port: 4242
 runtime_dir: /tmp/runtime
 log_file: /home/frodo/logfile
 control_log_mask: debug
+disable_caching: true
 transport_config:
   allow_insecure: true
 fabric_ifaces:
@@ -123,6 +124,7 @@ transport_config:
 				RuntimeDir:   "/tmp/runtime",
 				LogFile:      "/home/frodo/logfile",
 				LogLevel:     common.ControlLogLevelDebug,
+				DisableCache: true,
 				TransportConfig: &security.TransportConfig{
 					AllowInsecure:     true,
 					CertificateConfig: DefaultConfig().TransportConfig.CertificateConfig,

--- a/src/control/cmd/daos_agent/start.go
+++ b/src/control/cmd/daos_agent/start.go
@@ -45,14 +45,14 @@ func (cmd *startCmd) Execute(_ []string) error {
 		return err
 	}
 
-	aicEnabled := (os.Getenv("DAOS_AGENT_DISABLE_CACHE") != "true")
+	aicEnabled := !cmd.attachInfoCacheDisabled()
 	if !aicEnabled {
-		cmd.log.Debugf("GetAttachInfo agent caching has been disabled\n")
+		cmd.log.Debugf("GetAttachInfo agent caching has been disabled")
 	}
 
-	ficEnabled := (os.Getenv("DAOS_AGENT_DISABLE_OFI_CACHE") != "true")
+	ficEnabled := !cmd.fabricCacheDisabled()
 	if !ficEnabled {
-		cmd.log.Debugf("Local fabric interface caching has been disabled\n")
+		cmd.log.Debugf("Local fabric interface caching has been disabled")
 	}
 
 	hwprovFini, err := hwprov.Init(cmd.log)
@@ -126,4 +126,12 @@ func (cmd *startCmd) Execute(_ []string) error {
 
 	cmd.log.Debugf("shutdown complete in %s", time.Since(shutdownRcvd))
 	return nil
+}
+
+func (cmd *startCmd) attachInfoCacheDisabled() bool {
+	return cmd.cfg.DisableCache || os.Getenv("DAOS_AGENT_DISABLE_CACHE") == "true"
+}
+
+func (cmd *startCmd) fabricCacheDisabled() bool {
+	return cmd.cfg.DisableCache || os.Getenv("DAOS_AGENT_DISABLE_OFI_CACHE") == "true"
 }

--- a/utils/config/daos_agent.yml
+++ b/utils/config/daos_agent.yml
@@ -60,6 +60,13 @@
 ## default: INFO
 #control_log_mask: DEBUG
 
+## Disable the agent's internal caches. If set to true, the agent will query the
+## server access point and local hardware data every time a client requests
+## rank connection information.
+#
+## default: false
+#disable_caching: true
+
 # Manually define the fabric interfaces and domains to be used by the agent,
 # organized by NUMA node.
 # If not defined, the agent will automatically detect all fabric interfaces and


### PR DESCRIPTION
A new daos_agent configuration option, disable_caching, can be used
to avoid caching the GetAttachInfo response and local fabric hardware
details when clients request engine URIs. If disable_caching is set to
true, the agent will query the access point and rescan the hardware
every time a client requests the URIs.

Signed-off-by: Kris Jacque <kristin.jacque@intel.com>