### PR TITLE
DAOS-10227 vos: Optimize setting of aggregatable time (#8752)

### DIFF
--- a/src/include/daos_srv/evtree.h
+++ b/src/include/daos_srv/evtree.h
@@ -587,6 +587,10 @@ int evt_drain(daos_handle_t toh, int *credits, bool *destroyed);
  * \param toh		[IN]	The tree open handle
  * \param entry		[IN]	The entry to insert
  * \param csum_bufp	[OUT]	The pointer for the csum copy location.
+ *
+ * \return	0 success
+ *		1 success, detected potential need for aggregation
+ *		< 0 on error
  */
 int evt_insert(daos_handle_t toh, const struct evt_entry_in *entry,
 	       uint8_t **csum_bufp);

--- a/src/vos/evtree.c
+++ b/src/vos/evtree.c
@@ -2073,6 +2073,7 @@ evt_large_hole_insert(daos_handle_t toh, const struct evt_entry_in *entry)
 	struct evt_entry_in	 hole;
 	struct evt_filter	 filter = {0};
 	EVT_ENT_ARRAY_SM_PTR(ent_array);
+	int			 alt_rc = 0;
 	int			 rc = 0;
 
 	filter.fr_epr.epr_hi = entry->ei_bound;
@@ -2091,13 +2092,17 @@ evt_large_hole_insert(daos_handle_t toh, const struct evt_entry_in *entry)
 		hole = *entry;
 		hole.ei_rect.rc_ex = ent->en_sel_ext;
 		rc = evt_insert(toh, &hole, NULL);
-		if (rc != 0)
+		if (rc < 0)
 			break;
+		if (rc == 1) {
+			alt_rc = 1;
+			rc = 0;
+		}
 	}
 done:
 	evt_ent_array_fini(ent_array);
 
-	return rc;
+	return rc == 0 ? alt_rc : rc;
 }
 
 /**
@@ -2116,6 +2121,7 @@ evt_insert(daos_handle_t toh, const struct evt_entry_in *entry,
 	const struct evt_entry_in	*entryp = entry;
 	struct evt_filter		 filter;
 	int				 rc;
+	int				 alt_rc = 0;
 
 	tcx = evt_hdl2tcx(toh);
 	if (tcx == NULL)
@@ -2155,7 +2161,8 @@ evt_insert(daos_handle_t toh, const struct evt_entry_in *entry,
 	/* Phase-1: Check for overwrite and uncertainty */
 	rc = evt_ent_array_fill(tcx, EVT_FIND_OVERWRITE, DAOS_INTENT_UPDATE,
 				&filter, &entry->ei_rect, ent_array);
-	if (rc != 0)
+	alt_rc = rc;
+	if (rc < 0)
 		return rc;
 
 	if (ent_array->ea_ent_nr == 1) {
@@ -2232,7 +2239,9 @@ insert:
 	 * with 1 entry in the list
 	 */
 out:
-	return evt_tx_end(tcx, rc);
+	rc = evt_tx_end(tcx, rc);
+
+	return rc == 0 ? alt_rc : rc;
 }
 
 /** Fill the entry with the extent at the specified position of \a node */
@@ -2411,6 +2420,27 @@ evt_data_loss_check(d_list_t *head, struct evt_entry_array *ent_array)
 	return 0;
 }
 
+static inline bool
+agg_check(const struct evt_extent *inserted, const struct evt_extent *intree)
+{
+	if (inserted->ex_hi + 1 >= intree->ex_lo &&
+	    intree->ex_hi + 1 >= inserted->ex_lo) {
+		/** Extent overlaps or is adjacent, so assume aggregation is needed. */
+		return true;
+	} else if ((inserted->ex_hi & DAOS_EC_PARITY_BIT) !=
+		   (intree->ex_hi & DAOS_EC_PARITY_BIT)) {
+		/** EC aggregation needs to run if there is parity and we are doing a
+		 *  partial stripe write or vice versa.   Since we don't know the
+		 *  cell or stripe size, we can only approximate this by just flagging
+		 *  any parity mismatch between what we are writing and what is in
+		 *  the tree.
+		 */
+		return true;
+	}
+
+	return false;
+}
+
 /**
  * See the description in evt_priv.h
  */
