### PR TITLE
DAOS-10217-test: Invalid pool rebuild info rs_state=1 detected after rebuild

### DIFF
--- a/src/tests/ftest/rebuild/no_cap.py
+++ b/src/tests/ftest/rebuild/no_cap.py
@@ -156,7 +156,7 @@ class RbldNoCapacity(TestWithServers):
         pool_checks["pi_ndisabled"] = ">0"
         rebuild_checks["rs_obj_nr"] = ">=0"
         rebuild_checks["rs_rec_nr"] = ">=0"
-        rebuild_checks["rs_state"] = 0
+        rebuild_checks["rs_state"] = ">=0"
         self.assertTrue(
             self.pool.check_pool_info(**pool_checks),
             "#Invalid pool information detected after rebuild")


### PR DESCRIPTION
Description:  rebuild will keep retry due to out of space (-1007) error. Update test script per JIRA comment, rs_state could be 0 or 1.

Quick-Functional: true
Test-tag: no_cap
Test-repeat: 10
Signed-off-by: Ding Ho ding-hwa.ho@intel.com