### PR TITLE
DAOS-10430 test: Update container_get_prop() to use JSON

### DIFF
--- a/src/tests/ftest/datamover/dst_create.py
+++ b/src/tests/ftest/datamover/dst_create.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 '''
-  (C) Copyright 2020-2021 Intel Corporation.
+  (C) Copyright 2020-2022 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
@@ -8,6 +8,7 @@ from data_mover_test_base import DataMoverTestBase
 from os.path import join
 from pydaos.raw import DaosApiError
 import avocado
+
 
 class DmvrDstCreate(DataMoverTestBase):
     # pylint: disable=too-many-ancestors
@@ -196,14 +197,12 @@ class DmvrDstCreate(DataMoverTestBase):
             cont (TestContainer): the container to get props of.
 
         Returns:
-            list: string list of properties and values from daos command.
+            list: list of dictionaries that contain properties and values from daos
+                command.
 
         """
-        prop_result = self.daos_cmd.container_get_prop(
-            cont.pool.uuid, cont.uuid)
-        prop_text = prop_result.stdout_text
-        prop_list = prop_text.split('\n')[1:]
-        return prop_list
+        prop_result = self.daos_cmd.container_get_prop(cont.pool.uuid, cont.uuid)
+        return prop_result["response"]
 
     def verify_cont_prop(self, cont, prop_list, api):
         """Verify container properties against an input list.
@@ -212,7 +211,6 @@ class DmvrDstCreate(DataMoverTestBase):
         Args:
             cont (TestContainer): the container to verify.
             prop_list (list): list of properties from get_cont_prop.
-
         """
         actual_list = self.get_cont_prop(cont)
 
@@ -225,7 +223,7 @@ class DmvrDstCreate(DataMoverTestBase):
         # Make sure each property matches
         for prop_idx, prop in enumerate(prop_list):
             # This one is not set
-            if api == "DFS" and "OID" in prop_list[prop_idx]:
+            if api == "DFS" and "OID" in str(prop["description"]):
                 continue
             if prop != actual_list[prop_idx]:
                 self.log.info("Expected\n%s\nbut got\n%s\n",

--- a/src/tests/ftest/erasurecode/cell_size_property.py
+++ b/src/tests/ftest/erasurecode/cell_size_property.py
@@ -1,13 +1,13 @@
 #!/usr/bin/python
 '''
-  (C) Copyright 2020-2021 Intel Corporation.
+  (C) Copyright 2020-2022 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
 from itertools import product
 
 from ior_test_base import IorTestBase
-from general_utils import human_to_bytes
+
 
 class EcodCellSizeProperty(IorTestBase):
     # pylint: disable=too-many-ancestors
@@ -27,14 +27,14 @@ class EcodCellSizeProperty(IorTestBase):
             expected_size (int): expected container cell size
         """
         daos_cmd = self.get_daos_command()
-        cont_prop = daos_cmd.container_get_prop(self.pool.uuid,
-                                                self.container.uuid)
-        cont_prop_stdout = cont_prop.stdout_text
-        prop_list = cont_prop_stdout.split('\n')[1:]
-        cont_index = [i for i, word in enumerate(prop_list)
-                      if word.startswith('EC Cell Size')][0]
-        cell_size = (prop_list[cont_index].split('EC Cell Size')[1].strip())
-        cont_cell_size = (human_to_bytes(cell_size.replace(" ", "")))
+        cont_prop = daos_cmd.container_get_prop(self.pool.uuid, self.container.uuid)
+
+        cont_cell_size = None
+        for prop in cont_prop["response"]:
+            if prop["name"] == "ec_cell":
+                cont_cell_size = prop["value"]
+                break
+
         self.assertEqual(expected_size, cont_cell_size)
 
     def test_ec_pool_property(self):

--- a/src/tests/ftest/erasurecode/cell_size_property.py
+++ b/src/tests/ftest/erasurecode/cell_size_property.py
@@ -27,15 +27,11 @@ class EcodCellSizeProperty(IorTestBase):
             expected_size (int): expected container cell size
         """
         daos_cmd = self.get_daos_command()
