### PR TITLE
DAOS-10225 control: fix available storage with heterogeneous NVMe

### DIFF
--- a/src/control/lib/control/pool.go
+++ b/src/control/lib/control/pool.go
@@ -1125,6 +1125,11 @@ func GetMaxPoolSize(ctx context.Context, log logging.Logger, rpcClient UnaryInvo
 				}
 
 				nvmeRanksBytes[smdDevice.Rank] += smdDevice.AvailBytes
+				log.Debugf("Adding SMD device %s (instance %d, ctrlr %s) is usable: "+
+					"device state=%q, size=%d total=%d",
+					smdDevice.UUID, smdDevice.Rank, smdDevice.TrAddr,
+					smdDevice.NvmeState.String(), smdDevice.AvailBytes,
+					nvmeRanksBytes[smdDevice.Rank])
 			}
 		}
 		for _, nvmeRankBytes := range nvmeRanksBytes {

--- a/src/control/server/ctl_storage_rpc.go
+++ b/src/control/server/ctl_storage_rpc.go
@@ -8,6 +8,7 @@ package server
 
 import (
 	"fmt"
+	"math"
 	"os/user"
 	"strconv"
 
@@ -17,6 +18,7 @@ import (
 
 	"github.com/daos-stack/daos/src/control/common/proto"
 	"github.com/daos-stack/daos/src/control/common/proto/convert"
+	"github.com/daos-stack/daos/src/control/common/proto/ctl"
 	ctlpb "github.com/daos-stack/daos/src/control/common/proto/ctl"
 	"github.com/daos-stack/daos/src/control/drpc"
 	"github.com/daos-stack/daos/src/control/server/engine"
@@ -165,28 +167,53 @@ func (c *ControlService) scanScm(ctx context.Context, req *ctlpb.ScanScmReq) (*c
 
 // Adjust the NVME available size to its real usable size.
 func (c *ControlService) adjustNvmeSize(resp *ctlpb.ScanNvmeResp) {
-	for _, ctl := range resp.GetCtrlrs() {
-		for _, dev := range ctl.GetSmdDevices() {
+	devicesToAdjust := make(map[uint32]*struct {
+		size    uint64
+		devices []*ctl.NvmeController_SmdDevice
+	}, 0)
+	for _, ctlr := range resp.GetCtrlrs() {
+		for _, dev := range ctlr.GetSmdDevices() {
 			if dev.GetDevState() != "NORMAL" {
 				c.log.Debugf("Adjusting available size of unusable SMD device %s "+
 					"(ctlr %s) to O Bytes: device state %q",
-					dev.GetUuid(), ctl.GetPciAddr(), dev.GetDevState())
+					dev.GetUuid(), ctlr.GetPciAddr(), dev.GetDevState())
 				dev.AvailBytes = 0
 				continue
 			}
+
 			if dev.GetClusterSize() == 0 || len(dev.GetTgtIds()) == 0 {
 				c.log.Errorf("Skipping device %s (%s) with missing storage info",
-					dev.GetUuid(), ctl.GetPciAddr())
+					dev.GetUuid(), ctlr.GetPciAddr())
 				continue
 			}
 
+			rank := dev.GetRank()
+			if devicesToAdjust[rank] == nil {
+				devicesToAdjust[rank] = &struct {
+					size    uint64
+					devices []*ctl.NvmeController_SmdDevice
+				}{
+					size: math.MaxUint64,
+				}
+			}
 			targetCount := uint64(len(dev.GetTgtIds()))
 			unalignedBytes := dev.GetAvailBytes() % (targetCount * dev.GetClusterSize())
-			c.log.Debugf("Adjusting available size of SMD device %s (ctlr %s): "+
-				"excluding %s (%d Bytes) of unaligned storage",
-				dev.GetUuid(), ctl.GetPciAddr(),
-				humanize.Bytes(unalignedBytes), unalignedBytes)
-			dev.AvailBytes -= unalignedBytes
+			availBytes := dev.AvailBytes - unalignedBytes
+			if availBytes < devicesToAdjust[rank].size {
+				devicesToAdjust[rank].size = availBytes
+			}
+			devicesToAdjust[rank].devices = append(devicesToAdjust[rank].devices, dev)
+		}
+	}
+
+	for rank, item := range devicesToAdjust {
+		for _, dev := range item.devices {
+			unusedBytes := dev.AvailBytes - item.size
+			c.log.Debugf("Adjusting available size of SMD device %s from rank %d: "+
+				"excluding %s (%d Bytes) of unusable storage",
+				dev.GetUuid(), rank,
+				humanize.Bytes(unusedBytes), unusedBytes)
+			dev.AvailBytes = item.size
 		}
 	}
 }

--- a/src/control/server/ctl_storage_rpc.go
+++ b/src/control/server/ctl_storage_rpc.go
@@ -167,10 +167,12 @@ func (c *ControlService) scanScm(ctx context.Context, req *ctlpb.ScanScmReq) (*c
 
 // Adjust the NVME available size to its real usable size.
 func (c *ControlService) adjustNvmeSize(resp *ctlpb.ScanNvmeResp) {
-	devicesToAdjust := make(map[uint32]*struct {
+	type deviceSizeStat struct {
 		size    uint64
 		devices []*ctl.NvmeController_SmdDevice
-	}, 0)
+	}
+
+	devicesToAdjust := make(map[uint32]*deviceSizeStat, 0)
 	for _, ctlr := range resp.GetCtrlrs() {
 		for _, dev := range ctlr.GetSmdDevices() {
 			if dev.GetDevState() != "NORMAL" {
@@ -189,10 +191,7 @@ func (c *ControlService) adjustNvmeSize(resp *ctlpb.ScanNvmeResp) {
 
 			rank := dev.GetRank()
 			if devicesToAdjust[rank] == nil {
-				devicesToAdjust[rank] = &struct {
-					size    uint64
-					devices []*ctl.NvmeController_SmdDevice
-				}{
+				devicesToAdjust[rank] = &deviceSizeStat{
 					size: math.MaxUint64,
 				}
 			}

--- a/src/control/server/ctl_storage_rpc_test.go
+++ b/src/control/server/ctl_storage_rpc_test.go
@@ -9,6 +9,7 @@ package server
 import (
 	"context"
 	"fmt"
+	"math"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -24,6 +25,7 @@ import (
 	"github.com/daos-stack/daos/src/control/common"
 	"github.com/daos-stack/daos/src/control/common/proto"
 	"github.com/daos-stack/daos/src/control/common/proto/convert"
+	"github.com/daos-stack/daos/src/control/common/proto/ctl"
 	ctlpb "github.com/daos-stack/daos/src/control/common/proto/ctl"
 	"github.com/daos-stack/daos/src/control/drpc"
 	"github.com/daos-stack/daos/src/control/fault"
@@ -46,11 +48,21 @@ var (
 		protocmp.IgnoreFields(&ctlpb.NvmeController{}, "serial"))
 )
 
-func adjustNvmeSize(availBytes uint64) uint64 {
+func adjustNvmeSize(smdDevices []*ctl.NvmeController_SmdDevice) {
 	const targetNb uint64 = 4
 
-	unalignedMemory := availBytes % (targetNb * clusterSize)
-	return availBytes - unalignedMemory
+	availBytes := uint64(math.MaxUint64)
+	for _, dev := range smdDevices {
+		unalignedMemory := dev.AvailBytes % (targetNb * clusterSize)
+		usabledMemory := dev.AvailBytes - unalignedMemory
+		if usabledMemory < availBytes {
+			availBytes = usabledMemory
+		}
+	}
+
+	for _, dev := range smdDevices {
+		dev.AvailBytes = availBytes
+	}
 }
 
 func adjustScmSize(availBytes uint64) uint64 {
@@ -462,9 +474,7 @@ func TestServer_CtlSvc_StorageScan_PostEngineStart(t *testing.T) {
 	}
 	newCtrlrPBwMeta := func(idx int32, smdIndexes ...int32) *ctlpb.NvmeController {
 		c, _ := newCtrlrMeta(idx, smdIndexes...)
-		for _, sd := range c.GetSmdDevices() {
-			sd.AvailBytes = adjustNvmeSize(sd.AvailBytes)
-		}
+		adjustNvmeSize(c.GetSmdDevices())
 		return c
 	}
 	newSmdDevResp := func(idx int32, smdIndexes ...int32) *ctlpb.SmdDevResp {
@@ -2241,16 +2251,41 @@ func TestServer_adjustNvmeSize(t *testing.T) {
 					{
 						SmdDevices: []*ctlpb.NvmeController_SmdDevice{
 							{
+								Uuid:        "nvme0",
 								TgtIds:      []int32{0, 1, 2, 3},
 								AvailBytes:  10 * humanize.GiByte,
 								ClusterSize: clusterSize,
 								DevState:    "NORMAL",
+								Rank:        0,
 							},
 							{
-								TgtIds:      []int32{0, 1, 2},
+								Uuid:        "nvme1",
+								TgtIds:      []int32{0, 1, 2, 3},
 								AvailBytes:  10 * humanize.GiByte,
 								ClusterSize: clusterSize,
 								DevState:    "NORMAL",
+								Rank:        0,
+							},
+							{
+								TgtIds:      []int32{0, 1, 2, 3},
+								AvailBytes:  20 * humanize.GiByte,
+								ClusterSize: clusterSize,
+								DevState:    "NORMAL",
+								Rank:        0,
+							},
+							{
+								TgtIds:      []int32{0, 1, 2},
+								AvailBytes:  20 * humanize.GiByte,
+								ClusterSize: clusterSize,
+								DevState:    "NORMAL",
+								Rank:        1,
+							},
+							{
+								TgtIds:      []int32{0, 1, 2},
+								AvailBytes:  20 * humanize.GiByte,
+								ClusterSize: clusterSize,
+								DevState:    "NORMAL",
+								Rank:        1,
 							},
 						},
 					},
@@ -2259,8 +2294,42 @@ func TestServer_adjustNvmeSize(t *testing.T) {
 			output: ExpectedOutput{
 				availableBytes: []uint64{
 					8 * humanize.GiByte,
-					9 * humanize.GiByte,
+					8 * humanize.GiByte,
+					8 * humanize.GiByte,
+					18 * humanize.GiByte,
+					18 * humanize.GiByte,
 				},
+			},
+		},
+		"new": {
+			input: &ctlpb.ScanNvmeResp{
+				Ctrlrs: []*ctlpb.NvmeController{
+					{
+						SmdDevices: []*ctlpb.NvmeController_SmdDevice{
+							{
+								Uuid:        "nvme0",
+								TgtIds:      []int32{0, 1, 2, 3},
+								AvailBytes:  10 * humanize.GiByte,
+								ClusterSize: clusterSize,
+								DevState:    "NORMAL",
+							},
+							{
+								Uuid:        "nvme1",
+								TgtIds:      []int32{0, 1, 2},
+								AvailBytes:  10 * humanize.GiByte,
+								ClusterSize: clusterSize,
+								DevState:    "NEW",
+							},
+						},
+					},
+				},
+			},
+			output: ExpectedOutput{
+				availableBytes: []uint64{
+					8 * humanize.GiByte,
+					0,
+				},
+				message: "Adjusting available size of unusable SMD device",
 			},
 		},
 		"evicted": {
@@ -2327,12 +2396,14 @@ func TestServer_adjustNvmeSize(t *testing.T) {
 					{
 						SmdDevices: []*ctlpb.NvmeController_SmdDevice{
 							{
+								Uuid:        "nvme0",
 								TgtIds:      []int32{0, 1, 2, 3},
 								AvailBytes:  10 * humanize.GiByte,
 								ClusterSize: clusterSize,
 								DevState:    "NORMAL",
 							},
 							{
+								Uuid:       "nvme1",
 								TgtIds:     []int32{0, 1, 2},
 								AvailBytes: 10 * humanize.GiByte,
 								DevState:   "NORMAL",


### PR DESCRIPTION
# Decription

When NVMe of different size are used by the same engine, then the storage available for each device is equal to the one of the smallest device.

# Validation

Automatic functional tests could not be easily done as it will need to have at least one node equipped with NVMe devices of different size.

The unit tests were manually validated and the CI test suite will ne relaunched as soon as it will be fixed.

The patch was manually validated with wolf-157 which have disk of different size as illustrated in the following traces:
```
[1048] > $HOME/daos/install/bin/dmg -o /etc/daos/daos_control.yml storage scan -v
--------
wolf-157
--------
HugePage Size: 2048 KB
SCM Namespace Socket ID Capacity
------------- --------- --------
pmem0         0         3.2 TB
pmem1         1         3.2 TB

NVMe PCI       Model               FW Revision Socket ID Capacity
--------       -----               ----------- --------- --------
5d0505:01:00.0 INTEL SSDPE2KE016T8 VDV10170    0         1.6 TB
5d0505:03:00.0 INTEL SSDPE2KE016T8 VDV10170    0         1.6 TB
850505:07:00.0 INTEL SSDPE2KE016T8 VDV10170    1         1.6 TB
850505:09:00.0 INTEL SSDPE2KE016T8 VDV10170    1         1.6 TB
850505:0b:00.0 INTEL SSDPE2KE016T8 VDV10170    1         1.6 TB
850505:0d:00.0 INTEL SSDPE2KE016T8 VDV10170    1         1.6 TB
850505:0f:00.0 INTEL SSDPE2KE016T8 VDV10170    1         1.6 TB
850505:11:00.0 INTEL SSDPE2KE016T8 VDV10170    1         1.6 TB
850505:14:00.0 INTEL SSDPED1K750GA E2010475    1         750 GB
```

Sadly when we create a pool with 4 targets the 750GB is used as illustrated in following trace
```
"smd_devices": [
                {
                  "dev_state": "NORMAL",
                  "uuid": "beb5c666-cbfe-4899-84a2-0d20c9062ec0",
                  "tgt_ids": [
                    0
                  ],
                  "rank": 0,
                  "total_bytes": 748398051328,
                  "avail_bytes": 0,
                  "cluster_size": 1073741824,
                  "health": null,
                  "tr_addr": "850505:14:00.0"
                }
```

With the latest patch the nvme total and free size are consistent, and the creation of the pool could be successfully done with the dmg command
```
[1035] > $HOME/daos/install/bin/dmg -o /etc/daos/daos_control.yml storage query usage
Hosts    SCM-Total SCM-Free SCM-Used NVMe-Total NVMe-Free NVMe-Used
-----    --------- -------- -------- ---------- --------- ---------
wolf-157 3.2 TB    3.2 TB   0 %      5.5 TB     3.0 TB    46 %
13:57 ckochhof@wolf-157.wolf.hpdd.intel.com:/home/ckochhof/daos/daos-10225
[1036] > $HOME/daos/install/bin/dmg -o /etc/daos/daos_control.yml -d pool create --group=ckochhof --label=tank --size=100% --user=ckochhof
DEBUG 13:58:28.012392 main.go:216: debug output enabled
DEBUG 13:58:28.012770 main.go:244: control config loaded from /etc/daos/daos_control.yml
DEBUG 13:58:28.013210 rpc.go:254: request hosts: [wolf-157:10001]
WARNING: SMD device c1439c86-afb0-4116-a7ff-1239f6bfbaa2 (instance 0, ctrlr 5d0505:01:00.0) not usable (device state "NEW")
WARNING: SMD device 3272f00d-9ab6-49a6-bd88-ff13c0fdaa26 (instance 0, ctrlr 5d0505:03:00.0) not usable (device state "NEW")
WARNING: SMD device 7826dfc4-7ddb-4285-baae-91f2d4d449fb (instance 0, ctrlr 850505:07:00.0) not usable (device state "NEW")
WARNING: SMD device dc6892f5-a865-4f16-b243-7691820bc041 (instance 0, ctrlr 850505:09:00.0) not usable (device state "NEW")
WARNING: SMD device 5d18446a-9be2-4c63-b12a-f163012ad568 (instance 0, ctrlr 850505:0b:00.0) not usable (device state "NEW")
DEBUG 13:58:29.769463 pool.go:1128: Adding SMD device bf7329be-9dba-4495-b860-4b8457ec427d (instance 0, ctrlr 850505:0d:00.0) is usable: device state="NORMAL", size=748398051328 total=748398051328
DEBUG 13:58:29.769518 pool.go:1128: Adding SMD device 59e22894-a217-4d23-9409-c7132122ab0b (instance 0, ctrlr 850505:0f:00.0) is usable: device state="NORMAL", size=748398051328 total=1496796102656
DEBUG 13:58:29.769554 pool.go:1128: Adding SMD device edea5791-f1f8-4c4c-9741-bc906a65bebb (instance 0, ctrlr 850505:11:00.0) is usable: device state="NORMAL", size=748398051328 total=2245194153984
DEBUG 13:58:29.769590 pool.go:1128: Adding SMD device beb5c666-cbfe-4899-84a2-0d20c9062ec0 (instance 0, ctrlr 850505:14:00.0) is usable: device state="NORMAL", size=748398051328 total=2993592205312
DEBUG 13:58:29.769647 pool.go:1149: Maximal size of a pool: scmBytes=3.2 TB (3180963917824 B) nvmeBytes=3.0 TB (2993592205312 B)
Creating DAOS pool with 100% of all storage
DEBUG 13:58:29.770595 pool.go:255: Create DAOS pool request: &{poolRequest:{msRequest:{} unaryRequest:{request:{timeout:600000000000 deadline:{wall:13876370930934775707 ext:601775407084 loc:0x15fd300} Sys: HostList:[]} rpc:0xbb99e0} retryableRequest:{retryTimeout:0 retryInterval:0 retryMaxTries:0 retryTestFn:<nil> retryFn:<nil>}} User:ckochhof@ UserGroup:ckochhof@ ACL:nil NumSvcReps:0 Properties:[label:tank] TotalBytes:0 TierRatio:[] NumRanks:0 Ranks:[] TierBytes:[3180963917824 2993592205312]}
DEBUG 13:58:29.770892 rpc.go:254: request hosts: [wolf-157:10001]
DEBUG 13:58:32.843751 pool.go:265: Create DAOS pool response: *mgmt.PoolCreateResp svc_ranks: 0 tgt_ranks: 0 tiers: 0: 3180963917824 1: 2993592205312
Pool created with 51.52%,48.48% storage tier ratio
--------------------------------------------------
  UUID                 : 1eb76217-b5f7-4d88-820d-ce32686964a1
  Service Ranks        : 0
  Storage Ranks        : 0
  Total Size           : 6.2 TB
  Storage tier 0 (SCM) : 3.2 TB (3.2 TB / rank)
  Storage tier 1 (NVMe): 3.0 TB (3.0 TB / rank)

13:58 ckochhof@wolf-157.wolf.hpdd.intel.com:/home/ckochhof/daos/daos-10225
[1037] > $HOME/daos/install/bin/dmg -o /etc/daos/daos_control.yml storage query usage
Hosts    SCM-Total SCM-Free SCM-Used NVMe-Total NVMe-Free NVMe-Used
-----    --------- -------- -------- ---------- --------- ---------
wolf-157 3.2 TB    0 B      100 %    5.5 TB     0 B       100 %

```