### PR TITLE
DAOS-9583 mgmt: dRPC downcall interfaces for DAOS check

### DIFF
--- a/src/chk/chk_vos.c
+++ b/src/chk/chk_vos.c
@@ -167,7 +167,7 @@ chk_bk_fetch_pool(struct chk_bookmark *cbk, uuid_t uuid)
 	uuid_unparse_lower(uuid, uuid_str);
 	rc = chk_db_fetch(uuid_str, strlen(uuid_str), cbk, sizeof(*cbk));
 	if (rc != 0 && rc != -DER_NONEXIST)
-		D_ERROR("Failed to fetch pool "DF_UUID" bookmark on rank %u: "DF_RC"\n",
+		D_ERROR("Failed to fetch pool "DF_UUIDF" bookmark on rank %u: "DF_RC"\n",
 			DP_UUID(uuid), dss_self_rank(), DP_RC(rc));
 
 	return rc;
@@ -182,7 +182,7 @@ chk_bk_update_pool(struct chk_bookmark *cbk, uuid_t uuid)
 	uuid_unparse_lower(uuid, uuid_str);
 	rc = chk_db_update(uuid_str, strlen(uuid_str), cbk, sizeof(*cbk));
 	if (rc != 0)
-		D_ERROR("Failed to update pool "DF_UUID" bookmark on rank %u: "DF_RC"\n",
+		D_ERROR("Failed to update pool "DF_UUIDF" bookmark on rank %u: "DF_RC"\n",
 			DP_UUID(uuid), dss_self_rank(), DP_RC(rc));
 
 	return rc;
@@ -197,7 +197,7 @@ chk_bk_delete_pool(uuid_t uuid)
 	uuid_unparse_lower(uuid, uuid_str);
 	rc = chk_db_delete(uuid_str, strlen(uuid_str));
 	if (rc != 0)
-		D_ERROR("Failed to delete pool "DF_UUID" bookmark on rank %u: "DF_RC"\n",
+		D_ERROR("Failed to delete pool "DF_UUIDF" bookmark on rank %u: "DF_RC"\n",
 			DP_UUID(uuid), dss_self_rank(), DP_RC(rc));
 
 	return rc;

--- a/src/engine/drpc_ras.c
+++ b/src/engine/drpc_ras.c
@@ -394,7 +394,7 @@ ds_chk_listpool_upcall(struct chk_list_pool **clp)
 	}
 
 	respb = srv__check_list_pool_resp__unpack(&alloc.alloc, dresp->body.len, dresp->body.data);
-	if (alloc.oom || respb)
+	if (alloc.oom || respb == NULL)
 		D_GOTO(out_dresp, rc = -DER_NOMEM);
 
 	if (respb->status != 0)

--- a/src/include/daos_srv/daos_chk.h
+++ b/src/include/daos_srv/daos_chk.h
@@ -71,10 +71,10 @@ typedef int (*chk_query_head_cb_t)(uint32_t ins_status, uint32_t ins_phase,
 
 typedef int (*chk_query_pool_cb_t)(struct chk_query_pool_shard *shard, uint32_t idx, void *buf);
 
-typedef int (*chk_prop_cb_t)(void *buf, struct chk_policy **policies, int cnt, uint32_t flags);
+typedef int (*chk_prop_cb_t)(void *buf, struct chk_policy *policies, int cnt, uint32_t flags);
 
 int chk_leader_start(uint32_t rank_nr, d_rank_t *ranks, uint32_t policy_nr,
-		     struct chk_policy **policies, uint32_t pool_nr, uuid_t pools[],
+		     struct chk_policy *policies, uint32_t pool_nr, uuid_t pools[],
 		     uint32_t flags, int32_t phase);
 
 int chk_leader_stop(uint32_t pool_nr, uuid_t pools[]);

--- a/src/include/daos_srv/daos_engine.h
+++ b/src/include/daos_srv/daos_engine.h
@@ -843,4 +843,6 @@ enum dss_drpc_call_flag {
 int dss_drpc_call(int32_t module, int32_t method, void *req, size_t req_size,
 		  unsigned int flags, Drpc__Response **resp);
 
+bool engine_in_check(void);
+
 #endif /* __DSS_API_H__ */

--- a/src/include/daos_srv/daos_mgmt_srv.h
+++ b/src/include/daos_srv/daos_mgmt_srv.h
@@ -32,6 +32,6 @@ ds_mgmt_zombie_pool_iterate(int (*cb)(uuid_t uuid, void *arg), void *arg);
 int
 ds_mgmt_pool_exist(uuid_t uuid);
 int
-ds_mgmt_pool_shard_exist(uuid_t uuid, char **path);
+ds_mgmt_tgt_pool_exist(uuid_t uuid, char **path);
 
 #endif /* __MGMT_SRV_H__ */

--- a/src/include/daos_srv/iv.h
+++ b/src/include/daos_srv/iv.h
@@ -305,6 +305,7 @@ int ds_iv_ns_create(crt_context_t ctx, uuid_t pool_uuid, crt_group_t *grp,
 		    unsigned int *ns_id, struct ds_iv_ns **p_iv_ns);
 
 void ds_iv_ns_update(struct ds_iv_ns *ns, unsigned int master_rank);
+void ds_iv_ns_cleanup(struct ds_iv_ns *ns);
 void ds_iv_ns_stop(struct ds_iv_ns *ns);
 void ds_iv_ns_leader_stop(struct ds_iv_ns *ns);
 void ds_iv_ns_start(struct ds_iv_ns *ns);

--- a/src/include/daos_srv/vos_types.h
+++ b/src/include/daos_srv/vos_types.h
@@ -84,6 +84,8 @@ enum vos_pool_open_flags {
 	VOS_POF_EXCL	= (1 << 1),
 	/** Ignore the pool uuid passed into vos_pool_open */
 	VOS_POF_SKIP_UUID_CHECK = (1 << 2),
+	/** Open the pool for daos check query, that will bypass EXEL flags. */
+	VOS_POF_FOR_CHECK_QUERY = (1 << 3),
 };
 
 enum vos_oi_attr {
@@ -126,6 +128,17 @@ struct vos_pool_space {
 #define NVME_FREE(vps)	((vps)->vps_space.s_free[DAOS_MEDIA_NVME])
 #define NVME_SYS(vps)	((vps)->vps_space_sys[DAOS_MEDIA_NVME])
 
+struct chk_pool_info {
+	/** DAOS check phase on the pool shard. */
+	uint32_t		cpi_phase;
+	/** DAOS check instance status on the pool shard. */
+	uint32_t		cpi_ins_status;
+	/** Inconsistency information for DAOS check on the pool shard. */
+	struct chk_statistics	cpi_statistics;
+	/** Time information for DAOS check on the pool shard. */
+	struct chk_time		cpi_time;
+};
+
 /**
  * pool attributes returned to query
  */
@@ -136,14 +149,8 @@ typedef struct {
 	struct vos_pool_space	pif_space;
 	/** garbage collector statistics */
 	struct vos_gc_stat	pif_gc_stat;
-	/** DAOS check phase on the pool shard. */
-	uint32_t		pif_chk_phase;
-	/** DAOS check instance status on the pool shard. */
-	uint32_t		pif_chk_status;
-	/** Inconsistency information for DAOS check on the pool shard. */
-	struct chk_statistics	pif_chk_statistics;
-	/** Time information for DAOS check on the pool shard. */
-	struct chk_time		pif_chk_time;
+	/** DAOS check related information */
+	struct chk_pool_info	pif_chk;
 	/** TODO */
 } vos_pool_info_t;
 

--- a/src/mgmt/SConscript
+++ b/src/mgmt/SConscript
@@ -1,3 +1,4 @@
+# pylint: disable=consider-using-f-string
 """Build management server module"""
 import daos_build
 
@@ -38,7 +39,7 @@ def scons():
                                    'srv_pool.c', 'srv_system.c',
                                    'srv_target.c', 'srv_query.c',
                                    'srv_drpc.c', 'srv_util.c',
-                                   'srv_container.c'], install_off='../..')
+                                   'srv_container.c', 'srv_chk.c'], install_off='../..')
     senv.Install('$PREFIX/lib64/daos_srv', mgmt_srv)
 
     denv = senv

--- a/src/mgmt/srv_chk.c
+++ b/src/mgmt/srv_chk.c
@@ -1,0 +1,73 @@
+/**
+ * (C) Copyright 2022 Intel Corporation.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause-Patent
+ */
+/*
+ * ds_mgmt: Check Methods
+ */
+#define D_LOGFAC	DD_FAC(mgmt)
+
+#include <daos_srv/daos_chk.h>
+#include <daos_srv/daos_engine.h>
+
+#include "srv_internal.h"
+
+int
+ds_mgmt_check_start(uint32_t rank_nr, d_rank_t *ranks, uint32_t policy_nr,
+		    Mgmt__CheckInconsistPolicy **policies, uint32_t pool_nr, uuid_t pools[],
+		    uint32_t flags, int32_t phase)
+{
+	struct chk_policy *ply = NULL;
+	int		   rc = 0;
+	int		   i;
+
+	if (policy_nr != 0) {
+		D_ALLOC_ARRAY(ply, policy_nr);
+		if (ply == NULL)
+			D_GOTO(out, rc = -DER_NOMEM);
+
+		for (i = 0; i < policy_nr; i++) {
+			ply[i].cp_class = policies[i]->inconsist_cas;
+			ply[i].cp_action = policies[i]->inconsist_act;
+		}
+	}
+
+	rc = chk_leader_start(rank_nr, ranks, policy_nr, ply, pool_nr, pools, flags, phase);
+
+out:
+	D_FREE(ply);
+
+	return rc;
+}
+
+int
+ds_mgmt_check_stop(uint32_t pool_nr, uuid_t pools[])
+{
+	return chk_leader_stop(pool_nr, pools);
+}
+
+int
+ds_mgmt_check_query(uint32_t pool_nr, uuid_t pools[], chk_query_head_cb_t head_cb,
+		    chk_query_pool_cb_t pool_cb, void *buf)
+{
+	return chk_leader_query(pool_nr, pools, head_cb, pool_cb, buf);
+}
+
+int
+ds_mgmt_check_prop(chk_prop_cb_t prop_cb, void *buf)
+{
+	return chk_leader_prop(prop_cb, buf);
+}
+
+int
+ds_mgmt_check_act(uint64_t seq, uint32_t act, bool for_all)
+{
+	return chk_leader_act(seq, act, for_all);
+}
+
+bool
+ds_mgmt_check_enabled(void)
+{
+	return engine_in_check();
+}

--- a/src/mgmt/srv_internal.h
+++ b/src/mgmt/srv_internal.h
@@ -21,9 +21,11 @@
 #include <daos_srv/rdb.h>
 #include <daos_srv/rsvc.h>
 #include <daos_srv/smd.h>
+#include <daos_srv/daos_chk.h>
 #include <daos_security.h>
 #include <daos_prop.h>
 
+#include "check.pb-c.h"
 #include "svc.pb-c.h"
 #include "smd.pb-c.h"
 #include "rpc.h"
@@ -107,6 +109,17 @@ int ds_mgmt_pool_query_targets(uuid_t pool_uuid, d_rank_list_t *svc_ranks, d_ran
 int ds_mgmt_cont_set_owner(uuid_t pool_uuid, d_rank_list_t *svc_ranks,
 			   uuid_t cont_uuid, const char *user,
 			   const char *group);
+
+/** srv_chk.c */
+int ds_mgmt_check_start(uint32_t rank_nr, d_rank_t *ranks, uint32_t policy_nr,
+			Mgmt__CheckInconsistPolicy **policies, uint32_t pool_nr, uuid_t pools[],
+			uint32_t flags, int32_t phase);
+int ds_mgmt_check_stop(uint32_t pool_nr, uuid_t pools[]);
+int ds_mgmt_check_query(uint32_t pool_nr, uuid_t pools[], chk_query_head_cb_t head_cb,
+			chk_query_pool_cb_t pool_cb, void *buf);
+int ds_mgmt_check_prop(chk_prop_cb_t prop_cb, void *buf);
+int ds_mgmt_check_act(uint64_t seq, uint32_t act, bool for_all);
+bool ds_mgmt_check_enabled(void);
 
 /** srv_query.c */
 

--- a/src/mgmt/srv_target.c
+++ b/src/mgmt/srv_target.c
@@ -303,7 +303,7 @@ out:
 }
 
 int
-ds_mgmt_pool_shard_exist(uuid_t uuid, char **path)
+ds_mgmt_tgt_pool_exist(uuid_t uuid, char **path)
 {
 	int	tid = dss_get_module_info()->dmi_tgt_id;
 	int	rc;

--- a/src/mgmt/tests/mocks.c
+++ b/src/mgmt/tests/mocks.c
@@ -579,3 +579,42 @@ mock_ds_mgmt_pool_upgrade_setup(void)
 	ds_mgmt_pool_upgrade_return = 0;
 	uuid_clear(ds_mgmt_pool_upgrade_uuid);
 }
+
+int
+ds_mgmt_check_start(uint32_t rank_nr, d_rank_t *ranks, uint32_t policy_nr,
+		    Mgmt__CheckInconsistPolicy **policies, uint32_t pool_nr, uuid_t pools[],
+		    uint32_t flags, int32_t phase)
+{
+	return 0;
+}
+
+int
+ds_mgmt_check_stop(uint32_t pool_nr, uuid_t pools[])
+{
+	return 0;
+}
+
+int
+ds_mgmt_check_query(uint32_t pool_nr, uuid_t pools[], chk_query_head_cb_t head_cb,
+		    chk_query_pool_cb_t pool_cb, void *buf)
+{
+	return 0;
+}
+
+int
+ds_mgmt_check_prop(chk_prop_cb_t prop_cb, void *buf)
+{
+	return 0;
+}
+
+int
+ds_mgmt_check_act(uint64_t seq, uint32_t act, bool for_all)
+{
+	return 0;
+}
+
+bool
+ds_mgmt_check_enabled(void)
+{
+	return true;
+}

--- a/src/mgmt/tests/srv_drpc_tests.c
+++ b/src/mgmt/tests/srv_drpc_tests.c
@@ -21,6 +21,7 @@
 #include "../acl.pb-c.h"
 #include "../pool.pb-c.h"
 #include "../cont.pb-c.h"
+#include "../check.pb-c.h"
 #include "../svc.pb-c.h"
 #include "../server.pb-c.h"
 #include "../drpc_internal.h"
@@ -113,6 +114,11 @@ test_mgmt_drpc_handlers_bad_call_payload(void **state)
 	expect_failure_for_bad_call_payload(ds_mgmt_drpc_pool_set_prop);
 	expect_failure_for_bad_call_payload(ds_mgmt_drpc_cont_set_owner);
 	expect_failure_for_bad_call_payload(ds_mgmt_drpc_pool_upgrade);
+	expect_failure_for_bad_call_payload(ds_mgmt_drpc_check_start);
+	expect_failure_for_bad_call_payload(ds_mgmt_drpc_check_stop);
+	expect_failure_for_bad_call_payload(ds_mgmt_drpc_check_query);
+	expect_failure_for_bad_call_payload(ds_mgmt_drpc_check_prop);
+	expect_failure_for_bad_call_payload(ds_mgmt_drpc_check_act);
 }
 
 static daos_prop_t *
@@ -2562,6 +2568,51 @@ test_drpc_pool_upgrade_success(void **state)
 	D_FREE(resp.body.data);
 }
 
