### PR TITLE
DAOS-10397 test: Add ucx provider support to dmg_network_scan.py (#9025)

### DIFF
--- a/src/tests/ftest/control/dmg_network_scan.py
+++ b/src/tests/ftest/control/dmg_network_scan.py
@@ -4,273 +4,73 @@
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
-import os
-import re
-import socket
-
-from avocado.utils import process
 from apricot import TestWithServers
 
-
-class NetDev():
-    # pylint: disable=too-few-public-methods
-    """A class to represent the information of a network device"""
-
-    SUPPORTED_PROV = [
-        "gni", "psm2", "tcp", "sockets", "verbs", "ofi_rxm"]
-
-    def __init__(self, host=None, f_iface=None, providers=None, numa=None):
-        """Initialize the network device data object."""
-        self.host = host
-        self.f_iface = f_iface
-        self.providers = providers
-        self.numa = numa
-
-    def __repr__(self):
-        """Overwrite to display formatted devices."""
-        return self.__str__()
-
-    def __str__(self):
-        """Overwrite to display formatted devices."""
-        return "\n".join("{}: {}".format(key, getattr(self, key, "MISSING"))
-                         for key in self.__dict__)
-
-    def __ne__(self, other):
-        """Override the default not-equal implementation."""
-        return not self.__eq__(other)
-
-    def __eq__(self, other):
-        """Override the default implementation to compare devices."""
-        status = isinstance(other, NetDev)
-        for key in self.__dict__:
-            if not status:
-                break
-            try:
-                status &= getattr(self, key) == getattr(other, key)
-            except AttributeError:
-                status = False
-        return status
-
-    def get_copy(self):
-        """Create a copy instance of this object."""
-        return NetDev(self.host, self.f_iface, self.providers, self.numa)
-
-    def set_dev_info(self, dev_name, libfabric_prefix):
-        """Get all of this devices' information.
-
-        Args:
-            dev_name (str): device name or infiniband device name
-            prefix (str): prefix path pointing to libfabric install path
-        """
-        self.set_numa()
-        self.set_providers(dev_name, libfabric_prefix)
-
-    def set_numa(self):
-        """Get the numa node information for this device."""
-        if self.f_iface:
-            p = "/sys/class/net/{}/device/numa_node".format(self.f_iface)
-            if os.path.exists(p):
-                self.numa = ''.join(open(p, 'r').read()).rstrip()
-
-    def set_providers(self, dev_name, libfabric_prefix):
-        """Get the provider information."""
-        # Setup and run command
-        fi_info = os.path.join(libfabric_prefix, "bin",
-                               "fi_info -d {}".format(dev_name))
-        out = process.run(fi_info)
-
-        # Parse the list and divide the info
-        # pylint: disable=no-member
-        prov = re.findall(
-            r"(?:provider:|domain:)\s+([A-Za-z0-9;_+]+)", out.stdout_text, re.M)
-        # pylint: enable=no-member
-        info = [prov[i:(i + 2)] for i in range(0, len(prov), 2)]
-
-        # Get providers that are supported
-        supported = []
-        for i in info:
-            for sup in self.SUPPORTED_PROV:
-                if sup in i[0] and "rxd" not in i[0]:
-                    supported.append(i)
-
-        # Check that the domain name is in output found.
-        providers = []
-        for i in supported:
-            if i[1] == dev_name:
-                providers.append(i[0])
-
-        if self.providers:
-            self.providers.extend(providers)
-        else:
-            self.providers = providers
+from network_utils import get_network_information, get_dmg_network_information, SUPPORTED_PROVIDERS
 
 
 class DmgNetworkScanTest(TestWithServers):
     # pylint: disable=too-many-ancestors
     """Test Class Description:
+
     Simple test to verify the network scan function of the dmg tool.
+
     :avocado: recursive
     """
 
     def __init__(self, *args, **kwargs):
         """Initialize a DmgNetworkScanTest object."""
         super().__init__(*args, **kwargs)
-        self.start_agents_once = False
-        self.start_servers_once = False
         self.setup_start_agents = False
-        self.setup_start_servers = False
-
-    def setUp(self):
-        """Set up each test case."""
-        super().setUp()
-
-        # Run the dmg command locally, unset config to run locally
-        self.hostlist_servers = socket.gethostname().split(".")[0].split(",")
-        self.access_points = self.hostlist_servers[:1]
-        self.start_servers()
-        self.dmg = self.get_dmg_command()
-
-    @staticmethod
-    def get_devs():
-        """ Get list of devices."""
-        devs = {}
-        for dev in os.listdir("/sys/class/net/"):
-            devs[dev] = [dev]
-            # Check if we need to add infiniband dev to list
-            p = "/sys/class/net/{}/device/infiniband".format(dev)
-            if os.path.exists(p):
-                devs[dev].extend(os.listdir(p))
-        return devs
-
-    @staticmethod
-    def clean_info(net_devs):
-        """Clean up the devices found in the system.
-
-        Clean up devices that don't have a numa node and some providers that
-        might be duplicates, also need to attach 'ofi' to provider name.
-
-        Args:
-            net_devs (NetDev): list of NetDev objects.
-
-        Returns:
-            NetDev: list of NetDev objects.
-
-        """
-        idx_l = []
-        for idx, dev in enumerate(net_devs):
-            if dev.f_iface == "lo":
-                idx_l.append(idx)
-            elif not dev.numa:
-                idx_l.append(idx)
-            else:
-                if dev.providers:
-                    no_dups = list(dict.fromkeys(dev.providers))
-                    dev.providers = ["ofi+" + i for i in no_dups]
-        _ = [net_devs.pop(idx - i) for i, idx in enumerate(sorted(idx_l))]
-
-        return net_devs
 
     def get_sys_info(self):
         """Get the system device information.
 
         Returns:
-            list: list of NetDev objects.
+            list: list of NetworkDevice objects.
 
         """
-        sys_net_devs = []
-
-        # Get device names on this system
-        dev_names = self.get_devs()
-        for dev in dev_names:
-            dev_info = NetDev(self.hostlist_servers[-1], dev)
-            for dev_name in dev_names[dev]:
-                dev_info.set_dev_info(dev_name, self.ofi_prefix)
-            sys_net_devs.append(dev_info)
-
-        # Create NetDev per provider to match dmg output
-        f_net_devs = []
-        for dev in self.clean_info(sys_net_devs):
-            if dev.providers:
-                for provider in dev.providers:
-                    new_dev = dev.get_copy()
-                    new_dev.providers = [provider]
-                    f_net_devs.append(new_dev)
-
-        # Get the provider specified in server config
-        cfg_p = self.server_managers[0].get_config_value("provider")
-        if cfg_p:
-            if cfg_p == "ofi+tcp":
-                cfg_p = "ofi+tcp;ofi_rxm"
-            elif cfg_p == "ofi+verbs":
-                cfg_p = "ofi+verbs;ofi_rxm"
-            f_net_devs = [dev for dev in f_net_devs if dev.providers == [cfg_p]]
-
-        return f_net_devs
+        server_provider = self.server_managers[0].get_config_value("provider")
+        sys_info = []
+        for entry in get_network_information(self.hostlist_servers, SUPPORTED_PROVIDERS):
+            if entry.device.startswith("ib") and server_provider in entry.provider:
+                entry.ib_device = None
+                sys_info.append(entry)
+        return sys_info
 
     def get_dmg_info(self):
-        """Store the information received from dmg output.
+        """Get the information received from dmg network scan output.
 
         Returns:
-            list: list of NetDev objects.
+            list: list of NetworkDevice objects.
 
         """
-        host = None
-        numa = None
-        temp_net_devs = []
-        dmg_net_devs = []
-
-        # Get dmg info
-        network_out = self.dmg.network_scan()
-
-        # Get devices divided into dictionaries, with iface being the key. e.g.,
-        # temp_net_devs =
-        # [
-        #     {
-        #         'ib0': [['ofi+sockets'], 'wolf-154', '0'],
-        #         'ib1': [['ofi+sockets'], 'wolf-154', '1'],
-        #         'eth0': [['ofi+sockets'], 'wolf-154', '0']
-        #     }
-        # ]
-        host_fabrics = network_out["response"]["HostFabrics"]
-        struct_hash = list(host_fabrics.keys())[0]
-        interfaces = host_fabrics[struct_hash]["HostFabric"]["Interfaces"]
-
-        # Fill in the dictionary.
-        parsed_devs = {}
-        for interface in interfaces:
-            device = interface["Device"]
-            provider = interface["Provider"]
-            if device in parsed_devs:
-                parsed_devs[device][0].append(provider)
-            else:
-                host = host_fabrics[struct_hash]["HostSet"].split(":")[0]
-                parsed_devs[device] = [
-                    [provider], host, str(interface["NumaNode"])]
-
-        temp_net_devs.append(parsed_devs)
-
-        # Create NetDev objects
-        for d in temp_net_devs:
-            for iface in d:
-                net_dev = [NetDev(d[iface][1], iface, [provider], d[iface][2])
-                           for provider in d[iface][0]]
-                dmg_net_devs.extend(net_dev)
-
-        return dmg_net_devs
+        dmg = self.get_dmg_command()
+        return get_dmg_network_information(dmg.network_scan())
 
     def test_dmg_network_scan_basic(self):
-        """
-        JIRA ID: DAOS-2516
+        """JIRA ID: DAOS-2516
+
         Test Description: Test basic dmg functionality to scan the network
         devices on the system.
-        :avocado: tags=all,small,daily_regression,hw,dmg,network_scan,basic
+
+        :avocado: tags=all,daily_regression
+        :avocado: tags=hw,small
+        :avocado: tags=dmg,control
+        :avocado: tags=network_scan,basic,test_dmg_network_scan_basic
         """
         # Get info, both these functions will return a list of NetDev objects
         dmg_info = sorted(
-            self.get_dmg_info(), key=lambda x: (x.f_iface, x.providers))
+            self.get_dmg_info(), key=lambda x: (x.device, x.provider))
         sys_info = sorted(
-            self.get_sys_info(), key=lambda x: (x.f_iface, x.providers))
+            self.get_sys_info(), key=lambda x: (x.device, x.provider))
 
         # Validate the output with what we expect.
