### PR TITLE
DAOS-10174 control: Reduce duration of NVMe storage format (#8603)

### DIFF
--- a/src/control/lib/spdk/src/nvme_control_common.c
+++ b/src/control/lib/spdk/src/nvme_control_common.c
@@ -518,14 +518,15 @@ collect(void)
 void
 cleanup(bool detach)
 {
-	struct ns_entry		*nentry;
-	struct ctrlr_entry	*centry, *cnext;
+	struct ns_entry			*nentry;
+	struct ctrlr_entry		*centry, *cnext;
+	struct spdk_nvme_detach_ctx	*detach_ctx = NULL;
 
 	centry = g_controllers;
 
 	while (centry) {
 		if ((centry->ctrlr) && (detach))
-			spdk_nvme_detach(centry->ctrlr);
+			spdk_nvme_detach_async(centry->ctrlr, &detach_ctx);
 		while (centry->nss) {
 			nentry = centry->nss->next;
 			free(centry->nss);
@@ -538,6 +539,9 @@ cleanup(bool detach)
 		free(centry);
 		centry = cnext;
 	}
+
+	if (detach_ctx)
+		spdk_nvme_detach_poll(detach_ctx);
 
 	g_controllers = NULL;
 }


### PR DESCRIPTION
To reduce duration of dmg storage format command, which wipes NVMe
namespaces, use the async version of spdk_nvme_detach API which batches
detach tasks and performs them together when poll is called at a later time.
Format operations with 16TB NVMe SSDs previously took ~14s per SSD and
should now take ~15s per engine regardless of the number of SSDs.

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>