### PR TITLE
DAOS-9583 chk: DAOS check dRPC upcall

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -244,7 +244,6 @@ pipeline {
                                    password: GITHUB_USER_PSW,
                                    ignored_files: "src/control/vendor/*:" +
                                                   "*.pb-c.[ch]:" +
-                                                  "src/chk/chk_internal.h:" +
                                                   "src/client/java/daos-java/src/main/java/io/daos/dfs/uns/*:" +
                                                   "src/client/java/daos-java/src/main/java/io/daos/obj/attr/*:" +
                                                   "src/client/java/daos-java/src/main/native/include/daos_jni_common.h:" +

--- a/src/chk/SConscript
+++ b/src/chk/SConscript
@@ -21,8 +21,8 @@ def scons():
     # chk
     chk = daos_build.library(denv, 'chk',
                              [chk_pb, 'chk_srv.c', 'chk_common.c', 'chk_vos.c',
-                              'chk_rpc.c', 'chk_upcall.c'],
-                             install_off="../..")
+                              'chk_rpc.c', 'chk_upcall.c', 'chk_iv.c', 'chk_leader.c',
+                              'chk_engine.c'], install_off="../..")
     denv.Install('$PREFIX/lib64/daos_srv', chk)
 
 if __name__ == "SCons.Script":

--- a/src/chk/SConscript
+++ b/src/chk/SConscript
@@ -21,7 +21,7 @@ def scons():
     # chk
     chk = daos_build.library(denv, 'chk',
                              [chk_pb, 'chk_srv.c', 'chk_common.c', 'chk_vos.c',
-                              'chk_rpc.c'],
+                              'chk_rpc.c', 'chk_upcall.c'],
                              install_off="../..")
     denv.Install('$PREFIX/lib64/daos_srv', chk)
 

--- a/src/chk/chk_common.c
+++ b/src/chk/chk_common.c
@@ -6,51 +6,725 @@
 
 #define D_LOGFAC	DD_FAC(chk)
 
+#include <time.h>
+#include <abt.h>
+#include <cart/api.h>
+#include <daos/rpc.h>
+#include <daos/btree.h>
+#include <daos/btree_class.h>
+#include <daos_srv/daos_engine.h>
 #include <daos_srv/daos_chk.h>
+#include <daos_srv/pool.h>
+#include <daos_srv/vos.h>
+#include <daos_srv/iv.h>
 
 #include "chk.pb-c.h"
 #include "chk_internal.h"
 
-int
-chk_start(d_rank_list_t *ranks, struct chk_policy *policies, uuid_t *pools,
-	  int pool_cnt, uint32_t flags)
+struct chk_pool_bundle {
+	d_list_t		*cpb_head;
+	uint32_t		*cpb_shard_nr;
+	uuid_t			 cpb_uuid;
+	d_rank_t		 cpb_rank;
+	uint32_t		 cpb_phase;
+	struct chk_instance	*cpb_ins;
+	/* Pointer to the pool bookmark. */
+	struct chk_bookmark	*cpb_bk;
+	void			*cpb_data;
+	chk_pool_free_data_t	 cpb_free_cb;
+};
+
+static int
+chk_pool_hkey_size(void)
 {
+	return sizeof(uuid_t);
+}
+
+static void
+chk_pool_hkey_gen(struct btr_instance *tins, d_iov_t *key_iov, void *hkey)
+{
+	D_ASSERT(key_iov->iov_len == sizeof(uuid_t));
+
+	memcpy(hkey, key_iov->iov_buf, key_iov->iov_len);
+}
+
+static int
+chk_pool_alloc(struct btr_instance *tins, d_iov_t *key_iov, d_iov_t *val_iov,
+	       struct btr_record *rec, d_iov_t *val_out)
+{
+	struct chk_pool_bundle	*cpb = val_iov->iov_buf;
+	struct chk_pool_rec	*cpr = NULL;
+	struct chk_pool_shard	*cps = NULL;
+	int			 rc = 0;
+
+	D_ASSERT(cpb != NULL);
+
+	D_ALLOC_PTR(cpr);
+	if (cpr == NULL)
+		D_GOTO(out, rc = -DER_NOMEM);
+
+	if (cpb->cpb_data != NULL) {
+		D_ALLOC_PTR(cps);
+		if (cps == NULL) {
+			D_FREE(cpr);
+			D_GOTO(out, rc = -DER_NOMEM);
+		}
+	}
+
+	D_INIT_LIST_HEAD(&cpr->cpr_shard_list);
+	cpr->cpr_shard_nr = 0;
+	cpr->cpr_started = 0;
+	cpr->cpr_phase = cpb->cpb_phase;
+	uuid_copy(cpr->cpr_uuid, cpb->cpb_uuid);
+	cpr->cpr_thread = ABT_THREAD_NULL;
+	if (cpb->cpb_bk != NULL)
+		memcpy(&cpr->cpr_bk, cpb->cpb_bk, sizeof(cpr->cpr_bk));
+	cpr->cpr_ins = cpb->cpb_ins;
+
+	rec->rec_off = umem_ptr2off(&tins->ti_umm, cpr);
+	d_list_add_tail(&cpr->cpr_link, cpb->cpb_head);
+
+	if (cps != NULL) {
+		cps->cps_rank = cpb->cpb_rank;
+		cps->cps_data = cpb->cpb_data;
+		cps->cps_free_cb = cpb->cpb_free_cb;
+
+		d_list_add_tail(&cps->cps_link, &cpr->cpr_shard_list);
+		cpr->cpr_shard_nr++;
+		if (cpb->cpb_shard_nr != NULL)
+			(*cpb->cpb_shard_nr)++;
+	}
+
+out:
+	return rc;
+}
+
+static int
+chk_pool_free(struct btr_instance *tins, struct btr_record *rec, void *args)
+{
+	struct chk_pool_rec	*cpr = umem_off2ptr(&tins->ti_umm, rec->rec_off);
+	d_iov_t			*val_iov = args;
+	struct chk_pool_shard	*cps;
+	d_iov_t			 psid;
+
+	rec->rec_off = UMOFF_NULL;
+	d_list_del_init(&cpr->cpr_link);
+
+	if (cpr->cpr_thread != ABT_THREAD_NULL) {
+		cpr->cpr_stop = 1;
+		ABT_thread_join(cpr->cpr_thread);
+		ABT_thread_free(&cpr->cpr_thread);
+	}
+
+	if (cpr->cpr_started) {
+		d_iov_set(&psid, cpr->cpr_uuid, sizeof(uuid_t));
+		ds_rsvc_stop(DS_RSVC_CLASS_POOL, &psid, false);
+		ds_pool_stop(cpr->cpr_uuid);
+		cpr->cpr_started = 0;
+	}
+
+	while ((cps = d_list_pop_entry(&cpr->cpr_shard_list, struct chk_pool_shard,
+				       cps_link)) != NULL) {
+		if (cps->cps_free_cb != NULL)
+			cps->cps_free_cb(cps->cps_data);
+		else
+			D_FREE(cps->cps_data);
+		D_FREE(cps);
+	}
+
+	if (val_iov != 0)
+		d_iov_set(val_iov, cpr, sizeof(*cpr));
+	else
+		D_FREE(cpr);
+
 	return 0;
 }
 
-int
-chk_stop(uuid_t *pools, int pool_cnt)
+static int
+chk_pool_fetch(struct btr_instance *tins, struct btr_record *rec,
+	       d_iov_t *key_iov, d_iov_t *val_iov)
 {
+	struct chk_pool_rec	*cpr;
+
+	D_ASSERT(val_iov != NULL);
+
+	cpr = umem_off2ptr(&tins->ti_umm, rec->rec_off);
+	d_iov_set(val_iov, cpr, sizeof(*cpr));
+
 	return 0;
 }
 
-int
-chk_query(uuid_t *pools, int pool_cnt, chk_query_cb_t query_cb,
-	  struct chk_query_target *cqt, void *buf)
+static int
+chk_pool_update(struct btr_instance *tins, struct btr_record *rec,
+		d_iov_t *key, d_iov_t *val, d_iov_t *val_out)
 {
+	struct chk_pool_bundle	*cpb = val->iov_buf;
+	struct chk_pool_rec	*cpr = umem_off2ptr(&tins->ti_umm, rec->rec_off);
+	struct chk_pool_shard	*cps;
+	int			 rc = 0;
+
+	D_ASSERT(cpb != NULL);
+
+	D_ALLOC_PTR(cps);
+	if (cps == NULL)
+		D_GOTO(out, rc = -DER_NOMEM);
+
+	cps->cps_rank = cpb->cpb_rank;
+	cps->cps_data = cpb->cpb_data;
+	cps->cps_free_cb = cpb->cpb_free_cb;
+
+	if (cpb->cpb_phase < cpr->cpr_phase)
+		cpr->cpr_phase = cpb->cpb_phase;
+
+	d_list_add_tail(&cps->cps_link, &cpr->cpr_shard_list);
+	cpr->cpr_shard_nr++;
+	if (cpb->cpb_shard_nr != NULL)
+		(*cpb->cpb_shard_nr)++;
+
+out:
+	return rc;
+}
+
+btr_ops_t chk_pool_ops = {
+	.to_hkey_size	= chk_pool_hkey_size,
+	.to_hkey_gen	= chk_pool_hkey_gen,
+	.to_rec_alloc	= chk_pool_alloc,
+	.to_rec_free	= chk_pool_free,
+	.to_rec_fetch	= chk_pool_fetch,
+	.to_rec_update  = chk_pool_update,
+};
+
+struct chk_pending_bundle {
+	d_list_t		*cpb_ins_head;
+	d_list_t		*cpb_rank_head;
+	d_rank_t		 cpb_rank;
+	uint32_t		 cpb_class;
+	uint64_t		 cpb_seq;
+};
+
+static int
+chk_pending_hkey_size(void)
+{
+	return sizeof(uint64_t);
+}
+
+static void
+chk_pending_hkey_gen(struct btr_instance *tins, d_iov_t *key_iov, void *hkey)
+{
+	D_ASSERT(key_iov->iov_len == sizeof(uint64_t));
+
+	memcpy(hkey, key_iov->iov_buf, key_iov->iov_len);
+}
+
+static int
+chk_pending_alloc(struct btr_instance *tins, d_iov_t *key_iov, d_iov_t *val_iov,
+		  struct btr_record *rec, d_iov_t *val_out)
+{
+	struct chk_pending_bundle	*cpb = val_iov->iov_buf;
+	struct chk_pending_rec		*cpr = NULL;
+	int				 rc = 0;
+
+	D_ASSERT(cpb != NULL);
+
+	D_ALLOC_PTR(cpr);
+	if (cpr == NULL)
+		D_GOTO(out, rc = -DER_NOMEM);
+
+	/* It means that the caller wants to wait for the interaction from admin. */
+	if (val_out != NULL) {
+		rc = ABT_mutex_create(&cpr->cpr_mutex);
+		if (rc != 0)
+			D_GOTO(out, rc = dss_abterr2der(rc));
+
+		rc = ABT_cond_create(&cpr->cpr_cond);
+		if (rc != 0)
+			D_GOTO(out, rc = dss_abterr2der(rc));
+
+		d_iov_set(val_iov, cpr, sizeof(*cpr));
+	}
+
+	cpr->cpr_seq = cpb->cpb_seq;
+	cpr->cpr_rank = cpb->cpb_rank;
+	cpr->cpr_class = cpb->cpb_class;
+	cpr->cpr_action = CHK__CHECK_INCONSIST_ACTION__CIA_INTERACT;
+
+	if (cpb->cpb_rank_head != NULL)
+		d_list_add_tail(&cpr->cpr_rank_link, cpb->cpb_rank_head);
+	else
+		D_INIT_LIST_HEAD(&cpr->cpr_rank_link);
+
+	rec->rec_off = umem_ptr2off(&tins->ti_umm, cpr);
+	d_list_add_tail(&cpr->cpr_ins_link, cpb->cpb_ins_head);
+
+out:
+	if (rc != 0) {
+		if (cpr != NULL) {
+			if (cpr->cpr_mutex != ABT_MUTEX_NULL)
+				ABT_mutex_free(&cpr->cpr_mutex);
+			D_FREE(cpr);
+		}
+	}
+
+	return rc;
+}
+
+static int
+chk_pending_free(struct btr_instance *tins, struct btr_record *rec, void *args)
+{
+	struct chk_pending_rec	*cpr = umem_off2ptr(&tins->ti_umm, rec->rec_off);
+	d_iov_t			*val_iov = args;
+
+	rec->rec_off = UMOFF_NULL;
+	d_list_del_init(&cpr->cpr_ins_link);
+	d_list_del_init(&cpr->cpr_rank_link);
+
+	if (val_iov != NULL)
+		d_iov_set(val_iov, cpr, sizeof(*cpr));
+	else
+		chk_pending_destroy(cpr);
+
 	return 0;
 }
 
-int
-chk_prop(uint32_t *flags, chk_prop_cb_t prop_cb, struct chk_policy *policy, void *buf)
+static int
+chk_pending_fetch(struct btr_instance *tins, struct btr_record *rec,
+		  d_iov_t *key_iov, d_iov_t *val_iov)
 {
+	struct chk_pending_rec	*cpr;
+
+	D_ASSERT(val_iov != NULL);
+
+	cpr = umem_off2ptr(&tins->ti_umm, rec->rec_off);
+	d_iov_set(val_iov, cpr, sizeof(*cpr));
+
 	return 0;
 }
 
-int
-chk_act(uint64_t seq, uint32_t act, bool for_all)
+static int
+chk_pending_update(struct btr_instance *tins, struct btr_record *rec,
+		   d_iov_t *key, d_iov_t *val, d_iov_t *val_out)
 {
+	D_ASSERTF(0, "It should not be here\n");
+
 	return 0;
 }
 
-int
-chk_rejoin(void)
+btr_ops_t chk_pending_ops = {
+	.to_hkey_size	= chk_pending_hkey_size,
+	.to_hkey_gen	= chk_pending_hkey_gen,
+	.to_rec_alloc	= chk_pending_alloc,
+	.to_rec_free	= chk_pending_free,
+	.to_rec_fetch	= chk_pending_fetch,
+	.to_rec_update  = chk_pending_update,
+};
+
+void
+chk_ranks_dump(uint32_t rank_nr, d_rank_t *ranks)
 {
-	return 0;
+	char	 buf[128];
+	char	*ptr = buf;
+	int	 rc;
+	int	 i;
+
+	if (unlikely(rank_nr == 0))
+		return;
+
+	D_INFO("Ranks List:\n");
+
+	while (rank_nr >= 8) {
+		snprintf(ptr, 127, "%10u %10u %10u %10u %10u %10u %10u %10u",
+			 ranks[0], ranks[1], ranks[2], ranks[3],
+			 ranks[4], ranks[5], ranks[6], ranks[7]);
+		D_INFO("%s\n", ptr);
+		rank_nr -= 8;
+		ranks += 8;
+	}
+
+	if (rank_nr > 0) {
+		rc = snprintf(ptr, 127, "%10u", ranks[0]);
+		D_ASSERT(rc > 0);
+		ptr += rc;
+	}
+
+	for (i = 1; i < rank_nr; i++) {
+		rc = snprintf(ptr, 127, " %10u", ranks[i]);
+		D_ASSERT(rc > 0);
+		ptr += rc;
+	}
+
+	D_INFO("%s\n", buf);
+}
+
+void
+chk_pools_dump(uint32_t pool_nr, uuid_t pools[])
+{
+	char	 buf[256];
+	char	*ptr = buf;
+	int	 rc;
+	int	 i;
+
+	D_INFO("Pools List:\n");
+
+	while (pool_nr > 8) {
+		snprintf(buf, 255, "%s %s %s %s %s %s %s %s",
+			 pools[0], pools[1], pools[2], pools[3],
+			 pools[4], pools[5], pools[6], pools[7]);
+		D_INFO("%s\n", buf);
+		pool_nr -= 8;
+		pools += 8;
+	}
+
+	if (pool_nr > 0) {
+		rc = snprintf(ptr, 255, "%s", pools[0]);
+		D_ASSERT(rc > 0);
+		ptr += rc;
+	}
+
+	for (i = 1; i < pool_nr; i++) {
+		rc = snprintf(ptr, 255, " %s", pools[i]);
+		D_ASSERT(rc > 0);
+		ptr += rc;
+	}
+
+	D_INFO("%s\n", buf);
+}
+
+void
+chk_stop_sched(struct chk_instance *ins)
+{
+	if (ins->ci_sched != ABT_THREAD_NULL && ins->ci_sched_running) {
+		ABT_mutex_lock(ins->ci_abt_mutex);
+		ins->ci_sched_running = 0;
+		ABT_cond_broadcast(ins->ci_abt_cond);
+		ABT_mutex_unlock(ins->ci_abt_mutex);
+
+		ABT_thread_join(ins->ci_sched);
+		ABT_thread_free(&ins->ci_sched);
+	}
 }
 
 int
-chk_pause(void)
+chk_prop_prepare(uint32_t rank_nr, d_rank_t *ranks, uint32_t policy_nr,
+		 struct chk_policy **policies, uint32_t pool_nr, uuid_t pools[],
+		 uint32_t flags, int phase, d_rank_t leader,
+		 struct chk_property *prop, d_rank_list_t **rlist)
 {
-	return 0;
+	d_rank_list_t	*result = NULL;
+	uint32_t	 saved = prop->cp_rank_nr;
+	int		 rc = 0;
+	int		 i;
+
+	D_ASSERT(rlist != NULL);
+
+	if (rank_nr != 0) {
+		result = uint32_array_to_rank_list(ranks, rank_nr);
+		if (result == NULL)
+			D_GOTO(out, rc = -DER_NOMEM);
+
+		prop->cp_rank_nr = rank_nr;
+	} else if (*rlist == NULL) {
+		D_ERROR("Rank list cannot be NULL for check start\n");
+		D_GOTO(out, rc = -DER_INVAL);
+	}
+
+	prop->cp_leader = leader;
+	prop->cp_flags = flags;
+	prop->cp_phase = phase;
+
+	/* Reuse former policies if "policy_nr == 0". */
+	if (policy_nr > 0) {
+		memset(prop->cp_policies, 0, sizeof(Chk__CheckInconsistAction) * CHK_POLICY_MAX);
+		for (i = 0; i < policy_nr; i++) {
+			if (unlikely(policies[i]->cp_class >= CHK_POLICY_MAX)) {
+				D_ERROR("Invalid DAOS inconsistency class %u\n",
+					policies[i]->cp_class);
+				D_GOTO(out, rc = -DER_INVAL);
+			}
+
+			prop->cp_policies[policies[i]->cp_class] = policies[i]->cp_action;
+		}
+	}
+
+	/* Reuse former pools if "pool_nr == 0". */
+	if (pool_nr >= CHK_POOLS_MAX || pool_nr < 0) {
+		prop->cp_pool_nr = -1;
+	} else if (pool_nr > 0) {
+		for (i = 0; i < pool_nr; i++)
+			uuid_copy(prop->cp_pools[i], pools[i]);
+		prop->cp_pool_nr = pool_nr;
+	}
+
+	if (prop->cp_pool_nr == 0)
+		prop->cp_pool_nr = -1;
+
+	rc = chk_prop_update(prop, result);
+	if (rc == 0) {
+		if (result != NULL)
+			*rlist = result;
+	} else {
+		/* Keep the prop->cp_rank_nr to always match the rank list. */
+		prop->cp_rank_nr = saved;
+		d_rank_list_free(result);
+	}
+
+out:
+	return rc;
+}
+
+int
+chk_pool_add_shard(daos_handle_t hdl, d_list_t *head, uuid_t uuid, d_rank_t rank,
+		   uint32_t phase, struct chk_bookmark *bk, struct chk_instance *ins,
+		   uint32_t *shard_nr, void *data, chk_pool_free_data_t free_cb)
+{
+	struct chk_pool_bundle	rbund;
+	d_iov_t			kiov;
+	d_iov_t			riov;
+	int			rc;
+
+	rbund.cpb_head = head;
+	rbund.cpb_shard_nr = shard_nr;
+	uuid_copy(rbund.cpb_uuid, uuid);
+	rbund.cpb_rank = rank;
+	rbund.cpb_phase = phase;
+	rbund.cpb_bk = bk;
+	rbund.cpb_ins = ins;
+	rbund.cpb_data = data;
+	rbund.cpb_free_cb = free_cb;
+
+	d_iov_set(&riov, &rbund, sizeof(rbund));
+	d_iov_set(&kiov, uuid, sizeof(uuid_t));
+	rc = dbtree_upsert(hdl, BTR_PROBE_EQ, DAOS_INTENT_UPDATE, &kiov, &riov, NULL);
+
+	D_CDEBUG(rc != 0, DLOG_ERR, DLOG_DBG, "Add pool shard "DF_UUID" for rank %u: "DF_RC"\n",
+		 DP_UUID(uuid), rank, DP_RC(rc));
+
+	return rc;
+}
+
+int
+chk_pool_del_shard(daos_handle_t hdl, uuid_t uuid, d_rank_t rank)
+{
+	struct chk_pool_rec	*cpr;
+	struct chk_pool_shard	*cps;
+	d_iov_t			 kiov;
+	d_iov_t			 riov;
+	int			 rc;
+
+	d_iov_set(&riov, NULL, 0);
+	d_iov_set(&kiov, uuid, sizeof(uuid_t));
+	rc = dbtree_lookup(hdl, &kiov, &riov);
+	if (rc != 0)
+		goto out;
+
+	cpr = (struct chk_pool_rec *)riov.iov_buf;
+	d_list_for_each_entry(cps, &cpr->cpr_shard_list, cps_link) {
+		if (cps->cps_rank == rank) {
+			d_list_del(&cps->cps_link);
+			if (cps->cps_free_cb != NULL)
+				cps->cps_free_cb(cps->cps_data);
+			else
+				D_FREE(cps->cps_data);
+			D_FREE(cps);
+			cpr->cpr_shard_nr--;
+			if (d_list_empty(&cpr->cpr_shard_list)) {
+				D_ASSERTF(cpr->cpr_shard_nr == 0,
+					  "Invalid shard count %u for pool "DF_UUID"\n",
+					  cpr->cpr_shard_nr, DP_UUID(uuid));
+				rc = dbtree_delete(hdl, BTR_PROBE_EQ, &kiov, NULL);
+			}
+
+			goto out;
+		}
+	}
+
+	rc = -DER_ENOENT;
+
+out:
+	D_CDEBUG(rc != 0, DLOG_ERR, DLOG_DBG, "Del pool shard "DF_UUID" for rank %u: "DF_RC"\n",
+		 DP_UUID(uuid), rank, DP_RC(rc));
+
+	return rc;
+}
+
+int
+chk_pending_add(struct chk_instance *ins, d_list_t *rank_head, uint64_t seq,
+		uint32_t rank, uint32_t cla, struct chk_pending_rec **cpr)
+{
+	struct chk_pending_bundle	rbund;
+	d_iov_t				kiov;
+	d_iov_t				riov;
+	d_iov_t				viov;
+	int				rc;
+
+	rbund.cpb_ins_head = &ins->ci_pending_list;
+	rbund.cpb_rank_head = rank_head;
+	rbund.cpb_seq = seq;
+	rbund.cpb_rank = rank;
+	rbund.cpb_class = cla;
+
+	d_iov_set(&viov, NULL, 0);
+	d_iov_set(&riov, &rbund, sizeof(rbund));
+	d_iov_set(&kiov, &seq, sizeof(seq));
+
+	/* The access may from multiple XS (on check engine), so taking the lock firstly. */
+	ABT_rwlock_wrlock(ins->ci_abt_lock);
+	rc = dbtree_upsert(ins->ci_pending_hdl, BTR_PROBE_EQ, DAOS_INTENT_UPDATE,
+			   &kiov, &riov, &viov);
+	if (rc == 0 && cpr != NULL) {
+		*cpr = (struct chk_pending_rec *)viov.iov_buf;
+		(*cpr)->cpr_busy = 1;
+	}
+	ABT_rwlock_unlock(ins->ci_abt_lock);
+
+	D_CDEBUG(rc != 0, DLOG_ERR, DLOG_DBG, "Add pending record with gen "DF_X64", seq "
+		 DF_X64", rank %u, class %u: "DF_RC"\n",
+		 ins->ci_bk.cb_gen, seq, rank, cla, DP_RC(rc));
+
+	return rc;
+}
+
+int
+chk_pending_del(struct chk_instance *ins, uint64_t seq, struct chk_pending_rec **cpr)
+{
+	d_iov_t		kiov;
+	d_iov_t		riov;
+	int		rc;
+
+	d_iov_set(&riov, NULL, 0);
+	d_iov_set(&kiov, &seq, sizeof(seq));
+
+	ABT_rwlock_wrlock(ins->ci_abt_lock);
+	rc = dbtree_delete(ins->ci_pending_hdl, BTR_PROBE_EQ, &kiov, &riov);
+	ABT_rwlock_unlock(ins->ci_abt_lock);
+
+	if (rc == 0)
+		*cpr = (struct chk_pending_rec *)riov.iov_buf;
+	else
+		*cpr = NULL;
+
+	D_CDEBUG(rc != 0, DLOG_ERR, DLOG_DBG, "Del pending record with gen "DF_X64", seq "
+		 DF_X64": "DF_RC"\n", ins->ci_bk.cb_gen, seq, DP_RC(rc));
+
+	return rc;
+}
+
+void
+chk_pending_destroy(struct chk_pending_rec *cpr)
+{
+	D_ASSERT(d_list_empty(&cpr->cpr_ins_link));
+	D_ASSERT(d_list_empty(&cpr->cpr_rank_link));
+
+	if (cpr->cpr_cond != ABT_COND_NULL)
+		ABT_cond_free(&cpr->cpr_cond);
+
+	if (cpr->cpr_mutex != ABT_MUTEX_NULL)
+		ABT_mutex_free(&cpr->cpr_mutex);
+
+	D_FREE(cpr);
+}
+
+int
+chk_ins_init(struct chk_instance *ins)
+{
+	struct umem_attr	uma = { 0 };
+	int			rc;
+
+	D_ASSERT(ins != NULL);
+
+	D_INIT_LIST_HEAD(&ins->ci_pending_list);
+	ins->ci_sched = ABT_THREAD_NULL;
+	ins->ci_seq = crt_hlc_get();
+
+	if (ins->ci_is_leader)
+		D_INIT_LIST_HEAD(&ins->ci_rank_list);
+	else
+		D_INIT_LIST_HEAD(&ins->ci_pool_list);
+
+	rc = ABT_rwlock_create(&ins->ci_abt_lock);
+		D_GOTO(out_init, rc = dss_abterr2der(rc));
+
+	rc = ABT_mutex_create(&ins->ci_abt_mutex);
+	if (rc != ABT_SUCCESS)
+		D_GOTO(out_lock, rc = dss_abterr2der(rc));
+
+	rc = ABT_cond_create(&ins->ci_abt_cond);
+	if (rc != ABT_SUCCESS)
+		D_GOTO(out_mutex, rc = dss_abterr2der(rc));
+
+	uma.uma_id = UMEM_CLASS_VMEM;
+
+	rc = dbtree_create_inplace(DBTREE_CLASS_CHK_PA, 0, CHK_BTREE_ORDER, &uma,
+				   &ins->ci_pending_btr, &ins->ci_pending_hdl);
+	if (rc != 0)
+		goto out_cond;
+
+	if (ins->ci_is_leader)
+		rc = dbtree_create_inplace(DBTREE_CLASS_CHK_RANK, 0, CHK_BTREE_ORDER, &uma,
+					   &ins->ci_rank_btr, &ins->ci_rank_hdl);
+	else
+		rc = dbtree_create_inplace(DBTREE_CLASS_CHK_POOL, 0, CHK_BTREE_ORDER, &uma,
+					   &ins->ci_pool_btr, &ins->ci_pool_hdl);
+	if (rc != 0)
+		goto out_pending;
+
+	D_GOTO(out_init, rc = 0);
+
+out_pending:
+	dbtree_destroy(ins->ci_pending_hdl, NULL);
+	ins->ci_pending_hdl = DAOS_HDL_INVAL;
+out_cond:
+	ABT_cond_free(&ins->ci_abt_cond);
+	ins->ci_abt_cond = ABT_COND_NULL;
+out_mutex:
+	ABT_mutex_free(&ins->ci_abt_mutex);
+	ins->ci_abt_mutex = ABT_MUTEX_NULL;
+out_lock:
+	ABT_rwlock_free(&ins->ci_abt_lock);
+	ins->ci_abt_lock = ABT_RWLOCK_NULL;
+out_init:
+	return rc;
+}
+
+void
+chk_ins_fini(struct chk_instance *ins)
+{
+	if (ins == NULL)
+		return;
+
+	if (ins->ci_iv_ns != NULL)
+		ds_iv_ns_put(ins->ci_iv_ns);
+
+	if (ins->ci_iv_group != NULL)
+		crt_group_secondary_destroy(ins->ci_iv_group);
+
+	d_rank_list_free(ins->ci_ranks);
+
+	if (ins->ci_is_leader) {
+		if (daos_handle_is_valid(ins->ci_rank_hdl))
+			dbtree_destroy(ins->ci_rank_hdl, NULL);
+
+		D_ASSERT(d_list_empty(&ins->ci_rank_list));
+	} else {
+		if (daos_handle_is_valid(ins->ci_pool_hdl))
+			dbtree_destroy(ins->ci_pool_hdl, NULL);
+
+		D_ASSERT(d_list_empty(&ins->ci_pool_list));
+	}
+
+	if (daos_handle_is_valid(ins->ci_pending_hdl))
+		dbtree_destroy(ins->ci_pending_hdl, NULL);
+
+	D_ASSERT(d_list_empty(&ins->ci_pending_list));
+	D_ASSERT(ins->ci_sched == ABT_THREAD_NULL);
+
+	if (ins->ci_abt_cond != ABT_COND_NULL)
+		ABT_cond_free(&ins->ci_abt_cond);
+
+	if (ins->ci_abt_mutex != ABT_MUTEX_NULL)
+		ABT_mutex_free(&ins->ci_abt_mutex);
+
+	if (ins->ci_abt_lock != ABT_RWLOCK_NULL)
+		ABT_rwlock_free(&ins->ci_abt_lock);
+
+	D_FREE(ins);
 }

