### PR TITLE
DAOS-10458 build: Move dmg into daos-admin RPM (#8925)

### DIFF
--- a/ci/rpm/test_daos_node.sh
+++ b/ci/rpm/test_daos_node.sh
@@ -33,8 +33,12 @@ fi
 sudo "${YUM[@]}" erase $OPENMPI_RPM
 sudo "${YUM[@]}" install daos-client-tests-"${DAOS_PKG_VERSION}"
 if rpm -q $OPENMPI_RPM; then
-  echo "$OPENMPI_RPM RPM should be installed as a dependency of daos-client-tests"
+  echo "$OPENMPI_RPM RPM should not be installed as a dependency of daos-client-tests"
   exit 1
+fi
+if ! rpm -q daos-admin; then
+    echo "daos-admin should be installed as a dependency of daos-client-tests"
+    exit 1
 fi
 if ! sudo "${YUM[@]}" history undo last; then
     echo "Error trying to undo previous dnf transaction"
@@ -43,8 +47,12 @@ if ! sudo "${YUM[@]}" history undo last; then
 fi
 sudo "${YUM[@]}" install daos-server-tests-"${DAOS_PKG_VERSION}"
 if rpm -q $OPENMPI_RPM; then
-  echo "$OPENMPI_RPM RPM should be installed as a dependency of daos-server-tests"
+  echo "$OPENMPI_RPM RPM should not be installed as a dependency of daos-server-tests"
   exit 1
+fi
+if ! rpm -q daos-admin; then
+    echo "daos-admin should be installed as a dependency of daos-server-tests"
+    exit 1
 fi
 if ! sudo "${YUM[@]}" history undo last; then
     echo "Error trying to undo previous dnf transaction"

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+daos (2.1.102-6) unstable; urgency=medium
+  [ Michael MacDonald ]
+  * Move dmg to new daos-admin package
+
+ -- Michael MacDonald <mjmac.macdonald@intel.com>  Wed, 08 Jun 2022 13:58:03 -0000
+
 daos (2.1.102-5) unstable; urgency=medium
   [ Jeff Olivier ]
   * Make ucx required for build on all platforms

--- a/debian/control
+++ b/debian/control
@@ -115,7 +115,8 @@ Architecture: any
 Multi-Arch: same
 Depends: python (>=3.8), python3, python-yaml, python3-yaml,
          ${shlibs:Depends}, ${misc:Depends},
-         daos-client (= ${binary:Version})
+         daos-client (= ${binary:Version}),
+	 daos-admin (= ${binary:Version})
 Description: The Distributed Asynchronous Object Storage (DAOS) is an open-source
  software-defined object store designed from the ground up for
  massively distributed Non Volatile Memory (NVM). DAOS takes advantage
@@ -141,7 +142,8 @@ Package: daos-server-tests
 Architecture: any
 Multi-Arch: same
 Depends: ${shlibs:Depends}, ${misc:Depends},
-         daos-server (= ${binary:Version})
+         daos-server (= ${binary:Version}),
+	 daos-admin (= ${binary:Version})
 Description: This is the package needed to run the DAOS test suite (server tests)
  .
  This package contains tests
@@ -190,3 +192,22 @@ Description: The Distributed Asynchronous Object Storage (DAOS) is an open-sourc
  to optimize performance and cost.
  .
  This package contains the DAOS server.
+
+Package: daos-admin
+Section: net
+Architecture: any
+Multi-Arch: same
+Depends: ${shlibs:Depends}, ${misc:Depends},
+         daos-server (= ${binary:Version})
+Description: The Distributed Asynchronous Object Storage (DAOS) is an open-source
+ software-defined object store designed from the ground up for
+ massively distributed Non Volatile Memory (NVM). DAOS takes advantage
+ of next generation NVM technology like Storage Class Memory (SCM) and
+ NVM express (NVMe) while presenting a key-value storage interface and
+ providing features such as transactional non-blocking I/O, advanced
+ data protection with self healing on top of commodity hardware, end-
+ to-end data integrity, fine grained data control and elastic storage
+ to optimize performance and cost.
+ .
+ This package contains the DAOS administrative tools (e.g. dmg).
+

--- a/debian/daos-admin.dirs
+++ b/debian/daos-admin.dirs
@@ -1,0 +1,3 @@
+etc
+usr/bin
+usr/share/man/man8

--- a/debian/daos-admin.install
+++ b/debian/daos-admin.install
@@ -1,0 +1,3 @@
+usr/bin/dmg
+etc/daos/daos_control.yml
+usr/share/man/man8/dmg.8*

--- a/debian/daos-client.install
+++ b/debian/daos-client.install
@@ -1,6 +1,5 @@
 usr/bin/cart_ctl
 usr/bin/self_test
-usr/bin/dmg
 usr/bin/daos_agent
 usr/bin/dfuse
 usr/bin/daos
@@ -16,8 +15,6 @@ usr/lib64/python3.8/site-packages/pydaos/pydaos_shim.so
 usr/lib64/python3.8/site-packages/pydaos/raw/*.py
 usr/share/daos/ioil-ld-opts
 etc/daos/daos_agent.yml
-etc/daos/daos_control.yml
 usr/lib/systemd/system/daos_agent.service
 usr/share/man/man8/daos.8*
-usr/share/man/man8/dmg.8*
 usr/bin/cart_ctl

--- a/utils/rpms/daos.spec
+++ b/utils/rpms/daos.spec
@@ -15,7 +15,7 @@
 
 Name:          daos
 Version:       2.1.102
-Release:       5%{?relval}%{?dist}
+Release:       6%{?relval}%{?dist}
 Summary:       DAOS Storage Engine
 
 License:       BSD-2-Clause-Patent
@@ -184,6 +184,13 @@ Obsoletes: cart < 1000
 %description server
 This is the package needed to run a DAOS server
 
+%package admin
+Summary: DAOS admin tools
+Requires: %{name}%{?_isa} = %{version}-%{release}
+
+%description admin
+This package contains DAOS administrative tools (e.g. dmg).
+
 %package client
 Summary: The DAOS client
 Requires: %{name}%{?_isa} = %{version}-%{release}
@@ -231,6 +238,7 @@ This is the package is a metapackage to install all of the internal test package
 %package client-tests
 Summary: The DAOS test suite
 Requires: %{name}-client%{?_isa} = %{version}-%{release}
+Requires: %{name}-admin%{?_isa} = %{version}-%{release}
 %if (0%{?rhel} >= 7) && (0%{?rhel} < 8)
 Requires: python36-distro
 Requires: python36-tabulate
@@ -266,6 +274,7 @@ This is the package needed to run the DAOS client test suite openmpi tools
 %package server-tests
 Summary: The DAOS server test suite (server tests)
 Requires: %{name}-server%{?_isa} = %{version}-%{release}
+Requires: %{name}-admin%{?_isa} = %{version}-%{release}
 
 %description server-tests
 This is the package needed to run the DAOS server test suite (server tests)
@@ -458,11 +467,15 @@ getent passwd daos_agent >/dev/null || useradd -s /sbin/nologin -r -g daos_agent
 %{_unitdir}/%{server_svc_name}
 %{_sysctldir}/%{sysctl_script_name}
 
+%files admin
+%{_bindir}/dmg
+%{_mandir}/man8/dmg.8*
+%config(noreplace) %{conf_dir}/daos_control.yml
+
 %files client
 %{_libdir}/libdaos.so.*
 %{_bindir}/cart_ctl
 %{_bindir}/self_test
-%{_bindir}/dmg
 %{_bindir}/daos_agent
 %{_bindir}/dfuse
 %{_bindir}/daos
@@ -485,10 +498,8 @@ getent passwd daos_agent >/dev/null || useradd -s /sbin/nologin -r -g daos_agent
 %{python3_sitearch}/pydaos/pydaos_shim.so
 %{_datadir}/%{name}/ioil-ld-opts
 %config(noreplace) %{conf_dir}/daos_agent.yml
-%config(noreplace) %{conf_dir}/daos_control.yml
 %{_unitdir}/%{agent_svc_name}
 %{_mandir}/man8/daos.8*
-%{_mandir}/man8/dmg.8*
 
 %files client-tests
 %dir %{daoshome}
@@ -561,6 +572,9 @@ getent passwd daos_agent >/dev/null || useradd -s /sbin/nologin -r -g daos_agent
 # No files in a shim package
 
 %changelog
+* Wed Jun 8 2022 Michael MacDonald <mjmac.macdonald@intel.com> 2.1.102-6
+- Move dmg to new daos-admin RPM
+
 * Thu Jun 2 2022 Jeff Olivier <jeffrey.v.olivier@intel.com> 2.1.102-5
 - Make ucx required for build on all platforms
 


### PR DESCRIPTION
Create a new admin-only RPM to allow installation
independently of client/server dependencies.

Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com>
