### PR TITLE
SRE-92 ci: Updates to allow testing images

### DIFF
--- a/ci/provisioning/post_provision_config.sh
+++ b/ci/provisioning/post_provision_config.sh
@@ -51,6 +51,9 @@ if ! retry_cmd 2400 clush -B -S -l root -w "$NODESTRING" \
            REPO_FILE_URL=\"$REPO_FILE_URL\"
            ARTIFACTORY_URL=\"${ARTIFACTORY_URL:-}\"
            BRANCH_NAME=\"${BRANCH_NAME:-}\"
+           CHANGE_TARGET=\"${CHANGE_TARGET:-}\"
+           CI_RPM_TEST_VERSION=\"${CI_RPM_TEST_VERSION:-}\"
+           CI_PR_REPOS=\"${CI_PR_REPOS:-}\"
            $(cat ci/stacktrace.sh)
            $(cat ci/junit.sh)
            $(cat ci/provisioning/post_provision_config_common_functions.sh)

--- a/ci/provisioning/post_provision_config_common_functions.sh
+++ b/ci/provisioning/post_provision_config_common_functions.sh
@@ -176,6 +176,11 @@ pr_repos() {
 }
 
 rpm_test_version() {
+    if [ -n "$CI_RPM_TEST_VERSION" ]; then
+        echo "$CI_RPM_TEST_VERSION"
+        return 0
+    fi
+
     echo "$COMMIT_MESSAGE" |
              sed -ne '/^RPM-test-version: */s/^[^:]*: *//Ip'
     return 0
@@ -193,7 +198,7 @@ set_local_repo() {
     version=${version%%.*}
     if [ "$repo_server" = "artifactory" ] &&
        [ -z "$(rpm_test_version)" ] &&
-       [[ $BRANCH_NAME != weekly-testing* ]]; then
+       [[ ${CHANGE_TARGET:-$BRANCH_NAME} != weekly-testing* ]]; then
         # Disable the daos repo so that the Jenkins job repo or a PR-repos*: repo is
         # used for daos packages
         dnf -y config-manager \
@@ -238,6 +243,13 @@ update_repos() {
 }
 
 post_provision_config_nodes() {
+    # shellcheck disable=SC2154
+    if ! update_repos "$DISTRO_NAME"; then
+        # need to use the image supplied repos
+        # shellcheck disable=SC2034
+        repo_servers=()
+    fi
+
     bootstrap_dnf
 
     # Reserve port ranges 31416-31516 for DAOS and CART servers
@@ -251,13 +263,6 @@ post_provision_config_nodes() {
                      openpa pmix protobuf-c spdk libfabric libpmem \
                      libpmemblk munge-libs munge slurm             \
                      slurm-example-configs slurmctld slurm-slurmmd
-    fi
-
-    # shellcheck disable=SC2154
-    if ! update_repos "$DISTRO_NAME"; then
-        # need to use the image supplied repos
-        # shellcheck disable=SC2034
-        repo_servers=()
     fi
 
     if [ -n "$INST_REPOS" ]; then

--- a/ci/provisioning/post_provision_config_nodes.sh
+++ b/ci/provisioning/post_provision_config_nodes.sh
@@ -98,9 +98,10 @@ chmod 600 "${jenkins_ssh}"/{authorized_keys,id_rsa*,config}
 chown -R jenkins.jenkins /localhome/jenkins/
 echo "jenkins ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/jenkins
 
-# pin the release
-# shellcheck disable=SC2154
-echo "$release" > /etc/dnf/vars/releasever
+# remove any defined releasever
+# any deviation from the default releasever for a distro should be
+# handled on a per-test-run, or even per-dnf command basis
+rm -f  /etc/yum/vars/releasever
 
 # defined in ci/functional/post_provision_config_nodes_<distro>.sh
 # and catted to the remote node along with this script

--- a/ci/provisioning/post_provision_config_nodes_EL_8.sh
+++ b/ci/provisioning/post_provision_config_nodes_EL_8.sh
@@ -15,6 +15,9 @@ distro_custom() {
     dnf -y install python3-avocado{,-plugins-{output-html,varianter-yaml-to-mux}} \
                    clustershell
 
+    # for Launchable's pip install
+    dnf -y install python3-setuptools.noarch
+
     # New Rocky images don't have debuginfo baked into them
     if ! dnf --enablerepo=\*-debuginfo repolist 2>/dev/null | grep -e -debuginfo; then
         if [ "$(lsb_release -s -i)" = "Rocky" ]; then

--- a/ci/rpm/test_daos_node.sh
+++ b/ci/rpm/test_daos_node.sh
@@ -33,7 +33,7 @@ fi
 sudo "${YUM[@]}" erase $OPENMPI_RPM
 sudo "${YUM[@]}" install daos-client-tests-"${DAOS_PKG_VERSION}"
 if rpm -q $OPENMPI_RPM; then
-  echo "$OPENMPI_RPM RPM should be installed as a dependency of daos-client-tests"
+  echo "$OPENMPI_RPM RPM should not be installed as a dependency of daos-client-tests"
   exit 1
 fi
 if ! sudo "${YUM[@]}" history undo last; then
@@ -43,7 +43,7 @@ if ! sudo "${YUM[@]}" history undo last; then
 fi
 sudo "${YUM[@]}" install daos-server-tests-"${DAOS_PKG_VERSION}"
 if rpm -q $OPENMPI_RPM; then
-  echo "$OPENMPI_RPM RPM should be installed as a dependency of daos-server-tests"
+  echo "$OPENMPI_RPM RPM should not be installed as a dependency of daos-server-tests"
   exit 1
 fi
 if ! sudo "${YUM[@]}" history undo last; then

--- a/utils/rpms/packaging/rpm_chrootbuild
+++ b/utils/rpms/packaging/rpm_chrootbuild
@@ -17,6 +17,7 @@ config_opts['module_setup_commands'] = [
   ('enable', 'javapackages-tools:201801'),
   ('disable',  'go-toolset')
 ]
+config_opts['dnf_builddep_opts'] = ['--nobest']
 EOF
 fi
 

--- a/utils/scripts/install-el8.sh
+++ b/utils/scripts/install-el8.sh
@@ -8,6 +8,10 @@
 # post provisioning issue.
 # *** Keep these in as much alphbetical order as possible ***
 
+# This script use used by docker but can be invoked from elsewhere, in order to run it
+# interactively then these two commands can be used to set dnf into automatic mode.
+# dnf --assumeyes install dnf-plugins-core
+# dnf config-manager --save --setopt=assumeyes=True
 set -e
 
 dnf -y upgrade && \


### PR DESCRIPTION
Add CI_PROVISINING_POOL, CI_PR_REPOS and CI_FI_el8_TEST parameters.
    
Utilize the new parameters when configuring repos.

Always disable daos RPMs repo unless RPM-test-version or
CI_RPM_TEST_VERSION are used.

Fixes for launchable.