### PR TITLE
DAOS-9827 test: datamover: use base create_cont method

### DIFF
--- a/src/tests/ftest/aggregation/dfuse_space_check.py
+++ b/src/tests/ftest/aggregation/dfuse_space_check.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 """
-  (C) Copyright 2020-2021 Intel Corporation.
+  (C) Copyright 2020-2022 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -97,7 +97,7 @@ class DfuseSpaceCheck(IorTestBase):
 
         # Create a pool, container and start dfuse.
         self.create_pool()
-        self.create_cont()
+        self.container = self.get_container(self.pool)
         self.start_dfuse(self.hostlist_clients, self.pool, self.container)
 
         # get scm space before write

--- a/src/tests/ftest/container/multiple_delete.py
+++ b/src/tests/ftest/container/multiple_delete.py
@@ -41,7 +41,7 @@ class MultipleContainerDelete(IorTestBase):
 
         for i in range(50):
             self.log.info("Create-Write-Destroy Iteration %d", i)
-            self.create_cont()
+            self.container = self.get_container(self.pool, oclass=self.ior_cmd.dfs_oclass.value)
             self.ior_cmd.set_daos_params(
                 self.server_group, self.pool, self.container.uuid)
             # If the transfer size is less than 4K, the objects are

--- a/src/tests/ftest/control/dmg_system_cleanup.py
+++ b/src/tests/ftest/control/dmg_system_cleanup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 """
-  (C) Copyright 2020-2021 Intel Corporation.
+  (C) Copyright 2020-2022 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """

--- a/src/tests/ftest/datamover/copy_procs.py
+++ b/src/tests/ftest/datamover/copy_procs.py
@@ -45,8 +45,8 @@ class DmvrCopyProcs(DataMoverTestBase):
         """
         # Create pool and containers
         pool1 = self.create_pool()
-        cont1 = self.create_cont(pool1)
-        cont2 = self.create_cont(pool1)
+        cont1 = self.get_container(pool1)
+        cont2 = self.get_container(pool1)
 
         # Get the varying number of processes
         procs_list = self.params.get("processes", "/run/dcp/copy_procs/*")

--- a/src/tests/ftest/datamover/dst_create.py
+++ b/src/tests/ftest/datamover/dst_create.py
@@ -62,7 +62,7 @@ class DmvrDstCreate(DataMoverTestBase):
         pool1.connect(2)
 
         # Create a source cont
-        cont1 = self.create_cont(pool1, cont_type=cont_type)
+        cont1 = self.get_container(pool1, type=cont_type)
 
         # Create source data
         src_props = self.write_cont(cont1)

--- a/src/tests/ftest/datamover/large_dir.py
+++ b/src/tests/ftest/datamover/large_dir.py
@@ -48,7 +48,7 @@ class DmvrLargeDir(DataMoverTestBase):
 
         # create pool and cont1
         pool = self.create_pool()
-        cont1 = self.create_cont(pool)
+        cont1 = self.get_container(pool)
 
         # run mdtest to create data in cont1
         self.mdtest_cmd.write_bytes.update(file_size)
@@ -57,7 +57,7 @@ class DmvrLargeDir(DataMoverTestBase):
             flags=mdtest_flags[0])
 
         # create cont2
-        cont2 = self.create_cont(pool)
+        cont2 = self.get_container(pool)
 
         # copy from daos cont1 to cont2
         self.run_datamover(
@@ -74,7 +74,7 @@ class DmvrLargeDir(DataMoverTestBase):
             "POSIX", posix_path)
 
         # create cont3
