### PR TITLE
DAOS-10675 pool: fix potential program hang

### DIFF
--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -1521,8 +1521,8 @@ int ds_pool_failed_add(uuid_t uuid, int rc)
 	uuid_copy(psf->psf_uuid, uuid);
 	psf->psf_error = rc;
 	d_list_add_tail(&psf->psf_link, &pool_svc_failed_list);
-	D_RWLOCK_UNLOCK(&psfl_rwlock);
 out:
+	D_RWLOCK_UNLOCK(&psfl_rwlock);
 	return ret;
 }
 


### PR DESCRIPTION
if pool adding failed, unlock is missed which might
cause potential program hang later.

Signed-off-by: Wang Shilong <shilong.wang@intel.com>