### PR TITLE
DAOS-10155 test: Allow timeouts for server startup (#8594)

### DIFF
--- a/src/tests/ftest/harness/setup.py
+++ b/src/tests/ftest/harness/setup.py
@@ -22,4 +22,8 @@ class HarnessSetupTest(TestWithServers):
         :avocado: tags=hw,large
         :avocado: tags=harness,harness_setup_test,test_setup
         """
+        self.assertEqual(self.server_managers[0].storage_prepare_timeout.value, 60,
+                         "FAILED: storage prepare was not set correctly from the yaml")
+        self.assertEqual(self.server_managers[0].storage_format_timeout.value, 60,
+                         "FAILED: storage format was not set correctly from the yaml")
         self.log.info("Test passed!")

--- a/src/tests/ftest/harness/setup.yaml
+++ b/src/tests/ftest/harness/setup.yaml
@@ -7,7 +7,6 @@ hosts:
     - server-E
     - server-F
     - server-G
-    - server-H
   test_clients:
     - client-B
 timeout: 120
@@ -17,3 +16,6 @@ server_config:
     scm_size: 20
     bdev_class: nvme
     bdev_list: ["aaaa:aa:aa.a"]
+server_manager:
+  storage_prepare_timeout: 60
+  storage_format_timeout: 60

--- a/src/tests/ftest/launch.py
+++ b/src/tests/ftest/launch.py
@@ -74,6 +74,8 @@ YAML_KEYS = OrderedDict(
         ("pool_query_timeout", "timeout_multiplier"),
         ("rebuild_timeout", "timeout_multiplier"),
         ("srv_timeout", "timeout_multiplier"),
+        ("storage_prepare_timeout", "timeout_multiplier"),
+        ("storage_format_timeout", "timeout_multiplier"),
     ]
 )
 PROVIDER_KEYS = OrderedDict(
@@ -1851,7 +1853,7 @@ def resolve_debuginfo(pkg):
 
 
 def is_el(distro):
-    """Return True if a distro is an EL"""
+    """Return True if a distro is an EL."""
     return [d for d in ["almalinux", "rocky", "centos", "rhel"] if d in distro.name.lower()]
 
 

--- a/src/tests/ftest/util/command_utils.py
+++ b/src/tests/ftest/util/command_utils.py
@@ -18,8 +18,7 @@ from avocado.utils import process
 from ClusterShell.NodeSet import NodeSet
 
 from command_utils_base import \
-    BasicParameter, CommandWithParameters, \
-    EnvironmentVariables, LogParameter
+    BasicParameter, CommandWithParameters, EnvironmentVariables, LogParameter, ObjectWithParameters
 from exception_utils import CommandFailure
 from general_utils import check_file_exists, get_log_file, \
     run_command, DaosTestError, get_job_manager_class, create_directory, \
@@ -984,10 +983,10 @@ class YamlCommand(SubProcessCommand):
         return self.get_config_value("socket_dir")
 
 
-class SubprocessManager():
+class SubprocessManager(ObjectWithParameters):
     """Defines an object that manages a sub process launched with orterun."""
 
-    def __init__(self, command, manager="Orterun"):
+    def __init__(self, command, manager="Orterun", namespace=None):
         """Create a SubprocessManager object.
 
         Args:
@@ -995,7 +994,9 @@ class SubprocessManager():
             manager (str, optional): the name of the JobManager class used to
                 manage the YamlCommand defined through the "job" attribute.
                 Defaults to "OpenMpi"
+            namespace (str): yaml namespace (path to parameters)
         """
+        super().__init__(namespace)
         self.log = getLogger(__name__)
 
         # Define the JobManager class used to manage the command as a subprocess
@@ -1077,6 +1078,8 @@ class SubprocessManager():
         Args:
             test (Test): avocado Test object
         """
+        super().get_params(test)
+
         # Get the parameters for the JobManager command parameters
         self.manager.get_params(test)
 

--- a/src/tests/ftest/util/server_utils.py
+++ b/src/tests/ftest/util/server_utils.py
@@ -14,7 +14,7 @@ import random
 
 from avocado import fail_on
 
-from command_utils_base import CommonConfig
+from command_utils_base import CommonConfig, BasicParameter
 from exception_utils import CommandFailure
 from command_utils import SubprocessManager
 from general_utils import pcmd, get_log_file, human_to_bytes, bytes_to_human, \
@@ -72,7 +72,8 @@ class DaosServerManager(SubprocessManager):
 
     def __init__(self, group, bin_dir,
                  svr_cert_dir, svr_config_file, dmg_cert_dir, dmg_config_file,
-                 svr_config_temp=None, dmg_config_temp=None, manager="Orterun"):
+                 svr_config_temp=None, dmg_config_temp=None, manager="Orterun",
+                 namespace="/run/server_manager/*"):
         """Initialize a DaosServerManager object.
 
         Args:
@@ -91,11 +92,12 @@ class DaosServerManager(SubprocessManager):
             manager (str, optional): the name of the JobManager class used to
                 manage the YamlCommand defined through the "job" attribute.
                 Defaults to "Orterun".
+            namespace (str): yaml namespace (path to parameters)
         """
         self.group = group
         server_command = get_server_command(
             group, svr_cert_dir, bin_dir, svr_config_file, svr_config_temp)
