### PR TITLE
DAOS-10377 csum: Enable Target Auto Eviction Test

### DIFF
--- a/src/tests/ftest/scrubber/target_auto_eviction.py
+++ b/src/tests/ftest/scrubber/target_auto_eviction.py
@@ -17,7 +17,6 @@ class TestWithScrubberTargetEviction(TestWithScrubber):
 
     :avocado: recursive
     """
-    @skipForTicket("DAOS-10377")
     def test_scrubber_ssd_auto_eviction(self):
         """JIRA ID: DAOS-7300
 


### PR DESCRIPTION
In local testing the scrubber Target Auto Eviction test is
passing so removing skipForTicket("DAOS-10377"). If passes in
CI then a previous fix may have resolved the issue that was seen.

Signed-off-by: Ryon Jensen <ryon.jensen@intel.com>