### PR TITLE
    DAOS-10342 test: refine hard_rebuild.py/yaml

### DIFF
--- a/src/tests/ftest/ior/hard_rebuild.py
+++ b/src/tests/ftest/ior/hard_rebuild.py
@@ -54,11 +54,13 @@ class EcodIorHardRebuild(ErasureCodeIor):
         # Do not change the stoneWallingStatusFile during read
         self.ior_cmd.sw_wearout.update(None)
 
+        # remove first ior_read_dataset() calling, as it will zero the stoneWallingStatusFile
+        # and then fail the following 2nd ior_read_dataset (details in DAOS-10342).
         # Disabled Online rebuild
-        self.set_online_rebuild = False
+        # self.set_online_rebuild = False
         # Read IOR data and verify for different EC object kill single server while IOR Read phase
         # is in progress.
-        self.ior_read_dataset()
+        # self.ior_read_dataset()
 
         # Enabled Online rebuild during Read phase
         self.set_online_rebuild = True

--- a/src/tests/ftest/ior/hard_rebuild.yaml
+++ b/src/tests/ftest/ior/hard_rebuild.yaml
@@ -69,7 +69,7 @@ ior:
    np: 32
   dfs_destroy: False
   iorflags:
-   flags: "-C -k -e -w -g -G 27 -D 150 -Q 1 -vv"
+   flags: "-C -c -k -e -w -g -G 27 -D 150 -Q 1 -vv"
    read_flags: "-C -k -e -r -R -g -G 27 -D 150 -Q 1 -vv"
   test_file: daos:testFile
   segment_count: 2000000


### PR DESCRIPTION

    1) in hard_rebuild.py, remove the first time ior_read_dataset() calling,
       as it will zero the stoneWallingStatusFile's content and fail
       the 2nd ior_read_dataset().
    2) hard_rebuild.yaml, add "-c" (collective) flag for ior write to avoid
       generate holes (see ior code WriteOrRead() in ior.c, hitStonewall
       related code).
    
    Test-tag: ec_ior_hard_online_rebuild
    
    Signed-off-by: Xuezhao Liu <xuezhao.liu@intel.com>