### PR TITLE
DAOS-9310 test: Increase timeout for dtx/basic.py

### DIFF
--- a/src/tests/ftest/dtx/basic.yaml
+++ b/src/tests/ftest/dtx/basic.yaml
@@ -4,7 +4,7 @@ hosts:
   test_servers:
     - server-A
     - server-B
-timeout: 60
+timeout: 120
 faults: !mux
 # commenting out the fault injection bit
 # as it's still under development. Uncomment


### PR DESCRIPTION
Test-tag: basictx
Skip-unit-tests: true
Skip-func-test-leap15: false
Skip-func-test-el7: false
Skip-func-test-el8: false
Test-repeat: 5
Signed-off-by: Ding Ho ding-hwa.ho@intel.com