### PR TITLE
DAOS-10525 reintegrate: inflight I/O after discarding object

### DIFF
--- a/src/common/pool_map.c
+++ b/src/common/pool_map.c
@@ -3003,10 +3003,12 @@ pool_target_addr_equal(struct pool_target_addr *addr1,
 		       struct pool_target_addr *addr2)
 {
 	return addr1->pta_rank == addr2->pta_rank &&
-	       addr1->pta_target == addr2->pta_target;
+	       (addr1->pta_target == addr2->pta_target ||
+		addr1->pta_target == (uint32_t)(-1) ||
+		addr2->pta_target == (uint32_t)(-1));
 }
 
-static bool
+bool
 pool_target_addr_found(struct pool_target_addr_list *addr_list,
 		       struct pool_target_addr *tgt)
 {

--- a/src/dtx/dtx_resync.c
+++ b/src/dtx/dtx_resync.c
@@ -524,7 +524,7 @@ dtx_iter_cb(uuid_t co_uuid, vos_iter_entry_t *ent, void *args)
 	} else {
 		/* For pool map refresh. */
 		/* Leader: do nothing. */
-		if (ent->ie_dtx_flags & DTE_LEADER)
+		if (ent->ie_dtx_flags & DTE_LEADER && !dra->for_discard)
 			return 0;
 
 		/* Non-leader: handle the DTX with old version. */

--- a/src/include/daos/pool_map.h
+++ b/src/include/daos/pool_map.h
@@ -156,6 +156,10 @@ pool_target_addr_list_append(struct pool_target_addr_list *dst_list,
 void
 pool_target_addr_list_free(struct pool_target_addr_list *list);
 
+bool
+pool_target_addr_found(struct pool_target_addr_list *addr_list,
+		       struct pool_target_addr *tgt);
+
 struct pool_target_id {
 	uint32_t	pti_id;
 };

--- a/src/include/daos_errno.h
+++ b/src/include/daos_errno.h
@@ -280,7 +280,10 @@ extern "C" {
 	       No service available)					\
 	/** The TX ID may be reused. */				\
 	ACTION(DER_TX_ID_REUSED,	(DER_ERR_DAOS_BASE + 40),	\
-	       TX ID may be reused)
+	       TX ID may be reused)					\
+	/** Re-update again */						\
+	ACTION(DER_UPDATE_AGAIN,	(DER_ERR_DAOS_BASE + 41),	\
+	       update again)						\
 
 /** Defines the gurt error codes */
 #define D_FOREACH_ERR_RANGE(ACTION)	\

--- a/src/include/daos_srv/pool.h
+++ b/src/include/daos_srv/pool.h
@@ -68,8 +68,8 @@ struct ds_pool {
 	uuid_t			sp_srv_cont_hdl;
 	uuid_t			sp_srv_pool_hdl;
 	uint32_t		sp_stopping:1,
-				sp_fetch_hdls:1;
-
+				sp_fetch_hdls:1,
+				sp_need_discard:1;
 	int			sp_reintegrating;
 	/** path to ephemeral metrics */
 	char			sp_path[D_TM_MAX_NAME_LEN];
@@ -142,6 +142,7 @@ struct ds_pool_child {
 	int		spc_ref;
 	ABT_eventual	spc_ref_eventual;
 
+	uint64_t	spc_discard_done:1;
 	/**
 	 * Per-pool per-module metrics, see ${modname}_pool_metrics for the
 	 * actual structure. Initialized only for modules that specified a
@@ -250,6 +251,8 @@ map_ranks_fini(d_rank_list_t *ranks);
 
 int ds_pool_get_ranks(const uuid_t pool_uuid, int status,
 		      d_rank_list_t *ranks);
+int ds_pool_get_tgt_idx_by_state(const uuid_t pool_uuid, unsigned int status, int **tgts,
+				 unsigned int *tgts_cnt);
 int ds_pool_get_failed_tgt_idx(const uuid_t pool_uuid, int **failed_tgts,
 			       unsigned int *failed_tgts_cnt);
 int ds_pool_svc_list_cont(uuid_t uuid, d_rank_list_t *ranks,
@@ -276,6 +279,7 @@ int dsc_pool_open(uuid_t pool_uuid, uuid_t pool_hdl_uuid,
 		       struct pool_map *map, d_rank_list_t *svc_list,
 		       daos_handle_t *ph);
 int dsc_pool_close(daos_handle_t ph);
+int ds_pool_tgt_discard(uuid_t pool_uuid, uint64_t epoch);
 
 /**
  * Verify if pool status satisfy Redundancy Factor requirement, by checking

--- a/src/mgmt/rpc.h
+++ b/src/mgmt/rpc.h
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2021 Intel Corporation.
+ * (C) Copyright 2016-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */

--- a/src/mgmt/srv_target.c
+++ b/src/mgmt/srv_target.c
@@ -809,9 +809,11 @@ ds_mgmt_hdlr_tgt_create(crt_rpc_t *tc_req)
 	tc_out->tc_ranks.ca_count  = 1;
 
 	rc = ds_pool_start(tc_in->tc_pool_uuid);
-	if (rc)
+	if (rc) {
 		D_ERROR(DF_UUID": failed to start pool: "DF_RC"\n",
 			DP_UUID(tc_in->tc_pool_uuid), DP_RC(rc));
+		D_GOTO(out, rc);
+	}
 out:
 	if (rc && tca.tca_newborn != NULL) {
 		/*

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -1000,6 +1000,8 @@ obj_shard_tgts_query(struct dc_object *obj, uint32_t map_ver, uint32_t shard,
 	shard_tgt->st_tgt_idx	= obj_shard->do_target_idx;
 	if (obj_auxi->cond_modify && (obj_shard->do_rebuilding || obj_shard->do_reintegrating))
 		shard_tgt->st_flags |= DTF_DELAY_FORWARD;
+	if (obj_shard->do_reintegrating)
+		obj_auxi->reintegrating = 1;
 	rc = obj_shard2tgtid(obj, shard, map_ver, &shard_tgt->st_tgt_id);
 close:
 	obj_shard_close(obj_shard);
@@ -4544,6 +4546,7 @@ obj_task_init_common(tse_task_t *task, int opc, uint32_t map_ver,
 	obj_auxi->th = th;
 	obj_auxi->obj = obj;
 	obj_auxi->dkey_hash = 0;
+	obj_auxi->reintegrating = 0;
 	shard_task_list_init(obj_auxi);
 	obj_auxi->is_ec_obj = obj_is_ec(obj);
 	*auxi = obj_auxi;

--- a/src/object/cli_shard.c
+++ b/src/object/cli_shard.c
@@ -1270,6 +1270,8 @@ dc_obj_shard_rw(struct dc_obj_shard *shard, enum obj_rpc_opc opc,
 	uuid_copy(orw->orw_co_uuid, cont_uuid);
 	daos_dti_copy(&orw->orw_dti, &args->dti);
 	orw->orw_flags = auxi->flags | flags;
+	if (auxi->obj_auxi->reintegrating)
+		orw->orw_flags |= ORF_REINTEGRATING_IO;
 	orw->orw_tgt_idx = auxi->ec_tgt_idx;
 	if (args->reasb_req && args->reasb_req->orr_oca)
 		orw->orw_tgt_max = obj_ec_tgt_nr(args->reasb_req->orr_oca) - 1;

--- a/src/object/obj_internal.h
+++ b/src/object/obj_internal.h
@@ -296,13 +296,10 @@ struct obj_auxi_list_obj_enum {
 	int		iods_nr;
 };
 
-typedef int (*obj_enum_process_cb_t)(daos_key_desc_t *kds, void *ptr,
-				     unsigned int size, void *arg);
-int
-obj_enum_iterate(daos_key_desc_t *kdss, d_sg_list_t *sgl, int nr,
-		 unsigned int type, obj_enum_process_cb_t cb,
-		 void *cb_arg);
-#define CLI_OBJ_IO_PARMS	8
+struct shard_sync_args {
+	struct shard_auxi_args	 sa_auxi;
+	daos_epoch_t		*sa_epoch;
+};
 
 #define OBJ_TGT_INLINE_NR	9
 #define OBJ_INLINE_BTIMAP	4
@@ -342,11 +339,6 @@ struct obj_auxi_tgt_list {
 	uint32_t	tl_nr;
 };
 
-struct shard_sync_args {
-	struct shard_auxi_args	 sa_auxi;
-	daos_epoch_t		*sa_epoch;
-};
-
 /* Auxiliary args for object I/O */
 struct obj_auxi_args {
 	tse_task_t			*obj_task;
@@ -382,7 +374,8 @@ struct obj_auxi_args {
 					 tx_convert:1,
 					 cond_modify:1,
 					 /* conf_fetch split to multiple sub-tasks */
-					 cond_fetch_split:1;
+					 cond_fetch_split:1,
+					 reintegrating:1;
 	/* request flags. currently only: ORF_RESEND */
 	uint32_t			 flags;
 	uint32_t			 specified_shard;
@@ -407,8 +400,6 @@ struct obj_auxi_args {
 	};
 };
 
-#define obj_ec_dkey_hash_get(obj, dkey_hash)	\
-	(obj->cob_ec_parity_rotate ? dkey_hash : 0)
 /**
  * task memory space should enough to use -
  * obj API task with daos_task_args + obj_auxi_args,
@@ -419,6 +410,18 @@ D_CASSERT(sizeof(struct obj_auxi_args) + sizeof(struct shard_auxi_args) <=
 	  TSE_TASK_ARG_LEN);
 D_CASSERT(sizeof(struct obj_auxi_args) + sizeof(struct daos_task_args) <=
 	  TSE_TASK_ARG_LEN);
+
+
+typedef int (*obj_enum_process_cb_t)(daos_key_desc_t *kds, void *ptr,
+				     unsigned int size, void *arg);
+int
+obj_enum_iterate(daos_key_desc_t *kdss, d_sg_list_t *sgl, int nr,
+		 unsigned int type, obj_enum_process_cb_t cb,
+		 void *cb_arg);
+#define CLI_OBJ_IO_PARMS	8
+
+#define obj_ec_dkey_hash_get(obj, dkey_hash)	\
+	(obj->cob_ec_parity_rotate ? dkey_hash : 0)
 
 int
 merge_recx(d_list_t *head, uint64_t offset, uint64_t size, daos_epoch_t eph);
@@ -590,7 +593,7 @@ obj_retry_error(int err)
 	       err == -DER_EXCLUDED || err == -DER_CSUM ||
 	       err == -DER_TX_BUSY || err == -DER_TX_UNCERTAIN ||
 	       err == -DER_NEED_TX || err == -DER_NOTLEADER ||
-	       daos_crt_network_error(err);
+	       err == -DER_UPDATE_AGAIN || daos_crt_network_error(err);
 }
 
 static inline daos_handle_t

--- a/src/object/obj_rpc.h
+++ b/src/object/obj_rpc.h
@@ -31,7 +31,7 @@
  * These are for daos_rpc::dr_opc and DAOS_RPC_OPCODE(opc, ...) rather than
  * crt_req_create(..., opc, ...). See daos_rpc.h.
  */
-#define DAOS_OBJ_VERSION 8
+#define DAOS_OBJ_VERSION 9
 /* LIST of internal RPCS in form of:
  * OPCODE, flags, FMT, handler, corpc_hdlr and name
  */
@@ -180,6 +180,8 @@ enum obj_rpc_flags {
 	ORF_CONTAIN_LEADER	= (1 << 20),
 	/*Ascending Order - 0, descending order - 1*/
 	ORF_DESCENDING_ORDER	= (1 << 21),
+	/* send to reintegrating target */
+	ORF_REINTEGRATING_IO	= (1 << 22),
 };
 
 /* common for update/fetch */

--- a/src/object/obj_tx.c
+++ b/src/object/obj_tx.c
@@ -76,7 +76,8 @@ struct dc_tx {
 	uint64_t		 tx_flags;
 	uint32_t		 tx_fixed_epoch:1, /** epoch is specified. */
 				 tx_retry:1, /** Retry the commit RPC. */
-				 tx_set_resend:1; /** Set 'resend' flag. */
+				 tx_set_resend:1, /** Set 'resend' flag. */
+				 tx_reintegrating:1;
 	/** Transaction status (OPEN, COMMITTED, etc.), see dc_tx_status. */
 	enum dc_tx_status	 tx_status;
 	/** The rank for the server on which the TX leader resides. */
@@ -949,7 +950,7 @@ dc_tx_commit_cb(tse_task_t *task, void *data)
 	}
 
 	/* Need to restart the TX with newer epoch. */
-	if (rc == -DER_TX_RESTART || rc == -DER_STALE) {
+	if (rc == -DER_TX_RESTART || rc == -DER_STALE || rc == -DER_UPDATE_AGAIN) {
 		tx->tx_set_resend = 1;
 		tx->tx_status = TX_FAILED;
 
@@ -1227,6 +1228,8 @@ dc_tx_classify_common(struct dc_tx *tx, struct daos_cpd_sub_req *dcsr,
 		if (rc != 0)
 			goto out;
 
+		if (shard->do_reintegrating)
+			tx->tx_reintegrating = 1;
 		/* XXX: It is possible that more than one shards locate on the
 		 *	same DAOS target under OSA mode, then the "idx" may be
 		 *	not equal to "shard->do_shard".
@@ -1853,6 +1856,8 @@ dc_tx_commit_trigger(tse_task_t *task, struct dc_tx *tx, daos_tx_commit_t *args)
 	uuid_copy(oci->oci_pool_uuid, tx->tx_pool->dp_pool);
 	oci->oci_map_ver = tx->tx_pm_ver;
 	oci->oci_flags = ORF_CPD_LEADER | (tx->tx_set_resend ? ORF_RESEND : 0);
+	if (tx->tx_reintegrating)
+		oci->oci_flags |= ORF_REINTEGRATING_IO;
 
 	oci->oci_sub_heads.ca_arrays = &tx->tx_head;
 	oci->oci_sub_heads.ca_count = 1;

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -1998,6 +1998,13 @@ obj_ioc_begin(daos_obj_id_t oid, uint32_t rpc_map_ver, uuid_t pool_uuid,
 	if (rc != 0)
 		return rc;
 
+	if (obj_is_modification_opc(opc) && (flags & ORF_REINTEGRATING_IO) &&
+	    ioc->ioc_coc->sc_pool->spc_pool->sp_need_discard &&
+	    ioc->ioc_coc->sc_pool->spc_discard_done == 0) {
+		D_ERROR("reintegrating "DF_UUID" retry.\n", DP_UUID(pool_uuid));
+		D_GOTO(failed, rc = -DER_UPDATE_AGAIN);
+	}
+
 	rc = obj_capa_check(ioc->ioc_coh, obj_is_modification_opc(opc),
 			    obj_is_ec_agg_opc(opc) ||
 			    (flags & ORF_FOR_MIGRATION) ||
@@ -4649,6 +4656,13 @@ ds_obj_cpd_handler(crt_rpc_t *rpc)
 				opc_get(rpc->cr_opc), &ioc);
 	if (rc != 0)
 		goto reply;
+
+	if ((oci->oci_flags & ORF_REINTEGRATING_IO) &&
+	    ioc.ioc_coc->sc_pool->spc_pool->sp_need_discard &&
+	    ioc.ioc_coc->sc_pool->spc_rebuild_fence == 0) {
+		D_ERROR("reintegrating "DF_UUID" retry.\n", DP_UUID(oci->oci_pool_uuid));
+		D_GOTO(reply, rc = -DER_UPDATE_AGAIN);
+	}
 
 	if (!leader) {
 		if (tx_count != 1 || oci->oci_sub_reqs.ca_count != 1 ||

--- a/src/object/srv_obj_migrate.c
+++ b/src/object/srv_obj_migrate.c
@@ -2637,65 +2637,6 @@ migrate_obj_punch(struct iter_obj_arg *arg)
 			       arg->tgt_idx, MIGRATE_STACK_SIZE);
 }
 
-/* Destroys an object prior to migration. Called exactly once per object ID per
- * container on the appropriate VOS target xstream.
- */
-static int
-destroy_existing_obj(struct migrate_pool_tls *tls, unsigned int tgt_idx,
-		     daos_unit_oid_t *oid, uuid_t cont_uuid)
-{
-	struct ds_cont_child *cont = NULL;
-	daos_epoch_range_t   epr;
-	int rc;
-
-	rc = migrate_get_cont_child(tls, cont_uuid, &cont);
-	if (rc != 0 || cont == NULL)
-		return rc;
-
-	if (rc != 0) {
-		D_ERROR("Failed to open cont to clear obj before migrate; pool="
-			DF_UUID" cont="DF_UUID"\n",
-			DP_UUID(tls->mpt_pool_uuid), DP_UUID(cont_uuid));
-		return rc;
-	}
-
-	/* Wait until container aggregation are stopped */
-	while ((cont->sc_ec_agg_active || cont->sc_vos_agg_active) &&
-	       !tls->mpt_fini && !cont->sc_stopping) {
-		D_DEBUG(DB_REBUILD, "wait for "DF_UUID"/"DF_UUID"/%u vos aggregation"
-			" to be inactive\n", DP_UUID(tls->mpt_pool_uuid),
-			DP_UUID(cont_uuid), tls->mpt_version);
-		dss_sleep(2 * 1000);
-	}
-
-	if (tls->mpt_fini || cont->sc_stopping) {
-		D_DEBUG(DB_REBUILD, DF_UUID "container migration is aborted.\n",
-			DP_UUID(cont_uuid));
-		ds_cont_child_put(cont);
-		return 0;
-	}
-
-	epr.epr_hi = tls->mpt_max_eph;
-	epr.epr_lo = 0;
-	rc = vos_discard(cont->sc_hdl, oid, &epr, NULL, NULL);
-	if (rc != 0) {
-		D_ERROR("Migrate failed to destroy object prior to "
-			"reintegration: pool/object "DF_UUID"/"DF_UOID
-			" rc: "DF_RC"\n", DP_UUID(tls->mpt_pool_uuid),
-			DP_UOID(*oid), DP_RC(rc));
-		ds_cont_child_put(cont);
-		return rc;
-	}
-
-	D_DEBUG(DB_REBUILD, "destroyed pool/object "DF_UUID"/"DF_UOID
-		" before reintegration\n",
-		DP_UUID(tls->mpt_pool_uuid), DP_UOID(*oid));
-
-	ds_cont_child_put(cont);
-
-	return DER_SUCCESS;
-}
-
 /**
  * This ULT manages migration one object ID for one container. It does not do
  * the data migration itself - instead it iterates akeys/dkeys as a client and
@@ -2725,21 +2666,16 @@ migrate_obj_ult(void *data)
 		D_GOTO(free_notls, rc = 0);
 	}
 
-	if (tls->mpt_opc == RB_OP_REINT) {
-		/* Destroy this object ID locally prior to migration */
-		rc = destroy_existing_obj(tls, arg->tgt_idx, &arg->oid,
-					  arg->cont_uuid);
-		if (rc) {
-			/* Something went wrong trying to destroy this object.
-			 * Since destroying objects prior to migration is
-			 * currently only used for reintegration, it makes sense
-			 * to fail the reintegration operation at this point
-			 * rather than proceeding and potentially losing data
-			 */
-			D_ERROR("destroy_existing_obj failed: "DF_RC"\n",
-				DP_RC(rc));
-			D_GOTO(free, rc);
-		}
+	/* Only reintegrating targets/pool needs to discard the object,
+	 * if sp_need_discard is 0, either the target does not need to
+	 * discard, or discard has been done. spc_discard_done means
+	 * discarding has been done in the current VOS target.
+	 */
+	while (tls->mpt_pool->spc_pool->sp_need_discard &&
+	       !tls->mpt_pool->spc_discard_done) {
+		D_DEBUG(DB_REBUILD, DF_UUID" wait for discard to finish.\n",
+			DP_UUID(arg->pool_uuid));
+		dss_sleep(2 * 1000);
 	}
 
 	for (i = 0; i < arg->snap_cnt; i++) {

--- a/src/pool/rpc.c
+++ b/src/pool/rpc.c
@@ -119,6 +119,8 @@ CRT_RPC_DEFINE(pool_query_info, DAOS_ISEQ_POOL_QUERY_INFO,
 		DAOS_OSEQ_POOL_QUERY_INFO)
 CRT_RPC_DEFINE(pool_tgt_query_map, DAOS_ISEQ_POOL_TGT_QUERY_MAP,
 		DAOS_OSEQ_POOL_TGT_QUERY_MAP)
+CRT_RPC_DEFINE(pool_tgt_discard, DAOS_ISEQ_POOL_TGT_DISCARD,
+	       DAOS_OSEQ_POOL_TGT_DISCARD)
 
 /* Define for cont_rpcs[] array population below.
  * See POOL_PROTO_*_RPC_LIST macro definition

--- a/src/pool/rpc.h
+++ b/src/pool/rpc.h
@@ -134,8 +134,11 @@
 	X(POOL_UPGRADE,							\
 		0, &CQF_pool_upgrade,					\
 		ds_pool_upgrade_handler,				\
+		NULL),							\
+	X(POOL_TGT_DISCARD,						\
+		0, &CQF_pool_tgt_discard,				\
+		ds_pool_tgt_discard_handler,				\
 		NULL)
-
 /* Define for RPC enum population below */
 #define X(a, b, c, d, e) a
 
@@ -460,6 +463,16 @@ CRT_RPC_DECLARE(pool_upgrade, DAOS_ISEQ_POOL_UPGRADE, DAOS_OSEQ_POOL_UPGRADE)
 
 CRT_RPC_DECLARE(pool_tgt_query_map, DAOS_ISEQ_POOL_TGT_QUERY_MAP,
 		DAOS_OSEQ_POOL_TGT_QUERY_MAP)
+
+#define DAOS_ISEQ_POOL_TGT_DISCARD /* input fields */		 \
+	((uuid_t)		(ptdi_uuid)		CRT_VAR) \
+	((struct pool_target_addr) (ptdi_addrs)		CRT_ARRAY)
+
+#define DAOS_OSEQ_POOL_TGT_DISCARD /* output fields */		\
+	((int32_t)		(ptdo_rc)		CRT_VAR)
+
+CRT_RPC_DECLARE(pool_tgt_discard, DAOS_ISEQ_POOL_TGT_DISCARD,
+		DAOS_OSEQ_POOL_TGT_DISCARD)
 
 static inline int
 pool_req_create(crt_context_t crt_ctx, crt_endpoint_t *tgt_ep, crt_opcode_t opc,

--- a/src/pool/srv_internal.h
+++ b/src/pool/srv_internal.h
@@ -164,6 +164,7 @@ void ds_pool_replicas_update_handler(crt_rpc_t *rpc);
 int ds_pool_tgt_prop_update(struct ds_pool *pool, struct pool_iv_prop *iv_prop);
 int ds_pool_tgt_connect(struct ds_pool *pool, struct pool_iv_conn *pic);
 void ds_pool_tgt_query_map_handler(crt_rpc_t *rpc);
+void ds_pool_tgt_discard_handler(crt_rpc_t *rpc);
 
 /*
  * srv_util.c

--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -5412,6 +5412,65 @@ ds_pool_extend_handler(crt_rpc_t *rpc)
 	crt_reply_send(rpc);
 }
 
+static int
+pool_discard(crt_context_t ctx, struct pool_svc *svc, struct pool_target_addr_list *list)
+{
+	struct pool_tgt_discard_in	*ptdi_in;
+	struct pool_tgt_discard_out	*ptdi_out;
+	crt_rpc_t			*rpc;
+	d_rank_list_t			*rank_list = NULL;
+	crt_opcode_t			opc;
+	int				i;
+	int				rc;
+
+	rank_list = d_rank_list_alloc(list->pta_number);
+	if (rank_list == NULL)
+		D_GOTO(out, rc = -DER_NOMEM);
+
+	rank_list->rl_nr = 0;
+	/* remove the duplicate ranks from list, see reintegrate target case */
+	for (i = 0; i < list->pta_number; i++) {
+		if (daos_rank_in_rank_list(rank_list, list->pta_addrs[i].pta_rank))
+			continue;
+
+		rank_list->rl_ranks[rank_list->rl_nr++] = list->pta_addrs[i].pta_rank;
+		D_DEBUG(DB_MD, DF_UUID": discard rank %u\n",
+			DP_UUID(svc->ps_pool->sp_uuid), list->pta_addrs[i].pta_rank);
+	}
+
+	if (rank_list->rl_nr == 0) {
+		D_DEBUG(DB_MD, DF_UUID" discard 0 rank.\n", DP_UUID(svc->ps_pool->sp_uuid));
+		D_GOTO(out, rc = 0);
+	}
+
+	opc = DAOS_RPC_OPCODE(POOL_TGT_DISCARD, DAOS_POOL_MODULE, DAOS_POOL_VERSION);
+	rc = crt_corpc_req_create(ctx, NULL, rank_list, opc, NULL,
+				  NULL, CRT_RPC_FLAG_FILTER_INVERT,
+				  crt_tree_topo(CRT_TREE_KNOMIAL, 32), &rpc);
+	if (rc)
+		D_GOTO(out, rc);
+
+	ptdi_in = crt_req_get(rpc);
+	ptdi_in->ptdi_addrs.ca_arrays = list->pta_addrs;
+	ptdi_in->ptdi_addrs.ca_count = list->pta_number;
+	uuid_copy(ptdi_in->ptdi_uuid, svc->ps_pool->sp_uuid);
+	rc = dss_rpc_send(rpc);
+
+	ptdi_out = crt_reply_get(rpc);
+	D_ASSERT(ptdi_out != NULL);
+	rc = ptdi_out->ptdo_rc;
+	if (rc != 0)
+		D_ERROR(DF_UUID": pool discard failed: rc: %d\n",
+			DP_UUID(svc->ps_pool->sp_uuid), rc);
+
+	crt_req_decref(rpc);
+
+out:
+	if (rank_list)
+		d_rank_list_free(rank_list);
+	return rc;
+}
+
 void
 ds_pool_update_handler(crt_rpc_t *rpc)
 {
@@ -5436,6 +5495,13 @@ ds_pool_update_handler(crt_rpc_t *rpc)
 
 	list.pta_number = in->pti_addr_list.ca_count;
 	list.pta_addrs = in->pti_addr_list.ca_arrays;
+
+	if (opc_get(rpc->cr_opc) == POOL_REINT) {
+		rc = pool_discard(rpc->cr_ctx, svc, &list);
+		if (rc)
+			goto out_svc;
+	}
+
 	rc = pool_svc_update_map(svc, opc_get(rpc->cr_opc),
 				 false /* exclude_rank */, &list,
 				 &inval_list_out, &out->pto_op.po_map_version,

--- a/src/pool/srv_target.c
+++ b/src/pool/srv_target.c
@@ -1690,3 +1690,251 @@ out:
 		rpc, DP_RC(out->tmo_op.po_rc));
 	crt_reply_send(rpc);
 }
+
+struct tgt_discard_arg {
+	uuid_t			     pool_uuid;
+	uint64_t		     epoch;
+	struct pool_target_addr_list tgt_list;
+};
+
+struct child_discard_arg {
+	struct tgt_discard_arg	*tgt_discard;
+	uuid_t			cont_uuid;
+};
+
+static struct tgt_discard_arg*
+tgt_discard_arg_alloc(struct pool_target_addr_list *tgt_list)
+{
+	struct tgt_discard_arg	*arg;
+	int			i;
+	int			rc;
+
+	D_ALLOC_PTR(arg);
+	if (arg == NULL)
+		return NULL;
+
+	rc = pool_target_addr_list_alloc(tgt_list->pta_number, &arg->tgt_list);
+	if (rc != 0) {
+		D_FREE(arg);
+		return NULL;
+	}
+
+	for (i = 0; i < tgt_list->pta_number; i++) {
+		arg->tgt_list.pta_addrs[i].pta_rank = tgt_list->pta_addrs[i].pta_rank;
+		arg->tgt_list.pta_addrs[i].pta_target = tgt_list->pta_addrs[i].pta_target;
+	}
+
+	return arg;
+}
+
+static void
+tgt_discard_arg_free(struct tgt_discard_arg *arg)
+{
+	pool_target_addr_list_free(&arg->tgt_list);
+	D_FREE(arg);
+}
+
+static int
+obj_discard_cb(daos_handle_t ch, vos_iter_entry_t *ent,
+	       vos_iter_type_t type, vos_iter_param_t *param,
+	       void *data, unsigned *acts)
+{
+	struct child_discard_arg	*arg = data;
+	daos_epoch_range_t		epr;
+	int				rc;
+
+	epr.epr_hi = arg->tgt_discard->epoch;
+	epr.epr_lo = 0;
+	rc = vos_discard(param->ip_hdl, &ent->ie_oid, &epr, NULL, NULL);
+	if (rc != 0)
+		D_ERROR("discard object pool/object "DF_UUID"/"DF_UOID" rc: "DF_RC"\n",
+			DP_UUID(arg->tgt_discard->pool_uuid), DP_UOID(ent->ie_oid),
+			DP_RC(rc));
+	return rc;
+}
+
+/** vos_iter_cb_t */
+static int
+cont_discard_cb(daos_handle_t ih, vos_iter_entry_t *entry,
+		vos_iter_type_t type, vos_iter_param_t *iter_param,
+		void *cb_arg, unsigned int *acts)
+{
+	struct child_discard_arg *arg = cb_arg;
+	struct ds_cont_child	*cont = NULL;
+	vos_iter_param_t	param = { 0 };
+	struct vos_iter_anchors	anchor = { 0 };
+	daos_handle_t		coh;
+	int			rc;
+
+	D_ASSERT(type == VOS_ITER_COUUID);
+	if (uuid_compare(arg->cont_uuid, entry->ie_couuid) == 0) {
+		D_DEBUG(DB_REBUILD, DF_UUID" already discard\n",
+			DP_UUID(arg->cont_uuid));
+		return 0;
+	}
+
+	rc = ds_cont_child_lookup(arg->tgt_discard->pool_uuid, entry->ie_couuid,
+				  &cont);
+	if (rc != DER_SUCCESS) {
+		D_ERROR("Lookup container '"DF_UUIDF"' failed: "DF_RC"\n",
+			DP_UUID(entry->ie_couuid), DP_RC(rc));
+		return rc;
+	}
+
+	rc = vos_cont_open(iter_param->ip_hdl, entry->ie_couuid, &coh);
+	if (rc != 0) {
+		D_ERROR("Open container "DF_UUID" failed: "DF_RC"\n",
+			DP_UUID(entry->ie_couuid), DP_RC(rc));
+		D_GOTO(put, rc);
+	}
+
+	param.ip_hdl = coh;
+	param.ip_epr.epr_lo = 0;
+	param.ip_epr.epr_hi = arg->tgt_discard->epoch;
+	uuid_copy(arg->cont_uuid, entry->ie_couuid);
+
+	rc = vos_iterate(&param, VOS_ITER_OBJ, false, &anchor, obj_discard_cb, NULL,
+			 arg, NULL);
+	vos_cont_close(coh);
+	D_DEBUG(DB_TRACE, DF_UUID"/"DF_UUID" discard cont done: "DF_RC"\n",
+		DP_UUID(arg->tgt_discard->pool_uuid), DP_UUID(entry->ie_couuid),
+		DP_RC(rc));
+
+put:
+	ds_cont_child_put(cont);
+	return rc;
+}
+
+static int
+pool_child_discard(void *data)
+{
+	struct tgt_discard_arg	*arg = data;
+	struct child_discard_arg cont_arg;
+	struct ds_pool_child	*child;
+	vos_iter_param_t	param = { 0 };
+	struct vos_iter_anchors	anchor = { 0 };
+	struct pool_target_addr addr;
+	uint32_t		myrank;
+	int			rc;
+
+	myrank = dss_self_rank();
+	addr.pta_rank = myrank;
+	addr.pta_target = dss_get_module_info()->dmi_tgt_id;
+	if (!pool_target_addr_found(&arg->tgt_list, &addr)) {
+		D_DEBUG(DB_TRACE, "skip discard %u/%u.\n", addr.pta_rank,
+			addr.pta_target);
+		return 0;
+	}
+
+	D_DEBUG(DB_MD, DF_UUID" discard %u/%u\n", DP_UUID(arg->pool_uuid),
+		myrank, addr.pta_target);
+
+	child = ds_pool_child_lookup(arg->pool_uuid);
+	D_ASSERT(child != NULL);
+	param.ip_hdl = child->spc_hdl;
+
+	cont_arg.tgt_discard = arg;
+	child->spc_discard_done = 0;
+	rc = vos_iterate(&param, VOS_ITER_COUUID, false, &anchor,
+			 cont_discard_cb, NULL, &cont_arg, NULL);
+
+	child->spc_discard_done = 1;
+
+	ds_pool_child_put(child);
+
+	return rc;
+}
+
+/* Discard the objects by epoch in this pool */
+static void
+ds_pool_tgt_discard_ult(void *data)
+{
+	struct ds_pool		*pool;
+	struct tgt_discard_arg	*arg = data;
+	struct dss_coll_ops	coll_ops = { 0 };
+	struct dss_coll_args	coll_args = { 0 };
+	int			rc;
+
+	/* If discard failed, let's still go ahead, since reintegration might
+	 * still succeed, though it might leave some garbage on the reintegration
+	 * target, the future scrub tool might fix it. XXX
+	 */
+	pool = ds_pool_lookup(arg->pool_uuid);
+	if (pool == NULL) {
+		D_INFO(DF_UUID" is stopping!\n", DP_UUID(arg->pool_uuid));
+		D_GOTO(free, rc = 0);
+	}
+
+	/* collective operations */
+	coll_ops.co_func = pool_child_discard;
+	coll_args.ca_func_args	= arg;
+	if (pool->sp_map != NULL) {
+		unsigned int status;
+
+		/* It should only discard the target in DOWNOUT state, and skip
+		 * targets in other state.
+		 */
+		status = PO_COMP_ST_UP | PO_COMP_ST_UPIN | PO_COMP_ST_DRAIN |
+			 PO_COMP_ST_DOWN | PO_COMP_ST_NEW;
+		rc = ds_pool_get_tgt_idx_by_state(arg->pool_uuid, status,
+						  &coll_args.ca_exclude_tgts,
+						  &coll_args.ca_exclude_tgts_cnt);
+		if (rc) {
+			D_ERROR(DF_UUID "failed to get index : rc "DF_RC"\n",
+				DP_UUID(arg->pool_uuid), DP_RC(rc));
+			D_GOTO(put, rc);
+		}
+	}
+
+	rc = dss_thread_collective_reduce(&coll_ops, &coll_args, 0);
+	if (coll_args.ca_exclude_tgts)
+		D_FREE(coll_args.ca_exclude_tgts);
+	D_CDEBUG(rc == 0, DB_MD, DLOG_ERR, DF_UUID" tgt discard:" DF_RC"\n",
+		 DP_UUID(arg->pool_uuid), DP_RC(rc));
+put:
+	pool->sp_need_discard = 0;
+	ds_pool_put(pool);
+free:
+	tgt_discard_arg_free(arg);
+}
+
+void
+ds_pool_tgt_discard_handler(crt_rpc_t *rpc)
+{
+	struct pool_tgt_discard_in	*in = crt_req_get(rpc);
+	struct pool_tgt_discard_out	*out = crt_reply_get(rpc);
+	struct pool_target_addr_list	pta_list;
+	struct tgt_discard_arg		*arg = NULL;
+	struct ds_pool			*pool;
+	int				rc;
+
+	pta_list.pta_number = in->ptdi_addrs.ca_count;
+	pta_list.pta_addrs = in->ptdi_addrs.ca_arrays;
+	arg = tgt_discard_arg_alloc(&pta_list);
+	if (arg == NULL)
+		D_GOTO(out, rc = -DER_NOMEM);
+
+	/* POOL is already started in ds_mgmt_hdlr_tgt_create() during reintegration,
+	 * though pool might being stopped for some reason.
+	 * Let's do pool lookup to make sure pool child is already created.
+	 */
+	uuid_copy(arg->pool_uuid, in->ptdi_uuid);
+	arg->epoch = DAOS_EPOCH_MAX;
+	pool = ds_pool_lookup(arg->pool_uuid);
+	if (pool == NULL) {
+		D_INFO(DF_UUID" is stopping!\n", DP_UUID(arg->pool_uuid));
+		D_GOTO(out, rc = 0);
+	}
+
+	pool->sp_need_discard = 1;
+	rc = dss_ult_create(ds_pool_tgt_discard_ult, arg, DSS_XS_SYS, 0, 0, NULL);
+
+	ds_pool_put(pool);
+out:
+	out->ptdo_rc = rc;
+	D_DEBUG(DB_MD, DF_UUID": replying rpc "DF_RC"\n", DP_UUID(in->ptdi_uuid),
+		DP_RC(rc));
+	crt_reply_send(rpc);
+	if (rc != 0 && arg != NULL)
+		tgt_discard_arg_free(arg);
+}

--- a/src/tests/suite/daos_rebuild_simple.c
+++ b/src/tests/suite/daos_rebuild_simple.c
@@ -825,7 +825,12 @@ rebuild_sx_object_internal(void **state, daos_oclass_id_t oclass)
 		memset(buffer, 0, 32);
 		sprintf(dkey, "dkey_%d\n", i);
 		lookup_single(dkey, akey, 0, buffer, 32, DAOS_TX_NONE, &req);
-		assert_string_equal(buffer, rec);
+		/* SX only has one replica, and reintegration will delete the "stale"
+		 * data anyway, so it may lose data here, so do not need verify data
+		 * for SX object. Incremental reintegration might fix this.
+		 */
+		if (oclass != OC_SX)
+			assert_string_equal(buffer, rec);
 	}
 	ioreq_fini(&req);
 }

--- a/src/vos/vos_obj_cache.c
+++ b/src/vos/vos_obj_cache.c
@@ -408,6 +408,13 @@ check_object:
 		goto failed;
 	}
 
+	if (obj->obj_discard && intent == DAOS_INTENT_UPDATE) {
+		/** Cleanup before assert so unit test that triggers doesn't corrupt the state */
+		vos_obj_release(occ, obj, false);
+		rc = -DER_UPDATE_AGAIN;
+		goto failed;
+	}
+
 	if ((flags & VOS_OBJ_DISCARD) || intent == DAOS_INTENT_KILL || intent == DAOS_INTENT_PUNCH)
 		goto out;
 


### PR DESCRIPTION
During reintegration,  if inflight I/O arrives before dicarding,
then vos_dicard might dicard those data written by inflight I/O,
so let's discard all of the original data first, and if inflight
I/O arrives before discard finished, then it will return
DER_UPDATE_AGAIN and retry.

Signed-off-by: Di Wang <di.wang@intel.com>