### PR TITLE
DAOS-10132 control: Validate IOMMU is on during daos_server storage p…

### DIFF
--- a/src/control/cmd/daos_server/storage_test.go
+++ b/src/control/cmd/daos_server/storage_test.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2020-2021 Intel Corporation.
+// (C) Copyright 2020-2022 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -25,6 +25,15 @@ import (
 	"github.com/daos-stack/daos/src/control/server/storage/scm"
 )
 
+type mockIOMMUDetector struct {
+	enabled bool
+	err     error
+}
+
+func (mid *mockIOMMUDetector) IsIOMMUEnabled() (bool, error) {
+	return mid.enabled, mid.err
+}
+
 func TestDaosServer_StoragePrepare(t *testing.T) {
 	failedErr := errors.New("it failed")
 	var printNamespace strings.Builder
@@ -37,25 +46,29 @@ func TestDaosServer_StoragePrepare(t *testing.T) {
 	usrCurrent, _ := user.Current()
 	username := usrCurrent.Username
 	// bdev mock commands
-	bdevPrepCmd := commands.StoragePrepareCmd{
-		NvmeOnly: true,
+	newBdevPrepCmd := func() *commands.StoragePrepareCmd {
+		cmd := &commands.StoragePrepareCmd{
+			NvmeOnly: true,
+		}
+		cmd.NrHugepages = testNrHugePages
+		cmd.TargetUser = username
+		cmd.PCIAllowList = fmt.Sprintf("%s%s%s", test.MockPCIAddr(1),
+			storage.BdevPciAddrSep, test.MockPCIAddr(2))
+		cmd.PCIBlockList = test.MockPCIAddr(1)
+		return cmd
 	}
-	bdevPrepCmd.NrHugepages = testNrHugePages
-	bdevPrepCmd.TargetUser = username
-	bdevPrepCmd.PCIAllowList = fmt.Sprintf("%s%s%s", test.MockPCIAddr(1),
-		storage.BdevPciAddrSep, test.MockPCIAddr(2))
-	bdevPrepCmd.PCIBlockList = test.MockPCIAddr(1)
-	bdevResetCmd := bdevPrepCmd
+	bdevResetCmd := newBdevPrepCmd()
 	bdevResetCmd.Reset = true
 
 	for name, tc := range map[string]struct {
-		prepCmd      commands.StoragePrepareCmd
-		bmbc         *bdev.MockBackendConfig
-		smbc         *scm.MockBackendConfig
-		expLogMsg    string
-		expErr       error
-		expPrepCall  *storage.BdevPrepareRequest
-		expResetCall *storage.BdevPrepareRequest
+		prepCmd       *commands.StoragePrepareCmd
+		bmbc          *bdev.MockBackendConfig
+		smbc          *scm.MockBackendConfig
+		iommuDisabled bool
+		expLogMsg     string
+		expErr        error
+		expPrepCall   *storage.BdevPrepareRequest
+		expResetCall  *storage.BdevPrepareRequest
 	}{
 		"default no devices; success": {
 			expPrepCall: &storage.BdevPrepareRequest{
@@ -65,7 +78,7 @@ func TestDaosServer_StoragePrepare(t *testing.T) {
 			},
 		},
 		"nvme-only no devices; success": {
-			prepCmd: commands.StoragePrepareCmd{
+			prepCmd: &commands.StoragePrepareCmd{
 				NvmeOnly: true,
 			},
 			expPrepCall: &storage.BdevPrepareRequest{
@@ -74,19 +87,19 @@ func TestDaosServer_StoragePrepare(t *testing.T) {
 			},
 		},
 		"scm-only no devices; success": {
-			prepCmd: commands.StoragePrepareCmd{
+			prepCmd: &commands.StoragePrepareCmd{
 				ScmOnly: true,
 			},
 		},
 		"setting nvme-only and scm-only should fail": {
-			prepCmd: commands.StoragePrepareCmd{
+			prepCmd: &commands.StoragePrepareCmd{
 				ScmOnly:  true,
 				NvmeOnly: true,
 			},
 			expErr: errors.New("should not be set"),
 		},
 		"prepared scm; success": {
-			prepCmd: commands.StoragePrepareCmd{
+			prepCmd: &commands.StoragePrepareCmd{
 				ScmOnly: true,
 			},
 			smbc: &scm.MockBackendConfig{
@@ -96,7 +109,7 @@ func TestDaosServer_StoragePrepare(t *testing.T) {
 			},
 		},
 		"unprepared scm; warn": {
-			prepCmd: commands.StoragePrepareCmd{
+			prepCmd: &commands.StoragePrepareCmd{
 				ScmOnly: true,
 			},
 			smbc: &scm.MockBackendConfig{
@@ -106,7 +119,7 @@ func TestDaosServer_StoragePrepare(t *testing.T) {
 			expErr: errors.New("consent not given"), // prompts for confirmation and gets EOF
 		},
 		"unprepared scm; force": {
-			prepCmd: commands.StoragePrepareCmd{
+			prepCmd: &commands.StoragePrepareCmd{
 				ScmOnly: true,
 				Force:   true,
 			},
@@ -118,7 +131,7 @@ func TestDaosServer_StoragePrepare(t *testing.T) {
 			expLogMsg: storage.ScmMsgRebootRequired,
 		},
 		"prepare scm; create namespaces": {
-			prepCmd: commands.StoragePrepareCmd{
+			prepCmd: &commands.StoragePrepareCmd{
 				ScmOnly: true,
 				Force:   true,
 			},
@@ -130,7 +143,7 @@ func TestDaosServer_StoragePrepare(t *testing.T) {
 			expLogMsg: printNamespace.String(),
 		},
 		"reset scm": {
-			prepCmd: commands.StoragePrepareCmd{
+			prepCmd: &commands.StoragePrepareCmd{
 				ScmOnly: true,
 				Reset:   true,
 			},
@@ -142,7 +155,7 @@ func TestDaosServer_StoragePrepare(t *testing.T) {
 			expErr: errors.New("consent not given"), // prompts for confirmation and gets EOF
 		},
 		"scm scan fails": {
-			prepCmd: commands.StoragePrepareCmd{
+			prepCmd: &commands.StoragePrepareCmd{
 				ScmOnly: true,
 			},
 			smbc: &scm.MockBackendConfig{
@@ -151,7 +164,7 @@ func TestDaosServer_StoragePrepare(t *testing.T) {
 			expErr: failedErr,
 		},
 		"scm prepare fails": {
-			prepCmd: commands.StoragePrepareCmd{
+			prepCmd: &commands.StoragePrepareCmd{
 				ScmOnly: true,
 			},
 			smbc: &scm.MockBackendConfig{
@@ -162,7 +175,7 @@ func TestDaosServer_StoragePrepare(t *testing.T) {
 			expErr: failedErr,
 		},
 		"nvme prep succeeds; user params": {
-			prepCmd: bdevPrepCmd,
+			prepCmd: newBdevPrepCmd(),
 			expPrepCall: &storage.BdevPrepareRequest{
 				HugePageCount: testNrHugePages,
 				TargetUser:    username,
@@ -173,7 +186,7 @@ func TestDaosServer_StoragePrepare(t *testing.T) {
 			},
 		},
 		"nvme prep fails; user params": {
-			prepCmd: bdevPrepCmd,
+			prepCmd: newBdevPrepCmd(),
 			bmbc: &bdev.MockBackendConfig{
 				PrepareErr: errors.New("backed prep setup failed"),
 			},
@@ -186,6 +199,26 @@ func TestDaosServer_StoragePrepare(t *testing.T) {
 				EnableVMD:    true,
 			},
 			expErr: errors.New("backed prep setup failed"),
+		},
+		"non-root; vfio disabled": {
+			prepCmd: newBdevPrepCmd().WithDisableVFIO(true),
+			expErr:  errors.New("VFIO can not be disabled"),
+		},
+		"non-root; iommu not detected": {
+			iommuDisabled: true,
+			expErr:        errors.New("no IOMMU detected"),
+		},
+		"root; vfio disabled; iommu not detected": {
+			prepCmd:       newBdevPrepCmd().WithTargetUser("root").WithDisableVFIO(true),
+			iommuDisabled: true,
+			expPrepCall: &storage.BdevPrepareRequest{
+				HugePageCount: testNrHugePages,
+				TargetUser:    "root",
+				PCIAllowList: fmt.Sprintf("%s%s%s", test.MockPCIAddr(1),
+					storage.BdevPciAddrSep, test.MockPCIAddr(2)),
+				PCIBlockList: test.MockPCIAddr(1),
+				DisableVFIO:  true,
+			},
 		},
 		"nvme prep reset succeeds; user params": {
 			prepCmd: bdevResetCmd,
@@ -223,13 +256,18 @@ func TestDaosServer_StoragePrepare(t *testing.T) {
 			mbb := bdev.NewMockBackend(tc.bmbc)
 			mbp := bdev.NewProvider(log, mbb)
 
+			if tc.prepCmd == nil {
+				tc.prepCmd = &commands.StoragePrepareCmd{}
+			}
+
 			cmd := &storagePrepareCmd{
-				StoragePrepareCmd: tc.prepCmd,
+				StoragePrepareCmd: *tc.prepCmd,
 				logCmd: logCmd{
 					log: log,
 				},
 				scs: server.NewMockStorageControlService(log, nil, nil,
 					scm.NewMockProvider(log, tc.smbc, nil), mbp),
+				iommuDetector: &mockIOMMUDetector{enabled: !tc.iommuDisabled},
 			}
 
 			gotErr := cmd.Execute(nil)
@@ -237,11 +275,13 @@ func TestDaosServer_StoragePrepare(t *testing.T) {
 			mbb.RLock()
 			if tc.expPrepCall == nil {
 				if len(mbb.PrepareCalls) != 0 {
-					t.Fatal("unexpected number of prepared calls")
+					t.Fatalf("unexpected number of prepare calls, want 0 got %d",
+						len(mbb.PrepareCalls))
 				}
 			} else {
 				if len(mbb.PrepareCalls) != 1 {
-					t.Fatal("unexpected number of prepared calls")
+					t.Fatalf("unexpected number of prepare calls, want 1 got %d",
+						len(mbb.PrepareCalls))
 				}
 				if diff := cmp.Diff(*tc.expPrepCall, mbb.PrepareCalls[0]); diff != "" {
 					t.Fatalf("unexpected prepare calls (-want, +got):\n%s\n", diff)
@@ -252,14 +292,16 @@ func TestDaosServer_StoragePrepare(t *testing.T) {
 			mbb.RLock()
 			if tc.expResetCall == nil {
 				if len(mbb.ResetCalls) != 0 {
-					t.Fatal("unexpected number of prepared calls")
+					t.Fatalf("unexpected number of reset calls, want 0 got %d",
+						len(mbb.ResetCalls))
 				}
 			} else {
 				if len(mbb.ResetCalls) != 1 {
-					t.Fatal("unexpected number of prepared calls")
+					t.Fatalf("unexpected number of reset calls, want 1 got %d",
+						len(mbb.PrepareCalls))
 				}
 				if diff := cmp.Diff(*tc.expResetCall, mbb.ResetCalls[0]); diff != "" {
-					t.Fatalf("unexpected prepare calls (-want, +got):\n%s\n", diff)
+					t.Fatalf("unexpected reset calls (-want, +got):\n%s\n", diff)
 				}
 			}
 			mbb.RUnlock()

--- a/src/control/common/storage/commands.go
+++ b/src/control/common/storage/commands.go
@@ -25,6 +25,7 @@ type StoragePrepareNvmeCmd struct {
 	PCIBlockList string `long:"pci-block-list" description:"Whitespace separated list of PCI devices (by address) to be ignored when unbinding devices from Kernel driver to be used with SPDK (default is no PCI devices)."`
 	NrHugepages  int    `short:"p" long:"hugepages" description:"Number of hugepages to allocate for use by SPDK (default 1024)"`
 	TargetUser   string `short:"u" long:"target-user" description:"User that will own hugepage mountpoint directory and vfio groups."`
+	DisableVFIO  bool   `long:"disable-vfio" description:"Force SPDK to use the UIO driver for NVMe device access"`
 }
 
 type StoragePrepareScmCmd struct{}
@@ -79,4 +80,14 @@ func (cmd *StoragePrepareCmd) Warn(log *logging.LeveledLogger) error {
 	}
 
 	return nil
+}
+
+func (cmd *StoragePrepareCmd) WithDisableVFIO(b bool) *StoragePrepareCmd {
+	cmd.DisableVFIO = b
+	return cmd
+}
+
+func (cmd *StoragePrepareCmd) WithTargetUser(u string) *StoragePrepareCmd {
+	cmd.TargetUser = u
+	return cmd
 }

--- a/src/control/lib/hardware/hwprov/defaults.go
+++ b/src/control/lib/hardware/hwprov/defaults.go
@@ -107,3 +107,8 @@ func Init(log logging.Logger) (func(), error) {
 		}
 	}, nil
 }
+
+// DefaultIOMMUDetector gets the default provider for the IOMMU detector.
+func DefaultIOMMUDetector(log logging.Logger) hardware.IOMMUDetector {
+	return sysfs.NewProvider(log)
+}

--- a/src/control/lib/hardware/iommu.go
+++ b/src/control/lib/hardware/iommu.go
@@ -1,0 +1,14 @@
+//
+// (C) Copyright 2022 Intel Corporation.
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+
+package hardware
+
+type (
+	// IOMMUDetector is an interface for detecting if IOMMU is enabled on a system.
+	IOMMUDetector interface {
+		IsIOMMUEnabled() (bool, error)
+	}
+)

--- a/src/control/lib/hardware/sysfs/provider.go
+++ b/src/control/lib/hardware/sysfs/provider.go
@@ -475,3 +475,20 @@ func condenseNetDevState(states []hardware.NetDevState) hardware.NetDevState {
 
 	return condensed
 }
+
+// IsIOMMUEnabled checks whether IOMMU is enabled by interrogating files in sysfs and implements
+// the IOMMUDetector interface on sysfs provider.
+func (s *Provider) IsIOMMUEnabled() (bool, error) {
+	if s == nil {
+		return false, errors.New("sysfs provider is nil")
+	}
+
+	// Simple test for now -- if the path exists and contains
+	// DMAR entries, we assume that's good enough.
+	dmars, err := ioutil.ReadDir(s.sysPath("class", "iommu"))
+	if err != nil && !os.IsNotExist(err) {
+		return false, err
+	}
+
+	return err == nil && len(dmars) > 0, nil
+}

--- a/src/control/lib/hardware/sysfs/provider_test.go
+++ b/src/control/lib/hardware/sysfs/provider_test.go
@@ -1096,3 +1096,56 @@ func TestSysfs_condenseNetDevState(t *testing.T) {
 		})
 	}
 }
+
+func setupTestIsIOMMUEnabled(t *testing.T, root string, extraDirs ...string) {
+	t.Helper()
+
+	dirs := append([]string{root}, extraDirs...)
+
+	path := filepath.Join(dirs...)
+	os.MkdirAll(path, 0755)
+}
+
+func TestSysfs_Provider_IsIOMMUEnabled(t *testing.T) {
+	for name, tc := range map[string]struct {
+		nilProvider bool
+		extraDirs   []string
+		expResult   bool
+		expErr      error
+	}{
+		"nil provider": {
+			nilProvider: true,
+			expErr:      errors.New("provider is nil"),
+		},
+		"missing iommu dir": {
+			extraDirs: []string{"class"},
+		},
+		"iommu disabled": {
+			extraDirs: []string{"class", "iommu"},
+		},
+		"iommu enabled": {
+			extraDirs: []string{"class", "iommu", "dmar0"},
+			expResult: true,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			testDir, cleanupTestDir := test.CreateTestDir(t)
+			defer cleanupTestDir()
+
+			log, buf := logging.NewTestLogger(name)
+			defer test.ShowBufferOnFailure(t, buf)
+
+			var p *Provider
+			if !tc.nilProvider {
+				p = NewProvider(log)
+				p.root = testDir
+				setupTestIsIOMMUEnabled(t, testDir, tc.extraDirs...)
+			}
+
+			result, err := p.IsIOMMUEnabled()
+
+			test.CmpErr(t, tc.expErr, err)
+			test.AssertEqual(t, tc.expResult, result, "")
+		})
+	}
+}

--- a/src/control/server/server.go
+++ b/src/control/server/server.go
@@ -282,8 +282,13 @@ func (srv *server) addEngines(ctx context.Context) error {
 	var allStarted sync.WaitGroup
 	registerTelemetryCallbacks(ctx, srv)
 
+	iommuEnabled, err := hwprov.DefaultIOMMUDetector(srv.log).IsIOMMUEnabled()
+	if err != nil {
+		return err
+	}
+
 	// Allocate hugepages and rebind NVMe devices to userspace drivers.
-	if err := prepBdevStorage(srv, iommuDetected()); err != nil {
+	if err := prepBdevStorage(srv, iommuEnabled); err != nil {
 		return err
 	}
 

--- a/src/control/server/server_utils.go
+++ b/src/control/server/server_utils.go
@@ -9,7 +9,6 @@ package server
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"path/filepath"
@@ -39,10 +38,7 @@ type netListenFn func(string, string) (net.Listener, error)
 // resolveTCPFn is a type alias for the net.ResolveTCPAddr function signature.
 type resolveTCPFn func(string, string) (*net.TCPAddr, error)
 
-const (
-	iommuPath            = "/sys/class/iommu"
-	scanMinHugePageCount = 128
-)
+const scanMinHugePageCount = 128
 
 func engineCfgGetBdevs(engineCfg *engine.Config) *storage.BdevDeviceList {
 	bdevs := []string{}
@@ -105,17 +101,6 @@ func writeCoreDumpFilter(log logging.Logger, path string, filter uint8) error {
 
 	_, err = f.WriteString(fmt.Sprintf("0x%x\n", filter))
 	return err
-}
-
-func iommuDetected() bool {
-	// Simple test for now -- if the path exists and contains
-	// DMAR entries, we assume that's good enough.
-	dmars, err := ioutil.ReadDir(iommuPath)
-	if err != nil {
-		return false
-	}
-
-	return len(dmars) > 0
 }
 
 func createListener(ctlPort int, resolver resolveTCPFn, listener netListenFn) (*net.TCPAddr, net.Listener, error) {

--- a/src/control/server/server_utils_test.go
+++ b/src/control/server/server_utils_test.go
@@ -224,8 +224,7 @@ func TestServer_prepBdevStorage(t *testing.T) {
 	}
 	username := usrCurrent.Username
 	if username == "root" {
-		t.Log("Skip prepBdevStorage tests when run with root user")
-		return
+		t.Fatal("prepBdevStorage tests cannot be run as root user")
 	}
 
 	// basic engine configs populated enough to complete validation
@@ -255,18 +254,35 @@ func TestServer_prepBdevStorage(t *testing.T) {
 		getHpiErr       error
 		hugePagesFree   int
 		bmbc            *bdev.MockBackendConfig
+		overrideUser    string
 		expPrepErr      error
 		expPrepCall     *storage.BdevPrepareRequest
 		expMemChkErr    error
 		expMemSize      int
 		expHugePageSize int
 	}{
-		"vfio disabled": {
+		"vfio disabled; non-root user": {
 			srvCfgExtra: func(sc *config.Server) *config.Server {
 				return sc.WithDisableVFIO(true).
-					WithEngines(nvmeEngine(0), nvmeEngine(1))
+					WithEngines(nvmeEngine(0))
 			},
 			expPrepErr: FaultVfioDisabled,
+		},
+		"vfio disabled; root user": {
+			srvCfgExtra: func(sc *config.Server) *config.Server {
+				return sc.WithDisableVFIO(true).
+					WithEngines(nvmeEngine(0))
+			},
+			overrideUser:  "root",
+			hugePagesFree: 8192,
+			expPrepCall: &storage.BdevPrepareRequest{
+				HugePageCount: 8194,
+				HugeNodes:     "0",
+				TargetUser:    "root",
+				DisableVFIO:   true,
+			},
+			expMemSize:      16384,
+			expHugePageSize: 2,
 		},
 		"iommu disabled": {
 			iommuDisabled: true,
@@ -274,6 +290,21 @@ func TestServer_prepBdevStorage(t *testing.T) {
 				return sc.WithEngines(nvmeEngine(0), nvmeEngine(1))
 			},
 			expPrepErr: FaultIommuDisabled,
+		},
+		"iommu disabled; root user": {
+			iommuDisabled: true,
+			srvCfgExtra: func(sc *config.Server) *config.Server {
+				return sc.WithEngines(nvmeEngine(0))
+			},
+			overrideUser:  "root",
+			hugePagesFree: 8192,
+			expPrepCall: &storage.BdevPrepareRequest{
+				HugePageCount: 8194,
+				HugeNodes:     "0",
+				TargetUser:    "root",
+			},
+			expMemSize:      16384,
+			expHugePageSize: 2,
 		},
 		"no bdevs configured; -1 hugepages requested": {
 			srvCfgExtra: func(sc *config.Server) *config.Server {
@@ -497,6 +528,10 @@ func TestServer_prepBdevStorage(t *testing.T) {
 					scm.NewProvider(log, scm.NewMockBackend(nil), sp),
 					mbp),
 				srvCfg: cfg,
+			}
+
+			if tc.overrideUser != "" {
+				srv.runningUser = &user.User{Username: tc.overrideUser}
 			}
 
 			gotErr := prepBdevStorage(srv, !tc.iommuDisabled)


### PR DESCRIPTION
…repare (#8914)

Make behaviour consistent between NVMe storage prepare in daemon and
stand-alone daos_server commands. IOMMU has to be enabled if the target
user is not root. VFIO can only be disabled if running as root (SPDK
userspace driver falls back to UIO if available).

Modified version of port of PR-8914 that was applied to the master branch.

Features: control

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>