### PR TITLE
DAOS-10535 build: Remove daos_tests daos-*-tests-openmpi requirement

### DIFF
--- a/.rpmignore
+++ b/.rpmignore
@@ -7,16 +7,19 @@ centos7/daos-client-tests-openmpi*.rpm
 centos7/daos-firmware*.rpm
 centos7/daos-serialize*.rpm
 centos7/daos-server-tests-openmpi*.rpm
+centos7/daos-tests-internal*.rpm
 
 el8/daos-client-tests-openmpi*.rpm
 el8/daos-firmware*.rpm
 el8/daos-serialize*.rpm
 el8/daos-server-tests-openmpi*.rpm
+el8/daos-tests-internal*.rpm
 
 leap15/daos-client-tests-openmpi*.rpm
 leap15/daos-firmware*.rpm
 leap15/daos-serialize*.rpm
 leap15/daos-server-tests-openmpi*.rpm
+leap15/daos-tests-internal*.rpm
 
 ubuntu20.04/daos-*.deb
 ubuntu20.04/libdaos*.deb

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,12 +13,10 @@
 // To use a test branch (i.e. PR) until it lands to master
 // I.e. for testing library changes
 //@Library(value="pipeline-lib@your_branch") _
+@Library(value="pipeline-lib@DAOS-10535") _
 
 // For master, this is just some wildly high number
 next_version = "2.3.0"
-
-// Additional daos RPM packages required for functional tests
-add_daos_pkgs = ",-client-tests-openmpi,-server-tests-openmpi"
 
 // Don't define this as a type or it loses it's global scope
 target_branch = env.CHANGE_TARGET ? env.CHANGE_TARGET : env.BRANCH_NAME
