### PR TITLE
DAOS-9583 chk: daos check module infrastructure

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -227,6 +227,7 @@ pipeline {
                                    password: GITHUB_USER_PSW,
                                    ignored_files: "src/control/vendor/*:" +
                                                   "*.pb-c.[ch]:" +
+                                                  "src/chk/chk_internal.h:" +
                                                   "src/client/java/daos-java/src/main/java/io/daos/dfs/uns/*:" +
                                                   "src/client/java/daos-java/src/main/java/io/daos/obj/attr/*:" +
                                                   "src/client/java/daos-java/src/main/native/include/daos_jni_common.h:" +

--- a/src/chk/SConscript
+++ b/src/chk/SConscript
@@ -1,3 +1,4 @@
+# pylint: disable=consider-using-f-string
 """Build chk library"""
 import daos_build
 
@@ -19,8 +20,9 @@ def scons():
 
     # chk
     chk = daos_build.library(denv, 'chk',
-                             [chk_pb, 'chk_srv.c', 'chk_common.c'],
-                             install_off="../..")
+                             [chk_pb, 'chk_srv.c', 'chk_common.c', 'chk_vos.c',
+                              'chk_rpc.c', 'chk_upcall.c', 'chk_iv.c', 'chk_leader.c',
+                              'chk_engine.c'], install_off="../..")
     denv.Install('$PREFIX/lib64/daos_srv', chk)
 
 if __name__ == "SCons.Script":

--- a/src/chk/chk_common.c
+++ b/src/chk/chk_common.c
@@ -6,51 +6,697 @@
 
 #define D_LOGFAC	DD_FAC(chk)
 
+#include <time.h>
+#include <abt.h>
+#include <cart/api.h>
+#include <daos/rpc.h>
+#include <daos/btree.h>
+#include <daos/btree_class.h>
+#include <daos_srv/daos_engine.h>
 #include <daos_srv/daos_chk.h>
+#include <daos_srv/pool.h>
+#include <daos_srv/vos.h>
+#include <daos_srv/iv.h>
 
 #include "chk.pb-c.h"
 #include "chk_internal.h"
 
-int
-chk_start(d_rank_list_t *ranks, struct chk_policy *policies, uuid_t *pools,
-	  int pool_cnt, uint32_t flags)
+struct chk_pool_bundle {
+	d_list_t		*cpb_head;
+	uint32_t		*cpb_shard_nr;
+	uuid_t			 cpb_uuid;
+	d_rank_t		 cpb_rank;
+	uint32_t		 cpb_phase;
+	struct chk_instance	*cpb_ins;
+	/* Pointer to the pool bookmark. */
+	struct chk_bookmark	*cpb_bk;
+	void			*cpb_data;
+};
+
+static int
+chk_pool_hkey_size(void)
 {
+	return sizeof(uuid_t);
+}
+
+static void
+chk_pool_hkey_gen(struct btr_instance *tins, d_iov_t *key_iov, void *hkey)
+{
+	D_ASSERT(key_iov->iov_len == sizeof(uuid_t));
+
+	memcpy(hkey, key_iov->iov_buf, key_iov->iov_len);
+}
+
+static int
+chk_pool_alloc(struct btr_instance *tins, d_iov_t *key_iov, d_iov_t *val_iov,
+	       struct btr_record *rec, d_iov_t *val_out)
+{
+	struct chk_pool_bundle	*cpb = val_iov->iov_buf;
+	struct chk_pool_rec	*cpr = NULL;
+	struct chk_pool_shard	*cps = NULL;
+	int			 rc = 0;
+
+	D_ASSERT(cpb != NULL);
+
+	D_ALLOC_PTR(cpr);
+	if (cpr == NULL)
+		D_GOTO(out, rc = -DER_NOMEM);
+
+	if (cpb->cpb_data != NULL) {
+		D_ALLOC_PTR(cps);
+		if (cps == NULL) {
+			D_FREE(cpr);
+			D_GOTO(out, rc = -DER_NOMEM);
+		}
+	}
+
+	D_INIT_LIST_HEAD(&cpr->cpr_shard_list);
+	cpr->cpr_shard_nr = 0;
+	cpr->cpr_svc_started = 0;
+	cpr->cpr_phase = cpb->cpb_phase;
+	uuid_copy(cpr->cpr_uuid, cpb->cpb_uuid);
+	cpr->cpr_thread = ABT_THREAD_NULL;
+	if (cpb->cpb_bk != NULL)
+		memcpy(&cpr->cpr_bk, cpb->cpb_bk, sizeof(cpr->cpr_bk));
+	cpr->cpr_ins = cpb->cpb_ins;
+
+	rec->rec_off = umem_ptr2off(&tins->ti_umm, cpr);
+	d_list_add_tail(&cpr->cpr_link, cpb->cpb_head);
+
+	if (cps != NULL) {
+		cps->cps_rank = cpb->cpb_rank;
+		cps->cps_data = cpb->cpb_data;
+
+		d_list_add_tail(&cps->cps_link, &cpr->cpr_shard_list);
+		cpr->cpr_shard_nr++;
+		if (cpb->cpb_shard_nr != NULL)
+			(*cpb->cpb_shard_nr)++;
+	}
+
+out:
+	return rc;
+}
+
+static int
+chk_pool_free(struct btr_instance *tins, struct btr_record *rec, void *args)
+{
+	struct chk_pool_rec	*cpr = umem_off2ptr(&tins->ti_umm, rec->rec_off);
+	struct chk_pool_shard	*cps;
+
+	rec->rec_off = UMOFF_NULL;
+
+	if (cpr->cpr_thread != ABT_THREAD_NULL) {
+		ABT_thread_join(cpr->cpr_thread);
+		ABT_thread_free(&cpr->cpr_thread);
+	}
+
+	if (cpr->cpr_svc_started) {
+
+		/* TBD: stop the pool shard and PS if applicable. */
+
+	}
+
+	while ((cps = d_list_pop_entry(&cpr->cpr_shard_list, struct chk_pool_shard,
+				       cps_link)) != NULL)
+		D_FREE(cps);
+
+	d_list_del(&cpr->cpr_link);
+	D_FREE(cpr);
+
 	return 0;
 }
 
-int
-chk_stop(uuid_t *pools, int pool_cnt)
+static int
+chk_pool_fetch(struct btr_instance *tins, struct btr_record *rec,
+	       d_iov_t *key_iov, d_iov_t *val_iov)
 {
+	struct chk_pool_rec	*cpr;
+
+	D_ASSERT(val_iov != NULL);
+
+	cpr = umem_off2ptr(&tins->ti_umm, rec->rec_off);
+	d_iov_set(val_iov, cpr, sizeof(*cpr));
+
 	return 0;
 }
 
-int
-chk_query(uuid_t *pools, int pool_cnt, chk_query_cb_t query_cb,
-	  struct chk_query_target *cqt, void *buf)
+static int
+chk_pool_update(struct btr_instance *tins, struct btr_record *rec,
+		d_iov_t *key, d_iov_t *val, d_iov_t *val_out)
 {
+	struct chk_pool_bundle	*cpb = val->iov_buf;
+	struct chk_pool_rec	*cpr = umem_off2ptr(&tins->ti_umm, rec->rec_off);
+	struct chk_pool_shard	*cps;
+	int			 rc = 0;
+
+	D_ASSERT(cpb != NULL);
+
+	D_ALLOC_PTR(cps);
+	if (cps == NULL)
+		D_GOTO(out, rc = -DER_NOMEM);
+
+	cps->cps_rank = cpb->cpb_rank;
+	cps->cps_data = cpb->cpb_data;
+
+	if (cpb->cpb_phase < cpr->cpr_phase)
+		cpr->cpr_phase = cpb->cpb_phase;
+
+	d_list_add_tail(&cps->cps_link, &cpr->cpr_shard_list);
+	cpr->cpr_shard_nr++;
+	if (cpb->cpb_shard_nr != NULL)
+		(*cpb->cpb_shard_nr)++;
+
+out:
+	return rc;
+}
+
+btr_ops_t chk_pool_ops = {
+	.to_hkey_size	= chk_pool_hkey_size,
+	.to_hkey_gen	= chk_pool_hkey_gen,
+	.to_rec_alloc	= chk_pool_alloc,
+	.to_rec_free	= chk_pool_free,
+	.to_rec_fetch	= chk_pool_fetch,
+	.to_rec_update  = chk_pool_update,
+};
+
+struct chk_pending_bundle {
+	d_list_t		*cpb_ins_head;
+	d_list_t		*cpb_rank_head;
+	d_rank_t		 cpb_rank;
+	uint32_t		 cpb_class;
+	uint64_t		 cpb_seq;
+};
+
+static int
+chk_pending_hkey_size(void)
+{
+	return sizeof(uint64_t);
+}
+
+static void
+chk_pending_hkey_gen(struct btr_instance *tins, d_iov_t *key_iov, void *hkey)
+{
+	D_ASSERT(key_iov->iov_len == sizeof(uint64_t));
+
+	memcpy(hkey, key_iov->iov_buf, key_iov->iov_len);
+}
+
+static int
+chk_pending_alloc(struct btr_instance *tins, d_iov_t *key_iov, d_iov_t *val_iov,
+		  struct btr_record *rec, d_iov_t *val_out)
+{
+	struct chk_pending_bundle	*cpb = val_iov->iov_buf;
+	struct chk_pending_rec		*cpr = NULL;
+	int				 rc = 0;
+
+	D_ASSERT(cpb != NULL);
+
+	D_ALLOC_PTR(cpr);
+	if (cpr == NULL)
+		D_GOTO(out, rc = -DER_NOMEM);
+
+	/* It means that the caller wants to wait for the interaction from admin. */
+	if (val_out != NULL) {
+		rc = ABT_mutex_create(&cpr->cpr_mutex);
+		if (rc != 0)
+			D_GOTO(out, rc = dss_abterr2der(rc));
+
+		rc = ABT_cond_create(&cpr->cpr_cond);
+		if (rc != 0)
+			D_GOTO(out, rc = dss_abterr2der(rc));
+
+		d_iov_set(val_iov, cpr, sizeof(*cpr));
+	}
+
+	cpr->cpr_seq = cpb->cpb_seq;
+	cpr->cpr_rank = cpb->cpb_rank;
+	cpr->cpr_class = cpb->cpb_class;
+	cpr->cpr_action = CHK__CHECK_INCONSIST_ACTION__CIA_INTERACT;
+
+	if (cpb->cpb_rank_head != NULL)
+		d_list_add_tail(&cpr->cpr_rank_link, cpb->cpb_rank_head);
+	else
+		D_INIT_LIST_HEAD(&cpr->cpr_rank_link);
+
+	rec->rec_off = umem_ptr2off(&tins->ti_umm, cpr);
+	d_list_add_tail(&cpr->cpr_ins_link, cpb->cpb_ins_head);
+
+out:
+	return rc;
+}
+
+static int
+chk_pending_free(struct btr_instance *tins, struct btr_record *rec, void *args)
+{
+	struct chk_pending_rec	*cpr = umem_off2ptr(&tins->ti_umm, rec->rec_off);
+	d_iov_t			*val_iov = args;
+
+	rec->rec_off = UMOFF_NULL;
+	d_list_del_init(&cpr->cpr_ins_link);
+	d_list_del_init(&cpr->cpr_rank_link);
+
+	if (args != NULL)
+		d_iov_set(val_iov, cpr, sizeof(*cpr));
+	else
+		chk_pending_destroy(cpr);
+
 	return 0;
 }
 
-int
-chk_prop(uint32_t *flags, chk_prop_cb_t prop_cb, struct chk_policy *policy, void *buf)
+static int
+chk_pending_fetch(struct btr_instance *tins, struct btr_record *rec,
+		  d_iov_t *key_iov, d_iov_t *val_iov)
 {
+	struct chk_pending_rec	*cpr;
+
+	D_ASSERT(val_iov != NULL);
+
+	cpr = umem_off2ptr(&tins->ti_umm, rec->rec_off);
+	d_iov_set(val_iov, cpr, sizeof(*cpr));
+
 	return 0;
 }
 
-int
-chk_act(uint64_t seq, uint32_t act, bool for_all)
+static int
+chk_pending_update(struct btr_instance *tins, struct btr_record *rec,
+		   d_iov_t *key, d_iov_t *val, d_iov_t *val_out)
 {
+	D_ASSERTF(0, "It should not be here\n");
+
 	return 0;
 }
 
-int
-chk_rejoin(void)
+btr_ops_t chk_pending_ops = {
+	.to_hkey_size	= chk_pending_hkey_size,
+	.to_hkey_gen	= chk_pending_hkey_gen,
+	.to_rec_alloc	= chk_pending_alloc,
+	.to_rec_free	= chk_pending_free,
+	.to_rec_fetch	= chk_pending_fetch,
+	.to_rec_update  = chk_pending_update,
+};
+
+void
+chk_ranks_dump(uint32_t rank_nr, d_rank_t *ranks)
 {
-	return 0;
+	char	 buf[128];
+	char	*ptr = buf;
+	int	 rc;
+	int	 i;
+
+	if (unlikely(rank_nr == 0))
+		return;
+
+	D_INFO("Ranks List:\n");
+
+	while (rank_nr >= 8) {
+		snprintf(ptr, 127, "%10u %10u %10u %10u %10u %10u %10u %10u",
+			 ranks[0], ranks[1], ranks[2], ranks[3],
+			 ranks[4], ranks[5], ranks[6], ranks[7]);
+		D_INFO("%s\n", ptr);
+		rank_nr -= 8;
+		ranks += 8;
+	}
+
+	if (rank_nr > 0) {
+		rc = snprintf(ptr, 127, "%10u", ranks[0]);
+		D_ASSERT(rc > 0);
+		ptr += rc;
+	}
+
+	for (i = 1; i < rank_nr; i++) {
+		rc = snprintf(ptr, 127, " %10u", ranks[i]);
+		D_ASSERT(rc > 0);
+		ptr += rc;
+	}
+
+	D_INFO("%s\n", buf);
+}
+
+void
+chk_pools_dump(uint32_t pool_nr, uuid_t pools[])
+{
+	char	 buf[256];
+	char	*ptr = buf;
+	int	 rc;
+	int	 i;
+
+	D_INFO("Pools List:\n");
+
+	while (pool_nr > 8) {
+		snprintf(buf, 255, "%s %s %s %s %s %s %s %s",
+			 pools[0], pools[1], pools[2], pools[3],
+			 pools[4], pools[5], pools[6], pools[7]);
+		D_INFO("%s\n", buf);
+		pool_nr -= 8;
+		pools += 8;
+	}
+
+	if (pool_nr > 0) {
+		rc = snprintf(ptr, 255, "%s", pools[0]);
+		D_ASSERT(rc > 0);
+		ptr += rc;
+	}
+
+	for (i = 1; i < pool_nr; i++) {
+		rc = snprintf(ptr, 255, " %s", pools[i]);
+		D_ASSERT(rc > 0);
+		ptr += rc;
+	}
+
+	D_INFO("%s\n", buf);
+}
+
+void
+chk_stop_sched(struct chk_instance *ins)
+{
+	if (ins->ci_sched != ABT_THREAD_NULL) {
+		ABT_mutex_lock(ins->ci_abt_mutex);
+		ins->ci_sched_running = 0;
+		ABT_cond_broadcast(ins->ci_abt_cond);
+		ABT_mutex_unlock(ins->ci_abt_mutex);
+
+		ABT_thread_join(ins->ci_sched);
+		ABT_thread_free(&ins->ci_sched);
+	}
 }
 
 int
-chk_pause(void)
+chk_prop_prepare(uint32_t rank_nr, d_rank_t *ranks, uint32_t policy_nr,
+		 struct chk_policy **policies, uint32_t pool_nr, uuid_t pools[],
+		 uint32_t flags, int phase, d_rank_t leader,
+		 struct chk_property *prop, d_rank_list_t **rlist)
 {
-	return 0;
+	d_rank_list_t	*result = NULL;
+	uint32_t	 saved = prop->cp_rank_nr;
+	int		 rc = 0;
+	int		 i;
+
+	D_ASSERT(rlist != NULL);
+
+	if (rank_nr != 0) {
+		result = uint32_array_to_rank_list(ranks, rank_nr);
+		if (result == NULL)
+			D_GOTO(out, rc = -DER_NOMEM);
+
+		prop->cp_rank_nr = rank_nr;
+	} else if (*rlist == NULL) {
+		D_ERROR("Rank list cannot be NULL for check start\n");
+		D_GOTO(out, rc = -DER_INVAL);
+	}
+
+	prop->cp_leader = leader;
+	prop->cp_flags = flags;
+	prop->cp_phase = phase;
+
+	/* Reuse former policies if "policy_nr == 0". */
+	if (policy_nr > 0) {
+		memset(prop->cp_policies, 0, sizeof(Chk__CheckInconsistAction) * CHK_POLICY_MAX);
+		for (i = 0; i < policy_nr; i++) {
+			if (unlikely(policies[i]->cp_class >= CHK_POLICY_MAX)) {
+				D_ERROR("Invalid DAOS inconsistency class %u\n",
+					policies[i]->cp_class);
+				D_GOTO(out, rc = -DER_INVAL);
+			}
+
+			prop->cp_policies[policies[i]->cp_class] = policies[i]->cp_action;
+		}
+	}
+
+	/* Reuse former pools if "pool_nr == 0". */
+	if (pool_nr >= CHK_POOLS_MAX || pool_nr < 0) {
+		prop->cp_pool_nr = -1;
+	} else if (pool_nr > 0) {
+		for (i = 0; i < pool_nr; i++)
+			uuid_copy(prop->cp_pools[i], pools[i]);
+		prop->cp_pool_nr = pool_nr;
+	}
+
+	if (prop->cp_pool_nr == 0)
+		prop->cp_pool_nr = -1;
+
+	rc = chk_prop_update(prop, result);
+	if (rc == 0) {
+		if (result != NULL)
+			*rlist = result;
+	} else {
+		/* XXX: keep the prop->cp_rank_nr to always match the rank list. */
+		prop->cp_rank_nr = saved;
+		d_rank_list_free(result);
+	}
+
+out:
+	return rc;
+}
+
+int
+chk_pool_add_shard(daos_handle_t hdl, d_list_t *head, uuid_t uuid, d_rank_t rank,
+		   uint32_t phase, struct chk_bookmark *bk, struct chk_instance *ins,
+		   uint32_t *shard_nr, void *data)
+{
+	struct chk_pool_bundle	rbund;
+	d_iov_t			kiov;
+	d_iov_t			riov;
+	int			rc;
+
+	rbund.cpb_head = head;
+	rbund.cpb_shard_nr = shard_nr;
+	uuid_copy(rbund.cpb_uuid, uuid);
+	rbund.cpb_rank = rank;
+	rbund.cpb_phase = phase;
+	rbund.cpb_bk = bk;
+	rbund.cpb_ins = ins;
+	rbund.cpb_data = data;
+
+	d_iov_set(&riov, &rbund, sizeof(rbund));
+	d_iov_set(&kiov, uuid, sizeof(uuid_t));
+	rc = dbtree_upsert(hdl, BTR_PROBE_EQ, DAOS_INTENT_UPDATE, &kiov, &riov, NULL);
+
+	D_CDEBUG(rc != 0, DLOG_ERR, DLOG_DBG, "Add pool shard "DF_UUID" for rank %u: "DF_RC"\n",
+		 DP_UUID(uuid), rank, DP_RC(rc));
+
+	return rc;
+}
+
+int
+chk_pool_del_shard(daos_handle_t hdl, uuid_t uuid, d_rank_t rank)
+{
+	struct chk_pool_rec	*cpr;
+	struct chk_pool_shard	*cps;
+	d_iov_t			 kiov;
+	d_iov_t			 riov;
+	int			 rc;
+
+	d_iov_set(&riov, NULL, 0);
+	d_iov_set(&kiov, uuid, sizeof(uuid_t));
+	rc = dbtree_lookup(hdl, &kiov, &riov);
+	if (rc != 0)
+		goto out;
+
+	cpr = (struct chk_pool_rec *)riov.iov_buf;
+	d_list_for_each_entry(cps, &cpr->cpr_shard_list, cps_link) {
+		if (cps->cps_rank == rank) {
+			d_list_del(&cps->cps_link);
+			D_FREE(cps);
+			cpr->cpr_shard_nr--;
+			if (d_list_empty(&cpr->cpr_shard_list)) {
+				D_ASSERTF(cpr->cpr_shard_nr == 0,
+					  "Invalid shard count %u for pool "DF_UUID"\n",
+					  cpr->cpr_shard_nr, DP_UUID(uuid));
+				rc = dbtree_delete(hdl, BTR_PROBE_EQ, &kiov, NULL);
+			}
+
+			goto out;
+		}
+	}
+
+	rc = -DER_ENOENT;
+
+out:
+	D_CDEBUG(rc != 0, DLOG_ERR, DLOG_DBG, "Del pool shard "DF_UUID" for rank %u: "DF_RC"\n",
+		 DP_UUID(uuid), rank, DP_RC(rc));
+
+	return rc;
+}
+
+int
+chk_pending_add(struct chk_instance *ins, d_list_t *rank_head, uint64_t seq,
+		uint32_t rank, uint32_t cla, struct chk_pending_rec **cpr)
+{
+	struct chk_pending_bundle	rbund;
+	d_iov_t				kiov;
+	d_iov_t				riov;
+	d_iov_t				viov;
+	int				rc;
+
+	rbund.cpb_ins_head = &ins->ci_pending_list;
+	rbund.cpb_rank_head = rank_head;
+	rbund.cpb_seq = seq;
+	rbund.cpb_rank = rank;
+	rbund.cpb_class = cla;
+
+	d_iov_set(&viov, NULL, 0);
+	d_iov_set(&riov, &rbund, sizeof(rbund));
+	d_iov_set(&kiov, &seq, sizeof(seq));
+
+	/* The access may from multiple XS, so taking the lock firstly. */
+	ABT_rwlock_wrlock(ins->ci_abt_lock);
+	rc = dbtree_upsert(ins->ci_pending_hdl, BTR_PROBE_EQ, DAOS_INTENT_UPDATE,
+			   &kiov, &riov, &viov);
+	if (rc == 0 && cpr != NULL) {
+		*cpr = (struct chk_pending_rec *)viov.iov_buf;
+		(*cpr)->cpr_busy = 1;
+	}
+	ABT_rwlock_unlock(ins->ci_abt_lock);
+
+	D_CDEBUG(rc != 0, DLOG_ERR, DLOG_DBG, "Add pending record with gen "DF_X64", seq "
+		 DF_X64", rank %u, class %u: "DF_RC"\n",
+		 ins->ci_bk.cb_gen, seq, rank, cla, DP_RC(rc));
+
+	return rc;
+}
+
+int
+chk_pending_del(struct chk_instance *ins, uint64_t seq, struct chk_pending_rec **cpr)
+{
+	d_iov_t		kiov;
+	d_iov_t		riov;
+	int		rc;
+
+	d_iov_set(&riov, NULL, 0);
+	d_iov_set(&kiov, &seq, sizeof(seq));
+
+	ABT_rwlock_wrlock(ins->ci_abt_lock);
+	rc = dbtree_delete(ins->ci_pending_hdl, BTR_PROBE_EQ, &kiov, &riov);
+	ABT_rwlock_unlock(ins->ci_abt_lock);
+
+	if (rc == 0)
+		*cpr = (struct chk_pending_rec *)riov.iov_buf;
+	else
+		*cpr = NULL;
+
+	D_CDEBUG(rc != 0, DLOG_ERR, DLOG_DBG, "Del pending record with gen "DF_X64", seq "
+		 DF_X64": "DF_RC"\n", ins->ci_bk.cb_gen, seq, DP_RC(rc));
+
+	return rc;
+}
+
+void
+chk_pending_destroy(struct chk_pending_rec *cpr)
+{
+	D_ASSERT(d_list_empty(&cpr->cpr_ins_link));
+	D_ASSERT(d_list_empty(&cpr->cpr_rank_link));
+
+	if (cpr->cpr_cond != ABT_COND_NULL)
+		ABT_cond_free(&cpr->cpr_cond);
+
+	if (cpr->cpr_mutex != ABT_MUTEX_NULL)
+		ABT_mutex_free(&cpr->cpr_mutex);
+
+	D_FREE(cpr);
+}
+
+int
+chk_ins_init(struct chk_instance *ins)
+{
+	struct umem_attr	uma = { 0 };
+	int			rc;
+
+	D_ASSERT(ins != NULL);
+
+	D_INIT_LIST_HEAD(&ins->ci_pending_list);
+	ins->ci_sched = ABT_THREAD_NULL;
+	ins->ci_seq = crt_hlc_get();
+
+	if (ins->ci_is_leader)
+		D_INIT_LIST_HEAD(&ins->ci_rank_list);
+	else
+		D_INIT_LIST_HEAD(&ins->ci_pool_list);
+
+	rc = ABT_rwlock_create(&ins->ci_abt_lock);
+		D_GOTO(out_init, rc = dss_abterr2der(rc));
+
+	rc = ABT_mutex_create(&ins->ci_abt_mutex);
+	if (rc != ABT_SUCCESS)
+		D_GOTO(out_lock, rc = dss_abterr2der(rc));
+
+	rc = ABT_cond_create(&ins->ci_abt_cond);
+	if (rc != ABT_SUCCESS)
+		D_GOTO(out_mutex, rc = dss_abterr2der(rc));
+
+	uma.uma_id = UMEM_CLASS_VMEM;
+
+	rc = dbtree_create_inplace(DBTREE_CLASS_CHK_PA, 0, CHK_BTREE_ORDER, &uma,
+				   &ins->ci_pending_btr, &ins->ci_pending_hdl);
+	if (rc != 0)
+		goto out_cond;
+
+	if (ins->ci_is_leader)
+		rc = dbtree_create_inplace(DBTREE_CLASS_CHK_RANK, 0, CHK_BTREE_ORDER, &uma,
+					   &ins->ci_rank_btr, &ins->ci_rank_hdl);
+	else
+		rc = dbtree_create_inplace(DBTREE_CLASS_CHK_POOL, 0, CHK_BTREE_ORDER, &uma,
+					   &ins->ci_pool_btr, &ins->ci_pool_hdl);
+	if (rc != 0)
+		goto out_pending;
+
+	D_GOTO(out_init, rc = 0);
+
+out_pending:
+	dbtree_destroy(ins->ci_pending_hdl, NULL);
+	ins->ci_pending_hdl = DAOS_HDL_INVAL;
+out_cond:
+	ABT_cond_free(&ins->ci_abt_cond);
+	ins->ci_abt_cond = ABT_COND_NULL;
+out_mutex:
+	ABT_mutex_free(&ins->ci_abt_mutex);
+	ins->ci_abt_mutex = ABT_MUTEX_NULL;
+out_lock:
+	ABT_rwlock_free(&ins->ci_abt_lock);
+	ins->ci_abt_lock = ABT_RWLOCK_NULL;
+out_init:
+	return rc;
+}
+
+void
+chk_ins_fini(struct chk_instance *ins)
+{
+	if (ins == NULL)
+		return;
+
+	if (ins->ci_iv_ns != NULL)
+		ds_iv_ns_put(ins->ci_iv_ns);
+
+	if (ins->ci_iv_group != NULL)
+		crt_group_secondary_destroy(ins->ci_iv_group);
+
+	d_rank_list_free(ins->ci_ranks);
+
+	if (ins->ci_is_leader) {
+		if (daos_handle_is_valid(ins->ci_rank_hdl))
+			dbtree_destroy(ins->ci_rank_hdl, NULL);
+
+		D_ASSERT(d_list_empty(&ins->ci_rank_list));
+	} else {
+		if (daos_handle_is_valid(ins->ci_pool_hdl))
+			dbtree_destroy(ins->ci_pool_hdl, NULL);
+
+		D_ASSERT(d_list_empty(&ins->ci_pool_list));
+	}
+
+	if (daos_handle_is_valid(ins->ci_pending_hdl))
+		dbtree_destroy(ins->ci_pending_hdl, NULL);
+
+	D_ASSERT(d_list_empty(&ins->ci_pending_list));
+	D_ASSERT(ins->ci_sched == ABT_THREAD_NULL);
+
+	if (ins->ci_abt_cond != ABT_COND_NULL)
+		ABT_cond_free(&ins->ci_abt_cond);
+
+	if (ins->ci_abt_mutex != ABT_MUTEX_NULL)
+		ABT_mutex_free(&ins->ci_abt_mutex);
+
+	if (ins->ci_abt_lock != ABT_RWLOCK_NULL)
+		ABT_rwlock_free(&ins->ci_abt_lock);
+
+	D_FREE(ins);
 }

