### PR TITLE
DAOS-10227 vos: Fix a bug and add more bits to timestamp (#8709)

### DIFF
--- a/src/vos/evtree.c
+++ b/src/vos/evtree.c
@@ -2815,7 +2815,7 @@ evt_close(daos_handle_t toh)
 	return 0;
 }
 
-#define EVT_AGG_MASK (VOS_TF_AGG_HLC | VOS_TF_AGG_TIME_MASK | VOS_TF_AGG_OPT)
+#define EVT_AGG_MASK (VOS_TF_AGG_HLC | VOS_AGG_TIME_MASK | VOS_TF_AGG_OPT)
 /**
  * Create a new tree inplace of \a root, return the open handle.
  * Please check API comment in evtree.h for the details.

--- a/src/vos/tests/vts_aggregate.c
+++ b/src/vos/tests/vts_aggregate.c
@@ -2767,9 +2767,8 @@ aggregate_34(void **state)
 	cleanup();
 }
 
-#define INIT_FEATS 0x8000000010f93f43ULL
-
-D_CASSERT((INIT_FEATS & VOS_TF_AGG_TIME_MASK) == 0);
+#define INIT_FEATS 0x8000000000073f43ULL
+D_CASSERT((INIT_FEATS & VOS_AGG_TIME_MASK) == 0);
 
 static void
 aggregate_35(void **state)
@@ -2792,18 +2791,69 @@ aggregate_35(void **state)
 	assert_int_equal(epoch, 252);
 	assert_int_equal(feats & INIT_FEATS, INIT_FEATS);
 
-	vos_feats_agg_time_update(252, &feats);
+	/** Set lower time, same answer */
+	vos_feats_agg_time_update(242, &feats);
 	result = vos_feats_agg_time_get(feats, &epoch);
 	assert_true(result);
 	assert_int_equal(epoch, 252);
 	assert_int_equal(feats & INIT_FEATS, INIT_FEATS);
 
-	/** If upper 32-bits is set, we assume HLC */
-	vos_feats_agg_time_update(0x53abcdef00ULL, &feats);
+	/** Set higher time, new answer */
+	vos_feats_agg_time_update(342, &feats);
 	result = vos_feats_agg_time_get(feats, &epoch);
 	assert_true(result);
-	/** Since the lower 32 are masked, we always set them to ffffffff */
-	assert_int_equal(epoch, 0x53ffffffffULL);
+	assert_int_equal(epoch, 342);
+	assert_int_equal(feats & INIT_FEATS, INIT_FEATS);
+
+	/** If upper 24-bits is set, we assume HLC */
+	vos_feats_agg_time_update(0x463abcdef00ULL, &feats);
+	result = vos_feats_agg_time_get(feats, &epoch);
+	assert_true(result);
+	/** When we set the timestamp, we round up */
+	assert_int_equal(epoch, 0x463ac000000ULL);
+	assert_int_equal(feats & INIT_FEATS, INIT_FEATS);
+
+	/** Try setting a lower time, should get same result */
+	vos_feats_agg_time_update(0x463a00def00ULL, &feats);
+	result = vos_feats_agg_time_get(feats, &epoch);
+	assert_true(result);
+	assert_int_equal(epoch, 0x463ac000000ULL);
+	assert_int_equal(feats & INIT_FEATS, INIT_FEATS);
+
+	/** Try setting a higher time, should get updated */
+	vos_feats_agg_time_update(0x463adcdef00ULL, &feats);
+	result = vos_feats_agg_time_get(feats, &epoch);
+	assert_true(result);
+	assert_int_equal(epoch, 0x463ae000000ULL);
+	assert_int_equal(feats & INIT_FEATS, INIT_FEATS);
+
+	/** Test maximum epoch (not HLC) */
+	feats = INIT_FEATS;
+	epoch = (1ULL << VOS_AGG_NR_BITS) - 1;
+	vos_feats_agg_time_update(epoch, &feats);
+	result = vos_feats_agg_time_get(feats, &epoch);
+	assert_true(result);
+	assert_int_equal(epoch, (1ULL << VOS_AGG_NR_BITS) - 1);
+	assert_false(feats & VOS_TF_AGG_HLC);
+	assert_int_equal(feats & INIT_FEATS, INIT_FEATS);
+
+	/** Test minimum HLC */
+	epoch = 1ULL << VOS_AGG_NR_BITS;
+	vos_feats_agg_time_update(epoch, &feats);
+	result = vos_feats_agg_time_get(feats, &epoch);
+	assert_true(result);
+	/** Already rounded to nearest 1/4 ms */
+	assert_int_equal(epoch, 1ULL << VOS_AGG_NR_BITS);
+	assert_true(feats & VOS_TF_AGG_HLC);
+	assert_int_equal(feats & INIT_FEATS, INIT_FEATS);
+
+	/** Test rounding */
+	epoch = (1ULL << VOS_AGG_NR_BITS) + 1;
+	vos_feats_agg_time_update(epoch, &feats);
+	result = vos_feats_agg_time_get(feats, &epoch);
+	assert_true(result);
+	assert_int_equal(epoch, (1ULL << VOS_AGG_NR_BITS) + (1ULL << VOS_AGG_NR_HLC_BITS));
+	assert_true(feats & VOS_TF_AGG_HLC);
 	assert_int_equal(feats & INIT_FEATS, INIT_FEATS);
 }
 

