### PR TITLE
DAOS-10386 test: cart_self_test.py - Use pattern_timeout to wait 40 s…

### DIFF
--- a/src/tests/ftest/network/cart_self_test.yaml
+++ b/src/tests/ftest/network/cart_self_test.yaml
@@ -10,6 +10,8 @@ setup:
   start_servers_once: False
   agent_manager_class: Orterun
   server_manager_class: Orterun
+daos_server:
+  pattern_timeout: 40
 server_config:
   name: daos_server
 self_test:


### PR DESCRIPTION
…ec for server start up (#8766)

Current default server start up wait time is 30 sec, but
network/cart_self_test.py timed out, so increase the wait
time to 40 sec.

Test-tag: cartselftest
Test-repeat-vm: 10
Signed-off-by: Makito Kano <makito.kano@intel.com>