### PR TITLE
DAOS-9865 test: Run tearDown with 240 second timeout (#8473)

### DIFF
--- a/src/client/api/tests/eq_tests.c
+++ b/src/client/api/tests/eq_tests.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2021 Intel Corporation.
+ * (C) Copyright 2016-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */

--- a/src/control/cmd/daos/main.go
+++ b/src/control/cmd/daos/main.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2021 Intel Corporation.
+// (C) Copyright 2021-2022 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //

--- a/src/include/daos/dtx.h
+++ b/src/include/daos/dtx.h
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2019-2021 Intel Corporation.
+ * (C) Copyright 2019-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */

--- a/src/include/daos_kv.h
+++ b/src/include/daos_kv.h
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2016-2021 Intel Corporation.
+ * (C) Copyright 2016-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */

--- a/src/include/daos_mgmt.h
+++ b/src/include/daos_mgmt.h
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2021 Intel Corporation.
+ * (C) Copyright 2016-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */

--- a/src/include/daos_obj_class.h
+++ b/src/include/daos_obj_class.h
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2015-2021 Intel Corporation.
+ * (C) Copyright 2015-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */

--- a/src/include/daos_types.h
+++ b/src/include/daos_types.h
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2015-2021 Intel Corporation.
+ * (C) Copyright 2015-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */

--- a/src/include/daos_uns.h
+++ b/src/include/daos_uns.h
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2019-2021 Intel Corporation.
+ * (C) Copyright 2019-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */

--- a/src/rdb/rdb_kvs.c
+++ b/src/rdb/rdb_kvs.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2017-2021 Intel Corporation.
+ * (C) Copyright 2017-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */

--- a/src/rdb/rdb_tx.c
+++ b/src/rdb/rdb_tx.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2017-2021 Intel Corporation.
+ * (C) Copyright 2017-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */

--- a/src/tests/ftest/cart/test_group_np_cli.c
+++ b/src/tests/ftest/cart/test_group_np_cli.c
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2016-2021 Intel Corporation.
+ * (C) Copyright 2016-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */

--- a/src/tests/ftest/cart/test_group_np_common.h
+++ b/src/tests/ftest/cart/test_group_np_common.h
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2016-2021 Intel Corporation.
+ * (C) Copyright 2016-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */

--- a/src/tests/ftest/control/dmg_pool_query_test.py
+++ b/src/tests/ftest/control/dmg_pool_query_test.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 """
-  (C) Copyright 2020-2021 Intel Corporation.
+  (C) Copyright 2020-2022 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """

--- a/src/tests/ftest/daos_test/dfs.yaml
+++ b/src/tests/ftest/daos_test/dfs.yaml
@@ -65,3 +65,7 @@ daos_tests:
     test_daos_dfs_unit: 1
     test_daos_dfs_parallel: 32
     test_daos_dfs_sys: 1
+  pools_created:
+    test_daos_dfs_unit: 2
+    test_daos_dfs_parallel: 2
+    test_daos_dfs_sys: 1

--- a/src/tests/ftest/daos_test/rebuild.yaml
+++ b/src/tests/ftest/daos_test/rebuild.yaml
@@ -120,3 +120,8 @@ daos_tests:
     test_rebuild_27: ["random"]
     test_rebuild_28: [7]
     test_rebuild_29: ["random"]
+  pools_created:
+    test_rebuild_0to10: 16
+    test_rebuild_12to15: 5
+    test_rebuild_18: 5
+    test_rebuild_28: 2

--- a/src/tests/ftest/daos_test/suite.yaml
+++ b/src/tests/ftest/daos_test/suite.yaml
@@ -173,3 +173,13 @@ daos_tests:
   stopped_ranks:
     test_daos_degraded_mode: [5, 6, 7]
     test_daos_oid_allocator: [6, 7]
+  pools_created:
+    test_daos_management: 4
+    test_daos_pool: 9
+    test_daos_container: 17
+    test_daos_distributed_tx: 5
+    test_daos_rebuild_simple: 21
+    test_daos_drain_simple: 8
+    test_daos_extend_simple: 5
+    test_daos_rebuild_ec: 43
+    test_daos_degraded_ec: 29

--- a/src/tests/ftest/datamover/copy_procs.py
+++ b/src/tests/ftest/datamover/copy_procs.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 '''
-  (C) Copyright 2020-2021 Intel Corporation.
+  (C) Copyright 2020-2022 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''

--- a/src/tests/ftest/datamover/obj_large_posix.py
+++ b/src/tests/ftest/datamover/obj_large_posix.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 '''
-  (C) Copyright 2020-2021 Intel Corporation.
+  (C) Copyright 2020-2022 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''

--- a/src/tests/ftest/datamover/obj_small.py
+++ b/src/tests/ftest/datamover/obj_small.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 '''
-  (C) Copyright 2020-2021 Intel Corporation.
+  (C) Copyright 2020-2022 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''

--- a/src/tests/ftest/datamover/posix_meta_entry.py
+++ b/src/tests/ftest/datamover/posix_meta_entry.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 '''
-  (C) Copyright 2020-2021 Intel Corporation.
+  (C) Copyright 2020-2022 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''

--- a/src/tests/ftest/datamover/posix_symlinks.py
+++ b/src/tests/ftest/datamover/posix_symlinks.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 '''
-  (C) Copyright 2020-2021 Intel Corporation.
+  (C) Copyright 2020-2022 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''

--- a/src/tests/ftest/datamover/posix_types.py
+++ b/src/tests/ftest/datamover/posix_types.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 '''
-  (C) Copyright 2020-2021 Intel Corporation.
+  (C) Copyright 2020-2022 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''

--- a/src/tests/ftest/datamover/serial_large_posix.py
+++ b/src/tests/ftest/datamover/serial_large_posix.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 '''
-  (C) Copyright 2020-2021 Intel Corporation.
+  (C) Copyright 2020-2022 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''

--- a/src/tests/ftest/fault_injection/ec.py
+++ b/src/tests/ftest/fault_injection/ec.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 '''
-  (C) Copyright 2021 Intel Corporation.
+  (C) Copyright 2021-2022 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''

--- a/src/tests/ftest/harness/advanced.py
+++ b/src/tests/ftest/harness/advanced.py
@@ -8,7 +8,7 @@ from random import choice
 from re import findall
 
 from apricot import TestWithServers
-from general_utils import run_pcmd
+from general_utils import run_pcmd, get_config_value
 
 
 class HarnessAdvancedTest(TestWithServers):
@@ -77,3 +77,50 @@ class HarnessAdvancedTest(TestWithServers):
         :avocado: tags=test_core_files_hw
         """
         self.test_core_files()
+
+    def test_pool_timeout(self):
+        """Test to verify tearDown() timeout setting for timed out tests.
+
+        Adding a pool should increase the runner.timeout.after_interrupted,
+        runner.timeout.process_alive, and runner.timeout.process_died timeouts by 200 seconds each.
+
+        :avocado: tags=all
+        :avocado: tags=harness,harness_advanced_test,pool_timeout
+        :avocado: tags=test_pool_timeout
+        """
+        namespace = "runner.timeout"
+        timeouts = {"after_interrupted": [], "process_alive": [], "process_died": []}
+
+        self.log.info("Before creating pools:")
+        for key in sorted(timeouts):
+            timeouts[key].append(get_config_value(namespace, key))
+            self.log.info("    %s.%s = %s", namespace, key, timeouts[key][0])
+
+        self.add_pool(create=True, connect=True)
+        self.add_pool(create=True, connect=False)
+        self.add_pool(create=False)
+
+        self.log.info("After creating pools:")
+        for key in sorted(timeouts):
+            timeouts[key].append(get_config_value(namespace, key))
+            self.log.info("    %s.%s = %s", namespace, key, timeouts[key][1])
+
+        for key in sorted(timeouts):
+            self.assertEqual(
+                timeouts[key][1] - timeouts[key][0], 600,
+                "Incorrect {}.{} value detected after adding 3 pools".format(namespace, key))
+
+        self.log.info("Test passed")
+
+    def test_pool_timeout_hw(self):
+        """Test to verify tearDown() timeout setting for timed out tests.
+
+        Adding a pool should increase the runner.timeout.after_interrupted,
+        runner.timeout.process_alive, and runner.timeout.process_died timeouts by 200 seconds each.
+
+        :avocado: tags=all
+        :avocado: tags=hw,small,medium,ib2,large
+        :avocado: tags=harness,harness_advanced_test,pool_timeout
+        :avocado: tags=test_pool_timeout_hw
+        """
+        self.test_pool_timeout()

--- a/src/tests/ftest/harness/advanced.yaml
+++ b/src/tests/ftest/harness/advanced.yaml
@@ -3,3 +3,6 @@ hosts:
     - server-A
     - server-B
 timeout: 120
+pool:
+  size: 2G
+  control_method: dmg

--- a/src/tests/ftest/mdtest/small.py
+++ b/src/tests/ftest/mdtest/small.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 '''
-  (C) Copyright 2019-2021 Intel Corporation.
+  (C) Copyright 2019-2022 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''

--- a/src/tests/ftest/nvme/io.py
+++ b/src/tests/ftest/nvme/io.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 """
-  (C) Copyright 2020-2021 Intel Corporation.
+  (C) Copyright 2020-2022 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """

--- a/src/tests/ftest/nvme/pool_exclude.py
+++ b/src/tests/ftest/nvme/pool_exclude.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 """
-  (C) Copyright 2020-2021 Intel Corporation.
+  (C) Copyright 2020-2022 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -9,8 +9,7 @@ import random
 import threading
 import re
 
-from test_utils_pool import TestPool
-from test_utils_base import LabelGenerator
+from test_utils_pool import add_pool
 from osa_utils import OSAUtils
 from write_host_file import write_host_file
 
@@ -52,7 +51,6 @@ class NvmePoolExclude(OSAUtils):
                            Defaults to None
         """
         # Create a pool
-        label_generator = LabelGenerator()
         pool = {}
 
         if oclass is None:
@@ -63,11 +61,7 @@ class NvmePoolExclude(OSAUtils):
         rank_list = list(range(1, exclude_servers))
 
         for val in range(0, num_pool):
-            pool[val] = TestPool(
-                context=self.context, dmg_command=self.dmg_command,
-                label_generator=label_generator)
-            pool[val].get_params(self)
-            pool[val].create()
+            pool[val] = add_pool(self, connect=False)
             pool[val].set_property("reclaim", "disabled")
 
         for val in range(0, num_pool):

--- a/src/tests/ftest/osa/dmg_negative_test.py
+++ b/src/tests/ftest/osa/dmg_negative_test.py
@@ -5,7 +5,7 @@
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
 from osa_utils import OSAUtils
-from test_utils_pool import TestPool
+from test_utils_pool import add_pool
 
 
 class OSADmgNegativeTest(OSAUtils):
@@ -66,10 +66,7 @@ class OSADmgNegativeTest(OSAUtils):
         pool_uuid = []
 
         for val in range(0, num_pool):
-            pool[val] = TestPool(
-                context=self.context, dmg_command=self.dmg_command,
-                label_generator=self.label_generator)
-            pool[val].get_params(self)
+            pool[val] = add_pool(self, create=False, connect=False)
             # Split total SCM and NVME size for creating multiple pools.
             pool[val].scm_size.value = int(pool[val].scm_size.value /
                                            num_pool)
@@ -99,7 +96,7 @@ class OSADmgNegativeTest(OSAUtils):
                     output = self.dmg_command.pool_extend(self.pool.uuid, rank)
                     self.log.info(output)
                     self.validate_results(expected_result, output.stdout_text)
-                if (extend is False and rank in ["4","5"]):
+                if (extend is False and rank in ["4", "5"]):
                     continue
                 # Exclude a rank, target
                 output = self.dmg_command.pool_exclude(self.pool.uuid,

--- a/src/tests/ftest/osa/offline_drain.py
+++ b/src/tests/ftest/osa/offline_drain.py
@@ -1,13 +1,13 @@
 #!/usr/bin/python
 """
-  (C) Copyright 2020-2021 Intel Corporation.
+  (C) Copyright 2020-2022 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
 import random
 from osa_utils import OSAUtils
 from daos_utils import DaosCommand
-from test_utils_pool import TestPool
+from test_utils_pool import add_pool
 from nvme_utils import ServerFillUp
 from write_host_file import write_host_file
 
@@ -55,11 +55,7 @@ class OSAOfflineDrain(OSAUtils, ServerFillUp):
         t_string = "{},{}".format(target_list[0], target_list[1])
 
         for val in range(0, num_pool):
-            pool[val] = TestPool(
-                context=self.context, dmg_command=self.get_dmg_command(),
-                label_generator=self.label_generator)
-            pool[val].get_params(self)
-            pool[val].create()
+            pool[val] = add_pool(self, connect=False)
             self.pool = pool[val]
             self.pool.set_property("reclaim", "disabled")
             test_seq = self.ior_test_sequence[0]

--- a/src/tests/ftest/osa/offline_extend.py
+++ b/src/tests/ftest/osa/offline_extend.py
@@ -1,13 +1,12 @@
 #!/usr/bin/python
 """
-  (C) Copyright 2020-2021 Intel Corporation.
+  (C) Copyright 2020-2022 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
 from osa_utils import OSAUtils
 from daos_utils import DaosCommand
-from test_utils_pool import TestPool
-from test_utils_base import LabelGenerator
+from test_utils_pool import add_pool
 from dmg_utils import check_system_query_status
 from apricot import skipForTicket
 
@@ -45,7 +44,6 @@ class OSAOfflineExtend(OSAUtils):
             oclass (list) : list of daos object class (eg: "RP_2G8")
         """
         # Create a pool
-        label_generator = LabelGenerator()
         pool = {}
         if oclass is None:
             oclass = []
@@ -59,11 +57,7 @@ class OSAOfflineExtend(OSAUtils):
                 index = val
             else:
                 index = 0
-            pool[val] = TestPool(
-                context=self.context, dmg_command=self.get_dmg_command(),
-                label_generator=label_generator)
-            pool[val].get_params(self)
-            pool[val].create()
+            pool[val] = add_pool(self, connect=False)
             self.pool = pool[val]
             test_seq = self.ior_test_sequence[0]
             self.pool.set_property("reclaim", "disabled")

--- a/src/tests/ftest/osa/offline_parallel_test.py
+++ b/src/tests/ftest/osa/offline_parallel_test.py
@@ -12,8 +12,7 @@ from osa_utils import OSAUtils
 from daos_utils import DaosCommand
 from dmg_utils import check_system_query_status
 from exception_utils import CommandFailure
-from test_utils_pool import TestPool
-from test_utils_base import LabelGenerator
+from test_utils_pool import add_pool
 from apricot import skipForTicket
 import queue
 
@@ -86,7 +85,6 @@ class OSAOfflineParallelTest(OSAUtils):
             oclass (str) : Daos object class (RP_2G1,etc)
         """
         # Create a pool
-        label_generator = LabelGenerator()
         pool = {}
         pool_uuid = []
         target_list = []
@@ -104,11 +102,7 @@ class OSAOfflineParallelTest(OSAUtils):
 
         test_seq = self.ior_test_sequence[0]
         for val in range(0, num_pool):
-            pool[val] = TestPool(
-                context=self.context, dmg_command=self.get_dmg_command(),
-                label_generator=label_generator)
-            pool[val].get_params(self)
-            pool[val].create()
+            pool[val] = add_pool(self, connect=False)
             self.pool = pool[val]
             pool_uuid.append(self.pool.uuid)
             # Use only pool UUID while running the test.

--- a/src/tests/ftest/osa/offline_reintegration.py
+++ b/src/tests/ftest/osa/offline_reintegration.py
@@ -8,7 +8,7 @@ import random
 from osa_utils import OSAUtils
 from daos_utils import DaosCommand
 from nvme_utils import ServerFillUp
-from test_utils_pool import TestPool
+from test_utils_pool import add_pool
 from write_host_file import write_host_file
 
 
@@ -61,11 +61,7 @@ class OSAOfflineReintegration(OSAUtils, ServerFillUp):
         # Exclude ranks [0, 3, 4]
         rank = [0, 3, 4]
         for val in range(0, num_pool):
-            pool[val] = TestPool(
-                context=self.context, dmg_command=self.get_dmg_command(),
-                label_generator=self.label_generator)
-            pool[val].get_params(self)
-            pool[val].create()
+            pool[val] = add_pool(self, connect=False)
             self.pool = pool[val]
             self.pool.set_property("reclaim", "disabled")
             test_seq = self.ior_test_sequence[0]

--- a/src/tests/ftest/osa/online_extend.py
+++ b/src/tests/ftest/osa/online_extend.py
@@ -1,13 +1,13 @@
 #!/usr/bin/python
 """
-  (C) Copyright 2020-2021 Intel Corporation.
+  (C) Copyright 2020-2022 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
 import time
 import threading
 
-from test_utils_pool import TestPool
+from test_utils_pool import add_pool
 from write_host_file import write_host_file
 from daos_racer_utils import DaosRacerCommand
 from dmg_utils import check_system_query_status
@@ -77,11 +77,7 @@ class OSAOnlineExtend(OSAUtils):
             time.sleep(30)
 
         for val in range(0, num_pool):
-            pool[val] = TestPool(
-                context=self.context, dmg_command=self.get_dmg_command(),
-                label_generator=self.label_generator)
-            pool[val].get_params(self)
-            pool[val].create()
+            pool[val] = add_pool(self, connect=False)
             pool[val].set_property("reclaim", "disabled")
 
         # Extend the pool_uuid, rank and targets

--- a/src/tests/ftest/osa/online_reintegration.py
+++ b/src/tests/ftest/osa/online_reintegration.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 """
-  (C) Copyright 2020-2021 Intel Corporation.
+  (C) Copyright 2020-2022 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -8,8 +8,7 @@ import time
 import random
 import threading
 
-from test_utils_pool import TestPool
-from test_utils_base import LabelGenerator
+from test_utils_pool import add_pool
 from write_host_file import write_host_file
 from daos_racer_utils import DaosRacerCommand
 from osa_utils import OSAUtils
@@ -71,7 +70,6 @@ class OSAOnlineReintegration(OSAUtils):
             oclass = self.ior_cmd.dfs_oclass.value
         test_seq = self.ior_test_sequence[0]
         # Create a pool
-        label_generator = LabelGenerator()
         pool = {}
         exclude_servers = (len(self.hostlist_servers) * 2) - 1
 
@@ -85,11 +83,7 @@ class OSAOnlineReintegration(OSAUtils):
             time.sleep(30)
 
         for val in range(0, num_pool):
-            pool[val] = TestPool(
-                context=self.context, dmg_command=self.get_dmg_command(),
-                label_generator=label_generator)
-            pool[val].get_params(self)
-            pool[val].create()
+            pool[val] = add_pool(self, connect=False)
             pool[val].set_property("reclaim", "disabled")
 
         # Exclude and reintegrate the pool_uuid, rank and targets

--- a/src/tests/ftest/scripts/main.sh
+++ b/src/tests/ftest/scripts/main.sh
@@ -68,9 +68,9 @@ unset OFI_INTERFACE
 # shellcheck disable=SC2153
 export D_LOG_FILE="$TEST_TAG_DIR/daos.log"
 
-# The dmg pool destroy can take up to 3 minutes to timeout.  To help ensure
-# that the avocado test tearDown method is run long enough to account for this
-# use a 240 second timeout when running tearDown after the test has timed out.
+# Give the avocado test tearDown method a minimum of 120 seconds to complete when the test process
+# has timed out.  The test harness will increment this timeout based upon the number of pools
+# created in the test to account for pool destroy command timeouts.
 mkdir -p ~/.config/avocado/
 cat <<EOF > ~/.config/avocado/avocado.conf
 [datadir.paths]
@@ -81,7 +81,9 @@ data_dir = $logs_prefix/ftest/avocado/data
 loglevel = DEBUG
 
 [runner.timeout]
-process_died = 240
+after_interrupted = 120
+process_alive = 120
+process_died = 120
 
 [sysinfo.collectibles]
 files = \$HOME/.config/avocado/sysinfo/files

--- a/src/tests/ftest/server/daos_server_dump.py
+++ b/src/tests/ftest/server/daos_server_dump.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 """
-  (C) Copyright 2020-2021 Intel Corporation.
+  (C) Copyright 2020-2022 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """

--- a/src/tests/ftest/util/apricot/apricot/test.py
+++ b/src/tests/ftest/util/apricot/apricot/test.py
@@ -15,6 +15,7 @@ import time
 from avocado import fail_on, skip, TestFail
 from avocado import Test as avocadoTest
 from avocado.core import exceptions
+
 from ClusterShell.NodeSet import NodeSet
 
 from agent_utils import DaosAgentManager, include_local_host
@@ -26,13 +27,13 @@ from distro_utils import detect
 from dmg_utils import get_dmg_command
 from fault_config_utils import FaultInjection
 from general_utils import \
-    get_partition_hosts, stop_processes, \
-    get_default_config_file, pcmd, get_file_listing, DaosTestError, run_command
+    get_partition_hosts, stop_processes, get_default_config_file, pcmd, get_file_listing, \
+    DaosTestError, run_command, get_config_value, set_config_value
 from logger_utils import TestLogger
 from pydaos.raw import DaosContext, DaosLog, DaosApiError
 from server_utils import DaosServerManager
 from test_utils_container import TestContainer
-from test_utils_pool import TestPool, LabelGenerator
+from test_utils_pool import LabelGenerator, add_pool, POOL_NAMESPACE
 from write_host_file import write_host_file
 from job_manager_utils import get_job_manager
 
@@ -129,6 +130,10 @@ class Test(avocadoTest):
         self.ofi_prefix = None
         self.cancel_file = os.path.join(os.sep, "scratch",
                                         "CI-skip-list-master")
+
+        # List of methods to call during tearDown to cleanup after the steps
+        # Use the register_cleanup() method to add methods with optional arguments
+        self._cleanup_methods = []
 
     def setUp(self):
         """Set up each test case."""
@@ -387,6 +392,61 @@ class Test(avocadoTest):
         except DaosTestError as error:
             errors.append("Error removing temporary test files: {}".format(error))
         return errors
+
+    def _cleanup(self):
+        """Run all the the cleanup methods from last to first.
+
+        Returns:
+            list: a list of error strings to report at the end of tearDown().
+
+        """
+        errors = []
+        while self._cleanup_methods:
+            try:
+                cleanup = self._cleanup_methods.pop()
+                errors.extend(cleanup["method"](**cleanup["kwargs"]))
+            except Exception as error:      # pylint: disable=broad-except
+                kwargs_str = ", ".join(
+                    ["=".join([str(key), str(value)]) for key, value in cleanup["kwargs"].items()])
+                errors.append(
+                    "Unhandled exception when calling {}({}): {}".format(
+                        str(cleanup["method"]), kwargs_str, str(error)))
+        return errors
+
+    def register_cleanup(self, method, **kwargs):
+        """Add a method call to the list of cleanup methods to run in tearDown().
+
+        Args:
+            method (str): method to call with the kwargs
+        """
+        self._cleanup_methods.append({"method": method, "kwargs": kwargs})
+        kwargs_str = ", ".join(["=".join([str(key), str(value)]) for key, value in kwargs.items()])
+        self.log.debug("Register: Adding calling %s(%s) during tearDown()", method, kwargs_str)
+
+    def increment_timeout(self, increment):
+        """Increase the avocado runner timeout configuration settings by the provided value.
+
+        Increase the various runner timeout configuration values to ensure tearDown is given enough
+        time to perform all of its steps.
+
+        Args:
+            increment (int): number of additional seconds by which to increase the timeout.
+        """
+        namespace = "runner.timeout"
+        for key in ("after_interrupted", "process_alive", "process_died"):
+            section = ".".join([namespace, key])
+
+            # Get the existing value
+            try:
+                value = int(get_config_value(namespace, key))
+            except (TypeError, ValueError) as error:
+                self.log.debug("Unable to obtain the %s setting: %s", section, str(error))
+                continue
+
+            # Update the setting with the incremented value
+            self.log.debug(
+                "Incrementing %s from %s to %s seconds", section, value, value + increment)
+            set_config_value(namespace, key, value + increment)
 
     def tearDown(self):
         """Tear down after each test case."""
@@ -1228,8 +1288,8 @@ class TestWithServers(TestWithoutServers):
         # Destroy any containers first
         self._teardown_errors.extend(self.destroy_containers(self.container))
 
-        # Destroy any pools next
-        self._teardown_errors.extend(self.destroy_pools(self.pool))
+        # Destroy any pools next - eventually this call will encompass all teardown steps
+        self._teardown_errors.extend(self._cleanup())
 
         # Stop the agents
         self._teardown_errors.extend(self.stop_agents())
@@ -1545,16 +1605,16 @@ class TestWithServers(TestWithoutServers):
 
         This sequence is common for a lot of the container tests.
         """
-        self.add_pool(None, True, True, 0)
+        self.add_pool(POOL_NAMESPACE, True, True, 0)
 
-    def get_pool(self, namespace=None, create=True, connect=True, index=0):
+    def get_pool(self, namespace=POOL_NAMESPACE, create=True, connect=True, index=0, **params):
         """Get a test pool object.
 
         This method defines the common test pool creation sequence.
 
         Args:
             namespace (str, optional): namespace for TestPool parameters in the
-                test yaml file. Defaults to None.
+                test yaml file. Defaults to POOL_NAMESPACE.
             create (bool, optional): should the pool be created. Defaults to
                 True.
             connect (bool, optional): should the pool be connected. Defaults to
@@ -1565,36 +1625,25 @@ class TestWithServers(TestWithoutServers):
             TestPool: the created test pool object.
 
         """
-        pool = TestPool(
-            context=self.context, dmg_command=self.get_dmg_command(index),
-            label_generator=self.label_generator,
-            crt_timeout=self.server_managers[index].get_config_value("crt_timeout"))
-        if namespace is not None:
-            pool.namespace = namespace
-        pool.get_params(self)
-        if create:
-            pool.create()
-        if create and connect:
-            pool.connect()
-        return pool
+        return add_pool(self, namespace, create, connect, index, **params)
 
-    def add_pool(self, namespace=None, create=True, connect=True, index=0):
+    def add_pool(self, namespace=POOL_NAMESPACE, create=True, connect=True, index=0, **params):
         """Add a pool to the test case.
 
         This method defines the common test pool creation sequence.
 
         Args:
             namespace (str, optional): namespace for TestPool parameters in the
-                test yaml file. Defaults to None.
+                test yaml file. Defaults to POOL_NAMESPACE.
             create (bool, optional): should the pool be created. Defaults to
                 True.
             connect (bool, optional): should the pool be connected. Defaults to
                 True.
             index (int, optional): Server index for dmg command. Defaults to 0.
         """
-        self.pool = self.get_pool(namespace, create, connect, index)
+        self.pool = self.get_pool(namespace, create, connect, index, **params)
 
-    def add_pool_qty(self, quantity, namespace=None, create=True, connect=True,
+    def add_pool_qty(self, quantity, namespace=POOL_NAMESPACE, create=True, connect=True,
                      index=0):
         """Add multiple pools to the test case.
 
@@ -1604,7 +1653,7 @@ class TestWithServers(TestWithoutServers):
         Args:
             quantity (int): number of pools to create
             namespace (str, optional): namespace for TestPool parameters in the
-                test yaml file. Defaults to None.
+                test yaml file. Defaults to POOL_NAMESPACE.
             create (bool, optional): should the pool be created. Defaults to
                 True.
             connect (bool, optional): should the pool be connected. Defaults to

--- a/src/tests/ftest/util/command_utils_base.py
+++ b/src/tests/ftest/util/command_utils_base.py
@@ -302,6 +302,14 @@ class ObjectWithParameters():
         for name in self.get_param_names():
             getattr(self, name).get_yaml_value(name, test, self.namespace)
 
+    def update_params(self, **params):
+        """Update each of provided parameter name and value pairs."""
+        for name, value in params.items():
+            try:
+                getattr(self, name).update(value, name)
+            except AttributeError as error:
+                raise CommandFailure("Unknown parameter: {}".format(name)) from error
+
 
 class CommandWithParameters(ObjectWithParameters):
     """A class for command with parameters."""

--- a/src/tests/ftest/util/daos_core_base.py
+++ b/src/tests/ftest/util/daos_core_base.py
@@ -115,6 +115,8 @@ class DaosCoreBase(TestWithServers):
         nvme_size = self.params.get("nvme_size", '/run/pool/*')
         args = self.get_test_param("args", "")
         stopped_ranks = self.get_test_param("stopped_ranks", [])
+        pools_created = self.get_test_param("pools_created", 1)
+        self.increment_timeout(200 * pools_created)
         dmg = self.get_dmg_command()
         dmg_config_file = dmg.yaml.filename
         if self.hostlist_clients:

--- a/src/tests/ftest/util/general_utils.py
+++ b/src/tests/ftest/util/general_utils.py
@@ -19,6 +19,8 @@ from getpass import getuser
 from importlib import import_module
 from socket import gethostname
 
+from avocado.core.settings import settings
+from avocado.core.version import MAJOR
 from avocado.utils import process
 from ClusterShell.Task import task_self
 from ClusterShell.NodeSet import NodeSet, NodeSetParseError
@@ -1317,3 +1319,34 @@ def get_primary_group(user=None):
         user = getuser()
     gid = pwd.getpwnam(user).pw_gid
     return grp.getgrgid(gid).gr_name
+
+
+def get_config_value(section, key):
+    """Get an avocado configuration value.
+
+    Args:
+        section (str): the configuration section, e.g. 'runner.timeout'
+        key (str): the configuration key, e.g. 'process_died'
+
+    Returns:
+        object: the value of the requested config key in the specified section
+
+    """
+    if int(MAJOR) >= 82:
+        config = settings.as_dict()
+        return config.get(".".join([section, key]))
+    return settings.get_value(section, key)     # pylint: disable=no-member
+
+
+def set_config_value(section, key, value):
+    """Set an avocado configuration value.
+
+    Args:
+        section (str): the configuration section, e.g. 'runner.timeout'
+        key (str): the configuration key, e.g. 'process_died'
+        value (object): the value to set
+    """
+    if int(MAJOR) >= 82:
+        settings.update_option(".".join([section, key]), value)
+    else:
+        settings.config.set(".".join([section, key]), value)


### PR DESCRIPTION
Dynamically increase the runner.timeout.* values by 200 seconds for each
pool created in the tests to account for the dmg pool destroy timeout
during test cleanup.

Signed-off-by: Phillip Henderson <phillip.henderson@intel.com>