@@ -701,7 +699,7 @@ pipeline {
                     }
                     steps {
                         functionalTest inst_repos: daosRepos(),
-                                       inst_rpms: functionalPackages(1, next_version, add_daos_pkgs),
+                                       inst_rpms: functionalPackages(1, next_version),
                                        test_function: 'runTestFunctionalV2'
                     }
                     post {
@@ -720,7 +718,7 @@ pipeline {
                     }
                     steps {
                         functionalTest inst_repos: daosRepos(),
-                                       inst_rpms: functionalPackages(1, next_version, add_daos_pkgs),
+                                       inst_rpms: functionalPackages(1, next_version),
                                        test_function: 'runTestFunctionalV2'
                     }
                     post {
@@ -739,7 +737,7 @@ pipeline {
                     }
                     steps {
                         functionalTest inst_repos: daosRepos(),
-                                       inst_rpms: functionalPackages(1, next_version, add_daos_pkgs),
+                                       inst_rpms: functionalPackages(1, next_version),
                                        test_function: 'runTestFunctionalV2'
                     }
                     post {
@@ -758,7 +756,7 @@ pipeline {
                     }
                     steps {
                         functionalTest inst_repos: daosRepos(),
-                                       inst_rpms: functionalPackages(1, next_version, add_daos_pkgs),
+                                       inst_rpms: functionalPackages(1, next_version),
                                        test_function: 'runTestFunctionalV2'
                     }
                     post {
@@ -777,7 +775,7 @@ pipeline {
                     }
                     steps {
                         functionalTest inst_repos: daosRepos(),
-                                       inst_rpms: functionalPackages(1, next_version, add_daos_pkgs),
+                                       inst_rpms: functionalPackages(1, next_version),
                                        test_function: 'runTestFunctionalV2'
                     }
                     post {
@@ -911,7 +909,7 @@ pipeline {
             }
             steps {
                 storagePrepTest inst_repos: daosRepos(),
-                                inst_rpms: functionalPackages(1, next_version, add_daos_pkgs)
+                                inst_rpms: functionalPackages(1, next_version)
             }
         } // stage('Test Storage Prep')
         stage('Test Hardware') {
@@ -931,7 +929,7 @@ pipeline {
                     }
                     steps {
                         functionalTest inst_repos: daosRepos(),
-                                       inst_rpms: functionalPackages(1, next_version, add_daos_pkgs),
+                                       inst_rpms: functionalPackages(1, next_version),
                                        test_function: 'runTestFunctionalV2'
                     }
                     post {
@@ -951,7 +949,7 @@ pipeline {
                     }
                     steps {
                         functionalTest inst_repos: daosRepos(),
-                                       inst_rpms: functionalPackages(1, next_version, add_daos_pkgs),
+                                       inst_rpms: functionalPackages(1, next_version),
                                        test_function: 'runTestFunctionalV2'
                    }
                     post {
@@ -971,7 +969,7 @@ pipeline {
                     }
                     steps {
                         functionalTest inst_repos: daosRepos(),
-                                       inst_rpms: functionalPackages(1, next_version, add_daos_pkgs),
+                                       inst_rpms: functionalPackages(1, next_version),
                                        test_function: 'runTestFunctionalV2'
                     }
                     post {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,6 +13,7 @@
 // To use a test branch (i.e. PR) until it lands to master
 // I.e. for testing library changes
 //@Library(value="pipeline-lib@your_branch") _
+@Library(value="pipeline-lib@DAOS-10535") _
 
 // For master, this is just some wildly high number
 next_version = "2.3.0"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,10 +13,12 @@
 // To use a test branch (i.e. PR) until it lands to master
 // I.e. for testing library changes
 //@Library(value="pipeline-lib@your_branch") _
-@Library(value="pipeline-lib@DAOS-10535") _
 
 // For master, this is just some wildly high number
 next_version = "2.3.0"
+
+// Additional daos RPM packages required for functional tests
+add_daos_pkgs = ",-client-tests-openmpi,-server-tests-openmpi"
 
 // Don't define this as a type or it loses it's global scope
 target_branch = env.CHANGE_TARGET ? env.CHANGE_TARGET : env.BRANCH_NAME
@@ -699,7 +701,7 @@ pipeline {
                     }
                     steps {
                         functionalTest inst_repos: daosRepos(),
-                                       inst_rpms: functionalPackages(1, next_version),
+                                       inst_rpms: functionalPackages(1, next_version, add_daos_pkgs),
                                        test_function: 'runTestFunctionalV2'
                     }
                     post {
@@ -718,7 +720,7 @@ pipeline {
                     }
                     steps {
                         functionalTest inst_repos: daosRepos(),
-                                       inst_rpms: functionalPackages(1, next_version),
+                                       inst_rpms: functionalPackages(1, next_version, add_daos_pkgs),
                                        test_function: 'runTestFunctionalV2'
                     }
                     post {
@@ -737,7 +739,7 @@ pipeline {
                     }
                     steps {
                         functionalTest inst_repos: daosRepos(),
-                                       inst_rpms: functionalPackages(1, next_version),
+                                       inst_rpms: functionalPackages(1, next_version, add_daos_pkgs),
                                        test_function: 'runTestFunctionalV2'
                     }
                     post {
@@ -756,7 +758,7 @@ pipeline {
                     }
                     steps {
                         functionalTest inst_repos: daosRepos(),
-                                       inst_rpms: functionalPackages(1, next_version),
+                                       inst_rpms: functionalPackages(1, next_version, add_daos_pkgs),
                                        test_function: 'runTestFunctionalV2'
                     }
                     post {
@@ -775,7 +777,7 @@ pipeline {
                     }
                     steps {
                         functionalTest inst_repos: daosRepos(),
-                                       inst_rpms: functionalPackages(1, next_version),
+                                       inst_rpms: functionalPackages(1, next_version, add_daos_pkgs),
                                        test_function: 'runTestFunctionalV2'
                     }
                     post {
@@ -909,7 +911,7 @@ pipeline {
             }
             steps {
                 storagePrepTest inst_repos: daosRepos(),
-                                inst_rpms: functionalPackages(1, next_version)
+                                inst_rpms: functionalPackages(1, next_version, add_daos_pkgs)
             }
         } // stage('Test Storage Prep')
         stage('Test Hardware') {
@@ -929,7 +931,7 @@ pipeline {
                     }
                     steps {
                         functionalTest inst_repos: daosRepos(),
-                                       inst_rpms: functionalPackages(1, next_version),
+                                       inst_rpms: functionalPackages(1, next_version, add_daos_pkgs),
                                        test_function: 'runTestFunctionalV2'
                     }
                     post {
@@ -949,7 +951,7 @@ pipeline {
                     }
                     steps {
                         functionalTest inst_repos: daosRepos(),
-                                       inst_rpms: functionalPackages(1, next_version),
+                                       inst_rpms: functionalPackages(1, next_version, add_daos_pkgs),
                                        test_function: 'runTestFunctionalV2'
                    }
                     post {
@@ -969,7 +971,7 @@ pipeline {
                     }
                     steps {
                         functionalTest inst_repos: daosRepos(),
-                                       inst_rpms: functionalPackages(1, next_version),
+                                       inst_rpms: functionalPackages(1, next_version, add_daos_pkgs),
                                        test_function: 'runTestFunctionalV2'
                     }
                     post {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,7 +13,6 @@
 // To use a test branch (i.e. PR) until it lands to master
 // I.e. for testing library changes
 //@Library(value="pipeline-lib@your_branch") _
-@Library(value="pipeline-lib@DAOS-10535") _
 
 // For master, this is just some wildly high number
 next_version = "2.3.0"
@@ -699,7 +698,7 @@ pipeline {
                     }
                     steps {
                         functionalTest inst_repos: daosRepos(),
-                                       inst_rpms: functionalPackages(1, next_version),
+                                       inst_rpms: functionalPackages(1, next_version, "{client,server}-tests-openmpi"),
                                        test_function: 'runTestFunctionalV2'
                     }
                     post {
@@ -718,7 +717,7 @@ pipeline {
                     }
                     steps {
                         functionalTest inst_repos: daosRepos(),
-                                       inst_rpms: functionalPackages(1, next_version),
+                                       inst_rpms: functionalPackages(1, next_version, "{client,server}-tests-openmpi"),
                                        test_function: 'runTestFunctionalV2'
                     }
                     post {
@@ -737,7 +736,7 @@ pipeline {
                     }
                     steps {
                         functionalTest inst_repos: daosRepos(),
-                                       inst_rpms: functionalPackages(1, next_version),
+                                       inst_rpms: functionalPackages(1, next_version, "{client,server}-tests-openmpi"),
                                        test_function: 'runTestFunctionalV2'
                     }
                     post {
@@ -756,7 +755,7 @@ pipeline {
                     }
                     steps {
                         functionalTest inst_repos: daosRepos(),
-                                       inst_rpms: functionalPackages(1, next_version),
+                                       inst_rpms: functionalPackages(1, next_version, "{client,server}-tests-openmpi"),
                                        test_function: 'runTestFunctionalV2'
                     }
                     post {
@@ -775,7 +774,7 @@ pipeline {
                     }
                     steps {
                         functionalTest inst_repos: daosRepos(),
-                                       inst_rpms: functionalPackages(1, next_version),
+                                       inst_rpms: functionalPackages(1, next_version, "{client,server}-tests-openmpi"),
                                        test_function: 'runTestFunctionalV2'
                     }
                     post {
@@ -909,7 +908,7 @@ pipeline {
             }
             steps {
                 storagePrepTest inst_repos: daosRepos(),
-                                inst_rpms: functionalPackages(1, next_version)
+                                inst_rpms: functionalPackages(1, next_version, "{client,server}-tests-openmpi")
             }
         } // stage('Test Storage Prep')
         stage('Test Hardware') {
@@ -929,7 +928,7 @@ pipeline {
                     }
                     steps {
                         functionalTest inst_repos: daosRepos(),
-                                       inst_rpms: functionalPackages(1, next_version),
+                                       inst_rpms: functionalPackages(1, next_version, "{client,server}-tests-openmpi"),
                                        test_function: 'runTestFunctionalV2'
                     }
                     post {
@@ -949,7 +948,7 @@ pipeline {
                     }
                     steps {
                         functionalTest inst_repos: daosRepos(),
-                                       inst_rpms: functionalPackages(1, next_version),
+                                       inst_rpms: functionalPackages(1, next_version, "{client,server}-tests-openmpi"),
                                        test_function: 'runTestFunctionalV2'
                    }
                     post {
@@ -969,7 +968,7 @@ pipeline {
                     }
                     steps {
                         functionalTest inst_repos: daosRepos(),
-                                       inst_rpms: functionalPackages(1, next_version),
+                                       inst_rpms: functionalPackages(1, next_version, "{client,server}-tests-openmpi"),
                                        test_function: 'runTestFunctionalV2'
                     }
                     post {

--- a/ci/functional/required_packages.sh
+++ b/ci/functional/required_packages.sh
@@ -32,7 +32,9 @@ elif [[ $distro = el* ]] || [[ $distro = centos* ]] ||
           hdf5-vol-daos-mpich-tests    \
           MACSio-mpich                 \
           MACSio-$openmpi              \
-          mpifileutils-mpich"
+          mpifileutils-mpich           \
+          daos-server-tests-openmpi    \
+          daos-client-tests-openmpi"
 else
     echo "I don't know which packages should be installed for distro" \
          "\"$distro\""

--- a/ci/functional/required_packages.sh
+++ b/ci/functional/required_packages.sh
@@ -32,9 +32,7 @@ elif [[ $distro = el* ]] || [[ $distro = centos* ]] ||
           hdf5-vol-daos-mpich-tests    \
           MACSio-mpich                 \
           MACSio-$openmpi              \
-          mpifileutils-mpich           \
-          daos-server-tests-openmpi    \
-          daos-client-tests-openmpi"
+          mpifileutils-mpich"
 else
     echo "I don't know which packages should be installed for distro" \
          "\"$distro\""

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+daos (2.1.102-2) unstable; urgency=medium
+  [ Phillip Henderson ]
+  * Remove doas-*-tests-openmpi dependencies from daos-tests
+
+ -- Phillip Henderson <phillip.henderson@intel.com>  Mon, 9 May 2022 17:48:00 -0400
+
 daos (2.1.102-1) unstable; urgency=medium
   [ Johann Lombardi ]
   * Bump version to 2.1.102

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,7 @@
 daos (2.1.102-2) unstable; urgency=medium
   [ Phillip Henderson ]
   * Remove doas-*-tests-openmpi dependencies from daos-tests
+  * Add daos-tests-internal package
 
  -- Phillip Henderson <phillip.henderson@intel.com>  Mon, 9 May 2022 17:48:00 -0400
 

--- a/debian/control
+++ b/debian/control
@@ -98,6 +98,16 @@ Description: This is the package is a metapackage to install all of the test pac
  .
  This package contains tests
 
+Package: daos-tests-internal
+Architecture: any
+Multi-Arch: same
+Depends: daos-tests (= ${binary:Version}),
+         daos-client-tests-openmpi (= ${binary:Version})
+         daos-server-tests-openmpi (= ${binary:Version})
+Description: This is the package is a metapackage to install all of the internal test packages
+ .
+ This package contains tests
+
 Package: daos-client-tests
 Architecture: any
 Multi-Arch: same

--- a/debian/control
+++ b/debian/control
@@ -92,8 +92,8 @@ Description: The Distributed Asynchronous Object Storage (DAOS) is an open-sourc
 Package: daos-tests
 Architecture: any
 Multi-Arch: same
-Depends: daos-client-tests-openmpi (= ${binary:Version}),
-         daos-server-tests-openmpi (= ${binary:Version})
+Depends: daos-client-tests (= ${binary:Version}),
+         daos-server-tests (= ${binary:Version})
 Description: This is the package is a metapackage to install all of the test packages
  .
  This package contains tests

--- a/debian/control
+++ b/debian/control
@@ -102,7 +102,7 @@ Package: daos-tests-internal
 Architecture: any
 Multi-Arch: same
 Depends: daos-tests (= ${binary:Version}),
-         daos-client-tests-openmpi (= ${binary:Version})
+         daos-client-tests-openmpi (= ${binary:Version}),
          daos-server-tests-openmpi (= ${binary:Version})
 Description: This is the package is a metapackage to install all of the internal test packages
  .

--- a/utils/rpms/daos.spec
+++ b/utils/rpms/daos.spec
@@ -27,7 +27,7 @@
 
 Name:          daos
 Version:       2.1.102
-Release:       1%{?relval}%{?dist}
+Release:       2%{?relval}%{?dist}
 Summary:       DAOS Storage Engine
 
 License:       BSD-2-Clause-Patent
@@ -226,8 +226,8 @@ This is the package needed to run a DAOS client
 
 %package tests
 Summary: The entire DAOS test suite
-Requires: %{name}-client-tests-openmpi%{?_isa} = %{version}-%{release}
-Requires: %{name}-server-tests-openmpi%{?_isa} = %{version}-%{release}
+Requires: %{name}-client-tests%{?_isa} = %{version}-%{release}
+Requires: %{name}-server-tests%{?_isa} = %{version}-%{release}
 
 %description tests
 This is the package is a metapackage to install all of the test packages
@@ -562,6 +562,9 @@ getent passwd daos_agent >/dev/null || useradd -s /sbin/nologin -r -g daos_agent
 # No files in a shim package
 
 %changelog
+* Mon May 9 2022 Phillip Henderson <phillip.henderson@intel.com> 2.1.102-2
+- Remove doas-*-tests-openmpi dependencies from daos-tests
+
 * Thu May 5 2022 Johann Lombardi <johann.lombardi@intel.com> 2.1.102-1
 - Bump version to 2.1.102
 

--- a/utils/rpms/daos.spec
+++ b/utils/rpms/daos.spec
@@ -232,6 +232,15 @@ Requires: %{name}-server-tests%{?_isa} = %{version}-%{release}
 %description tests
 This is the package is a metapackage to install all of the test packages
 
+%package tests-internal
+Summary: The entire DAOS internal test suite
+Requires: %{name}-tests%{?_isa} = %{version}-%{release}
+Requires: %{name}-client-tests-openmpi%{?_isa} = %{version}-%{release}
+Requires: %{name}-server-tests-openmpi%{?_isa} = %{version}-%{release}
+
+%description tests-internal
+This is the package is a metapackage to install all of the internal test packages
+
 %package client-tests
 Summary: The DAOS test suite
 Requires: %{name}-client%{?_isa} = %{version}-%{release}
@@ -564,6 +573,7 @@ getent passwd daos_agent >/dev/null || useradd -s /sbin/nologin -r -g daos_agent
 %changelog
 * Mon May 9 2022 Phillip Henderson <phillip.henderson@intel.com> 2.1.102-2
 - Remove doas-*-tests-openmpi dependencies from daos-tests
+- Add the daos-tests-internal package
 
 * Thu May 5 2022 Johann Lombardi <johann.lombardi@intel.com> 2.1.102-1
 - Bump version to 2.1.102

--- a/utils/rpms/daos.spec
+++ b/utils/rpms/daos.spec
@@ -567,6 +567,9 @@ getent passwd daos_agent >/dev/null || useradd -s /sbin/nologin -r -g daos_agent
 %files tests
 # No files in a meta-package
 
+%files tests-internal
+# No files in a meta-package
+
 %files mofed-shim
 # No files in a shim package
 


### PR DESCRIPTION
Limit daos_tests requiement to the non-openmpi daos-*-tests packages.

Signed-off-by: Phillip Henderson <phillip.henderson@intel.com>