### PR TITLE
DAOS-10395 agent: Add component incompatibility error

### DIFF
--- a/src/control/cmd/daos_agent/mgmt_rpc.go
+++ b/src/control/cmd/daos_agent/mgmt_rpc.go
@@ -19,6 +19,8 @@ import (
 	"github.com/daos-stack/daos/src/control/common/proto/convert"
 	mgmtpb "github.com/daos-stack/daos/src/control/common/proto/mgmt"
 	"github.com/daos-stack/daos/src/control/drpc"
+	"github.com/daos-stack/daos/src/control/fault"
+	"github.com/daos-stack/daos/src/control/fault/code"
 	"github.com/daos-stack/daos/src/control/lib/control"
 	"github.com/daos-stack/daos/src/control/lib/daos"
 	"github.com/daos-stack/daos/src/control/lib/hardware"
@@ -125,7 +127,9 @@ func (mod *mgmtModule) handleGetAttachInfo(ctx context.Context, reqb []byte, pid
 	mod.log.Debugf("client process NUMA node %d", numaNode)
 
 	resp, err := mod.getAttachInfo(ctx, int(numaNode), pbReq.Sys)
-	if err != nil {
+	if fault.IsFaultCode(err, code.ServerWrongSystem) {
+		resp = &mgmtpb.GetAttachInfoResp{Status: int32(daos.ControlIncompatible)}
+	} else if err != nil {
 		return nil, err
 	}
 

--- a/src/control/cmd/daos_agent/mgmt_rpc_test.go
+++ b/src/control/cmd/daos_agent/mgmt_rpc_test.go
@@ -9,17 +9,22 @@ package main
 import (
 	"context"
 	"net"
+	"os"
 	"sync"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/pkg/errors"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/daos-stack/daos/src/control/common"
 	mgmtpb "github.com/daos-stack/daos/src/control/common/proto/mgmt"
 	"github.com/daos-stack/daos/src/control/common/test"
+	"github.com/daos-stack/daos/src/control/fault"
+	"github.com/daos-stack/daos/src/control/fault/code"
 	"github.com/daos-stack/daos/src/control/lib/control"
+	"github.com/daos-stack/daos/src/control/lib/daos"
 	"github.com/daos-stack/daos/src/control/lib/hardware"
 	"github.com/daos-stack/daos/src/control/logging"
 )
@@ -70,33 +75,88 @@ func TestAgent_mgmtModule_getAttachInfo(t *testing.T) {
 
 	hintResp := func(resp *mgmtpb.GetAttachInfoResp) *mgmtpb.GetAttachInfoResp {
 		withHint := new(mgmtpb.GetAttachInfoResp)
-		*withHint = *testResps[0]
+		*withHint = *resp
 		withHint.ClientNetHint.Interface = testFI[0].Name
 		withHint.ClientNetHint.Domain = testFI[0].Name
 
 		return withHint
 	}
 
+	unaryResps := func(hostResps []*control.HostResponse) []*control.UnaryResponse {
+		ur := make([]*control.UnaryResponse, 0, len(hostResps))
+		for _, hr := range hostResps {
+			ur = append(ur, &control.UnaryResponse{
+				Responses: []*control.HostResponse{hr},
+			})
+		}
+		return ur
+	}
+
+	type attachInfoResult struct {
+		resp *mgmtpb.GetAttachInfoResp
+		err  error
+	}
+
 	for name, tc := range map[string]struct {
 		cacheDisabled bool
 		rpcResps      []*control.HostResponse
-		expResps      []*mgmtpb.GetAttachInfoResp
+		expResult     []attachInfoResult
 	}{
+		"error": {
+			rpcResps: []*control.HostResponse{
+				{
+					Error: errors.New("host response"),
+				},
+			},
+			expResult: []attachInfoResult{
+				{
+					err: errors.New("host response"),
+				},
+			},
+		},
+		"incompatible fault": {
+			rpcResps: []*control.HostResponse{
+				{
+					Error: &fault.Fault{
+						Code: code.ServerWrongSystem,
+					},
+				},
+			},
+			expResult: []attachInfoResult{
+				{
+					resp: &mgmtpb.GetAttachInfoResp{
+						Status: int32(daos.ControlIncompatible),
+					},
+				},
+			},
+		},
 		"cache disabled": {
 			cacheDisabled: true,
 			rpcResps:      hostResps(testResps),
-			expResps: []*mgmtpb.GetAttachInfoResp{
-				hintResp(testResps[0]),
-				hintResp(testResps[1]),
-				hintResp(testResps[2]),
+			expResult: []attachInfoResult{
+				{
+					resp: hintResp(testResps[0]),
+				},
+				{
+					resp: hintResp(testResps[1]),
+				},
+				{
+					resp: hintResp(testResps[2]),
+				},
 			},
 		},
 		"cached": {
 			rpcResps: hostResps(testResps),
-			expResps: []*mgmtpb.GetAttachInfoResp{
-				hintResp(testResps[0]),
-				hintResp(testResps[0]),
-				hintResp(testResps[0]),
+			expResult: []attachInfoResult{
+				{
+					resp: hintResp(testResps[0]),
+				},
+				{
+					resp: hintResp(testResps[0]),
+				},
+				{
+					resp: hintResp(testResps[0]),
+				},
 			},
 		},
 	} {
@@ -116,19 +176,38 @@ func TestAgent_mgmtModule_getAttachInfo(t *testing.T) {
 				}),
 				attachInfo: newAttachInfoCache(log, !tc.cacheDisabled),
 				ctlInvoker: control.NewMockInvoker(log, &control.MockInvokerConfig{
-					Sys: sysName,
-					UnaryResponse: &control.UnaryResponse{
-						Responses: tc.rpcResps,
-					},
+					Sys:              sysName,
+					UnaryResponseSet: unaryResps(tc.rpcResps),
 				}),
+				numaGetter: &mockNUMAProvider{},
 			}
 
-			for _, expResp := range tc.expResps {
-				resp, err := mod.getAttachInfo(context.Background(), 0, sysName)
+			reqBytes, err := proto.Marshal(&mgmtpb.GetAttachInfoReq{
+				Sys: sysName,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
 
-				test.CmpErr(t, nil, err)
+			for i, exp := range tc.expResult {
+				t.Logf("iteration %d\n", i)
+				respBytes, err := mod.handleGetAttachInfo(context.Background(), reqBytes, int32(os.Getpid()))
 
-				if diff := cmp.Diff(expResp, resp, cmpopts.IgnoreUnexported(mgmtpb.GetAttachInfoResp{}, mgmtpb.ClientNetHint{})); diff != "" {
+				test.CmpErr(t, exp.err, err)
+
+				var resp mgmtpb.GetAttachInfoResp
+				if err := proto.Unmarshal(respBytes, &resp); err != nil {
+					t.Fatal(err)
+				}
+
+				if exp.resp == nil {
+					if respBytes == nil {
+						return
+					}
+					t.Fatalf("expected nil response, got:\n%+v\n", &resp)
+				}
+
+				if diff := cmp.Diff(exp.resp, &resp, cmpopts.IgnoreUnexported(mgmtpb.GetAttachInfoResp{}, mgmtpb.ClientNetHint{})); diff != "" {
 					t.Fatalf("-want, +got:\n%s", diff)
 				}
 			}

--- a/src/control/fault/fault.go
+++ b/src/control/fault/fault.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2018-2021 Intel Corporation.
+// (C) Copyright 2018-2022 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -129,4 +129,13 @@ func HasResolution(raw error) bool {
 func IsFault(raw error) bool {
 	_, ok := errors.Cause(raw).(*Fault)
 	return ok
+}
+
+// IsFaultCode indicates whether or not the error is a Fault with the given code.
+func IsFaultCode(raw error, faultCode code.Code) bool {
+	errFault, ok := errors.Cause(raw).(*Fault)
+	if !ok {
+		return false
+	}
+	return errFault.Code == faultCode
 }

--- a/src/control/fault/fault_test.go
+++ b/src/control/fault/fault_test.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2018-2021 Intel Corporation.
+// (C) Copyright 2018-2022 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -13,7 +13,9 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/daos-stack/daos/src/control/common/test"
 	"github.com/daos-stack/daos/src/control/fault"
+	"github.com/daos-stack/daos/src/control/fault/code"
 )
 
 func TestFaults(t *testing.T) {
@@ -153,6 +155,36 @@ func TestFaultComparison(t *testing.T) {
 			if actual != tc.expComparison {
 				t.Fatalf("expected %t, but got %t", tc.expComparison, actual)
 			}
+		})
+	}
+}
+
+func TestFault_IsFaultCode(t *testing.T) {
+	for name, tc := range map[string]struct {
+		err       error
+		code      code.Code
+		expResult bool
+	}{
+		"nil": {},
+		"not a fault": {
+			err: errors.New("something"),
+		},
+		"code matches": {
+			err: &fault.Fault{
+				Code: code.MissingSoftwareDependency,
+			},
+			code:      code.MissingSoftwareDependency,
+			expResult: true,
+		},
+		"code doesn't match": {
+			err: &fault.Fault{
+				Code: code.PrivilegedHelperNotPrivileged,
+			},
+			code: code.MissingSoftwareDependency,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			test.AssertEqual(t, tc.expResult, fault.IsFaultCode(tc.err, tc.code), "")
 		})
 	}
 }

--- a/src/control/lib/daos/status.go
+++ b/src/control/lib/daos/status.go
@@ -146,4 +146,6 @@ const (
 	NotReplica Status = -C.DER_NOTREPLICA
 	// ChecksumError indicates a checksum error
 	ChecksumError Status = -C.DER_CSUM
+	// ControlIncompatible indicates that one or more control plane components are incompatible
+	ControlIncompatible Status = -C.DER_CONTROL_INCOMPAT
 )

--- a/src/include/daos_errno.h
+++ b/src/include/daos_errno.h
@@ -273,6 +273,8 @@ extern "C" {
 		Retry with other target)				\
 	ACTION(DER_NOTSUPPORTED,	(DER_ERR_DAOS_BASE + 37),	\
 	       Operation not supported)					\
+	ACTION(DER_CONTROL_INCOMPAT,	(DER_ERR_DAOS_BASE + 38),	\
+	       One or more control plane components are incompatible)	\
 
 /** Defines the gurt error codes */
 #define D_FOREACH_ERR_RANGE(ACTION)	\


### PR DESCRIPTION
- Add a new error, DER_CONTROL_INCOMPAT, to indicate that control
  plane components (agent, server, dmg) are not compatible.
- Return the new error as a status code to client processes if the
  agent discovers it is not compatible with the DAOS server.
- Fix broken GetAttachInfo unit test.

Signed-off-by: Kris Jacque <kristin.jacque@intel.com>