### PR TITLE
DAOS-10204 dtx: delay IO forward for conditional ops during rebuild

### DIFF
--- a/src/dtx/dtx_common.c
+++ b/src/dtx/dtx_common.c
@@ -1003,9 +1003,12 @@ dtx_leader_begin(daos_handle_t coh, struct dtx_id *dti,
 	if (tgt_cnt > 0) {
 		dlh->dlh_future = ABT_FUTURE_NULL;
 		dlh->dlh_subs = (struct dtx_sub_status *)(dlh + 1);
-		for (i = 0; i < tgt_cnt; i++)
+		for (i = 0; i < tgt_cnt; i++) {
 			dlh->dlh_subs[i].dss_tgt = tgts[i];
-		dlh->dlh_sub_cnt = tgt_cnt;
+			if (unlikely(tgts[i].st_flags & DTF_DELAY_FORWARD))
+				dlh->dlh_delay_sub_cnt++;
+		}
+		dlh->dlh_normal_sub_cnt = tgt_cnt - dlh->dlh_delay_sub_cnt;
 	}
 
 	dth = &dlh->dlh_handle;
@@ -1076,16 +1079,6 @@ dtx_leader_end(struct dtx_leader_handle *dlh, struct ds_cont_hdl *coh, int resul
 	D_ASSERT(cont != NULL);
 
 	dtx_shares_fini(dth);
-
-	/* NB: even the local request failure, dth_ent == NULL, we
-	 * should still wait for remote object to finish the request.
-	 */
-
-	if (dlh->dlh_sub_cnt != 0) {
-		rc = dtx_leader_wait(dlh);
-		if (unlikely(rc == -DER_ALREADY))
-			rc = 0;
-	}
 
 	if (unlikely(result == -DER_ALREADY))
 		result = 0;
@@ -1770,7 +1763,8 @@ static void
 dtx_comp_cb(void **arg)
 {
 	struct dtx_leader_handle	*dlh;
-	uint32_t			i;
+	uint32_t			 sub_cnt;
+	uint32_t			 i;
 
 	dlh = arg[0];
 
@@ -1779,7 +1773,8 @@ dtx_comp_cb(void **arg)
 		return;
 	}
 
-	for (i = 0; i < dlh->dlh_sub_cnt; i++) {
+	sub_cnt = dlh->dlh_normal_sub_cnt + dlh->dlh_delay_sub_cnt;
+	for (i = 0; i < sub_cnt; i++) {
 		struct dtx_sub_status	*sub = &dlh->dlh_subs[i];
 
 		if (sub->dss_result == 0)
@@ -1816,20 +1811,24 @@ struct dtx_ult_arg {
 };
 
 static void
-dtx_leader_exec_ops_ult(void *arg)
+dtx_leader_exec_ops_normal_ult(void *arg)
 {
 	struct dtx_ult_arg		*ult_arg = arg;
 	struct dtx_leader_handle	*dlh = ult_arg->dlh;
 	struct dtx_sub_status		*sub;
 	ABT_future			 future = dlh->dlh_future;
+	uint32_t			 sub_cnt = dlh->dlh_normal_sub_cnt + dlh->dlh_delay_sub_cnt;
 	uint32_t			 i, j;
 	int				 rc = 0;
 
 	D_ASSERT(future != ABT_FUTURE_NULL);
-	for (i = 0, j = 0; i < dlh->dlh_sub_cnt; i++, j++) {
+	for (i = 0, j = 0; i < sub_cnt; i++, j++) {
 		sub = &dlh->dlh_subs[i];
 		sub->dss_result = 0;
 		sub->dss_comp = 0;
+
+		if (unlikely(sub->dss_tgt.st_flags & DTF_DELAY_FORWARD))
+			continue;
 
 		if (sub->dss_tgt.st_rank == DAOS_TGT_IGNORE ||
 		    (i == daos_fail_value_get() &&
@@ -1854,7 +1853,11 @@ next:
 	}
 
 	if (rc != 0) {
-		for (i++, j++; i < dlh->dlh_sub_cnt; i++, j++) {
+		for (i++, j++; i < sub_cnt; i++, j++) {
+			sub = &dlh->dlh_subs[i];
+			if (unlikely(sub->dss_tgt.st_flags & DTF_DELAY_FORWARD))
+				continue;
+
 			dtx_sub_comp_cb(dlh, i, 0);
 			if (j >= DTX_RPC_YIELD_THD) {
 				ABT_thread_yield();
@@ -1870,6 +1873,61 @@ next:
 	D_FREE(ult_arg);
 }
 
+static void
+dtx_leader_exec_ops_delay_ult(void *arg)
+{
+	struct dtx_ult_arg		*ult_arg = arg;
+	struct dtx_leader_handle	*dlh = ult_arg->dlh;
+	struct dtx_sub_status		*sub;
+	ABT_future			 future = dlh->dlh_future;
+	uint32_t			 sub_cnt = dlh->dlh_normal_sub_cnt + dlh->dlh_delay_sub_cnt;
+	uint32_t			 i, j;
+	int				 rc = 0;
+
+	D_ASSERT(future != ABT_FUTURE_NULL);
+	for (i = 0, j = 0; i < sub_cnt; i++, j++) {
+		sub = &dlh->dlh_subs[i];
+		if (!(sub->dss_tgt.st_flags & DTF_DELAY_FORWARD))
+			continue;
+
+		sub->dss_result = 0;
+		sub->dss_comp = 0;
+
+		rc = ult_arg->func(dlh, ult_arg->func_arg, i, dtx_sub_comp_cb);
+		if (rc != 0) {
+			if (sub->dss_comp == 0)
+				dtx_sub_comp_cb(dlh, i, rc);
+			break;
+		}
+
+		/* Yield to avoid holding CPU for too long time. */
+		if (j >= DTX_RPC_YIELD_THD) {
+			ABT_thread_yield();
+			j = 0;
+		}
+	}
+
+	if (rc != 0) {
+		for (i++, j++; i < sub_cnt; i++, j++) {
+			sub = &dlh->dlh_subs[i];
+			if (!(sub->dss_tgt.st_flags & DTF_DELAY_FORWARD))
+				continue;
+
+			dtx_sub_comp_cb(dlh, i, 0);
+			if (j >= DTX_RPC_YIELD_THD) {
+				ABT_thread_yield();
+				j = 0;
+			}
+		}
+	}
+
+	/* To indicate that the IO forward ULT itself has done. */
+	rc = ABT_future_set(future, dlh);
+	D_ASSERTF(rc == ABT_SUCCESS, "ABT_future_set failed (4) %d.\n", rc);
+
+	D_FREE(ult_arg);
+}
+
 /**
  * Execute the operations on all targets.
  */
@@ -1878,52 +1936,110 @@ dtx_leader_exec_ops(struct dtx_leader_handle *dlh, dtx_sub_func_t func,
 		    dtx_agg_cb_t agg_cb, void *agg_cb_arg, void *func_arg)
 {
 	struct dtx_ult_arg	*ult_arg;
-	int			rc;
+	int			 rc;
+	int			 rc1 = 0;
 
-	if (dlh->dlh_sub_cnt == 0)
+	dlh->dlh_result = 0;
+	dlh->dlh_normal_sub_done = 0;
+
+	if (dlh->dlh_normal_sub_cnt == 0)
 		goto exec;
 
 	D_ALLOC_PTR(ult_arg);
 	if (ult_arg == NULL)
 		return -DER_NOMEM;
-	ult_arg->func	= func;
+
+	ult_arg->func = func;
 	ult_arg->func_arg = func_arg;
-	ult_arg->dlh	= dlh;
-	dlh->dlh_agg_cb = agg_cb;
-	dlh->dlh_agg_cb_arg = agg_cb_arg;
+	ult_arg->dlh = dlh;
+
+	if (dlh->dlh_delay_sub_cnt > 0) {
+		dlh->dlh_agg_cb = NULL;
+		dlh->dlh_agg_cb_arg = NULL;
+	} else {
+		dlh->dlh_agg_cb = agg_cb;
+		dlh->dlh_agg_cb_arg = agg_cb_arg;
+	}
 
 	D_ASSERT(dlh->dlh_future == ABT_FUTURE_NULL);
 
-	/* Create the future with sub_cnt + 1, the additional one is used by the IO forward
+	/*
+	 * Create the future with sub_cnt + 1, the additional one is used by the IO forward
 	 * ULT itself to prevent the DTX handle being freed before the IO forward ULT exit.
 	 */
-	rc = ABT_future_create(dlh->dlh_sub_cnt + 1, dtx_comp_cb, &dlh->dlh_future);
+	rc = ABT_future_create(dlh->dlh_normal_sub_cnt + 1, dtx_comp_cb, &dlh->dlh_future);
 	if (rc != ABT_SUCCESS) {
-		D_ERROR("ABT_future_create failed %d.\n", rc);
+		D_ERROR("ABT_future_create failed (1): "DF_RC"\n", DP_RC(rc));
 		D_FREE_PTR(ult_arg);
 		return dss_abterr2der(rc);
 	}
 
 	/*
-	 * XXX ideally, we probably should create ULT for each shard, but
-	 * for performance reasons, let's only create one for all remote
-	 * targets for now.
+	 * XXX: Ideally, we probably should create ULT for each shard, but for performance
+	 *	reasons, let's only create one for all remote targets for now.
 	 */
-	dlh->dlh_result = 0;
-	rc = dss_ult_create(dtx_leader_exec_ops_ult, ult_arg, DSS_XS_IOFW,
-			    dss_get_module_info()->dmi_tgt_id,
-			    DSS_DEEP_STACK_SZ, NULL);
+	rc = dss_ult_create(dtx_leader_exec_ops_normal_ult, ult_arg, DSS_XS_IOFW,
+			    dss_get_module_info()->dmi_tgt_id, DSS_DEEP_STACK_SZ, NULL);
 	if (rc != 0) {
-		D_ERROR("ult create failed "DF_RC"\n", DP_RC(rc));
+		D_ERROR("ult create failed (2): "DF_RC"\n", DP_RC(rc));
 		D_FREE(ult_arg);
 		ABT_future_free(&dlh->dlh_future);
-		D_GOTO(out, rc);
+		return rc;
 	}
 
 exec:
 	/* Then execute the local operation */
 	rc = func(dlh, func_arg, -1, NULL);
-out:
+
+	/* Even the local request failure, we still need to wait for remote sub request. */
+	if (dlh->dlh_normal_sub_cnt > 0) {
+		rc1 = dtx_leader_wait(dlh);
+		if (unlikely(rc1 == -DER_ALREADY))
+			rc1 = 0;
+	}
+
+	if (rc != 0)
+		return rc;
+
+	if (rc1 != 0 || likely(dlh->dlh_delay_sub_cnt == 0))
+		return rc1;
+
+	/* For delay forward sub requests. */
+
+	dlh->dlh_normal_sub_done = 1;
+
+	D_ALLOC_PTR(ult_arg);
+	if (ult_arg == NULL)
+		return -DER_NOMEM;
+
+	ult_arg->func = func;
+	ult_arg->func_arg = func_arg;
+	ult_arg->dlh = dlh;
+	dlh->dlh_agg_cb = agg_cb;
+	dlh->dlh_agg_cb_arg = agg_cb_arg;
+
+	D_ASSERT(dlh->dlh_future == ABT_FUTURE_NULL);
+
+	rc = ABT_future_create(dlh->dlh_delay_sub_cnt + 1, dtx_comp_cb, &dlh->dlh_future);
+	if (rc != ABT_SUCCESS) {
+		D_ERROR("ABT_future_create failed (3): "DF_RC"\n", DP_RC(rc));
+		D_FREE_PTR(ult_arg);
+		return dss_abterr2der(rc);
+	}
+
+	rc = dss_ult_create(dtx_leader_exec_ops_delay_ult, ult_arg, DSS_XS_IOFW,
+			    dss_get_module_info()->dmi_tgt_id, DSS_DEEP_STACK_SZ, NULL);
+	if (rc != 0) {
+		D_ERROR("ult create failed (4): "DF_RC"\n", DP_RC(rc));
+		D_FREE(ult_arg);
+		ABT_future_free(&dlh->dlh_future);
+		return rc;
+	}
+
+	rc = dtx_leader_wait(dlh);
+	if (unlikely(rc == -DER_ALREADY))
+		rc = 0;
+
 	return rc;
 }
 

--- a/src/include/daos/object.h
+++ b/src/include/daos/object.h
@@ -174,6 +174,12 @@ struct daos_obj_layout {
  * update DAOS_OBJ_REPL_MAX obj with some target failed case.
  */
 #define DAOS_TGT_IGNORE		((d_rank_t)-1)
+
+enum daos_tgt_flags {
+	/* When leader forward IO RPC to non-leaders, delay the target until the others replied. */
+	DTF_DELAY_FORWARD	= (1 << 0),
+};
+
 /** to identify each obj shard's target */
 struct daos_shard_tgt {
 	uint32_t		st_rank;	/* rank of the shard */
@@ -181,8 +187,9 @@ struct daos_shard_tgt {
 	uint32_t		st_shard_id;	/* shard id */
 	uint32_t		st_tgt_id;	/* target id */
 	uint16_t		st_tgt_idx;	/* target xstream index */
-	/* target idx for EC obj, only used for client */
-	uint16_t		st_ec_tgt;
+	/* Target idx for EC obj, only used for client, consider OBJ_EC_MAX_M, 8-bits is enough. */
+	uint8_t			st_ec_tgt;
+	uint8_t			st_flags;	/* see daos_tgt_flags */
 };
 
 static inline bool

--- a/src/include/daos_errno.h
+++ b/src/include/daos_errno.h
@@ -250,9 +250,9 @@ extern "C" {
 	/** Agent is incompatible with libdaos */			\
 	ACTION(DER_AGENT_INCOMPAT,	(DER_ERR_DAOS_BASE + 29),	\
 	       Agent is incompatible with libdaos)			\
-	/** Multiple shards locate on the same target */		\
-	ACTION(DER_SHARDS_OVERLAP,	(DER_ERR_DAOS_BASE + 30),	\
-	       Shards overlap)						\
+	/** Needs to be handled via distributed transaction. */		\
+	ACTION(DER_NEED_TX,		(DER_ERR_DAOS_BASE + 30),	\
+	       To be handled via distributed transaction)		\
 	/** #failures exceed RF(Redundancy Factor), data possibly lost */ \
 	ACTION(DER_RF,			(DER_ERR_DAOS_BASE + 31),	\
 	       Failures exceed RF)					\

--- a/src/include/daos_srv/dtx_srv.h
+++ b/src/include/daos_srv/dtx_srv.h
@@ -152,11 +152,15 @@ struct dtx_leader_handle {
 	uint32_t			dlh_dti_cos_count;
 	struct dtx_id			*dlh_dti_cos;
 
-	/* The future to wait for all sub handle to finish */
+	/* The future to wait for sub requests to finish. */
 	ABT_future			dlh_future;
 
-	/* How many sub leader transaction */
-	uint32_t			dlh_sub_cnt;
+	/* Normal sub requests have been processed. */
+	uint32_t			dlh_normal_sub_done:1;
+	/* How many normal sub request. */
+	uint32_t			dlh_normal_sub_cnt;
+	/* How many delay forward sub request. */
+	uint32_t			dlh_delay_sub_cnt;
 	/* Sub transaction handle to manage the dtx leader */
 	struct dtx_sub_status		*dlh_subs;
 	dtx_agg_cb_t			dlh_agg_cb;

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -92,6 +92,7 @@ struct obj_auxi_args {
 					 force_degraded:1,
 					 shards_scheded:1,
 					 tx_convert:1,
+					 cond_modify:1,
 					 /* degraded fetch */
 					 deg_fetch:1,
 					 /* conf_fetch split to multiple sub-tasks */
@@ -622,7 +623,7 @@ obj_shard_find_replica(struct dc_object *obj, unsigned int target,
 }
 
 static int
-obj_ec_leader_select(struct dc_object *obj, int grp_idx, uint8_t *bit_map)
+obj_ec_leader_select(struct dc_object *obj, int grp_idx, bool cond_modify, uint8_t *bit_map)
 {
 	struct daos_oclass_attr *oca;
 	struct pl_obj_shard	*pl_shard;
@@ -650,6 +651,13 @@ obj_ec_leader_select(struct dc_object *obj, int grp_idx, uint8_t *bit_map)
 		}
 		goto found;
 	}
+
+	/*
+	 * If no parity node is available, then handle related task that has conditional
+	 * modification via distributed tranasaction.
+	 */
+	if (cond_modify)
+		return -DER_NEED_TX;
 
 	shard = -1;
 	tgt_idx = 0;
@@ -758,7 +766,7 @@ obj_replica_leader_select(struct dc_object *obj, unsigned int grp_idx)
 
 int
 obj_grp_leader_get(struct dc_object *obj, int grp_idx, unsigned int map_ver,
-		   uint8_t *bit_map)
+		   bool cond_modify, uint8_t *bit_map)
 {
 	int	rc = -DER_STALE;
 
@@ -767,7 +775,7 @@ obj_grp_leader_get(struct dc_object *obj, int grp_idx, unsigned int map_ver,
 		D_GOTO(unlock, rc);
 
 	if (obj_is_ec(obj))
-		rc = obj_ec_leader_select(obj, grp_idx, bit_map);
+		rc = obj_ec_leader_select(obj, grp_idx, cond_modify, bit_map);
 	else
 		rc = obj_replica_leader_select(obj, grp_idx);
 
@@ -872,7 +880,7 @@ obj_dkey2shard(struct dc_object *obj, uint64_t hash, unsigned int map_ver,
 	 * not has the expected data. Let's directly (or still) read from related data shard.
 	 */
 	if (to_leader && !obj_is_ec(obj))
-		return obj_grp_leader_get(obj, grp_idx, map_ver, NIL_BITMAP);
+		return obj_grp_leader_get(obj, grp_idx, map_ver, false, NIL_BITMAP);
 
 	return obj_grp_valid_shard_get(obj, grp_idx, map_ver, failed_tgt_list);
 }
@@ -1201,6 +1209,8 @@ ec_deg_get:
 	shard_tgt->st_shard	= shard;
 	shard_tgt->st_shard_id	= obj_shard->do_id.id_shard;
 	shard_tgt->st_tgt_idx	= obj_shard->do_target_idx;
+	if (obj_auxi->cond_modify && (obj_shard->do_rebuilding || obj_shard->do_reintegrating))
+		shard_tgt->st_flags |= DTF_DELAY_FORWARD;
 	rc = obj_shard2tgtid(obj, shard, map_ver, &shard_tgt->st_tgt_id);
 	obj_shard_close(obj_shard);
 out:
@@ -1406,7 +1416,8 @@ obj_shards_2_fwtgts(struct dc_object *obj, uint32_t map_ver, uint8_t *bit_map,
 		shard_idx = start_shard + i * grp_size;
 		head = tgt = req_tgts->ort_shard_tgts + i * grp_size;
 		if (req_tgts->ort_srv_disp) {
-			rc = obj_grp_leader_get(obj, shard_idx / grp_size, map_ver, bit_map);
+			rc = obj_grp_leader_get(obj, shard_idx / grp_size, map_ver,
+						obj_auxi->cond_modify, bit_map);
 			if (rc < 0) {
 				D_ERROR(DF_OID" no valid shard %u, grp size %u "
 					"grp nr %u, shards %u, reps %u, is %s: "
@@ -1471,7 +1482,7 @@ obj_shards_2_fwtgts(struct dc_object *obj, uint32_t map_ver, uint8_t *bit_map,
 						DP_OID(obj->cob_md.omd_id),
 						tmp->st_shard, last->st_shard,
 						tmp->st_rank, tmp->st_tgt_id);
-					return -DER_SHARDS_OVERLAP;
+					return -DER_NEED_TX;
 				}
 			}
 		}
@@ -2855,7 +2866,7 @@ obj_req_get_tgts(struct dc_object *obj, int *shard, daos_key_t *dkey,
 	rc = obj_shards_2_fwtgts(obj, map_ver, bit_map, shard_idx,
 				 shard_cnt, grp_nr, flags, obj_auxi);
 	if (rc != 0) {
-		if (rc != -DER_SHARDS_OVERLAP && rc != -DER_TGT_RETRY)
+		if (rc != -DER_NEED_TX && rc != -DER_TGT_RETRY)
 			D_ERROR("opc %d "DF_OID", obj_shards_2_fwtgts failed "
 				DF_RC"\n", opc, DP_OID(obj->cob_md.omd_id),
 				DP_RC(rc));
@@ -2866,18 +2877,6 @@ obj_req_get_tgts(struct dc_object *obj, int *shard, daos_key_t *dkey,
 	}
 out:
 	return rc;
-}
-
-static int
-shard_task_abort(tse_task_t *task, void *arg)
-{
-	int	rc = *((int *)arg);
-
-	tse_task_list_del(task);
-	tse_task_decref(task);
-	tse_task_complete(task, rc);
-
-	return 0;
 }
 
 static void
@@ -4599,7 +4598,7 @@ obj_comp_cb(tse_task_t *task, void *data)
 		     task->dt_result == -DER_CSUM)))
 			obj_auxi->io_retry = 0;
 
-		if (task->dt_result == -DER_SHARDS_OVERLAP)
+		if (task->dt_result == -DER_NEED_TX)
 			obj_auxi->tx_convert = 1;
 
 		if (task->dt_result == -DER_CSUM ||
@@ -5299,8 +5298,15 @@ dc_obj_fetch_task(tse_task_t *task)
 			tgt_bitmap = obj_auxi->reasb_req.tgt_bitmap;
 	}
 
-	if (args->extra_flags & DIOF_CHECK_EXISTENCE)
+	if (args->extra_flags & DIOF_CHECK_EXISTENCE) {
+		/*
+		 * XXX: Be as tempoary solution, fetch from leader fisrtly, that always workable
+		 *	for replicated object and will be changed when support conditional fetch
+		 *	EC object. DAOS-10204.
+		 */
+		obj_auxi->to_leader = 1;
 		tgt_bitmap = NIL_BITMAP;
+	}
 
 	rc = obj_req_get_tgts(obj, (int *)&shard, args->dkey, dkey_hash,
 			      tgt_bitmap, map_ver, obj_auxi->to_leader,
@@ -5378,7 +5384,7 @@ dc_obj_update(tse_task_t *task, struct dtx_epoch *epoch, uint32_t map_ver,
 		D_GOTO(out_task, rc);
 
 	if (daos_fail_check(DAOS_FAIL_TX_CONVERT))
-		D_GOTO(out_task, rc = -DER_SHARDS_OVERLAP);
+		D_GOTO(out_task, rc = -DER_NEED_TX);
 
 	/* For update, based on re-assembled sgl for csum calculate (to match with iod).
 	 * Then if with single data target use original user sgl in IO request to avoid
@@ -5396,6 +5402,9 @@ dc_obj_update(tse_task_t *task, struct dtx_epoch *epoch, uint32_t map_ver,
 
 	if (DAOS_FAIL_CHECK(DAOS_DTX_COMMIT_SYNC))
 		obj_auxi->flags |= ORF_DTX_SYNC;
+
+	if (args->flags & DAOS_COND_MASK)
+		obj_auxi->cond_modify = 1;
 
 	D_DEBUG(DB_IO, "update "DF_OID" dkey_hash "DF_U64"\n",
 		DP_OID(obj->cob_md.omd_id), dkey_hash);
@@ -5863,8 +5872,7 @@ obj_list_get_shard(struct obj_auxi_args *obj_auxi, unsigned int map_ver,
 		shard = obj_ec_list_get_shard(obj_auxi, map_ver, grp_idx, args);
 	} else {
 		if (obj_auxi->to_leader) {
-			shard = obj_grp_leader_get(obj, grp_idx,
-						   map_ver, NIL_BITMAP);
+			shard = obj_grp_leader_get(obj, grp_idx, map_ver, false, NIL_BITMAP);
 		} else {
 			shard = obj_grp_valid_shard_get(obj, grp_idx, map_ver,
 							obj_auxi->failed_tgt_list);
@@ -6100,7 +6108,10 @@ dc_obj_punch(tse_task_t *task, struct dc_object *obj, struct dtx_epoch *epoch,
 		D_GOTO(out_task, rc);
 
 	if (daos_fail_check(DAOS_FAIL_TX_CONVERT))
-		D_GOTO(out_task, rc = -DER_SHARDS_OVERLAP);
+		D_GOTO(out_task, rc = -DER_NEED_TX);
+
+	if (api_args->flags & DAOS_COND_MASK)
+		obj_auxi->cond_modify = 1;
 
 	if (DAOS_FAIL_CHECK(DAOS_DTX_COMMIT_SYNC))
 		obj_auxi->flags |= ORF_DTX_SYNC;
@@ -6396,7 +6407,7 @@ dc_obj_query_key(tse_task_t *api_task)
 		if (!obj_is_ec(obj) || likely(!DAOS_FAIL_CHECK(DAOS_OBJ_SKIP_PARITY))) {
 			int leader;
 
-			leader = obj_grp_leader_get(obj, i, map_ver, NIL_BITMAP);
+			leader = obj_grp_leader_get(obj, i, map_ver, false, NIL_BITMAP);
 			if (leader >= 0) {
 				if (obj_is_ec(obj) && !is_ec_parity_shard(leader, obj_get_oca(obj)))
 					goto non_leader;

--- a/src/object/obj_rpc.c
+++ b/src/object/obj_rpc.c
@@ -541,9 +541,7 @@ static int
 crt_proc_struct_daos_shard_tgt(crt_proc_t proc, crt_proc_op_t proc_op,
 			       struct daos_shard_tgt *p)
 {
-	/* st_ec_tgt need not pack */
-	return crt_proc_memcpy(proc, proc_op,
-			       p, sizeof(*p) - sizeof(p->st_ec_tgt));
+	return crt_proc_memcpy(proc, proc_op, p, sizeof(*p));
 }
 
 /* For compounded RPC. */

--- a/src/object/obj_tx.c
+++ b/src/object/obj_tx.c
@@ -1624,7 +1624,7 @@ dc_tx_commit_prepare(struct dc_tx *tx, tse_task_t *task)
 		else
 			bit_map = NIL_BITMAP;
 
-		i = obj_grp_leader_get(obj, grp_idx, tx->tx_pm_ver, bit_map);
+		i = obj_grp_leader_get(obj, grp_idx, tx->tx_pm_ver, false, bit_map);
 		if (i < 0)
 			D_GOTO(out, rc = i);
 
@@ -2541,8 +2541,72 @@ struct dc_tx_check_existence_cb_args {
 	uint64_t		nr;
 	void			*iods_or_akeys;
 	d_sg_list_t		*sgls;
+	uint64_t		tmp_iod_nr;
 	daos_iod_t		*tmp_iods;
 };
+
+static int
+dc_tx_check_update(uint64_t flags, int result)
+{
+	if (flags & (DAOS_COND_AKEY_INSERT | DAOS_COND_DKEY_INSERT)) {
+		if (result == 0)
+			return -DER_EXIST;
+
+		if (result != -DER_NONEXIST)
+			return result;
+
+		return 0;
+	}
+
+	if (flags & (DAOS_COND_AKEY_UPDATE | DAOS_COND_DKEY_UPDATE) && result != 0)
+		return result;
+
+	return 0;
+}
+
+static int
+dc_tx_per_akey_existence_sub_cb(tse_task_t *task, void *data)
+{
+	struct dc_tx_check_existence_cb_args	*args = data;
+
+	D_ASSERT(args->opc == DAOS_OBJ_RPC_UPDATE);
+	D_ASSERT(args->flags & DAOS_COND_PER_AKEY);
+	D_ASSERT(args->tmp_iods != NULL);
+	D_ASSERT(args->tmp_iod_nr == 1);
+
+	task->dt_result = dc_tx_check_update(args->tmp_iods->iod_flags, task->dt_result);
+
+	daos_iov_free(&args->tmp_iods->iod_name);
+	D_FREE(args->tmp_iods);
+
+	return 0;
+}
+
+static int
+dc_tx_per_akey_existence_parent_cb(tse_task_t *task, void *data)
+{
+	struct dc_tx_check_existence_cb_args	*args = data;
+	struct dc_object			*obj = NULL;
+	struct dc_tx				*tx = args->tx;
+	int					 rc = task->dt_result;
+
+	D_ASSERT(args->opc == DAOS_OBJ_RPC_UPDATE);
+	D_ASSERT(args->flags & DAOS_COND_PER_AKEY);
+
+	if (rc == 0) {
+		obj = obj_hdl2ptr(args->oh);
+		D_MUTEX_LOCK(&tx->tx_lock);
+		rc = dc_tx_add_update(tx, &obj, args->flags, args->dkey, args->nr,
+				      args->iods_or_akeys, args->sgls);
+		D_MUTEX_UNLOCK(&tx->tx_lock);
+		obj_decref(obj);
+	}
+
+	/* Drop the reference that is held via dc_tx_attach(). */
+	dc_tx_decref(tx);
+
+	return rc;
+}
 
 static int
 dc_tx_check_existence_cb(tse_task_t *task, void *data)
@@ -2551,24 +2615,16 @@ dc_tx_check_existence_cb(tse_task_t *task, void *data)
 	struct dc_object			*obj = NULL;
 	struct dc_tx				*tx = args->tx;
 	int					 rc = 0;
+	int					 i;
 
 	obj = obj_hdl2ptr(args->oh);
 	D_MUTEX_LOCK(&tx->tx_lock);
 
 	switch (args->opc) {
 	case DAOS_OBJ_RPC_UPDATE:
-		if (args->flags & (DAOS_COND_DKEY_INSERT |
-				   DAOS_COND_AKEY_INSERT)) {
-			if (task->dt_result == 0)
-				D_GOTO(out, rc = -DER_EXIST);
-
-			if (task->dt_result != -DER_NONEXIST)
-				D_GOTO(out, rc = task->dt_result);
-		} else if (args->flags & (DAOS_COND_DKEY_UPDATE |
-					  DAOS_COND_AKEY_UPDATE)) {
-			if (task->dt_result != 0)
-				D_GOTO(out, rc = task->dt_result);
-		}
+		rc = dc_tx_check_update(args->flags, task->dt_result);
+		if (rc != 0)
+			D_GOTO(out, rc);
 
 		rc = dc_tx_add_update(tx, &obj, args->flags,
 				      args->dkey, args->nr,
@@ -2601,8 +2657,6 @@ out:
 	D_MUTEX_UNLOCK(&tx->tx_lock);
 
 	if (args->tmp_iods != NULL) {
-		int		i;
-
 		for (i = 0; i < args->nr; i++)
 			daos_iov_free(&args->tmp_iods[i].iod_name);
 
@@ -2619,6 +2673,117 @@ out:
 		obj_decref(obj);
 
 	return 0;
+}
+
+static int
+dc_tx_per_akey_existence_task(enum obj_rpc_opc opc, daos_handle_t oh, struct dc_tx *tx,
+			      uint64_t flags, daos_key_t *dkey, uint32_t nr, void *iods_or_akeys,
+			      d_sg_list_t *sgls, tse_task_t *parent)
+{
+	struct dc_tx_check_existence_cb_args	 cb_args = { 0 };
+	daos_iod_t				*in_iods = iods_or_akeys;
+	daos_iod_t				*iods = NULL;
+	tse_task_t				*task = NULL;
+	d_list_t				 task_list;
+	int					 rc;
+	int					 i;
+
+	D_INIT_LIST_HEAD(&task_list);
+
+	cb_args.opc		= opc;
+	cb_args.tx		= tx;
+	cb_args.oh		= oh;
+	cb_args.flags		= flags;
+	cb_args.dkey		= dkey;
+	cb_args.nr		= nr;
+	cb_args.iods_or_akeys	= iods_or_akeys;
+	cb_args.sgls		= sgls;
+
+	/* XXX: individual sub-task for checking each akey's existence independently. */
+
+	for (i = 0; i < nr; i++) {
+		if (!(in_iods[i].iod_flags & (DAOS_COND_AKEY_INSERT | DAOS_COND_AKEY_UPDATE)))
+			continue;
+
+		D_ALLOC_ARRAY(iods, 1);
+		if (iods == NULL)
+			D_GOTO(out, rc = -DER_NOMEM);
+
+		rc = daos_iov_copy(&iods->iod_name, &in_iods[i].iod_name);
+		if (rc != 0)
+			goto out;
+
+		iods->iod_flags = in_iods[i].iod_flags;
+		cb_args.tmp_iod_nr = 1;
+		cb_args.tmp_iods = iods;
+
+		rc = dc_obj_fetch_task_create(oh, dc_tx_ptr2hdl(tx), DAOS_COND_AKEY_FETCH, dkey, 1,
+					      DIOF_CHECK_EXISTENCE, iods, NULL, NULL, NULL, NULL,
+					      NULL, tse_task2sched(parent), &task);
+		if (rc != 0)
+			goto out;
+
+		rc = tse_task_register_comp_cb(task, dc_tx_per_akey_existence_sub_cb,
+					       &cb_args, sizeof(cb_args));
+		if (rc != 0)
+			goto out;
+
+		/* decref and delete from head at shard_task_remove */
+		tse_task_addref(task);
+		tse_task_list_add(task, &task_list);
+
+		iods = NULL;
+
+		rc = dc_task_depend(parent, 1, &task);
+		if (rc != 0)
+			goto out;
+	}
+
+out:
+	if (rc == 0) {
+		if (unlikely(d_list_empty(&task_list))) {
+			struct dc_object	*obj;
+
+			obj_hdl2ptr(oh);
+			D_MUTEX_LOCK(&tx->tx_lock);
+			rc = dc_tx_add_update(tx, &obj, flags, dkey, nr, iods_or_akeys, sgls);
+			D_MUTEX_UNLOCK(&tx->tx_lock);
+			obj_decref(obj);
+
+			/* Drop the reference that is held via dc_tx_attach(). */
+			dc_tx_decref(tx);
+		} else {
+			rc = tse_task_register_comp_cb(parent, dc_tx_per_akey_existence_parent_cb,
+						       &cb_args, sizeof(cb_args));
+			if (rc != 0)
+				goto fail;
+
+			tse_task_list_sched(&task_list, true);
+
+			/*
+			 * Return positive value to notify the sponsor to not call
+			 * complete() the task until the checking existence callback.
+			 */
+			rc = 1;
+		}
+	} else {
+		if (iods != NULL) {
+			if (task != NULL)
+				dc_task_decref(task);
+
+			daos_iov_free(&iods->iod_name);
+			D_FREE(iods);
+		}
+
+fail:
+		tse_task_list_traverse(&task_list, shard_task_abort, &rc);
+		parent->dt_result = rc;
+
+		/* Drop the reference that is held via dc_tx_attach(). */
+		dc_tx_decref(tx);
+	}
+
+	return rc;
 }
 
 static int
@@ -2644,12 +2809,13 @@ dc_tx_check_existence_task(enum obj_rpc_opc opc, daos_handle_t oh,
 	cb_args.sgls		= sgls;
 
 	/* XXX: Use conditional fetch (with empty sgls) to check the target
-	 *	existence on related server.
+	 *	existence on related target.
 	 */
 	if (nr != 0) {
 		D_ASSERT(iods_or_akeys != NULL);
 
 		if (opc != DAOS_OBJ_RPC_UPDATE) {
+			/* For punch akey. */
 			D_ALLOC_ARRAY(iods, nr);
 			if (iods == NULL)
 				D_GOTO(out, rc = -DER_NOMEM);
@@ -2662,39 +2828,41 @@ dc_tx_check_existence_task(enum obj_rpc_opc opc, daos_handle_t oh,
 			}
 
 			api_flags = DAOS_COND_AKEY_FETCH;
+			cb_args.tmp_iod_nr = nr;
 			cb_args.tmp_iods = iods;
-		} else if (flags & (DAOS_COND_AKEY_INSERT |
-				    DAOS_COND_AKEY_UPDATE)) {
-			iods = iods_or_akeys;
-			api_flags = DAOS_COND_AKEY_FETCH |
-				    (flags & DAOS_COND_PER_AKEY);
 		} else {
-			/* Only check dkey existence. */
-			api_flags = DAOS_COND_DKEY_FETCH;
-			nr = 0;
+			if (flags & (DAOS_COND_AKEY_INSERT | DAOS_COND_AKEY_UPDATE)) {
+				iods = iods_or_akeys;
+				api_flags = DAOS_COND_AKEY_FETCH;
+			} else {
+				/* Only check dkey existence. */
+				api_flags = DAOS_COND_DKEY_FETCH;
+				nr = 0;
+			}
 		}
 	} else {
+		/* For punch dkey */
 		api_flags = DAOS_COND_DKEY_FETCH;
 	}
 
 	rc = dc_obj_fetch_task_create(oh, dc_tx_ptr2hdl(tx), api_flags, dkey,
-				      nr, DIOF_CHECK_EXISTENCE | DIOF_TO_LEADER,
+				      nr, DIOF_CHECK_EXISTENCE,
 				      iods, NULL, NULL, NULL, NULL, NULL,
 				      tse_task2sched(parent), &task);
 	if (rc != 0)
 		goto out;
 
-	rc = dc_task_depend(parent, 1, &task);
-	if (rc != 0) {
-		D_ERROR("Fail to add dep on check existence task: "DF_RC"\n",
-			DP_RC(rc));
-		goto out;
-	}
-
 	rc = tse_task_register_comp_cb(task, dc_tx_check_existence_cb,
 				       &cb_args, sizeof(cb_args));
 	if (rc != 0) {
 		D_ERROR("Fail to add CB for check existence task: "DF_RC"\n",
+			DP_RC(rc));
+		goto out;
+	}
+
+	rc = dc_task_depend(parent, 1, &task);
+	if (rc != 0) {
+		D_ERROR("Fail to add dep on check existence task: "DF_RC"\n",
 			DP_RC(rc));
 		goto out;
 	}
@@ -2750,6 +2918,19 @@ dc_tx_attach(daos_handle_t th, struct dc_object *obj, enum obj_rpc_opc opc,
 			return dc_tx_check_existence_task(opc, up->oh, tx,
 						up->flags, up->dkey, up->nr,
 						up->iods, up->sgls, task);
+		}
+
+		if (up->flags & DAOS_COND_PER_AKEY) {
+			D_MUTEX_UNLOCK(&tx->tx_lock);
+
+			if (up->nr == 0 || up->iods == NULL)
+				D_GOTO(out, rc = -DER_INVAL);
+
+			if (obj != NULL)
+				obj_decref(obj);
+
+			return dc_tx_per_akey_existence_task(opc, up->oh, tx, up->flags, up->dkey,
+							     up->nr, up->iods, up->sgls, task);
 		}
 
 		rc = dc_tx_add_update(tx, &obj, up->flags, up->dkey,
@@ -2963,60 +3144,22 @@ int
 dc_tx_convert(struct dc_object *obj, enum obj_rpc_opc opc, tse_task_t *task)
 {
 	struct tx_convert_cb_args	 conv = { 0 };
-	daos_handle_t			 coh;
 	daos_tx_commit_t		*args;
-	daos_obj_update_t		*up = NULL;
-	daos_obj_punch_t		*pu = NULL;
 	tse_task_t			*tx_task = NULL;
 	struct dc_tx			*tx = NULL;
 	int				 rc = 0;
 
 	D_ASSERT(obj != NULL);
 
-	switch (opc) {
-	case DAOS_OBJ_RPC_UPDATE:
-		up = dc_task_get_args(task);
-		coh = dc_obj_hdl2cont_hdl(up->oh);
-		break;
-	case DAOS_OBJ_RPC_PUNCH:
-	case DAOS_OBJ_RPC_PUNCH_DKEYS:
-	case DAOS_OBJ_RPC_PUNCH_AKEYS:
-		pu = dc_task_get_args(task);
-		coh = dc_obj_hdl2cont_hdl(pu->oh);
-		break;
-	default:
-		D_ERROR("Unsupportted TX convert opc %d\n", opc);
-		D_GOTO(out, rc = -DER_INVAL);
-	}
-
-	rc = dc_tx_alloc(coh, 0, DAOS_TF_ZERO_COPY, &tx);
+	rc = dc_tx_alloc(obj->cob_coh, 0, DAOS_TF_ZERO_COPY, &tx);
 	if (rc != 0) {
 		D_ERROR("Fail to open TX for opc %u: "DF_RC"\n",
 			opc, DP_RC(rc));
 		goto out;
 	}
 
-	tx->tx_pm_ver = dc_pool_get_version(tx->tx_pool);
-
-	switch (opc) {
-	case DAOS_OBJ_RPC_UPDATE:
-		rc = dc_tx_add_update(tx, &obj, up->flags, up->dkey,
-				      up->nr, up->iods, up->sgls);
-		break;
-	case DAOS_OBJ_RPC_PUNCH:
-		rc = dc_tx_add_punch_obj(tx, &obj, pu->flags);
-		break;
-	case DAOS_OBJ_RPC_PUNCH_DKEYS:
-		rc = dc_tx_add_punch_dkey(tx, &obj, pu->flags, pu->dkey);
-		break;
-	case DAOS_OBJ_RPC_PUNCH_AKEYS:
-		rc = dc_tx_add_punch_akeys(tx, &obj, pu->flags, pu->dkey,
-					   pu->akey_nr, pu->akeys);
-		break;
-	default:
-		D_ASSERT(0);
-	}
-
+	rc = dc_tx_attach(dc_tx_ptr2hdl(tx), obj, opc, task);
+	obj = NULL;
 	if (rc != 0) {
 		D_ERROR("Fail to attach TX for opc %u: "DF_RC"\n",
 			opc, DP_RC(rc));

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -3282,6 +3282,7 @@ static int
 obj_punch_agg_cb(struct dtx_leader_handle *dlh, void *agg_arg)
 {
 	uint64_t	*flag = agg_arg;
+	uint32_t	sub_cnt = dlh->dlh_normal_sub_cnt + dlh->dlh_delay_sub_cnt;
 	int		succeeds = 0;
 	int		allow_failure = 0;
 	int		allow_failure_cnt = 0;
@@ -3292,7 +3293,7 @@ obj_punch_agg_cb(struct dtx_leader_handle *dlh, void *agg_arg)
 	if (*flag & DAOS_COND_PUNCH)
 		allow_failure = -DER_NONEXIST;
 
-	for (i = 0; i < dlh->dlh_sub_cnt; i++) {
+	for (i = 0; i < sub_cnt; i++) {
 		struct dtx_sub_status	*sub = &dlh->dlh_subs[i];
 
 		if (sub->dss_result == 0) {
@@ -3316,7 +3317,7 @@ obj_punch_agg_cb(struct dtx_leader_handle *dlh, void *agg_arg)
 		 * due to EC partial update.
 		 */
 		if (result == 0 && succeeds == 0) {
-			D_ASSERT(dlh->dlh_sub_cnt == allow_failure_cnt);
+			D_ASSERT(sub_cnt == allow_failure_cnt);
 			return -DER_NONEXIST;
 		}
 
@@ -4342,7 +4343,7 @@ obj_obj_dtx_leader(struct dtx_leader_handle *dlh, void *arg, int idx,
 			dcsh = ds_obj_cpd_get_dcsh(dca->dca_rpc, dca->dca_idx);
 			dcsrs = ds_obj_cpd_get_dcsr(dca->dca_rpc, dca->dca_idx);
 
-			if (dlh->dlh_sub_cnt > 0 ||
+			if (dlh->dlh_normal_sub_cnt > 0 || dlh->dlh_delay_sub_cnt > 0 ||
 			    dlh->dlh_handle.dth_modification_cnt > 0)
 				pin = true;
 			else

--- a/src/object/srv_obj_remote.c
+++ b/src/object/srv_obj_remote.c
@@ -88,7 +88,7 @@ ds_obj_remote_update(struct dtx_leader_handle *dlh, void *data, int idx,
 	uint32_t			 tgt_idx;
 	int				 rc = 0;
 
-	D_ASSERT(idx < dlh->dlh_sub_cnt);
+	D_ASSERT(idx < dlh->dlh_normal_sub_cnt + dlh->dlh_delay_sub_cnt);
 	sub = &dlh->dlh_subs[idx];
 	shard_tgt = &sub->dss_tgt;
 	if (DAOS_FAIL_CHECK(DAOS_OBJ_TGT_IDX_CHANGE)) {
@@ -127,7 +127,7 @@ ds_obj_remote_update(struct dtx_leader_handle *dlh, void *data, int idx,
 	if (split_req != NULL) {
 		tgt_idx = shard_tgt->st_shard;
 		tgt_oiod = obj_ec_tgt_oiod_get(split_req->osr_tgt_oiods,
-					       dlh->dlh_sub_cnt + 1,
+					       dlh->dlh_normal_sub_cnt + dlh->dlh_delay_sub_cnt + 1,
 					       tgt_idx - obj_exec_arg->start);
 		D_ASSERT(tgt_oiod != NULL);
 		orw->orw_iod_array.oia_oiods = tgt_oiod->oto_oiods;
@@ -214,7 +214,7 @@ ds_obj_remote_punch(struct dtx_leader_handle *dlh, void *data, int idx,
 	crt_opcode_t			opc;
 	int				rc = 0;
 
-	D_ASSERT(idx < dlh->dlh_sub_cnt);
+	D_ASSERT(idx < dlh->dlh_normal_sub_cnt + dlh->dlh_delay_sub_cnt);
 	sub = &dlh->dlh_subs[idx];
 	shard_tgt = &sub->dss_tgt;
 	D_ALLOC_PTR(remote_arg);
@@ -412,7 +412,7 @@ ds_obj_cpd_dispatch(struct dtx_leader_handle *dlh, void *arg, int idx,
 	int				 count;
 	int				 rc = 0;
 
-	D_ASSERT(idx < dlh->dlh_sub_cnt);
+	D_ASSERT(idx < dlh->dlh_normal_sub_cnt + dlh->dlh_delay_sub_cnt);
 
 	sub = &dlh->dlh_subs[idx];
 	shard_tgt = &sub->dss_tgt;

--- a/src/tests/suite/daos_degrade_ec.c
+++ b/src/tests/suite/daos_degrade_ec.c
@@ -582,7 +582,7 @@ degrade_ec_update(void **state)
 	if (!test_runable(arg, 6) || (arg->srv_ntgts / arg->srv_nnodes) < 2)
 		return;
 
-	print_message("test 1 - DER_SHARDS_OVERLAP case\n");
+	print_message("test 1 - DER_NEED_TX case\n");
 	data = (char *)malloc(TEST_EC_STRIPE_SIZE);
 	assert_true(data != NULL);
 	oid = daos_test_oid_gen(arg->coh, OC_EC_4P2G2, DAOS_OF_DKEY_UINT64, 0, arg->myrank);

--- a/src/vos/vos_io.c
+++ b/src/vos/vos_io.c
@@ -1208,7 +1208,9 @@ akey_fetch(struct vos_io_context *ioc, daos_handle_t ak_toh)
 
 	rc = key_tree_prepare(ioc->ic_obj, ak_toh,
 			      VOS_BTR_AKEY, &iod->iod_name, flags,
-			      DAOS_INTENT_DEFAULT, &krec, &toh, ioc->ic_ts_set);
+			      DAOS_INTENT_DEFAULT, &krec,
+			      (ioc->ic_check_existence || ioc->ic_read_ts_only) ? NULL : &toh,
+			      ioc->ic_ts_set);
 
 	if (stop_check(ioc, VOS_OF_COND_AKEY_FETCH, iod, &rc, true)) {
 		if (rc == 0 && !ioc->ic_read_ts_only)


### PR DESCRIPTION
    master-commit: 723ae128931048e6ba9321cdcc7e69e5923a5379
    master-commit: e73e148708437eaea47335c5d22b2a244cc3bf67
    
    During object rebuild, if the client triggers conditional operation
    on the object that is in rebuilding, then condition check cannot be
    properly handled on the in-rebuilding target as to cause unexpected
    result when double failures happened.
    
    To resolve such trouble, we will delay IO forwarding of conditional
    sub requests to the in-rebuilding targets until the healthy targets
    have processed related condition check.
    
    From client perspective, related RPC will become slow, but consider
    that the case (conditionally modify the in-rebuilding object shard)
    is rare, then the total overhead is not too much.
    
    For conditional modification against EC object, if all parity nodes
    are lost, then it will be handled via distributed transaction.
    
    This patch also contains some fixes:
    
    1) In dc_tx_convert logic for update/punch with condition and needs
       to be handled via distributed transaction. In old implementation
       the condition check was discarded by wrong during the convert.
    
    2) When check existence in VOS, do not prepare sub tree under akey.
    
    If a distributed transaction contains per akey based modification,
    then we need to check every related akey's existence via each own
    sub-task independently. Each one is a conditional akey fetch task.
    
    Signed-off-by: Fan Yong <fan.yong@intel.com>