### PR TITLE
build fix: include daos/debug.h first

### DIFF
--- a/src/chk/chk_iv.c
+++ b/src/chk/chk_iv.c
@@ -6,6 +6,7 @@
 
 #define D_LOGFAC	DD_FAC(chk)
 
+#include <daos/debug.h>
 #include <gurt/list.h>
 #include <gurt/debug.h>
 #include <cart/iv.h>


### PR DESCRIPTION
Ensures that macros are evaluated in the correct order.

Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com>
