### PR TITLE
DAOS-10224 ddb: dump, load, rm commands

### DIFF
--- a/src/ddb/README.md
+++ b/src/ddb/README.md
@@ -24,9 +24,19 @@ interactive shell mode. Key features that will be supported are:
 ## Current State
 
 ddb is very much in development. Currently the interactive mode and the '-R'
-option with a single command work relatively well. The only commands that are
-currently implemented are quit (for interactive mode) and 'ls' to list the
-branches of a vos file (container, objects, ...).
+option with a single command work relatively well.
+
+Status of commands:
+- quit - done for interactive mode. Not applicable for other modes
+- ls - done
+- dump_value - done
+- dump_ilog - done, but not tested real well besides simple happy paths.
+- dump_superblock - done
+- dump_dtx - done
+- rm - done
+- load - done
+- rm_ilog - not started
+- rm_dtx - not started
 
 ## Design
 
@@ -42,10 +52,10 @@ The primary layers for the application are:
 
 #### Main/Entry Point
 
-The main function which initializes daos and vos and accepts program arguments.
-It then passes those arguments to the ddb_main function which will then parse
-the arguments and options into appropriate fields within the main program
-structure.
+The main function in ddb_entry.c initializes daos and vos and accepts program
+arguments. It then passes those arguments without any parsing to the ddb_main
+function in ddb_main.c which will then parse the arguments and options into
+appropriate fields within the main program structure.
 
 #### ddb_main
 
@@ -53,15 +63,16 @@ A unit testable "main" function. It accepts the traditional argc/argv parameters
 as well as a function table to input and output functions. Unit testing is then
 able to fake the input/output to verify that command line arguments, or
 arguments in the interactive mode, run the program in the correct mode and
-execute the correct sub command. A function table is defined for the actual sub
-commands so that these can be faked out as well and the cli can be unit tested
-in isolation.
+execute the correct sub command. For the most part, ddb_main() manages the
+shell, determining if a command should be run and then the program quit (-R),
+run a sequence of commands from a file (-f), or run in interactive mode.
 
 #### ddb commands (sub commands)
 
 The implementation of the individual commands that a user can pass in. It
-receives the command options/arguments as a well defined structure (fields of
-which are set by ddb).
+receives a command's options/arguments as a well defined structure (fields of
+which are set by ddb). It interacts with a ddb/vos adapter layer for using the
+VOS api.
 
 ### ddb vos (dv_)
 

--- a/src/ddb/SConscript
+++ b/src/ddb/SConscript
@@ -3,18 +3,19 @@ import daos_build
 
 def scons():
     """Execute build"""
-    Import('base_env', 'prereqs')
+    Import('env', 'prereqs')
 
     if not prereqs.server_requested():
         return
 
-    denv = base_env.Clone()
+    denv = env.Clone()
 
     libs = ['vos', 'daos_common_pmem', 'abt', 'gurt', 'uuid', 'bio']
     src = ['ddb_cmd_options.c',
            'ddb_commands.c',
            'ddb_main.c',
            'ddb_parse.c',
+           'ddb_printer.c',
            'ddb_vos.c']
 
     ddblib = denv.StaticObject(src)
@@ -23,6 +24,13 @@ def scons():
     # Add runtime paths for daos libraries
     denv.AppendUnique(RPATH_FULL=['$PREFIX/lib64/daos_srv'])
     denv.AppendUnique(RPATH_FULL=['$PREFIX/lib64'])
+
+    denv.Append(CPPDEFINES={'DAOS_PMEM_BUILD': '1'})
+
+    # Because ddb is so heavily dependent on VOS, allow it to have some internal
+    # knowledge of it.
+    denv.AppendUnique(CPPPATH=[Dir('../vos/').srcnode()])
+    denv.AppendUnique(CPPPATH=[Dir('../vos/')])
 
     prereqs.require(denv, 'argobots', 'protobufc', 'pmdk')
 

--- a/src/ddb/ddb_cmd_options.c
+++ b/src/ddb/ddb_cmd_options.c
@@ -66,10 +66,11 @@ ls_option_parse(struct ddb_ctx *ctx, struct ls_options *cmd_args, struct argv_pa
 
 	return 0;
 }
+
 /* Parse command line options for the 'dump_ilog' command */
 static int
 dump_ilog_option_parse(struct ddb_ctx *ctx, struct dump_ilog_options *cmd_args,
-	struct argv_parsed *argc_v)
+		       struct argv_parsed *argc_v)
 {
 	int		  index = 1;
 	uint32_t	  argc = argc_v->ap_argc;
@@ -95,6 +96,7 @@ dump_ilog_option_parse(struct ddb_ctx *ctx, struct dump_ilog_options *cmd_args,
 
 	return 0;
 }
+
 /* Parse command line options for the 'dump_dtx' command */
 static int
 dump_dtx_option_parse(struct ddb_ctx *ctx, struct dump_dtx_options *cmd_args,
@@ -150,6 +152,7 @@ dump_dtx_option_parse(struct ddb_ctx *ctx, struct dump_dtx_options *cmd_args,
 
 	return 0;
 }
+
 /* Parse command line options for the 'dump_value' command */
 static int
 dump_value_option_parse(struct ddb_ctx *ctx, struct dump_value_options *cmd_args,
@@ -186,6 +189,7 @@ dump_value_option_parse(struct ddb_ctx *ctx, struct dump_value_options *cmd_args
 
 	return 0;
 }
+
 /* Parse command line options for the 'rm' command */
 static int
 rm_option_parse(struct ddb_ctx *ctx, struct rm_options *cmd_args, struct argv_parsed *argc_v)
@@ -214,6 +218,7 @@ rm_option_parse(struct ddb_ctx *ctx, struct rm_options *cmd_args, struct argv_pa
 
 	return 0;
 }
+
 /* Parse command line options for the 'load' command */
 static int
 load_option_parse(struct ddb_ctx *ctx, struct load_options *cmd_args, struct argv_parsed *argc_v)

--- a/src/ddb/ddb_cmd_options.c
+++ b/src/ddb/ddb_cmd_options.c
@@ -10,8 +10,14 @@
 #include "ddb_cmd_options.h"
 #include "ddb_common.h"
 #define same(a, b) (strcmp((a), (b)) == 0)
-#define COMMAND_NAME_LS "ls"
 #define COMMAND_NAME_QUIT "quit"
+#define COMMAND_NAME_LS "ls"
+#define COMMAND_NAME_DUMP_SUPERBLOCK "dump_superblock"
+#define COMMAND_NAME_DUMP_ILOG "dump_ilog"
+#define COMMAND_NAME_DUMP_DTX "dump_dtx"
+#define COMMAND_NAME_DUMP_VALUE "dump_value"
+#define COMMAND_NAME_RM "rm"
+#define COMMAND_NAME_LOAD "load"
 
 /* Parse command line options for the 'ls' command */
 static int
@@ -42,17 +48,209 @@ ls_option_parse(struct ddb_ctx *ctx, struct ls_options *cmd_args, struct argv_pa
 			return -DER_INVAL;
 		}
 	}
-	D_ASSERT(argc > optind);
-	D_ASSERT(same(argv[optind], COMMAND_NAME_LS));
-	optind++;
 
-	if (argc - optind > 0) {
-		cmd_args->path = argv[optind];
-		optind++;
+	index = optind;
+
+	D_ASSERT(argc > index);
+	D_ASSERT(same(argv[index], COMMAND_NAME_LS));
+	index++;
+	if (argc - index > 0) {
+		cmd_args->path = argv[index];
+		index++;
 	}
 
-	if (argc - optind > 0) {
-		ddb_printf(ctx, "Unexpected argument: %s\\n", argv[optind]);
+	if (argc - index > 0) {
+		ddb_printf(ctx, "Unexpected argument: %s\\n", argv[index]);
+		return -DER_INVAL;
+	}
+
+	return 0;
+}
+/* Parse command line options for the 'dump_ilog' command */
+static int
+dump_ilog_option_parse(struct ddb_ctx *ctx, struct dump_ilog_options *cmd_args,
+	struct argv_parsed *argc_v)
+{
+	int		  index = 1;
+	uint32_t	  argc = argc_v->ap_argc;
+	char		**argv = argc_v->ap_argv;
+
+	memset(cmd_args, 0, sizeof(*cmd_args));
+
+	D_ASSERT(argc > index);
+	D_ASSERT(same(argv[index], COMMAND_NAME_DUMP_ILOG));
+	index++;
+	if (argc - index > 0) {
+		cmd_args->path = argv[index];
+		index++;
+	} else {
+		ddb_print(ctx, "Expected argument 'path'");
+		return -DER_INVAL;
+	}
+
+	if (argc - index > 0) {
+		ddb_printf(ctx, "Unexpected argument: %s\\n", argv[index]);
+		return -DER_INVAL;
+	}
+
+	return 0;
+}
+/* Parse command line options for the 'dump_dtx' command */
+static int
+dump_dtx_option_parse(struct ddb_ctx *ctx, struct dump_dtx_options *cmd_args,
+		      struct argv_parsed *argc_v)
+{
+	char		 *options_short = "ac";
+	int		  index = 0, opt;
+	uint32_t	  argc = argc_v->ap_argc;
+	char		**argv = argc_v->ap_argv;
+	struct option	  options_long[] = {
+		{ "active", no_argument, NULL, 'a' },
+		{ "committed", no_argument, NULL, 'c' },
+		{ NULL }
+	};
+
+	memset(cmd_args, 0, sizeof(*cmd_args));
+
+	/* Restart getopt */
+	optind = 1;
+	opterr = 0;
+	while ((opt = getopt_long(argc, argv, options_short, options_long, &index)) != -1) {
+		switch (opt) {
+		case 'a':
+			cmd_args->active = true;
+			break;
+		case 'c':
+			cmd_args->committed = true;
+			break;
+		case '?':
+			ddb_printf(ctx, "Unknown option: '%c'\n", optopt);
+		default:
+			return -DER_INVAL;
+		}
+	}
+
+	index = optind;
+
+	D_ASSERT(argc > index);
+	D_ASSERT(same(argv[index], COMMAND_NAME_DUMP_DTX));
+	index++;
+	if (argc - index > 0) {
+		cmd_args->path = argv[index];
+		index++;
+	} else {
+		ddb_print(ctx, "Expected argument 'path'");
+		return -DER_INVAL;
+	}
+
+	if (argc - index > 0) {
+		ddb_printf(ctx, "Unexpected argument: %s\\n", argv[index]);
+		return -DER_INVAL;
+	}
+
+	return 0;
+}
+/* Parse command line options for the 'dump_value' command */
+static int
+dump_value_option_parse(struct ddb_ctx *ctx, struct dump_value_options *cmd_args,
+			struct argv_parsed *argc_v)
+{
+	int		  index = 1;
+	uint32_t	  argc = argc_v->ap_argc;
+	char		**argv = argc_v->ap_argv;
+
+	memset(cmd_args, 0, sizeof(*cmd_args));
+
+	D_ASSERT(argc > index);
+	D_ASSERT(same(argv[index], COMMAND_NAME_DUMP_VALUE));
+	index++;
+	if (argc - index > 0) {
+		cmd_args->path = argv[index];
+		index++;
+	} else {
+		ddb_print(ctx, "Expected argument 'path'");
+		return -DER_INVAL;
+	}
+	if (argc - index > 0) {
+		cmd_args->dst = argv[index];
+		index++;
+	} else {
+		ddb_print(ctx, "Expected argument 'dst'");
+		return -DER_INVAL;
+	}
+
+	if (argc - index > 0) {
+		ddb_printf(ctx, "Unexpected argument: %s\\n", argv[index]);
+		return -DER_INVAL;
+	}
+
+	return 0;
+}
+/* Parse command line options for the 'rm' command */
+static int
+rm_option_parse(struct ddb_ctx *ctx, struct rm_options *cmd_args, struct argv_parsed *argc_v)
+{
+	int		  index = 1;
+	uint32_t	  argc = argc_v->ap_argc;
+	char		**argv = argc_v->ap_argv;
+
+	memset(cmd_args, 0, sizeof(*cmd_args));
+
+	D_ASSERT(argc > index);
+	D_ASSERT(same(argv[index], COMMAND_NAME_RM));
+	index++;
+	if (argc - index > 0) {
+		cmd_args->path = argv[index];
+		index++;
+	} else {
+		ddb_print(ctx, "Expected argument 'path'");
+		return -DER_INVAL;
+	}
+
+	if (argc - index > 0) {
+		ddb_printf(ctx, "Unexpected argument: %s\\n", argv[index]);
+		return -DER_INVAL;
+	}
+
+	return 0;
+}
+/* Parse command line options for the 'load' command */
+static int
+load_option_parse(struct ddb_ctx *ctx, struct load_options *cmd_args, struct argv_parsed *argc_v)
+{
+	int		  index = 1;
+	uint32_t	  argc = argc_v->ap_argc;
+	char		**argv = argc_v->ap_argv;
+
+	memset(cmd_args, 0, sizeof(*cmd_args));
+
+	D_ASSERT(argc > index);
+	D_ASSERT(same(argv[index], COMMAND_NAME_LOAD));
+	index++;
+	if (argc - index > 0) {
+		cmd_args->src = argv[index];
+		index++;
+	} else {
+		ddb_print(ctx, "Expected argument 'src'");
+		return -DER_INVAL;
+	}
+	if (argc - index > 0) {
+		cmd_args->dst = argv[index];
+		index++;
+	} else {
+		ddb_print(ctx, "Expected argument 'dst'");
+		return -DER_INVAL;
+	}
+	if (argc - index > 0) {
+		cmd_args->epoch = argv[index];
+		index++;
+	} else {
+		ddb_print(ctx, "Expected argument 'epoch'");
+		return -DER_INVAL;
+	}
+
+	if (argc - index > 0) {
+		ddb_printf(ctx, "Unexpected argument: %s\\n", argv[index]);
 		return -DER_INVAL;
 	}
 
@@ -64,14 +262,37 @@ ddb_parse_cmd_args(struct ddb_ctx *ctx, struct argv_parsed *parsed, struct ddb_c
 {
 	char *cmd = parsed->ap_argv[1];
 
+	if (same(cmd, COMMAND_NAME_QUIT)) {
+		info->dci_cmd = DDB_CMD_QUIT;
+		return 0;
+	}
 	if (same(cmd, COMMAND_NAME_LS)) {
 		info->dci_cmd = DDB_CMD_LS;
 		return ls_option_parse(ctx, &info->dci_cmd_option.dci_ls, parsed);
 	}
-
-	if (same(cmd, COMMAND_NAME_QUIT)) {
-		info->dci_cmd = DDB_CMD_QUIT;
+	if (same(cmd, COMMAND_NAME_DUMP_SUPERBLOCK)) {
+		info->dci_cmd = DDB_CMD_DUMP_SUPERBLOCK;
 		return 0;
+	}
+	if (same(cmd, COMMAND_NAME_DUMP_ILOG)) {
+		info->dci_cmd = DDB_CMD_DUMP_ILOG;
+		return dump_ilog_option_parse(ctx, &info->dci_cmd_option.dci_dump_ilog, parsed);
+	}
+	if (same(cmd, COMMAND_NAME_DUMP_DTX)) {
+		info->dci_cmd = DDB_CMD_DUMP_DTX;
+		return dump_dtx_option_parse(ctx, &info->dci_cmd_option.dci_dump_dtx, parsed);
+	}
+	if (same(cmd, COMMAND_NAME_DUMP_VALUE)) {
+		info->dci_cmd = DDB_CMD_DUMP_VALUE;
+		return dump_value_option_parse(ctx, &info->dci_cmd_option.dci_dump_value, parsed);
+	}
+	if (same(cmd, COMMAND_NAME_RM)) {
+		info->dci_cmd = DDB_CMD_RM;
+		return rm_option_parse(ctx, &info->dci_cmd_option.dci_rm, parsed);
+	}
+	if (same(cmd, COMMAND_NAME_LOAD)) {
+		info->dci_cmd = DDB_CMD_LOAD;
+		return load_option_parse(ctx, &info->dci_cmd_option.dci_load, parsed);
 	}
 
 	return -DER_INVAL;

--- a/src/ddb/ddb_cmd_options.h
+++ b/src/ddb/ddb_cmd_options.h
@@ -3,36 +3,75 @@
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
-
 #ifndef __DDB_RUN_CMDS_H
 #define __DDB_RUN_CMDS_H
 #include "ddb_common.h"
 
 enum ddb_cmd {
-
 	DDB_CMD_UNKNOWN = 0,
 	DDB_CMD_QUIT = 1,
 	DDB_CMD_LS = 2,
+	DDB_CMD_DUMP_SUPERBLOCK = 3,
+	DDB_CMD_DUMP_ILOG = 4,
+	DDB_CMD_DUMP_DTX = 5,
+	DDB_CMD_DUMP_VALUE = 6,
+	DDB_CMD_RM = 7,
+	DDB_CMD_LOAD = 8,
 };
 
+/* option and argument structures for commands that need them */
 struct ls_options {
 	bool recursive;
 	char *path;
+};
+
+struct dump_ilog_options {
+	char *path;
+};
+
+struct dump_dtx_options {
+	bool active;
+	bool committed;
+	char *path;
+};
+
+struct dump_value_options {
+	char *path;
+	char *dst;
+};
+
+struct rm_options {
+	char *path;
+};
+
+struct load_options {
+	char *src;
+	char *dst;
+	char *epoch;
 };
 
 struct ddb_cmd_info {
 	enum ddb_cmd dci_cmd;
 	union {
 		struct ls_options dci_ls;
-
+		struct dump_ilog_options dci_dump_ilog;
+		struct dump_dtx_options dci_dump_dtx;
+		struct dump_value_options dci_dump_value;
+		struct rm_options dci_rm;
+		struct load_options dci_load;
 	} dci_cmd_option;
 };
 
-/* Run commands ... */
-
 int ddb_parse_cmd_args(struct ddb_ctx *ctx, struct argv_parsed *parsed, struct ddb_cmd_info *info);
 
-int ddb_run_ls(struct ddb_ctx *ctx, struct ls_options *opt);
+/* Run commands ... */
 int ddb_run_quit(struct ddb_ctx *ctx);
+int ddb_run_ls(struct ddb_ctx *ctx, struct ls_options *opt);
+int ddb_run_dump_superblock(struct ddb_ctx *ctx);
+int ddb_run_dump_ilog(struct ddb_ctx *ctx, struct dump_ilog_options *opt);
+int ddb_run_dump_dtx(struct ddb_ctx *ctx, struct dump_dtx_options *opt);
+int ddb_run_dump_value(struct ddb_ctx *ctx, struct dump_value_options *opt);
+int ddb_run_rm(struct ddb_ctx *ctx, struct rm_options *opt);
+int ddb_run_load(struct ddb_ctx *ctx, struct load_options *opt);
 
 #endif /* __DDB_RUN_CMDS_H */

--- a/src/ddb/ddb_commands.c
+++ b/src/ddb/ddb_commands.c
@@ -271,7 +271,7 @@ ddb_run_dump_ilog(struct ddb_ctx *ctx, struct dump_ilog_options *opt)
 		return rc;
 	}
 	rc = dv_get_obj_ilog_entries(coh, vtp.vtp_path.vtp_oid,
-				dump_ilog_entry_cb, ctx);
+				     dump_ilog_entry_cb, ctx);
 	dv_cont_close(&coh);
 	ddb_vtp_fini(&vtp);
 
@@ -360,7 +360,7 @@ create_path_str(struct dv_tree_path *vt_path, char *buf, uint32_t buf_len)
 
 	if (vt_path->vtp_recx.rx_nr > 0)
 		snprintf(buf, buf_len, "%s/{%lu-%lu}", buf, vt_path->vtp_recx.rx_idx,
-			   vt_path->vtp_recx.rx_idx + vt_path->vtp_recx.rx_nr - 1);
+			 vt_path->vtp_recx.rx_idx + vt_path->vtp_recx.rx_nr - 1);
 }
 
 int

--- a/src/ddb/ddb_commands.c
+++ b/src/ddb/ddb_commands.c
@@ -9,6 +9,7 @@
 #include "ddb_parse.h"
 #include "ddb_cmd_options.h"
 #include "ddb_vos.h"
+#include "ddb_printer.h"
 
 int
 ddb_run_quit(struct ddb_ctx *ctx)
@@ -25,17 +26,23 @@ struct ls_ctx {
 	bool		 has_akey;
 };
 
-static void
-print_indent(struct ddb_ctx *ctx, int c)
-{
-	int i;
-
-	for (i = 0; i < c; i++)
-		ddb_print(ctx, "\t");
-}
-
 #define DF_IDX "[%d]"
 #define DP_IDX(idx) idx
+
+static int
+init_path(daos_handle_t poh, char *path, struct dv_tree_path_builder *vtp)
+{
+	int rc;
+
+	rc = ddb_vtp_init(poh, path, vtp);
+	if (!SUCCESS(rc))
+		return rc;
+
+	rc = dv_path_update_from_indexes(vtp);
+	if (!SUCCESS(rc))
+		return rc;
+	return 0;
+}
 
 static int
 ls_cont_handler(struct ddb_cont *cont, void *args)
@@ -43,100 +50,21 @@ ls_cont_handler(struct ddb_cont *cont, void *args)
 	struct ls_ctx *ctx = args;
 
 	ctx->has_cont = true;
-
-	ddb_printf(ctx->ctx, DF_IDX" "DF_UUIDF"\n", DP_IDX(cont->ddbc_idx),
-		   DP_UUID(cont->ddbc_cont_uuid));
+	ddb_print_cont(ctx->ctx, cont);
 
 	return 0;
-}
-
-static void
-get_object_type(enum daos_otype_t type, char *type_str)
-{
-	if (type == DAOS_OT_MULTI_HASHED)
-		strcpy(type_str, "DAOS_OT_MULTI_HASHED");
-	else if (type == DAOS_OT_OIT)
-		strcpy(type_str, "DAOS_OT_OIT");
-	else if (type == DAOS_OT_DKEY_UINT64)
-		strcpy(type_str, "DAOS_OT_DKEY_UINT64");
-	else if (type == DAOS_OT_AKEY_UINT64)
-		strcpy(type_str, "DAOS_OT_AKEY_UINT64");
-	else if (type == DAOS_OT_MULTI_UINT64)
-		strcpy(type_str, "DAOS_OT_MULTI_UINT64");
-	else if (type == DAOS_OT_DKEY_LEXICAL)
-		strcpy(type_str, "DAOS_OT_DKEY_LEXICAL");
-	else if (type == DAOS_OT_AKEY_LEXICAL)
-		strcpy(type_str, "DAOS_OT_AKEY_LEXICAL");
-	else if (type == DAOS_OT_MULTI_LEXICAL)
-		strcpy(type_str, "DAOS_OT_MULTI_LEXICAL");
-	else if (type == DAOS_OT_KV_HASHED)
-		strcpy(type_str, "DAOS_OT_KV_HASHED");
-	else if (type == DAOS_OT_KV_UINT64)
-		strcpy(type_str, "DAOS_OT_KV_UINT64");
-	else if (type == DAOS_OT_KV_LEXICAL)
-		strcpy(type_str, "DAOS_OT_KV_LEXICAL");
-	else if (type == DAOS_OT_ARRAY)
-		strcpy(type_str, "DAOS_OT_ARRAY");
-	else if (type == DAOS_OT_ARRAY_ATTR)
-		strcpy(type_str, "DAOS_OT_ARRAY_ATTR");
-	else if (type == DAOS_OT_ARRAY_BYTE)
-		strcpy(type_str, "DAOS_OT_ARRAY_BYTE");
-	else
-		strcpy(type_str, "UNKNOWN");
 }
 
 static int
 ls_obj_handler(struct ddb_obj *obj, void *args)
 {
 	struct ls_ctx		*ctx = args;
-	char			 otype_str[32] = {0};
-	enum daos_otype_t	 otype;
-	daos_obj_id_t		 oid;
-	uint32_t		 nr_grps;
 
 	ctx->has_obj = true;
 
-	otype = daos_obj_id2type(obj->ddbo_oid);
-
-	/*
-	 * It would be nice to get the object class name, but currently that is client
-	 * functionality and this tool is being installed as a server binary. If that changes, the
-	 * following code might be used ...
-	 * char			 obj_class_name[32];
-	 * int rc = obj_class_init();
-	 * daos_oclass_id_t	 oclass;
-	 * oclass = daos_obj_id2class(obj->ddbo_oid);
-	 * if (!SUCCESS(rc))
-	 *	return rc;
-	 * daos_oclass_id2name(oclass, obj_class_name);
-	 * obj_class_fini();
-	*/
-	oid = obj->ddbo_oid;
-
-	nr_grps = (oid.hi & OID_FMT_META_MASK) >> OID_FMT_META_SHIFT;
-
-	get_object_type(otype, otype_str);
-
-	print_indent(ctx->ctx, ctx->has_cont);
-	ddb_printf(ctx->ctx, DF_IDX" '"DF_OID"' (type: %s, groups: %d)\n",
-		   DP_IDX(obj->ddbo_idx),
-		   DP_OID(obj->ddbo_oid),
-		   otype_str,
-		   nr_grps);
+	ddb_print_obj(ctx->ctx, obj, ctx->has_cont);
 
 	return 0;
-}
-
-static void
-print_key(struct ddb_ctx *ctx, struct ddb_key *key)
-{
-	uint32_t	 str_len = min(100, key->ddbk_key.iov_len);
-
-	ddb_printf(ctx, DF_IDX" '%.*s' (%lu)\n",
-		   DP_IDX(key->ddbk_idx),
-		   str_len,
-		   (char *)key->ddbk_key.iov_buf,
-		   key->ddbk_key.iov_len);
 }
 
 static int
@@ -145,8 +73,7 @@ ls_dkey_handler(struct ddb_key *key, void *args)
 	struct ls_ctx *ctx = args;
 
 	ctx->has_dkey = true;
-	print_indent(ctx->ctx, ctx->has_cont + ctx->has_obj);
-	print_key(ctx->ctx, key);
+	ddb_print_key(ctx->ctx, key, ctx->has_cont + ctx->has_obj);
 
 	return 0;
 }
@@ -157,8 +84,7 @@ ls_akey_handler(struct ddb_key *key, void *args)
 	struct ls_ctx *ctx = args;
 
 	ctx->has_akey = true;
-	print_indent(ctx->ctx, ctx->has_cont + ctx->has_obj + ctx->has_dkey);
-	print_key(ctx->ctx, key);
+	ddb_print_key(ctx->ctx, key, ctx->has_cont + ctx->has_obj + ctx->has_dkey);
 
 	return 0;
 }
