### PR TITLE
DAOS-8752 control: Fix dmg cont set-owner to use svc ranks (#8668)

### DIFF
--- a/src/control/common/proto/mgmt/addons.go
+++ b/src/control/common/proto/mgmt/addons.go
@@ -183,6 +183,21 @@ func (r *DeleteACLReq) SetUUID(id uuid.UUID) {
 	r.Id = id.String()
 }
 
+// SetSvcRanks sets the request's Pool Service Ranks.
+func (r *ContSetOwnerReq) SetSvcRanks(rl []uint32) {
+	r.SvcRanks = rl
+}
+
+// SetUUID sets the request's ID to a UUID.
+func (r *ContSetOwnerReq) SetUUID(id uuid.UUID) {
+	r.PoolUUID = id.String()
+}
+
+// GetId fetches the pool ID.
+func (r *ContSetOwnerReq) GetId() string {
+	return r.PoolUUID
+}
+
 func Debug(msg proto.Message) string {
 	var bld strings.Builder
 	switch m := msg.(type) {

--- a/src/control/server/mgmt_cont.go
+++ b/src/control/server/mgmt_cont.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2020-2021 Intel Corporation.
+// (C) Copyright 2020-2022 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -45,7 +45,7 @@ func (svc *mgmtSvc) ContSetOwner(ctx context.Context, req *mgmtpb.ContSetOwnerRe
 	}
 	svc.log.Debugf("MgmtSvc.ContSetOwner dispatch, req:%+v\n", *req)
 
-	dresp, err := svc.harness.CallDrpc(ctx, drpc.MethodContSetOwner, req)
+	dresp, err := svc.makePoolServiceCall(ctx, drpc.MethodContSetOwner, req)
 	if err != nil {
 		return nil, err
 	}

--- a/src/control/server/mgmt_cont_test.go
+++ b/src/control/server/mgmt_cont_test.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2018-2021 Intel Corporation.
+// (C) Copyright 2018-2022 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	uuid "github.com/google/uuid"
 	"github.com/pkg/errors"
 
 	"github.com/daos-stack/daos/src/control/build"
@@ -140,88 +141,101 @@ func TestListCont_ManyContSuccess(t *testing.T) {
 	}
 }
 
-func newTestContSetOwnerReq() *mgmtpb.ContSetOwnerReq {
-	return &mgmtpb.ContSetOwnerReq{
-		Sys:        build.DefaultSystemName,
-		ContUUID:   "contUUID",
-		PoolUUID:   "poolUUID",
-		Owneruser:  "user@",
-		Ownergroup: "group@",
-	}
-}
-
-func TestContSetOwner_NoMS(t *testing.T) {
-	log, buf := logging.NewTestLogger(t.Name())
-	defer common.ShowBufferOnFailure(t, buf)
-
-	ms, db := system.MockMembership(t, log, mockTCPResolver)
-	svc := newMgmtSvc(NewEngineHarness(log), ms, db, nil,
-		events.NewPubSub(context.Background(), log))
-
-	resp, err := svc.ContSetOwner(context.TODO(), newTestContSetOwnerReq())
-
-	if resp != nil {
-		t.Errorf("Expected no response, got: %+v", resp)
+func TestMgmt_ContSetOwner(t *testing.T) {
+	validContSetOwnerReq := func() *mgmtpb.ContSetOwnerReq {
+		return &mgmtpb.ContSetOwnerReq{
+			Sys:        build.DefaultSystemName,
+			ContUUID:   "contUUID",
+			PoolUUID:   mockUUID,
+			Owneruser:  "user@",
+			Ownergroup: "group@",
+		}
 	}
 
-	common.CmpErr(t, FaultHarnessNotStarted, err)
-}
-
-func TestContSetOwner_DrpcFailed(t *testing.T) {
-	log, buf := logging.NewTestLogger(t.Name())
-	defer common.ShowBufferOnFailure(t, buf)
-
-	svc := newTestMgmtSvc(t, log)
-	expectedErr := errors.New("mock error")
-	setupMockDrpcClient(svc, nil, expectedErr)
-
-	resp, err := svc.ContSetOwner(context.TODO(), newTestContSetOwnerReq())
-
-	if resp != nil {
-		t.Errorf("Expected no response, got: %+v", resp)
+	testPoolService := &system.PoolService{
+		PoolLabel: "test-pool",
+		PoolUUID:  uuid.MustParse(mockUUID),
+		Replicas:  []system.Rank{0, 1, 2},
+		State:     system.PoolServiceStateReady,
+		Storage: &system.PoolServiceStorage{
+			CreationRankStr: system.MustCreateRankSet("0-2").String(),
+		},
 	}
 
-	common.CmpErr(t, expectedErr, err)
-}
+	for name, tc := range map[string]struct {
+		createMS  func(*testing.T, logging.Logger) *mgmtSvc
+		setupDrpc func(*testing.T, *mgmtSvc)
+		req       *mgmtpb.ContSetOwnerReq
+		expResp   *mgmtpb.ContSetOwnerResp
+		expErr    error
+	}{
+		"nil req": {
+			expErr: errors.New("nil"),
+		},
+		"pool svc not found": {
+			req: &mgmtpb.ContSetOwnerReq{
+				Sys:        build.DefaultSystemName,
+				ContUUID:   "contUUID",
+				PoolUUID:   "fake",
+				Owneruser:  "user@",
+				Ownergroup: "group@",
+			},
+			expErr: errors.New("unable to find pool"),
+		},
+		"harness not started": {
+			createMS: func(t *testing.T, log logging.Logger) *mgmtSvc {
+				ms, db := system.MockMembership(t, log, mockTCPResolver)
+				return newMgmtSvc(NewEngineHarness(log), ms, db, nil,
+					events.NewPubSub(context.Background(), log))
+			},
+			req:    validContSetOwnerReq(),
+			expErr: FaultHarnessNotStarted,
+		},
+		"drpc error": {
+			setupDrpc: func(t *testing.T, svc *mgmtSvc) {
+				setupMockDrpcClient(svc, nil, errors.New("mock drpc"))
+			},
+			req:    validContSetOwnerReq(),
+			expErr: errors.New("mock drpc"),
+		},
+		"bad drpc resp": {
+			setupDrpc: func(t *testing.T, svc *mgmtSvc) {
+				badBytes := makeBadBytes(16)
+				setupMockDrpcClientBytes(svc, badBytes, nil)
+			},
+			req:    validContSetOwnerReq(),
+			expErr: errors.New("unmarshal"),
+		},
+		"success": {
+			setupDrpc: func(t *testing.T, svc *mgmtSvc) {
+				setupMockDrpcClient(svc, &mgmtpb.ContSetOwnerResp{}, nil)
+			},
+			req: validContSetOwnerReq(),
+			expResp: &mgmtpb.ContSetOwnerResp{
+				Status: 0,
+			},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			log, buf := logging.NewTestLogger(t.Name())
+			defer common.ShowBufferOnFailure(t, buf)
 
-func TestContSetOwner_BadDrpcResp(t *testing.T) {
-	log, buf := logging.NewTestLogger(t.Name())
-	defer common.ShowBufferOnFailure(t, buf)
+			if tc.createMS == nil {
+				tc.createMS = newTestMgmtSvc
+			}
+			svc := tc.createMS(t, log)
+			addTestPoolService(t, svc.sysdb, testPoolService)
 
-	svc := newTestMgmtSvc(t, log)
-	// dRPC call returns junk in the message body
-	badBytes := makeBadBytes(16)
+			if tc.setupDrpc != nil {
+				tc.setupDrpc(t, svc)
+			}
 
-	setupMockDrpcClientBytes(svc, badBytes, nil)
+			resp, err := svc.ContSetOwner(context.TODO(), tc.req)
 
-	resp, err := svc.ContSetOwner(context.TODO(), newTestContSetOwnerReq())
-
-	if resp != nil {
-		t.Errorf("Expected no response, got: %+v", resp)
-	}
-
-	common.CmpErr(t, errors.New("unmarshal"), err)
-}
-
-func TestContSetOwner_Success(t *testing.T) {
-	log, buf := logging.NewTestLogger(t.Name())
-	defer common.ShowBufferOnFailure(t, buf)
-
-	svc := newTestMgmtSvc(t, log)
-
-	expectedResp := &mgmtpb.ContSetOwnerResp{
-		Status: 0,
-	}
-	setupMockDrpcClient(svc, expectedResp, nil)
-
-	resp, err := svc.ContSetOwner(context.TODO(), newTestContSetOwnerReq())
-
-	if err != nil {
-		t.Errorf("Expected no error, got: %v", err)
-	}
-
-	cmpOpts := common.DefaultCmpOpts()
-	if diff := cmp.Diff(expectedResp, resp, cmpOpts...); diff != "" {
-		t.Fatalf("bad response (-want, +got): \n%s\n", diff)
+			common.CmpErr(t, tc.expErr, err)
+			if diff := cmp.Diff(tc.expResp, resp, common.DefaultCmpOpts()...); diff != "" {
+				t.Fatalf("(-want, +got): \n%s\n", diff)
+			}
+		})
 	}
 }

--- a/src/control/server/mgmt_pool_test.go
+++ b/src/control/server/mgmt_pool_test.go
@@ -35,6 +35,7 @@ import (
 func addTestPoolService(t *testing.T, sysdb *system.Database, ps *system.PoolService) {
 	t.Helper()
 
+	var i uint32
 	for _, r := range ps.Replicas {
 		_, err := sysdb.FindMemberByRank(r)
 		if err == nil {
@@ -44,9 +45,11 @@ func addTestPoolService(t *testing.T, sysdb *system.Database, ps *system.PoolSer
 			t.Fatal(err)
 		}
 
-		if err := sysdb.AddMember(system.MockMember(t, 0, system.MemberStateJoined)); err != nil {
+		if err := sysdb.AddMember(system.MockMember(t, i, system.MemberStateJoined)); err != nil {
 			t.Fatal(err)
 		}
+
+		i++
 	}
 
 	if err := sysdb.AddPoolService(ps); err != nil {

--- a/src/mgmt/srv_container.c
+++ b/src/mgmt/srv_container.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2020-2021 Intel Corporation.
+ * (C) Copyright 2020-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -36,13 +36,18 @@ ds_mgmt_cont_set_owner(uuid_t pool_uuid, d_rank_list_t *svc_ranks,
 	daos_prop_t	*prop;
 	uint32_t	prop_nr = 0;
 	uint32_t	i = 0;
+	bool		user_set = false;
+	bool		grp_set = false;
 
 	D_DEBUG(DB_MGMT, "Setting owner for container "DF_UUID" in pool "
 		DF_UUID"\n", DP_UUID(cont_uuid), DP_UUID(pool_uuid));
 
-	if (user != NULL)
+	user_set = user != NULL && strnlen(user, DAOS_ACL_MAX_PRINCIPAL_LEN) > 0;
+	grp_set = group != NULL && strnlen(group, DAOS_ACL_MAX_PRINCIPAL_LEN) > 0;
+
+	if (user_set)
 		prop_nr++;
-	if (group != NULL)
+	if (grp_set)
 		prop_nr++;
 	if (prop_nr == 0) {
 		D_ERROR("user and group both null\n");
@@ -53,7 +58,7 @@ ds_mgmt_cont_set_owner(uuid_t pool_uuid, d_rank_list_t *svc_ranks,
 	if (prop == NULL)
 		return -DER_NOMEM;
 
-	if (user != NULL) {
+	if (user_set) {
 		prop->dpp_entries[i].dpe_type = DAOS_PROP_CO_OWNER;
 		D_STRNDUP(prop->dpp_entries[i].dpe_str, user,
 			  DAOS_ACL_MAX_PRINCIPAL_LEN);
@@ -62,7 +67,7 @@ ds_mgmt_cont_set_owner(uuid_t pool_uuid, d_rank_list_t *svc_ranks,
 		i++;
 	}
 
-	if (group != NULL) {
+	if (grp_set) {
 		prop->dpp_entries[i].dpe_type = DAOS_PROP_CO_OWNER_GROUP;
 		D_STRNDUP(prop->dpp_entries[i].dpe_str, group,
 			  DAOS_ACL_MAX_PRINCIPAL_LEN);


### PR DESCRIPTION
The dmg cont set-owner command wasn't updated to include the pool
service ranks.

Features: control security

Signed-off-by: Kris Jacque <kristin.jacque@intel.com>