### PR TITLE
DAOS-10355 dfuse: Add interception for ftruncate.

### DIFF
--- a/src/client/dfuse/il/int_posix.c
+++ b/src/client/dfuse/il/int_posix.c
@@ -1470,6 +1470,33 @@ dfuse_mmap(void *address, size_t length, int prot, int flags, int fd,
 }
 
 DFUSE_PUBLIC int
+dfuse_ftruncate(int fd, off_t length)
+{
+	struct fd_entry *entry;
+	int              rc;
+
+	rc = vector_get(&fd_table, fd, &entry);
+	if (rc != 0)
+		goto do_real_ftruncate;
+
+	DFUSE_LOG_DEBUG("ftuncate(fd=%d) intercepted, bypass=%s offset %#lx", fd,
+			bypass_status[entry->fd_status], length);
+
+	rc = dfs_punch(entry->fd_cont->ioc_dfs, entry->fd_dfsoh, length, DFS_MAX_FSIZE);
+
+	vector_decref(&fd_table, entry);
+
+	if (rc == -DER_SUCCESS)
+		return 0;
+
+	errno = rc;
+	return -1;
+
+do_real_ftruncate:
+	return __real_ftruncate(fd, length);
+}
+
+DFUSE_PUBLIC int
 dfuse_fsync(int fd)
 {
 	struct fd_entry *entry;

--- a/src/client/dfuse/il/intercept.h
+++ b/src/client/dfuse/il/intercept.h
@@ -26,17 +26,18 @@
  * all aio routines (for now)
  * fcntl (for now though we likely need for dup)
  */
-#define FOREACH_ALIASED_INTERCEPT(ACTION)                                     \
-	ACTION(FILE *,  fopen,     (const char *, const char *))              \
-	ACTION(FILE *,  freopen,   (const char *, const char *, FILE *))      \
-	ACTION(int,     open,      (const char *, int, ...))                  \
-	ACTION(int,     openat,    (int, const char *, int, ...))             \
-	ACTION(ssize_t, pread,     (int, void *, size_t, off_t))              \
-	ACTION(ssize_t, pwrite,    (int, const void *, size_t, off_t))        \
-	ACTION(off_t,   lseek,     (int, off_t, int))                         \
-	ACTION(ssize_t, preadv,    (int, const struct iovec *, int, off_t))   \
-	ACTION(ssize_t, pwritev,   (int, const struct iovec *, int, off_t))   \
-	ACTION(void *,  mmap,      (void *, size_t, int, int, int, off_t))
+#define FOREACH_ALIASED_INTERCEPT(ACTION)                                                          \
+	ACTION(FILE *, fopen, (const char *, const char *))                                        \
+	ACTION(FILE *, freopen, (const char *, const char *, FILE *))                              \
+	ACTION(int, open, (const char *, int, ...))                                                \
+	ACTION(int, openat, (int, const char *, int, ...))                                         \
+	ACTION(ssize_t, pread, (int, void *, size_t, off_t))                                       \
+	ACTION(ssize_t, pwrite, (int, const void *, size_t, off_t))                                \
+	ACTION(off_t, lseek, (int, off_t, int))                                                    \
+	ACTION(ssize_t, preadv, (int, const struct iovec *, int, off_t))                           \
+	ACTION(ssize_t, pwritev, (int, const struct iovec *, int, off_t))                          \
+	ACTION(void *, mmap, (void *, size_t, int, int, int, off_t))                               \
+	ACTION(int, ftruncate, (int, off_t))
 
 #define FOREACH_SINGLE_INTERCEPT(ACTION)                                      \
 	ACTION(int,     fclose,    (FILE *))                                  \


### PR DESCRIPTION
Add interception for ftruncate.  This does not change the file
position so is reasonably easy.

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>
