### PR TITLE
DAOS-10200 vos: Avoid setting dth in TLS across yield

### DIFF
--- a/src/vos/vos_common.c
+++ b/src/vos/vos_common.c
@@ -234,12 +234,21 @@ vos_tx_begin(struct dtx_handle *dth, struct umem_instance *umm)
 	if (dth == NULL)
 		return umem_tx_begin(umm, vos_txd_get());
 
-	if (dth->dth_local_tx_started)
+	/** Note: On successful return, dth tls gets set and will be cleared by the corresponding
+	 *        call to vos_tx_end.  This is to avoid ever keeping that set after a call to
+	 *        umem_tx_end, which may yield for bio operations.
+	 */
+
+	if (dth->dth_local_tx_started) {
+		vos_dth_set(dth);
 		return 0;
+	}
 
 	rc = umem_tx_begin(umm, vos_txd_get());
-	if (rc == 0)
+	if (rc == 0) {
 		dth->dth_local_tx_started = 1;
+		vos_dth_set(dth);
+	}
 
 	return rc;
 }
@@ -278,8 +287,10 @@ vos_tx_end(struct vos_container *cont, struct dtx_handle *dth_in,
 		goto cancel;
 
 	/* Not the last modification. */
-	if (err == 0 && dth->dth_modification_cnt > dth->dth_op_seq)
+	if (err == 0 && dth->dth_modification_cnt > dth->dth_op_seq) {
+		vos_dth_set(NULL);
 		return 0;
+	}
 
 	dth->dth_local_tx_started = 0;
 
@@ -288,6 +299,8 @@ vos_tx_end(struct vos_container *cont, struct dtx_handle *dth_in,
 
 	if (err == 0)
 		err = vos_tx_publish(dth, true);
+
+	vos_dth_set(NULL);
 
 	err = umem_tx_end(vos_cont2umm(cont), err);
 

--- a/src/vos/vos_internal.h
+++ b/src/vos/vos_internal.h
@@ -899,16 +899,6 @@ enum vos_iter_state {
 
 struct vos_iter_ops;
 
-/** Common fields for I/O operations */
-struct vos_io_info {
-	daos_epoch_range_t	 ii_epr;
-	daos_epoch_t		 ii_bound;
-	struct dtx_handle	*ii_dth;
-	struct vos_ts_set	*ii_ts_set;
-	struct vos_ilog_info	*ii_parent;
-	struct vos_ilog_info	 ii_info;
-};
-
 /** the common part of vos iterators */
 struct vos_iterator {
 	struct dtx_handle	*it_dth;

--- a/src/vos/vos_internal.h
+++ b/src/vos/vos_internal.h
@@ -899,6 +899,16 @@ enum vos_iter_state {
 
 struct vos_iter_ops;
 
+/** Common fields for I/O operations */
+struct vos_io_info {
+	daos_epoch_range_t	 ii_epr;
+	daos_epoch_t		 ii_bound;
+	struct dtx_handle	*ii_dth;
+	struct vos_ts_set	*ii_ts_set;
+	struct vos_ilog_info	*ii_parent;
+	struct vos_ilog_info	 ii_info;
+};
+
 /** the common part of vos iterators */
 struct vos_iterator {
 	struct dtx_handle	*it_dth;

--- a/src/vos/vos_io.c
+++ b/src/vos/vos_io.c
@@ -2285,8 +2285,6 @@ vos_update_end(daos_handle_t ioh, uint32_t pm_ver, daos_key_t *dkey, int err,
 
 	tx_started = true;
 
-	vos_dth_set(dth);
-
 	/* Commit the CoS DTXs via the IO PMDK transaction. */
 	if (dtx_is_valid_handle(dth) && dth->dth_dti_cos_count > 0 &&
 	    !dth->dth_cos_done) {
@@ -2348,8 +2346,6 @@ abort:
 
 	if (err == 0)
 		err = vos_ioc_mark_agg(ioc);
-
-	vos_dth_set(NULL);
 
 	err = vos_tx_end(ioc->ic_cont, dth, &ioc->ic_rsrvd_scm,
 			 &ioc->ic_blk_exts, tx_started, err);

--- a/src/vos/vos_io.c
+++ b/src/vos/vos_io.c
@@ -2349,6 +2349,8 @@ abort:
 	if (err == 0)
 		err = vos_ioc_mark_agg(ioc);
 
+	vos_dth_set(NULL);
+
 	err = vos_tx_end(ioc->ic_cont, dth, &ioc->ic_rsrvd_scm,
 			 &ioc->ic_blk_exts, tx_started, err);
 	if (err == 0) {
@@ -2383,7 +2385,6 @@ abort:
 	D_FREE(daes);
 	D_FREE(dces);
 	vos_ioc_destroy(ioc, err != 0);
-	vos_dth_set(NULL);
 
 	return err;
 }

--- a/src/vos/vos_obj.c
+++ b/src/vos/vos_obj.c
@@ -457,8 +457,6 @@ vos_obj_punch(daos_handle_t coh, daos_unit_oid_t oid, daos_epoch_t epoch,
 	if (rc != 0)
 		goto reset;
 
-	vos_dth_set(dth);
-
 	/* Commit the CoS DTXs via the PUNCH PMDK transaction. */
 	if (dtx_is_valid_handle(dth) && dth->dth_dti_cos_count > 0 &&
 	    !dth->dth_cos_done) {
@@ -526,7 +524,6 @@ reset:
 			rc = -DER_TX_RESTART;
 	}
 
-	vos_dth_set(NULL);
 	rc = vos_tx_end(cont, dth, NULL, NULL, true, rc);
 
 	if (rc == 0) {

--- a/src/vos/vos_obj_index.c
+++ b/src/vos/vos_obj_index.c
@@ -502,6 +502,7 @@ oi_iter_match_probe(struct vos_iterator *iter, daos_anchor_t *anchor, uint32_t f
 {
 	uint64_t		 start_seq;
 	struct vos_oi_iter	*oiter	= iter2oiter(iter);
+	struct dtx_handle	*dth;
 	char			*str	= NULL;
 	vos_iter_desc_t		 desc;
 	uint64_t		 feats;
@@ -538,8 +539,13 @@ oi_iter_match_probe(struct vos_iterator *iter, daos_anchor_t *anchor, uint32_t f
 			}
 			acts = 0;
 			start_seq = vos_sched_seq();
+			dth = vos_dth_get();
+			if (dth != NULL)
+				vos_dth_set(NULL);
 			rc = iter->it_filter_cb(vos_iter2hdl(iter), &desc, iter->it_filter_arg,
 						&acts);
+			if (dth != NULL)
+				vos_dth_set(dth);
 			if (rc != 0)
 				goto failed;
 			if (start_seq != vos_sched_seq())


### PR DESCRIPTION
Holding the value across a yield can cause undefined behavior.
At some point, this should be fixed so we pass the dth through
parameters rather than expecting us to always get this right
inside of VOS.  Making sure we never have it set across yield
points is difficult.

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>