### PR TITLE
DAOS-10226 test: Update internal timeouts (#8817)

### DIFF
--- a/src/tests/ftest/cart/iv_server.c
+++ b/src/tests/ftest/cart/iv_server.c
@@ -1316,7 +1316,7 @@ int main(int argc, char **argv)
 	rc = crt_group_ranks_get(grp, &rank_list);
 	assert(rc == 0);
 
-	rc = crtu_wait_for_ranks(g_main_ctx, grp, rank_list, 0, 1, 5, 120);
+	rc = crtu_wait_for_ranks(g_main_ctx, grp, rank_list, 0, 1, 60, 120);
 	assert(rc == 0);
 
 	d_rank_list_free(rank_list);

--- a/src/tests/ftest/cart/no_pmix_corpc_errors.c
+++ b/src/tests/ftest/cart/no_pmix_corpc_errors.c
@@ -405,7 +405,7 @@ int main(int argc, char **argv)
 	}
 
 	rc = crtu_wait_for_ranks(crt_ctx[0], grp, rank_list, 0,
-				 NUM_SERVER_CTX, 10, 100.0);
+				 NUM_SERVER_CTX, 50, 100.0);
 	if (rc != 0) {
 		D_ERROR("wait_for_ranks() failed; rc=%d\n", rc);
 		assert(0);

--- a/src/tests/ftest/cart/no_pmix_group_test.c
+++ b/src/tests/ftest/cart/no_pmix_group_test.c
@@ -542,7 +542,7 @@ int main(int argc, char **argv)
 	}
 
 	rc = crtu_wait_for_ranks(crt_ctx[0], grp, rank_list, 0,
-				 NUM_SERVER_CTX, 10, 100.0);
+				 NUM_SERVER_CTX, 50, 100.0);
 	if (rc != 0) {
 		D_ERROR("wait_for_ranks() failed; rc=%d\n", rc);
 		assert(0);

--- a/src/tests/ftest/cart/no_pmix_group_version.c
+++ b/src/tests/ftest/cart/no_pmix_group_version.c
@@ -411,7 +411,7 @@ int main(int argc, char **argv)
 	}
 
 	rc = crtu_wait_for_ranks(crt_ctx[0], grp, rank_list, 0,
-				 NUM_SERVER_CTX, 10, 100.0);
+				 NUM_SERVER_CTX, 50, 100.0);
 	if (rc != 0) {
 		D_ERROR("wait_for_ranks() failed; rc=%d\n", rc);
 		assert(0);

--- a/src/tests/ftest/cart/no_pmix_launcher_client.c
+++ b/src/tests/ftest/cart/no_pmix_launcher_client.c
@@ -142,7 +142,7 @@ int main(int argc, char **argv)
 	}
 
 	rc = crtu_wait_for_ranks(crt_ctx, grp, rank_list, NUM_SERVER_CTX - 1,
-				 NUM_SERVER_CTX, 5, 150);
+				 NUM_SERVER_CTX, 60, 120);
 	if (rc != 0) {
 		D_ERROR("wait_for_ranks() failed; rc=%d\n", rc);
 		assert(0);

--- a/src/tests/ftest/cart/test_corpc_exclusive.c
+++ b/src/tests/ftest/cart/test_corpc_exclusive.c
@@ -165,9 +165,8 @@ int main(void)
 		assert(0);
 	}
 
-	sleep(2);
 	rc = crtu_wait_for_ranks(g_main_ctx, grp, rank_list, 0,
-				 1, 10, 100.0);
+				 1, 50, 100.0);
 	if (rc != 0) {
 		D_ERROR("wait_for_ranks() failed; rc=%d\n", rc);
 		assert(0);

--- a/src/tests/ftest/cart/test_corpc_prefwd.c
+++ b/src/tests/ftest/cart/test_corpc_prefwd.c
@@ -180,9 +180,8 @@ int main(void)
 			assert(0);
 		}
 
-		sleep(2);
 		rc = crtu_wait_for_ranks(g_main_ctx, grp, rank_list,
-					 0, 1, 10, 100.0);
+					 0, 1, 50, 100.0);
 		if (rc != 0) {
 			D_ERROR("wait_for_ranks() failed; rc=%d\n", rc);
 			assert(0);

--- a/src/tests/ftest/cart/test_group_np_cli.c
+++ b/src/tests/ftest/cart/test_group_np_cli.c
@@ -127,7 +127,7 @@ test_run(void)
 					 rank_list,
 					 test_g.t_srv_ctx_num - 1,
 					 test_g.t_srv_ctx_num,
-					 5,
+					 50,
 					 test_g.t_wait_ranks_time);
 		D_ASSERTF(rc == 0, "wait_for_ranks() failed; rc=%d\n", rc);
 	}

--- a/src/tests/ftest/cart/test_no_timeout.c
+++ b/src/tests/ftest/cart/test_no_timeout.c
@@ -99,7 +99,7 @@ test_run(void)
 
 	rc = crtu_wait_for_ranks(test_g.t_crt_ctx[0], grp, rank_list,
 				 test_g.t_srv_ctx_num - 1,
-				 test_g.t_srv_ctx_num, 5, 150);
+				 test_g.t_srv_ctx_num, 60, 120);
 	D_ASSERTF(rc == 0, "wait_for_ranks() failed; rc=%d\n", rc);
 
 	crt_group_size(test_g.t_remote_group, &test_g.t_remote_group_size);

--- a/src/utils/self_test/self_test.c
+++ b/src/utils/self_test/self_test.c
@@ -194,11 +194,10 @@ static int self_test_init(char *dest_name, crt_context_t *crt_ctx,
 	/* waiting to sync with the following parameters
 	 * 0 - tag 0
 	 * 1 - total ctx
-	 * 5 - ping timeout
-	 * 150 - total timeout
+	 * 60 - ping timeout
+	 * 120 - total timeout
 	 */
-	ret = crtu_wait_for_ranks(*crt_ctx, *srv_grp, rank_list,
-				  0, 1, 5, 150);
+	ret = crtu_wait_for_ranks(*crt_ctx, *srv_grp, rank_list, 0, 1, 60, 120);
 	D_ASSERTF(ret == 0, "wait_for_ranks() failed; ret=%d\n", ret);
 
 	max_rank = rank_list->rl_ranks[0];


### PR DESCRIPTION
Internal timeouts for pings in cart tests were set to 5-10 seconds
causing CI failures under valgrind vm runs or multi-node vm runs
with many servers/clients. Timeouts changes to 50-60 seconds instead

Signed-off-by: Alexander A Oganezov <alexander.a.oganezov@intel.com>