### PR TITLE
DAOS-10150 agent: Load balance amongst NUMA nodes

### DIFF
--- a/src/control/cmd/daos_agent/fabric.go
+++ b/src/control/cmd/daos_agent/fabric.go
@@ -65,9 +65,8 @@ type NUMAFabric struct {
 
 	numaMap map[int][]*FabricInterface
 
-	// current device idx to use on each NUMA node
-	currentNumaDevIdx map[int]int
-	defaultNumaNode   int
+	currentNumaDevIdx map[int]int // current device idx to use on each NUMA node
+	currentNUMANode   int         // current NUMA node to search
 
 	getAddrInterface func(name string) (addrFI, error)
 }
@@ -236,12 +235,10 @@ func (n *NUMAFabric) getNextDevice(numaNode int) *FabricInterface {
 func (n *NUMAFabric) findOnAnyNUMA(netDevClass hardware.NetDevClass, provider string) (*FabricInterface, error) {
 	numNodes := n.getNumNUMANodes()
 	for i := 0; i < numNodes; i++ {
-		numa := (n.defaultNumaNode + i) % numNodes
-		fi, err := n.getDeviceFromNUMA(numa, netDevClass, provider)
+		n.currentNUMANode = (n.currentNUMANode + 1) % numNodes
+		fi, err := n.getDeviceFromNUMA(n.currentNUMANode, netDevClass, provider)
 		if err == nil {
-			// Start the search on this node next time
-			n.defaultNumaNode = numa
-			n.log.Debugf("Suitable fabric interface %q found on NUMA node %d", fi.Name, numa)
+			n.log.Debugf("Suitable fabric interface %q found on NUMA node %d", fi.Name, n.currentNUMANode)
 			return fi, nil
 		}
 	}
@@ -263,14 +260,6 @@ func (n *NUMAFabric) getNextDevIndex(numaNode int) int {
 
 	// Unreachable -- callers looping on n.getNumDevices()
 	panic(fmt.Sprintf("no fabric interfaces on NUMA node %d", numaNode))
-}
-
-func (n *NUMAFabric) setDefaultNUMANode() {
-	for numa := range n.numaMap {
-		n.defaultNumaNode = numa
-		n.log.Debugf("The default NUMA node is: %d", numa)
-		break
-	}
 }
 
 func newNUMAFabric(log logging.Logger) *NUMAFabric {
@@ -300,8 +289,6 @@ func NUMAFabricFromScan(ctx context.Context, log logging.Logger, scan *hardware.
 		log.Debugf("Added device %q, domain %q for NUMA %d, device number %d",
 			newIF.Name, newIF.Domain, numa, fabric.NumDevices(numa)-1)
 	}
-
-	fabric.setDefaultNUMANode()
 
 	if fabric.NumNUMANodes() == 0 {
 		log.Info("No network devices detected in fabric scan")
@@ -339,7 +326,6 @@ func NUMAFabricFromConfig(log logging.Logger, cfg []*NUMAFabricConfig) *NUMAFabr
 				})
 		}
 	}
-	fabric.setDefaultNUMANode()
 
 	return fabric
 }


### PR DESCRIPTION
If the client process's NUMA node doesn't have a local network
interface that is usable with DAOS, we now load-balance among
all other interfaces across NUMA nodes.

Features: control

Signed-off-by: Kris Jacque <kristin.jacque@intel.com>