### PR TITLE
DAOS-10494 common: Use likely in assert macro

### DIFF
--- a/src/include/gurt/common.h
+++ b/src/include/gurt/common.h
@@ -48,10 +48,10 @@ extern "C" {
 #endif
 
 #ifndef likely
-#define likely(x)	__builtin_expect((x), 1)
+#define likely(x)	__builtin_expect((uintptr_t)(x), 1)
 #endif
 #ifndef unlikely
-#define unlikely(x)	__builtin_expect((x), 0)
+#define unlikely(x)	__builtin_expect((uintptr_t)(x), 0)
 #endif
 
 /* Check if bit is set in passed val */

--- a/src/include/gurt/debug.h
+++ b/src/include/gurt/debug.h
@@ -286,7 +286,7 @@ int d_register_alt_assert(void (*alt_assert)(const int, const char*,
 
 #define D_ASSERT(e)							\
 	do {								\
-		if (e)							\
+		if (likely(e))						\
 			break;						\
 		D_FATAL("Assertion '%s' failed\n", #e);			\
 		d_log_sync();						\
@@ -297,7 +297,7 @@ int d_register_alt_assert(void (*alt_assert)(const int, const char*,
 
 #define D_ASSERTF(cond, fmt, ...)						\
 	do {									\
-		if (cond)							\
+		if (likely(cond))						\
 			break;							\
 		D_FATAL("Assertion '%s' failed: " fmt, #cond, ## __VA_ARGS__);	\
 		if (d_alt_assert != NULL)					\


### PR DESCRIPTION
Also casts the expression to a uintptr_t.  Otherwise we get
compiler warnings when someone does

D_ASSERT(x)

where x is a pointer.  I tried a couple of scenarios and codegen is
identical for cast vs no cast

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>