### PR TITLE
DAOS-10356 dfuse: Disable dfuse metadata caching when using IL.

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,7 +6,7 @@ site_author: DAOS Project
 # Repository
 repo_name: daos-stack/daos
 repo_url: https://github.com/daos-stack/daos
-#edit_uri: blob/release/2.4/docs/
+# edit_uri: blob/release/2.4/docs/
 edit_uri: blob/master/docs/
 copyright: Copyright 2016-2022 Intel Corporation
 

--- a/src/client/dfuse/ops/create.c
+++ b/src/client/dfuse/ops/create.c
@@ -198,6 +198,8 @@ dfuse_cb_create(fuse_req_t req, struct dfuse_inode_entry *parent,
 
 	dfuse_compute_inode(dfs, &ie->ie_oid, &ie->ie_stat.st_ino);
 
+	atomic_fetch_add_relaxed(&ie->ie_open_count, 1);
+
 	/* Return the new inode data, and keep the parent ref */
 	dfuse_reply_entry(fs_handle, ie, &fi_out, true, req);
 

--- a/src/client/dfuse/ops/forget.c
+++ b/src/client/dfuse/ops/forget.c
@@ -8,34 +8,40 @@
 #include "dfuse.h"
 
 static void
-dfuse_forget_one(struct dfuse_projection_info *fs_handle,
-		 fuse_ino_t ino, uintptr_t nlookup)
+dfuse_forget_one(struct dfuse_projection_info *fs_handle, fuse_ino_t ino, uintptr_t nlookup)
 {
-	d_list_t *rlink;
-	int rc;
+	d_list_t		 *rlink;
+	int                       rc;
+	struct dfuse_inode_entry *ie;
+	uint                      open_ref;
+	uint                      il_ref;
 
-	/* One additional reference is needed because the rec_find() itself
-	 * acquires one
-	 */
+	/* One additional reference is needed because the rec_find() itself acquires one */
 	nlookup++;
 
 	rlink = d_hash_rec_find(&fs_handle->dpi_iet, &ino, sizeof(ino));
 	if (!rlink) {
-		DFUSE_TRA_WARNING(fs_handle, "Unable to find ref for %#lx %lu",
-				  ino, nlookup);
+		DFUSE_TRA_WARNING(fs_handle, "Unable to find ref for %#lx %lu", ino, nlookup);
 		return;
 	}
 
-	DFUSE_TRA_DEBUG(container_of(rlink, struct dfuse_inode_entry, ie_htl),
-			"inode %#lx count %lu",
-			ino, nlookup);
+	ie = container_of(rlink, struct dfuse_inode_entry, ie_htl);
+
+	il_ref = atomic_load_relaxed(&ie->ie_il_count);
+	if (il_ref != 0) {
+		DFUSE_TRA_ERROR(ie, "Forget with non-zero ioctl count %d", il_ref);
+	}
+
+	open_ref = atomic_load_relaxed(&ie->ie_open_count);
+	if (open_ref != 0) {
+		DFUSE_TRA_ERROR(ie, "Forget with non-zero open count %d", open_ref);
+	}
+
+	DFUSE_TRA_DEBUG(ie, "inode %#lx count %lu", ino, nlookup);
 
 	rc = d_hash_rec_ndecref(&fs_handle->dpi_iet, nlookup, rlink);
 	if (rc != -DER_SUCCESS) {
-		DFUSE_TRA_ERROR(fs_handle, "Invalid refcount %lu on %p",
-				nlookup,
-				container_of(rlink, struct dfuse_inode_entry,
-					     ie_htl));
+		DFUSE_TRA_ERROR(fs_handle, "Invalid refcount %lu on %p", nlookup, ie);
 	}
 }
 
@@ -50,11 +56,10 @@ dfuse_cb_forget(fuse_req_t req, fuse_ino_t ino, uintptr_t nlookup)
 }
 
 void
