### PR TITLE
DAOS-10249 rdb: Fix uninitialized raft node ID (#8608)

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+daos (2.0.2-3) unstable; urgency=medium
+  [ Li Wei ]
+  * Update raft to 0.9.1-1401.gc18bcb8 to fix uninitialized node IDs
+
+ -- Li Wei <wei.g.li@intel.com>  Sun, 17 Apr 2022 11:15:00 +0800
+
 daos (2.0.2-2) unstable; urgency=medium
   [ Johann Lombardi ]
   * Version bump to 2.0.2 (rc2)

--- a/debian/control
+++ b/debian/control
@@ -28,7 +28,7 @@ Build-Depends: debhelper (>= 10),
                libboost-dev,
                libspdk-dev,
                libipmctl-dev,
-               libraft-dev (= 0.9.0-1394.gc81505f),
+               libraft-dev (= 0.9.1-1401.gc18bcb8),
                python3-tabulate,
                liblz4-dev
 Standards-Version: 4.1.2

--- a/src/rdb/rdb_raft.c
+++ b/src/rdb/rdb_raft.c
@@ -2515,6 +2515,7 @@ rdb_raft_start(struct rdb *db)
 		goto err_compact_cv;
 	}
 
+	raft_set_nodeid(db->d_raft, dss_self_rank());
 	raft_set_callbacks(db->d_raft, &rdb_raft_cbs, db);
 
 	rc = rdb_raft_load(db);

--- a/utils/rpms/daos.spec
+++ b/utils/rpms/daos.spec
@@ -14,7 +14,7 @@
 
 Name:          daos
 Version:       2.0.2
-Release:       2%{?relval}%{?dist}
+Release:       3%{?relval}%{?dist}
 Summary:       DAOS Storage Engine
 
 License:       BSD-2-Clause-Patent
@@ -81,7 +81,7 @@ BuildRequires: libisa-l_crypto-devel
 BuildRequires: libisal-devel
 BuildRequires: libisal_crypto-devel
 %endif
-BuildRequires: daos-raft-devel = 0.9.0-1394.gc81505f%{?dist}%{?dist}
+BuildRequires: daos-raft-devel = 0.9.1-1401.gc18bcb8%{?dist}
 BuildRequires: openssl-devel
 BuildRequires: libevent-devel
 BuildRequires: libyaml-devel
@@ -516,6 +516,9 @@ getent passwd daos_agent >/dev/null || useradd -s /sbin/nologin -r -g daos_agent
 # No files in a meta-package
 
 %changelog
+* Sun Apr 17 2022 Li Wei <wei.g.li@intel.com> 2.0.2-3
+- Update raft to 0.9.1-1401.gc18bcb8 to fix uninitialized node IDs
+
 * Fri Mar 18 2022 Johann Lombardi <johann.lombardi@intel.com> 2.0.2-2
 - Version bump to 2.0.2 (rc2)
 


### PR DESCRIPTION
Since rdb no longer calls raft_add_node when offering each add-node log
entry, it should set the self node ID via the new raft_set_nodeid
method, right after creating the raft_server_t object.

Update raft to pick up the new raft_set_nodeid method as well as a few
minor fixes.

Signed-off-by: Li Wei <wei.g.li@intel.com>