### PR TITLE
DAOS-10741 java: Update Netty to Latest Version

### DIFF
--- a/src/client/java/daos-java/pom.xml
+++ b/src/client/java/daos-java/pom.xml
@@ -41,7 +41,7 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-buffer</artifactId>
-      <version>4.1.59.Final</version>
+      <version>4.1.77.Final</version>
     </dependency>
     <dependency>
       <groupId>com.google.code.findbugs</groupId>


### PR DESCRIPTION
Update netty used by daos-java to the latest version to address CVE-2022-24823

Signed-off-by: David Quigley <david.quigley@intel.com>