### PR TITLE
DAOS-9888 obj: add support of EC conditional fetch

### DIFF
--- a/src/common/tse.c
+++ b/src/common/tse.c
@@ -640,7 +640,7 @@ tse_task_post_process(tse_task_t *task)
 		D_FREE(tlink);
 
 		/* propagate dep task's failure */
-		if (task_tmp->dt_result == 0)
+		if (task_tmp->dt_result == 0 && !dtp_tmp->dtp_no_propagate)
 			task_tmp->dt_result = task->dt_result;
 
 		/* see if the dependent task is ready to be scheduled */
@@ -904,7 +904,7 @@ tse_task_add_dependent(tse_task_t *task, tse_task_t *dep)
 	if (tlink == NULL)
 		return -DER_NOMEM;
 
-	D_DEBUG(DB_TRACE, "Add dependent %p ---> %p\n", dep_dtp, dtp);
+	D_DEBUG(DB_TRACE, "Add dependent %p ---> %p\n", dep, task);
 
 	D_MUTEX_LOCK(&dtp->dtp_sched->dsp_lock);
 
@@ -1308,4 +1308,12 @@ tse_task_list_traverse(d_list_t *head, tse_task_cb_t cb, void *arg)
 	}
 
 	return ret;
+}
+
+void
+tse_disable_propagate(tse_task_t *task)
+{
+	struct tse_task_private  *dtp = tse_task2priv(task);
+
+	dtp->dtp_no_propagate = 1;
 }

--- a/src/common/tse_internal.h
+++ b/src/common/tse_internal.h
@@ -49,7 +49,9 @@ struct tse_task_private {
 					 dtp_completed:1,
 					/* task is in running state */
 					 dtp_running:1,
-					 dtp_dep_cnt:29;
+					/* Don't propagate err-code from dependent tasks */
+					 dtp_no_propagate:1,
+					 dtp_dep_cnt:28;
 	/* refcount of the task */
 	uint32_t			 dtp_refcnt;
 	/**

--- a/src/include/daos/tse.h
+++ b/src/include/daos/tse.h
@@ -405,4 +405,10 @@ tse_task_depend_list(tse_task_t *task, d_list_t *head);
 int
 tse_task_list_traverse(d_list_t *head, tse_task_cb_t cb, void *arg);
 
+/**
+ * Set the task don't propagate err-code from dependent tasks.
+ */
+void
+tse_disable_propagate(tse_task_t *task);
+
 #endif /* __TSE_SCHEDULE_H__ */

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -896,7 +896,7 @@ obj_rw_req_reassemb(struct dc_object *obj, daos_obj_rw_t *args,
 	struct obj_reasb_req	*reasb_req = &obj_auxi->reasb_req;
 	struct daos_oclass_attr	*oca = obj_get_oca(obj);
 	daos_obj_id_t		 oid = obj->cob_md.omd_id;
-	int			rc = 0;
+	int			 rc = 0;
 
 	D_ASSERT(obj_is_ec(obj));
 
@@ -910,7 +910,6 @@ obj_rw_req_reassemb(struct dc_object *obj, daos_obj_rw_t *args,
 		return 0;
 	}
 
-	/** XXX possible re-order/merge for both replica and EC */
 	if (args->extra_flags & DIOF_CHECK_EXISTENCE ||
 	    args->extra_flags & DIOF_TO_SPEC_SHARD)
 		return 0;
@@ -1079,6 +1078,7 @@ obj_shards_2_fwtgts(struct dc_object *obj, uint32_t map_ver, uint8_t *bit_map,
 			D_FREE(req_tgts->ort_shard_tgts);
 		req_tgts->ort_shard_tgts = req_tgts->ort_tgts_inline;
 	}
+
 	req_tgts->ort_grp_nr = grp_nr;
 	req_tgts->ort_grp_size = (shard_nr == shard_cnt) ? grp_size : shard_nr;
 	shard_idx = start_shard;
@@ -1718,7 +1718,7 @@ out_put:
 	return rc;
 }
 
-static void
+static int
 obj_ec_recov_cb(tse_task_t *task, struct dc_object *obj,
 		struct obj_auxi_args *obj_auxi, d_iov_t *csum_iov)
 {
@@ -1818,6 +1818,7 @@ out:
 		D_ERROR("task %p "DF_OID" EC recovery failed "DF_RC"\n",
 			task, DP_OID(obj->cob_md.omd_id), DP_RC(rc));
 	}
+	return rc;
 }
 
 /* prepare the bulk handle(s) for obj request */
