### PR TITLE
DAOS-9318 test: Update the target eviction test case.

### DIFF
--- a/src/tests/ftest/scrubber/target_auto_eviction.yaml
+++ b/src/tests/ftest/scrubber/target_auto_eviction.yaml
@@ -60,7 +60,7 @@ pool:
 container:
   type: POSIX
   control_method: daos
-  oclass: RP_2G1
+  oclass: RP_2GX
   properties: "cksum:crc16"
 ior:
   ior_timeout: 60
@@ -72,9 +72,9 @@ ior:
   flags: "-v -W -w -r -R"
   api: DFS
   transfer_size: 1M
-  block_size: 32M
-  dfs_oclass: RP_2G1
-  dfs_dir_oclass: RP_2G1
+  block_size: 512M
+  dfs_oclass: RP_2GX
+  dfs_dir_oclass: RP_2GX
 faults:
   fault_list:
      - DAOS_CSUM_CORRUPT_DISK


### PR DESCRIPTION
Skip-build-leap15-rpm: true
Skip-build-ubuntu20-rpm: true
Skip-unit-tests: true
Skip-nlt: true
Test-tag: test_scrubber_target_auto_eviction
Test-repeat: 15

Summary:
-  Update the YAML file to make the test more reliable with fault injection framework. 
-  Use all the targets (using the RP_2GX)
-  Increase the block size so all targets gets some data and corruption happens in few targets.

Signed-off-by: rpadma2 <ravindran.padmanabhan@intel.com>