### PR TITLE
DAOS-10454 test: improve rebuild_widely_striped

### DIFF
--- a/src/tests/ftest/rebuild/widely_striped.py
+++ b/src/tests/ftest/rebuild/widely_striped.py
@@ -6,14 +6,11 @@
 """
 
 
-import threading
 import time
-
 from mdtest_test_base import MdtestBase
 
 
 # pylint: disable=too-few-public-methods,too-many-ancestors
-# pylint: disable=attribute-defined-outside-init
 class RbldWidelyStriped(MdtestBase):
     """Rebuild test cases featuring mdtest.
 
@@ -47,12 +44,12 @@ class RbldWidelyStriped(MdtestBase):
 
         :avocado: tags=all,full_regression
         :avocado: tags=hw,large
-        :avocado: tags=rebuild,widelystriped
+        :avocado: tags=rebuild
+        :avocado: tags=rebuild_widely_striped
         """
         # set params
         targets = self.params.get("targets", "/run/server_config/*")
-        rank = self.params.get("rank_to_kill", "/run/testparams/*")
-        self.dmg = self.get_dmg_command()
+        ranks_to_kill = self.params.get("ranks_to_kill", "/run/testparams/*")
 
         # create pool
         self.add_pool(connect=False)
@@ -77,33 +74,38 @@ class RbldWidelyStriped(MdtestBase):
         # start 1st mdtest run and let it complete
         self.execute_mdtest()
         # Kill rank[6] and wait for rebuild to complete
-        self.server_managers[0].stop_ranks([rank[0]], self.d_log, force=True)
+        self.server_managers[0].stop_ranks(ranks_to_kill[0], self.d_log, force=True)
         self.pool.wait_for_rebuild(False, interval=1)
 
         # create 2nd container
         self.add_container(self.pool)
-        # start 2nd mdtest job
-        thread = threading.Thread(target=self.execute_mdtest)
-        thread.start()
-        time.sleep(3)
 
-        # Kill rank[5] in the middle of mdtest run and
-        # wait for rebuild to complete
-        self.server_managers[0].stop_ranks([rank[1]], self.d_log, force=True)
+        # start 2nd mdtest job in the background
+        self.subprocess = True
+        self.execute_mdtest()
+
+        # Kill rank[5] in the middle of mdtest run and wait for rebuild to complete
+        time.sleep(3)
+        self.server_managers[0].stop_ranks(ranks_to_kill[1], self.d_log, force=True)
         self.pool.wait_for_rebuild(False, interval=1)
-        # wait for mdtest to complete
-        thread.join()
+
+        # wait for mdtest to complete successfully
+        mdtest_returncode = self.job_manager.process.wait()
+        if mdtest_returncode != 0:
+            self.fail("mdtest failed")
 
         # create 3rd container
         self.add_container(self.pool)
 
-        # start 3rd mdtest job
-        thread = threading.Thread(target=self.execute_mdtest)
-        thread.start()
-        time.sleep(3)
+        # start 3rd mdtest job in the background
+        self.execute_mdtest()
 
-        # Kill 2 server ranks [3,4]
-        self.server_managers[0].stop_ranks(rank[2], self.d_log, force=True)
+        # Kill 2 server ranks [3,4] during mdtest and wait for rebuild to complete
+        time.sleep(3)
+        self.server_managers[0].stop_ranks(ranks_to_kill[2], self.d_log, force=True)
         self.pool.wait_for_rebuild(False, interval=1)
-        # wait for mdtest to complete
-        thread.join()
+
+        # wait for mdtest to complete successfully
+        mdtest_returncode = self.job_manager.process.wait()
+        if mdtest_returncode != 0:
+            self.fail("mdtest failed")

--- a/src/tests/ftest/rebuild/widely_striped.yaml
+++ b/src/tests/ftest/rebuild/widely_striped.yaml
@@ -1,5 +1,3 @@
-# change host names to your reserved nodes, the
-# required quantity is indicated by the placeholders
 hosts:
   test_servers:
     - server-A
@@ -21,11 +19,10 @@ server_config:
     scm_class: dcpm
     scm_list: ["/dev/pmem0"]
 testparams:
-  ranks:
-    rank_to_kill:
-      - 6
-      - 5
-      - [3,4]
+  ranks_to_kill:
+    - [6]
+    - [5]
+    - [3,4]
 pool:
   mode: 146
   name: daos_server
@@ -39,13 +36,13 @@ container:
   type: POSIX
   control_method: daos
   oclass: RP_3G1
+  properties: "rf:2"
 mdtest:
   api: DFS
   client_processes:
     np: 30
   num_of_files_dirs: 4067         # creating total of 120K files
   test_dir: "/"
-  iteration: 1
   dfs_destroy: False
   dfs_oclass: RP_3G1
   dfs_dir_oclass: RP_3G1


### PR DESCRIPTION
- Set cont_rf so mdtest completes successfully
- Run mdtest as a subprocess instead of thread
  - Make sure mdtest is actually successful
- Misc cleanup

rf should be set on a POSIX container for root/SB objects.

Test-tag: rebuild_widely_striped
Skip-unit-tests: true
Skip-fault-injection-test: true