### PR TITLE
Refactor for affinity sources

### DIFF
--- a/src/control/lib/control/auto.go
+++ b/src/control/lib/control/auto.go
@@ -696,7 +696,7 @@ func genConfig(log logging.Logger, newEngineCfg newEngineCfgFn, accessPoints []s
 		WithNrHugePages(reqHugePages).
 		WithEnableVMD(sd.vmdEnabled)
 
-	if err := cfg.SetEngineAffinities(log, nil); err != nil {
+	if err := cfg.SetEngineAffinities(log); err != nil {
 		return nil, errors.Wrap(err, "setting engine affinities")
 	}
 

--- a/src/control/server/server.go
+++ b/src/control/server/server.go
@@ -36,6 +36,16 @@ import (
 	"github.com/daos-stack/daos/src/control/system/raft"
 )
 
+func genFiAffFn(fis *hardware.FabricInterfaceSet) config.EngineAffinityFn {
+	return func(l logging.Logger, e *engine.Config) (uint, error) {
+		fi, err := fis.GetInterfaceOnNetDevice(e.Fabric.Interface, e.Fabric.Provider)
+		if err != nil {
+			return 0, err
+		}
+		return fi.NUMANode, nil
+	}
+}
+
 func processConfig(log logging.Logger, cfg *config.Server, fis *hardware.FabricInterfaceSet) error {
 	processFabricProvider(cfg)
 
@@ -44,7 +54,12 @@ func processConfig(log logging.Logger, cfg *config.Server, fis *hardware.FabricI
 		return errors.Wrapf(err, "retrieve hugepage info")
 	}
 
-	if err := cfg.SetEngineAffinities(log, fis); err != nil {
+	affinitySources := []config.EngineAffinityFn{
+		// TODO: Add pmem as the primary source of NUMA affinity, if available,
+		// then fall back to other sources as necessary.
+		genFiAffFn(fis),
+	}
+	if err := cfg.SetEngineAffinities(log, affinitySources...); err != nil {
 		return errors.Wrap(err, "failed to set engine affinities")
 	}
 

--- a/src/control/server/server_utils_test.go
+++ b/src/control/server/server_utils_test.go
@@ -470,7 +470,7 @@ func TestServer_prepBdevStorage(t *testing.T) {
 			}
 
 			// ensure that the engine affinities are set.
-			if err := cfg.SetEngineAffinities(log, nil); err != nil {
+			if err := cfg.SetEngineAffinities(log); err != nil {
 				t.Fatal(err)
 			}
 


### PR DESCRIPTION
Allow affinity detection methods to be injected into
the config.Server.SetEngineAffinities() method in order
to maintain clean package boundaries and areas of
responsibility.

Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com>