--- a/src/chk/chk_engine.c
+++ b/src/chk/chk_engine.c
@@ -1,0 +1,1474 @@
+/**
+ * (C) Copyright 2022 Intel Corporation.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause-Patent
+ */
+
+#define D_LOGFAC	DD_FAC(chk)
+
+#include <time.h>
+#include <abt.h>
+#include <cart/api.h>
+#include <daos/btree.h>
+#include <daos/btree_class.h>
+#include <daos/common.h>
+#include <daos_srv/daos_engine.h>
+#include <daos_srv/daos_mgmt_srv.h>
+#include <daos_srv/daos_chk.h>
+#include <daos_srv/pool.h>
+#include <daos_srv/vos.h>
+#include <daos_srv/iv.h>
+#include <daos_srv/vos_types.h>
+
+#include "chk.pb-c.h"
+#include "chk_internal.h"
+
+static struct chk_instance	*chk_engine;
+
+struct chk_traverse_pools_args {
+	uint64_t			 ctpa_gen;
+	struct chk_instance		*ctpa_ins;
+	uint32_t			 ctpa_status;
+};
+
+struct chk_engine_clues_args {
+	uint32_t			 ceca_pool_nr;
+	uuid_t				*ceca_pools;
+};
+
+struct chk_query_pool_args {
+	uint32_t			 cqpa_cap;
+	uint32_t			 cqpa_idx;
+	struct chk_query_pool_shard	*cqpa_shards;
+};
+
+struct chk_query_xstream_args {
+	uuid_t				 cqxa_uuid;
+	struct chk_query_pool_args	*cqxa_args;
+	struct chk_query_target		 cqxa_target;
+};
+
+static inline bool
+chk_engine_on_leader(d_rank_t leader)
+{
+	return dss_self_rank() == leader;
+}
+
+static void
+chk_engine_exit(struct chk_instance *ins, uint32_t ins_status, uint32_t pool_status)
+{
+	struct chk_bookmark	*cbk;
+	struct chk_pool_rec	*cpr;
+	struct chk_pool_rec	*tmp;
+	d_iov_t			 kiov;
+	uuid_t			 uuid;
+	struct chk_iv		 iv;
+	int			 rc;
+
+	d_list_for_each_entry_safe(cpr, tmp, &ins->ci_pool_list, cpr_link) {
+		cbk = &cpr->cpr_bk;
+		uuid_copy(uuid, cpr->cpr_uuid);
+
+		if (cbk->cb_pool_status == CHK__CHECK_POOL_STATUS__CPS_CHECKING ||
+		    cbk->cb_pool_status == CHK__CHECK_POOL_STATUS__CPS_PENDING) {
+			cbk->cb_pool_status = pool_status;
+			cbk->cb_time.ct_stop_time = time(NULL);
+			chk_bk_update_pool(cbk, uuid);
+		}
+
+		d_iov_set(&kiov, uuid, sizeof(uuid_t));
+		rc = dbtree_delete(ins->ci_pool_hdl, BTR_PROBE_EQ, &kiov, NULL);
+		if (rc != 0)
+			D_ERROR("Check engine (gen "DF_X64") on rank %u failed to delete "
+				"pool record "DF_UUID" when exit: "DF_RC"\n",
+				cbk->cb_gen, dss_self_rank(), DP_UUID(uuid), DP_RC(rc));
+	}
+
+	cbk = &ins->ci_bk;
+
+	if (cbk->cb_ins_status == CHK__CHECK_INST_STATUS__CIS_RUNNING) {
+		cbk->cb_ins_status = ins_status;
+		cbk->cb_time.ct_stop_time = time(NULL);
+		chk_bk_update_engine(cbk);
+	}
+
+	if (ins_status != CHK__CHECK_INST_STATUS__CIS_PAUSED &&
+	    ins_status != CHK__CHECK_INST_STATUS__CIS_IMPLICATED && ins->ci_iv_ns != NULL) {
+		iv.ci_gen = cbk->cb_gen;
+		iv.ci_phase = cbk->cb_phase;
+		iv.ci_status = ins_status;
+		iv.ci_to_leader = 1;
+
+		/* Synchronously notify the leader that check instance exit on the engine. */
+		rc = chk_iv_update(ins->ci_iv_ns, &iv, CRT_IV_SHORTCUT_TO_ROOT,
+				   CRT_IV_SYNC_EAGER, true);
+		if (rc != 0)
+			D_ERROR("Check engine (gen "DF_X64") on rank %u failed to notify leader "
+				"for its exit, status %u: "DF_RC"\n",
+				cbk->cb_gen, dss_self_rank(), ins_status, DP_RC(rc));
+	}
+}
+
+static uint32_t
+chk_engine_find_slowest(struct chk_instance *ins)
+{
+	uint32_t		 phase = CHK__CHECK_SCAN_PHASE__DSP_DONE;
+	uint32_t		 base = ins->ci_bk.cb_phase;
+	struct chk_pool_rec	*cpr;
+
+	d_list_for_each_entry(cpr, &ins->ci_pool_list, cpr_link) {
+		if (cpr->cpr_phase <= base) {
+			phase = cpr->cpr_phase;
+			break;
+		}
+
+		if (cpr->cpr_phase < phase)
+			phase = cpr->cpr_phase;
+	}
+
+	return phase;
+}
+
+static void
+chk_engine_pool_ult(void *args)
+{
+	struct chk_pool_rec	*cpr = args;
+	/*
+	 *
+	 * TBD: start pool shard and PS if applicable.
+	 *
+	 * cpr->cpr_svc_started = 1;
+	 *
+	 * Drive the check since phase CHK__CHECK_SCAN_PHASE__CSP_POOL_MBS.
+	 */
+	while (cpr->cpr_ins->ci_sched_running) {
+		dss_sleep(300);
+	}
+}
+
+static void
+chk_engine_sched(void *args)
+{
+	struct chk_instance	*ins = args;
+	struct chk_bookmark	*cbk = &ins->ci_bk;
+	struct chk_pool_rec	*cpr;
+	struct chk_pool_rec	*tmp;
+	uint32_t		 phase;
+	uint32_t		 ins_status;
+	uint32_t		 pool_status;
+	d_rank_t		 myrank = dss_self_rank();
+	int			 rc = 0;
+
+	while (ins->ci_sched_running) {
+		switch (cbk->cb_phase) {
+		case CHK__CHECK_SCAN_PHASE__CSP_PREPARE:
+			/*
+			 * In this phase, the engine has already offer its known pools' svc list
+			 * to the leader via CHK_START RPC reply. Then let's move to next phase.
+			 */
+			cbk->cb_phase = CHK__CHECK_SCAN_PHASE__CSP_POOL_LIST;
+			/* XXX: How to estimate the lfet time? */
+			cbk->cb_time.ct_left_time = CHK__CHECK_SCAN_PHASE__DSP_DONE - cbk->cb_phase;
+			rc = chk_bk_update_engine(cbk);
+			if (rc != 0) {
+				D_ERROR("Check engine %u (gen "DF_X64") failed to change phase %u: "
+					DF_RC"\n", myrank, cbk->cb_gen, cbk->cb_phase, DP_RC(rc));
+				/*
+				 * Although above updating bookmark in persistent memory failed,
+				 * we still need to mark the in-DRAM check instance as 'failed'.
+				 * via chk_engine_exit(); otherwise, it may block next CHK_START.
+				 */
+				goto out;
+			}
+
+			break;
+		case CHK__CHECK_SCAN_PHASE__CSP_POOL_LIST:
+			/*
+			 * Wait for the leader to collect all pools svc information, then it will
+			 * notify all related engines to step into next phase after consolidating
+			 * the pools list.
+			 */
+			ABT_mutex_lock(ins->ci_abt_mutex);
+			if (!ins->ci_sched_running) {
+				ABT_mutex_unlock(ins->ci_abt_mutex);
+				goto out;
+			}
+
+			ABT_cond_wait(ins->ci_abt_cond, ins->ci_abt_mutex);
+			ABT_mutex_unlock(ins->ci_abt_mutex);
+
+			break;
+		case CHK__CHECK_SCAN_PHASE__CSP_POOL_MBS:
+			d_list_for_each_entry_safe(cpr, tmp, &ins->ci_pool_list, cpr_link) {
+				D_ASSERT(cpr->cpr_thread == ABT_THREAD_NULL);
+
+				rc = dss_ult_create(chk_engine_pool_ult, cpr, DSS_XS_SYS, 0,
+						    DSS_DEEP_STACK_SZ, &cpr->cpr_thread);
+				if (rc != 0) {
+					rc = dss_abterr2der(rc);
+					D_ERROR("Check engine %u (gen "DF_X64") failed when "
+						"create pool scan ULT: "DF_RC"\n",
+						myrank, cbk->cb_gen, DP_RC(rc));
+					goto out;
+				}
+			}
+
+			/* Fall through. */
+		case CHK__CHECK_SCAN_PHASE__CSP_POOL_CLEANUP:
+		case CHK__CHECK_SCAN_PHASE__CSP_CONT_LIST:
+		case CHK__CHECK_SCAN_PHASE__CSP_CONT_CLEANUP:
+			do {
+				dss_sleep(300);
+
+				/* Someone wants to stop the check. */
+				if (!ins->ci_sched_running)
+					D_GOTO(out, rc = 0);
+
+				phase = chk_engine_find_slowest(ins);
+				if (phase != cbk->cb_phase) {
+					cbk->cb_phase = phase;
+					/* XXX: How to estimate the lfet time? */
+					cbk->cb_time.ct_left_time =
+						CHK__CHECK_SCAN_PHASE__DSP_DONE - cbk->cb_phase;
+					rc = chk_bk_update_engine(cbk);
+					if (rc != 0) {
+						D_ERROR("Check engine %u (gen "DF_X64") failed "
+							"to change phase %u: "DF_RC"\n", myrank,
+							cbk->cb_gen, cbk->cb_phase, DP_RC(rc));
+						goto out;
+					}
+				}
+			} while (ins->ci_sched_running);
+
+			break;
+		case CHK__CHECK_SCAN_PHASE__CSP_DTX_RESYNC:
+		case CHK__CHECK_SCAN_PHASE__CSP_OBJ_SCRUB:
+		case CHK__CHECK_SCAN_PHASE__CSP_REBUILD:
+		case CHK__CHECK_SCAN_PHASE__OSP_AGGREGATION:
+			/* XXX: These phases will be implemented in the future. */
+			D_ASSERT(0);
+			break;
+		case CHK__CHECK_SCAN_PHASE__DSP_DONE:
+			D_GOTO(out, rc = 1);
+		default:
+			D_ASSERT(0);
+			goto out;
+		}
+	}
+
+out:
+	if (rc > 0) {
+		/* If failed to check some pool(s), then the engine will be marked as 'failed'. */
+		if (ins->ci_slowest_fail_phase != CHK__CHECK_SCAN_PHASE__CSP_PREPARE)
+			ins_status = CHK__CHECK_INST_STATUS__CIS_FAILED;
+		else
+			ins_status = CHK__CHECK_INST_STATUS__CIS_COMPLETED;
+		pool_status = CHK__CHECK_POOL_STATUS__CPS_CHECKED;
+	} else if (rc == 0) {
+		if (ins->ci_implicated) {
+			ins_status = CHK__CHECK_INST_STATUS__CIS_IMPLICATED;
+			pool_status = CHK__CHECK_POOL_STATUS__CPS_IMPLICATED;
+		} else if (ins->ci_stopping) {
+			ins_status = CHK__CHECK_INST_STATUS__CIS_STOPPED;
+			pool_status = CHK__CHECK_POOL_STATUS__CPS_STOPPED;
+		} else {
+			ins_status = CHK__CHECK_INST_STATUS__CIS_PAUSED;
+			pool_status = CHK__CHECK_POOL_STATUS__CPS_PAUSED;
+		}
+	} else {
+		ins_status = CHK__CHECK_INST_STATUS__CIS_FAILED;
+		pool_status = CHK__CHECK_POOL_STATUS__CPS_FAILED;
+	}
+
+	/* The pool scan ULTs will be terminated via chk_engine_exit(). */
+	chk_engine_exit(ins, ins_status, pool_status);
+
+	D_INFO("Check engine %u (gen "DF_X64") exit at the phase %u with "DF_RC"\n",
+	       myrank, cbk->cb_gen, cbk->cb_phase, DP_RC(rc));
+
+	/*
+	 * The engine scheduler may exit for its own reason (instead of by CHK_STOP),
+	 * then reset ci_sched_running to avoid blocking next CHK_START.
+	 */
+	ins->ci_sched_running = 0;
+}
+
+static int
+chk_engine_start_prepare(struct chk_instance *ins, uint32_t rank_nr, d_rank_t *ranks,
+			 uint32_t policy_nr, struct chk_policy **policies,
+			 uint32_t pool_nr, uuid_t pools[], uint64_t gen, int phase,
+			 uint32_t flags, d_rank_t leader, d_rank_list_t **rlist)
+{
+	struct chk_bookmark	*cbk = &ins->ci_bk;
+	struct chk_property	*prop = &ins->ci_prop;
+	bool			 reset = (flags & CHK__CHECK_FLAG__CF_RESET) ? true : false;
+	int			 rc = 0;
+	int			 i;
+	int			 j;
+
+	/*
+	 * XXX: Currently we cannot distinguish whether it is caused by resent start request
+	 *	or not. That can be resolved via introducing new RPC sequence in the future.
+	 */
+	if (ins->ci_sched_running)
+		D_GOTO(out, rc = -DER_ALREADY);
+
+	/* Corrupted bookmark or new created one. */
+	if (cbk->cb_magic != CHK_BK_MAGIC_ENGINE) {
+		if (!reset)
+			D_GOTO(out, rc = -DER_NOT_RESUME);
+
+		if (!chk_engine_on_leader(leader))
+			memset(prop, 0, sizeof(*prop));
+
+		memset(cbk, 0, sizeof(*cbk));
+		cbk->cb_magic = CHK_BK_MAGIC_ENGINE;
+		cbk->cb_version = DAOS_CHK_VERSION;
+		flags |= CHK__CHECK_FLAG__CF_RESET;
+		goto init;
+	}
+
+	if (cbk->cb_gen > gen)
+		D_GOTO(out, rc = -DER_EP_OLD);
+
+	/*
+	 * XXX: Leader wants to resume the check but with different generation, then this
+	 *	engine must be new joined one for current check instance. Under such case
+	 *	we have to restart the scan from scratch.
+	 */
+	if (cbk->cb_gen != gen && !reset)
+		D_GOTO(out, rc = -DER_NOT_RESUME);
+
+	if (cbk->cb_ins_status == CHK__CHECK_INST_STATUS__CIS_RUNNING)
+		D_GOTO(out, rc = -DER_ALREADY);
+
+	if (reset)
+		goto init;
+
+	if (cbk->cb_ins_status == CHK__CHECK_INST_STATUS__CIS_COMPLETED)
+		D_GOTO(out, rc = 1);
+
+	/* Drop dryrun flags needs to reset. */
+	if (prop->cp_flags & CHK__CHECK_FLAG__CF_DRYRUN && !(flags & CHK__CHECK_FLAG__CF_DRYRUN)) {
+		if (!reset)
+			D_GOTO(out, rc = -DER_NOT_RESUME);
+
+		goto init;
+	}
+
+	/*
+	 * XXX: If current rank list does not matches the former list, the we need to
+	 *	reset the check from scratch. Currently, we do not strictly check that.
+	 *	It is control plane's duty to generate valid rank list.
+	 */
+
+	/* Add new rank(s), need to reset. */
+	if (rank_nr > prop->cp_rank_nr) {
+		if (!reset)
+			D_GOTO(out, rc = -DER_NOT_RESUME);
+
+		goto init;
+	}
+
+	if (prop->cp_pool_nr < 0)
+		goto init;
+
+	/* Want to check new pool(s), need to reset. */
+	if (pool_nr < 0) {
+		if (!reset)
+			D_GOTO(out, rc = -DER_NOT_RESUME);
+
+		goto init;
+	}
+
+	for (i = 0; i < pool_nr; i++) {
+		for (j = 0; j < prop->cp_pool_nr; j++) {
+			if (uuid_compare(pools[i], prop->cp_pools[j]) == 0)
+				break;
+		}
+
+		/* Want to check new pool(s), need to reset. */
+		if (j == prop->cp_pool_nr) {
+			if (!reset)
+				D_GOTO(out, rc = -DER_NOT_RESUME);
+
+			goto init;
+		}
+	}
+
+init:
+	if (reset) {
+		cbk->cb_gen = gen;
+		cbk->cb_phase = CHK__CHECK_SCAN_PHASE__CSP_PREPARE;
+		memset(&cbk->cb_statistics, 0, sizeof(cbk->cb_statistics));
+	}
+
+	if (chk_engine_on_leader(prop->cp_leader)) {
+		/* The check leader has already verified the rank list. */
+		if (rank_nr != 0)
+			*rlist = uint32_array_to_rank_list(ranks, rank_nr);
+		else
+			rc = chk_prop_fetch(prop, rlist);
+	} else {
+		rc = chk_prop_prepare(rank_nr, ranks, policy_nr, policies, pool_nr,
+				      pools, flags, phase, leader, prop, rlist);
+	}
+
+out:
+	return rc;
+}
+
+/* Remove all old pool bookmarks. */
+static int
+chk_pools_cleanup_cb(struct sys_db *db, char *table, d_iov_t *key, void *args)
+{
+	struct chk_traverse_pools_args	*ctpa = args;
+	unsigned char			*uuid = key->iov_buf;
+	struct chk_bookmark		 cbk;
+	int				 rc = 0;
+
+	if (!d_is_uuid(uuid))
+		D_GOTO(out, rc = 0);
+
+	rc = chk_bk_fetch_pool(&cbk, uuid);
+	if (rc != 0)
+		goto out;
+
+	if (cbk.cb_gen >= ctpa->ctpa_gen)
+		D_GOTO(out, rc = 0);
+
+	rc = chk_bk_delete_pool(uuid);
+
+out:
+	return rc;
+}
+
+static int
+chk_pool_start_one(struct chk_instance *ins, uuid_t uuid, uint64_t gen)
+{
+	struct chk_bookmark	cbk;
+	int	rc;
+
+	rc = chk_bk_fetch_pool(&cbk, uuid);
+	if (rc != 0 && rc == -DER_NONEXIST)
+		goto out;
+
+	if (cbk.cb_magic != CHK_BK_MAGIC_POOL) {
+		cbk.cb_magic = CHK_BK_MAGIC_POOL;
+		cbk.cb_version = DAOS_CHK_VERSION;
+		cbk.cb_gen = gen;
+		cbk.cb_phase = CHK__CHECK_SCAN_PHASE__CSP_PREPARE;
+	} else if (cbk.cb_pool_status == CHK__CHECK_POOL_STATUS__CPS_FAILED) {
+		if (cbk.cb_phase < ins->ci_slowest_fail_phase)
+			ins->ci_slowest_fail_phase = cbk.cb_phase;
+	}
+
+	/* Always refresh the start time. */
+	cbk.cb_time.ct_start_time = time(NULL);
+	/* XXX: How to estimate the lfet time? */
+	cbk.cb_time.ct_left_time = CHK__CHECK_SCAN_PHASE__DSP_DONE - cbk.cb_phase;
+	cbk.cb_pool_status = CHK__CHECK_POOL_STATUS__CPS_CHECKING;
+	rc = chk_pool_add_shard(ins->ci_pool_hdl, &ins->ci_pool_list, uuid, dss_self_rank(),
+				cbk.cb_phase, &cbk, ins, NULL, NULL);
+	if (rc != 0)
+		goto out;
+
+	rc = chk_bk_update_pool(&cbk, uuid);
+	if (rc != 0)
+		chk_pool_del_shard(ins->ci_pool_hdl, uuid, dss_self_rank());
+
+out:
+	return rc;
+}
+
+static int
+chk_pools_add_from_dir(uuid_t uuid, void *args)
+{
+	struct chk_traverse_pools_args	*ctpa = args;
+	struct chk_instance		*ins = ctpa->ctpa_ins;
+
+	return chk_pool_start_one(ins, uuid, ctpa->ctpa_gen);
+}
+
+static int
+chk_pools_add_from_db(struct sys_db *db, char *table, d_iov_t *key, void *args)
+{
+	struct chk_traverse_pools_args	*ctpa = args;
+	struct chk_instance		*ins = ctpa->ctpa_ins;
+	unsigned char			*uuid = key->iov_buf;
+	struct chk_bookmark		 cbk;
+	int				 rc = 0;
+
+	if (!d_is_uuid(uuid))
+		D_GOTO(out, rc = 0);
+
+	rc = chk_bk_fetch_pool(&cbk, uuid);
+	if (rc != 0)
+		goto out;
+
+	if (cbk.cb_gen != ctpa->ctpa_gen)
+		D_GOTO(out, rc = 0);
+
+	if (cbk.cb_pool_status == CHK__CHECK_POOL_STATUS__CPS_FAILED) {
+		if (cbk.cb_phase < ins->ci_slowest_fail_phase)
+			ins->ci_slowest_fail_phase = cbk.cb_phase;
+	}
+
+	/* Always refresh the start time. */
+	cbk.cb_time.ct_start_time = time(NULL);
+	/* XXX: How to estimate the lfet time? */
+	cbk.cb_time.ct_left_time = CHK__CHECK_SCAN_PHASE__DSP_DONE - cbk.cb_phase;
+	cbk.cb_pool_status = CHK__CHECK_POOL_STATUS__CPS_CHECKING;
+	rc = chk_pool_add_shard(ins->ci_pool_hdl, &ins->ci_pool_list, uuid,
+				dss_self_rank(), ins->ci_bk.cb_phase, &cbk, ins, NULL, NULL);
+	if (rc != 0)
+		goto out;
+
+	rc = chk_bk_update_pool(&cbk, uuid);
+	if (rc != 0)
+		chk_pool_del_shard(ctpa->ctpa_ins->ci_pool_hdl, uuid, dss_self_rank());
+
+out:
+	return rc;
+}
+
+static int
+chk_engine_clues_filter(uuid_t uuid, void *arg)
+{
+	struct chk_engine_clues_args	*ceca = arg;
+	int				 i;
+
+	if (ceca->ceca_pool_nr == 0)
+		return 0;
+
+	for (i = 0; i < ceca->ceca_pool_nr; i++) {
+		if (uuid_compare(uuid, ceca->ceca_pools[i]) == 0)
+			return 0;
+	}
+
+	return 1;
+}
+
+int
+chk_engine_start(uint64_t gen, uint32_t rank_nr, d_rank_t *ranks,
+		 uint32_t policy_nr, struct chk_policy **policies, uint32_t pool_nr,
+		 uuid_t pools[], uint32_t flags, int32_t exp_phase, d_rank_t leader,
+		 uint32_t *cur_phase, struct ds_pool_clues *clues)
+{
+	struct chk_bookmark		*cbk = &chk_engine->ci_bk;
+	struct chk_property		*prop = &chk_engine->ci_prop;
+	d_rank_list_t			*rank_list = NULL;
+	struct chk_pool_rec		*cpr;
+	struct chk_pool_rec		*tmp;
+	struct chk_traverse_pools_args	 ctpa = { 0 };
+	struct chk_engine_clues_args	 ceca = { 0 };
+	d_rank_t			 myrank = dss_self_rank();
+	d_iov_t				 kiov;
+	int				 rc;
+	int				 i;
+
+	if (chk_engine->ci_starting)
+		D_GOTO(out_log, rc = -DER_INPROGRESS);
+
+	if (chk_engine->ci_stopping)
+		D_GOTO(out_log, rc = -DER_BUSY);
+
+	chk_engine->ci_starting = 1;
+
+	rc = chk_engine_start_prepare(chk_engine, rank_nr, ranks, policy_nr, policies,
+				      pool_nr, pools, gen, exp_phase, flags, leader, &rank_list);
+	if (rc != 0)
+		goto out_log;
+
+	D_ASSERT(rank_list != NULL);
+	D_ASSERT(d_list_empty(&chk_engine->ci_pool_list));
+	D_ASSERT(d_list_empty(&chk_engine->ci_pending_list));
+	D_ASSERT(chk_engine->ci_sched == ABT_THREAD_NULL);
+
+	if (chk_engine->ci_iv_ns != NULL) {
+		ds_iv_ns_put(chk_engine->ci_iv_ns);
+		chk_engine->ci_iv_ns = NULL;
+	}
+
+	if (chk_engine->ci_iv_group != NULL) {
+		crt_group_secondary_destroy(chk_engine->ci_iv_group);
+		chk_engine->ci_iv_group = NULL;
+	}
+
+	rc = crt_group_secondary_create(CHK_DUMMY_POOL, NULL, rank_list, &chk_engine->ci_iv_group);
+	if (rc != 0)
+		goto out_log;
+
+	rc = ds_iv_ns_create(dss_get_module_info()->dmi_ctx, (unsigned char *)CHK_DUMMY_POOL,
+			     chk_engine->ci_iv_group, &chk_engine->ci_iv_id, &chk_engine->ci_iv_ns);
+	if (rc != 0)
+		goto out_group;
+
+	ds_iv_ns_update(chk_engine->ci_iv_ns, leader);
+
+	if (prop->cp_pool_nr <= 0)
+		chk_engine->ci_all_pools = 1;
+	else
+		chk_engine->ci_all_pools = 0;
+
+	if (flags & CHK__CHECK_FLAG__CF_RESET) {
+		ctpa.ctpa_gen = cbk->cb_gen;
+		rc = chk_traverse_pools(chk_pools_cleanup_cb, &ctpa);
+		if (rc != 0)
+			goto out_iv;
+
+		ctpa.ctpa_gen = cbk->cb_gen;
+		ctpa.ctpa_ins = chk_engine;
+
+		rc = ds_mgmt_tgt_pool_iterate(chk_pools_add_from_dir, &ctpa);
+		if (rc != 0)
+			goto out_pool;
+
+		rc = ds_mgmt_newborn_pool_iterate(chk_pools_add_from_dir, &ctpa);
+		if (rc != 0)
+			goto out_pool;
+
+		rc = ds_mgmt_zombie_pool_iterate(chk_pools_add_from_dir, &ctpa);
+		if (rc != 0)
+			goto out_pool;
+
+		*cur_phase = CHK__CHECK_SCAN_PHASE__CSP_PREPARE;
+	} else {
+		if (chk_engine->ci_all_pools) {
+			ctpa.ctpa_gen = cbk->cb_gen;
+			ctpa.ctpa_ins = chk_engine;
+			rc = chk_traverse_pools(chk_pools_add_from_db, &ctpa);
+			if (rc != 0)
+				goto out_pool;
+		} else {
+			for (i = 0; i < pool_nr; i++) {
+				rc = chk_pool_start_one(chk_engine, pools[i], cbk->cb_gen);
+				if (rc != 0)
+					goto out_pool;
+			}
+		}
+
+		*cur_phase = chk_engine_find_slowest(chk_engine);
+	}
+
+	cbk->cb_ins_status = CHK__CHECK_INST_STATUS__CIS_RUNNING;
+	cbk->cb_phase = *cur_phase;
+	/* Always refresh the start time. */
+	cbk->cb_time.ct_start_time = time(NULL);
+	/* XXX: How to estimate the lfet time? */
+	cbk->cb_time.ct_left_time = CHK__CHECK_SCAN_PHASE__DSP_DONE - cbk->cb_phase;
+	rc = chk_bk_update_engine(cbk);
+	if (rc != 0)
+		goto out_pool;
+
+	if (cbk->cb_phase == CHK__CHECK_SCAN_PHASE__CSP_PREPARE ||
+	    cbk->cb_phase == CHK__CHECK_SCAN_PHASE__CSP_POOL_LIST) {
+		ceca.ceca_pool_nr = pool_nr;
+		ceca.ceca_pools = pools;
+		rc = ds_pool_clues_init(chk_engine_clues_filter, &ceca, clues);
+		if (rc != 0)
+			goto out_bk;
+	}
+
+	chk_engine->ci_sched_running = 1;
+
+	rc = dss_ult_create(chk_engine_sched, chk_engine, DSS_XS_SYS, 0, DSS_DEEP_STACK_SZ,
+			    &chk_engine->ci_sched);
+	if (rc != 0) {
+		chk_engine->ci_sched_running = 0;
+		goto out_bk;
+	}
+
+	goto out_log;
+
+out_bk:
+	if (rc != -DER_ALREADY && cbk->cb_ins_status == CHK__CHECK_INST_STATUS__CIS_RUNNING) {
+		cbk->cb_time.ct_stop_time = time(NULL);
+		cbk->cb_ins_status = CHK__CHECK_INST_STATUS__CIS_FAILED;
+		chk_bk_update_engine(cbk);
+	}
+out_pool:
+	d_list_for_each_entry_safe(cpr, tmp, &chk_engine->ci_pool_list, cpr_link) {
+		cpr->cpr_bk.cb_time.ct_stop_time = time(NULL);
+		cpr->cpr_bk.cb_pool_status = CHK__CHECK_POOL_STATUS__CPS_IMPLICATED;
+		chk_bk_update_pool(&cpr->cpr_bk, cpr->cpr_uuid);
+
+		d_iov_set(&kiov, cpr->cpr_uuid, sizeof(cpr->cpr_uuid));
+		dbtree_delete(chk_engine->ci_pool_hdl, BTR_PROBE_EQ, &kiov, NULL);
+	}
+out_iv:
+	ds_iv_ns_put(chk_engine->ci_iv_ns);
+	chk_engine->ci_iv_ns = NULL;
+out_group:
+	crt_group_secondary_destroy(chk_engine->ci_iv_group);
+	chk_engine->ci_iv_group = NULL;
+out_log:
+	chk_engine->ci_starting = 0;
+
+	if (rc == 0) {
+		D_INFO("Check engine (gen "DF_X64") started on rank %u with %u ranks, %u pools, "
+		       "flags %x, phase %d, leader %u\n",
+		       cbk->cb_gen, myrank, rank_nr, pool_nr, flags, exp_phase, leader);
+
+		chk_ranks_dump(rank_list->rl_nr, rank_list->rl_ranks);
+
+		if (pool_nr > 0)
+			chk_pools_dump(pool_nr, pools);
+		else if (prop->cp_pool_nr > 0)
+			chk_pools_dump(prop->cp_pool_nr, prop->cp_pools);
+	} else if (rc > 0) {
+		*cur_phase = CHK__CHECK_SCAN_PHASE__DSP_DONE;
+	} else if (rc != -DER_ALREADY) {
+		D_ERROR("Check engine (gen "DF_X64") failed to start on rank %u with %u ranks, "
+			"%u pools, flags %x, phase %d, leader %u, gen "DF_X64": "DF_RC"\n",
+			cbk->cb_gen, myrank, rank_nr, pool_nr,
+			flags, exp_phase, leader, gen, DP_RC(rc));
+	}
+
+	d_rank_list_free(rank_list);
+
+	return rc;
+}
+
+static int
+chk_pool_stop_one(daos_handle_t hdl, struct chk_bookmark *cbk, uuid_t uuid, uint32_t flags)
+{
+	d_iov_t		kiov;
+	int		rc = 0;
+
+	if (cbk->cb_pool_status == CHK__CHECK_POOL_STATUS__CPS_CHECKING ||
+	    cbk->cb_pool_status == CHK__CHECK_POOL_STATUS__CPS_PENDING) {
+		cbk->cb_pool_status = CHK__CHECK_POOL_STATUS__CPS_STOPPED;
+		cbk->cb_time.ct_stop_time = time(NULL);
+		rc = chk_bk_update_pool(cbk, uuid);
+		if (rc != 0)
+			goto out;
+	}
+
+	d_iov_set(&kiov, uuid, sizeof(uuid_t));
+	rc = dbtree_delete(hdl, flags | BTR_PROBE_EQ, &kiov, NULL);
+	if (rc != 0)
+		D_ERROR("Check engine (gen "DF_X64") on rank %u failed to delete pool record "
+			DF_UUID" when exit: "DF_RC"\n",
+			cbk->cb_gen, dss_self_rank(), DP_UUID(uuid), DP_RC(rc));
+
+out:
+	return rc;
+}
+
+int
+chk_engine_stop(uint64_t gen, uint32_t pool_nr, uuid_t pools[])
+{
+	struct chk_property	*prop = &chk_engine->ci_prop;
+	struct chk_bookmark	*cbk = &chk_engine->ci_bk;
+	struct chk_pool_rec	*cpr;
+	struct chk_pool_rec	*tmp;
+	d_iov_t			 riov;
+	d_iov_t			 kiov;
+	uuid_t			 uuid;
+	int			 rc = 0;
+	int			 i;
+
+	if (cbk->cb_magic != CHK_BK_MAGIC_ENGINE || cbk->cb_gen != gen)
+		D_GOTO(out, rc = -DER_NOTAPPLICABLE);
+
+	if (chk_engine->ci_starting)
+		D_GOTO(out, rc = -DER_BUSY);
+
+	if (chk_engine->ci_stopping)
+		D_GOTO(out, rc = -DER_INPROGRESS);
+
+	chk_engine->ci_stopping = 1;
+
+	if (cbk->cb_ins_status != CHK__CHECK_INST_STATUS__CIS_RUNNING)
+		D_GOTO(out, rc = -DER_ALREADY);
+
+	if (pool_nr == 0) {
+		d_list_for_each_entry_safe(cpr, tmp, &chk_engine->ci_pool_list, cpr_link) {
+			uuid_copy(uuid, cpr->cpr_uuid);
+			rc = chk_pool_stop_one(chk_engine->ci_pool_hdl, &cpr->cpr_bk, uuid, 0);
+			if (rc != 0)
+				goto out;
+		}
+	} else {
+		for (i = 0; i < pool_nr; i++) {
+			d_iov_set(&riov, NULL, 0);
+			d_iov_set(&kiov, pools[i], sizeof(pools[i]));
+			rc = dbtree_lookup(chk_engine->ci_pool_hdl, &kiov, &riov);
+			if (rc == -DER_NONEXIST)
+				continue;
+
+			if (rc != 0)
+				goto out;
+
+			cpr = (struct chk_pool_rec *)riov.iov_buf;
+			rc = chk_pool_stop_one(chk_engine->ci_pool_hdl, &cpr->cpr_bk, pools[i],
+					       BTR_PROBE_BYPASS);
+			if (rc != 0)
+				goto out;
+		}
+	}
+
+	if (d_list_empty(&chk_engine->ci_pool_list)) {
+		chk_stop_sched(chk_engine);
+		/* To indicate that there is no active pool(s) on this rank. */
+		rc = 1;
+	}
+
+out:
+	chk_engine->ci_stopping = 0;
+
+	if (rc == 0) {
+		D_INFO("Check engine (gen "DF_X64") stopped on rank %u with %u pools\n",
+		       cbk->cb_gen, dss_self_rank(), pool_nr > 0 ? pool_nr : prop->cp_pool_nr);
+
+		if (pool_nr > 0)
+			chk_pools_dump(pool_nr, pools);
+		else if (prop->cp_pool_nr > 0)
+			chk_pools_dump(prop->cp_pool_nr, prop->cp_pools);
+	} else if (rc < 0 && rc == -DER_ALREADY) {
+		D_ERROR("Check engine (gen "DF_X64") failed to stop on rank %u with %u pools, "
+			"gen "DF_X64": "DF_RC"\n", cbk->cb_gen, dss_self_rank(),
+			pool_nr > 0 ? pool_nr : prop->cp_pool_nr, gen, DP_RC(rc));
+	}
+
+	return rc;
+}
+
+/* Query one pool shard on one xstream. */
+static int
+chk_engine_query_one(void *args)
+{
+	struct dss_coll_stream_args	*reduce = args;
+	struct dss_stream_arg_type	*streams = reduce->csa_streams;
+	struct chk_query_xstream_args	*cqxa;
+	struct chk_query_target		*target;
+	char				*path = NULL;
+	daos_handle_t			 poh = DAOS_HDL_INVAL;
+	vos_pool_info_t			 info;
+	int				 tid = dss_get_module_info()->dmi_tgt_id;
+	int				 rc;
+
+	cqxa = streams[tid].st_arg;
+	target = &cqxa->cqxa_target;
+	rc = path_gen(cqxa->cqxa_uuid, dss_storage_path, VOS_FILE, &tid, &path);
+	if (rc != 0)
+		goto out;
+
+	rc = vos_pool_open(path, cqxa->cqxa_uuid, 0, &poh);
+	if (rc != 0) {
+		D_ERROR("Failed to open vos pool "DF_UUID" on target %u/%d: "DF_RC"\n",
+			cqxa->cqxa_uuid, dss_self_rank(), tid, DP_RC(rc));
+		goto out;
+	}
+
+	rc = vos_pool_query(poh, &info);
+	if (rc != 0) {
+		D_ERROR("Failed to query vos pool "DF_UUID" on target %u/%d: "DF_RC"\n",
+			cqxa->cqxa_uuid, dss_self_rank(), tid, DP_RC(rc));
+		goto out;
+	}
+
+	target->cqt_rank = dss_self_rank();
+	target->cqt_tgt = tid;
+	target->cqt_ins_status = info.pif_chk_status;
+	target->cqt_statistics = info.pif_chk_statistics;
+	target->cqt_time = info.pif_chk_time;
+
+out:
+	if (daos_handle_is_valid(poh))
+		vos_pool_close(poh);
+	D_FREE(path);
+	return rc;
+}
+
+static void
+chk_engine_query_reduce(void *a_args, void *s_args)
+{
+	struct	chk_query_xstream_args	*aggregator = a_args;
+	struct  chk_query_xstream_args	*stream = s_args;
+	struct chk_query_pool_shard	*shard;
+	struct chk_query_target		*target;
+
+	shard = &aggregator->cqxa_args->cqpa_shards[aggregator->cqxa_args->cqpa_idx];
+	target = &shard->cqps_targets[shard->cqps_target_nr];
+	*target = stream->cqxa_target;
+	shard->cqps_target_nr++;
+}
+
+static int
+chk_engine_query_stream_alloc(struct dss_stream_arg_type *args, void *a_arg)
+{
+	struct chk_query_xstream_args	*cqxa = a_arg;
+	int				 rc = 0;
+
+	D_ALLOC(args->st_arg, sizeof(struct chk_query_xstream_args));
+	if (args->st_arg == NULL)
+		D_GOTO(out, rc = -DER_NOMEM);
+
+	memcpy(args->st_arg, cqxa, sizeof(struct chk_query_xstream_args));
+
+out:
+	return rc;
+}
+
+static void
+chk_engine_query_stream_free(struct dss_stream_arg_type *args)
+{
+	D_ASSERT(args->st_arg != NULL);
+	D_FREE(args->st_arg);
+}
+
+static int
+chk_engine_query_pool(uuid_t uuid, void *args)
+{
+	struct chk_query_pool_args	*cqpa = args;
+	struct chk_query_pool_shard	*shard;
+	struct chk_query_pool_shard	*new_shards;
+	struct chk_bookmark		 cbk;
+	struct chk_query_xstream_args	 cqxa = { 0 };
+	struct dss_coll_args		 coll_args = { 0 };
+	struct dss_coll_ops		 coll_ops;
+	int				 rc = 0;
+
+	if (cqpa->cqpa_idx == cqpa->cqpa_cap) {
+		D_REALLOC_ARRAY(new_shards, cqpa->cqpa_shards, cqpa->cqpa_cap, cqpa->cqpa_cap << 1);
+		if (new_shards == NULL)
+			D_GOTO(out, rc = -DER_NOMEM);
+
+		cqpa->cqpa_shards = new_shards;
+		cqpa->cqpa_cap <<= 1;
+	}
+
+	shard = &cqpa->cqpa_shards[cqpa->cqpa_idx];
+	uuid_copy(shard->cqps_uuid, uuid);
+	shard->cqps_rank = dss_self_rank();
+	shard->cqps_target_nr = 0;
+
+	rc = chk_bk_fetch_pool(&cbk, uuid);
+	if (rc == -DER_NONEXIST) {
+		shard->cqps_status = CHK__CHECK_POOL_STATUS__CPS_UNCHECKED;
+		shard->cqps_phase = CHK__CHECK_SCAN_PHASE__CSP_PREPARE;
+		memset(&shard->cqps_statistics, 0, sizeof(shard->cqps_statistics));
+		memset(&shard->cqps_time, 0, sizeof(shard->cqps_time));
+		shard->cqps_targets = NULL;
+
+		D_GOTO(out, rc = 0);
+	}
+
+	if (rc != 0)
+		goto out;
+
+	D_ALLOC_ARRAY(shard->cqps_targets, dss_tgt_nr);
+	if (shard->cqps_targets == NULL)
+		D_GOTO(out, rc = -DER_NOMEM);
+
+	shard->cqps_status = cbk.cb_pool_status;
+	shard->cqps_phase = cbk.cb_phase;
+	memcpy(&shard->cqps_statistics, &cbk.cb_statistics, sizeof(shard->cqps_statistics));
+	memcpy(&shard->cqps_time, &cbk.cb_time, sizeof(shard->cqps_time));
+
+	uuid_copy(cqxa.cqxa_uuid, uuid);
+	cqxa.cqxa_args = cqpa;
+
+	coll_args.ca_func_args = &coll_args.ca_stream_args;
+	coll_args.ca_aggregator = &cqxa;
+
+	coll_ops.co_func = chk_engine_query_one;
+	coll_ops.co_reduce = chk_engine_query_reduce;
+	coll_ops.co_reduce_arg_alloc = chk_engine_query_stream_alloc;
+	coll_ops.co_reduce_arg_free = chk_engine_query_stream_free;
+
+	rc = dss_task_collective_reduce(&coll_ops, &coll_args, 0);
+
+out:
+	D_CDEBUG(rc != 0, DLOG_ERR, DLOG_DBG,
+		 "Check engine (gen "DF_X64") on rank %u query pool "DF_UUID":"DF_RC"\n",
+		 chk_engine->ci_bk.cb_gen, dss_self_rank(), DP_UUID(uuid), DP_RC(rc));
+	return rc;
+}
+
+int
+chk_engine_query(uint64_t gen, uint32_t pool_nr, uuid_t pools[],
+		 uint32_t *shard_nr, struct chk_query_pool_shard **shards)
+{
+	struct chk_bookmark		*cbk = &chk_engine->ci_bk;
+	struct chk_query_pool_args	 cqpa = { 0 };
+	int				 rc = 0;
+	int				 i;
+
+	if (cbk->cb_gen != gen)
+		D_GOTO(out, rc = -DER_NOTAPPLICABLE);
+
+	cqpa.cqpa_cap = 2;
+	cqpa.cqpa_idx = 0;
+	D_ALLOC_ARRAY(cqpa.cqpa_shards, cqpa.cqpa_cap);
+	if (cqpa.cqpa_shards == NULL)
+		D_GOTO(log, rc = -DER_NOMEM);
+
+	if (pool_nr == 0) {
+		rc = ds_mgmt_tgt_pool_iterate(chk_engine_query_pool, &cqpa);
+	} else {
+		for (i = 0; i < pool_nr; i++) {
+			rc = chk_engine_query_pool(pools[i], &cqpa);
+			if (rc != 0)
+				goto log;
+		}
+	}
+
+log:
+	if (rc != 0) {
+		chk_query_free(cqpa.cqpa_shards, cqpa.cqpa_idx);
+	} else {
+		*shards = cqpa.cqpa_shards;
+		*shard_nr = cqpa.cqpa_idx;
+	}
+
+	D_CDEBUG(rc != 0, DLOG_ERR, DLOG_DBG,
+		 "Check engine (gen "DF_X64") on rank %u handle query for %u pools :"DF_RC"\n",
+		 cbk->cb_gen, dss_self_rank(), pool_nr, DP_RC(rc));
+
+out:
+	return rc;
+}
+
+int
+chk_engine_mark_rank_dead(uint64_t gen, d_rank_t rank, uint32_t version)
+{
+	struct chk_property	*prop = &chk_engine->ci_prop;
+	struct chk_bookmark	*cbk = &chk_engine->ci_bk;
+	d_rank_list_t		*rank_list = NULL;
+	int			 rc = 0;
+
+	if (cbk->cb_gen != gen)
+		D_GOTO(out, rc = -DER_NOTAPPLICABLE);
+
+	rc = chk_prop_fetch(prop, &rank_list);
+	if (rc != 0)
+		goto out;
+
+	D_ASSERT(rank_list != NULL);
+
+	if (!chk_remove_rank_from_list(rank_list, rank))
+		D_GOTO(out, rc = -DER_NOTAPPLICABLE);
+
+	prop->cp_rank_nr--;
+	rc = chk_prop_update(prop, rank_list);
+	if (rc != 0)
+		goto out;
+
+	rc = crt_group_secondary_modify(chk_engine->ci_iv_group, rank_list, rank_list,
+					CRT_GROUP_MOD_OP_REPLACE, version);
+
+	/* TBD: mark related pools as 'failed'. */
+
+out:
+	d_rank_list_free(rank_list);
+	if (rc != -DER_NOTAPPLICABLE)
+		D_CDEBUG(rc != 0, DLOG_ERR, DLOG_INFO,
+			 "Check engine (gen "DF_X64") on rank %u mark rank %u as dead with gen "
+			 DF_X64", version %u: "DF_RC"\n",
+			 cbk->cb_gen, dss_self_rank(), rank, gen, version, DP_RC(rc));
+
+	return rc;
+}
+
+int
+chk_engine_act(uint64_t gen, uint64_t seq, uint32_t cla, uint32_t act, uint32_t flags)
+{
+	struct chk_property	*prop = &chk_engine->ci_prop;
+	struct chk_bookmark	*cbk = &chk_engine->ci_bk;
+	struct chk_pending_rec	*cpr = NULL;
+	int			 rc;
+
+	if (cbk->cb_gen != gen)
+		D_GOTO(out, rc = -DER_NOTAPPLICABLE);
+
+	if (unlikely(cla >= CHK_POLICY_MAX)) {
+		D_ERROR("Invalid DAOS inconsistency class %u\n", cla);
+		D_GOTO(out, rc = -DER_INVAL);
+	}
+
+	/* The admin may input the wrong option, not acceptable. */
+	if (unlikely(act == CHK__CHECK_INCONSIST_ACTION__CIA_INTERACT)) {
+		D_ERROR("%u is not acceptable for interaction decision.\n", cla);
+		D_GOTO(out, rc = -DER_INVAL);
+	}
+
+	rc = chk_pending_del(chk_engine, seq, &cpr);
+	if (rc == 0) {
+		/* The cpr will be destroyed by the waiter via chk_engine_report(). */
+		D_ASSERT(cpr->cpr_busy == 1);
+
+		ABT_mutex_lock(cpr->cpr_mutex);
+		cpr->cpr_action = act;
+		ABT_cond_broadcast(cpr->cpr_cond);
+		ABT_mutex_unlock(cpr->cpr_mutex);
+	}
+
+	if (rc != 0 || !(flags & CAF_FOR_ALL))
+		goto out;
+
+	if (likely(prop->cp_policies[cla] != act)) {
+		prop->cp_policies[cla] = act;
+		rc = chk_prop_update(prop, NULL);
+	}
+
+out:
+	D_CDEBUG(rc != 0, DLOG_ERR, DLOG_INFO,
+		 "Check engine (gen "DF_X64") on rank %u takes action for seq "
+		 DF_X64" with gen "DF_X64", class %u, action %u, flags %x: "DF_RC"\n",
+		 cbk->cb_gen, dss_self_rank(), seq, gen, cla, act, flags, DP_RC(rc));
+
+	return rc;
+}
+
+int
+chk_engine_report(uint32_t cla, uint32_t act, int32_t result, char *pool, char *cont,
+		  daos_unit_oid_t *obj, daos_key_t *dkey, daos_key_t *akey, char *msg,
+		  uint32_t option_nr, uint32_t *options, uint32_t detail_nr, d_sg_list_t *details)
+{
+	struct chk_bookmark	*cbk = &chk_engine->ci_bk;
+	struct chk_pending_rec	*cpr = NULL;
+	uint64_t		 seq = 0;
+	int			 rc;
+
+	rc = chk_report_remote(chk_engine->ci_prop.cp_leader, chk_engine->ci_bk.cb_gen, cla,
+			       act, result, dss_self_rank(), dss_get_module_info()->dmi_tgt_id,
+			       pool, cont, obj, dkey, akey, msg, option_nr, options, detail_nr,
+			       details, &seq);
+	if (rc != 0)
+		goto log;
+
+	if (act == CHK__CHECK_INCONSIST_ACTION__CIA_INTERACT)
+		rc = chk_pending_add(chk_engine, &chk_engine->ci_pending_list, seq,
+				     dss_self_rank(), cla, &cpr);
+
+log:
+	if (rc != 0) {
+		D_ERROR("Check engine (gen "DF_X64") on rank %u failed to report with class %u, "
+			"action %u, result %d: "DF_RC"\n",
+			cbk->cb_gen, dss_self_rank(), cla, act, result, DP_RC(rc));
+		goto out;
+	}
+
+	D_CDEBUG(act == CHK__CHECK_INCONSIST_ACTION__CIA_INTERACT, DLOG_INFO, DLOG_DBG,
+		 "Check engine (gen "DF_X64") on rank %u handle report with class %u, "
+		 "action %u, result %d: "DF_RC"\n",
+		 cbk->cb_gen, dss_self_rank(), cla, act, result, DP_RC(rc));
+
+	if (cpr == NULL)
+		goto out;
+
+	D_ASSERT(cpr->cpr_busy == 1);
+
+	ABT_mutex_lock(cpr->cpr_mutex);
+	if (cpr->cpr_action != CHK__CHECK_INCONSIST_ACTION__CIA_INTERACT) {
+		ABT_mutex_unlock(cpr->cpr_mutex);
+		goto handle;
+	}
+
+	ABT_cond_wait(cpr->cpr_cond, cpr->cpr_mutex);
+	ABT_mutex_unlock(cpr->cpr_mutex);
+	if (!chk_engine->ci_sched_running || cpr->cpr_exiting)
+		goto out;
+
+	D_ASSERT(cpr->cpr_action != CHK__CHECK_INCONSIST_ACTION__CIA_INTERACT);
+
+handle:
+
+	/* TBD: already got the interaction feedback, handle it and log the result. */
+
+out:
+	if (cpr != NULL)
+		chk_pending_destroy(cpr);
+
+	return rc;
+}
+
+int
+chk_engine_notify(uint64_t gen, d_rank_t rank, uint32_t phase, uint32_t status)
+{
+	struct chk_property	*prop = &chk_engine->ci_prop;
+	struct chk_bookmark	*cbk = &chk_engine->ci_bk;
+	int			 rc = 0;
+
+	if (cbk->cb_gen != gen)
+		D_GOTO(out, rc = -DER_NOTAPPLICABLE);
+
+	/* Ignore notification from non-leader. */
+	if (prop->cp_leader != rank)
+		D_GOTO(out, rc = -DER_NOTAPPLICABLE);
+
+	/* Ignore non-failure notification from leader. */
+	if (status != CHK__CHECK_INST_STATUS__CIS_FAILED)
+		D_GOTO(out, rc = 0);
+
+	if (cbk->cb_ins_status != CHK__CHECK_INST_STATUS__CIS_RUNNING)
+		D_GOTO(out, rc = 0);
+
+	chk_engine->ci_implicated = 1;
+	chk_stop_sched(chk_engine);
+
+out:
+	if (rc != -DER_NOTAPPLICABLE)
+		D_CDEBUG(rc != 0, DLOG_ERR, DLOG_INFO,
+			 "Check engine (gen "DF_X64") on rank %u got notification from rank %u, "
+			 "phase %u, status %u, gen "DF_X64": "DF_RC"\n",
+			 cbk->cb_gen, dss_self_rank(), rank, phase, status, gen, DP_RC(rc));
+
+	return (rc == 0 || rc == -DER_NOTAPPLICABLE) ? 0 : rc;
+}
+
+static int
+chk_rejoin_cb(struct sys_db *db, char *table, d_iov_t *key, void *args)
+{
+	struct chk_traverse_pools_args	*ctpa = args;
+	struct chk_instance		*ins = ctpa->ctpa_ins;
+	unsigned char			*uuid = key->iov_buf;
+	struct chk_bookmark		 cbk;
+	int				 rc;
+
+	if (!d_is_uuid(uuid))
+		goto out;
+
+	rc = chk_bk_fetch_pool(&cbk, uuid);
+	if (rc != 0) {
+		ctpa->ctpa_status = CHK__CHECK_INST_STATUS__CIS_FAILED;
+		goto out;
+	}
+
+	if (cbk.cb_gen != ctpa->ctpa_gen)
+		goto out;
+
+	if (cbk.cb_pool_status == CHK__CHECK_POOL_STATUS__CPS_FAILED) {
+		if (cbk.cb_phase < ins->ci_slowest_fail_phase)
+			ins->ci_slowest_fail_phase = cbk.cb_phase;
+		goto out;
+	}
+
+	if (cbk.cb_pool_status != CHK__CHECK_POOL_STATUS__CPS_CHECKING &&
+	    cbk.cb_pool_status != CHK__CHECK_POOL_STATUS__CPS_PAUSED &&
+	    cbk.cb_pool_status != CHK__CHECK_POOL_STATUS__CPS_PENDING)
+		goto out;
+
+	/* Always refresh the start time. */
+	cbk.cb_time.ct_start_time = time(NULL);
+	/* XXX: How to estimate the lfet time? */
+	cbk.cb_time.ct_left_time = CHK__CHECK_SCAN_PHASE__DSP_DONE - cbk.cb_phase;
+	cbk.cb_pool_status = CHK__CHECK_POOL_STATUS__CPS_CHECKING;
+	rc = chk_pool_add_shard(ins->ci_pool_hdl, &ins->ci_pool_list, uuid,
+				dss_self_rank(), cbk.cb_phase, &cbk, ins, NULL, NULL);
+	if (rc != 0) {
+		ctpa->ctpa_status = CHK__CHECK_INST_STATUS__CIS_FAILED;
+		goto out;
+	}
+
+	rc = chk_bk_update_pool(&cbk, uuid);
+	if (rc != 0)
+		chk_pool_del_shard(ins->ci_pool_hdl, uuid, dss_self_rank());
+
+out:
+	/* Ignore the failure to handle next one. */
+	return 0;
+}
+
+void
+chk_engine_rejoin(void)
+{
+	struct chk_property		*prop = &chk_engine->ci_prop;
+	struct chk_bookmark		*cbk = &chk_engine->ci_bk;
+	d_rank_list_t			*rank_list = NULL;
+	struct chk_traverse_pools_args	 ctpa = { 0 };
+	struct chk_iv			 iv;
+	d_rank_t			 myrank = dss_self_rank();
+	uint32_t			 phase;
+	int				 rc = 0;
+	bool				 need_join = false;
+	bool				 need_iv = false;
+	bool				 joined = false;
+
+	if (cbk->cb_magic != CHK_BK_MAGIC_ENGINE)
+		goto out;
+
+	if (cbk->cb_ins_status != CHK__CHECK_INST_STATUS__CIS_RUNNING &&
+	    cbk->cb_ins_status != CHK__CHECK_INST_STATUS__CIS_PAUSED)
+		goto out;
+
+	D_ASSERT(chk_engine->ci_starting == 0);
+	D_ASSERT(chk_engine->ci_stopping == 0);
+	D_ASSERT(chk_engine->ci_iv_group == NULL);
+	D_ASSERT(chk_engine->ci_iv_ns == NULL);
+
+	need_join = true;
+	chk_engine->ci_starting = 1;
+
+	rc = chk_prop_fetch(prop, &rank_list);
+	if (rc != 0)
+		goto out;
+
+	D_ASSERT(rank_list != NULL);
+
+	rc = crt_group_secondary_create(CHK_DUMMY_POOL, NULL, rank_list, &chk_engine->ci_iv_group);
+	if (rc != 0)
+		goto out;
+
+	rc = ds_iv_ns_create(dss_get_module_info()->dmi_ctx, (unsigned char *)CHK_DUMMY_POOL,
+			     chk_engine->ci_iv_group, &chk_engine->ci_iv_id, &chk_engine->ci_iv_ns);
+	if (rc != 0)
+		goto out;
+
+	ds_iv_ns_update(chk_engine->ci_iv_ns, prop->cp_leader);
+
+	/* Ask leader whether this engine can rejoin or not. */
+	rc = chk_rejoin_remote(prop->cp_leader, cbk->cb_gen, myrank, cbk->cb_phase);
+	if (rc != 0)
+		goto out;
+
+	joined = true;
+
+	ctpa.ctpa_gen = cbk->cb_gen;
+	ctpa.ctpa_ins = chk_engine;
+	rc = chk_traverse_pools(chk_rejoin_cb, &ctpa);
+	if (rc != 0)
+		goto out;
+
+	phase = chk_engine_find_slowest(chk_engine);
+	if (phase != cbk->cb_phase)
+		need_iv = true;
+
+	cbk->cb_phase = phase;
+	if (unlikely(d_list_empty(&chk_engine->ci_pool_list))) {
+		if (ctpa.ctpa_status == CHK__CHECK_INST_STATUS__CIS_FAILED)
+			cbk->cb_ins_status = CHK__CHECK_INST_STATUS__CIS_FAILED;
+		else
+			cbk->cb_ins_status = CHK__CHECK_INST_STATUS__CIS_COMPLETED;
+		cbk->cb_time.ct_stop_time = time(NULL);
+		need_iv = true;
+	} else {
+		cbk->cb_ins_status = CHK__CHECK_INST_STATUS__CIS_RUNNING;
+		/* Always refresh the start time. */
+		cbk->cb_time.ct_start_time = time(NULL);
+		/* XXX: How to estimate the lfet time? */
+		cbk->cb_time.ct_left_time = CHK__CHECK_SCAN_PHASE__DSP_DONE - cbk->cb_phase;
+	}
+
+	rc = chk_bk_update_engine(cbk);
+	if (rc != 0) {
+		need_iv = true;
+		goto out;
+	}
+
+	if (unlikely(d_list_empty(&chk_engine->ci_pool_list)))
+		goto out;
+
+	chk_engine->ci_sched_running = 1;
+
+	rc = dss_ult_create(chk_engine_sched, chk_engine, DSS_XS_SYS, 0, DSS_DEEP_STACK_SZ,
+			    &chk_engine->ci_sched);
+	if (rc != 0)
+		need_iv = true;
+	else
+		/* chk_engine_sched will do IV to leader. */
+		need_iv = false;
+
+out:
+	chk_engine->ci_starting = 0;
+	d_rank_list_free(rank_list);
+
+	if (rc != 0 && joined) {
+		chk_engine_exit(chk_engine, CHK__CHECK_INST_STATUS__CIS_FAILED,
+				CHK__CHECK_POOL_STATUS__CPS_IMPLICATED);
+	} else if (need_iv && cbk->cb_ins_status != CHK__CHECK_INST_STATUS__CIS_IMPLICATED &&
+		   chk_engine->ci_iv_ns != NULL) {
+		iv.ci_gen = cbk->cb_gen;
+		iv.ci_phase = cbk->cb_phase;
+		iv.ci_status = cbk->cb_ins_status;
+		iv.ci_to_leader = 1;
+
+		/* Synchronously notify the leader that check instance exit on the engine. */
+		rc = chk_iv_update(chk_engine->ci_iv_ns, &iv, CRT_IV_SHORTCUT_TO_ROOT,
+				   CRT_IV_SYNC_EAGER, true);
+		if (rc != 0)
+			D_ERROR("Check engine (gen "DF_X64") on rank %u failed to notify leader "
+				"for its changes, status %u: "DF_RC"\n",
+				cbk->cb_gen, myrank, cbk->cb_ins_status, DP_RC(rc));
+	}
+
+	/*
+	 * XXX: It is unnecessary to destroy the IV namespace that can be handled when next
+	 *	CHK_START or instance fini.
+	 */
+
+	if (need_join)
+		D_CDEBUG(rc != 0, DLOG_ERR, DLOG_INFO,
+			 "Check engine (gen "DF_X64") rejoin on rank %u: "DF_RC"\n",
+			 cbk->cb_gen, myrank, DP_RC(rc));
+}
+
+void
+chk_engine_pause(void)
+{
+	chk_stop_sched(chk_engine);
+	D_ASSERT(d_list_empty(&chk_engine->ci_pending_list));
+	D_ASSERT(d_list_empty(&chk_engine->ci_pool_list));
+}
+
+int
+chk_engine_init(void)
+{
+	struct chk_bookmark	*cbk;
+	int			 rc;
+
+	D_ALLOC(chk_engine, sizeof(*chk_engine));
+	if (chk_engine == NULL)
+		D_GOTO(out, rc = -DER_NOMEM);
+
+	rc = chk_ins_init(chk_engine);
+	if (rc != 0)
+		goto free;
+
+	/*
+	 * XXX: DAOS global consistency check depends on all related engines' local
+	 *	consistency. If hit some local data corruption, then it is possible
+	 *	that local consistency is not guaranteed. Need to break and resolve
+	 *	related local inconsistency firstly.
+	 */
+
+	cbk = &chk_engine->ci_bk;
+	rc = chk_bk_fetch_engine(cbk);
+	if (rc == -DER_NONEXIST)
+		rc = 0;
+
+	/* It may be caused by local data corruption, let's break. */
+	if (rc != 0)
+		goto fini;
+
+	if (unlikely(cbk->cb_magic != CHK_BK_MAGIC_ENGINE)) {
+		D_ERROR("Hit corrupted engine bookmark on rank %u: %u vs %u\n",
+			dss_self_rank(), cbk->cb_magic, CHK_BK_MAGIC_ENGINE);
+		D_GOTO(fini, rc = -DER_IO);
+	}
+
+	rc = chk_prop_fetch(&chk_engine->ci_prop, NULL);
+	if (rc == -DER_NONEXIST)
+		rc = 0;
+
+	if (rc != 0)
+		goto fini;
+
+	goto out;
+
+fini:
+	chk_ins_fini(chk_engine);
+free:
+	D_FREE(chk_engine);
+out:
+	return rc;
+}
+
+void
+chk_engine_fini(void)
+{
+	chk_ins_fini(chk_engine);
+}