--- a/src/chk/chk_engine.c
+++ b/src/chk/chk_engine.c
@@ -1,0 +1,1570 @@
+/**
+ * (C) Copyright 2022 Intel Corporation.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause-Patent
+ */
+
+#define D_LOGFAC	DD_FAC(chk)
+
+#include <time.h>
+#include <abt.h>
+#include <cart/api.h>
+#include <daos/btree.h>
+#include <daos/btree_class.h>
+#include <daos/common.h>
+#include <daos_srv/daos_engine.h>
+#include <daos_srv/daos_mgmt_srv.h>
+#include <daos_srv/daos_chk.h>
+#include <daos_srv/pool.h>
+#include <daos_srv/vos.h>
+#include <daos_srv/iv.h>
+#include <daos_srv/vos_types.h>
+
+#include "chk.pb-c.h"
+#include "chk_internal.h"
+
+#define DF_ENGINE	"Check engine (gen: "DF_X64")"
+#define DP_ENGINE(ins)	(ins)->ci_bk.cb_gen
+
+static struct chk_instance	*chk_engine;
+
+struct chk_traverse_pools_args {
+	uint64_t			 ctpa_gen;
+	struct chk_instance		*ctpa_ins;
+	uint32_t			 ctpa_status;
+};
+
+struct chk_engine_clues_args {
+	uint32_t			 ceca_pool_nr;
+	uuid_t				*ceca_pools;
+};
+
+struct chk_query_pool_args {
+	struct chk_instance		*cqpa_ins;
+	uint32_t			 cqpa_cap;
+	uint32_t			 cqpa_idx;
+	struct chk_query_pool_shard	*cqpa_shards;
+};
+
+struct chk_query_xstream_args {
+	uuid_t				 cqxa_uuid;
+	struct chk_query_pool_args	*cqxa_args;
+	struct chk_query_target		 cqxa_target;
+};
+
+static inline bool
+chk_engine_on_leader(d_rank_t leader)
+{
+	return dss_self_rank() == leader;
+}
+
+static int
+chk_pool_stop_one(struct chk_instance *ins, uuid_t uuid, uint32_t status, bool remove)
+{
+	struct chk_bookmark	*cbk;
+	struct chk_pool_rec	*cpr;
+	d_iov_t			 kiov;
+	d_iov_t			 riov;
+	int			 rc = 0;
+
+	/*
+	 * Remove the pool record from the tree firstly, that will cause related scan ULT
+	 * for such pool to exit, and then can update the pool's bookmark without race.
+	 */
+
+	d_iov_set(&riov, NULL, 0);
+	d_iov_set(&kiov, uuid, sizeof(uuid_t));
+	rc = dbtree_delete(ins->ci_pool_hdl, BTR_PROBE_EQ, &kiov, &riov);
+	if (rc != 0) {
+		if (rc != -DER_NONEXIST)
+			D_ERROR(DF_ENGINE" on rank %u failed to delete pool record "
+				DF_UUID" with status %u: "DF_RC"\n",
+				DP_ENGINE(ins), dss_self_rank(), DP_UUID(uuid), status, DP_RC(rc));
+	} else {
+		cpr = (struct chk_pool_rec *)riov.iov_buf;
+		cbk = &cpr->cpr_bk;
+
+		if (remove) {
+			rc = chk_bk_delete_pool(uuid);
+		} else if (cbk->cb_pool_status == CHK__CHECK_POOL_STATUS__CPS_CHECKING ||
+			   cbk->cb_pool_status == CHK__CHECK_POOL_STATUS__CPS_PENDING) {
+			cbk->cb_pool_status = status;
+			cbk->cb_time.ct_stop_time = time(NULL);
+			rc = chk_bk_update_pool(cbk, uuid);
+		}
+
+		D_FREE(cpr);
+	}
+
+	return rc;
+}
+
+static void
+chk_engine_exit(struct chk_instance *ins, uint32_t ins_status, uint32_t pool_status)
+{
+	struct chk_bookmark	*cbk = &ins->ci_bk;
+	struct chk_pool_rec	*cpr;
+	struct chk_pool_rec	*tmp;
+	struct chk_iv		 iv = { 0 };
+	int			 rc;
+
+	d_list_for_each_entry_safe(cpr, tmp, &ins->ci_pool_list, cpr_link)
+		chk_pool_stop_one(ins, cpr->cpr_uuid, pool_status, false);
+
+	if (cbk->cb_ins_status == CHK__CHECK_INST_STATUS__CIS_RUNNING) {
+		cbk->cb_ins_status = ins_status;
+		cbk->cb_time.ct_stop_time = time(NULL);
+		chk_bk_update_engine(cbk);
+	}
+
+	if (ins_status != CHK__CHECK_INST_STATUS__CIS_PAUSED &&
+	    ins_status != CHK__CHECK_INST_STATUS__CIS_IMPLICATED && ins->ci_iv_ns != NULL) {
+		iv.ci_gen = cbk->cb_gen;
+		iv.ci_phase = cbk->cb_phase;
+		iv.ci_status = ins_status;
+		iv.ci_to_leader = 1;
+
+		/* Synchronously notify the leader that check instance exit on the engine. */
+		rc = chk_iv_update(ins->ci_iv_ns, &iv, CRT_IV_SHORTCUT_TO_ROOT,
+				   CRT_IV_SYNC_EAGER, true);
+		if (rc != 0)
+			D_ERROR(DF_ENGINE" on rank %u failed to notify leader for its exit, "
+				"status %u: "DF_RC"\n",
+				DP_ENGINE(ins), dss_self_rank(), ins_status, DP_RC(rc));
+	}
+}
+
+static uint32_t
+chk_engine_find_slowest(struct chk_instance *ins)
+{
+	uint32_t		 phase = CHK__CHECK_SCAN_PHASE__DSP_DONE;
+	uint32_t		 base = ins->ci_bk.cb_phase;
+	struct chk_pool_rec	*cpr;
+
+	d_list_for_each_entry(cpr, &ins->ci_pool_list, cpr_link) {
+		if (cpr->cpr_phase <= base) {
+			phase = cpr->cpr_phase;
+			break;
+		}
+
+		if (cpr->cpr_phase < phase)
+			phase = cpr->cpr_phase;
+	}
+
+	return phase;
+}
+
+static int
+chk_engine_setup_pools(struct chk_instance *ins, bool svc)
+{
+	struct chk_property	*prop = &ins->ci_prop;
+	struct chk_bookmark	*cbk = &ins->ci_bk;
+	struct chk_bookmark	*pool_cbk;
+	struct chk_pool_rec	*cpr;
+	struct chk_pool_rec	*tmp;
+	uuid_t			 uuid;
+	int			 rc = 0;
+
+	d_list_for_each_entry_safe(cpr, tmp, &ins->ci_pool_list, cpr_link) {
+		if (cpr->cpr_started)
+			continue;
+
+		pool_cbk = &cpr->cpr_bk;
+		if (pool_cbk->cb_phase < cbk->cb_phase) {
+			pool_cbk->cb_phase = cbk->cb_phase;
+			/* XXX: How to estimate the left time? */
+			pool_cbk->cb_time.ct_left_time = CHK__CHECK_SCAN_PHASE__DSP_DONE -
+							 pool_cbk->cb_phase;
+			chk_bk_update_pool(pool_cbk, cpr->cpr_uuid);
+		}
+
+		rc = ds_pool_start(cpr->cpr_uuid);
+		if (rc != 0) {
+			uuid_copy(uuid, cpr->cpr_uuid);
+			ins->ci_slowest_fail_phase = pool_cbk->cb_phase;
+			chk_pool_stop_one(ins, uuid, CHK__CHECK_POOL_STATUS__CPS_FAILED, false);
+			if (prop->cp_flags & CHK__CHECK_FLAG__CF_FAILOUT) {
+				D_ERROR("Check engine %u (gen "DF_X64") failed to start pool "
+					DF_UUID": "DF_RC". Failout.\n",
+					dss_self_rank(), cbk->cb_gen, DP_UUID(uuid), DP_RC(rc));
+				goto out;
+			}
+
+			D_ERROR("Check engine %u (gen "DF_X64") failed to start pool "
+				DF_UUID": "DF_RC". Continue.\n",
+				dss_self_rank(), cbk->cb_gen, DP_UUID(uuid), DP_RC(rc));
+			rc = 0;
+		} else {
+			cpr->cpr_started = 1;
+		}
+	}
+
+out:
+	return rc;
+}
+
+static void
+chk_engine_pool_ult(void *args)
+{
+	struct chk_pool_rec	*cpr = args;
+
+	/* TBD: Drive the check since phase CHK__CHECK_SCAN_PHASE__CSP_POOL_MBS. */
+
+	while (!cpr->cpr_stop && cpr->cpr_ins->ci_sched_running) {
+		dss_sleep(300);
+	}
+}
+
+static void
+chk_engine_sched(void *args)
+{
+	struct chk_instance	*ins = args;
+	struct chk_bookmark	*cbk = &ins->ci_bk;
+	struct chk_property	*prop = &ins->ci_prop;
+	struct chk_bookmark	*pool_cbk;
+	struct chk_pool_rec	*cpr;
+	struct chk_pool_rec	*tmp;
+	uuid_t			 uuid;
+	uint32_t		 phase;
+	uint32_t		 ins_status;
+	uint32_t		 pool_status;
+	d_rank_t		 myrank = dss_self_rank();
+	int			 rc = 0;
+
+	if (cbk->cb_phase >= CHK__CHECK_SCAN_PHASE__CSP_POOL_LIST) {
+		rc = chk_engine_setup_pools(ins, true);
+		if (rc != 0)
+			goto out;
+	}
+
+	while (ins->ci_sched_running) {
+		switch (cbk->cb_phase) {
+		case CHK__CHECK_SCAN_PHASE__CSP_PREPARE:
+			/*
+			 * In this phase, the engine has already offer its known pools' svc list
+			 * to the leader via CHK_START RPC reply. The leader will notify engines
+			 * to go ahead after chk_leader_handle_pools_p1().
+			 */
+			/* Fall through to share code. */
+		case CHK__CHECK_SCAN_PHASE__CSP_POOL_LIST:
+			/*
+			 * Check leader has already done chk_leader_handle_pools_p1(), then engine
+			 * needs to setup pool module without pool service. And then notify leader
+			 * to start PS on specifiedreplica via chk_leader_handle_pools_p2(). After
+			 * that, check leader will notify engines to go ahead.
+			 */
+			ABT_mutex_lock(ins->ci_abt_mutex);
+			if (!ins->ci_sched_running) {
+				ABT_mutex_unlock(ins->ci_abt_mutex);
+				goto out;
+			}
+
+			if (d_list_empty(&ins->ci_pool_list)) {
+				ABT_mutex_unlock(ins->ci_abt_mutex);
+				D_GOTO(out, rc = 1);
+			}
+
+			ABT_cond_wait(ins->ci_abt_cond, ins->ci_abt_mutex);
+			ABT_mutex_unlock(ins->ci_abt_mutex);
+
+			/* XXX: How to estimate the left time? */
+			cbk->cb_time.ct_left_time = CHK__CHECK_SCAN_PHASE__DSP_DONE - cbk->cb_phase;
+			chk_bk_update_engine(cbk);
+
+			break;
+		case CHK__CHECK_SCAN_PHASE__CSP_POOL_MBS:
+			d_list_for_each_entry_safe(cpr, tmp, &ins->ci_pool_list, cpr_link) {
+				D_ASSERT(cpr->cpr_thread == ABT_THREAD_NULL);
+
+				rc = dss_ult_create(chk_engine_pool_ult, cpr, DSS_XS_SYS, 0,
+						    DSS_DEEP_STACK_SZ, &cpr->cpr_thread);
+				if (rc != 0) {
+					rc = dss_abterr2der(rc);
+					pool_cbk = &cpr->cpr_bk;
+					uuid_copy(uuid, cpr->cpr_uuid);
+					ins->ci_slowest_fail_phase = pool_cbk->cb_phase;
+					chk_pool_stop_one(ins, uuid,
+							  CHK__CHECK_POOL_STATUS__CPS_FAILED,
+							  false);
+					if (prop->cp_flags & CHK__CHECK_FLAG__CF_FAILOUT) {
+						D_ERROR("Check engine %u (gen "DF_X64") failed to "
+							"create ULT for pool "DF_UUID": "
+							DF_RC". Failout.\n", myrank,
+							cbk->cb_gen, DP_UUID(uuid), DP_RC(rc));
+						goto out;
+					}
+
+					D_ERROR("Check engine %u (gen "DF_X64") failed to create "
+						"ULT for pool "DF_UUID": "DF_RC". Continue.\n",
+						myrank, cbk->cb_gen, DP_UUID(uuid), DP_RC(rc));
+					rc = 0;
+				}
+			}
+
+			/* Fall through. */
+		case CHK__CHECK_SCAN_PHASE__CSP_POOL_CLEANUP:
+		case CHK__CHECK_SCAN_PHASE__CSP_CONT_LIST:
+		case CHK__CHECK_SCAN_PHASE__CSP_CONT_CLEANUP:
+			do {
+				dss_sleep(300);
+
+				/* Someone wants to stop the check. */
+				if (!ins->ci_sched_running)
+					D_GOTO(out, rc = 0);
+
+				if (d_list_empty(&ins->ci_pool_list))
+					D_GOTO(out, rc = 1);
+
+				phase = chk_engine_find_slowest(ins);
+				if (phase != cbk->cb_phase) {
+					cbk->cb_phase = phase;
+					/* XXX: How to estimate the left time? */
+					cbk->cb_time.ct_left_time =
+						CHK__CHECK_SCAN_PHASE__DSP_DONE - cbk->cb_phase;
+					chk_bk_update_engine(cbk);
+				}
+			} while (ins->ci_sched_running);
+
+			break;
+		case CHK__CHECK_SCAN_PHASE__CSP_DTX_RESYNC:
+		case CHK__CHECK_SCAN_PHASE__CSP_OBJ_SCRUB:
+		case CHK__CHECK_SCAN_PHASE__CSP_REBUILD:
+		case CHK__CHECK_SCAN_PHASE__OSP_AGGREGATION:
+			/* XXX: These phases will be implemented in the future. */
+			D_ASSERT(0);
+			break;
+		case CHK__CHECK_SCAN_PHASE__DSP_DONE:
+			D_GOTO(out, rc = 1);
+		default:
+			D_ASSERT(0);
+			goto out;
+		}
+	}
+
+out:
+	if (rc > 0) {
+		/* If failed to check some pool(s), then the engine will be marked as 'failed'. */
+		if (ins->ci_slowest_fail_phase != CHK__CHECK_SCAN_PHASE__CSP_PREPARE)
+			ins_status = CHK__CHECK_INST_STATUS__CIS_FAILED;
+		else
+			ins_status = CHK__CHECK_INST_STATUS__CIS_COMPLETED;
+		pool_status = CHK__CHECK_POOL_STATUS__CPS_CHECKED;
+	} else if (rc == 0) {
+		if (ins->ci_implicated) {
+			ins_status = CHK__CHECK_INST_STATUS__CIS_IMPLICATED;
+			pool_status = CHK__CHECK_POOL_STATUS__CPS_IMPLICATED;
+		} else if (ins->ci_stopping) {
+			ins_status = CHK__CHECK_INST_STATUS__CIS_STOPPED;
+			pool_status = CHK__CHECK_POOL_STATUS__CPS_STOPPED;
+		} else {
+			ins_status = CHK__CHECK_INST_STATUS__CIS_PAUSED;
+			pool_status = CHK__CHECK_POOL_STATUS__CPS_PAUSED;
+		}
+	} else {
+		ins_status = CHK__CHECK_INST_STATUS__CIS_FAILED;
+		pool_status = CHK__CHECK_POOL_STATUS__CPS_IMPLICATED;
+	}
+
+	/* The pool scan ULTs will be terminated via chk_engine_exit(). */
+	chk_engine_exit(ins, ins_status, pool_status);
+
+	D_INFO("Check engine %u (gen "DF_X64") exit at the phase %u with "DF_RC"\n",
+	       myrank, cbk->cb_gen, cbk->cb_phase, DP_RC(rc));
+
+	/*
+	 * The engine scheduler may exit for its own reason (instead of by CHK_STOP),
+	 * then reset ci_sched_running to avoid blocking next CHK_START.
+	 */
+	ins->ci_sched_running = 0;
+}
+
+static int
+chk_engine_start_prepare(struct chk_instance *ins, uint32_t rank_nr, d_rank_t *ranks,
+			 uint32_t policy_nr, struct chk_policy **policies,
+			 uint32_t pool_nr, uuid_t pools[], uint64_t gen, int phase,
+			 uint32_t flags, d_rank_t leader, d_rank_list_t **rlist)
+{
+	struct chk_bookmark	*cbk = &ins->ci_bk;
+	struct chk_property	*prop = &ins->ci_prop;
+	bool			 reset = (flags & CHK__CHECK_FLAG__CF_RESET) ? true : false;
+	int			 rc = 0;
+	int			 i;
+	int			 j;
+
+	/*
+	 * XXX: Currently we cannot distinguish whether it is caused by resent start request
+	 *	or not. That can be resolved via introducing new RPC sequence in the future.
+	 */
+	if (ins->ci_sched_running)
+		D_GOTO(out, rc = -DER_ALREADY);
+
+	/* Corrupted bookmark or new created one. */
+	if (cbk->cb_magic != CHK_BK_MAGIC_ENGINE) {
+		if (!reset)
+			D_GOTO(out, rc = -DER_NOT_RESUME);
+
+		if (!chk_engine_on_leader(leader))
+			memset(prop, 0, sizeof(*prop));
+
+		memset(cbk, 0, sizeof(*cbk));
+		cbk->cb_magic = CHK_BK_MAGIC_ENGINE;
+		cbk->cb_version = DAOS_CHK_VERSION;
+		flags |= CHK__CHECK_FLAG__CF_RESET;
+		goto init;
+	}
+
+	if (cbk->cb_gen > gen)
+		D_GOTO(out, rc = -DER_EP_OLD);
+
+	/*
+	 * XXX: Leader wants to resume the check but with different generation, then this
+	 *	engine must be new joined one for current check instance. Under such case
+	 *	we have to restart the scan from scratch.
+	 */
+	if (cbk->cb_gen != gen && !reset)
+		D_GOTO(out, rc = -DER_NOT_RESUME);
+
+	if (cbk->cb_ins_status == CHK__CHECK_INST_STATUS__CIS_RUNNING)
+		D_GOTO(out, rc = -DER_ALREADY);
+
+	if (reset)
+		goto init;
+
+	if (cbk->cb_ins_status == CHK__CHECK_INST_STATUS__CIS_COMPLETED)
+		D_GOTO(out, rc = 1);
+
+	/* Drop dryrun flags needs to reset. */
+	if (prop->cp_flags & CHK__CHECK_FLAG__CF_DRYRUN && !(flags & CHK__CHECK_FLAG__CF_DRYRUN)) {
+		if (!reset)
+			D_GOTO(out, rc = -DER_NOT_RESUME);
+
+		goto init;
+	}
+
+	/*
+	 * XXX: If current rank list does not matches the former list, the we need to
+	 *	reset the check from scratch. Currently, we do not strictly check that.
+	 *	It is control plane's duty to generate valid rank list.
+	 */
+
+	/* Add new rank(s), need to reset. */
+	if (rank_nr > prop->cp_rank_nr) {
+		if (!reset)
+			D_GOTO(out, rc = -DER_NOT_RESUME);
+
+		goto init;
+	}
+
+	if (prop->cp_pool_nr < 0)
+		goto init;
+
+	/* Want to check new pool(s), need to reset. */
+	if (pool_nr < 0) {
+		if (!reset)
+			D_GOTO(out, rc = -DER_NOT_RESUME);
+
+		goto init;
+	}
+
+	for (i = 0; i < pool_nr; i++) {
+		for (j = 0; j < prop->cp_pool_nr; j++) {
+			if (uuid_compare(pools[i], prop->cp_pools[j]) == 0)
+				break;
+		}
+
+		/* Want to check new pool(s), need to reset. */
+		if (j == prop->cp_pool_nr) {
+			if (!reset)
+				D_GOTO(out, rc = -DER_NOT_RESUME);
+
+			goto init;
+		}
+	}
+
+init:
+	if (reset) {
+		cbk->cb_gen = gen;
+		cbk->cb_phase = CHK__CHECK_SCAN_PHASE__CSP_PREPARE;
+		memset(&cbk->cb_statistics, 0, sizeof(cbk->cb_statistics));
+	}
+
+	if (chk_engine_on_leader(prop->cp_leader)) {
+		/* The check leader has already verified the rank list. */
+		if (rank_nr != 0)
+			*rlist = uint32_array_to_rank_list(ranks, rank_nr);
+		else
+			rc = chk_prop_fetch(prop, rlist);
+	} else {
+		rc = chk_prop_prepare(rank_nr, ranks, policy_nr, policies, pool_nr,
+				      pools, flags, phase, leader, prop, rlist);
+	}
+
+out:
+	return rc;
+}
+
+/* Remove all old pool bookmarks. */
+static int
+chk_pools_cleanup_cb(struct sys_db *db, char *table, d_iov_t *key, void *args)
+{
+	struct chk_traverse_pools_args	*ctpa = args;
+	unsigned char			*uuid = key->iov_buf;
+	struct chk_bookmark		 cbk;
+	int				 rc = 0;
+
+	if (!d_is_uuid(uuid))
+		D_GOTO(out, rc = 0);
+
+	rc = chk_bk_fetch_pool(&cbk, uuid);
+	if (rc != 0)
+		goto out;
+
+	if (cbk.cb_gen >= ctpa->ctpa_gen)
+		D_GOTO(out, rc = 0);
+
+	rc = chk_bk_delete_pool(uuid);
+
+out:
+	return rc;
+}
+
+static int
+chk_pool_start_one(struct chk_instance *ins, uuid_t uuid, uint64_t gen)
+{
+	struct chk_bookmark	cbk;
+	int	rc;
+
+	rc = chk_bk_fetch_pool(&cbk, uuid);
+	if (rc != 0 && rc == -DER_NONEXIST)
+		goto out;
+
+	if (cbk.cb_magic != CHK_BK_MAGIC_POOL) {
+		cbk.cb_magic = CHK_BK_MAGIC_POOL;
+		cbk.cb_version = DAOS_CHK_VERSION;
+		cbk.cb_gen = gen;
+		cbk.cb_phase = CHK__CHECK_SCAN_PHASE__CSP_PREPARE;
+	} else if (cbk.cb_pool_status == CHK__CHECK_POOL_STATUS__CPS_FAILED) {
+		if (cbk.cb_phase < ins->ci_slowest_fail_phase)
+			ins->ci_slowest_fail_phase = cbk.cb_phase;
+	}
+
+	/* Always refresh the start time. */
+	cbk.cb_time.ct_start_time = time(NULL);
+	/* XXX: How to estimate the left time? */
+	cbk.cb_time.ct_left_time = CHK__CHECK_SCAN_PHASE__DSP_DONE - cbk.cb_phase;
+	cbk.cb_pool_status = CHK__CHECK_POOL_STATUS__CPS_CHECKING;
+	rc = chk_pool_add_shard(ins->ci_pool_hdl, &ins->ci_pool_list, uuid, dss_self_rank(),
+				cbk.cb_phase, &cbk, ins, NULL, NULL, NULL);
+	if (rc != 0)
+		goto out;
+
+	rc = chk_bk_update_pool(&cbk, uuid);
+	if (rc != 0)
+		chk_pool_del_shard(ins->ci_pool_hdl, uuid, dss_self_rank());
+
+out:
+	return rc;
+}
+
+static int
+chk_pools_add_from_dir(uuid_t uuid, void *args)
+{
+	struct chk_traverse_pools_args	*ctpa = args;
+	struct chk_instance		*ins = ctpa->ctpa_ins;
+
+	return chk_pool_start_one(ins, uuid, ctpa->ctpa_gen);
+}
+
+static int
+chk_pools_add_from_db(struct sys_db *db, char *table, d_iov_t *key, void *args)
+{
+	struct chk_traverse_pools_args	*ctpa = args;
+	struct chk_instance		*ins = ctpa->ctpa_ins;
+	unsigned char			*uuid = key->iov_buf;
+	struct chk_bookmark		 cbk;
+	int				 rc = 0;
+
+	if (!d_is_uuid(uuid))
+		D_GOTO(out, rc = 0);
+
+	rc = chk_bk_fetch_pool(&cbk, uuid);
+	if (rc != 0)
+		goto out;
+
+	if (cbk.cb_gen != ctpa->ctpa_gen)
+		D_GOTO(out, rc = 0);
+
+	if (cbk.cb_pool_status == CHK__CHECK_POOL_STATUS__CPS_FAILED) {
+		if (cbk.cb_phase < ins->ci_slowest_fail_phase)
+			ins->ci_slowest_fail_phase = cbk.cb_phase;
+	}
+
+	/* Always refresh the start time. */
+	cbk.cb_time.ct_start_time = time(NULL);
+	/* XXX: How to estimate the left time? */
+	cbk.cb_time.ct_left_time = CHK__CHECK_SCAN_PHASE__DSP_DONE - cbk.cb_phase;
+	cbk.cb_pool_status = CHK__CHECK_POOL_STATUS__CPS_CHECKING;
+	rc = chk_pool_add_shard(ins->ci_pool_hdl, &ins->ci_pool_list, uuid,
+				dss_self_rank(), ins->ci_bk.cb_phase, &cbk, ins,
+				NULL, NULL, NULL);
+	if (rc != 0)
+		goto out;
+
+	rc = chk_bk_update_pool(&cbk, uuid);
+	if (rc != 0)
+		chk_pool_del_shard(ctpa->ctpa_ins->ci_pool_hdl, uuid, dss_self_rank());
+
+out:
+	return rc;
+}
+
+static int
+chk_engine_clues_filter(uuid_t uuid, void *arg)
+{
+	struct chk_engine_clues_args	*ceca = arg;
+	int				 i;
+
+	if (ceca->ceca_pool_nr == 0)
+		return 0;
+
+	for (i = 0; i < ceca->ceca_pool_nr; i++) {
+		if (uuid_compare(uuid, ceca->ceca_pools[i]) == 0)
+			return 0;
+	}
+
+	return 1;
+}
+
+int
+chk_engine_start(uint64_t gen, uint32_t rank_nr, d_rank_t *ranks,
+		 uint32_t policy_nr, struct chk_policy **policies, uint32_t pool_nr,
+		 uuid_t pools[], uint32_t flags, int32_t exp_phase, d_rank_t leader,
+		 uint32_t *cur_phase, struct ds_pool_clues *clues)
+{
+	struct chk_instance		*ins = chk_engine;
+	struct chk_bookmark		*cbk = &ins->ci_bk;
+	struct chk_property		*prop = &ins->ci_prop;
+	d_rank_list_t			*rank_list = NULL;
+	struct chk_pool_rec		*cpr;
+	struct chk_pool_rec		*tmp;
+	struct chk_traverse_pools_args	 ctpa = { 0 };
+	struct chk_engine_clues_args	 ceca = { 0 };
+	d_rank_t			 myrank = dss_self_rank();
+	int				 rc;
+	int				 i;
+
+	if (ins->ci_starting)
+		D_GOTO(out_log, rc = -DER_INPROGRESS);
+
+	if (ins->ci_stopping)
+		D_GOTO(out_log, rc = -DER_BUSY);
+
+	ins->ci_starting = 1;
+
+	rc = chk_engine_start_prepare(ins, rank_nr, ranks, policy_nr, policies,
+				      pool_nr, pools, gen, exp_phase, flags, leader, &rank_list);
+	if (rc != 0)
+		goto out_log;
+
+	D_ASSERT(rank_list != NULL);
+	D_ASSERT(d_list_empty(&ins->ci_pool_list));
+	D_ASSERT(d_list_empty(&ins->ci_pending_list));
+	D_ASSERT(ins->ci_sched == ABT_THREAD_NULL);
+
+	if (ins->ci_iv_ns != NULL) {
+		ds_iv_ns_put(ins->ci_iv_ns);
+		ins->ci_iv_ns = NULL;
+	}
+
+	if (ins->ci_iv_group != NULL) {
+		crt_group_secondary_destroy(ins->ci_iv_group);
+		ins->ci_iv_group = NULL;
+	}
+
+	rc = crt_group_secondary_create(CHK_DUMMY_POOL, NULL, rank_list, &ins->ci_iv_group);
+	if (rc != 0)
+		goto out_log;
+
+	rc = ds_iv_ns_create(dss_get_module_info()->dmi_ctx, (unsigned char *)CHK_DUMMY_POOL,
+			     ins->ci_iv_group, &ins->ci_iv_id, &ins->ci_iv_ns);
+	if (rc != 0)
+		goto out_group;
+
+	ds_iv_ns_update(ins->ci_iv_ns, leader);
+
+	if (prop->cp_pool_nr <= 0)
+		ins->ci_all_pools = 1;
+	else
+		ins->ci_all_pools = 0;
+
+	if (flags & CHK__CHECK_FLAG__CF_RESET) {
+		ctpa.ctpa_gen = cbk->cb_gen;
+		rc = chk_traverse_pools(chk_pools_cleanup_cb, &ctpa);
+		if (rc != 0)
+			goto out_iv;
+
+		ctpa.ctpa_gen = cbk->cb_gen;
+		ctpa.ctpa_ins = ins;
+
+		rc = ds_mgmt_tgt_pool_iterate(chk_pools_add_from_dir, &ctpa);
+		if (rc != 0)
+			goto out_pool;
+
+		rc = ds_mgmt_newborn_pool_iterate(chk_pools_add_from_dir, &ctpa);
+		if (rc != 0)
+			goto out_pool;
+
+		rc = ds_mgmt_zombie_pool_iterate(chk_pools_add_from_dir, &ctpa);
+		if (rc != 0)
+			goto out_pool;
+
+		*cur_phase = CHK__CHECK_SCAN_PHASE__CSP_PREPARE;
+	} else {
+		if (ins->ci_all_pools) {
+			ctpa.ctpa_gen = cbk->cb_gen;
+			ctpa.ctpa_ins = ins;
+			rc = chk_traverse_pools(chk_pools_add_from_db, &ctpa);
+			if (rc != 0)
+				goto out_pool;
+		} else {
+			for (i = 0; i < pool_nr; i++) {
+				rc = ds_mgmt_pool_exist(pools[i]);
+				if (rc < 0)
+					goto out_pool;
+
+				if (rc > 0) {
+					rc = chk_pool_start_one(ins, pools[i], cbk->cb_gen);
+					if (rc != 0)
+						goto out_pool;
+				}
+			}
+		}
+
+		*cur_phase = chk_engine_find_slowest(ins);
+	}
+
+	cbk->cb_ins_status = CHK__CHECK_INST_STATUS__CIS_RUNNING;
+	cbk->cb_phase = *cur_phase;
+	/* Always refresh the start time. */
+	cbk->cb_time.ct_start_time = time(NULL);
+	/* XXX: How to estimate the left time? */
+	cbk->cb_time.ct_left_time = CHK__CHECK_SCAN_PHASE__DSP_DONE - cbk->cb_phase;
+	rc = chk_bk_update_engine(cbk);
+	if (rc != 0)
+		goto out_pool;
+
+	if (cbk->cb_phase == CHK__CHECK_SCAN_PHASE__CSP_PREPARE ||
+	    cbk->cb_phase == CHK__CHECK_SCAN_PHASE__CSP_POOL_LIST) {
+		ceca.ceca_pool_nr = pool_nr;
+		ceca.ceca_pools = pools;
+		rc = ds_pool_clues_init(chk_engine_clues_filter, &ceca, clues);
+		if (rc != 0)
+			goto out_bk;
+	}
+
+	ins->ci_sched_running = 1;
+
+	rc = dss_ult_create(chk_engine_sched, ins, DSS_XS_SYS, 0, DSS_DEEP_STACK_SZ,
+			    &ins->ci_sched);
+	if (rc != 0) {
+		ins->ci_sched_running = 0;
+		goto out_bk;
+	}
+
+	goto out_log;
+
+out_bk:
+	if (rc != -DER_ALREADY && cbk->cb_ins_status == CHK__CHECK_INST_STATUS__CIS_RUNNING) {
+		cbk->cb_time.ct_stop_time = time(NULL);
+		cbk->cb_ins_status = CHK__CHECK_INST_STATUS__CIS_FAILED;
+		chk_bk_update_engine(cbk);
+	}
+out_pool:
+	d_list_for_each_entry_safe(cpr, tmp, &ins->ci_pool_list, cpr_link)
+		chk_pool_stop_one(ins, cpr->cpr_uuid,
+				  CHK__CHECK_POOL_STATUS__CPS_IMPLICATED, false);
+out_iv:
+	ds_iv_ns_put(ins->ci_iv_ns);
+	ins->ci_iv_ns = NULL;
+out_group:
+	crt_group_secondary_destroy(ins->ci_iv_group);
+	ins->ci_iv_group = NULL;
+out_log:
+	ins->ci_starting = 0;
+
+	if (rc == 0) {
+		D_INFO(DF_ENGINE" started on rank %u with %u ranks, %u pools, "
+		       "flags %x, phase %d, leader %u\n",
+		       DP_ENGINE(ins), myrank, rank_nr, pool_nr, flags, exp_phase, leader);
+
+		chk_ranks_dump(rank_list->rl_nr, rank_list->rl_ranks);
+
+		if (pool_nr > 0)
+			chk_pools_dump(pool_nr, pools);
+		else if (prop->cp_pool_nr > 0)
+			chk_pools_dump(prop->cp_pool_nr, prop->cp_pools);
+	} else if (rc > 0) {
+		*cur_phase = CHK__CHECK_SCAN_PHASE__DSP_DONE;
+	} else if (rc != -DER_ALREADY) {
+		D_ERROR(DF_ENGINE" failed to start on rank %u with %u ranks, %u pools, flags %x, "
+			"phase %d, leader %u, gen "DF_X64": "DF_RC"\n", DP_ENGINE(ins), myrank,
+			rank_nr, pool_nr, flags, exp_phase, leader, gen, DP_RC(rc));
+	}
+
+	d_rank_list_free(rank_list);
+
+	return rc;
+}
+
+int
+chk_engine_stop(uint64_t gen, uint32_t pool_nr, uuid_t pools[])
+{
+	struct chk_instance	*ins = chk_engine;
+	struct chk_property	*prop = &ins->ci_prop;
+	struct chk_bookmark	*cbk = &ins->ci_bk;
+	struct chk_pool_rec	*cpr;
+	struct chk_pool_rec	*tmp;
+	int			 rc = 0;
+	int			 i;
+
+	if (cbk->cb_magic != CHK_BK_MAGIC_ENGINE || cbk->cb_gen != gen)
+		D_GOTO(out, rc = -DER_NOTAPPLICABLE);
+
+	if (ins->ci_starting)
+		D_GOTO(out, rc = -DER_BUSY);
+
+	if (ins->ci_stopping)
+		D_GOTO(out, rc = -DER_INPROGRESS);
+
+	ins->ci_stopping = 1;
+
+	if (cbk->cb_ins_status != CHK__CHECK_INST_STATUS__CIS_RUNNING)
+		D_GOTO(out, rc = -DER_ALREADY);
+
+	if (pool_nr == 0) {
+		d_list_for_each_entry_safe(cpr, tmp, &ins->ci_pool_list, cpr_link) {
+			rc = chk_pool_stop_one(ins, cpr->cpr_uuid,
+					       CHK__CHECK_POOL_STATUS__CPS_STOPPED, false);
+			if (rc != 0)
+				goto out;
+		}
+	} else {
+		for (i = 0; i < pool_nr; i++) {
+			rc = chk_pool_stop_one(ins, pools[i],
+					       CHK__CHECK_POOL_STATUS__CPS_STOPPED, false);
+			if (rc == -DER_NONEXIST)
+				rc = 0;
+			if (rc != 0)
+				goto out;
+		}
+	}
+
+	if (d_list_empty(&ins->ci_pool_list)) {
+		chk_stop_sched(ins);
+		/* To indicate that there is no active pool(s) on this rank. */
+		rc = 1;
+	}
+
+out:
+	ins->ci_stopping = 0;
+
+	if (rc == 0) {
+		D_INFO(DF_ENGINE" stopped on rank %u with %u pools\n",
+		       DP_ENGINE(ins), dss_self_rank(), pool_nr > 0 ? pool_nr : prop->cp_pool_nr);
+
+		if (pool_nr > 0)
+			chk_pools_dump(pool_nr, pools);
+		else if (prop->cp_pool_nr > 0)
+			chk_pools_dump(prop->cp_pool_nr, prop->cp_pools);
+	} else if (rc < 0 && rc == -DER_ALREADY) {
+		D_ERROR(DF_ENGINE" failed to stop on rank %u with %u pools, "
+			"gen "DF_X64": "DF_RC"\n", DP_ENGINE(ins), dss_self_rank(),
+			pool_nr > 0 ? pool_nr : prop->cp_pool_nr, gen, DP_RC(rc));
+	}
+
+	return rc;
+}
+
+/* Query one pool shard on one xstream. */
+static int
+chk_engine_query_one(void *args)
+{
+	struct dss_coll_stream_args	*reduce = args;
+	struct dss_stream_arg_type	*streams = reduce->csa_streams;
+	struct chk_query_xstream_args	*cqxa;
+	struct chk_query_target		*target;
+	char				*path = NULL;
+	daos_handle_t			 poh = DAOS_HDL_INVAL;
+	vos_pool_info_t			 info;
+	int				 tid = dss_get_module_info()->dmi_tgt_id;
+	int				 rc;
+
+	cqxa = streams[tid].st_arg;
+	target = &cqxa->cqxa_target;
+	rc = ds_mgmt_pool_shard_exist(cqxa->cqxa_uuid,  &path);
+	/* We allow the target nonexist. */
+	if (rc <= 0)
+		goto out;
+
+	rc = vos_pool_open(path, cqxa->cqxa_uuid, 0, &poh);
+	if (rc != 0) {
+		D_ERROR("Failed to open vos pool "DF_UUID" on target %u/%d: "DF_RC"\n",
+			cqxa->cqxa_uuid, dss_self_rank(), tid, DP_RC(rc));
+		goto out;
+	}
+
+	rc = vos_pool_query(poh, &info);
+	if (rc != 0) {
+		D_ERROR("Failed to query vos pool "DF_UUID" on target %u/%d: "DF_RC"\n",
+			cqxa->cqxa_uuid, dss_self_rank(), tid, DP_RC(rc));
+		goto out;
+	}
+
+	target->cqt_rank = dss_self_rank();
+	target->cqt_tgt = tid;
+	target->cqt_ins_status = info.pif_chk_status;
+	target->cqt_statistics = info.pif_chk_statistics;
+	target->cqt_time = info.pif_chk_time;
+
+out:
+	if (daos_handle_is_valid(poh))
+		vos_pool_close(poh);
+	D_FREE(path);
+	return rc;
+}
+
+static void
+chk_engine_query_reduce(void *a_args, void *s_args)
+{
+	struct	chk_query_xstream_args	*aggregator = a_args;
+	struct  chk_query_xstream_args	*stream = s_args;
+	struct chk_query_pool_shard	*shard;
+	struct chk_query_target		*target;
+
+	shard = &aggregator->cqxa_args->cqpa_shards[aggregator->cqxa_args->cqpa_idx];
+	target = &shard->cqps_targets[shard->cqps_target_nr];
+	*target = stream->cqxa_target;
+	shard->cqps_target_nr++;
+}
+
+static int
+chk_engine_query_stream_alloc(struct dss_stream_arg_type *args, void *a_arg)
+{
+	struct chk_query_xstream_args	*cqxa = a_arg;
+	int				 rc = 0;
+
+	D_ALLOC(args->st_arg, sizeof(struct chk_query_xstream_args));
+	if (args->st_arg == NULL)
+		D_GOTO(out, rc = -DER_NOMEM);
+
+	memcpy(args->st_arg, cqxa, sizeof(struct chk_query_xstream_args));
+
+out:
+	return rc;
+}
+
+static void
+chk_engine_query_stream_free(struct dss_stream_arg_type *args)
+{
+	D_ASSERT(args->st_arg != NULL);
+	D_FREE(args->st_arg);
+}
+
+static int
+chk_engine_query_pool(uuid_t uuid, void *args)
+{
+	struct chk_query_pool_args	*cqpa = args;
+	struct chk_query_pool_shard	*shard;
+	struct chk_query_pool_shard	*new_shards;
+	struct chk_bookmark		 cbk;
+	struct chk_query_xstream_args	 cqxa = { 0 };
+	struct dss_coll_args		 coll_args = { 0 };
+	struct dss_coll_ops		 coll_ops;
+	int				 rc = 0;
+
+	if (cqpa->cqpa_idx == cqpa->cqpa_cap) {
+		D_REALLOC_ARRAY(new_shards, cqpa->cqpa_shards, cqpa->cqpa_cap, cqpa->cqpa_cap << 1);
+		if (new_shards == NULL)
+			D_GOTO(out, rc = -DER_NOMEM);
+
+		cqpa->cqpa_shards = new_shards;
+		cqpa->cqpa_cap <<= 1;
+	}
+
+	shard = &cqpa->cqpa_shards[cqpa->cqpa_idx];
+	uuid_copy(shard->cqps_uuid, uuid);
+	shard->cqps_rank = dss_self_rank();
+	shard->cqps_target_nr = 0;
+
+	rc = chk_bk_fetch_pool(&cbk, uuid);
+	if (rc == -DER_NONEXIST) {
+		shard->cqps_status = CHK__CHECK_POOL_STATUS__CPS_UNCHECKED;
+		shard->cqps_phase = CHK__CHECK_SCAN_PHASE__CSP_PREPARE;
+		memset(&shard->cqps_statistics, 0, sizeof(shard->cqps_statistics));
+		memset(&shard->cqps_time, 0, sizeof(shard->cqps_time));
+		shard->cqps_targets = NULL;
+
+		D_GOTO(out, rc = 0);
+	}
+
+	if (rc != 0)
+		goto out;
+
+	D_ALLOC_ARRAY(shard->cqps_targets, dss_tgt_nr);
+	if (shard->cqps_targets == NULL)
+		D_GOTO(out, rc = -DER_NOMEM);
+
+	shard->cqps_status = cbk.cb_pool_status;
+	shard->cqps_phase = cbk.cb_phase;
+	memcpy(&shard->cqps_statistics, &cbk.cb_statistics, sizeof(shard->cqps_statistics));
+	memcpy(&shard->cqps_time, &cbk.cb_time, sizeof(shard->cqps_time));
+
+	uuid_copy(cqxa.cqxa_uuid, uuid);
+	cqxa.cqxa_args = cqpa;
+
+	coll_args.ca_func_args = &coll_args.ca_stream_args;
+	coll_args.ca_aggregator = &cqxa;
+
+	coll_ops.co_func = chk_engine_query_one;
+	coll_ops.co_reduce = chk_engine_query_reduce;
+	coll_ops.co_reduce_arg_alloc = chk_engine_query_stream_alloc;
+	coll_ops.co_reduce_arg_free = chk_engine_query_stream_free;
+
+	rc = dss_task_collective_reduce(&coll_ops, &coll_args, 0);
+
+out:
+	D_CDEBUG(rc != 0, DLOG_ERR, DLOG_DBG,
+		 DF_ENGINE" on rank %u query pool "DF_UUID":"DF_RC"\n",
+		 DP_ENGINE(cqpa->cqpa_ins), dss_self_rank(), DP_UUID(uuid), DP_RC(rc));
+	return rc;
+}
+
+int
+chk_engine_query(uint64_t gen, uint32_t pool_nr, uuid_t pools[],
+		 uint32_t *shard_nr, struct chk_query_pool_shard **shards)
+{
+	struct chk_instance		*ins = chk_engine;
+	struct chk_bookmark		*cbk = &ins->ci_bk;
+	struct chk_query_pool_args	 cqpa = { 0 };
+	int				 rc = 0;
+	int				 i;
+
+	if (cbk->cb_gen != gen)
+		D_GOTO(out, rc = -DER_NOTAPPLICABLE);
+
+	cqpa.cqpa_ins = ins;
+	cqpa.cqpa_cap = 2;
+	cqpa.cqpa_idx = 0;
+	D_ALLOC_ARRAY(cqpa.cqpa_shards, cqpa.cqpa_cap);
+	if (cqpa.cqpa_shards == NULL)
+		D_GOTO(log, rc = -DER_NOMEM);
+
+	if (pool_nr == 0) {
+		rc = ds_mgmt_tgt_pool_iterate(chk_engine_query_pool, &cqpa);
+	} else {
+		for (i = 0; i < pool_nr; i++) {
+			rc = chk_engine_query_pool(pools[i], &cqpa);
+			if (rc != 0)
+				goto log;
+		}
+	}
+
+log:
+	if (rc != 0) {
+		chk_query_free(cqpa.cqpa_shards, cqpa.cqpa_idx);
+	} else {
+		*shards = cqpa.cqpa_shards;
+		*shard_nr = cqpa.cqpa_idx;
+	}
+
+	D_CDEBUG(rc != 0, DLOG_ERR, DLOG_DBG,
+		 DF_ENGINE" on rank %u handle query for %u pools :"DF_RC"\n",
+		 DP_ENGINE(ins), dss_self_rank(), pool_nr, DP_RC(rc));
+
+out:
+	return rc;
+}
+
+int
+chk_engine_mark_rank_dead(uint64_t gen, d_rank_t rank, uint32_t version)
+{
+	struct chk_instance	*ins = chk_engine;
+	struct chk_property	*prop = &ins->ci_prop;
+	struct chk_bookmark	*cbk = &ins->ci_bk;
+	d_rank_list_t		*rank_list = NULL;
+	int			 rc = 0;
+
+	if (cbk->cb_gen != gen)
+		D_GOTO(out, rc = -DER_NOTAPPLICABLE);
+
+	rc = chk_prop_fetch(prop, &rank_list);
+	if (rc != 0)
+		goto out;
+
+	D_ASSERT(rank_list != NULL);
+
+	if (!chk_remove_rank_from_list(rank_list, rank))
+		D_GOTO(out, rc = -DER_NOTAPPLICABLE);
+
+	prop->cp_rank_nr--;
+	rc = chk_prop_update(prop, rank_list);
+	if (rc != 0)
+		goto out;
+
+	rc = crt_group_secondary_modify(ins->ci_iv_group, rank_list, rank_list,
+					CRT_GROUP_MOD_OP_REPLACE, version);
+
+	/* TBD: mark related pools as 'failed'. */
+
+out:
+	d_rank_list_free(rank_list);
+	if (rc != -DER_NOTAPPLICABLE)
+		D_CDEBUG(rc != 0, DLOG_ERR, DLOG_INFO,
+			 DF_ENGINE" on rank %u mark rank %u as dead with gen "
+			 DF_X64", version %u: "DF_RC"\n",
+			 DP_ENGINE(ins), dss_self_rank(), rank, gen, version, DP_RC(rc));
+
+	return rc;
+}
+
+int
+chk_engine_act(uint64_t gen, uint64_t seq, uint32_t cla, uint32_t act, uint32_t flags)
+{
+	struct chk_instance	*ins = chk_engine;
+	struct chk_property	*prop = &ins->ci_prop;
+	struct chk_bookmark	*cbk = &ins->ci_bk;
+	struct chk_pending_rec	*cpr = NULL;
+	int			 rc;
+
+	if (cbk->cb_gen != gen)
+		D_GOTO(out, rc = -DER_NOTAPPLICABLE);
+
+	if (unlikely(cla >= CHK_POLICY_MAX)) {
+		D_ERROR("Invalid DAOS inconsistency class %u\n", cla);
+		D_GOTO(out, rc = -DER_INVAL);
+	}
+
+	/* The admin may input the wrong option, not acceptable. */
+	if (unlikely(act == CHK__CHECK_INCONSIST_ACTION__CIA_INTERACT)) {
+		D_ERROR("%u is not acceptable for interaction decision.\n", cla);
+		D_GOTO(out, rc = -DER_INVAL);
+	}
+
+	rc = chk_pending_del(ins, seq, &cpr);
+	if (rc == 0) {
+		/* The cpr will be destroyed by the waiter via chk_engine_report(). */
+		D_ASSERT(cpr->cpr_busy == 1);
+
+		ABT_mutex_lock(cpr->cpr_mutex);
+		/*
+		 * XXX: It is the control plane's duty to guarantee that the decision is a valid
+		 *	action from the report options. Otherwise, related inconsistency will be
+		 *	ignored.
+		 */
+		cpr->cpr_action = act;
+		ABT_cond_broadcast(cpr->cpr_cond);
+		ABT_mutex_unlock(cpr->cpr_mutex);
+	}
+
+	if (rc != 0 || !(flags & CAF_FOR_ALL))
+		goto out;
+
+	if (likely(prop->cp_policies[cla] != act)) {
+		prop->cp_policies[cla] = act;
+		rc = chk_prop_update(prop, NULL);
+	}
+
+out:
+	D_CDEBUG(rc != 0, DLOG_ERR, DLOG_INFO,
+		 DF_ENGINE" on rank %u takes action for seq "
+		 DF_X64" with gen "DF_X64", class %u, action %u, flags %x: "DF_RC"\n",
+		 DP_ENGINE(ins), dss_self_rank(), seq, gen, cla, act, flags, DP_RC(rc));
+
+	return rc;
+}
+
+int
+chk_engine_report(struct chk_report_unit *cru, int *decision)
+{
+	struct chk_instance	*ins = chk_engine;
+	struct chk_pending_rec	*cpr = NULL;
+	uint64_t		 seq = 0;
+	int			 rc;
+
+	rc = chk_report_remote(ins->ci_prop.cp_leader, ins->ci_bk.cb_gen, cru->cru_cla,
+			       cru->cru_act, cru->cru_result, cru->cru_rank, cru->cru_target,
+			       cru->cru_pool, cru->cru_cont, cru->cru_obj, cru->cru_dkey,
+			       cru->cru_akey, cru->cru_msg, cru->cru_option_nr, cru->cru_options,
+			       cru->cru_detail_nr, cru->cru_details, &seq);
+	if (rc != 0)
+		goto log;
+
+	if (cru->cru_act == CHK__CHECK_INCONSIST_ACTION__CIA_INTERACT)
+		rc = chk_pending_add(ins, &ins->ci_pending_list, seq,
+				     cru->cru_rank, cru->cru_cla, &cpr);
+
+log:
+	D_CDEBUG(rc != 0, DLOG_ERR, DLOG_INFO,
+		 DF_ENGINE" on rank %u report with class %u, action %u, "
+		 "handle_rc %d, report_rc %d\n",
+		 DP_ENGINE(ins), cru->cru_rank, cru->cru_cla, cru->cru_act, cru->cru_result, rc);
+
+	if (rc != 0 || cpr == NULL)
+		goto out;
+
+	D_ASSERT(cpr->cpr_busy == 1);
+
+	D_INFO(DF_ENGINE" on rank %u need interaction for class %u\n",
+	       DP_ENGINE(ins), cru->cru_rank, cru->cru_cla);
+
+	ABT_mutex_lock(cpr->cpr_mutex);
+	if (cpr->cpr_action != CHK__CHECK_INCONSIST_ACTION__CIA_INTERACT) {
+		ABT_mutex_unlock(cpr->cpr_mutex);
+	} else {
+		ABT_cond_wait(cpr->cpr_cond, cpr->cpr_mutex);
+		ABT_mutex_unlock(cpr->cpr_mutex);
+		if (!ins->ci_sched_running || cpr->cpr_exiting)
+			goto out;
+	}
+
+	*decision = cpr->cpr_action;
+
+out:
+	if (cpr != NULL)
+		chk_pending_destroy(cpr);
+
+	return rc;
+}
+
+int
+chk_engine_notify(uint64_t gen, uuid_t uuid, d_rank_t rank, uint32_t phase,
+		  uint32_t status, bool remove_pool)
+{
+	struct chk_instance	*ins = chk_engine;
+	struct chk_property	*prop = &ins->ci_prop;
+	struct chk_bookmark	*cbk = &ins->ci_bk;
+	bool			 stop_engine = false;
+	int			 rc = 0;
+
+	if (cbk->cb_gen != gen)
+		D_GOTO(out, rc = -DER_NOTAPPLICABLE);
+
+	/* Ignore notification from non-leader. */
+	if (prop->cp_leader != rank)
+		D_GOTO(out, rc = -DER_NOTAPPLICABLE);
+
+	if (remove_pool) {
+		if (uuid_is_null(uuid))
+			D_GOTO(out, rc = -DER_INVAL);
+
+		rc = chk_pool_stop_one(ins, uuid, CHK__CHECK_POOL_STATUS__CPS_IMPLICATED, true);
+		if (rc == 0 && d_list_empty(&ins->ci_pool_list))
+			stop_engine = true;
+
+		D_GOTO(out, rc = (rc == -DER_NONEXIST) ? -DER_NOTAPPLICABLE : rc);
+	}
+
+	if (cbk->cb_ins_status != CHK__CHECK_INST_STATUS__CIS_RUNNING)
+		D_GOTO(out, rc = -DER_NOTAPPLICABLE);
+
+	if (status == CHK__CHECK_INST_STATUS__CIS_RUNNING) {
+		if (unlikely(cbk->cb_phase >= phase))
+			D_GOTO(out, rc = -DER_NOTAPPLICABLE);
+
+		rc = chk_engine_setup_pools(ins, false);
+		if (rc == 0) {
+			ABT_mutex_lock(ins->ci_abt_mutex);
+			cbk->cb_phase = phase;
+			ABT_cond_broadcast(ins->ci_abt_cond);
+			ABT_mutex_unlock(ins->ci_abt_mutex);
+		}
+
+		goto out;
+	}
+
+	if (status != CHK__CHECK_INST_STATUS__CIS_FAILED &&
+	    status != CHK__CHECK_INST_STATUS__CIS_IMPLICATED)
+		D_GOTO(out, rc = -DER_NOTAPPLICABLE);
+
+	if (!uuid_is_null(uuid)) {
+		rc = chk_pool_stop_one(ins, uuid, CHK__CHECK_POOL_STATUS__CPS_IMPLICATED, false);
+		if (rc == 0 && d_list_empty(&ins->ci_pool_list))
+			stop_engine = true;
+
+		D_GOTO(out, rc = (rc == -DER_NONEXIST) ? -DER_NOTAPPLICABLE : rc);
+	}
+
+	/* Leader notify to exit the whole check if not specify the pool uuid. */
+	stop_engine = true;
+
+out:
+	if (stop_engine) {
+		ins->ci_implicated = 1;
+		chk_stop_sched(ins);
+	}
+
+	if (rc != -DER_NOTAPPLICABLE)
+		D_CDEBUG(rc != 0, DLOG_ERR, DLOG_INFO,
+			 DF_ENGINE" on rank %u got notification from rank %u, "
+			 "phase %u, status %u, gen "DF_X64": "DF_RC"\n",
+			 DP_ENGINE(ins), dss_self_rank(), rank, phase, status, gen, DP_RC(rc));
+
+	return (rc == 0 || rc == -DER_NOTAPPLICABLE) ? 0 : rc;
+}
+
+static int
+chk_rejoin_cb(struct sys_db *db, char *table, d_iov_t *key, void *args)
+{
+	struct chk_traverse_pools_args	*ctpa = args;
+	struct chk_instance		*ins = ctpa->ctpa_ins;
+	unsigned char			*uuid = key->iov_buf;
+	struct chk_bookmark		 cbk;
+	int				 rc;
+
+	if (!d_is_uuid(uuid))
+		goto out;
+
+	rc = chk_bk_fetch_pool(&cbk, uuid);
+	if (rc != 0) {
+		ctpa->ctpa_status = CHK__CHECK_INST_STATUS__CIS_FAILED;
+		goto out;
+	}
+
+	if (cbk.cb_gen != ctpa->ctpa_gen)
+		goto out;
+
+	if (cbk.cb_pool_status == CHK__CHECK_POOL_STATUS__CPS_FAILED) {
+		if (cbk.cb_phase < ins->ci_slowest_fail_phase)
+			ins->ci_slowest_fail_phase = cbk.cb_phase;
+		goto out;
+	}
+
+	if (cbk.cb_pool_status != CHK__CHECK_POOL_STATUS__CPS_CHECKING &&
+	    cbk.cb_pool_status != CHK__CHECK_POOL_STATUS__CPS_PAUSED &&
+	    cbk.cb_pool_status != CHK__CHECK_POOL_STATUS__CPS_PENDING)
+		goto out;
+
+	/* Always refresh the start time. */
+	cbk.cb_time.ct_start_time = time(NULL);
+	/* XXX: How to estimate the left time? */
+	cbk.cb_time.ct_left_time = CHK__CHECK_SCAN_PHASE__DSP_DONE - cbk.cb_phase;
+	cbk.cb_pool_status = CHK__CHECK_POOL_STATUS__CPS_CHECKING;
+	rc = chk_pool_add_shard(ins->ci_pool_hdl, &ins->ci_pool_list, uuid,
+				dss_self_rank(), cbk.cb_phase, &cbk, ins,
+				NULL, NULL, NULL);
+	if (rc != 0) {
+		ctpa->ctpa_status = CHK__CHECK_INST_STATUS__CIS_FAILED;
+		goto out;
+	}
+
+	rc = chk_bk_update_pool(&cbk, uuid);
+	if (rc != 0)
+		chk_pool_del_shard(ins->ci_pool_hdl, uuid, dss_self_rank());
+
+out:
+	/* Ignore the failure to handle next one. */
+	return 0;
+}
+
+void
+chk_engine_rejoin(void)
+{
+	struct chk_instance		*ins = chk_engine;
+	struct chk_property		*prop = &ins->ci_prop;
+	struct chk_bookmark		*cbk = &ins->ci_bk;
+	d_rank_list_t			*rank_list = NULL;
+	struct chk_traverse_pools_args	 ctpa = { 0 };
+	struct chk_iv			 iv = { 0 };
+	d_rank_t			 myrank = dss_self_rank();
+	uint32_t			 phase;
+	int				 rc = 0;
+	bool				 need_join = false;
+	bool				 need_iv = false;
+	bool				 joined = false;
+
+	if (cbk->cb_magic != CHK_BK_MAGIC_ENGINE)
+		goto out;
+
+	if (cbk->cb_ins_status != CHK__CHECK_INST_STATUS__CIS_RUNNING &&
+	    cbk->cb_ins_status != CHK__CHECK_INST_STATUS__CIS_PAUSED)
+		goto out;
+
+	D_ASSERT(ins->ci_starting == 0);
+	D_ASSERT(ins->ci_stopping == 0);
+	D_ASSERT(ins->ci_iv_group == NULL);
+	D_ASSERT(ins->ci_iv_ns == NULL);
+
+	need_join = true;
+	ins->ci_starting = 1;
+
+	rc = chk_prop_fetch(prop, &rank_list);
+	if (rc != 0)
+		goto out;
+
+	D_ASSERT(rank_list != NULL);
+
+	rc = crt_group_secondary_create(CHK_DUMMY_POOL, NULL, rank_list, &ins->ci_iv_group);
+	if (rc != 0)
+		goto out;
+
+	rc = ds_iv_ns_create(dss_get_module_info()->dmi_ctx, (unsigned char *)CHK_DUMMY_POOL,
+			     ins->ci_iv_group, &ins->ci_iv_id, &ins->ci_iv_ns);
+	if (rc != 0)
+		goto out;
+
+	ds_iv_ns_update(ins->ci_iv_ns, prop->cp_leader);
+
+	/* Ask leader whether this engine can rejoin or not. */
+	rc = chk_rejoin_remote(prop->cp_leader, cbk->cb_gen, myrank, cbk->cb_phase);
+	if (rc != 0)
+		goto out;
+
+	joined = true;
+
+	ctpa.ctpa_gen = cbk->cb_gen;
+	ctpa.ctpa_ins = ins;
+	rc = chk_traverse_pools(chk_rejoin_cb, &ctpa);
+	if (rc != 0)
+		goto out;
+
+	phase = chk_engine_find_slowest(ins);
+	if (phase != cbk->cb_phase)
+		need_iv = true;
+
+	cbk->cb_phase = phase;
+	if (unlikely(d_list_empty(&ins->ci_pool_list))) {
+		if (ctpa.ctpa_status == CHK__CHECK_INST_STATUS__CIS_FAILED)
+			cbk->cb_ins_status = CHK__CHECK_INST_STATUS__CIS_FAILED;
+		else
+			cbk->cb_ins_status = CHK__CHECK_INST_STATUS__CIS_COMPLETED;
+		cbk->cb_time.ct_stop_time = time(NULL);
+		need_iv = true;
+	} else {
+		cbk->cb_ins_status = CHK__CHECK_INST_STATUS__CIS_RUNNING;
+		/* Always refresh the start time. */
+		cbk->cb_time.ct_start_time = time(NULL);
+		/* XXX: How to estimate the left time? */
+		cbk->cb_time.ct_left_time = CHK__CHECK_SCAN_PHASE__DSP_DONE - cbk->cb_phase;
+	}
+
+	rc = chk_bk_update_engine(cbk);
+	if (rc != 0) {
+		need_iv = true;
+		goto out;
+	}
+
+	if (unlikely(d_list_empty(&ins->ci_pool_list)))
+		goto out;
+
+	ins->ci_sched_running = 1;
+
+	rc = dss_ult_create(chk_engine_sched, ins, DSS_XS_SYS, 0, DSS_DEEP_STACK_SZ,
+			    &ins->ci_sched);
+	if (rc != 0)
+		need_iv = true;
+	else
+		/* chk_engine_sched will do IV to leader. */
+		need_iv = false;
+
+out:
+	ins->ci_starting = 0;
+	d_rank_list_free(rank_list);
+
+	if (rc != 0 && joined) {
+		chk_engine_exit(ins, CHK__CHECK_INST_STATUS__CIS_FAILED,
+				CHK__CHECK_POOL_STATUS__CPS_IMPLICATED);
+	} else if (need_iv && cbk->cb_ins_status != CHK__CHECK_INST_STATUS__CIS_IMPLICATED &&
+		   ins->ci_iv_ns != NULL) {
+		iv.ci_gen = cbk->cb_gen;
+		iv.ci_phase = cbk->cb_phase;
+		iv.ci_status = cbk->cb_ins_status;
+		iv.ci_to_leader = 1;
+
+		/* Synchronously notify the leader that check instance exit on the engine. */
+		rc = chk_iv_update(ins->ci_iv_ns, &iv, CRT_IV_SHORTCUT_TO_ROOT,
+				   CRT_IV_SYNC_EAGER, true);
+		if (rc != 0)
+			D_ERROR(DF_ENGINE" on rank %u failed to notify leader "
+				"for its changes, status %u: "DF_RC"\n",
+				DP_ENGINE(ins), myrank, cbk->cb_ins_status, DP_RC(rc));
+	}
+
+	/*
+	 * XXX: It is unnecessary to destroy the IV namespace that can be handled when next
+	 *	CHK_START or instance fini.
+	 */
+
+	if (need_join)
+		D_CDEBUG(rc != 0, DLOG_ERR, DLOG_INFO,
+			 DF_ENGINE" rejoin on rank %u: "DF_RC"\n",
+			 DP_ENGINE(ins), myrank, DP_RC(rc));
+}
+
+void
+chk_engine_pause(void)
+{
+	struct chk_instance	*ins = chk_engine;
+
+	chk_stop_sched(ins);
+	D_ASSERT(d_list_empty(&ins->ci_pending_list));
+	D_ASSERT(d_list_empty(&ins->ci_pool_list));
+}
+
+int
+chk_engine_init(void)
+{
+	struct chk_bookmark	*cbk;
+	int			 rc;
+
+	D_ALLOC(chk_engine, sizeof(*chk_engine));
+	if (chk_engine == NULL)
+		D_GOTO(out, rc = -DER_NOMEM);
+
+	rc = chk_ins_init(chk_engine);
+	if (rc != 0)
+		goto free;
+
+	/*
+	 * XXX: DAOS global consistency check depends on all related engines' local
+	 *	consistency. If hit some local data corruption, then it is possible
+	 *	that local consistency is not guaranteed. Need to break and resolve
+	 *	related local inconsistency firstly.
+	 */
+
+	cbk = &chk_engine->ci_bk;
+	rc = chk_bk_fetch_engine(cbk);
+	if (rc == -DER_NONEXIST)
+		rc = 0;
+
+	/* It may be caused by local data corruption, let's break. */
+	if (rc != 0)
+		goto fini;
+
+	if (unlikely(cbk->cb_magic != CHK_BK_MAGIC_ENGINE)) {
+		D_ERROR("Hit corrupted engine bookmark on rank %u: %u vs %u\n",
+			dss_self_rank(), cbk->cb_magic, CHK_BK_MAGIC_ENGINE);
+		D_GOTO(fini, rc = -DER_IO);
+	}
+
+	rc = chk_prop_fetch(&chk_engine->ci_prop, NULL);
+	if (rc == -DER_NONEXIST)
+		rc = 0;
+
+	if (rc != 0)
+		goto fini;
+
+	goto out;
+
+fini:
+	chk_ins_fini(chk_engine);
+free:
+	D_FREE(chk_engine);
+out:
+	return rc;
+}
+
+void
+chk_engine_fini(void)
+{
+	chk_ins_fini(chk_engine);
+}