@@ -2427,6 +2457,7 @@ evt_ent_array_fill(struct evt_context *tcx, enum evt_find_opc find_opc,
 	int				 at;
 	int				 i;
 	int				 rc = 0;
+	bool				 has_agg = false;
 
 	V_TRACE(DB_TRACE, "Searching rectangle "DF_RECT" opc=%d\n",
 		DP_RECT(rect), find_opc);
@@ -2463,10 +2494,16 @@ evt_ent_array_fill(struct evt_context *tcx, enum evt_find_opc find_opc,
 
 			if (evt_filter_rect(filter, &rtmp, leaf)) {
 				V_TRACE(DB_TRACE, "Filtered "DF_RECT" filter=("
-					DF_FILTER")\n", DP_RECT(&rtmp),
-					DP_FILTER(filter));
+					DF_FILTER")\n", DP_RECT(&rtmp), DP_FILTER(filter));
+				if (find_opc == EVT_FIND_OVERWRITE && !has_agg) {
+					if (agg_check(&filter->fr_ex, &rtmp.rc_ex))
+						has_agg = true;
+				}
 				continue; /* Doesn't match the filter */
 			}
+
+			if (find_opc == EVT_FIND_OVERWRITE)
+				has_agg = true;
 
 			evt_rect_overlap(&rtmp, rect, &range_overlap,
 					 &time_overlap);
@@ -2621,7 +2658,7 @@ evt_ent_array_fill(struct evt_context *tcx, enum evt_find_opc find_opc,
 			if (level == 0) { /* done with the root */
 				V_TRACE(DB_TRACE, "Found total %d rects\n",
 					ent_array ? ent_array->ea_ent_nr : 0);
-				return 0; /* succeed and return */
+				return has_agg ? 1 : 0; /* succeed and return */
 			}
 
 			level--;
@@ -2643,6 +2680,8 @@ out:
 					edli_link)) != NULL)
 		D_FREE(edli);
 
+	if (rc == 0 && has_agg)
+		rc = 1;
 	return rc;
 }
 
