### PR TITLE
DAOS-10525 pool: cleanup MAP rank init

### DIFF
--- a/src/container/srv_container.c
+++ b/src/container/srv_container.c
@@ -1400,7 +1400,7 @@ cont_agg_eph_leader_ult(void *arg)
 	while (!dss_ult_exiting(svc->cs_ec_leader_ephs_req)) {
 		d_rank_list_t		fail_ranks = { 0 };
 
-		rc = map_ranks_init(pool->sp_map, MAP_RANKS_DOWN,
+		rc = map_ranks_init(pool->sp_map, PO_COMP_ST_DOWNOUT | PO_COMP_ST_DOWN,
 				    &fail_ranks);
 		if (rc) {
 			D_ERROR(DF_UUID": ranks init failed: %d\n",

--- a/src/gurt/misc.c
+++ b/src/gurt/misc.c
@@ -219,6 +219,60 @@ d_rank_list_filter(d_rank_list_t *src_set, d_rank_list_t *dst_set,
 	}
 }
 
+int
+d_rank_list_merge(d_rank_list_t *src_ranks, d_rank_list_t *ranks_merge)
+{
+	d_rank_t	*rs;
+	int		*indexes;
+	int		num = 0;
+	int		src_num;
+	int		i;
+	int		j;
+	int		rc = 0;
+
+	D_ASSERT(src_ranks != NULL);
+	if (ranks_merge == NULL || ranks_merge->rl_nr == 0)
+		return 0;
+
+	D_ALLOC_ARRAY(indexes, ranks_merge->rl_nr);
+	if (indexes == NULL)
+		return -DER_NOMEM;
+
+	for (i = 0; i < ranks_merge->rl_nr; i++) {
+		if (!d_rank_list_find(src_ranks, ranks_merge->rl_ranks[i], NULL)) {
+			indexes[num] = i;
+			num++;
+		}
+	}
+
+	if (num == 0)
+		D_GOTO(free, rc = 0);
+
+	src_num = src_ranks->rl_nr;
+	D_ALLOC_ARRAY(rs, (num + src_num));
+	if (rs == NULL)
+		D_GOTO(free, rc = -DER_NOMEM);
+
+	for (i = 0; i < src_num; i++)
+		rs[i] = src_ranks->rl_ranks[i];
+
+	for (i = src_num, j = 0; i < src_num + num; i++, j++) {
+		int idx = indexes[j];
+
+		rs[i] = ranks_merge->rl_ranks[idx];
+	}
+
+	if (src_ranks->rl_ranks)
+		D_FREE(src_ranks->rl_ranks);
+
+	src_ranks->rl_nr = num + src_num;
+	src_ranks->rl_ranks = rs;
+
+free:
+	D_FREE(indexes);
+	return rc;
+}
+
 d_rank_list_t *
 d_rank_list_alloc(uint32_t size)
 {

--- a/src/include/daos/common.h
+++ b/src/include/daos/common.h
@@ -615,6 +615,7 @@ daos_quiet_error(int err)
 #define daos_rank_list_dup		d_rank_list_dup
 #define daos_rank_list_dup_sort_uniq	d_rank_list_dup_sort_uniq
 #define daos_rank_list_filter		d_rank_list_filter
+#define daos_rank_list_merge		d_rank_list_merge
 #define daos_rank_list_alloc		d_rank_list_alloc
 #define daos_rank_list_copy		d_rank_list_copy
 #define daos_rank_list_shuffle		d_rank_list_shuffle

--- a/src/include/daos_srv/pool.h
+++ b/src/include/daos_srv/pool.h
@@ -236,14 +236,8 @@ ds_pool_child_map_refresh_sync(struct ds_pool_child *dpc);
 int
 ds_pool_child_map_refresh_async(struct ds_pool_child *dpc);
 
-enum map_ranks_class {
-	MAP_RANKS_UP,
-	MAP_RANKS_DOWN
-};
-
 int
-map_ranks_init(const struct pool_map *map, enum map_ranks_class class,
-	       d_rank_list_t *ranks);
+map_ranks_init(const struct pool_map *map, unsigned int status, d_rank_list_t *ranks);
 
 void
 map_ranks_fini(d_rank_list_t *ranks);

--- a/src/include/gurt/common.h
+++ b/src/include/gurt/common.h
@@ -390,6 +390,7 @@ int d_rank_list_dup(d_rank_list_t **dst, const d_rank_list_t *src);
 int d_rank_list_dup_sort_uniq(d_rank_list_t **dst, const d_rank_list_t *src);
 void d_rank_list_filter(d_rank_list_t *src_set, d_rank_list_t *dst_set,
 			bool exclude);
+int d_rank_list_merge(d_rank_list_t *src_set, d_rank_list_t *merge_set);
 d_rank_list_t *d_rank_list_alloc(uint32_t size);
 d_rank_list_t *d_rank_list_realloc(d_rank_list_t *ptr, uint32_t size);
 void d_rank_list_free(d_rank_list_t *rank_list);

--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -1168,7 +1168,6 @@ static void
 fini_svc_pool(struct pool_svc *svc)
 {
 	D_ASSERT(svc->ps_pool != NULL);
-	ds_pool_iv_ns_update(svc->ps_pool, -1 /* master_rank */);
 	ds_pool_put(svc->ps_pool);
 	svc->ps_pool = NULL;
 }
@@ -5978,7 +5977,10 @@ ds_pool_ranks_get_handler(crt_rpc_t *rpc)
 	if (daos_rpc_from_client(rpc))
 		D_GOTO(out, rc = -DER_INVAL);
 
-	rc = ds_pool_get_ranks(in->prgi_op.pi_uuid, MAP_RANKS_UP, &out_ranks);
+	/* Get available ranks */
+	rc = ds_pool_get_ranks(in->prgi_op.pi_uuid,
+			       PO_COMP_ST_UP | PO_COMP_ST_UPIN | PO_COMP_ST_DRAIN | PO_COMP_ST_NEW,
+			       &out_ranks);
 	if (rc != 0) {
 		D_ERROR(DF_UUID ": get ranks failed, " DF_RC "\n",
 			DP_UUID(in->prgi_op.pi_uuid), DP_RC(rc));
@@ -6473,4 +6475,3 @@ ds_pool_target_status_check(struct ds_pool *pool, uint32_t id, uint8_t matched_s
 
 	return target->ta_comp.co_status == matched_status ? 1 : 0;
 }
-

--- a/src/pool/srv_target.c
+++ b/src/pool/srv_target.c
@@ -1274,7 +1274,8 @@ update_pool_group(struct ds_pool *pool, struct pool_map *map)
 	D_DEBUG(DB_MD, DF_UUID": %u -> %u\n", DP_UUID(pool->sp_uuid), version,
 		pool_map_get_version(map));
 
-	rc = map_ranks_init(map, MAP_RANKS_UP, &ranks);
+	rc = map_ranks_init(map, PO_COMP_ST_UP | PO_COMP_ST_UPIN |
+				 PO_COMP_ST_DRAIN | PO_COMP_ST_NEW, &ranks);
 	if (rc != 0)
 		return rc;
 


### PR DESCRIPTION
Remove map_ranks_class and move map_ranks_merge to
d_rank_list_range.

And DRAIN rank are still accessible until the rank
is excluded from the pool_map, so broacast RPC should
still include DRAIN ranks.

Signed-off-by: Di Wang <di.wang@intel.com>