### PR TITLE
DAOS_9562 test: Support VMD clusters w/ non-Optane NVMes (#8571)

### DIFF
--- a/ftest.sh
+++ b/ftest.sh
@@ -60,7 +60,7 @@ LAUNCH_OPT_ARGS="${3:-}"
 
 # Add the missing '--nvme' argument identifier for backwards compatibility with
 # the 'auto:Optane' optional argument specified without the identifier.
-if [[ "${LAUNCH_OPT_ARGS}" == "auto:Optane" ]]; then
+if [[ "${LAUNCH_OPT_ARGS}" == "auto:-3DNAND" ]]; then
     LAUNCH_OPT_ARGS="--nvme=${LAUNCH_OPT_ARGS}"
 fi
 

--- a/src/tests/ftest/launch.py
+++ b/src/tests/ftest/launch.py
@@ -864,7 +864,9 @@ def auto_detect_devices(host_list, device_type, length, device_filter=None):
             "/sbin/lspci -D",
             "grep -E '^[0-9a-f]{{{0}}}:[0-9a-f]{{2}}:[0-9a-f]{{2}}.[0-9a-f] '".format(length),
             "grep -E 'Non-Volatile memory controller:'"]
-        if device_filter:
+        if device_filter and device_filter.startswith("-"):
+            command_list.append("grep -v '{}'".format(device_filter[1:]))
+        elif device_filter:
             command_list.append("grep '{}'".format(device_filter))
     else:
         print("ERROR: Invalid 'device_type' for NVMe/VMD auto-detection: {}".format(device_type))


### PR DESCRIPTION
Adding support for an updated default launch.py --nvme=auto:-3DNAND
argument to support inverted matching for newer clusters in CI.

Signed-off-by: Phillip Henderson <phillip.henderson@intel.com>