+/*
+ * dRPC check start tests
+ */
+
+static void
+test_drpc_check_start_success(void **state)
+{
+}
+
+/*
+ * dRPC check stop tests
+ */
+
+static void
+test_drpc_check_stop_success(void **state)
+{
+}
+
+/*
+ * dRPC check query tests
+ */
+
+static void
+test_drpc_check_query_success(void **state)
+{
+}
+
+/*
+ * dRPC check prop tests
+ */
+
+static void
+test_drpc_check_prop_success(void **state)
+{
+}
+
+/*
+ * dRPC check act tests
+ */
+
+static void
+test_drpc_check_act_success(void **state)
+{
+}
+
 #define ACL_TEST(x)	cmocka_unit_test_setup_teardown(x, \
 						drpc_pool_acl_setup, \
 						drpc_pool_acl_teardown)
@@ -2613,6 +2664,16 @@ test_drpc_pool_upgrade_success(void **state)
 #define CONT_SET_OWNER_TEST(x) cmocka_unit_test_setup_teardown(x, \
 						drpc_cont_set_owner_setup, \
 						drpc_cont_set_owner_teardown)
+
+#define CHECK_START_TEST(x)	cmocka_unit_test(x)
+
+#define CHECK_STOP_TEST(x)	cmocka_unit_test(x)
+
+#define CHECK_QUERY_TEST(x)	cmocka_unit_test(x)
+
+#define CHECK_PROP_TEST(x)	cmocka_unit_test(x)
+
+#define CHECK_ACT_TEST(x)	cmocka_unit_test(x)
 
 int
 main(void)