@@ -168,8 +94,7 @@ ls_sv_handler(struct ddb_sv *val, void *args)
 {
 	struct ls_ctx *ctx = args;
 
-	print_indent(ctx->ctx, ctx->has_cont + ctx->has_obj + ctx->has_dkey + ctx->has_akey);
-	ddb_printf(ctx->ctx, "Single Value: %lu record size\n", val->ddbs_record_size);
+	ddb_print_sv(ctx->ctx, val, ctx->has_cont + ctx->has_obj + ctx->has_dkey + ctx->has_akey);
 	return 0;
 }
 
@@ -178,11 +103,8 @@ ls_array_handler(struct ddb_array *val, void *args)
 {
 	struct ls_ctx *ctx = args;
 
-	print_indent(ctx->ctx, ctx->has_cont + ctx->has_obj + ctx->has_dkey + ctx->has_akey);
-	ddb_printf(ctx->ctx, "[Array] recx: "DF_RECX",  record size: %lu\n",
-		   DP_RECX(val->ddba_recx),
-		   val->ddba_record_size);
-
+	ddb_print_array(ctx->ctx, val,
+			ctx->has_cont + ctx->has_obj + ctx->has_dkey + ctx->has_akey);
 	return 0;
 }
 
@@ -199,23 +121,344 @@ int
 ddb_run_ls(struct ddb_ctx *ctx, struct ls_options *opt)
 {
 	int rc;
-	struct dv_tree_path_builder vt_path = {.vtp_poh = ctx->dc_poh};
+	struct dv_tree_path_builder vtp = {0};
 	struct ls_ctx lsctx = {0};
 
-	rc = ddb_vtp_init(opt->path, &vt_path);
+	rc = init_path(ctx->dc_poh, opt->path, &vtp);
 	if (!SUCCESS(rc))
 		return rc;
+	if (!SUCCESS(ddb_vtp_verify(ctx->dc_poh, &vtp.vtp_path))) {
+		ddb_print(ctx, "Not a valid path\n");
+		return -DER_NONEXIST;
+	}
 
-	rc = dv_path_update_from_indexes(&vt_path);
-	if (!SUCCESS(rc))
-		return rc;
-
-	vtp_print(ctx, &vt_path.vtp_path);
+	vtp_print(ctx, &vtp.vtp_path);
 	lsctx.ctx = ctx;
-	rc = dv_iterate(ctx->dc_poh, &vt_path.vtp_path, opt->recursive, &handlers, &lsctx);
+	rc = dv_iterate(ctx->dc_poh, &vtp.vtp_path, opt->recursive, &handlers, &lsctx);
 
-	ddb_vtp_fini(&vt_path);
+	ddb_vtp_fini(&vtp);
 
 	return rc;
+}
 
+static int
+print_superblock_cb(void *cb_arg, struct ddb_superblock *sb)
+{
+	struct ddb_ctx *ctx = cb_arg;
+
+	ddb_print_superblock(ctx, sb);
+
+	return 0;
+}
+
+int
+ddb_run_dump_superblock(struct ddb_ctx *ctx)
+{
+	int rc;
+
+	rc = dv_superblock(ctx->dc_poh, print_superblock_cb, ctx);
+
+	if (rc == -DER_DF_INVAL)
+		ddb_error(ctx, "Error with pool superblock");
+
+	return rc;
+}
+
+struct dump_value_args {
+	struct ddb_ctx			*dva_ctx;
+	struct dv_tree_path		*dva_vtp;
+	char				*dva_dst_path;
+};
+
+static int
+write_file_value_cb(void *cb_args, d_iov_t *value)
+{
+	struct dump_value_args *args = cb_args;
+	struct ddb_ctx *ctx = args->dva_ctx;
+
+	D_ASSERT(ctx->dc_io_ft.ddb_write_file);
+
+	if (value->iov_len == 0) {
+		ddb_print(ctx, "No value at: ");
+		vtp_print(ctx, args->dva_vtp);
+		return 0;
+	}
+
+	ddb_printf(ctx, "Dumping value (size: %lu) to: %s\n",
+		   value->iov_len,  args->dva_dst_path);
+
+	return ctx->dc_io_ft.ddb_write_file(args->dva_dst_path, value);
+}
+
+int
+ddb_run_dump_value(struct ddb_ctx *ctx, struct dump_value_options *opt)
+{
+	struct dv_tree_path_builder	vtp = {.vtp_poh = ctx->dc_poh};
+	struct dump_value_args		dva = {0};
+	int				rc;
+
+	if (!opt->path) {
+		ddb_error(ctx, "A VOS path to dump is required.\n");
+		return -DER_INVAL;
+	}
+	if (!opt->dst) {
+		ddb_error(ctx, "A destination path is required.\n");
+		return -DER_INVAL;
+	}
+
+	rc = init_path(ctx->dc_poh, opt->path, &vtp);
+	if (!SUCCESS(rc))
+		return rc;
+
+	vtp_print(ctx, &vtp.vtp_path);
+
+	if (!dvp_is_complete(&vtp.vtp_path)) {
+		ddb_errorf(ctx, "Path [%s] is incomplete.\n", opt->path);
+		ddb_vtp_fini(&vtp);
+		return -DER_INVAL;
+	}
+
+	dva.dva_dst_path = opt->dst;
+	dva.dva_ctx = ctx;
+	dva.dva_vtp = &vtp.vtp_path;
+	rc = dv_dump_value(ctx->dc_poh, &vtp.vtp_path, write_file_value_cb, &dva);
+	ddb_vtp_fini(&vtp);
+
+	return rc;
+}
+
+static int
+dump_ilog_entry_cb(void *cb_arg, struct ddb_ilog_entry *entry)
+{
+	struct ddb_ctx *ctx = cb_arg;
+
+	ddb_print_ilog_entry(ctx, entry);
+
+	return 0;
+}
+
+int
+ddb_run_dump_ilog(struct ddb_ctx *ctx, struct dump_ilog_options *opt)
+{
+	struct dv_tree_path_builder	vtp = {ctx->dc_poh};
+	int				rc;
+	daos_handle_t			coh;
+
+	if (!opt->path) {
+		ddb_error(ctx, "A VOS path to dump the ilog for is required.");
+		return -DER_INVAL;
+	}
+
+	rc = init_path(ctx->dc_poh, opt->path, &vtp);
+	if (!SUCCESS(rc))
+		return rc;
+
+	/*
+	 * ilog for object or dkey ...
+	 * Should have a path to at least the object, but not including an akey
+	 */
+	if (!dv_has_cont(&vtp.vtp_path) || !dv_has_obj(&vtp.vtp_path) ||
+	    dv_has_akey(&vtp.vtp_path)) {
+		ddb_error(ctx, "Path to object or dkey is required.\n");
+		ddb_vtp_fini(&vtp);
+		return -DER_INVAL;
+	}
+
+	vtp_print(ctx, &vtp.vtp_path);
+	rc = dv_cont_open(ctx->dc_poh, vtp.vtp_path.vtp_cont, &coh);
+	if (!SUCCESS(rc)) {
+		ddb_vtp_fini(&vtp);
+		return rc;
+	}
+	rc = dv_get_obj_ilog_entries(coh, vtp.vtp_path.vtp_oid,
+				dump_ilog_entry_cb, ctx);
+	dv_cont_close(&coh);
+	ddb_vtp_fini(&vtp);
+
+	return rc;
+}
+
+static int
+active_dtx_cb(struct dv_dtx_active_entry *entry, void *cb_arg)
+{
+	struct ddb_ctx *ctx = cb_arg;
+
+	ddb_print_dtx_active(ctx, entry);
+
+	return 0;
+}
+
+static int
+committed_cb(struct dv_dtx_committed_entry *entry, void *cb_arg)
+{
+	struct ddb_ctx *ctx = cb_arg;
+
+	ddb_print_dtx_committed(ctx, entry);
+
+	return 0;
+}
+
+int
+ddb_run_dump_dtx(struct ddb_ctx *ctx, struct dump_dtx_options *opt)
+{
+	struct dv_tree_path_builder	vtp;
+	int				rc;
+	daos_handle_t			coh;
+	bool				both = !(opt->committed ^ opt->active);
+
+	rc = init_path(ctx->dc_poh, opt->path, &vtp);
+	if (!SUCCESS(rc))
+		return rc;
+
+	if (!dv_has_cont(&vtp.vtp_path)) {
+		ddb_error(ctx, "Path to object is required.\n");
+		ddb_vtp_fini(&vtp);
+		return -DER_INVAL;
+	}
+
+	rc = dv_cont_open(ctx->dc_poh, vtp.vtp_path.vtp_cont, &coh);
+	if (!SUCCESS(rc)) {
+		ddb_vtp_fini(&vtp);
+		return rc;
+	}
+
+	if (both || opt->active) {
+		ddb_print(ctx, "Active Transactions:\n");
+		rc = dv_active_dtx(coh, active_dtx_cb, ctx);
+		if (!SUCCESS(rc)) {
+			ddb_vtp_fini(&vtp);
+			return rc;
+		}
+	}
+	if (both || opt->active) {
+		ddb_print(ctx, "Committed Transactions:\n");
+		rc = dv_committed_dtx(coh, committed_cb, ctx);
+		if (!SUCCESS(rc)) {
+			ddb_vtp_fini(&vtp);
+			return rc;
+		}
+	}
+
+	dv_cont_close(&coh);
+	ddb_vtp_fini(&vtp);
+
+	return 0;
+}
+
+static void
+create_path_str(struct dv_tree_path *vt_path, char *buf, uint32_t buf_len)
+{
+
+	if (dv_has_cont(vt_path))
+		snprintf(buf, buf_len, "/"DF_UUIDF"", DP_UUID(vt_path->vtp_cont));
+	if (dv_has_obj(vt_path))
+		snprintf(buf, buf_len, "%s/"DF_UOID"", buf, DP_UOID(vt_path->vtp_oid));
+	if (dv_has_dkey(vt_path))
+		snprintf(buf, buf_len, "%s/%s", buf, (char *)vt_path->vtp_dkey.iov_buf);
+	if (dv_has_akey(vt_path))
+		snprintf(buf, buf_len, "%s/%s", buf, (char *)vt_path->vtp_akey.iov_buf);
+
+	if (vt_path->vtp_recx.rx_nr > 0)
+		snprintf(buf, buf_len, "%s/{%lu-%lu}", buf, vt_path->vtp_recx.rx_idx,
+			   vt_path->vtp_recx.rx_idx + vt_path->vtp_recx.rx_nr - 1);
+}
+
+int
+ddb_run_rm(struct ddb_ctx *ctx, struct rm_options *opt)
+{
+	struct dv_tree_path_builder	vtpb;
+	int				rc;
+	char				path_str[256] = {0};
+
+	rc = init_path(ctx->dc_poh, opt->path, &vtpb);
+
+	if (!SUCCESS(rc))
+		return rc;
+
+	rc = dv_delete(ctx->dc_poh, &vtpb.vtp_path);
+
+	if (!SUCCESS(rc)) {
+		ddb_errorf(ctx, "Error: "DF_RC"\n", DP_RC(rc));
+		ddb_vtp_fini(&vtpb);
+
+		return rc;
+	}
+
+	create_path_str(&vtpb.vtp_path, path_str, ARRAY_SIZE(path_str));
+	ddb_printf(ctx, "%s deleted\n", path_str);
+	ddb_vtp_fini(&vtpb);
+
+	return 0;
+}
+
+int
+ddb_run_load(struct ddb_ctx *ctx, struct load_options *opt)
+{
+	struct dv_tree_path_builder	vtpb;
+	d_iov_t				iov = {0};
+	size_t				file_size;
+	uint32_t			epoch;
+	int				rc;
+	char				*end;
+
+	if (opt->epoch == NULL) {
+		ddb_error(ctx, "Epoch is not set\n");
+		return -DER_INVAL;
+	}
+	epoch = strtol(opt->epoch, &end, 10);
+	if (epoch == 0 || *end != '\0') {
+		ddb_errorf(ctx, "Epoch '%s' is not valid\n", opt->epoch);
+		return -DER_INVAL;
+	}
+
+	rc = init_path(ctx->dc_poh, opt->dst, &vtpb);
+
+	if (!SUCCESS(rc)) {
+		ddb_error(ctx, "Invalid VOS path\n");
+		return rc;
+	}
+
+
+	if (!dvp_is_complete(&vtpb.vtp_path)) {
+		ddb_error(ctx, "Invalid path");
+		D_GOTO(done, rc = -DER_INVAL);
+	}
+
+	vtp_print(ctx, &vtpb.vtp_path);
+
+	if (!ctx->dc_io_ft.ddb_get_file_exists(opt->src)) {
+		ddb_errorf(ctx, "Unable to access '%s'\n", opt->src);
+		return -DER_INVAL;
+	}
+
+	file_size = ctx->dc_io_ft.ddb_get_file_size(opt->src);
+	if (file_size == 0)
+		D_GOTO(done, rc = -DER_INVAL);
+	rc = daos_iov_alloc(&iov, file_size, false);
+	if (!SUCCESS(rc)) {
+		ddb_errorf(ctx, "System error: "DF_RC"\n", DP_RC(rc));
+		D_GOTO(done, rc);
+	}
+
+	rc = ctx->dc_io_ft.ddb_read_file(opt->src, &iov);
+	if (rc < 0) {
+		ddb_errorf(ctx, "System error: "DF_RC"\n", DP_RC(rc));
+		D_GOTO(done, rc);
+	}
+	D_ASSERT(rc == iov.iov_buf_len && rc == iov.iov_len);
+
+	rc = dv_update(ctx->dc_poh, &vtpb.vtp_path, &iov, epoch);
+	if (!SUCCESS(rc)) {
+		ddb_errorf(ctx, "Unable to update path: "DF_RC"\n", DP_RC(rc));
+		D_GOTO(done, rc);
+	}
+
+done:
+	daos_iov_free(&iov);
+	ddb_vtp_fini(&vtpb);
+
+	if (SUCCESS(rc))
+		ddb_printf(ctx, "Successfully loaded file '%s'\n", opt->src);
+
+	return rc;
 }

--- a/src/ddb/ddb_commands.c
+++ b/src/ddb/ddb_commands.c
@@ -397,7 +397,7 @@ ddb_run_load(struct ddb_ctx *ctx, struct load_options *opt)
 
 	if (!SUCCESS(rc)) {
 		ddb_error(ctx, "Invalid VOS path\n");
-		return rc;
+		D_GOTO(done, rc);
 	}
 
 
@@ -410,7 +410,7 @@ ddb_run_load(struct ddb_ctx *ctx, struct load_options *opt)
 
 	if (!ctx->dc_io_ft.ddb_get_file_exists(opt->src)) {
 		ddb_errorf(ctx, "Unable to access '%s'\n", opt->src);
-		return -DER_INVAL;
+		D_GOTO(done, rc = -DER_INVAL);
 	}
 
 	file_size = ctx->dc_io_ft.ddb_get_file_size(opt->src);

--- a/src/ddb/ddb_common.h
+++ b/src/ddb/ddb_common.h
@@ -189,9 +189,11 @@ vtp_print(struct ddb_ctx *ctx, struct dv_tree_path *vt_path, bool include_new_li
 	if (dv_has_obj(vt_path))
 		ddb_printf(ctx, "/"DF_UOID"",  DP_UOID(vt_path->vtp_oid));
 	if (dv_has_dkey(vt_path))
-		ddb_printf(ctx, "/%s", (char *)vt_path->vtp_dkey.iov_buf);
+		ddb_printf(ctx, "/'%.*s'", (int)vt_path->vtp_dkey.iov_len,
+			   (char *)vt_path->vtp_dkey.iov_buf);
 	if (dv_has_akey(vt_path))
-		ddb_printf(ctx, "/%s", (char *)vt_path->vtp_akey.iov_buf);
+		ddb_printf(ctx, "/'%.*s'", (int)vt_path->vtp_dkey.iov_len,
+			   (char *)vt_path->vtp_akey.iov_buf);
 
 	if (vt_path->vtp_recx.rx_nr > 0)
 		ddb_printf(ctx, "/{%lu-%lu}", vt_path->vtp_recx.rx_idx,

--- a/src/ddb/ddb_common.h
+++ b/src/ddb/ddb_common.h
@@ -44,11 +44,65 @@
 
 
 struct ddb_io_ft {
+	/**
+	 * Print a message.
+	 *
+	 * @param fmt	Typically printf string format
+	 * @param ...	Additional args will be formatted into the printed string
+	 * @return	Total number of characters written
+	 */
 	int (*ddb_print_message)(const char *fmt, ...);
-	int (*ddb_print_error)(const char *fmt, ...);
-	char *(*ddb_get_input)(char *buf, uint32_t buf_len);
-};
 
+	/**
+	 * Print an error message.
+	 *
+	 * @param fmt	Typically printf string format
+	 * @param ...	Additional args will be formatted into the printed string
+	 * @return	Total number of characters written
+	 */
+	int (*ddb_print_error)(const char *fmt, ...);
+
+	/**
+	 * Read a line from stdin and stores into buf.
+	 *
+	 * @param buf		Pointer to an array where the string read is stored
+	 * @param buf_len	Length of buf
+	 * @return		On success the same buf parameter, else NULL
+	 */
+	char *(*ddb_get_input)(char *buf, uint32_t buf_len);
+
+	/**
+	 * Check if a file exists
+	 *
+	 * @param path	Path to file to check
+	 * @return	true if the file exists, else false
+	 */
+	bool (*ddb_get_file_exists)(const char *path);
+
+	/**
+	 * Write the contents of the iov to a file
+	 *
+	 * @param dst_path	File to write to
+	 * @param contents	Contents to be written
+	 * @return		0 on success, else an error code
+	 */
+	int (*ddb_write_file)(const char *dst_path, d_iov_t *contents);
+
+	/**
+	 * Determine the size of a file at path
+	 * @param path	Path of file to check
+	 * @return	the size of the file at path in bytes
+	 */
+	size_t (*ddb_get_file_size)(const char *path);
+
+	/**
+	 * Read the contents of a file and store into the iov
+	 * @param src_path	Path of the file to read
+	 * @param contents	Where to load the contents of the file into
+	 * @return		number of bytes read from the src_path
+	 */
+	size_t (*ddb_read_file)(const char *src_path, d_iov_t *contents);
+};
 
 struct ddb_ctx {
 	struct ddb_io_ft	 dc_io_ft;
@@ -113,6 +167,18 @@ static inline bool
 dv_has_akey(struct dv_tree_path *vtp)
 {
 	return vtp->vtp_akey.iov_len > 0;
+}
+
+static inline bool
+dvp_is_complete(struct dv_tree_path *vtp)
+{
+	return dv_has_cont(vtp) && dv_has_obj(vtp) && dv_has_dkey(vtp) && dv_has_akey(vtp);
+}
+
+static inline bool
+dvp_is_empty(struct dv_tree_path *vtp)
+{
+	return !dv_has_cont(vtp) && !dv_has_obj(vtp) && !dv_has_dkey(vtp) && !dv_has_akey(vtp);
 }
 
 static inline void

--- a/src/ddb/ddb_common.h
+++ b/src/ddb/ddb_common.h
@@ -182,7 +182,7 @@ dvp_is_empty(struct dv_tree_path *vtp)
 }
 
 static inline void
-vtp_print(struct ddb_ctx *ctx, struct dv_tree_path *vt_path)
+vtp_print(struct ddb_ctx *ctx, struct dv_tree_path *vt_path, bool include_new_line)
 {
 	if (dv_has_cont(vt_path))
 		ddb_printf(ctx, "/"DF_UUIDF"", DP_UUID(vt_path->vtp_cont));
@@ -196,7 +196,8 @@ vtp_print(struct ddb_ctx *ctx, struct dv_tree_path *vt_path)
 	if (vt_path->vtp_recx.rx_nr > 0)
 		ddb_printf(ctx, "/{%lu-%lu}", vt_path->vtp_recx.rx_idx,
 			   vt_path->vtp_recx.rx_idx + vt_path->vtp_recx.rx_nr - 1);
-	ddb_print(ctx, "/\n");
+	if (include_new_line)
+		ddb_print(ctx, "/\n");
 }
 
 struct argv_parsed {

--- a/src/ddb/ddb_main.c
+++ b/src/ddb/ddb_main.c
@@ -43,6 +43,24 @@ run_cmd(struct ddb_ctx *ctx, struct argv_parsed *parse_args)
 	case DDB_CMD_LS:
 		rc = ddb_run_ls(ctx, &info.dci_cmd_option.dci_ls);
 		break;
+	case DDB_CMD_DUMP_SUPERBLOCK:
+		rc = ddb_run_dump_superblock(ctx);
+		break;
+	case DDB_CMD_DUMP_ILOG:
+		rc = ddb_run_dump_ilog(ctx, &info.dci_cmd_option.dci_dump_ilog);
+		break;
+	case DDB_CMD_DUMP_VALUE:
+		rc = ddb_run_dump_value(ctx, &info.dci_cmd_option.dci_dump_value);
+		break;
+	case DDB_CMD_RM:
+		rc = ddb_run_rm(ctx, &info.dci_cmd_option.dci_rm);
+		break;
+	case DDB_CMD_DUMP_DTX:
+		rc = ddb_run_dump_dtx(ctx, &info.dci_cmd_option.dci_dump_dtx);
+		break;
+	case DDB_CMD_LOAD:
+		rc = ddb_run_load(ctx, &info.dci_cmd_option.dci_load);
+		break;
 	}
 
 	if (!SUCCESS(rc))
@@ -70,7 +88,7 @@ ddb_main(struct ddb_io_ft *io_ft, int argc, char *argv[])
 	D_ASSERT(io_ft);
 	ctx.dc_io_ft = *io_ft;
 
-	rc = ddb_parse_program_args(argc, argv, &pa);
+	rc = ddb_parse_program_args(&ctx, argc, argv, &pa);
 	if (!SUCCESS(rc))
 		return rc;
 
@@ -125,6 +143,5 @@ ddb_main(struct ddb_io_ft *io_ft, int argc, char *argv[])
 		ddb_str2argv_free(&parse_args);
 	}
 
-	ddb_fini();
 	return 0;
 }

--- a/src/ddb/ddb_main.c
+++ b/src/ddb/ddb_main.c
@@ -79,23 +79,32 @@ ddb_main(struct ddb_io_ft *io_ft, int argc, char *argv[])
 	struct program_args	 pa = {0};
 	uint32_t		 input_buf_len = 1024;
 	uint32_t		 buf_len = input_buf_len * 2;
-	char			 buf[buf_len + 1024];
-	char			 input_buf[input_buf_len];
+	char			*buf;
+	char			*input_buf;
 	struct argv_parsed	 parse_args = {0};
-	int			 rc;
+	int			 rc = 0;
 	struct ddb_ctx		 ctx = {0};
 
 	D_ASSERT(io_ft);
 	ctx.dc_io_ft = *io_ft;
 
+	D_ALLOC(buf, buf_len + 1024);
+	if (buf == NULL)
+		return -DER_NOMEM;
+	D_ALLOC(input_buf, input_buf_len);
+	if (input_buf == NULL) {
+		D_FREE(buf);
+		return -DER_NOMEM;
+	}
+
 	rc = ddb_parse_program_args(&ctx, argc, argv, &pa);
 	if (!SUCCESS(rc))
-		return rc;
+		D_GOTO(done, rc);
 
 	if (str_has_value(pa.pa_pool_path)) {
 		rc = ddb_vos_pool_open(pa.pa_pool_path, &ctx.dc_poh);
 		if (!SUCCESS(rc))
-			return rc;
+			D_GOTO(done, rc);
 	}
 
 	if (str_has_value(pa.pa_r_cmd_run)) {
@@ -104,7 +113,7 @@ ddb_main(struct ddb_io_ft *io_ft, int argc, char *argv[])
 		rc = ddb_str2argv_create(buf, &parse_args);
 		if (!SUCCESS(rc)) {
 			ddb_vos_pool_close(ctx.dc_poh);
-			return rc;
+			D_GOTO(done, rc);
 		}
 
 		rc = run_cmd(&ctx, &parse_args);
@@ -112,13 +121,12 @@ ddb_main(struct ddb_io_ft *io_ft, int argc, char *argv[])
 			ddb_errorf(&ctx, "Error with command: "DF_RC"\n", DP_RC(rc));
 
 		ddb_str2argv_free(&parse_args);
-		return rc;
+		D_GOTO(done, rc);
 	}
 
 	if (str_has_value(pa.pa_cmd_file)) {
 		/* Still to be implemented */
-
-		return -DER_NOSYS;
+		D_GOTO(done, rc = -DER_NOSYS);
 	}
 
 	while (!ctx.dc_should_quit) {
@@ -143,5 +151,9 @@ ddb_main(struct ddb_io_ft *io_ft, int argc, char *argv[])
 		ddb_str2argv_free(&parse_args);
 	}
 
-	return 0;
+done:
+	D_FREE(buf);
+	D_FREE(input_buf);
+
+	return rc;
 }

--- a/src/ddb/ddb_parse.c
+++ b/src/ddb/ddb_parse.c
@@ -108,16 +108,22 @@ is_idx(char *str, uint32_t *idx)
 static int
 process_key(const char *tok, uint8_t **key_buf, daos_key_t *key)
 {
+	uint32_t key_buf_len;
+
 	if (tok[0] != '\'' || tok[strlen(tok) - 1] != '\'') {
 		D_ERROR("Keys must be surrounded by '\n");
 		return -DER_INVAL;
 	}
 
-	D_ALLOC(*key_buf, strlen(tok) - 2);
+	key_buf_len = strlen(tok) - 2 + 1; /* minus 2 because of "'"s, + 1 for '\0' */
+
+	D_ALLOC(*key_buf, key_buf_len);
 	if (*key_buf == NULL)
 		return -DER_NOMEM;
-	memcpy(*key_buf, tok + 1, strlen(tok) - 1);
-	d_iov_set(key, *key_buf, strlen(tok) - 2);
+	memcpy(*key_buf, tok + 1, key_buf_len);
+	(*key_buf)[key_buf_len - 1] = '\0';
+	d_iov_set(key, *key_buf, key_buf_len);
+	key->iov_len = key_buf_len - 1; /* don't include terminator */
 
 	return 0;
 }

--- a/src/ddb/ddb_parse.h
+++ b/src/ddb/ddb_parse.h
@@ -28,10 +28,11 @@ int ddb_str2argv_create(const char *buf, struct argv_parsed *parse_args);
 void ddb_str2argv_free(struct argv_parsed *parse_args);
 
 /* Parse argc/argv into the program arguments/options */
