### PR TITLE
DAOS-10416 ddb: Processing and Clearing ilog and dtx

### DIFF
--- a/src/ddb/ddb_cmd_options.c
+++ b/src/ddb/ddb_cmd_options.c
@@ -10,14 +10,18 @@
 #include "ddb_cmd_options.h"
 #include "ddb_common.h"
 #define same(a, b) (strcmp((a), (b)) == 0)
+#define COMMAND_NAME_HELP "help"
 #define COMMAND_NAME_QUIT "quit"
 #define COMMAND_NAME_LS "ls"
 #define COMMAND_NAME_DUMP_SUPERBLOCK "dump_superblock"
-#define COMMAND_NAME_DUMP_ILOG "dump_ilog"
-#define COMMAND_NAME_DUMP_DTX "dump_dtx"
 #define COMMAND_NAME_DUMP_VALUE "dump_value"
 #define COMMAND_NAME_RM "rm"
 #define COMMAND_NAME_LOAD "load"
+#define COMMAND_NAME_DUMP_ILOG "dump_ilog"
+#define COMMAND_NAME_PROCESS_ILOG "process_ilog"
+#define COMMAND_NAME_RM_ILOG "rm_ilog"
+#define COMMAND_NAME_DUMP_DTX "dump_dtx"
+#define COMMAND_NAME_CLEAR_DTX "clear_dtx"
 
 /* Parse command line options for the 'ls' command */
 static int
@@ -67,19 +71,296 @@ ls_option_parse(struct ddb_ctx *ctx, struct ls_options *cmd_args, struct argv_pa
 	return 0;
 }
 
