### PR TITLE
Do not land: test wolf-[215-218]

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,7 +12,7 @@
 
 // To use a test branch (i.e. PR) until it lands to master
 // I.e. for testing library changes
-//@Library(value="pipeline-lib@your_branch") _
+@Library(value="pipeline-lib@skip_optane_2") _
 
 // For master, this is just some wildly high number
 next_version = "1000"

--- a/src/tests/ftest/util/agent_utils.py
+++ b/src/tests/ftest/util/agent_utils.py
@@ -243,7 +243,6 @@ class DaosAgentManager(SubprocessManager):
 
     def get_attachinfo_file(self):
         """Run dump-attachinfo on the daos_agent."""
-
         server_name = self.get_config_value("name")
 
         self.dump_attachinfo()


### PR DESCRIPTION
Veriy all HW Medium tests pass on wolf-[215-218] w/ VMD enabled.

Skip-build-leap15-rpm: true
Skip-unit-tests: true
Skip-func-test-vm: true
Skip-func-hw-test-small: true
Skip-func-hw-test-large: true
Test-tag-hw-medium: pr daily_regression full_regression
Test-repeat-hw-medium: 5

Signed-off-by: Phillip Henderson <phillip.henderson@intel.com>