### PR TITLE
DAOS-10660 control: Remove duplicate rank results after system fanout

### DIFF
--- a/src/control/lib/control/system_test.go
+++ b/src/control/lib/control/system_test.go
@@ -8,6 +8,7 @@ package control
 
 import (
 	"context"
+	"net"
 	"testing"
 	"time"
 
@@ -546,6 +547,14 @@ func TestControl_SystemQuery(t *testing.T) {
 		fds[i] = system.MustCreateFaultDomainFromString(fdStrs[i])
 	}
 
+	mustNewMember := func(t *testing.T, r system.Rank, uuidStr, uri string, a *net.TCPAddr, s system.MemberState) *system.Member {
+		m, err := system.NewMember(r, uuidStr, uri, a, s)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return m
+	}
+
 	for name, tc := range map[string]struct {
 		req     *SystemQueryReq
 		uErr    error
@@ -621,10 +630,10 @@ func TestControl_SystemQuery(t *testing.T) {
 			),
 			expResp: &SystemQueryResp{
 				Members: system.Members{
-					system.NewMember(1, test.MockUUID(1), "", test.MockHostAddr(1), system.MemberStateReady).WithFaultDomain(fds[1]),
-					system.NewMember(2, test.MockUUID(2), "", test.MockHostAddr(1), system.MemberStateReady).WithFaultDomain(fds[2]),
-					system.NewMember(0, test.MockUUID(0), "", test.MockHostAddr(2), system.MemberStateStopped).WithFaultDomain(fds[0]),
-					system.NewMember(3, test.MockUUID(3), "", test.MockHostAddr(2), system.MemberStateStopped).WithFaultDomain(fds[3]),
+					mustNewMember(t, 1, test.MockUUID(1), "", test.MockHostAddr(1), system.MemberStateReady).WithFaultDomain(fds[1]),
+					mustNewMember(t, 2, test.MockUUID(2), "", test.MockHostAddr(1), system.MemberStateReady).WithFaultDomain(fds[2]),
+					mustNewMember(t, 0, test.MockUUID(0), "", test.MockHostAddr(2), system.MemberStateStopped).WithFaultDomain(fds[0]),
+					mustNewMember(t, 3, test.MockUUID(3), "", test.MockHostAddr(2), system.MemberStateStopped).WithFaultDomain(fds[3]),
 				},
 			},
 		},

--- a/src/control/lib/control/system_test.go
+++ b/src/control/lib/control/system_test.go
@@ -8,7 +8,6 @@ package control
 
 import (
 	"context"
-	"net"
 	"testing"
 	"time"
 
@@ -547,14 +546,6 @@ func TestControl_SystemQuery(t *testing.T) {
 		fds[i] = system.MustCreateFaultDomainFromString(fdStrs[i])
 	}
 
-	mustNewMember := func(t *testing.T, r system.Rank, uuidStr, uri string, a *net.TCPAddr, s system.MemberState) *system.Member {
-		m, err := system.NewMember(r, uuidStr, uri, a, s)
-		if err != nil {
-			t.Fatal(err)
-		}
-		return m
-	}
-
 	for name, tc := range map[string]struct {
 		req     *SystemQueryReq
 		uErr    error
@@ -630,10 +621,18 @@ func TestControl_SystemQuery(t *testing.T) {
 			),
 			expResp: &SystemQueryResp{
 				Members: system.Members{
-					mustNewMember(t, 1, test.MockUUID(1), "", test.MockHostAddr(1), system.MemberStateReady).WithFaultDomain(fds[1]),
-					mustNewMember(t, 2, test.MockUUID(2), "", test.MockHostAddr(1), system.MemberStateReady).WithFaultDomain(fds[2]),
-					mustNewMember(t, 0, test.MockUUID(0), "", test.MockHostAddr(2), system.MemberStateStopped).WithFaultDomain(fds[0]),
-					mustNewMember(t, 3, test.MockUUID(3), "", test.MockHostAddr(2), system.MemberStateStopped).WithFaultDomain(fds[3]),
+					system.MockMemberFullSpec(t, 1, test.MockUUID(1), "",
+						test.MockHostAddr(1), system.MemberStateReady).
+						WithFaultDomain(fds[1]),
+					system.MockMemberFullSpec(t, 2, test.MockUUID(2), "",
+						test.MockHostAddr(1), system.MemberStateReady).
+						WithFaultDomain(fds[2]),
+					system.MockMemberFullSpec(t, 0, test.MockUUID(0), "",
+						test.MockHostAddr(2), system.MemberStateStopped).
+						WithFaultDomain(fds[0]),
+					system.MockMemberFullSpec(t, 3, test.MockUUID(3), "",
+						test.MockHostAddr(2), system.MemberStateStopped).
+						WithFaultDomain(fds[3]),
 				},
 			},
 		},

--- a/src/control/server/mgmt_system.go
+++ b/src/control/server/mgmt_system.go
@@ -33,6 +33,7 @@ import (
 	"github.com/daos-stack/daos/src/control/lib/control"
 	"github.com/daos-stack/daos/src/control/lib/daos"
 	"github.com/daos-stack/daos/src/control/lib/hostlist"
+	"github.com/daos-stack/daos/src/control/logging"
 	"github.com/daos-stack/daos/src/control/system"
 )
 
@@ -498,6 +499,49 @@ func (svc *mgmtSvc) resolveRanks(hosts, ranks string) (hitRS, missRS *system.Ran
 	return
 }
 
+// synthesise "Stopped" rank results for any harness host errors
+func addUnresponsiveResults(log logging.Logger, hostRanks map[string][]system.Rank, rr *control.RanksResp, resp *fanoutResponse) {
+	for _, hes := range rr.HostErrors {
+		for _, addr := range strings.Split(hes.HostSet.DerangedString(), ",") {
+			for _, rank := range hostRanks[addr] {
+				resp.Results = append(resp.Results,
+					&system.MemberResult{
+						Rank: rank, Msg: hes.HostError.Error(),
+						State: system.MemberStateUnresponsive,
+					})
+			}
+			log.Debugf("harness %s (ranks %v) host error: %s", addr, hostRanks[addr],
+				hes.HostError)
+		}
+	}
+}
+
+// Remove any duplicate results from response.
+func removeDuplicateResults(log logging.Logger, resp *fanoutResponse) {
+	seenResults := make(map[uint32]*system.MemberResult)
+	for _, res := range resp.Results {
+		if res == nil {
+			continue
+		}
+		rID := res.Rank.Uint32()
+		if extant, existing := seenResults[rID]; !existing {
+			seenResults[rID] = res
+		} else if *extant != *res {
+			log.Errorf("nonidentical result for same rank: %+v != %+v", *extant, *res)
+		}
+	}
+
+	if len(seenResults) == len(resp.Results) {
+		return
+	}
+
+	newResults := make(system.MemberResults, 0, len(seenResults))
+	for _, res := range seenResults {
+		newResults = append(newResults, res)
+	}
+	resp.Results = newResults
+}
+
 // rpcFanout sends requests to ranks in list on their respective host
 // addresses through functions implementing UnaryInvoker.
 //
@@ -549,7 +593,7 @@ func (svc *mgmtSvc) rpcFanout(ctx context.Context, req *fanoutRequest, resp *fan
 	// Not strictly necessary but helps with debugging.
 	dl, ok := ctx.Deadline()
 	if ok {
-		ranksReq.SetTimeout(dl.Sub(time.Now()))
+		ranksReq.SetTimeout(time.Until(dl))
 	}
 
 	ranksReq.SetHostList(svc.membership.HostList(req.Ranks))
@@ -560,21 +604,9 @@ func (svc *mgmtSvc) rpcFanout(ctx context.Context, req *fanoutRequest, resp *fan
 
 	resp.Results = ranksResp.RankResults
 
-	// synthesise "Stopped" rank results for any harness host errors
-	hostRanks := svc.membership.HostRanks(req.Ranks)
-	for _, hes := range ranksResp.HostErrors {
-		for _, addr := range strings.Split(hes.HostSet.DerangedString(), ",") {
-			for _, rank := range hostRanks[addr] {
-				resp.Results = append(resp.Results,
-					&system.MemberResult{
-						Rank: rank, Msg: hes.HostError.Error(),
-						State: system.MemberStateUnresponsive,
-					})
-			}
-			svc.log.Debugf("harness %s (ranks %v) host error: %s",
-				addr, hostRanks[addr], hes.HostError)
-		}
-	}
+	addUnresponsiveResults(svc.log, svc.membership.HostRanks(req.Ranks), ranksResp, resp)
+
+	removeDuplicateResults(svc.log, resp)
 
 	if len(resp.Results) != req.Ranks.Count() {
 		svc.log.Debugf("expected %d results, got %d",

--- a/src/control/server/mgmt_system.go
+++ b/src/control/server/mgmt_system.go
@@ -526,7 +526,7 @@ func removeDuplicateResults(log logging.Logger, resp *fanoutResponse) {
 		rID := res.Rank.Uint32()
 		if extant, existing := seenResults[rID]; !existing {
 			seenResults[rID] = res
-		} else if !res.Equals(res) {
+		} else if !extant.Equals(res) {
 			log.Errorf("nonidentical result for same rank: %+v != %+v", *extant, *res)
 		}
 	}

--- a/src/control/server/mgmt_system.go
+++ b/src/control/server/mgmt_system.go
@@ -526,7 +526,7 @@ func removeDuplicateResults(log logging.Logger, resp *fanoutResponse) {
 		rID := res.Rank.Uint32()
 		if extant, existing := seenResults[rID]; !existing {
 			seenResults[rID] = res
-		} else if *extant != *res {
+		} else if !res.Equals(res) {
 			log.Errorf("nonidentical result for same rank: %+v != %+v", *extant, *res)
 		}
 	}

--- a/src/control/server/mgmt_system_test.go
+++ b/src/control/server/mgmt_system_test.go
@@ -450,11 +450,7 @@ func mockMember(t *testing.T, r, a int32, s string) *system.Member {
 	}
 	uri := fmt.Sprintf("tcp://%s", addr)
 
-	m, err := system.NewMember(system.Rank(r), test.MockUUID(r), uri, addr, state)
-	if err != nil {
-		t.Fatal(err)
-	}
-
+	m := system.MockMemberFullSpec(t, system.Rank(r), test.MockUUID(r), uri, addr, state)
 	m.FabricContexts = uint32(r)
 	m.FaultDomain = fd
 	m.Incarnation = uint64(r)

--- a/src/control/server/mgmt_system_test.go
+++ b/src/control/server/mgmt_system_test.go
@@ -450,7 +450,11 @@ func mockMember(t *testing.T, r, a int32, s string) *system.Member {
 	}
 	uri := fmt.Sprintf("tcp://%s", addr)
 
-	m := system.NewMember(system.Rank(r), test.MockUUID(r), uri, addr, state).WithFaultDomain(fd)
+	m, err := system.NewMember(system.Rank(r), test.MockUUID(r), uri, addr, state)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	m.FabricContexts = uint32(r)
 	m.FaultDomain = fd
 	m.Incarnation = uint64(r)
@@ -468,7 +472,6 @@ func checkMembers(t *testing.T, exp system.Members, ms *system.Membership) {
 			t.Fatal(err)
 		}
 		cmpOpts := append(test.DefaultCmpOpts(),
-			cmpopts.IgnoreUnexported(system.Member{}),
 			cmpopts.EquateApproxTime(time.Second),
 		)
 		if diff := cmp.Diff(em, am, cmpOpts...); diff != "" {
@@ -482,8 +485,6 @@ func checkMemberResults(t *testing.T, exp, got system.MemberResults) {
 
 	less := func(x, y *system.MemberResult) bool { return x.Rank < y.Rank }
 	cmpOpts := append(test.DefaultCmpOpts(),
-		cmpopts.IgnoreUnexported(system.MemberResult{}),
-		cmpopts.EquateApproxTime(time.Second),
 		cmpopts.SortSlices(less),
 	)
 	if diff := cmp.Diff(exp, got, cmpOpts...); diff != "" {

--- a/src/control/server/mgmt_system_test.go
+++ b/src/control/server/mgmt_system_test.go
@@ -461,27 +461,45 @@ func mockMember(t *testing.T, r, a int32, s string) *system.Member {
 func checkMembers(t *testing.T, exp system.Members, ms *system.Membership) {
 	t.Helper()
 
-	test.AssertEqual(t, len(exp), len(ms.Members(nil)),
-		"unexpected number of members")
+	test.AssertEqual(t, len(exp), len(ms.Members(nil)), "unexpected number of members")
 	for _, em := range exp {
 		am, err := ms.Get(em.Rank)
 		if err != nil {
 			t.Fatal(err)
 		}
-
-		// state is not exported so compare using access method
-		if diff := cmp.Diff(em.State, am.State); diff != "" {
-			t.Fatalf("unexpected member state for rank %d (-want, +got)\n%s\n", em.Rank, diff)
-		}
-
-		cmpOpts := []cmp.Option{
+		cmpOpts := append(test.DefaultCmpOpts(),
 			cmpopts.IgnoreUnexported(system.Member{}),
 			cmpopts.EquateApproxTime(time.Second),
-		}
+		)
 		if diff := cmp.Diff(em, am, cmpOpts...); diff != "" {
 			t.Fatalf("unexpected members (-want, +got)\n%s\n", diff)
 		}
+	}
+}
 
+func checkMemberResults(t *testing.T, exp, got system.MemberResults) {
+	t.Helper()
+
+	less := func(x, y *system.MemberResult) bool { return x.Rank < y.Rank }
+	cmpOpts := append(test.DefaultCmpOpts(),
+		cmpopts.IgnoreUnexported(system.MemberResult{}),
+		cmpopts.EquateApproxTime(time.Second),
+		cmpopts.SortSlices(less),
+	)
+	if diff := cmp.Diff(exp, got, cmpOpts...); diff != "" {
+		t.Fatalf("unexpected member results (-want, +got)\n%s\n", diff)
+	}
+}
+
+func checkRankResults(t *testing.T, exp, got []*sharedpb.RankResult) {
+	t.Helper()
+
+	less := func(x, y *sharedpb.RankResult) bool { return x.Rank < y.Rank }
+	cmpOpts := append(test.DefaultCmpOpts(),
+		cmpopts.SortSlices(less),
+	)
+	if diff := cmp.Diff(exp, got, cmpOpts...); diff != "" {
+		t.Fatalf("unexpected rank results (-want, +got)\n%s\n", diff)
 	}
 }
 
@@ -859,6 +877,84 @@ func TestServer_MgmtSvc_rpcFanout(t *testing.T) {
 			expRanks:       "0-5",
 			expAbsentHosts: "10.0.0.5",
 		},
+		// Test case relates to DAOS-10660. Ranks 0 & 3 joined via different interfaces but
+		// reside on the same host so a duplicate set of stop results is received.
+		"filtered ranks; duplicate rank results": {
+			sysReq: &mgmtpb.SystemStopReq{Ranks: "0-3"},
+			members: system.Members{
+				mockMember(t, 0, 1, "joined"),
+				mockMember(t, 1, 3, "joined"),
+				mockMember(t, 2, 3, "joined"),
+				mockMember(t, 3, 2, "joined"),
+				mockMember(t, 4, 4, "joined"),
+				mockMember(t, 5, 4, "joined"),
+				mockMember(t, 6, 5, "joined"),
+				mockMember(t, 7, 5, "joined"),
+			},
+			mResps: []*control.HostResponse{
+				{
+					Addr: test.MockHostAddr(1).String(),
+					Message: &mgmtpb.SystemStopResp{
+						Results: []*sharedpb.RankResult{
+							{Rank: 0, State: stateString(system.MemberStateStopped)},
+							{Rank: 3, State: stateString(system.MemberStateStopped)},
+						},
+					},
+				},
+				{
+					Addr: test.MockHostAddr(2).String(),
+					Message: &mgmtpb.SystemStopResp{
+						Results: []*sharedpb.RankResult{
+							{Rank: 0, State: stateString(system.MemberStateStopped)},
+							{Rank: 3, State: stateString(system.MemberStateStopped)},
+						},
+					},
+				},
+				{
+					Addr: test.MockHostAddr(3).String(),
+					Message: &mgmtpb.SystemStopResp{
+						Results: []*sharedpb.RankResult{
+							{Rank: 1, State: stateString(system.MemberStateStopped)},
+							{Rank: 2, State: stateString(system.MemberStateStopped)},
+						},
+					},
+				},
+			},
+			expFanReq: &fanoutRequest{
+				Method: control.StopRanks,
+				Ranks:  system.MustCreateRankSet("0-3"),
+			},
+			// Verifies de-duplication of rank results.
+			expResults: system.MemberResults{
+				{
+					Rank: 0, Addr: test.MockHostAddr(1).String(),
+					State: system.MemberStateStopped,
+				},
+				{
+					Rank: 1, Addr: test.MockHostAddr(3).String(),
+					State: system.MemberStateStopped,
+				},
+				{
+					Rank: 2, Addr: test.MockHostAddr(3).String(),
+					State: system.MemberStateStopped,
+				},
+				{
+					Rank: 3, Addr: test.MockHostAddr(2).String(),
+					State: system.MemberStateStopped,
+				},
+			},
+			expMembers: system.Members{
+				mockMember(t, 0, 1, "stopped"),
+				mockMember(t, 1, 3, "stopped"),
+				mockMember(t, 2, 3, "stopped"),
+				mockMember(t, 3, 2, "stopped"),
+				mockMember(t, 4, 4, "joined"),
+				mockMember(t, 5, 4, "joined"),
+				mockMember(t, 6, 5, "joined"),
+				mockMember(t, 7, 5, "joined"),
+			},
+			expRanks: "0-3",
+		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			log, buf := logging.NewTestLogger(t.Name())
@@ -880,6 +976,8 @@ func TestServer_MgmtSvc_rpcFanout(t *testing.T) {
 			switch tc.sysReq.(type) {
 			case *mgmtpb.SystemStartReq:
 				gotFanReq.Method = control.StartRanks
+			case *mgmtpb.SystemStopReq:
+				gotFanReq.Method = control.StopRanks
 			default:
 				gotFanReq.Method = control.PingRanks
 			}
@@ -911,14 +1009,7 @@ func TestServer_MgmtSvc_rpcFanout(t *testing.T) {
 				return
 			}
 
-			cmpOpts = []cmp.Option{
-				cmpopts.IgnoreUnexported(system.MemberResult{}, system.Member{}),
-				cmpopts.EquateApproxTime(time.Second),
-			}
-			if diff := cmp.Diff(tc.expResults, gotResp.Results, cmpOpts...); diff != "" {
-				t.Logf("unexpected results (-want, +got)\n%s\n", diff) // prints on err
-			}
-			test.AssertEqual(t, tc.expResults, gotResp.Results, name)
+			checkMemberResults(t, tc.expResults, gotResp.Results)
 			checkMembers(t, tc.expMembers, svc.membership)
 			if diff := cmp.Diff(tc.expRanks, gotRankSet.String(), test.DefaultCmpOpts()...); diff != "" {
 				t.Fatalf("unexpected ranks (-want, +got)\n%s\n", diff) // prints on err
@@ -1281,13 +1372,7 @@ func TestServer_MgmtSvc_SystemStart(t *testing.T) {
 				return
 			}
 
-			cmpOpts := append(test.DefaultCmpOpts(),
-				protocmp.IgnoreFields(&mgmtpb.SystemMember{}, "last_update"),
-			)
-			if diff := cmp.Diff(tc.expResults, gotResp.Results, cmpOpts...); diff != "" {
-				t.Logf("unexpected results (-want, +got)\n%s\n", diff) // prints on err
-			}
-			test.AssertEqual(t, tc.expResults, gotResp.Results, name)
+			checkRankResults(t, tc.expResults, gotResp.Results)
 			checkMembers(t, tc.expMembers, svc.membership)
 			test.AssertEqual(t, tc.expAbsentHosts, gotResp.Absenthosts, "absent hosts")
 			test.AssertEqual(t, tc.expAbsentRanks, gotResp.Absentranks, "absent ranks")
@@ -1476,13 +1561,7 @@ func TestServer_MgmtSvc_SystemStop(t *testing.T) {
 				return
 			}
 
-			cmpOpts := append(test.DefaultCmpOpts(),
-				protocmp.IgnoreFields(&mgmtpb.SystemMember{}, "last_update"),
-			)
-			if diff := cmp.Diff(tc.expResults, gotResp.Results, cmpOpts...); diff != "" {
-				t.Logf("unexpected results (-want, +got)\n%s\n", diff) // prints on err
-			}
-			test.AssertEqual(t, tc.expResults, gotResp.Results, name)
+			checkRankResults(t, tc.expResults, gotResp.Results)
 			checkMembers(t, tc.expMembers, svc.membership)
 			test.AssertEqual(t, tc.expAbsentHosts, gotResp.Absenthosts, "absent hosts")
 			test.AssertEqual(t, tc.expAbsentRanks, gotResp.Absentranks, "absent ranks")
@@ -1609,13 +1688,7 @@ func TestServer_MgmtSvc_SystemErase(t *testing.T) {
 				return
 			}
 
-			cmpOpts := append(test.DefaultCmpOpts(),
-				protocmp.IgnoreFields(&mgmtpb.SystemMember{}, "last_update"),
-			)
-			if diff := cmp.Diff(tc.expResults, gotResp.Results, cmpOpts...); diff != "" {
-				t.Logf("unexpected results (-want, +got)\n%s\n", diff) // prints on err
-			}
-			test.AssertEqual(t, tc.expResults, gotResp.Results, name)
+			checkRankResults(t, tc.expResults, gotResp.Results)
 			checkMembers(t, tc.expMembers, svc.membership)
 		})
 	}

--- a/src/control/system/member.go
+++ b/src/control/system/member.go
@@ -249,13 +249,21 @@ func (sm *Member) WithFaultDomain(fd *FaultDomain) *Member {
 }
 
 // NewMember returns a reference to a new member struct.
-func NewMember(rank Rank, uuidStr, uri string, addr *net.TCPAddr, state MemberState) *Member {
-	// FIXME: Either require a valid uuid.UUID to be supplied
-	// or else change the return signature to include an error
-	newUUID := uuid.MustParse(uuidStr)
-	return &Member{Rank: rank, UUID: newUUID, FabricURI: uri, Addr: addr,
-		State: state, FaultDomain: MustCreateFaultDomain(),
-		LastUpdate: time.Now()}
+func NewMember(rank Rank, uuidStr, uri string, addr *net.TCPAddr, state MemberState) (*Member, error) {
+	newUUID, err := uuid.Parse(uuidStr)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Member{
+		Rank:        rank,
+		UUID:        newUUID,
+		FabricURI:   uri,
+		Addr:        addr,
+		State:       state,
+		FaultDomain: MustCreateFaultDomain(),
+		LastUpdate:  time.Now(),
+	}, nil
 }
 
 // Members is a type alias for a slice of member references
@@ -308,6 +316,17 @@ func (mr *MemberResult) UnmarshalJSON(data []byte) error {
 	mr.State = memberStateFromString(from.State)
 
 	return nil
+}
+
+// Equals returns true if dereferenced structs share the same field values.
+func (mr *MemberResult) Equals(other *MemberResult) bool {
+	if mr == nil {
+		return false
+	}
+	if other == nil {
+		return false
+	}
+	return *mr == *other
 }
 
 // NewMemberResult returns a reference to a new member result struct.

--- a/src/control/system/member.go
+++ b/src/control/system/member.go
@@ -248,24 +248,6 @@ func (sm *Member) WithFaultDomain(fd *FaultDomain) *Member {
 	return sm
 }
 
-// NewMember returns a reference to a new member struct.
-func NewMember(rank Rank, uuidStr, uri string, addr *net.TCPAddr, state MemberState) (*Member, error) {
-	newUUID, err := uuid.Parse(uuidStr)
-	if err != nil {
-		return nil, err
-	}
-
-	return &Member{
-		Rank:        rank,
-		UUID:        newUUID,
-		FabricURI:   uri,
-		Addr:        addr,
-		State:       state,
-		FaultDomain: MustCreateFaultDomain(),
-		LastUpdate:  time.Now(),
-	}, nil
-}
-
 // Members is a type alias for a slice of member references
 type Members []*Member
 

--- a/src/control/system/membership_test.go
+++ b/src/control/system/membership_test.go
@@ -56,11 +56,7 @@ func mockStoppedRankOnHost1(t *testing.T, rID int32) *Member {
 	if err != nil {
 		t.Fatal(err)
 	}
-	m, err := NewMember(Rank(rID), MockUUID(rID), "", addr1, MemberStateStopped)
-	if err != nil {
-		t.Fatal(err)
-	}
-	return m
+	return MockMemberFullSpec(t, Rank(rID), MockUUID(rID), "", addr1, MemberStateStopped)
 }
 
 func TestSystem_Membership_Get(t *testing.T) {

--- a/src/control/system/membership_test.go
+++ b/src/control/system/membership_test.go
@@ -51,6 +51,18 @@ func populateMembership(t *testing.T, log logging.Logger, members ...*Member) *M
 	return ms
 }
 
+func mockStoppedRankOnHost1(t *testing.T, rID int32) *Member {
+	addr1, err := net.ResolveTCPAddr("tcp", "127.0.0.1:10001")
+	if err != nil {
+		t.Fatal(err)
+	}
+	m, err := NewMember(Rank(rID), MockUUID(rID), "", addr1, MemberStateStopped)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return m
+}
+
 func TestSystem_Membership_Get(t *testing.T) {
 	for name, tc := range map[string]struct {
 		memberToAdd *Member
@@ -244,15 +256,11 @@ func TestSystem_Membership_Add(t *testing.T) {
 }
 
 func TestSystem_Membership_HostRanks(t *testing.T) {
-	addr1, err := net.ResolveTCPAddr("tcp", "127.0.0.1:10001")
-	if err != nil {
-		t.Fatal(err)
-	}
 	members := Members{
 		MockMember(t, 1, MemberStateJoined),
 		MockMember(t, 2, MemberStateStopped),
 		MockMember(t, 3, MemberStateExcluded),
-		NewMember(Rank(4), MockUUID(4), addr1.String(), addr1, MemberStateStopped), // second host rank
+		mockStoppedRankOnHost1(t, 4),
 	}
 
 	for name, tc := range map[string]struct {
@@ -335,16 +343,12 @@ func TestSystem_Membership_HostRanks(t *testing.T) {
 }
 
 func TestSystem_Membership_CheckRanklist(t *testing.T) {
-	addr1, err := net.ResolveTCPAddr("tcp", "127.0.0.1:10001")
-	if err != nil {
-		t.Fatal(err)
-	}
 	members := Members{
 		MockMember(t, 0, MemberStateJoined),
 		MockMember(t, 1, MemberStateJoined),
 		MockMember(t, 2, MemberStateStopped),
 		MockMember(t, 3, MemberStateExcluded),
-		NewMember(Rank(4), MockUUID(4), "", addr1, MemberStateStopped), // second host rank
+		mockStoppedRankOnHost1(t, 4),
 	}
 
 	for name, tc := range map[string]struct {
@@ -424,17 +428,13 @@ func mockResolveFn(netString string, address string) (*net.TCPAddr, error) {
 }
 
 func TestSystem_Membership_CheckHostlist(t *testing.T) {
-	addr1, err := net.ResolveTCPAddr("tcp", "127.0.0.1:10001")
-	if err != nil {
-		t.Fatal(err)
-	}
 	members := Members{
 		MockMember(t, 1, MemberStateJoined),
 		MockMember(t, 2, MemberStateStopped),
 		MockMember(t, 3, MemberStateExcluded),
 		MockMember(t, 4, MemberStateJoined),
 		MockMember(t, 5, MemberStateJoined),
-		NewMember(Rank(6), MockUUID(6), "", addr1, MemberStateStopped), // second host rank
+		mockStoppedRankOnHost1(t, 6),
 	}
 
 	for name, tc := range map[string]struct {

--- a/src/control/system/mocks.go
+++ b/src/control/system/mocks.go
@@ -10,32 +10,57 @@ import (
 	"fmt"
 	"net"
 	"testing"
+	"time"
+
+	"github.com/google/uuid"
 
 	"github.com/daos-stack/daos/src/control/common/test"
 	"github.com/daos-stack/daos/src/control/logging"
 )
 
 func MockControlAddr(t *testing.T, idx uint32) *net.TCPAddr {
+	t.Helper()
+
 	addr, err := net.ResolveTCPAddr("tcp",
 		fmt.Sprintf("127.0.0.%d:10001", idx))
 	if err != nil {
 		t.Fatal(err)
 	}
+
 	return addr
+}
+
+// MockMemberFullSpec returns a reference to a new member struct.
+func MockMemberFullSpec(t *testing.T, rank Rank, uuidStr, uri string, addr *net.TCPAddr, state MemberState) *Member {
+	t.Helper()
+
+	newUUID, err := uuid.Parse(uuidStr)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return &Member{
+		Rank:        rank,
+		UUID:        newUUID,
+		FabricURI:   uri,
+		Addr:        addr,
+		State:       state,
+		FaultDomain: MustCreateFaultDomain(),
+		LastUpdate:  time.Now(),
+	}
 }
 
 // MockMember returns a system member with appropriate values.
 func MockMember(t *testing.T, idx uint32, state MemberState, info ...string) *Member {
+	t.Helper()
+
 	addr := MockControlAddr(t, idx)
-	m, err := NewMember(Rank(idx), test.MockUUID(int32(idx)),
-		addr.String(), addr, state)
-	if err != nil {
-		t.Fatal(err)
-	}
+	m := MockMemberFullSpec(t, Rank(idx), test.MockUUID(int32(idx)), addr.String(), addr, state)
 	m.FabricContexts = idx
 	if len(info) > 0 {
 		m.Info = info[0]
 	}
+
 	return m
 }
 
@@ -49,6 +74,8 @@ func MockMemberResult(rank Rank, action string, err error, state MemberState) *M
 
 // MockMembership returns an initialized *Membership using the given MemberStore.
 func MockMembership(t *testing.T, log logging.Logger, mdb MemberStore, resolver TCPResolver) *Membership {
+	t.Helper()
+
 	m := NewMembership(log, mdb)
 
 	if resolver != nil {

--- a/src/control/system/mocks.go
+++ b/src/control/system/mocks.go
@@ -27,8 +27,11 @@ func MockControlAddr(t *testing.T, idx uint32) *net.TCPAddr {
 // MockMember returns a system member with appropriate values.
 func MockMember(t *testing.T, idx uint32, state MemberState, info ...string) *Member {
 	addr := MockControlAddr(t, idx)
-	m := NewMember(Rank(idx), test.MockUUID(int32(idx)),
+	m, err := NewMember(Rank(idx), test.MockUUID(int32(idx)),
 		addr.String(), addr, state)
+	if err != nil {
+		t.Fatal(err)
+	}
 	m.FabricContexts = idx
 	if len(info) > 0 {
 		m.Info = info[0]

--- a/src/control/system/raft/database_test.go
+++ b/src/control/system/raft/database_test.go
@@ -570,15 +570,6 @@ func TestSystem_Database_memberRaftOps(t *testing.T) {
 	}
 }
 
-func testMemberWithFaultDomain(t *testing.T, rank Rank, fd *FaultDomain) *Member {
-	m, err := NewMember(rank, uuid.New().String(), "dontcare", &net.TCPAddr{},
-		MemberStateJoined)
-	if err != nil {
-		t.Fatal(err)
-	}
-	return m.WithFaultDomain(fd)
-}
-
 func TestSystem_Database_memberFaultDomain(t *testing.T) {
 	for name, tc := range map[string]struct {
 		rank        Rank
@@ -600,8 +591,8 @@ func TestSystem_Database_memberFaultDomain(t *testing.T) {
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			m := testMemberWithFaultDomain(t, tc.rank, tc.faultDomain)
-
+			m := MockMemberFullSpec(t, tc.rank, uuid.New().String(), "dontcare", &net.TCPAddr{},
+				MemberStateJoined).WithFaultDomain(tc.faultDomain)
 			result := MemberFaultDomain(m)
 
 			if diff := cmp.Diff(tc.expResult, result); diff != "" {
@@ -882,10 +873,8 @@ func TestSystem_Database_GroupMap(t *testing.T) {
 
 		return members
 	}
-	memberWithNoURI, err := NewMember(2, test.MockUUID(2), "", MockControlAddr(t, 2), MemberStateJoined)
-	if err != nil {
-		t.Fatal(err)
-	}
+	memberWithNoURI := MockMemberFullSpec(t, 2, test.MockUUID(2), "", MockControlAddr(t, 2),
+		MemberStateJoined)
 
 	for name, tc := range map[string]struct {
 		members     []*Member


### PR DESCRIPTION
There are situations where multiple results for the same rank maybe
received after a distributed system fanout request e.g. during
dmg system stop command execution.

Work-around this issue by removing duplicate results for a single rank
after the fanout results have been collected. Log an error if the
duplicate results do not have identical content.

Features: control

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>