### PR TITLE
DAOS-10197 ddb: Introduction of daos debug tool (ddb)

### DIFF
--- a/debian/daos-server-tests.install
+++ b/debian/daos-server-tests.install
@@ -7,4 +7,5 @@ usr/bin/smd_ut
 usr/bin/vea_ut
 usr/bin/srv_checksum_tests
 usr/bin/vos_tests
+usr/bin/ddb_tests
 usr/bin/vea_stress

--- a/debian/daos-server.install
+++ b/debian/daos-server.install
@@ -8,6 +8,7 @@ usr/bin/daos_admin
 usr/bin/daos_server
 usr/bin/daos_engine
 usr/bin/daos_metrics
+usr/bin/ddb
 usr/lib64/daos_srv/libcont.so
 usr/lib64/daos_srv/libdtx.so
 usr/lib64/daos_srv/libmgmt.so

--- a/src/SConscript
+++ b/src/SConscript
@@ -106,6 +106,9 @@ def scons():
     # Build test
     SConscript('tests/SConscript')
 
+    # Build ddb
+    SConscript('ddb/SConscript')
+
     if not env.GetOption('clean') and not env.GetOption('help'):
 
         print("Checking local headers can be included")

--- a/src/ddb/README.md
+++ b/src/ddb/README.md
@@ -1,0 +1,70 @@
+# DAOS Debug Tool (ddb)
+
+## Description
+
+The DAOS Debug Tool (ddb) allows a user to navigate through a file in the VOS
+format. It is similar to debugfs for ext2/3/4 and offers both a command line and
+interactive shell mode. Key features that will be supported are:
+
+### Parsing a VOS file:
+
+- Printing the VOS 'superblock'
+- listing containers, objects, dkeys, akeys, and records
+- dumping content of a value
+- dumping content of ilogs
+- iterating over the dtx committed and active tables
+
+### Altering a VOS file, including:
+
+- deleting containers, objects, dkeys, akeys, or records
+- changing/inserting new value
+- processing/removing ilogs
+- clearing the dtx committed table
+
+## Current State
+
+ddb is very much in development. Currently the interactive mode and the '-R'
+option with a single command work relatively well. The only commands that are
+currently implemented are quit (for interactive mode) and 'ls' to list the
+branches of a vos file (container, objects, ...).
+
+## Design
+
+DDB will be developed on top of the VOS API which already supports interacting
+with a VOS file. The vos_iterate api is heavily used to iterate and navigate
+over a VOS tree. Function tables/pointers are used quite a bit as well for
+injecting callbacks to vos_iterate which already uses a callback approach. It
+also helps support unit testing of the different layers.
+
+### Layers
+
+The primary layers for the application are:
+
+#### Main/Entry Point
+
+The main function which initializes daos and vos and accepts program arguments.
+It then passes those arguments to the ddb_main function which will then parse
+the arguments and options into appropriate fields within the main program
+structure.
+
+#### ddb_main
+
+A unit testable "main" function. It accepts the traditional argc/argv parameters
+as well as a function table to input and output functions. Unit testing is then
+able to fake the input/output to verify that command line arguments, or
+arguments in the interactive mode, run the program in the correct mode and
+execute the correct sub command. A function table is defined for the actual sub
+commands so that these can be faked out as well and the cli can be unit tested
+in isolation.
+
+#### ddb commands (sub commands)
+
+The implementation of the individual commands that a user can pass in. It
+receives the command options/arguments as a well defined structure (fields of
+which are set by ddb).
+
+### ddb vos (dv_)
+
+This layer will adapt the needs of the ddb commands to the current VOS API
+implementation, making the VOS interaction a bit nicer for ddb.
+

--- a/src/ddb/SConscript
+++ b/src/ddb/SConscript
@@ -1,0 +1,34 @@
+"""Build tests"""
+import daos_build
+
+def scons():
+    """Execute build"""
+    Import('base_env', 'prereqs')
+    denv = base_env.Clone()
+
+    libs = ['vos', 'daos_common_pmem', 'abt', 'gurt', 'daos', 'uuid', 'bio']
+    src = ['ddb_cmd_options.c',
+           'ddb_commands.c',
+           'ddb_main.c',
+           'ddb_parse.c',
+           'ddb_vos.c']
+
+    ddblib = denv.StaticObject(src)
+    Export('ddblib')
+
+    # Add runtime paths for daos libraries
+    denv.AppendUnique(RPATH_FULL=['$PREFIX/lib64/daos_srv'])
+    denv.AppendUnique(RPATH_FULL=['$PREFIX/lib64'])
+
+    prereqs.require(denv, 'argobots', 'protobufc', 'pmdk')
+
+    ddb = daos_build.program(denv, 'ddb', ['ddb_entry.c', ddblib], LIBS=libs)
+
+    denv.Install('$PREFIX/bin/', ddb)
+
+    # tests
+    SConscript('tests/SConscript', exports=['denv'])
+
+
+if __name__ == "SCons.Script":
+    scons()

--- a/src/ddb/ddb_cmd_options.c
+++ b/src/ddb/ddb_cmd_options.c
@@ -1,0 +1,78 @@
+/**
+* (C) Copyright 2022 Intel Corporation.
+*
+* SPDX-License-Identifier: BSD-2-Clause-Patent
+*/
+#include <ctype.h>
+#include <getopt.h>
+#include <gurt/debug.h>
+
+#include "ddb_cmd_options.h"
+#include "ddb_common.h"
+#define same(a, b) (strcmp((a), (b)) == 0)
+#define COMMAND_NAME_LS "ls"
+#define COMMAND_NAME_QUIT "quit"
+
+/* Parse command line options for the 'ls' command */
+static int
+ls_option_parse(struct ddb_ctx *ctx, struct ls_options *cmd_args, struct argv_parsed *argc_v)
+{
+	char		 *options_short = "r";
+	int		  index = 0, opt;
+	uint32_t	  argc = argc_v->ap_argc;
+	char		**argv = argc_v->ap_argv;
+	struct option	  options_long[] = {
+		{ "recursive", no_argument, NULL, 'r' },
+		{ NULL }
+	};
+
+	memset(cmd_args, 0, sizeof(*cmd_args));
+
+	/* Restart getopt */
+	optind = 1;
+	opterr = 0;
+	while ((opt = getopt_long(argc, argv, options_short, options_long, &index)) != -1) {
+		switch (opt) {
+		case 'r':
+			cmd_args->recursive = true;
+			break;
+		case '?':
+			ddb_printf(ctx, "Unknown option: '%c'\n", optopt);
+		default:
+			return -DER_INVAL;
+		}
+	}
+	D_ASSERT(argc > optind);
+	D_ASSERT(same(argv[optind], COMMAND_NAME_LS));
+	optind++;
+
+	if (argc - optind > 0) {
+		cmd_args->path = argv[optind];
+		optind++;
+	}
+
+	if (argc - optind > 0) {
+		ddb_printf(ctx, "Unexpected argument: %s\\n", argv[optind]);
+		return -DER_INVAL;
+	}
+
+	return 0;
+}
+
+int
+ddb_parse_cmd_args(struct ddb_ctx *ctx, struct argv_parsed *parsed, struct ddb_cmd_info *info)
+{
+	char *cmd = parsed->ap_argv[1];
+
+	if (same(cmd, COMMAND_NAME_LS)) {
+		info->dci_cmd = DDB_CMD_LS;
+		return ls_option_parse(ctx, &info->dci_cmd_option.dci_ls, parsed);
+	}
+
+	if (same(cmd, COMMAND_NAME_QUIT)) {
+		info->dci_cmd = DDB_CMD_QUIT;
+		return 0;
+	}
+
+	return -DER_INVAL;
+}

--- a/src/ddb/ddb_cmd_options.h
+++ b/src/ddb/ddb_cmd_options.h
@@ -1,0 +1,38 @@
+/**
+ * (C) Copyright 2022 Intel Corporation.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause-Patent
+ */
+
+#ifndef __DDB_RUN_CMDS_H
+#define __DDB_RUN_CMDS_H
+#include "ddb_common.h"
+
+enum ddb_cmd {
+
+	DDB_CMD_UNKNOWN = 0,
+	DDB_CMD_QUIT = 1,
+	DDB_CMD_LS = 2,
+};
+
+struct ls_options {
+	bool recursive;
+	char *path;
+};
+
+struct ddb_cmd_info {
+	enum ddb_cmd dci_cmd;
+	union {
+		struct ls_options dci_ls;
+
+	} dci_cmd_option;
+};
+
+/* Run commands ... */
+
+int ddb_parse_cmd_args(struct ddb_ctx *ctx, struct argv_parsed *parsed, struct ddb_cmd_info *info);
+
+int ddb_run_ls(struct ddb_ctx *ctx, struct ls_options *opt);
+int ddb_run_quit(struct ddb_ctx *ctx);
+
+#endif /* __DDB_RUN_CMDS_H */

--- a/src/ddb/ddb_commands.c
+++ b/src/ddb/ddb_commands.c
@@ -1,0 +1,213 @@
+/**
+ * (C) Copyright 2022 Intel Corporation.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause-Patent
+ */
+
+#include <daos/common.h>
+#include "ddb_common.h"
+#include "ddb_parse.h"
+#include "ddb_cmd_options.h"
+#include "ddb_vos.h"
+
+int
+ddb_run_quit(struct ddb_ctx *ctx)
+{
+	ctx->dc_should_quit = true;
+	return 0;
+}
+
+struct ls_ctx {
+	struct ddb_ctx	*ctx;
+	bool		 has_cont;
+	bool		 has_obj;
+	bool		 has_dkey;
+	bool		 has_akey;
+};
+
+static void
+print_indent(struct ddb_ctx *ctx, int c)
+{
+	int i;
+
+	for (i = 0; i < c; i++)
+		ddb_print(ctx, "\t");
+}
+
+#define DF_IDX "[%d]"
+#define DP_IDX(idx) idx
+
+static int
+ls_cont_handler(struct ddb_cont *cont, void *args)
+{
+	struct ls_ctx *ctx = args;
+
+	ctx->has_cont = true;
+
+	ddb_printf(ctx->ctx, DF_IDX" "DF_UUIDF"\n", DP_IDX(cont->ddbc_idx),
+		   DP_UUID(cont->ddbc_cont_uuid));
+
+	return 0;
+}
+
+static void
+get_object_type(enum daos_otype_t type, char *type_str)
+{
+	if (type == DAOS_OT_MULTI_HASHED)
+		strcpy(type_str, "DAOS_OT_MULTI_HASHED");
+	else if (type == DAOS_OT_OIT)
+		strcpy(type_str, "DAOS_OT_OIT");
+	else if (type == DAOS_OT_DKEY_UINT64)
+		strcpy(type_str, "DAOS_OT_DKEY_UINT64");
+	else if (type == DAOS_OT_AKEY_UINT64)
+		strcpy(type_str, "DAOS_OT_AKEY_UINT64");
+	else if (type == DAOS_OT_MULTI_UINT64)
+		strcpy(type_str, "DAOS_OT_MULTI_UINT64");
+	else if (type == DAOS_OT_DKEY_LEXICAL)
+		strcpy(type_str, "DAOS_OT_DKEY_LEXICAL");
+	else if (type == DAOS_OT_AKEY_LEXICAL)
+		strcpy(type_str, "DAOS_OT_AKEY_LEXICAL");
+	else if (type == DAOS_OT_MULTI_LEXICAL)
+		strcpy(type_str, "DAOS_OT_MULTI_LEXICAL");
+	else if (type == DAOS_OT_KV_HASHED)
+		strcpy(type_str, "DAOS_OT_KV_HASHED");
+	else if (type == DAOS_OT_KV_UINT64)
+		strcpy(type_str, "DAOS_OT_KV_UINT64");
+	else if (type == DAOS_OT_KV_LEXICAL)
+		strcpy(type_str, "DAOS_OT_KV_LEXICAL");
+	else if (type == DAOS_OT_ARRAY)
+		strcpy(type_str, "DAOS_OT_ARRAY");
+	else if (type == DAOS_OT_ARRAY_ATTR)
+		strcpy(type_str, "DAOS_OT_ARRAY_ATTR");
+	else if (type == DAOS_OT_ARRAY_BYTE)
+		strcpy(type_str, "DAOS_OT_ARRAY_BYTE");
+	else
+		strcpy(type_str, "UNKNOWN");
+}
+
+static int
+ls_obj_handler(struct ddb_obj *obj, void *args)
+{
+	struct ls_ctx		*ctx = args;
+	char		 	 obj_class_name[32];
+	daos_oclass_id_t 	 oclass;
+	char		 	 otype_str[32] = {0};
+	enum daos_otype_t	 otype;
+	daos_obj_id_t	 	 oid;
+	uint32_t		 nr_grps;
+
+	ctx->has_obj = true;
+
+	oclass = daos_obj_id2class(obj->ddbo_oid);
+	otype = daos_obj_id2type(obj->ddbo_oid);
+	daos_oclass_id2name(oclass, obj_class_name);
+
+	oid = obj->ddbo_oid;
+
+	nr_grps = (oid.hi & OID_FMT_META_MASK) >> OID_FMT_META_SHIFT;
+
+	get_object_type(otype, otype_str);
+
+	print_indent(ctx->ctx, ctx->has_cont);
+	ddb_printf(ctx->ctx, DF_IDX" '"DF_OID"' (class: %s, type: %s, groups: %d) \n",
+		   DP_IDX(obj->ddbo_idx),
+		   DP_OID(obj->ddbo_oid),
+		   obj_class_name,
+		   otype_str,
+		   nr_grps);
+
+	return 0;
+}
+
+static void
+print_key(struct ddb_ctx *ctx, struct ddb_key *key)
+{
+	uint32_t	 str_len = min(100, key->ddbk_key.iov_len);
+
+	ddb_printf(ctx, DF_IDX" '%.*s' (%lu)\n",
+		   DP_IDX(key->ddbk_idx),
+		   str_len,
+		   (char *)key->ddbk_key.iov_buf,
+		   key->ddbk_key.iov_len);
+}
+
+static int
+ls_dkey_handler(struct ddb_key *key, void *args)
+{
+	struct ls_ctx *ctx = args;
+
+	ctx->has_dkey = true;
+	print_indent(ctx->ctx, ctx->has_cont + ctx->has_obj);
+	print_key(ctx->ctx, key);
+
+	return 0;
+}
+
+static int
+ls_akey_handler(struct ddb_key *key, void *args)
+{
+	struct ls_ctx *ctx = args;
+
+	ctx->has_akey = true;
+	print_indent(ctx->ctx, ctx->has_cont + ctx->has_obj + ctx->has_dkey);
+	print_key(ctx->ctx, key);
+
+	return 0;
+}
+
+static int
+ls_sv_handler(struct ddb_sv *val, void *args)
+{
+	struct ls_ctx *ctx = args;
+
+	print_indent(ctx->ctx, ctx->has_cont + ctx->has_obj + ctx->has_dkey + ctx->has_akey);
+	ddb_printf(ctx->ctx, "Single Value: %lu record size\n", val->ddbs_record_size);
+	return 0;
+}
+
+static int
+ls_array_handler(struct ddb_array *val, void *args)
+{
+	struct ls_ctx *ctx = args;
+
+	print_indent(ctx->ctx, ctx->has_cont + ctx->has_obj + ctx->has_dkey + ctx->has_akey);
+	ddb_printf(ctx->ctx, "[Array] recx: "DF_RECX",  record size: %lu\n",
+		   DP_RECX(val->ddba_recx),
+		   val->ddba_record_size);
+
+	return 0;
+}
+
+static struct vos_tree_handlers handlers = {
+	.ddb_cont_handler = ls_cont_handler,
+	.ddb_obj_handler = ls_obj_handler,
+	.ddb_dkey_handler = ls_dkey_handler,
+	.ddb_akey_handler = ls_akey_handler,
+	.ddb_array_handler = ls_array_handler,
+	.ddb_sv_handler = ls_sv_handler,
+};
+
+int
+ddb_run_ls(struct ddb_ctx *ctx, struct ls_options *opt)
+{
+	int rc;
+	struct dv_tree_path_builder vt_path = {.vtp_poh = ctx->dc_poh};
+	struct ls_ctx lsctx = {0};
+
+	rc = ddb_vtp_init(opt->path, &vt_path);
+	if (!SUCCESS(rc))
+		return rc;
+
+	rc = dv_path_update_from_indexes(&vt_path);
+	if (!SUCCESS(rc))
+		return rc;
+
+	vtp_print(ctx, &vt_path.vtp_path);
+	lsctx.ctx = ctx;
+	rc = dv_iterate(ctx->dc_poh, &vt_path.vtp_path, opt->recursive, &handlers, &lsctx);
+
+	ddb_vtp_fini(&vt_path);
+
+	return rc;
+
+}

