### PR TITLE
DAOS-10188 dtx: handle race between DTX aggregation and DTX refresh

### DIFF
--- a/src/dtx/dtx_common.c
+++ b/src/dtx/dtx_common.c
@@ -17,7 +17,6 @@
 #include <daos_srv/daos_engine.h>
 #include "dtx_internal.h"
 
-uint64_t dtx_agg_gen;
 struct dtx_batched_cont_args;
 uint32_t dtx_agg_thd_cnt_up;
 uint32_t dtx_agg_thd_cnt_lo;
@@ -313,6 +312,9 @@ dtx_aggregate(void *arg)
 		     dtx_hlc_age2sec(stat.dtx_first_cmt_blob_time_lo) <=
 		     dtx_agg_thd_age_lo))
 			break;
+
+		if (dtx_hlc_age2sec(stat.dtx_first_cmt_blob_time_lo) <= DTX_AGG_AGE_PRESERVE)
+			break;
 	}
 
 	dbca->dbca_agg_done = 1;
@@ -331,6 +333,7 @@ dtx_aggregation_pool(struct dss_module_info *dmi, struct dtx_batched_pool_args *
 	struct sched_req_attr		 attr;
 	struct dtx_batched_cont_args	*victim_dbca = NULL;
 	struct dtx_stat			 victim_stat = { 0 };
+	struct dtx_tls			*tls = dtx_tls_get();
 
 	D_ASSERT(dbpa->dbpa_pool);
 	sched_req_attr_init(&attr, SCHED_REQ_GC, &dbpa->dbpa_pool->spc_uuid);
@@ -353,10 +356,10 @@ dtx_aggregation_pool(struct dss_module_info *dmi, struct dtx_batched_pool_args *
 		}
 
 		/* Finish this cycle scan. */
-		if (dbca->dbca_agg_gen == dtx_agg_gen)
+		if (dbca->dbca_agg_gen == tls->dt_agg_gen)
 			break;
 
-		dbca->dbca_agg_gen = dtx_agg_gen;
+		dbca->dbca_agg_gen = tls->dt_agg_gen;
 		d_list_move_tail(&dbca->dbca_pool_link, &dbpa->dbpa_cont_list);
 
 		if (dbca->dbca_agg_req != NULL)
@@ -366,6 +369,9 @@ dtx_aggregation_pool(struct dss_module_info *dmi, struct dtx_batched_pool_args *
 		dtx_stat(cont, &stat);
 		if (stat.dtx_cont_cmt_count == 0 ||
 		    stat.dtx_first_cmt_blob_time_lo == 0)
+			continue;
+
+		if (dtx_hlc_age2sec(stat.dtx_first_cmt_blob_time_lo) <= DTX_AGG_AGE_PRESERVE)
 			continue;
 
 		if (stat.dtx_cont_cmt_count >= dtx_agg_thd_cnt_up ||
@@ -422,6 +428,7 @@ dtx_aggregation_pool(struct dss_module_info *dmi, struct dtx_batched_pool_args *
 void
 dtx_aggregation_main(void *arg)
 {
+	struct dtx_tls			*tls = dtx_tls_get();
 	struct dss_module_info		*dmi = dss_get_module_info();
 	struct dtx_batched_pool_args	*dbpa;
 	struct sched_req_attr		 attr;
@@ -445,7 +452,7 @@ dtx_aggregation_main(void *arg)
 			d_list_move_tail(&dbpa->dbpa_sys_link,
 					 &dmi->dmi_dtx_batched_pool_list);
 
-			dtx_agg_gen++;
+			tls->dt_agg_gen++;
 			dtx_aggregation_pool(dmi, dbpa);
 		}
 
@@ -1530,6 +1537,7 @@ stop_dtx_reindex_ult(struct ds_cont_child *cont)
 int
 dtx_cont_register(struct ds_cont_child *cont)
 {
+	struct dtx_tls			*tls = dtx_tls_get();
 	struct dss_module_info		*dmi = dss_get_module_info();
 	struct dtx_batched_pool_args	*dbpa = NULL;
 	struct dtx_batched_cont_args	*dbca = NULL;
@@ -1592,7 +1600,7 @@ dtx_cont_register(struct ds_cont_child *cont)
 	dbca->dbca_refs = 0;
 	dbca->dbca_cont = cont;
 	dbca->dbca_pool = dbpa;
-	dbca->dbca_agg_gen = dtx_agg_gen;
+	dbca->dbca_agg_gen = tls->dt_agg_gen;
 	d_list_add_tail(&dbca->dbca_sys_link, &dmi->dmi_dtx_batched_cont_close_list);
 	d_list_add_tail(&dbca->dbca_pool_link, &dbpa->dbpa_cont_list);
 	if (new_pool)

--- a/src/dtx/dtx_internal.h
+++ b/src/dtx/dtx_internal.h
@@ -94,6 +94,21 @@ extern uint32_t dtx_agg_thd_cnt_lo;
 #define DTX_AGG_THD_AGE_MIN	210
 #define DTX_AGG_THD_AGE_DEF	630
 
+/* There is race between DTX aggregation and DTX refresh. Consider the following scenario:
+ *
+ * The DTX leader triggers DTX commit for some DTX entry, then related DTX participants
+ * (including the leader itself) will commit the DTX entry on each own target in parallel.
+ * It is possible that the leader has already committed locally but DTX aggregation removed
+ * the committed DTX very shortly after the commit. On the other hand, on some non-leader
+ * before the local commit, someone triggers DTX refresh for such DTX on such non-leader.
+ * Unfortunately the DTX entry has already gone on the leader. Then the non-leader will
+ * get -DER_TX_UNCERTAIN, that will cause related application to fail unexpectedly.
+ *
+ * So even if the system has DRAM pressure, we still need to keep some very recent committed
+ * DTX entries to handle above race.
+ */
+#define DTX_AGG_AGE_PRESERVE	3
+
 /* The threshold for yield CPU when handle DTX RPC. */
 #define DTX_RPC_YIELD_THD	64
 
@@ -130,6 +145,7 @@ struct dtx_pool_metrics {
  */
 struct dtx_tls {
 	struct d_tm_node_t	*dt_committable;
+	uint64_t		 dt_agg_gen;
 };
 
 extern struct dss_module_key dtx_module_key;
@@ -149,7 +165,6 @@ dtx_cont_opened(struct ds_cont_child *cont)
 extern struct crt_proto_format dtx_proto_fmt;
 extern btr_ops_t dbtree_dtx_cf_ops;
 extern btr_ops_t dtx_btr_cos_ops;
-extern uint64_t dtx_agg_gen;
 
 /* dtx_common.c */
 int dtx_handle_reinit(struct dtx_handle *dth);

--- a/src/dtx/dtx_srv.c
+++ b/src/dtx/dtx_srv.c
@@ -31,6 +31,7 @@ dtx_tls_init(int xs_id, int tgt_id)
 	if (tgt_id < 0)
 		return tls;
 
+	tls->dt_agg_gen = 1;
 	rc = d_tm_add_metric(&tls->dt_committable, D_TM_STATS_GAUGE,
 			     "total number of committable DTX entries",
 			     "entries", "io/dtx/committable/tgt_%u", tgt_id);
@@ -431,8 +432,6 @@ static int
 dtx_setup(void)
 {
 	int	rc;
-
-	dtx_agg_gen = 1;
 
 	rc = dss_ult_create_all(dtx_batched_commit, NULL, true);
 	if (rc != 0) {

--- a/src/vos/ilog.c
+++ b/src/vos/ilog.c
@@ -770,7 +770,7 @@ ilog_tree_modify(struct ilog_context *lctx, const struct ilog_id *id_in,
 	if (id_out->id_epoch <= epr->epr_hi &&
 	    id_out->id_epoch >= epr->epr_lo) {
 		visibility = ilog_status_get(lctx, id_out, DAOS_INTENT_UPDATE, true);
-		if (visibility < 0)
+		if (visibility < 0 && visibility != -DER_TX_UNCERTAIN)
 			return visibility;
 	}
 
@@ -897,7 +897,7 @@ ilog_modify(daos_handle_t loh, const struct ilog_id *id_in,
 	if (root->lr_tree.it_embedded && root->lr_id.id_epoch <= epr->epr_hi
 	    && root->lr_id.id_epoch >= epr->epr_lo) {
 		visibility = ilog_status_get(lctx, &root->lr_id, DAOS_INTENT_UPDATE, true);
-		if (visibility < 0) {
+		if (visibility < 0 && visibility != -DER_TX_UNCERTAIN) {
 			rc = visibility;
 			goto done;
 		}

--- a/src/vos/vos_internal.h
+++ b/src/vos/vos_internal.h
@@ -355,7 +355,7 @@ struct vos_dtx_cmt_ent {
 
 #define DCE_XID(dce)		((dce)->dce_base.dce_xid)
 #define DCE_EPOCH(dce)		((dce)->dce_base.dce_epoch)
-#define DCE_HANDLE_TIME(dce)	((dce)->dce_base.dce_handle_time)
+#define DCE_CMT_TIME(dce)	((dce)->dce_base.dce_cmt_time)
 
 extern uint64_t vos_evt_feats;
 

--- a/src/vos/vos_layout.h
+++ b/src/vos/vos_layout.h
@@ -147,8 +147,14 @@ struct vos_dtx_cmt_ent_df {
 	struct dtx_id			dce_xid;
 	/** The epoch# for the DTX. */
 	daos_epoch_t			dce_epoch;
-	/** The time of the DTX being handled on the server. */
-	daos_epoch_t			dce_handle_time;
+	/**
+	 * The time of the DTX being committed on the server.
+	 *
+	 * XXX: in the future, this field will be moved into
+	 *	vos_dtx_blob_df to shrink each committed DTX
+	 *	entry size.
+	 */
+	daos_epoch_t			dce_cmt_time;
 };
 
 /** Active DTX entry on-disk layout in both SCM and DRAM. */


### PR DESCRIPTION
master-commit: 2c69d62d4ff6fabcf47490d39af1e2637666cb43

There is race between DTX aggregation and DTX refresh. Consider the
following scenario:

The DTX leader triggers DTX commit for some DTX entry, then related
DTX participants (including the leader itself) will commit the DTX
entry on each own target in parallel. It is possible that the leader
has already committed locally but DTX aggregation removed the committed
DTX very shortly after the commit. On the other hand, on some non-leader
before the local commit, someone triggers DTX refresh for such DTX on
such non-leader. Unfortunately the DTX entry has already gone on the
leader. Then the non-leader will get -DER_TX_UNCERTAIN, that will cause
related application to fail unexpectedly.

So even if the system has DRAM pressue, we still need to keep some very
recent committed DTX entries to handle above race.

Signed-off-by: Fan Yong <fan.yong@intel.com>