### PR TITLE
DAOS-623 build: Remove a debug print from build

### DIFF
--- a/site_scons/site_tools/extra/extra.py
+++ b/site_scons/site_tools/extra/extra.py
@@ -88,8 +88,7 @@ def _preprocess_emitter(source, target, env):
                 continue
             if mod != "":
                 prefix = prefix + "_" + mod
-            newtarget = os.path.join(dirname, '{}{}_pp.{}'.format(prefix, base, ext))
-            print("newtarget = %s\n" % newtarget)
+            newtarget = os.path.join(dirname, '{}{}_pp{}'.format(prefix, base, ext))
             target.append(newtarget)
     return target, source
 


### PR DESCRIPTION
Also, fix the extension for Preprocessed files as it already
includes a .

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>