### PR TITLE
[DO NOT MERGE] - DAOS-10289 (#8705)  merge with DAOS-10517

### DIFF
--- a/src/tests/ftest/util/general_utils.py
+++ b/src/tests/ftest/util/general_utils.py
@@ -1317,3 +1317,23 @@ def get_primary_group(user=None):
         user = getuser()
     gid = pwd.getpwnam(user).pw_gid
     return grp.getgrgid(gid).gr_name
+
+
+def get_journalctl(hosts, since, until, journalctl_type):
+    """Run the journalctl on the hosts.
+    Args:
+        hosts (list): List of hosts to run journalctl.
+        since (str): Start time to search the log.
+        until (str): End time to search the log.
+        journalctl_type (str): String to search in the log. -t param for journalctl.
+    Returns:
+        list: a list of dictionaries containing the following key/value pairs:
+            "hosts": NodeSet containing the hosts with this data
+            "data":  data requested for the group of hosts
+    """
+    command = ("sudo /usr/bin/journalctl --system -t {} --since=\"{}\" "
+               "--until=\"{}\"".format(journalctl_type, since, until))
+    err = "Error gathering system log events"
+    results = get_host_data(hosts=hosts, command=command, text="journalctl", error=err)
+
+    return results


### PR DESCRIPTION
[DAOS-10289 bio: tuneable SPDK subsystem fini timeout (](https://github.com/daos-stack/daos/commit/45947ef7e17f8e80472e22b41f93ba4f4f2ee4d0)https://github.com/daos-stack/daos/pull/8705[)](https://github.com/daos-stack/daos/commit/45947ef7e17f8e80472e22b41f93ba4f4f2ee4d0) 

To analyze the issue of SPDK subsystem fini timeout on certain
cluster node, this patch makes the SPDK subsystem fini timeout
tuneable through through env var "DAOS_SPDK_SUBSYS_TIMEOUT".

The default timeout value is 9000 ms, one can change the default
value by setting "DAOS_SPDK_SUBSYS_TIMEOUT" to a different value
or disable timeout by setting "DAOS_SPDK_SUBSYS_TIMEOUT" to 0.

Signed-off-by: Niu Yawei <yawei.niu@intel.com>

[DAOS-10517 test: Improving deployment/critical_integration.py (](https://github.com/daos-stack/daos/commit/10beb9574695c565036e7a927b80159573102b07)https://github.com/daos-stack/daos/pull/8927[)](https://github.com/daos-stack/daos/commit/10beb9574695c565036e7a927b80159573102b07) 

Add log check for each host where rank was stopped
Stop ranks in parallel to save time

Test-tag: criticalintegration pr

Signed-off-by: Saurabh Tandan <saurabh.tandan@intel.com>