--- a/src/ddb/ddb_common.h
+++ b/src/ddb/ddb_common.h
@@ -1,0 +1,142 @@
+/**
+ * (C) Copyright 2019-2022 Intel Corporation.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause-Patent
+ */
+
+#ifndef __DAOS_DDB_COMMON_H
+#define __DAOS_DDB_COMMON_H
+
+#include <daos/common.h>
+#include <daos/object.h>
+#include <daos_obj.h>
+#include <daos_types.h>
+
+#define COMMAND_NAME_MAX 64
+
+#define SUCCESS(rc) ((rc) == DER_SUCCESS)
+
+#define ddb_print(ctx, str) \
+	do { if (ctx->dc_io_ft.ddb_print_message) \
+		ctx->dc_io_ft.ddb_print_message(str); \
+	else \
+		printf(str); } while (0)
+
+#define ddb_printf(ctx, fmt, ...) \
+	do { if ((ctx)->dc_io_ft.ddb_print_message) \
+		(ctx)->dc_io_ft.ddb_print_message(fmt, __VA_ARGS__); \
+	else                            \
+		printf(fmt, __VA_ARGS__); \
+	} while (0)
+
+#define ddb_error(ctx, str) \
+	do { if (ctx->dc_io_ft.ddb_print_error) \
+		ctx->dc_io_ft.ddb_print_error(str); \
+	else \
+		printf(str); } while (0)
+
+#define ddb_errorf(ctx, fmt, ...) \
+	do { if ((ctx)->dc_io_ft.ddb_print_error) \
+		(ctx)->dc_io_ft.ddb_print_error(fmt, __VA_ARGS__); \
+	else                            \
+		printf(fmt, __VA_ARGS__); \
+	} while (0)
+
+
+struct ddb_io_ft {
+	int (*ddb_print_message)(const char *fmt, ...);
+	int (*ddb_print_error)(const char *fmt, ...);
+	char *(*ddb_get_input)(char *buf, uint32_t buf_len);
+};
+
+
+struct ddb_ctx {
+	struct ddb_io_ft	 dc_io_ft;
+	daos_handle_t		 dc_poh;
+	daos_handle_t		 dc_coh;
+	bool			 dc_should_quit;
+};
+
+struct dv_tree_path {
+	uuid_t		vtp_cont;
+	daos_unit_oid_t vtp_oid;
+	daos_key_t	vtp_dkey;
+	daos_key_t	vtp_akey;
+	daos_recx_t	vtp_recx;
+};
+
+/* Is used while parsing user input for building the vos tree path. The builder can use branch
+ * indexes that will be converted to the appropriate vos part (i.e. cont uuid, object id, etc).
+ */
+struct dv_tree_path_builder {
+	daos_handle_t		 vtp_poh; /* pool handle */
+	struct dv_tree_path	 vtp_path;
+
+	/*
+	 * If a key value is passed instead of an index, then need a buffer to copy the key value
+	 * into.
+	 */
+	uint8_t			*vtp_dkey_buf;
+	uint8_t			*vtp_akey_buf;
+
+	/*
+	 * A user can pass an index of the path part. These indexes will be used to complete
+	 * the path parts.
+	 */
+	uint32_t		 vtp_cont_idx;
+	uint32_t		 vtp_oid_idx;
+	uint32_t		 vtp_dkey_idx;
+	uint32_t		 vtp_akey_idx;
+	uint32_t		 vtp_recx_idx;
+};
+
+static inline bool
+dv_has_cont(struct dv_tree_path *vtp)
+{
+	return !uuid_is_null(vtp->vtp_cont);
+}
+
+static inline bool
+dv_has_obj(struct dv_tree_path *vtp)
+{
+	return !(vtp->vtp_oid.id_pub.lo == 0 &&
+		 vtp->vtp_oid.id_pub.hi == 0);
+}
+
+static inline bool
+dv_has_dkey(struct dv_tree_path *vtp)
+{
+	return vtp->vtp_dkey.iov_len > 0;
+}
+
+static inline bool
+dv_has_akey(struct dv_tree_path *vtp)
+{
+	return vtp->vtp_akey.iov_len > 0;
+}
+
+static inline void
+vtp_print(struct ddb_ctx *ctx, struct dv_tree_path *vt_path)
+{
+	if (dv_has_cont(vt_path))
+		ddb_printf(ctx, "/"DF_UUIDF"", DP_UUID(vt_path->vtp_cont));
+	if (dv_has_obj(vt_path))
+		ddb_printf(ctx, "/"DF_UOID"",  DP_UOID(vt_path->vtp_oid));
+	if (dv_has_dkey(vt_path))
+		ddb_printf(ctx, "/%s", (char *)vt_path->vtp_dkey.iov_buf);
+	if (dv_has_akey(vt_path))
+		ddb_printf(ctx, "/%s", (char *)vt_path->vtp_akey.iov_buf);
+
+	if (vt_path->vtp_recx.rx_nr > 0)
+		ddb_printf(ctx, "/{%lu-%lu}", vt_path->vtp_recx.rx_idx,
+			   vt_path->vtp_recx.rx_idx + vt_path->vtp_recx.rx_nr - 1);
+	ddb_print(ctx, "/\n");
+}
+
+struct argv_parsed {
+	char		**ap_argv;
+	void		 *ap_ctx;
+	uint32_t	  ap_argc;
+};
+
+#endif /** __DAOS_DDB_COMMON_H */

--- a/src/ddb/ddb_entry.c
+++ b/src/ddb/ddb_entry.c
@@ -1,0 +1,52 @@
+/**
+ * (C) Copyright 2022 Intel Corporation.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause-Patent
+ */
+
+#include <stdio.h>
+#include <daos_types.h>
+#include <stdarg.h>
+#include "ddb_main.h"
+
+static char *
+get_input(char *buf, uint32_t buf_len)
+{
+	return fgets(buf, buf_len, stdin);
+}
+
+static int
+print_error(const char *fmt, ...)
+{
+	va_list args;
+	int	rc;
+
+	va_start(args, fmt);
+	rc = vfprintf(stderr, fmt, args);
+	va_end(args);
+
+	return rc;
+}
+
+int main(int argc, char *argv[])
+{
+	int rc;
+	struct ddb_io_ft ft = {
+		.ddb_print_message = printf,
+		.ddb_print_error = print_error,
+		.ddb_get_input = get_input,
+	};
+
+	rc = ddb_init();
+	if (rc != 0) {
+		fprintf(stderr, "Error with ddb_init: "DF_RC"\n", DP_RC(rc));
+		return -rc;
+	}
+	rc = ddb_main(&ft, argc, argv);
+	if (rc != 0)
+		fprintf(stderr, "Error: "DF_RC"\n", DP_RC(rc));
+
+	ddb_fini();
+
+	return -rc;
+}

--- a/src/ddb/ddb_main.c
+++ b/src/ddb/ddb_main.c
@@ -1,0 +1,136 @@
+/**
+ * (C) Copyright 2022 Intel Corporation.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause-Patent
+ */
+
+#include <daos/common.h>
+#include <daos/object.h>
+#include "ddb_main.h"
+#include "ddb_common.h"
+#include "ddb_parse.h"
+#include "ddb_vos.h"
+#include "ddb_cmd_options.h"
+
+int
+ddb_init()
+{
+	int rc = daos_debug_init(DAOS_LOG_DEFAULT);
+
+	if (!SUCCESS(rc))
+		return rc;
+
+	rc = obj_class_init();
+
+	return rc;
+}
+
+void
+ddb_fini()
+{
+	obj_class_fini();
+	daos_debug_fini();
+}
+
+static int
+run_cmd(struct ddb_ctx *ctx, struct argv_parsed *parse_args)
+{
+	struct ddb_cmd_info info = {0};
+	int rc = 0;
+
+	ddb_parse_cmd_args(ctx, parse_args, &info);
+
+	switch (info.dci_cmd) {
+	case DDB_CMD_UNKNOWN:
+		break;
+	case DDB_CMD_QUIT:
+		rc = ddb_run_quit(ctx);
+		break;
+	case DDB_CMD_LS:
+		rc = ddb_run_ls(ctx, &info.dci_cmd_option.dci_ls);
+		break;
+	}
+
+	if (!SUCCESS(rc))
+		ddb_errorf(ctx, "Error with command: "DF_RC"\n", DP_RC(rc));
+
+	ddb_str2argv_free(parse_args);
+
+	return rc;
+}
+
+#define str_has_value(str) (str) != NULL && strlen(str) > 0
+
+int
+ddb_main(struct ddb_io_ft *io_ft, int argc, char *argv[])
+{
+	struct program_args	 pa = {0};
+	uint32_t		 input_buf_len = 1024;
+	uint32_t		 buf_len = input_buf_len * 2;
+	char			 buf[buf_len + 1024];
+	char			 input_buf[input_buf_len];
+	struct argv_parsed	 parse_args = {0};
+	int			 rc;
+	struct ddb_ctx		 ctx = {0};
+
+	D_ASSERT(io_ft);
+	ctx.dc_io_ft = *io_ft;
+
+	rc = ddb_parse_program_args(argc, argv, &pa);
+	if (!SUCCESS(rc))
+		return rc;
+
+	if (str_has_value(pa.pa_pool_path)) {
+		rc = ddb_vos_pool_open(pa.pa_pool_path, &ctx.dc_poh);
+		if (!SUCCESS(rc))
+			return rc;
+	}
+
+	if (str_has_value(pa.pa_r_cmd_run)) {
+		/* Add program name back */
+		snprintf(buf, buf_len, "%s %s", argv[0], pa.pa_r_cmd_run);
+		rc = ddb_str2argv_create(buf, &parse_args);
+		if (!SUCCESS(rc)) {
+			ddb_vos_pool_close(ctx.dc_poh);
+			return rc;
+		}
+
+		rc = run_cmd(&ctx, &parse_args);
+		if (!SUCCESS(rc))
+			ddb_errorf(&ctx, "Error with command: "DF_RC"\n", DP_RC(rc));
+
+		ddb_str2argv_free(&parse_args);
+		return rc;
+	}
+
+	if (str_has_value(pa.pa_cmd_file)) {
+		/* Still to be implemented */
+
+		return -DER_NOSYS;
+	}
+
+	while (!ctx.dc_should_quit) {
+		io_ft->ddb_print_message("$ ");
+		io_ft->ddb_get_input(input_buf, input_buf_len);
+		input_buf[strlen(input_buf) - 1] = '\0'; /* Remove newline */
+
+		/* add program name to beginning of string that will be parsed into argv. That way
+		 * is the same as argv from command line into main()
+		 */
+		snprintf(buf, buf_len, "%s %s", argv[0], input_buf);
+		rc = ddb_str2argv_create(buf, &parse_args);
+		if (!SUCCESS(rc)) {
+			ddb_errorf(&ctx, "Error with input: "DF_RC"\n", DP_RC(rc));
+			ddb_str2argv_free(&parse_args);
+			continue;
+		}
+
+		rc = run_cmd(&ctx, &parse_args);
+		if (!SUCCESS(rc))
+			ddb_errorf(&ctx, "Error: "DF_RC"\n", DP_RC(rc));
+		ddb_str2argv_free(&parse_args);
+	}
+
+	ddb_fini();
+	return 0;
+}

--- a/src/ddb/ddb_main.h
+++ b/src/ddb/ddb_main.h
@@ -1,0 +1,18 @@
+/**
+ * (C) Copyright 2022 Intel Corporation.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause-Patent
+ */
+
+#ifndef DAOS_DDB_MAIN_H
+#define DAOS_DDB_MAIN_H
+
+#include <daos_types.h>
+#include "ddb_common.h"
+
+int ddb_init(void);
+void ddb_fini(void);
+
+int ddb_main(struct ddb_io_ft *io_ft, int argc, char *argv[]);
+
+#endif /* DAOS_DDB_MAIN_H */

--- a/src/ddb/ddb_parse.c
+++ b/src/ddb/ddb_parse.c
@@ -1,0 +1,232 @@
+/**
+ * (C) Copyright 2019-2022 Intel Corporation.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause-Patent
+ */
+
+#include <wordexp.h>
+#include <getopt.h>
+#include <gurt/common.h>
+#include "ddb_common.h"
+#include "ddb_parse.h"
+
+int
+ddb_str2argv_create(const char *buf, struct argv_parsed *parse_args)
+{
+	wordexp_t *we;
+	int rc;
+
+	D_ALLOC_PTR(we);
+	if (we == NULL)
+		return -DER_NOMEM;
+
+	rc = wordexp(buf, we, WRDE_SHOWERR | WRDE_UNDEF);
+	if (rc != 0) {
+		D_FREE(we);
+		return -DER_INVAL;
+	}
+
+	parse_args->ap_argc = we->we_wordc;
+	parse_args->ap_argv = we->we_wordv;
+	parse_args->ap_ctx = we;
+
+	return rc;
+}
+
+void
+ddb_str2argv_free(struct argv_parsed *parse_args)
+{
+	wordfree(parse_args->ap_ctx);
+	D_FREE(parse_args->ap_ctx);
+}
+
+int
+ddb_parse_program_args(uint32_t argc, char **argv, struct program_args *pa)
+{
+	struct option	program_options[] = {
+		{ "write_mode", no_argument, NULL,	'w' },
+		{ "run_cmd", required_argument, NULL,	'R' },
+		{ "cmd_file", required_argument, NULL,	'f' },
+		{ "pool", required_argument, NULL,	'p' },
+		{ NULL }
+	};
+	int		index = 0, opt;
+
+	optind = 1;
+	opterr = 0;
+	while ((opt = getopt_long(argc, argv,
+				  "wR:f:p:", program_options, &index)) != -1) {
+		switch (opt) {
+		case 'w':
+			break;
+		case 'R':
+			pa->pa_r_cmd_run = optarg;
+			break;
+		case 'f':
+			pa->pa_cmd_file = optarg;
+			break;
+		case 'p':
+			pa->pa_pool_uuid = optarg;
+			break;
+		case '?':
+			printf("'%c' is unknown\n", optopt);
+			return -DER_INVAL;
+		default:
+			return -DER_INVAL;
+		}
+	}
+
+	if (argc - optind > 1) {
+		printf("Too many commands\n");
+		return -DER_INVAL;
+	}
+	if (argc - optind == 1)
+		pa->pa_pool_path = argv[optind];
+
+	return 0;
+}
+
+/* parse the string to a bracketed index "[123]" */
+static bool
+is_idx(char *str, uint32_t *idx)
+{
+	uint32_t str_len;
+
+	D_ASSERT(idx && str);
+	str_len = strlen(str);
+
+	if (str_len < 3) /* must be at least 3 chars */
+		return false;
+
+	if (str[0] == '[' && str[str_len - 1] == ']') {
+		*idx = atol(str + 1);
+		return true;
+	}
+	return false;
+}
+
+int
+ddb_vtp_init(const char *path, struct dv_tree_path_builder *vt_path)
+{
+	char		*path_copy;
+	char		*path_idx;
+	char		*oid_str = NULL;
+	char		*recx_str = NULL;
+	char		*tok;
+	char		*hi;
+	char		*lo;
+	uint32_t	 path_len;
+	int		 rc = 0;
+	uint32_t	 recx_str_len;
+
+	ddb_vos_tree_path_setup(vt_path);
+
+	if (path == NULL)
+		return 0;
+
+	path_len = strlen(path) + 1; /* +1 for '\0' */
+	if (path_len == 0)
+		return 0;
+
+	D_ALLOC(path_copy, path_len);
+	if(path_copy == NULL)
+		return -DER_NOMEM;
+
+	strcpy(path_copy, path);
+	path_idx = path_copy;
+
+	/* Look for container */
+	tok = strtok(path_idx, "/");
+	if (tok == NULL) {
+		D_FREE(path_copy);
+		return 0;
+	}
+
+	if (!is_idx(tok, &vt_path->vtp_cont_idx)) {
+		rc = uuid_parse(tok, vt_path->vtp_path.vtp_cont);
+		if (rc != 0) {
+			D_FREE(path_copy);
+			return -DER_INVAL;
+		}
+	}
+
+	/* look for oid */
+	tok = strtok(NULL, "/");
+
+	if (tok != NULL)
+		oid_str = tok;
+
+	/* look for dkey */
+	tok = strtok(NULL, "/");
+	if (tok != NULL && !is_idx(tok, &vt_path->vtp_dkey_idx)) {
+		D_ALLOC(vt_path->vtp_dkey_buf, strlen(tok));
+		if (vt_path->vtp_dkey_buf == NULL)
+			D_GOTO(error, rc = -DER_NOMEM);
+		memcpy(vt_path->vtp_dkey_buf, tok, strlen(tok));
+		d_iov_set(&vt_path->vtp_path.vtp_dkey, vt_path->vtp_dkey_buf, strlen(tok));
+	}
+
+	/* look for akey */
+	tok = strtok(NULL, "/");
+	if (tok != NULL && !is_idx(tok, &vt_path->vtp_akey_idx)) {
+		D_ALLOC(vt_path->vtp_akey_buf, strlen(tok));
+		if (vt_path->vtp_akey_buf == NULL)
+			D_GOTO(error, rc = -DER_NOMEM);
+		memcpy(vt_path->vtp_akey_buf, tok, strlen(tok));
+		d_iov_set(&vt_path->vtp_path.vtp_akey, vt_path->vtp_akey_buf, strlen(tok));
+	}
+
+	/* look for recx */
+	tok = strtok(NULL, "/");
+	if (tok != NULL)
+		recx_str = tok;
+
+	/* parse oid */
+	if (oid_str != NULL && strlen(oid_str) > 0 && !is_idx(oid_str, &vt_path->vtp_oid_idx)) {
+		hi = strtok(oid_str, ".");
+		lo = strtok(NULL, ".");
+		if (hi == NULL || lo == NULL)
+			D_GOTO(error, rc = -DER_INVAL);
+		vt_path->vtp_path.vtp_oid.id_pub.hi = atoll(hi);
+		vt_path->vtp_path.vtp_oid.id_pub.lo = atoll(lo);
+	}
+
+	if (recx_str != NULL && strlen(recx_str) > 0 && !is_idx(tok, &vt_path->vtp_recx_idx)) {
+		recx_str_len = strlen(recx_str);
+
+		if (recx_str[0] == '{' && recx_str[recx_str_len - 1] == '}') {
+			recx_str++;
+		} else {
+			D_FREE(path_copy);
+			return -DER_INVAL;
+		}
+
+		lo = strtok(recx_str, "-");
+		hi = strtok(NULL, "-");
+
+		if (hi == NULL || lo == NULL) {
+			D_FREE(path_copy);
+			return -DER_INVAL;
+		}
+
+		vt_path->vtp_path.vtp_recx.rx_idx = atoll(lo);
+		vt_path->vtp_path.vtp_recx.rx_nr = atoll(hi) -
+						   vt_path->vtp_path.vtp_recx.rx_idx + 1;
+	}
+
+	D_FREE(path_copy);
+	return 0;
+
+error:
+	D_FREE(path_copy);
+	D_FREE(vt_path->vtp_dkey_buf);
+	D_FREE(vt_path->vtp_akey_buf);
+	return rc;
+}
+
+void
+ddb_vtp_fini(struct dv_tree_path_builder *vt_path)
+{
+	D_FREE(vt_path->vtp_dkey_buf);
+	D_FREE(vt_path->vtp_akey_buf);
+}

