### PR TITLE
DAOS-9644 doc: correct provider documentation in server.yml (#8934)

### DIFF
--- a/utils/config/daos_server.yml
+++ b/utils/config/daos_server.yml
@@ -70,10 +70,15 @@
 #
 ## Network provider
 #
-## Force a specific libfabric provider to be used by all the engines.
-## The default provider depends on the interfaces that will be auto-detected:
-##  ofi+verbs;ofi_rxm for Infiniband/RoCE and
-##  ofi+sockets for non-RDMA-capable Ethernet.
+## Set the network provider to be used by all the engines.
+## There is no default - run "daos_server network scan" to list the
+## providers that are supported on the fabric interfaces. Examples:
+##
+##   ofi+verbs;ofi_rxm  for libfabric with Infiniband/RoCE
+##   ofi+tcp;ofi_rxm    for libfabric with non-RDMA-capable fabrics
+##
+## (Starting with DAOS 2.2, ofi_rxm will be automatically added to the
+## libfabric verbs and tcp providers, if not explicitly specified.)
 #
 #provider: ofi+verbs;ofi_rxm
 #

--- a/utils/config/daos_server.yml
+++ b/utils/config/daos_server.yml
@@ -75,7 +75,12 @@
 ## providers that are supported on the fabric interfaces. Examples:
 ##
 ##   ofi+verbs;ofi_rxm  for libfabric with Infiniband/RoCE
+##   ofi+sockets        for libfabric with non-RDMA-capable fabrics
 ##   ofi+tcp;ofi_rxm    for libfabric with non-RDMA-capable fabrics
+##
+## (In DAOS 2.0, the supported non-RDMA provier is ofi+sockets;
+## the ofi+tcp provider has not been fully tested with DAOS 2.0.
+## Starting with DAOS 2.2, ofi+tcp is the supported non-RDMA provider.)
 ##
 ## (Starting with DAOS 2.2, ofi_rxm will be automatically added to the
 ## libfabric verbs and tcp providers, if not explicitly specified.)


### PR DESCRIPTION
clarify provider documentation in the daos_server.yml template

Doc-only: true
Signed-off-by: Michael Hennecke <michael.hennecke@intel.com>