### PR TITLE
DAOS-9736 NULL: Only for test

### DIFF
--- a/src/tests/ftest/erasurecode/rebuild_disabled_single.yaml
+++ b/src/tests/ftest/erasurecode/rebuild_disabled_single.yaml
@@ -18,7 +18,7 @@ hosts:
         - server-E
   test_clients:
     - client-A
-timeout: 400
+timeout: 420
 server_config:
   engines_per_host: 2
   name: daos_server


### PR DESCRIPTION
Quick-Functional: true
Skip-unit-tests: true
Skip-coverity-test: true
Skip-scan-centos-rpms: true
Skip-test-centos-rpms: true
Skip-fault-injection-test: true
RPM-test: false
Skip-python-bandit: true
Skip-func-test-el8: true
Skip-func-test-vm-valgrind-el8: true
Test-repeat: 20
Test-tag: ec_disabled_rebuild_single

Signed-off-by: Lei Huang <lei.huang@intel.com>