### PR TITLE
DAOS-10630 test: passwdlessssh not start servers

### DIFF
--- a/src/tests/ftest/deployment/critical_integration.py
+++ b/src/tests/ftest/deployment/critical_integration.py
@@ -6,22 +6,41 @@
 """
 
 from datetime import datetime
+from ClusterShell.NodeSet import NodeSet
 
 from general_utils import run_command, DaosTestError, get_journalctl
 from ior_test_base import IorTestBase
-from apricot import TestWithServers
 from exception_utils import CommandFailure
 
+# Imports need to be split or python fails to import
+from apricot import TestWithServers
+from apricot import TestWithoutServers
 
-class CriticalIntegration(TestWithServers):
+
+#TO-DO
+#Provision all daos nodes using provisioning tool provided by HPCM
+
+
+class CriticalIntegrationWithoutServers(TestWithoutServers):
     """Test Class Description: Verify the basic integration of
                                the server nodes with available
                                framework and amongst themselves.
     :avocado: recursive
     """
 
-    #TO-DO
-    #Provision all daos nodes using provisioning tool provided by HPCM
+    def __init__(self, *args, **kwargs):
+        """Initialize a CriticalIntegrationWithoutServers object."""
+        super().__init__(*args, **kwargs)
+        self.hostlist_servers = NodeSet()
+        self.hostlist_clients = NodeSet()
+
+    def setUp(self):
+        """Set up CriticalIntegrationWithoutServers."""
+        super().setUp()
+        self.hostlist_servers = list(self.get_hosts_from_yaml(
+            "test_servers", "server_partition", "server_reservation", "/run/hosts/*"))
+        self.hostlist_clients = list(self.get_hosts_from_yaml(
+            "test_clients", "server_partition", "server_reservation", "/run/hosts/*"))
 
     def test_passwdlessssh_versioncheck(self):
         # pylint: disable=protected-access
@@ -86,6 +105,14 @@ class CriticalIntegration(TestWithServers):
             self.log.info("Clients: %s", dmg_version_list)
             self.log.info("servers: %s", daos_server_version_list)
             self.fail()
+
+
+class CriticalIntegrationWithServers(TestWithServers):
+    """Test Class Description: Verify the basic integration of
+                               the server nodes with available
+                               framework and amongst themselves.
+    :avocado: recursive
+    """
 
     def test_ras(self):
         """

--- a/src/tests/ftest/util/apricot/apricot/test.py
+++ b/src/tests/ftest/util/apricot/apricot/test.py
@@ -486,6 +486,44 @@ class TestWithoutServers(Test):
                 hosts, ",".join(processes))
             stop_processes(hosts, "'({})'".format("|".join(processes)))
 
+    def get_hosts_from_yaml(self, yaml_key, partition_key, reservation_key, namespace):
+        """Get a NodeSet for the hosts to use in the test.
+        Args:
+            yaml_key (str): test yaml key used to obtain the set of hosts to test
+            partition_key (str): test yaml key used to obtain the host partition name
+            reservation_key (str): test yaml key used to obtain the host reservation name
+            namespace (str): test yaml path to the keys
+        Returns:
+            NodeSet: the set of hosts to test obtained from the test yaml
+        """
+        reservation_default = os.environ.get("_".join(["DAOS", reservation_key.upper()]), None)
+
+        # Collect any host information from the test yaml
+        host_data = self.params.get(yaml_key, namespace)
+        partition = self.params.get(partition_key, namespace)
+        reservation = self.params.get(reservation_key, namespace, reservation_default)
+        if partition is not None and host_data is not None:
+            self.fail(
+                "Specifying both a '{}' partition and '{}' set of hosts is not supported!".format(
+                    partition_key, yaml_key))
+
+        if partition is not None and host_data is None:
+            # If a partition is provided instead of a set of hosts get the set of hosts from the
+            # partition information
+            setattr(self, partition_key, partition)
+            setattr(self, reservation_key, reservation)
+            slurm_nodes = get_partition_hosts(partition, reservation)
+            if not slurm_nodes:
+                self.fail(
+                    "No valid nodes in {} partition with {} reservation".format(
+                        partition, reservation))
+            host_data = slurm_nodes
+
+        # Convert the set of hosts from slurm or the yaml file into a NodeSet
+        if isinstance(host_data, (list, tuple)):
+            return NodeSet.fromlist(host_data)
+        return NodeSet(host_data)
+
     def check_pool_free_space(self, pool, expected_scm=None, expected_nvme=None,
                               timeout=30):
         """Check pool free space with expected value.


### PR DESCRIPTION
Test-tag: criticalintegration
Skip-unit-tests: true
Skip-fault-injection-test: true

- Add get_hosts_from_yaml to TestWithoutServers
  - merge-compatible with https://github.com/daos-stack/daos/pull/8809 / DAOS-10390
- Split test_passwdlessssh_versioncheck and test_ras into separate classes
- Adjust test_passwdlessssh_versioncheck to not start servers
  - Use TestWithoutServers so the framework doesn't try to run any
    commands on the server or clients, which could fail the test early
    and prevent isolation of node failures.

Signed-off-by: Dalton Bohning <dalton.bohning@intel.com>