### PR TITLE
DAOS-9353 test: Detect engine start via dmg for cart_self_test (#8576)

### DIFF
--- a/src/tests/ftest/network/cart_self_test.py
+++ b/src/tests/ftest/network/cart_self_test.py
@@ -80,6 +80,7 @@ class CartSelfTest(TestWithServers):
         self.cart_env["DAOS_AGENT_DRPC_DIR"] = "/var/run/daos_agent/"
 
         self.server_managers[0].manager.assign_environment(self.cart_env, True)
+        self.server_managers[0].detect_start_via_dmg = True
 
         # Start the daos server
         self.start_server_managers()


### PR DESCRIPTION
Resolve intermittent daos engine start detection by using dmg to detect
the engine start.

Skip-unit-tests: true
Test-tag: cartselftest

Signed-off-by: Phillip Henderson <phillip.henderson@intel.com>