### PR TITLE
DAOS-10166 cart: Add shutdown delay to corpc errors test.

### DIFF
--- a/src/tests/ftest/cart/no_pmix_corpc_errors.c
+++ b/src/tests/ftest/cart/no_pmix_corpc_errors.c
@@ -265,6 +265,12 @@ int main(int argc, char **argv)
 	sem_t			sem;
 	int			rc;
 
+	if (D_ON_VALGRIND) {
+		crtu_set_shutdown_delay(10);
+	} else {
+		crtu_set_shutdown_delay(2);
+	}
+
 	env_self_rank = getenv("CRT_L_RANK");
 	my_rank = atoi(env_self_rank);
 


### PR DESCRIPTION
Signed-off-by: Joseph Moore <joseph.moore@intel.com>