--- a/src/vos/vos_internal.h
+++ b/src/vos/vos_internal.h
@@ -365,64 +365,79 @@ extern uint64_t vos_evt_feats;
 #define VOS_KEY_CMP_LEXICAL	(1ULL << 63)
 /** Indicates that a tree has aggregation optimization enabled */
 #define VOS_TF_AGG_OPT	(1ULL << 62)
-/** Indicates that the stored 32 bits from a timestamp are from an HLC */
+/** Indicates that the stored bits from a timestamp are from an HLC */
 #define VOS_TF_AGG_HLC	(1ULL << 61)
+/** Number of bits to use for timestamp (roughly 1/4 ms granularity) */
+#define VOS_AGG_NR_BITS	42
+/** HLC differentiation bits */
+#define VOS_AGG_NR_HLC_BITS	(64 - VOS_AGG_NR_BITS)
+/** Lower bits of HLC used for rounding */
+#define VOS_AGG_HLC_BITS	((1ULL << VOS_AGG_NR_HLC_BITS) - 1)
+/** Mask to check if epoch is HLC. */
+#define VOS_AGG_HLC_MASK	(VOS_AGG_HLC_BITS << (64 - VOS_AGG_NR_HLC_BITS))
+/** Mask of bits of epoch */
+#define VOS_AGG_EPOCH_MASK	(~VOS_AGG_HLC_MASK << (VOS_AGG_NR_HLC_BITS))
 /** Start bit of stored timestamp */
 #define VOS_TF_AGG_BIT	60
-/** Right shift for 32-bits of epoch */
-#define VOS_TF_AGG_RSHIFT	(63 - VOS_TF_AGG_BIT)
-/** Left shift for 32-bits of epoch */
-#define VOS_TF_AGG_LSHIFT	(32 - VOS_TF_AGG_RSHIFT)
+/** Right shift for stored portion of epoch */
+#define VOS_AGG_RSHIFT	(63 - VOS_TF_AGG_BIT)
+/** Left shift for stored portion of epoch */
+#define VOS_AGG_LSHIFT	(64 - VOS_AGG_NR_BITS - VOS_AGG_RSHIFT)
 /** In-place mask to get epoch from feature bits */
-#define VOS_TF_AGG_TIME_MASK	(0xffffffffULL << VOS_TF_AGG_LSHIFT)
+#define VOS_AGG_TIME_MASK	(VOS_AGG_EPOCH_MASK >> VOS_AGG_RSHIFT)
 
-D_CASSERT((VOS_TF_AGG_HLC & VOS_TF_AGG_TIME_MASK) == 0);
-D_CASSERT(VOS_TF_AGG_TIME_MASK & (1ULL << VOS_TF_AGG_BIT));
-D_CASSERT((VOS_TF_AGG_TIME_MASK & (1ULL << (VOS_TF_AGG_BIT + 1))) == 0);
-D_CASSERT((VOS_TF_AGG_TIME_MASK & (1ULL << (VOS_TF_AGG_BIT - 32))) == 0);
+D_CASSERT((VOS_TF_AGG_HLC & VOS_AGG_TIME_MASK) == 0);
+D_CASSERT(VOS_AGG_TIME_MASK & (1ULL << VOS_TF_AGG_BIT));
+D_CASSERT((VOS_AGG_TIME_MASK & (1ULL << (VOS_TF_AGG_BIT + 1))) == 0);
+D_CASSERT((VOS_AGG_TIME_MASK & (1ULL << (VOS_TF_AGG_BIT - VOS_AGG_NR_BITS))) == 0);
 
 #define CHECK_VOS_TREE_FLAG(flag)	\
 	D_CASSERT(((flag) & (EVT_FEATS_SUPPORTED | BTR_FEAT_MASK)) == 0)
 CHECK_VOS_TREE_FLAG(VOS_KEY_CMP_LEXICAL);
 CHECK_VOS_TREE_FLAG(VOS_TF_AGG_OPT);