@@ -2678,6 +2739,11 @@ main(void)
 		POOL_UPGRADE_TEST(test_drpc_pool_upgrade_bad_uuid),
 		POOL_UPGRADE_TEST(test_drpc_pool_upgrade_mgmt_svc_fails),
 		POOL_UPGRADE_TEST(test_drpc_pool_upgrade_success),
+		CHECK_START_TEST(test_drpc_check_start_success),
+		CHECK_STOP_TEST(test_drpc_check_stop_success),
+		CHECK_QUERY_TEST(test_drpc_check_query_success),
+		CHECK_PROP_TEST(test_drpc_check_prop_success),
+		CHECK_ACT_TEST(test_drpc_check_act_success),
 	};
 
 	return cmocka_run_group_tests_name("mgmt_srv_drpc", tests, NULL, NULL);

--- a/src/vos/vos_layout.h
+++ b/src/vos/vos_layout.h
@@ -19,7 +19,6 @@
 #include <daos_srv/bio.h>
 #include <daos_srv/vea.h>
 #include <daos_srv/dtx_srv.h>
-#include <daos_srv/daos_chk.h>
 #include "ilog.h"
 
 /**
@@ -97,7 +96,7 @@ enum vos_gc_type {
  *  This enables the user to continue using the pool with the older version unless
  *  they have explicitly upgraded it.
  */
