### PR TITLE
DAOS-10465 vos: Avoid using aggregation optimization on v2.0 pool (#8953)

### DIFF
--- a/src/container/srv_target.c
+++ b/src/container/srv_target.c
@@ -90,7 +90,7 @@ ds_cont_get_props(struct cont_props *cont_props, uuid_t pool_uuid,
 	/* The provided prop entry types should cover the types used in
 	 * daos_props_2cont_props().
 	 */
-	props = daos_prop_alloc(12);
+	props = daos_prop_alloc(13);
 	if (props == NULL)
 		return -DER_NOMEM;
 
@@ -106,6 +106,7 @@ ds_cont_get_props(struct cont_props *cont_props, uuid_t pool_uuid,
 	props->dpp_entries[9].dpe_type = DAOS_PROP_CO_EC_CELL_SZ;
 	props->dpp_entries[10].dpe_type = DAOS_PROP_CO_EC_PDA;
 	props->dpp_entries[11].dpe_type = DAOS_PROP_CO_RP_PDA;
+	props->dpp_entries[12].dpe_type = DAOS_PROP_CO_GLOBAL_VERSION;
 
 	rc = cont_iv_prop_fetch(pool_uuid, cont_uuid, props);
 	if (rc == DER_SUCCESS)

--- a/src/include/daos_srv/pool.h
+++ b/src/include/daos_srv/pool.h
@@ -47,6 +47,7 @@ struct ds_pool {
 	uint32_t		sp_ec_pda;
 	/* Performance Domain Affinity Level of replicated object */
 	uint32_t		sp_rp_pda;
+	uint32_t		sp_global_version;
 	crt_group_t	       *sp_group;
 	struct policy_desc_t	sp_policy_desc;	/* tiering policy descriptor */
 	ABT_mutex		sp_mutex;

--- a/src/include/daos_srv/vos.h
+++ b/src/include/daos_srv/vos.h
@@ -289,6 +289,14 @@ int
 vos_pool_open(const char *path, uuid_t uuid, unsigned int flags,
 	      daos_handle_t *poh);
 
+/** Enable any version specific features on the pool
+ *
+ * \param poh	[IN]	Container open handle
+ * \param feats	[IN]	Features to enable
+ */
+void
+vos_pool_features_set(daos_handle_t poh, uint64_t feats);
+
 /**
  * Extended vos_pool_open() with an additional 'metrics' parameter to VOS telemetry.
  */

--- a/src/include/daos_srv/vos_types.h
+++ b/src/include/daos_srv/vos_types.h
@@ -257,6 +257,11 @@ enum {
 	VOS_OF_EC			= (1 << 19),
 };
 
+enum {
+	/** Aggregation optimization is enabled for this pool */
+	VOS_POOL_FEAT_AGG_OPT	= (1 << 0),
+};
+
 /** Mask for any conditionals passed to to the fetch */
 #define VOS_COND_FETCH_MASK	\
 	(VOS_OF_COND_AKEY_FETCH | VOS_OF_COND_DKEY_FETCH)

--- a/src/object/obj_internal.h
+++ b/src/object/obj_internal.h
@@ -204,6 +204,7 @@ struct migrate_pool_tls {
 	/* POOL UUID and pool to be migrated */
 	uuid_t			mpt_pool_uuid;
 	struct ds_pool_child	*mpt_pool;
+	uint64_t		mpt_global_version;
 	unsigned int		mpt_version;
 
 	/* Link to the migrate_pool_tls list */

--- a/src/object/srv_obj_migrate.c
+++ b/src/object/srv_obj_migrate.c
@@ -359,6 +359,7 @@ struct migrate_pool_tls_create_arg {
 	uuid_t  co_hdl_uuid;
 	d_rank_list_t *svc_list;
 	uint64_t max_eph;
+	uint64_t global_version;
 	int	version;
 	uint32_t opc;
 };
@@ -399,6 +400,7 @@ migrate_pool_tls_create_one(void *data)
 	uuid_copy(pool_tls->mpt_pool_uuid, arg->pool_uuid);
 	uuid_copy(pool_tls->mpt_poh_uuid, arg->pool_hdl_uuid);
 	uuid_copy(pool_tls->mpt_coh_uuid, arg->co_hdl_uuid);
+	pool_tls->mpt_global_version = arg->global_version;
 	pool_tls->mpt_version = arg->version;
 	pool_tls->mpt_rec_count = 0;
 	pool_tls->mpt_obj_count = 0;
@@ -454,6 +456,11 @@ migrate_pool_tls_lookup_create(struct ds_pool *pool, int version,
 
 	entry = daos_prop_entry_get(prop, DAOS_PROP_PO_SVC_LIST);
 	D_ASSERT(entry != NULL);
+	arg.svc_list = (d_rank_list_t *)entry->dpe_val_ptr;
+	arg.global_version = 0;
+	entry = daos_prop_entry_get(prop, DAOS_PROP_PO_GLOBAL_VERSION);
+	if (entry != NULL)
+		arg.global_version = entry->dpe_val;
 
 	uuid_copy(arg.pool_uuid, pool->sp_uuid);
 	uuid_copy(arg.pool_hdl_uuid, pool_hdl_uuid);
@@ -461,7 +468,7 @@ migrate_pool_tls_lookup_create(struct ds_pool *pool, int version,
 	arg.version = version;
 	arg.opc = opc;
 	arg.max_eph = max_eph;
-	arg.svc_list = (d_rank_list_t *)entry->dpe_val_ptr;
+
 	rc = dss_task_collective(migrate_pool_tls_create_one, &arg, 0);
 	if (rc != 0) {
 		D_ERROR(DF_UUID": failed to create migrate tls: "DF_RC"\n",
@@ -1391,6 +1398,9 @@ migrate_get_cont_child(struct migrate_pool_tls *tls, uuid_t cont_uuid,
 			return rc;
 		}
 	}
+
+	if (tls->mpt_global_version >= 1)
+		vos_pool_features_set(cont_child->sc_pool->spc_hdl, VOS_POOL_FEAT_AGG_OPT);
 
 	*cont_p = cont_child;
 	return rc;

--- a/src/pool/srv_target.c
+++ b/src/pool/srv_target.c
@@ -1469,6 +1469,7 @@ update_vos_prop_on_targets(void *in)
 	struct ds_pool_child		*child = NULL;
 	struct policy_desc_t		policy_desc = {0};
 	int				ret = 0;
+	uint64_t			features = 0;
 
 	child = ds_pool_child_lookup(pool->sp_uuid);
 	if (child == NULL)
@@ -1476,6 +1477,10 @@ update_vos_prop_on_targets(void *in)
 
 	policy_desc = pool->sp_policy_desc;
 	ret = vos_pool_ctl(child->spc_hdl, VOS_PO_CTL_SET_POLICY, &policy_desc);
+
+	if (pool->sp_global_version >= 1)
+		features = VOS_POOL_FEAT_AGG_OPT;
+	vos_pool_features_set(child->spc_hdl, features);
 	ds_pool_child_put(child);
 
 	return ret;
@@ -1488,6 +1493,7 @@ ds_pool_tgt_prop_update(struct ds_pool *pool, struct pool_iv_prop *iv_prop)
 
 	D_ASSERT(dss_get_module_info()->dmi_xs_id == 0);
 	pool->sp_ec_cell_sz = iv_prop->pip_ec_cell_sz;
+	pool->sp_global_version = iv_prop->pip_global_version;
 	pool->sp_reclaim = iv_prop->pip_reclaim;
 	pool->sp_redun_fac = iv_prop->pip_redun_fac;
 	pool->sp_ec_pda = iv_prop->pip_ec_pda;

--- a/src/tests/vos_engine.c
+++ b/src/tests/vos_engine.c
@@ -76,6 +76,8 @@ engine_cont_init(struct credit_context *tsc)
 	if (rc)
 		return rc;
 
+	vos_pool_features_set(tsc->tsc_poh, VOS_POOL_FEAT_AGG_OPT);
+
 	tsc->tsc_coh = coh;
 	return rc;
 }

--- a/src/vos/tests/vts_common.c
+++ b/src/vos/tests/vts_common.c
@@ -127,6 +127,8 @@ vts_ctx_init(struct vos_test_ctx *tcx, size_t psize)
 		print_error("vos container open error: "DF_RC"\n", DP_RC(rc));
 		goto failed;
 	}
+
+	vos_pool_features_set(tcx->tc_po_hdl, VOS_POOL_FEAT_AGG_OPT);
 	tcx->tc_step = TCX_READY;
 	return 0;
 
@@ -309,6 +311,7 @@ cont_init(struct credit_context *tsc)
 	if (rc)
 		goto out;
 
+	vos_pool_features_set(tsc->tsc_poh, VOS_POOL_FEAT_AGG_OPT);
 	tsc->tsc_coh = coh;
  out:
 	return rc;

--- a/src/vos/vos_container.c
+++ b/src/vos/vos_container.c
@@ -92,7 +92,7 @@ cont_df_rec_alloc(struct btr_instance *tins, d_iov_t *key_iov,
 	cont_df = umem_off2ptr(&tins->ti_umm, offset);
 	uuid_copy(cont_df->cd_id, ukey->uuid);
 
-	rc = dbtree_create_inplace_ex(VOS_BTR_OBJ_TABLE, VOS_TF_AGG_OPT, VOS_OBJ_ORDER,
+	rc = dbtree_create_inplace_ex(VOS_BTR_OBJ_TABLE, 0, VOS_OBJ_ORDER,
 				      &pool->vp_uma, &cont_df->cd_obj_root,
 				      DAOS_HDL_INVAL, pool, &hdl);
 	if (rc) {

--- a/src/vos/vos_internal.h
+++ b/src/vos/vos_internal.h
@@ -205,6 +205,8 @@ struct vos_pool {
 	struct umem_instance	vp_umm;
 	/** Size of pool file */
 	uint64_t		vp_size;
+	/** Features enabled for this pool */
+	uint64_t		vp_feats;
 	/** btr handle for the container table */
 	daos_handle_t		vp_cont_th;
 	/** GC statistics of this pool */
@@ -1484,7 +1486,7 @@ recx_csum_len(daos_recx_t *recx, struct dcs_csum_info *csum,
 
 /** Mark that the object and container need aggregation.
  *
- * \param[in] umm	umem instance
+ * \param[in] cont	VOS container
  * \param[in] dkey_root	Root of dkey tree (marked for object)
  * \param[in] obj_root	Root of object tree (marked for container)
  * \param[in] epoch	Epoch of aggregatable update
@@ -1492,19 +1494,19 @@ recx_csum_len(daos_recx_t *recx, struct dcs_csum_info *csum,
  * \return 0 on success, error otherwise
  */
 int
-vos_mark_agg(struct umem_instance *umm, struct btr_root *dkey_root, struct btr_root *obj_root,
+vos_mark_agg(struct vos_container *cont, struct btr_root *dkey_root, struct btr_root *obj_root,
 	     daos_epoch_t epoch);
 
 /** Mark that the key needs aggregation.
  *
- * \param[in] umm	umem instance
+ * \param[in] cont	VOS container
  * \param[in] krec	The key's record
  * \param[in] epoch	Epoch of aggregatable update
  *
  * \return 0 on success, error otherwise
  */
 int
-vos_key_mark_agg(struct umem_instance *umm, struct vos_krec_df *krec, daos_epoch_t epoch);
+vos_key_mark_agg(struct vos_container *cont, struct vos_krec_df *krec, daos_epoch_t epoch);
 
 static inline bool
 vos_anchor_is_zero(daos_anchor_t *anchor)

--- a/src/vos/vos_io.c
+++ b/src/vos/vos_io.c
@@ -1647,8 +1647,14 @@ vos_btr_mark_agg(struct umem_instance *umm, struct btr_root *root, daos_epoch_t 
 }
 
 int
-vos_key_mark_agg(struct umem_instance *umm, struct vos_krec_df *krec, daos_epoch_t epoch)
+vos_key_mark_agg(struct vos_container *cont, struct vos_krec_df *krec, daos_epoch_t epoch)
 {
+	struct umem_instance	*umm;
+
+	if ((cont->vc_pool->vp_feats & VOS_POOL_FEAT_AGG_OPT) == 0)
+		return 0;
+
+	umm = vos_cont2umm(cont);
 	if (krec->kr_bmap & KREC_BF_BTR)
 		return vos_btr_mark_agg(umm, &krec->kr_btr, epoch);
 
@@ -1656,11 +1662,16 @@ vos_key_mark_agg(struct umem_instance *umm, struct vos_krec_df *krec, daos_epoch
 }
 
 int
-vos_mark_agg(struct umem_instance *umm, struct btr_root *dkey_root, struct btr_root *obj_root,
+vos_mark_agg(struct vos_container *cont, struct btr_root *dkey_root, struct btr_root *obj_root,
 	     daos_epoch_t epoch)
 {
-	int	rc;
+	struct umem_instance	*umm;
+	int			 rc;
 
+	if ((cont->vc_pool->vp_feats & VOS_POOL_FEAT_AGG_OPT) == 0)
+		return 0;
+
+	umm = vos_cont2umm(cont);
 	rc = vos_btr_mark_agg(umm, dkey_root, epoch);
 	if (rc == 0)
 		rc = vos_btr_mark_agg(umm, obj_root, epoch);
@@ -1674,7 +1685,7 @@ vos_ioc_mark_agg(struct vos_io_context *ioc)
 	if (!ioc->ic_agg_needed)
 		return 0;
 
-	return vos_mark_agg(vos_ioc2umm(ioc), &ioc->ic_obj->obj_df->vo_tree,
+	return vos_mark_agg(ioc->ic_cont, &ioc->ic_obj->obj_df->vo_tree,
 			    &ioc->ic_cont->vc_cont_df->cd_obj_root, ioc->ic_epr.epr_hi);
 }
 
@@ -1800,7 +1811,7 @@ out:
 		key_tree_release(toh, is_array);
 
 	if (rc == 0 && ioc->ic_agg_needed)
-		rc = vos_key_mark_agg(vos_ioc2umm(ioc), krec, ioc->ic_epr.epr_hi);
+		rc = vos_key_mark_agg(ioc->ic_cont, krec, ioc->ic_epr.epr_hi);
 
 	return rc;
 }
@@ -1872,7 +1883,7 @@ release:
 	key_tree_release(ak_toh, false);
 
 	if (rc == 0 && ioc->ic_agg_needed)
-		rc = vos_key_mark_agg(vos_ioc2umm(ioc), krec, ioc->ic_epr.epr_hi);
+		rc = vos_key_mark_agg(ioc->ic_cont, krec, ioc->ic_epr.epr_hi);
 
 	return rc;
 }

--- a/src/vos/vos_layout.h
+++ b/src/vos/vos_layout.h
@@ -89,8 +89,16 @@ enum vos_gc_type {
 
 /** Lowest supported durable format version */
 #define POOL_DF_VER_1				23
+/** Minimum pool version for built-in aggregation optimization. Otherwise,
+ *  the optimization can only be enabled by a pool upgrade which sets the global
+ *  version but doesn't update the durable format.  If both the durable format
+ *  and global version remain as currently set, the optimization is disabled.
+ *  This enables the user to continue using the pool with the older version unless
+ *  they have explicitly upgraded it.
+ */
+#define POOL_DF_AGG_OPT				24
 /** Current durable format version */
-#define POOL_DF_VERSION				POOL_DF_VER_1
+#define POOL_DF_VERSION				POOL_DF_AGG_OPT
 
 /**
  * Durable format for VOS pool

--- a/src/vos/vos_obj.c
+++ b/src/vos/vos_obj.c
@@ -315,7 +315,7 @@ key_punch(struct vos_object *obj, daos_epoch_t epoch, daos_epoch_t bound,
 	if (rc != 1) {
 		/** key_tree_punch will handle dkey flags if punch is propagated */
 		if (rc == 0)
-			rc = vos_key_mark_agg(vos_cont2umm(obj->obj_cont), krec, epoch);
+			rc = vos_key_mark_agg(obj->obj_cont, krec, epoch);
 		goto out;
 	}
 	/** else propagate the punch */
@@ -504,7 +504,7 @@ vos_obj_punch(daos_handle_t coh, daos_unit_oid_t oid, daos_epoch_t epoch,
 			}
 
 			if (rc == 0)
-				rc = vos_mark_agg(vos_cont2umm(cont), &obj->obj_df->vo_tree,
+				rc = vos_mark_agg(cont, &obj->obj_df->vo_tree,
 						  &cont->vc_cont_df->cd_obj_root, epoch);
 
 			vos_obj_release(vos_obj_cache_current(), obj, rc != 0);

--- a/src/vos/vos_pool.c
+++ b/src/vos/vos_pool.c
@@ -768,6 +768,8 @@ pool_open(PMEMobjpool *ph, struct vos_pool_df *pool_df, uuid_t uuid,
 	pool->vp_opened = 1;
 	pool->vp_excl = !!(flags & VOS_POF_EXCL);
 	pool->vp_small = !!(flags & VOS_POF_SMALL);
+	if (pool_df->pd_version >= POOL_DF_AGG_OPT)
+		pool->vp_feats |= VOS_POOL_FEAT_AGG_OPT;
 
 	vos_space_sys_init(pool);
 	/* Ensure GC is triggered after server restart */
@@ -877,6 +879,17 @@ int
 vos_pool_open(const char *path, uuid_t uuid, unsigned int flags, daos_handle_t *poh)
 {
 	return vos_pool_open_metrics(path, uuid, flags, NULL, poh);
+}
+
+void
+vos_pool_features_set(daos_handle_t poh, uint64_t feats)
+{
+	struct vos_pool	*pool;
+
+	pool = vos_hdl2pool(poh);
+	D_ASSERT(pool != NULL);
+
+	pool->vp_feats |= feats;
 }
 
 /**

--- a/src/vos/vos_tree.c
+++ b/src/vos/vos_tree.c
@@ -16,7 +16,7 @@
 #include <daos_srv/vos.h>
 #include "vos_internal.h"
 
-uint64_t vos_evt_feats = EVT_FEAT_SORT_DIST | VOS_TF_AGG_OPT;
+uint64_t vos_evt_feats = EVT_FEAT_SORT_DIST;
 
 /**
  * VOS Btree attributes, for tree registration and tree creation.
@@ -869,7 +869,7 @@ tree_open_create(struct vos_object *obj, enum vos_tree_class tclass, int flags,
 		}
 	} else {
 		struct vos_btr_attr	*ta;
-		uint64_t		 tree_feats = VOS_TF_AGG_OPT;
+		uint64_t		 tree_feats = 0;
 
 		/* Step-1: find the btree attributes and create btree */
 		if (tclass == VOS_BTR_DKEY) {
@@ -1123,7 +1123,7 @@ key_tree_punch(struct vos_object *obj, daos_handle_t toh, daos_epoch_t epoch,
 		*known_key |= 0x1;
 	}
 
-	rc = vos_key_mark_agg(vos_obj2umm(obj), krec, epoch);
+	rc = vos_key_mark_agg(obj->obj_cont, krec, epoch);
 done:
 	VOS_TX_LOG_FAIL(rc, "Failed to punch key: "DF_RC"\n", DP_RC(rc));
 
@@ -1149,7 +1149,7 @@ obj_tree_init(struct vos_object *obj)
 
 	D_ASSERT(obj->obj_df);
 	if (obj->obj_df->vo_tree.tr_class == 0) {
-		uint64_t tree_feats = VOS_TF_AGG_OPT;
+		uint64_t tree_feats = 0;
 		enum daos_otype_t type;
 
 		D_DEBUG(DB_DF, "Create btree for object\n");


### PR DESCRIPTION
Explicitly enable the optimization when the GLOBAL_VERSION is >= 1.
DAOS 2.0 has no such property so the global version will be 0. This
should allow us to use a 2.0 pool even if it's been touched by 2.2

For pools that are created with 2.2, we set an new durable format version
such that this feature is always enabled. This maintains compatibility with
the old durable format up until a pool upgrade.

Also added #9034 to this patch.

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>