### PR TITLE
DAOS-10611 control: Evict pool handles on agent shutdown (#9052)

### DIFF
--- a/src/control/cmd/daos_agent/config.go
+++ b/src/control/cmd/daos_agent/config.go
@@ -34,6 +34,7 @@ type Config struct {
 	LogLevel         common.ControlLogLevel    `yaml:"control_log_mask,omitempty"`
 	TransportConfig  *security.TransportConfig `yaml:"transport_config"`
 	DisableCache     bool                      `yaml:"disable_caching,omitempty"`
+	DisableAutoEvict bool                      `yaml:"disable_auto_evict,omitempty"`
 	FabricInterfaces []*NUMAFabricConfig       `yaml:"fabric_ifaces,omitempty"`
 }
 

--- a/src/control/cmd/daos_agent/config_test.go
+++ b/src/control/cmd/daos_agent/config_test.go
@@ -43,6 +43,7 @@ runtime_dir: /tmp/runtime
 log_file: /home/frodo/logfile
 control_log_mask: debug
 disable_caching: true
+disable_auto_evict: true
 transport_config:
   allow_insecure: true
 fabric_ifaces:
@@ -119,13 +120,14 @@ transport_config:
 		"all options": {
 			path: optCfg,
 			expResult: &Config{
-				SystemName:   "shire",
-				AccessPoints: []string{"one:10001", "two:10001"},
-				ControlPort:  4242,
-				RuntimeDir:   "/tmp/runtime",
-				LogFile:      "/home/frodo/logfile",
-				LogLevel:     common.ControlLogLevelDebug,
-				DisableCache: true,
+				SystemName:       "shire",
+				AccessPoints:     []string{"one:10001", "two:10001"},
+				ControlPort:      4242,
+				RuntimeDir:       "/tmp/runtime",
+				LogFile:          "/home/frodo/logfile",
+				LogLevel:         common.ControlLogLevelDebug,
+				DisableCache:     true,
+				DisableAutoEvict: true,
 				TransportConfig: &security.TransportConfig{
 					AllowInsecure:     true,
 					CertificateConfig: DefaultConfig().TransportConfig.CertificateConfig,

--- a/src/control/cmd/daos_agent/mgmt_rpc.go
+++ b/src/control/cmd/daos_agent/mgmt_rpc.go
@@ -65,6 +65,11 @@ func (mod *mgmtModule) HandleCall(ctx context.Context, session *drpc.Session, me
 		return nil, err
 	}
 
+	if agentIsShuttingDown(ctx) {
+		mod.log.Errorf("agent is shutting down, dropping %s", method)
+		return nil, drpc.NewFailureWithMessage("agent is shutting down")
+	}
+
 	switch method {
 	case drpc.MethodGetAttachInfo:
 		return mod.handleGetAttachInfo(ctx, req, cred.Pid)

--- a/src/control/cmd/daos_agent/procmon.go
+++ b/src/control/cmd/daos_agent/procmon.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2020-2021 Intel Corporation.
+// (C) Copyright 2020-2022 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -12,10 +12,16 @@ import (
 	"os"
 	"time"
 
+	"github.com/daos-stack/daos/src/control/common"
 	mgmtpb "github.com/daos-stack/daos/src/control/common/proto/mgmt"
 	"github.com/daos-stack/daos/src/control/drpc"
 	"github.com/daos-stack/daos/src/control/lib/control"
 	"github.com/daos-stack/daos/src/control/logging"
+)
+
+const (
+	// Agent-internal methods not linked to engine handlers.
+	flushAllHandles drpc.MgmtMethod = drpc.MgmtMethod(^uint32(0) >> 1)
 )
 
 type procMonRequest struct {
@@ -27,6 +33,10 @@ type procMonRequest struct {
 	poolUUID string
 	// The UUID of the pool handle associated with this request
 	poolHandleUUID string
+	// If the request should be blocking, the caller should
+	// supply a channel to be closed when the request is
+	// complete.
+	doneChan chan struct{}
 }
 
 type procMonResponse struct {
@@ -36,12 +46,21 @@ type procMonResponse struct {
 	err error
 }
 
+type poolHandleMap map[string]common.StringSet
+
+func (phm poolHandleMap) add(poolUUID, handleUUID string) {
+	if _, found := phm[poolUUID]; !found {
+		phm[poolUUID] = common.NewStringSet()
+	}
+	phm[poolUUID].Add(handleUUID)
+}
+
 type procInfo struct {
 	log       logging.Logger
 	pid       int32
 	cancelCtx func()
 	response  chan *procMonResponse
-	handles   map[string]map[string]struct{}
+	handles   poolHandleMap
 }
 
 func checkProcPidExists(pid int32) error {
@@ -144,6 +163,21 @@ func (p *procMon) NotifyExit(ctx context.Context, Pid int32) {
 	p.submitRequest(ctx, req)
 }
 
+// FlushAllHandles submits a request to flush (evict and remove) all known
+// open pool handles for local DAOS client processes. Blocks until the
+// request has been completely processed.
+func (p *procMon) FlushAllHandles(ctx context.Context) {
+	p.log.Info("Flushing all open local pool handles")
+
+	done := make(chan struct{})
+	p.submitRequest(ctx, &procMonRequest{
+		action:   flushAllHandles,
+		doneChan: done,
+	})
+
+	<-done
+}
+
 func (p *procMon) submitRequest(ctx context.Context, request *procMonRequest) {
 	select {
 	case <-ctx.Done():
@@ -163,19 +197,14 @@ func (p *procMon) handleNotifyPoolConnect(ctx context.Context, request *procMonR
 			pid:       request.pid,
 			cancelCtx: cancel,
 			response:  p.response,
-			handles:   make(map[string]map[string]struct{}),
+			handles:   make(poolHandleMap),
 		}
 
 		p.procs[request.pid] = info
 		go info.monitorProcess(child)
 	}
 
-	_, found = info.handles[request.poolUUID]
-	if !found {
-		info.handles[request.poolUUID] = make(map[string]struct{})
-	}
-	info.handles[request.poolUUID][request.poolHandleUUID] = struct{}{}
-
+	info.handles.add(request.poolUUID, request.poolHandleUUID)
 }
 
 func (p *procMon) handleNotifyPoolDisconnect(request *procMonRequest) {
@@ -203,14 +232,6 @@ func (p *procMon) handleNotifyPoolDisconnect(request *procMonRequest) {
 
 }
 
-func handleMapToList(handleMap map[string]struct{}) []string {
-	list := make([]string, 0, len(handleMap))
-	for uuid := range handleMap {
-		list = append(list, uuid)
-	}
-	return list
-}
-
 // A process will leak handles when it either dies illegally or exits without
 // calling daos_pool_disconnect on the handles it has open. This will be called
 // if we detect a process terminating without disconnect, or if during
@@ -223,7 +244,7 @@ func (p *procMon) cleanupLeakedHandles(ctx context.Context, info *procInfo) {
 	for poolUUID, element := range info.handles {
 		p.log.Debugf("Cleaning up %d leaked handles from Pool UUID: %s\n", len(element), poolUUID)
 
-		handles := handleMapToList(info.handles[poolUUID])
+		handles := info.handles[poolUUID].ToSlice()
 		req := &control.PoolEvictReq{ID: poolUUID, Handles: handles}
 		req.SetSystem(p.systemName)
 
@@ -246,6 +267,25 @@ func (p *procMon) handleNotifyExit(ctx context.Context, request *procMonRequest)
 	}
 }
 
+func (p *procMon) flushAllHandles(ctx context.Context) {
+	// create a single map of open handles to reduce the number of RPCs
+	allPoolHandles := make(poolHandleMap)
+
+	for _, info := range p.procs {
+		for pool, handles := range info.handles {
+			for handle := range handles {
+				allPoolHandles.add(pool, handle)
+			}
+		}
+
+		// NB: This is best-effort cleanup, so if something fails we can't
+		// retry it.
+		delete(p.procs, info.pid)
+	}
+
+	p.cleanupLeakedHandles(ctx, &procInfo{handles: allPoolHandles})
+}
+
 func (p *procMon) handleRequests(ctx context.Context) {
 	for {
 		select {
@@ -259,8 +299,14 @@ func (p *procMon) handleRequests(ctx context.Context) {
 				p.handleNotifyPoolDisconnect(request)
 			case drpc.MethodNotifyExit:
 				p.handleNotifyExit(ctx, request)
+			case flushAllHandles:
+				p.flushAllHandles(ctx)
 			default:
 				p.log.Debugf("Received request with invalid action type %s", request.action)
+			}
+
+			if request.doneChan != nil {
+				close(request.doneChan)
 			}
 		case resp := <-p.response:
 			p.log.Debugf("Received response from Process %d, terminated with %s", resp.pid, resp.err)

--- a/src/control/cmd/daos_agent/start.go
+++ b/src/control/cmd/daos_agent/start.go
@@ -15,13 +15,25 @@ import (
 	"time"
 
 	"github.com/daos-stack/daos/src/control/drpc"
+	"github.com/daos-stack/daos/src/control/lib/atm"
 	"github.com/daos-stack/daos/src/control/lib/hardware/hwloc"
 	"github.com/daos-stack/daos/src/control/lib/hardware/hwprov"
 )
 
+type ctxKey string
+
 const (
-	agentSockName = "daos_agent.sock"
+	agentSockName          = "daos_agent.sock"
+	shuttingDownKey ctxKey = "agent_shutting_down"
 )
+
+func agentIsShuttingDown(ctx context.Context) bool {
+	shuttingDown, ok := ctx.Value(shuttingDownKey).(*atm.Bool)
+	if !ok {
+		return false
+	}
+	return shuttingDown.IsTrue()
+}
 
 type startCmd struct {
 	logCmd
@@ -33,8 +45,11 @@ func (cmd *startCmd) Execute(_ []string) error {
 	cmd.log.Debugf("Starting %s (pid %d)", versionString(), os.Getpid())
 	startedAt := time.Now()
 
-	ctx, shutdown := context.WithCancel(context.Background())
+	parent, shutdown := context.WithCancel(context.Background())
 	defer shutdown()
+
+	var shuttingDown atm.Bool
+	ctx := context.WithValue(parent, shuttingDownKey, &shuttingDown)
 
 	sockPath := filepath.Join(cmd.cfg.RuntimeDir, agentSockName)
 	cmd.log.Debugf("Full socket path is now: %s", sockPath)
@@ -106,7 +121,7 @@ func (cmd *startCmd) Execute(_ []string) error {
 	signals := make(chan os.Signal)
 	finish := make(chan struct{})
 
-	signal.Notify(signals, syscall.SIGINT, syscall.SIGTERM, syscall.SIGPIPE)
+	signal.Notify(signals, syscall.SIGINT, syscall.SIGTERM, syscall.SIGPIPE, syscall.SIGUSR1)
 	// Anonymous goroutine to wait on the signals channel and tell the
 	// program to finish when it receives a signal. Since we notify on
 	// SIGINT and SIGTERM we should only catch these on a kill or ctrl+c
@@ -115,14 +130,23 @@ func (cmd *startCmd) Execute(_ []string) error {
 	// channel.
 	var shutdownRcvd time.Time
 	go func() {
-		sig := <-signals
-		switch sig {
-		case syscall.SIGPIPE:
-			cmd.log.Infof("Signal received.  Caught non-fatal %s; continuing", sig)
-		default:
-			shutdownRcvd = time.Now()
-			cmd.log.Infof("Signal received.  Caught %s; shutting down", sig)
-			close(finish)
+		for sig := range signals {
+			switch sig {
+			case syscall.SIGPIPE:
+				cmd.log.Infof("Signal received.  Caught non-fatal %s; continuing", sig)
+			case syscall.SIGUSR1:
+				cmd.log.Infof("Signal received.  Caught %s; flushing open pool handles", sig)
+				procmon.FlushAllHandles(ctx)
+			default:
+				shutdownRcvd = time.Now()
+				cmd.log.Infof("Signal received.  Caught %s; shutting down", sig)
+				shuttingDown.SetTrue()
+				if !cmd.cfg.DisableAutoEvict {
+					procmon.FlushAllHandles(ctx)
+				}
+				close(finish)
+				return
+			}
 		}
 	}()
 	<-finish

--- a/utils/config/daos_agent.yml
+++ b/utils/config/daos_agent.yml
@@ -60,6 +60,13 @@
 ## default: INFO
 #control_log_mask: DEBUG
 
+## Disable automatic eviction of open pool handles on agent shutdown. By default,
+## the agent will evict all open pool handles for local processes on shutdown.
+## Note that this implies that stopping or restarting the agent will result
+## in interruption of DAOS I/O for any local DAOS client processes that have
+## an open pool handle.
+# disable_auto_evict: true
+
 ## Disable the agent's internal caches. If set to true, the agent will query the
 ## server access point and local hardware data every time a client requests
 ## rank connection information.


### PR DESCRIPTION
When the agent is shut down, it loses all knowledge of
currently-open pool handles on the local node. By default,
it should instead attempt to evict all open pool handles
before shutting down.

This behavior can be overridden by setting the following
in the agent configuration:

disable_auto_evict: true

Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com>
