### PR TITLE
WIP DAOS-10202 event: reset the ev error to 0.

### DIFF
--- a/src/client/api/event.c
+++ b/src/client/api/event.c
@@ -392,6 +392,9 @@ daos_event_launch(struct daos_event *ev)
 	struct daos_eq_private		*eqx = NULL;
 	int				  rc = 0;
 
+	if (daos_event_is_priv(ev))
+		ev->ev_error = 0;
+
 	if (evx->evx_status != DAOS_EVS_READY) {
 		D_ERROR("Event status should be INIT: %d\n", evx->evx_status);
 		return -DER_NO_PERM;


### PR DESCRIPTION
this is still not clear why it's needed, but it seems the error code
does not reset in a multi threaded environment for a private event
when running mdtest with dfuse. if using the DFS API directly in a
single threaded environment, this is not needed, but not sure yet
why this makes a difference because the private event is thread private.

Signed-off-by: Mohamad Chaarawi <mohamad.chaarawi@intel.com>