### PR TITLE
DAOS-10346 test: Fix tests to use the existing container uuid instead…

### DIFF
--- a/src/tests/ftest/nvme/enospace.py
+++ b/src/tests/ftest/nvme/enospace.py
@@ -100,8 +100,11 @@ class NvmeEnospace(ServerFillUp):
 
         # Define the job manager for the IOR command
         job_manager = get_job_manager(self, "Mpirun", ior_bg_cmd, mpi_type="mpich")
-        self.create_cont()
-        job_manager.job.dfs_cont.update(self.container.uuid)
+
+        # create container
+        container = self.get_container(self.pool)
+
+        job_manager.job.dfs_cont.update(container.uuid)
         env = ior_bg_cmd.get_default_env(str(job_manager))
         job_manager.assign_hosts(self.hostlist_clients, self.workdir, None)
         job_manager.assign_processes(1)

--- a/src/tests/ftest/nvme/enospace.yaml
+++ b/src/tests/ftest/nvme/enospace.yaml
@@ -45,8 +45,8 @@ dmg:
 pool:
     mode: 146
     name: daos_server
-    scm_size: 5368709120 #5G
-    nvme_size: 5368709120 #5G
+    scm_size: 5G
+    nvme_size: 5G
     control_method: dmg
 container:
     control_method: daos
@@ -60,12 +60,8 @@ ior:
       flags: "-w -F -k -G 1"
       read_flags: "-r -R -F -k -G 1"
   test_file: /testFile
-  repetitions: 1
   transfersize_blocksize:
     2K:
       transfer_size: 2048 #2K
     16M:
       nvme_transfer_size: 16777216 #16M
-  objectclass:
-    S1:
-      obj_class: "S1"

--- a/src/tests/ftest/nvme/fault.yaml
+++ b/src/tests/ftest/nvme/fault.yaml
@@ -45,7 +45,7 @@ dmg:
 pool:
     mode: 146
     name: daos_server
-    scm_size: 53687091200 #50GB
+    scm_size: 50GB
     control_method: dmg
 container:
     type: POSIX
@@ -59,26 +59,17 @@ ior:
   iorflags:
       flags: "-w -F -r -R -k -G 1"
   test_file: /testFile
-  repetitions: 1
   transfersize_blocksize:
-    16M:
-      transfer_size: 16777216 #16M
-  objectclass:
-    RP_2G1:
-      dfs_oclass: "RP_2G1"
-  objectdirclass:
-    RP_2G1:
-      dfs_dir_oclass: "RP_2G1"
+      nvme_transfer_size: 16777216 #16M
+  dfs_oclass: "RP_2G1"
+  dfs_dir_oclass: "RP_2G1"
 faulttests:
   pool_capacity:
     10_Percent:
       percentage: 10
-  no_of_servers: !mux
+  no_of_servers:
     single:
       count: 1
-# Skipped because of DAOS-5281
-#    Two:
-#      count: 2
   no_of_drives:
     single:
       count: 1

--- a/src/tests/ftest/util/ec_utils.py
+++ b/src/tests/ftest/util/ec_utils.py
@@ -82,6 +82,7 @@ class ErasureCodeIor(ServerFillUp):
         self.cont_uuid = []
         self.cont_number = 0
         self.read_set_from_beginning = True
+        self.nvme_local_cont = None
 
     def setUp(self):
         """Set up each test case."""
@@ -108,12 +109,14 @@ class ErasureCodeIor(ServerFillUp):
         # update object class for container create, if supplied explicitly.
         ec_object = get_data_parity_number(self.log, oclass)
         rf = "rf:{}".format(ec_object['parity'])
-        if self.container.properties.value is None:
+        if self.ec_container.properties.value is None:
             self.ec_container.properties.update(rf)
         else:
-            self.ec_container.properties.update("{},{}".format(self.container.properties.value, rf))
+            self.ec_container.properties.update("{},{}"
+                                                .format(self.ec_container.properties.value, rf))
         # create container
         self.ec_container.create()
+        self.nvme_local_cont = self.ec_container
 
     def ior_param_update(self, oclass, sizes):
         """Update the IOR command parameters.
@@ -154,7 +157,6 @@ class ErasureCodeIor(ServerFillUp):
         self.update_ior_cmd_with_pool(create_cont=False)
 
         # Start IOR Write
-        self.container.uuid = self.ec_container.uuid
         self.start_ior_load(storage, operation, percent, create_cont=False)
 
         # Store the container UUID for future reading
@@ -192,7 +194,7 @@ class ErasureCodeIor(ServerFillUp):
         self.ior_param_update(oclass, sizes)
 
         # retrieve the container UUID to read the existing data
-        self.container.uuid = self.cont_uuid[self.cont_number]
+        self.nvme_local_cont.uuid = self.cont_uuid[self.cont_number]
 
         # Start IOR Read
         self.start_ior_load(storage, operation, percent, create_cont=False)

--- a/src/tests/ftest/util/nvme_utils.py
+++ b/src/tests/ftest/util/nvme_utils.py
@@ -72,6 +72,7 @@ class ServerFillUp(IorTestBase):
         self.fail_on_warning = False
         self.rank_to_kill = []
         self.pool_exclude = {}
+        self.nvme_local_cont = None
 
     def setUp(self):
         """Set up each test case."""
@@ -92,6 +93,16 @@ class ServerFillUp(IorTestBase):
         self.engines = self.server_managers[0].manager.job.yaml.engine_params
         self.dmg_command = self.get_dmg_command()
 
+    def create_container(self):
+        """Create the container """
+        self.nvme_local_cont = self.get_container(self.pool, create=False)
+
+        # update container oclass
+        if self.ior_local_cmd.dfs_oclass:
+            self.nvme_local_cont.oclass.update(self.ior_local_cmd.dfs_oclass.value)
+
+        self.nvme_local_cont.create()
+
     def start_ior_thread(self, create_cont, operation):
         """Start IOR write/read threads and wait until all threads are finished.
 
@@ -102,7 +113,7 @@ class ServerFillUp(IorTestBase):
                 Auto_Write/Auto_Read: It will calculate the IOR block size based on requested
                                         storage % to be fill.
         """
-        # IOR flag can be Write only or Write/Read based on test yaml
+        # IOR flag can Write/Read based on test yaml
         self.ior_local_cmd.flags.value = self.ior_default_flags
 
         # Calculate the block size based on server % to fill up.
@@ -118,11 +129,10 @@ class ServerFillUp(IorTestBase):
         self.ior_local_cmd.set_daos_params(self.server_group, self.pool)
         self.ior_local_cmd.test_file.update('/testfile')
 
-        # Created new container
+        # Created new container or use the existing container for reading
         if create_cont:
-            self.create_cont()
-        else:
-            self.ior_local_cmd.dfs_cont.update(self.container.uuid)
+            self.create_container()
+        self.ior_local_cmd.dfs_cont.update(self.nvme_local_cont.uuid)
 
         # Define the job manager for the IOR command
         job_manager_main = get_job_manager(self, "Mpirun", self.ior_local_cmd, mpi_type="mpich")


### PR DESCRIPTION
… of creating new one (#8726)

- nvme fault Test was failing as it was not using the correct container uuid.
- changed enospace code to use it's own container to avoid conflict with
   nvme util container which runs in background
- Updated nvme utility to create it's own container instead to avoid the
  conflicts when tests are run in threads
- Removed the skip test as DAOS-5281 as it's not valid test case.

Signed-off-by: Samir Raval <samir.raval@intel.com>