### PR TITLE
DAOS-10580 control: Fix dmg storage query usage output with dual-engi…

### DIFF
--- a/src/control/common/pci_utils.go
+++ b/src/control/common/pci_utils.go
@@ -24,6 +24,8 @@ const (
 	vmdDomainLen = 6
 )
 
+var ErrNotVMDBackingAddress = errors.New("not a vmd backing device address")
+
 // parsePCIAddress returns separated components of BDF format PCI address.
 func parsePCIAddress(addr string) (dom, bus, dev, fun uint64, err error) {
 	parts := strings.Split(addr, ":")
@@ -89,7 +91,7 @@ func (pa *PCIAddress) BackingToVMDAddress() (*PCIAddress, error) {
 		return nil, errors.New("PCIAddress is nil")
 	}
 	if !pa.IsVMDBackingAddress() {
-		return nil, errors.New("not a vmd backing device address")
+		return nil, ErrNotVMDBackingAddress
 
 	}
 

--- a/src/control/server/server.go
+++ b/src/control/server/server.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2018-2021 Intel Corporation.
+// (C) Copyright 2018-2022 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -266,7 +266,9 @@ func (srv *server) addEngines(ctx context.Context) error {
 			return err
 		}
 
-		engine.storage.SetBdevCache(*nvmeScanResp)
+		if err := engine.storage.SetBdevCache(*nvmeScanResp); err != nil {
+			return errors.Wrap(err, "setting engine storage bdev cache")
+		}
 
 		registerEngineEventCallbacks(engine, srv.hostname, srv.pubSub, &allStarted)
 

--- a/src/control/server/storage/bdev_test.go
+++ b/src/control/server/storage/bdev_test.go
@@ -1,0 +1,82 @@
+//
+// (C) Copyright 2022 Intel Corporation.
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+
+package storage
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/daos-stack/daos/src/control/common"
+	"github.com/google/go-cmp/cmp"
+)
+
+func Test_filterBdevScanResponse(t *testing.T) {
+	const (
+		vmdAddr1         = "0000:5d:05.5"
+		vmdBackingAddr1a = "5d0505:01:00.0"
+		vmdBackingAddr1b = "5d0505:03:00.0"
+		vmdAddr2         = "0000:7d:05.5"
+		vmdBackingAddr2a = "7d0505:01:00.0"
+		vmdBackingAddr2b = "7d0505:03:00.0"
+	)
+	ctrlrsFromPCIAddrs := func(addrs ...string) (ncs NvmeControllers) {
+		for _, addr := range addrs {
+			ncs = append(ncs, &NvmeController{PciAddr: addr})
+		}
+		return
+	}
+
+	for name, tc := range map[string]struct {
+		addrs    []string
+		scanResp *BdevScanResponse
+		expAddrs []string
+		expErr   error
+	}{
+		"two vmd endpoints; one filtered out": {
+			addrs: []string{vmdAddr2},
+			scanResp: &BdevScanResponse{
+				Controllers: ctrlrsFromPCIAddrs(vmdBackingAddr1a, vmdBackingAddr1b,
+					vmdBackingAddr2a, vmdBackingAddr2b),
+			},
+			expAddrs: []string{vmdBackingAddr2a, vmdBackingAddr2b},
+		},
+		"two ssds; one filtered out": {
+			addrs: []string{"0000:81:00.0"},
+			scanResp: &BdevScanResponse{
+				Controllers: ctrlrsFromPCIAddrs("0000:81:00.0", "0000:de:00.0"),
+			},
+			expAddrs: []string{"0000:81:00.0"},
+		},
+		"two aio kdev paths; both filtered out": {
+			addrs: []string{"/dev/sda"},
+			scanResp: &BdevScanResponse{
+				Controllers: ctrlrsFromPCIAddrs("/dev/sda", "/dev/sdb"),
+			},
+			expAddrs: []string{},
+		},
+		"bad address; filtered out": {
+			addrs: []string{"0000:81:00.0"},
+			scanResp: &BdevScanResponse{
+				Controllers: ctrlrsFromPCIAddrs("0000:81.00.0"),
+			},
+			expAddrs: []string{},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			gotErr := filterBdevScanResponse(tc.addrs, tc.scanResp)
+			common.CmpErr(t, tc.expErr, gotErr)
+			if gotErr != nil {
+				return
+			}
+
+			expAddrStr := strings.Join(tc.expAddrs, ", ")
+			if diff := cmp.Diff(expAddrStr, tc.scanResp.Controllers.String()); diff != "" {
+				t.Fatalf("unexpected output addresses (-want, +got):\n%s\n", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
…nes (#8945)

dmg storage query usage is only reporting half the expected NVMe usage
values in a dual engine setup.

The last engine's scan response will overwrite valid stats written by
previous engine because the bdev cache contains all engine's controllers.

Fix by filtering cache to include only controllers configured on engine.

Features: control

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>