### PR TITLE
DAOS-10345 test: Update container_get_prop() to use JSON - release/2.2

### DIFF
--- a/src/tests/ftest/erasurecode/cell_size_property.py
+++ b/src/tests/ftest/erasurecode/cell_size_property.py
@@ -27,15 +27,11 @@ class EcodCellSizeProperty(IorTestBase):
             expected_size (int): expected container cell size
         """
         daos_cmd = self.get_daos_command()
-        cont_prop = daos_cmd.container_get_prop(self.pool.uuid, self.container.uuid)
+        cont_prop = daos_cmd.container_get_prop(
+            pool=self.pool.uuid, cont=self.container.uuid, properties=["ec_cell"])
+        actual_size = cont_prop["response"][0]["value"]
 
-        cont_cell_size = None
-        for prop in cont_prop["response"]:
-            if prop["name"] == "ec_cell":
-                cont_cell_size = prop["value"]
-                break
-
-        self.assertEqual(expected_size, cont_cell_size)
+        self.assertEqual(expected_size, actual_size)
 
     def test_ec_pool_property(self):
         """Jira ID: DAOS-7321.

--- a/src/tests/ftest/pool/rf.py
+++ b/src/tests/ftest/pool/rf.py
@@ -4,8 +4,8 @@
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
-
 from ior_test_base import IorTestBase
+
 
 class PoolRedunFacProperty(IorTestBase):
     # pylint: disable=too-many-ancestors
@@ -23,14 +23,8 @@ class PoolRedunFacProperty(IorTestBase):
         Args:
             expected_value (int): expected container rf value
         """
-        daos_cmd = self.get_daos_command()
-        cont_prop = daos_cmd.container_get_prop(self.pool.uuid,
-                                                self.container.uuid)
-        cont_prop_stdout = cont_prop.stdout_text
-        prop_list = cont_prop_stdout.split('\n')[1:]
-        cont_index = [i for i, word in enumerate(prop_list)
-                      if word.startswith('Redundancy Factor')][0]
-        rf_str = (prop_list[cont_index].split('Redundancy Factor')[1].strip())
+        cont_props = self.container.get_prop(properties=["rf"])
+        rf_str = cont_props["response"][0]["value"]
         rf_value = int(rf_str.replace("rf", ""))
         self.assertEqual(expected_value, rf_value)
 

--- a/src/tests/ftest/util/container_rf_test_base.py
+++ b/src/tests/ftest/util/container_rf_test_base.py
@@ -62,20 +62,25 @@ class ContRedundancyFactor(RebuildTestBase):
             expected_rf (str): expected container redundancy factor.
             expect_cont_status (str): expected container health status.
         """
-        result = self.daos_cmd.container_get_prop(
-                      pool=self.pool.uuid,
-                      cont=self.container.uuid)
-        rf = re.search(r"Redundancy Factor\s*([A-Za-z0-9-]+)",
-                       str(result.stdout)).group(1)
-        health = re.search(r"Health\s*([A-Z]+)", str(result.stdout)).group(1)
+        actual_rf = None
+        actual_health = None
+
+        cont_props = self.daos_cmd.container_get_prop(
+            pool=self.pool.uuid, cont=self.container.uuid, properties=["rf", "status"])
+        for cont_prop in cont_props["response"]:
+            if cont_prop["name"] == "rf":
+                actual_rf = cont_prop["value"]
+            elif cont_prop["name"] == "status":
+                actual_health = cont_prop["value"]
+
         self.assertEqual(
-            rf, expected_rf,
+            actual_rf, expected_rf,
             "#Container redundancy factor mismatch, actual: {},"
-            " expected: {}.".format(rf, expected_rf))
+            " expected: {}.".format(actual_rf, expected_rf))
         self.assertEqual(
-            health, expected_health,
+            actual_health, expected_health,
             "#Container health-status mismatch, actual: {},"
-            " expected: {}.".format(health, expected_health))
+            " expected: {}.".format(actual_health, expected_health))
 
     def start_rebuild_cont_rf(self, rf):
         """Start the rebuild process and check for container properties.

--- a/src/tests/ftest/util/daos_utils.py
+++ b/src/tests/ftest/util/daos_utils.py
@@ -372,12 +372,13 @@ class DaosCommand(DaosCommandBase):
             ("container", "set-prop"),
             pool=pool, cont=cont, prop=prop_value)
 
-    def container_get_prop(self, pool, cont):
+    def container_get_prop(self, pool, cont, properties=None):
         """Call daos container get-prop.
 
         Args:
             pool (str): Pool UUID.
             cont (str): Container UUID.
