### PR TITLE
DAOS-9919 ci: Update dnf settings in docker containers.

### DIFF
--- a/utils/docker/Dockerfile.centos.7
+++ b/utils/docker/Dockerfile.centos.7
@@ -24,14 +24,16 @@ RUN set -e;                                                      \
         done;                                                    \
         mv daos_ci-centos7-artifactory.repo{.tmp,};              \
     fi;                                                          \
-    yum -y install dnf;                                          \
+    yum --assumeyes install dnf;                                 \
     yum clean all;                                               \
-    dnf --disablerepo \*epel\* -y install epel-release           \
-                                          dnf-plugins-core;      \
+    dnf --assumeyes --disablerepo \*epel\* install               \
+                        epel-release dnf-plugins-core;           \
+    dnf config-manager --save --setopt=assumeyes=True;           \
+    dnf config-manager --save --setopt=install_weak_deps=False;  \
     if [ -n "$REPO_FILE_URL" ]; then                             \
-        dnf -y --quiet config-manager --disable epel;            \
+        dnf --quiet config-manager --disable epel;               \
     fi;                                                          \
-    dnf -y clean all
+    dnf clean all
 
 ARG JENKINS_URL
 ARG REPOS
@@ -52,13 +54,13 @@ baseurl=${JENKINS_URL}job/daos-stack/job/$repo/job/$branch/$build_number/artifac
 enabled=1\n\
 gpgcheck=False\n" >> /etc/yum.repos.d/$repo:$branch:$build_number.repo;   \
         cat /etc/yum.repos.d/$repo:$branch:$build_number.repo; \
-        dnf -y repolist; \
+        dnf repolist; \
         dnf --disablerepo=\* --enablerepo=$repo:$branch:$build_number makecache; \
     done
 
 # Install OS updates and package.  Include basic tools and daos dependencies
 COPY ./utils/scripts/install-centos7.sh /tmp/install.sh
-RUN chmod +x /tmp/install.sh && dnf -y upgrade && /tmp/install.sh && dnf -y clean all && \
+RUN chmod +x /tmp/install.sh && dnf upgrade && /tmp/install.sh && dnf clean all && \
     rm -f /tmp/install.sh
 
 ARG UID=1000
@@ -84,8 +86,8 @@ ARG QUICKBUILD_DEPS
 RUN if $QUICKBUILD; then                                          \
         echo "Installing: $QUICKBUILD_DEPS";                      \
         echo "$QUICKBUILD_DEPS" | sed -e '/^$/d' | tr '\n' '\0' | \
-          xargs -0 dnf -y install;                                \
-        dnf -y clean all;                                            \
+          xargs -0 dnf install;                                   \
+        dnf clean all;                                            \
     fi
 
 ARG BULLSEYE
@@ -124,10 +126,9 @@ ARG DAOS_TARGET_TYPE=release
 # src hasn't changed then this won't do anything, but if it has then we want to
 # ensure that latest dependencies are used.
 USER root:root
