### PR TITLE
DAOS-10596 test: Increase the csum_basic test timeout

### DIFF
--- a/src/tests/ftest/checksum/csum_basic.yaml
+++ b/src/tests/ftest/checksum/csum_basic.yaml
@@ -5,7 +5,7 @@ hosts:
   - server-A
  test_clients:
   - client-B
-timeout: 60
+timeout: 100
 server_config:
  name: daos_server
 pool:


### PR DESCRIPTION
Test-tag: basic_checksum_object
Test-repeat: 10

Summary:
   Increase the test timeout due intermittent failures noticed under VM.

Signed-off-by: rpadma2 <ravindran.padmanabhan@intel.com>