### PR TITLE
DAOS-10643 control: Debounce SWIM Rank Dead events

### DIFF
--- a/src/control/events/pubsub_test.go
+++ b/src/control/events/pubsub_test.go
@@ -8,6 +8,7 @@ package events
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -34,7 +35,7 @@ func (tly *tally) OnEvent(_ context.Context, evt *RASEvent) {
 	tly.Lock()
 	defer tly.Unlock()
 
-	tly.rx = append(tly.rx, evt.Type.String())
+	tly.rx = append(tly.rx, evt.String())
 	if len(tly.rx) == tly.expectedRx {
 		close(tly.finished)
 	}
@@ -70,12 +71,10 @@ func TestEvents_PubSub_Basic(t *testing.T) {
 	<-tly1.finished
 	<-tly2.finished
 
-	test.AssertStringsEqual(t, []string{
-		RASTypeStateChange.String(), RASTypeStateChange.String(),
-	}, tly1.getRx(), "tly1 unexpected slice of received events")
-	test.AssertStringsEqual(t, []string{
-		RASTypeStateChange.String(), RASTypeStateChange.String(),
-	}, tly2.getRx(), "tly2 unexpected slice of received events")
+	test.AssertStringsEqual(t, []string{evt1.String(), evt1.String()},
+		tly1.getRx(), "tly1 unexpected slice of received events")
+	test.AssertStringsEqual(t, []string{evt1.String(), evt1.String()},
+		tly2.getRx(), "tly2 unexpected slice of received events")
 }
 
 func TestEvents_PubSub_Reset(t *testing.T) {
@@ -100,9 +99,8 @@ func TestEvents_PubSub_Reset(t *testing.T) {
 
 	ps.Reset()
 
-	test.AssertStringsEqual(t, []string{
-		RASTypeStateChange.String(), RASTypeStateChange.String(),
-	}, tly1.getRx(), "unexpected slice of received events")
+	test.AssertStringsEqual(t, []string{evt1.String(), evt1.String()},
+		tly1.getRx(), "unexpected slice of received events")
 	test.AssertEqual(t, 0, len(tly2.getRx()), "unexpected number of received events")
 
 	tly1 = newTally(2)
@@ -116,9 +114,8 @@ func TestEvents_PubSub_Reset(t *testing.T) {
 	<-tly2.finished
 	ps.Close()
 
-	test.AssertStringsEqual(t, []string{
-		RASTypeStateChange.String(), RASTypeStateChange.String(),
-	}, tly2.getRx(), "unexpected slice of received events")
+	test.AssertStringsEqual(t, []string{evt1.String(), evt1.String()},
+		tly2.getRx(), "unexpected slice of received events")
 	test.AssertEqual(t, 0, len(tly1.getRx()), "unexpected number of received events")
 }
 
@@ -158,6 +155,7 @@ func TestEvents_PubSub_DisableEvent(t *testing.T) {
 
 func TestEvents_PubSub_SubscribeAnyTopic(t *testing.T) {
 	evt1 := mockEvtDied(t)
+	evt2 := mockEvtGeneric(t) // of type InfoOnly will only match Any
 
 	log, buf := logging.NewTestLogger(t.Name())
 	defer test.ShowBufferOnFailure(t, buf)
@@ -175,19 +173,103 @@ func TestEvents_PubSub_SubscribeAnyTopic(t *testing.T) {
 
 	ps.Publish(evt1)
 	ps.Publish(evt1)
-	ps.Publish(mockEvtGeneric(t)) // of type InfoOnly will only match Any
+	ps.Publish(evt2)
 
 	<-tly1.finished
 	<-tly2.finished
 
-	test.AssertStringsEqual(t, []string{
-		RASTypeInfoOnly.String(),
-		RASTypeStateChange.String(),
-		RASTypeStateChange.String(),
-	}, tly1.getRx(), "tly1 unexpected slice of received events")
+	test.AssertStringsEqual(t, []string{evt1.String(), evt1.String(), evt2.String()},
+		tly1.getRx(), "tly1 unexpected slice of received events")
 
-	test.AssertStringsEqual(t, []string{
-		RASTypeStateChange.String(),
-		RASTypeStateChange.String(),
-	}, tly2.getRx(), "tly2 unexpected slice of received events")
+	test.AssertStringsEqual(t, []string{evt1.String(), evt1.String()},
+		tly2.getRx(), "tly2 unexpected slice of received events")
+}
+
+func mockSwimRankDeadEvt(rankInc ...uint32) *RASEvent {
+	var rank uint32
+	var inc uint64
+
+	switch len(rankInc) {
+	case 1:
+		rank = rankInc[0]
+	case 2:
+		rank = rankInc[0]
+		inc = uint64(rankInc[1])
+	}
+	return &RASEvent{
+		ID:          RASSwimRankDead,
+		Type:        RASTypeStateChange,
+		Rank:        rank,
+		Incarnation: inc,
+	}
+}
+
+func TestEvents_PubSub_Debounce_NoCooldown(t *testing.T) {
+	log, buf := logging.NewTestLogger(t.Name())
+	defer test.ShowBufferOnFailure(t, buf)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ps := NewPubSub(ctx, log)
+
+	evt1 := mockSwimRankDeadEvt(1, 1)
+	debounceType := evt1.ID
+	evt1_2 := mockSwimRankDeadEvt(1, 2)
+	evt2 := mockSwimRankDeadEvt(2, 2)
+	evt3 := mockEvtDied(t)
+	tally := newTally(4)
+
+	ps.Subscribe(RASTypeStateChange, tally)
+	ps.Debounce(debounceType, 0, func(ev *RASEvent) string {
+		return fmt.Sprintf("%d:%x", ev.Rank, ev.Incarnation)
+	})
+
+	ps.Publish(evt1)
+	ps.Publish(evt1_2)
+	ps.Publish(evt2)
+	ps.Publish(evt3)
+
+	// we should only see one of these, no matter how many times
+	// it's submitted
+	for i := 0; i < 16; i++ {
+		ps.Publish(evt1)
+	}
+
+	<-tally.finished
+
+	test.AssertStringsEqual(t, []string{evt1.String(), evt1_2.String(), evt2.String(), evt3.String()},
+		tally.getRx(), "unexpected slice of received events")
+}
+
+func TestEvents_PubSub_Debounce_Cooldown(t *testing.T) {
+	log, buf := logging.NewTestLogger(t.Name())
+	defer test.ShowBufferOnFailure(t, buf)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ps := NewPubSub(ctx, log)
+
+	evt1 := mockSwimRankDeadEvt(1, 1)
+	debounceType := evt1.ID
+	debounceCooldown := 10 * time.Millisecond
+	tally := newTally(3)
+
+	ps.Subscribe(RASTypeStateChange, tally)
+	ps.Debounce(debounceType, debounceCooldown, func(ev *RASEvent) string {
+		return fmt.Sprintf("%d:%x", ev.Rank, ev.Incarnation)
+	})
+
+	// We should only see this event three times, after the cooldown
+	// timer expires on each loop.
+	for i := 0; i < 3; i++ {
+		for j := 0; j < 16; j++ {
+			ps.Publish(evt1)
+		}
+		time.Sleep(debounceCooldown)
+	}
+
+	<-tally.finished
+
+	test.AssertStringsEqual(t, []string{evt1.String(), evt1.String(), evt1.String()},
+		tally.getRx(), "unexpected slice of received events")
 }

--- a/src/control/events/ras.go
+++ b/src/control/events/ras.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2020-2021 Intel Corporation.
+// (C) Copyright 2020-2022 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -303,6 +303,10 @@ func (evt *RASEvent) FromProto(pbEvt *sharedpb.RASEvent) (err error) {
 	}
 
 	return
+}
+
+func (ev *RASEvent) String() string {
+	return ev.PrintRAS()
 }
 
 // PrintRAS generates a string representation of the event consistent with

--- a/src/control/events/ras_test.go
+++ b/src/control/events/ras_test.go
@@ -50,12 +50,12 @@ func TestEvents_HandleClusterEvent(t *testing.T) {
 	pbPSREvent, _ := psrEvent.ToProto()
 
 	for name, tc := range map[string]struct {
-		req         *sharedpb.ClusterEventReq
-		subType     RASTypeID
-		fwded       bool
-		expEvtTypes []string
-		expResp     *sharedpb.ClusterEventResp
-		expErr      error
+		req     *sharedpb.ClusterEventReq
+		subType RASTypeID
+		fwded   bool
+		expEvts []string
+		expResp *sharedpb.ClusterEventResp
+		expErr  error
 	}{
 		"nil req": {
 			expErr: errors.New("nil request"),
@@ -68,9 +68,9 @@ func TestEvents_HandleClusterEvent(t *testing.T) {
 			req: &sharedpb.ClusterEventReq{
 				Event: pbGenericEvent,
 			},
-			subType:     RASTypeInfoOnly,
-			expEvtTypes: []string{RASTypeInfoOnly.String()},
-			expResp:     &sharedpb.ClusterEventResp{},
+			subType: RASTypeInfoOnly,
+			expEvts: []string{genericEvent.String()},
+			expResp: &sharedpb.ClusterEventResp{},
 		},
 		"filtered generic event": {
 			req: &sharedpb.ClusterEventReq{
@@ -83,9 +83,9 @@ func TestEvents_HandleClusterEvent(t *testing.T) {
 			req: &sharedpb.ClusterEventReq{
 				Event: pbEngineDiedEvent,
 			},
-			subType:     RASTypeStateChange,
-			expEvtTypes: []string{RASTypeStateChange.String()},
-			expResp:     &sharedpb.ClusterEventResp{},
+			subType: RASTypeStateChange,
+			expEvts: []string{engineDiedEvent.String()},
+			expResp: &sharedpb.ClusterEventResp{},
 		},
 		"filtered rank down event": {
 			req: &sharedpb.ClusterEventReq{
@@ -98,9 +98,9 @@ func TestEvents_HandleClusterEvent(t *testing.T) {
 			req: &sharedpb.ClusterEventReq{
 				Event: pbPSREvent,
 			},
-			subType:     RASTypeStateChange,
-			expEvtTypes: []string{RASTypeStateChange.String()},
-			expResp:     &sharedpb.ClusterEventResp{},
+			subType: RASTypeStateChange,
+			expEvts: []string{psrEvent.String()},
+			expResp: &sharedpb.ClusterEventResp{},
 		},
 		"filtered pool svc replica update event": {
 			req: &sharedpb.ClusterEventReq{
@@ -119,7 +119,7 @@ func TestEvents_HandleClusterEvent(t *testing.T) {
 			ps := NewPubSub(ctx, log)
 			defer ps.Close()
 
-			tly1 := newTally(len(tc.expEvtTypes))
+			tly1 := newTally(len(tc.expEvts))
 
 			ps.Subscribe(tc.subType, tly1)
 
@@ -134,7 +134,7 @@ func TestEvents_HandleClusterEvent(t *testing.T) {
 			case <-tly1.finished:
 			}
 
-			test.AssertStringsEqual(t, tc.expEvtTypes, tly1.getRx(),
+			test.AssertStringsEqual(t, tc.expEvts, tly1.getRx(),
 				"unexpected received events")
 
 			if diff := cmp.Diff(tc.expResp, resp, defEvtCmpOpts...); diff != "" {

--- a/src/control/server/server_utils.go
+++ b/src/control/server/server_utils.go
@@ -462,7 +462,7 @@ func registerFollowerSubscriptions(srv *server) {
 }
 
 // registerLeaderSubscriptions stops forwarding events to MS and instead starts
-// handling received forwardede(and local) events.
+// handling received forwarded (and local) events.
 func registerLeaderSubscriptions(srv *server) {
 	srv.pubSub.Reset()
 	srv.pubSub.Subscribe(events.RASTypeAny, srv.evtLogger)
@@ -485,6 +485,11 @@ func registerLeaderSubscriptions(srv *server) {
 				}
 			}
 		}))
+
+	// Add a debounce to throttle multiple SWIM Rank Dead events for the same rank/incarnation.
+	srv.pubSub.Debounce(events.RASSwimRankDead, 0, func(ev *events.RASEvent) string {
+		return strconv.FormatUint(uint64(ev.Rank), 10) + ":" + strconv.FormatUint(ev.Incarnation, 10)
+	})
 }
 
 func getGrpcOpts(cfgTransport *security.TransportConfig) ([]grpc.ServerOption, error) {


### PR DESCRIPTION
When a rank is seen as dead by multiple other ranks, the
number of events raised may be as large as N-1, where N
is the size of the cluster. As we only care about the first
event for the purpose of updating the system membership,
we can ignore subsequent events for the same rank:incarnation
combination.

Features: control

Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com>
