### PR TITLE
DAOS-10615 ddb: Fix ddb usage of vos_self_init

### DIFF
--- a/src/ddb/ddb_vos.c
+++ b/src/ddb/ddb_vos.c
@@ -68,7 +68,7 @@ ddb_vos_pool_open(char *path, daos_handle_t *poh)
 	 * VOS files must be under /mnt/daos directory. This is a current limitation and
 	 * will change in the future
 	 */
-	rc = vos_self_init(pool_base);
+	rc = vos_self_init(pool_base, true, 0);
 	if (!SUCCESS(rc))
 		return rc;
 

--- a/src/ddb/tests/ddb_test_driver.c
+++ b/src/ddb/tests/ddb_test_driver.c
@@ -568,7 +568,7 @@ int main(int argc, char *argv[])
 	rc = ddb_init();
 	if (rc != 0)
 		return -rc;
-	rc = vos_self_init("/mnt/daos");
+	rc = vos_self_init("/mnt/daos", false, 0);
 	if (rc != 0) {
 		fprintf(stderr, "Unable to initialize VOS: "DF_RC"\n", DP_RC(rc));
 		ddb_fini();


### PR DESCRIPTION
After a change landed to master, ddb's usage of vos_self_init
needs to be updated to work with the new interface.

Signed-off-by: Ryon Jensen <ryon.jensen@intel.com>