### PR TITLE
DAOS-9744 test: Update the avocado tag with ib2 (#8547) (Cherry-pick for release/2.0)

### DIFF
--- a/src/tests/ftest/control/dmg_telemetry_io_latency.py
+++ b/src/tests/ftest/control/dmg_telemetry_io_latency.py
@@ -525,7 +525,7 @@ class TestWithTelemetryIOLatency(IorTestBase, TestWithTelemetry):
             size.
 
         :avocado: tags=all,full_regression
-        :avocado: tags=hw,medium
+        :avocado: tags=hw,medium,ib2
         :avocado: tags=telemetry
         :avocado: tags=test_ior_latency_telemetry
 


### PR DESCRIPTION
Test-tag: test_ior_latency_telemetry

Update the avocado test-tag to include ib2 string.

Signed-off-by: rpadma2 <ravindran.padmanabhan@intel.com>