### PR TITLE
DAOS-623 hooks: Make the yamllint hook only run on diffs

### DIFF
--- a/utils/githooks/pre-commit.d/30-yamllint.sh
+++ b/utils/githooks/pre-commit.d/30-yamllint.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Runs yamllint for the DAOS project.
 #

--- a/utils/githooks/pre-commit.d/30-yamllint.sh
+++ b/utils/githooks/pre-commit.d/30-yamllint.sh
@@ -20,7 +20,7 @@ targets=(
     '*.yaml'
 )
 
-files=${files:=$(git diff --diff-filter=ACMRTUXB --name-only --cached -- "${targets[@]}")}
+files=${files:-$(git diff --diff-filter=ACMRTUXB --name-only --cached -- "${targets[@]}")}
 if [ -n "$files" ]; then
     # shellcheck disable=SC2086
     yamllint --strict $files

--- a/utils/githooks/pre-commit.d/30-yamllint.sh
+++ b/utils/githooks/pre-commit.d/30-yamllint.sh
@@ -22,5 +22,6 @@ targets=(
 
 files=${files:=$(git diff --diff-filter=ACMRTUXB --name-only --cached -- "${targets[@]}")}
 if [ -n "$files" ]; then
+    # shellcheck disable=SC2086
     yamllint --strict $files
 fi

--- a/utils/githooks/pre-commit.d/30-yamllint.sh
+++ b/utils/githooks/pre-commit.d/30-yamllint.sh
@@ -2,8 +2,9 @@
 
 # Runs yamllint for the DAOS project.
 #
-# Picks up yamllint config settings from .yamllint
-
+# Picks up yamllint config settings from .yamllint.yaml
+# The yamllint tool will use .yamllint in preference to this file and it is in .gitignore so users
+# can create one locally to overrule these settings for local commit hooks.
 set -ue
 
 if ! command -v yamllint > /dev/null 2>&1
@@ -14,4 +15,12 @@ then
 fi
 
 echo "Checking yaml formatting"
-yamllint --strict .
+targets=(
+    '*.yml'
+    '*.yaml'
+)
+
+files=${files:=$(git diff --diff-filter=ACMRTUXB --name-only --cached -- "${targets[@]}")}
+if [ -n "$files" ]; then
+    yamllint --strict $files
+fi

--- a/utils/githooks/pre-commit.d/30-yamllint.sh
+++ b/utils/githooks/pre-commit.d/30-yamllint.sh
@@ -20,8 +20,5 @@ targets=(
     '*.yaml'
 )
 
-files=${files:-$(git diff --diff-filter=ACMRTUXB --name-only --cached -- "${targets[@]}")}
-if [ -n "$files" ]; then
-    # shellcheck disable=SC2086
-    yamllint --strict $files
-fi
+git diff --diff-filter=ACMRTUXB --name-only --cached -z -- "${targets[@]}" |\
+    xargs -r0 yamllint --strict


### PR DESCRIPTION
Also fix some comments to make it clear how a user might workaround
issues locally.

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>