### PR TITLE
DAOS-10477 dfs: add new APIs to retrieve pool and container handles

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -43,7 +43,7 @@ def get_version(env):
 
 
 API_VERSION_MAJOR = "2"
-API_VERSION_MINOR = "2"
+API_VERSION_MINOR = "3"
 API_VERSION_FIX = "0"
 API_VERSION = "{}.{}.{}".format(API_VERSION_MAJOR, API_VERSION_MINOR,
                                 API_VERSION_FIX)

--- a/src/client/dfs/dfs.c
+++ b/src/client/dfs/dfs.c
@@ -142,8 +142,12 @@ struct dfs {
 	int			amode;
 	/** Open pool handle of the DFS mount */
 	daos_handle_t		poh;
+	/** refcount on pool handle that through the DFS API */
+	uint32_t		poh_refcount;
 	/** Open container handle of the DFS mount */
 	daos_handle_t		coh;
+	/** refcount on cont handle that through the DFS API */
+	uint32_t		coh_refcount;
 	/** Object ID reserved for this DFS (see oid_gen below) */
 	daos_obj_id_t		oid;
 	/** superblock object OID */
@@ -1980,13 +1984,97 @@ dfs_umount(dfs_t *dfs)
 		return EINVAL;
 	}
 
+	D_MUTEX_LOCK(&dfs->lock);
+	if (dfs->poh_refcount != 0) {
+		D_ERROR("Pool open handle refcount not 0\n");
+		D_MUTEX_UNLOCK(&dfs->lock);
+		return EBUSY;
+	}
+	if (dfs->coh_refcount != 0) {
+		D_ERROR("Cont open handle refcount not 0\n");
+		D_MUTEX_UNLOCK(&dfs->lock);
+		return EBUSY;
+	}
+	D_MUTEX_UNLOCK(&dfs->lock);
+
 	daos_obj_close(dfs->root.oh, NULL);
 	daos_obj_close(dfs->super_oh, NULL);
 
 	D_FREE(dfs->prefix);
-
 	D_MUTEX_DESTROY(&dfs->lock);
 	D_FREE(dfs);
+
+	return 0;
+}
+
+int
+dfs_pool_get(dfs_t *dfs, daos_handle_t *poh)
+{
+	if (dfs == NULL || !dfs->mounted)
+		return EINVAL;
+
+	D_MUTEX_LOCK(&dfs->lock);
+	dfs->poh_refcount++;
+	D_MUTEX_UNLOCK(&dfs->lock);
+
+	*poh = dfs->poh;
+	return 0;
+}
+
+int
+dfs_pool_put(dfs_t *dfs, daos_handle_t poh)
+{
+	if (dfs == NULL || !dfs->mounted)
+		return EINVAL;
+	if (poh.cookie != dfs->poh.cookie) {
+		D_ERROR("Pool handle is not the same as the DFS Mount handle\n");
+		return EINVAL;
+	}
+
+	D_MUTEX_LOCK(&dfs->lock);
+	if (dfs->poh_refcount <= 0) {
+		D_ERROR("Invalid pool handle refcount\n");
+		D_MUTEX_UNLOCK(&dfs->lock);
+		return EINVAL;
+	}
+	dfs->poh_refcount--;
+	D_MUTEX_UNLOCK(&dfs->lock);
+
+	return 0;
+}
+
+int
+dfs_cont_get(dfs_t *dfs, daos_handle_t *coh)
+{
+	if (dfs == NULL || !dfs->mounted)
+		return EINVAL;
+
+	D_MUTEX_LOCK(&dfs->lock);
+	dfs->coh_refcount++;
+	D_MUTEX_UNLOCK(&dfs->lock);
+
+	*coh = dfs->coh;
+	return 0;
+}
+
+int
+dfs_cont_put(dfs_t *dfs, daos_handle_t coh)
+{
+	if (dfs == NULL || !dfs->mounted)
+		return EINVAL;
+	if (coh.cookie != dfs->coh.cookie) {
+		D_ERROR("Cont handle is not the same as the DFS Mount handle\n");
+		return EINVAL;
+	}
+
+	D_MUTEX_LOCK(&dfs->lock);
+	if (dfs->coh_refcount <= 0) {
+		D_ERROR("Invalid cont handle refcount\n");
+		D_MUTEX_UNLOCK(&dfs->lock);
+		return EINVAL;
+	}
+	dfs->coh_refcount--;
+	D_MUTEX_UNLOCK(&dfs->lock);
 
 	return 0;
 }

