### PR TITLE
DAOS-10200 vos: Avoid setting dth in TLS across yield (#8857)

### DIFF
--- a/src/vos/vos_io.c
+++ b/src/vos/vos_io.c
@@ -2189,8 +2189,6 @@ vos_update_end(daos_handle_t ioh, uint32_t pm_ver, daos_key_t *dkey, int err,
 
 	tx_started = true;
 
-	vos_dth_set(dth);
-
 	/* Commit the CoS DTXs via the IO PMDK transaction. */
 	if (dtx_is_valid_handle(dth) && dth->dth_dti_cos_count > 0 &&
 	    !dth->dth_cos_done) {
@@ -2276,7 +2274,6 @@ abort:
 	D_FREE(daes);
 	D_FREE(dces);
 	vos_ioc_destroy(ioc, err != 0);
-	vos_dth_set(NULL);
 
 	return err;
 }

--- a/src/vos/vos_obj.c
+++ b/src/vos/vos_obj.c
@@ -422,7 +422,6 @@ vos_obj_punch(daos_handle_t coh, daos_unit_oid_t oid, daos_epoch_t epoch,
 	D_DEBUG(DB_IO, "Punch "DF_UOID", epoch "DF_X64"\n",
 		DP_UOID(oid), epr.epr_hi);
 
-	vos_dth_set(dth);
 	cont = vos_hdl2cont(coh);
 
 	if (dtx_is_valid_handle(dth)) {
@@ -533,7 +532,6 @@ reset:
 	D_FREE(daes);
 	D_FREE(dces);
 	vos_ts_set_free(ts_set);
-	vos_dth_set(NULL);
 
 	return rc;
 }


### PR DESCRIPTION
Holding the value across a yield can cause undefined behavior.
At some point, this should be fixed so we pass the dth through
parameters rather than expecting us to always get this right
inside of VOS.  Making sure we never have it set across yield
points is difficult.

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>