### PR TITLE
DAOS-623 build: Use nobest with mock

### DIFF
--- a/ci/provisioning/post_provision_config_common_functions.sh
+++ b/ci/provisioning/post_provision_config_common_functions.sh
@@ -311,7 +311,7 @@ post_provision_config_nodes() {
 
     # now make sure everything is fully up-to-date
     # shellcheck disable=SC2154
-    if ! RETRY_COUNT=4 retry_dnf 600 upgrade --exclude "$EXCLUDE_UPGRADE"; then
+    if ! RETRY_COUNT=4 retry_dnf 600 --setopt=best=0 upgrade --exclude "$EXCLUDE_UPGRADE"; then
         dump_repos
         return 1
     fi

--- a/utils/rpms/packaging/rpm_chrootbuild
+++ b/utils/rpms/packaging/rpm_chrootbuild
@@ -18,8 +18,20 @@ config_opts['module_setup_commands'] = [
   ('disable',  'go-toolset')
 ]
 EOF
-
 fi
+
+# Use dnf on CentOS 7
+if [[ $CHROOT_NAME == *epel-7-x86_64 ]]; then
+    MOCK_OPTIONS="--dnf --no-bootstrap-chroot${MOCK_OPTIONS:+ }$MOCK_OPTIONS"
+fi
+
+# Allow BR: foo-devel < 1.2 to work when foo-devel-1.3 is actually available
+cat <<EOF >> "$cfg_file"
+config_opts['dnf.conf'] += """
+[main]
+best=0
+"""
+EOF
 
 # shellcheck disable=SC2153
 repo_adds=()


### PR DESCRIPTION
To allow dnf builddep to install less-than-latest versions of packages
which have a BR: < $latest.