### PR TITLE
DAOS-9888 obj: add support of EC conditional fetch

### DIFF
--- a/src/common/tse.c
+++ b/src/common/tse.c
@@ -642,7 +642,7 @@ tse_task_post_process(tse_task_t *task)
 		D_FREE(tlink);
 
 		/* propagate dep task's failure */
-		if (task_tmp->dt_result == 0)
+		if (task_tmp->dt_result == 0 && !dtp_tmp->dtp_no_propagate)
 			task_tmp->dt_result = task->dt_result;
 
 		/* see if the dependent task is ready to be scheduled */
@@ -909,7 +909,7 @@ tse_task_add_dependent(tse_task_t *task, tse_task_t *dep)
 	if (tlink == NULL)
 		return -DER_NOMEM;
 
-	D_DEBUG(DB_TRACE, "Add dependent %p ---> %p\n", dep_dtp, dtp);
+	D_DEBUG(DB_TRACE, "Add dependent %p ---> %p\n", dep, task);
 
 	D_MUTEX_LOCK(&dtp->dtp_sched->dsp_lock);
 
@@ -1313,4 +1313,12 @@ tse_task_list_traverse(d_list_t *head, tse_task_cb_t cb, void *arg)
 	}
 
 	return ret;
+}
+
+void
+tse_disable_propagate(tse_task_t *task)
+{
+	struct tse_task_private  *dtp = tse_task2priv(task);
+
+	dtp->dtp_no_propagate = 1;
 }