@@ -3632,6 +3671,7 @@ evt_remove_all(daos_handle_t toh, const struct evt_extent *ext,
 	struct evt_filter	 filter = {0};
 	struct evt_rect		 rect;
 	int			 rc = 0;
+	int			 alt_rc = 0;
 
 	/** Find all of the overlapping rectangles and insert a delete record
 	 *  for each one in the specified epoch range
@@ -3670,14 +3710,18 @@ evt_remove_all(daos_handle_t toh, const struct evt_extent *ext,
 		BIO_ADDR_SET_HOLE(&entry.ei_addr);
 
 		rc = evt_insert(toh, &entry, NULL);
-		if (rc != 0)
+		if (rc == 1) {
+			alt_rc = 1;
+			rc = 0;
+		}
+		if (rc < 0)
 			break;
 	}
 	rc = evt_tx_end(tcx, rc);
 done:
 	evt_ent_array_fini(ent_array);
 
-	return rc;
+	return rc == 0 ? alt_rc : rc;
 }
 
 daos_size_t

--- a/src/vos/tests/evt_ctl.c
+++ b/src/vos/tests/evt_ctl.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2017-2021 Intel Corporation.
+ * (C) Copyright 2017-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -360,6 +360,8 @@ ts_add_rect(void)
 	entry.ei_inob = val == NULL ? 0 : 1;
 
 	rc = evt_insert(ts_toh, &entry, NULL);
+	if (rc == 1)
+		rc = 0;
 	if (rc == 0)
 		total_added++;
 
@@ -744,6 +746,8 @@ ts_many_add(void)
 		entry.ei_inob = 1;
 
 		rc = evt_insert(ts_toh, &entry, NULL);
+		if (rc == 1)
+			rc = 0;
 		if (rc != 0) {
 			D_FATAL("Add rect %d failed "DF_RC"\n", i, DP_RC(rc));
 			fail();
@@ -1099,6 +1103,8 @@ test_evt_iter_flags(void **state)
 			if (rc != 0)
 				goto finish;
 			rc = evt_insert(toh, &entry, NULL);
+			if (rc == 1)
+				rc = 0;
 			if (rc != 0)
 				goto finish;
 		}
@@ -1235,6 +1241,8 @@ test_evt_iter_delete(void **state)
 			assert_int_equal(rc, 0);
 
 			rc = evt_insert(toh, &entry, NULL);
+			if (rc == 1)
+				rc = 0;
 			assert_rc_equal(rc, 0);
 			rc = utest_check_mem_increase(arg->ta_utx);
 			assert_int_equal(rc, 0);
@@ -1391,6 +1399,8 @@ test_evt_find_internal(void **state)
 				assert_int_equal(rc, 0);
 			}
 			rc = evt_insert(toh, &entry, NULL);
+			if (rc == 1)
+				rc = 0;
 			assert_rc_equal(rc, 0);
 			rc = utest_check_mem_increase(arg->ta_utx);
 			assert_int_equal(rc, 0);
@@ -1517,6 +1527,8 @@ test_evt_iter_delete_internal(void **state)
 			assert_int_equal(rc, 0);
 
 			rc = evt_insert(toh, &entry, NULL);
+			if (rc == 1)
+				rc = 0;
 			assert_rc_equal(rc, 0);
 		}
 	}
@@ -1584,6 +1596,8 @@ test_evt_variable_record_size_internal(void **state)
 					    data, data_size);
 			assert_int_equal(rc, 0);
 			rc = evt_insert(toh, &entry, NULL);
+			if (rc == 1)
+				rc = 0;
 			if (count > 0)
 				assert_int_not_equal(rc, 0);
 			else
@@ -1655,6 +1669,8 @@ test_evt_various_data_size_internal(void **state)
 				break;
 			}
 			rc = evt_insert(toh, &entry, NULL);
+			if (rc == 1)
+				rc = 0;
 			if (rc != 0) {
 				assert_rc_equal(rc, -DER_NOSPACE);
 				break;
@@ -1731,6 +1747,82 @@ test_evt_various_data_size_internal(void **state)
 	}
 }
 
+static int
+insert_one(struct test_arg *arg, daos_handle_t toh, daos_epoch_t epoch, uint64_t start_offset,
+	   uint64_t length)
+{
+	struct evt_entry_in	 entry = {0};
+	char			*data;
+	int			 rc;
+
+	D_ALLOC_ARRAY(data, length);
+	if (data == NULL)
+		return -DER_NOMEM;
+	memset(data, 'a', length);
+
+	entry.ei_rect.rc_ex.ex_lo = start_offset;
+	entry.ei_rect.rc_ex.ex_hi = start_offset + length - 1;
+	entry.ei_rect.rc_epc = epoch;
+	entry.ei_ver = 0;
+	entry.ei_bound = epoch;
+	entry.ei_inob = 1;
+
+	memset(&entry.ei_csum, 0, sizeof(entry.ei_csum));
+
+	rc = bio_alloc_init(arg->ta_utx, &entry.ei_addr,
+			    &data, sizeof(data));
+	if (rc != 0)
+		return rc;
+
+	D_FREE(data);
+
+	return evt_insert(toh, &entry, NULL);
+}
+
+static void
+test_evt_agg_check(void **state)
+{
+	struct test_arg		*arg = *state;
+	daos_handle_t		 toh;
+	int			 rc;
+	int			 epoch;
+
+	epoch = 1;
+	rc = evt_create(arg->ta_root, ts_feats, ORDER_DEF_INTERNAL,
+			arg->ta_uma, &ts_evt_desc_cbs, &toh);
+	assert_rc_equal(rc, 0);
+
+	rc = insert_one(arg, toh, epoch++, 0, 1);
+	assert_rc_equal(rc, 0);
+
+	rc = insert_one(arg, toh, epoch++, 1, 2);
+	assert_rc_equal(rc, 1); /* Adjacent is aggregatable */
+
+	rc = insert_one(arg, toh, epoch++, 10, 5);
+	assert_rc_equal(rc, 0); /** Standalone, not aggregatable */
+
+	rc = insert_one(arg, toh, epoch++, 9, 8);
+	assert_rc_equal(rc, 1); /** Encapsulates prior extent, aggregatable */
+
+	rc = insert_one(arg, toh, epoch++, 7, 2);
+	assert_rc_equal(rc, 1); /** Adjacent to prior extent, aggregatable */
+
+	rc = insert_one(arg, toh, epoch++, 5, 1);
+	assert_rc_equal(rc, 0); /** Standalone, not aggregatable */
+
+	rc = insert_one(arg, toh, epoch++, 11, 2);
+	assert_rc_equal(rc, 1); /** Partial coverage, aggregatable */
+
+	rc = insert_one(arg, toh, epoch++, DAOS_EC_PARITY_BIT | 1000, 2);
+	assert_rc_equal(rc, 1); /** Parity written with non-parity in tree, aggregatable */
+
+	rc = insert_one(arg, toh, epoch++, 1000, 2);
+	assert_rc_equal(rc, 1); /** Simulate partial write with in-tree parity, aggregatable */
+
+	rc = evt_destroy(toh);
+	assert_rc_equal(rc, 0);
+}
+
 static void
 test_evt_node_size_internal(void **state)
 {
@@ -1791,6 +1883,8 @@ set_data(struct test_arg *arg, daos_handle_t toh, char *dest_data,
 			    src, size);
 	assert_int_equal(rc, 0);
 	rc = evt_insert(toh, &entry, NULL);
+	if (rc == 1)
+		rc = 0;
 	assert_rc_equal(rc, 0);
 }
 
