### PR TITLE
DAOS-10603 control: Add disable_hugepages server config file parameter

### DIFF
--- a/src/control/cmd/dmg/auto_test.go
+++ b/src/control/cmd/dmg/auto_test.go
@@ -165,6 +165,7 @@ disable_vfio: false
 disable_vmd: false
 enable_hotplug: false
 nr_hugepages: 6144
+disable_hugepages: false
 control_log_mask: INFO
 control_log_file: /tmp/daos_server.log
 helper_log_file: ""

--- a/src/control/common/hugepages.go
+++ b/src/control/common/hugepages.go
@@ -105,7 +105,7 @@ func GetHugePageInfo() (*HugePageInfo, error) {
 // requested for the given number of targets.
 func CalcMinHugePages(hugePageSizeKb int, numTargets int) (int, error) {
 	if numTargets < 1 {
-		return 0, errors.New("numTargets must be >= 1")
+		return 0, errors.New("numTargets must be > 0")
 	}
 
 	hugepageSizeBytes := hugePageSizeKb << 10 // KiB to B

--- a/src/control/common/hugepages_test.go
+++ b/src/control/common/hugepages_test.go
@@ -112,7 +112,9 @@ func TestCommon_CalcMinHugePages(t *testing.T) {
 			expErr:     errors.New("invalid system hugepage size"),
 		},
 		"no targets": {
-			input:  &HugePageInfo{},
+			input: &HugePageInfo{
+				PageSizeKb: 2048,
+			},
 			expErr: errors.New("numTargets"),
 		},
 		"2KB pagesize; 16 targets": {

--- a/src/control/server/config/faults.go
+++ b/src/control/server/config/faults.go
@@ -8,7 +8,6 @@ package config
 
 import (
 	"fmt"
-	"math"
 
 	"github.com/daos-stack/daos/src/control/fault"
 	"github.com/daos-stack/daos/src/control/fault/code"
@@ -90,11 +89,6 @@ var (
 		code.ServerConfigFaultDomainTooManyLayers,
 		"only a single fault domain layer below the root is supported",
 		"update either the fault domain ('fault_path' parameter) or callback script ('fault_cb' parameter) and restart the control server",
-	)
-	FaultConfigNrHugepagesOutOfRange = serverConfigFault(
-		code.ServerConfigNrHugepagesOutOfRange,
-		"number of hugepages specified is out of range",
-		fmt.Sprintf("specify a nr_hugepages value between -1 and %d", math.MaxInt32),
 	)
 	FaultConfigHugepagesDisabled = serverConfigFault(
 		code.ServerConfigHugepagesDisabled,
@@ -199,6 +193,16 @@ func FaultConfigFaultCallbackInsecure(requiredDir string) *fault.Fault {
 		fmt.Sprintf("ensure that the 'fault_cb' path is under the parent directory %q, "+
 			"not a symbolic link, does not have the setuid bit set, and does not have "+
 			"write permissions for non-owners", requiredDir),
+	)
+}
+
+// FaultConfigNrHugepagesOutOfRange creates a fault for the scenario where the number of configured
+// huge pages is smaller than zero or larger than the maximum value allowed.
+func FaultConfigNrHugepagesOutOfRange(req, max int) *fault.Fault {
+	return serverConfigFault(
+		code.ServerConfigNrHugepagesOutOfRange,
+		fmt.Sprintf("number of hugepages specified (%d) is out of range (0 - %d)", req, max),
+		fmt.Sprintf("specify a nr_hugepages value between 0 and %d", max),
 	)
 }
 

--- a/src/control/server/config/server.go
+++ b/src/control/server/config/server.go
@@ -49,6 +49,7 @@ type Server struct {
 	DisableVMD          bool                   `yaml:"disable_vmd"`
 	EnableHotplug       bool                   `yaml:"enable_hotplug"`
 	NrHugepages         int                    `yaml:"nr_hugepages"` // total for all engines
+	DisableHugepages    bool                   `yaml:"disable_hugepages"`
 	ControlLogMask      common.ControlLogLevel `yaml:"control_log_mask"`
 	ControlLogFile      string                 `yaml:"control_log_file"`
 	ControlLogJSON      bool                   `yaml:"control_log_json,omitempty"`
@@ -224,26 +225,32 @@ func (cfg *Server) WithDisableVFIO(disabled bool) *Server {
 
 // WithDisableVMD can be used to set the state of VMD functionality,
 // if disabled then VMD devices will not be used if they exist.
-func (cfg *Server) WithDisableVMD(disable bool) *Server {
-	cfg.DisableVMD = disable
+func (cfg *Server) WithDisableVMD(disabled bool) *Server {
+	cfg.DisableVMD = disabled
 	return cfg
 }
 
 // WithEnableHotplug can be used to enable hotplug
-func (cfg *Server) WithEnableHotplug(enable bool) *Server {
-	cfg.EnableHotplug = enable
+func (cfg *Server) WithEnableHotplug(enabled bool) *Server {
+	cfg.EnableHotplug = enabled
 	return cfg
 }
 
 // WithHyperthreads enables or disables hyperthread support.
-func (cfg *Server) WithHyperthreads(enable bool) *Server {
-	cfg.Hyperthreads = enable
+func (cfg *Server) WithHyperthreads(enabled bool) *Server {
+	cfg.Hyperthreads = enabled
 	return cfg
 }
 
 // WithNrHugePages sets the number of huge pages to be used (total for all engines).
 func (cfg *Server) WithNrHugePages(nr int) *Server {
 	cfg.NrHugepages = nr
+	return cfg
+}
+
+// WithDisableHugePages disables the use of huge pages.
+func (cfg *Server) WithDisableHugePages(disabled bool) *Server {
+	cfg.DisableHugepages = disabled
 	return cfg
 }
 
@@ -527,12 +534,12 @@ func (cfg *Server) Validate(log logging.Logger, hugePageSize int) (err error) {
 			ec.Fabric.NumaNodeIndex, ec.Storage.NumaNodeIndex)
 	}
 
-	if cfg.NrHugepages < -1 || cfg.NrHugepages > math.MaxInt32 {
-		return FaultConfigNrHugepagesOutOfRange
+	if cfg.NrHugepages < 0 || cfg.NrHugepages > math.MaxInt32 {
+		return FaultConfigNrHugepagesOutOfRange(cfg.NrHugepages, math.MaxInt32)
 	}
 
 	if cfgHasBdevs {
-		if cfg.NrHugepages == -1 {
+		if cfg.DisableHugepages {
 			return FaultConfigHugepagesDisabled
 		}
 

--- a/src/control/server/config/server_test.go
+++ b/src/control/server/config/server_test.go
@@ -448,7 +448,6 @@ func TestServerConfig_Validation(t *testing.T) {
 				// add multiple bdevs for engine 0 to create mismatch
 				c.Engines[0].Storage.Tiers.BdevConfigs()[0].
 					WithBdevDeviceList("0000:10:00.0", "0000:11:00.0", "0000:12:00.0")
-
 				return c
 			},
 			expErr: FaultConfigBdevCountMismatch(1, 2, 0, 3),
@@ -457,7 +456,6 @@ func TestServerConfig_Validation(t *testing.T) {
 			extraConfig: func(c *Server) *Server {
 				// change engine 0 number of targets to create mismatch
 				c.Engines[0].WithTargetCount(1)
-
 				return c
 			},
 			expErr: FaultConfigTargetCountMismatch(1, 16, 0, 1),
@@ -466,7 +464,6 @@ func TestServerConfig_Validation(t *testing.T) {
 			extraConfig: func(c *Server) *Server {
 				// change engine 0 number of helper streams to create mismatch
 				c.Engines[0].WithHelperStreamCount(9)
-
 				return c
 			},
 			expErr: FaultConfigHelperStreamCountMismatch(1, 4, 0, 9),
@@ -475,17 +472,17 @@ func TestServerConfig_Validation(t *testing.T) {
 			extraConfig: func(c *Server) *Server {
 				return c.WithNrHugePages(-2048)
 			},
-			expErr: FaultConfigNrHugepagesOutOfRange,
+			expErr: FaultConfigNrHugepagesOutOfRange(-2048, math.MaxInt32),
 		},
 		"out of range hugepages; high": {
 			extraConfig: func(c *Server) *Server {
 				return c.WithNrHugePages(math.MaxInt32 + 1)
 			},
-			expErr: FaultConfigNrHugepagesOutOfRange,
+			expErr: FaultConfigNrHugepagesOutOfRange(math.MaxInt32+1, math.MaxInt32),
 		},
 		"disabled hugepages; bdevs configured": {
 			extraConfig: func(c *Server) *Server {
-				return c.WithNrHugePages(-1).
+				return c.WithDisableHugePages(true).
 					WithEngines(
 						engine.NewConfig().
 							WithStorage(
@@ -507,7 +504,7 @@ func TestServerConfig_Validation(t *testing.T) {
 		},
 		"disabled hugepages; emulated bdevs configured": {
 			extraConfig: func(c *Server) *Server {
-				return c.WithNrHugePages(-1).
+				return c.WithDisableHugePages(true).
 					WithEngines(
 						engine.NewConfig().
 							WithStorage(
@@ -530,7 +527,7 @@ func TestServerConfig_Validation(t *testing.T) {
 		},
 		"disabled hugepages; no bdevs configured": {
 			extraConfig: func(c *Server) *Server {
-				return c.WithNrHugePages(-1).
+				return c.WithDisableHugePages(true).
 					WithEngines(
 						engine.NewConfig().
 							WithStorage(
@@ -990,15 +987,34 @@ func TestServerConfig_Parsing(t *testing.T) {
 				if nr != 2 {
 					return errors.Errorf("want %d storage tiers, got %d", 2, nr)
 				}
-
 				want := storage.MustNewBdevBusRange("0x00-0x80")
 				got := c.Engines[0].Storage.Tiers.BdevConfigs()[0].Bdev.BusidRange
 				if want.String() != got.String() {
 					return errors.Errorf("want %s bus-id range, got %s", want, got)
 				}
-
 				return nil
 			},
+		},
+		"legacy storage; empty bdev_list; hugepages disabled": {
+			legacyStorage: true,
+			inTxt:         "telemetry_port: 9191",
+			outTxt:        "disable_hugepages: true",
+			expCheck: func(c *Server) error {
+				if !c.DisableHugepages {
+					return errors.Errorf("expected hugepages to be disabled")
+				}
+				return nil
+			},
+		},
+		"legacy storage; non-empty bdev_list; hugepages disabled": {
+			legacyStorage: true,
+			inTxtList: []string{
+				"    bdev_list: []", "telemetry_port: 9191",
+			},
+			outTxtList: []string{
+				"    bdev_list: [0000:80:00.0]", "disable_hugepages: true",
+			},
+			expValidateErr: FaultConfigHugepagesDisabled,
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
@@ -1033,7 +1049,7 @@ func TestServerConfig_Parsing(t *testing.T) {
 				return
 			}
 			config = tt.extraConfig(config)
-
+			fmt.Printf("XXX %s: %v\n", name, config.DisableHugepages)
 			CmpErr(t, tt.expValidateErr, config.Validate(log, defHugePageInfo.PageSizeKb))
 
 			if tt.expCheck != nil {

--- a/src/control/server/config/server_test.go
+++ b/src/control/server/config/server_test.go
@@ -1048,8 +1048,8 @@ func TestServerConfig_Parsing(t *testing.T) {
 			if tt.expParseErr != nil {
 				return
 			}
+
 			config = tt.extraConfig(config)
-			fmt.Printf("XXX %s: %v\n", name, config.DisableHugepages)
 			CmpErr(t, tt.expValidateErr, config.Validate(log, defHugePageInfo.PageSizeKb))
 
 			if tt.expCheck != nil {

--- a/src/control/server/server_utils.go
+++ b/src/control/server/server_utils.go
@@ -196,8 +196,8 @@ func prepBdevStorage(srv *server, iommuEnabled bool) error {
 				return FaultIommuDisabled
 			}
 		}
-	} else if srv.cfg.NrHugepages < 0 {
-		srv.log.Debugf("skip nvme prepare as no bdevs in cfg and nr_hugepages: -1 in config")
+	} else if srv.cfg.DisableHugepages {
+		srv.log.Debugf("skip nvme prepare as no bdevs in cfg and disable_hugepages: true in config")
 		return nil
 	}
 
@@ -265,7 +265,7 @@ func prepBdevStorage(srv *server, iommuEnabled bool) error {
 func scanBdevStorage(srv *server) (*storage.BdevScanResponse, error) {
 	defer srv.logDuration(track("time to scan bdev storage"))
 
-	if srv.cfg.NrHugepages < 0 {
+	if srv.cfg.DisableHugepages {
 		srv.log.Debugf("skip nvme scan as hugepages have been disabled in config")
 		return &storage.BdevScanResponse{}, nil
 	}

--- a/src/control/server/server_utils_test.go
+++ b/src/control/server/server_utils_test.go
@@ -306,9 +306,9 @@ func TestServer_prepBdevStorage(t *testing.T) {
 			expMemSize:      16384,
 			expHugePageSize: 2,
 		},
-		"no bdevs configured; -1 hugepages requested": {
+		"no bdevs configured; hugepages disabled": {
 			srvCfgExtra: func(sc *config.Server) *config.Server {
-				return sc.WithNrHugePages(-1).
+				return sc.WithDisableHugePages(true).
 					WithEngines(scmEngine(0), scmEngine(1))
 			},
 		},
@@ -588,9 +588,9 @@ func TestServer_prepBdevStorage(t *testing.T) {
 // also be covered.
 func TestServer_scanBdevStorage(t *testing.T) {
 	for name, tc := range map[string]struct {
-		nrHugepages int
-		bmbc        *bdev.MockBackendConfig
-		expErr      error
+		disableHugepages bool
+		bmbc             *bdev.MockBackendConfig
+		expErr           error
 	}{
 		"spdk fails init": {
 			bmbc: &bdev.MockBackendConfig{
@@ -612,7 +612,7 @@ func TestServer_scanBdevStorage(t *testing.T) {
 			},
 		},
 		"hugepages disabled": {
-			nrHugepages: -1,
+			disableHugepages: true,
 			bmbc: &bdev.MockBackendConfig{
 				ScanErr: errors.New("spdk failed"),
 			},
@@ -623,7 +623,7 @@ func TestServer_scanBdevStorage(t *testing.T) {
 			defer test.ShowBufferOnFailure(t, buf)
 
 			cfg := config.DefaultServer().WithFabricProvider("ofi+verbs").
-				WithNrHugePages(tc.nrHugepages)
+				WithDisableHugePages(tc.disableHugepages)
 
 			// test only with 2M hugepage size
 			if err := cfg.Validate(log, 2048); err != nil {

--- a/utils/config/daos_server.yml
+++ b/utils/config/daos_server.yml
@@ -200,11 +200,15 @@
 #
 ## Example: (2 engines * (16 targets/engine * 1GiB)) / 2MiB hugepage size = 16834
 #
-## Hugepages are mandatory with NVME SSDs configured and optional without.
-## To disabled the use of hugepages when no NVMe SSDs are configured, set
-## nr_hugepages to -1.
+## default: 0
+#nr_hugepages: 0
 #
-##nr_hugepages: -1
+## Hugepages are mandatory with NVME SSDs configured and optional without.
+## To disable the use of hugepages when no NVMe SSDs are configured, set
+## disable_hugepages to true.
+#
+## default: false
+#disable_hugepages: false
 #
 #
 ## Set specific debug mask for daos_server (control plane).

--- a/utils/config/examples/daos_server_unittests.yml
+++ b/utils/config/examples/daos_server_unittests.yml
@@ -6,7 +6,6 @@ access_points: ['example']  # management service leader (bootstrap)
 provider: ofi+tcp
 control_log_mask: DEBUG
 control_log_file: /tmp/daos_server.log
-
 telemetry_port: 9191
 
 ## Transport Credentials Specifying certificates to secure communications

--- a/utils/nlt_server.yaml
+++ b/utils/nlt_server.yaml
@@ -1,7 +1,7 @@
 name: daos_server
 port: 10001
 provider: ofi+tcp;ofi_rxm
-nr_hugepages: -1
+disable_hugepages: true
 control_log_mask: DEBUG
 access_points: ['localhost:10001']
 engines:


### PR DESCRIPTION
Replace setting nr_hugepages: -1 with an explicit disable_hugepages: true
directive to improve clarity of intent.

Features: control

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>