### PR TITLE
DAOS-9310 test: Fix dtx/basic.py pool connect timeout (#7840)

### DIFF
--- a/src/tests/ftest/dtx/basic.yaml
+++ b/src/tests/ftest/dtx/basic.yaml
@@ -4,7 +4,7 @@ hosts:
   test_servers:
     - server-A
     - server-B
-timeout: 60
+timeout: 120
 faults: !mux
 # commenting out the fault injection bit
 # as it's still under development. Uncomment


### PR DESCRIPTION
Increase test timeout.

Skip-unit-tests: true
Test-tag: basictx

Signed-off-by: Ding Ho ding-hwa.ho@intel.com