### PR TITLE
DAOS-9989 test: Enable weekly testing with tcp and ucx providers

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -174,7 +174,7 @@ pipeline {
                                     branch: env.BaseBranch,
                                     withSubmodules: true
                         functionalTest inst_repos: daosRepos(),
-                                       inst_rpms: functionalPackages(1, next_version),
+                                       inst_rpms: functionalPackages(1, next_version, "tests-internal"),
                                        test_function: 'runTestFunctionalV2'
                     }
                     post {
@@ -197,7 +197,7 @@ pipeline {
                                     branch: env.BaseBranch,
                                     withSubmodules: true
                         functionalTest inst_repos: daosRepos(),
-                                       inst_rpms: functionalPackages(1, next_version),
+                                       inst_rpms: functionalPackages(1, next_version, "tests-internal"),
                                        test_function: 'runTestFunctionalV2'
                     }
                     post {
@@ -220,7 +220,7 @@ pipeline {
                                     branch: env.BaseBranch,
                                     withSubmodules: true
                         functionalTest inst_repos: daosRepos(),
-                                       inst_rpms: functionalPackages(1, next_version),
+                                       inst_rpms: functionalPackages(1, next_version, "tests-internal"),
                                        test_function: 'runTestFunctionalV2'
                     }
                     post {
@@ -243,7 +243,7 @@ pipeline {
                                     branch: env.BaseBranch,
                                     withSubmodules: true
                         functionalTest inst_repos: daosRepos(),
-                                       inst_rpms: functionalPackages(1, next_version),
+                                       inst_rpms: functionalPackages(1, next_version, "tests-internal"),
                                        test_function: 'runTestFunctionalV2'
                     }
                     post {
@@ -267,7 +267,7 @@ pipeline {
                                     branch: env.BaseBranch,
                                     withSubmodules: true
                         functionalTest inst_repos: daosRepos(),
-                                       inst_rpms: functionalPackages(1, next_version),
+                                       inst_rpms: functionalPackages(1, next_version, "tests-internal"),
                                        test_function: 'runTestFunctionalV2'
                     }
                     post {
@@ -291,7 +291,7 @@ pipeline {
                                     branch: env.BaseBranch,
                                     withSubmodules: true
                         functionalTest inst_repos: daosRepos(),
-                                       inst_rpms: functionalPackages(1, next_version),
+                                       inst_rpms: functionalPackages(1, next_version, "tests-internal"),
                                        test_function: 'runTestFunctionalV2'
                     }
                     post {
@@ -315,7 +315,7 @@ pipeline {
                                     branch: env.BaseBranch,
                                     withSubmodules: true
                         functionalTest inst_repos: daosRepos(),
-                                       inst_rpms: functionalPackages(1, next_version),
+                                       inst_rpms: functionalPackages(1, next_version, "tests-internal"),
                                        test_function: 'runTestFunctionalV2'
                     }
                     post {
@@ -339,7 +339,7 @@ pipeline {
                                     branch: env.BaseBranch,
                                     withSubmodules: true
                         functionalTest inst_repos: daosRepos(),
-                                       inst_rpms: functionalPackages(1, next_version),
+                                       inst_rpms: functionalPackages(1, next_version, "tests-internal"),
                                        test_tag: params.TestTagTCP,
                                        ftest_arg: '--nvme=auto:-3DNAND --provider=ofi+tcp',
                                        test_function: 'runTestFunctionalV2'
@@ -365,7 +365,7 @@ pipeline {
                                     branch: env.BaseBranch,
                                     withSubmodules: true
                         functionalTest inst_repos: daosRepos(),
-                                       inst_rpms: functionalPackages(1, next_version),
+                                       inst_rpms: functionalPackages(1, next_version, "tests-internal"),
                                        test_tag: params.TestTagTCP,
                                        ftest_arg: '--nvme=auto:-3DNAND --provider=ofi+tcp',
                                        test_function: 'runTestFunctionalV2'
@@ -391,7 +391,7 @@ pipeline {
                                     branch: env.BaseBranch,
                                     withSubmodules: true
                         functionalTest inst_repos: daosRepos(),
-                                       inst_rpms: functionalPackages(1, next_version),
+                                       inst_rpms: functionalPackages(1, next_version, "tests-internal"),
                                        test_tag: params.TestTagTCP,
                                        ftest_arg: '--nvme=auto:-3DNAND --provider=ofi+tcp',
                                        test_function: 'runTestFunctionalV2'
@@ -417,7 +417,7 @@ pipeline {
                                     branch: env.BaseBranch,
                                     withSubmodules: true
                         functionalTest inst_repos: daosRepos(),
-                                       inst_rpms: functionalPackages(1, next_version) + "mercury-ucx",
+                                       inst_rpms: functionalPackages(1, next_version, "tests-internal") + "mercury-ucx",
                                        test_tag: params.TestTagUCX,
                                        ftest_arg: '--nvme=auto:-3DNAND --provider=ucx+dc_x',
                                        test_function: 'runTestFunctionalV2'
@@ -443,7 +443,7 @@ pipeline {
                                     branch: env.BaseBranch,
                                     withSubmodules: true
                         functionalTest inst_repos: daosRepos(),
-                                       inst_rpms: functionalPackages(1, next_version) + "mercury-ucx",
+                                       inst_rpms: functionalPackages(1, next_version, "tests-internal") + "mercury-ucx",
                                        test_tag: params.TestTagUCX,
                                        ftest_arg: '--nvme=auto:-3DNAND --provider=ucx+dc_x',
                                        test_function: 'runTestFunctionalV2'
@@ -469,7 +469,7 @@ pipeline {
                                     branch: env.BaseBranch,
                                     withSubmodules: true
                         functionalTest inst_repos: daosRepos(),
-                                       inst_rpms: functionalPackages(1, next_version) + "mercury-ucx",
+                                       inst_rpms: functionalPackages(1, next_version, "tests-internal") + "mercury-ucx",
                                        test_tag: params.TestTagUCX,
                                        ftest_arg: '--nvme=auto:-3DNAND --provider=ucx+dc_x',
                                        test_function: 'runTestFunctionalV2'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -111,13 +111,13 @@ pipeline {
                      defaultValue: true,
                      description: 'Run the CI Functional Hardware Large TCP test stage')
         booleanParam(name: 'CI_small_ucx_TEST',
-                     defaultValue: false,
+                     defaultValue: true,
                      description: 'Run the CI Functional Hardware Small UCX test stage')
         booleanParam(name: 'CI_medium_ucx_TEST',
-                     defaultValue: false,
+                     defaultValue: true,
                      description: 'Run the CI Functional Hardware Medium UCX test stage')
         booleanParam(name: 'CI_large_ucx_TEST',
-                     defaultValue: false,
+                     defaultValue: true,
                      description: 'Run the CI Functional Hardware Large UCX test stage')
         string(name: 'CI_FUNCTIONAL_VM9_LABEL',
                defaultValue: 'ci_vm9',

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -94,13 +94,13 @@ pipeline {
                      description: 'Run the functional Ubuntu 20 CI tests')
         booleanParam(name: 'CI_small_TEST',
                      defaultValue: true,
-                     description: 'Run the Small Cluster CI tests')
+                     description: 'Run the CI Functional Hardware Small test stage')
         booleanParam(name: 'CI_medium_TEST',
                      defaultValue: true,
-                     description: 'Run the Medium Cluster CI tests')
+                     description: 'Run the CI Functional Hardware Medium test stage')
         booleanParam(name: 'CI_large_TEST',
                      defaultValue: true,
-                     description: 'Run the Large Cluster CI tests')
+                     description: 'Run the CI Functional Hardware Large test stage')
         booleanParam(name: 'CI_small_tcp_TEST',
                      defaultValue: true,
                      description: 'Run the CI Functional Hardware Small TCP test stage')

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -82,16 +82,16 @@ pipeline {
                description: 'The base branch to run weekly-testing against (i.e. master, or a PR\'s branch)')
         booleanParam(name: 'CI_FUNCTIONAL_el7_TEST',
                      defaultValue: true,
-                     description: 'Run the functional CentOS 7 CI tests')
+                     description: 'Run the Functional on CentOS 7 test stage')
         booleanParam(name: 'CI_FUNCTIONAL_el8_TEST',
                      defaultValue: true,
-                     description: 'Run the functional EL 8 CI tests')
+                     description: 'Run the Functional on EL 8 test stage')
         booleanParam(name: 'CI_FUNCTIONAL_leap15_TEST',
                      defaultValue: true,
-                     description: 'Run the functional OpenSUSE Leap 15 CI tests')
+                     description: 'Run the Functional on Leap 15 test stage')
         booleanParam(name: 'CI_FUNCTIONAL_ubuntu20_TEST',
                      defaultValue: false,
-                     description: 'Run the functional Ubuntu 20 CI tests')
+                     description: 'Run the Functional on Ubuntu 20 test stage')
         booleanParam(name: 'CI_small_TEST',
                      defaultValue: true,
                      description: 'Run the CI Functional Hardware Small test stage')

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,7 +14,6 @@
 // To use a test branch (i.e. PR) until it lands to master
 // I.e. for testing library changes
 //@Library(value="pipeline-lib@your_branch") _
-@Library(value="pipeline-lib@DAOS-9979") _
 
 // Should try to figure this out automatically
 /* groovylint-disable-next-line CompileStatic, VariableName */

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,6 +14,7 @@
 // To use a test branch (i.e. PR) until it lands to master
 // I.e. for testing library changes
 //@Library(value="pipeline-lib@your_branch") _
+@Library(value="pipeline-lib@DAOS-9989") _
 
 // Should try to figure this out automatically
 /* groovylint-disable-next-line CompileStatic, VariableName */
@@ -69,52 +70,73 @@ pipeline {
                description: 'Priority of this build.  DO NOT USE WITHOUT PERMISSION.')
         string(name: 'TestTag',
                defaultValue: 'full_regression',
-               description: 'Test-tag to use for the weekly stages of this run (i.e. pr, daily_regression, full_regression, etc.)')
-        string(name: 'TestTagDailyTCP',
+               description: 'Test-tag to use for the weekly Functional Hardware Small/Medium/Large stages of this run (i.e. pr, daily_regression, full_regression, etc.)')
+        string(name: 'TestTagTCP',
                defaultValue: 'pr daily_regression',
-               description: 'Test-tag to use for the daily TCP stages of this run (i.e. pr, daily_regression, full_regression, etc.)')
-        string(name: 'TestTagDailyUCX',
+               description: 'Test-tag to use for the Functional Hardware Small/Medium/Large TCP stages of this run (i.e. pr, daily_regression, full_regression, etc.)')
+        string(name: 'TestTagUCX',
                defaultValue: 'pr daily_regression',
-               description: 'Test-tag to use for the daily UCX stages of this run (i.e. pr, daily_regression, full_regression, etc.)')
-        string(name: 'LaunchArgsDailyTCP',
-               defaultValue: '--nvme=auto:-3DNAND --provider=ofi+tcp',
-               description: 'Launch.py arguments to use in the HW daily TCP stages of this run')
-        string(name: 'LaunchArgsDailyUCX',
-               defaultValue: '--nvme=auto:-3DNAND --provider=ucx+dc_x',
-               description: 'Launch.py arguments to use in the HW daily UCX stages of this run')
+               description: 'Test-tag to use for the Functional Hardware Small/Medium/Large UCX stages of this run (i.e. pr, daily_regression, full_regression, etc.)')
         string(name: 'BaseBranch',
                defaultValue: base_branch,
                description: 'The base branch to run weekly-testing against (i.e. master, or a PR\'s branch)')
+        booleanParam(name: 'CI_small_TEST',
+                     defaultValue: true,
+                     description: 'Run the Small Cluster CI tests')
+        booleanParam(name: 'CI_medium_TEST',
+                     defaultValue: true,
+                     description: 'Run the Medium Cluster CI tests')
+        booleanParam(name: 'CI_large_TEST',
+                     defaultValue: true,
+                     description: 'Run the Large Cluster CI tests')
+        booleanParam(name: 'CI_FUNCTIONAL_HARDWARE_SMALL_TCP',
+                     defaultValue: true,
+                     description: 'Run the CI Functional Hardware Small TCP test stage')
+        booleanParam(name: 'CI_FUNCTIONAL_HARDWARE_MEDIUM_TCP',
+                     defaultValue: true,
+                     description: 'Run the CI Functional Hardware Medium TCP test stage')
+        booleanParam(name: 'CI_FUNCTIONAL_HARDWARE_LARGE_TCP',
+                     defaultValue: true,
+                     description: 'Run the CI Functional Hardware Large TCP test stage')
+        booleanParam(name: 'CI_FUNCTIONAL_HARDWARE_SMALL_UCX',
+                     defaultValue: false,
+                     description: 'Run the CI Functional Hardware Small UCX test stage')
+        booleanParam(name: 'CI_FUNCTIONAL_HARDWARE_MEDIUM_UCX',
+                     defaultValue: false,
+                     description: 'Run the CI Functional Hardware Medium UCX test stage')
+        booleanParam(name: 'CI_FUNCTIONAL_HARDWARE_LARGE_UCX',
+                     defaultValue: false,
+                     description: 'Run the CI Functional Hardware Large UCX test stage')
         string(name: 'CI_FUNCTIONAL_VM9_LABEL',
                defaultValue: 'ci_vm9',
                description: 'Label to use for 9 VM functional tests')
         string(name: 'CI_NVME_3_LABEL',
                defaultValue: 'ci_nvme3',
-               description: 'Label to use for 3 node NVMe tests')
+               description: 'Label to use for 3 node Functional Hardware Small stage')
         string(name: 'CI_NVME_5_LABEL',
                defaultValue: 'ci_nvme5',
-               description: 'Label to use for 5 node NVMe tests')
+               description: 'Label to use for 5 node Functional Hardware Medium stage')
         string(name: 'CI_NVME_9_LABEL',
                defaultValue: 'ci_nvme9',
-               description: 'Label to use for 9 node NVMe tests')
-        string(name: 'CI_HW_SMALL_DAILY_TCP_LABEL',
+               description: 'Label to use for 9 node Functional Hardware Large stage')
+        string(name: 'CI_HW_SMALL_TCP_LABEL',
                defaultValue: 'ci_nvme3',
-               description: 'Label to use for 3 node HW Small Daily TCP tests')
-        string(name: 'CI_HW_MEDIUM_DAILY_TCP_LABEL',
+               description: 'Label to use for 3 node Functional Hardware Small TCP stage')
+        string(name: 'CI_HW_MEDIUM_TCP_LABEL',
                defaultValue: 'ci_nvme5',
-               description: 'Label to use for 5 node HW Medium Daily TCP tests')
-        string(name: 'CI_HW_LARGE_DAILY_TCP_LABEL',
+               description: 'Label to use for 5 node Functional Hardware Medium TCP stage')
+        string(name: 'CI_HW_LARGE_TCP_LABEL',
                defaultValue: 'ci_nvme9',
-               description: 'Label to use for 9 node HW Large Daily TCP tests')
-        string(name: 'CI_HW_SMALL_DAILY_UCX_LABEL',
+               description: 'Label to use for 9 node Functional Hardware Large TCP stage')
+        string(name: 'CI_HW_SMALL_UCX_LABEL',
                defaultValue: 'ci_nvme3',
-               description: 'Label to use for 3 node HW Small Daily UCX tests')
-        string(name: 'CI_HW_MEDIUM_DAILY_UCX_LABEL',
+               description: 'Label to use for 3 node Functional Hardware Small UCX stage')
+        string(name: 'CI_HW_MEDIUM_UCX_LABEL',
                defaultValue: 'ci_nvme5',
-               description: 'Label to use for 5 node HW Medium Daily UCX tests')
-        string(name: 'CI_HW_LARGE_DAILY_UCX_LABEL',
+               description: 'Label to use for 5 node Functional Hardware Medium UCX stage')
+        string(name: 'CI_HW_LARGE_UCX_LABEL',
                defaultValue: 'ci_nvme9',
-               description: 'Label to use for 9 node HW Large Daily UCX tests')
+               description: 'Label to use for 9 node Functional Hardware Large UCX stage')
     }
 
     stages {
@@ -302,14 +324,14 @@ pipeline {
                         }
                     }
                 } // stage('Functional_Hardware_Large')
-                stage('Functional Hardware Small Daily TCP') {
+                stage('Functional Hardware Small TCP') {
                     when {
                         beforeAgent true
                         expression { !skipStage() }
                     }
                     agent {
                         // 2 node cluster with 1 IB/node + 1 test control node
-                        label params.CI_HW_SMALL_DAILY_TCP_LABEL
+                        label params.CI_HW_SMALL_TCP_LABEL
                     }
                     steps {
                         // Need to get back onto base_branch for ci/
@@ -318,8 +340,8 @@ pipeline {
                                     withSubmodules: true
                         functionalTest inst_repos: daosRepos(),
                                        inst_rpms: functionalPackages(1, next_version),
-                                       test_tag: params.TestTagDailyTCP,
-                                       ftest_arg: params.LaunchArgsDailyTCP,
+                                       test_tag: params.TestTagTCP,
+                                       ftest_arg: '--nvme=auto:-3DNAND --provider=ofi+tcp',
                                        test_function: 'runTestFunctionalV2'
                     }
                     post {
@@ -327,15 +349,15 @@ pipeline {
                             functionalTestPostV2()
                         }
                     }
-                } // stage('Functional Hardware Small Daily TCP')
-                stage('Functional Hardware Medium Daily TCP') {
+                } // stage('Functional Hardware Small TCP')
+                stage('Functional Hardware Medium TCP') {
                     when {
                         beforeAgent true
                         expression { !skipStage() }
                     }
                     agent {
                         // 4 node cluster with 2 IB/node + 1 test control node
-                        label params.CI_HW_MEDIUM_DAILY_TCP_LABEL
+                        label params.CI_HW_MEDIUM_TCP_LABEL
                     }
                     steps {
                         // Need to get back onto base_branch for ci/
@@ -344,8 +366,8 @@ pipeline {
                                     withSubmodules: true
                         functionalTest inst_repos: daosRepos(),
                                        inst_rpms: functionalPackages(1, next_version),
-                                       test_tag: params.TestTagDailyTCP,
-                                       ftest_arg: params.LaunchArgsDailyTCP,
+                                       test_tag: params.TestTagTCP,
+                                       ftest_arg: '--nvme=auto:-3DNAND --provider=ofi+tcp',
                                        test_function: 'runTestFunctionalV2'
                     }
                     post {
@@ -353,15 +375,15 @@ pipeline {
                             functionalTestPostV2()
                         }
                     }
-                } // stage('Functional Hardware Medium Daily TCP')
-                stage('Functional Hardware Large Daily TCP') {
+                } // stage('Functional Hardware Medium TCP')
+                stage('Functional Hardware Large TCP') {
                     when {
                         beforeAgent true
                         expression { !skipStage() }
                     }
                     agent {
                         // 8+ node cluster with 1 IB/node + 1 test control node
-                        label params.CI_HW_LARGE_DAILY_TCP_LABEL
+                        label params.CI_HW_LARGE_TCP_LABEL
                     }
                     steps {
                         // Need to get back onto base_branch for ci/
@@ -370,8 +392,8 @@ pipeline {
                                     withSubmodules: true
                         functionalTest inst_repos: daosRepos(),
                                        inst_rpms: functionalPackages(1, next_version),
-                                       test_tag: params.TestTagDailyTCP,
-                                       ftest_arg: params.LaunchArgsDailyTCP,
+                                       test_tag: params.TestTagTCP,
+                                       ftest_arg: '--nvme=auto:-3DNAND --provider=ofi+tcp',
                                        test_function: 'runTestFunctionalV2'
                     }
                     post {
@@ -379,15 +401,15 @@ pipeline {
                             functionalTestPostV2()
                         }
                     }
-                } // stage('Functional Hardware Large Daily TCP')
-                stage('Functional Hardware Small Daily UCX') {
+                } // stage('Functional Hardware Large TCP')
+                stage('Functional Hardware Small UCX') {
                     when {
                         beforeAgent true
                         expression { !skipStage() }
                     }
                     agent {
                         // 2 node cluster with 1 IB/node + 1 test control node
-                        label params.CI_HW_SMALL_DAILY_UCX_LABEL
+                        label params.CI_HW_SMALL_UCX_LABEL
                     }
                     steps {
                         // Need to get back onto base_branch for ci/
@@ -395,9 +417,9 @@ pipeline {
                                     branch: env.BaseBranch,
                                     withSubmodules: true
                         functionalTest inst_repos: daosRepos(),
-                                       inst_rpms: functionalPackages(1, next_version),
-                                       test_tag: params.TestTagDailyUCX,
-                                       ftest_arg: params.LaunchArgsDailyUCX,
+                                       inst_rpms: functionalPackages(1, next_version) + "mercury-ucx",
+                                       test_tag: params.TestTagUCX,
+                                       ftest_arg: '--nvme=auto:-3DNAND --provider=ucx+dc_x',
                                        test_function: 'runTestFunctionalV2'
                     }
                     post {
@@ -405,15 +427,15 @@ pipeline {
                             functionalTestPostV2()
                         }
                     }
-                } // stage('Functional Hardware Small Daily UCX')
-                stage('Functional Hardware Medium Daily UCX') {
+                } // stage('Functional Hardware Small UCX')
+                stage('Functional Hardware Medium UCX') {
                     when {
                         beforeAgent true
                         expression { !skipStage() }
                     }
                     agent {
                         // 4 node cluster with 2 IB/node + 1 test control node
-                        label params.CI_HW_MEDIUM_DAILY_UCX_LABEL
+                        label params.CI_HW_MEDIUM_UCX_LABEL
                     }
                     steps {
                         // Need to get back onto base_branch for ci/
@@ -421,9 +443,9 @@ pipeline {
                                     branch: env.BaseBranch,
                                     withSubmodules: true
                         functionalTest inst_repos: daosRepos(),
-                                       inst_rpms: functionalPackages(1, next_version),
-                                       test_tag: params.TestTagDailyUCX,
-                                       ftest_arg: params.LaunchArgsDailyUCX,
+                                       inst_rpms: functionalPackages(1, next_version) + "mercury-ucx",
+                                       test_tag: params.TestTagUCX,
+                                       ftest_arg: '--nvme=auto:-3DNAND --provider=ucx+dc_x',
                                        test_function: 'runTestFunctionalV2'
                     }
                     post {
@@ -431,15 +453,15 @@ pipeline {
                             functionalTestPostV2()
                         }
                     }
-                } // stage('Functional Hardware Medium Daily UCX')
-                stage('Functional Hardware Large Daily UCX') {
+                } // stage('Functional Hardware Medium UCX')
+                stage('Functional Hardware Large UCX') {
                     when {
                         beforeAgent true
                         expression { !skipStage() }
                     }
                     agent {
                         // 8+ node cluster with 1 IB/node + 1 test control node
-                        label params.CI_HW_LARGE_DAILY_UCX_LABEL
+                        label params.CI_HW_LARGE_UCX_LABEL
                     }
                     steps {
                         // Need to get back onto base_branch for ci/
@@ -447,9 +469,9 @@ pipeline {
                                     branch: env.BaseBranch,
                                     withSubmodules: true
                         functionalTest inst_repos: daosRepos(),
-                                       inst_rpms: functionalPackages(1, next_version),
-                                       test_tag: params.TestTagDailyUCX,
-                                       ftest_arg: params.LaunchArgsDailyUCX,
+                                       inst_rpms: functionalPackages(1, next_version) + "mercury-ucx",
+                                       test_tag: params.TestTagUCX,
+                                       ftest_arg: '--nvme=auto:-3DNAND --provider=ucx+dc_x',
                                        test_function: 'runTestFunctionalV2'
                     }
                     post {
@@ -457,7 +479,7 @@ pipeline {
                             functionalTestPostV2()
                         }
                     }
-                } // stage('Functional Hardware Large Daily UCX')
+                } // stage('Functional Hardware Large UCX')
             } // parallel
         } // stage('Test')
     } //stages

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -69,7 +69,19 @@ pipeline {
                description: 'Priority of this build.  DO NOT USE WITHOUT PERMISSION.')
         string(name: 'TestTag',
                defaultValue: 'full_regression',
-               description: 'Test-tag to use for this run (i.e. pr, daily_regression, full_regression, etc.)')
+               description: 'Test-tag to use for the weekly stages of this run (i.e. pr, daily_regression, full_regression, etc.)')
+        string(name: 'TestTagDailyTCP',
+               defaultValue: 'pr daily_regression',
+               description: 'Test-tag to use for the daily TCP stages of this run (i.e. pr, daily_regression, full_regression, etc.)')
+        string(name: 'TestTagDailyUCX',
+               defaultValue: 'pr daily_regression',
+               description: 'Test-tag to use for the daily UCX stages of this run (i.e. pr, daily_regression, full_regression, etc.)')
+        string(name: 'LaunchArgsDailyTCP',
+               defaultValue: '--nvme=auto:-3DNAND --provider=ofi+tcp',
+               description: 'Launch.py arguments to use in the HW daily TCP stages of this run')
+        string(name: 'LaunchArgsDailyUCX',
+               defaultValue: '--nvme=auto:-3DNAND --provider=ucx+dc_x',
+               description: 'Launch.py arguments to use in the HW daily UCX stages of this run')
         string(name: 'BaseBranch',
                defaultValue: base_branch,
                description: 'The base branch to run weekly-testing against (i.e. master, or a PR\'s branch)')
@@ -85,6 +97,24 @@ pipeline {
         string(name: 'CI_NVME_9_LABEL',
                defaultValue: 'ci_nvme9',
                description: 'Label to use for 9 node NVMe tests')
+        string(name: 'CI_HW_SMALL_DAILY_TCP_LABEL',
+               defaultValue: 'ci_nvme3',
+               description: 'Label to use for 3 node HW Small Daily TCP tests')
+        string(name: 'CI_HW_MEDIUM_DAILY_TCP_LABEL',
+               defaultValue: 'ci_nvme5',
+               description: 'Label to use for 5 node HW Medium Daily TCP tests')
+        string(name: 'CI_HW_LARGE_DAILY_TCP_LABEL',
+               defaultValue: 'ci_nvme9',
+               description: 'Label to use for 9 node HW Large Daily TCP tests')
+        string(name: 'CI_HW_SMALL_DAILY_UCX_LABEL',
+               defaultValue: 'ci_nvme3',
+               description: 'Label to use for 3 node HW Small Daily UCX tests')
+        string(name: 'CI_HW_MEDIUM_DAILY_UCX_LABEL',
+               defaultValue: 'ci_nvme5',
+               description: 'Label to use for 5 node HW Medium Daily UCX tests')
+        string(name: 'CI_HW_LARGE_DAILY_UCX_LABEL',
+               defaultValue: 'ci_nvme9',
+               description: 'Label to use for 9 node HW Large Daily UCX tests')
     }
 
     stages {
@@ -272,6 +302,162 @@ pipeline {
                         }
                     }
                 } // stage('Functional_Hardware_Large')
+                stage('Functional Hardware Small Daily TCP') {
+                    when {
+                        beforeAgent true
+                        expression { !skipStage() }
+                    }
+                    agent {
+                        // 2 node cluster with 1 IB/node + 1 test control node
+                        label params.CI_HW_SMALL_DAILY_TCP_LABEL
+                    }
+                    steps {
+                        // Need to get back onto base_branch for ci/
+                        checkoutScm url: 'https://github.com/daos-stack/daos.git',
+                                    branch: env.BaseBranch,
+                                    withSubmodules: true
+                        functionalTest inst_repos: daosRepos(),
+                                       inst_rpms: functionalPackages(1, next_version),
+                                       test_tag: params.TestTagDailyTCP,
+                                       ftest_arg: params.LaunchArgsDailyTCP,
+                                       test_function: 'runTestFunctionalV2'
+                    }
+                    post {
+                        always {
+                            functionalTestPostV2()
+                        }
+                    }
+                } // stage('Functional Hardware Small Daily TCP')
+                stage('Functional Hardware Medium Daily TCP') {
+                    when {
+                        beforeAgent true
+                        expression { !skipStage() }
+                    }
+                    agent {
+                        // 4 node cluster with 2 IB/node + 1 test control node
+                        label params.CI_HW_MEDIUM_DAILY_TCP_LABEL
+                    }
+                    steps {
+                        // Need to get back onto base_branch for ci/
+                        checkoutScm url: 'https://github.com/daos-stack/daos.git',
+                                    branch: env.BaseBranch,
+                                    withSubmodules: true
+                        functionalTest inst_repos: daosRepos(),
+                                       inst_rpms: functionalPackages(1, next_version),
+                                       test_tag: params.TestTagDailyTCP,
+                                       ftest_arg: params.LaunchArgsDailyTCP,
+                                       test_function: 'runTestFunctionalV2'
+                    }
+                    post {
+                        always {
+                            functionalTestPostV2()
+                        }
+                    }
+                } // stage('Functional Hardware Medium Daily TCP')
+                stage('Functional Hardware Large Daily TCP') {
+                    when {
+                        beforeAgent true
+                        expression { !skipStage() }
+                    }
+                    agent {
+                        // 8+ node cluster with 1 IB/node + 1 test control node
+                        label params.CI_HW_LARGE_DAILY_TCP_LABEL
+                    }
+                    steps {
+                        // Need to get back onto base_branch for ci/
+                        checkoutScm url: 'https://github.com/daos-stack/daos.git',
+                                    branch: env.BaseBranch,
+                                    withSubmodules: true
+                        functionalTest inst_repos: daosRepos(),
+                                       inst_rpms: functionalPackages(1, next_version),
+                                       test_tag: params.TestTagDailyTCP,
+                                       ftest_arg: params.LaunchArgsDailyTCP,
+                                       test_function: 'runTestFunctionalV2'
+                    }
+                    post {
+                        always {
+                            functionalTestPostV2()
+                        }
+                    }
+                } // stage('Functional Hardware Large Daily TCP')
+                stage('Functional Hardware Small Daily UCX') {
+                    when {
+                        beforeAgent true
+                        expression { !skipStage() }
+                    }
+                    agent {
+                        // 2 node cluster with 1 IB/node + 1 test control node
+                        label params.CI_HW_SMALL_DAILY_UCX_LABEL
+                    }
+                    steps {
+                        // Need to get back onto base_branch for ci/
+                        checkoutScm url: 'https://github.com/daos-stack/daos.git',
+                                    branch: env.BaseBranch,
+                                    withSubmodules: true
+                        functionalTest inst_repos: daosRepos(),
+                                       inst_rpms: functionalPackages(1, next_version),
+                                       test_tag: params.TestTagDailyUCX,
+                                       ftest_arg: params.LaunchArgsDailyUCX,
+                                       test_function: 'runTestFunctionalV2'
+                    }
+                    post {
+                        always {
+                            functionalTestPostV2()
+                        }
+                    }
+                } // stage('Functional Hardware Small Daily UCX')
+                stage('Functional Hardware Medium Daily UCX') {
+                    when {
+                        beforeAgent true
+                        expression { !skipStage() }
+                    }
+                    agent {
+                        // 4 node cluster with 2 IB/node + 1 test control node
+                        label params.CI_HW_MEDIUM_DAILY_UCX_LABEL
+                    }
+                    steps {
+                        // Need to get back onto base_branch for ci/
+                        checkoutScm url: 'https://github.com/daos-stack/daos.git',
+                                    branch: env.BaseBranch,
+                                    withSubmodules: true
+                        functionalTest inst_repos: daosRepos(),
+                                       inst_rpms: functionalPackages(1, next_version),
+                                       test_tag: params.TestTagDailyUCX,
+                                       ftest_arg: params.LaunchArgsDailyUCX,
+                                       test_function: 'runTestFunctionalV2'
+                    }
+                    post {
+                        always {
+                            functionalTestPostV2()
+                        }
+                    }
+                } // stage('Functional Hardware Medium Daily UCX')
+                stage('Functional Hardware Large Daily UCX') {
+                    when {
+                        beforeAgent true
+                        expression { !skipStage() }
+                    }
+                    agent {
+                        // 8+ node cluster with 1 IB/node + 1 test control node
+                        label params.CI_HW_LARGE_DAILY_UCX_LABEL
+                    }
+                    steps {
+                        // Need to get back onto base_branch for ci/
+                        checkoutScm url: 'https://github.com/daos-stack/daos.git',
+                                    branch: env.BaseBranch,
+                                    withSubmodules: true
+                        functionalTest inst_repos: daosRepos(),
+                                       inst_rpms: functionalPackages(1, next_version),
+                                       test_tag: params.TestTagDailyUCX,
+                                       ftest_arg: params.LaunchArgsDailyUCX,
+                                       test_function: 'runTestFunctionalV2'
+                    }
+                    post {
+                        always {
+                            functionalTestPostV2()
+                        }
+                    }
+                } // stage('Functional Hardware Large Daily UCX')
             } // parallel
         } // stage('Test')
     } //stages

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -80,9 +80,6 @@ pipeline {
         string(name: 'BaseBranch',
                defaultValue: base_branch,
                description: 'The base branch to run weekly-testing against (i.e. master, or a PR\'s branch)')
-        string(name: 'CI_RPM_TEST_VERSION',
-               defaultValue: '',
-               description: 'Package version to use instead of building. example: 1.3.103-1, 1.2-2')
         booleanParam(name: 'CI_FUNCTIONAL_el7_TEST',
                      defaultValue: true,
                      description: 'Run the functional CentOS 7 CI tests')

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,7 +14,6 @@
 // To use a test branch (i.e. PR) until it lands to master
 // I.e. for testing library changes
 //@Library(value="pipeline-lib@your_branch") _
-@Library(value="pipeline-lib@DAOS-9989") _
 
 // Should try to figure this out automatically
 /* groovylint-disable-next-line CompileStatic, VariableName */
@@ -80,9 +79,6 @@ pipeline {
         string(name: 'BaseBranch',
                defaultValue: base_branch,
                description: 'The base branch to run weekly-testing against (i.e. master, or a PR\'s branch)')
-        booleanParam(name: 'CI_FUNCTIONAL_el7_TEST',
-                     defaultValue: true,
-                     description: 'Run the Functional on CentOS 7 test stage')
         booleanParam(name: 'CI_FUNCTIONAL_el8_TEST',
                      defaultValue: true,
                      description: 'Run the Functional on EL 8 test stage')
@@ -172,30 +168,7 @@ pipeline {
                 expression { !skipStage() }
             }
             parallel {
-                stage('Functional on CentOS 7') {
-                    when {
-                        beforeAgent true
-                        expression { !skipStage() }
-                    }
-                    agent {
-                        label params.CI_FUNCTIONAL_VM9_LABEL
-                    }
-                    steps {
-                        // Need to get back onto base_branch for ci/
-                        checkoutScm url: 'https://github.com/daos-stack/daos.git',
-                                    branch: env.BaseBranch,
-                                    withSubmodules: true
-                        functionalTest inst_repos: daosRepos(),
-                                       inst_rpms: functionalPackages(1, next_version, "tests-internal"),
-                                       test_function: 'runTestFunctionalV2'
-                    }
-                    post {
-                        always {
-                            functionalTestPostV2()
-                        }
-                    }
-                } // stage('Functional on CentOS 7')
-                stage('Functional on CentOS 8') {
+                 stage('Functional on CentOS 8') {
                     when {
                         beforeAgent true
                         expression { !skipStage() }
@@ -423,7 +396,7 @@ pipeline {
                                     branch: env.BaseBranch,
                                     withSubmodules: true
                         functionalTest inst_repos: daosRepos(),
-                                       inst_rpms: functionalPackages(1, next_version, "tests-internal") + "mercury-ucx",
+                                       inst_rpms: "mercury-ucx " + functionalPackages(1, next_version, "tests-internal"),
                                        test_function: 'runTestFunctionalV2'
                     }
                     post {
@@ -447,7 +420,7 @@ pipeline {
                                     branch: env.BaseBranch,
                                     withSubmodules: true
                         functionalTest inst_repos: daosRepos(),
-                                       inst_rpms: functionalPackages(1, next_version, "tests-internal") + "mercury-ucx",
+                                       inst_rpms: "mercury-ucx " + functionalPackages(1, next_version, "tests-internal"),
                                        test_function: 'runTestFunctionalV2'
                     }
                     post {
@@ -471,7 +444,7 @@ pipeline {
                                     branch: env.BaseBranch,
                                     withSubmodules: true
                         functionalTest inst_repos: daosRepos(),
-                                       inst_rpms: functionalPackages(1, next_version, "tests-internal") + "mercury-ucx",
+                                       inst_rpms: "mercury-ucx " + functionalPackages(1, next_version, "tests-internal"),
                                        test_function: 'runTestFunctionalV2'
                     }
                     post {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -352,8 +352,6 @@ pipeline {
                                     withSubmodules: true
                         functionalTest inst_repos: daosRepos(),
                                        inst_rpms: functionalPackages(1, next_version, "tests-internal"),
-                                       test_tag: params.TestTagTCP,
-                                       ftest_arg: '--nvme=auto:-3DNAND --provider=ofi+tcp',
                                        test_function: 'runTestFunctionalV2'
                     }
                     post {
@@ -378,8 +376,6 @@ pipeline {
                                     withSubmodules: true
                         functionalTest inst_repos: daosRepos(),
                                        inst_rpms: functionalPackages(1, next_version, "tests-internal"),
-                                       test_tag: params.TestTagTCP,
-                                       ftest_arg: '--nvme=auto:-3DNAND --provider=ofi+tcp',
                                        test_function: 'runTestFunctionalV2'
                     }
                     post {
@@ -404,8 +400,6 @@ pipeline {
                                     withSubmodules: true
                         functionalTest inst_repos: daosRepos(),
                                        inst_rpms: functionalPackages(1, next_version, "tests-internal"),
-                                       test_tag: params.TestTagTCP,
-                                       ftest_arg: '--nvme=auto:-3DNAND --provider=ofi+tcp',
                                        test_function: 'runTestFunctionalV2'
                     }
                     post {
@@ -430,8 +424,6 @@ pipeline {
                                     withSubmodules: true
                         functionalTest inst_repos: daosRepos(),
                                        inst_rpms: functionalPackages(1, next_version, "tests-internal") + "mercury-ucx",
-                                       test_tag: params.TestTagUCX,
-                                       ftest_arg: '--nvme=auto:-3DNAND --provider=ucx+dc_x',
                                        test_function: 'runTestFunctionalV2'
                     }
                     post {
@@ -456,8 +448,6 @@ pipeline {
                                     withSubmodules: true
                         functionalTest inst_repos: daosRepos(),
                                        inst_rpms: functionalPackages(1, next_version, "tests-internal") + "mercury-ucx",
-                                       test_tag: params.TestTagUCX,
-                                       ftest_arg: '--nvme=auto:-3DNAND --provider=ucx+dc_x',
                                        test_function: 'runTestFunctionalV2'
                     }
                     post {
@@ -482,8 +472,6 @@ pipeline {
                                     withSubmodules: true
                         functionalTest inst_repos: daosRepos(),
                                        inst_rpms: functionalPackages(1, next_version, "tests-internal") + "mercury-ucx",
-                                       test_tag: params.TestTagUCX,
-                                       ftest_arg: '--nvme=auto:-3DNAND --provider=ucx+dc_x',
                                        test_function: 'runTestFunctionalV2'
                     }
                     post {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -101,22 +101,22 @@ pipeline {
         booleanParam(name: 'CI_large_TEST',
                      defaultValue: true,
                      description: 'Run the Large Cluster CI tests')
-        booleanParam(name: 'CI_FUNCTIONAL_HARDWARE_SMALL_TCP',
+        booleanParam(name: 'CI_small_tcp_TEST',
                      defaultValue: true,
                      description: 'Run the CI Functional Hardware Small TCP test stage')
-        booleanParam(name: 'CI_FUNCTIONAL_HARDWARE_MEDIUM_TCP',
+        booleanParam(name: 'CI_medium_tcp_TEST',
                      defaultValue: true,
                      description: 'Run the CI Functional Hardware Medium TCP test stage')
-        booleanParam(name: 'CI_FUNCTIONAL_HARDWARE_LARGE_TCP',
+        booleanParam(name: 'CI_large_tcp_TEST',
                      defaultValue: true,
                      description: 'Run the CI Functional Hardware Large TCP test stage')
-        booleanParam(name: 'CI_FUNCTIONAL_HARDWARE_SMALL_UCX',
+        booleanParam(name: 'CI_small_ucx_TEST',
                      defaultValue: false,
                      description: 'Run the CI Functional Hardware Small UCX test stage')
-        booleanParam(name: 'CI_FUNCTIONAL_HARDWARE_MEDIUM_UCX',
+        booleanParam(name: 'CI_medium_ucx_TEST',
                      defaultValue: false,
                      description: 'Run the CI Functional Hardware Medium UCX test stage')
-        booleanParam(name: 'CI_FUNCTIONAL_HARDWARE_LARGE_UCX',
+        booleanParam(name: 'CI_large_ucx_TEST',
                      defaultValue: false,
                      description: 'Run the CI Functional Hardware Large UCX test stage')
         string(name: 'CI_FUNCTIONAL_VM9_LABEL',

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,6 +14,7 @@
 // To use a test branch (i.e. PR) until it lands to master
 // I.e. for testing library changes
 //@Library(value="pipeline-lib@your_branch") _
+@Library(value="pipeline-lib@DAOS-9979") _
 
 // Should try to figure this out automatically
 /* groovylint-disable-next-line CompileStatic, VariableName */
@@ -396,7 +397,7 @@ pipeline {
                                     branch: env.BaseBranch,
                                     withSubmodules: true
                         functionalTest inst_repos: daosRepos(),
-                                       inst_rpms: "mercury-ucx " + functionalPackages(1, next_version, "tests-internal"),
+                                       inst_rpms: functionalPackages(1, next_version, "tests-internal"),
                                        test_function: 'runTestFunctionalV2'
                     }
                     post {
@@ -420,7 +421,7 @@ pipeline {
                                     branch: env.BaseBranch,
                                     withSubmodules: true
                         functionalTest inst_repos: daosRepos(),
-                                       inst_rpms: "mercury-ucx " + functionalPackages(1, next_version, "tests-internal"),
+                                       inst_rpms: functionalPackages(1, next_version, "tests-internal"),
                                        test_function: 'runTestFunctionalV2'
                     }
                     post {
@@ -444,7 +445,7 @@ pipeline {
                                     branch: env.BaseBranch,
                                     withSubmodules: true
                         functionalTest inst_repos: daosRepos(),
-                                       inst_rpms: "mercury-ucx " + functionalPackages(1, next_version, "tests-internal"),
+                                       inst_rpms: functionalPackages(1, next_version, "tests-internal"),
                                        test_function: 'runTestFunctionalV2'
                     }
                     post {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -80,6 +80,21 @@ pipeline {
         string(name: 'BaseBranch',
                defaultValue: base_branch,
                description: 'The base branch to run weekly-testing against (i.e. master, or a PR\'s branch)')
+        string(name: 'CI_RPM_TEST_VERSION',
+               defaultValue: '',
+               description: 'Package version to use instead of building. example: 1.3.103-1, 1.2-2')
+        booleanParam(name: 'CI_FUNCTIONAL_el7_TEST',
+                     defaultValue: true,
+                     description: 'Run the functional CentOS 7 CI tests')
+        booleanParam(name: 'CI_FUNCTIONAL_el8_TEST',
+                     defaultValue: true,
+                     description: 'Run the functional EL 8 CI tests')
+        booleanParam(name: 'CI_FUNCTIONAL_leap15_TEST',
+                     defaultValue: true,
+                     description: 'Run the functional OpenSUSE Leap 15 CI tests')
+        booleanParam(name: 'CI_FUNCTIONAL_ubuntu20_TEST',
+                     defaultValue: false,
+                     description: 'Run the functional Ubuntu 20 CI tests')
         booleanParam(name: 'CI_small_TEST',
                      defaultValue: true,
                      description: 'Run the Small Cluster CI tests')


### PR DESCRIPTION
Enable weekly testing of the pr and daily_regession taggged tests on the
Functional HW test stages with the tcp and ucx providers.  This extends
the normal CI daily testing of pr and daily_regession tagged tests on
the Functional HW test stages with the verbs provider.

Signed-off-by: Phillip Henderson <phillip.henderson@intel.com>