@@ -1897,7 +1898,7 @@ obj_rw_bulk_prep(struct dc_object *obj, daos_iod_t *iods, d_sg_list_t *sgls,
 	int			rc = 0;
 
 	if ((obj_auxi->io_retry && !obj_auxi->reasb_req.orr_size_fetched &&
-	     obj_auxi->bulks != NULL) || obj_auxi->reasb_req.orr_size_fetch)
+	     obj_auxi->bulks != NULL) || obj_auxi->reasb_req.orr_size_fetch || sgls == NULL)
 		return 0;
 
 	/* inline fetch needs to pack sgls buffer into RPC so uses it to check
@@ -2173,6 +2174,50 @@ obj_key_valid(daos_obj_id_t oid, daos_key_t *key, bool check_dkey)
 	return key != NULL && key->iov_buf != NULL && key->iov_len != 0;
 }
 
+static bool
+obj_req_with_cond_flags(uint64_t flags)
+{
+	return flags & DAOS_COND_MASK;
+}
+
+static bool
+obj_req_is_ec_cond_fetch(struct obj_auxi_args *obj_auxi)
+{
+	daos_obj_rw_t	*api_args = dc_task_get_args(obj_auxi->obj_task);
+
+	return obj_auxi->is_ec_obj && obj_is_fetch_opc(obj_auxi->opc) &&
+	       obj_req_with_cond_flags(api_args->flags);
+}
+
+static bool
+obj_req_is_ec_check_exist(struct obj_auxi_args *obj_auxi)
+{
+	daos_obj_rw_t	*api_args = dc_task_get_args(obj_auxi->obj_task);
+
+	return obj_auxi->is_ec_obj &&
+	       (api_args->extra_flags & DIOF_CHECK_EXISTENCE);
+}
+
+static bool
+obj_ec_req_sent2_all_data_tgts(struct obj_auxi_args *obj_auxi)
+{
+	struct dc_object	*obj = obj_auxi->obj;
+	struct obj_reasb_req	*reasb_req = &obj_auxi->reasb_req;
+	struct daos_oclass_attr	*oca;
+	uint32_t		 shard, i;
+
+	D_ASSERT(obj_auxi->req_reasbed && reasb_req->tgt_bitmap != NULL);
+	oca = obj_get_oca(obj);
+	shard = obj_ec_shard_idx(obj_ec_dkey_hash_get(obj, obj_auxi->dkey_hash), oca, 0);
+	for (i = 0; i < obj_ec_data_tgt_nr(oca); i++) {
+		if (isclr(reasb_req->tgt_bitmap, shard))
+			return false;
+		shard = (shard + 1) % obj_ec_tgt_nr(oca);
+	}
+
+	return true;
+}
+
 /* check if the obj request is valid */
 static int
 obj_req_valid(tse_task_t *task, void *args, int opc, struct dtx_epoch *epoch,
@@ -2190,6 +2235,7 @@ obj_req_valid(tse_task_t *task, void *args, int opc, struct dtx_epoch *epoch,
 	switch (opc) {
 	case DAOS_OBJ_RPC_FETCH: {
 		daos_obj_fetch_t	*f_args = args;
+		uint64_t		 flags = f_args->flags;
 		bool			 size_fetch, spec_shard, check_exist;
 
 		spec_shard  = f_args->extra_flags & DIOF_TO_SPEC_SHARD;
@@ -2199,6 +2245,21 @@ obj_req_valid(tse_task_t *task, void *args, int opc, struct dtx_epoch *epoch,
 		obj = obj_hdl2ptr(f_args->oh);
 		if (obj == NULL)
 			D_GOTO(out, rc = -DER_NO_HDL);
+
+		if (obj_req_with_cond_flags(flags)) {
+			if (flags & (DAOS_COND_PUNCH | DAOS_COND_DKEY_INSERT |
+				     DAOS_COND_DKEY_UPDATE | DAOS_COND_AKEY_INSERT |
+				     DAOS_COND_AKEY_UPDATE)) {
+				D_ERROR("invalid fetch - with conditional modification flags "
+					DF_X64"\n", flags);
+				D_GOTO(out, rc = -DER_INVAL);
+			}
+			if ((flags & DAOS_COND_PER_AKEY) && (flags & (DAOS_COND_AKEY_FETCH))) {
+				D_ERROR("cannot with both DAOS_COND_PER_AKEY and "
+					"DAOS_COND_AKEY_FETCH\n");
+				D_GOTO(out, rc = -DER_INVAL);
+			}
+		}
 
 		if ((!obj_auxi->io_retry && !obj_auxi->req_reasbed) ||
 		    size_fetch) {
@@ -2221,10 +2282,26 @@ obj_req_valid(tse_task_t *task, void *args, int opc, struct dtx_epoch *epoch,
 	}
 	case DAOS_OBJ_RPC_UPDATE: {
 		daos_obj_update_t	*u_args = args;
+		uint64_t		 flags = u_args->flags;
 
 		obj = obj_hdl2ptr(u_args->oh);
 		if (obj == NULL)
 			D_GOTO(out, rc = -DER_NO_HDL);
+
+		if (obj_req_with_cond_flags(flags)) {
+			if (flags & (DAOS_COND_PUNCH | DAOS_COND_DKEY_FETCH |
+				     DAOS_COND_AKEY_FETCH)) {
+				D_ERROR("invalid update - with conditional punch/fetch flags "
+					DF_X64"\n", flags);
+				D_GOTO(out, rc = -DER_INVAL);
+			}
+			if ((flags & DAOS_COND_PER_AKEY) &&
+			    (flags & (DAOS_COND_AKEY_UPDATE | DAOS_COND_AKEY_INSERT))) {
+				D_ERROR("cannot with both DAOS_COND_PER_AKEY and "
+					"DAOS_COND_AKEY_UPDATE | DAOS_COND_AKEY_INSERT\n");
+				D_GOTO(out, rc = -DER_INVAL);
+			}
+		}
 
 		if (!obj_auxi->io_retry && !obj_auxi->req_reasbed) {
 			if (!obj_key_valid(obj->cob_md.omd_id, u_args->dkey,
@@ -2390,7 +2467,7 @@ obj_req_valid(tse_task_t *task, void *args, int opc, struct dtx_epoch *epoch,
 				D_GOTO(out, rc);
 		}
 	} else {
-		dc_io_epoch_set(epoch);
+		dc_io_epoch_set(epoch, opc);
 		D_DEBUG(DB_IO, "set fetch epoch "DF_U64"\n", epoch->oe_value);
 	}
 
@@ -2946,6 +3023,7 @@ struct comp_iter_arg {
 	d_list_t	*merged_list;
 	int		merge_nr;
 	daos_off_t	merge_sgl_off;
+	bool		cond_fetch_exist; /* cond_fetch got exist from one shard */
 	bool		retry;
 };
 
@@ -3315,11 +3393,10 @@ obj_shard_list_comp_cb(struct shard_auxi_args *shard_auxi,
 }
 
 static int
-obj_shard_comp_cb(struct shard_auxi_args *shard_auxi,
+obj_shard_comp_cb(tse_task_t *task, struct shard_auxi_args *shard_auxi,
 		  struct obj_auxi_args *obj_auxi, void *cb_arg)
 {
 	struct comp_iter_arg	*iter_arg = cb_arg;
-	tse_task_t		*task = obj_auxi->obj_task;
 	int			ret = task->dt_result;
 
 	if (shard_auxi == NULL) {
@@ -3336,6 +3413,13 @@ obj_shard_comp_cb(struct shard_auxi_args *shard_auxi,
 	if (ret == 0) {
 		if (obj_auxi->map_ver_reply < shard_auxi->map_ver)
 			obj_auxi->map_ver_reply = shard_auxi->map_ver;
+		if (obj_req_is_ec_cond_fetch(obj_auxi)) {
+			iter_arg->cond_fetch_exist = true;
+			if (obj_auxi->result == -DER_NONEXIST)
+				obj_auxi->result = 0;
+			D_DEBUG(DB_IO, "shard %d EC cond_fetch replied 0 - exist.\n",
+				shard_auxi->shard);
+		}
 	} else if (obj_retry_error(ret)) {
 		D_DEBUG(DB_IO, "shard %d ret %d.\n", shard_auxi->shard, ret);
 		if (obj_auxi->result == 0)
@@ -3346,6 +3430,12 @@ obj_shard_comp_cb(struct shard_auxi_args *shard_auxi,
 		 */
 		if (obj_auxi->result == 0 || obj_retry_error(obj_auxi->result))
 			obj_auxi->result = ret;
+	} else if (ret == -DER_NONEXIST && obj_req_is_ec_cond_fetch(obj_auxi)) {
+		D_DEBUG(DB_IO, "shard %d EC cond_fetch replied -DER_NONEXIST.\n",
+			shard_auxi->shard);
+		if (obj_auxi->result == 0 && !iter_arg->cond_fetch_exist)
+			obj_auxi->result = ret;
+		ret = 0;
 	} else {
 		/* for un-retryable failure, set the err to whole obj IO */
 		D_DEBUG(DB_IO, "shard %d ret %d.\n", shard_auxi->shard, ret);
@@ -3357,7 +3447,8 @@ obj_shard_comp_cb(struct shard_auxi_args *shard_auxi,
 			/** Conditional fetch returns -DER_NONEXIST if the key doesn't exist. We
 			 *  do not want to try another replica in this case.
 			 */
-			D_DEBUG(DB_IO, "Fetch returned -DER_NONEXIST, no retry on conditional\n");
+			D_DEBUG(DB_IO, "shard %d fetch returned -DER_NONEXIST, no retry on "
+				"conditional\n", shard_auxi->shard);
 			iter_arg->retry = false;
 		} else if (ret != -DER_REC2BIG && !obj_retry_error(ret) &&
 			   !obj_is_modification_opc(obj_auxi->opc) &&
@@ -3418,7 +3509,7 @@ obj_shard_comp_cb(struct shard_auxi_args *shard_auxi,
 	return ret;
 }
 
-typedef int (*shard_comp_cb_t)(struct shard_auxi_args *shard_auxi,
+typedef int (*shard_comp_cb_t)(tse_task_t *task, struct shard_auxi_args *shard_auxi,
 			       struct obj_auxi_args *obj_auxi, void *cb_arg);
 struct shard_list_comp_cb_arg {
 	shard_comp_cb_t		cb;
@@ -3434,7 +3525,7 @@ shard_auxi_task_cb(tse_task_t *task, void *data)
 
 	shard_auxi = tse_task_buf_embedded(task, sizeof(*shard_auxi));
 
-	return arg->cb(shard_auxi, arg->obj_auxi, arg->cb_arg);
+	return arg->cb(task, shard_auxi, arg->obj_auxi, arg->cb_arg);
 }
 
 static int
@@ -3453,7 +3544,7 @@ obj_auxi_shards_iterate(struct obj_auxi_args *obj_auxi, shard_comp_cb_t cb,
 		struct shard_auxi_args *shard_auxi;
 
 		shard_auxi = obj_embedded_shard_arg(obj_auxi);
-		rc = cb(shard_auxi, obj_auxi, cb_arg);
+		rc = cb(obj_auxi->obj_task, shard_auxi, obj_auxi, cb_arg);
 		return rc;
 	}
 
@@ -3496,7 +3587,7 @@ obj_set_sub_anchors(daos_obj_list_t *obj_args, int opc, struct shard_anchors *an
 }
 
 static int
-update_sub_anchor_cb(struct shard_auxi_args *shard_auxi,
+update_sub_anchor_cb(tse_task_t *shard_task, struct shard_auxi_args *shard_auxi,
 		     struct obj_auxi_args *obj_auxi, void *cb_arg)
 {
 	tse_task_t		*task = obj_auxi->obj_task;
@@ -3847,6 +3938,9 @@ obj_comp_cb_internal(struct obj_auxi_args *obj_auxi)
 	struct comp_iter_arg	iter_arg = { 0 };
 	int			rc;
 
+	if (obj_auxi->cond_fetch_split)
+		return 0;
+
 	iter_arg.retry = true;
 	obj_args = dc_task_get_args(obj_auxi->obj_task);
 	D_INIT_LIST_HEAD(&merged_list);
@@ -4109,13 +4203,17 @@ obj_ec_comp_cb(struct obj_auxi_args *obj_auxi)
 	}
 
 	if (obj_ec_should_init_recover_cb(obj_auxi)) {
+		int	rc;
+
 		daos_obj_fetch_t *args = dc_task_get_args(task);
 
 		task->dt_result = 0;
 		obj_bulk_fini(obj_auxi);
 		D_DEBUG(DB_IO, "opc %d init recover task for "DF_OID"\n",
 			obj_auxi->opc, DP_OID(obj->cob_md.omd_id));
-		obj_ec_recov_cb(task, obj, obj_auxi, args->csum_iov);
+		rc = obj_ec_recov_cb(task, obj, obj_auxi, args->csum_iov);
+		if (rc)
+			obj_reasb_io_fini(obj_auxi, false);
 		return;
 	}
 
@@ -4126,7 +4224,7 @@ obj_ec_comp_cb(struct obj_auxi_args *obj_auxi)
 			obj_ec_recov_data(&obj_auxi->reasb_req, obj->cob_md.omd_id,
 					  args->nr);
 	} else if ((task->dt_result == 0 || task->dt_result == -DER_REC2BIG) &&
-		    obj_auxi->opc == DAOS_OBJ_RPC_FETCH) {
+		    obj_auxi->opc == DAOS_OBJ_RPC_FETCH && obj_auxi->req_reasbed) {
 		daos_obj_fetch_t *args = dc_task_get_args(task);
 
 		obj_ec_update_iod_size(&obj_auxi->reasb_req, args->nr);
@@ -4156,6 +4254,13 @@ obj_comp_cb(tse_task_t *task, void *data)
 	if (rc != 0 || obj_auxi->result) {
 		if (task->dt_result == 0)
 			task->dt_result = rc ? rc : obj_auxi->result;
+	} else if (obj_req_is_ec_cond_fetch(obj_auxi) && task->dt_result == -DER_NONEXIST &&
+		   !obj_auxi->cond_fetch_split) {
+		/* EC cond_fetch/check_exist task created multiple shard tasks, tse will populate
+		 * shard tasks' DER_NONEXIST to parent task, obj_auxi_shards_iterate() zeroed
+		 * obj_auxi->result, here should zero task->dt_result.
+		 */
+		task->dt_result = 0;
 	}
 
 	D_DEBUG(DB_IO, "opc %u retry: %d leader %d obj complete callback: %d\n",
@@ -4231,6 +4336,21 @@ obj_comp_cb(tse_task_t *task, void *data)
 		obj_auxi->ec_in_recov = 0;
 		obj_reasb_io_fini(obj_auxi, true);
 		D_DEBUG(DB_IO, DF_OID" EC fetch again.\n", DP_OID(obj->cob_md.omd_id));
+	} else if (obj_req_is_ec_cond_fetch(obj_auxi) && task->dt_result == -DER_NONEXIST &&
+		   !obj_auxi->ec_degrade_fetch && !obj_auxi->cond_fetch_split) {
+		daos_obj_fetch_t *args = dc_task_get_args(task);
+
+		if (!(args->extra_flags & DIOF_CHECK_EXISTENCE) &&
+		    !obj_ec_req_sent2_all_data_tgts(obj_auxi)) {
+			/* retry the original task to check existence */
+			args->iods = obj_auxi->reasb_req.orr_uiods;
+			args->sgls = obj_auxi->reasb_req.orr_usgls;
+			obj_reasb_req_fini(&obj_auxi->reasb_req, obj_auxi->iod_nr);
+			obj_auxi->req_reasbed = 0;
+			memset(&obj_auxi->rw_args, 0, sizeof(obj_auxi->rw_args));
+			args->extra_flags |= DIOF_CHECK_EXISTENCE;
+			obj_auxi->io_retry = 1;
+		}
 	}
 
 	if (!obj_auxi->io_retry && task->dt_result == 0 &&
@@ -4377,8 +4497,7 @@ obj_task_init_common(tse_task_t *task, int opc, uint32_t map_ver,
 	obj_auxi->obj = obj;
 	obj_auxi->dkey_hash = 0;
 	shard_task_list_init(obj_auxi);
-	if (obj_is_ec(obj))
-		obj_auxi->is_ec_obj = 1;
+	obj_auxi->is_ec_obj = obj_is_ec(obj);
 	*auxi = obj_auxi;
 }
 
@@ -4722,6 +4841,10 @@ obj_ec_valid_shard_get(struct obj_auxi_args *obj_auxi, uint8_t *tgt_bitmap,
 }
 
 static int
+obj_ec_get_parity_or_alldata_shard(struct obj_auxi_args *obj_auxi, unsigned int map_ver,
+				   int grp_idx, daos_key_t *dkey, uint32_t *shard_cnt);
+
+static int
 obj_ec_fetch_shards_get(struct dc_object *obj, daos_obj_fetch_t *args, unsigned int map_ver,
 			struct obj_auxi_args *obj_auxi, uint32_t *shard, uint32_t *shard_cnt)
 {
@@ -4737,10 +4860,22 @@ obj_ec_fetch_shards_get(struct dc_object *obj, daos_obj_fetch_t *args, unsigned 
 	if (grp_idx < 0)
 		return grp_idx;
 
+	tgt_bitmap = obj_auxi->reasb_req.tgt_bitmap;
+	if (obj_req_is_ec_check_exist(obj_auxi)) {
+		D_ASSERT(obj_req_is_ec_cond_fetch(obj_auxi));
+		D_ASSERT(tgt_bitmap == NULL);
+		rc = obj_ec_get_parity_or_alldata_shard(obj_auxi, map_ver, grp_idx, args->dkey,
+							shard_cnt);
+		if (rc >= 0) {
+			*shard = rc;
+			rc = 0;
+		}
+		return rc;
+	}
+
 	oca = obj_get_oca(obj);
 	/* Check if it needs to do degraded fetch.*/
 	grp_start = grp_idx * obj_get_grp_size(obj);
-	tgt_bitmap = obj_auxi->reasb_req.tgt_bitmap;
 	tgt_idx = obj_ec_shard_idx(obj_ec_dkey_hash_get(obj, obj_auxi->dkey_hash), oca, 0);
 	D_DEBUG(DB_TRACE, DF_OID" grp idx %d shard start %u\n",
 		DP_OID(obj->cob_md.omd_id), grp_idx, tgt_idx);
@@ -4884,6 +5019,75 @@ out:
 	return rc;
 }
 
+/* pre-process for cond_fetch -
+ * for multiple-akeys case, split obj task to multiple sub-tasks each for one akey. For this
+ * case return 1 to indicate wait sub-tasks' completion.
+ */
+static int
+obj_cond_fetch_prep(tse_task_t *task, struct obj_auxi_args *obj_auxi)
+{
+	daos_obj_fetch_t	*args = dc_task_get_args(task);
+	d_list_t		*task_list = &obj_auxi->shard_task_head;
+	tse_task_t		*sub_task;
+	d_sg_list_t		*sgl;
+	bool			 per_akey = args->flags & DAOS_COND_PER_AKEY;
+	uint64_t		 fetch_flags;
+	uint32_t		 i;
+	int			 rc = 0;
+
+	if (args->nr <= 1 || (args->flags & (DAOS_COND_AKEY_FETCH | DAOS_COND_PER_AKEY)) == 0)
+		return rc;
+
+	/* If cond_fetch include multiple akeys, splits the obj task to multiple sub-tasks, one for
+	 * each akey. Because -
+	 * 1. for each akey's cond_fetch if any shard returns 0 (exist) then the akey is exist.
+	 * 2. for multi-akeys' cond_fetch, should return non-exist if any akey non-exist.
+	 * Now one fetch request only with one return code. So creates one sub-task for each akey.
+	 */
+	D_ASSERT(d_list_empty(task_list));
+	D_ASSERT(obj_auxi->cond_fetch_split == 0);
+	for (i = 0; i < args->nr; i++) {
+		fetch_flags = per_akey ? args->iods[i].iod_flags : args->flags;
+		sgl = args->sgls != NULL ? &args->sgls[i] : NULL;
+		rc = dc_obj_fetch_task_create(args->oh, obj_auxi->th, fetch_flags, args->dkey, 1,
+					      0, &args->iods[i], sgl, NULL, NULL, NULL,
+					      NULL, tse_task2sched(task), &sub_task);
+		if (rc) {
+			D_ERROR("task %p "DF_OID" dc_obj_fetch_task_create failed, "DF_RC"\n",
+				task, DP_OID(obj_auxi->obj->cob_md.omd_id), DP_RC(rc));
+			goto out;
+		}
+
+		tse_task_addref(sub_task);
+		tse_task_list_add(sub_task, task_list);
+
+		rc = dc_task_depend(task, 1, &sub_task);
+		if (rc) {
+			D_ERROR("task %p "DF_OID" dc_task_depend failed "DF_RC"\n",
+				task, DP_OID(obj_auxi->obj->cob_md.omd_id), DP_RC(rc));
+			goto out;
+		}
+
+		D_DEBUG(DB_IO, DF_OID" created sub_task %p for obj task %p\n",
+			DP_OID(obj_auxi->obj->cob_md.omd_id), sub_task, task);
+	}
+
+out:
+	if (rc == 0) {
+		D_DEBUG(DB_IO, "scheduling %d sub-tasks for cond_fetch IO task %p.\n",
+			args->nr, task);
+		obj_auxi->no_retry = 1;
+		obj_auxi->cond_fetch_split = 1;
+		tse_task_list_sched(task_list, false);
+		rc = 1;
+	} else {
+		if (!d_list_empty(task_list))
+			tse_task_list_traverse(task_list, shard_task_abort, &rc);
+		task->dt_result = rc;
+	}
+	return rc;
+}
+
 int
 dc_obj_fetch_task(tse_task_t *task)
 {
@@ -4907,6 +5111,15 @@ dc_obj_fetch_task(tse_task_t *task)
 	if (rc != 0) {
 		obj_decref(obj);
 		D_GOTO(out_task, rc);
+	}
+
+	if (obj_req_with_cond_flags(args->flags)) {
+		rc = obj_cond_fetch_prep(task, obj_auxi);
+		D_ASSERT(rc <= 1);
+		if (rc < 0)
+			D_GOTO(out_task, rc);
+		if (rc == 1)
+			return 0;
 	}
 
 	if ((args->extra_flags & DIOF_EC_RECOV) != 0) {
@@ -5462,9 +5675,13 @@ obj_ec_random_parity_get(struct dc_object *obj, uint64_t dkey_hash, int grp)
 	return shard;
 }
 
+/**
+ * Get parity or all data shards, used for EC enumerate or EC check existence.
+ * (dkey == NULL) only possible for the case of EC enumerate - list dkey.
+ */
 static int
-obj_ec_list_get_shard(struct obj_auxi_args *obj_auxi, unsigned int map_ver,
-		      int grp_idx, daos_obj_list_t *args, uint32_t *shard_cnt)
+obj_ec_get_parity_or_alldata_shard(struct obj_auxi_args *obj_auxi, unsigned int map_ver,
+				   int grp_idx, daos_key_t *dkey, uint32_t *shard_cnt)
 {
 	struct dc_object	*obj = obj_auxi->obj;
 	struct daos_oclass_attr *oca;
@@ -5474,7 +5691,7 @@ obj_ec_list_get_shard(struct obj_auxi_args *obj_auxi, unsigned int map_ver,
 	unsigned int		first;
 
 	oca = obj_get_oca(obj);
-	if (args->dkey == NULL && obj->cob_ec_parity_rotate) {
+	if (dkey == NULL && obj->cob_ec_parity_rotate) {
 		/**
 		 * Normally, it only needs to enumerate from tgt_nr - parity_nr,
 		 * but then if enumeration is shifted to others shards due to
@@ -5492,7 +5709,7 @@ obj_ec_list_get_shard(struct obj_auxi_args *obj_auxi, unsigned int map_ver,
 			shard = obj_ec_leader_select(obj, grp_idx, false, map_ver,
 						     obj_ec_dkey_hash_get(obj, obj_auxi->dkey_hash),
 						     NIL_BITMAP);
-			if (args->dkey == NULL) {
+			if (dkey == NULL) {
 				uint64_t dkey_hash = obj_ec_dkey_hash_get(obj_auxi->obj,
 									  obj_auxi->dkey_hash);
 
@@ -5589,7 +5806,8 @@ obj_list_shards_get(struct obj_auxi_args *obj_auxi, unsigned int map_ver,
 	}
 
 	if (obj_auxi->is_ec_obj) {
-		rc = obj_ec_list_get_shard(obj_auxi, map_ver, grp_idx, args, shard_cnt);
+		rc = obj_ec_get_parity_or_alldata_shard(obj_auxi, map_ver, grp_idx, args->dkey,
+							shard_cnt);
 	} else {
 		*shard_cnt = 1;
 		if (obj_auxi->to_leader) {

--- a/src/object/cli_shard.c
+++ b/src/object/cli_shard.c
@@ -876,8 +876,8 @@ dc_rw_cb(tse_task_t *task, void *arg)
 	int			 rc = 0;
 
 	opc = opc_get(rw_args->rpc->cr_opc);
-	D_DEBUG(DB_IO, "rpc %p opc:%d completed, dt_result %d.\n",
-		rw_args->rpc, opc, ret);
+	D_DEBUG(DB_IO, "rpc %p opc:%d completed, task %p dt_result %d.\n",
+		rw_args->rpc, opc, task, ret);
 	if (opc == DAOS_OBJ_RPC_FETCH &&
 	    DAOS_FAIL_CHECK(DAOS_SHARD_OBJ_FETCH_TIMEOUT)) {
 		D_ERROR("Inducing -DER_TIMEDOUT error on shard I/O fetch\n");
@@ -907,7 +907,7 @@ dc_rw_cb(tse_task_t *task, void *arg)
 		 * If any failure happens inside Cart, let's reset failure to
 		 * TIMEDOUT, so the upper layer can retry.
 		 */
-		D_ERROR("RPC %d failed, "DF_RC"\n", opc, DP_RC(ret));
+		D_ERROR("RPC %d, task %p failed, "DF_RC"\n", opc, task, DP_RC(ret));
 		D_GOTO(out, ret);
 	}
 

--- a/src/object/obj_internal.h
+++ b/src/object/obj_internal.h
@@ -380,7 +380,9 @@ struct obj_auxi_args {
 					 sub_anchors:1,
 					 ec_degrade_fetch:1,
 					 tx_convert:1,
-					 cond_modify:1;
+					 cond_modify:1,
+					 /* conf_fetch split to multiple sub-tasks */
+					 cond_fetch_split:1;
 	/* request flags. currently only: ORF_RESEND */
 	uint32_t			 flags;
 	uint32_t			 specified_shard;
@@ -601,9 +603,9 @@ obj_ptr2hdl(struct dc_object *obj)
 }
 
 static inline void
-dc_io_epoch_set(struct dtx_epoch *epoch)
+dc_io_epoch_set(struct dtx_epoch *epoch, uint32_t opc)
 {
-	if (srv_io_mode == DIM_CLIENT_DISPATCH) {
+	if (srv_io_mode == DIM_CLIENT_DISPATCH && obj_is_modification_opc(opc)) {
 		epoch->oe_value = crt_hlc_get();
 		epoch->oe_first = epoch->oe_value;
 		/* DIM_CLIENT_DISPATCH doesn't promise consistency. */

--- a/src/object/obj_tx.c
+++ b/src/object/obj_tx.c
@@ -785,6 +785,7 @@ dc_tx_get_epoch(tse_task_t *task, daos_handle_t th, struct dtx_epoch *epoch)
 		 * already choosing it. We'll "wait" for that "epoch task" to
 		 * complete.
 		 */
+		tse_disable_propagate(task);
 		D_DEBUG(DB_IO, DF_X64"/%p: waiting for epoch task %p\n",
 			th.cookie, task, tx->tx_epoch_task);
 		rc = tse_task_register_deps(task, 1, &tx->tx_epoch_task);

--- a/src/tests/suite/daos_obj_ec.c
+++ b/src/tests/suite/daos_obj_ec.c
@@ -20,6 +20,7 @@
 #include "../../object/obj_ec.h"
 
 unsigned int ec_obj_class = OC_EC_4P2G1;
+unsigned int ec_cell_size = 32768;
 
 static int
 get_dkey_cnt(struct ioreq *req)
@@ -1532,14 +1533,162 @@ ec_singv_diff_size_fetch(void **state)
 	ec_singv_size_fetch_oc(state, OC_EC_4P2G1, 12 * 1024, 4000);
 }
 
+static void
+ec_cond_fetch(void **state)
+{
+	test_arg_t	*arg = *state;
+	daos_obj_id_t	 oid;
+	daos_handle_t	 oh;
+	d_iov_t		 dkey;
+	d_iov_t		 non_exist_dkey;
+	d_sg_list_t	 sgl[2];
+	d_iov_t		 sg_iov[2];
+	daos_iod_t	 iod[2];
+	daos_recx_t	 recx[2];
+	char		*buf[2];
+	char		*akey[2];
+	const char	*akey_fmt = "akey%d";
+	int		 i, rc;
+	daos_size_t	 size = 8192;
+
+	if (!test_runable(arg, 6))
+		return;
+
+	/** open object */
+	oid = daos_test_oid_gen(arg->coh, ec_obj_class, 0, 0, arg->myrank);
+	rc = daos_obj_open(arg->coh, oid, 0, &oh, NULL);
+	assert_rc_equal(rc, 0);
+
+	/** init dkey */
+	d_iov_set(&dkey, "dkey", strlen("dkey"));
+	d_iov_set(&non_exist_dkey, "non_dkey", strlen("non_dkey"));
+
+	for (i = 0; i < 2; i++) {
+		D_ALLOC(akey[i], strlen(akey_fmt) + 1);
+		sprintf(akey[i], akey_fmt, i);
+
+		D_ALLOC(buf[i], size);
+		assert_non_null(buf[i]);
+
+		dts_buf_render(buf[i], size);
+
+		/** init scatter/gather */
+		d_iov_set(&sg_iov[i], buf[i], size);
+		sgl[i].sg_nr		= 1;
+		sgl[i].sg_nr_out	= 0;
+		sgl[i].sg_iovs		= &sg_iov[i];
+
+		/** init I/O descriptor */
+		d_iov_set(&iod[i].iod_name, akey[i], strlen(akey[i]));
+		iod[i].iod_nr		= 1;
+		iod[i].iod_size		= 1;
+		iod[i].iod_recxs	= &recx[i];
+		iod[i].iod_type		= DAOS_IOD_ARRAY;
+		if (i == 0) {
+			recx[i].rx_idx		= 0;
+			recx[i].rx_nr		= size;
+		} else {
+			recx[i].rx_idx		= ec_cell_size;
+			recx[i].rx_nr		= size;
+		}
+	}
+
+	/** update record */
+	rc = daos_obj_update(oh, DAOS_TX_NONE, 0, &dkey, 2, iod, sgl,
+			     NULL);
+	assert_rc_equal(rc, 0);
+
+	/** normal fetch */
+	for (i = 0; i < 2; i++)
+		iod[i].iod_size	= DAOS_REC_ANY;
+
+	print_message("normal fetch\n");
+	rc = daos_obj_fetch(oh, DAOS_TX_NONE, 0, &dkey, 2, iod, NULL,
+			    NULL, NULL);
+	assert_rc_equal(rc, 0);
+	for (i = 0; i < 2; i++)
+		assert_int_equal(iod[i].iod_size, 1);
+
+	for (i = 0; i < 2; i++)
+		d_iov_set(&sg_iov[i], buf[i], size);
+	rc = daos_obj_fetch(oh, DAOS_TX_NONE, 0, &dkey, 2, iod, sgl,
+			    NULL, NULL);
+	assert_rc_equal(rc, 0);
+
+	print_message("cond_deky, fetch non-exist dkey\n");
+	rc = daos_obj_fetch(oh, DAOS_TX_NONE, DAOS_COND_DKEY_FETCH, &non_exist_dkey, 2, iod, sgl,
+			    NULL, NULL);
+	assert_rc_equal(rc, -DER_NONEXIST);
+
+	print_message("cond_dkey, dkey exist, akey non-exist...\n");
+	recx[0].rx_idx	= ec_cell_size;
+	recx[0].rx_nr	= size;
+	d_iov_set(&iod[0].iod_name, "non-akey", strlen("non-akey"));
+	rc = daos_obj_fetch(oh, DAOS_TX_NONE, DAOS_COND_DKEY_FETCH, &dkey, 1, iod, sgl, NULL, NULL);
+	assert_rc_equal(rc, 0);
+
+	print_message("cond_akey fetch, akey exist on another data shard...\n");
+	d_iov_set(&iod[0].iod_name, akey[0], strlen(akey[0]));
+	rc = daos_obj_fetch(oh, DAOS_TX_NONE, DAOS_COND_AKEY_FETCH, &dkey, 1, iod, sgl, NULL, NULL);
+	assert_rc_equal(rc, 0);
+
+	recx[1].rx_idx	= 0;
+	recx[1].rx_nr	= size;
+	print_message("cond_akey fetch, check exist from parity shard\n");
+	rc = daos_obj_fetch(oh, DAOS_TX_NONE, DAOS_COND_AKEY_FETCH, &dkey, 1, &iod[1], sgl, NULL,
+			    NULL);
+	assert_rc_equal(rc, 0);
+
+	print_message("cond_akey fetch, check exist from all data shards\n");
+	daos_fail_loc_set(DAOS_OBJ_SKIP_PARITY | DAOS_FAIL_ALWAYS);
+	rc = daos_obj_fetch(oh, DAOS_TX_NONE, DAOS_COND_AKEY_FETCH, &dkey, 1, &iod[1], sgl, NULL,
+			    NULL);
+	assert_rc_equal(rc, 0);
+	daos_fail_loc_set(0);
+
+	print_message("cond_akey fetch, one akey exist and another akey non-exist\n");
+	d_iov_set(&iod[1].iod_name, "non-akey", strlen("non-akey"));
+	rc = daos_obj_fetch(oh, DAOS_TX_NONE, DAOS_COND_AKEY_FETCH, &dkey, 2, iod, sgl, NULL, NULL);
+	assert_rc_equal(rc, -DER_NONEXIST);
+
+	print_message("cond fetch per akey, one akey exist and another akey non-exist\n");
+	iod[0].iod_flags = DAOS_COND_AKEY_FETCH;
+	iod[1].iod_flags = DAOS_COND_AKEY_FETCH;
+	rc = daos_obj_fetch(oh, DAOS_TX_NONE, DAOS_COND_PER_AKEY, &dkey, 2, iod, sgl, NULL, NULL);
+	assert_rc_equal(rc, -DER_NONEXIST);
+
+	print_message("cond fetch per akey, two akeys both exist\n");
+	recx[0].rx_idx	= 0;
+	recx[0].rx_nr	= size;
+	recx[1].rx_idx	= ec_cell_size;
+	recx[1].rx_nr	= size;
+	d_iov_set(&iod[0].iod_name, akey[0], strlen(akey[0]));
+	d_iov_set(&iod[1].iod_name, akey[1], strlen(akey[1]));
+	rc = daos_obj_fetch(oh, DAOS_TX_NONE, DAOS_COND_PER_AKEY, &dkey, 2, iod, sgl, NULL, NULL);
+	assert_rc_equal(rc, 0);
+
+	/** close object */
+	rc = daos_obj_close(oh, NULL);
+	assert_rc_equal(rc, 0);
+
+	for (i = 0; i < 2; i++) {
+		D_FREE(akey[i]);
+		D_FREE(buf[i]);
+	}
+}
+
 static int
 ec_setup(void  **state)
 {
-	int rc;
+	int		rc;
+	unsigned int	orig_dt_cell_size;
 
+	orig_dt_cell_size = dt_cell_size;
+	dt_cell_size = ec_cell_size;
 	save_group_state(state);
 	rc = test_setup(state, SETUP_CONT_CONNECT, true,
 			DEFAULT_POOL_SIZE, 6, NULL);
+	dt_cell_size = orig_dt_cell_size;
 	if (rc) {
 		/* Let's skip for this case, since it is possible there
 		 * is not enough ranks here.
@@ -1592,6 +1741,7 @@ static const struct CMUnitTest ec_tests[] = {
 	 test_case_teardown},
 	{"EC17: ec single-value different size fetch", ec_singv_diff_size_fetch, async_disable,
 	 test_case_teardown},
+	{"EC18: ec conditional fetch", ec_cond_fetch, async_disable, test_case_teardown},
 };
 
 int

--- a/src/vos/vos_io.c
+++ b/src/vos/vos_io.c
@@ -1196,8 +1196,15 @@ akey_fetch(struct vos_io_context *ioc, daos_handle_t ak_toh)
 		iod->iod_type == DAOS_IOD_ARRAY ? "array" : "single",
 		ioc->ic_epr.epr_lo, ioc->ic_epr.epr_hi);
 
-	if (is_array)
+	if (is_array) {
+		if (iod->iod_nr == 0 || iod->iod_recxs == NULL) {
+			D_ASSERT(iod->iod_nr == 0 && iod->iod_recxs == NULL);
+			D_DEBUG(DB_TRACE, "akey "DF_KEY" fetch array bypassed - NULL iod_recxs.\n",
+				DP_KEY(&iod->iod_name));
+			return 0;
+		}
 		flags |= SUBTR_EVT;
+	}
 
 	rc = key_tree_prepare(ioc->ic_obj, ak_toh,
 			      VOS_BTR_AKEY, &iod->iod_name, flags,
@@ -1711,8 +1718,15 @@ akey_update(struct vos_io_context *ioc, uint32_t pm_ver, daos_handle_t ak_toh,
 		DP_KEY(&iod->iod_name), is_array ? "array" : "single",
 		ioc->ic_epr.epr_hi);
 
-	if (is_array)
+	if (is_array) {
+		if (iod->iod_nr == 0 || iod->iod_recxs == NULL) {
+			D_ASSERT(iod->iod_nr == 0 && iod->iod_recxs == NULL);
+			D_DEBUG(DB_TRACE, "akey "DF_KEY" update array bypassed - NULL iod_recxs.\n",
+				DP_KEY(&iod->iod_name));
+			return rc;
+		}
 		flags |= SUBTR_EVT;
+	}
 
 	rc = key_tree_prepare(obj, ak_toh, VOS_BTR_AKEY,
 			      &iod->iod_name, flags, DAOS_INTENT_UPDATE,


### PR DESCRIPTION
Add support of EC conditional fetch.
split to multiple sub-tasks for cond_akey fetch with multiple akeys

Add related UT cases.
A few bug fixes -
skip fetch/update in akey_fetch()/akey_update() for NULL recxs which is
possible when fetch multiple IODs and recxs only valid on partial shard.
fix a bug in shard_auxi_task_cb() that may use incorrect task pointer.

And add tse_disable_propagate() for the use case in dc_tx_get_epoch().

Signed-off-by: Xuezhao Liu <xuezhao.liu@intel.com>