### PR TITLE
DCO-10410: Moved the dnf --upgrade to before the REPOS

### DIFF
--- a/utils/docker/Dockerfile.centos.7
+++ b/utils/docker/Dockerfile.centos.7
@@ -31,7 +31,7 @@ RUN set -e;                                                      \
     if [ -n "$REPO_FILE_URL" ]; then                             \
         dnf -y --quiet config-manager --disable epel;            \
     fi;                                                          \
-    dnf -y clean all && dnf -y upgrade
+    dnf -y upgrade && dnf -y clean all
 
 ARG JENKINS_URL
 ARG REPOS

--- a/utils/docker/Dockerfile.centos.7
+++ b/utils/docker/Dockerfile.centos.7
@@ -31,7 +31,7 @@ RUN set -e;                                                      \
     if [ -n "$REPO_FILE_URL" ]; then                             \
         dnf -y --quiet config-manager --disable epel;            \
     fi;                                                          \
-    dnf -y clean all
+    dnf -y clean all && dnf -y upgrade
 
 ARG JENKINS_URL
 ARG REPOS
@@ -63,8 +63,7 @@ gpgcheck=False\n" >> /etc/yum.repos.d/$repo:$branch:$build_number.repo;   \
 # libatomic should be in this list, but can not for now due to CI
 # post provisioning issue.
 # *** Keep these in as much alphbetical order as possible ***
-RUN dnf -y upgrade && \
-    dnf -y install \
+RUN dnf -y install \
         boost-python36-devel \
         bzip2 \
         clang-analyzer \


### PR DESCRIPTION
Adding in custom repos with post scripts can sometimes hang the upgrade.  If this is done before we add in custom repos, it reduces the impact the custom repos have.

Signed-off-by: Ray Dennis <ray.dennis@intel.com>