### PR TITLE
DAOS-8640 obj: bug fixes in EC degraded update, key query and aggrega…

### DIFF
--- a/src/include/daos_srv/evtree.h
+++ b/src/include/daos_srv/evtree.h
@@ -153,8 +153,8 @@ struct evt_filter {
 
 #define DP_FILTER(filter)					\
 	DP_EXT(&(filter)->fr_ex), (filter)->fr_epr.epr_lo,	\
-	(filter)->fr_epr.epr_hi, (filter)->fr_punch_epc,	\
-	(filter)->fr_epoch, (filter)->fr_punch_minor_epc
+	(filter)->fr_epr.epr_hi, (filter)->fr_epoch,		\
+	(filter)->fr_punch_epc, (filter)->fr_punch_minor_epc
 
 /** Return the width of an extent */
 static inline daos_size_t

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -6096,6 +6096,9 @@ dc_obj_query_key(tse_task_t *api_task)
 
 			leader = obj_grp_leader_get(obj, i, map_ver, NIL_BITMAP);
 			if (leader >= 0) {
+				if (obj_is_ec(obj) && !is_ec_parity_shard(leader, obj_get_oca(obj)))
+					goto non_leader;
+
 				rc = queue_shard_query_key_task(api_task, obj_auxi, &epoch, leader,
 								map_ver, obj, dkey_hash, &dti,
 								coh_uuid, cont_uuid);
@@ -6115,6 +6118,7 @@ dc_obj_query_key(tse_task_t *api_task)
 			}
 		}
 
+non_leader:
 		/* Then Try non-leader shards */
 		D_DEBUG(DB_IO, DF_OID" try non-leader shards for group %d.\n",
 			DP_OID(obj->cob_md.omd_id), i);

--- a/src/object/obj_enum.c
+++ b/src/object/obj_enum.c
@@ -957,8 +957,8 @@ unpack_recxs(daos_iod_t *iod, daos_epoch_t **recx_ephs, int *recxs_cap,
 			  sgl->sg_nr, iod->iod_nr);
 	}
 
