### PR TITLE
DAOS-10538 control: Remove inner RPC timeouts for system commands (#8…

### DIFF
--- a/src/control/server/ctl_ranks_rpc_test.go
+++ b/src/control/server/ctl_ranks_rpc_test.go
@@ -128,18 +128,6 @@ func TestServer_CtlSvc_PrepShutdownRanks(t *testing.T) {
 				{Rank: 2, State: msErrored, Errored: true},
 			},
 		},
-		"prep shutdown timeout": { // dRPC req-resp duration > rankReqTime
-			req:           &ctlpb.RanksReq{Ranks: "0-3"},
-			responseDelay: 200 * time.Millisecond,
-			drpcResps: []proto.Message{
-				&mgmtpb.DaosResp{Status: 0},
-				&mgmtpb.DaosResp{Status: 0},
-			},
-			expResults: []*sharedpb.RankResult{
-				{Rank: 1, State: stateString(system.MemberStateUnresponsive)},
-				{Rank: 2, State: stateString(system.MemberStateUnresponsive)},
-			},
-		},
 		"context timeout": { // dRPC req-resp duration > parent context timeout
 			req:           &ctlpb.RanksReq{Ranks: "0-3"},
 			responseDelay: 40 * time.Millisecond,
@@ -229,8 +217,6 @@ func TestServer_CtlSvc_PrepShutdownRanks(t *testing.T) {
 				srv.setDrpcClient(newMockDrpcClient(cfg))
 			}
 
-			svc.harness.rankReqTimeout = 50 * time.Millisecond
-
 			var cancel context.CancelFunc
 			ctx := context.Background()
 			if tc.ctxTimeout != 0 {
@@ -258,16 +244,17 @@ func TestServer_CtlSvc_PrepShutdownRanks(t *testing.T) {
 
 func TestServer_CtlSvc_StopRanks(t *testing.T) {
 	for name, tc := range map[string]struct {
-		missingSB        bool
-		engineCount      int
-		instancesStopped bool
-		req              *ctlpb.RanksReq
-		signal           os.Signal
-		signalErr        error
-		ctxTimeout       time.Duration
-		expSignalsSent   map[uint32]os.Signal
-		expResults       []*sharedpb.RankResult
-		expErr           error
+		missingSB         bool
+		engineCount       int
+		instancesStopped  bool
+		instancesDontStop bool
+		req               *ctlpb.RanksReq
+		timeout           time.Duration
+		signal            os.Signal
+		signalErr         error
+		expSignalsSent    map[uint32]os.Signal
+		expResults        []*sharedpb.RankResult
+		expErr            error
 	}{
 		"nil request": {
 			expErr: errors.New("nil request"),
@@ -293,26 +280,28 @@ func TestServer_CtlSvc_StopRanks(t *testing.T) {
 			signalErr: errors.New("sending signal failed"),
 			expErr:    errors.New("sending killed: sending signal failed"),
 		},
-		"context timeout": { // near-immediate parent context Timeout
-			req:        &ctlpb.RanksReq{Ranks: "0-3"},
-			ctxTimeout: time.Millisecond,
-			expErr:     context.DeadlineExceeded, // parent ctx timeout
-		},
-		"instances started": { // unsuccessful result for kill
+		"instances successfully stopped": {
 			req:            &ctlpb.RanksReq{Ranks: "0-3"},
 			expSignalsSent: map[uint32]os.Signal{0: syscall.SIGINT, 1: syscall.SIGINT},
 			expResults: []*sharedpb.RankResult{
-				{Rank: 1, State: msErrored, Errored: true},
-				{Rank: 2, State: msErrored, Errored: true},
+				{Rank: 1, State: msStopped},
+				{Rank: 2, State: msStopped},
 			},
 		},
-		"force stop instances started": { // unsuccessful result for kill
+		"instances successfully stopped with force": {
 			req:            &ctlpb.RanksReq{Ranks: "0-3", Force: true},
 			expSignalsSent: map[uint32]os.Signal{0: syscall.SIGKILL, 1: syscall.SIGKILL},
 			expResults: []*sharedpb.RankResult{
-				{Rank: 1, State: msErrored, Errored: true},
-				{Rank: 2, State: msErrored, Errored: true},
+				{Rank: 1, State: msStopped},
+				{Rank: 2, State: msStopped},
 			},
+		},
+		"instances not stopped in time": {
+			req:               &ctlpb.RanksReq{Ranks: "0-3"},
+			timeout:           time.Second,
+			expSignalsSent:    map[uint32]os.Signal{0: syscall.SIGINT, 1: syscall.SIGINT},
+			instancesDontStop: true,
+			expErr:            errors.New("deadline exceeded"),
 		},
 		"instances already stopped": { // successful result for kill
 			req:              &ctlpb.RanksReq{Ranks: "0-3"},
@@ -320,13 +309,6 @@ func TestServer_CtlSvc_StopRanks(t *testing.T) {
 			expResults: []*sharedpb.RankResult{
 				{Rank: 1, State: msStopped},
 				{Rank: 2, State: msStopped},
-			},
-		},
-		"force stop single instance started": {
-			req:            &ctlpb.RanksReq{Ranks: "1", Force: true},
-			expSignalsSent: map[uint32]os.Signal{0: syscall.SIGKILL},
-			expResults: []*sharedpb.RankResult{
-				{Rank: 1, State: msErrored, Errored: true},
 			},
 		},
 		"single instance already stopped": {
@@ -353,13 +335,13 @@ func TestServer_CtlSvc_StopRanks(t *testing.T) {
 			)
 			svc := mockControlService(t, log, cfg, nil, nil, nil)
 
-			if tc.ctxTimeout == 0 {
-				tc.ctxTimeout = 500 * time.Millisecond
+			ctx := context.Background()
+			ctx, cancel := context.WithCancel(ctx)
+			if tc.timeout != time.Duration(0) {
+				t.Logf("timeout of %s being applied", tc.timeout)
+				ctx, cancel = context.WithTimeout(ctx, tc.timeout)
 			}
-			ctx, cancel := context.WithTimeout(context.Background(), tc.ctxTimeout)
 			defer cancel()
-
-			svc.harness.rankReqTimeout = 50 * time.Millisecond
 
 			ps := events.NewPubSub(ctx, log)
 			defer ps.Close()
@@ -369,32 +351,36 @@ func TestServer_CtlSvc_StopRanks(t *testing.T) {
 			svc.events.Subscribe(events.RASTypeStateChange, dispatched)
 
 			for i, e := range svc.harness.instances {
-				srv := e.(*EngineInstance)
+				ei := e.(*EngineInstance)
 				if tc.missingSB {
-					srv._superblock = nil
+					ei._superblock = nil
 					continue
 				}
 
 				trc := &engine.TestRunnerConfig{}
 				if !tc.instancesStopped {
 					trc.Running.SetTrue()
-					srv.ready.SetTrue()
+					ei.ready.SetTrue()
 				}
 				trc.SignalCb = func(idx uint32, sig os.Signal) {
 					signalsSent.Store(idx, sig)
-					// simulate process exit which will call
-					// onInstanceExit handlers.
-					svc.harness.instances[idx].(*EngineInstance).exit(context.TODO(),
-						common.NormalExit)
+					if tc.instancesDontStop {
+						return
+					}
+					// simulate process exit which will call onInstanceExit handlers
+					ei.exit(ctx, common.NormalExit)
+					// set false on test runner so IsStarted on engine returns false
+					ei.runner.(*engine.TestRunner).GetRunnerConfig().Running.SetFalse()
+					log.Debugf("mock handling signal %v on engine %d", sig, idx)
 				}
 				trc.SignalErr = tc.signalErr
-				srv.runner = engine.NewTestRunner(trc, engine.MockConfig())
-				srv.setIndex(uint32(i))
+				ei.runner = engine.NewTestRunner(trc, engine.MockConfig())
+				ei.setIndex(uint32(i))
 
-				srv._superblock.Rank = new(system.Rank)
-				*srv._superblock.Rank = system.Rank(i + 1)
+				ei._superblock.Rank = new(system.Rank)
+				*ei._superblock.Rank = system.Rank(i + 1)
 
-				srv.OnInstanceExit(
+				ei.OnInstanceExit(
 					func(_ context.Context, _ uint32, _ system.Rank, _ error, _ uint64) error {
 						svc.events.Publish(mockEvtEngineDied(t))
 						return nil
@@ -407,7 +393,9 @@ func TestServer_CtlSvc_StopRanks(t *testing.T) {
 				return
 			}
 
-			<-ctx.Done()
+			if tc.timeout != time.Duration(0) {
+				<-ctx.Done()
+			}
 			common.AssertEqual(t, 0, len(dispatched.rx), "number of events published")
 
 			if diff := cmp.Diff(tc.expResults, gotResp.Results, defRankCmpOpts...); diff != "" {
@@ -496,19 +484,6 @@ func TestServer_CtlSvc_PingRanks(t *testing.T) {
 			expResults: []*sharedpb.RankResult{
 				{Rank: 1, State: msErrored, Errored: true},
 				{Rank: 2, State: msErrored, Errored: true},
-			},
-		},
-		"dRPC ping timeout": { // dRPC req-resp duration > rankReqTimeout
-			// force flag in request triggers dRPC ping
-			req:           &ctlpb.RanksReq{Ranks: "0-3", Force: true},
-			responseDelay: 200 * time.Millisecond,
-			drpcResps: []proto.Message{
-				&mgmtpb.DaosResp{Status: 0},
-				&mgmtpb.DaosResp{Status: 0},
-			},
-			expResults: []*sharedpb.RankResult{
-				{Rank: 1, State: stateString(system.MemberStateUnresponsive)},
-				{Rank: 2, State: stateString(system.MemberStateUnresponsive)},
 			},
 		},
 		"dRPC context timeout": { // dRPC req-resp duration > parent context Timeout
@@ -616,8 +591,6 @@ func TestServer_CtlSvc_PingRanks(t *testing.T) {
 				srv.setDrpcClient(newMockDrpcClient(cfg))
 			}
 
-			svc.harness.rankReqTimeout = 50 * time.Millisecond
-
 			var cancel context.CancelFunc
 			ctx := context.Background()
 			if tc.ctxTimeout != 0 {
@@ -650,7 +623,7 @@ func TestServer_CtlSvc_ResetFormatRanks(t *testing.T) {
 		instancesStarted bool
 		startFails       bool
 		req              *ctlpb.RanksReq
-		ctxTimeout       time.Duration
+		timeout          time.Duration
 		expResults       []*sharedpb.RankResult
 		expErr           error
 	}{
@@ -667,15 +640,6 @@ func TestServer_CtlSvc_ResetFormatRanks(t *testing.T) {
 			// no results as rank can't be read from superblock
 			expResults: []*sharedpb.RankResult{},
 		},
-		"missing ranks": {
-			req:        &ctlpb.RanksReq{Ranks: "0,3"},
-			expResults: []*sharedpb.RankResult{},
-		},
-		"context timeout": { // near-immediate parent context Timeout
-			req:        &ctlpb.RanksReq{Ranks: "0-3"},
-			ctxTimeout: time.Nanosecond,
-			expErr:     context.DeadlineExceeded, // parent ctx timeout
-		},
 		"instances already started": {
 			req:              &ctlpb.RanksReq{Ranks: "0-3"},
 			instancesStarted: true,
@@ -691,10 +655,8 @@ func TestServer_CtlSvc_ResetFormatRanks(t *testing.T) {
 		"instances stay stopped": {
 			req:        &ctlpb.RanksReq{Ranks: "0-3"},
 			startFails: true,
-			expResults: []*sharedpb.RankResult{
-				{Rank: 1, State: msStopped, Errored: true},
-				{Rank: 2, State: msStopped, Errored: true},
-			},
+			timeout:    time.Second,
+			expErr:     errors.New("deadline exceeded"),
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
@@ -706,6 +668,12 @@ func TestServer_CtlSvc_ResetFormatRanks(t *testing.T) {
 			}
 
 			ctx := context.Background()
+			if tc.timeout != time.Duration(0) {
+				t.Logf("timeout of %s being applied", tc.timeout)
+				newCtx, cancel := context.WithTimeout(context.Background(), tc.timeout)
+				ctx = newCtx
+				defer cancel()
+			}
 
 			cfg := config.DefaultServer().WithEngines(
 				engine.MockConfig().
@@ -724,9 +692,9 @@ func TestServer_CtlSvc_ResetFormatRanks(t *testing.T) {
 			svc := mockControlService(t, log, cfg, nil, nil, nil)
 
 			for i, e := range svc.harness.instances {
-				srv := e.(*EngineInstance)
+				ei := e.(*EngineInstance)
 				if tc.missingSB {
-					srv._superblock = nil
+					ei._superblock = nil
 					continue
 				}
 
@@ -739,12 +707,16 @@ func TestServer_CtlSvc_ResetFormatRanks(t *testing.T) {
 				trc := &engine.TestRunnerConfig{}
 				if tc.instancesStarted {
 					trc.Running.SetTrue()
-					srv.ready.SetTrue()
+					ei.ready.SetTrue()
 				}
-				srv.runner = engine.NewTestRunner(trc, engineCfg)
-				srv.setIndex(uint32(i))
+				if !tc.startFails {
+					ei.waitFormat.SetTrue()
+				}
 
-				cfg, err := srv.storage.GetScmConfig()
+				ei.runner = engine.NewTestRunner(trc, engineCfg)
+				ei.setIndex(uint32(i))
+
+				cfg, err := ei.storage.GetScmConfig()
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -756,28 +728,17 @@ func TestServer_CtlSvc_ResetFormatRanks(t *testing.T) {
 				}
 				superblock.Rank = new(system.Rank)
 				*superblock.Rank = system.Rank(i + 1)
-				srv.setSuperblock(superblock)
-				if err := srv.WriteSuperblock(); err != nil {
+				ei.setSuperblock(superblock)
+				if err := ei.WriteSuperblock(); err != nil {
 					t.Fatal(err)
 				}
 
-				// mimic srv.run, set "ready" on startLoop rx
+				// Unblock requestStart() called from ResetFormatRanks() by reading
+				// from startRequested channel.
 				go func(s *EngineInstance, startFails bool) {
 					<-s.startRequested
-					if startFails {
-						return
-					}
-					// processing loop reaches wait for format state
-					s.waitFormat.SetTrue()
-				}(srv, tc.startFails)
+				}(ei, tc.startFails)
 			}
-
-			if tc.ctxTimeout != 0 {
-				var cancel context.CancelFunc
-				ctx, cancel = context.WithTimeout(ctx, tc.ctxTimeout)
-				defer cancel()
-			}
-			svc.harness.rankStartTimeout = 50 * time.Millisecond
 
 			gotResp, gotErr := svc.ResetFormatRanks(ctx, tc.req)
 			common.CmpErr(t, tc.expErr, gotErr)
@@ -799,7 +760,7 @@ func TestServer_CtlSvc_StartRanks(t *testing.T) {
 		instancesStopped bool
 		startFails       bool
 		req              *ctlpb.RanksReq
-		ctxTimeout       time.Duration
+		timeout          time.Duration
 		expResults       []*sharedpb.RankResult
 		expErr           error
 	}{
@@ -820,11 +781,6 @@ func TestServer_CtlSvc_StartRanks(t *testing.T) {
 			req:        &ctlpb.RanksReq{Ranks: "0,3"},
 			expResults: []*sharedpb.RankResult{},
 		},
-		"context timeout": { // near-immediate parent context Timeout
-			req:        &ctlpb.RanksReq{Ranks: "0-3"},
-			ctxTimeout: time.Nanosecond,
-			expErr:     context.DeadlineExceeded, // parent ctx timeout
-		},
 		"instances already started": {
 			req: &ctlpb.RanksReq{Ranks: "0-3"},
 			expResults: []*sharedpb.RankResult{
@@ -840,14 +796,12 @@ func TestServer_CtlSvc_StartRanks(t *testing.T) {
 				{Rank: 2, State: msReady},
 			},
 		},
-		"instances stay stopped": {
+		"instances not started in time": {
 			req:              &ctlpb.RanksReq{Ranks: "0-3"},
+			timeout:          time.Second,
 			instancesStopped: true,
 			startFails:       true,
-			expResults: []*sharedpb.RankResult{
-				{Rank: 1, State: msErrored, Errored: true},
-				{Rank: 2, State: msErrored, Errored: true},
-			},
+			expErr:           errors.New("deadline exceeded"),
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
@@ -859,6 +813,12 @@ func TestServer_CtlSvc_StartRanks(t *testing.T) {
 			}
 
 			ctx := context.Background()
+			ctx, cancel := context.WithCancel(ctx)
+			if tc.timeout != time.Duration(0) {
+				t.Logf("timeout of %s being applied", tc.timeout)
+				ctx, cancel = context.WithTimeout(ctx, tc.timeout)
+			}
+			defer cancel()
 
 			cfg := config.DefaultServer().WithEngines(
 				engine.MockConfig().WithTargetCount(1),
@@ -888,27 +848,21 @@ func TestServer_CtlSvc_StartRanks(t *testing.T) {
 				go func(s *EngineInstance, startFails bool) {
 					<-s.startRequested
 					t.Logf("instance %d: start signal received", s.Index())
-					if startFails {
+					if startFails || !tc.instancesStopped {
 						return
 					}
 
 					// set instance runner started and ready
 					ch := make(chan error, 1)
-					if err := s.runner.Start(context.TODO(), ch); err != nil {
+					if err := s.runner.Start(ctx, ch); err != nil {
 						t.Logf("failed to start runner: %s", err)
 						return
 					}
 					<-ch
 					s.ready.SetTrue()
+					t.Log("ready set to true")
 				}(srv, tc.startFails)
 			}
-
-			if tc.ctxTimeout != 0 {
-				var cancel context.CancelFunc
-				ctx, cancel = context.WithTimeout(ctx, tc.ctxTimeout)
-				defer cancel()
-			}
-			svc.harness.rankStartTimeout = 50 * time.Millisecond
 
 			gotResp, gotErr := svc.StartRanks(ctx, tc.req)
 			common.CmpErr(t, tc.expErr, gotErr)
@@ -1035,8 +989,6 @@ func TestServer_CtlSvc_SetEngineLogMasks(t *testing.T) {
 				}
 				srv.setDrpcClient(newMockDrpcClient(cfg))
 			}
-
-			svc.harness.rankReqTimeout = 50 * time.Millisecond
 
 			var cancel context.CancelFunc
 			ctx := context.Background()

--- a/src/control/server/engine/mocks.go
+++ b/src/control/server/engine/mocks.go
@@ -93,3 +93,7 @@ func (tr *TestRunner) GetLastPid() uint64 {
 func (tr *TestRunner) GetConfig() *Config {
 	return tr.serverCfg
 }
+
+func (tr *TestRunner) GetRunnerConfig() *TestRunnerConfig {
+	return &tr.runnerCfg
+}

--- a/src/control/server/harness.go
+++ b/src/control/server/harness.go
@@ -10,7 +10,6 @@ import (
 	"context"
 	"os"
 	"sync"
-	"time"
 
 	"github.com/pkg/errors"
 	"google.golang.org/protobuf/proto"
@@ -24,11 +23,6 @@ import (
 	"github.com/daos-stack/daos/src/control/server/config"
 	"github.com/daos-stack/daos/src/control/server/storage"
 	"github.com/daos-stack/daos/src/control/system"
-)
-
-const (
-	rankReqTimeout   = 30 * time.Second
-	rankStartTimeout = 2 * rankReqTimeout
 )
 
 // Engine defines an interface to be implemented by engine instances.
@@ -77,22 +71,18 @@ type Engine interface {
 // EngineHarness is responsible for managing Engine instances.
 type EngineHarness struct {
 	sync.RWMutex
-	log              logging.Logger
-	instances        []Engine
-	started          atm.Bool
-	rankReqTimeout   time.Duration
-	rankStartTimeout time.Duration
-	faultDomain      *system.FaultDomain
-	onDrpcFailure    []func(context.Context, error)
+	log           logging.Logger
+	instances     []Engine
+	started       atm.Bool
+	faultDomain   *system.FaultDomain
+	onDrpcFailure []func(context.Context, error)
 }
 
 // NewEngineHarness returns an initialized *EngineHarness.
 func NewEngineHarness(log logging.Logger) *EngineHarness {
 	return &EngineHarness{
-		log:              log,
-		instances:        make([]Engine, 0),
-		rankReqTimeout:   rankReqTimeout,
-		rankStartTimeout: rankStartTimeout,
+		log:       log,
+		instances: make([]Engine, 0),
 	}
 }
 


### PR DESCRIPTION
…936)

To avoid timeouts on high-capacity storage installations, remove inner
timeouts intended to provide detail on command activity and instead
rely on lower granularity higher level RPC timeouts.

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>