### PR TITLE
DAOS-10436 control: Don't call fi_getinfo with empty hint (#8820)

### DIFF
--- a/src/control/lib/hardware/libfabric/provider.go
+++ b/src/control/lib/hardware/libfabric/provider.go
@@ -56,7 +56,7 @@ func (p *Provider) getFabricInterfaces(ch chan *fabricResult) {
 	}
 	defer hdl.Close()
 
-	fiInfo, cleanup, err := fiGetInfo(hdl, "")
+	fiInfo, cleanup, err := fiGetInfo(hdl)
 	if err != nil {
 		ch <- &fabricResult{
 			err: err,


### PR DESCRIPTION
With libfabric v1.15.0 release candidates, an empty hint resulted
in fabric interfaces not being returned.

Signed-off-by: Kris Jacque <kristin.jacque@intel.com>