### PR TITLE
DAOS-10677 test: Add a new suppression for internal MPI leak

### DIFF
--- a/utils/test_memcheck.supp
+++ b/utils/test_memcheck.supp
@@ -279,6 +279,14 @@
    fun:par_init
 }
 {
+   memalign issue in MPI
+   Memcheck:Leak
+   match-leak-kinds: all
+   fun:memalign
+   ...
+   fun:par_init
+}
+{
    par_fini mpi leak
    Memcheck:Leak
    match-leak-kinds: all


### PR DESCRIPTION
We started seeing a new leak inside of OpenMPI so suppress it

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>

Required-githooks: true