### PR TITLE
DAOS-10579 tools: Ensure daos list-container JSON is lowercase

### DIFF
--- a/src/control/lib/ui/flags.go
+++ b/src/control/lib/ui/flags.go
@@ -30,8 +30,8 @@ var (
 // LabelOrUUIDFlag is used to hold a pool or container ID supplied
 // via command-line argument.
 type LabelOrUUIDFlag struct {
-	UUID  uuid.UUID
-	Label string
+	UUID  uuid.UUID `json:"uuid"`
+	Label string    `json:"label"`
 }
 
 // Empty returns true if neither UUID or Label were set.

--- a/src/tests/ftest/container/list.py
+++ b/src/tests/ftest/container/list.py
@@ -46,7 +46,7 @@ class ListContainerTest(TestWithServers):
         data = self.daos_cmd.container_list(pool=pool_uuid)
         actual_uuids = []
         for uuid_label in data["response"]:
-            actual_uuids.append(uuid_label["UUID"])
+            actual_uuids.append(uuid_label["uuid"])
         actual_uuids.sort()
 
         self.assertEqual(expected_uuids, actual_uuids)

--- a/src/tests/ftest/control/dmg_pool_evict.py
+++ b/src/tests/ftest/control/dmg_pool_evict.py
@@ -79,7 +79,7 @@ class DmgPoolEvictTest(TestWithServers):
         # upper case since we use upper case in object.
         uuids_cmd = []
         for uuid_label in data["response"]:
-            uuids_cmd.append(uuid_label["UUID"].upper())
+            uuids_cmd.append(uuid_label["uuid"].upper())
         uuids_obj = []
         for cont in self.container[1:]:
             uuids_obj.append(cont.uuid)

--- a/src/tests/ftest/nvme/enospace.py
+++ b/src/tests/ftest/nvme/enospace.py
@@ -73,7 +73,7 @@ class NvmeEnospace(ServerFillUp):
         #List all the container
         kwargs = {"pool": self.pool.uuid}
         data = self.daos_cmd.container_list(**kwargs)
-        containers = [uuid_label["UUID"] for uuid_label in data["response"]]
+        containers = [uuid_label["uuid"] for uuid_label in data["response"]]
 
         #Destroy all the containers
         for _cont in containers:

--- a/src/tests/ftest/util/daos_utils.py
+++ b/src/tests/ftest/util/daos_utils.py
@@ -258,12 +258,12 @@ class DaosCommand(DaosCommandBase):
         # {
         #   "response": [
         #     {
-        #       "UUID": "bad80a98-aabd-498c-b001-6547cd061c8c",
-        #       "Label": "container_label_not_set"
+        #       "uuid": "bad80a98-aabd-498c-b001-6547cd061c8c",
+        #       "label": "container_label_not_set"
         #     },
         #     {
-        #       "UUID": "dd9fc365-5729-4736-9d34-e46504a4a92d",
-        #       "Label": "mkc1"
+        #       "uuid": "dd9fc365-5729-4736-9d34-e46504a4a92d",
+        #       "label": "mkc1"
         #     }
         #   ],
         #   "error": null,


### PR DESCRIPTION
The default behavior is to use CamelCase; just add json: tags
to the struct fields to make them snake_case.

Features: container

Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com>
