### PR TITLE
DAOS-10734 ftests: container.destroy() needs uuid parameter to test non-existing uuid

### DIFF
--- a/src/client/pydaos/raw/daos_api.py
+++ b/src/client/pydaos/raw/daos_api.py
@@ -1591,15 +1591,15 @@ class DaosContainer():
                                             self))
             thread.start()
 
-    def destroy(self, force=1, poh=None, cb_func=None):
+    def destroy(self, force=1, poh=None, uuid_str=None, cb_func=None):
         """Send a container destroy request to the daos server group."""
         # caller can override pool handle and uuid
         if poh is not None:
             self.poh = poh
         if self.uuid is None:
             raise DaosApiError("Fail to destroy a container with uuid as none.")
-        uuid_str = self.get_uuid_str()
-
+        if uuid_str is None:
+            uuid_str = self.get_uuid_str()
         c_force = ctypes.c_uint(force)
 
         func = self.context.get_function('destroy-cont')

--- a/src/client/pydaos/raw/daos_api.py
+++ b/src/client/pydaos/raw/daos_api.py
@@ -1591,15 +1591,17 @@ class DaosContainer():
                                             self))
             thread.start()
 
-    def destroy(self, force=1, poh=None, uuid_str=None, cb_func=None):
+    def destroy(self, force=1, poh=None, con_uuid=None, cb_func=None):
         """Send a container destroy request to the daos server group."""
         # caller can override pool handle and uuid
         if poh is not None:
             self.poh = poh
         if self.uuid is None:
             raise DaosApiError("Fail to destroy a container with uuid as none.")
-        if uuid_str is None:
+        if con_uuid is None:
             uuid_str = self.get_uuid_str()
+        else:
+            uuid_str = str(con_uuid)
         c_force = ctypes.c_uint(force)
 
         func = self.context.get_function('destroy-cont')

--- a/src/client/pydaos/raw/daos_api.py
+++ b/src/client/pydaos/raw/daos_api.py
@@ -1598,9 +1598,6 @@ class DaosContainer():
             self.poh = poh
         if self.uuid is None:
             raise DaosApiError("Fail to destroy a container with uuid as none.")
-
-        if self.uuid is None:
-            raise DaosApiError("Container uuid is None.")
         uuid_str = self.get_uuid_str()
 
         c_force = ctypes.c_uint(force)

--- a/src/tests/ftest/container/destroy.py
+++ b/src/tests/ftest/container/destroy.py
@@ -5,10 +5,9 @@
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
 import traceback
-import uuid
 
 from apricot import TestWithServers
-from pydaos.raw import DaosApiError, conversion
+from pydaos.raw import DaosApiError
 
 
 class ContainerDestroyTest(TestWithServers):
@@ -30,7 +29,6 @@ class ContainerDestroyTest(TestWithServers):
         expected_for_param = []
         change_result_uuid = self.params.get(
             "change_result", '/run/destroy_variants/destroy_uuid/*/')