-        cont_prop = daos_cmd.container_get_prop(self.pool.uuid, self.container.uuid)
+        cont_prop = daos_cmd.container_get_prop(
+            pool=self.pool.uuid, cont=self.container.uuid, properties=["ec_cell"])
+        actual_size = cont_prop["response"][0]["value"]
 
-        cont_cell_size = None
-        for prop in cont_prop["response"]:
-            if prop["name"] == "ec_cell":
-                cont_cell_size = prop["value"]
-                break
-
-        self.assertEqual(expected_size, cont_cell_size)
+        self.assertEqual(expected_size, actual_size)
 
     def test_ec_pool_property(self):
         """Jira ID: DAOS-7321.

--- a/src/tests/ftest/rebuild/container_rf.py
+++ b/src/tests/ftest/rebuild/container_rf.py
@@ -5,7 +5,6 @@
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
 from container_rf_test_base import ContRedundancyFactor
-from apricot import skipForTicket
 
 
 class RbldContRfTest(ContRedundancyFactor):
@@ -20,7 +19,6 @@ class RbldContRfTest(ContRedundancyFactor):
         super().__init__(*args, **kwargs)
         self.daos_cmd = None
 
-    @skipForTicket("DAOS-10156")
     def test_rebuild_with_container_rf(self):
         """Jira ID:
         DAOS-6270: container with RF 2 can lose up to 2 concurrent

--- a/src/tests/ftest/rebuild/container_rf.py
+++ b/src/tests/ftest/rebuild/container_rf.py
@@ -5,6 +5,7 @@
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
 from container_rf_test_base import ContRedundancyFactor
+from apricot import skipForTicket
 
 
 class RbldContRfTest(ContRedundancyFactor):
@@ -19,6 +20,7 @@ class RbldContRfTest(ContRedundancyFactor):
         super().__init__(*args, **kwargs)
         self.daos_cmd = None
 
+    @skipForTicket("DAOS-10156")
     def test_rebuild_with_container_rf(self):
         """Jira ID:
         DAOS-6270: container with RF 2 can lose up to 2 concurrent

--- a/src/tests/ftest/util/container_rf_test_base.py
+++ b/src/tests/ftest/util/container_rf_test_base.py
@@ -62,20 +62,25 @@ class ContRedundancyFactor(RebuildTestBase):
             expected_rf (str): expected container redundancy factor.
             expect_cont_status (str): expected container health status.
         """
-        result = self.daos_cmd.container_get_prop(
-                      pool=self.pool.uuid,
-                      cont=self.container.uuid)
-        rf = re.search(r"Redundancy Factor\s*([A-Za-z0-9-]+)",
-                       str(result.stdout)).group(1)
-        health = re.search(r"Health\s*([A-Z]+)", str(result.stdout)).group(1)
+        actual_rf = None
+        actual_health = None
+
+        cont_props = self.daos_cmd.container_get_prop(
+            pool=self.pool.uuid, cont=self.container.uuid, properties=["rf", "status"])
+        for cont_prop in cont_props["response"]:
+            if cont_prop["name"] == "rf":
+                actual_rf = cont_prop["value"]
+            elif cont_prop["name"] == "status":
+                actual_health = cont_prop["value"]
+
         self.assertEqual(
-            rf, expected_rf,
+            actual_rf, expected_rf,
             "#Container redundancy factor mismatch, actual: {},"
-            " expected: {}.".format(rf, expected_rf))
+            " expected: {}.".format(actual_rf, expected_rf))
         self.assertEqual(
-            health, expected_health,
+            actual_health, expected_health,
             "#Container health-status mismatch, actual: {},"
-            " expected: {}.".format(health, expected_health))
+            " expected: {}.".format(actual_health, expected_health))
 
     def start_rebuild_cont_rf(self, rf):
         """Start the rebuild process and check for container properties.

--- a/src/tests/ftest/util/daos_utils.py
+++ b/src/tests/ftest/util/daos_utils.py
@@ -379,14 +379,118 @@ class DaosCommand(DaosCommandBase):
             cont (str): Container UUID.
 
         Returns:
-            CmdResult: Object that contains exit status, stdout, and other
-                information.
+            str: JSON that contains the command output.
 
         Raises:
             CommandFailure: if the daos container get-prop command fails.
 
         """
