### PR TITLE
DAOS-10202 event: private event needs lock on completion and poll

### DIFF
--- a/src/client/api/client_internal.h
+++ b/src/client/api/client_internal.h
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2021 Intel Corporation.
+ * (C) Copyright 2016-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */

--- a/src/client/api/client_internal.h
+++ b/src/client/api/client_internal.h
@@ -66,6 +66,8 @@ struct daos_event_private {
 	struct daos_event_callback evx_callback;
 
 	tse_sched_t		*evx_sched;
+	/** Lock for events that are not in an EQ, including the thread private event */
+	pthread_mutex_t		evx_lock;	
 };
 
 static inline struct daos_event_private *

--- a/src/client/api/client_internal.h
+++ b/src/client/api/client_internal.h
@@ -67,7 +67,7 @@ struct daos_event_private {
 
 	tse_sched_t		*evx_sched;
 	/** Lock for events that are not in an EQ, including the thread private event */
-	pthread_mutex_t		evx_lock;	
+	pthread_mutex_t		evx_lock;
 };
 
 static inline struct daos_event_private *

--- a/src/client/api/event.c
+++ b/src/client/api/event.c
@@ -1222,12 +1222,10 @@ daos_event_priv_get(daos_event_t **ev)
 
 	D_ASSERT(*ev == NULL);
 
-	if (!ev_thpriv_is_init) {
-		rc = daos_event_priv_reset();
-		if (rc)
-			return rc;
-		ev_thpriv_is_init = true;
-	}
+	rc = daos_event_priv_reset();
+	if (rc)
+		return rc;
+	ev_thpriv_is_init = true;
 
 	if (evx->evx_status != DAOS_EVS_READY) {
 		D_CRIT("private event is inuse, status=%d\n", evx->evx_status);

--- a/src/client/api/event.c
+++ b/src/client/api/event.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2021 Intel Corporation.
+ * (C) Copyright 2016-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */

--- a/src/client/api/event.c
+++ b/src/client/api/event.c
@@ -90,7 +90,6 @@ daos_eq_lib_init()
 		D_GOTO(crt, rc);
 
 	eq_ref = 1;
-	ev_thpriv_is_init = false;
 
 unlock:
 	D_MUTEX_UNLOCK(&daos_eq_lock);


### PR DESCRIPTION
It is possible that the error is not reset to 0 when a process is retrieving the private event in a multi-threaded environment since another thread might have processed the event completion. 

add a lock on daos_event_t for events that are not part of an event queue, including the thread private event. This is required because in a multithreaded environment like dfuse, the event can be completed and the error set non
atomically, while the main thread sees the completion but before the error has actually set, causing the owner of the event to reset the event error, with the other thread setting the error after. this affects future use of the event that launches with ev_error already set to the previous error.

Signed-off-by: Mohamad Chaarawi <mohamad.chaarawi@intel.com>