-        change_uuid = change_result_uuid[0]
         expected_for_param.append(change_result_uuid[1])
 
         validity_result_poh = self.params.get(

--- a/src/tests/ftest/container/destroy.py
+++ b/src/tests/ftest/container/destroy.py
@@ -78,13 +78,13 @@ class ContainerDestroyTest(TestWithServers):
         else:
             poh = self.pool.pool.handle
 
-        uuid_str = None
+        con_uuid = None
         # Update container UUID used during destroy based on the variant.
         if change_uuid:
-            uuid_str = str(uuid.uuid4())
+            con_uuid = uuid.uuid4()
 
         try:
-            self.container.container.destroy(force=force, poh=poh, uuid_str=uuid_str)
+            self.container.container.destroy(force=force, poh=poh, con_uuid=con_uuid)
             passed = True
         except DaosApiError:
             self.log.info(traceback.format_exc())

--- a/src/tests/ftest/container/destroy.py
+++ b/src/tests/ftest/container/destroy.py
@@ -5,9 +5,10 @@
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
 import traceback
+import uuid
 
 from apricot import TestWithServers
-from pydaos.raw import DaosApiError
+from pydaos.raw import DaosApiError, conversion
 
 
 class ContainerDestroyTest(TestWithServers):
@@ -29,6 +30,7 @@ class ContainerDestroyTest(TestWithServers):
         expected_for_param = []
         change_result_uuid = self.params.get(
             "change_result", '/run/destroy_variants/destroy_uuid/*/')
+        change_uuid = change_result_uuid[0]
         expected_for_param.append(change_result_uuid[1])
 
         validity_result_poh = self.params.get(
@@ -76,8 +78,13 @@ class ContainerDestroyTest(TestWithServers):
         else:
             poh = self.pool.pool.handle
 
+        uuid_str = None
+        # Update container UUID used during destroy based on the variant.
+        if change_uuid:
+            uuid_str = str(uuid.uuid4())
+
         try:
-            self.container.container.destroy(force=force, poh=poh)
+            self.container.container.destroy(force=force, poh=poh, uuid_str=uuid_str)
             passed = True
         except DaosApiError:
             self.log.info(traceback.format_exc())

--- a/src/tests/ftest/container/destroy.py
+++ b/src/tests/ftest/container/destroy.py
@@ -8,7 +8,7 @@ import traceback
 import uuid
 
 from apricot import TestWithServers
-from pydaos.raw import DaosApiError, conversion
+from pydaos.raw import DaosApiError
 
 
 class ContainerDestroyTest(TestWithServers):

--- a/src/tests/ftest/container/destroy.py
+++ b/src/tests/ftest/container/destroy.py
@@ -78,14 +78,8 @@ class ContainerDestroyTest(TestWithServers):
         else:
             poh = self.pool.pool.handle
 
-        # Update container UUID used during destroy based on the variant.
-        if change_uuid:
-            con_uuid = uuid.uuid4()
-        else:
-            con_uuid = uuid.UUID(self.container.uuid)
-
         try:
-            self.container.container.destroy(force=force, poh=poh, con_uuid=con_uuid)
+            self.container.container.destroy(force=force, poh=poh)
             passed = True
         except DaosApiError:
             self.log.info(traceback.format_exc())
@@ -96,10 +90,6 @@ class ContainerDestroyTest(TestWithServers):
             # here before getting to tearDown. To do so, set uuid and poh in the
             # DaosContainer instance. Then call destroy on the TestContainer instance.
             self.container.container.poh = self.pool.pool.handle
-            con_uuid = uuid.UUID(self.container.uuid)
-            # Use conversion.c_uuid() to set the correct UUID into uuid.
-            conversion.c_uuid(con_uuid, self.container.container.uuid)
-
             self.container.destroy()
 
         if expected_result == 'PASS' and not passed:

--- a/src/tests/ftest/container/destroy.yaml
+++ b/src/tests/ftest/container/destroy.yaml
@@ -20,10 +20,6 @@ destroy_variants:
       change_result:
         - FALSE
         - PASS
-    nonexisting_uuid:
-      change_result:
-        - TRUE
-        - FAIL
 
   connection_open: !mux
     # opened=TRUE and force=0 should FAIL (noForce below causes FAIL)

--- a/src/tests/ftest/container/destroy.yaml
+++ b/src/tests/ftest/container/destroy.yaml
@@ -20,6 +20,10 @@ destroy_variants:
       change_result:
         - FALSE
         - PASS
+    nonexisting_uuid:
+      change_result:
+        - TRUE
+        - FAIL
 
   connection_open: !mux
     # opened=TRUE and force=0 should FAIL (noForce below causes FAIL)


### PR DESCRIPTION
daos_cont_destroy() in c still supports passing uuid, so container.destroy() needs uuid parameter to test non-existing uuid.

Features: container
Test-tag: container

Signed-off-by: Lei Huang <lei.huang@intel.com>