### PR TITLE
DAOS-10194 candidate fix no added logging DO NOT LAND

### DIFF
--- a/src/container/container_iv.c
+++ b/src/container/container_iv.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2019-2021 Intel Corporation.
+ * (C) Copyright 2019-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -552,13 +552,6 @@ cont_iv_ent_update(struct ds_iv_entry *entry, struct ds_iv_key *key,
 	d_iov_set(&key_iov, &civ_key->cont_uuid, sizeof(civ_key->cont_uuid));
 	if (src == NULL) {
 		/* If src == NULL, it is invalidate */
-		if (entry->iv_class->iv_class_id == IV_CONT_CAPA &&
-		    !uuid_is_null(civ_key->cont_uuid)) {
-			rc = ds_cont_tgt_close(civ_key->cont_uuid);
-			if (rc)
-				D_GOTO(out, rc);
-		}
-
 		if (uuid_is_null(civ_key->cont_uuid)) {
 			rc = dbtree_empty(root_hdl);
 			if (rc)
@@ -568,6 +561,12 @@ cont_iv_ent_update(struct ds_iv_entry *entry, struct ds_iv_key *key,
 					   NULL);
 			if (rc == -DER_NONEXIST)
 				rc = 0;
+		}
+		if (entry->iv_class->iv_class_id == IV_CONT_CAPA &&
+		    !uuid_is_null(civ_key->cont_uuid)) {
+			rc = ds_cont_tgt_close(civ_key->cont_uuid);
+			if (rc)
+				D_GOTO(out, rc);
 		}
 	} else {
 		struct cont_iv_entry *iv_entry;


### PR DESCRIPTION
Let's delete IV entry before container handle, which might yield,
to avoid inflight I/O might re-open/start the container through IV
at the same time.

Test-tag: pr daily_regression

Signed-off-by: Di Wang <di.wang@intel.com>
Signed-off-by: Kenneth Cain <kenneth.c.cain@intel.com>