### PR TITLE
DAOS-10072 test: Add new pool query fields to test

### DIFF
--- a/src/tests/ftest/control/dmg_pool_query_test.py
+++ b/src/tests/ftest/control/dmg_pool_query_test.py
@@ -97,7 +97,7 @@ class DmgPoolQueryTest(ControlTestBase, IorTestBase):
                     "records", path="/run/exp_vals/rebuild/*")
             },
             "enabled_ranks": None,
-            "disabled_ranks": None,
+            "disabled_ranks": None
         }
 
         self.assertDictEqual(

--- a/src/tests/ftest/control/dmg_pool_query_test.py
+++ b/src/tests/ftest/control/dmg_pool_query_test.py
@@ -95,7 +95,9 @@ class DmgPoolQueryTest(ControlTestBase, IorTestBase):
                     "objects", path="/run/exp_vals/rebuild/*"),
                 "records": self.params.get(
                     "records", path="/run/exp_vals/rebuild/*")
-            }
+            },
+            "enabled_ranks": None,
+            "disabled_ranks": None,
         }
 
         self.assertDictEqual(


### PR DESCRIPTION
Pool query now provides "enabled_ranks" and "disabled_ranks" fields.
In the basic case, they aren't returned.

Features: pool_query

Signed-off-by: Kris Jacque <kristin.jacque@intel.com>