### PR TITLE
DAOS-9028 gc: Pre-allocate first GC bags (#8708)

### DIFF
--- a/src/vos/vos_gc.c
+++ b/src/vos/vos_gc.c
@@ -29,7 +29,7 @@ enum {
  * - each item consumes 16 bytes, 250 * 16 = 4000 bytes
  * - together is 4080 bytes, reserve 16 bytes for future use
  */
-static int gc_bag_size	= 250;
+static int gc_bag_size	= 250 + 3 * 256;
 
 /** VOS garbage collector */
 struct vos_gc {
@@ -808,7 +808,10 @@ gc_reclaim_pool(struct vos_pool *pool, int *credits, bool *empty_ret)
 int
 gc_init_pool(struct umem_instance *umm, struct vos_pool_df *pd)
 {
-	int	i;
+	int		i;
+	umem_off_t	bag_id;
+	int		size;
+	int		rc;
 
 	D_DEBUG(DB_IO, "Init garbage bins for pool="DF_UUID"\n",
 		DP_UUID(pd->pd_id));
@@ -816,10 +819,19 @@ gc_init_pool(struct umem_instance *umm, struct vos_pool_df *pd)
 	for (i = 0; i < GC_MAX; i++) {
 		struct vos_gc_bin_df *bin = &pd->pd_gc_bins[i];
 
-		bin->bin_bag_first = UMOFF_NULL;
-		bin->bin_bag_last  = UMOFF_NULL;
+		size = offsetof(struct vos_gc_bag_df, bag_items[gc_bag_size]);
+		bag_id = umem_zalloc(umm, size);
+		if (UMOFF_IS_NULL(bag_id))
+			return -DER_NOMEM;
+
+		rc = umem_tx_add_ptr(umm, bin, sizeof(*bin));
+		if (rc != 0)
+			return rc;
+
 		bin->bin_bag_size  = gc_bag_size;
-		bin->bin_bag_nr	   = 0;
+		bin->bin_bag_first = bag_id;
+		bin->bin_bag_last = bag_id;
+		bin->bin_bag_nr = 1;
 	}
 	return 0;
 }


### PR DESCRIPTION
When pools are too small, SCM space reserving is disabled. This
is problematic for tests that use tiny pools, fill them and then
try to delete a container. The gc bag isn't able to be allocated
for garbage collection. By pre-allocating the first bags this
issue can be worked around.

Signed-off-by: Ryon Jensen <ryon.jensen@intel.com>

Back-port of PR #8708 