### PR TITLE
DAOS-10350 test: Fix eraurecode/rank_failure.py test (#8770)

### DIFF
--- a/src/tests/ftest/util/daos_io_conf.py
+++ b/src/tests/ftest/util/daos_io_conf.py
@@ -11,7 +11,8 @@ from apricot import TestWithServers
 from command_utils import ExecutableCommand
 from command_utils_base import \
     BasicParameter, FormattedParameter
-from exception_utils import CommandFailure
+from exception_utils import CommandFailure, MPILoadError
+from env_modules import load_mpi
 from job_manager_utils import Orterun
 
 
@@ -21,7 +22,7 @@ class IoConfGen(ExecutableCommand):
     :avocado: recursive
     """
 
-    def __init__(self, path="", filename="testfile", env=None):
+    def __init__(self, path="", filename="testfile", mpi_type="openmpi"):
         """Create a ExecutableCommand object.
 
         Uses Avocado's utils.process module to run a command str provided.
@@ -29,10 +30,10 @@ class IoConfGen(ExecutableCommand):
         Args:
             command (str): string of the command to be executed.
             path (str, optional): path to location of command binary file. Defaults to ""
+            mpi_type (str, optional): MPI type to load or use with the job manager
         """
         super().__init__("/run/gen_io_conf/*", "daos_gen_io_conf", path)
         self.verbose = True
-        self.env = env
         self.ranks = FormattedParameter("-g {}")
         self.targets = FormattedParameter("-t {}")
         self.obj_num = FormattedParameter("-o {}")
@@ -41,6 +42,20 @@ class IoConfGen(ExecutableCommand):
         self.record_size = FormattedParameter("-s {}")
         self.obj_class = FormattedParameter("-O {}")
         self.filename = BasicParameter(None, filename)
+        self.mpi_type = mpi_type
+
+    def run(self):
+        """Run the command.
+
+        Raises:
+            CommandFailure: if there is an error running the command
+            MPILoadError: if there is an error loading mpi
+
+        """
+        if not load_mpi(self.mpi_type):
+            raise MPILoadError(self.mpi_type)
+
+        return super().run()
 
     def run_conf(self, dmg_config_file):
         """Run the daos_run_io_conf command as a foreground process.
@@ -56,24 +71,25 @@ class IoConfGen(ExecutableCommand):
         command = " ".join([os.path.join(self._path, "daos_run_io_conf"), " -n ",
                             dmg_config_file, self.filename.value])
 
-        manager = Orterun(command)
+        manager = Orterun(command, mpi_type=self.mpi_type)
         # run daos_run_io_conf Command using Openmpi
         try:
             out = manager.run()
 
-            #Return False if "ERROR" in stdout
+            # Return False if "ERROR" in stdout
             for line in out.stdout_text.splitlines():
                 if 'ERROR' in line:
                     return False
-            #Return False if not expected message to confirm test completed.
+            # Return False if not expected message to confirm test completed.
             if success_msg not in out.stdout_text.splitlines()[-1]:
                 return False
 
-        #Return False if Command failed.
+        # Return False if Command failed.
         except CommandFailure:
             return False
 
         return True
+
 
 def gen_unaligned_io_conf(record_size, filename="testfile"):
     """Generate the data-set file based on record size.
@@ -104,11 +120,13 @@ def gen_unaligned_io_conf(record_size, filename="testfile"):
     except Exception as error:
         raise error
 
+
 class IoConfTestBase(TestWithServers):
     """Base rebuild test class.
 
     :avocado: recursive
     """
+
     def __init__(self, *args, **kwargs):
         """Initialize a IoConfTestBase object."""
         super().__init__(*args, **kwargs)
@@ -119,17 +137,28 @@ class IoConfTestBase(TestWithServers):
     def setup_test_pool(self):
         """Define a TestPool object."""
         self.add_pool(create=False)
-        avocao_tmp_dir = os.environ['AVOCADO_TESTS_COMMON_TMPDIR']
-        self.testfile = os.path.join(avocao_tmp_dir, 'testfile')
+        avocado_tmp_dir = os.environ['AVOCADO_TESTS_COMMON_TMPDIR']
+        self.testfile = os.path.join(avocado_tmp_dir, 'testfile')
         self.dmg = self.get_dmg_command()
         self.dmg_config_file = self.dmg.yaml.filename
+
+    def get_io_conf_gen(self):
+        """Get a IoConfGen command object.
+
+        Returns:
+            IoConfGen: a configured IoConfGen object
+
+        """
+        mpi_type = self.params.get("mpi_type", "/run/gen_io_conf/*", "openmpi")
+        io_conf = IoConfGen(os.path.join(self.prefix, "bin"), self.testfile, mpi_type)
+        io_conf.set_environment({"POOL_SCM_SIZE": "{}".format(self.pool.scm_size)})
+        io_conf.get_params(self)
+        return io_conf
 
     def execute_io_conf_run_test(self):
         """Execute the rebuild test steps."""
         self.setup_test_pool()
-        pool_env = {"POOL_SCM_SIZE": "{}".format(self.pool.scm_size)}
-        io_conf = IoConfGen(os.path.join(self.prefix, "bin"), self.testfile, env=pool_env)
-        io_conf.get_params(self)
+        io_conf = self.get_io_conf_gen()
         io_conf.run()
         # Run test file using daos_run_io_conf
         if not io_conf.run_conf(self.dmg_config_file):
@@ -140,11 +169,7 @@ class IoConfTestBase(TestWithServers):
         total_sizes = self.params.get("sizes", "/run/datasize/*")
         # Setup the pool
         self.setup_test_pool()
-        pool_env = {"POOL_SCM_SIZE": "{}".format(self.pool.scm_size)}
-        io_conf = IoConfGen(os.path.join(self.prefix, "bin"), self.testfile,
-                            env=pool_env)
-
-        io_conf.get_params(self)
+        io_conf = self.get_io_conf_gen()
         for record_size in total_sizes:
             print("Start test for record size = {}".format(record_size))
             # Create unaligned test data set


### PR DESCRIPTION
The eraurecode/rank_failure.py test is currently failing to run the
daos_gen_io_conf command outside of orterun because openmpi has not been
loaded.  The test is being updated to load a mpi prior to running the
daos_gen_io_conf command to avoid this failure. Also moved the
packaging of the daos_gen_io_conf and daos_run_io_conf to the
daos-client-tests RPM.

Test-tag: ec_io_conf_run iorebuild unaligned_io

Signed-off-by: Phillip Henderson <phillip.henderson@intel.com>