### PR TITLE
DAOS-10251 test: Test ranks state with pool query

### DIFF
--- a/src/tests/ftest/control/dmg_pool_query_ranks.py
+++ b/src/tests/ftest/control/dmg_pool_query_ranks.py
@@ -70,7 +70,7 @@ class DmgPoolQueryRanks(ControlTestBase):
         """Test that ranks state option are mutually exclusive
 
         Test Description:
-            Check that options '--show-enabled' and '--show-disabled" are muttually exclusive.
+            Check that options '--show-enabled' and '--show-disabled" are mutually exclusive.
 
         :avocado: tags=all,daily_regression
         :avocado: tags=vm

--- a/src/tests/ftest/control/dmg_pool_query_ranks.py
+++ b/src/tests/ftest/control/dmg_pool_query_ranks.py
@@ -1,0 +1,161 @@
+#!/usr/bin/python3
+"""
+  (C) Copyright 2022 Intel Corporation.
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+"""
+import time
+
+from control_test_base import ControlTestBase
+
+
+class DmgPoolQueryRanks(ControlTestBase):
+    # pylint: disable=too-many-ancestors
+    """Test dmg query ranks enabled/disabled command.
+
+    Test Class Description:
+        Simple test to verify the pool query command ranks of dmg tool.
+
+    :avocado: recursive
+    """
+
+    def setUp(self):
+        """Set up for dmg pool query."""
+        super().setUp()
+
+        # Init the pool
+        self.add_pool(connect=False)
+
+    def test_pool_query_ranks_basic(self):
+        """Test the state of ranks with dmg pool query
+
+        Test Description:
+            Create a pool with some engines and check they are all enabled.
+
+        :avocado: tags=all,daily_regression
+        :avocado: tags=vm
+        :avocado: tags=dmg,pool_query,pool_query_ranks
+        :avocado: tags=pool_query_ranks_basic
+        """
+        self.log.info("Basic tests of pool query with ranks state")
+
+        self.log.debug("Checking without ranks state information")
+        data = self.dmg.pool_query(self.pool.identifier)
+        self.assertIsNone(data['response']['enabled_ranks'],
+                "Invalid enabled_ranks field: want=None, "
+                "got={}".format(data['response']['enabled_ranks']))
+        self.assertIsNone(data['response']['disabled_ranks'],
+                "Invalid disabled_ranks field: want=None, "
+                "got={}".format(data['response']['disabled_ranks']))
+
+        self.log.debug("Checking enabled ranks state information")
+        data = self.dmg.pool_query(self.pool.identifier, show_enabled=True)
+        self.assertListEqual(data['response']['enabled_ranks'], [0, 1, 2],
+                "Invalid enabled_ranks field: want=None, "
+                "got={}".format(data['response']['enabled_ranks']))
+        self.assertIsNone(data['response']['disabled_ranks'],
+                "Invalid disabled_ranks field: want=None, "
+                "got={}".format(data['response']['disabled_ranks']))
+
+        self.log.debug("Checking disabled ranks state information")
+        data = self.dmg.pool_query(self.pool.identifier, show_disabled=True)
+        self.assertIsNone(data['response']['enabled_ranks'],
+                "Invalid enabled_ranks field: want=None, "
+                "got={}".format(data['response']['enabled_ranks']))
+        self.assertListEqual(data['response']['disabled_ranks'], [],
+                "Invalid disabled_ranks field: want=None, "
+                "got={}".format(data['response']['disabled_ranks']))
+
+    def test_pool_query_ranks_error(self):
+        """Test that ranks state option are mutually exclusive
+
+        Test Description:
+            Check that options '--show-enabled' and '--show-disabled" are muttually exclusive.
+
+        :avocado: tags=all,daily_regression
+        :avocado: tags=vm
+        :avocado: tags=dmg,pool_query,pool_query_ranks
+        :avocado: tags=pool_query_ranks_error
+        """
+        self.log.info("Tests of pool query with incompatible options")
+
+        # Disable raising an exception if the dmg command fails
+        self.dmg.exit_status_exception = False
+        try:
+            data = self.dmg.pool_query(self.pool.identifier, show_enabled=True, show_disabled=True)
+            self.assertIsNotNone(data["error"], "Invalid error field: want={}, "
+                    "got=None".format(data['error']))
+            self.assertIn(r'may not be mixed with', str(data['error']), "Invalid error message")
+        finally:
+            self.dmg.exit_status_exception = True
+
+    def test_pool_query_ranks_mgmt(self):
+        """Test the state of ranks after excluding and reintegrate them
+
+        Test Description:
+            Create a pool with some engines exclude them one by one and check the consistency of the
+            list of enabled and disabled ranks.  Then, reintegrate them and check the consistency of
+            the list of enabled and disabled ranks.
+
+        :avocado: tags=all,daily_regression
+        :avocado: tags=vm
+        :avocado: tags=dmg,pool_query,pool_query_ranks
+        :avocado: tags=pool_query_ranks_mgmt
+        """
+        self.log.info("Tests of pool query with ranks state when playing with ranks")
+
+        enabled_ranks = [0, 1, 2]
+        disabled_ranks = []
+        for rank in [1, 0, 2]:
+            self.log.debug("Excluding rank %d", rank)
+            self.dmg.pool_exclude(self.pool.uuid, rank)
+            enabled_ranks.remove(rank)
+            disabled_ranks = sorted(disabled_ranks + [rank])
+
+            self.log.debug("Checking enabled ranks state information")
+            data = self.dmg.pool_query(self.pool.identifier, show_enabled=True)
+            self.assertListEqual(data['response']['enabled_ranks'], enabled_ranks,
+                    "Invalid enabled_ranks field: want={}, "
+                    "got={}".format(enabled_ranks, data['response']['enabled_ranks']))
+
+            self.log.debug("Checking disabled ranks state information")
+            data = self.dmg.pool_query(self.pool.identifier, show_disabled=True)
+            self.assertListEqual(data['response']['disabled_ranks'], disabled_ranks,
+                    "Invalid disabled_ranks field: want={}, "
+                    "got={}".format(disabled_ranks, data['response']['disabled_ranks']))
+
+        for rank in [2, 0, 1]:
+            self.log.debug("Reintegrating rank %d", rank)
+            self.dmg.exit_status_exception = False
+            # NOTE Reintegrating ranks could not be done immediately => looping with timeout until
+            # the eviction is done.
+            timeout = 60
+            try:
+                while timeout > 0:
+                    rc = self.dmg.pool_reintegrate(self.pool.uuid, rank)
+                    if rc.exit_status == 0:
+                        break
+                    self.assertIn('DER_BUSY', str(rc.stdout),
+                            "Pool reintegration failed: {}".format(str(rc.stdout)))
+                    self.log.debug('Pool reintegration of rank=%d failed: msg="Resource busy", '
+                            'timeout=%d', rank, timeout)
+                    time.sleep(1.)
+                    timeout -= 1
+            finally:
+                self.dmg.exit_status_exception = True
+            self.assertNotEqual(timeout, 0, "Rank {} could not be reintegrated".format(rank))
+
+            enabled_ranks = sorted(enabled_ranks + [rank])
+            disabled_ranks.remove(rank)
+
+            self.log.debug("Checking enabled ranks state information")
+            data = self.dmg.pool_query(self.pool.identifier, show_enabled=True)
+            self.assertListEqual(data['response']['enabled_ranks'], enabled_ranks,
+                    "Invalid enabled_ranks field: want={}, "
+                    "got={}".format(enabled_ranks, data['response']['enabled_ranks']))
+
+            self.log.debug("Checking disabled ranks state information")
+            data = self.dmg.pool_query(self.pool.identifier, show_disabled=True)
+            self.assertListEqual(data['response']['disabled_ranks'], disabled_ranks,
+                    "Invalid disabled_ranks field: want={}, "
+                    "got={}".format(disabled_ranks, data['response']['disabled_ranks']))

--- a/src/tests/ftest/control/dmg_pool_query_ranks.py
+++ b/src/tests/ftest/control/dmg_pool_query_ranks.py
@@ -4,8 +4,6 @@
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
-import time
-
 from control_test_base import ControlTestBase
 
 

--- a/src/tests/ftest/control/dmg_pool_query_ranks.py
+++ b/src/tests/ftest/control/dmg_pool_query_ranks.py
@@ -4,6 +4,8 @@
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
+import random
+
 from control_test_base import ControlTestBase
 
 
@@ -101,9 +103,13 @@ class DmgPoolQueryRanks(ControlTestBase):
         """
         self.log.info("Tests of pool query with ranks state when playing with ranks")
 
