### PR TITLE
DAOS-10125 rebuild: add rebuild generation

### DIFF
--- a/src/include/daos_srv/rebuild.h
+++ b/src/include/daos_srv/rebuild.h
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2017-2021 Intel Corporation.
+ * (C) Copyright 2017-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -36,12 +36,12 @@ typedef enum {
 			  "Unknown")
 
 int ds_rebuild_schedule(struct ds_pool *pool, uint32_t map_ver,
-			struct pool_target_id_list *tgts,
+			uint32_t rebuild_gen, struct pool_target_id_list *tgts,
 			daos_rebuild_opc_t rebuild_op, uint64_t delay_sec);
 int ds_rebuild_query(uuid_t pool_uuid,
 		     struct daos_rebuild_status *status);
 int ds_rebuild_regenerate_task(struct ds_pool *pool, daos_prop_t *prop);
 void ds_rebuild_leader_stop_all(void);
-void ds_rebuild_leader_stop(const uuid_t pool_uuid, unsigned int version);
-void ds_rebuild_abort(uuid_t pool_uuid, unsigned int version);
+void ds_rebuild_leader_stop(const uuid_t pool_uuid, unsigned int version, uint32_t rebuild_gen);
+void ds_rebuild_abort(uuid_t pool_uuid, unsigned int version, uint32_t rebuild_gen);
 #endif

