### PR TITLE
Revert "DAOS-10495 control: Remove inner RPC timeouts for system commands (#8875)"

### DIFF
--- a/src/control/server/engine/mocks.go
+++ b/src/control/server/engine/mocks.go
@@ -93,7 +93,3 @@ func (tr *TestRunner) GetLastPid() uint64 {
 func (tr *TestRunner) GetConfig() *Config {
 	return tr.serverCfg
 }
-
-func (tr *TestRunner) GetRunnerConfig() *TestRunnerConfig {
-	return &tr.runnerCfg
-}


### PR DESCRIPTION
This reverts commit 30a960b698fc2d8453b7b9cd9a0578f3657a3c2b, which
is causing frequent unit test failures in CI.

Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com>
