### PR TITLE
Debug dmg network scan

### DIFF
--- a/src/tests/ftest/control/dmg_network_scan.yaml
+++ b/src/tests/ftest/control/dmg_network_scan.yaml
@@ -7,4 +7,4 @@ timeout: 180
 server_config:
   name: daos_server
   port: 10001
-  control_log_mask: INFO
+  control_log_mask: DEBUG


### PR DESCRIPTION
Enable debug output on dmg network scan to gather more info on failure.

Test-tag: network_scan
Test-repeat: 5

Signed-off-by: Kris Jacque <kristin.jacque@intel.com>