### PR TITLE
DAOS-10378 cont: Adjust cell size prop name to match pool

### DIFF
--- a/src/common/tests/prop_tests.c
+++ b/src/common/tests/prop_tests.c
@@ -264,7 +264,7 @@ test_daos_prop_from_str(void **state)
 	char		*COMP		= "compression:lz4";
 	char		*ENC		= "encryption:aes-xts128";
 	char		*RF		= "rf:2";
-	char		*EC_CELL	= "ec_cell:2021";
+	char		*EC_CELL	= "ec_cell_sz:2021";
 	char		*EC_PDA		= "ec_pda:1";
 	char		*RP_PDA		= "rp_pda:4";
 

--- a/src/include/daos/cont_props.h
+++ b/src/include/daos/cont_props.h
@@ -20,7 +20,7 @@
 #define DAOS_PROP_ENTRY_ENCRYPT		"encryption"
 #define DAOS_PROP_ENTRY_REDUN_FAC	"rf"
 #define DAOS_PROP_ENTRY_STATUS		"status"
-#define DAOS_PROP_ENTRY_EC_CELL_SZ	"ec_cell"
+#define DAOS_PROP_ENTRY_EC_CELL_SZ	"ec_cell_sz"
 #define DAOS_PROP_ENTRY_LAYOUT_TYPE	"layout_type"
 #define DAOS_PROP_ENTRY_LAYOUT_VER	"layout_version"
 #define DAOS_PROP_ENTRY_REDUN_LVL	"rf_lvl"

--- a/src/include/daos_prop.h
+++ b/src/include/daos_prop.h
@@ -555,7 +555,8 @@ daos_prop_free(daos_prop_t *prop);
  * prop_entry_name1:value1;prop_entry_name2:value2;prop_entry_name3:value3;
  * \a prop must be freed with daos_prop_free() to release allocated space.
  * This supports properties that can be modified on container creation only:
- * label, cksum, cksum_size, srv_cksum, dedup, dedup_threshold, compression, encryption, rf, ec_cell
+ *   label, cksum, cksum_size, srv_cksum, dedup, dedup_threshold, compression,
+ *   encryption, rf, ec_cell_sz
  *
  * \param[in]	str	Serialized string of property entries and their values
  * \param[in]	len	Serialized string length

--- a/src/tests/ftest/erasurecode/cell_size_property.py
+++ b/src/tests/ftest/erasurecode/cell_size_property.py
@@ -28,7 +28,7 @@ class EcodCellSizeProperty(IorTestBase):
         """
         daos_cmd = self.get_daos_command()
         cont_prop = daos_cmd.container_get_prop(
-            pool=self.pool.uuid, cont=self.container.uuid, properties=["ec_cell"])
+            pool=self.pool.uuid, cont=self.container.uuid, properties=["ec_cell_sz"])
         actual_size = cont_prop["response"][0]["value"]
 
         self.assertEqual(expected_size, actual_size)
@@ -74,7 +74,7 @@ class EcodCellSizeProperty(IorTestBase):
 
             # Use the default pool property for container and do not update
             if cont_cell != pool_prop_expected:
-                self.container.properties.update("ec_cell:{}"
+                self.container.properties.update("ec_cell_sz:{}"
                                                  .format(cont_cell))
 
             # Create the container and open handle

--- a/src/tests/ftest/util/daos_utils.py
+++ b/src/tests/ftest/util/daos_utils.py
@@ -422,7 +422,7 @@ class DaosCommand(DaosCommandBase):
         #     },
         #     {
         #       "value": 65536,
-        #       "name": "ec_cell",
+        #       "name": "ec_cell_sz",
         #       "description": "EC Cell Size"
         #     },
         #     {


### PR DESCRIPTION
The pool property name is "ec_cell_sz". For command parity
and better UX, adjust the container property name to match.

Test-tag: pr ec_cell_size ec_cell_property

Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com>
