### PR TITLE
DAOS-10736 control: Improve UCX transport support (#9214)

### DIFF
--- a/src/control/lib/hardware/ucx/ucx.go
+++ b/src/control/lib/hardware/ucx/ucx.go
@@ -16,6 +16,11 @@ import (
 	"github.com/daos-stack/daos/src/control/logging"
 )
 
+const (
+	compInfiniband = "ib"
+	compTCP        = "tcp"
+)
+
 // NewProvider creates a new UCX data provider.
 func NewProvider(log logging.Logger) *Provider {
 	return &Provider{
@@ -46,9 +51,14 @@ func (p *Provider) GetFabricInterfaces(ctx context.Context) (*hardware.FabricInt
 		}
 	}()
 
+	supportedComps := common.NewStringSet(compInfiniband, compTCP)
 	fis := hardware.NewFabricInterfaceSet()
 
 	for _, comp := range components {
+		if !supportedComps.Has(comp.name) {
+			continue
+		}
+
 		mdResources, err := getMDResourceNames(uctHdl, comp)
 		if err != nil {
 			p.log.Error(err.Error())
@@ -72,7 +82,7 @@ func (p *Provider) GetFabricInterfaces(ctx context.Context) (*hardware.FabricInt
 			continue
 		}
 
-		if err := p.addFabricDevices(netDevs, fis); err != nil {
+		if err := p.addFabricDevices(comp.name, netDevs, fis); err != nil {
 			p.log.Error(err.Error())
 		}
 	}
@@ -111,7 +121,7 @@ func (p *Provider) getCompNetworkDevices(uctHdl *dlopen.LibHandle, comp *uctComp
 	return netDevs, nil
 }
 
-func (p *Provider) addFabricDevices(netDevs []*transportDev, fis *hardware.FabricInterfaceSet) error {
+func (p *Provider) addFabricDevices(comp string, netDevs []*transportDev, fis *hardware.FabricInterfaceSet) error {
 	allDevs := common.NewStringSet()
 	for _, dev := range netDevs {
 		allDevs.AddUnique(dev.device)
@@ -122,7 +132,7 @@ func (p *Provider) addFabricDevices(netDevs []*transportDev, fis *hardware.Fabri
 		osDev := strings.Split(dev.device, ":")[0]
 
 		fis.Update(&hardware.FabricInterface{
-			Name:      getExternalName(dev.device, allDevs.ToSlice()),
+			Name:      getExternalName(comp, dev.device, allDevs.ToSlice()),
 			OSName:    osDev,
 			Providers: p.getProviderSet(dev.transport),
 		})
@@ -131,9 +141,13 @@ func (p *Provider) addFabricDevices(netDevs []*transportDev, fis *hardware.Fabri
 	return nil
 }
 
-// getExternalName constructs the name that must be used by DAOS to specify the fabric device. For
-// UCX, this is a comma-separated list of all device names.
-func getExternalName(dev string, allDevs []string) string {
+// getExternalName constructs the name that must be used by DAOS to specify the fabric device.
+func getExternalName(comp, dev string, allDevs []string) string {
+	if comp != compInfiniband {
+		return dev
+	}
+
+	// Infiniband device names need to include the full list of devices for the component.
 	// To ensure unique names, each list has the main device string first.
 	ordered := []string{dev}
 	for _, d := range allDevs {
@@ -154,6 +168,8 @@ func (p *Provider) getProviderSet(transport string) common.StringSet {
 			p.log.Error(err.Error())
 		}
 	}
+	// Any interface with at least one provider should allow ucx+all
+	providers.Add("ucx+all")
 	return providers
 }
 


### PR DESCRIPTION
- Add support for ucx+all alias.
- Stop scanning non-network components. For now we will limit
  scanning to the infiniband (ib) and tcp components.
- For tcp, don't attempt to build a multirail device name.

Signed-off-by: Kris Jacque <kristin.jacque@intel.com>