### PR TITLE
DAOS-10200 vos: Avoid setting dth in TLS across yield (#8857)

### DIFF
--- a/src/vos/vos_common.c
+++ b/src/vos/vos_common.c
@@ -234,12 +234,21 @@ vos_tx_begin(struct dtx_handle *dth, struct umem_instance *umm)
 	if (dth == NULL)
 		return umem_tx_begin(umm, vos_txd_get());
 
-	if (dth->dth_local_tx_started)
+	/** Note: On successful return, dth tls gets set and will be cleared by the corresponding
+	 *        call to vos_tx_end.  This is to avoid ever keeping that set after a call to
+	 *        umem_tx_end, which may yield for bio operations.
+	 */
+
+	if (dth->dth_local_tx_started) {
+		vos_dth_set(dth);
 		return 0;
+	}
 
 	rc = umem_tx_begin(umm, vos_txd_get());
-	if (rc == 0)
+	if (rc == 0) {
 		dth->dth_local_tx_started = 1;
+		vos_dth_set(dth);
+	}
 
 	return rc;
 }
@@ -278,8 +287,10 @@ vos_tx_end(struct vos_container *cont, struct dtx_handle *dth_in,
 		goto cancel;
 
 	/* Not the last modification. */
-	if (err == 0 && dth->dth_modification_cnt > dth->dth_op_seq)
+	if (err == 0 && dth->dth_modification_cnt > dth->dth_op_seq) {
+		vos_dth_set(NULL);
 		return 0;
+	}
 
 	dth->dth_local_tx_started = 0;
 
@@ -288,6 +299,8 @@ vos_tx_end(struct vos_container *cont, struct dtx_handle *dth_in,
 
 	if (err == 0)
 		err = vos_tx_publish(dth, true);
+
+	vos_dth_set(NULL);
 
 	err = umem_tx_end(vos_cont2umm(cont), err);
 

--- a/src/vos/vos_io.c
+++ b/src/vos/vos_io.c
@@ -2285,8 +2285,6 @@ vos_update_end(daos_handle_t ioh, uint32_t pm_ver, daos_key_t *dkey, int err,
 
 	tx_started = true;
 
-	vos_dth_set(dth);
-
 	/* Commit the CoS DTXs via the IO PMDK transaction. */
 	if (dtx_is_valid_handle(dth) && dth->dth_dti_cos_count > 0 &&
 	    !dth->dth_cos_done) {
@@ -2383,7 +2381,6 @@ abort:
 	D_FREE(daes);
 	D_FREE(dces);
 	vos_ioc_destroy(ioc, err != 0);
-	vos_dth_set(NULL);
 
 	return err;
 }

--- a/src/vos/vos_obj.c
+++ b/src/vos/vos_obj.c
@@ -426,7 +426,6 @@ vos_obj_punch(daos_handle_t coh, daos_unit_oid_t oid, daos_epoch_t epoch,
 	D_DEBUG(DB_IO, "Punch "DF_UOID", epoch "DF_X64"\n",
 		DP_UOID(oid), epr.epr_hi);
 
-	vos_dth_set(dth);
 	cont = vos_hdl2cont(coh);
 
 	if (dtx_is_valid_handle(dth)) {
@@ -551,7 +550,6 @@ reset:
 	D_FREE(daes);
 	D_FREE(dces);
 	vos_ts_set_free(ts_set);
-	vos_dth_set(NULL);
 
 	return rc;
 }
@@ -791,6 +789,7 @@ key_iter_fetch(struct vos_obj_iter *oiter, vos_iter_entry_t *ent,
 	vos_iter_desc_t		 desc;
 	struct vos_rec_bundle	 rbund;
 	struct vos_krec_df	*krec;
+	struct dtx_handle	*dth;
 	uint64_t		 feats;
 	uint32_t		 ts_type;
 	unsigned int		 acts;
@@ -824,9 +823,14 @@ key_iter_fetch(struct vos_obj_iter *oiter, vos_iter_entry_t *ent,
 
 		acts = 0;
 		start_seq = vos_sched_seq();
+		dth = vos_dth_get();
+		if (dth != NULL)
+			vos_dth_set(NULL);
 		rc = oiter->it_iter.it_filter_cb(vos_iter2hdl(&oiter->it_iter), &desc,
 						 oiter->it_iter.it_filter_arg,
 						 &acts);
+		if (dth != NULL)
+			vos_dth_set(dth);
 		if (rc != 0)
 			return rc;
 		if (start_seq != vos_sched_seq())

--- a/src/vos/vos_obj_index.c
+++ b/src/vos/vos_obj_index.c
@@ -502,6 +502,7 @@ oi_iter_match_probe(struct vos_iterator *iter, daos_anchor_t *anchor, uint32_t f
 {
 	uint64_t		 start_seq;
 	struct vos_oi_iter	*oiter	= iter2oiter(iter);
+	struct dtx_handle	*dth;
 	char			*str	= NULL;
 	vos_iter_desc_t		 desc;
 	uint64_t		 feats;
@@ -538,8 +539,13 @@ oi_iter_match_probe(struct vos_iterator *iter, daos_anchor_t *anchor, uint32_t f
 			}
 			acts = 0;
 			start_seq = vos_sched_seq();
+			dth = vos_dth_get();
+			if (dth != NULL)
+				vos_dth_set(NULL);
 			rc = iter->it_filter_cb(vos_iter2hdl(iter), &desc, iter->it_filter_arg,
 						&acts);
+			if (dth != NULL)
+				vos_dth_set(dth);
 			if (rc != 0)
 				goto failed;
 			if (start_seq != vos_sched_seq())


### PR DESCRIPTION
Holding the value across a yield can cause undefined behavior.
At some point, this should be fixed so we pass the dth through
parameters rather than expecting us to always get this right
inside of VOS.  Making sure we never have it set across yield
points is difficult.

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>