### PR TITLE
Proposed updates to PR

### DIFF
--- a/src/control/lib/control/auto.go
+++ b/src/control/lib/control/auto.go
@@ -696,5 +696,9 @@ func genConfig(log logging.Logger, newEngineCfg newEngineCfgFn, accessPoints []s
 		WithNrHugePages(reqHugePages).
 		WithEnableVMD(sd.vmdEnabled)
 
-	return cfg, cfg.Validate(log, sd.hugePageSize, nil)
+	if err := cfg.SetEngineAffinities(log, nil); err != nil {
+		return nil, errors.Wrap(err, "setting engine affinities")
+	}
+
+	return cfg, cfg.Validate(log, sd.hugePageSize)
 }

--- a/src/control/lib/control/auto_test.go
+++ b/src/control/lib/control/auto_test.go
@@ -907,8 +907,7 @@ func TestControl_AutoConfig_genConfig(t *testing.T) {
 					WithStorageConfigOutputPath("/mnt/daos0/daos_nvme.conf").
 					WithStorageVosEnv("NVME").
 					WithTargetCount(15).
-					WithHelperStreamCount(6).
-					WithMultiEngine(true),
+					WithHelperStreamCount(6),
 				defaultEngineCfg(1).
 					WithPinnedNumaNode(1).
 					WithFabricInterface("ib1").
@@ -928,8 +927,7 @@ func TestControl_AutoConfig_genConfig(t *testing.T) {
 					WithStorageConfigOutputPath("/mnt/daos1/daos_nvme.conf").
 					WithStorageVosEnv("NVME").
 					WithTargetCount(15).
-					WithHelperStreamCount(6).
-					WithMultiEngine(true)),
+					WithHelperStreamCount(6)),
 		},
 		"hugepages test": {
 			engineCount:  1,
@@ -992,8 +990,7 @@ func TestControl_AutoConfig_genConfig(t *testing.T) {
 					WithStorageConfigOutputPath("/mnt/daos0/daos_nvme.conf").
 					WithStorageVosEnv("NVME").
 					WithTargetCount(6).
-					WithHelperStreamCount(0).
-					WithMultiEngine(true),
+					WithHelperStreamCount(0),
 				defaultEngineCfg(1).
 					WithPinnedNumaNode(1).
 					WithFabricInterface("ib1").
@@ -1014,8 +1011,7 @@ func TestControl_AutoConfig_genConfig(t *testing.T) {
 					WithStorageVosEnv("NVME").
 					WithStorageNumaNodeIndex(1).
 					WithTargetCount(6).
-					WithHelperStreamCount(0).
-					WithMultiEngine(true)),
+					WithHelperStreamCount(0)),
 		},
 		"vmd enabled; balanced nr ssds": {
 			engineCount:  2,
@@ -1048,8 +1044,7 @@ func TestControl_AutoConfig_genConfig(t *testing.T) {
 					WithStorageConfigOutputPath("/mnt/daos0/daos_nvme.conf").
 					WithStorageVosEnv("NVME").
 					WithTargetCount(22).
-					WithHelperStreamCount(1).
-					WithMultiEngine(true),
+					WithHelperStreamCount(1),
 				defaultEngineCfg(1).
 					WithPinnedNumaNode(1).
 					WithFabricInterface("ib1").
@@ -1070,8 +1065,7 @@ func TestControl_AutoConfig_genConfig(t *testing.T) {
 					WithStorageVosEnv("NVME").
 					WithStorageNumaNodeIndex(1).
 					WithTargetCount(22).
-					WithHelperStreamCount(1).
-					WithMultiEngine(true)),
+					WithHelperStreamCount(1)),
 		},
 		"vmd enabled; imbalanced nr ssds": {
 			engineCount:  2,

--- a/src/control/server/engine/config_test.go
+++ b/src/control/server/engine/config_test.go
@@ -20,8 +20,6 @@ import (
 	"gopkg.in/yaml.v2"
 
 	"github.com/daos-stack/daos/src/control/common"
-	"github.com/daos-stack/daos/src/control/lib/hardware"
-	"github.com/daos-stack/daos/src/control/logging"
 	"github.com/daos-stack/daos/src/control/server/storage"
 )
 
@@ -345,10 +343,7 @@ func TestConfig_ScmValidation(t *testing.T) {
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			log, buf := logging.NewTestLogger(t.Name())
-			defer common.ShowBufferOnFailure(t, buf)
-
-			common.CmpErr(t, tc.expErr, tc.cfg.Validate(log, nil))
+			common.CmpErr(t, tc.expErr, tc.cfg.Validate())
 		})
 	}
 }