--- a/src/chk/chk_internal.h
+++ b/src/chk/chk_internal.h
@@ -11,8 +11,14 @@
 #ifndef __CHK_INTERNAL_H__
 #define __CHK_INTERNAL_H__
 
+#include <abt.h>
+#include <uuid/uuid.h>
 #include <daos/rpc.h>
+#include <daos/btree.h>
+#include <daos/object.h>
+#include <daos_srv/pool.h>
 #include <daos_srv/daos_chk.h>
+#include <daos_srv/daos_engine.h>
 
 #include "chk.pb-c.h"
 
@@ -22,26 +28,549 @@
  * These are for daos_rpc::dr_opc and DAOS_RPC_OPCODE(opc, ...) rather than
  * crt_req_create(..., opc, ...). See daos/rpc.h.
  */
-#define DAOS_CHK_VERSION 1
+#define DAOS_CHK_VERSION	1
 
 #define CHK_PROTO_SRV_RPC_LIST									\
-	X(CHK_START,	0,	&CQF_chk_start,	ds_chk_start_hdlr,	NULL,	"chk_start")	\
-	X(CHK_STOP,	0,	&CQF_chk_stop,	ds_chk_stop_hdlr,	NULL,	"chk_stop")	\
-	X(CHK_QUERY,	0,	&CQF_chk_query,	ds_chk_query_hdlr,	NULL,	"chk_query")	\
-	X(CHK_ACT,	0,	&CQF_chk_act,	ds_chk_act_hdlr,	NULL,	"chk_act")
+	X(CHK_START,										\
+		0,	&CQF_chk_start,		ds_chk_start_hdlr,	&chk_start_co_ops),	\
+	X(CHK_STOP,										\
+		0,	&CQF_chk_stop,		ds_chk_stop_hdlr,	&chk_stop_co_ops),	\
+	X(CHK_QUERY,										\
+		0,	&CQF_chk_query,		ds_chk_query_hdlr,	&chk_query_co_ops),	\
+	X(CHK_MARK,										\
+		0,	&CQF_chk_mark,		ds_chk_mark_hdlr,	&chk_mark_co_ops),	\
+	X(CHK_ACT,										\
+		0,	&CQF_chk_act,		ds_chk_act_hdlr,	&chk_act_co_ops),	\
+	X(CHK_REPORT,										\
+		0,	&CQF_chk_report,	ds_chk_report_hdlr,	NULL),			\
+	X(CHK_REJOIN,										\
+		0,	&CQF_chk_rejoin,	ds_chk_rejoin_hdlr,	NULL)
 
 /* Define for RPC enum population below */
-#define X(a, b, c, d, e, f) a,
+#define X(a, b, c, d, e) a
 
 enum chk_rpc_opc {
-	CHK_PROTO_SRV_RPC_LIST
+	CHK_PROTO_SRV_RPC_LIST,
 	CHK_PROTO_SRV_RPC_COUNT,
 };
 
 #undef X
 
-int chk_rejoin(void);
+/* check start in/out */
+#define DAOS_ISEQ_CHK_START							\
+	((uint64_t)		(csi_gen)		CRT_VAR)		\
+	((uint32_t)		(csi_flags)		CRT_VAR)		\
+	((int32_t)		(csi_phase)		CRT_VAR)		\
+	((d_rank_t)		(csi_leader_rank)	CRT_VAR)		\
+	((uint32_t)		(csi_padding)		CRT_VAR)		\
+	((d_rank_t)		(csi_ranks)		CRT_ARRAY)		\
+	((struct chk_policy)	(csi_policies)		CRT_ARRAY)		\
+	((uuid_t)		(csi_uuids)		CRT_ARRAY)
 
-int chk_pause(void);
+#define DAOS_OSEQ_CHK_START							\
+	((int32_t)		(cso_status)		CRT_VAR)		\
+	((d_rank_t)		(cso_rank)		CRT_VAR)		\
+	((uint32_t)		(cso_phase)		CRT_VAR)		\
+	((uint32_t)		(cso_padding)		CRT_VAR)		\
+	((struct ds_pool_clue)	(cso_clues)		CRT_ARRAY)
+
+CRT_RPC_DECLARE(chk_start, DAOS_ISEQ_CHK_START, DAOS_OSEQ_CHK_START);
+
+/* check stop in/out */
+#define DAOS_ISEQ_CHK_STOP							\
+	((uint64_t)		(csi_gen)		CRT_VAR)		\
+	((uuid_t)		(csi_uuids)		CRT_ARRAY)
+
+#define DAOS_OSEQ_CHK_STOP							\
+	((int32_t)		(cso_status)		CRT_VAR)		\
+	((d_rank_t)		(cso_rank)		CRT_VAR)
+
+CRT_RPC_DECLARE(chk_stop, DAOS_ISEQ_CHK_STOP, DAOS_OSEQ_CHK_STOP);
+
+/* check query in/out */
+#define DAOS_ISEQ_CHK_QUERY							\
+	((uint64_t)		(cqi_gen)		CRT_VAR)		\
+	((uuid_t)		(cqi_uuids)		CRT_ARRAY)
+
+#define DAOS_OSEQ_CHK_QUERY							\
+	((int32_t)			(cqo_status)	CRT_VAR)		\
+	((int32_t)			(cqo_padding)	CRT_VAR)		\
+	((struct chk_query_pool_shard)	(cqo_shards)	CRT_ARRAY)
+
+CRT_RPC_DECLARE(chk_query, DAOS_ISEQ_CHK_QUERY, DAOS_OSEQ_CHK_QUERY);
+
+/* check mark in/out */
+#define DAOS_ISEQ_CHK_MARK							\
+	((uint64_t)		(cmi_gen)		CRT_VAR)		\
+	((d_rank_t)		(cmi_rank)		CRT_VAR)		\
+	((uint32_t)		(cmi_version)		CRT_VAR)
+
+#define DAOS_OSEQ_CHK_MARK							\
+	((int32_t)		(cmo_status)		CRT_VAR)
+
+CRT_RPC_DECLARE(chk_mark, DAOS_ISEQ_CHK_MARK, DAOS_OSEQ_CHK_MARK);
+
+/* check act in/out */
+#define DAOS_ISEQ_CHK_ACT							\
+	((uint64_t)		(cai_gen)		CRT_VAR)		\
+	((uint64_t)		(cai_seq)		CRT_VAR)		\
+	((uint32_t)		(cai_cla)		CRT_VAR)		\
+	((uint32_t)		(cai_act)		CRT_VAR)		\
+	((uint32_t)		(cai_flags)		CRT_VAR)
+
+#define DAOS_OSEQ_CHK_ACT							\
+	((int32_t)		(cao_status)		CRT_VAR)
+
+CRT_RPC_DECLARE(chk_act, DAOS_ISEQ_CHK_ACT, DAOS_OSEQ_CHK_ACT);
+
+/* check report in/out */
+#define DAOS_ISEQ_CHK_REPORT							\
+	((uint64_t)		(cri_gen)		CRT_VAR)		\
+	((uint32_t)		(cri_ics_class)		CRT_VAR)		\
+	((uint32_t)		(cri_ics_action)	CRT_VAR)		\
+	((int32_t)		(cri_ics_result)	CRT_VAR)		\
+	((d_rank_t)		(cri_rank)		CRT_VAR)		\
+	((uint32_t)		(cri_target)		CRT_VAR)		\
+	((uint32_t)		(cri_padding)		CRT_VAR)		\
+	((uuid_t)		(cri_pool)		CRT_VAR)		\
+	((uuid_t)		(cri_cont)		CRT_VAR)		\
+	((daos_unit_oid_t)	(cri_obj)		CRT_VAR)		\
+	((daos_key_t)		(cri_dkey)		CRT_VAR)		\
+	((daos_key_t)		(cri_akey)		CRT_VAR)		\
+	((d_string_t)		(cri_msg)		CRT_VAR)		\
+	((uint32_t)		(cri_options)		CRT_ARRAY)		\
+	((d_sg_list_t)		(cri_details)		CRT_ARRAY)
+
+#define DAOS_OSEQ_CHK_REPORT							\
+	((int32_t)		(cro_status)		CRT_VAR)		\
+	((int32_t)		(cro_padding)		CRT_VAR)		\
+	((uint64_t)		(cro_seq)		CRT_VAR)
+
+CRT_RPC_DECLARE(chk_report, DAOS_ISEQ_CHK_REPORT, DAOS_OSEQ_CHK_REPORT);
+
+/* check rejoin in/out */
+#define DAOS_ISEQ_CHK_REJOIN							\
+	((uint64_t)		(cri_gen)		CRT_VAR)		\
+	((d_rank_t)		(cri_rank)		CRT_VAR)		\
+	((d_rank_t)		(cri_phase)		CRT_VAR)
+
+#define DAOS_OSEQ_CHK_REJOIN							\
+	((int32_t)		(cro_status)		CRT_VAR)
+
+CRT_RPC_DECLARE(chk_rejoin, DAOS_ISEQ_CHK_REJOIN, DAOS_OSEQ_CHK_REJOIN);
+
+/* dkey for check DB under sys_db */
+#define CHK_DB_TABLE		"chk"
+
+/* akey for leader bookmark under CHK_DB_TABLE */
+#define CHK_BK_LEADER		"leader"
+
+/* akey for engine bookmark under CHK_DB_TABLE */
+#define CHK_BK_ENGINE		"engine"
+
+/* akey for check property under CHK_DB_TABLE */
+#define CHK_PROPERTY		"property"
+
+/* akey for the list of ranks under CHK_DB_TABLE */
+#define CHK_RANKS		"ranks"
+
+#define CHK_BK_MAGIC_LEADER	0xe6f703da
+#define CHK_BK_MAGIC_ENGINE	0xe6f703db
+#define CHK_BK_MAGIC_POOL	0xe6f703dc
+
+#define CHK_DUMMY_POOL		"00000000-0000-0000-0000-000020220531"
+
+#define CHK_BTREE_ORDER		16
+
+/*
+ * XXX: Please be careful when change CHK__CHECK_INCONSIST_CLASS__CIC_UNKNOWN
+ *	to avoid hole is the struct chk_property.
+ */
+#define CHK_POLICY_MAX		(CHK__CHECK_INCONSIST_CLASS__CIC_UNKNOWN + 1)
+#define CHK_POOLS_MAX		(1 << 6)
+
+enum chk_act_flags {
+	/* The action is applicable to the same kind of inconssitency. */
+	CAF_FOR_ALL	= 1,
+};
+
+/*
+ * Each check instance has a unique leader engine that uses key "chk/leader" under its local
+ * sys_db to trace the check instance.
+ *
+ * For each engine, include the leader engine, there is a system level key "chk/engine" under
+ * the engine's local sys_db to trace the check instance on the engine. When server (re)start
+ * the check module uses it to determain whether needs to rejoin the check instance.
+ *
+ * For each pool, there is a key "chk/$pool_uuid" under the engine's local sys_db to trace
+ * check process for the pool on related engine.
+ */
+struct chk_bookmark {
+	uint32_t			cb_magic;
+	uint32_t			cb_version;
+	uint64_t			cb_gen;
+	Chk__CheckScanPhase		cb_phase;
+	union {
+		Chk__CheckInstStatus	cb_ins_status;
+		Chk__CheckPoolStatus	cb_pool_status;
+	};
+	/*
+	 * For leader bookmark, it is the inconsistency statistics during the phases range
+	 * [CSP_PREPARE, CSP_POOL_LIST] for the whole system. The inconsistency and related
+	 * reparation during these phases may be in MS, not related with any engine.
+	 *
+	 * For pool bookmark, it is the inconsistency statistics during the phases range
+	 * [CSP_POOL_MBS, CSP_CONT_CLEANUP] for the pool. The inconsistency and related
+	 * reparation during these phases is applied to the pool service leader.
+	 */
+	struct chk_statistics		cb_statistics;
+	struct chk_time			cb_time;
+};
+
+/* On each engine (including the leader), there is a key "chk/property" under its local sys_db. */
+struct chk_property {
+	d_rank_t			cp_leader;
+	Chk__CheckFlag			cp_flags;
+	Chk__CheckInconsistAction	cp_policies[CHK_POLICY_MAX];
+	/*
+	 * How many pools will be handled by the check instance. -1 means to handle all pools.
+	 * If the specified pools count exceeds CHK_POOLS_MAX, then all pools will be handled.
+	 */
+	int32_t				cp_pool_nr;
+	uuid_t				cp_pools[CHK_POOLS_MAX];
+	/*
+	 * XXX: Preserve for supporting to continue the check until the specified phase in the
+	 *	future. -1 means to check all phases.
+	 */
+	int32_t				cp_phase;
+	/* How many ranks (ever or should) take part in the check instance. */
+	uint32_t			cp_rank_nr;
+};
+
+/*
+ * XXX: For each check instance, there are one leader instance and 1 ~ N engine instances.
+ *	For each rank, there can be at most one leader instance and one engine instance.
+ *
+ *	Currently, we do not support to run multiple check instances in the system (even
+ *	if they are on different ranks sets) at the same time. If multiple pools need to
+ *	be checked, then please either specify their uuids together (or not specify pool
+ *	option, then check all pools by default) via single "dmg check" command, or wait
+ *	one check instance done and then start next.
+ */
+struct chk_instance {
+	struct chk_bookmark	 ci_bk;
+	struct chk_property	 ci_prop;
+	/*
+	 * For leader, ci_{btr,hdl,list} trace the ranks (engines) that still run check.
+	 * For engine, they trace the local pools that are still in checking or pending.
+	 */
+	union {
+		struct btr_root	 ci_rank_btr;
+		struct btr_root	 ci_pool_btr;
+	};
+	union {
+		daos_handle_t	 ci_rank_hdl;
+		daos_handle_t	 ci_pool_hdl;
+	};
+	union {
+		d_list_t	 ci_rank_list;
+		d_list_t	 ci_pool_list;
+	};
+
+	struct btr_root		 ci_pending_btr;
+	daos_handle_t		 ci_pending_hdl;
+	d_list_t		 ci_pending_list;
+
+	/* The slowest phase for the failed pool or rank. */
+	uint32_t		 ci_slowest_fail_phase;
+
+	uint32_t		 ci_iv_id;
+	struct ds_iv_ns		*ci_iv_ns;
+	crt_group_t		*ci_iv_group;
+
+	d_rank_list_t		*ci_ranks;
+
+	ABT_thread		 ci_sched;
+	ABT_rwlock		 ci_abt_lock;
+	ABT_mutex		 ci_abt_mutex;
+	ABT_cond		 ci_abt_cond;
+
+	/* Generator for report event, pending repair actions, and so on. Only for leader. */
+	uint64_t		 ci_seq;
+
+	uint32_t		 ci_all_pools:1, /* Check all pools or not. */
+				 ci_is_leader:1,
+				 ci_sched_running:1,
+				 ci_starting:1,
+				 ci_stopping:1,
+				 ci_started:1,
+				 ci_implicated:1;
+};
+
+struct chk_iv {
+	uint64_t		 ci_gen;
+	d_rank_t		 ci_rank;
+	uint32_t		 ci_phase;
+	uint32_t		 ci_status;
+	uint32_t		 ci_to_leader:1;
+};
+
+/* Check engine uses it to trace pools. Query logic uses it to organize the result. */
+struct chk_pool_shard {
+	/* Link into chk_pool_rec::cpr_shard_list. */
+	d_list_t		 cps_link;
+	d_rank_t		 cps_rank;
+	void			*cps_data;
+};
+
+/* Check engine uses it to trace pools. Query logic uses it to organize the result. */
+struct chk_pool_rec {
+	/* Link into chk_instance::ci_pool_list. */
+	d_list_t		 cpr_link;
+	/* The list of chk_pool_shard. */
+	d_list_t		 cpr_shard_list;
+	uint32_t		 cpr_shard_nr;
+	uint32_t		 cpr_svc_started:1;
+	uint32_t		 cpr_phase;
+	uuid_t			 cpr_uuid;
+	ABT_thread		 cpr_thread;
+	struct chk_bookmark	 cpr_bk;
+	struct chk_instance	*cpr_ins;
+};
+
+struct chk_pending_rec {
+	/* Link into chk_instance::ci_pending_list. */
+	d_list_t		 cpr_ins_link;
+	/* Link into chk_rank_rec::crr_pending_list. */
+	d_list_t		 cpr_rank_link;
+	uint64_t		 cpr_seq;
+	d_rank_t		 cpr_rank;
+	uint32_t		 cpr_class;
+	uint32_t		 cpr_action;
+	uint32_t		 cpr_busy:1,
+				 cpr_exiting:1,
+				 cpr_on_leader:1;
+	ABT_mutex		 cpr_mutex;
+	ABT_cond		 cpr_cond;
+};
+
+typedef int (*chk_co_rpc_cb_t)(void *args, uint32_t rank, uint32_t phase, int result,
+			       void *data, uint32_t nr);
+
+extern struct crt_proto_format	chk_proto_fmt;
+
+extern struct crt_corpc_ops	chk_start_co_ops;
+extern struct crt_corpc_ops	chk_stop_co_ops;
+extern struct crt_corpc_ops	chk_query_co_ops;
+extern struct crt_corpc_ops	chk_mark_co_ops;
+extern struct crt_corpc_ops	chk_act_co_ops;
+
+extern btr_ops_t		chk_pool_ops;
+extern btr_ops_t		chk_pending_ops;
+extern btr_ops_t		chk_rank_ops;
+
+/* chk_common.c */
+
+void chk_ranks_dump(uint32_t rank_nr, d_rank_t *ranks);
+
+void chk_ranks_dump_by_bitmap(uint32_t rank_nr, uint32_t max, uint8_t *bitmap);
+
+void chk_pools_dump(uint32_t pool_nr, uuid_t pools[]);
+
+int chk_bitmap2ranklist(uint32_t rank_nr, d_rank_t max_rank, uint8_t *bitmap,
+			d_rank_list_t **rlist);
+
+void chk_stop_sched(struct chk_instance *ins);
+
+int chk_prop_prepare(uint32_t rank_nr, d_rank_t *ranks, uint32_t policy_nr,
+		     struct chk_policy **policies, uint32_t pool_nr, uuid_t pools[],
+		     uint32_t flags, int phase, d_rank_t leader,
+		     struct chk_property *prop, d_rank_list_t **rlist);
+
+int chk_pool_add_shard(daos_handle_t hdl, d_list_t *head, uuid_t uuid, d_rank_t rank,
+		       uint32_t phase, struct chk_bookmark *bk, struct chk_instance *ins,
+		       uint32_t *shard_nr, void *data);
+
+int chk_pool_del_shard(daos_handle_t hdl, uuid_t pool, d_rank_t rank);
+
+int chk_pending_add(struct chk_instance *ins, d_list_t *rank_head, uint64_t seq,
+		    uint32_t rank, uint32_t cla, struct chk_pending_rec **cpr);
+
+int chk_pending_del(struct chk_instance *ins, uint64_t seq, struct chk_pending_rec **cpr);
+
+void chk_pending_destroy(struct chk_pending_rec *cpr);
+
+int chk_ins_init(struct chk_instance *ins);
+
+void chk_ins_fini(struct chk_instance *ins);
+
+/* chk_engine.c */
+
+int chk_engine_start(uint64_t gen, uint32_t rank_nr, d_rank_t *ranks,
+		     uint32_t policy_nr, struct chk_policy **policies, uint32_t pool_nr,
+		     uuid_t pools[], uint32_t flags, int32_t exp_phase, d_rank_t leader,
+		     uint32_t *cur_phase, struct ds_pool_clues *clues);
+
+int chk_engine_stop(uint64_t gen, uint32_t pool_nr, uuid_t pools[]);
+
+int chk_engine_query(uint64_t gen, uint32_t pool_nr, uuid_t pools[],
+		     uint32_t *shard_nr, struct chk_query_pool_shard **shards);
+
+int chk_engine_mark_rank_dead(uint64_t gen, d_rank_t rank, uint32_t version);
+
+int chk_engine_act(uint64_t gen, uint64_t seq, uint32_t cla, uint32_t act, uint32_t flags);
+
+int chk_engine_notify(uint64_t gen, d_rank_t rank, uint32_t phase, uint32_t status);
+
+void chk_engine_rejoin(void);
+
+void chk_engine_pause(void);
+
+int chk_engine_init(void);
+
+void chk_engine_fini(void);
+
+/* chk_iv.c */
+
+int chk_iv_update(void *ns, struct chk_iv *iv, uint32_t shortcut, uint32_t sync_mode, bool retry);
+
+int chk_iv_init(void);
+
+int chk_iv_fini(void);
+
+/* chk_leader.c */
+
+int chk_leader_report(uint64_t gen, uint32_t cla, uint32_t act, int32_t result, d_rank_t rank,
+		      uint32_t target, uuid_t *pool, uuid_t *cont, daos_unit_oid_t *obj,
+		      daos_key_t *dkey, daos_key_t *akey, char *msg, uint32_t option_nr,
+		      uint32_t *options, uint32_t detail_nr, d_sg_list_t *details, bool local,
+		      uint64_t *seq);
+
+int chk_leader_notify(uint64_t gen, d_rank_t rank, uint32_t phase, uint32_t status);
+
+int chk_leader_rejoin(uint64_t gen, d_rank_t rank, uint32_t phase);
+
+void chk_leader_pause(void);
+
+int chk_leader_init(void);
+
+void chk_leader_fini(void);
+
+/* chk_rpc.c */
+
+int chk_start_remote(d_rank_list_t *rank_list, uint64_t gen, uint32_t rank_nr, d_rank_t *ranks,
+		     uint32_t policy_nr, struct chk_policy **policies, uint32_t pool_nr,
+		     uuid_t pools[], uint32_t flags, int32_t phase, d_rank_t leader,
+		     chk_co_rpc_cb_t start_cb, void *args);
+
+int chk_stop_remote(d_rank_list_t *rank_list, uint64_t gen, uint32_t pool_nr, uuid_t pools[],
+		    chk_co_rpc_cb_t stop_cb, void *args);
+
+int chk_query_remote(d_rank_list_t *rank_list, uint64_t gen, uint32_t pool_nr, uuid_t pools[],
+		     chk_co_rpc_cb_t query_cb, void *args);
+
+int chk_mark_remote(d_rank_list_t *rank_list, uint64_t gen, d_rank_t rank, uint32_t version);
+
+int chk_act_remote(d_rank_list_t *rank_list, uint64_t gen, uint64_t seq, uint32_t cla,
+		   uint32_t act, d_rank_t rank, bool for_all);
+
+int chk_report_remote(d_rank_t leader, uint64_t gen, uint32_t cla, uint32_t act, int32_t result,
+		      d_rank_t rank, uint32_t target, char *pool, char *cont, daos_unit_oid_t *obj,
+		      daos_key_t *dkey, daos_key_t *akey, char *msg, uint32_t option_nr,
+		      uint32_t *options, uint32_t detail_nr, d_sg_list_t *details, uint64_t *seq);
+
+int chk_rejoin_remote(d_rank_t leader, uint64_t gen, d_rank_t rank, uint32_t phase);
+
+/* chk_updcall.c */
+
+int chk_report_upcall(uint64_t gen, uint64_t seq, uint32_t cla, uint32_t act, int32_t result,
+		      d_rank_t rank, uint32_t target, uuid_t *pool, uuid_t *cont,
+		      daos_unit_oid_t *obj, daos_key_t *dkey, daos_key_t *akey, char *msg,
+		      uint32_t option_nr, uint32_t *options, uint32_t detail_nr,
+		      d_sg_list_t *details);
+
+/* chk_vos.c */
+
+int chk_bk_fetch_leader(struct chk_bookmark *cbk);
+
+int chk_bk_update_leader(struct chk_bookmark *cbk);
+
+int chk_bk_delete_leader(void);
+
+int chk_bk_fetch_engine(struct chk_bookmark *cbk);
+
+int chk_bk_update_engine(struct chk_bookmark *cbk);
+
+int chk_bk_delete_engine(void);
+
+int chk_bk_fetch_pool(struct chk_bookmark *cbk, uuid_t uuid);
+
+int chk_bk_update_pool(struct chk_bookmark *cbk, uuid_t uuid);
+
+int chk_bk_delete_pool(uuid_t uuid);
+
+int chk_prop_fetch(struct chk_property *cpp, d_rank_list_t **rank_list);
+
+int chk_prop_update(struct chk_property *cpp, d_rank_list_t *rank_list);
+
+int chk_traverse_pools(sys_db_trav_cb_t cb, void *args);
+
+void chk_vos_init(void);
+
+void chk_vos_fini(void);
+
+static inline bool
+chk_rank_in_list(d_rank_list_t *rlist, d_rank_t rank)
+{
+	int	i;
+	bool	found = false;
+
+	/* XXX: if the rank list is sorted, then we can search more efficiently. */
+
+	for (i = 0; i < rlist->rl_nr; i++) {
+		if (rlist->rl_ranks[i] == rank) {
+			found = true;
+			break;
+		}
+	}
+
+	return found;
+}
+
+static inline bool
+chk_remove_rank_from_list(d_rank_list_t *rlist, d_rank_t rank)
+{
+	int	i;
+	bool	found = false;
+
+	/* XXX: if the rank list is sorted, then we can search more efficiently. */
+
+	for (i = 0; i < rlist->rl_nr; i++) {
+		if (rlist->rl_ranks[i] == rank) {
+			found = true;
+			rlist->rl_nr--;
+			/* The leader rank will always be in the rank list. */
+			D_ASSERT(rlist->rl_nr > 0);
+
+			if (i < rlist->rl_nr)
+				memmove(&rlist->rl_ranks[i], &rlist->rl_ranks[i + 1],
+					rlist->rl_nr - i);
+			break;
+		}
+	}
+
+	return found;
+}
+
+static inline void
+chk_query_free(struct chk_query_pool_shard *shards, uint32_t shard_nr)
+{
+	int	i;
+
+	for (i = 0; i < shard_nr; i++)
+		D_FREE(shards[i].cqps_targets);
+
+	D_FREE(shards);
+}
 
 #endif /* __CHK_INTERNAL_H__ */

