### PR TITLE
DAOS-9592 chk: pool list consolidation

### DIFF
--- a/src/chk/chk_common.c
+++ b/src/chk/chk_common.c
@@ -116,6 +116,8 @@ chk_pool_free(struct btr_instance *tins, struct btr_record *rec, void *args)
 		D_FREE(cps);
 	}
 
+	D_FREE(cpr->cpr_clues.pcs_array);
+
 	if (val_iov != 0)
 		d_iov_set(val_iov, cpr, sizeof(*cpr));
 	else

--- a/src/chk/chk_engine.c
+++ b/src/chk/chk_engine.c
@@ -69,7 +69,7 @@ chk_destroy_pool_tree(struct chk_instance *ins)
 	 * Once the pool record is deleted from the tree, the initial reference held when
 	 * created will be released: if it is current ULT delete the record from the tree,
 	 * then it will be via chk_pool_free()->chk_pool_put(). Otherwise, if it has been
-	 * deleted from the tree by others, then related logic wii call chk_pool_put().
+	 * deleted from the tree by others, then related logic will call chk_pool_put().
 	 */
 	chk_destroy_tree(&ins->ci_pool_hdl, &ins->ci_pool_btr);
 
@@ -156,7 +156,7 @@ chk_engine_exit(struct chk_instance *ins, uint32_t ins_status, uint32_t pool_sta
 		iv.ci_status = ins_status;
 		iv.ci_to_leader = 1;
 
-		/* Synchronously notify the leader that check instance exit on the engine. */
+		/* Notify the leader that check instance exit on the engine. */
 		rc = chk_iv_update(ins->ci_iv_ns, &iv, CRT_IV_SHORTCUT_TO_ROOT,
 				   CRT_IV_SYNC_NONE, true);
 		if (rc != 0)
@@ -1592,7 +1592,7 @@ out:
 		iv.ci_status = cbk->cb_ins_status;
 		iv.ci_to_leader = 1;
 
-		/* Synchronously notify the leader that check instance exit on the engine. */
+		/* Notify the leader that check instance exit on the engine. */
 		rc = chk_iv_update(ins->ci_iv_ns, &iv, CRT_IV_SHORTCUT_TO_ROOT,
 				   CRT_IV_SYNC_NONE, true);
 		if (rc != 0)

--- a/src/chk/chk_internal.h
+++ b/src/chk/chk_internal.h
@@ -375,12 +375,18 @@ struct chk_pool_rec {
 	uint32_t		 cpr_shard_nr;
 	uint32_t		 cpr_started:1,
 				 cpr_stop:1,
-				 cpr_done:1;
-	int			 cpr_refs;
+				 cpr_done:1,
+				 cpr_skip:1,
+				 cpr_healthy:1,
+				 cpr_exist_on_ms:1;
+	int			 cpr_advice;
+	uint32_t		 cpr_phase;
 	uuid_t			 cpr_uuid;
 	ABT_thread		 cpr_thread;
+	struct ds_pool_clues	 cpr_clues;
 	struct chk_bookmark	 cpr_bk;
 	struct chk_instance	*cpr_ins;
+	int			 cpr_refs;
 };
 
 struct chk_pending_rec {

--- a/src/dtx/dtx_srv.c
+++ b/src/dtx/dtx_srv.c
@@ -433,6 +433,9 @@ dtx_setup(void)
 {
 	int	rc;
 
+	if (engine_in_check())
+		return 0;
+
 	rc = dss_ult_create_all(dtx_batched_commit, NULL, true);
 	if (rc != 0) {
 		D_ERROR("Failed to create DTX batched commit ULT: "DF_RC"\n", DP_RC(rc));

--- a/src/engine/init.c
+++ b/src/engine/init.c
@@ -31,11 +31,7 @@
 
 #define MAX_MODULE_OPTIONS	64
 #define MODULE_LIST	"vos,rdb,rsvc,security,mgmt,dtx,pool,cont,obj,rebuild"
-#define MODS_CHK_BASE	"vos,rdb,rsvc,chk,mgmt"
-#define MODS_CHK_POOL	MODS_CHK_BASE",pool"
-#define MODS_CHK_CONT	MODS_CHK_POOL",cont"
-#define MODS_CHK_OBJ	MODS_CHK_CONT",dtx,obj"
-#define MODS_CHK_RBD	MODS_CHK_OBJ",rebuild"
+#define MODS_LIST_CHK	"vos,rdb,rsvc,chk,security,mgmt,dtx,pool,cont,obj,rebuild"
 
 /** List of modules to load */
 static char		modules[MAX_MODULE_OPTIONS + 1];
@@ -1015,7 +1011,7 @@ parse(int argc, char **argv)
 				printf("'-c|--modules' option is ignored under check mode\n");
 				spec_mod = false;
 			}
-			snprintf(modules, sizeof(modules), "%s", MODS_CHK_BASE);
+			snprintf(modules, sizeof(modules), "%s", MODS_LIST_CHK);
 			break;
 		default:
 			usage(argv[0], stderr);

--- a/src/include/daos_srv/daos_mgmt_srv.h
+++ b/src/include/daos_srv/daos_mgmt_srv.h
@@ -33,5 +33,7 @@ int
 ds_mgmt_pool_exist(uuid_t uuid);
 int
 ds_mgmt_tgt_pool_exist(uuid_t uuid, char **path);
+int
+ds_mgmt_tgt_pool_destroy(uuid_t pool_uuid, d_rank_list_t *ranks);
 
 #endif /* __MGMT_SRV_H__ */

--- a/src/mgmt/srv_pool.c
+++ b/src/mgmt/srv_pool.c
@@ -69,7 +69,7 @@ fini_ranks:
 /**
  * Destroy the pool on specified storage ranks
  */
-static int
+int
 ds_mgmt_tgt_pool_destroy(uuid_t pool_uuid, d_rank_list_t *ranks)
 {
 	int				 rc;

--- a/src/pool/srv.c
+++ b/src/pool/srv.c
@@ -77,9 +77,12 @@ setup(void)
 {
 	bool start = true;
 
-	d_getenv_bool("DAOS_START_POOL_SVC", &start);
-	if (start)
-		return ds_pool_start_all();
+	if (!engine_in_check()) {
+		d_getenv_bool("DAOS_START_POOL_SVC", &start);
+		if (start)
+			return ds_pool_start_all();
+	}
+
 	return 0;
 }
 

--- a/src/pool/srv_pool_check.c
+++ b/src/pool/srv_pool_check.c
@@ -407,7 +407,7 @@ ds_pool_check_svc_clues(struct ds_pool_clues *clues, int *advice_out)
 		struct ds_pool_clue *clue = &clues->pcs_array[i];
 
 		D_ASSERT(uuid_compare(uuid, clue->pc_uuid) == 0);
-		D_ASSERTF(clue->pc_rc == 0, DF_RC"\n", DP_RC(clue->pc_rc));
+		D_ASSERTF(clue->pc_rc > 0, DF_RC"\n", DP_RC(clue->pc_rc));
 		D_ASSERT(clue->pc_svc_clue != NULL);
 	}
 

--- a/src/vos/vos_layout.h
+++ b/src/vos/vos_layout.h
@@ -123,7 +123,6 @@ struct vos_pool_df {
 	 * the phases range [CSP_DTX_RESYNC, OSP_AGGREGATION] for the pool shard on the target.
 	 */
 	umem_off_t				pd_chk;
-	uint64_t				pd_reserv;
 	/** Unique PoolID for each VOS pool assigned on creation */
 	uuid_t					pd_id;
 	/** Total space in bytes on SCM */


### PR DESCRIPTION
Compare the engines reported pools (and services) list with the ones
from MS. Handle the following cases:

1. Dangling pool: the pool only exists in MS but not on the engines.
   Then the pool record will be removed from MS, or need to interact
   with admin if it is required.

2. Orphan pool: the pool only exists on the engines but not in MS.
   Then register the orphan pool to MS by default, or interact with
   admin if it is required. If some pool shards are under zombies,
   then it is suggest to destroy the orphan pool.

3. We lost the majority pool service replicas, but we still can find
   some valid pool service replica. Then we will dictate the service
   from some specified pool service replica.

4. For a pool, we lost all pool service replicas, can neither have a
   quorum or dictate the service from some specified one. Under such
   case, it is suggested to destroy the pool.

Signed-off-by: Li Wei <wei.g.li@intel.com>
Signed-off-by: Fan Yong <fan.yong@intel.com>