### PR TITLE
DAOS-9590 chk: Update SConscript to export chk_pb

### DIFF
--- a/src/chk/SConscript
+++ b/src/chk/SConscript
@@ -7,21 +7,21 @@ def scons():
 
     env.AppendUnique(LIBPATH=[Dir('.')])
 
+    denv = env.Clone()
+
+    # common
+    prereqs.require(denv, 'argobots', 'protobufc')
+    chk_pb = denv.SharedObject(['chk.pb-c.c'])
+    Export('chk_pb')
+
     if not prereqs.server_requested():
         return
 
-    denv = env.Clone()
-
-    prereqs.require(denv, 'argobots', 'protobufc')
-
     # chk
-    chk_pb = denv.SharedObject(['chk.pb-c.c'])
     chk = daos_build.library(denv, 'chk',
                              [chk_pb, 'chk_srv.c', 'chk_common.c'],
                              install_off="../..")
     denv.Install('$PREFIX/lib64/daos_srv', chk)
-
-    Export('chk_pb')
 
 if __name__ == "SCons.Script":
     scons()


### PR DESCRIPTION
Small fix to always export the chk_pb variable so it
can be used by server and client.

Signed-off-by: Ryon Jensen <ryon.jensen@intel.com>