--- a/src/chk/chk_iv.c
+++ b/src/chk/chk_iv.c
@@ -1,0 +1,223 @@
+/**
+ * (C) Copyright 2022 Intel Corporation.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause-Patent
+ */
+
+#define D_LOGFAC	DD_FAC(chk)
+
+#include <gurt/list.h>
+#include <gurt/debug.h>
+#include <cart/iv.h>
+#include <daos_srv/iv.h>
+#include <daos_srv/daos_engine.h>
+
+#include "chk_internal.h"
+
+static int
+chk_iv_alloc_internal(d_sg_list_t *sgl)
+{
+	int	rc;
+
+	rc = d_sgl_init(sgl, 1);
+	if (rc != 0)
+		return rc;
+
+	D_ALLOC(sgl->sg_iovs[0].iov_buf, sizeof(struct chk_iv));
+	if (sgl->sg_iovs[0].iov_buf == NULL) {
+		d_sgl_fini(sgl, true);
+		return -DER_NOMEM;
+	}
+
+	sgl->sg_iovs[0].iov_buf_len = sizeof(struct chk_iv);
+	sgl->sg_iovs[0].iov_len = sizeof(struct chk_iv);
+
+	return 0;
+}
+
+static int
+chk_iv_ent_init(struct ds_iv_key *iv_key, void *data, struct ds_iv_entry *entry)
+{
+	int	rc;
+
+	rc = chk_iv_alloc_internal(&entry->iv_value);
+	if (rc == 0) {
+		entry->iv_key.class_id = iv_key->class_id;
+		entry->iv_key.rank = iv_key->rank;
+	}
+
+	return rc;
+}
+
+static int
+chk_iv_ent_get(struct ds_iv_entry *entry, void **priv)
+{
+	return 0;
+}
+
+static int
+chk_iv_ent_put(struct ds_iv_entry *entry, void **priv)
+{
+	return 0;
+}
+
+static int
+chk_iv_ent_destroy(d_sg_list_t *sgl)
+{
+	d_sgl_fini(sgl, true);
+
+	return 0;
+}
+
+static int
+chk_iv_ent_fetch(struct ds_iv_entry *entry, struct ds_iv_key *key, d_sg_list_t *dst, void **priv)
+{
+	D_ASSERT(0);
+
+	return 0;
+}
+
+/* Update the chk pool svc lists and status from engine to leader. */
+static int
+chk_iv_ent_update(struct ds_iv_entry *entry, struct ds_iv_key *key,
+		  d_sg_list_t *src, void **priv)
+{
+	struct chk_iv	*dst_iv = entry->iv_value.sg_iovs[0].iov_buf;
+	struct chk_iv	*src_iv = src->sg_iovs[0].iov_buf;
+	int		 rc;
+
+	if (!src_iv->ci_to_leader)
+		return -DER_IVCB_FORWARD;
+
+	if (dst_iv->ci_gen == 0)
+		goto update;
+
+	if (unlikely(dst_iv->ci_gen != src_iv->ci_gen)) {
+		D_WARN("Receive invalid update IV message: "DF_X64" vs "DF_X64"\n",
+		       dst_iv->ci_gen, src_iv->ci_gen);
+		return 0;
+	}
+
+	if (dst_iv->ci_phase < src_iv->ci_phase)
+		goto update;
+
+	/* Old IV update message. */
+	if (dst_iv->ci_phase > src_iv->ci_phase)
+		return 0;
+
+update:
+	dst_iv->ci_gen = src_iv->ci_gen;
+	dst_iv->ci_rank = src_iv->ci_rank;
+	dst_iv->ci_phase = src_iv->ci_phase;
+	dst_iv->ci_status = src_iv->ci_status;
+
+	rc = chk_leader_notify(dst_iv->ci_gen, dst_iv->ci_rank, dst_iv->ci_phase,
+			       dst_iv->ci_status);
+
+	D_CDEBUG(rc != 0, DLOG_ERR, DLOG_INFO,
+		 "Handled CHK IV update with gen "DF_X64", rank %u, phase %u, status %d: "DF_RC"\n",
+		 src_iv->ci_gen, src_iv->ci_rank, src_iv->ci_phase, src_iv->ci_status, DP_RC(rc));
+
+	return rc;
+}
+
+/* Refresh the chk status from leader to engines. */
+static int
+chk_iv_ent_refresh(struct ds_iv_entry *entry, struct ds_iv_key *key,
+		   d_sg_list_t *src, int ref_rc, void **priv)
+{
+	struct chk_iv	*dst_iv = entry->iv_value.sg_iovs[0].iov_buf;
+	struct chk_iv	*src_iv = src->sg_iovs[0].iov_buf;
+	int		 rc;
+
+	D_ASSERT(src_iv->ci_to_leader == 0);
+
+	if (dst_iv->ci_gen == 0)
+		goto refresh;
+
+	if (unlikely(dst_iv->ci_gen != src_iv->ci_gen)) {
+		D_WARN("Receive invalid refresh IV message: "DF_X64" vs "DF_X64"\n",
+		       dst_iv->ci_gen, src_iv->ci_gen);
+		return 0;
+	}
+
+	if (dst_iv->ci_phase < src_iv->ci_phase)
+		goto refresh;
+
+	/* Old IV refresh message. */
+	if (dst_iv->ci_phase > src_iv->ci_phase)
+		return 0;
+
+	/* Repeated IV refresh message. */
+	if (dst_iv->ci_status == src_iv->ci_status)
+		return 0;
+
+refresh:
+	dst_iv->ci_gen = src_iv->ci_gen;
+	dst_iv->ci_rank = src_iv->ci_rank;
+	dst_iv->ci_phase = src_iv->ci_phase;
+	dst_iv->ci_status = src_iv->ci_status;
+
+	rc = chk_engine_notify(dst_iv->ci_gen, dst_iv->ci_rank, dst_iv->ci_phase,
+			       dst_iv->ci_status);
+
+	D_CDEBUG(rc != 0, DLOG_ERR, DLOG_INFO,
+		 "Handled CHK IV refresh with gen "DF_X64", phase %u, status %d: "DF_RC"\n",
+		 src_iv->ci_gen, src_iv->ci_phase, src_iv->ci_status, DP_RC(rc));
+
+	return rc;
+}
+
+static int
+chk_iv_value_alloc(struct ds_iv_entry *entry, struct ds_iv_key *key, d_sg_list_t *sgl)
+{
+	return chk_iv_alloc_internal(sgl);
+}
+
+struct ds_iv_class_ops chk_iv_ops = {
+	.ivc_ent_init		= chk_iv_ent_init,
+	.ivc_ent_get		= chk_iv_ent_get,
+	.ivc_ent_put		= chk_iv_ent_put,
+	.ivc_ent_destroy	= chk_iv_ent_destroy,
+	.ivc_ent_fetch		= chk_iv_ent_fetch,
+	.ivc_ent_update		= chk_iv_ent_update,
+	.ivc_ent_refresh	= chk_iv_ent_refresh,
+	.ivc_value_alloc	= chk_iv_value_alloc,
+};
+
+int
+chk_iv_update(void *ns, struct chk_iv *iv, uint32_t shortcut, uint32_t sync_mode, bool retry)
+{
+	d_sg_list_t		sgl;
+	d_iov_t			iov;
+	struct ds_iv_key	key;
+	int			rc;
+
+	iv->ci_rank = dss_self_rank();
+	iov.iov_buf = iv;
+	iov.iov_len = sizeof(*iv);
+	iov.iov_buf_len = sizeof(*iv);
+	sgl.sg_nr = 1;
+	sgl.sg_nr_out = 0;
+	sgl.sg_iovs = &iov;
+
+	memset(&key, 0, sizeof(key));
+	key.class_id = IV_CHK;
+	rc = ds_iv_update(ns, &key, &sgl, shortcut, sync_mode, 0, retry);
+	if (rc != 0)
+		D_ERROR("CHK iv update failed: "DF_RC"\n", DP_RC(rc));
+
+	return rc;
+}
+
+int
+chk_iv_init(void)
+{
+	return ds_iv_class_register(IV_CHK, &iv_cache_ops, &chk_iv_ops);
+}
+
+int
+chk_iv_fini(void)
+{
+	return ds_iv_class_unregister(IV_CHK);
+}