+            properties (list): "name" field(s). Defaults to None.
 
         Returns:
             str: JSON that contains the command output.
@@ -388,111 +389,128 @@ class DaosCommand(DaosCommandBase):
         """
         # Sample output
         # {
-        #     "response": [
-        #         {
-        #             "value": 0,
-        #             "name": "alloc_oid",
-        #             "description": "Highest Allocated OID"
-        #         },
-        #         {
-        #             "value": "off",
-        #             "name": "cksum",
-        #             "description": "Checksum"
-        #         },
-        #         {
-        #             "value": 32768,
-        #             "name": "cksum_size",
-        #             "description": "Checksum Chunk Size"
-        #         },
-        #         {
-        #             "value": "off",
-        #             "name": "compression",
-        #             "description": "Compression"
-        #         },
-        #         {
-        #             "value": "off",
-        #             "name": "dedup",
-        #             "description": "Deduplication"
-        #         },
-        #         {
-        #             "value": 4096,
-        #             "name": "dedup_threshold",
-        #             "description": "Dedupe Threshold"
-        #         },
-        #         {
-        #             "value": 65536,
-        #             "name": "ec_cell",
-        #             "description": "EC Cell Size"
-        #         },
-        #         {
-        #             "value": "off",
-        #             "name": "encryption",
-        #             "description": "Encryption"
-        #         },
-        #         {
-        #             "value": "mkano@",
-        #             "name": "group",
-        #             "description": "Group"
-        #         },
-        #         {
-        #             "value": "mkc1",
-        #             "name": "label",
-        #             "description": "Label"
-        #         },
-        #         {
-        #             "value": "POSIX (1)",
-        #             "name": "layout_type",
-        #             "description": "Layout Type"
-        #         },
-        #         {
-        #             "value": 1,
-        #             "name": "layout_version",
-        #             "description": "Layout Version"
-        #         },
-        #         {
-        #             "value": 0,
-        #             "name": "max_snapshot",
-        #             "description": "Max Snapshot"
-        #         },
-        #         {
-        #             "value": "mkano@",
-        #             "name": "owner",
-        #             "description": "Owner"
-        #         },
-        #         {
-        #             "value": "rf0",
-        #             "name": "rf",
-        #             "description": "Redundancy Factor"
-        #         },
-        #         {
-        #             "value": "rank (1)",
-        #             "name": "rf_lvl",
-        #             "description": "Redundancy Level"
-        #         },
-        #         {
-        #             "value": "off",
-        #             "name": "srv_cksum",
-        #             "description": "Server Checksumming"
-        #         },
-        #         {
-        #             "value": "HEALTHY",
-        #             "name": "status",
-        #             "description": "Health"
-        #         },
-        #         {
-        #             "value": [
-        #                 "A::OWNER@:rwdtTaAo",
-        #                 "A:G:GROUP@:rwtT"
-        #             ],
-        #             "name": "acl",
-        #             "description": "Access Control List"
-        #         }
-        #     ],
-        #     "error": null,
-        #     "status": 0
+        #   "response": [
+        #     {
+        #       "value": 0,
+        #       "name": "alloc_oid",
+        #       "description": "Highest Allocated OID"
+        #     },
+        #     {
+        #       "value": "off",
+        #       "name": "cksum",
+        #       "description": "Checksum"
+        #     },
+        #     {
+        #       "value": 32768,
+        #       "name": "cksum_size",
+        #       "description": "Checksum Chunk Size"
+        #     },
+        #     {
+        #       "value": "off",
+        #       "name": "compression",
+        #       "description": "Compression"
+        #     },
+        #     {
+        #       "value": "off",
+        #       "name": "dedup",
+        #       "description": "Deduplication"
+        #     },
+        #     {
+        #       "value": 4096,
+        #       "name": "dedup_threshold",
+        #       "description": "Dedupe Threshold"
+        #     },
+        #     {
+        #       "value": 65536,
+        #       "name": "ec_cell",
+        #       "description": "EC Cell Size"
+        #     },
+        #     {
+        #       "value": "1",
+        #       "name": "ec_pda",
+        #       "description": "Performance domain affinity level of EC"
+        #     },
+        #     {
+        #       "value": "off",
+        #       "name": "encryption",
+        #       "description": "Encryption"
+        #     },
+        #     {
+        #       "value": "1",
+        #       "name": "global_version",
+        #       "description": "Global Version"
+        #     },
+        #     {
+        #       "value": "mkano@",
+        #       "name": "group",
+        #       "description": "Group"
+        #     },
+        #     {
+        #       "value": "mkc1",
+        #       "name": "label",
+        #       "description": "Label"
+        #     },
+        #     {
+        #       "value": "unknown (0)",
+        #       "name": "layout_type",
+        #       "description": "Layout Type"
+        #     },
+        #     {
+        #       "value": 1,
+        #       "name": "layout_version",
+        #       "description": "Layout Version"
+        #     },
+        #     {
+        #       "value": 0,
+        #       "name": "max_snapshot",
+        #       "description": "Max Snapshot"
+        #     },
+        #     {
+        #       "value": "mkano@",
+        #       "name": "owner",
+        #       "description": "Owner"
+        #     },
+        #     {
+        #       "value": "rf0",
+        #       "name": "rf",
+        #       "description": "Redundancy Factor"
+        #     },
+        #     {
+        #       "value": "rank (1)",
+        #       "name": "rf_lvl",
+        #       "description": "Redundancy Level"
+        #     },
+        #     {
+        #       "value": "3",
+        #       "name": "rp_pda",
+        #       "description": "Performance domain affinity level of RP"
+        #     },
+        #     {
+        #       "value": "off",
+        #       "name": "srv_cksum",
+        #       "description": "Server Checksumming"
+        #     },
+        #     {
+        #       "value": "HEALTHY",
+        #       "name": "status",
+        #       "description": "Health"
+        #     },
+        #     {
+        #       "value": [
+        #         "A::OWNER@:rwdtTaAo",
+        #         "A:G:GROUP@:rwtT"
+        #       ],
+        #       "name": "acl",
+        #       "description": "Access Control List"
+        #     }
+        #   ],
+        #   "error": null,
+        #   "status": 0
         # }
+        props = ','.join(properties) if properties else None
+
         return self._get_json_result(
-            ("container", "get-prop"), pool=pool, cont=cont)
+            ("container", "get-prop"), pool=pool, cont=cont, prop=props)
 
     def container_set_owner(self, pool, cont, user, group):
         """Call daos container set-owner.

