### PR TITLE
build: Install meson using pip on el8/fedora.

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -349,6 +349,11 @@ def scons(): # pylint: disable=too-many-locals
 
     platform_arm = is_platform_arm()
 
+    if 'VIRTUAL_ENV' in os.environ:
+        env.PrependENVPath('PATH', os.path.join(os.environ['VIRTUAL_ENV'], 'bin'))
+        # pylint: disable=invalid-sequence-index
+        env['ENV']['VIRTUAL_ENV'] = os.environ['VIRTUAL_ENV']
+
     prereqs = PreReqComponent(env, opts, commits_file)
     if not GetOption('help') and not GetOption('clean'):
         daos_build.load_mpi_path(env)

--- a/utils/docker/Dockerfile.el.8
+++ b/utils/docker/Dockerfile.el.8
@@ -113,7 +113,7 @@ ENV PATH=/home/daos/venv/bin:$PATH
 ENV VIRTUAL_ENV=/home/daos/venv/
 
 RUN python3 -m pip --no-cache-dir install --upgrade pip && \
-    python3 -m pip --no-cache-dir install distro scons meson==0.59.4
+    python3 -m pip --no-cache-dir install distro scons pyelftools meson==0.59.4
 
 WORKDIR /home/daos/pre
 COPY --chown=daos_server:daos_server SConstruct .

--- a/utils/docker/Dockerfile.el.8
+++ b/utils/docker/Dockerfile.el.8
@@ -113,7 +113,7 @@ ENV PATH=/home/daos/venv/bin:$PATH
 ENV VIRTUAL_ENV=/home/daos/venv/
 
 RUN python3 -m pip --no-cache-dir install --upgrade pip && \
-    python3 -m pip --no-cache-dir install scons meson==0.59.4
+    python3 -m pip --no-cache-dir install distro scons meson==0.59.4
 
 WORKDIR /home/daos/pre
 COPY --chown=daos_server:daos_server SConstruct .

--- a/utils/docker/Dockerfile.el.8
+++ b/utils/docker/Dockerfile.el.8
@@ -107,8 +107,13 @@ RUN if [ "x$BULLSEYE" != "x" ]; then \
 
 USER daos_server:daos_server
 
-# Install scons from pip to avoid dependency cycle bug.
-RUN python3 -m pip --no-cache-dir --disable-pip-version-check install --user scons
+# Setup a python venv so that python packages can be installed locally.
+RUN python3 -m venv /home/daos/venv
+ENV PATH=/home/daos/venv/bin:$PATH
+ENV VIRTUAL_ENV=/home/daos/venv/
+
+RUN python3 -m pip --no-cache-dir install --upgrade pip && \
+    python3 -m pip --no-cache-dir install scons meson==0.59.4
 
 WORKDIR /home/daos/pre
 COPY --chown=daos_server:daos_server SConstruct .

--- a/utils/scripts/install-el8.sh
+++ b/utils/scripts/install-el8.sh
@@ -46,7 +46,6 @@ dnf -y --nodocs install \
     Lmod \
     lz4-devel \
     make \
-    meson \
     ndctl \
     ninja-build \
     numactl \

--- a/utils/scripts/install-el8.sh
+++ b/utils/scripts/install-el8.sh
@@ -56,10 +56,8 @@ dnf -y --nodocs install \
     patchelf \
     python3-defusedxml \
     python3-devel \
-    python3-distro \
     python3-junit_xml \
     python3-pip \
-    python3-pyelftools \
     python3-pyxattr \
     python3-tabulate \
     python3-yaml \


### PR DESCRIPTION
Fedora have recently updated their meson version and spdk
no longer builds.  This is a partial backport of a bigger
update from master to install dependencies through pip
rather than use the distrobution versions.

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>
