### PR TITLE
DAOS-4661 Test: Adding test case and Python APi for pool target query.

### DIFF
--- a/src/client/pydaos/raw/daos_cref.py
+++ b/src/client/pydaos/raw/daos_cref.py
@@ -45,15 +45,6 @@ class EpochRange(ctypes.Structure):
                 ("epr_hi", ctypes.c_uint64)]
 
 
-class TargetInfo(ctypes.Structure):
-    """ Represents info about a given target
-    Represents struct: daos_target_info_t"""
-    _fields_ = [("ta_type", ctypes.c_uint),
-                ("ta_state", ctypes.c_uint),
-                ("ta_perf", ctypes.c_int),
-                ("ta_space", ctypes.c_int)]
-
-
 class RebuildStatus(ctypes.Structure):
     """ Structure to represent rebuild status info
     Represents struct: daos_rebuild_status"""
@@ -80,6 +71,15 @@ class Daos_Space(ctypes.Structure):
     Represents struct: daos_space"""
     _fields_ = [("s_total", ctypes.c_uint64 * 2),
                 ("s_free", ctypes.c_uint64 * 2)]
+
+
+class TargetInfo(ctypes.Structure):
+    """ Represents info about a given target
+    Represents struct: daos_target_info_t"""
+    _fields_ = [("ta_type", ctypes.c_uint),
+                ("ta_state", ctypes.c_uint),
+                ("ta_perf", ctypes.c_int),
+                ("ta_space", Daos_Space)]
 
 
 class PoolSpace(ctypes.Structure):

--- a/src/tests/ftest/pool/target_query.py
+++ b/src/tests/ftest/pool/target_query.py
@@ -1,0 +1,76 @@
+#!/usr/bin/python
+'''
+  (C) Copyright 2022 Intel Corporation.
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+'''
+from ior_test_base import IorTestBase
+
+class PoolTargetQueryTest(IorTestBase):
+    # pylint: disable=too-many-ancestors
+    """
+    Test Class Description: To verify object is writing on expected pool targets based on
+                            it's type.
+    :avocado: recursive
+    """
+    def setUp(self):
+        """Set up each test case."""
+        super().setUp()
+        engine_count = self.server_managers[0].get_config_value("engines_per_host")
+        self.server_count = len(self.hostlist_servers) * engine_count
+        self.target_usage_count = self.params.get("target_usage_count", '/run/ior/objectclass/*')
+
+    def target_space_info(self):
+        """Get the NVMe Target Space Information from all Targets.
+
+        return:
+            nvme_rank_space (list): nvme free space list from all targets.
+
+        """
+        nvme_rank_space = []
+        self.pool.connect()
+
+        # Collect the space information for all the ranks and targets
+        for _rank in range(0, self.server_count):
+            for _target in range(0, self.server_managers[0].get_config_value("targets")):
+                result = self.pool.pool.target_query(_target, _rank)
+                nvme_rank_space.append(result.ta_space.s_free[1])
+
+        return nvme_rank_space
+
+    def test_pool_target_space_query(self):
+        """Jira ID: DAOS-4661.
+
+        Test Description: Test Pool Target space is used based on object type.
+        Use Case: Create the pool, Get the Initial NVMe space for all targets,
+                  Use IOR to write the specific object type, Get the NVMe
+                  space from all targets. Verify that space is getting used based
+                  on object type.
+
+        :avocado: tags=all,full_regression
+        :avocado: tags=hw,large,ib2
+        :avocado: tags=pool
+        :avocado: tags=pool_query_target
+        """
+        self.update_ior_cmd_with_pool()
+        # Check the initial size of all targets
+        initial_nvme_size = self.target_space_info()
+        self.log.info("Initial Target space = %s", initial_nvme_size)
+
+        # Write the IOR data
+        self.run_ior_with_pool()
+
+        # Get the size after writing the IOR data
+        latest_nvme_size = self.target_space_info()
+        self.log.info("Latest Target space = %s", latest_nvme_size)
+
+        # Verify the target sizes is only increasing based on object layout
+        # specified in yaml file
+        target_count = 0
+        for count, _ in enumerate(initial_nvme_size):
+            if latest_nvme_size[count] != initial_nvme_size[count]:
+                target_count += 1
+        if target_count != self.target_usage_count:
+            self.fail("Expected to change the free space capacity for {} targets,"
+                      " But it's changed for {} targets".format(self.target_usage_count,
+                                                               str(target_count)))

--- a/src/tests/ftest/pool/target_query.py
+++ b/src/tests/ftest/pool/target_query.py
@@ -31,14 +31,14 @@ class PoolTargetQueryTest(IorTestBase):
         self.pool.connect()
 
         # Collect the space information for all the ranks and targets
-        for _rank in range(0, self.server_count):
-            for _target in range(0, self.server_managers[0].get_config_value("targets")):
+        for _rank in range(self.server_count):
+            for _target in range(self.server_managers[0].get_config_value("targets")):
                 result = self.pool.pool.target_query(_target, _rank)
                 nvme_rank_space.append(result.ta_space.s_free[1])
 
         return nvme_rank_space
 
-    def test_pool_target_space_query(self):
+    def test_pool_target_query(self):
         """Jira ID: DAOS-4661.
 
         Test Description: Test Pool Target space is used based on object type.
