### PR TITLE
DAOS-10601 client: fix daos_event_abort corruption issue

### DIFF
--- a/src/client/api/tests/eq_tests.c
+++ b/src/client/api/tests/eq_tests.c
@@ -58,7 +58,6 @@ eq_test_1()
 {
 	struct daos_event	*ep;
 	struct daos_event	ev;
-	struct daos_event	abort_ev;
 	daos_handle_t		eqh;
 	int			rc;
 
@@ -79,14 +78,6 @@ eq_test_1()
 
 	daos_event_complete(&ev, 0);
 
-	rc = daos_event_init(&abort_ev, eqh, NULL);
-	D_ASSERT(rc == 0);
-
-	rc = daos_event_launch(&abort_ev);
-	D_ASSERT(rc == 0);
-
-	daos_event_abort(&abort_ev);
-
 	print_message("Destroy non-empty EQ\n");
 	rc = daos_eq_destroy(eqh, 0);
 	if (rc != -DER_BUSY) {
@@ -100,7 +91,6 @@ eq_test_1()
 		goto out;
 	}
 	daos_event_fini(&ev);
-	daos_event_fini(&abort_ev);
 
 	print_message("Destroy empty EQ\n");
 	rc = daos_eq_destroy(eqh, 0);

--- a/src/include/daos_event.h
+++ b/src/include/daos_event.h
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2015-2021 Intel Corporation.
+ * (C) Copyright 2015-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -231,7 +231,8 @@ int
 daos_event_parent_barrier(struct daos_event *ev);
 
 /**
- * Try to abort operations associated with this event.
+ * Try to abort operations associated with this event. This currently does not abort any internal
+ * DAOS operations associated with that event, but will just wait on their completion.
  * If \a ev is a parent event, this call will abort all child operations.
  *
  * \param ev [IN]	Event (operation) to abort

--- a/src/tests/suite/dfs_unit_test.c
+++ b/src/tests/suite/dfs_unit_test.c
@@ -567,7 +567,7 @@ dfs_test_syml_follow(void **state)
 }
 
 static int
-dfs_test_file_gen(const char *name, daos_size_t chunk_size,
+dfs_test_file_gen(const char *name, daos_size_t chunk_size, daos_oclass_id_t cid,
 		  daos_size_t file_size)
 {
 	dfs_obj_t	*obj;
@@ -589,7 +589,7 @@ dfs_test_file_gen(const char *name, daos_size_t chunk_size,
 	sgl.sg_iovs = &iov;
 
 	rc = dfs_open(dfs_mt, NULL, name, S_IFREG | S_IWUSR | S_IRUSR,
-		      O_RDWR | O_CREAT, OC_S1, chunk_size, NULL, &obj);
+		      O_RDWR | O_CREAT, cid, chunk_size, NULL, &obj);
 	assert_int_equal(rc, 0);
 
 	rc = dfs_punch(dfs_mt, obj, 10, DFS_MAX_FSIZE);
@@ -715,7 +715,7 @@ dfs_test_read_shared_file(void **state)
 	par_barrier(PAR_COMM_WORLD);
 
 	sprintf(name, "MTA_file_%d", arg->myrank);
-	rc = dfs_test_file_gen(name, chunk_size, file_size);
+	rc = dfs_test_file_gen(name, chunk_size, OC_S1, file_size);
 	assert_int_equal(rc, 0);
 
 	/* usr barrier to all threads start at the same time and start
@@ -1395,7 +1395,7 @@ dfs_test_mtime(void **state)
 	assert_int_equal(rc, 0);
 }
 
-#define NUM_IOS 128
+#define NUM_IOS 256
 #define IO_SIZE 8192
 
 struct dfs_test_async_arg {
@@ -1491,7 +1491,7 @@ dfs_test_async_io_th(void **state)
 	assert_int_equal(rc, 0);
 
 	sprintf(name, "file_async_mt_%d", arg->myrank);
-	rc = dfs_test_file_gen(name, 0, IO_SIZE * NUM_IOS);
+	rc = dfs_test_file_gen(name, 0, OC_S1, IO_SIZE * NUM_IOS);
 	assert_int_equal(rc, 0);
 
 	rc = dfs_open(dfs_mt, NULL, name, S_IFREG, O_RDONLY, 0, 0, NULL, &obj);
@@ -1541,6 +1541,94 @@ dfs_test_async_io_th(void **state)
 	par_barrier(PAR_COMM_WORLD);
 }
 
+
+#define NUM_ABORTS 64
+#define IO_SIZE_2 1048576
+
+static void
+dfs_test_async_io(void **state)
+{
+	test_arg_t		*arg = *state;
+	char			name[16];
+	dfs_obj_t		*obj;
+	int			i, j;
+	int			rc;
+
+	par_barrier(PAR_COMM_WORLD);
+
+	sprintf(name, "file_async_%d", arg->myrank);
+	rc = dfs_test_file_gen(name, 0, OC_SX, IO_SIZE_2 * NUM_IOS);
+	assert_int_equal(rc, 0);
+
+	rc = dfs_open(dfs_mt, NULL, name, S_IFREG, O_RDONLY, 0, 0, NULL, &obj);
+	assert_int_equal(rc, 0);
+
+	struct daos_event	evs[NUM_IOS];
+	d_sg_list_t		sgls[NUM_IOS];
+	d_iov_t			iovs[NUM_IOS];
+	daos_size_t		read_sizes[NUM_IOS];
+	char			*bufs[NUM_IOS];
+
+	for (i = 0; i < NUM_IOS; i++) {
+		rc = daos_event_init(&evs[i], arg->eq, NULL);
+		assert_rc_equal(rc, 0);
+
+		D_ALLOC(bufs[i], IO_SIZE_2);
+		D_ASSERT(bufs[i] != NULL);
+
+		d_iov_set(&iovs[i], bufs[i], IO_SIZE_2);
+		sgls[i].sg_nr = 1;
+		sgls[i].sg_nr_out = 1;
+		sgls[i].sg_iovs = &iovs[i];
+	}
+
+	for (j = 0; j < NUM_ABORTS; j++) {
+		for (i = 0; i < NUM_IOS; i++) {
+			bool flag;
+			daos_event_t *ev = &evs[i];
+
+			rc = daos_event_test(ev, DAOS_EQ_NOWAIT, &flag);
+			assert_int_equal(rc, 0);
+
+			if (!flag) {
+				rc = daos_event_abort(ev);
+				assert_int_equal(rc, 0);
+
+				rc = daos_event_test(ev, DAOS_EQ_WAIT, &flag);
+				assert_int_equal(rc, 0);
+			}
+			D_ASSERT(flag == true);
+
+			rc = daos_event_fini(ev);
+			assert_int_equal(rc, 0);
+			rc = daos_event_init(ev, arg->eq, NULL);
+			assert_int_equal(rc, 0);
+
+			rc = dfs_read(dfs_mt, obj, &sgls[i], 0, &read_sizes[i], ev);
+			assert_int_equal(rc, 0);
+		}
+	}
+
+	for (i = 0; i < NUM_IOS; i++) {
+		bool flag;
+
+		rc = daos_event_test(&evs[i], DAOS_EQ_WAIT, &flag);
+		assert_int_equal(rc, 0);
+		D_ASSERT(flag == true);
+		daos_event_fini(&evs[i]);
+		evs[i].ev_error = INT_MAX;
+		evs[i].ev_private.space[0] = ULONG_MAX;
+		D_FREE(bufs[i]);
+		D_ASSERT(read_sizes[i] == IO_SIZE_2);
+	}
+
+	rc = dfs_release(obj);
+	assert_int_equal(rc, 0);
+
+	dfs_test_rm(name);
+	par_barrier(PAR_COMM_WORLD);
+}
+
 static const struct CMUnitTest dfs_unit_tests[] = {
 	{ "DFS_UNIT_TEST1: DFS mount / umount",
 	  dfs_test_mount, async_disable, test_case_teardown},
@@ -1576,6 +1664,8 @@ static const struct CMUnitTest dfs_unit_tests[] = {
 	  dfs_test_mtime, async_disable, test_case_teardown},
 	{ "DFS_UNIT_TEST17: multi-threads async IO",
 	  dfs_test_async_io_th, async_disable, test_case_teardown},
+	{ "DFS_UNIT_TEST18: async IO",
+	  dfs_test_async_io, async_disable, test_case_teardown},
 };
 
 static int


### PR DESCRIPTION
daos_event_abort() was marking the event as aborted, however the DAOS
internal task is not aborted, and currently there is no way to abort
that. So later if a user progresses (through test or poll) that aborted
event, the event API frees the event and marks it as ready to initialized
since it was aborted before, but the DAOS internal task is still not done.

When the DAOS task finally progresses, it can cause corruption because the
user might have resused the event, or even reused the buffers that were passed
to the event.

Since we do not support cancellations of internal DAOS tasks and RPCs, change
the abort implementation to just wait for the event to complete; just like
daos_event_test. When we support internal RPC and DAOS tse cancel, we can
support proper abort.

Signed-off-by: Mohamad Chaarawi <mohamad.chaarawi@intel.com>