### PR TITLE
DAOS-9583 chk: interface for vos operations to trace check process

### DIFF
--- a/src/chk/SConscript
+++ b/src/chk/SConscript
@@ -1,3 +1,4 @@
+# pylint: disable=consider-using-f-string
 """Build chk library"""
 import daos_build
 
@@ -19,7 +20,7 @@ def scons():
 
     # chk
     chk = daos_build.library(denv, 'chk',
-                             [chk_pb, 'chk_srv.c', 'chk_common.c'],
+                             [chk_pb, 'chk_srv.c', 'chk_common.c', 'chk_vos.c'],
                              install_off="../..")
     denv.Install('$PREFIX/lib64/daos_srv', chk)
 

--- a/src/chk/chk_internal.h
+++ b/src/chk/chk_internal.h
@@ -11,8 +11,14 @@
 #ifndef __CHK_INTERNAL_H__
 #define __CHK_INTERNAL_H__
 
+#include <abt.h>
+#include <uuid/uuid.h>
 #include <daos/rpc.h>
+#include <daos/btree.h>
+#include <daos/object.h>
+#include <daos_srv/pool.h>
 #include <daos_srv/daos_chk.h>
+#include <daos_srv/daos_engine.h>
 
 #include "chk.pb-c.h"
 
@@ -40,8 +46,113 @@ enum chk_rpc_opc {
 
 #undef X
 
-int chk_rejoin(void);
+/* dkey for check DB under sys_db */
+#define CHK_DB_TABLE		"chk"
 
-int chk_pause(void);
+/* akey for leader bookmark under CHK_DB_TABLE */
+#define CHK_BK_LEADER		"leader"
+
+/* akey for engine bookmark under CHK_DB_TABLE */
+#define CHK_BK_ENGINE		"engine"
+
+/* akey for check property under CHK_DB_TABLE */
+#define CHK_PROPERTY		"property"
+
+/* akey for the list of ranks under CHK_DB_TABLE */
+#define CHK_RANKS		"ranks"
+
+#define CHK_BK_MAGIC_LEADER	0xe6f703da
+#define CHK_BK_MAGIC_ENGINE	0xe6f703db
+#define CHK_BK_MAGIC_POOL	0xe6f703dc
+
+/*
+ * XXX: Please be careful when change CHK__CHECK_INCONSIST_CLASS__CIC_UNKNOWN
+ *	to avoid hole is the struct chk_property.
+ */
+#define CHK_POLICY_MAX		(CHK__CHECK_INCONSIST_CLASS__CIC_UNKNOWN + 1)
+#define CHK_POOLS_MAX		(1 << 6)
+
+/*
+ * Each check instance has a unique leader engine that uses key "chk/leader" under its local
+ * sys_db to trace the check instance.
+ *
+ * For each engine, include the leader engine, there is a system level key "chk/engine" under
+ * the engine's local sys_db to trace the check instance on the engine. When server (re)start
+ * the check module uses it to determain whether needs to rejoin the check instance.
+ *
+ * For each pool, there is a key "chk/$pool_uuid" under the engine's local sys_db to trace
+ * check process for the pool on related engine.
+ */
+struct chk_bookmark {
+	uint32_t			cb_magic;
+	uint32_t			cb_version;
+	uint64_t			cb_gen;
+	Chk__CheckScanPhase		cb_phase;
+	union {
+		Chk__CheckInstStatus	cb_ins_status;
+		Chk__CheckPoolStatus	cb_pool_status;
+	};
+	/*
+	 * For leader bookmark, it is the inconsistency statistics during the phases range
+	 * [CSP_PREPARE, CSP_POOL_LIST] for the whole system. The inconsistency and related
+	 * reparation during these phases may be in MS, not related with any engine.
+	 *
+	 * For pool bookmark, it is the inconsistency statistics during the phases range
+	 * [CSP_POOL_MBS, CSP_CONT_CLEANUP] for the pool. The inconsistency and related
+	 * reparation during these phases is applied to the pool service leader.
+	 */
+	struct chk_statistics		cb_statistics;
+	struct chk_time			cb_time;
+};
+
+/* On each engine (including the leader), there is a key "chk/property" under its local sys_db. */
+struct chk_property {
+	d_rank_t			cp_leader;
+	Chk__CheckFlag			cp_flags;
+	Chk__CheckInconsistAction	cp_policies[CHK_POLICY_MAX];
+	/*
+	 * How many pools will be handled by the check instance. -1 means to handle all pools.
+	 * If the specified pools count exceeds CHK_POOLS_MAX, then all pools will be handled.
+	 */
+	int32_t				cp_pool_nr;
+	uuid_t				cp_pools[CHK_POOLS_MAX];
+	/*
+	 * XXX: Preserve for supporting to continue the check until the specified phase in the
+	 *	future. -1 means to check all phases.
+	 */
+	int32_t				cp_phase;
+	/* How many ranks (ever or should) take part in the check instance. */
+	uint32_t			cp_rank_nr;
+};
+
+/* chk_vos.c */
+
+int chk_bk_fetch_leader(struct chk_bookmark *cbk);
+
+int chk_bk_update_leader(struct chk_bookmark *cbk);
+
+int chk_bk_delete_leader(void);
+
+int chk_bk_fetch_engine(struct chk_bookmark *cbk);
+
+int chk_bk_update_engine(struct chk_bookmark *cbk);
+
+int chk_bk_delete_engine(void);
+
+int chk_bk_fetch_pool(struct chk_bookmark *cbk, uuid_t uuid);
+
+int chk_bk_update_pool(struct chk_bookmark *cbk, uuid_t uuid);
+
+int chk_bk_delete_pool(uuid_t uuid);
+
+int chk_prop_fetch(struct chk_property *cpp, d_rank_list_t **rank_list);
+
+int chk_prop_update(struct chk_property *cpp, d_rank_list_t *rank_list);
+
+int chk_traverse_pools(sys_db_trav_cb_t cb, void *args);
+
+void chk_vos_init(void);
+
+void chk_vos_fini(void);
 
 #endif /* __CHK_INTERNAL_H__ */

--- a/src/chk/chk_srv.c
+++ b/src/chk/chk_srv.c
@@ -10,13 +10,7 @@
 #include <daos_srv/daos_chk.h>
 #include <daos_srv/daos_engine.h>
 
-#include "chk.pb-c.h"
 #include "chk_internal.h"
-
-static bool
-ds_chk_need_rejoin(void) {
-	return true;
-}
 
 static void
 ds_chk_start_hdlr(crt_rpc_t *rpc)
@@ -53,19 +47,8 @@ ds_chk_fini(void)
 static int
 ds_chk_setup(void)
 {
-	int	rc;
-
-	/* TBD: open log. */
-
-	if (ds_chk_need_rejoin()) {
-		rc = chk_rejoin();
-		/* Rejoin check may fail, that is normal. Because former check instance may has
-		 * already been stopped or exited, or current rank may miss some critical phase
-		 * or has been excluded. Just some warning message without stopping the engine.
-		 */
-		if (rc != 0)
-			D_WARN("Cannot rejoin CHECK: "DF_RC"\n", DP_RC(rc));
-	}
+	/* Do NOT move chk_vos_init into ds_chk_init, because sys_db is not ready at that time. */
+	chk_vos_init();
 
 	return 0;
 }
@@ -73,9 +56,7 @@ ds_chk_setup(void)
 static int
 ds_chk_cleanup(void)
 {
-	chk_pause();
-
-	/* TBD: close log. */
+	chk_vos_fini();
 
 	return 0;
 }

--- a/src/chk/chk_vos.c
+++ b/src/chk/chk_vos.c
@@ -1,0 +1,311 @@
+/**
+ * (C) Copyright 2022 Intel Corporation.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause-Patent
+ */
+
+#define D_LOGFAC	DD_FAC(chk)
+
+#include <daos_srv/vos.h>
+#include <daos_srv/daos_chk.h>
+#include <daos_srv/daos_engine.h>
+
+#include "chk_internal.h"
+
+static struct sys_db	*chk_db;
+
+static int
+chk_db_fetch(char *key, int key_size, void *val, int val_size)
+{
+	d_iov_t	key_iov;
+	d_iov_t	val_iov;
+
+	d_iov_set(&key_iov, key, key_size);
+	d_iov_set(&val_iov, val, val_size);
+
+	return chk_db->sd_fetch(chk_db, CHK_DB_TABLE, &key_iov, &val_iov);
+}
+
+static int
+chk_db_update(char *key, int key_size, void *val, int val_size)
+{
+	d_iov_t	key_iov;
+	d_iov_t	val_iov;
+	int	rc;
+
+	if (chk_db->sd_tx_begin) {
+		rc = chk_db->sd_tx_begin(chk_db);
+		if (rc != 0)
+			goto out;
+	}
+
+	d_iov_set(&key_iov, key, key_size);
+	d_iov_set(&val_iov, val, val_size);
+
+	rc = chk_db->sd_upsert(chk_db, CHK_DB_TABLE, &key_iov, &val_iov);
+
+	if (chk_db->sd_tx_end)
+		rc = chk_db->sd_tx_end(chk_db, rc);
+
+out:
+	return rc;
+}
+
+static int
+chk_db_delete(char *key, int key_size)
+{
+	d_iov_t	key_iov;
+	int	rc;
+
+	if (chk_db->sd_tx_begin) {
+		rc = chk_db->sd_tx_begin(chk_db);
+		if (rc != 0)
+			goto out;
+	}
+
+	d_iov_set(&key_iov, key, key_size);
+
+	rc = chk_db->sd_delete(chk_db, CHK_DB_TABLE, &key_iov);
+
+	if (chk_db->sd_tx_end)
+		rc = chk_db->sd_tx_end(chk_db, rc);
+
+out:
+	return rc;
+}
+
+static int
+chk_db_traverse(sys_db_trav_cb_t cb, void *args)
+{
+	return chk_db->sd_traverse(chk_db, CHK_DB_TABLE, cb, args);
+}
+
+int
+chk_bk_fetch_leader(struct chk_bookmark *cbk)
+{
+	int	rc;
+
+	rc = chk_db_fetch(CHK_BK_LEADER, strlen(CHK_BK_LEADER), cbk, sizeof(*cbk));
+	if (rc != 0 && rc != -DER_NONEXIST)
+		D_ERROR("Failed to fetch leader bookmark on rank %u: "DF_RC"\n",
+			dss_self_rank(), DP_RC(rc));
+
+	return rc;
+}
+
+int
+chk_bk_update_leader(struct chk_bookmark *cbk)
+{
+	int	rc;
+
+	rc = chk_db_update(CHK_BK_LEADER, strlen(CHK_BK_LEADER), cbk, sizeof(*cbk));
+	if (rc != 0)
+		D_ERROR("Failed to update leader bookmark on rank %u: "DF_RC"\n",
+			dss_self_rank(), DP_RC(rc));
+
+	return rc;
+}
+
+int
+chk_bk_delete_leader(void)
+{
+	int	rc;
+
+	rc = chk_db_delete(CHK_BK_LEADER, strlen(CHK_BK_LEADER));
+	if (rc != 0)
+		D_ERROR("Failed to delete leader bookmark on rank %u: "DF_RC"\n",
+			dss_self_rank(), DP_RC(rc));
+
+	return rc;
+}
+
+int
+chk_bk_fetch_engine(struct chk_bookmark *cbk)
+{
+	int	rc;
+
+	rc = chk_db_fetch(CHK_BK_ENGINE, strlen(CHK_BK_ENGINE), cbk, sizeof(*cbk));
+	if (rc != 0 && rc != -DER_NONEXIST)
+		D_ERROR("Failed to fetch engine bookmark on rank %u: "DF_RC"\n",
+			dss_self_rank(), DP_RC(rc));
+
+	return rc;
+}
+
+int
+chk_bk_update_engine(struct chk_bookmark *cbk)
+{
+	int	rc;
+
+	rc = chk_db_update(CHK_BK_ENGINE, strlen(CHK_BK_ENGINE), cbk, sizeof(*cbk));
+	if (rc != 0)
+		D_ERROR("Failed to update engine bookmark on rank %u: "DF_RC"\n",
+			dss_self_rank(), DP_RC(rc));
+
+	return rc;
+}
+
+int
+chk_bk_delete_engine(void)
+{
+	int	rc;
+
+	rc = chk_db_delete(CHK_BK_ENGINE, strlen(CHK_BK_ENGINE));
+	if (rc != 0)
+		D_ERROR("Failed to delete engine bookmark on rank %u: "DF_RC"\n",
+			dss_self_rank(), DP_RC(rc));
+
+	return rc;
+}
+
+int
+chk_bk_fetch_pool(struct chk_bookmark *cbk, uuid_t uuid)
+{
+	char	uuid_str[DAOS_UUID_STR_SIZE];
+	int	rc;
+
+	uuid_unparse_lower(uuid, uuid_str);
+	rc = chk_db_fetch(uuid_str, strlen(uuid_str), cbk, sizeof(*cbk));
+	if (rc != 0 && rc != -DER_NONEXIST)
+		D_ERROR("Failed to fetch pool "DF_UUID" bookmark on rank %u: "DF_RC"\n",
+			DP_UUID(uuid), dss_self_rank(), DP_RC(rc));
+
+	return rc;
+}
+
+int
+chk_bk_update_pool(struct chk_bookmark *cbk, uuid_t uuid)
+{
+	char	uuid_str[DAOS_UUID_STR_SIZE];
+	int	rc;
+
+	uuid_unparse_lower(uuid, uuid_str);
+	rc = chk_db_update(uuid_str, strlen(uuid_str), cbk, sizeof(*cbk));
+	if (rc != 0)
+		D_ERROR("Failed to update pool "DF_UUID" bookmark on rank %u: "DF_RC"\n",
+			DP_UUID(uuid), dss_self_rank(), DP_RC(rc));
+
+	return rc;
+}
+
+int
+chk_bk_delete_pool(uuid_t uuid)
+{
+	char	uuid_str[DAOS_UUID_STR_SIZE];
+	int	rc;
+
+	uuid_unparse_lower(uuid, uuid_str);
+	rc = chk_db_delete(uuid_str, strlen(uuid_str));
+	if (rc != 0)
+		D_ERROR("Failed to delete pool "DF_UUID" bookmark on rank %u: "DF_RC"\n",
+			DP_UUID(uuid), dss_self_rank(), DP_RC(rc));
+
+	return rc;
+}
+
+int
+chk_prop_fetch(struct chk_property *cpp, d_rank_list_t **rank_list)
+{
+	d_rank_list_t	*ranks = NULL;
+	int		 rc;
+
+	rc = chk_db_fetch(CHK_PROPERTY, strlen(CHK_PROPERTY), cpp, sizeof(*cpp));
+	if (rc == 0 && cpp->cp_rank_nr != 0 && rank_list != NULL) {
+		ranks = d_rank_list_alloc(cpp->cp_rank_nr);
+		if (ranks == NULL)
+			D_GOTO(out, rc = -DER_NOMEM);
+
+		rc = chk_db_fetch(CHK_RANKS, strlen(CHK_RANKS), ranks->rl_ranks,
+				  sizeof(*ranks->rl_ranks) * ranks->rl_nr);
+		/*
+		 * CHK_PROPERTY and CHK_RANKS must be exist together.
+		 * Otherwise there is local corruption.
+		 */
+		if (rc == -DER_NONEXIST) {
+			d_rank_list_free(ranks);
+			ranks = NULL;
+			D_GOTO(out, rc = -DER_IO);
+		}
+
+		if (rc != 0)
+			goto out;
+	}
+
+out:
+	if (rank_list != NULL)
+		*rank_list = ranks;
+
+	if (rc != 0 && rc != -DER_NONEXIST)
+		D_ERROR("Failed to fetch check property on rank %u: "DF_RC"\n",
+			dss_self_rank(), DP_RC(rc));
+
+	return rc;
+}
+
+int
+chk_prop_update(struct chk_property *cpp, d_rank_list_t *rank_list)
+{
+	d_iov_t	key_iov;
+	d_iov_t	val_iov;
+	int	rc;
+
+	if (chk_db->sd_tx_begin) {
+		rc = chk_db->sd_tx_begin(chk_db);
+		if (rc != 0)
+			goto out;
+	}
+
+	if (cpp->cp_rank_nr != 0 && rank_list != NULL) {
+		D_ASSERTF(cpp->cp_rank_nr == rank_list->rl_nr, "Invalid rank nr %u/%u\n",
+			  cpp->cp_rank_nr, rank_list->rl_nr);
+
+		d_iov_set(&key_iov, CHK_RANKS, strlen(CHK_RANKS));
+		d_iov_set(&val_iov, rank_list->rl_ranks,
+			  sizeof(*rank_list->rl_ranks) * rank_list->rl_nr);
+
+		rc = chk_db->sd_upsert(chk_db, CHK_DB_TABLE, &key_iov, &val_iov);
+		if (rc != 0)
+			goto end;
+	}
+
+	d_iov_set(&key_iov, CHK_PROPERTY, strlen(CHK_PROPERTY));
+	d_iov_set(&val_iov, cpp, sizeof(*cpp));
+
+	rc = chk_db->sd_upsert(chk_db, CHK_DB_TABLE, &key_iov, &val_iov);
+
+end:
+	if (chk_db->sd_tx_end)
+		rc = chk_db->sd_tx_end(chk_db, rc);
+
+out:
+	if (rc != 0)
+		D_ERROR("Failed to update check property on rank %u: "DF_RC"\n",
+			dss_self_rank(), DP_RC(rc));
+
+	return rc;
+}
+
+int
+chk_traverse_pools(sys_db_trav_cb_t cb, void *args)
+{
+	int	rc;
+
+	rc = chk_db_traverse(cb, args);
+	if (rc < 0)
+		D_ERROR("Failed to traverse pools on rank %u for pause: "DF_RC"\n",
+			dss_self_rank(), DP_RC(rc));
+
+	return rc;
+}
+
+void
+chk_vos_init(void)
+{
+	chk_db = vos_db_get();
+}
+
+void
+chk_vos_fini(void)
+{
+	chk_db = NULL;
+}

--- a/src/include/daos_srv/daos_chk.h
+++ b/src/include/daos_srv/daos_chk.h
@@ -15,30 +15,37 @@ struct chk_policy {
 	uint32_t		cp_action;
 };
 
-/* Check query result for the pool (all ranks) or pool shard (per target). */
-struct chk_query_pool {
-	uuid_t			cqp_uuid;
-	char			cqp_label[DAOS_PROP_MAX_LABEL_BUF_LEN];
-	uint32_t		cqp_status;
-	uint32_t		cqp_phase;
-	uint32_t		cqp_total;
-	uint32_t		cqp_repaired;
-	uint32_t		cqp_ignored;
-	uint32_t		cqp_failed;
-	uint64_t		cqp_start_time;
+/* Time information on related component: system, pool or target. */
+struct chk_time {
+	/* The time of check instance being started on the component. */
+	uint64_t		ct_start_time;
 	union {
-		uint64_t	cqp_remain_time;
-		uint64_t	cqp_stop_time;
+		/* The time of the check instance completed, failed or stopped on the component. */
+		uint64_t	ct_stop_time;
+		/* The estimated remaining time to complete the check on the component. */
+		uint64_t	ct_left_time;
 	};
 };
 
-/* Check query result for the target including all the pool shards on this target. */
+/* Inconsistency statistics on related component: system, pool or target. */
+struct chk_statistics {
+	/* The count of total found inconsistency on the component. */
+	uint64_t		cs_total;
+	/* The count of repaired inconsistency on the component. */
+	uint64_t		cs_repaired;
+	/* The count of ignored inconsistency on the component. */
+	uint64_t		cs_ignored;
+	/* The count of fail to repaired inconsistency on the component. */
+	uint64_t		cs_failed;
+};
+
 struct chk_query_target {
-	d_rank_t		dqt_rank;
-	uint32_t		dqt_tgt;
-	uint32_t		dqt_status;
-	uint32_t		dqt_cnt;
-	struct chk_query_pool	dqt_shards[0];
+	d_rank_t		cqt_rank;
+	uint32_t		cqt_tgt;
+	uint32_t		cqt_ins_status;
+	uint32_t		cqt_padding;
+	struct chk_statistics	cqt_statistics;
+	struct chk_time		cqt_time;
 };
 
 typedef int (*chk_query_cb_t)(void *buf, struct chk_query_target *cqt);


### PR DESCRIPTION
The leader instance uses the bookmark "CHK_BK_LEADER" to trace the
leader check process, such as the instance status, the scan phase,
inconsistency statistics information related with the leader, time
information, and so on. Each engine instance has each own bookmark,
called CHK_BK_ENGINE, to trace related check process on the engine.
The engine's bookmark does not include detailed pools' check info,
that will be traced via the pool bookmark named with the pool UUID.
Every pool shard on each related engines all has its pool bookmark.

All above bookmarks are organized as KV under vos sys_db. The dkey
is "CHK_DB_TABLE".

On each engine participating in the check, there is shared property
KV "CHK_PROPERTY" under the vos sys_db. It contains the check flags,
leader information, inconsistency repair policies, the engines that
take part in the check, and so on.

Quick-Functional: true

Signed-off-by: Fan Yong <fan.yong@intel.com>