-dfuse_cb_forget_multi(fuse_req_t req, size_t count,
-		      struct fuse_forget_data *forgets)
+dfuse_cb_forget_multi(fuse_req_t req, size_t count, struct fuse_forget_data *forgets)
 {
 	struct dfuse_projection_info *fs_handle = fuse_req_userdata(req);
-	int i;
+	int                           i;
 
 	fuse_reply_none(req);
 

--- a/src/client/dfuse/ops/lookup.c
+++ b/src/client/dfuse/ops/lookup.c
@@ -27,14 +27,6 @@ dfuse_reply_entry(struct dfuse_projection_info *fs_handle,
 	D_ASSERT(ie->ie_parent);
 	D_ASSERT(ie->ie_dfs);
 
-	if (S_ISDIR(ie->ie_stat.st_mode))
-		entry.entry_timeout = ie->ie_dfs->dfc_dentry_dir_timeout;
-	else
-		entry.entry_timeout = ie->ie_dfs->dfc_dentry_timeout;
-
-	/* Set the attr caching attributes of this entry */
-	entry.attr_timeout = ie->ie_dfs->dfc_attr_timeout;
-
 	ie->ie_root = (ie->ie_stat.st_ino == ie->ie_dfs->dfs_ino);
 
 	entry.attr = ie->ie_stat;
@@ -117,6 +109,19 @@ dfuse_reply_entry(struct dfuse_projection_info *fs_handle,
 		atomic_fetch_sub_relaxed(&ie->ie_ref, 1);
 		dfuse_ie_close(fs_handle, ie);
 		ie = inode;
+	}
+
+	/* Set the attr caching attributes of this entry.  The lookup may have resulted in a
+	 * already known inode for while the interception library is already in use so check
+	 * this and disable caching in this case.
+	 */
+	if ((atomic_load_relaxed(&ie->ie_il_count)) == 0) {
+		if (S_ISDIR(ie->ie_stat.st_mode))
+			entry.entry_timeout = ie->ie_dfs->dfc_dentry_dir_timeout;
+		else
+			entry.entry_timeout = ie->ie_dfs->dfc_dentry_timeout;
+
+		entry.attr_timeout = ie->ie_dfs->dfc_attr_timeout;
 	}
 
 	if (fi_out)

--- a/src/client/dfuse/ops/open.c
+++ b/src/client/dfuse/ops/open.c
@@ -10,12 +10,12 @@
 void
 dfuse_cb_open(fuse_req_t req, fuse_ino_t ino, struct fuse_file_info *fi)
 {
-	struct dfuse_projection_info	*fs_handle = fuse_req_userdata(req);
-	struct dfuse_inode_entry	*ie;
-	d_list_t			*rlink;
-	struct dfuse_obj_hdl		*oh = NULL;
-	struct fuse_file_info	        fi_out = {0};
-	int				rc;
+	struct dfuse_projection_info *fs_handle = fuse_req_userdata(req);
+	struct dfuse_inode_entry     *ie;
+	d_list_t		     *rlink;
+	struct dfuse_obj_hdl         *oh     = NULL;
+	struct fuse_file_info         fi_out = {0};
+	int                           rc;
 
 	rlink = d_hash_rec_find(&fs_handle->dpi_iet, &ino, sizeof(ino));
 	if (!rlink) {
@@ -33,22 +33,20 @@ dfuse_cb_open(fuse_req_t req, fuse_ino_t ino, struct fuse_file_info *fi)
 	/* Upgrade fd permissions from O_WRONLY to O_RDWR if wb caching is
 	 * enabled so the kernel can do read-modify-write
 	 */
-	if (ie->ie_dfs->dfc_data_caching &&
-		fs_handle->dpi_info->di_wb_cache &&
-		(fi->flags & O_ACCMODE) == O_WRONLY) {
+	if (ie->ie_dfs->dfc_data_caching && fs_handle->dpi_info->di_wb_cache &&
+	    (fi->flags & O_ACCMODE) == O_WRONLY) {
 		DFUSE_TRA_DEBUG(ie, "Upgrading fd to O_RDRW");
 		fi->flags &= ~O_ACCMODE;
 		fi->flags |= O_RDWR;
 	}
 
 	/** duplicate the file handle for the fuse handle */
-	rc = dfs_dup(ie->ie_dfs->dfs_ns, ie->ie_obj, fi->flags,
-		     &oh->doh_obj);
+	rc = dfs_dup(ie->ie_dfs->dfs_ns, ie->ie_obj, fi->flags, &oh->doh_obj);
 	if (rc)
 		D_GOTO(err, rc);
 
 	oh->doh_dfs = ie->ie_dfs->dfs_ns;
-	oh->doh_ie = ie;
+	oh->doh_ie  = ie;
 
 	if (ie->ie_dfs->dfc_data_caching) {
 		if (fi->flags & O_DIRECT)
@@ -72,11 +70,12 @@ dfuse_cb_open(fuse_req_t req, fuse_ino_t ino, struct fuse_file_info *fi)
 	 * O_TRUNC flag, we need to truncate the file manually.
 	 */
 	if (fi->flags & O_TRUNC) {
-		rc = dfs_punch(ie->ie_dfs->dfs_ns, ie->ie_obj, 0,
-			       DFS_MAX_FSIZE);
+		rc = dfs_punch(ie->ie_dfs->dfs_ns, ie->ie_obj, 0, DFS_MAX_FSIZE);
 		if (rc)
 			D_GOTO(err, rc);
 	}
+
+	atomic_fetch_add_relaxed(&ie->ie_open_count, 1);
 
 	d_hash_rec_decref(&fs_handle->dpi_iet, rlink);
 	DFUSE_REPLY_OPEN(oh, req, &fi_out);
@@ -91,8 +90,19 @@ err:
 void
 dfuse_cb_release(fuse_req_t req, fuse_ino_t ino, struct fuse_file_info *fi)
 {
-	struct dfuse_obj_hdl	*oh = (struct dfuse_obj_hdl *)fi->fh;
-	int			rc;
+	struct dfuse_obj_hdl *oh = (struct dfuse_obj_hdl *)fi->fh;
+	int                   rc;
+	uint                  il_count;
+
+	/* Perform the opposite of what the ioctl call does, always change the open handle count
+	 * but the inode only tracks number of open handles with non-zero ioctl counts
+	 */
+	il_count = atomic_load_relaxed(&oh->doh_il_calls);
+
+	if (il_count != 0) {
+		atomic_fetch_sub_relaxed(&oh->doh_ie->ie_il_count, 1);
+	}
+	atomic_fetch_sub_relaxed(&oh->doh_ie->ie_open_count, 1);
 
 	rc = dfs_release(oh->doh_obj);
 	if (rc == 0)


### PR DESCRIPTION
Track when the IL has opened file handles and invalidate all kernel
metadata when in use.  Track the ioctl calls and use atomics to
track the number of calls per open file, and the number of files
per inode, when returning inode metadata check the il-in-use count.

This should mean that when the IL is in use, all metadata requests
will go to the servers, so avoids a situation where a file is opened,
the IL writes data to it then the kernel will continue to return
stale size data.

Add checks in forget that the IL and open file count are at zero.

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>
