### PR TITLE
DAOS-8012 tests: reenable test_daos_server_dump_basic

### DIFF
--- a/src/tests/ftest/server/daos_server_dump.py
+++ b/src/tests/ftest/server/daos_server_dump.py
@@ -71,8 +71,6 @@ class DaosServerDumpTest(TestWithServers):
                 "No daos_engine processes found on {}".format(
                     str(ret_codes[0])))
 
-        self.log.info("Test passed!")
-
     def test_daos_server_dump_on_error(self):
         """JIRA ID: DAOS-1452.
 


### PR DESCRIPTION
Re-enable test_daos_server_dump_basic test using commit
pragma, to verify it now works, after recent changes from
DAOS-1452.

Change-Id: I73208f8680a78b5146bb6980fcbf295f765f488e
Test-tag: test_daos_server_dump_basic
Signed-off-by: Bruno Faccini <bruno.faccini@intel.com>