### PR TITLE
DAOS-10082 doc: fix pool per-server msg (#8758)

### DIFF
--- a/src/control/cmd/dmg/pool.go
+++ b/src/control/cmd/dmg/pool.go
@@ -180,7 +180,7 @@ func (cmd *PoolCreateCmd) Execute(args []string) error {
 			cmd.log.Infof("SCM:NVMe ratio is less than %0.2f %%, DAOS "+
 				"performance will suffer!\n", storage.MinScmToNVMeRatio*100)
 		}
-		cmd.log.Infof("Creating DAOS pool with manual per-server storage allocation: "+
+		cmd.log.Infof("Creating DAOS pool with manual per-engine storage allocation: "+
 			"%s SCM, %s NVMe (%0.2f%% ratio)", humanize.Bytes(ScmBytes),
 			humanize.Bytes(NvmeBytes), scmRatio*100)
 	}


### PR DESCRIPTION
fix this message in dmg pool create to say "per-engine":
"Creating DAOS pool with manual per-server storage allocation"

Signed-off-by: Michael Hennecke <michael.hennecke@intel.com>