### PR TITLE
DAOS-6004 test: Re-enabled skipped tests

### DIFF
--- a/src/tests/ftest/control/dmg_system_reformat.py
+++ b/src/tests/ftest/control/dmg_system_reformat.py
@@ -1,10 +1,9 @@
 #!/usr/bin/python
 """
-  (C) Copyright 2020-2021 Intel Corporation.
+  (C) Copyright 2020-2022 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
-from apricot import skipForTicket
 from avocado.core.exceptions import TestFail
 from pool_test_base import PoolTestBase
 
@@ -19,7 +18,6 @@ class DmgSystemReformatTest(PoolTestBase):
     :avocado: recursive
     """
 
-    @skipForTicket("DAOS-6004")
     def test_dmg_system_reformat(self):
         """
         JIRA ID: DAOS-5415

--- a/src/tests/ftest/control/dmg_telemetry_io_latency.py
+++ b/src/tests/ftest/control/dmg_telemetry_io_latency.py
@@ -10,7 +10,6 @@ from ior_test_base import IorTestBase
 from telemetry_test_base import TestWithTelemetry
 from telemetry_utils import TelemetryUtils
 from test_utils_container import TestContainer
-from apricot import skipForTicket
 
 
 def get_rf(oclass):
@@ -514,7 +513,6 @@ class TestWithTelemetryIOLatency(IorTestBase, TestWithTelemetry):
         if errors:
             self.fail("Test FAILED")
 
-    @skipForTicket("DAOS-9031")
     def test_ior_latency_telmetry_metrics(self):
         """JIRA ID: DAOS-8624.
 

--- a/src/tests/ftest/erasurecode/offline_rebuild_aggregation.py
+++ b/src/tests/ftest/erasurecode/offline_rebuild_aggregation.py
@@ -1,12 +1,12 @@
 #!/usr/bin/python
 '''
-  (C) Copyright 2020-2021 Intel Corporation.
+  (C) Copyright 2020-2022 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
 import time
 from ec_utils import ErasureCodeIor, check_aggregation_status
-from apricot import skipForTicket
+
 
 class EcodAggregationOffRebuild(ErasureCodeIor):
     # pylint: disable=too-many-ancestors
@@ -90,7 +90,6 @@ class EcodAggregationOffRebuild(ErasureCodeIor):
         self.pool.set_property("reclaim", "disabled")
         self.execution()
 
-    @skipForTicket("DAOS-8542")
     def test_ec_offline_rebuild_agg_default(self):
         """Jira ID: DAOS-7313.
 
@@ -113,7 +112,6 @@ class EcodAggregationOffRebuild(ErasureCodeIor):
         """
         self.execution(agg_trigger=True)
 
-    @skipForTicket("DAOS-8542")
     def test_ec_offline_agg_during_rebuild(self):
         """Jira ID: DAOS-7313.
 

--- a/src/tests/ftest/erasurecode/rebuild_fio.py
+++ b/src/tests/ftest/erasurecode/rebuild_fio.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 '''
-  (C) Copyright 2019-2021 Intel Corporation.
+  (C) Copyright 2019-2022 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
@@ -65,7 +65,7 @@ class EcodFioRebuild(ErasureCodeFio):
             # Read and verify the original data.
             self.fio_cmd.run()
 
-    @skipForTicket("DAOS-9783,DAOS-9785")
+    @skipForTicket("DAOS-9785")
     def test_ec_online_rebuild_fio(self):
         """Jira ID: DAOS-7320.
 
@@ -88,7 +88,7 @@ class EcodFioRebuild(ErasureCodeFio):
         """
         self.execution('on-line')
 
-    @skipForTicket("DAOS-9783,DAOS-9785")
+    @skipForTicket("DAOS-9785")
     def test_ec_offline_rebuild_fio(self):
         """Jira ID: DAOS-7320.
 

--- a/src/tests/ftest/pool/permission.py
+++ b/src/tests/ftest/pool/permission.py
@@ -22,14 +22,6 @@ class Permission(TestWithServers):
     :avocado: recursive
     """
 
-    # Cancel any tests with tickets already assigned
-    CANCEL_FOR_TICKET = [
-        ["DAOS-3442", "mode", 73],
-        ["DAOS-3442", "mode", 146, "perm", 0],
-        ["DAOS-3442", "mode", 146, "perm", 2],
-        ["DAOS-3442", "mode", 292],
-    ]
-
     def test_connect_permission(self):
         """Test ID: DAOS-???.
 


### PR DESCRIPTION
Removing skipForTicket decorators and CANCEL_FOR_TICKET entries for
tests whose tickets have been resolved.

Skip-unit-tests: true
Test-tag: dmg_system_reformat test_ior_latency_telemetry ec_offline_rebuild_agg_default ec_offline_agg_during_rebuild ec_online_rebuild_fio ec_offline_rebuild_fio pool,permission

Signed-off-by: Phillip Henderson <phillip.henderson@intel.com>