### PR TITLE
DAOS-7133 tse: refine task re-init checking

### DIFF
--- a/src/common/tse.c
+++ b/src/common/tse.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2021 Intel Corporation.
+ * (C) Copyright 2016-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -36,8 +36,7 @@ tse_sched_init(tse_sched_t *sched, tse_sched_comp_cb_t comp_cb,
 	       void *udata)
 {
 	struct tse_sched_private	*dsp = tse_sched2priv(sched);
-	pthread_mutexattr_t		attr;
-	int rc;
+	int				 rc;
 
 	D_CASSERT(sizeof(sched->ds_private) >= sizeof(*dsp));
 
@@ -55,19 +54,6 @@ tse_sched_init(tse_sched_t *sched, tse_sched_comp_cb_t comp_cb,
 	rc = D_MUTEX_INIT(&dsp->dsp_lock, NULL);
 	if (rc != 0)
 		return rc;
-
-	rc = pthread_mutexattr_init(&attr);
-	if (rc != 0) {
-		D_MUTEX_DESTROY(&dsp->dsp_lock);
-		return -DER_INVAL;
-	}
-	pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE);
-
-	rc = D_MUTEX_INIT(&dsp->dsp_comp_lock, &attr);
-	if (rc != 0) {
-		D_MUTEX_DESTROY(&dsp->dsp_lock);
-		return rc;
-	}
 
 	if (comp_cb != NULL) {
 		rc = tse_sched_register_comp_cb(sched, comp_cb, udata);
@@ -102,6 +88,7 @@ tse_task_buf_embedded(tse_task_t *task, int size)
 	/** Let's assume dtp_buf is always enough at the moment */
 	/** MSC - should malloc if size requested is bigger */
 	size = tse_task_buf_size(size);
+	D_ASSERT(size < UINT16_MAX);
 	avail_size = sizeof(dtp->dtp_buf) - dtp->dtp_stack_top;
 	D_ASSERTF(size <= avail_size,
 		  "req size %u avail size %u (all_size %lu stack_top %u)\n",
@@ -294,7 +281,6 @@ tse_sched_fini(tse_sched_t *sched)
 	D_ASSERT(d_list_empty(&dsp->dsp_complete_list));
 	D_ASSERT(d_list_empty(&dsp->dsp_sleeping_list));
 	D_MUTEX_DESTROY(&dsp->dsp_lock);
-	D_MUTEX_DESTROY(&dsp->dsp_comp_lock);
 }
 
 static inline void
@@ -394,7 +380,6 @@ tse_task_complete_locked(struct tse_task_private *dtp,
 	}
 
 	dtp->dtp_running = 0;
-	dtp->dtp_completing = 0;
 	dtp->dtp_completed = 1;
 	d_list_move_tail(&dtp->dtp_list, &dsp->dsp_complete_list);
 }
@@ -459,6 +444,18 @@ tse_task_register_cbs(tse_task_t *task, tse_task_cb_t prep_cb,
 	return rc;
 }
 
+static uint32_t
+dtp_generation_get(struct tse_task_private *dtp)
+{
+	return atomic_fetch_add(&dtp->dtp_generation, 0);
+}
+
+static void
+dtp_generation_inc(struct tse_task_private *dtp)
+{
+	atomic_fetch_add(&dtp->dtp_generation, 1);
+}
+
 /*
  * Execute the prep callback(s) of the task.
  */
@@ -468,12 +465,14 @@ tse_task_prep_callback(tse_task_t *task)
 	struct tse_task_private	*dtp = tse_task2priv(task);
 	struct tse_task_cb	*dtc;
 	struct tse_task_cb	*tmp;
+	uint32_t		 gen, new_gen;
 	bool			 ret = true;
 	int			 rc;
 
 	d_list_for_each_entry_safe(dtc, tmp, &dtp->dtp_prep_cb_list, dtc_list) {
 		d_list_del(&dtc->dtc_list);
 		/** no need to call if task was completed in one of the cbs */
+		gen = dtp_generation_get(dtp);
 		if (!dtp->dtp_completed) {
 			rc = dtc->dtc_cb(task, dtc->dtc_arg);
 			if (task->dt_result == 0)
@@ -482,8 +481,9 @@ tse_task_prep_callback(tse_task_t *task)
 
 		D_FREE(dtc);
 
+		new_gen = dtp_generation_get(dtp);
 		/** Task was re-initialized; */
-		if (!dtp->dtp_running && !dtp->dtp_completing)
+		if (!dtp->dtp_running && new_gen != gen)
 			ret = false;
 	}
 
@@ -502,16 +502,16 @@ static bool
 tse_task_complete_callback(tse_task_t *task)
 {
 	struct tse_task_private	*dtp = tse_task2priv(task);
-	struct tse_sched_private *dsp = dtp->dtp_sched;
 	uint32_t		 dep_cnt = dtp->dtp_dep_cnt;
+	uint32_t		 gen, new_gen;
 	struct tse_task_cb	*dtc;
 	struct tse_task_cb	*tmp;
 
-	D_MUTEX_LOCK(&dsp->dsp_comp_lock);
 	d_list_for_each_entry_safe(dtc, tmp, &dtp->dtp_comp_cb_list, dtc_list) {
 		int ret;
 
 		d_list_del(&dtc->dtc_list);
+		gen = dtp_generation_get(dtp);
 		ret = dtc->dtc_cb(task, dtc->dtc_arg);
 		if (task->dt_result == 0)
 			task->dt_result = ret;
@@ -519,9 +519,9 @@ tse_task_complete_callback(tse_task_t *task)
 		D_FREE(dtc);
 
 		/** Task was re-initialized; break */
-		if (!dtp->dtp_completing) {
+		new_gen = dtp_generation_get(dtp);
+		if (new_gen != gen) {
 			D_DEBUG(DB_TRACE, "re-init task %p\n", task);
-			D_MUTEX_UNLOCK(&dsp->dsp_comp_lock);
 			return false;
 		}
 
@@ -529,11 +529,9 @@ tse_task_complete_callback(tse_task_t *task)
 		if (dtp->dtp_dep_cnt > dep_cnt) {
 			D_DEBUG(DB_TRACE, "new dep-task added to task %p\n",
 				task);
-			D_MUTEX_UNLOCK(&dsp->dsp_comp_lock);
 			return false;
 		}
 	}
-	D_MUTEX_UNLOCK(&dsp->dsp_comp_lock);
 
 	return true;
 }
@@ -663,8 +661,6 @@ tse_task_post_process(tse_task_t *task)
 			 * it is completed when they completed in this code
 			 * block.
 			 */
-
-			dtp_tmp->dtp_completing = 1;
 			/** release lock for CB */
 			D_MUTEX_UNLOCK(&dsp->dsp_lock);
 			done = tse_task_complete_callback(task_tmp);
@@ -857,7 +853,6 @@ tse_task_complete(tse_task_t *task, int ret)
 	if (task->dt_result == 0)
 		task->dt_result = ret;
 
-	dtp->dtp_completing = 1;
 	/** Execute task completion callbacks first. */
 	done = tse_task_complete_callback(task);
 
@@ -1099,8 +1094,9 @@ tse_task_reinit_with_delay(tse_task_t *task, uint64_t delay)
 
 	/** Mark the task back at init state */
 	dtp->dtp_running = 0;
-	dtp->dtp_completing = 0;
 	dtp->dtp_completed = 0;
+
+	dtp_generation_inc(dtp);
 
 	/** reset stack pointer as zero */
 	if (dtp->dtp_stack_top != 0) {
@@ -1185,7 +1181,6 @@ tse_task_reset(tse_task_t *task, tse_task_func_t task_func, void *priv)
 
 	/** Mark the task back at init state */
 	dtp->dtp_running = 0;
-	dtp->dtp_completing = 0;
 	dtp->dtp_completed = 0;
 
 	/** reset stack pointer as zero */


### PR DESCRIPTION
Original code using dtp_completing flag for task re-init check -
1. first set dtp_completing == 1 and call task completion CB,
2. inside task completion CB if it calls re-init then will zero the flag,
3. check dtp_completing flag if it is zero then the task was re-inited

But a problem is once the task re-inited in step2, it possibly get
executing and complete (which will set the dtp_completing flag)
immediately even before step 3.
Previously we added a lock dsp_comp_lock to avoid that but did not
resolve some cases' problem, and the lock is bad as it actually
serialized all tasks' completion callbacks' executing.

This patch refines that by adding an ATOMIC generation to the task,
and removes the dsp_comp_lock.

Signed-off-by: Xuezhao Liu <xuezhao.liu@intel.com>