-int ddb_parse_program_args(uint32_t argc, char **argv, struct program_args *pa);
+int
+ddb_parse_program_args(struct ddb_ctx *ctx, uint32_t argc, char **argv, struct program_args *pa);
 
 /* Parse a string into the parts of a vos tree path (cont, object, ...) */
-int ddb_vtp_init(const char *path, struct dv_tree_path_builder *vt_path);
+int ddb_vtp_init(daos_handle_t poh, const char *path, struct dv_tree_path_builder *vt_path);
 void ddb_vtp_fini(struct dv_tree_path_builder *vt_path);
 
 #define DDB_IDX_UNSET ((uint32_t)-1)

--- a/src/ddb/ddb_printer.c
+++ b/src/ddb/ddb_printer.c
@@ -1,0 +1,204 @@
+/**
+ * (C) Copyright 2022 Intel Corporation.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause-Patent
+ */
+
+#include "ddb_printer.h"
+
+#define DF_IDX "[%d]"
+#define DP_IDX(idx) idx
+
+static void
+print_indent(struct ddb_ctx *ctx, int c)
+{
+	int i;
+
+	for (i = 0; i < c; i++)
+		ddb_print(ctx, "\t");
+}
+
+void
+ddb_print_cont(struct ddb_ctx *ctx, struct ddb_cont *cont)
+{
+	ddb_printf(ctx, DF_IDX" "DF_UUIDF"\n", DP_IDX(cont->ddbc_idx),
+		DP_UUID(cont->ddbc_cont_uuid));
+}
+
+void
+ddb_print_obj(struct ddb_ctx *ctx, struct ddb_obj *obj, uint32_t indent)
+{
+	print_indent(ctx, indent);
+	ddb_printf(ctx, DF_IDX" '"DF_OID"' (class: %s, type: %s, groups: %d)\n",
+		   DP_IDX(obj->ddbo_idx),
+		   DP_OID(obj->ddbo_oid),
+		   obj->ddbo_obj_class_name,
+		   obj->ddbo_otype_str,
+		   obj->ddbo_nr_grps);
+}
+
+static bool
+can_print(struct ddb_key *key)
+{
+	char	*str = key->ddbk_key.iov_buf;
+	uint32_t len = key->ddbk_key.iov_len;
+	int	 i;
+
+	for (i = 0 ; i < len ; i++) {
+		if (str[i] == '\0')
+			return true;
+		if (!isprint(str[i]))
+			return false;
+	}
+	return true;
+}
+
+void
+ddb_print_key(struct ddb_ctx *ctx, struct ddb_key *key, uint32_t indent)
+{
+	const uint32_t	buf_len = 64;
+	char		buf[buf_len];
+	uint32_t	str_len = min(100, key->ddbk_key.iov_len);
+
+	memset(buf, 0, buf_len);
+	print_indent(ctx, indent);
+	if (can_print(key)) {
+		ddb_printf(ctx, DF_IDX" '%.*s' (%lu)\n",
+			   DP_IDX(key->ddbk_idx),
+			   str_len,
+			   (char *)key->ddbk_key.iov_buf,
+			   key->ddbk_key.iov_len);
+		return;
+	}
+
+	switch (key->ddbk_key.iov_len) {
+	case sizeof(uint8_t):
+		sprintf(buf, "uint8:0x%x", ((uint8_t *)key->ddbk_key.iov_buf)[0]);
+		break;
+	case sizeof(uint16_t):
+		sprintf(buf, "uint16:0x%04hx", ((uint16_t *)key->ddbk_key.iov_buf)[0]);
+		break;
+	case sizeof(uint32_t):
+		sprintf(buf, "uint32:0x%x", ((uint32_t *)key->ddbk_key.iov_buf)[0]);
+		break;
+	case sizeof(uint64_t):
+		sprintf(buf, "uint64:0x%lx", ((uint64_t *)key->ddbk_key.iov_buf)[0]);
+		break;
+	default:
+	{
+		int i;
+
+		sprintf(buf, "bin(%lu):0x", key->ddbk_key.iov_len);
+
+		for (i = 0; i < key->ddbk_key.iov_len; i++) {
+			sprintf(buf, "%s%02x", buf, ((uint8_t *)key->ddbk_key.iov_buf)[i]);
+
+			if (key->ddbk_key.iov_len > buf_len
+			    && i == (buf_len / 4) - 12) {
+				sprintf(buf, "%s...", buf);
+				i = key->ddbk_key.iov_len - ((buf_len / 4) - 10);
+			}
+		}
+	}
+	}
+	ddb_printf(ctx, DF_IDX" '{%s}'\n", DP_IDX(key->ddbk_idx), buf);
+}
+
+void
+ddb_print_sv(struct ddb_ctx *ctx, struct ddb_sv *sv, uint32_t indent)
+{
+	print_indent(ctx, indent);
+	ddb_printf(ctx, DF_IDX" Single Value (Length: "DF_U64" bytes)\n",
+		   sv->ddbs_idx,
+		   sv->ddbs_record_size);
+}
+
+void
+ddb_print_array(struct ddb_ctx *ctx, struct ddb_array *array, uint32_t indent)
+{
+	print_indent(ctx, indent);
+	ddb_printf(ctx, DF_IDX" Array Value (Length: "DF_U64" records, Record Indexes: "
+			"{"DF_U64"-"DF_U64"}, Record Size: "DF_U64")\n",
+		   array->ddba_idx,
+		   array->ddba_recx.rx_nr,
+		   array->ddba_recx.rx_idx,
+		   array->ddba_recx.rx_idx + array->ddba_recx.rx_nr - 1,
+		   array->ddba_record_size);
+}
+
+void
+ddb_bytes_hr(uint64_t bytes, char *buf, uint32_t buf_len)
+{
+	int			i = 0;
+	static const char	*const units[] = {"B", "KB", "MB", "GB", "TB"};
+
+	while (bytes >= 1024) {
+		bytes /= 1024;
+		i++;
+	}
+	snprintf(buf, buf_len, "%lu%s", bytes, units[i]);
+}
+
+static void
+print_bytes(struct ddb_ctx *ctx, char *prefix, uint64_t bytes)
+{
+	char buf[32];
+
+	ddb_bytes_hr(bytes, buf, ARRAY_SIZE(buf));
+	ddb_printf(ctx, "%s: %s\n", prefix, buf);
+}
+
+void
+ddb_print_superblock(struct ddb_ctx *ctx, struct ddb_superblock *sb)
+{
+	ddb_printf(ctx, "Pool UUID: "DF_UUIDF"\n", DP_UUID(sb->dsb_id));
+	ddb_printf(ctx, "Format Version: %d\n", sb->dsb_durable_format_version);
+	ddb_printf(ctx, "Containers: %lu\n", sb->dsb_cont_nr);
+	print_bytes(ctx, "SCM Size", sb->dsb_scm_sz);
+	print_bytes(ctx, "NVME Size", sb->dsb_nvme_sz);
+	print_bytes(ctx, "Block Size", sb->dsb_blk_sz);
+	ddb_printf(ctx, "Reserved Blocks: %d\n", sb->dsb_hdr_blks);
+	print_bytes(ctx, "Block Device Capacity", sb->dsb_tot_blks);
+}
+
+void
+ddb_print_ilog_entry(struct ddb_ctx *ctx, struct ddb_ilog_entry *entry)
+{
+	ddb_printf(ctx, "Index: %d\n", entry->die_idx);
+	ddb_printf(ctx, "Status: %s (%d)\n", entry->die_status_str, entry->die_status);
+	ddb_printf(ctx, "Epoch: %lu\n", entry->die_epoch);
+	ddb_printf(ctx, "Txn ID: %d\n", entry->die_tx_id);
+}
+
+void
+ddb_print_dtx_committed(struct ddb_ctx *ctx, struct dv_dtx_committed_entry *entry)
+{
+	ddb_printf(ctx, "UUID: "DF_UUIDF"\n", DP_UUID(entry->ddtx_uuid));
+	ddb_printf(ctx, "Epoch: "DF_U64"\n", entry->ddtx_epoch);
+	ddb_printf(ctx, "Exist: "DF_BOOL"\n", DP_BOOL(entry->ddtx_exist));
+	ddb_printf(ctx, "Invalid: "DF_BOOL"\n", DP_BOOL(entry->ddtx_invalid));
+}
+
+void
+ddb_print_dtx_active(struct ddb_ctx *ctx, struct dv_dtx_active_entry *entry)
+{
+	ddb_printf(ctx, "UUID: "DF_UUIDF"\n", DP_UUID(entry->ddtx_uuid));
+	ddb_printf(ctx, "Epoch: "DF_U64"\n", entry->ddtx_epoch);
+	ddb_printf(ctx, "Exist: "DF_BOOL"\n", DP_BOOL(entry->ddtx_exist));
+	ddb_printf(ctx, "Invalid: "DF_BOOL"\n", DP_BOOL(entry->ddtx_invalid));
+	ddb_printf(ctx, "Reindex: "DF_BOOL"\n", DP_BOOL(entry->ddtx_reindex));
+	ddb_printf(ctx, "Handle Time: "DF_U64"\n", entry->ddtx_handle_time);
+	ddb_printf(ctx, "Oid Cnt: %d\n", entry->ddtx_oid_cnt);
+	ddb_printf(ctx, "Start Time: "DF_U64"\n", entry->ddtx_start_time);
+	ddb_printf(ctx, "Committable: "DF_BOOL"\n", DP_BOOL(entry->ddtx_committable));
+	ddb_printf(ctx, "Committed: "DF_BOOL"\n", DP_BOOL(entry->ddtx_committed));
+	ddb_printf(ctx, "Aborted: "DF_BOOL"\n", DP_BOOL(entry->ddtx_aborted));
+	ddb_printf(ctx, "Maybe Shared: "DF_BOOL"\n", DP_BOOL(entry->ddtx_maybe_shared));
+	ddb_printf(ctx, "Prepared: "DF_BOOL"\n", DP_BOOL(entry->ddtx_prepared));
+	ddb_printf(ctx, "Grp Cnt: %d\n", entry->ddtx_grp_cnt);
+	ddb_printf(ctx, "Ver: %d\n", entry->ddtx_ver);
+	ddb_printf(ctx, "Rec Cnt: %d\n", entry->ddtx_rec_cnt);
+	ddb_printf(ctx, "Mbs Flags: %d\n", entry->ddtx_mbs_flags);
+	ddb_printf(ctx, "Flags: %d\n", entry->ddtx_flags);
+	ddb_printf(ctx, "Oid: "DF_UOID"\n", DP_UOID(entry->ddtx_oid));
+}

--- a/src/ddb/ddb_printer.c
+++ b/src/ddb/ddb_printer.c
@@ -22,7 +22,7 @@ void
 ddb_print_cont(struct ddb_ctx *ctx, struct ddb_cont *cont)
 {
 	ddb_printf(ctx, DF_IDX" "DF_UUIDF"\n", DP_IDX(cont->ddbc_idx),
-		DP_UUID(cont->ddbc_cont_uuid));
+		   DP_UUID(cont->ddbc_cont_uuid));
 }
 
 void

