### PR TITLE
DAOS-10621 test: Don't disable daos repos for weekly branch PRs (#9067)

### DIFF
--- a/ci/provisioning/post_provision_config.sh
+++ b/ci/provisioning/post_provision_config.sh
@@ -48,6 +48,7 @@ if ! retry_cmd 2400 clush -B -S -l root -w "$NODESTRING" \
            REPO_FILE_URL=\"$REPO_FILE_URL\"
            ARTIFACTORY_URL=\"${ARTIFACTORY_URL:-}\"
            BRANCH_NAME=\"${BRANCH_NAME:-}\"
+           CHANGE_BRANCH=\"${CHANGE_BRANCH:-}\"
            $(cat ci/stacktrace.sh)
            $(cat ci/junit.sh)
            $(cat ci/provisioning/post_provision_config_common_functions.sh)

--- a/ci/provisioning/post_provision_config_common_functions.sh
+++ b/ci/provisioning/post_provision_config_common_functions.sh
@@ -193,7 +193,7 @@ set_local_repo() {
     version=${version%%.*}
     if [ "$repo_server" = "artifactory" ] &&
        [ -z "$(rpm_test_version)" ] &&
-       [[ $BRANCH_NAME != weekly-testing* ]]; then
+       [[ $CHANGE_BRANCH != weekly-testing* ]]; then
         # Disable the daos repo so that the Jenkins job repo or a PR-repos*: repo is
         # used for daos packages
         dnf -y config-manager \


### PR DESCRIPTION
Ensure the daos repos are enabled for weekly branch PR testing.

Skip-unit-tests: true
Test-tag: always_passes

Signed-off-by: Phillip Henderson <phillip.henderson@intel.com>