### PR TITLE
DAOS-10677 test: Backport for #9173 to suppress MPI leak

### DIFF
--- a/utils/test_memcheck.supp
+++ b/utils/test_memcheck.supp
@@ -97,6 +97,16 @@
    fun:na_ofi_check_protocol
 }
 {
+   OpenMPI initialize leaks memalign
+   Memcheck:Leak
+   match-leak-kinds: all
+   ...
+   fun:memalign
+   ...
+   fun:ompi_mpi_init
+   ...
+}
+{
    OpenMPI initialize leaks
    Memcheck:Leak
    match-leak-kinds: all


### PR DESCRIPTION
This isn't really a backport because master branch has diverged to use
libdpar.so to wrap MPI calls whereas 2.2 and 2.0 have not.  So rather
this is an equivalent suppression for 2.2.

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>