+/* Parse command line options for the 'dump_value' command */
+static int
+dump_value_option_parse(struct ddb_ctx *ctx, struct dump_value_options *cmd_args,
+			struct argv_parsed *argc_v)
+{
+	char		 *options_short = "";
+	int		  index = 0, opt;
+	uint32_t	  argc = argc_v->ap_argc;
+	char		**argv = argc_v->ap_argv;
+	struct option	  options_long[] = {
+		{ NULL }
+	};
+
+	memset(cmd_args, 0, sizeof(*cmd_args));
+
+	/* Restart getopt */
+	optind = 1;
+	opterr = 0;
+	while ((opt = getopt_long(argc, argv, options_short, options_long, &index)) != -1) {
+		switch (opt) {
+		case '?':
+			ddb_printf(ctx, "Unknown option: '%c'\n", optopt);
+		default:
+			return -DER_INVAL;
+		}
+	}
+
+	index = optind;
+
+	D_ASSERT(argc > index);
+	D_ASSERT(same(argv[index], COMMAND_NAME_DUMP_VALUE));
+	index++;
+	if (argc - index > 0) {
+		cmd_args->path = argv[index];
+		index++;
+	} else {
+		ddb_print(ctx, "Expected argument 'path'");
+		return -DER_INVAL;
+	}
+	if (argc - index > 0) {
+		cmd_args->dst = argv[index];
+		index++;
+	} else {
+		ddb_print(ctx, "Expected argument 'dst'");
+		return -DER_INVAL;
+	}
+
+	if (argc - index > 0) {
+		ddb_printf(ctx, "Unexpected argument: %s\\n", argv[index]);
+		return -DER_INVAL;
+	}
+
+	return 0;
+}
+
+/* Parse command line options for the 'rm' command */
+static int
+rm_option_parse(struct ddb_ctx *ctx, struct rm_options *cmd_args, struct argv_parsed *argc_v)
+{
+	char		 *options_short = "";
+	int		  index = 0, opt;
+	uint32_t	  argc = argc_v->ap_argc;
+	char		**argv = argc_v->ap_argv;
+	struct option	  options_long[] = {
+		{ NULL }
+	};
+
+	memset(cmd_args, 0, sizeof(*cmd_args));
+
+	/* Restart getopt */
+	optind = 1;
+	opterr = 0;
+	while ((opt = getopt_long(argc, argv, options_short, options_long, &index)) != -1) {
+		switch (opt) {
+		case '?':
+			ddb_printf(ctx, "Unknown option: '%c'\n", optopt);
+		default:
+			return -DER_INVAL;
+		}
+	}
+
+	index = optind;
+
+	D_ASSERT(argc > index);
+	D_ASSERT(same(argv[index], COMMAND_NAME_RM));
+	index++;
+	if (argc - index > 0) {
+		cmd_args->path = argv[index];
+		index++;
+	} else {
+		ddb_print(ctx, "Expected argument 'path'");
+		return -DER_INVAL;
+	}
+
+	if (argc - index > 0) {
+		ddb_printf(ctx, "Unexpected argument: %s\\n", argv[index]);
+		return -DER_INVAL;
+	}
+
+	return 0;
+}
+
+/* Parse command line options for the 'load' command */
+static int
+load_option_parse(struct ddb_ctx *ctx, struct load_options *cmd_args, struct argv_parsed *argc_v)
+{
+	char		 *options_short = "";
+	int		  index = 0, opt;
+	uint32_t	  argc = argc_v->ap_argc;
+	char		**argv = argc_v->ap_argv;
+	struct option	  options_long[] = {
+		{ NULL }
+	};
+
+	memset(cmd_args, 0, sizeof(*cmd_args));
+
+	/* Restart getopt */
+	optind = 1;
+	opterr = 0;
+	while ((opt = getopt_long(argc, argv, options_short, options_long, &index)) != -1) {
+		switch (opt) {
+		case '?':
+			ddb_printf(ctx, "Unknown option: '%c'\n", optopt);
+		default:
+			return -DER_INVAL;
+		}
+	}
+
+	index = optind;
+
+	D_ASSERT(argc > index);
+	D_ASSERT(same(argv[index], COMMAND_NAME_LOAD));
+	index++;
+	if (argc - index > 0) {
+		cmd_args->src = argv[index];
+		index++;
+	} else {
+		ddb_print(ctx, "Expected argument 'src'");
+		return -DER_INVAL;
+	}
+	if (argc - index > 0) {
+		cmd_args->dst = argv[index];
+		index++;
+	} else {
+		ddb_print(ctx, "Expected argument 'dst'");
+		return -DER_INVAL;
+	}
+	if (argc - index > 0) {
+		cmd_args->epoch = argv[index];
+		index++;
+	} else {
+		ddb_print(ctx, "Expected argument 'epoch'");
+		return -DER_INVAL;
+	}
+
+	if (argc - index > 0) {
+		ddb_printf(ctx, "Unexpected argument: %s\\n", argv[index]);
+		return -DER_INVAL;
+	}
+
+	return 0;
+}
+
 /* Parse command line options for the 'dump_ilog' command */
 static int
 dump_ilog_option_parse(struct ddb_ctx *ctx, struct dump_ilog_options *cmd_args,
 		       struct argv_parsed *argc_v)
 {
-	int		  index = 1;
+	char		 *options_short = "";
+	int		  index = 0, opt;
 	uint32_t	  argc = argc_v->ap_argc;
 	char		**argv = argc_v->ap_argv;
+	struct option	  options_long[] = {
+		{ NULL }
+	};
 
 	memset(cmd_args, 0, sizeof(*cmd_args));
 
+	/* Restart getopt */
+	optind = 1;
+	opterr = 0;
+	while ((opt = getopt_long(argc, argv, options_short, options_long, &index)) != -1) {
+		switch (opt) {
+		case '?':
+			ddb_printf(ctx, "Unknown option: '%c'\n", optopt);
+		default:
+			return -DER_INVAL;
+		}
+	}
+
+	index = optind;
+
 	D_ASSERT(argc > index);
 	D_ASSERT(same(argv[index], COMMAND_NAME_DUMP_ILOG));
+	index++;
+	if (argc - index > 0) {
+		cmd_args->path = argv[index];
+		index++;
+	} else {
+		ddb_print(ctx, "Expected argument 'path'");
+		return -DER_INVAL;
+	}
+
+	if (argc - index > 0) {
+		ddb_printf(ctx, "Unexpected argument: %s\\n", argv[index]);
+		return -DER_INVAL;
+	}
+
+	return 0;
+}
+
+/* Parse command line options for the 'process_ilog' command */
+static int
+process_ilog_option_parse(struct ddb_ctx *ctx, struct process_ilog_options *cmd_args,
+			  struct argv_parsed *argc_v)
+{
+	char		 *options_short = "";
+	int		  index = 0, opt;
+	uint32_t	  argc = argc_v->ap_argc;
+	char		**argv = argc_v->ap_argv;
+	struct option	  options_long[] = {
+		{ NULL }
+	};
+
+	memset(cmd_args, 0, sizeof(*cmd_args));
+
+	/* Restart getopt */
+	optind = 1;
+	opterr = 0;
+	while ((opt = getopt_long(argc, argv, options_short, options_long, &index)) != -1) {
+		switch (opt) {
+		case '?':
+			ddb_printf(ctx, "Unknown option: '%c'\n", optopt);
+		default:
+			return -DER_INVAL;
+		}
+	}
+
+	index = optind;
+
+	D_ASSERT(argc > index);
+	D_ASSERT(same(argv[index], COMMAND_NAME_PROCESS_ILOG));
+	index++;
+	if (argc - index > 0) {
+		cmd_args->path = argv[index];
+		index++;
+	} else {
+		ddb_print(ctx, "Expected argument 'path'");
+		return -DER_INVAL;
+	}
+
+	if (argc - index > 0) {
+		ddb_printf(ctx, "Unexpected argument: %s\\n", argv[index]);
+		return -DER_INVAL;
+	}
+
+	return 0;
+}
+
+/* Parse command line options for the 'rm_ilog' command */
+static int
+rm_ilog_option_parse(struct ddb_ctx *ctx, struct rm_ilog_options *cmd_args,
+		     struct argv_parsed *argc_v)
+{
+	char		 *options_short = "";
+	int		  index = 0, opt;
+	uint32_t	  argc = argc_v->ap_argc;
+	char		**argv = argc_v->ap_argv;
+	struct option	  options_long[] = {
+		{ NULL }
+	};
+
+	memset(cmd_args, 0, sizeof(*cmd_args));
+
+	/* Restart getopt */
+	optind = 1;
+	opterr = 0;
+	while ((opt = getopt_long(argc, argv, options_short, options_long, &index)) != -1) {
+		switch (opt) {
+		case '?':
+			ddb_printf(ctx, "Unknown option: '%c'\n", optopt);
+		default:
+			return -DER_INVAL;
+		}
+	}
+
+	index = optind;
+
+	D_ASSERT(argc > index);
+	D_ASSERT(same(argv[index], COMMAND_NAME_RM_ILOG));
 	index++;
 	if (argc - index > 0) {
 		cmd_args->path = argv[index];
@@ -153,104 +434,43 @@ dump_dtx_option_parse(struct ddb_ctx *ctx, struct dump_dtx_options *cmd_args,
 	return 0;
 }
 
-/* Parse command line options for the 'dump_value' command */
+/* Parse command line options for the 'clear_dtx' command */
 static int
-dump_value_option_parse(struct ddb_ctx *ctx, struct dump_value_options *cmd_args,
-			struct argv_parsed *argc_v)
+clear_dtx_option_parse(struct ddb_ctx *ctx, struct clear_dtx_options *cmd_args,
+		       struct argv_parsed *argc_v)
 {
-	int		  index = 1;
+	char		 *options_short = "";
+	int		  index = 0, opt;
 	uint32_t	  argc = argc_v->ap_argc;
 	char		**argv = argc_v->ap_argv;
+	struct option	  options_long[] = {
+		{ NULL }
+	};
 
 	memset(cmd_args, 0, sizeof(*cmd_args));
 
+	/* Restart getopt */
+	optind = 1;
+	opterr = 0;
+	while ((opt = getopt_long(argc, argv, options_short, options_long, &index)) != -1) {
+		switch (opt) {
+		case '?':
+			ddb_printf(ctx, "Unknown option: '%c'\n", optopt);
+		default:
+			return -DER_INVAL;
+		}
+	}
+
+	index = optind;
+
 	D_ASSERT(argc > index);
-	D_ASSERT(same(argv[index], COMMAND_NAME_DUMP_VALUE));
+	D_ASSERT(same(argv[index], COMMAND_NAME_CLEAR_DTX));
 	index++;
 	if (argc - index > 0) {
 		cmd_args->path = argv[index];
 		index++;
 	} else {
 		ddb_print(ctx, "Expected argument 'path'");
-		return -DER_INVAL;
-	}
-	if (argc - index > 0) {
-		cmd_args->dst = argv[index];
-		index++;
-	} else {
-		ddb_print(ctx, "Expected argument 'dst'");
-		return -DER_INVAL;
-	}
-
-	if (argc - index > 0) {
-		ddb_printf(ctx, "Unexpected argument: %s\\n", argv[index]);
-		return -DER_INVAL;
-	}
-
-	return 0;
-}
-
-/* Parse command line options for the 'rm' command */
-static int
-rm_option_parse(struct ddb_ctx *ctx, struct rm_options *cmd_args, struct argv_parsed *argc_v)
-{
-	int		  index = 1;
-	uint32_t	  argc = argc_v->ap_argc;
-	char		**argv = argc_v->ap_argv;
-
-	memset(cmd_args, 0, sizeof(*cmd_args));
-
-	D_ASSERT(argc > index);
-	D_ASSERT(same(argv[index], COMMAND_NAME_RM));
-	index++;
-	if (argc - index > 0) {
-		cmd_args->path = argv[index];
-		index++;
-	} else {
-		ddb_print(ctx, "Expected argument 'path'");
-		return -DER_INVAL;
-	}
-
-	if (argc - index > 0) {
-		ddb_printf(ctx, "Unexpected argument: %s\\n", argv[index]);
-		return -DER_INVAL;
-	}
-
-	return 0;
-}
-
-/* Parse command line options for the 'load' command */
-static int
-load_option_parse(struct ddb_ctx *ctx, struct load_options *cmd_args, struct argv_parsed *argc_v)
-{
-	int		  index = 1;
-	uint32_t	  argc = argc_v->ap_argc;
-	char		**argv = argc_v->ap_argv;
-
-	memset(cmd_args, 0, sizeof(*cmd_args));
-
-	D_ASSERT(argc > index);
-	D_ASSERT(same(argv[index], COMMAND_NAME_LOAD));
-	index++;
-	if (argc - index > 0) {
-		cmd_args->src = argv[index];
-		index++;
-	} else {
-		ddb_print(ctx, "Expected argument 'src'");
-		return -DER_INVAL;
-	}
-	if (argc - index > 0) {
-		cmd_args->dst = argv[index];
-		index++;
-	} else {
-		ddb_print(ctx, "Expected argument 'dst'");
-		return -DER_INVAL;
-	}
-	if (argc - index > 0) {
-		cmd_args->epoch = argv[index];
-		index++;
-	} else {
-		ddb_print(ctx, "Expected argument 'epoch'");
 		return -DER_INVAL;
 	}
 
@@ -267,6 +487,10 @@ ddb_parse_cmd_args(struct ddb_ctx *ctx, struct argv_parsed *parsed, struct ddb_c
 {
 	char *cmd = parsed->ap_argv[1];
 
+	if (same(cmd, COMMAND_NAME_HELP)) {
+		info->dci_cmd = DDB_CMD_HELP;
+		return 0;
+	}
 	if (same(cmd, COMMAND_NAME_QUIT)) {
 		info->dci_cmd = DDB_CMD_QUIT;
 		return 0;
@@ -278,14 +502,6 @@ ddb_parse_cmd_args(struct ddb_ctx *ctx, struct argv_parsed *parsed, struct ddb_c
 	if (same(cmd, COMMAND_NAME_DUMP_SUPERBLOCK)) {
 		info->dci_cmd = DDB_CMD_DUMP_SUPERBLOCK;
 		return 0;
-	}
-	if (same(cmd, COMMAND_NAME_DUMP_ILOG)) {
-		info->dci_cmd = DDB_CMD_DUMP_ILOG;
-		return dump_ilog_option_parse(ctx, &info->dci_cmd_option.dci_dump_ilog, parsed);
-	}
-	if (same(cmd, COMMAND_NAME_DUMP_DTX)) {
-		info->dci_cmd = DDB_CMD_DUMP_DTX;
-		return dump_dtx_option_parse(ctx, &info->dci_cmd_option.dci_dump_dtx, parsed);
 	}
 	if (same(cmd, COMMAND_NAME_DUMP_VALUE)) {
 		info->dci_cmd = DDB_CMD_DUMP_VALUE;
@@ -299,6 +515,57 @@ ddb_parse_cmd_args(struct ddb_ctx *ctx, struct argv_parsed *parsed, struct ddb_c
 		info->dci_cmd = DDB_CMD_LOAD;
 		return load_option_parse(ctx, &info->dci_cmd_option.dci_load, parsed);
 	}
+	if (same(cmd, COMMAND_NAME_DUMP_ILOG)) {
+		info->dci_cmd = DDB_CMD_DUMP_ILOG;
+		return dump_ilog_option_parse(ctx, &info->dci_cmd_option.dci_dump_ilog, parsed);
+	}
+	if (same(cmd, COMMAND_NAME_PROCESS_ILOG)) {
+		info->dci_cmd = DDB_CMD_PROCESS_ILOG;
+		return process_ilog_option_parse(ctx, &info->dci_cmd_option.dci_process_ilog,
+						 parsed);
+	}
+	if (same(cmd, COMMAND_NAME_RM_ILOG)) {
+		info->dci_cmd = DDB_CMD_RM_ILOG;
+		return rm_ilog_option_parse(ctx, &info->dci_cmd_option.dci_rm_ilog, parsed);
+	}
+	if (same(cmd, COMMAND_NAME_DUMP_DTX)) {
+		info->dci_cmd = DDB_CMD_DUMP_DTX;
+		return dump_dtx_option_parse(ctx, &info->dci_cmd_option.dci_dump_dtx, parsed);
+	}
+	if (same(cmd, COMMAND_NAME_CLEAR_DTX)) {
+		info->dci_cmd = DDB_CMD_CLEAR_DTX;
+		return clear_dtx_option_parse(ctx, &info->dci_cmd_option.dci_clear_dtx, parsed);
+	}
 
 	return -DER_INVAL;
+}
+
+int
+ddb_run_help(struct ddb_ctx *ctx)
+{
+	ddb_print(ctx, "Usage:\n");
+	ddb_print(ctx, "ddb [OPTIONS] <command>\n");
+	ddb_print(ctx, "\n");
+	ddb_print(ctx, "ddb (DAOS Debug) is a tool for connecting to a VOS file for "
+		       "the purpose of investigating and resolving issues.\n");
+
+	ddb_print(ctx, "\nOptions:\n");
+	ddb_print(ctx, "   -R, --run_cmd\n");
+
+	ddb_print(ctx, "\nCommands:\n");
+	ddb_print(ctx, "   help\t\t\tShow this help message\n");
+	ddb_print(ctx, "   quit\t\t\tExit interactive mode\n");
+	ddb_print(ctx, "   ls\t\t\tList the containers, objects, dkeys, akeys, "
+		       "or value depending\n");
+	ddb_print(ctx, "   dump_superblock\tDump the pool superblock information\n");
+	ddb_print(ctx, "   dump_value\t\tDump a value to a file\n");
+	ddb_print(ctx, "   rm\t\t\tRemove a branch of the VOS tree\n");
+	ddb_print(ctx, "   load\t\t\tLoad an updated or new value\n");
+	ddb_print(ctx, "   dump_ilog\t\tDump the ilog\n");
+	ddb_print(ctx, "   process_ilog\t\tProcess the ilog\n");
+	ddb_print(ctx, "   rm_ilog\t\tRemove all the ilog entries\n");
+	ddb_print(ctx, "   dump_dtx\t\tDump the dtx tables\n");
+	ddb_print(ctx, "   clear_dtx\t\tClear the dtx committed table\n");
+
+	return 0;
 }

--- a/src/ddb/ddb_cmd_options.c
+++ b/src/ddb/ddb_cmd_options.c
@@ -18,14 +18,15 @@
 #define COMMAND_NAME_RM "rm"
 #define COMMAND_NAME_LOAD "load"
 #define COMMAND_NAME_DUMP_ILOG "dump_ilog"
-#define COMMAND_NAME_PROCESS_ILOG "process_ilog"
+#define COMMAND_NAME_COMMIT_ILOG "commit_ilog"
 #define COMMAND_NAME_RM_ILOG "rm_ilog"
 #define COMMAND_NAME_DUMP_DTX "dump_dtx"
-#define COMMAND_NAME_CLEAR_DTX "clear_dtx"
+#define COMMAND_NAME_CLEAR_CMT_DTX "clear_cmt_dtx"
 
 /* Parse command line options for the 'ls' command */
 static int
-ls_option_parse(struct ddb_ctx *ctx, struct ls_options *cmd_args, struct argv_parsed *argc_v)
+ls_option_parse(struct ddb_ctx *ctx, struct ls_options *cmd_args,
+		struct argv_parsed *argc_v)
 {
 	char		 *options_short = "r";
 	int		  index = 0, opt;
@@ -128,7 +129,8 @@ dump_value_option_parse(struct ddb_ctx *ctx, struct dump_value_options *cmd_args
 
 /* Parse command line options for the 'rm' command */
 static int
-rm_option_parse(struct ddb_ctx *ctx, struct rm_options *cmd_args, struct argv_parsed *argc_v)
+rm_option_parse(struct ddb_ctx *ctx, struct rm_options *cmd_args,
+		struct argv_parsed *argc_v)
 {
 	char		 *options_short = "";
 	int		  index = 0, opt;
@@ -175,7 +177,8 @@ rm_option_parse(struct ddb_ctx *ctx, struct rm_options *cmd_args, struct argv_pa
 
 /* Parse command line options for the 'load' command */
 static int
-load_option_parse(struct ddb_ctx *ctx, struct load_options *cmd_args, struct argv_parsed *argc_v)
+load_option_parse(struct ddb_ctx *ctx, struct load_options *cmd_args,
+		  struct argv_parsed *argc_v)
 {
 	char		 *options_short = "";
 	int		  index = 0, opt;
@@ -282,10 +285,10 @@ dump_ilog_option_parse(struct ddb_ctx *ctx, struct dump_ilog_options *cmd_args,
 	return 0;
 }
 
-/* Parse command line options for the 'process_ilog' command */
+/* Parse command line options for the 'commit_ilog' command */
 static int
-process_ilog_option_parse(struct ddb_ctx *ctx, struct process_ilog_options *cmd_args,
-			  struct argv_parsed *argc_v)
+commit_ilog_option_parse(struct ddb_ctx *ctx, struct commit_ilog_options *cmd_args,
+			 struct argv_parsed *argc_v)
 {
 	char		 *options_short = "";
 	int		  index = 0, opt;
@@ -312,7 +315,7 @@ process_ilog_option_parse(struct ddb_ctx *ctx, struct process_ilog_options *cmd_
 	index = optind;
 
 	D_ASSERT(argc > index);
-	D_ASSERT(same(argv[index], COMMAND_NAME_PROCESS_ILOG));
+	D_ASSERT(same(argv[index], COMMAND_NAME_COMMIT_ILOG));
 	index++;
 	if (argc - index > 0) {
 		cmd_args->path = argv[index];
@@ -434,10 +437,10 @@ dump_dtx_option_parse(struct ddb_ctx *ctx, struct dump_dtx_options *cmd_args,
 	return 0;
 }
 
-/* Parse command line options for the 'clear_dtx' command */
+/* Parse command line options for the 'clear_cmt_dtx' command */
 static int
-clear_dtx_option_parse(struct ddb_ctx *ctx, struct clear_dtx_options *cmd_args,
-		       struct argv_parsed *argc_v)
+clear_cmt_dtx_option_parse(struct ddb_ctx *ctx, struct clear_cmt_dtx_options *cmd_args,
+			   struct argv_parsed *argc_v)
 {
 	char		 *options_short = "";
 	int		  index = 0, opt;
@@ -464,7 +467,7 @@ clear_dtx_option_parse(struct ddb_ctx *ctx, struct clear_dtx_options *cmd_args,
 	index = optind;
 
 	D_ASSERT(argc > index);
-	D_ASSERT(same(argv[index], COMMAND_NAME_CLEAR_DTX));
+	D_ASSERT(same(argv[index], COMMAND_NAME_CLEAR_CMT_DTX));
 	index++;
 	if (argc - index > 0) {
 		cmd_args->path = argv[index];
@@ -519,10 +522,9 @@ ddb_parse_cmd_args(struct ddb_ctx *ctx, struct argv_parsed *parsed, struct ddb_c
 		info->dci_cmd = DDB_CMD_DUMP_ILOG;
 		return dump_ilog_option_parse(ctx, &info->dci_cmd_option.dci_dump_ilog, parsed);
 	}
-	if (same(cmd, COMMAND_NAME_PROCESS_ILOG)) {
-		info->dci_cmd = DDB_CMD_PROCESS_ILOG;
-		return process_ilog_option_parse(ctx, &info->dci_cmd_option.dci_process_ilog,
-						 parsed);
+	if (same(cmd, COMMAND_NAME_COMMIT_ILOG)) {
+		info->dci_cmd = DDB_CMD_COMMIT_ILOG;
+		return commit_ilog_option_parse(ctx, &info->dci_cmd_option.dci_commit_ilog, parsed);
 	}
 	if (same(cmd, COMMAND_NAME_RM_ILOG)) {
 		info->dci_cmd = DDB_CMD_RM_ILOG;
@@ -532,9 +534,10 @@ ddb_parse_cmd_args(struct ddb_ctx *ctx, struct argv_parsed *parsed, struct ddb_c
 		info->dci_cmd = DDB_CMD_DUMP_DTX;
 		return dump_dtx_option_parse(ctx, &info->dci_cmd_option.dci_dump_dtx, parsed);
 	}
-	if (same(cmd, COMMAND_NAME_CLEAR_DTX)) {
-		info->dci_cmd = DDB_CMD_CLEAR_DTX;
-		return clear_dtx_option_parse(ctx, &info->dci_cmd_option.dci_clear_dtx, parsed);
+	if (same(cmd, COMMAND_NAME_CLEAR_CMT_DTX)) {
+		info->dci_cmd = DDB_CMD_CLEAR_CMT_DTX;
+		return clear_cmt_dtx_option_parse(ctx, &info->dci_cmd_option.dci_clear_cmt_dtx,
+						  parsed);
 	}
 
 	return -DER_INVAL;
@@ -552,20 +555,19 @@ ddb_run_help(struct ddb_ctx *ctx)
 	ddb_print(ctx, "\nOptions:\n");
 	ddb_print(ctx, "   -R, --run_cmd\n");
 
-	ddb_print(ctx, "\nCommands:\n");
-	ddb_print(ctx, "   help\t\t\tShow this help message\n");
-	ddb_print(ctx, "   quit\t\t\tExit interactive mode\n");
-	ddb_print(ctx, "   ls\t\t\tList the containers, objects, dkeys, akeys, "
-		       "or value depending\n");
-	ddb_print(ctx, "   dump_superblock\tDump the pool superblock information\n");
-	ddb_print(ctx, "   dump_value\t\tDump a value to a file\n");
-	ddb_print(ctx, "   rm\t\t\tRemove a branch of the VOS tree\n");
-	ddb_print(ctx, "   load\t\t\tLoad an updated or new value\n");
-	ddb_print(ctx, "   dump_ilog\t\tDump the ilog\n");
-	ddb_print(ctx, "   process_ilog\t\tProcess the ilog\n");
-	ddb_print(ctx, "   rm_ilog\t\tRemove all the ilog entries\n");
-	ddb_print(ctx, "   dump_dtx\t\tDump the dtx tables\n");
-	ddb_print(ctx, "   clear_dtx\t\tClear the dtx committed table\n");
+	ddb_print(ctx, "Commands:\n");
+	ddb_print(ctx, "   help              Show this help message\n");
+	ddb_print(ctx, "   quit              Quit interactive mode\n");
+	ddb_print(ctx, "   ls                List containers, objects, dkeys, akeys, and values\n");
+	ddb_print(ctx, "   dump_superblock   Dump the pool superblock information\n");
+	ddb_print(ctx, "   dump_value        Dump a value to a file\n");
+	ddb_print(ctx, "   rm                Remove a branch of the VOS tree\n");
+	ddb_print(ctx, "   load              Load an updated or new value\n");
+	ddb_print(ctx, "   dump_ilog         Dump the ilog\n");
+	ddb_print(ctx, "   commit_ilog       Process the ilog\n");
+	ddb_print(ctx, "   rm_ilog           Remove all the ilog entries\n");
+	ddb_print(ctx, "   dump_dtx          Dump the dtx tables\n");
+	ddb_print(ctx, "   clear_cmt_dtx     Clear the dtx committed table\n");
 
 	return 0;
 }

--- a/src/ddb/ddb_cmd_options.h
+++ b/src/ddb/ddb_cmd_options.h
@@ -9,29 +9,24 @@
 
 enum ddb_cmd {
 	DDB_CMD_UNKNOWN = 0,
-	DDB_CMD_QUIT = 1,
-	DDB_CMD_LS = 2,
-	DDB_CMD_DUMP_SUPERBLOCK = 3,
-	DDB_CMD_DUMP_ILOG = 4,
-	DDB_CMD_DUMP_DTX = 5,
-	DDB_CMD_DUMP_VALUE = 6,
-	DDB_CMD_RM = 7,
-	DDB_CMD_LOAD = 8,
+	DDB_CMD_HELP = 1,
+
+	DDB_CMD_QUIT = 2,
+	DDB_CMD_LS = 3,
+	DDB_CMD_DUMP_SUPERBLOCK = 4,
+	DDB_CMD_DUMP_VALUE = 5,
+	DDB_CMD_RM = 6,
+	DDB_CMD_LOAD = 7,
+	DDB_CMD_DUMP_ILOG = 8,
+	DDB_CMD_PROCESS_ILOG = 9,
+	DDB_CMD_RM_ILOG = 10,
+	DDB_CMD_DUMP_DTX = 11,
+	DDB_CMD_CLEAR_DTX = 12,
 };
 
 /* option and argument structures for commands that need them */
 struct ls_options {
 	bool recursive;
-	char *path;
-};
-
-struct dump_ilog_options {
-	char *path;
-};
-
-struct dump_dtx_options {
-	bool active;
-	bool committed;
 	char *path;
 };
 
@@ -50,28 +45,57 @@ struct load_options {
 	char *epoch;
 };
 
+struct dump_ilog_options {
+	char *path;
+};
+
+struct process_ilog_options {
+	char *path;
+};
+
+struct rm_ilog_options {
+	char *path;
+};
+
+struct dump_dtx_options {
+	bool active;
+	bool committed;
+	char *path;
+};
+
+struct clear_dtx_options {
+	char *path;
+};
+
 struct ddb_cmd_info {
 	enum ddb_cmd dci_cmd;
 	union {
 		struct ls_options dci_ls;
-		struct dump_ilog_options dci_dump_ilog;
-		struct dump_dtx_options dci_dump_dtx;
 		struct dump_value_options dci_dump_value;
 		struct rm_options dci_rm;
 		struct load_options dci_load;
+		struct dump_ilog_options dci_dump_ilog;
+		struct process_ilog_options dci_process_ilog;
+		struct rm_ilog_options dci_rm_ilog;
+		struct dump_dtx_options dci_dump_dtx;
+		struct clear_dtx_options dci_clear_dtx;
 	} dci_cmd_option;
 };
 
 int ddb_parse_cmd_args(struct ddb_ctx *ctx, struct argv_parsed *parsed, struct ddb_cmd_info *info);
 
 /* Run commands ... */
+int ddb_run_help(struct ddb_ctx *ctx);
 int ddb_run_quit(struct ddb_ctx *ctx);
 int ddb_run_ls(struct ddb_ctx *ctx, struct ls_options *opt);
 int ddb_run_dump_superblock(struct ddb_ctx *ctx);
-int ddb_run_dump_ilog(struct ddb_ctx *ctx, struct dump_ilog_options *opt);
-int ddb_run_dump_dtx(struct ddb_ctx *ctx, struct dump_dtx_options *opt);
 int ddb_run_dump_value(struct ddb_ctx *ctx, struct dump_value_options *opt);
 int ddb_run_rm(struct ddb_ctx *ctx, struct rm_options *opt);
 int ddb_run_load(struct ddb_ctx *ctx, struct load_options *opt);
+int ddb_run_dump_ilog(struct ddb_ctx *ctx, struct dump_ilog_options *opt);
+int ddb_run_process_ilog(struct ddb_ctx *ctx, struct process_ilog_options *opt);
+int ddb_run_rm_ilog(struct ddb_ctx *ctx, struct rm_ilog_options *opt);
+int ddb_run_dump_dtx(struct ddb_ctx *ctx, struct dump_dtx_options *opt);
+int ddb_run_clear_dtx(struct ddb_ctx *ctx, struct clear_dtx_options *opt);
 
 #endif /* __DDB_RUN_CMDS_H */

--- a/src/ddb/ddb_cmd_options.h
+++ b/src/ddb/ddb_cmd_options.h
@@ -10,7 +10,6 @@
 enum ddb_cmd {
 	DDB_CMD_UNKNOWN = 0,
 	DDB_CMD_HELP = 1,
-
 	DDB_CMD_QUIT = 2,
 	DDB_CMD_LS = 3,
 	DDB_CMD_DUMP_SUPERBLOCK = 4,
@@ -18,10 +17,10 @@ enum ddb_cmd {
 	DDB_CMD_RM = 6,
 	DDB_CMD_LOAD = 7,
 	DDB_CMD_DUMP_ILOG = 8,
-	DDB_CMD_PROCESS_ILOG = 9,
+	DDB_CMD_COMMIT_ILOG = 9,
 	DDB_CMD_RM_ILOG = 10,
 	DDB_CMD_DUMP_DTX = 11,
-	DDB_CMD_CLEAR_DTX = 12,
+	DDB_CMD_CLEAR_CMT_DTX = 12,
 };
 
 /* option and argument structures for commands that need them */
@@ -49,7 +48,7 @@ struct dump_ilog_options {
 	char *path;
 };
 
-struct process_ilog_options {
+struct commit_ilog_options {
 	char *path;
 };
 
@@ -63,7 +62,7 @@ struct dump_dtx_options {
 	char *path;
 };
 
-struct clear_dtx_options {
+struct clear_cmt_dtx_options {
 	char *path;
 };
 
@@ -75,10 +74,10 @@ struct ddb_cmd_info {
 		struct rm_options dci_rm;
 		struct load_options dci_load;
 		struct dump_ilog_options dci_dump_ilog;
-		struct process_ilog_options dci_process_ilog;
+		struct commit_ilog_options dci_commit_ilog;
 		struct rm_ilog_options dci_rm_ilog;
 		struct dump_dtx_options dci_dump_dtx;
-		struct clear_dtx_options dci_clear_dtx;
+		struct clear_cmt_dtx_options dci_clear_cmt_dtx;
 	} dci_cmd_option;
 };
 
@@ -93,9 +92,9 @@ int ddb_run_dump_value(struct ddb_ctx *ctx, struct dump_value_options *opt);
 int ddb_run_rm(struct ddb_ctx *ctx, struct rm_options *opt);
 int ddb_run_load(struct ddb_ctx *ctx, struct load_options *opt);
 int ddb_run_dump_ilog(struct ddb_ctx *ctx, struct dump_ilog_options *opt);
-int ddb_run_process_ilog(struct ddb_ctx *ctx, struct process_ilog_options *opt);
+int ddb_run_commit_ilog(struct ddb_ctx *ctx, struct commit_ilog_options *opt);
 int ddb_run_rm_ilog(struct ddb_ctx *ctx, struct rm_ilog_options *opt);
 int ddb_run_dump_dtx(struct ddb_ctx *ctx, struct dump_dtx_options *opt);
-int ddb_run_clear_dtx(struct ddb_ctx *ctx, struct clear_dtx_options *opt);
+int ddb_run_clear_cmt_dtx(struct ddb_ctx *ctx, struct clear_cmt_dtx_options *opt);
 
 #endif /* __DDB_RUN_CMDS_H */

--- a/src/ddb/ddb_commands.c
+++ b/src/ddb/ddb_commands.c
@@ -278,12 +278,18 @@ ddb_run_dump_ilog(struct ddb_ctx *ctx, struct dump_ilog_options *opt)
 	return rc;
 }
 
+struct committed_cb_args {
+	struct ddb_ctx *ctx;
+	uint32_t entry_count;
+};
+
 static int
 active_dtx_cb(struct dv_dtx_active_entry *entry, void *cb_arg)
 {
-	struct ddb_ctx *ctx = cb_arg;
+	struct committed_cb_args *args = cb_arg;
 
-	ddb_print_dtx_active(ctx, entry);
+	ddb_print_dtx_active(args->ctx, entry);
+	args->entry_count++;
 
 	return 0;
 }
@@ -291,9 +297,10 @@ active_dtx_cb(struct dv_dtx_active_entry *entry, void *cb_arg)
 static int
 committed_cb(struct dv_dtx_committed_entry *entry, void *cb_arg)
 {
-	struct ddb_ctx *ctx = cb_arg;
+	struct committed_cb_args *args = cb_arg;
 
-	ddb_print_dtx_committed(ctx, entry);
+	ddb_print_dtx_committed(args->ctx, entry);
+	args->entry_count++;
 
 	return 0;
 }
@@ -305,6 +312,8 @@ ddb_run_dump_dtx(struct ddb_ctx *ctx, struct dump_dtx_options *opt)
 	int				rc;
 	daos_handle_t			coh;
 	bool				both = !(opt->committed ^ opt->active);
+	struct committed_cb_args	args = {.ctx = ctx, .entry_count = 0};
+
 
 	rc = init_path(ctx->dc_poh, opt->path, &vtp);
 	if (!SUCCESS(rc))
@@ -322,21 +331,26 @@ ddb_run_dump_dtx(struct ddb_ctx *ctx, struct dump_dtx_options *opt)
 		return rc;
 	}
 
+	vtp_print(ctx, &vtp.vtp_path, true);
+
 	if (both || opt->active) {
 		ddb_print(ctx, "Active Transactions:\n");
-		rc = dv_active_dtx(coh, active_dtx_cb, ctx);
+		rc = dv_active_dtx(coh, active_dtx_cb, &args);
 		if (!SUCCESS(rc)) {
 			ddb_vtp_fini(&vtp);
 			return rc;
 		}
+		ddb_printf(ctx, "%d Active Entries\n", args.entry_count);
 	}
-	if (both || opt->active) {
+	if (both || opt->committed) {
+		args.entry_count = 0;
 		ddb_print(ctx, "Committed Transactions:\n");
-		rc = dv_committed_dtx(coh, committed_cb, ctx);
+		rc = dv_committed_dtx(coh, committed_cb, &args);
 		if (!SUCCESS(rc)) {
 			ddb_vtp_fini(&vtp);
 			return rc;
 		}
+		ddb_printf(ctx, "%d Committed Entries\n", args.entry_count);
 	}
 
 	dv_cont_close(&coh);
@@ -442,5 +456,94 @@ done:
 	if (SUCCESS(rc))
 		ddb_printf(ctx, "Successfully loaded file '%s'\n", opt->src);
 
+	return rc;
+}
+
+static int
+process_ilog_op(struct ddb_ctx *ctx, char *path, enum ddb_ilog_op op)
+{
+	struct dv_tree_path_builder	 vtpb = {0};
+	daos_handle_t			 coh = {0};
+	int				 rc;
+	struct dv_tree_path		*vtp = &vtpb.vtp_path;
+
+	if (path == NULL) {
+		ddb_error(ctx, "path is required\n");
+		return -DER_INVAL;
+	}
+
+	rc = init_path(ctx->dc_poh, path, &vtpb);
+	if (!SUCCESS(rc))
+		D_GOTO(done, rc);
+	vtp_print(ctx, &vtpb.vtp_path, true);
+
+	if (!dv_has_obj(vtp)) /* At least object is required */
+		D_GOTO(done, rc = -DER_INVAL);
+
+	rc = dv_cont_open(ctx->dc_poh, vtp->vtp_cont, &coh);
+	if (!SUCCESS(rc))
+		D_GOTO(done, rc);
+
+	if (dv_has_dkey(vtp))
+		rc = dv_process_dkey_ilog_entries(coh, vtp->vtp_oid, &vtp->vtp_dkey, op);
+	else
+		rc = dv_process_obj_ilog_entries(coh, vtp->vtp_oid, op);
+	if (!SUCCESS(rc))
+		D_GOTO(done, rc);
+
+	ddb_print(ctx, "Done\n");
+done:
+	dv_cont_close(&coh);
+	ddb_vtp_fini(&vtpb);
+
+	return rc;
+}
+
+int
+ddb_run_rm_ilog(struct ddb_ctx *ctx, struct rm_ilog_options *opt)
+{
+	return process_ilog_op(ctx, opt->path, DDB_ILOG_OP_ABORT);
+}
+
+int
+ddb_run_process_ilog(struct ddb_ctx *ctx, struct process_ilog_options *opt)
+{
+	return process_ilog_op(ctx, opt->path, DDB_ILOG_OP_PERSIST);
+}
+
+int
+ddb_run_clear_dtx(struct ddb_ctx *ctx, struct clear_dtx_options *opt)
+{
+	struct dv_tree_path_builder	 vtpb = {0};
+	struct dv_tree_path		*vtp = &vtpb.vtp_path;
+	daos_handle_t			 coh = {0};
+	int				 rc;
+
+	if (opt->path == NULL) {
+		ddb_error(ctx, "path is required\n");
+		return -DER_INVAL;
+	}
+
+	rc = init_path(ctx->dc_poh, opt->path, &vtpb);
+	if (!SUCCESS(rc))
+		D_GOTO(done, rc);
+	vtp_print(ctx, &vtpb.vtp_path, true);
+
+	if (!dv_has_cont(vtp))
+		D_GOTO(done, rc = -DER_INVAL);
+
+	rc = dv_cont_open(ctx->dc_poh, vtp->vtp_cont, &coh);
+	if (!SUCCESS(rc))
+		D_GOTO(done, rc);
+
+	rc = dv_clear_committed_table(coh);
+	if (!SUCCESS(rc))
+		D_GOTO(done, rc);
+
+	ddb_print(ctx, "Done\n");
+
+done:
+	ddb_vtp_fini(&vtpb);
+	dv_cont_close(&coh);
 	return rc;
 }

--- a/src/ddb/ddb_main.c
+++ b/src/ddb/ddb_main.c
@@ -36,6 +36,12 @@ run_cmd(struct ddb_ctx *ctx, struct argv_parsed *parse_args)
 
 	switch (info.dci_cmd) {
 	case DDB_CMD_UNKNOWN:
+		ddb_print(ctx, "Unknown command\n");
+		ddb_run_help(ctx);
+		rc = -DER_INVAL;
+		break;
+	case DDB_CMD_HELP:
+		rc = ddb_run_help(ctx);
 		break;
 	case DDB_CMD_QUIT:
 		rc = ddb_run_quit(ctx);
@@ -61,10 +67,16 @@ run_cmd(struct ddb_ctx *ctx, struct argv_parsed *parse_args)
 	case DDB_CMD_LOAD:
 		rc = ddb_run_load(ctx, &info.dci_cmd_option.dci_load);
 		break;
+	case DDB_CMD_PROCESS_ILOG:
+		rc = ddb_run_process_ilog(ctx, &info.dci_cmd_option.dci_process_ilog);
+		break;
+	case DDB_CMD_RM_ILOG:
+		rc = ddb_run_rm_ilog(ctx, &info.dci_cmd_option.dci_rm_ilog);
+		break;
+	case DDB_CMD_CLEAR_DTX:
+		rc = ddb_run_clear_dtx(ctx, &info.dci_cmd_option.dci_clear_dtx);
+		break;
 	}
-
-	if (!SUCCESS(rc))
-		ddb_errorf(ctx, "Error with command: "DF_RC"\n", DP_RC(rc));
 
 	ddb_str2argv_free(parse_args);
 
@@ -117,8 +129,6 @@ ddb_main(struct ddb_io_ft *io_ft, int argc, char *argv[])
 		}
 
 		rc = run_cmd(&ctx, &parse_args);
-		if (!SUCCESS(rc))
-			ddb_errorf(&ctx, "Error with command: "DF_RC"\n", DP_RC(rc));
 
 		ddb_str2argv_free(&parse_args);
 		D_GOTO(done, rc);
@@ -146,8 +156,6 @@ ddb_main(struct ddb_io_ft *io_ft, int argc, char *argv[])
 		}
 
 		rc = run_cmd(&ctx, &parse_args);
-		if (!SUCCESS(rc))
-			ddb_errorf(&ctx, "Error: "DF_RC"\n", DP_RC(rc));
 		ddb_str2argv_free(&parse_args);
 	}
 

--- a/src/ddb/ddb_main.c
+++ b/src/ddb/ddb_main.c
@@ -67,14 +67,14 @@ run_cmd(struct ddb_ctx *ctx, struct argv_parsed *parse_args)
 	case DDB_CMD_LOAD:
 		rc = ddb_run_load(ctx, &info.dci_cmd_option.dci_load);
 		break;
-	case DDB_CMD_PROCESS_ILOG:
-		rc = ddb_run_process_ilog(ctx, &info.dci_cmd_option.dci_process_ilog);
+	case DDB_CMD_COMMIT_ILOG:
+		rc = ddb_run_commit_ilog(ctx, &info.dci_cmd_option.dci_commit_ilog);
 		break;
 	case DDB_CMD_RM_ILOG:
 		rc = ddb_run_rm_ilog(ctx, &info.dci_cmd_option.dci_rm_ilog);
 		break;
-	case DDB_CMD_CLEAR_DTX:
-		rc = ddb_run_clear_dtx(ctx, &info.dci_cmd_option.dci_clear_dtx);
+	case DDB_CMD_CLEAR_CMT_DTX:
+		rc = ddb_run_clear_cmt_dtx(ctx, &info.dci_cmd_option.dci_clear_cmt_dtx);
 		break;
 	}
 

--- a/src/ddb/ddb_printer.c
+++ b/src/ddb/ddb_printer.c
@@ -29,10 +29,9 @@ void
 ddb_print_obj(struct ddb_ctx *ctx, struct ddb_obj *obj, uint32_t indent)
 {
 	print_indent(ctx, indent);
-	ddb_printf(ctx, DF_IDX" '"DF_OID"' (class: %s, type: %s, groups: %d)\n",
+	ddb_printf(ctx, DF_IDX" '"DF_OID"' (type: %s, groups: %d)\n",
 		   DP_IDX(obj->ddbo_idx),
 		   DP_OID(obj->ddbo_oid),
-		   obj->ddbo_obj_class_name,
 		   obj->ddbo_otype_str,
 		   obj->ddbo_nr_grps);
 }
@@ -166,40 +165,41 @@ void
 ddb_print_ilog_entry(struct ddb_ctx *ctx, struct ddb_ilog_entry *entry)
 {
 	ddb_printf(ctx, "Index: %d\n", entry->die_idx);
-	ddb_printf(ctx, "Status: %s (%d)\n", entry->die_status_str, entry->die_status);
-	ddb_printf(ctx, "Epoch: %lu\n", entry->die_epoch);
-	ddb_printf(ctx, "Txn ID: %d\n", entry->die_tx_id);
+	ddb_printf(ctx, "\tStatus: %s (%d)\n", entry->die_status_str, entry->die_status);
+	ddb_printf(ctx, "\tEpoch: %lu\n", entry->die_epoch);
+	ddb_printf(ctx, "\tTxn ID: %d\n", entry->die_tx_id);
 }
 
 void
 ddb_print_dtx_committed(struct ddb_ctx *ctx, struct dv_dtx_committed_entry *entry)
 {
 	ddb_printf(ctx, "UUID: "DF_UUIDF"\n", DP_UUID(entry->ddtx_uuid));
-	ddb_printf(ctx, "Epoch: "DF_U64"\n", entry->ddtx_epoch);
-	ddb_printf(ctx, "Exist: "DF_BOOL"\n", DP_BOOL(entry->ddtx_exist));
-	ddb_printf(ctx, "Invalid: "DF_BOOL"\n", DP_BOOL(entry->ddtx_invalid));
+	ddb_printf(ctx, "\tEpoch: "DF_U64"\n", entry->ddtx_epoch);
+	ddb_printf(ctx, "\tExist: "DF_BOOL"\n", DP_BOOL(entry->ddtx_exist));
+	ddb_printf(ctx, "\tInvalid: "DF_BOOL"\n", DP_BOOL(entry->ddtx_invalid));
 }
 
 void
 ddb_print_dtx_active(struct ddb_ctx *ctx, struct dv_dtx_active_entry *entry)
 {
 	ddb_printf(ctx, "UUID: "DF_UUIDF"\n", DP_UUID(entry->ddtx_uuid));
-	ddb_printf(ctx, "Epoch: "DF_U64"\n", entry->ddtx_epoch);
-	ddb_printf(ctx, "Exist: "DF_BOOL"\n", DP_BOOL(entry->ddtx_exist));
-	ddb_printf(ctx, "Invalid: "DF_BOOL"\n", DP_BOOL(entry->ddtx_invalid));
-	ddb_printf(ctx, "Reindex: "DF_BOOL"\n", DP_BOOL(entry->ddtx_reindex));
-	ddb_printf(ctx, "Handle Time: "DF_U64"\n", entry->ddtx_handle_time);
-	ddb_printf(ctx, "Oid Cnt: %d\n", entry->ddtx_oid_cnt);
-	ddb_printf(ctx, "Start Time: "DF_U64"\n", entry->ddtx_start_time);
-	ddb_printf(ctx, "Committable: "DF_BOOL"\n", DP_BOOL(entry->ddtx_committable));
-	ddb_printf(ctx, "Committed: "DF_BOOL"\n", DP_BOOL(entry->ddtx_committed));
-	ddb_printf(ctx, "Aborted: "DF_BOOL"\n", DP_BOOL(entry->ddtx_aborted));
-	ddb_printf(ctx, "Maybe Shared: "DF_BOOL"\n", DP_BOOL(entry->ddtx_maybe_shared));
-	ddb_printf(ctx, "Prepared: "DF_BOOL"\n", DP_BOOL(entry->ddtx_prepared));
-	ddb_printf(ctx, "Grp Cnt: %d\n", entry->ddtx_grp_cnt);
-	ddb_printf(ctx, "Ver: %d\n", entry->ddtx_ver);
-	ddb_printf(ctx, "Rec Cnt: %d\n", entry->ddtx_rec_cnt);
-	ddb_printf(ctx, "Mbs Flags: %d\n", entry->ddtx_mbs_flags);
-	ddb_printf(ctx, "Flags: %d\n", entry->ddtx_flags);
-	ddb_printf(ctx, "Oid: "DF_UOID"\n", DP_UOID(entry->ddtx_oid));
+	ddb_printf(ctx, "\tID HLC: "DF_U64"\n", entry->ddtx_id_hlc);
+	ddb_printf(ctx, "\tEpoch: "DF_U64"\n", entry->ddtx_epoch);
+	ddb_printf(ctx, "\tExist: "DF_BOOL"\n", DP_BOOL(entry->ddtx_exist));
+	ddb_printf(ctx, "\tInvalid: "DF_BOOL"\n", DP_BOOL(entry->ddtx_invalid));
+	ddb_printf(ctx, "\tReindex: "DF_BOOL"\n", DP_BOOL(entry->ddtx_reindex));
+	ddb_printf(ctx, "\tHandle Time: "DF_U64"\n", entry->ddtx_handle_time);
+	ddb_printf(ctx, "\tOid Cnt: %d\n", entry->ddtx_oid_cnt);
+	ddb_printf(ctx, "\tStart Time: "DF_U64"\n", entry->ddtx_start_time);
+	ddb_printf(ctx, "\tCommittable: "DF_BOOL"\n", DP_BOOL(entry->ddtx_committable));
+	ddb_printf(ctx, "\tCommitted: "DF_BOOL"\n", DP_BOOL(entry->ddtx_committed));
+	ddb_printf(ctx, "\tAborted: "DF_BOOL"\n", DP_BOOL(entry->ddtx_aborted));
+	ddb_printf(ctx, "\tMaybe Shared: "DF_BOOL"\n", DP_BOOL(entry->ddtx_maybe_shared));
+	ddb_printf(ctx, "\tPrepared: "DF_BOOL"\n", DP_BOOL(entry->ddtx_prepared));
+	ddb_printf(ctx, "\tGrp Cnt: %d\n", entry->ddtx_grp_cnt);
+	ddb_printf(ctx, "\tVer: %d\n", entry->ddtx_ver);
+	ddb_printf(ctx, "\tRec Cnt: %d\n", entry->ddtx_rec_cnt);
+	ddb_printf(ctx, "\tMbs Flags: %d\n", entry->ddtx_mbs_flags);
+	ddb_printf(ctx, "\tFlags: %d\n", entry->ddtx_flags);
+	ddb_printf(ctx, "\tOid: "DF_UOID"\n", DP_UOID(entry->ddtx_oid));
 }

--- a/src/ddb/ddb_printer.c
+++ b/src/ddb/ddb_printer.c
@@ -173,29 +173,16 @@ ddb_print_ilog_entry(struct ddb_ctx *ctx, struct ddb_ilog_entry *entry)
 void
 ddb_print_dtx_committed(struct ddb_ctx *ctx, struct dv_dtx_committed_entry *entry)
 {
-	ddb_printf(ctx, "UUID: "DF_UUIDF"\n", DP_UUID(entry->ddtx_uuid));
+	ddb_printf(ctx, "ID: "DF_DTI"\n", DP_DTI(&entry->ddtx_id));
 	ddb_printf(ctx, "\tEpoch: "DF_U64"\n", entry->ddtx_epoch);
-	ddb_printf(ctx, "\tExist: "DF_BOOL"\n", DP_BOOL(entry->ddtx_exist));
-	ddb_printf(ctx, "\tInvalid: "DF_BOOL"\n", DP_BOOL(entry->ddtx_invalid));
 }
 
 void
 ddb_print_dtx_active(struct ddb_ctx *ctx, struct dv_dtx_active_entry *entry)
 {
-	ddb_printf(ctx, "UUID: "DF_UUIDF"\n", DP_UUID(entry->ddtx_uuid));
-	ddb_printf(ctx, "\tID HLC: "DF_U64"\n", entry->ddtx_id_hlc);
+	ddb_printf(ctx, "ID: "DF_DTI"\n", DP_DTI(&entry->ddtx_id));
 	ddb_printf(ctx, "\tEpoch: "DF_U64"\n", entry->ddtx_epoch);
-	ddb_printf(ctx, "\tExist: "DF_BOOL"\n", DP_BOOL(entry->ddtx_exist));
-	ddb_printf(ctx, "\tInvalid: "DF_BOOL"\n", DP_BOOL(entry->ddtx_invalid));
-	ddb_printf(ctx, "\tReindex: "DF_BOOL"\n", DP_BOOL(entry->ddtx_reindex));
 	ddb_printf(ctx, "\tHandle Time: "DF_U64"\n", entry->ddtx_handle_time);
-	ddb_printf(ctx, "\tOid Cnt: %d\n", entry->ddtx_oid_cnt);
-	ddb_printf(ctx, "\tStart Time: "DF_U64"\n", entry->ddtx_start_time);
-	ddb_printf(ctx, "\tCommittable: "DF_BOOL"\n", DP_BOOL(entry->ddtx_committable));
-	ddb_printf(ctx, "\tCommitted: "DF_BOOL"\n", DP_BOOL(entry->ddtx_committed));
-	ddb_printf(ctx, "\tAborted: "DF_BOOL"\n", DP_BOOL(entry->ddtx_aborted));
-	ddb_printf(ctx, "\tMaybe Shared: "DF_BOOL"\n", DP_BOOL(entry->ddtx_maybe_shared));
-	ddb_printf(ctx, "\tPrepared: "DF_BOOL"\n", DP_BOOL(entry->ddtx_prepared));
 	ddb_printf(ctx, "\tGrp Cnt: %d\n", entry->ddtx_grp_cnt);
 	ddb_printf(ctx, "\tVer: %d\n", entry->ddtx_ver);
 	ddb_printf(ctx, "\tRec Cnt: %d\n", entry->ddtx_rec_cnt);

--- a/src/ddb/ddb_vos.h
+++ b/src/ddb/ddb_vos.h
@@ -21,7 +21,6 @@ struct ddb_obj {
 	uint32_t		ddbo_idx;
 	enum daos_otype_t	ddbo_otype;
 	char			ddbo_otype_str[32];
-	char			ddbo_obj_class_name[16];
 	uint32_t		ddbo_nr_grps;
 };
 
@@ -124,12 +123,22 @@ struct ddb_ilog_entry {
 	uint16_t	die_punch_minor_eph;
 };
 
+enum ddb_ilog_op {
+	DDB_ILOG_OP_UNKNOWN = 0,
+	DDB_ILOG_OP_ABORT = 1,
+	DDB_ILOG_OP_PERSIST = 2,
+};
+
 typedef int (*dv_dump_ilog_entry)(void *cb_arg, struct ddb_ilog_entry *entry);
 int dv_get_obj_ilog_entries(daos_handle_t coh, daos_unit_oid_t oid, dv_dump_ilog_entry cb,
 			    void *cb_args);
+int dv_process_obj_ilog_entries(daos_handle_t coh, daos_unit_oid_t oid, enum ddb_ilog_op op);
+
 int dv_get_dkey_ilog_entries(daos_handle_t coh, daos_unit_oid_t oid, daos_key_t *dkey,
 			     dv_dump_ilog_entry cb, void *cb_args);
 
+int dv_process_dkey_ilog_entries(daos_handle_t coh, daos_unit_oid_t oid, daos_key_t *dkey,
+				 enum ddb_ilog_op op);
 
 struct dv_dtx_committed_entry {
 	uuid_t		ddtx_uuid;
@@ -142,6 +151,7 @@ struct dv_dtx_committed_entry {
 
 struct dv_dtx_active_entry {
 	uuid_t		ddtx_uuid;
+	uint64_t	ddtx_id_hlc;
 	bool		ddtx_reindex;
 	bool		ddtx_exist;
 	bool		ddtx_invalid;
@@ -166,6 +176,8 @@ typedef int (*dv_committed_dtx_handler)(struct dv_dtx_committed_entry *entry, vo
 int dv_committed_dtx(daos_handle_t coh, dv_committed_dtx_handler handler_cb, void *handler_arg);
 typedef int (*dv_active_dtx_handler)(struct dv_dtx_active_entry *entry, void *cb_arg);
 int dv_active_dtx(daos_handle_t coh, dv_active_dtx_handler handler_cb, void *handler_arg);
+int dv_clear_committed_table(daos_handle_t coh);
+
 int dv_delete(daos_handle_t poh, struct dv_tree_path *vtp);
 int dv_update(daos_handle_t poh, struct dv_tree_path *vtp, d_iov_t *iov, daos_epoch_t epoch);
 

--- a/src/ddb/ddb_vos.h
+++ b/src/ddb/ddb_vos.h
@@ -134,36 +134,23 @@ int dv_get_obj_ilog_entries(daos_handle_t coh, daos_unit_oid_t oid, dv_dump_ilog
 			    void *cb_args);
 int dv_process_obj_ilog_entries(daos_handle_t coh, daos_unit_oid_t oid, enum ddb_ilog_op op);
 
-int dv_get_dkey_ilog_entries(daos_handle_t coh, daos_unit_oid_t oid, daos_key_t *dkey,
-			     dv_dump_ilog_entry cb, void *cb_args);
+int
+dv_get_key_ilog_entries(daos_handle_t coh, daos_unit_oid_t oid, daos_key_t *dkey, daos_key_t *akey,
+			dv_dump_ilog_entry cb, void *cb_args);
 
-int dv_process_dkey_ilog_entries(daos_handle_t coh, daos_unit_oid_t oid, daos_key_t *dkey,
-				 enum ddb_ilog_op op);
+int dv_process_key_ilog_entries(daos_handle_t coh, daos_unit_oid_t oid, daos_key_t *dkey,
+				daos_key_t *akey, enum ddb_ilog_op op);
 
 struct dv_dtx_committed_entry {
-	uuid_t		ddtx_uuid;
-	bool		ddtx_reindex;
-	bool		ddtx_exist;
-	bool		ddtx_invalid;
+	struct dtx_id	ddtx_id;
 	daos_epoch_t	ddtx_cmt_time;
 	daos_epoch_t	ddtx_epoch;
 };
 
 struct dv_dtx_active_entry {
-	uuid_t		ddtx_uuid;
-	uint64_t	ddtx_id_hlc;
-	bool		ddtx_reindex;
-	bool		ddtx_exist;
-	bool		ddtx_invalid;
+	struct dtx_id	ddtx_id;
 	daos_epoch_t	ddtx_handle_time;
 	daos_epoch_t	ddtx_epoch;
-	uint32_t	ddtx_oid_cnt;
-	daos_epoch_t	ddtx_start_time;
-	uint32_t	ddtx_committable;
-	uint32_t	ddtx_committed;
-	uint32_t	ddtx_aborted;
-	uint32_t	ddtx_maybe_shared;
-	uint32_t	ddtx_prepared;
 	uint32_t	ddtx_grp_cnt;
 	uint32_t	ddtx_ver;
 	uint32_t	ddtx_rec_cnt;

--- a/src/ddb/tests/ddb_cmd_options_tests.c
+++ b/src/ddb/tests/ddb_cmd_options_tests.c
@@ -149,17 +149,17 @@ dump_ilog_options_parsing(void **state)
 }
 
 static void
-process_ilog_options_parsing(void **state)
+commit_ilog_options_parsing(void **state)
 {
 	struct ddb_cmd_info	 info = {0};
-	struct process_ilog_options	*options = &info.dci_cmd_option.dci_process_ilog;
+	struct commit_ilog_options	*options = &info.dci_cmd_option.dci_commit_ilog;
 
 	/* test invalid arguments and options */
-	test_run_inval_cmd("process_ilog", "path", "extra"); /* too many argument */
-	test_run_inval_cmd("process_ilog", "-z"); /* invalid option */
+	test_run_inval_cmd("commit_ilog", "path", "extra"); /* too many argument */
+	test_run_inval_cmd("commit_ilog", "-z"); /* invalid option */
 
 	/* test all arguments */
-	test_run_cmd(&info, "process_ilog", "path");
+	test_run_cmd(&info, "commit_ilog", "path");
 	assert_non_null(options->path);
 
 }
@@ -204,17 +204,17 @@ dump_dtx_options_parsing(void **state)
 }
 
 static void
-clear_dtx_options_parsing(void **state)
+clear_cmt_dtx_options_parsing(void **state)
 {
 	struct ddb_cmd_info	 info = {0};
-	struct clear_dtx_options	*options = &info.dci_cmd_option.dci_clear_dtx;
+	struct clear_cmt_dtx_options	*options = &info.dci_cmd_option.dci_clear_cmt_dtx;
 
 	/* test invalid arguments and options */
-	test_run_inval_cmd("clear_dtx", "path", "extra"); /* too many argument */
-	test_run_inval_cmd("clear_dtx", "-z"); /* invalid option */
+	test_run_inval_cmd("clear_cmt_dtx", "path", "extra"); /* too many argument */
+	test_run_inval_cmd("clear_cmt_dtx", "-z"); /* invalid option */
 
 	/* test all arguments */
-	test_run_cmd(&info, "clear_dtx", "path");
+	test_run_cmd(&info, "clear_cmt_dtx", "path");
 	assert_non_null(options->path);
 }
 
@@ -233,10 +233,10 @@ ddb_cmd_options_tests_run()
 		TEST(rm_options_parsing),
 		TEST(load_options_parsing),
 		TEST(dump_ilog_options_parsing),
-		TEST(process_ilog_options_parsing),
+		TEST(commit_ilog_options_parsing),
 		TEST(rm_ilog_options_parsing),
 		TEST(dump_dtx_options_parsing),
-		TEST(clear_dtx_options_parsing),
+		TEST(clear_cmt_dtx_options_parsing),
 	};
 
 	return cmocka_run_group_tests_name("DDB commands option parsing tests", tests,

--- a/src/ddb/tests/ddb_cmd_options_tests.c
+++ b/src/ddb/tests/ddb_cmd_options_tests.c
@@ -65,102 +65,158 @@ ls_options_parsing(void **state)
 	struct ddb_cmd_info	 info = {0};
 	struct ls_options	*options = &info.dci_cmd_option.dci_ls;
 
-	test_run_inval_cmd("ls", "path", "invalid_argument"); /* invalid argument */
+	/* test invalid arguments and options */
+	test_run_inval_cmd("ls", "path", "extra"); /* too many argument */
 	test_run_inval_cmd("ls", "-z"); /* invalid option */
 
-	test_run_cmd(&info, "ls");
-	assert_false(options->recursive);
-	assert_null(options->path);
-
-	test_run_cmd(&info, "ls", "-r");
-	assert_true(options->recursive);
-	assert_null(options->path);
-
-	test_run_cmd(&info, "ls", "/[0]/[0]");
-	assert_false(options->recursive);
+	/* test all arguments */
+	test_run_cmd(&info, "ls", "path");
 	assert_non_null(options->path);
-	assert_string_equal("/[0]/[0]", options->path);
+	assert_false(options->recursive);
+
+	/* test all options and arguments */
+	test_run_cmd(&info, "ls", "-r", "path");
+	assert_non_null(options->path);
+	assert_true(options->recursive);
+
 }
 
 static void
-value_dump_options_parsing(void **state)
+dump_value_options_parsing(void **state)
 {
-	struct ddb_cmd_info		 info = {0};
+	struct ddb_cmd_info	 info = {0};
 	struct dump_value_options	*options = &info.dci_cmd_option.dci_dump_value;
 
-	test_run_inval_cmd("dump_value"); /* no path to dump */
-	test_run_inval_cmd("dump_value", "this/is/a/path"); /* no destination path to dump to */
+	/* test invalid arguments and options */
+	test_run_inval_cmd("dump_value", "path", "dst", "extra"); /* too many argument */
+	test_run_inval_cmd("dump_value", "-z"); /* invalid option */
 
-	test_run_cmd(&info, "dump_value", "this/is/a/path", "/this/is/a/destination");
-	assert_string_equal("this/is/a/path", options->path);
-	assert_string_equal("/this/is/a/destination", options->dst);
+	/* test all arguments */
+	test_run_cmd(&info, "dump_value", "path", "dst");
+	assert_non_null(options->path);
+	assert_non_null(options->dst);
+
 }
 
 static void
-ilog_dump_parsing(void **state)
+rm_options_parsing(void **state)
 {
-	struct ddb_cmd_info		 info = {0};
+	struct ddb_cmd_info	 info = {0};
+	struct rm_options	*options = &info.dci_cmd_option.dci_rm;
+
+	/* test invalid arguments and options */
+	test_run_inval_cmd("rm", "path", "extra"); /* too many argument */
+	test_run_inval_cmd("rm", "-z"); /* invalid option */
+
+	/* test all arguments */
+	test_run_cmd(&info, "rm", "path");
+	assert_non_null(options->path);
+
+}
+
+static void
+load_options_parsing(void **state)
+{
+	struct ddb_cmd_info	 info = {0};
+	struct load_options	*options = &info.dci_cmd_option.dci_load;
+
+	/* test invalid arguments and options */
+	test_run_inval_cmd("load", "src", "dst", "epoch", "extra"); /* too many argument */
+	test_run_inval_cmd("load", "-z"); /* invalid option */
+
+	/* test all arguments */
+	test_run_cmd(&info, "load", "src", "dst", "epoch");
+	assert_non_null(options->src);
+	assert_non_null(options->dst);
+	assert_non_null(options->epoch);
+
+}
+
+static void
+dump_ilog_options_parsing(void **state)
+{
+	struct ddb_cmd_info	 info = {0};
 	struct dump_ilog_options	*options = &info.dci_cmd_option.dci_dump_ilog;
 
-	test_run_inval_cmd("dump_ilog"); /* no path to dump */
+	/* test invalid arguments and options */
+	test_run_inval_cmd("dump_ilog", "path", "extra"); /* too many argument */
+	test_run_inval_cmd("dump_ilog", "-z"); /* invalid option */
 
-	test_run_cmd(&info, "dump_ilog", "this/is/a/path");
-	assert_string_equal("this/is/a/path", options->path);
+	/* test all arguments */
+	test_run_cmd(&info, "dump_ilog", "path");
+	assert_non_null(options->path);
+
 }
 
 static void
-dtx_dump_parsing(void **state)
+process_ilog_options_parsing(void **state)
 {
-	struct ddb_cmd_info		 info = {0};
-	struct dump_dtx_options		*options = &info.dci_cmd_option.dci_dump_dtx;
+	struct ddb_cmd_info	 info = {0};
+	struct process_ilog_options	*options = &info.dci_cmd_option.dci_process_ilog;
 
-	test_run_inval_cmd("dump_dtx"); /* no path to dump */
-	test_run_inval_cmd("dump_dtx", "path", "-a", "-t");
+	/* test invalid arguments and options */
+	test_run_inval_cmd("process_ilog", "path", "extra"); /* too many argument */
+	test_run_inval_cmd("process_ilog", "-z"); /* invalid option */
 
+	/* test all arguments */
+	test_run_cmd(&info, "process_ilog", "path");
+	assert_non_null(options->path);
+
+}
+
+static void
+rm_ilog_options_parsing(void **state)
+{
+	struct ddb_cmd_info	 info = {0};
+	struct rm_ilog_options	*options = &info.dci_cmd_option.dci_rm_ilog;
+
+	/* test invalid arguments and options */
+	test_run_inval_cmd("rm_ilog", "path", "extra"); /* too many argument */
+	test_run_inval_cmd("rm_ilog", "-z"); /* invalid option */
+
+	/* test all arguments */
+	test_run_cmd(&info, "rm_ilog", "path");
+	assert_non_null(options->path);
+
+}
+
+static void
+dump_dtx_options_parsing(void **state)
+{
+	struct ddb_cmd_info	 info = {0};
+	struct dump_dtx_options	*options = &info.dci_cmd_option.dci_dump_dtx;
+
+	/* test invalid arguments and options */
+	test_run_inval_cmd("dump_dtx", "path", "extra"); /* too many argument */
+	test_run_inval_cmd("dump_dtx", "-z"); /* invalid option */
+
+	/* test all arguments */
 	test_run_cmd(&info, "dump_dtx", "path");
-	assert_int_equal(DDB_CMD_DUMP_DTX, info.dci_cmd);
-	assert_string_equal("path", options->path);
+	assert_non_null(options->path);
 	assert_false(options->active);
 	assert_false(options->committed);
 
-	test_run_cmd(&info, "dump_dtx", "path", "-a", "-c");
-	assert_string_equal("path", options->path);
-	assert_true(options->active);
-	assert_true(options->committed);
-
-	test_run_cmd(&info, "dump_dtx", "path", "-ac");
-	assert_string_equal("path", options->path);
+	/* test all options and arguments */
+	test_run_cmd(&info, "dump_dtx", "-a", "-c", "path");
+	assert_non_null(options->path);
 	assert_true(options->active);
 	assert_true(options->committed);
 }
 
 static void
-rm_parsing(void **state)
+clear_dtx_options_parsing(void **state)
 {
-	struct ddb_cmd_info		 info = {0};
-	struct rm_options		*options = &info.dci_cmd_option.dci_rm;
+	struct ddb_cmd_info	 info = {0};
+	struct clear_dtx_options	*options = &info.dci_cmd_option.dci_clear_dtx;
 
-	test_run_inval_cmd("rm"); /* no path to dump */
+	/* test invalid arguments and options */
+	test_run_inval_cmd("clear_dtx", "path", "extra"); /* too many argument */
+	test_run_inval_cmd("clear_dtx", "-z"); /* invalid option */
 
-	test_run_cmd(&info, "rm", "path");
-	assert_string_equal("path", options->path);
+	/* test all arguments */
+	test_run_cmd(&info, "clear_dtx", "path");
+	assert_non_null(options->path);
 }
-
-static void
-load_parsing(void **state)
-{
-	struct ddb_cmd_info		 info = {0};
-	struct load_options		*options = &info.dci_cmd_option.dci_load;
-
-	test_run_inval_cmd("load"); /* no file path to load or destination to load it to */
-	test_run_inval_cmd("load", "only_one_path"); /* no destination to load it to */
-
-	test_run_cmd(&info, "load", "src", "dst", "1");
-	assert_string_equal("src", options->src);
-	assert_string_equal("dst", options->dst);
-	assert_string_equal("1", options->epoch);
-}
-
 
 /*
  * -----------------------------------------------
@@ -173,12 +229,16 @@ ddb_cmd_options_tests_run()
 {
 	static const struct CMUnitTest tests[] = {
 		TEST(ls_options_parsing),
-		TEST(value_dump_options_parsing),
-		TEST(ilog_dump_parsing),
-		TEST(dtx_dump_parsing),
-		TEST(rm_parsing),
-		TEST(load_parsing),
+		TEST(dump_value_options_parsing),
+		TEST(rm_options_parsing),
+		TEST(load_options_parsing),
+		TEST(dump_ilog_options_parsing),
+		TEST(process_ilog_options_parsing),
+		TEST(rm_ilog_options_parsing),
+		TEST(dump_dtx_options_parsing),
+		TEST(clear_dtx_options_parsing),
 	};
+
 	return cmocka_run_group_tests_name("DDB commands option parsing tests", tests,
 					   NULL, NULL);
 }

--- a/src/ddb/tests/ddb_cmocka.h
+++ b/src/ddb/tests/ddb_cmocka.h
@@ -53,5 +53,6 @@
 			fail_msg("'%s' not found in '%s'", substr, str); \
 	} while (0)
 
+#define assert_invalid(x) assert_rc_equal(-DER_INVAL, (x))
 
 #endif /* DAOS_DDB_CMOCKA_H */

--- a/src/ddb/tests/ddb_commands_print_tests.c
+++ b/src/ddb/tests/ddb_commands_print_tests.c
@@ -34,12 +34,11 @@ print_object_test(void **state)
 	obj.ddbo_oid.lo = 1;
 	obj.ddbo_oid.hi = 10;
 	obj.ddbo_nr_grps = 2;
-	strcpy(obj.ddbo_obj_class_name, "TEST CLASS");
 	strcpy(obj.ddbo_otype_str, "TEST TYPE");
 
 	ddb_print_obj(&ctx, &obj, 1);
 
-	assert_str_exact("\t[2] '10.1' (class: TEST CLASS, type: TEST TYPE, groups: 2)\n");
+	assert_str_exact("\t[2] '10.1' (type: TEST TYPE, groups: 2)\n");
 }
 
 static void set_key_buf(struct ddb_key	*key, uint32_t len)
@@ -231,10 +230,10 @@ print_ilog_test(void **state)
 
 	ddb_print_ilog_entry(&ctx, &ilog);
 
-	assert_str_exact("Index: 1\n"
-			 "Status: TEST STATUS (1)\n"
-			 "Epoch: 1234567890\n"
-			 "Txn ID: 2\n");
+	assert_str("Index: 1\n");
+	assert_str("Status: TEST STATUS (1)\n");
+	assert_str("Epoch: 1234567890\n");
+	assert_str("Txn ID: 2\n");
 }
 
 static void
@@ -242,6 +241,7 @@ print_dtx_active(void **state)
 {
 	struct dv_dtx_active_entry entry = {
 		.ddtx_uuid = {0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc},
+		.ddtx_id_hlc = 1234,
 		.ddtx_reindex = false,
 		.ddtx_exist = true,
 		.ddtx_invalid = false,
@@ -265,6 +265,7 @@ print_dtx_active(void **state)
 	ddb_print_dtx_active(&ctx, &entry);
 
 	assert_str("UUID: 12345678-9abc-0000-0000-000000000000\n");
+	assert_str("ID HLC: 1234\n");
 	assert_str("Epoch: 99\n");
 	assert_str("Exist: true\n");
 	assert_str("Invalid: false\n");

--- a/src/ddb/tests/ddb_commands_print_tests.c
+++ b/src/ddb/tests/ddb_commands_print_tests.c
@@ -240,20 +240,9 @@ static void
 print_dtx_active(void **state)
 {
 	struct dv_dtx_active_entry entry = {
-		.ddtx_uuid = {0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc},
-		.ddtx_id_hlc = 1234,
-		.ddtx_reindex = false,
-		.ddtx_exist = true,
-		.ddtx_invalid = false,
+		.ddtx_id = {.dti_uuid = {0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc}, .dti_hlc = 0x1234},
 		.ddtx_handle_time = 12345690,
 		.ddtx_epoch = 99,
-		.ddtx_oid_cnt = 1,
-		.ddtx_start_time = 489387371,
-		.ddtx_committable = true,
-		.ddtx_committed = false,
-		.ddtx_aborted = false,
-		.ddtx_maybe_shared = true,
-		.ddtx_prepared = true,
 		.ddtx_grp_cnt = 3,
 		.ddtx_ver = 1,
 		.ddtx_rec_cnt = 1,
@@ -264,20 +253,9 @@ print_dtx_active(void **state)
 
 	ddb_print_dtx_active(&ctx, &entry);
 
-	assert_str("UUID: 12345678-9abc-0000-0000-000000000000\n");
-	assert_str("ID HLC: 1234\n");
+	assert_str("ID: 12345678.1234\n");
 	assert_str("Epoch: 99\n");
-	assert_str("Exist: true\n");
-	assert_str("Invalid: false\n");
-	assert_str("Reindex: false\n");
 	assert_str("Handle Time: 12345690\n");
-	assert_str("Oid Cnt: 1\n");
-	assert_str("Start Time: 489387371\n");
-	assert_str("Committable: true\n");
-	assert_str("Committed: false\n");
-	assert_str("Aborted: false\n");
-	assert_str("Maybe Shared: true\n");
-	assert_str("Prepared: true\n");
 	assert_str("Grp Cnt: 3\n");
 	assert_str("Ver: 1\n");
 	assert_str("Rec Cnt: 1\n");
@@ -291,17 +269,13 @@ print_dtx_committed(void **state)
 {
 	struct dv_dtx_committed_entry entry = {
 		.ddtx_epoch = 1234,
-		.ddtx_exist = true,
-		.ddtx_invalid = false,
-		.ddtx_uuid = {0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc},
+		.ddtx_id = {.dti_uuid = {0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc}, .dti_hlc = 0x1234},
 	};
 
 	ddb_print_dtx_committed(&ctx, &entry);
 
-	assert_str("UUID: 12345678-9abc-0000-0000-000000000000\n");
+	assert_str("ID: 12345678.1234\n");
 	assert_str("Epoch: 1234\n");
-	assert_str("Exist: true\n");
-	assert_str("Invalid: false\n");
 }
 
 static int

--- a/src/ddb/tests/ddb_commands_tests.c
+++ b/src/ddb/tests/ddb_commands_tests.c
@@ -23,7 +23,6 @@ struct ddb_ctx g_ctx = {
 	.dc_io_ft.ddb_read_file = dvt_fake_read_file,
 	.dc_io_ft.ddb_get_file_size = dvt_fake_get_file_size,
 	.dc_io_ft.ddb_get_file_exists = dvt_fake_get_file_exists,
-
 };
 
 static uint32_t fake_write_file_called;
@@ -103,15 +102,15 @@ dump_value_cmd_tests(void **state)
 	ctx.dc_poh = tctx->dvt_poh;
 
 	/* requires a path to dump */
-	assert_rc_equal(-DER_INVAL, ddb_run_dump_value(&ctx, &opt));
+	assert_invalid(ddb_run_dump_value(&ctx, &opt));
 
 	/* path must be complete (to a value) */
 	opt.path = "[0]";
-	assert_rc_equal(-DER_INVAL, ddb_run_dump_value(&ctx, &opt));
+	assert_invalid(ddb_run_dump_value(&ctx, &opt));
 
 	/* Path is complete, but needs destination */
 	opt.path = "[0]/[0]/[0]/[1]";
-	assert_rc_equal(-DER_INVAL, ddb_run_dump_value(&ctx, &opt));
+	assert_invalid(ddb_run_dump_value(&ctx, &opt));
 
 	/* success */
 	opt.dst = "/tmp/dumped_file";
@@ -131,7 +130,7 @@ dump_ilog_cmd_tests(void **state)
 	ctx.dc_io_ft.ddb_write_file = fake_write_file;
 	ctx.dc_poh = tctx->dvt_poh;
 
-	assert_rc_equal(-DER_INVAL, ddb_run_dump_ilog(&ctx, &opt));
+	assert_invalid(ddb_run_dump_ilog(&ctx, &opt));
 
 	/* Dump object ilog */
 	dvt_fake_print_called = 0;
@@ -146,7 +145,7 @@ dump_ilog_cmd_tests(void **state)
 	assert_true(dvt_fake_print_called);
 
 	opt.path = "[0]/[0]/[0]/[0]";
-	assert_rc_equal(-DER_INVAL, ddb_run_dump_ilog(&ctx, &opt));
+	assert_invalid(ddb_run_dump_ilog(&ctx, &opt));
 }
 
 static void
@@ -177,7 +176,7 @@ dump_dtx_cmd_tests(void **state)
 	ctx.dc_io_ft.ddb_print_error = dvt_fake_print;
 	ctx.dc_poh = tctx->dvt_poh;
 
-	assert_rc_equal(-DER_INVAL, ddb_run_dump_dtx(&ctx, &opt));
+	assert_invalid(ddb_run_dump_dtx(&ctx, &opt));
 
 	assert_success(vos_cont_open(tctx->dvt_poh, g_uuids[0], &coh));
 
@@ -202,7 +201,7 @@ rm_cmd_tests(void **state)
 	ctx.dc_io_ft.ddb_print_message = dvt_fake_print;
 	ctx.dc_io_ft.ddb_print_error = dvt_fake_print;
 
-	assert_rc_equal(-DER_INVAL, ddb_run_rm(&ctx, &opt));
+	assert_invalid(ddb_run_rm(&ctx, &opt));
 
 	dvt_fake_print_reset();
 	opt.path = "[0]";
@@ -218,14 +217,14 @@ load_cmd_tests(void **state)
 	char			buf[256];
 	daos_unit_oid_t		new_oid = g_oids[0];
 
-	assert_rc_equal(-DER_INVAL, ddb_run_load(&g_ctx, &opt));
+	assert_invalid(ddb_run_load(&g_ctx, &opt));
 
 	opt.dst = "/[0]/[0]/[0]/[1]";
 	opt.src = "/tmp/value_src";
 	opt.epoch = "1";
 	dvt_fake_get_file_exists_result = true;
 	snprintf(dvt_fake_read_file_buf, ARRAY_SIZE(dvt_fake_read_file_buf), "Some text");
-	assert_rc_equal(-DER_INVAL, ddb_run_load(&g_ctx, &opt));
+	assert_invalid(ddb_run_load(&g_ctx, &opt));
 	dvt_fake_get_file_size_result = strlen(dvt_fake_read_file_buf);
 	dvt_fake_read_file_result = strlen(dvt_fake_read_file_buf);
 	assert_success(ddb_run_load(&g_ctx, &opt));
@@ -251,19 +250,19 @@ load_cmd_tests(void **state)
 
 	/* File not found */
 	dvt_fake_get_file_exists_result = false;
-	assert_rc_equal(-DER_INVAL, ddb_run_load(&g_ctx, &opt));
+	assert_invalid(ddb_run_load(&g_ctx, &opt));
 	dvt_fake_get_file_exists_result = true;
 
 	/* invalid epoch */
 	opt.epoch = "a";
-	assert_rc_equal(-DER_INVAL, ddb_run_load(&g_ctx, &opt));
+	assert_invalid(ddb_run_load(&g_ctx, &opt));
 	opt.epoch = "1a";
-	assert_rc_equal(-DER_INVAL, ddb_run_load(&g_ctx, &opt));
+	assert_invalid(ddb_run_load(&g_ctx, &opt));
 	opt.epoch = "1";
 
 	/* incomplete path */
 	opt.dst = "/[0]/[0]/";
-	assert_rc_equal(-DER_INVAL, ddb_run_load(&g_ctx, &opt));
+	assert_invalid(ddb_run_load(&g_ctx, &opt));
 
 	/* Can't use index for a new path */
 	opt.dst = "/[0]/[0]/[0]/[9999]";
@@ -274,6 +273,47 @@ load_cmd_tests(void **state)
 		DP_OID(g_oids[0].id_pub));
 	opt.dst = buf;
 	assert_rc_equal(-DER_NONEXIST, ddb_run_load(&g_ctx, &opt));
+}
+
+static void
+rm_ilog_cmd_tests(void **state)
+{
+	struct rm_ilog_options opt = {0};
+
+	assert_invalid(ddb_run_rm_ilog(&g_ctx, &opt));
+	opt.path = "[0]"; /* just container ... bad */
+	assert_invalid(ddb_run_rm_ilog(&g_ctx, &opt));
+
+	opt.path = "[1]/[0]"; /* object */
+	assert_success(ddb_run_rm_ilog(&g_ctx, &opt));
+	opt.path = "[2]/[0]/[0]"; /* dkey */
+	assert_success(ddb_run_rm_ilog(&g_ctx, &opt));
+}
+
+static void
+process_ilog_cmd_tests(void **state)
+{
+	struct process_ilog_options opt = {0};
+
+	assert_invalid(ddb_run_process_ilog(&g_ctx, &opt));
+	opt.path = "[0]"; /* just container ... bad */
+	assert_invalid(ddb_run_process_ilog(&g_ctx, &opt));
+
+	opt.path = "[1]/[0]"; /* object */
+	assert_success(ddb_run_process_ilog(&g_ctx, &opt));
+	opt.path = "[2]/[0]/[0]"; /* dkey */
+	assert_success(ddb_run_process_ilog(&g_ctx, &opt));
+}
+
+static void
+clear_dtx_cmd_tests(void **state)
+{
+	struct clear_dtx_options opt = {0};
+
+	assert_invalid(ddb_run_clear_dtx(&g_ctx, &opt));
+
+	opt.path = "[0]";
+	assert_success(ddb_run_clear_dtx(&g_ctx, &opt));
 }
 
 /*
@@ -325,7 +365,11 @@ dvc_tests_run()
 		TEST(dump_dtx_cmd_tests),
 		TEST(rm_cmd_tests),
 		TEST(load_cmd_tests),
+		TEST(rm_ilog_cmd_tests),
+		TEST(process_ilog_cmd_tests),
+		TEST(clear_dtx_cmd_tests),
 	};
+
 	return cmocka_run_group_tests_name("DDB commands tests", tests,
 					   dcv_suit_setup, dcv_suit_teardown);
 }

--- a/src/ddb/tests/ddb_commands_tests.c
+++ b/src/ddb/tests/ddb_commands_tests.c
@@ -144,8 +144,9 @@ dump_ilog_cmd_tests(void **state)
 	assert_success(ddb_run_dump_ilog(&ctx, &opt));
 	assert_true(dvt_fake_print_called);
 
+	/* Dump akey ilog */
 	opt.path = "[0]/[0]/[0]/[0]";
-	assert_invalid(ddb_run_dump_ilog(&ctx, &opt));
+	assert_success(ddb_run_dump_ilog(&ctx, &opt));
 }
 
 static void
@@ -293,27 +294,27 @@ rm_ilog_cmd_tests(void **state)
 static void
 process_ilog_cmd_tests(void **state)
 {
-	struct process_ilog_options opt = {0};
+	struct commit_ilog_options opt = {0};
 
-	assert_invalid(ddb_run_process_ilog(&g_ctx, &opt));
+	assert_invalid(ddb_run_commit_ilog(&g_ctx, &opt));
 	opt.path = "[0]"; /* just container ... bad */
-	assert_invalid(ddb_run_process_ilog(&g_ctx, &opt));
+	assert_invalid(ddb_run_commit_ilog(&g_ctx, &opt));
 
 	opt.path = "[1]/[0]"; /* object */
-	assert_success(ddb_run_process_ilog(&g_ctx, &opt));
+	assert_success(ddb_run_commit_ilog(&g_ctx, &opt));
 	opt.path = "[2]/[0]/[0]"; /* dkey */
-	assert_success(ddb_run_process_ilog(&g_ctx, &opt));
+	assert_success(ddb_run_commit_ilog(&g_ctx, &opt));
 }
 
 static void
-clear_dtx_cmd_tests(void **state)
+clear_cmt_dtx_cmd_tests(void **state)
 {
-	struct clear_dtx_options opt = {0};
+	struct clear_cmt_dtx_options opt = {0};
 
-	assert_invalid(ddb_run_clear_dtx(&g_ctx, &opt));
+	assert_invalid(ddb_run_clear_cmt_dtx(&g_ctx, &opt));
 
 	opt.path = "[0]";
-	assert_success(ddb_run_clear_dtx(&g_ctx, &opt));
+	assert_success(ddb_run_clear_cmt_dtx(&g_ctx, &opt));
 }
 
 /*
@@ -367,7 +368,7 @@ dvc_tests_run()
 		TEST(load_cmd_tests),
 		TEST(rm_ilog_cmd_tests),
 		TEST(process_ilog_cmd_tests),
-		TEST(clear_dtx_cmd_tests),
+		TEST(clear_cmt_dtx_cmd_tests),
 	};
 
 	return cmocka_run_group_tests_name("DDB commands tests", tests,

--- a/src/ddb/tests/ddb_smoke_tests.sh
+++ b/src/ddb/tests/ddb_smoke_tests.sh
@@ -43,45 +43,51 @@ function run_cmd() {
 run_cmd ddb_tests -c
 vos_file=/mnt/daos/12345678-1234-1234-1234-123456789012/ddb_vos_test
 
-msg "'ls' commands"
-run_cmd ddb $vos_file -R 'ls'
-run_cmd ddb $vos_file -R 'ls 12345678-1234-1234-1234-123456789001'
-run_cmd ddb $vos_file -R 'ls [0]'
-run_cmd ddb $vos_file -R 'ls [0]/[1]'
-run_cmd ddb $vos_file -R 'ls [0]/[1] -r'
+#msg "'ls' commands"
+#run_cmd ddb $vos_file -R 'ls'
+#run_cmd ddb $vos_file -R 'ls 12345678-1234-1234-1234-123456789001'
+#run_cmd ddb $vos_file -R 'ls [0]'
+#run_cmd ddb $vos_file -R 'ls [0]/[1]'
+#run_cmd ddb $vos_file -R 'ls [0]/[1] -r'
+#
+#msg "'dump' and 'load' commands"
+#vos_path="[0]/[0]/[0]/[1]"
+#echo 'echo "A New Value" > /tmp/ddb_new_value'
+#echo "A New Value" > /tmp/ddb_new_value
+#
+#run_cmd ddb $vos_file -R "dump_value $vos_path /tmp/ddb_value_dump"
+#run_cmd cat /tmp/ddb_value_dump
+#run_cmd ddb $vos_file -R "dump_value [0]/[0]/[0]/[0]/[0] /tmp/ddb_value_dump"
+#run_cmd cat /tmp/ddb_value_dump
+#
+#run_cmd ddb $vos_file -R "load /tmp/ddb_new_value $vos_path 2"
+#run_cmd ddb $vos_file -R "dump_value $vos_path /tmp/ddb_value_dump"
+#run_cmd cat /tmp/ddb_value_dump
+#run_cmd diff /tmp/ddb_new_value /tmp/ddb_value_dump
+#
+#msg "'load' to new key"
+#vos_path="[0]/[0]/[0]/\'new_new_new_new_key\'"
+#
+#run_cmd ddb $vos_file -R "load /tmp/ddb_new_value $vos_path 1"
+#run_cmd ddb $vos_file -R "dump_value $vos_path /tmp/ddb_value_dump"
+#run_cmd cat /tmp/ddb_value_dump
+#run_cmd ddb $vos_file -R 'ls [0]/[0]/[0] -r'
+#diff /tmp/ddb_new_value /tmp/ddb_value_dump
+#
+#msg "'rm'"
+#run_cmd ddb $vos_file -R 'ls'
+#run_cmd ddb $vos_file -R 'rm [1]'
+#run_cmd ddb $vos_file -R 'ls'
 
-msg "'dump' and 'load' commands"
-vos_path="[0]/[0]/[0]/[1]"
-echo 'echo "A New Value" > /tmp/ddb_new_value'
-echo "A New Value" > /tmp/ddb_new_value
-
-run_cmd ddb $vos_file -R "dump_value $vos_path /tmp/ddb_value_dump"
-run_cmd cat /tmp/ddb_value_dump
-run_cmd ddb $vos_file -R "dump_value [0]/[0]/[0]/[0]/[0] /tmp/ddb_value_dump"
-run_cmd cat /tmp/ddb_value_dump
-
-run_cmd ddb $vos_file -R "load /tmp/ddb_new_value $vos_path 2"
-run_cmd ddb $vos_file -R "dump_value $vos_path /tmp/ddb_value_dump"
-run_cmd cat /tmp/ddb_value_dump
-run_cmd diff /tmp/ddb_new_value /tmp/ddb_value_dump
-
-msg "'load' to new key"
-vos_path="[0]/[0]/[0]/\'new_new_new_new_key\'"
-
-run_cmd ddb $vos_file -R "load /tmp/ddb_new_value $vos_path 1"
-run_cmd ddb $vos_file -R "dump_value $vos_path /tmp/ddb_value_dump"
-run_cmd cat /tmp/ddb_value_dump
-run_cmd ddb $vos_file -R 'ls [0]/[0]/[0] -r'
-diff /tmp/ddb_new_value /tmp/ddb_value_dump
 
 msg "'superblock', 'ilog' and 'dtx' dumps"
 run_cmd ddb $vos_file -R 'dump_superblock'
 run_cmd ddb $vos_file -R 'dump_ilog [0]/[0]'
 run_cmd ddb $vos_file -R 'dump_ilog [0]/[0]/[0]'
+run_cmd ddb $vos_file -R 'process_ilog [0]/[0]/[0]'
+run_cmd ddb $vos_file -R 'rm_ilog [1]/[0]/[0]'
+
 
 run_cmd ddb $vos_file -R 'dump_dtx [0]'
-
-msg "'rm'"
-run_cmd ddb $vos_file -R 'ls'
-run_cmd ddb $vos_file -R 'rm [1]'
-run_cmd ddb $vos_file -R 'ls'
+run_cmd ddb $vos_file -R 'clear_dtx [0]'
+run_cmd ddb $vos_file -R 'dump_dtx [0]'

--- a/src/ddb/tests/ddb_smoke_tests.sh
+++ b/src/ddb/tests/ddb_smoke_tests.sh
@@ -43,51 +43,52 @@ function run_cmd() {
 run_cmd ddb_tests -c
 vos_file=/mnt/daos/12345678-1234-1234-1234-123456789012/ddb_vos_test
 
-#msg "'ls' commands"
-#run_cmd ddb $vos_file -R 'ls'
-#run_cmd ddb $vos_file -R 'ls 12345678-1234-1234-1234-123456789001'
-#run_cmd ddb $vos_file -R 'ls [0]'
-#run_cmd ddb $vos_file -R 'ls [0]/[1]'
-#run_cmd ddb $vos_file -R 'ls [0]/[1] -r'
-#
-#msg "'dump' and 'load' commands"
-#vos_path="[0]/[0]/[0]/[1]"
-#echo 'echo "A New Value" > /tmp/ddb_new_value'
-#echo "A New Value" > /tmp/ddb_new_value
-#
-#run_cmd ddb $vos_file -R "dump_value $vos_path /tmp/ddb_value_dump"
-#run_cmd cat /tmp/ddb_value_dump
-#run_cmd ddb $vos_file -R "dump_value [0]/[0]/[0]/[0]/[0] /tmp/ddb_value_dump"
-#run_cmd cat /tmp/ddb_value_dump
-#
-#run_cmd ddb $vos_file -R "load /tmp/ddb_new_value $vos_path 2"
-#run_cmd ddb $vos_file -R "dump_value $vos_path /tmp/ddb_value_dump"
-#run_cmd cat /tmp/ddb_value_dump
-#run_cmd diff /tmp/ddb_new_value /tmp/ddb_value_dump
-#
-#msg "'load' to new key"
-#vos_path="[0]/[0]/[0]/\'new_new_new_new_key\'"
-#
-#run_cmd ddb $vos_file -R "load /tmp/ddb_new_value $vos_path 1"
-#run_cmd ddb $vos_file -R "dump_value $vos_path /tmp/ddb_value_dump"
-#run_cmd cat /tmp/ddb_value_dump
-#run_cmd ddb $vos_file -R 'ls [0]/[0]/[0] -r'
-#diff /tmp/ddb_new_value /tmp/ddb_value_dump
-#
-#msg "'rm'"
-#run_cmd ddb $vos_file -R 'ls'
-#run_cmd ddb $vos_file -R 'rm [1]'
-#run_cmd ddb $vos_file -R 'ls'
+msg "'ls' commands"
+run_cmd ddb $vos_file -R 'ls'
+run_cmd ddb $vos_file -R 'ls 12345678-1234-1234-1234-123456789001'
+run_cmd ddb $vos_file -R 'ls [0]'
+run_cmd ddb $vos_file -R 'ls [0]/[1]'
+run_cmd ddb $vos_file -R 'ls [0]/[1] -r'
+
+msg "'dump' and 'load' commands"
+vos_path="[0]/[0]/[0]/[2]"
+echo 'echo "A New Value" > /tmp/ddb_new_value'
+echo "A New Value" > /tmp/ddb_new_value
+
+run_cmd ddb $vos_file -R "ls -r $vos_path"
+run_cmd ddb $vos_file -R "dump_value $vos_path /tmp/ddb_value_dump"
+run_cmd cat /tmp/ddb_value_dump
+run_cmd ddb $vos_file -R "dump_value [0]/[0]/[0]/[1]/[0] /tmp/ddb_value_dump"
+run_cmd cat /tmp/ddb_value_dump
+
+run_cmd ddb $vos_file -R "load /tmp/ddb_new_value $vos_path 2"
+run_cmd ddb $vos_file -R "dump_value $vos_path /tmp/ddb_value_dump"
+run_cmd cat /tmp/ddb_value_dump
+run_cmd diff /tmp/ddb_new_value /tmp/ddb_value_dump
+
+msg "'load' to new key"
+vos_path="[0]/[0]/[0]/\'new_new_new_new_key\'"
+
+run_cmd ddb $vos_file -R "load /tmp/ddb_new_value $vos_path 1"
+run_cmd ddb $vos_file -R "dump_value $vos_path /tmp/ddb_value_dump"
+run_cmd cat /tmp/ddb_value_dump
+run_cmd ddb $vos_file -R 'ls [0]/[0]/[0] -r'
+diff /tmp/ddb_new_value /tmp/ddb_value_dump
+
+msg "'rm'"
+run_cmd ddb $vos_file -R 'ls'
+run_cmd ddb $vos_file -R 'rm [1]'
+run_cmd ddb $vos_file -R 'ls'
 
 
 msg "'superblock', 'ilog' and 'dtx' dumps"
 run_cmd ddb $vos_file -R 'dump_superblock'
 run_cmd ddb $vos_file -R 'dump_ilog [0]/[0]'
 run_cmd ddb $vos_file -R 'dump_ilog [0]/[0]/[0]'
-run_cmd ddb $vos_file -R 'process_ilog [0]/[0]/[0]'
+run_cmd ddb $vos_file -R 'dump_ilog [0]/[0]/[0]/[0]'
+run_cmd ddb $vos_file -R 'commit_ilog [0]/[0]/[0]/[0]'
 run_cmd ddb $vos_file -R 'rm_ilog [1]/[0]/[0]'
 
-
 run_cmd ddb $vos_file -R 'dump_dtx [0]'
-run_cmd ddb $vos_file -R 'clear_dtx [0]'
+run_cmd ddb $vos_file -R 'clear_cmt_dtx [0]'
 run_cmd ddb $vos_file -R 'dump_dtx [0]'

--- a/src/ddb/tests/ddb_vos_tests.c
+++ b/src/ddb/tests/ddb_vos_tests.c
@@ -840,7 +840,7 @@ clear_committed_table(void **state)
 
 	dvt_vos_insert_2_records_with_dtx(coh);
 
-	assert_success(dv_clear_committed_table(coh));
+	assert_int_equal(1, dv_clear_committed_table(coh));
 
 	entry_handler_called = 0;
 	dv_committed_dtx(coh, committed_entry_handler, NULL);


### PR DESCRIPTION
Introduce the commands to process and remove ilogs and
committed dtx entries. Also added a help command.

Signed-off-by: Ryon Jensen <ryon.jensen@intel.com>