### PR TITLE
DAOS-9923 control: Wait for IB to be ready

### DIFF
--- a/src/control/lib/hardware/hwprov/defaults.go
+++ b/src/control/lib/hardware/hwprov/defaults.go
@@ -69,6 +69,11 @@ func DefaultFabricScanner(log logging.Logger) *hardware.FabricScanner {
 	return fs
 }
 
+// DefaultFabricReadyChecker gets the default provider for fabric readiness checking.
+func DefaultFabricReadyChecker(log logging.Logger) hardware.FabricReadyChecker {
+	return sysfs.NewProvider(log)
+}
+
 // Init loads up any dynamic libraries that need to be loaded at runtime.
 func Init(log logging.Logger) (func(), error) {
 	initFns := []func() (func(), error){

--- a/src/control/lib/hardware/hwprov/defaults_test.go
+++ b/src/control/lib/hardware/hwprov/defaults_test.go
@@ -155,3 +155,16 @@ func TestHwprov_DefaultFabricScanner(t *testing.T) {
 		t.Fatalf("(-want, +got)\n%s\n", diff)
 	}
 }
+
+func TestHwprov_DefaultFabricReadyChecker(t *testing.T) {
+	log, buf := logging.NewTestLogger(t.Name())
+	defer common.ShowBufferOnFailure(t, buf)
+
+	result := DefaultFabricReadyChecker(log)
+
+	if diff := cmp.Diff(sysfs.NewProvider(log), result,
+		cmpopts.IgnoreUnexported(sysfs.Provider{}),
+	); diff != "" {
+		t.Fatalf("(-want, +got)\n%s\n", diff)
+	}
+}

--- a/src/control/lib/hardware/mocks.go
+++ b/src/control/lib/hardware/mocks.go
@@ -153,3 +153,21 @@ func (m *mockFabricInterfaceSetBuilder) BuildPart(_ context.Context, _ *FabricIn
 	m.buildPartCalled++
 	return m.buildPartReturn
 }
+
+type mockFabricReadyChecker struct {
+	isReadyCount int
+	isReadyErr   []error
+}
+
+func (m *mockFabricReadyChecker) CheckFabricReady(iface string) error {
+	if len(m.isReadyErr) == 0 {
+		return nil
+	}
+
+	idx := m.isReadyCount
+	if idx >= len(m.isReadyErr) {
+		idx = len(m.isReadyErr) - 1
+	}
+	m.isReadyCount++
+	return m.isReadyErr[idx]
+}

--- a/src/control/lib/hardware/sysfs/provider.go
+++ b/src/control/lib/hardware/sysfs/provider.go
@@ -24,6 +24,10 @@ import (
 
 var netSubsystems = []string{"cxi", "infiniband", "net"}
 
+// ibPortActiveState is the enum used to represent the "active" state for an infiniband port in
+// sysfs.
+const ibPortActiveState = 4
+
 func isNetwork(subsystem string) bool {
 	for _, netSubsystem := range netSubsystems {
 		if subsystem == netSubsystem {
@@ -240,4 +244,65 @@ func (s *Provider) getCXIFabricInterfaces() ([]*hardware.FabricInterface, error)
 	}
 
 	return cxiFIs, nil
+}
+
+// CheckFabricReady inspects the fabric interface to determine whether it is fully initialized
+// and ready for use.
+func (s *Provider) CheckFabricReady(iface string) error {
+	if s == nil {
+		return errors.New("sysfs provider is nil")
+	}
+
+	if iface == "" {
+		return errors.New("fabric interface name is required")
+	}
+
+	devClass, err := s.GetNetDevClass(iface)
+	if err != nil {
+		return errors.Wrapf(err, "can't determine device class for %q", iface)
+	}
+
+	if devClass != hardware.Infiniband {
+		// Infiniband is the only type we need to actively check
+		return nil
+	}
+
+	// The best way to determine that an Infiniband interface is ready is to check the state
+	// of its ports. Ports in the "ACTIVE" state are either fully ready or will be very soon.
+	ibPath := s.sysPath("class", "net", iface, "device", "infiniband")
+	ibDevs, err := ioutil.ReadDir(ibPath)
+	if err != nil {
+		return errors.Wrapf(err, "can't access Infiniband details for %q", iface)
+	}
+
+	for _, dev := range ibDevs {
+		portPath := filepath.Join(ibPath, dev.Name(), "ports")
+		ports, err := ioutil.ReadDir(portPath)
+		if err != nil {
+			return errors.Wrapf(err, "unable to get ports for %s/%s", iface, dev.Name())
+		}
+
+		for _, port := range ports {
+			statePath := filepath.Join(portPath, port.Name(), "state")
+			stateBytes, err := ioutil.ReadFile(statePath)
+			if err != nil {
+				return errors.Wrapf(err, "unable to get state for %s/%s port %s",
+					iface, dev.Name(), port.Name())
+			}
+
+			stateStrs := strings.Split(string(stateBytes), ": ")
+			stateNum, err := strconv.Atoi(stateStrs[0])
+			if err != nil {
+				s.log.Debugf("unable to parse %s/%s port %s state %q: %s",
+					iface, dev.Name(), port.Name(), string(stateBytes), err.Error())
+				continue
+			}
+			if stateNum == ibPortActiveState {
+				// At least one IB port is active on the interface
+				return nil
+			}
+		}
+	}
+
+	return hardware.ErrFabricNotReady(iface)
 }

--- a/src/control/server/server.go
+++ b/src/control/server/server.go
@@ -36,16 +36,16 @@ import (
 	"github.com/daos-stack/daos/src/control/system/raft"
 )
 
-func processConfig(log logging.Logger, cfg *config.Server, fis *hardware.FabricInterfaceSet) (*system.FaultDomain, error) {
+func processConfig(log logging.Logger, cfg *config.Server, fis *hardware.FabricInterfaceSet) error {
 	processFabricProvider(cfg)
 
 	hpi, err := common.GetHugePageInfo()
 	if err != nil {
-		return nil, errors.Wrapf(err, "retrieve hugepage info")
+		return errors.Wrapf(err, "retrieve hugepage info")
 	}
 
 	if err := cfg.Validate(log, hpi.PageSizeKb, fis); err != nil {
-		return nil, errors.Wrapf(err, "%s: validation failed", cfg.Path)
+		return errors.Wrapf(err, "%s: validation failed", cfg.Path)
 	}
 
 	lookupNetIF := func(name string) (netInterface, error) {
@@ -58,27 +58,21 @@ func processConfig(log logging.Logger, cfg *config.Server, fis *hardware.FabricI
 
 	for _, ec := range cfg.Engines {
 		if err := checkFabricInterface(ec.Fabric.Interface, lookupNetIF); err != nil {
-			return nil, err
+			return err
 		}
 
 		if err := updateFabricEnvars(log, ec, fis); err != nil {
-			return nil, errors.Wrap(err, "update engine fabric envars")
+			return errors.Wrap(err, "update engine fabric envars")
 		}
 	}
 
 	cfg.SaveActiveConfig(log)
 
 	if err := setDaosHelperEnvs(cfg, os.Setenv); err != nil {
-		return nil, err
+		return err
 	}
 
-	faultDomain, err := getFaultDomain(cfg)
-	if err != nil {
-		return nil, err
-	}
-	log.Debugf("fault domain: %s", faultDomain.String())
-
-	return faultDomain, nil
+	return nil
 }
 
 func processFabricProvider(cfg *config.Server) {
@@ -437,6 +431,23 @@ func (srv *server) start(ctx context.Context, shutdown context.CancelFunc) error
 		"%s harness exited", build.ControlPlaneName)
 }
 
+func waitFabricReady(ctx context.Context, log logging.Logger, cfg *config.Server) error {
+	ifaces := make([]string, 0, len(cfg.Engines))
+	for _, eng := range cfg.Engines {
+		ifaces = append(ifaces, eng.Fabric.Interface)
+	}
+
+	if err := hardware.WaitFabricReady(ctx, log, hardware.WaitFabricReadyParams{
+		Checker:        hwprov.DefaultFabricReadyChecker(log),
+		FabricIfaces:   ifaces,
+		IterationSleep: time.Second,
+	}); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // Start is the entry point for a daos_server instance.
 func Start(log logging.Logger, cfg *config.Server) error {
 	// Create the root context here. All contexts should inherit from this one so
@@ -450,16 +461,27 @@ func Start(log logging.Logger, cfg *config.Server) error {
 	}
 	defer hwprovFini()
 
+	if err := waitFabricReady(ctx, log, cfg); err != nil {
+		return err
+	}
+
 	scanner := hwprov.DefaultFabricScanner(log)
+
 	fiSet, err := scanner.Scan(ctx)
 	if err != nil {
 		return errors.Wrap(err, "scan fabric")
 	}
 
-	faultDomain, err := processConfig(log, cfg, fiSet)
+	err = processConfig(log, cfg, fiSet)
 	if err != nil {
 		return err
 	}
+
+	faultDomain, err := getFaultDomain(cfg)
+	if err != nil {
+		return err
+	}
+	log.Debugf("fault domain: %s", faultDomain.String())
 
 	srv, err := newServer(log, cfg, faultDomain)
 	if err != nil {


### PR DESCRIPTION
Wait for infiniband fabric interfaces to be ready before scanning
for their details on daos_server startup.

- Add method to check fabric readiness via sysfs. It checks the same
  sysfs data used by ibstat/libibumad to determine if the interface
  is active.
- Add function hardware.WaitFabricReady to loop on ready checks,
  with a configurable sleep between loops. It will be canceled when
  the context is canceled.
- Log an informative message at error level if a fabric interface isn't
  ready.

Features: control

Signed-off-by: Kris Jacque <kristin.jacque@intel.com>