### PR TITLE
DAOS-10244 test: Improve deployment/agent_failure.py - release/2.2 (#8690)

### DIFF
--- a/src/tests/ftest/deployment/agent_failure.py
+++ b/src/tests/ftest/deployment/agent_failure.py
@@ -11,8 +11,9 @@ import threading
 
 from ior_test_base import IorTestBase
 from ior_utils import IorCommand
-from general_utils import report_errors, get_host_data
+from general_utils import report_errors, stop_processes, get_journalctl
 from command_utils_base import CommandFailure
+from job_manager_utils import get_job_manager
 
 
 class AgentFailure(IorTestBase):
@@ -21,45 +22,29 @@ class AgentFailure(IorTestBase):
 
     :avocado: recursive
     """
-    @staticmethod
-    def get_journalctl(hosts, since, until, journalctl_type):
-        """Run the journalctl on the hosts.
-
-        Args:
-            hosts (list): List of hosts to run journalctl.
-            since (str): Start time to search the log.
-            until (str): End time to search the log.
-            journalctl_type (str): String to search in the log. -t param for journalctl.
-
-        Returns:
-            list: a list of dictionaries containing the following key/value pairs:
-                "hosts": NodeSet containing the hosts with this data
-                "data":  data requested for the group of hosts
-
-        """
-        command = ("sudo /usr/bin/journalctl --system -t {} --since=\"{}\" "
-                   "--until=\"{}\"".format(journalctl_type, since, until))
-        err = "Error gathering system log events"
-        results = get_host_data(
-            hosts=hosts, command=command, text="journalctl", error=err)
-
-        return results
-
-    def run_ior_collect_error(self, results, job_num, file_name):
+    def run_ior_collect_error(self, results, job_num, file_name, clients):
         """Run IOR command and store error in results.
 
         Args:
-            results (dict): A dictionary object to store the ior metrics
-            job_num (int): Assigned job number
+            results (dict): A dictionary object to store the ior metrics.
+            job_num (int): Assigned job number.
             file_name (str): File name used for self.ior_cmd.test_file.
+            clients (list): Client hostnames to run IOR from.
         """
-        self.ior_cmd.set_daos_params(self.server_group, self.pool, self.container.uuid)
+        ior_cmd = IorCommand()
+        ior_cmd.get_params(self)
+        ior_cmd.set_daos_params(
+            group=self.server_group, pool=self.pool, cont_uuid=self.container.uuid)
         testfile = os.path.join("/", file_name)
-        self.ior_cmd.test_file.update(testfile)
+        ior_cmd.test_file.update(testfile)
 
-        manager = self.get_ior_job_manager_command()
-        manager.assign_hosts(
-            self.hostlist_clients, self.workdir, self.hostfile_clients_slots)
+        manager = get_job_manager(
+            test=self, class_name="Mpirun", job=ior_cmd, subprocess=self.subprocess,
+            mpi_type="mpich")
+        manager.assign_hosts(clients, self.workdir, self.hostfile_clients_slots)
+        ppn = self.params.get("ppn", '/run/ior/client_processes/*')
+        manager.ppn.update(ppn, 'mpirun.ppn')
+        manager.processes.update(None, 'mpirun.np')
 
         try:
             ior_output = manager.run()
@@ -92,8 +77,8 @@ class AgentFailure(IorTestBase):
 
         :avocado: tags=all,full_regression
         :avocado: tags=hw,large
-        :avocado: tags=deployment
-        :avocado: tags=agent_failure
+        :avocado: tags=deployment,fault_management,agent_failure
+        :avocado: tags=agent_failure_basic
         """
         # 1. Create a pool and a container.
         self.add_pool()
@@ -104,14 +89,15 @@ class AgentFailure(IorTestBase):
         job_num = 1
         self.log.info("Run IOR with thread")
         job = threading.Thread(
-            target=self.run_ior_collect_error, args=[ior_results, job_num, "test_file_1"])
+            target=self.run_ior_collect_error,
+            args=[ior_results, job_num, "test_file_1", [self.hostlist_clients[0]]])
 
         self.log.info("Start IOR 1 (thread)")
         job.start()
 
         # We need to stop daos_agent while IOR is running, so need to wait for a few
         # seconds for IOR to start.
-        self.log.info("Sleep 5 sec")
+        self.log.info("Waiting 5 sec for IOR to start writing data...")
         time.sleep(5)
 
         errors = []
@@ -136,7 +122,7 @@ class AgentFailure(IorTestBase):
             errors.append("-1005 is not in IOR error! {}".format(ior_error))
 
         # 5. Verify journalctl shows the log that the agent is stopped.
