### PR TITLE
DAOS-9923 agent: Wait for fabric ready before scan

### DIFF
--- a/src/control/cmd/daos_agent/mgmt_rpc.go
+++ b/src/control/cmd/daos_agent/mgmt_rpc.go
@@ -8,6 +8,7 @@ package main
 
 import (
 	"net"
+	"time"
 
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
@@ -19,7 +20,6 @@ import (
 	"github.com/daos-stack/daos/src/control/drpc"
 	"github.com/daos-stack/daos/src/control/lib/control"
 	"github.com/daos-stack/daos/src/control/lib/hardware"
-	"github.com/daos-stack/daos/src/control/lib/hardware/hwprov"
 	"github.com/daos-stack/daos/src/control/logging"
 )
 
@@ -34,7 +34,12 @@ type mgmtModule struct {
 	fabricInfo     *localFabricCache
 	monitor        *procMon
 	useDefaultNUMA bool
+
 	numaGetter     hardware.ProcessNUMAProvider
+	devClassGetter hardware.NetDevClassProvider
+	devStateGetter hardware.NetDevStateProvider
+	fabricScanner  *hardware.FabricScanner
+	netIfaces      func() ([]net.Interface, error)
 }
 
 func (mod *mgmtModule) HandleCall(ctx context.Context, session *drpc.Session, method drpc.Method, req []byte) ([]byte, error) {
@@ -199,9 +204,11 @@ func (mod *mgmtModule) getFabricInterface(ctx context.Context, numaNode int, net
 		return mod.fabricInfo.GetDevice(numaNode, netDevClass, provider)
 	}
 
-	scanner := hwprov.DefaultFabricScanner(mod.log)
+	if err := mod.waitFabricReady(ctx, netDevClass); err != nil {
+		return nil, err
+	}
 
-	result, err := scanner.Scan(ctx)
+	result, err := mod.fabricScanner.Scan(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -209,6 +216,34 @@ func (mod *mgmtModule) getFabricInterface(ctx context.Context, numaNode int, net
 	mod.fabricInfo.CacheScan(ctx, result)
 
 	return mod.fabricInfo.GetDevice(numaNode, netDevClass, provider)
+}
+
+func (mod *mgmtModule) waitFabricReady(ctx context.Context, netDevClass hardware.NetDevClass) error {
+	if mod.netIfaces == nil {
+		mod.netIfaces = net.Interfaces
+	}
+	ifaces, err := mod.netIfaces()
+	if err != nil {
+		return err
+	}
+
+	var needIfaces []string
+	for _, iface := range ifaces {
+		devClass, err := mod.devClassGetter.GetNetDevClass(iface.Name)
+		if err != nil {
+			return err
+		}
+		if devClass == netDevClass {
+			needIfaces = append(needIfaces, iface.Name)
+		}
+	}
+
+	return hardware.WaitFabricReady(ctx, mod.log, hardware.WaitFabricReadyParams{
+		StateProvider:  mod.devStateGetter,
+		FabricIfaces:   needIfaces,
+		IgnoreUnusable: true,
+		IterationSleep: time.Second,
+	})
 }
 
 func (mod *mgmtModule) handleNotifyPoolConnect(ctx context.Context, reqb []byte, pid int32) error {

--- a/src/control/cmd/daos_agent/mgmt_rpc.go
+++ b/src/control/cmd/daos_agent/mgmt_rpc.go
@@ -8,6 +8,7 @@ package main
 
 import (
 	"net"
+	"sync"
 	"time"
 
 	"github.com/pkg/errors"
@@ -27,6 +28,8 @@ import (
 // Management Service proxy, handling dRPCs sent by libdaos by forwarding them
 // to MS.
 type mgmtModule struct {
+	attachInfoMutex sync.RWMutex
+
 	log            logging.Logger
 	sys            string
 	ctlInvoker     control.Invoker
@@ -200,6 +203,9 @@ func (mod *mgmtModule) getAttachInfoRemote(ctx context.Context, numaNode int, sy
 }
 
 func (mod *mgmtModule) getFabricInterface(ctx context.Context, numaNode int, netDevClass hardware.NetDevClass, provider string) (*FabricInterface, error) {
+	mod.attachInfoMutex.Lock()
+	defer mod.attachInfoMutex.Unlock()
+
 	if mod.fabricInfo.IsCached() {
 		return mod.fabricInfo.GetDevice(numaNode, netDevClass, provider)
 	}

--- a/src/control/cmd/daos_agent/mgmt_rpc_test.go
+++ b/src/control/cmd/daos_agent/mgmt_rpc_test.go
@@ -8,6 +8,7 @@ package main
 
 import (
 	"context"
+	"net"
 	"sync"
 	"testing"
 
@@ -248,6 +249,117 @@ func TestAgent_mgmtModule_getNUMANode(t *testing.T) {
 
 			common.AssertEqual(t, tc.expResult, result, "")
 			common.CmpErr(t, tc.expErr, err)
+		})
+	}
+}
+
+func TestAgent_mgmtModule_waitFabricReady(t *testing.T) {
+	defaultNetIfaceFn := func() ([]net.Interface, error) {
+		return []net.Interface{
+			{Name: "t0"},
+			{Name: "t1"},
+			{Name: "t2"},
+		}, nil
+	}
+
+	defaultDevClassProv := &hardware.MockNetDevClassProvider{
+		GetNetDevClassReturn: []hardware.MockGetNetDevClassResult{
+			{
+				ExpInput: "t0",
+				NDC:      hardware.Infiniband,
+			},
+			{
+				ExpInput: "t1",
+				NDC:      hardware.Infiniband,
+			},
+			{
+				ExpInput: "t2",
+				NDC:      hardware.Ether,
+			},
+		},
+	}
+
+	for name, tc := range map[string]struct {
+		netIfacesFn  func() ([]net.Interface, error)
+		devClassProv *hardware.MockNetDevClassProvider
+		devStateProv *hardware.MockNetDevStateProvider
+		netDevClass  hardware.NetDevClass
+		expErr       error
+		expChecked   []string
+	}{
+		"netIfaces fails": {
+			netIfacesFn: func() ([]net.Interface, error) {
+				return nil, errors.New("mock netIfaces")
+			},
+			netDevClass: hardware.Infiniband,
+			expErr:      errors.New("mock netIfaces"),
+		},
+		"GetNetDevClass fails": {
+			devClassProv: &hardware.MockNetDevClassProvider{
+				GetNetDevClassReturn: []hardware.MockGetNetDevClassResult{
+					{
+						ExpInput: "t0",
+						Err:      errors.New("mock GetNetDevClass"),
+					},
+				},
+			},
+			netDevClass: hardware.Infiniband,
+			expErr:      errors.New("mock GetNetDevClass"),
+		},
+		"GetNetDevState fails": {
+			devStateProv: &hardware.MockNetDevStateProvider{
+				GetStateReturn: []hardware.MockNetDevStateResult{
+					{Err: errors.New("mock NetDevStateProvider")},
+				},
+			},
+			netDevClass: hardware.Infiniband,
+			expErr:      errors.New("mock NetDevStateProvider"),
+			expChecked:  []string{"t0"},
+		},
+		"down devices are ignored": {
+			devStateProv: &hardware.MockNetDevStateProvider{
+				GetStateReturn: []hardware.MockNetDevStateResult{
+					{State: hardware.NetDevStateDown},
+					{State: hardware.NetDevStateReady},
+				},
+			},
+			netDevClass: hardware.Infiniband,
+			expChecked:  []string{"t0", "t1"},
+		},
+		"success": {
+			netDevClass: hardware.Infiniband,
+			expChecked:  []string{"t0", "t1"},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			log, buf := logging.NewTestLogger(t.Name())
+			defer common.ShowBufferOnFailure(t, buf)
+
+			if tc.netIfacesFn == nil {
+				tc.netIfacesFn = defaultNetIfaceFn
+			}
+
+			if tc.devClassProv == nil {
+				tc.devClassProv = defaultDevClassProv
+			}
+
+			if tc.devStateProv == nil {
+				tc.devStateProv = &hardware.MockNetDevStateProvider{}
+			}
+
+			mod := &mgmtModule{
+				log:            log,
+				netIfaces:      tc.netIfacesFn,
+				devClassGetter: tc.devClassProv,
+				devStateGetter: tc.devStateProv,
+			}
+
+			err := mod.waitFabricReady(context.Background(), tc.netDevClass)
+
+			common.CmpErr(t, tc.expErr, err)
+			if diff := cmp.Diff(tc.expChecked, tc.devStateProv.GetStateCalled); diff != "" {
+				t.Fatalf("-want, +got:\n%s", diff)
+			}
 		})
 	}
 }

--- a/src/control/cmd/daos_agent/start.go
+++ b/src/control/cmd/daos_agent/start.go
@@ -75,13 +75,16 @@ func (cmd *startCmd) Execute(_ []string) error {
 
 	drpcServer.RegisterRPCModule(NewSecurityModule(cmd.Logger, cmd.cfg.TransportConfig))
 	drpcServer.RegisterRPCModule(&mgmtModule{
-		log:        cmd.Logger,
-		sys:        cmd.cfg.SystemName,
-		ctlInvoker: cmd.ctlInvoker,
-		attachInfo: newAttachInfoCache(cmd.Logger, aicEnabled),
-		fabricInfo: fabricCache,
-		numaGetter: hwprov.DefaultProcessNUMAProvider(cmd.Logger),
-		monitor:    procmon,
+		log:            cmd.Logger,
+		sys:            cmd.cfg.SystemName,
+		ctlInvoker:     cmd.ctlInvoker,
+		attachInfo:     newAttachInfoCache(cmd.Logger, aicEnabled),
+		fabricInfo:     fabricCache,
+		numaGetter:     hwprov.DefaultProcessNUMAProvider(cmd.Logger),
+		fabricScanner:  hwprov.DefaultFabricScanner(cmd.Logger),
+		devClassGetter: hwprov.DefaultNetDevClassProvider(cmd.Logger),
+		devStateGetter: hwprov.DefaultNetDevStateProvider(cmd.Logger),
+		monitor:        procmon,
 	})
 
 	// Cache hwloc data in context on startup, since it'll be used extensively at runtime.

--- a/src/control/common/collection_utils.go
+++ b/src/control/common/collection_utils.go
@@ -189,18 +189,9 @@ func ParseNumberList(stringList string, output interface{}) error {
 // DedupeStringSlice is responsible for returning a slice based on
 // the input with any duplicates removed.
 func DedupeStringSlice(in []string) []string {
-	keys := make(map[string]struct{})
+	set := NewStringSet(in...)
 
-	for _, el := range in {
-		keys[el] = struct{}{}
-	}
-
-	out := make([]string, 0, len(keys))
-	for key := range keys {
-		out = append(out, key)
-	}
-
-	return out
+	return set.ToSlice()
 }
 
 // StringSliceHasDuplicates checks whether there are duplicate strings in the

--- a/src/control/lib/hardware/errors.go
+++ b/src/control/lib/hardware/errors.go
@@ -1,0 +1,62 @@
+//
+// (C) Copyright 2022 Intel Corporation.
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+
+package hardware
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+)
+
+// ErrNoNUMANodes indicates that the system can't detect any NUMA nodes.
+var ErrNoNUMANodes = errors.New("no NUMA nodes detected")
+
+// IsUnsupportedFabric returns true if the supplied error is
+// an instance of errUnsupportedFabric.
+func IsUnsupportedFabric(err error) bool {
+	_, ok := errors.Cause(err).(*errUnsupportedFabric)
+	return ok
+}
+
+type errUnsupportedFabric struct {
+	provider string
+}
+
+func (euf *errUnsupportedFabric) Error() string {
+	return fmt.Sprintf("fabric provider %q not supported", euf.provider)
+}
+
+// ErrUnsupportedFabric returns an error indicating that the denoted
+// fabric provider is not supported by this build/platform.
+func ErrUnsupportedFabric(provider string) error {
+	return &errUnsupportedFabric{provider: provider}
+}
+
+// IsProviderNotOnDevice indicates whether the error is an instance of
+// errProviderNotOnDevice.
+func IsProviderNotOnDevice(err error) bool {
+	_, ok := errors.Cause(err).(*errProviderNotOnDevice)
+	return ok
+}
+
+type errProviderNotOnDevice struct {
+	provider string
+	device   string
+}
+
+func (e *errProviderNotOnDevice) Error() string {
+	return fmt.Sprintf("fabric provider %q not supported on network device %q", e.provider, e.device)
+}
+
+// ErrProviderNotOnDevice returns an error indicated that the fabric provider
+// is not available on the given network device.
+func ErrProviderNotOnDevice(provider, dev string) error {
+	return &errProviderNotOnDevice{
+		provider: provider,
+		device:   dev,
+	}
+}

--- a/src/control/lib/hardware/errors_test.go
+++ b/src/control/lib/hardware/errors_test.go
@@ -1,0 +1,54 @@
+//
+// (C) Copyright 2022 Intel Corporation.
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+
+package hardware
+
+import (
+	"testing"
+
+	"github.com/daos-stack/daos/src/control/common"
+	"github.com/pkg/errors"
+)
+
+func TestHardware_IsUnsupportedFabric(t *testing.T) {
+	for name, tc := range map[string]struct {
+		err       error
+		expResult bool
+	}{
+		"nil": {},
+		"true": {
+			err:       ErrUnsupportedFabric("dontcare"),
+			expResult: true,
+		},
+		"false": {
+			err: errors.New("something else"),
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			common.AssertEqual(t, tc.expResult, IsUnsupportedFabric(tc.err), "")
+		})
+	}
+}
+
+func TestHardware_IsProviderNotOnDevice(t *testing.T) {
+	for name, tc := range map[string]struct {
+		err       error
+		expResult bool
+	}{
+		"nil": {},
+		"true": {
+			err:       ErrProviderNotOnDevice("dontcare", "dontcare"),
+			expResult: true,
+		},
+		"false": {
+			err: errors.New("something else"),
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			common.AssertEqual(t, tc.expResult, IsProviderNotOnDevice(tc.err), "")
+		})
+	}
+}

--- a/src/control/lib/hardware/fabric_test.go
+++ b/src/control/lib/hardware/fabric_test.go
@@ -19,66 +19,6 @@ import (
 	"github.com/daos-stack/daos/src/control/logging"
 )
 
-func TestHardware_IsUnsupportedFabric(t *testing.T) {
-	for name, tc := range map[string]struct {
-		err       error
-		expResult bool
-	}{
-		"nil": {},
-		"true": {
-			err:       ErrUnsupportedFabric("dontcare"),
-			expResult: true,
-		},
-		"false": {
-			err: errors.New("something else"),
-		},
-	} {
-		t.Run(name, func(t *testing.T) {
-			common.AssertEqual(t, tc.expResult, IsUnsupportedFabric(tc.err), "")
-		})
-	}
-}
-
-func TestHardware_IsFabricNotReady(t *testing.T) {
-	for name, tc := range map[string]struct {
-		err       error
-		expResult bool
-	}{
-		"nil": {},
-		"true": {
-			err:       ErrFabricNotReady("dontcare"),
-			expResult: true,
-		},
-		"false": {
-			err: errors.New("something else"),
-		},
-	} {
-		t.Run(name, func(t *testing.T) {
-			common.AssertEqual(t, tc.expResult, IsFabricNotReady(tc.err), "")
-		})
-	}
-}
-
-func TestHardware_IsProviderNotOnDevice(t *testing.T) {
-	for name, tc := range map[string]struct {
-		err       error
-		expResult bool
-	}{
-		"nil": {},
-		"true": {
-			err:       ErrProviderNotOnDevice("dontcare", "dontcare"),
-			expResult: true,
-		},
-		"false": {
-			err: errors.New("something else"),
-		},
-	} {
-		t.Run(name, func(t *testing.T) {
-			common.AssertEqual(t, tc.expResult, IsProviderNotOnDevice(tc.err), "")
-		})
-	}
-}
-
 func TestHardware_FabricInterface_String(t *testing.T) {
 	for name, tc := range map[string]struct {
 		fi        *FabricInterface
@@ -2019,89 +1959,126 @@ func TestHardware_NetDevClassBuilder_BuildPart(t *testing.T) {
 
 func TestHardware_WaitFabricReady(t *testing.T) {
 	for name, tc := range map[string]struct {
-		checker *mockFabricReadyChecker
-		ifaces  []string
-		timeout time.Duration
-		expErr  error
+		stateProv      *MockNetDevStateProvider
+		ifaces         []string
+		ignoreUnusable bool
+		timeout        time.Duration
+		expErr         error
 	}{
 		"nil checker": {
 			ifaces: []string{"fi0"},
 			expErr: errors.New("nil"),
 		},
 		"no interfaces": {
-			checker: &mockFabricReadyChecker{},
-			expErr:  errors.New("no fabric interfaces"),
+			stateProv: &MockNetDevStateProvider{},
+			expErr:    errors.New("no fabric interfaces"),
 		},
 		"instant success": {
-			checker: &mockFabricReadyChecker{},
-			ifaces:  []string{"fi0"},
+			stateProv: &MockNetDevStateProvider{},
+			ifaces:    []string{"fi0"},
 		},
 		"instant failure": {
-			checker: &mockFabricReadyChecker{
-				isReadyErr: []error{errors.New("mock CheckFabricReady")},
+			stateProv: &MockNetDevStateProvider{
+				GetStateReturn: []MockNetDevStateResult{
+					{Err: errors.New("mock GetNetDevState")},
+				},
 			},
 			ifaces: []string{"fi0"},
-			expErr: errors.New("mock CheckFabricReady"),
+			expErr: errors.New("mock GetNetDevState"),
 		},
 		"success after tries": {
-			checker: &mockFabricReadyChecker{
-				isReadyErr: []error{
-					ErrFabricNotReady("fi0"),
-					ErrFabricNotReady("fi0"),
-					ErrFabricNotReady("fi0"),
-					nil,
+			stateProv: &MockNetDevStateProvider{
+				GetStateReturn: []MockNetDevStateResult{
+					{State: NetDevStateNotReady},
+					{State: NetDevStateNotReady},
+					{State: NetDevStateReady},
 				},
 			},
 			ifaces: []string{"fi0"},
 		},
 		"failure after tries": {
-			checker: &mockFabricReadyChecker{
-				isReadyErr: []error{
-					ErrFabricNotReady("fi0"),
-					ErrFabricNotReady("fi0"),
-					errors.New("mock CheckFabricReady"),
+			stateProv: &MockNetDevStateProvider{
+				GetStateReturn: []MockNetDevStateResult{
+					{State: NetDevStateNotReady},
+					{State: NetDevStateNotReady},
+					{Err: errors.New("mock GetNetDevState")},
 				},
 			},
 			ifaces: []string{"fi0"},
-			expErr: errors.New("mock CheckFabricReady"),
+			expErr: errors.New("mock GetNetDevState"),
 		},
 		"multi iface with failure": {
-			checker: &mockFabricReadyChecker{
-				isReadyErr: []error{
-					ErrFabricNotReady("fi0"),
-					ErrFabricNotReady("fi1"),
-					nil,
-					errors.New("mock CheckFabricReady"),
+			stateProv: &MockNetDevStateProvider{
+				GetStateReturn: []MockNetDevStateResult{
+					{State: NetDevStateNotReady},
+					{State: NetDevStateNotReady},
+					{State: NetDevStateReady},
+					{Err: errors.New("mock GetNetDevState")},
 				},
 			},
 			ifaces: []string{"fi0", "fi1"},
-			expErr: errors.New("mock CheckFabricReady"),
+			expErr: errors.New("mock GetNetDevState"),
 		},
 		"multi iface success": {
-			checker: &mockFabricReadyChecker{
-				isReadyErr: []error{
-					ErrFabricNotReady("fi0"),
-					ErrFabricNotReady("fi1"),
-					nil,
-					ErrFabricNotReady("fi1"),
-					nil,
+			stateProv: &MockNetDevStateProvider{
+				GetStateReturn: []MockNetDevStateResult{
+					{State: NetDevStateNotReady},
+					{State: NetDevStateNotReady},
+					{State: NetDevStateReady},
+					{State: NetDevStateNotReady},
+					{State: NetDevStateReady},
 				},
 			},
 			ifaces: []string{"fi0", "fi1"},
 		},
 		"duplicates": {
-			checker: &mockFabricReadyChecker{},
-			ifaces:  []string{"fi0", "fi0"},
+			stateProv: &MockNetDevStateProvider{},
+			ifaces:    []string{"fi0", "fi0"},
 		},
 		"timeout": {
-			checker: &mockFabricReadyChecker{
-				isReadyErr: []error{
-					ErrFabricNotReady("fi0"),
+			stateProv: &MockNetDevStateProvider{
+				GetStateReturn: []MockNetDevStateResult{
+					{State: NetDevStateNotReady},
 				},
 			},
 			timeout: time.Millisecond,
 			ifaces:  []string{"fi0"},
 			expErr:  errors.New("context deadline"),
+		},
+		"requested interface unusable": {
+			stateProv: &MockNetDevStateProvider{
+				GetStateReturn: []MockNetDevStateResult{
+					{State: NetDevStateNotReady},
+					{State: NetDevStateDown},
+				},
+			},
+			ifaces: []string{"fi0", "fi1"},
+			expErr: errors.New("unusable"),
+		},
+		"ignore unusable": {
+			stateProv: &MockNetDevStateProvider{
+				GetStateReturn: []MockNetDevStateResult{
+					{State: NetDevStateNotReady},
+					{State: NetDevStateDown},
+					{State: NetDevStateUnknown},
+					{State: NetDevStateReady},
+					{State: NetDevStateDown},
+					{State: NetDevStateUnknown},
+				},
+			},
+			ignoreUnusable: true,
+			ifaces:         []string{"fi0", "fi1", "fi2"},
+		},
+		"all unusable": {
+			stateProv: &MockNetDevStateProvider{
+				GetStateReturn: []MockNetDevStateResult{
+					{State: NetDevStateDown},
+					{State: NetDevStateUnknown},
+				},
+			},
+			ignoreUnusable: true,
+			ifaces:         []string{"fi0", "fi1"},
+			expErr:         errors.New("no usable fabric interfaces"),
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
@@ -2119,8 +2096,9 @@ func TestHardware_WaitFabricReady(t *testing.T) {
 			}
 
 			err := WaitFabricReady(ctx, log, WaitFabricReadyParams{
-				Checker:      tc.checker,
-				FabricIfaces: tc.ifaces,
+				StateProvider:  tc.stateProv,
+				FabricIfaces:   tc.ifaces,
+				IgnoreUnusable: tc.ignoreUnusable,
 			})
 
 			common.CmpErr(t, tc.expErr, err)

--- a/src/control/lib/hardware/hwprov/defaults.go
+++ b/src/control/lib/hardware/hwprov/defaults.go
@@ -69,8 +69,8 @@ func DefaultFabricScanner(log logging.Logger) *hardware.FabricScanner {
 	return fs
 }
 
-// DefaultFabricReadyChecker gets the default provider for fabric readiness checking.
-func DefaultFabricReadyChecker(log logging.Logger) hardware.FabricReadyChecker {
+// DefaultNetDevStateProvider gets the default provider for getting the fabric interface state.
+func DefaultNetDevStateProvider(log logging.Logger) hardware.NetDevStateProvider {
 	return sysfs.NewProvider(log)
 }
 

--- a/src/control/lib/hardware/hwprov/defaults_test.go
+++ b/src/control/lib/hardware/hwprov/defaults_test.go
@@ -156,11 +156,11 @@ func TestHwprov_DefaultFabricScanner(t *testing.T) {
 	}
 }
 
-func TestHwprov_DefaultFabricReadyChecker(t *testing.T) {
+func TestHwprov_DefaultNetDevStateProvider(t *testing.T) {
 	log, buf := logging.NewTestLogger(t.Name())
 	defer common.ShowBufferOnFailure(t, buf)
 
-	result := DefaultFabricReadyChecker(log)
+	result := DefaultNetDevStateProvider(log)
 
 	if diff := cmp.Diff(sysfs.NewProvider(log), result,
 		cmpopts.IgnoreUnexported(sysfs.Provider{}),

--- a/src/control/lib/hardware/mocks.go
+++ b/src/control/lib/hardware/mocks.go
@@ -154,20 +154,28 @@ func (m *mockFabricInterfaceSetBuilder) BuildPart(_ context.Context, _ *FabricIn
 	return m.buildPartReturn
 }
 
-type mockFabricReadyChecker struct {
-	isReadyCount int
-	isReadyErr   []error
+// MockNetDevStateResult is a structure for injecting results into MockNetDevStateProvider.
+type MockNetDevStateResult struct {
+	State NetDevState
+	Err   error
 }
 
-func (m *mockFabricReadyChecker) CheckFabricReady(iface string) error {
-	if len(m.isReadyErr) == 0 {
-		return nil
+// MockNetDevStateProvider is a fake NetDevStateProvider for testing.
+type MockNetDevStateProvider struct {
+	GetStateReturn []MockNetDevStateResult
+	GetStateCalled []string
+}
+
+func (m *MockNetDevStateProvider) GetNetDevState(iface string) (NetDevState, error) {
+	m.GetStateCalled = append(m.GetStateCalled, iface)
+
+	if len(m.GetStateReturn) == 0 {
+		return NetDevStateReady, nil
 	}
 
-	idx := m.isReadyCount
-	if idx >= len(m.isReadyErr) {
-		idx = len(m.isReadyErr) - 1
+	idx := len(m.GetStateCalled) - 1
+	if idx >= len(m.GetStateReturn) {
+		idx = len(m.GetStateReturn) - 1
 	}
-	m.isReadyCount++
-	return m.isReadyErr[idx]
+	return m.GetStateReturn[idx].State, m.GetStateReturn[idx].Err
 }

--- a/src/control/lib/hardware/sysfs/provider.go
+++ b/src/control/lib/hardware/sysfs/provider.go
@@ -24,10 +24,6 @@ import (
 
 var netSubsystems = []string{"cxi", "infiniband", "net"}
 
-// ibPortActiveState is the enum used to represent the "active" state for an infiniband port in
-// sysfs.
-const ibPortActiveState = 4
-
 func isNetwork(subsystem string) bool {
 	for _, netSubsystem := range netSubsystems {
 		if subsystem == netSubsystem {
@@ -246,63 +242,150 @@ func (s *Provider) getCXIFabricInterfaces() ([]*hardware.FabricInterface, error)
 	return cxiFIs, nil
 }
 
-// CheckFabricReady inspects the fabric interface to determine whether it is fully initialized
-// and ready for use.
-func (s *Provider) CheckFabricReady(iface string) error {
+// GetNetDevState fetches the state of a network interface.
+func (s *Provider) GetNetDevState(iface string) (hardware.NetDevState, error) {
 	if s == nil {
-		return errors.New("sysfs provider is nil")
+		return hardware.NetDevStateUnknown, errors.New("sysfs provider is nil")
 	}
 
 	if iface == "" {
-		return errors.New("fabric interface name is required")
+		return hardware.NetDevStateUnknown, errors.New("fabric interface name is required")
 	}
 
 	devClass, err := s.GetNetDevClass(iface)
 	if err != nil {
-		return errors.Wrapf(err, "can't determine device class for %q", iface)
+		return hardware.NetDevStateUnknown, errors.Wrapf(err, "can't determine device class for %q", iface)
 	}
 
-	if devClass != hardware.Infiniband {
-		// Infiniband is the only type we need to actively check
-		return nil
+	if devClass == hardware.Infiniband {
+		return s.getInfinibandDevState(iface)
 	}
 
+	return s.getNetOperState(iface)
+}
+
+func (s *Provider) getNetOperState(iface string) (hardware.NetDevState, error) {
+	statePath := s.sysPath("class", "net", iface, "operstate")
+	stateBytes, err := ioutil.ReadFile(statePath)
+	if err != nil {
+		return hardware.NetDevStateUnknown, errors.Wrapf(err, "failed to get %q operational state", iface)
+	}
+
+	stateStr := strings.TrimSpace(string(stateBytes))
+
+	// Operational states as described in kernel docs:
+	// https://www.kernel.org/doc/html/latest/networking/operstates.html#tlv-ifla-operstate
+	state := hardware.NetDevStateUnknown
+	switch stateStr {
+	case "up":
+		state = hardware.NetDevStateReady
+	case "down", "lowerlayerdown", "notpresent":
+		// down: Interface is unable to transfer data on L1, f.e. ethernet is not plugged or
+		//       interface is ADMIN down.
+		// lowerlayerdown: Interfaces stacked on an interface that is down (f.e. VLAN).
+		// notpresent: Interface is physically not present. Typically the kernel hides them
+		//             but the status is included in code.
+		state = hardware.NetDevStateDown
+	case "testing", "dormant":
+		// testing: Interface is in testing mode, for example executing driver self-tests or
+		//          media (cable) test. It can’t be used for normal traffic until tests complete.
+		// dormant: Interface is L1 up, but waiting for an external event, f.e. for a protocol
+		//          to establish. (802.1X)
+		state = hardware.NetDevStateNotReady
+	default:
+		state = hardware.NetDevStateUnknown
+	}
+	return state, nil
+}
+
+func (s *Provider) getInfinibandDevState(iface string) (hardware.NetDevState, error) {
 	// The best way to determine that an Infiniband interface is ready is to check the state
 	// of its ports. Ports in the "ACTIVE" state are either fully ready or will be very soon.
 	ibPath := s.sysPath("class", "net", iface, "device", "infiniband")
 	ibDevs, err := ioutil.ReadDir(ibPath)
 	if err != nil {
-		return errors.Wrapf(err, "can't access Infiniband details for %q", iface)
+		return hardware.NetDevStateUnknown, errors.Wrapf(err, "can't access Infiniband details for %q", iface)
 	}
 
+	ibDevState := make([]hardware.NetDevState, 0)
 	for _, dev := range ibDevs {
 		portPath := filepath.Join(ibPath, dev.Name(), "ports")
 		ports, err := ioutil.ReadDir(portPath)
 		if err != nil {
-			return errors.Wrapf(err, "unable to get ports for %s/%s", iface, dev.Name())
+			return hardware.NetDevStateUnknown, errors.Wrapf(err, "unable to get ports for %s/%s", iface, dev.Name())
 		}
 
+		portState := make([]hardware.NetDevState, 0)
 		for _, port := range ports {
 			statePath := filepath.Join(portPath, port.Name(), "state")
 			stateBytes, err := ioutil.ReadFile(statePath)
 			if err != nil {
-				return errors.Wrapf(err, "unable to get state for %s/%s port %s",
+				return hardware.NetDevStateUnknown, errors.Wrapf(err, "unable to get state for %s/%s port %s",
 					iface, dev.Name(), port.Name())
 			}
 
-			stateStrs := strings.Split(string(stateBytes), ": ")
-			stateNum, err := strconv.Atoi(stateStrs[0])
-			if err != nil {
-				s.log.Debugf("unable to parse %s/%s port %s state %q: %s",
-					iface, dev.Name(), port.Name(), string(stateBytes), err.Error())
-				continue
+			portState = append(portState, s.ibStateToNetDevState(string(stateBytes)))
+		}
+
+		ibDevState = append(ibDevState, condenseNetDevState(portState))
+	}
+
+	return condenseNetDevState(ibDevState), nil
+}
+
+// Infiniband state enum is derived from ibstat:
+// https://github.com/linux-rdma/rdma-core/blob/master/infiniband-diags/ibstat.c
+const (
+	ibStateUnknown = 0
+	ibStateDown    = 1
+	ibStateInit    = 2
+	ibStateArmed   = 3
+	ibStateActive  = 4
+)
+
+func (s *Provider) ibStateToNetDevState(stateStr string) hardware.NetDevState {
+	stateSubstrs := strings.Split(string(stateStr), ": ")
+	stateNum, err := strconv.Atoi(stateSubstrs[0])
+	if err != nil {
+		s.log.Debugf("unable to parse IB state %q: %s", stateStr, err.Error())
+		return hardware.NetDevStateUnknown
+	}
+
+	switch stateNum {
+	case ibStateDown:
+		return hardware.NetDevStateDown
+	case ibStateActive:
+		return hardware.NetDevStateReady
+	case ibStateArmed, ibStateInit:
+		return hardware.NetDevStateNotReady
+	default:
+		return hardware.NetDevStateUnknown
+	}
+}
+
+// condenseNetDevState uses a set of states to determine an overall state.
+func condenseNetDevState(states []hardware.NetDevState) hardware.NetDevState {
+	condensed := hardware.NetDevStateUnknown
+	for _, state := range states {
+		switch state {
+		case hardware.NetDevStateReady:
+			// Device is overall ready if:
+			// - at least one port is ready
+			// - no ports are not ready
+			if condensed != hardware.NetDevStateNotReady {
+				condensed = hardware.NetDevStateReady
 			}
-			if stateNum == ibPortActiveState {
-				// At least one IB port is active on the interface
-				return nil
+		case hardware.NetDevStateDown:
+			// Device is overall down if all ports are down. If any port is in any other
+			// state, the device cannot be considered down.
+			if condensed == hardware.NetDevStateUnknown {
+				condensed = hardware.NetDevStateDown
 			}
+		case hardware.NetDevStateNotReady:
+			// Device is not ready if any port is not ready.
+			condensed = hardware.NetDevStateNotReady
 		}
 	}
 
-	return hardware.ErrFabricNotReady(iface)
+	return condensed
 }

--- a/src/control/lib/hardware/sysfs/provider.go
+++ b/src/control/lib/hardware/sysfs/provider.go
@@ -287,7 +287,7 @@ func (s *Provider) getNetOperState(iface string) (hardware.NetDevState, error) {
 		return hardware.NetDevStateUnknown, errors.Wrapf(err, "failed to get %q operational state", iface)
 	}
 
-	stateStr := strings.TrimSpace(string(stateBytes))
+	stateStr := strings.ToLower(strings.TrimSpace(string(stateBytes)))
 
 	// Operational states as described in kernel docs:
 	// https://www.kernel.org/doc/html/latest/networking/operstates.html#tlv-ifla-operstate

--- a/src/control/lib/hardware/sysfs/provider_test.go
+++ b/src/control/lib/hardware/sysfs/provider_test.go
@@ -748,6 +748,17 @@ func TestSysfs_Provider_GetNetDevState(t *testing.T) {
 			iface:    "net0",
 			expState: hardware.NetDevStateUnknown,
 		},
+		"net operstate case-insensitive": {
+			setup: func(t *testing.T, root string) {
+				setupNet(t, root)
+				setupTestNetDevOperStates(t, root, map[string]string{
+					"net0": "UP",
+				})
+			},
+			p:        &Provider{},
+			iface:    "net0",
+			expState: hardware.NetDevStateReady,
+		},
 		"loopback unknown is ready": {
 			setup: func(t *testing.T, root string) {
 				setupNet(t, root)

--- a/src/control/lib/hardware/sysfs/provider_test.go
+++ b/src/control/lib/hardware/sysfs/provider_test.go
@@ -56,6 +56,26 @@ func setupTestNetDevClasses(t *testing.T, root string, devClasses map[string]uin
 	}
 }
 
+func setupTestNetDevOperStates(t *testing.T, root string, devStates map[string]string) {
+	t.Helper()
+
+	for dev, state := range devStates {
+		path := filepath.Join(root, "class", "net", dev)
+		os.MkdirAll(path, 0755)
+
+		f, err := os.Create(filepath.Join(path, "operstate"))
+		if err != nil {
+			t.Fatal(err.Error())
+		}
+
+		_, err = f.WriteString(fmt.Sprintf("%s\n", state))
+		f.Close()
+		if err != nil {
+			t.Fatal(err.Error())
+		}
+	}
+}
+
 func TestSysfs_Provider_GetNetDevClass(t *testing.T) {
 	testDir, cleanupTestDir := common.CreateTestDir(t)
 	defer cleanupTestDir()
@@ -562,7 +582,7 @@ func TestSysfs_Provider_GetFabricInterfaces(t *testing.T) {
 	}
 }
 
-func TestSysfs_Provider_CheckFabricReady(t *testing.T) {
+func TestSysfs_Provider_GetNetDevState(t *testing.T) {
 	setupNet := func(t *testing.T, root string) {
 		t.Helper()
 
@@ -623,10 +643,11 @@ func TestSysfs_Provider_CheckFabricReady(t *testing.T) {
 	}
 
 	for name, tc := range map[string]struct {
-		setup  func(*testing.T, string)
-		p      *Provider
-		iface  string
-		expErr error
+		setup    func(*testing.T, string)
+		p        *Provider
+		iface    string
+		expState hardware.NetDevState
+		expErr   error
 	}{
 		"nil": {
 			iface:  "ib0",
@@ -641,10 +662,90 @@ func TestSysfs_Provider_CheckFabricReady(t *testing.T) {
 			iface:  "fake",
 			expErr: errors.New("can't determine device class"),
 		},
-		"not infiniband": {
-			setup: setupNet,
-			p:     &Provider{},
-			iface: "net0",
+		"net no operstate": {
+			setup: func(t *testing.T, root string) {
+				setupNet(t, root)
+			},
+			p:      &Provider{},
+			iface:  "net0",
+			expErr: errors.New("failed to get \"net0\" operational state"),
+		},
+		"net ready": {
+			setup: func(t *testing.T, root string) {
+				setupNet(t, root)
+				setupTestNetDevOperStates(t, root, map[string]string{
+					"net0": "up",
+				})
+			},
+			p:        &Provider{},
+			iface:    "net0",
+			expState: hardware.NetDevStateReady,
+		},
+		"net down": {
+			setup: func(t *testing.T, root string) {
+				setupNet(t, root)
+				setupTestNetDevOperStates(t, root, map[string]string{
+					"net0": "down",
+				})
+			},
+			p:        &Provider{},
+			iface:    "net0",
+			expState: hardware.NetDevStateDown,
+		},
+		"net lowerlayerdown": {
+			setup: func(t *testing.T, root string) {
+				setupNet(t, root)
+				setupTestNetDevOperStates(t, root, map[string]string{
+					"net0": "lowerlayerdown",
+				})
+			},
+			p:        &Provider{},
+			iface:    "net0",
+			expState: hardware.NetDevStateDown,
+		},
+		"net notpresent": {
+			setup: func(t *testing.T, root string) {
+				setupNet(t, root)
+				setupTestNetDevOperStates(t, root, map[string]string{
+					"net0": "notpresent",
+				})
+			},
+			p:        &Provider{},
+			iface:    "net0",
+			expState: hardware.NetDevStateDown,
+		},
+		"net testing": {
+			setup: func(t *testing.T, root string) {
+				setupNet(t, root)
+				setupTestNetDevOperStates(t, root, map[string]string{
+					"net0": "testing",
+				})
+			},
+			p:        &Provider{},
+			iface:    "net0",
+			expState: hardware.NetDevStateNotReady,
+		},
+		"net dormant": {
+			setup: func(t *testing.T, root string) {
+				setupNet(t, root)
+				setupTestNetDevOperStates(t, root, map[string]string{
+					"net0": "dormant",
+				})
+			},
+			p:        &Provider{},
+			iface:    "net0",
+			expState: hardware.NetDevStateNotReady,
+		},
+		"net unknown": {
+			setup: func(t *testing.T, root string) {
+				setupNet(t, root)
+				setupTestNetDevOperStates(t, root, map[string]string{
+					"net0": "unknown",
+				})
+			},
+			p:        &Provider{},
+			iface:    "net0",
+			expState: hardware.NetDevStateUnknown,
 		},
 		"no IB dir": {
 			setup: func(t *testing.T, root string) {
@@ -666,9 +767,9 @@ func TestSysfs_Provider_CheckFabricReady(t *testing.T) {
 					"ib0": uint32(hardware.Infiniband),
 				})
 			},
-			p:      &Provider{},
-			iface:  "ib0",
-			expErr: hardware.ErrFabricNotReady("ib0"),
+			p:        &Provider{},
+			iface:    "ib0",
+			expState: hardware.NetDevStateUnknown,
 		},
 		"no port info": {
 			setup: func(t *testing.T, root string) {
@@ -700,11 +801,11 @@ func TestSysfs_Provider_CheckFabricReady(t *testing.T) {
 					1: "garbage",
 				})
 			},
-			p:      &Provider{},
-			iface:  "ib0",
-			expErr: hardware.ErrFabricNotReady("ib0"),
+			p:        &Provider{},
+			iface:    "ib0",
+			expState: hardware.NetDevStateUnknown,
 		},
-		"port not ready": {
+		"port down": {
 			setup: func(t *testing.T, root string) {
 				t.Helper()
 
@@ -714,22 +815,38 @@ func TestSysfs_Provider_CheckFabricReady(t *testing.T) {
 					1: "1: DOWN",
 				})
 			},
-			p:      &Provider{},
-			iface:  "ib0",
-			expErr: hardware.ErrFabricNotReady("ib0"),
+			p:        &Provider{},
+			iface:    "ib0",
+			expState: hardware.NetDevStateDown,
 		},
-		"success": {
-			p:     &Provider{},
-			iface: "ib0",
+		"port not ready": {
+			setup: func(t *testing.T, root string) {
+				t.Helper()
+
+				ibPath := setupIBDevPath(t, root, "ib0", "mlx0")
+
+				setupIBPorts(t, ibPath, map[int]string{
+					1: "2: INITIALIZING",
+				})
+			},
+			p:        &Provider{},
+			iface:    "ib0",
+			expState: hardware.NetDevStateNotReady,
 		},
-		"all devs not ready": {
+		"ready": {
+			p:        &Provider{},
+			iface:    "ib0",
+			expState: hardware.NetDevStateReady,
+		},
+		"one dev not ready": {
 			setup: func(t *testing.T, root string) {
 				t.Helper()
 
 				for dev, state := range map[string]string{
 					"mlx0_0": "1: DOWN",
 					"mlx0_1": "0: UNKNOWN",
-					"mlx0_2": "2: INITIALIZING",
+					"mlx0_2": "4: ACTIVE",
+					"mlx0_3": "3: ARMED",
 				} {
 					ibPath := setupIBDevPath(t, root, "ib0", dev)
 
@@ -738,11 +855,11 @@ func TestSysfs_Provider_CheckFabricReady(t *testing.T) {
 					})
 				}
 			},
-			p:      &Provider{},
-			iface:  "ib0",
-			expErr: hardware.ErrFabricNotReady("ib0"),
+			p:        &Provider{},
+			iface:    "ib0",
+			expState: hardware.NetDevStateNotReady,
 		},
-		"one of many devs up": {
+		"one IB dev up, others down/unknown": {
 			setup: func(t *testing.T, root string) {
 				t.Helper()
 
@@ -758,27 +875,50 @@ func TestSysfs_Provider_CheckFabricReady(t *testing.T) {
 					})
 				}
 			},
-			p:     &Provider{},
-			iface: "ib0",
+			p:        &Provider{},
+			iface:    "ib0",
+			expState: hardware.NetDevStateReady,
 		},
-		"all ports not ready": {
+		"all IB devs down or unknown": {
 			setup: func(t *testing.T, root string) {
 				t.Helper()
 
-				ibPath := setupIBDevPath(t, root, "ib0", "mlx0")
+				for dev, state := range map[string]string{
+					"mlx0_0": "1: DOWN",
+					"mlx0_1": "0: UNKNOWN",
+					"mlx0_2": "0: UNKNOWN",
+				} {
+					ibPath := setupIBDevPath(t, root, "ib0", dev)
 
-				setupIBPorts(t, ibPath, map[int]string{
-					1: "1: DOWN",
-					2: "0: UNKNOWN",
-					3: "1: DOWN",
-					4: "2: INITIALIZING",
-				})
+					setupIBPorts(t, ibPath, map[int]string{
+						1: state,
+					})
+				}
 			},
-			p:      &Provider{},
-			iface:  "ib0",
-			expErr: hardware.ErrFabricNotReady("ib0"),
+			p:        &Provider{},
+			iface:    "ib0",
+			expState: hardware.NetDevStateDown,
 		},
-		"at least one port up": {
+		"all IB devs unknown": {
+			setup: func(t *testing.T, root string) {
+				t.Helper()
+
+				for dev, state := range map[string]string{
+					"mlx0_1": "0: UNKNOWN",
+					"mlx0_2": "0: UNKNOWN",
+				} {
+					ibPath := setupIBDevPath(t, root, "ib0", dev)
+
+					setupIBPorts(t, ibPath, map[int]string{
+						1: state,
+					})
+				}
+			},
+			p:        &Provider{},
+			iface:    "ib0",
+			expState: hardware.NetDevStateUnknown,
+		},
+		"at least one IB port not ready": {
 			setup: func(t *testing.T, root string) {
 				t.Helper()
 
@@ -791,8 +931,25 @@ func TestSysfs_Provider_CheckFabricReady(t *testing.T) {
 					4: "2: INITIALIZING",
 				})
 			},
-			p:     &Provider{},
-			iface: "ib0",
+			p:        &Provider{},
+			iface:    "ib0",
+			expState: hardware.NetDevStateNotReady,
+		},
+		"one IB port active, others down/unknown": {
+			setup: func(t *testing.T, root string) {
+				t.Helper()
+
+				ibPath := setupIBDevPath(t, root, "ib0", "mlx0")
+
+				setupIBPorts(t, ibPath, map[int]string{
+					1: "1: DOWN",
+					2: "0: UNKNOWN",
+					3: "4: ACTIVE",
+				})
+			},
+			p:        &Provider{},
+			iface:    "ib0",
+			expState: hardware.NetDevStateReady,
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
@@ -814,9 +971,126 @@ func TestSysfs_Provider_CheckFabricReady(t *testing.T) {
 			}
 			tc.setup(t, testDir)
 
-			err := tc.p.CheckFabricReady(tc.iface)
+			state, err := tc.p.GetNetDevState(tc.iface)
 
 			common.CmpErr(t, tc.expErr, err)
+			common.AssertEqual(t, tc.expState, state, "")
+		})
+	}
+}
+
+func TestSysfs_Provider_ibStateToNetDevState(t *testing.T) {
+	for name, tc := range map[string]struct {
+		input     string
+		expResult hardware.NetDevState
+	}{
+		"empty": {
+			expResult: hardware.NetDevStateUnknown,
+		},
+		"garbage": {
+			input:     "trash",
+			expResult: hardware.NetDevStateUnknown,
+		},
+		"unknown": {
+			input:     "0: UNKNOWN",
+			expResult: hardware.NetDevStateUnknown,
+		},
+		"down": {
+			input:     "1: DOWN",
+			expResult: hardware.NetDevStateDown,
+		},
+		"init": {
+			input:     "2: INITIALIZING",
+			expResult: hardware.NetDevStateNotReady,
+		},
+		"armed": {
+			input:     "3: ARMED",
+			expResult: hardware.NetDevStateNotReady,
+		},
+		"active": {
+			input:     "4: ACTIVE",
+			expResult: hardware.NetDevStateReady,
+		},
+		"bad enum": {
+			input:     "1234: something",
+			expResult: hardware.NetDevStateUnknown,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			log, buf := logging.NewTestLogger(name)
+			defer common.ShowBufferOnFailure(t, buf)
+
+			p := &Provider{log: log}
+			result := p.ibStateToNetDevState(tc.input)
+
+			common.AssertEqual(t, tc.expResult, result, "")
+		})
+	}
+}
+
+func TestSysfs_condenseNetDevState(t *testing.T) {
+	for name, tc := range map[string]struct {
+		input     []hardware.NetDevState
+		expResult hardware.NetDevState
+	}{
+		"nil": {
+			expResult: hardware.NetDevStateUnknown,
+		},
+		"empty": {
+			input:     []hardware.NetDevState{},
+			expResult: hardware.NetDevStateUnknown,
+		},
+		"unknown": {
+			input:     []hardware.NetDevState{hardware.NetDevStateUnknown},
+			expResult: hardware.NetDevStateUnknown,
+		},
+		"down": {
+			input:     []hardware.NetDevState{hardware.NetDevStateDown},
+			expResult: hardware.NetDevStateDown,
+		},
+		"not ready": {
+			input:     []hardware.NetDevState{hardware.NetDevStateNotReady},
+			expResult: hardware.NetDevStateNotReady,
+		},
+		"ready": {
+			input:     []hardware.NetDevState{hardware.NetDevStateReady},
+			expResult: hardware.NetDevStateReady,
+		},
+		"down overrides unknown": {
+			input: []hardware.NetDevState{
+				hardware.NetDevStateUnknown,
+				hardware.NetDevStateDown,
+				hardware.NetDevStateUnknown,
+			},
+			expResult: hardware.NetDevStateDown,
+		},
+		"ready overrides down/unknown": {
+			input: []hardware.NetDevState{
+				hardware.NetDevStateUnknown,
+				hardware.NetDevStateDown,
+				hardware.NetDevStateReady,
+				hardware.NetDevStateUnknown,
+				hardware.NetDevStateDown,
+			},
+			expResult: hardware.NetDevStateReady,
+		},
+		"not ready overrides all": {
+			input: []hardware.NetDevState{
+				hardware.NetDevStateUnknown,
+				hardware.NetDevStateDown,
+				hardware.NetDevStateReady,
+				hardware.NetDevStateNotReady,
+				hardware.NetDevStateUnknown,
+				hardware.NetDevStateDown,
+				hardware.NetDevStateReady,
+			},
+			expResult: hardware.NetDevStateNotReady,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			result := condenseNetDevState(tc.input)
+
+			common.AssertEqual(t, tc.expResult, result, "")
 		})
 	}
 }

--- a/src/control/lib/hardware/sysfs/provider_test.go
+++ b/src/control/lib/hardware/sysfs/provider_test.go
@@ -591,6 +591,7 @@ func TestSysfs_Provider_GetNetDevState(t *testing.T) {
 
 		setupTestNetDevClasses(t, root, map[string]uint32{
 			"net0": uint32(hardware.Ether),
+			"lo":   uint32(hardware.Loopback),
 		})
 	}
 
@@ -746,6 +747,17 @@ func TestSysfs_Provider_GetNetDevState(t *testing.T) {
 			p:        &Provider{},
 			iface:    "net0",
 			expState: hardware.NetDevStateUnknown,
+		},
+		"loopback unknown is ready": {
+			setup: func(t *testing.T, root string) {
+				setupNet(t, root)
+				setupTestNetDevOperStates(t, root, map[string]string{
+					"lo": "unknown",
+				})
+			},
+			p:        &Provider{},
+			iface:    "lo",
+			expState: hardware.NetDevStateReady,
 		},
 		"no IB dir": {
 			setup: func(t *testing.T, root string) {

--- a/src/control/lib/hardware/topology.go
+++ b/src/control/lib/hardware/topology.go
@@ -13,9 +13,6 @@ import (
 	"github.com/pkg/errors"
 )
 
-// ErrNoNUMANodes indicates that the system can't detect any NUMA nodes.
-var ErrNoNUMANodes = errors.New("no NUMA nodes detected")
-
 type (
 	// TopologyProvider is an interface for acquiring a system topology.
 	TopologyProvider interface {

--- a/src/control/server/server.go
+++ b/src/control/server/server.go
@@ -438,7 +438,7 @@ func waitFabricReady(ctx context.Context, log logging.Logger, cfg *config.Server
 	}
 
 	if err := hardware.WaitFabricReady(ctx, log, hardware.WaitFabricReadyParams{
-		Checker:        hwprov.DefaultFabricReadyChecker(log),
+		StateProvider:  hwprov.DefaultNetDevStateProvider(log),
 		FabricIfaces:   ifaces,
 		IterationSleep: time.Second,
 	}); err != nil {


### PR DESCRIPTION
The agent must, similar to the server, wait for fabric interfaces
to become ready before performing a full fabric scan. In the agent
we scan as needed, so it won't happen until the client makes a
GetAttachInfo call.

- Add mechanism for agent to check fabric readiness for the relevant
  class of net interfaces for the GetAttachInfo call. This will
  happen only before the fabric scan, which means cached fabric info
  will not require a re-check.
- Refactor hardware.FabricReadyChecker into NetDevStateProvider,
  which fetches the state directly, for the caller to act on.
- Replace sysfs.Provider CheckFabricReady() function with
  GetNetDevState(). This gets the state of ordinary net interfaces
  as well as IB. The logic for multi-device/multi-port configs
  is more sophisticated now: A device is ready only when all ports
  that could become ready are.
- Allow WaitFabricReady() to ignore interfaces that aren't usable
  (i.e. down/disabled or in an unknown state). If not ignored, these
  states cause the function to fail.

Features: control

Signed-off-by: Kris Jacque <kristin.jacque@intel.com>