### PR TITLE
daos-10444: pipeline API returns records' sizes

### DIFF
--- a/src/client/api/pipeline.c
+++ b/src/client/api/pipeline.c
@@ -128,16 +128,16 @@ daos_pipeline_free(daos_pipeline_t *pipeline)
 
 int
 daos_pipeline_run(daos_handle_t coh, daos_handle_t oh, daos_pipeline_t *pipeline, daos_handle_t th,
-		  uint64_t flags, daos_key_t *dkey, uint32_t nr_iods_dkey, uint32_t *nr_iods,
-		  daos_iod_t *iods, daos_anchor_t *anchor, uint32_t *nr_kds, daos_key_desc_t *kds,
-		  d_sg_list_t *sgl_keys, d_sg_list_t *sgl_recx, d_sg_list_t *sgl_agg,
-		  daos_pipeline_stats_t *scanned, daos_event_t *ev)
+		  uint64_t flags, daos_key_t *dkey, uint32_t *nr_iods, daos_iod_t *iods,
+		  daos_anchor_t *anchor, uint32_t *nr_kds, daos_key_desc_t *kds,
+		  d_sg_list_t *sgl_keys, d_sg_list_t *sgl_recx, daos_size_t *recx_size,
+		  d_sg_list_t *sgl_agg, daos_pipeline_stats_t *scanned, daos_event_t *ev)
 {
 	tse_task_t *task;
 	int         rc;
 
-	rc = dc_pipeline_run_task_create(coh, oh, th, pipeline, flags, dkey, nr_iods_dkey, nr_iods,
-					 iods, anchor, nr_kds, kds, sgl_keys, sgl_recx, sgl_agg,
+	rc = dc_pipeline_run_task_create(coh, oh, th, pipeline, flags, dkey, nr_iods, iods, anchor,
+					 nr_kds, kds, sgl_keys, sgl_recx, recx_size, sgl_agg,
 					 scanned, ev, NULL, &task);
 	if (rc) {
 		return rc;

--- a/src/include/daos/task.h
+++ b/src/include/daos/task.h
@@ -252,9 +252,9 @@ dc_obj_list_obj_task_create(daos_handle_t oh, daos_handle_t th,
 int
 dc_pipeline_run_task_create(daos_handle_t coh, daos_handle_t oh, daos_handle_t th,
 			    daos_pipeline_t *pipeline, uint64_t flags, daos_key_t *dkey,
-			    uint32_t nr_iods_dkey, uint32_t *nr_iods, daos_iod_t *iods,
-			    daos_anchor_t *anchor, uint32_t *nr_kds, daos_key_desc_t *kds,
-			    d_sg_list_t *sgl_keys, d_sg_list_t *sgl_recx, d_sg_list_t *sgl_agg,
+			    uint32_t *nr_iods, daos_iod_t *iods, daos_anchor_t *anchor,
+			    uint32_t *nr_kds, daos_key_desc_t *kds, d_sg_list_t *sgl_keys,
+			    d_sg_list_t *sgl_recx, daos_size_t *recx_size, d_sg_list_t *sgl_agg,
 			    daos_pipeline_stats_t *stats, daos_event_t *ev, tse_sched_t *tse,
 			    tse_task_t **task);
 

--- a/src/include/daos_pipeline.h
+++ b/src/include/daos_pipeline.h
@@ -261,21 +261,20 @@ daos_pipeline_free(daos_pipeline_t *pipeline);
  *
  * \param[in]		flags		Conditional operations.
  *
- * \param[in]		dkey		Optional dkey. When passed, no iteration is done and
+ * \param[in]		dkey		Optional dkey. When passed, no key iteration is done and
  *					processing is only performed on this specific dkey.
  *
- * \param[in]		nr_iods_dkey	[in]: Number of I/O descriptors per dkey.
+ * \param[in/out]	nr_iods		[in]: Number of I/O descriptors in the iods table.
+ *					[out]: Number of returned I/O descriptors. Only relevant
+ *					when \dkey is passed (in that case filtering is done to
+ *					return those akeys that pass a particular filter for a
+ *					given dkey).
  *
- * \param[in,out]	nr_iods		[in]: Number of I/O descriptors in the iods table. \nr_iods
- *					should be equal to \nr_iods_dkey x \nr_kds.
- *					[out]: Number of returned I/O descriptors in the iods table.
- *
- * \param[in,out]	iods		[in/out]: Array of I/O descriptors. Each descriptor is
+ * \param[in/out]	iods		[in]: Array of I/O descriptors. Each descriptor is
  *					associated with a given akey and describes the list of
  *					record extents to fetch from the array.
- *					NOTE: The fields iod_name and iod_recx only need to be set
- *					for the first \nr_iods_dkey descriptors (since the rest will
- *					be repeated, they are ignored).
+ *					[out]: Only relevant when \dkey is passed (see comment for
+ *					\nr_iods).
  *
  * \param[in,out]	anchor		Hash anchor for the next call, it should be set to zeroes
  *					for the first call, it should not be changed by caller
@@ -297,11 +296,18 @@ daos_pipeline_free(daos_pipeline_t *pipeline);
  *					[out]: All returned dkeys.
  *
  * \param[in]		sgl_recx	[in]: Preallocated array to store all the records to be
- *					returned (at most \nr_iods). When doing aggregations, only
- *					one record (the data corresponding to \nr_iods_dkey I/O
- *					descriptors) at most is returned (no matter the size of
- *					\nr_iods).
+ *					returned (at most \nr_kds x \nr_iods). When doing
+ *					aggregations, or when \dkey is passed, only one record (the
+ *					data corresponding to \nr_iods I/O descriptors) at most is
+ *					returned (no matter the size of \nr_kds).
  *					[out]: All returned records.
+ *
+ * \param[in]		recx_size	[in]: Optional prealocated array to store all the records'
+ *					sizes to be returned (at most \nr_kds x \nr_iods). When
+ *					doing aggregations, or when \dkey is pased, only the sizes
+ *					for one dkey's records (the data corresponding to \nr_iods
+ *					I/O descriptors) at most is returned (no matter the size of
+ *					\nr_kds).
  *
  * \param[in]		sgl_agg		[in]: Optional preallocated array of iovs for aggregated
  *					values (number of iovs has to match the number of
@@ -320,10 +326,10 @@ daos_pipeline_free(daos_pipeline_t *pipeline);
  */
 int
 daos_pipeline_run(daos_handle_t coh, daos_handle_t oh, daos_pipeline_t *pipeline, daos_handle_t th,
-		  uint64_t flags, daos_key_t *dkey, uint32_t nr_iods_dkey, uint32_t *nr_iods,
-		  daos_iod_t *iods, daos_anchor_t *anchor, uint32_t *nr_kds, daos_key_desc_t *kds,
-		  d_sg_list_t *sgl_keys, d_sg_list_t *sgl_recx, d_sg_list_t *sgl_agg,
-		  daos_pipeline_stats_t *stats, daos_event_t *ev);
+		  uint64_t flags, daos_key_t *dkey, uint32_t *nr_iods, daos_iod_t *iods,
+		  daos_anchor_t *anchor, uint32_t *nr_kds, daos_key_desc_t *kds,
+		  d_sg_list_t *sgl_keys, d_sg_list_t *sgl_recx, daos_size_t *recx_size,
+		  d_sg_list_t *sgl_agg, daos_pipeline_stats_t *stats, daos_event_t *ev);
 
 #if defined(__cplusplus)
 }

--- a/src/include/daos_task.h
+++ b/src/include/daos_task.h
@@ -996,8 +996,6 @@ typedef struct {
 	uint64_t			flags;
 	/** operation done on this specific dkey */
 	daos_key_t			*dkey;
-	/** I/O descriptors per dkey */
-	uint32_t			nr_iods_dkey;
 	/** I/O descriptors in the iods table. */
 	uint32_t			*nr_iods;
 	/** akeys */
@@ -1012,6 +1010,8 @@ typedef struct {
 	d_sg_list_t			*sgl_keys;
 	/** records  */
 	d_sg_list_t			*sgl_recx;
+	/** records' size */
+	daos_size_t			*recx_size;
 	/** aggregations */
 	d_sg_list_t			*sgl_agg;
 	/** returned pipeline stats  */

--- a/src/pipeline/pipeline_rpc.h
+++ b/src/pipeline/pipeline_rpc.h
@@ -61,7 +61,7 @@ obj_opc_to_str(crt_opcode_t opc)
 	((crt_bulk_t)		(pri_sgl_recx_bulk)	CRT_VAR)	\
 	((uint64_t)		(pri_flags)		CRT_VAR)	\
 	((uint32_t)		(pri_nr_kds)		CRT_VAR)	\
-	((uint32_t)		(pri_nr_iods_dkey)	CRT_VAR)
+	((uint32_t)		(pri_pad32)		CRT_VAR)
 
 #define DAOS_OSEQ_PIPELINE_RUN	/* output fields */			\
 	((daos_size_t)			(pro_recx_size)	CRT_ARRAY)	\

--- a/src/pipeline/pipeline_task.c
+++ b/src/pipeline/pipeline_task.c
@@ -12,9 +12,9 @@
 int
 dc_pipeline_run_task_create(daos_handle_t coh, daos_handle_t oh, daos_handle_t th,
 			    daos_pipeline_t *pipeline, uint64_t flags, daos_key_t *dkey,
-			    uint32_t nr_iods_dkey, uint32_t *nr_iods, daos_iod_t *iods,
-			    daos_anchor_t *anchor, uint32_t *nr_kds, daos_key_desc_t *kds,
-			    d_sg_list_t *sgl_keys, d_sg_list_t *sgl_recx, d_sg_list_t *sgl_agg,
+			    uint32_t *nr_iods, daos_iod_t *iods, daos_anchor_t *anchor,
+			    uint32_t *nr_kds, daos_key_desc_t *kds, d_sg_list_t *sgl_keys,
+			    d_sg_list_t *sgl_recx, daos_size_t *recx_size, d_sg_list_t *sgl_agg,
 			    daos_pipeline_stats_t *stats, daos_event_t *ev, tse_sched_t *tse,
 			    tse_task_t **task)
 {
@@ -32,7 +32,6 @@ dc_pipeline_run_task_create(daos_handle_t coh, daos_handle_t oh, daos_handle_t t
 	args->pipeline     = pipeline;
 	args->flags        = flags;
 	args->dkey         = dkey;
-	args->nr_iods_dkey = nr_iods_dkey;
 	args->nr_iods      = nr_iods;
 	args->iods         = iods;
 	args->anchor       = anchor;
@@ -40,6 +39,7 @@ dc_pipeline_run_task_create(daos_handle_t coh, daos_handle_t oh, daos_handle_t t
 	args->kds          = kds;
 	args->sgl_keys     = sgl_keys;
 	args->sgl_recx     = sgl_recx;
+	args->recx_size    = recx_size;
 	args->sgl_agg      = sgl_agg;
 	args->stats        = stats;
 

--- a/src/tests/simple_pipeline.c
+++ b/src/tests/simple_pipeline.c
@@ -22,10 +22,10 @@ static daos_handle_t coh; /** container */
 static daos_handle_t oh;  /** object */
 
 /** DB info */
-#define NR_IODS_PER_DKEY 4
-#define STRING_MAX_LEN   10
+#define NR_IODS		4
+#define STRING_MAX_LEN	10
 
-static char *fields[NR_IODS_PER_DKEY] = {"Owner", "Species", "Sex", "Age"};
+static char *fields[NR_IODS] = {"Owner", "Species", "Sex", "Age"};
 int          nr_aggr;
 
 void
@@ -33,19 +33,19 @@ insert_example_records(void)
 {
 	int         rc;
 	d_iov_t     dkey;
-	d_sg_list_t sgls[NR_IODS_PER_DKEY];
-	d_iov_t     iovs[NR_IODS_PER_DKEY];
-	daos_iod_t  iods[NR_IODS_PER_DKEY];
+	d_sg_list_t sgls[NR_IODS];
+	d_iov_t     iovs[NR_IODS];
+	daos_iod_t  iods[NR_IODS];
 	uint32_t    i, j;
 
-	char       *name[] = {"Slim",   "Buffy",   "Claws", "Whistler",
+	char     *name[] = {"Slim",   "Buffy",   "Claws", "Whistler",
 			      "Chirpy", "Browser", "Fang",  "Fluffy"};
-	char    *owner[] = {"Benny", "Harold", "GWen", "Gwen", "Gwen", "Diane", "Benny", "Harold"};
-	char    *species[] = {"snake", "dog", "cat", "bird", "bird", "dog", "dog", "cat"};
-	char    *sex[]     = {"m", "f", "m", "m", "f", "m", "m", "f"};
-	uint64_t age[]     = {1, 10, 4, 2, 3, 2, 7, 9};
+	char     *owner[] = {"Benny", "Harold", "GWen", "Gwen", "Gwen", "Diane", "Benny", "Harold"};
+	char     *species[] = {"snake", "dog", "cat", "bird", "bird", "dog", "dog", "cat"};
+	char     *sex[]     = {"m", "f", "m", "m", "f", "m", "m", "f"};
+	uint64_t  age[]     = {1, 10, 4, 2, 3, 2, 7, 9};
 
-	void    *data[NR_IODS_PER_DKEY];
+	void      *data[NR_IODS];
 
 	data[0] = (void *)owner;
 	data[1] = (void *)species;
@@ -58,7 +58,7 @@ insert_example_records(void)
 		/** set dkey for record */
 		d_iov_set(&dkey, name[i], strlen(name[i]));
 
-		for (j = 0; j < NR_IODS_PER_DKEY - 1; j++) { /** str fields */
+		for (j = 0; j < NR_IODS - 1; j++) { /** str fields */
 			char **strdata = (char **)data[j];
 
 			printf("%s(akey)=%s%*c", fields[j], strdata[i],
@@ -75,25 +75,24 @@ insert_example_records(void)
 			iods[j].iod_recxs = NULL;
 			iods[j].iod_type  = DAOS_IOD_SINGLE;
 		}
-		uint64_t *intdata = (uint64_t *)data[NR_IODS_PER_DKEY - 1];
+		uint64_t *intdata = (uint64_t *)data[NR_IODS - 1];
 
-		printf("%s(akey)=%lu\n", fields[NR_IODS_PER_DKEY - 1], intdata[i]);
+		printf("%s(akey)=%lu\n", fields[NR_IODS - 1], intdata[i]);
 		/** akeys */
-		sgls[NR_IODS_PER_DKEY - 1].sg_nr     = 1;
-		sgls[NR_IODS_PER_DKEY - 1].sg_nr_out = 0;
-		sgls[NR_IODS_PER_DKEY - 1].sg_iovs   = &iovs[NR_IODS_PER_DKEY - 1];
-		d_iov_set(&iovs[NR_IODS_PER_DKEY - 1], &intdata[i], sizeof(uint64_t));
+		sgls[NR_IODS - 1].sg_nr     = 1;
+		sgls[NR_IODS - 1].sg_nr_out = 0;
+		sgls[NR_IODS - 1].sg_iovs   = &iovs[NR_IODS - 1];
+		d_iov_set(&iovs[NR_IODS - 1], &intdata[i], sizeof(uint64_t));
 
-		d_iov_set(&iods[NR_IODS_PER_DKEY - 1].iod_name,
-			  (void *)fields[NR_IODS_PER_DKEY - 1],
-			  strlen(fields[NR_IODS_PER_DKEY - 1]));
-		iods[NR_IODS_PER_DKEY - 1].iod_nr    = 1;
-		iods[NR_IODS_PER_DKEY - 1].iod_size  = sizeof(uint64_t);
-		iods[NR_IODS_PER_DKEY - 1].iod_recxs = NULL;
-		iods[NR_IODS_PER_DKEY - 1].iod_type  = DAOS_IOD_SINGLE;
+		d_iov_set(&iods[NR_IODS - 1].iod_name,
+			  (void *)fields[NR_IODS - 1],
+			  strlen(fields[NR_IODS - 1]));
+		iods[NR_IODS - 1].iod_nr    = 1;
+		iods[NR_IODS - 1].iod_size  = sizeof(uint64_t);
+		iods[NR_IODS - 1].iod_recxs = NULL;
+		iods[NR_IODS - 1].iod_type  = DAOS_IOD_SINGLE;
 
-		rc = daos_obj_update(oh, DAOS_TX_NONE, 0, &dkey, NR_IODS_PER_DKEY, iods, sgls,
-				     NULL);
+		rc = daos_obj_update(oh, DAOS_TX_NONE, 0, &dkey, NR_IODS, iods, sgls, NULL);
 		ASSERT(rc == 0, "Obj update failed with %d", rc);
 	}
 	printf("\n");
@@ -590,47 +589,43 @@ build_pipeline_four(daos_pipeline_t *pipeline)
 void
 run_pipeline(daos_pipeline_t *pipeline)
 {
-	daos_iod_t            *iods      = NULL;
-	daos_anchor_t          anchor;
-	uint32_t               nr_iods;
-	uint32_t               nr_kds;
-	daos_key_desc_t       *kds       = NULL;
-	d_sg_list_t            sgl_keys;
-	d_iov_t               *iov_keys  = NULL;
-	char                  *buf_keys  = NULL;
-	d_sg_list_t            sgl_recx;
-	d_iov_t               *iov_recx  = NULL;
-	char                  *buf_recx  = NULL;
-	d_sg_list_t            sgl_aggr;
-	d_iov_t               *iovs_aggr = NULL;
-	char                  *buf_aggr  = NULL;
-	daos_pipeline_stats_t  stats     = {0};
-	uint32_t               i, j;
-	int                    rc;
+	daos_iod_t             *iods      = NULL;
+	daos_anchor_t           anchor;
+	uint32_t                nr_iods;
+	uint32_t                nr_kds;
+	daos_key_desc_t        *kds       = NULL;
+	d_sg_list_t             sgl_keys;
+	d_iov_t                *iov_keys  = NULL;
+	char                   *buf_keys  = NULL;
+	d_sg_list_t             sgl_recx;
+	d_iov_t                *iov_recx  = NULL;
+	char                   *buf_recx  = NULL;
+	daos_size_t            *recx_size = NULL;
+	d_sg_list_t             sgl_aggr;
+	d_iov_t                *iovs_aggr = NULL;
+	char                   *buf_aggr  = NULL;
+	daos_pipeline_stats_t   stats     = {0};
+	uint32_t                i, j;
+	int                     rc;
 
 	/**
 	 * reading in chunks of 64 keys (at most) at a time
 	 */
 	nr_kds    = 64;
-	nr_iods   = NR_IODS_PER_DKEY * nr_kds;
+	nr_iods   = NR_IODS;
 
 	kds       = malloc(sizeof(*kds) * nr_kds);
-	iods      = calloc(nr_iods, sizeof(*iods));
+	iods      = malloc(sizeof(*iods) * nr_iods);
 
 	/**
-	 * iods:
-	 *  --  0 <= i < NR_IODS_PER_DKEY: information about what akeys to retrieve
-	 *  --  0 <= i < nr_iods         : output information about akeys retrieved
+	 * iods: information about what akeys to retrieve
 	 */
 	for (i = 0; i < nr_iods; i++) {
 		iods[i].iod_nr    = 1;
 		iods[i].iod_size  = STRING_MAX_LEN;
 		iods[i].iod_recxs = NULL;
 		iods[i].iod_type  = DAOS_IOD_SINGLE;
-		if (i < NR_IODS_PER_DKEY) {
-			/** The rest of iods are output only */
-			d_iov_set(&iods[i].iod_name, (void *)fields[i], strlen(fields[i]));
-		}
+		d_iov_set(&iods[i].iod_name, (void *)fields[i], strlen(fields[i]));
 	}
 
 	/** sgl_keys: to store the retrieved dkeys */
@@ -643,15 +638,16 @@ run_pipeline(daos_pipeline_t *pipeline)
 	iov_keys->iov_buf_len = nr_kds * STRING_MAX_LEN;
 	iov_keys->iov_len     = 0;
 
-	/** sgl_recx: to store the retrieved data for the akeys of each dkey */
+	/** sgl_recx and recx_size: to store the retrieved data for the akeys of each dkey */
 	sgl_recx.sg_nr        = 1;
 	sgl_recx.sg_nr_out    = 0;
-	iov_recx              = malloc(sizeof(*iov_recx) * nr_iods);
+	iov_recx              = malloc(sizeof(*iov_recx));
 	sgl_recx.sg_iovs      = iov_recx;
-	buf_recx              = malloc(nr_iods * STRING_MAX_LEN);
+	buf_recx              = malloc(nr_iods * nr_kds * STRING_MAX_LEN);
 	iov_recx->iov_buf     = buf_recx;
-	iov_recx->iov_buf_len = nr_iods * STRING_MAX_LEN;
+	iov_recx->iov_buf_len = nr_iods * nr_kds * STRING_MAX_LEN;
 	iov_recx->iov_len     = 0;
+	recx_size             = malloc(sizeof(*recx_size) * nr_iods * nr_kds);
 
 	/** sgl_aggr: for aggregation of data */
 	sgl_aggr.sg_nr     = nr_aggr;
@@ -677,13 +673,10 @@ run_pipeline(daos_pipeline_t *pipeline)
 
 		/** restoring value for in/out parameters */
 		nr_kds  = 64; /** trying to read 64 at a time again */
-		nr_iods = NR_IODS_PER_DKEY * nr_kds;
-		for (i = 0; i < NR_IODS_PER_DKEY; i++) {
-			iods[i].iod_size  = STRING_MAX_LEN; /** restoring iod_size to buf size */
-		}
+		nr_iods = NR_IODS;
 		/** calling pipeline run */
-		rc = daos_pipeline_run(coh, oh, pipeline, DAOS_TX_NONE, 0, NULL, NR_IODS_PER_DKEY,
-				       &nr_iods, iods, &anchor, &nr_kds, kds, &sgl_keys, &sgl_recx,
+		rc = daos_pipeline_run(coh, oh, pipeline, DAOS_TX_NONE, 0, NULL, &nr_iods, iods,
+				       &anchor, &nr_kds, kds, &sgl_keys, &sgl_recx, recx_size,
 				       &sgl_aggr, &stats, NULL);
 
 		ASSERT(rc == 0, "Pipeline run failed with %d", rc);
@@ -698,15 +691,15 @@ run_pipeline(daos_pipeline_t *pipeline)
 			       (int)(STRING_MAX_LEN - dkey_s), ' ');
 			dkey += dkey_s;
 
-			for (j = 0; j < NR_IODS_PER_DKEY - 1; j++) {
-				rec_s         = iods[j].iod_size;
+			for (j = 0; j < nr_iods - 1; j++) {
+				rec_s = recx_size[i * nr_iods + j];
 
 				printf("%.*s(akey)=%.*s%*c", (int)iods[j].iod_name.iov_len,
 				       (char *)iods[j].iod_name.iov_buf, (int)rec_s, rec,
 				       (int)(STRING_MAX_LEN - rec_s), ' ');
 				rec += rec_s;
 			}
-			printf("%.*s(akey)=%lu\n", (int)iods[NR_IODS_PER_DKEY - 1].iod_name.iov_len,
+			printf("%.*s(akey)=%lu\n", (int)iods[nr_iods - 1].iod_name.iov_len,
 			       (char *)iods[nr_iods - 1].iod_name.iov_buf, *((uint64_t *)rec));
 			rec += sizeof(uint64_t);
 		}
@@ -725,6 +718,7 @@ run_pipeline(daos_pipeline_t *pipeline)
 	free(buf_keys);
 	free(iov_recx);
 	free(buf_recx);
+	free(recx_size);
 	if (nr_aggr > 0) {
 		free(iovs_aggr);
 		free(buf_aggr);

--- a/src/tests/simple_pipeline_arrays.c
+++ b/src/tests/simple_pipeline_arrays.c
@@ -22,8 +22,7 @@ static daos_handle_t coh; /** container */
 static daos_handle_t oh;  /** object */
 
 /** DB info */
-#define NR_RECXS         4
-#define NR_IODS_PER_DKEY 1
+#define NR_RECXS	4
 
 static char field[] = "Array";
 int         nr_aggr;
@@ -295,20 +294,20 @@ build_pipeline_two(daos_pipeline_t *pipeline)
 void
 run_pipeline(daos_pipeline_t *pipeline)
 {
-	daos_iod_t             *iods;
-	daos_anchor_t          anchor;
-	uint32_t               nr_iods, nr_kds;
-	daos_key_desc_t       *kds;
-	d_sg_list_t            sgl_keys;
-	d_iov_t               *iovs_keys;
-	char                  *buf_keys;
-	d_sg_list_t            sgl_recs;
-	d_iov_t               *iovs_recs;
-	char                  *buf_recs;
-	daos_recx_t            recxs[NR_RECXS];
-	daos_pipeline_stats_t  stats = {0};
-	uint32_t               i, j;
-	int                    rc;
+	daos_iod_t              iod;
+	daos_anchor_t           anchor;
+	uint32_t                nr_iods, nr_kds;
+	daos_key_desc_t        *kds;
+	d_sg_list_t             sgl_keys;
+	d_iov_t                *iovs_keys;
+	char                   *buf_keys;
+	d_sg_list_t             sgl_recs;
+	d_iov_t                *iovs_recs;
+	char                   *buf_recs;
+	daos_recx_t             recxs[NR_RECXS];
+	daos_pipeline_stats_t   stats = {0};
+	uint32_t                i, j;
+	int                     rc;
 
 	/* record extensions for akey's array */
 	recxs[0].rx_idx = 0;
@@ -322,7 +321,7 @@ run_pipeline(daos_pipeline_t *pipeline)
 
 	/* reading chunks of 64 keys (at most) at a time */
 	nr_kds          = 64;
-	nr_iods         = NR_IODS_PER_DKEY * nr_kds;
+	nr_iods         = 1;
 
 	/* to store retrieved dkeys */
 	kds                   = malloc(sizeof(*kds) * nr_kds);
@@ -332,31 +331,24 @@ run_pipeline(daos_pipeline_t *pipeline)
 	sgl_keys.sg_iovs      = iovs_keys;
 	buf_keys              = malloc(nr_kds * 8);
 	/* to store retrieved data */
-	iods                  = calloc(nr_iods, sizeof(*iods));
-	iovs_recs             = malloc(sizeof(*iovs_recs) * nr_iods);
-	sgl_recs.sg_nr        = nr_iods;
+	iovs_recs             = malloc(sizeof(*iovs_recs) * nr_kds);
+	sgl_recs.sg_nr        = nr_kds;
 	sgl_recs.sg_nr_out    = 0;
 	sgl_recs.sg_iovs      = iovs_recs;
-	buf_recs              = malloc(18 * nr_iods);
+	buf_recs              = malloc(18 * nr_kds);
 
 	for (i = 0; i < nr_kds; i++) {
 		d_iov_set(&iovs_keys[i], &buf_keys[i * 8], 8);
-	}
-	for (i = 0; i < nr_iods; i++) {
 		d_iov_set(&iovs_recs[i], &buf_recs[i * 18], 18);
-
-		/**
-		 * iods:
-		 *  -- 0 <= i < NR_IODS_PER_DKEY: for akey's metadata
-		 *  -- 0 <= i < nr_iods         : output information about akeys retrieved
-		 */
-		iods[i].iod_nr    = NR_RECXS;
-		iods[i].iod_size  = 1; /* we interpret it as an array of bytes */
-		iods[i].iod_recxs = recxs;
-		iods[i].iod_type  = DAOS_IOD_ARRAY;
-		if (i < NR_IODS_PER_DKEY)
-			d_iov_set(&iods[i].iod_name, (char *)field, strlen(field));
 	}
+	/**
+	 * iods: information about what akeys to retrieve
+	 */
+	iod.iod_nr    = NR_RECXS;
+	iod.iod_size  = 1; /* we interpret it as an array of bytes */
+	iod.iod_recxs = recxs;
+	iod.iod_type  = DAOS_IOD_ARRAY;
+	d_iov_set(&iod.iod_name, (char *)field, strlen(field));
 
 	/** reset anchor */
 	memset(&anchor, 0, sizeof(daos_anchor_t));
@@ -365,12 +357,12 @@ run_pipeline(daos_pipeline_t *pipeline)
 	while (!daos_anchor_is_eof(&anchor)) {
 		/** restorin value for in/out parameters */
 		nr_kds  = 64; /** trying to read 64 in each iteration */
-		nr_iods = NR_IODS_PER_DKEY * nr_kds;
+		nr_iods = 1;
 
 		/** pipeline run */
-		rc     = daos_pipeline_run(coh, oh, pipeline, DAOS_TX_NONE, 0, NULL,
-					   NR_IODS_PER_DKEY, &nr_iods, iods, &anchor, &nr_kds, kds,
-					   &sgl_keys, &sgl_recs, NULL, &stats, NULL);
+		rc     = daos_pipeline_run(coh, oh, pipeline, DAOS_TX_NONE, 0, NULL, &nr_iods, &iod,
+					   &anchor, &nr_kds, kds, &sgl_keys, &sgl_recs, NULL, NULL,
+					   &stats, NULL);
 		ASSERT(rc == 0, "Pipeline run failed with %d", rc);
 
 		/** processing nr_kds records */
@@ -405,7 +397,6 @@ run_pipeline(daos_pipeline_t *pipeline)
 	}
 	printf("\t(scanned %lu dkeys)\n\n", stats.nr_dkeys);
 
-	free(iods);
 	free(kds);
 	free(iovs_keys);
 	free(buf_keys);


### PR DESCRIPTION
Instead of using the iods vector, which should be kept as a one
dimensional vector representing only the akeys to fetch from each dkey,
we use a separate buffer (the size of the records returned) to store the
size of the records. In this case, iods is kept as an INPUT only
parameter. In the future, this may change when a dkey can be passed to
filter akeys for a fixed dkey (this is still not implemented).

Skip-test: true

Signed-off-by: Eduardo Berrocal <eduardo.berrocal@intel.com>