### PR TITLE
DAOS-10611 control: Evict pool handles on agent shutdown

### DIFF
--- a/src/control/cmd/daos_agent/config.go
+++ b/src/control/cmd/daos_agent/config.go
@@ -34,6 +34,7 @@ type Config struct {
 	LogLevel         common.ControlLogLevel    `yaml:"control_log_mask,omitempty"`
 	TransportConfig  *security.TransportConfig `yaml:"transport_config"`
 	DisableCache     bool                      `yaml:"disable_caching,omitempty"`
+	DisableAutoEvict bool                      `yaml:"disable_auto_evict,omitempty"`
 	FabricInterfaces []*NUMAFabricConfig       `yaml:"fabric_ifaces,omitempty"`
 }
 

--- a/src/control/cmd/daos_agent/config_test.go
+++ b/src/control/cmd/daos_agent/config_test.go
@@ -43,6 +43,7 @@ runtime_dir: /tmp/runtime
 log_file: /home/frodo/logfile
 control_log_mask: debug
 disable_caching: true
+disable_auto_evict: true
 transport_config:
   allow_insecure: true
 fabric_ifaces:
@@ -119,13 +120,14 @@ transport_config:
 		"all options": {
 			path: optCfg,
 			expResult: &Config{
-				SystemName:   "shire",
-				AccessPoints: []string{"one:10001", "two:10001"},
-				ControlPort:  4242,
-				RuntimeDir:   "/tmp/runtime",
-				LogFile:      "/home/frodo/logfile",
-				LogLevel:     common.ControlLogLevelDebug,
-				DisableCache: true,
+				SystemName:       "shire",
+				AccessPoints:     []string{"one:10001", "two:10001"},
+				ControlPort:      4242,
+				RuntimeDir:       "/tmp/runtime",
+				LogFile:          "/home/frodo/logfile",
+				LogLevel:         common.ControlLogLevelDebug,
+				DisableCache:     true,
+				DisableAutoEvict: true,
 				TransportConfig: &security.TransportConfig{
 					AllowInsecure:     true,
 					CertificateConfig: DefaultConfig().TransportConfig.CertificateConfig,

--- a/src/control/cmd/daos_agent/mgmt_rpc.go
+++ b/src/control/cmd/daos_agent/mgmt_rpc.go
@@ -64,6 +64,11 @@ func (mod *mgmtModule) HandleCall(ctx context.Context, session *drpc.Session, me
 		return nil, err
 	}
 
+	if agentIsShuttingDown(ctx) {
+		mod.log.Errorf("agent is shutting down, dropping %s", method)
+		return nil, drpc.NewFailureWithMessage("agent is shutting down")
+	}
+
 	switch method {
 	case drpc.MethodGetAttachInfo:
 		return mod.handleGetAttachInfo(ctx, req, cred.Pid)

--- a/src/control/cmd/daos_agent/start.go
+++ b/src/control/cmd/daos_agent/start.go
@@ -16,13 +16,25 @@ import (
 
 	"github.com/daos-stack/daos/src/control/common/cmdutil"
 	"github.com/daos-stack/daos/src/control/drpc"
+	"github.com/daos-stack/daos/src/control/lib/atm"
 	"github.com/daos-stack/daos/src/control/lib/hardware/hwloc"
 	"github.com/daos-stack/daos/src/control/lib/hardware/hwprov"
 )
 
+type ctxKey string
+
 const (
-	agentSockName = "daos_agent.sock"
+	agentSockName          = "daos_agent.sock"
+	shuttingDownKey ctxKey = "agent_shutting_down"
 )
+
+func agentIsShuttingDown(ctx context.Context) bool {
+	shuttingDown, ok := ctx.Value(shuttingDownKey).(*atm.Bool)
+	if !ok {
+		return false
+	}
+	return shuttingDown.IsTrue()
+}
 
 type startCmd struct {
 	cmdutil.LogCmd
@@ -34,8 +46,11 @@ func (cmd *startCmd) Execute(_ []string) error {
 	cmd.Debugf("Starting %s (pid %d)", versionString(), os.Getpid())
 	startedAt := time.Now()
 
-	ctx, shutdown := context.WithCancel(context.Background())
+	parent, shutdown := context.WithCancel(context.Background())
 	defer shutdown()
+
+	var shuttingDown atm.Bool
+	ctx := context.WithValue(parent, shuttingDownKey, &shuttingDown)
 
 	sockPath := filepath.Join(cmd.cfg.RuntimeDir, agentSockName)
 	cmd.Debugf("Full socket path is now: %s", sockPath)
@@ -107,7 +122,7 @@ func (cmd *startCmd) Execute(_ []string) error {
 	signals := make(chan os.Signal)
 	finish := make(chan struct{})
 
-	signal.Notify(signals, syscall.SIGINT, syscall.SIGTERM, syscall.SIGPIPE)
+	signal.Notify(signals, syscall.SIGINT, syscall.SIGTERM, syscall.SIGPIPE, syscall.SIGUSR1)
 	// Anonymous goroutine to wait on the signals channel and tell the
 	// program to finish when it receives a signal. Since we notify on
 	// SIGINT and SIGTERM we should only catch these on a kill or ctrl+c
@@ -116,14 +131,23 @@ func (cmd *startCmd) Execute(_ []string) error {
 	// channel.
 	var shutdownRcvd time.Time
 	go func() {
-		sig := <-signals
-		switch sig {
-		case syscall.SIGPIPE:
-			cmd.Infof("Signal received.  Caught non-fatal %s; continuing", sig)
-		default:
-			shutdownRcvd = time.Now()
-			cmd.Infof("Signal received.  Caught %s; shutting down", sig)
-			close(finish)
+		for sig := range signals {
+			switch sig {
+			case syscall.SIGPIPE:
+				cmd.Infof("Signal received.  Caught non-fatal %s; continuing", sig)
+			case syscall.SIGUSR1:
+				cmd.Infof("Signal received.  Caught %s; flushing open pool handles", sig)
+				procmon.FlushAllHandles(ctx)
+			default:
+				shutdownRcvd = time.Now()
+				cmd.Infof("Signal received.  Caught %s; shutting down", sig)
+				shuttingDown.SetTrue()
+				if !cmd.cfg.DisableAutoEvict {
+					procmon.FlushAllHandles(ctx)
+				}
+				close(finish)
+				return
+			}
 		}
 	}()
 	<-finish

--- a/utils/config/daos_agent.yml
+++ b/utils/config/daos_agent.yml
@@ -60,6 +60,13 @@
 ## default: INFO
 #control_log_mask: DEBUG
 
+## Disable automatic eviction of open pool handles on agent shutdown. By default,
+## the agent will evict all open pool handles for local processes on shutdown.
+## Note that this implies that stopping or restarting the agent will result
+## in interruption of DAOS I/O for any local DAOS client processes that have
+## an open pool handle.
+# disable_auto_evict: true
+
 ## Disable the agent's internal caches. If set to true, the agent will query the
 ## server access point and local hardware data every time a client requests
 ## rank connection information.


### PR DESCRIPTION
When the agent is shut down, it loses all knowledge of
currently-open pool handles on the local node. By default,
it should instead attempt to evict all open pool handles
before shutting down.

This behavior can be overridden by setting the following
in the agent configuration:

disable_auto_evict: true

Features: control pool container

Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com>
