### PR TITLE
DAOS-10621 test: Fix weekly-testing timed builds

### DIFF
--- a/ci/provisioning/post_provision_config.sh
+++ b/ci/provisioning/post_provision_config.sh
@@ -48,7 +48,7 @@ if ! retry_cmd 2400 clush -B -S -l root -w "$NODESTRING" \
            REPO_FILE_URL=\"$REPO_FILE_URL\"
            ARTIFACTORY_URL=\"${ARTIFACTORY_URL:-}\"
            BRANCH_NAME=\"${BRANCH_NAME:-}\"
-           CHANGE_TARGET=\"${CHANGE_TARGET:-$BRANCH_NAME}\"
+           CHANGE_TARGET=\"${CHANGE_TARGET:-}\"
            $(cat ci/stacktrace.sh)
            $(cat ci/junit.sh)
            $(cat ci/provisioning/post_provision_config_common_functions.sh)

--- a/ci/provisioning/post_provision_config.sh
+++ b/ci/provisioning/post_provision_config.sh
@@ -48,7 +48,7 @@ if ! retry_cmd 2400 clush -B -S -l root -w "$NODESTRING" \
            REPO_FILE_URL=\"$REPO_FILE_URL\"
            ARTIFACTORY_URL=\"${ARTIFACTORY_URL:-}\"
            BRANCH_NAME=\"${BRANCH_NAME:-}\"
-           CHANGE_TARGET=\"${CHANGE_TARGET:-}\"
+           CHANGE_TARGET=\"${CHANGE_TARGET:-$BRANCH_NAME}\"
            $(cat ci/stacktrace.sh)
            $(cat ci/junit.sh)
            $(cat ci/provisioning/post_provision_config_common_functions.sh)

--- a/ci/provisioning/post_provision_config_common_functions.sh
+++ b/ci/provisioning/post_provision_config_common_functions.sh
@@ -193,7 +193,7 @@ set_local_repo() {
     version=${version%%.*}
     if [ "$repo_server" = "artifactory" ] &&
        [ -z "$(rpm_test_version)" ] &&
-       [[ $CHANGE_TARGET != weekly-testing* ]]; then
+       [[ ${CHANGE_TARGET:-$BRANCH_NAME} != weekly-testing* ]]; then
         # Disable the daos repo so that the Jenkins job repo or a PR-repos*: repo is
         # used for daos packages
         dnf -y config-manager \


### PR DESCRIPTION
Moving to using CHANGE_TARGET resolves the issue of running with the
correct daos RPMs in a weekly-testing* branch PR, but this variable is
not set during timed weekly-testing* builds.  Use the BRANCH_NAME
variable if the CHANGE_TARGET variable is not set to allow
weekly-testing* timed builds to install the correct doas RPMs.

Skip-unit-tests: true
Test-tag: always_passes

Signed-off-by: Phillip Henderson <phillip.henderson@intel.com>