-#define POOL_DF_AGG_OPT				24
+#define POOL_DF_AGG_OPT				25
 /** Current durable format version */
 #define POOL_DF_VERSION				POOL_DF_AGG_OPT
 
@@ -118,7 +117,12 @@ struct vos_pool_df {
 	 * a new format, containers with old format can be attached at here.
 	 */
 	uint64_t				pd_reserv_upgrade;
-	/** Reserved for future usage */
+	/**
+	 * Offset to area for DAOS check related information (chk_pool_info) for this pool.
+	 * The chk_pool_info::cpi_statistics contains the inconsistency statistics during
+	 * the phases range [CSP_DTX_RESYNC, OSP_AGGREGATION] for the pool shard on the target.
+	 */
+	umem_off_t				pd_chk;
 	uint64_t				pd_reserv;
 	/** Unique PoolID for each VOS pool assigned on creation */
 	uuid_t					pd_id;
@@ -136,16 +140,6 @@ struct vos_pool_df {
 	struct vea_space_df			pd_vea_df;
 	/** GC bins for container/object/dkey... */
 	struct vos_gc_bin_df			pd_gc_bins[GC_MAX];
-	/** DAOS check phase. */
-	uint32_t				pd_chk_phase;
-	/** DAOS check instance status. */
-	uint32_t				pd_chk_status;
-	/**
-	 * The inconsistency statistics during the phases range [CSP_DTX_RESYNC, OSP_AGGREGATION]
-	 * for the pool shard on the target.
-	 */
-	struct chk_statistics			pd_chk_statistics;
-	struct chk_time				pd_chk_time;
 };
 
 /**


### PR DESCRIPTION
The DAOS check dRPC download interfaces are implemented inside mgmt,
include the following:

1. DRPC_METHOD_MGMT_CHK_START:
   Start DAOS check on the spcified ranks. Both the ranks list and
   the leader rank are specified by the control plane.

2. DRPC_METHOD_MGMT_CHK_STOP:
   Stop DAOS check for the specified pool(s), or for all pools if
   without pool option. If only some pools are specified to stop,
   then the check instance will continue the check for the other
   left pool(s).

3. DRPC_METHOD_MGMT_CHK_QUERY:
   Query check process for specified pools or all pools by default,
   including the instance status, related pool status, summary for
   all the engines (and the leader) found inconsistencies, related
   handle actions and the results, and so on.

4. DRPC_METHOD_MGMT_CHK_PROP:
   Get current check instance run flags and inconsistency handle
   policies. If no check instance is running at the time, former
   one's information will be returned.

5. DRPC_METHOD_MGMT_CHK_ACT:
   Execute the action to handle (repair or ignore) the specified
   inconsistency under interaction mode.

Quick-Functional: true

Signed-off-by: Fan Yong <fan.yong@intel.com>