### PR TITLE
DAOS-8495 test: Increase test timeout for pool/svc.py (#9012)

### DIFF
--- a/src/tests/ftest/pool/svc.yaml
+++ b/src/tests/ftest/pool/svc.yaml
@@ -7,7 +7,7 @@ hosts:
     - server-E
 server_config:
     name: daos_server
-timeout: 150
+timeout: 200
 pool:
     control_method: dmg
     mode: 146


### PR DESCRIPTION
To avoid intermittent timeout errors with the pool/svc.py test the
avocado test timeout is being increased by 50 seconds.

Skip-unit-tests: true
Skip-func-test-el7: false
Skip-func-test-leap15: false
Test-tag: test_pool_svc
Test-repeat-vm: 5

Signed-off-by: Phillip Henderson <phillip.henderson@intel.com>