### PR TITLE
DAOS-10494 common: Assert macros run the condition more than once (#8873)

### DIFF
--- a/src/include/gurt/debug.h
+++ b/src/include/gurt/debug.h
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2017-2021 Intel Corporation.
+ * (C) Copyright 2017-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -286,23 +286,24 @@ int d_register_alt_assert(void (*alt_assert)(const int, const char*,
 
 #define D_ASSERT(e)							\
 	do {								\
-		if (!(e)) {						\
-			D_FATAL("Assertion '%s' failed\n", #e);		\
-			d_log_sync();					\
-		}							\
+		if (e)							\
+			break;						\
+		D_FATAL("Assertion '%s' failed\n", #e);			\
+		d_log_sync();						\
 		if (d_alt_assert != NULL)				\
-			d_alt_assert((int64_t)(e), #e, __FILE__, __LINE__);\
-		assert(e);						\
+			d_alt_assert(0, #e, __FILE__, __LINE__);	\
+		assert(0);						\
 	} while (0)
 
-#define D_ASSERTF(cond, fmt, ...)					\
-do {									\
-	if (!(cond))							\
-		D_FATAL("Assertion '%s' failed: " fmt, #cond, ## __VA_ARGS__); \
-	if (d_alt_assert != NULL)					\
-		d_alt_assert((int64_t)(cond), #cond, __FILE__, __LINE__);\
-	assert(cond);							\
-} while (0)
+#define D_ASSERTF(cond, fmt, ...)						\
+	do {									\
+		if (cond)							\
+			break;							\
+		D_FATAL("Assertion '%s' failed: " fmt, #cond, ## __VA_ARGS__);	\
+		if (d_alt_assert != NULL)					\
+			d_alt_assert(0, #cond, __FILE__, __LINE__);		\
+		assert(0);							\
+	} while (0)
 
 #define D_CASSERT(cond, ...)						\
 	_Static_assert(cond, #cond ": " __VA_ARGS__)

--- a/src/vos/evtree.c
+++ b/src/vos/evtree.c
@@ -3462,7 +3462,7 @@ evt_node_delete(struct evt_context *tcx)
 {
 	struct evt_trace	*trace;
 	struct evt_node		*node;
-	struct evt_node_entry	*ne;
+	struct evt_node_entry	*ne = NULL;
 	void			*data;
 	umem_off_t		*child_offp;
 	umem_off_t		 child_off;

--- a/src/vos/vos_gc.c
+++ b/src/vos/vos_gc.c
@@ -130,7 +130,7 @@ gc_drain_evt(struct vos_gc *gc, struct vos_pool *pool, daos_handle_t coh,
 
 	D_DEBUG(DB_TRACE, "drain %s evtree, creds=%d\n", gc->gc_name, *credits);
 	rc = evt_drain(toh, credits, empty);
-	evt_close(toh);
+	D_ASSERT(evt_close(toh) == 0);
 	if (rc)
 		goto failed;
 


### PR DESCRIPTION
This can be problematic if the condition runs a function.  We noticed
this when trying to insert a patch for coverity issue 349749. That
fix is in this patch for reference.

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>