### PR TITLE
DAOS-10469 test: adjust dfuse caching performance threshold (#8920)

### DIFF
--- a/src/tests/ftest/dfuse/caching_check.yaml
+++ b/src/tests/ftest/dfuse/caching_check.yaml
@@ -34,7 +34,7 @@ ior:
     transfer_size: '1M'
     block_size: '64M'
     dfs_oclass: "EC_2P1G1"
-    read_x: 10 # 1000%
+    read_x: 5 # 500%
     iorflags:
       - "-v -w -k"
       - "-v -r -k"


### PR DESCRIPTION
Test-tag: dfusecachingcheck
Quick-functional: true

Performance in CI is not stable enough, so reduce 10x -> 5x

Signed-off-by: Dalton Bohning <dalton.bohning@intel.com>