@@ -473,10 +468,7 @@ func TestConfig_BdevValidation(t *testing.T) {
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			log, buf := logging.NewTestLogger(t.Name())
-			defer common.ShowBufferOnFailure(t, buf)
-
-			common.CmpErr(t, tc.expErr, tc.cfg.Validate(log, nil))
+			common.CmpErr(t, tc.expErr, tc.cfg.Validate())
 			if tc.expErr != nil {
 				return
 			}
@@ -500,29 +492,38 @@ func TestConfig_BdevValidation(t *testing.T) {
 }
 
 func TestConfig_Validation(t *testing.T) {
-	log, buf := logging.NewTestLogger(t.Name())
-	defer common.ShowBufferOnFailure(t, buf)
-
-	bad := MockConfig()
-
-	if err := bad.Validate(log, nil); err == nil {
-		t.Fatal("expected empty config to fail validation")
+	validConfig := func() *Config {
+		return MockConfig().WithFabricProvider("foo").
+			WithFabricInterface("ib0").
+			WithFabricInterfacePort(42).
+			WithStorage(
+				storage.NewTierConfig().
+					WithStorageClass("ram").
+					WithScmRamdiskSize(1).
+					WithScmMountPoint("/foo/bar"),
+			).
+			WithPinnedNumaNode(0)
 	}
 
-	// create a minimally-valid config
-	good := MockConfig().WithFabricProvider("foo").
-		WithFabricInterface("ib0").
-		WithFabricInterfacePort(42).
-		WithStorage(
-			storage.NewTierConfig().
-				WithStorageClass("ram").
-				WithScmRamdiskSize(1).
-				WithScmMountPoint("/foo/bar"),
-		).
-		WithPinnedNumaNode(0)
-
-	if err := good.Validate(log, nil); err != nil {
-		t.Fatalf("expected %#v to validate; got %s", good, err)
+	for name, tc := range map[string]struct {
+		cfg    *Config
+		expErr error
+	}{
+		"empty config should fail": {
+			cfg:    MockConfig(),
+			expErr: errors.New("provider not set"),
+		},
+		"config with pinned_numa_node and nonzero first_core should fail": {
+			cfg:    validConfig().WithPinnedNumaNode(1).WithServiceThreadCore(1),
+			expErr: errors.New("cannot specify both"),
+		},
+		"minimally-valid config should pass": {
+			cfg: validConfig(),
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			common.CmpErr(t, tc.expErr, tc.cfg.Validate())
+		})
 	}
 }
 
@@ -658,207 +659,5 @@ func TestConfig_ToCmdVals(t *testing.T) {
 	}
 	if diff := cmp.Diff(wantEnv, gotEnv, defConfigCmpOpts...); diff != "" {
 		t.Fatalf("(-want, +got):\n%s", diff)
-	}
-}
-
-func TestConfig_setAffinity(t *testing.T) {
-	var zero uint = 0
-	var one uint = 1
-
-	for name, tc := range map[string]struct {
-		cfg           *Config
-		fi            *hardware.FabricInterface
-		expErr        error
-		expPinnedNuma *uint
-		expNuma       uint
-	}{
-		"numa pinned; matching iface": {
-			cfg: MockConfig().
-				WithPinnedNumaNode(1).
-				WithFabricInterface("ib1").
-				WithFabricProvider("ofi+verbs"),
-			fi: &hardware.FabricInterface{
-				Name:         "ib1",
-				NetInterface: "ib1",
-				NUMANode:     1,
-				Providers:    common.NewStringSet("ofi+verbs"),
-			},
-			expNuma:       1,
-			expPinnedNuma: &one,
-		},
-		// NOTE: this currently logs an error but could instead return one
-		//       but there might be legitimate use cases e.g. sharing interface
-		"numa pinned; not matching iface": {
-			cfg: MockConfig().
-				WithPinnedNumaNode(1).
-				WithFabricInterface("ib2").
-				WithFabricProvider("ofi+verbs"),
-			fi: &hardware.FabricInterface{
-				Name:         "ib2",
-				NetInterface: "ib2",
-				NUMANode:     2,
-				Providers:    common.NewStringSet("ofi+verbs"),
-			},
-			expNuma:       1,
-			expPinnedNuma: &one,
-		},
-		"numa not pinned": {
-			cfg: MockConfig().
-				WithFabricInterface("ib1").
-				WithFabricProvider("ofi+verbs"),
-			fi: &hardware.FabricInterface{
-				Name:         "ib1",
-				NetInterface: "ib1",
-				NUMANode:     1,
-				Providers:    common.NewStringSet("ofi+verbs"),
-			},
-			expNuma:       1,
-			expPinnedNuma: &one,
-		},
-		"validation success": {
-			cfg: MockConfig().
-				WithFabricInterface("net1").
-				WithFabricProvider("test").
-				WithPinnedNumaNode(1),
-			fi: &hardware.FabricInterface{
-				Name:         "net1",
-				NetInterface: "net1",
-				NUMANode:     1,
-				Providers:    common.NewStringSet("test"),
-			},
-			expNuma:       1,
-			expPinnedNuma: &one,
-		},
-		"provider not supported": {
-			cfg: MockConfig().
-				WithFabricInterface("net1").
-				WithFabricProvider("test").
-				WithPinnedNumaNode(1),
-			fi: &hardware.FabricInterface{
-				Name:         "net1",
-				NetInterface: "net1",
-				NUMANode:     1,
-				Providers:    common.NewStringSet("test2"),
-			},
-			expErr: errors.New("not supported"),
-		},
-		"no fabric info; pinned numa": {
-			cfg: MockConfig().
-				WithFabricInterface("net1").
-				WithFabricProvider("test").
-				WithPinnedNumaNode(1),
-			expNuma:       1,
-			expPinnedNuma: &one,
-		},
-		// Legacy core allocation mode activated, no pinned numa as no multi-engine and NUMA-0.
-		"no fabric info; no pinned numa": {
-			cfg: MockConfig().
-				WithFabricInterface("net1").
-				WithFabricProvider("test"),
-			expNuma: 0,
-		},
-		"pinned numa; first_core set": {
-			cfg: MockConfig().
-				WithFabricInterface("net1").
-				WithFabricProvider("test").
-				WithPinnedNumaNode(1).
-				WithServiceThreadCore(25),
-			expErr: errors.New("cannot both be set"),
-		},
-		// Regardless of whether first_core is set, control plane value for NUMA node will follow
-		// fabric interface affinity.
-		// TODO DAOS-10472: Add test cases to verify derived NUMA values are consistent for
-		//                  engine and control plane when first_core > 0.
-		"numa not pinned; first_core set": {
-			cfg: MockConfig().
-				WithFabricInterface("net1").
-				WithFabricProvider("test").
-				WithServiceThreadCore(25),
-			fi: &hardware.FabricInterface{
-				Name:         "net1",
-				NetInterface: "net1",
-				NUMANode:     1,
-				Providers:    common.NewStringSet("test"),
-			},
-			expNuma: 1,
-		},
-		// Legacy core allocation mode activated, no pinned numa as no multi-engine and NUMA-0.
-		"numa not pinned; iface on numa 0; 1 engine": {
-			cfg: MockConfig().
-				WithFabricInterface("net0").
-				WithFabricProvider("test").
-				WithServiceThreadCore(25),
-			fi: &hardware.FabricInterface{
-				Name:         "net0",
-				NetInterface: "net0",
-				NUMANode:     0,
-				Providers:    common.NewStringSet("test"),
-			},
-			expNuma: 0,
-		},
-		"numa not pinned; iface on numa 0; 2 engines": {
-			cfg: MockConfig().
-				WithFabricInterface("net0").
-				WithFabricProvider("test").
-				WithMultiEngine(true),
-			fi: &hardware.FabricInterface{
-				Name:         "net0",
-				NetInterface: "net0",
-				NUMANode:     0,
-				Providers:    common.NewStringSet("test"),
-			},
-			expNuma:       0,
-			expPinnedNuma: &zero,
-		},
-		"numa not pinned; iface on numa 1; 1 engine": {
-			cfg: MockConfig().
-				WithFabricInterface("net1").
-				WithFabricProvider("test"),
-			fi: &hardware.FabricInterface{
-				Name:         "net1",
-				NetInterface: "net1",
-				NUMANode:     1,
-				Providers:    common.NewStringSet("test"),
-			},
-			expNuma:       1,
-			expPinnedNuma: &one,
-		},
-		"numa not pinned; iface on numa 1; 2 engines": {
-			cfg: MockConfig().
-				WithFabricInterface("net1").
-				WithFabricProvider("test").
-				WithMultiEngine(true),
-			fi: &hardware.FabricInterface{
-				Name:         "net1",
-				NetInterface: "net1",
-				NUMANode:     1,
-				Providers:    common.NewStringSet("test"),
-			},
-			expNuma:       1,
-			expPinnedNuma: &one,
-		},
-	} {
-		t.Run(name, func(t *testing.T) {
-			log, buf := logging.NewTestLogger(t.Name())
-			defer common.ShowBufferOnFailure(t, buf)
-
-			var fis *hardware.FabricInterfaceSet
-			if tc.fi != nil {
-				fis = hardware.NewFabricInterfaceSet(tc.fi)
-			}
-
-			err := tc.cfg.setAffinity(log, fis)
-			common.CmpErr(t, tc.expErr, err)
-			if tc.expErr != nil {
-				return
-			}
-
-			common.AssertEqual(t, tc.expPinnedNuma, tc.cfg.PinnedNumaNode,
-				"unexpected pinned numa node id")
-			common.AssertEqual(t, tc.expNuma, tc.cfg.Storage.NumaNodeIndex,
-				"unexpected storage numa node id")
-			common.AssertEqual(t, tc.expNuma, tc.cfg.Fabric.NumaNodeIndex,
-				"unexpected fabric numa node id")
-		})
 	}
 }

--- a/src/control/server/server.go
+++ b/src/control/server/server.go
@@ -44,7 +44,11 @@ func processConfig(log logging.Logger, cfg *config.Server, fis *hardware.FabricI
 		return errors.Wrapf(err, "retrieve hugepage info")
 	}
 
-	if err := cfg.Validate(log, hpi.PageSizeKb, fis); err != nil {
+	if err := cfg.SetEngineAffinities(log, fis); err != nil {
+		return errors.Wrap(err, "failed to set engine affinities")
+	}
+
+	if err := cfg.Validate(log, hpi.PageSizeKb); err != nil {
 		return errors.Wrapf(err, "%s: validation failed", cfg.Path)
 	}
 

--- a/src/control/server/server_utils_test.go
+++ b/src/control/server/server_utils_test.go
@@ -469,8 +469,13 @@ func TestServer_prepBdevStorage(t *testing.T) {
 				cfg = tc.srvCfgExtra(cfg)
 			}
 
+			// ensure that the engine affinities are set.
+			if err := cfg.SetEngineAffinities(log, nil); err != nil {
+				t.Fatal(err)
+			}
+
 			// test only with 2M hugepage size
-			if err := cfg.Validate(log, 2048, nil); err != nil {
+			if err := cfg.Validate(log, 2048); err != nil {
 				t.Fatal(err)
 			}
 
@@ -583,7 +588,7 @@ func TestServer_scanBdevStorage(t *testing.T) {
 				WithNrHugePages(tc.nrHugepages)
 
 			// test only with 2M hugepage size
-			if err := cfg.Validate(log, 2048, nil); err != nil {
+			if err := cfg.Validate(log, 2048); err != nil {
 				t.Fatal(err)
 			}
 

--- a/src/control/server/storage/bdev/backend_json_test.go
+++ b/src/control/server/storage/bdev/backend_json_test.go
@@ -202,7 +202,7 @@ func TestBackend_newSpdkConfig(t *testing.T) {
 				WithStorageEnableHotplug(tc.enableHotplug).
 				WithPinnedNumaNode(0)
 
-			gotValidateErr := engineConfig.Validate(log, nil) // populate output path
+			gotValidateErr := engineConfig.Validate() // populate output path
 			common.CmpErr(t, tc.expValidateErr, gotValidateErr)
 			if tc.expValidateErr != nil {
 				return


### PR DESCRIPTION
* Remove engine/Config.MultiEngine field
  - Leaks details across package boundaries and requires
    changes throughout the codebase
* Fix bad precedent that Validate() methods may be used
  to change state
  - These methods should be as read-only as possible and
    simply verify that the config is sane and meets requirements
* Centralize logic for determining per-engine NUMA affinity
  in a single location to improve maintainability and
  testability
  - Makes future changes to enhance NUMA affinity detection
    easier to make in a targeted way with minimal changes to
    the surrounding codebase
  - It would be better not to have this logic implemented in
    a method on server/config/server.Config, in order to
    encourage cleaner separation of responsibilities, but putting
    it here for now is a compromise to maintain compability with
    the config generation logic