@@ -48,9 +48,9 @@ class PoolTargetQueryTest(IorTestBase):
                   on object type.
 
         :avocado: tags=all,full_regression
-        :avocado: tags=hw,large,ib2
+        :avocado: tags=hw,large
         :avocado: tags=pool
-        :avocado: tags=pool_query_target
+        :avocado: tags=pool_target_query
         """
         self.update_ior_cmd_with_pool()
         # Check the initial size of all targets
@@ -67,8 +67,8 @@ class PoolTargetQueryTest(IorTestBase):
         # Verify the target sizes is only increasing based on object layout
         # specified in yaml file
         target_count = 0
-        for count, _ in enumerate(initial_nvme_size):
-            if latest_nvme_size[count] != initial_nvme_size[count]:
+        for count, initial_size in enumerate(initial_nvme_size):
+            if latest_nvme_size[count] != initial_size:
                 target_count += 1
         if target_count != self.target_usage_count:
             self.fail("Expected to change the free space capacity for {} targets,"

--- a/src/tests/ftest/pool/target_query.yaml
+++ b/src/tests/ftest/pool/target_query.yaml
@@ -1,0 +1,90 @@
+hosts:
+  test_servers:
+    - server-A
+    - server-B
+    - server-C
+    - server-D
+    - server-E
+  test_clients:
+    - client-A
+timeout: 800
+setup:
+  start_agents_once: False
+  start_servers_once: False
+server_config:
+  engines_per_host: 2
+  name: daos_server
+  servers:
+    0:
+      pinned_numa_node: 0
+      nr_xs_helpers: 1
+      fabric_iface: ib0
+      fabric_iface_port: 31416
+      log_file: daos_server0.log
+      bdev_class: nvme
+      bdev_list: ["aaaa:aa:aa.a"]
+      scm_class: dcpm
+      scm_list: ["/dev/pmem0"]
+      scm_mount: /mnt/daos0
+      targets: 2
+    1:
+      pinned_numa_node: 1
+      nr_xs_helpers: 1
+      fabric_iface: ib1
+      fabric_iface_port: 31517
+      log_file: daos_server1.log
+      bdev_class: nvme
+      bdev_list: ["bbbb:bb:bb.b"]
+      scm_class: dcpm
+      scm_list: ["/dev/pmem1"]
+      scm_mount: /mnt/daos1
+      targets: 2
+pool:
+    mode: 146
+    name: daos_server
+    scm_size: 2G
+    nvme_size: 16G
+    control_method: dmg
+    pool_query_timeout: 30
+container:
+    type: POSIX
+    control_method: daos
+ior:
+  api: "DFS"
+  client_processes:
+   np: 1
+  dfs_destroy: False
+  iorflags:
+   flags: "-w -F -k -G 1 -vv"
+  test_file: /testFile
+  repetitions: 1
+  transfer_size: 1M
+  block_size: 1G
+  objectclass: !mux
+    #SX Should write to all Targets
+    SX:
+      dfs_oclass: "SX"
+      target_usage_count: 20
+    #RP_2G1 is Group G1 so will write to Two replica targets with in 1 groups only.
+    RP_2G1:
+      dfs_oclass: "RP_2G1"
+      target_usage_count: 2
+    #RP_2GX is Group GX and so will write to all targets with Two Replicas.
+    RP_2GX:
+      dfs_oclass: "RP_2GX"
+      target_usage_count: 20
+    #EC_2P1G1 is Group G1 with EC_2P1, so it should write to 2data+1parity (3 targets),
+    #with in 1 group only.
+    EC_2P1G1:
+      dfs_oclass: "EC_2P1G1"
+      target_usage_count: 3
+    #EC_4P2GX is Group GX with EC_4P2, so it should write to 4data+2parity (6 targets),
+    #among max groups (In this case Three so 6x3 targets)
+    EC_4P2GX:
+      dfs_oclass: "EC_4P2GX"
+      target_usage_count: 18
+    #EC_8P2GX is Group GX with EC_8P2, so it should write to 8data+2parity (10 targets),
+    #among max groups (In this case 2 so 10x2 targets)
+    EC_8P2GX:
+      dfs_oclass: "EC_8P2GX"
+      target_usage_count: 20

--- a/src/tests/ftest/pool/target_query.yaml
+++ b/src/tests/ftest/pool/target_query.yaml
@@ -7,7 +7,7 @@ hosts:
     - server-E
   test_clients:
     - client-A
-timeout: 800
+timeout: 300
 server_config:
   engines_per_host: 2
   name: daos_server
@@ -57,30 +57,30 @@ ior:
   transfer_size: 1M
   block_size: 1G
   objectclass: !mux
-    #SX Should write to all Targets
     SX:
       dfs_oclass: "SX"
       target_usage_count: 20
-    #RP_2G1 is Group G1 so will write to Two replica targets with in 1 groups only.
+      notes: "SX should write to all Targets"
     RP_2G1:
       dfs_oclass: "RP_2G1"
       target_usage_count: 2
-    #RP_2GX is Group GX and so will write to all targets with Two Replicas.
+      notes: "RP_2G1 is Group G1 so it should write to Two replica targets with in 1 group only."
     RP_2GX:
       dfs_oclass: "RP_2GX"
       target_usage_count: 20
-    #EC_2P1G1 is Group G1 with EC_2P1, so it should write to 2data+1parity (3 targets),
-    #with in 1 group only.
+      notes: "RP_2GX is Group GX and so it should write to all targets with Two Replicas."
     EC_2P1G1:
       dfs_oclass: "EC_2P1G1"
       target_usage_count: 3
-    #EC_4P2GX is Group GX with EC_4P2, so it should write to 4data+2parity (6 targets),
-    #among max groups (In this case Three so 6x3 targets)
+      notes: "EC_2P1G1 is Group G1 with EC_2P1, so it should write to 2data+1parity (3 targets),
+              with in 1 group only."
     EC_4P2GX:
       dfs_oclass: "EC_4P2GX"
       target_usage_count: 18
-    #EC_8P2GX is Group GX with EC_8P2, so it should write to 8data+2parity (10 targets),
-    #among max groups (In this case 2 so 10x2 targets)
+      notes: "EC_4P2GX is Group GX with EC_4P2, so it should write to 4data+2parity (6 targets),
+              among max groups (In this case 3 so 6x3=18 targets)"
     EC_8P2GX:
       dfs_oclass: "EC_8P2GX"
       target_usage_count: 20
+      notes: "EC_8P2GX is Group GX with EC_8P2, so it should write to 8data+2parity (10 targets),
+              among max groups (In this case 2 so 10x2 targets)"

--- a/src/tests/ftest/pool/target_query.yaml
+++ b/src/tests/ftest/pool/target_query.yaml
@@ -8,9 +8,6 @@ hosts:
   test_clients:
     - client-A
 timeout: 800
-setup:
-  start_agents_once: False
-  start_servers_once: False
 server_config:
   engines_per_host: 2
   name: daos_server
@@ -52,12 +49,11 @@ container:
 ior:
   api: "DFS"
   client_processes:
-   np: 1
+    np: 1
   dfs_destroy: False
   iorflags:
-   flags: "-w -F -k -G 1 -vv"
+    flags: "-w -F -k -G 1 -vv"
   test_file: /testFile
-  repetitions: 1
   transfer_size: 1M
   block_size: 1G
   objectclass: !mux


### PR DESCRIPTION
- Adding python API support for target_query.
- Adding Avocado test to validate the specific object data is
  writing to the expected number of targets

Test-tag: iorsmall pool_query_target

Signed-off-by: Samir Raval <samir.raval@intel.com>