### PR TITLE
DAOS-9592 pool: Introduce ds_pool_check_svc_clues

### DIFF
--- a/src/include/daos_srv/pool.h
+++ b/src/include/daos_srv/pool.h
@@ -353,4 +353,6 @@ int ds_pool_clues_init(ds_pool_clues_init_filter_t filter, void *filter_arg,
 void ds_pool_clues_fini(struct ds_pool_clues *clues);
 void ds_pool_clues_print(struct ds_pool_clues *clues);
 
+int ds_pool_check_svc_clues(struct ds_pool_clues *clues, int *advice_out);
+
 #endif /* __DAOS_SRV_POOL_H__ */

--- a/src/pool/srv_internal.h
+++ b/src/pool/srv_internal.h
@@ -209,10 +209,4 @@ int ds_pool_metrics_count(void);
 int ds_pool_metrics_start(struct ds_pool *pool);
 void ds_pool_metrics_stop(struct ds_pool *pool);
 
-/*
- * srv_pool_check.c
- */
-void ds_pool_test_compare_logs(void);
-void ds_pool_test_check_svc_clues(void);
-
 #endif /* __POOL_SRV_INTERNAL_H__ */

--- a/src/pool/srv_internal.h
+++ b/src/pool/srv_internal.h
@@ -209,4 +209,10 @@ int ds_pool_metrics_count(void);
 int ds_pool_metrics_start(struct ds_pool *pool);
 void ds_pool_metrics_stop(struct ds_pool *pool);
 
+/*
+ * srv_pool_check.c
+ */
+void ds_pool_test_compare_logs(void);
+void ds_pool_test_check_svc_clues(void);
+
 #endif /* __POOL_SRV_INTERNAL_H__ */

--- a/src/pool/srv_pool_check.c
+++ b/src/pool/srv_pool_check.c
@@ -348,7 +348,7 @@ compare_logs(uint64_t x_last_term, uint64_t x_last_index,
  * of one PS, and report if this PS requires catastrophic recovery or not.
  *
  * \param[in]	clues		pool clues for one PS
- * \param[out]	advice_out	when the return value is 1, the index of the
+ * \param[out]	advice_out	when the return value is >0, the index of the
  *				advised replica in \a clues to rebootstrap the
  *				PS from
  *

--- a/src/pool/srv_pool_check.c
+++ b/src/pool/srv_pool_check.c
@@ -307,3 +307,417 @@ ds_pool_clues_print(struct ds_pool_clues *clues)
 			dc->bcl_oid_next);
 	}
 }