--- a/src/ddb/ddb_parse.h
+++ b/src/ddb/ddb_parse.h
@@ -1,0 +1,47 @@
+/**
+ * (C) Copyright 2019-2022 Intel Corporation.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause-Patent
+ */
+
+#ifndef __DAOS_DDB_PARSE_H
+#define __DAOS_DDB_PARSE_H
+
+#include <linux/limits.h>
+#include <stdint.h>
+#include <uuid/uuid.h>
+#include <daos_obj.h>
+#include <daos_types.h>
+#include "ddb_common.h"
+
+struct program_args {
+	char *pa_cmd_file;
+	char *pa_r_cmd_run;
+	char *pa_pool_path;
+	char *pa_pool_uuid;
+};
+
+/* Parse a string into an array of words with the count of words */
+int ddb_str2argv_create(const char *buf, struct argv_parsed *parse_args);
+
+/* Free resources used for str2argv */
+void ddb_str2argv_free(struct argv_parsed *parse_args);
+
+/* Parse argc/argv into the program arguments/options */
+int ddb_parse_program_args(uint32_t argc, char **argv, struct program_args *pa);
+
+/* Parse a string into the parts of a vos tree path (cont, object, ...) */
+int ddb_vtp_init(const char *path, struct dv_tree_path_builder *vt_path);
+void ddb_vtp_fini(struct dv_tree_path_builder *vt_path);
+
+#define DDB_IDX_UNSET ((uint32_t)-1)
+static inline void ddb_vos_tree_path_setup(struct dv_tree_path_builder *vt_path)
+{
+	vt_path->vtp_cont_idx = DDB_IDX_UNSET;
+	vt_path->vtp_oid_idx = DDB_IDX_UNSET;
+	vt_path->vtp_dkey_idx = DDB_IDX_UNSET;
+	vt_path->vtp_akey_idx = DDB_IDX_UNSET;
+	vt_path->vtp_recx_idx = DDB_IDX_UNSET;
+}
+
+#endif /** __DAOS_DDB_PARSE_H */

--- a/src/ddb/ddb_vos.c
+++ b/src/ddb/ddb_vos.c
@@ -1,0 +1,584 @@
+/**
+ * (C) Copyright 2022 Intel Corporation.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause-Patent
+ */
+
+#include <string.h>
+#include <libpmemobj/types.h>
+#include <daos_srv/vos.h>
+#include <gurt/debug.h>
+#include "ddb_common.h"
+#include "ddb_parse.h"
+#include "ddb_vos.h"
+
+#define ddb_vos_iterate(param, iter_type, recursive, anchors, cb, args) \
+				vos_iterate(param, iter_type, recursive, \
+						anchors, cb, NULL, args, NULL)
+
+static int
+vos_path_parse(const char *path, uuid_t pool_uuid,
+	       char *pool_base, uint32_t pool_base_len)
+{
+	uint32_t	path_len = strlen(path);
+	char		uuid_test_str[DAOS_UUID_STR_SIZE];
+	int		path_idx, sub_path_idx;
+
+	D_ASSERT(path != NULL && pool_base != NULL);
+
+	for (path_idx = 0, sub_path_idx = 0; path_idx < path_len; path_idx++) {
+		if (path[path_idx] == '/') {
+			uuid_test_str[sub_path_idx] = '\0';
+			if(uuid_parse(uuid_test_str, pool_uuid) == 0) {
+				uint32_t src_pool_base_len = path_idx - sub_path_idx;
+
+				if (src_pool_base_len > pool_base_len) {
+					D_ERROR("The path's pool base is too long.\n");
+					return -DER_INVAL;
+				}
+
+				strncpy(pool_base, path, src_pool_base_len);
+				pool_base[src_pool_base_len + 1] = '\0';
+				return 0;
+			}
+			/* start on the next dir */
+			sub_path_idx = 0;
+		} else {
+			if (sub_path_idx <= DAOS_UUID_STR_SIZE)
+				uuid_test_str[sub_path_idx++] = path[path_idx];
+		}
+	}
+
+	return -DER_INVAL;
+}
+
+int
+ddb_vos_pool_open(char *path, daos_handle_t *poh)
+{
+	char		pool_base[64];
+	uuid_t		pool_uuid = {0};
+	uint32_t	flags = 0; /* Will need to be a flag to ignore uuid check */
+	int		rc;
+
+	rc = vos_path_parse(path, pool_uuid, pool_base, ARRAY_SIZE(pool_base));
+	if (!SUCCESS(rc))
+		return rc;
+	/*
+	 * VOS files must be under /mnt/daos directory. This is a current limitation and
+	 * will change in the future
+	 */
+	rc = vos_self_init(pool_base);
+	if (!SUCCESS(rc))
+		return rc;
+
+	rc = vos_pool_open(path, pool_uuid, flags, poh);
+	if (!SUCCESS(rc))
+		vos_self_fini();
+
+	return rc;
+}
+
+int
+dv_cont_open(daos_handle_t poh, uuid_t uuid, daos_handle_t *coh)
+{
+	return vos_cont_open(poh, uuid, coh);
+}
+
+int
+dv_cont_close(daos_handle_t *coh)
+{
+	int rc;
+
+	D_ASSERT(coh);
+	if (daos_handle_is_inval(*coh))
+		return 0;
+
+	rc = vos_cont_close(*coh);
+
+	*coh = DAOS_HDL_INVAL;
+
+	return rc;
+}
+
+int
+ddb_vos_pool_close(daos_handle_t poh)
+{
+	int rc;
+
+	rc = vos_pool_close(poh);
+	vos_self_fini();
+
+	return rc;
+}
+
+struct search_args {
+	uint32_t	sa_idx;
+	uint32_t	sa_current;
+	uuid_t		sa_uuid;
+	daos_unit_oid_t	sa_uoid;
+	daos_key_t	sa_key;
+	daos_recx_t	sa_recx;
+};
+
+static int
+get_by_idx_cb(daos_handle_t ih, vos_iter_entry_t *entry, vos_iter_type_t type,
+	      vos_iter_param_t *param, void *cb_arg, unsigned int *acts)
+{
+	struct search_args *args = cb_arg;
+
+	/* not found yet */
+	if (args->sa_idx != args->sa_current) {
+		args->sa_current++;
+		return 0;
+	}
+
+	switch (type) {
+	case VOS_ITER_COUUID:
+		uuid_copy(args->sa_uuid, entry->ie_couuid);
+		break;
+	case VOS_ITER_OBJ:
+		args->sa_uoid = entry->ie_oid;
+		break;
+	case VOS_ITER_DKEY:
+		args->sa_key = entry->ie_key;
+		break;
+	case VOS_ITER_AKEY:
+		args->sa_key = entry->ie_key;
+		break;
+	case VOS_ITER_SINGLE:
+		break;
+	case VOS_ITER_RECX:
+		args->sa_recx = entry->ie_orig_recx;
+		break;
+	case VOS_ITER_DTX:
+		break;
+	case VOS_ITER_NONE:
+		break;
+	}
+
+	return 1;
+}
+
+static int
+get_by_idx(daos_handle_t hdl, uint32_t idx, struct search_args *args, daos_unit_oid_t *uoid,
+	   daos_key_t *dkey, daos_key_t *akey, vos_iter_type_t type)
+{
+	vos_iter_param_t param = {0};
+	struct vos_iter_anchors anchors = {0};
+	int found;
+
+	args->sa_idx = idx;
+
+	param.ip_hdl = hdl;
+	param.ip_epr.epr_hi = DAOS_EPOCH_MAX;
+	if (uoid)
+		param.ip_oid = *uoid;
+	if (dkey)
+		param.ip_dkey = *dkey;
+	if (akey)
+		param.ip_akey = *akey;
+	found = vos_iterate(&param, type, false, &anchors, get_by_idx_cb, NULL, args, NULL);
+
+	if (!found)
+		return -DER_INVAL;
+
+	return 0;
+}
+
+int
+dv_get_cont_uuid(daos_handle_t poh, uint32_t idx, uuid_t uuid)
+{
+	struct search_args args = {0};
+	int rc;
+
+	rc = get_by_idx(poh, idx, &args, NULL, NULL, NULL, VOS_ITER_COUUID);
+	if (SUCCESS(rc))
+		uuid_copy(uuid, args.sa_uuid);
+	return rc;
+}
+
+int
+dv_get_object_oid(daos_handle_t coh, uint32_t idx, daos_unit_oid_t *uoid)
+{
+	struct search_args args = {0};
+	int rc;
+
+	D_ASSERT(uoid != NULL);
+	if (daos_handle_is_inval(coh))
+		return -DER_INVAL;
+
+	rc = get_by_idx(coh, idx, &args, NULL, NULL, NULL, VOS_ITER_OBJ);
+	if (SUCCESS(rc))
+		*uoid = args.sa_uoid;
+
+	return rc;
+}
+
+int
+dv_get_dkey(daos_handle_t coh, daos_unit_oid_t uoid, uint32_t idx, daos_key_t *dkey)
+{
+	struct search_args args = {0};
+	int rc;
+
+	D_ASSERT(dkey != NULL);
+	if (daos_handle_is_inval(coh) || daos_unit_oid_is_null(uoid))
+		return -DER_INVAL;
+
+	rc = get_by_idx(coh, idx, &args, &uoid, NULL, NULL, VOS_ITER_DKEY);
+	if (SUCCESS(rc))
+		*dkey = args.sa_key;
+
+	return rc;
+}
+
+int
+dv_get_akey(daos_handle_t coh, daos_unit_oid_t uoid, daos_key_t *dkey, uint32_t idx,
+	    daos_key_t *akey)
+{
+	struct search_args args = {0};
+	int rc;
+
+	D_ASSERT(dkey != NULL);
+	D_ASSERT(akey != NULL);
+	if (daos_handle_is_inval(coh) || daos_unit_oid_is_null(uoid))
+		return -DER_INVAL;
+
+	rc = get_by_idx(coh, idx, &args, &uoid, dkey, NULL, VOS_ITER_AKEY);
+	if (SUCCESS(rc))
+		*akey = args.sa_key;
+
+	return rc;
+}
+
+int
+dv_get_recx(daos_handle_t coh, daos_unit_oid_t uoid, daos_key_t *dkey, daos_key_t *akey,
+	    uint32_t idx, daos_recx_t *recx)
+{
+	struct search_args args = {0};
+	int rc;
+
+	D_ASSERT(dkey != NULL);
+	D_ASSERT(akey != NULL);
+	D_ASSERT(recx != NULL);
+	if (daos_handle_is_inval(coh) || daos_unit_oid_is_null(uoid))
+		return -DER_INVAL;
+
+	rc = get_by_idx(coh, idx, &args, &uoid, dkey, akey, VOS_ITER_RECX);
+	if (SUCCESS(rc))
+		*recx = args.sa_recx;
+
+	return rc;
+}
+
+#define is_path_idx_set(idx) ((idx) != DDB_IDX_UNSET)
+
+int
+dv_path_update_from_indexes(struct dv_tree_path_builder *vt_path)
+{
+	daos_handle_t	poh = vt_path->vtp_poh;
+	daos_handle_t	coh;
+	int		rc = 0;
+
+	if (is_path_idx_set(vt_path->vtp_cont_idx))
+		dv_get_cont_uuid(poh, vt_path->vtp_cont_idx,
+				 vt_path->vtp_path.vtp_cont);
+
+	if (is_path_idx_set(vt_path->vtp_oid_idx)) {
+		daos_unit_oid_t uoid = {0};
+
+		rc = dv_cont_open(poh, vt_path->vtp_path.vtp_cont, &coh);
+		if (!SUCCESS(rc))
+			return rc;
+		rc = dv_get_object_oid(coh, vt_path->vtp_oid_idx, &uoid);
+		if (!SUCCESS(rc))
+			goto out;
+		vt_path->vtp_path.vtp_oid = uoid;
+	}
+
+	if (is_path_idx_set(vt_path->vtp_dkey_idx)) {
+		if (daos_handle_is_inval(coh)) {
+			rc = dv_cont_open(poh, vt_path->vtp_path.vtp_cont, &coh);
+			if (!SUCCESS(rc))
+				return rc;
+		}
+
+		rc = dv_get_dkey(coh, vt_path->vtp_path.vtp_oid, vt_path->vtp_dkey_idx,
+				 &vt_path->vtp_path.vtp_dkey);
+		if (!SUCCESS(rc))
+			goto out;
+	}
+
+	if (is_path_idx_set(vt_path->vtp_akey_idx)) {
+		if (daos_handle_is_inval(coh)) {
+			rc = dv_cont_open(poh, vt_path->vtp_path.vtp_cont, &coh);
+			if (!SUCCESS(rc))
+				return rc;
+		}
+
+		rc = dv_get_akey(coh, vt_path->vtp_path.vtp_oid,
+				 &vt_path->vtp_path.vtp_dkey, vt_path->vtp_akey_idx,
+				 &vt_path->vtp_path.vtp_akey);
+		if (!SUCCESS(rc))
+			goto out;
+
+	}
+
+	if (is_path_idx_set(vt_path->vtp_recx_idx)) {
+		rc = dv_get_recx(coh, vt_path->vtp_path.vtp_oid,
+				 &vt_path->vtp_path.vtp_dkey,
+				 &vt_path->vtp_path.vtp_akey,
+				 vt_path->vtp_recx_idx,
+				 &vt_path->vtp_path.vtp_recx);
+	}
+out:
+	dv_cont_close(&coh);
+
+	return rc;
+}
+
+struct ddb_iter_ctx {
+	daos_handle_t			 poh;
+	struct vos_tree_handlers	*handlers;
+	void				*handler_args;
+	uuid_t				 current_cont;
+	uint32_t			 cont_seen;
+	daos_unit_oid_t			 current_obj;
+	uint32_t			 obj_seen;
+	daos_key_t			 current_dkey;
+	uint32_t			 dkey_seen;
+	daos_key_t			 current_akey;
+	uint32_t			 akey_seen;
+	uint32_t			 value_seen;
+};
+
+static int
+handle_cont(struct ddb_iter_ctx *ctx, vos_iter_entry_t *entry, vos_iter_param_t *param)
+{
+	struct ddb_cont	cont = {0};
+
+	D_ASSERT(ctx && ctx->handlers && ctx->handlers->ddb_cont_handler);
+
+	uuid_copy(ctx->current_cont, entry->ie_couuid);
+	uuid_copy(cont.ddbc_cont_uuid, entry->ie_couuid);
+	cont.ddbc_idx = ctx->cont_seen++;
+
+	/* Restart object count for container */
+	ctx->obj_seen = 0;
+
+	return ctx->handlers->ddb_cont_handler(&cont, ctx->handler_args);
+}
+
+static int
+handle_obj(struct ddb_iter_ctx *ctx, vos_iter_entry_t *entry)
+{
+	struct ddb_obj obj = {0};
+
+	D_ASSERT(ctx && ctx->handlers && ctx->handlers->ddb_obj_handler);
+	obj.ddbo_idx = ctx->obj_seen++;
+	obj.ddbo_oid = entry->ie_oid.id_pub;
+	ctx->current_obj = entry->ie_oid;
+
+	/* Restart dkey count for the object */
+	ctx->dkey_seen = 0;
+
+	return ctx->handlers->ddb_obj_handler(&obj, ctx->handler_args);
+}
+
+static int
+handle_dkey(struct ddb_iter_ctx *ctx, vos_iter_entry_t *entry)
+{
+	struct ddb_key dkey = {0};
+
+	D_ASSERT(ctx && ctx->handlers && ctx->handlers->ddb_dkey_handler);
+	dkey.ddbk_idx = ctx->dkey_seen++;
+	dkey.ddbk_key = entry->ie_key;
+	ctx->current_dkey = entry->ie_key;
+
+	/* Restart the akey count for the dkey */
+	ctx->akey_seen = 0;
+
+	return ctx->handlers->ddb_dkey_handler(&dkey, ctx->handler_args);
+}
+
+static int
+handle_akey(struct ddb_iter_ctx *ctx, vos_iter_entry_t *entry)
+{
+	struct ddb_key akey = {0};
+
+	D_ASSERT(ctx && ctx->handlers && ctx->handlers->ddb_akey_handler);
+	akey.ddbk_idx = ctx->akey_seen++;
+	akey.ddbk_key = entry->ie_key;
+	ctx->current_akey = entry->ie_key;
+
+
+	/* Restart the values seen for the akey */
+	ctx->value_seen = 0;
+
+	return ctx->handlers->ddb_akey_handler(&akey, ctx->handler_args);
+}
+
+static int
+handle_sv(struct ddb_iter_ctx *ctx, vos_iter_entry_t *entry)
+{
+	struct ddb_sv value = {0};
+
+	D_ASSERT(ctx && ctx->handlers && ctx->handlers->ddb_sv_handler);
+	value.ddbs_record_size = entry->ie_rsize;
+	value.ddbs_idx = ctx->value_seen++;
+
+
+	return ctx->handlers->ddb_sv_handler(&value, ctx->handler_args);
+}
+
+static int
+handle_array(struct ddb_iter_ctx *ctx, vos_iter_entry_t *entry)
+{
+	struct ddb_array value = {0};
+
+	D_ASSERT(ctx && ctx->handlers && ctx->handlers->ddb_array_handler);
+	value.ddba_record_size = entry->ie_rsize;
+	value.ddba_recx = entry->ie_orig_recx;
+	value.ddba_idx = ctx->value_seen++;
+
+	return ctx->handlers->ddb_array_handler(&value, ctx->handler_args);
+}
+
+static int
+handle_iter_cb(daos_handle_t ih, vos_iter_entry_t *entry, vos_iter_type_t type,
+	       vos_iter_param_t *param, void *cb_arg, unsigned int *acts)
+{
+	switch (type) {
+	case VOS_ITER_COUUID:
+		return handle_cont(cb_arg, entry, param);
+	case VOS_ITER_OBJ:
+		return handle_obj(cb_arg, entry);
+	case VOS_ITER_DKEY:
+		return handle_dkey(cb_arg, entry);
+	case VOS_ITER_AKEY:
+		return handle_akey(cb_arg, entry);
+	case VOS_ITER_SINGLE:
+		return handle_sv(cb_arg, entry);
+	case VOS_ITER_RECX:
+		return handle_array(cb_arg, entry);
+	case VOS_ITER_DTX:
+		printf("dtx\n");
+		break;
+	case VOS_ITER_NONE:
+		break;
+	}
+
+	return 0;
+}
+
+static int
+iter_cont_recurse_cb(daos_handle_t ih, vos_iter_entry_t *entry, vos_iter_type_t type,
+		     vos_iter_param_t *param, void *cb_arg, unsigned int *acts)
+{
+	vos_iter_param_t	 cont_param = {0};
+	struct vos_iter_anchors	 anchors = {0};
+	daos_handle_t		 coh;
+	int			 rc;
+
+	D_ASSERT(type == VOS_ITER_COUUID);
+
+	rc = handle_cont(cb_arg, entry, param);
+	if (!SUCCESS(rc))
+		return rc;
+
+	/* recursively iterate the objects in the container */
+	rc = vos_cont_open(param->ip_hdl, entry->ie_couuid, &coh);
+	if (!SUCCESS(rc))
+		return rc;
+
+	cont_param.ip_hdl = coh;
+	cont_param.ip_epr.epr_hi = DAOS_EPOCH_MAX;
+	rc = ddb_vos_iterate(&cont_param, VOS_ITER_OBJ, true, &anchors, handle_iter_cb, cb_arg);
+
+	if (rc != 0)
+		D_ERROR("vos_iterate error: "DF_RC"\n", DP_RC(rc));
+
+	rc = vos_cont_close(coh);
+
+	return rc;
+}
+
+static int
+iter_cont_recurse(vos_iter_param_t *param, struct ddb_iter_ctx *ctx)
+{
+	struct vos_iter_anchors	anchors = {0};
+
+	return ddb_vos_iterate(param, VOS_ITER_COUUID, false, &anchors, iter_cont_recurse_cb, ctx);
+}
+
+int
+dv_iterate(daos_handle_t poh, struct dv_tree_path *path, bool recursive,
+	   struct vos_tree_handlers *handlers, void *handler_args)
+{
+	vos_iter_param_t	param = {0};
+	struct vos_iter_anchors	anchors = {0};
+	int			rc;
+	daos_handle_t		coh = DAOS_HDL_INVAL;
+	vos_iter_type_t		type;
+	struct ddb_iter_ctx	ctx = {0};
+
+	ctx.handlers = handlers;
+	ctx.handler_args = handler_args;
+	ctx.poh = poh;
+
+	param.ip_epr.epr_hi = DAOS_EPOCH_MAX;
+
+	if (uuid_is_null(path->vtp_cont)) {
+		param.ip_hdl = poh;
+
+		if (recursive)
+			/*
+			 * currently vos_iterate doesn't handle recursive iteration starting with a
+			 * container. This works around that limitation.
+			 */
+			return iter_cont_recurse(&param, &ctx);
+		return ddb_vos_iterate(&param, VOS_ITER_COUUID, false, &anchors,
+				       handle_iter_cb, &ctx);
+	}
+
+	rc = vos_cont_open(poh, path->vtp_cont, &coh);
+	if (!SUCCESS(rc))
+		return rc;
+
+	param.ip_hdl = coh;
+
+	param.ip_oid = path->vtp_oid;
+	param.ip_dkey = path->vtp_dkey;
+	param.ip_akey = path->vtp_akey;
+
+	if (daos_oid_is_null(path->vtp_oid.id_pub)) {
+		type = VOS_ITER_OBJ;
+	} else if (path->vtp_dkey.iov_len == 0) {
+		type = VOS_ITER_DKEY;
+	} else if (path->vtp_akey.iov_len == 0) {
+		type = VOS_ITER_AKEY;
+	} else {
+		/* Don't know if the akey value is sv or array so just
+		 * try to iterate both. Doesn't seem to have any negative consequences for
+		 * trying to iterate what the value is not.
+		 */
+		rc = ddb_vos_iterate(&param, VOS_ITER_RECX, recursive, &anchors,
+				     handle_iter_cb, &ctx);
+		if (!SUCCESS(rc)) {
+			vos_cont_close(coh);
+
+			return rc;
+		}
+		rc = ddb_vos_iterate(&param, VOS_ITER_SINGLE, recursive, &anchors,
+				     handle_iter_cb, &ctx);
+		vos_cont_close(coh);
+
+		return rc;
+	}
+
+	rc = ddb_vos_iterate(&param, type, recursive, &anchors, handle_iter_cb, &ctx);
+
+	if (!daos_handle_is_inval(coh))
+		vos_cont_close(coh);
+
+	return rc;
+}

