### PR TITLE
DAOS-623 build: Add dev-build-watchers for SCons changes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -28,5 +28,10 @@ docs/ @daos-stack/doc-watchers
 #src/include/*.h @daos-stack/doc-watchers
 *.md @daos-stack/doc-watchers
 
+# dev-build-watchers: Files affecting local builds (e.g. SCons)
+SConstruct @daos-stack/dev-build-watchers
+SConscript @daos-stack/dev-build-watchers
+site_scons/ @daos-stack/dev-build-watchers
+
 # ftest-watchers: files affecting functional tests
 src/tests/ftest @daos-stack/ftest-watchers


### PR DESCRIPTION
To try to prevent bugs being committed to SCons build files,
add dev-build-watchers when changes happen.

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>