### PR TITLE
DAOS-10466 test: improve dfusespacecheck

### DIFF
--- a/src/tests/ftest/aggregation/dfuse_space_check.yaml
+++ b/src/tests/ftest/aggregation/dfuse_space_check.yaml
@@ -15,14 +15,14 @@ server_config:
 pool:
   mode: 146
   name: daos_server
-  scm_size: 200000000
-  nvme_size: 1073741824
+  scm_size: 200MB
+  nvme_size: 1GiB # Minimum for 1 target
   svcn: 1
   control_method: dmg
 container:
   type: POSIX
   control_method: daos
 dfusespacecheck:
-  block_size: 2097152
+  block_size: 2097152 # 2M
 dfuse:
   mount_dir: "/tmp/daos_dfuse/"


### PR DESCRIPTION
Test-tag: dfusespacecheck
Test-repeat: 5
Skip-unit-tests: true
Skip-fault-injection-test: true

- Use int type for dd count
- Better logging
- Cleanup some functions
- Disable aggregation when writing files to get accurate space
  measurement

Signed-off-by: Dalton Bohning <dalton.bohning@intel.com>