--- a/src/ddb/ddb_vos.h
+++ b/src/ddb/ddb_vos.h
@@ -1,0 +1,94 @@
+/**
+ * (C) Copyright 2022 Intel Corporation.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause-Patent
+ */
+
+#ifndef DAOS_DDB_VOS_H
+#define DAOS_DDB_VOS_H
+
+#include <daos_srv/vos_types.h>
+#include "ddb_common.h"
+
+struct ddb_cont {
+	uuid_t		ddbc_cont_uuid;
+	uint32_t	ddbc_idx;
+};
+
+struct ddb_obj {
+	daos_obj_id_t	ddbo_oid;
+	uint32_t	ddbo_idx;
+};
+
+struct ddb_key {
+	daos_key_t	ddbk_key;
+	uint32_t	ddbk_idx;
+};
+
+struct ddb_sv {
+	uint64_t	ddbs_record_size;
+	uint32_t	ddbs_idx;
+};
+
+struct ddb_array {
+	uint64_t	ddba_record_size;
+	daos_recx_t	ddba_recx;
+	uint32_t	ddba_idx;
+};
+
+/* Open and close a pool for a ddb_ctx */
+int ddb_vos_pool_open(char *path, daos_handle_t *poh);
+int ddb_vos_pool_close(daos_handle_t poh);
+
+/* Open and close a cont for a ddb_ctx */
+int dv_cont_open(daos_handle_t poh, unsigned char *uuid, daos_handle_t *coh);
+int dv_cont_close(daos_handle_t *coh);
+
+/*
+ * Table of functions for handling parts of a vos tree. Is used with vos_iterate and well defined
+ * structures for each tree branch.
+ */
+struct vos_tree_handlers {
+	int (*ddb_cont_handler)(struct ddb_cont *cont, void *args);
+	int (*ddb_obj_handler)(struct ddb_obj *obj, void *args);
+	int (*ddb_dkey_handler)(struct ddb_key *key, void *args);
+	int (*ddb_akey_handler)(struct ddb_key *key, void *args);
+	int (*ddb_sv_handler)(struct ddb_sv *key, void *args);
+	int (*ddb_array_handler)(struct ddb_array *key, void *args);
+};
+
+/*
+ * Traverse over a vos tree. The starting point is indicated by the path passed.
+ */
+/**
+ *
+ * @param poh		Open pool handle
+ * @param path		Starting point for traversing the tree
+ * @param recursive	Whether to traverse the tree from the starting path recursively, or
+ *			just the immediate children
+ * @param handlers	Function table providing the callbacks for handling the vos tree parts
+ * @param handler_args	arguments to the handlers
+ * @return		0 if success, else error
+ */
+int dv_iterate(daos_handle_t poh, struct dv_tree_path *path, bool recursive,
+	       struct vos_tree_handlers *handlers, void *handler_args);
+
+
+/* The following functions lookup a vos path part given a starting point and the index desired */
+int dv_get_cont_uuid(daos_handle_t poh, uint32_t idx, uuid_t uuid);
+int dv_get_object_oid(daos_handle_t coh, uint32_t idx, daos_unit_oid_t *uoid);
+int dv_get_dkey(daos_handle_t coh, daos_unit_oid_t uoid, uint32_t idx, daos_key_t *dkey);
+int dv_get_akey(daos_handle_t coh, daos_unit_oid_t uoid, daos_key_t *dkey, uint32_t idx,
+		daos_key_t *akey);
+int dv_get_recx(daos_handle_t coh, daos_unit_oid_t uoid, daos_key_t *dkey, daos_key_t *akey,
+		uint32_t idx, daos_recx_t *recx);
+
+/**
+ * Update the tree path within the builder with any indexes that the builder was set with.
+ * @param ctx		application context
+ * @param vt_path	The path builder structure.
+ * @return		0 if successful, else error.
+ */
+int dv_path_update_from_indexes(struct dv_tree_path_builder *vt_path);
+
+#endif /* DAOS_DDB_VOS_H */

--- a/src/ddb/tests/SConscript
+++ b/src/ddb/tests/SConscript
@@ -1,0 +1,37 @@
+"""Build tests"""
+import daos_build
+import os
+
+def scons():
+    """Execute build"""
+    Import('base_env', 'prereqs', 'ddblib')
+
+    denv = base_env.Clone()
+
+    # Add runtime paths for daos libraries
+    denv.AppendUnique(RPATH_FULL=['$PREFIX/lib64/daos_srv'])
+    denv.AppendUnique(RPATH_FULL=['$PREFIX/lib64'])
+
+    prereqs.require(denv, 'argobots', 'protobufc', 'pmdk')
+
+    # for ddb includes
+    denv.AppendUnique(CPPPATH=[Dir('../').srcnode()])
+    denv.AppendUnique(LIBPATH=[Dir('../')])
+    denv.AppendUnique(CPPDEFINES='_GNU_SOURCE') # for fallocate
+
+    libs = ['vos', 'daos_common_pmem', 'abt', 'gurt', 'daos', 'uuid', 'bio',
+            'cmocka']
+    src = ['ddb_cmd_options_tests.c',
+           'ddb_commands_tests.c',
+           'ddb_main_tests.c',
+           'ddb_parse_tests.c',
+           'ddb_test_driver.c',
+           'ddb_vos_tests.c']
+    ddb_tests = daos_build.program(denv, 'ddb_tests',
+                                   [ddblib, src],
+                                   LIBS=libs)
+
+    denv.Install('$PREFIX/bin/', ddb_tests)
+
+if __name__ == "SCons.Script":
+    scons()