--- a/src/tests/ftest/util/test_utils_container.py
+++ b/src/tests/ftest/util/test_utils_container.py
@@ -882,3 +882,31 @@ class TestContainer(TestDaosApiBase):
 
         # Return the number of punched objects
         return count
+
+    @fail_on(CommandFailure)
+    def get_prop(self, properties=None):
+        """Get container property by calling daos container get-prop.
+
+        Args:
+            properties (list): "name" field(s). Defaults to None.
+
+        Returns:
+            str: JSON output of daos container get-prop.
+
+        Raises:
+            CommandFailure: Raised from the daos command call.
+
+        """
+        if self.control_method.value == self.USE_DAOS and self.daos:
+            # Get container property using daos utility.
+            return self.daos.container_get_prop(
+                pool=self.pool.uuid, cont=self.uuid, properties=properties)
+
+        if self.control_method.value == self.USE_DAOS:
+            self.log.error("Error: Undefined daos command")
+
+        else:
+            self.log.error(
+                "Error: Undefined control_method: %s", self.control_method.value)
+
+        return None


### PR DESCRIPTION
DAOS-10446 test: Update container_get_prop() to use JSON - release/2.2

Update DaosCommand.container_get_prop() to use JSON and
support properties. Also add TestContainer.get_prop().

Update the tests that use container_get_prop().

This is the cherry-pick PR of the following two PRs.
[8454](https://github.com/daos-stack/daos/pull/8454), [8741](https://github.com/daos-stack/daos/pull/8741)

The tags from the two PRs above are merged and used in this PR.

(The Jira ID in the branch name is the ticket to track the progress
while the ID in the first line is to run the skipped test.)

Tag - File
cont_sec - security/cont_acl.py
dm_dst_create - datamover/dst_create.py
dm_preserve_props_fs_copy_posix_dfs - datamover/posix_preserve_props.py
ec_cell_property - erasurecode/cell_size_property.py
rebuild_container_rf - rebuild/container_rf.py
cont_rf_oclass_enforcement - container/rf_enforcement.py
pool_rf_property - pool/rf.py
pool_pda_property - pool/pda.py

Skip-unit-tests: true
Skip-fault-injection-test: true
Test-tag: cont_sec dm_dst_create dm_preserve_props_fs_copy_posix_dfs ec_cell_property rebuild_container_rf cont_rf_oclass_enforcement pool_rf_property pool_pda_property
Signed-off-by: Makito Kano <makito.kano@intel.com>