### PR TITLE
DAOS-10216 test: remove unecessary soak sudo cmds (#8611)

### DIFF
--- a/src/tests/ftest/slurm_setup.py
+++ b/src/tests/ftest/slurm_setup.py
@@ -57,17 +57,10 @@ def update_config_cmdlist(args):
 
     """
     all_nodes = NodeSet("{},{}".format(str(args.control), str(args.nodes)))
-    cmd_list = [
-        "sed -i -e 's/ClusterName=cluster/ClusterName=ci_cluster/g' {}".format(
-            SLURM_CONF),
-        "sed -i -e 's/SlurmUser=slurm/SlurmUser={}/g' {}".format(
-            args.user, SLURM_CONF),
-        "sed -i -e 's/NodeName/#NodeName/g' {}".format(
-            SLURM_CONF), ]
-    if not args.sudo:
-        sudo = ""
-    else:
-        sudo = "sudo"
+    cmd_list = ["sed -i -e 's/ClusterName=cluster/ClusterName=ci_cluster/g' {}".format(SLURM_CONF),
+                "sed -i -e 's/SlurmUser=slurm/SlurmUser={}/g' {}".format(args.user, SLURM_CONF),
+                "sed -i -e 's/NodeName/#NodeName/g' {}".format(SLURM_CONF)]
+    sudo = "sudo" if args.sudo else ""
     # Copy the slurm*example.conf files to /etc/slurm/
     if execute_cluster_cmds(all_nodes, COPY_LIST, args.sudo) > 0:
         sys.exit(1)
@@ -162,6 +155,7 @@ def start_munge(args):
         args (Namespace): Commandline arguments
 
     """
+    sudo = "sudo" if args.sudo else ""
     all_nodes = NodeSet("{},{}".format(str(args.control), str(args.nodes)))
     # exclude the control node
     nodes = NodeSet(str(args.nodes))
@@ -170,8 +164,8 @@ def start_munge(args):
     # copy key to all nodes FROM slurmctl node;
     # change the protections/ownership on the munge dir on all nodes
     cmd_list = [
-        "sudo chmod -R 777 /etc/munge; sudo chown {}. /etc/munge".format(
-            args.user)]
+        "{0} chmod -R 777 /etc/munge; {0} chown {1}. /etc/munge".format(
+            sudo, args.user)]
     if execute_cluster_cmds(all_nodes, cmd_list) > 0:
         return 1
 
@@ -180,25 +174,25 @@ def start_munge(args):
     cmd_list = ["set -Eeu",
                 "rc=0",
                 "if [ ! -f /etc/munge/munge.key ]",
-                "then sudo create-munge-key",
+                "then {} create-munge-key".format(sudo),
                 "fi",
-                "sudo chmod 777 /etc/munge/munge.key",
-                "sudo chown {}. /etc/munge/munge.key".format(args.user)]
+                "{} chmod 777 /etc/munge/munge.key".format(sudo),
+                "{} chown {}. /etc/munge/munge.key".format(sudo, args.user)]
 
     if execute_cluster_cmds(args.control, ["; ".join(cmd_list)]) > 0:
         return 1
     # remove any existing key from other nodes
-    cmd_list = ["sudo rm -f /etc/munge/munge.key",
+    cmd_list = ["{} rm -f /etc/munge/munge.key".format(sudo),
                 "scp -p {}:/etc/munge/munge.key /etc/munge/munge.key".format(
                     args.control)]
     if execute_cluster_cmds(nodes, ["; ".join(cmd_list)]) > 0:
         return 1
     # set the protection back to defaults
     cmd_list = [
-        "sudo chmod 400 /etc/munge/munge.key",
-        "sudo chown munge. /etc/munge/munge.key",
-        "sudo chmod 700 /etc/munge",
-        "sudo chown munge. /etc/munge"]
+        "{} chmod 400 /etc/munge/munge.key".format(sudo),
+        "{} chown munge. /etc/munge/munge.key".format(sudo),
+        "{} chmod 700 /etc/munge".format(sudo),
+        "{} chown munge. /etc/munge".format(sudo)]
     if execute_cluster_cmds(all_nodes, ["; ".join(cmd_list)]) > 0:
         return 1
 
