### PR TITLE
DAOS-10525 object: retry for NONLEADER

### DIFF
--- a/src/object/obj_internal.h
+++ b/src/object/obj_internal.h
@@ -470,7 +470,7 @@ obj_retry_error(int err)
 	       err == -DER_INPROGRESS || err == -DER_GRPVER ||
 	       err == -DER_EXCLUDED || err == -DER_CSUM ||
 	       err == -DER_TX_BUSY || err == -DER_TX_UNCERTAIN ||
-	       err == -DER_NEED_TX ||
+	       err == -DER_NEED_TX || err == -DER_NOTLEADER ||
 	       daos_crt_network_error(err);
 }
 


### PR DESCRIPTION
Nonleader is a temporary state during leader swich,
so let's retry for object I/O.

Signed-off-by: Di Wang <di.wang@intel.com>