@@ -1963,6 +2057,8 @@ insert_and_check(daos_handle_t toh, struct evt_entry_in *entry, int idx, int nr)
 	entry->ei_rect.rc_epc = epoch;
 	entry->ei_bound = epoch;
 	rc = evt_insert(toh, entry, NULL);
+	if (rc == 1)
+		rc = 0;
 	assert_rc_equal(rc, 0);
 
 	return epoch++;
@@ -2114,6 +2210,8 @@ test_evt_outer_punch(void **state)
 			assert_int_equal(rc, 0);
 
 			rc = evt_insert(toh, &entry, NULL);
+			if (rc == 1)
+				rc = 0;
 			assert_rc_equal(rc, 0);
 		}
 	}
@@ -2242,6 +2340,9 @@ run_internal_tests(char *test_name)
 			setup_builtin, teardown_builtin},
 		{ "EVT019: evt_various_data_size_internal",
 			test_evt_various_data_size_internal,
+			setup_builtin, teardown_builtin},
+		{ "EVT020: evt_agg_check",
+			test_evt_agg_check,
 			setup_builtin, teardown_builtin},
 		{ NULL, NULL, NULL, NULL }
 	};

--- a/src/vos/vos_aggregate.c
+++ b/src/vos/vos_aggregate.c
@@ -1490,6 +1490,8 @@ insert_segments(daos_handle_t ih, struct agg_merge_window *mw,
 		 */
 		rc = evt_insert(oiter->it_hdl, ent_in,
 				&ent_in->ei_csum.cs_csum);
+		if (rc == 1)
+			rc = 0;
 		if (rc) {
 			D_ERROR("Insert segment "DF_RECT" error: "DF_RC"\n",
 				DP_RECT(&ent_in->ei_rect), DP_RC(rc));

--- a/src/vos/vos_io.c
+++ b/src/vos/vos_io.c
@@ -1784,6 +1784,10 @@ akey_update(struct vos_io_context *ioc, uint32_t pm_ver, daos_handle_t ak_toh,
 		rc = akey_update_recx(toh, pm_ver, &iod->iod_recxs[i],
 				      recx_csum, iod->iod_size, ioc,
 				      minor_epc);
+		if (rc == 1) {
+			ioc->ic_agg_needed = 1;
+			rc = 0;
+		}
 		if (rc != 0) {
 			VOS_TX_LOG_FAIL(rc, "akey "DF_KEY" update, akey_update_recx failed, "
 					DF_RC"\n", DP_KEY(&iod->iod_name), DP_RC(rc));

--- a/src/vos/vos_tree.c
+++ b/src/vos/vos_tree.c
@@ -1017,10 +1017,12 @@ key_tree_prepare(struct vos_object *obj, daos_handle_t toh,
 	if (rc != 0 || tclass != VOS_BTR_AKEY || !(flags & SUBTR_CREATE))
 		return rc;
 
-	/* As a first cut for aggregation detection, just return 1 if it's not the first update.
-	 * This can be improved upon for evtree to take into account actual extent overlap but
-	 * this is a simpler solution for now.
+	/** If it's evtree, evt_insert will detect if aggregation is needed.  For single value,
+	 *  return 1 to indicate aggregation is on update to an existing tree.
 	 */
+	if (flags & SUBTR_EVT)
+		return 0;
+
 	return created ? 0 : 1;
 }
 


### PR DESCRIPTION
Avoid setting aggregatable time when the evtree has nothing to
aggregate.  For example, if extents are disjoint, there is no
need to scan the tree, even if there is more than one extent.

Since this is also used for EC aggregation, we need to ensure we
invoke EC aggregation when there is a parity mismatch.  Without
stripe and cell size, the best we can do is set the flag any time
there is both a partial and a parity extent.

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>