-        super().__init__(server_command, manager)
+        super().__init__(server_command, manager, namespace)
         self.manager.job.sub_command_override = "start"
 
         # Dmg command to access this group of servers which will be configured
@@ -123,6 +125,10 @@ class DaosServerManager(SubprocessManager):
 
         # Flag used to determine which method is used to detect that the server has started
         self.detect_start_via_dmg = False
+
+        # Parameters to set storage prepare and format timeout
+        self.storage_prepare_timeout = BasicParameter(None, 40)
+        self.storage_format_timeout = BasicParameter(None, 40)
 
     def get_params(self, test):
         """Get values for all of the command params from the yaml file.
@@ -293,7 +299,7 @@ class DaosServerManager(SubprocessManager):
             cmd.sub_command_class.sub_command_class.nvme_only.value = True
 
         self.log.info("Preparing DAOS server storage: %s", str(cmd))
-        results = run_pcmd(self._hosts, str(cmd), timeout=40)
+        results = run_pcmd(self._hosts, str(cmd), timeout=self.storage_prepare_timeout.value)
 
         # gratuitously lifted from pcmd() and get_current_state()
         result = {}
@@ -464,8 +470,9 @@ class DaosServerManager(SubprocessManager):
             pcmd(self._hosts, "; ".join(cmd_list), verbose)
 
     def restart(self, hosts, wait=False):
-        """Restart the specified servers after a stop. The servers must
-           have been previously formatted and started.
+        """Restart the specified servers after a stop.
+
+           The servers must have been previously formatted and started.
 
         Args:
             hosts (list): List of servers to restart.
@@ -480,7 +487,7 @@ class DaosServerManager(SubprocessManager):
             self.manager.run()
 
             host_ranks = self.get_host_ranks(hosts)
-            self.update_expected_states(host_ranks , ["joined"])
+            self.update_expected_states(host_ranks, ["joined"])
 
             if not wait:
                 return
@@ -511,7 +518,7 @@ class DaosServerManager(SubprocessManager):
         self.log.info("<SERVER> Formatting hosts: <%s>", self.dmg.hostlist)
         # Temporarily increasing timeout to avoid CI errors until DAOS-5764 can
         # be further investigated.
-        self.dmg.storage_format(timeout=40)
+        self.dmg.storage_format(timeout=self.storage_format_timeout.value)
 
         # Wait for all the engines to start
         self.detect_engine_start()
@@ -601,7 +608,7 @@ class DaosServerManager(SubprocessManager):
         return states.pop()
 
     def check_rank_state(self, rank, valid_state, max_checks=1):
-        """Check the state of single rank in DAOS system
+        """Check the state of single rank in DAOS system.
 
         Args:
             rankv(int): daos rank whose state need's to be checked
@@ -614,6 +621,7 @@ class DaosServerManager(SubprocessManager):
         Returns:
             bool: returns True if there is a match for checked state,
                   else False.
+
         """
         checks = 0
         while checks < max_checks:
@@ -1082,7 +1090,7 @@ class DaosServerManager(SubprocessManager):
         return params
 
     def get_daos_metrics(self, verbose=False, timeout=60):
-        """Get daos_metrics for the server
+        """Get daos_metrics for the server.
 
         Args:
             verbose (bool, optional): pass verbose to run_pcmd. Defaults to False.
@@ -1094,6 +1102,7 @@ class DaosServerManager(SubprocessManager):
                     general_utils.run_pcmd(), # engine 0
                     general_utils.run_pcmd()  # engine 1
                 ]
+
         """
         engines_per_host = self.get_config_value("engines_per_host") or 1
         engines = []


### PR DESCRIPTION

The timeouts for server prepare and format were hardcoded
and should be settable in the test yaml.

Signed-off-by: Maureen Jean <maureen.jean@intel.com>