### PR TITLE
DAOS-10082 doc: fix pool per-server msg

### DIFF
--- a/src/control/cmd/dmg/pool.go
+++ b/src/control/cmd/dmg/pool.go
@@ -218,7 +218,7 @@ func (cmd *PoolCreateCmd) Execute(args []string) error {
 
 		scmRatio := cmd.updateRequest(req, scmBytes, nvmeBytes)
 
-		cmd.Infof("Creating DAOS pool with manual per-server storage allocation: "+
+		cmd.Infof("Creating DAOS pool with manual per-engine storage allocation: "+
 			"%s SCM, %s NVMe (%0.2f%% ratio)",
 			humanize.Bytes(scmBytes),
 			humanize.Bytes(nvmeBytes),


### PR DESCRIPTION
fix this message in dmg pool create to say "per-engine":
"Creating DAOS pool with manual per-server storage allocation"

Signed-off-by: Michael Hennecke <michael.hennecke@intel.com>