--- a/src/include/daos_fs.h
+++ b/src/include/daos_fs.h
@@ -218,6 +218,52 @@ int
 dfs_umount(dfs_t *dfs);
 
 /**
+ * Retrieve the open pool handle on the DFS mount. This is refcounted internally and must be
+ * released with dfs_pool_put().
+ *
+ * \param[in]	dfs	Pointer to the mounted file system.
+ * \param[out]	poh	Open pool handle.
+ *
+ * \return		0 on success, errno code on failure.
+ */
+int
+dfs_pool_get(dfs_t *dfs, daos_handle_t *poh);
+
+/**
+ * Release refcount of pool handle taken by dfs_pool_get().
+ *
+ * \param[in]	dfs	Pointer to the mounted file system.
+ * \param[out]	poh	Pool handle that was returned from dfs_pool_get().
+ *
+ * \return		0 on success, errno code on failure.
+ */
+int
+dfs_pool_put(dfs_t *dfs, daos_handle_t poh);
+
+/**
+ * Retrieve the open cont handle on the DFS mount. This is refcounted internally and must be
+ * released with dfs_cont_put().
+ *
+ * \param[in]	dfs	Pointer to the mounted file system.
+ * \param[out]	coh	Open cont handle.
+ *
+ * \return		0 on success, errno code on failure.
+ */
+int
+dfs_cont_get(dfs_t *dfs, daos_handle_t *coh);
+
+/**
+ * Release refcount of cont handle taken by dfs_cont_get().
+ *
+ * \param[in]	dfs	Pointer to the mounted file system.
+ * \param[out]	coh	Cont handle that was returned from dfs_cont_get().
+ *
+ * \return		0 on success, errno code on failure.
+ */
+int
+dfs_cont_put(dfs_t *dfs, daos_handle_t coh);
+
+/**
  * Query attributes of a DFS mount.
  *
  * \param[in]	dfs	Pointer to the mounted file system.
@@ -1060,7 +1106,6 @@ dfs_cont_create_cpp(daos_handle_t poh, const uuid_t cuuid, dfs_attr_t *attr, dao
 		}							\
 		_ret;							\
 	})
-
 
 #endif /* __cplusplus */
 #endif /* __DAOS_FS_H__ */

--- a/src/tests/suite/dfs_unit_test.c
+++ b/src/tests/suite/dfs_unit_test.c
@@ -22,6 +22,7 @@ dfs_test_mount(void **state)
 	uuid_t			cuuid;
 	daos_cont_info_t	co_info;
 	daos_handle_t		coh;
+	daos_handle_t		poh_tmp, coh_tmp;
 	dfs_t			*dfs;
 	int			rc;
 
@@ -125,6 +126,26 @@ dfs_test_mount(void **state)
 	assert_rc_equal(rc, 0);
 	rc = dfs_mount(arg->pool.poh, coh, O_RDWR, &dfs);
 	assert_int_equal(rc, 0);
+
+	/** get/put poh and coh */
+	print_message("Testing dfs_pool/cont_get/put\n");
+	rc = dfs_pool_get(dfs, &poh_tmp);
+	assert_int_equal(rc, 0);
+	assert_int_equal(poh_tmp.cookie, arg->pool.poh.cookie);
+	/** try to umount now, should fail */
+	rc = dfs_umount(dfs);
+	assert_int_equal(rc, EBUSY);
+	rc = dfs_pool_put(dfs, poh_tmp);
+	assert_int_equal(rc, 0);
+	rc = dfs_cont_get(dfs, &coh_tmp);
+	assert_int_equal(rc, 0);
+	assert_int_equal(coh_tmp.cookie, coh.cookie);
+	/** try to umount now, should fail */
+	rc = dfs_umount(dfs);
+	assert_int_equal(rc, EBUSY);
+	rc = dfs_cont_put(dfs, coh_tmp);
+	assert_int_equal(rc, 0);
+
 	rc = dfs_umount(dfs);
 	assert_int_equal(rc, 0);
 	rc = daos_cont_close(coh, NULL);


### PR DESCRIPTION
If a user connect to a DFS container with dfs_connect(), they don't have
access to the pool and container handles that are opened by DFS internally.
Users sometimes need to add attributes or query the pool and container info,
so provide a mechanism to return those internal pool and container handles
with proper refcounting, requiring users to put the handles when done before
umount of dfs.

Signed-off-by: Mohamad Chaarawi <mohamad.chaarawi@intel.com>