### PR TITLE
DAOS-10148 tse: fix TSE task buffer to account for aarch64 architectu…

### DIFF
--- a/src/client/dfuse/dfuse_obj_da.h
+++ b/src/client/dfuse/dfuse_obj_da.h
@@ -13,7 +13,8 @@
 #define MAX_POOL_OBJ_SIZE 256
 
 typedef struct {
-	char data[128];
+	/** 124 + 8 bytes pad for pthread_mutex_t size difference on __aarch64__ */
+	char data[132];
 } obj_da_t;
 
 /* Initialize an object obj_da

--- a/src/include/daos/tse.h
+++ b/src/include/daos/tse.h
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2015-2021 Intel Corporation.
+ * (C) Copyright 2015-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -14,15 +14,13 @@
 #define __TSE_SCHEDULE_H__
 
 #include <gurt/list.h>
-/**
- * tse_task is used to track single asynchronous operation.
- * 1K bytes all together.
- */
-#define TSE_TASK_SIZE		1024
-/* 8 bytes used for public members */
-#define TSE_PRIV_SIZE		1016
-/* tse_task arguments max length */
-#define TSE_TASK_ARG_LEN		880
+
+/* tse_task arguments max length (pthread_mutex_t is of different size between x86 and aarch64). */
+#define TSE_TASK_ARG_LEN	(840 + sizeof(pthread_mutex_t))
+/* internal tse private data size (struct tse_task_private) */
+#define TSE_PRIV_SIZE		(TSE_TASK_ARG_LEN + 136)
+/* tse_task is used to track single asynchronous operation (8 bytes used for public members). */
+#define TSE_TASK_SIZE		(TSE_PRIV_SIZE + 8)
 
 typedef struct tse_task {
 	int			dt_result;


### PR DESCRIPTION
…re (#8747)

* pthread_mutex_t on arm is 8 bytes longer than on x86, so adjust the TSE
preallocated buffer to fix the static compile time assertion.
* update the tse stack sizes to be dependent on each other.
* fix another size issue on aarch64 in dfuse_obj_da.h

Signed-off-by: Mohamad Chaarawi <mohamad.chaarawi@intel.com>