### PR TITLE
DAOS-623 test: Resolve flake8 lint import error

### DIFF
--- a/src/tests/ftest/util/test_utils_base.py
+++ b/src/tests/ftest/util/test_utils_base.py
@@ -5,7 +5,6 @@
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
 from logging import getLogger
-from os import environ
 from time import sleep
 
 from command_utils_base import ObjectWithParameters, BasicParameter


### PR DESCRIPTION
Fix the F401 'os.environ' imported but unused Flake8 error recently
introduced in test_utils_base.py.

Skip-uint-tests: true

Signed-off-by: Phillip Henderson <phillip.henderson@intel.com>