-        results = self.get_journalctl(
+        results = get_journalctl(
             hosts=self.hostlist_clients, since=since, until=until,
             journalctl_type="daos_agent")
         self.log.info("journalctl results = %s", results)
@@ -152,7 +138,8 @@ class AgentFailure(IorTestBase):
         # 7. Run IOR again.
         self.log.info("Start IOR 2")
         self.run_ior_collect_error(
-            job_num=job_num, results=ior_results, file_name="test_file_2")
+            job_num=job_num, results=ior_results, file_name="test_file_2",
+            clients=[self.hostlist_clients[0]])
 
         # Verify that there's no error this time.
         self.log.info("--- IOR results 2 ---")
@@ -161,4 +148,132 @@ class AgentFailure(IorTestBase):
         if ior_error:
             errors.append("Error found in second IOR run! {}".format(ior_error))
 
+        self.log.info("########## Errors ##########")
         report_errors(test=self, errors=errors)
+        self.log.info("############################")
+
+    def test_agent_failure_isolation(self):
+        """Jira ID: DAOS-9385.
+
+        1. Create a pool and a container.
+        2. Run IOR from the two client nodes.
+        3. Stop daos_agent process while IOR is running on one of the clients.
+        4. Wait until both of the IOR ends.
+        5. Check that there's no error on both of the clients. (No error occurs if there's
+        another agent running.)
+        6. On the killed client, verify journalctl shows the log that the agent is
+        stopped.
+        7. On the other client where agent is still running, verify that the journalctl
+        doesn't show that the agent is stopped.
+        8. Restart both daos_agent.
+        9. Run IOR again from both clients. It should succeed without any error.
+
+        :avocado: tags=all,full_regression
+        :avocado: tags=hw,large
+        :avocado: tags=deployment,fault_management,agent_failure
+        :avocado: tags=agent_failure_isolation
+        """
+        # 1. Create a pool and a container.
+        self.add_pool()
+        self.add_container(self.pool)
+
+        agent_hosts = self.agent_managers[0].hosts
+        self.log.info("agent_hosts = %s", agent_hosts)
+        agent_host_keep = agent_hosts[0]
+        agent_host_kill = agent_hosts[1]
+
+        # 2. Run IOR from the two client nodes.
+        ior_results = {}
+        job_num_keep = 1
+        job_num_kill = 2
+        self.log.info("Run IOR with thread")
+        thread_1 = threading.Thread(
+            target=self.run_ior_collect_error,
+            args=[ior_results, job_num_keep, "test_file_1", [agent_host_keep]])
+        thread_2 = threading.Thread(
+            target=self.run_ior_collect_error,
+            args=[ior_results, job_num_kill, "test_file_2", [agent_host_kill]])
+
+        self.log.info("Start IOR 1 (thread)")
+        thread_1.start()
+        thread_2.start()
+
+        # We need to stop daos_agent while IOR is running, so need to wait for a few
+        # seconds for IOR to start.
+        self.log.info("Waiting 5 sec for IOR to start writing data...")
+        time.sleep(5)
+
+        errors = []
+
+        # 3. Stop daos_agent process while IOR is running on one of the clients.
+        since = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        self.log.info("Stopping agent on %s", agent_host_kill)
+        pattern = self.agent_managers[0].manager.job.command_regex
+        result = stop_processes(hosts=[agent_host_kill], pattern=pattern)
+        if 0 in result and len(result) == 1:
+            msg = "No daos_agent process killed from {}!".format(agent_host_kill)
+            errors.append(msg)
+        else:
+            self.log.info("daos_agent in %s killed", agent_host_kill)
+        until = datetime.now().strftime('%Y-%m-%d %H:%M:%S')
+
+        # 4. Wait until both of the IOR thread ends.
+        thread_1.join()
+        thread_2.join()
+
+        # 5. Check that there's no error on both of the clients. (No error occurs if
+        # there's another agent running.)
+        self.log.info("--- IOR results Kill ---")
+        self.log.info(ior_results[job_num_kill])
+        ior_error = ior_results[job_num_kill][-1]
+        if ior_error:
+            errors.append("Error found in IOR on kill client! {}".format(ior_error))
+
+        self.log.info("--- IOR results Keep ---")
+        self.log.info(ior_results[job_num_keep])
+        ior_error = ior_results[job_num_keep][-1]
+        if ior_error:
+            errors.append("Error found in IOR on keep client! {}".format(ior_error))
+
+        # 6. On the killed client, verify journalctl shows the log that the agent is
+        # stopped.
+        results = get_journalctl(
+            hosts=[agent_host_kill], since=since, until=until,
+            journalctl_type="daos_agent")
+        self.log.info("journalctl results (kill) = %s", results)
+        if "shutting down" not in results[0]["data"]:
+            msg = ("Agent shut down message not found in journalctl on killed client! "
+                   "Output = {}".format(results))
+            errors.append(msg)
+
+        # 7. On the other client where agent is still running, verify that the journalctl
+        # in the previous step doesn't show that the agent is stopped.
+        results = get_journalctl(
+            hosts=[agent_host_keep], since=since, until=until,
+            journalctl_type="daos_agent")
+        self.log.info("journalctl results (keep) = %s", results)
+        if "shutting down" in results[0]["data"]:
+            msg = ("Agent shut down message found in journalctl on keep client! "
+                   "Output = {}".format(results))
+            errors.append(msg)
+
+        # 8. Restart both daos_agent. (Currently, there's no clean way to restart one.)
+        self.start_agent_managers()
+
+        # 9. Run IOR again from both clients. It should succeed this time without any
+        # error.
+        self.log.info("--- Start IOR 2 ---")
+        self.run_ior_collect_error(
+            job_num=job_num_keep, results=ior_results, file_name="test_file_3",
+            clients=agent_hosts)
+
+        # Verify that there's no error this time.
+        self.log.info("--- IOR results 2 ---")
+        self.log.info(ior_results[job_num_keep])
+        ior_error = ior_results[job_num_keep][-1]
+        if ior_error:
+            errors.append("Error found in second IOR run! {}".format(ior_error))
+
+        self.log.info("########## Errors ##########")
+        report_errors(test=self, errors=errors)
+        self.log.info("############################")

