### PR TITLE
DAOS-10502 control: Enable discovery mode by skipping wait for fabric…

### DIFF
--- a/src/control/server/server.go
+++ b/src/control/server/server.go
@@ -435,6 +435,11 @@ func waitFabricReady(ctx context.Context, log logging.Logger, cfg *config.Server
 		ifaces = append(ifaces, eng.Fabric.Interface)
 	}
 
+	// Skip wait if no fabric interfaces specified in config.
+	if len(ifaces) == 0 {
+		return nil
+	}
+
 	if err := hardware.WaitFabricReady(ctx, log, hardware.WaitFabricReadyParams{
 		Checker:        hwprov.DefaultFabricReadyChecker(log),
 		FabricIfaces:   ifaces,


### PR DESCRIPTION
… check (#8884)

When no fabric interfaces have been specified in config, for example in
discovery mode, skip the wait for fabric check so bringup can continue
without no fabric interfaces requested error.

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>