### PR TITLE
DAOS-10415 EC: various fixes about EC (#8506)

### DIFF
--- a/src/object/cli_ec.c
+++ b/src/object/cli_ec.c
@@ -2442,7 +2442,7 @@ obj_ec_recov_prep(struct obj_reasb_req *reasb_req, daos_obj_id_t oid,
 	/* when new target failed in recovery, the efi_stripe_lists and
 	 * efi_recov_tasks already initialized.
 	 */
-	if (fail_info->efi_stripe_lists == NULL) {
+	if (fail_info->efi_stripe_sgls == NULL) {
 		rc = obj_ec_stripe_list_init(reasb_req);
 		if (rc)
 			goto out;
@@ -2567,7 +2567,10 @@ again:
 			rec_nr += recov_recx.rx_idx - iod_recx.rx_idx;
 			break;
 		}
-		D_ASSERT(overlapped);
+
+		if (!overlapped)
+			continue;
+
 		iod_off = rec_nr * iod_size;
 
 		/* break the to-be-recovered recx per stripe, can copy


### PR DESCRIPTION
1. Various fixes for EC multiple shards enumeration.

2. Check efi_stripe_sgls, instead of efi_stripe_lists, which will
not be set for single value.

3. Remove unnecessary assert in obj_ec_recov_stripe(), since fail_info
list might be shared by multiple recover tasks, so one recov ent list
may not exist in one IOD.

4. Remove unnecessary invalid nr check for multiple shards enumeration.

5. Reset kd_key_len to 0 for enumeration, since it may return the
required size for KEY2BIG case.

Signed-off-by: Di Wang <di.wang@intel.com>

Signed-off-by: Di Wang <di.wang@intel.com>

Conflicts:
	src/object/cli_obj.c