### PR TITLE
DAOS-10541 pool: backport compatibility check

### DIFF
--- a/src/pool/srv_layout.c
+++ b/src/pool/srv_layout.c
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2017-2021 Intel Corporation.
+ * (C) Copyright 2017-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -29,6 +29,7 @@ RDB_STRING_KEY(ds_pool_prop_, nhandles);
 RDB_STRING_KEY(ds_pool_prop_, handles);
 RDB_STRING_KEY(ds_pool_prop_, ec_cell_sz);
 RDB_STRING_KEY(ds_pool_attr_, user);
+RDB_STRING_KEY(ds_pool_prop_, global_version);
 
 /** default properties, should cover all optional pool properties */
 struct daos_prop_entry pool_prop_entries_default[DAOS_PROP_PO_NUM] = {

--- a/src/pool/srv_layout.h
+++ b/src/pool/srv_layout.h
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2016-2021 Intel Corporation.
+ * (C) Copyright 2016-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -56,6 +56,7 @@ extern d_iov_t ds_pool_prop_nhandles;		/* uint32_t */
 extern d_iov_t ds_pool_prop_handles;		/* pool handle KVS */
 extern d_iov_t ds_pool_prop_ec_cell_sz;		/* pool EC cell size */
 extern d_iov_t ds_pool_attr_user;		/* pool user attributes KVS */
+extern d_iov_t ds_pool_prop_global_version;	/* global pool status */
 
 /*
  * Pool handle KVS (RDB_KVS_GENERIC)


### PR DESCRIPTION
If pool created after daos 2.2, downgrade it back
to 2.0 should be unsupported and fail properly.

Signed-off-by: Wang Shilong <shilong.wang@intel.com>