### PR TITLE
DAOS-10542 Jenkinsfile: Simplify pb-c patterns

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -220,16 +220,10 @@ pipeline {
                         checkPatch user: GITHUB_USER_USR,
                                    password: GITHUB_USER_PSW,
                                    ignored_files: "src/control/vendor/*:" +
-                                                  "src/include/daos/*.pb-c.h:" +
-                                                  "src/common/*.pb-c.[ch]:" +
-                                                  "src/mgmt/*.pb-c.[ch]:" +
-                                                  "src/engine/*.pb-c.[ch]:" +
-                                                  "src/security/*.pb-c.[ch]:" +
+                                                  "*.pb-c.[ch]:" +
                                                   "src/client/java/daos-java/src/main/java/io/daos/dfs/uns/*:" +
                                                   "src/client/java/daos-java/src/main/java/io/daos/obj/attr/*:" +
                                                   "src/client/java/daos-java/src/main/native/include/daos_jni_common.h:" +
-                                                  "src/client/java/daos-java/src/main/native/*.pb-c.[ch]:" +
-                                                  "src/client/java/daos-java/src/main/native/include/*.pb-c.[ch]:" +
                                                   "*.crt:" +
                                                   "*.pem:" +
                                                   "*_test.go:" +


### PR DESCRIPTION
Replace

    "<module>/*.pb-c.[ch]:"

with

    "*.pb-c.[ch]:"

to avoid the scenario where one adds a new pb-c file but forgets to
update this list.

Skip-build: true
Signed-off-by: Li Wei <wei.g.li@intel.com>