### PR TITLE
DAOS-10367 tests: enable NVMe for VOS unit tests

### DIFF
--- a/ci/unit/test_main_node.sh
+++ b/ci/unit/test_main_node.sh
@@ -35,6 +35,8 @@ sudo ln -sf "$SL_PREFIX/share/spdk/scripts/setup.sh" /usr/share/spdk/scripts/
 sudo ln -sf "$SL_PREFIX/share/spdk/scripts/common.sh" /usr/share/spdk/scripts/
 sudo ln -s "$SL_PREFIX/include"  /usr/share/spdk/include
 
+sudo bash -c 'echo 1024 > /proc/sys/vm/nr_hugepages'
+
 # set CMOCKA envs here
 export CMOCKA_MESSAGE_OUTPUT=xml
 if [[ -z ${WITH_VALGRIND} ]]; then

--- a/src/vos/tests/daos_nvme.conf
+++ b/src/vos/tests/daos_nvme.conf
@@ -1,0 +1,44 @@
+{
+  "daos_data": {
+    "config": []
+  },
+  "subsystems": [
+    {
+      "subsystem": "bdev",
+      "config": [
+        {
+          "params": {
+            "bdev_io_pool_size": 65536,
+            "bdev_io_cache_size": 256
+          },
+          "method": "bdev_set_options"
+        },
+        {
+          "params": {
+            "retry_count": 4,
+            "timeout_us": 0,
+            "nvme_adminq_poll_period_us": 100000,
+            "action_on_timeout": "none",
+            "nvme_ioq_poll_period_us": 0
+          },
+          "method": "bdev_nvme_set_options"
+        },
+        {
+          "params": {
+            "enable": false,
+            "period_us": 0
+          },
+          "method": "bdev_nvme_set_hotplug"
+        },
+        {
+          "params": {
+            "block_size": 4096,
+            "name": "AIO_1",
+            "filename": "/tmp/aio_file"
+          },
+          "method": "bdev_aio_create"
+        }
+      ]
+    }
+  ]
+}

--- a/src/vos/tests/vts_aggregate.c
+++ b/src/vos/tests/vts_aggregate.c
@@ -2726,6 +2726,7 @@ aggregate_34(void **state)
 	struct agg_tst_dataset	 ds = { 0 };
 	daos_recx_t		*recx_arr;
 	int			 rc, i, rec_cnt = vos_agg_nvme_thresh - 1;
+	unsigned int		 agg_flags = VOS_AGG_FL_FORCE_SCAN;
 
 	rc = vos_pool_query(arg->ctx.tc_po_hdl, &pool_info);
 	assert_rc_equal(rc, 0);
@@ -2757,11 +2758,12 @@ aggregate_34(void **state)
 	ds.td_discard = false;
 
 	VERBOSE_MSG("Aggregate NVMe records w/o 'force_merge' flag\n");
-	aggregate_basic_lb(arg, &ds, 0, NULL, NULL, 0);
+	aggregate_basic_lb(arg, &ds, 0, NULL, NULL, agg_flags);
 
 	VERBOSE_MSG("Aggregate NVMe records with 'force_merge' flag\n");
 	ds.td_expected_recs = 1;
-	aggregate_basic_lb(arg, &ds, 0, NULL, NULL, VOS_AGG_FL_FORCE_MERGE);
+	agg_flags |= VOS_AGG_FL_FORCE_MERGE;
+	aggregate_basic_lb(arg, &ds, 0, NULL, NULL, agg_flags);
 
 	D_FREE(recx_arr);
 	cleanup();


### PR DESCRIPTION
Enable NVMe when running VOS unit tests.

Signed-off-by: Niu Yawei <yawei.niu@intel.com>