--- a/src/chk/chk_internal.h
+++ b/src/chk/chk_internal.h
@@ -313,6 +313,14 @@ int chk_report_remote(d_rank_t leader, uint64_t gen, uint32_t cla, uint32_t act,
 
 int chk_rejoin_remote(d_rank_t leader, uint64_t gen, d_rank_t rank, uint32_t phase);
 
+/* chk_updcall.c */
+
+int chk_report_upcall(uint64_t gen, uint64_t seq, uint32_t cla, uint32_t act, int32_t result,
+		      d_rank_t rank, uint32_t target, uuid_t *pool, uuid_t *cont,
+		      daos_unit_oid_t *obj, daos_key_t *dkey, daos_key_t *akey, char *msg,
+		      uint32_t option_nr, uint32_t *options, uint32_t detail_nr,
+		      d_sg_list_t *details);
+
 /* chk_vos.c */
 
 int chk_bk_fetch_leader(struct chk_bookmark *cbk);

--- a/src/chk/chk_iv.c
+++ b/src/chk/chk_iv.c
@@ -1,0 +1,221 @@
+/**
+ * (C) Copyright 2022 Intel Corporation.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause-Patent
+ */
+
+#define D_LOGFAC	DD_FAC(chk)
+
+#include <gurt/list.h>
+#include <gurt/debug.h>
+#include <cart/iv.h>
+#include <daos_srv/iv.h>
+#include <daos_srv/daos_engine.h>
+
+#include "chk_internal.h"
+
+static int
+chk_iv_alloc_internal(d_sg_list_t *sgl)
+{
+	int	rc;
+
+	rc = d_sgl_init(sgl, 1);
+	if (rc != 0)
+		return rc;
+
+	D_ALLOC(sgl->sg_iovs[0].iov_buf, sizeof(struct chk_iv));
+	if (sgl->sg_iovs[0].iov_buf == NULL) {
+		d_sgl_fini(sgl, true);
+		return -DER_NOMEM;
+	}
+
+	sgl->sg_iovs[0].iov_buf_len = sizeof(struct chk_iv);
+	sgl->sg_iovs[0].iov_len = sizeof(struct chk_iv);
+
+	return 0;
+}
+
+static int
+chk_iv_ent_init(struct ds_iv_key *iv_key, void *data, struct ds_iv_entry *entry)
+{
+	int	rc;
+
+	rc = chk_iv_alloc_internal(&entry->iv_value);
+	if (rc == 0) {
+		entry->iv_key.class_id = iv_key->class_id;
+		entry->iv_key.rank = iv_key->rank;
+	}
+
+	return rc;
+}
+
+static int
+chk_iv_ent_get(struct ds_iv_entry *entry, void **priv)
+{
+	return 0;
+}
+
+static int
+chk_iv_ent_put(struct ds_iv_entry *entry, void **priv)
+{
+	return 0;
+}
+
+static int
+chk_iv_ent_destroy(d_sg_list_t *sgl)
+{
+	d_sgl_fini(sgl, true);
+
+	return 0;
+}
+
+static int
+chk_iv_ent_fetch(struct ds_iv_entry *entry, struct ds_iv_key *key, d_sg_list_t *dst, void **priv)
+{
+	D_ASSERT(0);
+
+	return 0;
+}
+
+/* Update the chk pool svc lists and status from engine to leader. */
+static int
+chk_iv_ent_update(struct ds_iv_entry *entry, struct ds_iv_key *key,
+		  d_sg_list_t *src, void **priv)
+{
+	struct chk_iv	*dst_iv = entry->iv_value.sg_iovs[0].iov_buf;
+	struct chk_iv	*src_iv = src->sg_iovs[0].iov_buf;
+	int		 rc = 0;
+
+	/*
+	 * When check leader (IV master) tirgger chk_iv_update, it will set ci_to_leader as 0,
+	 * then chk_iv_ent_update() for any IV message from leader will get -DER_IVCB_FORWARD.
+	 */
+	if (!src_iv->ci_to_leader)
+		D_GOTO(out, rc = -DER_IVCB_FORWARD);
+
+	if (dst_iv->ci_gen == 0)
+		goto update;
+
+	if (unlikely(dst_iv->ci_gen != src_iv->ci_gen)) {
+		D_WARN("Receive invalid update IV message: "DF_X64" vs "DF_X64"\n",
+		       dst_iv->ci_gen, src_iv->ci_gen);
+		goto out;
+	}
+
+	/* Old IV update message. */
+	if (dst_iv->ci_phase > src_iv->ci_phase)
+		goto out;
+
+update:
+	dst_iv->ci_gen = src_iv->ci_gen;
+	dst_iv->ci_rank = src_iv->ci_rank;
+	dst_iv->ci_phase = src_iv->ci_phase;
+	dst_iv->ci_status = src_iv->ci_status;
+
+	rc = chk_leader_notify(dst_iv->ci_gen, dst_iv->ci_rank, dst_iv->ci_phase,
+			       dst_iv->ci_status);
+
+	D_CDEBUG(rc != 0, DLOG_ERR, DLOG_INFO,
+		 "Handled CHK IV update with gen "DF_X64", rank %u, phase %u, status %d: "DF_RC"\n",
+		 src_iv->ci_gen, src_iv->ci_rank, src_iv->ci_phase, src_iv->ci_status, DP_RC(rc));
+
+out:
+	return rc;
+}
+
+/* Refresh the chk status from leader to engines. */
+static int
+chk_iv_ent_refresh(struct ds_iv_entry *entry, struct ds_iv_key *key,
+		   d_sg_list_t *src, int ref_rc, void **priv)
+{
+	struct chk_iv	*dst_iv = entry->iv_value.sg_iovs[0].iov_buf;
+	struct chk_iv	*src_iv = src->sg_iovs[0].iov_buf;
+	int		 rc = 0;
+
+	D_ASSERT(src_iv->ci_to_leader == 0);
+
+	if (dst_iv->ci_gen == 0)
+		goto refresh;
+
+	if (unlikely(dst_iv->ci_gen != src_iv->ci_gen)) {
+		D_WARN("Receive invalid refresh IV message: "DF_X64" vs "DF_X64"\n",
+		       dst_iv->ci_gen, src_iv->ci_gen);
+		goto out;
+	}
+
+	/* Repeated or old IV refresh message. */
+	if (dst_iv->ci_status >= src_iv->ci_status)
+		goto out;
+
+refresh:
+	dst_iv->ci_gen = src_iv->ci_gen;
+	uuid_copy(dst_iv->ci_uuid, src_iv->ci_uuid);
+	dst_iv->ci_rank = src_iv->ci_rank;
+	dst_iv->ci_phase = src_iv->ci_phase;
+	dst_iv->ci_status = src_iv->ci_status;
+	dst_iv->ci_remove_pool = src_iv->ci_remove_pool;
+
+	rc = chk_engine_notify(dst_iv->ci_gen, dst_iv->ci_uuid, dst_iv->ci_rank, dst_iv->ci_phase,
+			       dst_iv->ci_status, dst_iv->ci_remove_pool ? true : false);
+
+	D_CDEBUG(rc != 0, DLOG_ERR, DLOG_INFO,
+		 "Handled CHK IV refresh with gen "DF_X64", phase %u, status %d: "DF_RC"\n",
+		 src_iv->ci_gen, src_iv->ci_phase, src_iv->ci_status, DP_RC(rc));
+
+out:
+	return rc;
+}
+
+static int
+chk_iv_value_alloc(struct ds_iv_entry *entry, struct ds_iv_key *key, d_sg_list_t *sgl)
+{
+	return chk_iv_alloc_internal(sgl);
+}
+
+struct ds_iv_class_ops chk_iv_ops = {
+	.ivc_ent_init		= chk_iv_ent_init,
+	.ivc_ent_get		= chk_iv_ent_get,
+	.ivc_ent_put		= chk_iv_ent_put,
+	.ivc_ent_destroy	= chk_iv_ent_destroy,
+	.ivc_ent_fetch		= chk_iv_ent_fetch,
+	.ivc_ent_update		= chk_iv_ent_update,
+	.ivc_ent_refresh	= chk_iv_ent_refresh,
+	.ivc_value_alloc	= chk_iv_value_alloc,
+};
+
+int
+chk_iv_update(void *ns, struct chk_iv *iv, uint32_t shortcut, uint32_t sync_mode, bool retry)
+{
+	d_sg_list_t		sgl;
+	d_iov_t			iov;
+	struct ds_iv_key	key;
+	int			rc;
+
+	iv->ci_rank = dss_self_rank();
+	iov.iov_buf = iv;
+	iov.iov_len = sizeof(*iv);
+	iov.iov_buf_len = sizeof(*iv);
+	sgl.sg_nr = 1;
+	sgl.sg_nr_out = 0;
+	sgl.sg_iovs = &iov;
+
+	memset(&key, 0, sizeof(key));
+	key.class_id = IV_CHK;
+	rc = ds_iv_update(ns, &key, &sgl, shortcut, sync_mode, 0, retry);
+	if (rc != 0)
+		D_ERROR("CHK iv update failed: "DF_RC"\n", DP_RC(rc));
+
+	return rc;
+}
+
+int
+chk_iv_init(void)
+{
+	return ds_iv_class_register(IV_CHK, &iv_cache_ops, &chk_iv_ops);
+}
+
+int
+chk_iv_fini(void)
+{
+	return ds_iv_class_unregister(IV_CHK);
+}

--- a/src/chk/chk_leader.c
+++ b/src/chk/chk_leader.c
@@ -1,0 +1,1436 @@
+/**
+ * (C) Copyright 2022 Intel Corporation.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause-Patent
+ */
+
+#define D_LOGFAC	DD_FAC(chk)
+
+#include <time.h>
+#include <cart/api.h>
+#include <daos/btree.h>
+#include <daos/btree_class.h>
+#include <daos_srv/daos_engine.h>
+#include <daos_srv/daos_chk.h>
+#include <daos_srv/vos.h>
+#include <daos_srv/iv.h>
+
+#include "chk.pb-c.h"
+#include "chk_internal.h"
+
+#define DF_LEADER	"Check leader (gen: "DF_X64")"
+#define DP_LEADER(ins)	(ins)->ci_bk.cb_gen
+
+static struct chk_instance	*chk_leader;
+
+struct chk_sched_args {
+	struct chk_instance	*csa_ins;
+	struct btr_root		 csa_btr;
+	daos_handle_t		 csa_hdl;
+	d_list_t		 csa_list;
+	uint32_t		 csa_count;
+	uint32_t		 csa_refs;
+};
+
+static struct chk_sched_args *
+chk_csa_alloc(struct chk_instance *ins)
+{
+	struct umem_attr	 uma = { 0 };
+	struct chk_sched_args	*csa;
+	int			 rc;
+
+	D_ALLOC_PTR(csa);
+	if (csa == NULL)
+		goto out;
+
+	D_INIT_LIST_HEAD(&csa->csa_list);
+	csa->csa_refs = 1;
+	csa->csa_ins = ins;
+
+	uma.uma_id = UMEM_CLASS_VMEM;
+	rc = dbtree_create_inplace(DBTREE_CLASS_CHK_POOL, 0, CHK_BTREE_ORDER, &uma,
+				   &csa->csa_btr, &csa->csa_hdl);
+	if (rc != 0)
+		D_FREE(csa);
+
+out:
+	return csa;
+}
+
+static inline void
+chk_csa_get(struct chk_sched_args *csa)
+{
+	csa->csa_refs++;
+}
+
+static inline void
+chk_csa_put(struct chk_sched_args *csa)
+{
+	if (csa != NULL) {
+		csa->csa_refs--;
+		if (csa->csa_refs == 0) {
+			dbtree_destroy(csa->csa_hdl, NULL);
+			D_FREE(csa);
+		}
+	}
+}
+
+struct chk_rank_rec {
+	/* Link into chk_instance::ci_rank_list. */
+	d_list_t		 crr_link;
+	/* The list of chk_pending_rec. */
+	d_list_t		 crr_pending_list;
+	d_rank_t		 crr_rank;
+	uint32_t		 crr_phase;
+	struct chk_instance	*crr_ins;
+};
+
+struct chk_rank_bundle {
+	d_rank_t		 crb_rank;
+	uint32_t		 crb_phase;
+	struct chk_instance	*crb_ins;
+};
+
+static int
+chk_rank_hkey_size(void)
+{
+	return sizeof(d_rank_t);
+}
+
+static void
+chk_rank_hkey_gen(struct btr_instance *tins, d_iov_t *key_iov, void *hkey)
+{
+	D_ASSERT(key_iov->iov_len == sizeof(d_rank_t));
+
+	memcpy(hkey, key_iov->iov_buf, key_iov->iov_len);
+}
+
+static int
+chk_rank_alloc(struct btr_instance *tins, d_iov_t *key_iov, d_iov_t *val_iov,
+	       struct btr_record *rec, d_iov_t *val_out)
+{
+	struct chk_rank_bundle	*crb = val_iov->iov_buf;
+	struct chk_rank_rec	*crr;
+	int			 rc = 0;
+
+	D_ASSERT(crb != NULL);
+
+	D_ALLOC_PTR(crr);
+	if (crr == NULL)
+		D_GOTO(out, rc = -DER_NOMEM);
+
+	D_INIT_LIST_HEAD(&crr->crr_pending_list);
+	crr->crr_rank = crb->crb_rank;
+	crr->crr_phase = crb->crb_phase;
+	crr->crr_ins = crb->crb_ins;
+
+	rec->rec_off = umem_ptr2off(&tins->ti_umm, crr);
+	d_list_add_tail(&crr->crr_link, &crb->crb_ins->ci_rank_list);
+
+out:
+	return rc;
+}
+
+static int
+chk_rank_free(struct btr_instance *tins, struct btr_record *rec, void *args)
+{
+	struct chk_rank_rec	*crr;
+	struct chk_pending_rec	*cpr;
+	struct chk_pending_rec	*tmp;
+	struct chk_instance	*ins;
+	d_iov_t			 kiov;
+	uint64_t		 seq;
+	int			 rc = 0;
+	int			 rc1 = 0;
+
+	crr = (struct chk_rank_rec *)umem_off2ptr(&tins->ti_umm, rec->rec_off);
+	rec->rec_off = UMOFF_NULL;
+	ins = crr->crr_ins;
+
+	ABT_rwlock_wrlock(ins->ci_abt_lock);
+	/* Cleanup all pending records belong to this rank. */
+	d_list_for_each_entry_safe(cpr, tmp, &crr->crr_pending_list, cpr_rank_link) {
+		ABT_mutex_lock(cpr->cpr_mutex);
+		if (cpr->cpr_busy) {
+			cpr->cpr_exiting = 1;
+			ABT_cond_broadcast(cpr->cpr_cond);
+			ABT_mutex_unlock(cpr->cpr_mutex);
+		} else {
+			ABT_mutex_unlock(cpr->cpr_mutex);
+			/* Copy the seq to avoid accessing free DRAM after dbtree_delete. */
+			seq = cpr->cpr_seq;
+			d_iov_set(&kiov, &seq, sizeof(cpr->cpr_seq));
+			rc1 = dbtree_delete(ins->ci_pending_hdl, BTR_PROBE_EQ, &kiov, NULL);
+			if (unlikely(rc1 != 0)) {
+				D_ERROR("Failed to remove pending rec for rank %u, seq "
+					DF_X64", gen "DF_X64": "DF_RC"\n",
+					crr->crr_rank, seq, ins->ci_bk.cb_gen, DP_RC(rc1));
+				if (rc == 0)
+					rc = rc1;
+			}
+		}
+	}
+	ABT_rwlock_unlock(ins->ci_abt_lock);
+
+	d_list_del(&crr->crr_link);
+	D_FREE(crr);
+
+	return rc;
+}
+
+static int
+chk_rank_fetch(struct btr_instance *tins, struct btr_record *rec,
+	       d_iov_t *key_iov, d_iov_t *val_iov)
+{
+	struct chk_rank_rec	*crr;
+
+	D_ASSERT(val_iov != NULL);
+
+	crr = umem_off2ptr(&tins->ti_umm, rec->rec_off);
+	d_iov_set(val_iov, crr, sizeof(*crr));
+
+	return 0;
+}
+
+static int
+chk_rank_update(struct btr_instance *tins, struct btr_record *rec,
+		d_iov_t *key, d_iov_t *val, d_iov_t *val_out)
+{
+	struct chk_rank_bundle  *crb = val->iov_buf;
+	struct chk_rank_rec	*crr;
+
+	crr = (struct chk_rank_rec *)umem_off2ptr(&tins->ti_umm, rec->rec_off);
+	crr->crr_phase = crb->crb_phase;
+
+	return 0;
+}
+
+btr_ops_t chk_rank_ops = {
+	.to_hkey_size	= chk_rank_hkey_size,
+	.to_hkey_gen	= chk_rank_hkey_gen,
+	.to_rec_alloc	= chk_rank_alloc,
+	.to_rec_free	= chk_rank_free,
+	.to_rec_fetch	= chk_rank_fetch,
+	.to_rec_update  = chk_rank_update,
+};
+
+static void
+chk_leader_exit(struct chk_instance *ins, uint32_t status, bool bcast)
+{
+	struct chk_bookmark	*cbk = &ins->ci_bk;
+	struct chk_iv		 iv = { 0 };
+	int			 rc = 0;
+
+	if ((bcast && status == CHK__CHECK_INST_STATUS__CIS_FAILED) ||
+	    status == CHK__CHECK_INST_STATUS__CIS_IMPLICATED) {
+		iv.ci_gen = cbk->cb_gen;
+		iv.ci_phase = cbk->cb_phase;
+		iv.ci_status = status;
+
+		/* Asynchronously notify the engines that the check leader exit. */
+		rc = chk_iv_update(ins->ci_iv_ns, &iv, CRT_IV_SHORTCUT_NONE,
+				   CRT_IV_SYNC_LAZY, true);
+		if (rc != 0)
+			D_ERROR(DF_LEADER" failed to notify the engines its exit, status %u: "
+				DF_RC"\n", DP_LEADER(ins), status, DP_RC(rc));
+	}
+
+	ABT_rwlock_wrlock(ins->ci_abt_lock);
+	rc = dbtree_destroy(ins->ci_pending_hdl, NULL);
+	ABT_rwlock_unlock(ins->ci_abt_lock);
+	if (rc != 0)
+		D_ERROR(DF_LEADER" failed to destroy pending record tree, status %u: "DF_RC"\n",
+			DP_LEADER(ins), status, DP_RC(rc));
+
+	rc = dbtree_destroy(ins->ci_rank_hdl, NULL);
+	if (rc != 0)
+		D_ERROR(DF_LEADER" failed to destroy rank tree, status %u: "DF_RC"\n",
+			DP_LEADER(ins), status, DP_RC(rc));
+
+	if (cbk->cb_ins_status == CHK__CHECK_INST_STATUS__CIS_RUNNING) {
+		cbk->cb_ins_status = status;
+		cbk->cb_time.ct_stop_time = time(NULL);
+		rc = chk_bk_update_leader(cbk);
+		if (rc != 0)
+			D_ERROR(DF_LEADER" exit with status %u: "DF_RC"\n",
+				DP_LEADER(ins), status, DP_RC(rc));
+	}
+}
+
+static uint32_t
+chk_leader_find_slowest(struct chk_instance *ins)
+{
+	uint32_t		 phase = CHK__CHECK_SCAN_PHASE__DSP_DONE;
+	uint32_t		 base = ins->ci_bk.cb_phase;
+	struct chk_rank_rec	*crr;
+
+	d_list_for_each_entry(crr, &ins->ci_rank_list, crr_link) {
+		if (crr->crr_phase <= base) {
+			phase = crr->crr_phase;
+			break;
+		}
+
+		if (crr->crr_phase < phase)
+			phase = crr->crr_phase;
+	}
+
+	return phase;
+}
+
+static int
+chk_leader_handle_pools_p1(struct chk_sched_args *csa)
+{
+	/* TBD: merge with Liwei's patch. */
+
+	return 0;
+}
+
+static int
+chk_leader_handle_pools_p2(struct chk_sched_args *csa)
+{
+	/* TBD: merge with Liwei's patch. */
+
+	return 0;
+}
+
+static void
+chk_leader_sched(void *args)
+{
+	struct chk_sched_args	*csa = args;
+	struct chk_instance	*ins = csa->csa_ins;
+	struct chk_bookmark	*cbk = &ins->ci_bk;
+	uint32_t		 phase;
+	uint32_t		 status;
+	struct chk_iv		 iv = { 0 };
+	int			 rc = 0;
+	bool			 bcast = false;
+
+	ABT_mutex_lock(ins->ci_abt_mutex);
+
+again:
+	if (!ins->ci_sched_running) {
+		ABT_mutex_unlock(ins->ci_abt_mutex);
+		D_GOTO(out, rc = 0);
+	}
+
+	if (ins->ci_started) {
+		ABT_mutex_unlock(ins->ci_abt_mutex);
+		goto handle;
+	}
+
+	ABT_cond_wait(ins->ci_abt_cond, ins->ci_abt_mutex);
+
+	goto again;
+
+handle:
+	phase = chk_leader_find_slowest(ins);
+	if (phase != cbk->cb_phase) {
+		cbk->cb_phase = phase;
+		chk_bk_update_leader(cbk);
+	}
+
+	if (cbk->cb_phase == CHK__CHECK_SCAN_PHASE__CSP_PREPARE) {
+		rc = chk_leader_handle_pools_p1(csa);
+		if (rc != 0)
+			D_GOTO(out, bcast = true);
+
+		iv.ci_gen = cbk->cb_gen;
+		iv.ci_phase = CHK__CHECK_SCAN_PHASE__CSP_POOL_LIST;
+		iv.ci_status = CHK__CHECK_INST_STATUS__CIS_RUNNING;
+
+		/* Synchronously notify the engines to move ahead. */
+		rc = chk_iv_update(ins->ci_iv_ns, &iv, CRT_IV_SHORTCUT_NONE,
+				   CRT_IV_SYNC_EAGER, true);
+		if (rc != 0) {
+			D_ERROR(DF_LEADER" failed to notify the engines to move phase to %u: "
+				DF_RC"\n",
+				DP_LEADER(ins), CHK__CHECK_SCAN_PHASE__CSP_POOL_MBS, DP_RC(rc));
+
+			/* Have to failout since cannot drive the check to go ahead. */
+			D_GOTO(out, bcast = false);
+		}
+
+		/*
+		 * XXX: Update the bookmark after successfully notify the check engines.
+		 *	Do not change the order, otherwise if the check instance restart
+		 *	before the phase CHK__CHECK_SCAN_PHASE__CSP_POOL_LIST, then next
+		 *	time leader will not IV for CHK__CHECK_SCAN_PHASE__CSP_POOL_LIST.
+		 */
+		cbk->cb_phase = CHK__CHECK_SCAN_PHASE__CSP_POOL_LIST;
+		chk_bk_update_leader(cbk);
+	}
+
+	if (cbk->cb_phase == CHK__CHECK_SCAN_PHASE__CSP_POOL_LIST) {
+		rc = chk_leader_handle_pools_p2(csa);
+		if (rc != 0)
+			D_GOTO(out, bcast = true);
+
+		iv.ci_gen = cbk->cb_gen;
+		iv.ci_phase = CHK__CHECK_SCAN_PHASE__CSP_POOL_MBS;
+		iv.ci_status = CHK__CHECK_INST_STATUS__CIS_RUNNING;
+
+		/* Synchronously notify the engines to move ahead. */
+		rc = chk_iv_update(ins->ci_iv_ns, &iv, CRT_IV_SHORTCUT_NONE,
+				   CRT_IV_SYNC_EAGER, true);
+		if (rc != 0) {
+			D_ERROR(DF_LEADER" failed to notify the engines to move phase to %u: "
+				DF_RC"\n",
+				DP_LEADER(ins), CHK__CHECK_SCAN_PHASE__CSP_POOL_MBS, DP_RC(rc));
+
+			/* Have to failout since cannot drive the check to go ahead. */
+			D_GOTO(out, bcast = false);
+		}
+
+		/*
+		 * XXX: Update the bookmark after successfully notify the check engines.
+		 *	Do not change the order, otherwise if the check instance restart
+		 *	before the phase CHK__CHECK_SCAN_PHASE__CSP_POOL_LIST, then next
+		 *	time leader will not IV for CHK__CHECK_SCAN_PHASE__CSP_POOL_MBS.
+		 */
+		cbk->cb_phase = CHK__CHECK_SCAN_PHASE__CSP_POOL_MBS;
+		chk_bk_update_leader(cbk);
+	}
+
+	while (ins->ci_sched_running) {
+		dss_sleep(300);
+
+		/* Someone wants to stop the check. */
+		if (!ins->ci_sched_running)
+			D_GOTO(out, rc = 0);
+
+		/*
+		 * TBD: The leader may need to detect engines' status/phase actively, otherwise
+		 *	if some engine failed to notify the leader for its status/phase changes,
+		 *	then the leader will be blocked there.
+		 */
+
+		phase = chk_leader_find_slowest(ins);
+		if (phase != cbk->cb_phase) {
+			cbk->cb_phase = phase;
+			/* XXX: How to estimate the left time? */
+			cbk->cb_time.ct_left_time = CHK__CHECK_SCAN_PHASE__DSP_DONE - cbk->cb_phase;
+			chk_bk_update_leader(cbk);
+			if (phase == CHK__CHECK_SCAN_PHASE__DSP_DONE)
+				D_GOTO(out, rc = 1);
+		}
+	}
+
+out:
+	if (rc > 0) {
+		/* If some engine(s) failed during the start, then mark the instance as 'failed'. */
+		if (ins->ci_slowest_fail_phase != CHK__CHECK_SCAN_PHASE__CSP_PREPARE)
+			status = CHK__CHECK_INST_STATUS__CIS_FAILED;
+		else
+			status = CHK__CHECK_INST_STATUS__CIS_COMPLETED;
+	} else if (rc == 0) {
+		if (ins->ci_implicated)
+			status = CHK__CHECK_INST_STATUS__CIS_IMPLICATED;
+		else if (ins->ci_stopping)
+			status = CHK__CHECK_INST_STATUS__CIS_STOPPED;
+		else
+			status = CHK__CHECK_INST_STATUS__CIS_PAUSED;
+	} else {
+		status = CHK__CHECK_INST_STATUS__CIS_FAILED;
+	}
+
+	chk_leader_exit(ins, status, bcast);
+	chk_csa_put(csa);
+
+	D_INFO(DF_LEADER" exit at the phase %u: "DF_RC"\n", DP_LEADER(ins), cbk->cb_phase, DP_RC(rc));
+}
+
+static int
+chk_leader_start_prepare(struct chk_instance *ins, uint32_t rank_nr, d_rank_t *ranks,
+			 uint32_t policy_nr, struct chk_policy **policies,
+			 uint32_t pool_nr, uuid_t pools[], int phase,
+			 uint32_t *flags, d_rank_list_t **rlist)
+{
+	struct chk_property	*prop = &ins->ci_prop;
+	struct chk_bookmark	*cbk = &ins->ci_bk;
+	int			 rc = 0;
+	int			 i;
+	int			 j;
+
+	/*
+	 * XXX: Consider the following scenario:
+	 *
+	 *	1. Start check on pool_A and pool_B: dmg check start -p pool_A -p pool_B
+	 *	2. Before the check done, we stop the check, at the time, pool_A's check is in
+	 *	   the phase_A, pool_B's is in the phase_B: dmg check stop
+	 *	3. Sometime later, we restart the check for the pool_A: dmg start -p pool_A
+	 *	   That will resume the check from the phase_A for the pool_A.
+	 *	4. When the check for pool_A is done, the check is marked as 'completed' although
+	 *	   pool_B is not full checked.
+	 *	5. Then we restart the check on the pool_B: dmg start -p pool_B
+	 *	   The expected behavior is to resume the check from the phase_B for the pool_B,
+	 *	   but because we trace the check engine process via single bookmark, the real
+	 *	   action is re-check pool_B from the beginning. That will waste some of former
+	 *	   check work on the pool_B.
+	 *
+	 *	Let's optimize above scenario in next step.
+	 */
+
+	if (ins->ci_sched_running)
+		D_GOTO(out, rc = -DER_ALREADY);
+
+	/* Corrupted bookmark or new created one. Nothing can be reused. */
+	if (cbk->cb_magic != CHK_BK_MAGIC_LEADER) {
+		memset(prop, 0, sizeof(*prop));
+		memset(cbk, 0, sizeof(*cbk));
+		cbk->cb_magic = CHK_BK_MAGIC_LEADER;
+		cbk->cb_version = DAOS_CHK_VERSION;
+		*flags |= CHK__CHECK_FLAG__CF_RESET;
+		goto init;
+	}
+
+	if (cbk->cb_ins_status == CHK__CHECK_INST_STATUS__CIS_RUNNING)
+		D_GOTO(out, rc = -DER_ALREADY);
+
+	if (*flags & CHK__CHECK_FLAG__CF_RESET)
+		goto init;
+
+	/* Former instance is done, restart from the beginning. */
+	if (cbk->cb_ins_status == CHK__CHECK_INST_STATUS__CIS_COMPLETED) {
+		*flags |= CHK__CHECK_FLAG__CF_RESET;
+		goto init;
+	}
+
+	if (cbk->cb_phase == CHK__CHECK_SCAN_PHASE__CSP_PREPARE) {
+		*flags |= CHK__CHECK_FLAG__CF_RESET;
+		goto init;
+	}
+
+	/* Drop dryrun flags needs to reset. */
+	if (prop->cp_flags & CHK__CHECK_FLAG__CF_DRYRUN && !(*flags & CHK__CHECK_FLAG__CF_DRYRUN)) {
+		*flags |= CHK__CHECK_FLAG__CF_RESET;
+		goto init;
+	}
+
+	/*
+	 * XXX: If current rank list does not matches the former list, the we need to
+	 *	reset the check from scratch. Currently, we do not strictly check that.
+	 *	It is control plane's duty to generate valid rank list.
+	 */
+
+	/* Add new rank(s), need to reset. */
+	if (rank_nr > prop->cp_rank_nr) {
+		*flags |= CHK__CHECK_FLAG__CF_RESET;
+		goto init;
+	}
+
+	if (prop->cp_pool_nr < 0)
+		goto init;
+
+	/* Want to check new pool(s), need to reset. */
+	if (pool_nr < 0) {
+		*flags |= CHK__CHECK_FLAG__CF_RESET;
+		goto init;
+	}
+
+	for (i = 0; i < pool_nr; i++) {
+		for (j = 0; j < prop->cp_pool_nr; j++) {
+			if (uuid_compare(pools[i], prop->cp_pools[j]) == 0)
+				break;
+		}
+
+		/* Want to check new pool(s), need to reset. */
+		if (j == prop->cp_pool_nr) {
+			*flags |= CHK__CHECK_FLAG__CF_RESET;
+			goto init;
+		}
+	}
+
+init:
+	rc = chk_prop_prepare(rank_nr, ranks, policy_nr, policies, pool_nr, pools,
+			      *flags, phase, dss_self_rank(), prop, rlist);
+	if (rc == 0 && *flags & CHK__CHECK_FLAG__CF_RESET) {
+		/* New generation for reset case. */
+		cbk->cb_gen = crt_hlc_get();
+		cbk->cb_phase = CHK__CHECK_SCAN_PHASE__CSP_PREPARE;
+		memset(&cbk->cb_statistics, 0, sizeof(cbk->cb_statistics));
+	}
+
+out:
+	return rc;
+}
+
+static int
+chk_leader_dup_clue(struct ds_pool_clue **tgt, struct ds_pool_clue *src)
+{
+	struct ds_pool_clue		*clue = NULL;
+	struct ds_pool_svc_clue		*svc = NULL;
+	char				*label = NULL;
+	int				 rc = 0;
+
+	D_ALLOC_PTR(clue);
+	if (clue == NULL)
+		D_GOTO(out, rc = -DER_NOMEM);
+
+	if (src->pc_svc_clue != NULL) {
+		D_ALLOC_PTR(svc);
+		if (svc == NULL)
+			D_GOTO(out, rc = -DER_NOMEM);
+
+		memcpy(svc, src->pc_svc_clue, sizeof(*svc));
+		if (src->pc_svc_clue->psc_db_clue.bcl_replicas != NULL) {
+			rc = d_rank_list_dup(&svc->psc_db_clue.bcl_replicas,
+					     src->pc_svc_clue->psc_db_clue.bcl_replicas);
+			if (rc != 0) {
+				svc->psc_db_clue.bcl_replicas = NULL;
+				goto out;
+			}
+		}
+	}
+
+	if (src->pc_label != NULL) {
+		D_ALLOC(label, src->pc_label_len + 1);
+		if (label == NULL)
+			D_GOTO(out, rc = -DER_NOMEM);
+
+		memcpy(label, src->pc_label, src->pc_label_len);
+	}
+
+	memcpy(clue, src, sizeof(*clue));
+	clue->pc_svc_clue = svc;
+	clue->pc_label = label;
+
+out:
+	if (rc != 0) {
+		if (svc != NULL) {
+			d_rank_list_free(svc->psc_db_clue.bcl_replicas);
+			D_FREE(svc);
+		}
+
+		D_FREE(clue);
+	} else {
+		*tgt = clue;
+	}
+
+	return rc;
+}
+
+static void
+chk_leader_free_clue(void *data)
+{
+	struct ds_pool_clue	*clue = data;
+
+	if (clue != NULL) {
+		ds_pool_clue_fini(clue);
+		D_FREE(clue);
+	}
+}
+
+static int
+chk_leader_start_cb(void *args, uint32_t rank, uint32_t phase, int result, void *data, uint32_t nr)
+{
+	struct chk_sched_args	*csa = args;
+	struct ds_pool_clue	*clues = data;
+	struct ds_pool_clue	*clue;
+	d_iov_t			 kiov;
+	int			 rc = 0;
+	int			 i;
+
+	D_ASSERTF(result >= 0, "Unexpected result for start CB %d\n", result);
+
+	/* The engine has completed the check, remove it from the rank list. */
+	if (result > 0) {
+		d_iov_set(&kiov, &rank, sizeof(d_rank_t));
+		rc = dbtree_delete(csa->csa_ins->ci_rank_hdl, BTR_PROBE_EQ, &kiov, NULL);
+		goto out;
+	}
+
+	for (i = 0; i < nr; i++) {
+		/*
+		 * @clues is from chk_start_remote RPC reply, the buffer will be released after
+		 * the RPC done. Let's copy all related data to new the buffer for further using.
+		 */
+		rc = chk_leader_dup_clue(&clue, &clues[i]);
+		if (rc != 0)
+			goto out;
+
+		rc = chk_pool_add_shard(csa->csa_hdl, &csa->csa_list, clue->pc_uuid,
+					clue->pc_rank, 0, NULL, csa->csa_ins, NULL,
+					clue, chk_leader_free_clue);
+		if (rc != 0) {
+			chk_leader_free_clue(clue);
+			goto out;
+		}
+	}
+
+out:
+	if (rc != 0)
+		D_ERROR(DF_LEADER" failed to handle start CB with ranks %u phase %d, result %d: "
+			DF_RC"\n", DP_LEADER(csa->csa_ins), rank, phase, result, DP_RC(rc));
+
+	return rc;
+}
+
+int
+chk_leader_start(uint32_t rank_nr, d_rank_t *ranks,
+		 uint32_t policy_nr, struct chk_policy **policies,
+		 uint32_t pool_nr, uuid_t pools[], uint32_t flags, int32_t phase)
+{
+	struct chk_instance	*ins = chk_leader;
+	struct chk_property	*prop = &ins->ci_prop;
+	struct chk_bookmark	*cbk = &ins->ci_bk;
+	d_rank_list_t		*rank_list = ins->ci_ranks;
+	struct chk_sched_args	*csa = NULL;
+	struct chk_rank_bundle	 rbund = { 0 };
+	d_rank_t		 myrank = dss_self_rank();
+	d_iov_t			 riov;
+	d_iov_t			 kiov;
+	int			 rc;
+	int			 i;
+
+	if (ins->ci_starting)
+		D_GOTO(out_log, rc = -DER_INPROGRESS);
+
+	if (ins->ci_stopping)
+		D_GOTO(out_log, rc = -DER_BUSY);
+
+	ins->ci_starting = 1;
+	ins->ci_started = 0;
+
+	rc = chk_leader_start_prepare(ins, rank_nr, ranks, policy_nr, policies,
+				      pool_nr, pools, phase, &flags, &rank_list);
+	if (rc != 0)
+		goto out_log;
+
+	D_ASSERT(rank_list != NULL);
+	D_ASSERT(d_list_empty(&ins->ci_rank_list));
+	D_ASSERT(d_list_empty(&ins->ci_pending_list));
+	D_ASSERT(ins->ci_sched == ABT_THREAD_NULL);
+
+	d_rank_list_free(ins->ci_ranks);
+	ins->ci_ranks = rank_list;
+
+	if (ins->ci_iv_ns != NULL) {
+		ds_iv_ns_put(ins->ci_iv_ns);
+		ins->ci_iv_ns = NULL;
+	}
+
+	if (ins->ci_iv_group != NULL) {
+		crt_group_secondary_destroy(ins->ci_iv_group);
+		ins->ci_iv_group = NULL;
+	}
+
+	rc = crt_group_secondary_create(CHK_DUMMY_POOL, NULL, rank_list, &ins->ci_iv_group);
+	if (rc != 0)
+		goto out_prep;
+
+	rc = ds_iv_ns_create(dss_get_module_info()->dmi_ctx, (unsigned char *)CHK_DUMMY_POOL,
+			     ins->ci_iv_group, &ins->ci_iv_id, &ins->ci_iv_ns);
+	if (rc != 0)
+		goto out_group;
+
+	ds_iv_ns_update(ins->ci_iv_ns, myrank);
+
+	for (i = 0; i < rank_list->rl_nr; i++) {
+		rbund.crb_rank = rank_list->rl_ranks[i];
+		rbund.crb_phase = cbk->cb_phase;
+		rbund.crb_ins = ins;
+
+		d_iov_set(&riov, &rbund, sizeof(rbund));
+		d_iov_set(&kiov, &rank_list->rl_ranks[i], sizeof(d_rank_t));
+		rc = dbtree_upsert(ins->ci_rank_hdl, BTR_PROBE_EQ, DAOS_INTENT_UPDATE,
+				   &kiov, &riov, NULL);
+		if (rc != 0)
+			goto out_rank;
+	}
+
+	/* Always refresh the start time. */
+	cbk->cb_time.ct_start_time = time(NULL);
+	/* XXX: How to estimate the left time? */
+	cbk->cb_time.ct_left_time = CHK__CHECK_SCAN_PHASE__DSP_DONE - cbk->cb_phase;
+	cbk->cb_ins_status = CHK__CHECK_INST_STATUS__CIS_RUNNING;
+	rc = chk_bk_update_leader(cbk);
+	if (rc != 0)
+		goto out_rank;
+
+	csa = chk_csa_alloc(ins);
+	if (csa == NULL)
+		D_GOTO(out_bk, rc = -DER_NOMEM);
+
+	/* Take another reference for RPC. */
+	chk_csa_get(csa);
+
+	ins->ci_sched_running = 1;
+
+	rc = dss_ult_create(chk_leader_sched, csa, DSS_XS_SYS, 0, DSS_DEEP_STACK_SZ,
+			    &ins->ci_sched);
+	if (rc != 0) {
+		chk_csa_put(csa);
+		goto out_csa;
+	}
+
+	rc = chk_start_remote(rank_list, cbk->cb_gen, rank_nr, ranks, policy_nr, policies,
+			      pool_nr, pools, flags, phase, myrank, chk_leader_start_cb, csa);
+	if (rc != 0)
+		goto out_sched;
+
+	/* Drop the reference for RPC. */
+	chk_csa_put(csa);
+
+	ABT_mutex_lock(ins->ci_abt_mutex);
+	ins->ci_started = 1;
+	ABT_cond_broadcast(ins->ci_abt_cond);
+	ABT_mutex_unlock(ins->ci_abt_mutex);
+
+	goto out_log;
+
+out_sched:
+	chk_stop_sched(ins);
+out_csa:
+	chk_csa_put(csa);
+out_bk:
+	if (rc != -DER_ALREADY && cbk->cb_ins_status == CHK__CHECK_INST_STATUS__CIS_RUNNING) {
+		cbk->cb_time.ct_stop_time = time(NULL);
+		cbk->cb_ins_status = CHK__CHECK_INST_STATUS__CIS_FAILED;
+		chk_bk_update_leader(cbk);
+	}
+out_rank:
+	dbtree_destroy(ins->ci_rank_hdl, NULL);
+	ins->ci_rank_hdl = DAOS_HDL_INVAL;
+	ds_iv_ns_put(ins->ci_iv_ns);
+	ins->ci_iv_ns = NULL;
+out_group:
+	crt_group_secondary_destroy(ins->ci_iv_group);
+	ins->ci_iv_group = NULL;
+out_prep:
+	d_rank_list_free(ins->ci_ranks);
+	ins->ci_ranks = NULL;
+	prop->cp_rank_nr = 0;
+out_log:
+	ins->ci_starting = 0;
+
+	if (rc == 0) {
+		D_INFO("Leader %s check on %u ranks for %u pools with "
+		       "flags %x, phase %d, leader %u, gen "DF_X64"\n",
+		       (flags & CHK__CHECK_FLAG__CF_RESET) ? "start" : "restart",
+		       rank_nr, pool_nr, flags, phase, myrank, cbk->cb_gen);
+
+		chk_ranks_dump(ins->ci_ranks->rl_nr, ins->ci_ranks->rl_ranks);
+
+		if (pool_nr > 0)
+			chk_pools_dump(pool_nr, pools);
+		else if (prop->cp_pool_nr > 0)
+			chk_pools_dump(prop->cp_pool_nr, prop->cp_pools);
+	} else if (rc != -DER_ALREADY) {
+		D_ERROR("Leader failed to start check on %u ranks for %u pools with "
+			"flags %x, phase %d, leader %u, gen "DF_X64": "DF_RC"\n",
+			rank_nr, pool_nr, flags, phase, myrank, cbk->cb_gen, DP_RC(rc));
+	}
+
+	return rc;
+}
+
+static int
+chk_leader_stop_cb(void *args, uint32_t rank, uint32_t phase, int result, void *data, uint32_t nr)
+{
+	struct chk_instance	*ins = args;
+	d_iov_t			 kiov;
+	int			 rc;
+
+	D_ASSERTF(result > 0, "Unexpected result for stop CB %d\n", result);
+
+	/* The engine has stop on the rank, remove it from the rank list. */
+	d_iov_set(&kiov, &rank, sizeof(d_rank_t));
+	rc = dbtree_delete(ins->ci_rank_hdl, BTR_PROBE_EQ, &kiov, NULL);
+	if (rc != 0)
+		D_ERROR(DF_LEADER" failed to handle stop CB with ranks %u: "DF_RC"\n",
+			DP_LEADER(ins), rank, DP_RC(rc));
+
+	return rc;
+}
+
+int
+chk_leader_stop(uint32_t pool_nr, uuid_t pools[])
+{
+	struct chk_instance	*ins = chk_leader;
+	struct chk_property	*prop = &ins->ci_prop;
+	struct chk_bookmark	*cbk = &ins->ci_bk;
+	d_rank_list_t		*ranks = NULL;
+	int			 rc = 0;
+
+	if (ins->ci_starting)
+		D_GOTO(out, rc = -DER_BUSY);
+
+	if (ins->ci_stopping)
+		D_GOTO(out, rc = -DER_INPROGRESS);
+
+	/*
+	 * XXX: It is possible that the check leader is dead. If we want to stop the stale
+	 *	check instance on other engines, then we may execute the CHK_STOP from new
+	 *	check leader. But if the old leader is still active, but the CHK_STOP dRPC
+	 *	is sent to non-leader (or new leader), then it will cause trouble.
+	 *
+	 *	Here, it is not easy to know whether the old leader is still valid or not.
+	 *	We have to trust control plane. It is the control plane duty to guarantee
+	 *	that the CHK_STOP dRPC is sent to the right one.
+	 */
+
+	ins->ci_stopping = 1;
+
+	/*
+	 * The check instance on current engine may have failed or stopped, but we do not know
+	 * whether there is active check instance on other engines or not, send stop RPC anyway.
+	 */
+
+	if (ins->ci_ranks == NULL) {
+		rc = chk_prop_fetch(&ins->ci_prop, &ins->ci_ranks);
+		/* We do not know the rank list, the sponsor needs to choose another leader. */
+		if (rc == -DER_NONEXIST)
+			D_GOTO(out, rc = -DER_NOTLEADER);
+
+		if (rc != 0)
+			goto out;
+
+		if (unlikely(ins->ci_ranks == NULL))
+			D_GOTO(out, rc = -DER_NOTLEADER);
+	}
+
+	rc = chk_stop_remote(ranks, cbk->cb_gen, pool_nr, pools, chk_leader_stop_cb, ins);
+	if (rc != 0)
+		goto out;
+
+	if (cbk->cb_ins_status == CHK__CHECK_INST_STATUS__CIS_RUNNING &&
+	    d_list_empty(&ins->ci_rank_list))
+		chk_stop_sched(ins);
+
+out:
+	ins->ci_stopping = 0;
+
+	if (rc == 0) {
+		D_INFO("Leader stopped check with gen "DF_X64" for %u pools\n",
+		       cbk->cb_gen, pool_nr > 0 ? pool_nr : prop->cp_pool_nr);
+
+		if (pool_nr > 0)
+			chk_pools_dump(pool_nr, pools);
+		else if (prop->cp_pool_nr > 0)
+			chk_pools_dump(prop->cp_pool_nr, prop->cp_pools);
+	} else {
+		D_ERROR("Leader failed to stop check with gen "DF_X64" for %u pools: "DF_RC"\n",
+			cbk->cb_gen, pool_nr > 0 ? pool_nr : prop->cp_pool_nr, DP_RC(rc));
+	}
+
+	return rc;
+}
+
+static int
+chk_leader_dup_shard(struct chk_query_pool_shard **tgt, struct chk_query_pool_shard *src)
+{
+	struct chk_query_pool_shard	*shard = NULL;
+	struct chk_query_target		*target = NULL;
+	int				 rc = 0;
+
+	D_ALLOC_PTR(shard);
+	if (shard == NULL)
+		D_GOTO(out, rc = -DER_NOMEM);
+
+	if (src->cqps_targets != NULL) {
+		D_ALLOC_ARRAY(target, src->cqps_target_nr);
+		if (target == NULL)
+			D_GOTO(out, rc = -DER_NOMEM);
+
+		memcpy(target, src->cqps_targets, sizeof(*target) * src->cqps_target_nr);
+	}
+
+	memcpy(shard, src, sizeof(*shard));
+	shard->cqps_targets = target;
+
+out:
+	if (rc != 0)
+		D_FREE(shard);
+	else
+		*tgt = shard;
+
+	return rc;
+}
+
+static void
+chk_leader_free_shard(void *data)
+{
+	struct chk_query_pool_shard	*shard = data;
+
+	D_FREE(shard->cqps_targets);
+	D_FREE(shard);
+}
+
+static int
+chk_leader_query_cb(void *args, uint32_t rank, uint32_t phase, int result, void *data, uint32_t nr)
+{
+	struct chk_sched_args		*csa = args;
+	struct chk_query_pool_shard	*shards = data;
+	struct chk_query_pool_shard	*shard;
+	int				 rc = 0;
+	int				 i;
+
+	D_ASSERTF(result == 0, "Unexpected result for query CB %d\n", result);
+
+	for (i = 0; i < nr; i++) {
+		/*
+		 * @shards is from chk_query_remote RPC reply, the buffer will be released after
+		 * the RPC done. Let's copy all related data to new the buffer for further using.
+		 */
+		rc = chk_leader_dup_shard(&shard, &shards[i]);
+		if (rc != 0)
+			goto out;
+
+		rc = chk_pool_add_shard(csa->csa_hdl, &csa->csa_list, shard->cqps_uuid,
+					shard->cqps_rank, shard->cqps_phase, NULL,
+					csa->csa_ins, &csa->csa_count, shard,
+					chk_leader_free_shard);
+		if (rc != 0) {
+			chk_leader_free_shard(shard);
+			goto out;
+		}
+	}
+
+out:
+	if (rc != 0)
+		D_ERROR(DF_LEADER" failed to handle query CB with ranks %u phase %d, result %d: "
+			DF_RC"\n", DP_LEADER(csa->csa_ins), rank, phase, result, DP_RC(rc));
+
+	return rc;
+}
+
+int
+chk_leader_query(uint32_t pool_nr, uuid_t pools[], chk_query_head_cb_t head_cb,
+		 chk_query_pool_cb_t pool_cb, void *buf)
+{
+	struct chk_instance	*ins = chk_leader;
+	struct chk_bookmark	*cbk = &ins->ci_bk;
+	struct chk_sched_args	*csa = NULL;
+	struct chk_pool_rec	*cpr;
+	struct chk_pool_shard	*cps;
+	uint32_t		 idx = 0;
+	int			 rc;
+
+	/*
+	 * XXX: Similar as stop case, we need the ability to query check information from
+	 *	new leader if the old one dead. But the information from new leader may be
+	 *	not very accurate. It is the control plane duty to send the CHK_QUERY dRPC
+	 *	to the right one.
+	 */
+
+	if (ins->ci_ranks == NULL) {
+		rc = chk_prop_fetch(&ins->ci_prop, &ins->ci_ranks);
+		/* We do not know the rank list, the sponsor needs to choose another leader. */
+		if (rc == -DER_NONEXIST)
+			D_GOTO(out, rc = -DER_NOTLEADER);
+
+		if (rc != 0)
+			goto out;
+
+		if (unlikely(ins->ci_ranks == NULL))
+			D_GOTO(out, rc = -DER_NOTLEADER);
+	}
+
+	csa = chk_csa_alloc(ins);
+	if (csa == NULL)
+		D_GOTO(out, rc = -DER_NOMEM);
+
+	rc = chk_query_remote(ins->ci_ranks, ins->ci_bk.cb_gen, pool_nr,
+			      pools, chk_leader_query_cb, csa);
+	if (rc != 0)
+		goto out;
+
+	rc = head_cb(cbk->cb_ins_status, cbk->cb_phase, &cbk->cb_statistics, &cbk->cb_time,
+		     csa->csa_count, buf);
+	if (rc != 0)
+		goto out;
+
+	d_list_for_each_entry(cpr, &csa->csa_list, cpr_link) {
+		d_list_for_each_entry(cps, &cpr->cpr_shard_list, cps_link) {
+			rc = pool_cb(cps->cps_data, idx++, buf);
+			if (rc != 0)
+				goto out;
+
+			D_ASSERT(csa->csa_count >= idx);
+		}
+	}
+out:
+	chk_csa_put(csa);
+	D_CDEBUG(rc != 0, DLOG_ERR, DLOG_INFO,
+		 "Leader query check with gen "DF_X64" for %u pools: "DF_RC"\n",
+		 cbk->cb_gen, pool_nr, DP_RC(rc));
+	return rc;
+}
+
+int
+chk_leader_prop(chk_prop_cb_t prop_cb, void *buf)
+{
+	struct chk_property	*prop = &chk_leader->ci_prop;
+
+	return prop_cb(buf, (struct chk_policy **)&prop->cp_policies,
+		       CHK_POLICY_MAX - 1, prop->cp_flags);
+}
+
+static void
+chk_leader_mark_rank_dead(d_rank_t rank, uint64_t incarnation, enum crt_event_source src,
+			  enum crt_event_type type, void *arg)
+{
+	struct chk_instance	*ins = chk_leader;
+	struct chk_property	*prop = &ins->ci_prop;
+	struct chk_bookmark	*cbk = &ins->ci_bk;
+	d_iov_t			 kiov;
+	uint32_t		 version = cbk->cb_gen - prop->cp_rank_nr - 1;
+	int			 rc = 0;
+
+	/* Ignore the event that is not applicable to current rank. */
+
+	if (src != CRT_EVS_SWIM || type != CRT_EVT_DEAD)
+		D_GOTO(out, rc = -DER_NOTAPPLICABLE);
+
+	if (cbk->cb_magic != CHK_BK_MAGIC_LEADER ||
+	    cbk->cb_ins_status != CHK__CHECK_INST_STATUS__CIS_RUNNING)
+		D_GOTO(out, rc = -DER_NOTAPPLICABLE);
+
+	if (!chk_remove_rank_from_list(ins->ci_ranks, rank))
+		D_GOTO(out, rc = -DER_NOTAPPLICABLE);
+
+	prop->cp_rank_nr--;
+	rc = chk_prop_update(prop, ins->ci_ranks);
+	if (rc != 0)
+		goto out;
+
+	rc = crt_group_secondary_modify(ins->ci_iv_group, ins->ci_ranks,
+					ins->ci_ranks, CRT_GROUP_MOD_OP_REPLACE, version);
+	if (rc != 0)
+		goto out;
+
+	d_iov_set(&kiov, &rank, sizeof(rank));
+	rc = dbtree_delete(ins->ci_rank_hdl, BTR_PROBE_EQ, &kiov, NULL);
+	if (rc != 0)
+		goto out;
+
+	/* The dead one is the last one, then stop the scheduler. */
+	if (d_list_empty(&ins->ci_rank_list))
+		chk_stop_sched(ins);
+	else
+		rc = chk_mark_remote(ins->ci_ranks, cbk->cb_gen, rank, version);
+
+out:
+	if (rc != -DER_NOTAPPLICABLE)
+		D_CDEBUG(rc != 0, DLOG_ERR, DLOG_INFO,
+			 DF_LEADER" mark rank %u as dead with version %u: "DF_RC"\n",
+			 DP_LEADER(ins), rank, version, DP_RC(rc));
+}
+
+int
+chk_leader_act(uint64_t seq, uint32_t act, bool for_all)
+{
+	struct chk_instance	*ins = chk_leader;
+	struct chk_bookmark	*cbk = &ins->ci_bk;
+	struct chk_pending_rec	*cpr = NULL;
+	int			 rc;
+
+	if (cbk->cb_magic != CHK_BK_MAGIC_LEADER)
+		D_GOTO(out, rc = -DER_NOTLEADER);
+
+	/* Tell control plane that no check instance is running via "-DER_NOTAPPLICABLE". */
+	if (cbk->cb_ins_status != CHK__CHECK_INST_STATUS__CIS_RUNNING)
+		D_GOTO(out, rc = -DER_NOTAPPLICABLE);
+
+	/* The admin may input the wrong option, not acceptable. */
+	if (unlikely(act == CHK__CHECK_INCONSIST_ACTION__CIA_INTERACT)) {
+		D_ERROR("%u is not acceptable for interaction decision.\n", act);
+		D_GOTO(out, rc = -DER_INVAL);
+	}
+
+	rc = chk_pending_del(ins, seq, &cpr);
+	if (rc != 0)
+		goto out;
+
+	D_ASSERT(cpr->cpr_busy == 1);
+
+	if (cpr->cpr_on_leader) {
+		ABT_mutex_lock(cpr->cpr_mutex);
+		/*
+		 * XXX: It is the control plane's duty to guarantee that the decision is a valid
+		 *	action from the report options. Otherwise, related inconsistency will be
+		 *	ignored.
+		 */
+		cpr->cpr_action = act;
+		ABT_cond_broadcast(cpr->cpr_cond);
+		ABT_mutex_unlock(cpr->cpr_mutex);
+	}
+
+	if (!cpr->cpr_on_leader || for_all) {
+		rc = chk_act_remote(ins->ci_ranks, cbk->cb_gen, seq,
+				    cpr->cpr_class, act, cpr->cpr_rank, for_all);
+		if (rc != 0)
+			goto out;
+	}
+
+out:
+	if (cpr != NULL && !cpr->cpr_on_leader)
+		chk_pending_destroy(cpr);
+
+	D_CDEBUG(rc != 0, DLOG_ERR, DLOG_INFO,
+		 DF_LEADER" takes action for report with seq "DF_X64", action %u, flags %s: "
+		 DF_RC"\n", DP_LEADER(ins), seq, act, for_all ? "all" : "once", DP_RC(rc));
+
+	return rc;
+
+}
+
+int
+chk_leader_report(struct chk_report_unit *cru, uint64_t *seq, int *decision)
+{
+	struct chk_instance	*ins = chk_leader;
+	struct chk_bookmark	*cbk = &ins->ci_bk;
+	struct chk_pending_rec	*cpr = NULL;
+	int			 rc;
+
+	if (cbk->cb_magic != CHK_BK_MAGIC_LEADER)
+		D_GOTO(out, rc = -DER_NOTLEADER);
+
+	/* Tell check engine that check leader is not running via "-DER_NOTAPPLICABLE". */
+	if (cbk->cb_ins_status != CHK__CHECK_INST_STATUS__CIS_RUNNING)
+		D_GOTO(out, rc = -DER_NOTAPPLICABLE);
+
+	*seq = ++(ins->ci_seq);
+
+	D_INFO(DF_LEADER" handle %s report from rank %u with seq "
+	       DF_X64" class %u, action %u, result %d\n", DP_LEADER(ins),
+	       decision != NULL ? "local" : "remote", cru->cru_rank, *seq, cru->cru_cla,
+	       cru->cru_act, cru->cru_result);
+
+	if (cru->cru_act == CHK__CHECK_INCONSIST_ACTION__CIA_INTERACT) {
+		rc = chk_pending_add(ins, &ins->ci_pending_list, *seq,
+				     cru->cru_rank, cru->cru_cla, &cpr);
+		if (rc != 0)
+			goto log;
+	}
+
+	rc = chk_report_upcall(cru->cru_gen, *seq, cru->cru_cla, cru->cru_act, cru->cru_result,
+			       cru->cru_rank, cru->cru_target, cru->cru_pool, cru->cru_cont,
+			       cru->cru_obj, cru->cru_dkey, cru->cru_akey, cru->cru_msg,
+			       cru->cru_option_nr, cru->cru_options, cru->cru_detail_nr,
+			       cru->cru_details);
+
+log:
+	if (rc != 0) {
+		D_ERROR(DF_LEADER" failed to handle %s report from rank %u with seq "
+			DF_X64", class %u, action %u, handle_rc %d, report_rc %d\n",
+			DP_LEADER(ins), decision != NULL ? "local" : "remote", cru->cru_rank, *seq,
+			cru->cru_cla, cru->cru_act, cru->cru_result, rc);
+		goto out;
+	}
+
+	if (decision == NULL || cpr == NULL)
+		goto out;
+
+	D_ASSERT(cpr->cpr_busy == 1);
+
+	D_INFO(DF_LEADER" need interaction for class %u with seq "DF_X64"\n",
+	       DP_LEADER(ins), cru->cru_cla, *seq);
+
+	ABT_mutex_lock(cpr->cpr_mutex);
+	if (cpr->cpr_action != CHK__CHECK_INCONSIST_ACTION__CIA_INTERACT) {
+		ABT_mutex_unlock(cpr->cpr_mutex);
+	} else {
+		ABT_cond_wait(cpr->cpr_cond, cpr->cpr_mutex);
+		ABT_mutex_unlock(cpr->cpr_mutex);
+		if (!ins->ci_sched_running || cpr->cpr_exiting)
+			goto out;
+	}
+
+	*decision = cpr->cpr_action;
+
+out:
+	if (cpr != NULL)
+		chk_pending_destroy(cpr);
+
+	return rc;
+}
+
+int
+chk_leader_notify(uint64_t gen, d_rank_t rank, uint32_t phase, uint32_t status)
+{
+	struct chk_instance	*ins = chk_leader;
+	struct chk_property	*prop = &ins->ci_prop;
+	struct chk_bookmark	*cbk = &ins->ci_bk;
+	struct chk_rank_bundle	 rbund = { 0 };
+	d_iov_t			 kiov;
+	d_iov_t			 riov;
+	int			 rc = 0;
+
+	/* Ignore the notification that is not applicable to current rank. */
+
+	if (cbk->cb_magic != CHK_BK_MAGIC_LEADER ||
+	    cbk->cb_ins_status != CHK__CHECK_INST_STATUS__CIS_RUNNING)
+		D_GOTO(out, rc = -DER_NOTAPPLICABLE);
+
+	if (cbk->cb_gen != gen)
+		D_GOTO(out, rc = -DER_NOTAPPLICABLE);
+
+	if (cbk->cb_ins_status != CHK__CHECK_INST_STATUS__CIS_RUNNING)
+		D_GOTO(out, rc = -DER_NOTAPPLICABLE);
+
+	switch (status) {
+	case CHK__CHECK_INST_STATUS__CIS_INIT:
+	case CHK__CHECK_INST_STATUS__CIS_STOPPED:
+	case CHK__CHECK_INST_STATUS__CIS_PAUSED:
+	case CHK__CHECK_INST_STATUS__CIS_IMPLICATED:
+		/* Directly ignore above. */
+		break;
+	case CHK__CHECK_INST_STATUS__CIS_RUNNING:
+		if (unlikely(phase < cbk->cb_phase))
+			D_GOTO(out, rc = -DER_INVAL);
+
+		if (phase == cbk->cb_phase)
+			D_GOTO(out, rc = 0);
+
+		rbund.crb_rank = rank;
+		rbund.crb_phase = phase;
+		rbund.crb_ins = ins;
+
+		d_iov_set(&riov, &rbund, sizeof(rbund));
+		d_iov_set(&kiov, &rank, sizeof(rank));
+		rc = dbtree_upsert(ins->ci_rank_hdl, BTR_PROBE_EQ, DAOS_INTENT_UPDATE,
+				   &kiov, &riov, NULL);
+		break;
+	case CHK__CHECK_INST_STATUS__CIS_COMPLETED:
+		/*
+		 * XXX: Currently, we do not support to partial check till the specified phase.
+		 *	Then the completed phase will be either container cleanup or all done.
+		 */
+		if (unlikely(phase != CHK__CHECK_SCAN_PHASE__CSP_CONT_CLEANUP &&
+			     phase != CHK__CHECK_SCAN_PHASE__DSP_DONE))
+			D_GOTO(out, rc = -DER_INVAL);
+
+		d_iov_set(&kiov, &rank, sizeof(rank));
+		rc = dbtree_delete(ins->ci_pending_hdl, BTR_PROBE_EQ, &kiov, NULL);
+		if (rc == -DER_NONEXIST)
+			rc = 0;
+		break;
+	case CHK__CHECK_INST_STATUS__CIS_FAILED:
+		if (ins->ci_slowest_fail_phase > phase)
+			ins->ci_slowest_fail_phase = phase;
+
+		d_iov_set(&kiov, &rank, sizeof(rank));
+		rc = dbtree_delete(ins->ci_pending_hdl, BTR_PROBE_EQ, &kiov, NULL);
+		if (rc != 0 || !(prop->cp_flags & CHK__CHECK_FLAG__CF_FAILOUT))
+			D_GOTO(out, rc = (rc == -DER_NONEXIST ? 0 : rc));
+
+		ins->ci_implicated = 1;
+		chk_stop_sched(ins);
+		break;
+	default:
+		rc = -DER_INVAL;
+		break;
+	}
+
+out:
+	if (rc != -DER_NOTAPPLICABLE)
+		D_CDEBUG(rc != 0, DLOG_ERR, DLOG_INFO,
+			 DF_LEADER" handle notification from rank %u, phase %u, status %u: "
+			 DF_RC"\n", DP_LEADER(ins), rank, phase, status, DP_RC(rc));
+
+	return (rc == 0 || rc == -DER_NOTAPPLICABLE) ? 0 : rc;
+}
+
+int
+chk_leader_rejoin(uint64_t gen, d_rank_t rank, uint32_t phase)
+{
+	struct chk_instance	*ins = chk_leader;
+	struct chk_bookmark	*cbk = &ins->ci_bk;
+	int			 rc = 0;
+
+	if (cbk->cb_magic != CHK_BK_MAGIC_LEADER)
+		D_GOTO(out, rc = -DER_NOTLEADER);
+
+	if (cbk->cb_gen != gen)
+		D_GOTO(out, rc = -DER_STALE);
+
+	if (cbk->cb_ins_status != CHK__CHECK_INST_STATUS__CIS_RUNNING)
+		D_GOTO(out, rc = -DER_SHUTDOWN);
+
+	/* The rank has been excluded from (or never been part of) the check instance. */
+	if (!chk_rank_in_list(ins->ci_ranks, rank))
+		D_GOTO(out, rc = -DER_NO_PERM);
+
+out:
+	D_CDEBUG(rc != 0, DLOG_ERR, DLOG_INFO,
+		 DF_LEADER" %u handle rejoin from rank %u with gen "DF_X64", phase %u :"DF_RC"\n",
+		 DP_LEADER(ins), cbk->cb_ins_status, rank, gen, phase, DP_RC(rc));
+
+	return rc;
+}
+
+void
+chk_leader_pause(void)
+{
+	struct chk_instance	*ins = chk_leader;
+
+	chk_stop_sched(ins);
+	D_ASSERT(d_list_empty(&ins->ci_pending_list));
+	D_ASSERT(d_list_empty(&ins->ci_rank_list));
+}
+
+int
+chk_leader_init(void)
+{
+	struct chk_bookmark	*cbk;
+	int			 rc;
+
+	D_ALLOC(chk_leader, sizeof(*chk_leader));
+	if (chk_leader == NULL)
+		D_GOTO(out, rc = -DER_NOMEM);
+
+	chk_leader->ci_is_leader = 1;
+	rc = chk_ins_init(chk_leader);
+	if (rc != 0)
+		goto free;
+
+	/*
+	 * XXX: DAOS global consistency check depends on all related engines' local
+	 *	consistency. If hit some local data corruption, then it is possible
+	 *	that local consistency is not guaranteed. Need to break and resolve
+	 *	related local inconsistency firstly.
+	 */
+
+	cbk = &chk_leader->ci_bk;
+	rc = chk_bk_fetch_leader(cbk);
+	if (rc == -DER_NONEXIST)
+		rc = 0;
+
+	/* It may be caused by local data corruption, let's break. */
+	if (rc != 0)
+		goto fini;
+
+	if (unlikely(cbk->cb_magic != CHK_BK_MAGIC_LEADER)) {
+		D_ERROR("Hit corrupted leader bookmark on rank %u: %u vs %u\n",
+			dss_self_rank(), cbk->cb_magic, CHK_BK_MAGIC_LEADER);
+		D_GOTO(fini, rc = -DER_IO);
+	}
+
+	rc = chk_prop_fetch(&chk_leader->ci_prop, &chk_leader->ci_ranks);
+	if (rc == -DER_NONEXIST)
+		rc = 0;
+
+	if (rc != 0)
+		goto fini;
+
+	rc = crt_register_event_cb(chk_leader_mark_rank_dead, NULL);
+	if (rc != 0)
+		goto fini;
+
+	goto out;
+
+fini:
+	chk_ins_fini(chk_leader);
+free:
+	D_FREE(chk_leader);
+out:
+	return rc;
+}
+
+void
+chk_leader_fini(void)
+{
+	crt_unregister_event_cb(chk_leader_mark_rank_dead, NULL);
+	chk_ins_fini(chk_leader);
+}

--- a/src/chk/chk_srv.c
+++ b/src/chk/chk_srv.c
@@ -7,6 +7,8 @@
 #define D_LOGFAC	DD_FAC(chk)
 
 #include <daos/rpc.h>
+#include <daos/btree.h>
+#include <daos/btree_class.h>
 #include <daos_srv/daos_chk.h>
 #include <daos_srv/daos_engine.h>
 
@@ -15,62 +17,224 @@
 static void
 ds_chk_start_hdlr(crt_rpc_t *rpc)
 {
+	struct chk_start_in	*csi = crt_req_get(rpc);
+	struct chk_start_out	*cso = crt_reply_get(rpc);
+	struct ds_pool_clues	 clues = { 0 };
+	uint32_t		 phase = 0;
+	int			 rc;
+
+	rc = chk_engine_start(csi->csi_gen, csi->csi_ranks.ca_count, csi->csi_ranks.ca_arrays,
+			      csi->csi_policies.ca_count,
+			      (struct chk_policy **)csi->csi_policies.ca_arrays,
+			      csi->csi_uuids.ca_count, csi->csi_uuids.ca_arrays,
+			      csi->csi_flags, csi->csi_phase, csi->csi_leader_rank, &phase, &clues);
+
+	cso->cso_status = rc;
+	cso->cso_rank = dss_self_rank();
+	cso->cso_phase = phase;
+	cso->cso_clues.ca_count = clues.pcs_len;
+	cso->cso_clues.ca_arrays = clues.pcs_array;
+	rc = crt_reply_send(rpc);
+	if (rc != 0)
+		D_ERROR("Failed to reply check start: "DF_RC"\n", DP_RC(rc));
+
+	ds_pool_clues_fini(&clues);
 }
 
 static void
 ds_chk_stop_hdlr(crt_rpc_t *rpc)
 {
+	struct chk_stop_in	*csi = crt_req_get(rpc);
+	struct chk_stop_out	*cso = crt_reply_get(rpc);
+	int			 rc;
+
+	rc = chk_engine_stop(csi->csi_gen, csi->csi_uuids.ca_count, csi->csi_uuids.ca_arrays);
+
+	cso->cso_status = rc;
+	cso->cso_rank = dss_self_rank();
+	rc = crt_reply_send(rpc);
+	if (rc != 0)
+		D_ERROR("Failed to reply check stop: "DF_RC"\n", DP_RC(rc));
 }
 
 static void
 ds_chk_query_hdlr(crt_rpc_t *rpc)
 {
+	struct chk_query_in		*cqi = crt_req_get(rpc);
+	struct chk_query_out		*cqo = crt_reply_get(rpc);
+	struct chk_query_pool_shard	*shards = NULL;
+	uint32_t			 shard_nr = 0;
+	int				 rc;
+
+	rc = chk_engine_query(cqi->cqi_gen, cqi->cqi_uuids.ca_count, cqi->cqi_uuids.ca_arrays,
+			      &shard_nr, &shards);
+
+	if (rc != 0) {
+		cqo->cqo_status = rc;
+		cqo->cqo_shards.ca_count = 0;
+		cqo->cqo_shards.ca_arrays = NULL;
+	} else {
+		cqo->cqo_status = 0;
+		cqo->cqo_shards.ca_count = shard_nr;
+		cqo->cqo_shards.ca_arrays = shards;
+	}
+
+	rc = crt_reply_send(rpc);
+	if (rc != 0)
+		D_ERROR("Failed to reply check query: "DF_RC"\n", DP_RC(rc));
+
+	chk_query_free(shards, shard_nr);
 }
 
 static void
 ds_chk_mark_hdlr(crt_rpc_t *rpc)
 {
+	struct chk_mark_in	*cmi = crt_req_get(rpc);
+	struct chk_mark_out	*cmo = crt_reply_get(rpc);
+	int			 rc;
+
+	rc = chk_engine_mark_rank_dead(cmi->cmi_gen, cmi->cmi_rank, cmi->cmi_version);
+
+	cmo->cmo_status = rc;
+	rc = crt_reply_send(rpc);
+	if (rc != 0)
+		D_ERROR("Failed to reply check mark rank dead: "DF_RC"\n", DP_RC(rc));
 }
 
 static void
 ds_chk_act_hdlr(crt_rpc_t *rpc)
 {
+	struct chk_act_in	*cai = crt_req_get(rpc);
+	struct chk_act_out	*cao = crt_reply_get(rpc);
+	int			 rc;
+
+	rc = chk_engine_act(cai->cai_gen, cai->cai_seq, cai->cai_cla, cai->cai_act, cai->cai_flags);
+
+	cao->cao_status = rc;
+	rc = crt_reply_send(rpc);
+	if (rc != 0)
+		D_ERROR("Failed to reply check act: "DF_RC"\n", DP_RC(rc));
 }
 
 static void
 ds_chk_report_hdlr(crt_rpc_t *rpc)
 {
+	struct chk_report_in	*cri = crt_req_get(rpc);
+	struct chk_report_out	*cro = crt_reply_get(rpc);
+	struct chk_report_unit	 cru;
+	int			 rc;
+
+	cru.cru_gen = cri->cri_gen;
+	cru.cru_cla = cri->cri_ics_class;
+	cru.cru_act = cri->cri_ics_action;
+	cru.cru_target = cri->cri_target;
+	cru.cru_rank = cri->cri_rank;
+	cru.cru_option_nr = cri->cri_options.ca_count;
+	cru.cru_detail_nr = cri->cri_details.ca_count;
+	cru.cru_pool = &cri->cri_pool;
+	cru.cru_cont = &cri->cri_cont;
+	cru.cru_obj = &cri->cri_obj;
+	cru.cru_dkey = &cri->cri_dkey;
+	cru.cru_akey = &cri->cri_akey;
+	cru.cru_msg = cri->cri_msg;
+	cru.cru_options = cri->cri_options.ca_arrays;
+	cru.cru_details = cri->cri_details.ca_arrays;
+	cru.cru_result = cri->cri_ics_result;
+
+	rc = chk_leader_report(&cru, &cro->cro_seq, NULL);
+
+	cro->cro_status = rc;
+	rc = crt_reply_send(rpc);
+	if (rc != 0)
+		D_ERROR("Failed to reply check report: "DF_RC"\n", DP_RC(rc));
 }
 
 static void
 ds_chk_rejoin_hdlr(crt_rpc_t *rpc)
 {
+	struct chk_rejoin_in	*cri = crt_req_get(rpc);
+	struct chk_rejoin_out	*cro = crt_reply_get(rpc);
+	int			 rc;
+
+	rc = chk_leader_rejoin(cri->cri_gen, cri->cri_rank, cri->cri_phase);
+
+	cro->cro_status = rc;
+	rc = crt_reply_send(rpc);
+	if (rc != 0)
+		D_ERROR("Failed to reply check rejoin: "DF_RC"\n", DP_RC(rc));
 }
 
 static int
 ds_chk_init(void)
 {
-	return 0;
+	int	rc;
+
+	rc = dbtree_class_register(DBTREE_CLASS_CHK_POOL, 0, &chk_pool_ops);
+	if (rc != 0)
+		goto out;
+
+	rc = dbtree_class_register(DBTREE_CLASS_CHK_RANK, 0, &chk_rank_ops);
+	if (rc != 0)
+		goto out;
+
+	rc = dbtree_class_register(DBTREE_CLASS_CHK_PA, 0, &chk_pending_ops);
+	if (rc != 0)
+		goto out;
+
+	rc = chk_iv_init();
+
+out:
+	return rc;
 }
 
 static int
 ds_chk_fini(void)
 {
-	return 0;
+	return chk_iv_fini();
 }
 
 static int
 ds_chk_setup(void)
 {
+	int	rc;
+
 	/* Do NOT move chk_vos_init into ds_chk_init, because sys_db is not ready at that time. */
 	chk_vos_init();
 
-	return 0;
+	rc = chk_leader_init();
+	if (rc != 0)
+		goto out_vos;
+
+	rc = chk_engine_init();
+	if (rc != 0)
+		goto out_leader;
+
+	/*
+	 * Currently, we do NOT support leader to rejoin the former check instance. Because we do
+	 * not support leader switch, during current leader down time, the reported inconsistency
+	 * and related repair result are lost. Under such case, the admin has to stop and restart
+	 * the check explicitly.
+	 */
+
+	chk_engine_rejoin();
+
+	goto out_done;
+
+out_leader:
+	chk_leader_fini();
+out_vos:
+	chk_vos_fini();
+out_done:
+	return rc;
 }
 
 static int
 ds_chk_cleanup(void)
 {
+	chk_engine_pause();
+	chk_leader_pause();
+	chk_engine_fini();
+	chk_leader_fini();
 	chk_vos_fini();
 
 	return 0;

--- a/src/chk/chk_upcall.c
+++ b/src/chk/chk_upcall.c
@@ -1,0 +1,217 @@
+/*
+ * (C) Copyright 2022 Intel Corporation.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause-Patent
+ */
+
+#define D_LOGFAC DD_FAC(chk)
+
+#include <time.h>
+#include <daos_types.h>
+#include <daos/common.h>
+#include <daos/object.h>
+#include <daos/drpc_modules.h>
+#include <daos_srv/ras.h>
+
+#include "chk.pb-c.h"
+#include "chk_internal.h"
+
+#define OBJID_STR_SIZE	32
+#define TIME_STR_SIZE	128
+
+#ifndef DF_KEY_STR_SIZE
+#define DF_KEY_STR_SIZE	64
+#endif
+
+#define CHK_ACTION_MAX	CHK__CHECK_INCONSIST_ACTION__CIA_TRUST_EC_DATA
+
+/* XXX: Must be strictly matches the order in Chk__CheckInconsistAction. */
+static char *chk_act_strings[CHK_ACTION_MAX + 1] = {
+	/* CHK__CHECK_INCONSIST_ACTION__CIA_DEFAULT = 0 */
+	"Default action, depends on the detailed inconsistency class.",
+
+	/* CHK__CHECK_INCONSIST_ACTION__CIA_INTERACT = 1 */
+	"Interact with administrator for further action.",
+
+	/* CHK__CHECK_INCONSIST_ACTION__CIA_IGNORE = 2 */
+	"Ignore but log the inconsistency.",
+
+	/* CHK__CHECK_INCONSIST_ACTION__CIA_DISCARD = 3 */
+	"Discard the unrecognized element: pool service, pool itself, container, and so on.",
+
+	/* CHK__CHECK_INCONSIST_ACTION__CIA_READD = 4 */
+	"Re-add the missing element: pool to MS, target to pool map, and so on.",
+
+	/* CHK__CHECK_INCONSIST_ACTION__CIA_TRUST_MS = 5 */
+	"Trust the information recorded in MS DB.",
+
+	/* CHK__CHECK_INCONSIST_ACTION__CIA_TRUST_PS = 6 */
+	"Trust the information recorded in PS DB.",
+
+	/* CHK__CHECK_INCONSIST_ACTION__CIA_TRUST_TARGET = 7 */
+	"Trust the information recorded by target(s).",
+
+	/* CHK__CHECK_INCONSIST_ACTION__CIA_TRUST_MAJORITY = 8 */
+	"Trust the majority parts (if have).",
+
+	/* CHK__CHECK_INCONSIST_ACTION__CIA_TRUST_LATEST = 9 */
+	"Trust the one with latest (pool map or epoch) information. Keep the latest data.",
+
+	/* CHK__CHECK_INCONSIST_ACTION__CIA_TRUST_OLDEST = 10 */
+	"Trust the one with oldest (pool map or epoch) information. Rollback to old version.",
+
+	/* CHK__CHECK_INCONSIST_ACTION__CIA_TRUST_EC_PARITY = 11 */
+	"Trust EC parity shard.",
+
+	/* CHK__CHECK_INCONSIST_ACTION__CIA_TRUST_EC_DATA = 12 */
+	"Trust EC data shard."
+};
+
+static int
+chk_sg_list2string_array(d_sg_list_t *sgls, uint32_t sgl_nr, char ***array)
+{
+	char	**buf = NULL;
+	int	  cnt = 0;
+	int	  i;
+	int	  j;
+	int	  k;
+
+	for (i = 0; i < sgl_nr; i++)
+		cnt += sgls[i].sg_nr;
+
+	if (unlikely(cnt == 0))
+		goto out;
+
+	D_ALLOC_ARRAY(buf, cnt);
+	if (buf == NULL)
+		D_GOTO(out, cnt = -DER_NOMEM);
+
+	/*
+	 * XXX: How to transfer all the data into d_sg_list_t array? Some may be not string.
+	 */
+
+	for (i = 0, k = 0; i < sgl_nr; i++) {
+		for (j = 0; j < sgls[i].sg_nr; j++)
+			buf[k++] = sgls[i].sg_iovs[j].iov_buf;
+	}
+
+out:
+	*array = buf;
+
+	return cnt;
+}
+
+int
+chk_report_upcall(uint64_t gen, uint64_t seq, uint32_t cla, uint32_t act, int32_t result,
+		  d_rank_t rank, uint32_t target, uuid_t *pool, uuid_t *cont, daos_unit_oid_t *obj,
+		  daos_key_t *dkey, daos_key_t *akey, char *msg, uint32_t option_nr,
+		  uint32_t *options, uint32_t detail_nr, d_sg_list_t *details)
+{
+	Chk__CheckReport	  report = CHK__CHECK_REPORT__INIT;
+	time_t			  tm = time(NULL);
+	char			**act_msgs = NULL;
+	int			  rc;
+	int			  i;
+
+	if (act == CHK__CHECK_INCONSIST_ACTION__CIA_INTERACT) {
+		D_ASSERT(option_nr > 0);
+		D_ASSERT(options != NULL);
+
+		D_ALLOC(act_msgs, option_nr);
+		if (act_msgs == NULL)
+			D_GOTO(out, rc = -DER_NOMEM);
+
+		for (i = 0; i < option_nr; i++) {
+			D_ASSERT(options[i] <= CHK_ACTION_MAX);
+			act_msgs[i] = chk_act_strings[options[i]];
+		}
+	}
+
+	report.seq = seq;
+	report.class_ = cla;
+	report.action = act;
+	report.result = result;
+	report.rank = rank;
+	report.target = target;
+
+	if (pool != NULL && !uuid_is_null(*pool)) {
+		D_ASPRINTF(report.pool_uuid, DF_UUIDF, DP_UUID(*pool));
+		if (report.pool_uuid == NULL)
+			D_GOTO(out, rc = -DER_NOMEM);
+	} else {
+		report.pool_uuid = NULL;
+	}
+
+	if (cont != NULL && !uuid_is_null(*cont)) {
+		D_ASPRINTF(report.cont_uuid, DF_UUIDF, DP_UUID(*cont));
+		if (report.cont_uuid == NULL)
+			D_GOTO(out, rc = -DER_NOMEM);
+	} else {
+		report.cont_uuid = NULL;
+	}
+
+	if (obj != NULL && !daos_unit_oid_is_null(*obj)) {
+		D_ASPRINTF(report.objid, DF_UOID, DP_UOID(*obj));
+		if (report.objid == NULL)
+			D_GOTO(out, rc = -DER_NOMEM);
+	} else {
+		report.objid = NULL;
+	}
+
+	if (dkey != NULL && !daos_key_is_null(*dkey)) {
+		D_ASPRINTF(report.dkey, DF_KEY, DP_KEY(dkey));
+		if (report.dkey == NULL)
+			D_GOTO(out, rc = -DER_NOMEM);
+	} else {
+		report.dkey = NULL;
+	}
+
+	if (akey != NULL && !daos_key_is_null(*akey)) {
+		D_ASPRINTF(report.akey, DF_KEY, DP_KEY(akey));
+		if (report.akey == NULL)
+			D_GOTO(out, rc = -DER_NOMEM);
+	} else {
+		report.akey = NULL;
+	}
+
+	D_ASPRINTF(report.timestamp, "%s", ctime(&tm));
+	if (report.timestamp == NULL)
+		D_GOTO(out, rc = -DER_NOMEM);
+
+	report.msg = msg;
+	report.n_act_choices = option_nr;
+	report.act_choices = option_nr != 0 ? options : NULL;
+
+	if (detail_nr != 0) {
+		D_ASSERT(details != NULL);
+
+		rc = chk_sg_list2string_array(details, detail_nr, &report.act_details);
+		if (rc < 0)
+			goto out;
+
+		report.n_act_details = rc;
+	} else {
+		report.n_act_details = 0;
+		report.act_details = NULL;
+	}
+
+	report.n_act_msgs = option_nr;
+	report.act_msgs = act_msgs;
+
+	rc = ds_chk_report_upcall(&report);
+
+out:
+	D_FREE(act_msgs);
+	D_FREE(report.pool_uuid);
+	D_FREE(report.cont_uuid);
+	D_FREE(report.objid);
+	D_FREE(report.dkey);
+	D_FREE(report.akey);
+	D_FREE(report.timestamp);
+
+	D_CDEBUG(rc != 0, DLOG_ERR, DLOG_INFO,
+		 "Check leader upcall for instance "DF_X64" for seq "DF_X64": "DF_RC"\n",
+		 gen, seq, DP_RC(rc));
+
+	return rc;
+}

--- a/src/include/daos/btree_class.h
+++ b/src/include/daos/btree_class.h
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2021 Intel Corporation.
+ * (C) Copyright 2016-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -97,5 +97,20 @@ extern btr_ops_t dbtree_recx_ops;
  * The key is dtx_cos_key: oid + dkey_hash
  */
 #define DBTREE_CLASS_DTX_COS (DBTREE_DSM_BEGIN + 7)
+
+/**
+ * DAOS check pool tree, the key is pool uuid
+ */
+#define DBTREE_CLASS_CHK_POOL (DBTREE_DSM_BEGIN + 8)
+
+/**
+ * DAOS check rank tree, the key is rank ID
+ */
+#define DBTREE_CLASS_CHK_RANK (DBTREE_DSM_BEGIN + 9)
+
+/**
+ * DAOS check pending action tree, the key is 64-bit sequence
+ */
+#define DBTREE_CLASS_CHK_PA (DBTREE_DSM_BEGIN + 10)
 
 #endif /* __DAOS_SRV_BTREE_CLASS_H__ */

--- a/src/include/daos_errno.h
+++ b/src/include/daos_errno.h
@@ -277,7 +277,10 @@ extern "C" {
 	       One or more control plane components are incompatible)	\
 	/** No service available */					\
 	ACTION(DER_NO_SERVICE,		(DER_ERR_DAOS_BASE + 39),	\
-	       No service available)
+	       No service available)					\
+	/** Cannot resume former DAOS check instance. */		\
+	ACTION(DER_NOT_RESUME,		(DER_ERR_DAOS_BASE + 40),	\
+	       Cannot resume former DAOS check instance)		\
 
 /** Defines the gurt error codes */
 #define D_FOREACH_ERR_RANGE(ACTION)	\

--- a/src/include/daos_srv/daos_chk.h
+++ b/src/include/daos_srv/daos_chk.h
@@ -65,20 +65,25 @@ struct chk_list_pool {
 	d_rank_list_t		*clp_svcreps;
 };
 
-typedef int (*chk_query_cb_t)(void *buf, struct chk_query_target *cqt);
+typedef int (*chk_query_head_cb_t)(uint32_t ins_status, uint32_t ins_phase,
+				   struct chk_statistics *inconsistency, struct chk_time *time,
+				   size_t n_pools, void *buf);
 
-typedef int (*chk_prop_cb_t)(void *buf, struct chk_policy *policies);
+typedef int (*chk_query_pool_cb_t)(struct chk_query_pool_shard *shard, uint32_t idx, void *buf);
 
-int chk_start(d_rank_list_t *ranks, struct chk_policy *policies, uuid_t *pools,
-	      int pool_cnt, uint32_t flags);
+typedef int (*chk_prop_cb_t)(void *buf, struct chk_policy **policies, int cnt, uint32_t flags);
 
-int chk_stop(uuid_t *pools, int pool_cnt);
+int chk_leader_start(uint32_t rank_nr, d_rank_t *ranks, uint32_t policy_nr,
+		     struct chk_policy **policies, uint32_t pool_nr, uuid_t pools[],
+		     uint32_t flags, int32_t phase);
 
-int chk_query(uuid_t *pools, int pool_cnt, chk_query_cb_t query_cb,
-	      struct chk_query_target *cqt, void *buf);
+int chk_leader_stop(uint32_t pool_nr, uuid_t pools[]);
 
-int chk_prop(uint32_t *flags, chk_prop_cb_t prop_cb, struct chk_policy *policy, void *buf);
+int chk_leader_query(uint32_t pool_nr, uuid_t pools[], chk_query_head_cb_t head_cb,
+		     chk_query_pool_cb_t pool_cb, void *buf);
 
-int chk_act(uint64_t seq, uint32_t act, bool for_all);
+int chk_leader_prop(chk_prop_cb_t prop_cb, void *buf);
+
+int chk_leader_act(uint64_t seq, uint32_t act, bool for_all);
 
 #endif /* __DAOS_CHK_H__ */

--- a/src/include/daos_srv/daos_chk.h
+++ b/src/include/daos_srv/daos_chk.h
@@ -59,6 +59,12 @@ struct chk_query_pool_shard {
 	struct chk_query_target	*cqps_targets;
 };
 
+struct chk_list_pool {
+	uuid_t			 clp_uuid;
+	char			*clp_label;
+	d_rank_list_t		*clp_svcreps;
+};
+
 typedef int (*chk_query_cb_t)(void *buf, struct chk_query_target *cqt);
 
 typedef int (*chk_prop_cb_t)(void *buf, struct chk_policy *policies);

--- a/src/include/daos_srv/daos_mgmt_srv.h
+++ b/src/include/daos_srv/daos_mgmt_srv.h
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2021 Intel Corporation.
+ * (C) Copyright 2016-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -29,5 +29,9 @@ int
 ds_mgmt_newborn_pool_iterate(int (*cb)(uuid_t uuid, void *arg), void *arg);
 int
 ds_mgmt_zombie_pool_iterate(int (*cb)(uuid_t uuid, void *arg), void *arg);
+int
+ds_mgmt_pool_exist(uuid_t uuid);
+int
+ds_mgmt_pool_shard_exist(uuid_t uuid, char **path);
 
 #endif /* __MGMT_SRV_H__ */

--- a/src/include/daos_srv/iv.h
+++ b/src/include/daos_srv/iv.h
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2017-2021 Intel Corporation.
+ * (C) Copyright 2017-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -289,6 +289,7 @@ enum iv_key {
 	 * other servers
 	 */
 	IV_CONT_AGG_EPOCH_BOUNDRY,
+	IV_CHK,
 };
 
 int ds_iv_fetch(struct ds_iv_ns *ns, struct ds_iv_key *key, d_sg_list_t *value,

--- a/src/include/daos_srv/ras.h
+++ b/src/include/daos_srv/ras.h
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2020-2021 Intel Corporation.
+ * (C) Copyright 2020-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -13,6 +13,7 @@
 
 #include <daos_types.h>
 #include <daos/object.h>
+#include <daos_srv/daos_chk.h>
 
 #define DAOS_RAS_STR_FIELD_SIZE 128
 #define DAOS_RAS_ID_FIELD_SIZE 64
@@ -173,5 +174,53 @@ ds_notify_pool_svc_update(uuid_t *pool, d_rank_list_t *svcl);
  */
 int
 ds_notify_swim_rank_dead(d_rank_t rank, uint64_t incarnation);
+
+/**
+ * List all the known pools from control plane (MS).
+ *
+ * \param[out] clp	The pools list.
+ *
+ * \retval		Positive value for the conut of pools.
+ *			Negative value if error.
+ */
+int
+ds_chk_listpool_upcall(struct chk_list_pool **clp);
+
+/**
+ * Register the pool to control plane (MS).
+ *
+ * \param[in] seq	DAOS Check event sequence, unique for the instance.
+ * \param[in] uuid	The pool uuid.
+ * \param[in] label	The pool label, optional.
+ * \param[in] svcreps	Ranks for the pool service.
+ *
+ * \retval		Zero on success, non-zero otherwise.
+ */
+int
+ds_chk_regpool_upcall(uint64_t seq, uuid_t uuid, char *label, d_rank_list_t *svcreps);
+
+/**
+ * Deregister the pool from control plane (MS).
+ *
+ * \param[in] seq	DAOS Check event sequence, unique for the instance.
+ * \param[in] uuid	The pool uuid.
+ *
+ * \retval		Zero on success, non-zero otherwise.
+ */
+int
+ds_chk_deregpool_upcall(uint64_t seq, uuid_t uuid);
+
+/**
+ * Report inconsistency to control plane (MS).
+ *
+ * \param[in] rpt	The pointer to Chk__CheckReport.
+ *
+ * \retval		Zero on success, non-zero otherwise.
+ */
+int
+ds_chk_report_upcall(void *rpt);
+
+void
+ds_chk_free_pool_list(struct chk_list_pool *clp, uint32_t nr);
 
 #endif /* __DAOS_RAS_H_ */

--- a/src/include/daos_srv/vos_types.h
+++ b/src/include/daos_srv/vos_types.h
@@ -11,6 +11,7 @@
 #include <daos_pool.h>
 #include <daos_srv/bio.h>
 #include <daos_srv/vea.h>
+#include <daos_srv/daos_chk.h>
 #include <daos/object.h>
 #include <daos/dtx.h>
 #include <daos/checksum.h>
@@ -135,6 +136,14 @@ typedef struct {
 	struct vos_pool_space	pif_space;
 	/** garbage collector statistics */
 	struct vos_gc_stat	pif_gc_stat;
+	/** DAOS check phase on the pool shard. */
+	uint32_t		pif_chk_phase;
+	/** DAOS check instance status on the pool shard. */
+	uint32_t		pif_chk_status;
+	/** Inconsistency information for DAOS check on the pool shard. */
+	struct chk_statistics	pif_chk_statistics;
+	/** Time information for DAOS check on the pool shard. */
+	struct chk_time		pif_chk_time;
 	/** TODO */
 } vos_pool_info_t;
 

--- a/src/include/daos_types.h
+++ b/src/include/daos_types.h
@@ -128,6 +128,12 @@ typedef struct {
 
 typedef d_iov_t daos_key_t;
 
+static inline bool
+daos_key_is_null(daos_key_t key)
+{
+	return key.iov_buf_len == 0 || key.iov_buf == NULL;
+}
+
 /**
  * Event and event queue
  */

--- a/src/vos/vos_layout.h
+++ b/src/vos/vos_layout.h
@@ -19,6 +19,7 @@
 #include <daos_srv/bio.h>
 #include <daos_srv/vea.h>
 #include <daos_srv/dtx_srv.h>
+#include <daos_srv/daos_chk.h>
 #include "ilog.h"
 
 /**
@@ -135,6 +136,16 @@ struct vos_pool_df {
 	struct vea_space_df			pd_vea_df;
 	/** GC bins for container/object/dkey... */
 	struct vos_gc_bin_df			pd_gc_bins[GC_MAX];
+	/** DAOS check phase. */
+	uint32_t				pd_chk_phase;
+	/** DAOS check instance status. */
+	uint32_t				pd_chk_status;
+	/**
+	 * The inconsistency statistics during the phases range [CSP_DTX_RESYNC, OSP_AGGREGATION]
+	 * for the pool shard on the target.
+	 */
+	struct chk_statistics			pd_chk_statistics;
+	struct chk_time				pd_chk_time;
 };
 
 /**

--- a/src/vos/vos_pool.c
+++ b/src/vos/vos_pool.c
@@ -944,6 +944,10 @@ vos_pool_query(daos_handle_t poh, vos_pool_info_t *pinfo)
 	D_ASSERT(pinfo != NULL);
 	pinfo->pif_cont_nr = pool_df->pd_cont_nr;
 	pinfo->pif_gc_stat = pool->vp_gc_stat;
+	pinfo->pif_chk_phase = pool_df->pd_chk_phase;
+	pinfo->pif_chk_status = pool_df->pd_chk_status;
+	pinfo->pif_chk_statistics = pool_df->pd_chk_statistics;
+	pinfo->pif_chk_time = pool_df->pd_chk_time;
 
 	rc = vos_space_query(pool, &pinfo->pif_space, true);
 	if (rc)


### PR DESCRIPTION
There are four upcalls as following:

1. DRPC_METHOD_CHK_LIST_POOL:
   Check leader uses it to get all the known pools list and related pool
   service replicas from MS.

2. DRPC_METHOD_CHK_REG_POOL:
   Check leader adds some orphan pool and the pool service replicas to MS.

3. DRPC_METHOD_CHK_DEREG_POOL:
   Check leader delete some (dangling) pool from MS.

4. DRPC_METHOD_CHK_REPORT:
   Check leader reports its found inconsistency and related repair result,
   or forward other engines detected inconsistency and related reparation
   to the control plane.

Re-enable code format check against chk_internal.

Quick-Functional: true

Signed-off-by: Fan Yong <fan.yong@intel.com>