-        enabled_ranks = [0, 1, 2]
+        enabled_ranks = list(range(len(self.hostlist_servers)))
         disabled_ranks = []
-        for rank in [1, 0, 2]:
+
+        all_ranks = enabled_ranks.copy()
+        random.shuffle(all_ranks)
+        self.log.info("Starting excluding ranks: all_ranks=%s", all_ranks)
+        for rank in all_ranks:
             self.log.debug("Excluding rank %d", rank)
             self.dmg.pool_exclude(self.pool.uuid, rank)
             enabled_ranks.remove(rank)
@@ -124,7 +130,9 @@ class DmgPoolQueryRanks(ControlTestBase):
             self.log.debug("Waiting for pool to be rebuild")
             self.pool.wait_for_rebuild(False)
 
-        for rank in [2, 0, 1]:
+        random.shuffle(all_ranks)
+        self.log.info("Starting reintegrating ranks: all_ranks=%s", all_ranks)
+        for rank in all_ranks:
             self.log.debug("Reintegrating rank %d", rank)
             self.pool.reintegrate(rank)
 

--- a/src/tests/ftest/control/dmg_pool_query_ranks.yaml
+++ b/src/tests/ftest/control/dmg_pool_query_ranks.yaml
@@ -6,7 +6,7 @@ hosts:
 timeouts:
   test_pool_query_ranks_basic: 120
   test_pool_query_ranks_error: 120
