### PR TITLE
DAOS-10227 vos: Export aggregatable time to filter callback (#8620)

### DIFF
--- a/src/include/daos_srv/vos_types.h
+++ b/src/include/daos_srv/vos_types.h
@@ -339,6 +339,11 @@ typedef struct {
 		/** The key for the entry */
 		d_iov_t		 id_key;
 	};
+	/** Conservative approximation of last aggregatable write for object or key. */
+	daos_epoch_t		 id_agg_write;
+	/** Timestamp of latest parent punch, if applicable.  Zero if there is no punch */
+	daos_epoch_t		 id_parent_punch;
+	/** Type of entry */
 	vos_iter_type_t		 id_type;
 } vos_iter_desc_t;
 

--- a/src/vos/vos_aggregate.c
+++ b/src/vos/vos_aggregate.c
@@ -155,6 +155,8 @@ struct vos_agg_param {
 	struct vos_agg_credits	ap_credits;
 	daos_handle_t		ap_coh;		/* container handle */
 	daos_unit_oid_t		ap_oid;		/* current object ID */
+	/* Boundary for aggregatable write filter */
+	daos_epoch_t		ap_filter_epoch;
 	uint32_t		ap_flags;
 	unsigned int		ap_discard:1,
 				ap_csum_err:1,
@@ -291,18 +293,16 @@ inc_agg_counter(struct vos_agg_param *agg_param, vos_iter_type_t type, unsigned 
 static inline bool
 need_aggregate(daos_handle_t ih, struct vos_agg_param *agg_param, vos_iter_desc_t *desc)
 {
-	bool			 agg_needed;
+	bool			 agg_needed = true;
 	struct vos_container	*cont = vos_hdl2cont(agg_param->ap_coh);
 
 	/** Skip this check for discard */
 	if (agg_param->ap_discard_obj || agg_param->ap_discard)
 		return true;
 
-	if (desc->id_type == VOS_ITER_OBJ)
-		agg_needed = oi_iter_start_agg(ih, agg_param->ap_flags & VOS_AGG_FL_FORCE_SCAN);
-	else
-		agg_needed = vos_obj_iter_start_agg(ih,
-						    agg_param->ap_flags & VOS_AGG_FL_FORCE_SCAN);
+	if (desc->id_agg_write <= agg_param->ap_filter_epoch &&
+	    desc->id_parent_punch <= agg_param->ap_filter_epoch)
+		agg_needed = false;
 
 	D_DEBUG(DB_EPC, "flags:%u, hae:"DF_U64" agg_needed=%s\n", agg_param->ap_flags,
 		cont->vc_cont_df->cd_hae, agg_needed ? "yes" : "no");
@@ -2562,12 +2562,19 @@ vos_aggregate(daos_handle_t coh, daos_epoch_range_t *epr,
 	if (rc)
 		goto free_agg_data;
 
-	if ((flags & VOS_AGG_FL_FORCE_SCAN) == 0) {
-		feats = dbtree_feats_get(&cont->vc_cont_df->cd_obj_root);
-		has_agg_write = vos_feats_agg_time_get(feats, &agg_write);
-		if (has_agg_write && agg_write <= cont->vc_cont_df->cd_hae)
-			goto update_hae;
-	}
+	/** Use the lower end of the epoch range as the barrier when we are aggregating a
+	 *  deleted snapshot.  If there is no write above that range for a given key,
+	 *  the scan would be a noop anyway.
+	 */
+	if (flags & VOS_AGG_FL_FORCE_SCAN)
+		ad->ad_agg_param.ap_filter_epoch = epr->epr_lo;
+	else
+		ad->ad_agg_param.ap_filter_epoch = cont->vc_cont_df->cd_hae;
+
+	feats = dbtree_feats_get(&cont->vc_cont_df->cd_obj_root);
+	has_agg_write = vos_feats_agg_time_get(feats, &agg_write);
+	if (has_agg_write && agg_write <= ad->ad_agg_param.ap_filter_epoch)
+		goto update_hae;
 
 	/* Set iteration parameters */
 	ad->ad_iter_param.ip_hdl = coh;

--- a/src/vos/vos_internal.h
+++ b/src/vos/vos_internal.h
@@ -1185,19 +1185,6 @@ void
 gc_reserve_space(daos_size_t *rsrvd);
 
 /**
- * Start aggregation of an object.  Mark object for aggregation for aggregation, if applicable
- *
- * \param ih[IN]	Iterator handle
- * \param full_scan[IN]	Full scan is needed regardless so just mark aggregation start
- *
- * \return		1 if aggregation is needed
- *			0 if aggregation can be skipped
- *			< 0 on error
- */
-int
-oi_iter_start_agg(daos_handle_t ih, bool full_scan);
-
-/**
  * If the object is fully punched, bypass normal aggregation and move it to container
  * discard pool.
  *
@@ -1224,20 +1211,6 @@ oi_iter_check_punch(daos_handle_t ih);
  */
 int
 oi_iter_aggregate(daos_handle_t ih, bool range_discard);
-
-/**
- * Start aggregation of a key.  Mark key for aggregation for aggregation, if applicable
- *
- * \param ih[IN]	Iterator handle
- * \param full_scan[IN]	Full scan is needed regardless so just mark aggregation start
- *
- * \return		1 if aggregation is needed
- *			0 if aggregation can be skipped
- *			< 0 on error
- */
-
-int
-vos_obj_iter_start_agg(daos_handle_t ih, bool full_scan);
 
 /**
  * If the key is fully punched, bypass normal aggregation and move it to container

--- a/src/vos/vos_obj.c
+++ b/src/vos/vos_obj.c
@@ -790,6 +790,9 @@ key_iter_fetch(struct vos_obj_iter *oiter, vos_iter_entry_t *ent,
 	uint64_t		 start_seq;
 	vos_iter_desc_t		 desc;
 	struct vos_rec_bundle	 rbund;
+	struct vos_krec_df	*krec;
+	uint64_t		 feats;
+	uint32_t		 ts_type;
 	unsigned int		 acts;
 	int			 rc;
 
@@ -799,10 +802,26 @@ key_iter_fetch(struct vos_obj_iter *oiter, vos_iter_entry_t *ent,
 	if (rc != 0)
 		return rc;
 
+	D_ASSERT(rbund.rb_krec);
+	krec = rbund.rb_krec;
+
 	if (check_existence && oiter->it_iter.it_filter_cb != NULL &&
 	    (flags & VOS_ITER_PROBE_AGAIN) == 0) {
 		desc.id_type = oiter->it_iter.it_type;
 		desc.id_key = ent->ie_key;
+		desc.id_parent_punch = oiter->it_punched.pr_epc;
+		if (krec->kr_bmap & KREC_BF_BTR)
+			feats = dbtree_feats_get(&krec->kr_btr);
+		else
+			feats = evt_feats_get(&krec->kr_evt);
+		if (!vos_feats_agg_time_get(feats, &desc.id_agg_write)) {
+			if (desc.id_type == VOS_ITER_DKEY)
+				ts_type = VOS_TS_TYPE_DKEY;
+			else
+				ts_type = VOS_TS_TYPE_AKEY;
+			vos_ilog_last_update(&krec->kr_ilog, ts_type, &desc.id_agg_write);
+		}
+
 		acts = 0;
 		start_seq = vos_sched_seq();
 		rc = oiter->it_iter.it_filter_cb(vos_iter2hdl(&oiter->it_iter), &desc,
@@ -819,8 +838,7 @@ key_iter_fetch(struct vos_obj_iter *oiter, vos_iter_entry_t *ent,
 			return VOS_ITER_CB_SKIP;
 	}
 
-	D_ASSERT(rbund.rb_krec);
-	return key_iter_fill(rbund.rb_krec, oiter, check_existence, ent);
+	return key_iter_fill(krec, oiter, check_existence, ent);
 }
 
 static int
@@ -1944,70 +1962,6 @@ exit:
 		D_CDEBUG(rc == -DER_TX_BUSY, DB_TRACE, DLOG_ERR,
 			 "Failed to delete iter entry: "DF_RC"\n", DP_RC(rc));
 	return rc;
-}
-
-int
-vos_obj_iter_start_agg(daos_handle_t ih, bool full_scan)
-{
-	vos_iter_entry_t	 ent;
-	struct vos_iterator	*iter = vos_hdl2iter(ih);
-	struct vos_obj_iter	*oiter = vos_iter2oiter(iter);
-	struct vos_container	*cont = oiter->it_obj->obj_cont;
-	struct vos_krec_df	*krec;
-	daos_key_t		 key;
-	struct vos_rec_bundle	 rbund;
-	int			 rc;
-	uint64_t		 feats;
-	daos_epoch_t		 agg_write;
-	daos_epoch_t		 hae;
-	bool			 agg_has_write;
-
-	D_ASSERTF(oiter->it_iter.it_for_purge,
-		  "Function should only be called by aggregation\n");
-	D_ASSERTF(iter->it_type == VOS_ITER_AKEY ||
-		  iter->it_type == VOS_ITER_DKEY,
-		  "Aggregation only supported on keys\n");
-
-	if (full_scan)
-		return 1;
-
-	rc = key_iter_fetch_helper(oiter, &rbund, &key, NULL);
-	D_ASSERTF(rc != -DER_NONEXIST,
-		  "Iterator should probe before aggregation\n");
-	if (rc != 0)
-		return rc;
-
-	krec = rbund.rb_krec;
-
-	if (krec->kr_bmap & KREC_BF_BTR)
-		feats = dbtree_feats_get(&krec->kr_btr);
-	else
-		feats = evt_feats_get(&krec->kr_evt);
-
-	agg_has_write = vos_feats_agg_time_get(feats, &agg_write);
-	hae = cont->vc_cont_df->cd_hae;
-	if (agg_has_write) {
-		if (agg_write <= hae && oiter->it_punched.pr_epc <= hae)
-			return 0;
-		return 1;
-	}
-
-	/** Fall through to check other filters for legacy case */
-	rc = key_iter_fill(krec, oiter, true, &ent);
-	if (rc == VOS_ITER_CB_SKIP)
-		return 0;
-	if (rc < 0)
-		return rc; /** Likely the entry isn't in the range or we hit some other error.
-			    *  Let the iterator sort this out later.
-			    */
-	if (ent.ie_vis_flags & VOS_VIS_FLAG_COVERED)
-		return 1; /* Punched entries can likely be aggregated */
-
-	D_ASSERT(ent.ie_last_update != 0);
-	if (ent.ie_last_update <= hae)
-		return 0; /* No new updates since last time we ran */
-
-	return 1;
 }
 
 int


### PR DESCRIPTION
DAOS-10227 vos: Export aggregatable time to filter callback (#8620)
    
If we simply export the aggregatable time, we don't need to call
into vos iterator functions to retrieve it and we can do the filter
directly in the aggregation filter callback. This will make it
simpler to use this timestamp in EC aggregation code.
    
Also, optimize the snapshot aggregation case to ignore trees that
have no aggregatable write after the low epoch.
    
Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>
