### PR TITLE
DAOS-10435 IV: add update and sync epoch for pool IV.

### DIFF
--- a/src/engine/server_iv.c
+++ b/src/engine/server_iv.c
@@ -1203,6 +1203,6 @@ ds_iv_invalidate(struct ds_iv_ns *ns, struct ds_iv_key *key,
 	iv_sync.ivs_event = CRT_IV_SYNC_EVENT_NOTIFY;
 	iv_sync.ivs_mode = sync_mode;
 	iv_sync.ivs_flags = sync_flags;
-
+	key->eph = crt_hlc_get();
 	return iv_op(ns, key, NULL, &iv_sync, shortcut, retry, IV_INVALIDATE);
 }

--- a/src/include/daos_srv/iv.h
+++ b/src/include/daos_srv/iv.h
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2017-2021 Intel Corporation.
+ * (C) Copyright 2017-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -74,6 +74,7 @@ struct ds_iv_class {
 struct ds_iv_key {
 	d_rank_t	rank;
 	int		class_id;
+	daos_epoch_t	eph;
 	char		key_buf[IV_KEY_BUF_SIZE];
 };
 


### PR DESCRIPTION
Assume these IV update process.

1. pool service start, IV prop update asynchronously.
2. set property.
3. pool IV update asynchronously.

Since 1 and 3 are asynchrnously, especially if 1 needs to
retry, then 1 might arrive later than 3 for one engine, so
adding epoch to pool IV key, and if the incoming IV update epoch
is older than the current epoch of the entry, let's ignore
the update.

Test-tag: pr offline_reintegration_with_rf offline_reintegration_oclass
Signed-off-by: Di Wang <di.wang@intel.com>