### PR TITLE
DCO-10397 test: Resolve NVMe SSD not found errors

### DIFF
--- a/ci/provisioning/post_provision_config_nodes.sh
+++ b/ci/provisioning/post_provision_config_nodes.sh
@@ -102,6 +102,14 @@ echo "jenkins ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/jenkins
 # and catted to the remote node along with this script
 post_provision_config_nodes
 
+# Woraround to enable binding devices back to nvme or vfio-pci after they are unbound from vfio-pci
+# to nvme.  Sometimes the device gets unbound from vfio-pci, but it is not removed the iommu group
+# for that device and future bindings to the device do not work, resulting in messages like, "NVMe
+# SSD [xxxx:xx:xx.x] not found" when starting daos engines.
+if lspci | grep -i nvme; then
+  daos_server storage prepare -n --reset && rmmod vfio_pci && modprobe vfio_pci
+fi
+
 systemctl enable nfs-server.service
 systemctl start nfs-server.service
 sync

--- a/ci/provisioning/post_provision_config_nodes.sh
+++ b/ci/provisioning/post_provision_config_nodes.sh
@@ -102,7 +102,7 @@ echo "jenkins ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/jenkins
 # and catted to the remote node along with this script
 post_provision_config_nodes
 
-# Woraround to enable binding devices back to nvme or vfio-pci after they are unbound from vfio-pci
+# Workaround to enable binding devices back to nvme or vfio-pci after they are unbound from vfio-pci
 # to nvme.  Sometimes the device gets unbound from vfio-pci, but it is not removed the iommu group
 # for that device and future bindings to the device do not work, resulting in messages like, "NVMe
 # SSD [xxxx:xx:xx.x] not found" when starting daos engines.


### PR DESCRIPTION
Adding a workaround to enable binding devices back to nvme or vfio-pci
after they are unbound from vfio-pci to nvme.  This should resolve the
following error seen when attempting to start daos engines:

storage: code = 304 description = "NVMe SSD [0000:86:00.0] not found"

Signed-off-by: Phillip Henderson <phillip.henderson@intel.com>