### PR TITLE
DAOS-10535 tests: Add daos-tests-internal package

### DIFF
--- a/.rpmignore
+++ b/.rpmignore
@@ -7,16 +7,19 @@ centos7/daos-client-tests-openmpi*.rpm
 centos7/daos-firmware*.rpm
 centos7/daos-serialize*.rpm
 centos7/daos-server-tests-openmpi*.rpm
+centos7/daos-tests-internal*.rpm
 
 el8/daos-client-tests-openmpi*.rpm
 el8/daos-firmware*.rpm
 el8/daos-serialize*.rpm
 el8/daos-server-tests-openmpi*.rpm
+el8/daos-tests-internal*.rpm
 
 leap15/daos-client-tests-openmpi*.rpm
 leap15/daos-firmware*.rpm
 leap15/daos-serialize*.rpm
 leap15/daos-server-tests-openmpi*.rpm
+leap15/daos-tests-internal*.rpm
 
 ubuntu20.04/daos-*.deb
 ubuntu20.04/libdaos*.deb

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,6 +13,7 @@
 // To use a test branch (i.e. PR) until it lands to master
 // I.e. for testing library changes
 //@Library(value="pipeline-lib@your_branch") _
+@Library(value="pipeline-lib@DAOS-10535") _
 
 // For master, this is just some wildly high number
 next_version = "2.1.0"