-	D_DEBUG(DB_IO, "unpacked data %p idx/nr "DF_U64"/"DF_U64
-		" ver %u eph "DF_U64" size %zd epr ["DF_U64"/"DF_U64"]\n",
+	D_DEBUG(DB_IO, "unpacked data %p idx/nr "DF_X64"/"DF_U64
+		" ver %u eph "DF_X64" size %zd epr ["DF_X64"/"DF_X64"]\n",
 		rec, iod->iod_recxs[iod->iod_nr - 1].rx_idx,
 		iod->iod_recxs[iod->iod_nr - 1].rx_nr, rec->rec_version,
 		*eph, iod->iod_size, rec->rec_epr.epr_lo, rec->rec_epr.epr_hi);

--- a/src/object/srv_ec.c
+++ b/src/object/srv_ec.c
@@ -73,8 +73,6 @@ obj_ec_rw_req_split(daos_unit_oid_t oid, struct obj_iod_array *iod_array,
 	int			 count = 0;
 	int			 rc = 0;
 
-	/* minimal K/P is 2/1, so at least 1 forward targets */
-	D_ASSERT(tgt_nr >= 1);
 	D_ASSERT(oiods != NULL);
 	/* as we select the last parity node as leader, and for any update
 	 * there must be a siod (the last siod) for leader except for singv.

--- a/src/object/srv_ec_aggregate.c
+++ b/src/object/srv_ec_aggregate.c
@@ -486,7 +486,9 @@ agg_get_obj_handle(struct ec_agg_entry *entry)
 	struct ec_agg_param	*agg_param;
 	unsigned int		 k = ec_age2k(entry);
 	d_rank_t		 myrank;
-	int			 i, j, rc = 0;
+	uint32_t		 grp_idx;
+	struct daos_obj_shard	*sd;
+	int			 i, p, rc = 0;
 
 	if (daos_handle_is_valid(entry->ae_obj_hdl))
 		return rc;
@@ -503,19 +505,15 @@ agg_get_obj_handle(struct ec_agg_entry *entry)
 	if (rc)
 		goto out;
 
-	for (i = 0; i < layout->ol_nr; i++) {
-		struct daos_obj_shard *sd = layout->ol_shards[i];
-		int p;
-
-		for (j = p = 0; j < sd->os_replica_nr; j++) {
-			if (j >= k) {
-				entry->ae_peer_pshards[p].sd_rank
-					= sd->os_shard_loc[j].sd_rank;
-				entry->ae_peer_pshards[p].sd_tgt_idx
-					= sd->os_shard_loc[j].sd_tgt_idx;
-				p++;
-			}
-		}
+	grp_idx = ec_age2shard(entry) / (ec_age2k(entry) + ec_age2p(entry));
+	sd = layout->ol_shards[grp_idx];
+	for (i = k, p = 0; i < sd->os_replica_nr; i++) {
+		entry->ae_peer_pshards[p].sd_rank = sd->os_shard_loc[i].sd_rank;
+		entry->ae_peer_pshards[p].sd_tgt_idx = sd->os_shard_loc[i].sd_tgt_idx;
+		D_DEBUG(DB_TRACE, "ae_peer_pshards[%d] (grp %d), rank %d, tgt_idx %d\n",
+			p, grp_idx, entry->ae_peer_pshards[p].sd_rank,
+			entry->ae_peer_pshards[p].sd_tgt_idx);
+		p++;
 	}
 	daos_obj_layout_free(layout);
 out:
@@ -1367,6 +1365,8 @@ agg_peer_update_ult(void *arg)
 			crt_bulk_free(bulk_hdl);
 			bulk_hdl = NULL;
 		}
+		D_DEBUG(DB_TRACE, "send DAOS_OBJ_RPC_EC_AGGREGATE to %d:%d, peer %d, rc %d\n",
+			tgt_ep.ep_rank, tgt_ep.ep_tag, peer, rc);
 		if (csummer != NULL && iod_csums != NULL)
 			daos_csummer_free_ic(csummer, &iod_csums);
 		crt_req_decref(rpc);
@@ -2234,10 +2234,13 @@ ec_agg_object(daos_handle_t ih, vos_iter_entry_t *entry, struct ec_agg_param *ag
 	rc = agg_obj_is_leader(info->api_pool, &oca, &entry->ie_oid,
 			       info->api_pool->sp_map_version);
 	if (rc == 1) {
+		char	obj_class_name[32] = {0};
+
 		D_ASSERT((entry->ie_oid.id_shard % obj_ec_tgt_nr(&oca)) ==
 			 obj_ec_tgt_nr(&oca) - 1);
-		D_DEBUG(DB_EPC, "oid:"DF_UOID" ec agg starting\n",
-			DP_UOID(entry->ie_oid));
+		daos_oclass_id2name(daos_obj_id2class(entry->ie_oid.id_pub), obj_class_name);
+		D_DEBUG(DB_EPC, "oid:"DF_UOID"(%s) ec agg starting\n",
+			DP_UOID(entry->ie_oid), obj_class_name);
 
 		agg_reset_entry(&agg_param->ap_agg_entry, entry, &oca);
 		rc = 0;

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -1402,8 +1402,16 @@ obj_local_rw_internal(crt_rpc_t *rpc, struct obj_io_context *ioc,
 			}
 			iod_converted = true;
 
-			if (orw->orw_flags & ORF_EC_RECOV_FROM_PARITY)
+			if (orw->orw_flags & ORF_EC_RECOV_FROM_PARITY) {
+				if (shadows == NULL) {
+					rc = -DER_IO;
+					D_ERROR(DF_UOID" ORF_EC_RECOV_FROM_PARITY should not with "
+						"NULL shadows, "DF_RC"\n", DP_UOID(orw->orw_oid),
+						DP_RC(rc));
+					goto out;
+				}
 				fetch_flags |= VOS_OF_SKIP_FETCH;
+			}
 		}
 
 		rc = vos_fetch_begin(ioc->ioc_vos_coh, orw->orw_oid,
@@ -2559,7 +2567,7 @@ again1:
 	}
 
 again2:
-	if (orw->orw_iod_array.oia_oiods != NULL && split_req == NULL && tgt_cnt != 0) {
+	if (orw->orw_iod_array.oia_oiods != NULL && split_req == NULL) {
 		rc = obj_ec_rw_req_split(orw->orw_oid, &orw->orw_iod_array,
 					 orw->orw_nr, orw->orw_start_shard,
 					 orw->orw_tgt_max, PO_COMP_ID_ALL,

--- a/src/object/srv_obj_migrate.c
+++ b/src/object/srv_obj_migrate.c
@@ -1175,7 +1175,7 @@ __migrate_fetch_update_bulk(struct migrate_one *mrone, daos_handle_t oh,
 	}
 
 	D_DEBUG(DB_REBUILD,
-		DF_UOID" mrone %p dkey "DF_KEY" nr %d eph "DF_U64"\n",
+		DF_UOID" mrone %p dkey "DF_KEY" nr %d eph "DF_X64"\n",
 		DP_UOID(mrone->mo_oid), mrone, DP_KEY(&mrone->mo_dkey),
 		iod_num, mrone->mo_epoch);
 
@@ -1822,16 +1822,18 @@ rw_iod_pack(struct migrate_one *mrone, daos_iod_t *iod, daos_epoch_t *ephs, d_sg
 				}
 				nr++;
 			}
-			D_DEBUG(DB_REBUILD, "new recx "DF_U64"/"DF_U64"\n",
-				iod->iod_recxs[i].rx_idx, iod->iod_recxs[i].rx_nr);
+			D_DEBUG(DB_REBUILD, "new recx "DF_X64"/"DF_U64", parity_nr %d, nr %d, "
+				"start %d.\n", iod->iod_recxs[i].rx_idx, iod->iod_recxs[i].rx_nr,
+				parity_nr, nr, start);
 		}
+
 
 		if (parity_nr > 0) {
 			rc = migrate_insert_recxs_sgl(mrone->mo_iods_from_parity, NULL,
-						     &mrone->mo_iods_num_from_parity, iod,
-						     &iod->iod_recxs[start],
-						     &ephs[start], parity_nr,
-						     mrone->mo_sgls, sgl);
+						      &mrone->mo_iods_num_from_parity, iod,
+						      &iod->iod_recxs[start],
+						      &ephs[start], parity_nr,
+						      mrone->mo_sgls, sgl);
 			if (rc)
 				D_GOTO(out, rc);
 		}

--- a/src/tests/ftest/erasurecode/rebuild_fio.py
+++ b/src/tests/ftest/erasurecode/rebuild_fio.py
@@ -40,12 +40,16 @@ class EcodFioRebuild(ErasureCodeFio):
         self.start_online_fio()
 
         # Verify Aggregation should start for Partial stripes IO
-        if not any(check_aggregation_status(self.pool).values()):
+        if not any(check_aggregation_status(self.pool, attempt=60).values()):
             self.fail("Aggregation failed to start..")
 
         if 'off-line' in rebuild_mode:
             self.server_managers[0].stop_ranks(
                 [self.server_count - 1], self.d_log, force=True)
+
+        # Adding unlink option for final read command
+        if int(self.container.properties.value.split(":")[1]) == 1:
+            self.fio_cmd._jobs['test'].unlink.value = 1
 
         # Read and verify the original data.
         self.fio_cmd._jobs['test'].rw.value = self.read_option
@@ -53,6 +57,7 @@ class EcodFioRebuild(ErasureCodeFio):
 
         # If RF is 2 kill one more server and validate the data is not corrupted.
         if int(self.container.properties.value.split(":")[1]) == 2:
+            self.fio_cmd._jobs['test'].unlink.value = 1
             self.log.info("RF is 2,So kill another server and verify data")
             # Kill one more server rank
             self.server_managers[0].stop_ranks([self.server_count - 2],

--- a/src/tests/ftest/erasurecode/rebuild_fio.yaml
+++ b/src/tests/ftest/erasurecode/rebuild_fio.yaml
@@ -41,6 +41,7 @@ server_config:
       scm_list: ["/dev/pmem0"]
       scm_mount: /mnt/daos0
       log_mask: ERR
+      targets: 2
     1:
       pinned_numa_node: 1
       nr_xs_helpers: 1
@@ -53,6 +54,7 @@ server_config:
       scm_list: ["/dev/pmem1"]
       scm_mount: /mnt/daos1
       log_mask: ERR
+      targets: 2
 pool:
   mode: 146
   name: daos_server
@@ -70,6 +72,7 @@ container:
 fio:
   names:
     - test
+  api: POSIX
   test:
     numjobs: 10
     directory: "/tmp/daos_dfuse"
@@ -77,7 +80,7 @@ fio:
     verify_pattern: '0xabcdabcd'
     do_verify: 1
     iodepth: 10
-    size: 333MB
+    size: 133MB
     read_write: !mux
       write_read:
         rw: 'write'

--- a/src/tests/suite/daos_degrade_ec.c
+++ b/src/tests/suite/daos_degrade_ec.c
@@ -582,6 +582,7 @@ degrade_ec_update(void **state)
 	if (!test_runable(arg, 6) || (arg->srv_ntgts / arg->srv_nnodes) < 2)
 		return;
 
+	print_message("test 1 - DER_SHARDS_OVERLAP case\n");
 	data = (char *)malloc(TEST_EC_STRIPE_SIZE);
 	assert_true(data != NULL);
 	oid = daos_test_oid_gen(arg->coh, OC_EC_4P2G2, DAOS_OF_DKEY_UINT64, 0, arg->myrank);
@@ -601,6 +602,7 @@ degrade_ec_update(void **state)
 	}
 	ioreq_fini(&req);
 
+	print_message("test 2 - DAOS_FAIL_SHARD_OPEN case\n");
 	fail_shards[0] = 7;
 	fail_shards[1] = 8;
 	arg->fail_loc = DAOS_FAIL_SHARD_OPEN | DAOS_FAIL_ALWAYS;
@@ -615,6 +617,27 @@ degrade_ec_update(void **state)
 		memset(data, 'a' + i, TEST_EC_STRIPE_SIZE);
 		inset_recxs_dkey_uint64(&dkey_int, "a_key_1", 1, DAOS_TX_NONE, &recx, 1,
 			     data, TEST_EC_STRIPE_SIZE, &req);
+	}
+	ioreq_fini(&req);
+
+	print_message("test 3 - partial update only one leader alive case\n");
+	oid = daos_test_oid_gen(arg->coh, OC_EC_4P1G1, DAOS_OF_DKEY_UINT64, 0, arg->myrank);
+	/* simulate shard 0's failure, then partial update [0, 4096] will need to update
+	 * data shard 0 and parity shard 4, so only the leader shard 4 alive.
+	 */
+	fail_shards[0] = 1;
+	arg->fail_loc = DAOS_FAIL_SHARD_OPEN | DAOS_FAIL_ALWAYS;
+	arg->fail_value = daos_shard_fail_value(fail_shards, 1);
+	ioreq_init(&req, arg->coh, oid, DAOS_IOD_ARRAY, arg);
+	for (i = 0; i < 1; i++) {
+		daos_recx_t recx;
+
+		req.iod_type = DAOS_IOD_ARRAY;
+		recx.rx_nr = 4096;
+		recx.rx_idx = i * TEST_EC_STRIPE_SIZE;
+		memset(data, 'a' + i, 4096);
+		inset_recxs_dkey_uint64(&dkey_int, "a_key_2", 1, DAOS_TX_NONE, &recx, 1,
+					data, 4096, &req);
 	}
 	ioreq_fini(&req);
 

--- a/src/vos/evtree.c
+++ b/src/vos/evtree.c
@@ -977,8 +977,8 @@ evt_ent_array_sort(struct evt_context *tcx, struct evt_entry_array *ent_array,
 	int			 num_visible = 0;
 	int			 rc;
 
-	D_DEBUG(DB_TRACE, "Sorting array with filter "DF_FILTER"\n",
-		DP_FILTER(filter));
+	D_DEBUG(DB_TRACE, "Sorting array with filter "DF_FILTER", ea_ent_nr %d.\n",
+		DP_FILTER(filter), ent_array->ea_ent_nr);
 	if (ent_array->ea_ent_nr == 0)
 		return 0;
 


### PR DESCRIPTION
…tion (#8535)

(master commit : 9f6ffda55d81)
1) fix a bug in EC degraded update
For EC (K+1) obj partial update, it will update to one data shard and
replicate to one parity shard. When that data shard failed, the degraded
update will send to the leader parity shard.
The code of ds_obj_rw_handler() -> obj_gen_dtx_mbs() will change the
tgt_cnt to zero, then will not call obj_ec_rw_req_split() for the update
request. Actually for that case still need to call obj_ec_rw_req_split()
to split the iod->iod_recxs[] for the leader.
2) Fix a bug in dc_obj_query_key
For EC obj, obj_grp_leader_get() possibly return data shard when
parity shard failed, in that case for key query should send RPC
to all data shards.
3) Fix a bug in peer address in EC agg
Fix a bug in peer address (entry->ae_peer_pshards) for multiple
group case.
And a few refines of log msg and err handling.
Add a test case in degrade_ec_update.

Signed-off-by: Xuezhao Liu <xuezhao.liu@intel.com>