### PR TITLE
DAOS-623 build: Turn back on weak deps for Rocky installs.

### DIFF
--- a/utils/docker/Dockerfile.el.8
+++ b/utils/docker/Dockerfile.el.8
@@ -27,7 +27,6 @@ RUN set -e;                                                      \
     fi;                                                          \
     dnf --assumeyes --disablerepo \*epel\* install dnf-plugins-core;     \
     dnf config-manager --save --setopt=assumeyes=True;           \
-    dnf config-manager --save --setopt=install_weak_deps=False;  \
     if [ ! -f /etc/fedora-release ]; then                        \
         dnf --assumeyes --disablerepo \*epel\* install epel-release; \
         if [ -n "$REPO_FILE_URL" ]; then                         \


### PR DESCRIPTION
Previously we had set the install_weak_deps option to false
in order to reduce CI image sizes however this got disable
a few weeks ago and re-enabled on the 19th, during the
time it was disabled however an upstream change means
the build no longer completes with this option enabled.

Disable the option again until we can work out which
weakly required packages are needed for the build.

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>
