### PR TITLE
DAOS-9644 doc: correct provider documentation in server.yml

### DIFF
--- a/src/control/server/config/server_test.go
+++ b/src/control/server/config/server_test.go
@@ -208,7 +208,7 @@ func TestServerConfig_Constructed(t *testing.T) {
 		WithTelemetryPort(9191).
 		WithSystemName("daos_server").
 		WithSocketDir("./.daos/daos_server").
-		WithFabricProvider("ofi+verbs").
+		WithFabricProvider("ofi+verbs;ofi_rxm").
 		WithCrtCtxShareAddr(0).
 		WithCrtTimeout(30).
 		WithAccessPoints("hostname1").
@@ -237,7 +237,7 @@ func TestServerConfig_Constructed(t *testing.T) {
 			).
 			WithFabricInterface("ib0").
 			WithFabricInterfacePort(20000).
-			WithFabricProvider("ofi+verbs").
+			WithFabricProvider("ofi+verbs;ofi_rxm").
 			WithCrtCtxShareAddr(0).
 			WithCrtTimeout(30).
 			WithPinnedNumaNode(0).
@@ -266,7 +266,7 @@ func TestServerConfig_Constructed(t *testing.T) {
 			WithPinnedNumaNode(1).
 			WithFabricInterface("ib1").
 			WithFabricInterfacePort(20000).
-			WithFabricProvider("ofi+verbs").
+			WithFabricProvider("ofi+verbs;ofi_rxm").
 			WithCrtCtxShareAddr(0).
 			WithCrtTimeout(30).
 			WithPinnedNumaNode(1).

--- a/utils/config/daos_server.yml
+++ b/utils/config/daos_server.yml
@@ -70,12 +70,13 @@
 #
 ## Network provider
 #
-## Force a specific libfabric provider to be used by all the engines.
-## The default provider depends on the interfaces that will be auto-detected:
-##  ofi+verbs for Infiniband/RoCE and
-##  ofi+tcp for non-RDMA-capable Ethernet.
+## Set the libfabric provider to be used by all the engines.
+## There is no default - run "daos_server network scan" to list the
+## providers that are supported on the fabric interfaces. Examples:
+##  ofi+verbs;ofi_rxm  for Infiniband/RoCE and
+##  ofi+tcp            for non-RDMA-capable fabrics
 #
-#provider: ofi+verbs
+#provider: ofi+verbs;ofi_rxm
 #
 #
 ## CART: Whether to enable share address in the network stack

--- a/utils/config/daos_server.yml
+++ b/utils/config/daos_server.yml
@@ -70,11 +70,15 @@
 #
 ## Network provider
 #
-## Set the libfabric provider to be used by all the engines.
+## Set the network provider to be used by all the engines.
 ## There is no default - run "daos_server network scan" to list the
 ## providers that are supported on the fabric interfaces. Examples:
-##  ofi+verbs;ofi_rxm  for Infiniband/RoCE and
-##  ofi+tcp            for non-RDMA-capable fabrics
+##
+##   ofi+verbs;ofi_rxm  for libfabric with Infiniband/RoCE
+##   ofi+tcp;ofi_rxm    for libfabric with non-RDMA-capable fabrics
+##
+## (Starting with DAOS 2.2, ofi_rxm will be automatically added to the
+## libfabric verbs and tcp providers, if not explicitly specified.)
 #
 #provider: ofi+verbs;ofi_rxm
 #


### PR DESCRIPTION
correct provider documentation in the daos_server.yml template

Doc-only: true
Signed-off-by: Michael Hennecke <michael.hennecke@intel.com>