### PR TITLE
DAOS-10202 event: private event needs lock on completion and poll (#8…

### DIFF
--- a/src/client/api/client_internal.h
+++ b/src/client/api/client_internal.h
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2021 Intel Corporation.
+ * (C) Copyright 2016-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -66,6 +66,8 @@ struct daos_event_private {
 	struct daos_event_callback evx_callback;
 
 	tse_sched_t		*evx_sched;
+	/** Lock for events that are not in an EQ, including the thread private event */
+	pthread_mutex_t		evx_lock;
 };
 
 static inline struct daos_event_private *

--- a/src/client/api/event.c
+++ b/src/client/api/event.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2021 Intel Corporation.
+ * (C) Copyright 2016-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -328,6 +328,8 @@ daos_event_complete_locked(struct daos_eq_private *eqx,
 
 	if (eqx != NULL)
 		eq = daos_eqx2eq(eqx);
+	else
+		D_MUTEX_LOCK(&evx->evx_lock);
 
 	evx->evx_status = DAOS_EVS_COMPLETED;
 	rc = daos_event_complete_cb(evx, rc);
@@ -349,21 +351,21 @@ daos_event_complete_locked(struct daos_eq_private *eqx,
 		if (parent_evx->evx_nchild_comp < parent_evx->evx_nchild) {
 			/* Not all children have completed yet */
 			parent_ev->ev_error = parent_ev->ev_error ?: rc;
-			return 0;
+			goto out;
 		}
 
 		/* If the parent is not launched yet, let's return */
 		if (parent_evx->evx_status == DAOS_EVS_READY)
-			return 0;
+			goto out;
 
 		/* If the parent was completed or aborted, we can return */
 		if (parent_evx->evx_status == DAOS_EVS_COMPLETED ||
 		    parent_evx->evx_status == DAOS_EVS_ABORTED)
-			return 0;
+			goto out;
 
 		/* If the parent is not a barrier it will complete on its own */
 		if (!parent_evx->is_barrier)
-			return 0;
+			goto out;
 
 		/* Complete the barrier parent */
 		D_ASSERT(parent_evx->evx_status == DAOS_EVS_RUNNING);
@@ -382,6 +384,9 @@ daos_event_complete_locked(struct daos_eq_private *eqx,
 		eq->eq_n_running--;
 	}
 
+out:
+	if (eq == NULL)
+		D_MUTEX_UNLOCK(&evx->evx_lock);
 	return 0;
 }
 
@@ -514,12 +519,11 @@ ev_progress_cb(void *arg)
 	if (evx->evx_nchild_running > 0)
 		return 0;
 
-	/*
-	 * Change status of event to INIT only if event is not in EQ and get
-	 * out.
-	 */
+	/** Change status of event to INIT only if event is not in EQ and get out. */
 	if (daos_handle_is_inval(evx->evx_eqh)) {
+		D_MUTEX_LOCK(&evx->evx_lock);
 		evx->evx_status = DAOS_EVS_READY;
+		D_MUTEX_UNLOCK(&evx->evx_lock);
 		return 1;
 	}
 
@@ -1041,12 +1045,19 @@ daos_event_init(struct daos_event *ev, daos_handle_t eqh,
 		daos_eq_putref(eqx);
 	} else {
 		if (daos_sched_g.ds_udata == NULL) {
-			D_ERROR("The DAOS client library is not initialized: "
-				DF_RC"\n", DP_RC(-DER_UNINIT));
+			D_ERROR("The DAOS client library is not initialized: "DF_RC"\n",
+				DP_RC(-DER_UNINIT));
 			return -DER_UNINIT;
 		}
 		evx->evx_ctx = daos_eq_ctx;
 		evx->evx_sched = &daos_sched_g;
+	}
+
+	if (daos_handle_is_inval(evx->evx_eqh)) {
+		/** since there is no EQ, initialize the evx lock */
+		rc = D_MUTEX_INIT(&evx->evx_lock, NULL);
+		if (rc)
+			return rc;
 	}
 
 	return rc;
@@ -1079,6 +1090,10 @@ daos_event_fini(struct daos_event *ev)
 		rc = -DER_BUSY;
 		goto out;
 	}
+
+	/** destroy the event lock if there is not event queue or this is a child event */
+	if (daos_handle_is_inval(evx->evx_eqh))
+		D_MUTEX_DESTROY(&evx->evx_lock);
 
 	/* If there are child events */
 	while (!d_list_empty(&evx->evx_child)) {
@@ -1197,6 +1212,8 @@ daos_event_abort(struct daos_event *ev)
 			return -DER_NONEXIST;
 		}
 		D_MUTEX_LOCK(&eqx->eqx_lock);
+	} else {
+		D_MUTEX_LOCK(&evx->evx_lock);
 	}
 
 	daos_event_abort_locked(eqx, evx);
@@ -1204,6 +1221,8 @@ daos_event_abort(struct daos_event *ev)
 	if (eqx != NULL) {
 		D_MUTEX_UNLOCK(&eqx->eqx_lock);
 		daos_eq_putref(eqx);
+	} else {
+		D_MUTEX_UNLOCK(&evx->evx_lock);
 	}
 
 	return 0;
@@ -1249,7 +1268,7 @@ daos_event_priv_wait()
 {
 	struct ev_progress_arg	epa;
 	struct daos_event_private *evx = daos_ev2evx(&ev_thpriv);
-	int rc = 0;
+	int rc = 0, rc2;
 
 	D_ASSERT(ev_thpriv_is_init);
 
@@ -1258,19 +1277,13 @@ daos_event_priv_wait()
 
 	/* Wait on the event to complete */
 	while (evx->evx_status != DAOS_EVS_READY) {
-		int rc2;
-
 		rc = crt_progress_cond(evx->evx_ctx, 0, ev_progress_cb, &epa);
 
 		/** progress succeeded, loop can exit if event completed */
 		if (rc == 0) {
 			rc = ev_thpriv.ev_error;
-			if (rc) {
-				rc2 = daos_event_priv_reset();
-				D_ASSERT(rc2 == 0);
-				ev_thpriv_is_init = true;
+			if (rc)
 				break;
-			}
 			continue;
 		}
 
@@ -1280,15 +1293,14 @@ daos_event_priv_wait()
 
 		D_ERROR("crt progress failed with "DF_RC"\n", DP_RC(rc));
 
-		/*
-		 * other progress failure; op should fail with that err. reset the private event
-		 * first so it can be resused.
-		 */
-		rc2 = daos_event_priv_reset();
-		D_ASSERT(rc2 == 0);
-		ev_thpriv_is_init = true;
+		/** other progress failure; op should fail with that err. */
 		break;
 	}
+
+	rc2 = daos_event_priv_reset();
+	if (rc == 0)
+		rc = rc2;
+	D_ASSERT(ev_thpriv.ev_error == 0);
 	return rc;
 }
 


### PR DESCRIPTION
…738)

It is possible that the error is not reset to 0 when a process is retrieving the private event in a multi-threaded environment since another thread might have processed the event completion.

add a lock on daos_event_t for events that are not part of an event queue, including the thread private event. This is required because in a multithreaded environment like dfuse, the event can be completed and the error set non
atomically, while the main thread sees the completion but before the error has actually set, causing the owner of the event to reset the event error, with the other thread setting the error after. this affects future use of the event that launches with ev_error already set to the previous error.

Signed-off-by: Mohamad Chaarawi <mohamad.chaarawi@intel.com>