--- a/src/chk/chk_leader.c
+++ b/src/chk/chk_leader.c
@@ -1,0 +1,1239 @@
+/**
+ * (C) Copyright 2022 Intel Corporation.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause-Patent
+ */
+
+#define D_LOGFAC	DD_FAC(chk)
+
+#include <time.h>
+#include <cart/api.h>
+#include <daos/btree.h>
+#include <daos/btree_class.h>
+#include <daos_srv/daos_engine.h>
+#include <daos_srv/daos_chk.h>
+#include <daos_srv/vos.h>
+#include <daos_srv/iv.h>
+
+#include "chk.pb-c.h"
+#include "chk_internal.h"
+
+static struct chk_instance	*chk_leader;
+
+struct chk_sched_args {
+	struct chk_instance	*csa_ins;
+	struct btr_root		 csa_btr;
+	daos_handle_t		 csa_hdl;
+	d_list_t		 csa_list;
+	uint32_t		 csa_count;
+	uint32_t		 csa_refs;
+};
+
+static struct chk_sched_args *
+chk_csa_alloc(struct chk_instance *ins)
+{
+	struct umem_attr	 uma = { 0 };
+	struct chk_sched_args	*csa;
+	int			 rc;
+
+	D_ALLOC_PTR(csa);
+	if (csa == NULL)
+		goto out;
+
+	D_INIT_LIST_HEAD(&csa->csa_list);
+	csa->csa_refs = 1;
+	csa->csa_ins = ins;
+
+	uma.uma_id = UMEM_CLASS_VMEM;
+	rc = dbtree_create_inplace(DBTREE_CLASS_CHK_POOL, 0, CHK_BTREE_ORDER, &uma,
+				   &csa->csa_btr, &csa->csa_hdl);
+	if (rc != 0)
+		D_FREE(csa);
+
+out:
+	return csa;
+}
+
+static inline void
+chk_csa_get(struct chk_sched_args *csa)
+{
+	csa->csa_refs++;
+}
+
+static inline void
+chk_csa_put(struct chk_sched_args *csa)
+{
+	if (csa != NULL) {
+		csa->csa_refs--;
+		if (csa->csa_refs == 0) {
+			dbtree_destroy(csa->csa_hdl, NULL);
+			D_FREE(csa);
+		}
+	}
+}
+
+struct chk_rank_rec {
+	/* Link into chk_instance::ci_rank_list. */
+	d_list_t		 crr_link;
+	/* The list of chk_pending_rec. */
+	d_list_t		 crr_pending_list;
+	d_rank_t		 crr_rank;
+	uint32_t		 crr_phase;
+	struct chk_instance	*crr_ins;
+};
+
+struct chk_rank_bundle {
+	d_rank_t		 crb_rank;
+	uint32_t		 crb_phase;
+	struct chk_instance	*crb_ins;
+};
+
+static int
+chk_rank_hkey_size(void)
+{
+	return sizeof(d_rank_t);
+}
+
+static void
+chk_rank_hkey_gen(struct btr_instance *tins, d_iov_t *key_iov, void *hkey)
+{
+	D_ASSERT(key_iov->iov_len == sizeof(d_rank_t));
+
+	memcpy(hkey, key_iov->iov_buf, key_iov->iov_len);
+}
+
+static int
+chk_rank_alloc(struct btr_instance *tins, d_iov_t *key_iov, d_iov_t *val_iov,
+	       struct btr_record *rec, d_iov_t *val_out)
+{
+	struct chk_rank_bundle	*crb = val_iov->iov_buf;
+	struct chk_rank_rec	*crr;
+	int			 rc = 0;
+
+	D_ASSERT(crb != NULL);
+
+	D_ALLOC_PTR(crr);
+	if (crr == NULL)
+		D_GOTO(out, rc = -DER_NOMEM);
+
+	D_INIT_LIST_HEAD(&crr->crr_pending_list);
+	crr->crr_rank = crb->crb_rank;
+	crr->crr_phase = crb->crb_phase;
+	crr->crr_ins = crb->crb_ins;
+
+	rec->rec_off = umem_ptr2off(&tins->ti_umm, crr);
+	d_list_add_tail(&crr->crr_link, &crb->crb_ins->ci_rank_list);
+
+out:
+	return rc;
+}
+
+static int
+chk_rank_free(struct btr_instance *tins, struct btr_record *rec, void *args)
+{
+	struct chk_rank_rec	*crr;
+	struct chk_pending_rec	*cpr;
+	struct chk_pending_rec	*tmp;
+	struct chk_instance	*ins;
+	d_iov_t			 kiov;
+	uint64_t		 seq;
+	int			 rc = 0;
+	int			 rc1 = 0;
+
+	crr = (struct chk_rank_rec *)umem_off2ptr(&tins->ti_umm, rec->rec_off);
+	rec->rec_off = UMOFF_NULL;
+	ins = crr->crr_ins;
+
+	ABT_rwlock_wrlock(ins->ci_abt_lock);
+	/* Cleanup all pending records belong to this rank. */
+	d_list_for_each_entry_safe(cpr, tmp, &crr->crr_pending_list, cpr_rank_link) {
+		ABT_mutex_lock(cpr->cpr_mutex);
+		if (cpr->cpr_busy) {
+			cpr->cpr_exiting = 1;
+			ABT_cond_broadcast(cpr->cpr_cond);
+			ABT_mutex_unlock(cpr->cpr_mutex);
+		} else {
+			ABT_mutex_unlock(cpr->cpr_mutex);
+			/* Copy the seq to avoid accessing free DRAM after dbtree_delete. */
+			seq = cpr->cpr_seq;
+			d_iov_set(&kiov, &seq, sizeof(cpr->cpr_seq));
+			rc1 = dbtree_delete(ins->ci_pending_hdl, BTR_PROBE_EQ, &kiov, NULL);
+			if (unlikely(rc1 != 0)) {
+				D_ERROR("Failed to remove pending rec for rank %u, seq "
+					DF_X64", gen "DF_X64": "DF_RC"\n",
+					crr->crr_rank, seq, ins->ci_bk.cb_gen, DP_RC(rc1));
+				if (rc == 0)
+					rc = rc1;
+			}
+		}
+	}
+	ABT_rwlock_unlock(ins->ci_abt_lock);
+
+	d_list_del(&crr->crr_link);
+	D_FREE(crr);
+
+	return rc;
+}
+
+static int
+chk_rank_fetch(struct btr_instance *tins, struct btr_record *rec,
+	       d_iov_t *key_iov, d_iov_t *val_iov)
+{
+	struct chk_rank_rec	*crr;
+
+	D_ASSERT(val_iov != NULL);
+
+	crr = umem_off2ptr(&tins->ti_umm, rec->rec_off);
+	d_iov_set(val_iov, crr, sizeof(*crr));
+
+	return 0;
+}
+
+static int
+chk_rank_update(struct btr_instance *tins, struct btr_record *rec,
+		d_iov_t *key, d_iov_t *val, d_iov_t *val_out)
+{
+	struct chk_rank_bundle  *crb = val->iov_buf;
+	struct chk_rank_rec	*crr;
+
+	crr = (struct chk_rank_rec *)umem_off2ptr(&tins->ti_umm, rec->rec_off);
+	crr->crr_phase = crb->crb_phase;
+
+	return 0;
+}
+
+btr_ops_t chk_rank_ops = {
+	.to_hkey_size	= chk_rank_hkey_size,
+	.to_hkey_gen	= chk_rank_hkey_gen,
+	.to_rec_alloc	= chk_rank_alloc,
+	.to_rec_free	= chk_rank_free,
+	.to_rec_fetch	= chk_rank_fetch,
+	.to_rec_update  = chk_rank_update,
+};
+
+static void
+chk_leader_exit(struct chk_instance *ins, uint32_t status, bool bcast)
+{
+	struct chk_bookmark	*cbk = &ins->ci_bk;
+	struct chk_iv		 iv;
+	int			 rc = 0;
+
+	if ((bcast && status == CHK__CHECK_INST_STATUS__CIS_FAILED) ||
+	    status == CHK__CHECK_INST_STATUS__CIS_IMPLICATED) {
+		iv.ci_gen = cbk->cb_gen;
+		iv.ci_phase = cbk->cb_phase;
+		iv.ci_status = status;
+
+		/* Asynchronously notify the engines that the check leader exit. */
+		rc = chk_iv_update(ins->ci_iv_ns, &iv, CRT_IV_SHORTCUT_NONE,
+				   CRT_IV_SYNC_LAZY, true);
+		if (rc != 0)
+			D_ERROR("Check leader (gen "DF_X64") failed to notify the engines "
+				"its exit, status %u: "DF_RC"\n", cbk->cb_gen, status, DP_RC(rc));
+	}
+
+	ABT_rwlock_wrlock(ins->ci_abt_lock);
+	rc = dbtree_destroy(ins->ci_pending_hdl, NULL);
+	ABT_rwlock_unlock(ins->ci_abt_lock);
+	if (rc != 0)
+		D_ERROR("Check leader (gen "DF_X64") failed to destroy pending record tree, "
+			"status %u: "DF_RC"\n", cbk->cb_gen, status, DP_RC(rc));
+
+	rc = dbtree_destroy(ins->ci_rank_hdl, NULL);
+	if (rc != 0)
+		D_ERROR("Check leader (gen "DF_X64") failed to destroy rank tree, "
+			"status %u: "DF_RC"\n", cbk->cb_gen, status, DP_RC(rc));
+
+	if (cbk->cb_ins_status == CHK__CHECK_INST_STATUS__CIS_RUNNING) {
+		cbk->cb_ins_status = status;
+		cbk->cb_time.ct_stop_time = time(NULL);
+		rc = chk_bk_update_leader(cbk);
+		if (rc != 0)
+			D_ERROR("Check leader (gen "DF_X64") exit with status %u: "DF_RC"\n",
+				cbk->cb_gen, status, DP_RC(rc));
+	}
+}
+
+static uint32_t
+chk_leader_find_slowest(struct chk_instance *ins)
+{
+	uint32_t		 phase = CHK__CHECK_SCAN_PHASE__DSP_DONE;
+	uint32_t		 base = ins->ci_bk.cb_phase;
+	struct chk_rank_rec	*crr;
+
+	d_list_for_each_entry(crr, &ins->ci_rank_list, crr_link) {
+		if (crr->crr_phase <= base) {
+			phase = crr->crr_phase;
+			break;
+		}
+
+		if (crr->crr_phase < phase)
+			phase = crr->crr_phase;
+	}
+
+	return phase;
+}
+
+static int
+chk_leader_handle_pools(struct chk_sched_args *csa)
+{
+	struct chk_list_pool	*clp = NULL;
+	int			 clp_nr;
+	int			 rc = 0;
+
+	clp_nr = ds_chk_listpool_upcall(&clp);
+	if (clp_nr < 0) {
+		rc = clp_nr;
+		clp_nr = 0;
+		goto out;
+	}
+
+	/* TBD: elect the proper PS replica with Liwei's patch. */
+
+out:
+	ds_chk_free_pool_list(clp, clp_nr);
+	return rc;
+}
+
+static void
+chk_leader_sched(void *args)
+{
+	struct chk_sched_args	*csa = args;
+	struct chk_instance	*ins = csa->csa_ins;
+	struct chk_bookmark	*cbk = &ins->ci_bk;
+	uint32_t		 phase;
+	uint32_t		 status;
+	int			 rc = 0;
+	bool			 bcast = false;
+
+	ABT_mutex_lock(ins->ci_abt_mutex);
+
+again:
+	if (!ins->ci_sched_running) {
+		ABT_mutex_unlock(ins->ci_abt_mutex);
+		D_GOTO(out, rc = 0);
+	}
+
+	if (ins->ci_started) {
+		ABT_mutex_unlock(ins->ci_abt_mutex);
+		goto handle;
+	}
+
+	ABT_cond_wait(ins->ci_abt_cond, ins->ci_abt_mutex);
+
+	goto again;
+
+handle:
+	phase = chk_leader_find_slowest(ins);
+	if (phase == CHK__CHECK_SCAN_PHASE__CSP_PREPARE ||
+	    phase == CHK__CHECK_SCAN_PHASE__CSP_POOL_LIST) {
+		rc = chk_leader_handle_pools(csa);
+		if (rc != 0)
+			D_GOTO(out, bcast = true);
+	}
+
+	while (ins->ci_sched_running) {
+		dss_sleep(300);
+
+		/* Someone wants to stop the check. */
+		if (!ins->ci_sched_running)
+			D_GOTO(out, rc = 0);
+
+		phase = chk_leader_find_slowest(ins);
+		if (phase != cbk->cb_phase) {
+			cbk->cb_phase = phase;
+			/* XXX: How to estimate the lfet time? */
+			cbk->cb_time.ct_left_time = CHK__CHECK_SCAN_PHASE__DSP_DONE - cbk->cb_phase;
+			rc = chk_bk_update_leader(cbk);
+			if (rc != 0) {
+				D_ERROR("Check leader (gen "DF_X64") failed to move phase to %u: "
+					DF_RC"\n", cbk->cb_gen, cbk->cb_phase, DP_RC(rc));
+
+				/* If it is not the complete phase, then we can retry next time. */
+				if (phase == CHK__CHECK_SCAN_PHASE__DSP_DONE)
+					goto out;
+			}
+		}
+	}
+
+out:
+	if (rc > 0) {
+		/* If some engine(s) failed during the check, then mark the instance as 'failed'. */
+		if (ins->ci_slowest_fail_phase != CHK__CHECK_SCAN_PHASE__CSP_PREPARE)
+			status = CHK__CHECK_INST_STATUS__CIS_FAILED;
+		else
+			status = CHK__CHECK_INST_STATUS__CIS_COMPLETED;
+	} else if (rc == 0) {
+		if (ins->ci_implicated)
+			status = CHK__CHECK_INST_STATUS__CIS_IMPLICATED;
+		else if (ins->ci_stopping)
+			status = CHK__CHECK_INST_STATUS__CIS_STOPPED;
+		else
+			status = CHK__CHECK_INST_STATUS__CIS_PAUSED;
+	} else {
+		status = CHK__CHECK_INST_STATUS__CIS_FAILED;
+	}
+
+	chk_leader_exit(ins, status, bcast);
+	chk_csa_put(csa);
+
+	D_INFO("Check leader (gen "DF_X64") exit at the phase %u: "DF_RC"\n",
+	       cbk->cb_gen, cbk->cb_phase, DP_RC(rc));
+}
+
+static int
+chk_leader_start_prepare(struct chk_instance *ins, uint32_t rank_nr, d_rank_t *ranks,
+			 uint32_t policy_nr, struct chk_policy **policies,
+			 uint32_t pool_nr, uuid_t pools[], int phase,
+			 uint32_t *flags, d_rank_list_t **rlist)
+{
+	struct chk_property	*prop = &ins->ci_prop;
+	struct chk_bookmark	*cbk = &ins->ci_bk;
+	int			 rc = 0;
+	int			 i;
+	int			 j;
+
+	/*
+	 * XXX: Consider the following scenario:
+	 *
+	 *	1. Start check on pool_A and pool_B: dmg check start -p pool_A -p pool_B
+	 *	2. Before the check done, we stop the check, at the time, pool_A's check is in
+	 *	   the phase_A, pool_B's is in the phase_B: dmg check stop
+	 *	3. Sometime later, we restart the check for the pool_A: dmg start -p pool_A
+	 *	   That will resume the check from the phase_A for the pool_A.
+	 *	4. When the check for pool_A is done, the check is marked as 'completed' although
+	 *	   pool_B is not full checked.
+	 *	5. Then we restart the check on the pool_B: dmg start -p pool_B
+	 *	   The expected behavior is to resume the check from the phase_B for the pool_B,
+	 *	   but because we trace the check engine process via single bookmark, the real
+	 *	   action is re-check pool_B from the beginning. That will waste some of former
+	 *	   check work on the pool_B.
+	 *
+	 *	Let's optimize above scenario in next step.
+	 */
+
+	if (ins->ci_sched_running)
+		D_GOTO(out, rc = -DER_ALREADY);
+
+	/* Corrupted bookmark or new created one. Nothing can be reused. */
+	if (cbk->cb_magic != CHK_BK_MAGIC_LEADER) {
+		memset(prop, 0, sizeof(*prop));
+		memset(cbk, 0, sizeof(*cbk));
+		cbk->cb_magic = CHK_BK_MAGIC_LEADER;
+		cbk->cb_version = DAOS_CHK_VERSION;
+		*flags |= CHK__CHECK_FLAG__CF_RESET;
+		goto init;
+	}
+
+	if (cbk->cb_ins_status == CHK__CHECK_INST_STATUS__CIS_RUNNING)
+		D_GOTO(out, rc = -DER_ALREADY);
+
+	if (*flags & CHK__CHECK_FLAG__CF_RESET)
+		goto init;
+
+	/* Former instance is done, restart from the beginning. */
+	if (cbk->cb_ins_status == CHK__CHECK_INST_STATUS__CIS_COMPLETED) {
+		*flags |= CHK__CHECK_FLAG__CF_RESET;
+		goto init;
+	}
+
+	if (cbk->cb_phase == CHK__CHECK_SCAN_PHASE__CSP_PREPARE) {
+		*flags |= CHK__CHECK_FLAG__CF_RESET;
+		goto init;
+	}
+
+	/* Drop dryrun flags needs to reset. */
+	if (prop->cp_flags & CHK__CHECK_FLAG__CF_DRYRUN && !(*flags & CHK__CHECK_FLAG__CF_DRYRUN)) {
+		*flags |= CHK__CHECK_FLAG__CF_RESET;
+		goto init;
+	}
+
+	/*
+	 * XXX: If current rank list does not matches the former list, the we need to
+	 *	reset the check from scratch. Currently, we do not strictly check that.
+	 *	It is control plane's duty to generate valid rank list.
+	 */
+
+	/* Add new rank(s), need to reset. */
+	if (rank_nr > prop->cp_rank_nr) {
+		*flags |= CHK__CHECK_FLAG__CF_RESET;
+		goto init;
+	}
+
+	if (prop->cp_pool_nr < 0)
+		goto init;
+
+	/* Want to check new pool(s), need to reset. */
+	if (pool_nr < 0) {
+		*flags |= CHK__CHECK_FLAG__CF_RESET;
+		goto init;
+	}
+
+	for (i = 0; i < pool_nr; i++) {
+		for (j = 0; j < prop->cp_pool_nr; j++) {
+			if (uuid_compare(pools[i], prop->cp_pools[j]) == 0)
+				break;
+		}
+
+		/* Want to check new pool(s), need to reset. */
+		if (j == prop->cp_pool_nr) {
+			*flags |= CHK__CHECK_FLAG__CF_RESET;
+			goto init;
+		}
+	}
+
+init:
+	rc = chk_prop_prepare(rank_nr, ranks, policy_nr, policies, pool_nr, pools,
+			      *flags, phase, dss_self_rank(), prop, rlist);
+	if (rc == 0 && *flags & CHK__CHECK_FLAG__CF_RESET) {
+		/* New generation for reset case. */
+		cbk->cb_gen = crt_hlc_get();
+		cbk->cb_phase = CHK__CHECK_SCAN_PHASE__CSP_PREPARE;
+		memset(&cbk->cb_statistics, 0, sizeof(cbk->cb_statistics));
+	}
+
+out:
+	return rc;
+}
+
+static int
+chk_leader_start_cb(void *args, uint32_t rank, uint32_t phase, int result, void *data, uint32_t nr)
+{
+	struct chk_sched_args	*csa = args;
+	struct ds_pool_clue	*clues = data;
+	d_iov_t			 kiov;
+	int			 rc = 0;
+	int			 i;
+
+	D_ASSERTF(result >= 0, "Unexpected result for start CB %d\n", result);
+
+	/* The engine has completed the check, remove it from the rank list. */
+	if (result > 0) {
+		d_iov_set(&kiov, &rank, sizeof(d_rank_t));
+		rc = dbtree_delete(csa->csa_ins->ci_rank_hdl, BTR_PROBE_EQ, &kiov, NULL);
+		goto out;
+	}
+
+	for (i = 0; i < nr; i++) {
+		rc = chk_pool_add_shard(csa->csa_hdl, &csa->csa_list, clues[i].pc_uuid,
+					clues[i].pc_rank, 0, NULL, csa->csa_ins, NULL,
+					clues[i].pc_svc_clue);
+		if (rc != 0)
+			goto out;
+	}
+
+out:
+	if (rc != 0)
+		D_ERROR("Check leader (gen "DF_X64") failed to handle start CB with ranks %u "
+			"phase %d, result %d: "DF_RC"\n",
+			csa->csa_ins->ci_bk.cb_gen, rank, phase, result, DP_RC(rc));
+
+	return rc;
+}
+
+int
+chk_leader_start(uint32_t rank_nr, d_rank_t *ranks,
+		 uint32_t policy_nr, struct chk_policy **policies,
+		 uint32_t pool_nr, uuid_t pools[], uint32_t flags, int32_t phase)
+{
+	struct chk_property	*prop = &chk_leader->ci_prop;
+	struct chk_bookmark	*cbk = &chk_leader->ci_bk;
+	d_rank_list_t		*rank_list = chk_leader->ci_ranks;
+	struct chk_sched_args	*csa = NULL;
+	struct chk_rank_bundle	 rbund = { 0 };
+	d_rank_t		 myrank = dss_self_rank();
+	d_iov_t			 riov;
+	d_iov_t			 kiov;
+	int			 rc;
+	int			 i;
+
+	if (chk_leader->ci_starting)
+		D_GOTO(out_log, rc = -DER_INPROGRESS);
+
+	if (chk_leader->ci_stopping)
+		D_GOTO(out_log, rc = -DER_BUSY);
+
+	chk_leader->ci_starting = 1;
+	chk_leader->ci_started = 0;
+
+	rc = chk_leader_start_prepare(chk_leader, rank_nr, ranks, policy_nr, policies,
+				      pool_nr, pools, phase, &flags, &rank_list);
+	if (rc != 0)
+		goto out_log;
+
+	D_ASSERT(rank_list != NULL);
+	D_ASSERT(d_list_empty(&chk_leader->ci_rank_list));
+	D_ASSERT(d_list_empty(&chk_leader->ci_pending_list));
+	D_ASSERT(chk_leader->ci_sched == ABT_THREAD_NULL);
+
+	d_rank_list_free(chk_leader->ci_ranks);
+	chk_leader->ci_ranks = rank_list;
+
+	if (chk_leader->ci_iv_ns != NULL) {
+		ds_iv_ns_put(chk_leader->ci_iv_ns);
+		chk_leader->ci_iv_ns = NULL;
+	}
+
+	if (chk_leader->ci_iv_group != NULL) {
+		crt_group_secondary_destroy(chk_leader->ci_iv_group);
+		chk_leader->ci_iv_group = NULL;
+	}
+
+	rc = crt_group_secondary_create(CHK_DUMMY_POOL, NULL, rank_list, &chk_leader->ci_iv_group);
+	if (rc != 0)
+		goto out_prep;
+
+	rc = ds_iv_ns_create(dss_get_module_info()->dmi_ctx, (unsigned char *)CHK_DUMMY_POOL,
+			     chk_leader->ci_iv_group, &chk_leader->ci_iv_id, &chk_leader->ci_iv_ns);
+	if (rc != 0)
+		goto out_group;
+
+	ds_iv_ns_update(chk_leader->ci_iv_ns, myrank);
+
+	for (i = 0; i < rank_list->rl_nr; i++) {
+		rbund.crb_rank = rank_list->rl_ranks[i];
+		rbund.crb_phase = cbk->cb_phase;
+		rbund.crb_ins = chk_leader;
+
+		d_iov_set(&riov, &rbund, sizeof(rbund));
+		d_iov_set(&kiov, &rank_list->rl_ranks[i], sizeof(d_rank_t));
+		rc = dbtree_upsert(chk_leader->ci_rank_hdl, BTR_PROBE_EQ, DAOS_INTENT_UPDATE,
+				   &kiov, &riov, NULL);
+		if (rc != 0)
+			goto out_rank;
+	}
+
+	/* Always refresh the start time. */
+	cbk->cb_time.ct_start_time = time(NULL);
+	/* XXX: How to estimate the lfet time? */
+	cbk->cb_time.ct_left_time = CHK__CHECK_SCAN_PHASE__DSP_DONE - cbk->cb_phase;
+	cbk->cb_ins_status = CHK__CHECK_INST_STATUS__CIS_RUNNING;
+	rc = chk_bk_update_leader(cbk);
+	if (rc != 0)
+		goto out_rank;
+
+	csa = chk_csa_alloc(chk_leader);
+	if (csa == NULL)
+		D_GOTO(out_bk, rc = -DER_NOMEM);
+
+	/* Take another reference for RPC. */
+	chk_csa_get(csa);
+
+	chk_leader->ci_sched_running = 1;
+
+	rc = dss_ult_create(chk_leader_sched, csa, DSS_XS_SYS, 0, DSS_DEEP_STACK_SZ,
+			    &chk_leader->ci_sched);
+	if (rc != 0) {
+		chk_csa_put(csa);
+		goto out_csa;
+	}
+
+	rc = chk_start_remote(rank_list, cbk->cb_gen, rank_nr, ranks, policy_nr, policies,
+			      pool_nr, pools, flags, phase, myrank, chk_leader_start_cb, csa);
+	if (rc != 0)
+		goto out_sched;
+
+	/* Drop the reference for RPC. */
+	chk_csa_put(csa);
+
+	ABT_mutex_lock(chk_leader->ci_abt_mutex);
+	chk_leader->ci_started = 1;
+	ABT_cond_broadcast(chk_leader->ci_abt_cond);
+	ABT_mutex_unlock(chk_leader->ci_abt_mutex);
+
+	goto out_log;
+
+out_sched:
+	chk_stop_sched(chk_leader);
+out_csa:
+	chk_csa_put(csa);
+out_bk:
+	if (rc != -DER_ALREADY && cbk->cb_ins_status == CHK__CHECK_INST_STATUS__CIS_RUNNING) {
+		cbk->cb_time.ct_stop_time = time(NULL);
+		cbk->cb_ins_status = CHK__CHECK_INST_STATUS__CIS_FAILED;
+		chk_bk_update_leader(cbk);
+	}
+out_rank:
+	dbtree_destroy(chk_leader->ci_rank_hdl, NULL);
+	chk_leader->ci_rank_hdl = DAOS_HDL_INVAL;
+	ds_iv_ns_put(chk_leader->ci_iv_ns);
+	chk_leader->ci_iv_ns = NULL;
+out_group:
+	crt_group_secondary_destroy(chk_leader->ci_iv_group);
+	chk_leader->ci_iv_group = NULL;
+out_prep:
+	d_rank_list_free(chk_leader->ci_ranks);
+	chk_leader->ci_ranks = NULL;
+	prop->cp_rank_nr = 0;
+out_log:
+	chk_leader->ci_starting = 0;
+
+	if (rc == 0) {
+		D_INFO("Leader %s check on %u ranks for %u pools with "
+		       "flags %x, phase %d, leader %u, gen "DF_X64"\n",
+		       (flags & CHK__CHECK_FLAG__CF_RESET) ? "start" : "restart",
+		       rank_nr, pool_nr, flags, phase, myrank, cbk->cb_gen);
+
+		chk_ranks_dump(chk_leader->ci_ranks->rl_nr, chk_leader->ci_ranks->rl_ranks);
+
+		if (pool_nr > 0)
+			chk_pools_dump(pool_nr, pools);
+		else if (prop->cp_pool_nr > 0)
+			chk_pools_dump(prop->cp_pool_nr, prop->cp_pools);
+	} else if (rc != -DER_ALREADY) {
+		D_ERROR("Leader failed to start check on %u ranks for %u pools with "
+			"flags %x, phase %d, leader %u, gen "DF_X64": "DF_RC"\n",
+			rank_nr, pool_nr, flags, phase, myrank, cbk->cb_gen, DP_RC(rc));
+	}
+
+	return rc;
+}
+
+static int
+chk_leader_stop_cb(void *args, uint32_t rank, uint32_t phase, int result, void *data, uint32_t nr)
+{
+	struct chk_instance	*ins = args;
+	d_iov_t			 kiov;
+	int			 rc;
+
+	D_ASSERTF(result > 0, "Unexpected result for stop CB %d\n", result);
+
+	/* The engine has stop on the rank, remove it from the rank list. */
+	d_iov_set(&kiov, &rank, sizeof(d_rank_t));
+	rc = dbtree_delete(ins->ci_rank_hdl, BTR_PROBE_EQ, &kiov, NULL);
+	if (rc != 0)
+		D_ERROR("Check leader (gen "DF_X64") failed to handle stop CB with ranks %u: "
+			DF_RC"\n", ins->ci_bk.cb_gen, rank, DP_RC(rc));
+
+	return rc;
+}
+
+int
+chk_leader_stop(uint32_t pool_nr, uuid_t pools[])
+{
+	struct chk_property	*prop = &chk_leader->ci_prop;
+	struct chk_bookmark	*cbk = &chk_leader->ci_bk;
+	d_rank_list_t		*ranks = NULL;
+	int			 rc = 0;
+
+	if (chk_leader->ci_starting)
+		D_GOTO(out, rc = -DER_BUSY);
+
+	if (chk_leader->ci_stopping)
+		D_GOTO(out, rc = -DER_INPROGRESS);
+
+	/*
+	 * XXX: It is possible that the check leader is dead. If we want to stop the stale
+	 *	check instance on other engines, then we may execute the CHK_STOP from new
+	 *	check leader. But if the old leader is still active, but the CHK_STOP dRPC
+	 *	is sent to non-leader (or new leader), then it will cause trouble.
+	 *
+	 *	Here, it is not easy to know whether the old leader is still valid or not.
+	 *	We have to trust control plane. It is the control plane duty to guarantee
+	 *	that the CHK_STOP dRPC is sent to the right one.
+	 */
+
+	chk_leader->ci_stopping = 1;
+
+	/*
+	 * The check instance on current engine may have failed or stopped, but we do not know
+	 * whether there is active check instance on other engines or not, send stop RPC anyway.
+	 */
+
+	if (chk_leader->ci_ranks == NULL) {
+		rc = chk_prop_fetch(&chk_leader->ci_prop, &chk_leader->ci_ranks);
+		/* We do not know the rank list, the sponsor needs to choose another leader. */
+		if (rc == -DER_NONEXIST)
+			D_GOTO(out, rc = -DER_NOTLEADER);
+
+		if (rc != 0)
+			goto out;
+
+		if (unlikely(chk_leader->ci_ranks == NULL))
+			D_GOTO(out, rc = -DER_NOTLEADER);
+	}
+
+	rc = chk_stop_remote(ranks, cbk->cb_gen, pool_nr, pools, chk_leader_stop_cb, chk_leader);
+	if (rc != 0)
+		goto out;
+
+	if (cbk->cb_ins_status == CHK__CHECK_INST_STATUS__CIS_RUNNING &&
+	    d_list_empty(&chk_leader->ci_rank_list))
+		chk_stop_sched(chk_leader);
+
+out:
+	chk_leader->ci_stopping = 0;
+
+	if (rc == 0) {
+		D_INFO("Leader stopped check with gen "DF_X64" for %u pools\n",
+		       cbk->cb_gen, pool_nr > 0 ? pool_nr : prop->cp_pool_nr);
+
+		if (pool_nr > 0)
+			chk_pools_dump(pool_nr, pools);
+		else if (prop->cp_pool_nr > 0)
+			chk_pools_dump(prop->cp_pool_nr, prop->cp_pools);
+	} else {
+		D_ERROR("Leader failed to stop check with gen "DF_X64" for %u pools: "DF_RC"\n",
+			cbk->cb_gen, pool_nr > 0 ? pool_nr : prop->cp_pool_nr, DP_RC(rc));
+	}
+
+	return rc;
+}
+
+static int
+chk_leader_query_cb(void *args, uint32_t rank, uint32_t phase, int result, void *data, uint32_t nr)
+{
+	struct chk_sched_args		*csa = args;
+	struct chk_query_pool_shard	*shards = data;
+	int				 rc = 0;
+	int				 i;
+
+	D_ASSERTF(result == 0, "Unexpected result for query CB %d\n", result);
+
+	for (i = 0; i < nr; i++) {
+		rc = chk_pool_add_shard(csa->csa_hdl, &csa->csa_list, shards[i].cqps_uuid,
+					shards[i].cqps_rank, shards[i].cqps_phase, NULL,
+					csa->csa_ins, &csa->csa_count, &shards[i]);
+		if (rc != 0)
+			goto out;
+	}
+
+out:
+	if (rc != 0)
+		D_ERROR("Check leader (gen "DF_X64") failed to handle query CB with ranks %u "
+			"phase %d, result %d: "DF_RC"\n",
+			csa->csa_ins->ci_bk.cb_gen, rank, phase, result, DP_RC(rc));
+
+	return rc;
+}
+
+int
+chk_leader_query(uint32_t pool_nr, uuid_t pools[], chk_query_head_cb_t head_cb,
+		 chk_query_pool_cb_t pool_cb, void *buf)
+{
+	struct chk_bookmark	*cbk = &chk_leader->ci_bk;
+	struct chk_sched_args	*csa = NULL;
+	struct chk_pool_rec	*cpr;
+	struct chk_pool_shard	*cps;
+	uint32_t		 idx = 0;
+	int			 rc;
+
+	/*
+	 * XXX: Similar as stop case, we need the ability to query check information from
+	 *	new leader if the old one dead. But the information from new leader may be
+	 *	not very accurate. It is the control plane duty to send the CHK_QUERY dRPC
+	 *	to the right one.
+	 */
+
+	if (chk_leader->ci_ranks == NULL) {
+		rc = chk_prop_fetch(&chk_leader->ci_prop, &chk_leader->ci_ranks);
+		/* We do not know the rank list, the sponsor needs to choose another leader. */
+		if (rc == -DER_NONEXIST)
+			D_GOTO(out, rc = -DER_NOTLEADER);
+
+		if (rc != 0)
+			goto out;
+
+		if (unlikely(chk_leader->ci_ranks == NULL))
+			D_GOTO(out, rc = -DER_NOTLEADER);
+	}
+
+	csa = chk_csa_alloc(chk_leader);
+	if (csa == NULL)
+		D_GOTO(out, rc = -DER_NOMEM);
+
+	rc = chk_query_remote(chk_leader->ci_ranks, chk_leader->ci_bk.cb_gen, pool_nr,
+			      pools, chk_leader_query_cb, csa);
+	if (rc != 0)
+		goto out;
+
+	rc = head_cb(cbk->cb_ins_status, cbk->cb_phase, &cbk->cb_statistics, &cbk->cb_time,
+		     csa->csa_count, buf);
+	if (rc != 0)
+		goto out;
+
+	d_list_for_each_entry(cpr, &csa->csa_list, cpr_link) {
+		d_list_for_each_entry(cps, &cpr->cpr_shard_list, cps_link) {
+			rc = pool_cb(cps->cps_data, idx++, buf);
+			if (rc != 0)
+				goto out;
+
+			D_ASSERT(csa->csa_count >= idx);
+		}
+	}
+out:
+	chk_csa_put(csa);
+	D_CDEBUG(rc != 0, DLOG_ERR, DLOG_INFO,
+		 "Leader query check with gen "DF_X64" for %u pools: "DF_RC"\n",
+		 cbk->cb_gen, pool_nr, DP_RC(rc));
+	return rc;
+}
+
+int
+chk_leader_prop(chk_prop_cb_t prop_cb, void *buf)
+{
+	struct chk_property	*prop = &chk_leader->ci_prop;
+
+	return prop_cb(buf, (struct chk_policy **)&prop->cp_policies,
+		       CHK_POLICY_MAX - 1, prop->cp_flags);
+}
+
+static void
+chk_leader_mark_rank_dead(d_rank_t rank, uint64_t incarnation, enum crt_event_source src,
+			  enum crt_event_type type, void *arg)
+{
+	struct chk_property	*prop = &chk_leader->ci_prop;
+	struct chk_bookmark	*cbk = &chk_leader->ci_bk;
+	d_iov_t			 kiov;
+	uint32_t		 version = cbk->cb_gen - prop->cp_rank_nr - 1;
+	int			 rc = 0;
+
+	/* Ignore the event that is not applicable to current rank. */
+
+	if (src != CRT_EVS_SWIM || type != CRT_EVT_DEAD)
+		D_GOTO(out, rc = -DER_NOTAPPLICABLE);
+
+	if (cbk->cb_magic != CHK_BK_MAGIC_LEADER ||
+	    cbk->cb_ins_status != CHK__CHECK_INST_STATUS__CIS_RUNNING)
+		D_GOTO(out, rc = -DER_NOTAPPLICABLE);
+
+	if (!chk_remove_rank_from_list(chk_leader->ci_ranks, rank))
+		D_GOTO(out, rc = -DER_NOTAPPLICABLE);
+
+	prop->cp_rank_nr--;
+	rc = chk_prop_update(prop, chk_leader->ci_ranks);
+	if (rc != 0)
+		goto out;
+
+	rc = crt_group_secondary_modify(chk_leader->ci_iv_group, chk_leader->ci_ranks,
+					chk_leader->ci_ranks, CRT_GROUP_MOD_OP_REPLACE, version);
+	if (rc != 0)
+		goto out;
+
+	d_iov_set(&kiov, &rank, sizeof(rank));
+	rc = dbtree_delete(chk_leader->ci_rank_hdl, BTR_PROBE_EQ, &kiov, NULL);
+	if (rc != 0)
+		goto out;
+
+	/* The dead one is the last one, then stop the scheduler. */
+	if (d_list_empty(&chk_leader->ci_rank_list))
+		chk_stop_sched(chk_leader);
+	else
+		rc = chk_mark_remote(chk_leader->ci_ranks, cbk->cb_gen, rank, version);
+
+out:
+	if (rc != -DER_NOTAPPLICABLE)
+		D_CDEBUG(rc != 0, DLOG_ERR, DLOG_INFO,
+			 "Check Leader (gen "DF_X64") mark rank %u as dead with version %u: "
+			 DF_RC"\n", cbk->cb_gen, rank, version, DP_RC(rc));
+}
+
+int
+chk_leader_act(uint64_t seq, uint32_t act, bool for_all)
+{
+	struct chk_bookmark	*cbk = &chk_leader->ci_bk;
+	struct chk_pending_rec	*cpr = NULL;
+	int			 rc;
+
+	if (cbk->cb_magic != CHK_BK_MAGIC_LEADER)
+		D_GOTO(out, rc = -DER_NOTLEADER);
+
+	/* Tell control plane that no check instance is running via "-DER_NOTAPPLICABLE". */
+	if (cbk->cb_ins_status != CHK__CHECK_INST_STATUS__CIS_RUNNING)
+		D_GOTO(out, rc = -DER_NOTAPPLICABLE);
+
+	/* The admin may input the wrong option, not acceptable. */
+	if (unlikely(act == CHK__CHECK_INCONSIST_ACTION__CIA_INTERACT)) {
+		D_ERROR("%u is not acceptable for interaction decision.\n", act);
+		D_GOTO(out, rc = -DER_INVAL);
+	}
+
+	rc = chk_pending_del(chk_leader, seq, &cpr);
+	if (rc != 0)
+		goto out;
+
+	D_ASSERT(cpr->cpr_busy == 1);
+
+	if (cpr->cpr_on_leader) {
+		ABT_mutex_lock(cpr->cpr_mutex);
+		cpr->cpr_action = act;
+		ABT_cond_broadcast(cpr->cpr_cond);
+		ABT_mutex_unlock(cpr->cpr_mutex);
+	}
+
+	if (!cpr->cpr_on_leader || for_all) {
+		rc = chk_act_remote(chk_leader->ci_ranks, cbk->cb_gen, seq,
+				    cpr->cpr_class, act, cpr->cpr_rank, for_all);
+		if (rc != 0)
+			goto out;
+	}
+
+out:
+	if (cpr != NULL && !cpr->cpr_on_leader)
+		chk_pending_destroy(cpr);
+
+	D_CDEBUG(rc != 0, DLOG_ERR, DLOG_INFO,
+		 "Check leader (gen "DF_X64") takes action for report with seq "
+		 DF_X64", action %u, flags %s: "DF_RC"\n",
+		 cbk->cb_gen, seq, act, for_all ? "all" : "once", DP_RC(rc));
+
+	return rc;
+
+}
+
+int
+chk_leader_report(uint64_t gen, uint32_t cla, uint32_t act, int32_t result, d_rank_t rank,
+		  uint32_t target, uuid_t *pool, uuid_t *cont, daos_unit_oid_t *obj,
+		  daos_key_t *dkey, daos_key_t *akey, char *msg, uint32_t option_nr,
+		  uint32_t *options, uint32_t detail_nr, d_sg_list_t *details, bool local,
+		  uint64_t *seq)
+{
+	struct chk_bookmark	*cbk = &chk_leader->ci_bk;
+	struct chk_pending_rec	*cpr = NULL;
+	int			 rc;
+
+	if (cbk->cb_magic != CHK_BK_MAGIC_LEADER)
+		D_GOTO(out, rc = -DER_NOTLEADER);
+
+	/* Tell check engine that check leader is not running via "-DER_NOTAPPLICABLE". */
+	if (cbk->cb_ins_status != CHK__CHECK_INST_STATUS__CIS_RUNNING)
+		D_GOTO(out, rc = -DER_NOTAPPLICABLE);
+
+	*seq = ++chk_leader->ci_seq;
+
+	if (act == CHK__CHECK_INCONSIST_ACTION__CIA_INTERACT) {
+		rc = chk_pending_add(chk_leader, &chk_leader->ci_pending_list, *seq,
+				     rank, cla, &cpr);
+		if (rc != 0)
+			goto log;
+	}
+
+	rc = chk_report_upcall(gen, *seq, cla, act, result, rank, target, pool, cont, obj,
+			       dkey, akey, msg, option_nr, options, detail_nr, details);
+
+log:
+	if (rc != 0) {
+		D_ERROR("Check leader (gen "DF_X64") failed to handle %s report from rank %u with "
+			"seq "DF_X64", class %u, action %u, result %d: "DF_RC"\n", cbk->cb_gen,
+			local ? "local" : "remote", rank, *seq, cla, act, result, DP_RC(rc));
+		goto out;
+	}
+
+	D_CDEBUG(act == CHK__CHECK_INCONSIST_ACTION__CIA_INTERACT, DLOG_INFO, DLOG_DBG,
+		 "Check leader (gen "DF_X64") handle %s report from rank %u with seq "
+		 DF_X64" class %u, action %u, result %d: "DF_RC"\n",
+		 cbk->cb_gen, local ? "local" : "remote", rank, *seq, cla, act, result, DP_RC(rc));
+
+	if (!local || cpr == NULL)
+		goto out;
+
+	D_ASSERT(cpr->cpr_busy == 1);
+
+	ABT_mutex_lock(cpr->cpr_mutex);
+	if (cpr->cpr_action != CHK__CHECK_INCONSIST_ACTION__CIA_INTERACT) {
+		ABT_mutex_unlock(cpr->cpr_mutex);
+		goto handle;
+	}
+
+	ABT_cond_wait(cpr->cpr_cond, cpr->cpr_mutex);
+	ABT_mutex_unlock(cpr->cpr_mutex);
+	if (!chk_leader->ci_sched_running || cpr->cpr_exiting)
+		goto out;
+
+	D_ASSERT(cpr->cpr_action != CHK__CHECK_INCONSIST_ACTION__CIA_INTERACT);
+
+handle:
+
+	/* TBD: already got the interaction feedback, handle it and log the result. */
+
+out:
+	if (cpr != NULL)
+		chk_pending_destroy(cpr);
+
+	return rc;
+}
+
+int
+chk_leader_notify(uint64_t gen, d_rank_t rank, uint32_t phase, uint32_t status)
+{
+	struct chk_property	*prop = &chk_leader->ci_prop;
+	struct chk_bookmark	*cbk = &chk_leader->ci_bk;
+	struct chk_rank_bundle	 rbund = { 0 };
+	d_iov_t			 kiov;
+	d_iov_t			 riov;
+	int			 rc = 0;
+
+	/* Ignore the notification that is not applicable to current rank. */
+
+	if (cbk->cb_magic != CHK_BK_MAGIC_LEADER ||
+	    cbk->cb_ins_status != CHK__CHECK_INST_STATUS__CIS_RUNNING)
+		D_GOTO(out, rc = -DER_NOTAPPLICABLE);
+
+	if (cbk->cb_gen != gen)
+		D_GOTO(out, rc = -DER_NOTAPPLICABLE);
+
+	if (cbk->cb_ins_status != CHK__CHECK_INST_STATUS__CIS_RUNNING)
+		D_GOTO(out, rc = -DER_NOTAPPLICABLE);
+
+	switch (status) {
+	case CHK__CHECK_INST_STATUS__CIS_INIT:
+	case CHK__CHECK_INST_STATUS__CIS_STOPPED:
+	case CHK__CHECK_INST_STATUS__CIS_PAUSED:
+	case CHK__CHECK_INST_STATUS__CIS_IMPLICATED:
+		/* Directly ignore above. */
+		break;
+	case CHK__CHECK_INST_STATUS__CIS_RUNNING:
+		if (unlikely(phase < cbk->cb_phase))
+			D_GOTO(out, rc = -DER_INVAL);
+
+		if (phase == cbk->cb_phase)
+			D_GOTO(out, rc = 0);
+
+		rbund.crb_rank = rank;
+		rbund.crb_phase = phase;
+		rbund.crb_ins = chk_leader;
+
+		d_iov_set(&riov, &rbund, sizeof(rbund));
+		d_iov_set(&kiov, &rank, sizeof(rank));
+		rc = dbtree_upsert(chk_leader->ci_rank_hdl, BTR_PROBE_EQ, DAOS_INTENT_UPDATE,
+				   &kiov, &riov, NULL);
+		break;
+	case CHK__CHECK_INST_STATUS__CIS_COMPLETED:
+		/*
+		 * XXX: Currently, we do not support to partial check till the specified phase.
+		 *	Then the completed phase will be either container cleanup or all done.
+		 */
+		if (unlikely(phase != CHK__CHECK_SCAN_PHASE__CSP_CONT_CLEANUP &&
+			     phase != CHK__CHECK_SCAN_PHASE__DSP_DONE))
+			D_GOTO(out, rc = -DER_INVAL);
+
+		d_iov_set(&kiov, &rank, sizeof(rank));
+		rc = dbtree_delete(chk_leader->ci_pending_hdl, BTR_PROBE_EQ, &kiov, NULL);
+		if (rc == -DER_NONEXIST)
+			rc = 0;
+		break;
+	case CHK__CHECK_INST_STATUS__CIS_FAILED:
+		if (chk_leader->ci_slowest_fail_phase > phase)
+			chk_leader->ci_slowest_fail_phase = phase;
+
+		d_iov_set(&kiov, &rank, sizeof(rank));
+		rc = dbtree_delete(chk_leader->ci_pending_hdl, BTR_PROBE_EQ, &kiov, NULL);
+		if (rc != 0 || !(prop->cp_flags & CHK__CHECK_FLAG__CF_FAILOUT))
+			D_GOTO(out, rc = (rc == -DER_NONEXIST ? 0 : rc));
+
+		chk_leader->ci_implicated = 1;
+		chk_stop_sched(chk_leader);
+		break;
+	default:
+		rc = -DER_INVAL;
+		break;
+	}
+
+out:
+	if (rc != -DER_NOTAPPLICABLE)
+		D_CDEBUG(rc != 0, DLOG_ERR, DLOG_INFO,
+			 "Check leader (gen "DF_X64") handle notification from rank %u, phase %u, "
+			 "status %u: "DF_RC"\n", cbk->cb_gen, rank, phase, status, DP_RC(rc));
+
+	return (rc == 0 || rc == -DER_NOTAPPLICABLE) ? 0 : rc;
+}
+
+int
+chk_leader_rejoin(uint64_t gen, d_rank_t rank, uint32_t phase)
+{
+	struct chk_bookmark	*cbk = &chk_leader->ci_bk;
+	int			 rc = 0;
+
+	if (cbk->cb_magic != CHK_BK_MAGIC_LEADER)
+		D_GOTO(out, rc = -DER_NOTLEADER);
+
+	if (cbk->cb_gen != gen)
+		D_GOTO(out, rc = -DER_STALE);
+
+	if (cbk->cb_ins_status != CHK__CHECK_INST_STATUS__CIS_RUNNING)
+		D_GOTO(out, rc = -DER_SHUTDOWN);
+
+	/* The rank has been excluded from (or never been part of) the check instance. */
+	if (!chk_rank_in_list(chk_leader->ci_ranks, rank))
+		D_GOTO(out, rc = -DER_NO_PERM);
+
+out:
+	D_CDEBUG(rc != 0, DLOG_ERR, DLOG_INFO, "Check leader on rank %u rejoin with gen "
+		 DF_X64" (leader magic %u, gen "DF_X64", status %u): "DF_RC"\n",
+		 rank, gen, cbk->cb_magic, cbk->cb_gen, cbk->cb_ins_status, DP_RC(rc));
+
+	return rc;
+}
+
+void
+chk_leader_pause(void)
+{
+	chk_stop_sched(chk_leader);
+	D_ASSERT(d_list_empty(&chk_leader->ci_pending_list));
+	D_ASSERT(d_list_empty(&chk_leader->ci_rank_list));
+}
+
+int
+chk_leader_init(void)
+{
+	struct chk_bookmark	*cbk;
+	int			 rc;
+
+	D_ALLOC(chk_leader, sizeof(*chk_leader));
+	if (chk_leader == NULL)
+		D_GOTO(out, rc = -DER_NOMEM);
+
+	chk_leader->ci_is_leader = 1;
+	rc = chk_ins_init(chk_leader);
+	if (rc != 0)
+		goto free;
+
+	/*
+	 * XXX: DAOS global consistency check depends on all related engines' local
+	 *	consistency. If hit some local data corruption, then it is possible
+	 *	that local consistency is not guaranteed. Need to break and resolve
+	 *	related local inconsistency firstly.
+	 */
+
+	cbk = &chk_leader->ci_bk;
+	rc = chk_bk_fetch_leader(cbk);
+	if (rc == -DER_NONEXIST)
+		rc = 0;
+
+	/* It may be caused by local data corruption, let's break. */
+	if (rc != 0)
+		goto fini;
+
+	if (unlikely(cbk->cb_magic != CHK_BK_MAGIC_LEADER)) {
+		D_ERROR("Hit corrupted leader bookmark on rank %u: %u vs %u\n",
+			dss_self_rank(), cbk->cb_magic, CHK_BK_MAGIC_LEADER);
+		D_GOTO(fini, rc = -DER_IO);
+	}
+
+	rc = chk_prop_fetch(&chk_leader->ci_prop, &chk_leader->ci_ranks);
+	if (rc == -DER_NONEXIST)
+		rc = 0;
+
+	if (rc != 0)
+		goto fini;
+
+	rc = crt_register_event_cb(chk_leader_mark_rank_dead, NULL);
+	if (rc != 0)
+		goto fini;
+
+	goto out;
+
+fini:
+	chk_ins_fini(chk_leader);
+free:
+	D_FREE(chk_leader);
+out:
+	return rc;
+}
+
+void
+chk_leader_fini(void)
+{
+	crt_unregister_event_cb(chk_leader_mark_rank_dead, NULL);
+	chk_ins_fini(chk_leader);
+}

