### PR TITLE
DAOS-10202 event: private event needs lock on completion and poll (#8…

### DIFF
--- a/src/client/api/client_internal.h
+++ b/src/client/api/client_internal.h
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2021 Intel Corporation.
+ * (C) Copyright 2016-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -66,6 +66,8 @@ struct daos_event_private {
 	struct daos_event_callback evx_callback;
 
 	tse_sched_t		*evx_sched;
+	/** Lock for events that are not in an EQ, including the thread private event */
+	pthread_mutex_t		evx_lock;
 };
 
 static inline struct daos_event_private *


### PR DESCRIPTION
…738)

It is possible that the error is not reset to 0 when a process is retrieving the private event in a multi-threaded environment since another thread might have processed the event completion.

add a lock on daos_event_t for events that are not part of an event queue, including the thread private event. This is required because in a multithreaded environment like dfuse, the event can be completed and the error set non
atomically, while the main thread sees the completion but before the error has actually set, causing the owner of the event to reset the event error, with the other thread setting the error after. this affects future use of the event that launches with ev_error already set to the previous error.

Signed-off-by: Mohamad Chaarawi <mohamad.chaarawi@intel.com>