### PR TITLE
DAOS-10569 client: fix build on aarch64 (#8986)

### DIFF
--- a/src/client/dfuse/dfuse_obj_da.c
+++ b/src/client/dfuse/dfuse_obj_da.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2017-2021 Intel Corporation.
+ * (C) Copyright 2017-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -26,6 +26,7 @@ struct da_entry {
 };
 
 struct obj_da {
+	int magic;                 /* magic number for sanity */
 	pthread_key_t key;         /* key to threadprivate data */
 	pthread_mutex_t lock;      /* lock thread events */
 	d_list_t free_entries;     /* entries put in da by dead thread */
@@ -34,7 +35,6 @@ struct obj_da {
 	size_t obj_size;           /* size of objects in da */
 	size_t padded_size;        /* real size of objects in da */
 	size_t block_size;         /* allocation size */
-	int magic;                 /* magic number for sanity */
 };
 
 #define PAD8(size) ((size + 7) & ~7)

--- a/src/client/pydaos/raw/daos_cref.py
+++ b/src/client/pydaos/raw/daos_cref.py
@@ -146,7 +146,7 @@ class ContInfo(ctypes.Structure):
 class DaosEvent(ctypes.Structure):
     """Represents struct: daos_event_t"""
     _fields_ = [("ev_error", ctypes.c_int),
-                ("ev_private", ctypes.c_ulonglong * 19),
+                ("ev_private", ctypes.c_ulonglong * 20),
                 ("ev_debug", ctypes.c_ulonglong)]
 
 

--- a/src/include/daos_types.h
+++ b/src/include/daos_types.h
@@ -130,9 +130,9 @@ typedef d_iov_t daos_key_t;
 
 typedef struct daos_event {
 	int			ev_error;
-	/** Internal use, please do not modify */
+	/** Internal use - 152 + 8 bytes pad for pthread_mutex_t size difference on __aarch64__ */
 	struct {
-		uint64_t	space[19];
+		uint64_t	space[20];
 	}			ev_private;
 	/** Used for debugging */
 	uint64_t		ev_debug;


### PR DESCRIPTION
* New mutex added in private event did not take into consideration extra
8 byte of mutex size on aarch64. add that padding to private event size.
* move the magic int to be next to the pthread key since both are
4 bytes so compiler doesn't insert an extra 8 byte pads (4 each) when
statically checking the size.

Signed-off-by: Mohamad Chaarawi <mohamad.chaarawi@intel.com>