### PR TITLE
DAOS-10386 test: cart_self_test.py - Increase pattern_timeout to 60 s…

### DIFF
--- a/src/tests/ftest/network/cart_self_test.yaml
+++ b/src/tests/ftest/network/cart_self_test.yaml
@@ -11,7 +11,7 @@ setup:
   agent_manager_class: Orterun
   server_manager_class: Orterun
 daos_server:
-  pattern_timeout: 40
+  pattern_timeout: 60
 server_config:
   name: daos_server
 self_test:


### PR DESCRIPTION
…ec (#8843)

Cherry-pick from master.

Current default server start up wait time is 30 sec, but
network/cart_self_test.py takes longer and the wait time
varies depending on the VM performance. We tried 40 sec,
but it still failed, so increase to 60.

Test-tag: cartselftest
Test-repeat-vm: 10
Signed-off-by: Makito Kano <makito.kano@intel.com>