### PR TITLE
daos-10209 pipeline: freeing allocated structs

### DIFF
--- a/src/include/daos_pipeline.h
+++ b/src/include/daos_pipeline.h
@@ -238,6 +238,16 @@ int
 daos_pipeline_check(daos_pipeline_t *pipeline);
 
 /**
+ * Frees all memory allocated by DAOS for the pipeline during construction. More specifically, it
+ * frees memory for filter and filter_part objects created during calls to \a daos_filter_add() and
+ * \a daos_pipeline_add().
+ *
+ * \param[in,out]	pipeline	Pipeline object.
+ */
+void
+daos_pipeline_free(daos_pipeline_t *pipeline);
+
+/**
  * Runs a pipeline on DAOS, returning objects and/or aggregated results.
  *
  * \params[in]		coh		Container open handle.

--- a/src/tests/pipeline_common.c
+++ b/src/tests/pipeline_common.c
@@ -2,36 +2,31 @@
 #include "pipeline_common.h"
 
 static void
-free_filters(daos_filter_t **filters, uint32_t num_filters)
+free_filter_data(daos_filter_t **filters, uint32_t nfilters)
 {
-	uint32_t            i, j, k;
-	daos_filter_t      *filter;
-	daos_filter_part_t *part;
+	uint32_t i, j, k;
 
-	for (i = 0; i < num_filters; i++) {
-		filter = filters[i];
-		free(filter->filter_type.iov_buf);
-		for (j = 0; j < filter->num_parts; j++) {
-			part = filter->parts[j];
-			free(part->part_type.iov_buf);
-			if (part->data_type.iov_buf_len > 0)
-				free(part->data_type.iov_buf);
-			if (part->akey.iov_buf_len > 0)
-				free(part->akey.iov_buf);
-			for (k = 0; k < part->num_constants; k++)
-				free(part->constant[k].iov_buf);
-			free(part);
+	for (i = 0; i < nfilters; i++) {
+		for (j = 0; j < filters[i]->num_parts; j++) {
+			free(filters[i]->parts[j]->part_type.iov_buf);
+			if (filters[i]->parts[j]->data_type.iov_buf_len > 0)
+				free(filters[i]->parts[j]->data_type.iov_buf);
+			if (filters[i]->parts[j]->akey.iov_buf_len > 0)
+				free(filters[i]->parts[j]->akey.iov_buf);
+			for (k = 0; k < filters[i]->parts[j]->num_constants; k++) {
+				free(filters[i]->parts[j]->constant[k].iov_buf);
+			}
 		}
-		free(filter);
 	}
-	if (num_filters > 0)
-		free(filters);
 }
 
 void
 free_pipeline(daos_pipeline_t *pipe)
 {
-	free_filters(pipe->filters, pipe->num_filters);
-	free_filters(pipe->aggr_filters, pipe->num_aggr_filters);
-	daos_pipeline_init(pipe);
+	/** freeing objects allocated by client */
+	free_filter_data(pipe->filters, pipe->num_filters);
+	free_filter_data(pipe->aggr_filters, pipe->num_aggr_filters);
+
+	/** freeing objects allocated by DAOS */
+	daos_pipeline_free(pipe);
 }


### PR DESCRIPTION
Added API function to free allocated objects (filters and filter parts)
during pipeline construction. This can be expanded in the future when
we add more helper functions to make DAOS allocate all needed data for
the pipeline. Then, we can free also iovs used for data types and such.

Skip-test: true

Signed-off-by: Eduardo Berrocal <eduardo.berrocal@intel.com>