--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -4980,7 +4980,7 @@ pool_svc_update_map(struct pool_svc *svc, crt_opcode_t opc, bool exclude_rank,
 	D_DEBUG(DB_MD, "map ver %u/%u\n", map_version ? *map_version : -1,
 		tgt_map_ver);
 	if (tgt_map_ver != 0) {
-		rc = ds_rebuild_schedule(svc->ps_pool, tgt_map_ver,
+		rc = ds_rebuild_schedule(svc->ps_pool, tgt_map_ver, 0,
 					 &target_list, op, delay);
 		if (rc != 0) {
 			D_ERROR("rebuild fails rc: "DF_RC"\n", DP_RC(rc));
@@ -5119,7 +5119,7 @@ pool_extend_internal(uuid_t pool_uuid, struct rsvc_hint *hint, uint32_t nnodes,
 	}
 
 	/* Schedule an extension rebuild for those targets */
-	rc = ds_rebuild_schedule(svc->ps_pool, *map_version_p, &tgts,
+	rc = ds_rebuild_schedule(svc->ps_pool, *map_version_p, 0, &tgts,
 				 RB_OP_EXTEND, 2);
 	if (rc != 0) {
 		D_ERROR("failed to schedule extend rc: "DF_RC"\n", DP_RC(rc));

--- a/src/pool/srv_target.c
+++ b/src/pool/srv_target.c
@@ -793,7 +793,7 @@ ds_pool_stop(uuid_t uuid)
 	ds_pool_tgt_ec_eph_query_abort(pool);
 	pool_fetch_hdls_ult_abort(pool);
 
-	ds_rebuild_abort(pool->sp_uuid, -1);
+	ds_rebuild_abort(pool->sp_uuid, -1, -1);
 	ds_migrate_stop(pool, -1);
 	ds_pool_put(pool); /* held by ds_pool_start */
 	ds_pool_put(pool);

--- a/src/rebuild/rebuild_internal.h
+++ b/src/rebuild/rebuild_internal.h
@@ -33,6 +33,9 @@ struct rebuild_tgt_pool_tracker {
 	/** the current version being rebuilt, only used by leader */
 	uint32_t		rt_rebuild_ver;
 
+	/* rebuild generation, will increase for each re-schedule */
+	uint32_t		rt_rebuild_gen;
+
 	/** the current rebuild operation */
 	daos_rebuild_opc_t	rt_rebuild_op;
 
@@ -110,11 +113,11 @@ struct rebuild_global_pool_tracker {
 	/* the pool uuid */
 	uuid_t		rgt_pool_uuid;
 
-	/** the current version being rebuilt */
-	uint32_t	rgt_rebuild_ver;
-
 	/** rebuild status for each server */
 	struct rebuild_server_status *rgt_servers;
+
+	/** the current version being rebuilt */
+	uint32_t	rgt_rebuild_ver;
 
 	/** global resync dtx version */
 	uint32_t	rgt_dtx_resync_version;
@@ -122,6 +125,7 @@ struct rebuild_global_pool_tracker {
 	/** number of rgt_server_status */
 	uint32_t	rgt_servers_number;
 
+	uint32_t	rgt_rebuild_gen;
 	/* The term of the current rebuild leader */
 	uint64_t	rgt_leader_term;
 
@@ -198,6 +202,7 @@ struct rebuild_task {
 	daos_rebuild_opc_t		dst_rebuild_op;
 	uint64_t			dst_schedule_time;
 	uint32_t			dst_map_ver;
+	uint32_t			dst_rebuild_gen;
 };
 
 /* Per pool structure in TLS to check pool rebuild status
@@ -252,6 +257,7 @@ struct rebuild_iv {
 	unsigned int	riv_rank;
 	unsigned int	riv_master_rank;
 	unsigned int	riv_ver;
+	unsigned int	riv_rebuild_gen;
 	uint32_t	riv_global_done:1,
 			riv_global_scan_done:1,
 			riv_scan_done:1,
@@ -330,7 +336,7 @@ int
 rebuilt_btr_destroy(daos_handle_t btr_hdl);
 
 struct rebuild_tgt_pool_tracker *
-rpt_lookup(uuid_t pool_uuid, unsigned int ver);
+rpt_lookup(uuid_t pool_uuid, unsigned int ver, uint32_t gen);
 
 void
 rgt_get(struct rebuild_global_pool_tracker *rgt);
@@ -339,7 +345,7 @@ void
 rgt_put(struct rebuild_global_pool_tracker *rgt);
 
 struct rebuild_global_pool_tracker *
-rebuild_global_pool_tracker_lookup(const uuid_t pool_uuid, unsigned int ver);
+rebuild_global_pool_tracker_lookup(const uuid_t pool_uuid, unsigned int ver, unsigned int gen);
 
 int
 rebuild_global_status_update(struct rebuild_global_pool_tracker *master_rpt,

--- a/src/rebuild/rebuild_iv.c
+++ b/src/rebuild/rebuild_iv.c
@@ -119,7 +119,7 @@ rebuild_iv_ent_update(struct ds_iv_entry *entry, struct ds_iv_key *key,
 
 	/* Gathering the rebuild status here */
 	rgt = rebuild_global_pool_tracker_lookup(src_iv->riv_pool_uuid,
-						 src_iv->riv_ver);
+						 src_iv->riv_ver, src_iv->riv_rebuild_gen);
 	if (rgt == NULL)
 		D_GOTO(out, rc);
 
@@ -139,11 +139,11 @@ rebuild_iv_ent_update(struct ds_iv_entry *entry, struct ds_iv_key *key,
 			if (src_iv->riv_status != 0)
 				rgt->rgt_status.rs_fail_rank = src_iv->riv_rank;
 		}
-		D_DEBUG(DB_TRACE, "update rebuild "DF_UUID" ver %d "
+		D_DEBUG(DB_TRACE, "update rebuild "DF_UUID" ver %d gen %u"
 			"toberb_obj/rb_obj/rec/global state/status/rank "
 			DF_U64"/"DF_U64"/"DF_U64"/%d/%d/%d\n",
 			DP_UUID(rgt->rgt_pool_uuid), rgt->rgt_rebuild_ver,
-			rgt->rgt_status.rs_toberb_obj_nr,
+			rgt->rgt_rebuild_gen, rgt->rgt_status.rs_toberb_obj_nr,
 			rgt->rgt_status.rs_obj_nr, rgt->rgt_status.rs_rec_nr,
 			rgt->rgt_status.rs_state, rgt->rgt_status.rs_errno,
 			src_iv->riv_rank);
@@ -176,7 +176,8 @@ rebuild_iv_ent_refresh(struct ds_iv_entry *entry, struct ds_iv_key *key,
 	    dst_iv->riv_stable_epoch || dst_iv->riv_dtx_resyc_version) {
 		struct rebuild_tgt_pool_tracker *rpt;
 
-		rpt = rpt_lookup(src_iv->riv_pool_uuid, src_iv->riv_ver);
+		rpt = rpt_lookup(src_iv->riv_pool_uuid, src_iv->riv_ver,
+				 src_iv->riv_rebuild_gen);
 		if (rpt == NULL)
 			return 0;
 
@@ -185,11 +186,12 @@ rebuild_iv_ent_refresh(struct ds_iv_entry *entry, struct ds_iv_key *key,
 			return 0;
 		}
 
-		D_DEBUG(DB_REBUILD, DF_UUID"/%u rebuild status gsd/gd %d/%d"
+		D_DEBUG(DB_REBUILD, DF_UUID"/%u/%u rebuild status gsd/gd %d/%d"
 			" stable eph "DF_U64" resync ver %u\n",
 			DP_UUID(src_iv->riv_pool_uuid), src_iv->riv_ver,
-			dst_iv->riv_global_scan_done, dst_iv->riv_global_done,
-			dst_iv->riv_stable_epoch, dst_iv->riv_dtx_resyc_version);
+			src_iv->riv_rebuild_gen, dst_iv->riv_global_scan_done,
+			dst_iv->riv_global_done, dst_iv->riv_stable_epoch,
+			dst_iv->riv_dtx_resyc_version);
 
 		if (rpt->rt_stable_epoch == 0)
 			rpt->rt_stable_epoch = dst_iv->riv_stable_epoch;

--- a/src/rebuild/rpc.h
+++ b/src/rebuild/rpc.h
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2017-2021 Intel Corporation.
+ * (C) Copyright 2017-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -23,7 +23,7 @@
  * These are for daos_rpc::dr_opc and DAOS_RPC_OPCODE(opc, ...) rather than
  * crt_req_create(..., opc, ...). See src/include/daos/rpc.h.
  */
-#define DAOS_REBUILD_VERSION 2
+#define DAOS_REBUILD_VERSION 3
 /* LIST of internal RPCS in form of:
  * OPCODE, flags, FMT, handler, corpc_hdlr,
  */
@@ -51,7 +51,7 @@ extern struct crt_proto_format rebuild_proto_fmt;
 	((uint32_t)		(rsi_ns_id)		CRT_VAR) \
 	((uint32_t)		(rsi_rebuild_ver)	CRT_VAR) \
 	((uint32_t)		(rsi_master_rank)	CRT_VAR) \
-	((uint32_t)		(rsi_padding)		CRT_VAR)
+	((uint32_t)		(rsi_rebuild_gen)	CRT_VAR)
 
 #define DAOS_OSEQ_REBUILD_SCAN	/* output fields */		 \
 	((uint64_t)		(rso_stable_epoch)	CRT_VAR) \

--- a/src/rebuild/scan.c
+++ b/src/rebuild/scan.c
@@ -869,9 +869,9 @@ rebuild_tgt_scan_handler(crt_rpc_t *rpc)
 	rsi = crt_req_get(rpc);
 	D_ASSERT(rsi != NULL);
 
-	D_DEBUG(DB_REBUILD, "%d scan rebuild for "DF_UUID" ver %d\n",
+	D_DEBUG(DB_REBUILD, "%d scan rebuild for "DF_UUID" ver %d gen %u\n",
 		dss_get_module_info()->dmi_tgt_id, DP_UUID(rsi->rsi_pool_uuid),
-		rsi->rsi_rebuild_ver);
+		rsi->rsi_rebuild_ver, rsi->rsi_rebuild_gen);
 
 	/* If PS leader has been changed, and rebuild version is also increased
 	 * due to adding new failure targets for rebuild, let's abort previous
@@ -889,7 +889,7 @@ rebuild_tgt_scan_handler(crt_rpc_t *rpc)
 	}
 
 	/* check if the rebuild is already started */
-	rpt = rpt_lookup(rsi->rsi_pool_uuid, rsi->rsi_rebuild_ver);
+	rpt = rpt_lookup(rsi->rsi_pool_uuid, rsi->rsi_rebuild_ver, rsi->rsi_rebuild_gen);
 	if (rpt != NULL) {
 		if (rpt->rt_global_done) {
 			D_WARN("the previous rebuild "DF_UUID"/%d"
@@ -932,8 +932,8 @@ rebuild_tgt_scan_handler(crt_rpc_t *rpc)
 			/* If this is the old leader, then also stop the rebuild
 			 * tracking ULT.
 			 */
-			ds_rebuild_leader_stop(rsi->rsi_pool_uuid,
-					       rsi->rsi_rebuild_ver);
+			ds_rebuild_leader_stop(rsi->rsi_pool_uuid, rsi->rsi_rebuild_ver,
+					       rsi->rsi_rebuild_gen);
 		}
 
 		rpt->rt_leader_term = rsi->rsi_leader_term;

--- a/src/rebuild/srv.c
+++ b/src/rebuild/srv.c
@@ -203,7 +203,7 @@ rebuild_get_global_dtx_resync_ver(struct rebuild_global_pool_tracker *rgt)
 }
 
 struct rebuild_tgt_pool_tracker *
-rpt_lookup(uuid_t pool_uuid, unsigned int ver)
+rpt_lookup(uuid_t pool_uuid, unsigned int ver, unsigned int gen)
 {
 	struct rebuild_tgt_pool_tracker	*rpt;
 	struct rebuild_tgt_pool_tracker	*found = NULL;
@@ -211,7 +211,8 @@ rpt_lookup(uuid_t pool_uuid, unsigned int ver)
 	/* Only stream 0 will access the list */
 	d_list_for_each_entry(rpt, &rebuild_gst.rg_tgt_tracker_list, rt_list) {
 		if (uuid_compare(rpt->rt_pool_uuid, pool_uuid) == 0 &&
-		    (ver == (unsigned int)(-1) || rpt->rt_rebuild_ver == ver)) {
+		    (ver == (unsigned int)(-1) || rpt->rt_rebuild_ver == ver) &&
+		    (gen == (unsigned int)(-1) || rpt->rt_rebuild_gen == gen)) {
 			rpt_get(rpt);
 			found = rpt;
 			break;
@@ -470,7 +471,7 @@ ds_rebuild_query(uuid_t pool_uuid, struct daos_rebuild_status *status)
 
 	memset(status, 0, sizeof(*status));
 
-	rgt = rebuild_global_pool_tracker_lookup(pool_uuid, -1);
+	rgt = rebuild_global_pool_tracker_lookup(pool_uuid, -1, -1);
 	if (rgt == NULL) {
 		rs_inlist = rebuild_status_completed_lookup(pool_uuid);
 		if (rs_inlist != NULL)
@@ -513,6 +514,37 @@ out:
 		status->rs_version, status->rs_errno);
 
 	return rc;
+}
+
+static void
+rebuild_status_notify(struct rebuild_global_pool_tracker *rgt, struct ds_pool *pool, int op)
+{
+	struct rebuild_iv	iv = { 0 };
+	int			rc;
+
+	uuid_copy(iv.riv_pool_uuid, rgt->rgt_pool_uuid);
+	iv.riv_master_rank	= pool->sp_iv_ns->iv_master_rank;
+	iv.riv_ver		= rgt->rgt_rebuild_ver;
+	iv.riv_global_scan_done = is_rebuild_global_scan_done(rgt);
+	iv.riv_global_done	= rgt->rgt_abort || is_rebuild_global_done(rgt);
+	iv.riv_leader_term	= rgt->rgt_leader_term;
+	iv.riv_rebuild_gen	= rgt->rgt_rebuild_gen;
+	iv.riv_toberb_obj_count = rgt->rgt_status.rs_toberb_obj_nr;
+	iv.riv_obj_count	= rgt->rgt_status.rs_obj_nr;
+	iv.riv_rec_count	= rgt->rgt_status.rs_rec_nr;
+	iv.riv_size		= rgt->rgt_status.rs_size;
+	iv.riv_seconds          = rgt->rgt_status.rs_seconds;
+	iv.riv_stable_epoch	= rgt->rgt_stable_epoch;
+	iv.riv_global_dtx_resyc_version = rebuild_get_global_dtx_resync_ver(rgt);
+
+	D_DEBUG(DB_REBUILD, "rebuild IV %u final "DF_UUID"/%u : %d\n",
+		op, DP_UUID(rgt->rgt_pool_uuid), rgt->rgt_rebuild_ver, rgt->rgt_status.rs_errno);
+
+	rc = rebuild_iv_update(pool->sp_iv_ns, &iv, CRT_IV_SHORTCUT_NONE,
+			       CRT_IV_SYNC_LAZY, true);
+	if (rc)
+		D_ERROR("iv final update fails"DF_UUID":rc "DF_RC"\n",
+			DP_UUID(rgt->rgt_pool_uuid), DP_RC(rc));
 }
 
 #define RBLD_SBUF_LEN	256
@@ -591,35 +623,9 @@ rebuild_leader_status_check(struct ds_pool *pool, uint32_t map_ver, uint32_t op,
 				" %u->%u.\n", DP_UUID(pool->sp_uuid), myrank,
 				pool->sp_iv_ns->iv_master_rank);
 
-		if (!rgt->rgt_abort && myrank == pool->sp_iv_ns->iv_master_rank) {
-			struct rebuild_iv iv = { 0 };
-
-			D_ASSERT(rgt->rgt_stable_epoch != 0);
-			uuid_copy(iv.riv_pool_uuid, rgt->rgt_pool_uuid);
-			iv.riv_master_rank = pool->sp_iv_ns->iv_master_rank;
-			iv.riv_global_scan_done =
-					is_rebuild_global_scan_done(rgt);
-			iv.riv_global_done = is_rebuild_global_done(rgt);
-			iv.riv_stable_epoch = rgt->rgt_stable_epoch;
-			iv.riv_ver = rgt->rgt_rebuild_ver;
-			iv.riv_leader_term = rgt->rgt_leader_term;
-			iv.riv_sync = 1;
-			iv.riv_global_dtx_resyc_version = rebuild_get_global_dtx_resync_ver(rgt);
-			D_DEBUG(DB_REBUILD, "rebuild IV update "DF_UUID"/%u:"
-				" gsd/gd %d/%d stable eph "DF_U64" resync %u\n",
-				DP_UUID(iv.riv_pool_uuid), rgt->rgt_rebuild_ver,
-				iv.riv_global_scan_done, iv.riv_global_done,
-				iv.riv_stable_epoch, iv.riv_global_dtx_resyc_version);
-			/* Notify others the global scan is done, then
-			 * each target can reliablly report its pull status
-			 */
-			rc = rebuild_iv_update(pool->sp_iv_ns,
-					       &iv, CRT_IV_SHORTCUT_NONE,
-					       CRT_IV_SYNC_LAZY, false);
-			if (rc)
-				D_WARN("master %u iv update failed: %d\n",
-				       pool->sp_iv_ns->iv_master_rank, rc);
-		}
+		if (!rgt->rgt_abort && !is_rebuild_global_done(rgt) &&
+		    myrank == pool->sp_iv_ns->iv_master_rank)
+			rebuild_status_notify(rgt, pool, op);
 
 		/* query the current rebuild status */
 		if (is_rebuild_global_done(rgt))
@@ -745,17 +751,16 @@ rgt_put(struct rebuild_global_pool_tracker *rgt)
 }
 
 struct rebuild_global_pool_tracker *
-rebuild_global_pool_tracker_lookup(const uuid_t pool_uuid, unsigned int ver)
+rebuild_global_pool_tracker_lookup(const uuid_t pool_uuid, unsigned int ver, unsigned int gen)
 {
 	struct rebuild_global_pool_tracker	*rgt;
 	struct rebuild_global_pool_tracker	*found = NULL;
 
 	/* Only stream 0 will access the list */
-	d_list_for_each_entry(rgt, &rebuild_gst.rg_global_tracker_list,
-			      rgt_list) {
+	d_list_for_each_entry(rgt, &rebuild_gst.rg_global_tracker_list, rgt_list) {
 		if (uuid_compare(rgt->rgt_pool_uuid, pool_uuid) == 0 &&
-		    (ver == (unsigned int)(-1) ||
-		     rgt->rgt_rebuild_ver == ver)) {
+		    (ver == (unsigned int)(-1) || rgt->rgt_rebuild_ver == ver) &&
+		    (gen == (unsigned int)(-1) || rgt->rgt_rebuild_gen == gen)) {
 			rgt_get(rgt);
 			found = rgt;
 			break;
@@ -768,7 +773,7 @@ rebuild_global_pool_tracker_lookup(const uuid_t pool_uuid, unsigned int ver)
 /* To notify all targets to prepare the rebuild */
 static int
 rebuild_prepare(struct ds_pool *pool, uint32_t rebuild_ver,
-		uint64_t leader_term,
+		uint32_t rebuild_gen, uint64_t leader_term,
 		struct pool_target_id_list *tgts,
 		daos_rebuild_opc_t rebuild_op,
 		struct rebuild_global_pool_tracker **rgt)
@@ -792,8 +797,8 @@ rebuild_prepare(struct ds_pool *pool, uint32_t rebuild_ver,
 	}
 
 	(*rgt)->rgt_leader_term = leader_term;
+	(*rgt)->rgt_rebuild_gen = rebuild_gen;
 	(*rgt)->rgt_time_start = d_timeus_secdiff(0);
-
 	D_ASSERT(rebuild_op == RB_OP_FAIL ||
 		 rebuild_op == RB_OP_DRAIN ||
 		 rebuild_op == RB_OP_REINT ||
@@ -880,6 +885,7 @@ rebuild_scan_broadcast(struct ds_pool *pool,
 	rsi->rsi_ns_id = pool->sp_iv_ns->iv_ns_id;
 	rsi->rsi_leader_term = rgt->rgt_leader_term;
 	rsi->rsi_rebuild_ver = rgt->rgt_rebuild_ver;
+	rsi->rsi_rebuild_gen = rgt->rgt_rebuild_gen;
 	rsi->rsi_tgts_num = tgts_failed->pti_number;
 	rsi->rsi_rebuild_op = rebuild_op;
 	crt_group_rank(pool->sp_group,  &rsi->rsi_master_rank);
@@ -1096,15 +1102,15 @@ rebuild_try_merge_tgts(const uuid_t pool_uuid, uint32_t map_ver,
  */
 static int
 rebuild_leader_start(struct ds_pool *pool, uint32_t rebuild_ver,
-		     struct pool_target_id_list *tgts,
+		     uint32_t rebuild_gen, struct pool_target_id_list *tgts,
 		     daos_rebuild_opc_t rebuild_op,
 		     struct rebuild_global_pool_tracker **p_rgt)
 {
 	uint64_t	leader_term;
 	int		rc;
 
-	D_DEBUG(DB_REBUILD, "rebuild "DF_UUID", rebuild version=%u, op=%s\n",
-		DP_UUID(pool->sp_uuid), rebuild_ver, RB_OP_STR(rebuild_op));
+	D_DEBUG(DB_REBUILD, "rebuild "DF_UUID", rebuild version=%u/%u, op=%s\n",
+		DP_UUID(pool->sp_uuid), rebuild_ver, rebuild_gen, RB_OP_STR(rebuild_op));
 
 	rc = ds_pool_svc_term_get(pool->sp_uuid, &leader_term);
 	if (rc) {
@@ -1113,7 +1119,7 @@ rebuild_leader_start(struct ds_pool *pool, uint32_t rebuild_ver,
 		D_GOTO(out, rc);
 	}
 
-	rc = rebuild_prepare(pool, rebuild_ver, leader_term, tgts, rebuild_op,
+	rc = rebuild_prepare(pool, rebuild_ver, rebuild_gen, leader_term, tgts, rebuild_op,
 			     p_rgt);
 	if (rc) {
 		D_ERROR("rebuild prepare failed: "DF_RC"\n", DP_RC(rc));
@@ -1137,7 +1143,6 @@ rebuild_task_ult(void *arg)
 	struct rebuild_task			*task = arg;
 	struct ds_pool				*pool;
 	struct rebuild_global_pool_tracker	*rgt = NULL;
-	struct rebuild_iv                       iv = { 0 };
 	d_rank_t				myrank;
 	uint64_t				cur_ts = 0;
 	int					rc;
@@ -1168,8 +1173,8 @@ rebuild_task_ult(void *arg)
 		RB_OP_STR(task->dst_rebuild_op), DP_UUID(task->dst_pool_uuid),
 		task->dst_map_ver);
 
-	rc = rebuild_leader_start(pool, task->dst_map_ver, &task->dst_tgts,
-				  task->dst_rebuild_op, &rgt);
+	rc = rebuild_leader_start(pool, task->dst_map_ver, task->dst_rebuild_gen,
+				  &task->dst_tgts, task->dst_rebuild_op, &rgt);
 	if (rc != 0) {
 		if (rc == -DER_CANCELED ||
 		    (rc == -DER_NOTLEADER &&
@@ -1266,34 +1271,7 @@ iv_stop:
 			D_GOTO(try_reschedule, rc);
 		}
 
-		uuid_copy(iv.riv_pool_uuid, task->dst_pool_uuid);
-		iv.riv_master_rank	= pool->sp_iv_ns->iv_master_rank;
-		iv.riv_ver		= rgt->rgt_rebuild_ver;
-		iv.riv_global_scan_done = is_rebuild_global_scan_done(rgt);
-		iv.riv_global_done	= 1;
-		iv.riv_leader_term	= rgt->rgt_leader_term;
-		iv.riv_toberb_obj_count = rgt->rgt_status.rs_toberb_obj_nr;
-		iv.riv_obj_count	= rgt->rgt_status.rs_obj_nr;
-		iv.riv_rec_count	= rgt->rgt_status.rs_rec_nr;
-		iv.riv_size		= rgt->rgt_status.rs_size;
-		iv.riv_seconds          = rgt->rgt_status.rs_seconds;
-		iv.riv_stable_epoch	= rgt->rgt_stable_epoch;
-		iv.riv_global_dtx_resyc_version = rebuild_get_global_dtx_resync_ver(rgt);
-
-		D_DEBUG(DB_REBUILD, "rebuild IV %u final "DF_UUID"/%u : %d\n",
-			task->dst_rebuild_op, DP_UUID(task->dst_pool_uuid),
-			rgt->rgt_rebuild_ver, rgt->rgt_status.rs_errno);
-		if (!is_rebuild_global_done(rgt) || rgt->rgt_status.rs_errno != 0 ||
-		    task->dst_rebuild_op == RB_OP_REINT || task->dst_rebuild_op == RB_OP_EXTEND) {
-			rc = rebuild_iv_update(pool->sp_iv_ns, &iv, CRT_IV_SHORTCUT_NONE,
-					       CRT_IV_SYNC_EAGER, true);
-		} else {
-			rc = rebuild_iv_update(pool->sp_iv_ns, &iv, CRT_IV_SHORTCUT_NONE,
-					       CRT_IV_SYNC_LAZY, true);
-		}
-		if (rc)
-			D_ERROR("iv final update fails"DF_UUID":rc "DF_RC"\n",
-				DP_UUID(task->dst_pool_uuid), DP_RC(rc));
+		rebuild_status_notify(rgt, pool, task->dst_rebuild_op);
 	}
 
 try_reschedule:
@@ -1317,7 +1295,7 @@ try_reschedule:
 		    (opc == RB_OP_REINT || opc == RB_OP_EXTEND))
 			opc = RB_OP_RECLAIM;
 
-		ret = ds_rebuild_schedule(pool, task->dst_map_ver,
+		ret = ds_rebuild_schedule(pool, task->dst_map_ver, ++task->dst_rebuild_gen,
 					  &task->dst_tgts, opc, 5);
 		if (ret != 0)
 			D_ERROR("reschedule "DF_RC" opc %u\n", DP_RC(ret), opc);
@@ -1441,17 +1419,9 @@ rebuild_ults(void *arg)
 	ABT_mutex_unlock(rebuild_gst.rg_lock);
 }
 
-void
-ds_rebuild_abort(uuid_t pool_uuid, unsigned int version)
+static void
+rpt_abort(struct rebuild_tgt_pool_tracker *rpt)
 {
-	struct rebuild_tgt_pool_tracker *rpt;
-
-	ds_rebuild_leader_stop(pool_uuid, version);
-
-	rpt = rpt_lookup(pool_uuid, version);
-	if (rpt == NULL)
-		return;
-
 	/* If it can find rpt, it means rebuild has not finished yet
 	 * on this target, so the rpt has to been hold by someone
 	 * else, so it is safe to use rpt after rpt_put().
@@ -1460,7 +1430,6 @@ ds_rebuild_abort(uuid_t pool_uuid, unsigned int version)
 	 * rebuild_tgt_fini().
 	 */
 	D_ASSERT(rpt->rt_refcount > 1);
-	rpt_put(rpt);
 
 	rpt->rt_abort = 1;
 	/* Since the rpt will be destroyed after signal rt_done_cond,
@@ -1471,35 +1440,29 @@ ds_rebuild_abort(uuid_t pool_uuid, unsigned int version)
 	ABT_mutex_unlock(rebuild_gst.rg_lock);
 }
 
-/* If this is called on non-leader node, it will do nothing */
 void
-ds_rebuild_leader_stop(const uuid_t pool_uuid, unsigned int version)
+ds_rebuild_abort(uuid_t pool_uuid, unsigned int ver, unsigned int gen)
 {
-	struct rebuild_global_pool_tracker	*rgt;
-	struct rebuild_task			*task;
-	struct rebuild_task			*task_tmp;
+	struct rebuild_tgt_pool_tracker *rpt;
+	struct rebuild_tgt_pool_tracker	*tmp;
 
-	/* Remove the rebuild tasks from queue list */
-	d_list_for_each_entry_safe(task, task_tmp, &rebuild_gst.rg_queue_list,
-				   dst_list) {
-		if (uuid_compare(task->dst_pool_uuid, pool_uuid) == 0 &&
-		    (version == -1 || task->dst_map_ver == version)) {
-			rebuild_task_destroy(task);
-			if (version != -1)
-				break;
-		}
+	ds_rebuild_leader_stop(pool_uuid, ver, gen);
+
+	/* Only stream 0 will access the list */
+	d_list_for_each_entry_safe(rpt, tmp, &rebuild_gst.rg_tgt_tracker_list, rt_list) {
+		if (uuid_compare(rpt->rt_pool_uuid, pool_uuid) == 0 &&
+		    (ver == (unsigned int)(-1) || rpt->rt_rebuild_ver == ver) &&
+		    (gen == (unsigned int)(-1) || rpt->rt_rebuild_gen == gen))
+			rpt_abort(rpt);
 	}
+}
 
-	/* Then check running list, Note: each rebuilding pool can only have one
-	 * version being rebuilt each time, so we do not need check version for
-	 * running list.
-	 */
-	rgt = rebuild_global_pool_tracker_lookup(pool_uuid, version);
-	if (rgt == NULL)
-		return;
-
+static void
+rgt_leader_stop(struct rebuild_global_pool_tracker *rgt)
+{
+	rgt_get(rgt);
 	D_DEBUG(DB_REBUILD, "try abort rebuild "DF_UUID" version %d\n",
-		DP_UUID(pool_uuid), version);
+		DP_UUID(rgt->rgt_pool_uuid), rgt->rgt_rebuild_ver);
 	rgt->rgt_abort = 1;
 
 	/* Since the rpt will be destroyed after signal rt_done_cond,
@@ -1510,9 +1473,37 @@ ds_rebuild_leader_stop(const uuid_t pool_uuid, unsigned int version)
 	ABT_mutex_unlock(rgt->rgt_lock);
 
 	D_DEBUG(DB_REBUILD, "rebuild "DF_UUID"/ %d is stopped.\n",
-		DP_UUID(pool_uuid), version);
+		DP_UUID(rgt->rgt_pool_uuid), rgt->rgt_rebuild_ver);
 
 	rgt_put(rgt);
+}
+
+/* If this is called on non-leader node, it will do nothing */
+void
+ds_rebuild_leader_stop(const uuid_t pool_uuid, unsigned int ver, unsigned int gen)
+{
+	struct rebuild_global_pool_tracker	*rgt;
+	struct rebuild_global_pool_tracker	*rgt_tmp;
+	struct rebuild_task			*task;
+	struct rebuild_task			*task_tmp;
+
+	/* Remove the rebuild tasks from queue list */
+	d_list_for_each_entry_safe(task, task_tmp, &rebuild_gst.rg_queue_list,
+				   dst_list) {
+		if (uuid_compare(task->dst_pool_uuid, pool_uuid) == 0 &&
+		    (ver == (unsigned int)(-1) || task->dst_map_ver == ver) &&
+		    (gen == (unsigned int)(-1) || task->dst_rebuild_gen == gen))
+			rebuild_task_destroy(task);
+	}
+
+	/* Only stream 0 will access the list */
+	d_list_for_each_entry_safe(rgt, rgt_tmp, &rebuild_gst.rg_global_tracker_list,
+				   rgt_list) {
+		if (uuid_compare(rgt->rgt_pool_uuid, pool_uuid) == 0 &&
+		    (ver == (unsigned int)(-1) || rgt->rgt_rebuild_ver == ver) &&
+		    (gen == (unsigned int)(-1) || rgt->rgt_rebuild_gen == gen))
+			rgt_leader_stop(rgt);
+	}
 }
 
 void
@@ -1567,7 +1558,7 @@ rebuild_print_list_update(const uuid_t uuid, const uint32_t map_ver,
  * pool.
  */
 int
-ds_rebuild_schedule(struct ds_pool *pool, uint32_t map_ver,
+ds_rebuild_schedule(struct ds_pool *pool, uint32_t map_ver, uint32_t rebuild_gen,
 		    struct pool_target_id_list *tgts,
 		    daos_rebuild_opc_t rebuild_op, uint64_t delay_sec)
 {
@@ -1599,6 +1590,7 @@ ds_rebuild_schedule(struct ds_pool *pool, uint32_t map_ver,
 
 	new_task->dst_schedule_time = cur_ts + delay_sec;
 	new_task->dst_map_ver = map_ver;
+	new_task->dst_rebuild_gen = rebuild_gen;
 	new_task->dst_rebuild_op = rebuild_op;
 	uuid_copy(new_task->dst_pool_uuid, pool->sp_uuid);
 	D_INIT_LIST_HEAD(&new_task->dst_list);
@@ -1630,8 +1622,8 @@ ds_rebuild_schedule(struct ds_pool *pool, uint32_t map_ver,
 	/* Print out the current queue to the debug log */
 	rebuild_debug_print_queue();
 
-	D_DEBUG(DB_REBUILD, "rebuild queue "DF_UUID" ver=%u, op=%s",
-		DP_UUID(pool->sp_uuid), map_ver, RB_OP_STR(rebuild_op));
+	D_DEBUG(DB_REBUILD, "rebuild queue "DF_UUID" ver=%u, gen=%u, op=%s",
+		DP_UUID(pool->sp_uuid), map_ver, rebuild_gen, RB_OP_STR(rebuild_op));
 
 	if (!rebuild_gst.rg_rebuild_running) {
 		rc = ABT_cond_create(&rebuild_gst.rg_stop_cond);
@@ -1672,10 +1664,10 @@ regenerate_task_internal(struct ds_pool *pool, struct pool_target *tgts,
 		id_list.pti_number = 1;
 
 		if (rebuild_op == RB_OP_FAIL || rebuild_op == RB_OP_DRAIN)
-			rc = ds_rebuild_schedule(pool, tgt->ta_comp.co_fseq,
+			rc = ds_rebuild_schedule(pool, tgt->ta_comp.co_fseq, 0,
 						 &id_list, rebuild_op, 0);
 		else
-			rc = ds_rebuild_schedule(pool, tgt->ta_comp.co_in_ver,
+			rc = ds_rebuild_schedule(pool, tgt->ta_comp.co_in_ver, 0,
 						 &id_list, rebuild_op, 0);
 
 		if (rc) {
@@ -1927,6 +1919,7 @@ rebuild_tgt_status_check_ult(void *arg)
 			iv.riv_master_rank = ns->iv_master_rank;
 			iv.riv_rank = rpt->rt_rank;
 			iv.riv_ver = rpt->rt_rebuild_ver;
+			iv.riv_rebuild_gen = rpt->rt_rebuild_gen;
 			iv.riv_leader_term = rpt->rt_leader_term;
 			iv.riv_dtx_resyc_version = rpt->rt_pool->sp_dtx_resync_version;
 			/* Cart does not support failure recovery yet, let's
@@ -2032,7 +2025,8 @@ rebuild_prepare_one(void *data)
 
 static int
 rpt_create(struct ds_pool *pool, uint32_t pm_ver, uint64_t leader_term,
-	   uint32_t tgts_num, struct rebuild_tgt_pool_tracker **p_rpt)
+	   uint32_t rebuild_gen, uint32_t tgts_num,
+	   struct rebuild_tgt_pool_tracker **p_rpt)
 {
 	struct rebuild_tgt_pool_tracker	*rpt;
 	d_rank_t	rank;
@@ -2062,6 +2056,7 @@ rpt_create(struct ds_pool *pool, uint32_t pm_ver, uint64_t leader_term,
 	rpt->rt_reported_size = 0;
 	rpt->rt_rebuild_ver = pm_ver;
 	rpt->rt_leader_term = leader_term;
+	rpt->rt_rebuild_gen = rebuild_gen;
 	rpt->rt_tgts_num = tgts_num;
 	crt_group_rank(pool->sp_group, &rank);
 	rpt->rt_rank = rank;
@@ -2132,7 +2127,7 @@ rebuild_tgt_prepare(crt_rpc_t *rpc, struct rebuild_tgt_pool_tracker **p_rpt)
 
 	/* Create rpt for the target */
 	rc = rpt_create(pool, rsi->rsi_rebuild_ver, rsi->rsi_leader_term,
-			rsi->rsi_tgts_num, &rpt);
+			rsi->rsi_rebuild_gen, rsi->rsi_tgts_num, &rpt);
 	if (rc)
 		D_GOTO(out, rc);
 


### PR DESCRIPTION
Add rebuild generation for each rebuild retry, which will
be increased whenever it needs to retry rebuild, to avoid
retry rebuild might mess with the original rebuild.

Some cleanup for rebuild complete notification.

Signed-off-by: Di Wang <di.wang@intel.com>