### PR TITLE
DAOS-10580 control: Fix dmg storage query usage output with dual-engi…

### DIFF
--- a/src/control/lib/hardware/pci.go
+++ b/src/control/lib/hardware/pci.go
@@ -28,6 +28,8 @@ const (
 	PCIAddrBusBitSize = 8
 )
 
+var ErrNotVMDBackingAddress = errors.New("not a vmd backing device address")
+
 // parseVMDAddress returns the domain string interpreted as the VMD address.
 func parseVMDAddress(addr string) (*PCIAddress, error) {
 	if len(addr) != vmdDomainLen {
@@ -165,8 +167,7 @@ func (pa *PCIAddress) BackingToVMDAddress() (*PCIAddress, error) {
 		return nil, errors.New("PCIAddress is nil")
 	}
 	if !pa.IsVMDBackingAddress() {
-		return nil, errors.New("not a vmd backing device address")
-
+		return nil, ErrNotVMDBackingAddress
 	}
 
 	return pa.VMDAddr, nil

--- a/src/control/server/server.go
+++ b/src/control/server/server.go
@@ -304,7 +304,9 @@ func (srv *server) addEngines(ctx context.Context) error {
 			return errors.Wrap(err, "creating engine instances")
 		}
 
-		engine.storage.SetBdevCache(*nvmeScanResp)
+		if err := engine.storage.SetBdevCache(*nvmeScanResp); err != nil {
+			return errors.Wrap(err, "setting engine storage bdev cache")
+		}
 
 		registerEngineEventCallbacks(srv, engine, &allStarted)
 

--- a/src/control/server/storage/bdev/backend_vmd.go
+++ b/src/control/server/storage/bdev/backend_vmd.go
@@ -21,22 +21,16 @@ import (
 	"github.com/daos-stack/daos/src/control/server/storage"
 )
 
+// getVMD returns VMD endpoint address when provided string is a VMD backing device PCI address.
+// If the input string is not a VMD backing device PCI address, hardware.ErrNotVMDBackingAddress
+// is returned.
 func getVMD(inAddr string) (*hardware.PCIAddress, error) {
 	addr, err := hardware.NewPCIAddress(inAddr)
 	if err != nil {
 		return nil, errors.Wrap(err, "controller pci address invalid")
 	}
 
-	if !addr.IsVMDBackingAddress() {
-		return nil, nil
-	}
-
-	vmdAddr, err := addr.BackingToVMDAddress()
-	if err != nil {
-		return nil, err
-	}
-
-	return vmdAddr, nil
+	return addr.BackingToVMDAddress()
 }
 
 // mapVMDToBackingDevs stores found vmd backing device details under vmd address key.
@@ -46,10 +40,10 @@ func mapVMDToBackingDevs(foundCtrlrs storage.NvmeControllers) (map[string]storag
 	for _, ctrlr := range foundCtrlrs {
 		vmdAddr, err := getVMD(ctrlr.PciAddr)
 		if err != nil {
+			if err == hardware.ErrNotVMDBackingAddress {
+				continue
+			}
 			return nil, err
-		}
-		if vmdAddr == nil {
-			continue // not a backing device address
 		}
 
 		if _, exists := vmds[vmdAddr.String()]; !exists {
@@ -70,10 +64,10 @@ func mapVMDToBackingAddrs(foundCtrlrs storage.NvmeControllers) (map[string]*hard
 	for _, ctrlr := range foundCtrlrs {
 		vmdAddr, err := getVMD(ctrlr.PciAddr)
 		if err != nil {
+			if err == hardware.ErrNotVMDBackingAddress {
+				continue
+			}
 			return nil, err
-		}
-		if vmdAddr == nil {
-			continue // not a backing device address
 		}
 
 		if _, exists := vmds[vmdAddr.String()]; !exists {

--- a/src/control/server/storage/bdev_test.go
+++ b/src/control/server/storage/bdev_test.go
@@ -8,7 +8,10 @@ package storage
 
 import (
 	"fmt"
+	"strings"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 
 	"github.com/daos-stack/daos/src/control/common/test"
 )
@@ -103,6 +106,77 @@ func Test_NvmeDevStateFromString_invalid(t *testing.T) {
 
 			test.AssertEqual(t, tc.expState, state, "unexpected state")
 			test.AssertEqual(t, tc.expStr, state.String(), "unexpected states string")
+		})
+	}
+}
+
+func Test_filterBdevScanResponse(t *testing.T) {
+	const (
+		vmdAddr1         = "0000:5d:05.5"
+		vmdBackingAddr1a = "5d0505:01:00.0"
+		vmdBackingAddr1b = "5d0505:03:00.0"
+		vmdAddr2         = "0000:7d:05.5"
+		vmdBackingAddr2a = "7d0505:01:00.0"
+		vmdBackingAddr2b = "7d0505:03:00.0"
+	)
+	ctrlrsFromPCIAddrs := func(addrs ...string) (ncs NvmeControllers) {
+		for _, addr := range addrs {
+			ncs = append(ncs, &NvmeController{PciAddr: addr})
+		}
+		return
+	}
+
+	for name, tc := range map[string]struct {
+		addrs    []string
+		scanResp *BdevScanResponse
+		expAddrs []string
+		expErr   error
+	}{
+		"two vmd endpoints; one filtered out": {
+			addrs: []string{vmdAddr2},
+			scanResp: &BdevScanResponse{
+				Controllers: ctrlrsFromPCIAddrs(vmdBackingAddr1a, vmdBackingAddr1b,
+					vmdBackingAddr2a, vmdBackingAddr2b),
+			},
+			expAddrs: []string{vmdBackingAddr2a, vmdBackingAddr2b},
+		},
+		"two ssds; one filtered out": {
+			addrs: []string{"0000:81:00.0"},
+			scanResp: &BdevScanResponse{
+				Controllers: ctrlrsFromPCIAddrs("0000:81:00.0", "0000:de:00.0"),
+			},
+			expAddrs: []string{"0000:81:00.0"},
+		},
+		"two aio kdev paths; both filtered out": {
+			addrs: []string{"/dev/sda"},
+			scanResp: &BdevScanResponse{
+				Controllers: ctrlrsFromPCIAddrs("/dev/sda", "/dev/sdb"),
+			},
+			expAddrs: []string{},
+		},
+		"bad address; filtered out": {
+			addrs: []string{"0000:81:00.0"},
+			scanResp: &BdevScanResponse{
+				Controllers: ctrlrsFromPCIAddrs("0000:81.00.0"),
+			},
+			expAddrs: []string{},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			bdl := new(BdevDeviceList)
+			if err := bdl.fromStrings(tc.addrs); err != nil {
+				t.Fatal(err)
+			}
+			gotErr := filterBdevScanResponse(bdl, tc.scanResp)
+			test.CmpErr(t, tc.expErr, gotErr)
+			if gotErr != nil {
+				return
+			}
+
+			expAddrStr := strings.Join(tc.expAddrs, ", ")
+			if diff := cmp.Diff(expAddrStr, tc.scanResp.Controllers.String()); diff != "" {
+				t.Fatalf("unexpected output addresses (-want, +got):\n%s\n", diff)
+			}
 		})
 	}
 }

--- a/src/control/server/storage/provider.go
+++ b/src/control/server/storage/provider.go
@@ -224,19 +224,24 @@ func (p *Provider) PrepareBdevs(req BdevPrepareRequest) (*BdevPrepareResponse, e
 	return resp, err
 }
 
-// HasBlockDevices returns true if provider engine storage config has configured
-// block devices.
-func (p *Provider) HasBlockDevices() bool {
+// GetBlockDevices returns the addresses of all block devices in all bdev storage tiers.
+func (p *Provider) GetBlockDevices() *BdevDeviceList {
+	bdevs := []string{}
 	for _, cfg := range p.engineStorage.Tiers.BdevConfigs() {
-		if cfg.Bdev.DeviceList.Len() > 0 {
-			return true
-		}
+		bdevs = append(bdevs, cfg.Bdev.DeviceList.Devices()...)
 	}
-	return false
+
+	p.log.Debugf("bdevs on instance %d: %v", p.engineIndex, bdevs)
+
+	return MustNewBdevDeviceList(bdevs...)
 }
 
-// BdevTierPropertiesFromConfig returns BdevTierProperties struct from given
-// TierConfig.
+// HasBlockDevices returns true if provider engine storage config has configured block devices.
+func (p *Provider) HasBlockDevices() bool {
+	return p.GetBlockDevices().Len() > 0
+}
+
+// BdevTierPropertiesFromConfig returns BdevTierProperties struct from given TierConfig.
 func BdevTierPropertiesFromConfig(cfg *TierConfig) BdevTierProperties {
 	return BdevTierProperties{
 		Class:      cfg.Class,
@@ -489,12 +494,21 @@ func (p *Provider) ScanBdevs(req BdevScanRequest) (*BdevScanResponse, error) {
 }
 
 // SetBdevCache stores given scan response in provider bdev cache.
-func (p *Provider) SetBdevCache(resp BdevScanResponse) {
+func (p *Provider) SetBdevCache(resp BdevScanResponse) error {
 	p.Lock()
 	defer p.Unlock()
 
+	// Filter out any controllers not configured in provider's engine storage config.
+	if err := filterBdevScanResponse(p.GetBlockDevices(), &resp); err != nil {
+		return errors.Wrap(err, "filtering scan response before caching")
+	}
+
+	p.log.Debugf("setting bdev cache in storage provider for engine %d: %v", p.engineIndex,
+		resp.Controllers)
 	p.bdevCache = resp
 	p.vmdEnabled = resp.VMDEnabled
+
+	return nil
 }
 
 // WithVMDEnabled enables VMD on storage provider.


### PR DESCRIPTION
…nes (#8945)

dmg storage query usage is only reporting half the expected NVMe usage
values in a dual engine setup.

The last engine's scan response will overwrite valid stats written by
previous engine because the bdev cache contains all engine's controllers.

Fix by filtering cache to include only controllers configured on engine.

Features: control

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>