### PR TITLE
DAOS-623 test: replace duplicate get_rf functions

### DIFF
--- a/src/tests/ftest/control/dmg_telemetry_io_latency.py
+++ b/src/tests/ftest/control/dmg_telemetry_io_latency.py
@@ -5,35 +5,12 @@
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
 
-import re
 from ior_test_base import IorTestBase
 from telemetry_test_base import TestWithTelemetry
 from telemetry_utils import TelemetryUtils
 from test_utils_container import TestContainer
+from oclass_utils import extract_redundancy_factor
 from apricot import skipForTicket
-
-
-def get_rf(oclass):
-    """Return redundancy factor based on the oclass.
-
-    Args:
-        oclass(string): object class.
-
-    return:
-        redundancy factor(int) from object type
-    """
-    rf = 0
-    if "EC" in oclass:
-        tmp = re.findall(r'\d+', oclass)
-        if tmp:
-            rf = int(tmp[1])
-    elif "RP" in oclass:
-        tmp = re.findall(r'\d+', oclass)
-        if tmp:
-            rf = int(tmp[0]) - 1
-    else:
-        rf = 0
-    return rf
 
 
 def convert_to_number(size):
@@ -92,7 +69,7 @@ class TestWithTelemetryIOLatency(IorTestBase, TestWithTelemetry):
         # include rf based on the class
         if oclass:
             self.container[-1].oclass.update(oclass)
-            redundancy_factor = get_rf(oclass)
+            redundancy_factor = extract_redundancy_factor(oclass)
             rf = 'rf:{}'.format(str(redundancy_factor))
         properties = self.container[-1].properties.value
         cont_properties = (",").join(filter(None, [properties, rf]))

--- a/src/tests/ftest/util/file_count_test_base.py
+++ b/src/tests/ftest/util/file_count_test_base.py
@@ -3,33 +3,10 @@
   (C) Copyright 2020-2022 Intel Corporation.
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
-import re
 from ior_test_base import IorTestBase
 from mdtest_test_base import MdtestBase
 from avocado.core.exceptions import TestFail
-
-
-def get_rf(oclass):
-    """Return redundancy factor based on the oclass.
-
-    Args:
-        oclass(string): object class.
-
-    return:
-        redundancy factor(int) from object type
-    """
-    rf = 0
-    if "EC" in oclass:
-        tmp = re.findall(r'\d+', oclass)
-        if tmp:
-            rf = int(tmp[1])
-    elif "RP" in oclass:
-        tmp = re.findall(r'\d+', oclass)
-        if tmp:
-            rf = int(tmp[0]) - 1
-    else:
-        rf = 0
-    return rf
+from oclass_utils import extract_redundancy_factor
 
 
 # pylint: disable=attribute-defined-outside-init
@@ -53,7 +30,7 @@ class FileCountTestBase(IorTestBase, MdtestBase):
         # don't include oclass in daos cont cmd; include rf based on the class
         if oclass:
             container.oclass.update(oclass)
-            redundancy_factor = get_rf(oclass)
+            redundancy_factor = extract_redundancy_factor(oclass)
             rf = 'rf:{}'.format(str(redundancy_factor))
         properties = container.properties.value
         cont_properties = (",").join(filter(None, [properties, rf]))
@@ -79,7 +56,7 @@ class FileCountTestBase(IorTestBase, MdtestBase):
             self.mdtest_cmd.dfs_oclass.update(oclass)
             self.ior_cmd.dfs_dir_oclass.update(oclass)
             # oclass_dir can not be EC must be RP based on rf
-            rf = get_rf(oclass)
+            rf = extract_redundancy_factor(oclass)
             if rf >= 2:
                 self.mdtest_cmd.dfs_dir_oclass.update("RP_3G1")
             elif rf == 1:


### PR DESCRIPTION
Replace duplicate get_rf functions with
oclass_utils.extract_redundancy_factor

Test-tag: smallfilecount soak_smoke test_io_latency_telemetry
Quick-functional: true

Signed-off-by: Dalton Bohning <dalton.bohning@intel.com>