-  test_pool_query_ranks_mgmt: 360
+  test_pool_query_ranks_mgmt: 480
 server_config:
   name: daos_server
   servers:
@@ -17,5 +17,4 @@ server_config:
 pool:
   name: daos_server
   control_method: dmg
-  scm_size: 4GB
-  nvme_size: 16GB
+  size: 4GB

--- a/src/tests/ftest/control/dmg_pool_query_ranks.yaml
+++ b/src/tests/ftest/control/dmg_pool_query_ranks.yaml
@@ -1,0 +1,21 @@
+hosts:
+  test_servers:
+    - server-A
+    - server-B
+    - server-C
+timeouts:
+  test_pool_query_ranks_basic: 120
+  test_pool_query_ranks_error: 120
+  test_pool_query_ranks_mgmt: 360
+server_config:
+  name: daos_server
+  servers:
+    0:
+      scm_class: ram
+      scm_mount: /mnt/daos
+      scm_size: 6
+pool:
+  name: daos_server
+  control_method: dmg
+  scm_size: 4GB
+  nvme_size: 16GB

--- a/src/tests/ftest/util/dmg_utils.py
+++ b/src/tests/ftest/util/dmg_utils.py
@@ -533,11 +533,13 @@ class DmgCommand(DmgCommandBase):
 
         return data
 
-    def pool_query(self, pool):
+    def pool_query(self, pool, show_enabled=False, show_disabled=False):
         """Query a pool with the dmg command.
 
         Args:
             uuid (str): Pool UUID to query.
+            show_enabled (bool, optional): Display enabled ranks.
+            show_disabled (bool, optional): Display disabled ranks.
 
         Raises:
             CommandFailure: if the dmg pool query command fails.
@@ -576,12 +578,15 @@ class DmgCommand(DmgCommandBase):
         #             "min": 3999993856,
         #             "max": 3999993856,
         #             "mean": 3999993856
-        #         }
+        #         },
+        #         "enabled_ranks": None,
+        #         "disabled_ranks": None
         #     },
         #     "error": null,
         #     "status": 0
         # }
-        return self._get_json_result(("pool", "query"), pool=pool)
+        return self._get_json_result(("pool", "query"), pool=pool,
+                show_enabled=show_enabled, show_disabled=show_disabled)
 
     def pool_destroy(self, pool, force=True):
         """Destroy a pool with the dmg command.

--- a/src/tests/ftest/util/dmg_utils_base.py
+++ b/src/tests/ftest/util/dmg_utils_base.py
@@ -323,6 +323,8 @@ class DmgCommandBase(YamlCommand):
                 """Create a dmg pool query command object."""
                 super().__init__("/run/dmg/pool/query/*", "query")
                 self.pool = FormattedParameter("{}", None)
+                self.show_enabled = FormattedParameter("--show-enabled", False)
+                self.show_disabled = FormattedParameter("--show-disabled", False)
 
         class SetPropSubCommand(CommandWithParameters):
             """Defines an object for the dmg pool set-prop command."""


### PR DESCRIPTION
# Description

Add tests checking the state of ranks (i.e. enabled or disabled) with the pool query new features introduced with patches https://github.com/daos-stack/daos/pull/8587 and https://github.com/daos-stack/daos/pull/8659. 
Update `pool_query()` helper function to handle the new options `--show-enabled` and `--show-disabled` of the dmg cli sub-command pool query.

# Validation

The tests introduced within this patch have been manually tested and also extensively been tested with the CI (thanks to the pragma Test-repeat-vm).
https://build.hpdd.intel.com/blue/organizations/jenkins/daos-stack%2Fdaos/detail/PR-8699/3/tests
