### PR TITLE
DAOS-10609 test: fix usage of time

### DIFF
--- a/src/tests/ftest/util/apricot/apricot/test.py
+++ b/src/tests/ftest/util/apricot/apricot/test.py
@@ -341,7 +341,7 @@ class Test(avocadoTest):
             float: number of seconds since the start of the test
 
         """
-        return time.time() - self.time_start
+        return time() - self.time_start
 
     def get_remaining_time(self):
         """Get the remaining time before the test timeout will expire.


### PR DESCRIPTION
Due to import change, call time() instead of time.time()

Test-tag: ior_intercept_verify_data
Skip-unit-tests: true
Skip-fault-injection-test: true

Signed-off-by: Dalton Bohning <dalton.bohning@intel.com>