--- a/src/ddb/tests/ddb_cmd_options_tests.c
+++ b/src/ddb/tests/ddb_cmd_options_tests.c
@@ -1,0 +1,98 @@
+/**
+ * (C) Copyright 2022 Intel Corporation.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause-Patent
+ */
+#include <daos/tests_lib.h>
+#include <gurt/debug.h>
+#include <ddb_common.h>
+#include <ddb_parse.h>
+#include <ddb_cmd_options.h>
+#include "ddb_cmocka.h"
+#include "ddb_test_driver.h"
+
+#define test_run_inval_cmd(...) \
+	assert_rc_equal(-DER_INVAL, __test_run_cmd(NULL, (char *[]){"prog_name", \
+	__VA_ARGS__, NULL}))
+#define test_run_cmd(ctx, ...) \
+	assert_success(__test_run_cmd(ctx, (char *[]){"prog_name", __VA_ARGS__, NULL}))
+
+static int
+fake_print(const char *fmt, ...)
+{
+	return 0;
+}
+static int
+__test_run_cmd(struct ddb_cmd_info *info, char *argv[])
+{
+	struct argv_parsed	parse_args = {0};
+	uint32_t		argc = 0;
+	struct ddb_ctx		ctx = {0};
+	struct ddb_cmd_info	tmp_info = {0};
+
+	ctx.dc_io_ft.ddb_print_message = fake_print;
+	ctx.dc_io_ft.ddb_print_error = fake_print;
+	if (info == NULL)
+		info = &tmp_info;
+
+	assert_non_null(argv);
+	if (g_verbose)
+		printf("Command: ");
+	while (argv[argc] != NULL) {
+		if (g_verbose)
+			printf("%s ", argv[argc]);
+		argc++;
+	}
+	if (g_verbose)
+		printf("\n");
+
+	parse_args.ap_argv = argv;
+	parse_args.ap_argc = argc;
+
+	int rc = ddb_parse_cmd_args(&ctx, &parse_args, info);
+
+	if (!SUCCESS(rc))
+		return rc;
+
+	return rc;
+}
+
+static void
+ls_options_parsing(void **state)
+{
+	struct ddb_cmd_info	 info = {0};
+	struct ls_options	*options = &info.dci_cmd_option.dci_ls;
+
+	test_run_inval_cmd("ls", "path", "invalid_argument"); /* invalid argument */
+	test_run_inval_cmd("ls", "-z"); /* invalid option */
+
+	test_run_cmd(&info, "ls");
+	assert_false(options->recursive);
+	assert_null(options->path);
+
+	test_run_cmd(&info, "ls", "-r");
+	assert_true(options->recursive);
+	assert_null(options->path);
+
+	test_run_cmd(&info, "ls", "/[0]/[0]");
+	assert_false(options->recursive);
+	assert_non_null(options->path);
+	assert_string_equal("/[0]/[0]", options->path);
+}
+
+#define TEST(dsc, test) { dsc, test, NULL, NULL }
+static const struct CMUnitTest tests[] = {
+	TEST("01: ls option parsing", ls_options_parsing),
+};
+
+/*
+ * -----------------------------------------------
+ * Execute
+ * -----------------------------------------------
+ */
+int
+ddb_cmd_options_tests_run()
+{
+	return cmocka_run_group_tests_name("DDB commands option parsing tests", tests,
+					   NULL, NULL);
+}

--- a/src/ddb/tests/ddb_cmocka.h
+++ b/src/ddb/tests/ddb_cmocka.h
@@ -1,0 +1,44 @@
+/**
+ * (C) Copyright 2022 Intel Corporation.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause-Patent
+ */
+
+#ifndef DAOS_DDB_CMOCKA_H
+#define DAOS_DDB_CMOCKA_H
+#include <stddef.h>
+#include <setjmp.h>
+#include <stdarg.h>
+#include <cmocka.h>
+
+#define assert_uuid_equal(a, b) \
+	do { \
+	char str_a[DAOS_UUID_STR_SIZE]; \
+	char str_b[DAOS_UUID_STR_SIZE]; \
+	uuid_unparse(a, str_a); \
+	uuid_unparse(b, str_b); \
+	assert_string_equal(str_a, str_b); \
+	} while (0)
+#define assert_uuid_not_equal(a, b) \
+	do { \
+		char str_a[DAOS_UUID_STR_SIZE]; \
+		char str_b[DAOS_UUID_STR_SIZE]; \
+		uuid_unparse(a, str_a); \
+		uuid_unparse(b, str_b); \
+		assert_string_not_equal(str_a, str_b); \
+	} while (0)
+#define assert_oid_equal(a, b) \
+	do { \
+		assert_int_equal((a).hi, (b).hi); \
+		assert_int_equal((a).lo, (b).lo); \
+	} while (0)
+
+#define assert_oid_not_equal(a, b) assert_true(a.hi != b.hi || a.lo != b.lo)
+#define assert_key_equal(a, b) \
+	do { \
+		assert_int_equal(a.iov_len, b.iov_len); \
+		assert_int_equal(a.iov_buf_len, b.iov_buf_len); \
+		assert_memory_equal(a.iov_buf, b.iov_buf, a.iov_len); \
+	} while (0)
+
+#endif /* DAOS_DDB_CMOCKA_H */

--- a/src/ddb/tests/ddb_commands_tests.c
+++ b/src/ddb/tests/ddb_commands_tests.c
@@ -1,0 +1,127 @@
+/**
+ * (C) Copyright 2022 Intel Corporation.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause-Patent
+ */
+#include <gurt/debug.h>
+#include <daos/tests_lib.h>
+#include <ddb_common.h>
+#include <ddb_cmd_options.h>
+#include <daos_srv/vos.h>
+#include "ddb_cmocka.h"
+#include "ddb_test_driver.h"
+
+/*
+ * Test that the command line arguments execute the correct tool command with the correct
+ * options/arguments for the command. Verification depends on the ability to set fake command
+ * functions in a command function table that the program uses.
+ */
+
+static uint32_t fake_print_called;
+static char fake_print_buffer[1024];
+int fake_print(const char *fmt, ...)
+{
+	va_list args;
+
+	fake_print_called++;
+	va_start(args, fmt);
+	vsnprintf(fake_print_buffer, ARRAY_SIZE(fake_print_buffer), fmt, args);
+	va_end(args);
+	if (g_verbose)
+		printf("%s", fake_print_buffer);
+
+	return 0;
+}
+
+/*
+ * -----------------------------------------------
+ * Test Functions
+ * -----------------------------------------------
+ */
+static void
+test_quit(void **state)
+{
+	struct ddb_ctx		 ctx = {0};
+
+	/* Quit is really simple and should just indicate to the program context that it's
+	 * time to quit
+	 */
+	assert_success(ddb_run_quit(&ctx));
+	assert_true(ctx.dc_should_quit);
+}
+
+static void
+test_ls(void **state)
+{
+	struct dt_vos_pool_ctx	*tctx = *state;
+	struct ddb_ctx		 ctx = {0};
+	struct ls_options	 opt = {.recursive = false, .path = ""};
+	int			 items_in_tree;
+
+	ctx.dc_poh = tctx->dvt_poh;
+	ctx.dc_io_ft.ddb_print_message = fake_print;
+	ctx.dc_io_ft.ddb_print_error = fake_print;
+	assert_success(ddb_run_ls(&ctx, &opt));
+
+	/* At least each container should be printed */
+	assert_true(ARRAY_SIZE(g_uuids) <= fake_print_called);
+
+	/* With recursive set, every item in the tree should be printed */
+	opt.recursive = true;
+	items_in_tree = ARRAY_SIZE(g_uuids) * ARRAY_SIZE(g_oids) *
+			ARRAY_SIZE(g_dkeys) * ARRAY_SIZE(g_akeys);
+	fake_print_called = 0;
+	assert_success(ddb_run_ls(&ctx, &opt));
+	assert_true(items_in_tree <= fake_print_called);
+
+	/* pick a specific oid - each dkey should be printed */
+	opt.path = "[0]/[0]";
+	opt.recursive = false;
+	assert_success(ddb_run_ls(&ctx, &opt));
+	assert_true(ARRAY_SIZE(g_dkeys) <= fake_print_called);
+}
+
+/*
+ * --------------------------------------------------------------
+ * End test functions
+ * --------------------------------------------------------------
+ */
+
+static int
+dcv_suit_setup(void **state)
+{
+	struct dt_vos_pool_ctx *tctx;
+
+	assert_success(ddb_test_setup_vos(state));
+
+	/* test setup creates the pool, but doesn't open it ... leave it open for these tests */
+	tctx = *state;
+	assert_success(vos_pool_open(tctx->dvt_pmem_file, tctx->dvt_pool_uuid, 0, &tctx->dvt_poh));
+
+	return 0;
+}
+
+static int
+dcv_suit_teardown(void **state)
+{
+	struct dt_vos_pool_ctx *tctx = *state;
+
+	dvt_delete_all_containers(tctx->dvt_poh);
+	assert_success(vos_pool_close(tctx->dvt_poh));
+	ddb_teardown_vos(state);
+
+	return 0;
+}
+
+#define TEST(dsc, test) { dsc, test, NULL, NULL }
+static const struct CMUnitTest tests[] = {
+	TEST("01: quit", test_quit),
+	TEST("01: ls", test_ls),
+};
+
+int
+dvc_tests_run()
+{
+	return cmocka_run_group_tests_name("DDB commands tests", tests,
+					   dcv_suit_setup, dcv_suit_teardown);
+}

--- a/src/ddb/tests/ddb_main_tests.c
+++ b/src/ddb/tests/ddb_main_tests.c
@@ -1,0 +1,134 @@
+/**
+ * (C) Copyright 2022 Intel Corporation.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause-Patent
+ */
+#include <daos/tests_lib.h>
+#include <ddb_main.h>
+#include <ddb_cmd_options.h>
+#include "ddb_cmocka.h"
+#include "ddb_test_driver.h"
+
+/*
+ * Test that the command line interface interacts with a 'user' correctly. Will verify that the
+ * command line options and arguments are handled correctly and the interactive mode.
+ */
+
+
+#define assert_main(...) \
+	assert_success(__test_run_main((char *[]){"prog_name", __VA_ARGS__, NULL}))
+#define assert_invalid_main(...) \
+	assert_rc_equal(-DER_INVAL, __test_run_main((char *[]){"prog_name", __VA_ARGS__, NULL}))
+
+
+static int
+fake_print_message(const char *fmt, ...)
+{
+	return 0;
+}
+
+uint32_t fake_get_input_called;
+int fake_get_input_inputs_count;
+int fake_get_input_inputs_idx;
+char fake_get_input_inputs[64][64];
+
+#define set_fake_inputs(...) __set_fake_inputs((char *[]){__VA_ARGS__, NULL})
+static inline void
+__set_fake_inputs(char *inputs[])
+{
+	int i = 0;
+
+	while (inputs[i] != NULL) {
+		/* input from user will always have a new line at the end */
+		sprintf(fake_get_input_inputs[i], "%s\n", inputs[i]);
+		i++;
+	}
+	fake_get_input_inputs_count = i;
+	fake_get_input_inputs_idx = 0;
+}
+
+static char *
+fake_get_input(char *buf, uint32_t buf_len)
+{
+	char *input = fake_get_input_inputs[fake_get_input_inputs_idx++];
+
+	strncpy(buf, input, min(strlen(input) + 1, buf_len));
+	fake_get_input_called++;
+
+	return input;
+}
+
+static int
+__test_run_main(char *argv[])
+{
+	struct argv_parsed	parse_args = {0};
+	uint32_t		argc = 0;
+	struct ddb_io_ft ft = {
+		.ddb_print_message = fake_print_message,
+		.ddb_print_error = fake_print_message,
+		.ddb_get_input = fake_get_input,
+	};
+
+	assert_non_null(argv);
+	if (g_verbose)
+		printf("Command: ");
+	while (argv[argc] != NULL && strcmp(argv[argc], "") != 0) {
+		if (g_verbose)
+			printf("%s ", argv[argc]);
+		argc++;
+	}
+	if (g_verbose)
+		printf("\n");
+
+	parse_args.ap_argv = argv;
+	parse_args.ap_argc = argc;
+
+	return ddb_main(&ft, argc, argv);
+}
+
+#define assert_main_interactive_with_input(...) \
+	__assert_main_interactive_with_input((char *[]) {__VA_ARGS__, NULL})
+static void
+__assert_main_interactive_with_input(char *inputs[])
+{
+	__set_fake_inputs(inputs);
+	assert_main("");
+}
+
+/*
+ * -----------------------------------------------
+ * Test Functions
+ * -----------------------------------------------
+ */
+
+static void
+test_interactive_mode(void **state)
+{
+	assert_main_interactive_with_input("quit");
+	assert_int_equal(1, fake_get_input_called);
+
+	fake_get_input_called = 0;
+	assert_main_interactive_with_input("ls", "ls", "quit");
+	assert_int_equal(3, fake_get_input_called);
+
+	assert_invalid_main("path", "invalid_extra_arg");
+}
+
+/* Not tested yet:
+ *   - -R is passed
+ *   - -f is passed
+ *   - -w is passed
+ *   - pool shard file is passed as argument
+ */
+
+#define TEST(dsc, test) { dsc, test, NULL, NULL }
+
+static const struct CMUnitTest tests[] = {
+	TEST("Interactive mode asks for input until 'quit'", test_interactive_mode),
+};
+
+int
+ddb_main_tests()
+{
+	return cmocka_run_group_tests_name("DDB CLI tests", tests, NULL, NULL);
+}