-        return self._get_result(
+        # Sample output
+        # {
+        #     "response": [
+        #         {
+        #             "value": 0,
+        #             "name": "alloc_oid",
+        #             "description": "Highest Allocated OID"
+        #         },
+        #         {
+        #             "value": "off",
+        #             "name": "cksum",
+        #             "description": "Checksum"
+        #         },
+        #         {
+        #             "value": 32768,
+        #             "name": "cksum_size",
+        #             "description": "Checksum Chunk Size"
+        #         },
+        #         {
+        #             "value": "off",
+        #             "name": "compression",
+        #             "description": "Compression"
+        #         },
+        #         {
+        #             "value": "off",
+        #             "name": "dedup",
+        #             "description": "Deduplication"
+        #         },
+        #         {
+        #             "value": 4096,
+        #             "name": "dedup_threshold",
+        #             "description": "Dedupe Threshold"
+        #         },
+        #         {
+        #             "value": 65536,
+        #             "name": "ec_cell",
+        #             "description": "EC Cell Size"
+        #         },
+        #         {
+        #             "value": "off",
+        #             "name": "encryption",
+        #             "description": "Encryption"
+        #         },
+        #         {
+        #             "value": "mkano@",
+        #             "name": "group",
+        #             "description": "Group"
+        #         },
+        #         {
+        #             "value": "mkc1",
+        #             "name": "label",
+        #             "description": "Label"
+        #         },
+        #         {
+        #             "value": "POSIX (1)",
+        #             "name": "layout_type",
+        #             "description": "Layout Type"
+        #         },
+        #         {
+        #             "value": 1,
+        #             "name": "layout_version",
+        #             "description": "Layout Version"
+        #         },
+        #         {
+        #             "value": 0,
+        #             "name": "max_snapshot",
+        #             "description": "Max Snapshot"
+        #         },
+        #         {
+        #             "value": "mkano@",
+        #             "name": "owner",
+        #             "description": "Owner"
+        #         },
+        #         {
+        #             "value": "rf0",
+        #             "name": "rf",
+        #             "description": "Redundancy Factor"
+        #         },
+        #         {
+        #             "value": "rank (1)",
+        #             "name": "rf_lvl",
+        #             "description": "Redundancy Level"
+        #         },
+        #         {
+        #             "value": "off",
+        #             "name": "srv_cksum",
+        #             "description": "Server Checksumming"
+        #         },
+        #         {
+        #             "value": "HEALTHY",
+        #             "name": "status",
+        #             "description": "Health"
+        #         },
+        #         {
+        #             "value": [
+        #                 "A::OWNER@:rwdtTaAo",
+        #                 "A:G:GROUP@:rwtT"
+        #             ],
+        #             "name": "acl",
+        #             "description": "Access Control List"
+        #         }
+        #     ],
+        #     "error": null,
+        #     "status": 0
+        # }
+        return self._get_json_result(
             ("container", "get-prop"), pool=pool, cont=cont)
 
     def container_set_owner(self, pool, cont, user, group):

--- a/src/tests/ftest/util/daos_utils.py
+++ b/src/tests/ftest/util/daos_utils.py
@@ -371,12 +371,13 @@ class DaosCommand(DaosCommandBase):
             ("container", "set-prop"),
             pool=pool, cont=cont, prop=prop_value)
 
-    def container_get_prop(self, pool, cont):
+    def container_get_prop(self, pool, cont, properties=None):
         """Call daos container get-prop.
 
         Args:
             pool (str): Pool UUID.
             cont (str): Container UUID.
+            properties (list): "name" field(s). Defaults to None.
 
         Returns:
             str: JSON that contains the command output.
@@ -387,111 +388,128 @@ class DaosCommand(DaosCommandBase):
         """
         # Sample output
         # {