--- a/src/chk/chk_rpc.c
+++ b/src/chk/chk_rpc.c
@@ -1,0 +1,751 @@
+/**
+ * (C) Copyright 2022 Intel Corporation.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause-Patent
+ */
+
+#define D_LOGFAC	DD_FAC(chk)
+
+#include <daos/rpc.h>
+#include <daos/common.h>
+#include <daos_srv/pool.h>
+#include <daos_srv/daos_chk.h>
+
+#include "chk_internal.h"
+
+#define X(a, b, c, d, e)	\
+{				\
+	.prf_flags   = b,	\
+	.prf_req_fmt = c,	\
+	.prf_hdlr    = NULL,	\
+	.prf_co_ops  = NULL,	\
+}
+
+static struct crt_proto_rpc_format chk_proto_rpc_fmt[] = {
+	CHK_PROTO_SRV_RPC_LIST,
+};
+
+#undef X
+
+struct crt_proto_format chk_proto_fmt = {
+	.cpf_name  = "chk-proto",
+	.cpf_ver   = DAOS_CHK_VERSION,
+	.cpf_count = ARRAY_SIZE(chk_proto_rpc_fmt),
+	.cpf_prf   = chk_proto_rpc_fmt,
+	.cpf_base  = DAOS_RPC_OPCODE(0, DAOS_CHK_MODULE, 0)
+};
+
+struct chk_co_rpc_priv {
+	chk_co_rpc_cb_t	 cb;
+	void		*args;
+};
+
+static daos_unit_oid_t		chk_dummy_obj = { 0 };
+static daos_key_t		chk_dummy_key = { 0 };
+
+static int
+chk_start_aggregator(crt_rpc_t *source, crt_rpc_t *result, void *priv)
+{
+	struct chk_start_in	*in_source = crt_req_get(source);
+	struct chk_start_out	*out_source = crt_reply_get(source);
+	struct chk_start_out	*out_result = crt_reply_get(result);
+	struct chk_co_rpc_priv	*ccrp = priv;
+	int			 rc;
+
+	if (out_source->cso_status < 0) {
+		D_ERROR("Failed to check start with gen "DF_X64": "DF_RC"\n",
+			in_source->csi_gen, DP_RC(out_source->cso_status));
+
+		if (out_result->cso_status == 0)
+			out_result->cso_status = out_source->cso_status;
+	} else {
+		rc = ccrp->cb(ccrp->args, out_source->cso_rank, out_source->cso_phase,
+			      out_source->cso_status, out_result->cso_clues.ca_arrays,
+			      out_result->cso_clues.ca_count);
+		if (rc != 0 && out_result->cso_status == 0)
+			out_result->cso_status = rc;
+	}
+
+	return 0;
+}
+
+static int
+chk_stop_aggregator(crt_rpc_t *source, crt_rpc_t *result, void *priv)
+{
+	struct chk_stop_in	*in_source = crt_req_get(source);
+	struct chk_stop_out	*out_source = crt_reply_get(source);
+	struct chk_stop_out	*out_result = crt_reply_get(result);
+	struct chk_co_rpc_priv	*ccrp = priv;
+	int			 rc;
+
+	if (out_source->cso_status != 0) {
+		D_ERROR("Failed to check stop with gen "DF_X64": "DF_RC"\n",
+			in_source->csi_gen, DP_RC(out_source->cso_status));
+
+		if (out_result->cso_status == 0)
+			out_result->cso_status = out_source->cso_status;
+	} else if (ccrp->cb != NULL && out_source->cso_status > 0) {
+		rc = ccrp->cb(ccrp->args, out_source->cso_rank, 0, out_source->cso_status, NULL, 0);
+		if (rc != 0 && out_result->cso_status == 0)
+			out_result->cso_status = rc;
+	}
+
+	return 0;
+}
+
+static int
+chk_query_aggregator(crt_rpc_t *source, crt_rpc_t *result, void *priv)
+{
+	struct chk_query_in	*in_source = crt_req_get(source);
+	struct chk_query_out	*out_source = crt_reply_get(source);
+	struct chk_query_out	*out_result = crt_reply_get(result);
+	struct chk_co_rpc_priv	*ccrp = priv;
+	int			 rc;
+
+	if (out_source->cqo_status != 0) {
+		D_ERROR("Failed to check query rank dead with gen "DF_X64": "DF_RC"\n",
+			in_source->cqi_gen, DP_RC(out_source->cqo_status));
+
+		if (out_result->cqo_status == 0)
+			out_result->cqo_status = out_source->cqo_status;
+	} else {
+		rc = ccrp->cb(ccrp->args, 0, 0, out_source->cqo_status,
+			      out_result->cqo_shards.ca_arrays, out_result->cqo_shards.ca_count);
+		if (rc != 0 && out_result->cqo_status == 0)
+			out_result->cqo_status = rc;
+	}
+
+	return 0;
+}
+
+static int
+chk_mark_aggregator(crt_rpc_t *source, crt_rpc_t *result, void *priv)
+{
+	struct chk_mark_in	*in_source = crt_req_get(source);
+	struct chk_mark_out	*out_source = crt_reply_get(source);
+	struct chk_mark_out	*out_result = crt_reply_get(result);
+
+	if (out_source->cmo_status != 0) {
+		D_ERROR("Failed to check mark rank dead with gen "DF_X64": "DF_RC"\n",
+			in_source->cmi_gen, DP_RC(out_source->cmo_status));
+
+		if (out_result->cmo_status == 0)
+			out_result->cmo_status = out_source->cmo_status;
+	}
+
+	return 0;
+}
+
+static int
+chk_act_aggregator(crt_rpc_t *source, crt_rpc_t *result, void *priv)
+{
+	struct chk_act_in	*in_source = crt_req_get(source);
+	struct chk_act_out	*out_source = crt_reply_get(source);
+	struct chk_act_out	*out_result = crt_reply_get(result);
+
+	if (out_source->cao_status != 0) {
+		D_ERROR("Failed to check act with gen "DF_X64": "DF_RC"\n",
+			in_source->cai_gen, DP_RC(out_source->cao_status));
+
+		if (out_result->cao_status == 0)
+			out_result->cao_status = out_source->cao_status;
+	}
+
+	return 0;
+}
+
+struct crt_corpc_ops chk_start_co_ops = {
+	.co_aggregate	= chk_start_aggregator,
+	.co_pre_forward	= NULL,
+};
+
+struct crt_corpc_ops chk_stop_co_ops = {
+	.co_aggregate	= chk_stop_aggregator,
+	.co_pre_forward	= NULL,
+};
+
+struct crt_corpc_ops chk_query_co_ops = {
+	.co_aggregate	= chk_query_aggregator,
+	.co_pre_forward	= NULL,
+};
+
+struct crt_corpc_ops chk_mark_co_ops = {
+	.co_aggregate	= chk_mark_aggregator,
+	.co_pre_forward	= NULL,
+};
+
+struct crt_corpc_ops chk_act_co_ops = {
+	.co_aggregate	= chk_act_aggregator,
+	.co_pre_forward	= NULL,
+};
+
+static inline int
+chk_co_rpc_prepare(d_rank_list_t *rank_list, crt_opcode_t opc, struct chk_co_rpc_priv *priv,
+		   crt_rpc_t **req)
+{
+	int	topo;
+
+	topo = crt_tree_topo(CRT_TREE_KNOMIAL, 32);
+	opc = DAOS_RPC_OPCODE(opc, DAOS_CHK_MODULE, DAOS_CHK_VERSION);
+
+	return crt_corpc_req_create(dss_get_module_info()->dmi_ctx, NULL, rank_list, opc,
+				    NULL, priv, CRT_RPC_FLAG_FILTER_INVERT, topo, req);
+}
+
+static inline int
+chk_sg_rpc_prepare(d_rank_t rank, crt_opcode_t opc, crt_rpc_t **req)
+{
+	crt_endpoint_t	tgt_ep;
+
+	tgt_ep.ep_grp = NULL;
+	tgt_ep.ep_rank = rank;
+	tgt_ep.ep_tag = daos_rpc_tag(DAOS_REQ_CHK, 0);
+	opc = DAOS_RPC_OPCODE(opc, DAOS_CHK_MODULE, DAOS_CHK_VERSION);
+
+	return crt_req_create(dss_get_module_info()->dmi_ctx, &tgt_ep, opc, req);
+}
+
+int
+chk_start_remote(d_rank_list_t *rank_list, uint64_t gen, uint32_t rank_nr, d_rank_t *ranks,
+		 uint32_t policy_nr, struct chk_policy **policies, uint32_t pool_nr,
+		 uuid_t pools[], uint32_t flags, int32_t phase, d_rank_t leader,
+		 chk_co_rpc_cb_t start_cb, void *args)
+{
+	struct chk_co_rpc_priv	 ccrp;
+	crt_rpc_t		*req = NULL;
+	struct chk_start_in	*csi;
+	struct chk_start_out	*cso;
+	int			 rc;
+
+	ccrp.cb = start_cb;
+	ccrp.args = args;
+	rc = chk_co_rpc_prepare(rank_list, CHK_START, &ccrp, &req);
+	if (rc != 0)
+		goto out;
+
+	csi = crt_req_get(req);
+	csi->csi_gen = gen;
+	csi->csi_flags = flags;
+	csi->csi_phase = phase;
+	csi->csi_leader_rank = leader;
+	csi->csi_ranks.ca_count = rank_nr;
+	csi->csi_ranks.ca_arrays = ranks;
+	csi->csi_policies.ca_count = policy_nr;
+	csi->csi_policies.ca_arrays = (void *)policies;
+	csi->csi_uuids.ca_count = pool_nr;
+	csi->csi_uuids.ca_arrays = pools;
+
+	rc = dss_rpc_send(req);
+	if (rc != 0)
+		goto out;
+
+	cso = crt_reply_get(req);
+	rc = cso->cso_status;
+
+out:
+	if (rc < 0 && req != NULL)
+		chk_stop_remote(rank_list, gen, pool_nr, pools, NULL, NULL);
+
+	D_CDEBUG(rc != 0, DLOG_ERR, DLOG_INFO,
+		 "Rank %u start DAOS check with gen "DF_X64", flags %x, phase %u: "DF_RC"\n",
+		 leader, gen, flags, phase, DP_RC(rc));
+
+	return rc;
+}
+
+int
+chk_stop_remote(d_rank_list_t *rank_list, uint64_t gen, uint32_t pool_nr, uuid_t pools[],
+		chk_co_rpc_cb_t stop_cb, void *args)
+{
+	struct chk_co_rpc_priv	 ccrp;
+	crt_rpc_t		*req;
+	struct chk_stop_in	*csi;
+	struct chk_stop_out	*cso;
+	int			 rc;
+
+	ccrp.cb = stop_cb;
+	ccrp.args = args;
+	rc = chk_co_rpc_prepare(rank_list, CHK_STOP, &ccrp, &req);
+	if (rc != 0)
+		goto out;
+
+	csi = crt_req_get(req);
+	csi->csi_gen = gen;
+	csi->csi_uuids.ca_count = pool_nr;
+	csi->csi_uuids.ca_arrays = pools;
+
+	rc = dss_rpc_send(req);
+	if (rc != 0)
+		goto out;
+
+	cso = crt_reply_get(req);
+	rc = cso->cso_status;
+
+out:
+	D_CDEBUG(rc != 0, DLOG_ERR, DLOG_INFO,
+		 "Rank %u stop DAOS check with gen "DF_X64", pool_nr %u: "DF_RC"\n",
+		 dss_self_rank(), gen, pool_nr, DP_RC(rc));
+
+	return rc;
+}
+
+int
+chk_query_remote(d_rank_list_t *rank_list, uint64_t gen, uint32_t pool_nr, uuid_t pools[],
+		 chk_co_rpc_cb_t query_cb, void *args)
+{
+	struct chk_co_rpc_priv	 ccrp;
+	crt_rpc_t		*req;
+	struct chk_query_in	*cqi;
+	struct chk_query_out	*cqo;
+	int			 rc;
+
+	ccrp.cb = query_cb;
+	ccrp.args = args;
+	rc = chk_co_rpc_prepare(rank_list, CHK_QUERY, &ccrp, &req);
+	if (rc != 0)
+		goto out;
+
+	cqi = crt_req_get(req);
+	cqi->cqi_gen = gen;
+	cqi->cqi_uuids.ca_count = pool_nr;
+	cqi->cqi_uuids.ca_arrays = pools;
+
+	rc = dss_rpc_send(req);
+	if (rc != 0)
+		goto out;
+
+	cqo = crt_reply_get(req);
+	rc = cqo->cqo_status;
+
+out:
+	D_CDEBUG(rc != 0, DLOG_ERR, DLOG_INFO,
+		 "Rank %u query DAOS check with gen "DF_X64", pool_nr %u: "DF_RC"\n",
+		 dss_self_rank(), gen, pool_nr, DP_RC(rc));
+
+	return rc;
+}
+
+int
+chk_mark_remote(d_rank_list_t *rank_list, uint64_t gen, d_rank_t rank, uint32_t version)
+{
+	crt_rpc_t		*req;
+	struct chk_mark_in	*cmi;
+	struct chk_mark_out	*cmo;
+	int			 rc;
+
+	rc = chk_co_rpc_prepare(rank_list, CHK_MARK, NULL, &req);
+	if (rc != 0)
+		goto out;
+
+	cmi = crt_req_get(req);
+	cmi->cmi_gen = gen;
+	cmi->cmi_rank = rank;
+	cmi->cmi_version = version;
+
+	rc = dss_rpc_send(req);
+	if (rc != 0)
+		goto out;
+
+	cmo = crt_reply_get(req);
+	rc = cmo->cmo_status;
+
+out:
+	D_CDEBUG(rc != 0, DLOG_ERR, DLOG_INFO,
+		 "Rank %u as dead for DAOS check with gen "DF_X64": "DF_RC"\n",
+		 rank, gen, DP_RC(rc));
+
+	return rc;
+}
+
+int
+chk_act_remote(d_rank_list_t *rank_list, uint64_t gen, uint64_t seq, uint32_t cla,
+	       uint32_t act, d_rank_t rank, bool for_all)
+{
+	crt_rpc_t		*req;
+	struct chk_act_in	*cai;
+	struct chk_act_out	*cao;
+	int			 rc;
+
+	if (for_all)
+		rc = chk_co_rpc_prepare(rank_list, CHK_ACT, NULL, &req);
+	else
+		rc = chk_sg_rpc_prepare(rank, CHK_ACT, &req);
+
+	if (rc != 0)
+		goto out;
+
+	cai = crt_req_get(req);
+	cai->cai_gen = gen;
+	cai->cai_cla = cla;
+	cai->cai_act = act;
+	cai->cai_flags = for_all ? CAF_FOR_ALL : 0;
+
+	rc = dss_rpc_send(req);
+	if (rc != 0)
+		goto out;
+
+	cao = crt_reply_get(req);
+	rc = cao->cao_status;
+
+out:
+	D_CDEBUG(rc != 0, DLOG_ERR, DLOG_INFO,
+		 "Rank %u take action for DAOS check with gen "DF_X64", seq "DF_X64": "DF_RC"\n",
+		 rank, gen, seq, DP_RC(rc));
+
+	return rc;
+}
+
+int chk_report_remote(d_rank_t leader, uint64_t gen, uint32_t cla, uint32_t act, int32_t result,
+		      d_rank_t rank, uint32_t target, char *pool, char *cont, daos_unit_oid_t *obj,
+		      daos_key_t *dkey, daos_key_t *akey, char *msg, uint32_t option_nr,
+		      uint32_t *options, uint32_t detail_nr, d_sg_list_t *details, uint64_t *seq)
+{
+	crt_rpc_t		*req;
+	struct chk_report_in	*cri;
+	struct chk_report_out	*cro;
+	int			 rc;
+
+	rc = chk_sg_rpc_prepare(leader, CHK_REPORT, &req);
+	if (rc != 0)
+		goto out;
+
+	cri = crt_req_get(req);
+	cri->cri_gen = gen;
+	cri->cri_ics_class = cla;
+	cri->cri_ics_action = act;
+	cri->cri_ics_result = result;
+	cri->cri_rank = rank;
+	cri->cri_target = target;
+
+	uuid_copy(cri->cri_pool, pool != NULL ? (const unsigned char *)pool :
+		  (const unsigned char *)CHK_DUMMY_POOL);
+	uuid_copy(cri->cri_cont, cont != NULL ? (const unsigned char *)cont :
+		  (const unsigned char *)CHK_DUMMY_POOL);
+
+	if (obj != NULL)
+		cri->cri_obj = *obj;
+	else
+		cri->cri_obj = chk_dummy_obj;
+
+	if (dkey != NULL)
+		cri->cri_dkey = *dkey;
+	else
+		cri->cri_dkey = chk_dummy_key;
+
+	if (akey != NULL)
+		cri->cri_akey = *akey;
+	else
+		cri->cri_akey = chk_dummy_key;
+
+	cri->cri_msg = msg;
+	cri->cri_options.ca_count = option_nr;
+	cri->cri_options.ca_arrays = options;
+	cri->cri_details.ca_count = detail_nr;
+	cri->cri_details.ca_arrays = details;
+
+	rc = dss_rpc_send(req);
+	if (rc != 0)
+		goto out;
+
+	cro = crt_reply_get(req);
+	rc = cro->cro_status;
+	*seq = cro->cro_seq;
+
+out:
+	D_CDEBUG(rc != 0, DLOG_ERR, DLOG_INFO,
+		 "Rank %u report DAOS check to leader %u, gen "DF_X64", class %u, action %u, "
+		 "result %d, obj "DF_UOID", dkey "DF_KEY", akey "DF_KEY", msg %s, got seq "
+		 DF_X64": "DF_RC"\n", rank, leader, gen, cla, act, result,
+		 DP_UOID(obj != NULL ? *obj : chk_dummy_obj),
+		 DP_KEY(dkey != NULL ? dkey : &chk_dummy_key),
+		 DP_KEY(akey != NULL ? akey : &chk_dummy_key), msg, *seq, DP_RC(rc));
+
+	return rc;
+}
+
+int
+chk_rejoin_remote(d_rank_t leader, uint64_t gen, d_rank_t rank, uint32_t phase)
+{
+	crt_rpc_t		*req;
+	struct chk_rejoin_in	*cri;
+	struct chk_rejoin_out	*cro;
+	int			 rc;
+
+	rc = chk_sg_rpc_prepare(leader, CHK_REJOIN, &req);
+	if (rc != 0)
+		goto out;
+
+	cri = crt_req_get(req);
+	cri->cri_gen = gen;
+	cri->cri_rank = rank;
+	cri->cri_phase = phase;
+
+	rc = dss_rpc_send(req);
+	if (rc != 0)
+		goto out;
+
+	cro = crt_reply_get(req);
+	rc = cro->cro_status;
+
+out:
+	D_CDEBUG(rc != 0, DLOG_ERR, DLOG_INFO,
+		 "Rank %u rejoin DAOS check with leader %u, gen "DF_X64": "DF_RC"\n",
+		 rank, leader, gen, DP_RC(rc));
+
+	return rc;
+}
+
+static int
+crt_proc_daos_unit_oid_t(crt_proc_t proc, crt_proc_op_t proc_op, daos_unit_oid_t *p)
+{
+	return crt_proc_memcpy(proc, proc_op, p, sizeof(*p));
+}
+
+static int
+crt_proc_struct_chk_policy(crt_proc_t proc, crt_proc_op_t proc_op, struct chk_policy *policy)
+{
+	int	rc;
+
+	rc = crt_proc_uint32_t(proc, proc_op, &policy->cp_class);
+	if (unlikely(rc != 0))
+		return rc;
+
+	return crt_proc_uint32_t(proc, proc_op, &policy->cp_action);
+}
+
+static int
+crt_proc_struct_chk_time(crt_proc_t proc, crt_proc_op_t proc_op, struct chk_time *time)
+{
+	int	rc;
+
+	rc = crt_proc_uint64_t(proc, proc_op, &time->ct_start_time);
+	if (unlikely(rc != 0))
+		return rc;
+
+	return crt_proc_uint64_t(proc, proc_op, &time->ct_start_time);
+}
+
+static int
+crt_proc_struct_chk_statistics(crt_proc_t proc, crt_proc_op_t proc_op, struct chk_statistics *cs)
+{
+	int	rc;
+
+	rc = crt_proc_uint64_t(proc, proc_op, &cs->cs_total);
+	if (unlikely(rc != 0))
+		return rc;
+
+	rc = crt_proc_uint64_t(proc, proc_op, &cs->cs_repaired);
+	if (unlikely(rc != 0))
+		return rc;
+
+	rc = crt_proc_uint64_t(proc, proc_op, &cs->cs_ignored);
+	if (unlikely(rc != 0))
+		return rc;
+
+	return crt_proc_uint64_t(proc, proc_op, &cs->cs_failed);
+}
+
+static int
+crt_proc_struct_chk_query_target(crt_proc_t proc, crt_proc_op_t proc_op,
+				 struct chk_query_target *target)
+{
+	int	rc;
+
+	rc = crt_proc_d_rank_t(proc, proc_op, &target->cqt_rank);
+	if (unlikely(rc != 0))
+		return rc;
+
+	rc = crt_proc_uint32_t(proc, proc_op, &target->cqt_tgt);
+	if (unlikely(rc != 0))
+		return rc;
+
+	rc = crt_proc_uint32_t(proc, proc_op, &target->cqt_ins_status);
+	if (unlikely(rc != 0))
+		return rc;
+
+	rc = crt_proc_uint32_t(proc, proc_op, &target->cqt_padding);
+	if (unlikely(rc != 0))
+		return rc;
+
+	rc = crt_proc_struct_chk_statistics(proc, proc_op, &target->cqt_statistics);
+	if (unlikely(rc != 0))
+		return rc;
+
+	return crt_proc_struct_chk_time(proc, proc_op, &target->cqt_time);
+}
+
+static int
+crt_proc_struct_chk_query_pool_shard(crt_proc_t proc, crt_proc_op_t proc_op,
+				     struct chk_query_pool_shard *shard)
+{
+	int	rc;
+	int	i;
+
+	rc = crt_proc_uuid_t(proc, proc_op, &shard->cqps_uuid);
+	if (unlikely(rc != 0))
+		return rc;
+
+	rc = crt_proc_uint32_t(proc, proc_op, &shard->cqps_status);
+	if (unlikely(rc != 0))
+		return rc;
+
+	rc = crt_proc_uint32_t(proc, proc_op, &shard->cqps_phase);
+	if (unlikely(rc != 0))
+		return rc;
+
+	rc = crt_proc_struct_chk_statistics(proc, proc_op, &shard->cqps_statistics);
+	if (unlikely(rc != 0))
+		return rc;
+
+	rc = crt_proc_struct_chk_time(proc, proc_op, &shard->cqps_time);
+	if (unlikely(rc != 0))
+		return rc;
+
+	rc = crt_proc_uint32_t(proc, proc_op, &shard->cqps_rank);
+	if (unlikely(rc != 0))
+		return rc;
+
+	rc = crt_proc_uint32_t(proc, proc_op, &shard->cqps_target_nr);
+	if (unlikely(rc != 0))
+		return rc;
+
+	if (FREEING(proc_op)) {
+		D_FREE(shard->cqps_targets);
+		return 0;
+	}
+
+	if (DECODING(proc_op)) {
+		D_ALLOC_ARRAY(shard->cqps_targets, shard->cqps_target_nr);
+		if (shard->cqps_targets == NULL)
+			return -DER_NOMEM;
+	}
+
+	for (i = 0; i < shard->cqps_target_nr; i++) {
+		rc = crt_proc_struct_chk_query_target(proc, proc_op, &shard->cqps_targets[i]);
+		if (unlikely(rc != 0)) {
+			if (DECODING(proc_op))
+				D_FREE(shard->cqps_targets);
+			return rc;
+		}
+	}
+
+	return 0;
+}
+
+static int
+crp_proc_struct_rdb_clue(crt_proc_t proc, crt_proc_op_t proc_op, struct rdb_clue *rdb)
+{
+	int	rc;
+
+	rc = crt_proc_uint64_t(proc, proc_op, &rdb->bcl_term);
+	if (unlikely(rc != 0))
+		return rc;
+
+	rc = crt_proc_int32_t(proc, proc_op, &rdb->bcl_vote);
+	if (unlikely(rc != 0))
+		return rc;
+
+	rc = crt_proc_d_rank_t(proc, proc_op, &rdb->bcl_self);
+	if (unlikely(rc != 0))
+		return rc;
+
+	rc = crt_proc_uint64_t(proc, proc_op, &rdb->bcl_last_index);
+	if (unlikely(rc != 0))
+		return rc;
+
+	rc = crt_proc_uint64_t(proc, proc_op, &rdb->bcl_last_term);
+	if (unlikely(rc != 0))
+		return rc;
+
+	rc = crt_proc_uint64_t(proc, proc_op, &rdb->bcl_base_index);
+	if (unlikely(rc != 0))
+		return rc;
+
+	rc = crt_proc_uint64_t(proc, proc_op, &rdb->bcl_base_term);
+	if (unlikely(rc != 0))
+		return rc;
+
+	rc = crt_proc_d_rank_list_t(proc, proc_op, &rdb->bcl_replicas);
+	if (unlikely(rc != 0))
+		return rc;
+
+	rc = crt_proc_uint64_t(proc, proc_op, &rdb->bcl_oid_next);
+	if (unlikely(rc != 0))
+		return rc;
+
+	return 0;
+}
+
+static int
+crt_proc_struct_ds_pool_svc_clue(crt_proc_t proc, crt_proc_op_t proc_op,
+				 struct ds_pool_svc_clue *psc)
+{
+	int	rc;
+
+	rc = crp_proc_struct_rdb_clue(proc, proc_op, &psc->psc_db_clue);
+	if (unlikely(rc != 0))
+		return rc;
+
+	rc = crt_proc_uint32_t(proc, proc_op, &psc->psc_map_version);
+	if (unlikely(rc != 0))
+		return rc;
+
+	return 0;
+}
+
+static int
+crt_proc_struct_ds_pool_clue(crt_proc_t proc, crt_proc_op_t proc_op, struct ds_pool_clue *clue)
+{
+	int	rc;
+
+	rc = crt_proc_uuid_t(proc, proc_op, &clue->pc_uuid);
+	if (unlikely(rc != 0))
+		return rc;
+
+	rc = crt_proc_d_rank_t(proc, proc_op, &clue->pc_rank);
+	if (unlikely(rc != 0))
+		return rc;
+
+	rc = crt_proc_uint32_t(proc, proc_op, &clue->pc_dir);
+	if (unlikely(rc != 0))
+		return rc;
+
+	rc = crt_proc_int32_t(proc, proc_op, &clue->pc_rc);
+	if (unlikely(rc != 0))
+		return rc;
+
+	rc = crt_proc_uint32_t(proc, proc_op, &clue->pc_padding);
+	if (unlikely(rc != 0))
+		return rc;
+
+	if (clue->pc_rc <= 0)
+		return 0;
+
+	if (FREEING(proc_op)) {
+		D_FREE(clue->pc_svc_clue);
+		return 0;
+	}
+
+	if (DECODING(proc_op)) {
+		D_ALLOC_PTR(clue->pc_svc_clue);
+		if (clue->pc_svc_clue == NULL)
+			return -DER_NOMEM;
+	}
+
+	rc = crt_proc_struct_ds_pool_svc_clue(proc, proc_op, clue->pc_svc_clue);
+	if (unlikely(rc != 0)) {
+		if (DECODING(proc_op))
+			D_FREE(clue->pc_svc_clue);
+		return rc;
+	}
+
+	return 0;
+}
+
+CRT_RPC_DEFINE(chk_start, DAOS_ISEQ_CHK_START, DAOS_OSEQ_CHK_START);
+CRT_RPC_DEFINE(chk_stop, DAOS_ISEQ_CHK_STOP, DAOS_OSEQ_CHK_STOP);
+CRT_RPC_DEFINE(chk_query, DAOS_ISEQ_CHK_QUERY, DAOS_OSEQ_CHK_QUERY);
+CRT_RPC_DEFINE(chk_mark, DAOS_ISEQ_CHK_MARK, DAOS_OSEQ_CHK_MARK);
+CRT_RPC_DEFINE(chk_act, DAOS_ISEQ_CHK_ACT, DAOS_OSEQ_CHK_ACT);
+CRT_RPC_DEFINE(chk_report, DAOS_ISEQ_CHK_REPORT, DAOS_OSEQ_CHK_REPORT);
+CRT_RPC_DEFINE(chk_rejoin, DAOS_ISEQ_CHK_REJOIN, DAOS_OSEQ_CHK_REJOIN);

--- a/src/chk/chk_srv.c
+++ b/src/chk/chk_srv.c
@@ -7,47 +7,178 @@
 #define D_LOGFAC	DD_FAC(chk)
 
 #include <daos/rpc.h>
+#include <daos/btree.h>
+#include <daos/btree_class.h>
 #include <daos_srv/daos_chk.h>
 #include <daos_srv/daos_engine.h>
 
-#include "chk.pb-c.h"
 #include "chk_internal.h"
-
-static bool
-ds_chk_need_rejoin(void) {
-	return true;
-}
 
 static void
 ds_chk_start_hdlr(crt_rpc_t *rpc)
 {
+	struct chk_start_in	*csi = crt_req_get(rpc);
+	struct chk_start_out	*cso = crt_reply_get(rpc);
+	struct ds_pool_clues	 clues = { 0 };
+	uint32_t		 phase = 0;
+	int			 rc;
+
+	rc = chk_engine_start(csi->csi_gen, csi->csi_ranks.ca_count, csi->csi_ranks.ca_arrays,
+			      csi->csi_policies.ca_count,
+			      (struct chk_policy **)csi->csi_policies.ca_arrays,
+			      csi->csi_uuids.ca_count, csi->csi_uuids.ca_arrays,
+			      csi->csi_flags, csi->csi_phase, csi->csi_leader_rank, &phase, &clues);
+
+	cso->cso_status = rc;
+	cso->cso_rank = dss_self_rank();
+	cso->cso_phase = phase;
+	cso->cso_clues.ca_count = clues.pcs_len;
+	cso->cso_clues.ca_arrays = clues.pcs_array;
+	rc = crt_reply_send(rpc);
+	if (rc != 0)
+		D_ERROR("Failed to reply check start: "DF_RC"\n", DP_RC(rc));
+
+	ds_pool_clues_fini(&clues);
 }
 
 static void
 ds_chk_stop_hdlr(crt_rpc_t *rpc)
 {
+	struct chk_stop_in	*csi = crt_req_get(rpc);
+	struct chk_stop_out	*cso = crt_reply_get(rpc);
+	int			 rc;
+
+	rc = chk_engine_stop(csi->csi_gen, csi->csi_uuids.ca_count, csi->csi_uuids.ca_arrays);
+
+	cso->cso_status = rc;
+	cso->cso_rank = dss_self_rank();
+	rc = crt_reply_send(rpc);
+	if (rc != 0)
+		D_ERROR("Failed to reply check stop: "DF_RC"\n", DP_RC(rc));
 }
 
 static void
 ds_chk_query_hdlr(crt_rpc_t *rpc)
 {
+	struct chk_query_in		*cqi = crt_req_get(rpc);
+	struct chk_query_out		*cqo = crt_reply_get(rpc);
+	struct chk_query_pool_shard	*shards = NULL;
+	uint32_t			 shard_nr = 0;
+	int				 rc;
+
+	rc = chk_engine_query(cqi->cqi_gen, cqi->cqi_uuids.ca_count, cqi->cqi_uuids.ca_arrays,
+			      &shard_nr, &shards);
+
+	if (rc != 0) {
+		cqo->cqo_status = rc;
+		cqo->cqo_shards.ca_count = 0;
+		cqo->cqo_shards.ca_arrays = NULL;
+	} else {
+		cqo->cqo_status = 0;
+		cqo->cqo_shards.ca_count = shard_nr;
+		cqo->cqo_shards.ca_arrays = shards;
+	}
+
+	rc = crt_reply_send(rpc);
+	if (rc != 0)
+		D_ERROR("Failed to reply check query: "DF_RC"\n", DP_RC(rc));
+
+	chk_query_free(shards, shard_nr);
+}
+
+static void
+ds_chk_mark_hdlr(crt_rpc_t *rpc)
+{
+	struct chk_mark_in	*cmi = crt_req_get(rpc);
+	struct chk_mark_out	*cmo = crt_reply_get(rpc);
+	int			 rc;
+
+	rc = chk_engine_mark_rank_dead(cmi->cmi_gen, cmi->cmi_rank, cmi->cmi_version);
+
+	cmo->cmo_status = rc;
+	rc = crt_reply_send(rpc);
+	if (rc != 0)
+		D_ERROR("Failed to reply check mark rank dead: "DF_RC"\n", DP_RC(rc));
 }
 
 static void
 ds_chk_act_hdlr(crt_rpc_t *rpc)
 {
+	struct chk_act_in	*cai = crt_req_get(rpc);
+	struct chk_act_out	*cao = crt_reply_get(rpc);
+	int			 rc;
+
+	rc = chk_engine_act(cai->cai_gen, cai->cai_seq, cai->cai_cla, cai->cai_act, cai->cai_flags);
+
+	cao->cao_status = rc;
+	rc = crt_reply_send(rpc);
+	if (rc != 0)
+		D_ERROR("Failed to reply check act: "DF_RC"\n", DP_RC(rc));
+}
+
+static void
+ds_chk_report_hdlr(crt_rpc_t *rpc)
+{
+	struct chk_report_in	*cri = crt_req_get(rpc);
+	struct chk_report_out	*cro = crt_reply_get(rpc);
+	int			 rc;
+
+	rc = chk_leader_report(cri->cri_gen, cri->cri_ics_class, cri->cri_ics_action,
+			       cri->cri_ics_result, cri->cri_rank, cri->cri_target,
+			       &cri->cri_pool, &cri->cri_cont, &cri->cri_obj,
+			       &cri->cri_dkey, &cri->cri_akey, cri->cri_msg,
+			       cri->cri_options.ca_count, cri->cri_options.ca_arrays,
+			       cri->cri_details.ca_count, cri->cri_details.ca_arrays,
+			       false, &cro->cro_seq);
+
+	cro->cro_status = rc;
+	rc = crt_reply_send(rpc);
+	if (rc != 0)
+		D_ERROR("Failed to reply check report: "DF_RC"\n", DP_RC(rc));
+}
+
+static void
+ds_chk_rejoin_hdlr(crt_rpc_t *rpc)
+{
+	struct chk_rejoin_in	*cri = crt_req_get(rpc);
+	struct chk_rejoin_out	*cro = crt_reply_get(rpc);
+	int			 rc;
+
+	rc = chk_leader_rejoin(cri->cri_gen, cri->cri_rank, cri->cri_phase);
+
+	cro->cro_status = rc;
+	rc = crt_reply_send(rpc);
+	if (rc != 0)
+		D_ERROR("Failed to reply check rejoin: "DF_RC"\n", DP_RC(rc));
 }
 
 static int
 ds_chk_init(void)
 {
-	return 0;
+	int	rc;
+
+	rc = dbtree_class_register(DBTREE_CLASS_CHK_POOL, 0, &chk_pool_ops);
+	if (rc != 0)
+		goto out;
+
+	rc = dbtree_class_register(DBTREE_CLASS_CHK_RANK, 0, &chk_rank_ops);
+	if (rc != 0)
+		goto out;
+
+	rc = dbtree_class_register(DBTREE_CLASS_CHK_PA, 0, &chk_pending_ops);
+	if (rc != 0)
+		goto out;
+
+	rc = chk_iv_init();
+
+out:
+	return rc;
 }
 
 static int
 ds_chk_fini(void)
 {
-	return 0;
+	return chk_iv_fini();
 }
 
 static int
@@ -55,40 +186,57 @@ ds_chk_setup(void)
 {
 	int	rc;
 
-	/* TBD: open log. */
+	/* Do NOT move chk_vos_init into ds_chk_init, because sys_db is not ready at that time. */
+	chk_vos_init();
 
-	if (ds_chk_need_rejoin()) {
-		rc = chk_rejoin();
-		/* Rejoin check may fail, that is normal. Because former check instance may has
-		 * already been stopped or exited, or current rank may miss some critical phase
-		 * or has been excluded. Just some warning message without stopping the engine.
-		 */
-		if (rc != 0)
-			D_WARN("Cannot rejoin CHECK: "DF_RC"\n", DP_RC(rc));
-	}
+	rc = chk_leader_init();
+	if (rc != 0)
+		goto out_vos;
 
-	return 0;
+	rc = chk_engine_init();
+	if (rc != 0)
+		goto out_leader;
+
+	/*
+	 * Currently, we do NOT support leader to rejoin the former check instance. Because we do
+	 * not support leader switch, during current leader down time, the reported inconsistency
+	 * and related repair result are lost. Under such case, the admin has to stop and restart
+	 * the check explicitly.
+	 */
+
+	chk_engine_rejoin();
+
+	goto out_done;
+
+out_leader:
+	chk_leader_fini();
+out_vos:
+	chk_vos_fini();
+out_done:
+	return rc;
 }
 
 static int
 ds_chk_cleanup(void)
 {
-	chk_pause();
-
-	/* TBD: close log. */
+	chk_engine_pause();
+	chk_leader_pause();
+	chk_engine_fini();
+	chk_leader_fini();
+	chk_vos_fini();
 
 	return 0;
 }
 
-#define X(a, b, c, d, e, f)	\
+#define X(a, b, c, d, e)	\
 {				\
 	.dr_opc       = a,	\
 	.dr_hdlr      = d,	\
 	.dr_corpc_ops = e,	\
-},
+}
 
 static struct daos_rpc_handler chk_handlers[] = {
-	CHK_PROTO_SRV_RPC_LIST
+	CHK_PROTO_SRV_RPC_LIST,
 };
 
 #undef X
@@ -101,6 +249,8 @@ struct dss_module chk_module = {
 	.sm_fini		= ds_chk_fini,
 	.sm_setup		= ds_chk_setup,
 	.sm_cleanup		= ds_chk_cleanup,
+	.sm_proto_count		= 1,
+	.sm_proto_fmt		= &chk_proto_fmt,
 	.sm_cli_count		= 0,
 	.sm_handlers		= chk_handlers,
 };

