### PR TITLE
DAOS-10456 control: Enable VMD by default (#8933)

### DIFF
--- a/src/control/cmd/dmg/auto_test.go
+++ b/src/control/cmd/dmg/auto_test.go
@@ -162,7 +162,7 @@ engines:
   fabric_iface_port: 32416
   pinned_numa_node: 1
 disable_vfio: false
-enable_vmd: false
+disable_vmd: false
 enable_hotplug: false
 nr_hugepages: 6144
 control_log_mask: INFO

--- a/src/control/lib/control/auto.go
+++ b/src/control/lib/control/auto.go
@@ -399,7 +399,6 @@ func mapSSDs(ssds storage.NvmeControllers) (numaSSDsMap, error) {
 
 type storageDetails struct {
 	hugePageSize int
-	vmdEnabled   bool
 	numaPMems    numaPMemsMap
 	numaSSDs     numaSSDsMap
 }
@@ -436,10 +435,6 @@ func (sd *storageDetails) validate(log logging.Logger, engineCount int, minNrSSD
 
 		if ssds.Len() < minNrSSDs {
 			return errors.Errorf(errInsufNrSSDs, nn, minNrSSDs, ssds.Len())
-		}
-
-		if ssds.HasVMD() {
-			sd.vmdEnabled = true
 		}
 	}
 
@@ -693,8 +688,7 @@ func genConfig(log logging.Logger, newEngineCfg newEngineCfgFn, accessPoints []s
 		WithFabricProvider(engines[0].Fabric.Provider).
 		WithEngines(engines...).
 		WithControlLogFile(defaultControlLogFile).
-		WithNrHugePages(reqHugePages).
-		WithEnableVMD(sd.vmdEnabled)
+		WithNrHugePages(reqHugePages)
 
 	if err := cfg.SetEngineAffinities(log); err != nil {
 		return nil, errors.Wrap(err, "setting engine affinities")

--- a/src/control/server/config/server.go
+++ b/src/control/server/config/server.go
@@ -46,7 +46,7 @@ type Server struct {
 	BdevInclude         []string               `yaml:"bdev_include,omitempty"`
 	BdevExclude         []string               `yaml:"bdev_exclude,omitempty"`
 	DisableVFIO         bool                   `yaml:"disable_vfio"`
-	EnableVMD           bool                   `yaml:"enable_vmd"`
+	DisableVMD          bool                   `yaml:"disable_vmd"`
 	EnableHotplug       bool                   `yaml:"enable_hotplug"`
 	NrHugepages         int                    `yaml:"nr_hugepages"` // total for all engines
 	ControlLogMask      common.ControlLogLevel `yaml:"control_log_mask"`
@@ -222,10 +222,10 @@ func (cfg *Server) WithDisableVFIO(disabled bool) *Server {
 	return cfg
 }
 
-// WithEnableVMD can be used to set the state of VMD functionality,
-// if enabled then VMD devices will be used if they exist.
-func (cfg *Server) WithEnableVMD(enable bool) *Server {
-	cfg.EnableVMD = enable
+// WithDisableVMD can be used to set the state of VMD functionality,
+// if disabled then VMD devices will not be used if they exist.
+func (cfg *Server) WithDisableVMD(disable bool) *Server {
+	cfg.DisableVMD = disable
 	return cfg
 }
 
@@ -295,7 +295,6 @@ func DefaultServer() *Server {
 		Hyperthreads:    false,
 		Path:            defaultConfigPath,
 		ControlLogMask:  common.ControlLogLevel(logging.LogLevelInfo),
-		EnableVMD:       false, // disabled by default
 		EnableHotplug:   false, // disabled by default
 		// https://man7.org/linux/man-pages/man5/core.5.html
 		CoreDumpFilter: 0b00010011, // private, shared, ELF
@@ -422,7 +421,7 @@ func (cfg *Server) Validate(log logging.Logger, hugePageSize int) (err error) {
 	}
 
 	log.Debugf("vfio=%v hotplug=%v vmd=%v requested in config", !cfg.DisableVFIO,
-		cfg.EnableHotplug, cfg.EnableVMD)
+		cfg.EnableHotplug, !cfg.DisableVMD)
 
 	// Update access point addresses with control port if port is not supplied.
 	newAPs := make([]string, 0, len(cfg.AccessPoints))

--- a/src/control/server/config/server_test.go
+++ b/src/control/server/config/server_test.go
@@ -200,7 +200,7 @@ func TestServerConfig_Constructed(t *testing.T) {
 		WithBdevInclude("0000:81:00.1", "0000:81:00.2", "0000:81:00.3").
 		WithBdevExclude("0000:81:00.1").
 		WithDisableVFIO(true).   // vfio enabled by default
-		WithEnableVMD(true).     // vmd disabled by default
+		WithDisableVMD(true).    // vmd enabled by default
 		WithEnableHotplug(true). // hotplug disabled by default
 		WithControlLogMask(common.ControlLogLevelError).
 		WithControlLogFile("/tmp/daos_server.log").

--- a/src/control/server/server_utils.go
+++ b/src/control/server/server_utils.go
@@ -220,7 +220,15 @@ func prepBdevStorage(srv *server, iommuEnabled bool) error {
 		PCIAllowList: strings.Join(srv.cfg.BdevInclude, storage.BdevPciAddrSep),
 		PCIBlockList: strings.Join(srv.cfg.BdevExclude, storage.BdevPciAddrSep),
 		DisableVFIO:  srv.cfg.DisableVFIO,
-		EnableVMD:    srv.cfg.EnableVMD && !srv.cfg.DisableVFIO && iommuEnabled,
+	}
+
+	switch {
+	case !srv.cfg.DisableVMD && srv.cfg.DisableVFIO:
+		srv.log.Info("VMD not enabled because VFIO disabled in config")
+	case !srv.cfg.DisableVMD && !iommuEnabled:
+		srv.log.Info("VMD not enabled because IOMMU disabled on system")
+	default:
+		prepReq.EnableVMD = !srv.cfg.DisableVMD
 	}
 
 	if hasBdevs {

--- a/src/control/server/server_utils_test.go
+++ b/src/control/server/server_utils_test.go
@@ -289,6 +289,7 @@ func TestServer_prepBdevStorage(t *testing.T) {
 			expPrepCall: &storage.BdevPrepareRequest{
 				HugePageCount: scanMinHugePageCount,
 				TargetUser:    username,
+				EnableVMD:     true,
 			},
 		},
 		"no bdevs configured; nr_hugepages set": {
@@ -299,6 +300,7 @@ func TestServer_prepBdevStorage(t *testing.T) {
 			expPrepCall: &storage.BdevPrepareRequest{
 				HugePageCount: 1024,
 				TargetUser:    username,
+				EnableVMD:     true,
 			},
 		},
 		"2 engines both numa 0; hugepage alloc only on numa 0": {
@@ -316,6 +318,7 @@ func TestServer_prepBdevStorage(t *testing.T) {
 				PCIAllowList: fmt.Sprintf("%s%s%s", test.MockPCIAddr(1),
 					storage.BdevPciAddrSep, test.MockPCIAddr(2)),
 				PCIBlockList: test.MockPCIAddr(1),
+				EnableVMD:    true,
 			},
 			expMemSize:      16384,
 			expHugePageSize: 2,
@@ -330,6 +333,7 @@ func TestServer_prepBdevStorage(t *testing.T) {
 				HugePageCount: 16386,
 				HugeNodes:     "1",
 				TargetUser:    username,
+				EnableVMD:     true,
 			},
 			expMemSize:      16384,
 			expHugePageSize: 2,
@@ -344,6 +348,7 @@ func TestServer_prepBdevStorage(t *testing.T) {
 				HugePageCount: 8194, // 2 extra huge pages requested per-engine
 				HugeNodes:     "0,1",
 				TargetUser:    username,
+				EnableVMD:     true,
 			},
 			expMemSize:      16384,
 			expHugePageSize: 2,
@@ -358,6 +363,7 @@ func TestServer_prepBdevStorage(t *testing.T) {
 				HugePageCount: 8194,
 				HugeNodes:     "0,1",
 				TargetUser:    username,
+				EnableVMD:     true,
 			},
 			expMemChkErr: errors.New("0: want 16 GiB (8192 hugepages), got 16 GiB (8191"),
 		},
@@ -366,6 +372,7 @@ func TestServer_prepBdevStorage(t *testing.T) {
 			expPrepCall: &storage.BdevPrepareRequest{
 				HugePageCount: 128,
 				TargetUser:    username,
+				EnableVMD:     true,
 			},
 		},
 		"2 engines; scm only; nr_hugepages unset; insufficient free": {
@@ -373,6 +380,7 @@ func TestServer_prepBdevStorage(t *testing.T) {
 			expPrepCall: &storage.BdevPrepareRequest{
 				HugePageCount: 128,
 				TargetUser:    username,
+				EnableVMD:     true,
 			},
 			expMemChkErr: errors.New("requested 128 hugepages; got 0"),
 		},
@@ -381,6 +389,7 @@ func TestServer_prepBdevStorage(t *testing.T) {
 			expPrepCall: &storage.BdevPrepareRequest{
 				HugePageCount: 128,
 				TargetUser:    username,
+				EnableVMD:     true,
 			},
 		},
 		"0 engines; nr_hugepages unset; insufficient free": {
@@ -388,8 +397,8 @@ func TestServer_prepBdevStorage(t *testing.T) {
 			expPrepCall: &storage.BdevPrepareRequest{
 				HugePageCount: 128,
 				TargetUser:    username,
+				EnableVMD:     true,
 			},
-
 			expMemChkErr: errors.New("requested 128 hugepages; got 0"),
 		},
 		"0 engines; nr_hugepages unset; hpi fetch fails": {
@@ -397,6 +406,7 @@ func TestServer_prepBdevStorage(t *testing.T) {
 			expPrepCall: &storage.BdevPrepareRequest{
 				HugePageCount: 128,
 				TargetUser:    username,
+				EnableVMD:     true,
 			},
 		},
 		"1 engine; nr_hugepages unset; hpi fetch fails": {
@@ -409,6 +419,7 @@ func TestServer_prepBdevStorage(t *testing.T) {
 				HugePageCount: 8194,
 				HugeNodes:     "0",
 				TargetUser:    username,
+				EnableVMD:     true,
 			},
 			expMemChkErr: errors.New("could not find hugepage info"),
 		},
@@ -431,32 +442,23 @@ func TestServer_prepBdevStorage(t *testing.T) {
 				PCIAllowList: fmt.Sprintf("%s%s%s", test.MockPCIAddr(1),
 					storage.BdevPciAddrSep, test.MockPCIAddr(2)),
 				PCIBlockList: test.MockPCIAddr(1),
+				EnableVMD:    true,
 			},
 			expMemSize:      16384,
 			expHugePageSize: 2,
 		},
-		"reset fails; 2 engines; vmd enabled": {
+		"2 engines; vmd disabled": {
 			srvCfgExtra: func(sc *config.Server) *config.Server {
 				return sc.WithNrHugePages(16384).
 					WithEngines(nvmeEngine(0), nvmeEngine(1)).
-					WithBdevInclude(test.MockPCIAddr(1), test.MockPCIAddr(2)).
-					WithBdevExclude(test.MockPCIAddr(1)).
-					WithEnableVMD(true)
+					WithDisableVMD(true)
 			},
 			hugePagesFree: 16384,
-			bmbc: &bdev.MockBackendConfig{
-				ResetErr: errors.New("backed prep reset failed"),
-			},
 			expPrepCall: &storage.BdevPrepareRequest{
 				HugePageCount: 8194,
 				HugeNodes:     "0,1",
 				TargetUser:    username,
-				PCIAllowList: fmt.Sprintf("%s%s%s", test.MockPCIAddr(1),
-					storage.BdevPciAddrSep, test.MockPCIAddr(2)),
-				PCIBlockList: test.MockPCIAddr(1),
-				EnableVMD:    true,
 			},
-
 			expMemSize:      16384,
 			expHugePageSize: 2,
 		},

--- a/src/tests/ftest/launch.py
+++ b/src/tests/ftest/launch.py
@@ -751,11 +751,6 @@ def get_test_files(test_list, args, yaml_dir, vmd_flag=False):
         yaml_file = replace_yaml_file("{}.yaml".format(base), args, yaml_dir, vmd_flag)
         test_file["yaml"] = yaml_file
 
-        # Set enable_vmd: true in the daos_server yaml if there are VMD devices on the host
-        # regardless of whether they are being specified in the server config file to avoid
-        # failures in the server start-up NVMe scan.
-        test_file["env"] = {"DAOS_ENABLE_VMD": "True" if vmd_flag else "False"}
-
         # Display the modified yaml file variants with debug
         command = ["avocado", "variants", "--mux-yaml", test_file["yaml"]]
         if args.extra_yaml:

--- a/src/tests/ftest/util/server_utils_params.py
+++ b/src/tests/ftest/util/server_utils_params.py
@@ -5,7 +5,6 @@
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
 import os
-import ast
 
 from command_utils_base import \
     BasicParameter, LogParameter, YamlParameters, TransportCredentials
@@ -116,9 +115,7 @@ class DaosServerYamlParameters(YamlParameters):
         self.control_log_file = LogParameter(log_dir, None, "daos_control.log")
         self.helper_log_file = LogParameter(log_dir, None, "daos_admin.log")
         self.telemetry_port = BasicParameter(None, 9191)
-        default_enable_vmd_val = os.environ.get("DAOS_ENABLE_VMD", "False")
-        default_enable_vmd = ast.literal_eval(default_enable_vmd_val)
-        self.enable_vmd = BasicParameter(None, default_enable_vmd)
+        self.disable_vmd = BasicParameter(None)
 
         # Used to drop privileges before starting data plane
         # (if started as root to perform hardware provisioning)

--- a/utils/config/daos_server.yml
+++ b/utils/config/daos_server.yml
@@ -136,13 +136,16 @@
 #disable_vfio: true
 #
 #
-## Enable VMD Usage
+## Disable VMD Usage
 #
-## The use of Intel Volume Management Devices can be optionally enabled.
-## VMD needs to be available and configured in the system BIOS before use.
+## VMD (Intel Volume Management Devices) is enabled by default but can be
+## optionally disabled in which case VMD backing devices will not be visible.
+#
+## VMD needs to be available and configured in the system BIOS before it
+## can be used. The main use case for VMD is managing NVMe SSD LED activity.
 #
 ## default: false
-#enable_vmd: true
+#disable_vmd: true
 #
 #
 ## Enable NVMe SSD Hotplug


### PR DESCRIPTION
Currently VMD has to be manually enabled by setting enable_vmd: true in
server config file, the downside is that on VMD enabled systems storage
scan will fail if not manually enabled. This also relates to the use case
of DAOS RPM installation on a VMD-enabled system, where discovery mode
will fail with a blank server config file (default on first install)
until the user manually creates a server config file with enable_vmd: true
in it. Enable by default to avoid this issue.

Features: control

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>