### PR TITLE
DAOS-10429 test: remove unused import

### DIFF
--- a/src/tests/ftest/util/test_utils_base.py
+++ b/src/tests/ftest/util/test_utils_base.py
@@ -5,7 +5,6 @@
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
 from logging import getLogger
-from os import environ
 from time import sleep
 
 from command_utils_base import ObjectWithParameters, BasicParameter


### PR DESCRIPTION
flake check reported:
./src/tests/ftest/util/test_utils_base.py:8:1:
F401 'os.environ' imported but unused

Skip-func-test: true
Skip-func-hw-test: true
Signed-off-by: Wang Shilong <shilong.wang@intel.com>