-        #     "response": [
-        #         {
-        #             "value": 0,
-        #             "name": "alloc_oid",
-        #             "description": "Highest Allocated OID"
-        #         },
-        #         {
-        #             "value": "off",
-        #             "name": "cksum",
-        #             "description": "Checksum"
-        #         },
-        #         {
-        #             "value": 32768,
-        #             "name": "cksum_size",
-        #             "description": "Checksum Chunk Size"
-        #         },
-        #         {
-        #             "value": "off",
-        #             "name": "compression",
-        #             "description": "Compression"
-        #         },
-        #         {
-        #             "value": "off",
-        #             "name": "dedup",
-        #             "description": "Deduplication"
-        #         },
-        #         {
-        #             "value": 4096,
-        #             "name": "dedup_threshold",
-        #             "description": "Dedupe Threshold"
-        #         },
-        #         {
-        #             "value": 65536,
-        #             "name": "ec_cell",
-        #             "description": "EC Cell Size"
-        #         },
-        #         {
-        #             "value": "off",
-        #             "name": "encryption",
-        #             "description": "Encryption"
-        #         },
-        #         {
-        #             "value": "mkano@",
-        #             "name": "group",
-        #             "description": "Group"
-        #         },
-        #         {
-        #             "value": "mkc1",
-        #             "name": "label",
-        #             "description": "Label"
-        #         },
-        #         {
-        #             "value": "POSIX (1)",
-        #             "name": "layout_type",
-        #             "description": "Layout Type"
-        #         },
-        #         {
-        #             "value": 1,
-        #             "name": "layout_version",
-        #             "description": "Layout Version"
-        #         },
-        #         {
-        #             "value": 0,
-        #             "name": "max_snapshot",
-        #             "description": "Max Snapshot"
-        #         },
-        #         {
-        #             "value": "mkano@",
-        #             "name": "owner",
-        #             "description": "Owner"
-        #         },
-        #         {
-        #             "value": "rf0",
-        #             "name": "rf",
-        #             "description": "Redundancy Factor"
-        #         },
-        #         {
-        #             "value": "rank (1)",
-        #             "name": "rf_lvl",
-        #             "description": "Redundancy Level"
-        #         },
-        #         {
-        #             "value": "off",
-        #             "name": "srv_cksum",
-        #             "description": "Server Checksumming"
-        #         },
-        #         {
-        #             "value": "HEALTHY",
-        #             "name": "status",
-        #             "description": "Health"
-        #         },
-        #         {
-        #             "value": [
-        #                 "A::OWNER@:rwdtTaAo",
-        #                 "A:G:GROUP@:rwtT"
-        #             ],
-        #             "name": "acl",
-        #             "description": "Access Control List"
-        #         }
-        #     ],
-        #     "error": null,
-        #     "status": 0
+        #   "response": [
+        #     {
+        #       "value": 0,
+        #       "name": "alloc_oid",
+        #       "description": "Highest Allocated OID"
+        #     },
+        #     {
+        #       "value": "off",
+        #       "name": "cksum",
+        #       "description": "Checksum"
+        #     },
+        #     {
+        #       "value": 32768,
+        #       "name": "cksum_size",
+        #       "description": "Checksum Chunk Size"
+        #     },
+        #     {
+        #       "value": "off",
+        #       "name": "compression",
+        #       "description": "Compression"
+        #     },
+        #     {
+        #       "value": "off",
+        #       "name": "dedup",
+        #       "description": "Deduplication"
+        #     },
+        #     {
+        #       "value": 4096,
+        #       "name": "dedup_threshold",
+        #       "description": "Dedupe Threshold"
+        #     },
+        #     {
+        #       "value": 65536,
+        #       "name": "ec_cell",
+        #       "description": "EC Cell Size"
+        #     },
+        #     {
+        #       "value": "1",
+        #       "name": "ec_pda",
+        #       "description": "Performance domain affinity level of EC"
+        #     },
+        #     {
+        #       "value": "off",
+        #       "name": "encryption",
+        #       "description": "Encryption"
+        #     },
+        #     {
+        #       "value": "1",
+        #       "name": "global_version",
+        #       "description": "Global Version"
+        #     },
+        #     {
+        #       "value": "mkano@",
+        #       "name": "group",
+        #       "description": "Group"
+        #     },
+        #     {
+        #       "value": "mkc1",
+        #       "name": "label",
+        #       "description": "Label"
+        #     },
+        #     {
+        #       "value": "unknown (0)",
+        #       "name": "layout_type",
+        #       "description": "Layout Type"
+        #     },
+        #     {
+        #       "value": 1,
+        #       "name": "layout_version",
+        #       "description": "Layout Version"
+        #     },
+        #     {
+        #       "value": 0,
+        #       "name": "max_snapshot",
+        #       "description": "Max Snapshot"
+        #     },
+        #     {
+        #       "value": "mkano@",
+        #       "name": "owner",
+        #       "description": "Owner"
+        #     },
+        #     {
+        #       "value": "rf0",
+        #       "name": "rf",
+        #       "description": "Redundancy Factor"
+        #     },
+        #     {
+        #       "value": "rank (1)",
+        #       "name": "rf_lvl",
+        #       "description": "Redundancy Level"
+        #     },
+        #     {
+        #       "value": "3",
+        #       "name": "rp_pda",
+        #       "description": "Performance domain affinity level of RP"
+        #     },
+        #     {
+        #       "value": "off",
+        #       "name": "srv_cksum",
+        #       "description": "Server Checksumming"
+        #     },
+        #     {
+        #       "value": "HEALTHY",
+        #       "name": "status",
+        #       "description": "Health"
+        #     },
+        #     {
+        #       "value": [
+        #         "A::OWNER@:rwdtTaAo",
+        #         "A:G:GROUP@:rwtT"
+        #       ],
+        #       "name": "acl",
+        #       "description": "Access Control List"
+        #     }
+        #   ],
+        #   "error": null,
+        #   "status": 0
         # }
