### PR TITLE
DAOS-623 pylint: disable consider-using-f-string (#9022)

### DIFF
--- a/utils/sl/pylint3.rc
+++ b/utils/sl/pylint3.rc
@@ -1,7 +1,7 @@
 [MESSAGES CONTROL]
 disable=locally-disabled,locally-enabled,star-args,wrong-import-order,
         unused-wildcard-import,invalid-name,global-statement,bad-option-value,
-        wrong-import-position
+        wrong-import-position,consider-using-f-string
 
 [FORMAT]
 max-line-length=100


### PR DESCRIPTION
Test-tag: pr,-hw

Skip-unit-tests: true
Skip-fault-injection-test: true

This spews too many warnings and we aren't yet away from the yoke of
python2

Signed-off-by: Dalton Bohning <dalton.bohning@intel.com>