-RUN [ "$DAOS_DEPS_BUILD" != "yes" ] || {                                       \
-        dnf -y upgrade                                                         \
-            --exclude=spdk,spdk-devel,dpdk-devel,dpdk,mercury-devel,mercury && \
-        dnf -y clean all;                                                         \
+RUN [ "$DAOS_DEPS_BUILD" != "yes" ] || {                                               \
+        dnf upgrade --exclude=spdk,spdk-devel,dpdk-devel,dpdk,mercury-devel,mercury && \
+        dnf clean all;                                                                 \
     }
 USER daos_server:daos_server
 
@@ -140,13 +141,11 @@ RUN [ "$DAOS_DEPS_BUILD" != "yes" ] || {                            \
     }
 USER root:root
 
-# select compiler to use
-ARG COMPILER=gcc
 # force an upgrade to get any newly built RPMs, but only if CACHEBUST is set.
 ARG CACHEBUST
-RUN [ -z "$CACHEBUST" ] || {                                                              \
-        dnf -y upgrade --exclude=spdk,spdk-devel,dpdk-devel,dpdk,mercury-devel,mercury && \
-        dnf -y clean all;                                                                    \
+RUN [ -z "$CACHEBUST" ] || {                                                           \
+        dnf upgrade --exclude=spdk,spdk-devel,dpdk-devel,dpdk,mercury-devel,mercury && \
+        dnf clean all;                                                                 \
     }
 USER daos_server:daos_server
 
@@ -160,6 +159,8 @@ COPY --chown=daos_server:daos_server site_scons site_scons
 COPY --chown=daos_server:daos_server utils utils
 COPY --chown=daos_server:daos_server src src
 
+# select compiler to use
+ARG COMPILER=gcc
 ARG JOBS=$DEPS_JOBS
 ARG DAOS_BUILD_TYPE=$DAOS_TARGET_TYPE
 ARG DAOS_BUILD=$DAOS_DEPS_BUILD
@@ -186,7 +187,7 @@ RUN [ "$DAOS_JAVA_BUILD" != "yes" ] || {                                        
         mkdir /home/daos/.m2 &&                                                               \
         cp /home/daos/daos/utils/scripts/maven-settings.xml.in /home/daos/.m2/settings.xml && \
         mvn clean install -T 1C                                                               \
-            -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn                                                   \
+            -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn \
             -DskipITs -Dgpg.skip -Ddaos.install.path=/opt/daos;                               \
     }
 WORKDIR /home/daos

--- a/utils/docker/Dockerfile.el.8
+++ b/utils/docker/Dockerfile.el.8
@@ -29,14 +29,26 @@ RUN set -e;                                                      \
     dnf config-manager --save --setopt=assumeyes=True;           \
     dnf config-manager --save --setopt=install_weak_deps=False;  \
     if [ ! -f /etc/fedora-release ]; then                        \
+<<<<<<< HEAD
         dnf --disablerepo \*epel\* install epel-release;         \
+=======
+        dnf --assumeyes --disablerepo \*epel\* install           \
+                            epel-release dnf-plugins-core;       \
+>>>>>>> fed4c9754 (DAOS-9919 ci: Update dnf settings in docker containers.)
         if [ -n "$REPO_FILE_URL" ]; then                         \
             PT_REPO=daos_ci-rocky8-powertools-artifactory;       \
         else                                                     \
             PT_REPO=powertools;                                  \
         fi;                                                      \
+<<<<<<< HEAD
         dnf config-manager --enable $PT_REPO;                    \
     fi;                                                          \
+=======
+        dnf --assumeyes config-manager --enable $PT_REPO;        \
+    fi;                                                          \
+    dnf config-manager --save --setopt=assumeyes=True;           \
+    dnf config-manager --save --setopt=install_weak_deps=False;  \
+>>>>>>> fed4c9754 (DAOS-9919 ci: Update dnf settings in docker containers.)
     dnf clean all
 
 ARG JENKINS_URL

--- a/utils/docker/Dockerfile.el.8
+++ b/utils/docker/Dockerfile.el.8
@@ -25,9 +25,11 @@ RUN set -e;                                                      \
         done;                                                    \
         mv daos_ci-el8-artifactory.repo{.tmp,};                  \
     fi;                                                          \
+    dnf --assumeyes --disablerepo \*epel\* install dnf-plugins-core;     \
+    dnf config-manager --save --setopt=assumeyes=True;           \
+    dnf config-manager --save --setopt=install_weak_deps=False;  \
     if [ ! -f /etc/fedora-release ]; then                        \
-        dnf --assumeyes --disablerepo \*epel\* install           \
-                            epel-release dnf-plugins-core;       \
+        dnf --assumeyes --disablerepo \*epel\* install epel-release; \
         if [ -n "$REPO_FILE_URL" ]; then                         \
             PT_REPO=daos_ci-rocky8-powertools-artifactory;       \
         else                                                     \
@@ -35,8 +37,6 @@ RUN set -e;                                                      \
         fi;                                                      \
         dnf --assumeyes config-manager --enable $PT_REPO;        \
     fi;                                                          \
-    dnf config-manager --save --setopt=assumeyes=True;           \
-    dnf config-manager --save --setopt=install_weak_deps=False;  \
     dnf clean all
 
 ARG JENKINS_URL

--- a/utils/docker/Dockerfile.el.8
+++ b/utils/docker/Dockerfile.el.8
@@ -29,26 +29,16 @@ RUN set -e;                                                      \
     dnf config-manager --save --setopt=assumeyes=True;           \
     dnf config-manager --save --setopt=install_weak_deps=False;  \
     if [ ! -f /etc/fedora-release ]; then                        \
-<<<<<<< HEAD
-        dnf --disablerepo \*epel\* install epel-release;         \
-=======
         dnf --assumeyes --disablerepo \*epel\* install           \
                             epel-release dnf-plugins-core;       \
->>>>>>> fed4c9754 (DAOS-9919 ci: Update dnf settings in docker containers.)
+        dnf --assumeyes --disablerepo \*epel\* install epel-release; \
         if [ -n "$REPO_FILE_URL" ]; then                         \
             PT_REPO=daos_ci-rocky8-powertools-artifactory;       \
         else                                                     \
             PT_REPO=powertools;                                  \
         fi;                                                      \
-<<<<<<< HEAD
         dnf config-manager --enable $PT_REPO;                    \
     fi;                                                          \
-=======
-        dnf --assumeyes config-manager --enable $PT_REPO;        \
-    fi;                                                          \
-    dnf config-manager --save --setopt=assumeyes=True;           \
-    dnf config-manager --save --setopt=install_weak_deps=False;  \
->>>>>>> fed4c9754 (DAOS-9919 ci: Update dnf settings in docker containers.)
     dnf clean all
 
 ARG JENKINS_URL

--- a/utils/docker/Dockerfile.el.8
+++ b/utils/docker/Dockerfile.el.8
@@ -26,16 +26,18 @@ RUN set -e;                                                      \
         mv daos_ci-el8-artifactory.repo{.tmp,};                  \
     fi;                                                          \
     if [ ! -f /etc/fedora-release ]; then                        \
-        dnf --disablerepo \*epel\* -y install epel-release       \
-                                              dnf-plugins-core;  \
+        dnf --assumeyes --disablerepo \*epel\* install           \
+                            epel-release dnf-plugins-core;       \
         if [ -n "$REPO_FILE_URL" ]; then                         \
             PT_REPO=daos_ci-rocky8-powertools-artifactory;       \
         else                                                     \
             PT_REPO=powertools;                                  \
         fi;                                                      \
-        dnf -y config-manager --enable $PT_REPO;                 \
+        dnf --assumeyes config-manager --enable $PT_REPO;        \
     fi;                                                          \
-    dnf -y clean all
+    dnf config-manager --save --setopt=assumeyes=True;           \
+    dnf config-manager --save --setopt=install_weak_deps=False;  \
+    dnf clean all
 
 ARG JENKINS_URL
 ARG REPOS
@@ -56,13 +58,13 @@ baseurl=${JENKINS_URL}job/daos-stack/job/$repo/job/$branch/$build_number/artifac
 enabled=1\n\
 gpgcheck=False\n" >> /etc/yum.repos.d/$repo:$branch:$build_number.repo;   \
         cat /etc/yum.repos.d/$repo:$branch:$build_number.repo; \
-        dnf -y repolist; \
+        dnf repolist; \
         dnf --disablerepo=\* --enablerepo=$repo:$branch:$build_number makecache; \
     done
 
 # Install OS updates and package.  Include basic tools and daos dependencies
 COPY ./utils/scripts/install-el8.sh /tmp/install.sh
-RUN chmod +x /tmp/install.sh && dnf -y upgrade && /tmp/install.sh && dnf -y clean all && \
+RUN chmod +x /tmp/install.sh && dnf upgrade && /tmp/install.sh && dnf clean all && \
     rm -f /tmp/install.sh
 
 ARG UID=1000
@@ -86,8 +88,8 @@ ARG QUICKBUILD_DEPS
 RUN if $QUICKBUILD; then                                          \
         echo "Installing: $QUICKBUILD_DEPS";                      \
         echo "$QUICKBUILD_DEPS" | sed -e '/^$/d' | tr '\n' '\0' | \
-          xargs -0 dnf -y install;                                \
-        dnf -y clean all;                                            \
+          xargs -0 dnf install;                                   \
+        dnf clean all;                                            \
     fi
 
 ARG BULLSEYE
@@ -133,10 +135,9 @@ ARG DAOS_TARGET_TYPE=release
 # src hasn't changed then this won't do anything, but if it has then we want to
 # ensure that latest dependencies are used.
 USER root:root
-RUN [ "$DAOS_DEPS_BUILD" != "yes" ] || {                                       \
-        dnf -y upgrade                                                         \
-            --exclude=spdk,spdk-devel,dpdk-devel,dpdk,mercury-devel,mercury && \
-        dnf -y clean all;                                                         \
+RUN [ "$DAOS_DEPS_BUILD" != "yes" ] || {                                               \
+        dnf upgrade --exclude=spdk,spdk-devel,dpdk-devel,dpdk,mercury-devel,mercury && \
+        dnf clean all;                                                                 \
     }
 USER daos_server:daos_server
 
@@ -149,13 +150,11 @@ RUN [ "$DAOS_DEPS_BUILD" != "yes" ] || {                            \
     }
 USER root:root
 
-# select compiler to use
-ARG COMPILER=gcc
 # force an upgrade to get any newly built RPMs, but only if CACHEBUST is set.
 ARG CACHEBUST
-RUN [ -z "$CACHEBUST" ] || {                                                              \
-        dnf -y upgrade --exclude=spdk,spdk-devel,dpdk-devel,dpdk,mercury-devel,mercury && \
-        dnf -y clean all;                                                                    \
+RUN [ -z "$CACHEBUST" ] || {                                                           \
+        dnf upgrade --exclude=spdk,spdk-devel,dpdk-devel,dpdk,mercury-devel,mercury && \
+        dnf clean all;                                                                 \
     }
 USER daos_server:daos_server
 
@@ -169,6 +168,8 @@ COPY --chown=daos_server:daos_server site_scons site_scons
 COPY --chown=daos_server:daos_server utils utils
 COPY --chown=daos_server:daos_server src src
 
+# select compiler to use
+ARG COMPILER=gcc
 ARG JOBS=$DEPS_JOBS
 ARG DAOS_BUILD_TYPE=$DAOS_TARGET_TYPE
 ARG DAOS_BUILD=$DAOS_DEPS_BUILD
@@ -195,7 +196,7 @@ RUN [ "$DAOS_JAVA_BUILD" != "yes" ] || {                                        
         mkdir /home/daos/.m2 &&                                                               \
         cp /home/daos/daos/utils/scripts/maven-settings.xml.in /home/daos/.m2/settings.xml && \
         mvn clean install -T 1C                                                               \
-            -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn                                                   \
+            -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn \
             -DskipITs -Dgpg.skip -Ddaos.install.path=/opt/daos;                               \
     }
 WORKDIR /home/daos

--- a/utils/docker/Dockerfile.el.8
+++ b/utils/docker/Dockerfile.el.8
@@ -29,13 +29,13 @@ RUN set -e;                                                      \
     dnf config-manager --save --setopt=assumeyes=True;           \
     dnf config-manager --save --setopt=install_weak_deps=False;  \
     if [ ! -f /etc/fedora-release ]; then                        \
-        dnf --assumeyes --disablerepo \*epel\* install epel-release; \
+        dnf --disablerepo \*epel\* install epel-release;         \
         if [ -n "$REPO_FILE_URL" ]; then                         \
             PT_REPO=daos_ci-rocky8-powertools-artifactory;       \
         else                                                     \
             PT_REPO=powertools;                                  \
         fi;                                                      \
-        dnf --assumeyes config-manager --enable $PT_REPO;        \
+        dnf config-manager --enable $PT_REPO;                    \
     fi;                                                          \
     dnf clean all
 

--- a/utils/docker/Dockerfile.leap.15
+++ b/utils/docker/Dockerfile.leap.15
@@ -31,7 +31,10 @@ RUN set -e;                                                      \
     for file in *.repo; do                                       \
         sed -e '/type=NONE/d' < $file > /etc/dnf/repos.d/$file;  \
     done;                                                        \
-    zypper --non-interactive clean --all
+    zypper --non-interactive clean --all;                        \
+    dnf config-manager --save --setopt=assumeyes=True;           \
+    dnf config-manager --save --setopt=install_weak_deps=False
+
 ARG JENKINS_URL
 ARG REPOS
 RUN for repo in $REPOS; do                                                                                 \
@@ -51,13 +54,13 @@ baseurl=${JENKINS_URL}job/daos-stack/job/$repo/job/$branch/$build_number/artifac
 enabled=1\n\
 gpgcheck=False\n" >> /etc/dnf/repos.d/$repo:$branch:$build_number.repo;   \
         cat /etc/dnf/repos.d/$repo:$branch:$build_number.repo; \
-        dnf -y repolist; \
+        dnf repolist; \
         dnf --disablerepo=\* --enablerepo=$repo:$branch:$build_number makecache; \
     done
 
 # Install OS updates and package.  Include basic tools and daos dependencies
 COPY ./utils/scripts/install-leap15.sh /tmp/install.sh
-RUN chmod +x /tmp/install.sh && dnf -y upgrade && /tmp/install.sh && dnf -y clean all && \
+RUN chmod +x /tmp/install.sh && dnf upgrade && /tmp/install.sh && dnf clean all && \
     rm -f /tmp/install.sh
 RUN if ! grep MODULEPATH=.*/usr/share/modules /etc/profile.d/lmod.sh; then \
         sed -e '/MODULEPATH=/s/$/:\/usr\/share\/modules/'                  \
@@ -89,11 +92,10 @@ ARG QUICKBUILD_DEPS
 RUN if $QUICKBUILD; then                                          \
         echo "Installing: $QUICKBUILD_DEPS";                      \
         echo "$QUICKBUILD_DEPS" | sed -e '/^$/d' | tr '\n' '\0' | \
-          xargs -0 dnf -y install;                                \
-        dnf -y clean all;                                         \
+          xargs -0 dnf install;                                   \
+        dnf clean all;                                            \
     fi
 
-USER daos_server:daos_server
 WORKDIR /home/daos/pre
 COPY --chown=daos_server:daos_server SConstruct .
 COPY --chown=daos_server:daos_server site_scons site_scons
@@ -109,11 +111,10 @@ ARG DAOS_TARGET_TYPE=release
 # Now do an update to ensure software is up to date for the deps build.  If the
 # src hasn't changed then this won't do anything, but if it has then we want to
 # ensure that latest dependencies are used.
-USER root:root
 RUN [ "$DAOS_DEPS_BUILD" != "yes" ] || {                                                  \
-        dnf -y upgrade                                                                    \
+        dnf upgrade                                                                       \
             --exclude=fuse,fuse-libs,fuse-devel,libraft0,raft-devel,mercury,mercury-devel \
-        dnf -y clean all;                                                                 \
+        dnf clean all;                                                                    \
     }
 USER daos_server:daos_server
 
@@ -139,17 +140,17 @@ ARG COMPILER=gcc
 RUN if [ "$COMPILER" = "icc" ]; then                                                                     \
         if [ -z "$REPO_FILE_URL" ] || true; then                                                         \
             rpm --import https://yum.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB && \
-            dnf -y config-manager --add-repo https://yum.repos.intel.com/oneapi oneAPI;                  \
+            dnf config-manager --add-repo https://yum.repos.intel.com/oneapi oneAPI;                     \
         fi;                                                                                              \
-        dnf -y install intel-oneapi-compiler-dpcpp-cpp &&                                                \
-        dnf -y clean all;                                                                                \
+        dnf install intel-oneapi-compiler-dpcpp-cpp &&                                                   \
+        dnf clean all;                                                                                   \
     fi
 
 # force an upgrade to get any newly built RPMs, but only if CACHEBUST is set.
 ARG CACHEBUST
-RUN [ -z "$CACHEBUST" ] || {                                                                            \
-        dnf -y upgrade --exclude=fuse,fuse-libs,fuse-devel,libraft0,raft-devel,mercury,mercury-devel && \
-        dnf -y clean all;                                                                               \
+RUN [ -z "$CACHEBUST" ] || {                                                                         \
+        dnf upgrade --exclude=fuse,fuse-libs,fuse-devel,libraft0,raft-devel,mercury,mercury-devel && \
+        dnf clean all;                                                                               \
     }
 USER daos_server:daos_server
 

--- a/utils/docker/Dockerfile.leap.15
+++ b/utils/docker/Dockerfile.leap.15
@@ -111,6 +111,7 @@ ARG DAOS_TARGET_TYPE=release
 # Now do an update to ensure software is up to date for the deps build.  If the
 # src hasn't changed then this won't do anything, but if it has then we want to
 # ensure that latest dependencies are used.
+USER root:root
 RUN [ "$DAOS_DEPS_BUILD" != "yes" ] || {                                                  \
         dnf upgrade                                                                       \
             --exclude=fuse,fuse-libs,fuse-devel,libraft0,raft-devel,mercury,mercury-devel \

--- a/utils/scripts/install-centos7.sh
+++ b/utils/scripts/install-centos7.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/sh -e
 
 # Install OS updates and package.  Include basic tools and daos dependencies
 # that come from the core repo.
@@ -8,10 +8,7 @@
 # post provisioning issue.
 # *** Keep these in as much alphbetical order as possible ***
 
-set -e
-
-dnf -y install deltarpm
-dnf -y --nodocs install \
+dnf --nodocs install \
     boost-python36-devel \
     bzip2 \
     clang-analyzer \

--- a/utils/scripts/install-el8.sh
+++ b/utils/scripts/install-el8.sh
@@ -7,9 +7,8 @@
 # interactively then these two commands can be used to set dnf into automatic mode.
 # dnf --assumeyes install dnf-plugins-core
 # dnf config-manager --save --setopt=assumeyes=True
-set -e
 
-dnf -y --nodocs install \
+dnf --nodocs install \
     boost-python3-devel \
     bzip2 \
     clang \
@@ -66,7 +65,7 @@ dnf -y --nodocs install \
 # installed specifically.
 
 if [ -e /etc/fedora-release ]; then
-        dnf -y install java-1.8.0-openjdk-devel maven-openjdk8
+        dnf install java-1.8.0-openjdk-devel maven-openjdk8
 else
-        dnf -y install maven
+        dnf install maven
 fi

--- a/utils/scripts/install-leap15.sh
+++ b/utils/scripts/install-leap15.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/sh -e
 
 # Install OS updates and package.  Include basic tools and daos dependencies
 # that come from the core repo.
@@ -8,9 +8,7 @@
 # post provisioning issue.
 # *** Keep these in as much alphbetical order as possible ***
 
-set -e
-
-dnf -y --nodocs install \
+dnf --nodocs install \
     boost-devel \
     bzip2 \
     curl \


### PR DESCRIPTION
Set assumeyes=True in the config file so the scripts can be
run without the -y flag allowing for interactive use if desired.

Move the COMPILER arg as late as possible before it's required
to make most use of the docker cache.

Whitespace fixes after the previous commit.

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>