@@ -694,8 +695,7 @@ pipeline {
                     }
                     steps {
                         functionalTest inst_repos: daosRepos(),
-                                       inst_rpms: functionalPackages(1, next_version,
-                                                                     "{client,server}-tests-openmpi"),
+                                       inst_rpms: functionalPackages(1, next_version),
                                        test_function: 'runTestFunctionalV2'
                     }
                     post {
@@ -714,8 +714,7 @@ pipeline {
                     }
                     steps {
                         functionalTest inst_repos: daosRepos(),
-                                       inst_rpms: functionalPackages(1, next_version,
-                                                                     "{client,server}-tests-openmpi"),
+                                       inst_rpms: functionalPackages(1, next_version),
                                        test_function: 'runTestFunctionalV2'
                     }
                     post {
@@ -734,8 +733,7 @@ pipeline {
                     }
                     steps {
                         functionalTest inst_repos: daosRepos(),
-                                       inst_rpms: functionalPackages(1, next_version,
-                                                                     "{client,server}-tests-openmpi"),
+                                       inst_rpms: functionalPackages(1, next_version),
                                        test_function: 'runTestFunctionalV2'
                     }
                     post {
@@ -754,8 +752,7 @@ pipeline {
                     }
                     steps {
                         functionalTest inst_repos: daosRepos(),
-                                       inst_rpms: functionalPackages(1, next_version,
-                                                                     "{client,server}-tests-openmpi"),
+                                       inst_rpms: functionalPackages(1, next_version),
                                        test_function: 'runTestFunctionalV2'
                     }
                     post {
@@ -774,8 +771,7 @@ pipeline {
                     }
                     steps {
                         functionalTest inst_repos: daosRepos(),
-                                       inst_rpms: functionalPackages(1, next_version,
-                                                                     "{client,server}-tests-openmpi"),
+                                       inst_rpms: functionalPackages(1, next_version),
                                        test_function: 'runTestFunctionalV2'
                     }
                     post {
@@ -922,8 +918,7 @@ pipeline {
             }
             steps {
                 storagePrepTest inst_repos: daosRepos(),
-                                inst_rpms: functionalPackages(1, next_version,
-                                                              "{client,server}-tests-openmpi")
+                                inst_rpms: functionalPackages(1, next_version)
             }
         } // stage('Test Storage Prep')
         stage('Test Hardware') {
@@ -943,8 +938,7 @@ pipeline {
                     }
                     steps {
                         functionalTest inst_repos: daosRepos(),
-                                       inst_rpms: functionalPackages(1, next_version,
-                                                                     "{client,server}-tests-openmpi"),
+                                       inst_rpms: functionalPackages(1, next_version),
                                        test_function: 'runTestFunctionalV2'
                     }
                     post {
@@ -964,8 +958,7 @@ pipeline {
                     }
                     steps {
                         functionalTest inst_repos: daosRepos(),
-                                       inst_rpms: functionalPackages(1, next_version,
-                                                                     "{client,server}-tests-openmpi"),
+                                       inst_rpms: functionalPackages(1, next_version),
                                        test_function: 'runTestFunctionalV2'
                    }
                     post {
@@ -985,8 +978,7 @@ pipeline {
                     }
                     steps {
                         functionalTest inst_repos: daosRepos(),
-                                       inst_rpms: functionalPackages(1, next_version,
-                                                                     "{client,server}-tests-openmpi"),
+                                       inst_rpms: functionalPackages(1, next_version),
                                        test_function: 'runTestFunctionalV2'
                     }
                     post {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,7 +13,6 @@
 // To use a test branch (i.e. PR) until it lands to master
 // I.e. for testing library changes
 //@Library(value="pipeline-lib@your_branch") _
-@Library(value="pipeline-lib@DAOS-10535") _
 
 // For master, this is just some wildly high number
 next_version = "2.1.0"
@@ -695,7 +694,8 @@ pipeline {
                     }
                     steps {
                         functionalTest inst_repos: daosRepos(),
-                                       inst_rpms: functionalPackages(1, next_version),
+                                       inst_rpms: functionalPackages(1, next_version,
+                                                                     "{client,server}-tests-openmpi"),
                                        test_function: 'runTestFunctionalV2'
                     }
                     post {
@@ -714,7 +714,8 @@ pipeline {
                     }
                     steps {
                         functionalTest inst_repos: daosRepos(),
-                                       inst_rpms: functionalPackages(1, next_version),
+                                       inst_rpms: functionalPackages(1, next_version,
+                                                                     "{client,server}-tests-openmpi"),
                                        test_function: 'runTestFunctionalV2'
                     }
                     post {
@@ -733,7 +734,8 @@ pipeline {
                     }
                     steps {
                         functionalTest inst_repos: daosRepos(),
-                                       inst_rpms: functionalPackages(1, next_version),
+                                       inst_rpms: functionalPackages(1, next_version,
+                                                                     "{client,server}-tests-openmpi"),
                                        test_function: 'runTestFunctionalV2'
                     }
                     post {
@@ -752,7 +754,8 @@ pipeline {
                     }
                     steps {
                         functionalTest inst_repos: daosRepos(),
-                                       inst_rpms: functionalPackages(1, next_version),
+                                       inst_rpms: functionalPackages(1, next_version,
+                                                                     "{client,server}-tests-openmpi"),
                                        test_function: 'runTestFunctionalV2'
                     }
                     post {
@@ -771,7 +774,8 @@ pipeline {
                     }
                     steps {
                         functionalTest inst_repos: daosRepos(),
-                                       inst_rpms: functionalPackages(1, next_version),
+                                       inst_rpms: functionalPackages(1, next_version,
+                                                                     "{client,server}-tests-openmpi"),
                                        test_function: 'runTestFunctionalV2'
                     }
                     post {
@@ -918,7 +922,8 @@ pipeline {
             }
             steps {
                 storagePrepTest inst_repos: daosRepos(),
-                                inst_rpms: functionalPackages(1, next_version)
+                                inst_rpms: functionalPackages(1, next_version,
+                                                              "{client,server}-tests-openmpi")
             }
         } // stage('Test Storage Prep')
         stage('Test Hardware') {
@@ -938,7 +943,8 @@ pipeline {
                     }
                     steps {
                         functionalTest inst_repos: daosRepos(),
-                                       inst_rpms: functionalPackages(1, next_version),
+                                       inst_rpms: functionalPackages(1, next_version,
+                                                                     "{client,server}-tests-openmpi"),
                                        test_function: 'runTestFunctionalV2'
                     }
                     post {
@@ -958,7 +964,8 @@ pipeline {
                     }
                     steps {
                         functionalTest inst_repos: daosRepos(),
-                                       inst_rpms: functionalPackages(1, next_version),
+                                       inst_rpms: functionalPackages(1, next_version,
+                                                                     "{client,server}-tests-openmpi"),
                                        test_function: 'runTestFunctionalV2'
                    }
                     post {
@@ -978,7 +985,8 @@ pipeline {
                     }
                     steps {
                         functionalTest inst_repos: daosRepos(),
-                                       inst_rpms: functionalPackages(1, next_version),
+                                       inst_rpms: functionalPackages(1, next_version,
+                                                                     "{client,server}-tests-openmpi"),
                                        test_function: 'runTestFunctionalV2'
                     }
                     post {

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+daos (2.0.2-5) unstable; urgency=medium
+  [ Phillip Henderson ]
+  * Add daos-tests-internal package
+
+ -- Phillip Henderson <phillip.henderson@intel.com>  Thu, 12 May 2022 11:43:00 -0400
+
 daos (2.0.2-4) unstable; urgency=medium
   [ Lei Huang ]
   * Update libfabric to v1.15.0rc3-1 with critical performance patches

--- a/debian/control
+++ b/debian/control
@@ -98,6 +98,16 @@ Description: This is the package is a metapackage to install all of the test pac
  .
  This package contains tests
 
+Package: daos-tests-internal
+Architecture: any
+Multi-Arch: same
+Depends: daos-tests (= ${binary:Version}),
+         daos-client-tests-openmpi (= ${binary:Version}),
+         daos-server-tests-openmpi (= ${binary:Version})
+Description: This is the package is a metapackage to install all of the internal test packages
+ .
+ This package contains tests
+
 Package: daos-client-tests
 Architecture: any
 Multi-Arch: same

--- a/utils/rpms/daos.spec
+++ b/utils/rpms/daos.spec
@@ -524,6 +524,9 @@ getent passwd daos_agent >/dev/null || useradd -s /sbin/nologin -r -g daos_agent
 %files tests
 # No files in a meta-package
 
+%files tests-internal
+# No files in a meta-package
+
 %changelog
 * Thu May 12 2022 Phillip Henderson <phillip.henderson@intel.com> 2.0.2-5
 - Add daos-tests-internal package

--- a/utils/rpms/daos.spec
+++ b/utils/rpms/daos.spec
@@ -14,7 +14,7 @@
 
 Name:          daos
 Version:       2.0.2
-Release:       4%{?relval}%{?dist}
+Release:       5%{?relval}%{?dist}
 Summary:       DAOS Storage Engine
 
 License:       BSD-2-Clause-Patent
@@ -207,6 +207,15 @@ Requires: %{name}-server-tests%{?_isa} = %{version}-%{release}
 
 %description tests
 This is the package is a metapackage to install all of the test packages
+
+%package tests-internal
+Summary: The entire DAOS internal test suite
+Requires: %{name}-tests%{?_isa} = %{version}-%{release}
+Requires: %{name}-client-tests-openmpi%{?_isa} = %{version}-%{release}
+Requires: %{name}-server-tests-openmpi%{?_isa} = %{version}-%{release}
+
+%description tests-internal
+This is the package is a metapackage to install all of the internal test packages
 
 %package client-tests
 Summary: The DAOS test suite
@@ -516,6 +525,9 @@ getent passwd daos_agent >/dev/null || useradd -s /sbin/nologin -r -g daos_agent
 # No files in a meta-package
 
 %changelog
+* Thu May 12 2022 Phillip Henderson <phillip.henderson@intel.com> 2.0.2-5
+- Add daos-tests-internal package
+
 * Wed Apr 20 2022 Lei Huang <lei.huang@intel.com> 2.0.2-4
 - Update libfabric to v1.15.0rc3-1 with critical performance patches
 


### PR DESCRIPTION
Creating the daos-tests-internal metadata package to provide all the
test packages required for functional testing in CI.

Signed-off-by: Phillip Henderson <phillip.henderson@intel.com>