### PR TITLE
DAOS-10600 ci: Prevent UCX pkg from breaking MLNX

### DIFF
--- a/ci/provisioning/post_provision_config_common.sh
+++ b/ci/provisioning/post_provision_config_common.sh
@@ -30,7 +30,7 @@ release=$(lsb_release -sr)
 EXCLUDE_UPGRADE=mercury,daos,daos-\*
 if rpm -qa | grep mlnx; then
     # packages not to allow upgrading if MLNX OFED is installed
-    EXCLUDE_UPGRADE+=,openmpi,\*mlnx\*
+    EXCLUDE_UPGRADE+=,openmpi,\*mlnx\*,\*ucx\*
 fi
 case "$id" in
     CentOS|Rocky|AlmaLinux|RedHatEnterpriseServer)


### PR DESCRIPTION
There was a conflict between UCX and Mellanox packages on some
CI nodes.

PR-repos-el8: openucx@master
PR-repos-el7: openucx@master
PR-repos-leap15: openucx@master
Skip-func-test-el7: false
Skip-func-test-leap15: false
Skip-func-hw-test-large: true
Skip-func-hw-test-medium: true
Quick-functional: true

Signed-off-by: Kris Jacque <kristin.jacque@intel.com>