### PR TITLE
DAOS-10526 control: Add block devices to topology scan (#8970)

### DIFF
--- a/src/control/lib/hardware/hwloc/bindings.go
+++ b/src/control/lib/hardware/hwloc/bindings.go
@@ -234,6 +234,7 @@ const (
 	objTypeNUMANode  = C.HWLOC_OBJ_NUMANODE
 	objTypeCore      = C.HWLOC_OBJ_CORE
 
+	osDevTypeBlock       = C.HWLOC_OBJ_OSDEV_BLOCK
 	osDevTypeNetwork     = C.HWLOC_OBJ_OSDEV_NETWORK
 	osDevTypeOpenFabrics = C.HWLOC_OBJ_OSDEV_OPENFABRICS
 

--- a/src/control/lib/hardware/hwloc/provider.go
+++ b/src/control/lib/hardware/hwloc/provider.go
@@ -301,7 +301,7 @@ func (p *Provider) getPCIDevsPerNUMANode(topo *topology, nodes hardware.NodeMap)
 		var addr *hardware.PCIAddress
 		var linkSpeed float64
 		switch osDevType {
-		case osDevTypeNetwork, osDevTypeOpenFabrics:
+		case osDevTypeBlock, osDevTypeNetwork, osDevTypeOpenFabrics:
 			if pciDev, err := osDev.getAncestorByType(objTypePCIDevice); err == nil {
 				addr, err = pciDev.pciAddr()
 				if err != nil {
@@ -312,8 +312,9 @@ func (p *Provider) getPCIDevsPerNUMANode(topo *topology, nodes hardware.NodeMap)
 					return err
 				}
 			} else {
-				// unexpected - network devices should be on the PCI bus
+				// unexpected - these devices should be on the PCI bus
 				p.log.Error(err.Error())
+				continue
 			}
 		default:
 			continue
@@ -376,6 +377,8 @@ func osDevTypeToHardwareDevType(osType int) hardware.DeviceType {
 		return hardware.DeviceTypeNetInterface
 	case osDevTypeOpenFabrics:
 		return hardware.DeviceTypeOFIDomain
+	case osDevTypeBlock:
+		return hardware.DeviceTypeBlock
 	}
 
 	return hardware.DeviceTypeUnknown

--- a/src/control/lib/hardware/hwloc/provider_test.go
+++ b/src/control/lib/hardware/hwloc/provider_test.go
@@ -129,6 +129,11 @@ func TestHwlocProvider_GetTopology_Samples(t *testing.T) {
 									Type:    hardware.DeviceTypeOFIDomain,
 									PCIAddr: *hardware.MustNewPCIAddress("0000:3d:00.1"),
 								},
+								{
+									Name:    "sda",
+									Type:    hardware.DeviceTypeBlock,
+									PCIAddr: *hardware.MustNewPCIAddress("0000:00:11.5"),
+								},
 							},
 						),
 					1: hardware.MockNUMANode(1, 24, 24),
@@ -179,6 +184,11 @@ func TestHwlocProvider_GetTopology_Samples(t *testing.T) {
 									Name:    "i40iw0",
 									Type:    hardware.DeviceTypeOFIDomain,
 									PCIAddr: *hardware.MustNewPCIAddress("0000:3d:00.1"),
+								},
+								{
+									Name:    "sda",
+									Type:    hardware.DeviceTypeBlock,
+									PCIAddr: *hardware.MustNewPCIAddress("0000:00:11.5"),
 								},
 							},
 						),
@@ -251,6 +261,16 @@ func TestHwlocProvider_GetTopology_Samples(t *testing.T) {
 									Type:    hardware.DeviceTypeNetInterface,
 									PCIAddr: *hardware.MustNewPCIAddress("0000:06:00.0"),
 								},
+								{
+									Name:    "sda",
+									Type:    hardware.DeviceTypeBlock,
+									PCIAddr: *hardware.MustNewPCIAddress("0000:00:1f.2"),
+								},
+								{
+									Name:    "sdb",
+									Type:    hardware.DeviceTypeBlock,
+									PCIAddr: *hardware.MustNewPCIAddress("0000:00:1f.2"),
+								},
 							},
 						),
 					1: hardware.MockNUMANode(1, 8, 8).
@@ -304,6 +324,16 @@ func TestHwlocProvider_GetTopology_Samples(t *testing.T) {
 										Name:    "hfi1_0",
 										Type:    hardware.DeviceTypeOFIDomain,
 										PCIAddr: *hardware.MustNewPCIAddress("0000:18:00.0"),
+									},
+									{
+										Name:    "sda",
+										Type:    hardware.DeviceTypeBlock,
+										PCIAddr: *hardware.MustNewPCIAddress("0000:00:1f.2"),
+									},
+									{
+										Name:    "sr0",
+										Type:    hardware.DeviceTypeBlock,
+										PCIAddr: *hardware.MustNewPCIAddress("0000:00:1f.2"),
 									},
 								},
 							)