@@ -216,16 +210,17 @@ def start_slurm(args):
     """
     # Setting up slurm on all nodes
     all_nodes = NodeSet("{},{}".format(str(args.control), str(args.nodes)))
-    cmd_list = ["mkdir -p /var/log/slurm",
-                "chown {}. {}".format(args.user, "/var/log/slurm"),
-                "mkdir -p /var/spool/slurmd",
-                "mkdir -p /var/spool/slurmctld",
-                "mkdir -p /var/spool/slurm/d",
-                "mkdir -p /var/spool/slurm/ctld",
-                "chown {}. {}/ctld".format(args.user, "/var/spool/slurm"),
-                "chown {}. {}".format(args.user, "/var/spool/slurmctld"),
-                "chmod 775 {}".format("/var/spool/slurmctld"),
-                "rm -f /var/spool/slurmctld/clustername"]
+    cmd_list = [
+        "mkdir -p /var/log/slurm",
+        "chown {}. {}".format(args.user, "/var/log/slurm"),
+        "mkdir -p /var/spool/slurmd",
+        "mkdir -p /var/spool/slurmctld",
+        "mkdir -p /var/spool/slurm/d",
+        "mkdir -p /var/spool/slurm/ctld",
+        "chown {}. {}/ctld".format(args.user, "/var/spool/slurm"),
+        "chown {}. {}".format(args.user, "/var/spool/slurmctld"),
+        "chmod 775 {}".format("/var/spool/slurmctld"),
+        "rm -f /var/spool/slurmctld/clustername"]
 
     if execute_cluster_cmds(all_nodes, cmd_list, args.sudo) > 0:
         return 1

--- a/src/tests/ftest/soak/smoke.yaml
+++ b/src/tests/ftest/soak/smoke.yaml
@@ -12,6 +12,7 @@ hosts:
 orterun:
     allow_run_as_root: True
 mpi_module: mpi/mpich-x86_64
+enable_sudo: True
 # This timeout must be longer than the test_timeout param (+15minutes)
 # 24 Min test
 timeout: 30M

--- a/src/tests/ftest/soak/test_base.py
+++ b/src/tests/ftest/soak/test_base.py
@@ -66,6 +66,7 @@ class SoakTestBase(TestWithServers):
         self.initial_resv_file = None
         self.resv_cont = None
         self.mpi_module = None
+        self.sudo_cmd = None
 
     def setUp(self):
         """Define test setup to be done."""
@@ -148,10 +149,10 @@ class SoakTestBase(TestWithServers):
             try:
                 reserved_file_copy(self, final_resv_file, self.pool[0], self.resv_cont)
             except CommandFailure:
-                self.soak_errors.append("<<FAILED: Soak reserved container read failed>>")
+                errors.append("<<FAILED: Soak reserved container read failed>>")
 
             if not cmp(self.initial_resv_file, final_resv_file):
-                self.soak_errors.append("<<FAILED: Data verification error on reserved pool"
+                errors.append("<<FAILED: Data verification error on reserved pool"
                                         " after SOAK completed>>")
 
             for file in [self.initial_resv_file, final_resv_file]:
@@ -162,7 +163,10 @@ class SoakTestBase(TestWithServers):
         # display final metrics
         run_metrics_check(self, prefix="final")
         # Gather server logs
-        get_daos_server_logs(self)
+        try:
+            get_daos_server_logs(self)
+        except SoakTestError as error:
+            errors.append("<<FAILED: Failed to gather server logs {}>>".format(error))
         # Gather journalctl logs
         hosts = list(set(self.hostlist_servers))
         since = time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(self.start_time))
@@ -170,9 +174,13 @@ class SoakTestBase(TestWithServers):
         for journalctl_type in ["kernel", "daos_server"]:
             get_journalctl(self, hosts, since, until, journalctl_type, logging=True)
         # Gather client daos logs with resource manager
-        get_remote_dir(
-            self, self.base_test_dir, self.outputsoak_dir, self.hostlist_clients,
-            shared_dir=self.sharedsoak_dir, rm_remote=False, append="/daos_logs-")
+        try:
+            get_remote_dir(
+                self, self.base_test_dir, self.outputsoak_dir, self.hostlist_clients,
+                shared_dir=self.sharedsoak_dir, rm_remote=False, append="/daos_logs-")
+        except SoakTestError as error:
+            errors.append(
+                "<<FAILED: Failed to copy remote logs - {}>>".format(error))
 
         if self.all_failed_harassers:
             errors.extend(self.all_failed_harassers)
@@ -526,6 +534,7 @@ class SoakTestBase(TestWithServers):
         self.check_errors = []
         self.used = []
         self.mpi_module = self.params.get("mpi_module", "/run/*", default="mpi/mpich-x86_64")
+        enable_sudo = self.params.get("enable_sudo", "/run/*", default=True)
         test_to = self.params.get("test_timeout", test_param + "*")
         self.test_name = self.params.get("name", test_param + "*")
         single_test_pool = self.params.get(
@@ -534,6 +543,7 @@ class SoakTestBase(TestWithServers):
         job_list = self.params.get("joblist", test_param + "*")
         resv_bytes = self.params.get("resv_bytes", test_param + "*", 500000000)
         ignore_soak_errors = self.params.get("ignore_soak_errors", test_param + "*", False)
+        self.sudo_cmd = "sudo" if enable_sudo else ""
         if harassers:
             run_harasser = True
             self.log.info("<< Initial harasser list = %s>>", harassers)


### PR DESCRIPTION
Skip-unit-tests: true
Test-tag: soak_smoke offline_extend_oclass

Some command lines in soak have prepended sudo and they are unnecessary and should be removed.

Signed-off-by: Maureen Jean <maureen.jean@intel.com>