### PR TITLE
DAOS-10450 control: Always set engine NUMA node on exec (#8827)

### DIFF
--- a/src/control/lib/control/auto.go
+++ b/src/control/lib/control/auto.go
@@ -696,5 +696,9 @@ func genConfig(log logging.Logger, newEngineCfg newEngineCfgFn, accessPoints []s
 		WithNrHugePages(reqHugePages).
 		WithEnableVMD(sd.vmdEnabled)
 
-	return cfg, cfg.Validate(log, sd.hugePageSize, nil)
+	if err := cfg.SetEngineAffinities(log); err != nil {
+		return nil, errors.Wrap(err, "setting engine affinities")
+	}
+
+	return cfg, cfg.Validate(log, sd.hugePageSize)
 }

--- a/src/control/server/config/server.go
+++ b/src/control/server/config/server.go
@@ -21,7 +21,6 @@ import (
 	"github.com/daos-stack/daos/src/control/build"
 	"github.com/daos-stack/daos/src/control/common"
 	"github.com/daos-stack/daos/src/control/fault"
-	"github.com/daos-stack/daos/src/control/lib/hardware"
 	"github.com/daos-stack/daos/src/control/logging"
 	"github.com/daos-stack/daos/src/control/security"
 	"github.com/daos-stack/daos/src/control/server/engine"
@@ -400,7 +399,7 @@ func getAccessPointAddrWithPort(log logging.Logger, addr string, portDefault int
 }
 
 // Validate asserts that config meets minimum requirements.
-func (cfg *Server) Validate(log logging.Logger, hugePageSize int, fis *hardware.FabricInterfaceSet) (err error) {
+func (cfg *Server) Validate(log logging.Logger, hugePageSize int) (err error) {
 	msg := "validating config file"
 	if cfg.Path != "" {
 		msg += fmt.Sprintf(" read from %q", cfg.Path)
@@ -521,7 +520,7 @@ func (cfg *Server) Validate(log logging.Logger, hugePageSize int, fis *hardware.
 
 		ec.Fabric.Update(cfg.Fabric)
 
-		if err := ec.Validate(log, fis); err != nil {
+		if err := ec.Validate(); err != nil {
 			return errors.Wrapf(err, "I/O Engine %d failed config validation", idx)
 		}
 
@@ -648,6 +647,98 @@ func (cfg *Server) validateMultiServerConfig(log logging.Logger) error {
 		seenBdevCount = bdevCount
 		seenTargetCount = engine.TargetCount
 		seenHelperStreamCount = engine.HelperStreamCount
+	}
+
+	return nil
+}
+
+var (
+	// ErrNoAffinityDetected is a sentinel error used to indicate that no affinity was detected.
+	ErrNoAffinityDetected = errors.New("no NUMA affinity detected")
+)
+
+// EngineAffinityFn defines a function which returns the NUMA node affinity of a given engine.
+type EngineAffinityFn func(logging.Logger, *engine.Config) (uint, error)
+
+func detectEngineAffinity(log logging.Logger, engineCfg *engine.Config, affSources ...EngineAffinityFn) (node uint, err error) {
+	for _, affSource := range affSources {
+		if affSource == nil {
+			return 0, errors.New("nil affinity source")
+		}
+
+		node, err = affSource(log, engineCfg)
+		if err == nil {
+			return
+		}
+
+		if err != nil && err != ErrNoAffinityDetected {
+			return
+		}
+	}
+
+	return 0, ErrNoAffinityDetected
+}
+
+func setEngineAffinity(log logging.Logger, engineCfg *engine.Config, node uint) error {
+	if engineCfg.PinnedNumaNode != nil && engineCfg.ServiceThreadCore != 0 {
+		return errors.New("cannot set both NUMA node and service core")
+	}
+
+	if engineCfg.PinnedNumaNode != nil {
+		if *engineCfg.PinnedNumaNode != node {
+			// TODO: This should probably be a fatal error, but we may need to allow the config
+			// override in case our affinity detection is incorrect.
+			log.Errorf("engine config pinned_numa_node is set to %d but detected affinity is with NUMA node %d",
+				*engineCfg.PinnedNumaNode, node)
+		}
+	} else {
+		// If not set via config, use the detected NUMA node affinity.
+		engineCfg.PinnedNumaNode = &node
+	}
+
+	// Propagate the NUMA node affinity to the nested config structs.
+	engineCfg.Fabric.NumaNodeIndex = *engineCfg.PinnedNumaNode
+	engineCfg.Storage.NumaNodeIndex = *engineCfg.PinnedNumaNode
+
+	// TODO: Remove this special case when we have removed first_core as an exposed config
+	// parameter. For the moment, if first_core is set, then we need to unset pinned_numa_node
+	// so that the engine uses its legacy core allocation algorithm.
+	if engineCfg.ServiceThreadCore != 0 {
+		log.Debugf("engine is pinned to core %d; not setting NUMA affinity", engineCfg.ServiceThreadCore)
+		engineCfg.PinnedNumaNode = nil
+	}
+
+	return nil
+}
+
+// SetEngineAffinities sets the NUMA node affinity for all engines in the configuration.
+func (cfg *Server) SetEngineAffinities(log logging.Logger, affSources ...EngineAffinityFn) error {
+	defaultAffinity := uint(0)
+
+	for idx, engineCfg := range cfg.Engines {
+		numaAffinity, err := detectEngineAffinity(log, engineCfg, affSources...)
+		if err != nil {
+			if err != ErrNoAffinityDetected {
+				return errors.Wrap(err, "failure while detecting engine affinity")
+			}
+
+			log.Debugf("no NUMA affinity detected for engine %d; defaulting to %d", idx, defaultAffinity)
+			numaAffinity = defaultAffinity
+		} else {
+			log.Debugf("detected NUMA affinity %d for engine %d", numaAffinity, idx)
+		}
+
+		// Special case: If only one engine is defined and engine's detected NUMA node is zero,
+		// don't pin the engine to any NUMA node in order to enable the engine's legacy core
+		// allocation algorithm.
+		if len(cfg.Engines) == 1 && numaAffinity == 0 {
+			log.Debug("enabling single-engine legacy core allocation algorithm")
+			continue
+		}
+
+		if err := setEngineAffinity(log, engineCfg, numaAffinity); err != nil {
+			return errors.Wrapf(err, "unable to set engine affinity to %d", numaAffinity)
+		}
 	}
 
 	return nil

--- a/src/control/server/config/server_test.go
+++ b/src/control/server/config/server_test.go
@@ -145,7 +145,7 @@ func TestServerConfig_MarshalUnmarshal(t *testing.T) {
 			configA.Path = tt.inPath
 			err := configA.Load()
 			if err == nil {
-				err = configA.Validate(log, defHugePageInfo.PageSizeKb, nil)
+				err = configA.Validate(log, defHugePageInfo.PageSizeKb)
 			}
 
 			CmpErr(t, tt.expErr, err)
@@ -164,7 +164,7 @@ func TestServerConfig_MarshalUnmarshal(t *testing.T) {
 
 			err = configB.Load()
 			if err == nil {
-				err = configB.Validate(log, defHugePageInfo.PageSizeKb, nil)
+				err = configB.Validate(log, defHugePageInfo.PageSizeKb)
 			}
 
 			if err != nil {
@@ -263,13 +263,11 @@ func TestServerConfig_Constructed(t *testing.T) {
 					WithBdevDeviceList("/tmp/daos-bdev1", "/tmp/daos-bdev2").
 					WithBdevFileSize(16),
 			).
-			WithPinnedNumaNode(1).
 			WithFabricInterface("ib1").
 			WithFabricInterfacePort(20000).
 			WithFabricProvider("ofi+verbs").
 			WithCrtCtxShareAddr(0).
 			WithCrtTimeout(30).
-			WithPinnedNumaNode(1).
 			WithBypassHealthChk(&bypass).
 			WithEnvVars("CRT_TIMEOUT=100").
 			WithLogFile("/tmp/daos_engine.1.log").
@@ -754,7 +752,7 @@ func TestServerConfig_Validation(t *testing.T) {
 			// Apply extra config test case
 			dupe := tt.extraConfig(baseCfg())
 
-			CmpErr(t, tt.expErr, dupe.Validate(log, defHugePageInfo.PageSizeKb, nil))
+			CmpErr(t, tt.expErr, dupe.Validate(log, defHugePageInfo.PageSizeKb))
 			if tt.expErr != nil || tt.expConfig == nil {
 				return
 			}
@@ -1035,7 +1033,7 @@ func TestServerConfig_Parsing(t *testing.T) {
 			}
 			config = tt.extraConfig(config)
 
-			CmpErr(t, tt.expValidateErr, config.Validate(log, defHugePageInfo.PageSizeKb, nil))
+			CmpErr(t, tt.expValidateErr, config.Validate(log, defHugePageInfo.PageSizeKb))
 
 			if tt.expCheck != nil {
 				if err := tt.expCheck(config); err != nil {
@@ -1238,7 +1236,7 @@ func TestServerConfig_DuplicateValues(t *testing.T) {
 				WithFabricProvider("test").
 				WithEngines(tc.configA, tc.configB)
 
-			gotErr := conf.Validate(log, defHugePageInfo.PageSizeKb, nil)
+			gotErr := conf.Validate(log, defHugePageInfo.PageSizeKb)
 			CmpErr(t, tc.expErr, gotErr)
 		})
 	}
@@ -1273,6 +1271,334 @@ func TestServerConfig_SaveActiveConfig(t *testing.T) {
 
 			AssertTrue(t, strings.Contains(buf.String(), tc.expLogOut),
 				fmt.Sprintf("expected %q in %q", tc.expLogOut, buf.String()))
+		})
+	}
+}
+
+func TestConfig_detectEngineAffinity(t *testing.T) {
+	genAffFn := func(node uint, err error) EngineAffinityFn {
+		return func(logging.Logger, *engine.Config) (uint, error) {
+			return node, err
+		}
+	}
+
+	for name, tc := range map[string]struct {
+		cfg         *engine.Config
+		affSrcSet   []EngineAffinityFn
+		expErr      error
+		expDetected uint
+	}{
+		"first source misses; second hits": {
+			cfg: engine.MockConfig(),
+			affSrcSet: []EngineAffinityFn{
+				genAffFn(0, ErrNoAffinityDetected),
+				genAffFn(1, nil),
+			},
+			expDetected: 1,
+		},
+		"first source hits": {
+			cfg: engine.MockConfig(),
+			affSrcSet: []EngineAffinityFn{
+				genAffFn(1, nil),
+				genAffFn(2, nil),
+			},
+			expDetected: 1,
+		},
+		"first source errors": {
+			cfg: engine.MockConfig(),
+			affSrcSet: []EngineAffinityFn{
+				genAffFn(1, errors.New("fatal")),
+				genAffFn(2, nil),
+			},
+			expErr: errors.New("fatal"),
+		},
+		"no sources hit": {
+			cfg: engine.MockConfig(),
+			affSrcSet: []EngineAffinityFn{
+				genAffFn(1, ErrNoAffinityDetected),
+				genAffFn(2, ErrNoAffinityDetected),
+			},
+			expErr: ErrNoAffinityDetected,
+		},
+		"no sources defined": {
+			cfg:    engine.MockConfig(),
+			expErr: ErrNoAffinityDetected,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			log, buf := logging.NewTestLogger(t.Name())
+			defer ShowBufferOnFailure(t, buf)
+
+			detected, err := detectEngineAffinity(log, tc.cfg, tc.affSrcSet...)
+			CmpErr(t, tc.expErr, err)
+			if tc.expErr != nil {
+				return
+			}
+
+			AssertEqual(t, tc.expDetected, detected,
+				"unexpected detected numa node")
+		})
+	}
+}
+
+func TestConfig_setEngineAffinity(t *testing.T) {
+	for name, tc := range map[string]struct {
+		cfg     *engine.Config
+		setNUMA uint
+		expErr  error
+		expNUMA uint
+	}{
+		"pinned_numa_node set in config overrides detected affinity": {
+			cfg: engine.MockConfig().
+				WithPinnedNumaNode(2).
+				WithFabricInterface("ib1").
+				WithFabricProvider("ofi+verbs"),
+			setNUMA: 1,
+			expNUMA: 2,
+		},
+		"pinned_numa_node not set in config; detected affinity used": {
+			cfg: engine.MockConfig().
+				WithFabricInterface("ib1").
+				WithFabricProvider("ofi+verbs"),
+			setNUMA: 1,
+			expNUMA: 1,
+		},
+		"pinned_numa_node and first_core set": {
+			cfg: engine.MockConfig().
+				WithPinnedNumaNode(2).
+				WithServiceThreadCore(1).
+				WithFabricInterface("ib1").
+				WithFabricProvider("ofi+verbs"),
+			expErr: errors.New("cannot set both"),
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			log, buf := logging.NewTestLogger(t.Name())
+			defer ShowBufferOnFailure(t, buf)
+
+			err := setEngineAffinity(log, tc.cfg, tc.setNUMA)
+			CmpErr(t, tc.expErr, err)
+			if tc.expErr != nil {
+				return
+			}
+
+			AssertEqual(t, tc.expNUMA, *tc.cfg.PinnedNumaNode,
+				"unexpected pinned numa node")
+			AssertEqual(t, tc.expNUMA, tc.cfg.Fabric.NumaNodeIndex,
+				"unexpected numa node in fabric config")
+			AssertEqual(t, tc.expNUMA, tc.cfg.Storage.NumaNodeIndex,
+				"unexpected numa node in storage config")
+		})
+	}
+}
+
+func TestConfig_SetEngineAffinities(t *testing.T) {
+	baseSrvCfg := func() *Server {
+		return DefaultServer()
+	}
+	genAffFn := func(iface string, node uint) EngineAffinityFn {
+		return func(_ logging.Logger, cfg *engine.Config) (uint, error) {
+			if iface == cfg.Fabric.Interface {
+				return node, nil
+			}
+			return 0, ErrNoAffinityDetected
+		}
+	}
+
+	for name, tc := range map[string]struct {
+		cfg         *Server
+		affSrcSet   []EngineAffinityFn
+		expNumaSet  []int
+		expFabNumas []int
+		expErr      error
+	}{
+		"no affinity detected (default NUMA nodes)": {
+			cfg: baseSrvCfg().
+				WithEngines(
+					engine.MockConfig().
+						WithFabricInterface("ib0").
+						WithFabricProvider("ofi+verbs"),
+					engine.MockConfig().
+						WithFabricInterface("ib1").
+						WithFabricProvider("ofi+verbs"),
+				),
+			expNumaSet: []int{0, 0},
+		},
+		"engines have first_core set; NUMA nodes should not be set": {
+			cfg: baseSrvCfg().
+				WithEngines(
+					engine.MockConfig().
+						WithFabricInterface("ib0").
+						WithFabricProvider("ofi+verbs").
+						WithServiceThreadCore(1),
+					engine.MockConfig().
+						WithFabricInterface("ib1").
+						WithFabricProvider("ofi+verbs").
+						WithServiceThreadCore(2),
+				),
+			expNumaSet: []int{-1, -1},
+		},
+		"single engine with pinned_numa_node set": {
+			cfg: baseSrvCfg().
+				WithEngines(
+					engine.MockConfig().
+						WithFabricInterface("ib0").
+						WithFabricProvider("ofi+verbs").
+						WithPinnedNumaNode(1),
+				),
+			expNumaSet: []int{1},
+		},
+		"single engine without pinned_numa_node set and no detected affinity": {
+			cfg: baseSrvCfg().
+				WithEngines(
+					engine.MockConfig().
+						WithFabricInterface("ib0").
+						WithFabricProvider("ofi+verbs"),
+				),
+			expNumaSet: []int{-1},
+		},
+		"single engine without pinned_numa_node set and affinity detected as != 0": {
+			cfg: baseSrvCfg().
+				WithEngines(
+					engine.MockConfig().
+						WithFabricInterface("ib0").
+						WithFabricProvider("ofi+verbs"),
+				),
+			affSrcSet: []EngineAffinityFn{
+				genAffFn("ib0", 1),
+			},
+			expNumaSet: []int{1},
+		},
+		"single engine without pinned_numa_node set and affinity detected as 0": {
+			cfg: baseSrvCfg().
+				WithEngines(
+					engine.MockConfig().
+						WithFabricInterface("ib0").
+						WithFabricProvider("ofi+verbs"),
+				),
+			affSrcSet: []EngineAffinityFn{
+				genAffFn("ib0", 0),
+			},
+			expNumaSet: []int{-1},
+		},
+		"multi engine without pinned_numa_node set and affinity for both detected as 0": {
+			cfg: baseSrvCfg().
+				WithEngines(
+					engine.MockConfig().
+						WithFabricInterface("ib0").
+						WithFabricProvider("ofi+verbs"),
+					engine.MockConfig().
+						WithFabricInterface("ib1").
+						WithFabricProvider("ofi+verbs"),
+				),
+			affSrcSet: []EngineAffinityFn{
+				genAffFn("ib0", 0),
+				genAffFn("ib1", 0),
+			},
+			expNumaSet: []int{0, 0},
+		},
+		"multi engine without pinned_numa_node set": {
+			cfg: baseSrvCfg().
+				WithEngines(
+					engine.MockConfig().
+						WithFabricInterface("ib0").
+						WithFabricProvider("ofi+verbs"),
+					engine.MockConfig().
+						WithFabricInterface("ib1").
+						WithFabricProvider("ofi+verbs"),
+				),
+			affSrcSet: []EngineAffinityFn{
+				genAffFn("ib0", 1),
+				genAffFn("ib1", 2),
+			},
+			expNumaSet: []int{1, 2},
+		},
+		"multi engine with pinned_numa_node set matching detected affinities": {
+			cfg: baseSrvCfg().
+				WithEngines(
+					engine.MockConfig().
+						WithPinnedNumaNode(1).
+						WithFabricInterface("ib0").
+						WithFabricProvider("ofi+verbs"),
+					engine.MockConfig().
+						WithPinnedNumaNode(2).
+						WithFabricInterface("ib1").
+						WithFabricProvider("ofi+verbs"),
+				),
+			affSrcSet: []EngineAffinityFn{
+				genAffFn("ib0", 1),
+				genAffFn("ib1", 2),
+			},
+			expNumaSet: []int{1, 2},
+		},
+		"multi engine with pinned_numa_node set overriding detected affinities": {
+			cfg: baseSrvCfg().
+				WithEngines(
+					engine.MockConfig().
+						WithPinnedNumaNode(2).
+						WithFabricInterface("ib0").
+						WithFabricProvider("ofi+verbs"),
+					engine.MockConfig().
+						WithPinnedNumaNode(1).
+						WithFabricInterface("ib1").
+						WithFabricProvider("ofi+verbs"),
+				),
+			affSrcSet: []EngineAffinityFn{
+				genAffFn("ib0", 1),
+				genAffFn("ib1", 2),
+			},
+			expNumaSet: []int{2, 1},
+		},
+		"multi engine with first_core set; detected affinities take precedence": {
+			cfg: baseSrvCfg().
+				WithEngines(
+					engine.MockConfig().
+						WithServiceThreadCore(1).
+						WithFabricInterface("ib0").
+						WithFabricProvider("ofi+verbs"),
+					engine.MockConfig().
+						WithServiceThreadCore(25).
+						WithFabricInterface("ib1").
+						WithFabricProvider("ofi+verbs"),
+				),
+			affSrcSet: []EngineAffinityFn{
+				genAffFn("ib0", 1),
+				genAffFn("ib1", 2),
+			},
+			expNumaSet:  []int{-1, -1}, // PinnedNumaNode should not be set
+			expFabNumas: []int{1, 2},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			gotNumaSet := make([]int, 0, len(tc.expNumaSet))
+			fabNumaSet := make([]int, 0, len(tc.expFabNumas))
+
+			log, buf := logging.NewTestLogger(t.Name())
+			defer ShowBufferOnFailure(t, buf)
+
+			gotErr := tc.cfg.SetEngineAffinities(log, tc.affSrcSet...)
+			CmpErr(t, tc.expErr, gotErr)
+			if tc.expErr != nil {
+				return
+			}
+
+			for _, engine := range tc.cfg.Engines {
+				fabNumaSet = append(fabNumaSet, int(engine.Fabric.NumaNodeIndex))
+				if engine.PinnedNumaNode == nil {
+					gotNumaSet = append(gotNumaSet, -1)
+					continue
+				}
+				gotNumaSet = append(gotNumaSet, int(*engine.PinnedNumaNode))
+			}
+
+			if diff := cmp.Diff(tc.expNumaSet, gotNumaSet); diff != "" {
+				t.Errorf("unexpected engine numa node set (-want +got):\n%s", diff)
+			}
+			if tc.expFabNumas != nil {
+				if diff := cmp.Diff(tc.expFabNumas, fabNumaSet); diff != "" {
+					t.Errorf("unexpected fabric numa node set (-want +got):\n%s", diff)
+				}
+			}
 		})
 	}
 }

--- a/src/control/server/server.go
+++ b/src/control/server/server.go
@@ -35,6 +35,16 @@ import (
 	"github.com/daos-stack/daos/src/control/system"
 )
 
+func genFiAffFn(fis *hardware.FabricInterfaceSet) config.EngineAffinityFn {
+	return func(l logging.Logger, e *engine.Config) (uint, error) {
+		fi, err := fis.GetInterfaceOnNetDevice(e.Fabric.Interface, e.Fabric.Provider)
+		if err != nil {
+			return 0, err
+		}
+		return fi.NUMANode, nil
+	}
+}
+
 func processConfig(log logging.Logger, cfg *config.Server, fis *hardware.FabricInterfaceSet) error {
 	processFabricProvider(cfg)
 
@@ -43,7 +53,16 @@ func processConfig(log logging.Logger, cfg *config.Server, fis *hardware.FabricI
 		return errors.Wrapf(err, "retrieve hugepage info")
 	}
 
-	if err := cfg.Validate(log, hpi.PageSizeKb, fis); err != nil {
+	affinitySources := []config.EngineAffinityFn{
+		// TODO: Add pmem as the primary source of NUMA affinity, if available,
+		// then fall back to other sources as necessary.
+		genFiAffFn(fis),
+	}
+	if err := cfg.SetEngineAffinities(log, affinitySources...); err != nil {
+		return errors.Wrap(err, "failed to set engine affinities")
+	}
+
+	if err := cfg.Validate(log, hpi.PageSizeKb); err != nil {
 		return errors.Wrapf(err, "%s: validation failed", cfg.Path)
 	}
 

--- a/src/control/server/server_utils_test.go
+++ b/src/control/server/server_utils_test.go
@@ -469,8 +469,13 @@ func TestServer_prepBdevStorage(t *testing.T) {
 				cfg = tc.srvCfgExtra(cfg)
 			}
 
+			// ensure that the engine affinities are set.
+			if err := cfg.SetEngineAffinities(log); err != nil {
+				t.Fatal(err)
+			}
+
 			// test only with 2M hugepage size
-			if err := cfg.Validate(log, 2048, nil); err != nil {
+			if err := cfg.Validate(log, 2048); err != nil {
 				t.Fatal(err)
 			}
 
@@ -583,7 +588,7 @@ func TestServer_scanBdevStorage(t *testing.T) {
 				WithNrHugePages(tc.nrHugepages)
 
 			// test only with 2M hugepage size
-			if err := cfg.Validate(log, 2048, nil); err != nil {
+			if err := cfg.Validate(log, 2048); err != nil {
 				t.Fatal(err)
 			}
 

--- a/src/control/server/storage/bdev/backend_json_test.go
+++ b/src/control/server/storage/bdev/backend_json_test.go
@@ -202,7 +202,7 @@ func TestBackend_newSpdkConfig(t *testing.T) {
 				WithStorageEnableHotplug(tc.enableHotplug).
 				WithPinnedNumaNode(0)
 
-			gotValidateErr := engineConfig.Validate(log, nil) // populate output path
+			gotValidateErr := engineConfig.Validate() // populate output path
 			common.CmpErr(t, tc.expValidateErr, gotValidateErr)
 			if tc.expValidateErr != nil {
 				return

--- a/utils/config/daos_server.yml
+++ b/utils/config/daos_server.yml
@@ -289,7 +289,7 @@
 #  # For best performance, it is necessary that the fabric_iface of this engine
 #  # resides on the same NUMA node as the first_core.
 #  #
-#  # Optional parameter; set either this option or pinned_numa_node but not both.
+#  # Optional parameter; set either this option non-zero or pinned_numa_node but not both.
 #
 #  first_core: 0
 #
@@ -421,7 +421,7 @@
 #  #
 #  # Optional parameter; set either this option or first_core, but not both.
 #
-#  pinned_numa_node: 1
+#  #pinned_numa_node: 1
 #
 #  # Offset of the first core to be used for I/O service threads (targets).
 #  # Immutable after running "dmg storage format".
@@ -429,7 +429,7 @@
 #  # For best performance, it is necessary that the fabric_iface of this engine
 #  # resides on the same NUMA node as the first_core.
 #  #
-#  # Optional parameter; set either this option or pinned_numa_node but not both.
+#  # Optional parameter; set either this option non-zero or pinned_numa_node but not both.
 #
 #  first_core: 22
 #


### PR DESCRIPTION
Previous behavior is that pinned_numa_node is not always passed when
executing engine which causes engine to default to NUMA-0.

In the case where server config does not specify pinned_numa_node and
control plane derives NUMA node to be 1 (e.g. from fabric_iface "ib1"
affinity), hugepages will be allocated on NUMA-1 but engine will try to
allocate DMA buffer from NUMA-0 and fail.

Correct behavior by passing pinned_numa_node commandline parameter when
starting engine unless single engine is on NUMA-0 or first_core is set,
in which case we want to avoid passing pinned_numa_node so that the
legacy core allocation algorithm is activated in the engine. Verify that
first_core and pinned_numa_node parameters are never be set together in
server config file engine section.

Co-authored-by: Michael MacDonald <mjmac.macdonald@intel.com>
Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>