### PR TITLE
DAOS-10356 dfuse: Disable dfuse metadata caching when using IL. (#8760)

### DIFF
--- a/src/client/dfuse/dfuse.h
+++ b/src/client/dfuse/dfuse.h
@@ -70,9 +70,7 @@ struct dfuse_readdir_entry {
 	off_t	dre_next_offset;
 };
 
-/** what is returned as the handle for fuse fuse_file_info on
- * create/open/opendir
- */
+/** what is returned as the handle for fuse fuse_file_info on create/open/opendir */
 struct dfuse_obj_hdl {
 	/** pointer to dfs_t */
 	dfs_t				*doh_dfs;
@@ -80,9 +78,6 @@ struct dfuse_obj_hdl {
 	dfs_obj_t			*doh_obj;
 	/** the inode entry for the file */
 	struct dfuse_inode_entry	*doh_ie;
-
-	/** True if caching is enabled for this file. */
-	bool				doh_caching;
 
 	/* Below here is only used for directories */
 	/** an anchor to track listing in readdir */
@@ -96,6 +91,14 @@ struct dfuse_obj_hdl {
 	uint32_t			doh_dre_last_index;
 	/** Next value from anchor */
 	uint32_t			doh_anchor_index;
+
+	ATOMIC uint32_t                  doh_il_calls;
+
+	/** True if caching is enabled for this file. */
+	bool				doh_caching;
+
+	/* True if the file handle is writeable - used for cache invalidation */
+	bool                             doh_writeable;
 };
 
 struct dfuse_inode_ops {
@@ -368,13 +371,15 @@ struct fuse_lowlevel_ops dfuse_ops;
 #define DFUSE_REPLY_ATTR(ie, req, attr)					\
 	do {								\
 		int __rc;						\
+		double timeout = 0;					\
+		if (atomic_load_relaxed(&(ie)->ie_il_count) == 0)	\
+			timeout = (ie)->ie_dfs->dfc_attr_timeout;	\
 		DFUSE_TRA_DEBUG(ie,					\
 				"Returning attr inode %#lx mode %#o size %zi",	\
 				(attr)->st_ino,				\
 				(attr)->st_mode,			\
 				(attr)->st_size);			\
-		__rc = fuse_reply_attr(req, attr,			\
-				(ie)->ie_dfs->dfc_attr_timeout);	\
+		__rc = fuse_reply_attr(req, attr, timeout);		\
 		if (__rc != 0)						\
 			DFUSE_TRA_ERROR(ie,				\
 					"fuse_reply_attr returned %d:%s", \
@@ -525,14 +530,20 @@ struct dfuse_inode_entry {
 	 */
 	d_list_t		ie_htl;
 
+	/** written region for truncated files (i.e. ie_truncated set) */
+	size_t                   ie_start_off;
+	size_t                   ie_end_off;
+
 	/** Reference counting for the inode.
 	 * Used by the hash table callbacks
 	 */
 	ATOMIC uint		ie_ref;
 
-	/** written region for truncated files (i.e. ie_truncated set) */
-	size_t			ie_start_off;
-	size_t			ie_end_off;
+	/* Number of open file descriptors for this inode */
+	ATOMIC uint32_t          ie_open_count;
+
+	/* Number of file open file descriptors using IL */
+	ATOMIC uint32_t          ie_il_count;
 
 	/** file was truncated from 0 to a certain size */
 	bool			ie_truncated;
@@ -541,7 +552,7 @@ struct dfuse_inode_entry {
 	bool			ie_root;
 
 	/** File has been unlinked from daos */
-	bool			ie_unlinked;
+	bool                     ie_unlinked;
 };
 
 /* Generate the inode to use for this dfs object.  This is generating a single

--- a/src/client/dfuse/dfuse_core.c
+++ b/src/client/dfuse/dfuse_core.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2021 Intel Corporation.
+ * (C) Copyright 2016-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -1004,13 +1004,16 @@ dfuse_ie_close(struct dfuse_projection_info *fs_handle,
 	       struct dfuse_inode_entry *ie)
 {
 	int	rc;
-	int	ref = atomic_load_relaxed(&ie->ie_ref);
+	int	ref;
 
+	ref = atomic_load_relaxed(&ie->ie_ref);
 	DFUSE_TRA_DEBUG(ie,
 			"closing, inode %#lx ref %u, name '%s', parent %#lx",
 			ie->ie_stat.st_ino, ref, ie->ie_name, ie->ie_parent);
 
 	D_ASSERT(ref == 0);
+	D_ASSERT(atomic_load_relaxed(&ie->ie_il_count) == 0);
+	D_ASSERT(atomic_load_relaxed(&ie->ie_open_count) == 0);
 
 	if (ie->ie_obj) {
 		rc = dfs_release(ie->ie_obj);

--- a/src/client/dfuse/ops/create.c
+++ b/src/client/dfuse/ops/create.c
@@ -30,7 +30,7 @@ _dfuse_mode_update(fuse_req_t req, struct dfuse_inode_entry *parent, mode_t *_mo
 
 	/* First check the UID, if this is different then copy the mode bits from user to group */
 	if (ctx->uid != parent->ie_stat.st_uid) {
-		DFUSE_TRA_DEBUG(parent, "create with mismatched UID, setting group perms\n");
+		DFUSE_TRA_DEBUG(parent, "create with mismatched UID, setting group perms");
 		if (mode & S_IRUSR)
 			mode |= S_IRGRP;
 		if (mode & S_IWUSR)
@@ -49,7 +49,7 @@ _dfuse_mode_update(fuse_req_t req, struct dfuse_inode_entry *parent, mode_t *_mo
 		bool have_group_match = false;
 		int i;
 
-		DFUSE_TRA_DEBUG(parent, "create with mismatched GID\n");
+		DFUSE_TRA_DEBUG(parent, "create with mismatched GID");
 
 		gcount = fuse_req_getgroups(req, START_GROUP_SIZE, glist);
 		gsize = min(2, gcount);
@@ -79,7 +79,7 @@ _dfuse_mode_update(fuse_req_t req, struct dfuse_inode_entry *parent, mode_t *_mo
 		}
 
 		if (!have_group_match) {
-			DFUSE_TRA_DEBUG(parent, "No GIDs match, setting other perms\n");
+			DFUSE_TRA_DEBUG(parent, "No GIDs match, setting other perms");
 
 			if (mode & S_IRUSR)
 				mode |= S_IROTH;
@@ -170,6 +170,7 @@ dfuse_cb_create(fuse_req_t req, struct dfuse_inode_entry *parent,
 
 	oh->doh_dfs = dfs->dfs_ns;
 	oh->doh_ie = ie;
+	oh->doh_writeable = true;
 
 	if (dfs->dfc_data_caching) {
 		if (fi->flags & O_DIRECT)
@@ -197,6 +198,8 @@ dfuse_cb_create(fuse_req_t req, struct dfuse_inode_entry *parent,
 	dfs_obj2id(ie->ie_obj, &ie->ie_oid);
 
 	dfuse_compute_inode(dfs, &ie->ie_oid, &ie->ie_stat.st_ino);
+
+	atomic_fetch_add_relaxed(&ie->ie_open_count, 1);
 
 	/* Return the new inode data, and keep the parent ref */
 	dfuse_reply_entry(fs_handle, ie, &fi_out, true, req);

--- a/src/client/dfuse/ops/ioctl.c
+++ b/src/client/dfuse/ops/ioctl.c
@@ -16,8 +16,10 @@
 static void
 handle_il_ioctl(struct dfuse_obj_hdl *oh, fuse_req_t req)
 {
-	struct dfuse_il_reply	il_reply = {0};
-	int			rc;
+	struct dfuse_projection_info *fs_handle = fuse_req_userdata(req);
+	struct dfuse_il_reply         il_reply  = {0};
+	int                           rc;
+	uint32_t                      old_calls;
 
 	rc = dfs_obj2id(oh->doh_ie->ie_obj, &il_reply.fir_oid);
 	if (rc)
@@ -30,6 +32,26 @@ handle_il_ioctl(struct dfuse_obj_hdl *oh, fuse_req_t req)
 
 	if (oh->doh_ie->ie_dfs->dfc_attr_timeout > 0)
 		il_reply.fir_flags |= DFUSE_IOCTL_FLAGS_MCACHE;
+
+	if (oh->doh_writeable) {
+		rc = fuse_lowlevel_notify_inval_inode(fs_handle->dpi_info->di_session,
+						      oh->doh_ie->ie_stat.st_ino, 0, 0);
+
+		if (rc == 0) {
+			DFUSE_TRA_DEBUG(oh, "inval inode %#lx rc is %d", oh->doh_ie->ie_stat.st_ino,
+					rc);
+		} else {
+			DFUSE_TRA_ERROR(oh, "inval inode %#lx rc is %d", oh->doh_ie->ie_stat.st_ino,
+					rc);
+		}
+
+		/* Mark this file handle as using the IL or similar, and if this is new then mark
+		 * the inode as well
+		 */
+		old_calls = atomic_fetch_add_relaxed(&oh->doh_il_calls, 1);
+		if (old_calls == 0)
+			atomic_fetch_add_relaxed(&oh->doh_ie->ie_il_count, 1);
+	}
 
 	DFUSE_REPLY_IOCTL(oh, req, il_reply);
 	return;

--- a/src/client/dfuse/ops/lookup.c
+++ b/src/client/dfuse/ops/lookup.c
@@ -27,14 +27,6 @@ dfuse_reply_entry(struct dfuse_projection_info *fs_handle,
 	D_ASSERT(ie->ie_parent);
 	D_ASSERT(ie->ie_dfs);
 
-	if (S_ISDIR(ie->ie_stat.st_mode))
-		entry.entry_timeout = ie->ie_dfs->dfc_dentry_dir_timeout;
-	else
-		entry.entry_timeout = ie->ie_dfs->dfc_dentry_timeout;
-
-	/* Set the attr caching attributes of this entry */
-	entry.attr_timeout = ie->ie_dfs->dfc_attr_timeout;
-
 	ie->ie_root = (ie->ie_stat.st_ino == ie->ie_dfs->dfs_ino);
 
 	entry.attr = ie->ie_stat;
@@ -117,6 +109,19 @@ dfuse_reply_entry(struct dfuse_projection_info *fs_handle,
 		atomic_fetch_sub_relaxed(&ie->ie_ref, 1);
 		dfuse_ie_close(fs_handle, ie);
 		ie = inode;
+	}
+
+	/* Set the attr caching attributes of this entry.  The lookup may have resulted in a
+	 * already known inode for while the interception library is already in use so check
+	 * this and disable caching in this case.
+	 */
+	if ((atomic_load_relaxed(&ie->ie_il_count)) == 0) {
+		if (S_ISDIR(ie->ie_stat.st_mode))
+			entry.entry_timeout = ie->ie_dfs->dfc_dentry_dir_timeout;
+		else
+			entry.entry_timeout = ie->ie_dfs->dfc_dentry_timeout;
+
+		entry.attr_timeout = ie->ie_dfs->dfc_attr_timeout;
 	}
 
 	if (fi_out)

--- a/src/client/dfuse/ops/open.c
+++ b/src/client/dfuse/ops/open.c
@@ -10,12 +10,12 @@
 void
 dfuse_cb_open(fuse_req_t req, fuse_ino_t ino, struct fuse_file_info *fi)
 {
-	struct dfuse_projection_info	*fs_handle = fuse_req_userdata(req);
-	struct dfuse_inode_entry	*ie;
-	d_list_t			*rlink;
-	struct dfuse_obj_hdl		*oh = NULL;
-	struct fuse_file_info	        fi_out = {0};
-	int				rc;
+	struct dfuse_projection_info *fs_handle = fuse_req_userdata(req);
+	struct dfuse_inode_entry     *ie;
+	d_list_t		     *rlink;
+	struct dfuse_obj_hdl         *oh     = NULL;
+	struct fuse_file_info         fi_out = {0};
+	int                           rc;
 
 	rlink = d_hash_rec_find(&fs_handle->dpi_iet, &ino, sizeof(ino));
 	if (!rlink) {
@@ -33,22 +33,22 @@ dfuse_cb_open(fuse_req_t req, fuse_ino_t ino, struct fuse_file_info *fi)
 	/* Upgrade fd permissions from O_WRONLY to O_RDWR if wb caching is
 	 * enabled so the kernel can do read-modify-write
 	 */
-	if (ie->ie_dfs->dfc_data_caching &&
-		fs_handle->dpi_info->di_wb_cache &&
-		(fi->flags & O_ACCMODE) == O_WRONLY) {
+	if (ie->ie_dfs->dfc_data_caching && fs_handle->dpi_info->di_wb_cache &&
+	    (fi->flags & O_ACCMODE) == O_WRONLY) {
 		DFUSE_TRA_DEBUG(ie, "Upgrading fd to O_RDRW");
 		fi->flags &= ~O_ACCMODE;
 		fi->flags |= O_RDWR;
 	}
 
 	/** duplicate the file handle for the fuse handle */
-	rc = dfs_dup(ie->ie_dfs->dfs_ns, ie->ie_obj, fi->flags,
-		     &oh->doh_obj);
+	rc = dfs_dup(ie->ie_dfs->dfs_ns, ie->ie_obj, fi->flags, &oh->doh_obj);
 	if (rc)
 		D_GOTO(err, rc);
 
+	if ((fi->flags & O_ACCMODE) != O_RDONLY)
+		oh->doh_writeable = true;
 	oh->doh_dfs = ie->ie_dfs->dfs_ns;
-	oh->doh_ie = ie;
+	oh->doh_ie  = ie;
 
 	if (ie->ie_dfs->dfc_data_caching) {
 		if (fi->flags & O_DIRECT)
@@ -72,11 +72,12 @@ dfuse_cb_open(fuse_req_t req, fuse_ino_t ino, struct fuse_file_info *fi)
 	 * O_TRUNC flag, we need to truncate the file manually.
 	 */
 	if (fi->flags & O_TRUNC) {
-		rc = dfs_punch(ie->ie_dfs->dfs_ns, ie->ie_obj, 0,
-			       DFS_MAX_FSIZE);
+		rc = dfs_punch(ie->ie_dfs->dfs_ns, ie->ie_obj, 0, DFS_MAX_FSIZE);
 		if (rc)
 			D_GOTO(err, rc);
 	}
+
+	atomic_fetch_add_relaxed(&ie->ie_open_count, 1);
 
 	d_hash_rec_decref(&fs_handle->dpi_iet, rlink);
 	DFUSE_REPLY_OPEN(oh, req, &fi_out);
@@ -91,8 +92,16 @@ err:
 void
 dfuse_cb_release(fuse_req_t req, fuse_ino_t ino, struct fuse_file_info *fi)
 {
-	struct dfuse_obj_hdl	*oh = (struct dfuse_obj_hdl *)fi->fh;
-	int			rc;
+	struct dfuse_obj_hdl *oh = (struct dfuse_obj_hdl *)fi->fh;
+	int                   rc;
+
+	/* Perform the opposite of what the ioctl call does, always change the open handle count
+	 * but the inode only tracks number of open handles with non-zero ioctl counts
+	 */
+
+	if (atomic_load_relaxed(&oh->doh_il_calls) != 0)
+		atomic_fetch_sub_relaxed(&oh->doh_ie->ie_il_count, 1);
+	atomic_fetch_sub_relaxed(&oh->doh_ie->ie_open_count, 1);
 
 	rc = dfs_release(oh->doh_obj);
 	if (rc == 0)

--- a/src/client/dfuse/ops/opendir.c
+++ b/src/client/dfuse/ops/opendir.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2021 Intel Corporation.
+ * (C) Copyright 2016-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -8,12 +8,11 @@
 #include "dfuse.h"
 
 void
-dfuse_cb_opendir(fuse_req_t req, struct dfuse_inode_entry *ie,
-		 struct fuse_file_info *fi)
+dfuse_cb_opendir(fuse_req_t req, struct dfuse_inode_entry *ie, struct fuse_file_info *fi)
 {
-	struct dfuse_obj_hdl	*oh = NULL;
-	struct fuse_file_info	fi_out = {0};
-	int			rc;
+	struct dfuse_obj_hdl *oh     = NULL;
+	struct fuse_file_info fi_out = {0};
+	int                   rc;
 
 	D_ALLOC_PTR(oh);
 	if (!oh)
@@ -22,13 +21,12 @@ dfuse_cb_opendir(fuse_req_t req, struct dfuse_inode_entry *ie,
 	DFUSE_TRA_UP(oh, ie, "open handle");
 
 	/** duplicate the file handle for the fuse handle */
-	rc = dfs_dup(ie->ie_dfs->dfs_ns, ie->ie_obj, fi->flags,
-		     &oh->doh_obj);
+	rc = dfs_dup(ie->ie_dfs->dfs_ns, ie->ie_obj, fi->flags, &oh->doh_obj);
 	if (rc)
 		D_GOTO(err, rc);
 
 	oh->doh_dfs = ie->ie_dfs->dfs_ns;
-	oh->doh_ie = ie;
+	oh->doh_ie  = ie;
 
 	fi_out.fh = (uint64_t)oh;
 
@@ -36,6 +34,8 @@ dfuse_cb_opendir(fuse_req_t req, struct dfuse_inode_entry *ie,
 	if (ie->ie_dfs->dfc_dentry_timeout > 0)
 		fi_out.cache_readdir = 1;
 #endif
+
+	atomic_fetch_add_relaxed(&ie->ie_open_count, 1);
 
 	DFUSE_REPLY_OPEN(oh, req, &fi_out);
 	return;
@@ -45,11 +45,18 @@ err:
 }
 
 void
-dfuse_cb_releasedir(fuse_req_t req, struct dfuse_inode_entry *ino,
-		    struct fuse_file_info *fi)
+dfuse_cb_releasedir(fuse_req_t req, struct dfuse_inode_entry *ino, struct fuse_file_info *fi)
 {
-	struct dfuse_obj_hdl	*oh = (struct dfuse_obj_hdl *)fi->fh;
-	int			rc;
+	struct dfuse_obj_hdl *oh = (struct dfuse_obj_hdl *)fi->fh;
+	int                   rc;
+
+	/* Perform the opposite of what the ioctl call does, always change the open handle count
+	 * but the inode only tracks number of open handles with non-zero ioctl counts
+	 */
+
+	if (atomic_load_relaxed(&oh->doh_il_calls) != 0)
+		atomic_fetch_sub_relaxed(&oh->doh_ie->ie_il_count, 1);
+	atomic_fetch_sub_relaxed(&oh->doh_ie->ie_open_count, 1);
 
 	rc = dfs_release(oh->doh_obj);
 	if (rc == 0)

--- a/src/client/dfuse/ops/readdir.c
+++ b/src/client/dfuse/ops/readdir.c
@@ -110,11 +110,13 @@ create_entry(struct dfuse_projection_info *fs_handle,
 
 	dfs_obj2id(ie->ie_obj, &ie->ie_oid);
 
-	entry->attr_timeout = parent->ie_dfs->dfc_attr_timeout;
-	if (S_ISDIR(ie->ie_stat.st_mode))
-		entry->entry_timeout = parent->ie_dfs->dfc_dentry_dir_timeout;
-	else
-		entry->entry_timeout = parent->ie_dfs->dfc_dentry_timeout;
+	if ((atomic_load_relaxed(&ie->ie_il_count)) == 0) {
+		entry->attr_timeout = parent->ie_dfs->dfc_attr_timeout;
+		if (S_ISDIR(ie->ie_stat.st_mode))
+			entry->entry_timeout = parent->ie_dfs->dfc_dentry_dir_timeout;
+		else
+			entry->entry_timeout = parent->ie_dfs->dfc_dentry_timeout;
+	}
 
 	ie->ie_parent = parent->ie_stat.st_ino;
 	ie->ie_dfs = parent->ie_dfs;


### PR DESCRIPTION
Track when the IL has opened file handles and invalidate all kernel
metadata when in use.  Track the ioctl calls and use atomics to
track the number of calls per open file, and the number of files
per inode, when returning inode metadata check the il-in-use count.

This should mean that when the IL is in use, all metadata requests
will go to the servers, so avoids a situation where a file is opened,
the IL writes data to it then the kernel will continue to return
stale size data.

Add checks in forget that the IL and open file count are at zero.

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>
