### PR TITLE
Revert "DAOS-10608 ci: Fix post_provision_config scripts"

### DIFF
--- a/ci/provisioning/post_provision_config_common_functions.sh
+++ b/ci/provisioning/post_provision_config_common_functions.sh
@@ -300,7 +300,7 @@ post_provision_config_nodes() {
             if ! RETRY_COUNT=4 retry_dnf 360 install $INST_RPMS; then
                 rc=${PIPESTATUS[0]}
                 dump_repos
-                return "$rc"
+                exit "$rc"
             fi
         fi
     fi
@@ -313,7 +313,7 @@ post_provision_config_nodes() {
     # shellcheck disable=SC2154
     if ! RETRY_COUNT=4 retry_dnf 600 upgrade --exclude "$EXCLUDE_UPGRADE"; then
         dump_repos
-        return 1
+        exit 1
     fi
 
     lsb_release -a
@@ -323,5 +323,5 @@ post_provision_config_nodes() {
     fi
     cat /etc/os-release
 
-    return 0
+    exit 0
 }

--- a/ci/provisioning/post_provision_config_nodes.sh
+++ b/ci/provisioning/post_provision_config_nodes.sh
@@ -105,10 +105,7 @@ rm -f  /etc/yum/vars/releasever
 
 # defined in ci/functional/post_provision_config_nodes_<distro>.sh
 # and catted to the remote node along with this script
-if ! post_provision_config_nodes; then
-    rc=${PIPESTATUS[0]}
-    exit "$rc"
-fi
+post_provision_config_nodes
 
 # Workaround to enable binding devices back to nvme or vfio-pci after they are unbound from vfio-pci
 # to nvme.  Sometimes the device gets unbound from vfio-pci, but it is not removed the iommu group

--- a/ci/provisioning/post_provision_config_nodes_UBUNTU_20_04.sh
+++ b/ci/provisioning/post_provision_config_nodes_UBUNTU_20_04.sh
@@ -43,7 +43,7 @@ post_provision_config_nodes() {
             rc=${PIPESTATUS[0]}
             if [ $rc -ne 100 ]; then
                 echo "Error $rc removing $INST_RPMS"
-                return $rc
+                exit $rc
             fi
         fi
     fi
@@ -60,7 +60,7 @@ post_provision_config_nodes() {
             echo "---- $file ----"
             cat "$file"
         done
-        return "$rc"
+        exit "$rc"
     fi
 
     # temporary hack until Python 3 is supported by Functional testing
@@ -69,6 +69,4 @@ post_provision_config_nodes() {
 
     # change the default shell to bash -- we write a lot of bash
     chsh -s /bin/bash
-
-    return 0
 }


### PR DESCRIPTION
Reverts daos-stack/daos#9140

This is causing valgrind failures in the build.