### PR TITLE
DAOS-9826 datamover: truncate files that exist in daos fs copy.

### DIFF
--- a/src/utils/daos_hdlr.c
+++ b/src/utils/daos_hdlr.c
@@ -989,7 +989,7 @@ fs_copy_file(struct cmd_args_s *ap,
 	     const char *dst_path)
 {
 	int src_flags		= O_RDONLY;
-	int dst_flags		= O_CREAT | O_WRONLY;
+	int dst_flags		= O_CREAT | O_TRUNC | O_WRONLY;
 	mode_t tmp_mode_file	= S_IRUSR | S_IWUSR;
 	int rc;
 	uint64_t file_length	= src_stat->st_size;


### PR DESCRIPTION
Add O_TRUNC flag in fs_copy_file().

Signed-off-by: Lei Huang <lei.huang@intel.com>