### PR TITLE
DAOS-10500 test: nvme/health.py: increase pool capacity

### DIFF
--- a/src/tests/ftest/nvme/health.py
+++ b/src/tests/ftest/nvme/health.py
@@ -27,7 +27,8 @@ class NvmeHealth(ServerFillUp):
 
         :avocado: tags=all,full_regression
         :avocado: tags=hw,medium
-        :avocado: tags=nvme,ib2,nvme_health
+        :avocado: tags=nvme
+        :avocado: tags=nvme_health
         """
         # pylint: disable=attribute-defined-outside-init
         # pylint: disable=too-many-branches
@@ -59,8 +60,7 @@ class NvmeHealth(ServerFillUp):
         # List all pools
         self.dmg.set_sub_command("storage")
         self.dmg.sub_command_class.set_sub_command("query")
-        self.dmg.sub_command_class.sub_command_class.set_sub_command(
-            "list-pools")
+        self.dmg.sub_command_class.sub_command_class.set_sub_command("list-pools")
         for host in self.hostlist_servers:
             self.dmg.hostlist = host
             try:

--- a/src/tests/ftest/nvme/health.yaml
+++ b/src/tests/ftest/nvme/health.yaml
@@ -44,4 +44,4 @@ pool:
     name: daos_server
     control_method: dmg
     number_of_pools: 40
-    pool_used_percentage: 75
+    pool_used_percentage: 90


### PR DESCRIPTION
Test-tag: nvme_health
Skip-unit-tests: true
Skip-fault-injection-test: true

nvme/health.py
- Increase total space usage from 75% to 90%

Signed-off-by: Dalton Bohning <dalton.bohning@intel.com>