--- a/src/ddb/tests/ddb_parse_tests.c
+++ b/src/ddb/tests/ddb_parse_tests.c
@@ -1,0 +1,284 @@
+/**
+ * (C) Copyright 2022 Intel Corporation.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause-Patent
+ */
+#include <daos/tests_lib.h>
+#include <gurt/debug.h>
+#include <ddb_common.h>
+#include <ddb_parse.h>
+#include "ddb_cmocka.h"
+#include "ddb_test_driver.h"
+
+#define assert_parsed_words2(str, count, ...) \
+	__assert_parsed_words2(str, count, (char *[])__VA_ARGS__)
+static void
+__assert_parsed_words2(const char *str, int count, char **expected_words)
+{
+	struct argv_parsed	parse_args = {0};
+	int			i;
+
+	assert_success(ddb_str2argv_create(str, &parse_args));
+	assert_int_equal(count, parse_args.ap_argc);
+
+	for (i = 0; i < parse_args.ap_argc; i++)
+		assert_string_equal(parse_args.ap_argv[i], expected_words[i]);
+
+	ddb_str2argv_free(&parse_args);
+}
+
+static void
+assert_parsed_fail(const char *str)
+{
+	struct argv_parsed	parse_args = {0};
+	int			rc;
+
+	rc = ddb_str2argv_create(str, &parse_args);
+	ddb_str2argv_free(&parse_args);
+	assert_rc_equal(-DER_INVAL, rc);
+}
+
+/*
+ * -----------------------------------------------
+ * Test implementations
+ * -----------------------------------------------
+ */
+
+static void
+test_string_to_argv(void **state)
+{
+	assert_parsed_words2("one", 1, { "one" });
+	assert_parsed_words2("one two", 2, {"one", "two"});
+	assert_parsed_words2("one two three four five", 5, {"one", "two", "three", "four", "five"});
+	assert_parsed_words2("one 'two two two'", 2, {"one", "two two two"});
+	assert_parsed_words2("one 'two two two' three", 3, {"one", "two two two", "three"});
+	assert_parsed_words2("one \"two two two\" three", 3, {"one", "two two two", "three"});
+
+	assert_parsed_fail("one>");
+	assert_parsed_fail("one<");
+	assert_parsed_fail("'one");
+	assert_parsed_fail(" \"one");
+	assert_parsed_fail("one \"two");
+}
+
+#define assert_invalid_program_args(argc, ...) \
+	assert_rc_equal(-DER_INVAL, _assert_invalid_program_args(argc, ((char*[])__VA_ARGS__)))
+static int
+_assert_invalid_program_args(uint32_t argc, char **argv)
+{
+	struct program_args	pa;
+
+	return ddb_parse_program_args(argc, argv, &pa);
+}
+
+#define assert_program_args(expected_program_args, argc, ...) \
+	assert_success(_assert_program_args(&expected_program_args, argc, ((char*[])__VA_ARGS__)))
+static int
+_assert_program_args(struct program_args *expected_pa, uint32_t argc, char **argv)
+{
+	struct program_args pa = {0};
+	int rc;
+
+	rc = ddb_parse_program_args(argc, argv, &pa);
+	if (rc != 0)
+		return rc;
+
+
+	if (expected_pa->pa_r_cmd_run != NULL && pa.pa_r_cmd_run != NULL &&
+	    strcmp(expected_pa->pa_r_cmd_run, pa.pa_r_cmd_run) != 0) {
+		print_error("ERROR: %s != %s\n", expected_pa->pa_r_cmd_run, pa.pa_r_cmd_run);
+		return -DER_INVAL;
+	}
+
+	if (expected_pa->pa_cmd_file != NULL &&  pa.pa_cmd_file != NULL &&
+	    strcmp(expected_pa->pa_cmd_file, pa.pa_cmd_file) != 0) {
+		print_error("ERROR: %s != %s\n", expected_pa->pa_cmd_file, pa.pa_cmd_file);
+		return -DER_INVAL;
+	}
+
+	return 0;
+}
+
+static void
+test_parse_args(void **state)
+{
+	struct program_args pa = {0};
+
+	assert_invalid_program_args(2, {"", "-z"});
+	assert_invalid_program_args(3, {"", "command1", "command2"});
+	pa.pa_r_cmd_run = "command";
+	assert_program_args(pa, 3, {"", "-R", "command"});
+	pa.pa_r_cmd_run = "";
+
+	pa.pa_cmd_file = "path";
+	assert_program_args(pa, 3, {"", "-f", "path"});
+}
+
+#define assert_vtp_eq(a, b) \
+do { \
+	assert_uuid_equal(a.vtp_path.vtp_cont, b.vtp_path.vtp_cont); \
+	assert_int_equal(a.vtp_cont_idx, b.vtp_cont_idx); \
+	assert_int_equal(a.vtp_oid_idx, b.vtp_oid_idx); \
+	assert_int_equal(a.vtp_dkey_idx, b.vtp_dkey_idx); \
+	assert_int_equal(a.vtp_akey_idx, b.vtp_akey_idx); \
+	assert_int_equal(a.vtp_recx_idx, b.vtp_recx_idx); \
+	assert_int_equal(a.vtp_path.vtp_oid.id_pub.hi, b.vtp_path.vtp_oid.id_pub.hi); \
+	assert_int_equal(a.vtp_path.vtp_oid.id_pub.lo, b.vtp_path.vtp_oid.id_pub.lo); \
+	assert_int_equal(a.vtp_path.vtp_dkey.iov_len, b.vtp_path.vtp_dkey.iov_len); \
+	if (a.vtp_path.vtp_dkey.iov_len > 0) \
+		assert_memory_equal(a.vtp_path.vtp_dkey.iov_buf, b.vtp_path.vtp_dkey.iov_buf, \
+					a.vtp_path.vtp_dkey.iov_len); \
+	assert_int_equal(a.vtp_path.vtp_akey.iov_len, b.vtp_path.vtp_akey.iov_len); \
+	if (a.vtp_path.vtp_akey.iov_len > 0) \
+		assert_memory_equal(a.vtp_path.vtp_akey.iov_buf, b.vtp_path.vtp_akey.iov_buf,\
+		                			a.vtp_path.vtp_akey.iov_len); \
+	} while (0)
+
+#define assert_invalid_path(path) \
+do { \
+	struct dv_tree_path_builder __vt = {0}; \
+	assert_rc_equal(-DER_INVAL, ddb_vtp_init(path, &__vt)); \
+} while (0)
+
+#define assert_path(path, expected) \
+do { \
+	struct dv_tree_path_builder __vt = {0}; \
+	assert_success(ddb_vtp_init(path, &__vt)); \
+	assert_vtp_eq(expected, __vt); \
+	ddb_vtp_fini(&__vt); \
+} while (0)
+
+
+/** easily setup an iov and allocate */
+static void
+iov_alloc(d_iov_t *iov, size_t len)
+{
+	D_ALLOC(iov->iov_buf, len);
+	assert_non_null(iov->iov_buf);
+	iov->iov_buf_len = iov->iov_len = len;
+}
+
+static void
+iov_alloc_str(d_iov_t *iov, const char *str)
+{
+	iov_alloc(iov, strlen(str));
+	memcpy(iov->iov_buf, str, strlen(str));
+}
+
+static void
+test_vos_path_parse(void **state)
+{
+	struct dv_tree_path_builder expected_vt = {0};
+	daos_obj_id_t oid;
+
+	ddb_vos_tree_path_setup(&expected_vt);
+
+	/* empty paths are valid */
+	assert_path("", expected_vt);
+	assert_path(NULL, expected_vt);
+
+	/* first part must be a valid uuid */
+	assert_invalid_path("12345678");
+
+	uuid_parse("12345678-1234-1234-1234-123456789012", expected_vt.vtp_path.vtp_cont);
+	oid.lo = 1234;
+	oid.hi = 4321;
+
+	/* handle just container */
+	assert_path("12345678-1234-1234-1234-123456789012", expected_vt);
+	assert_path("/12345678-1234-1234-1234-123456789012", expected_vt);
+	assert_path("12345678-1234-1234-1234-123456789012/", expected_vt);
+	assert_path("/12345678-1234-1234-1234-123456789012/", expected_vt);
+
+	/* handle container and object id */
+	assert_invalid_path("/12345678-1234-1234-1234-123456789012/4321.");
+	expected_vt.vtp_path.vtp_oid.id_pub.lo = 1234;
+	expected_vt.vtp_path.vtp_oid.id_pub.hi = 4321;
+
+	assert_path("/12345678-1234-1234-1234-123456789012/4321.1234", expected_vt);
+
+	/* handle dkey */
+	iov_alloc_str(&expected_vt.vtp_path.vtp_dkey, "dkey");
+	assert_path("/12345678-1234-1234-1234-123456789012/4321.1234/dkey", expected_vt);
+	assert_path("/12345678-1234-1234-1234-123456789012/4321.1234/dkey/", expected_vt);
+
+	iov_alloc_str(&expected_vt.vtp_path.vtp_akey, "akey");
+	assert_path("/12345678-1234-1234-1234-123456789012/4321.1234/dkey/akey", expected_vt);
+	assert_path("/12345678-1234-1234-1234-123456789012/4321.1234/dkey/akey/", expected_vt);
+
+	expected_vt.vtp_path.vtp_recx.rx_idx = 1;
+	expected_vt.vtp_path.vtp_recx.rx_nr = 5;
+	assert_path("/12345678-1234-1234-1234-123456789012/4321.1234/dkey/akey/{1-6}", expected_vt);
+
+	daos_iov_free(&expected_vt.vtp_path.vtp_dkey);
+	daos_iov_free(&expected_vt.vtp_path.vtp_akey);
+}
+
+static void
+test_parse_idx(void **state)
+{
+	struct dv_tree_path_builder expected_vt = {0};
+
+	ddb_vos_tree_path_setup(&expected_vt);
+
+	expected_vt.vtp_cont_idx = 1;
+	assert_path("[1]", expected_vt);
+
+	expected_vt.vtp_cont_idx = 11;
+	assert_path("[11]", expected_vt);
+
+	expected_vt.vtp_cont_idx = 1234;
+	assert_path("[1234]", expected_vt);
+
+	expected_vt.vtp_cont_idx = 1;
+	expected_vt.vtp_oid_idx = 2;
+	expected_vt.vtp_dkey_idx = 3;
+	expected_vt.vtp_akey_idx = 4;
+
+	expected_vt.vtp_recx_idx = 5;
+	assert_path("[1]/[2]/[3]/[4]/[5]", expected_vt);
+}
+
+static void
+test_has_parts(void **state)
+{
+	struct dv_tree_path vtp = {0};
+
+	assert_false(dv_has_cont(&vtp));
+	uuid_copy(vtp.vtp_cont, g_uuids[0]);
+	assert_true(dv_has_cont(&vtp));
+
+	assert_false(dv_has_obj(&vtp));
+	vtp.vtp_oid = g_oids[0];
+	assert_true(dv_has_obj(&vtp));
+
+	assert_false(dv_has_dkey(&vtp));
+	vtp.vtp_dkey = g_dkeys[0];
+	assert_true(dv_has_dkey(&vtp));
+
+	assert_false(dv_has_akey(&vtp));
+	vtp.vtp_akey = g_akeys[0];
+	assert_true(dv_has_akey(&vtp));
+}
+
+#define TEST(dsc, test) { dsc, test, NULL, NULL }
+
+static const struct CMUnitTest tests[] = {
+	TEST("01: string to argv", test_string_to_argv),
+	TEST("03: parse program arguments", test_parse_args),
+	TEST("04: parse a vos path", test_vos_path_parse),
+	TEST("05: parse a vos path with indexes", test_parse_idx),
+	TEST("06: check to see if the path has parts", test_has_parts)
+};
+
+/*
+ * -----------------------------------------------
+ * Execute
+ * -----------------------------------------------
+ */
+int
+ddb_parse_tests_run()
+{
+	return cmocka_run_group_tests_name("DDB helper parsing function tests", tests,
+					   NULL, NULL);
+}

--- a/src/ddb/tests/ddb_smoke_tests.sh
+++ b/src/ddb/tests/ddb_smoke_tests.sh
@@ -1,0 +1,50 @@
+# -----------------------------------------------------------------------------
+# Utility functions
+# -----------------------------------------------------------------------------
+function title() {
+  LINE="======================================================================="
+    echo -e "\e[1m\e[94m${LINE}"
+    echo "$1"
+    echo -e "${LINE}\e[0m"
+}
+
+function p() {
+   if [ "$v_pause" == "1" ]; then
+    read -r var
+    if [ "$var" == "c" ]; then
+        v_pause=0
+    fi
+   fi
+}
+
+
+function pause() {
+  echo -e "\e[1m\e[94m==> $*\e[0m"
+  p
+}
+function msg() {
+   echo -e "\e[1m\e[94m*** $* ***\e[0m"
+}
+
+function echo_cmd() {
+  echo -e "\e[1m\e[32m"
+  echo -e "\$ " "$@"
+  echo -e "\e[0m"
+  p
+}
+
+function run_cmd() {
+  echo_cmd "$@"
+  "$@"
+  echo ""
+  p
+}
+
+# create a vos file to connect to
+run_cmd ddb_tests -c
+
+run_cmd ddb /mnt/daos/12345678-1234-1234-1234-123456789012/ddb_vos_test -R 'ls'
+run_cmd ddb /mnt/daos/12345678-1234-1234-1234-123456789012/ddb_vos_test -R 'ls 12345678-1234-1234-1234-123456789001'
+run_cmd ddb /mnt/daos/12345678-1234-1234-1234-123456789012/ddb_vos_test -R 'ls [0]'
+run_cmd ddb /mnt/daos/12345678-1234-1234-1234-123456789012/ddb_vos_test -R 'ls [0]/[1]'
+run_cmd ddb /mnt/daos/12345678-1234-1234-1234-123456789012/ddb_vos_test -R 'ls -r'

