### PR TITLE
DAOS-10567 daos: fail if all replicas tried

### DIFF
--- a/src/common/rsvc.c
+++ b/src/common/rsvc.c
@@ -54,7 +54,6 @@ rsvc_client_init(struct rsvc_client *client, const d_rank_list_t *ranks)
 	}
 	rsvc_client_reset_leader(client);
 	client->sc_next = 0;
-	client->sc_tried = 0;
 	return 0;
 }
 
@@ -84,14 +83,14 @@ rsvc_client_choose(struct rsvc_client *client, crt_endpoint_t *ep)
 	D_DEBUG(DB_MD, DF_CLI"\n", DP_CLI(client));
 	if (client->sc_leader_known && client->sc_leader_aliveness > 0) {
 		chosen = client->sc_leader_index;
-	} else if (client->sc_tried >= client->sc_ranks->rl_nr) {
-		D_DEBUG(DB_MD, "All replica tried\n");
+	} else if (client->sc_ranks->rl_nr > 0 &&
+		   client->sc_next >= client->sc_ranks->rl_nr) {
+		D_DEBUG(DB_MD, "All replicas tried\n");
 		return -DER_NO_SERVICE;
 	} else if (client->sc_ranks->rl_nr > 0) {
 		chosen = client->sc_next;
 		/* The hintless search is a round robin of all replicas. */
 		client->sc_next++;
-		client->sc_tried++;
 		client->sc_next %= client->sc_ranks->rl_nr;
 	}
 

--- a/src/include/daos/rsvc.h
+++ b/src/include/daos/rsvc.h
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2017-2021 Intel Corporation.
+ * (C) Copyright 2017-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -34,6 +34,7 @@ struct rsvc_client {
 	uint64_t	sc_leader_term;
 	int		sc_leader_index;	/* in sc_ranks */
 	int		sc_next;		/* in sc_ranks */
+	int		sc_tried;
 };
 
 /** Return code of rsvc_client_complete_rpc() */

--- a/src/include/daos/rsvc.h
+++ b/src/include/daos/rsvc.h
@@ -34,7 +34,6 @@ struct rsvc_client {
 	uint64_t	sc_leader_term;
 	int		sc_leader_index;	/* in sc_ranks */
 	int		sc_next;		/* in sc_ranks */
-	int		sc_tried;
 };
 
 /** Return code of rsvc_client_complete_rpc() */

--- a/src/include/daos_errno.h
+++ b/src/include/daos_errno.h
@@ -273,6 +273,8 @@ extern "C" {
 		Retry with other target)				\
 	ACTION(DER_NOTSUPPORTED,	(DER_ERR_DAOS_BASE + 37),	\
 	       Operation not supported)					\
+	ACTION(DER_NO_SERVICE,		(DER_ERR_DAOS_BASE + 38),	\
+	       No service available)					\
 
 /** Defines the gurt error codes */
 #define D_FOREACH_ERR_RANGE(ACTION)	\


### PR DESCRIPTION
If one pool is not up because of disk incompatible reasons,
pool query will return DER_NOTLEADER and retry forever.

'dmg pool list' will hang because of above reason, improve
the case by breaking loop if all replicas have been tried.

Signed-off-by: Wang Shilong <shilong.wang@intel.com>