### PR TITLE
DAOS-10479 test: log more on JSON parsing error in dmg helper

### DIFF
--- a/src/control/cmd/dmg/main.go
+++ b/src/control/cmd/dmg/main.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2018-2021 Intel Corporation.
+// (C) Copyright 2018-2022 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -220,6 +220,7 @@ and access control settings, along with system wide operations.`
 		if opts.Debug {
 			log.WithLogLevel(logging.LogLevelDebug)
 			log.Debug("debug output enabled")
+			os.Stderr.Sync()
 		}
 
 		if opts.JSONLogs {
@@ -241,19 +242,24 @@ and access control settings, along with system wide operations.`
 		ctlCfg, err := control.LoadConfig(opts.ConfigPath)
 		if err != nil {
 			if errors.Cause(err) != control.ErrNoConfigFile {
-				return errors.Wrap(err, "failed to load control configuration")
+					log.Debug("failed to load control configuration")
+					os.Stderr.Sync()
+					return errors.Wrap(err, "failed to load control configuration")
 			}
 			// Use the default config if no config file was found.
 			ctlCfg = control.DefaultConfig()
 		}
 		if ctlCfg.Path != "" {
 			log.Debugf("control config loaded from %s", ctlCfg.Path)
+			os.Stderr.Sync()
 		}
 
 		if opts.Insecure {
 			ctlCfg.TransportConfig.AllowInsecure = true
 		}
 		if err := ctlCfg.TransportConfig.PreLoadCertData(); err != nil {
+			log.Debug("Unable to load Certificate Data")
+			os.Stderr.Sync()
 			return errors.Wrap(err, "Unable to load Certificate Data")
 		}
 
@@ -268,6 +274,8 @@ and access control settings, along with system wide operations.`
 				hlCmd.setHostList(hl)
 				ctlCfg.HostList = hl
 			} else {
+				log.Debug("hostlist parameter not accepted with this command")
+				os.Stderr.Sync()
 				return errors.Errorf("this command does not accept a hostlist parameter (set it in %s or %s)",
 					control.UserConfigPath(), control.SystemConfigPath())
 			}
@@ -279,12 +287,16 @@ and access control settings, along with system wide operations.`
 
 		if argsCmd, ok := cmd.(cmdutil.ArgsHandler); ok {
 			if err := argsCmd.CheckArgs(args); err != nil {
-				return err
+				log.Debug("checkArgs")
+				os.Stderr.Sync()
+				return errors.Wrap(err, "checkArgs")
 			}
 		}
 
 		if err := cmd.Execute(args); err != nil {
-			return err
+			log.Debug("checkArgs")
+			os.Stderr.Sync()
+			return errors.Wrap(err, "cmd.Execute")
 		}
 
 		return nil

--- a/src/control/common/proto/convert/types.go
+++ b/src/control/common/proto/convert/types.go
@@ -1,19 +1,24 @@
 //
-// (C) Copyright 2019-2021 Intel Corporation.
+// (C) Copyright 2019-2022 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
 package convert
 
-import "encoding/json"
-
+import ("encoding/json"
+	"github.com/pkg/errors"
+)
 // Types attempts an automatic conversion between the in/out types
 // using JSON as an intermediate representation.
 func Types(in interface{}, out interface{}) error {
 	data, err := json.Marshal(in)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "Marshal JSON")
 	}
 
-	return json.Unmarshal(data, out)
+	err = json.Unmarshal(data, out)
+	if err != nil {
+		return errors.Wrap(err, "Unmarshal JSON")
+	}
+	return nil
 }

--- a/src/control/lib/control/pool.go
+++ b/src/control/lib/control/pool.go
@@ -255,7 +255,7 @@ func PoolCreate(ctx context.Context, rpcClient UnaryInvoker, req *PoolCreateReq)
 	rpcClient.Debugf("Create DAOS pool request: %+v\n", req)
 	ur, err := rpcClient.InvokeUnaryRPC(ctx, req)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "InvokeUnaryRPC")
 	}
 
 	msResp, err := ur.getMSResponse()
@@ -295,11 +295,13 @@ func PoolDestroy(ctx context.Context, rpcClient UnaryInvoker, req *PoolDestroyRe
 	rpcClient.Debugf("Destroy DAOS pool request: %v\n", req)
 	ur, err := rpcClient.InvokeUnaryRPC(ctx, req)
 	if err != nil {
+		rpcClient.Debugf("error: InvokeUnaryRPC\n")
 		return err
 	}
 
 	msResp, err := ur.getMSResponse()
 	if err != nil {
+		rpcClient.Debugf("error: getMSResponse\n")
 		return errors.Wrap(err, "pool destroy failed")
 	}
 	rpcClient.Debugf("Destroy DAOS pool response: %s\n", msResp)

--- a/src/tests/ftest/util/daos_core_base.py
+++ b/src/tests/ftest/util/daos_core_base.py
@@ -126,7 +126,7 @@ class DaosCoreBase(TestWithServers):
             [
                 "-x", "=".join(["D_LOG_FILE", get_log_file(self.client_log)]),
                 "--map-by node", "-x", "D_LOG_MASK=DEBUG",
-                "-x", "DD_MASK=mgmt,io,md,epc,rebuild",
+                "-x", "DD_MASK=mgmt,io,md,epc,rebuild,test",
                 "-x", "COVFILE=/tmp/test.cov",
                 self.daos_test,
                 "-n", dmg_config_file,


### PR DESCRIPTION
Print the JSON that faled to parse, print the jerr value that may
actually be json_tokener_continue. Also print the jbuf total bytes
calculated by the logic, and the strlen(jbuf) to see if there are
any NULL characters embedded in the JSON.

Wrap more errors that may occur within the dmg command implementation
so that a null pool create response can be accompanied by an error
string in the JSON output. And redirect dmg command stderr to a file
and read it back and print the lines in the event of a command failure.

Quick-Functional: true
Test-tag: test_daos_pool
Test-repeat: 50

Signed-off-by: Kenneth Cain <kenneth.c.cain@intel.com>