--- a/src/common/tse_internal.h
+++ b/src/common/tse_internal.h
@@ -55,7 +55,9 @@ struct tse_task_private {
 					 dtp_completing:1,
 					/* task is in running state */
 					 dtp_running:1,
-					 dtp_dep_cnt:29;
+					/* Don't propagate err-code from dependent tasks */
+					 dtp_no_propagate:1,
+					 dtp_dep_cnt:28;
 	/* refcount of the task */
 	uint32_t			 dtp_refcnt;
 	/**

--- a/src/include/daos/tse.h
+++ b/src/include/daos/tse.h
@@ -405,4 +405,10 @@ tse_task_depend_list(tse_task_t *task, d_list_t *head);
 int
 tse_task_list_traverse(d_list_t *head, tse_task_cb_t cb, void *arg);
 
+/**
+ * Set the task don't propagate err-code from dependent tasks.
+ */
+void
+tse_disable_propagate(tse_task_t *task);
+
 #endif /* __TSE_SCHEDULE_H__ */

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -91,7 +91,17 @@ struct obj_auxi_args {
 					 reset_param:1,
 					 force_degraded:1,
 					 shards_scheded:1,
-					 tx_convert:1;
+					 tx_convert:1,
+					 /* degraded fetch */
+					 deg_fetch:1,
+					 /* conf_fetch split to multiple sub-tasks */
+					 cond_fetch_split:1,
+					 /* cond_fetch got exist from one shard */
+					 cond_fetch_exist:1,
+					 /* wait check exist task's completion */
+					 wait_check_exist:1,
+					 /* local TX created by dc_tx_local_open() */
+					 tx_local:1;
 	/* request flags. currently only: ORF_RESEND */
 	uint32_t			 flags;
 	uint32_t			 specified_shard;
@@ -1034,7 +1044,6 @@ obj_rw_req_reassemb(struct dc_object *obj, daos_obj_rw_t *args,
 		return 0;
 
 	if (!obj_auxi->req_reasbed) {
-		obj_auxi->is_ec_obj = 1;
 		rc = obj_reasb_req_init(&obj_auxi->reasb_req, obj, args->iods,
 					args->nr, oca);
 		if (rc) {
@@ -1069,6 +1078,12 @@ bool
 obj_op_is_ec_fetch(struct obj_auxi_args *obj_auxi)
 {
 	return obj_auxi->is_ec_obj && obj_auxi->opc == DAOS_OBJ_RPC_FETCH;
+}
+
+void
+obj_auxi_set_degfetch(struct obj_auxi_args *obj_auxi)
+{
+	obj_auxi->deg_fetch = 1;
 }
 
 /**
@@ -1220,12 +1235,102 @@ obj_req_tgts_dump(struct obj_req_tgts *req_tgts)
 	}
 }
 
+static int
+obj_ec_check_exist_tgts_get(struct dc_object *obj, uint32_t map_ver, uint32_t start_shard,
+			    uint32_t shard_cnt, struct obj_auxi_args *obj_auxi)
+{
+	struct obj_req_tgts	*req_tgts = &obj_auxi->req_tgts;
+	struct daos_oclass_attr	*oca;
+	struct daos_shard_tgt	*tgt = NULL;
+	uint32_t		 psize, dsize, shard, i;
+	int			 rc = 0;
+
+	/* TODO  need change after parity shard rotate */
+	oca = obj_get_oca(obj);
+	psize = obj_ec_parity_tgt_nr(oca);
+	dsize = obj_ec_data_tgt_nr(oca);
+	D_ASSERT(start_shard % (psize + dsize) == 0);
+	D_ASSERT(shard_cnt == psize + dsize);
+
+	shard = start_shard + dsize;
+	D_RWLOCK_RDLOCK(&obj->cob_lock);
+	if (obj->cob_version != map_ver) {
+		D_DEBUG(DB_IO, "ol ver %d != map ver %d\n", obj->cob_version, map_ver);
+		D_RWLOCK_UNLOCK(&obj->cob_lock);
+		return -DER_STALE;
+	}
+	for (i = 0; i < psize; i++, shard++) {
+		if (obj->cob_shards->do_shards[shard].do_rebuilding)
+			continue;
+		if (obj->cob_shards->do_shards[shard].do_target_id != -1)
+			break;
+	}
+	D_RWLOCK_UNLOCK(&obj->cob_lock);
+
+	/* check exist from one parity shard */
+	if (i < psize && likely(!DAOS_FAIL_CHECK(DAOS_OBJ_SKIP_PARITY))) {
+		D_DEBUG(DB_IO, DF_OID" choose parity shard %d\n",
+			DP_OID(obj->cob_md.omd_id), shard);
+		tgt = req_tgts->ort_shard_tgts;
+		/* obj_shard_tgts_query() should not goes to degraded fetch as long as the
+		 * map_ver not changed.
+		 */
+		rc = obj_shard_tgts_query(obj, map_ver, shard, shard - start_shard, tgt, obj_auxi);
+		if (rc == 0) {
+			req_tgts->ort_grp_nr = 1;
+			req_tgts->ort_grp_size = 1;
+		} else {
+			D_ERROR(DF_OID" obj_shard_tgts_query failed "DF_RC"\n",
+				DP_OID(obj->cob_md.omd_id), DP_RC(rc));
+		}
+		return rc;
+	}
+
+	/* check exist from all data shards */
+	shard = start_shard;
+	D_RWLOCK_RDLOCK(&obj->cob_lock);
+	if (obj->cob_version != map_ver) {
+		D_DEBUG(DB_IO, "ol ver %d != map ver %d\n", obj->cob_version, map_ver);
+		D_RWLOCK_UNLOCK(&obj->cob_lock);
+		return -DER_STALE;
+	}
+	for (i = 0; i < dsize; i++, shard++) {
+		if (obj->cob_shards->do_shards[shard].do_rebuilding ||
+		    obj->cob_shards->do_shards[shard].do_target_id == -1) {
+			rc = -DER_DATA_LOSS;
+			D_ERROR(DF_OID" too more shards failed, "DF_RC"\n",
+				DP_OID(obj->cob_md.omd_id), DP_RC(rc));
+			D_RWLOCK_UNLOCK(&obj->cob_lock);
+			return rc;
+		}
+	}
+	D_RWLOCK_UNLOCK(&obj->cob_lock);
+
+	shard = start_shard;
+	tgt = req_tgts->ort_shard_tgts;
+	for (i = 0; i < dsize; i++, shard++, tgt++) {
+		rc = obj_shard_tgts_query(obj, map_ver, shard, shard - start_shard, tgt, obj_auxi);
+		if (rc) {
+			D_ERROR(DF_OID" obj_shard_tgts_query failed "DF_RC"\n",
+				DP_OID(obj->cob_md.omd_id), DP_RC(rc));
+			return rc;
+		}
+	}
+	D_DEBUG(DB_IO, DF_OID" choose all data shards\n", DP_OID(obj->cob_md.omd_id));
+	req_tgts->ort_grp_nr = 1;
+	req_tgts->ort_grp_size = dsize;
+
+	return 0;
+}
+
 /* only send to leader and need not forward */
 #define OBJ_TGT_FLAG_LEADER_ONLY	(1U << 0)
 /* client side dispatch, despite of srv_io_mode setting */
 #define OBJ_TGT_FLAG_CLI_DISPATCH	(1U << 1)
 /* Forward leader information. */
 #define OBJ_TGT_FLAG_FW_LEADER_INFO	(1U << 2)
+/* EC dkey/akey check exist */
+#define OBJ_TGT_FLAG_EC_CHECK_EXIST	(1U << 3)
 
 static int
 obj_shards_2_fwtgts(struct dc_object *obj, uint32_t map_ver, uint8_t *bit_map,
@@ -1278,6 +1383,19 @@ obj_shards_2_fwtgts(struct dc_object *obj, uint32_t map_ver, uint8_t *bit_map,
 			D_FREE(req_tgts->ort_shard_tgts);
 		req_tgts->ort_shard_tgts = req_tgts->ort_tgts_inline;
 	}
+
+	/* some special handing for ec check exist */
+	if (flags & OBJ_TGT_FLAG_EC_CHECK_EXIST) {
+		D_ASSERT(grp_nr == 1);
+		D_ASSERT(bit_map == NULL);
+		D_ASSERT(req_tgts->ort_srv_disp == 0);
+		rc = obj_ec_check_exist_tgts_get(obj, map_ver, start_shard, shard_cnt, obj_auxi);
+		if (rc)
+			D_ERROR(DF_OID" obj_ec_check_exist_tgts_get failed "DF_RC"\n",
+				DP_OID(obj->cob_md.omd_id), DP_RC(rc));
+		return rc;
+	}
+
 	req_tgts->ort_grp_nr = grp_nr;
 	req_tgts->ort_grp_size = (shard_nr == shard_cnt) ? grp_size : shard_nr;
 	for (i = 0; i < grp_nr; i++) {
@@ -1847,7 +1965,7 @@ recov_task_cb(tse_task_t *task, void *data)
 	return 0;
 }
 
-static void
+static int
 obj_ec_recov_cb(tse_task_t *task, struct dc_object *obj,
 		struct obj_auxi_args *obj_auxi, d_iov_t *csum_iov)
 {
@@ -1946,6 +2064,53 @@ out:
 		D_ERROR("task %p "DF_OID" EC recovery failed "DF_RC"\n",
 			task, DP_OID(obj->cob_md.omd_id), DP_RC(rc));
 	}
+	return rc;
+}
+
+static int
+obj_ec_check_exist(tse_task_t *task, struct dc_object *obj, struct obj_auxi_args *obj_auxi)
+{
+	daos_obj_fetch_t		*args = dc_task_get_args(task);
+	tse_task_t			*check_task;
+	int				 rc;
+
+	rc = dc_obj_fetch_task_create(args->oh, obj_auxi->th, args->flags, args->dkey, args->nr,
+				      DIOF_CHECK_EXISTENCE, args->iods, NULL, NULL, NULL, NULL,
+				      NULL, tse_task2sched(task), &check_task);
+	if (rc) {
+		D_ERROR("task %p "DF_OID" dc_obj_fetch_task_create failed "DF_RC"\n",
+			task, DP_OID(obj->cob_md.omd_id), DP_RC(rc));
+		goto out;
+	}
+
+	rc = dc_task_depend(task, 1, &check_task);
+	if (rc) {
+		D_ERROR("task %p "DF_OID" dc_task_depend failed "DF_RC"\n",
+			task, DP_OID(obj->cob_md.omd_id), DP_RC(rc));
+		goto out;
+	}
+
+	rc = dc_task_resched(task);
+	if (rc != 0) {
+		D_ERROR("task %p "DF_OID" dc_task_resched failed "DF_RC"\n",
+			task, DP_OID(obj->cob_md.omd_id), DP_RC(rc));
+		goto out;
+	}
+
+out:
+	if (rc == 0) {
+		obj_auxi->wait_check_exist = 1;
+		D_DEBUG(DB_IO, "scheduling EC check exist task %p for IO task %p.\n",
+			check_task, task);
+		tse_task_schedule(check_task, false);
+	} else {
+		if (check_task != NULL)
+			tse_task_complete(check_task, rc);
+		task->dt_result = rc;
+		D_ERROR("task %p "DF_OID" EC check exist failed "DF_RC"\n",
+			task, DP_OID(obj->cob_md.omd_id), DP_RC(rc));
+	}
+	return rc;
 }
 
 /* prepare the bulk handle(s) for obj request */
@@ -2025,7 +2190,7 @@ obj_rw_bulk_prep(struct dc_object *obj, daos_iod_t *iods, d_sg_list_t *sgls,
 	int			rc = 0;
 
 	if ((obj_auxi->io_retry && !obj_auxi->reasb_req.orr_size_fetched &&
-	     obj_auxi->bulks != NULL) || obj_auxi->reasb_req.orr_size_fetch)
+	     obj_auxi->bulks != NULL) || obj_auxi->reasb_req.orr_size_fetch || sgls == NULL)
 		return 0;
 
 	/* inline fetch needs to pack sgls buffer into RPC so uses it to check
@@ -2301,6 +2466,36 @@ obj_key_valid(daos_obj_id_t oid, daos_key_t *key, bool check_dkey)
 	return key != NULL && key->iov_buf != NULL && key->iov_len != 0;
 }
 
+static bool
+obj_req_with_cond_flags(uint64_t flags)
+{
+	return flags & DAOS_COND_MASK;
+}
+
+static bool
+obj_req_is_ec_cond_fetch(struct obj_auxi_args *obj_auxi)
+{
+	return obj_auxi->is_ec_obj && obj_is_fetch_opc(obj_auxi->opc) &&
+	       obj_req_with_cond_flags(obj_auxi->rw_args.api_args->flags);
+}
+
+
+static bool
+obj_req_is_ec_check_exist(struct obj_auxi_args *obj_auxi)
+{
+	return obj_auxi->is_ec_obj &&
+	       obj_auxi->rw_args.api_args->extra_flags & DIOF_CHECK_EXISTENCE;
+}
+
+static bool
+obj_ec_req_sent2_all_data_tgts(struct obj_auxi_args *obj_auxi)
+{
+	struct obj_reasb_req	*reasb_req = &obj_auxi->reasb_req;
+
+	/* TODO need change for parity shard rotate */
+	return isset_range(reasb_req->tgt_bitmap, 0, obj_ec_data_tgt_nr(reasb_req->orr_oca) - 1);
+}
+
 /* check if the obj request is valid */
 static int
 obj_req_valid(tse_task_t *task, void *args, int opc, struct dtx_epoch *epoch,
@@ -2318,6 +2513,7 @@ obj_req_valid(tse_task_t *task, void *args, int opc, struct dtx_epoch *epoch,
 	switch (opc) {
 	case DAOS_OBJ_RPC_FETCH: {
 		daos_obj_fetch_t	*f_args = args;
+		uint64_t		 flags = f_args->flags;
 		bool			 size_fetch, spec_shard, check_exist;
 
 		spec_shard  = f_args->extra_flags & DIOF_TO_SPEC_SHARD;
@@ -2327,6 +2523,21 @@ obj_req_valid(tse_task_t *task, void *args, int opc, struct dtx_epoch *epoch,
 		obj = obj_hdl2ptr(f_args->oh);
 		if (obj == NULL)
 			D_GOTO(out, rc = -DER_NO_HDL);
+
+		if (obj_req_with_cond_flags(flags)) {
+			if (flags & (DAOS_COND_PUNCH | DAOS_COND_DKEY_INSERT |
+				     DAOS_COND_DKEY_UPDATE | DAOS_COND_AKEY_INSERT |
+				     DAOS_COND_AKEY_UPDATE)) {
+				D_ERROR("invalid fetch - with conditional modification flags "
+					DF_X64"\n", flags);
+				D_GOTO(out, rc = -DER_INVAL);
+			}
+			if ((flags & DAOS_COND_PER_AKEY) && (flags & (DAOS_COND_AKEY_FETCH))) {
+				D_ERROR("cannot with both DAOS_COND_PER_AKEY and "
+					"DAOS_COND_AKEY_FETCH\n");
+				D_GOTO(out, rc = -DER_INVAL);
+			}
+		}
 
 		if ((!obj_auxi->io_retry && !obj_auxi->req_reasbed) ||
 		    size_fetch) {
@@ -2349,10 +2560,26 @@ obj_req_valid(tse_task_t *task, void *args, int opc, struct dtx_epoch *epoch,
 	}
 	case DAOS_OBJ_RPC_UPDATE: {
 		daos_obj_update_t	*u_args = args;
+		uint64_t		 flags = u_args->flags;
 
 		obj = obj_hdl2ptr(u_args->oh);
 		if (obj == NULL)
 			D_GOTO(out, rc = -DER_NO_HDL);
+
+		if (obj_req_with_cond_flags(flags)) {
+			if (flags & (DAOS_COND_PUNCH | DAOS_COND_DKEY_FETCH |
+				     DAOS_COND_AKEY_FETCH)) {
+				D_ERROR("invalid update - with conditional punch/fetch flags "
+					DF_X64"\n", flags);
+				D_GOTO(out, rc = -DER_INVAL);
+			}
+			if ((flags & DAOS_COND_PER_AKEY) &&
+			    (flags & (DAOS_COND_AKEY_UPDATE | DAOS_COND_AKEY_INSERT))) {
+				D_ERROR("cannot with both DAOS_COND_PER_AKEY and "
+					"DAOS_COND_AKEY_UPDATE | DAOS_COND_AKEY_INSERT\n");
+				D_GOTO(out, rc = -DER_INVAL);
+			}
+		}
 
 		if (!obj_auxi->io_retry && !obj_auxi->req_reasbed) {
 			if (!obj_key_valid(obj->cob_md.omd_id, u_args->dkey,
@@ -2518,7 +2745,7 @@ obj_req_valid(tse_task_t *task, void *args, int opc, struct dtx_epoch *epoch,
 				D_GOTO(out, rc);
 		}
 	} else {
-		dc_io_epoch_set(epoch);
+		dc_io_epoch_set(epoch, opc);
 		D_DEBUG(DB_IO, "set fetch epoch "DF_U64"\n", epoch->oe_value);
 	}
 
@@ -2557,11 +2784,18 @@ obj_req_get_tgts(struct dc_object *obj, int *shard, daos_key_t *dkey,
 	uint32_t		shard_cnt = 0;
 	uint32_t		grp_nr;
 	uint32_t		flags = 0;
+	bool			is_ec_check_exist;
 	int			rc;
 
 	switch (opc) {
 	case DAOS_OBJ_RPC_FETCH:
-		if (bit_map == NIL_BITMAP) {
+
+		is_ec_check_exist = obj_req_is_ec_check_exist(obj_auxi);
+		if (is_ec_check_exist) {
+			D_ASSERT(obj_req_is_ec_cond_fetch(obj_auxi));
+			flags |= OBJ_TGT_FLAG_EC_CHECK_EXIST;
+		}
+		if (bit_map == NIL_BITMAP && !is_ec_check_exist) {
 			if (spec_shard) {
 				D_ASSERT(shard != NULL);
 
@@ -2602,7 +2836,7 @@ obj_req_get_tgts(struct dc_object *obj, int *shard, daos_key_t *dkey,
 				goto out;
 		}
 		grp_nr = 1;
-		flags = OBJ_TGT_FLAG_CLI_DISPATCH;
+		flags |= OBJ_TGT_FLAG_CLI_DISPATCH;
 		break;
 	case DAOS_OBJ_RPC_UPDATE:
 	case DAOS_OBJ_RPC_PUNCH_DKEYS:
@@ -3594,11 +3828,10 @@ obj_shard_list_comp_cb(struct shard_auxi_args *shard_auxi,
 }
 
 static int
-obj_shard_comp_cb(struct shard_auxi_args *shard_auxi,
+obj_shard_comp_cb(tse_task_t *task, struct shard_auxi_args *shard_auxi,
 		  struct obj_auxi_args *obj_auxi, void *cb_arg)
 {
 	struct comp_iter_arg	*iter_arg = cb_arg;
-	tse_task_t		*task = obj_auxi->obj_task;
 	int			ret = task->dt_result;
 
 	if (shard_auxi == NULL) {
@@ -3615,6 +3848,13 @@ obj_shard_comp_cb(struct shard_auxi_args *shard_auxi,
 	if (ret == 0) {
 		if (obj_auxi->map_ver_reply < shard_auxi->map_ver)
 			obj_auxi->map_ver_reply = shard_auxi->map_ver;
+		if (obj_req_is_ec_cond_fetch(obj_auxi)) {
+			obj_auxi->cond_fetch_exist = 1;
+			if (obj_auxi->result == -DER_NONEXIST)
+				obj_auxi->result = 0;
+			D_DEBUG(DB_IO, "shard %d EC cond_fetch returned 0 - exist.\n",
+				shard_auxi->shard);
+		}
 	} else if (obj_retry_error(ret)) {
 		D_DEBUG(DB_IO, "shard %d ret %d.\n", shard_auxi->shard, ret);
 		if (obj_auxi->result == 0)
@@ -3625,6 +3865,12 @@ obj_shard_comp_cb(struct shard_auxi_args *shard_auxi,
 		 */
 		if (obj_auxi->result == 0 || obj_retry_error(obj_auxi->result))
 			obj_auxi->result = ret;
+	} else if (ret == -DER_NONEXIST && obj_req_is_ec_cond_fetch(obj_auxi)) {
+		D_DEBUG(DB_IO, "shard %d EC cond_fetch returned -DER_NONEXIST.\n",
+			shard_auxi->shard);
+		if (obj_auxi->result == 0 && !obj_auxi->cond_fetch_exist)
+			obj_auxi->result = ret;
+		ret = 0;
 	} else {
 		/* for un-retryable failure, set the err to whole obj IO */
 		D_DEBUG(DB_IO, "shard %d ret %d.\n", shard_auxi->shard, ret);
@@ -3636,7 +3882,8 @@ obj_shard_comp_cb(struct shard_auxi_args *shard_auxi,
 			/** Conditional fetch returns -DER_NONEXIST if the key doesn't exist. We
 			 *  do not want to try another replica in this case.
 			 */
-			D_DEBUG(DB_IO, "Fetch returned -DER_NONEXIST, no retry on conditional\n");
+			D_DEBUG(DB_IO, "shard %d fetch returned -DER_NONEXIST, no retry on "
+				"conditional\n", shard_auxi->shard);
 			iter_arg->retry = false;
 		} else if (ret != -DER_REC2BIG && !obj_retry_error(ret) &&
 			   !obj_is_modification_opc(obj_auxi->opc) &&
@@ -3697,7 +3944,7 @@ obj_shard_comp_cb(struct shard_auxi_args *shard_auxi,
 	return ret;
 }
 
-typedef int (*shard_comp_cb_t)(struct shard_auxi_args *shard_auxi,
+typedef int (*shard_comp_cb_t)(tse_task_t *task, struct shard_auxi_args *shard_auxi,
 			       struct obj_auxi_args *obj_auxi, void *cb_arg);
 struct shard_list_comp_cb_arg {
 	shard_comp_cb_t		cb;
@@ -3713,7 +3960,7 @@ shard_auxi_task_cb(tse_task_t *task, void *data)
 
 	shard_auxi = tse_task_buf_embedded(task, sizeof(*shard_auxi));
 
-	return arg->cb(shard_auxi, arg->obj_auxi, arg->cb_arg);
+	return arg->cb(task, shard_auxi, arg->obj_auxi, arg->cb_arg);
 }
 
 static int
@@ -3732,7 +3979,7 @@ obj_auxi_shards_iterate(struct obj_auxi_args *obj_auxi, shard_comp_cb_t cb,
 		struct shard_auxi_args *shard_auxi;
 
 		shard_auxi = obj_embedded_shard_arg(obj_auxi);
-		rc = cb(shard_auxi, obj_auxi, cb_arg);
+		rc = cb(obj_auxi->obj_task, shard_auxi, obj_auxi, cb_arg);
 		return rc;
 	}
 
@@ -3775,7 +4022,7 @@ obj_set_sub_anchors(daos_obj_list_t *obj_args, int opc, struct shard_anchors *an
 }
 
 static int
-update_sub_anchor_cb(struct shard_auxi_args *shard_auxi,
+update_sub_anchor_cb(tse_task_t *shard_task, struct shard_auxi_args *shard_auxi,
 		     struct obj_auxi_args *obj_auxi, void *cb_arg)
 {
 	tse_task_t		*task = obj_auxi->obj_task;
@@ -4124,6 +4371,9 @@ obj_comp_cb_internal(struct obj_auxi_args *obj_auxi)
 	struct comp_iter_arg	iter_arg = { 0 };
 	int			rc;
 
+	if (obj_auxi->cond_fetch_split)
+		return 0;
+
 	iter_arg.retry = true;
 	obj_args = dc_task_get_args(obj_auxi->obj_task);
 	D_INIT_LIST_HEAD(&merged_list);
@@ -4321,11 +4571,17 @@ obj_reasb_io_fini(struct obj_auxi_args *obj_auxi, bool retry)
 	obj_update_sgls_free(obj_auxi);
 	obj_reasb_req_fini(&obj_auxi->reasb_req, obj_auxi->iod_nr);
 
-	/* zero it as user might reuse/resched the task, for
-	 * example the usage in dac_array_set_size().
-	 */
-	if (!retry)
+	if (!retry) {
+		if (obj_auxi->tx_local) {
+			D_ASSERT(obj_is_fetch_opc(obj_auxi->opc));
+			D_ASSERT(daos_handle_is_valid(obj_auxi->th));
+			dc_tx_local_close(obj_auxi->th);
+			obj_auxi->tx_local = 0;
+			obj_auxi->rw_args.api_args->th = DAOS_HDL_INVAL;
+		}
+		/* zero it as user might reuse/resched the task, for example dac_array_set_size() */
 		memset(obj_auxi, 0, sizeof(*obj_auxi));
+	}
 }
 
 static int
@@ -4348,6 +4604,13 @@ obj_comp_cb(tse_task_t *task, void *data)
 		if (task->dt_result == 0)
 			task->dt_result = rc ? rc : obj_auxi->result;
 		D_DEBUG(DB_IO, "obj complete callback: %d\n", task->dt_result);
+	} else if (obj_req_is_ec_cond_fetch(obj_auxi) && task->dt_result == -DER_NONEXIST &&
+		   !obj_auxi->cond_fetch_split) {
+		/* EC cond_fetch/check_exist task created multiple shard tasks, tse will populate
+		 * shard tasks' DER_NONEXIST to parent task, obj_auxi_shards_iterate() zeroed
+		 * obj_auxi->result, here should zero task->dt_result.
+		 */
+		task->dt_result = 0;
 	}
 
 	if (obj->cob_time_fetch_leader != NULL &&
@@ -4451,6 +4714,7 @@ obj_comp_cb(tse_task_t *task, void *data)
 	if (!io_task_reinited) {
 		struct obj_ec_fail_info	*fail_info;
 		bool new_tgt_fail = false;
+		bool ec_check_exist = false;
 		d_list_t *head = &obj_auxi->shard_task_head;
 
 		switch (obj_auxi->opc) {
@@ -4479,8 +4743,14 @@ obj_comp_cb(tse_task_t *task, void *data)
 			 */
 			obj_rw_csum_destroy(obj, obj_auxi);
 
-			if (daos_handle_is_valid(obj_auxi->th) &&
-			    !(args->extra_flags & DIOF_CHECK_EXISTENCE) &&
+			if (obj_req_is_ec_cond_fetch(obj_auxi) && task->dt_result == -DER_NONEXIST
+			    && !obj_auxi->deg_fetch && !(args->extra_flags & DIOF_CHECK_EXISTENCE)
+			    && !obj_auxi->cond_fetch_split && !obj_auxi->wait_check_exist
+			    && !obj_ec_req_sent2_all_data_tgts(obj_auxi))
+				ec_check_exist = true;
+
+			if (daos_handle_is_valid(obj_auxi->th) && !obj_auxi->tx_local &&
+			    !(args->extra_flags & DIOF_CHECK_EXISTENCE) && !ec_check_exist &&
 				 (task->dt_result == 0 ||
 				  task->dt_result == -DER_NONEXIST)) {
 				obj_addref(obj);
@@ -4529,6 +4799,15 @@ obj_comp_cb(tse_task_t *task, void *data)
 			D_ASSERT(d_list_empty(head));
 		}
 
+		if (ec_check_exist) {
+			task->dt_result = 0;
+			obj_bulk_fini(obj_auxi);
+			rc = obj_ec_check_exist(task, obj, obj_auxi);
+			if (rc)
+				obj_reasb_io_fini(obj_auxi, false);
+			goto out;
+		}
+
 		fail_info = obj_auxi->reasb_req.orr_fail;
 		new_tgt_fail = obj_auxi->ec_wait_recov &&
 			       task->dt_result == -DER_TGT_RETRY;
@@ -4557,8 +4836,9 @@ obj_comp_cb(tse_task_t *task, void *data)
 
 				task->dt_result = 0;
 				obj_bulk_fini(obj_auxi);
-				obj_ec_recov_cb(task, obj, obj_auxi,
-						args->csum_iov);
+				rc = obj_ec_recov_cb(task, obj, obj_auxi, args->csum_iov);
+				if (rc)
+					obj_reasb_io_fini(obj_auxi, false);
 			}
 		} else {
 			if (obj_auxi->is_ec_obj &&
@@ -4578,6 +4858,7 @@ obj_comp_cb(tse_task_t *task, void *data)
 		}
 	}
 
+out:
 	obj_decref(obj);
 	return 0;
 }
@@ -4595,8 +4876,10 @@ obj_task_init_common(tse_task_t *task, int opc, uint32_t map_ver,
 	obj_auxi->opc = opc;
 	obj_auxi->map_ver_req = map_ver;
 	obj_auxi->obj_task = task;
-	obj_auxi->th = th;
+	if (!obj_auxi->tx_local)
+		obj_auxi->th = th;
 	obj_auxi->obj = obj;
+	obj_auxi->is_ec_obj = obj_is_ec(obj);
 	shard_task_list_init(obj_auxi);
 	*auxi = obj_auxi;
 }
@@ -4899,6 +5182,85 @@ obj_retry_next_shard(struct dc_object *obj, struct obj_auxi_args *obj_auxi,
 	return 0;
 }
 
+/* some pre-process for cond_fetch -
+ * 1. create local TX if it is no in a user transaction - to ensure all the fetches on same epoch
+ *    chosen by first operation (reuse dtx_epoch_chosen related logic).
+ * 2. for multiple-akeys case, split obj task to multiple sub-tasks each for one akey. For this
+ *    case return 1 to indicate wait sub-tasks' completion.
+ */
+static int
+obj_cond_fetch_prep(tse_task_t *task, struct obj_auxi_args *obj_auxi)
+{
+	daos_obj_fetch_t	*args = dc_task_get_args(task);
+	d_list_t		*task_list = &obj_auxi->shard_task_head;
+	tse_task_t		*sub_task;
+	bool			 per_akey = args->flags & DAOS_COND_PER_AKEY;
+	uint64_t		 fetch_flags;
+	uint32_t		 i;
+	int			 rc = 0;
+
+	if (!daos_handle_is_valid(obj_auxi->th)) {
+		D_ASSERT(!obj_auxi->tx_local);
+		D_ASSERT(!daos_handle_is_valid(args->th));
+		rc = dc_tx_local_open(obj_auxi->obj->cob_coh, DAOS_EPOCH_MAX, 0, &obj_auxi->th);
+		if (rc) {
+			D_ERROR("task %p "DF_OID" dc_tx_local_open failed "
+				DF_RC"\n", task, DP_OID(obj_auxi->obj->cob_md.omd_id),
+				DP_RC(rc));
+			return rc;
+		}
+		args->th = obj_auxi->th;
+		obj_auxi->tx_local = 1;
+	}
+
+	if (args->nr <= 1 || (args->flags & (DAOS_COND_AKEY_FETCH | DAOS_COND_PER_AKEY)) == 0)
+		return rc;
+
+	/* If cond_fetch include multiple akeys, splits the obj task to multiple sub-tasks, one for
+	 * each akey. Because -
+	 * 1. for each akey's cond_fetch if any shard returns 0 (exist) then the akey is exist.
+	 * 2. for multi-akeys' cond_fetch, should return non-exist if any akey non-exist.
+	 * Now one fetch request only with one return code. So creates one sub-task for each akey.
+	 */
+	D_ASSERT(d_list_empty(task_list));
+	D_ASSERT(obj_auxi->cond_fetch_split == 0);
+	for (i = 0; i < args->nr; i++) {
+		fetch_flags = per_akey ? args->iods[i].iod_flags : args->flags;
+		rc = dc_obj_fetch_task_create(args->oh, obj_auxi->th, fetch_flags, args->dkey, 1,
+					      0, &args->iods[i], &args->sgls[i], NULL, NULL, NULL,
+					      NULL, tse_task2sched(task), &sub_task);
+		if (rc) {
+			D_ERROR("task %p "DF_OID" dc_obj_fetch_task_create failed, "DF_RC"\n",
+				task, DP_OID(obj_auxi->obj->cob_md.omd_id), DP_RC(rc));
+			goto out;
+		}
+
+		tse_task_list_add(sub_task, task_list);
+
+		rc = dc_task_depend(task, 1, &sub_task);
+		if (rc) {
+			D_ERROR("task %p "DF_OID" dc_task_depend failed "DF_RC"\n",
+				task, DP_OID(obj_auxi->obj->cob_md.omd_id), DP_RC(rc));
+			goto out;
+		}
+	}
+
+out:
+	if (rc == 0) {
+		D_DEBUG(DB_IO, "scheduling %d sub-tasks for cond_fetch IO task %p.\n",
+			args->nr, task);
+		obj_auxi->no_retry = 1;
+		obj_auxi->cond_fetch_split = 1;
+		tse_task_list_sched(task_list, false);
+		rc = 1;
+	} else {
+		if (!d_list_empty(task_list))
+			tse_task_list_traverse(task_list, recov_task_abort, &rc);
+		task->dt_result = rc;
+	}
+	return rc;
+}
+
 int
 dc_obj_fetch_task(tse_task_t *task)
 {
@@ -4924,6 +5286,16 @@ dc_obj_fetch_task(tse_task_t *task)
 		D_GOTO(out_task, rc);
 	}
 
+	obj_auxi->rw_args.api_args = args;
+	if (obj_req_with_cond_flags(args->flags)) {
+		rc = obj_cond_fetch_prep(task, obj_auxi);
+		D_ASSERT(rc <= 0 || rc == 1);
+		if (rc < 0)
+			D_GOTO(out_task, rc);
+		if (rc == 1)
+			return 0;
+	}
+
 	if ((args->extra_flags & DIOF_EC_RECOV) != 0) {
 		obj_auxi->ec_in_recov = 1;
 		obj_auxi->reasb_req.orr_fail = args->extra_arg;
@@ -4931,7 +5303,7 @@ dc_obj_fetch_task(tse_task_t *task)
 		if ((args->extra_flags & DIOF_EC_RECOV_SNAP) != 0)
 			obj_auxi->reasb_req.orr_recov_snap = 1;
 	}
-	if (obj_auxi->ec_wait_recov)
+	if (obj_auxi->ec_wait_recov || obj_auxi->wait_check_exist)
 		goto out_task;
 
 	if (args->extra_flags & DIOF_FOR_MIGRATION) {
@@ -5624,17 +5996,14 @@ obj_list_common(tse_task_t *task, int opc, daos_obj_list_t *args)
 	    daos_anchor_get_flags(args->dkey_anchor) & DIOF_FOR_FORCE_DEGRADE)
 		obj_auxi->force_degraded = 1;
 
-	if (obj_is_ec(obj)) {
-		obj_auxi->is_ec_obj = 1;
-		if (obj_auxi->io_retry) {
-			/* Since enumeration retry might retry to send multiple
-			 * shards, remove the original shard fetch tasks and will
-			 * recreate new shard fetch tasks with new parameters.
-			 */
-			D_DEBUG(DB_IO, DF_OID" retrying enumeration.\n",
-				DP_OID(obj->cob_md.omd_id));
-			obj_io_set_new_shard_task(obj_auxi);
-		}
+	if (obj_auxi->is_ec_obj && obj_auxi->io_retry) {
+		/* Since enumeration retry might retry to send multiple
+		 * shards, remove the original shard fetch tasks and will
+		 * recreate new shard fetch tasks with new parameters.
+		 */
+		D_DEBUG(DB_IO, DF_OID" retrying enumeration.\n",
+			DP_OID(obj->cob_md.omd_id));
+		obj_io_set_new_shard_task(obj_auxi);
 	}
 
 	shard = obj_list_get_shard(obj_auxi, map_ver, args);

--- a/src/object/cli_shard.c
+++ b/src/object/cli_shard.c
@@ -1249,9 +1249,10 @@ dc_obj_shard_rw(struct dc_obj_shard *shard, enum obj_rpc_opc opc,
 	orw->orw_tgt_idx = auxi->ec_tgt_idx;
 	if (args->reasb_req && args->reasb_req->orr_oca)
 		orw->orw_tgt_max = obj_ec_tgt_nr(args->reasb_req->orr_oca) - 1;
-	if (obj_op_is_ec_fetch(auxi->obj_auxi) &&
-	    (auxi->shard != (auxi->start_shard + auxi->ec_tgt_idx)))
+	if (obj_op_is_ec_fetch(auxi->obj_auxi) && obj_shard_redirected(auxi)) {
 		orw->orw_flags |= ORF_EC_DEGRADED;
+		obj_auxi_set_degfetch(auxi->obj_auxi);
+	}
 	orw->orw_dti_cos.ca_count = 0;
 	orw->orw_dti_cos.ca_arrays = NULL;
 

--- a/src/object/cli_shard.c
+++ b/src/object/cli_shard.c
@@ -855,8 +855,8 @@ dc_rw_cb(tse_task_t *task, void *arg)
 	int			 rc = 0;
 
 	opc = opc_get(rw_args->rpc->cr_opc);
-	D_DEBUG(DB_IO, "rpc %p opc:%d completed, dt_result %d.\n",
-		rw_args->rpc, opc, ret);
+	D_DEBUG(DB_IO, "rpc %p opc:%d completed, task %p dt_result %d.\n",
+		rw_args->rpc, opc, task, ret);
 	if (opc == DAOS_OBJ_RPC_FETCH &&
 	    DAOS_FAIL_CHECK(DAOS_SHARD_OBJ_FETCH_TIMEOUT)) {
 		D_ERROR("Inducing -DER_TIMEDOUT error on shard I/O fetch\n");
@@ -886,7 +886,7 @@ dc_rw_cb(tse_task_t *task, void *arg)
 		 * If any failure happens inside Cart, let's reset failure to
 		 * TIMEDOUT, so the upper layer can retry.
 		 */
-		D_ERROR("RPC %d failed, "DF_RC"\n", opc, DP_RC(ret));
+		D_ERROR("RPC %d, task %p failed, "DF_RC"\n", opc, task, DP_RC(ret));
 		D_GOTO(out, ret);
 	}
 

--- a/src/object/obj_internal.h
+++ b/src/object/obj_internal.h
@@ -512,6 +512,13 @@ int dc_obj_shard_rw(struct dc_obj_shard *shard, enum obj_rpc_opc opc,
 		    void *shard_args, struct daos_shard_tgt *fw_shard_tgts,
 		    uint32_t fw_cnt, tse_task_t *task);
 
+/* check if a EC obj shard IO request has been re-directed (to parity shard) */
+static inline bool
+obj_shard_redirected(struct shard_auxi_args *auxi)
+{
+	return auxi->shard != (auxi->start_shard + auxi->ec_tgt_idx);
+}
+
 int
 ec_obj_update_encode(tse_task_t *task, daos_obj_id_t oid,
 		     struct daos_oclass_attr *oca, uint64_t *tgt_set);
@@ -539,6 +546,7 @@ int dc_obj_shard_sync(struct dc_obj_shard *shard, enum obj_rpc_opc opc,
 int dc_obj_verify_rdg(struct dc_object *obj, struct dc_obj_verify_args *dova,
 		      uint32_t rdg_idx, uint32_t reps, daos_epoch_t epoch);
 bool obj_op_is_ec_fetch(struct obj_auxi_args *obj_auxi);
+void obj_auxi_set_degfetch(struct obj_auxi_args *obj_auxi);
 int obj_recx_ec2_daos(struct daos_oclass_attr *oca, int shard, daos_recx_t **recxs_p,
 		      daos_epoch_t **recx_ephs_p, unsigned int *nr, bool convert_parity);
 int obj_reasb_req_init(struct obj_reasb_req *reasb_req, struct dc_object *obj,
@@ -603,9 +611,9 @@ obj_ptr2hdl(struct dc_object *obj)
 }
 
 static inline void
-dc_io_epoch_set(struct dtx_epoch *epoch)
+dc_io_epoch_set(struct dtx_epoch *epoch, uint32_t opc)
 {
-	if (srv_io_mode == DIM_CLIENT_DISPATCH) {
+	if (srv_io_mode == DIM_CLIENT_DISPATCH && obj_is_modification_opc(opc)) {
 		epoch->oe_value = crt_hlc_get();
 		epoch->oe_first = epoch->oe_value;
 		/* DIM_CLIENT_DISPATCH doesn't promise consistency. */

--- a/src/object/obj_tx.c
+++ b/src/object/obj_tx.c
@@ -2140,6 +2140,11 @@ dc_tx_local_open(daos_handle_t coh, daos_epoch_t epoch, uint32_t flags,
 	struct dc_tx	*tx = NULL;
 	int		 rc;
 
+	if (epoch == 0 || epoch == DAOS_EPOCH_MAX) {
+		D_ERROR("Invalid epoch for tx_local_open\n");
+		return -DER_INVAL;
+	}
+
 	/* local TX must be read-only. */
 	rc = dc_tx_alloc(coh, epoch, flags | DAOS_TF_RDONLY, &tx);
 	if (rc == 0)

--- a/src/object/obj_tx.c
+++ b/src/object/obj_tx.c
@@ -785,6 +785,7 @@ dc_tx_get_epoch(tse_task_t *task, daos_handle_t th, struct dtx_epoch *epoch)
 		 * already choosing it. We'll "wait" for that "epoch task" to
 		 * complete.
 		 */
+		tse_disable_propagate(task);
 		D_DEBUG(DB_IO, DF_X64"/%p: waiting for epoch task %p\n",
 			th.cookie, task, tx->tx_epoch_task);
 		rc = tse_task_register_deps(task, 1, &tx->tx_epoch_task);

--- a/src/object/obj_tx.c
+++ b/src/object/obj_tx.c
@@ -2139,11 +2139,6 @@ dc_tx_local_open(daos_handle_t coh, daos_epoch_t epoch, uint32_t flags,
 	struct dc_tx	*tx = NULL;
 	int		 rc;
 
-	if (epoch == 0 || epoch == DAOS_EPOCH_MAX) {
-		D_ERROR("Invalid epoch for tx_local_open\n");
-		return -DER_INVAL;
-	}
-
 	/* local TX must be read-only. */
 	rc = dc_tx_alloc(coh, epoch, flags | DAOS_TF_RDONLY, &tx);
 	if (rc == 0)

--- a/src/vos/vos_io.c
+++ b/src/vos/vos_io.c
@@ -1196,8 +1196,15 @@ akey_fetch(struct vos_io_context *ioc, daos_handle_t ak_toh)
 		iod->iod_type == DAOS_IOD_ARRAY ? "array" : "single",
 		ioc->ic_epr.epr_lo, ioc->ic_epr.epr_hi);
 
-	if (is_array)
+	if (is_array) {
+		if (iod->iod_nr == 0 || iod->iod_recxs == NULL) {
+			D_ASSERT(iod->iod_nr == 0 && iod->iod_recxs == NULL);
+			D_DEBUG(DB_TRACE, "akey "DF_KEY" fetch array bypassed - NULL iod_recxs.\n",
+				DP_KEY(&iod->iod_name));
+			return 0;
+		}
 		flags |= SUBTR_EVT;
+	}
 
 	rc = key_tree_prepare(ioc->ic_obj, ak_toh,
 			      VOS_BTR_AKEY, &iod->iod_name, flags,
@@ -1709,8 +1716,15 @@ akey_update(struct vos_io_context *ioc, uint32_t pm_ver, daos_handle_t ak_toh,
 		DP_KEY(&iod->iod_name), is_array ? "array" : "single",
 		ioc->ic_epr.epr_hi);
 
-	if (is_array)
+	if (is_array) {
+		if (iod->iod_nr == 0 || iod->iod_recxs == NULL) {
+			D_ASSERT(iod->iod_nr == 0 && iod->iod_recxs == NULL);
+			D_DEBUG(DB_TRACE, "akey "DF_KEY" update array bypassed - NULL iod_recxs.\n",
+				DP_KEY(&iod->iod_name));
+			return rc;
+		}
 		flags |= SUBTR_EVT;
+	}
 
 	rc = key_tree_prepare(obj, ak_toh, VOS_BTR_AKEY,
 			      &iod->iod_name, flags, DAOS_INTENT_UPDATE,


### PR DESCRIPTION
Add support of EC conditional fetch -
create local TX for conditional fetch,
split to multiple sub-tasks for cond_akey fetch with multiple akeys

Add related UT cases.

A few bug fixes -
skip fetch/update in akey_fetch()/akey_update() for NULL recxs which is
possible when fetch multiple IODs and recxs only valid on partial shard.
fix a bug in shard_auxi_task_cb() that may use incorrect task pointer.

Signed-off-by: Xuezhao Liu <xuezhao.liu@intel.com>