--- a/src/ddb/tests/ddb_test_driver.c
+++ b/src/ddb/tests/ddb_test_driver.c
@@ -1,0 +1,415 @@
+/**
+ * (C) Copyright 2022 Intel Corporation.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause-Patent
+ */
+
+#include <fcntl.h>
+#include <libgen.h>
+#include <daos/tests_lib.h>
+#include <daos_srv/vos.h>
+#include <gurt/debug.h>
+#include <ddb_common.h>
+#include <ddb_main.h>
+#include <sys/stat.h>
+#include "ddb_cmocka.h"
+#include "ddb_test_driver.h"
+
+#define DEFINE_IOV(str) {.iov_buf = str, .iov_buf_len = strlen(str), .iov_len = strlen(str)}
+
+bool g_verbose; /* Can be set to true while developing/debugging tests */
+
+const char *g_uuids_str[] = {
+	"12345678-1234-1234-1234-123456789001",
+	"12345678-1234-1234-1234-123456789002",
+	"12345678-1234-1234-1234-123456789003",
+	"12345678-1234-1234-1234-123456789004",
+	"12345678-1234-1234-1234-123456789005",
+	"12345678-1234-1234-1234-123456789006",
+	"12345678-1234-1234-1234-123456789007",
+	"12345678-1234-1234-1234-123456789008",
+	"12345678-1234-1234-1234-123456789009",
+	"12345678-1234-1234-1234-123456789010",
+};
+
+char *g_dkeys_str[] = {
+	"dkey-1",
+	"dkey-2",
+	"dkey-3",
+	"dkey-4",
+	"dkey-5",
+	"dkey-6",
+	"dkey-7",
+	"dkey-8",
+	"dkey-9",
+	"dkey-10",
+};
+
+char *g_akeys_str[] = {
+	"akey-1",
+	"akey-2",
+	"akey-3",
+	"akey-4",
+	"akey-5",
+	"akey-6",
+	"akey-7",
+	"akey-8",
+	"akey-9",
+	"akey-10",
+};
+
+daos_unit_oid_t	g_oids[10];
+uuid_t		g_uuids[10];
+daos_key_t	g_dkeys[10];
+daos_key_t	g_akeys[10];
+
+daos_obj_id_t
+oid_gen(uint32_t lo)
+{
+	daos_obj_id_t	oid;
+	uint64_t	hdr;
+
+	hdr = 100;
+	hdr <<= 32;
+
+	/* generate a unique and not scary long object ID */
+	oid.lo	= lo;
+	oid.lo	|= hdr;
+	oid.hi	= 100;
+
+	return oid;
+}
+
+daos_unit_oid_t
+gen_uoid(uint32_t lo)
+{
+	daos_unit_oid_t	uoid;
+
+	uoid.id_pub	= oid_gen(lo);
+	daos_obj_set_oid(&uoid.id_pub, daos_obj_feat2type(0), OC_SX, 1, 0);
+	uoid.id_shard	= 0;
+	uoid.id_pad_32	= 0;
+
+	return uoid;
+}
+
+void
+dvt_vos_insert_recx(daos_handle_t coh, daos_unit_oid_t uoid, char *dkey_str, char *akey_str,
+		    int recx_idx, char *data_str, daos_epoch_t epoch)
+{
+	daos_key_t dkey = DEFINE_IOV(dkey_str);
+
+	d_iov_t iov = DEFINE_IOV(data_str);
+	d_sg_list_t sgl = {.sg_iovs = &iov, .sg_nr = 1, .sg_nr_out = 1};
+
+	daos_recx_t recx = {.rx_nr = daos_sgl_buf_size(&sgl), .rx_idx = recx_idx};
+	daos_iod_t iod = {
+		.iod_name = DEFINE_IOV(akey_str),
+		.iod_type = DAOS_IOD_ARRAY,
+		.iod_nr = 1,
+		.iod_size = 1,
+		.iod_recxs = &recx
+	};
+
+	assert_success(vos_obj_update(coh, uoid, epoch, 0, 0, &dkey, 1, &iod, NULL, &sgl));
+}
+
+void
+dvt_vos_insert_single(daos_handle_t coh, daos_unit_oid_t uoid, char *dkey_str, char *akey_str,
+		      char *data_str, daos_epoch_t epoch)
+{
+	daos_key_t dkey = DEFINE_IOV(dkey_str);
+
+	d_iov_t iov = DEFINE_IOV(data_str);
+	d_sg_list_t sgl = {.sg_iovs = &iov, .sg_nr = 1, .sg_nr_out = 1};
+
+	daos_iod_t iod = {
+		.iod_name = DEFINE_IOV(akey_str),
+		.iod_type = DAOS_IOD_SINGLE,
+		.iod_nr = 1,
+		.iod_size = strlen(data_str)
+	};
+
+	assert_success(vos_obj_update(coh, uoid, epoch, 0, 0, &dkey, 1, &iod, NULL, &sgl));
+}
+
+/*
+ * -----------------------------------------------
+ * Test infrastructure
+ * -----------------------------------------------
+ */
+
+int
+ddb_test_pool_setup(struct dt_vos_pool_ctx *tctx)
+{
+	int			 rc;
+	uint64_t		 size = (1ULL << 30);
+	struct stat		 st = {0};
+	char			*pool_uuid = "12345678-1234-1234-1234-123456789012";
+
+	if (strlen(tctx->dvt_pmem_file) == 0) {
+		char dir[64] = {0};
+
+		sprintf(dir, "/mnt/daos/%s", pool_uuid);
+		if (stat(dir, &st) == -1) {
+			if (!SUCCESS(mkdir(dir, 0700))) {
+				rc = daos_errno2der(errno);
+				return rc;
+			}
+		}
+		snprintf(tctx->dvt_pmem_file, ARRAY_SIZE(tctx->dvt_pmem_file),
+			 "%s/ddb_vos_test", dir);
+	}
+	if (uuid_is_null(tctx->dvt_pool_uuid))
+		uuid_parse(pool_uuid, tctx->dvt_pool_uuid);
+
+	D_ASSERT(!daos_file_is_dax(tctx->dvt_pmem_file));
+	rc = open(tctx->dvt_pmem_file, O_CREAT | O_TRUNC | O_RDWR, 0666);
+	if (rc < 0) {
+		rc = daos_errno2der(errno);
+		return rc;
+	}
+
+	tctx->dvt_fd = rc;
+	rc = fallocate(tctx->dvt_fd, 0, 0, size);
+	if (rc) {
+		rc = daos_errno2der(errno);
+		close(tctx->dvt_fd);
+		return rc;
+	}
+
+	rc = vos_pool_create(tctx->dvt_pmem_file, tctx->dvt_pool_uuid, 0, 0, 0, NULL);
+	if (rc) {
+		close(tctx->dvt_fd);
+		return rc;
+	}
+
+	return rc;
+}
+
+static int
+setup_global_arrays()
+{
+	int i;
+
+	for (i = 0; i < ARRAY_SIZE(g_oids); i++)
+		g_oids[i] = gen_uoid(i);
+
+	for (i = 0; i < ARRAY_SIZE(g_uuids_str); i++)
+		uuid_parse(g_uuids_str[i], g_uuids[i]);
+
+	for (i = 0; i < ARRAY_SIZE(g_dkeys); i++)
+		d_iov_set(&g_dkeys[i], g_dkeys_str[i], strlen(g_dkeys_str[i]));
+
+	for (i = 0; i < ARRAY_SIZE(g_akeys); i++)
+		d_iov_set(&g_akeys[i], g_akeys_str[i], strlen(g_akeys_str[i]));
+	return 0;
+}
+
+int
+ddb_test_setup_vos(void **state)
+{
+	struct dt_vos_pool_ctx *tctx = NULL;
+	daos_handle_t poh;
+
+	D_ASSERT(state);
+	D_ALLOC_PTR(tctx);
+	assert_non_null(tctx);
+
+	assert_success(ddb_test_pool_setup(tctx));
+
+	assert_success(vos_pool_open(tctx->dvt_pmem_file, tctx->dvt_pool_uuid, 0, &poh));
+	dvt_insert_data(poh, 0, 0, 0, 0);
+	vos_pool_close(poh);
+
+	*state = tctx;
+
+	return 0;
+}
+
+int
+ddb_teardown_vos(void **state)
+{
+	struct dt_vos_pool_ctx		*tctx = *state;
+
+	assert_success(vos_pool_destroy(tctx->dvt_pmem_file, tctx->dvt_pool_uuid));
+	close(tctx->dvt_fd);
+	D_FREE(tctx);
+
+	return 0;
+}
+
+void
+dvt_iov_alloc(d_iov_t *iov, size_t len)
+{
+	D_ALLOC(iov->iov_buf, len);
+	iov->iov_buf_len = iov->iov_len = len;
+}
+
+void
+dvt_iov_alloc_str(d_iov_t *iov, const char *str)
+{
+	dvt_iov_alloc(iov, strlen(str) + 1);
+	strcpy(iov->iov_buf, str);
+}
+
+void
+dvt_insert_data(daos_handle_t poh, uint32_t conts, uint32_t objs, uint32_t dkeys, uint32_t akeys)
+{
+	daos_handle_t		coh;
+	uint32_t		cont_to_create = ARRAY_SIZE(g_uuids);
+	uint32_t		obj_to_create = ARRAY_SIZE(g_oids);
+	uint32_t		dkeys_to_create = ARRAY_SIZE(g_dkeys);
+	uint32_t		akeys_to_create = ARRAY_SIZE(g_akeys);
+	int			c, o, d, a; /* loop indexes */
+
+	if (conts > 0)
+		cont_to_create = conts;
+	if (objs > 0)
+		obj_to_create = objs;
+	if (dkeys > 0)
+		dkeys_to_create = dkeys;
+	if (akeys > 0)
+		akeys_to_create = akeys;
+
+	/* Setup by creating containers */
+	for (c = 0; c < cont_to_create; c++) {
+		assert_success(vos_cont_create(poh, g_uuids[c]));
+		assert_success(vos_cont_open(poh, g_uuids[c], &coh));
+		for (o = 0; o < obj_to_create; o++) {
+			for (d = 0; d < dkeys_to_create; d++) {
+				for (a = 0; a < akeys_to_create; a++) {
+					if (a % 2 == 0) {
+						dvt_vos_insert_recx(coh, g_oids[o],
+								    g_dkeys_str[d],
+								    g_akeys_str[a], 1,
+								    "This is an array value", 1);
+					} else {
+						dvt_vos_insert_single(coh, g_oids[o],
+								      g_dkeys_str[d],
+								      g_akeys_str[a],
+								      "This is a single value", 1);
+					}
+				}
+			}
+		}
+		vos_cont_close(coh);
+	}
+}
+
+void
+dvt_delete_all_containers(daos_handle_t poh)
+{
+	int	c;
+	uuid_t	uuid;
+
+	for (c = 0; c < ARRAY_SIZE(g_uuids_str); c++) {
+		uuid_parse(g_uuids_str[c], uuid);
+		assert_success(vos_cont_destroy(poh, uuid));
+	}
+}
+
+
+struct ddb_test_driver_arguments {
+	bool	 dtda_create_vos_file;
+};
+
+static int
+ddb_test_driver_arguments_parse(uint32_t argc, char **argv, struct ddb_test_driver_arguments *args)
+{
+	struct option	program_options[] = {
+		{ "create_vos", optional_argument, NULL,	'c' },
+		{ NULL }
+	};
+	int		index = 0, opt;
+
+	memset(args, 0, sizeof(*args));
+
+	optind = 1;
+	opterr = 0;
+	while ((opt = getopt_long(argc, argv, "c", program_options, &index)) != -1) {
+		switch (opt) {
+		case 'c':
+			args->dtda_create_vos_file = true;
+			break;
+		case '?':
+			printf("'%c' is unknown\n", optopt);
+			return -DER_INVAL;
+		default:
+			return -DER_INVAL;
+		}
+	}
+
+	return 0;
+}
+
+static int
+create_test_vos_file()
+{
+	struct dt_vos_pool_ctx	tctx = {0};
+	daos_handle_t		poh;
+	int			conts = 2;
+	int			objs = 5;
+	int			dkeys = 5;
+	int			akeys = 5;
+	int			rc;
+
+	rc = ddb_test_pool_setup(&tctx);
+	if (!SUCCESS(rc)) {
+		print_error("Unable to setup pool: "DF_RC"\n", DP_RC(rc));
+		return rc;
+	}
+	assert_success(vos_pool_open(tctx.dvt_pmem_file, tctx.dvt_pool_uuid, 0, &poh));
+	dvt_insert_data(poh, conts, objs, dkeys, akeys);
+	vos_pool_close(poh);
+
+	close(tctx.dvt_fd);
+
+	print_message("VOS file created at: %s\n", tctx.dvt_pmem_file);
+	print_message("\t- pool uuid: "DF_UUIDF"\n", DP_UUID(tctx.dvt_pool_uuid));
+	print_message("\t- containers: %d\n", conts);
+	print_message("\t- objs: %d\n", objs);
+	print_message("\t- dkeys: %d\n", dkeys);
+	print_message("\t- akeys: %d\n", akeys);
+
+	return 0;
+}
+
+/*
+ * -----------------------------------------------
+ * Execute
+ * -----------------------------------------------
+ */
+int main(int argc, char *argv[])
+{
+	struct ddb_test_driver_arguments	args = {0};
+	int					rc;
+
+	rc = ddb_init();
+	if (rc != 0)
+		return -rc;
+	rc = vos_self_init("/mnt/daos");
+	if (rc != 0) {
+		fprintf(stderr, "Unable to initialize VOS: "DF_RC"\n", DP_RC(rc));
+		ddb_fini();
+		return -rc;
+	}
+
+	ddb_test_driver_arguments_parse(argc, argv, &args);
+
+	setup_global_arrays();
+
+	if (args.dtda_create_vos_file) {
+		create_test_vos_file();
+	} else {
+		rc += ddb_parse_tests_run();
+		rc += ddb_cmd_options_tests_run();
+		rc += dv_tests_run();
+		rc += dvc_tests_run();
+		rc += ddb_main_tests();
+	}
+
+	vos_self_fini();
+	ddb_fini();
+	return rc;
+}

--- a/src/ddb/tests/ddb_test_driver.h
+++ b/src/ddb/tests/ddb_test_driver.h
@@ -1,0 +1,54 @@
+/**
+ * (C) Copyright 2022 Intel Corporation.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause-Patent
+ */
+#ifndef DAOS_DDB_TEST_DRIVER_H
+#define DAOS_DDB_TEST_DRIVER_H
+
+extern bool		 g_verbose;
+extern const char	*g_uuids_str[10];
+extern uuid_t		 g_uuids[10];
+extern daos_unit_oid_t	 g_oids[10];
+extern char		*g_dkeys_str[10];
+extern char		*g_akeys_str[10];
+extern daos_key_t	 g_dkeys[10];
+extern daos_key_t	 g_akeys[10];
+
+struct dt_vos_pool_ctx {
+	daos_handle_t	dvt_poh;
+	uuid_t		dvt_pool_uuid;
+	int		dvt_fd;
+	char		dvt_pmem_file[128];
+};
+
+daos_unit_oid_t gen_uoid(uint32_t lo);
+
+void dvt_vos_insert_recx(daos_handle_t coh, daos_unit_oid_t uoid, char *dkey_str, char *akey_str,
+			 int recx_idx, char *data_str, daos_epoch_t epoch);
+void
+dvt_vos_insert_single(daos_handle_t coh, daos_unit_oid_t uoid, char *dkey_str, char *akey_str,
+		      char *data_str, daos_epoch_t epoch);
+
+void dvt_iov_alloc(d_iov_t *iov, size_t len);
+void dvt_iov_alloc_str(d_iov_t *iov, const char *str);
+
+
+int ddb_test_setup_vos(void **state);
+int ddb_teardown_vos(void **state);
+
+int ddb_parse_tests_run(void);
+int dv_tests_run(void);
+int dvc_tests_run(void);
+int ddb_main_tests(void);
+int ddb_cmd_options_tests_run(void);
+
+/*
+ * Insert data into the pool. The cont, objs, ... parameters indicate how many of each to
+ * insert into its parent. If numbers are 0, then it will use a default number.
+ */
+void dvt_insert_data(daos_handle_t poh, uint32_t conts, uint32_t objs, uint32_t dkeys,
+		    uint32_t akeys);
+void dvt_delete_all_containers(daos_handle_t poh);
+
+#endif /* DAOS_DDB_TEST_DRIVER_H */