+
+int
+ds_pool_clues_find_rank(struct ds_pool_clues *clues, d_rank_t rank)
+{
+	int i;
+
+	for (i = 0; i < clues->pcs_len; i++)
+		if (clues->pcs_array[i].pc_rank == rank)
+			return i;
+	return -DER_NONEXIST;
+}
+
+/*
+ * Return
+ *
+ *   > 0	<x_last_term, x_last_index> is newer than <y_last_term, y_last_index>
+ *   < 0	<x_last_term, x_last_index> is older than <y_last_term, y_last_index>
+ *   = 0	<x_last_term, x_last_index> is equal to   <y_last_term, y_last_index>
+ */
+static int
+compare_logs(uint64_t x_last_term, uint64_t x_last_index,
+	     uint64_t y_last_term, uint64_t y_last_index)
+{
+	if (x_last_term > y_last_term)
+		return 1;
+	if (x_last_term < y_last_term)
+		return -1;
+
+	if (x_last_index > y_last_index)
+		return 1;
+	if (x_last_index < y_last_index)
+		return -1;
+
+	return 0;
+}
+
+/**
+ * Analyze \a clues, which must be nonempty and comprise clues about replicas
+ * of one PS, and report if this PS requires catastrophic recovery or not.
+ *
+ * \param[in]	clues		pool clues
+ * \param[out]	advice_out	when the return value is 0, the index of the
+ *				advised replica in \a clues to rebootstrap the
+ *				PS from
+ *
+ * \return	0	this PS does not require catastrophic recovery
+ *		>0	this PS is advised to rebootstrap from the replica at
+ *			index \a *advice_out in \a clues
+ */
+int
+ds_pool_check_svc_clues(struct ds_pool_clues *clues, int *advice_out)
+{
+	uuid_t		uuid;
+	uint32_t	map_version = 0;
+	uint64_t	log_term = 0;
+	uint64_t	log_index = 0;
+	int		advice = -1;
+	int		i;
+
+	/* Assert that all clues are about replicas of the same PS. */
+	D_ASSERT(clues->pcs_len > 0);
+	uuid_copy(uuid, clues->pcs_array[0].pc_uuid);
+	for (i = 0; i < clues->pcs_len; i++) {
+		struct ds_pool_clue *clue = &clues->pcs_array[i];
+
+		D_ASSERT(uuid_compare(uuid, clue->pc_uuid) == 0);
+		D_ASSERTF(clue->pc_rc == 0, DF_RC"\n", DP_RC(clue->pc_rc));
+		D_ASSERT(clue->pc_svc_clue != NULL);
+	}
+
+	/* For each replica, see if it can get votes from a majority. */
+	for (i = 0; i < clues->pcs_len; i++) {
+		struct ds_pool_clue	       *clue = &clues->pcs_array[i];
+		struct ds_pool_svc_clue	       *svc_clue = clue->pc_svc_clue;
+		struct rdb_clue		       *db_clue = &svc_clue->psc_db_clue;
+		int				n_votes = 0;
+		int				j;
+
+		/* This replica must be a voting node itself. */
+		if (!d_rank_list_find(db_clue->bcl_replicas, db_clue->bcl_self, NULL /* idx */))
+			continue;
+
+		/*
+		 * Check each replica in the local membership and count the
+		 * number of votes this replica can get.
+		 */
+		for (j = 0; j < db_clue->bcl_replicas->rl_nr; j++) {
+			struct rdb_clue	       *c = &svc_clue->psc_db_clue;
+			int			k;
+
+			/*
+			 * Find the member, which may be missing. If it is
+			 * ourself, the log comparison will pass.
+			 */
+			k = ds_pool_clues_find_rank(clues, db_clue->bcl_replicas->rl_ranks[j]);
+			if (k < 0)
+				continue;
+
+			/*
+			 * Since terms will grow as replicas communicate with
+			 * each other, we only compare the logs.
+			 */
+			if (compare_logs(db_clue->bcl_last_term, db_clue->bcl_last_index,
+					 c->bcl_last_term, c->bcl_last_index) < 0)
+				continue;
+
+			n_votes++;
+		}
+
+		D_DEBUG(DB_MD, DF_UUID": rank %u: %d/%u votes\n", DP_UUID(uuid),
+			db_clue->bcl_self, n_votes, db_clue->bcl_replicas->rl_nr);
+
+		if (n_votes > db_clue->bcl_replicas->rl_nr / 2)
+			return 0;
+	}
+
+	/*
+	 * No replica can become a leader. Find out which replica among those
+	 * who have the newest pool map version has the newest log.
+	 */
+	for (i = 0; i < clues->pcs_len; i++) {
+		struct ds_pool_clue	       *clue = &clues->pcs_array[i];
+		struct ds_pool_svc_clue	       *svc_clue = clue->pc_svc_clue;
+		struct rdb_clue		       *db_clue = &svc_clue->psc_db_clue;
+
+		/* Track who has the newest pool map version. */
+		if (svc_clue->psc_map_version > map_version) {
+			map_version = svc_clue->psc_map_version;
+			log_term = db_clue->bcl_last_term;
+			log_index = db_clue->bcl_last_index;
+			advice = i;
+		} else if (svc_clue->psc_map_version == map_version) {
+			/*
+			 * Track who among those with this map version has the
+			 * newest log.
+			 */
+			if (compare_logs(db_clue->bcl_last_term, db_clue->bcl_last_index,
+					 log_term, log_index) > 0) {
+				log_term = db_clue->bcl_last_term;
+				log_index = db_clue->bcl_last_index;
+				advice = i;
+			}
+		}
+	}
+	D_ASSERTF(advice >= 0 && advice < clues->pcs_len, "%d\n", advice);
+	*advice_out = advice;
+	return 1;
+}
+
+/* Test compare_logs. */
+void
+ds_pool_test_compare_logs(void)
+{
+	D_ASSERT(compare_logs(2, 2, 1, 2) > 0);		/* term > */
+	D_ASSERT(compare_logs(1, 2, 2, 1) < 0);		/* term < */
+	D_ASSERT(compare_logs(1, 4, 1, 3) > 0);		/* term ==, index > */
+	D_ASSERT(compare_logs(1, 2, 1, 3) < 0);		/* term ==, index < */
+	D_ASSERT(compare_logs(1, 2, 1, 2) == 0);	/* term ==, index == */
+}
+
+static d_rank_t			test_ranks[] = {0, 1, 2, 3, 4};
+static struct ds_pool_svc_clue	test_svc_clues[ARRAY_SIZE(test_ranks)];
+static struct ds_pool_clue	test_clues[ARRAY_SIZE(test_ranks)];
+
+/* Test ds_pool_check_svc_clues. */
+void
+ds_pool_test_check_svc_clues(void)
+{
+	uuid_t	uuid;
+	int	i;
+	int	rc;
+
+	/*
+	 * Initialize test data that can't be initialized at compile time.
+	 * Every test_svc_clues[i] corresponds to test_clues[i]. Each subtest
+	 * must set the following fields.
+	 *
+	 *   test_svc_clue[i].psc_db_clue.bcl_replicas
+	 *   test_svc_clue[i].psc_db_clue.bcl_last_index
+	 *   test_svc_clue[i].psc_db_clue.bcl_last_term
+	 *   test_svc_clue[i].psc_map_version
+	 */
+	uuid_generate(uuid);
+	for (i = 0; i < ARRAY_SIZE(test_clues); i++) {
+		uuid_copy(test_clues[i].pc_uuid, uuid);
+		test_clues[i].pc_rank = i;
+		test_clues[i].pc_dir = DS_POOL_DIR_NORMAL;
+		test_clues[i].pc_svc_clue = &test_svc_clues[i];
+	}
+	for (i = 0; i < ARRAY_SIZE(test_svc_clues); i++)
+		test_svc_clues[i].psc_db_clue.bcl_self = i;
+
+	/* Test a single replica that does not require CR. */
+	{
+		struct ds_pool_clues	clues = {
+			.pcs_array	= test_clues,
+			.pcs_len	= 1,
+			.pcs_cap	= 1
+		};
+		d_rank_list_t		replicas = {
+			.rl_ranks	= test_ranks,
+			.rl_nr		= 1
+		};
+		int			advice = -1;
+
+		test_svc_clues[0].psc_db_clue.bcl_replicas = &replicas;
+		test_svc_clues[0].psc_db_clue.bcl_last_index = 9;
+		test_svc_clues[0].psc_db_clue.bcl_last_term = 1;
+		test_svc_clues[0].psc_map_version = 1;
+
+		rc = ds_pool_check_svc_clues(&clues, &advice);
+		D_ASSERTF(rc == 0, DF_RC"\n", DP_RC(rc));
+	}
+
+	/*
+	 * Test a single replica that has not itself but a missing replica in
+	 * the membership and requires CR.
+	 */
+	{
+		struct ds_pool_clues	clues = {
+			.pcs_array	= test_clues,
+			.pcs_len	= 1,
+			.pcs_cap	= 1
+		};
+		d_rank_list_t		replicas = {
+			.rl_ranks	= &test_ranks[1],
+			.rl_nr		= 1
+		};
+		int			advice = -1;
+
+		test_svc_clues[0].psc_db_clue.bcl_replicas = &replicas;
+		test_svc_clues[0].psc_db_clue.bcl_last_index = 9;
+		test_svc_clues[0].psc_db_clue.bcl_last_term = 1;
+		test_svc_clues[0].psc_map_version = 1;
+
+		rc = ds_pool_check_svc_clues(&clues, &advice);
+		D_ASSERTF(rc > 0, DF_RC"\n", DP_RC(rc));
+		D_ASSERTF(advice == 0, "%d\n", advice);
+	}
+
+	/* Test a complete set of replicas that do not require CR. */
+	{
+		const int		n = 3;
+		struct ds_pool_clues	clues = {
+			.pcs_array	= test_clues,
+			.pcs_len	= n,
+			.pcs_cap	= n
+		};
+		d_rank_list_t		replicas = {
+			.rl_ranks	= test_ranks,
+			.rl_nr		= n
+		};
+		int			advice = -1;
+
+		D_ASSERT(n <= ARRAY_SIZE(test_ranks));
+
+		test_svc_clues[0].psc_db_clue.bcl_replicas = &replicas;
+		test_svc_clues[0].psc_db_clue.bcl_last_index = 9;
+		test_svc_clues[0].psc_db_clue.bcl_last_term = 1;
+		test_svc_clues[0].psc_map_version = 1;
+
+		test_svc_clues[1].psc_db_clue.bcl_replicas = &replicas;
+		test_svc_clues[1].psc_db_clue.bcl_last_index = 9;
+		test_svc_clues[1].psc_db_clue.bcl_last_term = 1;
+		test_svc_clues[1].psc_map_version = 1;
+
+		test_svc_clues[2].psc_db_clue.bcl_replicas = &replicas;
+		test_svc_clues[2].psc_db_clue.bcl_last_index = 9;
+		test_svc_clues[2].psc_db_clue.bcl_last_term = 1;
+		test_svc_clues[2].psc_map_version = 1;
+
+		rc = ds_pool_check_svc_clues(&clues, &advice);
+		D_ASSERTF(rc == 0, DF_RC"\n", DP_RC(rc));
+	}
+
+	/* Test an incomplete but sufficient set of replicas that do not require CR. */
+	{
+		const int		m = 2;
+		const int		n = 3;
+		struct ds_pool_clues	clues = {
+			.pcs_array	= test_clues,
+			.pcs_len	= m,
+			.pcs_cap	= m
+		};
+		d_rank_list_t		replicas = {
+			.rl_ranks	= test_ranks,
+			.rl_nr		= n
+		};
+		int			advice = -1;
+
+		D_ASSERT(m <= ARRAY_SIZE(test_ranks));
+		D_ASSERT(n <= ARRAY_SIZE(test_ranks));
+		D_ASSERT(m < n);
+
+		test_svc_clues[0].psc_db_clue.bcl_replicas = &replicas;
+		test_svc_clues[0].psc_db_clue.bcl_last_index = 9;
+		test_svc_clues[0].psc_db_clue.bcl_last_term = 1;
+		test_svc_clues[0].psc_map_version = 1;
+
+		test_svc_clues[1].psc_db_clue.bcl_replicas = &replicas;
+		test_svc_clues[1].psc_db_clue.bcl_last_index = 9;
+		test_svc_clues[1].psc_db_clue.bcl_last_term = 1;
+		test_svc_clues[1].psc_map_version = 1;
+
+		rc = ds_pool_check_svc_clues(&clues, &advice);
+		D_ASSERTF(rc == 0, DF_RC"\n", DP_RC(rc));
+	}
+
+	/* Test an insufficient set of replicas that require CR: case 1. */
+	{
+		const int		m = 2;
+		const int		n = 5;
+		struct ds_pool_clues	clues = {
+			.pcs_array	= test_clues,
+			.pcs_len	= m,
+			.pcs_cap	= m
+		};
+		d_rank_list_t		replicas = {
+			.rl_ranks	= test_ranks,
+			.rl_nr		= n
+		};
+		int			advice = -1;
+
+		D_ASSERT(m <= ARRAY_SIZE(test_ranks));
+		D_ASSERT(n <= ARRAY_SIZE(test_ranks));
+		D_ASSERT(m < n);
+
+		test_svc_clues[0].psc_db_clue.bcl_replicas = &replicas;
+		test_svc_clues[0].psc_db_clue.bcl_last_index = 9;
+		test_svc_clues[0].psc_db_clue.bcl_last_term = 1;
+		test_svc_clues[0].psc_map_version = 1;
+
+		/* A newer map version and a newer log. */
+		test_svc_clues[1].psc_db_clue.bcl_replicas = &replicas;
+		test_svc_clues[1].psc_db_clue.bcl_last_index = 11;
+		test_svc_clues[1].psc_db_clue.bcl_last_term = 1;
+		test_svc_clues[1].psc_map_version = 2;
+
+		rc = ds_pool_check_svc_clues(&clues, &advice);
+		D_ASSERTF(rc > 0, DF_RC"\n", DP_RC(rc));
+		D_ASSERTF(advice == 1, "%d\n", advice);
+	}
+
+	/* Test an insufficient set of replicas that require CR: case 2. */
+	{
+		const int		m = 2;
+		const int		n = 5;
+		struct ds_pool_clues	clues = {
+			.pcs_array	= test_clues,
+			.pcs_len	= m,
+			.pcs_cap	= m
+		};
+		d_rank_list_t		replicas = {
+			.rl_ranks	= test_ranks,
+			.rl_nr		= n
+		};
+		int			advice = -1;
+
+		D_ASSERT(m <= ARRAY_SIZE(test_ranks));
+		D_ASSERT(n <= ARRAY_SIZE(test_ranks));
+		D_ASSERT(m < n);
+
+		/* A newer map version. */
+		test_svc_clues[0].psc_db_clue.bcl_replicas = &replicas;
+		test_svc_clues[0].psc_db_clue.bcl_last_index = 11;
+		test_svc_clues[0].psc_db_clue.bcl_last_term = 1;
+		test_svc_clues[0].psc_map_version = 2;
+
+		/* A newer log. */
+		test_svc_clues[1].psc_db_clue.bcl_replicas = &replicas;
+		test_svc_clues[1].psc_db_clue.bcl_last_index = 10;
+		test_svc_clues[1].psc_db_clue.bcl_last_term = 2;
+		test_svc_clues[1].psc_map_version = 1;
+
+		rc = ds_pool_check_svc_clues(&clues, &advice);
+		D_ASSERTF(rc > 0, DF_RC"\n", DP_RC(rc));
+		D_ASSERTF(advice == 0, "%d\n", advice);
+	}
+
+	/* Test an insufficient set of replicas that require CR: case 3. */
+	{
+		const int		m = 2;
+		const int		n = 5;
+		struct ds_pool_clues	clues = {
+			.pcs_array	= test_clues,
+			.pcs_len	= m,
+			.pcs_cap	= m
+		};
+		d_rank_list_t		replicas = {
+			.rl_ranks	= test_ranks,
+			.rl_nr		= n
+		};
+		int			advice = -1;
+
+		D_ASSERT(m <= ARRAY_SIZE(test_ranks));
+		D_ASSERT(n <= ARRAY_SIZE(test_ranks));
+		D_ASSERT(m < n);
+
+		test_svc_clues[0].psc_db_clue.bcl_replicas = &replicas;
+		test_svc_clues[0].psc_db_clue.bcl_last_index = 11;
+		test_svc_clues[0].psc_db_clue.bcl_last_term = 1;
+		test_svc_clues[0].psc_map_version = 2;
+
+		/* The same map version but a newer log. */
+		test_svc_clues[1].psc_db_clue.bcl_replicas = &replicas;
+		test_svc_clues[1].psc_db_clue.bcl_last_index = 10;
+		test_svc_clues[1].psc_db_clue.bcl_last_term = 2;
+		test_svc_clues[1].psc_map_version = 2;
+
+		rc = ds_pool_check_svc_clues(&clues, &advice);
+		D_ASSERTF(rc > 0, DF_RC"\n", DP_RC(rc));
+		D_ASSERTF(advice == 1, "%d\n", advice);
+	}
+}


### PR DESCRIPTION
Add a ds_pool_check_svc_clues API, which analyzes clues about replicas of a PS
and reports whether rebootstrapping is required as well as which replica
to rebootstrap from.

Quick-Functional: true
Signed-off-by: Li Wei <wei.g.li@intel.com>