--- a/src/control/lib/hardware/pci.go
+++ b/src/control/lib/hardware/pci.go
@@ -212,7 +212,7 @@ func (pas *PCIAddressSet) Equals(other *PCIAddressSet) bool {
 
 // Contains returns true if provided address is already in set.
 func (pas *PCIAddressSet) Contains(a *PCIAddress) bool {
-	if pas == nil {
+	if pas == nil || a == nil {
 		return false
 	}
 
@@ -221,6 +221,10 @@ func (pas *PCIAddressSet) Contains(a *PCIAddress) bool {
 }
 
 func (pas *PCIAddressSet) add(a *PCIAddress) {
+	if a == nil {
+		return
+	}
+
 	if pas.addrMap == nil {
 		pas.addrMap = make(map[string]*PCIAddress)
 	}
@@ -464,7 +468,7 @@ func (b *PCIBus) AddDevice(dev *PCIDevice) error {
 	if b == nil || dev == nil {
 		return errors.New("bus or device is nil")
 	}
-	if !b.Contains(dev.PCIAddr) {
+	if !b.Contains(&dev.PCIAddr) {
 		return fmt.Errorf("device %s is not on bus %s", &dev.PCIAddr, b)
 	}
 	if b.PCIDevices == nil {
@@ -478,8 +482,8 @@ func (b *PCIBus) AddDevice(dev *PCIDevice) error {
 }
 
 // Contains returns true if the given PCI address is contained within the bus.
-func (b *PCIBus) Contains(addr PCIAddress) bool {
-	if b == nil {
+func (b *PCIBus) Contains(addr *PCIAddress) bool {
+	if b == nil || addr == nil {
 		return false
 	}
 
@@ -566,4 +570,17 @@ func (d PCIDevices) Keys() []*PCIAddress {
 		}
 	}
 	return set.Addresses()
+}
+
+// Get returns the devices for the given PCI address.
+func (d PCIDevices) Get(addr *PCIAddress) []*PCIDevice {
+	if d == nil || addr == nil {
+		return nil
+	}
+
+	if devs, found := d[*addr]; found {
+		return devs
+	}
+
+	return nil
 }

--- a/src/control/lib/hardware/pretty.go
+++ b/src/control/lib/hardware/pretty.go
@@ -23,7 +23,7 @@ func PrintTopology(t *Topology, output io.Writer) error {
 		return nil
 	}
 
-	for _, numaNode := range t.NUMANodes {
+	for _, numaNode := range t.NUMANodes.AsSlice() {
 		coreSet := &system.RankSet{}
 		for _, core := range numaNode.Cores {
 			coreSet.Add(system.Rank(core.ID))
@@ -31,17 +31,21 @@ func PrintTopology(t *Topology, output io.Writer) error {
 
 		fmt.Fprintf(ew, "NUMA Node %d\n", numaNode.ID)
 		fmt.Fprintf(ew, "  CPU cores: %s\n", coreSet)
-		fmt.Fprintf(ew, "  PCI devices:\n")
-		for addr, devs := range numaNode.PCIDevices {
-			fmt.Fprintf(ew, "    %s\n", &addr)
-			for _, dev := range devs {
-				fmt.Fprintf(ew, "      %s\n", dev)
-			}
-		}
 		fmt.Fprintf(ew, "  PCI buses:\n")
 		for _, bus := range numaNode.PCIBuses {
 			fmt.Fprintf(ew, "    %s\n", bus)
+			for _, addr := range numaNode.PCIDevices.Keys() {
+				if !bus.Contains(addr) {
+					continue
+				}
+
+				fmt.Fprintf(ew, "      %s\n", addr)
+				for _, dev := range numaNode.PCIDevices.Get(addr) {
+					fmt.Fprintf(ew, "        %s\n", dev)
+				}
+			}
 		}
+
 	}
 
 	if len(t.VirtualDevices) > 0 {

--- a/src/control/lib/hardware/pretty_test.go
+++ b/src/control/lib/hardware/pretty_test.go
@@ -57,12 +57,11 @@ func TestHardware_PrintTopology(t *testing.T) {
 			expOut: `
 NUMA Node 0
   CPU cores: 0-7
-  PCI devices:
-    0000:01:01.1
-      0000:01:01.1 test0 (network interface) @ 2.50 GB/s
-      0000:01:01.1 test0-peer (OFI domain) @ 1.20 GB/s
   PCI buses:
     0000:[00-0f]
+      0000:01:01.1
+        0000:01:01.1 test0 (network interface) @ 2.50 GB/s
+        0000:01:01.1 test0-peer (OFI domain) @ 1.20 GB/s
 `,
 		},
 		"virtual": {
@@ -85,16 +84,87 @@ NUMA Node 0
 			expOut: `
 NUMA Node 0
   CPU cores: 0-7
-  PCI devices:
-    0000:01:01.1
-      0000:01:01.1 test0 (network interface) @ 2.50 GB/s
-      0000:01:01.1 test0-peer (OFI domain) @ 1.20 GB/s
   PCI buses:
     0000:[00-0f]
+      0000:01:01.1
+        0000:01:01.1 test0 (network interface) @ 2.50 GB/s
+        0000:01:01.1 test0-peer (OFI domain) @ 1.20 GB/s
 Virtual Devices
   virt0 (network interface)
   virt1 (network interface)
     backed by: 0000:01:01.1 test0 (network interface) @ 2.50 GB/s
+`,
+		},
+		"multiple NUMA nodes": {
+			topo: &Topology{
+				NUMANodes: map[uint]*NUMANode{
+					2: MockNUMANode(2, 8, 8).
+						WithPCIBuses(
+							[]*PCIBus{
+								{
+									LowAddress:  *MustNewPCIAddress("0000:00:00.0"),
+									HighAddress: *MustNewPCIAddress("0000:0f:00.0"),
+								},
+							},
+						).
+						WithDevices(
+							[]*PCIDevice{
+								{
+									Name:      "test2-net",
+									Type:      DeviceTypeNetInterface,
+									PCIAddr:   *MustNewPCIAddress("0000:01:01.1"),
+									LinkSpeed: 2.5,
+								},
+								{
+									Name:    "test2-block",
+									Type:    DeviceTypeBlock,
+									PCIAddr: *MustNewPCIAddress("0000:00:1f.2"),
+								},
+							},
+						),
+					0: MockNUMANode(0, 8).
+						WithPCIBuses(
+							[]*PCIBus{
+								{
+									LowAddress:  *MustNewPCIAddress("0000:80:00.0"),
+									HighAddress: *MustNewPCIAddress("0000:88:00.0"),
+								},
+							},
+						).
+						WithDevices(
+							[]*PCIDevice{
+								{
+									Name:      "test0-net",
+									Type:      DeviceTypeNetInterface,
+									PCIAddr:   *MustNewPCIAddress("0000:80:01.1"),
+									LinkSpeed: 2.5,
+								},
+								{
+									Name:    "test0-block",
+									Type:    DeviceTypeBlock,
+									PCIAddr: *MustNewPCIAddress("0000:83:00.0"),
+								},
+							},
+						),
+				},
+			},
+			expOut: `
+NUMA Node 0
+  CPU cores: 0-7
+  PCI buses:
+    0000:[80-88]
+      0000:80:01.1
+        0000:80:01.1 test0-net (network interface) @ 2.50 GB/s
+      0000:83:00.0
+        0000:83:00.0 test0-block (block device)
+NUMA Node 2
+  CPU cores: 8-15
+  PCI buses:
+    0000:[00-0f]
+      0000:00:1f.2
+        0000:00:1f.2 test2-block (block device)
+      0000:01:01.1
+        0000:01:01.1 test2-net (network interface) @ 2.50 GB/s
 `,
 		},
 	} {

--- a/src/control/lib/hardware/topology.go
+++ b/src/control/lib/hardware/topology.go
@@ -44,6 +44,21 @@ type (
 	}
 )
 
+// AsSlice returns the node map as a sorted slice of NUMANodes.
+func (nm NodeMap) AsSlice() []*NUMANode {
+	nodes := make([]*NUMANode, 0, len(nm))
+
+	for _, node := range nm {
+		nodes = append(nodes, node)
+	}
+
+	sort.Slice(nodes, func(i, j int) bool {
+		return nodes[i].ID < nodes[j].ID
+	})
+
+	return nodes
+}
+
 // DeviceName is the name of the virtual device.
 func (d *VirtualDevice) DeviceName() string {
 	if d == nil {
@@ -344,7 +359,7 @@ func (n *NUMANode) AddDevice(dev *PCIDevice) error {
 	n.PCIDevices.Add(dev)
 
 	for _, bus := range n.PCIBuses {
-		if bus.Contains(dev.PCIAddr) {
+		if bus.Contains(&dev.PCIAddr) {
 			return bus.AddDevice(dev)
 		}
 	}
@@ -374,6 +389,8 @@ const (
 	DeviceTypeNetInterface
 	// DeviceTypeOFIDomain indicates an OpenFabrics domain device.
 	DeviceTypeOFIDomain
+	// DeviceTypeBlock indicates a block device.
+	DeviceTypeBlock
 )
 
 func (t DeviceType) String() string {
@@ -382,6 +399,8 @@ func (t DeviceType) String() string {
 		return "network interface"
 	case DeviceTypeOFIDomain:
 		return "OFI domain"
+	case DeviceTypeBlock:
+		return "block device"
 	}
 
 	return "unknown device type"


### PR DESCRIPTION
Allow dump-topology subcommands to include block devices and
their NUMA affinities in the scan output. Also tweaks the pretty-printer
output to group PCI devices by bus.

Features: control

Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com>