-CHECK_VOS_TREE_FLAG(VOS_TF_AGG_TIME_MASK);
+CHECK_VOS_TREE_FLAG(VOS_AGG_TIME_MASK);
 
-/** Update the aggregatable write timestamp within 1/4 second granularity */
-static inline void
-vos_feats_agg_time_update(daos_epoch_t epoch, uint64_t *feats)
-{
-	uint64_t extra_flag = 0;
-
-	if (epoch & 0xffffffff00000000ULL) {
-		/** Assume aggregation only happens at most once every quarter second */
-		epoch &= 0xffffffff00000000ULL;
-		/** Ensure the resulting epoch is not zero regardless, mostly for standalone */
-		epoch = (epoch >> VOS_TF_AGG_RSHIFT);
-		extra_flag = VOS_TF_AGG_HLC;
-	} else {
-		epoch &= 0x0ffffffffULL;
-		epoch = (epoch << VOS_TF_AGG_LSHIFT);
-	}
-
-	*feats &= ~VOS_TF_AGG_TIME_MASK;
-	*feats |= epoch | VOS_TF_AGG_OPT | extra_flag;
-}
-
-/** Get the aggregatable write timestamp within 1/4 second granularity */
+/** Get the aggregatable write timestamp within 1/4 ms granularity */
 static inline bool
 vos_feats_agg_time_get(uint64_t feats, daos_epoch_t *epoch)
 {
 	if ((feats & VOS_TF_AGG_OPT) == 0)
 		return false;
 
-	if (feats & VOS_TF_AGG_HLC) {
-		*epoch = ((feats & VOS_TF_AGG_TIME_MASK) << VOS_TF_AGG_RSHIFT);
-		*epoch += 0xffffffffULL;
-	} else {
-		*epoch = ((feats & VOS_TF_AGG_TIME_MASK) >> VOS_TF_AGG_LSHIFT);
-	}
+	if (feats & VOS_TF_AGG_HLC)
+		*epoch = ((feats & VOS_AGG_TIME_MASK) << VOS_AGG_RSHIFT);
+	else
+		*epoch = ((feats & VOS_AGG_TIME_MASK) >> VOS_AGG_LSHIFT);
 
 	return true;
+}
+
+/** Update the aggregatable write timestamp within 1/4 ms granularity */
+static inline void
+vos_feats_agg_time_update(daos_epoch_t epoch, uint64_t *feats)
+{
+	uint64_t	extra_flag = 0;
+	daos_epoch_t	old_epoch = 0;
+
+	if (!vos_feats_agg_time_get(*feats, &old_epoch))
+		old_epoch = 0;
+
+	if (epoch <= old_epoch) /** Only need to save newest */
+		return;
+
+	if (epoch & VOS_AGG_HLC_MASK) {
+		/** We only save the top bits so round up so the stored timestamp works */
+		epoch += VOS_AGG_HLC_BITS;
+		epoch &= VOS_AGG_EPOCH_MASK;
+		/** Ensure the resulting epoch is not zero regardless, mostly for standalone */
+		epoch = (epoch >> VOS_AGG_RSHIFT);
+		extra_flag = VOS_TF_AGG_HLC;
+	} else {
+		epoch = (epoch << VOS_AGG_LSHIFT);
+	}
+
+	*feats &= ~VOS_AGG_TIME_MASK;
+	*feats |= epoch | VOS_TF_AGG_OPT | extra_flag;
 }
 
 #define VOS_KEY_CMP_UINT64_SET	(BTR_FEAT_UINT_KEY)


### PR DESCRIPTION
For RDB to perform 1000 txns/s, we need more bits to store
an epoch.   Use 42-bits of HLC instead of 32.  This gives us
roughly 116 years worth of epochs.
    
Also, don't update the epoch if it's lower than the stored
one.  This is a bug.

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>