### PR TITLE
DAOS-9355 doc: fix mkdocs edit_uri

### DIFF
--- a/docs/release/upgrading.md
+++ b/docs/release/upgrading.md
@@ -1,0 +1,6 @@
+# Upgrading to DAOS Version 2.4
+
+DAOS 2.4 is under active development and has not been released yet.
+The release is planned for the second half of 2022.
+In the meantime, please refer to the upgrading information for the
+[latest](https://docs.daos.io/latest/release/upgrading/) DAOS release.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,6 +6,8 @@ site_author: DAOS Project
 # Repository
 repo_name: daos-stack/daos
 repo_url: https://github.com/daos-stack/daos
+#edit_uri: blob/release/2.4/docs/
+edit_uri: blob/master/docs/
 copyright: Copyright 2016-2022 Intel Corporation
 
 # Theme
@@ -55,10 +57,15 @@ markdown_extensions:
 nav:
     - Intro:
           - 'index.md'
-          - 'Community Wiki': 'http://wiki.daos.io'
+          - 'Community Wiki': 'http://wiki.daos.io/'
           - 'Community Roadmap': 'http://wiki.daos.io/spaces/DC/pages/4836661105/Roadmap'
           - 'Community Mailing list': 'https://daos.groups.io/g/daos'
-          - 'Issue tracker': 'http://jira.daos.io'
+          - 'Issue tracker': 'http://jira.daos.io/'
+    - Release Information:
+          - 'Release Notes v2.4': 'release/release_notes.md'
+          - 'Support Matrix v2.4': 'release/support_matrix.md'
+          - 'Upgrading to v2.4': 'release/upgrading.md'
+          - 'Roadmap': 'http://wiki.daos.io/spaces/DC/pages/4836661105/Roadmap'
     - Overview:
           - 'Architecture': 'overview/architecture.md'
           - 'Storage Model': 'overview/storage.md'
@@ -102,10 +109,6 @@ nav:
           - 'Data Mover': 'user/datamover.md'
           - 'Tensorflow-IO Support': 'user/tensorflow.md'
           - 'Native Programming Interface': 'user/interface.md'
-    - Releases:
-          - 'Release Notes v2.4': 'release/release_notes.md'
-          - 'Support Matrix': 'release/support_matrix.md'
-          - 'Roadmap': 'http://wiki.daos.io/spaces/DC/pages/4836661105/Roadmap'
     - Developer Zone:
           - 'Dev Environment': 'dev/development.md'
           - 'Contributing': 'dev/contributing.md'


### PR DESCRIPTION
fix mkdocs.yml edit_uri to point to release branch
add dummy upgrading.ml

Doc-only: true
Signed-off-by: Michael Hennecke <michael.hennecke@intel.com>