### PR TITLE
[DAO-10593] Fix NVMe available space

### DIFF
--- a/src/control/server/ctl_storage_rpc.go
+++ b/src/control/server/ctl_storage_rpc.go
@@ -168,8 +168,8 @@ func (c *ControlService) scanScm(ctx context.Context, req *ctlpb.ScanScmReq) (*c
 // Adjust the NVME available size to its real usable size.
 func (c *ControlService) adjustNvmeSize(resp *ctlpb.ScanNvmeResp) {
 	type deviceSizeStat struct {
-		size    uint64
-		devices []*ctl.NvmeController_SmdDevice
+		clusterCount uint64 // Number of SPDK cluster for each target
+		devices      []*ctl.NvmeController_SmdDevice
 	}
 
 	devicesToAdjust := make(map[uint32]*deviceSizeStat, 0)
@@ -192,14 +192,13 @@ func (c *ControlService) adjustNvmeSize(resp *ctlpb.ScanNvmeResp) {
 			rank := dev.GetRank()
 			if devicesToAdjust[rank] == nil {
 				devicesToAdjust[rank] = &deviceSizeStat{
-					size: math.MaxUint64,
+					clusterCount: math.MaxUint64,
 				}
 			}
 			targetCount := uint64(len(dev.GetTgtIds()))
-			unalignedBytes := dev.GetAvailBytes() % (targetCount * dev.GetClusterSize())
-			availBytes := dev.AvailBytes - unalignedBytes
-			if availBytes < devicesToAdjust[rank].size {
-				devicesToAdjust[rank].size = availBytes
+			clusterCount := dev.GetAvailBytes() / (targetCount * dev.GetClusterSize())
+			if clusterCount < devicesToAdjust[rank].clusterCount {
+				devicesToAdjust[rank].clusterCount = clusterCount
 			}
 			devicesToAdjust[rank].devices = append(devicesToAdjust[rank].devices, dev)
 		}
@@ -207,12 +206,16 @@ func (c *ControlService) adjustNvmeSize(resp *ctlpb.ScanNvmeResp) {
 
 	for rank, item := range devicesToAdjust {
 		for _, dev := range item.devices {
-			unusedBytes := dev.AvailBytes - item.size
-			c.log.Debugf("Adjusting available size of SMD device %s from rank %d: "+
-				"excluding %s (%d Bytes) of unusable storage",
-				dev.GetUuid(), rank,
-				humanize.Bytes(unusedBytes), unusedBytes)
-			dev.AvailBytes = item.size
+			targetCount := uint64(len(dev.GetTgtIds()))
+			availBytes := targetCount * item.clusterCount * dev.GetClusterSize()
+			if availBytes != dev.GetAvailBytes() {
+				c.log.Debugf("Adjusting available size of SMD device %s from rank %d "+
+					"(targets: %d): from %s (%d Bytes) to %s (%d bytes)",
+					dev.GetUuid(), rank, dev.GetTgtIds(),
+					humanize.Bytes(dev.GetAvailBytes()), dev.GetAvailBytes(),
+					humanize.Bytes(availBytes), availBytes)
+				dev.AvailBytes = availBytes
+			}
 		}
 	}
 }

--- a/src/control/server/ctl_storage_rpc_test.go
+++ b/src/control/server/ctl_storage_rpc_test.go
@@ -52,17 +52,16 @@ var (
 func adjustNvmeSize(smdDevices []*ctl.NvmeController_SmdDevice) {
 	const targetNb uint64 = 4
 
-	availBytes := uint64(math.MaxUint64)
+	clusterCount := uint64(math.MaxUint64)
 	for _, dev := range smdDevices {
-		unalignedMemory := dev.AvailBytes % (targetNb * clusterSize)
-		usabledMemory := dev.AvailBytes - unalignedMemory
-		if usabledMemory < availBytes {
-			availBytes = usabledMemory
+		targetClusterCount := dev.AvailBytes / (targetNb * clusterSize)
+		if targetClusterCount < clusterCount {
+			clusterCount = targetClusterCount
 		}
 	}
 
 	for _, dev := range smdDevices {
-		dev.AvailBytes = availBytes
+		dev.AvailBytes = clusterCount * targetNb * clusterSize
 	}
 }
 
@@ -2246,7 +2245,7 @@ func TestServer_adjustNvmeSize(t *testing.T) {
 		input  *ctlpb.ScanNvmeResp
 		output ExpectedOutput
 	}{
-		"success": {
+		"homogeneous": {
 			input: &ctlpb.ScanNvmeResp{
 				Ctrlrs: []*ctlpb.NvmeController{
 					{
@@ -2261,20 +2260,22 @@ func TestServer_adjustNvmeSize(t *testing.T) {
 							},
 							{
 								Uuid:        "nvme1",
-								TgtIds:      []int32{0, 1, 2, 3},
+								TgtIds:      []int32{4, 5, 6, 7},
 								AvailBytes:  10 * humanize.GiByte,
 								ClusterSize: clusterSize,
 								DevState:    "NORMAL",
 								Rank:        0,
 							},
 							{
-								TgtIds:      []int32{0, 1, 2, 3},
+								Uuid:        "nvme2",
+								TgtIds:      []int32{8, 9, 10, 11},
 								AvailBytes:  20 * humanize.GiByte,
 								ClusterSize: clusterSize,
 								DevState:    "NORMAL",
 								Rank:        0,
 							},
 							{
+								Uuid:        "nvme3",
 								TgtIds:      []int32{0, 1, 2},
 								AvailBytes:  20 * humanize.GiByte,
 								ClusterSize: clusterSize,
@@ -2282,7 +2283,8 @@ func TestServer_adjustNvmeSize(t *testing.T) {
 								Rank:        1,
 							},
 							{
-								TgtIds:      []int32{0, 1, 2},
+								Uuid:        "nvme4",
+								TgtIds:      []int32{3, 4, 5},
 								AvailBytes:  20 * humanize.GiByte,
 								ClusterSize: clusterSize,
 								DevState:    "NORMAL",
@@ -2296,6 +2298,65 @@ func TestServer_adjustNvmeSize(t *testing.T) {
 				availableBytes: []uint64{
 					8 * humanize.GiByte,
 					8 * humanize.GiByte,
+					8 * humanize.GiByte,
+					18 * humanize.GiByte,
+					18 * humanize.GiByte,
+				},
+			},
+		},
+		"heterogeneous": {
+			input: &ctlpb.ScanNvmeResp{
+				Ctrlrs: []*ctlpb.NvmeController{
+					{
+						SmdDevices: []*ctlpb.NvmeController_SmdDevice{
+							{
+								Uuid:        "nvme0",
+								TgtIds:      []int32{0, 1, 2, 3},
+								AvailBytes:  10 * humanize.GiByte,
+								ClusterSize: clusterSize,
+								DevState:    "NORMAL",
+								Rank:        0,
+							},
+							{
+								Uuid:        "nvme1",
+								TgtIds:      []int32{4, 5, 6},
+								AvailBytes:  10 * humanize.GiByte,
+								ClusterSize: clusterSize,
+								DevState:    "NORMAL",
+								Rank:        0,
+							},
+							{
+								Uuid:        "nvme2",
+								TgtIds:      []int32{7, 8, 9, 10},
+								AvailBytes:  20 * humanize.GiByte,
+								ClusterSize: clusterSize,
+								DevState:    "NORMAL",
+								Rank:        0,
+							},
+							{
+								Uuid:        "nvme3",
+								TgtIds:      []int32{0, 1, 2},
+								AvailBytes:  20 * humanize.GiByte,
+								ClusterSize: clusterSize,
+								DevState:    "NORMAL",
+								Rank:        1,
+							},
+							{
+								Uuid:        "nvme4",
+								TgtIds:      []int32{3, 4, 5},
+								AvailBytes:  20 * humanize.GiByte,
+								ClusterSize: clusterSize,
+								DevState:    "NORMAL",
+								Rank:        1,
+							},
+						},
+					},
+				},
+			},
+			output: ExpectedOutput{
+				availableBytes: []uint64{
+					8 * humanize.GiByte,
+					6 * humanize.GiByte,
 					8 * humanize.GiByte,
 					18 * humanize.GiByte,
 					18 * humanize.GiByte,
@@ -2339,12 +2400,14 @@ func TestServer_adjustNvmeSize(t *testing.T) {
 					{
 						SmdDevices: []*ctlpb.NvmeController_SmdDevice{
 							{
+								Uuid:        "nvme0",
 								TgtIds:      []int32{0, 1, 2, 3},
 								AvailBytes:  10 * humanize.GiByte,
 								ClusterSize: clusterSize,
 								DevState:    "NORMAL",
 							},
 							{
+								Uuid:        "nvme1",
 								TgtIds:      []int32{0, 1, 2},
 								AvailBytes:  10 * humanize.GiByte,
 								ClusterSize: clusterSize,

--- a/src/tests/ftest/pool/create_all_hw.yaml
+++ b/src/tests/ftest/pool/create_all_hw.yaml
@@ -1,3 +1,6 @@
+setup:
+    start_agents_once: False
+    start_servers_once: False
 hosts:
   test_servers:
     - server-A
@@ -15,7 +18,15 @@ server_config:
   name: daos_server
   servers:
     0:
-      targets: 4
+      targets_count: !mux
+        1_target:
+          targets: 1
+        2_targets:
+          targets: 2
+        3_targets:
+          targets: 3
+        4_targets:
+          targets: 4
       bdev_class: nvme
       bdev_list: ["aaaa:aa:aa.a", "bbbb:bb:bb.b"]
       scm_class: dcpm


### PR DESCRIPTION
# Description

The available space of NVMe devices was miscalculated: it was based on the hypothesis that all NVMe devices of one engine were fairly shared by its targets. At the end, one target can only manage one NVMe device. For one engine, if the number of its targets is greater than the number of NVMe devices, then some NVMe devices are fairly shared by two or more targets.

# Validation

The go unit tests have been updated according to the fix of the NVMe available space calculation.

The HW Functional tests have also been updated consequently. More over, the number of targets of one engine is now multiplexed to check that this parameter is properly managed.

The HW functional tests are currently disabled (see [DAOS-10448](https://daosio.atlassian.net/browse/DAOS-10448)). To validate these modifications, the commit of this PR was temporarily modified to run and validate them: details of the Jenkins job validating this patch could be found at:
https://build.hpdd.intel.com/blue/organizations/jenkins/daos-stack%2Fdaos/detail/PR-9118/19/tests

# Miscellaneous

Some python indentation issues were also fixed.