### PR TITLE
DAOS-10225 control: fix available storage with heterogeneous NVMe

### DIFF
--- a/src/control/lib/control/pool.go
+++ b/src/control/lib/control/pool.go
@@ -1125,6 +1125,11 @@ func GetMaxPoolSize(ctx context.Context, log logging.Logger, rpcClient UnaryInvo
 				}
 
 				nvmeRanksBytes[smdDevice.Rank] += smdDevice.AvailBytes
+				log.Debugf("Adding SMD device %s (instance %d, ctrlr %s) is usable: "+
+					"device state=%q, size=%d total=%d",
+					smdDevice.UUID, smdDevice.Rank, smdDevice.TrAddr,
+					smdDevice.NvmeState.String(), smdDevice.AvailBytes,
+					nvmeRanksBytes[smdDevice.Rank])
 			}
 		}
 		for _, nvmeRankBytes := range nvmeRanksBytes {

--- a/src/control/server/ctl_storage_rpc.go
+++ b/src/control/server/ctl_storage_rpc.go
@@ -8,6 +8,7 @@ package server
 
 import (
 	"fmt"
+	"math"
 	"os/user"
 	"strconv"
 
@@ -17,6 +18,7 @@ import (
 
 	"github.com/daos-stack/daos/src/control/common/proto"
 	"github.com/daos-stack/daos/src/control/common/proto/convert"
+	"github.com/daos-stack/daos/src/control/common/proto/ctl"
 	ctlpb "github.com/daos-stack/daos/src/control/common/proto/ctl"
 	"github.com/daos-stack/daos/src/control/drpc"
 	"github.com/daos-stack/daos/src/control/server/engine"
@@ -167,28 +169,52 @@ func (c *ControlService) scanScm(ctx context.Context, req *ctlpb.ScanScmReq) (*c
 
 // Adjust the NVME available size to its real usable size.
 func (c *ControlService) adjustNvmeSize(resp *ctlpb.ScanNvmeResp) {
-	for _, ctl := range resp.GetCtrlrs() {
-		for _, dev := range ctl.GetSmdDevices() {
+	type deviceSizeStat struct {
+		size    uint64
+		devices []*ctl.NvmeController_SmdDevice
+	}
+
+	devicesToAdjust := make(map[uint32]*deviceSizeStat, 0)
+	for _, ctlr := range resp.GetCtrlrs() {
+		for _, dev := range ctlr.GetSmdDevices() {
 			if dev.GetDevState() != "NORMAL" {
 				c.log.Debugf("Adjusting available size of unusable SMD device %s "+
 					"(ctlr %s) to O Bytes: device state %q",
-					dev.GetUuid(), ctl.GetPciAddr(), dev.GetDevState())
+					dev.GetUuid(), ctlr.GetPciAddr(), dev.GetDevState())
 				dev.AvailBytes = 0
 				continue
 			}
+
 			if dev.GetClusterSize() == 0 || len(dev.GetTgtIds()) == 0 {
 				c.log.Errorf("Skipping device %s (%s) with missing storage info",
-					dev.GetUuid(), ctl.GetPciAddr())
+					dev.GetUuid(), ctlr.GetPciAddr())
 				continue
 			}
 
+			rank := dev.GetRank()
+			if devicesToAdjust[rank] == nil {
+				devicesToAdjust[rank] = &deviceSizeStat{
+					size: math.MaxUint64,
+				}
+			}
 			targetCount := uint64(len(dev.GetTgtIds()))
 			unalignedBytes := dev.GetAvailBytes() % (targetCount * dev.GetClusterSize())
-			c.log.Debugf("Adjusting available size of SMD device %s (ctlr %s): "+
-				"excluding %s (%d Bytes) of unaligned storage",
-				dev.GetUuid(), ctl.GetPciAddr(),
-				humanize.Bytes(unalignedBytes), unalignedBytes)
-			dev.AvailBytes -= unalignedBytes
+			availBytes := dev.AvailBytes - unalignedBytes
+			if availBytes < devicesToAdjust[rank].size {
+				devicesToAdjust[rank].size = availBytes
+			}
+			devicesToAdjust[rank].devices = append(devicesToAdjust[rank].devices, dev)
+		}
+	}
+
+	for rank, item := range devicesToAdjust {
+		for _, dev := range item.devices {
+			unusedBytes := dev.AvailBytes - item.size
+			c.log.Debugf("Adjusting available size of SMD device %s from rank %d: "+
+				"excluding %s (%d Bytes) of unusable storage",
+				dev.GetUuid(), rank,
+				humanize.Bytes(unusedBytes), unusedBytes)
+			dev.AvailBytes = item.size
 		}
 	}
 }

--- a/src/control/server/ctl_storage_rpc_test.go
+++ b/src/control/server/ctl_storage_rpc_test.go
@@ -9,6 +9,7 @@ package server
 import (
 	"context"
 	"fmt"
+	"math"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -24,6 +25,7 @@ import (
 	"github.com/daos-stack/daos/src/control/common"
 	"github.com/daos-stack/daos/src/control/common/proto"
 	"github.com/daos-stack/daos/src/control/common/proto/convert"
+	"github.com/daos-stack/daos/src/control/common/proto/ctl"
 	ctlpb "github.com/daos-stack/daos/src/control/common/proto/ctl"
 	"github.com/daos-stack/daos/src/control/drpc"
 	"github.com/daos-stack/daos/src/control/fault"
@@ -46,11 +48,21 @@ var (
 		protocmp.IgnoreFields(&ctlpb.NvmeController{}, "serial"))
 )
 
-func adjustNvmeSize(availBytes uint64) uint64 {
+func adjustNvmeSize(smdDevices []*ctl.NvmeController_SmdDevice) {
 	const targetNb uint64 = 4
 
-	unalignedMemory := availBytes % (targetNb * clusterSize)
-	return availBytes - unalignedMemory
+	availBytes := uint64(math.MaxUint64)
+	for _, dev := range smdDevices {
+		unalignedMemory := dev.AvailBytes % (targetNb * clusterSize)
+		usabledMemory := dev.AvailBytes - unalignedMemory
+		if usabledMemory < availBytes {
+			availBytes = usabledMemory
+		}
+	}
+
+	for _, dev := range smdDevices {
+		dev.AvailBytes = availBytes
+	}
 }
 
 func adjustScmSize(availBytes uint64) uint64 {
@@ -438,9 +450,7 @@ func TestServer_CtlSvc_StorageScan_PostEngineStart(t *testing.T) {
 	}
 	newCtrlrPBwMeta := func(idx int32, smdIndexes ...int32) *ctlpb.NvmeController {
 		c, _ := newCtrlrMeta(idx, smdIndexes...)
-		for _, sd := range c.GetSmdDevices() {
-			sd.AvailBytes = adjustNvmeSize(sd.AvailBytes)
-		}
+		adjustNvmeSize(c.GetSmdDevices())
 		return c
 	}
 	newSmdDevResp := func(idx int32, smdIndexes ...int32) *ctlpb.SmdDevResp {
@@ -2217,16 +2227,41 @@ func TestServer_adjustNvmeSize(t *testing.T) {
 					{
 						SmdDevices: []*ctlpb.NvmeController_SmdDevice{
 							{
+								Uuid:        "nvme0",
 								TgtIds:      []int32{0, 1, 2, 3},
 								AvailBytes:  10 * humanize.GiByte,
 								ClusterSize: clusterSize,
 								DevState:    "NORMAL",
+								Rank:        0,
 							},
 							{
-								TgtIds:      []int32{0, 1, 2},
+								Uuid:        "nvme1",
+								TgtIds:      []int32{0, 1, 2, 3},
 								AvailBytes:  10 * humanize.GiByte,
 								ClusterSize: clusterSize,
 								DevState:    "NORMAL",
+								Rank:        0,
+							},
+							{
+								TgtIds:      []int32{0, 1, 2, 3},
+								AvailBytes:  20 * humanize.GiByte,
+								ClusterSize: clusterSize,
+								DevState:    "NORMAL",
+								Rank:        0,
+							},
+							{
+								TgtIds:      []int32{0, 1, 2},
+								AvailBytes:  20 * humanize.GiByte,
+								ClusterSize: clusterSize,
+								DevState:    "NORMAL",
+								Rank:        1,
+							},
+							{
+								TgtIds:      []int32{0, 1, 2},
+								AvailBytes:  20 * humanize.GiByte,
+								ClusterSize: clusterSize,
+								DevState:    "NORMAL",
+								Rank:        1,
 							},
 						},
 					},
@@ -2235,8 +2270,42 @@ func TestServer_adjustNvmeSize(t *testing.T) {
 			output: ExpectedOutput{
 				availableBytes: []uint64{
 					8 * humanize.GiByte,
-					9 * humanize.GiByte,
+					8 * humanize.GiByte,
+					8 * humanize.GiByte,
+					18 * humanize.GiByte,
+					18 * humanize.GiByte,
 				},
+			},
+		},
+		"new": {
+			input: &ctlpb.ScanNvmeResp{
+				Ctrlrs: []*ctlpb.NvmeController{
+					{
+						SmdDevices: []*ctlpb.NvmeController_SmdDevice{
+							{
+								Uuid:        "nvme0",
+								TgtIds:      []int32{0, 1, 2, 3},
+								AvailBytes:  10 * humanize.GiByte,
+								ClusterSize: clusterSize,
+								DevState:    "NORMAL",
+							},
+							{
+								Uuid:        "nvme1",
+								TgtIds:      []int32{0, 1, 2},
+								AvailBytes:  10 * humanize.GiByte,
+								ClusterSize: clusterSize,
+								DevState:    "NEW",
+							},
+						},
+					},
+				},
+			},
+			output: ExpectedOutput{
+				availableBytes: []uint64{
+					8 * humanize.GiByte,
+					0,
+				},
+				message: "Adjusting available size of unusable SMD device",
 			},
 		},
 		"evicted": {
@@ -2303,12 +2372,14 @@ func TestServer_adjustNvmeSize(t *testing.T) {
 					{
 						SmdDevices: []*ctlpb.NvmeController_SmdDevice{
 							{
+								Uuid:        "nvme0",
 								TgtIds:      []int32{0, 1, 2, 3},
 								AvailBytes:  10 * humanize.GiByte,
 								ClusterSize: clusterSize,
 								DevState:    "NORMAL",
 							},
 							{
+								Uuid:       "nvme1",
 								TgtIds:     []int32{0, 1, 2},
 								AvailBytes: 10 * humanize.GiByte,
 								DevState:   "NORMAL",


### PR DESCRIPTION
When NVMe of different size are used by the same engine, then the
storage available for each device is equal to the one of the smallest
device.

Features: control

Signed-off-by: Cedric Koch-Hofer <cedric.koch-hofer@intel.com>