-        msg = "\nDmg Info:\n{} \n\nSysInfo:\n{}".format(dmg_info, sys_info)
+        for title, info in {"SYS INFO": sys_info, "DMG INFO": dmg_info}.items():
+            self.log.info("-" * 100)
+            self.log.info(title)
+            for entry in info:
+                self.log.info("  %s", entry)
+        self.log.info("-" * 100)
+        msg = f"\nDmg Info:\n{dmg_info} \n\nSysInfo:\n{sys_info}"
         self.assertEqual(sys_info, dmg_info, msg)

--- a/src/tests/ftest/util/general_utils.py
+++ b/src/tests/ftest/util/general_utils.py
@@ -288,26 +288,102 @@ def run_command(command, timeout=60, verbose=True, raise_exception=True,
         raise DaosTestError(msg)
 
 
-def run_task(hosts, command, timeout=None):
+def run_task(hosts, command, timeout=None, verbose=False):
     """Create a task to run a command on each host in parallel.
 
     Args:
         hosts (list): list of hosts
         command (str): the command to run in parallel
         timeout (int, optional): command timeout in seconds. Defaults to None.
+        verbose (bool, optional): display message for command execution. Defaults to False.
 
     Returns:
         Task: a ClusterShell.Task.Task object for the executed command
 
     """
+    if not isinstance(hosts, NodeSet):
+        hosts = NodeSet.fromlist(hosts)
     task = task_self()
     # Enable forwarding of the ssh authentication agent connection
     task.set_info("ssh_options", "-oForwardAgent=yes")
-    kwargs = {"command": command, "nodes": NodeSet.fromlist(hosts)}
+    kwargs = {"command": command, "nodes": hosts}
     if timeout is not None:
         kwargs["timeout"] = timeout
+    if verbose:
+        log = getLogger()
+        log.info("Running on %s: %s", hosts, command)
     task.run(**kwargs)
     return task
+
+
+def check_task(task, logger=None):
+    """Check the results of the executed task and get the output.
+
+    Args:
+        task (Task): a ClusterShell.Task.Task object for the executed command
+
+    Returns:
+        bool: if the command returned an 0 exit status on every host
+
+    """
+    def check_task_log(message):
+        """Log the provided text if a logger is present.
+
+        Args:
+            message (str): text to display
+        """
+        if logger:
+            logger.info(message)
+
+    # Create a dictionary of hosts for each unique return code
+    results = dict(task.iter_retcodes())
+
+    # Display the command output
+    for code in sorted(results):
+        output_data = list(task.iter_buffers(results[code]))
+        if not output_data:
+            output_data = [["<NONE>", results[code]]]
+        for output, o_hosts in output_data:
+            node_set = NodeSet.fromlist(o_hosts)
+            lines = list(output.splitlines())
+            if len(lines) > 1:
+                # Print the sub-header for multiple lines of output
+                check_task_log("    {}: rc={}, output:".format(node_set, code))
+            for number, line in enumerate(lines):
+                if isinstance(line, bytes):
+                    line = line.decode("utf-8")
+                if len(lines) == 1:
+                    # Print the sub-header and line for one line of output
+                    check_task_log("    {}: rc={}, output: {}".format(node_set, code, line))
+                    continue
+                try:
+                    check_task_log("      {}".format(line))
+                except IOError:
+                    # DAOS-5781 Jenkins doesn't like receiving large amounts of data in a short
+                    # space of time so catch this and retry.
+                    check_task_log(
+                        "*** DAOS-5781: Handling IOError detected while processing line {}/{} with "
+                        "retry ***".format(*number + 1, len(lines)))
+                    time.sleep(5)
+                    check_task_log("      {}".format(line))
+
+    # List any hosts that timed out
+    timed_out = [str(hosts) for hosts in task.iter_keys_timeout()]
+    if timed_out:
+        check_task_log("    {}: timeout detected".format(NodeSet.fromlist(timed_out)))
+
+    # Determine if the command completed successfully across all the hosts
+    return len(results) == 1 and 0 in results
+
+
+def display_task(task):
+    """Display the output for the executed task.
+
+    Args:
+        task (Task): a ClusterShell.Task.Task object for the executed command
+    """
+    log = getLogger()
+    return check_task(task, log)
 
 
 def run_pcmd(hosts, command, verbose=True, timeout=None, expect_rc=0):
@@ -602,7 +678,7 @@ def get_random_string(length, exclude=None, include=None):
 
     random_string = None
     while not isinstance(random_string, str) or random_string in exclude:
-        random_string = "".join(random.choice(include) for _ in range(length)) #nosec
+        random_string = "".join(random.choice(include) for _ in range(length))  # nosec
     return random_string
 
 

--- a/src/tests/ftest/util/network_utils.py
+++ b/src/tests/ftest/util/network_utils.py
@@ -1,0 +1,559 @@
+#!/usr/bin/python3
+"""
+  (C) Copyright 2022 Intel Corporation.
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+"""
+import errno
+from logging import getLogger
+import os
+import re
+
+from ClusterShell.NodeSet import NodeSet
+
+from exception_utils import CommandFailure
+from general_utils import run_task, display_task
+
+SUPPORTED_PROVIDERS = ("ofi+sockets", "ofi+tcp;ofi_rxm", "ofi+verbs;ofi_rxm", "ucx+dc_x")
+
+
+class NetworkDevice():
+    """A class to represent the information of a network device."""
+
+    def __init__(self, host, device, ib_device, port, provider, numa):
+        """Initialize the network device data object."""
+        self.host = host
+        self.device = device
+        self.ib_device = ib_device
+        self.port = port
+        self.provider = provider
+        self.numa = numa
+
+    def __repr__(self):
+        """Overwrite to display formatted devices."""
+        return self.__str__()
+
+    def __str__(self):
+        """Overwrite to display formatted devices."""
+        settings = [f"{key}={getattr(self, key, None)}" for key in self.__dict__]
+        return f"NetworkDevice({', '.join(settings)})"
+
+    def __ne__(self, other):
+        """Override the default not-equal implementation."""
+        return not self.__eq__(other)
+
+    def __eq__(self, other):
+        """Override the default implementation to compare devices."""
+        status = True
+        if not isinstance(other, NetworkDevice):
+            return False
+        for key in self.__dict__:
+            try:
+                status &= str(getattr(self, key)) == str(getattr(other, key))
+            except AttributeError:
+                return False
+        return status
+
+    @property
+    def domain(self):
+        """Get the domain for this network device.
+
+        Returns:
+            str: the domain for this network device
+
+        """
+        if "ucx" in self.provider:
+            return ":".join([self.ib_device, self.port])
+        return self.ib_device
+
+
+def get_active_network_interfaces(hosts, verbose=True):
+    """Get all active network interfaces on the hosts.
+
+    Args:
+        hosts (NodeSet): hosts on which to find active interfaces
+        verbose (bool, optional): display command details. Defaults to True.
+
+    Returns:
+        dict: a dictionary of interface keys and NodeSet values on which they were found
+
+    """
+    net_path = os.path.join(os.path.sep, "sys", "class", "net")
+    operstate = os.path.join(net_path, "*", "operstate")
+    command = " | ".join([f"grep -l 'up' {operstate}", "grep -Ev '/(lo|bonding_masters)/'", "sort"])
+    task = run_task(hosts, command, verbose=verbose)
+    if verbose:
+        display_task(task)
+
+    # Populate a dictionary of active interfaces with a NodSet of hosts on which it was found
+    active_interfaces = {}
+    for output, nodelist in task.iter_buffers():
+        output_lines = [line.decode("utf-8") for line in output]
+        nodeset = NodeSet.fromlist(nodelist)
+        for line in output_lines:
+            try:
+                interface = line.split("/")[-2]
+                if interface not in active_interfaces:
+                    active_interfaces[interface] = NodeSet()
+                active_interfaces[interface].update(nodeset)
+            except IndexError:
+                pass
+
+    return active_interfaces
+
+
+def get_common_interfaces(hosts, verbose=True):
+    """Get the active interfaces that exists on all the hosts.
+
+    Args:
+        hosts (NodeSet): hosts on which to find active interfaces
+        verbose (bool, optional): display command details. Defaults to True.
+
+    Returns:
+        list: a list of available NetworkDevice objects common to all hosts
+
+    """
+    log = getLogger()
+
+    # Find any active network interfaces on the server or client hosts
+    interfaces_per_host = get_active_network_interfaces(hosts, verbose)
+
+    # From the active interface dictionary find all the interfaces that are common to all hosts
+    log.info("Active network interfaces detected:")
+    common_interfaces = []
+    for interface, node_set in interfaces_per_host.items():
+        log.info("  - %-8s on %s (Common=%s)", interface, node_set, node_set == hosts)
+        if node_set == hosts:
+            common_interfaces.append(interface)
+
+    return common_interfaces
+
+
+def get_interface_speeds(hosts, interface, verbose=True):
+    """Get the speeds of this network interface on each host.
+
+    Args:
+        hosts (NodeSet): hosts on which to detect the interface speed
+        interface (str): interface for which to obtain the speed
+        verbose (bool, optional): display command details. Defaults to True.
+
+    Returns:
+        dict: a dictionary of interface speed keys and NodeSet values on which they were detected
+
+    """
+    net_path = os.path.join(os.path.sep, "sys", "class", "net")
+    command = f"cat {os.path.join(net_path, interface, 'speed')}"
+    task = run_task(hosts, command, verbose=verbose)
+    if verbose:
+        display_task(task)
+
+    # Populate a dictionary of interface speeds with a NodSet of hosts on which it was detected
+    interface_speeds = {}
+    results = dict(task.iter_retcodes())
+    if 0 in results:
+        for output, nodelist in task.iter_buffers(results[0]):
+            output_lines = [line.decode("utf-8") for line in output]
+            nodeset = NodeSet.fromlist(nodelist)
+            for line in output_lines:
+                try:
+                    speed = int(line.strip())
+                except IOError as io_error:
+                    # KVM/Qemu/libvirt returns an EINVAL
+                    if io_error.errno == errno.EINVAL:
+                        speed = 1000
+                except ValueError:
+                    # Any line not containing a speed (integer)
+                    continue
+                if speed not in interface_speeds:
+                    interface_speeds[speed] = NodeSet()
+                interface_speeds[speed].update(nodeset)
+
+    return interface_speeds
+
+
+def get_interface_numa_node(hosts, interface, verbose=True):
+    """Get the NUMA node ID of this network interface on each host.
+
+    Args:
+        hosts (NodeSet): hosts on which to detect the NUMA node
+        interface (str): interface for which to obtain the NUMA node
+        verbose (bool, optional): display command details. Defaults to True.
+
+    Returns:
+        dict: a dictionary of NUMA node ID keys and NodeSet values on which they were detected
+
+    """
+    net_path = os.path.join(os.path.sep, "sys", "class", "net")
+    command = f"cat {os.path.join(net_path, interface, 'device', 'numa_node')}"
+    task = run_task(hosts, command, verbose=verbose)
+    if verbose:
+        display_task(task)
+
+    # Populate a dictionary of numa node IDs with a NodSet of hosts on which it was detected
+    numa_nodes = {}
+    results = dict(task.iter_retcodes())
+    if 0 in results:
+        for output, nodelist in task.iter_buffers(results[0]):
+            output_lines = [line.decode("utf-8") for line in output]
+            nodeset = NodeSet.fromlist(nodelist)
+            for line in output_lines:
+                try:
+                    numa_node = int(line.strip())
+                except ValueError:
+                    continue
+                if numa_node not in numa_nodes:
+                    numa_nodes[numa_node] = NodeSet()
+                numa_nodes[numa_node].update(nodeset)
+
+    return numa_nodes
+
+
+def get_interface_ib_name(hosts, interface, verbose=True):
+    """Get the InfiniBand name of this network interface on each host.
+
+    Args:
+        hosts (NodeSet): hosts on which to detect the InfiniBand name
+        interface (str): interface for which to obtain the InfiniBand name
+        verbose (bool, optional): display command details. Defaults to True.
+
+    Returns:
+        dict: a dictionary of InfiniBand name keys and NodeSet values on which they were detected
+
+    """
+    net_path = os.path.join(os.path.sep, "sys", "class", "net")
+    command = f"ls -1 {os.path.join(net_path, interface, 'device', 'infiniband')}"
+    task = run_task(hosts, command, verbose=verbose)
+    if verbose:
+        display_task(task)
+
+    # Populate a dictionary of IB names with a NodSet of hosts on which it was detected
+    ib_names = {}
+    results = dict(task.iter_retcodes())
+    if 0 in results:
+        for output, nodelist in task.iter_buffers(results[0]):
+            ib_name_list = []
+            for line in output:
+                match = re.findall(r"([A-Za-z0-9;_+]+)", line.decode("utf-8"))
+                if len(match) == 1:
+                    ib_name_list.append(match[0])
+            if ib_name_list:
+                ib_names[",".join(ib_name_list)] = NodeSet.fromlist(nodelist)
+
+    return ib_names
+
+
+def get_ofi_info(hosts, supported=None, verbose=True):
+    """Get the OFI provider information from the specified hosts.
+
+    Args:
+        hosts (NodeSet): hosts from which to gather the information
+        supported (list, optional): list of supported providers when if provided will limit the
+            inclusion to only those providers specified. Defaults to None.
+        verbose (bool, optional): display command details. Defaults to True.
+
+    Returns:
+        dict: a dictionary of interface keys with a dictionary value of a comma-separated string of
+            providers key with a NodeSet value where the providers where detected.
+
+    """
+    task = run_task(hosts, "fi_info", verbose=verbose)
+    if verbose:
+        display_task(task)
+
+    # Populate a dictionary of interfaces with a list of provider lists and NodSet of hosts on which
+    # the providers were detected.
+    providers = {}
+    results = dict(task.iter_retcodes())
+    if 0 in results:
+        for output, nodelist in task.iter_buffers(results[0]):
+            output_lines = [line.decode("utf-8").rstrip(os.linesep) for line in output]
+            nodeset = NodeSet.fromlist(nodelist)
+
+            # Find all the provider and domain pairings. The fi_info output reports these on
+            # separate lines when processing the re matches ensure each domain is preceded by a
+            # provider.
+            interface_providers = {}
+            data = re.findall(r"(provider|domain):\s+([A-Za-z0-9;_+]+)", "\n".join(output_lines))
+            while data:
+                provider = list(data.pop(0))
+                if provider[0] == "provider" and data[0][0] == "domain":
+                    provider.pop(0)
+                    domain = list(data.pop(0))
+                    domain.pop(0)
+
+                    # A provider and domain must be specified
+                    if not provider or not domain:
+                        continue
+
+                    # Add 'ofi+' to the provider
+                    provider = ["+".join(["ofi", item]) for item in provider]
+
+                    # Only include supported providers if a supported list is provided
+                    if supported and provider[0] not in supported:
+                        continue
+
+                    if domain[0] not in interface_providers:
+                        interface_providers[domain[0]] = set()
+                    interface_providers[domain[0]].update(provider)
+
+            for interface, provider_set in interface_providers.items():
+                if interface not in providers:
+                    providers[interface] = {}
+                provider_key = ",".join(list(provider_set))
+                if provider_key not in providers[interface]:
+                    providers[interface][provider_key] = NodeSet()
+                providers[interface][provider_key].update(nodeset)
+
+    return providers
+
+
+def get_ucx_info(hosts, supported=None, verbose=True):
+    """Get the UCX provider information from the specified hosts.
+
+    Args:
+        hosts (NodeSet): hosts from which to gather the information
+        supported (list, optional): list of supported providers when if provided will limit the
+            inclusion to only those providers specified. Defaults to None.
+        verbose (bool, optional): display command details. Defaults to True.
+
+    Returns:
+        dict: a dictionary of interface keys with a dictionary value of a comma-separated string of
+            providers key with a NodeSet value where the providers where detected.
+
+    """
+    task = run_task(hosts, "ucx_info -d", verbose=verbose)
+    if verbose:
+        display_task(task)
+
+    # Populate a dictionary of interfaces with a list of provider lists and NodSet of hosts on which
+    # the providers were detected.
+    providers = {}
+    results = dict(task.iter_retcodes())
+    if 0 in results:
+        for output, nodelist in task.iter_buffers(results[0]):
+            output_lines = [line.decode("utf-8").rstrip(os.linesep) for line in output]
+            nodeset = NodeSet.fromlist(nodelist)
+
+            # Find all the transport, device, and type pairings. The ucx_info output reports these
+            # on separate lines so when processing the re matches ensure each device is preceded by
+            # a provider.
+            interface_providers = {}
+            data = re.findall(r"(Transport|Device):\s+([A-Za-z0-9;_+]+)", "\n".join(output_lines))
+            while data:
+                transport = list(data.pop(0))
+                if transport[0] == "Transport" and data[0][0] == "Device":
+                    transport.pop(0)
+                    device = list(data.pop(0))
+                    device.pop(0)
+
+                    # A transport and device must be specified
+                    if not transport or not device:
+                        continue
+
+                    # Add 'ucx+' to the provider and replace 'mlx[0-9]' with 'x'
+                    transport = [
+                        "+".join(["ucx", re.sub(r"mlx[0-9]+", "x", item)]) for item in transport]
+
+                    # Only include supported providers if a supported list is provided
+                    if supported and transport[0] not in supported:
+                        continue
+
+                    if device[0] not in interface_providers:
+                        interface_providers[device[0]] = set()
+                    interface_providers[device[0]].update(transport)
+
+            for interface, provider_set in interface_providers.items():
+                if interface not in providers:
+                    providers[interface] = {}
+                provider_key = ",".join(list(provider_set))
+                if provider_key not in providers[interface]:
+                    providers[interface][provider_key] = NodeSet()
+                providers[interface][provider_key].update(nodeset)
+
+    return providers
+
+
+def get_interface_providers(interface, provider_data):
+    """Get the providers supported by this interface.
+
+    Args:
+        interface (str): interface for which to obtain the InfiniBand name
+        provider_data (dict): output from get_ofi_info() or get_ucx_info()
+
+    Returns:
+        dict: a dictionary of comma-separated strings of providers keys and NodeSet values on which
+            they were detected
+
+    """
+    providers = {}
+    if interface in provider_data:
+        for provider, node_set in provider_data[interface].items():
+            if provider not in providers:
+                providers[provider] = NodeSet()
+            providers[provider].update(node_set)
+
+    return providers
+
+
+def get_fastest_interface(hosts, verbose=True):
+    """Get the fastest active interface common to all hosts.
+
+    Args:
+        hosts (NodeSet): hosts on which to find the fastest interfaces
+        verbose (bool, optional): display command details. Defaults to True.
+
+    Returns:
+        str: the fastest active interface common to all hosts specified
+
+    """
+    log = getLogger()
+    common_interfaces = get_common_interfaces(hosts, verbose)
+
+    # Find the speed of each common active interface in order to be able to choose the fastest
+    interface_speeds = {}
+    for interface in common_interfaces:
+        detected_speeds = get_interface_speeds(hosts, interface, verbose)
+        speed_list = []
+        for speed, node_set in detected_speeds.items():
+            if node_set == hosts:
+                # Only include detected homogeneous interface speeds
+                speed_list.append(speed)
+        if speed_list:
+            interface_speeds[interface] = min(speed_list)
+
+    log.info("Active network interface speeds on %s:", hosts)
+    available_interfaces = {}
+    for interface in sorted(interface_speeds):
+        log.info("  - %-8s (speed: %6s)", interface, interface_speeds[interface])
+
+        # Only include the first active interface (as determined by alphabetic sort) for each speed
+        if interface_speeds[interface] not in available_interfaces:
+            available_interfaces[interface_speeds[interface]] = interface
+
+    log.info("Available interfaces on %s: %s", hosts, available_interfaces)
+    try:
+        # Select the fastest active interface available by sorting the speed
+        interface = available_interfaces[sorted(available_interfaces)[-1]]
+    except IndexError:
+        interface = None
+
+    log.info("Fastest interface detected on %s: %s", hosts, interface)
+    return interface
+
+
+def get_common_provider(hosts, interface, supported=None, verbose=True):
+    """Get the list of providers supported by the interface on every host.
+
+    Args:
+        hosts (NodeSet): hosts on which to find the provider information
+        interface (str): interface for which to obtain the providers
+        supported (list, optional): list of supported providers when if provided will limit the
+            inclusion to only those providers specified. Defaults to None.
+        verbose (bool, optional): display command details. Defaults to True.
+
+    Returns:
+        list: a list of providers supported by the interface on every host
+
+    """
+    ofi_info = get_ofi_info(hosts, supported, verbose)
+    providers = get_interface_providers(interface, ofi_info)
+    for ib_name in get_interface_ib_name(hosts, interface, verbose):
+        providers.update(get_interface_providers(ib_name, ofi_info))
+
+    if not supported or "ucx" in supported:
+        ucx_info = get_ucx_info(hosts, supported, verbose)
+        for ib_name in get_interface_ib_name(hosts, interface, verbose):
+            for add_on in ([], ["1"]):
+                device = ":".join([ib_name] + add_on)
+                providers.update(get_interface_providers(device, ucx_info))
+
+    # Only include the providers supported by the interface on all of the hosts
+    common_providers = set()
+    for provider, node_set in providers.items():
+        if node_set == hosts:
+            common_providers.update(provider.split(","))
+
+    return list(common_providers)
+
+
+def get_network_information(hosts, supported=None, verbose=True):
+    """Get the network device information on the hosts specified.
+
+    Args:
+        hosts (NodeSet): hosts on which to find the network information
+        supported (list, optional): list of supported providers when if provided will limit the
+            inclusion to only those providers specified. Defaults to None.
+        verbose (bool, optional): display command details. Defaults to True.
+
+    Returns:
+        list: a list of NetworkDevice objects identifying the network devices on each host
+
+    """
+    network_devices = []
+
+    ofi_info = get_ofi_info(hosts, supported, verbose)
+    ucx_info = get_ucx_info(hosts, supported, verbose)
+
+    interfaces = get_active_network_interfaces(hosts, verbose)
+    for host in hosts:
+        for interface, node_set in interfaces.items():
+            if host not in node_set:
+                continue
+            kwargs = {"host": host, "device": interface, "port": 1}
+            data_gather = {
+                "ib_device": get_interface_ib_name(node_set, interface, verbose),
+                "provider": get_interface_providers(interface, ofi_info),
+                "numa": get_interface_numa_node(node_set, interface, verbose),
+            }
+            for ib_name in data_gather["ib_device"]:
+                for add_on in ([], ["1"]):
+                    device = ":".join([ib_name] + add_on)
+                    data_gather["provider"].update(get_interface_providers(device, ofi_info))
+                    data_gather["provider"].update(get_interface_providers(device, ucx_info))
+            for key, data in data_gather.items():
+                kwargs[key] = []
+                for item, item_node_set in data.items():
+                    if node_set == item_node_set:
+                        kwargs[key].append(item)
+                if kwargs[key]:
+                    kwargs[key] = ",".join([str(item) for item in kwargs[key]])
+                else:
+                    kwargs[key] = None
+
+            for item in kwargs["provider"].split(","):
+                these_kwargs = kwargs.copy()
+                these_kwargs["provider"] = item
+                network_devices.append(NetworkDevice(**these_kwargs))
+
+    return network_devices
+
+
+def get_dmg_network_information(dmg_network_scan):
+    """Get the network device information from the dmg network scan output.
+
+    Args:
+        dmg_network_scan (dict): the dmg network scan json command output
+
+    Raises:
+        CommandFailure: if there was an error processing the dmg network scan output
+
+    Returns:
+        list: a list of NetworkDevice objects identifying the network devices on each host
+
+    """
+    network_devices = []
+
+    try:
+        for host_fabric in dmg_network_scan["response"]["HostFabrics"].values():
+            for host in NodeSet(host_fabric["HostSet"].split(":")[0]):
+                for interface in host_fabric["HostFabric"]["Interfaces"]:
+                    network_devices.append(
+                        NetworkDevice(
+                            host, interface["Device"], None, 1, interface["Provider"],
+                            interface["NumaNode"])
+                    )
+    except KeyError as error:
+        raise CommandFailure(
+            f"Error processing dmg network scan json output: {dmg_network_scan}") from error
+
+    return network_devices


### PR DESCRIPTION
Adding new network_utils.py methods to collect network information for
ofi and ucx and providing a data structure for storing this information.

Updating the dmg_network_scan.py to make use of these new utility
methods to verify interfaces used with ofi and ucx providers.

Use the specified remote host to run the server and issue the network
discovery commands on the same remote host (DAOS-10062).

Skip-unit-tests: true
Test-tag: dmg,network_scan,basic zero_config

Signed-off-by: Phillip Henderson <phillip.henderson@intel.com>