--- a/src/ddb/ddb_printer.c
+++ b/src/ddb/ddb_printer.c
@@ -87,15 +87,16 @@ ddb_print_key(struct ddb_ctx *ctx, struct ddb_key *key, uint32_t indent)
 	default:
 	{
 		int i;
+		char *buf_dst = buf;
 
-		sprintf(buf, "bin(%lu):0x", key->ddbk_key.iov_len);
+		buf_dst += sprintf(buf_dst, "bin(%lu):0x", key->ddbk_key.iov_len);
 
 		for (i = 0; i < key->ddbk_key.iov_len; i++) {
-			sprintf(buf, "%s%02x", buf, ((uint8_t *)key->ddbk_key.iov_buf)[i]);
+			buf_dst += sprintf(buf_dst, "%02x", ((uint8_t *)key->ddbk_key.iov_buf)[i]);
 
 			if (key->ddbk_key.iov_len > buf_len
 			    && i == (buf_len / 4) - 12) {
-				sprintf(buf, "%s...", buf);
+				buf_dst += sprintf(buf_dst, "...");
 				i = key->ddbk_key.iov_len - ((buf_len / 4) - 10);
 			}
 		}

--- a/src/ddb/ddb_printer.h
+++ b/src/ddb/ddb_printer.h
@@ -1,0 +1,26 @@
+/**
+ * (C) Copyright 2022 Intel Corporation.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause-Patent
+ */
+
+#ifndef DAOS_DDB_PRINTER_H
+#define DAOS_DDB_PRINTER_H
+
+#include "ddb_vos.h"
+
+void ddb_print_cont(struct ddb_ctx *ctx, struct ddb_cont *cont);
+void ddb_print_obj(struct ddb_ctx *ctx, struct ddb_obj *obj, uint32_t indent);
+void ddb_print_key(struct ddb_ctx *ctx, struct ddb_key *key, uint32_t indent);
+void ddb_print_sv(struct ddb_ctx *ctx, struct ddb_sv *sv, uint32_t indent);
+void ddb_print_array(struct ddb_ctx *ctx, struct ddb_array *sv, uint32_t indent);
+void ddb_print_superblock(struct ddb_ctx *ctx, struct ddb_superblock *sb);
+void ddb_print_ilog_entry(struct ddb_ctx *ctx, struct ddb_ilog_entry *entry);
+void ddb_print_dtx_committed(struct ddb_ctx *ctx, struct dv_dtx_committed_entry *entry);
+void ddb_print_dtx_active(struct ddb_ctx *ctx, struct dv_dtx_active_entry *entry);
+
+/* some utility functions helpful for printing */
+void ddb_bytes_hr(uint64_t bytes, char *buf, uint32_t buf_len);
+
+
+#endif /* DAOS_DDB_PRINTER_H */

--- a/src/ddb/ddb_vos.c
+++ b/src/ddb/ddb_vos.c
@@ -960,11 +960,10 @@ committed_dtx_cb(daos_handle_t ih, d_iov_t *key, d_iov_t *val, void *cb_arg)
 static int
 active_dtx_cb(daos_handle_t ih, d_iov_t *key, d_iov_t *val, void *cb_arg)
 {
-	int rc;
-	struct active_dtx_cb_arg *arg = cb_arg;
-	struct dv_dtx_active_entry entry;
-
-	struct vos_dtx_act_ent *ent = val->iov_buf;
+	struct dv_dtx_active_entry	 entry = {0};
+	struct active_dtx_cb_arg	*arg = cb_arg;
+	struct vos_dtx_act_ent		*ent = val->iov_buf;
+	int				 rc;
 
 	uuid_copy(entry.ddtx_uuid, ent->dae_base.dae_xid.dti_uuid);
 	entry.ddtx_oid_cnt = ent->dae_oid_cnt;
@@ -990,9 +989,9 @@ active_dtx_cb(daos_handle_t ih, d_iov_t *key, d_iov_t *val, void *cb_arg)
 int
 dv_committed_dtx(daos_handle_t coh, dv_committed_dtx_handler handler_cb, void *handler_arg)
 {
-	struct vos_container	*cont;
-	int			 rc;
-	struct committed_dtx_cb_arg cb_arg = {0};
+	struct vos_container		*cont;
+	int				 rc;
+	struct committed_dtx_cb_arg	 cb_arg = {0};
 
 	if (daos_handle_is_inval(coh))
 		return -DER_INVAL;

--- a/src/ddb/ddb_vos.c
+++ b/src/ddb/ddb_vos.c
@@ -1113,7 +1113,7 @@ daos_recx_match(daos_recx_t a, daos_recx_t b)
 
 static int
 find_cb(daos_handle_t ih, vos_iter_entry_t *entry, vos_iter_type_t type, vos_iter_param_t *param,
-			     void *cb_arg, unsigned int *acts)
+	void *cb_arg, unsigned int *acts)
 {
 	struct dv_tree_path *path = cb_arg;
 

--- a/src/ddb/ddb_vos.c
+++ b/src/ddb/ddb_vos.c
@@ -8,6 +8,7 @@
 #include <libpmemobj/types.h>
 #include <daos_srv/vos.h>
 #include <gurt/debug.h>
+#include <vos_internal.h>
 #include "ddb_common.h"
 #include "ddb_parse.h"
 #include "ddb_vos.h"
@@ -180,7 +181,7 @@ get_by_idx(daos_handle_t hdl, uint32_t idx, struct search_args *args, daos_unit_
 	found = vos_iterate(&param, type, false, &anchors, get_by_idx_cb, NULL, args, NULL);
 
 	if (!found)
-		return -DER_INVAL;
+		return -DER_NONEXIST;
 
 	return 0;
 }
@@ -368,14 +369,93 @@ handle_cont(struct ddb_iter_ctx *ctx, vos_iter_entry_t *entry, vos_iter_param_t 
 	return ctx->handlers->ddb_cont_handler(&cont, ctx->handler_args);
 }
 
+static void
+get_object_type(enum daos_otype_t type, char *type_str)
+{
+	switch (type) {
+	case DAOS_OT_MULTI_HASHED:
+		strcpy(type_str, "DAOS_OT_MULTI_HASHED");
+		break;
+	case DAOS_OT_OIT:
+		strcpy(type_str, "DAOS_OT_OIT");
+		break;
+	case DAOS_OT_DKEY_UINT64:
+		strcpy(type_str, "DAOS_OT_DKEY_UINT64");
+		break;
+	case DAOS_OT_AKEY_UINT64:
+		strcpy(type_str, "DAOS_OT_AKEY_UINT64");
+		break;
+	case DAOS_OT_MULTI_UINT64:
+		strcpy(type_str, "DAOS_OT_MULTI_UINT64");
+		break;
+	case DAOS_OT_DKEY_LEXICAL:
+		strcpy(type_str, "DAOS_OT_DKEY_LEXICAL");
+		break;
+	case DAOS_OT_AKEY_LEXICAL:
+		strcpy(type_str, "DAOS_OT_AKEY_LEXICAL");
+		break;
+	case DAOS_OT_MULTI_LEXICAL:
+		strcpy(type_str, "DAOS_OT_MULTI_LEXICAL");
+		break;
+	case DAOS_OT_KV_HASHED:
+		strcpy(type_str, "DAOS_OT_KV_HASHED");
+		break;
+	case DAOS_OT_KV_UINT64:
+		strcpy(type_str, "DAOS_OT_KV_UINT64");
+		break;
+	case DAOS_OT_KV_LEXICAL:
+		strcpy(type_str, "DAOS_OT_KV_LEXICAL");
+		break;
+	case DAOS_OT_ARRAY:
+		strcpy(type_str, "DAOS_OT_ARRAY");
+		break;
+	case DAOS_OT_ARRAY_ATTR:
+		strcpy(type_str, "DAOS_OT_ARRAY_ATTR");
+		break;
+	case DAOS_OT_ARRAY_BYTE:
+		strcpy(type_str, "DAOS_OT_ARRAY_BYTE");
+		break;
+	default:
+		strcpy(type_str, "UNKNOWN");
+		break;
+	}
+}
+
+void
+dv_oid_to_obj(daos_obj_id_t oid, struct ddb_obj *obj)
+{
+	obj->ddbo_oid = oid;
+	obj->ddbo_nr_grps = (oid.hi & OID_FMT_META_MASK) >> OID_FMT_META_SHIFT;
+
+	/*
+	 * It would be nice to get the object class name, but currently that is client
+	 * functionality and this tool is being installed as a server binary. If that changes, the
+	 * following code might be used ...
+	 * char			 obj_class_name[32];
+	 * int rc = obj_class_init();
+	 * daos_oclass_id_t	 oclass;
+	 * oclass = daos_obj_id2class(obj->ddbo_oid);
+	 * if (!SUCCESS(rc))
+	 *	return rc;
+	 * daos_oclass_id2name(oclass, obj_class_name);
+	 * obj_class_fini();
+	*/
+
+	obj->ddbo_otype = daos_obj_id2type(oid);
+	get_object_type(obj->ddbo_otype, obj->ddbo_otype_str);
+}
+
 static int
 handle_obj(struct ddb_iter_ctx *ctx, vos_iter_entry_t *entry)
 {
-	struct ddb_obj obj = {0};
+	struct ddb_obj		obj = {0};
 
 	D_ASSERT(ctx && ctx->handlers && ctx->handlers->ddb_obj_handler);
+
+	dv_oid_to_obj(entry->ie_oid.id_pub, &obj);
+
 	obj.ddbo_idx = ctx->obj_seen++;
-	obj.ddbo_oid = entry->ie_oid.id_pub;
+
 	ctx->current_obj = entry->ie_oid;
 
 	/* Restart dkey count for the object */
@@ -545,7 +625,6 @@ dv_iterate(daos_handle_t poh, struct dv_tree_path *path, bool recursive,
 		return rc;
 
 	param.ip_hdl = coh;
-
 	param.ip_oid = path->vtp_oid;
 	param.ip_dkey = path->vtp_dkey;
 	param.ip_akey = path->vtp_akey;
@@ -565,9 +644,9 @@ dv_iterate(daos_handle_t poh, struct dv_tree_path *path, bool recursive,
 				     handle_iter_cb, &ctx);
 		if (!SUCCESS(rc)) {
 			vos_cont_close(coh);
-
 			return rc;
 		}
+
 		rc = ddb_vos_iterate(&param, VOS_ITER_SINGLE, recursive, &anchors,
 				     handle_iter_cb, &ctx);
 		vos_cont_close(coh);
@@ -579,6 +658,543 @@ dv_iterate(daos_handle_t poh, struct dv_tree_path *path, bool recursive,
 
 	if (!daos_handle_is_inval(coh))
 		vos_cont_close(coh);
+
+	return rc;
+}
+
+int
+dv_superblock(daos_handle_t poh, dv_dump_superblock_cb cb, void *cb_args)
+{
+	struct ddb_superblock	 sb = {0};
+	struct vos_pool		*pool;
+	struct vos_pool_df	*pool_df;
+
+	D_ASSERT(cb);
+
+	pool = vos_hdl2pool(poh);
+
+	if (pool == NULL)
+		return -DER_INVAL;
+
+	pool_df = pool->vp_pool_df;
+
+	if (pool_df == NULL || pool_df->pd_magic != POOL_DF_MAGIC)
+		return -DER_DF_INVAL;
+
+	uuid_copy(sb.dsb_id, pool_df->pd_id);
+	sb.dsb_durable_format_version = pool_df->pd_version;
+	sb.dsb_cont_nr = pool_df->pd_cont_nr;
+	sb.dsb_nvme_sz = pool_df->pd_nvme_sz;
+	sb.dsb_scm_sz = pool_df->pd_scm_sz;
+
+	sb.dsb_blk_sz = pool_df->pd_vea_df.vsd_blk_sz;
+	sb.dsb_hdr_blks = pool_df->pd_vea_df.vsd_hdr_blks;
+	sb.dsb_tot_blks = pool_df->pd_vea_df.vsd_tot_blks;
+
+
+	cb(cb_args, &sb);
+
+	return 0;
+}
+
+int
+dv_dump_value(daos_handle_t poh, struct dv_tree_path *path, dv_dump_value_cb dump_cb, void *cb_arg)
+{
+	daos_iod_t	iod = {0};
+	d_sg_list_t	sgl;
+	daos_handle_t	coh;
+	size_t		data_size;
+	int		rc;
+
+	d_sgl_init(&sgl, 1);
+
+	rc = vos_cont_open(poh, path->vtp_cont, &coh);
+	if (!SUCCESS(rc))
+		return rc;
+
+	iod.iod_name = path->vtp_akey;
+	iod.iod_recxs = &path->vtp_recx;
+	iod.iod_nr = 1;
+	iod.iod_size = 0;
+	iod.iod_type = path->vtp_recx.rx_nr == 0 ? DAOS_IOD_SINGLE : DAOS_IOD_ARRAY;
+
+	/* First, get record size */
+	rc = vos_obj_fetch(coh, path->vtp_oid, DAOS_EPOCH_MAX, 0, &path->vtp_dkey, 1, &iod, NULL);
+	if (!SUCCESS(rc)) {
+		d_sgl_fini(&sgl, true);
+		vos_cont_close(coh);
+
+		return rc;
+	}
+
+	data_size = iod.iod_size;
+
+	if (path->vtp_recx.rx_nr > 0)
+		data_size *= path->vtp_recx.rx_nr;
+
+	D_ALLOC(sgl.sg_iovs[0].iov_buf, data_size);
+	if (sgl.sg_iovs[0].iov_buf == NULL)
+		return -DER_NOMEM;
+	sgl.sg_iovs[0].iov_buf_len = data_size;
+
+	rc = vos_obj_fetch(coh, path->vtp_oid, DAOS_EPOCH_MAX, 0, &path->vtp_dkey, 1, &iod, &sgl);
+	if (!SUCCESS(rc)) {
+		D_ERROR("Unable to fetch object: "DF_RC"\n", DP_RC(rc));
+		d_sgl_fini(&sgl, true);
+		vos_cont_close(coh);
+
+		return rc;
+	}
+
+	if (dump_cb)
+		rc = dump_cb(cb_arg, &sgl.sg_iovs[0]);
+
+	d_sgl_fini(&sgl, true);
+	vos_cont_close(coh);
+
+	return rc;
+}
+
+static void
+ilog_entry_status(enum ilog_status status, char *status_str, uint32_t status_str_len)
+{
+	switch (status) {
+
+	case ILOG_INVALID:
+		snprintf(status_str, status_str_len, "INVALID");
+		break;
+	case ILOG_COMMITTED:
+		snprintf(status_str, status_str_len, "COMMITTED");
+		break;
+	case ILOG_UNCOMMITTED:
+		snprintf(status_str, status_str_len, "UNCOMMITTED");
+		break;
+	case ILOG_REMOVED:
+		snprintf(status_str, status_str_len, "REMOVED");
+		break;
+	}
+}
+
+
+static int
+cb_foreach_entry(dv_dump_ilog_entry cb, void *cb_args, struct ilog_entries *entries)
+{
+	struct ilog_entry	 e;
+	struct ddb_ilog_entry	 ent = {0};
+	int			 rc;
+
+	ilog_foreach_entry(entries, &e) {
+		ent.die_idx = e.ie_idx;
+		ent.die_status = e.ie_status;
+		ilog_entry_status(e.ie_status, ent.die_status_str, ARRAY_SIZE(ent.die_status_str));
+		ent.die_epoch = e.ie_id.id_epoch;
+		ent.die_tx_id = e.ie_id.id_tx_id;
+		ent.die_update_minor_eph = e.ie_id.id_update_minor_eph;
+		ent.die_punch_minor_eph = e.ie_id.id_punch_minor_eph;
+
+		rc = cb(cb_args, &ent);
+		if (!SUCCESS(rc))
+			return rc;
+	}
+
+	return 0;
+}
+
+int
+dv_get_obj_ilog_entries(daos_handle_t coh, daos_unit_oid_t oid, dv_dump_ilog_entry cb,
+			void *cb_args)
+{
+	struct ilog_entries	 entries = {0};
+	struct ilog_desc_cbs	 cbs = {0};
+	struct vos_container	*cont = NULL;
+	struct vos_obj_df	*obj_df = NULL;
+	struct umem_instance	*umm;
+	int			 rc;
+
+	D_ASSERT(cb);
+	if (daos_handle_is_inval(coh) || daos_unit_oid_is_null(oid))
+		return -DER_INVAL;
+
+	ilog_fetch_init(&entries);
+	cont = vos_hdl2cont(coh);
+
+	rc = vos_oi_find(cont, oid, &obj_df, NULL);
+	if (!SUCCESS(rc)) {
+		if (rc == -DER_NONEXIST)
+			return -DER_INVAL;
+		return rc;
+	}
+
+	umm = vos_cont2umm(cont);
+
+	vos_ilog_desc_cbs_init(&cbs, coh);
+	rc = ilog_fetch(umm, &obj_df->vo_ilog, &cbs, DAOS_INTENT_DEFAULT, &entries);
+	if (!SUCCESS(rc))
+		return rc;
+
+	rc = cb_foreach_entry(cb, cb_args, &entries);
+	return rc;
+}
+
+static inline int
+ddb_key_iter_fetch_helper(struct vos_obj_iter *oiter, struct vos_rec_bundle *rbund, d_iov_t *keybuf)
+{
+	d_iov_t			 kiov;
+	d_iov_t			 riov;
+	struct dcs_csum_info	 csum;
+
+	tree_rec_bundle2iov(rbund, &riov);
+
+	rbund->rb_iov	= keybuf;
+	rbund->rb_csum	= &csum;
+
+	d_iov_set(rbund->rb_iov, NULL, 0); /* no copy */
+	ci_set_null(rbund->rb_csum);
+
+	return dbtree_iter_fetch(oiter->it_hdl, &kiov, &riov, NULL);
+}
+
+struct ilog_cb_args {
+	daos_key_t *key;
+	dv_dump_ilog_entry cb;
+	void *cb_args;
+};
+
+static int
+dkey_ilog_cb(daos_handle_t ih, vos_iter_entry_t *entry, vos_iter_type_t type,
+	     vos_iter_param_t *param, void *cb_arg, unsigned int *acts)
+{
+	struct vos_iterator	*iter = vos_hdl2iter(ih);
+	struct vos_obj_iter	*oiter = vos_iter2oiter(iter);
+	struct umem_instance	*umm;
+	struct vos_rec_bundle	 rbund;
+	daos_key_t		 key;
+	struct ilog_cb_args	*args = cb_arg;
+	struct vos_krec_df	*krec;
+	int			 rc;
+	struct ilog_desc_cbs	 cbs = {0};
+	daos_handle_t		 coh = param->ip_hdl;
+	struct ilog_entries	 entries = {0};
+
+	D_ASSERT(type == VOS_ITER_DKEY);
+	if (!daos_key_match(&entry->ie_key, args->key))
+		return 0;
+
+	ilog_fetch_init(&entries);
+
+	rc = ddb_key_iter_fetch_helper(oiter, &rbund, &key);
+	if (!SUCCESS(rc))
+		return rc;
+
+	krec = rbund.rb_krec;
+	umm = vos_obj2umm(oiter->it_obj);
+
+	vos_ilog_desc_cbs_init(&cbs, coh);
+
+	rc = ilog_fetch(umm, &krec->kr_ilog, &cbs, DAOS_INTENT_DEFAULT, &entries);
+	if (!SUCCESS(rc))
+		return rc;
+
+	rc = cb_foreach_entry(args->cb, args->cb_args, &entries);
+
+	return rc;
+}
+
+int
+dv_get_dkey_ilog_entries(daos_handle_t coh, daos_unit_oid_t oid, daos_key_t *dkey,
+			 dv_dump_ilog_entry cb, void *cb_args)
+{
+	vos_iter_param_t	param = {0};
+	struct vos_iter_anchors anchors = {0};
+	struct ilog_cb_args	args = {0};
+
+	D_ASSERT(cb);
+
+	if (daos_handle_is_inval(coh) || daos_unit_oid_is_null(oid) ||
+	    dkey == NULL || dkey->iov_len == 0)
+		return -DER_INVAL;
+
+	param.ip_hdl = coh;
+	param.ip_oid = oid;
+	param.ip_epr.epr_hi = DAOS_EPOCH_MAX;
+	args.key = dkey;
+	args.cb = cb;
+	args.cb_args = cb_args;
+
+	return ddb_vos_iterate(&param, VOS_ITER_DKEY, false, &anchors, dkey_ilog_cb, &args);
+}
+
+struct committed_dtx_cb_arg {
+	dv_committed_dtx_handler handler;
+	void *handler_arg;
+};
+
+struct active_dtx_cb_arg {
+	dv_active_dtx_handler handler;
+	void *handler_arg;
+};
+
+static int
+committed_dtx_cb(daos_handle_t ih, d_iov_t *key, d_iov_t *val, void *cb_arg)
+{
+	int rc;
+	struct committed_dtx_cb_arg *arg = cb_arg;
+	struct dv_dtx_committed_entry entry;
+
+	struct vos_dtx_cmt_ent *ent = val->iov_buf;
+
+	uuid_copy(entry.ddtx_uuid, ent->dce_base.dce_xid.dti_uuid);
+	entry.ddtx_reindex = ent->dce_reindex;
+	entry.ddtx_exist = ent->dce_exist;
+	entry.ddtx_invalid = ent->dce_invalid;
+	entry.ddtx_cmt_time = ent->dce_base.dce_cmt_time;
+	entry.ddtx_epoch = ent->dce_base.dce_epoch;
+
+
+
+	rc = arg->handler(&entry, arg->handler_arg);
+
+	return rc;
+}
+
+static int
+active_dtx_cb(daos_handle_t ih, d_iov_t *key, d_iov_t *val, void *cb_arg)
+{
+	int rc;
+	struct active_dtx_cb_arg *arg = cb_arg;
+	struct dv_dtx_active_entry entry;
+
+	struct vos_dtx_act_ent *ent = val->iov_buf;
+
+	uuid_copy(entry.ddtx_uuid, ent->dae_base.dae_xid.dti_uuid);
+	entry.ddtx_oid_cnt = ent->dae_oid_cnt;
+	entry.ddtx_start_time = ent->dae_start_time;
+	entry.ddtx_committable = ent->dae_committable;
+	entry.ddtx_committed = ent->dae_committed;
+	entry.ddtx_aborted = ent->dae_aborted;
+	entry.ddtx_maybe_shared = ent->dae_maybe_shared;
+	entry.ddtx_prepared = ent->dae_prepared;
+	entry.ddtx_epoch = ent->dae_base.dae_epoch;
+	entry.ddtx_grp_cnt = ent->dae_base.dae_grp_cnt;
+	entry.ddtx_ver = ent->dae_base.dae_ver;
+	entry.ddtx_rec_cnt = ent->dae_base.dae_rec_cnt;
+	entry.ddtx_mbs_flags = ent->dae_base.dae_mbs_flags;
+	entry.ddtx_flags = ent->dae_base.dae_flags;
+	entry.ddtx_oid = ent->dae_base.dae_oid;
+
+	rc = arg->handler(&entry, arg->handler_arg);
+
+	return rc;
+}
+
+int
+dv_committed_dtx(daos_handle_t coh, dv_committed_dtx_handler handler_cb, void *handler_arg)
+{
+	struct vos_container	*cont;
+	int			 rc;
+	struct committed_dtx_cb_arg cb_arg = {0};
+
+	if (daos_handle_is_inval(coh))
+		return -DER_INVAL;
+
+	cb_arg.handler = handler_cb;
+	cb_arg.handler_arg = handler_arg;
+
+	cont = vos_hdl2cont(coh);
+	rc = dbtree_iterate(cont->vc_dtx_committed_hdl, DAOS_INTENT_DEFAULT, false,
+			    committed_dtx_cb, &cb_arg);
+	return rc;
+}
+
+int
+dv_active_dtx(daos_handle_t coh, dv_active_dtx_handler handler_cb, void *handler_arg)
+{
+	struct vos_container	*cont;
+	int			 rc;
+	struct active_dtx_cb_arg cb_arg = {0};
+
+	if (daos_handle_is_inval(coh))
+		return -DER_INVAL;
+
+	cb_arg.handler = handler_cb;
+	cb_arg.handler_arg = handler_arg;
+
+	cont = vos_hdl2cont(coh);
+
+
+	rc = dbtree_iterate(cont->vc_dtx_active_hdl, DAOS_INTENT_DEFAULT, false,
+			    active_dtx_cb, &cb_arg);
+
+	return rc;
+}
+
+int
+dv_delete(daos_handle_t poh, struct dv_tree_path *vtp)
+{
+	daos_handle_t	coh;
+	int		rc;
+
+	/* Don't allow deleting all contents ... must specify at least a container */
+	if (dvp_is_empty(vtp))
+		return -DER_INVAL;
+
+	if (!SUCCESS(ddb_vtp_verify(poh, vtp)))
+		return -DER_NONEXIST;
+
+	if (!dv_has_obj(vtp))
+		return vos_cont_destroy(poh, vtp->vtp_cont);
+
+	rc = dv_cont_open(poh, vtp->vtp_cont, &coh);
+	if (!SUCCESS(rc))
+		return rc;
+
+	if (dv_has_akey(vtp))
+		rc = vos_obj_del_key(coh, vtp->vtp_oid, &vtp->vtp_dkey, &vtp->vtp_akey);
+	else if (dv_has_dkey(vtp))
+		rc = vos_obj_del_key(coh, vtp->vtp_oid, &vtp->vtp_dkey, NULL);
+	else /* delete object */
+		rc = vos_obj_delete(coh, vtp->vtp_oid);
+
+	dv_cont_close(&coh);
+
+	return rc;
+}
+
+int dv_update(daos_handle_t poh, struct dv_tree_path *vtp, d_iov_t *iov, daos_epoch_t epoch)
+{
+	daos_iod_t	iod = {0};
+	d_sg_list_t	sgl = {0};
+	uint64_t	flags = 0;
+	daos_handle_t	coh;
+	uint32_t	pool_ver = 0;
+	int		rc;
+
+	if (!dvp_is_complete(vtp) || iov->iov_len == 0)
+		return -DER_INVAL;
+
+	rc = dv_cont_open(poh, vtp->vtp_cont, &coh);
+	if (!SUCCESS(rc))
+		return rc;
+
+	d_sgl_init(&sgl, 1);
+	sgl.sg_nr_out = 1;
+	sgl.sg_iovs[0] = *iov;
+
+	iod.iod_name = vtp->vtp_akey;
+	iod.iod_nr = 1;
+	if (vtp->vtp_recx.rx_nr == 0) {
+		iod.iod_type = DAOS_IOD_SINGLE;
+		iod.iod_size = iov->iov_len;
+	} else {
+		iod.iod_type = DAOS_IOD_ARRAY;
+		iod.iod_recxs = &vtp->vtp_recx;
+		iod.iod_size = 1;
+	}
+
+	rc = vos_obj_update(coh, vtp->vtp_oid, epoch, pool_ver, flags,
+			    &vtp->vtp_dkey, 1, &iod, NULL, &sgl);
+	if (rc == -DER_NO_PERM)
+		D_ERROR("Unable to update. Trying to update with the wrong value type? "
+			"(Array vs SV)\n");
+	if (rc == -DER_REC2BIG)
+		D_ERROR("Unable to update. Data value might not be large enough to fill the "
+			"supplied recx\n");
+	d_sgl_fini(&sgl, false);
+	dv_cont_close(&coh);
+
+	return rc;
+}
+
+static bool
+daos_recx_match(daos_recx_t a, daos_recx_t b)
+{
+	return a.rx_nr == b.rx_nr && a.rx_idx == b.rx_idx;
+}
+
+static int
+find_cb(daos_handle_t ih, vos_iter_entry_t *entry, vos_iter_type_t type, vos_iter_param_t *param,
+			     void *cb_arg, unsigned int *acts)
+{
+	struct dv_tree_path *path = cb_arg;
+
+	switch (type) {
+
+	case VOS_ITER_NONE:
+		break;
+	case VOS_ITER_COUUID:
+		break;
+	case VOS_ITER_OBJ:
+		if (daos_oid_cmp(path->vtp_oid.id_pub, entry->ie_oid.id_pub) == 0)
+			return 1;
+		break;
+	case VOS_ITER_DKEY:
+		if (daos_key_match(&path->vtp_dkey, &entry->ie_key))
+			return 1;
+		break;
+	case VOS_ITER_AKEY:
+		if (daos_key_match(&path->vtp_akey, &entry->ie_key))
+			return 1;
+		break;
+	case VOS_ITER_SINGLE:
+		break;
+	case VOS_ITER_RECX:
+		if (daos_recx_match(path->vtp_recx, entry->ie_orig_recx))
+			return 1;
+		break;
+	case VOS_ITER_DTX:
+		break;
+	}
+	return 0;
+}
+
+/* Note:
+ * This can be improved by verifying the path in a single vos_iterate ... instead of 1 for
+ * path part.
+ */
+static bool
+part_is_valid(daos_handle_t coh, struct dv_tree_path *path, vos_iter_type_t type)
+{
+	vos_iter_param_t param = {0};
+	struct vos_iter_anchors anchors = {0};
+
+	param.ip_hdl = coh;
+	param.ip_oid = path->vtp_oid;
+	param.ip_dkey = path->vtp_dkey;
+	if (type == VOS_ITER_RECX)
+		param.ip_akey = path->vtp_akey;
+
+	param.ip_epr.epr_hi = DAOS_EPOCH_MAX;
+
+	return vos_iterate(&param, type, false, &anchors, find_cb, NULL, path, NULL) == 1;
+}
+
+int
+ddb_vtp_verify(daos_handle_t poh, struct dv_tree_path *vtp)
+{
+	daos_handle_t coh;
+	int rc = 0;
+
+	if (uuid_is_null(vtp->vtp_cont)) /* empty path is fine */
+		return 0;
+
+	rc = dv_cont_open(poh, vtp->vtp_cont, &coh);
+	if (!SUCCESS(rc))
+		return rc;
+
+	if (!daos_oid_is_null(vtp->vtp_oid.id_pub) && !part_is_valid(coh, vtp, VOS_ITER_OBJ))
+		D_GOTO(done, rc = -DER_NONEXIST);
+
+	if (vtp->vtp_dkey.iov_len > 0 && !part_is_valid(coh, vtp, VOS_ITER_DKEY))
+		D_GOTO(done, rc = -DER_NONEXIST);
+
+	if (vtp->vtp_akey.iov_len > 0 && !part_is_valid(coh, vtp, VOS_ITER_AKEY))
+		D_GOTO(done, rc = -DER_NONEXIST);
+
+	if (vtp->vtp_recx.rx_nr > 0 && !part_is_valid(coh, vtp, VOS_ITER_RECX))
+		D_GOTO(done, rc = -DER_NONEXIST);
+
+done:
+	dv_cont_close(&coh);
 
 	return rc;
 }

--- a/src/ddb/ddb_vos.h
+++ b/src/ddb/ddb_vos.h
@@ -46,7 +46,7 @@ int ddb_vos_pool_open(char *path, daos_handle_t *poh);
 int ddb_vos_pool_close(daos_handle_t poh);
 
 /* Open and close a cont for a ddb_ctx */
-int dv_cont_open(daos_handle_t poh, unsigned char *uuid, daos_handle_t *coh);
+int dv_cont_open(daos_handle_t poh, uuid_t uuid, daos_handle_t *coh);
 int dv_cont_close(daos_handle_t *coh);
 
 /*

--- a/src/ddb/ddb_vos.h
+++ b/src/ddb/ddb_vos.h
@@ -7,6 +7,7 @@
 #ifndef DAOS_DDB_VOS_H
 #define DAOS_DDB_VOS_H
 
+#include <vos_layout.h>
 #include <daos_srv/vos_types.h>
 #include "ddb_common.h"
 
@@ -16,8 +17,12 @@ struct ddb_cont {
 };
 
 struct ddb_obj {
-	daos_obj_id_t	ddbo_oid;
-	uint32_t	ddbo_idx;
+	daos_obj_id_t		ddbo_oid;
+	uint32_t		ddbo_idx;
+	enum daos_otype_t	ddbo_otype;
+	char			ddbo_otype_str[32];
+	char			ddbo_obj_class_name[16];
+	uint32_t		ddbo_nr_grps;
 };
 
 struct ddb_key {
@@ -73,7 +78,6 @@ struct vos_tree_handlers {
 int dv_iterate(daos_handle_t poh, struct dv_tree_path *path, bool recursive,
 	       struct vos_tree_handlers *handlers, void *handler_args);
 
-
 /* The following functions lookup a vos path part given a starting point and the index desired */
 int dv_get_cont_uuid(daos_handle_t poh, uint32_t idx, uuid_t uuid);
 int dv_get_object_oid(daos_handle_t coh, uint32_t idx, daos_unit_oid_t *uoid);
@@ -90,5 +94,83 @@ int dv_get_recx(daos_handle_t coh, daos_unit_oid_t uoid, daos_key_t *dkey, daos_
  * @return		0 if successful, else error.
  */
 int dv_path_update_from_indexes(struct dv_tree_path_builder *vt_path);
+
+struct ddb_superblock {
+	uuid_t		dsb_id;
+	uint64_t	dsb_cont_nr;
+	uint64_t	dsb_nvme_sz;
+	uint64_t	dsb_scm_sz;
+	uint64_t	dsb_tot_blks; /* vea: Block device capacity */
+	uint32_t	dsb_durable_format_version;
+	uint32_t	dsb_blk_sz; /* vea: Block size, 4k bytes by default */
+	uint32_t	dsb_hdr_blks; /* vea: Reserved blocks for the block device header */
+};
+
+typedef int (*dv_dump_superblock_cb)(void *cb_arg, struct ddb_superblock *sb);
+
+int dv_superblock(daos_handle_t poh, dv_dump_superblock_cb cb, void *cb_args);
+
+typedef int (*dv_dump_value_cb)(void *cb_arg, d_iov_t *value);
+int dv_dump_value(daos_handle_t poh, struct dv_tree_path *path, dv_dump_value_cb dump_cb,
+		  void *cb_arg);
+
+struct ddb_ilog_entry {
+	uint32_t	die_idx;
+	int32_t		die_status;
+	char		die_status_str[32];
+	daos_epoch_t	die_epoch;
+	uint32_t	die_tx_id;
+	uint16_t	die_update_minor_eph;
+	uint16_t	die_punch_minor_eph;
+};
+
+typedef int (*dv_dump_ilog_entry)(void *cb_arg, struct ddb_ilog_entry *entry);
+int dv_get_obj_ilog_entries(daos_handle_t coh, daos_unit_oid_t oid, dv_dump_ilog_entry cb,
+			    void *cb_args);
+int dv_get_dkey_ilog_entries(daos_handle_t coh, daos_unit_oid_t oid, daos_key_t *dkey,
+			     dv_dump_ilog_entry cb, void *cb_args);
+
+
+struct dv_dtx_committed_entry {
+	uuid_t		ddtx_uuid;
+	bool		ddtx_reindex;
+	bool		ddtx_exist;
+	bool		ddtx_invalid;
+	daos_epoch_t	ddtx_cmt_time;
+	daos_epoch_t	ddtx_epoch;
+};
+
+struct dv_dtx_active_entry {
+	uuid_t		ddtx_uuid;
+	bool		ddtx_reindex;
+	bool		ddtx_exist;
+	bool		ddtx_invalid;
+	daos_epoch_t	ddtx_handle_time;
+	daos_epoch_t	ddtx_epoch;
+	uint32_t	ddtx_oid_cnt;
+	daos_epoch_t	ddtx_start_time;
+	uint32_t	ddtx_committable;
+	uint32_t	ddtx_committed;
+	uint32_t	ddtx_aborted;
+	uint32_t	ddtx_maybe_shared;
+	uint32_t	ddtx_prepared;
+	uint32_t	ddtx_grp_cnt;
+	uint32_t	ddtx_ver;
+	uint32_t	ddtx_rec_cnt;
+	uint16_t	ddtx_mbs_flags;
+	uint16_t	ddtx_flags;
+	daos_unit_oid_t ddtx_oid;
+};
+
+typedef int (*dv_committed_dtx_handler)(struct dv_dtx_committed_entry *entry, void *cb_arg);
+int dv_committed_dtx(daos_handle_t coh, dv_committed_dtx_handler handler_cb, void *handler_arg);
+typedef int (*dv_active_dtx_handler)(struct dv_dtx_active_entry *entry, void *cb_arg);
+int dv_active_dtx(daos_handle_t coh, dv_active_dtx_handler handler_cb, void *handler_arg);
+int dv_delete(daos_handle_t poh, struct dv_tree_path *vtp);
+int dv_update(daos_handle_t poh, struct dv_tree_path *vtp, d_iov_t *iov, daos_epoch_t epoch);
+
+void dv_oid_to_obj(daos_obj_id_t oid, struct ddb_obj *obj);
+
+int ddb_vtp_verify(daos_handle_t poh, struct dv_tree_path *vtp);
 
 #endif /* DAOS_DDB_VOS_H */

--- a/src/ddb/tests/SConscript
+++ b/src/ddb/tests/SConscript
@@ -4,9 +4,9 @@ import os
 
 def scons():
     """Execute build"""
-    Import('base_env', 'prereqs', 'ddblib')
+    Import('env', 'prereqs', 'ddblib')
 
-    denv = base_env.Clone()
+    denv = env.Clone()
 
     # Add runtime paths for daos libraries
     denv.AppendUnique(RPATH_FULL=['$PREFIX/lib64/daos_srv'])
@@ -17,6 +17,10 @@ def scons():
     # for ddb includes
     denv.AppendUnique(CPPPATH=[Dir('../').srcnode()])
     denv.AppendUnique(LIBPATH=[Dir('../')])
+
+    # Add include directory for vos internal headers
+    denv.AppendUnique(CPPPATH=[Dir('../../vos/').srcnode()])
+    denv.AppendUnique(CPPPATH=[Dir('../../vos/')])
     denv.AppendUnique(CPPDEFINES='_GNU_SOURCE') # for fallocate
 
     libs = ['vos', 'daos_common_pmem', 'abt', 'gurt', 'uuid', 'bio',
@@ -26,7 +30,8 @@ def scons():
            'ddb_main_tests.c',
            'ddb_parse_tests.c',
            'ddb_test_driver.c',
-           'ddb_vos_tests.c']
+           'ddb_vos_tests.c',
+           'ddb_commands_print_tests.c']
     ddb_tests = daos_build.program(denv, 'ddb_tests',
                                    [ddblib, src],
                                    LIBS=libs)

--- a/src/ddb/tests/ddb_cmd_options_tests.c
+++ b/src/ddb/tests/ddb_cmd_options_tests.c
@@ -30,6 +30,7 @@ __test_run_cmd(struct ddb_cmd_info *info, char *argv[])
 	uint32_t		argc = 0;
 	struct ddb_ctx		ctx = {0};
 	struct ddb_cmd_info	tmp_info = {0};
+	int			rc;
 
 	ctx.dc_io_ft.ddb_print_message = fake_print;
 	ctx.dc_io_ft.ddb_print_error = fake_print;
@@ -50,7 +51,7 @@ __test_run_cmd(struct ddb_cmd_info *info, char *argv[])
 	parse_args.ap_argv = argv;
 	parse_args.ap_argc = argc;
 
-	int rc = ddb_parse_cmd_args(&ctx, &parse_args, info);
+	rc = ddb_parse_cmd_args(&ctx, &parse_args, info);
 
 	if (!SUCCESS(rc))
 		return rc;
@@ -81,19 +82,103 @@ ls_options_parsing(void **state)
 	assert_string_equal("/[0]/[0]", options->path);
 }
 
-#define TEST(dsc, test) { dsc, test, NULL, NULL }
-static const struct CMUnitTest tests[] = {
-	TEST("01: ls option parsing", ls_options_parsing),
-};
+static void
+value_dump_options_parsing(void **state)
+{
+	struct ddb_cmd_info		 info = {0};
+	struct dump_value_options	*options = &info.dci_cmd_option.dci_dump_value;
+
+	test_run_inval_cmd("dump_value"); /* no path to dump */
+	test_run_inval_cmd("dump_value", "this/is/a/path"); /* no destination path to dump to */
+
+	test_run_cmd(&info, "dump_value", "this/is/a/path", "/this/is/a/destination");
+	assert_string_equal("this/is/a/path", options->path);
+	assert_string_equal("/this/is/a/destination", options->dst);
+}
+
+static void
+ilog_dump_parsing(void **state)
+{
+	struct ddb_cmd_info		 info = {0};
+	struct dump_ilog_options	*options = &info.dci_cmd_option.dci_dump_ilog;
+
+	test_run_inval_cmd("dump_ilog"); /* no path to dump */
+
+	test_run_cmd(&info, "dump_ilog", "this/is/a/path");
+	assert_string_equal("this/is/a/path", options->path);
+}
+
+static void
+dtx_dump_parsing(void **state)
+{
+	struct ddb_cmd_info		 info = {0};
+	struct dump_dtx_options		*options = &info.dci_cmd_option.dci_dump_dtx;
+
+	test_run_inval_cmd("dump_dtx"); /* no path to dump */
+	test_run_inval_cmd("dump_dtx", "path", "-a", "-t");
+
+	test_run_cmd(&info, "dump_dtx", "path");
+	assert_int_equal(DDB_CMD_DUMP_DTX, info.dci_cmd);
+	assert_string_equal("path", options->path);
+	assert_false(options->active);
+	assert_false(options->committed);
+
+	test_run_cmd(&info, "dump_dtx", "path", "-a", "-c");
+	assert_string_equal("path", options->path);
+	assert_true(options->active);
+	assert_true(options->committed);
+
+	test_run_cmd(&info, "dump_dtx", "path", "-ac");
+	assert_string_equal("path", options->path);
+	assert_true(options->active);
+	assert_true(options->committed);
+}
+
+static void
+rm_parsing(void **state)
+{
+	struct ddb_cmd_info		 info = {0};
+	struct rm_options		*options = &info.dci_cmd_option.dci_rm;
+
+	test_run_inval_cmd("rm"); /* no path to dump */
+
+	test_run_cmd(&info, "rm", "path");
+	assert_string_equal("path", options->path);
+}
+
+static void
+load_parsing(void **state)
+{
+	struct ddb_cmd_info		 info = {0};
+	struct load_options		*options = &info.dci_cmd_option.dci_load;
+
+	test_run_inval_cmd("load"); /* no file path to load or destination to load it to */
+	test_run_inval_cmd("load", "only_one_path"); /* no destination to load it to */
+
+	test_run_cmd(&info, "load", "src", "dst", "1");
+	assert_string_equal("src", options->src);
+	assert_string_equal("dst", options->dst);
+	assert_string_equal("1", options->epoch);
+}
+
 
 /*
  * -----------------------------------------------
  * Execute
  * -----------------------------------------------
  */
+#define TEST(x) { #x, x, NULL, NULL }
 int
 ddb_cmd_options_tests_run()
 {
+	static const struct CMUnitTest tests[] = {
+		TEST(ls_options_parsing),
+		TEST(value_dump_options_parsing),
+		TEST(ilog_dump_parsing),
+		TEST(dtx_dump_parsing),
+		TEST(rm_parsing),
+		TEST(load_parsing),
+	};
 	return cmocka_run_group_tests_name("DDB commands option parsing tests", tests,
 					   NULL, NULL);
 }

--- a/src/ddb/tests/ddb_cmocka.h
+++ b/src/ddb/tests/ddb_cmocka.h
@@ -13,11 +13,11 @@
 
 #define assert_uuid_equal(a, b) \
 	do { \
-	char str_a[DAOS_UUID_STR_SIZE]; \
-	char str_b[DAOS_UUID_STR_SIZE]; \
-	uuid_unparse(a, str_a); \
-	uuid_unparse(b, str_b); \
-	assert_string_equal(str_a, str_b); \
+		char str_a[DAOS_UUID_STR_SIZE]; \
+		char str_b[DAOS_UUID_STR_SIZE]; \
+		uuid_unparse(a, str_a); \
+		uuid_unparse(b, str_b); \
+		assert_string_equal(str_a, str_b); \
 	} while (0)
 #define assert_uuid_not_equal(a, b) \
 	do { \
@@ -40,5 +40,18 @@
 		assert_int_equal(a.iov_buf_len, b.iov_buf_len); \
 		assert_memory_equal(a.iov_buf, b.iov_buf, a.iov_len); \
 	} while (0)
+
+#define assert_key_not_equal(a, b) \
+	do { \
+		if (a.iov_len == b.iov_len && a.iov_buf_len == b.iov_buf_len) \
+			assert_memory_not_equal(a.iov_buf, b.iov_buf, a.iov_len); \
+	} while (0)
+
+#define assert_string_contains(str, substr) \
+	do { \
+		if (strstr(str, substr) == NULL) \
+			fail_msg("'%s' not found in '%s'", substr, str); \
+	} while (0)
+
 
 #endif /* DAOS_DDB_CMOCKA_H */

--- a/src/ddb/tests/ddb_commands_print_tests.c
+++ b/src/ddb/tests/ddb_commands_print_tests.c
@@ -57,6 +57,9 @@ print_key_test(void **state)
 {
 	struct ddb_key	key = {0};
 	char		key_buf[1024] = {0};
+	uint64_t	ll = 0x1abc2abc3abc4abc;
+	int		i = 0x1234abcd;
+	short		s = 0xabcd;
 
 	key.ddbk_idx = 4;
 	d_iov_set(&key.ddbk_key, key_buf, ARRAY_SIZE(key_buf));
@@ -102,7 +105,6 @@ print_key_test(void **state)
 	dvt_fake_print_reset();
 
 	/* short key */
-	short s = 0xabcd;
 	key.ddbk_key.iov_buf = (uint8_t *)&s;
 	key.ddbk_key.iov_len = sizeof(short);
 	ddb_print_key(&ctx, &key, 0);
@@ -110,7 +112,6 @@ print_key_test(void **state)
 	dvt_fake_print_reset();
 
 	/* int key */
-	int i = 0x1234abcd;
 	key.ddbk_key.iov_buf = (int *)&i;
 	key.ddbk_key.iov_len = sizeof(int);
 	ddb_print_key(&ctx, &key, 0);
@@ -118,7 +119,6 @@ print_key_test(void **state)
 	dvt_fake_print_reset();
 
 	/* 64 bit key */
-	uint64_t ll = 0x1abc2abc3abc4abc;
 	key.ddbk_key.iov_buf = (uint64_t *)&ll;
 	key.ddbk_key.iov_len = sizeof(uint64_t);
 	ddb_print_key(&ctx, &key, 0);

--- a/src/ddb/tests/ddb_commands_print_tests.c
+++ b/src/ddb/tests/ddb_commands_print_tests.c
@@ -1,0 +1,329 @@
+/**
+ * (C) Copyright 2022 Intel Corporation.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause-Patent
+ */
+#include <ddb_vos.h>
+#include <ddb_printer.h>
+#include "ddb_cmocka.h"
+#include "ddb_test_driver.h"
+
+static struct ddb_ctx ctx = {.dc_io_ft.ddb_print_message = dvt_fake_print};
+
+#define assert_str_exact(str) assert_string_equal(str, dvt_fake_print_buffer)
+#define assert_str(str) assert_string_contains(dvt_fake_print_buffer, str)
+
+static void
+print_container_test(void **state)
+{
+	struct ddb_cont cont = {0};
+
+	uuid_parse("12345678-1234-1243-1243-123456789012", cont.ddbc_cont_uuid);
+	cont.ddbc_idx = 1;
+
+	ddb_print_cont(&ctx, &cont);
+	assert_str_exact("[1] 12345678-1234-1243-1243-123456789012\n");
+}
+
+static void
+print_object_test(void **state)
+{
+	struct ddb_obj obj = {0};
+
+	obj.ddbo_idx = 2;
+	obj.ddbo_oid.lo = 1;
+	obj.ddbo_oid.hi = 10;
+	obj.ddbo_nr_grps = 2;
+	strcpy(obj.ddbo_obj_class_name, "TEST CLASS");
+	strcpy(obj.ddbo_otype_str, "TEST TYPE");
+
+	ddb_print_obj(&ctx, &obj, 1);
+
+	assert_str_exact("\t[2] '10.1' (class: TEST CLASS, type: TEST TYPE, groups: 2)\n");
+}
+
+static void set_key_buf(struct ddb_key	*key, uint32_t len)
+{
+	int i;
+
+	for (i = 0; i < len; i++)
+		((uint8_t *)key->ddbk_key.iov_buf)[i] = (i % 16 + 0x1);
+
+	key->ddbk_key.iov_len = len;
+}
+
+static void
+print_key_test(void **state)
+{
+	struct ddb_key	key = {0};
+	char		key_buf[1024] = {0};
+
+	key.ddbk_idx = 4;
+	d_iov_set(&key.ddbk_key, key_buf, ARRAY_SIZE(key_buf));
+
+	ddb_print_key(&ctx, &key, 2);
+
+	/* empty large key */
+	assert_str_exact("\t\t[4] '' (1024)\n");
+	dvt_fake_print_reset();
+
+	/* Large key buffer, but only part is text */
+	strcpy(key_buf, "string key");
+	ddb_print_key(&ctx, &key, 0);
+	assert_str_exact("[4] 'string key' (1024)\n");
+	dvt_fake_print_reset();
+
+	/* No ending '\0' */
+	strcpy(key_buf, "abcdefghijklmnopqrstuvwxyz");
+	key.ddbk_key.iov_len = 5;
+	ddb_print_key(&ctx, &key, 0);
+	assert_str_exact("[4] 'abcde' (5)\n");
+	dvt_fake_print_reset();
+
+	/* With ending '\0' in middle ... only prints to null terminator */
+	strcpy(key_buf, "abcdefghijklmnopqrstuvwxyz");
+	key_buf[10] = '\0';
+	key.ddbk_key.iov_len = 26;
+	ddb_print_key(&ctx, &key, 0);
+	assert_str_exact("[4] 'abcdefghij' (26)\n");
+	dvt_fake_print_reset();
+
+	/*
+	 * Print binary keys.
+	 * If key length is a number type, then print as that.
+	 */
+	memset(key_buf, 0, ARRAY_SIZE(key_buf));
+
+	/* char key */
+	key_buf[0] = 0xab;
+	key.ddbk_key.iov_len = sizeof(char);
+	ddb_print_key(&ctx, &key, 0);
+	assert_str_exact("[4] '{uint8:0xab}'\n");
+	dvt_fake_print_reset();
+
+	/* short key */
+	*((short *)key_buf) = 0xabcd;
+	key.ddbk_key.iov_len = sizeof(short);
+	ddb_print_key(&ctx, &key, 0);
+	assert_str_exact("[4] '{uint16:0xabcd}'\n");
+	dvt_fake_print_reset();
+
+	/* int key */
+	*((int *)key_buf) = 0x1234abcd;
+	key.ddbk_key.iov_len = sizeof(int);
+	ddb_print_key(&ctx, &key, 0);
+	assert_str_exact("[4] '{uint32:0x1234abcd}'\n");
+	dvt_fake_print_reset();
+
+	/* 64 bit key */
+	*((uint64_t *)key_buf) = 0x1abc2abc3abc4abc;
+	key.ddbk_key.iov_len = sizeof(uint64_t);
+	ddb_print_key(&ctx, &key, 0);
+	assert_str_exact("[4] '{uint64:0x1abc2abc3abc4abc}'\n");
+	dvt_fake_print_reset();
+
+	/* random length binary key */
+	*((uint64_t *)key_buf) = 0x1abc2abc3abc4abc;
+	key_buf[0] = 0xaa;
+	key_buf[1] = 0xbb;
+	key_buf[2] = 0xcc;
+
+	key.ddbk_key.iov_len = 3;
+	ddb_print_key(&ctx, &key, 0);
+	assert_str_exact("[4] '{bin(3):0xaabbcc}'\n");
+	dvt_fake_print_reset();
+
+	set_key_buf(&key, 12);
+	ddb_print_key(&ctx, &key, 0);
+	assert_str_exact("[4] '{bin(12):0x0102030405060708090a0b0c}'\n");
+	dvt_fake_print_reset();
+
+	set_key_buf(&key, 128);
+	ddb_print_key(&ctx, &key, 0);
+	assert_str_exact("[4] '{bin(128):0x0102030405...0c0d0e0f10}'\n");
+	dvt_fake_print_reset();
+}
+
+static void
+print_sv_test(void **state)
+{
+	struct ddb_sv sv = {.ddbs_record_size = 19089555};
+
+	ddb_print_sv(&ctx, &sv, 1);
+	assert_str_exact("\t[0] Single Value (Length: 19089555 bytes)\n");
+}
+
+static void
+print_array_test(void **state)
+{
+	struct ddb_array array = {
+		.ddba_recx.rx_idx = 64,
+		.ddba_recx.rx_nr = 128,
+		.ddba_record_size = 3,
+		.ddba_idx = 8,
+	};
+
+	ddb_print_array(&ctx, &array, 2);
+	assert_str_exact("\t\t[8] Array Value (Length: 128 records, "
+		   "Record Indexes: {64-191}, Record Size: 3)\n");
+}
+
+#define assert_hr_bytes(expected_str, bytes) \
+	do { \
+		uint32_t __buf_len = 32; \
+		char __buf[__buf_len]; \
+	ddb_bytes_hr(bytes, __buf, __buf_len); \
+	assert_string_equal(expected_str, __buf); \
+	} while (0)
+
+static void
+bytes_hr_tests(void **state)
+{
+	assert_hr_bytes("1KB", 1024);
+	assert_hr_bytes("1KB", 1025);
+	assert_hr_bytes("1KB", 1025);
+	assert_hr_bytes("1KB", 1024 + 50);
+	assert_hr_bytes("2KB", 1024 * 2);
+	assert_hr_bytes("1MB", 1024 * 1024);
+	assert_hr_bytes("1GB", 1024 * 1024 * 1024);
+	assert_hr_bytes("1TB", 0x10000000000);
+}
+
+static void
+print_superblock_test(void **state)
+{
+	struct ddb_superblock sb = {
+		.dsb_scm_sz = 0x100000000, /* 4 GB */
+		.dsb_nvme_sz = 0x40000000000, /* 4 TB */
+		.dsb_cont_nr = 2,
+		.dsb_durable_format_version = 23,
+		.dsb_blk_sz = 4096,
+		.dsb_hdr_blks = 1024,
+		.dsb_tot_blks = 0x40000000000,
+	};
+
+	uuid_parse("12345678-1234-1234-1234-123456789012", sb.dsb_id);
+
+	ddb_print_superblock(&ctx, &sb);
+
+	assert_str("Pool UUID: 12345678-1234-1234-1234-123456789012\n");
+	assert_str("Format Version: 23\n");
+	assert_str("Containers: 2\n");
+	assert_str("SCM Size: 4GB\n");
+	assert_str("NVME Size: 4TB\n");
+	assert_str("Block Size: 4KB\n");
+	assert_str("Reserved Blocks: 1024\n");
+	assert_str("Block Device Capacity: 4TB\n");
+}
+
+static void
+print_ilog_test(void **state)
+{
+	struct ddb_ilog_entry ilog = {
+		.die_status = 1,
+		.die_status_str = "TEST STATUS",
+		.die_epoch = 1234567890,
+		.die_idx = 1,
+		.die_tx_id = 2
+	};
+
+	ddb_print_ilog_entry(&ctx, &ilog);
+
+	assert_str_exact("Index: 1\n"
+			 "Status: TEST STATUS (1)\n"
+			 "Epoch: 1234567890\n"
+			 "Txn ID: 2\n");
+}
+
+static void
+print_dtx_active(void **state)
+{
+	struct dv_dtx_active_entry entry = {
+		.ddtx_uuid = {0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc},
+		.ddtx_reindex = false,
+		.ddtx_exist = true,
+		.ddtx_invalid = false,
+		.ddtx_handle_time = 12345690,
+		.ddtx_epoch = 99,
+		.ddtx_oid_cnt = 1,
+		.ddtx_start_time = 489387371,
+		.ddtx_committable = true,
+		.ddtx_committed = false,
+		.ddtx_aborted = false,
+		.ddtx_maybe_shared = true,
+		.ddtx_prepared = true,
+		.ddtx_grp_cnt = 3,
+		.ddtx_ver = 1,
+		.ddtx_rec_cnt = 1,
+		.ddtx_mbs_flags = 1,
+		.ddtx_flags = 0,
+		.ddtx_oid = g_oids[0],
+	};
+
+	ddb_print_dtx_active(&ctx, &entry);
+
+	assert_str("UUID: 12345678-9abc-0000-0000-000000000000\n");
+	assert_str("Epoch: 99\n");
+	assert_str("Exist: true\n");
+	assert_str("Invalid: false\n");
+	assert_str("Reindex: false\n");
+	assert_str("Handle Time: 12345690\n");
+	assert_str("Oid Cnt: 1\n");
+	assert_str("Start Time: 489387371\n");
+	assert_str("Committable: true\n");
+	assert_str("Committed: false\n");
+	assert_str("Aborted: false\n");
+	assert_str("Maybe Shared: true\n");
+	assert_str("Prepared: true\n");
+	assert_str("Grp Cnt: 3\n");
+	assert_str("Ver: 1\n");
+	assert_str("Rec Cnt: 1\n");
+	assert_str("Mbs Flags: 1\n");
+	assert_str("Flags: 0\n");
+	assert_str("Oid: 281479271743488.4294967296.0\n");
+}
+
+static void
+print_dtx_committed(void **state)
+{
+	struct dv_dtx_committed_entry entry = {
+		.ddtx_epoch = 1234,
+		.ddtx_exist = true,
+		.ddtx_invalid = false,
+		.ddtx_uuid = {0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc},
+	};
+
+	ddb_print_dtx_committed(&ctx, &entry);
+
+	assert_str("UUID: 12345678-9abc-0000-0000-000000000000\n");
+	assert_str("Epoch: 1234\n");
+	assert_str("Exist: true\n");
+	assert_str("Invalid: false\n");
+}
+
+static int
+ddb_print_setup(void **state)
+{
+	dvt_fake_print_reset();
+	return 0;
+}
+
+#define TEST(x) { #x, x, ddb_print_setup, NULL }
+static const struct CMUnitTest tests[] = {
+	TEST(print_container_test),
+	TEST(print_object_test),
+	TEST(print_key_test),
+	TEST(print_sv_test),
+	TEST(print_array_test),
+	TEST(bytes_hr_tests),
+	TEST(print_superblock_test),
+	TEST(print_ilog_test),
+	TEST(print_dtx_active),
+	TEST(print_dtx_committed),
+};
+
+int
+ddb_commands_print_tests_run()
+{
+	return cmocka_run_group_tests_name("ddb commands printer", tests, NULL, NULL);
+}

--- a/src/ddb/tests/ddb_commands_print_tests.c
+++ b/src/ddb/tests/ddb_commands_print_tests.c
@@ -102,32 +102,34 @@ print_key_test(void **state)
 	dvt_fake_print_reset();
 
 	/* short key */
-	*((short *)key_buf) = 0xabcd;
+	short s = 0xabcd;
+	key.ddbk_key.iov_buf = (uint8_t *)&s;
 	key.ddbk_key.iov_len = sizeof(short);
 	ddb_print_key(&ctx, &key, 0);
 	assert_str_exact("[4] '{uint16:0xabcd}'\n");
 	dvt_fake_print_reset();
 
 	/* int key */
-	*((int *)key_buf) = 0x1234abcd;
+	int i = 0x1234abcd;
+	key.ddbk_key.iov_buf = (int *)&i;
 	key.ddbk_key.iov_len = sizeof(int);
 	ddb_print_key(&ctx, &key, 0);
 	assert_str_exact("[4] '{uint32:0x1234abcd}'\n");
 	dvt_fake_print_reset();
 
 	/* 64 bit key */
-	*((uint64_t *)key_buf) = 0x1abc2abc3abc4abc;
+	uint64_t ll = 0x1abc2abc3abc4abc;
+	key.ddbk_key.iov_buf = (uint64_t *)&ll;
 	key.ddbk_key.iov_len = sizeof(uint64_t);
 	ddb_print_key(&ctx, &key, 0);
 	assert_str_exact("[4] '{uint64:0x1abc2abc3abc4abc}'\n");
 	dvt_fake_print_reset();
 
 	/* random length binary key */
-	*((uint64_t *)key_buf) = 0x1abc2abc3abc4abc;
 	key_buf[0] = 0xaa;
 	key_buf[1] = 0xbb;
 	key_buf[2] = 0xcc;
-
+	key.ddbk_key.iov_buf = key_buf;
 	key.ddbk_key.iov_len = 3;
 	ddb_print_key(&ctx, &key, 0);
 	assert_str_exact("[4] '{bin(3):0xaabbcc}'\n");

--- a/src/ddb/tests/ddb_commands_tests.c
+++ b/src/ddb/tests/ddb_commands_tests.c
@@ -312,20 +312,20 @@ dcv_suit_teardown(void **state)
 }
 
 #define TEST(test) { #test, test, NULL, NULL }
-static const struct CMUnitTest tests[] = {
-	TEST(quit_cmd_tests),
-	TEST(ls_cmd_tests),
-	TEST(dump_value_cmd_tests),
-	TEST(dump_ilog_cmd_tests),
-	TEST(dump_superblock_cmd_tests),
-	TEST(dump_dtx_cmd_tests),
-	TEST(rm_cmd_tests),
-	TEST(load_cmd_tests),
-};
 
 int
 dvc_tests_run()
 {
+	const struct CMUnitTest tests[] = {
+		TEST(quit_cmd_tests),
+		TEST(ls_cmd_tests),
+		TEST(dump_value_cmd_tests),
+		TEST(dump_ilog_cmd_tests),
+		TEST(dump_superblock_cmd_tests),
+		TEST(dump_dtx_cmd_tests),
+		TEST(rm_cmd_tests),
+		TEST(load_cmd_tests),
+	};
 	return cmocka_run_group_tests_name("DDB commands tests", tests,
 					   dcv_suit_setup, dcv_suit_teardown);
 }

--- a/src/ddb/tests/ddb_commands_tests.c
+++ b/src/ddb/tests/ddb_commands_tests.c
@@ -17,18 +17,20 @@
  * functions in a command function table that the program uses.
  */
 
-static uint32_t fake_print_called;
-static char fake_print_buffer[1024];
-int fake_print(const char *fmt, ...)
-{
-	va_list args;
+struct ddb_ctx g_ctx = {
+	.dc_io_ft.ddb_print_message = dvt_fake_print,
+	.dc_io_ft.ddb_print_error = dvt_fake_print,
+	.dc_io_ft.ddb_read_file = dvt_fake_read_file,
+	.dc_io_ft.ddb_get_file_size = dvt_fake_get_file_size,
+	.dc_io_ft.ddb_get_file_exists = dvt_fake_get_file_exists,
 
-	fake_print_called++;
-	va_start(args, fmt);
-	vsnprintf(fake_print_buffer, ARRAY_SIZE(fake_print_buffer), fmt, args);
-	va_end(args);
-	if (g_verbose)
-		printf("%s", fake_print_buffer);
+};
+
+static uint32_t fake_write_file_called;
+static int
+fake_write_file(const char *path, d_iov_t *contents)
+{
+	fake_write_file_called++;
 
 	return 0;
 }
@@ -39,46 +41,239 @@ int fake_print(const char *fmt, ...)
  * -----------------------------------------------
  */
 static void
-test_quit(void **state)
+quit_cmd_tests(void **state)
 {
-	struct ddb_ctx		 ctx = {0};
-
 	/* Quit is really simple and should just indicate to the program context that it's
 	 * time to quit
 	 */
-	assert_success(ddb_run_quit(&ctx));
-	assert_true(ctx.dc_should_quit);
+	assert_success(ddb_run_quit(&g_ctx));
+	assert_true(g_ctx.dc_should_quit);
 }
 
 static void
-test_ls(void **state)
+ls_cmd_tests(void **state)
 {
 	struct dt_vos_pool_ctx	*tctx = *state;
 	struct ddb_ctx		 ctx = {0};
 	struct ls_options	 opt = {.recursive = false, .path = ""};
 	int			 items_in_tree;
+	char			 buf[256];
 
 	ctx.dc_poh = tctx->dvt_poh;
-	ctx.dc_io_ft.ddb_print_message = fake_print;
-	ctx.dc_io_ft.ddb_print_error = fake_print;
+	ctx.dc_io_ft.ddb_print_message = dvt_fake_print;
+	ctx.dc_io_ft.ddb_print_error = dvt_fake_print;
 	assert_success(ddb_run_ls(&ctx, &opt));
 
 	/* At least each container should be printed */
-	assert_true(ARRAY_SIZE(g_uuids) <= fake_print_called);
+	assert_true(ARRAY_SIZE(g_uuids) <= dvt_fake_print_called);
 
 	/* With recursive set, every item in the tree should be printed */
 	opt.recursive = true;
 	items_in_tree = ARRAY_SIZE(g_uuids) * ARRAY_SIZE(g_oids) *
 			ARRAY_SIZE(g_dkeys) * ARRAY_SIZE(g_akeys);
-	fake_print_called = 0;
+	dvt_fake_print_called = 0;
 	assert_success(ddb_run_ls(&ctx, &opt));
-	assert_true(items_in_tree <= fake_print_called);
+	assert_true(items_in_tree <= dvt_fake_print_called);
 
 	/* pick a specific oid - each dkey should be printed */
 	opt.path = "[0]/[0]";
 	opt.recursive = false;
 	assert_success(ddb_run_ls(&ctx, &opt));
-	assert_true(ARRAY_SIZE(g_dkeys) <= fake_print_called);
+	assert_true(ARRAY_SIZE(g_dkeys) <= dvt_fake_print_called);
+
+	/* invalid paths ... */
+	opt.path = buf;
+
+	sprintf(buf, "%s", g_invalid_uuid_str);
+	assert_rc_equal(-DER_NONEXIST, ddb_run_ls(&ctx, &opt));
+	sprintf(buf, "%s/"DF_OID"/", g_uuids_str[0], DP_OID(g_invalid_oid.id_pub));
+	assert_rc_equal(-DER_NONEXIST, ddb_run_ls(&ctx, &opt));
+}
+
+static void
+dump_value_cmd_tests(void **state)
+{
+	struct dt_vos_pool_ctx		*tctx = *state;
+	struct ddb_ctx			 ctx = {0};
+	struct dump_value_options	 opt = {0};
+
+	ctx.dc_io_ft.ddb_print_message = dvt_fake_print;
+	ctx.dc_io_ft.ddb_print_error = dvt_fake_print;
+	ctx.dc_io_ft.ddb_write_file = fake_write_file;
+	ctx.dc_poh = tctx->dvt_poh;
+
+	/* requires a path to dump */
+	assert_rc_equal(-DER_INVAL, ddb_run_dump_value(&ctx, &opt));
+
+	/* path must be complete (to a value) */
+	opt.path = "[0]";
+	assert_rc_equal(-DER_INVAL, ddb_run_dump_value(&ctx, &opt));
+
+	/* Path is complete, but needs destination */
+	opt.path = "[0]/[0]/[0]/[1]";
+	assert_rc_equal(-DER_INVAL, ddb_run_dump_value(&ctx, &opt));
+
+	/* success */
+	opt.dst = "/tmp/dumped_file";
+	assert_success(ddb_run_dump_value(&ctx, &opt));
+	assert_true(fake_write_file_called >= 1);
+}
+
+static void
+dump_ilog_cmd_tests(void **state)
+{
+	struct dt_vos_pool_ctx		*tctx = *state;
+	struct ddb_ctx			 ctx = {0};
+	struct dump_ilog_options	 opt = {0};
+
+	ctx.dc_io_ft.ddb_print_message = dvt_fake_print;
+	ctx.dc_io_ft.ddb_print_error = dvt_fake_print;
+	ctx.dc_io_ft.ddb_write_file = fake_write_file;
+	ctx.dc_poh = tctx->dvt_poh;
+
+	assert_rc_equal(-DER_INVAL, ddb_run_dump_ilog(&ctx, &opt));
+
+	/* Dump object ilog */
+	dvt_fake_print_called = 0;
+	opt.path = "[0]/[0]";
+	assert_success(ddb_run_dump_ilog(&ctx, &opt));
+	assert_true(dvt_fake_print_called);
+
+	/* Dump dkey ilog */
+	dvt_fake_print_called = 0;
+	opt.path = "[0]/[0]/[0]";
+	assert_success(ddb_run_dump_ilog(&ctx, &opt));
+	assert_true(dvt_fake_print_called);
+
+	opt.path = "[0]/[0]/[0]/[0]";
+	assert_rc_equal(-DER_INVAL, ddb_run_dump_ilog(&ctx, &opt));
+}
+
+static void
+dump_superblock_cmd_tests(void **state)
+{
+	struct dt_vos_pool_ctx	*tctx = *state;
+	struct ddb_ctx		 ctx = {0};
+
+	ctx.dc_io_ft.ddb_print_message = dvt_fake_print;
+	ctx.dc_poh = tctx->dvt_poh;
+
+	ddb_run_dump_superblock(&ctx);
+
+	assert_true(dvt_fake_print_called >= 1); /* Should have printed at least once */
+}
+
+static void
+dump_dtx_cmd_tests(void **state)
+{
+	struct dt_vos_pool_ctx	*tctx = *state;
+	struct ddb_ctx		 ctx = {0};
+	struct dump_dtx_options	 opt = {0};
+	daos_handle_t		 coh;
+
+	dvt_fake_print_reset();
+
+	ctx.dc_io_ft.ddb_print_message = dvt_fake_print;
+	ctx.dc_io_ft.ddb_print_error = dvt_fake_print;
+	ctx.dc_poh = tctx->dvt_poh;
+
+	assert_rc_equal(-DER_INVAL, ddb_run_dump_dtx(&ctx, &opt));
+
+	assert_success(vos_cont_open(tctx->dvt_poh, g_uuids[0], &coh));
+
+	dvt_vos_insert_2_records_with_dtx(coh);
+	vos_cont_close(coh);
+
+	opt.path = "[0]";
+	assert_success(ddb_run_dump_dtx(&ctx, &opt));
+
+	assert_string_contains(dvt_fake_print_buffer, "Active Transactions:");
+	assert_string_contains(dvt_fake_print_buffer, "Committed Transactions:");
+}
+
+static void
+rm_cmd_tests(void **state)
+{
+	struct dt_vos_pool_ctx	*tctx = *state;
+	struct ddb_ctx		 ctx = {0};
+	struct rm_options	 opt = {0};
+
+	ctx.dc_poh = tctx->dvt_poh;
+	ctx.dc_io_ft.ddb_print_message = dvt_fake_print;
+	ctx.dc_io_ft.ddb_print_error = dvt_fake_print;
+
+	assert_rc_equal(-DER_INVAL, ddb_run_rm(&ctx, &opt));
+
+	dvt_fake_print_reset();
+	opt.path = "[0]";
+	assert_success(ddb_run_rm(&ctx, &opt));
+	assert_string_equal(dvt_fake_print_buffer,
+			    "/12345678-1234-1234-1234-123456789001 deleted\n");
+}
+
+static void
+load_cmd_tests(void **state)
+{
+	struct load_options	opt = {0};
+	char			buf[256];
+	daos_unit_oid_t		new_oid = g_oids[0];
+
+	assert_rc_equal(-DER_INVAL, ddb_run_load(&g_ctx, &opt));
+
+	opt.dst = "/[0]/[0]/[0]/[1]";
+	opt.src = "/tmp/value_src";
+	opt.epoch = "1";
+	dvt_fake_get_file_exists_result = true;
+	snprintf(dvt_fake_read_file_buf, ARRAY_SIZE(dvt_fake_read_file_buf), "Some text");
+	assert_rc_equal(-DER_INVAL, ddb_run_load(&g_ctx, &opt));
+	dvt_fake_get_file_size_result = strlen(dvt_fake_read_file_buf);
+	dvt_fake_read_file_result = strlen(dvt_fake_read_file_buf);
+	assert_success(ddb_run_load(&g_ctx, &opt));
+
+	/* add a new 'a' key */
+	opt.dst = "/[0]/[0]/[0]/'a-new-key'";
+	assert_success(ddb_run_load(&g_ctx, &opt));
+
+	/* add a new 'd' key */
+	opt.dst = "/[0]/[0]/'a-new-key'/'a-new-key'";
+	assert_success(ddb_run_load(&g_ctx, &opt));
+
+	/*
+	 * Error cases ...
+	 */
+
+	/* File not found */
+	dvt_fake_get_file_exists_result = false;
+	assert_rc_equal(-DER_INVAL, ddb_run_load(&g_ctx, &opt));
+	dvt_fake_get_file_exists_result = true;
+
+	/* invalid epoch */
+	opt.epoch = "a";
+	assert_rc_equal(-DER_INVAL, ddb_run_load(&g_ctx, &opt));
+	opt.epoch = "1a";
+	assert_rc_equal(-DER_INVAL, ddb_run_load(&g_ctx, &opt));
+	opt.epoch = "1";
+
+	/* incomplete path */
+	opt.dst = "/[0]/[0]/";
+	assert_rc_equal(-DER_INVAL, ddb_run_load(&g_ctx, &opt));
+
+	/* Can't use index for a new path */
+	opt.dst = "/[0]/[0]/[0]/[9999]";
+	assert_rc_equal(-DER_NONEXIST, ddb_run_load(&g_ctx, &opt));
+
+	/* can't create new container */
+	sprintf(buf, "%s/"DF_OID"/'dkey_new'/'akey_new'", g_invalid_uuid_str,
+		DP_OID(g_oids[0].id_pub));
+	opt.dst = buf;
+	assert_rc_equal(-DER_NONEXIST, ddb_run_load(&g_ctx, &opt));
+
+	/* can't create new object */
+	new_oid.id_pub.lo = 999;
+	sprintf(buf, "%s/"DF_OID"/'dkey_new'/'akey_new'", g_uuids_str[0],
+		DP_OID(new_oid.id_pub));
+	opt.dst = buf;
+	assert_rc_equal(-DER_NONEXIST, ddb_run_load(&g_ctx, &opt));
 }
 
 /*
@@ -98,6 +293,8 @@ dcv_suit_setup(void **state)
 	tctx = *state;
 	assert_success(vos_pool_open(tctx->dvt_pmem_file, tctx->dvt_pool_uuid, 0, &tctx->dvt_poh));
 
+	g_ctx.dc_poh = tctx->dvt_poh;
+
 	return 0;
 }
 
@@ -106,17 +303,24 @@ dcv_suit_teardown(void **state)
 {
 	struct dt_vos_pool_ctx *tctx = *state;
 
-	dvt_delete_all_containers(tctx->dvt_poh);
+	if (tctx == NULL)
+		fail_msg("Test not setup correctly");
 	assert_success(vos_pool_close(tctx->dvt_poh));
 	ddb_teardown_vos(state);
 
 	return 0;
 }
 
-#define TEST(dsc, test) { dsc, test, NULL, NULL }
+#define TEST(test) { #test, test, NULL, NULL }
 static const struct CMUnitTest tests[] = {
-	TEST("01: quit", test_quit),
-	TEST("01: ls", test_ls),
+	TEST(quit_cmd_tests),
+	TEST(ls_cmd_tests),
+	TEST(dump_value_cmd_tests),
+	TEST(dump_ilog_cmd_tests),
+	TEST(dump_superblock_cmd_tests),
+	TEST(dump_dtx_cmd_tests),
+	TEST(rm_cmd_tests),
+	TEST(load_cmd_tests),
 };
 
 int

--- a/src/ddb/tests/ddb_commands_tests.c
+++ b/src/ddb/tests/ddb_commands_tests.c
@@ -238,6 +238,13 @@ load_cmd_tests(void **state)
 	opt.dst = "/[0]/[0]/'a-new-key'/'a-new-key'";
 	assert_success(ddb_run_load(&g_ctx, &opt));
 
+	/* add a new object */
+	new_oid.id_pub.lo = 999;
+	sprintf(buf, "%s/"DF_OID"/'dkey_new'/'akey_new'", g_uuids_str[3],
+		DP_OID(new_oid.id_pub));
+	opt.dst = buf;
+	assert_success(ddb_run_load(&g_ctx, &opt));
+
 	/*
 	 * Error cases ...
 	 */
@@ -265,13 +272,6 @@ load_cmd_tests(void **state)
 	/* can't create new container */
 	sprintf(buf, "%s/"DF_OID"/'dkey_new'/'akey_new'", g_invalid_uuid_str,
 		DP_OID(g_oids[0].id_pub));
-	opt.dst = buf;
-	assert_rc_equal(-DER_NONEXIST, ddb_run_load(&g_ctx, &opt));
-
-	/* can't create new object */
-	new_oid.id_pub.lo = 999;
-	sprintf(buf, "%s/"DF_OID"/'dkey_new'/'akey_new'", g_uuids_str[0],
-		DP_OID(new_oid.id_pub));
 	opt.dst = buf;
 	assert_rc_equal(-DER_NONEXIST, ddb_run_load(&g_ctx, &opt));
 }

--- a/src/ddb/tests/ddb_main_tests.c
+++ b/src/ddb/tests/ddb_main_tests.c
@@ -51,13 +51,12 @@ static char *
 fake_get_input(char *buf, uint32_t buf_len)
 {
 	char *input;
-	uint32_t input_len;
 
 	assert_true(fake_get_input_inputs_idx < ARRAY_SIZE(fake_get_input_inputs));
 	input = fake_get_input_inputs[fake_get_input_inputs_idx++];
-	input_len = strlen(input) + 1;
+	assert_true(strlen(input) < buf_len);
 
-	strncpy(buf, input, min(input_len, buf_len));
+	strcpy(buf, input);
 	fake_get_input_called++;
 
 	return input;

--- a/src/ddb/tests/ddb_main_tests.c
+++ b/src/ddb/tests/ddb_main_tests.c
@@ -50,7 +50,10 @@ __set_fake_inputs(char *inputs[])
 static char *
 fake_get_input(char *buf, uint32_t buf_len)
 {
-	char *input = fake_get_input_inputs[fake_get_input_inputs_idx++];
+	char *input;
+
+	assert_true(fake_get_input_inputs_idx < ARRAY_SIZE(fake_get_input_inputs));
+	input = fake_get_input_inputs[fake_get_input_inputs_idx++];
 
 	strncpy(buf, input, min(strlen(input) + 1, buf_len));
 	fake_get_input_called++;
@@ -61,7 +64,6 @@ fake_get_input(char *buf, uint32_t buf_len)
 static int
 __test_run_main(char *argv[])
 {
-	struct argv_parsed	parse_args = {0};
 	uint32_t		argc = 0;
 	struct ddb_io_ft ft = {
 		.ddb_print_message = fake_print_message,
@@ -79,9 +81,6 @@ __test_run_main(char *argv[])
 	}
 	if (g_verbose)
 		printf("\n");
-
-	parse_args.ap_argv = argv;
-	parse_args.ap_argc = argc;
 
 	return ddb_main(&ft, argc, argv);
 }
@@ -102,7 +101,7 @@ __assert_main_interactive_with_input(char *inputs[])
  */
 
 static void
-test_interactive_mode(void **state)
+interactive_mode_tests(void **state)
 {
 	assert_main_interactive_with_input("quit");
 	assert_int_equal(1, fake_get_input_called);
@@ -121,14 +120,13 @@ test_interactive_mode(void **state)
  *   - pool shard file is passed as argument
  */
 
-#define TEST(dsc, test) { dsc, test, NULL, NULL }
-
-static const struct CMUnitTest tests[] = {
-	TEST("Interactive mode asks for input until 'quit'", test_interactive_mode),
-};
-
+#define TEST(x) { #x, x, NULL, NULL }
 int
 ddb_main_tests()
 {
+	static const struct CMUnitTest tests[] = {
+		TEST(interactive_mode_tests),
+	};
+
 	return cmocka_run_group_tests_name("DDB CLI tests", tests, NULL, NULL);
 }

--- a/src/ddb/tests/ddb_main_tests.c
+++ b/src/ddb/tests/ddb_main_tests.c
@@ -51,11 +51,13 @@ static char *
 fake_get_input(char *buf, uint32_t buf_len)
 {
 	char *input;
+	uint32_t input_len;
 
 	assert_true(fake_get_input_inputs_idx < ARRAY_SIZE(fake_get_input_inputs));
 	input = fake_get_input_inputs[fake_get_input_inputs_idx++];
+	input_len = strlen(input) + 1;
 
-	strncpy(buf, input, min(strlen(input) + 1, buf_len));
+	strncpy(buf, input, min(input_len, buf_len));
 	fake_get_input_called++;
 
 	return input;

--- a/src/ddb/tests/ddb_parse_tests.c
+++ b/src/ddb/tests/ddb_parse_tests.c
@@ -10,6 +10,12 @@
 #include "ddb_cmocka.h"
 #include "ddb_test_driver.h"
 
+static int
+fake_print(const char *fmt, ...)
+{
+	return 0;
+}
+
 #define assert_parsed_words2(str, count, ...) \
 	__assert_parsed_words2(str, count, (char *[])__VA_ARGS__)
 static void
@@ -45,7 +51,7 @@ assert_parsed_fail(const char *str)
  */
 
 static void
-test_string_to_argv(void **state)
+string_to_argv_tests(void **state)
 {
 	assert_parsed_words2("one", 1, { "one" });
 	assert_parsed_words2("one two", 2, {"one", "two"});
@@ -67,8 +73,12 @@ static int
 _assert_invalid_program_args(uint32_t argc, char **argv)
 {
 	struct program_args	pa;
+	struct ddb_ctx		ctx = {
+		.dc_io_ft.ddb_print_message = fake_print,
+		.dc_io_ft.ddb_print_error = fake_print
+	};
 
-	return ddb_parse_program_args(argc, argv, &pa);
+	return ddb_parse_program_args(&ctx, argc, argv, &pa);
 }
 
 #define assert_program_args(expected_program_args, argc, ...) \
@@ -76,10 +86,14 @@ _assert_invalid_program_args(uint32_t argc, char **argv)
 static int
 _assert_program_args(struct program_args *expected_pa, uint32_t argc, char **argv)
 {
-	struct program_args pa = {0};
-	int rc;
+	struct program_args	pa = {0};
+	int			rc;
+	struct ddb_ctx		ctx = {
+		.dc_io_ft.ddb_print_message = fake_print,
+		.dc_io_ft.ddb_print_error = fake_print
+	};
 
-	rc = ddb_parse_program_args(argc, argv, &pa);
+	rc = ddb_parse_program_args(&ctx, argc, argv, &pa);
 	if (rc != 0)
 		return rc;
 
@@ -100,7 +114,7 @@ _assert_program_args(struct program_args *expected_pa, uint32_t argc, char **arg
 }
 
 static void
-test_parse_args(void **state)
+parse_args_tests(void **state)
 {
 	struct program_args pa = {0};
 
@@ -130,20 +144,22 @@ do { \
 					a.vtp_path.vtp_dkey.iov_len); \
 	assert_int_equal(a.vtp_path.vtp_akey.iov_len, b.vtp_path.vtp_akey.iov_len); \
 	if (a.vtp_path.vtp_akey.iov_len > 0) \
-		assert_memory_equal(a.vtp_path.vtp_akey.iov_buf, b.vtp_path.vtp_akey.iov_buf,\
+		assert_memory_equal(a.vtp_path.vtp_akey.iov_buf, b.vtp_path.vtp_akey.iov_buf, \
 					a.vtp_path.vtp_akey.iov_len); \
 	} while (0)
 
 #define assert_invalid_path(path) \
 do { \
 	struct dv_tree_path_builder __vt = {0}; \
-	assert_rc_equal(-DER_INVAL, ddb_vtp_init(path, &__vt)); \
+		daos_handle_t poh = {0}; \
+		assert_rc_equal(-DER_INVAL, ddb_vtp_init(poh, path, &__vt)); \
 } while (0)
 
 #define assert_path(path, expected) \
 do { \
 	struct dv_tree_path_builder __vt = {0}; \
-	assert_success(ddb_vtp_init(path, &__vt)); \
+	daos_handle_t poh = {0}; \
+	assert_success(ddb_vtp_init(poh, path, &__vt)); \
 	assert_vtp_eq(expected, __vt); \
 	ddb_vtp_fini(&__vt); \
 } while (0)
@@ -166,23 +182,19 @@ iov_alloc_str(d_iov_t *iov, const char *str)
 }
 
 static void
-test_vos_path_parse(void **state)
+vos_path_parse_tests(void **state)
 {
 	struct dv_tree_path_builder expected_vt = {0};
-	daos_obj_id_t oid;
 
 	ddb_vos_tree_path_setup(&expected_vt);
 
 	/* empty paths are valid */
 	assert_path("", expected_vt);
-	assert_path(NULL, expected_vt);
 
 	/* first part must be a valid uuid */
 	assert_invalid_path("12345678");
 
 	uuid_parse("12345678-1234-1234-1234-123456789012", expected_vt.vtp_path.vtp_cont);
-	oid.lo = 1234;
-	oid.hi = 4321;
 
 	/* handle just container */
 	assert_path("12345678-1234-1234-1234-123456789012", expected_vt);
@@ -199,23 +211,26 @@ test_vos_path_parse(void **state)
 
 	/* handle dkey */
 	iov_alloc_str(&expected_vt.vtp_path.vtp_dkey, "dkey");
-	assert_path("/12345678-1234-1234-1234-123456789012/4321.1234/dkey", expected_vt);
-	assert_path("/12345678-1234-1234-1234-123456789012/4321.1234/dkey/", expected_vt);
+	assert_invalid_path("/12345678-1234-1234-1234-123456789012/4321.1234/dkey");
+	assert_path("/12345678-1234-1234-1234-123456789012/4321.1234/'dkey'", expected_vt);
+	assert_path("/12345678-1234-1234-1234-123456789012/4321.1234/'dkey'/", expected_vt);
 
 	iov_alloc_str(&expected_vt.vtp_path.vtp_akey, "akey");
-	assert_path("/12345678-1234-1234-1234-123456789012/4321.1234/dkey/akey", expected_vt);
-	assert_path("/12345678-1234-1234-1234-123456789012/4321.1234/dkey/akey/", expected_vt);
+	assert_invalid_path("/12345678-1234-1234-1234-123456789012/4321.1234/'dkey'/akey");
+	assert_path("/12345678-1234-1234-1234-123456789012/4321.1234/'dkey'/'akey'", expected_vt);
+	assert_path("/12345678-1234-1234-1234-123456789012/4321.1234/'dkey'/'akey'/", expected_vt);
 
 	expected_vt.vtp_path.vtp_recx.rx_idx = 1;
 	expected_vt.vtp_path.vtp_recx.rx_nr = 5;
-	assert_path("/12345678-1234-1234-1234-123456789012/4321.1234/dkey/akey/{1-6}", expected_vt);
+	assert_path("/12345678-1234-1234-1234-123456789012/4321.1234/'dkey'/'akey'/{1-6}",
+		    expected_vt);
 
 	daos_iov_free(&expected_vt.vtp_path.vtp_dkey);
 	daos_iov_free(&expected_vt.vtp_path.vtp_akey);
 }
 
 static void
-test_parse_idx(void **state)
+parse_idx_tests(void **state)
 {
 	struct dv_tree_path_builder expected_vt = {0};
 
@@ -240,7 +255,7 @@ test_parse_idx(void **state)
 }
 
 static void
-test_has_parts(void **state)
+has_parts_tests(void **state)
 {
 	struct dv_tree_path vtp = {0};
 
@@ -261,24 +276,23 @@ test_has_parts(void **state)
 	assert_true(dv_has_akey(&vtp));
 }
 
-#define TEST(dsc, test) { dsc, test, NULL, NULL }
-
-static const struct CMUnitTest tests[] = {
-	TEST("01: string to argv", test_string_to_argv),
-	TEST("03: parse program arguments", test_parse_args),
-	TEST("04: parse a vos path", test_vos_path_parse),
-	TEST("05: parse a vos path with indexes", test_parse_idx),
-	TEST("06: check to see if the path has parts", test_has_parts)
-};
 
 /*
  * -----------------------------------------------
  * Execute
  * -----------------------------------------------
  */
+#define TEST(x) {#x, x, NULL, NULL}
 int
 ddb_parse_tests_run()
 {
+	static const struct CMUnitTest tests[] = {
+		TEST(string_to_argv_tests),
+		TEST(parse_args_tests),
+		TEST(vos_path_parse_tests),
+		TEST(parse_idx_tests),
+		TEST(has_parts_tests)
+	};
 	return cmocka_run_group_tests_name("DDB helper parsing function tests", tests,
 					   NULL, NULL);
 }

--- a/src/ddb/tests/ddb_parse_tests.c
+++ b/src/ddb/tests/ddb_parse_tests.c
@@ -230,6 +230,27 @@ vos_path_parse_tests(void **state)
 }
 
 static void
+vos_path_parse_and_print_tests(void **state)
+{
+	struct dv_tree_path_builder	 vt = {0};
+	daos_handle_t			 poh = {0};
+	struct ddb_ctx			 ctx = {0};
+	char				*path;
+
+	path = "/12435678-1234-1234-1234-124356789012/1234.4321.0/'akey'/'dkey'";
+
+	ctx.dc_io_ft.ddb_print_message = dvt_fake_print;
+
+	assert_success(ddb_vtp_init(poh, path, &vt));
+
+	vtp_print(&ctx, &vt.vtp_path, false);
+
+	assert_string_equal(path, dvt_fake_print_buffer);
+
+	ddb_vtp_fini(&vt);
+}
+
+static void
 parse_idx_tests(void **state)
 {
 	struct dv_tree_path_builder expected_vt = {0};
@@ -290,6 +311,7 @@ ddb_parse_tests_run()
 		TEST(string_to_argv_tests),
 		TEST(parse_args_tests),
 		TEST(vos_path_parse_tests),
+		TEST(vos_path_parse_and_print_tests),
 		TEST(parse_idx_tests),
 		TEST(has_parts_tests)
 	};

--- a/src/ddb/tests/ddb_smoke_tests.sh
+++ b/src/ddb/tests/ddb_smoke_tests.sh
@@ -17,7 +17,6 @@ function p() {
    fi
 }
 
-
 function pause() {
   echo -e "\e[1m\e[94m==> $*\e[0m"
   p
@@ -42,10 +41,47 @@ function run_cmd() {
 
 # create a vos file to connect to
 run_cmd ddb_tests -c
-
 vos_file=/mnt/daos/12345678-1234-1234-1234-123456789012/ddb_vos_test
+
+msg "'ls' commands"
 run_cmd ddb $vos_file -R 'ls'
 run_cmd ddb $vos_file -R 'ls 12345678-1234-1234-1234-123456789001'
 run_cmd ddb $vos_file -R 'ls [0]'
 run_cmd ddb $vos_file -R 'ls [0]/[1]'
-run_cmd ddb $vos_file -R 'ls -r'
+run_cmd ddb $vos_file -R 'ls [0]/[1] -r'
+
+msg "'dump' and 'load' commands"
+vos_path="[0]/[0]/[0]/[1]"
+echo 'echo "A New Value" > /tmp/ddb_new_value'
+echo "A New Value" > /tmp/ddb_new_value
+
+run_cmd ddb $vos_file -R "dump_value $vos_path /tmp/ddb_value_dump"
+run_cmd cat /tmp/ddb_value_dump
+run_cmd ddb $vos_file -R "dump_value [0]/[0]/[0]/[0]/[0] /tmp/ddb_value_dump"
+run_cmd cat /tmp/ddb_value_dump
+
+run_cmd ddb $vos_file -R "load /tmp/ddb_new_value $vos_path 2"
+run_cmd ddb $vos_file -R "dump_value $vos_path /tmp/ddb_value_dump"
+run_cmd cat /tmp/ddb_value_dump
+run_cmd diff /tmp/ddb_new_value /tmp/ddb_value_dump
+
+msg "'load' to new key"
+vos_path="[0]/[0]/[0]/\'new_new_new_new_key\'"
+
+run_cmd ddb $vos_file -R "load /tmp/ddb_new_value $vos_path 1"
+run_cmd ddb $vos_file -R "dump_value $vos_path /tmp/ddb_value_dump"
+run_cmd cat /tmp/ddb_value_dump
+run_cmd ddb $vos_file -R 'ls [0]/[0]/[0] -r'
+diff /tmp/ddb_new_value /tmp/ddb_value_dump
+
+msg "'superblock', 'ilog' and 'dtx' dumps"
+run_cmd ddb $vos_file -R 'dump_superblock'
+run_cmd ddb $vos_file -R 'dump_ilog [0]/[0]'
+run_cmd ddb $vos_file -R 'dump_ilog [0]/[0]/[0]'
+
+run_cmd ddb $vos_file -R 'dump_dtx [0]'
+
+msg "'rm'"
+run_cmd ddb $vos_file -R 'ls'
+run_cmd ddb $vos_file -R 'rm [1]'
+run_cmd ddb $vos_file -R 'ls'

--- a/src/ddb/tests/ddb_test_driver.c
+++ b/src/ddb/tests/ddb_test_driver.c
@@ -132,6 +132,10 @@ dvt_vos_insert_single(daos_handle_t coh, daos_unit_oid_t uoid, char *dkey_str, c
 /*
  * These tests look at and verify how the ddb types are printed.
  */
+
+uint32_t dvt_fake_print_called;
+char dvt_fake_print_buffer[1024];
+
 int
 dvt_fake_print(const char *fmt, ...)
 {
@@ -155,17 +159,24 @@ void dvt_fake_print_reset(void)
 	memset(dvt_fake_print_buffer, 0, ARRAY_SIZE(dvt_fake_print_buffer));
 }
 
+size_t dvt_fake_get_file_size_result;
+
 size_t
 dvt_fake_get_file_size(const char *path)
 {
 	return dvt_fake_get_file_size_result;
 }
 
+bool dvt_fake_get_file_exists_result;
+
 bool
 dvt_fake_get_file_exists(const char *path)
 {
 	return dvt_fake_get_file_exists_result;
 }
+
+size_t dvt_fake_read_file_result;
+char dvt_fake_read_file_buf[64];
 
 size_t
 dvt_fake_read_file(const char *src_path, d_iov_t *contents)

--- a/src/ddb/tests/ddb_test_driver.c
+++ b/src/ddb/tests/ddb_test_driver.c
@@ -61,7 +61,8 @@ char *g_akeys_str[] = {
 	"akey-9",
 	"akey-10",
 };
-char	*g_invalid_key_str = "invalid key";
+
+char *g_invalid_key_str = "invalid key";
 
 daos_unit_oid_t	g_oids[10];
 uuid_t		g_uuids[10];
@@ -307,7 +308,7 @@ dvt_iov_alloc_str(d_iov_t *iov, const char *str)
 
 static void
 create_object_data(daos_handle_t *coh, uint32_t obj_to_create, uint32_t dkeys_to_create,
-			uint32_t akeys_to_create, uint32_t recx_to_create)
+		   uint32_t akeys_to_create, uint32_t recx_to_create)
 {
 	int o, d, a, r; /* loop indexes */
 

--- a/src/ddb/tests/ddb_test_driver.c
+++ b/src/ddb/tests/ddb_test_driver.c
@@ -149,7 +149,7 @@ dvt_fake_print(const char *fmt, ...)
 	vsnprintf(dvt_fake_print_buffer + buffer_offset, buffer_left, fmt, args);
 	va_end(args);
 	if (g_verbose)
-		printf("%s", dvt_fake_print_buffer);
+		printf("%s", dvt_fake_print_buffer + buffer_offset);
 
 	return 0;
 }
@@ -374,7 +374,6 @@ dvt_insert_data(daos_handle_t poh, uint32_t conts, uint32_t objs, uint32_t dkeys
 	}
 }
 
-
 static void
 dvt_dtx_begin_helper(daos_handle_t coh, const daos_unit_oid_t *oid, daos_epoch_t epoch,
 		     uint64_t dkey_hash, struct dtx_handle **dthp)
@@ -466,6 +465,8 @@ dvt_vos_insert_2_records_with_dtx(daos_handle_t coh)
 
 	dvt_dtx_end(dth1);
 	dvt_dtx_end(dth2);
+	daos_iov_free(&iod.iod_name);
+	d_sgl_fini(&sgl, false);
 }
 
 struct ddb_test_driver_arguments {

--- a/src/ddb/tests/ddb_test_driver.c
+++ b/src/ddb/tests/ddb_test_driver.c
@@ -570,8 +570,9 @@ int main(int argc, char *argv[])
 
 		/* filtering suites and tests */
 		char test_suites[] = "";
-
+#if CMOCKA_FILTER_SUPPORTED == 1 /** requires cmocka 1.1.5 */
 		cmocka_set_test_filter("**");
+#endif
 		RUN_TEST_SUIT('a', ddb_parse_tests_run);
 		RUN_TEST_SUIT('b', ddb_cmd_options_tests_run);
 		RUN_TEST_SUIT('c', dv_tests_run);

--- a/src/ddb/tests/ddb_test_driver.c
+++ b/src/ddb/tests/ddb_test_driver.c
@@ -7,6 +7,7 @@
 #include <fcntl.h>
 #include <libgen.h>
 #include <daos/tests_lib.h>
+#include <daos_srv/dtx_srv.h>
 #include <daos_srv/vos.h>
 #include <gurt/debug.h>
 #include <ddb_common.h>
@@ -31,6 +32,9 @@ const char *g_uuids_str[] = {
 	"12345678-1234-1234-1234-123456789009",
 	"12345678-1234-1234-1234-123456789010",
 };
+
+const char *g_invalid_uuid_str = "99999999-9999-9999-9999-999999999999";
+daos_unit_oid_t g_invalid_oid = {.id_pub = {.lo = 99999, .hi = 9999} };
 
 char *g_dkeys_str[] = {
 	"dkey-1",
@@ -57,58 +61,49 @@ char *g_akeys_str[] = {
 	"akey-9",
 	"akey-10",
 };
+char	*g_invalid_key_str = "invalid key";
 
 daos_unit_oid_t	g_oids[10];
 uuid_t		g_uuids[10];
 daos_key_t	g_dkeys[10];
 daos_key_t	g_akeys[10];
+daos_recx_t	g_recxs[10];
+daos_key_t	g_invalid_key;
+daos_recx_t	g_invalid_recx = {.rx_nr = 9999, .rx_idx = 9999};
 
-daos_obj_id_t
-oid_gen(uint32_t lo)
-{
-	daos_obj_id_t	oid;
-	uint64_t	hdr;
-
-	hdr = 100;
-	hdr <<= 32;
-
-	/* generate a unique and not scary long object ID */
-	oid.lo	= lo;
-	oid.lo	|= hdr;
-	oid.hi	= 100;
-
-	return oid;
-}
 
 daos_unit_oid_t
-gen_uoid(uint32_t lo)
+dvt_gen_uoid(uint32_t i)
 {
-	daos_unit_oid_t	uoid;
+	daos_unit_oid_t	uoid = {0};
+	daos_obj_id_t	oid;
 
-	uoid.id_pub	= oid_gen(lo);
-	daos_obj_set_oid(&uoid.id_pub, daos_obj_feat2type(0), OC_SX, 1, 0);
+	oid.lo	= (1L << 32) + i;
+	oid.hi = (1 << 16) + i;
+	daos_obj_set_oid(&oid, DAOS_OT_MULTI_HASHED, OR_RP_1, 1, 0);
+
 	uoid.id_shard	= 0;
 	uoid.id_pad_32	= 0;
+	uoid.id_pub = oid;
 
 	return uoid;
 }
 
 void
 dvt_vos_insert_recx(daos_handle_t coh, daos_unit_oid_t uoid, char *dkey_str, char *akey_str,
-		    int recx_idx, char *data_str, daos_epoch_t epoch)
+		    daos_recx_t *recx, daos_epoch_t epoch)
 {
 	daos_key_t dkey = DEFINE_IOV(dkey_str);
 
-	d_iov_t iov = DEFINE_IOV(data_str);
+	d_iov_t iov = DEFINE_IOV("This is a recx value");
 	d_sg_list_t sgl = {.sg_iovs = &iov, .sg_nr = 1, .sg_nr_out = 1};
 
-	daos_recx_t recx = {.rx_nr = daos_sgl_buf_size(&sgl), .rx_idx = recx_idx};
 	daos_iod_t iod = {
 		.iod_name = DEFINE_IOV(akey_str),
 		.iod_type = DAOS_IOD_ARRAY,
 		.iod_nr = 1,
 		.iod_size = 1,
-		.iod_recxs = &recx
+		.iod_recxs = recx
 	};
 
 	assert_success(vos_obj_update(coh, uoid, epoch, 0, 0, &dkey, 1, &iod, NULL, &sgl));
@@ -131,6 +126,55 @@ dvt_vos_insert_single(daos_handle_t coh, daos_unit_oid_t uoid, char *dkey_str, c
 	};
 
 	assert_success(vos_obj_update(coh, uoid, epoch, 0, 0, &dkey, 1, &iod, NULL, &sgl));
+}
+
+/*
+ * These tests look at and verify how the ddb types are printed.
+ */
+int
+dvt_fake_print(const char *fmt, ...)
+{
+	va_list args;
+	uint32_t buffer_offset = strlen(dvt_fake_print_buffer);
+	uint32_t buffer_left;
+
+	buffer_left = ARRAY_SIZE(dvt_fake_print_buffer) - buffer_offset;
+	dvt_fake_print_called++;
+	va_start(args, fmt);
+	vsnprintf(dvt_fake_print_buffer + buffer_offset, buffer_left, fmt, args);
+	va_end(args);
+	if (g_verbose)
+		printf("%s", dvt_fake_print_buffer);
+
+	return 0;
+}
+
+void dvt_fake_print_reset(void)
+{
+	memset(dvt_fake_print_buffer, 0, ARRAY_SIZE(dvt_fake_print_buffer));
+}
+
+size_t
+dvt_fake_get_file_size(const char *path)
+{
+	return dvt_fake_get_file_size_result;
+}
+
+bool
+dvt_fake_get_file_exists(const char *path)
+{
+	return dvt_fake_get_file_exists_result;
+}
+
+size_t
+dvt_fake_read_file(const char *src_path, d_iov_t *contents)
+{
+	size_t to_copy = min(contents->iov_buf_len, ARRAY_SIZE(dvt_fake_read_file_buf));
+
+	memcpy(contents->iov_buf, dvt_fake_read_file_buf, to_copy);
+	contents->iov_len = to_copy;
+
+	return dvt_fake_read_file_result;
 }
 
 /*
@@ -193,7 +237,7 @@ setup_global_arrays()
 	int i;
 
 	for (i = 0; i < ARRAY_SIZE(g_oids); i++)
-		g_oids[i] = gen_uoid(i);
+		g_oids[i] = dvt_gen_uoid(i);
 
 	for (i = 0; i < ARRAY_SIZE(g_uuids_str); i++)
 		uuid_parse(g_uuids_str[i], g_uuids[i]);
@@ -203,6 +247,14 @@ setup_global_arrays()
 
 	for (i = 0; i < ARRAY_SIZE(g_akeys); i++)
 		d_iov_set(&g_akeys[i], g_akeys_str[i], strlen(g_akeys_str[i]));
+
+	d_iov_set(&g_invalid_key, g_invalid_key_str, strlen(g_invalid_key_str));
+
+	for (i = 0; i < ARRAY_SIZE(g_recxs); i++) {
+		g_recxs[0].rx_idx = i;
+		g_recxs[0].rx_nr = 10;
+	}
+
 	return 0;
 }
 
@@ -253,6 +305,32 @@ dvt_iov_alloc_str(d_iov_t *iov, const char *str)
 	strcpy(iov->iov_buf, str);
 }
 
+static void
+create_object_data(daos_handle_t *coh, uint32_t obj_to_create, uint32_t dkeys_to_create,
+			uint32_t akeys_to_create, uint32_t recx_to_create)
+{
+	int o, d, a, r; /* loop indexes */
+
+	for (o = 0; o < obj_to_create; o++) {
+		for (d = 0; d < dkeys_to_create; d++) {
+			for (a = 0; a < akeys_to_create; a++) {
+				if (a % 2 == 0) {
+					for (r = 0; r < recx_to_create; r++)
+						dvt_vos_insert_recx((*coh), g_oids[o],
+								    g_dkeys_str[d],
+								    g_akeys_str[a],
+								    &g_recxs[r], 1);
+				} else {
+					dvt_vos_insert_single((*coh), g_oids[o],
+							      g_dkeys_str[d],
+							      g_akeys_str[a],
+							      "This is a single value", 1);
+				}
+			}
+		}
+	}
+}
+
 void
 dvt_insert_data(daos_handle_t poh, uint32_t conts, uint32_t objs, uint32_t dkeys, uint32_t akeys)
 {
@@ -261,7 +339,8 @@ dvt_insert_data(daos_handle_t poh, uint32_t conts, uint32_t objs, uint32_t dkeys
 	uint32_t		obj_to_create = ARRAY_SIZE(g_oids);
 	uint32_t		dkeys_to_create = ARRAY_SIZE(g_dkeys);
 	uint32_t		akeys_to_create = ARRAY_SIZE(g_akeys);
-	int			c, o, d, a; /* loop indexes */
+	uint32_t		recx_to_create = ARRAY_SIZE(g_recxs);
+	int			c;
 
 	if (conts > 0)
 		cont_to_create = conts;
@@ -276,39 +355,106 @@ dvt_insert_data(daos_handle_t poh, uint32_t conts, uint32_t objs, uint32_t dkeys
 	for (c = 0; c < cont_to_create; c++) {
 		assert_success(vos_cont_create(poh, g_uuids[c]));
 		assert_success(vos_cont_open(poh, g_uuids[c], &coh));
-		for (o = 0; o < obj_to_create; o++) {
-			for (d = 0; d < dkeys_to_create; d++) {
-				for (a = 0; a < akeys_to_create; a++) {
-					if (a % 2 == 0) {
-						dvt_vos_insert_recx(coh, g_oids[o],
-								    g_dkeys_str[d],
-								    g_akeys_str[a], 1,
-								    "This is an array value", 1);
-					} else {
-						dvt_vos_insert_single(coh, g_oids[o],
-								      g_dkeys_str[d],
-								      g_akeys_str[a],
-								      "This is a single value", 1);
-					}
-				}
-			}
-		}
+
+		create_object_data(&coh, obj_to_create, dkeys_to_create, akeys_to_create,
+				   recx_to_create);
 		vos_cont_close(coh);
 	}
 }
 
-void
-dvt_delete_all_containers(daos_handle_t poh)
-{
-	int	c;
-	uuid_t	uuid;
 
-	for (c = 0; c < ARRAY_SIZE(g_uuids_str); c++) {
-		uuid_parse(g_uuids_str[c], uuid);
-		assert_success(vos_cont_destroy(poh, uuid));
-	}
+static void
+dvt_dtx_begin_helper(daos_handle_t coh, const daos_unit_oid_t *oid, daos_epoch_t epoch,
+		     uint64_t dkey_hash, struct dtx_handle **dthp)
+{
+	struct dtx_handle	*dth;
+	struct dtx_memberships	*mbs;
+	size_t			 size;
+
+	D_ALLOC_PTR(dth);
+	assert_non_null(dth);
+
+	memset(dth, 0, sizeof(*dth));
+
+	size = sizeof(struct dtx_memberships) + sizeof(struct dtx_daos_target);
+
+	D_ALLOC(mbs, size);
+	assert_non_null(mbs);
+
+	mbs->dm_tgt_cnt = 1;
+	mbs->dm_grp_cnt = 1;
+	mbs->dm_data_size = sizeof(struct dtx_daos_target);
+	mbs->dm_tgts[0].ddt_id = 1;
+
+	/** Use unique API so new UUID is generated even on same thread */
+	daos_dti_gen_unique(&(&dth->dth_dte)->dte_xid);
+	dth->dth_dte.dte_ver = 1;
+	dth->dth_dte.dte_refs = 1;
+	dth->dth_dte.dte_mbs = mbs;
+
+	dth->dth_coh = coh;
+	dth->dth_epoch = epoch;
+	dth->dth_leader_oid = *oid;
+
+	dth->dth_flags = DTE_LEADER;
+	dth->dth_modification_cnt = 1;
+
+	dth->dth_op_seq = 1;
+	dth->dth_dkey_hash = dkey_hash;
+
+	D_INIT_LIST_HEAD(&dth->dth_share_cmt_list);
+	D_INIT_LIST_HEAD(&dth->dth_share_abt_list);
+	D_INIT_LIST_HEAD(&dth->dth_share_act_list);
+	D_INIT_LIST_HEAD(&dth->dth_share_tbd_list);
+	dth->dth_shares_inited = 1;
+
+	vos_dtx_rsrvd_init(dth);
+
+	*dthp = dth;
 }
 
+static void
+dvt_dtx_end(struct dtx_handle *dth)
+{
+	D_FREE(dth->dth_dte.dte_mbs);
+	D_FREE_PTR(dth);
+}
+
+void
+dvt_vos_insert_2_records_with_dtx(daos_handle_t coh)
+{
+	struct dtx_handle	*dth1;
+	struct dtx_handle	*dth2;
+	const uint32_t		 recxs_nr = 1;
+	const uint32_t		 rec_size = 1;
+	daos_recx_t		 recxs[recxs_nr];
+	daos_iod_t		 iod = {0};
+	d_sg_list_t		 sgl = {0};
+	daos_epoch_t		 epoch = 1;
+
+	d_sgl_init(&sgl, 1);
+
+	recxs[0].rx_idx = 0;
+	recxs[0].rx_nr = daos_sgl_buf_size(&sgl);
+
+	iod.iod_recxs = recxs;
+	iod.iod_nr = recxs_nr;
+	iod.iod_size = rec_size;
+	iod.iod_type = DAOS_IOD_ARRAY;
+	dvt_iov_alloc_str(&iod.iod_name, "akey");
+
+	dvt_dtx_begin_helper(coh, &g_oids[0], epoch++, 0x123, &dth1);
+	dvt_dtx_begin_helper(coh, &g_oids[0], epoch++, 0x124, &dth2);
+	assert_success(vos_obj_update_ex(coh, g_oids[0], epoch, 0, 0, &g_dkeys[0], 1, &iod,
+					 NULL, &sgl, dth1));
+	assert_success(vos_obj_update_ex(coh, g_oids[1], epoch, 0, 0, &g_dkeys[1], 1, &iod,
+					 NULL, &sgl, dth2));
+	/* Only commit 1 of the  transactions */
+	assert_int_equal(1, vos_dtx_commit(coh, &dth1->dth_xid, 1, NULL));
+
+	dvt_dtx_end(dth1);
+	dvt_dtx_end(dth2);
+}
 
 struct ddb_test_driver_arguments {
 	bool	 dtda_create_vos_file;
@@ -375,6 +521,21 @@ create_test_vos_file()
 	return 0;
 }
 
+static bool
+char_in_tests(char a, char *str, uint32_t str_len)
+{
+	int i;
+
+	if (strlen(str) == 0) /* if there is no filter, always return true */
+		return true;
+	for (i = 0; i < str_len; i++) {
+		if (a == str[i])
+			return true;
+	}
+
+	return false;
+}
+
 /*
  * -----------------------------------------------
  * Execute
@@ -402,11 +563,20 @@ int main(int argc, char *argv[])
 	if (args.dtda_create_vos_file) {
 		create_test_vos_file();
 	} else {
-		rc += ddb_parse_tests_run();
-		rc += ddb_cmd_options_tests_run();
-		rc += dv_tests_run();
-		rc += dvc_tests_run();
-		rc += ddb_main_tests();
+#define RUN_TEST_SUIT(c, func)\
+	do {if (char_in_tests(c, test_suites, ARRAY_SIZE(test_suites))) \
+		rc += func(); } while (0)
+
+		/* filtering suites and tests */
+		char test_suites[] = "";
+
+		cmocka_set_test_filter("**");
+		RUN_TEST_SUIT('a', ddb_parse_tests_run);
+		RUN_TEST_SUIT('b', ddb_cmd_options_tests_run);
+		RUN_TEST_SUIT('c', dv_tests_run);
+		RUN_TEST_SUIT('d', dvc_tests_run);
+		RUN_TEST_SUIT('e', ddb_main_tests);
+		RUN_TEST_SUIT('f', ddb_commands_print_tests_run);
 	}
 
 	vos_self_fini();

--- a/src/ddb/tests/ddb_test_driver.h
+++ b/src/ddb/tests/ddb_test_driver.h
@@ -26,6 +26,7 @@ struct dt_vos_pool_ctx {
 	int		dvt_fd;
 	char		dvt_pmem_file[128];
 };
+
 daos_unit_oid_t dvt_gen_uoid(uint32_t i);
 void dvt_vos_insert_recx(daos_handle_t coh, daos_unit_oid_t uoid, char *dkey_str, char *akey_str,
 			 daos_recx_t *recx, daos_epoch_t epoch);

--- a/src/ddb/tests/ddb_test_driver.h
+++ b/src/ddb/tests/ddb_test_driver.h
@@ -8,12 +8,17 @@
 
 extern bool		 g_verbose;
 extern const char	*g_uuids_str[10];
+extern const char	*g_invalid_uuid_str;
 extern uuid_t		 g_uuids[10];
 extern daos_unit_oid_t	 g_oids[10];
+extern daos_unit_oid_t	 g_invalid_oid;
 extern char		*g_dkeys_str[10];
 extern char		*g_akeys_str[10];
 extern daos_key_t	 g_dkeys[10];
 extern daos_key_t	 g_akeys[10];
+extern daos_key_t	 g_invalid_key;
+extern daos_recx_t	 g_recxs[10];
+extern daos_recx_t	 g_invalid_recx;
 
 struct dt_vos_pool_ctx {
 	daos_handle_t	dvt_poh;
@@ -21,11 +26,9 @@ struct dt_vos_pool_ctx {
 	int		dvt_fd;
 	char		dvt_pmem_file[128];
 };
-
-daos_unit_oid_t gen_uoid(uint32_t lo);
-
+daos_unit_oid_t dvt_gen_uoid(uint32_t i);
 void dvt_vos_insert_recx(daos_handle_t coh, daos_unit_oid_t uoid, char *dkey_str, char *akey_str,
-			 int recx_idx, char *data_str, daos_epoch_t epoch);
+			 daos_recx_t *recx, daos_epoch_t epoch);
 void
 dvt_vos_insert_single(daos_handle_t coh, daos_unit_oid_t uoid, char *dkey_str, char *akey_str,
 		      char *data_str, daos_epoch_t epoch);
@@ -42,6 +45,7 @@ int dv_tests_run(void);
 int dvc_tests_run(void);
 int ddb_main_tests(void);
 int ddb_cmd_options_tests_run(void);
+int ddb_commands_print_tests_run(void);
 
 /*
  * Insert data into the pool. The cont, objs, ... parameters indicate how many of each to
@@ -49,6 +53,25 @@ int ddb_cmd_options_tests_run(void);
  */
 void dvt_insert_data(daos_handle_t poh, uint32_t conts, uint32_t objs, uint32_t dkeys,
 		     uint32_t akeys);
-void dvt_delete_all_containers(daos_handle_t poh);
+
+int ddb_test_pool_setup(struct dt_vos_pool_ctx *tctx);
+
+uint32_t dvt_fake_print_called;
+char dvt_fake_print_buffer[1024];
+int dvt_fake_print(const char *fmt, ...);
+void dvt_fake_print_reset(void);
+
+
+size_t dvt_fake_get_file_size_result;
+size_t dvt_fake_get_file_size(const char *path);
+
+bool dvt_fake_get_file_exists_result;
+bool dvt_fake_get_file_exists(const char *path);
+
+size_t dvt_fake_read_file_result;
+char dvt_fake_read_file_buf[64];
+size_t dvt_fake_read_file(const char *src_path, d_iov_t *contents);
+
+void dvt_vos_insert_2_records_with_dtx(daos_handle_t coh);
 
 #endif /* DAOS_DDB_TEST_DRIVER_H */

--- a/src/ddb/tests/ddb_test_driver.h
+++ b/src/ddb/tests/ddb_test_driver.h
@@ -57,20 +57,20 @@ void dvt_insert_data(daos_handle_t poh, uint32_t conts, uint32_t objs, uint32_t 
 
 int ddb_test_pool_setup(struct dt_vos_pool_ctx *tctx);
 
-uint32_t dvt_fake_print_called;
-char dvt_fake_print_buffer[1024];
+extern uint32_t dvt_fake_print_called;
+extern char dvt_fake_print_buffer[1024];
 int dvt_fake_print(const char *fmt, ...);
 void dvt_fake_print_reset(void);
 
 
-size_t dvt_fake_get_file_size_result;
+extern size_t dvt_fake_get_file_size_result;
 size_t dvt_fake_get_file_size(const char *path);
 
-bool dvt_fake_get_file_exists_result;
+extern bool dvt_fake_get_file_exists_result;
 bool dvt_fake_get_file_exists(const char *path);
 
-size_t dvt_fake_read_file_result;
-char dvt_fake_read_file_buf[64];
+extern size_t dvt_fake_read_file_result;
+extern char dvt_fake_read_file_buf[64];
 size_t dvt_fake_read_file(const char *src_path, d_iov_t *contents);
 
 void dvt_vos_insert_2_records_with_dtx(daos_handle_t coh);

--- a/src/ddb/tests/ddb_vos_tests.c
+++ b/src/ddb/tests/ddb_vos_tests.c
@@ -486,7 +486,7 @@ static void
 obj_id_2_ddb_test(void **state)
 {
 	struct ddb_obj	obj = {0};
-	daos_obj_id_t	oid;
+	daos_obj_id_t	oid = {0};
 
 	daos_obj_set_oid(&oid, DAOS_OT_MULTI_HASHED, OR_RP_2, 2, 0);
 
@@ -672,11 +672,11 @@ static void
 assert_update_existing_path(daos_handle_t poh, struct dv_tree_path *vtp)
 {
 	d_iov_t	value_iov = {0};
-	char	value_buf[64];
+	char	value_buf[256];
 
 	/* First get the value_buf using dump_value then use it to create an updated value */
 	assert_success(dv_dump_value(poh, vtp, fake_dump_value_cb, NULL));
-	snprintf(value_buf, 64, "Updated: %s", fake_dump_value_cb_value_buf);
+	snprintf(value_buf, 256, "Updated: %s", fake_dump_value_cb_value_buf);
 
 	d_iov_set(&value_iov, value_buf, strlen(value_buf));
 

--- a/src/ddb/tests/ddb_vos_tests.c
+++ b/src/ddb/tests/ddb_vos_tests.c
@@ -536,7 +536,7 @@ get_value_tests(void **state)
 
 	/* first akey is a recx */
 	assert_success(test_dump_value(tctx->dvt_poh, g_uuids[0], g_oids[0], &g_dkeys[0],
-				     &g_akeys[0], &recx, fake_dump_value_cb, NULL));
+				       &g_akeys[0], &recx, fake_dump_value_cb, NULL));
 
 	assert_int_equal(1, fake_dump_value_cb_called);
 	assert_non_null(fake_dump_value_cb_value.iov_buf);
@@ -545,7 +545,7 @@ get_value_tests(void **state)
 	/* second akey is a single value */
 	fake_dump_value_cb_called = 0;
 	assert_success(test_dump_value(tctx->dvt_poh, g_uuids[0], g_oids[0], &g_dkeys[0],
-				     &g_akeys[1], NULL, fake_dump_value_cb, NULL));
+				       &g_akeys[1], NULL, fake_dump_value_cb, NULL));
 
 	assert_int_equal(1, fake_dump_value_cb_called);
 	assert_non_null(fake_dump_value_cb_value.iov_buf);
@@ -586,6 +586,7 @@ get_obj_ilog_tests(void **state)
 
 	vos_cont_close(coh);
 }
+
 static void
 get_dkey_ilog_tests(void **state)
 {

--- a/src/ddb/tests/ddb_vos_tests.c
+++ b/src/ddb/tests/ddb_vos_tests.c
@@ -112,10 +112,10 @@ static struct vos_tree_handlers fake_handlers = {
 	} while (0)
 
 #define assert_ddb_iterate(poh, cont_uuid, oid, dkey, akey, recursive, expected_cont, \
-			   expected_obj, expected_dkey, expected_akey,                   \
-			   expected_sv, expected_array)                                    \
-	assert_success(__assert_ddb_iterate(poh, cont_uuid, oid, dkey,    \
-	akey, recursive, expected_cont, expected_obj,                     \
+			   expected_obj, expected_dkey, expected_akey, \
+			   expected_sv, expected_array) \
+	assert_success(__assert_ddb_iterate(poh, cont_uuid, oid, dkey, \
+	akey, recursive, expected_cont, expected_obj, \
 	expected_dkey, expected_akey, expected_sv, expected_array))
 static int
 __assert_ddb_iterate(daos_handle_t poh, uuid_t *cont_uuid, daos_unit_oid_t *oid, daos_key_t *dkey,
@@ -223,14 +223,14 @@ list_items_test(void **state)
 }
 
 static void
-get_cont_uuid_tests(void **state)
+get_cont_uuid_from_idx_tests(void **state)
 {
 	struct dt_vos_pool_ctx	*tctx = *state;
 	uuid_t uuid;
 	uuid_t uuid_2;
 	int i;
 
-	assert_rc_equal(-DER_INVAL, dv_get_cont_uuid(tctx->dvt_poh, 10000000, uuid));
+	assert_rc_equal(-DER_NONEXIST, dv_get_cont_uuid(tctx->dvt_poh, 10000000, uuid));
 	assert_success(dv_get_cont_uuid(tctx->dvt_poh, 0, uuid));
 	for (i = 1; i < 5; i++) {
 		assert_success(dv_get_cont_uuid(tctx->dvt_poh, i, uuid_2));
@@ -248,7 +248,7 @@ get_cont_uuid_tests(void **state)
 }
 
 static void
-get_oid_tests(void **state)
+get_oid_from_idx_tests(void **state)
 {
 	struct dt_vos_pool_ctx	*tctx = *state;
 	daos_unit_oid_t		 uoid;
@@ -259,7 +259,7 @@ get_oid_tests(void **state)
 	assert_rc_equal(-DER_INVAL, dv_get_object_oid(coh, 0, &uoid));
 	vos_cont_open(tctx->dvt_poh, g_uuids[0], &coh);
 
-	assert_rc_equal(-DER_INVAL, dv_get_object_oid(coh, 10000000, &uoid));
+	assert_rc_equal(-DER_NONEXIST, dv_get_object_oid(coh, 10000000, &uoid));
 	assert_success(dv_get_object_oid(coh, 0, &uoid));
 	for (i = 1; i < 5; i++) {
 		assert_success(dv_get_object_oid(coh, i, &uoid_2));
@@ -279,7 +279,7 @@ get_oid_tests(void **state)
 }
 
 static void
-get_dkey_tests(void **state)
+get_dkey_from_idx_tests(void **state)
 {
 	struct dt_vos_pool_ctx	*tctx = *state;
 	daos_unit_oid_t uoid = {0};
@@ -309,7 +309,7 @@ get_dkey_tests(void **state)
 }
 
 static void
-get_akey_tests(void **state)
+get_akey_from_idx_tests(void **state)
 {
 	struct dt_vos_pool_ctx	*tctx = *state;
 	daos_unit_oid_t uoid = {0};
@@ -325,7 +325,7 @@ get_akey_tests(void **state)
 	assert_success(vos_cont_open(tctx->dvt_poh, g_uuids[0], &coh));
 	assert_rc_equal(-DER_INVAL, dv_get_akey(coh, uoid, &dkey, 0, &akey));
 	uoid = g_oids[0];
-	assert_rc_equal(-DER_INVAL, dv_get_akey(coh, uoid, &dkey, 0, &akey));
+	assert_rc_equal(-DER_NONEXIST, dv_get_akey(coh, uoid, &dkey, 0, &akey));
 	dv_get_dkey(coh, uoid, 0, &dkey);
 
 	assert_success(dv_get_akey(coh, uoid, &dkey, 0, &akey));
@@ -343,7 +343,7 @@ get_akey_tests(void **state)
 }
 
 static void
-get_recx_tests(void **state)
+get_recx_from_idx_tests(void **state)
 {
 	struct dt_vos_pool_ctx	*tctx = *state;
 	daos_unit_oid_t		 uoid = {0};
@@ -357,9 +357,9 @@ get_recx_tests(void **state)
 	assert_success(vos_cont_open(tctx->dvt_poh, g_uuids[0], &coh));
 	assert_rc_equal(-DER_INVAL, dv_get_recx(coh, uoid, &dkey, &akey, 0, &recx));
 	dv_get_object_oid(coh, 0, &uoid);
-	assert_rc_equal(-DER_INVAL, dv_get_recx(coh, uoid, &dkey, &akey, 0, &recx));
+	assert_rc_equal(-DER_NONEXIST, dv_get_recx(coh, uoid, &dkey, &akey, 0, &recx));
 	dv_get_dkey(coh, uoid, 0, &dkey);
-	assert_rc_equal(-DER_INVAL, dv_get_recx(coh, uoid, &dkey, &akey, 0, &recx));
+	assert_rc_equal(-DER_NONEXIST, dv_get_recx(coh, uoid, &dkey, &akey, 0, &recx));
 	dv_get_akey(coh, uoid, &dkey, 0, &akey);
 	assert_success(dv_get_recx(coh, uoid, &dkey, &akey, 0, &recx));
 
@@ -367,7 +367,7 @@ get_recx_tests(void **state)
 }
 
 static void
-test_update_path_with_values_from_index(void **state)
+update_path_with_values_from_index_tests(void **state)
 {
 	struct dt_vos_pool_ctx	*tctx = *state;
 
@@ -381,8 +381,445 @@ test_update_path_with_values_from_index(void **state)
 	assert_oid_equal(g_oids[0].id_pub, vt_path.vtp_path.vtp_oid.id_pub);
 	assert_key_equal(g_dkeys[0], vt_path.vtp_path.vtp_dkey);
 	assert_key_equal(g_akeys[0], vt_path.vtp_path.vtp_akey);
-	assert_int_equal(1, vt_path.vtp_path.vtp_recx.rx_idx);
-	assert_int_equal(0x16, vt_path.vtp_path.vtp_recx.rx_nr);
+	assert_int_equal(9, vt_path.vtp_path.vtp_recx.rx_idx);
+	assert_int_equal(10, vt_path.vtp_path.vtp_recx.rx_nr);
+}
+
+static void
+idx_in_path_must_be_valid_tests(void **state)
+{
+	struct dt_vos_pool_ctx	*tctx = *state;
+
+	struct dv_tree_path_builder vt_path = {0};
+
+	vt_path.vtp_poh = tctx->dvt_poh;
+	vt_path.vtp_cont_idx = 999;
+	assert_rc_equal(-DER_NONEXIST, dv_path_update_from_indexes(&vt_path));
+	vt_path.vtp_cont_idx = 0;
+
+	vt_path.vtp_oid_idx = 999;
+	assert_rc_equal(-DER_NONEXIST, dv_path_update_from_indexes(&vt_path));
+	vt_path.vtp_oid_idx = 0;
+
+	vt_path.vtp_dkey_idx = 999;
+	assert_rc_equal(-DER_NONEXIST, dv_path_update_from_indexes(&vt_path));
+	vt_path.vtp_dkey_idx = 0;
+
+	vt_path.vtp_akey_idx = 999;
+	assert_rc_equal(-DER_NONEXIST, dv_path_update_from_indexes(&vt_path));
+	vt_path.vtp_akey_idx = 0;
+}
+
+#define assert_path(path, expected) \
+do { \
+	struct dv_tree_path_builder __vt = {0}; \
+	daos_handle_t poh = {0}; \
+	assert_success(ddb_vtp_init(poh, path, &__vt)); \
+	assert_vtp_eq(expected, __vt); \
+	ddb_vtp_fini(&__vt); \
+} while (0)
+
+static void
+path_must_be_valid_tests(void **state)
+{
+	struct dt_vos_pool_ctx		*tctx = *state;
+	daos_handle_t			 poh = tctx->dvt_poh;
+	struct dv_tree_path		 vt_path = {0};
+
+	/* Nothing set should be a valid path */
+	assert_success(ddb_vtp_verify(poh, &vt_path));
+
+	uuid_parse(g_invalid_uuid_str, vt_path.vtp_cont);
+	assert_rc_equal(-DER_NONEXIST, ddb_vtp_verify(poh, &vt_path));
+
+	uuid_copy(vt_path.vtp_cont, g_uuids[0]);
+	assert_success(ddb_vtp_verify(poh, &vt_path));
+
+	vt_path.vtp_oid = g_invalid_oid;
+	assert_rc_equal(-DER_NONEXIST, ddb_vtp_verify(poh, &vt_path));
+	vt_path.vtp_oid = g_oids[0];
+	assert_success(ddb_vtp_verify(poh, &vt_path));
+
+	vt_path.vtp_dkey = g_invalid_key;
+	assert_rc_equal(-DER_NONEXIST, ddb_vtp_verify(poh, &vt_path));
+	vt_path.vtp_dkey = g_dkeys[0];
+	assert_success(ddb_vtp_verify(poh, &vt_path));
+
+	vt_path.vtp_akey = g_invalid_key;
+	assert_rc_equal(-DER_NONEXIST, ddb_vtp_verify(poh, &vt_path));
+	vt_path.vtp_akey = g_akeys[0];
+	assert_success(ddb_vtp_verify(poh, &vt_path));
+
+	vt_path.vtp_recx = g_invalid_recx;
+	assert_rc_equal(-DER_NONEXIST, ddb_vtp_verify(poh, &vt_path));
+	vt_path.vtp_recx = g_recxs[0];
+	assert_success(ddb_vtp_verify(poh, &vt_path));
+}
+
+static int fake_dump_superblock_cb_called;
+static struct ddb_superblock fake_dump_superblock_cb_sb;
+static int
+fake_dump_superblock_cb(void *cb_arg, struct ddb_superblock *sb)
+{
+	fake_dump_superblock_cb_called++;
+	fake_dump_superblock_cb_sb = *sb;
+
+	return 0;
+}
+
+static void
+get_superblock_tests(void **state)
+{
+	struct dt_vos_pool_ctx	*tctx = *state;
+
+	assert_rc_equal(-DER_INVAL, dv_superblock(DAOS_HDL_INVAL,
+						  fake_dump_superblock_cb, NULL));
+
+	assert_success(dv_superblock(tctx->dvt_poh, fake_dump_superblock_cb, NULL));
+	assert_int_equal(1, fake_dump_superblock_cb_called);
+
+	/* just do some basics to verify got a valid pool df */
+	assert_true(fake_dump_superblock_cb_sb.dsb_durable_format_version);
+}
+
+static void
+obj_id_2_ddb_test(void **state)
+{
+	struct ddb_obj	obj = {0};
+	daos_obj_id_t	oid;
+
+	daos_obj_set_oid(&oid, DAOS_OT_MULTI_HASHED, OR_RP_2, 2, 0);
+
+	dv_oid_to_obj(oid, &obj);
+
+	assert_int_equal(2, obj.ddbo_nr_grps);
+	assert_string_equal("DAOS_OT_MULTI_HASHED", obj.ddbo_otype_str);
+}
+
+
+static uint32_t fake_dump_value_cb_called;
+static d_iov_t fake_dump_value_cb_value;
+static uint8_t fake_dump_value_cb_value_buf[128];
+static int
+fake_dump_value_cb(void *cb_args, d_iov_t *value)
+{
+	fake_dump_value_cb_called++;
+	assert_true(value->iov_len <= ARRAY_SIZE(fake_dump_value_cb_value_buf));
+	fake_dump_value_cb_value = *value;
+	fake_dump_value_cb_value.iov_buf = fake_dump_value_cb_value_buf;
+	memcpy(fake_dump_value_cb_value_buf, value->iov_buf, value->iov_len);
+	return 0;
+}
+
+static int
+test_dump_value(daos_handle_t poh, uuid_t cont_uuid, daos_unit_oid_t oid, daos_key_t *dkey,
+		daos_key_t *akey, daos_recx_t *recx, dv_dump_value_cb dump_cb, void *cb_arg)
+{
+	struct dv_tree_path	 path = {0};
+
+	uuid_copy(path.vtp_cont, cont_uuid);
+	path.vtp_oid = oid;
+	path.vtp_dkey = *dkey;
+	path.vtp_akey = *akey;
+	if (recx)
+		path.vtp_recx = *recx;
+
+	return dv_dump_value(poh, &path, dump_cb, cb_arg);
+
+}
+
+static void
+get_value_tests(void **state)
+{
+	struct dt_vos_pool_ctx	*tctx = *state;
+	daos_recx_t		 recx = {.rx_idx = 0, .rx_nr = 10};
+
+	/* first akey is a recx */
+	assert_success(test_dump_value(tctx->dvt_poh, g_uuids[0], g_oids[0], &g_dkeys[0],
+				     &g_akeys[0], &recx, fake_dump_value_cb, NULL));
+
+	assert_int_equal(1, fake_dump_value_cb_called);
+	assert_non_null(fake_dump_value_cb_value.iov_buf);
+	assert_true(fake_dump_value_cb_value.iov_len > 0);
+
+	/* second akey is a single value */
+	fake_dump_value_cb_called = 0;
+	assert_success(test_dump_value(tctx->dvt_poh, g_uuids[0], g_oids[0], &g_dkeys[0],
+				     &g_akeys[1], NULL, fake_dump_value_cb, NULL));
+
+	assert_int_equal(1, fake_dump_value_cb_called);
+	assert_non_null(fake_dump_value_cb_value.iov_buf);
+	assert_true(fake_dump_value_cb_value.iov_len > 0);
+}
+
+static uint32_t fake_dump_ilog_entry_called;
+static int
+fake_dump_ilog_entry(void *cb_arg, struct ddb_ilog_entry *entry)
+{
+	fake_dump_ilog_entry_called++;
+	return 0;
+}
+
+static void
+get_obj_ilog_tests(void **state)
+{
+	struct dt_vos_pool_ctx	*tctx = *state;
+	daos_handle_t coh;
+
+	daos_unit_oid_t null_oid = {0};
+	daos_unit_oid_t bad_oid = {.id_pub.lo = 1};
+
+	assert_success(vos_cont_open(tctx->dvt_poh, g_uuids[0], &coh));
+
+	assert_rc_equal(-DER_INVAL, dv_get_obj_ilog_entries(DAOS_HDL_INVAL, null_oid,
+							    fake_dump_ilog_entry, NULL));
+	assert_rc_equal(-DER_INVAL, dv_get_obj_ilog_entries(DAOS_HDL_INVAL, g_oids[0],
+							    fake_dump_ilog_entry, NULL));
+	assert_rc_equal(-DER_INVAL, dv_get_obj_ilog_entries(coh, null_oid,
+							    fake_dump_ilog_entry, NULL));
+	assert_rc_equal(-DER_INVAL, dv_get_obj_ilog_entries(coh, bad_oid,
+							    fake_dump_ilog_entry, NULL));
+
+	assert_success(dv_get_obj_ilog_entries(coh, g_oids[0], fake_dump_ilog_entry, NULL));
+
+	assert_int_equal(1, fake_dump_ilog_entry_called);
+
+	vos_cont_close(coh);
+}
+static void
+get_dkey_ilog_tests(void **state)
+{
+	struct dt_vos_pool_ctx	*tctx = *state;
+	daos_handle_t		 coh;
+	daos_unit_oid_t		 null_oid = {0};
+
+	assert_success(vos_cont_open(tctx->dvt_poh, g_uuids[0], &coh));
+
+	assert_rc_equal(-DER_INVAL, dv_get_dkey_ilog_entries(DAOS_HDL_INVAL, null_oid, NULL,
+							     fake_dump_ilog_entry, NULL));
+
+	fake_dump_ilog_entry_called = 0;
+	assert_success(dv_get_dkey_ilog_entries(coh, g_oids[0], &g_dkeys[0], fake_dump_ilog_entry,
+						NULL));
+	assert_int_equal(1, fake_dump_ilog_entry_called);
+
+	vos_cont_close(coh);
+}
+
+/* End of where to put these functions */
+
+int entry_handler_called;
+static int
+committed_entry_handler(struct dv_dtx_committed_entry *entry, void *cb_arg)
+{
+	entry_handler_called++;
+	return 0;
+}
+
+static int
+active_entry_handler(struct dv_dtx_active_entry *entry, void *cb_arg)
+{
+	entry_handler_called++;
+	return 0;
+}
+
+static void
+get_dtx_tables_tests(void **state)
+{
+	struct dt_vos_pool_ctx	*tctx = *state;
+	daos_handle_t		 coh = DAOS_HDL_INVAL;
+
+	assert_rc_equal(-DER_INVAL, dv_committed_dtx(coh, committed_entry_handler, NULL));
+	assert_int_equal(0, entry_handler_called);
+
+	assert_rc_equal(-DER_INVAL, dv_active_dtx(coh, active_entry_handler, NULL));
+	assert_int_equal(0, entry_handler_called);
+
+	assert_success(vos_cont_open(tctx->dvt_poh, g_uuids[0], &coh));
+
+	dvt_vos_insert_2_records_with_dtx(coh);
+
+	assert_success(dv_committed_dtx(coh, committed_entry_handler, NULL));
+	assert_int_equal(1, entry_handler_called);
+
+	entry_handler_called = 0;
+	assert_success(dv_active_dtx(coh, active_entry_handler, NULL));
+	assert_int_equal(1, entry_handler_called);
+
+	vos_cont_close(coh);
+}
+
+static void
+verify_correct_params_for_update_value_tests(void **state)
+{
+	struct dt_vos_pool_ctx *tctx = *state;
+	daos_handle_t		poh = tctx->dvt_poh;
+	struct dv_tree_path	vtp = {};
+	d_iov_t			value_iov = {0};
+
+	assert_rc_equal(-DER_INVAL, dv_update(DAOS_HDL_INVAL, &vtp, &value_iov, 1));
+	assert_rc_equal(-DER_INVAL, dv_update(poh, &vtp, &value_iov, 1));
+
+	uuid_copy(vtp.vtp_cont, g_uuids[3]);
+	vtp.vtp_oid = g_oids[0];
+	vtp.vtp_dkey = g_dkeys[0];
+	vtp.vtp_akey = g_akeys[0];
+	assert_rc_equal(-DER_INVAL, dv_update(poh, &vtp, &value_iov, 1));
+}
+
+static void
+assert_update_existing_path(daos_handle_t poh, struct dv_tree_path *vtp)
+{
+	d_iov_t	value_iov = {0};
+	char	value_buf[64];
+
+	/* First get the value_buf using dump_value then use it to create an updated value */
+	assert_success(dv_dump_value(poh, vtp, fake_dump_value_cb, NULL));
+	snprintf(value_buf, 64, "Updated: %s", fake_dump_value_cb_value_buf);
+
+	d_iov_set(&value_iov, value_buf, strlen(value_buf));
+
+	/* if it's an array path, update so will be same length as new value */
+	if (vtp->vtp_recx.rx_nr > 0)
+		vtp->vtp_recx.rx_nr = value_iov.iov_len;
+	assert_success(dv_update(poh, vtp, &value_iov, 3));
+
+	/* Verify that after loading the value_buf, the same value_buf is dumped */
+	assert_success(dv_dump_value(poh, vtp, fake_dump_value_cb, NULL));
+	assert_key_equal(value_iov, fake_dump_value_cb_value);
+}
+
+static void
+update_value_to_modify_tests(void **state)
+{
+	struct dt_vos_pool_ctx *tctx = *state;
+	daos_handle_t		poh = tctx->dvt_poh;
+	struct dv_tree_path	vtp = {};
+	daos_handle_t		coh;
+
+
+	uuid_copy(vtp.vtp_cont, g_uuids[3]);
+	vtp.vtp_oid = g_oids[0];
+	vtp.vtp_dkey = g_dkeys[0];
+	vtp.vtp_akey = g_akeys[1]; /* single value type */
+
+	assert_update_existing_path(poh, &vtp);
+
+	vtp.vtp_akey = g_akeys[0]; /* array value type */
+	dv_cont_open(poh, vtp.vtp_cont, &coh);
+	dv_get_recx(coh, vtp.vtp_oid, &vtp.vtp_dkey, &vtp.vtp_akey, 0, &vtp.vtp_recx);
+	dv_cont_close(&coh);
+	assert_update_existing_path(poh, &vtp);
+}
+
+static void
+assert_update_new_path(daos_handle_t poh, struct dv_tree_path *vtp)
+{
+	d_iov_t	 value_iov = {0};
+	char	*value_buf = "A New value";
+
+	/* First check that the value doesn't exist */
+	memset(fake_dump_value_cb_value_buf, 0, ARRAY_SIZE(fake_dump_value_cb_value_buf));
+	assert_success(dv_dump_value(poh, vtp, fake_dump_value_cb, NULL));
+	assert_string_equal("", fake_dump_value_cb_value_buf);
+
+	d_iov_set(&value_iov, value_buf, strlen(value_buf));
+
+	assert_success(dv_update(poh, vtp, &value_iov, 3));
+
+	/* Verify that after loading the value_buf, the same value_buf is dumped */
+	assert_success(dv_dump_value(poh, vtp, fake_dump_value_cb, NULL));
+	assert_key_equal(value_iov, fake_dump_value_cb_value);
+}
+
+static void
+update_value_to_insert_tests(void **state)
+{
+	struct dt_vos_pool_ctx *tctx = *state;
+	daos_handle_t		poh = tctx->dvt_poh;
+	struct dv_tree_path	vtp = {};
+
+	uuid_copy(vtp.vtp_cont, g_uuids[3]);
+	/*
+	 * Create a new object with dkey & akey. If this succeeds, we assume that could also create
+	 * a new dkey within an existing oid, etc
+	 */
+	vtp.vtp_oid = dvt_gen_uoid(999);
+	vtp.vtp_dkey = g_dkeys[0];
+	vtp.vtp_akey = g_akeys[0];
+
+	assert_update_new_path(poh, &vtp);
+}
+
+#define DELETE_SUCCESS(poh, vtp) assert_success(dv_delete(poh, &vtp))
+static void
+delete_path_parts_tests(void **state)
+{
+	struct dt_vos_pool_ctx	*tctx = *state;
+	daos_handle_t		 poh = tctx->dvt_poh;
+	daos_handle_t		 coh;
+	struct dv_tree_path	 vtp = {0};
+	uuid_t			 cont_test;
+	daos_unit_oid_t		 uoid_test = {0};
+	daos_key_t		 dkey_test = {0};
+	daos_key_t		 akey_test = {0};
+
+	/* Don't allow empty path */
+	assert_rc_equal(-DER_INVAL, dv_delete(poh, &vtp));
+
+	dv_get_cont_uuid(poh, 0, vtp.vtp_cont);
+	DELETE_SUCCESS(poh, vtp);
+	dv_get_cont_uuid(poh, 0, cont_test);
+	assert_uuid_not_equal(vtp.vtp_cont, cont_test);
+	/* shouldn't be able to delete same container */
+	assert_rc_equal(-DER_NONEXIST, dv_delete(poh, &vtp));
+
+	/*
+	 * Remaining deletes happen within a container, so open the container to get the
+	 * VOS path part identifier
+	 */
+	dv_get_cont_uuid(poh, 0, vtp.vtp_cont);
+	assert_success(dv_cont_open(poh, vtp.vtp_cont, &coh));
+
+	/*
+	 * Delete an object
+	 * get oid from index 0. This will be deleted, so should not exist after
+	 */
+	assert_success(dv_get_object_oid(coh, 0, &vtp.vtp_oid));
+	DELETE_SUCCESS(poh, vtp);
+	/* index 0 should not be same oid now */
+	assert_success(dv_get_object_oid(coh, 0, &uoid_test));
+	assert_oid_not_equal(vtp.vtp_oid.id_pub, uoid_test.id_pub);
+	/* Shouldn't be able to delete the same object again */
+	assert_rc_equal(-DER_NONEXIST, dv_delete(poh, &vtp));
+
+	/*
+	 * delete dkey
+	 */
+	vtp.vtp_oid = uoid_test; /* reset uoid_before to oid that hasn't been deleted */
+	dv_get_dkey(coh, vtp.vtp_oid, 0, &vtp.vtp_dkey);
+	DELETE_SUCCESS(poh, vtp);
+	/* should still have the object */
+	assert_success(dv_get_object_oid(coh, 0, &uoid_test));
+	assert_oid_equal(vtp.vtp_oid.id_pub, uoid_test.id_pub);
+	dv_get_dkey(coh, vtp.vtp_oid, 0, &dkey_test);
+	assert_key_not_equal(vtp.vtp_dkey, dkey_test);
+
+	/*
+	 * delete akey
+	 */
+	vtp.vtp_dkey = dkey_test;
+	dv_get_akey(coh, vtp.vtp_oid, &vtp.vtp_dkey, 0, &vtp.vtp_akey);
+	DELETE_SUCCESS(poh, vtp);
+	/* should still have the object and dkey */
+	assert_success(dv_get_object_oid(coh, 0, &uoid_test));
+	assert_oid_equal(vtp.vtp_oid.id_pub, uoid_test.id_pub);
+	dv_get_dkey(coh, vtp.vtp_oid, 0, &dkey_test);
+	assert_key_equal(vtp.vtp_dkey, dkey_test);
+	dv_get_akey(coh, vtp.vtp_oid, &vtp.vtp_dkey, 0, &akey_test);
+	assert_key_not_equal(vtp.vtp_akey, akey_test);
+
+	dv_cont_close(&coh);
 }
 
 static int
@@ -422,16 +859,32 @@ dv_test_teardown(void **state)
 }
 
 
-#define TEST(dsc, test) { dsc, test, dv_test_setup, dv_test_teardown }
+/*
+ * All these tests use the same VOS tree that is created at suit_setup. Therefore, tests
+ * that modify the state of the tree (delete, add, etc) should be run after all others.
+ */
+#define TEST(x) { #x, x, dv_test_setup, dv_test_teardown }
 const struct CMUnitTest dv_test_cases[] = {
 	{ "open_pool", open_pool_test, NULL, NULL }, /* don't want this test to run with setup */
-	TEST("list items", list_items_test),
-	TEST("get container uuid from idx", get_cont_uuid_tests),
-	TEST("get object oid from idx", get_oid_tests),
-	TEST("get dkey from idx", get_dkey_tests),
-	TEST("get akey from idx", get_akey_tests),
-	TEST("get recx from idx", get_recx_tests),
-	TEST("get data value", test_update_path_with_values_from_index),
+	TEST(list_items_test),
+	TEST(get_cont_uuid_from_idx_tests),
+	TEST(get_oid_from_idx_tests),
+	TEST(get_dkey_from_idx_tests),
+	TEST(get_akey_from_idx_tests),
+	TEST(get_recx_from_idx_tests),
+	TEST(update_path_with_values_from_index_tests),
+	TEST(idx_in_path_must_be_valid_tests),
+	TEST(path_must_be_valid_tests),
+	TEST(get_value_tests),
+	TEST(get_obj_ilog_tests),
+	TEST(get_dkey_ilog_tests),
+	TEST(get_superblock_tests),
+	TEST(obj_id_2_ddb_test),
+	TEST(get_dtx_tables_tests),
+	TEST(delete_path_parts_tests),
+	TEST(verify_correct_params_for_update_value_tests),
+	TEST(update_value_to_modify_tests),
+	TEST(update_value_to_insert_tests),
 };
 
 int


### PR DESCRIPTION
- Introduces the dump, dump_ilog, dump_dtx, load, and rm commands for the 
  ddb tool.
- Reworked the construction of the unit test lists so that the
  test function name is printed in stead of a separate description.
- Added some filtering to the unit tests.
- Abstracted out the printing of the commands so that what is
  printed is more easily testable and to clean up the
  command functions a little.

Signed-off-by: Ryon Jensen <ryon.jensen@intel.com>