+        props = ','.join(properties) if properties else None
+
         return self._get_json_result(
-            ("container", "get-prop"), pool=pool, cont=cont)
+            ("container", "get-prop"), pool=pool, cont=cont, prop=props)
 
     def container_set_owner(self, pool, cont, user, group):
         """Call daos container set-owner.

--- a/src/tests/ftest/util/test_utils_container.py
+++ b/src/tests/ftest/util/test_utils_container.py
@@ -882,3 +882,31 @@ class TestContainer(TestDaosApiBase):
 
         # Return the number of punched objects
         return count
+
+    @fail_on(CommandFailure)
+    def get_prop(self, properties=None):
+        """Get container property by calling daos container get-prop.
+
+        Args:
+            properties (list): "name" field(s). Defaults to None.
+
+        Returns:
+            str: JSON output of daos container get-prop.
+
+        Raises:
+            CommandFailure: Raised from the daos command call.
+
+        """
+        if self.control_method.value == self.USE_DAOS and self.daos:
+            # Get container property using daos utility.
+            return self.daos.container_get_prop(
+                pool=self.pool.uuid, cont=self.uuid, properties=properties)
+
+        if self.control_method.value == self.USE_DAOS:
+            self.log.error("Error: Undefined daos command")
+
+        else:
+            self.log.error(
+                "Error: Undefined control_method: %s", self.control_method.value)
+
+        return None


### PR DESCRIPTION
Update `DaosCommand.container_get_prop()` to use JSON and
support `properties`. Also add `TestContainer.get_prop()`.

Update the tests that use `container_get_prop()`.

This is the cherry-pick PR of the following two PRs.
https://github.com/daos-stack/daos/pull/8454, https://github.com/daos-stack/daos/pull/8741

The tags from the two PRs above are merged and used in this PR.

(Some of the tests, such as pool/rf.py, don't exist in 2.0, so the
changes to those tests aren't included.)