### PR TITLE
DAOS-9625 test: Increase the timeout.

### DIFF
--- a/src/tests/ftest/osa/dmg_negative_test.yaml
+++ b/src/tests/ftest/osa/dmg_negative_test.yaml
@@ -11,7 +11,7 @@ test_clients:
 extra_servers:
   test_servers:
     - server-C
-timeout: 1200
+timeout: 1800
 skip_add_log_msg: true
 server_config:
   name: daos_server


### PR DESCRIPTION
Skip-unit-tests: true
Test-tag: osa_dmg_negative_test
Test-repeat: 10

Signed-off-by: rpadma2 <ravindran.padmanabhan@intel.com>