--- a/src/tests/ftest/deployment/agent_failure.yaml
+++ b/src/tests/ftest/deployment/agent_failure.yaml
@@ -6,9 +6,9 @@ hosts:
         - server-D
         - server-E
         - server-F
-        - server-G
     test_clients:
         - client-A
+        - client-B
 
 timeout: 300
 
@@ -57,14 +57,13 @@ ior:
     client_processes:
         np: 4
     iorflags:
-        flags: "-k -D 300 -v -w -W"
+        flags: -k -v -w -W
         api: DFS
         # This test doesn't work if the IOR runs too fast. In that case, increase
         # block_size and/or decrease transfer_size. To decrease transfer_size, divide it
         # by 2, 4, 8, etc.
-        transfer_size: '256K'
-        block_size: '20G'
-        write_x: 4
-        read_x: 2
-        dfs_oclass: "SX"
-        dfs_dir_oclass: "SX"
+        transfer_size: 256K
+        block_size: 20G
+        sw_deadline: 60
+        dfs_oclass: SX
+        dfs_dir_oclass: SX

--- a/src/tests/ftest/util/general_utils.py
+++ b/src/tests/ftest/util/general_utils.py
@@ -1317,3 +1317,26 @@ def get_primary_group(user=None):
         user = getuser()
     gid = pwd.getpwnam(user).pw_gid
     return grp.getgrgid(gid).gr_name
+
+
+def get_journalctl(hosts, since, until, journalctl_type):
+    """Run the journalctl on the hosts.
+
+    Args:
+        hosts (list): List of hosts to run journalctl.
+        since (str): Start time to search the log.
+        until (str): End time to search the log.
+        journalctl_type (str): String to search in the log. -t param for journalctl.
+
+    Returns:
+        list: a list of dictionaries containing the following key/value pairs:
+            "hosts": NodeSet containing the hosts with this data
+            "data":  data requested for the group of hosts
+
+    """
+    command = ("sudo /usr/bin/journalctl --system -t {} --since=\"{}\" "
+               "--until=\"{}\"".format(journalctl_type, since, until))
+    err = "Error gathering system log events"
+    results = get_host_data(hosts=hosts, command=command, text="journalctl", error=err)
+
+    return results


### PR DESCRIPTION
Cherry-pick of https://github.com/daos-stack/daos/pull/8690 to release/2.2.

* Test with multiple clients to verify the failure isolation.
  Run IOR from two separate clients using separate agent process.
  Kill one of the agents and verify that the other client
  isn’t affected.
* Use `ppn: 10` for IOR processes.
* Remove `write_x` and `read_x` from IOR section in the yaml.
* Use `sw_deadline: 300` instead of `-D 300` in IOR section in
the yaml.
* Move `get_journalctl` to ftest/util/general_utils.py

Skip-unit-tests: true
Skip-fault-injection-test: true
Test-tag: agent_failure
Signed-off-by: Makito Kano <makito.kano@intel.com>