### PR TITLE
DAOS-9970 test: Increase test timeout for dmg_negative_test (#8365) (Cherry pick to release/2.0)

### DIFF
--- a/src/tests/ftest/osa/dmg_negative_test.yaml
+++ b/src/tests/ftest/osa/dmg_negative_test.yaml
@@ -11,7 +11,7 @@ test_clients:
 extra_servers:
   test_servers:
     - server-C
-timeout: 1000
+timeout: 1200
 server_config:
   name: daos_server
   engines_per_host: 2


### PR DESCRIPTION
Skip-unit-tests: true
Test-tag: osa_dmg_negative_test
Test-repeat: 10

Increase test timeout to account for different cluster hardware.

Signed-off-by: rpadma2 <ravindran.padmanabhan@intel.com>