### PR TITLE
DAOS-9586 control: Fix race in control RPCs

### DIFF
--- a/src/control/cmd/dmg/system_test.go
+++ b/src/control/cmd/dmg/system_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/daos-stack/daos/src/control/build"
 	"github.com/daos-stack/daos/src/control/common"
 	mgmtpb "github.com/daos-stack/daos/src/control/common/proto/mgmt"
 	sharedpb "github.com/daos-stack/daos/src/control/common/proto/shared"
@@ -22,6 +23,24 @@ import (
 )
 
 func TestDmg_SystemCommands(t *testing.T) {
+	defSysName := build.DefaultSystemName + "-" + build.DaosVersion
+	startReqWithRanks := func(ranks string) *control.SystemStartReq {
+		return &control.SystemStartReq{
+			SystemStartReq: mgmtpb.SystemStartReq{
+				Sys:   defSysName,
+				Ranks: ranks,
+			},
+		}
+	}
+	startReqWithHosts := func(hosts string) *control.SystemStartReq {
+		return &control.SystemStartReq{
+			SystemStartReq: mgmtpb.SystemStartReq{
+				Sys:   defSysName,
+				Hosts: hosts,
+			},
+		}
+	}
+
 	runCmdTests(t, []cmdTest{
 		{
 			"system query with no arguments",
@@ -145,7 +164,7 @@ func TestDmg_SystemCommands(t *testing.T) {
 			"system start with no arguments",
 			"system start",
 			strings.Join([]string{
-				printRequest(t, &control.SystemStartReq{}),
+				printRequest(t, startReqWithRanks("")),
 			}, " "),
 			nil,
 		},
@@ -153,7 +172,7 @@ func TestDmg_SystemCommands(t *testing.T) {
 			"system start with single rank",
 			"system start --ranks 0",
 			strings.Join([]string{
-				`*control.SystemStartReq-{"Sys":"","HostList":null,"ranks":"0"}`,
+				printRequest(t, startReqWithRanks("0")),
 			}, " "),
 			nil,
 		},
@@ -161,7 +180,7 @@ func TestDmg_SystemCommands(t *testing.T) {
 			"system start with multiple ranks",
 			"system start --ranks 0,1,4",
 			strings.Join([]string{
-				`*control.SystemStartReq-{"Sys":"","HostList":null,"ranks":"0-1,4"}`,
+				printRequest(t, startReqWithRanks("0-1,4")),
 			}, " "),
 			nil,
 		},
@@ -169,7 +188,7 @@ func TestDmg_SystemCommands(t *testing.T) {
 			"system start with multiple hosts",
 			"system start --rank-hosts bar9,foo-[0-100]",
 			strings.Join([]string{
-				`*control.SystemStartReq-{"Sys":"","HostList":null,"hosts":"bar9,foo-[0-100]"}`,
+				printRequest(t, startReqWithHosts("bar9,foo-[0-100]")),
 			}, " "),
 			nil,
 		},

--- a/src/control/lib/control/check.go
+++ b/src/control/lib/control/check.go
@@ -39,8 +39,8 @@ func SystemCheckStart(ctx context.Context, rpcClient UnaryInvoker, req *SystemCh
 		return errors.Errorf("nil %T", req)
 	}
 
+	req.CheckStartReq.Sys = req.getSystem(rpcClient)
 	req.setRPC(func(ctx context.Context, conn *grpc.ClientConn) (proto.Message, error) {
-		req.CheckStartReq.Sys = req.getSystem(rpcClient)
 		return mgmtpb.NewMgmtSvcClient(conn).SystemCheckStart(ctx, &req.CheckStartReq)
 	})
 	rpcClient.Debugf("DAOS system check start request: %+v", req)
@@ -71,8 +71,8 @@ func SystemCheckStop(ctx context.Context, rpcClient UnaryInvoker, req *SystemChe
 		return errors.Errorf("nil %T", req)
 	}
 
+	req.CheckStopReq.Sys = req.getSystem(rpcClient)
 	req.setRPC(func(ctx context.Context, conn *grpc.ClientConn) (proto.Message, error) {
-		req.CheckStopReq.Sys = req.getSystem(rpcClient)
 		return mgmtpb.NewMgmtSvcClient(conn).SystemCheckStop(ctx, &req.CheckStopReq)
 	})
 	rpcClient.Debugf("DAOS system check stop request: %+v", req)
@@ -115,8 +115,8 @@ func SystemCheckQuery(ctx context.Context, rpcClient UnaryInvoker, req *SystemCh
 		return nil, errors.Errorf("nil %T", req)
 	}
 
+	req.CheckQueryReq.Sys = req.getSystem(rpcClient)
 	req.setRPC(func(ctx context.Context, conn *grpc.ClientConn) (proto.Message, error) {
-		req.CheckQueryReq.Sys = req.getSystem(rpcClient)
 		return mgmtpb.NewMgmtSvcClient(conn).SystemCheckQuery(ctx, &req.CheckQueryReq)
 	})
 	rpcClient.Debugf("DAOS system check query request: %+v", req)
@@ -161,8 +161,8 @@ func SystemCheckProp(ctx context.Context, rpcClient UnaryInvoker, req *SystemChe
 		return nil, errors.Errorf("nil %T", req)
 	}
 
+	req.CheckPropReq.Sys = req.getSystem(rpcClient)
 	req.setRPC(func(ctx context.Context, conn *grpc.ClientConn) (proto.Message, error) {
-		req.CheckPropReq.Sys = req.getSystem(rpcClient)
 		return mgmtpb.NewMgmtSvcClient(conn).SystemCheckProp(ctx, &req.CheckPropReq)
 	})
 	rpcClient.Debugf("DAOS system check prop request: %+v", req)

--- a/src/control/lib/control/system.go
+++ b/src/control/lib/control/system.go
@@ -322,8 +322,8 @@ func SystemStart(ctx context.Context, rpcClient UnaryInvoker, req *SystemStartRe
 		return nil, errors.New("cannot specify hosts or ranks with checker")
 	}
 
+	req.SystemStartReq.Sys = req.getSystem(rpcClient)
 	req.setRPC(func(ctx context.Context, conn *grpc.ClientConn) (proto.Message, error) {
-		req.SystemStartReq.Sys = req.getSystem(rpcClient)
 		return mgmtpb.NewMgmtSvcClient(conn).SystemStart(ctx, &req.SystemStartReq)
 	})
 	rpcClient.Debugf("DAOS system start request: %+v", req)


### PR DESCRIPTION
Setting the system name in the RPC callback is racy.

Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com>
