### PR TITLE
DAOS-10539 build: Autodetect UCX (#8967)

### DIFF
--- a/site_scons/components/__init__.py
+++ b/site_scons/components/__init__.py
@@ -176,7 +176,9 @@ def define_mercury(reqs):
                 libs=['opa'],
                 package='openpa-devel' if inst(reqs, 'openpa') else None)
 
-    reqs.define('ucx', libs=['ucp'])
+    reqs.define('ucx',
+                libs=['ucp', 'uct'],
+                headers=['uct/api/uct.h'])
 
     mercury_build = ['cmake',
                      '-DMERCURY_USE_CHECKSUMS=OFF',
@@ -196,7 +198,7 @@ def define_mercury(reqs):
     else:
         mercury_build.append('-DMERCURY_ENABLE_DEBUG=OFF')
 
-    if reqs.get_env('UCX'):
+    if reqs.check_component('ucx'):
         mercury_build.extend(['-DNA_USE_UCX=ON',
                               '-DUCX_INCLUDE_DIR=/usr/include',
                               '-DUCP_LIBRARY=/usr/lib64/libucp.so',

--- a/site_scons/prereq_tools/base.py
+++ b/site_scons/prereq_tools/base.py
@@ -725,7 +725,6 @@ class PreReqComponent():
                        'Specifies name of pkg-config to load for MPI', None))
         self.add_opts(BoolVariable('FIRMWARE_MGMT',
                                    'Build in device firmware management.', 0))
-        self.add_opts(BoolVariable('UCX', 'Build UCX support.', 0))
         self.add_opts(PathVariable('PREFIX', 'Installation path', install_dir,
                                    PathVariable.PathIsDirCreate),
                       PathVariable('GOPATH',

--- a/src/control/SConscript
+++ b/src/control/SConscript
@@ -41,7 +41,7 @@ def is_firmware_mgmt_build(benv):
 
 def is_ucx_build(benv):
     "Check whether this build has UCX enabled."
-    return benv["UCX"] == 1
+    return prereqs.check_component('ucx')
 
 def get_build_tags(benv):
     "Get custom go build tags."

--- a/src/control/fault/fault.go
+++ b/src/control/fault/fault.go
@@ -84,6 +84,9 @@ func sanitizeDescription(inDescription string) (outDescription string) {
 }
 
 func (f *Fault) Error() string {
+	if f == nil {
+		return "(nil)"
+	}
 	return fmt.Sprintf("%s: code = %d description = %q",
 		sanitizeDomain(f.Domain), f.Code, sanitizeDescription(f.Description))
 }

--- a/src/control/fault/fault_test.go
+++ b/src/control/fault/fault_test.go
@@ -17,6 +17,8 @@ import (
 )
 
 func TestFaults(t *testing.T) {
+	var nilFault *fault.Fault
+
 	for _, tc := range []struct {
 		name        string
 		testErr     error
@@ -27,6 +29,12 @@ func TestFaults(t *testing.T) {
 		{
 			name:        "nil error",
 			testErr:     nil,
+			expFaultRes: "unknown: code = 0 resolution = \"no known resolution\"",
+		},
+		{
+			name:        "nil Fault",
+			testErr:     nilFault,
+			expFaultStr: "(nil)",
 			expFaultRes: "unknown: code = 0 resolution = \"no known resolution\"",
 		},
 		{

--- a/src/control/lib/hardware/ucx/bindings_test.go
+++ b/src/control/lib/hardware/ucx/bindings_test.go
@@ -1,0 +1,37 @@
+//
+// (C) Copyright 2022 Intel Corporation.
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+//go:build ucx
+// +build ucx
+
+package ucx
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestUCXBindings_signalHandling(t *testing.T) {
+	close, err := Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer close()
+
+	defer func() {
+		// We would expect this to allow us to recover from the SIGSEGV
+		// we'll trigger on ourselves below.
+		if result := recover(); result != nil {
+			fmt.Printf("successfully recovered from panic: %+v\n", result)
+		}
+	}()
+
+	type Example struct {
+		Val int
+	}
+
+	var ex *Example
+	_ = ex.Val // this will segfault
+}

--- a/src/control/server/storage/config.go
+++ b/src/control/server/storage/config.go
@@ -398,6 +398,10 @@ func (bdl *BdevDeviceList) Equals(other *BdevDeviceList) bool {
 
 // Devices returns a slice of strings representing the block device addresses.
 func (bdl *BdevDeviceList) Devices() []string {
+	if bdl == nil {
+		return []string{}
+	}
+
 	if bdl.PCIAddressSet.Len() == 0 {
 		return bdl.stringBdevSet.ToSlice()
 	}

--- a/src/control/server/storage/config_test.go
+++ b/src/control/server/storage/config_test.go
@@ -31,6 +31,44 @@ func defConfigCmpOpts() cmp.Options {
 	}
 }
 
+func TestStorage_BdevDeviceList_Devices(t *testing.T) {
+	for name, tc := range map[string]struct {
+		list      *BdevDeviceList
+		expResult []string
+	}{
+		"nil": {
+			expResult: []string{},
+		},
+		"empty": {
+			list:      &BdevDeviceList{},
+			expResult: []string{},
+		},
+		"string set": {
+			list: &BdevDeviceList{
+				stringBdevSet: common.NewStringSet("one", "two"),
+			},
+			expResult: []string{"one", "two"},
+		},
+		"PCI addresses": {
+			list: &BdevDeviceList{
+				PCIAddressSet: *hardware.MustNewPCIAddressSet(
+					"0000:01:01.0",
+					"0000:02:02.0",
+				),
+			},
+			expResult: []string{"0000:01:01.0", "0000:02:02.0"},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			result := tc.list.Devices()
+
+			if diff := cmp.Diff(tc.expResult, result); diff != "" {
+				t.Fatalf("(-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
 func TestStorage_BdevDeviceList(t *testing.T) {
 	for name, tc := range map[string]struct {
 		devices    []string


### PR DESCRIPTION
Build UCX support in the control plane and in Mercury (if we are
building dependencies) if the UCX libraries/headers are detected.

Features: control

Signed-off-by: Kris Jacque <kristin.jacque@intel.com>