--- a/src/chk/chk_upcall.c
+++ b/src/chk/chk_upcall.c
@@ -1,0 +1,215 @@
+/*
+ * (C) Copyright 2022 Intel Corporation.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause-Patent
+ */
+
+#define D_LOGFAC DD_FAC(chk)
+
+#include <time.h>
+#include <daos_types.h>
+#include <daos/common.h>
+#include <daos/object.h>
+#include <daos/drpc_modules.h>
+#include <daos_srv/ras.h>
+
+#include "chk.pb-c.h"
+#include "chk_internal.h"
+
+#define OBJID_STR_SIZE	32
+#define TIME_STR_SIZE	128
+
+#ifndef DF_KEY_STR_SIZE
+#define DF_KEY_STR_SIZE	64
+#endif
+
+#define CHK_ACTION_MAX	CHK__CHECK_INCONSIST_ACTION__CIA_TRUST_EC_DATA
+
+/* XXX: Must be strictly matches the order in Chk__CheckInconsistAction. */
+static char *chk_act_strings[CHK_ACTION_MAX + 1] = {
+	/* CHK__CHECK_INCONSIST_ACTION__CIA_DEFAULT = 0 */
+	"Default action, depends on the detailed inconsistency class.",
+
+	/* CHK__CHECK_INCONSIST_ACTION__CIA_INTERACT = 1 */
+	"Interact with administrator for further action.",
+
+	/* CHK__CHECK_INCONSIST_ACTION__CIA_IGNORE = 2 */
+	"Ignore but log the inconsistency.",
+
+	/* CHK__CHECK_INCONSIST_ACTION__CIA_DISCARD = 3 */
+	"Discard the unrecognized element: pool service, pool itself, container, and so on.",
+
+	/* CHK__CHECK_INCONSIST_ACTION__CIA_READD = 4 */
+	"Re-add the missing element: pool to MS, target to pool map, and so on.",
+
+	/* CHK__CHECK_INCONSIST_ACTION__CIA_TRUST_MS = 5 */
+	"Trust the information recorded in MS DB.",
+
+	/* CHK__CHECK_INCONSIST_ACTION__CIA_TRUST_PS = 6 */
+	"Trust the information recorded in PS DB.",
+
+	/* CHK__CHECK_INCONSIST_ACTION__CIA_TRUST_TARGET = 7 */
+	"Trust the information recorded by target(s).",
+
+	/* CHK__CHECK_INCONSIST_ACTION__CIA_TRUST_MAJORITY = 8 */
+	"Trust the majority parts (if have).",
+
+	/* CHK__CHECK_INCONSIST_ACTION__CIA_TRUST_LATEST = 9 */
+	"Trust the one with latest (pool map or epoch) information. Keep the latest data.",
+
+	/* CHK__CHECK_INCONSIST_ACTION__CIA_TRUST_OLDEST = 10 */
+	"Trust the one with oldest (pool map or epoch) information. Rollback to old version.",
+
+	/* CHK__CHECK_INCONSIST_ACTION__CIA_TRUST_EC_PARITY = 11 */
+	"Trust EC parity shard.",
+
+	/* CHK__CHECK_INCONSIST_ACTION__CIA_TRUST_EC_DATA = 12 */
+	"Trust EC data shard."
+};
+
+static int
+chk_sg_list2string_array(d_sg_list_t *sgls, uint32_t sgl_nr, char ***array)
+{
+	char	**buf = NULL;
+	int	  cnt = 0;
+	int	  i;
+	int	  j;
+	int	  k;
+
+	for (i = 0; i < sgl_nr; i++)
+		cnt += sgls[i].sg_nr;
+
+	if (unlikely(cnt == 0))
+		goto out;
+
+	D_ALLOC_ARRAY(buf, cnt);
+	if (buf == NULL)
+		D_GOTO(out, cnt = -DER_NOMEM);
+
+	/*
+	 * XXX: How to transfer all the data into d_sg_list_t array? Some may be not string.
+	 */
+
+	for (i = 0, k = 0; i < sgl_nr; i++) {
+		for (j = 0; j < sgls[i].sg_nr; j++)
+			buf[k++] = sgls[i].sg_iovs[j].iov_buf;
+	}
+
+out:
+	*array = buf;
+
+	return cnt;
+}
+
+int
+chk_report_upcall(uint64_t gen, uint64_t seq, uint32_t cla, uint32_t act, int32_t result,
+		  d_rank_t rank, uint32_t target, uuid_t *pool, uuid_t *cont, daos_unit_oid_t *obj,
+		  daos_key_t *dkey, daos_key_t *akey, char *msg, uint32_t option_nr,
+		  uint32_t *options, uint32_t detail_nr, d_sg_list_t *details)
+{
+	Chk__CheckReport	  report = CHK__CHECK_REPORT__INIT;
+	time_t			  tm = time(NULL);
+	char			**act_msgs = NULL;
+	int			  rc;
+	int			  i;
+
+	if (act == CHK__CHECK_INCONSIST_ACTION__CIA_INTERACT) {
+		D_ASSERT(option_nr > 0);
+		D_ASSERT(options != NULL);
+
+		D_ALLOC(act_msgs, option_nr);
+		if (act_msgs == NULL)
+			D_GOTO(out, rc = -DER_NOMEM);
+
+		for (i = 0; i < option_nr; i++) {
+			D_ASSERT(options[i] <= CHK_ACTION_MAX);
+			act_msgs[i] = chk_act_strings[options[i]];
+		}
+	}
+
+	report.seq = seq;
+	report.class_ = cla;
+	report.action = act;
+	report.result = result;
+	report.rank = rank;
+	report.target = target;
+
+	if (pool != NULL && !uuid_is_null(*pool)) {
+		D_ASPRINTF(report.pool_uuid, DF_UUIDF, DP_UUID(*pool));
+		if (report.pool_uuid == NULL)
+			D_GOTO(out, rc = -DER_NOMEM);
+	} else {
+		report.pool_uuid = NULL;
+	}
+
+	if (cont != NULL && !uuid_is_null(*cont)) {
+		D_ASPRINTF(report.cont_uuid, DF_UUIDF, DP_UUID(*cont));
+		if (report.cont_uuid == NULL)
+			D_GOTO(out, rc = -DER_NOMEM);
+	} else {
+		report.cont_uuid = NULL;
+	}
+
+	if (obj != NULL && !daos_unit_oid_is_null(*obj)) {
+		D_ASPRINTF(report.objid, DF_UOID, DP_UOID(*obj));
+		if (report.objid == NULL)
+			D_GOTO(out, rc = -DER_NOMEM);
+	} else {
+		report.objid = NULL;
+	}
+
+	if (dkey != NULL && !daos_key_is_null(*dkey)) {
+		D_ASPRINTF(report.dkey, DF_KEY, DP_KEY(dkey));
+		if (report.dkey == NULL)
+			D_GOTO(out, rc = -DER_NOMEM);
+	} else {
+		report.dkey = NULL;
+	}
+
+	if (akey != NULL && !daos_key_is_null(*akey)) {
+		D_ASPRINTF(report.akey, DF_KEY, DP_KEY(akey));
+		if (report.akey == NULL)
+			D_GOTO(out, rc = -DER_NOMEM);
+	} else {
+		report.akey = NULL;
+	}
+
+	D_ASPRINTF(report.timestamp, "%s", ctime(&tm));
+	if (report.timestamp == NULL)
+		D_GOTO(out, rc = -DER_NOMEM);
+
+	report.msg = msg;
+	report.n_act_choices = option_nr;
+	report.act_choices = options;
+
+	if (details != NULL) {
+		rc = chk_sg_list2string_array(details, detail_nr, &report.act_details);
+		if (rc < 0)
+			goto out;
+
+		report.n_act_details = rc;
+	} else {
+		report.n_act_details = 0;
+		report.act_details = NULL;
+	}
+
+	report.n_act_msgs = option_nr;
+	report.act_msgs = act_msgs;
+
+	rc = ds_chk_report_upcall(&report);
+
+out:
+	D_FREE(act_msgs);
+	D_FREE(report.pool_uuid);
+	D_FREE(report.cont_uuid);
+	D_FREE(report.objid);
+	D_FREE(report.dkey);
+	D_FREE(report.akey);
+	D_FREE(report.timestamp);
+
+	D_CDEBUG(rc != 0, DLOG_ERR, DLOG_INFO,
+		 "Check leader upcall for instance "DF_X64" for seq "DF_X64": "DF_RC"\n",
+		 gen, seq, DP_RC(rc));
+
+	return rc;
+}

--- a/src/chk/chk_vos.c
+++ b/src/chk/chk_vos.c
@@ -1,0 +1,311 @@
+/**
+ * (C) Copyright 2022 Intel Corporation.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause-Patent
+ */
+
+#define D_LOGFAC	DD_FAC(chk)
+
+#include <daos_srv/vos.h>
+#include <daos_srv/daos_chk.h>
+#include <daos_srv/daos_engine.h>
+
+#include "chk_internal.h"
+
+static struct sys_db	*chk_db;
+
+static int
+chk_db_fetch(char *key, int key_size, void *val, int val_size)
+{
+	d_iov_t	key_iov;
+	d_iov_t	val_iov;
+
+	d_iov_set(&key_iov, key, key_size);
+	d_iov_set(&val_iov, val, val_size);
+
+	return chk_db->sd_fetch(chk_db, CHK_DB_TABLE, &key_iov, &val_iov);
+}
+
+static int
+chk_db_update(char *key, int key_size, void *val, int val_size)
+{
+	d_iov_t	key_iov;
+	d_iov_t	val_iov;
+	int	rc;
+
+	if (chk_db->sd_tx_begin) {
+		rc = chk_db->sd_tx_begin(chk_db);
+		if (rc != 0)
+			goto out;
+	}
+
+	d_iov_set(&key_iov, key, key_size);
+	d_iov_set(&val_iov, val, val_size);
+
+	rc = chk_db->sd_upsert(chk_db, CHK_DB_TABLE, &key_iov, &val_iov);
+
+	if (chk_db->sd_tx_end)
+		rc = chk_db->sd_tx_end(chk_db, rc);
+
+out:
+	return rc;
+}
+
+static int
+chk_db_delete(char *key, int key_size)
+{
+	d_iov_t	key_iov;
+	int	rc;
+
+	if (chk_db->sd_tx_begin) {
+		rc = chk_db->sd_tx_begin(chk_db);
+		if (rc != 0)
+			goto out;
+	}
+
+	d_iov_set(&key_iov, key, key_size);
+
+	rc = chk_db->sd_delete(chk_db, CHK_DB_TABLE, &key_iov);
+
+	if (chk_db->sd_tx_end)
+		rc = chk_db->sd_tx_end(chk_db, rc);
+
+out:
+	return rc;
+}
+
+static int
+chk_db_traverse(sys_db_trav_cb_t cb, void *args)
+{
+	return chk_db->sd_traverse(chk_db, CHK_DB_TABLE, cb, args);
+}
+
+int
+chk_bk_fetch_leader(struct chk_bookmark *cbk)
+{
+	int	rc;
+
+	rc = chk_db_fetch(CHK_BK_LEADER, strlen(CHK_BK_LEADER), cbk, sizeof(*cbk));
+	if (rc != 0 && rc != -DER_NONEXIST)
+		D_ERROR("Failed to fetch leader bookmark on rank %u: "DF_RC"\n",
+			dss_self_rank(), DP_RC(rc));
+
+	return rc;
+}
+
+int
+chk_bk_update_leader(struct chk_bookmark *cbk)
+{
+	int	rc;
+
+	rc = chk_db_update(CHK_BK_LEADER, strlen(CHK_BK_LEADER), cbk, sizeof(*cbk));
+	if (rc != 0)
+		D_ERROR("Failed to update leader bookmark on rank %u: "DF_RC"\n",
+			dss_self_rank(), DP_RC(rc));
+
+	return rc;
+}
+
+int
+chk_bk_delete_leader(void)
+{
+	int	rc;
+
+	rc = chk_db_delete(CHK_BK_LEADER, strlen(CHK_BK_LEADER));
+	if (rc != 0)
+		D_ERROR("Failed to delete leader bookmark on rank %u: "DF_RC"\n",
+			dss_self_rank(), DP_RC(rc));
+
+	return rc;
+}
+
+int
+chk_bk_fetch_engine(struct chk_bookmark *cbk)
+{
+	int	rc;
+
+	rc = chk_db_fetch(CHK_BK_ENGINE, strlen(CHK_BK_ENGINE), cbk, sizeof(*cbk));
+	if (rc != 0 && rc != -DER_NONEXIST)
+		D_ERROR("Failed to fetch engine bookmark on rank %u: "DF_RC"\n",
+			dss_self_rank(), DP_RC(rc));
+
+	return rc;
+}
+
+int
+chk_bk_update_engine(struct chk_bookmark *cbk)
+{
+	int	rc;
+
+	rc = chk_db_update(CHK_BK_ENGINE, strlen(CHK_BK_ENGINE), cbk, sizeof(*cbk));
+	if (rc != 0)
+		D_ERROR("Failed to update engine bookmark on rank %u: "DF_RC"\n",
+			dss_self_rank(), DP_RC(rc));
+
+	return rc;
+}
+
+int
+chk_bk_delete_engine(void)
+{
+	int	rc;
+
+	rc = chk_db_delete(CHK_BK_ENGINE, strlen(CHK_BK_ENGINE));
+	if (rc != 0)
+		D_ERROR("Failed to delete engine bookmark on rank %u: "DF_RC"\n",
+			dss_self_rank(), DP_RC(rc));
+
+	return rc;
+}
+
+int
+chk_bk_fetch_pool(struct chk_bookmark *cbk, uuid_t uuid)
+{
+	char	uuid_str[DAOS_UUID_STR_SIZE];
+	int	rc;
+
+	uuid_unparse_lower(uuid, uuid_str);
+	rc = chk_db_fetch(uuid_str, strlen(uuid_str), cbk, sizeof(*cbk));
+	if (rc != 0 && rc != -DER_NONEXIST)
+		D_ERROR("Failed to fetch pool "DF_UUID" bookmark on rank %u: "DF_RC"\n",
+			DP_UUID(uuid), dss_self_rank(), DP_RC(rc));
+
+	return rc;
+}
+
+int
+chk_bk_update_pool(struct chk_bookmark *cbk, uuid_t uuid)
+{
+	char	uuid_str[DAOS_UUID_STR_SIZE];
+	int	rc;
+
+	uuid_unparse_lower(uuid, uuid_str);
+	rc = chk_db_update(uuid_str, strlen(uuid_str), cbk, sizeof(*cbk));
+	if (rc != 0)
+		D_ERROR("Failed to update pool "DF_UUID" bookmark on rank %u: "DF_RC"\n",
+			DP_UUID(uuid), dss_self_rank(), DP_RC(rc));
+
+	return rc;
+}
+
+int
+chk_bk_delete_pool(uuid_t uuid)
+{
+	char	uuid_str[DAOS_UUID_STR_SIZE];
+	int	rc;
+
+	uuid_unparse_lower(uuid, uuid_str);
+	rc = chk_db_delete(uuid_str, strlen(uuid_str));
+	if (rc != 0)
+		D_ERROR("Failed to delete pool "DF_UUID" bookmark on rank %u: "DF_RC"\n",
+			DP_UUID(uuid), dss_self_rank(), DP_RC(rc));
+
+	return rc;
+}
+
+int
+chk_prop_fetch(struct chk_property *cpp, d_rank_list_t **rank_list)
+{
+	d_rank_list_t	*ranks = NULL;
+	int		 rc;
+
+	rc = chk_db_fetch(CHK_PROPERTY, strlen(CHK_PROPERTY), cpp, sizeof(*cpp));
+	if (rc == 0 && cpp->cp_rank_nr != 0 && rank_list != NULL) {
+		ranks = d_rank_list_alloc(cpp->cp_rank_nr);
+		if (ranks == NULL)
+			D_GOTO(out, rc = -DER_NOMEM);
+
+		rc = chk_db_fetch(CHK_RANKS, strlen(CHK_RANKS), ranks->rl_ranks,
+				  sizeof(*ranks->rl_ranks) * ranks->rl_nr);
+		/*
+		 * CHK_PROPERTY and CHK_RANKS must be exist together.
+		 * Otherwise there is local corruption.
+		 */
+		if (rc == -DER_NONEXIST) {
+			d_rank_list_free(ranks);
+			ranks = NULL;
+			D_GOTO(out, rc = -DER_IO);
+		}
+
+		if (rc != 0)
+			goto out;
+	}
+
+out:
+	if (rank_list != NULL)
+		*rank_list = ranks;
+
+	if (rc != 0 && rc != -DER_NONEXIST)
+		D_ERROR("Failed to fetch check property on rank %u: "DF_RC"\n",
+			dss_self_rank(), DP_RC(rc));
+
+	return rc;
+}
+
+int
+chk_prop_update(struct chk_property *cpp, d_rank_list_t *rank_list)
+{
+	d_iov_t	key_iov;
+	d_iov_t	val_iov;
+	int	rc;
+
+	if (chk_db->sd_tx_begin) {
+		rc = chk_db->sd_tx_begin(chk_db);
+		if (rc != 0)
+			goto out;
+	}
+
+	if (cpp->cp_rank_nr != 0 && rank_list != NULL) {
+		D_ASSERTF(cpp->cp_rank_nr == rank_list->rl_nr, "Invalid rank nr %u/%u\n",
+			  cpp->cp_rank_nr, rank_list->rl_nr);
+
+		d_iov_set(&key_iov, CHK_RANKS, strlen(CHK_RANKS));
+		d_iov_set(&val_iov, rank_list->rl_ranks,
+			  sizeof(*rank_list->rl_ranks) * rank_list->rl_nr);
+
+		rc = chk_db->sd_upsert(chk_db, CHK_DB_TABLE, &key_iov, &val_iov);
+		if (rc != 0)
+			goto end;
+	}
+
+	d_iov_set(&key_iov, CHK_PROPERTY, strlen(CHK_PROPERTY));
+	d_iov_set(&val_iov, cpp, sizeof(*cpp));
+
+	rc = chk_db->sd_upsert(chk_db, CHK_DB_TABLE, &key_iov, &val_iov);
+
+end:
+	if (chk_db->sd_tx_end)
+		rc = chk_db->sd_tx_end(chk_db, rc);
+
+out:
+	if (rc != 0)
+		D_ERROR("Failed to update check property on rank %u: "DF_RC"\n",
+			dss_self_rank(), DP_RC(rc));
+
+	return rc;
+}
+
+int
+chk_traverse_pools(sys_db_trav_cb_t cb, void *args)
+{
+	int	rc;
+
+	rc = chk_db_traverse(cb, args);
+	if (rc < 0)
+		D_ERROR("Failed to traverse pools on rank %u for pause: "DF_RC"\n",
+			dss_self_rank(), DP_RC(rc));
+
+	return rc;
+}
+
+void
+chk_vos_init(void)
+{
+	chk_db = vos_db_get();
+}
+
+void
+chk_vos_fini(void)
+{
+	chk_db = NULL;
+}

--- a/src/common/misc.c
+++ b/src/common/misc.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2021 Intel Corporation.
+ * (C) Copyright 2016-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -742,4 +742,40 @@ void
 daos_recx_free(daos_recx_t *recx)
 {
 	D_FREE(recx);
+}
+
+int
+path_gen(const uuid_t pool_uuid, const char *dir, const char *fname, int *idx,
+	 char **fpath)
+{
+	int	 size;
+	int	 off;
+
+	/** *fpath = dir + "/" + pool_uuid + "/" + fname + idx */
+
+	/** DAOS_UUID_STR_SIZE includes the trailing '\0' */
+	size = strlen(dir) + 1 /* "/" */ + DAOS_UUID_STR_SIZE;
+	if (fname != NULL || idx != NULL)
+		size += 1 /* "/" */;
+	if (fname)
+		size += strlen(fname);
+	if (idx)
+		size += snprintf(NULL, 0, "%d", *idx);
+
+	D_ALLOC(*fpath, size);
+	if (*fpath == NULL)
+		return -DER_NOMEM;
+
+	off = sprintf(*fpath, "%s", dir);
+	off += sprintf(*fpath + off, "/");
+	uuid_unparse_lower(pool_uuid, *fpath + off);
+	off += DAOS_UUID_STR_SIZE - 1;
+	if (fname != NULL || idx != NULL)
+		off += sprintf(*fpath + off, "/");
+	if (fname)
+		off += sprintf(*fpath + off, "%s", fname);
+	if (idx)
+		sprintf(*fpath + off, "%d", *idx);
+
+	return 0;
 }

--- a/src/common/proc.c
+++ b/src/common/proc.c
@@ -205,3 +205,49 @@ crt_proc_daos_prop_t(crt_proc_t proc, crt_proc_op_t proc_op, daos_prop_t **data)
 		return -DER_INVAL;
 	}
 }
+
+int
+crt_proc_d_sg_list_t(crt_proc_t proc, crt_proc_op_t proc_op, d_sg_list_t *p)
+{
+	int		i;
+	int		rc;
+
+	if (FREEING(proc_op)) {
+		/* NB: don't need free in crt_proc_d_iov_t() */
+		D_FREE(p->sg_iovs);
+		return 0;
+	}
+
+	rc = crt_proc_uint32_t(proc, proc_op, &p->sg_nr);
+	if (unlikely(rc))
+		return rc;
+
+	rc = crt_proc_uint32_t(proc, proc_op, &p->sg_nr_out);
+	if (unlikely(rc))
+		return rc;
+
+	if (p->sg_nr == 0)
+		return 0;
+
+	switch (proc_op) {
+	case CRT_PROC_DECODE:
+		D_ALLOC_ARRAY(p->sg_iovs, p->sg_nr);
+		if (p->sg_iovs == NULL)
+			return -DER_NOMEM;
+		/* fall through to fill sg_iovs */
+	case CRT_PROC_ENCODE:
+		for (i = 0; i < p->sg_nr; i++) {
+			rc = crt_proc_d_iov_t(proc, proc_op, &p->sg_iovs[i]);
+			if (unlikely(rc)) {
+				if (DECODING(proc_op))
+					D_FREE(p->sg_iovs);
+				return rc;
+			}
+		}
+		break;
+	default:
+		return -DER_INVAL;
+	}
+
+	return rc;
+}

--- a/src/include/daos/btree_class.h
+++ b/src/include/daos/btree_class.h
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2021 Intel Corporation.
+ * (C) Copyright 2016-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -97,5 +97,20 @@ extern btr_ops_t dbtree_recx_ops;
  * The key is dtx_cos_key: oid + dkey_hash
  */
 #define DBTREE_CLASS_DTX_COS (DBTREE_DSM_BEGIN + 7)
+
+/**
+ * DAOS check pool tree, the key is pool uuid
+ */
+#define DBTREE_CLASS_CHK_POOL (DBTREE_DSM_BEGIN + 8)
+
+/**
+ * DAOS check rank tree, the key is rank ID
+ */
+#define DBTREE_CLASS_CHK_RANK (DBTREE_DSM_BEGIN + 9)
+
+/**
+ * DAOS check pending action tree, the key is 64-bit sequence
+ */
+#define DBTREE_CLASS_CHK_PA (DBTREE_DSM_BEGIN + 10)
 
 #endif /* __DAOS_SRV_BTREE_CLASS_H__ */

--- a/src/include/daos/common.h
+++ b/src/include/daos/common.h
@@ -900,6 +900,7 @@ int crt_proc_daos_prop_t(crt_proc_t proc, crt_proc_op_t proc_op,
 			 daos_prop_t **data);
 int crt_proc_struct_daos_acl(crt_proc_t proc, crt_proc_op_t proc_op,
 			     struct daos_acl **data);
+int crt_proc_d_sg_list_t(crt_proc_t proc, crt_proc_op_t proc_op, d_sg_list_t *p);
 
 bool daos_prop_valid(daos_prop_t *prop, bool pool, bool input);
 daos_prop_t *daos_prop_dup(daos_prop_t *prop, bool pool, bool input);
@@ -910,6 +911,7 @@ int daos_prop_entry_copy(struct daos_prop_entry *entry,
 			 struct daos_prop_entry *entry_dup);
 daos_recx_t *daos_recx_alloc(uint32_t nr);
 void daos_recx_free(daos_recx_t *recx);
+int path_gen(const uuid_t pool_uuid, const char *dir, const char *fname, int *idx, char **fpath);
 
 static inline void
 daos_parse_ctype(const char *string, daos_cont_layout_t *type)

--- a/src/include/daos/rpc.h
+++ b/src/include/daos/rpc.h
@@ -91,6 +91,8 @@ enum daos_rpc_type {
 	DAOS_REQ_SWIM,
 	/** Per VOS target request */
 	DAOS_REQ_TGT,
+	/** The DAOS check request handled by cart, send/recv by tag 0. */
+	DAOS_REQ_CHK,
 };
 
 /** DAOS_TGT0_OFFSET is target 0's cart context offset */
@@ -124,6 +126,7 @@ daos_rpc_tag(int req_type, int tgt_idx)
 	case DAOS_REQ_REBUILD:
 	case DAOS_REQ_IV:
 	case DAOS_REQ_BCAST:
+	case DAOS_REQ_CHK:
 		return 0;
 	default:
 		D_ASSERTF(0, "bad req_type %d.\n", req_type);

--- a/src/include/daos_errno.h
+++ b/src/include/daos_errno.h
@@ -273,6 +273,9 @@ extern "C" {
 		Retry with other target)				\
 	ACTION(DER_NOTSUPPORTED,	(DER_ERR_DAOS_BASE + 37),	\
 	       Operation not supported)					\
+	/** Cannot resume former DAOS check instance. */		\
+	ACTION(DER_NOT_RESUME,		(DER_ERR_DAOS_BASE + 38),	\
+	       Cannot resume former DAOS check instance)		\
 
 /** Defines the gurt error codes */
 #define D_FOREACH_ERR_RANGE(ACTION)	\

--- a/src/include/daos_srv/daos_chk.h
+++ b/src/include/daos_srv/daos_chk.h
@@ -15,46 +15,75 @@ struct chk_policy {
 	uint32_t		cp_action;
 };
 
