### PR TITLE
DAOS-9562 test: Prevent running release/2.0 tests with VMD

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -71,7 +71,7 @@ pipeline {
                defaultValue: 'ci_nvme3',
                description: 'Label to use for 3 node NVMe tests')
         string(name: 'CI_NVME_5_LABEL',
-               defaultValue: 'ci_nvme5',
+               defaultValue: 'ci_nvme9',
                description: 'Label to use for 5 node NVMe tests')
         string(name: 'CI_NVME_9_LABEL',
                defaultValue: 'ci_nvme9',


### PR DESCRIPTION
Use the 9-node clusters to run functional HW Medium tests in the
release/2.0 branch to avoid running these tests on VMD-enabled clusters.

Signed-off-by: Phillip Henderson <phillip.henderson@intel.com>