### PR TITLE
DAOS-9592 rsvc: Fix ds_rsvc leaks

### DIFF
--- a/src/rsvc/srv.c
+++ b/src/rsvc/srv.c
@@ -1078,7 +1078,7 @@ ds_rsvc_add_replicas(enum ds_rsvc_class_id class, d_iov_t *id,
 		return rc;
 	rc = ds_rsvc_add_replicas_s(svc, ranks, size);
 	ds_rsvc_set_hint(svc, hint);
-	put_leader(svc);
+	ds_rsvc_put_leader(svc);
 	return rc;
 }
 
@@ -1114,7 +1114,7 @@ ds_rsvc_remove_replicas(enum ds_rsvc_class_id class, d_iov_t *id,
 		return rc;
 	rc = ds_rsvc_remove_replicas_s(svc, ranks, stop);
 	ds_rsvc_set_hint(svc, hint);
-	put_leader(svc);
+	ds_rsvc_put_leader(svc);
 	return rc;
 }
 


### PR DESCRIPTION
When working on feature/cat_recovery, we found a ds_rsvc leak
during "rdbt test-multi". The functions ds_rsvc_{add,remove}_replicas
use put_leader to release only the leader reference, leaking the ds_rsvc
reference. This patch replaces the put_leader calls with
ds_rsvc_put_leader, which releases both references.

Since these functions are currently called only from rdbt, this is a
test issue at the moment.

Signed-off-by: Li Wei <wei.g.li@intel.com>