### PR TITLE
DAOS-10337-test: Cherry pick script fix enospace.py to release_2.2

### DIFF
--- a/src/tests/ftest/nvme/enospace.py
+++ b/src/tests/ftest/nvme/enospace.py
@@ -409,9 +409,9 @@ class NvmeEnospace(ServerFillUp):
             time.sleep(60)
             print(pool_usage)
             #SCM pool size should be released (some still be used for system)
-            #Pool SCM free % should not be less than 50%
-            if pool_usage['scm'] > 55:
-                self.fail('SCM pool used percentage should be < 55, instead {}'.
+            #Pool SCM free % should not be less than 62%
+            if pool_usage['scm'] > 62:
+                self.fail('SCM pool used percentage should be < 62, instead {}'.
                           format(pool_usage['scm']))
 
         #Run last IO


### PR DESCRIPTION
Description: Cherrypick to 2.2 increase SCM size per triage suggestion, 62% is proven stable.

Quick-Functional: true
Test-repeat: 5
Test-tag: der_enospace
Signed-off-by: Ding Ho ding-hwa.ho@intel.com