### PR TITLE
DAOS-10354 dfuse: Disable interception library on files opened FMODE_EXEC

### DIFF
--- a/src/client/dfuse/dfuse.h
+++ b/src/client/dfuse/dfuse.h
@@ -94,6 +94,8 @@ struct dfuse_obj_hdl {
 
 	ATOMIC uint32_t                  doh_il_calls;
 
+	ATOMIC uint32_t                  doh_exec_calls;
+
 	/** True if caching is enabled for this file. */
 	bool				doh_caching;
 
@@ -544,6 +546,8 @@ struct dfuse_inode_entry {
 
 	/* Number of file open file descriptors using IL */
 	ATOMIC uint32_t          ie_il_count;
+
+	ATOMIC uint32_t          ie_exec_count;
 
 	/** file was truncated from 0 to a certain size */
 	bool			ie_truncated;

--- a/src/client/dfuse/ops/ioctl.c
+++ b/src/client/dfuse/ops/ioctl.c
@@ -314,7 +314,12 @@ void dfuse_cb_ioctl(fuse_req_t req, fuse_ino_t ino, unsigned int cmd, void *arg,
 		D_GOTO(out_err, rc = ENOTSUP);
 	}
 
-	DFUSE_TRA_DEBUG(oh, "ioctl cmd=%#x", cmd);
+	DFUSE_TRA_DEBUG(oh, "ioctl cmd=%#x exec count %d", cmd, oh->doh_ie->ie_exec_count);
+
+	if (atomic_load_relaxed(&oh->doh_ie->ie_exec_count) != 0) {
+		DFUSE_TRA_ERROR(oh, "Not allowing interception for executable");
+		D_GOTO(out_err, rc = ENOTSUP);
+	}
 
 	if (cmd == DFUSE_IOCTL_IL) {
 		if (out_bufsz < sizeof(struct dfuse_il_reply))


### PR DESCRIPTION
This avoids a deadlock in the intercetion library when running shell
scripts from dfuse.  When doing this the file gets opened once with
FMODE_EXEC, then closed, then opened again without the flag, and the
IL will call the ioctl on this second handle.  To avoid the issue
detect the FMODE_EXEC flag and permantly disable the ioctl for the
inode.

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>