--- a/src/ddb/tests/ddb_vos_tests.c
+++ b/src/ddb/tests/ddb_vos_tests.c
@@ -1,0 +1,443 @@
+/**
+ * (C) Copyright 2022 Intel Corporation.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause-Patent
+ */
+#include <gurt/debug.h>
+#include <daos/tests_lib.h>
+#include <ddb_vos.h>
+#include <ddb_common.h>
+#include <daos_srv/vos.h>
+#include "ddb_cmocka.h"
+#include "ddb_test_driver.h"
+
+/*
+ * The tests in this file depend on a VOS instance with a bunch of data written. The tests will
+ * verify that different parts of the VOS tree can be navigated/iterated. The way the
+ */
+
+static int fake_cont_handler_call_count;
+static struct ddb_cont fake_cont_handler_conts[64];
+int fake_cont_handler(struct ddb_cont *cont, void *args)
+{
+	assert_true(fake_cont_handler_call_count < ARRAY_SIZE(fake_cont_handler_conts));
+	fake_cont_handler_conts[fake_cont_handler_call_count] = *cont;
+	fake_cont_handler_call_count++;
+
+	return 0;
+}
+
+static int fake_obj_handler_call_count;
+static struct ddb_obj fake_obj_handler_objs[128];
+int fake_obj_handler(struct ddb_obj *obj, void *args)
+{
+	assert_true(fake_obj_handler_call_count < ARRAY_SIZE(fake_obj_handler_objs));
+	fake_obj_handler_objs[fake_obj_handler_call_count] = *obj;
+	fake_obj_handler_call_count++;
+
+	return 0;
+}
+
+static int fake_dkey_handler_call_count;
+static struct ddb_key fake_dkey_handler_dkeys[1024];
+int fake_dkey_handler(struct ddb_key *key, void *args)
+{
+	assert_true(fake_dkey_handler_call_count < ARRAY_SIZE(fake_dkey_handler_dkeys));
+	fake_dkey_handler_dkeys[fake_dkey_handler_call_count] = *key;
+	fake_dkey_handler_call_count++;
+
+	return 0;
+}
+
+static int fake_akey_handler_call_count;
+static struct ddb_key fake_akey_handler_akeys[2048 * 10];
+int fake_akey_handler(struct ddb_key *key, void *args)
+{
+	assert_true(fake_akey_handler_call_count < ARRAY_SIZE(fake_akey_handler_akeys));
+	fake_akey_handler_akeys[fake_akey_handler_call_count] = *key;
+	fake_akey_handler_call_count++;
+
+	return 0;
+}
+
+static int fake_sv_handler_call_count;
+static struct ddb_sv fake_sv_handler_svs[2048 * 10];
+int fake_sv_handler(struct ddb_sv *sv, void *args)
+{
+	assert_true((uint32_t)fake_sv_handler_call_count < ARRAY_SIZE(fake_sv_handler_svs));
+	fake_sv_handler_svs[fake_sv_handler_call_count] = *sv;
+	fake_sv_handler_call_count++;
+
+	return 0;
+}
+
+static int fake_array_handler_call_count;
+static struct ddb_array fake_array_handler_arrays[2048 * 10];
+int fake_array_handler(struct ddb_array *array, void *args)
+{
+	assert_true(fake_array_handler_call_count < ARRAY_SIZE(fake_array_handler_arrays));
+	fake_array_handler_arrays[fake_array_handler_call_count] = *array;
+	fake_array_handler_call_count++;
+
+	return 0;
+}
+
+static void
+fake_call_counts_reset()
+{
+	fake_cont_handler_call_count = 0;
+	fake_obj_handler_call_count = 0;
+	fake_dkey_handler_call_count = 0;
+	fake_akey_handler_call_count = 0;
+	fake_sv_handler_call_count = 0;
+	fake_array_handler_call_count = 0;
+}
+
+static struct vos_tree_handlers fake_handlers = {
+	.ddb_cont_handler = fake_cont_handler,
+	.ddb_obj_handler = fake_obj_handler,
+	.ddb_dkey_handler = fake_dkey_handler,
+	.ddb_akey_handler = fake_akey_handler,
+	.ddb_sv_handler = fake_sv_handler,
+	.ddb_array_handler = fake_array_handler,
+};
+
+#define expect_int_equal(a, b, rc) \
+	do { \
+		if ((a) != (b)) { \
+			rc++; \
+			print_error("%s:%d - %lu != %lu\n", __FILE__, __LINE__, \
+					(uint64_t)(a), (uint64_t)(b)); \
+		} \
+	} while (0)
+
+#define assert_ddb_iterate(poh, cont_uuid, oid, dkey, akey, recursive, expected_cont, \
+			   expected_obj, expected_dkey, expected_akey,                   \
+			   expected_sv, expected_array)                                    \
+	assert_success(__assert_ddb_iterate(poh, cont_uuid, oid, dkey,    \
+	akey, recursive, expected_cont, expected_obj,                     \
+	expected_dkey, expected_akey, expected_sv, expected_array))
+static int
+__assert_ddb_iterate(daos_handle_t poh, uuid_t *cont_uuid, daos_unit_oid_t *oid, daos_key_t *dkey,
+		     daos_key_t *akey, _Bool recursive, uint32_t expected_cont,
+		     uint32_t expected_obj, uint32_t expected_dkey, uint32_t expected_akey,
+		     uint32_t expected_sv, uint32_t expected_array)
+{
+	int			i;
+	int			rc = 0;
+	struct dv_tree_path	path = {0};
+
+
+	if (cont_uuid)
+		uuid_copy(path.vtp_cont, *cont_uuid);
+	if (oid)
+		path.vtp_oid = *oid;
+	if (dkey)
+		path.vtp_dkey = *dkey;
+	if (akey)
+		path.vtp_akey = *akey;
+
+
+	assert_success(dv_iterate(poh, &path, recursive, &fake_handlers,
+				  NULL));
+
+	expect_int_equal(expected_cont, fake_cont_handler_call_count, rc);
+	expect_int_equal(expected_obj, fake_obj_handler_call_count, rc);
+	expect_int_equal(expected_dkey, fake_dkey_handler_call_count, rc);
+	expect_int_equal(expected_akey, fake_akey_handler_call_count, rc);
+	expect_int_equal(expected_sv, fake_sv_handler_call_count, rc);
+	expect_int_equal(expected_array, fake_array_handler_call_count, rc);
+
+	for (i = 0; i < expected_cont; i++)
+		expect_int_equal(i, fake_cont_handler_conts[i].ddbc_idx, rc);
+
+	/* Even if a parent handler isn't seen it's because only children of the parent
+	 * are listed. Always assume 1 parent.
+	 */
+
+	/* In these tests the objs will always be evenly distributed in the conts */
+	expected_cont = expected_cont == 0 ? 1 : expected_cont;
+	for (i = 0; i < expected_obj; i++)
+		expect_int_equal(i % (expected_obj / expected_cont),
+				 fake_obj_handler_objs[i].ddbo_idx, rc);
+
+	expected_obj = expected_obj == 0 ? 1 : expected_obj;
+	for (i = 0; i < expected_dkey; i++)
+		expect_int_equal(i % (expected_dkey / expected_obj),
+				 fake_dkey_handler_dkeys[i].ddbk_idx, rc);
+
+	expected_dkey = expected_dkey == 0 ? 1 : expected_dkey;
+	for (i = 0; i < expected_akey; i++)
+		expect_int_equal(i % (expected_akey / expected_dkey),
+				 fake_akey_handler_akeys[i].ddbk_idx, rc);
+
+	fake_call_counts_reset();
+
+	return rc;
+}
+
+static void
+open_pool_test(void **state)
+{
+	daos_handle_t		 poh;
+	struct dt_vos_pool_ctx	*tctx = *state;
+
+	assert_rc_equal(-DER_INVAL, ddb_vos_pool_open("/bad/path", &poh));
+
+	assert_success(ddb_vos_pool_open(tctx->dvt_pmem_file, &poh));
+
+	assert_success(ddb_vos_pool_close(poh));
+}
+
+static void
+list_items_test(void **state)
+{
+	struct dt_vos_pool_ctx	*tctx = *state;
+	daos_handle_t		 poh = tctx->dvt_poh;
+
+	/* list containers */
+	assert_ddb_iterate(poh, NULL, NULL, NULL, NULL, false, 10, 0, 0, 0, 0, 0);
+	assert_ddb_iterate(poh, NULL, NULL, NULL, NULL, true,
+			   10, 100, 1000, 10000, 5000, 5000);
+
+	/* list objects of a container */
+	assert_ddb_iterate(poh, &g_uuids[0], NULL, NULL, NULL, false, 0, 10, 0, 0, 0, 0);
+	assert_ddb_iterate(poh, &g_uuids[0], NULL, NULL, NULL, true,
+			   0, 10, 100, 1000, 500, 500);
+
+	/* list dkeys of an object */
+	assert_ddb_iterate(poh, &g_uuids[0], &g_oids[0], NULL, NULL, false, 0, 0, 10, 0, 0, 0);
+	assert_ddb_iterate(poh, &g_uuids[0], &g_oids[0], NULL, NULL, true, 0, 0, 10, 100, 50, 50);
+
+	/* list akeys of a dkey */
+	assert_ddb_iterate(poh, &g_uuids[0], &g_oids[0], &g_dkeys[0], NULL, false,
+			   0, 0, 0, 10, 0, 0);
+	assert_ddb_iterate(poh, &g_uuids[0], &g_oids[0], &g_dkeys[0], NULL, true,
+			   0, 0, 0, 10, 5, 5);
+
+	/* list values in akeys */
+	assert_ddb_iterate(poh, &g_uuids[0], &g_oids[0], &g_dkeys[0], &g_akeys[0], false,
+			   0, 0, 0, 0, 0, 1);
+	assert_ddb_iterate(poh, &g_uuids[0], &g_oids[0], &g_dkeys[0], &g_akeys[1], true,
+			   0, 0, 0, 0, 1, 0);
+}
+
+static void
+get_cont_uuid_tests(void **state)
+{
+	struct dt_vos_pool_ctx	*tctx = *state;
+	uuid_t uuid;
+	uuid_t uuid_2;
+	int i;
+
+	assert_rc_equal(-DER_INVAL, dv_get_cont_uuid(tctx->dvt_poh, 10000000, uuid));
+	assert_success(dv_get_cont_uuid(tctx->dvt_poh, 0, uuid));
+	for (i = 1; i < 5; i++) {
+		assert_success(dv_get_cont_uuid(tctx->dvt_poh, i, uuid_2));
+		assert_uuid_not_equal(uuid, uuid_2);
+	}
+
+	/* while containers aren't in the same order they were inserted (and the order can't
+	 * be guaranteed), it should be the same order each time assuming no data is
+	 * inserted/deleted.
+	 */
+	for (i = 0; i < 100; i++) {
+		assert_success(dv_get_cont_uuid(tctx->dvt_poh, 0, uuid_2));
+		assert_uuid_equal(uuid, uuid_2);
+	}
+}
+
+static void
+get_oid_tests(void **state)
+{
+	struct dt_vos_pool_ctx	*tctx = *state;
+	daos_unit_oid_t		 uoid;
+	daos_unit_oid_t		 uoid_2;
+	int			 i;
+	daos_handle_t		 coh = DAOS_HDL_INVAL;
+
+	assert_rc_equal(-DER_INVAL, dv_get_object_oid(coh, 0, &uoid));
+	vos_cont_open(tctx->dvt_poh, g_uuids[0], &coh);
+
+	assert_rc_equal(-DER_INVAL, dv_get_object_oid(coh, 10000000, &uoid));
+	assert_success(dv_get_object_oid(coh, 0, &uoid));
+	for (i = 1; i < 5; i++) {
+		assert_success(dv_get_object_oid(coh, i, &uoid_2));
+		assert_oid_not_equal(uoid.id_pub, uoid_2.id_pub);
+	}
+
+	/* while objects aren't in the same order they were inserted (and the order can't
+	 * be guaranteed), it should be the same order each time assuming no data is
+	 * inserted/deleted.
+	 */
+	for (i = 0; i < 100; i++) {
+		assert_success(dv_get_object_oid(coh, 0, &uoid_2));
+		assert_oid_equal(uoid.id_pub, uoid_2.id_pub);
+	}
+
+	vos_cont_close(coh);
+}
+
+static void
+get_dkey_tests(void **state)
+{
+	struct dt_vos_pool_ctx	*tctx = *state;
+	daos_unit_oid_t uoid = {0};
+	int i;
+
+	daos_handle_t coh = DAOS_HDL_INVAL;
+	daos_key_t dkey;
+	daos_key_t dkey2;
+
+	assert_rc_equal(-DER_INVAL, dv_get_dkey(coh, uoid, 0, &dkey));
+	vos_cont_open(tctx->dvt_poh, g_uuids[0], &coh);
+	assert_rc_equal(-DER_INVAL, dv_get_dkey(coh, uoid, 0, &dkey));
+	uoid = g_oids[0];
+
+	assert_success(dv_get_dkey(coh, uoid, 0, &dkey));
+	for (i = 1; i < 5; i++) {
+		assert_success(dv_get_dkey(coh, uoid, i, &dkey2));
+		assert_string_not_equal(dkey.iov_buf, dkey2.iov_buf);
+	}
+
+	for (i = 0; i < 100; i++) {
+		assert_success(dv_get_dkey(coh, uoid, 0, &dkey2));
+		assert_string_equal(dkey.iov_buf, dkey2.iov_buf);
+	}
+
+	vos_cont_close(coh);
+}
+
+static void
+get_akey_tests(void **state)
+{
+	struct dt_vos_pool_ctx	*tctx = *state;
+	daos_unit_oid_t uoid = {0};
+	int i;
+
+	daos_handle_t coh = DAOS_HDL_INVAL;
+	daos_key_t dkey = {0};
+
+	daos_key_t akey;
+	daos_key_t akey2;
+
+	assert_rc_equal(-DER_INVAL, dv_get_akey(coh, uoid, &dkey, 0, &akey));
+	assert_success(vos_cont_open(tctx->dvt_poh, g_uuids[0], &coh));
+	assert_rc_equal(-DER_INVAL, dv_get_akey(coh, uoid, &dkey, 0, &akey));
+	uoid = g_oids[0];
+	assert_rc_equal(-DER_INVAL, dv_get_akey(coh, uoid, &dkey, 0, &akey));
+	dv_get_dkey(coh, uoid, 0, &dkey);
+
+	assert_success(dv_get_akey(coh, uoid, &dkey, 0, &akey));
+	for (i = 1; i < 5; i++) {
+		assert_success(dv_get_akey(coh, uoid, &dkey, i, &akey2));
+		assert_string_not_equal(akey.iov_buf, akey2.iov_buf);
+	}
+
+	for (i = 0; i < 100; i++) {
+		assert_success(dv_get_akey(coh, uoid, &dkey, 0, &akey2));
+		assert_string_equal(akey.iov_buf, akey2.iov_buf);
+	}
+
+	vos_cont_close(coh);
+}
+
+static void
+get_recx_tests(void **state)
+{
+	struct dt_vos_pool_ctx	*tctx = *state;
+	daos_unit_oid_t		 uoid = {0};
+	daos_handle_t		 coh = DAOS_HDL_INVAL;
+	daos_key_t		 dkey = {0};
+	daos_key_t		 akey = {0};
+	daos_recx_t		 recx = {0};
+
+	assert_rc_equal(-DER_INVAL, dv_get_recx(coh, uoid, &dkey, &akey, 0, &recx));
+
+	assert_success(vos_cont_open(tctx->dvt_poh, g_uuids[0], &coh));
+	assert_rc_equal(-DER_INVAL, dv_get_recx(coh, uoid, &dkey, &akey, 0, &recx));
+	dv_get_object_oid(coh, 0, &uoid);
+	assert_rc_equal(-DER_INVAL, dv_get_recx(coh, uoid, &dkey, &akey, 0, &recx));
+	dv_get_dkey(coh, uoid, 0, &dkey);
+	assert_rc_equal(-DER_INVAL, dv_get_recx(coh, uoid, &dkey, &akey, 0, &recx));
+	dv_get_akey(coh, uoid, &dkey, 0, &akey);
+	assert_success(dv_get_recx(coh, uoid, &dkey, &akey, 0, &recx));
+
+	vos_cont_close(coh);
+}
+
+static void
+test_update_path_with_values_from_index(void **state)
+{
+	struct dt_vos_pool_ctx	*tctx = *state;
+
+	struct dv_tree_path_builder vt_path = {0};
+
+	vt_path.vtp_poh = tctx->dvt_poh;
+	/* Because all path part indexes are 0, should update the path with the first */
+	dv_path_update_from_indexes(&vt_path);
+
+	assert_uuid_equal(g_uuids[0], vt_path.vtp_path.vtp_cont);
+	assert_oid_equal(g_oids[0].id_pub, vt_path.vtp_path.vtp_oid.id_pub);
+	assert_key_equal(g_dkeys[0], vt_path.vtp_path.vtp_dkey);
+	assert_key_equal(g_akeys[0], vt_path.vtp_path.vtp_akey);
+	assert_int_equal(1, vt_path.vtp_path.vtp_recx.rx_idx);
+	assert_int_equal(0x16, vt_path.vtp_path.vtp_recx.rx_nr);
+}
+
+static int
+dv_suit_setup(void **state)
+{
+	return ddb_test_setup_vos(state);
+}
+
+static int
+dv_suit_teardown(void **state)
+{
+	struct dt_vos_pool_ctx *tctx = *state;
+
+	if (tctx == NULL) {
+		fail_msg("Test context wasn't setup. Possible issue in test setup\n");
+	}
+	ddb_teardown_vos(state);
+
+	return 0;
+}
+
+static int
+dv_test_setup(void **state)
+{
+	struct dt_vos_pool_ctx *tctx = *state;
+
+	assert_success(ddb_vos_pool_open(tctx->dvt_pmem_file, &tctx->dvt_poh));
+	return 0;
+}
+
+static int
+dv_test_teardown(void **state)
+{
+	struct dt_vos_pool_ctx *tctx = *state;
+
+	assert_success(ddb_vos_pool_close(tctx->dvt_poh));
+	return 0;
+}
+
+
+#define TEST(dsc, test) { dsc, test, dv_test_setup, dv_test_teardown }
+const struct CMUnitTest dv_test_cases[] = {
+	{ "open_pool", open_pool_test, NULL, NULL }, /* don't want this test to run with setup */
+	TEST("list items", list_items_test),
+	TEST("get container uuid from idx", get_cont_uuid_tests),
+	TEST("get object oid from idx", get_oid_tests),
+	TEST("get dkey from idx", get_dkey_tests),
+	TEST("get akey from idx", get_akey_tests),
+	TEST("get recx from idx", get_recx_tests),
+	TEST("get data value", test_update_path_with_values_from_index),
+};
+
+int
+dv_tests_run()
+{
+	return cmocka_run_group_tests_name("DDB VOS Interface Tests", dv_test_cases,
+					   dv_suit_setup, dv_suit_teardown);
+}

--- a/utils/rpms/daos.spec
+++ b/utils/rpms/daos.spec
@@ -409,6 +409,7 @@ getent passwd daos_agent >/dev/null || useradd -s /sbin/nologin -r -g daos_agent
 %attr(2755,root,daos_server) %{_bindir}/daos_server
 %{_bindir}/daos_engine
 %{_bindir}/daos_metrics
+%{_bindir}/ddb
 %dir %{_libdir}/daos_srv
 %{_libdir}/daos_srv/libcont.so
 %{_libdir}/daos_srv/libdtx.so
@@ -447,6 +448,7 @@ getent passwd daos_agent >/dev/null || useradd -s /sbin/nologin -r -g daos_agent
 %{_bindir}/daos_agent
 %{_bindir}/dfuse
 %{_bindir}/daos
+%{_bindir}/ddb
 %{_libdir}/libdaos_cmd_hdlrs.so
 %{_libdir}/libdfs.so
 %{_libdir}/%{name}/API_VERSION
@@ -511,6 +513,7 @@ getent passwd daos_agent >/dev/null || useradd -s /sbin/nologin -r -g daos_agent
 %{_bindir}/vea_ut
 %{_bindir}/vos_tests
 %{_bindir}/vea_stress
+%{_bindir}/ddb_tests
 
 %files server-tests-openmpi
 %{_bindir}/daos_gen_io_conf

--- a/utils/run_test.sh
+++ b/utils/run_test.sh
@@ -132,6 +132,9 @@ if [ -d "/mnt/daos" ]; then
     run_test "${SL_PREFIX}/bin/vos_tests" -A 500
     run_test "${SL_PREFIX}/bin/vos_tests" -n -A 500
 
+    COMP="UTEST_ddb"
+    run_test "${SL_PREFIX}/bin/ddb_tests"
+
     COMP="UTEST_vea"
     run_test "${SL_PREFIX}/bin/vea_ut"
     run_test "${SL_PREFIX}/bin/vea_stress -d 60"


### PR DESCRIPTION
The DAOS Debug Tool (ddb) is a new executable that allows a user to
navigate through a file in the VOS format. It is similar to debugfs
for ext2/3/4 and offers both a command line and interactive shell
mode. This commit is the introduction of the tool with just a couple
commands supported. For more details about the tool see
src/ddb/README.md

Signed-off-by: Ryon Jensen <ryon.jensen@intel.com>