### PR TITLE
DAOS-9355 doc: add infos for DAOS in the Cloud

### DIFF
--- a/docs/QSG/cloud.md
+++ b/docs/QSG/cloud.md
@@ -1,0 +1,7 @@
+# Deploying DAOS in the Cloud
+
+## Deploying DAOS in Google Cloud
+
+DAOS is available in GCP. Please refer to the
+[How To Deploy DAOS in Google Cloud](https://github.com/GoogleCloudPlatform/hpc-toolkit/tree/main/community/examples/intel)
+section of the GCP documentation for details.

--- a/docs/QSG/cloud.md
+++ b/docs/QSG/cloud.md
@@ -2,6 +2,6 @@
 
 ## Deploying DAOS in Google Cloud
 
-DAOS is available in GCP. Please refer to the
+DAOS can be installed in GCP. Please refer to the
 [How To Deploy DAOS in Google Cloud](https://github.com/GoogleCloudPlatform/hpc-toolkit/tree/main/community/examples/intel)
-section of the GCP documentation for details.
+section of the Google Cloud HPC Toolkit documentation for details.

--- a/docs/cloud/index.md
+++ b/docs/cloud/index.md
@@ -1,0 +1,18 @@
+# DAOS in the Cloud
+
+In addition to on-prem deployments, DAOS is available as part of
+cloud offerings.
+
+## DAOS in Google Cloud
+
+DAOS is available as an HPC storage option in Google Cloud.
+ 
+To learn more about DAOS in Google Cloud, please refer to the
+[Google Cloud DAOS repository](https://github.com/daos-stack/google-cloud-daos)
+on github and the 
+[Google Cloud Platform documentation for DAOS](https://github.com/GoogleCloudPlatform/hpc-toolkit/blob/main/community/modules/file-system/Intel-DAOS/README.md).
+
+A discussion forum for technical questions and support
+for DAOS in Google Cloud is available in the
+[DAOS on Google Cloud](https://daos-stack.slack.com/archives/C03GLTLHA59)
+Slack channel.

--- a/docs/cloud/index.md
+++ b/docs/cloud/index.md
@@ -1,16 +1,16 @@
 # DAOS in the Cloud
 
-In addition to on-prem deployments, DAOS is available as part of
-cloud offerings.
+In addition to on-prem deployments, DAOS can be deployed in cloud
+environments.
 
 ## DAOS in Google Cloud
 
 DAOS is available as an HPC storage option in Google Cloud.
- 
+
 To learn more about DAOS in Google Cloud, please refer to the
 [Google Cloud DAOS repository](https://github.com/daos-stack/google-cloud-daos)
-on github and the 
-[Google Cloud Platform documentation for DAOS](https://github.com/GoogleCloudPlatform/hpc-toolkit/blob/main/community/modules/file-system/Intel-DAOS/README.md).
+on github and the
+[Google Cloud HPC Toolkit documentation for DAOS](https://github.com/GoogleCloudPlatform/hpc-toolkit/blob/main/community/modules/file-system/Intel-DAOS/README.md).
 
 A discussion forum for technical questions and support
 for DAOS in Google Cloud is available in the

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,6 +11,10 @@ I/O, advanced data protection with self-healing, end-to-end data
 integrity, fine-grained data control, and elastic storage, to optimize
 performance and cost.
 
+In addition to on-prem deployments, DAOS is available as part of
+cloud offerings. More information on cloud deployments is available
+in the [DAOS in the Cloud](./cloud/) section.
+
 The included document versions are associated with DAOS v2.0.
 They may also describe features that are currently under development
 for a future DAOS release. Those features will be clearly marked as such.

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,8 +11,8 @@ I/O, advanced data protection with self-healing, end-to-end data
 integrity, fine-grained data control, and elastic storage, to optimize
 performance and cost.
 
-In addition to on-prem deployments, DAOS is available as part of
-cloud offerings. More information on cloud deployments is available
+In addition to on-prem deployments, DAOS can be deployed in cloud
+environments. More information on cloud deployments is available
 in the [DAOS in the Cloud](./cloud/) section.
 
 The included document versions are associated with DAOS v2.0.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -59,6 +59,7 @@ nav:
         - 'Community Wiki': 'http://wiki.daos.io/'
         - 'Community Roadmap': 'http://wiki.daos.io/spaces/DC/pages/4836661105/Roadmap'
         - 'Community Mailing list': 'https://daos.groups.io/g/daos'
+        - 'DAOS in the Cloud': 'cloud/index.md'
         - 'Issue tracker': 'http://jira.daos.io/'
     - Release Information:
         - 'Release Notes v2.0': 'release/release_notes.md'
@@ -78,6 +79,7 @@ nav:
         - 'RHEL and clones': 'QSG/setup_rhel.md'
         - 'SUSE': 'QSG/setup_suse.md'
         - 'DAOS in Docker': 'QSG/docker.md'
+        - 'DAOS in the Cloud': 'QSG/cloud.md'
         - 'Build from Scratch': 'QSG/build_from_scratch.md'
         - 'Admin/Client Tools': 'QSG/tour.md'
     - Administration Guide:


### PR DESCRIPTION
add documentation for DAOS in the Cloud,
including DAOS on GCP references

Doc-only: true
Signed-off-by: Michael Hennecke <michael.hennecke@intel.com>