-/* Check query result for the pool (all ranks) or pool shard (per target). */
-struct chk_query_pool {
-	uuid_t			cqp_uuid;
-	char			cqp_label[DAOS_PROP_MAX_LABEL_BUF_LEN];
-	uint32_t		cqp_status;
-	uint32_t		cqp_phase;
-	uint32_t		cqp_total;
-	uint32_t		cqp_repaired;
-	uint32_t		cqp_ignored;
-	uint32_t		cqp_failed;
-	uint64_t		cqp_start_time;
+/* Time information on related component: system, pool or target. */
+struct chk_time {
+	/* The time of check instance being started on the component. */
+	uint64_t		ct_start_time;
 	union {
-		uint64_t	cqp_remain_time;
-		uint64_t	cqp_stop_time;
+		/* The time of the check instance completed, failed or stopped on the component. */
+		uint64_t	ct_stop_time;
+		/* The estimated remaining time to complete the check on the component. */
+		uint64_t	ct_left_time;
 	};
 };
 
-/* Check query result for the target including all the pool shards on this target. */
-struct chk_query_target {
-	d_rank_t		dqt_rank;
-	uint32_t		dqt_tgt;
-	uint32_t		dqt_status;
-	uint32_t		dqt_cnt;
-	struct chk_query_pool	dqt_shards[0];
+/* Inconsistency statistics on related component: system, pool or target. */
+struct chk_statistics {
+	/* The count of total found inconsistency on the component. */
+	uint64_t		cs_total;
+	/* The count of repaired inconsistency on the component. */
+	uint64_t		cs_repaired;
+	/* The count of ignored inconsistency on the component. */
+	uint64_t		cs_ignored;
+	/* The count of fail to repaired inconsistency on the component. */
+	uint64_t		cs_failed;
 };
 
-typedef int (*chk_query_cb_t)(void *buf, struct chk_query_target *cqt);
+struct chk_query_target {
+	d_rank_t		cqt_rank;
+	uint32_t		cqt_tgt;
+	uint32_t		cqt_ins_status;
+	uint32_t		cqt_padding;
+	struct chk_statistics	cqt_statistics;
+	struct chk_time		cqt_time;
+};
 
-typedef int (*chk_prop_cb_t)(void *buf, struct chk_policy *policies);
+struct chk_query_pool_shard {
+	uuid_t			 cqps_uuid;
+	uint32_t		 cqps_status;
+	uint32_t		 cqps_phase;
+	struct chk_statistics	 cqps_statistics;
+	struct chk_time		 cqps_time;
+	uint32_t		 cqps_rank;
+	uint32_t		 cqps_target_nr;
+	struct chk_query_target	*cqps_targets;
+};
 
-int chk_start(d_rank_list_t *ranks, struct chk_policy *policies, uuid_t *pools,
-	      int pool_cnt, uint32_t flags);
+struct chk_list_pool {
+	uuid_t			 clp_uuid;
+	char			*clp_label;
+	d_rank_list_t		*clp_svcreps;
+};
 
-int chk_stop(uuid_t *pools, int pool_cnt);
+typedef int (*chk_query_head_cb_t)(uint32_t ins_status, uint32_t ins_phase,
+				   struct chk_statistics *inconsistency, struct chk_time *time,
+				   size_t n_pools, void *buf);
 
-int chk_query(uuid_t *pools, int pool_cnt, chk_query_cb_t query_cb,
-	      struct chk_query_target *cqt, void *buf);
+typedef int (*chk_query_pool_cb_t)(struct chk_query_pool_shard *shard, uint32_t idx, void *buf);
 
-int chk_prop(uint32_t *flags, chk_prop_cb_t prop_cb, struct chk_policy *policy, void *buf);
+typedef int (*chk_prop_cb_t)(void *buf, struct chk_policy **policies, int cnt, uint32_t flags);
 
-int chk_act(uint64_t seq, uint32_t act, bool for_all);
+int chk_leader_start(uint32_t rank_nr, d_rank_t *ranks, uint32_t policy_nr,
+		     struct chk_policy **policies, uint32_t pool_nr, uuid_t pools[],
+		     uint32_t flags, int32_t phase);
+
+int chk_leader_stop(uint32_t pool_nr, uuid_t pools[]);
+
+int chk_leader_query(uint32_t pool_nr, uuid_t pools[], chk_query_head_cb_t head_cb,
+		     chk_query_pool_cb_t pool_cb, void *buf);
+
+int chk_leader_prop(chk_prop_cb_t prop_cb, void *buf);
+
+int chk_leader_act(uint64_t seq, uint32_t act, bool for_all);
 
 #endif /* __DAOS_CHK_H__ */

--- a/src/include/daos_srv/daos_engine.h
+++ b/src/include/daos_srv/daos_engine.h
@@ -843,4 +843,6 @@ enum dss_drpc_call_flag {
 int dss_drpc_call(int32_t module, int32_t method, void *req, size_t req_size,
 		  unsigned int flags, Drpc__Response **resp);
 
+bool engine_in_check(void);
+
 #endif /* __DSS_API_H__ */

--- a/src/include/daos_srv/iv.h
+++ b/src/include/daos_srv/iv.h
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2017-2021 Intel Corporation.
+ * (C) Copyright 2017-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -289,6 +289,7 @@ enum iv_key {
 	 * other servers
 	 */
 	IV_CONT_AGG_EPOCH_BOUNDRY,
+	IV_CHK,
 };
 
 int ds_iv_fetch(struct ds_iv_ns *ns, struct ds_iv_key *key, d_sg_list_t *value,

--- a/src/include/daos_srv/pool.h
+++ b/src/include/daos_srv/pool.h
@@ -323,13 +323,14 @@ enum ds_pool_dir {
  *
  * Pool shard and service replica (if applicable) info gathered when glancing
  * at a pool. The pc_uuid, pc_dir, and pc_rc fields are always valid; the
- * pc_svc_clue field is valid only if pc_rc is zero.
+ * pc_svc_clue field is valid only if pc_rc is positive value.
  */
 struct ds_pool_clue {
 	uuid_t				pc_uuid;
 	d_rank_t			pc_rank;
 	enum ds_pool_dir		pc_dir;
 	int				pc_rc;
+	uint32_t			pc_padding;
 	struct ds_pool_svc_clue	       *pc_svc_clue;
 };
 

--- a/src/include/daos_srv/ras.h
+++ b/src/include/daos_srv/ras.h
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2020-2021 Intel Corporation.
+ * (C) Copyright 2020-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -13,6 +13,7 @@
 
 #include <daos_types.h>
 #include <daos/object.h>
+#include <daos_srv/daos_chk.h>
 
 #define DAOS_RAS_STR_FIELD_SIZE 128
 #define DAOS_RAS_ID_FIELD_SIZE 64
@@ -173,5 +174,53 @@ ds_notify_pool_svc_update(uuid_t *pool, d_rank_list_t *svcl);
  */
 int
 ds_notify_swim_rank_dead(d_rank_t rank, uint64_t incarnation);
+
+/**
+ * List all the known pools from control plane (MS).
+ *
+ * \param[out] clp	The pools list.
+ *
+ * \retval		Positive value for the conut of pools.
+ *			Negative value if error.
+ */
+int
+ds_chk_listpool_upcall(struct chk_list_pool **clp);
+
+/**
+ * Register the pool to control plane (MS).
+ *
+ * \param[in] seq	DAOS Check event sequence, unique for the instance.
+ * \param[in] uuid	The pool uuid.
+ * \param[in] label	The pool label, optional.
+ * \param[in] svcreps	Ranks for the pool service.
+ *
+ * \retval		Zero on success, non-zero otherwise.
+ */
+int
+ds_chk_regpool_upcall(uint64_t seq, uuid_t uuid, char *label, d_rank_list_t *svcreps);
+
+/**
+ * Deregister the pool from control plane (MS).
+ *
+ * \param[in] seq	DAOS Check event sequence, unique for the instance.
+ * \param[in] uuid	The pool uuid.
+ *
+ * \retval		Zero on success, non-zero otherwise.
+ */
+int
+ds_chk_deregpool_upcall(uint64_t seq, uuid_t uuid);
+
+/**
+ * Report inconsistency to control plane (MS).
+ *
+ * \param[in] rpt	The pointer to Chk__CheckReport.
+ *
+ * \retval		Zero on success, non-zero otherwise.
+ */
+int
+ds_chk_report_upcall(void *rpt);
+
+void
+ds_chk_free_pool_list(struct chk_list_pool *clp, uint32_t nr);
 
 #endif /* __DAOS_RAS_H_ */

--- a/src/include/daos_srv/vos_types.h
+++ b/src/include/daos_srv/vos_types.h
@@ -11,6 +11,7 @@
 #include <daos_pool.h>
 #include <daos_srv/bio.h>
 #include <daos_srv/vea.h>
+#include <daos_srv/daos_chk.h>
 #include <daos/object.h>
 #include <daos/dtx.h>
 #include <daos/checksum.h>
@@ -135,6 +136,14 @@ typedef struct {
 	struct vos_pool_space	pif_space;
 	/** garbage collector statistics */
 	struct vos_gc_stat	pif_gc_stat;
+	/** DAOS check phase on the pool shard. */
+	uint32_t		pif_chk_phase;
+	/** DAOS check instance status on the pool shard. */
+	uint32_t		pif_chk_status;
+	/** Inconsistency information for DAOS check on the pool shard. */
+	struct chk_statistics	pif_chk_statistics;
+	/** Time information for DAOS check on the pool shard. */
+	struct chk_time		pif_chk_time;
 	/** TODO */
 } vos_pool_info_t;
 

--- a/src/include/daos_types.h
+++ b/src/include/daos_types.h
@@ -128,6 +128,12 @@ typedef struct {
 
 typedef d_iov_t daos_key_t;
 
+static inline bool
+daos_key_is_null(daos_key_t key)
+{
+	return key.iov_buf_len == 0 || key.iov_buf == NULL;
+}
+
 /**
  * Event and event queue
  */

--- a/src/mgmt/SConscript
+++ b/src/mgmt/SConscript
@@ -1,3 +1,4 @@
+# pylint: disable=consider-using-f-string
 """Build management server module"""
 import daos_build
 
@@ -38,7 +39,7 @@ def scons():
                                    'srv_pool.c', 'srv_system.c',
                                    'srv_target.c', 'srv_query.c',
                                    'srv_drpc.c', 'srv_util.c',
-                                   'srv_container.c'], install_off='../..')
+                                   'srv_container.c', 'srv_chk.c'], install_off='../..')
     senv.Install('$PREFIX/lib64/daos_srv', mgmt_srv)
 
     denv = senv

--- a/src/mgmt/srv_chk.c
+++ b/src/mgmt/srv_chk.c
@@ -1,0 +1,53 @@
+/**
+ * (C) Copyright 2022 Intel Corporation.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause-Patent
+ */
+/*
+ * ds_mgmt: Check Methods
+ */
+#define D_LOGFAC	DD_FAC(mgmt)
+
+#include <daos_srv/daos_chk.h>
+#include <daos_srv/daos_engine.h>
+
+#include "srv_internal.h"
+
+int
+ds_mgmt_check_start(uint32_t rank_nr, d_rank_t *ranks, uint32_t policy_nr,
+		    struct chk_policy **policies, uint32_t pool_nr, uuid_t pools[],
+		    uint32_t flags, int32_t phase)
+{
+	return chk_leader_start(rank_nr, ranks, policy_nr, policies, pool_nr, pools, flags, phase);
+}
+
+int
+ds_mgmt_check_stop(uint32_t pool_nr, uuid_t pools[])
+{
+	return chk_leader_stop(pool_nr, pools);
+}
+
+int
+ds_mgmt_check_query(uint32_t pool_nr, uuid_t pools[], chk_query_head_cb_t head_cb,
+		    chk_query_pool_cb_t pool_cb, void *buf)
+{
+	return chk_leader_query(pool_nr, pools, head_cb, pool_cb, buf);
+}
+
+int
+ds_mgmt_check_prop(chk_prop_cb_t prop_cb, void *buf)
+{
+	return chk_leader_prop(prop_cb, buf);
+}
+
+int
+ds_mgmt_check_act(uint64_t seq, uint32_t act, bool for_all)
+{
+	return chk_leader_act(seq, act, for_all);
+}
+
+bool
+ds_mgmt_check_enabled(void)
+{
+	return engine_in_check();
+}

--- a/src/mgmt/srv_drpc.c
+++ b/src/mgmt/srv_drpc.c
@@ -2457,27 +2457,526 @@ out:
 	mgmt__cont_set_owner_req__free_unpacked(req, &alloc.alloc);
 }
 
+/*
+ * XXX: It is the control plane to choose the check leader and rank list.
+ *	There are some requirements for the rank list:
+ *	1. There are no repeated ranks in the list.
+ *	2. It is better to sort ranks in the list that will much speedup searching rank in the list.
+ */
 void
 ds_mgmt_drpc_check_start(Drpc__Call *drpc_req, Drpc__Response *drpc_resp)
 {
+	struct drpc_alloc	 alloc = PROTO_ALLOCATOR_INIT(alloc);
+	Mgmt__CheckStartReq	*req = NULL;
+	Mgmt__CheckStartResp	 resp = MGMT__CHECK_START_RESP__INIT;
+	uuid_t			*pools = NULL;
+	uint8_t			*body;
+	size_t			 len;
+	int			 rc = 0;
+	int			 i;
+
+	if (!ds_mgmt_check_enabled()) {
+		D_ERROR("Not in check mode\n");
+		drpc_resp->status = DRPC__STATUS__UNKNOWN_MODULE;
+		return;
+	}
+
+	req = mgmt__check_start_req__unpack(&alloc.alloc, drpc_req->body.len, drpc_req->body.data);
+	if (alloc.oom || req == NULL) {
+		D_ERROR("Failed to unpack req (start check)\n");
+		drpc_resp->status = DRPC__STATUS__FAILED_UNMARSHAL_PAYLOAD;
+		return;
+	}
+
+	D_INFO("Received request to start check\n");
+
+	if (req->n_uuids != 0) {
+		D_ALLOC_ARRAY(pools, req->n_uuids);
+		if (pools == NULL)
+			D_GOTO(rep, rc = -DER_NOMEM);
+
+		for (i = 0; i < req->n_uuids; i++) {
+			rc = uuid_parse(req->uuids[i], pools[i]);
+			if (rc != 0) {
+				D_ERROR("Failed to parse uuid %s: %d\n", req->uuids[i], rc);
+				D_GOTO(rep, rc);
+			}
+		}
+	}
+
+	/* XXX: support to check to the specified phase in the future. */
+
+	rc = ds_mgmt_check_start(req->n_ranks, req->ranks, req->n_policies,
+				 (struct chk_policy **)req->policies, req->n_uuids,
+				 pools, req->flags, -1 /* phase */);
+	if (rc != 0)
+		D_ERROR("Failed to start check: "DF_RC"\n", DP_RC(rc));
+
+rep:
+	resp.status = rc;
+	len = mgmt__check_start_resp__get_packed_size(&resp);
+	D_ALLOC(body, len);
+	if (body == NULL) {
+		D_ERROR("Failed to allocate response body (start check)\n");
+		drpc_resp->status = DRPC__STATUS__FAILED_MARSHAL;
+	} else {
+		mgmt__check_start_resp__pack(&resp, body);
+		drpc_resp->body.len = len;
+		drpc_resp->body.data = body;
+	}
+
+	D_FREE(pools);
+	mgmt__check_start_req__free_unpacked(req, &alloc.alloc);
 }
 
+/*
+ * It is the control plane's duty to guarantee that if the check leader is still available,
+ * then the CHK_STOP dRPC needs to be sent to the check leader.
+ */
 void
 ds_mgmt_drpc_check_stop(Drpc__Call *drpc_req, Drpc__Response *drpc_resp)
 {
+	struct drpc_alloc	 alloc = PROTO_ALLOCATOR_INIT(alloc);
+	Mgmt__CheckStopReq	*req = NULL;
+	Mgmt__CheckStopResp	 resp = MGMT__CHECK_STOP_RESP__INIT;
+	uuid_t			*pools = NULL;
+	uint8_t			*body;
+	size_t			 len;
+	int			 rc = 0;
+	int			 i;
+
+	if (!ds_mgmt_check_enabled()) {
+		D_ERROR("Not in check mode\n");
+		drpc_resp->status = DRPC__STATUS__UNKNOWN_MODULE;
+		return;
+	}
+
+	req = mgmt__check_stop_req__unpack(&alloc.alloc, drpc_req->body.len, drpc_req->body.data);
+	if (alloc.oom || req == NULL) {
+		D_ERROR("Failed to unpack req (stop check)\n");
+		drpc_resp->status = DRPC__STATUS__FAILED_UNMARSHAL_PAYLOAD;
+		return;
+	}
+
+	D_INFO("Received request to stop check\n");
+
+	if (req->n_uuids != 0) {
+		D_ALLOC_ARRAY(pools, req->n_uuids);
+		if (pools == NULL)
+			D_GOTO(rep, rc = -DER_NOMEM);
+
+		for (i = 0; i < req->n_uuids; i++) {
+			rc = uuid_parse(req->uuids[i], pools[i]);
+			if (rc != 0) {
+				D_ERROR("Failed to parse uuid %s: %d\n", req->uuids[i], rc);
+				D_GOTO(rep, rc);
+			}
+		}
+	}
+
+	rc = ds_mgmt_check_stop(req->n_uuids, pools);
+	if (rc != 0)
+		D_ERROR("Failed to stop check: "DF_RC"\n", DP_RC(rc));
+
+rep:
+	resp.status = rc;
+	len = mgmt__check_stop_resp__get_packed_size(&resp);
+	D_ALLOC(body, len);
+	if (body == NULL) {
+		D_ERROR("Failed to allocate response body (stop check)\n");
+		drpc_resp->status = DRPC__STATUS__FAILED_MARSHAL;
+	} else {
+		mgmt__check_stop_resp__pack(&resp, body);
+		drpc_resp->body.len = len;
+		drpc_resp->body.data = body;
+	}
+
+	D_FREE(pools);
+	mgmt__check_stop_req__free_unpacked(req, &alloc.alloc);
 }
 
+static void
+ds_chk_query_free(Mgmt__CheckQueryResp *resp)
+{
+	Mgmt__CheckQueryPool	*pool;
+	Mgmt__CheckQueryTarget	*target;
+	int			 i;
+	int			 j;
+
+	D_FREE(resp->inconsistency);
+	D_FREE(resp->time);
+
+	if (resp->pools != NULL) {
+		for (i = 0; i < resp->n_pools; i++) {
+			pool = resp->pools[i];
+			if (pool == NULL)
+				break;
+
+			D_FREE(pool->uuid);
+			D_FREE(pool->inconsistency);
+			D_FREE(pool->time);
+			if (pool->targets != NULL) {
+				for (j = 0; j < pool->n_targets; j++) {
+					target = pool->targets[j];
+					if (target == NULL)
+						break;
+
+					D_FREE(target->inconsistency);
+					D_FREE(target->time);
+
+					D_FREE(target);
+				}
+
+				D_FREE(pool->targets);
+			}
+
+			D_FREE(pool);
+		}
+
+		D_FREE(resp->pools);
+	}
+}
+
+static int
+ds_chk_copy_inconsistency(Mgmt__CheckQueryInconsist **dst, struct chk_statistics *src)
+{
+	int	rc = 0;
+
+	D_ALLOC_PTR(*dst);
+	if (*dst == NULL)
+		D_GOTO(out, rc = -DER_NOMEM);
+
+	(*dst)->total = src->cs_total;
+	(*dst)->repaired = src->cs_repaired;
+	(*dst)->ignored = src->cs_ignored;
+	(*dst)->failed = src->cs_failed;
+
+out:
+	return rc;
+}
+
+static int
+ds_chk_copy_time(Mgmt__CheckQueryTime **dst, struct chk_time *src)
+{
+	int	rc = 0;
+
+	D_ALLOC_PTR(*dst);
+	if (*dst == NULL)
+		D_GOTO(out, rc = -DER_NOMEM);
+
+	(*dst)->start_time = src->ct_start_time;
+	(*dst)->misc_time = src->ct_stop_time;
+
+out:
+	return rc;
+}
+
+static int
+ds_chk_query_head_cb(uint32_t ins_status, uint32_t ins_phase, struct chk_statistics *inconsistency,
+		     struct chk_time *time, size_t n_pools, void *buf)
+{
+	Mgmt__CheckQueryResp	*resp = buf;
+	int			  rc = 0;
+
+	resp->ins_status = ins_status;
+	resp->ins_phase = ins_phase;
+
+	rc = ds_chk_copy_inconsistency(&resp->inconsistency, inconsistency);
+	if (resp->inconsistency == NULL)
+		D_GOTO(out, rc = -DER_NOMEM);
+
+	rc = ds_chk_copy_time(&resp->time, time);
+	if (resp->time == NULL)
+		D_GOTO(out, rc = -DER_NOMEM);
+
+	D_ALLOC_ARRAY(resp->pools, n_pools);
+	if (resp->pools == NULL)
+		D_GOTO(out, rc = -DER_NOMEM);
+
+	resp->n_pools = n_pools;
+
+out:
+	if (rc != 0)
+		ds_chk_query_free(resp);
+
+	return rc;
+}
+
+static int
+ds_chk_query_pool_cb(struct chk_query_pool_shard *shard, uint32_t idx, void *buf)
+{
+	Mgmt__CheckQueryResp	*resp = buf;
+	Mgmt__CheckQueryPool	*pool;
+	Mgmt__CheckQueryTarget	*target;
+	int			 rc;
+	int			 i;
+
+	D_ALLOC_PTR(pool);
+	if (pool == NULL)
+		D_GOTO(out, rc = -DER_NOMEM);
+
+	resp->pools[idx] = pool;
+	D_ASPRINTF(pool->uuid, DF_UUIDF, DP_UUID(shard->cqps_uuid));
+	if (pool->uuid == NULL)
+		D_GOTO(out, rc = -DER_NOMEM);
+
+	pool->status = shard->cqps_status;
+	pool->phase = shard->cqps_phase;
+	rc = ds_chk_copy_inconsistency(&pool->inconsistency, &shard->cqps_statistics);
+	if (pool->inconsistency == NULL)
+		D_GOTO(out, rc = -DER_NOMEM);
+
+	rc = ds_chk_copy_time(&pool->time, &shard->cqps_time);
+	if (pool->time == NULL)
+		D_GOTO(out, rc = -DER_NOMEM);
+
+	D_ALLOC_ARRAY(pool->targets, shard->cqps_target_nr);
+	if (pool->targets == NULL)
+		D_GOTO(out, rc = -DER_NOMEM);
+
+	pool->n_targets = shard->cqps_target_nr;
+	for (i = 0; i < shard->cqps_target_nr; i++) {
+		D_ALLOC_PTR(target);
+		if (target == NULL)
+			D_GOTO(out, rc = -DER_NOMEM);
+
+		pool->targets[i] = target;
+		target->rank = shard->cqps_targets[i].cqt_rank;
+		target->target = shard->cqps_targets[i].cqt_tgt;
+		target->status = shard->cqps_targets[i].cqt_ins_status;
+		rc = ds_chk_copy_inconsistency(&target->inconsistency,
+					       &shard->cqps_targets[i].cqt_statistics);
+		if (target->inconsistency == NULL)
+			D_GOTO(out, rc = -DER_NOMEM);
+
+		rc = ds_chk_copy_time(&target->time, &shard->cqps_targets[i].cqt_time);
+		if (target->time == NULL)
+			D_GOTO(out, rc = -DER_NOMEM);
+	}
+
+out:
+	if (rc != 0)
+		ds_chk_query_free(resp);
+
+	return rc;
+}
+
+/*
+ * XXX: One pool may have M pool shards on M daos engines. Each of them has each own status and
+ *	summary in the qurey result. They have the same UUID and contiguous each other. Control
+ *	plane can decide how to show them to the admin based on the qurey option.
+ *
+ *	Similarly, each pool shard may have N vos target on the engine. Then there will be M * N
+ *	vos targets for the whole pool. Each of them has each own check summary in qurey result.
+ *	It is the control plane's duty to re-organize related result before showing to the admin.
+ *
+ *	If some required pool is absence in the qurey result, then means that it does not exist.
+ *
+ *	On the other hand, it is the control plane's duty to guarantee that if the check leader
+ *	is still available, the CHK_QUERY dRPC needs to be sent to the check leader. Otherwise,
+ *	the query result may be not inaccurate.
+ */
 void
 ds_mgmt_drpc_check_query(Drpc__Call *drpc_req, Drpc__Response *drpc_resp)
 {
+	struct drpc_alloc		 alloc = PROTO_ALLOCATOR_INIT(alloc);
+	Mgmt__CheckQueryReq		*req = NULL;
+	Mgmt__CheckQueryResp		 resp = MGMT__CHECK_QUERY_RESP__INIT;
+	uuid_t				*pools = NULL;
+	uint8_t				*body;
+	size_t				 len;
+	int				 rc = 0;
+	int				 i;
+
+	if (!ds_mgmt_check_enabled()) {
+		D_ERROR("Not in check mode\n");
+		drpc_resp->status = DRPC__STATUS__UNKNOWN_MODULE;
+		return;
+	}
+
+	req = mgmt__check_query_req__unpack(&alloc.alloc, drpc_req->body.len, drpc_req->body.data);
+	if (alloc.oom || req == NULL) {
+		D_ERROR("Failed to unpack req (query check)\n");
+		drpc_resp->status = DRPC__STATUS__FAILED_UNMARSHAL_PAYLOAD;
+		return;
+	}
+
+	D_INFO("Received request to query check\n");
+
+	if (req->n_uuids != 0) {
+		D_ALLOC_ARRAY(pools, req->n_uuids);
+		if (pools == NULL)
+			D_GOTO(rep, rc = -DER_NOMEM);
+
+		for (i = 0; i < req->n_uuids; i++) {
+			rc = uuid_parse(req->uuids[i], pools[i]);
+			if (rc != 0) {
+				D_ERROR("Failed to parse uuid %s: %d\n", req->uuids[i], rc);
+				D_GOTO(rep, rc);
+			}
+		}
+	}
+
+	rc = ds_mgmt_check_query(req->n_uuids, pools, ds_chk_query_head_cb,
+				 ds_chk_query_pool_cb, &resp);
+	if (rc != 0)
+		D_ERROR("Failed to query check: "DF_RC"\n", DP_RC(rc));
+
+rep:
+	resp.req_status = rc;
+	len = mgmt__check_query_resp__get_packed_size(&resp);
+	D_ALLOC(body, len);
+	if (body == NULL) {
+		D_ERROR("Failed to allocate response body (query check)\n");
+		drpc_resp->status = DRPC__STATUS__FAILED_MARSHAL;
+	} else {
+		mgmt__check_query_resp__pack(&resp, body);
+		drpc_resp->body.len = len;
+		drpc_resp->body.data = body;
+	}
+
+	D_FREE(pools);
+	ds_chk_query_free(&resp);
+	mgmt__check_query_req__free_unpacked(req, &alloc.alloc);
 }
 
+static void
+ds_chk_prob_free(Mgmt__CheckInconsistPolicy **policies, uint32_t policy_nr)
+{
+	int	i;
+
+	if (policies != NULL) {
+		for (i = 0; i < policy_nr; i++)
+			D_FREE(policies[i]);
+		D_FREE(policies);
+	}
+}
+
+static int
+ds_chk_prop_cb(void *buf, struct chk_policy **policies, int cnt, uint32_t flags)
+{
+	Mgmt__CheckInconsistPolicy	**ply = NULL;
+	Mgmt__CheckPropResp		 *resp = buf;
+	int				  rc = 0;
+	int				  i = 0;
+
+	D_ALLOC_ARRAY(ply, cnt);
+	if (ply == NULL)
+		return -DER_NOMEM;
+
+	for (i = 0; i < cnt; i++) {
+		D_ALLOC(ply[i], sizeof(*ply[i]));
+		if (ply[i] == NULL)
+			D_GOTO(out, rc = -DER_NOMEM);
+
+		ply[i]->inconsist_cas = policies[i]->cp_class;
+		ply[i]->inconsist_act = policies[i]->cp_action;
+	}
+
+
+out:
+	if (rc != 0) {
+		ds_chk_prob_free(ply, i);
+	} else {
+		resp->policies = ply;
+		resp->n_policies = cnt;
+		resp->flags = flags;
+	}
+
+	return rc;
+}
+
+/*
+ * CHK_PROP dRPC can be sent to any engine that participates in the check.
+ */
 void
 ds_mgmt_drpc_check_prop(Drpc__Call *drpc_req, Drpc__Response *drpc_resp)
 {
+	struct drpc_alloc		 alloc = PROTO_ALLOCATOR_INIT(alloc);
+	Mgmt__CheckPropReq		*req = NULL;
+	Mgmt__CheckPropResp		 resp = MGMT__CHECK_PROP_RESP__INIT;
+	uint8_t				*body;
+	size_t				 len;
+	int				 rc = 0;
+
+	if (!ds_mgmt_check_enabled()) {
+		D_ERROR("Not in check mode\n");
+		drpc_resp->status = DRPC__STATUS__UNKNOWN_MODULE;
+		return;
+	}
+
+	req = mgmt__check_prop_req__unpack(&alloc.alloc, drpc_req->body.len, drpc_req->body.data);
+	if (alloc.oom || req == NULL) {
+		D_ERROR("Failed to unpack req (get property for check)\n");
+		drpc_resp->status = DRPC__STATUS__FAILED_UNMARSHAL_PAYLOAD;
+		return;
+	}
+
+	D_INFO("Received request to get property for check\n");
+
+	rc = ds_mgmt_check_prop(ds_chk_prop_cb, &resp);
+	if (rc != 0)
+		D_ERROR("Failed to set get property for check: "DF_RC"\n", DP_RC(rc));
+
+	resp.status = rc;
+	len = mgmt__check_prop_resp__get_packed_size(&resp);
+	D_ALLOC(body, len);
+	if (body == NULL) {
+		D_ERROR("Failed to allocate response body (get property for check)\n");
+		drpc_resp->status = DRPC__STATUS__FAILED_MARSHAL;
+	} else {
+		mgmt__check_prop_resp__pack(&resp, body);
+		drpc_resp->body.len = len;
+		drpc_resp->body.data = body;
+	}
+
+	ds_chk_prob_free(resp.policies, resp.n_policies);
+	mgmt__check_prop_req__free_unpacked(req, &alloc.alloc);
 }
 
+/*
+ * CHK_ACT dRPC only can be sent to the check leader.
+ */
 void
 ds_mgmt_drpc_check_act(Drpc__Call *drpc_req, Drpc__Response *drpc_resp)
 {
+	struct drpc_alloc	 alloc = PROTO_ALLOCATOR_INIT(alloc);
+	Mgmt__CheckActReq	*req = NULL;
+	Mgmt__CheckActResp	 resp = MGMT__CHECK_ACT_RESP__INIT;
+	uint8_t			*body;
+	size_t			 len;
+	int			 rc = 0;
+
+	if (!ds_mgmt_check_enabled()) {
+		D_ERROR("Not in check mode\n");
+		drpc_resp->status = DRPC__STATUS__UNKNOWN_MODULE;
+		return;
+	}
+
+	req = mgmt__check_act_req__unpack(&alloc.alloc, drpc_req->body.len, drpc_req->body.data);
+	if (alloc.oom || req == NULL) {
+		D_ERROR("Failed to unpack req (set action for check)\n");
+		drpc_resp->status = DRPC__STATUS__FAILED_UNMARSHAL_PAYLOAD;
+		return;
+	}
+
+	D_INFO("Received request to set action for check\n");
+
+	rc = ds_mgmt_check_act(req->seq, req->act, req->for_all);
+	if (rc != 0)
+		D_ERROR("Failed to set action for check: "DF_RC"\n", DP_RC(rc));
+
+	resp.status = rc;
+	len = mgmt__check_act_resp__get_packed_size(&resp);
+	D_ALLOC(body, len);
+	if (body == NULL) {
+		D_ERROR("Failed to allocate response body (set action for check)\n");
+		drpc_resp->status = DRPC__STATUS__FAILED_MARSHAL;
+	} else {
+		mgmt__check_act_resp__pack(&resp, body);
+		drpc_resp->body.len = len;
+		drpc_resp->body.data = body;
+	}
+
+	mgmt__check_act_req__free_unpacked(req, &alloc.alloc);
 }

--- a/src/mgmt/srv_internal.h
+++ b/src/mgmt/srv_internal.h
@@ -21,9 +21,11 @@
 #include <daos_srv/rdb.h>
 #include <daos_srv/rsvc.h>
 #include <daos_srv/smd.h>
+#include <daos_srv/daos_chk.h>
 #include <daos_security.h>
 #include <daos_prop.h>
 
+#include "check.pb-c.h"
 #include "svc.pb-c.h"
 #include "smd.pb-c.h"
 #include "rpc.h"
@@ -104,6 +106,17 @@ int ds_mgmt_pool_query(uuid_t pool_uuid, d_rank_list_t *svc_ranks, d_rank_list_t
 int ds_mgmt_cont_set_owner(uuid_t pool_uuid, d_rank_list_t *svc_ranks,
 			   uuid_t cont_uuid, const char *user,
 			   const char *group);
+
+/** srv_chk.c */
+int ds_mgmt_check_start(uint32_t rank_nr, d_rank_t *ranks, uint32_t policy_nr,
+			struct chk_policy **policies, uint32_t pool_nr, uuid_t pools[],
+			uint32_t flags, int32_t phase);
+int ds_mgmt_check_stop(uint32_t pool_nr, uuid_t pools[]);
+int ds_mgmt_check_query(uint32_t pool_nr, uuid_t pools[], chk_query_head_cb_t head_cb,
+			chk_query_pool_cb_t pool_cb, void *buf);
+int ds_mgmt_check_prop(chk_prop_cb_t prop_cb, void *buf);
+int ds_mgmt_check_act(uint64_t seq, uint32_t act, bool for_all);
+bool ds_mgmt_check_enabled(void);
 
 /** srv_query.c */
 

--- a/src/mgmt/srv_target.c
+++ b/src/mgmt/srv_target.c
@@ -70,42 +70,6 @@ static d_hash_table_ops_t pooltgts_hops = {
 	.hop_key_cmp		= pooltgts_cmp_keys,
 };
 
-static int
-path_gen(const uuid_t pool_uuid, const char *dir, const char *fname, int *idx,
-	 char **fpath)
-{
-	int	 size;
-	int	 off;
-
-	/** *fpath = dir + "/" + pool_uuid + "/" + fname + idx */
-
-	/** DAOS_UUID_STR_SIZE includes the trailing '\0' */
-	size = strlen(dir) + 1 /* "/" */ + DAOS_UUID_STR_SIZE;
-	if (fname != NULL || idx != NULL)
-		size += 1 /* "/" */;
-	if (fname)
-		size += strlen(fname);
-	if (idx)
-		size += snprintf(NULL, 0, "%d", *idx);
-
-	D_ALLOC(*fpath, size);
-	if (*fpath == NULL)
-		return -DER_NOMEM;
-
-	off = sprintf(*fpath, "%s", dir);
-	off += sprintf(*fpath + off, "/");
-	uuid_unparse_lower(pool_uuid, *fpath + off);
-	off += DAOS_UUID_STR_SIZE - 1;
-	if (fname != NULL || idx != NULL)
-		off += sprintf(*fpath + off, "/");
-	if (fname)
-		off += sprintf(*fpath + off, "%s", fname);
-	if (idx)
-		sprintf(*fpath + off, "%d", *idx);
-
-	return 0;
-}
-
 static inline int
 dir_fsync(const char *path)
 {

--- a/src/mgmt/tests/mocks.c
+++ b/src/mgmt/tests/mocks.c
@@ -522,3 +522,42 @@ mock_ds_mgmt_pool_upgrade_setup(void)
 	ds_mgmt_pool_upgrade_return = 0;
 	uuid_clear(ds_mgmt_pool_upgrade_uuid);
 }
+
+int
+ds_mgmt_check_start(uint32_t rank_nr, d_rank_t *ranks, uint32_t policy_nr,
+		    struct chk_policy **policies, uint32_t pool_nr, uuid_t pools[],
+		    uint32_t flags, int32_t phase)
+{
+	return 0;
+}
+
+int
+ds_mgmt_check_stop(uint32_t pool_nr, uuid_t pools[])
+{
+	return 0;
+}
+
+int
+ds_mgmt_check_query(uint32_t pool_nr, uuid_t pools[], chk_query_head_cb_t head_cb,
+		    chk_query_pool_cb_t pool_cb, void *buf)
+{
+	return 0;
+}
+
+int
+ds_mgmt_check_prop(chk_prop_cb_t prop_cb, void *buf)
+{
+	return 0;
+}
+
+int
+ds_mgmt_check_act(uint64_t seq, uint32_t act, bool for_all)
+{
+	return 0;
+}
+
+bool
+ds_mgmt_check_enabled(void)
+{
+	return true;
+}

--- a/src/mgmt/tests/srv_drpc_tests.c
+++ b/src/mgmt/tests/srv_drpc_tests.c
@@ -21,6 +21,7 @@
 #include "../acl.pb-c.h"
 #include "../pool.pb-c.h"
 #include "../cont.pb-c.h"
+#include "../check.pb-c.h"
 #include "../svc.pb-c.h"
 #include "../server.pb-c.h"
 #include "../drpc_internal.h"
@@ -112,6 +113,11 @@ test_mgmt_drpc_handlers_bad_call_payload(void **state)
 	expect_failure_for_bad_call_payload(ds_mgmt_drpc_pool_set_prop);
 	expect_failure_for_bad_call_payload(ds_mgmt_drpc_cont_set_owner);
 	expect_failure_for_bad_call_payload(ds_mgmt_drpc_pool_upgrade);
+	expect_failure_for_bad_call_payload(ds_mgmt_drpc_check_start);
+	expect_failure_for_bad_call_payload(ds_mgmt_drpc_check_stop);
+	expect_failure_for_bad_call_payload(ds_mgmt_drpc_check_query);
+	expect_failure_for_bad_call_payload(ds_mgmt_drpc_check_prop);
+	expect_failure_for_bad_call_payload(ds_mgmt_drpc_check_act);
 }
 
 static daos_prop_t *
@@ -2407,6 +2413,51 @@ test_drpc_pool_upgrade_success(void **state)
 	D_FREE(resp.body.data);
 }
 
+/*
+ * dRPC check start tests
+ */
+
+static void
+test_drpc_check_start_success(void **state)
+{
+}
+
+/*
+ * dRPC check stop tests
+ */
+
+static void
+test_drpc_check_stop_success(void **state)
+{
+}
+
+/*
+ * dRPC check query tests
+ */
+
+static void
+test_drpc_check_query_success(void **state)
+{
+}
+
+/*
+ * dRPC check prop tests
+ */
+
+static void
+test_drpc_check_prop_success(void **state)
+{
+}
+
+/*
+ * dRPC check act tests
+ */
+
+static void
+test_drpc_check_act_success(void **state)
+{
+}
+
 #define ACL_TEST(x)	cmocka_unit_test_setup_teardown(x, \
 						drpc_pool_acl_setup, \
 						drpc_pool_acl_teardown)
@@ -2454,6 +2505,16 @@ test_drpc_pool_upgrade_success(void **state)
 #define CONT_SET_OWNER_TEST(x) cmocka_unit_test_setup_teardown(x, \
 						drpc_cont_set_owner_setup, \
 						drpc_cont_set_owner_teardown)
+
+#define CHECK_START_TEST(x)	cmocka_unit_test(x)
+
+#define CHECK_STOP_TEST(x)	cmocka_unit_test(x)
+
+#define CHECK_QUERY_TEST(x)	cmocka_unit_test(x)
+
+#define CHECK_PROP_TEST(x)	cmocka_unit_test(x)
+
+#define CHECK_ACT_TEST(x)	cmocka_unit_test(x)
 
 int
 main(void)
@@ -2516,6 +2577,11 @@ main(void)
 		POOL_UPGRADE_TEST(test_drpc_pool_upgrade_bad_uuid),
 		POOL_UPGRADE_TEST(test_drpc_pool_upgrade_mgmt_svc_fails),
 		POOL_UPGRADE_TEST(test_drpc_pool_upgrade_success),
+		CHECK_START_TEST(test_drpc_check_start_success),
+		CHECK_STOP_TEST(test_drpc_check_stop_success),
+		CHECK_QUERY_TEST(test_drpc_check_query_success),
+		CHECK_PROP_TEST(test_drpc_check_prop_success),
+		CHECK_ACT_TEST(test_drpc_check_act_success),
 	};
 
 	return cmocka_run_group_tests_name("mgmt_srv_drpc", tests, NULL, NULL);

--- a/src/object/obj_rpc.c
+++ b/src/object/obj_rpc.c
@@ -492,52 +492,6 @@ crt_proc_struct_obj_iod_array(crt_proc_t proc, crt_proc_op_t proc_op,
 }
 
 static int
-crt_proc_d_sg_list_t(crt_proc_t proc, crt_proc_op_t proc_op, d_sg_list_t *p)
-{
-	int		i;
-	int		rc;
-
-	if (FREEING(proc_op)) {
-		/* NB: don't need free in crt_proc_d_iov_t() */
-		D_FREE(p->sg_iovs);
-		return 0;
-	}
-
-	rc = crt_proc_uint32_t(proc, proc_op, &p->sg_nr);
-	if (unlikely(rc))
-		return rc;
-
-	rc = crt_proc_uint32_t(proc, proc_op, &p->sg_nr_out);
-	if (unlikely(rc))
-		return rc;
-
-	if (p->sg_nr == 0)
-		return 0;
-
-	switch (proc_op) {
-	case CRT_PROC_DECODE:
-		D_ALLOC_ARRAY(p->sg_iovs, p->sg_nr);
-		if (p->sg_iovs == NULL)
-			return -DER_NOMEM;
-		/* fall through to fill sg_iovs */
-	case CRT_PROC_ENCODE:
-		for (i = 0; i < p->sg_nr; i++) {
-			rc = crt_proc_d_iov_t(proc, proc_op, &p->sg_iovs[i]);
-			if (unlikely(rc)) {
-				if (DECODING(proc_op))
-					D_FREE(p->sg_iovs);
-				return rc;
-			}
-		}
-		break;
-	default:
-		return -DER_INVAL;
-	}
-
-	return rc;
-}
-
-static int
 crt_proc_struct_daos_shard_tgt(crt_proc_t proc, crt_proc_op_t proc_op,
 			       struct daos_shard_tgt *p)
 {

--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -1051,11 +1051,13 @@ init_events(struct pool_svc *svc)
 	D_ASSERT(d_list_empty(&events->pse_queue));
 	D_ASSERT(events->pse_handler == ABT_THREAD_NULL);
 
-	rc = crt_register_event_cb(ds_pool_crt_event_cb, svc);
-	if (rc != 0) {
-		D_ERROR(DF_UUID": failed to register event callback: "DF_RC"\n",
-			DP_UUID(svc->ps_uuid), DP_RC(rc));
-		goto err;
+	if (!engine_in_check()) {
+		rc = crt_register_event_cb(ds_pool_crt_event_cb, svc);
+		if (rc != 0) {
+			D_ERROR(DF_UUID": failed to register event callback: "DF_RC"\n",
+				DP_UUID(svc->ps_uuid), DP_RC(rc));
+			goto err;
+		}
 	}
 
 	/*
@@ -1080,7 +1082,8 @@ init_events(struct pool_svc *svc)
 	return 0;
 
 err_cb:
-	crt_unregister_event_cb(ds_pool_crt_event_cb, svc);
+	if (!engine_in_check())
+		crt_unregister_event_cb(ds_pool_crt_event_cb, svc);
 	discard_events(&events->pse_queue);
 err:
 	return rc;
@@ -1094,7 +1097,8 @@ fini_events(struct pool_svc *svc)
 
 	D_ASSERT(events->pse_handler != ABT_THREAD_NULL);
 
-	crt_unregister_event_cb(ds_pool_crt_event_cb, svc);
+	if (!engine_in_check())
+		crt_unregister_event_cb(ds_pool_crt_event_cb, svc);
 
 	ABT_mutex_lock(events->pse_mutex);
 	events->pse_stop = true;

--- a/src/pool/srv_pool_check.c
+++ b/src/pool/srv_pool_check.c
@@ -146,6 +146,10 @@ ds_pool_clue_init(uuid_t uuid, enum ds_pool_dir dir, struct ds_pool_clue *clue)
 out_path:
 	D_FREE(path);
 out:
+	if (clue->pc_svc_clue != NULL)
+		rc = 1;
+	else
+		D_ASSERT(rc <= 0);
 	clue->pc_rc = rc;
 }
 
@@ -157,7 +161,7 @@ out:
 void
 ds_pool_clue_fini(struct ds_pool_clue *clue)
 {
-	if (clue->pc_rc == 0 && clue->pc_svc_clue != NULL) {
+	if (clue->pc_svc_clue != NULL) {
 		d_rank_list_free(clue->pc_svc_clue->psc_db_clue.bcl_replicas);
 		D_FREE(clue->pc_svc_clue);
 	}

--- a/src/vos/vos_layout.h
+++ b/src/vos/vos_layout.h
@@ -19,6 +19,7 @@
 #include <daos_srv/bio.h>
 #include <daos_srv/vea.h>
 #include <daos_srv/dtx_srv.h>
+#include <daos_srv/daos_chk.h>
 #include "ilog.h"
 
 /**
@@ -135,6 +136,16 @@ struct vos_pool_df {
 	struct vea_space_df			pd_vea_df;
 	/** GC bins for container/object/dkey... */
 	struct vos_gc_bin_df			pd_gc_bins[GC_MAX];
+	/** DAOS check phase. */
+	uint32_t				pd_chk_phase;
+	/** DAOS check instance status. */
+	uint32_t				pd_chk_status;
+	/**
+	 * The inconsistency statistics during the phases range [CSP_DTX_RESYNC, OSP_AGGREGATION]
+	 * for the pool shard on the target.
+	 */
+	struct chk_statistics			pd_chk_statistics;
+	struct chk_time				pd_chk_time;
 };
 
 /**

--- a/src/vos/vos_pool.c
+++ b/src/vos/vos_pool.c
@@ -944,6 +944,10 @@ vos_pool_query(daos_handle_t poh, vos_pool_info_t *pinfo)
 	D_ASSERT(pinfo != NULL);
 	pinfo->pif_cont_nr = pool_df->pd_cont_nr;
 	pinfo->pif_gc_stat = pool->vp_gc_stat;
+	pinfo->pif_chk_phase = pool_df->pd_chk_phase;
+	pinfo->pif_chk_status = pool_df->pd_chk_status;
+	pinfo->pif_chk_statistics = pool_df->pd_chk_statistics;
+	pinfo->pif_chk_time = pool_df->pd_chk_time;
 
 	rc = vos_space_query(pool, &pinfo->pif_space, true);
 	if (rc)


### PR DESCRIPTION
This patch combines the PR#904[1-8]. It is the infrastructure for
DAOS check module. More inconsistency detect and reparation logic
will be added in subsequent patches.

Signed-off-by: Fan Yong <fan.yong@intel.com>