### PR TITLE
DAOS-10651 test: Install daos-tests-internal for weekly tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -122,7 +122,7 @@ pipeline {
                                     branch: env.BaseBranch,
                                     withSubmodules: true
                         functionalTest inst_repos: daosRepos(),
-                                       inst_rpms: functionalPackages(1, next_version),
+                                       inst_rpms: functionalPackages(1, next_version, "tests-internal"),
                                        test_function: 'runTestFunctionalV2'
                     }
                     post {
@@ -145,7 +145,7 @@ pipeline {
                                     branch: env.BaseBranch,
                                     withSubmodules: true
                         functionalTest inst_repos: daosRepos(),
-                                       inst_rpms: functionalPackages(1, next_version),
+                                       inst_rpms: functionalPackages(1, next_version, "tests-internal"),
                                        test_function: 'runTestFunctionalV2'
                     }
                     post {
@@ -168,7 +168,7 @@ pipeline {
                                     branch: env.BaseBranch,
                                     withSubmodules: true
                         functionalTest inst_repos: daosRepos(),
-                                       inst_rpms: functionalPackages(1, next_version),
+                                       inst_rpms: functionalPackages(1, next_version, "tests-internal"),
                                        test_function: 'runTestFunctionalV2'
                     }
                     post {
@@ -191,7 +191,7 @@ pipeline {
                                     branch: env.BaseBranch,
                                     withSubmodules: true
                         functionalTest inst_repos: daosRepos(),
-                                       inst_rpms: functionalPackages(1, next_version),
+                                       inst_rpms: functionalPackages(1, next_version, "tests-internal"),
                                        test_function: 'runTestFunctionalV2'
                     }
                     post {
@@ -215,7 +215,7 @@ pipeline {
                                     branch: env.BaseBranch,
                                     withSubmodules: true
                         functionalTest inst_repos: daosRepos(),
-                                       inst_rpms: functionalPackages(1, next_version),
+                                       inst_rpms: functionalPackages(1, next_version, "tests-internal"),
                                        test_function: 'runTestFunctionalV2'
                     }
                     post {
@@ -239,7 +239,7 @@ pipeline {
                                     branch: env.BaseBranch,
                                     withSubmodules: true
                         functionalTest inst_repos: daosRepos(),
-                                       inst_rpms: functionalPackages(1, next_version),
+                                       inst_rpms: functionalPackages(1, next_version, "tests-internal"),
                                        test_function: 'runTestFunctionalV2'
                     }
                     post {
@@ -263,7 +263,7 @@ pipeline {
                                     branch: env.BaseBranch,
                                     withSubmodules: true
                         functionalTest inst_repos: daosRepos(),
-                                       inst_rpms: functionalPackages(1, next_version),
+                                       inst_rpms: functionalPackages(1, next_version, "tests-internal"),
                                        test_function: 'runTestFunctionalV2'
                     }
                     post {


### PR DESCRIPTION
The daos-tests-clients-openmpi RPM is now installed via the
daos-tests-internal package.  Include the installation of this
package in all functional test stages.

Test-tag: daos_racer_parallel daosperf,full_regression

Signed-off-by: Phillip Henderson <phillip.henderson@intel.com>