-        cont3 = self.create_cont(pool)
+        cont3 = self.get_container(pool)
 
         # copy from posix file system to daos cont3
         self.run_datamover(

--- a/src/tests/ftest/datamover/large_file.py
+++ b/src/tests/ftest/datamover/large_file.py
@@ -42,13 +42,13 @@ class DmvrPosixLargeFile(DataMoverTestBase):
 
         # create pool and cont
         pool = self.create_pool()
-        cont1 = self.create_cont(pool)
+        cont1 = self.get_container(pool)
 
         # create initial data in cont1
         self.run_ior_with_params("DAOS", self.ior_cmd.test_file.value, pool, cont1)
 
         # create cont2
-        cont2 = self.create_cont(pool)
+        cont2 = self.get_container(pool)
 
         # copy from daos cont1 to cont2
         self.run_datamover(
@@ -65,7 +65,7 @@ class DmvrPosixLargeFile(DataMoverTestBase):
             "POSIX", posix_path)
 
         # create cont3
-        cont3 = self.create_cont(pool)
+        cont3 = self.get_container(pool)
 
         # copy from posix file system to daos cont3
         self.run_datamover(

--- a/src/tests/ftest/datamover/negative.py
+++ b/src/tests/ftest/datamover/negative.py
@@ -61,10 +61,11 @@ class DmvrNegativeTest(DataMoverTestBase):
         pool1 = self.create_pool()
 
         # Create a special container to hold UNS entries
-        uns_cont = self.create_cont(pool1)
+        uns_cont = self.get_container(pool1)
 
         # Create a test container
-        cont1 = self.create_cont(pool1, True, pool1, uns_cont)
+        cont1_path = join(self.dfuse.mount_dir.value, pool1.uuid, uns_cont.uuid, 'uns1')
+        cont1 = self.get_container(pool1, path=cont1_path)
 
         # Create test files
         self.run_ior_with_params("POSIX", self.posix_test_file)
@@ -203,7 +204,7 @@ class DmvrNegativeTest(DataMoverTestBase):
 
         # Create pool and containers
         pool1 = self.create_pool()
-        cont1 = self.create_cont(pool1)
+        cont1 = self.get_container(pool1)
 
         # Create source file
         self.run_ior_with_params("DAOS_UUID", self.daos_test_file,

--- a/src/tests/ftest/datamover/negative_space.py
+++ b/src/tests/ftest/datamover/negative_space.py
@@ -41,7 +41,7 @@ class DmvrNegativeSpaceTest(DataMoverTestBase):
 
         # Create destination test pool and container
         dst_pool = self.create_pool()
-        dst_cont = self.create_cont(dst_pool)
+        dst_cont = self.get_container(dst_pool)
         dst_daos_path = "/"
 
         # Try to copy, and expect a proper error message.

--- a/src/tests/ftest/datamover/obj_large_posix.py
+++ b/src/tests/ftest/datamover/obj_large_posix.py
@@ -39,7 +39,7 @@ class DmvrObjLargePosix(DataMoverTestBase):
 
         # Create pool1 and cont1
         pool1 = self.create_pool()
-        cont1 = self.create_cont(pool1)
+        cont1 = self.get_container(pool1)
 
         # Create a large directory in cont1
         self.mdtest_cmd.write_bytes.update(file_size)

--- a/src/tests/ftest/datamover/obj_small.py
+++ b/src/tests/ftest/datamover/obj_small.py
@@ -62,7 +62,7 @@ class DmvrObjSmallTest(DataMoverTestBase):
         pool1.connect(2)
 
         # Create cont1
-        cont1 = self.create_cont(pool1)
+        cont1 = self.get_container(pool1)
 
         # Create dataset in cont1
         obj_list = self.dataset_gen(

--- a/src/tests/ftest/datamover/posix_meta_entry.py
+++ b/src/tests/ftest/datamover/posix_meta_entry.py
@@ -64,7 +64,7 @@ class DmvrPosixMetaEntry(DataMoverTestBase):
         pool1 = self.create_pool()
 
         # Create 1 source container with test data
-        cont1 = self.create_cont(pool1)
+        cont1 = self.get_container(pool1)
         daos_src_path = self.new_daos_test_path(False)
         dfuse_src_path = "{}/{}/{}{}".format(
             self.dfuse.mount_dir.value, pool1.uuid, cont1.uuid, daos_src_path)

--- a/src/tests/ftest/datamover/posix_preserve_props.py
+++ b/src/tests/ftest/datamover/posix_preserve_props.py
@@ -61,7 +61,7 @@ class DmvrPreserveProps(DataMoverTestBase):
         self.preserve_props_path = join(self.tmp, "cont_props.h5")
 
         # Create a source cont
-        cont1 = self.create_cont(pool1, cont_type=cont_type)
+        cont1 = self.get_container(pool1, type=cont_type)
 
         # Create source data
         src_props = self.write_cont(cont1)

--- a/src/tests/ftest/datamover/posix_subsets.py
+++ b/src/tests/ftest/datamover/posix_subsets.py
@@ -54,17 +54,18 @@ class DmvrPosixSubsets(DataMoverTestBase):
         pool1 = self.create_pool()
 
         # create dfuse containers to test copying to dfuse subdirectories
-        dfuse_cont1 = self.create_cont(pool1)
-        dfuse_cont2 = self.create_cont(pool1)
+        dfuse_cont1 = self.get_container(pool1)
+        dfuse_cont2 = self.get_container(pool1)
         dfuse_cont1_dir = join(self.dfuse.mount_dir.value, pool1.uuid, dfuse_cont1.uuid)
         # destination directory should be created by program
         dfuse_cont2_dir = self.new_posix_test_path(create=False,
             parent=join(self.dfuse.mount_dir.value, pool1.uuid, dfuse_cont2.uuid))
         # Create a special container to hold UNS entries
-        uns_cont = self.create_cont(pool1)
+        uns_cont = self.get_container(pool1)
 
         # Create a testing container
-        container1 = self.create_cont(pool1, True, pool1, uns_cont)
+        container1_path = join(self.dfuse.mount_dir.value, pool1.uuid, uns_cont.uuid, 'uns1')
+        container1 = self.get_container(pool1, path=container1_path)
 
         # Create some source directories in the container
         sub_dir = self.new_daos_test_path(False)

--- a/src/tests/ftest/datamover/posix_symlinks.py
+++ b/src/tests/ftest/datamover/posix_symlinks.py
@@ -61,20 +61,23 @@ class DmvrPosixSymlinks(DataMoverTestBase):
         pool1 = self.create_pool()
 
         # Create a special container to hold UNS entries
-        uns_cont = self.create_cont(pool1)
+        uns_cont = self.get_container(pool1)
 
         # Test links that point forward
-        container1 = self.create_cont(pool1, True, pool1, uns_cont)
+        container1_path = join(self.dfuse.mount_dir.value, pool1.uuid, uns_cont.uuid, 'uns1')
+        container1 = self.get_container(pool1, path=container1_path)
         self.run_dm_posix_symlinks_fun(
             pool1, container1, self.create_links_forward, "forward")
 
         # Test links that point backward
-        container2 = self.create_cont(pool1, True, pool1, uns_cont)
+        container2_path = join(self.dfuse.mount_dir.value, pool1.uuid, uns_cont.uuid, 'uns2')
+        container2 = self.get_container(pool1, path=container2_path)
         self.run_dm_posix_symlinks_fun(
             pool1, container2, self.create_links_backward, "backward")
 
         # Test a mix of forward and backward links
-        container3 = self.create_cont(pool1, True, pool1, uns_cont)
+        container3_path = join(self.dfuse.mount_dir.value, pool1.uuid, uns_cont.uuid, 'uns3')
+        container3 = self.get_container(pool1, path=container3_path)
         self.run_dm_posix_symlinks_fun(
             pool1, container3, self.create_links_mixed, "mixed")
 

--- a/src/tests/ftest/datamover/posix_types.py
+++ b/src/tests/ftest/datamover/posix_types.py
@@ -70,12 +70,15 @@ class DmvrPosixTypesTest(DataMoverTestBase):
         pool2 = self.create_pool()
 
         # Create a special container to hold UNS entries
-        uns_cont = self.create_cont(pool1)
+        uns_cont = self.get_container(pool1)
 
         # Create all other containers
-        container1 = self.create_cont(pool1, True, pool1, uns_cont)
-        container2 = self.create_cont(pool1, True, pool1, uns_cont)
-        container3 = self.create_cont(pool2, True, pool1, uns_cont)
+        container1_path = join(self.dfuse.mount_dir.value, pool1.uuid, uns_cont.uuid, 'uns1')
+        container1 = self.get_container(pool1, path=container1_path)
+        container2_path = join(self.dfuse.mount_dir.value, pool1.uuid, uns_cont.uuid, 'uns2')
+        container2 = self.get_container(pool1, path=container2_path)
+        container3_path = join(self.dfuse.mount_dir.value, pool1.uuid, uns_cont.uuid, 'uns3')
+        container3 = self.get_container(pool2, path=container3_path)
 
         # Create each source location
         p1_c1 = ["/", pool1, container1]

--- a/src/tests/ftest/datamover/serial_large_posix.py
+++ b/src/tests/ftest/datamover/serial_large_posix.py
@@ -43,7 +43,7 @@ class DmvrSerialLargePosix(DataMoverTestBase):
 
         # Create pool1 and cont1
         pool1 = self.create_pool()
-        cont1 = self.create_cont(pool1)
+        cont1 = self.get_container(pool1)
 
         # Create a large directory in cont1
         self.mdtest_cmd.write_bytes.update(file_size)
@@ -55,7 +55,7 @@ class DmvrSerialLargePosix(DataMoverTestBase):
         pool2 = self.create_pool()
 
         # Use dfuse as a shared intermediate for serialize + deserialize
-        dfuse_cont = self.create_cont(pool1)
+        dfuse_cont = self.get_container(pool1)
         self.start_dfuse(self.dfuse_hosts, pool1, dfuse_cont)
         self.serial_tmp_dir = self.dfuse.mount_dir.value
 

--- a/src/tests/ftest/datamover/serial_small.py
+++ b/src/tests/ftest/datamover/serial_small.py
@@ -60,7 +60,7 @@ class DmvrSerialSmall(DataMoverTestBase):
         pool1.connect(2)
 
         # Create cont1
-        cont1 = self.create_cont(pool1)
+        cont1 = self.get_container(pool1)
 
         # Create dataset in cont1
         obj_list = self.dataset_gen(

--- a/src/tests/ftest/deployment/io_sys_admin.py
+++ b/src/tests/ftest/deployment/io_sys_admin.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 """
-  (C) Copyright 2018-2021 Intel Corporation.
+  (C) Copyright 2018-2022 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -53,8 +53,9 @@ class IoSysAdmin(DataMoverTestBase, FileCountTestBase):
             PoolTestBase.check_pool_creation(self, 60)
             self.pool[-1].connect()
             for cont_idx in range(1, 4):
-                self.add_container_qty(1, self.pool[-1],
-                                       namespace="/run/container_{}/".format(cont_idx))
+                # Appends to self.container
+                self.get_container(
+                    self.pool[-1], namespace="/run/container_{}/".format(cont_idx))
                 daos.container_set_owner(self.pool[-1].uuid, self.container[-1].uuid,
                                          new_test_user, new_test_group)
 

--- a/src/tests/ftest/dfuse/sparse_file.py
+++ b/src/tests/ftest/dfuse/sparse_file.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 """
-  (C) Copyright 2020-2021 Intel Corporation.
+  (C) Copyright 2020-2022 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -49,7 +49,7 @@ class SparseFile(IorTestBase):
         """
         # Create a pool, container and start dfuse.
         self.create_pool()
-        self.create_cont()
+        self.container = self.get_container(self.pool)
         self.start_dfuse(self.hostlist_clients, self.pool, self.container)
 
         # get scm space before write

--- a/src/tests/ftest/io/parallel_io.py
+++ b/src/tests/ftest/io/parallel_io.py
@@ -137,7 +137,8 @@ class ParallelIo(FioBase, IorTestBase):
         self.create_pool()
         self.start_dfuse(self.hostlist_clients, self.pool[0], None)
         # create multiple containers
-        self.add_container_qty(self.cont_count, self.pool[0])
+        for _ in self.cont_count:
+            self.container.append(self.get_container(self.pool[0]))
 
         # check if all the created containers can be accessed and perform
         # io on each container using fio in parallel
@@ -248,7 +249,8 @@ class ParallelIo(FioBase, IorTestBase):
         # different times and get appended in the self.container variable in
         # unorderly manner, causing problems during the write process.
         for _, pool in enumerate(self.pool):
-            self.add_container_qty(self.cont_count, pool)
+            for _ in self.cont_count:
+                self.container.append(self.get_container(pool))
 
         # Try to access each dfuse mounted container using ls. Once it is
         # accessed successfully, go ahead and perform io on that location

--- a/src/tests/ftest/performance/performance_test_base.py
+++ b/src/tests/ftest/performance/performance_test_base.py
@@ -370,8 +370,9 @@ class PerformanceTestBase(IorTestBase, MdtestBase):
 
         # Create pool and container upfront for flexibility and so rank stop timing is accurate
         self.create_pool()
-        self.create_cont(
-            chunk_size=self.ior_cmd.dfs_chunk.value, properties="rf:{}".format(cont_rf))
+        self.container = self.get_container(
+            self.pool, extra_props="rf:{}".format(cont_rf),
+            chunk_size=self.ior_cmd.dfs_chunk.value, oclass=self.ior_cmd.dfs_oclass.value)
         self.update_ior_cmd_with_pool(False)
 
         for iteration in range(num_iterations):

--- a/src/tests/ftest/util/apricot/apricot/test.py
+++ b/src/tests/ftest/util/apricot/apricot/test.py
@@ -1716,13 +1716,14 @@ class TestWithServers(TestWithoutServers):
             self.pool.append(self.get_pool(namespace, create, connect, index))
 
     @fail_on(AttributeError)
-    def get_container(self, pool, namespace=None, create=True, **kwargs):
+    def get_container(self, pool, namespace=None, extra_props=None, create=True, **kwargs):
         """Create a TestContainer object.
 
         Args:
             pool (TestPool): pool in which to create the container.
             namespace (str, optional): namespace for TestContainer parameters in
                 the test yaml file. Defaults to None.
+            extra_props (str, optional): extra properties to append. Defaults to None.
             create (bool, optional): should the container be created. Defaults to True.
             kwargs (dict): name/value of attributes for which to call update(value, name).
                 See TestContainer for available attributes.
@@ -1744,6 +1745,12 @@ class TestWithServers(TestWithoutServers):
         for name, value in kwargs.items():
             getattr(container, name).update(value, name=name)
 
+        # Append properties
+        if extra_props:
+            cur_props = container.properties.value
+            new_props = ','.join(filter(None, [cur_props, extra_props]))
+            container.properties.update(new_props)
+
         if create:
             container.create()
 
@@ -1762,34 +1769,6 @@ class TestWithServers(TestWithoutServers):
                 to True.
         """
         self.container = self.get_container(pool=pool, namespace=namespace, create=create)
-
-    def add_container_qty(self, quantity, pool, namespace=None, create=True):
-        """Add multiple containers to the test case.
-
-        This method requires self.container to be defined as a list.
-        If self.container is undefined it will define it as a list.
-
-        Args:
-            quantity (int): number of containers to create
-            namespace (str, optional): namespace for TestContainer parameters in the
-                test yaml file. Defaults to None.
-            pool (TestPool): Pool object
-            create (bool, optional): should the container be created. Defaults to
-                True.
-
-        Raises:
-            TestFail: if self.pool is defined, but not as a list object.
-
-        """
-        if self.container is None:
-            self.container = []
-        if not isinstance(self.container, list):
-            self.fail(
-                "add_container_qty(): self.container must be a list: {}".format(
-                    type(self.container)))
-        for _ in range(quantity):
-            self.container.append(
-                self.get_container(pool=pool, namespace=namespace, create=create))
 
     def start_additional_servers(self, additional_servers, index=0,
                                  access_points=None):

--- a/src/tests/ftest/util/ior_test_base.py
+++ b/src/tests/ftest/util/ior_test_base.py
@@ -56,42 +56,6 @@ class IorTestBase(DfuseTestBase):
         # Get the pool params and create a pool
         self.add_pool(connect=False)
 
-    def create_cont(self, chunk_size=None, properties=None):
-        """Create a TestContainer object to be used to create container.
-
-        Args:
-            chunk_size (str, optional): container chunk size. Defaults to None.
-            properties (str, optional): additional properties to append. Defaults to None.
-        Returns:
-            TestContainer: the created container.
-
-        """
-        params = {}
-
-        # Set container oclass to match ior oclass
-        if self.ior_cmd.dfs_oclass:
-            params["oclass"] = self.ior_cmd.dfs_oclass.value
-
-        # update container chunk size
-        if chunk_size is not None:
-            params["chunk_size"] = chunk_size
-
-        # create container from params
-        self.container = self.get_container(self.pool, create=False, **params)
-
-        # append container properties
-        if properties is not None:
-            current_properties = self.container.properties.value
-            if current_properties:
-                new_properties = current_properties + "," + properties
-            else:
-                new_properties = properties
-            self.container.properties.update(new_properties)
-
-        # create container
-        self.container.create()
-        return self.container
-
     def display_pool_space(self, pool=None):
         """Display the current pool space.
 
@@ -200,7 +164,9 @@ class IorTestBase(DfuseTestBase):
         # It will not enable checksum feature
         if create_cont:
             self.pool.connect()
-            self.create_cont()
+            self.container = self.get_container(
+                self.pool,
+                oclass=(self.ior_cmd.dfs_oclass.value if self.ior_cmd.dfs_oclass else None))
         # Update IOR params with the pool and container params
         self.ior_cmd.set_daos_params(self.server_group, self.pool,
                                      self.container.uuid)

--- a/src/tests/ftest/util/nvme_utils.py
+++ b/src/tests/ftest/util/nvme_utils.py
@@ -93,16 +93,6 @@ class ServerFillUp(IorTestBase):
         self.engines = self.server_managers[0].manager.job.yaml.engine_params
         self.dmg_command = self.get_dmg_command()
 
-    def create_container(self):
-        """Create the container """
-        self.nvme_local_cont = self.get_container(self.pool, create=False)
-
-        # update container oclass
-        if self.ior_local_cmd.dfs_oclass:
-            self.nvme_local_cont.oclass.update(self.ior_local_cmd.dfs_oclass.value)
-
-        self.nvme_local_cont.create()
-
     def start_ior_thread(self, create_cont, operation):
         """Start IOR write/read threads and wait until all threads are finished.
 
@@ -131,7 +121,8 @@ class ServerFillUp(IorTestBase):
 
         # Created new container or use the existing container for reading
         if create_cont:
-            self.create_container()
+            self.nvme_local_cont = self.get_container(
+                self.pool, oclass=self.ior_local_cmd.dfs_oclass.value)
         self.ior_local_cmd.dfs_cont.update(self.nvme_local_cont.uuid)
 
         # Define the job manager for the IOR command


### PR DESCRIPTION
Replace DataMoverTestBase.create_cont with TestWithServers.get_container

Skip-build: true
Skip-test: true

Test-tag: Test-tag: datamover,-iosysadmin,-dm_posix_meta_entry,-dm_serial_large_posix,-dm_obj_large_posix

Signed-off-by: Dalton Bohning <dalton.bohning@intel.com>