### PR TITLE
Revert DAOS-10456 control: Enable VMD by default (#8933) (#9104)

### DIFF
--- a/src/control/cmd/dmg/auto_test.go
+++ b/src/control/cmd/dmg/auto_test.go
@@ -162,7 +162,7 @@ engines:
   fabric_iface_port: 32416
   pinned_numa_node: 1
 disable_vfio: false
-disable_vmd: false
+enable_vmd: false
 enable_hotplug: false
 nr_hugepages: 6144
 control_log_mask: INFO

--- a/src/control/lib/control/auto.go
+++ b/src/control/lib/control/auto.go
@@ -399,6 +399,7 @@ func mapSSDs(ssds storage.NvmeControllers) (numaSSDsMap, error) {
 
 type storageDetails struct {
 	hugePageSize int
+	vmdEnabled   bool
 	numaPMems    numaPMemsMap
 	numaSSDs     numaSSDsMap
 }
@@ -435,6 +436,10 @@ func (sd *storageDetails) validate(log logging.Logger, engineCount int, minNrSSD
 
 		if ssds.Len() < minNrSSDs {
 			return errors.Errorf(errInsufNrSSDs, nn, minNrSSDs, ssds.Len())
+		}
+
+		if ssds.HasVMD() {
+			sd.vmdEnabled = true
 		}
 	}
 
@@ -688,7 +693,8 @@ func genConfig(log logging.Logger, newEngineCfg newEngineCfgFn, accessPoints []s
 		WithFabricProvider(engines[0].Fabric.Provider).
 		WithEngines(engines...).
 		WithControlLogFile(defaultControlLogFile).
-		WithNrHugePages(reqHugePages)
+		WithNrHugePages(reqHugePages).
+		WithEnableVMD(sd.vmdEnabled)
 
 	if err := cfg.SetEngineAffinities(log); err != nil {
 		return nil, errors.Wrap(err, "setting engine affinities")

--- a/src/control/server/config/server.go
+++ b/src/control/server/config/server.go
@@ -46,7 +46,7 @@ type Server struct {
 	BdevInclude         []string               `yaml:"bdev_include,omitempty"`
 	BdevExclude         []string               `yaml:"bdev_exclude,omitempty"`
 	DisableVFIO         bool                   `yaml:"disable_vfio"`
-	DisableVMD          bool                   `yaml:"disable_vmd"`
+	EnableVMD           bool                   `yaml:"enable_vmd"`
 	EnableHotplug       bool                   `yaml:"enable_hotplug"`
 	NrHugepages         int                    `yaml:"nr_hugepages"` // total for all engines
 	ControlLogMask      common.ControlLogLevel `yaml:"control_log_mask"`
@@ -222,10 +222,10 @@ func (cfg *Server) WithDisableVFIO(disabled bool) *Server {
 	return cfg
 }
 
-// WithDisableVMD can be used to set the state of VMD functionality,
-// if disabled then VMD devices will not be used if they exist.
-func (cfg *Server) WithDisableVMD(disable bool) *Server {
-	cfg.DisableVMD = disable
+// WithEnableVMD can be used to set the state of VMD functionality,
+// if enabled then VMD devices will be used if they exist.
+func (cfg *Server) WithEnableVMD(enable bool) *Server {
+	cfg.EnableVMD = enable
 	return cfg
 }
 
@@ -295,6 +295,7 @@ func DefaultServer() *Server {
 		Hyperthreads:    false,
 		Path:            defaultConfigPath,
 		ControlLogMask:  common.ControlLogLevel(logging.LogLevelInfo),
+		EnableVMD:       false, // disabled by default
 		EnableHotplug:   false, // disabled by default
 		// https://man7.org/linux/man-pages/man5/core.5.html
 		CoreDumpFilter: 0b00010011, // private, shared, ELF
@@ -421,7 +422,7 @@ func (cfg *Server) Validate(log logging.Logger, hugePageSize int) (err error) {
 	}
 
 	log.Debugf("vfio=%v hotplug=%v vmd=%v requested in config", !cfg.DisableVFIO,
-		cfg.EnableHotplug, !cfg.DisableVMD)
+		cfg.EnableHotplug, cfg.EnableVMD)
 
 	// Update access point addresses with control port if port is not supplied.
 	newAPs := make([]string, 0, len(cfg.AccessPoints))

--- a/src/control/server/config/server_test.go
+++ b/src/control/server/config/server_test.go
@@ -200,7 +200,7 @@ func TestServerConfig_Constructed(t *testing.T) {
 		WithBdevInclude("0000:81:00.1", "0000:81:00.2", "0000:81:00.3").
 		WithBdevExclude("0000:81:00.1").
 		WithDisableVFIO(true).   // vfio enabled by default
-		WithDisableVMD(true).    // vmd enabled by default
+		WithEnableVMD(true).     // vmd disabled by default
 		WithEnableHotplug(true). // hotplug disabled by default
 		WithControlLogMask(common.ControlLogLevelError).
 		WithControlLogFile("/tmp/daos_server.log").

--- a/src/control/server/server_utils.go
+++ b/src/control/server/server_utils.go
@@ -220,15 +220,7 @@ func prepBdevStorage(srv *server, iommuEnabled bool) error {
 		PCIAllowList: strings.Join(srv.cfg.BdevInclude, storage.BdevPciAddrSep),
 		PCIBlockList: strings.Join(srv.cfg.BdevExclude, storage.BdevPciAddrSep),
 		DisableVFIO:  srv.cfg.DisableVFIO,
-	}
-
-	switch {
-	case !srv.cfg.DisableVMD && srv.cfg.DisableVFIO:
-		srv.log.Info("VMD not enabled because VFIO disabled in config")
-	case !srv.cfg.DisableVMD && !iommuEnabled:
-		srv.log.Info("VMD not enabled because IOMMU disabled on system")
-	default:
-		prepReq.EnableVMD = !srv.cfg.DisableVMD
+		EnableVMD:    srv.cfg.EnableVMD && !srv.cfg.DisableVFIO && iommuEnabled,
 	}
 
 	if hasBdevs {

--- a/src/tests/ftest/launch.py
+++ b/src/tests/ftest/launch.py
@@ -751,6 +751,11 @@ def get_test_files(test_list, args, yaml_dir, vmd_flag=False):
         yaml_file = replace_yaml_file("{}.yaml".format(base), args, yaml_dir, vmd_flag)
         test_file["yaml"] = yaml_file
 
+        # Set enable_vmd: true in the daos_server yaml if there are VMD devices on the host
+        # regardless of whether they are being specified in the server config file to avoid
+        # failures in the server start-up NVMe scan.
+        test_file["env"] = {"DAOS_ENABLE_VMD": "True" if vmd_flag else "False"}
+
         # Display the modified yaml file variants with debug
         command = ["avocado", "variants", "--mux-yaml", test_file["yaml"]]
         if args.extra_yaml:

--- a/src/tests/ftest/util/server_utils_params.py
+++ b/src/tests/ftest/util/server_utils_params.py
@@ -5,6 +5,7 @@
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
 import os
+import ast
 
 from command_utils_base import \
     BasicParameter, LogParameter, YamlParameters, TransportCredentials
@@ -115,7 +116,9 @@ class DaosServerYamlParameters(YamlParameters):
         self.control_log_file = LogParameter(log_dir, None, "daos_control.log")
         self.helper_log_file = LogParameter(log_dir, None, "daos_admin.log")
         self.telemetry_port = BasicParameter(None, 9191)
-        self.disable_vmd = BasicParameter(None)
+        default_enable_vmd_val = os.environ.get("DAOS_ENABLE_VMD", "False")
+        default_enable_vmd = ast.literal_eval(default_enable_vmd_val)
+        self.enable_vmd = BasicParameter(None, default_enable_vmd)
 
         # Used to drop privileges before starting data plane
         # (if started as root to perform hardware provisioning)

--- a/utils/config/daos_server.yml
+++ b/utils/config/daos_server.yml
@@ -136,16 +136,13 @@
 #disable_vfio: true
 #
 #
-## Disable VMD Usage
+## Enable VMD Usage
 #
-## VMD (Intel Volume Management Devices) is enabled by default but can be
-## optionally disabled in which case VMD backing devices will not be visible.
-#
-## VMD needs to be available and configured in the system BIOS before it
-## can be used. The main use case for VMD is managing NVMe SSD LED activity.
+## The use of Intel Volume Management Devices can be optionally enabled.
+## VMD needs to be available and configured in the system BIOS before use.
 #
 ## default: false
-#disable_vmd: true
+#enable_vmd: true
 #
 #
 ## Enable NVMe SSD Hotplug


### PR DESCRIPTION
This reverts commit 49b75ac2ef12a453a7c019764021f145511e411c,
which was landed prematurely.
