### PR TITLE
DAOS-9078 test: Fix sequential decrease in containers (#8424) (Cherry pick for release/2.2)

### DIFF
--- a/src/tests/ftest/server/metadata.py
+++ b/src/tests/ftest/server/metadata.py
@@ -303,42 +303,50 @@ class ObjectMetadata(TestWithServers):
         """
         self.create_pool()
         self.container = []
+        mean_cont_cnt = 0
+        percent_cont = self.params.get("mean_percent", "/run/metadata/*")
 
         test_failed = False
         containers_created = []
         for loop in range(10):
             self.log.info("Container Create Iteration %d / 9", loop)
+            # The test will encounter ENOSPACE (-1007) while creating
+            # containers.
             if not self.create_all_containers():
                 self.log.error("Errors during create iteration %d/9", loop)
-                test_failed = True
 
             containers_created.append(len(self.container))
-
+            # We should make sure containers which are created should
+            # be destroyed without issues. Here we have to check for
+            # any container destroy errors.
             self.log.info("Container Remove Iteration %d / 9", loop)
             if not self.destroy_all_containers():
                 self.log.error("Errors during remove iteration %d/9", loop)
                 test_failed = True
+        # Calculate the mean container count
+        mean_cont_cnt = sum(containers_created) / len(containers_created)
+        percent_from_mean = int(mean_cont_cnt * (percent_cont / 100))
+        self.log.info(
+            "Mean number of containers created in %s loops: %s",
+            len(containers_created), mean_cont_cnt)
+        self.log.info(
+            "Max variation in number of containers from %s%% from mean: %s",
+            percent_cont, percent_from_mean)
 
         self.log.info("Summary")
         self.log.info("  Loop  Containers Created  Variation")
         self.log.info("  ----  ------------------  ---------")
-        sequential_negative_count = 0
         for loop, quantity in enumerate(containers_created):
             variation = 0
             if loop > 0:
-                # Variations in the number of containers created is expected,
-                # but make sure the number does not decrease more than 3 times
-                # in a row.
-                variation = quantity - containers_created[loop - 1]
-                if variation < 0:
-                    sequential_negative_count += 1
-                    if sequential_negative_count > 2:
-                        test_failed = True
-                        variation = \
-                            "{}  **FAIL: {} sequential decreases".format(
-                                variation, sequential_negative_count)
-                else:
-                    sequential_negative_count = 0
+                # Variation in the number of containers created
+                # should be less than %x from mean containers created
+                variation = abs(mean_cont_cnt - containers_created[loop - 1])
+                if variation > percent_from_mean:
+                    test_failed = True
+                    variation = \
+                        "{}  **FAIL: {} variation failure from mean".format(
+                            variation, percent_from_mean)
             self.log.info("  %-4d  %-18d  %s", loop + 1, quantity, variation)
 
         if test_failed:

--- a/src/tests/ftest/server/metadata.yaml
+++ b/src/tests/ftest/server/metadata.yaml
@@ -70,3 +70,5 @@ ior:
     F: "-r -R -G 1"
   objectclass:
     dfs_oclass: "SX"
+metadata:
+  mean_percent: 0.5


### PR DESCRIPTION
Skip-unit-tests: true
Test-tag: offline_extend_oclass metadata_addremove
Test-repeat: 10

Test now calculates the total container difference the test should not deviate for each test loop. (eg: Assume mean containers created for each run is around 2500 containers. total container difference for each test loop = 2500 * (mean_percent [defined in yaml] / 100) = 13 containers.

Each test loop cannot exceed mean_container_count + percent deviation accepted. As shown in the above example, if mean_container_count is 2500, the percent deviation is 13. Which means total containers created for each loop can be in between 2513 and 2487.

Based on more investigation, we can still update the mean_percent value in the YAML to either high value or low value. For now, the value is 0.5 percent.

Signed-off-by: rpadma2 ravindran.padmanabhan@intel.com