### PR TITLE
DAOS-10530 agent: Fix NUMA node rotation (#8973)

### DIFF
--- a/src/control/cmd/daos_agent/fabric.go
+++ b/src/control/cmd/daos_agent/fabric.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"sort"
 	"sync"
 
 	"github.com/pkg/errors"
@@ -233,16 +234,27 @@ func (n *NUMAFabric) getNextDevice(numaNode int) *FabricInterface {
 }
 
 func (n *NUMAFabric) findOnAnyNUMA(netDevClass hardware.NetDevClass, provider string) (*FabricInterface, error) {
-	numNodes := n.getNumNUMANodes()
+	nodes := n.getNUMANodes()
+	numNodes := len(nodes)
+
 	for i := 0; i < numNodes; i++ {
 		n.currentNUMANode = (n.currentNUMANode + 1) % numNodes
-		fi, err := n.getDeviceFromNUMA(n.currentNUMANode, netDevClass, provider)
+		fi, err := n.getDeviceFromNUMA(nodes[n.currentNUMANode], netDevClass, provider)
 		if err == nil {
 			n.log.Debugf("Suitable fabric interface %q found on NUMA node %d", fi.Name, n.currentNUMANode)
 			return fi, nil
 		}
 	}
 	return nil, FabricNotFoundErr(netDevClass)
+}
+
+func (n *NUMAFabric) getNUMANodes() []int {
+	keys := make([]int, 0)
+	for k := range n.numaMap {
+		keys = append(keys, k)
+	}
+	sort.Ints(keys)
+	return keys
 }
 
 // getNextDevIndex is a simple round-robin load balancing scheme

--- a/src/control/cmd/daos_agent/fabric_test.go
+++ b/src/control/cmd/daos_agent/fabric_test.go
@@ -376,7 +376,7 @@ func TestAgent_NUMAFabric_GetDevice(t *testing.T) {
 						DeviceClass:   hardware.Infiniband,
 						Providers:     common.NewStringSet("ofi+sockets"),
 					}),
-					1: fabricInterfacesFromHardware(&hardware.FabricInterface{
+					3: fabricInterfacesFromHardware(&hardware.FabricInterface{
 						NetInterfaces: common.NewStringSet("t2"),
 						Name:          "t2",
 						DeviceClass:   hardware.Ether,
@@ -385,15 +385,19 @@ func TestAgent_NUMAFabric_GetDevice(t *testing.T) {
 				},
 			},
 			node:        1,
-			netDevClass: hardware.Infiniband,
+			netDevClass: hardware.Ether,
 			expResults: []*FabricInterface{
 				{
-					Name:        "t1",
-					NetDevClass: hardware.Infiniband,
+					Name:        "t2",
+					NetDevClass: hardware.Ether,
 				},
 				{
-					Name:        "t1",
-					NetDevClass: hardware.Infiniband,
+					Name:        "t2",
+					NetDevClass: hardware.Ether,
+				},
+				{
+					Name:        "t2",
+					NetDevClass: hardware.Ether,
 				},
 			},
 		},


### PR DESCRIPTION
The agent was assuming NUMA nodes were sorted by index rather than
ID for load balancing purposes. This broke in cases with network
interfaces on non-sequential NUMA nodes.

Feature: control

Signed-off-by: Kris Jacque <kristin.jacque@intel.com>